### PR TITLE
Refactor rendPersL.

### DIFF
--- a/code/Language/Drasil/HTML/Print.hs
+++ b/code/Language/Drasil/HTML/Print.hs
@@ -21,7 +21,7 @@ import qualified Language.Drasil.Symbol as S
 import qualified Language.Drasil.Document as L
 import Language.Drasil.HTML.Monad
 import Language.Drasil.People (People,Person(..),rendPersLFM',rendPersLFM'',
-  Conv(..),nameStr,rendPersLFM, dotInitial, nameSep)
+  Conv(..),nameStr,rendPersLFM)
 import Language.Drasil.Config (StyleGuide(..), bibStyleH)
 import Language.Drasil.ChunkDB(HasSymbolTable)
 
@@ -454,12 +454,8 @@ rendPers = rendPersLFM
 
 -- To render the last person's name
 rendPersL :: Person -> String
-rendPersL (Person {_surname = n, _convention = Mono}) = n
-rendPersL (Person {_given = f, _surname = l, _middle = []}) =
-  dotInitial l ++ ", " ++ dotInitial f
-rendPersL (Person {_given = f, _surname = l, _middle = ms}) =
-  dotInitial l ++ ", " ++ foldr1 nameSep (
-    dotInitial f : map dotInitial (init ms) ++ [last ms])
+rendPersL =
+  (\n -> (if not (null n) && last n == '.' then init else id) n) . rendPers
 
 --adds an 's' if there is more than one person in a list
 toPlural :: People -> String -> String

--- a/code/Language/Drasil/People.hs
+++ b/code/Language/Drasil/People.hs
@@ -4,8 +4,8 @@ module Language.Drasil.People
   , HasName
   , name, manyNames, nameStr
   , Conv(..) --This is needed to unwrap names for the bibliography
-  , lstName, initial, dotInitial
-  , rendPersLFM, rendPersLFM', rendPersLFM'', nameSep
+  , lstName
+  , rendPersLFM, rendPersLFM', rendPersLFM''
   ) where
 
 -- | A person can have a given name, middle name(s), and surname, as well

--- a/code/stable/ssp/SSP_SRS.html
+++ b/code/stable/ssp/SSP_SRS.html
@@ -4532,7 +4532,7 @@ References
 </a>
 <a id="fredlund1977">
 <ul>
-[2]: Fredlund, D. G. and Krahn, J.. "Comparison of slope stability methods of analysis." <em>Canadian Geotechnical Journal</em>, vol. 14, no. 3, April, 1977. pp. 429&ndash;439. Print.
+[2]: Fredlund, D. G. and Krahn, J. "Comparison of slope stability methods of analysis." <em>Canadian Geotechnical Journal</em>, vol. 14, no. 3, April, 1977. pp. 429&ndash;439. Print.
 </ul>
 </a>
 <a id="koothoor2013">


### PR DESCRIPTION
Followup to #515 

rendPersL now does not have knowledge of how to render a Person. 

This commit:
- Fixes leaking rendering of Person in HTML backend.
- Fixes an instance of a citation ending with '..'