### PR TITLE
Create Label ADT and some constructors

### DIFF
--- a/code/Language/Drasil/Label.hs
+++ b/code/Language/Drasil/Label.hs
@@ -1,0 +1,17 @@
+{-# Language TemplateHaskell #-}
+module Language.Drasil.Label (Label) where
+
+import Control.Lens (makeLenses)
+import Language.Drasil.UID (UID)
+import Language.Drasil.Classes (HasUID(uid))
+
+-- import reference address from Language.Drasil.References?
+data LblType = RefAdd | MetaLink | URI
+
+data Label = Lbl 
+  { _uniqueID  :: UID
+  , lblType    :: LblType 
+  }
+makeLenses ''Label
+  
+instance HasUID Label where uid = uniqueID

--- a/code/Language/Drasil/Label.hs
+++ b/code/Language/Drasil/Label.hs
@@ -6,12 +6,24 @@ import Language.Drasil.UID (UID)
 import Language.Drasil.Classes (HasUID(uid))
 
 -- import reference address from Language.Drasil.References?
-data LblType = RefAdd | MetaLink | URI
+data LblType = RefAdd String | MetaLink String | URI String
 
-data Label = Lbl 
-  { _uniqueID  :: UID
+-- Used for referencing; has to be pure ASCII
+data Label = Lbl
+  { _uniqueID  :: UID --internal, unique
   , lblType    :: LblType 
   }
 makeLenses ''Label
   
 instance HasUID Label where uid = uniqueID
+
+-- multiple mkLabel constructors for label creation
+
+mkLabelRA :: String -> String -> Label
+mkLabelRA id ref = Lbl id (RefAdd ref)
+
+mkLabelML :: String -> String -> Label
+mkLabelML id ref = Lbl id (MetaLink ref)
+
+mkLabelURI :: String -> String -> Label
+mkLabelURI id ref = Lbl id (URI ref)

--- a/code/Language/Drasil/Label.hs
+++ b/code/Language/Drasil/Label.hs
@@ -4,6 +4,7 @@ module Language.Drasil.Label (Label) where
 import Control.Lens (makeLenses)
 import Language.Drasil.UID (UID)
 import Language.Drasil.Classes (HasUID(uid))
+import Data.Char (isAscii)
 
 -- import reference address from Language.Drasil.References?
 data LblType = RefAdd String | MetaLink String | URI String
@@ -20,10 +21,14 @@ instance HasUID Label where uid = uniqueID
 -- multiple mkLabel constructors for label creation
 
 mkLabelRA :: String -> String -> Label
-mkLabelRA id ref = Lbl id (RefAdd ref)
+mkLabelRA id ref = Lbl id (RefAdd $ ensureASCII ref)
 
 mkLabelML :: String -> String -> Label
-mkLabelML id ref = Lbl id (MetaLink ref)
+mkLabelML id ref = Lbl id (MetaLink $ ensureASCII ref)
 
 mkLabelURI :: String -> String -> Label
-mkLabelURI id ref = Lbl id (URI ref)
+mkLabelURI id ref = Lbl id (URI $ ensureASCII ref)
+
+-- helpers
+ensureASCII :: String -> String
+ensureASCII s = map (\y -> if isAscii y then y else error "Label needs to be pure ASCII.") s

--- a/code/drasil.cabal
+++ b/code/drasil.cabal
@@ -41,6 +41,7 @@ library
     , Language.Drasil.Expr.Math
     , Language.Drasil.Expr.Precedence
     , Language.Drasil.Classes
+    , Language.Drasil.Label
     , Language.Drasil.Config
     , Language.Drasil.Document
     , Language.Drasil.Format


### PR DESCRIPTION
This is for issue #629.

In this PR, the data type `Label` is created and some `mkLabel` constructors as well (which corresponds to the 1st and 3rd points in #567 under Label):
"
- create abstract data type `Label` which has a `uid`, and an enumerated type (`reference address`, `meta-link`, `uri`) and is not "attached" to anything
...
- multiple `mkLabel` constructors should be created for label creation
".

@szymczdm @JacquesCarette Would the next step for these issues be to create the `isLabel` class or make several of the `refer` functions in this module?

Edit: After thinking about it, I think both tasks can be done in parallel... since nothing is implemented yet in the examples, it should be alright starting with either or...
