### PR TITLE
Improved imports in LanguageRenderer.hs

### DIFF
--- a/code/drasil-code/Language/Drasil/Code/Imperative/LanguageRenderer.hs
+++ b/code/drasil-code/Language/Drasil/Code/Imperative/LanguageRenderer.hs
@@ -33,7 +33,9 @@ import Language.Drasil.Code.Imperative.Helpers (angles,blank,doubleQuotedText,on
 import qualified Data.Map as Map (fromList,lookup)
 import Data.List (find)
 import Prelude hiding (break,print,return,last,mod)
-import Text.PrettyPrint.HughesPJ
+import Text.PrettyPrint.HughesPJ (Doc, text, empty, render, (<>), (<+>), brackets, parens,
+  isEmpty, rbrace, lbrace, vcat, space, char, double, quotes, integer, semi, equals, braces,
+  int, comma, colon)
 
 
 data Options = Options {


### PR DESCRIPTION
As per issue #569.

@JacquesCarette Hello Dr. Carette, I tried to explicitly import things from `AST.hs` in this file but there were a lot of things imported over from there so I've left it as is and will keep it un-checked in issue #569 so that I can come back to it. 