### PR TITLE
Removed Warnings in Make

### DIFF
--- a/code/Data/Drasil/Concepts/Documentation.hs
+++ b/code/Data/Drasil/Concepts/Documentation.hs
@@ -8,6 +8,9 @@ import Data.Drasil.Phrase (ofA, andRT, and_, and_', of_, of_', of__)
 import Control.Lens ((^.))
 import qualified Language.Drasil.NounPhrase as NP
 
+assumption, dataDefn, desSpec, genDefn, goalStmt, dataConst, inModel, likelyChg,
+  unlikelyChg, physSyst, requirement, thModel, mg, notApp, typUnc, srs :: CI
+
 -------------------------------------------------------------------------------------------------
 -- | CI       |           |    uid      |         term                        | abbreviation | --
 -------------------------------------------------------------------------------------------------

--- a/code/Example/Drasil/GlassBR/IMods.hs
+++ b/code/Example/Drasil/GlassBR/IMods.hs
@@ -8,7 +8,7 @@ import Drasil.DocumentLanguage.RefHelpers
 import Data.Drasil.SentenceStructures (foldlSent, isThe, sAnd, sOr)
 import Data.Drasil.Utils (getES)
 import Data.Drasil.Concepts.Math (parameter)
-import Data.Drasil.Concepts.Documentation (coordinate, assumption)
+import Data.Drasil.Concepts.Documentation (coordinate)
 
 import Prelude hiding (exp)
 import Control.Lens ((^.))

--- a/code/Example/Drasil/NoPCM/Body.hs
+++ b/code/Example/Drasil/NoPCM/Body.hs
@@ -45,8 +45,8 @@ import Data.Drasil.Concepts.Documentation as Doc (datumConstraint, inModel,
   requirement, section_, traceyGraph, item, assumption, dataDefn,
   likelyChg, genDefn, thModel, traceyMatrix, model, 
   output_, quantity, input_, physicalConstraint, condition,
-  property, variable, description, symbol_, uncertainty,
-  information, uncertCol, value, column, softwareConstraint, goalStmt,
+  property, variable, description, symbol_,
+  information, value, column, softwareConstraint, goalStmt,
   physSyst, problem, definition, srs, content, reference, document,
   goal, purpose, typUnc)
 

--- a/code/Example/Drasil/SSP/GenDefs.hs
+++ b/code/Example/Drasil/SSP/GenDefs.hs
@@ -8,10 +8,9 @@ import Drasil.SSP.Unitals (baseAngle, genDisplace, rotatedDispl, dy_i,
   dx_i, inxi, index, nrmDispl, shrDispl, elmPrllDispl, elmNrmDispl,
   nrmStiffBase, shrStiffIntsl, genPressure, intShrForce, intNormForce,
   fy, fx, impLoadAngle, surfLoad, surfHydroForce, baseHydroForce,
-  slcWght, inxiM1, surfAngle, earthqkLoadFctr, watrForceDif, midpntHght,
-  baseWthX, sliceHght, watrForce, scalFunc, xi, normToShear, fs, shrResI,
-  shearFNoIntsl, shrResI, mobShrI, nrmFSubWat, totNrmForce, baseLngth,
-  shrStress, cohesion, fricAngle)
+  slcWght, inxiM1, surfAngle, earthqkLoadFctr, watrForceDif, baseWthX,
+  scalFunc, xi, normToShear, fs, shrResI, shearFNoIntsl, shrResI, mobShrI, 
+  nrmFSubWat, totNrmForce, baseLngth, shrStress, cohesion, fricAngle)
 import Data.Drasil.Concepts.Documentation (element,
   system, value, variable, definition, model,
   assumption, property, method_)

--- a/code/Example/Drasil/SSP/TMods.hs
+++ b/code/Example/Drasil/SSP/TMods.hs
@@ -12,7 +12,7 @@ import Data.Drasil.SentenceStructures (ofThe, ofThe',
   foldlSent, getTandS, sAnd, sOf)
 import Data.Drasil.Utils (getES)
 import Data.Drasil.Quantities.Physics (force, distance, displacement)
-import Data.Drasil.Concepts.Documentation (safety, model, source, assumption)
+import Data.Drasil.Concepts.Documentation (safety, model, source)
 import Data.Drasil.Concepts.Math (surface)
 import Data.Drasil.Quantities.SolidMechanics (shearRes, mobShear, stffness)
 import Data.Drasil.Concepts.SolidMechanics (normForce, shearForce)

--- a/code/Example/Drasil/SSP/Unitals.hs
+++ b/code/Example/Drasil/SSP/Unitals.hs
@@ -394,8 +394,8 @@ sspUnitless = [earthqkLoadFctr, normToShear,scalFunc,
   numbSlices, minFunction, fsloc, index, varblU, varblV, fs_min,
   ufixme1, ufixme2]
 
-earthqkLoadFctr, normToShear, scalFunc,
-  numbSlices, minFunction, fsloc, index, varblU, varblV :: DefinedQuantityDict
+earthqkLoadFctr, normToShear, scalFunc, numbSlices, minFunction,
+  fsloc, index, varblU, varblV, ufixme1, ufixme2 :: DefinedQuantityDict
 
 earthqkLoadFctr = dqd' (dcc "K_c" (nounPhraseSP $ "earthquake load factor")
   ("proportionality factor of force that " ++

--- a/code/Example/Drasil/SSP/Unitals.hs
+++ b/code/Example/Drasil/SSP/Unitals.hs
@@ -394,8 +394,8 @@ sspUnitless = [earthqkLoadFctr, normToShear,scalFunc,
   numbSlices, minFunction, fsloc, index, varblU, varblV, fs_min,
   ufixme1, ufixme2]
 
-earthqkLoadFctr, normToShear, scalFunc, numbSlices, minFunction,
-  fsloc, index, varblU, varblV, ufixme1, ufixme2 :: DefinedQuantityDict
+earthqkLoadFctr, normToShear, scalFunc, numbSlices,
+  minFunction, fsloc, index, varblU, varblV :: DefinedQuantityDict
 
 earthqkLoadFctr = dqd' (dcc "K_c" (nounPhraseSP $ "earthquake load factor")
   ("proportionality factor of force that " ++

--- a/code/Example/Drasil/SWHS/Body.hs
+++ b/code/Example/Drasil/SWHS/Body.hs
@@ -44,7 +44,6 @@ import Drasil.SWHS.TMods (tModels, t1ConsThermE, s4_2_2_swhsTMods)
 import Drasil.SWHS.IMods (s4_2_5_IMods)
 import Drasil.SWHS.DataDefs (dd1HtFluxC, dd2HtFluxP, s4_2_4_swhsDataDefs, swhsDataDefs)
 import Drasil.SWHS.GenDefs (swhsGenDefs)
-import Drasil.SWHS.References (s9_swhs_citations)
 import Drasil.SWHS.Assumptions (swhsRefDB, swhsAssumptions, assump3, assump4, assump5,
   assump6, assump13, assump15, assump16, assump17, assump18)
 import Drasil.SWHS.Requirements (req1, req2, s5_1_2_Eqn1, s5_1_2_Eqn2,
@@ -55,7 +54,7 @@ import Drasil.SWHS.DataDesc (swhsInputMod)
 
 import qualified Drasil.SRS as SRS (inModel, missingP, likeChg,
   funcReq, propCorSol, genDefn, dataDefn, thModel, probDesc, goalStmt,
-  sysCont, reference, assumpt)
+  sysCont, reference)
 
 import Drasil.DocumentLanguage (DocDesc, mkDoc, tsymb'',
   LFunc (TermExcept),

--- a/code/Example/Drasil/SWHS/GenDefs.hs
+++ b/code/Example/Drasil/SWHS/GenDefs.hs
@@ -16,7 +16,6 @@ import Data.Drasil.SentenceStructures (isThe, sAnd)
 import Data.Drasil.Utils (getES, unwrap)
 import Data.Drasil.Concepts.Math (equation, rOfChng, rate)
 import Data.Drasil.Concepts.Thermodynamics (law_conv_cooling)
-import Data.Drasil.Concepts.Documentation (assumption)
 import Drasil.SWHS.Assumptions
 
 ---------------------------

--- a/code/Example/Drasil/Sections/SolutionCharacterSpec.hs
+++ b/code/Example/Drasil/Sections/SolutionCharacterSpec.hs
@@ -278,7 +278,7 @@ genericSect (SectionModel niname xs) = section (pullTitle xs niname)
 ------------------------------------------------
 
 systemConstraintSect :: SubSec -> Section
-systemConstraintSect (SectionModel niname xs) = SRS.sysCon
+systemConstraintSect (SectionModel _ xs) = SRS.sysCon
   ((systemConstraintIntro (pullSents xs)):(pullContents xs)) (pullSections xs)
 
 -------------------------------------------------
@@ -286,11 +286,11 @@ systemConstraintSect (SectionModel niname xs) = SRS.sysCon
 -------------------------------------------------
 
 termDefinitionSect :: SubSec -> Section
-termDefinitionSect (SectionModel niname xs) = SRS.termAndDefn
+termDefinitionSect (SectionModel _ xs) = SRS.termAndDefn
   ((termDefinitionIntro (pullSents xs)):(pullContents xs)) (pullSections xs)
 
 goalStatementSect :: SubSec -> Section
-goalStatementSect (SectionModel niname xs) = SRS.goalStmt
+goalStatementSect (SectionModel _ xs) = SRS.goalStmt
   ((goalStatementIntro (pullSents xs)):(pullContents xs)) (pullSections xs)
 
 -----------------------------------------------------------
@@ -298,12 +298,12 @@ goalStatementSect (SectionModel niname xs) = SRS.goalStmt
 -----------------------------------------------------------
 
 assumptionSect :: SubSec -> Section
-assumptionSect (SectionModel niname xs) = SRS.assumpt
+assumptionSect (SectionModel _ xs) = SRS.assumpt
   (assumpIntro:(pullContents xs)) (pullSections xs)
 
 
 theoreticalModelSect :: (Idea a, HasSymbolTable s) => SubSec -> s -> a -> Section
-theoreticalModelSect (SectionModel niname xs) _ progName = SRS.thModel
+theoreticalModelSect (SectionModel _ xs) _ progName = SRS.thModel
  ((tModIntro progName):theoreticalModels ++ 
   (pullContents xs)) (pullSections xs)
   where theoreticalModels = map symMap $ pullTMods xs
@@ -311,21 +311,21 @@ theoreticalModelSect (SectionModel niname xs) _ progName = SRS.thModel
 
 
 generalDefinitionSect :: (HasSymbolTable s) => SubSec -> s -> Section
-generalDefinitionSect (SectionModel niname xs) _ = SRS.genDefn
+generalDefinitionSect (SectionModel _ xs) _ = SRS.genDefn
   (generalDefsIntro:contents) (pullSections xs)
   where generalDefsIntro = generalDefinitionIntro contents
         contents         = (pullContents xs)
 
 
 instanceModelSect :: (HasSymbolTable s) => SubSec -> s -> Section
-instanceModelSect (SectionModel niname xs) _ = SRS.inModel
+instanceModelSect (SectionModel _ xs) _ = SRS.inModel
   (iModIntro:instanceModels ++ (pullContents xs)) (pullSections xs)
   where symMap         = Definition . Theory
         instanceModels = map symMap $ pullIMods xs
 
 
 dataDefinitionSect :: (HasSymbolTable s) => SubSec -> s -> Section
-dataDefinitionSect (SectionModel niname xs) _ = SRS.dataDefn
+dataDefinitionSect (SectionModel _ xs) _ = SRS.dataDefn
   (dataIntro:dataDefinitions ++ (pullContents xs)) (pullSections xs)
   where dataIntro       = dataDefinitionIntro $ pullSents xs
         symMap          = Definition . Data
@@ -333,7 +333,7 @@ dataDefinitionSect (SectionModel niname xs) _ = SRS.dataDefn
 
 
 dataConstraintSect :: SubSec -> Section
-dataConstraintSect (SectionModel niname xs) = SRS.datCon
+dataConstraintSect (SectionModel _ xs) = SRS.datCon
   ([dataConIntro, inputTable, outputTable] ++ (pullContents xs)) (pullSections xs)
   where dataConIntro = dataConstraintParagraph (pullContents xs) (pullSents xs)
         inputTable  = inDataConstTbl $ pullUQI xs

--- a/code/Language/Drasil/Code/Imperative/LanguageRenderer/CSharpRenderer.hs
+++ b/code/Language/Drasil/Code/Imperative/LanguageRenderer/CSharpRenderer.hs
@@ -110,9 +110,9 @@ unOpDoc' op = unOpDocD op
 objAccessDoc' :: Config -> Value -> Function -> Doc
 objAccessDoc' c v (Cast (Base Float) (Base String)) = funcAppDoc c "Double.Parse" [v]
 objAccessDoc' c v (ListExtend t) = valueDoc c v <> dot <> text "Add" <> parens (dftVal)
-    where dftVal = case t of Base bt   -> valueDoc c (defaultValue bt)
-                             List lt t  -> new <+> stateType c (List lt t) Dec <> parens (empty)
-                             _         -> error $ "ListExtend does not yet support list type " ++ render (doubleQuotes $ stateType c t Def)
+    where dftVal = case t of Base bt     -> valueDoc c (defaultValue bt)
+                             List lt t'  -> new <+> stateType c (List lt t') Dec <> parens (empty)
+                             _           -> error $ "ListExtend does not yet support list type " ++ render (doubleQuotes $ stateType c t Def)
 objAccessDoc' c v f = objAccessDocD c v f
 
 ioDoc' :: Config -> IOSt -> Doc

--- a/code/Language/Drasil/Code/Imperative/LanguageRenderer/CppRenderer.hs
+++ b/code/Language/Drasil/Code/Imperative/LanguageRenderer/CppRenderer.hs
@@ -234,9 +234,9 @@ objAccessDoc' c v   (Floor) = funcAppDoc c "floor" [v]
 objAccessDoc' c v   (Ceiling) = funcAppDoc c "ceil" [v]
 objAccessDoc' c v (Cast (Base Float) (Base String)) = funcAppDoc c "std::stod" [v]
 objAccessDoc' c v (ListExtend t) = valueDoc c v <> dot <> text "push_back" <> parens (dftVal)
-    where dftVal = case t of Base bt   -> valueDoc c (defaultValue bt)
-                             List lt t  -> stateType c (List lt t) Dec <> parens (empty)
-                             _         -> error $ "ListExtend does not yet support list type " ++ render (doubleQuotes $ stateType c t Def)
+    where dftVal = case t of Base bt     -> valueDoc c (defaultValue bt)
+                             List lt t'  -> stateType c (List lt t') Dec <> parens (empty)
+                             _           -> error $ "ListExtend does not yet support list type " ++ render (doubleQuotes $ stateType c t Def)
 objAccessDoc' c v f = objAccessDocD c v f
 
 objVarDoc' :: Config -> Value -> Value -> Doc

--- a/code/Language/Drasil/Code/Imperative/LanguageRenderer/JavaRenderer.hs
+++ b/code/Language/Drasil/Code/Imperative/LanguageRenderer/JavaRenderer.hs
@@ -152,9 +152,9 @@ objAccessDoc' c v Floor = funcAppDoc c "Math.floor" [v]
 objAccessDoc' c v Ceiling = funcAppDoc c "Math.ceil" [v]
 objAccessDoc' c v (Cast (Base Float) (Base String)) = funcAppDoc c "Double.parseDouble" [v]
 objAccessDoc' c v (ListExtend t) = valueDoc c v <> dot <> text "add" <> parens (dftVal)
-    where dftVal = case t of Base bt   -> valueDoc c (defaultValue bt)
-                             List lt t  -> new <+> stateType c (List lt t) Dec <> parens (empty)
-                             _         -> error $ "ListExtend does not yet support list type " ++ render (doubleQuotes $ stateType c t Def)
+    where dftVal = case t of Base bt     -> valueDoc c (defaultValue bt)
+                             List lt t'  -> new <+> stateType c (List lt t') Dec <> parens (empty)
+                             _           -> error $ "ListExtend does not yet support list type " ++ render (doubleQuotes $ stateType c t Def)
 objAccessDoc' c v f = objAccessDocD c v f
 
 methodDoc' :: Config -> FileType -> Label -> Method -> Doc
@@ -165,8 +165,8 @@ methodDoc' c _ _ (Method n s p t ps b) = vcat [
     rbrace]
   where perm Dynamic = empty
         perm Static  = text "static "
-        throwState False = empty
-        throwState True  = text " throws Exception"
+        --throwState False = empty
+        --throwState True  = text " throws Exception"
 methodDoc' c _ _ (MainMethod b) = vcat [
     scopeDoc c Public <+> text "static" <+> methodTypeDoc c Void <+> text "main" <> parens (text "String[] args") 
       <+> text "throws Exception" <+> lbrace,  -- main throws exceptions for now, need to fix!
@@ -233,10 +233,9 @@ inputFn :: Config -> IOType -> Doc
 inputFn c Console = inputFunc c
 inputFn c (File f) = valueDoc c f
 
-
-
 -- check if method throws
-checkExceptions :: Body -> Bool
+-- FIXME: The following code calls itself recursively, and isn't used at all or exported.
+{-checkExceptions :: Body -> Bool
 checkExceptions b = foldl (||) False $ map checkExcBlock b
 
 checkExcBlock :: Block -> Bool
@@ -254,7 +253,7 @@ checkExc' (IterState (While _ b)) = checkExceptions b
 checkExc' (ExceptState _) = True
 checkExc' (IOState _) = True
 checkExc' (MultiState s) = checkExc s 
-checkExc' _ = False    
+checkExc' _ = False
                
 checkExcVB :: [(a, Body)] -> Bool
-checkExcVB vb = foldl (||) False $ map (\(_, b) -> checkExceptions b) vb 
+checkExcVB vb = foldl (||) False $ map (\(_, b) -> checkExceptions b) vb-}

--- a/code/Language/Drasil/NounPhrase.hs
+++ b/code/Language/Drasil/NounPhrase.hs
@@ -217,8 +217,8 @@ findNotCaps s = concat $ intersperse " " ((head $ words s) : map isNotCaps (tail
 
 isNotCaps :: String -> String
 isNotCaps (c:cs)
-  	| not ((isLetter c) && (isLatin1 c)) = (toLower c) : cs
-  	| ((toLower c) : cs) `elem` doNotCaps = (toLower c) : cs
+    | not ((isLetter c) && (isLatin1 c)) = (toLower c) : cs
+    | ((toLower c) : cs) `elem` doNotCaps = (toLower c) : cs
 isNotCaps s = s
 
 doNotCaps :: [String]


### PR DESCRIPTION
I removed all warnings (redundancies, missing type declarations, etc.) when running `make` in the master branch. The following warnings persist:

1. In Goal.hs and AssumpChunk.hs, fields exist that aren't used in the file, but I'm sure that will be better implemented in the future and/or are used in other places in Drasil:

https://github.com/JacquesCarette/Drasil/blob/b6503677bf43a9f4ba41c2e0354fa3ae4fa919f4/code/Language/Drasil/Chunk/Goal.hs#L18-L26
https://github.com/JacquesCarette/Drasil/blob/b6503677bf43a9f4ba41c2e0354fa3ae4fa919f4/code/Language/Drasil/Chunk/AssumpChunk.hs#L16-L21

2. In Attribute.hs, it throws a "redundant pattern match" warning when I don't think it is:

https://github.com/JacquesCarette/Drasil/blob/b6503677bf43a9f4ba41c2e0354fa3ae4fa919f4/code/Language/Drasil/Chunk/Attribute.hs#L19-L25

3. In SSP/BasicExprs.hs, it says that the following imports are redundant, when they are very much not:

https://github.com/JacquesCarette/Drasil/blob/b6503677bf43a9f4ba41c2e0354fa3ae4fa919f4/code/Example/Drasil/SSP/BasicExprs.hs#L7-L29

4. In SSP/Main.hs, SWHS/Generate.hs, and HGHC/Main.hs, it says that sspChoices, swhsChoices, and thisChoices, respectively, are defined but not used, but @niazim3 said that these were to be ignored then they were first implemented:

https://github.com/JacquesCarette/Drasil/blob/b6503677bf43a9f4ba41c2e0354fa3ae4fa919f4/code/Example/Drasil/SSP/Main.hs#L10-L20
https://github.com/JacquesCarette/Drasil/blob/b6503677bf43a9f4ba41c2e0354fa3ae4fa919f4/code/Example/Drasil/SWHS/Generate.hs#L7-L17
https://github.com/JacquesCarette/Drasil/blob/b6503677bf43a9f4ba41c2e0354fa3ae4fa919f4/code/Example/Drasil/HGHC/Main.hs#L7-L17
