### PR TITLE
Added Unlikely Changes Section to SSP

### DIFF
--- a/code/Example/Drasil/DocumentLanguage.hs
+++ b/code/Example/Drasil/DocumentLanguage.hs
@@ -522,3 +522,6 @@ mkRequirement i desc shrtn = Requirement $ frc i desc (shortname' shrtn)
 
 mkLklyChnk :: String -> Sentence -> String -> Contents
 mkLklyChnk i desc shrtn = Change $ lc i desc (shortname' shrtn)
+
+mkUnLklyChnk :: String -> Sentence -> String -> Contents
+mkUnLklyChnk i desc shrtn = Change $ ulc i desc (shortname' shrtn)

--- a/code/Example/Drasil/DocumentLanguage.hs
+++ b/code/Example/Drasil/DocumentLanguage.hs
@@ -19,8 +19,8 @@ import Drasil.Sections.TableOfAbbAndAcronyms (table_of_abb_and_acronyms)
 import Drasil.Sections.TableOfSymbols (table)
 import Drasil.Sections.TableOfUnits (table_of_units)
 import qualified Drasil.SRS as SRS (appendix, dataDefn, genDefn, genSysDes, 
-  inModel, likeChg, probDesc, reference, solCharSpec, stakeholder, thModel, 
-  tOfSymb, userChar)
+  inModel, likeChg, unlikeChg, probDesc, reference, solCharSpec, stakeholder,
+  thModel, tOfSymb, userChar)
 import qualified Drasil.Sections.AuxiliaryConstants as AC (valsOfAuxConstantsF)
 import qualified Drasil.Sections.GeneralSystDesc as GSD (genSysF, genSysIntro,
   systCon, usrCharsF)
@@ -58,6 +58,7 @@ data DocSection = Verbatim Section
                 | SSDSec SSDSec
                 | ReqrmntSec ReqrmntSec
                 | LCsSec LCsSec
+                | UCsSec UCsSec
                 | TraceabilitySec TraceabilitySec
                 | AuxConstntSec AuxConstntSec
                 | Bibliography
@@ -212,6 +213,10 @@ data LCsSec = LCsVerb Section | LCsProg [Contents]
 
 {--}
 
+data UCsSec = UCsVerb Section | UCsProg [Contents]
+
+{--}
+
 data TraceabilitySec = TraceabilityVerb Section | TraceabilityProg [Contents] [Sentence] [Contents] [Section]
 
 {--}
@@ -246,6 +251,7 @@ mkSections si l = map doit l
     doit (ScpOfProjSec sop)  = mkScpOfProjSec sop
     doit (ReqrmntSec r)      = mkReqrmntSec r
     doit (LCsSec lc')        = mkLCsSec lc'
+    doit (UCsSec ulc)        = mkUCsSec ulc
     doit (TraceabilitySec t) = mkTraceabilitySec t
     doit (AppndxSec a)       = mkAppndxSec a
 
@@ -477,6 +483,13 @@ mkReqrmntSec (ReqsProg l) = R.reqF $ map mkSubs l
 mkLCsSec :: LCsSec -> Section
 mkLCsSec (LCsVerb s) = s
 mkLCsSec (LCsProg c) = SRS.likeChg c []
+
+{--}
+
+-- | Helper for making the 'UnikelyChanges' section
+mkUCsSec :: UCsSec -> Section
+mkUCsSec (UCsVerb s) = s
+mkUCsSec (UCsProg c) = SRS.unlikeChg c []
 
 {--}
 

--- a/code/Example/Drasil/SRS.hs
+++ b/code/Example/Drasil/SRS.hs
@@ -2,8 +2,9 @@ module Drasil.SRS
  (doc, doc', intro, prpsOfDoc, scpOfReq, charOfIR, orgOfDoc, stakeholder, theCustomer, theClient, 
   genSysDes, sysCont, userChar, sysCon, scpOfTheProj, prodUCTable, indPRCase, specSysDes,
   probDesc, termAndDefn, termogy, physSyst, goalStmt, solCharSpec, assumpt, thModel,
-  genDefn, inModel, dataDefn, datCon, require, nonfuncReq, funcReq, likeChg, traceyMandG,
-  appendix, reference, propCorSol, offShelfSol, missingP, valsOfAuxCons, tOfSymb) where
+  genDefn, inModel, dataDefn, datCon, require, nonfuncReq, funcReq, likeChg, unlikeChg, 
+  traceyMandG, appendix, reference, propCorSol, offShelfSol, missingP, valsOfAuxCons,
+  tOfSymb) where
 --Temporary file for keeping the "srs" document constructor until I figure out
 -- a better place for it. Maybe Data.Drasil or Language.Drasil.Template?
 
@@ -14,7 +15,7 @@ import Language.Drasil
 import qualified Data.Drasil.Concepts.Documentation as Doc (appendix, 
     assumption, charOfIR, client, customer, consVals, dataDefn, datumConstraint, 
     functionalRequirement, genDefn, generalSystemDescription, goalStmt, 
-    indPRCase, inModel, introduction, likelyChg, nonfunctionalRequirement,
+    indPRCase, inModel, introduction, likelyChg, unlikelyChg, nonfunctionalRequirement,
     offShelfSolution, orgOfDoc, physSyst, prodUCTable, problemDescription, 
     propOfCorSol, prpsOfDoc, reference, requirement, scpOfReq, scpOfTheProj,
     solutionCharSpec, specificsystemdescription, srs, stakeholder, sysCont, 
@@ -83,6 +84,7 @@ nonfuncReq  cs ss = section' (titleize' Doc.nonfunctionalRequirement) cs ss "NFR
 funcReq     cs ss = section' (titleize' Doc.functionalRequirement) cs ss "FRs"
 
 likeChg     cs ss = section' (titleize' Doc.likelyChg)        cs ss "LCs"
+unlikeChg   cs ss = section' (titleize' Doc.unlikelyChg)      cs ss "UCs"
 
 traceyMandG cs ss = section' (titleize' Doc.traceyMandG)      cs ss "TraceMatrices"
 

--- a/code/Example/Drasil/SSP/Body.hs
+++ b/code/Example/Drasil/SSP/Body.hs
@@ -24,7 +24,7 @@ import Data.Drasil.SentenceStructures (foldlList, foldlSP, foldlSent,
   foldlSent_, ofThe, sAnd, sOr)
 import Data.Drasil.SI_Units (degree, metre, newton, pascal)
 import Data.Drasil.Utils (enumBullet, enumSimple, getES, weave)
-import Drasil.SSP.Changes (likelyChanges_SRS)
+import Drasil.SSP.Changes (likelyChanges_SRS, unlikelyChanges_SRS)
 import Drasil.SSP.Assumptions (sspAssumptions, sspRefDB)
 import Drasil.SSP.DataDefs (ddRef, lengthLb, lengthLs, mobShrDerivation, 
   resShrDerivation, sliceWght, sspDataDefs, stfMtrxDerivation)
@@ -46,7 +46,7 @@ import qualified Drasil.SRS as SRS (funcReq, inModel, likeChg, missingP,
 
 import Drasil.DocumentLanguage (DocDesc, DocSection(..), IntroSec(..), 
   IntroSub(..), LFunc(..), RefSec(..), RefTab(..), TConvention(..), TSIntro, 
-  TSIntro(..), LCsSec(..), mkDoc, tsymb'')
+  TSIntro(..), LCsSec(..), UCsSec(..), mkDoc, tsymb'')
 
 import Drasil.Sections.AuxiliaryConstants (valsOfAuxConstantsF)
 import Drasil.Sections.GeneralSystDesc (genSysF)
@@ -106,8 +106,8 @@ mkSRS = RefSec (RefProg intro
       EmptyS
     , IOrgSec orgSecStart inModel (SRS.inModel SRS.missingP []) orgSecEnd]) :
     --FIXME: issue #235
-  map Verbatim [s3, s4, s5] ++ [LCsSec (LCsProg likelyChanges_SRS)] ++ [Verbatim s7] ++
-  (Bibliography : [])
+  map Verbatim [s3, s4, s5] ++ [LCsSec (LCsProg likelyChanges_SRS)] 
+  ++ [UCsSec (UCsProg unlikelyChanges_SRS)] ++[Verbatim s7] ++ (Bibliography : [])
   
 ssp_code :: CodeSpec
 ssp_code = codeSpec ssp_si [sspInputMod]

--- a/code/Example/Drasil/SSP/Body.hs
+++ b/code/Example/Drasil/SSP/Body.hs
@@ -7,10 +7,9 @@ import Prelude hiding (sin, cos, tan)
 import Data.Drasil.Concepts.Documentation (analysis, assumption, definition, 
   design, document, effect, element, endUser, goalStmt, inModel, input_, 
   interest, interest, issue, loss, method_, model, organization, physics, 
-  problem, property, requirement, srs, table_, template, value, variable,
-  system)
+  problem, property, requirement, srs, table_, template, value, variable)
 import Data.Drasil.Concepts.Education (solidMechanics, undergraduate)
-import Data.Drasil.Concepts.Math (equation, surface, calculation)
+import Data.Drasil.Concepts.Math (equation, surface)
 import Data.Drasil.Concepts.PhysicalProperties (mass)
 import Data.Drasil.Concepts.Physics (compression, fbd, force, strain, stress,
   tension)
@@ -25,8 +24,8 @@ import Data.Drasil.SentenceStructures (foldlList, foldlSP, foldlSent,
   foldlSent_, ofThe, sAnd, sOr)
 import Data.Drasil.SI_Units (degree, metre, newton, pascal)
 import Data.Drasil.Utils (enumBullet, enumSimple, getES, weave)
-
-import Drasil.SSP.Assumptions (sspAssumptions, newA3, sspRefDB)
+import Drasil.SSP.Changes (likelyChanges_SRS)
+import Drasil.SSP.Assumptions (sspAssumptions, sspRefDB)
 import Drasil.SSP.DataDefs (ddRef, lengthLb, lengthLs, mobShrDerivation, 
   resShrDerivation, sliceWght, sspDataDefs, stfMtrxDerivation)
 import Drasil.SSP.DataDesc (sspInputMod)
@@ -37,7 +36,6 @@ import Drasil.SSP.Goals (sspGoals)
 import Drasil.SSP.IMods (fctSftyDerivation, instModIntro1, instModIntro2, 
   intrSlcDerivation, nrmShrDerivation, rigDisDerivation, rigFoSDerivation, 
   sspIMods)
-import Drasil.DocumentLanguage.RefHelpers (refA)
 import Drasil.SSP.Requirements (sspInputDataTable, sspRequirements)
 import Drasil.SSP.TMods (sspTMods)
 import Drasil.SSP.Unitals (fs, index, numbSlices, sspConstrained, sspInputs, 
@@ -48,7 +46,7 @@ import qualified Drasil.SRS as SRS (funcReq, inModel, likeChg, missingP,
 
 import Drasil.DocumentLanguage (DocDesc, DocSection(..), IntroSec(..), 
   IntroSub(..), LFunc(..), RefSec(..), RefTab(..), TConvention(..), TSIntro, 
-  TSIntro(..), LCsSec(..), mkDoc, tsymb'', mkLklyChnk)
+  TSIntro(..), LCsSec(..), mkDoc, tsymb'')
 
 import Drasil.Sections.AuxiliaryConstants (valsOfAuxConstantsF)
 import Drasil.Sections.GeneralSystDesc (genSysF)
@@ -60,7 +58,7 @@ import Drasil.Sections.SpecificSystemDescription (dataConstraintUncertainty,
 
 
 --type declarations for sections--
-s3, s4, s5, s6, s7 :: Section
+s3, s4, s5, s7 :: Section
 
 s1_2_intro :: [TSIntro]
 
@@ -301,7 +299,7 @@ s4_1_3 = goalStmtF (map (\(x, y) -> x `ofThe` y) [
 goals_list = enumSimple 1 (short goalStmt) sspGoals
 
 -- SECTION 4.2 --
-s4_2 = solChSpecF ssa (s4_1, s6) ddEnding
+s4_2 = solChSpecF ssa (s4_1, SRS.likeChg [] []) ddEnding
   (EmptyS, dataConstraintUncertainty, EmptyS)
   ([s4_2_1_list], s4_2_2_tmods, s4_2_3_genDefs, s4_2_4_dataDefs, 
   instModIntro1:instModIntro2:s4_2_5_IMods, [s4_2_6Table2, s4_2_6Table3]) []
@@ -385,21 +383,8 @@ s5_2 = nonFuncReqF [accuracy, performanceSpd]
   [correctness, understandability, reusability, maintainability] r EmptyS
   where r = (short ssa) +:+ S "is intended to be an educational tool"
 
--- SECTION 6     --
+-- SECTION 6      --
 -- Likely Changes --
-s6 = SRS.likeChg [] [] -- can be removed with work on #321
-
-likelyChanges_SRS :: [Contents]
-likelyChanges_SRS = [likelychg1]
-
-likelychg1 :: Contents
-likelychg1 = mkLklyChnk "LC_inhomogeneous" lc1Desc "Calculate-Inhomogeneous-Soil-Layers"
-
-lc1Desc :: Sentence
-lc1Desc = foldlSent [(refA sspRefDB newA3) `sDash` S "The",
-  phrase system +:+. S "currently assumes the different layers of the soil are homogeneous",
-  S "In the future,", plural calculation,
-  S "can be added for inconsistent soil properties throughout"]
 
 -- SECTION 7 --
 s7 = valsOfAuxConstantsF ssa []

--- a/code/Example/Drasil/SSP/Changes.hs
+++ b/code/Example/Drasil/SSP/Changes.hs
@@ -1,4 +1,4 @@
-module Drasil.SSP.Changes (likelyChanges_SRS) where
+module Drasil.SSP.Changes (likelyChanges_SRS, unlikelyChanges_SRS) where
 
 -- A list of likely and unlikely changes for the SSP example
 

--- a/code/Example/Drasil/SSP/Changes.hs
+++ b/code/Example/Drasil/SSP/Changes.hs
@@ -1,0 +1,25 @@
+module Drasil.SSP.Changes (likelyChanges_SRS) where
+
+-- A list of likely and unlikely changes for the SSP example
+
+import Language.Drasil
+import Drasil.DocumentLanguage (mkLklyChnk)
+import Data.Drasil.SentenceStructures (foldlSent)
+import Drasil.SSP.Assumptions (sspRefDB, newA3)
+import Data.Drasil.Concepts.Math (calculation)
+import Drasil.DocumentLanguage.RefHelpers (refA)
+import Data.Drasil.Concepts.Documentation (system)
+
+likelyChanges_SRS :: [Contents]
+likelyChanges_SRS = [likelychg1]
+
+likelychg1 :: Contents
+likelychg1 = mkLklyChnk "LC_inhomogeneous" lc1Desc "Calculate-Inhomogeneous-Soil-Layers"
+
+lc1Desc :: Sentence
+lc1Desc = foldlSent [(refA sspRefDB newA3) `sDash` S "The",
+  phrase system +:+. S "currently assumes the different layers of the soil are homogeneous",
+  S "In the future,", plural calculation,
+  S "can be added for inconsistent soil properties throughout"]
+
+--unlikelyChanges_SRS :: [Contents]

--- a/code/Example/Drasil/SSP/Changes.hs
+++ b/code/Example/Drasil/SSP/Changes.hs
@@ -3,9 +3,9 @@ module Drasil.SSP.Changes (likelyChanges_SRS) where
 -- A list of likely and unlikely changes for the SSP example
 
 import Language.Drasil
-import Drasil.DocumentLanguage (mkLklyChnk)
+import Drasil.DocumentLanguage (mkLklyChnk, mkUnLklyChnk)
 import Data.Drasil.SentenceStructures (foldlSent)
-import Drasil.SSP.Assumptions (sspRefDB, newA3)
+import Drasil.SSP.Assumptions (sspRefDB, newA3, newA5, newA6, newA8)
 import Data.Drasil.Concepts.Math (calculation)
 import Drasil.DocumentLanguage.RefHelpers (refA)
 import Data.Drasil.Concepts.Documentation (system)
@@ -22,4 +22,20 @@ lc1Desc = foldlSent [(refA sspRefDB newA3) `sDash` S "The",
   S "In the future,", plural calculation,
   S "can be added for inconsistent soil properties throughout"]
 
---unlikelyChanges_SRS :: [Contents]
+unlikelyChanges_SRS :: [Contents]
+unlikelyChanges_SRS = [unlikelychg1, unlikelychg2]
+
+unlikelychg1 = mkUnLklyChnk "UC_normshearlinear" uc1Desc "Normal-And-Shear-Linear-Only"
+unlikelychg2 = mkUnLklyChnk "UC_2donly"          uc2Desc "2D-Analysis-Only"
+
+uc1Desc, uc2Desc :: Sentence
+
+uc1Desc = foldlSent [S "Chages related to", (refA sspRefDB newA5), S "and",
+  (refA sspRefDB newA6), S "are not possible due to the dependency",
+  S "of the", plural calculation, S "on the linear relationship between",
+  S "interslice normal and shear forces"]
+
+uc2Desc = foldlSent [(refA sspRefDB newA8), S "allows for 2D analysis" +:+.
+  S "with these models only because stress along z-direction is zero", 
+  S "These models do not take into account stress in the z-direction, and",
+  S "therefore cannot be without manipulation to attempt 3d analysis"]

--- a/code/Example/Drasil/SSP/Changes.hs
+++ b/code/Example/Drasil/SSP/Changes.hs
@@ -4,7 +4,7 @@ module Drasil.SSP.Changes (likelyChanges_SRS, unlikelyChanges_SRS) where
 
 import Language.Drasil
 import Drasil.DocumentLanguage (mkLklyChnk, mkUnLklyChnk)
-import Data.Drasil.SentenceStructures (foldlSent)
+import Data.Drasil.SentenceStructures (foldlSent, foldlSP)
 import Drasil.SSP.Assumptions (sspRefDB, newA3, newA5, newA6, newA8)
 import Data.Drasil.Concepts.Math (calculation)
 import Drasil.DocumentLanguage.RefHelpers (refA)
@@ -23,7 +23,9 @@ lc1Desc = foldlSent [(refA sspRefDB newA3) `sDash` S "The",
   S "can be added for inconsistent soil properties throughout"]
 
 unlikelyChanges_SRS :: [Contents]
-unlikelyChanges_SRS = [unlikelychg1, unlikelychg2]
+unlikelyChanges_SRS = [ucIntro, unlikelychg1, unlikelychg2]
+
+unlikelychg1, unlikelychg2 :: Contents
 
 unlikelychg1 = mkUnLklyChnk "UC_normshearlinear" uc1Desc "Normal-And-Shear-Linear-Only"
 unlikelychg2 = mkUnLklyChnk "UC_2donly"          uc2Desc "2D-Analysis-Only"
@@ -39,3 +41,7 @@ uc2Desc = foldlSent [(refA sspRefDB newA8), S "allows for 2D analysis" +:+.
   S "with these models only because stress along z-direction is zero", 
   S "These models do not take into account stress in the z-direction, and",
   S "therefore cannot be without manipulation to attempt 3d analysis"]
+
+ucIntro :: Contents
+ucIntro = foldlSP [S "If changes were to be made with regard to the following" `sC`
+  S "a different algorithm would be needed"]

--- a/code/drasil.cabal
+++ b/code/drasil.cabal
@@ -237,6 +237,7 @@ executable ssp
     , Drasil.SRS
     , Drasil.SSP.Assumptions
     , Drasil.SSP.Body
+    , Drasil.SSP.Changes
     , Drasil.SSP.DataDefs
     , Drasil.SSP.DataDesc
     , Drasil.SSP.Defs

--- a/code/stable/ssp/SSP_SRS.html
+++ b/code/stable/ssp/SSP_SRS.html
@@ -4517,6 +4517,30 @@ Calculate-Inhomogeneous-Soil-Layers: <a href=#A:Soil-Layer-Homogeneous>Soil-Laye
 </ul>
 </div>
 </div>
+<div id="Sec:UCs">
+<div class="section">
+<h1>
+Unlikely Changes
+</h1>
+<p class="paragraph">
+If changes were to be made with regard to the following, a different algorithm would be needed.
+</p>
+<ul class="hide-list-style">
+<li>
+<div id="UC:UC.normshearlinear">
+Normal-And-Shear-Linear-Only: Chages related to <a href=#A:Interslice-Norm-Shear-Forces-Linear>Interslice-Norm-Shear-Forces-Linear</a> and <a href=#A:Base-Norm-Shear-Forces-Linear-on-FS>Base-Norm-Shear-Forces-Linear-on-FS</a> are not possible due to the dependency of the calculations on the linear relationship between interslice normal and shear forces.
+</div>
+</li>
+</ul>
+<ul class="hide-list-style">
+<li>
+<div id="UC:UC.2donly">
+2D-Analysis-Only: <a href=#A:Plane-Strain-Conditions>Plane-Strain-Conditions</a> allows for 2D analysis with these models only because stress along z-direction is zero. These models do not take into account stress in the z-direction, and therefore cannot be without manipulation to attempt 3d analysis.
+</div>
+</li>
+</ul>
+</div>
+</div>
 <div id="Sec:AuxConstants">
 <div class="section">
 <h1>

--- a/code/stable/ssp/SSP_SRS.tex
+++ b/code/stable/ssp/SSP_SRS.tex
@@ -20,6 +20,8 @@
 \global\tabulinesep=1mm
 \newcounter{lcnum}
 \newcommand{\lcthelcnum}{LC\thelcnum}
+\newcounter{ucnum}
+\newcommand{\uctheucnum}{UC\theucnum}
 \bibliography{bibfile}
 \title{Software Requirements Specification for Slope Stability Analysis}
 \author{Henry Frankis}
@@ -1325,6 +1327,15 @@ SSA is intended to be an educational tool, so accuracy and performance are not p
 \label{Sec:LCs}
 \begin{description}
 \item[\refstepcounter{lcnum}\lcthelcnum\label{LC:LC.inhomogeneous}:]A\ref{A:Soil-Layer-Homogeneous} - The system currently assumes the different layers of the soil are homogeneous. In the future, calculations can be added for inconsistent soil properties throughout.
+\end{description}
+\section{Unlikely Changes}
+\label{Sec:UCs}
+If changes were to be made with regard to the following, a different algorithm would be needed.
+\begin{description}
+\item[\refstepcounter{ucnum}\uctheucnum\label{UC:UC.normshearlinear}:]Chages related to A\ref{A:Interslice-Norm-Shear-Forces-Linear} and A\ref{A:Base-Norm-Shear-Forces-Linear-on-FS} are not possible due to the dependency of the calculations on the linear relationship between interslice normal and shear forces.
+\end{description}
+\begin{description}
+\item[\refstepcounter{ucnum}\uctheucnum\label{UC:UC.2donly}:]A\ref{A:Plane-Strain-Conditions} allows for 2D analysis with these models only because stress along z-direction is zero. These models do not take into account stress in the z-direction, and therefore cannot be without manipulation to attempt 3d analysis.
 \end{description}
 \section{Values of Auxiliary Constants}
 \label{Sec:AuxConstants}


### PR DESCRIPTION
As mentioned in smiths/caseStudies#47, an unlikely changes section can be added to the SSP example.

This PR's end files reflect said change, however, similar to PR #681, the links to assumptions need to be checked as their generated addresses are not defined. (Tracking in #683.)