### PR TITLE
Migrate SSP to ConceptInstance.

### DIFF
--- a/code/drasil-example/Drasil/SSP/Assumptions.hs
+++ b/code/drasil-example/Drasil/SSP/Assumptions.hs
@@ -5,33 +5,43 @@ import Language.Drasil
 import Drasil.SSP.Defs (slpSrf, slopeSrf, slope,
   mtrlPrpty, soil, soilLyr, soilPrpty, intrslce, slice)
 import Drasil.SSP.Unitals (coords, normToShear, scalFunc, fs)
-import Drasil.SSP.References (sspCitations)
 import Data.Drasil.SentenceStructures (ofThe, ofThe', getTandS, foldlSent)
 
-import Data.Drasil.Concepts.Documentation (condition)
+import Data.Drasil.Concepts.Documentation (assumpDom, condition)
 import Data.Drasil.Concepts.Physics (force, stress, strain)
 import Data.Drasil.Concepts.Math (surface, unit_)
 import Data.Drasil.Concepts.SolidMechanics (shearForce)
 
-sspRefDB :: ReferenceDB
-sspRefDB = rdb [] [] newAssumptions [] [] sspCitations []
--- FIXME: Convert the rest to new chunk types (similar to issues #446 and #447)
-
 newAssumptions :: [AssumpChunk]
 newAssumptions = [newA1, newA2, newA3, newA4, newA5, newA6, newA7, newA8, newA9, newA10]
 
+-- FIXME: Remove the newA AssumpChunk's once ConceptInstance and SCSProg's
+-- Assumptions has been migrated to using assumpDom
+
 newA1, newA2, newA3, newA4, newA5, newA6, newA7, newA8, newA9, newA10 :: AssumpChunk
+assumpSSC, assumpGSMPSL, assumpSLH, assumpSLI, assumpINSFL, assumpBNSFLFS,
+  assumpSSCIL, assumpPSC, assumpENSL, assumpSBSBISL :: ConceptInstance
 newA1 = assump "Slip-Surface-Concave" monotonicF (mkLabelRAAssump' "Slip-Surface-Concave")
+assumpSSC = cic "assumpSSC" monotonicF "Slip-Surface-Concave" assumpDom
 newA2 = assump "Geo-Slope-Mat-Props-of-Soil-Inputs" slopeG (mkLabelRAAssump' "Geo-Slope-Mat-Props-of-Soil-Inputs")
+assumpGSMPSL = cic "assumpGSMPSL" slopeG "Geo-Slope-Mat-Props-of-Soil-Inputs" assumpDom
 newA3 = assump "Soil-Layer-Homogeneous" homogeneousL (mkLabelRAAssump' "Soil-Layer-Homogeneous")
+assumpSLH = cic "assumpSLH" homogeneousL "Soil-Layer-Homogeneous" assumpDom
 newA4 = assump "Soil-Layers-Isotropic" isotropicP (mkLabelRAAssump' "Soil-Layers-Isotropic")
+assumpSLI = cic "assumpSLI" isotropicP "Soil-Layers-Isotropic" assumpDom
 newA5 = assump "Interslice-Norm-Shear-Forces-Linear" linearS (mkLabelRAAssump' "Interslice-Norm-Shear-Forces-Linear")
+assumpINSFL = cic "assumpINSFL" linearS "Interslice-Norm-Shear-Forces-Linear" assumpDom
 newA6 = assump "Base-Norm-Shear-Forces-Linear-on-FS" linearF (mkLabelRAAssump' "Base-Norm-Shear-Forces-Linear-on-FS")
+assumpBNSFLFS = cic "assumpBNSFLFS" linearF "Base-Norm-Shear-Forces-Linear-on-FS" assumpDom
 newA7 = assump "Stress-Strain-Curve-interslice-Linear" stressC (mkLabelRAAssump' "Stress-Strain-Curve-interslice-Linear")
+assumpSSCIL = cic "assumpSSCIL" stressC "Stress-Strain-Curve-interslice-Linear" assumpDom
 newA8 = assump "Plane-Strain-Conditions" planeS (mkLabelRAAssump' "Plane-Strain-Conditions")
+assumpPSC = cic "assumpPSC" planeS "Plane-Strain-Conditions" assumpDom
 newA9 = assump "Effective-Norm-Stress-Large" largeN (mkLabelRAAssump' "Effective-Norm-Stress-Large")
+assumpENSL = cic "assumpENSL" largeN "Effective-Norm-Stress-Large" assumpDom
 newA10 = assump "Surface-Base-Slice-between-Interslice-Straight-Lines" straightS 
            (mkLabelRAAssump' "Surface-Base-Slice-between-Interslice-Straight-Lines")
+assumpSBSBISL = cic "assumpSBSBISL" straightS "Surface-Base-Slice-between-Interslice-Straight-Lines" assumpDom
 
 monotonicF, slopeG, homogeneousL, isotropicP, linearS,
   linearF, stressC, planeS, largeN, straightS :: Sentence

--- a/code/drasil-example/Drasil/SSP/Changes.hs
+++ b/code/drasil-example/Drasil/SSP/Changes.hs
@@ -1,44 +1,51 @@
-module Drasil.SSP.Changes (likelyChanges_SRS, unlikelyChanges_SRS) where
+module Drasil.SSP.Changes (likelyChanges_SRS, likelyChgs, unlikelyChanges_SRS,
+  unlikelyChgs) where
 
 -- A list of likely and unlikely changes for the SSP example
 
 import Language.Drasil
-import Drasil.DocLang (mkLklyChnk, mkUnLklyChnk)
+import Drasil.DocLang (mkEnumSimpleD)
 
-import Data.Drasil.Concepts.Documentation (system)
+import Data.Drasil.Concepts.Documentation (likeChgDom, system, unlikeChgDom)
 import Data.Drasil.Concepts.Math (calculation)
 import Data.Drasil.SentenceStructures (foldlSent, foldlSP, sAnd)
 
 import Drasil.SSP.Assumptions (newA3, newA5, newA6, newA8)
 
-likelyChanges_SRS :: [LabelledContent]
-likelyChanges_SRS = [likelychg1]
+likelyChanges_SRS :: [Contents]
+likelyChanges_SRS = mkEnumSimpleD likelyChgs
 
-likelychg1 :: LabelledContent
-likelychg1 = mkLklyChnk "LC_inhomogeneous" lc1Desc "Calculate-Inhomogeneous-Soil-Layers"
+likelyChgs :: [ConceptInstance]
+likelyChgs = [likelyChgCISL]
 
-lc1Desc :: Sentence
-lc1Desc = foldlSent [(makeRef newA3) `sDash` S "The",
+likelyChgCISL :: ConceptInstance
+likelyChgCISL = cic "LC_inhomogeneous" lcCISLDesc "Calculate-Inhomogeneous-Soil-Layers" likeChgDom
+
+lcCISLDesc :: Sentence
+lcCISLDesc = foldlSent [(makeRef newA3) `sDash` S "The",
   phrase system +:+. S "currently assumes the different layers of the soil are homogeneous",
   S "In the future,", plural calculation,
   S "can be added for inconsistent soil properties throughout"]
 
 unlikelyChanges_SRS :: [Contents]
-unlikelyChanges_SRS = [ucIntro, LlC unlikelychg1, LlC unlikelychg2]
+unlikelyChanges_SRS = [ucIntro] ++ mkEnumSimpleD unlikelyChgs
 
-unlikelychg1, unlikelychg2 :: LabelledContent
+unlikelyChgs :: [ConceptInstance]
+unlikelyChgs = [unlikelyChgNISLO, unlikelyChg2AO]
 
-unlikelychg1 = mkUnLklyChnk "UC_normshearlinear" uc1Desc "Normal-And-Shear-Linear-Only"
-unlikelychg2 = mkUnLklyChnk "UC_2donly"          uc2Desc "2D-Analysis-Only"
+unlikelyChgNISLO, unlikelyChg2AO :: ConceptInstance
 
-uc1Desc, uc2Desc :: Sentence
+unlikelyChgNISLO = cic "UC_normshearlinear" ucNASLODesc "Normal-And-Shear-Linear-Only" unlikeChgDom
+unlikelyChg2AO =   cic "UC_2donly"          uc2AODesc   "2D-Analysis-Only"             unlikeChgDom
 
-uc1Desc = foldlSent [S "Changes related to", (makeRef newA5) `sAnd`
+ucNASLODesc, uc2AODesc :: Sentence
+
+ucNASLODesc = foldlSent [S "Changes related to", (makeRef newA5) `sAnd`
   (makeRef newA6), S "are not possible due to the dependency",
   S "of the", plural calculation, S "on the linear relationship between",
   S "interslice normal and shear forces"]
 
-uc2Desc = foldlSent [makeRef newA8, S "allows for 2D analysis" +:+.
+uc2AODesc = foldlSent [makeRef newA8, S "allows for 2D analysis" +:+.
   S "with these models only because stress along z-direction is zero", 
   S "These models do not take into account stress in the z-direction, and",
   S "therefore cannot be without manipulation to attempt 3d analysis"]

--- a/code/drasil-example/Drasil/SSP/Requirements.hs
+++ b/code/drasil-example/Drasil/SSP/Requirements.hs
@@ -1,10 +1,10 @@
 module Drasil.SSP.Requirements (sspRequirements, sspInputDataTable) where
 
 import Language.Drasil
-import Drasil.DocLang (mkRequirement)
 
 import Data.Drasil.Concepts.Computation (inDatum)
-import Data.Drasil.Concepts.Documentation (datum, element, input_, method_, value)
+import Data.Drasil.Concepts.Documentation (datum, element, funcReqDom, input_,
+  method_, value)
 
 import Data.Drasil.SentenceStructures (FoldType(List), SepType(Comma), andThe, 
   foldlList, foldlSent, ofThe, sOf)
@@ -13,67 +13,71 @@ import Data.Drasil.Utils (mkInputDatTb)
 import Drasil.SSP.Defs (crtSlpSrf, morPrice, slice, slope, slpSrf)
 import Drasil.SSP.Unitals (coords, fs, fs_min, sspInputs)
 
-sspRequirements :: [LabelledContent]
+sspRequirements :: [ConceptInstance]
 sspRequirements = [readAndStore, generateCSS, testSlipSrf, prepareSlipS, 
     calculateFS, rankSlope, generateCSS', repeatFindFS, prepareCSS, 
     calculateFS', displayGraph]
 
 readAndStore, generateCSS, testSlipSrf, prepareSlipS, calculateFS, rankSlope, 
     generateCSS', repeatFindFS, prepareCSS, calculateFS', 
-    displayGraph :: LabelledContent
+    displayGraph :: ConceptInstance
 
-readAndStore = mkRequirement "readAndStore" ( foldlSent [
+readAndStore = cic "readAndStore" ( foldlSent [
   S "Read the", phrase input_, S "file and store the" +:+. 
   plural datum, S "Necessary", plural inDatum, S "summarized in", 
-  makeRef sspInputDataTable]) "Read-and-Store"
+  makeRef sspInputDataTable]) "Read-and-Store" funcReqDom
 
-generateCSS = mkRequirement "generateCSS" ( foldlSent [
+generateCSS = cic "generateCSS" ( foldlSent [
   S "Generate potential", plural crtSlpSrf,S "for the", 
-  phrase input_, phrase slope]) "Generate-Critical-Slip-Surfaces"
+  phrase input_, phrase slope]) "Generate-Critical-Slip-Surfaces" funcReqDom
 
-testSlipSrf = mkRequirement "testSlipSrf" ( foldlSent [
+testSlipSrf = cic "testSlipSrf" ( foldlSent [
   S "Test the", plural slpSrf, S "to determine if they are physically",
   S "realizable based on a set of pass or fail criteria"]) "Test-Slip-Surfaces"
+  funcReqDom
 
-prepareSlipS = mkRequirement "prepareSlipS" ( foldlSent [
+prepareSlipS = cic "prepareSlipS" ( foldlSent [
   S "Prepare the", plural slpSrf, S "for a", phrase method_ `sOf`
   plural slice, S "or limit equilibrium analysis"]) "Prepare-Slip-Surfaces"
+  funcReqDom
 
-calculateFS = mkRequirement "calculateFS" ( foldlSent [
+calculateFS = cic "calculateFS" ( foldlSent [
   S "Calculate", plural fs `ofThe` plural slpSrf]) "Calculate-Factors-of-Safety"
+  funcReqDom
 
-rankSlope = mkRequirement "rankSlope" ( foldlSent [
+rankSlope = cic "rankSlope" ( foldlSent [
   S "Rank and weight the", plural slope, S "based on their", 
   phrase fs `sC` S "such that a", phrase slpSrf, S "with a smaller", 
-  phrase fs, S "has a larger weighting"]) "Rank-and-Weight-Slopes"
+  phrase fs, S "has a larger weighting"]) "Rank-and-Weight-Slopes" funcReqDom
 
-generateCSS' = mkRequirement "generateCSS'" ( foldlSent [
+generateCSS' = cic "generateCSS'" ( foldlSent [
   S "Generate new potential", plural crtSlpSrf, 
   S "based on previously analysed", plural slpSrf, S "with low", 
-  plural fs]) "Generate-New-Critical-Slip-Surfaces"
+  plural fs]) "Generate-New-Critical-Slip-Surfaces" funcReqDom
 
-repeatFindFS = mkRequirement "repeatFindFS" ( foldlSent [
-  S "Repeat", (foldlList Comma List $ map makeRef [testSlipSrf, prepareSlipS, calculateFS, rankSlope, generateCSS']), 
-  S "until the", phrase fs_min, S "remains approximately the same over a",
+repeatFindFS = cic "repeatFindFS" ( foldlSent [
+  S "Repeat", (foldlList Comma List $ map makeRef [testSlipSrf, prepareSlipS,
+  calculateFS, rankSlope, generateCSS']), S "until the", phrase fs_min,
+  S "remains approximately the same over a",
   S "predetermined number of repetitions. Identify the", phrase slpSrf, 
   S "that generates the", phrase fs_min, S "as the", phrase crtSlpSrf])
-  "Repeat-Find-Factor-of-Safety"
+  "Repeat-Find-Factor-of-Safety" funcReqDom
 
-prepareCSS = mkRequirement "prepareCSS" ( foldlSent [
+prepareCSS = cic "prepareCSS" ( foldlSent [
   S "Prepare the", phrase crtSlpSrf, S "for", phrase method_ `sOf` 
   plural slice, S "or limit equilibrium analysis"])
-  "Prepare-Critical-Slip-Surface"
+  "Prepare-Critical-Slip-Surface" funcReqDom
 
-calculateFS' = mkRequirement "calculateFS'" ( foldlSent [
+calculateFS' = cic "calculateFS'" ( foldlSent [
   S "Calculate", phrase fs `ofThe` phrase crtSlpSrf, 
   S "using the", titleize morPrice, phrase method_])
-  "Calculate-Final-Factor-of-Safety"
+  "Calculate-Final-Factor-of-Safety" funcReqDom
 
-displayGraph = mkRequirement "displayGraph" ( foldlSent [
+displayGraph = cic "displayGraph" ( foldlSent [
   S "Display the", phrase crtSlpSrf `andThe` phrase slice, 
   phrase element, S "displacements graphically. Give", plural value `ofThe` 
   plural fs, S "calculated by the", titleize morPrice, phrase method_]) 
-  "Display-Graph"
+  "Display-Graph" funcReqDom
 
 ------------------
 sspInputDataTable :: LabelledContent

--- a/code/drasil-example/drasil-example.cabal
+++ b/code/drasil-example/drasil-example.cabal
@@ -165,11 +165,11 @@ executable ssp
     directory >= 1.2.6.2,
     split >= 0.2.3.1,
     drasil-lang >= 0.1.23,
-    drasil-data >= 0.1.6,
+    drasil-data >= 0.1.7,
     drasil-code >= 0.1.4,
     drasil-printers >= 0.1.5,
     drasil-gen >= 0.1.2,
-    drasil-docLang >= 0.1.8
+    drasil-docLang >= 0.1.11
   default-language: Haskell2010
   ghc-options:      -Wall
 

--- a/code/stable/ssp/SRS/SSP_SRS.tex
+++ b/code/stable/ssp/SRS/SSP_SRS.tex
@@ -22,12 +22,6 @@
 \global\tabulinesep=1mm
 \newcounter{assumpnum}
 \newcommand{\atheassumpnum}{A\theassumpnum}
-\newcounter{reqnum}
-\newcommand{\rthereqnum}{R\thereqnum}
-\newcounter{lcnum}
-\newcommand{\lcthelcnum}{LC\thelcnum}
-\newcounter{ucnum}
-\newcommand{\uctheucnum}{UC\theucnum}
 \bibliography{bibfile}
 \title{Software Requirements Specification for Slope Stability Analysis}
 \author{Henry Frankis}
@@ -2047,39 +2041,19 @@ $δy$ & --
 This section provides the functional requirements, the business tasks that the software is expected to complete, and the non-functional requirements, the qualities that the software is expected to exhibit.
 \subsection{Functional Requirements}
 \label{Sec:FRs}
-\begin{description}
-\item[\refstepcounter{reqnum}\rthereqnum\label{FR:Read-and-Store}:]Read the input file and store the data. Necessary input data summarized in Table~\ref{Table:inDataTable}.
-\end{description}
-\begin{description}
-\item[\refstepcounter{reqnum}\rthereqnum\label{FR:Generate-Critical-Slip-Surfaces}:]Generate potential critical slip surfaces for the input slope.
-\end{description}
-\begin{description}
-\item[\refstepcounter{reqnum}\rthereqnum\label{FR:Test-Slip-Surfaces}:]Test the slip surfaces to determine if they are physically realizable based on a set of pass or fail criteria.
-\end{description}
-\begin{description}
-\item[\refstepcounter{reqnum}\rthereqnum\label{FR:Prepare-Slip-Surfaces}:]Prepare the slip surfaces for a method of slices or limit equilibrium analysis.
-\end{description}
-\begin{description}
-\item[\refstepcounter{reqnum}\rthereqnum\label{FR:Calculate-Factors-of-Safety}:]Calculate the factors of safety of the slip surfaces.
-\end{description}
-\begin{description}
-\item[\refstepcounter{reqnum}\rthereqnum\label{FR:Rank-and-Weight-Slopes}:]Rank and weight the slopes based on their factor of safety, such that a slip surface with a smaller factor of safety has a larger weighting.
-\end{description}
-\begin{description}
-\item[\refstepcounter{reqnum}\rthereqnum\label{FR:Generate-New-Critical-Slip-Surfaces}:]Generate new potential critical slip surfaces based on previously analysed slip surfaces with low factors of safety.
-\end{description}
-\begin{description}
-\item[\refstepcounter{reqnum}\rthereqnum\label{FR:Repeat-Find-Factor-of-Safety}:]Repeat R\ref{FR:Test-Slip-Surfaces}, R\ref{FR:Prepare-Slip-Surfaces}, R\ref{FR:Calculate-Factors-of-Safety}, R\ref{FR:Rank-and-Weight-Slopes}, and R\ref{FR:Generate-New-Critical-Slip-Surfaces} until the minimum factor of safety remains approximately the same over a predetermined number of repetitions. Identify the slip surface that generates the minimum factor of safety as the critical slip surface.
-\end{description}
-\begin{description}
-\item[\refstepcounter{reqnum}\rthereqnum\label{FR:Prepare-Critical-Slip-Surface}:]Prepare the critical slip surface for method of slices or limit equilibrium analysis.
-\end{description}
-\begin{description}
-\item[\refstepcounter{reqnum}\rthereqnum\label{FR:Calculate-Final-Factor-of-Safety}:]Calculate the factor of safety of the critical slip surface using the Morgenstern Price method.
-\end{description}
-\begin{description}
-\item[\refstepcounter{reqnum}\rthereqnum\label{FR:Display-Graph}:]Display the critical slip surface and the slice element displacements graphically. Give the values of the factors of safety calculated by the Morgenstern Price method.
-\end{description}
+\begin{itemize}
+\item[Read-and-Store:\phantomsection\label{readAndStore}]Read the input file and store the data. Necessary input data summarized in Table~\ref{Table:inDataTable}.
+\item[Generate-Critical-Slip-Surfaces:\phantomsection\label{generateCSS}]Generate potential critical slip surfaces for the input slope.
+\item[Test-Slip-Surfaces:\phantomsection\label{testSlipSrf}]Test the slip surfaces to determine if they are physically realizable based on a set of pass or fail criteria.
+\item[Prepare-Slip-Surfaces:\phantomsection\label{prepareSlipS}]Prepare the slip surfaces for a method of slices or limit equilibrium analysis.
+\item[Calculate-Factors-of-Safety:\phantomsection\label{calculateFS}]Calculate the factors of safety of the slip surfaces.
+\item[Rank-and-Weight-Slopes:\phantomsection\label{rankSlope}]Rank and weight the slopes based on their factor of safety, such that a slip surface with a smaller factor of safety has a larger weighting.
+\item[Generate-New-Critical-Slip-Surfaces:\phantomsection\label{generateCSS'}]Generate new potential critical slip surfaces based on previously analysed slip surfaces with low factors of safety.
+\item[Repeat-Find-Factor-of-Safety:\phantomsection\label{repeatFindFS}]Repeat \hyperref[testSlipSrf]{FR: Test-Slip-Surfaces}, \hyperref[prepareSlipS]{FR: Prepare-Slip-Surfaces}, \hyperref[calculateFS]{FR: Calculate-Factors-of-Safety}, \hyperref[rankSlope]{FR: Rank-and-Weight-Slopes}, and \hyperref[generateCSS']{FR: Generate-New-Critical-Slip-Surfaces} until the minimum factor of safety remains approximately the same over a predetermined number of repetitions. Identify the slip surface that generates the minimum factor of safety as the critical slip surface.
+\item[Prepare-Critical-Slip-Surface:\phantomsection\label{prepareCSS}]Prepare the critical slip surface for method of slices or limit equilibrium analysis.
+\item[Calculate-Final-Factor-of-Safety:\phantomsection\label{calculateFS'}]Calculate the factor of safety of the critical slip surface using the Morgenstern Price method.
+\item[Display-Graph:\phantomsection\label{displayGraph}]Display the critical slip surface and the slice element displacements graphically. Give the values of the factors of safety calculated by the Morgenstern Price method.
+\end{itemize}
 \begin{longtable}{l l l}
 \toprule
 Symbol & Unit & Name
@@ -2116,18 +2090,16 @@ $κ$ & Pa & constant
 SSA is intended to be an educational tool, so accuracy and performance are not priorities. Rather, the non-functional requirement priorities are correctness, understandability, reusability, and maintainability.
 \section{Likely Changes}
 \label{Sec:LCs}
-\begin{description}
-\item[\refstepcounter{lcnum}\lcthelcnum\label{LC:Calculate-Inhomogeneous-Soil-Layers}:]A\ref{A:Soil-Layer-Homogeneous} - The system currently assumes the different layers of the soil are homogeneous. In the future, calculations can be added for inconsistent soil properties throughout.
-\end{description}
+\begin{itemize}
+\item[Calculate-Inhomogeneous-Soil-Layers:\phantomsection\label{LC\_inhomogeneous}]A\ref{A:Soil-Layer-Homogeneous} - The system currently assumes the different layers of the soil are homogeneous. In the future, calculations can be added for inconsistent soil properties throughout.
+\end{itemize}
 \section{Unlikely Changes}
 \label{Sec:UCs}
 If changes were to be made with regard to the following, a different algorithm would be needed.
-\begin{description}
-\item[\refstepcounter{ucnum}\uctheucnum\label{UC:Normal-And-Shear-Linear-Only}:]Changes related to A\ref{A:Interslice-Norm-Shear-Forces-Linear} and A\ref{A:Base-Norm-Shear-Forces-Linear-on-FS} are not possible due to the dependency of the calculations on the linear relationship between interslice normal and shear forces.
-\end{description}
-\begin{description}
-\item[\refstepcounter{ucnum}\uctheucnum\label{UC:2D-Analysis-Only}:]A\ref{A:Plane-Strain-Conditions} allows for 2D analysis with these models only because stress along z-direction is zero. These models do not take into account stress in the z-direction, and therefore cannot be without manipulation to attempt 3d analysis.
-\end{description}
+\begin{itemize}
+\item[Normal-And-Shear-Linear-Only:\phantomsection\label{UC\_normshearlinear}]Changes related to A\ref{A:Interslice-Norm-Shear-Forces-Linear} and A\ref{A:Base-Norm-Shear-Forces-Linear-on-FS} are not possible due to the dependency of the calculations on the linear relationship between interslice normal and shear forces.
+\item[2D-Analysis-Only:\phantomsection\label{UC\_2donly}]A\ref{A:Plane-Strain-Conditions} allows for 2D analysis with these models only because stress along z-direction is zero. These models do not take into account stress in the z-direction, and therefore cannot be without manipulation to attempt 3d analysis.
+\end{itemize}
 \section{Values of Auxiliary Constants}
 \label{Sec:AuxConstants}
 There are no auxiliary constants.

--- a/code/stable/ssp/Website/SSP_SRS.html
+++ b/code/stable/ssp/Website/SSP_SRS.html
@@ -6614,83 +6614,63 @@ This section provides the functional requirements, the business tasks that the s
 <h2>
 Functional Requirements
 </h2>
-<ul class="hide-list-style">
-<li>
-<div id="FR:Read-and-Store">
+<div class="list">
+<p>
+<div id="readAndStore">
 Read-and-Store: Read the input file and store the data. Necessary input data summarized in <a href=#Table:inDataTable>inDataTable</a>.
 </div>
-</li>
-</ul>
-<ul class="hide-list-style">
-<li>
-<div id="FR:Generate-Critical-Slip-Surfaces">
+</p>
+<p>
+<div id="generateCSS">
 Generate-Critical-Slip-Surfaces: Generate potential critical slip surfaces for the input slope.
 </div>
-</li>
-</ul>
-<ul class="hide-list-style">
-<li>
-<div id="FR:Test-Slip-Surfaces">
+</p>
+<p>
+<div id="testSlipSrf">
 Test-Slip-Surfaces: Test the slip surfaces to determine if they are physically realizable based on a set of pass or fail criteria.
 </div>
-</li>
-</ul>
-<ul class="hide-list-style">
-<li>
-<div id="FR:Prepare-Slip-Surfaces">
+</p>
+<p>
+<div id="prepareSlipS">
 Prepare-Slip-Surfaces: Prepare the slip surfaces for a method of slices or limit equilibrium analysis.
 </div>
-</li>
-</ul>
-<ul class="hide-list-style">
-<li>
-<div id="FR:Calculate-Factors-of-Safety">
+</p>
+<p>
+<div id="calculateFS">
 Calculate-Factors-of-Safety: Calculate the factors of safety of the slip surfaces.
 </div>
-</li>
-</ul>
-<ul class="hide-list-style">
-<li>
-<div id="FR:Rank-and-Weight-Slopes">
+</p>
+<p>
+<div id="rankSlope">
 Rank-and-Weight-Slopes: Rank and weight the slopes based on their factor of safety, such that a slip surface with a smaller factor of safety has a larger weighting.
 </div>
-</li>
-</ul>
-<ul class="hide-list-style">
-<li>
-<div id="FR:Generate-New-Critical-Slip-Surfaces">
+</p>
+<p>
+<div id="generateCSS'">
 Generate-New-Critical-Slip-Surfaces: Generate new potential critical slip surfaces based on previously analysed slip surfaces with low factors of safety.
 </div>
-</li>
-</ul>
-<ul class="hide-list-style">
-<li>
-<div id="FR:Repeat-Find-Factor-of-Safety">
-Repeat-Find-Factor-of-Safety: Repeat <a href=#FR:Test-Slip-Surfaces>FR: Test-Slip-Surfaces</a>, <a href=#FR:Prepare-Slip-Surfaces>FR: Prepare-Slip-Surfaces</a>, <a href=#FR:Calculate-Factors-of-Safety>FR: Calculate-Factors-of-Safety</a>, <a href=#FR:Rank-and-Weight-Slopes>FR: Rank-and-Weight-Slopes</a>, and <a href=#FR:Generate-New-Critical-Slip-Surfaces>FR: Generate-New-Critical-Slip-Surfaces</a> until the minimum factor of safety remains approximately the same over a predetermined number of repetitions. Identify the slip surface that generates the minimum factor of safety as the critical slip surface.
+</p>
+<p>
+<div id="repeatFindFS">
+Repeat-Find-Factor-of-Safety: Repeat <a href=#testSlipSrf>FR: Test-Slip-Surfaces</a>, <a href=#prepareSlipS>FR: Prepare-Slip-Surfaces</a>, <a href=#calculateFS>FR: Calculate-Factors-of-Safety</a>, <a href=#rankSlope>FR: Rank-and-Weight-Slopes</a>, and <a href=#generateCSS'>FR: Generate-New-Critical-Slip-Surfaces</a> until the minimum factor of safety remains approximately the same over a predetermined number of repetitions. Identify the slip surface that generates the minimum factor of safety as the critical slip surface.
 </div>
-</li>
-</ul>
-<ul class="hide-list-style">
-<li>
-<div id="FR:Prepare-Critical-Slip-Surface">
+</p>
+<p>
+<div id="prepareCSS">
 Prepare-Critical-Slip-Surface: Prepare the critical slip surface for method of slices or limit equilibrium analysis.
 </div>
-</li>
-</ul>
-<ul class="hide-list-style">
-<li>
-<div id="FR:Calculate-Final-Factor-of-Safety">
+</p>
+<p>
+<div id="calculateFS'">
 Calculate-Final-Factor-of-Safety: Calculate the factor of safety of the critical slip surface using the Morgenstern Price method.
 </div>
-</li>
-</ul>
-<ul class="hide-list-style">
-<li>
-<div id="FR:Display-Graph">
+</p>
+<p>
+<div id="displayGraph">
 Display-Graph: Display the critical slip surface and the slice element displacements graphically. Give the values of the factors of safety calculated by the Morgenstern Price method.
 </div>
-</li>
-</ul>
+</p>
+</div>
 <div id="Table:inDataTable">
 <table class="table">
 <tr>
@@ -6849,13 +6829,13 @@ SSA is intended to be an educational tool, so accuracy and performance are not p
 <h1>
 Likely Changes
 </h1>
-<ul class="hide-list-style">
-<li>
-<div id="LC:Calculate-Inhomogeneous-Soil-Layers">
+<div class="list">
+<p>
+<div id="LC_inhomogeneous">
 Calculate-Inhomogeneous-Soil-Layers: <a href=#A:Soil-Layer-Homogeneous>A: Soil-Layer-Homogeneous</a> - The system currently assumes the different layers of the soil are homogeneous. In the future, calculations can be added for inconsistent soil properties throughout.
 </div>
-</li>
-</ul>
+</p>
+</div>
 </div>
 </div>
 <div id="Sec:UCs">
@@ -6866,20 +6846,18 @@ Unlikely Changes
 <p class="paragraph">
 If changes were to be made with regard to the following, a different algorithm would be needed.
 </p>
-<ul class="hide-list-style">
-<li>
-<div id="UC:Normal-And-Shear-Linear-Only">
+<div class="list">
+<p>
+<div id="UC_normshearlinear">
 Normal-And-Shear-Linear-Only: Changes related to <a href=#A:Interslice-Norm-Shear-Forces-Linear>A: Interslice-Norm-Shear-Forces-Linear</a> and <a href=#A:Base-Norm-Shear-Forces-Linear-on-FS>A: Base-Norm-Shear-Forces-Linear-on-FS</a> are not possible due to the dependency of the calculations on the linear relationship between interslice normal and shear forces.
 </div>
-</li>
-</ul>
-<ul class="hide-list-style">
-<li>
-<div id="UC:2D-Analysis-Only">
+</p>
+<p>
+<div id="UC_2donly">
 2D-Analysis-Only: <a href=#A:Plane-Strain-Conditions>A: Plane-Strain-Conditions</a> allows for 2D analysis with these models only because stress along z-direction is zero. These models do not take into account stress in the z-direction, and therefore cannot be without manipulation to attempt 3d analysis.
 </div>
-</li>
-</ul>
+</p>
+</div>
 </div>
 </div>
 <div id="Sec:AuxConstants">


### PR DESCRIPTION
This PR continues work on #985. Like the other example migrations, Assumption `ConceptInstance`s are present but unused at the moment. 