### PR TITLE
Add meta charset tag to HTML output generation.

### DIFF
--- a/code/Language/Drasil/HTML/Print.hs
+++ b/code/Language/Drasil/HTML/Print.hs
@@ -39,7 +39,8 @@ build fn (Document t a c) =
           " \"http://www.w3.org/TR/html4/loose.dtd\">" ++ "\n" ++
           "<script src='https://cdnjs.cloudflare.com/ajax/libs/mathjax/"++
           "2.7.0/MathJax.js?config=TeX-MML-AM_CHTML'></script>") $$
-  html (head_tag ((linkCSS fn) $$ title (title_spec t)) $$
+  html ( head_tag ((linkCSS fn) $$ title (title_spec t) $$
+  text ("<meta charset=\"utf-8\">")) $$
   body (article_title (p_spec t) $$ author (p_spec a)
   $$ print c
   ))

--- a/code/stable/gamephys/Chipmunk_SRS.html
+++ b/code/stable/gamephys/Chipmunk_SRS.html
@@ -6,6 +6,7 @@
 <title>
 Software Requirements Specification for Chipmunk2D
 </title>
+<meta charset="utf-8">
 </head>
 <body>
 <div class="title">

--- a/code/stable/glassbr/GlassBR_SRS.html
+++ b/code/stable/glassbr/GlassBR_SRS.html
@@ -6,6 +6,7 @@
 <title>
 Software Requirements Specification for GlassBR program
 </title>
+<meta charset="utf-8">
 </head>
 <body>
 <div class="title">

--- a/code/stable/nopcm/NoPCM_SRS.html
+++ b/code/stable/nopcm/NoPCM_SRS.html
@@ -6,6 +6,7 @@
 <title>
 Software Requirements Specification for Solar Water Heating Systems
 </title>
+<meta charset="utf-8">
 </head>
 <body>
 <div class="title">

--- a/code/stable/ssp/SSP_SRS.html
+++ b/code/stable/ssp/SSP_SRS.html
@@ -6,6 +6,7 @@
 <title>
 Software Requirements Specification for Slope Stability Analysis
 </title>
+<meta charset="utf-8">
 </head>
 <body>
 <div class="title">

--- a/code/stable/swhs/SWHS_SRS.html
+++ b/code/stable/swhs/SWHS_SRS.html
@@ -6,6 +6,7 @@
 <title>
 Software Requirements Specification for Solar Water Heating Systems Incorporating PCM
 </title>
+<meta charset="utf-8">
 </head>
 <body>
 <div class="title">

--- a/code/stable/tiny/SRS.html
+++ b/code/stable/tiny/SRS.html
@@ -6,6 +6,7 @@
 <title>
 Software Requirements Specification for Tiny
 </title>
+<meta charset="utf-8">
 </head>
 <body>
 <div class="title">


### PR DESCRIPTION
Hint to browsers that the charset is UTF-8 due to "Système International d'Unités".