### PR TITLE
[Small PR] qtoc is now constraint-based instead of type-based

### DIFF
--- a/code/drasil-code/Language/Drasil/Chunk/Code.hs
+++ b/code/drasil-code/Language/Drasil/Chunk/Code.hs
@@ -177,7 +177,7 @@ instance Quantity      CodeDefinition where getUnit = getUnit . view quant
 instance CodeIdea      CodeDefinition where codeName = (^. ci)
 instance Eq            CodeDefinition where c1 == c2 = (c1 ^. uid) == (c2 ^. uid)
 
-qtoc :: QDefinition  -> CodeDefinition
+qtoc :: (Quantity q, ExprRelat q, HasSymbol q) => q -> CodeDefinition
 qtoc q = CD (qw q) (funcPrefix ++ symbToCodeName (codeSymb q)) (q ^. relat)
 
 qtov :: QDefinition -> CodeDefinition


### PR DESCRIPTION
As mentioned in the comments of commit 62c3725, the fix implemented for `DataDefinition` was sub-optimal.