### PR TITLE
[Small] Change argument order for cic

### DIFF
--- a/code/drasil-lang/Language/Drasil/Chunk/Concept.hs
+++ b/code/drasil-lang/Language/Drasil/Chunk/Concept.hs
@@ -55,5 +55,5 @@ ccs n d l = ConDict (nw n) $ DAD d $ map (^. uid) l
 cw :: Concept c => c -> ConceptChunk
 cw c = ConDict (nw c) $ DAD (c ^. defn) (c ^. cdom)
 
-cic :: Concept c => String -> Sentence -> c -> String -> ConceptInstance
-cic u d dom sn = ConInst (ccs (nc u $ pn sn) d [dom]) $ shortname' sn
+cic :: Concept c => String -> Sentence -> String -> c -> ConceptInstance
+cic u d sn dom = ConInst (ccs (nc u $ pn sn) d [dom]) $ shortname' sn


### PR DESCRIPTION
This PR is part of #562. It moves the domain argument to be the last in the `cic` constructor. 

This change is aimed to make using `ConceptInstance` more ergonomic by being able to `zipWith` over `[Concept -> ConceptInstance]`. The rational is a list of `ConceptInstance`s probably all belong to the same domain, so by being able to (easily) associate a domain to an entire list reduces inconsistencies, and helps avoid tedium while writing something like requirements or assumptions.