### PR TITLE
commented out/removed Breqns

### DIFF
--- a/code/Language/Drasil/TeX/Preamble.hs
+++ b/code/Language/Drasil/TeX/Preamble.hs
@@ -20,7 +20,7 @@ data Package = AMSMath
              | Dot2Tex
              | AdjustBox
              | AMSsymb --displays bold math sets (reals, naturals, etc.)
-             | Breqn --line breaks long equations automaticly
+--           | Breqn --line breaks long equations automaticly
              | FileContents --creates .bib file within .tex file
              | BibLaTeX
              | Tabu --adds auto column width feature for tables 
@@ -45,7 +45,7 @@ addPackage Tikz      = usepackage "tikz" %%
 addPackage Dot2Tex   = usepackage "dot2texi"
 addPackage AdjustBox = usepackage "adjustbox"
 addPackage AMSsymb   = usepackage "amssymb"
-addPackage Breqn     = usepackage "breqn"
+--addPackage Breqn     = usepackage "breqn"
 addPackage FileContents = usepackage "filecontents"
 addPackage BibLaTeX  = command1o "usepackage" (Just "backend=bibtex") "biblatex"
 addPackage Tabu      = usepackage "tabu"
@@ -83,7 +83,7 @@ genPreamble los = let (pkgs, defs) = parseDoc los
 
 parseDoc :: [LayoutObj] -> ([Package], [Def])
 parseDoc los' = 
-  ([FontSpec, FullPage, HyperRef, AMSMath, AMSsymb, Mathtools, Breqn, Unicode] ++ 
+  ([FontSpec, FullPage, HyperRef, AMSMath, AMSsymb, Mathtools, Unicode] ++ 
    (nub $ concat $ map fst res)
   , [SetMathFont] ++ (nub $ concat $ map snd res))
   where 

--- a/code/stable/gamephys/Chipmunk_SRS.tex
+++ b/code/stable/gamephys/Chipmunk_SRS.tex
@@ -6,7 +6,6 @@
 \usepackage{amsmath}
 \usepackage{amssymb}
 \usepackage{mathtools}
-\usepackage{breqn}
 \usepackage{unicode-math}
 \usepackage{tabu}
 \usepackage{longtable}

--- a/code/stable/glassbr/GlassBR_SRS.tex
+++ b/code/stable/glassbr/GlassBR_SRS.tex
@@ -6,7 +6,6 @@
 \usepackage{amsmath}
 \usepackage{amssymb}
 \usepackage{mathtools}
-\usepackage{breqn}
 \usepackage{unicode-math}
 \usepackage{tabu}
 \usepackage{longtable}

--- a/code/stable/nopcm/NoPCM_SRS.tex
+++ b/code/stable/nopcm/NoPCM_SRS.tex
@@ -6,7 +6,6 @@
 \usepackage{amsmath}
 \usepackage{amssymb}
 \usepackage{mathtools}
-\usepackage{breqn}
 \usepackage{unicode-math}
 \usepackage{tabu}
 \usepackage{longtable}

--- a/code/stable/ssp/SSP_SRS.tex
+++ b/code/stable/ssp/SSP_SRS.tex
@@ -6,7 +6,6 @@
 \usepackage{amsmath}
 \usepackage{amssymb}
 \usepackage{mathtools}
-\usepackage{breqn}
 \usepackage{unicode-math}
 \usepackage{tabu}
 \usepackage{longtable}

--- a/code/stable/swhs/SWHS_SRS.tex
+++ b/code/stable/swhs/SWHS_SRS.tex
@@ -6,7 +6,6 @@
 \usepackage{amsmath}
 \usepackage{amssymb}
 \usepackage{mathtools}
-\usepackage{breqn}
 \usepackage{unicode-math}
 \usepackage{tabu}
 \usepackage{longtable}

--- a/code/stable/tiny/SRS.tex
+++ b/code/stable/tiny/SRS.tex
@@ -6,7 +6,6 @@
 \usepackage{amsmath}
 \usepackage{amssymb}
 \usepackage{mathtools}
-\usepackage{breqn}
 \usepackage{unicode-math}
 \usepackage{tabu}
 \usepackage{longtable}
@@ -120,7 +119,7 @@ ${h_{p}}$ & Initial gap film conductance &
 \\
 ${k_{c}}$ & Clad conductivity & 
 \\
-${τ_{c}}$ & Clad thickness &  
+${τ_{c}}$ & Clad thickness & 
 \\
 \bottomrule
 \label{Table:ToS}


### PR DESCRIPTION
As discussed in #701, removing `Breqns` for now may be a good idea to get the pdfs to generate for the SWHS and SSP examples (along with removing some of the warnings coming up in the other examples).