### PR TITLE
Renamed Reference Names in GlassBR

### DIFF
--- a/code/Example/Drasil/GlassBR/Assumptions.hs
+++ b/code/Example/Drasil/GlassBR/Assumptions.hs
@@ -16,7 +16,7 @@ import Drasil.GlassBR.Unitals ( lite, explosion, lateral, load_dur, explosion,
   constant_LoadDur, constant_ModElas, constant_M, constant_K, constant_LoadDF, constant_LoadSF)
 import Drasil.GlassBR.Concepts (lShareFac, gLassBR,
   glaSlab, glass, responseTy, cantilever, beam, plane, edge)
-import Drasil.GlassBR.References (gbCitations, astm_LR2009)
+import Drasil.GlassBR.References (gbCitations, astm2009)
  
 gbRefDB :: ReferenceDB
 gbRefDB = rdb [] [] newAssumptions [] [] gbCitations
@@ -55,7 +55,7 @@ a1Desc = foldlSent [S "The standard E1300-09a for",
   S "supported on one side acts as a", phrase cantilever]
 
 a2Desc :: Sentence
-a2Desc = foldlSent [S "Following", cite gbRefDB astm_LR2009 +:+ sParen
+a2Desc = foldlSent [S "Following", cite gbRefDB astm2009 +:+ sParen
   (S "pg. 1") `sC` S "this", phrase practice,
   S "does not apply to any form of", foldlOptions $ map S ["wired",
   "patterned", "etched", "sandblasted", "drilled", "notched", "grooved glass"],

--- a/code/Example/Drasil/GlassBR/References.hs
+++ b/code/Example/Drasil/GlassBR/References.hs
@@ -5,48 +5,41 @@ import Language.Drasil
 import Data.Drasil.Citations (koothoor2013, smithLai2005, parnasClements1986)
 import Data.Drasil.People (jRobertson, jmBracci, sRobertson, tlKohutek, wlBeason)
 
-rbrtsn2012, astm_LR2009, astm_C1036, astm_C1048, glThick1998 :: Citation
+rbrtsn2012, astm2009, astm2016, astm2012, beasonEtAl1998 :: Citation
 
 gbCitations :: BibRef
-gbCitations = [koothoor2013, smithLai2005, rbrtsn2012, astm_LR2009, astm_C1036,
-  astm_C1048, glThick1998, parnasClements1986]
+gbCitations = [koothoor2013, smithLai2005, rbrtsn2012, astm2009, astm2016,
+  astm2012, beasonEtAl1998, parnasClements1986]
 
 rbrtsn2012 = cMisc "rbrtsn2012" [author [jRobertson, sRobertson], title
   (S "Volere requirements specification template edition 16"),
   howPublishedU (S "https://pdfs.semanticscholar.org/cf57/27a59801086cbd3d14e5" :+: 
     S "87e09880561dbe22.pdf"), year 2012]
 
-astm_LR2009 = cMisc "astm_LR2009" [author [mononym "ASTM E1300-09"],
+astm2009 = cMisc "astm2009" [author [mononym "ASTM"],
   title (S "Standard Practice for Determining Load Resistance of Glass in Buildings"),
   publisher (S "ASTM International"),
   bookTitle (S "Standard E1300-09a"),
-  year (2009),
-  howPublishedU (S "www.astm.org")]
+  year (2009), howPublishedU (S "www.astm.org")]
 
-astm_C1036 = cMisc "astm_C1036"
-  [ author [mononym "ASTM C1036-16"],
+astm2016 = cMisc "astm2016"
+  [ author [mononym "ASTM"],
   title (S "Standard specification for Flat Glass"),
   publisher (S "ASTM International"),  
   address (S "West Conshohocken, PA"),
-  year 2016, howPublishedU (S "www.astm.org")
-  ]
+  year 2016, howPublishedU (S "https://doi.org/10.1520/C1036-16")]
 
-astm_C1048 = cMisc "astm_C1048"
-  [
-  author [mononym "ASTM C1048-04"],
-  title (S "Specification for Heat-Treated Flat Glass-Kind" +:+
-    S "HS, Kind FT Coated and Uncoated Glass"),
+astm2012 = cMisc "astm2012"
+  [ author [mononym "ASTM"],
+  title (S "Standard Specification for Heat-Strengthened and Fully Tempered" +:+
+    S "Flat Glass"),
   publisher (S "ASTM International"),
   address (S "West Conshohocken, PA"),
-  year 2009,
-  howPublishedU (S "www.astm.org")
-  ]
+  year 2012, howPublishedU (S "https://doi.org/10.1520/C1048-12E01")]
 
-glThick1998 = cMisc "glThick1998"
-  [
-  author [wlBeason, tlKohutek, jmBracci],
+beasonEtAl1998 = cMisc "beasonEtAl1998"
+  [ author [wlBeason, tlKohutek, jmBracci],
   title (S "Basis for ASTME E 1300 Annealed Glass Thickness Selection Charts"),
   bookTitle (S "ASCE Library"),
   month Feb, year 1998,
-  howPublishedU (S "doi.org/10.1061/(ASCE)0733-9445(1998)124:2(215)")
-  ]
+  howPublishedU (S "doi.org/10.1061/(ASCE)0733-9445(1998)124:2(215)")]

--- a/code/stable/glassbr/GlassBR_SRS.html
+++ b/code/stable/glassbr/GlassBR_SRS.html
@@ -1082,7 +1082,7 @@ glassTy: The standard E1300-09a for calculation applies only to monolithic, lami
 <ul class="hide-list-style">
 <li>
 <div id="A:glassConditionA">
-glassCondition: Following <a href=#astm.LR2009>astm_LR2009</a> (pg. 1), this practice does not apply to any form of wired, patterned, etched, sandblasted, drilled, notched, or grooved glass with surface and edge treatments that alter the glass strength.
+glassCondition: Following <a href=#astm2009>astm2009</a> (pg. 1), this practice does not apply to any form of wired, patterned, etched, sandblasted, drilled, notched, or grooved glass with surface and edge treatments that alter the glass strength.
 </div>
 </li>
 </ul>
@@ -4452,22 +4452,22 @@ References
 </h1>
 <ul class="hide-list-style">
 <li>
-<div id="astm_C1036">
-[1]: ASTM C1036-16. <em>Standard specification for Flat Glass</em>. West Conshohocken, PA: ASTM International, 2016. www.astm.org.
+<div id="astm2009">
+[1]: ASTM. <em>Standard Practice for Determining Load Resistance of Glass in Buildings</em>. <em>Standard E1300-09a</em>. ASTM International, 2009. www.astm.org.
 </div>
 </li>
 <li>
-<div id="astm_C1048">
-[2]: ASTM C1048-04. <em>Specification for Heat-Treated Flat Glass-Kind HS, Kind FT Coated and Uncoated Glass</em>. West Conshohocken, PA: ASTM International, 2009. www.astm.org.
+<div id="astm2012">
+[2]: ASTM. <em>Standard Specification for Heat-Strengthened and Fully Tempered Flat Glass</em>. West Conshohocken, PA: ASTM International, 2012. https://doi.org/10.1520/C1048-12E01.
 </div>
 </li>
 <li>
-<div id="astm_LR2009">
-[3]: ASTM E1300-09. <em>Standard Practice for Determining Load Resistance of Glass in Buildings</em>. <em>Standard E1300-09a</em>. ASTM International, 2009. www.astm.org.
+<div id="astm2016">
+[3]: ASTM. <em>Standard specification for Flat Glass</em>. West Conshohocken, PA: ASTM International, 2016. https://doi.org/10.1520/C1036-16.
 </div>
 </li>
 <li>
-<div id="glThick1998">
+<div id="beasonEtAl1998">
 [4]: Beason, W. Lynn, Kohutek, Terry L., and Bracci, Joseph M. <em>Basis for ASTME E 1300 Annealed Glass Thickness Selection Charts</em>. <em>ASCE Library</em>. February, 1998. doi.org/10.1061/(ASCE)0733-9445(1998)124:2(215).
 </div>
 </li>

--- a/code/stable/glassbr/GlassBR_SRS.tex
+++ b/code/stable/glassbr/GlassBR_SRS.tex
@@ -325,7 +325,7 @@ This section simplifies the original problem and helps in developing the theoret
 \item[\refstepcounter{assumpnum}\atheassumpnum\label{A:glassTyA}:]The standard E1300-09a for calculation applies only to monolithic, laminated, or insulating glass constructions of rectangular shape with continuous lateral support along. one, two, three, or four edge This practice assumes that (1) the supported glass edge for two, three and four-sided support conditions are simply supported and free to slip in plane; (2) glass supported on two sides acts as a simply supported beam and (3) glass supported on one side acts as a cantilever.
 \end{description}
 \begin{description}
-\item[\refstepcounter{assumpnum}\atheassumpnum\label{A:glassConditionA}:]Following \cite{astm.LR2009} (pg. 1), this practice does not apply to any form of wired, patterned, etched, sandblasted, drilled, notched, or grooved glass with surface and edge treatments that alter the glass strength.
+\item[\refstepcounter{assumpnum}\atheassumpnum\label{A:glassConditionA}:]Following \cite{astm2009} (pg. 1), this practice does not apply to any form of wired, patterned, etched, sandblasted, drilled, notched, or grooved glass with surface and edge treatments that alter the glass strength.
 \end{description}
 \begin{description}
 \item[\refstepcounter{assumpnum}\atheassumpnum\label{A:explsnScenarioA}:]This system only considers the external explosion scenario for its calculations.
@@ -880,31 +880,31 @@ ${SD_{max}}$ & maximum stand off distance permissible for input & $130.0$ & m
 \section{References}
 \label{Sec:References}
 \begin{filecontents*}{bibfile.bib}
-@misc{astm\_C1036,
-author={ASTM C1036-16},
-title={Standard specification for Flat Glass},
-publisher={ASTM International},
-address={West Conshohocken, PA},
-year={2016},
-howpublished={\url{www.astm.org}}}
-
-@misc{astm\_C1048,
-author={ASTM C1048-04},
-title={Specification for Heat-Treated Flat Glass-Kind HS, Kind FT Coated and Uncoated Glass},
-publisher={ASTM International},
-address={West Conshohocken, PA},
-year={2009},
-howpublished={\url{www.astm.org}}}
-
-@misc{astm\_LR2009,
-author={ASTM E1300-09},
+@misc{astm2009,
+author={ASTM},
 title={Standard Practice for Determining Load Resistance of Glass in Buildings},
 publisher={ASTM International},
 booktitle={Standard E1300-09a},
 year={2009},
 howpublished={\url{www.astm.org}}}
 
-@misc{glThick1998,
+@misc{astm2012,
+author={ASTM},
+title={Standard Specification for Heat-Strengthened and Fully Tempered Flat Glass},
+publisher={ASTM International},
+address={West Conshohocken, PA},
+year={2012},
+howpublished={\url{https://doi.org/10.1520/C1048-12E01}}}
+
+@misc{astm2016,
+author={ASTM},
+title={Standard specification for Flat Glass},
+publisher={ASTM International},
+address={West Conshohocken, PA},
+year={2016},
+howpublished={\url{https://doi.org/10.1520/C1036-16}}}
+
+@misc{beasonEtAl1998,
 author={Beason, W. Lynn and Kohutek, Terry L. and Bracci, Joseph M.},
 title={Basis for ASTME E 1300 Annealed Glass Thickness Selection Charts},
 booktitle={ASCE Library},


### PR DESCRIPTION
As per #721, the names of the references were renamed according to the agreed-upon convention of AuthorYYYY.