### PR TITLE
Add ShortName to ConceptChunk.

### DIFF
--- a/code/Language/Drasil/Chunk/Concept.hs
+++ b/code/Language/Drasil/Chunk/Concept.hs
@@ -20,7 +20,7 @@ import Control.Lens ((^.))
 dcc :: String -> NP -> String -> ConceptChunk 
 -- | Smart constructor for creating concept chunks given an id, 
 -- 'NounPhrase' ('NP') and definition (as String).
-dcc i ter des = ConDict (mkIdea i ter Nothing) (DAD (S des) [])
+dcc i ter des = ConDict (mkIdea i ter Nothing) (DAD (S des) []) Nothing
 -- ^ Concept domain tagging is not yet implemented in this constructor.
 
 -- | Identical to 'dcc', but adds an abbreviation (String)
@@ -29,7 +29,7 @@ dcc' i t d a = ComConDict (commonIdea i t a) (S d) []
 
 -- | Similar to 'dcc', except the definition is a 'Sentence'
 dccWDS :: String -> NP -> Sentence -> ConceptChunk
-dccWDS i t d = ConDict (mkIdea i t Nothing) (DAD d [])
+dccWDS i t d = ConDict (mkIdea i t Nothing) (DAD d []) Nothing
 
 -- | Similar to 'dcc', except the definition is a 'Sentence' and adds
 -- an abbreviation (String)
@@ -38,16 +38,16 @@ dccWDS' i t d a = ComConDict (commonIdea i t a) d []
 
 -- | Constructor for 'ConceptChunk'. Does not allow concept domain tagging.
 cc :: Idea c => c -> String -> ConceptChunk
-cc n d = ConDict (nw n) (DAD (S d) [])
+cc n d = ConDict (nw n) (DAD (S d) []) Nothing
 
 -- | Same as cc, except definition is a 'Sentence'
 cc' :: Idea c => c -> Sentence -> ConceptChunk
-cc' n d = ConDict (nw n) (DAD d [])
+cc' n d = ConDict (nw n) (DAD d []) Nothing
 
 -- | Constructor for 'ConceptChunk'. Allows explicit tagging.
 ccs :: (Idea c, Concept d) => c -> Sentence -> [d] -> ConceptChunk --Explicit tagging
-ccs n d l = ConDict (nw n) (DAD d $ map (\x -> x ^. uid) l)
+ccs n d l = ConDict (nw n) (DAD d $ map (\x -> x ^. uid) l) Nothing
 
 -- | For projecting out to the ConceptChunk data-type
 cw :: Concept c => c -> ConceptChunk
-cw c = ConDict (nw c) $ DAD (c ^. defn) (c ^. cdom)
+cw c = ConDict (nw c) (DAD (c ^. defn) (c ^. cdom)) Nothing

--- a/code/Language/Drasil/Chunk/Concept/Core.hs
+++ b/code/Language/Drasil/Chunk/Concept/Core.hs
@@ -7,6 +7,7 @@ import Language.Drasil.Chunk.CommonIdea (CI)
 import Language.Drasil.UID (UID)
 import Language.Drasil.Classes (HasUID(uid), NamedIdea(term), Idea(getA),
   Definition(defn), ConceptDomain(cdom), Concept, CommonIdea(abrv))
+import Language.Drasil.Chunk.ShortName (HasShortName(shortname), ShortName)
 
 import Control.Lens (makeLenses, (^.), view)
 
@@ -17,8 +18,11 @@ data DefnAndDomain = DAD { _defn' :: Sentence, _cdom' :: [UID]}
 makeLenses ''DefnAndDomain
 
 -- | The ConceptChunk datatype is a Concept
--- ConDict is not exported, nor are _idea and _dad
-data ConceptChunk = ConDict { _idea :: IdeaDict, _dad :: DefnAndDomain }
+-- ConDict is not exported, nor are _idea, _dad, and _sn.
+data ConceptChunk = ConDict { _idea :: IdeaDict
+                            , _dad :: DefnAndDomain
+                            , _sn :: Maybe ShortName
+                            }
 makeLenses ''ConceptChunk
 
 instance Definition    DefnAndDomain where defn = defn'
@@ -31,6 +35,10 @@ instance Idea          ConceptChunk where getA = getA . view idea
 instance Definition    ConceptChunk where defn = dad . defn'
 instance ConceptDomain ConceptChunk where cdom = dad . cdom'
 instance Concept       ConceptChunk where
+instance HasShortName  ConceptChunk where
+  shortname x = maybe
+    (error $ "No ShortName found for ConceptChunk: " ++ (view uid x)) id $
+    view sn x
  
 data CommonConcept = ComConDict { _comm :: CI, _def :: Sentence, _dom :: [UID]}
 makeLenses ''CommonConcept


### PR DESCRIPTION
This is the first of (probably) a few pull requests to enable/support referencing of `ConceptChunk` s as per #562 [comment 6](https://github.com/JacquesCarette/Drasil/issues/562#issuecomment-393544664), third bullet point. 

In an effort to not break everything, Maybe was added to the ShortName field's type for `ConceptChunk`. All existing constructors for `ConceptChunk` have been updated to "ignore" the short name. Which I believe makes sense as not all `ConceptChunk` s will be referenced. 

@JacquesCarette I misspoke earlier. All the constructors of `ConceptChunk` take an existing `NP` (or type which contains an `NP`) as input so we don't have the `String` mentioned when `ShortName` would be constructed. 

PS. I will send another PR adding Label related content once #643 has been merged.