### PR TITLE
Change CSS table padding to prevent text from overflowing a table cell.

### DIFF
--- a/code/Language/Drasil/HTML/Helpers.hs
+++ b/code/Language/Drasil/HTML/Helpers.hs
@@ -149,7 +149,7 @@ makeCSS _ = vcat [
     text "  border-collapse: collapse;",
     text "  margin-left: auto;",
     text "  margin-right: auto;}"],
-  text "th, td {border: 1px solid black; padding: 1%;}",
+  text "th, td {border: 1px solid black; padding: 0.5em;}",
   text ".tdefn, .ddefn {width: 75%; margin-top: 1%; margin-bottom: 1%;}",
   text ".tdefn th {width: 15%;}",
   text ".ddefn th {width: 15%;}",

--- a/code/stable/gamephys/Chipmunk_SRS.css
+++ b/code/stable/gamephys/Chipmunk_SRS.css
@@ -42,7 +42,7 @@ table, th, td {
   border-collapse: collapse;
   margin-left: auto;
   margin-right: auto;}
-th, td {border: 1px solid black; padding: 1%;}
+th, td {border: 1px solid black; padding: 0.5em;}
 .tdefn, .ddefn {width: 75%; margin-top: 1%; margin-bottom: 1%;}
 .tdefn th {width: 15%;}
 .ddefn th {width: 15%;}

--- a/code/stable/glassbr/GlassBR_SRS.css
+++ b/code/stable/glassbr/GlassBR_SRS.css
@@ -42,7 +42,7 @@ table, th, td {
   border-collapse: collapse;
   margin-left: auto;
   margin-right: auto;}
-th, td {border: 1px solid black; padding: 1%;}
+th, td {border: 1px solid black; padding: 0.5em;}
 .tdefn, .ddefn {width: 75%; margin-top: 1%; margin-bottom: 1%;}
 .tdefn th {width: 15%;}
 .ddefn th {width: 15%;}

--- a/code/stable/nopcm/NoPCM_SRS.css
+++ b/code/stable/nopcm/NoPCM_SRS.css
@@ -42,7 +42,7 @@ table, th, td {
   border-collapse: collapse;
   margin-left: auto;
   margin-right: auto;}
-th, td {border: 1px solid black; padding: 1%;}
+th, td {border: 1px solid black; padding: 0.5em;}
 .tdefn, .ddefn {width: 75%; margin-top: 1%; margin-bottom: 1%;}
 .tdefn th {width: 15%;}
 .ddefn th {width: 15%;}

--- a/code/stable/ssp/SSP_SRS.css
+++ b/code/stable/ssp/SSP_SRS.css
@@ -42,7 +42,7 @@ table, th, td {
   border-collapse: collapse;
   margin-left: auto;
   margin-right: auto;}
-th, td {border: 1px solid black; padding: 1%;}
+th, td {border: 1px solid black; padding: 0.5em;}
 .tdefn, .ddefn {width: 75%; margin-top: 1%; margin-bottom: 1%;}
 .tdefn th {width: 15%;}
 .ddefn th {width: 15%;}

--- a/code/stable/swhs/SWHS_SRS.css
+++ b/code/stable/swhs/SWHS_SRS.css
@@ -42,7 +42,7 @@ table, th, td {
   border-collapse: collapse;
   margin-left: auto;
   margin-right: auto;}
-th, td {border: 1px solid black; padding: 1%;}
+th, td {border: 1px solid black; padding: 0.5em;}
 .tdefn, .ddefn {width: 75%; margin-top: 1%; margin-bottom: 1%;}
 .tdefn th {width: 15%;}
 .ddefn th {width: 15%;}

--- a/code/stable/tiny/SRS.css
+++ b/code/stable/tiny/SRS.css
@@ -42,7 +42,7 @@ table, th, td {
   border-collapse: collapse;
   margin-left: auto;
   margin-right: auto;}
-th, td {border: 1px solid black; padding: 1%;}
+th, td {border: 1px solid black; padding: 0.5em;}
 .tdefn, .ddefn {width: 75%; margin-top: 1%; margin-bottom: 1%;}
 .tdefn th {width: 15%;}
 .ddefn th {width: 15%;}


### PR DESCRIPTION
This was noticeable in large tables (like the 3rd traceability matrix in Chipmunk). The left padding would be too large causing the 'x' s to look misaligned and "funny." The table row and column headers would typically overflow their cell and render text outside of it.