### PR TITLE
Use ConceptInstance for NoPCM Reqs

### DIFF
--- a/code/drasil-docLang/Drasil/DocLang.hs
+++ b/code/drasil-docLang/Drasil/DocLang.hs
@@ -9,7 +9,7 @@ module Drasil.DocLang (
     StkhldrSec(StkhldrProg2),
     StkhldrSub(Client, Cstmr), TConvention(..), TraceabilitySec(TraceabilityProg), 
     TSIntro(..), UCsSec(..), mkDoc, mkLklyChnk, mkRequirement, 
-    mkUnLklyChnk, tsymb, tsymb'',
+    mkUnLklyChnk, tsymb, tsymb'', mkConCC, mkConCC', mkEnumCC,
     -- DocumentLanguage.Definitions
     Field(..), Fields, InclUnits(IncludeUnits), Verbosity(Verbose),
     -- DocumentLanguage.RefHelpers 
@@ -47,7 +47,8 @@ import Drasil.DocumentLanguage (AppndxSec(..), AuxConstntSec(..),
     ScpOfProjSec(ScpOfProjProg), SCSSub(..), SSDSec(..), SSDSub(..), SolChSpec(..), 
     StkhldrSec(StkhldrProg2), StkhldrSub(Client, Cstmr), TConvention(..), 
     TraceabilitySec(TraceabilityProg), TSIntro(..), UCsSec(..), mkDoc, 
-    mkLklyChnk, mkRequirement, mkUnLklyChnk, tsymb, tsymb'')
+    mkLklyChnk, mkRequirement, mkUnLklyChnk, tsymb, tsymb'', mkConCC, mkConCC',
+    mkEnumCC)
 import Drasil.DocumentLanguage.Definitions (Field(..), Fields, 
     InclUnits(IncludeUnits), Verbosity(Verbose))
 import Drasil.DocumentLanguage.RefHelpers (ModelDB, cite, ddRefDB, mdb, refA, 

--- a/code/drasil-docLang/drasil-docLang.cabal
+++ b/code/drasil-docLang/drasil-docLang.cabal
@@ -1,5 +1,5 @@
 Name:		drasil-docLang
-Version:	0.1.1
+Version:	0.1.2
 Cabal-Version:  >= 1.18
 Author:		Dan Szymczak, Steven Palmer, Jacques Carette, Spencer Smith
 build-type:     Simple

--- a/code/drasil-example/drasil-example.cabal
+++ b/code/drasil-example/drasil-example.cabal
@@ -57,7 +57,7 @@ executable glassbr
     drasil-code >= 0.1.1,
     drasil-printers >= 0.1.0,
     drasil-gen >= 0.1.0,
-    drasil-docLang >= 0.1.0   
+    drasil-docLang >= 0.1.0
   default-language: Haskell2010
   ghc-options:      -Wall
 
@@ -96,7 +96,7 @@ executable nopcm
     drasil-code >= 0.1.1,
     drasil-printers >= 0.1.0,
     drasil-gen >= 0.1.0,
-    drasil-docLang >= 0.1.1
+    drasil-docLang >= 0.1.2
   default-language: Haskell2010
   ghc-options:      -Wall -O2
 

--- a/code/drasil-printers/Language/Drasil/TeX/Print.hs
+++ b/code/drasil-printers/Language/Drasil/TeX/Print.hs
@@ -391,22 +391,22 @@ makeList (Ordered items)     = enumerate   $ vcat $ map pl_item items
 makeList (Definitions items) = symbDescription $ vcat $ def_item items
 
 pl_item :: (ItemType,Maybe Label) -> D
-pl_item (i, l) = mlref l $ p_item i
+pl_item (i, l) = mlref l <> p_item i
 
-mlref :: Maybe Label -> D -> D
-mlref = maybe id $ (%%) . label . spec
+mlref :: Maybe Label -> D
+mlref = maybe empty $ label . spec
 
 p_item :: ItemType -> D
 p_item (Flat s) = item $ spec s
 p_item (Nested t s) = vcat [item $ spec t, makeList s]
 
 sim_item :: [(Spec,ItemType,Maybe Label)] -> [D]
-sim_item = map (\(x,y,l) -> item' (spec $ x :+: S ":") $ mlref l $ sp_item y)
+sim_item = map (\(x,y,l) -> item' (spec (x :+: S ":") <> mlref l) $ sp_item y)
   where sp_item (Flat s) = spec s
         sp_item (Nested t s) = vcat [spec t, makeList s]
 
 def_item :: [(Spec, ItemType,Maybe Label)] -> [D]
-def_item = map (\(x,y,l) -> item $ mlref l $ spec $ x :+: S " is the " :+: d_item y)
+def_item = map (\(x,y,l) -> item $ mlref l <> (spec $ x :+: S " is the " :+: d_item y))
   where d_item (Flat s) = s
         d_item (Nested _ _) = error "Cannot use sublists in definitions"
 -----------------------------------------------------------------

--- a/code/stable/nopcm/SRS/NoPCM_SRS.tex
+++ b/code/stable/nopcm/SRS/NoPCM_SRS.tex
@@ -21,8 +21,6 @@
 \global\tabulinesep=1mm
 \newcounter{assumpnum}
 \newcommand{\atheassumpnum}{A\theassumpnum}
-\newcounter{reqnum}
-\newcommand{\rthereqnum}{R\thereqnum}
 \newcounter{lcnum}
 \newcommand{\lcthelcnum}{LC\thelcnum}
 \newcounter{ucnum}
@@ -612,9 +610,20 @@ ${E_{W}}$ & ${E_{W}}\geq{}0$
 This section provides the functional requirements, the business tasks that the software is expected to complete, and the non-functional requirements, the qualities that the software is expected to exhibit.
 \subsection{Functional Requirements}
 \label{Sec:FRs}
-\begin{description}
-\item[\refstepcounter{reqnum}\rthereqnum\label{Input-Inital-Values}:]Input the following quantities, which define the tank parameters, material properties and initial conditions:
-\end{description}
+\begin{itemize}
+\item[Input-Inital-Values:]\label{nr1}
+                           Input the quantities described in Table~\ref{Table:Input-Variable-Requirements}, which define the tank parameters, material properties and initial conditions.
+\item[Find-Mass:]\label{nr2}
+                 Use the inputs in \hyperref[nr1]{Definition~nr1} to find the mass needed for IM1 to IM2, as follows, where ${V_{W}}$ is the volume of water and ${V_{tank}}$ is the volume of the cylindrical tank: ${m_{W}}={V_{W}} {ρ_{W}}=\frac{D}{2} L {ρ_{W}}$
+\item[Check-Inputs-Satisfy-Physical-Constraints:]\label{nr3}
+                                                 Verify that the inputs satisfy the required physical constraint shown in Table~\ref{Table:InDataConstraints}.
+\item[Output-Input-Derivied-Quantities:]\label{nr4}
+                                        Outputs and inputs quantities and derived quantities in the following list: the quantities from \hyperref[nr1]{Definition~nr1}, the mass from \hyperref[nr2]{Definition~nr2} and ${τ_{W}}$ (from IM1).
+\item[Calculate-Temperature-Water-Over-Time:]\label{nr5}
+                                             Calculate and output the temperature of the water (${T_{W}}$($t$)) over the simulation time
+\item[Calculate-Change-Heat\_Energy-Water-Time:]\label{nr6}
+                                                Calculate and output the change in heat energy in the water (${E_{W}}$($t$)) over the simulation time (from IM3).
+\end{itemize}
 \begin{longtabu}{l l X[l]}
 \toprule
 Symbol & Unit & Description
@@ -639,26 +648,9 @@ ${T_{init}}$ & ${}^{\circ}$C & initial temperature
 ${t_{final}}$ & s & final time
 \\
 \bottomrule
-\label{Table:fr1list}
+\caption{Input Variable Requirements}
+\label{Table:Input-Variable-Requirements}
 \end{longtabu}
-\begin{description}
-\item[\refstepcounter{reqnum}\rthereqnum\label{Use-Above-Find-Mass-IM1-IM2}:]Use the inputs in R\ref{FR:req1} to find the mass needed for IM1 to IM2, as follows, where ${V_{W}}$ is the volume of water and ${V_{tank}}$ is the volume of the cylindrical tank:
-\end{description}
-\begin{dmath}
-{m_{W}}={V_{W}} {ρ_{W}}=\frac{D}{2} L {ρ_{W}}
-\end{dmath}
-\begin{description}
-\item[\refstepcounter{reqnum}\rthereqnum\label{Check-Inputs-Satisfy-Physical-Constraints}:]Verify that the inputs satisfy the required physical constraint shown in Table~\ref{Table:InDataConstraints}.
-\end{description}
-\begin{description}
-\item[\refstepcounter{reqnum}\rthereqnum\label{Output-Input-Derivied-Quantities}:]Outputs and inputs quantities and derived quantities in the following list: the quantities from R\ref{FR:req1}, the mass from R\ref{FR:req2} and ${τ_{W}}$ (from IM1).
-\end{description}
-\begin{description}
-\item[\refstepcounter{reqnum}\rthereqnum\label{Calculate-Temperature-Water-Over-Time}:]Calculate and output the temperature of the water (${T_{W}}$($t$)) over the simulation time
-\end{description}
-\begin{description}
-\item[\refstepcounter{reqnum}\rthereqnum\label{Calculate-Change-Heat\_Energy-Water-Time}:]Calculate and output the change in heat energy in the water (${E_{W}}$($t$)) over the simulation time (from IM3).
-\end{description}
 \subsection{Non-Functional Requirements}
 \label{Sec:NFRs}
 This problem is small in size and relatively simple, so performance is not a priority. Any reasonable implementation will be very quick and use minimal storage. Rather than performance, the non-functional requirement priorities are correctness, verifiability, understandability, reusability, and maintainability.
@@ -710,24 +702,24 @@ IM2 (\hyperref[T:heatEInWtr]{Definition~T:heatEInWtr}) &  &  &  &  &  &
 \end{longtable}
 \begin{longtable}{l l l l l l l l l l}
 \toprule
- & IM1 (\hyperref[T:eBalanceOnWtr]{Definition~T:eBalanceOnWtr}) & IM2 (\hyperref[T:heatEInWtr]{Definition~T:heatEInWtr}) & Data Constraints (Table~\ref{Table:InDataConstraints}) & R1 (R\ref{FR:req1}) & R2 (R\ref{FR:req2}) & R3 (R\ref{FR:req3}) & R4 (R\ref{FR:req4}) & R5 (R\ref{FR:req5}) & R6 (R\ref{FR:req6})
+ & IM1 (\hyperref[T:eBalanceOnWtr]{Definition~T:eBalanceOnWtr}) & IM2 (\hyperref[T:heatEInWtr]{Definition~T:heatEInWtr}) & Data Constraints (Table~\ref{Table:InDataConstraints}) & R1 (\hyperref[nr1]{Definition~nr1}) & R2 (\hyperref[nr2]{Definition~nr2}) & R3 (\hyperref[nr3]{Definition~nr3}) & R4 (\hyperref[nr4]{Definition~nr4}) & R5 (\hyperref[nr5]{Definition~nr5}) & R6 (\hyperref[nr6]{Definition~nr6})
 \\
 \midrule
 IM1 (\hyperref[T:eBalanceOnWtr]{Definition~T:eBalanceOnWtr}) &  &  &  &  &  &  &  &  & 
 \\
 IM2 (\hyperref[T:heatEInWtr]{Definition~T:heatEInWtr}) &  &  &  &  &  &  &  &  & 
 \\
-R1 (R\ref{FR:req1}) &  &  &  &  &  &  &  &  & 
+R1 (\hyperref[nr1]{Definition~nr1}) &  &  &  &  &  &  &  &  & 
 \\
-R2 (R\ref{FR:req2}) &  &  &  & X &  &  &  &  & 
+R2 (\hyperref[nr2]{Definition~nr2}) &  &  &  & X &  &  &  &  & 
 \\
-R3 (R\ref{FR:req3}) &  &  & X &  &  &  &  &  & 
+R3 (\hyperref[nr3]{Definition~nr3}) &  &  & X &  &  &  &  &  & 
 \\
-R4 (R\ref{FR:req4}) &  &  &  & X & X &  &  &  & 
+R4 (\hyperref[nr4]{Definition~nr4}) &  &  &  & X & X &  &  &  & 
 \\
-R5 (R\ref{FR:req5}) & X &  &  &  &  &  &  &  & 
+R5 (\hyperref[nr5]{Definition~nr5}) & X &  &  &  &  &  &  &  & 
 \\
-R6 (R\ref{FR:req6}) &  & X &  &  &  &  &  &  & 
+R6 (\hyperref[nr6]{Definition~nr6}) &  & X &  &  &  &  &  &  & 
 \\
 \bottomrule
 \caption{Traceability Matrix Showing the Connections Between Requirements and Instance Models}

--- a/code/stable/nopcm/SRS/NoPCM_SRS.tex
+++ b/code/stable/nopcm/SRS/NoPCM_SRS.tex
@@ -611,18 +611,12 @@ This section provides the functional requirements, the business tasks that the s
 \subsection{Functional Requirements}
 \label{Sec:FRs}
 \begin{itemize}
-\item[Input-Inital-Values:]\label{nr1}
-                           Input the quantities described in Table~\ref{Table:Input-Variable-Requirements}, which define the tank parameters, material properties and initial conditions.
-\item[Find-Mass:]\label{nr2}
-                 Use the inputs in \hyperref[nr1]{Definition~nr1} to find the mass needed for IM1 to IM2, as follows, where ${V_{W}}$ is the volume of water and ${V_{tank}}$ is the volume of the cylindrical tank: ${m_{W}}={V_{W}} {ρ_{W}}=\frac{D}{2} L {ρ_{W}}$
-\item[Check-Inputs-Satisfy-Physical-Constraints:]\label{nr3}
-                                                 Verify that the inputs satisfy the required physical constraint shown in Table~\ref{Table:InDataConstraints}.
-\item[Output-Input-Derivied-Quantities:]\label{nr4}
-                                        Outputs and inputs quantities and derived quantities in the following list: the quantities from \hyperref[nr1]{Definition~nr1}, the mass from \hyperref[nr2]{Definition~nr2} and ${τ_{W}}$ (from IM1).
-\item[Calculate-Temperature-Water-Over-Time:]\label{nr5}
-                                             Calculate and output the temperature of the water (${T_{W}}$($t$)) over the simulation time
-\item[Calculate-Change-Heat\_Energy-Water-Time:]\label{nr6}
-                                                Calculate and output the change in heat energy in the water (${E_{W}}$($t$)) over the simulation time (from IM3).
+\item[Input-Inital-Values:\label{nr1}]Input the quantities described in Table~\ref{Table:Input-Variable-Requirements}, which define the tank parameters, material properties and initial conditions.
+\item[Find-Mass:\label{nr2}]Use the inputs in \hyperref[nr1]{Definition~nr1} to find the mass needed for IM1 to IM2, as follows, where ${V_{W}}$ is the volume of water and ${V_{tank}}$ is the volume of the cylindrical tank: ${m_{W}}={V_{W}} {ρ_{W}}=\frac{D}{2} L {ρ_{W}}$
+\item[Check-Inputs-Satisfy-Physical-Constraints:\label{nr3}]Verify that the inputs satisfy the required physical constraint shown in Table~\ref{Table:InDataConstraints}.
+\item[Output-Input-Derivied-Quantities:\label{nr4}]Outputs and inputs quantities and derived quantities in the following list: the quantities from \hyperref[nr1]{Definition~nr1}, the mass from \hyperref[nr2]{Definition~nr2} and ${τ_{W}}$ (from IM1).
+\item[Calculate-Temperature-Water-Over-Time:\label{nr5}]Calculate and output the temperature of the water (${T_{W}}$($t$)) over the simulation time
+\item[Calculate-Change-Heat\_Energy-Water-Time:\label{nr6}]Calculate and output the change in heat energy in the water (${E_{W}}$($t$)) over the simulation time (from IM3).
 \end{itemize}
 \begin{longtabu}{l l X[l]}
 \toprule

--- a/code/stable/nopcm/Website/NoPCM_SRS.html
+++ b/code/stable/nopcm/Website/NoPCM_SRS.html
@@ -2041,14 +2041,46 @@ This section provides the functional requirements, the business tasks that the s
 <h2>
 Functional Requirements
 </h2>
-<ul class="hide-list-style">
-<li>
-<div id="Input-Inital-Values">
-Input-Inital-Values: Input the following quantities, which define the tank parameters, material properties and initial conditions:
+<div class="list">
+<p>
+<div id="nr1">
+Input-Inital-Values: Input the quantities described in <a href=#Table:Input-Variable-Requirements>Input-Variable-Requirements</a>, which define the tank parameters, material properties and initial conditions.
 </div>
-</li>
-</ul>
-<div id="Table:fr1list">
+</p>
+<p>
+<div id="nr2">
+Find-Mass: Use the inputs in <a href=#nr1>Input-Inital-Values</a> to find the mass needed for IM1 to IM2, as follows, where <em>V<sub>W</sub></em> is the volume of water and <em>V<sub>tank</sub></em> is the volume of the cylindrical tank: <em>m<sub>W</sub> = V<sub>W</sub>&#8239;ρ<sub>W</sub> = <div class="fraction">
+<span class="fup">
+D
+</span>
+<span class="fdn">
+2
+</span>
+</div>&#8239;L&#8239;ρ<sub>W</sub></em>
+</div>
+</p>
+<p>
+<div id="nr3">
+Check-Inputs-Satisfy-Physical-Constraints: Verify that the inputs satisfy the required physical constraint shown in <a href=#Table:InDataConstraints>InDataConstraints</a>.
+</div>
+</p>
+<p>
+<div id="nr4">
+Output-Input-Derivied-Quantities: Outputs and inputs quantities and derived quantities in the following list: the quantities from <a href=#nr1>Input-Inital-Values</a>, the mass from <a href=#nr2>Find-Mass</a> and <em>τ<sub>W</sub></em> (from IM1).
+</div>
+</p>
+<p>
+<div id="nr5">
+Calculate-Temperature-Water-Over-Time: Calculate and output the temperature of the water (<em>T<sub>W</sub></em>(<em>t</em>)) over the simulation time
+</div>
+</p>
+<p>
+<div id="nr6">
+Calculate-Change-Heat_Energy-Water-Time: Calculate and output the change in heat energy in the water (<em>E<sub>W</sub></em>(<em>t</em>)) over the simulation time (from IM3).
+</div>
+</p>
+</div>
+<div id="Table:Input-Variable-Requirements">
 <table class="table">
 <tr>
 <th>
@@ -2161,54 +2193,10 @@ final time
 </td>
 </tr>
 </table>
+<p class="caption">
+Input Variable Requirements
+</p>
 </div>
-<ul class="hide-list-style">
-<li>
-<div id="Use-Above-Find-Mass-IM1-IM2">
-Use-Above-Find-Mass-IM1-IM2: Use the inputs in <a href=#FR:req1>Input-Inital-Values</a> to find the mass needed for IM1 to IM2, as follows, where <em>V<sub>W</sub></em> is the volume of water and <em>V<sub>tank</sub></em> is the volume of the cylindrical tank:
-</div>
-</li>
-</ul>
-<div id="Eqn:empty">
-<div class="equation">
-<em>m<sub>W</sub> = V<sub>W</sub>&#8239;ρ<sub>W</sub> = <div class="fraction">
-<span class="fup">
-D
-</span>
-<span class="fdn">
-2
-</span>
-</div>&#8239;L&#8239;ρ<sub>W</sub></em>
-</div>
-</div>
-<ul class="hide-list-style">
-<li>
-<div id="Check-Inputs-Satisfy-Physical-Constraints">
-Check-Inputs-Satisfy-Physical-Constraints: Verify that the inputs satisfy the required physical constraint shown in <a href=#Table:InDataConstraints>InDataConstraints</a>.
-</div>
-</li>
-</ul>
-<ul class="hide-list-style">
-<li>
-<div id="Output-Input-Derivied-Quantities">
-Output-Input-Derivied-Quantities: Outputs and inputs quantities and derived quantities in the following list: the quantities from <a href=#FR:req1>Input-Inital-Values</a>, the mass from <a href=#FR:req2>Use-Above-Find-Mass-IM1-IM2</a> and <em>τ<sub>W</sub></em> (from IM1).
-</div>
-</li>
-</ul>
-<ul class="hide-list-style">
-<li>
-<div id="Calculate-Temperature-Water-Over-Time">
-Calculate-Temperature-Water-Over-Time: Calculate and output the temperature of the water (<em>T<sub>W</sub></em>(<em>t</em>)) over the simulation time
-</div>
-</li>
-</ul>
-<ul class="hide-list-style">
-<li>
-<div id="Calculate-Change-Heat_Energy-Water-Time">
-Calculate-Change-Heat_Energy-Water-Time: Calculate and output the change in heat energy in the water (<em>E<sub>W</sub></em>(<em>t</em>)) over the simulation time (from IM3).
-</div>
-</li>
-</ul>
 </div>
 </div>
 <div id="Sec:NFRs">
@@ -2471,22 +2459,22 @@ IM2 (<a href=#T:heatEInWtr>empty</a>)
 Data Constraints (<a href=#Table:InDataConstraints>InDataConstraints</a>)
 </th>
 <th>
-R1 (<a href=#FR:req1>Input-Inital-Values</a>)
+R1 (<a href=#nr1>Input-Inital-Values</a>)
 </th>
 <th>
-R2 (<a href=#FR:req2>Use-Above-Find-Mass-IM1-IM2</a>)
+R2 (<a href=#nr2>Find-Mass</a>)
 </th>
 <th>
-R3 (<a href=#FR:req3>Check-Inputs-Satisfy-Physical-Constraints</a>)
+R3 (<a href=#nr3>Check-Inputs-Satisfy-Physical-Constraints</a>)
 </th>
 <th>
-R4 (<a href=#FR:req4>Output-Input-Derivied-Quantities</a>)
+R4 (<a href=#nr4>Output-Input-Derivied-Quantities</a>)
 </th>
 <th>
-R5 (<a href=#FR:req5>Calculate-Temperature-Water-Over-Time</a>)
+R5 (<a href=#nr5>Calculate-Temperature-Water-Over-Time</a>)
 </th>
 <th>
-R6 (<a href=#FR:req6>Calculate-Change-Heat_Energy-Water-Time</a>)
+R6 (<a href=#nr6>Calculate-Change-Heat_Energy-Water-Time</a>)
 </th>
 </tr>
 <tr>
@@ -2555,7 +2543,7 @@ IM2 (<a href=#T:heatEInWtr>empty</a>)
 </tr>
 <tr>
 <td>
-R1 (<a href=#FR:req1>Input-Inital-Values</a>)
+R1 (<a href=#nr1>Input-Inital-Values</a>)
 </td>
 <td>
 
@@ -2587,7 +2575,7 @@ R1 (<a href=#FR:req1>Input-Inital-Values</a>)
 </tr>
 <tr>
 <td>
-R2 (<a href=#FR:req2>Use-Above-Find-Mass-IM1-IM2</a>)
+R2 (<a href=#nr2>Find-Mass</a>)
 </td>
 <td>
 
@@ -2619,7 +2607,7 @@ X
 </tr>
 <tr>
 <td>
-R3 (<a href=#FR:req3>Check-Inputs-Satisfy-Physical-Constraints</a>)
+R3 (<a href=#nr3>Check-Inputs-Satisfy-Physical-Constraints</a>)
 </td>
 <td>
 
@@ -2651,7 +2639,7 @@ X
 </tr>
 <tr>
 <td>
-R4 (<a href=#FR:req4>Output-Input-Derivied-Quantities</a>)
+R4 (<a href=#nr4>Output-Input-Derivied-Quantities</a>)
 </td>
 <td>
 
@@ -2683,7 +2671,7 @@ X
 </tr>
 <tr>
 <td>
-R5 (<a href=#FR:req5>Calculate-Temperature-Water-Over-Time</a>)
+R5 (<a href=#nr5>Calculate-Temperature-Water-Over-Time</a>)
 </td>
 <td>
 X
@@ -2715,7 +2703,7 @@ X
 </tr>
 <tr>
 <td>
-R6 (<a href=#FR:req6>Calculate-Change-Heat_Energy-Water-Time</a>)
+R6 (<a href=#nr6>Calculate-Change-Heat_Energy-Water-Time</a>)
 </td>
 <td>
 


### PR DESCRIPTION
This PR is part of #562. It introduces the first use of `ConceptInstance` into the examples. This PR only affects the functional requirements of NoPCM. The old requirements still exist for compatibility with SWHS. As noted, there is a small formatting change with the new requirements as highlighted in the extended commit message of f123c6b. Below is a comparison of the requirements formatting:

# Old
<img width="1139" alt="screen shot 2018-07-27 at 1 46 04 am" src="https://user-images.githubusercontent.com/1929800/43363413-4eec0b1a-92d2-11e8-818c-639b1af89074.png">

# New
<img width="1131" alt="screen shot 2018-07-29 at 1 53 41 am" src="https://user-images.githubusercontent.com/1929800/43363416-5cf321da-92d2-11e8-9f5e-bad4c1078c78.png">

I have included @smiths as a reviewer due to this formatting change.