### PR TITLE
562 Domains in ChunkDB

### DIFF
--- a/code/drasil-docLang/Drasil/DocLang.hs
+++ b/code/drasil-docLang/Drasil/DocLang.hs
@@ -9,7 +9,7 @@ module Drasil.DocLang (
     StkhldrSec(StkhldrProg2),
     StkhldrSub(Client, Cstmr), TConvention(..), TraceabilitySec(TraceabilityProg), 
     TSIntro(..), UCsSec(..), mkDoc, mkLklyChnk, mkRequirement, 
-    mkUnLklyChnk, tsymb, tsymb'', mkConCC, mkConCC', mkEnumCC,
+    mkUnLklyChnk, srsDomains, tsymb, tsymb'', mkConCC, mkConCC', mkEnumCC,
     -- DocumentLanguage.Definitions
     Field(..), Fields, InclUnits(IncludeUnits), Verbosity(Verbose),
     -- DocumentLanguage.RefHelpers 
@@ -23,7 +23,7 @@ module Drasil.DocLang (
     -- Sections.ReferenceMaterial
     intro,
     -- Sections.Requirements
-    nonFuncReqF, reqF, funcReqDom,
+    nonFuncReqF, reqF, reqDom, funcReqDom,
     -- Sections.ScopeOfTheProject
     -- Sections.SolutionCharacterSpec
     SubSec, assembler, sSubSec, siCon, siDDef, siIMod, siSTitl, siSent, siTMod, 
@@ -47,7 +47,7 @@ import Drasil.DocumentLanguage (AppndxSec(..), AuxConstntSec(..),
     ScpOfProjSec(ScpOfProjProg), SCSSub(..), SSDSec(..), SSDSub(..), SolChSpec(..), 
     StkhldrSec(StkhldrProg2), StkhldrSub(Client, Cstmr), TConvention(..), 
     TraceabilitySec(TraceabilityProg), TSIntro(..), UCsSec(..), mkDoc, 
-    mkLklyChnk, mkRequirement, mkUnLklyChnk, tsymb, tsymb'', mkConCC, mkConCC',
+    mkLklyChnk, mkRequirement, mkUnLklyChnk, srsDomains, tsymb, tsymb'', mkConCC, mkConCC',
     mkEnumCC)
 import Drasil.DocumentLanguage.Definitions (Field(..), Fields, 
     InclUnits(IncludeUnits), Verbosity(Verbose))
@@ -58,7 +58,7 @@ import Drasil.Sections.AuxiliaryConstants (valsOfAuxConstantsF)
 import Drasil.Sections.GeneralSystDesc (genSysF)
 --import Drasil.Sections.Introduction
 import Drasil.Sections.ReferenceMaterial (intro)
-import Drasil.Sections.Requirements (nonFuncReqF, reqF, funcReqDom)
+import Drasil.Sections.Requirements (nonFuncReqF, reqF, reqDom, funcReqDom)
 --import Drasil.Sections.ScopeOfTheProject
 import Drasil.Sections.SolutionCharacterSpec (SubSec, assembler, sSubSec, siCon, 
     siDDef, siIMod, siSTitl, siSent, siTMod, siUQI, siUQO)

--- a/code/drasil-docLang/Drasil/DocumentLanguage.hs
+++ b/code/drasil-docLang/Drasil/DocumentLanguage.hs
@@ -27,7 +27,8 @@ import qualified Drasil.Sections.GeneralSystDesc as GSD (genSysF, genSysIntro,
   systCon, usrCharsF, sysContxt)
 import qualified Drasil.Sections.Introduction as Intro (charIntRdrF, 
   introductionSection, orgSec, purposeOfDoc, scopeOfRequirements)
-import qualified Drasil.Sections.Requirements as R (fReqF, nonFuncReqF, reqF)
+import qualified Drasil.Sections.Requirements as R (fReqF, nonFuncReqF, reqF,
+  reqDom, funcReqDom)
 import qualified Drasil.Sections.ScopeOfTheProject as SotP (scopeOfTheProjF)
 import qualified Drasil.Sections.SpecificSystemDescription as SSD (assumpF,
   datConF, dataDefnF, genDefnF, inModelF, probDescF, solutionCharSpecIntro, 
@@ -236,6 +237,12 @@ data AuxConstntSec = AuxConsProg CI [QDefinition] | AuxConsVerb Section
 {--}
 
 data AppndxSec = AppndxVerb Section | AppndxProg [Contents]
+
+{--}
+
+-- | List of domains for SRS
+srsDomains :: [ConceptChunk]
+srsDomains = [R.reqDom, R.funcReqDom]
 
 {--}
 

--- a/code/drasil-docLang/Drasil/Sections/Requirements.hs
+++ b/code/drasil-docLang/Drasil/Sections/Requirements.hs
@@ -33,10 +33,10 @@ reqIntro = mkParagraph reqIntroS
 
 -- Requirements Domains
 reqDom :: ConceptChunk
-reqDom = ccs (nc "reqDom" $ requirement ^. term) reqIntroS [SRS.srsDom]
+reqDom = ccs (mkIdea "reqDom" (requirement ^. term) $ Just "R") reqIntroS [SRS.srsDom]
 
 funcReqDom :: ConceptChunk
-funcReqDom = ccs (nc "funcReqDom" $ functionalRequirement ^. term) EmptyS [reqDom]
+funcReqDom = ccs (mkIdea "funcReqDom" (functionalRequirement ^. term) $ Just "FR") EmptyS [reqDom]
 
 -- wrapper for nonfuncReq
 nonFuncReqF :: (Concept c) => [c] -> [c] -> Sentence -> Sentence -> Section

--- a/code/drasil-docLang/Drasil/Sections/Requirements.hs
+++ b/code/drasil-docLang/Drasil/Sections/Requirements.hs
@@ -1,5 +1,5 @@
 module Drasil.Sections.Requirements
-  (fReqF, reqF, nonFuncReqF, funcReqDom) where
+  (fReqF, reqF, nonFuncReqF, reqDom, funcReqDom) where
 
 import Language.Drasil
 

--- a/code/drasil-docLang/drasil-docLang.cabal
+++ b/code/drasil-docLang/drasil-docLang.cabal
@@ -39,7 +39,7 @@ library
     MissingH >= 1.4.0.1,
     parsec >= 3.1.9,
     data-fix (>= 0.0.4 && <= 1.0),
-    drasil-lang >= 0.1.6,
+    drasil-lang >= 0.1.9,
     drasil-data >= 0.1.4
   default-language: Haskell2010
   ghc-options:      -Wall

--- a/code/drasil-docLang/drasil-docLang.cabal
+++ b/code/drasil-docLang/drasil-docLang.cabal
@@ -1,5 +1,5 @@
 Name:		drasil-docLang
-Version:	0.1.2
+Version:	0.1.3
 Cabal-Version:  >= 1.18
 Author:		Dan Szymczak, Steven Palmer, Jacques Carette, Spencer Smith
 build-type:     Simple

--- a/code/drasil-example/Drasil/NoPCM/Body.hs
+++ b/code/drasil-example/Drasil/NoPCM/Body.hs
@@ -71,8 +71,8 @@ import Drasil.DocLang (DocDesc, Fields, Field(..), Verbosity(Verbose),
   RefSec(RefProg), RefTab(TAandA, TUnits), 
   TSIntro(SymbOrder, SymbConvention, TSPurpose), dataConstraintUncertainty, 
   funcReqDom, inDataConstTbl, intro, mkDoc, mkEnumCC, mkRequirement,
-  mkUnLklyChnk, outDataConstTbl, physSystDesc, reqF, termDefnF, traceMGF,
-  tsymb, valsOfAuxConstantsF)
+  mkUnLklyChnk, outDataConstTbl, physSystDesc, reqF, srsDomains, termDefnF,
+  traceMGF, tsymb, valsOfAuxConstantsF)
  
 import Data.Drasil.SentenceStructures (showingCxnBw, foldlSent_, sAnd,
   isThe, sOf, ofThe, foldlSPCol, foldlSent, foldlSP, acroIM, acroGD)
@@ -189,7 +189,7 @@ nopcm_srs :: Document
 nopcm_srs = mkDoc mkSRS (for) nopcm_si
 
 nopcm_SymbMap :: ChunkDB
-nopcm_SymbMap = cdb nopcm_SymbolsAll (map nw nopcm_Symbols ++ map nw acronyms) nopcm_Symbols
+nopcm_SymbMap = cdb nopcm_SymbolsAll (map nw nopcm_Symbols ++ map nw acronyms) (map cw nopcm_Symbols ++ srsDomains)
   this_si
 
 assumps_Nopcm_list_new :: [AssumpChunk]

--- a/code/drasil-example/drasil-example.cabal
+++ b/code/drasil-example/drasil-example.cabal
@@ -96,7 +96,7 @@ executable nopcm
     drasil-code >= 0.1.1,
     drasil-printers >= 0.1.0,
     drasil-gen >= 0.1.0,
-    drasil-docLang >= 0.1.2
+    drasil-docLang >= 0.1.3
   default-language: Haskell2010
   ghc-options:      -Wall -O2
 

--- a/code/drasil-lang/Language/Drasil.hs
+++ b/code/drasil-lang/Language/Drasil.hs
@@ -62,7 +62,7 @@ module Language.Drasil (
   , NamedChunk, short, nc, IdeaDict
   , nw -- bad name (historical)
   , compoundNC, compoundNC', compoundNC'', compoundNC''', compoundNCP1, compoundNCPlPh, compoundNCPlPl
-  , the, theCustom
+  , the, theCustom, mkIdea
   -- Chunk.Constrained.Core
   , physc, sfwrc, enumc , isPhysC, isSfwrC
   , Constraint(..), ConstraintReason(..)

--- a/code/drasil-lang/drasil-lang.cabal
+++ b/code/drasil-lang/drasil-lang.cabal
@@ -1,5 +1,5 @@
 Name:		drasil-lang
-Version:	0.1.8
+Version:	0.1.9
 Cabal-Version:  >= 1.18
 Author:		Dan Szymczak, Steven Palmer, Jacques Carette, Spencer Smith
 build-type:     Simple


### PR DESCRIPTION
This PR adds domains used in `ConceptInstance`s to the `ConceptMap` in `ChunkDB`. This PR is part of #562 specifically, [comment 19](
https://github.com/JacquesCarette/Drasil/issues/562#issuecomment-410323483).

The domains are not currently used from the database.