### PR TITLE
Replace RefName completely

### DIFF
--- a/code/Example/Drasil/DocumentLanguage.hs
+++ b/code/Example/Drasil/DocumentLanguage.hs
@@ -510,8 +510,8 @@ siSys (SI {_sys = sys}) = nw sys
 -- mkAssump i desc = Assumption $ ac' i desc
 
 mkRequirement :: String -> Sentence -> String -> Contents
-mkRequirement i desc shrtn = Requirement $ frc i desc (shrtn) [shortname' shrtn] --FIXME: HACK - Should have explicit refname
+mkRequirement i desc shrtn = Requirement $ frc i desc shrtn [shortname' shrtn]
 
 mkLklyChnk :: String -> Sentence -> String -> Contents
-mkLklyChnk i desc shrtn = Change $ lc i desc (shrtn) [shortname' shrtn] -- FIXME: HACK -- See above
+mkLklyChnk i desc shrtn = Change $ lc i desc shrtn [shortname' shrtn]
 

--- a/code/Language/Drasil/Chunk/AssumpChunk.hs
+++ b/code/Language/Drasil/Chunk/AssumpChunk.hs
@@ -7,8 +7,8 @@ module Language.Drasil.Chunk.AssumpChunk
 import Language.Drasil.Classes (HasUID(uid), HasAttributes(attributes))
 import Language.Drasil.Chunk.Attribute (shortname')
 import Language.Drasil.Chunk.Attribute.Core (Attributes)
-import Language.Drasil.Spec (Sentence(..), RefName)
-
+import Language.Drasil.Spec (Sentence(..))
+import Language.Drasil.Chunk.Attribute.ShortName
 import Control.Lens (makeLenses, (^.))
 
 -- | Assumption chunk type. Has id, what is being assumed, and attributes.
@@ -16,7 +16,7 @@ import Control.Lens (makeLenses, (^.))
 data AssumpChunk = AC 
                  { _aid :: String
                  , assuming :: Sentence
-                 , _refName :: RefName -- HACK for refs?. No spaces/special chars allowed
+                 , _refName :: ShortName
                  , _attribs :: Attributes
                  }
 makeLenses ''AssumpChunk
@@ -24,8 +24,10 @@ makeLenses ''AssumpChunk
 instance HasUID        AssumpChunk where uid = aid
 instance HasAttributes AssumpChunk where attributes = attribs
 instance Eq            AssumpChunk where a == b = a ^. uid == b ^. uid
-  
+instance HasShortName  AssumpChunk where
+  shortname (AC _ _ sn _) = sn
+
 -- | Smart constructor for Assumption chunks. The second 'Sentence' here is 
 -- a short name (attribute).
-assump :: String -> Sentence -> RefName -> Attributes -> AssumpChunk
+assump :: String -> Sentence -> ShortName -> Attributes -> AssumpChunk
 assump i a s att = AC i a s ((shortname' s):att)

--- a/code/Language/Drasil/Chunk/Attribute/Core.hs
+++ b/code/Language/Drasil/Chunk/Attribute/Core.hs
@@ -2,7 +2,6 @@ module Language.Drasil.Chunk.Attribute.Core
   ( Attributes, Attribute(..)
   ) where
 
-import Language.Drasil.Chunk.Attribute.Derivation (Derivation)
 
 -- | Attributes are just a list of 'Attribute'
 type Attributes = [Attribute]

--- a/code/Language/Drasil/Chunk/Attribute/ShortName.hs
+++ b/code/Language/Drasil/Chunk/Attribute/ShortName.hs
@@ -1,9 +1,6 @@
 {-# Language TemplateHaskell #-}
 module Language.Drasil.Chunk.Attribute.ShortName where
 
-
-import Language.Drasil.Classes (HasUID(uid))
-import Language.Drasil.Chunk.AssumpChunk as A
 import Language.Drasil.Chunk.Change as Ch
 import Language.Drasil.Chunk.Citation as Ci
 import Language.Drasil.Chunk.Eq
@@ -13,14 +10,13 @@ import Language.Drasil.Chunk.InstanceModel
 import Language.Drasil.Chunk.PhysSystDesc as PD
 import Language.Drasil.Chunk.ReqChunk as R
 import Language.Drasil.Chunk.Theory
-import Language.Drasil.Document
 import Control.Lens ((^.))
-import Language.Drasil.Spec (Sentence(..), RefName)
 
---data ShortNm = ShortName String
+--hack to think of ShortName as a Strings
+type ShortName = String
 
 class HasShortName  s where
-  shortname :: s -> RefName -- String; The text to be displayed for the link.
+  shortname :: s -> ShortName -- String; The text to be displayed for the link.
                             -- A short name used for referencing within a document that can 
                             -- include symbols and whatnot if required.
                             -- Visible in the typeset documents (pdf)
@@ -32,17 +28,11 @@ instance HasShortName  Goal where
 instance HasShortName  PhysSystDesc where
   shortname p = p ^. PD.refAddr
 
-instance HasShortName  AssumpChunk where
-  shortname (AC _ _ sn _) = sn
-
 instance HasShortName  ReqChunk where
   shortname (RC _ _ _ sn _)   = sn
 
 instance HasShortName  Change where
   shortname (ChC _ _ _ sn _)     = sn
-
-instance HasShortName  Section where
-  shortname (Section _ _ _ sn) = sn
 
 instance HasShortName  Citation where
   shortname c = citeID c
@@ -61,32 +51,3 @@ instance HasShortName  QDefinition where -- FIXME: This could lead to trouble; n
 
 instance HasShortName  InstanceModel where
   shortname _ = error "No explicit name given for instance model -- build a custom Ref"
-
-instance HasShortName  Contents where
-  shortname (Table _ _ _ _ r)     = "Table:" ++ r
-  shortname (Figure _ _ _ r)      = "Figure:" ++ r
-  shortname (Graph _ _ _ _ r)     = "Figure:" ++ r
-  shortname (EqnBlock _ r)        = "Equation:" ++ r
-  shortname (Definition d)        = getDefName d
-  shortname (Defnt _ _ r)         = r
-  shortname (Requirement rc)      = shortname rc
-  shortname (Assumption ca)       = shortname ca
-  shortname (Change lcc)          = shortname lcc
-  shortname (Enumeration _)       = error "Can't reference lists"
-  shortname (Paragraph _)         = error "Can't reference paragraphs"
-  shortname (Bib _)               = error $
-    "Bibliography list of references cannot be referenced. " ++
-    "You must reference the Section or an individual citation."
-
--- | Automatically create the label for a definition
-getDefName :: DType -> String
-getDefName (Data c)   = "DD:" ++ concatMap repUnd (c ^. uid) -- FIXME: To be removed
-getDefName (Theory c) = "T:" ++ concatMap repUnd (c ^. uid) -- FIXME: To be removed
-getDefName TM         = "T:"
-getDefName DD         = "DD:"
-getDefName Instance   = "IM:"
-getDefName General    = "GD:"
-
-repUnd :: Char -> String
-repUnd '_' = "."
-repUnd c = c : []

--- a/code/Language/Drasil/Chunk/Attribute/ShortName.hs
+++ b/code/Language/Drasil/Chunk/Attribute/ShortName.hs
@@ -1,7 +1,6 @@
 {-# Language TemplateHaskell #-}
 module Language.Drasil.Chunk.Attribute.ShortName where
 
-import Language.Drasil.Chunk.Change as Ch
 import Language.Drasil.Chunk.Citation as Ci
 import Language.Drasil.Chunk.Eq
 import Language.Drasil.Chunk.GenDefn
@@ -30,9 +29,6 @@ instance HasShortName  PhysSystDesc where
 
 instance HasShortName  ReqChunk where
   shortname (RC _ _ _ sn _)   = sn
-
-instance HasShortName  Change where
-  shortname (ChC _ _ _ sn _)     = sn
 
 instance HasShortName  Citation where
   shortname c = citeID c

--- a/code/Language/Drasil/Chunk/Attribute/ShortName.hs
+++ b/code/Language/Drasil/Chunk/Attribute/ShortName.hs
@@ -1,15 +1,6 @@
 {-# Language TemplateHaskell #-}
 module Language.Drasil.Chunk.Attribute.ShortName where
 
-import Language.Drasil.Chunk.Citation as Ci
-import Language.Drasil.Chunk.Eq
-import Language.Drasil.Chunk.GenDefn
-import Language.Drasil.Chunk.Goal as G
-import Language.Drasil.Chunk.InstanceModel
-import Language.Drasil.Chunk.PhysSystDesc as PD
-import Language.Drasil.Chunk.Theory
-import Control.Lens ((^.))
-
 --hack to think of ShortName as a Strings
 type ShortName = String
 
@@ -18,28 +9,3 @@ class HasShortName  s where
                             -- A short name used for referencing within a document that can 
                             -- include symbols and whatnot if required.
                             -- Visible in the typeset documents (pdf)
-                            
-
-instance HasShortName  Goal where
-  shortname g = g ^. G.refAddr
-
-instance HasShortName  PhysSystDesc where
-  shortname p = p ^. PD.refAddr
-
-instance HasShortName  Citation where
-  shortname c = citeID c
-
--- error used below is on purpose. These shortnames should be made explicit as necessary
-instance HasShortName  TheoryModel where
-  shortname _ = error "No explicit name given for theory model -- build a custom Ref"
-
-instance HasShortName  GenDefn where
-  shortname _ = error "No explicit name given for general definition -- build a custom Ref"
-
-instance HasShortName  QDefinition where -- FIXME: This could lead to trouble; need
-                                     -- to ensure sanity checking when building
-                                     -- Refs. Double-check QDef is a DD before allowing
-  shortname _ = error "No explicit name given for data definition -- build a custom Ref"
-
-instance HasShortName  InstanceModel where
-  shortname _ = error "No explicit name given for instance model -- build a custom Ref"

--- a/code/Language/Drasil/Chunk/Attribute/ShortName.hs
+++ b/code/Language/Drasil/Chunk/Attribute/ShortName.hs
@@ -7,7 +7,6 @@ import Language.Drasil.Chunk.GenDefn
 import Language.Drasil.Chunk.Goal as G
 import Language.Drasil.Chunk.InstanceModel
 import Language.Drasil.Chunk.PhysSystDesc as PD
-import Language.Drasil.Chunk.ReqChunk as R
 import Language.Drasil.Chunk.Theory
 import Control.Lens ((^.))
 
@@ -26,9 +25,6 @@ instance HasShortName  Goal where
 
 instance HasShortName  PhysSystDesc where
   shortname p = p ^. PD.refAddr
-
-instance HasShortName  ReqChunk where
-  shortname (RC _ _ _ sn _)   = sn
 
 instance HasShortName  Citation where
   shortname c = citeID c

--- a/code/Language/Drasil/Chunk/Change.hs
+++ b/code/Language/Drasil/Chunk/Change.hs
@@ -5,8 +5,9 @@ module Language.Drasil.Chunk.Change
 
 import Language.Drasil.Classes (HasUID(uid),HasAttributes(attributes))
 import Language.Drasil.Chunk.Attribute.Core(Attributes)
+import Language.Drasil.Chunk.Attribute.ShortName
 import Language.Drasil.Chunk.Attribute(shortname')
-import Language.Drasil.Spec (Sentence, RefName)
+import Language.Drasil.Spec (Sentence)
 
 import Control.Lens (set, (^.))
 
@@ -30,22 +31,24 @@ data Change = ChC
   { _id      :: String
   , chngType :: ChngType 
   , chng     :: Sentence
-  , _refName :: RefName -- HACK for refs?
+  , _refName :: ShortName
   , _atts    :: Attributes
   }
   
 instance HasUID        Change where uid f (ChC a b c d e) = fmap (\x -> ChC x b c d e) (f a)
 instance HasAttributes Change where attributes f (ChC a b c d e) = fmap (\x -> ChC a b c d x) (f e)
 instance Eq            Change where a == b = a ^. uid == b ^. uid
+instance HasShortName  Change where
+  shortname (ChC _ _ _ sn _)     = sn
 
 -- | Smart constructor for requirement chunks (should not be exported)
-chc :: String -> ChngType -> Sentence -> RefName -> Attributes -> Change
+chc :: String -> ChngType -> Sentence -> ShortName -> Attributes -> Change
 chc = ChC
 
 chc' :: Change -> String -> Change
 chc' c s = set attributes ([shortname' s] ++ (c ^. attributes)) c
 
-lc, ulc :: String -> Sentence -> RefName -> Attributes -> Change
+lc, ulc :: String -> Sentence -> ShortName -> Attributes -> Change
 -- | Smart constructor for functional requirement chunks.
 lc i = chc i Likely
 

--- a/code/Language/Drasil/Chunk/Citation.hs
+++ b/code/Language/Drasil/Chunk/Citation.hs
@@ -26,6 +26,7 @@ import Language.Drasil.People
 import Language.Drasil.Spec (Sentence(..))
 import Language.Drasil.Classes (HasUID(uid))
 import Language.Drasil.Printing.Helpers (noSpaces)
+import Language.Drasil.Chunk.Attribute.ShortName
 
 type BibRef = [Citation]
 type EntryID = String -- Should contain no spaces
@@ -101,6 +102,7 @@ cite i = Cite i (noSpaces i)
 
 -- | Citations are chunks.
 instance HasUID Citation where uid f (Cite a b c d) = fmap (\x -> Cite x b c d) (f a)
+instance HasShortName  Citation where shortname c = citeID c
 
 -- | External references come in many flavours. Articles, Books, etc.
 -- (we are using the types available in Bibtex)

--- a/code/Language/Drasil/Chunk/Eq.hs
+++ b/code/Language/Drasil/Chunk/Eq.hs
@@ -18,6 +18,7 @@ import Language.Drasil.Unit (unitWrapper)
 import Language.Drasil.Symbol (Symbol)
 import Language.Drasil.Space
 import Language.Drasil.Chunk.Attribute.Derivation
+import Language.Drasil.Chunk.Attribute.ShortName
 
 import Language.Drasil.NounPhrase (NP)
 import Language.Drasil.Spec (Sentence)

--- a/code/Language/Drasil/Chunk/Eq.hs
+++ b/code/Language/Drasil/Chunk/Eq.hs
@@ -43,7 +43,12 @@ instance HasAttributes QDefinition where attributes = qua . attributes
 instance HasReference  QDefinition where getReferences = ref
 instance Eq            QDefinition where a == b = (a ^. uid) == (b ^. uid)
 instance HasDerivation QDefinition where derivations = deri
- 
+-- error used below is on purpose. These shortnames should be made explicit as necessary
+instance HasShortName  QDefinition where -- FIXME: This could lead to trouble; need
+                                         -- to ensure sanity checking when building
+                                         -- Refs. Double-check QDef is a DD before allowing
+  shortname _ = error "No explicit name given for data definition -- build a custom Ref"
+
 -- | Create a 'QDefinition' with an uid, noun phrase (term), definition, symbol,
 -- unit, and defining equation.  And it ignores the definition...
 --FIXME: Space hack

--- a/code/Language/Drasil/Chunk/GenDefn.hs
+++ b/code/Language/Drasil/Chunk/GenDefn.hs
@@ -37,6 +37,9 @@ instance ExprRelat     GenDefn where relat = relC . relat
 instance HasDerivation GenDefn where derivations = deri
 instance HasAttributes GenDefn where attributes = attribs
 instance HasReference  GenDefn where getReferences = ref
+-- error used below is on purpose. These shortnames should be made explicit as necessary
+instance HasShortName  GenDefn where
+  shortname _ = error "No explicit name given for general definition -- build a custom Ref"
 
 gd :: (IsUnit u, DOM u ~ ConceptChunk) => RelationConcept -> Maybe u -> Derivation -> GenDefn
 gd r (Just u) derivs = GD r (Just (unitWrapper u)) [] derivs []

--- a/code/Language/Drasil/Chunk/GenDefn.hs
+++ b/code/Language/Drasil/Chunk/GenDefn.hs
@@ -13,6 +13,7 @@ import Language.Drasil.Chunk.Concept (ConceptChunk)
 import Language.Drasil.Chunk.Relation (RelationConcept)
 import Language.Drasil.Unit (unitWrapper, UnitDefn)
 import Language.Drasil.Chunk.Attribute.Derivation
+import Language.Drasil.Chunk.Attribute.ShortName
 
 import Control.Lens (makeLenses)
 

--- a/code/Language/Drasil/Chunk/GenDefn.hs
+++ b/code/Language/Drasil/Chunk/GenDefn.hs
@@ -19,8 +19,8 @@ import Control.Lens (makeLenses)
 -- | A GenDefn is a RelationConcept that may have units
 data GenDefn = GD { _relC :: RelationConcept
                   , gdUnit :: Maybe UnitDefn
-		  , _attribs :: Attributes
-		  , _deri :: Derivation
+                  , _attribs :: Attributes
+                  , _deri :: Derivation
                   , _ref :: References
                   }
 makeLenses ''GenDefn

--- a/code/Language/Drasil/Chunk/Goal.hs
+++ b/code/Language/Drasil/Chunk/Goal.hs
@@ -30,7 +30,9 @@ makeLenses ''Goal
 instance HasUID        Goal where uid = gid
 instance HasAttributes Goal where attributes = attribs
 instance Eq            Goal where a == b = a ^. uid == b ^. uid
-  
+instance HasShortName  Goal where
+  shortname g = g ^. refAddr
+
 -- | Goal smart constructor (with explicit 'Attributes')
 mkGoal :: String -> Sentence -> RefAdd -> Attributes -> Goal
 mkGoal = GS

--- a/code/Language/Drasil/Chunk/Goal.hs
+++ b/code/Language/Drasil/Chunk/Goal.hs
@@ -12,6 +12,7 @@ import Language.Drasil.Classes (HasUID(uid), HasAttributes(attributes))
 import Language.Drasil.Chunk.Attribute.Core (Attributes)
 import Language.Drasil.Spec (Sentence)
 import Language.Drasil.RefTypes (RefAdd)
+import Language.Drasil.Chunk.Attribute.ShortName
 
 import Control.Lens (makeLenses, (^.))
 

--- a/code/Language/Drasil/Chunk/InstanceModel.hs
+++ b/code/Language/Drasil/Chunk/InstanceModel.hs
@@ -54,7 +54,10 @@ instance ConceptDomain InstanceModel where
 instance ExprRelat     InstanceModel where relat = rc . relat
 instance HasAttributes InstanceModel where attributes = attribs
 instance HasDerivation InstanceModel where derivations = deri
+-- error used below is on purpose. These shortnames should be made explicit as necessary
 instance HasReference  InstanceModel where getReferences = ref
+instance HasShortName  InstanceModel where
+  shortname _ = error "No explicit name given for instance model -- build a custom Ref"
 
 -- | Smart constructor for instance models
 im :: RelationConcept -> Inputs -> InputConstraints -> Output -> 

--- a/code/Language/Drasil/Chunk/InstanceModel.hs
+++ b/code/Language/Drasil/Chunk/InstanceModel.hs
@@ -21,6 +21,7 @@ import Language.Drasil.Expr.Math (sy)
 import Language.Drasil.Expr.Extract (vars)
 import Language.Drasil.Spec (Sentence)
 import Language.Drasil.Chunk.Attribute.Derivation
+import Language.Drasil.Chunk.Attribute.ShortName
 
 import Control.Lens (makeLenses, (^.))
 
@@ -39,7 +40,7 @@ data InstanceModel = IM { _rc :: RelationConcept
                         , _outCons :: OutputConstraints
                         , _ref :: References
                         , _attribs :: Attributes 
- 			, _deri :: Derivation
+                        , _deri :: Derivation
                         }
 makeLenses ''InstanceModel
   

--- a/code/Language/Drasil/Chunk/PhysSystDesc.hs
+++ b/code/Language/Drasil/Chunk/PhysSystDesc.hs
@@ -13,7 +13,7 @@ import Language.Drasil.Classes (HasUID(uid), HasAttributes(attributes))
 import Language.Drasil.Chunk.Attribute.Core (Attributes)
 import Language.Drasil.Spec (Sentence)
 import Language.Drasil.RefTypes (RefAdd)
-
+import Language.Drasil.Chunk.Attribute.ShortName
 import Control.Lens (makeLenses, (^.))
 
 data PhysSystDesc = PSD
@@ -28,7 +28,9 @@ makeLenses ''PhysSystDesc
 instance HasUID        PhysSystDesc where uid = did
 instance HasAttributes PhysSystDesc where attributes = attribs
 instance Eq            PhysSystDesc where a == b = a ^. uid == b ^. uid
-  
+instance HasShortName  PhysSystDesc where
+  shortname p = p ^. refAddr
+
 -- | PhysSystDesc smart constructor (has no explicit 'Attributes')
 psd :: String -> Sentence -> RefAdd -> PhysSystDesc
 psd i g r = PSD i g r []

--- a/code/Language/Drasil/Chunk/ReqChunk.hs
+++ b/code/Language/Drasil/Chunk/ReqChunk.hs
@@ -6,7 +6,8 @@ module Language.Drasil.Chunk.ReqChunk
 import Language.Drasil.Classes (HasUID(uid), HasAttributes(attributes))
 import Language.Drasil.Chunk.Attribute (shortname')
 import Language.Drasil.Chunk.Attribute.Core (Attributes)
-import Language.Drasil.Spec (Sentence, RefName)
+import Language.Drasil.Chunk.Attribute.ShortName
+import Language.Drasil.Spec (Sentence)
 
 import Control.Lens (set, (^.))
 
@@ -34,22 +35,24 @@ data ReqChunk = RC
   { _id        :: String
   , reqType    :: ReqType 
   , requires   :: Sentence
-  , _refName   :: RefName -- HACK for refs?
+  , _refName   :: ShortName
   , _atts      :: Attributes
   }
   
 instance HasUID        ReqChunk where uid f (RC a b c d e) = fmap (\x -> RC x b c d e) (f a)
 instance HasAttributes ReqChunk where attributes f (RC a b c d e) = fmap (\x -> RC a b c d x) (f e)
 instance Eq            ReqChunk where a == b = a ^. uid == b ^. uid
+instance HasShortName  ReqChunk where
+  shortname (RC _ _ _ sn _)   = sn
 
 -- | Smart constructor for requirement chunks (should not be exported)
-rc :: String -> ReqType -> Sentence -> RefName -> Attributes -> ReqChunk
+rc :: String -> ReqType -> Sentence -> ShortName -> Attributes -> ReqChunk
 rc = RC
 
 rc' :: ReqChunk -> String -> ReqChunk
 rc' r s = set attributes (shortname' s : (r ^. attributes)) r
 
-frc, nfrc :: String -> Sentence -> RefName -> Attributes -> ReqChunk
+frc, nfrc :: String -> Sentence -> ShortName -> Attributes -> ReqChunk
 -- | Smart constructor for functional requirement chunks.
 frc i = rc i FR
 

--- a/code/Language/Drasil/Chunk/Theory.hs
+++ b/code/Language/Drasil/Chunk/Theory.hs
@@ -64,6 +64,9 @@ instance Idea          TheoryModel where getA = getA . view con
 instance Definition    TheoryModel where defn = con . defn
 instance HasAttributes TheoryModel where attributes = thy . attributes
 instance HasReference  TheoryModel where getReferences = thy . getReferences
+-- error used below is on purpose. These shortnames should be made explicit as necessary
+instance HasShortName  TheoryModel where
+  shortname _ = error "No explicit name given for theory model -- build a custom Ref"
 instance ConceptDomain TheoryModel where
   type DOM TheoryModel = ConceptChunk
   cdom = con . cdom

--- a/code/Language/Drasil/Chunk/Theory.hs
+++ b/code/Language/Drasil/Chunk/Theory.hs
@@ -12,6 +12,7 @@ import Language.Drasil.Chunk.Eq
 import Language.Drasil.Chunk.Quantity
 import Language.Drasil.Chunk.Attribute.Core (Attributes)
 import Language.Drasil.Chunk.Attribute.References (References)
+import Language.Drasil.Chunk.Attribute.ShortName
 
 import Control.Lens (Lens', view, makeLenses)
 

--- a/code/Language/Drasil/Printing/Import.hs
+++ b/code/Language/Drasil/Printing/Import.hs
@@ -31,7 +31,6 @@ import Language.Drasil.Spec (Sentence(..))
 import Language.Drasil.Misc (unit'2Contents)
 import Language.Drasil.NounPhrase (phrase, titleize)
 import Language.Drasil.Reference
-import Language.Drasil.Chunk.Attribute.ShortName
 import Language.Drasil.Document
 
 import Control.Lens ((^.))

--- a/code/Language/Drasil/Reference.hs
+++ b/code/Language/Drasil/Reference.hs
@@ -185,7 +185,6 @@ instance Referable Citation where
   refAdd c = concatMap repUnd $ citeID c -- citeID should be unique.
   rType _ = Cite
 
--- error used below is on purpose. These refNames should be made explicit as necessary
 instance Referable TheoryModel where
   refAdd  t = "T:" ++ t ^. uid
   rType   _ = Def
@@ -253,7 +252,7 @@ assumptionsFromDB am = dropNums $ sortBy (compare `on` snd) assumptions
 makeRef :: (HasShortName l, Referable l) => l -> Sentence
 makeRef r = customRef r (shortname r)
 
--- | Create a reference with a custom 'RefName'
+-- | Create a reference with a custom 'ShortName'
 customRef :: (HasShortName l, Referable l) => l -> String -> Sentence
 customRef r n = Ref (rType r) (refAdd r) n
 

--- a/code/Language/Drasil/Spec.hs
+++ b/code/Language/Drasil/Spec.hs
@@ -7,9 +7,8 @@ import Language.Drasil.Symbol
 import Language.Drasil.Expr
 import Language.Drasil.RefTypes
 import Language.Drasil.UnitLang (USymb)
+import Language.Drasil.Chunk.Attribute.ShortName
 
--- | One slight hack remaining
-type RefName = String
 
 -- | For writing "sentences" via combining smaller elements
 -- Sentences are made up of some known vocabulary of things:
@@ -24,8 +23,8 @@ data Sentence where
   S     :: String -> Sentence       -- Strings, used for Descriptions in Chunks
   Sp    :: Special -> Sentence
   P     :: Symbol -> Sentence
-  Ref   :: RefType -> RefAdd -> RefName -> Sentence  -- Needs helper func to create Ref
-                                    -- See Reference.hs
+  Ref   :: RefType -> RefAdd -> ShortName -> Sentence  -- Needs helper func to create Ref
+                                                       -- See Reference.hs
   Quote :: Sentence -> Sentence     -- Adds quotation marks around a sentence
                                     
   -- Direct concatenation of two Sentences (no implicit spaces!)

--- a/code/Language/Drasil/TeX/Print.hs
+++ b/code/Language/Drasil/TeX/Print.hs
@@ -324,7 +324,7 @@ makeDefTable :: HasSymbolTable s => s -> [(String,[LayoutObj])] -> D -> D
 makeDefTable _ [] _ = error "Trying to make empty Data Defn"
 makeDefTable sm ps l = vcat [
   pure $ text $ "\\begin{tabular}{p{"++show colAwidth++"\\textwidth} p{"++show colBwidth++"\\textwidth}}",
-  (pure $ text "\\toprule \\textbf{Refname} & \\textbf{") <> l <> (pure $ text "}"),
+  (pure $ text "\\toprule \\textbf{Refname} & \\textbf{") <> l <> (pure $ text "}"), --shortname instead of refname?
   (pure $ text "\\phantomsection "), label l,
   makeDRows sm ps,
   pure $ dbs <+> text ("\\bottomrule \\end{tabular}")


### PR DESCRIPTION
- Replaced `RefName` alias with `ShortName` one
- moved instance definitions for `HasShortName` for the chunks into their own files to avoid import cycles