### PR TITLE
Improved imports in Concepts/Computation.hs, Documentation.hs, and Education.hs

### DIFF
--- a/code/Data/Drasil/Concepts/Computation.hs
+++ b/code/Data/Drasil/Concepts/Computation.hs
@@ -1,8 +1,9 @@
 module Data.Drasil.Concepts.Computation where
 
 import Language.Drasil
-import Data.Drasil.Concepts.Documentation
-import qualified Language.Drasil.NounPhrase as NP
+import Data.Drasil.Concepts.Documentation (datum, input_, literacy, output_, 
+    quantity, type_, value, variable)
+import qualified Language.Drasil.NounPhrase as NP (phrase, plural)
 import Data.Drasil.Concepts.Math (parameter)
 
 

--- a/code/Data/Drasil/Concepts/Documentation.hs
+++ b/code/Data/Drasil/Concepts/Documentation.hs
@@ -3,10 +3,10 @@ module Data.Drasil.Concepts.Documentation where
 import Language.Drasil hiding (organization)
 
 import Data.Drasil.Concepts.Math (graph)
-import Data.Drasil.Phrase (ofA, andRT, and_, and_', of_, of_', of__)
+import Data.Drasil.Phrase (andRT, and_, and_', ofA, of_, of_', of__)
 
 import Control.Lens ((^.))
-import qualified Language.Drasil.NounPhrase as NP
+import qualified Language.Drasil.NounPhrase as NP (plural)
 
 assumption, dataDefn, desSpec, genDefn, goalStmt, dataConst, inModel, likelyChg,
   unlikelyChg, physSyst, requirement, thModel, mg, notApp, typUnc, srs :: CI

--- a/code/Data/Drasil/Concepts/Education.hs
+++ b/code/Data/Drasil/Concepts/Education.hs
@@ -1,8 +1,8 @@
 module Data.Drasil.Concepts.Education where
 
 import Language.Drasil hiding (year)
-import Data.Drasil.Concepts.Documentation
-import Data.Drasil.Concepts.PhysicalProperties
+import Data.Drasil.Concepts.Documentation (first, physics, second_, year)
+import Data.Drasil.Concepts.PhysicalProperties (solid)
 
 calculus, civil, degree_, engineering, structural, mechanics,
   undergraduate, highSchool, physical_, chemistry :: NamedChunk

--- a/code/Data/Drasil/Concepts/Education.hs
+++ b/code/Data/Drasil/Concepts/Education.hs
@@ -13,8 +13,8 @@ degree_         = nc "degree"         (cn'  "degree"       )
 engineering     = nc "engineering"    (cn'  "engineering"  )
 mechanics       = nc "mechanics"      (cn   "mechanics"    )
 structural      = nc "structural"     (cn'  "structural"   )--FIXME: Adjective
-undergraduate   = nc "undergraduate"  (cn'  "undergraduate")
-highSchool      = nc "highSchool"     (cn'  "high school"  )
+undergraduate   = nc "undergraduate"  (cn'  "undergraduate")--FIXME: Functions as adjective
+highSchool      = nc "highSchool"     (cn'  "high school"  )--FIXME: Functions as adjective
 chemistry       = nc "chemistry"      (cn'  "chemistry"    )
 physical_       = nc "physical"       (cn'  "physical"     )--FIXME: Adjective
 


### PR DESCRIPTION
#569 -> Specified

Also added comments to Education.hs, as "undergraduate" and "high school" function as adjectives in "undergraduate degree" and "high school calculus".