### PR TITLE
Fix missing spaces in names.

### DIFF
--- a/code/Language/Drasil/HTML/Print.hs
+++ b/code/Language/Drasil/HTML/Print.hs
@@ -20,7 +20,8 @@ import           Language.Drasil.Symbol (Symbol(..))
 import qualified Language.Drasil.Symbol as S
 import qualified Language.Drasil.Document as L
 import Language.Drasil.HTML.Monad
-import Language.Drasil.People (People,Person(..),rendPersLFM',rendPersLFM'',Conv(..),nameStr,rendPersLFM, dotInitial)
+import Language.Drasil.People (People,Person(..),rendPersLFM',rendPersLFM'',
+  Conv(..),nameStr,rendPersLFM, dotInitial, nameSep)
 import Language.Drasil.Config (StyleGuide(..), bibStyleH)
 import Language.Drasil.ChunkDB(HasSymbolTable)
 
@@ -302,7 +303,7 @@ renderCite (Cite e Misc cfs) = (text e, renderF cfs useStyleBk)
 renderCite (Cite e _ cfs) = (text e, renderF cfs useStyleArtcl) --FIXME: Properly render these later.
 
 renderF :: [CiteField] -> (StyleGuide -> (CiteField -> Doc)) -> Doc
-renderF fields styl = hcat $ map (styl bibStyleH) (sortBy compCiteField fields)
+renderF fields styl = hsep $ map (styl bibStyleH) (sortBy compCiteField fields)
 
 compCiteField :: CiteField -> CiteField -> Ordering
 compCiteField (Institution _) _ = LT
@@ -457,7 +458,8 @@ rendPersL (Person {_surname = n, _convention = Mono}) = n
 rendPersL (Person {_given = f, _surname = l, _middle = []}) =
   dotInitial l ++ ", " ++ dotInitial f
 rendPersL (Person {_given = f, _surname = l, _middle = ms}) =
-  dotInitial l ++ ", " ++ foldr1 (++) (dotInitial f : map dotInitial (init ms) ++ [last ms])
+  dotInitial l ++ ", " ++ foldr1 nameSep (
+    dotInitial f : map dotInitial (init ms) ++ [last ms])
 
 --adds an 's' if there is more than one person in a list
 toPlural :: People -> String -> String

--- a/code/Language/Drasil/People.hs
+++ b/code/Language/Drasil/People.hs
@@ -5,7 +5,7 @@ module Language.Drasil.People
   , name, manyNames, nameStr
   , Conv(..) --This is needed to unwrap names for the bibliography
   , lstName, initial, dotInitial
-  , rendPersLFM, rendPersLFM', rendPersLFM''
+  , rendPersLFM, rendPersLFM', rendPersLFM'', nameSep
   ) where
 
 -- | A person can have a given name, middle name(s), and surname, as well
@@ -58,9 +58,9 @@ class HasName p where
 
 instance HasName Person where
   nameStr (Person _ n _ Mono) =  dotInitial n
-  nameStr (Person f l ms Western) = foldr (++) "" (
+  nameStr (Person f l ms Western) = foldr nameSep "" (
     [dotInitial f] ++ map dotInitial ms ++ [dotInitial l])
-  nameStr (Person g s ms Eastern) = foldr (++) "" (
+  nameStr (Person g s ms Eastern) = foldr nameSep "" (
     [dotInitial s] ++ map dotInitial ms ++ [dotInitial g])
 
 name :: (HasName n) => n -> String
@@ -73,8 +73,8 @@ manyNames [x,y] = name x ++ " and " ++ (name y)
 manyNames names = nameList names
   where nameList [] = ""
         nameList [x] = name x
-        nameList [x,y] = (name x) ++ ", and" ++ (name y)
-        nameList (x : y : rest) = (name x) ++ "," ++ (nameList (y : rest))
+        nameList [x,y] = (name x) ++ ", and " ++ (name y)
+        nameList (x : y : rest) = (name x) ++ ", " ++ (nameList (y : rest))
 
 lstName :: Person -> String
 lstName (Person {_surname = l}) = l
@@ -83,19 +83,20 @@ lstName (Person {_surname = l}) = l
 rendPersLFM :: Person -> String
 rendPersLFM (Person {_surname = n, _convention = Mono}) = n
 rendPersLFM (Person {_given = f, _surname = l, _middle = ms}) =
-  (dotInitial l) ++ ", " ++ (dotInitial f) ++ foldr (++) "" (map dotInitial ms)
+  (dotInitial l) ++ ", " ++ (dotInitial f) `nameSep`
+  foldr nameSep "" (map dotInitial ms)
 
 -- LFM' is Last, F. M.
 rendPersLFM' :: Person -> String
 rendPersLFM' (Person {_surname = n, _convention = Mono}) = n
 rendPersLFM' (Person {_given = f, _surname = l, _middle = ms}) =
-  (dotInitial l) ++ ", " ++ foldr (++) "" (map initial (f:ms))
+  (dotInitial l) ++ ", " ++ foldr nameSep "" (map initial (f:ms))
 
 -- LFM'' is Last, First M.
 rendPersLFM'' :: Person -> String
 rendPersLFM'' (Person {_surname = n, _convention = Mono}) = n
 rendPersLFM'' (Person {_given = f, _surname = l, _middle = ms}) =
-  (dotInitial l) ++ ", " ++ foldr1 (++) (dotInitial f : (map (initial) ms))
+  (dotInitial l) ++ ", " ++ foldr1 nameSep (dotInitial f : (map (initial) ms))
 
 initial :: String -> String
 initial []    = [] -- is this right?
@@ -105,3 +106,8 @@ initial (x:_) = [x , '.']
 dotInitial :: String -> String
 dotInitial [x] = [x,'.']
 dotInitial nm  = nm
+
+nameSep :: String -> String -> String
+"" `nameSep` b = b
+a `nameSep` "" = a
+a `nameSep` b = a ++ " " ++ b

--- a/code/stable/gamephys/Chipmunk_SRS.html
+++ b/code/stable/gamephys/Chipmunk_SRS.html
@@ -16,7 +16,7 @@ Software Requirements Specification for Chipmunk2D
 </div>
 <div class="author">
 <h2>
-AlexHalliwushka and LuthfiMawarid
+Alex Halliwushka and Luthfi Mawarid
 </h2>
 </div>
 <a id="Sec:RefMat">
@@ -5270,42 +5270,42 @@ References
 </h1>
 <a id="dParnas1972">
 <ul>
-[1]: Parnas, DavidL."On the Criteria To Be Used in Decomposing Systems into Modules."<em>Communications of the ACM</em>,1972.pp. 1053&ndash;1058. Print.
+[1]: Parnas, David L. "On the Criteria To Be Used in Decomposing Systems into Modules." <em>Communications of the ACM</em>, 1972. pp. 1053&ndash;1058. Print.
 </ul>
 </a>
 <a id="dParnasPcClements1984">
 <ul>
-[2]: Parnas, DavidL., Clements, P.C., and Wiess, ."The Modular Structure of Complex Systems."<em>ICSE '84: Proceedings of the 7th international conference on Software engineering</em>.1984.pp. 408&ndash;417.
+[2]: Parnas, David L., Clements, P. C., and Wiess, . "The Modular Structure of Complex Systems." <em>ICSE '84: Proceedings of the 7th international conference on Software engineering</em>. 1984. pp. 408&ndash;417.
 </ul>
 </a>
 <a id="jfBeucheIntro">
 <ul>
-[3]: Bueche, J.Frederick.<em>Introduction to Physics for Scientists, Fourth Edition</em>.Mcgraw-Hill College,1986.
+[3]: Bueche, J. Frederick. <em>Introduction to Physics for Scientists, Fourth Edition</em>. Mcgraw-Hill College, 1986.
 </ul>
 </a>
 <a id="koothoor2013">
 <ul>
-[4]: Koothoor, Nirmitha.<em>A document drive approach to certifying scientific computing software</em>.McMaster University,Hamilton, ON, Canada:2013. Print.
+[4]: Koothoor, Nirmitha. <em>A document drive approach to certifying scientific computing software</em>. McMaster University, Hamilton, ON, Canada: 2013. Print.
 </ul>
 </a>
 <a id="parnas1978">
 <ul>
-[5]: Parnas, DavidL."Designing Software for Ease of Extension and Contraction.."<em>ICSE '78: Proceedings of the 3rd international conference on Software engineering</em>.1978.pp. 264&ndash;277.
+[5]: Parnas, David L. "Designing Software for Ease of Extension and Contraction.." <em>ICSE '78: Proceedings of the 3rd international conference on Software engineering</em>. 1978. pp. 264&ndash;277.
 </ul>
 </a>
 <a id="parnas1986">
 <ul>
-[6]: Parnas, DavidL. and Clements, P.C."A rational design process: How and why to fake it."<em>IEEE Transactions on Software Engineering</em>,vol. 12,no. 2,Washington, USA:February,1986.pp. 251&ndash;257. Print.
+[6]: Parnas, David L. and Clements, P. C. "A rational design process: How and why to fake it." <em>IEEE Transactions on Software Engineering</em>, vol. 12, no. 2, Washington, USA: February, 1986. pp. 251&ndash;257. Print.
 </ul>
 </a>
 <a id="sciComp2013">
 <ul>
-[7]: Wilson, Greg, Aruliah, D.A., Titus, C., Chue Hong, NeilP., Davis, Matt, Guy, RichardT., Haddock, StevenH.D., Huff, KathrynD., Mitchell, IanM., Plumblet, MarkD., Waugh, Ben, White, EthanP., and Wilson, Paul."Best Practices for Scientific Computing, 2013."<em>PLoS Biol</em>,vol. 12,no. 1,2013. Print.
+[7]: Wilson, Greg, Aruliah, D. A., Titus, C., Chue Hong, Neil P., Davis, Matt, Guy, Richard T., Haddock, Steven H. D., Huff, Kathryn D., Mitchell, Ian M., Plumblet, Mark D., Waugh, Ben, White, Ethan P., and Wilson, Paul. "Best Practices for Scientific Computing, 2013." <em>PLoS Biol</em>, vol. 12, no. 1, 2013. Print.
 </ul>
 </a>
 <a id="smithLai2005">
 <ul>
-[8]: Smith, W.Spencer and Lai, Lei."A new requirements template for scientific computing."<em>Proceedings of the First International Workshop on Situational Requirements Engineering Processes - Methods, Techniques and Tools to Support Situation-Specific Requirements Engineering Processes, SREP'05</em>.Edited by PJAgerfalk, N.Kraiem, and J.Ralyte,Paris, France:2005.pp. 107&ndash;121.In conjunction with 13th IEEE International Requirements Engineering Conference,
+[8]: Smith, W. Spencer and Lai, Lei. "A new requirements template for scientific computing." <em>Proceedings of the First International Workshop on Situational Requirements Engineering Processes - Methods, Techniques and Tools to Support Situation-Specific Requirements Engineering Processes, SREP'05</em>. Edited by PJ Agerfalk, N. Kraiem, and J. Ralyte, Paris, France: 2005. pp. 107&ndash;121. In conjunction with 13th IEEE International Requirements Engineering Conference,
 </ul>
 </a>
 </div>

--- a/code/stable/gamephys/Chipmunk_SRS.tex
+++ b/code/stable/gamephys/Chipmunk_SRS.tex
@@ -17,7 +17,7 @@
 \global\tabulinesep=1mm
 \bibliography{bibfile}
 \title{Software Requirements Specification for Chipmunk2D}
-\author{AlexHalliwushka and LuthfiMawarid}
+\author{Alex Halliwushka and Luthfi Mawarid}
 \begin{document}
 \maketitle
 \tableofcontents
@@ -798,21 +798,21 @@ There are no auxiliary constants.
 \label{Sec:References}
 \begin{filecontents*}{bibfile.bib}
 @article{dParnas1972,
-author={Parnas, DavidL.},
+author={Parnas, David L.},
 title={On the Criteria To Be Used in Decomposing Systems into Modules},
 journal={Communications of the ACM},
 year={1972},
 pages={"1053-1058"}}
 
 @inproceedings{dParnasPcClements1984,
-author={Parnas, DavidL. and Clements, P.C. and Wiess, },
+author={Parnas, David L. and Clements, P. C. and Wiess, },
 title={The Modular Structure of Complex Systems},
 booktitle={ICSE '84: Proceedings of the 7th international conference on Software engineering},
 year={1984},
 pages={"408-417"}}
 
 @misc{jfBeucheIntro,
-author={Bueche, J.Frederick},
+author={Bueche, J. Frederick},
 title={Introduction to Physics for Scientists, Fourth Edition},
 publisher={Mcgraw-Hill College},
 year={1986}}
@@ -825,14 +825,14 @@ year={2013},
 address={Hamilton, ON, Canada}}
 
 @inproceedings{parnas1978,
-author={Parnas, DavidL.},
+author={Parnas, David L.},
 title={Designing Software for Ease of Extension and Contraction.},
 booktitle={ICSE '78: Proceedings of the 3rd international conference on Software engineering},
 year={1978},
 pages={"264-277"}}
 
 @article{parnas1986,
-author={Parnas, DavidL. and Clements, P.C.},
+author={Parnas, David L. and Clements, P. C.},
 title={A rational design process: How and why to fake it},
 journal={IEEE Transactions on Software Engineering},
 year={1986},
@@ -843,7 +843,7 @@ pages={"251-257"},
 address={Washington, USA}}
 
 @article{sciComp2013,
-author={Wilson, Greg and Aruliah, D.A. and Titus, C. and Chue Hong, NeilP. and Davis, Matt and Guy, RichardT. and Haddock, StevenH.D. and Huff, KathrynD. and Mitchell, IanM. and Plumblet, MarkD. and Waugh, Ben and White, EthanP. and Wilson, Paul},
+author={Wilson, Greg and Aruliah, D. A. and Titus, C. and Chue Hong, Neil P. and Davis, Matt and Guy, Richard T. and Haddock, Steven H. D. and Huff, Kathryn D. and Mitchell, Ian M. and Plumblet, Mark D. and Waugh, Ben and White, Ethan P. and Wilson, Paul},
 title={Best Practices for Scientific Computing, 2013},
 journal={PLoS Biol},
 year={2013},
@@ -851,7 +851,7 @@ volume={12},
 number={1}}
 
 @inproceedings{smithLai2005,
-author={Smith, W.Spencer and Lai, Lei},
+author={Smith, W. Spencer and Lai, Lei},
 title={A new requirements template for scientific computing},
 booktitle={Proceedings of the First International Workshop on Situational Requirements Engineering Processes - Methods, Techniques and Tools to Support Situation-Specific Requirements Engineering Processes, SREP'05},
 year={2005},

--- a/code/stable/glassbr/GlassBR_SRS.html
+++ b/code/stable/glassbr/GlassBR_SRS.html
@@ -16,7 +16,7 @@ Software Requirements Specification for GlassBR program
 </div>
 <div class="author">
 <h2>
-NikithaKrithnan and W.SpencerSmith
+Nikitha Krithnan and W. Spencer Smith
 </h2>
 </div>
 <a id="Sec:RefMat">
@@ -797,7 +797,7 @@ This section describes the Stakeholders: the people who have an interest in the 
 The Client
 </h2>
 <p class="paragraph">
-The client for GlassBR is a company named Entuitive. It is developed by Dr. ManuelCampidelli. The client has the final say on acceptance of the product.
+The client for GlassBR is a company named Entuitive. It is developed by Dr. Manuel Campidelli. The client has the final say on acceptance of the product.
 </p>
 </div>
 </a>
@@ -4387,37 +4387,37 @@ References
 </h1>
 <a id="astm_C1036">
 <ul>
-[1]: ASTM C1036-16.<em>Standard specification for Flat Glass</em>.West Conshohocken, PA:ASTM International,2016.www.astm.org.
+[1]: ASTM C1036-16. <em>Standard specification for Flat Glass</em>. West Conshohocken, PA: ASTM International, 2016. www.astm.org.
 </ul>
 </a>
 <a id="astm_C1048">
 <ul>
-[2]: ASTM C1048-04.<em>Specification for Heat-Treated Flat Glass-Kind HS, Kind FT Coated and Uncoated Glass</em>.West Conshohocken, PA:ASTM International,2009.www.astm.org.
+[2]: ASTM C1048-04. <em>Specification for Heat-Treated Flat Glass-Kind HS, Kind FT Coated and Uncoated Glass</em>. West Conshohocken, PA: ASTM International, 2009. www.astm.org.
 </ul>
 </a>
 <a id="astm_LR2009">
 <ul>
-[3]: ASTM E1300-09.<em>Standard Practice for Determining Load Resistance of Glass in Buildings</em>.<em>Standard E1300-09a</em>.ASTM International,2009.www.astm.org.
+[3]: ASTM E1300-09. <em>Standard Practice for Determining Load Resistance of Glass in Buildings</em>. <em>Standard E1300-09a</em>. ASTM International, 2009. www.astm.org.
 </ul>
 </a>
 <a id="glThick1998">
 <ul>
-[4]: Beason, W.Lynn, Kohutek, TerryL., and Bracci, JosephM.<em>Basis for ASTME E 1300 Annealed Glass Thickness Selection Charts</em>.<em>ASCE Library</em>.February,1998.doi.org/10.1061/(ASCE)0733-9445(1998)124:2(215).
+[4]: Beason, W. Lynn, Kohutek, Terry L., and Bracci, Joseph M. <em>Basis for ASTME E 1300 Annealed Glass Thickness Selection Charts</em>. <em>ASCE Library</em>. February, 1998. doi.org/10.1061/(ASCE)0733-9445(1998)124:2(215).
 </ul>
 </a>
 <a id="koothoor2013">
 <ul>
-[5]: Koothoor, Nirmitha.<em>A document drive approach to certifying scientific computing software</em>.McMaster University,Hamilton, ON, Canada:2013. Print.
+[5]: Koothoor, Nirmitha. <em>A document drive approach to certifying scientific computing software</em>. McMaster University, Hamilton, ON, Canada: 2013. Print.
 </ul>
 </a>
 <a id="rbrtsn2012">
 <ul>
-[6]: Robertson, James and Robertson, Suzanne.<em>Volere requirements specification template edition 16</em>.2012.https://pdfs.semanticscholar.org/cf57/27a59801086cbd3d14e587e09880561dbe22.pdf.
+[6]: Robertson, James and Robertson, Suzanne. <em>Volere requirements specification template edition 16</em>. 2012. https://pdfs.semanticscholar.org/cf57/27a59801086cbd3d14e587e09880561dbe22.pdf.
 </ul>
 </a>
 <a id="smithLai2005">
 <ul>
-[7]: Smith, W.Spencer and Lai, Lei."A new requirements template for scientific computing."<em>Proceedings of the First International Workshop on Situational Requirements Engineering Processes - Methods, Techniques and Tools to Support Situation-Specific Requirements Engineering Processes, SREP'05</em>.Edited by PJAgerfalk, N.Kraiem, and J.Ralyte,Paris, France:2005.pp. 107&ndash;121.In conjunction with 13th IEEE International Requirements Engineering Conference,
+[7]: Smith, W. Spencer and Lai, Lei. "A new requirements template for scientific computing." <em>Proceedings of the First International Workshop on Situational Requirements Engineering Processes - Methods, Techniques and Tools to Support Situation-Specific Requirements Engineering Processes, SREP'05</em>. Edited by PJ Agerfalk, N. Kraiem, and J. Ralyte, Paris, France: 2005. pp. 107&ndash;121. In conjunction with 13th IEEE International Requirements Engineering Conference,
 </ul>
 </a>
 </div>

--- a/code/stable/glassbr/GlassBR_SRS.tex
+++ b/code/stable/glassbr/GlassBR_SRS.tex
@@ -24,7 +24,7 @@
 \newcommand{\lcthelcnum}{LC\thelcnum}
 \bibliography{bibfile}
 \title{Software Requirements Specification for GlassBR program}
-\author{NikithaKrithnan and W.SpencerSmith}
+\author{Nikitha Krithnan and W. Spencer Smith}
 \begin{document}
 \maketitle
 \tableofcontents
@@ -215,7 +215,7 @@ The goal statements are refined to the theoretical models, and the theoretical m
 This section describes the Stakeholders: the people who have an interest in the product.
 \subsection{The Client}
 \label{Sec:Client}
-The client for GlassBR is a company named Entuitive. It is developed by Dr. ManuelCampidelli. The client has the final say on acceptance of the product.
+The client for GlassBR is a company named Entuitive. It is developed by Dr. Manuel Campidelli. The client has the final say on acceptance of the product.
 \subsection{The Customer}
 \label{Sec:Customer}
 The customers are the end user of GlassBR.
@@ -892,7 +892,7 @@ year={2009},
 howpublished={\url{www.astm.org}}}
 
 @misc{glThick1998,
-author={Beason, W.Lynn and Kohutek, TerryL. and Bracci, JosephM.},
+author={Beason, W. Lynn and Kohutek, Terry L. and Bracci, Joseph M.},
 title={Basis for ASTME E 1300 Annealed Glass Thickness Selection Charts},
 booktitle={ASCE Library},
 month={feb},
@@ -913,7 +913,7 @@ howpublished={\url{https://pdfs.semanticscholar.org/cf57/27a59801086cbd3d14e587e
 year={2012}}
 
 @inproceedings{smithLai2005,
-author={Smith, W.Spencer and Lai, Lei},
+author={Smith, W. Spencer and Lai, Lei},
 title={A new requirements template for scientific computing},
 booktitle={Proceedings of the First International Workshop on Situational Requirements Engineering Processes - Methods, Techniques and Tools to Support Situation-Specific Requirements Engineering Processes, SREP'05},
 year={2005},

--- a/code/stable/nopcm/NoPCM_SRS.html
+++ b/code/stable/nopcm/NoPCM_SRS.html
@@ -16,7 +16,7 @@ Software Requirements Specification for Solar Water Heating Systems
 </div>
 <div class="author">
 <h2>
-ThulasiJegatheesan
+Thulasi Jegatheesan
 </h2>
 </div>
 <a id="Sec:RefMat">
@@ -3010,27 +3010,27 @@ References
 </h1>
 <a id="incroperaEtAl2007">
 <ul>
-[1]: Incropera, F.P., Dewitt, D.P., Bergman, T.L., and Lavine, A.S.<em>Fundamentals of Heat and Mass Transfer</em>.6th. ed.,Hoboken, New Jersey:John Wiley and Sons,2007. Print.
+[1]: Incropera, F. P., Dewitt, D. P., Bergman, T. L., and Lavine, A. S. <em>Fundamentals of Heat and Mass Transfer</em>. 6th. ed., Hoboken, New Jersey: John Wiley and Sons, 2007. Print.
 </ul>
 </a>
 <a id="koothoor2013">
 <ul>
-[2]: Koothoor, Nirmitha.<em>A document drive approach to certifying scientific computing software</em>.McMaster University,Hamilton, ON, Canada:2013. Print.
+[2]: Koothoor, Nirmitha. <em>A document drive approach to certifying scientific computing software</em>. McMaster University, Hamilton, ON, Canada: 2013. Print.
 </ul>
 </a>
 <a id="lightstone2012">
 <ul>
-[3]: Lightstone, Marilyn.<em>Derivation of tank/pcm model</em>.2012.From Marilyn Lightstone's Personal Notes
+[3]: Lightstone, Marilyn. <em>Derivation of tank/pcm model</em>. 2012. From Marilyn Lightstone's Personal Notes
 </ul>
 </a>
 <a id="parnas1986">
 <ul>
-[4]: Parnas, DavidL. and Clements, P.C."A rational design process: How and why to fake it."<em>IEEE Transactions on Software Engineering</em>,vol. 12,no. 2,Washington, USA:February,1986.pp. 251&ndash;257. Print.
+[4]: Parnas, David L. and Clements, P. C. "A rational design process: How and why to fake it." <em>IEEE Transactions on Software Engineering</em>, vol. 12, no. 2, Washington, USA: February, 1986. pp. 251&ndash;257. Print.
 </ul>
 </a>
 <a id="smithLai2005">
 <ul>
-[5]: Smith, W.Spencer and Lai, Lei."A new requirements template for scientific computing."<em>Proceedings of the First International Workshop on Situational Requirements Engineering Processes - Methods, Techniques and Tools to Support Situation-Specific Requirements Engineering Processes, SREP'05</em>.Edited by PJAgerfalk, N.Kraiem, and J.Ralyte,Paris, France:2005.pp. 107&ndash;121.In conjunction with 13th IEEE International Requirements Engineering Conference,
+[5]: Smith, W. Spencer and Lai, Lei. "A new requirements template for scientific computing." <em>Proceedings of the First International Workshop on Situational Requirements Engineering Processes - Methods, Techniques and Tools to Support Situation-Specific Requirements Engineering Processes, SREP'05</em>. Edited by PJ Agerfalk, N. Kraiem, and J. Ralyte, Paris, France: 2005. pp. 107&ndash;121. In conjunction with 13th IEEE International Requirements Engineering Conference,
 </ul>
 </a>
 </div>

--- a/code/stable/nopcm/NoPCM_SRS.tex
+++ b/code/stable/nopcm/NoPCM_SRS.tex
@@ -24,7 +24,7 @@
 \newcommand{\lcthelcnum}{LC\thelcnum}
 \bibliography{bibfile}
 \title{Software Requirements Specification for Solar Water Heating Systems}
-\author{ThulasiJegatheesan}
+\author{Thulasi Jegatheesan}
 \begin{document}
 \maketitle
 \tableofcontents
@@ -681,7 +681,7 @@ ${{t_{final}}^{max}}$ & maximum final time & $86400$ & s
 \label{Sec:References}
 \begin{filecontents*}{bibfile.bib}
 @book{incroperaEtAl2007,
-author={Incropera, F.P. and Dewitt, D.P. and Bergman, T.L. and Lavine, A.S.},
+author={Incropera, F. P. and Dewitt, D. P. and Bergman, T. L. and Lavine, A. S.},
 title={Fundamentals of Heat and Mass Transfer},
 publisher={John Wiley and Sons},
 year={2007},
@@ -702,7 +702,7 @@ year={2012},
 note={From Marilyn Lightstone's Personal Notes}}
 
 @article{parnas1986,
-author={Parnas, DavidL. and Clements, P.C.},
+author={Parnas, David L. and Clements, P. C.},
 title={A rational design process: How and why to fake it},
 journal={IEEE Transactions on Software Engineering},
 year={1986},
@@ -713,7 +713,7 @@ pages={"251-257"},
 address={Washington, USA}}
 
 @inproceedings{smithLai2005,
-author={Smith, W.Spencer and Lai, Lei},
+author={Smith, W. Spencer and Lai, Lei},
 title={A new requirements template for scientific computing},
 booktitle={Proceedings of the First International Workshop on Situational Requirements Engineering Processes - Methods, Techniques and Tools to Support Situation-Specific Requirements Engineering Processes, SREP'05},
 year={2005},

--- a/code/stable/ssp/SSP_SRS.html
+++ b/code/stable/ssp/SSP_SRS.html
@@ -16,7 +16,7 @@ Software Requirements Specification for Slope Stability Analysis
 </div>
 <div class="author">
 <h2>
-HenryFrankis
+Henry Frankis
 </h2>
 </div>
 <a id="Sec:RefMat">
@@ -4527,37 +4527,37 @@ References
 </h1>
 <a id="chen2005">
 <ul>
-[1]: Qian, Q.H., Zhu, D.Y., Lee, C.F., and Chen, G.R."A concise algorithm for computing the factor of safety using the morgenstern price method."<em>Canadian Geotechnical Journal</em>,vol. 42,no. 1,February,2005.pp. 272&ndash;278. Print.
+[1]: Qian, Q. H., Zhu, D. Y., Lee, C. F., and Chen, G. R. "A concise algorithm for computing the factor of safety using the morgenstern price method." <em>Canadian Geotechnical Journal</em>, vol. 42, no. 1, February, 2005. pp. 272&ndash;278. Print.
 </ul>
 </a>
 <a id="fredlund1977">
 <ul>
-[2]: Fredlund, D.G. and Krahn, J.."Comparison of slope stability methods of analysis."<em>Canadian Geotechnical Journal</em>,vol. 14,no. 3,April,1977.pp. 429&ndash;439. Print.
+[2]: Fredlund, D. G. and Krahn, J.. "Comparison of slope stability methods of analysis." <em>Canadian Geotechnical Journal</em>, vol. 14, no. 3, April, 1977. pp. 429&ndash;439. Print.
 </ul>
 </a>
 <a id="koothoor2013">
 <ul>
-[3]: Koothoor, Nirmitha.<em>A document drive approach to certifying scientific computing software</em>.McMaster University,Hamilton, ON, Canada:2013. Print.
+[3]: Koothoor, Nirmitha. <em>A document drive approach to certifying scientific computing software</em>. McMaster University, Hamilton, ON, Canada: 2013. Print.
 </ul>
 </a>
 <a id="li2010">
 <ul>
-[4]: Yu-Chao, Li, Yun-Min, Chen, Zhan, TonyL.T., Sao-Sheng, Ling, and Cleall, PeterJohn."An efficient approach for locating the critical slip surface in slope stability analyses using a real-coded genetic algorithm."<em>Canadian Geotechnical Journal</em>,vol. 47,no. 7,June,2010.pp. 806&ndash;820. Print.
+[4]: Yu-Chao, Li, Yun-Min, Chen, Zhan, Tony L. T., Sao-Sheng, Ling, and Cleall, Peter John. "An efficient approach for locating the critical slip surface in slope stability analyses using a real-coded genetic algorithm." <em>Canadian Geotechnical Journal</em>, vol. 47, no. 7, June, 2010. pp. 806&ndash;820. Print.
 </ul>
 </a>
 <a id="parnas1986">
 <ul>
-[5]: Parnas, DavidL. and Clements, P.C."A rational design process: How and why to fake it."<em>IEEE Transactions on Software Engineering</em>,vol. 12,no. 2,Washington, USA:February,1986.pp. 251&ndash;257. Print.
+[5]: Parnas, David L. and Clements, P. C. "A rational design process: How and why to fake it." <em>IEEE Transactions on Software Engineering</em>, vol. 12, no. 2, Washington, USA: February, 1986. pp. 251&ndash;257. Print.
 </ul>
 </a>
 <a id="smithLai2005">
 <ul>
-[6]: Smith, W.Spencer and Lai, Lei."A new requirements template for scientific computing."<em>Proceedings of the First International Workshop on Situational Requirements Engineering Processes - Methods, Techniques and Tools to Support Situation-Specific Requirements Engineering Processes, SREP'05</em>.Edited by PJAgerfalk, N.Kraiem, and J.Ralyte,Paris, France:2005.pp. 107&ndash;121.In conjunction with 13th IEEE International Requirements Engineering Conference,
+[6]: Smith, W. Spencer and Lai, Lei. "A new requirements template for scientific computing." <em>Proceedings of the First International Workshop on Situational Requirements Engineering Processes - Methods, Techniques and Tools to Support Situation-Specific Requirements Engineering Processes, SREP'05</em>. Edited by PJ Agerfalk, N. Kraiem, and J. Ralyte, Paris, France: 2005. pp. 107&ndash;121. In conjunction with 13th IEEE International Requirements Engineering Conference,
 </ul>
 </a>
 <a id="stolle2008">
 <ul>
-[7]: Stolle, Dieter and Guo, Peijun."Limit equilibrum slope stability analysis using rigid finite elements."<em>Canadian Geotechnical Journal</em>,vol. 45,no. 5,May,2008.pp. 653&ndash;662. Print.
+[7]: Stolle, Dieter and Guo, Peijun. "Limit equilibrum slope stability analysis using rigid finite elements." <em>Canadian Geotechnical Journal</em>, vol. 45, no. 5, May, 2008. pp. 653&ndash;662. Print.
 </ul>
 </a>
 </div>

--- a/code/stable/ssp/SSP_SRS.tex
+++ b/code/stable/ssp/SSP_SRS.tex
@@ -18,7 +18,7 @@
 \global\tabulinesep=1mm
 \bibliography{bibfile}
 \title{Software Requirements Specification for Slope Stability Analysis}
-\author{HenryFrankis}
+\author{Henry Frankis}
 \begin{document}
 \maketitle
 \tableofcontents
@@ -1326,7 +1326,7 @@ There are no auxiliary constants.
 \label{Sec:References}
 \begin{filecontents*}{bibfile.bib}
 @article{chen2005,
-author={Qian, Q.H. and Zhu, D.Y. and Lee, C.F. and Chen, G.R.},
+author={Qian, Q. H. and Zhu, D. Y. and Lee, C. F. and Chen, G. R.},
 title={A concise algorithm for computing the factor of safety using the morgenstern price method},
 journal={Canadian Geotechnical Journal},
 year={2005},
@@ -1336,7 +1336,7 @@ number={1},
 pages={"272-278"}}
 
 @article{fredlund1977,
-author={Fredlund, D.G. and Krahn, J.},
+author={Fredlund, D. G. and Krahn, J.},
 title={Comparison of slope stability methods of analysis},
 journal={Canadian Geotechnical Journal},
 year={1977},
@@ -1353,7 +1353,7 @@ year={2013},
 address={Hamilton, ON, Canada}}
 
 @article{li2010,
-author={Yu-Chao, Li and Yun-Min, Chen and Zhan, TonyL.T. and Sao-Sheng, Ling and Cleall, PeterJohn},
+author={Yu-Chao, Li and Yun-Min, Chen and Zhan, Tony L. T. and Sao-Sheng, Ling and Cleall, Peter John},
 title={An efficient approach for locating the critical slip surface in slope stability analyses using a real-coded genetic algorithm},
 journal={Canadian Geotechnical Journal},
 year={2010},
@@ -1363,7 +1363,7 @@ volume={47},
 number={7}}
 
 @article{parnas1986,
-author={Parnas, DavidL. and Clements, P.C.},
+author={Parnas, David L. and Clements, P. C.},
 title={A rational design process: How and why to fake it},
 journal={IEEE Transactions on Software Engineering},
 year={1986},
@@ -1374,7 +1374,7 @@ pages={"251-257"},
 address={Washington, USA}}
 
 @inproceedings{smithLai2005,
-author={Smith, W.Spencer and Lai, Lei},
+author={Smith, W. Spencer and Lai, Lei},
 title={A new requirements template for scientific computing},
 booktitle={Proceedings of the First International Workshop on Situational Requirements Engineering Processes - Methods, Techniques and Tools to Support Situation-Specific Requirements Engineering Processes, SREP'05},
 year={2005},

--- a/code/stable/swhs/SWHS_SRS.html
+++ b/code/stable/swhs/SWHS_SRS.html
@@ -16,7 +16,7 @@ Software Requirements Specification for Solar Water Heating Systems Incorporatin
 </div>
 <div class="author">
 <h2>
-ThulasiJegatheesan,BrooksMacLachlan, andW.SpencerSmith
+Thulasi Jegatheesan, Brooks MacLachlan, and W. Spencer Smith
 </h2>
 </div>
 <a id="Sec:RefMat">
@@ -6208,32 +6208,32 @@ References
 </h1>
 <a id="bueche1986">
 <ul>
-[1]: Bueche, J.Frederick.<em>Introduction to Physics for Scientists</em>.4nd. ed.,New York City, New York:McGraw Hill,1986. Print.
+[1]: Bueche, J. Frederick. <em>Introduction to Physics for Scientists</em>. 4nd. ed., New York City, New York: McGraw Hill, 1986. Print.
 </ul>
 </a>
 <a id="incroperaEtAl2007">
 <ul>
-[2]: Incropera, F.P., Dewitt, D.P., Bergman, T.L., and Lavine, A.S.<em>Fundamentals of Heat and Mass Transfer</em>.6th. ed.,Hoboken, New Jersey:John Wiley and Sons,2007. Print.
+[2]: Incropera, F. P., Dewitt, D. P., Bergman, T. L., and Lavine, A. S. <em>Fundamentals of Heat and Mass Transfer</em>. 6th. ed., Hoboken, New Jersey: John Wiley and Sons, 2007. Print.
 </ul>
 </a>
 <a id="koothoor2013">
 <ul>
-[3]: Koothoor, Nirmitha.<em>A document drive approach to certifying scientific computing software</em>.McMaster University,Hamilton, ON, Canada:2013. Print.
+[3]: Koothoor, Nirmitha. <em>A document drive approach to certifying scientific computing software</em>. McMaster University, Hamilton, ON, Canada: 2013. Print.
 </ul>
 </a>
 <a id="lightstone2012">
 <ul>
-[4]: Lightstone, Marilyn.<em>Derivation of tank/pcm model</em>.2012.From Marilyn Lightstone's Personal Notes
+[4]: Lightstone, Marilyn. <em>Derivation of tank/pcm model</em>. 2012. From Marilyn Lightstone's Personal Notes
 </ul>
 </a>
 <a id="parnas1986">
 <ul>
-[5]: Parnas, DavidL. and Clements, P.C."A rational design process: How and why to fake it."<em>IEEE Transactions on Software Engineering</em>,vol. 12,no. 2,Washington, USA:February,1986.pp. 251&ndash;257. Print.
+[5]: Parnas, David L. and Clements, P. C. "A rational design process: How and why to fake it." <em>IEEE Transactions on Software Engineering</em>, vol. 12, no. 2, Washington, USA: February, 1986. pp. 251&ndash;257. Print.
 </ul>
 </a>
 <a id="smithLai2005">
 <ul>
-[6]: Smith, W.Spencer and Lai, Lei."A new requirements template for scientific computing."<em>Proceedings of the First International Workshop on Situational Requirements Engineering Processes - Methods, Techniques and Tools to Support Situation-Specific Requirements Engineering Processes, SREP'05</em>.Edited by PJAgerfalk, N.Kraiem, and J.Ralyte,Paris, France:2005.pp. 107&ndash;121.In conjunction with 13th IEEE International Requirements Engineering Conference,
+[6]: Smith, W. Spencer and Lai, Lei. "A new requirements template for scientific computing." <em>Proceedings of the First International Workshop on Situational Requirements Engineering Processes - Methods, Techniques and Tools to Support Situation-Specific Requirements Engineering Processes, SREP'05</em>. Edited by PJ Agerfalk, N. Kraiem, and J. Ralyte, Paris, France: 2005. pp. 107&ndash;121. In conjunction with 13th IEEE International Requirements Engineering Conference,
 </ul>
 </a>
 </div>

--- a/code/stable/swhs/SWHS_SRS.tex
+++ b/code/stable/swhs/SWHS_SRS.tex
@@ -24,7 +24,7 @@
 \newcommand{\lcthelcnum}{LC\thelcnum}
 \bibliography{bibfile}
 \title{Software Requirements Specification for Solar Water Heating Systems Incorporating PCM}
-\author{ThulasiJegatheesan,BrooksMacLachlan, andW.SpencerSmith}
+\author{Thulasi Jegatheesan, Brooks MacLachlan, and W. Spencer Smith}
 \begin{document}
 \maketitle
 \tableofcontents
@@ -1049,7 +1049,7 @@ ${{t_{final}}^{max}}$ & maximum final time & $86400$ & s
 \label{Sec:References}
 \begin{filecontents*}{bibfile.bib}
 @book{bueche1986,
-author={Bueche, J.Frederick},
+author={Bueche, J. Frederick},
 title={Introduction to Physics for Scientists},
 publisher={McGraw Hill},
 year={1986},
@@ -1057,7 +1057,7 @@ edition={4},
 address={New York City, New York}}
 
 @book{incroperaEtAl2007,
-author={Incropera, F.P. and Dewitt, D.P. and Bergman, T.L. and Lavine, A.S.},
+author={Incropera, F. P. and Dewitt, D. P. and Bergman, T. L. and Lavine, A. S.},
 title={Fundamentals of Heat and Mass Transfer},
 publisher={John Wiley and Sons},
 year={2007},
@@ -1078,7 +1078,7 @@ year={2012},
 note={From Marilyn Lightstone's Personal Notes}}
 
 @article{parnas1986,
-author={Parnas, DavidL. and Clements, P.C.},
+author={Parnas, David L. and Clements, P. C.},
 title={A rational design process: How and why to fake it},
 journal={IEEE Transactions on Software Engineering},
 year={1986},
@@ -1089,7 +1089,7 @@ pages={"251-257"},
 address={Washington, USA}}
 
 @inproceedings{smithLai2005,
-author={Smith, W.Spencer and Lai, Lei},
+author={Smith, W. Spencer and Lai, Lei},
 title={A new requirements template for scientific computing},
 booktitle={Proceedings of the First International Workshop on Situational Requirements Engineering Processes - Methods, Techniques and Tools to Support Situation-Specific Requirements Engineering Processes, SREP'05},
 year={2005},

--- a/code/stable/tiny/SRS.html
+++ b/code/stable/tiny/SRS.html
@@ -16,7 +16,7 @@ Software Requirements Specification for Tiny
 </div>
 <div class="author">
 <h2>
-W.SpencerSmith
+W. Spencer Smith
 </h2>
 </div>
 <a id="Sec:RefMat">

--- a/code/stable/tiny/SRS.tex
+++ b/code/stable/tiny/SRS.tex
@@ -13,7 +13,7 @@
 \usepackage{caption}
 \global\tabulinesep=1mm
 \title{Software Requirements Specification for Tiny}
-\author{W.SpencerSmith}
+\author{W. Spencer Smith}
 \begin{document}
 \maketitle
 \tableofcontents


### PR DESCRIPTION
Fixes a previous refactoring which removed spaces between names. 

[Commit 1019565](https://github.com/JacquesCarette/Drasil/commit/10195651cd0c2ee467ac69102c1de6c6065c7b3d) refactored _People_ to output _String_ instead of _Sentence_, however the +:+ combinator was replaced with ++. The former adds a space between two sentences if both are non-empty.  [Commit 4942a2a](https://github.com/JacquesCarette/Drasil/commit/4942a2a1b9d4ab642d4f4edf0c0c8fc6e9416b4c) is the commit where stable was updated with the erroneous name output. 

This bug is a shortcoming of the _diff_ command being used; _diff_ is called with argument _--ignore-all-space_ meaning [Commit 1019565](https://github.com/JacquesCarette/Drasil/commit/10195651cd0c2ee467ac69102c1de6c6065c7b3d) would have passed all tests despite not matching. 