### PR TITLE
Updated GlassBR SRS (c)

### DIFF
--- a/code/Example/Drasil/GlassBR/Unitals.hs
+++ b/code/Example/Drasil/GlassBR/Unitals.hs
@@ -67,7 +67,7 @@ gbInputDataConstraints = (map uncrtnw gbInputsWUnitsUncrtn) ++
 plate_len = uqcND "plate_len" (nounPhraseSP "plate length (long dimension)")
   lA metre Real 
   [ gtZeroConstr,
-    physc $ UpFrom (Exc, sy plate_width),
+    physc $ UpFrom (Inc, sy plate_width),
     sfwrc $ Bounded (Inc , sy dim_min) (Inc , sy dim_max),
     sfwrc $ UpTo (Exc, sy ar_max * sy plate_width)] (dbl 1.5) defaultUncrt
 

--- a/code/stable/glassbr/GlassBR_SRS.html
+++ b/code/stable/glassbr/GlassBR_SRS.html
@@ -1921,7 +1921,7 @@ TU
 <em>a</em>
 </td>
 <td>
-<em>a&thinsp;&gt;&thinsp;0</em> and <em>a&thinsp;&gt;&thinsp;b</em>
+<em>a&thinsp;&gt;&thinsp;0</em> and <em>a&thinsp;&ge;&thinsp;b</em>
 </td>
 <td>
 <em>d<sub>min</sub>&thinsp;&le;&thinsp;a&thinsp;&le;&thinsp;d<sub>max</sub></em> and <em>a&thinsp;&lt;&thinsp;AR<sub>max</sub>&#8239;b</em>

--- a/code/stable/glassbr/GlassBR_SRS.tex
+++ b/code/stable/glassbr/GlassBR_SRS.tex
@@ -577,7 +577,7 @@ Table~\ref{Table:InDataConstraints}, and Table~\ref{Table:OutDataConstraints} sh
 Var & Physical Constraints & Software Constraints & Typical Value & TU
 \\
 \midrule
-$a$ & $a>0$ and $a>b$ & ${d_{min}}\leq{}a\leq{}{d_{max}}$ and $a<{AR_{max}} b$ & $1.5$ m & 10.0\%
+$a$ & $a>0$ and $a\geqb$ & ${d_{min}}\leq{}a\leq{}{d_{max}}$ and $a<{AR_{max}} b$ & $1.5$ m & 10.0\%
 \\
 $b$ & $b>0$ and $0<b<a$ & ${d_{min}}\leq{}b\leq{}{d_{max}}$ and $b<\frac{a}{{AR_{max}}}$ & $1.2$ m & 10.0\%
 \\

--- a/code/stable/glassbr/GlassBR_SRS.tex
+++ b/code/stable/glassbr/GlassBR_SRS.tex
@@ -577,7 +577,7 @@ Table~\ref{Table:InDataConstraints}, and Table~\ref{Table:OutDataConstraints} sh
 Var & Physical Constraints & Software Constraints & Typical Value & TU
 \\
 \midrule
-$a$ & $a>0$ and $a\geqb$ & ${d_{min}}\leq{}a\leq{}{d_{max}}$ and $a<{AR_{max}} b$ & $1.5$ m & 10.0\%
+$a$ & $a>0$ and $a\geq{}b$ & ${d_{min}}\leq{}a\leq{}{d_{max}}$ and $a<{AR_{max}} b$ & $1.5$ m & 10.0\%
 \\
 $b$ & $b>0$ and $0<b<a$ & ${d_{min}}\leq{}b\leq{}{d_{max}}$ and $b<\frac{a}{{AR_{max}}}$ & $1.2$ m & 10.0\%
 \\


### PR DESCRIPTION
As per #675, GlassBR was updated in stable and generated to reflect changes in smiths/caseStudies@8f7bb39.