### PR TITLE
Added Likely Changes to SSP

### DIFF
--- a/code/Example/Drasil/SSP/Assumptions.hs
+++ b/code/Example/Drasil/SSP/Assumptions.hs
@@ -15,7 +15,8 @@ import Data.Drasil.SentenceStructures (foldlSent, getTandS, ofThe, ofThe')
 import Data.Drasil.Utils (getES)
 
 sspRefDB :: ReferenceDB
-sspRefDB = rdb [] [] newAssumptions [] [] sspCitations -- FIXME: Convert the rest to new chunk types
+sspRefDB = rdb [] [] newAssumptions [] [] sspCitations 
+-- FIXME: Convert the rest to new chunk types (similar to issues #446 and #447)
 
 newAssumptions :: [AssumpChunk]
 newAssumptions = [newA1, newA2, newA3, newA4, newA5, newA6, newA7, newA8, newA9, newA10]

--- a/code/Example/Drasil/SSP/Body.hs
+++ b/code/Example/Drasil/SSP/Body.hs
@@ -26,7 +26,7 @@ import Data.Drasil.SentenceStructures (foldlList, foldlSP, foldlSent,
 import Data.Drasil.SI_Units (degree, metre, newton, pascal)
 import Data.Drasil.Utils (enumBullet, enumSimple, getES, weave)
 
-import Drasil.SSP.Assumptions (sspAssumptions, newA3)
+import Drasil.SSP.Assumptions (sspAssumptions, newA3, sspRefDB)
 import Drasil.SSP.DataDefs (ddRef, lengthLb, lengthLs, mobShrDerivation, 
   resShrDerivation, sliceWght, sspDataDefs, stfMtrxDerivation)
 import Drasil.SSP.DataDesc (sspInputMod)
@@ -49,7 +49,7 @@ import qualified Drasil.SRS as SRS (funcReq, inModel, likeChg, missingP,
 
 import Drasil.DocumentLanguage (DocDesc, DocSection(..), IntroSec(..), 
   IntroSub(..), LFunc(..), RefSec(..), RefTab(..), TConvention(..), TSIntro, 
-  TSIntro(..), mkDoc, tsymb'', mkLklyChnk)
+  TSIntro(..), LCsSec(..), mkDoc, tsymb'', mkLklyChnk)
 
 import Drasil.Sections.AuxiliaryConstants (valsOfAuxConstantsF)
 import Drasil.Sections.GeneralSystDesc (genSysF)
@@ -96,10 +96,9 @@ ssp_si = SI {
   _refdb = sspRefDB
 }
 
-sspRefDB :: ReferenceDB
-sspRefDB = rdb [] [] [] [] [] sspCitations
--- FIXME: Convert the rest to new chunk types (similar to issues #446 and #447)
-
+ssp_srs :: Document
+ssp_srs = mkDoc mkSRS (for) ssp_si
+  
 mkSRS :: DocDesc
 mkSRS = RefSec (RefProg intro
   [TUnits, tsymb'' s1_2_intro TAD, TAandA]) :
@@ -110,10 +109,8 @@ mkSRS = RefSec (RefProg intro
       EmptyS
     , IOrgSec orgSecStart inModel (SRS.inModel SRS.missingP []) orgSecEnd]) :
     --FIXME: issue #235
-  map Verbatim [s3, s4, s5, s6, s7] ++ (Bibliography : [])
-  
-ssp_srs :: Document
-ssp_srs = mkDoc mkSRS (for) ssp_si
+  map Verbatim [s3, s4, s5] ++ [LCsSec (LCsProg likelyChanges_SRS)] ++ [Verbatim s7] ++
+  (Bibliography : [])
   
 ssp_code :: CodeSpec
 ssp_code = codeSpec ssp_si [sspInputMod]

--- a/code/Example/Drasil/SSP/Body.hs
+++ b/code/Example/Drasil/SSP/Body.hs
@@ -7,16 +7,16 @@ import Prelude hiding (sin, cos, tan)
 import Data.Drasil.Concepts.Documentation (analysis, assumption, definition, 
   design, document, effect, element, endUser, goalStmt, inModel, input_, 
   interest, interest, issue, loss, method_, model, organization, physics, 
-  problem, property, requirement, srs, table_, template, value, variable)
+  problem, property, requirement, srs, table_, template, value, variable,
+  system)
 import Data.Drasil.Concepts.Education (solidMechanics, undergraduate)
-import Data.Drasil.Concepts.Math (equation, surface)
+import Data.Drasil.Concepts.Math (equation, surface, calculation)
 import Data.Drasil.Concepts.PhysicalProperties (mass)
 import Data.Drasil.Concepts.Physics (compression, fbd, force, strain, stress,
   tension)
 import Data.Drasil.Concepts.Software (accuracy, correctness, maintainability, 
   performanceSpd, program, reusability, understandability)
 import Data.Drasil.Concepts.SolidMechanics (normForce, shearForce)
-
 import Data.Drasil.Software.Products (sciCompS)
 
 import Data.Drasil.People (henryFrankis)
@@ -26,7 +26,7 @@ import Data.Drasil.SentenceStructures (foldlList, foldlSP, foldlSent,
 import Data.Drasil.SI_Units (degree, metre, newton, pascal)
 import Data.Drasil.Utils (enumBullet, enumSimple, getES, weave)
 
-import Drasil.SSP.Assumptions (sspAssumptions)
+import Drasil.SSP.Assumptions (sspAssumptions, newA3)
 import Drasil.SSP.DataDefs (ddRef, lengthLb, lengthLs, mobShrDerivation, 
   resShrDerivation, sliceWght, sspDataDefs, stfMtrxDerivation)
 import Drasil.SSP.DataDesc (sspInputMod)
@@ -37,6 +37,7 @@ import Drasil.SSP.Goals (sspGoals)
 import Drasil.SSP.IMods (fctSftyDerivation, instModIntro1, instModIntro2, 
   intrSlcDerivation, nrmShrDerivation, rigDisDerivation, rigFoSDerivation, 
   sspIMods)
+import Drasil.DocumentLanguage.RefHelpers (refA)
 import Drasil.SSP.References (sspCitations)
 import Drasil.SSP.Requirements (sspInputDataTable, sspRequirements)
 import Drasil.SSP.TMods (sspTMods)
@@ -48,7 +49,7 @@ import qualified Drasil.SRS as SRS (funcReq, inModel, likeChg, missingP,
 
 import Drasil.DocumentLanguage (DocDesc, DocSection(..), IntroSec(..), 
   IntroSub(..), LFunc(..), RefSec(..), RefTab(..), TConvention(..), TSIntro, 
-  TSIntro(..), mkDoc, tsymb'')
+  TSIntro(..), mkDoc, tsymb'', mkLklyChnk)
 
 import Drasil.Sections.AuxiliaryConstants (valsOfAuxConstantsF)
 import Drasil.Sections.GeneralSystDesc (genSysF)
@@ -388,8 +389,21 @@ s5_2 = nonFuncReqF [accuracy, performanceSpd]
   [correctness, understandability, reusability, maintainability] r EmptyS
   where r = (short ssa) +:+ S "is intended to be an educational tool"
 
--- SECTION 6 --
+-- SECTION 6     --
+-- LikelyChanges --
 s6 = SRS.likeChg [] []
+
+likelyChanges_SRS :: [Contents]
+likelyChanges_SRS = [likelychg1]
+
+likelychg1 :: Contents
+likelychg1 = mkLklyChnk "LC_inhomogeneous" lc1Desc "Calculate-Inhomogeneous-Soil-Layers"
+
+lc1Desc :: Sentence
+lc1Desc = foldlSent [(refA sspRefDB newA3) `sDash` S "The",
+  phrase system +:+. S "currently assumes the different layers of the soil are homogeneous",
+  S "In the future", plural calculation,
+  S "can be added for inconsistent soil properties throughout"]
 
 -- SECTION 7 --
 s7 = valsOfAuxConstantsF ssa []

--- a/code/Example/Drasil/SSP/Body.hs
+++ b/code/Example/Drasil/SSP/Body.hs
@@ -38,7 +38,6 @@ import Drasil.SSP.IMods (fctSftyDerivation, instModIntro1, instModIntro2,
   intrSlcDerivation, nrmShrDerivation, rigDisDerivation, rigFoSDerivation, 
   sspIMods)
 import Drasil.DocumentLanguage.RefHelpers (refA)
-import Drasil.SSP.References (sspCitations)
 import Drasil.SSP.Requirements (sspInputDataTable, sspRequirements)
 import Drasil.SSP.TMods (sspTMods)
 import Drasil.SSP.Unitals (fs, index, numbSlices, sspConstrained, sspInputs, 
@@ -387,8 +386,8 @@ s5_2 = nonFuncReqF [accuracy, performanceSpd]
   where r = (short ssa) +:+ S "is intended to be an educational tool"
 
 -- SECTION 6     --
--- LikelyChanges --
-s6 = SRS.likeChg [] []
+-- Likely Changes --
+s6 = SRS.likeChg [] [] -- can be removed with work on #321
 
 likelyChanges_SRS :: [Contents]
 likelyChanges_SRS = [likelychg1]
@@ -399,7 +398,7 @@ likelychg1 = mkLklyChnk "LC_inhomogeneous" lc1Desc "Calculate-Inhomogeneous-Soil
 lc1Desc :: Sentence
 lc1Desc = foldlSent [(refA sspRefDB newA3) `sDash` S "The",
   phrase system +:+. S "currently assumes the different layers of the soil are homogeneous",
-  S "In the future", plural calculation,
+  S "In the future,", plural calculation,
   S "can be added for inconsistent soil properties throughout"]
 
 -- SECTION 7 --

--- a/code/stable/gamephys/Chipmunk_SRS.tex
+++ b/code/stable/gamephys/Chipmunk_SRS.tex
@@ -495,7 +495,7 @@ Label & Angular Displacement
 \\ \midrule \\
 Units & rad
 \\ \midrule \\
- Equation & $θ=\frac{d\,ϕ\left(t\right)}{d\,t}$
+Equation & $θ=\frac{d\,ϕ\left(t\right)}{d\,t}$
 \\ \midrule \\
 Description & $θ$ is the angular displacement (rad)\newline$t$ is the time (s)\newline$ϕ$ is the orientation (rad)
 \\ \bottomrule \end{tabular}
@@ -570,11 +570,11 @@ $ϕ$ & None & $\frac{π}{2}$ rad & 10.0\%
 \\
 $\mathbf{v}$ & None & $2.51$ $\frac{\text{m}}{\text{s}}$ & 10.0\%
 \\
- $ω$ & None & $2.1$ $\frac{\text{rad}}{\text{s}}$ & 10.0\%
+$ω$ & None & $2.1$ $\frac{\text{rad}}{\text{s}}$ & 10.0\%
 \\
 $\mathbf{F}$ & None & $98.1$ N & 10.0\%
 \\
- $τ$ & None & $200.0$ Nm & 10.0\%
+$τ$ & None & $200.0$ Nm & 10.0\%
 \\
 ${C_{R}}$ & $0\leq{}{C_{R}}\leq{}1$ & $0.8$ & 10.0\%
 \\

--- a/code/stable/nopcm/NoPCM_SRS.tex
+++ b/code/stable/nopcm/NoPCM_SRS.tex
@@ -457,7 +457,7 @@ ${A_{C}}$ & ${A_{C}}>0$ & ${A_{C}}\leq{}{{A_{C}}^{max}}$ & $0.12$ $\text{m}^{2}$
 \\
 ${T_{C}}$ & $0<{T_{C}}<100$ & None & $50.0$ ${}^{\circ}$C & 10.0\%
 \\
- ${ρ_{W}}$ & ${ρ_{W}}>0$ & ${{ρ_{W}}^{min}}<{ρ_{W}}\leq{}{{ρ_{W}}^{max}}$ & $1000.0$ $\frac{\text{kg}}{\text{m}^{3}}$ & 10.0\%
+${ρ_{W}}$ & ${ρ_{W}}>0$ & ${{ρ_{W}}^{min}}<{ρ_{W}}\leq{}{{ρ_{W}}^{max}}$ & $1000.0$ $\frac{\text{kg}}{\text{m}^{3}}$ & 10.0\%
 \\
 ${C_{W}}$ & ${C_{W}}>0$ & ${{C_{W}}^{min}}<{C_{W}}<{{C_{W}}^{max}}$ & $4186.0$ $\frac{\text{J}}{(\text{kg}{}^{\circ}\text{C})}$ & 10.0\%
 \\
@@ -663,7 +663,7 @@ ${h_{min}}$ & minimum convective heat transfer coefficient & $0.001$ & $\frac{\t
 \\
 ${{ρ_{W}}^{min}}$ & minimum density of water & $950$ & $\frac{\text{kg}}{\text{m}^{3}}$
 \\
- ${{ρ_{W}}^{max}}$ & maximum density of water & $1000$ & $\frac{\text{kg}}{\text{m}^{3}}$
+${{ρ_{W}}^{max}}$ & maximum density of water & $1000$ & $\frac{\text{kg}}{\text{m}^{3}}$
 \\
 ${{C_{W}}^{min}}$ & minimum specific heat capacity of water & $4170$ & $\frac{\text{J}}{(\text{kg}{}^{\circ}\text{C})}$
 \\

--- a/code/stable/ssp/SSP_SRS.html
+++ b/code/stable/ssp/SSP_SRS.html
@@ -4508,6 +4508,13 @@ SSA is intended to be an educational tool, so accuracy and performance are not p
 <h1>
 Likely Changes
 </h1>
+<ul class="hide-list-style">
+<li>
+<div id="LC:LC.inhomogeneous">
+Calculate-Inhomogeneous-Soil-Layers: <a href=#A:Soil-Layer-Homogeneous>Soil-Layer-Homogeneous</a> - The system currently assumes the different layers of the soil are homogeneous. In the future, calculations can be added for inconsistent soil properties throughout.
+</div>
+</li>
+</ul>
 </div>
 </div>
 <div id="Sec:AuxConstants">

--- a/code/stable/ssp/SSP_SRS.tex
+++ b/code/stable/ssp/SSP_SRS.tex
@@ -18,6 +18,8 @@
 \usepackage{url}
 \setmathfont{Latin Modern Math}
 \global\tabulinesep=1mm
+\newcounter{lcnum}
+\newcommand{\lcthelcnum}{LC\thelcnum}
 \bibliography{bibfile}
 \title{Software Requirements Specification for Slope Stability Analysis}
 \author{Henry Frankis}
@@ -211,7 +213,7 @@ $σ$ & Normal Stress: The stress exerted perpendicular to the plain of the objec
 \\
 $τ$ & Resistive Shear Stress: acting on the base of a slice & Pa
 \\
-$Υ$ & Function: generic minimization function or algorithm &
+$Υ$ & Function: generic minimization function or algorithm & 
 \\
 $φ'$ & Effective Angle of Friction: The angle of inclination with respect to the horizontal axis of the Mohr-Coulomb shear resistance line & ${}^{\circ}$
 \\
@@ -1321,6 +1323,9 @@ $κ$ & Pa & constant
 SSA is intended to be an educational tool, so accuracy and performance are not priorities. Rather, the non-functional requirement priorities are correctness, understandability, reusability, and maintainability.
 \section{Likely Changes}
 \label{Sec:LCs}
+\begin{description}
+\item[\refstepcounter{lcnum}\lcthelcnum\label{LC:LC.inhomogeneous}:]A\ref{A:Soil-Layer-Homogeneous} - The system currently assumes the different layers of the soil are homogeneous. In the future, calculations can be added for inconsistent soil properties throughout.
+\end{description}
 \section{Values of Auxiliary Constants}
 \label{Sec:AuxConstants}
 There are no auxiliary constants.

--- a/code/stable/swhs/SWHS_SRS.tex
+++ b/code/stable/swhs/SWHS_SRS.tex
@@ -171,7 +171,7 @@ ${V_{tank}}$ & Volume of the cylindrical tank & $\text{m}^{3}$
 \\
 ${V_{W}}$ & Volume of water & $\text{m}^{3}$
 \\
-$η$ & ODE parameter &
+$η$ & ODE parameter & 
 \\
 $ρ$ & Density & $\frac{\text{kg}}{\text{m}^{3}}$
 \\
@@ -187,7 +187,7 @@ ${{τ_{P}}^{S}}$ & ODE parameter for solid PCM & s
 \\
 ${τ_{W}}$ & ODE parameter for water & s
 \\
-$ϕ$ & Melt fraction &
+$ϕ$ & Melt fraction & 
 \\
 \bottomrule
 \label{Table:ToS}


### PR DESCRIPTION
As mentioned in smiths/caseStudies#47, a likely change should be added to the SSP example.

This PR's end files reflect said change, however, the link for the assumption that the likely change attempts to link to doesn't actually work.

This problem is related to how Assumptions are displayed **/** stored.

In glassBR, the assumptions are shown as shortnames followed by a ":" and a description of the assumption, and there is no such issue when a likely change source-assumption like the following is clicked:
![image](https://user-images.githubusercontent.com/28247301/41564269-43851e1e-7320-11e8-9bb2-54f644aa9d0e.png)

-->

![image](https://user-images.githubusercontent.com/28247301/41564312-64178ffe-7320-11e8-8d85-26afd35ec1fb.png).

On the other hand, assumptions are still displayed as "A" appended to a number, followed by a ":" and finally, the description. When the source-link in SSP's likely change is clicked,

![image](https://user-images.githubusercontent.com/28247301/41564363-90080cd8-7320-11e8-8a43-f04f052552f5.png)

the address is updated from "...code/build/SSP/Website/SSP_SRS.html" to "...code/build/SSP/Website/SSP_SRS.html#A:Soil-Layer-Homogeneous", but one doesn't actually see the assumptions section.