### PR TITLE
SSP Image Symbol Update Note

### DIFF
--- a/code/Example/Drasil/SSP/Body.hs
+++ b/code/Example/Drasil/SSP/Body.hs
@@ -289,7 +289,8 @@ fig_indexconv = fig (foldlSent_ [S "Index convention for numbering",
 
 fig_forceacting :: Contents
 fig_forceacting = fig (at_start' force +:+ S "acting on a" +:+
-  phrase slice) "ForceDiagram.png" "ForceDiagram"
+  phrase slice +:+ S "(Note: Instances of E in the figure is" +:+
+  S "to be relabelled G)") "ForceDiagram.png" "ForceDiagram"
 
 -- SECTION 4.1.3 --
 s4_1_3 = goalStmtF (map (\(x, y) -> x `ofThe` y) [

--- a/code/stable/ssp/SSP_SRS.html
+++ b/code/stable/ssp/SSP_SRS.html
@@ -1328,9 +1328,9 @@ Index convention for numbering slice and interslice force variables
 </p>
 </div>
 <div id="Figure:ForceDiagram">
-<img class="figure" src="ForceDiagram.png" alt="Forces acting on a slice"></img>
+<img class="figure" src="ForceDiagram.png" alt="Forces acting on a slice (Note: Instances of E in the figure is to be relabelled G)"></img>
 <p class="caption">
-Forces acting on a slice
+Forces acting on a slice (Note: Instances of E in the figure is to be relabelled G)
 </p>
 </div>
 </div>

--- a/code/stable/ssp/SSP_SRS.tex
+++ b/code/stable/ssp/SSP_SRS.tex
@@ -329,7 +329,7 @@ A free body diagram of the forces acting on the slice is displayed in Figure~\re
 \begin{figure}
 \begin{center}
 \includegraphics[width=\textwidth]{ForceDiagram.png}
-\caption{Forces acting on a slice}
+\caption{Forces acting on a slice (Note: Instances of E in the figure is to be relabelled G)}
 \label{Figure:ForceDiagram}
 \end{center}
 \end{figure}


### PR DESCRIPTION
Small change propagating from smiths/caseStudies#98: add note for the force diagram picture about relabelling E to G.