### PR TITLE
Moving contents of ExprRelat.hs to a more general file

### DIFF
--- a/code/Language/Drasil.hs
+++ b/code/Language/Drasil.hs
@@ -37,6 +37,7 @@ module Language.Drasil (
   , CommonIdea(abrv)
   , Constrained(constraints)
   , HasReasVal(reasVal)
+  , ExprRelat(relat)
   -- Chunk.VarChunk
   , VarChunk
   , vc, implVar
@@ -78,7 +79,7 @@ module Language.Drasil (
   -- Chunk.Unitary
   , Unitary(..), UnitaryChunk, unitary
   -- Chunk.Relation
-  , RelationConcept, makeRC, makeRC', relat, ExprRelat
+  , RelationConcept, makeRC, makeRC'
   --Chunk.DefinedQuantity
   , cqs, DefinedQuantityDict
   -- Chunk.UnitaryConcept
@@ -244,7 +245,6 @@ import Language.Drasil.Chunk.Constrained.Core (physc, sfwrc, enumc, isPhysC, isS
 import Language.Drasil.Chunk.ConVar (cv, ConVar)
 import Language.Drasil.Chunk.DefinedQuantity
 import Language.Drasil.Chunk.Eq (QDefinition, fromEqn, fromEqn', fromEqn'', getVC, equat, aqd, ec, ec')
-import Language.Drasil.Chunk.ExprRelat
 import Language.Drasil.Chunk.GenDefn
 import Language.Drasil.Chunk.Goal (Goal, mkGoal)
 import Language.Drasil.Chunk.InstanceModel

--- a/code/Language/Drasil.hs
+++ b/code/Language/Drasil.hs
@@ -211,7 +211,7 @@ import Language.Drasil.Unit -- all of it
 import Language.Drasil.Classes (HasUID(uid), NamedIdea(term), Idea(getA),
   Definition(defn), ConceptDomain(cdom), Concept, HasSymbol(symbol), HasUnitSymbol(usymb),
   IsUnit, HasAttributes(attributes), CommonIdea(abrv),
-  Constrained(constraints), HasReasVal(reasVal))
+  Constrained(constraints), HasReasVal(reasVal), ExprRelat(relat))
 import Language.Drasil.Chunk.AssumpChunk
 import Language.Drasil.Chunk.Attribute
 import Language.Drasil.Chunk.Attribute.Core (Attributes)

--- a/code/Language/Drasil/Chunk/Code.hs
+++ b/code/Language/Drasil/Chunk/Code.hs
@@ -10,13 +10,12 @@ module Language.Drasil.Chunk.Code (
 
 import Control.Lens ((^.),makeLenses,view)
 
-import Language.Drasil.Chunk.Constrained.Core (Constraint,isPhysC)
+import Language.Drasil.Chunk.Constrained.Core (Constraint, isPhysC)
 import Language.Drasil.Chunk.Quantity
 import Language.Drasil.Chunk.Eq (QDefinition)
-import Language.Drasil.Chunk.ExprRelat (relat)
 import Language.Drasil.Chunk.SymbolForm (codeSymb)
 import Language.Drasil.Classes (HasUID(uid), NamedIdea(term), Idea(getA),
-  HasSymbol(symbol), CommonIdea(abrv), Constrained(constraints))
+  HasSymbol(symbol), CommonIdea(abrv), Constrained(constraints), ExprRelat(relat))
 
 import Language.Drasil.Space as S
 import Language.Drasil.Code.Code as G (CodeType(..))

--- a/code/Language/Drasil/Chunk/Eq.hs
+++ b/code/Language/Drasil/Chunk/Eq.hs
@@ -5,13 +5,12 @@ module Language.Drasil.Chunk.Eq
 
 import Control.Lens ((^.), makeLenses)
 import Language.Drasil.Expr (Expr)
-import Language.Drasil.Classes (HasUID(uid),NamedIdea(term), Idea(getA),DOM,
-  HasSymbol(symbol), IsUnit, HasAttributes(attributes))
+import Language.Drasil.Classes (HasUID(uid),NamedIdea(term), Idea(getA), DOM,
+  HasSymbol(symbol), IsUnit, HasAttributes(attributes), ExprRelat(relat))
 import Language.Drasil.Chunk.Attribute.Core (Attributes)
 import Language.Drasil.Chunk.Concept (ConceptChunk)
-import Language.Drasil.Chunk.Quantity (Quantity(getUnit),HasSpace(typ), QuantityDict,
+import Language.Drasil.Chunk.Quantity (Quantity(getUnit), HasSpace(typ), QuantityDict,
   mkQuant, qw)
-import Language.Drasil.Chunk.ExprRelat
 import Language.Drasil.Chunk.VarChunk (VarChunk, vcSt)
 import Language.Drasil.Unit (unitWrapper)
 import Language.Drasil.Symbol (Symbol)

--- a/code/Language/Drasil/Chunk/ExprRelat.hs
+++ b/code/Language/Drasil/Chunk/ExprRelat.hs
@@ -1,8 +1,0 @@
-module Language.Drasil.Chunk.ExprRelat (ExprRelat (relat)) where
-
-import Language.Drasil.Expr (Expr)
-
-import Control.Lens (Lens')
-
-class ExprRelat c where
-  relat :: Lens' c Expr

--- a/code/Language/Drasil/Chunk/GenDefn.hs
+++ b/code/Language/Drasil/Chunk/GenDefn.hs
@@ -4,10 +4,10 @@ module Language.Drasil.Chunk.GenDefn
   ) where
 
 import Language.Drasil.Classes (HasUID(uid), NamedIdea(term), Idea(getA),
-  Definition(defn), ConceptDomain(cdom,DOM), Concept, IsUnit, HasAttributes(attributes))
+  Definition(defn), ConceptDomain(cdom,DOM), Concept, IsUnit, 
+  HasAttributes(attributes), ExprRelat(relat))
 import Language.Drasil.Chunk.Attribute.Core (Attributes)
 import Language.Drasil.Chunk.Concept (ConceptChunk)
-import Language.Drasil.Chunk.ExprRelat (ExprRelat(relat))
 import Language.Drasil.Chunk.Relation (RelationConcept)
 import Language.Drasil.Unit (unitWrapper, UnitDefn)
 

--- a/code/Language/Drasil/Chunk/InstanceModel.hs
+++ b/code/Language/Drasil/Chunk/InstanceModel.hs
@@ -5,12 +5,12 @@ module Language.Drasil.Chunk.InstanceModel
   )where
 
 import Language.Drasil.Classes (HasUID(uid), NamedIdea(term), Idea(getA),
-  Definition(defn),ConceptDomain(cdom,DOM),Concept, HasAttributes(attributes))
+  Definition(defn),ConceptDomain(cdom,DOM),Concept, HasAttributes(attributes),
+  ExprRelat(relat))
 import Language.Drasil.Chunk.Attribute.Core (Attributes)
 import Language.Drasil.Chunk.Concept
 import Language.Drasil.Chunk.Constrained.Core (TheoryConstraint)
 import Language.Drasil.Chunk.Eq
-import Language.Drasil.Chunk.ExprRelat
 import Language.Drasil.Chunk.Relation
 import Language.Drasil.Chunk.Quantity
 import Language.Drasil.ChunkDB

--- a/code/Language/Drasil/Chunk/Relation.hs
+++ b/code/Language/Drasil/Chunk/Relation.hs
@@ -7,10 +7,9 @@ module Language.Drasil.Chunk.Relation
 import Control.Lens (makeLenses, (^.))
 import Language.Drasil.Expr (Relation)
 import Language.Drasil.Classes (HasUID(uid),NamedIdea(term),Idea(getA),
-  Definition(defn),ConceptDomain(cdom,DOM),Concept)
+  Definition(defn), ConceptDomain(cdom, DOM), Concept, ExprRelat)
 import Language.Drasil.Chunk.Concept
 import Language.Drasil.Spec (Sentence(..))
-import Language.Drasil.Chunk.ExprRelat
 
 import Language.Drasil.NounPhrase (NP)
 

--- a/code/Language/Drasil/Chunk/Relation.hs
+++ b/code/Language/Drasil/Chunk/Relation.hs
@@ -7,7 +7,7 @@ module Language.Drasil.Chunk.Relation
 import Control.Lens (makeLenses, (^.))
 import Language.Drasil.Expr (Relation)
 import Language.Drasil.Classes (HasUID(uid),NamedIdea(term),Idea(getA),
-  Definition(defn), ConceptDomain(cdom, DOM), Concept, ExprRelat)
+  Definition(defn), ConceptDomain(cdom, DOM), Concept, ExprRelat(relat))
 import Language.Drasil.Chunk.Concept
 import Language.Drasil.Spec (Sentence(..))
 

--- a/code/Language/Drasil/Classes.hs
+++ b/code/Language/Drasil/Classes.hs
@@ -21,9 +21,9 @@ module Language.Drasil.Classes (
 
 import Language.Drasil.NounPhrase.Core (NP)
 import Language.Drasil.Spec (Sentence)
-import Language.Drasil.Symbol (Stage,Symbol)
+import Language.Drasil.Symbol (Stage, Symbol)
 import Language.Drasil.Space (Space)
-import Language.Drasil.UnitLang (USymb,UDefn)
+import Language.Drasil.UnitLang (USymb, UDefn)
 import Language.Drasil.Chunk.Attribute.Core (Attributes)
 import Language.Drasil.Chunk.Constrained.Core (Constraint)
 import Language.Drasil.Expr (Expr)

--- a/code/Language/Drasil/Classes.hs
+++ b/code/Language/Drasil/Classes.hs
@@ -106,6 +106,6 @@ class (Idea u, Definition u, HasUnitSymbol u) => IsUnit u where
 class UnitEq u where
    uniteq :: Lens' u UDefn
 
--- ?
+-- TODO : there is a design bug here not at all apparent from its definition; have to come back to it (Pull Request #532)
 class ExprRelat c where
   relat :: Lens' c Expr

--- a/code/Language/Drasil/Classes.hs
+++ b/code/Language/Drasil/Classes.hs
@@ -16,6 +16,7 @@ module Language.Drasil.Classes (
   , CommonIdea(abrv)
   , Constrained(constraints)
   , HasReasVal(reasVal)
+  , ExprRelat(relat)
   ) where
 
 import Language.Drasil.NounPhrase.Core (NP)
@@ -105,3 +106,6 @@ class (Idea u, Definition u, HasUnitSymbol u) => IsUnit u where
 class UnitEq u where
    uniteq :: Lens' u UDefn
 
+-- ?
+class ExprRelat c where
+  relat :: Lens' c Expr

--- a/code/Language/Drasil/CodeSpec.hs
+++ b/code/Language/Drasil/CodeSpec.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE GADTs #-}
 module Language.Drasil.CodeSpec where
 
-import Language.Drasil.Classes (term,CommonIdea)
+import Language.Drasil.Classes (term, CommonIdea, ExprRelat(relat))
 import Language.Drasil.Chunk.Code
 import Language.Drasil.Chunk.Eq
 import Language.Drasil.Chunk.Quantity -- for hack
@@ -14,7 +14,6 @@ import Language.Drasil.Expr -- for hack
 import Language.Drasil.Expr.Math (sy)
 import Language.Drasil.Space -- for hack
 import Language.Drasil.DataDesc
-import Language.Drasil.Chunk.ExprRelat
 import Language.Drasil.ChunkDB
 import Language.Drasil.Expr.Extract (codevars, codevars')
 import Language.Drasil.Chunk.VarChunk

--- a/code/Language/Drasil/HTML/Print.hs
+++ b/code/Language/Drasil/HTML/Print.hs
@@ -20,8 +20,8 @@ import           Language.Drasil.Symbol (Symbol(..))
 import qualified Language.Drasil.Symbol as S
 import qualified Language.Drasil.Document as L
 import Language.Drasil.HTML.Monad
-import Language.Drasil.People (People,Person(..),rendPersLFM',rendPersLFM'',
-  Conv(..),nameStr,rendPersLFM)
+import Language.Drasil.People (People, Person(..), rendPersLFM', rendPersLFM'',
+  nameStr, rendPersLFM)
 import Language.Drasil.Config (StyleGuide(..), bibStyleH)
 import Language.Drasil.ChunkDB(HasSymbolTable)
 

--- a/code/Language/Drasil/Printing/Import.hs
+++ b/code/Language/Drasil/Printing/Import.hs
@@ -10,13 +10,12 @@ import qualified Language.Drasil.Printing.AST as P
 import qualified Language.Drasil.Printing.Citation as P
 import qualified Language.Drasil.Printing.LayoutObj as T
 
-import Language.Drasil.Classes (term,defn,usymb,HasAttributes)
+import Language.Drasil.Classes (term, defn, usymb, HasAttributes, relat)
 import qualified Language.Drasil.Chunk.SymbolForm as SF
 import Language.Drasil.Chunk.AssumpChunk
 import Language.Drasil.Chunk.Attribute (getShortName)
 import Language.Drasil.Chunk.Change (chng, chngType, ChngType(Likely))
 import Language.Drasil.Chunk.Eq
-import Language.Drasil.Chunk.ExprRelat (relat)
 import Language.Drasil.Chunk.Quantity (Quantity(..))
 import Language.Drasil.Chunk.SymbolForm (eqSymb)
 import Language.Drasil.ChunkDB (getUnitLup, HasSymbolTable(..),symbLookup)

--- a/code/drasil.cabal
+++ b/code/drasil.cabal
@@ -96,7 +96,6 @@ library
     , Language.Drasil.Chunk.Constrained.Core
     , Language.Drasil.Chunk.DefinedQuantity
     , Language.Drasil.Chunk.Eq
-    , Language.Drasil.Chunk.ExprRelat
     , Language.Drasil.Chunk.GenDefn
     , Language.Drasil.Chunk.Goal
     , Language.Drasil.Chunk.InstanceModel


### PR DESCRIPTION
Is there a reason why [this file](https://github.com/JacquesCarette/Drasil/blob/master/code/Language/Drasil/Chunk/ExprRelat.hs) is on its own?

Does it make sense for its contents to be in https://github.com/JacquesCarette/Drasil/blob/master/code/Language/Drasil/Classes.hs, so the data-type-files do not need to import Language.Drasil.Chunk.ExprRelat separately when they are instances of this class?