### PR TITLE
Add transitional framework for shortname use to TeX printer.

### DIFF
--- a/code/drasil-printers/Language/Drasil/TeX/Helpers.hs
+++ b/code/drasil-printers/Language/Drasil/TeX/Helpers.hs
@@ -93,10 +93,11 @@ genSec d
       TP.<> (if (not numberedSections) then text "*" else TP.empty) 
 
 -- For references
-ref, sref, hyperref :: String -> D -> D
+ref, sref, hyperref, snref :: String -> D -> D
 sref         = if numberedSections then ref else hyperref
 ref      t x = custRef (t ++ "~\\ref") x
 hyperref t x = command0 "hyperref" <> sq x <> br ((pure $ text (t ++ "~")) <> x)
+snref    r t = command0 "hyperref" <> sq (pure $ text r) <> br t
 
 custRef :: String -> D -> D
 custRef t x = (pure $ text t) <> br x

--- a/code/drasil-printers/Language/Drasil/TeX/Print.hs
+++ b/code/drasil-printers/Language/Drasil/TeX/Print.hs
@@ -36,7 +36,7 @@ import Language.Drasil.Printing.Helpers hiding (paren, sqbrac)
 import Language.Drasil.TeX.Helpers (label, caption, centering, mkEnv, item', description,
   includegraphics, center, figure, item, symbDescription, enumerate, itemize, toEqn, empty,
   newline, superscript, parens, fraction, quote, ref, ucref, lcref, aref, mref, sref, rref,
-  hyperref, cite, sec, newpage, maketoc, maketitle, document, author, title)
+  hyperref, snref, cite, sec, newpage, maketoc, maketitle, document, author, title)
 import Language.Drasil.TeX.Monad (D, MathContext(Curr, Math, Text), (<>), vcat, (%%),
   toMath, switch, unPL, lub, hpunctuate, toText, ($+$), runPrint)
 import Language.Drasil.TeX.Preamble (genPreamble)
@@ -270,6 +270,7 @@ spec (Ref RT.Assump r _ _) = aref  (pure $ text r)
 spec (Ref RT.LCh r _ _)     = lcref (pure $ text r)
 spec (Ref RT.UnCh r _ _)     = ucref (pure $ text r)
 spec (Ref RT.Cite r _ _)   = cite  (pure $ text r)
+spec (Ref RT.Blank r sn _) = snref r $ spec sn
 spec (Ref t r _ _)         = ref (show t) (pure $ text r)
 spec EmptyS              = empty
 spec (Quote q)           = quote $ spec q
@@ -383,7 +384,7 @@ pl_item :: (ItemType,Maybe Label) -> D
 pl_item (i, l) = mlref l <> p_item i
 
 mlref :: Maybe Label -> D
-mlref = maybe empty $ label . spec
+mlref = maybe empty $ ((<>) $ pure $ text "\\phantomsection") . label . spec
 
 p_item :: ItemType -> D
 p_item (Flat s) = item $ spec s

--- a/code/stable/glassbr/SRS/GlassBR_SRS.tex
+++ b/code/stable/glassbr/SRS/GlassBR_SRS.tex
@@ -995,21 +995,21 @@ This section provides the functional requirements, the business tasks that the s
 \item[\refstepcounter{reqnum}\rthereqnum\label{FR:Check-Glass-Safety}:]If $is\_safePb$ ∧ $is\_safeLR$ (from \hyperref[T:isSafePb]{Definition~T:isSafePb} and \hyperref[T:isSafeLR]{Definition~T:isSafeLR}) are true, output the message ``For the given input parameters, the glass is considered safe.'' If the condition is false, then output the message ``For the given input parameters, the glass is NOT considered safe.''
 \end{description}
 \begin{itemize}
-\item[R6:\label{List:output.quantities}]Output the following quantities:
-                                        \begin{itemize}
-                                        \item{Probability of breakage (${P_{b}}$) (\hyperref[IM:probOfBr]{Definition~IM:probOfBr})}
-                                        \item{Load resistance ($LR$) (\hyperref[IM:calOfCap]{Definition~IM:calOfCap})}
-                                        \item{Applied load (demand) ($q$) (\hyperref[IM:calOfDemand]{Definition~IM:calOfDemand})}
-                                        \item{Risk of failure ($B$) (\hyperref[DD:risk.fun]{Definition~DD:risk.fun})}
-                                        \item{Stress distribution factor (Function) ($J$) (\hyperref[DD:stressDistFac]{Definition~DD:stressDistFac})}
-                                        \item{Non-factored load ($NFL$) (\hyperref[DD:nFL]{Definition~DD:nFL})}
-                                        \item{Glass type factor ($GTF$) (\hyperref[DD:gTF]{Definition~DD:gTF})}
-                                        \item{Dimensionless load ($\hat{q}$) (\hyperref[DD:dimlessLoad]{Definition~DD:dimlessLoad})}
-                                        \item{Tolerable load (${\hat{q}_{tol}}$) (\hyperref[DD:tolLoad]{Definition~DD:tolLoad})}
-                                        \item{Stress distribution factor (Function) based on Pbtol (${J_{tol}}$) (\hyperref[DD:sdf.tol]{Definition~DD:sdf.tol})}
-                                        \item{Minimum thickness ($h$) (\hyperref[DD:min.thick]{Definition~DD:min.thick})}
-                                        \item{Aspect ratio ($AR$) (\hyperref[DD:aspect.ratio]{Definition~DD:aspect.ratio})}
-                                        \end{itemize}
+\item[R6:\phantomsection\label{List:output.quantities}]Output the following quantities:
+                                                       \begin{itemize}
+                                                       \item{Probability of breakage (${P_{b}}$) (\hyperref[IM:probOfBr]{Definition~IM:probOfBr})}
+                                                       \item{Load resistance ($LR$) (\hyperref[IM:calOfCap]{Definition~IM:calOfCap})}
+                                                       \item{Applied load (demand) ($q$) (\hyperref[IM:calOfDemand]{Definition~IM:calOfDemand})}
+                                                       \item{Risk of failure ($B$) (\hyperref[DD:risk.fun]{Definition~DD:risk.fun})}
+                                                       \item{Stress distribution factor (Function) ($J$) (\hyperref[DD:stressDistFac]{Definition~DD:stressDistFac})}
+                                                       \item{Non-factored load ($NFL$) (\hyperref[DD:nFL]{Definition~DD:nFL})}
+                                                       \item{Glass type factor ($GTF$) (\hyperref[DD:gTF]{Definition~DD:gTF})}
+                                                       \item{Dimensionless load ($\hat{q}$) (\hyperref[DD:dimlessLoad]{Definition~DD:dimlessLoad})}
+                                                       \item{Tolerable load (${\hat{q}_{tol}}$) (\hyperref[DD:tolLoad]{Definition~DD:tolLoad})}
+                                                       \item{Stress distribution factor (Function) based on Pbtol (${J_{tol}}$) (\hyperref[DD:sdf.tol]{Definition~DD:sdf.tol})}
+                                                       \item{Minimum thickness ($h$) (\hyperref[DD:min.thick]{Definition~DD:min.thick})}
+                                                       \item{Aspect ratio ($AR$) (\hyperref[DD:aspect.ratio]{Definition~DD:aspect.ratio})}
+                                                       \end{itemize}
 \end{itemize}
 \begin{longtabu}{l X[l] l}
 \toprule

--- a/code/stable/nopcm/SRS/NoPCM_SRS.tex
+++ b/code/stable/nopcm/SRS/NoPCM_SRS.tex
@@ -611,12 +611,12 @@ This section provides the functional requirements, the business tasks that the s
 \subsection{Functional Requirements}
 \label{Sec:FRs}
 \begin{itemize}
-\item[Input-Inital-Values:\label{Input-Inital-Values}]Input the quantities described in Table~\ref{Table:Input-Variable-Requirements}, which define the tank parameters, material properties and initial conditions.
-\item[Find-Mass:\label{Find-Mass}]Use the inputs in Blank~\ref{Input-Inital-Values} to find the mass needed for IM1 to IM2, as follows, where ${V_{W}}$ is the volume of water and ${V_{tank}}$ is the volume of the cylindrical tank: ${m_{W}}={V_{W}} {ρ_{W}}=\frac{D}{2} L {ρ_{W}}$
-\item[Check-Inputs-Satisfy-Physical-Constraints:\label{Check-Inputs-Satisfy-Physical-Constraints}]Verify that the inputs satisfy the required physical constraint shown in Table~\ref{Table:InDataConstraints}.
-\item[Output-Input-Derivied-Quantities:\label{Output-Input-Derivied-Quantities}]Outputs and inputs quantities and derived quantities in the following list: the quantities from Blank~\ref{Input-Inital-Values}, the mass from Blank~\ref{Find-Mass} and ${τ_{W}}$ (from IM1).
-\item[Calculate-Temperature-Water-Over-Time:\label{Calculate-Temperature-Water-Over-Time}]Calculate and output the temperature of the water (${T_{W}}$($t$)) over the simulation time
-\item[Calculate-Change-Heat\_Energy-Water-Time:\label{Calculate-Change-Heat\_Energy-Water-Time}]Calculate and output the change in heat energy in the water (${E_{W}}$($t$)) over the simulation time (from IM3).
+\item[Input-Inital-Values:\phantomsection\label{Input-Inital-Values}]Input the quantities described in Table~\ref{Table:Input-Variable-Requirements}, which define the tank parameters, material properties and initial conditions.
+\item[Find-Mass:\phantomsection\label{Find-Mass}]Use the inputs in \hyperref[Input-Inital-Values]{Input-Inital-Values} to find the mass needed for IM1 to IM2, as follows, where ${V_{W}}$ is the volume of water and ${V_{tank}}$ is the volume of the cylindrical tank: ${m_{W}}={V_{W}} {ρ_{W}}=\frac{D}{2} L {ρ_{W}}$
+\item[Check-Inputs-Satisfy-Physical-Constraints:\phantomsection\label{Check-Inputs-Satisfy-Physical-Constraints}]Verify that the inputs satisfy the required physical constraint shown in Table~\ref{Table:InDataConstraints}.
+\item[Output-Input-Derivied-Quantities:\phantomsection\label{Output-Input-Derivied-Quantities}]Outputs and inputs quantities and derived quantities in the following list: the quantities from \hyperref[Input-Inital-Values]{Input-Inital-Values}, the mass from \hyperref[Find-Mass]{Find-Mass} and ${τ_{W}}$ (from IM1).
+\item[Calculate-Temperature-Water-Over-Time:\phantomsection\label{Calculate-Temperature-Water-Over-Time}]Calculate and output the temperature of the water (${T_{W}}$($t$)) over the simulation time
+\item[Calculate-Change-Heat\_Energy-Water-Time:\phantomsection\label{Calculate-Change-Heat\_Energy-Water-Time}]Calculate and output the change in heat energy in the water (${E_{W}}$($t$)) over the simulation time (from IM3).
 \end{itemize}
 \begin{longtabu}{l l X[l]}
 \toprule
@@ -696,24 +696,24 @@ IM2 (\hyperref[IM:heatEInWtr]{Definition~IM:heatEInWtr}) &  &  &  &  &  &
 \end{longtable}
 \begin{longtable}{l l l l l l l l l l}
 \toprule
- & IM1 (\hyperref[IM:eBalanceOnWtr]{Definition~IM:eBalanceOnWtr}) & IM2 (\hyperref[IM:heatEInWtr]{Definition~IM:heatEInWtr}) & Data Constraints (Table~\ref{Table:InDataConstraints}) & R1 (Blank~\ref{Input-Inital-Values}) & R2 (Blank~\ref{Find-Mass}) & R3 (Blank~\ref{Check-Inputs-Satisfy-Physical-Constraints}) & R4 (Blank~\ref{Output-Input-Derivied-Quantities}) & R5 (Blank~\ref{Calculate-Temperature-Water-Over-Time}) & R6 (Blank~\ref{Calculate-Change-Heat_Energy-Water-Time})
+ & IM1 (\hyperref[IM:eBalanceOnWtr]{Definition~IM:eBalanceOnWtr}) & IM2 (\hyperref[IM:heatEInWtr]{Definition~IM:heatEInWtr}) & Data Constraints (Table~\ref{Table:InDataConstraints}) & R1 (\hyperref[Input-Inital-Values]{Input-Inital-Values}) & R2 (\hyperref[Find-Mass]{Find-Mass}) & R3 (\hyperref[Check-Inputs-Satisfy-Physical-Constraints]{Check-Inputs-Satisfy-Physical-Constraints}) & R4 (\hyperref[Output-Input-Derivied-Quantities]{Output-Input-Derivied-Quantities}) & R5 (\hyperref[Calculate-Temperature-Water-Over-Time]{Calculate-Temperature-Water-Over-Time}) & R6 (\hyperref[Calculate-Change-Heat_Energy-Water-Time]{Calculate-Change-Heat\_Energy-Water-Time})
 \\
 \midrule
 IM1 (\hyperref[IM:eBalanceOnWtr]{Definition~IM:eBalanceOnWtr}) &  &  &  &  &  &  &  &  & 
 \\
 IM2 (\hyperref[IM:heatEInWtr]{Definition~IM:heatEInWtr}) &  &  &  &  &  &  &  &  & 
 \\
-R1 (Blank~\ref{Input-Inital-Values}) &  &  &  &  &  &  &  &  & 
+R1 (\hyperref[Input-Inital-Values]{Input-Inital-Values}) &  &  &  &  &  &  &  &  & 
 \\
-R2 (Blank~\ref{Find-Mass}) &  &  &  & X &  &  &  &  & 
+R2 (\hyperref[Find-Mass]{Find-Mass}) &  &  &  & X &  &  &  &  & 
 \\
-R3 (Blank~\ref{Check-Inputs-Satisfy-Physical-Constraints}) &  &  & X &  &  &  &  &  & 
+R3 (\hyperref[Check-Inputs-Satisfy-Physical-Constraints]{Check-Inputs-Satisfy-Physical-Constraints}) &  &  & X &  &  &  &  &  & 
 \\
-R4 (Blank~\ref{Output-Input-Derivied-Quantities}) &  &  &  & X & X &  &  &  & 
+R4 (\hyperref[Output-Input-Derivied-Quantities]{Output-Input-Derivied-Quantities}) &  &  &  & X & X &  &  &  & 
 \\
-R5 (Blank~\ref{Calculate-Temperature-Water-Over-Time}) & X &  &  &  &  &  &  &  & 
+R5 (\hyperref[Calculate-Temperature-Water-Over-Time]{Calculate-Temperature-Water-Over-Time}) & X &  &  &  &  &  &  &  & 
 \\
-R6 (Blank~\ref{Calculate-Change-Heat_Energy-Water-Time}) &  & X &  &  &  &  &  &  & 
+R6 (\hyperref[Calculate-Change-Heat_Energy-Water-Time]{Calculate-Change-Heat\_Energy-Water-Time}) &  & X &  &  &  &  &  &  & 
 \\
 \bottomrule
 \caption{Traceability Matrix Showing the Connections Between Requirements and Instance Models}


### PR DESCRIPTION
This PR is a first step in #984, it introduces a (temporary) function `snref` which uses the `hyperref` package and macro to set the displayed text on references. It is used when the `RefType` of a `Ref` is `Blank` as that seems like the best way to transition from `RefType`.

Additionally, `hyperref` appears to not link to a specific `item`, but the previous section. This is the reason `\phantomsection` is added before labels in enumerations, so the reference points to the item specifically.