### PR TITLE
Add Maybe Label to the items in LayoutObj's List constructor.

### DIFF
--- a/code/drasil-lang/Language/Drasil/Printing/AST.hs
+++ b/code/drasil-lang/Language/Drasil/Printing/AST.hs
@@ -14,6 +14,7 @@ data Fence = Paren | Curly | Norm | Abs
 data OverSymb = Hat
 data Fonts = Bold | Emph
 data Spacing = Thin
+type Label = Spec
 
 data Expr = Dbl   Double
           | Int   Integer
@@ -49,11 +50,11 @@ data Spec = E Expr
                           -- so it's not really a big deal ATM.
 type Title    = Spec
 
-data ListType = Ordered [ItemType] 
-              | Unordered [ItemType]
-              | Simple      [(Title,ItemType)]
-              | Desc        [(Title,ItemType)]
-              | Definitions  [(Title,ItemType)]
+data ListType = Ordered [(ItemType,Maybe Label)]
+              | Unordered [(ItemType,Maybe Label)]
+              | Simple      [(Title,ItemType,Maybe Label)]
+              | Desc        [(Title,ItemType,Maybe Label)]
+              | Definitions  [(Title,ItemType,Maybe Label)]
 
 data ItemType = Flat Spec
               | Nested Spec ListType

--- a/code/drasil-lang/Language/Drasil/Printing/Import.hs
+++ b/code/drasil-lang/Language/Drasil/Printing/Import.hs
@@ -328,11 +328,11 @@ layField sm (HowPublished (Verb v)) = P.HowPublished (P.Verb $ spec sm v)
 
 -- | Translates lists
 makeL :: HasSymbolTable ctx => ctx -> ListType -> P.ListType
-makeL sm (Bullet bs)      = P.Unordered   $ map (item sm) bs
-makeL sm (Numeric ns)     = P.Ordered     $ map (item sm) ns
-makeL sm (Simple ps)      = P.Simple      $ map (\(x,y) -> (spec sm x, item sm y)) ps
-makeL sm (Desc ps)        = P.Desc        $ map (\(x,y) -> (spec sm x, item sm y)) ps
-makeL sm (Definitions ps) = P.Definitions $ map (\(x,y) -> (spec sm x, item sm y)) ps
+makeL sm (Bullet bs)      = P.Unordered   $ map (\x -> (item sm x, Nothing)) bs
+makeL sm (Numeric ns)     = P.Ordered     $ map (\x -> (item sm x, Nothing)) ns
+makeL sm (Simple ps)      = P.Simple      $ map (\(x,y) -> (spec sm x, item sm y, Nothing)) ps
+makeL sm (Desc ps)        = P.Desc        $ map (\(x,y) -> (spec sm x, item sm y, Nothing)) ps
+makeL sm (Definitions ps) = P.Definitions $ map (\(x,y) -> (spec sm x, item sm y, Nothing)) ps
 
 -- | Helper for translating list items
 item :: HasSymbolTable ctx => ctx -> ItemType -> P.ItemType

--- a/code/drasil-lang/Language/Drasil/Printing/LayoutObj.hs
+++ b/code/drasil-lang/Language/Drasil/Printing/LayoutObj.hs
@@ -1,7 +1,7 @@
 module Language.Drasil.Printing.LayoutObj where
 
 import Language.Drasil.Document (MaxWidthPercent, DType)
-import Language.Drasil.Printing.AST (ListType, Spec, Title)
+import Language.Drasil.Printing.AST (ListType, Spec, Title, Label)
 import Language.Drasil.Printing.Citation (BibRef)
 
 data Document = Document Title Author [LayoutObj]
@@ -12,7 +12,6 @@ type Tags     = [String]
 type Depth    = Int
 type Width    = Float
 type Height   = Float
-type Label    = Spec
 type Filepath = String
 type Caption  = Spec
 


### PR DESCRIPTION
This PR is a part of the infrastructure needed for #562. Specifically this provides a replacement for `ALUR` at `LayoutObj` level. 

Currently, the replacement is unused. 