### PR TITLE
Corrected import of AST.hs

### DIFF
--- a/code/drasil-code/Language/Drasil/Code/AST.hs
+++ b/code/drasil-code/Language/Drasil/Code/AST.hs
@@ -8,8 +8,7 @@
 
 module Language.Drasil.Code.AST where
 
-import Language.Drasil.Chunk
-import Language.Drasil.Chunk.Eq
+import Language.Drasil
 
 type HighLevelCode = [Module]
 type Name = String


### PR DESCRIPTION
The import list was incorrect, @JacquesCarette Should I still avoid specifying the imports of `Language.Drasil`?