### PR TITLE
Added Unlikely Changes to NoPCM

### DIFF
--- a/code/drasil-code/drasil-code.cabal
+++ b/code/drasil-code/drasil-code.cabal
@@ -36,7 +36,7 @@ library
     mtl >= 2.2.1,
     directory >= 1.2.6.2,
     split >= 0.2.3.1,
-    drasil-lang >= 0.1.0,
+    drasil-lang >= 0.1.2,
     MissingH >= 1.4.0.1,
     parsec >= 3.1.9
   default-language: Haskell2010

--- a/code/drasil-data/drasil-data.cabal
+++ b/code/drasil-data/drasil-data.cabal
@@ -42,7 +42,7 @@ library
     mtl >= 2.2.1,
     directory >= 1.2.6.2,
     split >= 0.2.3.1,
-    drasil-lang >= 0.1.0,
+    drasil-lang >= 0.1.2,
     MissingH >= 1.4.0.1,
     parsec >= 3.1.9,
     data-fix (>= 0.0.4 && <= 1.0),

--- a/code/drasil-example/Drasil/NoPCM/Body.hs
+++ b/code/drasil-example/Drasil/NoPCM/Body.hs
@@ -35,7 +35,7 @@ import Drasil.NoPCM.IMods (eBalanceOnWtr)
 import Drasil.NoPCM.Unitals (temp_init)
 import Drasil.SWHS.References (ref2, ref3, ref4)
 import Drasil.SWHS.Requirements (nonFuncReqs)
-import Drasil.SWHS.Changes (chgsStart, likeChg2, likeChg3, likeChg6, unlikeChg2)
+import Drasil.SWHS.Changes (chgsStart, likeChg2, likeChg3, likeChg6)
 
 import Data.Drasil.People (thulasi)
 import Data.Drasil.Utils (enumSimple, getES, refFromType,
@@ -781,6 +781,11 @@ unlikeChg1 = mkUnLklyChnk "unlikeChg1" (
   foldlSent [chgsStart assump14, S "It is unlikely for the change of",
   phrase water, S "from liquid to a solid, or from liquid to gas to be considered"]) 
   "Water-Fixed-States" 
+
+unlikeChg2 :: Contents
+unlikeChg2 = mkUnLklyChnk "unlikeChg2" (
+  foldlSent [chgsStart assump12, S "Is used for the derivations of IM1",
+  S "(Hack: need Label to fix)"] ) "No-Internal-Heat-Generation"
 
 ----------------------------------------------
 --Section 7:  TRACEABILITY MATRICES AND GRAPHS

--- a/code/drasil-example/Drasil/NoPCM/Body.hs
+++ b/code/drasil-example/Drasil/NoPCM/Body.hs
@@ -35,7 +35,7 @@ import Drasil.NoPCM.IMods (eBalanceOnWtr)
 import Drasil.NoPCM.Unitals (temp_init)
 import Drasil.SWHS.References (ref2, ref3, ref4)
 import Drasil.SWHS.Requirements (nonFuncReqs)
-import Drasil.SWHS.Changes (likeChg2, likeChg3, likeChg6)
+import Drasil.SWHS.Changes (chgsStart, likeChg2, likeChg3, likeChg6, unlikeChg2)
 
 import Data.Drasil.People (thulasi)
 import Data.Drasil.Utils (enumSimple, getES, refFromType,
@@ -148,7 +148,7 @@ mkSRS = RefSec (RefProg intro
            , Description Verbose IncludeUnits
            , Source, RefBy] generalDefinitions ShowDerivation)])]) : --Testing General Definitions.-}
   Verbatim specSystDesc: -- Comment this out and the above in for testing GDs.
-  map Verbatim [reqS, likelyChgs, traceMAndG, specParamVal] ++ (Bibliography : [])
+  map Verbatim [reqS, likelyChgs, unlikelyChgs, traceMAndG, specParamVal] ++ (Bibliography : [])
 
 generalDefinitions :: [GenDefn]
 generalDefinitions = [gd nwtnCooling (Just thermal_flux) ([] :: Derivation) "nwtnCooling",
@@ -774,7 +774,13 @@ likeChg3_npcm = mkLklyChnk "likeChg3" (
 unlikelyChgs = SRS.unlikeChg unlikelyChgsList []
 
 unlikelyChgsList :: [Contents]
-unlikelyChgsList = []
+unlikelyChgsList = [unlikeChg1, unlikeChg2]
+
+unlikeChg1 :: Contents 
+unlikeChg1 = mkUnLklyChnk "unlikeChg1" (
+  foldlSent [chgsStart assump14, S "It is unlikely for the change of",
+  phrase water, S "from liquid to a solid, or from liquid to gas to be considered"]) 
+  "Water-Fixed-States" 
 
 ----------------------------------------------
 --Section 7:  TRACEABILITY MATRICES AND GRAPHS

--- a/code/drasil-example/Drasil/SWHS/Changes.hs
+++ b/code/drasil-example/Drasil/SWHS/Changes.hs
@@ -77,7 +77,7 @@ unlikeChg1 = mkUnLklyChnk "unlikeChg1" (
   phrase water, S "from liquid to a solid or the state change of the", phrase phsChgMtrl, 
   S "from a liquid to a gas to be considered"] ) "Water-PCM-Fixed-States"
 --
-unlikeChg2 = mkUnLklyChnk "unlikeChg1" (
+unlikeChg2 = mkUnLklyChnk "unlikeChg2" (
   foldlSent [chgsStart assump16, S "Is used for the derivations of IM1 and IM2",
   S "(Hack: need Label to fix)"] ) "No-Internal-Heat-Generation"
 --

--- a/code/drasil-example/Drasil/SWHS/Changes.hs
+++ b/code/drasil-example/Drasil/SWHS/Changes.hs
@@ -73,7 +73,7 @@ unlikeChgList = [unlikeChg1, unlikeChg2]
 unlikeChg1, unlikeChg2 :: Contents
 
 unlikeChg1 = mkUnLklyChnk "unlikeChg1" ( 
-  foldlSent [makeRef assump14, S ", ", chgsStart assump18, S "It is unlikely for the changeof", 
+  foldlSent [makeRef assump14, S ", ", chgsStart assump18, S "It is unlikely for the change of", 
   phrase water, S "from liquid to a solid or the state change of the", phrase phsChgMtrl, 
   S "from a liquid to a gas to be considered"] ) "Water-PCM-Fixed-States"
 --

--- a/code/drasil-example/drasil-example.cabal
+++ b/code/drasil-example/drasil-example.cabal
@@ -1,5 +1,5 @@
 Name:		drasil-example
-Version:	0.1.1
+Version:	0.1.2
 Cabal-Version:  >= 1.18
 Author:		Dan Szymczak, Steven Palmer, Jacques Carette, Spencer Smith
 build-type:     Simple
@@ -37,7 +37,7 @@ executable tiny
     mtl >= 2.2.1,
     directory >= 1.2.6.2,
     split >= 0.2.3.1,
-    drasil-lang >= 0.1.1,
+    drasil-lang >= 0.1.2,
     drasil-data >= 0.1.1,
     drasil-code >= 0.1.1
   default-language: Haskell2010

--- a/code/drasil-lang/drasil-lang.cabal
+++ b/code/drasil-lang/drasil-lang.cabal
@@ -1,5 +1,5 @@
 Name:		drasil-lang
-Version:	0.1.1
+Version:	0.1.2
 Cabal-Version:  >= 1.18
 Author:		Dan Szymczak, Steven Palmer, Jacques Carette, Spencer Smith
 build-type:     Simple

--- a/code/stable/nopcm/SRS/NoPCM_SRS.tex
+++ b/code/stable/nopcm/SRS/NoPCM_SRS.tex
@@ -26,6 +26,8 @@
 \newcommand{\rthereqnum}{R\thereqnum}
 \newcounter{lcnum}
 \newcommand{\lcthelcnum}{LC\thelcnum}
+\newcounter{ucnum}
+\newcommand{\uctheucnum}{UC\theucnum}
 \bibliography{bibfile}
 \title{Software Requirements Specification for Solar Water Heating Systems}
 \author{Thulasi Jegatheesan}
@@ -556,6 +558,14 @@ This problem is small in size and relatively simple, so performance is not a pri
 \end{description}
 \begin{description}
 \item[\refstepcounter{lcnum}\lcthelcnum\label{LC:likeChg6}:]A\ref{A:assump15} - Any real tank cannot be perfectly insulated and will lose heat.
+\end{description}
+\section{Unlikely Changes}
+\label{Sec:UCs}
+\begin{description}
+\item[\refstepcounter{ucnum}\uctheucnum\label{UC:unlikeChg1}:]A\ref{A:assump14} - It is unlikely for the change of water from liquid to a solid, or from liquid to gas to be considered.
+\end{description}
+\begin{description}
+\item[\refstepcounter{ucnum}\uctheucnum\label{UC:unlikeChg2}:]A\ref{A:assump12} - Is used for the derivations of IM1 (Hack: need Label to fix).
 \end{description}
 \section{Traceability Matrices and Graphs}
 \label{Sec:TraceMatrices}

--- a/code/stable/nopcm/Website/NoPCM_SRS.html
+++ b/code/stable/nopcm/Website/NoPCM_SRS.html
@@ -1873,6 +1873,27 @@ Tank-Lose-Heat: <a href=#A:assump15>assump15</a> - Any real tank cannot be perfe
 </ul>
 </div>
 </div>
+<div id="Sec:UCs">
+<div class="section">
+<h1>
+Unlikely Changes
+</h1>
+<ul class="hide-list-style">
+<li>
+<div id="UC:unlikeChg1">
+Water-Fixed-States: <a href=#A:assump14>assump14</a> - It is unlikely for the change of water from liquid to a solid, or from liquid to gas to be considered.
+</div>
+</li>
+</ul>
+<ul class="hide-list-style">
+<li>
+<div id="UC:unlikeChg2">
+No-Internal-Heat-Generation: <a href=#A:assump12>assump12</a> - Is used for the derivations of IM1 (Hack: need Label to fix).
+</div>
+</li>
+</ul>
+</div>
+</div>
 <div id="Sec:TraceMatrices">
 <div class="section">
 <h1>

--- a/code/stable/swhs/SRS/SWHS_SRS.tex
+++ b/code/stable/swhs/SRS/SWHS_SRS.tex
@@ -871,7 +871,7 @@ This problem is small in size and relatively simple, so performance is not a pri
 \item[\refstepcounter{ucnum}\uctheucnum\label{UC:unlikeChg1}:]A\ref{A:assump14} ,  A\ref{A:assump18} - It is unlikely for the changeof water from liquid to a solid or the state change of the phase change material from a liquid to a gas to be considered.
 \end{description}
 \begin{description}
-\item[\refstepcounter{ucnum}\uctheucnum\label{UC:unlikeChg1}:]A\ref{A:assump16} - Is used for the derivations of IM1 and IM2 (Hack: need Label to fix).
+\item[\refstepcounter{ucnum}\uctheucnum\label{UC:unlikeChg2}:]A\ref{A:assump16} - Is used for the derivations of IM1 and IM2 (Hack: need Label to fix).
 \end{description}
 \section{Traceability Matrices and Graphs}
 \label{Sec:TraceMatrices}

--- a/code/stable/swhs/Website/SWHS_SRS.html
+++ b/code/stable/swhs/Website/SWHS_SRS.html
@@ -3261,7 +3261,7 @@ Water-PCM-Fixed-States: <a href=#A:assump14>assump14</a> ,  <a href=#A:assump18>
 </ul>
 <ul class="hide-list-style">
 <li>
-<div id="UC:unlikeChg1">
+<div id="UC:unlikeChg2">
 No-Internal-Heat-Generation: <a href=#A:assump16>assump16</a> - Is used for the derivations of IM1 and IM2 (Hack: need Label to fix).
 </div>
 </li>


### PR DESCRIPTION
As it is I am unable to move likely or unlikely changes to a separate file, `Changes.hs`, due to them referencing assumptions which are defined in `Body.hs` due to them needing to reference `IMs`. Creating `Changes.hs` now would result in an import cycle, however, this can be fixed once `Label` is implemented. 

For now, I've defined unlikely changes so that, once able to, creating `Changes.hs` would only require moving them out of `Body.hs`.