### PR TITLE
Change section tags from <a> to <div> in HTML backend.

### DIFF
--- a/code/Language/Drasil/HTML/Helpers.hs
+++ b/code/Language/Drasil/HTML/Helpers.hs
@@ -49,7 +49,7 @@ caption = wrap "p" ["caption"]
 
 -- | Helper for setting up references
 refwrap :: Doc -> Doc -> Doc
-refwrap r x = vcat [hcat [text "<a id=\"", r, text  "\">"], x, text "</a>"]
+refwrap r x = vcat [hcat [text "<div id=\"", r, text  "\">"], x, text "</div>"]
 
 -- | Helper for setting up links to references
 reflink :: String -> Doc -> Doc

--- a/code/stable/gamephys/Chipmunk_SRS.html
+++ b/code/stable/gamephys/Chipmunk_SRS.html
@@ -19,7 +19,7 @@ Software Requirements Specification for Chipmunk2D
 Alex Halliwushka and Luthfi Mawarid
 </h2>
 </div>
-<a id="Sec:RefMat">
+<div id="Sec:RefMat">
 <div class="section">
 <h1>
 Reference Material
@@ -27,7 +27,7 @@ Reference Material
 <p class="paragraph">
 This section records information for easy reference.
 </p>
-<a id="Sec:ToU">
+<div id="Sec:ToU">
 <div class="subsection">
 <h2>
 Table of Units
@@ -35,7 +35,7 @@ Table of Units
 <p class="paragraph">
 The unit system used throughout is SI (Système International d'Unités). In addition to the basic units, several derived units are also used. For each unit, the table lists the symbol, a description and the SI name.
 </p>
-<a id="Table:ToU">
+<div id="Table:ToU">
 <table class="table">
 <tr>
 <th>
@@ -86,10 +86,10 @@ time (second)
 </td>
 </tr>
 </table>
-</a>
 </div>
-</a>
-<a id="Sec:ToS">
+</div>
+</div>
+<div id="Sec:ToS">
 <div class="subsection">
 <h2>
 Table of Symbols
@@ -97,7 +97,7 @@ Table of Symbols
 <p class="paragraph">
 The table that follows summarizes the symbols used in this document along with their units. Throughout the document, symbols in bold will represent vectors, and scalars otherwise. The symbols are listed in alphabetical order.
 </p>
-<a id="Table:ToS">
+<div id="Table:ToS">
 <table class="table">
 <tr>
 <th>
@@ -848,15 +848,15 @@ rad/s
 </td>
 </tr>
 </table>
-</a>
 </div>
-</a>
-<a id="Sec:TAbbAcc">
+</div>
+</div>
+<div id="Sec:TAbbAcc">
 <div class="subsection">
 <h2>
 Abbreviations and Acronyms
 </h2>
-<a id="Table:TAbbAcc">
+<div id="Table:TAbbAcc">
 <table class="table">
 <tr>
 <th>
@@ -971,12 +971,12 @@ Theoretical Model
 </td>
 </tr>
 </table>
-</a>
 </div>
-</a>
 </div>
-</a>
-<a id="Sec:Intro">
+</div>
+</div>
+</div>
+<div id="Sec:Intro">
 <div class="section">
 <h1>
 Introduction
@@ -987,7 +987,7 @@ Due to the rising cost of developing video games, developers are looking for way
 <p class="paragraph">
 The following section provides an overview of the Software Requirements Specification (SRS) for Chipmunk2D. This section explains the purpose of this document, the scope of the system, the organization of the document, and the characteristics of the intended reader.
 </p>
-<a id="Sec:DocPurpose">
+<div id="Sec:DocPurpose">
 <div class="subsection">
 <h2>
 Purpose of Document
@@ -999,8 +999,8 @@ This document descibes the modeling of an open source 2D rigid body physics libr
 This document will be used as a starting point for subsequent development phases, including writing the design specification and the software verification and validation plan. The design document will show how the requirements are to be realized, including decisions on the numerical algorithms and programming environment. The verification and validation plan will show the steps that will be used to increase confidence in the software documentation and the implementation. Although the SRS fits in a series of documents that follow the so-called waterfall model, the actual development process is not constrained in any way. Even when the waterfall model is not followed, as Parnas and Clements point out, the most logical way to present the documentation is still to &quot;fake&quot; a rational design process.
 </p>
 </div>
-</a>
-<a id="Sec:ReqsScope">
+</div>
+<div id="Sec:ReqsScope">
 <div class="subsection">
 <h2>
 Scope of Requirements
@@ -1009,8 +1009,8 @@ Scope of Requirements
 The scope of the requirements includes the physical simulation of 2D rigid bodies acted on by forces. Given the appropriate inputs, the code for Chipmunk2D is intended to simulate how these rigid bodies interact with one another.
 </p>
 </div>
-</a>
-<a id="Sec:ReaderChars">
+</div>
+<div id="Sec:ReaderChars">
 <div class="subsection">
 <h2>
 Characteristics of Intended Reader
@@ -1019,8 +1019,8 @@ Characteristics of Intended Reader
 Reviewers of this documentation should have a strong knowledge in rigid body dynamics. The reviewers should also have an understanding of high school calculus. The users of Chipmunk2D can have a lower level of expertise, as explained in <a href=#Sec:UserChars>User Characteristics</a>.
 </p>
 </div>
-</a>
-<a id="Sec:DocOrg">
+</div>
+<div id="Sec:DocOrg">
 <div class="subsection">
 <h2>
 Organization of Document
@@ -1032,10 +1032,10 @@ The organization of this document follows the template for an SRS for scientific
 The goal statements are refined to the theoretical models, and the theoretical models to the instance models.
 </p>
 </div>
-</a>
 </div>
-</a>
-<a id="Sec:GenSysDesc">
+</div>
+</div>
+<div id="Sec:GenSysDesc">
 <div class="section">
 <h1>
 General System Description
@@ -1043,7 +1043,7 @@ General System Description
 <p class="paragraph">
 This section provides general information about the system, identifies the interfaces between the system and its environment, and describes the user characteristics and the system constraints.
 </p>
-<a id="Sec:usercharacteristic">
+<div id="Sec:usercharacteristic">
 <div class="subsection">
 <h2>
 User Characteristics
@@ -1052,8 +1052,8 @@ User Characteristics
 The end user of Chipmunk2D should have an understanding of first year programming concepts and an understanding of high school physics.
 </p>
 </div>
-</a>
-<a id="Sec:SysConstraints">
+</div>
+<div id="Sec:SysConstraints">
 <div class="subsection">
 <h2>
 System Constraints
@@ -1062,10 +1062,10 @@ System Constraints
 There are no system constraints.
 </p>
 </div>
-</a>
 </div>
-</a>
-<a id="Sec:SpecSystDesc">
+</div>
+</div>
+<div id="Sec:SpecSystDesc">
 <div class="section">
 <h1>
 Specific System Description
@@ -1073,7 +1073,7 @@ Specific System Description
 <p class="paragraph">
 This section first presents the problem description, which gives a high-level view of the problem to be solved. This is followed by the solution characteristics specification, which presents the assumptions, theories, and definitions that are used for the physics library.
 </p>
-<a id="Sec:ProbDesc">
+<div id="Sec:ProbDesc">
 <div class="subsection">
 <h2>
 Problem Description
@@ -1081,7 +1081,7 @@ Problem Description
 <p class="paragraph">
 Creating a gaming physics library is a difficult task. Games need physics libraries that simulate objects acting under various physical conditions, while simultaneously being fast and efficient enough to work in soft real-time during the game. Developing a physics library from scratch takes a long period of time and is very costly, presenting barriers of entry which make it difficult for game developers to include physics in their products. There are a few free, open source and high quality physics libraries available to be used for consumer products (<a href=#Sec:ExistingSolns>Off-The-Shelf Solutions</a>). By creating a simple, lightweight, fast and portable 2D rigid body physics library, game development will be more accessible to the masses and higher quality products will be produced.
 </p>
-<a id="Sec:TermDefs">
+<div id="Sec:TermDefs">
 <div class="subsubsection">
 <h3>
 Terminology and Definitions
@@ -1107,8 +1107,8 @@ Right-handed coordinate system: A coordinate system where the positive z-axis co
 </li>
 </ul>
 </div>
-</a>
-<a id="Sec:GoalStmt">
+</div>
+<div id="Sec:GoalStmt">
 <div class="subsubsection">
 <h3>
 Goal Statements
@@ -1131,10 +1131,10 @@ GS4: Given the physical properties, initial positions, orientations, linear velo
 </p>
 </div>
 </div>
-</a>
 </div>
-</a>
-<a id="Sec:SolCharSpec">
+</div>
+</div>
+<div id="Sec:SolCharSpec">
 <div class="subsection">
 <h2>
 Solution Characteristics Specification
@@ -1142,7 +1142,7 @@ Solution Characteristics Specification
 <p class="paragraph">
 The instance models that govern Chipmunk2D are presented in FIXME REF to IModSection. The information to understand the meaning of the instance models and their derivation is also presented, so that the instance models can be verified.
 </p>
-<a id="Sec:Assumps">
+<div id="Sec:Assumps">
 <div class="subsubsection">
 <h3>
 Assumptions
@@ -1174,8 +1174,8 @@ A7: There are no constraints and joints involved throughout the simulation.
 </p>
 </div>
 </div>
-</a>
-<a id="Sec:TMs">
+</div>
+<div id="Sec:TMs">
 <div class="subsubsection">
 <h3>
 Theoretical Models
@@ -1183,7 +1183,7 @@ Theoretical Models
 <p class="paragraph">
 This section focuses on the general equations and laws that Chipmunk2D is based on.
 </p>
-<a id="T:t1NewtonSL">
+<div id="T:t1NewtonSL">
 <table class="tdefn">
 <tr>
 <th>
@@ -1200,13 +1200,13 @@ Newton's Second Law of Motion
 Equation
 </th>
 <td>
-<a id="">
+<div id="">
 <div class="equation">
 <p class="paragraph">
 <em><b>F</b> = m&#8239;<b>a</b></em>
 </p>
 </div>
-</a>
+</div>
 </td>
 </tr>
 <tr>
@@ -1220,8 +1220,8 @@ The net force <em><b>F</b></em> (N) on a rigid body is proportional to the accel
 </td>
 </tr>
 </table>
-</a>
-<a id="T:t2NewtonTL">
+</div>
+<div id="T:t2NewtonTL">
 <table class="tdefn">
 <tr>
 <th>
@@ -1238,13 +1238,13 @@ Newton's Third Law of Motion
 Equation
 </th>
 <td>
-<a id="">
+<div id="">
 <div class="equation">
 <p class="paragraph">
 <em><b>F</b><sub>1</sub> = &minus;<b>F</b><sub>2</sub></em>
 </p>
 </div>
-</a>
+</div>
 </td>
 </tr>
 <tr>
@@ -1258,8 +1258,8 @@ Every action has an equal and opposite reaction. In other words, the force <em><
 </td>
 </tr>
 </table>
-</a>
-<a id="T:t3NewtonLUG">
+</div>
+<div id="T:t3NewtonLUG">
 <table class="tdefn">
 <tr>
 <th>
@@ -1276,7 +1276,7 @@ Newton's Law of Universal Gravitation
 Equation
 </th>
 <td>
-<a id="">
+<div id="">
 <div class="equation">
 <p class="paragraph">
 <em><b>F</b> = G&#8239;<div class="fraction">
@@ -1303,7 +1303,7 @@ m<sub>1</sub>&#8239;m<sub>2</sub>
 </div></em>
 </p>
 </div>
-</a>
+</div>
 </td>
 </tr>
 <tr>
@@ -1317,8 +1317,8 @@ Two rigid bodies in the universe attract each other with a force <em><b>F</b></e
 </td>
 </tr>
 </table>
-</a>
-<a id="T:t4ChaslesThm">
+</div>
+<div id="T:t4ChaslesThm">
 <table class="tdefn">
 <tr>
 <th>
@@ -1335,13 +1335,13 @@ Chasles' Theorem
 Equation
 </th>
 <td>
-<a id="">
+<div id="">
 <div class="equation">
 <p class="paragraph">
 <em><b>v</b><sub>B</sub> = <b>v</b><sub>O</sub>&plus;&omega;&#10799;<b>r</b><sub>OB</sub></em>
 </p>
 </div>
-</a>
+</div>
 </td>
 </tr>
 <tr>
@@ -1355,8 +1355,8 @@ The linear velocity <em><b>v</b><sub>B</sub></em> (m/s) of any point B in a rigi
 </td>
 </tr>
 </table>
-</a>
-<a id="T:t5NewtonSLR">
+</div>
+<div id="T:t5NewtonSLR">
 <table class="tdefn">
 <tr>
 <th>
@@ -1373,13 +1373,13 @@ Newton's Second Law for Rotational Motion
 Equation
 </th>
 <td>
-<a id="">
+<div id="">
 <div class="equation">
 <p class="paragraph">
 <em>&tau; = <b>I</b>&#8239;&alpha;</em>
 </p>
 </div>
-</a>
+</div>
 </td>
 </tr>
 <tr>
@@ -1393,10 +1393,10 @@ The net torque <em>&tau;</em> (N&sdot;m) on a rigid body is proportional to its 
 </td>
 </tr>
 </table>
-</a>
 </div>
-</a>
-<a id="Sec:GDs">
+</div>
+</div>
+<div id="Sec:GDs">
 <div class="subsubsection">
 <h3>
 General Definitions
@@ -1405,8 +1405,8 @@ General Definitions
 There are no general definitions.
 </p>
 </div>
-</a>
-<a id="Sec:IMs">
+</div>
+<div id="Sec:IMs">
 <div class="subsubsection">
 <h3>
 Instance Models
@@ -1414,7 +1414,7 @@ Instance Models
 <p class="paragraph">
 This section transforms the problem defined in FIXME REF into one which is expressed in mathematical terms. It uses concrete symbols defined in FIXME REF to replace the abstract symbols in the models identified in FIXME REF and FIXME REF.
 </p>
-<a id="T:im1">
+<div id="T:im1">
 <table class="tdefn">
 <tr>
 <th>
@@ -1431,7 +1431,7 @@ Force on the Translational Motion of a Set of 2d Rigid Bodies
 Equation
 </th>
 <td>
-<a id="">
+<div id="">
 <div class="equation">
 <p class="paragraph">
 <em><b>a</b><sub>i</sub> = <div class="fraction">
@@ -1451,7 +1451,7 @@ m<sub>j</sub>
 </div></em>
 </p>
 </div>
-</a>
+</div>
 </td>
 </tr>
 <tr>
@@ -1465,8 +1465,8 @@ The above equation expresses the total acceleration of the rigid body (A1, A2) i
 </td>
 </tr>
 </table>
-</a>
-<a id="T:im2">
+</div>
+<div id="T:im2">
 <table class="tdefn">
 <tr>
 <th>
@@ -1483,7 +1483,7 @@ Force on the Rotational Motion of a Set of 2D Rigid Body
 Equation
 </th>
 <td>
-<a id="">
+<div id="">
 <div class="equation">
 <p class="paragraph">
 <em>&alpha; = <div class="fraction">
@@ -1503,7 +1503,7 @@ d&#8239;t
 </div></em>
 </p>
 </div>
-</a>
+</div>
 </td>
 </tr>
 <tr>
@@ -1517,8 +1517,8 @@ The above equation for the total angular acceleration of the rigid body (A1, A2)
 </td>
 </tr>
 </table>
-</a>
-<a id="T:im3">
+</div>
+<div id="T:im3">
 <table class="tdefn">
 <tr>
 <th>
@@ -1535,7 +1535,7 @@ Collisions on 2D Rigid Bodies
 Equation
 </th>
 <td>
-<a id="">
+<div id="">
 <div class="equation">
 <p class="paragraph">
 <em><b>v</b><sub>A</sub>(t<sub>c</sub>) = <b>v</b><sub>A</sub>(t)&plus;<div class="fraction">
@@ -1548,7 +1548,7 @@ m<sub>A</sub>
 </div>&#8239;<b>n</b></em>
 </p>
 </div>
-</a>
+</div>
 </td>
 </tr>
 <tr>
@@ -1562,10 +1562,10 @@ This instance model is based on our assumptions regarding rigid body (A1, A2) co
 </td>
 </tr>
 </table>
-</a>
 </div>
-</a>
-<a id="Sec:DDs">
+</div>
+</div>
+<div id="Sec:DDs">
 <div class="subsubsection">
 <h3>
 Data Definitions
@@ -1573,7 +1573,7 @@ Data Definitions
 <p class="paragraph">
 This section collects and defines all the data needed to build the instance models. The dimension of each quantity is also given.
 </p>
-<a id="DD:p.CM">
+<div id="DD:p.CM">
 <table class="ddefn">
 <tr>
 <th>
@@ -1600,7 +1600,7 @@ m
 Equation
 </th>
 <td>
-<a id="">
+<div id="">
 <div class="equation">
 <p class="paragraph">
 <em><b>p</b><sub>CM</sub> = <div class="fraction">
@@ -1613,7 +1613,7 @@ M
 </div></em>
 </p>
 </div>
-</a>
+</div>
 </td>
 </tr>
 <tr>
@@ -1627,8 +1627,8 @@ Description
 </td>
 </tr>
 </table>
-</a>
-<a id="DD:linearDisplacement">
+</div>
+<div id="DD:linearDisplacement">
 <table class="ddefn">
 <tr>
 <th>
@@ -1655,7 +1655,7 @@ m
 Equation
 </th>
 <td>
-<a id="">
+<div id="">
 <div class="equation">
 <p class="paragraph">
 <em><b>r</b>(t) = <div class="fraction">
@@ -1668,7 +1668,7 @@ d&#8239;t
 </div></em>
 </p>
 </div>
-</a>
+</div>
 </td>
 </tr>
 <tr>
@@ -1682,8 +1682,8 @@ Description
 </td>
 </tr>
 </table>
-</a>
-<a id="DD:linearVelocity">
+</div>
+<div id="DD:linearVelocity">
 <table class="ddefn">
 <tr>
 <th>
@@ -1710,7 +1710,7 @@ m/s
 Equation
 </th>
 <td>
-<a id="">
+<div id="">
 <div class="equation">
 <p class="paragraph">
 <em><b>v</b>(t) = <div class="fraction">
@@ -1723,7 +1723,7 @@ d&#8239;t
 </div></em>
 </p>
 </div>
-</a>
+</div>
 </td>
 </tr>
 <tr>
@@ -1737,8 +1737,8 @@ Description
 </td>
 </tr>
 </table>
-</a>
-<a id="DD:linearAcceleration">
+</div>
+<div id="DD:linearAcceleration">
 <table class="ddefn">
 <tr>
 <th>
@@ -1765,7 +1765,7 @@ m/s<sup>2</sup>
 Equation
 </th>
 <td>
-<a id="">
+<div id="">
 <div class="equation">
 <p class="paragraph">
 <em><b>a</b>(t) = <div class="fraction">
@@ -1778,7 +1778,7 @@ d&#8239;t
 </div></em>
 </p>
 </div>
-</a>
+</div>
 </td>
 </tr>
 <tr>
@@ -1792,8 +1792,8 @@ Description
 </td>
 </tr>
 </table>
-</a>
-<a id="DD:angularDisplacement">
+</div>
+<div id="DD:angularDisplacement">
 <table class="ddefn">
 <tr>
 <th>
@@ -1820,7 +1820,7 @@ rad
 Equation
 </th>
 <td>
-<a id="">
+<div id="">
 <div class="equation">
 <p class="paragraph">
 <em>&theta; = <div class="fraction">
@@ -1833,7 +1833,7 @@ d&#8239;t
 </div></em>
 </p>
 </div>
-</a>
+</div>
 </td>
 </tr>
 <tr>
@@ -1847,8 +1847,8 @@ Description
 </td>
 </tr>
 </table>
-</a>
-<a id="DD:angularVelocity">
+</div>
+<div id="DD:angularVelocity">
 <table class="ddefn">
 <tr>
 <th>
@@ -1875,7 +1875,7 @@ rad/s
 Equation
 </th>
 <td>
-<a id="">
+<div id="">
 <div class="equation">
 <p class="paragraph">
 <em>&omega; = <div class="fraction">
@@ -1888,7 +1888,7 @@ d&#8239;t
 </div></em>
 </p>
 </div>
-</a>
+</div>
 </td>
 </tr>
 <tr>
@@ -1902,8 +1902,8 @@ Description
 </td>
 </tr>
 </table>
-</a>
-<a id="DD:angularAcceleration">
+</div>
+<div id="DD:angularAcceleration">
 <table class="ddefn">
 <tr>
 <th>
@@ -1930,7 +1930,7 @@ rad/s<sup>2</sup>
 Equation
 </th>
 <td>
-<a id="">
+<div id="">
 <div class="equation">
 <p class="paragraph">
 <em>&alpha; = <div class="fraction">
@@ -1943,7 +1943,7 @@ d&#8239;t
 </div></em>
 </p>
 </div>
-</a>
+</div>
 </td>
 </tr>
 <tr>
@@ -1957,8 +1957,8 @@ Description
 </td>
 </tr>
 </table>
-</a>
-<a id="DD:impulseS">
+</div>
+<div id="DD:impulseS">
 <table class="ddefn">
 <tr>
 <th>
@@ -1985,7 +1985,7 @@ N&sdot;s
 Equation
 </th>
 <td>
-<a id="">
+<div id="">
 <div class="equation">
 <p class="paragraph">
 <em>j = <div class="fraction">
@@ -2026,7 +2026,7 @@ m<sub>B</sub>
 </div></em>
 </p>
 </div>
-</a>
+</div>
 </td>
 </tr>
 <tr>
@@ -2040,10 +2040,10 @@ Description
 </td>
 </tr>
 </table>
-</a>
 </div>
-</a>
-<a id="Sec:DataConstraints">
+</div>
+</div>
+<div id="Sec:DataConstraints">
 <div class="subsubsection">
 <h3>
 Data Constraints
@@ -2051,7 +2051,7 @@ Data Constraints
 <p class="paragraph">
 the data constraints on the input and output variables, respectively. The column for physical constraints gives the physical limitations on the range of values that can be taken by the variable. The constraints are conservative, to give the user of the model the flexibility to experiment with unusual situations. The column of typical values is intended to provide a feel for a common scenario. The uncertainty column provides an estimate of the confidence with which the physical quantities can be measured. This information would be part of the input if one were performing an uncertainty quantification exercise. FIXME
 </p>
-<a id="Table:InDataConstraints">
+<div id="Table:InDataConstraints">
 <table class="table">
 <tr>
 <th>
@@ -2232,8 +2232,8 @@ None
 <p class="caption">
 Input Data Constraints
 </p>
-</a>
-<a id="Table:OutDataConstraints">
+</div>
+<div id="Table:OutDataConstraints">
 <table class="table">
 <tr>
 <th>
@@ -2264,14 +2264,14 @@ Var
 <p class="caption">
 Output Data Constraints
 </p>
-</a>
 </div>
-</a>
 </div>
-</a>
 </div>
-</a>
-<a id="Sec:Requirements">
+</div>
+</div>
+</div>
+</div>
+<div id="Sec:Requirements">
 <div class="section">
 <h1>
 Requirements
@@ -2279,7 +2279,7 @@ Requirements
 <p class="paragraph">
 This section provides the functional requirements, the business tasks that the software is expected to complete, and the non-functional requirements, the qualities that the software is expected to exhibit.
 </p>
-<a id="Sec:FRs">
+<div id="Sec:FRs">
 <div class="subsection">
 <h2>
 Functional Requirements
@@ -2311,8 +2311,8 @@ R8: Determine the positions and velocities over a period of time of the 2D rigid
 </p>
 </div>
 </div>
-</a>
-<a id="Sec:NFRs">
+</div>
+<div id="Sec:NFRs">
 <div class="subsection">
 <h2>
 Non-Functional Requirements
@@ -2321,10 +2321,10 @@ Non-Functional Requirements
 Games are resource intensive, so performance is a high priority. Other non-functional requirements that are a priority are: correctness, understandability, portability, reliability, and maintainability.
 </p>
 </div>
-</a>
 </div>
-</a>
-<a id="Sec:LCs">
+</div>
+</div>
+<div id="Sec:LCs">
 <div class="section">
 <h1>
 Likely Changes
@@ -2347,8 +2347,8 @@ LC4: The library may be expanded to include joints and constraints.
 </p>
 </div>
 </div>
-</a>
-<a id="Sec:ExistingSolns">
+</div>
+<div id="Sec:ExistingSolns">
 <div class="section">
 <h1>
 Off-The-Shelf Solutions
@@ -2379,8 +2379,8 @@ Newton Game Dynamics: http://newtondynamics.com/
 </li>
 </ul>
 </div>
-</a>
-<a id="Sec:TraceMatrices">
+</div>
+<div id="Sec:TraceMatrices">
 <div class="section">
 <h1>
 Traceability Matrices and Graphs
@@ -2388,7 +2388,7 @@ Traceability Matrices and Graphs
 <p class="paragraph">
 The purpose of the traceability matrices is to provide easy references on what has to be additionally modified if a certain component is changed. Every time a component is changed, the items in the column of that component that are marked with an &quot;X&quot; should be modified as well. <a href=#Table:TraceyReqGoalsOther>Table:TraceyReqGoalsOther</a> shows the dependencies of goal statements, requirements, instance models, and data constraints with each other. <a href=#Table:TraceyAssumpsOther>Table:TraceyAssumpsOther</a> shows the dependencies of theoretical models, general definitions, data definitions, instance models, and on the assumptions. <a href=#Table:TraceyItemsSecs>Table:TraceyItemsSecs</a> shows the dependencies of theoretical models, general definitions, data definitions, and instance models on each other.
 </p>
-<a id="Table:TraceyReqGoalsOther">
+<div id="Table:TraceyReqGoalsOther">
 <table class="table">
 <tr>
 <th>
@@ -2732,8 +2732,8 @@ X
 <p class="caption">
 Traceability Matrix Showing the Connections Between Requirements (<a href=#Sec:Requirements>Requirements</a>), Goal Statements (<a href=#Sec:ProbDesc>Problem Description</a>) and Other Items
 </p>
-</a>
-<a id="Table:TraceyAssumpsOther">
+</div>
+<div id="Table:TraceyAssumpsOther">
 <table class="table">
 <tr>
 <th>
@@ -3467,8 +3467,8 @@ X
 <p class="caption">
 Traceability Matrix Showing the Connections Between Assumptions (<a href=#Sec:ProbDesc>Problem Description</a>) and Other Items
 </p>
-</a>
-<a id="Table:TraceyItemsSecs">
+</div>
+<div id="Table:TraceyItemsSecs">
 <table class="table">
 <tr>
 <th>
@@ -5250,10 +5250,10 @@ X
 <p class="caption">
 Traceability Matrix Showing the Connections Between Items and Other Sections
 </p>
-</a>
 </div>
-</a>
-<a id="Sec:AuxConstants">
+</div>
+</div>
+<div id="Sec:AuxConstants">
 <div class="section">
 <h1>
 Values of Auxiliary Constants
@@ -5262,53 +5262,53 @@ Values of Auxiliary Constants
 There are no auxiliary constants.
 </p>
 </div>
-</a>
-<a id="Sec:References">
+</div>
+<div id="Sec:References">
 <div class="section">
 <h1>
 References
 </h1>
-<a id="dParnas1972">
+<div id="dParnas1972">
 <ul>
 [1]: Parnas, David L. "On the Criteria To Be Used in Decomposing Systems into Modules." <em>Communications of the ACM</em>, 1972. pp. 1053&ndash;1058. Print.
 </ul>
-</a>
-<a id="dParnasPcClements1984">
+</div>
+<div id="dParnasPcClements1984">
 <ul>
 [2]: Parnas, David L., Clements, P. C., and Wiess, . "The Modular Structure of Complex Systems." <em>ICSE '84: Proceedings of the 7th international conference on Software engineering</em>. 1984. pp. 408&ndash;417.
 </ul>
-</a>
-<a id="jfBeucheIntro">
+</div>
+<div id="jfBeucheIntro">
 <ul>
 [3]: Bueche, J. Frederick. <em>Introduction to Physics for Scientists, Fourth Edition</em>. Mcgraw-Hill College, 1986.
 </ul>
-</a>
-<a id="koothoor2013">
+</div>
+<div id="koothoor2013">
 <ul>
 [4]: Koothoor, Nirmitha. <em>A document drive approach to certifying scientific computing software</em>. McMaster University, Hamilton, ON, Canada: 2013. Print.
 </ul>
-</a>
-<a id="parnas1978">
+</div>
+<div id="parnas1978">
 <ul>
 [5]: Parnas, David L. "Designing Software for Ease of Extension and Contraction.." <em>ICSE '78: Proceedings of the 3rd international conference on Software engineering</em>. 1978. pp. 264&ndash;277.
 </ul>
-</a>
-<a id="parnas1986">
+</div>
+<div id="parnas1986">
 <ul>
 [6]: Parnas, David L. and Clements, P. C. "A rational design process: How and why to fake it." <em>IEEE Transactions on Software Engineering</em>, vol. 12, no. 2, Washington, USA: February, 1986. pp. 251&ndash;257. Print.
 </ul>
-</a>
-<a id="sciComp2013">
+</div>
+<div id="sciComp2013">
 <ul>
 [7]: Wilson, Greg, Aruliah, D. A., Titus, C., Chue Hong, Neil P., Davis, Matt, Guy, Richard T., Haddock, Steven H. D., Huff, Kathryn D., Mitchell, Ian M., Plumblet, Mark D., Waugh, Ben, White, Ethan P., and Wilson, Paul. "Best Practices for Scientific Computing, 2013." <em>PLoS Biol</em>, vol. 12, no. 1, 2013. Print.
 </ul>
-</a>
-<a id="smithLai2005">
+</div>
+<div id="smithLai2005">
 <ul>
 [8]: Smith, W. Spencer and Lai, Lei. "A new requirements template for scientific computing." <em>Proceedings of the First International Workshop on Situational Requirements Engineering Processes - Methods, Techniques and Tools to Support Situation-Specific Requirements Engineering Processes, SREP'05</em>. Edited by PJ Agerfalk, N. Kraiem, and J. Ralyte, Paris, France: 2005. pp. 107&ndash;121. In conjunction with 13th IEEE International Requirements Engineering Conference,
 </ul>
-</a>
 </div>
-</a>
+</div>
+</div>
 </body>
 </html>

--- a/code/stable/glassbr/GlassBR_SRS.html
+++ b/code/stable/glassbr/GlassBR_SRS.html
@@ -19,7 +19,7 @@ Software Requirements Specification for GlassBR program
 Nikitha Krithnan and W. Spencer Smith
 </h2>
 </div>
-<a id="Sec:RefMat">
+<div id="Sec:RefMat">
 <div class="section">
 <h1>
 Reference Material
@@ -27,7 +27,7 @@ Reference Material
 <p class="paragraph">
 This section records information for easy reference.
 </p>
-<a id="Sec:ToU">
+<div id="Sec:ToU">
 <div class="subsection">
 <h2>
 Table of Units
@@ -35,7 +35,7 @@ Table of Units
 <p class="paragraph">
 The unit system used throughout is SI (Système International d'Unités). In addition to the basic units, several derived units are also used. For each unit, the table lists the symbol, a description and the SI name.
 </p>
-<a id="Table:ToU">
+<div id="Table:ToU">
 <table class="table">
 <tr>
 <th>
@@ -86,10 +86,10 @@ time (second)
 </td>
 </tr>
 </table>
-</a>
 </div>
-</a>
-<a id="Sec:ToS">
+</div>
+</div>
+<div id="Sec:ToS">
 <div class="subsection">
 <h2>
 Table of Symbols
@@ -97,7 +97,7 @@ Table of Symbols
 <p class="paragraph">
 The table that follows summarizes the symbols used in this document along with their units. The symbols are listed in alphabetical order.
 </p>
-<a id="Table:ToS">
+<div id="Table:ToS">
 <table class="table">
 <tr>
 <th>
@@ -540,15 +540,15 @@ kg
 </td>
 </tr>
 </table>
-</a>
 </div>
-</a>
-<a id="Sec:TAbbAcc">
+</div>
+</div>
+<div id="Sec:TAbbAcc">
 <div class="subsection">
 <h2>
 Abbreviations and Acronyms
 </h2>
-<a id="Table:TAbbAcc">
+<div id="Table:TAbbAcc">
 <table class="table">
 <tr>
 <th>
@@ -719,12 +719,12 @@ Typical Uncertainty
 </td>
 </tr>
 </table>
-</a>
 </div>
-</a>
 </div>
-</a>
-<a id="Sec:Intro">
+</div>
+</div>
+</div>
+<div id="Sec:Intro">
 <div class="section">
 <h1>
 Introduction
@@ -735,7 +735,7 @@ Software is helpful to efficiently and correctly predict the blast risk involved
 <p class="paragraph">
 The following section provides an overview of the Software Requirements Specification (SRS) for GlassBR. This section explains the purpose of this document, the scope of the system, the organization of the document, and the characteristics of the intended reader.
 </p>
-<a id="Sec:DocPurpose">
+<div id="Sec:DocPurpose">
 <div class="subsection">
 <h2>
 Purpose of Document
@@ -747,8 +747,8 @@ The main purpose of this document is to predict whether a given glass slab is li
 This document will be used as a starting point for subsequent development phases, including writing the design specification and the software verification and validation plan. The design document will show how the requirements are to be realized, including decisions on the numerical algorithms and programming environment. The verification and validation plan will show the steps that will be used to increase confidence in the software documentation and the implementation. Although the SRS fits in a series of documents that follow the so-called waterfall model, the actual development process is not constrained in any way. Even when the waterfall model is not followed, as Parnas and Clements point out, the most logical way to present the documentation is still to &quot;fake&quot; a rational design process.
 </p>
 </div>
-</a>
-<a id="Sec:ReqsScope">
+</div>
+<div id="Sec:ReqsScope">
 <div class="subsection">
 <h2>
 Scope of Requirements
@@ -757,8 +757,8 @@ Scope of Requirements
 The scope of the requirements includes getting all input parameters related to the glass slab and also the parameters related to blast type. Given the appropriate inputs, the code for GlassBR is intended to use the data and predict whether the glass slab is safe to use or not.
 </p>
 </div>
-</a>
-<a id="Sec:ReaderChars">
+</div>
+<div id="Sec:ReaderChars">
 <div class="subsection">
 <h2>
 Characteristics of Intended Reader
@@ -767,8 +767,8 @@ Characteristics of Intended Reader
 Reviewers of this documentation should have a strong knowledge in theory behind glass breakage and blast risk. The reviewers should also have an understanding of second year calculus, structural mechanics, and computer applications in civil engineering.In addition, reviewers should be familiar with the applicable standards for constructions using glass from [4-6] in <a href=#Sec:References>References</a>. The users of GlassBR can have a lower level of expertise, as explained in <a href=#Sec:UserChars>User Characteristics</a>.
 </p>
 </div>
-</a>
-<a id="Sec:DocOrg">
+</div>
+<div id="Sec:DocOrg">
 <div class="subsection">
 <h2>
 Organization of Document
@@ -780,10 +780,10 @@ The organization of this document follows the template for an SRS for scientific
 The goal statements are refined to the theoretical models, and the theoretical models to the instance models. The data definitions are used to support the definitions of the different models.
 </p>
 </div>
-</a>
 </div>
-</a>
-<a id="Sec:Stakeholder">
+</div>
+</div>
+<div id="Sec:Stakeholder">
 <div class="section">
 <h1>
 Stakeholders
@@ -791,7 +791,7 @@ Stakeholders
 <p class="paragraph">
 This section describes the Stakeholders: the people who have an interest in the product.
 </p>
-<a id="Sec:Client">
+<div id="Sec:Client">
 <div class="subsection">
 <h2>
 The Client
@@ -800,8 +800,8 @@ The Client
 The client for GlassBR is a company named Entuitive. It is developed by Dr. Manuel Campidelli. The client has the final say on acceptance of the product.
 </p>
 </div>
-</a>
-<a id="Sec:Customer">
+</div>
+<div id="Sec:Customer">
 <div class="subsection">
 <h2>
 The Customer
@@ -810,10 +810,10 @@ The Customer
 The customers are the end user of GlassBR.
 </p>
 </div>
-</a>
 </div>
-</a>
-<a id="Sec:GenSysDesc">
+</div>
+</div>
+<div id="Sec:GenSysDesc">
 <div class="section">
 <h1>
 General System Description
@@ -821,7 +821,7 @@ General System Description
 <p class="paragraph">
 This section provides general information about the system, identifies the interfaces between the system and its environment, and describes the user characteristics and the system constraints.
 </p>
-<a id="Sec:UserChars">
+<div id="Sec:UserChars">
 <div class="subsection">
 <h2>
 User Characteristics
@@ -838,8 +838,8 @@ The end user is expected to have basic computer literacy to handle the software.
 </li>
 </ul>
 </div>
-</a>
-<a id="Sec:SysConstraints">
+</div>
+<div id="Sec:SysConstraints">
 <div class="subsection">
 <h2>
 System Constraints
@@ -848,10 +848,10 @@ System Constraints
 There are no system constraints.
 </p>
 </div>
-</a>
 </div>
-</a>
-<a id="Sec:ProjScope">
+</div>
+</div>
+<div id="Sec:ProjScope">
 <div class="section">
 <h1>
 Scope of the Project
@@ -859,12 +859,12 @@ Scope of the Project
 <p class="paragraph">
 This section presents the scope of the project. It describes the expected use of GlassBR as well as the inputs and outputs of each action. The use cases are input and output, which defines the action of getting the input and displaying the output.
 </p>
-<a id="Sec:UseCaseTable">
+<div id="Sec:UseCaseTable">
 <div class="subsection">
 <h2>
 Product Use Case Table
 </h2>
-<a id="Table:useCaseTable">
+<div id="Table:useCaseTable">
 <table class="table">
 <tr>
 <th>
@@ -894,10 +894,10 @@ Whether or not the glass slab is safe for the calculated load and supporting cal
 <p class="caption">
 Use Case Table
 </p>
-</a>
 </div>
-</a>
-<a id="Sec:IndividualProdUC">
+</div>
+</div>
+<div id="Sec:IndividualProdUC">
 <div class="subsection">
 <h2>
 Individual Product Use Cases
@@ -906,10 +906,10 @@ Individual Product Use Cases
 The user provides the inputs to GlassBR for use within the analysis. There are two main classes of inputs: glass geometry and blast type. The glass geometry based inputs include the glass type and dimensions of the glass plane. The blast type input includes parameters like weight of charge, TNT equivalent factor and stand off distance from the point of explosion. These parameters describe charge weight and stand off blast. Another input the user gives is the tolerable value of probability of breakage. GlassBR outputs if the glass slab will be safe by comparing whether capacity is greater than demand. Capacity is the the load resistance calculated and demand is the requirement which is the 3 second duration equivalent pressure. The second condition is to check whether the calculated probability (<em>P<sub>b</sub></em>) is less than the tolerable probability (<em>P<sub>btol</sub></em>) which is obtained from the user as an input. If both conditions return true then it's shown that the glass slab is safe to use, else if both return false then the glass slab is considered unsafe. All the supporting calculated values are also displayed as output.
 </p>
 </div>
-</a>
 </div>
-</a>
-<a id="Sec:SpecSystDesc">
+</div>
+</div>
+<div id="Sec:SpecSystDesc">
 <div class="section">
 <h1>
 Specific System Description
@@ -917,7 +917,7 @@ Specific System Description
 <p class="paragraph">
 This section first presents the problem description, which gives a high-level view of the problem to be solved. This is followed by the solution characteristics specification, which presents the assumptions, theories, and definitions.
 </p>
-<a id="Sec:ProbDesc">
+<div id="Sec:ProbDesc">
 <div class="subsection">
 <h2>
 Problem Description
@@ -925,7 +925,7 @@ Problem Description
 <p class="paragraph">
 A system is needed to efficiently and correctly predict the blast risk involved with the glass. GlassBR is a computer program developed to interpret the inputs to give out the outputs which predicts whether the glass slab can withstand the blast under the conditions.
 </p>
-<a id="Sec:TermDefs">
+<div id="Sec:TermDefs">
 <div class="subsubsection">
 <h3>
 Terminology and Definitions
@@ -1006,8 +1006,8 @@ Probability of breakage (<em>P<sub>b</sub></em>) - The fraction of glass lites o
 </li>
 </ol>
 </div>
-</a>
-<a id="Sec:PhysSyst">
+</div>
+<div id="Sec:PhysSyst">
 <div class="subsubsection">
 <h3>
 Physical System Description
@@ -1023,15 +1023,15 @@ PS1: Glass slab
 PS2: The point of explosion. Where the bomb, or any kind of man-made explosion, is located. The stand off distance is the distance between the point of explosion and the glass.
 </p>
 </div>
-<a id="Figure:physSystImage">
+<div id="Figure:physSystImage">
 <img class="figure" src="../../../datafiles/GlassBR/physicalsystimage.png" alt="The physical system"></img>
 <p class="caption">
 The physical system
 </p>
-</a>
 </div>
-</a>
-<a id="Sec:GoalStmt">
+</div>
+</div>
+<div id="Sec:GoalStmt">
 <div class="subsubsection">
 <h3>
 Goal Statements
@@ -1045,10 +1045,10 @@ GS1: Analyze and predict whether the glass slab under consideration will be able
 </p>
 </div>
 </div>
-</a>
 </div>
-</a>
-<a id="Sec:SolCharSpec">
+</div>
+</div>
+<div id="Sec:SolCharSpec">
 <div class="subsection">
 <h2>
 Solution Characteristics Specification
@@ -1056,7 +1056,7 @@ Solution Characteristics Specification
 <p class="paragraph">
 The instance models that govern GlassBR are presented in <a href=#Sec:IMs>Instance Models</a>. The information to understand the meaning of the instance models and their derivation is also presented, so that the instance models can be verified.
 </p>
-<a id="Sec:Assumps">
+<div id="Sec:Assumps">
 <div class="subsubsection">
 <h3>
 Assumptions
@@ -1064,42 +1064,42 @@ Assumptions
 <p class="paragraph">
 This section simplifies the original problem and helps in developing the theoretical model by filling in the missing information for the physical system. The numbers given in the square brackets refer to the Theoretical Models [<a href=#Sec:TMs>Theoretical Models</a>], General Definitions [<a href=#Sec:GDs>General Definitions</a>], Data Definitions [<a href=#Sec:DDs>Data Definitions</a>], Instance Models [<a href=#Sec:IMs>Instance Models</a>], or Likely Changes [<a href=#Sec:LCs>Likely Changes</a>], in which the respective assumption is used.
 </p>
-<a id="A:glassTyA">
+<div id="A:glassTyA">
 <ul>
 glassTy: The standard E1300-09a for calculation applies only to monolithic, laminated, or insulating glass constructions of rectangular shape with continuous lateral support along. one, two, three, or four edge This practice assumes that (1) the supported glass edge for two, three and four-sided support conditions are simply supported and free to slip in plane; (2) glass supported on two sides acts as a simply supported beam and (3) glass supported on one side acts as a cantilever.
 </ul>
-</a>
-<a id="A:glassConditionA">
+</div>
+<div id="A:glassConditionA">
 <ul>
 glassCondition: Following <a href=#astm.LR2009>astm_LR2009</a> (pg. 1), this practice does not apply to any form of wired, patterned, etched, sandblasted, drilled, notched, or grooved glass with surface and edge treatments that alter the glass strength.
 </ul>
-</a>
-<a id="A:explsnScenarioA">
+</div>
+<div id="A:explsnScenarioA">
 <ul>
 explainScenario: This system only considers the external explosion scenario for its calculations.
 </ul>
-</a>
-<a id="A:standardValuesA">
+</div>
+<div id="A:standardValuesA">
 <ul>
 StandardValues: The values provided in <a href=#Sec:AuxConstants>Values of Auxiliary Constants</a> are assumed for the duration of load (<em>t<sub>d</sub></em>), and the material properties of <em>m</em>, <em>k</em>, and <em>E</em>.
 </ul>
-</a>
-<a id="A:glassLiteA">
+</div>
+<div id="A:glassLiteA">
 <ul>
 glassLite: Glass under consideration is assumed to be a single lite. Hence the value of LSF is equal to 1 for all calculations in GlassBR.
 </ul>
-</a>
-<a id="A:bndryConditionsA">
+</div>
+<div id="A:bndryConditionsA">
 <ul>
 boundaryConditions: Boundary conditions for the glass slab is assumed to be 4-sided support for calculations.
 </ul>
-</a>
-<a id="A:responseTyA">
+</div>
+<div id="A:responseTyA">
 <ul>
 responseType: The response type considered in GlassBR is flexural.
 </ul>
-</a>
-<a id="A:ldfConstantA">
+</div>
+<div id="A:ldfConstantA">
 <ul>
 ldfConstant: With reference to <a href=#A:standardValuesA>StandardValues</a> the value of load duration factor (<em>LDF</em>) is a constant in GlassBR. It is calculated by the equation: <em>LDF = (<div class="fraction">
 <span class="fup">
@@ -1117,10 +1117,10 @@ m
 </span>
 </div></sup></em>. Using this, <em>LDF = 0.27</em>.
 </ul>
-</a>
 </div>
-</a>
-<a id="Sec:TMs">
+</div>
+</div>
+<div id="Sec:TMs">
 <div class="subsubsection">
 <h3>
 Theoretical Models
@@ -1128,7 +1128,7 @@ Theoretical Models
 <p class="paragraph">
 This section focuses on the general equations and laws that GlassBR is based on.
 </p>
-<a id="T:t1SafetyReq">
+<div id="T:t1SafetyReq">
 <table class="tdefn">
 <tr>
 <th>
@@ -1145,13 +1145,13 @@ Safety Requirement-1
 Equation
 </th>
 <td>
-<a id="">
+<div id="">
 <div class="equation">
 <p class="paragraph">
 <em>is_safe1 = P<sub>b</sub>&thinsp;&lt;&thinsp;P<sub>btol</sub></em>
 </p>
 </div>
-</a>
+</div>
 </td>
 </tr>
 <tr>
@@ -1165,8 +1165,8 @@ If <em>is_safe1</em>, the glass is considered safe. <em>is_safe1</em> and <em>is
 </td>
 </tr>
 </table>
-</a>
-<a id="T:t2SafetyReq">
+</div>
+<div id="T:t2SafetyReq">
 <table class="tdefn">
 <tr>
 <th>
@@ -1183,13 +1183,13 @@ Safety Requirement-2
 Equation
 </th>
 <td>
-<a id="">
+<div id="">
 <div class="equation">
 <p class="paragraph">
 <em>is_safe2 = LR&thinsp;&gt;&thinsp;q</em>
 </p>
 </div>
-</a>
+</div>
 </td>
 </tr>
 <tr>
@@ -1203,10 +1203,10 @@ If <em>is_safe2</em>, the glass is considered safe. <em>is_safe1</em> (from <a h
 </td>
 </tr>
 </table>
-</a>
 </div>
-</a>
-<a id="Sec:GDs">
+</div>
+</div>
+<div id="Sec:GDs">
 <div class="subsubsection">
 <h3>
 General Definitions
@@ -1215,8 +1215,8 @@ General Definitions
 There are no general definitions.
 </p>
 </div>
-</a>
-<a id="Sec:DDs">
+</div>
+<div id="Sec:DDs">
 <div class="subsubsection">
 <h3>
 Data Definitions
@@ -1224,7 +1224,7 @@ Data Definitions
 <p class="paragraph">
 This section collects and defines all the data needed to build the instance models.
 </p>
-<a id="DD:risk.fun">
+<div id="DD:risk.fun">
 <table class="ddefn">
 <tr>
 <th>
@@ -1251,7 +1251,7 @@ Unitless
 Equation
 </th>
 <td>
-<a id="">
+<div id="">
 <div class="equation">
 <p class="paragraph">
 <em>B = <div class="fraction">
@@ -1264,7 +1264,7 @@ k
 </div>&#8239;(1000&#8239;E&#8239;h<sup>2</sup>)<sup>m</sup>&#8239;LDF&#8239;e<sup>J</sup></em>
 </p>
 </div>
-</a>
+</div>
 </td>
 </tr>
 <tr>
@@ -1278,8 +1278,8 @@ Description
 </td>
 </tr>
 </table>
-</a>
-<a id="DD:act.thick">
+</div>
+<div id="DD:act.thick">
 <table class="ddefn">
 <tr>
 <th>
@@ -1306,7 +1306,7 @@ m
 Equation
 </th>
 <td>
-<a id="">
+<div id="">
 <div class="equation">
 <p class="paragraph">
 <em>h = <div class="fraction">
@@ -1383,7 +1383,7 @@ t = 22.0
 </div></em>
 </p>
 </div>
-</a>
+</div>
 </td>
 </tr>
 <tr>
@@ -1397,8 +1397,8 @@ Description
 </td>
 </tr>
 </table>
-</a>
-<a id="DD:stressDistFac">
+</div>
+<div id="DD:stressDistFac">
 <table class="ddefn">
 <tr>
 <th>
@@ -1425,7 +1425,7 @@ Unitless
 Equation
 </th>
 <td>
-<a id="">
+<div id="">
 <div class="equation">
 <p class="paragraph">
 <em>J = J(q&#770;,<div class="fraction">
@@ -1438,7 +1438,7 @@ b
 </div>)</em>
 </p>
 </div>
-</a>
+</div>
 </td>
 </tr>
 <tr>
@@ -1452,8 +1452,8 @@ Description
 </td>
 </tr>
 </table>
-</a>
-<a id="DD:nFL">
+</div>
+<div id="DD:nFL">
 <table class="ddefn">
 <tr>
 <th>
@@ -1480,7 +1480,7 @@ Unitless
 Equation
 </th>
 <td>
-<a id="">
+<div id="">
 <div class="equation">
 <p class="paragraph">
 <em>NFL = <div class="fraction">
@@ -1493,7 +1493,7 @@ q&#770;<sub>tol</sub>&#8239;E&#8239;h<sup>4</sup>
 </div></em>
 </p>
 </div>
-</a>
+</div>
 </td>
 </tr>
 <tr>
@@ -1507,8 +1507,8 @@ Description
 </td>
 </tr>
 </table>
-</a>
-<a id="DD:gTF">
+</div>
+<div id="DD:gTF">
 <table class="ddefn">
 <tr>
 <th>
@@ -1535,7 +1535,7 @@ Unitless
 Equation
 </th>
 <td>
-<a id="">
+<div id="">
 <div class="equation">
 <p class="paragraph">
 <em>GTF = <span class="casebr">
@@ -1560,7 +1560,7 @@ g = HS
 </div></em>
 </p>
 </div>
-</a>
+</div>
 </td>
 </tr>
 <tr>
@@ -1574,8 +1574,8 @@ Description
 </td>
 </tr>
 </table>
-</a>
-<a id="DD:dimlessLoad">
+</div>
+<div id="DD:dimlessLoad">
 <table class="ddefn">
 <tr>
 <th>
@@ -1602,7 +1602,7 @@ Unitless
 Equation
 </th>
 <td>
-<a id="">
+<div id="">
 <div class="equation">
 <p class="paragraph">
 <em>q&#770; = <div class="fraction">
@@ -1615,7 +1615,7 @@ E&#8239;h<sup>4</sup>&#8239;GTF
 </div></em>
 </p>
 </div>
-</a>
+</div>
 </td>
 </tr>
 <tr>
@@ -1629,8 +1629,8 @@ Description
 </td>
 </tr>
 </table>
-</a>
-<a id="DD:tolLoad">
+</div>
+<div id="DD:tolLoad">
 <table class="ddefn">
 <tr>
 <th>
@@ -1657,7 +1657,7 @@ Unitless
 Equation
 </th>
 <td>
-<a id="">
+<div id="">
 <div class="equation">
 <p class="paragraph">
 <em>q&#770;<sub>tol</sub> = q&#770;<sub>tol</sub>(J<sub>tol</sub>,<div class="fraction">
@@ -1670,7 +1670,7 @@ b
 </div>)</em>
 </p>
 </div>
-</a>
+</div>
 </td>
 </tr>
 <tr>
@@ -1684,8 +1684,8 @@ Description
 </td>
 </tr>
 </table>
-</a>
-<a id="DD:sdf.tol">
+</div>
+<div id="DD:sdf.tol">
 <table class="ddefn">
 <tr>
 <th>
@@ -1712,7 +1712,7 @@ Unitless
 Equation
 </th>
 <td>
-<a id="">
+<div id="">
 <div class="equation">
 <p class="paragraph">
 <em>J<sub>tol</sub> = log(log(<div class="fraction">
@@ -1732,7 +1732,7 @@ k&#8239;(1000&#8239;E&#8239;h<sup>2</sup>)<sup>m</sup>&#8239;LDF
 </div>)</em>
 </p>
 </div>
-</a>
+</div>
 </td>
 </tr>
 <tr>
@@ -1746,10 +1746,10 @@ Description
 </td>
 </tr>
 </table>
-</a>
 </div>
-</a>
-<a id="Sec:IMs">
+</div>
+</div>
+<div id="Sec:IMs">
 <div class="subsubsection">
 <h3>
 Instance Models
@@ -1757,7 +1757,7 @@ Instance Models
 <p class="paragraph">
 This section transforms the problem defined in <a href=#Sec:ProbDesc>Problem Description</a> into one which is expressed in mathematical terms. It uses concrete symbols defined in <a href=#Sec:DDs>Data Definitions</a> to replace the abstract symbols in the models identified in <a href=#Sec:TMs>Theoretical Models</a> and <a href=#Sec:GDs>General Definitions</a>.
 </p>
-<a id="T:probOfBr">
+<div id="T:probOfBr">
 <table class="tdefn">
 <tr>
 <th>
@@ -1774,13 +1774,13 @@ Probability of Glass Breakage
 Equation
 </th>
 <td>
-<a id="">
+<div id="">
 <div class="equation">
 <p class="paragraph">
 <em>P<sub>b</sub> = 1&minus;e<sup>&minus;B</sup></em>
 </p>
 </div>
-</a>
+</div>
 </td>
 </tr>
 <tr>
@@ -1794,8 +1794,8 @@ Description
 </td>
 </tr>
 </table>
-</a>
-<a id="T:calOfCap">
+</div>
+<div id="T:calOfCap">
 <table class="tdefn">
 <tr>
 <th>
@@ -1812,13 +1812,13 @@ Calculation of Capacity(LR)
 Equation
 </th>
 <td>
-<a id="">
+<div id="">
 <div class="equation">
 <p class="paragraph">
 <em>LR = NFL&#8239;GTF&#8239;LSF</em>
 </p>
 </div>
-</a>
+</div>
 </td>
 </tr>
 <tr>
@@ -1832,8 +1832,8 @@ Description
 </td>
 </tr>
 </table>
-</a>
-<a id="T:calOfDe">
+</div>
+<div id="T:calOfDe">
 <table class="tdefn">
 <tr>
 <th>
@@ -1850,13 +1850,13 @@ Calculation of Demand(q)
 Equation
 </th>
 <td>
-<a id="">
+<div id="">
 <div class="equation">
 <p class="paragraph">
 <em>q = q(w<sub>TNT</sub>,SD)</em>
 </p>
 </div>
-</a>
+</div>
 </td>
 </tr>
 <tr>
@@ -1870,10 +1870,10 @@ Description
 </td>
 </tr>
 </table>
-</a>
 </div>
-</a>
-<a id="Sec:DataConstraints">
+</div>
+</div>
+<div id="Sec:DataConstraints">
 <div class="subsubsection">
 <h3>
 Data Constraints
@@ -1881,7 +1881,7 @@ Data Constraints
 <p class="paragraph">
 <a href=#Table:InDataConstraints>Table:InDataConstraints</a>, and <a href=#Table:OutDataConstraints>Table:OutDataConstraints</a> shows the data constraints on the input and output variables, respectively. The column for physical constraints gives the physical limitations on the range of values that can be taken by the variable. The uncertainty column provides an estimate of the confidence with which the physical quantities can be measured. This information would be part of the input if one were performing an uncertainty quantification exercise. The constraints are conservative, to give the user of the model the flexibility to experiment with unusual situations. The column of typical values is intended to provide a feel for a common scenario. <a href=#Sec:AuxConstants>Values of Auxiliary Constants</a> gives the values of the specification parameters used in <a href=#Table:InDataConstraints>Table:InDataConstraints</a>. <a href=#Table:OutDataConstraints>Table:OutDataConstraints</a> shows the constraints that must be satisfied by the output.
 </p>
-<a id="Table:InDataConstraints">
+<div id="Table:InDataConstraints">
 <table class="table">
 <tr>
 <th>
@@ -2013,8 +2013,8 @@ None
 <p class="caption">
 Input Data Constraints
 </p>
-</a>
-<a id="Table:OutDataConstraints">
+</div>
+<div id="Table:OutDataConstraints">
 <table class="table">
 <tr>
 <th>
@@ -2036,14 +2036,14 @@ Physical Constraints
 <p class="caption">
 Output Data Constraints
 </p>
-</a>
 </div>
-</a>
 </div>
-</a>
 </div>
-</a>
-<a id="Sec:Requirements">
+</div>
+</div>
+</div>
+</div>
+<div id="Sec:Requirements">
 <div class="section">
 <h1>
 Requirements
@@ -2051,36 +2051,36 @@ Requirements
 <p class="paragraph">
 This section provides the functional requirements, the business tasks that the software is expected to complete, and the non-functional requirements, the qualities that the software is expected to exhibit.
 </p>
-<a id="Sec:FRs">
+<div id="Sec:FRs">
 <div class="subsection">
 <h2>
 Functional Requirements
 </h2>
-<a id="FR:s7.1.req1">
+<div id="FR:s7.1.req1">
 <ul>
 Input-Glass-Props: Input the quantities from <a href=#Table:R1ReqInputs>Table:R1ReqInputs</a>, which define the glass dimensions, type of glass, tolerable probability of failure and the characteristics of the blast Note: <em>a</em> and <em>b</em> will be input in terms of millimetres and will be converted to the equivalent value in metres.
 </ul>
-</a>
-<a id="FR:s7.1.req2">
+</div>
+<div id="FR:s7.1.req2">
 <ul>
 System-Set-Values-Following-Assumptions: The system shall set the known values as follows: <em>m</em>, <em>k</em>, <em>E</em>, <em>t<sub>d</sub></em> following A4, <em>LDF</em> following A8, and LSF following A5.
 </ul>
-</a>
-<a id="FR:s7.1.req3">
+</div>
+<div id="FR:s7.1.req3">
 <ul>
 Check-Input-with-Data_Constraints: The system shall check the entered input values to ensure that they do not exceed the data constraints mentioned in <a href=#Sec:DataConstraints>Data Constraints</a>. If any of the input parameters is out of bounds, an error message is displayed and the calculations stop.
 </ul>
-</a>
-<a id="FR:s7.1.req4">
+</div>
+<div id="FR:s7.1.req4">
 <ul>
 Output-Values-and-Known-Quantities: Output the input quantities from R1 and the known quantities from R2.
 </ul>
-</a>
-<a id="FR:s7.1.req5">
+</div>
+<div id="FR:s7.1.req5">
 <ul>
 Check-Glass-Safety: If <em>is_safe1</em> and <em>is_safe2</em> (from <a href=#T:t1SafetyReq>T:t1SafetyReq</a> and <a href=#T:t2SafetyReq>T:t2SafetyReq</a>) are true, output the message &quot;For the given input parameters, the glass is considered safe.&quot; If the condition is false, then output the message &quot;For the given input parameters, the glass is NOT considered safe.&quot;
 </ul>
-</a>
+</div>
 <div class="list">
 <p>
 R6: Output the following quantities:
@@ -2128,7 +2128,7 @@ b
     </ul>
 </p>
 </div>
-<a id="Table:R1ReqInputs">
+<div id="Table:R1ReqInputs">
 <table class="table">
 <tr>
 <th>
@@ -2255,10 +2255,10 @@ mm
 <p class="caption">
 Required Inputs following R1
 </p>
-</a>
 </div>
-</a>
-<a id="Sec:NFRs">
+</div>
+</div>
+<div id="Sec:NFRs">
 <div class="subsection">
 <h2>
 Non-Functional Requirements
@@ -2267,42 +2267,42 @@ Non-Functional Requirements
 This problem is small in size and relatively simple, so performance is not a priority. Any reasonable implementation will be very quick and use minimal storage. Rather than performance, the non-functional requirement priorities are correctness, verifiability, understandability, reusability, maintainability, and portability.
 </p>
 </div>
-</a>
 </div>
-</a>
-<a id="Sec:LCs">
+</div>
+</div>
+<div id="Sec:LCs">
 <div class="section">
 <h1>
 Likely Changes
 </h1>
-<a id="LC:s8.likelychg1">
+<div id="LC:s8.likelychg1">
 <ul>
 Calculate-Internal-Blask-Risk: <a href=#A:explsnScenarioA>explainScenario</a> - The system currently only calculates for external blast risk. In the future calculations can be added for the internal blast risk.
 </ul>
-</a>
-<a id="LC:s8.likelychg2">
+</div>
+<div id="LC:s8.likelychg2">
 <ul>
 Variable-Values-of-m,k,E: <a href=#A:standardValuesA>StandardValues</a>, <a href=#A:ldfConstantA>ldfConstant</a> - Currently the values for <em>m</em>, <em>k</em>, and <em>E</em> are assumed to be the same for all glass. In the future these values can be changed to variable inputs.
 </ul>
-</a>
-<a id="LC:s8.likelychg3">
+</div>
+<div id="LC:s8.likelychg3">
 <ul>
 Accomodate-More-than-Single-Lite: <a href=#A:glassLiteA>glassLite</a> - The software may be changed to accommodate more than a single lite.
 </ul>
-</a>
-<a id="LC:s8.likelychg4">
+</div>
+<div id="LC:s8.likelychg4">
 <ul>
 Accomodate-More-Boundary-Conditions: <a href=#A:bndryConditionsA>boundaryConditions</a> - The software may be changed to accommodate more boundary conditions than 4-sided support.
 </ul>
-</a>
-<a id="LC:s8.likelychg5">
+</div>
+<div id="LC:s8.likelychg5">
 <ul>
 Consider-More-than-Flexure-Glass: <a href=#A:responseTyA>responseType</a> - The software may be changed to consider more than just flexure of the glass.
 </ul>
-</a>
 </div>
-</a>
-<a id="Sec:TraceMatrices">
+</div>
+</div>
+<div id="Sec:TraceMatrices">
 <div class="section">
 <h1>
 Traceability Matrices and Graphs
@@ -2310,7 +2310,7 @@ Traceability Matrices and Graphs
 <p class="paragraph">
 The purpose of the traceability matrices is to provide easy references on what has to be additionally modified if a certain component is changed. Every time a component is changed, the items in the column of that component that are marked with an &quot;X&quot; should be modified as well. <a href=#Table:TraceyItemSecs>Table:TraceyItemSecs</a> shows the dependencies of theoretical models, instance models, and data definitions with each other. <a href=#Table:TraceyReqsItems>Table:TraceyReqsItems</a> shows the dependencies of requirements on theoretical models, instance models, data definitions, and data constraints. <a href=#Table:TraceyAssumpsOthers>Table:TraceyAssumpsOthers</a> shows the dependencies of theoretical models, instance models, data definitions, likely changes and requirements on the assumptions.
 </p>
-<a id="Table:TraceyItemSecs">
+<div id="Table:TraceyItemSecs">
 <table class="table">
 <tr>
 <th>
@@ -2932,8 +2932,8 @@ X
 <p class="caption">
 Traceability Matrix Showing the Connections Between Items of Different Sections
 </p>
-</a>
-<a id="Table:TraceyReqsItems">
+</div>
+<div id="Table:TraceyReqsItems">
 <table class="table">
 <tr>
 <th>
@@ -3394,8 +3394,8 @@ X
 <p class="caption">
 Traceability Matrix Showing the Connections Between Requirements and Other Items
 </p>
-</a>
-<a id="Table:TraceyAssumpsOthers">
+</div>
+<div id="Table:TraceyAssumpsOthers">
 <table class="table">
 <tr>
 <th>
@@ -4126,34 +4126,34 @@ R6 (<a href=#Sec:FRs>Functional Requirements</a>)
 <p class="caption">
 Traceability Matrix Showing the Connections Between Assumptions and Other Items
 </p>
-</a>
+</div>
 <p class="paragraph">
 The purpose of the traceability graphs is also to provide easy references on what has to be additionally modified if a certain component is changed. The arrows in the graphs represent dependencies. The component at the tail of an arrow is depended on by the component at the head of that arrow. Therefore, if a component is changed, the components that it points to should also be changed. <a href=#Figure:TraceyItemSecs>Figure:TraceyItemSecs</a> shows the dependencies of theoretical models, instance models, and data definitions on each other. <a href=#Figure:TraceyReqsItems>Figure:TraceyReqsItems</a> shows the dependencies of requirements on theoretical models, instance models, data definitions, and data constraints. <a href=#Figure:TraceyAssumpsOthers>Figure:TraceyAssumpsOthers</a> shows the dependencies of theoretical models, instance models, data definitions, requirements, and likely changes on assumptions.
 </p>
 <p class="paragraph">
 NOTE: Building a tool to automatically generate the graphical representation of the matrix by scanning the labels and reference can be future work.
 </p>
-<a id="Figure:TraceyItemSecs">
+<div id="Figure:TraceyItemSecs">
 <img class="figure" src="../../../datafiles/GlassBR/Trace.png" alt="Figure 2: Traceability Matrix Showing the Connections Between Items of Different Sections"></img>
 <p class="caption">
 Figure 2: Traceability Matrix Showing the Connections Between Items of Different Sections
 </p>
-</a>
-<a id="Figure:TraceyReqsItems">
+</div>
+<div id="Figure:TraceyReqsItems">
 <img class="figure" src="../../../datafiles/GlassBR/RTrace.png" alt="Figure 3: Traceability Matrix Showing the Connections Between Requirements and Other Items"></img>
 <p class="caption">
 Figure 3: Traceability Matrix Showing the Connections Between Requirements and Other Items
 </p>
-</a>
-<a id="Figure:TraceyAssumpsOthers">
+</div>
+<div id="Figure:TraceyAssumpsOthers">
 <img class="figure" src="../../../datafiles/GlassBR/ATrace.png" alt="Figure 4: Traceability Matrix Showing the Connections Between Assumptions and Other Items"></img>
 <p class="caption">
 Figure 4: Traceability Matrix Showing the Connections Between Assumptions and Other Items
 </p>
-</a>
 </div>
-</a>
-<a id="Sec:AuxConstants">
+</div>
+</div>
+<div id="Sec:AuxConstants">
 <div class="section">
 <h1>
 Values of Auxiliary Constants
@@ -4161,7 +4161,7 @@ Values of Auxiliary Constants
 <p class="paragraph">
 This section contains the standard values that are used for calculations in GlassBR.
 </p>
-<a id="Table:TAuxConsts">
+<div id="Table:TAuxConsts">
 <table class="table">
 <tr>
 <th>
@@ -4377,52 +4377,52 @@ m
 <p class="caption">
 Auxiliary Constants
 </p>
-</a>
 </div>
-</a>
-<a id="Sec:References">
+</div>
+</div>
+<div id="Sec:References">
 <div class="section">
 <h1>
 References
 </h1>
-<a id="astm_C1036">
+<div id="astm_C1036">
 <ul>
 [1]: ASTM C1036-16. <em>Standard specification for Flat Glass</em>. West Conshohocken, PA: ASTM International, 2016. www.astm.org.
 </ul>
-</a>
-<a id="astm_C1048">
+</div>
+<div id="astm_C1048">
 <ul>
 [2]: ASTM C1048-04. <em>Specification for Heat-Treated Flat Glass-Kind HS, Kind FT Coated and Uncoated Glass</em>. West Conshohocken, PA: ASTM International, 2009. www.astm.org.
 </ul>
-</a>
-<a id="astm_LR2009">
+</div>
+<div id="astm_LR2009">
 <ul>
 [3]: ASTM E1300-09. <em>Standard Practice for Determining Load Resistance of Glass in Buildings</em>. <em>Standard E1300-09a</em>. ASTM International, 2009. www.astm.org.
 </ul>
-</a>
-<a id="glThick1998">
+</div>
+<div id="glThick1998">
 <ul>
 [4]: Beason, W. Lynn, Kohutek, Terry L., and Bracci, Joseph M. <em>Basis for ASTME E 1300 Annealed Glass Thickness Selection Charts</em>. <em>ASCE Library</em>. February, 1998. doi.org/10.1061/(ASCE)0733-9445(1998)124:2(215).
 </ul>
-</a>
-<a id="koothoor2013">
+</div>
+<div id="koothoor2013">
 <ul>
 [5]: Koothoor, Nirmitha. <em>A document drive approach to certifying scientific computing software</em>. McMaster University, Hamilton, ON, Canada: 2013. Print.
 </ul>
-</a>
-<a id="rbrtsn2012">
+</div>
+<div id="rbrtsn2012">
 <ul>
 [6]: Robertson, James and Robertson, Suzanne. <em>Volere requirements specification template edition 16</em>. 2012. https://pdfs.semanticscholar.org/cf57/27a59801086cbd3d14e587e09880561dbe22.pdf.
 </ul>
-</a>
-<a id="smithLai2005">
+</div>
+<div id="smithLai2005">
 <ul>
 [7]: Smith, W. Spencer and Lai, Lei. "A new requirements template for scientific computing." <em>Proceedings of the First International Workshop on Situational Requirements Engineering Processes - Methods, Techniques and Tools to Support Situation-Specific Requirements Engineering Processes, SREP'05</em>. Edited by PJ Agerfalk, N. Kraiem, and J. Ralyte, Paris, France: 2005. pp. 107&ndash;121. In conjunction with 13th IEEE International Requirements Engineering Conference,
 </ul>
-</a>
 </div>
-</a>
-<a id="Sec:Appendix">
+</div>
+</div>
+<div id="Sec:Appendix">
 <div class="section">
 <h1>
 Appendix
@@ -4430,19 +4430,19 @@ Appendix
 <p class="paragraph">
 This appendix holds the graphs (<a href=#Figure:demandVSsod>Figure:demandVSsod</a> and <a href=#Figure:dimlessloadVSaspect>Figure:dimlessloadVSaspect</a>) used for interpolating values needed in the models.
 </p>
-<a id="Figure:demandVSsod">
+<div id="Figure:demandVSsod">
 <img class="figure" src="../../../datafiles/GlassBR/ASTM_F2248-09.png" alt="Figure 5: 3 second duration equivalent pressure (<em>q</em>) versus Stand off distance (SD) versus Charge weight (<em>m</em>)"></img>
 <p class="caption">
 Figure 5: 3 second duration equivalent pressure (<em>q</em>) versus Stand off distance (SD) versus Charge weight (<em>m</em>)
 </p>
-</a>
-<a id="Figure:dimlessloadVSaspect">
+</div>
+<div id="Figure:dimlessloadVSaspect">
 <img class="figure" src="../../../datafiles/GlassBR/ASTM_F2248-09_BeasonEtAl.png" alt="Figure 6: Non dimensional lateral load (<em>q&#770;</em>) versus Aspect Ratio (AR) versus Stress distribution factor (Function) (<em>J</em>)"></img>
 <p class="caption">
 Figure 6: Non dimensional lateral load (<em>q&#770;</em>) versus Aspect Ratio (AR) versus Stress distribution factor (Function) (<em>J</em>)
 </p>
-</a>
 </div>
-</a>
+</div>
+</div>
 </body>
 </html>

--- a/code/stable/nopcm/NoPCM_SRS.html
+++ b/code/stable/nopcm/NoPCM_SRS.html
@@ -19,7 +19,7 @@ Software Requirements Specification for Solar Water Heating Systems
 Thulasi Jegatheesan
 </h2>
 </div>
-<a id="Sec:RefMat">
+<div id="Sec:RefMat">
 <div class="section">
 <h1>
 Reference Material
@@ -27,7 +27,7 @@ Reference Material
 <p class="paragraph">
 This section records information for easy reference.
 </p>
-<a id="Sec:ToU">
+<div id="Sec:ToU">
 <div class="subsection">
 <h2>
 Table of Units
@@ -35,7 +35,7 @@ Table of Units
 <p class="paragraph">
 The unit system used throughout is SI (Système International d'Unités). In addition to the basic units, several derived units are also used. For each unit, the table lists the symbol, a description and the SI name.
 </p>
-<a id="Table:ToU">
+<div id="Table:ToU">
 <table class="table">
 <tr>
 <th>
@@ -94,10 +94,10 @@ power (watt)
 </td>
 </tr>
 </table>
-</a>
 </div>
-</a>
-<a id="Sec:ToS">
+</div>
+</div>
+<div id="Sec:ToS">
 <div class="subsection">
 <h2>
 Table of Symbols
@@ -105,7 +105,7 @@ Table of Symbols
 <p class="paragraph">
 The table that follows summarizes the symbols used in this document along with their units. The choice of symbols was made to be consistent with the heat transfer literature and with existing documentation for solar water heating systems. The symbols are listed in alphabetical order.
 </p>
-<a id="Table:ToS">
+<div id="Table:ToS">
 <table class="table">
 <tr>
 <th>
@@ -482,15 +482,15 @@ s
 </td>
 </tr>
 </table>
-</a>
 </div>
-</a>
-<a id="Sec:TAbbAcc">
+</div>
+</div>
+<div id="Sec:TAbbAcc">
 <div class="subsection">
 <h2>
 Abbreviations and Acronyms
 </h2>
-<a id="Table:TAbbAcc">
+<div id="Table:TAbbAcc">
 <table class="table">
 <tr>
 <th>
@@ -605,12 +605,12 @@ Typical Uncertainty
 </td>
 </tr>
 </table>
-</a>
 </div>
-</a>
 </div>
-</a>
-<a id="Sec:Intro">
+</div>
+</div>
+</div>
+<div id="Sec:Intro">
 <div class="section">
 <h1>
 Introduction
@@ -621,7 +621,7 @@ Due to increasing cost, diminishing availability, and negative environmental imp
 <p class="paragraph">
 The following section provides an overview of the Software Requirements Specification (SRS) for solar water heating systems. The developed program will be referred to as Solar Water Heating System (SWHS). This section explains the purpose of this document, the scope of the system, the organization of the document, and the characteristics of the intended reader.
 </p>
-<a id="Sec:DocPurpose">
+<div id="Sec:DocPurpose">
 <div class="subsection">
 <h2>
 Purpose of Document
@@ -633,8 +633,8 @@ The main purpose of this document is to describe the modelling of solar water he
 This document will be used as a starting point for subsequent development phases, including writing the design specification and the software verification and validation plan. The design document will show how the requirements are to be realized, including decisions on the numerical algorithms and programming environment. The verification and validation plan will show the steps that will be used to increase confidence in the software documentation and the implementation. Although the SRS fits in a series of documents that follow the so-called waterfall model, the actual development process is not constrained in any way. Even when the waterfall model is not followed, as Parnas and Clements point out, the most logical way to present the documentation is still to &quot;fake&quot; a rational design process.
 </p>
 </div>
-</a>
-<a id="Sec:ReqsScope">
+</div>
+<div id="Sec:ReqsScope">
 <div class="subsection">
 <h2>
 Scope of Requirements
@@ -643,8 +643,8 @@ Scope of Requirements
 The scope of the requirements includes thermal analysis of a single solar water heating tank. Given the appropriate inputs, the code for SWHS is intended to predict the temperature and thermal energy histories for the water.
 </p>
 </div>
-</a>
-<a id="Sec:ReaderChars">
+</div>
+<div id="Sec:ReaderChars">
 <div class="subsection">
 <h2>
 Characteristics of Intended Reader
@@ -653,8 +653,8 @@ Characteristics of Intended Reader
 Reviewers of this documentation should have a strong knowledge in heat transfer theory. A third or fourth year Mechanical Engineering course on this topic is recommended. The reviewers should also have an understanding of differential equations, as typically covered in first and second year Calculus courses. The users of SWHS can have a lower level of expertise, as explained in <a href=#Sec:UserChars>User Characteristics</a>.
 </p>
 </div>
-</a>
-<a id="Sec:DocOrg">
+</div>
+<div id="Sec:DocOrg">
 <div class="subsection">
 <h2>
 Organization of Document
@@ -666,10 +666,10 @@ The organization of this document follows the template for an SRS for scientific
 The goal statements are refined to the theoretical models, and the theoretical models to the instance models. The instance model (<a href=#Sec:IMs>Instance Models</a>) to be solved is referred to as IM1. The instance model provides the Ordinary Differential Equation (ODE) that model the solar water heating system. SWHS solves this ODE.
 </p>
 </div>
-</a>
 </div>
-</a>
-<a id="Sec:GenSysDesc">
+</div>
+</div>
+<div id="Sec:GenSysDesc">
 <div class="section">
 <h1>
 General System Description
@@ -677,7 +677,7 @@ General System Description
 <p class="paragraph">
 This section provides general information about the system, identifies the interfaces between the system and its environment, and describes the user characteristics and the system constraints.
 </p>
-<a id="Sec:SysContext">
+<div id="Sec:SysContext">
 <div class="subsection">
 <h2>
 System Context
@@ -685,12 +685,12 @@ System Context
 <p class="paragraph">
 <a href=#Figure:SysCon>Figure:SysCon</a> shows the system context. A circle represents an external entity outside the software, the user in this case. A rectangle represents the software system itself (SWHS). Arrows are used to show the data flow between the system and its environment.
 </p>
-<a id="Figure:SysCon">
+<div id="Figure:SysCon">
 <img class="figure" src="SystemContextFigure.png" alt="<a href=#Figure:SysCon>Figure:SysCon</a>: System Context"></img>
 <p class="caption">
 <a href=#Figure:SysCon>Figure:SysCon</a>: System Context
 </p>
-</a>
+</div>
 <p class="paragraph">
 SWHS is mostly self-contained. The only external interaction is through the user interface. The responsibilities of the user and the system are as follows:
 </p>
@@ -722,8 +722,8 @@ Calculate the required outputs
 </li>
 </ul>
 </div>
-</a>
-<a id="Sec:UserChars">
+</div>
+<div id="Sec:UserChars">
 <div class="subsection">
 <h2>
 User Characteristics
@@ -732,8 +732,8 @@ User Characteristics
 The end user of SWHS should have an understanding of undergraduate Level 1 Calculus and Physics.
 </p>
 </div>
-</a>
-<a id="Sec:SysConstraints">
+</div>
+<div id="Sec:SysConstraints">
 <div class="subsection">
 <h2>
 System Constraints
@@ -742,10 +742,10 @@ System Constraints
 There are no system constraints.
 </p>
 </div>
-</a>
 </div>
-</a>
-<a id="Sec:SpecSystDesc">
+</div>
+</div>
+<div id="Sec:SpecSystDesc">
 <div class="section">
 <h1>
 Specific System Description
@@ -753,7 +753,7 @@ Specific System Description
 <p class="paragraph">
 This section first presents the problem description, which gives a high-level view of the problem to be solved. This is followed by the solution characteristics specification, which presents the assumptions, theories, definitions and finally the instance model (ODE) that models the solar water heating tank.
 </p>
-<a id="Sec:ProbDesc">
+<div id="Sec:ProbDesc">
 <div class="subsection">
 <h2>
 Problem Description
@@ -761,7 +761,7 @@ Problem Description
 <p class="paragraph">
 SWHS is a computer program developed to investigate the heating of water in a solar water heating tank.
 </p>
-<a id="Sec:TermDefs">
+<div id="Sec:TermDefs">
 <div class="subsubsection">
 <h3>
 Terminology and Definitions
@@ -784,8 +784,8 @@ Transient: Changing with time
 </li>
 </ul>
 </div>
-</a>
-<a id="Sec:PhysSyst">
+</div>
+<div id="Sec:PhysSyst">
 <div class="subsubsection">
 <h3>
 Physical System Description
@@ -801,15 +801,15 @@ PS1: Tank containing water.
 PS2: Heating coil at bottom of tank. (<em>q<sub>C</sub></em> represents the heat flux into the water from the coil.)
 </p>
 </div>
-<a id="Figure:Tank">
+<div id="Figure:Tank">
 <img class="figure" src="TankWaterOnly.png" alt="Solar water heating tank, with heat flux from heating coil of <em>q<sub>C</sub></em>"></img>
 <p class="caption">
 Solar water heating tank, with heat flux from heating coil of <em>q<sub>C</sub></em>
 </p>
-</a>
 </div>
-</a>
-<a id="Sec:GoalStmt">
+</div>
+</div>
+<div id="Sec:GoalStmt">
 <div class="subsubsection">
 <h3>
 Goal Statements
@@ -826,10 +826,10 @@ GS2: predict the change in heat energy in the water over time
 </p>
 </div>
 </div>
-</a>
 </div>
-</a>
-<a id="Sec:SolCharSpec">
+</div>
+</div>
+<div id="Sec:SolCharSpec">
 <div class="subsection">
 <h2>
 Solution Characteristics Specification
@@ -837,7 +837,7 @@ Solution Characteristics Specification
 <p class="paragraph">
 The instance models that govern SWHS are presented in <a href=#Sec:IMs>Instance Models</a>. The information to understand the meaning of the instance models and their derivation is also presented, so that the instance models can be verified.
 </p>
-<a id="Sec:Assumps">
+<div id="Sec:Assumps">
 <div class="subsubsection">
 <h3>
 Assumptions
@@ -845,79 +845,79 @@ Assumptions
 <p class="paragraph">
 This section simplifies the original problem and helps in developing the theoretical model by filling in the missing information for the physical system. The numbers given in the square brackets refer to the Theoretical Models [<a href=#Sec:TMs>Theoretical Models</a>], General Definitions [<a href=#Sec:GDs>General Definitions</a>], Data Definitions [<a href=#Sec:DDs>Data Definitions</a>], Instance Models [<a href=#Sec:IMs>Instance Models</a>], or Likely Changes [<a href=#Sec:LCs>Likely Changes</a>], in which the respective assumption is used.
 </p>
-<a id="A:assump1">
+<div id="A:assump1">
 <ul>
 assump1: The only form of energy that is relevant for this problem is thermal energy. All other forms of energy, such as mechanical energy, are assumed to be negligible [<a href=#T:t1ConsThermE>T:t1ConsThermE</a>].
 </ul>
-</a>
-<a id="A:assump2">
+</div>
+<div id="A:assump2">
 <ul>
 assump2: All heat transfer coefficients are constant over time [GD1].
 </ul>
-</a>
-<a id="A:assump3">
+</div>
+<div id="A:assump3">
 <ul>
 assump3: The water in the tank is fully mixed, so the temperature of the water is the same throughout the entire tank [GD2].
 </ul>
-</a>
-<a id="A:assump4">
+</div>
+<div id="A:assump4">
 <ul>
 assump4: The density of water has no spatial variation; that is, it is constant over their entire volume [GD2, <a href=#LC:likeChg2>Temperature-Coil-Variable-Over-Day</a>].
 </ul>
-</a>
-<a id="A:assump5">
+</div>
+<div id="A:assump5">
 <ul>
 assump5: The specific heat capacity of water has no spatial variation; that is, it is constant over its entire volume [GD2].
 </ul>
-</a>
-<a id="A:assump7">
+</div>
+<div id="A:assump7">
 <ul>
 assump7: Newton's law of convective cooling applies between the heating coil and the water [<a href=#DD:ht.flux.C>DD:ht.flux.C</a>].
 </ul>
-</a>
-<a id="A:assump8">
+</div>
+<div id="A:assump8">
 <ul>
 assump8: The temperature of the heating coil is constant over time [<a href=#DD:ht.flux.C>DD:ht.flux.C</a>].
 </ul>
-</a>
-<a id="A:assump9">
+</div>
+<div id="A:assump9">
 <ul>
 assump9: The temperature of the heating coil does not vary along its length [<a href=#DD:ht.flux.C>DD:ht.flux.C</a>].
 </ul>
-</a>
-<a id="A:assump9.npcm">
+</div>
+<div id="A:assump9.npcm">
 <ul>
 assump9_npcm: The model only accounts for charging of the tank, not discharging. The temperature of the water can only increase, or remain constant; it cannot decrease. This implies that the initial temperature is less than (or equal to) the temperature of the heating coil [IM1, <a href=#LC:likeChg3>Temperature-Coil-Variable-Over-Length</a>].
 </ul>
-</a>
-<a id="A:assump14">
+</div>
+<div id="A:assump14">
 <ul>
 assump14: The operating temperature range of the system is such that the water is always in liquid state. That is, the temperature will not drop below the melting point temperature of water, or rise above its boiling point temperature [IM1, IM3].
 </ul>
-</a>
-<a id="A:assump15">
+</div>
+<div id="A:assump15">
 <ul>
 assump15: The tank is perfectly insulated so that there is no heat loss from the tank [IM1].
 </ul>
-</a>
-<a id="A:assump12">
+</div>
+<div id="A:assump12">
 <ul>
 assump12: No internal heat is generated by the water; therefore, the volumetric heat generation per unit volume is zero [IM1].
 </ul>
-</a>
-<a id="A:assump13">
+</div>
+<div id="A:assump13">
 <ul>
 assump13: The pressure in the tank is atmospheric, so the melting point temperature and boiling point temperature are 0&deg;C and 100&deg;C, respectively [IM1, IM2].
 </ul>
-</a>
-<a id="A:assump20">
+</div>
+<div id="A:assump20">
 <ul>
 assump20: When considering the volume of water in the tank, the volume of the heating coil is assumed to be negligible.
 </ul>
-</a>
 </div>
-</a>
-<a id="Sec:TMs">
+</div>
+</div>
+<div id="Sec:TMs">
 <div class="subsubsection">
 <h3>
 Theoretical Models
@@ -925,7 +925,7 @@ Theoretical Models
 <p class="paragraph">
 This section focuses on the general equations and laws that SWHS is based on.
 </p>
-<a id="T:t1ConsThermE">
+<div id="T:t1ConsThermE">
 <table class="tdefn">
 <tr>
 <th>
@@ -942,7 +942,7 @@ Conservation of Thermal Energy
 Equation
 </th>
 <td>
-<a id="">
+<div id="">
 <div class="equation">
 <p class="paragraph">
 <em>&minus;&nabla;&sdot;<b>q</b>&plus;g = &rho;&#8239;C&#8239;<div class="fraction">
@@ -955,7 +955,7 @@ Equation
 </div></em>
 </p>
 </div>
-</a>
+</div>
 </td>
 </tr>
 <tr>
@@ -969,10 +969,10 @@ The above equation gives the law of conservation of energy for transient heat tr
 </td>
 </tr>
 </table>
-</a>
 </div>
-</a>
-<a id="Sec:GDs">
+</div>
+</div>
+<div id="Sec:GDs">
 <div class="subsubsection">
 <h3>
 General Definitions
@@ -980,7 +980,7 @@ General Definitions
 <p class="paragraph">
 This section collects the laws and equations that will be used in deriving the data definitions, which in turn are used to build the instance models.
 </p>
-<a id="T:nwtnCooling">
+<div id="T:nwtnCooling">
 <table class="tdefn">
 <tr>
 <th>
@@ -997,13 +997,13 @@ Newton's Law of Cooling
 Equation
 </th>
 <td>
-<a id="">
+<div id="">
 <div class="equation">
 <p class="paragraph">
 <em><b>q</b>(t) = h&#8239;&Delta;T(t)</em>
 </p>
 </div>
-</a>
+</div>
 </td>
 </tr>
 <tr>
@@ -1017,8 +1017,8 @@ Newton's law of cooling describes convective cooling from a surface. The law is 
 </td>
 </tr>
 </table>
-</a>
-<a id="T:rocTempSimp">
+</div>
+<div id="T:rocTempSimp">
 <table class="tdefn">
 <tr>
 <th>
@@ -1035,7 +1035,7 @@ Simplified Rate of Change of Temperature
 Equation
 </th>
 <td>
-<a id="">
+<div id="">
 <div class="equation">
 <p class="paragraph">
 <em>m&#8239;C&#8239;<div class="fraction">
@@ -1048,7 +1048,7 @@ d&#8239;t
 </div> = q<sub>in</sub>&#8239;A<sub>in</sub>&minus;q<sub>out</sub>&#8239;A<sub>out</sub>&plus;g&#8239;V</em>
 </p>
 </div>
-</a>
+</div>
 </td>
 </tr>
 <tr>
@@ -1062,14 +1062,14 @@ The basic equation governing the rate of change of temperature, for a given volu
 </td>
 </tr>
 </table>
-</a>
+</div>
 <p class="paragraph">
 Detailed derivation of simplified rate of change of temperature:
 </p>
 <p class="paragraph">
 Integrating <a href=#T:t1ConsThermE>T:t1ConsThermE</a> over a volume (<em>V</em>), we have:
 </p>
-<a id="">
+<div id="">
 <div class="equation">
 <em>&minus;&int;<sub>V</sub>&nabla;&sdot;<b>q</b>&#8239;dV&plus;&int;<sub>V</sub>g&#8239;dV = &int;<sub>V</sub>&rho;&#8239;C&#8239;<div class="fraction">
 <span class="fup">
@@ -1080,11 +1080,11 @@ Integrating <a href=#T:t1ConsThermE>T:t1ConsThermE</a> over a volume (<em>V</em>
 </span>
 </div>&#8239;dV</em>
 </div>
-</a>
+</div>
 <p class="paragraph">
 Applying Gauss's Divergence Theorem to the first term over the surface <em>S</em> of the volume, with <em><b>q</b></em> as the thermal flux vector for the surface and <em><b>n&#770;</b></em> as a unit outward normal vector for a surface:
 </p>
-<a id="">
+<div id="">
 <div class="equation">
 <em>&minus;&int;<sub>S</sub><b>q</b>&sdot;<b>n&#770;</b>&#8239;dS&plus;&int;<sub>V</sub>g&#8239;dV = &int;<sub>V</sub>&rho;&#8239;C&#8239;<div class="fraction">
 <span class="fup">
@@ -1095,11 +1095,11 @@ Applying Gauss's Divergence Theorem to the first term over the surface <em>S</em
 </span>
 </div>&#8239;dV</em>
 </div>
-</a>
+</div>
 <p class="paragraph">
 We consider an arbitrary volume. The volumetric heat generation per unit volume is assumed constant. Then (1) can be written as:
 </p>
-<a id="">
+<div id="">
 <div class="equation">
 <em>q<sub>in</sub>&#8239;A<sub>in</sub>&minus;q<sub>out</sub>&#8239;A<sub>out</sub>&plus;g&#8239;V = &int;<sub>V</sub>&rho;&#8239;C&#8239;<div class="fraction">
 <span class="fup">
@@ -1110,11 +1110,11 @@ We consider an arbitrary volume. The volumetric heat generation per unit volume 
 </span>
 </div>&#8239;dV</em>
 </div>
-</a>
+</div>
 <p class="paragraph">
 Where <em>q<sub>in</sub></em>, <em>q<sub>out</sub></em>, <em>A<sub>in</sub></em>, and <em>A<sub>out</sub></em> are explained in GD2. Assuming <em>&rho;</em>, <em>C</em> and <em>T</em> are constant over the volume, which is true in our case by Assumptions (<a href=#A:assump3>assump3</a>), (<a href=#A:assump4>assump4</a>), and (<a href=#A:assump5>assump5</a>), we have:
 </p>
-<a id="">
+<div id="">
 <div class="equation">
 <em>&rho;&#8239;C&#8239;V&#8239;<div class="fraction">
 <span class="fup">
@@ -1125,11 +1125,11 @@ d&#8239;t
 </span>
 </div> = q<sub>in</sub>&#8239;A<sub>in</sub>&minus;q<sub>out</sub>&#8239;A<sub>out</sub>&plus;g&#8239;V</em>
 </div>
-</a>
+</div>
 <p class="paragraph">
 Using the fact that <em>&rho;</em>=<em>m</em>/<em>V</em>, (2) can be written as:
 </p>
-<a id="">
+<div id="">
 <div class="equation">
 <em>m&#8239;C&#8239;<div class="fraction">
 <span class="fup">
@@ -1140,10 +1140,10 @@ d&#8239;t
 </span>
 </div> = q<sub>in</sub>&#8239;A<sub>in</sub>&minus;q<sub>out</sub>&#8239;A<sub>out</sub>&plus;g&#8239;V</em>
 </div>
-</a>
 </div>
-</a>
-<a id="Sec:DDs">
+</div>
+</div>
+<div id="Sec:DDs">
 <div class="subsubsection">
 <h3>
 Data Definitions
@@ -1151,7 +1151,7 @@ Data Definitions
 <p class="paragraph">
 This section collects and defines all the data needed to build the instance models. The dimension of each quantity is also given.
 </p>
-<a id="DD:ht.flux.C">
+<div id="DD:ht.flux.C">
 <table class="ddefn">
 <tr>
 <th>
@@ -1178,13 +1178,13 @@ W/m<sup>2</sup>
 Equation
 </th>
 <td>
-<a id="">
+<div id="">
 <div class="equation">
 <p class="paragraph">
 <em>q<sub>C</sub> = h<sub>C</sub>&#8239;(T<sub>C</sub>&minus;T<sub>W</sub>(t))</em>
 </p>
 </div>
-</a>
+</div>
 </td>
 </tr>
 <tr>
@@ -1198,10 +1198,10 @@ Description
 </td>
 </tr>
 </table>
-</a>
 </div>
-</a>
-<a id="Sec:IMs">
+</div>
+</div>
+<div id="Sec:IMs">
 <div class="subsubsection">
 <h3>
 Instance Models
@@ -1209,7 +1209,7 @@ Instance Models
 <p class="paragraph">
 This section transforms the problem defined in <a href=#Sec:ProbDesc>Problem Description</a> into one which is expressed in mathematical terms. It uses concrete symbols defined in <a href=#Sec:DDs>Data Definitions</a> to replace the abstract symbols in the models identified in <a href=#Sec:TMs>Theoretical Models</a> and <a href=#Sec:GDs>General Definitions</a>.
 </p>
-<a id="T:eBalanceOnWtr">
+<div id="T:eBalanceOnWtr">
 <table class="tdefn">
 <tr>
 <th>
@@ -1226,7 +1226,7 @@ Energy Balance on Water to Find the Temperature of the Water
 Equation
 </th>
 <td>
-<a id="">
+<div id="">
 <div class="equation">
 <p class="paragraph">
 <em><div class="fraction">
@@ -1246,7 +1246,7 @@ d&#8239;t
 </div>&#8239;(T<sub>C</sub>&minus;T<sub>W</sub>(t))</em>
 </p>
 </div>
-</a>
+</div>
 </td>
 </tr>
 <tr>
@@ -1267,14 +1267,14 @@ h<sub>C</sub>&#8239;A<sub>C</sub>
 </td>
 </tr>
 </table>
-</a>
+</div>
 <p class="paragraph">
 Derivation of the energy balance on water:
 </p>
 <p class="paragraph">
 To find the rate of change of <em>T<sub>W</sub></em>, we look at the energy balance on water. The volume being considered is the volume of water <em>V<sub>W</sub></em>, which has mass <em>m<sub>W</sub></em> and specific heat capacity of water, <em>C<sub>W</sub></em>. Heat transfer occurs in the water from the coil as <em>q<sub>C</sub></em>, over area <em>A<sub>C</sub></em>. No heat transfer occurs to the outside of the tank, since it has been assumed to be perfectly insulated (<a href=#A:assump15>assump15</a>). Assuming no volumetric heat generation per unit volume (<a href=#A:assump12>assump12</a>), <em>g = 0</em>. Therefore, the equation for GD2 can be written as:
 </p>
-<a id="">
+<div id="">
 <div class="equation">
 <em>m<sub>W</sub>&#8239;C<sub>W</sub>&#8239;<div class="fraction">
 <span class="fup">
@@ -1285,11 +1285,11 @@ d&#8239;t
 </span>
 </div> = q<sub>C</sub>&#8239;A<sub>C</sub></em>
 </div>
-</a>
+</div>
 <p class="paragraph">
 Using <a href=#DD:ht.flux.C>DD:ht.flux.C</a>, this can be written as:
 </p>
-<a id="">
+<div id="">
 <div class="equation">
 <em>m<sub>W</sub>&#8239;C<sub>W</sub>&#8239;<div class="fraction">
 <span class="fup">
@@ -1300,11 +1300,11 @@ d&#8239;t
 </span>
 </div> = h<sub>C</sub>&#8239;A<sub>C</sub>&#8239;(T<sub>C</sub>&minus;T<sub>W</sub>)</em>
 </div>
-</a>
+</div>
 <p class="paragraph">
 Dividing (3) by <em>m<sub>W</sub></em><em>C<sub>W</sub></em>, we obtain:
 </p>
-<a id="">
+<div id="">
 <div class="equation">
 <em><div class="fraction">
 <span class="fup">
@@ -1322,11 +1322,11 @@ m<sub>W</sub>&#8239;C<sub>W</sub>
 </span>
 </div>&#8239;(T<sub>C</sub>&minus;T<sub>W</sub>)</em>
 </div>
-</a>
+</div>
 <p class="paragraph">
 Setting <em>&tau;<sub>W</sub></em>=<em>m<sub>W</sub></em><em>C<sub>W</sub></em>/<em>h<sub>C</sub></em><em>A<sub>C</sub></em>, Equation (4) can be written in its final form as:
 </p>
-<a id="">
+<div id="">
 <div class="equation">
 <em><div class="fraction">
 <span class="fup">
@@ -1344,8 +1344,8 @@ d&#8239;t
 </span>
 </div>&#8239;(T<sub>C</sub>&minus;T<sub>W</sub>)</em>
 </div>
-</a>
-<a id="T:heatEInWtr">
+</div>
+<div id="T:heatEInWtr">
 <table class="tdefn">
 <tr>
 <th>
@@ -1362,13 +1362,13 @@ Heat Energy in the Water
 Equation
 </th>
 <td>
-<a id="">
+<div id="">
 <div class="equation">
 <p class="paragraph">
 <em>E<sub>W</sub>(t) = C<sub>W</sub>&#8239;m<sub>W</sub>&#8239;(T<sub>W</sub>(t)&minus;T<sub>init</sub>)</em>
 </p>
 </div>
-</a>
+</div>
 </td>
 </tr>
 <tr>
@@ -1382,10 +1382,10 @@ The above equation is derived using T2. <em>E<sub>W</sub></em> is the change in 
 </td>
 </tr>
 </table>
-</a>
 </div>
-</a>
-<a id="Sec:DataConstraints">
+</div>
+</div>
+<div id="Sec:DataConstraints">
 <div class="subsubsection">
 <h3>
 Data Constraints
@@ -1393,7 +1393,7 @@ Data Constraints
 <p class="paragraph">
 <a href=#Table:InDataConstraints>Table:InDataConstraints</a>, and <a href=#Table:OutDataConstraints>Table:OutDataConstraints</a> shows the data constraints on the input and output variables, respectively. The column for physical constraints gives the physical limitations on the range of values that can be taken by the variable. The uncertainty column provides an estimate of the confidence with which the physical quantities can be measured. This information would be part of the input if one were performing an uncertainty quantification exercise. The constraints are conservative, to give the user of the model the flexibility to experiment with unusual situations. The column of typical values is intended to provide a feel for a common scenario. The column for software constraints restricts the range of inputs to reasonable values.
 </p>
-<a id="Table:InDataConstraints">
+<div id="Table:InDataConstraints">
 <table class="table">
 <tr>
 <th>
@@ -1569,8 +1569,8 @@ None
 <p class="caption">
 Input Data Constraints
 </p>
-</a>
-<a id="Table:OutDataConstraints">
+</div>
+<div id="Table:OutDataConstraints">
 <table class="table">
 <tr>
 <th>
@@ -1600,14 +1600,14 @@ Physical Constraints
 <p class="caption">
 Output Data Constraints
 </p>
-</a>
 </div>
-</a>
 </div>
-</a>
 </div>
-</a>
-<a id="Sec:Requirements">
+</div>
+</div>
+</div>
+</div>
+<div id="Sec:Requirements">
 <div class="section">
 <h1>
 Requirements
@@ -1615,17 +1615,17 @@ Requirements
 <p class="paragraph">
 This section provides the functional requirements, the business tasks that the software is expected to complete, and the non-functional requirements, the qualities that the software is expected to exhibit.
 </p>
-<a id="Sec:FRs">
+<div id="Sec:FRs">
 <div class="subsection">
 <h2>
 Functional Requirements
 </h2>
-<a id="FR:req1">
+<div id="FR:req1">
 <ul>
 Input-Inital-Values: Input the following quantities, which define the tank parameters, material properties and initial conditions:
 </ul>
-</a>
-<a id="Table:fr1list">
+</div>
+<div id="Table:fr1list">
 <table class="table">
 <tr>
 <th>
@@ -1738,13 +1738,13 @@ final time
 </td>
 </tr>
 </table>
-</a>
-<a id="FR:req2">
+</div>
+<div id="FR:req2">
 <ul>
 Use-Above-Find-Mass-IM1-IM2: Use the inputs in <a href=#FR:req1>Input-Inital-Values</a> to find the mass needed for IM1 to IM2, as follows, where <em>V<sub>W</sub></em> is the volume of water and <em>V<sub>tank</sub></em> is the volume of the cylindrical tank:
 </ul>
-</a>
-<a id="">
+</div>
+<div id="">
 <div class="equation">
 <em>m<sub>W</sub> = V<sub>W</sub>&#8239;&rho;<sub>W</sub> = <div class="fraction">
 <span class="fup">
@@ -1755,30 +1755,30 @@ D
 </span>
 </div>&#8239;L&#8239;&rho;<sub>W</sub></em>
 </div>
-</a>
-<a id="FR:req3">
+</div>
+<div id="FR:req3">
 <ul>
 Check-Inputs-Satisfy-Physical-Constraints: Verify that the inputs satisfy the required physical constraint shown in <a href=#Table:InDataConstraints>Table:InDataConstraints</a>.
 </ul>
-</a>
-<a id="FR:req4">
+</div>
+<div id="FR:req4">
 <ul>
 Output-Input-Derivied-Quantities: Outputs and inputs quantities and derived quantities in the following list: the quantities from <a href=#FR:req1>Input-Inital-Values</a>, the mass from <a href=#FR:req2>Use-Above-Find-Mass-IM1-IM2</a> and <em>&tau;<sub>W</sub></em> (from IM1).
 </ul>
-</a>
-<a id="FR:req5">
+</div>
+<div id="FR:req5">
 <ul>
 Calculate-Temperature-Water-Over-Time: Calculate and output the temperature of the water (<em>T<sub>W</sub></em>(<em>t</em>)) over the simulation time
 </ul>
-</a>
-<a id="FR:req6">
+</div>
+<div id="FR:req6">
 <ul>
 Calculate-Change-Heat_Energy-Water-Time: Calculate and output the change in heat energy in the water (<em>E<sub>W</sub></em>(<em>t</em>)) over the simulation time (from IM3).
 </ul>
-</a>
 </div>
-</a>
-<a id="Sec:NFRs">
+</div>
+</div>
+<div id="Sec:NFRs">
 <div class="subsection">
 <h2>
 Non-Functional Requirements
@@ -1787,37 +1787,37 @@ Non-Functional Requirements
 This problem is small in size and relatively simple, so performance is not a priority. Any reasonable implementation will be very quick and use minimal storage. Rather than performance, the non-functional requirement priorities are correctness, verifiability, understandability, reusability, and maintainability.
 </p>
 </div>
-</a>
 </div>
-</a>
-<a id="Sec:LCs">
+</div>
+</div>
+<div id="Sec:LCs">
 <div class="section">
 <h1>
 Likely Changes
 </h1>
-<a id="LC:likeChg2">
+<div id="LC:likeChg2">
 <ul>
 Temperature-Coil-Variable-Over-Day: <a href=#A:assump8>assump8</a> - The temperature of the heating coil will change over the course of the day, depending on the energy received from the sun.
 </ul>
-</a>
-<a id="LC:likeChg3">
+</div>
+<div id="LC:likeChg3">
 <ul>
 Temperature-Coil-Variable-Over-Length: <a href=#A:assump9>assump9</a> - The temperature of the heating coil will actually change along its length as the water within it cools.
 </ul>
-</a>
-<a id="LC:likeChg3">
+</div>
+<div id="LC:likeChg3">
 <ul>
 Discharging-Tank: <a href=#A:assump9.npcm>assump9_npcm</a>- The model currently only accounts for charging of the tank. A more complete model would also account for discharging of the tank.
 </ul>
-</a>
-<a id="LC:likeChg6">
+</div>
+<div id="LC:likeChg6">
 <ul>
 Tank-Lose-Heat: <a href=#A:assump15>assump15</a> - Any real tank cannot be perfectly insulated and will lose heat.
 </ul>
-</a>
 </div>
-</a>
-<a id="Sec:TraceMatrices">
+</div>
+</div>
+<div id="Sec:TraceMatrices">
 <div class="section">
 <h1>
 Traceability Matrices and Graphs
@@ -1825,7 +1825,7 @@ Traceability Matrices and Graphs
 <p class="paragraph">
 The purpose of the traceability matrices is to provide easy references on what has to be additionally modified if a certain component is changed. Every time a component is changed, the items in the column of that component that are marked with an &quot;X&quot; should be modified as well. <a href=#Table:TraceyRI>Table:TraceyRI</a> shows the dependencies of theoretical models, general definitions, data definitions, and instance models with each other. <a href=#Table:TraceyRIs>Table:TraceyRIs</a> shows the dependencies of instance models, requirements, and data constraints on each other. <a href=#Table:TraceyAI>Table:TraceyAI</a> shows the dependencies of theoretical models, general definitions, data definitions, instance models, and likely changes on the assumptions.
 </p>
-<a id="Table:TraceyRI">
+<div id="Table:TraceyRI">
 <table class="table">
 <tr>
 <th>
@@ -1992,8 +1992,8 @@ IM2 (<a href=#T:heatEInWtr>T:heatEInWtr</a>)
 <p class="caption">
 Traceability Matrix Showing the Connections Between Requirements and Instance Models
 </p>
-</a>
-<a id="Table:TraceyRIs">
+</div>
+<div id="Table:TraceyRIs">
 <table class="table">
 <tr>
 <th>
@@ -2287,8 +2287,8 @@ X
 <p class="caption">
 Traceability Matrix Showing the Connections Between Requirements and Instance Models
 </p>
-</a>
-<a id="Table:TraceyAI">
+</div>
+<div id="Table:TraceyAI">
 <table class="table">
 <tr>
 <th>
@@ -2811,28 +2811,28 @@ X
 <p class="caption">
 Traceability Matrix Showing the Connections Between Assumptions and Other Items
 </p>
-</a>
+</div>
 <p class="paragraph">
 The purpose of the traceability graphs is also to provide easy references on what has to be additionally modified if a certain component is changed. The arrows in the graphs represent dependencies. The component at the tail of an arrow is depended on by the component at the head of that arrow. Therefore, if a component is changed, the components that it points to should also be changed. <a href=#Figure:TraceA>Figure:TraceA</a> shows the dependencies of theoretical models, general definitions, data definitions, instance models, likely changes, and assumptions on each other. <a href=#Figure:TraceR>Figure:TraceR</a> shows the dependencies of instance models, requirements, and data constraints on each other.
 </p>
 <p class="paragraph">
 NOTE: Building a tool to automatically generate the graphical representation of the matrix by scanning the labels and reference can be future work.
 </p>
-<a id="Figure:TraceA">
+<div id="Figure:TraceA">
 <img class="figure" src="ATrace.png" alt="Traceability Graph Showing the Connections Between Items of Different Sections"></img>
 <p class="caption">
 Traceability Graph Showing the Connections Between Items of Different Sections
 </p>
-</a>
-<a id="Figure:TraceR">
+</div>
+<div id="Figure:TraceR">
 <img class="figure" src="RTrace.png" alt="Traceability Graph Showing the Connections Between Requirements, Instance Models, and Data Constraints"></img>
 <p class="caption">
 Traceability Graph Showing the Connections Between Requirements, Instance Models, and Data Constraints
 </p>
-</a>
 </div>
-</a>
-<a id="Sec:AuxConstants">
+</div>
+</div>
+<div id="Sec:AuxConstants">
 <div class="section">
 <h1>
 Values of Auxiliary Constants
@@ -2840,7 +2840,7 @@ Values of Auxiliary Constants
 <p class="paragraph">
 This section contains the standard values that are used for calculations in SWHS.
 </p>
-<a id="Table:TAuxConsts">
+<div id="Table:TAuxConsts">
 <table class="table">
 <tr>
 <th>
@@ -3000,40 +3000,40 @@ s
 <p class="caption">
 Auxiliary Constants
 </p>
-</a>
 </div>
-</a>
-<a id="Sec:References">
+</div>
+</div>
+<div id="Sec:References">
 <div class="section">
 <h1>
 References
 </h1>
-<a id="incroperaEtAl2007">
+<div id="incroperaEtAl2007">
 <ul>
 [1]: Incropera, F. P., Dewitt, D. P., Bergman, T. L., and Lavine, A. S. <em>Fundamentals of Heat and Mass Transfer</em>. 6th. ed., Hoboken, New Jersey: John Wiley and Sons, 2007. Print.
 </ul>
-</a>
-<a id="koothoor2013">
+</div>
+<div id="koothoor2013">
 <ul>
 [2]: Koothoor, Nirmitha. <em>A document drive approach to certifying scientific computing software</em>. McMaster University, Hamilton, ON, Canada: 2013. Print.
 </ul>
-</a>
-<a id="lightstone2012">
+</div>
+<div id="lightstone2012">
 <ul>
 [3]: Lightstone, Marilyn. <em>Derivation of tank/pcm model</em>. 2012. From Marilyn Lightstone's Personal Notes
 </ul>
-</a>
-<a id="parnas1986">
+</div>
+<div id="parnas1986">
 <ul>
 [4]: Parnas, David L. and Clements, P. C. "A rational design process: How and why to fake it." <em>IEEE Transactions on Software Engineering</em>, vol. 12, no. 2, Washington, USA: February, 1986. pp. 251&ndash;257. Print.
 </ul>
-</a>
-<a id="smithLai2005">
+</div>
+<div id="smithLai2005">
 <ul>
 [5]: Smith, W. Spencer and Lai, Lei. "A new requirements template for scientific computing." <em>Proceedings of the First International Workshop on Situational Requirements Engineering Processes - Methods, Techniques and Tools to Support Situation-Specific Requirements Engineering Processes, SREP'05</em>. Edited by PJ Agerfalk, N. Kraiem, and J. Ralyte, Paris, France: 2005. pp. 107&ndash;121. In conjunction with 13th IEEE International Requirements Engineering Conference,
 </ul>
-</a>
 </div>
-</a>
+</div>
+</div>
 </body>
 </html>

--- a/code/stable/ssp/SSP_SRS.html
+++ b/code/stable/ssp/SSP_SRS.html
@@ -19,7 +19,7 @@ Software Requirements Specification for Slope Stability Analysis
 Henry Frankis
 </h2>
 </div>
-<a id="Sec:RefMat">
+<div id="Sec:RefMat">
 <div class="section">
 <h1>
 Reference Material
@@ -27,7 +27,7 @@ Reference Material
 <p class="paragraph">
 This section records information for easy reference.
 </p>
-<a id="Sec:ToU">
+<div id="Sec:ToU">
 <div class="subsection">
 <h2>
 Table of Units
@@ -35,7 +35,7 @@ Table of Units
 <p class="paragraph">
 The unit system used throughout is SI (Système International d'Unités). In addition to the basic units, several derived units are also used. For each unit, the table lists the symbol, a description and the SI name.
 </p>
-<a id="Table:ToU">
+<div id="Table:ToU">
 <table class="table">
 <tr>
 <th>
@@ -78,10 +78,10 @@ pressure (pascal)
 </td>
 </tr>
 </table>
-</a>
 </div>
-</a>
-<a id="Sec:ToS">
+</div>
+</div>
+<div id="Sec:ToS">
 <div class="subsection">
 <h2>
 Table of Symbols
@@ -89,7 +89,7 @@ Table of Symbols
 <p class="paragraph">
 The table that follows summarizes the symbols used in this document along with their units. Throughout the document, values with a subscript <em>i</em> implies that the value will be taken at and analyzed at a slice or slice interface composing the total slip mass.
 </p>
-<a id="Table:ToS">
+<div id="Table:ToS">
 <table class="table">
 <tr>
 <th>
@@ -1038,15 +1038,15 @@ m
 </td>
 </tr>
 </table>
-</a>
 </div>
-</a>
-<a id="Sec:TAbbAcc">
+</div>
+</div>
+<div id="Sec:TAbbAcc">
 <div class="subsection">
 <h2>
 Abbreviations and Acronyms
 </h2>
-<a id="Table:TAbbAcc">
+<div id="Table:TAbbAcc">
 <table class="table">
 <tr>
 <th>
@@ -1153,12 +1153,12 @@ Typical Uncertainty
 </td>
 </tr>
 </table>
-</a>
 </div>
-</a>
 </div>
-</a>
-<a id="Sec:Intro">
+</div>
+</div>
+</div>
+<div id="Sec:Intro">
 <div class="section">
 <h1>
 Introduction
@@ -1169,7 +1169,7 @@ A slope of geological mass, composed of soil and rock, is subject to the influen
 <p class="paragraph">
 The following section provides an overview of the Software Requirements Specification (SRS) for a slope stability analysis problem. The developed program will be referred to as the Slope Stability Analysis (SSA) program. This section explains the purpose of this document, the scope of the system, the organization of the document, and the characteristics of the intended reader.
 </p>
-<a id="Sec:DocPurpose">
+<div id="Sec:DocPurpose">
 <div class="subsection">
 <h2>
 Purpose of Document
@@ -1181,8 +1181,8 @@ The SSA program determines the critical slip surface, and its respective factor 
 This document will be used as a starting point for subsequent development phases, including writing the design specification and the software verification and validation plan. The design document will show how the requirements are to be realized, including decisions on the numerical algorithms and programming environment. The verification and validation plan will show the steps that will be used to increase confidence in the software documentation and the implementation. Although the SRS fits in a series of documents that follow the so-called waterfall model, the actual development process is not constrained in any way. Even when the waterfall model is not followed, as Parnas and Clements point out, the most logical way to present the documentation is still to &quot;fake&quot; a rational design process.
 </p>
 </div>
-</a>
-<a id="Sec:ReqsScope">
+</div>
+<div id="Sec:ReqsScope">
 <div class="subsection">
 <h2>
 Scope of Requirements
@@ -1191,8 +1191,8 @@ Scope of Requirements
 The scope of the requirements includes stability analysis of a 2 dimensional slope, composed of homogeneous soil layers. Given the appropriate inputs, the code for SSA is intended to identify the most likely failure surface within the possible input range, and find the factor of safety for the slope as well as displacement of soil that will occur on the slope.
 </p>
 </div>
-</a>
-<a id="Sec:ReaderChars">
+</div>
+<div id="Sec:ReaderChars">
 <div class="subsection">
 <h2>
 Characteristics of Intended Reader
@@ -1201,8 +1201,8 @@ Characteristics of Intended Reader
 Reviewers of this documentation should have a strong knowledge in solid mechanics. The reviewers should also have an understanding of undergraduate level 4 physics. The users of SSA can have a lower level of expertise, as explained in <a href=#Sec:UserChars>User Characteristics</a>.
 </p>
 </div>
-</a>
-<a id="Sec:DocOrg">
+</div>
+<div id="Sec:DocOrg">
 <div class="subsection">
 <h2>
 Organization of Document
@@ -1214,10 +1214,10 @@ The organization of this document follows the template for an SRS for scientific
 The goal statements are refined to the theoretical models, and the theoretical models to the instance models. The instance models provide the set of algebraic equations that must be solved iteratively to perform a Morgenstern Price Analysis.
 </p>
 </div>
-</a>
 </div>
-</a>
-<a id="Sec:GenSysDesc">
+</div>
+</div>
+<div id="Sec:GenSysDesc">
 <div class="section">
 <h1>
 General System Description
@@ -1225,7 +1225,7 @@ General System Description
 <p class="paragraph">
 This section provides general information about the system, identifies the interfaces between the system and its environment, and describes the user characteristics and the system constraints.
 </p>
-<a id="Sec:UserChars">
+<div id="Sec:UserChars">
 <div class="subsection">
 <h2>
 User Characteristics
@@ -1234,8 +1234,8 @@ User Characteristics
 The end user of SSA should have an understanding of undergraduate Level 1 Calculus and Physics, and be familiar with soil and material properties.
 </p>
 </div>
-</a>
-<a id="Sec:SysConstraints">
+</div>
+<div id="Sec:SysConstraints">
 <div class="subsection">
 <h2>
 System Constraints
@@ -1244,10 +1244,10 @@ System Constraints
 There are no system constraints.
 </p>
 </div>
-</a>
 </div>
-</a>
-<a id="Sec:SpecSystDesc">
+</div>
+</div>
+<div id="Sec:SpecSystDesc">
 <div class="section">
 <h1>
 Specific System Description
@@ -1255,7 +1255,7 @@ Specific System Description
 <p class="paragraph">
 This section first presents the problem description, which gives a high-level view of the problem to be solved. This is followed by the solution characteristics specification, which presents the assumptions, theories, definitions and finally the instance models that model the slope.
 </p>
-<a id="Sec:ProbDesc">
+<div id="Sec:ProbDesc">
 <div class="subsection">
 <h2>
 Problem Description
@@ -1263,7 +1263,7 @@ Problem Description
 <p class="paragraph">
 SSA is a computer program developed to evaluate the factor of safety of a slope's slip surface and to calculate the displacement that the slope will experience.
 </p>
-<a id="Sec:TermDefs">
+<div id="Sec:TermDefs">
 <div class="subsubsection">
 <h3>
 Terminology and Definitions
@@ -1301,8 +1301,8 @@ Plane Strain: The resultant stresses in one of the directions of a 3 dimensional
 </p>
 </div>
 </div>
-</a>
-<a id="Sec:PhysSyst">
+</div>
+<div id="Sec:PhysSyst">
 <div class="subsubsection">
 <h3>
 Physical System Description
@@ -1321,21 +1321,21 @@ Slice properties convention is noted by. <em>i</em>
 <p class="paragraph">
 A free body diagram of the forces acting on the slice is displayed in <a href=#Figure:ForceDiagram>Figure:ForceDiagram</a>.
 </p>
-<a id="Figure:IndexConvention">
+<div id="Figure:IndexConvention">
 <img class="figure" src="IndexConvention.png" alt="Index convention for numbering slice and interslice force variables"></img>
 <p class="caption">
 Index convention for numbering slice and interslice force variables
 </p>
-</a>
-<a id="Figure:ForceDiagram">
+</div>
+<div id="Figure:ForceDiagram">
 <img class="figure" src="ForceDiagram.png" alt="Forces acting on a slice"></img>
 <p class="caption">
 Forces acting on a slice
 </p>
-</a>
 </div>
-</a>
-<a id="Sec:GoalStmt">
+</div>
+</div>
+<div id="Sec:GoalStmt">
 <div class="subsubsection">
 <h3>
 Goal Statements
@@ -1355,10 +1355,10 @@ GS3: Determine the displacement of the slope.
 </p>
 </div>
 </div>
-</a>
 </div>
-</a>
-<a id="Sec:SolCharSpec">
+</div>
+</div>
+<div id="Sec:SolCharSpec">
 <div class="subsection">
 <h2>
 Solution Characteristics Specification
@@ -1366,7 +1366,7 @@ Solution Characteristics Specification
 <p class="paragraph">
 The instance models that govern SSA are presented in <a href=#Sec:IMs>Instance Models</a>. The information to understand the meaning of the instance models and their derivation is also presented, so that the instance models can be verified.
 </p>
-<a id="Sec:Assumps">
+<div id="Sec:Assumps">
 <div class="subsubsection">
 <h3>
 Assumptions
@@ -1407,8 +1407,8 @@ A10: The surface and base of a slice between interslice nodes are approximated a
 </p>
 </div>
 </div>
-</a>
-<a id="Sec:TMs">
+</div>
+<div id="Sec:TMs">
 <div class="subsubsection">
 <h3>
 Theoretical Models
@@ -1416,7 +1416,7 @@ Theoretical Models
 <p class="paragraph">
 This section focuses on the general equations and laws that SSA is based on.
 </p>
-<a id="T:fs.rc">
+<div id="T:fs.rc">
 <table class="tdefn">
 <tr>
 <th>
@@ -1433,7 +1433,7 @@ Factor of Safety
 Equation
 </th>
 <td>
-<a id="">
+<div id="">
 <div class="equation">
 <p class="paragraph">
 <em>FS = <div class="fraction">
@@ -1446,7 +1446,7 @@ S
 </div></em>
 </p>
 </div>
-</a>
+</div>
 </td>
 </tr>
 <tr>
@@ -1460,8 +1460,8 @@ The stability metric of the slope, known as the factor of safety (<em>FS</em>), 
 </td>
 </tr>
 </table>
-</a>
-<a id="T:equilibrium">
+</div>
+<div id="T:equilibrium">
 <table class="tdefn">
 <tr>
 <th>
@@ -1478,13 +1478,13 @@ Equilibrium
 Equation
 </th>
 <td>
-<a id="">
+<div id="">
 <div class="equation">
 <p class="paragraph">
 <em>&sum;F<sub>x</sub> = &sum;F<sub>y</sub> = &sum;M = 0</em>
 </p>
 </div>
-</a>
+</div>
 </td>
 </tr>
 <tr>
@@ -1498,8 +1498,8 @@ For a body in static equilibrium, the net forces and net moments acting on the b
 </td>
 </tr>
 </table>
-</a>
-<a id="T:mcShrStrgth">
+</div>
+<div id="T:mcShrStrgth">
 <table class="tdefn">
 <tr>
 <th>
@@ -1516,13 +1516,13 @@ Mohr-Coulumb Shear Strength
 Equation
 </th>
 <td>
-<a id="">
+<div id="">
 <div class="equation">
 <p class="paragraph">
 <em>&tau; = &sigma;&#8239;tan(&phiv;&prime;)&plus;c&prime;</em>
 </p>
 </div>
-</a>
+</div>
 </td>
 </tr>
 <tr>
@@ -1536,8 +1536,8 @@ For a soil under stress it will exert a shear resistive strength based on the Co
 </td>
 </tr>
 </table>
-</a>
-<a id="T:effStress">
+</div>
+<div id="T:effStress">
 <table class="tdefn">
 <tr>
 <th>
@@ -1554,13 +1554,13 @@ Effective Stress
 Equation
 </th>
 <td>
-<a id="">
+<div id="">
 <div class="equation">
 <p class="paragraph">
 <em>&sigma; = &sigma;&minus;&mu;</em>
 </p>
 </div>
-</a>
+</div>
 </td>
 </tr>
 <tr>
@@ -1574,8 +1574,8 @@ Description
 </td>
 </tr>
 </table>
-</a>
-<a id="T:hookesLaw">
+</div>
+<div id="T:hookesLaw">
 <table class="tdefn">
 <tr>
 <th>
@@ -1592,13 +1592,13 @@ Hooke's Law
 Equation
 </th>
 <td>
-<a id="">
+<div id="">
 <div class="equation">
 <p class="paragraph">
 <em>F = K&#8239;&delta;</em>
 </p>
 </div>
-</a>
+</div>
 </td>
 </tr>
 <tr>
@@ -1612,10 +1612,10 @@ Description Stiffness <em>K</em> is the resistance a body others to deformation 
 </td>
 </tr>
 </table>
-</a>
 </div>
-</a>
-<a id="Sec:GDs">
+</div>
+</div>
+<div id="Sec:GDs">
 <div class="subsubsection">
 <h3>
 General Definitions
@@ -1623,7 +1623,7 @@ General Definitions
 <p class="paragraph">
 This section collects the laws and equations that will be used in deriving the data definitions, which in turn are used to build the instance models.
 </p>
-<a id="T:normForcEq">
+<div id="T:normForcEq">
 <table class="tdefn">
 <tr>
 <th>
@@ -1640,13 +1640,13 @@ Normal Force Equilibrium
 Equation
 </th>
 <td>
-<a id="">
+<div id="">
 <div class="equation">
 <p class="paragraph">
 <em>N<sub>i</sub> = (W<sub>i</sub>&minus;X<sub>i&minus;1</sub>&plus;X<sub>i</sub>&plus;U<sub>t,i</sub>&#8239;cos(&beta;<sub>i</sub>)&plus;Q<sub>i</sub>&#8239;cos(&omega;<sub>i</sub>))&#8239;cos(&alpha;<sub>i</sub>)&plus;(&minus;K<sub>c</sub>&#8239;W<sub>i</sub>&minus;E<sub>i</sub>&plus;E<sub>i&minus;1</sub>&minus;H<sub>i</sub>&plus;H<sub>i&minus;1</sub>&plus;U<sub>t,i</sub>&#8239;sin(&beta;<sub>i</sub>)&plus;Q<sub>i</sub>&#8239;sin(&omega;<sub>i</sub>))&#8239;sin(&alpha;<sub>i</sub>)</em>
 </p>
 </div>
-</a>
+</div>
 </td>
 </tr>
 <tr>
@@ -1660,8 +1660,8 @@ For a slice of mass in the slope the force equilibrium to satisfy T2 in the dire
 </td>
 </tr>
 </table>
-</a>
-<a id="T:bsShrFEq">
+</div>
+<div id="T:bsShrFEq">
 <table class="tdefn">
 <tr>
 <th>
@@ -1678,13 +1678,13 @@ Base Shear Force Equilibrium
 Equation
 </th>
 <td>
-<a id="">
+<div id="">
 <div class="equation">
 <p class="paragraph">
 <em>S<sub>i</sub> = (W<sub>i</sub>&minus;X<sub>i&minus;1</sub>&plus;X<sub>i</sub>&plus;U<sub>t,i</sub>&#8239;cos(&beta;<sub>i</sub>)&plus;Q<sub>i</sub>&#8239;cos(&omega;<sub>i</sub>))&#8239;sin(&alpha;<sub>i</sub>)&plus;(&minus;K<sub>c</sub>&#8239;W<sub>i</sub>&minus;E<sub>i</sub>&plus;E<sub>i&minus;1</sub>&minus;H<sub>i</sub>&plus;H<sub>i&minus;1</sub>&plus;U<sub>t,i</sub>&#8239;sin(&beta;<sub>i</sub>)&plus;Q<sub>i</sub>&#8239;sin(&omega;<sub>i</sub>))&#8239;cos(&alpha;<sub>i</sub>)</em>
 </p>
 </div>
-</a>
+</div>
 </td>
 </tr>
 <tr>
@@ -1698,8 +1698,8 @@ For a slice of mass in the slope the force equilibrium to satisfy T2 in the dire
 </td>
 </tr>
 </table>
-</a>
-<a id="T:resShr">
+</div>
+<div id="T:resShr">
 <table class="tdefn">
 <tr>
 <th>
@@ -1716,13 +1716,13 @@ Resistive Shear Force
 Equation
 </th>
 <td>
-<a id="">
+<div id="">
 <div class="equation">
 <p class="paragraph">
 <em>P<sub>i</sub> = N&prime;<sub>i</sub>&#8239;tan(&phiv;&prime;<sub>i</sub>)&plus;c&prime;<sub>i</sub>&#8239;b<sub>i</sub>&#8239;sec(&alpha;<sub>i</sub>)</em>
 </p>
 </div>
-</a>
+</div>
 </td>
 </tr>
 <tr>
@@ -1736,8 +1736,8 @@ The Mohr-Coulomb resistive shear strength of a slice <em>&tau;</em> from T3 is m
 </td>
 </tr>
 </table>
-</a>
-<a id="T:mobShr">
+</div>
+<div id="T:mobShr">
 <table class="tdefn">
 <tr>
 <th>
@@ -1754,7 +1754,7 @@ Mobile Shear Force
 Equation
 </th>
 <td>
-<a id="">
+<div id="">
 <div class="equation">
 <p class="paragraph">
 <em>S<sub>i</sub> = <div class="fraction">
@@ -1774,7 +1774,7 @@ FS
 </div></em>
 </p>
 </div>
-</a>
+</div>
 </td>
 </tr>
 <tr>
@@ -1788,8 +1788,8 @@ From the definition of the factor of safety in T1, and the new definition of <em
 </td>
 </tr>
 </table>
-</a>
-<a id="T:normShrR">
+</div>
+<div id="T:normShrR">
 <table class="tdefn">
 <tr>
 <th>
@@ -1806,13 +1806,13 @@ Interslice Normal/shear Relationship
 Equation
 </th>
 <td>
-<a id="">
+<div id="">
 <div class="equation">
 <p class="paragraph">
 <em>X = &lambda;&#8239;f&#8239;E</em>
 </p>
 </div>
-</a>
+</div>
 </td>
 </tr>
 <tr>
@@ -1826,8 +1826,8 @@ The assumption for the Morgenstern Price method (<a href=#A:Interslice-Norm-Shea
 </td>
 </tr>
 </table>
-</a>
-<a id="T:momentEql">
+</div>
+<div id="T:momentEql">
 <table class="tdefn">
 <tr>
 <th>
@@ -1844,7 +1844,7 @@ Moment Equilibrium
 Equation
 </th>
 <td>
-<a id="">
+<div id="">
 <div class="equation">
 <p class="paragraph">
 <em>0 = &minus;E<sub>i</sub>&#8239;(z<sub>i</sub>&minus;<div class="fraction">
@@ -1892,7 +1892,7 @@ K<sub>c</sub>&#8239;W<sub>i</sub>&#8239;h<sub>i</sub>
 </div>&minus;U<sub>t,i</sub>&#8239;sin(&beta;<sub>i</sub>)&#8239;h<sub>i</sub>&minus;Q<sub>i</sub>&#8239;sin(&omega;<sub>i</sub>)&#8239;h<sub>i</sub></em>
 </p>
 </div>
-</a>
+</div>
 </td>
 </tr>
 <tr>
@@ -1906,8 +1906,8 @@ For a slice of mass in the slope the moment equilibrium to satisfy T2 in the dir
 </td>
 </tr>
 </table>
-</a>
-<a id="T:netForce">
+</div>
+<div id="T:netForce">
 <table class="tdefn">
 <tr>
 <th>
@@ -1924,13 +1924,13 @@ Net X-Component Force
 Equation
 </th>
 <td>
-<a id="">
+<div id="">
 <div class="equation">
 <p class="paragraph">
 <em>F<sub>x,i</sub> = &minus;&Delta;H<sub>i</sub>&minus;K<sub>c</sub>&#8239;W<sub>i</sub>&minus;U<sub>b,i</sub>&#8239;sin(&alpha;<sub>i</sub>)&plus;U<sub>t,i</sub>&#8239;sin(&beta;<sub>i</sub>)&plus;Q<sub>i</sub>&#8239;sin(&omega;<sub>i</sub>)</em>
 </p>
 </div>
-</a>
+</div>
 </td>
 </tr>
 <tr>
@@ -1944,8 +1944,8 @@ Description
 </td>
 </tr>
 </table>
-</a>
-<a id="T:netForce">
+</div>
+<div id="T:netForce">
 <table class="tdefn">
 <tr>
 <th>
@@ -1962,13 +1962,13 @@ Net Y-Component Force
 Equation
 </th>
 <td>
-<a id="">
+<div id="">
 <div class="equation">
 <p class="paragraph">
 <em>F<sub>y,i</sub> = &minus;W<sub>i</sub>&plus;U<sub>b,i</sub>&#8239;cos(&alpha;<sub>i</sub>)&minus;U<sub>t,i</sub>&#8239;cos(&beta;<sub>i</sub>)&minus;Q<sub>i</sub>&#8239;cos(&omega;<sub>i</sub>)</em>
 </p>
 </div>
-</a>
+</div>
 </td>
 </tr>
 <tr>
@@ -1982,8 +1982,8 @@ These equations show the net sum of the forces acting on a slice for the RFEM mo
 </td>
 </tr>
 </table>
-</a>
-<a id="T:hookesLaw2d">
+</div>
+<div id="T:hookesLaw2d">
 <table class="tdefn">
 <tr>
 <th>
@@ -2000,7 +2000,7 @@ Hooke's Law 2D
 Equation
 </th>
 <td>
-<a id="">
+<div id="">
 <div class="equation">
 <p class="paragraph">
 <em><table class="matrix">
@@ -2015,7 +2015,7 @@ Equation
 </table></em>
 </p>
 </div>
-</a>
+</div>
 </td>
 </tr>
 <tr>
@@ -2029,8 +2029,8 @@ A 2D component implementation of Hooke's law as seen in T5. <em>&delta;n</em> is
 </td>
 </tr>
 </table>
-</a>
-<a id="T:displVect">
+</div>
+<div id="T:displVect">
 <table class="tdefn">
 <tr>
 <th>
@@ -2047,7 +2047,7 @@ Displacement Vectors
 Equation
 </th>
 <td>
-<a id="">
+<div id="">
 <div class="equation">
 <p class="paragraph">
 <em>&epsilon;<sub>i</sub> = <table class="matrix">
@@ -2065,7 +2065,7 @@ Equation
 </table></em>
 </p>
 </div>
-</a>
+</div>
 </td>
 </tr>
 <tr>
@@ -2079,10 +2079,10 @@ Vectors describing the displacement of slice <em>i</em>. <em>&delta;</em> is the
 </td>
 </tr>
 </table>
-</a>
 </div>
-</a>
-<a id="Sec:DDs">
+</div>
+</div>
+<div id="Sec:DDs">
 <div class="subsubsection">
 <h3>
 Data Definitions
@@ -2090,7 +2090,7 @@ Data Definitions
 <p class="paragraph">
 This section collects and defines all the data needed to build the instance models. Definitions DD1 to DD8 are the force variables that can be solved by direct analysis of given inputs. The interslice forces DD9 are force variables that must be written in terms of DD1 to DD8 to solve.
 </p>
-<a id="DD:W.i">
+<div id="DD:W.i">
 <table class="ddefn">
 <tr>
 <th>
@@ -2117,7 +2117,7 @@ N
 Equation
 </th>
 <td>
-<a id="">
+<div id="">
 <div class="equation">
 <p class="paragraph">
 <em>W = b<sub>i</sub>&#8239;<span class="casebr">
@@ -2142,7 +2142,7 @@ y<sub>wt,i</sub>&thinsp;&le;&thinsp;y<sub>slip,i</sub>
 </div></em>
 </p>
 </div>
-</a>
+</div>
 </td>
 </tr>
 <tr>
@@ -2156,8 +2156,8 @@ Description
 </td>
 </tr>
 </table>
-</a>
-<a id="DD:U.b,i">
+</div>
+<div id="DD:U.b,i">
 <table class="ddefn">
 <tr>
 <th>
@@ -2184,7 +2184,7 @@ N
 Equation
 </th>
 <td>
-<a id="">
+<div id="">
 <div class="equation">
 <p class="paragraph">
 <em>U<sub>b</sub> = &#8467;<sub>b,i</sub>&#8239;<span class="casebr">
@@ -2204,7 +2204,7 @@ y<sub>wt,i</sub>&thinsp;&le;&thinsp;y<sub>slip,i</sub>
 </div></em>
 </p>
 </div>
-</a>
+</div>
 </td>
 </tr>
 <tr>
@@ -2218,8 +2218,8 @@ Description
 </td>
 </tr>
 </table>
-</a>
-<a id="DD:U.t,i">
+</div>
+<div id="DD:U.t,i">
 <table class="ddefn">
 <tr>
 <th>
@@ -2246,7 +2246,7 @@ N
 Equation
 </th>
 <td>
-<a id="">
+<div id="">
 <div class="equation">
 <p class="paragraph">
 <em>U<sub>t</sub> = &#8467;<sub>s,i</sub>&#8239;<span class="casebr">
@@ -2266,7 +2266,7 @@ y<sub>wt,i</sub>&thinsp;&le;&thinsp;y<sub>us,i</sub>
 </div></em>
 </p>
 </div>
-</a>
+</div>
 </td>
 </tr>
 <tr>
@@ -2280,8 +2280,8 @@ Description
 </td>
 </tr>
 </table>
-</a>
-<a id="DD:H.i">
+</div>
+<div id="DD:H.i">
 <table class="ddefn">
 <tr>
 <th>
@@ -2308,7 +2308,7 @@ N
 Equation
 </th>
 <td>
-<a id="">
+<div id="">
 <div class="equation">
 <p class="paragraph">
 <em>H = <span class="casebr">
@@ -2347,7 +2347,7 @@ y<sub>wt,i</sub>&thinsp;&le;&thinsp;y<sub>slip,i</sub>
 </div></em>
 </p>
 </div>
-</a>
+</div>
 </td>
 </tr>
 <tr>
@@ -2361,8 +2361,8 @@ Description
 </td>
 </tr>
 </table>
-</a>
-<a id="DD:alpha.i">
+</div>
+<div id="DD:alpha.i">
 <table class="ddefn">
 <tr>
 <th>
@@ -2389,7 +2389,7 @@ Units
 Equation
 </th>
 <td>
-<a id="">
+<div id="">
 <div class="equation">
 <p class="paragraph">
 <em>&alpha; = <div class="fraction">
@@ -2402,7 +2402,7 @@ x<sub>slip,i</sub>&minus;x<sub>slip,i&minus;1</sub>
 </div></em>
 </p>
 </div>
-</a>
+</div>
 </td>
 </tr>
 <tr>
@@ -2416,8 +2416,8 @@ Description
 </td>
 </tr>
 </table>
-</a>
-<a id="DD:beta.i">
+</div>
+<div id="DD:beta.i">
 <table class="ddefn">
 <tr>
 <th>
@@ -2444,7 +2444,7 @@ Units
 Equation
 </th>
 <td>
-<a id="">
+<div id="">
 <div class="equation">
 <p class="paragraph">
 <em>&beta; = <div class="fraction">
@@ -2457,7 +2457,7 @@ x<sub>us,i</sub>&minus;x<sub>us,i&minus;1</sub>
 </div></em>
 </p>
 </div>
-</a>
+</div>
 </td>
 </tr>
 <tr>
@@ -2471,8 +2471,8 @@ Description
 </td>
 </tr>
 </table>
-</a>
-<a id="DD:b.i">
+</div>
+<div id="DD:b.i">
 <table class="ddefn">
 <tr>
 <th>
@@ -2499,13 +2499,13 @@ m
 Equation
 </th>
 <td>
-<a id="">
+<div id="">
 <div class="equation">
 <p class="paragraph">
 <em>b = x<sub>slip,i</sub>&minus;x<sub>slip,i&minus;1</sub></em>
 </p>
 </div>
-</a>
+</div>
 </td>
 </tr>
 <tr>
@@ -2519,8 +2519,8 @@ Description
 </td>
 </tr>
 </table>
-</a>
-<a id="DD:l.b,i">
+</div>
+<div id="DD:l.b,i">
 <table class="ddefn">
 <tr>
 <th>
@@ -2547,13 +2547,13 @@ m
 Equation
 </th>
 <td>
-<a id="">
+<div id="">
 <div class="equation">
 <p class="paragraph">
 <em>&#8467;<sub>b</sub> = b<sub>i</sub>&#8239;sec(&alpha;<sub>i</sub>)</em>
 </p>
 </div>
-</a>
+</div>
 </td>
 </tr>
 <tr>
@@ -2567,8 +2567,8 @@ Description
 </td>
 </tr>
 </table>
-</a>
-<a id="DD:l.s,i">
+</div>
+<div id="DD:l.s,i">
 <table class="ddefn">
 <tr>
 <th>
@@ -2595,13 +2595,13 @@ m
 Equation
 </th>
 <td>
-<a id="">
+<div id="">
 <div class="equation">
 <p class="paragraph">
 <em>&#8467;<sub>s</sub> = b<sub>i</sub>&#8239;sec(&beta;<sub>i</sub>)</em>
 </p>
 </div>
-</a>
+</div>
 </td>
 </tr>
 <tr>
@@ -2615,8 +2615,8 @@ Description
 </td>
 </tr>
 </table>
-</a>
-<a id="DD:K.c">
+</div>
+<div id="DD:K.c">
 <table class="ddefn">
 <tr>
 <th>
@@ -2643,13 +2643,13 @@ Unitless
 Equation
 </th>
 <td>
-<a id="">
+<div id="">
 <div class="equation">
 <p class="paragraph">
 <em>K<sub>c</sub> = K<sub>c</sub>&#8239;W<sub>i</sub></em>
 </p>
 </div>
-</a>
+</div>
 </td>
 </tr>
 <tr>
@@ -2663,8 +2663,8 @@ Description
 </td>
 </tr>
 </table>
-</a>
-<a id="DD:Q.i">
+</div>
+<div id="DD:Q.i">
 <table class="ddefn">
 <tr>
 <th>
@@ -2691,13 +2691,13 @@ N
 Equation
 </th>
 <td>
-<a id="">
+<div id="">
 <div class="equation">
 <p class="paragraph">
 <em>Q = Q<sub>i</sub>&#8239;&omega;<sub>i</sub></em>
 </p>
 </div>
-</a>
+</div>
 </td>
 </tr>
 <tr>
@@ -2711,8 +2711,8 @@ Description
 </td>
 </tr>
 </table>
-</a>
-<a id="DD:X.i">
+</div>
+<div id="DD:X.i">
 <table class="ddefn">
 <tr>
 <th>
@@ -2739,13 +2739,13 @@ N
 Equation
 </th>
 <td>
-<a id="">
+<div id="">
 <div class="equation">
 <p class="paragraph">
 <em>X = &lambda;&#8239;f<sub>i</sub>&#8239;E<sub>i</sub></em>
 </p>
 </div>
-</a>
+</div>
 </td>
 </tr>
 <tr>
@@ -2759,8 +2759,8 @@ Description
 </td>
 </tr>
 </table>
-</a>
-<a id="DD:R.i">
+</div>
+<div id="DD:R.i">
 <table class="ddefn">
 <tr>
 <th>
@@ -2787,13 +2787,13 @@ N
 Equation
 </th>
 <td>
-<a id="">
+<div id="">
 <div class="equation">
 <p class="paragraph">
 <em>R = ((W<sub>i</sub>&plus;U<sub>t,i</sub>&#8239;cos(&beta;<sub>i</sub>)&plus;Q<sub>i</sub>&#8239;cos(&omega;<sub>i</sub>))&#8239;cos(&alpha;<sub>i</sub>)&plus;(&minus;K<sub>c</sub>&#8239;W<sub>i</sub>&minus;&Delta;H<sub>i</sub>&plus;U<sub>t,i</sub>&#8239;sin(&beta;<sub>i</sub>)&plus;Q<sub>i</sub>&#8239;sin(&omega;<sub>i</sub>))&#8239;sin(&alpha;<sub>i</sub>)&minus;U<sub>b,i</sub>)&#8239;tan(&phiv;&prime;<sub>i</sub>)&plus;c&prime;<sub>i</sub>&#8239;b<sub>i</sub>&#8239;sec(&alpha;<sub>i</sub>)</em>
 </p>
 </div>
-</a>
+</div>
 </td>
 </tr>
 <tr>
@@ -2807,32 +2807,32 @@ Description
 </td>
 </tr>
 </table>
-</a>
+</div>
 <p class="paragraph">
 The resistive shear force of a slice is defined as <em>P</em> in GD3. The effective normal force in the equation for <em>P</em> of the soil is defined in the perpendicular force equilibrium of a slice from GD2, using the effective normal force <em>N&prime;</em> of T4 shown in equation (1).
 </p>
-<a id="">
+<div id="">
 <div class="equation">
 <em>N&prime;<sub>i</sub> = (W<sub>i</sub>&minus;X<sub>i&minus;1</sub>&plus;X<sub>i</sub>&plus;U<sub>t,i</sub>&#8239;cos(&beta;<sub>i</sub>)&plus;Q<sub>i</sub>&#8239;cos(&omega;<sub>i</sub>))&#8239;cos(&alpha;<sub>i</sub>)&plus;(&minus;K<sub>c</sub>&#8239;W<sub>i</sub>&minus;E<sub>i</sub>&plus;E<sub>i&minus;1</sub>&minus;H<sub>i</sub>&plus;H<sub>i&minus;1</sub>&plus;U<sub>t,i</sub>&#8239;sin(&beta;<sub>i</sub>)&plus;Q<sub>i</sub>&#8239;sin(&omega;<sub>i</sub>))&#8239;sin(&alpha;<sub>i</sub>)&minus;U<sub>b,i</sub></em>
 </div>
-</a>
+</div>
 <p class="paragraph">
 The values of the interslice forces <em>E</em> and <em>X</em> in the equation are unknown, while the other values are found from the physical force definitions of DD1 to DD9. Consider a force equilibrium without the affect of interslice forces, to obtain a solvable value as done for <em>N*</em> in equation (2).
 </p>
-<a id="">
+<div id="">
 <div class="equation">
 <em>N*<sub>i</sub> = (W<sub>i</sub>&plus;U<sub>t,i</sub>&#8239;cos(&beta;<sub>i</sub>)&plus;Q<sub>i</sub>&#8239;cos(&omega;<sub>i</sub>))&#8239;cos(&alpha;<sub>i</sub>)&plus;(&minus;K<sub>c</sub>&#8239;W<sub>i</sub>&minus;H<sub>i</sub>&plus;H<sub>i&minus;1</sub>&plus;U<sub>t,i</sub>&#8239;sin(&beta;<sub>i</sub>)&plus;Q<sub>i</sub>&#8239;sin(&omega;<sub>i</sub>))&#8239;sin(&alpha;<sub>i</sub>)&minus;U<sub>b,i</sub></em>
 </div>
-</a>
+</div>
 <p class="paragraph">
 Using <em>N*</em>, a resistive shear force without the influence of interslice forces for slice index i can be solved for in terms of all known values as done in equation (3).
 </p>
-<a id="">
+<div id="">
 <div class="equation">
 <em>R<sub>i</sub> = N*<sub>i</sub>&#8239;tan(&phiv;&prime;<sub>i</sub>)&plus;c&prime;<sub>i</sub>&#8239;b<sub>i</sub>&#8239;sec(&alpha;<sub>i</sub>) = ((W<sub>i</sub>&plus;U<sub>t,i</sub>&#8239;cos(&beta;<sub>i</sub>)&plus;Q<sub>i</sub>&#8239;cos(&omega;<sub>i</sub>))&#8239;cos(&alpha;<sub>i</sub>)&plus;(&minus;K<sub>c</sub>&#8239;W<sub>i</sub>&minus;&Delta;H<sub>i</sub>&plus;U<sub>t,i</sub>&#8239;sin(&beta;<sub>i</sub>)&plus;Q<sub>i</sub>&#8239;sin(&omega;<sub>i</sub>))&#8239;sin(&alpha;<sub>i</sub>)&minus;U<sub>b,i</sub>)&#8239;tan(&phiv;&prime;<sub>i</sub>)&plus;c&prime;<sub>i</sub>&#8239;b<sub>i</sub>&#8239;sec(&alpha;<sub>i</sub>)</em>
 </div>
-</a>
-<a id="DD:T.i">
+</div>
+<div id="DD:T.i">
 <table class="ddefn">
 <tr>
 <th>
@@ -2859,13 +2859,13 @@ N
 Equation
 </th>
 <td>
-<a id="">
+<div id="">
 <div class="equation">
 <p class="paragraph">
 <em>T = (W<sub>i</sub>&plus;U<sub>t,i</sub>&#8239;cos(&beta;<sub>i</sub>)&plus;Q<sub>i</sub>&#8239;cos(&omega;<sub>i</sub>))&#8239;sin(&alpha;<sub>i</sub>)&minus;(&minus;K<sub>c</sub>&#8239;W<sub>i</sub>&minus;&Delta;H<sub>i</sub>&plus;U<sub>t,i</sub>&#8239;sin(&beta;<sub>i</sub>)&plus;Q<sub>i</sub>&#8239;sin(&omega;<sub>i</sub>))&#8239;cos(&alpha;<sub>i</sub>)</em>
 </p>
 </div>
-</a>
+</div>
 </td>
 </tr>
 <tr>
@@ -2879,27 +2879,27 @@ Description
 </td>
 </tr>
 </table>
-</a>
+</div>
 <p class="paragraph">
 The mobilized shear force acting on a slice is defined as <em>S</em> from the force equilibrium in GD2, also shown in equation (4).
 </p>
-<a id="">
+<div id="">
 <div class="equation">
 <em>S<sub>i</sub> = (W<sub>i</sub>&minus;X<sub>i&minus;1</sub>&plus;X<sub>i</sub>&plus;U<sub>t,i</sub>&#8239;cos(&beta;<sub>i</sub>)&plus;Q<sub>i</sub>&#8239;cos(&omega;<sub>i</sub>))&#8239;sin(&alpha;<sub>i</sub>)&plus;(&minus;K<sub>c</sub>&#8239;W<sub>i</sub>&minus;E<sub>i</sub>&plus;E<sub>i&minus;1</sub>&minus;H<sub>i</sub>&plus;H<sub>i&minus;1</sub>&plus;U<sub>t,i</sub>&#8239;sin(&beta;<sub>i</sub>)&plus;Q<sub>i</sub>&#8239;sin(&omega;<sub>i</sub>))&#8239;cos(&alpha;<sub>i</sub>)</em>
 </div>
-</a>
+</div>
 <p class="paragraph">
 The equation is unsolvable, containing the unknown interslice normal force <em>E</em> and interslice shear force <em>X</em>. Consider a force equilibrium without the influence of interslice forces, to obtain the mobilized shear force <em>T</em>, as done in equation (5).
 </p>
-<a id="">
+<div id="">
 <div class="equation">
 <em>T<sub>i</sub> = (W<sub>i</sub>&plus;U<sub>t,i</sub>&#8239;cos(&beta;<sub>i</sub>)&plus;Q<sub>i</sub>&#8239;cos(&omega;<sub>i</sub>))&#8239;sin(&alpha;<sub>i</sub>)&minus;(&minus;K<sub>c</sub>&#8239;W<sub>i</sub>&minus;&Delta;H<sub>i</sub>&plus;U<sub>t,i</sub>&#8239;sin(&beta;<sub>i</sub>)&plus;Q<sub>i</sub>&#8239;sin(&omega;<sub>i</sub>))&#8239;cos(&alpha;<sub>i</sub>)</em>
 </div>
-</a>
+</div>
 <p class="paragraph">
 The values of <em>R</em> and <em>T</em> are now defined completely in terms of the known force property values of DD1 to DD9.
 </p>
-<a id="DD:pressure">
+<div id="DD:pressure">
 <table class="ddefn">
 <tr>
 <th>
@@ -2926,7 +2926,7 @@ Pa
 Equation
 </th>
 <td>
-<a id="">
+<div id="">
 <div class="equation">
 <p class="paragraph">
 <em>p = <table class="matrix">
@@ -2938,7 +2938,7 @@ Equation
 </table></em>
 </p>
 </div>
-</a>
+</div>
 </td>
 </tr>
 <tr>
@@ -2952,8 +2952,8 @@ Description
 </td>
 </tr>
 </table>
-</a>
-<a id="DD:pressure">
+</div>
+<div id="DD:pressure">
 <table class="ddefn">
 <tr>
 <th>
@@ -2980,7 +2980,7 @@ Pa
 Equation
 </th>
 <td>
-<a id="">
+<div id="">
 <div class="equation">
 <p class="paragraph">
 <em>p = <table class="matrix">
@@ -2992,7 +2992,7 @@ Equation
 </table></em>
 </p>
 </div>
-</a>
+</div>
 </td>
 </tr>
 <tr>
@@ -3006,25 +3006,25 @@ Description
 </td>
 </tr>
 </table>
-</a>
+</div>
 <p class="paragraph">
 Using the force-displacement relationship of GD8 to define stiffness matrix <em>K<sub>st</sub></em>, as seen in equation (6).
 </p>
-<a id="">
+<div id="">
 <div class="equation">
 <em>K<sub>st,i</sub> = <table class="matrix">
 <tr><td>K<sub>st,i</sub></td><td>0</td></tr>
 <tr><td>0</td><td>K<sub>bn,i</sub></td></tr>
 </table></em>
 </div>
-</a>
+</div>
 <p class="paragraph">
 For interslice surfaces the stiffness constants and displacements refer to an unrotated coordinate system, <em>&delta;</em> of GD9. The interslice elements are left in their standard coordinate system, and therefore are described by the same equation from GD8. Seen as <em>K<sub>st</sub></em> in DD12. <em>K<sub>st</sub></em> is the shear element in the matrix, and <em>K<sub>sn</sub></em> is the normal element in the matrix, calculated as in DD14.
 </p>
 <p class="paragraph">
 For basal surfaces the stiffness constants and displacements refer to a system rotated for the base angle alpha (DD5). To analyze the effect of force-displacement relationships occurring on both basal and interslice surfaces of an element <em>i</em> they must reference the same coordinate system. The basal stiffness matrix must be rotated counter clockwise to align with the angle of the basal surface. The base stiffness counter clockwise rotation is applied in equation (7) to the new matrix <em>N*</em>.
 </p>
-<a id="">
+<div id="">
 <div class="equation">
 <em>K<sub>st,i</sub> = <table class="matrix">
 <tr><td>cos(&alpha;<sub>i</sub>)</td><td>&minus;sin(&alpha;<sub>i</sub>)</td></tr>
@@ -3034,11 +3034,11 @@ For basal surfaces the stiffness constants and displacements refer to a system r
 <tr><td>K<sub>bt,i</sub>&#8239;sin(&alpha;<sub>i</sub>)</td><td>K<sub>bn,i</sub>&#8239;cos(&alpha;<sub>i</sub>)</td></tr>
 </table></em>
 </div>
-</a>
+</div>
 <p class="paragraph">
 The Hooke's law force displacement relationship of GD8 applied to the base also references a displacement vector <em>&epsilon;</em> of GD9 rotated for the base angle of the slice <em>&alpha;</em> The basal displacement vector. <em>&delta;</em> is rotated clockwise to align with the interslice displacement vector <em>&delta;</em>, applying the definition of <em>&epsilon;</em> in terms of <em>&delta;</em> as seen in GD9. Using this with base stiffness matrix <em>K<sub>bt</sub></em>, a basal force displacement relationship in the same coordinate system as the interslice relationship can be derived as done in equation (8).
 </p>
-<a id="">
+<div id="">
 <div class="equation">
 <em><table class="matrix">
 <tr><td>p<sub>i</sub></td></tr>
@@ -3060,11 +3060,11 @@ The Hooke's law force displacement relationship of GD8 applied to the base also 
 <tr><td>&delta;y<sub>i</sub></td></tr>
 </table></em>
 </div>
-</a>
+</div>
 <p class="paragraph">
 The new effective base stiffness matrix <em>K<sub>bt</sub></em> as derived in equation (7) is defined in equation (9). This is seen as matrix <em>K<sub>bt</sub></em> in GD12. <em>K<sub>bt</sub></em> is the shear element in the matrix, and <em>K<sub>bn</sub></em> is the normal element in the matrix, calculated as in DD14. The notation is simplified by the introduction of the constants <em>K<sub>bA</sub></em> and <em>K<sub>bB</sub></em>, defined in equation (10) and equation (11) respectively.
 </p>
-<a id="">
+<div id="">
 <div class="equation">
 <em>K<sub>bt,i</sub> = <table class="matrix">
 <tr><td>K<sub>bt,i</sub>&#8239;cos(&alpha;<sub>i</sub>)<sup>2</sup>&plus;K<sub>sn,i</sub>&#8239;sin(&alpha;<sub>i</sub>)<sup>2</sup></td><td>(K<sub>bt,i</sub>&minus;K<sub>bn,i</sub>)&#8239;sin(&alpha;<sub>i</sub>)&#8239;cos(&alpha;<sub>i</sub>)</td></tr>
@@ -3074,21 +3074,21 @@ The new effective base stiffness matrix <em>K<sub>bt</sub></em> as derived in eq
 <tr><td>K<sub>bB,i</sub></td><td>K<sub>bA,i</sub></td></tr>
 </table></em>
 </div>
-</a>
-<a id="">
+</div>
+<div id="">
 <div class="equation">
 <em>K<sub>bA,i</sub> = K<sub>bt,i</sub>&#8239;cos(&alpha;<sub>i</sub>)<sup>2</sup>&plus;K<sub>bn,i</sub>&#8239;sin(&alpha;<sub>i</sub>)<sup>2</sup></em>
 </div>
-</a>
-<a id="">
+</div>
+<div id="">
 <div class="equation">
 <em>K<sub>bB,i</sub> = (K<sub>bt,i</sub>&minus;K<sub>bn,i</sub>)&#8239;sin(&alpha;<sub>i</sub>)&#8239;cos(&alpha;<sub>i</sub>)</em>
 </div>
-</a>
+</div>
 <p class="paragraph">
 A force-displacement relationship for an element <em>i</em> can be written in terms of displacements occurring in the unrotated coordinate system <em>&delta;</em> of GD9 using the matrix <em>K<sub>bt</sub></em>, and <em>K<sub>bt</sub></em> as seen in DD12.
 </p>
-<a id="DD:force">
+<div id="DD:force">
 <table class="ddefn">
 <tr>
 <th>
@@ -3115,13 +3115,13 @@ N
 Equation
 </th>
 <td>
-<a id="">
+<div id="">
 <div class="equation">
 <p class="paragraph">
 <em>F = &minus;&#8467;<sub>s,i&minus;1</sub>&#8239;K<sub>sn,i&minus;1</sub>&#8239;&delta;<sub>i&minus;1</sub>&plus;(&#8467;<sub>s,i&minus;1</sub>&#8239;K<sub>sn,i&minus;1</sub>&plus;&#8467;<sub>b,i</sub>&#8239;K<sub>bn,i</sub>&plus;&#8467;<sub>s,i</sub>&#8239;K<sub>sn,i</sub>)&#8239;&delta;<sub>i</sub>&minus;&#8467;<sub>s,i</sub>&#8239;K<sub>sn,i</sub>&#8239;&delta;<sub>i&plus;1</sub></em>
 </p>
 </div>
-</a>
+</div>
 </td>
 </tr>
 <tr>
@@ -3135,8 +3135,8 @@ Description
 </td>
 </tr>
 </table>
-</a>
-<a id="DD:K.bt,i">
+</div>
+<div id="DD:K.bt,i">
 <table class="ddefn">
 <tr>
 <th>
@@ -3163,7 +3163,7 @@ Pa/m
 Equation
 </th>
 <td>
-<a id="">
+<div id="">
 <div class="equation">
 <p class="paragraph">
 <em>K<sub>bt</sub> = <div class="fraction">
@@ -3190,7 +3190,7 @@ c&prime;<sub>i</sub>&minus;&sigma;&#8239;tan(&phiv;&prime;<sub>i</sub>)
 </div></em>
 </p>
 </div>
-</a>
+</div>
 </td>
 </tr>
 <tr>
@@ -3204,8 +3204,8 @@ Description
 </td>
 </tr>
 </table>
-</a>
-<a id="DD:K.bn,i">
+</div>
+<div id="DD:K.bn,i">
 <table class="ddefn">
 <tr>
 <th>
@@ -3232,7 +3232,7 @@ Pa/m
 Equation
 </th>
 <td>
-<a id="">
+<div id="">
 <div class="equation">
 <p class="paragraph">
 <em>K<sub>bn</sub> = <span class="casebr">
@@ -3273,7 +3273,7 @@ E&#8239;(1&minus;&nu;)
 </div></em>
 </p>
 </div>
-</a>
+</div>
 </td>
 </tr>
 <tr>
@@ -3287,8 +3287,8 @@ Description
 </td>
 </tr>
 </table>
-</a>
-<a id="DD:fixme1">
+</div>
+<div id="DD:fixme1">
 <table class="ddefn">
 <tr>
 <th>
@@ -3315,13 +3315,13 @@ Unitless
 Equation
 </th>
 <td>
-<a id="">
+<div id="">
 <div class="equation">
 <p class="paragraph">
 <em>SpencerFixme1Please = E<sub>i</sub>&plus;E<sub>i&minus;1</sub></em>
 </p>
 </div>
-</a>
+</div>
 </td>
 </tr>
 <tr>
@@ -3335,8 +3335,8 @@ Description
 </td>
 </tr>
 </table>
-</a>
-<a id="DD:fixme2">
+</div>
+<div id="DD:fixme2">
 <table class="ddefn">
 <tr>
 <th>
@@ -3363,13 +3363,13 @@ Unitless
 Equation
 </th>
 <td>
-<a id="">
+<div id="">
 <div class="equation">
 <p class="paragraph">
 <em>SpencerFixme2Please = H<sub>i</sub>&plus;H<sub>i&minus;1</sub></em>
 </p>
 </div>
-</a>
+</div>
 </td>
 </tr>
 <tr>
@@ -3383,10 +3383,10 @@ Description
 </td>
 </tr>
 </table>
-</a>
 </div>
-</a>
-<a id="Sec:IMs">
+</div>
+</div>
+<div id="Sec:IMs">
 <div class="subsubsection">
 <h3>
 Instance Models
@@ -3400,7 +3400,7 @@ The Morgenstern Price method is a vertical slice, limit equilibrium slope stabil
 <p class="paragraph">
 The values of the interslice normal force <em>E</em> the interslice normal/shear force ratio <em>&lambda;</em>, and the Factor of Safety (<em>FS</em>), are unknown. Equations for the unknowns are written in terms of only the values in DD1 to DD9, the values of <em>R</em>, and <em>T</em> in DD10 and DD11, and each other. The relationships between the unknowns are non linear, and therefore explicit equations cannot be derived and an iterative solutions method is required.
 </p>
-<a id="T:fctSfty">
+<div id="T:fctSfty">
 <table class="tdefn">
 <tr>
 <th>
@@ -3417,7 +3417,7 @@ Factor of Safety
 Equation
 </th>
 <td>
-<a id="">
+<div id="">
 <div class="equation">
 <p class="paragraph">
 <em>FS = <div class="fraction">
@@ -3444,7 +3444,7 @@ Equation
 </div></em>
 </p>
 </div>
-</a>
+</div>
 </td>
 </tr>
 <tr>
@@ -3458,11 +3458,11 @@ Equation for the Factor of Safety is the ratio between resistive and mobile shea
 </td>
 </tr>
 </table>
-</a>
+</div>
 <p class="paragraph">
 Using equation (21) from IM3, rearranging, and applying the boundary condition that <em>E<sub>0</sub></em> and <em>E<sub>n</sub></em> are equal to <em>0</em>, an equation for the factor of safety is found as equation (12), also seen in IM1.
 </p>
-<a id="">
+<div id="">
 <div class="equation">
 <em>FS = <div class="fraction">
 <span class="fup">
@@ -3487,11 +3487,11 @@ Using equation (21) from IM3, rearranging, and applying the boundary condition t
 </span>
 </div></em>
 </div>
-</a>
+</div>
 <p class="paragraph">
 The constants <em>&Psi;</em> and <em>&Phi;</em> described in equation (20) and equation (19) are functions of the unknowns: the interslice normal/shear force ratio <em>&lambda;</em> (IM2) and the factor of safety <em>FS</em> (IM1).
 </p>
-<a id="T:nrmShrFor">
+<div id="T:nrmShrFor">
 <table class="tdefn">
 <tr>
 <th>
@@ -3508,7 +3508,7 @@ Normal/shear Force Ratio
 Equation
 </th>
 <td>
-<a id="">
+<div id="">
 <div class="equation">
 <p class="paragraph">
 <em>C1<sub>i</sub> = <span class="casebr">
@@ -3559,7 +3559,7 @@ i = 1
 </div></em>
 </p>
 </div>
-</a>
+</div>
 </td>
 </tr>
 <tr>
@@ -3573,11 +3573,11 @@ Description
 </td>
 </tr>
 </table>
-</a>
+</div>
 <p class="paragraph">
 Taking the last static equation of T2 with the moment equilibrium of GD6 about the midpoint of the base and the assumption of GD5 results in equation (13).
 </p>
-<a id="">
+<div id="">
 <div class="equation">
 <em>0 = &minus;E<sub>i</sub>&#8239;(z<sub>i</sub>&minus;<div class="fraction">
 <span class="fup">
@@ -3623,11 +3623,11 @@ K<sub>c</sub>&#8239;W<sub>i</sub>&#8239;h<sub>i</sub>
 </span>
 </div>&minus;U<sub>t,i</sub>&#8239;sin(&beta;<sub>i</sub>)&#8239;h<sub>i</sub>&minus;Q<sub>i</sub>&#8239;sin(&omega;<sub>i</sub>)&#8239;h<sub>i</sub></em>
 </div>
-</a>
+</div>
 <p class="paragraph">
 The equation in terms of <em>&lambda;</em> leads to equation (14).
 </p>
-<a id="">
+<div id="">
 <div class="equation">
 <em>&lambda; = <div class="fraction">
 <span class="fup">
@@ -3680,11 +3680,11 @@ b<sub>i</sub>
 </span>
 </div></em>
 </div>
-</a>
+</div>
 <p class="paragraph">
 Taking a summation of each slice, and applying the boundary condition that <em>E<sub>0</sub></em> and <em>E<sub>n</sub></em> are equal to <em>0</em>, a general equation for the constant <em>&lambda;</em> is developed in equation (15), also found in IM2.
 </p>
-<a id="">
+<div id="">
 <div class="equation">
 <em>&lambda;<sub>i</sub> = <div class="fraction">
 <span class="fup">
@@ -3695,11 +3695,11 @@ Taking a summation of each slice, and applying the boundary condition that <em>E
 </span>
 </div></em>
 </div>
-</a>
+</div>
 <p class="paragraph">
 equation (15) for <em>&lambda;</em>, is a function of the unknown interslice normal force <em>E</em> IM3.
 </p>
-<a id="T:intsliceFs">
+<div id="T:intsliceFs">
 <table class="tdefn">
 <tr>
 <th>
@@ -3716,7 +3716,7 @@ Interslice Forces
 Equation
 </th>
 <td>
-<a id="">
+<div id="">
 <div class="equation">
 <p class="paragraph">
 <em>E<sub>i</sub> = <span class="casebr">
@@ -3755,7 +3755,7 @@ i = 0 &or; i = n
 </div></em>
 </p>
 </div>
-</a>
+</div>
 </td>
 </tr>
 <tr>
@@ -3769,19 +3769,19 @@ The value of the interslice normal force <em>E</em> at interface <em>i</em> The 
 </td>
 </tr>
 </table>
-</a>
+</div>
 <p class="paragraph">
 Taking the normal force equilibrium of GD1 with the effective stress definition from T4 that <em>N<sub>i</sub> = N&prime;<sub>i</sub>&minus;U<sub>b,i</sub></em>, and the assumption of GD5 the equilibrium equation can be rewritten as equation (16).
 </p>
-<a id="">
+<div id="">
 <div class="equation">
 <em>N&prime;<sub>i</sub> = (W<sub>i</sub>&minus;&lambda;&#8239;f<sub>i&minus;1</sub>&#8239;E<sub>i&minus;1</sub>&plus;&lambda;&#8239;f<sub>i</sub>&#8239;E<sub>i</sub>&plus;U<sub>t,i</sub>&#8239;cos(&beta;<sub>i</sub>)&plus;Q<sub>i</sub>&#8239;cos(&omega;<sub>i</sub>))&#8239;cos(&alpha;<sub>i</sub>)&plus;(&minus;K<sub>c</sub>&#8239;W<sub>i</sub>&minus;E<sub>i</sub>&plus;E<sub>i&minus;1</sub>&minus;H<sub>i</sub>&plus;H<sub>i&minus;1</sub>&plus;U<sub>t,i</sub>&#8239;sin(&beta;<sub>i</sub>)&plus;Q<sub>i</sub>&#8239;sin(&omega;<sub>i</sub>))&#8239;sin(&alpha;<sub>i</sub>)&minus;U<sub>b,i</sub></em>
 </div>
-</a>
+</div>
 <p class="paragraph">
 Taking the base shear force equilibrium of GD2 with the definition of mobilized shear force from GD4 and the assumption of GD5, the equilibrium equation can be rewritten as equation (17).
 </p>
-<a id="">
+<div id="">
 <div class="equation">
 <em><div class="fraction">
 <span class="fup">
@@ -3792,29 +3792,29 @@ FS
 </span>
 </div> = (W<sub>i</sub>&minus;&lambda;&#8239;f<sub>i&minus;1</sub>&#8239;E<sub>i&minus;1</sub>&plus;&lambda;&#8239;f<sub>i</sub>&#8239;E<sub>i</sub>&plus;U<sub>t,i</sub>&#8239;cos(&beta;<sub>i</sub>)&plus;Q<sub>i</sub>&#8239;cos(&omega;<sub>i</sub>))&#8239;sin(&alpha;<sub>i</sub>)&plus;(&minus;K<sub>c</sub>&#8239;W<sub>i</sub>&minus;E<sub>i</sub>&plus;E<sub>i&minus;1</sub>&minus;H<sub>i</sub>&plus;H<sub>i&minus;1</sub>&plus;U<sub>t,i</sub>&#8239;sin(&beta;<sub>i</sub>)&plus;Q<sub>i</sub>&#8239;sin(&omega;<sub>i</sub>))&#8239;cos(&alpha;<sub>i</sub>)</em>
 </div>
-</a>
+</div>
 <p class="paragraph">
 Substituting the equation for <em>N&prime;</em> from equation (16) into equation (17) and rearranging results in equation (18).
 </p>
-<a id="">
+<div id="">
 <div class="equation">
 <em>E<sub>i</sub>&#8239;((&lambda;&#8239;f<sub>i</sub>&#8239;cos(&alpha;<sub>i</sub>)&minus;sin(&alpha;<sub>i</sub>))&#8239;tan(&phiv;&prime;<sub>i</sub>)&minus;(&lambda;&#8239;f<sub>i</sub>&#8239;sin(&alpha;<sub>i</sub>)&minus;cos(&alpha;<sub>i</sub>))&#8239;FS) = E<sub>i&minus;1</sub>&#8239;((&lambda;&#8239;f<sub>i&minus;1</sub>&#8239;cos(&alpha;<sub>i</sub>)&minus;sin(&alpha;<sub>i</sub>))&#8239;tan(&phiv;&prime;<sub>i</sub>)&minus;(&lambda;&#8239;f<sub>i&minus;1</sub>&#8239;sin(&alpha;<sub>i</sub>)&minus;cos(&alpha;<sub>i</sub>))&#8239;FS)&plus;FS&#8239;T<sub>i</sub>&minus;R<sub>i</sub></em>
 </div>
-</a>
+</div>
 <p class="paragraph">
 Where <em>R</em> and <em>T</em> are the resistive and mobile shear of the slice, without the influence of interslice forces <em>E</em> and <em>X</em>, as defined in DD10 and DD11 Making use of the constants, and with full equations found below in equation (19) and equation (20) respectively, then equation (18) can be simplified to equation (21), also seen in IM3.
 </p>
-<a id="">
+<div id="">
 <div class="equation">
 <em>&Phi;<sub>i</sub> = (&lambda;&#8239;f<sub>i</sub>&#8239;cos(&alpha;<sub>i</sub>)&minus;sin(&alpha;<sub>i</sub>))&#8239;tan(&phiv;&prime;<sub>i</sub>)&minus;(&lambda;&#8239;f<sub>i</sub>&#8239;sin(&alpha;<sub>i</sub>)&minus;cos(&alpha;<sub>i</sub>))&#8239;FS</em>
 </div>
-</a>
-<a id="">
+</div>
+<div id="">
 <div class="equation">
 <em>&Psi;<sub>i</sub> = (&lambda;&#8239;f<sub>i</sub>&#8239;cos(&alpha;<sub>i&plus;1</sub>)&minus;sin(&alpha;<sub>i&plus;1</sub>))&#8239;tan(&phiv;&prime;<sub>i</sub>)&minus;(&lambda;&#8239;f<sub>i</sub>&#8239;sin(&alpha;<sub>i&plus;1</sub>)&minus;cos(&alpha;<sub>i&plus;1</sub>))&#8239;FS</em>
 </div>
-</a>
-<a id="">
+</div>
+<div id="">
 <div class="equation">
 <em>E<sub>i</sub> = <div class="fraction">
 <span class="fup">
@@ -3825,11 +3825,11 @@ Where <em>R</em> and <em>T</em> are the resistive and mobile shear of the slice,
 </span>
 </div></em>
 </div>
-</a>
+</div>
 <p class="paragraph">
 The constants <em>&Psi;</em> and <em>&Phi;</em> described in equation (20) and equation (19) are functions of the unknowns: the interslice normal/shear force ratio <em>&lambda;</em> (IM2) and the factor of safety <em>FS</em> (IM1).
 </p>
-<a id="T:forDisEqlb">
+<div id="T:forDisEqlb">
 <table class="tdefn">
 <tr>
 <th>
@@ -3846,13 +3846,13 @@ Force Displacement Equilibrium
 Equation
 </th>
 <td>
-<a id="">
+<div id="">
 <div class="equation">
 <p class="paragraph">
 <em>&minus;&Delta;H<sub>i</sub>&minus;K<sub>c</sub>&#8239;W<sub>i</sub>&minus;U<sub>b,i</sub>&#8239;sin(&alpha;<sub>i</sub>)&plus;U<sub>t,i</sub>&#8239;sin(&beta;<sub>i</sub>)&plus;Q<sub>i</sub>&#8239;sin(&omega;<sub>i</sub>) = &delta;x<sub>i&minus;1</sub>&#8239;&minus;&#8467;<sub>s,i&minus;1</sub>&#8239;K<sub>sn,i&minus;1</sub>&plus;&delta;x<sub>i</sub>&#8239;(&minus;&#8467;<sub>s,i&minus;1</sub>&#8239;K<sub>sn,i&minus;1</sub>&plus;&#8467;<sub>s,i</sub>&#8239;K<sub>sn,i</sub>&plus;&#8467;<sub>b,i</sub>&#8239;K<sub>bA,i</sub>)&plus;&delta;x<sub>i&plus;1</sub>&#8239;&minus;&#8467;<sub>s,i</sub>&#8239;K<sub>sn,i</sub>&plus;&delta;y<sub>i</sub>&#8239;&minus;&#8467;<sub>b,i</sub>&#8239;K<sub>bB,i</sub> = &minus;W<sub>i</sub>&minus;U<sub>b,i</sub>&#8239;cos(&alpha;<sub>i</sub>)&plus;U<sub>t,i</sub>&#8239;cos(&beta;<sub>i</sub>)&plus;Q<sub>i</sub>&#8239;cos(&omega;<sub>i</sub>) = &delta;y<sub>i&minus;1</sub>&#8239;&minus;&#8467;<sub>s,i&minus;1</sub>&#8239;K<sub>st,i&minus;1</sub>&plus;&delta;y<sub>i</sub>&#8239;(&minus;&#8467;<sub>s,i&minus;1</sub>&#8239;K<sub>st,i&minus;1</sub>&plus;&#8467;<sub>s,i</sub>&#8239;K<sub>sn,i</sub>&plus;&#8467;<sub>b,i</sub>&#8239;K<sub>bA,i</sub>)&plus;&delta;y<sub>i&plus;1</sub>&#8239;&minus;&#8467;<sub>s,i</sub>&#8239;K<sub>st,i</sub>&plus;&delta;x<sub>i</sub>&#8239;&minus;&#8467;<sub>b,i</sub>&#8239;K<sub>bB,i</sub></em>
 </p>
 </div>
-</a>
+</div>
 </td>
 </tr>
 <tr>
@@ -3866,19 +3866,19 @@ There is one set of force displacement equilibrium equations in the x and y dire
 </td>
 </tr>
 </table>
-</a>
+</div>
 <p class="paragraph">
 Using the net force-displacement equilibrium equation of a slice from DD13 with the definitions of the stiffness matrices from DD12 and the force definitions from GD7 a broken down force displacement equilibrium equation can be derived. equation (22) gives the broken down equation in the <em>x</em> direction, and equation (23) gives the broken down equation in the <em>y</em> direction.
 </p>
-<a id="">
+<div id="">
 <div class="equation">
 <em>&minus;&Delta;H<sub>i</sub>&minus;K<sub>c</sub>&#8239;W<sub>i</sub>&minus;U<sub>b,i</sub>&#8239;sin(&alpha;<sub>i</sub>)&plus;U<sub>t,i</sub>&#8239;sin(&beta;<sub>i</sub>)&plus;Q<sub>i</sub>&#8239;sin(&omega;<sub>i</sub>) = &delta;x<sub>i&minus;1</sub>&#8239;&minus;&#8467;<sub>s,i&minus;1</sub>&#8239;K<sub>sn,i&minus;1</sub>&plus;&delta;x<sub>i</sub>&#8239;(&minus;&#8467;<sub>s,i&minus;1</sub>&#8239;K<sub>sn,i&minus;1</sub>&plus;&#8467;<sub>s,i</sub>&#8239;K<sub>sn,i</sub>&plus;&#8467;<sub>b,i</sub>&#8239;K<sub>bA,i</sub>)&plus;&delta;x<sub>i&plus;1</sub>&#8239;&minus;&#8467;<sub>s,i</sub>&#8239;K<sub>sn,i</sub>&plus;&delta;y<sub>i</sub>&#8239;&minus;&#8467;<sub>b,i</sub>&#8239;K<sub>bB,i</sub> = &minus;W<sub>i</sub>&minus;U<sub>b,i</sub>&#8239;cos(&alpha;<sub>i</sub>)&plus;U<sub>t,i</sub>&#8239;cos(&beta;<sub>i</sub>)&plus;Q<sub>i</sub>&#8239;cos(&omega;<sub>i</sub>) = &delta;y<sub>i&minus;1</sub>&#8239;&minus;&#8467;<sub>s,i&minus;1</sub>&#8239;K<sub>st,i&minus;1</sub>&plus;&delta;y<sub>i</sub>&#8239;(&minus;&#8467;<sub>s,i&minus;1</sub>&#8239;K<sub>st,i&minus;1</sub>&plus;&#8467;<sub>s,i</sub>&#8239;K<sub>sn,i</sub>&plus;&#8467;<sub>b,i</sub>&#8239;K<sub>bA,i</sub>)&plus;&delta;y<sub>i&plus;1</sub>&#8239;&minus;&#8467;<sub>s,i</sub>&#8239;K<sub>st,i</sub>&plus;&delta;x<sub>i</sub>&#8239;&minus;&#8467;<sub>b,i</sub>&#8239;K<sub>bB,i</sub></em>
 </div>
-</a>
+</div>
 <p class="paragraph">
 Using the known input assumption of <a href=#A:Geo-Slope-Mat-Props-of-Soil-Inputs>Geo-Slope-Mat-Props-of-Soil-Inputs</a>, the force variable definitions of DD1 to DD8 on the left side of the equations can be solved for. The only unknown in the variables to solve for the stiffness values from DD14 is the displacements. Therefore taking the equation from each slice a set of <em>2&#8239;n</em> equations, with <em>2&#8239;n</em> unknown displacements in the <em>x</em> and <em>y</em> directions of each slice can be derived. Solutions for the displacements of each slice can then be found. The use of displacement in the definition of the stiffness values makes the equation implicit, which means an iterative solution method, with an initial guess for the displacements in the stiffness values is required.
 </p>
-<a id="T:rfemFoS">
+<div id="T:rfemFoS">
 <table class="tdefn">
 <tr>
 <th>
@@ -3895,7 +3895,7 @@ RFEM Factor of Safety
 Equation
 </th>
 <td>
-<a id="">
+<div id="">
 <div class="equation">
 <p class="paragraph">
 <em>FS<sub>Loc,i,i</sub> = <div class="fraction">
@@ -3915,7 +3915,7 @@ K<sub>bt,i</sub>&#8239;&delta;u<sub>i</sub>
 </div></em>
 </p>
 </div>
-</a>
+</div>
 </td>
 </tr>
 <tr>
@@ -3929,40 +3929,40 @@ Description
 </td>
 </tr>
 </table>
-</a>
+</div>
 <p class="paragraph">
 RFEM analysis can also be used to calculate the factor of safety for the slope. For a slice element <em>i</em> the displacements <em>&delta;x</em> and <em>&delta;y</em>, are solved from the system of equations in IM4. The definition of <em>&epsilon;</em> as the rotation of the displacement vector <em>&delta;</em> is seen in GD9. This is used to find the displacements of the slice parallel to the base of the slice <em>&delta;u</em> in equation (24) and normal to the base of the slice <em>&delta;v</em> in equation (25).
 </p>
-<a id="">
+<div id="">
 <div class="equation">
 <em>&delta;u<sub>i</sub> = cos(&alpha;<sub>i</sub>)&#8239;&delta;x<sub>i</sub>&plus;sin(&alpha;<sub>i</sub>)&#8239;&delta;y<sub>i</sub></em>
 </div>
-</a>
-<a id="">
+</div>
+<div id="">
 <div class="equation">
 <em>&delta;v<sub>i</sub> = &minus;sin(&alpha;<sub>i</sub>)&#8239;&delta;x<sub>i</sub>&plus;sin(&alpha;<sub>i</sub>)&#8239;&delta;y<sub>i</sub></em>
 </div>
-</a>
+</div>
 <p class="paragraph">
 With the definition of normal stiffness from DD14 to find the normal stiffness of the base <em>K<sub>bn</sub></em> and the now known base displacement perpendicular to the surface <em>&delta;v</em> from equation (25) the normal base stress can be calculated from the force-displacement relationship of T5. Stress <em>&sigma;</em> is used in place of force <em>F</em> as the stiffness hasn't been normalized for the length of the base. Results in equation (26).
 </p>
-<a id="">
+<div id="">
 <div class="equation">
 <em>&sigma;<sub>i</sub> = K<sub>bn,i</sub>&#8239;&delta;v<sub>i</sub></em>
 </div>
-</a>
+</div>
 <p class="paragraph">
 The resistive shear to calculate the factor of safety <em>FS</em> is found from the Mohr Coulomb resistive strength of soil in T3 Using the normal stress <em>&sigma;</em> from equation (26) as the stress, the resistive shear of the slice can be calculated from equation (27).
 </p>
-<a id="">
+<div id="">
 <div class="equation">
 <em>s<sub>i</sub> = c&prime;<sub>i</sub>&minus;&sigma;<sub>i</sub>&#8239;tan(&phiv;&prime;<sub>i</sub>)</em>
 </div>
-</a>
+</div>
 <p class="paragraph">
 Previously the value of the shear stiffness <em>K<sub>bt</sub></em> as seen in equation (28) was unsolvable because the normal stress <em>&sigma;</em> was unknown. With the definition of <em>&sigma;</em> from equation (26) and the definition of displacement shear to the base <em>&delta;u</em> from equation (25), the value of <em>K<sub>bt</sub></em> becomes solvable.
 </p>
-<a id="">
+<div id="">
 <div class="equation">
 <em>K<sub>bt,i</sub> = <div class="fraction">
 <span class="fup">
@@ -3987,19 +3987,19 @@ c&prime;<sub>i</sub>&minus;&sigma;<sub>i</sub>&#8239;tan(&phiv;&prime;<sub>i</su
 </span>
 </div></em>
 </div>
-</a>
+</div>
 <p class="paragraph">
 With shear stiffness <em>K<sub>bt</sub></em> calculated in equation (28) and shear displacement <em>&delta;u</em> calculated in equation (24) values now known the resistive shear stress acting on the base of a slice <em>&tau;</em> can be calculated using T5, as done in equation (29). Again, stress <em>&tau;</em> is used in place of force <em>F</em> as the stiffness has not been normalized for the length of the base.
 </p>
-<a id="">
+<div id="">
 <div class="equation">
 <em>&tau;<sub>i</sub> = K<sub>bt,i</sub>&#8239;&delta;u<sub>i</sub></em>
 </div>
-</a>
+</div>
 <p class="paragraph">
 The resistive shear stress acting on the base of a slice <em>&tau;</em> acts as the mobile shear acting on the base. Using the definition Factor of Safety equation from T1, with the definitions of resistive shear strength of a slice <em>s</em> from equation (27) and resistive shear stress <em>&tau;</em> from equation (29) the local factor of safety <em>FS<sub>Loc,i</sub></em> can be found from as seen in equation (30) and IM5.
 </p>
-<a id="">
+<div id="">
 <div class="equation">
 <em>FS<sub>Loc,i</sub> = <div class="fraction">
 <span class="fup">
@@ -4017,11 +4017,11 @@ K<sub>bt,i</sub>&#8239;&delta;u<sub>i</sub>
 </span>
 </div></em>
 </div>
-</a>
+</div>
 <p class="paragraph">
 The global Factor of Safety is then the ratio of the summation of the resistive and mobile shears for each slice, with a weighting for the length of the slice's base. Shown in equation (31) and IM5.
 </p>
-<a id="">
+<div id="">
 <div class="equation">
 <em>FS = <div class="fraction">
 <span class="fup">
@@ -4039,8 +4039,8 @@ The global Factor of Safety is then the ratio of the summation of the resistive 
 </span>
 </div></em>
 </div>
-</a>
-<a id="T:crtSlpId">
+</div>
+<div id="T:crtSlpId">
 <table class="tdefn">
 <tr>
 <th>
@@ -4057,13 +4057,13 @@ Critical Slip Identification
 Equation
 </th>
 <td>
-<a id="">
+<div id="">
 <div class="equation">
 <p class="paragraph">
 <em>FS<sub>min</sub> = &Upsilon;({x<sub>cs</sub>,y<sub>cs</sub>})</em>
 </p>
 </div>
-</a>
+</div>
 </td>
 </tr>
 <tr>
@@ -4077,10 +4077,10 @@ Given the necessary slope inputs, a minimization algorithm or function <em>&Upsi
 </td>
 </tr>
 </table>
-</a>
 </div>
-</a>
-<a id="Sec:DataConstraints">
+</div>
+</div>
+<div id="Sec:DataConstraints">
 <div class="subsubsection">
 <h3>
 Data Constraints
@@ -4088,7 +4088,7 @@ Data Constraints
 <p class="paragraph">
 <a href=#Table:InDataConstraints>Table:InDataConstraints</a>, and <a href=#Table:OutDataConstraints>Table:OutDataConstraints</a> shows the data constraints on the input and output variables, respectively. The column for physical constraints gives the physical limitations on the range of values that can be taken by the variable. The uncertainty column provides an estimate of the confidence with which the physical quantities can be measured. This information would be part of the input if one were performing an uncertainty quantification exercise. The constraints are conservative, to give the user of the model the flexibility to experiment with unusual situations. The column of typical values is intended to provide a feel for a common scenario.
 </p>
-<a id="Table:InDataConstraints">
+<div id="Table:InDataConstraints">
 <table class="table">
 <tr>
 <th>
@@ -4248,8 +4248,8 @@ None
 <p class="caption">
 Input Data Constraints
 </p>
-</a>
-<a id="Table:OutDataConstraints">
+</div>
+<div id="Table:OutDataConstraints">
 <table class="table">
 <tr>
 <th>
@@ -4295,14 +4295,14 @@ None
 <p class="caption">
 Output Data Constraints
 </p>
-</a>
 </div>
-</a>
 </div>
-</a>
 </div>
-</a>
-<a id="Sec:Requirements">
+</div>
+</div>
+</div>
+</div>
+<div id="Sec:Requirements">
 <div class="section">
 <h1>
 Requirements
@@ -4310,7 +4310,7 @@ Requirements
 <p class="paragraph">
 This section provides the functional requirements, the business tasks that the software is expected to complete, and the non-functional requirements, the qualities that the software is expected to exhibit.
 </p>
-<a id="Sec:FRs">
+<div id="Sec:FRs">
 <div class="subsection">
 <h2>
 Functional Requirements
@@ -4350,7 +4350,7 @@ R10: Calculate the factor of safety of the critical slip surface using the Morge
 R11: Display the critical slip surface and the slice element displacements graphically. Give the values of the factors of safety calculated by the Morgenstern Price method.
 </p>
 </div>
-<a id="Table:inDataTable">
+<div id="Table:inDataTable">
 <table class="table">
 <tr>
 <th>
@@ -4488,10 +4488,10 @@ constant
 <p class="caption">
 Required Inputs
 </p>
-</a>
 </div>
-</a>
-<a id="Sec:NFRs">
+</div>
+</div>
+<div id="Sec:NFRs">
 <div class="subsection">
 <h2>
 Non-Functional Requirements
@@ -4500,17 +4500,17 @@ Non-Functional Requirements
 SSA is intended to be an educational tool, so accuracy and performance are not priorities. Rather, the non-functional requirement priorities are correctness, understandability, reusability, and maintainability.
 </p>
 </div>
-</a>
 </div>
-</a>
-<a id="Sec:LCs">
+</div>
+</div>
+<div id="Sec:LCs">
 <div class="section">
 <h1>
 Likely Changes
 </h1>
 </div>
-</a>
-<a id="Sec:AuxConstants">
+</div>
+<div id="Sec:AuxConstants">
 <div class="section">
 <h1>
 Values of Auxiliary Constants
@@ -4519,48 +4519,48 @@ Values of Auxiliary Constants
 There are no auxiliary constants.
 </p>
 </div>
-</a>
-<a id="Sec:References">
+</div>
+<div id="Sec:References">
 <div class="section">
 <h1>
 References
 </h1>
-<a id="chen2005">
+<div id="chen2005">
 <ul>
 [1]: Qian, Q. H., Zhu, D. Y., Lee, C. F., and Chen, G. R. "A concise algorithm for computing the factor of safety using the morgenstern price method." <em>Canadian Geotechnical Journal</em>, vol. 42, no. 1, February, 2005. pp. 272&ndash;278. Print.
 </ul>
-</a>
-<a id="fredlund1977">
+</div>
+<div id="fredlund1977">
 <ul>
 [2]: Fredlund, D. G. and Krahn, J. "Comparison of slope stability methods of analysis." <em>Canadian Geotechnical Journal</em>, vol. 14, no. 3, April, 1977. pp. 429&ndash;439. Print.
 </ul>
-</a>
-<a id="koothoor2013">
+</div>
+<div id="koothoor2013">
 <ul>
 [3]: Koothoor, Nirmitha. <em>A document drive approach to certifying scientific computing software</em>. McMaster University, Hamilton, ON, Canada: 2013. Print.
 </ul>
-</a>
-<a id="li2010">
+</div>
+<div id="li2010">
 <ul>
 [4]: Yu-Chao, Li, Yun-Min, Chen, Zhan, Tony L. T., Sao-Sheng, Ling, and Cleall, Peter John. "An efficient approach for locating the critical slip surface in slope stability analyses using a real-coded genetic algorithm." <em>Canadian Geotechnical Journal</em>, vol. 47, no. 7, June, 2010. pp. 806&ndash;820. Print.
 </ul>
-</a>
-<a id="parnas1986">
+</div>
+<div id="parnas1986">
 <ul>
 [5]: Parnas, David L. and Clements, P. C. "A rational design process: How and why to fake it." <em>IEEE Transactions on Software Engineering</em>, vol. 12, no. 2, Washington, USA: February, 1986. pp. 251&ndash;257. Print.
 </ul>
-</a>
-<a id="smithLai2005">
+</div>
+<div id="smithLai2005">
 <ul>
 [6]: Smith, W. Spencer and Lai, Lei. "A new requirements template for scientific computing." <em>Proceedings of the First International Workshop on Situational Requirements Engineering Processes - Methods, Techniques and Tools to Support Situation-Specific Requirements Engineering Processes, SREP'05</em>. Edited by PJ Agerfalk, N. Kraiem, and J. Ralyte, Paris, France: 2005. pp. 107&ndash;121. In conjunction with 13th IEEE International Requirements Engineering Conference,
 </ul>
-</a>
-<a id="stolle2008">
+</div>
+<div id="stolle2008">
 <ul>
 [7]: Stolle, Dieter and Guo, Peijun. "Limit equilibrum slope stability analysis using rigid finite elements." <em>Canadian Geotechnical Journal</em>, vol. 45, no. 5, May, 2008. pp. 653&ndash;662. Print.
 </ul>
-</a>
 </div>
-</a>
+</div>
+</div>
 </body>
 </html>

--- a/code/stable/swhs/SWHS_SRS.html
+++ b/code/stable/swhs/SWHS_SRS.html
@@ -19,7 +19,7 @@ Software Requirements Specification for Solar Water Heating Systems Incorporatin
 Thulasi Jegatheesan, Brooks MacLachlan, and W. Spencer Smith
 </h2>
 </div>
-<a id="Sec:RefMat">
+<div id="Sec:RefMat">
 <div class="section">
 <h1>
 Reference Material
@@ -27,7 +27,7 @@ Reference Material
 <p class="paragraph">
 This section records information for easy reference.
 </p>
-<a id="Sec:ToU">
+<div id="Sec:ToU">
 <div class="subsection">
 <h2>
 Table of Units
@@ -35,7 +35,7 @@ Table of Units
 <p class="paragraph">
 The unit system used throughout is SI (Système International d'Unités). In addition to the basic units, several derived units are also used. For each unit, the table lists the symbol, a description and the SI name.
 </p>
-<a id="Table:ToU">
+<div id="Table:ToU">
 <table class="table">
 <tr>
 <th>
@@ -94,10 +94,10 @@ power (watt)
 </td>
 </tr>
 </table>
-</a>
 </div>
-</a>
-<a id="Sec:ToS">
+</div>
+</div>
+<div id="Sec:ToS">
 <div class="subsection">
 <h2>
 Table of Symbols
@@ -105,7 +105,7 @@ Table of Symbols
 <p class="paragraph">
 The table that follows summarizes the symbols used in this document along with their units. The choice of symbols was made to be consistent with the heat transfer literature and with existing documentation for solar water heating systems. The symbols are listed in alphabetical order.
 </p>
-<a id="Table:ToS">
+<div id="Table:ToS">
 <table class="table">
 <tr>
 <th>
@@ -801,15 +801,15 @@ Melt fraction
 </td>
 </tr>
 </table>
-</a>
 </div>
-</a>
-<a id="Sec:TAbbAcc">
+</div>
+</div>
+<div id="Sec:TAbbAcc">
 <div class="subsection">
 <h2>
 Abbreviations and Acronyms
 </h2>
-<a id="Table:TAbbAcc">
+<div id="Table:TAbbAcc">
 <table class="table">
 <tr>
 <th>
@@ -940,12 +940,12 @@ Typical Uncertainty
 </td>
 </tr>
 </table>
-</a>
 </div>
-</a>
 </div>
-</a>
-<a id="Sec:Intro">
+</div>
+</div>
+</div>
+<div id="Sec:Intro">
 <div class="section">
 <h1>
 Introduction
@@ -956,7 +956,7 @@ Due to increasing cost, diminishing availability, and negative environmental imp
 <p class="paragraph">
 The following section provides an overview of the Software Requirements Specification (SRS) for solar water heating systems incorporating PCM. The developed program will be referred to as Solar Water Heating System (SWHS). This section explains the purpose of this document, the scope of the system, the organization of the document, and the characteristics of the intended reader.
 </p>
-<a id="Sec:DocPurpose">
+<div id="Sec:DocPurpose">
 <div class="subsection">
 <h2>
 Purpose of Document
@@ -968,8 +968,8 @@ The main purpose of this document is to describe the modelling of solar water he
 This document will be used as a starting point for subsequent development phases, including writing the design specification and the software verification and validation plan. The design document will show how the requirements are to be realized, including decisions on the numerical algorithms and programming environment. The verification and validation plan will show the steps that will be used to increase confidence in the software documentation and the implementation. Although the SRS fits in a series of documents that follow the so-called waterfall model, the actual development process is not constrained in any way. Even when the waterfall model is not followed, as Parnas and Clements point out, the most logical way to present the documentation is still to &quot;fake&quot; a rational design process.
 </p>
 </div>
-</a>
-<a id="Sec:ReqsScope">
+</div>
+<div id="Sec:ReqsScope">
 <div class="subsection">
 <h2>
 Scope of Requirements
@@ -978,8 +978,8 @@ Scope of Requirements
 The scope of the requirements includes thermal analysis of a single solar water heating tank incorporating PCM. Given the appropriate inputs, the code for SWHS is intended to predict the temperature and thermal energy histories for the water and the PCM. This entire document is written assuming that the substances inside the solar water heating tank are water and PCM.
 </p>
 </div>
-</a>
-<a id="Sec:ReaderChars">
+</div>
+<div id="Sec:ReaderChars">
 <div class="subsection">
 <h2>
 Characteristics of Intended Reader
@@ -988,8 +988,8 @@ Characteristics of Intended Reader
 Reviewers of this documentation should have a strong knowledge in heat transfer theory. A third or fourth year Mechanical Engineering course on this topic is recommended. The reviewers should also have an understanding of differential equations, as typically covered in first and second year Calculus courses. The users of SWHS can have a lower level of expertise, as explained in <a href=#Sec:UserChars>User Characteristics</a>.
 </p>
 </div>
-</a>
-<a id="Sec:DocOrg">
+</div>
+<div id="Sec:DocOrg">
 <div class="subsection">
 <h2>
 Organization of Document
@@ -1001,10 +1001,10 @@ The organization of this document follows the template for an SRS for scientific
 The goal statements are refined to the theoretical models, and the theoretical models to the instance models. The instance models (<a href=#Sec:IMs>Instance Models</a>) to be solved are referred to as IM1 to IM4. The instance models provide the Ordinary Differential Equation (ODEs) and algebraic equations that model the solar water heating systems incorporating PCM. SWHS solves these ODEs.
 </p>
 </div>
-</a>
 </div>
-</a>
-<a id="Sec:GenSysDesc">
+</div>
+</div>
+<div id="Sec:GenSysDesc">
 <div class="section">
 <h1>
 General System Description
@@ -1012,7 +1012,7 @@ General System Description
 <p class="paragraph">
 This section provides general information about the system, identifies the interfaces between the system and its environment, and describes the user characteristics and the system constraints.
 </p>
-<a id="Sec:SysContext">
+<div id="Sec:SysContext">
 <div class="subsection">
 <h2>
 System Context
@@ -1020,12 +1020,12 @@ System Context
 <p class="paragraph">
 <a href=#Figure:SysCon>Figure:SysCon</a> shows the system context. A circle represents an external entity outside the software, the user in this case. A rectangle represents the software system itself (SWHS). Arrows are used to show the data flow between the system and its environment.
 </p>
-<a id="Figure:SysCon">
+<div id="Figure:SysCon">
 <img class="figure" src="SystemContextFigure.png" alt="<a href=#Figure:SysCon>Figure:SysCon</a>: System Context"></img>
 <p class="caption">
 <a href=#Figure:SysCon>Figure:SysCon</a>: System Context
 </p>
-</a>
+</div>
 <p class="paragraph">
 SWHS is mostly self-contained. The only external interaction is through the user interface. The responsibilities of the user and the system are as follows:
 </p>
@@ -1057,8 +1057,8 @@ Calculate the required outputs
 </li>
 </ul>
 </div>
-</a>
-<a id="Sec:UserChars">
+</div>
+<div id="Sec:UserChars">
 <div class="subsection">
 <h2>
 User Characteristics
@@ -1067,8 +1067,8 @@ User Characteristics
 The end user of SWHS should have an understanding of undergraduate Level 1 Calculus and Physics.
 </p>
 </div>
-</a>
-<a id="Sec:SysConstraints">
+</div>
+<div id="Sec:SysConstraints">
 <div class="subsection">
 <h2>
 System Constraints
@@ -1077,10 +1077,10 @@ System Constraints
 There are no system constraints.
 </p>
 </div>
-</a>
 </div>
-</a>
-<a id="Sec:SpecSystDesc">
+</div>
+</div>
+<div id="Sec:SpecSystDesc">
 <div class="section">
 <h1>
 Specific System Description
@@ -1088,7 +1088,7 @@ Specific System Description
 <p class="paragraph">
 This section first presents the problem description, which gives a high-level view of the problem to be solved. This is followed by the solution characteristics specification, which presents the assumptions, theories, theoretical models, general definitions, data definitions, and finally the instance models (ODEs) that model the solar water heating systems incorporating PCM.
 </p>
-<a id="Sec:ProbDesc">
+<div id="Sec:ProbDesc">
 <div class="subsection">
 <h2>
 Problem Description
@@ -1096,7 +1096,7 @@ Problem Description
 <p class="paragraph">
 SWHS is a computer program developed to investigate the effect of employing PCM within a solar water heating tank.
 </p>
-<a id="Sec:TermDefs">
+<div id="Sec:TermDefs">
 <div class="subsubsection">
 <h3>
 Terminology and Definitions
@@ -1122,8 +1122,8 @@ Transient: Changing with time.
 </li>
 </ul>
 </div>
-</a>
-<a id="Sec:PhysSyst">
+</div>
+<div id="Sec:PhysSyst">
 <div class="subsubsection">
 <h3>
 Physical System Description
@@ -1142,15 +1142,15 @@ PS2: Heating coil at bottom of tank. (<em>q<sub>C</sub></em> represents the heat
 PS3: PCM suspended in tank. (<em>q<sub>P</sub></em> represents the heat flux into the PCM from water.)
 </p>
 </div>
-<a id="Figure:Tank">
+<div id="Figure:Tank">
 <img class="figure" src="Tank.png" alt="Solar water heating tank, with heat flux into the water from the coil of <em>q<sub>C</sub></em> and heat flux into the PCM from water of <em>q<sub>P</sub></em>"></img>
 <p class="caption">
 Solar water heating tank, with heat flux into the water from the coil of <em>q<sub>C</sub></em> and heat flux into the PCM from water of <em>q<sub>P</sub></em>
 </p>
-</a>
 </div>
-</a>
-<a id="Sec:GoalStmt">
+</div>
+</div>
+<div id="Sec:GoalStmt">
 <div class="subsubsection">
 <h3>
 Goal Statements
@@ -1173,10 +1173,10 @@ GS4: Predict the change in heat energy in the PCM over time.
 </p>
 </div>
 </div>
-</a>
 </div>
-</a>
-<a id="Sec:SolCharSpec">
+</div>
+</div>
+<div id="Sec:SolCharSpec">
 <div class="subsection">
 <h2>
 Solution Characteristics Specification
@@ -1184,7 +1184,7 @@ Solution Characteristics Specification
 <p class="paragraph">
 The instance models that govern SWHS are presented in <a href=#Sec:IMs>Instance Models</a>. The information to understand the meaning of the instance models and their derivation is also presented, so that the instance models can be verified.
 </p>
-<a id="Sec:Assumps">
+<div id="Sec:Assumps">
 <div class="subsubsection">
 <h3>
 Assumptions
@@ -1192,109 +1192,109 @@ Assumptions
 <p class="paragraph">
 This section simplifies the original problem and helps in developing the theoretical model by filling in the missing information for the physical system. The numbers given in the square brackets refer to the Theoretical Models [<a href=#Sec:TMs>Theoretical Models</a>], General Definitions [<a href=#Sec:GDs>General Definitions</a>], Data Definitions [<a href=#Sec:DDs>Data Definitions</a>], Instance Models [<a href=#Sec:IMs>Instance Models</a>], or Likely Changes [<a href=#Sec:LCs>Likely Changes</a>], in which the respective assumption is used.
 </p>
-<a id="A:assump1">
+<div id="A:assump1">
 <ul>
 assump1: The only form of energy that is relevant for this problem is thermal energy. All other forms of energy, such as mechanical energy, are assumed to be negligible [<a href=#T:t1ConsThermE>T:t1ConsThermE</a>].
 </ul>
-</a>
-<a id="A:assump2">
+</div>
+<div id="A:assump2">
 <ul>
 assump2: All heat transfer coefficients are constant over time [GD1].
 </ul>
-</a>
-<a id="A:assump3">
+</div>
+<div id="A:assump3">
 <ul>
 assump3: The water in the tank is fully mixed, so the temperature of the water is the same throughout the entire tank [GD2, <a href=#DD:ht.flux.P>DD:ht.flux.P</a>].
 </ul>
-</a>
-<a id="A:assump4">
+</div>
+<div id="A:assump4">
 <ul>
 assump4: The temperature of the phase change material is the same throughout the volume of PCM [GD2, <a href=#DD:ht.flux.P>DD:ht.flux.P</a>].
 </ul>
-</a>
-<a id="A:assump5">
+</div>
+<div id="A:assump5">
 <ul>
 assump5: The density of water and density of PCM have no spatial variation; that is, they are each constant over their entire volume [GD2].
 </ul>
-</a>
-<a id="A:assump6">
+</div>
+<div id="A:assump6">
 <ul>
 assump6: The specific heat capacity of water, specific heat capacity of PCM as a solid, and specific heat capacity of PCM as a liquid have no spatial variation; that is, they are each constant over their entire volume [GD2].
 </ul>
-</a>
-<a id="A:assump7">
+</div>
+<div id="A:assump7">
 <ul>
 assump7: Newton's law of convective cooling applies between the heating coil and the water [<a href=#DD:ht.flux.C>DD:ht.flux.C</a>].
 </ul>
-</a>
-<a id="A:assump8">
+</div>
+<div id="A:assump8">
 <ul>
 assump8: The temperature of the heating coil is constant over time [<a href=#DD:ht.flux.C>DD:ht.flux.C</a>].
 </ul>
-</a>
-<a id="A:assump9">
+</div>
+<div id="A:assump9">
 <ul>
 assump9: The temperature of the heating coil does not vary along its length [<a href=#DD:ht.flux.C>DD:ht.flux.C</a>].
 </ul>
-</a>
-<a id="A:assump10">
+</div>
+<div id="A:assump10">
 <ul>
 assump10: Newton's law of convective cooling applies between the water and the PCM [<a href=#DD:ht.flux.P>DD:ht.flux.P</a>].
 </ul>
-</a>
-<a id="A:assump11">
+</div>
+<div id="A:assump11">
 <ul>
 assump11: The model only accounts for charging of the tank, not discharging. The temperature of the water and temperature of the phase change material can only increase, or remain constant; they do not decrease. This implies that the initial temperature [<a href=#A:assump12>assump12</a>] is less than (or equal) to the temperature of the heating coil [IM1].
 </ul>
-</a>
-<a id="A:assump12">
+</div>
+<div id="A:assump12">
 <ul>
 assump12: The initial temperature of the water and the PCM is the same [IM1, IM2].
 </ul>
-</a>
-<a id="A:assump13">
+</div>
+<div id="A:assump13">
 <ul>
 assump13: The simulation will start with the PCM in a solid state [IM2, IM4].
 </ul>
-</a>
-<a id="A:assump14">
+</div>
+<div id="A:assump14">
 <ul>
 assump14: The operating temperature range of the system is such that the water is always in liquid state. That is, the temperature will not drop below the melting point temperature of water, or rise above its boiling point temperature [IM1, IM3].
 </ul>
-</a>
-<a id="A:assump15">
+</div>
+<div id="A:assump15">
 <ul>
 assump15: The tank is perfectly insulated so that there is no heat loss from the tank [IM1].
 </ul>
-</a>
-<a id="A:assump16">
+</div>
+<div id="A:assump16">
 <ul>
 assump16: No internal heat is generated by either the water or the PCM; therefore, the volumetric heat generation per unit volume is zero [IM1, IM2].
 </ul>
-</a>
-<a id="A:assump17">
+</div>
+<div id="A:assump17">
 <ul>
 assump17: The volume change of the PCM due to melting is negligible [IM2].
 </ul>
-</a>
-<a id="A:assump18">
+</div>
+<div id="A:assump18">
 <ul>
 assump18: The PCM is either in a liquid state or a solid state but not a gaseous state [IM2, IM4].
 </ul>
-</a>
-<a id="A:assump19">
+</div>
+<div id="A:assump19">
 <ul>
 assump19: The pressure in the tank is atmospheric, so the melting point temperature and boiling point temperature are 0&deg;C and 100&deg;C, respectively [IM1, IM3].
 </ul>
-</a>
-<a id="A:assump20">
+</div>
+<div id="A:assump20">
 <ul>
 assump20: When considering the volume of water in the tank, the volume of the heating coil is assumed to be negligible.
 </ul>
-</a>
 </div>
-</a>
-<a id="Sec:TMs">
+</div>
+</div>
+<div id="Sec:TMs">
 <div class="subsubsection">
 <h3>
 Theoretical Models
@@ -1302,7 +1302,7 @@ Theoretical Models
 <p class="paragraph">
 This section focuses on the general equations and laws that SWHS is based on.
 </p>
-<a id="T:t1ConsThermE">
+<div id="T:t1ConsThermE">
 <table class="tdefn">
 <tr>
 <th>
@@ -1319,7 +1319,7 @@ Conservation of Thermal Energy
 Equation
 </th>
 <td>
-<a id="">
+<div id="">
 <div class="equation">
 <p class="paragraph">
 <em>&minus;&nabla;&sdot;<b>q</b>&plus;g = &rho;&#8239;C&#8239;<div class="fraction">
@@ -1332,7 +1332,7 @@ Equation
 </div></em>
 </p>
 </div>
-</a>
+</div>
 </td>
 </tr>
 <tr>
@@ -1346,8 +1346,8 @@ The above equation gives the law of conservation of energy for transient heat tr
 </td>
 </tr>
 </table>
-</a>
-<a id="T:t2SensHtE">
+</div>
+<div id="T:t2SensHtE">
 <table class="tdefn">
 <tr>
 <th>
@@ -1364,7 +1364,7 @@ Sensible Heat Energy
 Equation
 </th>
 <td>
-<a id="">
+<div id="">
 <div class="equation">
 <p class="paragraph">
 <em>E = <span class="casebr">
@@ -1389,7 +1389,7 @@ T<sub>boil</sub>&thinsp;&lt;&thinsp;T
 </div></em>
 </p>
 </div>
-</a>
+</div>
 </td>
 </tr>
 <tr>
@@ -1403,8 +1403,8 @@ Description
 </td>
 </tr>
 </table>
-</a>
-<a id="T:t3LatHtE">
+</div>
+<div id="T:t3LatHtE">
 <table class="tdefn">
 <tr>
 <th>
@@ -1421,7 +1421,7 @@ Latent Heat Energy
 Equation
 </th>
 <td>
-<a id="">
+<div id="">
 <div class="equation">
 <p class="paragraph">
 <em>Q(t) = &int;<sub>0</sub><sup>t</sup><div class="fraction">
@@ -1434,7 +1434,7 @@ d&#8239;&tau;
 </div>&#8239;d&tau;</em>
 </p>
 </div>
-</a>
+</div>
 </td>
 </tr>
 <tr>
@@ -1455,10 +1455,10 @@ d&#8239;&tau;
 </td>
 </tr>
 </table>
-</a>
 </div>
-</a>
-<a id="Sec:GDs">
+</div>
+</div>
+<div id="Sec:GDs">
 <div class="subsubsection">
 <h3>
 General Definitions
@@ -1466,7 +1466,7 @@ General Definitions
 <p class="paragraph">
 This section collects the laws and equations that will be used in deriving the data definitions, which in turn are used to build the instance models.
 </p>
-<a id="T:nwtnCooling">
+<div id="T:nwtnCooling">
 <table class="tdefn">
 <tr>
 <th>
@@ -1483,13 +1483,13 @@ Newton's Law of Cooling
 Equation
 </th>
 <td>
-<a id="">
+<div id="">
 <div class="equation">
 <p class="paragraph">
 <em><b>q</b>(t) = h&#8239;&Delta;T(t)</em>
 </p>
 </div>
-</a>
+</div>
 </td>
 </tr>
 <tr>
@@ -1503,8 +1503,8 @@ Newton's law of cooling describes convective cooling from a surface. The law is 
 </td>
 </tr>
 </table>
-</a>
-<a id="T:rocTempSimp">
+</div>
+<div id="T:rocTempSimp">
 <table class="tdefn">
 <tr>
 <th>
@@ -1521,7 +1521,7 @@ Simplified Rate of Change of Temperature
 Equation
 </th>
 <td>
-<a id="">
+<div id="">
 <div class="equation">
 <p class="paragraph">
 <em>m&#8239;C&#8239;<div class="fraction">
@@ -1534,7 +1534,7 @@ d&#8239;t
 </div> = q<sub>in</sub>&#8239;A<sub>in</sub>&minus;q<sub>out</sub>&#8239;A<sub>out</sub>&plus;g&#8239;V</em>
 </p>
 </div>
-</a>
+</div>
 </td>
 </tr>
 <tr>
@@ -1548,14 +1548,14 @@ The basic equation governing the rate of change of temperature, for a given volu
 </td>
 </tr>
 </table>
-</a>
+</div>
 <p class="paragraph">
 Detailed derivation of simplified rate of change of temperature:
 </p>
 <p class="paragraph">
 Integrating <a href=#T:t1ConsThermE>T:t1ConsThermE</a> over a volume (<em>V</em>), we have:
 </p>
-<a id="">
+<div id="">
 <div class="equation">
 <em>&minus;&int;<sub>V</sub>&nabla;&sdot;<b>q</b>&#8239;dV&plus;&int;<sub>V</sub>g&#8239;dV = &int;<sub>V</sub>&rho;&#8239;C&#8239;<div class="fraction">
 <span class="fup">
@@ -1566,11 +1566,11 @@ Integrating <a href=#T:t1ConsThermE>T:t1ConsThermE</a> over a volume (<em>V</em>
 </span>
 </div>&#8239;dV</em>
 </div>
-</a>
+</div>
 <p class="paragraph">
 Applying Gauss's Divergence Theorem to the first term over the surface <em>S</em> of the volume, with <em><b>q</b></em> as the thermal flux vector for the surface and <em><b>n&#770;</b></em> as a unit outward normal vector for a surface:
 </p>
-<a id="">
+<div id="">
 <div class="equation">
 <em>&minus;&int;<sub>S</sub><b>q</b>&sdot;<b>n&#770;</b>&#8239;dS&plus;&int;<sub>V</sub>g&#8239;dV = &int;<sub>V</sub>&rho;&#8239;C&#8239;<div class="fraction">
 <span class="fup">
@@ -1581,11 +1581,11 @@ Applying Gauss's Divergence Theorem to the first term over the surface <em>S</em
 </span>
 </div>&#8239;dV</em>
 </div>
-</a>
+</div>
 <p class="paragraph">
 We consider an arbitrary volume. The volumetric heat generation per unit volume is assumed constant. Then (1) can be written as:
 </p>
-<a id="">
+<div id="">
 <div class="equation">
 <em>q<sub>in</sub>&#8239;A<sub>in</sub>&minus;q<sub>out</sub>&#8239;A<sub>out</sub>&plus;g&#8239;V = &int;<sub>V</sub>&rho;&#8239;C&#8239;<div class="fraction">
 <span class="fup">
@@ -1596,11 +1596,11 @@ We consider an arbitrary volume. The volumetric heat generation per unit volume 
 </span>
 </div>&#8239;dV</em>
 </div>
-</a>
+</div>
 <p class="paragraph">
 Where <em>q<sub>in</sub></em>, <em>q<sub>out</sub></em>, <em>A<sub>in</sub></em>, and <em>A<sub>out</sub></em> are explained in GD2. Assuming <em>&rho;</em>, <em>C</em> and <em>T</em> are constant over the volume, which is true in our case by Assumptions (<a href=#A:assump3>assump3</a>), (<a href=#A:assump4>assump4</a>), (<a href=#A:assump5>assump5</a>), and (<a href=#A:assump6>assump6</a>), we have:
 </p>
-<a id="">
+<div id="">
 <div class="equation">
 <em>&rho;&#8239;C&#8239;V&#8239;<div class="fraction">
 <span class="fup">
@@ -1611,11 +1611,11 @@ d&#8239;t
 </span>
 </div> = q<sub>in</sub>&#8239;A<sub>in</sub>&minus;q<sub>out</sub>&#8239;A<sub>out</sub>&plus;g&#8239;V</em>
 </div>
-</a>
+</div>
 <p class="paragraph">
 Using the fact that <em>&rho;</em>=<em>m</em>/<em>V</em>, (2) can be written as:
 </p>
-<a id="">
+<div id="">
 <div class="equation">
 <em>m&#8239;C&#8239;<div class="fraction">
 <span class="fup">
@@ -1626,10 +1626,10 @@ d&#8239;t
 </span>
 </div> = q<sub>in</sub>&#8239;A<sub>in</sub>&minus;q<sub>out</sub>&#8239;A<sub>out</sub>&plus;g&#8239;V</em>
 </div>
-</a>
 </div>
-</a>
-<a id="Sec:DDs">
+</div>
+</div>
+<div id="Sec:DDs">
 <div class="subsubsection">
 <h3>
 Data Definitions
@@ -1637,7 +1637,7 @@ Data Definitions
 <p class="paragraph">
 This section collects and defines all the data needed to build the instance models. The dimension of each quantity is also given.
 </p>
-<a id="DD:ht.flux.C">
+<div id="DD:ht.flux.C">
 <table class="ddefn">
 <tr>
 <th>
@@ -1664,13 +1664,13 @@ W/m<sup>2</sup>
 Equation
 </th>
 <td>
-<a id="">
+<div id="">
 <div class="equation">
 <p class="paragraph">
 <em>q<sub>C</sub> = h<sub>C</sub>&#8239;(T<sub>C</sub>&minus;T<sub>W</sub>(t))</em>
 </p>
 </div>
-</a>
+</div>
 </td>
 </tr>
 <tr>
@@ -1684,8 +1684,8 @@ Description
 </td>
 </tr>
 </table>
-</a>
-<a id="DD:ht.flux.P">
+</div>
+<div id="DD:ht.flux.P">
 <table class="ddefn">
 <tr>
 <th>
@@ -1712,13 +1712,13 @@ W/m<sup>2</sup>
 Equation
 </th>
 <td>
-<a id="">
+<div id="">
 <div class="equation">
 <p class="paragraph">
 <em>q<sub>P</sub> = h<sub>P</sub>&#8239;(T<sub>W</sub>(t)&minus;T<sub>P</sub>(t))</em>
 </p>
 </div>
-</a>
+</div>
 </td>
 </tr>
 <tr>
@@ -1732,8 +1732,8 @@ Description
 </td>
 </tr>
 </table>
-</a>
-<a id="DD:htFusion">
+</div>
+<div id="DD:htFusion">
 <table class="ddefn">
 <tr>
 <th>
@@ -1760,7 +1760,7 @@ J/kg
 Equation
 </th>
 <td>
-<a id="">
+<div id="">
 <div class="equation">
 <p class="paragraph">
 <em>H<sub>f</sub> = <div class="fraction">
@@ -1773,7 +1773,7 @@ m
 </div></em>
 </p>
 </div>
-</a>
+</div>
 </td>
 </tr>
 <tr>
@@ -1787,8 +1787,8 @@ Description
 </td>
 </tr>
 </table>
-</a>
-<a id="DD:melt.frac">
+</div>
+<div id="DD:melt.frac">
 <table class="ddefn">
 <tr>
 <th>
@@ -1815,7 +1815,7 @@ Unitless
 Equation
 </th>
 <td>
-<a id="">
+<div id="">
 <div class="equation">
 <p class="paragraph">
 <em>&phi; = <div class="fraction">
@@ -1828,7 +1828,7 @@ H<sub>f</sub>&#8239;m<sub>P</sub>
 </div></em>
 </p>
 </div>
-</a>
+</div>
 </td>
 </tr>
 <tr>
@@ -1842,10 +1842,10 @@ Description
 </td>
 </tr>
 </table>
-</a>
 </div>
-</a>
-<a id="Sec:IMs">
+</div>
+</div>
+<div id="Sec:IMs">
 <div class="subsubsection">
 <h3>
 Instance Models
@@ -1856,7 +1856,7 @@ This section transforms the problem defined in <a href=#Sec:ProbDesc>Problem Des
 <p class="paragraph">
 The goals GS1 to GS4 are solved by IM1 to IM4. The solutions for IM1 and IM2 are coupled since the solution for <em>T<sub>W</sub></em> and <em>T<sub>P</sub></em> depend on one another. IM3 can be solved once IM1 has been solved. The solution of IM2 and IM4 are also coupled, since the temperature of the phase change material and change in heat energy in the PCM depend on the phase change.
 </p>
-<a id="T:eBalanceOnWtr">
+<div id="T:eBalanceOnWtr">
 <table class="tdefn">
 <tr>
 <th>
@@ -1873,7 +1873,7 @@ Energy Balance on Water to Find the Temperature of the Water
 Equation
 </th>
 <td>
-<a id="">
+<div id="">
 <div class="equation">
 <p class="paragraph">
 <em><div class="fraction">
@@ -1893,7 +1893,7 @@ d&#8239;t
 </div>&#8239;(T<sub>C</sub>&minus;T<sub>W</sub>(t)&plus;&eta;&#8239;(T<sub>P</sub>(t)&minus;T<sub>W</sub>(t)))</em>
 </p>
 </div>
-</a>
+</div>
 </td>
 </tr>
 <tr>
@@ -1921,14 +1921,14 @@ h<sub>C</sub>&#8239;A<sub>C</sub>
 </td>
 </tr>
 </table>
-</a>
+</div>
 <p class="paragraph">
 Derivation of the energy balance on water:
 </p>
 <p class="paragraph">
 To find the rate of change of <em>T<sub>W</sub></em>, we look at the energy balance on water. The volume being considered is the volume of water <em>V<sub>W</sub></em>, which has mass of water <em>m<sub>W</sub></em> and specific heat capacity of water, <em>C<sub>W</sub></em>. <em>q<sub>C</sub></em> represents the heat flux into the water from the coil and <em>q<sub>P</sub></em> represents the heat flux into the PCM from water, over heating coil surface area and phase change material surface area of <em>A<sub>C</sub></em> and <em>A<sub>P</sub></em>, respectively. No heat transfer occurs to the outside of the tank, since it has been assumed to be perfectly insulated (<a href=#A:assump15>assump15</a>). Assuming no volumetric heat generation per unit volume (<a href=#A:assump16>assump16</a>), <em>g = 0</em>. Therefore, the equation for GD2 can be written as:
 </p>
-<a id="">
+<div id="">
 <div class="equation">
 <em>m<sub>W</sub>&#8239;C<sub>W</sub>&#8239;<div class="fraction">
 <span class="fup">
@@ -1939,11 +1939,11 @@ d&#8239;t
 </span>
 </div> = q<sub>C</sub>&#8239;A<sub>C</sub>&minus;q<sub>P</sub>&#8239;A<sub>P</sub></em>
 </div>
-</a>
+</div>
 <p class="paragraph">
 Using <a href=#DD:ht.flux.C>DD:ht.flux.C</a> and <a href=#DD:ht.flux.P>DD:ht.flux.P</a> for <em>q<sub>C</sub></em> and <em>q<sub>P</sub></em> respectively, this can be written as:
 </p>
-<a id="">
+<div id="">
 <div class="equation">
 <em>m<sub>W</sub>&#8239;C<sub>W</sub>&#8239;<div class="fraction">
 <span class="fup">
@@ -1954,11 +1954,11 @@ d&#8239;t
 </span>
 </div> = h<sub>C</sub>&#8239;A<sub>C</sub>&#8239;(T<sub>C</sub>&minus;T<sub>W</sub>)&minus;h<sub>P</sub>&#8239;A<sub>P</sub>&#8239;(T<sub>W</sub>&minus;T<sub>P</sub>)</em>
 </div>
-</a>
+</div>
 <p class="paragraph">
 Dividing (3) by <em>m<sub>W</sub></em><em>C<sub>W</sub></em>, we obtain:
 </p>
-<a id="">
+<div id="">
 <div class="equation">
 <em><div class="fraction">
 <span class="fup">
@@ -1983,11 +1983,11 @@ m<sub>W</sub>&#8239;C<sub>W</sub>
 </span>
 </div>&#8239;(T<sub>W</sub>&minus;T<sub>P</sub>)</em>
 </div>
-</a>
+</div>
 <p class="paragraph">
 Factoring the negative sign out of the second term of the RHS of Equation (4) and multiplying it by <em>h<sub>C</sub></em><em>A<sub>C</sub></em>/<em>h<sub>C</sub></em><em>A<sub>C</sub></em> yields:
 </p>
-<a id="">
+<div id="">
 <div class="equation">
 <em><div class="fraction">
 <span class="fup">
@@ -2019,11 +2019,11 @@ m<sub>W</sub>&#8239;C<sub>W</sub>
 </span>
 </div>&#8239;(T<sub>P</sub>&minus;T<sub>W</sub>)</em>
 </div>
-</a>
+</div>
 <p class="paragraph">
 Which simplifies to:
 </p>
-<a id="">
+<div id="">
 <div class="equation">
 <em><div class="fraction">
 <span class="fup">
@@ -2055,7 +2055,7 @@ m<sub>W</sub>&#8239;C<sub>W</sub>
 </span>
 </div>&#8239;(T<sub>P</sub>&minus;T<sub>W</sub>)</em>
 </div>
-</a>
+</div>
 <p class="paragraph">
 Setting <em>&tau;<sub>W</sub> = <div class="fraction">
 <span class="fup">
@@ -2073,7 +2073,7 @@ h<sub>C</sub>&#8239;A<sub>C</sub>
 </span>
 </div></em>, Equation (5) can be written as:
 </p>
-<a id="">
+<div id="">
 <div class="equation">
 <em><div class="fraction">
 <span class="fup">
@@ -2098,7 +2098,7 @@ d&#8239;t
 </span>
 </div>&#8239;(T<sub>P</sub>&minus;T<sub>W</sub>)</em>
 </div>
-</a>
+</div>
 <p class="paragraph">
 Finally, factoring out <em><div class="fraction">
 <span class="fup">
@@ -2109,7 +2109,7 @@ Finally, factoring out <em><div class="fraction">
 </span>
 </div></em>, we are left with the governing ODE for IM1:
 </p>
-<a id="">
+<div id="">
 <div class="equation">
 <em><div class="fraction">
 <span class="fup">
@@ -2127,8 +2127,8 @@ d&#8239;t
 </span>
 </div>&#8239;(T<sub>C</sub>&minus;T<sub>W</sub>&plus;&eta;&#8239;(T<sub>P</sub>&minus;T<sub>W</sub>))</em>
 </div>
-</a>
-<a id="T:eBalanceOnPCM">
+</div>
+<div id="T:eBalanceOnPCM">
 <table class="tdefn">
 <tr>
 <th>
@@ -2145,7 +2145,7 @@ Energy Balance on PCM to Find T_p
 Equation
 </th>
 <td>
-<a id="">
+<div id="">
 <div class="equation">
 <p class="paragraph">
 <em><div class="fraction">
@@ -2196,7 +2196,7 @@ T<sub>P</sub> = T<sub>melt</sub><sup>P</sup>
 </div></em>
 </p>
 </div>
-</a>
+</div>
 </td>
 </tr>
 <tr>
@@ -2224,14 +2224,14 @@ h<sub>P</sub>&#8239;A<sub>P</sub>
 </td>
 </tr>
 </table>
-</a>
+</div>
 <p class="paragraph">
 Detailed derivation of the energy balance on the PCM during sensible heating phase:
 </p>
 <p class="paragraph">
 To find the rate of change of <em>T<sub>P</sub></em>, we look at the energy balance on the PCM. The volume being considered is the volume of PCM, <em>V<sub>P</sub></em>. The derivation that follows is initially for the solid PCM. The mass of phase change material is <em>m<sub>P</sub></em> and the specific heat capacity of PCM as a solid is <em>C<sub>P</sub><sup>S</sup></em>. The heat flux into the PCM from water is <em>q<sub>P</sub></em> over phase change material surface area <em>A<sub>P</sub></em>. There is no heat flux output. Assuming no volumetric heat generation per unit volume (<a href=#A:assump16>assump16</a>), <em>g</em>=0, the equation for GD2 can be written as:
 </p>
-<a id="">
+<div id="">
 <div class="equation">
 <em>m<sub>P</sub>&#8239;C<sub>P</sub><sup>S</sup>&#8239;<div class="fraction">
 <span class="fup">
@@ -2242,11 +2242,11 @@ d&#8239;t
 </span>
 </div> = q<sub>P</sub>&#8239;A<sub>P</sub></em>
 </div>
-</a>
+</div>
 <p class="paragraph">
 Using <a href=#DD:ht.flux.P>DD:ht.flux.P</a> for <em>q<sub>P</sub></em>, this equation can be written as:
 </p>
-<a id="">
+<div id="">
 <div class="equation">
 <em>m<sub>P</sub>&#8239;C<sub>P</sub><sup>S</sup>&#8239;<div class="fraction">
 <span class="fup">
@@ -2257,11 +2257,11 @@ d&#8239;t
 </span>
 </div> = h<sub>P</sub>&#8239;A<sub>P</sub>&#8239;(T<sub>W</sub>&minus;T<sub>P</sub>)</em>
 </div>
-</a>
+</div>
 <p class="paragraph">
 Dividing by <em>m<sub>P</sub></em><em>C<sub>P</sub><sup>S</sup></em> we obtain:
 </p>
-<a id="">
+<div id="">
 <div class="equation">
 <em><div class="fraction">
 <span class="fup">
@@ -2279,11 +2279,11 @@ m<sub>P</sub>&#8239;C<sub>P</sub><sup>S</sup>
 </span>
 </div>&#8239;(T<sub>W</sub>&minus;T<sub>P</sub>)</em>
 </div>
-</a>
+</div>
 <p class="paragraph">
 Setting <em>&tau;<sub>P</sub><sup>S</sup></em>=<em>m<sub>P</sub></em><em>C<sub>P</sub><sup>S</sup></em>/<em>h<sub>P</sub></em><em>A<sub>P</sub></em>, this can be written as:
 </p>
-<a id="">
+<div id="">
 <div class="equation">
 <em><div class="fraction">
 <span class="fup">
@@ -2301,7 +2301,7 @@ d&#8239;t
 </span>
 </div>&#8239;(T<sub>W</sub>&minus;T<sub>P</sub>)</em>
 </div>
-</a>
+</div>
 <p class="paragraph">
 Equation (6) applies for the solid PCM. In the case where all of the PCM is melted, the same derivation applies, except that <em>C<sub>P</sub><sup>S</sup></em> is replaced by <em>C<sub>P</sub><sup>L</sup></em>, and thus <em>&tau;<sub>P</sub><sup>S</sup></em> is replaced by <em>&tau;<sub>P</sub><sup>L</sup></em>. Although a small change in surface area would be expected with melting, this is not included, since the volume change of the PCM with melting is assumed to be negligible (<a href=#A:assump17>assump17</a>).
 </p>
@@ -2311,7 +2311,7 @@ In the case where <em>T<sub>P</sub></em>=<em>T<sub>melt</sub><sup>P</sup></em> a
 <p class="paragraph">
 This derivation does not consider the boiling of the PCM, as the PCM is assumed to either be in a solid state or a liquid state (<a href=#A:assump18>assump18</a>).
 </p>
-<a id="T:heatEInWtr">
+<div id="T:heatEInWtr">
 <table class="tdefn">
 <tr>
 <th>
@@ -2328,13 +2328,13 @@ Heat Energy in the Water
 Equation
 </th>
 <td>
-<a id="">
+<div id="">
 <div class="equation">
 <p class="paragraph">
 <em>E<sub>W</sub>(t) = C<sub>W</sub>&#8239;m<sub>W</sub>&#8239;(T<sub>W</sub>(t)&minus;T<sub>init</sub>)</em>
 </p>
 </div>
-</a>
+</div>
 </td>
 </tr>
 <tr>
@@ -2348,8 +2348,8 @@ The above equation is derived using T2. <em>E<sub>W</sub></em> is the change in 
 </td>
 </tr>
 </table>
-</a>
-<a id="T:heatEInPCM">
+</div>
+<div id="T:heatEInPCM">
 <table class="tdefn">
 <tr>
 <th>
@@ -2366,7 +2366,7 @@ Heat Energy in the PCM
 Equation
 </th>
 <td>
-<a id="">
+<div id="">
 <div class="equation">
 <p class="paragraph">
 <em>E<sub>P</sub> = <span class="casebr">
@@ -2396,7 +2396,7 @@ E<sub>P</sub><sub>melt</sub><sup>init</sup>&plus;Q<sub>P</sub>(t) , <span class=
 </div></em>
 </p>
 </div>
-</a>
+</div>
 </td>
 </tr>
 <tr>
@@ -2410,10 +2410,10 @@ The above equation is derived using T2 and T3. <em>E<sub>P</sub></em> is the cha
 </td>
 </tr>
 </table>
-</a>
 </div>
-</a>
-<a id="Sec:DataConstraints">
+</div>
+</div>
+<div id="Sec:DataConstraints">
 <div class="subsubsection">
 <h3>
 Data Constraints
@@ -2428,7 +2428,7 @@ h<sub>min</sub>
 </span>
 </div></em>, where <em>h<sub>min</sub></em> is the thickness of a &quot;sheet&quot; of PCM. A thin sheet has the greatest surface area to volume ratio. (**) The constraint on the maximum time at the end of the simulation is the total number of seconds in one day.
 </p>
-<a id="Table:InDataConstraints">
+<div id="Table:InDataConstraints">
 <table class="table">
 <tr>
 <th>
@@ -2747,8 +2747,8 @@ None
 <p class="caption">
 Input Data Constraints
 </p>
-</a>
-<a id="Table:OutDataConstraints">
+</div>
+<div id="Table:OutDataConstraints">
 <table class="table">
 <tr>
 <th>
@@ -2794,10 +2794,10 @@ Physical Constraints
 <p class="caption">
 Output Data Constraints
 </p>
-</a>
 </div>
-</a>
-<a id="Sec:CorSolProps">
+</div>
+</div>
+<div id="Sec:CorSolProps">
 <div class="subsubsection">
 <h3>
 Properties of a Correct Solution
@@ -2805,29 +2805,29 @@ Properties of a Correct Solution
 <p class="paragraph">
 A correct solution must exhibit the law of conservation of energy. This means that the change in heat energy in the water should equal the difference between the total energy input from the heating coil and the energy output to the PCM. This can be shown as an equation by taking <a href=#DD:ht.flux.C>DD:ht.flux.C</a> and <a href=#DD:ht.flux.P>DD:ht.flux.P</a>, multiplying each by their respective surface area of heat transfer, and integrating each over the simulation time, as follows:
 </p>
-<a id="">
+<div id="">
 <div class="equation">
 <em>E<sub>W</sub> = &int;<sub>0</sub><sup>t</sup>h<sub>C</sub>&#8239;A<sub>C</sub>&#8239;(T<sub>C</sub>&minus;T<sub>W</sub>(t))&#8239;dt&minus;&int;<sub>0</sub><sup>t</sup>h<sub>P</sub>&#8239;A<sub>P</sub>&#8239;(T<sub>W</sub>(t)&minus;T<sub>P</sub>(t))&#8239;dt</em>
 </div>
-</a>
+</div>
 <p class="paragraph">
 In addition, the change in heat energy in the PCM should equal the energy input to the PCM from the water. This can be expressed as
 </p>
-<a id="">
+<div id="">
 <div class="equation">
 <em>E<sub>P</sub> = &int;<sub>0</sub><sup>t</sup>h<sub>P</sub>&#8239;A<sub>P</sub>&#8239;(T<sub>W</sub>(t)&minus;T<sub>P</sub>(t))&#8239;dt</em>
 </div>
-</a>
+</div>
 <p class="paragraph">
 Equations (FIXME: Equation 7) and (FIXME: Equation 8) can be used as &quot;sanity&quot;checks to gain confidence in any solution computed by SWHS. The relative error between the results computed by SWHS and the results calculated from the RHS of these equations should be less than 0.001% <a href=#FR:req9>Verify-Energy-Output-follow-Conservation-of-Energy</a>.
 </p>
 </div>
-</a>
 </div>
-</a>
 </div>
-</a>
-<a id="Sec:Requirements">
+</div>
+</div>
+</div>
+<div id="Sec:Requirements">
 <div class="section">
 <h1>
 Requirements
@@ -2835,17 +2835,17 @@ Requirements
 <p class="paragraph">
 This section provides the functional requirements, the business tasks that the software is expected to complete, and the non-functional requirements, the qualities that the software is expected to exhibit.
 </p>
-<a id="Sec:FRs">
+<div id="Sec:FRs">
 <div class="subsection">
 <h2>
 Functional Requirements
 </h2>
-<a id="FR:req1">
+<div id="FR:req1">
 <ul>
 Input-Initial-Quantities: Input the following quantities, which define the tank parameters, material properties and initial conditions:
 </ul>
-</a>
-<a id="Table:InConstraints">
+</div>
+<div id="Table:InConstraints">
 <table class="table">
 <tr>
 <th>
@@ -3046,13 +3046,13 @@ final time
 </td>
 </tr>
 </table>
-</a>
-<a id="FR:req2">
+</div>
+<div id="FR:req2">
 <ul>
 Use-Above-Find-Mass-IM1-IM4: Use the inputs in <a href=#FR:req1>Input-Initial-Quantities</a> to find the mass needed for IM1 to IM4, as follows, where <em>V<sub>W</sub></em> is the volume of water and <em>V<sub>tank</sub></em> is the volume of the cylindrical tank:
 </ul>
-</a>
-<a id="">
+</div>
+<div id="">
 <div class="equation">
 <em>m<sub>W</sub> = V<sub>W</sub>&#8239;&rho;<sub>W</sub> = (V<sub>tank</sub>&minus;V<sub>P</sub>)&#8239;&rho;<sub>W</sub> = (<div class="fraction">
 <span class="fup">
@@ -3063,60 +3063,60 @@ D
 </span>
 </div>&#8239;L&minus;V<sub>P</sub>)&#8239;&rho;<sub>W</sub></em>
 </div>
-</a>
-<a id="">
+</div>
+<div id="">
 <div class="equation">
 <em>m<sub>P</sub> = V<sub>P</sub>&#8239;&rho;<sub>P</sub></em>
 </div>
-</a>
-<a id="FR:req3">
+</div>
+<div id="FR:req3">
 <ul>
 Check-Input-with-Physical_Constraints: Verify that the inputs satisfy the required physical constraints.
 </ul>
-</a>
-<a id="FR:req4">
+</div>
+<div id="FR:req4">
 <ul>
 Output-Input-Derived-Quantities: Output the input quantities and derived quantities in the following list: the quantities from R1, the masses from R2, <em>&tau;<sub>W</sub></em> (from IM1), <em>&eta;</em> (from IM1), <em>&tau;<sub>P</sub><sup>S</sup></em> (from IM2) and <em>&tau;<sub>P</sub><sup>L</sup></em> (from IM2).
 </ul>
-</a>
-<a id="FR:req5">
+</div>
+<div id="FR:req5">
 <ul>
 Calculate-Temperature-Water-OverTime: Calculate and output the temperature of the water (<em>T<sub>W</sub></em>(<em>t</em>)) over the simulation time (from IM1).
 </ul>
-</a>
-<a id="FR:req6">
+</div>
+<div id="FR:req6">
 <ul>
  Calculate-Temperature-PCM-Over-Time: Calculate and output the temperature of the phase change material (<em>T<sub>P</sub></em>(<em>t</em>)) over the simulation time (from IM2).
 </ul>
-</a>
-<a id="FR:req7">
+</div>
+<div id="FR:req7">
 <ul>
 Calculate-Change-Heat_Energy-Water-Over-Time: Calculate and output the change in heat energy in the water (<em>E<sub>W</sub></em>(<em>t</em>)) over the simulation time (from IM3).
 </ul>
-</a>
-<a id="FR:req8">
+</div>
+<div id="FR:req8">
 <ul>
 Calculate-Change-Heat_Energy-PCM-Over-Time: Calculate and output the change in heat energy in the PCM (<em>E<sub>P</sub></em>(<em>t</em>)) over the simulation time (from IM4).
 </ul>
-</a>
-<a id="FR:req9">
+</div>
+<div id="FR:req9">
 <ul>
 Verify-Energy-Output-follow-Conservation-of-Energy: Verify that the energy outputs (<em>E<sub>W</sub></em>(<em>t</em>) and <em>E<sub>P</sub></em>(<em>t</em>)) follow the law of conservation of energy with relative error no greater than 0.001%.
 </ul>
-</a>
-<a id="FR:req10">
+</div>
+<div id="FR:req10">
 <ul>
 Calculate-PCM-melt-begin-time: Calculate and output the time at which the PCM begins to melt <em>t<sub>melt</sub><sup>init</sup></em> (from IM2).
 </ul>
-</a>
-<a id="FR:req11">
+</div>
+<div id="FR:req11">
 <ul>
 Calculate-PCM-melt-end-time: Calculate and output the time at which the PCM stops melting <em>t<sub>melt</sub><sup>final</sup></em> (from IM2).
 </ul>
-</a>
 </div>
-</a>
-<a id="Sec:NFRs">
+</div>
+</div>
+<div id="Sec:NFRs">
 <div class="subsection">
 <h2>
 Non-Functional Requirements
@@ -3125,47 +3125,47 @@ Non-Functional Requirements
 This problem is small in size and relatively simple, so performance is not a priority. Any reasonable implementation will be very quick and use minimal storage. Rather than performance, the non-functional requirement priorities are correctness, verifiability, understandability, reusability, and maintainability.
 </p>
 </div>
-</a>
 </div>
-</a>
-<a id="Sec:LCs">
+</div>
+</div>
+<div id="Sec:LCs">
 <div class="section">
 <h1>
 Likely Changes
 </h1>
-<a id="LC:likeChg1">
+<div id="LC:likeChg1">
 <ul>
 Uniform-Temperature-PCM: <a href=#A:assump4>assump4</a> - PCM is actually a poor thermal conductor, so the assumption of uniform temperature of the phase change material is not likely.
 </ul>
-</a>
-<a id="LC:likeChg2">
+</div>
+<div id="LC:likeChg2">
 <ul>
 Temperature-Coil-Variable-Over-Day: <a href=#A:assump8>assump8</a> - The temperature of the heating coil will change over the course of the day, depending on the energy received from the sun.
 </ul>
-</a>
-<a id="LC:likeChg3">
+</div>
+<div id="LC:likeChg3">
 <ul>
 Temperature-Coil-Variable-Over-Length: <a href=#A:assump9>assump9</a> - The temperature of the heating coil will actually change along its length as the water within it cools.
 </ul>
-</a>
-<a id="LC:likeChg4">
+</div>
+<div id="LC:likeChg4">
 <ul>
 Discharging-Tank: <a href=#A:assump11>assump11</a> - The model currently only accounts for charging of the tank. A more complete model would also account for discharging of the tank.
 </ul>
-</a>
-<a id="LC:likeChg5">
+</div>
+<div id="LC:likeChg5">
 <ul>
 Different-Initial-Temps-PCM-Water: <a href=#A:assump12>assump12</a> - To add more flexibility to the simulation, the initial temperature of the water and the PCM could be allowed to have different values.
 </ul>
-</a>
-<a id="LC:likeChg6">
+</div>
+<div id="LC:likeChg6">
 <ul>
 Tank-Lose-Heat: <a href=#A:assump15>assump15</a> - Any real tank cannot be perfectly insulated and will lose heat.
 </ul>
-</a>
 </div>
-</a>
-<a id="Sec:TraceMatrices">
+</div>
+</div>
+<div id="Sec:TraceMatrices">
 <div class="section">
 <h1>
 Traceability Matrices and Graphs
@@ -3173,7 +3173,7 @@ Traceability Matrices and Graphs
 <p class="paragraph">
 The purpose of the traceability matrices is to provide easy references on what has to be additionally modified if a certain component is changed. Every time a component is changed, the items in the column of that component that are marked with an &quot;X&quot; should be modified as well. <a href=#Table:Tracey2>Table:Tracey2</a> shows the dependencies of theoretical models, general definitions, data definitions, and instance models with each other. <a href=#Table:Tracey1>Table:Tracey1</a> shows the dependencies of instance models, requirements, and data constraints on each other. <a href=#Table:Tracey3>Table:Tracey3</a> shows the dependencies of theoretical models, general definitions, data definitions, instance models, and likely changes on the assumptions.
 </p>
-<a id="Table:Tracey2">
+<div id="Table:Tracey2">
 <table class="table">
 <tr>
 <th>
@@ -3795,8 +3795,8 @@ X
 <p class="caption">
 Traceability Matrix Showing the Connections Between Items of Different Sections
 </p>
-</a>
-<a id="Table:Tracey1">
+</div>
+<div id="Table:Tracey1">
 <table class="table">
 <tr>
 <th>
@@ -4650,8 +4650,8 @@ X
 <p class="caption">
 Traceability Matrix Showing the Connections Between Requirements and Instance Models
 </p>
-</a>
-<a id="Table:Tracey3">
+</div>
+<div id="Table:Tracey3">
 <table class="table">
 <tr>
 <th>
@@ -5897,28 +5897,28 @@ X
 <p class="caption">
 Traceability Matrix Showing the Connections Between Assumptions and Other Items
 </p>
-</a>
+</div>
 <p class="paragraph">
 The purpose of the traceability graphs is also to provide easy references on what has to be additionally modified if a certain component is changed. The arrows in the graphs represent dependencies. The component at the tail of an arrow is depended on by the component at the head of that arrow. Therefore, if a component is changed, the components that it points to should also be changed. <a href=#Figure:TraceyA>Figure:TraceyA</a> shows the dependencies of theoretical models, general definitions, data definitions, instance models, likely changes, and assumptions on each other. <a href=#Figure:TraceyR>Figure:TraceyR</a> shows the dependencies of instance models, requirements, and data constraints on each other.
 </p>
 <p class="paragraph">
 NOTE: Building a tool to automatically generate the graphical representation of the matrix by scanning the labels and reference can be future work.
 </p>
-<a id="Figure:TraceyA">
+<div id="Figure:TraceyA">
 <img class="figure" src="ATrace.png" alt="Traceability Graph Showing the Connections Between Items of Different Sections"></img>
 <p class="caption">
 Traceability Graph Showing the Connections Between Items of Different Sections
 </p>
-</a>
-<a id="Figure:TraceyR">
+</div>
+<div id="Figure:TraceyR">
 <img class="figure" src="RTrace.png" alt="Traceability Graph Showing the Connections Between Instance Models, Requirements, and Data Constraints"></img>
 <p class="caption">
 Traceability Graph Showing the Connections Between Instance Models, Requirements, and Data Constraints
 </p>
-</a>
 </div>
-</a>
-<a id="Sec:AuxConstants">
+</div>
+</div>
+<div id="Sec:AuxConstants">
 <div class="section">
 <h1>
 Values of Auxiliary Constants
@@ -5926,7 +5926,7 @@ Values of Auxiliary Constants
 <p class="paragraph">
 This section contains the standard values that are used for calculations in SWHS.
 </p>
-<a id="Table:TAuxConsts">
+<div id="Table:TAuxConsts">
 <table class="table">
 <tr>
 <th>
@@ -6198,45 +6198,45 @@ s
 <p class="caption">
 Auxiliary Constants
 </p>
-</a>
 </div>
-</a>
-<a id="Sec:References">
+</div>
+</div>
+<div id="Sec:References">
 <div class="section">
 <h1>
 References
 </h1>
-<a id="bueche1986">
+<div id="bueche1986">
 <ul>
 [1]: Bueche, J. Frederick. <em>Introduction to Physics for Scientists</em>. 4nd. ed., New York City, New York: McGraw Hill, 1986. Print.
 </ul>
-</a>
-<a id="incroperaEtAl2007">
+</div>
+<div id="incroperaEtAl2007">
 <ul>
 [2]: Incropera, F. P., Dewitt, D. P., Bergman, T. L., and Lavine, A. S. <em>Fundamentals of Heat and Mass Transfer</em>. 6th. ed., Hoboken, New Jersey: John Wiley and Sons, 2007. Print.
 </ul>
-</a>
-<a id="koothoor2013">
+</div>
+<div id="koothoor2013">
 <ul>
 [3]: Koothoor, Nirmitha. <em>A document drive approach to certifying scientific computing software</em>. McMaster University, Hamilton, ON, Canada: 2013. Print.
 </ul>
-</a>
-<a id="lightstone2012">
+</div>
+<div id="lightstone2012">
 <ul>
 [4]: Lightstone, Marilyn. <em>Derivation of tank/pcm model</em>. 2012. From Marilyn Lightstone's Personal Notes
 </ul>
-</a>
-<a id="parnas1986">
+</div>
+<div id="parnas1986">
 <ul>
 [5]: Parnas, David L. and Clements, P. C. "A rational design process: How and why to fake it." <em>IEEE Transactions on Software Engineering</em>, vol. 12, no. 2, Washington, USA: February, 1986. pp. 251&ndash;257. Print.
 </ul>
-</a>
-<a id="smithLai2005">
+</div>
+<div id="smithLai2005">
 <ul>
 [6]: Smith, W. Spencer and Lai, Lei. "A new requirements template for scientific computing." <em>Proceedings of the First International Workshop on Situational Requirements Engineering Processes - Methods, Techniques and Tools to Support Situation-Specific Requirements Engineering Processes, SREP'05</em>. Edited by PJ Agerfalk, N. Kraiem, and J. Ralyte, Paris, France: 2005. pp. 107&ndash;121. In conjunction with 13th IEEE International Requirements Engineering Conference,
 </ul>
-</a>
 </div>
-</a>
+</div>
+</div>
 </body>
 </html>

--- a/code/stable/tiny/SRS.html
+++ b/code/stable/tiny/SRS.html
@@ -19,7 +19,7 @@ Software Requirements Specification for Tiny
 W. Spencer Smith
 </h2>
 </div>
-<a id="Sec:RefMat">
+<div id="Sec:RefMat">
 <div class="section">
 <h1>
 Reference Material
@@ -27,7 +27,7 @@ Reference Material
 <p class="paragraph">
 This section records information for easy reference.
 </p>
-<a id="Sec:ToU">
+<div id="Sec:ToU">
 <div class="subsection">
 <h2>
 Table of Units
@@ -35,7 +35,7 @@ Table of Units
 <p class="paragraph">
 The unit system used throughout is SI (Système International d'Unités). In addition to the basic units, several derived units are also used. For each unit, the table lists the symbol, a description and the SI name.
 </p>
-<a id="Table:ToU">
+<div id="Table:ToU">
 <table class="table">
 <tr>
 <th>
@@ -318,10 +318,10 @@ resistance (ohm)
 </td>
 </tr>
 </table>
-</a>
 </div>
-</a>
-<a id="Sec:ToS">
+</div>
+</div>
+<div id="Sec:ToS">
 <div class="subsection">
 <h2>
 Table of Symbols
@@ -329,7 +329,7 @@ Table of Symbols
 <p class="paragraph">
 The table that follows summarizes the symbols used in this document along with their units. The choice of symbols was made to be consistent with the nuclear physics literature and with that used in the FP manual.
 </p>
-<a id="Table:ToS">
+<div id="Table:ToS">
 <table class="table">
 <tr>
 <th>
@@ -409,12 +409,12 @@ Clad thickness
 </td>
 </tr>
 </table>
-</a>
 </div>
-</a>
 </div>
-</a>
-<a id="Sec:DDs">
+</div>
+</div>
+</div>
+<div id="Sec:DDs">
 <div class="section">
 <h1>
 Data Definitions
@@ -422,7 +422,7 @@ Data Definitions
 <p class="paragraph">
 This section collects and defines all the data needed to build the instance models.
 </p>
-<a id="DD:htTransCladFuel">
+<div id="DD:htTransCladFuel">
 <table class="ddefn">
 <tr>
 <th>
@@ -449,7 +449,7 @@ W/(m<sup>2</sup>&sdot;&deg;C)
 Equation
 </th>
 <td>
-<a id="">
+<div id="">
 <div class="equation">
 <p class="paragraph">
 <em>h<sub>g</sub> = <div class="fraction">
@@ -462,7 +462,7 @@ Equation
 </div></em>
 </p>
 </div>
-</a>
+</div>
 </td>
 </tr>
 <tr>
@@ -476,8 +476,8 @@ Description
 </td>
 </tr>
 </table>
-</a>
-<a id="DD:htTransCladCool">
+</div>
+<div id="DD:htTransCladCool">
 <table class="ddefn">
 <tr>
 <th>
@@ -504,7 +504,7 @@ W/(m<sup>2</sup>&sdot;&deg;C)
 Equation
 </th>
 <td>
-<a id="">
+<div id="">
 <div class="equation">
 <p class="paragraph">
 <em>h<sub>c</sub> = <div class="fraction">
@@ -517,7 +517,7 @@ Equation
 </div></em>
 </p>
 </div>
-</a>
+</div>
 </td>
 </tr>
 <tr>
@@ -531,8 +531,8 @@ Description
 </td>
 </tr>
 </table>
-</a>
 </div>
-</a>
+</div>
+</div>
 </body>
 </html>


### PR DESCRIPTION
Changes `<a>` tag, which didn't include a hyperlink and was only used for the `id` attribute to a `<div>` tag. This was noticeable on macOS' QuickLook as the cursor became a "pointer" when moused over most of the document. 

**Note:** db82cff on branch gabe has already resolved conflicts caused as a result of changes from this branch, so that pull request will come after this one is merged.