### PR TITLE
Remove DOM and Update Lookup Functions.

### DIFF
--- a/code/Language/Drasil/Chunk/Concept.hs
+++ b/code/Language/Drasil/Chunk/Concept.hs
@@ -6,7 +6,7 @@ module Language.Drasil.Chunk.Concept
   )where
 
 import Language.Drasil.Classes (HasUID(uid), Idea, Definition(defn),
-  ConceptDomain(cdom,DOM), Concept)
+  ConceptDomain(cdom), Concept)
 import Language.Drasil.Chunk.NamedIdea(mkIdea,nw)
 import Language.Drasil.Chunk.CommonIdea (commonIdea)
 import Language.Drasil.Spec
@@ -49,5 +49,5 @@ ccs :: (Idea c, Concept d) => c -> Sentence -> [d] -> ConceptChunk --Explicit ta
 ccs n d l = ConDict (nw n) (DAD d $ map (\x -> x ^. uid) l)
 
 -- | For projecting out to the ConceptChunk data-type
-cw :: (Concept c, DOM c ~ ConceptChunk) => c -> ConceptChunk
+cw :: Concept c => c -> ConceptChunk
 cw c = ConDict (nw c) $ DAD (c ^. defn) (c ^. cdom)

--- a/code/Language/Drasil/Chunk/Concept/Core.hs
+++ b/code/Language/Drasil/Chunk/Concept/Core.hs
@@ -6,7 +6,7 @@ import Language.Drasil.Chunk.NamedIdea (IdeaDict)
 import Language.Drasil.Chunk.CommonIdea (CI)
 import Language.Drasil.UID (UID)
 import Language.Drasil.Classes (HasUID(uid), NamedIdea(term), Idea(getA),
-  Definition(defn), ConceptDomain(DOM,cdom), Concept, CommonIdea(abrv))
+  Definition(defn), ConceptDomain(cdom), Concept, CommonIdea(abrv))
 
 import Control.Lens (makeLenses, (^.), view)
 
@@ -23,7 +23,6 @@ makeLenses ''ConceptChunk
 
 instance Definition    DefnAndDomain where defn = defn'
 instance ConceptDomain DefnAndDomain where
-  type DOM DefnAndDomain = ConceptChunk
   cdom = cdom'
 
 instance Eq            ConceptChunk where c1 == c2 = (c1 ^. uid) == (c2 ^. uid)
@@ -32,7 +31,6 @@ instance NamedIdea     ConceptChunk where term = idea . term
 instance Idea          ConceptChunk where getA = getA . view idea
 instance Definition    ConceptChunk where defn = dad . defn'
 instance ConceptDomain ConceptChunk where
-  type DOM ConceptChunk = ConceptChunk
   cdom = dad . cdom'
 instance Concept       ConceptChunk where
  
@@ -46,7 +44,6 @@ instance Idea          CommonConcept where getA = getA . view comm
 instance Definition    CommonConcept where defn = def
 instance CommonIdea    CommonConcept where abrv = abrv . view comm
 instance ConceptDomain CommonConcept where 
-  type DOM CommonConcept = ConceptChunk
   cdom = dom
 instance Concept       CommonConcept where
 

--- a/code/Language/Drasil/Chunk/Constrained.hs
+++ b/code/Language/Drasil/Chunk/Constrained.hs
@@ -21,7 +21,7 @@ import Language.Drasil.Unit (unitWrapper)
 import Language.Drasil.Space
 import Language.Drasil.Symbol (Symbol)
 import Language.Drasil.Classes (HasUID(uid), NamedIdea(term), Idea(getA),
-  Definition(defn), ConceptDomain(cdom, DOM), Concept, HasSymbol(symbol),
+  Definition(defn), ConceptDomain(cdom), Concept, HasSymbol(symbol),
   IsUnit, Constrained(constraints), HasReasVal(reasVal))
 
 -- | ConstrainedChunks are 'Symbolic Quantities'
@@ -47,7 +47,7 @@ constrained :: (Quantity c) => c -> [Constraint] -> Expr -> ConstrainedChunk
 constrained q cs ex = ConstrainedChunk (qw q) cs (Just ex)
 
 -- | Creates a constrained unitary
-cuc :: (IsUnit u, DOM u ~ ConceptChunk) => String -> NP -> Symbol -> u
+cuc :: (IsUnit u, ConceptDomain u) => String -> NP -> Symbol -> u
                 -> Space -> [Constraint] -> Expr  -> ConstrainedChunk
 cuc i t s u space cs rv =
   ConstrainedChunk (qw (unitary i t s u space)) cs (Just rv)
@@ -78,22 +78,21 @@ instance HasSymbol     ConstrConcept where symbol c = symbol (c^.defq)
 instance Quantity      ConstrConcept where getUnit = getUnit . view defq
 instance Definition    ConstrConcept where defn = defq . defn
 instance ConceptDomain ConstrConcept where
-  type DOM ConstrConcept = ConceptChunk
   cdom = defq . cdom
 instance Concept       ConstrConcept where
 instance Constrained   ConstrConcept where constraints  = constr'
 instance HasReasVal    ConstrConcept where reasVal      = reasV'
 instance Eq            ConstrConcept where c1 == c2 = (c1 ^.defq.uid) == (c2 ^.defq.uid)
 
-constrained' :: (HasSpace c, HasSymbol c, Concept c, Quantity c, DOM c ~ ConceptChunk) =>
+constrained' :: (HasSpace c, HasSymbol c, Concept c, Quantity c) =>
   c -> [Constraint] -> Expr -> ConstrConcept
 constrained' q cs rv = ConstrConcept (dqd' (cw q) (symbol q) (q ^. typ) (getUnit q)) cs (Just rv)
 
-constrainedNRV' :: (HasSpace c, HasSymbol c, Concept c, Quantity c, DOM c ~ ConceptChunk) => 
+constrainedNRV' :: (HasSpace c, HasSymbol c, Concept c, Quantity c) =>
   c -> [Constraint] -> ConstrConcept
 constrainedNRV' q cs = ConstrConcept (dqd' (cw q) (symbol q) (q ^. typ) (getUnit q)) cs Nothing
 
-cuc' :: (IsUnit u, DOM u ~ ConceptChunk) => String -> NP -> String -> Symbol -> u
+cuc' :: (IsUnit u, ConceptDomain u) => String -> NP -> String -> Symbol -> u
             -> Space -> [Constraint] -> Expr -> ConstrConcept
 cuc' nam trm desc sym un space cs rv =
   ConstrConcept (dqd (cw (ucs nam trm desc sym un space)) sym space (Just uu)) cs (Just rv)

--- a/code/Language/Drasil/Chunk/DefinedQuantity.hs
+++ b/code/Language/Drasil/Chunk/DefinedQuantity.hs
@@ -5,7 +5,7 @@ module Language.Drasil.Chunk.DefinedQuantity
   ) where
 
 import Language.Drasil.Classes (HasUID(uid), NamedIdea(term), Idea(getA),
-  Definition(defn), ConceptDomain(cdom, DOM), Concept, HasSymbol(symbol),
+  Definition(defn), ConceptDomain(cdom), Concept, HasSymbol(symbol),
   HasSpace(typ), IsUnit, HasDerivation(derivations))
 import Language.Drasil.Chunk.Concept (ConceptChunk, cw)
 import qualified Language.Drasil.Chunk.Quantity as Q
@@ -33,7 +33,6 @@ instance NamedIdea     DefinedQuantityDict where term = con . term
 instance Idea          DefinedQuantityDict where getA = getA . view con
 instance Definition    DefinedQuantityDict where defn = con . defn
 instance ConceptDomain DefinedQuantityDict where
-  type DOM DefinedQuantityDict = ConceptChunk
   cdom = con . cdom
 instance Concept       DefinedQuantityDict where
 instance Q.HasSpace    DefinedQuantityDict where typ = spa
@@ -54,5 +53,5 @@ dqdEL :: (IsUnit u) => ConceptChunk -> Symbol -> Space -> u -> DefinedQuantityDi
 dqdEL c s sp un = DQD c (\_ -> s) sp uu []
   where uu = Just $ unitWrapper un
 
-dqdWr :: (Q.Quantity c, Concept c, Q.HasSpace c, HasSymbol c, DOM c ~ ConceptChunk) => c -> DefinedQuantityDict
+dqdWr :: (Q.Quantity c, Concept c, Q.HasSpace c, HasSymbol c) => c -> DefinedQuantityDict
 dqdWr c = DQD (cw c) (symbol c) (c ^. typ) (Q.getUnit c) []

--- a/code/Language/Drasil/Chunk/Eq.hs
+++ b/code/Language/Drasil/Chunk/Eq.hs
@@ -5,11 +5,10 @@ module Language.Drasil.Chunk.Eq
 
 import Control.Lens ((^.), makeLenses)
 import Language.Drasil.Expr (Expr)
-import Language.Drasil.Classes (HasUID(uid),NamedIdea(term), Idea(getA), DOM,
+import Language.Drasil.Classes (HasUID(uid),NamedIdea(term), Idea(getA),
   HasSymbol(symbol), IsUnit, ExprRelat(relat), HasDerivation(derivations), 
-  HasReference(getReferences))
+  HasReference(getReferences), ConceptDomain)
 import Language.Drasil.Chunk.Attribute.References (References)
-import Language.Drasil.Chunk.Concept (ConceptChunk)
 import Language.Drasil.Chunk.Quantity (Quantity(getUnit), HasSpace(typ), QuantityDict,
   mkQuant, qw)
 import Language.Drasil.Chunk.VarChunk (VarChunk, vcSt)
@@ -51,7 +50,7 @@ instance HasShortName  QDefinition where -- FIXME: This could lead to trouble; n
 -- | Create a 'QDefinition' with an uid, noun phrase (term), definition, symbol,
 -- unit, and defining equation.  And it ignores the definition...
 --FIXME: Space hack
-fromEqn :: (IsUnit u, DOM u ~ ConceptChunk) => 
+fromEqn :: (IsUnit u, ConceptDomain u) =>
   String -> NP -> Sentence -> Symbol -> u -> Expr -> References -> QDefinition
 fromEqn nm desc _ symb un eqn refs = 
   EC (mkQuant nm desc symb Real (Just $ unitWrapper un) Nothing) eqn refs []
@@ -63,7 +62,7 @@ fromEqn' nm desc _ symb eqn refs = EC (mkQuant nm desc symb Real Nothing Nothing
 
 -- | Create a 'QDefinition' with an uid, noun phrase (term), symbol,
 -- abbreviation, unit, and defining equation.
-fromEqn'' :: (IsUnit u, DOM u ~ ConceptChunk) => String -> NP -> Sentence ->
+fromEqn'' :: (IsUnit u, ConceptDomain u) => String -> NP -> Sentence ->
  Symbol -> String -> Maybe u -> Expr -> References -> QDefinition
 fromEqn'' nm desc _ symb abbr u eqn refs = 
   EC (mkQuant nm desc symb Real (fmap unitWrapper u) (Just abbr)) eqn refs []

--- a/code/Language/Drasil/Chunk/GenDefn.hs
+++ b/code/Language/Drasil/Chunk/GenDefn.hs
@@ -4,10 +4,9 @@ module Language.Drasil.Chunk.GenDefn
   ) where
 
 import Language.Drasil.Classes (HasUID(uid), NamedIdea(term), Idea(getA),
-  Definition(defn), ConceptDomain(cdom,DOM), Concept, IsUnit, 
+  Definition(defn), ConceptDomain(cdom), Concept, IsUnit,
   ExprRelat(relat), HasDerivation(derivations), HasReference(getReferences))
 import Language.Drasil.Chunk.Attribute.References (References)
-import Language.Drasil.Chunk.Concept (ConceptChunk)
 import Language.Drasil.Chunk.Relation (RelationConcept)
 import Language.Drasil.Unit (unitWrapper, UnitDefn)
 import Language.Drasil.Chunk.Attribute.Derivation
@@ -29,7 +28,6 @@ instance Idea          GenDefn where getA (GD a _ _ _) = getA a
 instance Concept       GenDefn where
 instance Definition    GenDefn where defn = relC . defn
 instance ConceptDomain GenDefn where
-  type DOM GenDefn = ConceptChunk
   cdom = relC . cdom
 instance ExprRelat     GenDefn where relat = relC . relat
 instance HasDerivation GenDefn where derivations = deri
@@ -38,6 +36,6 @@ instance HasReference  GenDefn where getReferences = ref
 instance HasShortName  GenDefn where
   shortname _ = error "No explicit name given for general definition -- build a custom Ref"
 
-gd :: (IsUnit u, DOM u ~ ConceptChunk) => RelationConcept -> Maybe u -> Derivation -> GenDefn
+gd :: (IsUnit u, ConceptDomain u) => RelationConcept -> Maybe u -> Derivation -> GenDefn
 gd r (Just u) derivs = GD r (Just (unitWrapper u)) derivs []
 gd r Nothing derivs = GD r Nothing derivs []

--- a/code/Language/Drasil/Chunk/InstanceModel.hs
+++ b/code/Language/Drasil/Chunk/InstanceModel.hs
@@ -5,12 +5,11 @@ module Language.Drasil.Chunk.InstanceModel
   )where
 
 import Language.Drasil.Classes (HasUID(uid), NamedIdea(term), Idea(getA),
-  Definition(defn),ConceptDomain(cdom,DOM), Concept, ExprRelat(relat),
+  Definition(defn),ConceptDomain(cdom), Concept, ExprRelat(relat),
   HasDerivation(derivations), HasReference(getReferences))
 import Language.Drasil.Chunk.Attribute.References (References)
 import Language.Drasil.Chunk.Attribute.Derivation
 import Language.Drasil.Chunk.Attribute.ShortName
-import Language.Drasil.Chunk.Concept
 import Language.Drasil.Chunk.Constrained.Core (TheoryConstraint)
 import Language.Drasil.Chunk.Eq
 import Language.Drasil.Chunk.Relation
@@ -47,7 +46,6 @@ instance Idea          InstanceModel where getA (IM a _ _ _ _ _ _) = getA a
 instance Concept       InstanceModel where
 instance Definition    InstanceModel where defn = rc . defn
 instance ConceptDomain InstanceModel where
-  type DOM InstanceModel = ConceptChunk
   cdom = rc . cdom
 instance ExprRelat     InstanceModel where relat = rc . relat
 instance HasDerivation InstanceModel where derivations = deri

--- a/code/Language/Drasil/Chunk/Relation.hs
+++ b/code/Language/Drasil/Chunk/Relation.hs
@@ -7,7 +7,7 @@ module Language.Drasil.Chunk.Relation
 import Control.Lens (makeLenses, (^.))
 import Language.Drasil.Expr (Relation)
 import Language.Drasil.Classes (HasUID(uid),NamedIdea(term),Idea(getA),
-  Definition(defn), ConceptDomain(cdom, DOM), Concept, ExprRelat(relat))
+  Definition(defn), ConceptDomain(cdom), Concept, ExprRelat(relat))
 import Language.Drasil.Chunk.Concept
 import Language.Drasil.Spec (Sentence(..))
 
@@ -23,7 +23,6 @@ instance NamedIdea     RelationConcept where term = conc . term
 instance Idea          RelationConcept where getA (RC c _) = getA c
 instance Definition    RelationConcept where defn = conc . defn
 instance ConceptDomain RelationConcept where
-  type DOM RelationConcept = ConceptChunk
   cdom = conc . cdom
 instance Concept       RelationConcept where
 instance ExprRelat     RelationConcept where relat = rel

--- a/code/Language/Drasil/Chunk/Theory.hs
+++ b/code/Language/Drasil/Chunk/Theory.hs
@@ -6,7 +6,7 @@ module Language.Drasil.Chunk.Theory
 
 import Language.Drasil.UID (UID)
 import Language.Drasil.Classes (HasUID(uid), NamedIdea(term), Idea(getA),
-  Definition(defn), ConceptDomain(cdom,DOM), Concept, HasReference(getReferences))
+  Definition(defn), ConceptDomain(cdom), Concept, HasReference(getReferences))
 import Language.Drasil.Chunk.Concept
 import Language.Drasil.Chunk.Constrained.Core (TheoryConstraint)
 import Language.Drasil.Chunk.Eq
@@ -66,7 +66,6 @@ instance HasReference  TheoryModel where getReferences = thy . getReferences
 instance HasShortName  TheoryModel where
   shortname _ = error "No explicit name given for theory model -- build a custom Ref"
 instance ConceptDomain TheoryModel where
-  type DOM TheoryModel = ConceptChunk
   cdom = con . cdom
 instance Concept       TheoryModel where
 instance Theory        TheoryModel where
@@ -78,15 +77,15 @@ instance Theory        TheoryModel where
   invariants    = thy . invariants
   defined_fun   = thy . defined_fun
 
-tc :: (DOM c ~ ConceptChunk, Concept c, Quantity q) =>
+tc :: (Concept c, Quantity q) =>
     String -> [TheoryChunk] -> [SpaceDefn] -> [q] -> [c] -> 
     [QDefinition] -> [TheoryConstraint] -> [QDefinition] -> TheoryChunk
 tc cid t s q c = \dq inv dfn -> TC cid t s (map qw q) (map cw c) dq inv dfn []
 
-tc' :: (Quantity q, Concept c, DOM c ~ ConceptChunk) =>
+tc' :: (Quantity q, Concept c) =>
     String -> [q] -> [c] -> [QDefinition] -> 
     [TheoryConstraint] -> [QDefinition] -> TheoryChunk
 tc' cid q c = tc cid ([] :: [TheoryChunk]) [] q c
 
-tm :: (Concept c, DOM c ~ ConceptChunk) => c -> TheoryChunk -> TheoryModel
+tm :: Concept c => c -> TheoryChunk -> TheoryModel
 tm c t = TM (cw c) t

--- a/code/Language/Drasil/Chunk/UncertainQuantity.hs
+++ b/code/Language/Drasil/Chunk/UncertainQuantity.hs
@@ -13,7 +13,7 @@ module Language.Drasil.Chunk.UncertainQuantity
   ) where
   
 import Language.Drasil.Classes (HasUID(uid), NamedIdea(term), Idea(getA),
-  Definition(defn), ConceptDomain(cdom, DOM), Concept, HasSymbol(symbol),
+  Definition(defn), ConceptDomain(cdom), Concept, HasSymbol(symbol),
   IsUnit, Constrained(constraints), HasReasVal(reasVal))
 import Language.Drasil.Chunk.Quantity
 import Language.Drasil.Chunk.DefinedQuantity (dqd')
@@ -85,32 +85,31 @@ instance Constrained       UncertQ where constraints = coco . constraints
 instance HasReasVal        UncertQ where reasVal = coco . reasVal
 instance Definition        UncertQ where defn = coco . defn
 instance ConceptDomain     UncertQ where
-  type DOM UncertQ = ConceptChunk
   cdom = coco . cdom
 instance Concept           UncertQ where
 
 {-- Constructors --}
 -- | The UncertainQuantity constructor. Requires a Quantity, a percentage, and a typical value
-uq :: (Quantity c, Constrained c, Concept c, HasReasVal c, DOM c ~ ConceptChunk) => 
+uq :: (Quantity c, Constrained c, Concept c, HasReasVal c) =>
   c -> Double -> UncertQ
 uq q u = UQ (ConstrConcept (dqd' (cw q) (symbol q) (q ^. typ) (getUnit q)) (q ^. constraints) (q ^. reasVal)) (Just u) 
 
-uqNU :: (Quantity c, Constrained c, Concept c, HasReasVal c, DOM c ~ ConceptChunk) =>
+uqNU :: (Quantity c, Constrained c, Concept c, HasReasVal c) =>
   c -> UncertQ
 uqNU q = UQ (ConstrConcept (dqd' (cw q) (symbol q) (q ^. typ) (getUnit q)) (q ^. constraints) (q ^. reasVal)) Nothing 
 
 -- this is kind of crazy and probably shouldn't be used!
-uqc :: (IsUnit u, DOM u ~ ConceptChunk) => String -> NP -> String -> Symbol -> u -> Space
+uqc :: (IsUnit u, ConceptDomain u) => String -> NP -> String -> Symbol -> u -> Space
                 -> [Constraint] -> Expr -> Double -> UncertQ
 uqc nam trm desc sym un space cs val uncrt = uq (cuc' nam trm desc sym un space cs val) uncrt
 
 --uncertainty quanity constraint no uncertainty
-uqcNU :: (IsUnit u, DOM u ~ ConceptChunk) => String -> NP -> String -> Symbol -> u 
+uqcNU :: (IsUnit u, ConceptDomain u) => String -> NP -> String -> Symbol -> u
                   -> Space -> [Constraint] -> Expr -> UncertQ
 uqcNU nam trm desc sym un space cs val = uqNU (cuc' nam trm desc sym un space cs val)
 
 --uncertainty quantity constraint no description
-uqcND :: (IsUnit u, DOM u ~ ConceptChunk) => String -> NP -> Symbol -> u -> Space -> [Constraint]
+uqcND :: (IsUnit u, ConceptDomain u) => String -> NP -> Symbol -> u -> Space -> [Constraint]
                   -> Expr -> Double -> UncertQ
 uqcND nam trm sym un space cs val uncrt = uq (cuc' nam trm "" sym un space cs val) uncrt
 

--- a/code/Language/Drasil/Chunk/Unital.hs
+++ b/code/Language/Drasil/Chunk/Unital.hs
@@ -12,9 +12,9 @@ module Language.Drasil.Chunk.Unital
 
 import Control.Lens (makeLenses, view, (^.))
 import Language.Drasil.Classes (HasUID(uid), NamedIdea(term), Idea(getA),
-  Definition(defn), ConceptDomain(cdom, DOM), Concept, HasSymbol(symbol),
+  Definition(defn), ConceptDomain(cdom), Concept, HasSymbol(symbol),
   IsUnit)
-import Language.Drasil.Chunk.Concept (ConceptChunk, dcc, dccWDS,cw)
+import Language.Drasil.Chunk.Concept (dcc, dccWDS,cw)
 import Language.Drasil.Chunk.DefinedQuantity (DefinedQuantityDict, dqd)
 import Language.Drasil.Chunk.Quantity (Quantity(..),HasSpace(typ))
 import Language.Drasil.Chunk.Unitary (Unitary(..))
@@ -36,7 +36,6 @@ instance NamedIdea     UnitalChunk where term = defq' . term
 instance Idea          UnitalChunk where getA (UC qc _) = getA qc
 instance Definition    UnitalChunk where defn = defq' . defn
 instance ConceptDomain UnitalChunk where
-  type DOM UnitalChunk = ConceptChunk
   cdom = defq' . cdom
 instance Concept       UnitalChunk where
 instance HasSpace      UnitalChunk where typ = defq' . typ
@@ -48,30 +47,30 @@ instance Unitary       UnitalChunk where unit = view uni
 
 -- | Used to create a UnitalChunk from a 'Concept', 'Symbol', and 'Unit'.
 -- Assumes the 'Space' is Real
-uc :: (Concept c, IsUnit u, DOM c ~ ConceptChunk, DOM u ~ ConceptChunk) =>
+uc :: (Concept c, IsUnit u, ConceptDomain u) =>
   c -> Symbol -> u -> UnitalChunk
 uc a b c = ucs' a b c Real
 
-ucs' :: (Concept c, IsUnit u, DOM c ~ ConceptChunk, DOM u ~ ConceptChunk) =>
+ucs' :: (Concept c, IsUnit u, ConceptDomain u) =>
   c -> Symbol -> u -> Space -> UnitalChunk
 ucs' a sym c space = UC (dqd (cw a) sym space (Just un)) un
  where un = unitWrapper c
 
 -- | Same as 'uc', except it builds the Concept portion of the UnitalChunk
 -- from a given uid, term, and defn. Those are the first three arguments
-uc' :: (IsUnit u, DOM u ~ ConceptChunk) => String -> NP -> String -> Symbol ->
+uc' :: (IsUnit u, ConceptDomain u) => String -> NP -> String -> Symbol ->
   u -> UnitalChunk
 uc' i t d s u = UC (dqd (dcc i t d) s Real (Just un)) un
  where un = unitWrapper u
 
 -- | Same as 'uc'', but does not assume the 'Space'
-ucs :: (IsUnit u, DOM u ~ ConceptChunk) => String -> NP ->
+ucs :: (IsUnit u, ConceptDomain u) => String -> NP ->
   String -> Symbol -> u -> Space -> UnitalChunk
 ucs nam trm desc sym un space = UC (dqd (dcc nam trm desc) sym space (Just uu)) uu
   where uu = unitWrapper un
 
 -- ucs With a Sentence for desc
-ucsWS :: (IsUnit u, DOM u ~ ConceptChunk) => String -> NP -> 
+ucsWS :: (IsUnit u, ConceptDomain u) => String -> NP ->
   Sentence -> Symbol -> u -> Space -> UnitalChunk
 ucsWS nam trm desc sym un space = UC (dqd (dccWDS nam trm desc) sym space (Just uu)) uu
   where uu = unitWrapper un
@@ -79,7 +78,7 @@ ucsWS nam trm desc sym un space = UC (dqd (dccWDS nam trm desc) sym space (Just 
 --Better names will come later.
 -- | Create a UnitalChunk in the same way as 'uc'', but with a 'Sentence' for
 -- the definition instead of a String
-makeUCWDS :: (IsUnit u, DOM u ~ ConceptChunk) => String -> NP -> Sentence -> Symbol ->
+makeUCWDS :: (IsUnit u, ConceptDomain u) => String -> NP -> Sentence -> Symbol ->
   u -> UnitalChunk
 makeUCWDS nam trm desc sym un = UC (dqd (dccWDS nam trm desc) sym Real (Just uu)) uu
   where uu = unitWrapper un

--- a/code/Language/Drasil/Chunk/Unitary.hs
+++ b/code/Language/Drasil/Chunk/Unitary.hs
@@ -5,14 +5,13 @@ module Language.Drasil.Chunk.Unitary
   , Unitary(..)) where
 
 import Language.Drasil.Classes (HasUID(uid), NamedIdea(term), Idea(getA),
-  ConceptDomain(DOM), HasSymbol(symbol), IsUnit)
+  ConceptDomain, HasSymbol(symbol), IsUnit)
 import Language.Drasil.Chunk.Quantity (Quantity(..), QuantityDict, mkQuant, qw, 
   HasSpace(typ))
 import Language.Drasil.Unit (UnitDefn, unitWrapper)
 import Language.Drasil.Symbol
 import Language.Drasil.Space
 import Language.Drasil.NounPhrase (NP)
-import Language.Drasil.Chunk.Concept (ConceptChunk)
 
 import Control.Lens ((^.), makeLenses)
 
@@ -36,7 +35,7 @@ instance Unitary       UnitaryChunk where unit x = x ^. un
 
 -- Builds the Quantity part from the uid, term, symbol and space.
 -- assumes there's no abbreviation.
-unitary :: (IsUnit u, DOM u ~ ConceptChunk) => 
+unitary :: (IsUnit u, ConceptDomain u) =>
   String -> NP -> Symbol -> u -> Space -> UnitaryChunk
 unitary i t s u space = UC (mkQuant i t s space (Just uu) Nothing) uu -- Unit doesn't have a unitDefn, so [] is passed in
   where uu = unitWrapper u

--- a/code/Language/Drasil/Chunk/UnitaryConcept.hs
+++ b/code/Language/Drasil/Chunk/UnitaryConcept.hs
@@ -1,11 +1,11 @@
 {-# Language TemplateHaskell, TypeFamilies #-}
 module Language.Drasil.Chunk.UnitaryConcept (ucw, UnitaryConceptDict) where
 
-import Language.Drasil.Chunk.Concept (DefnAndDomain(DAD), ConceptChunk)
+import Language.Drasil.Chunk.Concept (DefnAndDomain(DAD))
 import Language.Drasil.Chunk.Unitary (UnitaryChunk, mkUnitary, Unitary)
 import Language.Drasil.Chunk.Quantity (Quantity(getUnit),HasSpace(typ))
 import Language.Drasil.Classes (HasUID(uid), NamedIdea(term), Idea(getA),
-  Definition(defn), ConceptDomain(cdom, DOM), Concept, HasSymbol(symbol))
+  Definition(defn), ConceptDomain(cdom), Concept, HasSymbol(symbol))
 import Control.Lens ((^.), makeLenses, view)
 
 data UnitaryConceptDict = UCC { _unitary :: UnitaryChunk
@@ -18,7 +18,6 @@ instance NamedIdea     UnitaryConceptDict where term = unitary . term
 instance Idea          UnitaryConceptDict where getA u = getA (u ^. unitary)
 instance Definition    UnitaryConceptDict where defn = dad . defn
 instance ConceptDomain UnitaryConceptDict where
-  type DOM UnitaryConceptDict = ConceptChunk
   cdom = dad . cdom
 instance Concept       UnitaryConceptDict where
 instance HasSpace      UnitaryConceptDict where typ = unitary . typ
@@ -27,5 +26,5 @@ instance Quantity      UnitaryConceptDict where getUnit = getUnit . view unitary
 
 instance Eq            UnitaryConceptDict where a == b = (a ^. uid) == (b ^. uid)
 
-ucw :: (Unitary c, Concept c, DOM c ~ ConceptChunk) => c -> UnitaryConceptDict
+ucw :: (Unitary c, Concept c) => c -> UnitaryConceptDict
 ucw c = UCC (mkUnitary c) (DAD (c ^. defn) (c ^. cdom))

--- a/code/Language/Drasil/ChunkDB.hs
+++ b/code/Language/Drasil/ChunkDB.hs
@@ -57,8 +57,7 @@ unitMap = Map.fromList . map (\x -> (x ^. uid, unitWrapper x))
 -- | Looks up an uid in the symbol table. If nothing is found, an error is thrown
 symbLookup :: UID -> SymbolMap -> QuantityDict
 symbLookup c m = getS $ Map.lookup c m
-  where getS (Just x) = x
-        getS Nothing = error $ "Symbol: " ++ c ++ " not found in SymbolMap"
+  where getS = maybe (error $ "Symbol: " ++ c ++ " not found in SymbolMap") id
 
 --- SYMBOL TABLE ---
 class HasSymbolTable s where
@@ -83,8 +82,7 @@ getUnitLup c m = getUnit $ symbLookup (c ^. uid) (m ^. symbolTable)
 -- | Looks up an uid in the term table. If nothing is found, an error is thrown
 termLookup :: (HasUID c) => c -> TermMap -> IdeaDict
 termLookup c m = getT $ Map.lookup (c ^. uid) m
-  where getT (Just x) = x
-        getT Nothing  = error $ "Term: " ++ (c ^. uid) ++ " not found in TermMap"
+  where getT = maybe (error $ "Term: " ++ (c ^. uid) ++ " not found in TermMap") id
 
 -- | Looks up a uid in the definition table. If nothing is found, an error is thrown.
 defLookup :: UID -> ConceptMap -> ConceptChunk

--- a/code/Language/Drasil/ChunkDB.hs
+++ b/code/Language/Drasil/ChunkDB.hs
@@ -8,7 +8,8 @@ module Language.Drasil.ChunkDB
   ) where
 
 import Language.Drasil.UID (UID)
-import Language.Drasil.Classes (HasUID(uid), Idea, Concept, DOM, IsUnit)
+import Language.Drasil.Classes (HasUID(uid), Idea, Concept, IsUnit,
+  ConceptDomain)
 import Language.Drasil.Chunk.NamedIdea (IdeaDict, nw)
 import Language.Drasil.Chunk.Quantity
 import Language.Drasil.Chunk.Concept 
@@ -47,11 +48,11 @@ termMap :: (Idea c) => [c] -> TermMap
 termMap = Map.fromList . map (\x -> (x ^. uid, nw x))
 
 -- | Smart constructor for a 'ConceptMap'
-conceptMap :: (Concept c, DOM c ~ ConceptChunk) => [c] -> ConceptMap
+conceptMap :: (Concept c) => [c] -> ConceptMap
 conceptMap = Map.fromList . map (\x -> (x ^. uid, cw x))
 
 -- | Smart constructor for a 'UnitMap'
-unitMap :: (IsUnit u, DOM u ~ ConceptChunk) => [u] -> UnitMap
+unitMap :: (IsUnit u, ConceptDomain u) => [u] -> UnitMap
 unitMap = Map.fromList . map (\x -> (x ^. uid, unitWrapper x))
 
 -- | Looks up an uid in the symbol table. If nothing is found, an error is thrown
@@ -101,7 +102,7 @@ makeLenses ''ChunkDB
 -- (for SymbolTable), NamedIdeas (for TermTable), Concepts (for DefinitionTable),
 -- and Units (for UnitTable)
 cdb :: (Quantity q, Idea t, Concept c, IsUnit u,
-        DOM c ~ ConceptChunk, DOM u ~ ConceptChunk) => [q] -> [t] -> [c] -> [u] -> ChunkDB
+        ConceptDomain u) => [q] -> [t] -> [c] -> [u] -> ChunkDB
 cdb s t c u = CDB (symbolMap s) (termMap t) (conceptMap c) (unitMap u)
 
 ----------------------

--- a/code/Language/Drasil/ChunkDB.hs
+++ b/code/Language/Drasil/ChunkDB.hs
@@ -89,8 +89,7 @@ termLookup c m = getT $ Map.lookup (c ^. uid) m
 -- | Looks up a uid in the definition table. If nothing is found, an error is thrown.
 defLookup :: UID -> ConceptMap -> ConceptChunk
 defLookup u m = getC $ Map.lookup u m
-  where getC (Just x) = x
-        getC Nothing = error $ "Concept: " ++ u ++ " not found in ConceptMap"
+  where getC = maybe (error $ "Concept: " ++ u ++ " not found in ConceptMap") id
 
 -- | Our chunk databases. Should contain all the maps we will need.
 data ChunkDB = CDB { _csymbs :: SymbolMap

--- a/code/Language/Drasil/Classes.hs
+++ b/code/Language/Drasil/Classes.hs
@@ -5,7 +5,7 @@ module Language.Drasil.Classes (
   , NamedIdea(term)
   , Idea(getA)
   , Definition(defn)
-  , ConceptDomain(cdom, DOM)
+  , ConceptDomain(cdom)
   , Concept
   , HasSymbol(symbol)
   , HasSpace(typ)
@@ -56,7 +56,6 @@ class Definition c where
   defn :: Lens' c Sentence
 
 class ConceptDomain c where
-  type DOM c :: *
   -- | cdom provides (a 'Lens' to) the concept domain tags for a chunk
   cdom :: Lens' c [UID]
   -- ^ /cdom/ should be exported for use by the

--- a/code/Language/Drasil/Unit.hs
+++ b/code/Language/Drasil/Unit.hs
@@ -12,7 +12,7 @@ import Control.Lens (Simple, Lens, (^.))
 import Control.Arrow (second)
 
 import Language.Drasil.Classes (HasUID(uid), NamedIdea(term), Idea(getA),
-  Definition(defn), ConceptDomain(cdom, DOM), HasUnitSymbol(usymb), IsUnit,
+  Definition(defn), ConceptDomain(cdom), HasUnitSymbol(usymb), IsUnit,
   UnitEq(uniteq))
 import Language.Drasil.Chunk.Concept (ConceptChunk, dcc, cc')
 import Language.Drasil.Symbol
@@ -59,7 +59,6 @@ instance Idea          UnitDefn where getA c = getA (c ^. vc)
 instance Definition    UnitDefn where defn = vc . defn
 instance Eq            UnitDefn where a == b = (a ^. usymb) == (b ^. usymb)
 instance ConceptDomain UnitDefn where
-  type DOM UnitDefn = ConceptChunk
   cdom = vc . cdom
 instance HasUnitSymbol UnitDefn where usymb f (UD a b) = fmap (\x -> UD a x) (f b)
 instance IsUnit        UnitDefn
@@ -78,7 +77,6 @@ instance NamedIdea     DerUChunk where term = duc . term
 instance Idea          DerUChunk where getA c = getA (c ^. duc)
 instance Definition    DerUChunk where defn = duc . defn
 instance ConceptDomain DerUChunk where
-  type DOM DerUChunk = ConceptChunk
   cdom = duc . cdom
 instance HasUnitSymbol DerUChunk where usymb  = duc . usymb
 instance IsUnit        DerUChunk where


### PR DESCRIPTION
This PR does two things (sorry), both as a result of comments on previous conceptchunk_uid commits.
1. Removes the associated type "DOM" as indicated by [a comment](https://github.com/JacquesCarette/Drasil/commit/6b737048cf59fa194ed4e175e6ac7c00168ea438#r29277062) on commit 6b73704 by @JacquesCarette.
2. Updates lookup function in ChunkDB to use `maybe` instead of pattern matching as suggested by @JacquesCarette in [this comment](https://github.com/JacquesCarette/Drasil/commit/d4261b644c38968c550d99f543e28effc47888e8#commitcomment-29277073) on commit d4261b6.