### PR TITLE
562 Data

### DIFF
--- a/code/drasil-docLang/Drasil/DocLang.hs
+++ b/code/drasil-docLang/Drasil/DocLang.hs
@@ -23,7 +23,7 @@ module Drasil.DocLang (
     -- Sections.ReferenceMaterial
     intro,
     -- Sections.Requirements
-    nonFuncReqF, reqF,
+    nonFuncReqF, reqF, funcReqDom,
     -- Sections.ScopeOfTheProject
     -- Sections.SolutionCharacterSpec
     SubSec, assembler, sSubSec, siCon, siDDef, siIMod, siSTitl, siSent, siTMod, 
@@ -57,7 +57,7 @@ import Drasil.Sections.AuxiliaryConstants (valsOfAuxConstantsF)
 import Drasil.Sections.GeneralSystDesc (genSysF)
 --import Drasil.Sections.Introduction
 import Drasil.Sections.ReferenceMaterial (intro)
-import Drasil.Sections.Requirements (nonFuncReqF, reqF)
+import Drasil.Sections.Requirements (nonFuncReqF, reqF, funcReqDom)
 --import Drasil.Sections.ScopeOfTheProject
 import Drasil.Sections.SolutionCharacterSpec (SubSec, assembler, sSubSec, siCon, 
     siDDef, siIMod, siSTitl, siSent, siTMod, siUQI, siUQO)

--- a/code/drasil-docLang/Drasil/DocLang/SRS.hs
+++ b/code/drasil-docLang/Drasil/DocLang/SRS.hs
@@ -1,10 +1,10 @@
 module Drasil.DocLang.SRS
- (doc, doc', intro, prpsOfDoc, scpOfReq, charOfIR, orgOfDoc, stakeholder, theCustomer, theClient, 
+ (doc, doc', intro, prpsOfDoc, scpOfReq, charOfIR, orgOfDoc, stakeholder, theCustomer, theClient,
   genSysDes, sysCont, userChar, sysCon, scpOfTheProj, prodUCTable, indPRCase, specSysDes,
   probDesc, termAndDefn, termogy, physSyst, goalStmt, solCharSpec, assumpt, thModel,
-  genDefn, inModel, dataDefn, datCon, require, nonfuncReq, funcReq, likeChg, unlikeChg, 
+  genDefn, inModel, dataDefn, datCon, require, nonfuncReq, funcReq, likeChg, unlikeChg,
   traceyMandG, appendix, reference, propCorSol, offShelfSol, missingP, valsOfAuxCons,
-  tOfSymb) where
+  tOfSymb, srsDom) where
 --Temporary file for keeping the "srs" document constructor until I figure out
 -- a better place for it. Maybe Data.Drasil or Language.Drasil.Template?
 
@@ -21,6 +21,8 @@ import qualified Data.Drasil.Concepts.Documentation as Doc (appendix,
     systemConstraint, termAndDef, terminology, thModel, traceyMandG, tOfSymb, 
     userCharacteristic)
 import Data.Drasil.Phrase (for'')
+
+import Control.Lens ((^.))
 
 -- Local function to keep things looking clean, not exported.
 forTT :: (NamedIdea c, NamedIdea d) => c -> d -> Sentence
@@ -95,6 +97,10 @@ reference   cs ss = section' (titleize' Doc.reference)        cs ss "References"
 offShelfSol cs ss = section' (titleize' Doc.offShelfSolution) cs ss "ExistingSolns"
 
 tOfSymb cs ss = section' (titleize Doc.tOfSymb) cs ss "ToS"
+
+--Root SRS Domain
+srsDom :: CommonConcept
+srsDom = dcc' "srsDom" (Doc.srs ^. term) "srs" ""
 
 --function that sets the shortname of each section to be the reference address
 section' :: Sentence -> [Contents] -> [Section] -> RefAdd -> Section

--- a/code/drasil-docLang/Drasil/DocumentLanguage.hs
+++ b/code/drasil-docLang/Drasil/DocumentLanguage.hs
@@ -363,6 +363,21 @@ symbConvention scs = S "The choice of symbols was made to be consistent with the
 tuIntro :: [TUIntro] -> Contents
 tuIntro x = Paragraph $ foldr ((+:+) . tuI) EmptyS x
 
+-- | mkConCC converts a list of ConceptInstances to Contents using a generic
+-- two-step process for flexibility.
+mkConCC :: (ConceptInstance -> a) -> ([a] -> [Contents]) -> [ConceptInstance] -> [Contents]
+mkConCC f t = t . map f
+
+-- | mkConCC' is a convenient version of mkConCC for when the conversion can be
+-- done in a single, direct step.
+mkConCC' :: (ConceptInstance -> Contents) -> [ConceptInstance] -> [Contents]
+mkConCC' f = mkConCC f id
+
+-- | mkEnumCC is a convenience function for converting ConceptInstances to an
+-- enumeration.
+mkEnumCC :: (ConceptInstance -> ListTuple) -> [ConceptInstance] -> [Contents]
+mkEnumCC f = mkConCC f (replicate 1 . Enumeration . Simple)
+
 -- | table of units intro writer. Translates a TUIntro to a Sentence.
 tuI :: TUIntro -> Sentence
 tuI System  = 

--- a/code/drasil-docLang/Drasil/Sections/Requirements.hs
+++ b/code/drasil-docLang/Drasil/Sections/Requirements.hs
@@ -1,14 +1,16 @@
 module Drasil.Sections.Requirements
-  (fReqF, reqF, nonFuncReqF) where
+  (fReqF, reqF, nonFuncReqF, funcReqDom) where
 
 import Language.Drasil
 
-import Data.Drasil.Concepts.Documentation (priority, software, nonfunctionalRequirement,
+import Data.Drasil.Concepts.Documentation (priority, software, requirement, nonfunctionalRequirement,
   functionalRequirement, section_)
 import Data.Drasil.Concepts.Software (program)
-import Data.Drasil.SentenceStructures (foldlSP, foldlList)
+import Data.Drasil.SentenceStructures (foldlSP, foldlList, foldlSent)
 
 import qualified Drasil.DocLang.SRS as SRS
+
+import Control.Lens ((^.))
 
 -- wrapper for reqIntro
 reqF :: [Section] -> Section
@@ -18,13 +20,23 @@ fReqF :: [Contents] -> Section
 fReqF listOfReqs = SRS.funcReq (listOfReqs) []
 
 --generalized requirements introduction
-reqIntro :: Contents
-reqIntro = foldlSP
+reqIntroS :: Sentence
+reqIntroS = foldlSent
         [S "This", (phrase section_), S "provides the",
         (plural functionalRequirement) `sC` S "the business tasks that the",
         (phrase software), S "is expected to complete" `sC` S "and the", 
         (plural nonfunctionalRequirement) `sC` S "the qualities that the",
         (phrase software), S "is expected to exhibit"]
+
+reqIntro :: Contents
+reqIntro = Paragraph reqIntroS
+
+-- Requirements Domains
+reqDom :: ConceptChunk
+reqDom = ccs (nc "reqDom" $ requirement ^. term) reqIntroS [SRS.srsDom]
+
+funcReqDom :: ConceptChunk
+funcReqDom = ccs (nc "funcReqDom" $ functionalRequirement ^. term) EmptyS [reqDom]
 
 -- wrapper for nonfuncReq
 nonFuncReqF :: (Concept c) => [c] -> [c] -> Sentence -> Sentence -> Section


### PR DESCRIPTION
This PR is part of #562. It adds:
* A tree (chain at the moment) of domains to support functional requirements. `srsDom` -> `reqDom` -> `funcReqDom`
* Generic convenience functions to convert ConceptInstances to Contents. `mkConCC`, `mkConCC'`, and `mkConCC''`. The latter two are more "convenient" uses of the first.