### PR TITLE
Improve Consistency of Manual version and Drasil

### DIFF
--- a/code/drasil-example/Drasil/SSP/Assumptions.hs
+++ b/code/drasil-example/Drasil/SSP/Assumptions.hs
@@ -14,37 +14,39 @@ import Data.Drasil.Concepts.Math (surface, unit_)
 import Data.Drasil.Concepts.SolidMechanics (shearForce)
 
 newAssumptions :: [AssumpChunk]
-newAssumptions = [newA1, newA2, newA3, newA4, newA5, newA6, newA7, newA8, newA9, newA10]
+newAssumptions = [newA1, newA2, newA3, newA4, newA5, newA6, newA7, newA8, newA9, newA10, newA11]
 
 -- FIXME: Remove the newA AssumpChunk's once ConceptInstance and SCSProg's
 -- Assumptions has been migrated to using assumpDom
 
-newA1, newA2, newA3, newA4, newA5, newA6, newA7, newA8, newA9, newA10 :: AssumpChunk
-assumpSSC, assumpGSMPSL, assumpSLH, assumpSLI, assumpINSFL, assumpBNSFLFS,
-  assumpSSCIL, assumpPSC, assumpENSL, assumpSBSBISL :: ConceptInstance
+newA1, newA2, newA3, newA4, newA5, newA6, newA7, newA8, newA9, newA10, newA11 :: AssumpChunk
+assumpSSC, assumpFOSL, assumpSLH, assumpSLI, assumpINSFL, assumpBNSFLFS,
+  assumpSSCIL, assumpPSC, assumpENSL, assumpSBSBISL, assumpSP :: ConceptInstance
 newA1 = assump "Slip-Surface-Concave" monotonicF (mkLabelRAAssump' "Slip-Surface-Concave")
 assumpSSC = cic "assumpSSC" monotonicF "Slip-Surface-Concave" assumpDom
-newA2 = assump "Geo-Slope-Mat-Props-of-Soil-Inputs" slopeG (mkLabelRAAssump' "Geo-Slope-Mat-Props-of-Soil-Inputs")
-assumpGSMPSL = cic "assumpGSMPSL" slopeG "Geo-Slope-Mat-Props-of-Soil-Inputs" assumpDom
+newA2 = assump "Factor-of-Safety" slopeS (mkLabelRAAssump' "Factor-of-Safety")
+assumpFOSL = cic "assumpFOS" slopeS "Factor-of-Safety" assumpDom
 newA3 = assump "Soil-Layer-Homogeneous" homogeneousL (mkLabelRAAssump' "Soil-Layer-Homogeneous")
 assumpSLH = cic "assumpSLH" homogeneousL "Soil-Layer-Homogeneous" assumpDom
-newA4 = assump "Soil-Layers-Isotropic" isotropicP (mkLabelRAAssump' "Soil-Layers-Isotropic")
+newA4 = assump "Soil-Properties" propertiesS (mkLabelRAAssump' "Soil-Properties")
+assumpSP = cic "assumpSP" propertiesS "Soil-Properties" assumpDom
+newA5 = assump "Soil-Layers-Isotropic" isotropicP (mkLabelRAAssump' "Soil-Layers-Isotropic")
 assumpSLI = cic "assumpSLI" isotropicP "Soil-Layers-Isotropic" assumpDom
-newA5 = assump "Interslice-Norm-Shear-Forces-Linear" linearS (mkLabelRAAssump' "Interslice-Norm-Shear-Forces-Linear")
+newA6 = assump "Interslice-Norm-Shear-Forces-Linear" linearS (mkLabelRAAssump' "Interslice-Norm-Shear-Forces-Linear")
 assumpINSFL = cic "assumpINSFL" linearS "Interslice-Norm-Shear-Forces-Linear" assumpDom
-newA6 = assump "Base-Norm-Shear-Forces-Linear-on-FS" linearF (mkLabelRAAssump' "Base-Norm-Shear-Forces-Linear-on-FS")
-assumpBNSFLFS = cic "assumpBNSFLFS" linearF "Base-Norm-Shear-Forces-Linear-on-FS" assumpDom
-newA7 = assump "Stress-Strain-Curve-interslice-Linear" stressC (mkLabelRAAssump' "Stress-Strain-Curve-interslice-Linear")
-assumpSSCIL = cic "assumpSSCIL" stressC "Stress-Strain-Curve-interslice-Linear" assumpDom
-newA8 = assump "Plane-Strain-Conditions" planeS (mkLabelRAAssump' "Plane-Strain-Conditions")
+newA7 = assump "Plane-Strain-Conditions" planeS (mkLabelRAAssump' "Plane-Strain-Conditions")
 assumpPSC = cic "assumpPSC" planeS "Plane-Strain-Conditions" assumpDom
-newA9 = assump "Effective-Norm-Stress-Large" largeN (mkLabelRAAssump' "Effective-Norm-Stress-Large")
+newA8 = assump "Effective-Norm-Stress-Large" largeN (mkLabelRAAssump' "Effective-Norm-Stress-Large")
 assumpENSL = cic "assumpENSL" largeN "Effective-Norm-Stress-Large" assumpDom
-newA10 = assump "Surface-Base-Slice-between-Interslice-Straight-Lines" straightS 
+newA9 = assump "Surface-Base-Slice-between-Interslice-Straight-Lines" straightS 
            (mkLabelRAAssump' "Surface-Base-Slice-between-Interslice-Straight-Lines")
 assumpSBSBISL = cic "assumpSBSBISL" straightS "Surface-Base-Slice-between-Interslice-Straight-Lines" assumpDom
+newA10 = assump "Seismic-Force" linearF (mkLabelRAAssump' "Seismic-Force")
+assumpBNSFLFS = cic "assumpBNSFLFS" linearF "Base-Norm-Shear-Forces-Linear-on-FS" assumpDom
+newA11 = assump "Surface-Load" stressC (mkLabelRAAssump' "Surface-Load")
+assumpSSCIL = cic "assumpSSCIL" stressC "Surface-Load" assumpDom
 
-monotonicF, slopeG, homogeneousL, isotropicP, linearS,
+monotonicF, slopeS, homogeneousL, isotropicP, linearS,
   linearF, stressC, planeS, largeN, straightS :: Sentence
 
 monotonicF = foldlSent [S "The", phrase slpSrf,
@@ -52,13 +54,15 @@ monotonicF = foldlSent [S "The", phrase slpSrf,
   ((ch coords +:+ S "coordinates") `ofThe'` S "failure"),
   phrase surface, S "follow a monotonic function"]
 
-slopeG = foldlSent [S "geometry" `ofThe'` phrase slope `sC` S "and",
-  plural mtrlPrpty `ofThe` plural soilLyr, S "are given as inputs"]
+slopeS = foldlSent [S "The factor of safety is assumed to be constant across a whole",
+  phrase slpSrf]
+
+propertiesS = foldlSent [S "The", plural soilPrpty, S "are independent of dry or saturated",
+  plural condition `sC` S "with the exception of", phrase unit_, S "weight"]
 
 homogeneousL = foldlSent [S "different layers" `ofThe'` phrase soil,
-  S "are homogeneous" `sC` S "with consistent", plural soilPrpty,
-  S "throughout" `sC` S "and independent of dry or saturated",
-  plural condition `sC` S "with the exception of", phrase unit_, S "weight"]
+  S "are homogeneous" `sC` S "with consistent", plural soilPrpty +:+
+  S "throughout"]
 
 isotropicP = foldlSent [at_start' soilLyr, S "are treated as if they have",
   S "isotropic properties"]
@@ -68,13 +72,11 @@ linearS = foldlSent [at_start intrslce, S "normal and", plural shearForce,
   sParen (ch normToShear), S "and an", phrase intrslce, phrase force,
   S "function", sParen (ch scalFunc), S "depending on x position"]
 
-linearF = foldlSent [at_start slice, S "to base normal and",
-  plural shearForce, S "have", S "a linear relationship, dependent on the",
-  getTandS fs `sC` S "and the Coulomb sliding law"]
+linearF = foldlSent [S "There is no seismic force acting on the slope"]
 
-stressC = foldlSent [S "The stress - strain curve for",
-  phrase intrslce, S "relationships is",
-  S "linear with a constant", phrase slope]
+stressC = foldlSent [S "There is no imposed", phrase surface `sC` 
+  S "load and therefore no external force" `sC` S "acting on the",
+  phrase slope]
 
 planeS = foldlSent [S "The", phrase slope, S "and", phrase slpSrf +:+.
   S "extends far into and out of the geometry (z coordinate)",

--- a/code/drasil-example/Drasil/SSP/BasicExprs.hs
+++ b/code/drasil-example/Drasil/SSP/BasicExprs.hs
@@ -18,6 +18,15 @@ eqlExpr f1_ f2_ _e_ = (inxi slcWght `_e_`
   (inxi surfHydroForce) * sin (inxi surfAngle) +
   (inxi surfLoad) * (sin (inxi impLoadAngle))) * (f2_ (inxi baseAngle))
 
+eqlExprN :: (Expr -> Expr) -> (Expr -> Expr) -> (Expr -> Expr -> Expr) -> Expr
+eqlExprN f1_ f2_ _e_ = (inxi slcWght `_e_`
+  (inxi surfHydroForce * cos (inxi surfAngle)) +
+  (inxi surfLoad) * (cos (inxi impLoadAngle))) * (f1_ (inxi baseAngle)) -
+  (negate (sy earthqkLoadFctr) * (inxi slcWght) - (inxi intNormForce) +
+  (inxiM1 intNormForce) - (inxi watrForce) + (inxiM1 watrForce) +
+  (inxi surfHydroForce) * sin (inxi surfAngle) +
+  (inxi surfLoad) * (sin (inxi impLoadAngle))) * (f2_ (inxi baseAngle))
+
 momExpr :: (Expr -> Expr -> Expr) -> Expr
 momExpr _e_ = (negate (inxi intNormForce) * (inxi sliceHght -
   inxi baseWthX / 2 *  tan (inxi baseAngle)) + inxiM1 intNormForce *

--- a/code/drasil-example/Drasil/SSP/DataDefs.hs
+++ b/code/drasil-example/Drasil/SSP/DataDefs.hs
@@ -14,7 +14,7 @@ import Data.Drasil.SentenceStructures (eqN, foldlSentCol, foldlSP, getTandS,
   isThe, ofThe', sAnd)
 import Data.Drasil.Concepts.Math (equation)
 
-
+import Drasil.SSP.Assumptions (newA10, newA11)
 import Drasil.SSP.BasicExprs (eqlExpr)
 import Drasil.SSP.Labels (genDef2Label, genDef3Label, sliceWghtL, baseWtrFL, 
   surfWtrFL, intersliceWtrFL, angleAL, angleBL, lengthLbL , sliceWghtL, 
@@ -250,8 +250,7 @@ mobShearWOEqn = ((inxi slcWght) + (inxi surfHydroForce) *
   (inxi surfLoad) * (sin (inxi impLoadAngle))) * (cos (inxi baseAngle))
 
 mobShr_deriv_ssp :: Derivation
-mobShr_deriv_ssp = (weave [mobShrDerivation_sentence, map E mobShr_deriv_eqns_ssp]) ++
-  mobShr_deriv_sentences_ssp_s3
+mobShr_deriv_ssp = (weave [mobShrDerivation_sentence, map E mobShr_deriv_eqns_ssp])
 
 -----------------
 -- Hacks --------
@@ -296,15 +295,20 @@ resShr_deriv_sentences_ssp_s3 = [S "Using", ch nrmFNoIntsl `sC` S "a", phrase sh
   shearRNoIntsl ^. defn, S "can be solved for in terms of all known",
   plural value, S "as done in", eqN 3]
 
+resShr_deriv_sentences_ssp_s4 :: [Sentence]
+resShr_deriv_sentences_ssp_s4 = [S "This can be further simplified by considering assumptions",
+  makeRefS newA10, S "and", makeRefS newA11 `sC`
+  S "which state that the seismic coefficient and the external force" `sC` S "respectively"
+  `sC` S "are0", S "Removing seismic and external forces yields ", eqN 4]
 
 resShrDerivation_sentence :: [Sentence]
 resShrDerivation_sentence = map foldlSentCol [resShr_deriv_sentences_ssp_s1, resShr_deriv_sentences_ssp_s2,
-  resShr_deriv_sentences_ssp_s3]
+  resShr_deriv_sentences_ssp_s3, resShr_deriv_sentences_ssp_s4]
 
 resShr_deriv_eqns_ssp :: [Expr]
-resShr_deriv_eqns_ssp = [eq1, eq2, eq3]
+resShr_deriv_eqns_ssp = [eq1, eq2, eq3, eq8]
 
-eq1, eq2, eq3 :: Expr
+eq1, eq2, eq3, eq8 :: Expr
 eq1 = (inxi nrmFSubWat) $= eqlExpr cos sin (\x y -> x -
   inxiM1 intShrForce + inxi intShrForce + y) - inxi baseHydroForce
 
@@ -325,6 +329,14 @@ eq3 = inxi shearRNoIntsl $= (inxi nrmFNoIntsl) * tan (inxi fricAngle) +
   (inxi baseHydroForce)) * tan (inxi fricAngle) + (inxi cohesion) *
   (inxi baseWthX) * sec (inxi baseAngle)
 
+eq8 = inxi shearRNoIntsl $=
+  (((inxi slcWght) + (inxi surfHydroForce) * (cos (inxi surfAngle))) * (cos (inxi baseAngle)) +
+  (- (inxi watrForceDif) +
+  (inxi surfHydroForce) * sin (inxi surfAngle) + (inxi surfLoad) *
+  (sin (inxi impLoadAngle))) * (sin (inxi baseAngle)) -
+  (inxi baseHydroForce)) * tan (inxi fricAngle) + (inxi cohesion) *
+  (inxi baseWthX) * sec (inxi baseAngle)
+
 -------old chunk---------
 
 resShrDerivation :: [Contents]
@@ -335,7 +347,7 @@ resShrDerivation = [
   phrase nrmFSubWat, S "in the", phrase equation, S "for", ch shrResI,
   S "of the soil is defined in the perpendicular force equilibrium",
   S "of a slice from", makeRefS genDef2Label `sC` S "using the", getTandS nrmFSubWat,
-  S "of", makeRefS effStress, S "shown in", eqN 1],
+  S "of", makeRefS effStress, S "shown in", eqN 5],
   
   eqUnR' $ (inxi nrmFSubWat) $= eqlExpr cos sin (\x y -> x -
   inxiM1 intShrForce + inxi intShrForce + y) - inxi baseHydroForce,
@@ -378,27 +390,31 @@ resShrDerivation = [
 mobShr_deriv_sentences_ssp_s1 :: [Sentence]
 mobShr_deriv_sentences_ssp_s1 = [S "The", phrase mobShrI, S "acting on a slice is defined as",
   ch mobShrI, S "from the force equilibrium in", makeRefS genDef2Label `sC`
-  S "also shown in", eqN 4]
+  S "also shown in", eqN 5]
 
 mobShr_deriv_sentences_ssp_s2 :: [Sentence]
 mobShr_deriv_sentences_ssp_s2 = [S "The", phrase equation, S "is unsolvable, containing the unknown",
   getTandS intNormForce, S "and" +:+. getTandS intShrForce,
   S "Consider a force equilibrium", S wiif `sC` S "to obtain the",
-  getTandS shearFNoIntsl `sC` S "as done in", eqN 5]
+  getTandS shearFNoIntsl `sC` S "as done in", eqN 6]
 
 mobShr_deriv_sentences_ssp_s3 :: [Sentence]
-mobShr_deriv_sentences_ssp_s3 = [S "The" +:+ plural value +:+ S "of" +:+ ch shearRNoIntsl `sAnd`
-  ch shearFNoIntsl +:+ S "are now defined completely in terms of the" +:+
-  S "known force property" +:+ plural value +:+ S "of" +:+ makeRefS sliceWght +:+ S "to" +:+. makeRefS lengthLs]
+mobShr_deriv_sentences_ssp_s3 = [S "The" +:+ plural value +:+ S "of" +:+ 
+  ch shearFNoIntsl +:+ S "is now defined completely in terms of the" +:+
+  S "known" +:+. plural value +:+ S "This can be further simplified by considering assumptions" +:+
+  makeRefS newA10 +:+ S "and" +:+ makeRefS newA11 `sC`
+  S "which state that the seismic coefficient and the external force" `sC` S "respectively"
+  `sC` S "are0" +:+ S "Removing seismic and external forces yields " +:+ eqN 7]
 
 
 mobShrDerivation_sentence :: [Sentence]
-mobShrDerivation_sentence = map foldlSentCol [mobShr_deriv_sentences_ssp_s1, mobShr_deriv_sentences_ssp_s2]
+mobShrDerivation_sentence = map foldlSentCol [mobShr_deriv_sentences_ssp_s1, mobShr_deriv_sentences_ssp_s2,
+  mobShr_deriv_sentences_ssp_s3]
 
 mobShr_deriv_eqns_ssp :: [Expr]
-mobShr_deriv_eqns_ssp = [eq4, eq5]
+mobShr_deriv_eqns_ssp = [eq4, eq5, eq6]
 
-eq4, eq5:: Expr
+eq4, eq5, eq6:: Expr
 eq4 = inxi mobShrI $= eqlExpr sin cos
     (\x y -> x - inxiM1 intShrForce + inxi intShrForce + y)
 
@@ -407,6 +423,11 @@ eq5 = inxi shearFNoIntsl $= ((inxi slcWght) + (inxi surfHydroForce) *
   (sin (inxi baseAngle)) - (negate (sy earthqkLoadFctr) * (inxi slcWght) -
   (inxi watrForceDif) + (inxi surfHydroForce) * sin (inxi surfAngle) +
   (inxi surfLoad) * (sin (inxi impLoadAngle))) * (cos (inxi baseAngle))
+
+eq6 = inxi shearFNoIntsl $= ((inxi slcWght) + (inxi surfHydroForce) *
+  (cos (inxi surfAngle))) *
+  (sin (inxi baseAngle)) -
+  ((inxi watrForceDif) + (inxi surfHydroForce) * sin (inxi surfAngle)) * (cos (inxi baseAngle))
 
   ------old chunk-----
 mobShrDerivation :: [Contents]

--- a/code/drasil-example/Drasil/SSP/GenDefs.hs
+++ b/code/drasil-example/Drasil/SSP/GenDefs.hs
@@ -19,10 +19,10 @@ import Data.Drasil.Quantities.SolidMechanics (nrmStrss)
 import Data.Drasil.SentenceStructures (foldlSent, getTandS, ofThe, sAnd)
 
 import Drasil.SSP.Assumptions (newA6)
-import Drasil.SSP.BasicExprs (eqlExpr, momExpr)
+import Drasil.SSP.BasicExprs (eqlExpr, eqlExprN, momExpr)
 import Drasil.SSP.DataDefs (lengthLs, sliceWght)
 import Drasil.SSP.Defs (intrslce, slice, slope, slpSrf)
-import Drasil.SSP.Labels (genDef3Label)
+import Drasil.SSP.Labels (genDef3Label, forceDiagramL)
 import Drasil.SSP.References (chen2005)
 import Drasil.SSP.TMods (factOfSafety, equilibrium, mcShrStrgth, effStress)
 import Drasil.SSP.Unitals (baseAngle, baseHydroForce, baseLngth, baseWthX, 
@@ -54,19 +54,10 @@ nmFEq_rel = inxi totNrmForce $= eqlExpr cos sin
   (\x y -> x - inxiM1 intShrForce + inxi intShrForce + y)
 
 nmFEq_desc :: Sentence
-nmFEq_desc = foldlSent [S "For a", phrase slice, S "of", phrase mass,
-  S "in the", phrase slope, S "the", phrase force,
-  S "equilibrium to satisfy", makeRefS equilibrium, S "in the direction",
-  phrase perp, S "to" +:+. (S "base" +:+ phrase surface `ofThe`
-  phrase slice), S "Rearranged to solve for", (phrase normForce `ofThe`
-  phrase surface) +:+. ch totNrmForce, at_start force, S "equilibrium is",
-  S "derived from the free body diagram of",
-  makeRefS SRS.physSystLabel, S "Index i",
-  S "refers to", (plural value `ofThe` plural property), S "for",
-  phrase slice :+: S "/" :+: plural intrslce, S "following convention in" +:+.
-  makeRefS SRS.physSystLabel, at_start force, phrase variable,
-  plural definition, S "can be found in", makeRefS sliceWght, S "to",
-  makeRefS lengthLs]
+nmFEq_desc = foldlSent [S "This equation satisfies", makeRefS equilibrium +:+.
+  S "in the shear direction", at_start force, S "equilibrium is",
+  S "derived from the free body diagram of", makeRefS forceDiagramL,
+  S "in", makeRefS SRS.physSystLabel]
 
 --
 bsShrFEq :: RelationConcept
@@ -74,23 +65,14 @@ bsShrFEq = makeRC "bsShrFEq" (nounPhraseSP "base shear force equilibrium")
   bShFEq_desc bShFEq_rel -- genDef2Label
 
 bShFEq_rel :: Relation
-bShFEq_rel = inxi mobShrI $= eqlExpr sin cos
+bShFEq_rel = inxi mobShrI $= eqlExprN sin cos
   (\x y -> x - inxiM1 intShrForce + inxi intShrForce + y)
 
 bShFEq_desc :: Sentence
-bShFEq_desc = foldlSent [S "For a", phrase slice, S "of", phrase mass,
-  S "in the", phrase slope, S "the", phrase force,
-  S "equilibrium to satisfy", makeRefS equilibrium, S "in the direction",
-  S "parallel to" +:+. (S "base" +:+ phrase surface `ofThe`
-  phrase slice), S "Rearranged to solve for the", phrase shearForce,
-  S "on the base" +:+. ch mobShrI, at_start force, S "equilibrium is",
-  S "derived from the free body diagram of",
-  makeRefS SRS.physSystLabel, S "Index", ch index,
-  S "refers to", (plural value `ofThe` plural property), S "for",
-  phrase slice :+: S "/" :+: plural intrslce, S "following convention in" +:+.
-  makeRefS SRS.physSystLabel, at_start force, phrase variable,
-  plural definition, S "can be found in", makeRefS sliceWght, S "to",
-  makeRefS lengthLs]
+bShFEq_desc = foldlSent [S "This equation satisfies", makeRefS equilibrium +:+.
+  S "in the shear direction", at_start force, S "equilibrium is",
+  S "derived from the free body diagram of", makeRefS forceDiagramL,
+  S "in", makeRefS SRS.physSystLabel]
 
 --
 shrResEqn :: Expr

--- a/code/drasil-example/Drasil/SSP/GenDefs.hs
+++ b/code/drasil-example/Drasil/SSP/GenDefs.hs
@@ -1,5 +1,6 @@
 module Drasil.SSP.GenDefs (normForcEq, bsShrFEq, resShr, mobShr,
-  normShrR, momentEql, generalDefinitions) where
+  normShrR, momentEql, generalDefinitions,
+  normForcEqGD, bsShrFEqGD, resShrGD, mobShrGD, normShrRGD, momentEqlGD) where
 
 import Prelude hiding (sin, cos, tan)
 import Language.Drasil
@@ -17,7 +18,7 @@ import Data.Drasil.Quantities.SolidMechanics (nrmStrss)
 
 import Data.Drasil.SentenceStructures (foldlSent, getTandS, ofThe, sAnd)
 
-import Drasil.SSP.Assumptions (newA5)
+import Drasil.SSP.Assumptions (newA6)
 import Drasil.SSP.BasicExprs (eqlExpr, momExpr)
 import Drasil.SSP.DataDefs (lengthLs, sliceWght)
 import Drasil.SSP.Defs (intrslce, slice, slope, slpSrf)
@@ -33,14 +34,15 @@ import Drasil.SSP.Unitals (baseAngle, baseHydroForce, baseLngth, baseWthX,
 --  General Definitions  --
 ---------------------------
 generalDefinitions :: [GenDefn]
-generalDefinitions = [
-  gd'' normForcEq  [makeRef chen2005]   "normForcEq"  [nmFEq_desc],
-  gd'' bsShrFEq    [makeRef chen2005]   "bsShrFEq"    [bShFEq_desc],
-  gd'' resShr      [makeRef chen2005]   "resShr"      [resShr_desc],
-  gd'' mobShr      [makeRef chen2005]   "mobShr"      [mobShr_desc],
-  gd'' normShrR    [makeRef chen2005]   "normShrR"    [nmShrR_desc],
-  gd'' momentEql   [makeRef chen2005]   "momentEql"   [momEql_desc]
-  ]
+generalDefinitions = [normForcEqGD, bsShrFEqGD, resShrGD, mobShrGD, normShrRGD, momentEqlGD]
+
+normForcEqGD, bsShrFEqGD, resShrGD, mobShrGD, normShrRGD, momentEqlGD :: GenDefn
+normForcEqGD = gd'' normForcEq  [makeRef chen2005]   "normForcEq"  [nmFEq_desc]
+bsShrFEqGD   = gd'' bsShrFEq    [makeRef chen2005]   "bsShrFEq"    [bShFEq_desc]
+resShrGD     = gd'' resShr      [makeRef chen2005]   "resShr"      [resShr_desc]
+mobShrGD     = gd'' mobShr      [makeRef chen2005]   "mobShr"      [mobShr_desc]
+normShrRGD   = gd'' normShrR    [makeRef chen2005]   "normShrR"    [nmShrR_desc]
+momentEqlGD  = gd'' momentEql   [makeRef chen2005]   "momentEql"   [momEql_desc]
 
 --
 normForcEq :: RelationConcept
@@ -143,7 +145,7 @@ nmShrR_rel = sy intShrForce $= sy normToShear * sy scalFunc * sy intNormForce
 
 nmShrR_desc :: Sentence
 nmShrR_desc = foldlSent [S "The", phrase assumption,
-  S "for the Morgenstern Price", phrase method_, sParen (makeRefS newA5),
+  S "for the Morgenstern Price", phrase method_, sParen (makeRefS newA6),
   S "that the", phrase intrslce, phrase shearForce, ch xi,
   S "is proportional to the", phrase intrslce, 
   phrase normForce, ch intNormForce, S "by a proportionality constant",

--- a/code/drasil-example/Drasil/SSP/IMods.hs
+++ b/code/drasil-example/Drasil/SSP/IMods.hs
@@ -16,10 +16,12 @@ import Data.Drasil.Concepts.Physics (force)
 import Data.Drasil.SentenceStructures (andThe, eqN, foldlSent, foldlSent_, 
   foldlSentCol, foldlSP, getTandS, getTDS, isThe, ofThe, ofThe', sAnd, sIs, sOf)
 
+import Drasil.SSP.Assumptions (newA10, newA11,newA6)
 import Drasil.SSP.BasicExprs (eqlExpr, momExpr)
 import Drasil.SSP.DataDefs (fixme1, fixme2,
   lengthLs, mobShearWO, resShearWO, seismicLoadF, sliceWght, 
   surfLoads)
+import Drasil.SSP.GenDefs (normShrRGD, momentEqlGD, normForcEqGD)
 import Drasil.SSP.Defs (crtSlpSrf, factorOfSafety, intrslce, morPrice, slice, slip, slope, ssa)
 import Drasil.SSP.Labels (genDef1Label, genDef2Label, genDef4Label, genDef5Label, 
   genDef6Label)
@@ -42,8 +44,7 @@ sspIMods = [fctSfty, nrmShrFor, intsliceFs, crtSlpId]
 
 --
 fctSfty :: InstanceModel
-fctSfty = im'' fctSfty_rc [qw shearRNoIntsl, qw shearFNoIntsl,
- qw mobShrC, qw shrResC, qw varblV]
+fctSfty = im'' fctSfty_rc [qw shearRNoIntsl, qw shearFNoIntsl, qw mobShrC, qw shrResC, qw varblV]
   [] (qw fs) [] [makeRef chen2005] fctSftyDeriv "fctSfty" [fcSfty_desc]
 
 fctSfty_rc :: RelationConcept
@@ -238,22 +239,22 @@ nrmShrDeriv :: Derivation
 nrmShrDeriv = (weave [nrmShrDerivationSentences, map E nrmShrDerivEqns]) ++ nrmShrDerivSentence4
 
 nrmShrDerivSentence1 :: [Sentence]
-nrmShrDerivSentence1 = [S "Taking the last static", phrase equation,
-  S "of", makeRefS equilibrium, S "with the", S "moment equilibrium" `sOf` makeRefS genDef6Label,
-  S "about", (S "midpoint" `ofThe` S "base") `sAnd` S "the",
-  phrase assumption, S "of", makeRefS genDef5Label, S "results in", eqN 13]
+nrmShrDerivSentence1 = [S "From the moment equilibrium of", makeRefS momentEqlGD,
+  S "with the primary assumption for the Morgenstern-Price method of", makeRefS newA6 `sAnd`
+  S "associated definition", makeRefS normShrRGD, S "equation", eqN 9, S "can be derived"]
 
 nrmShrDerivSentence2 :: [Sentence]
-nrmShrDerivSentence2 = [S "The", phrase equation, S "in terms of", ch normToShear,
-  S "leads to", eqN 14]
+nrmShrDerivSentence2 = [S "Rearranging the", phrase equation, S "in terms of", ch normToShear,
+  S "leads to", eqN 10]
 
 nrmShrDerivSentence3 :: [Sentence]
 nrmShrDerivSentence3 = [S "Taking a summation of each slice, and", boundaryCon `sC`
-  S "a general", phrase equation, S "for the constant", ch normToShear,
-  S "is developed in", eqN 15 `sC` S "also found in", makeRefS nrmShrFor]
+  S "and removing the seismic and external forces due to", makeRefS newA10 `sAnd` makeRefS newA11
+  `sC` S "a general", phrase equation, S "for the constant", ch normToShear,
+  S "is developed in", eqN 11 `sC` S "also found in", makeRefS nrmShrFor]
 
 nrmShrDerivSentence4 :: [Sentence]
-nrmShrDerivSentence4 = [eqN 15 +:+ S "for" +:+ ch normToShear `sC`
+nrmShrDerivSentence4 = [eqN 11 +:+ S "for" +:+ ch normToShear `sC`
   S "is a function of the unknown" +:+ getTandS intNormForce +:+. makeRefS intsliceFs]
 
 
@@ -289,13 +290,11 @@ intrSlcDeriv :: Derivation
 intrSlcDeriv = weave [intrSlcDerivationSentences, map E intrSlcDerivEqns] ++ fUnknowns
 
 intrSlcDerivSentence1 :: [Sentence]
-intrSlcDerivSentence1 = [S "Taking the", S "normal force equilibrium" `sOf` makeRefS genDef1Label,
-  S "with the", S "effective stress", phrase definition, S "from", makeRefS effStress,
-  -- NOTE: "Taking this with that and the assumption of _
-  -- to get equation #" pattern
-  S "that", E (inxi totNrmForce $= inxi nrmFSubWat - inxi baseHydroForce) `sC`
-  S "and the assumption of", makeRefS genDef5Label, S "the equilibrium", phrase equation, 
-  S "can be rewritten as", eqN 16]
+intrSlcDerivSentence1 = [S "Substituting the", S "normal force equilibrium" `sOf`
+  (makeRefS normForcEqGD) `sAnd` S "the assumption", makeRefS newA6,
+  S "represented by", makeRefS momentEqlGD, 
+  S "into the effective normal force definition from", makeRefS normShrRGD,
+  S "yields equation", eqN 12] 
 
 intrSlcDerivSentence2 :: [Sentence]
 intrSlcDerivSentence2 = [S "Taking the", S "base shear force equilibrium" `sOf`

--- a/code/drasil-example/Drasil/SSP/Labels.hs
+++ b/code/drasil-example/Drasil/SSP/Labels.hs
@@ -55,3 +55,7 @@ fctSftyL = mkLabelSame "fctSfty"    (Def Instance)
 nrmShrForL = mkLabelSame "nrmShrFor"  (Def Instance)
 inslideFxL = mkLabelSame "inslideFx"  (Def Instance)
 crtSlpIdL = mkLabelSame "crtSlpId"   (Def Instance)
+
+-- Fig
+forceDiagramL :: Label
+forceDiagramL = (mkLabelRAFig "ForceDiagram")

--- a/code/stable/ssp/SRS/SSP_SRS.tex
+++ b/code/stable/ssp/SRS/SSP_SRS.tex
@@ -324,22 +324,19 @@ This section simplifies the original problem and helps in developing the theoret
 \item[\refstepcounter{assumpnum}\atheassumpnum\label{A:Slip-Surface-Concave}:]The slip surface is concave with respect to the slope surface. The $(x,y)$ coordinates of the failure surface follow a monotonic function.
 \end{description}
 \begin{description}
-\item[\refstepcounter{assumpnum}\atheassumpnum\label{A:Geo-Slope-Mat-Props-of-Soil-Inputs}:]The geometry of the slope, and the material properties of the soil layers are given as inputs.
+\item[\refstepcounter{assumpnum}\atheassumpnum\label{A:Factor-of-Safety}:]The factor of safety is assumed to be constant across a whole slip surface.
 \end{description}
 \begin{description}
-\item[\refstepcounter{assumpnum}\atheassumpnum\label{A:Soil-Layer-Homogeneous}:]The different layers of the soil are homogeneous, with consistent soil properties throughout, and independent of dry or saturated conditions, with the exception of unit weight.
+\item[\refstepcounter{assumpnum}\atheassumpnum\label{A:Soil-Layer-Homogeneous}:]The different layers of the soil are homogeneous, with consistent soil properties throughout.
+\end{description}
+\begin{description}
+\item[\refstepcounter{assumpnum}\atheassumpnum\label{A:Soil-Properties}:]The soil properties are independent of dry or saturated conditions, with the exception of unit weight.
 \end{description}
 \begin{description}
 \item[\refstepcounter{assumpnum}\atheassumpnum\label{A:Soil-Layers-Isotropic}:]Soil layers are treated as if they have isotropic properties.
 \end{description}
 \begin{description}
 \item[\refstepcounter{assumpnum}\atheassumpnum\label{A:Interslice-Norm-Shear-Forces-Linear}:]Interslice normal and shear forces have a linear relationship, proportional to a constant ($λ$) and an interslice force function ($f$) depending on x position.
-\end{description}
-\begin{description}
-\item[\refstepcounter{assumpnum}\atheassumpnum\label{A:Base-Norm-Shear-Forces-Linear-on-FS}:]Slice to base normal and shear forces have a linear relationship, dependent on the factor of safety $FS$, and the Coulomb sliding law.
-\end{description}
-\begin{description}
-\item[\refstepcounter{assumpnum}\atheassumpnum\label{A:Stress-Strain-Curve-interslice-Linear}:]The stress - strain curve for interslice relationships is linear with a constant slope.
 \end{description}
 \begin{description}
 \item[\refstepcounter{assumpnum}\atheassumpnum\label{A:Plane-Strain-Conditions}:]The slope and slip surface extends far into and out of the geometry (z coordinate). This implies plane strain conditions, making 2D analysis appropriate.
@@ -349,6 +346,12 @@ This section simplifies the original problem and helps in developing the theoret
 \end{description}
 \begin{description}
 \item[\refstepcounter{assumpnum}\atheassumpnum\label{A:Surface-Base-Slice-between-Interslice-Straight-Lines}:]The surface and base of a slice between interslice nodes are approximated as straight lines.
+\end{description}
+\begin{description}
+\item[\refstepcounter{assumpnum}\atheassumpnum\label{A:Seismic-Force}:]There is no seismic force acting on the slope.
+\end{description}
+\begin{description}
+\item[\refstepcounter{assumpnum}\atheassumpnum\label{A:Surface-Load}:]There is no imposed surface, load and therefore no external force, acting on the slope.
 \end{description}
 \subsubsection{Theoretical Models}
 \label{Sec:TMs}
@@ -398,7 +401,7 @@ Description & \begin{symbDescription}
               \item{$M$ is the moment (Nm)}
               \end{symbDescription}
 \\ \midrule \\
-Notes & For a body in static equilibrium, the net forces and net moments acting on the body will cancel out. Assuming a 2D problem (A\ref{A:Plane-Strain-Conditions}) the x-component of the net force ${F_{x}}$ and y-component of the net force ${F_{y}}$ will be equal to $0$. All forces and their distance from the chosen point of rotation will create a net moment equal to $0$.
+Notes & For a body in static equilibrium, the net forces and net moments acting on the body will cancel out. Assuming a 2D problem (A\ref{A:Effective-Norm-Stress-Large}) the x-component of the net force ${F_{x}}$ and y-component of the net force ${F_{y}}$ will be equal to $0$. All forces and their distance from the chosen point of rotation will create a net moment equal to $0$.
 \\ \midrule \\
 Source & \cite{fredlund1977}
 \\ \midrule \\
@@ -425,7 +428,7 @@ Description & \begin{symbDescription}
               \item{$c'$ is the effective cohesion (Pa)}
               \end{symbDescription}
 \\ \midrule \\
-Notes & For a soil under stress it will exert a shear resistive strength based on the Coulomb sliding law. The resistive shear is the maximum amount of shear a surface can experience while remaining rigid, analogous to a maximum normal force. In this model the resistive shear stress $τ$ is proportional to the product of the normal stress on the plane $σ$ with it's static friction in the angular form $\tan\left(φ'\right)={U_{t}}$. The $τ$ versus $σ$ relationship is not truly linear, but assuming the effective normal force is strong enough, it can be approximated with a linear fit (A\ref{A:Effective-Norm-Stress-Large}) where the cohesion $c'$ represents the $τ$ intercept of the fitted line.
+Notes & For a soil under stress it will exert a shear resistive strength based on the Coulomb sliding law. The resistive shear is the maximum amount of shear a surface can experience while remaining rigid, analogous to a maximum normal force. In this model the resistive shear stress $τ$ is proportional to the product of the normal stress on the plane $σ$ with it's static friction in the angular form $\tan\left(φ'\right)={U_{t}}$. The $τ$ versus $σ$ relationship is not truly linear, but assuming the effective normal force is strong enough, it can be approximated with a linear fit (A\ref{A:Surface-Base-Slice-between-Interslice-Straight-Lines}) where the cohesion $c'$ represents the $τ$ intercept of the fitted line.
 \\ \midrule \\
 Source & \cite{fredlund1977}
 \\ \midrule \\
@@ -1082,6 +1085,10 @@ Using $N*$, a resistive shear force without the influence of interslice forces f
 \begin{dmath}
 R_{i}=N*_{i} \tan\left({φ'}_{i}\right)+{c'}_{i} b_{i} \sec\left(α_{i}\right)=\left(\left(W_{i}+{U_{t,i}} \cos\left(β_{i}\right)+Q_{i} \cos\left(ω_{i}\right)\right) \cos\left(α_{i}\right)+\left(-{K_{c}} W_{i}-{ΔH}_{i}+{U_{t,i}} \sin\left(β_{i}\right)+Q_{i} \sin\left(ω_{i}\right)\right) \sin\left(α_{i}\right)-{U_{b,i}}\right) \tan\left({φ'}_{i}\right)+{c'}_{i} b_{i} \sec\left(α_{i}\right)
 \end{dmath}
+This can be further simplified by considering assumptions A\ref{A:Seismic-Force} and A\ref{A:Surface-Load}, which state that the seismic coefficient and the external force, respectively, are0 Removing seismic and external forces yields  equation (4):
+\begin{dmath}
+R_{i}=\left(\left(W_{i}+{U_{t,i}} \cos\left(β_{i}\right)\right) \cos\left(α_{i}\right)+\left(-{ΔH}_{i}+{U_{t,i}} \sin\left(β_{i}\right)+Q_{i} \sin\left(ω_{i}\right)\right) \sin\left(α_{i}\right)-{U_{b,i}}\right) \tan\left({φ'}_{i}\right)+{c'}_{i} b_{i} \sec\left(α_{i}\right)
+\end{dmath}
 ~\newline
 \noindent \begin{minipage}{\textwidth}
 \begin{tabular}{p{0.2\textwidth} p{0.73\textwidth}}
@@ -1117,15 +1124,18 @@ Source & \cite{chen2005}
 RefBy & FIXME: This needs to be filled in
 \\ \bottomrule \end{tabular}
 \end{minipage}\\
-The mobilized shear force acting on a slice is defined as $S$ from the force equilibrium in \hyperref[GD:bsShrFEq]{Definition~GD:bsShrFEq}, also shown in equation (4):
+The mobilized shear force acting on a slice is defined as $S$ from the force equilibrium in \hyperref[GD:bsShrFEq]{Definition~GD:bsShrFEq}, also shown in equation (5):
 \begin{dmath}
 S_{i}=\left(W_{i}-X_{i-1}+X_{i}+{U_{t,i}} \cos\left(β_{i}\right)+Q_{i} \cos\left(ω_{i}\right)\right) \sin\left(α_{i}\right)+\left(-{K_{c}} W_{i}-G_{i}+G_{i-1}-H_{i}+H_{i-1}+{U_{t,i}} \sin\left(β_{i}\right)+Q_{i} \sin\left(ω_{i}\right)\right) \cos\left(α_{i}\right)
 \end{dmath}
-The equation is unsolvable, containing the unknown interslice normal force $G$ and interslice shear force $X$. Consider a force equilibrium without the influence of interslice forces, to obtain the mobilized shear force $T$, as done in equation (5):
+The equation is unsolvable, containing the unknown interslice normal force $G$ and interslice shear force $X$. Consider a force equilibrium without the influence of interslice forces, to obtain the mobilized shear force $T$, as done in equation (6):
 \begin{dmath}
 T_{i}=\left(W_{i}+{U_{t,i}} \cos\left(β_{i}\right)+Q_{i} \cos\left(ω_{i}\right)\right) \sin\left(α_{i}\right)-\left(-{K_{c}} W_{i}-{ΔH}_{i}+{U_{t,i}} \sin\left(β_{i}\right)+Q_{i} \sin\left(ω_{i}\right)\right) \cos\left(α_{i}\right)
 \end{dmath}
-The values of $R$ and $T$ are now defined completely in terms of the known force property values of \hyperref[DD:sliceWght]{Definition~DD:sliceWght} to \hyperref[DD:lengthLs]{Definition~DD:lengthLs}.
+The values of $T$ is now defined completely in terms of the known values. This can be further simplified by considering assumptions A\ref{A:Seismic-Force} and A\ref{A:Surface-Load}, which state that the seismic coefficient and the external force, respectively, are0 Removing seismic and external forces yields  equation (7):
+\begin{dmath}
+T_{i}=\left(W_{i}+{U_{t,i}} \cos\left(β_{i}\right)\right) \sin\left(α_{i}\right)-\left({ΔH}_{i}+{U_{t,i}} \sin\left(β_{i}\right)\right) \cos\left(α_{i}\right)
+\end{dmath}
 ~\newline
 \noindent \begin{minipage}{\textwidth}
 \begin{tabular}{p{0.2\textwidth} p{0.73\textwidth}}
@@ -1291,19 +1301,19 @@ Source & \cite{chen2005}
 RefBy & FIXME: This needs to be filled in
 \\ \bottomrule \end{tabular}
 \end{minipage}\\
-Taking the last static equation of \hyperref[T:equilibrium]{Definition~T:equilibrium} with the moment equilibrium of \hyperref[GD:momentEql]{Definition~GD:momentEql} about the midpoint of the base and the assumption of \hyperref[GD:normShrR]{Definition~GD:normShrR} results in equation (13):
+From the moment equilibrium of \hyperref[GD:momentEql]{Definition~GD:momentEql} with the primary assumption for the Morgenstern-Price method of A\ref{A:Interslice-Norm-Shear-Forces-Linear} and associated definition \hyperref[GD:normShrR]{Definition~GD:normShrR} equation equation (9) can be derived:
 \begin{dmath}
 0=-G_{i} \left(z_{i}-\frac{b_{i}}{2} \tan\left(α_{i}\right)\right)+G_{i-1} \left(z_{i-1}-\frac{b_{i}}{2} \tan\left(α_{i}\right)\right)-H_{i} \left(z_{i}-\frac{b_{i}}{2} \tan\left(α_{i}\right)\right)+H_{i-1} \left(z_{i-1}-\frac{b_{i}}{2} \tan\left(α_{i}\right)\right)-λ \frac{b_{i}}{2} \left(G_{i} f_{i}+G_{i-1} f_{i-1}\right)+\frac{{K_{c}} W_{i} h_{i}}{2}-{U_{t,i}} \sin\left(β_{i}\right) h_{i}-Q_{i} \sin\left(ω_{i}\right) h_{i}
 \end{dmath}
-The equation in terms of $λ$ leads to equation (14):
+Rearranging the equation in terms of $λ$ leads to equation (10):
 \begin{dmath}
 λ=\frac{-G_{i} \left(z_{i}-\frac{b_{i}}{2} \tan\left(α_{i}\right)\right)+G_{i-1} \left(z_{i-1}-\frac{b_{i}}{2} \tan\left(α_{i}\right)\right)-H_{i} \left(z_{i}-\frac{b_{i}}{2} \tan\left(α_{i}\right)\right)+H_{i-1} \left(z_{i-1}-\frac{b_{i}}{2} \tan\left(α_{i}\right)\right)+\frac{{K_{c}} W_{i} h_{i}}{2}-{U_{t,i}} \sin\left(β_{i}\right) h_{i}-Q_{i} \sin\left(ω_{i}\right) h_{i}}{\frac{b_{i}}{2} \left(G_{i} f_{i}+G_{i-1} f_{i-1}\right)}
 \end{dmath}
-Taking a summation of each slice, and applying the boundary condition that $G_{0}$ and $G_{n}$ are equal to $0$, a general equation for the constant $λ$ is developed in equation (15), also found in \hyperref[IM:nrmShrFor]{Definition~IM:nrmShrFor}:
+Taking a summation of each slice, and applying the boundary condition that $G_{0}$ and $G_{n}$ are equal to $0$, and removing the seismic and external forces due to A\ref{A:Seismic-Force} and A\ref{A:Surface-Load}, a general equation for the constant $λ$ is developed in equation (11), also found in \hyperref[IM:nrmShrFor]{Definition~IM:nrmShrFor}:
 \begin{dmath}
 λ_{i}=\frac{\displaystyle\sum_{i=1}^{n}{b_{i} \left(SpencerFixme1Please+SpencerFixme2Please\right) \tan\left(α_{i}\right)+h_{i} \left({K_{c}} W_{i}-2 {U_{t,i}} \sin\left(β_{i}\right)-2 Q_{i} \sin\left(ω_{i}\right)\right)}}{\displaystyle\sum_{i=1}^{n}{b_{i} \left(G_{i} f_{i}+G_{i-1} f_{i-1}\right)}}
 \end{dmath}
-equation (15) for $λ$, is a function of the unknown interslice normal force $G$ \hyperref[IM:intsliceFs]{Definition~IM:intsliceFs}.
+equation (11) for $λ$, is a function of the unknown interslice normal force $G$ \hyperref[IM:intsliceFs]{Definition~IM:intsliceFs}.
 ~\newline
 \noindent \begin{minipage}{\textwidth}
 \begin{tabular}{p{0.2\textwidth} p{0.73\textwidth}}
@@ -1347,7 +1357,7 @@ Source & \cite{chen2005}
 RefBy & FIXME: This needs to be filled in
 \\ \bottomrule \end{tabular}
 \end{minipage}\\
-Taking the normal force equilibrium of \hyperref[GD:normForcEq]{Definition~GD:normForcEq} with the effective stress definition from \hyperref[T:effStress]{Definition~T:effStress} that $N_{i}={N'}_{i}-{U_{b,i}}$, and the assumption of \hyperref[GD:normShrR]{Definition~GD:normShrR} the equilibrium equation can be rewritten as equation (16):
+Substituting the normal force equilibrium of \hyperref[GD:normForcEq]{Definition~GD:normForcEq} and the assumption A\ref{A:Interslice-Norm-Shear-Forces-Linear} represented by \hyperref[GD:momentEql]{Definition~GD:momentEql} into the effective normal force definition from \hyperref[GD:normShrR]{Definition~GD:normShrR} yields equation equation (12):
 \begin{dmath}
 {N'}_{i}=\left(W_{i}-λ f_{i-1} G_{i-1}+λ f_{i} G_{i}+{U_{t,i}} \cos\left(β_{i}\right)+Q_{i} \cos\left(ω_{i}\right)\right) \cos\left(α_{i}\right)+\left(-{K_{c}} W_{i}-G_{i}+G_{i-1}-H_{i}+H_{i-1}+{U_{t,i}} \sin\left(β_{i}\right)+Q_{i} \sin\left(ω_{i}\right)\right) \sin\left(α_{i}\right)-{U_{b,i}}
 \end{dmath}
@@ -1490,8 +1500,8 @@ SSA is intended to be an educational tool, so accuracy and performance are not p
 \label{Sec:UCs}
 If changes were to be made with regard to the following, a different algorithm would be needed.
 \begin{itemize}
-\item[Normal-And-Shear-Linear-Only:\phantomsection\label{UC\_normshearlinear}]Changes related to A\ref{A:Interslice-Norm-Shear-Forces-Linear} and A\ref{A:Base-Norm-Shear-Forces-Linear-on-FS} are not possible due to the dependency of the calculations on the linear relationship between interslice normal and shear forces.
-\item[2D-Analysis-Only:\phantomsection\label{UC\_2donly}]A\ref{A:Plane-Strain-Conditions} allows for 2D analysis with these models only because stress along z-direction is zero. These models do not take into account stress in the z-direction, and therefore cannot be without manipulation to attempt 3d analysis.
+\item[Normal-And-Shear-Linear-Only:\phantomsection\label{UC\_normshearlinear}]Changes related to A\ref{A:Soil-Layers-Isotropic} and A\ref{A:Interslice-Norm-Shear-Forces-Linear} are not possible due to the dependency of the calculations on the linear relationship between interslice normal and shear forces.
+\item[2D-Analysis-Only:\phantomsection\label{UC\_2donly}]A\ref{A:Effective-Norm-Stress-Large} allows for 2D analysis with these models only because stress along z-direction is zero. These models do not take into account stress in the z-direction, and therefore cannot be without manipulation to attempt 3d analysis.
 \end{itemize}
 \section{Values of Auxiliary Constants}
 \label{Sec:AuxConstants}

--- a/code/stable/ssp/SRS/SSP_SRS.tex
+++ b/code/stable/ssp/SRS/SSP_SRS.tex
@@ -491,7 +491,7 @@ Description & \begin{symbDescription}
               \item{$H$ is the interslice water force (N)}
               \end{symbDescription}
 \\ \midrule \\
-Notes & For a slice of mass in the slope the force equilibrium to satisfy \hyperref[T:equilibrium]{Definition~T:equilibrium} in the direction perpendicular to the base surface of the slice. Rearranged to solve for the normal force of the surface $N$. Force equilibrium is derived from the free body diagram of Section~\ref{Sec:PhysSyst} Index i refers to the values of the properties for slice/interslices following convention in Section~\ref{Sec:PhysSyst}. Force variable definitions can be found in \hyperref[DD:sliceWght]{Definition~DD:sliceWght} to \hyperref[DD:lengthLs]{Definition~DD:lengthLs}.
+Notes & This equation satisfies \hyperref[T:equilibrium]{Definition~T:equilibrium} in the shear direction. Force equilibrium is derived from the free body diagram of Figure~\ref{Figure:ForceDiagram} in Section~\ref{Sec:PhysSyst}.
 \\ \midrule \\
 Source & \cite{chen2005}
 \\ \midrule \\
@@ -508,7 +508,7 @@ RefBy & FIXME: This needs to be filled in
 Label & Base shear force equilibrium
 \\ \midrule \\
 Equation & \begin{dmath}
-           S_{i}=\left(W_{i}-X_{i-1}+X_{i}+{U_{t,i}} \cos\left(β_{i}\right)+Q_{i} \cos\left(ω_{i}\right)\right) \sin\left(α_{i}\right)+\left(-{K_{c}} W_{i}-G_{i}+G_{i-1}-H_{i}+H_{i-1}+{U_{t,i}} \sin\left(β_{i}\right)+Q_{i} \sin\left(ω_{i}\right)\right) \cos\left(α_{i}\right)
+           S_{i}=\left(W_{i}-X_{i-1}+X_{i}+{U_{t,i}} \cos\left(β_{i}\right)+Q_{i} \cos\left(ω_{i}\right)\right) \sin\left(α_{i}\right)-\left(-{K_{c}} W_{i}-G_{i}+G_{i-1}-H_{i}+H_{i-1}+{U_{t,i}} \sin\left(β_{i}\right)+Q_{i} \sin\left(ω_{i}\right)\right) \cos\left(α_{i}\right)
            \end{dmath}
 \\ \midrule \\
 Description & \begin{symbDescription}
@@ -526,7 +526,7 @@ Description & \begin{symbDescription}
               \item{$H$ is the interslice water force (N)}
               \end{symbDescription}
 \\ \midrule \\
-Notes & For a slice of mass in the slope the force equilibrium to satisfy \hyperref[T:equilibrium]{Definition~T:equilibrium} in the direction parallel to the base surface of the slice. Rearranged to solve for the shear force on the base $S$. Force equilibrium is derived from the free body diagram of Section~\ref{Sec:PhysSyst} Index $i$ refers to the values of the properties for slice/interslices following convention in Section~\ref{Sec:PhysSyst}. Force variable definitions can be found in \hyperref[DD:sliceWght]{Definition~DD:sliceWght} to \hyperref[DD:lengthLs]{Definition~DD:lengthLs}.
+Notes & This equation satisfies \hyperref[T:equilibrium]{Definition~T:equilibrium} in the shear direction. Force equilibrium is derived from the free body diagram of Figure~\ref{Figure:ForceDiagram} in Section~\ref{Sec:PhysSyst}.
 \\ \midrule \\
 Source & \cite{chen2005}
 \\ \midrule \\

--- a/code/stable/ssp/Website/SSP_SRS.html
+++ b/code/stable/ssp/Website/SSP_SRS.html
@@ -1603,7 +1603,7 @@ Notes
 </th>
 <td>
 <p class="paragraph">
-For a slice of mass in the slope the force equilibrium to satisfy <a href=#T:equilibrium>T: equilibrium</a> in the direction perpendicular to the base surface of the slice. Rearranged to solve for the normal force of the surface <em>N</em>. Force equilibrium is derived from the free body diagram of <a href=#Sec:PhysSyst>Physical System Description</a> Index i refers to the values of the properties for slice/interslices following convention in <a href=#Sec:PhysSyst>Physical System Description</a>. Force variable definitions can be found in <a href=#DD:sliceWght>DD: sliceWght</a> to <a href=#DD:lengthLs>DD: lengthLs</a>.
+This equation satisfies <a href=#T:equilibrium>T: equilibrium</a> in the shear direction. Force equilibrium is derived from the free body diagram of <a href=#Figure:ForceDiagram>ForceDiagram</a> in <a href=#Sec:PhysSyst>Physical System Description</a>.
 </p>
 </td>
 </tr>
@@ -1648,7 +1648,7 @@ Equation
 <td>
 <div id="Eqn:GD:bsShrFEq">
 <div class="equation">
-<em>S<sub>i</sub> = (W<sub>i</sub>&minus;X<sub>i&minus;1</sub>&plus;X<sub>i</sub>&plus;U<sub>t,i</sub>&#8239;cos(β<sub>i</sub>)&plus;Q<sub>i</sub>&#8239;cos(ω<sub>i</sub>))&#8239;sin(α<sub>i</sub>)&plus;(&minus;K<sub>c</sub>&#8239;W<sub>i</sub>&minus;G<sub>i</sub>&plus;G<sub>i&minus;1</sub>&minus;H<sub>i</sub>&plus;H<sub>i&minus;1</sub>&plus;U<sub>t,i</sub>&#8239;sin(β<sub>i</sub>)&plus;Q<sub>i</sub>&#8239;sin(ω<sub>i</sub>))&#8239;cos(α<sub>i</sub>)</em>
+<em>S<sub>i</sub> = (W<sub>i</sub>&minus;X<sub>i&minus;1</sub>&plus;X<sub>i</sub>&plus;U<sub>t,i</sub>&#8239;cos(β<sub>i</sub>)&plus;Q<sub>i</sub>&#8239;cos(ω<sub>i</sub>))&#8239;sin(α<sub>i</sub>)&minus;(&minus;K<sub>c</sub>&#8239;W<sub>i</sub>&minus;G<sub>i</sub>&plus;G<sub>i&minus;1</sub>&minus;H<sub>i</sub>&plus;H<sub>i&minus;1</sub>&plus;U<sub>t,i</sub>&#8239;sin(β<sub>i</sub>)&plus;Q<sub>i</sub>&#8239;sin(ω<sub>i</sub>))&#8239;cos(α<sub>i</sub>)</em>
 </div>
 </div>
 </td>
@@ -1704,7 +1704,7 @@ Notes
 </th>
 <td>
 <p class="paragraph">
-For a slice of mass in the slope the force equilibrium to satisfy <a href=#T:equilibrium>T: equilibrium</a> in the direction parallel to the base surface of the slice. Rearranged to solve for the shear force on the base <em>S</em>. Force equilibrium is derived from the free body diagram of <a href=#Sec:PhysSyst>Physical System Description</a> Index <em>i</em> refers to the values of the properties for slice/interslices following convention in <a href=#Sec:PhysSyst>Physical System Description</a>. Force variable definitions can be found in <a href=#DD:sliceWght>DD: sliceWght</a> to <a href=#DD:lengthLs>DD: lengthLs</a>.
+This equation satisfies <a href=#T:equilibrium>T: equilibrium</a> in the shear direction. Force equilibrium is derived from the free body diagram of <a href=#Figure:ForceDiagram>ForceDiagram</a> in <a href=#Sec:PhysSyst>Physical System Description</a>.
 </p>
 </td>
 </tr>

--- a/code/stable/ssp/Website/SSP_SRS.html
+++ b/code/stable/ssp/Website/SSP_SRS.html
@@ -1137,15 +1137,22 @@ Slip-Surface-Concave: The slip surface is concave with respect to the slope surf
 </ul>
 <ul class="hide-list-style">
 <li>
-<div id="A:Geo-Slope-Mat-Props-of-Soil-Inputs">
-Geo-Slope-Mat-Props-of-Soil-Inputs: The geometry of the slope, and the material properties of the soil layers are given as inputs.
+<div id="A:Factor-of-Safety">
+Factor-of-Safety: The factor of safety is assumed to be constant across a whole slip surface.
 </div>
 </li>
 </ul>
 <ul class="hide-list-style">
 <li>
 <div id="A:Soil-Layer-Homogeneous">
-Soil-Layer-Homogeneous: The different layers of the soil are homogeneous, with consistent soil properties throughout, and independent of dry or saturated conditions, with the exception of unit weight.
+Soil-Layer-Homogeneous: The different layers of the soil are homogeneous, with consistent soil properties throughout.
+</div>
+</li>
+</ul>
+<ul class="hide-list-style">
+<li>
+<div id="A:Soil-Properties">
+Soil-Properties: The soil properties are independent of dry or saturated conditions, with the exception of unit weight.
 </div>
 </li>
 </ul>
@@ -1160,20 +1167,6 @@ Soil-Layers-Isotropic: Soil layers are treated as if they have isotropic propert
 <li>
 <div id="A:Interslice-Norm-Shear-Forces-Linear">
 Interslice-Norm-Shear-Forces-Linear: Interslice normal and shear forces have a linear relationship, proportional to a constant (<em>λ</em>) and an interslice force function (<em>f</em>) depending on x position.
-</div>
-</li>
-</ul>
-<ul class="hide-list-style">
-<li>
-<div id="A:Base-Norm-Shear-Forces-Linear-on-FS">
-Base-Norm-Shear-Forces-Linear-on-FS: Slice to base normal and shear forces have a linear relationship, dependent on the factor of safety <em>FS</em>, and the Coulomb sliding law.
-</div>
-</li>
-</ul>
-<ul class="hide-list-style">
-<li>
-<div id="A:Stress-Strain-Curve-interslice-Linear">
-Stress-Strain-Curve-interslice-Linear: The stress - strain curve for interslice relationships is linear with a constant slope.
 </div>
 </li>
 </ul>
@@ -1195,6 +1188,20 @@ Effective-Norm-Stress-Large: The effective normal stress is large enough that th
 <li>
 <div id="A:Surface-Base-Slice-between-Interslice-Straight-Lines">
 Surface-Base-Slice-between-Interslice-Straight-Lines: The surface and base of a slice between interslice nodes are approximated as straight lines.
+</div>
+</li>
+</ul>
+<ul class="hide-list-style">
+<li>
+<div id="A:Seismic-Force">
+Seismic-Force: There is no seismic force acting on the slope.
+</div>
+</li>
+</ul>
+<ul class="hide-list-style">
+<li>
+<div id="A:Surface-Load">
+Surface-Load: There is no imposed surface, load and therefore no external force, acting on the slope.
 </div>
 </li>
 </ul>
@@ -1337,7 +1344,7 @@ Notes
 </th>
 <td>
 <p class="paragraph">
-For a body in static equilibrium, the net forces and net moments acting on the body will cancel out. Assuming a 2D problem (<a href=#A:Plane-Strain-Conditions>A: Plane-Strain-Conditions</a>) the x-component of the net force <em>F<sub>x</sub></em> and y-component of the net force <em>F<sub>y</sub></em> will be equal to <em>0</em>. All forces and their distance from the chosen point of rotation will create a net moment equal to <em>0</em>.
+For a body in static equilibrium, the net forces and net moments acting on the body will cancel out. Assuming a 2D problem (<a href=#A:Effective-Norm-Stress-Large>A: Effective-Norm-Stress-Large</a>) the x-component of the net force <em>F<sub>x</sub></em> and y-component of the net force <em>F<sub>y</sub></em> will be equal to <em>0</em>. All forces and their distance from the chosen point of rotation will create a net moment equal to <em>0</em>.
 </p>
 </td>
 </tr>
@@ -1414,7 +1421,7 @@ Notes
 </th>
 <td>
 <p class="paragraph">
-For a soil under stress it will exert a shear resistive strength based on the Coulomb sliding law. The resistive shear is the maximum amount of shear a surface can experience while remaining rigid, analogous to a maximum normal force. In this model the resistive shear stress <em>τ</em> is proportional to the product of the normal stress on the plane <em>σ</em> with it's static friction in the angular form <em>tan(φ&prime;) = U<sub>t</sub></em>. The <em>τ</em> versus <em>σ</em> relationship is not truly linear, but assuming the effective normal force is strong enough, it can be approximated with a linear fit (<a href=#A:Effective-Norm-Stress-Large>A: Effective-Norm-Stress-Large</a>) where the cohesion <em>c&prime;</em> represents the <em>τ</em> intercept of the fitted line.
+For a soil under stress it will exert a shear resistive strength based on the Coulomb sliding law. The resistive shear is the maximum amount of shear a surface can experience while remaining rigid, analogous to a maximum normal force. In this model the resistive shear stress <em>τ</em> is proportional to the product of the normal stress on the plane <em>σ</em> with it's static friction in the angular form <em>tan(φ&prime;) = U<sub>t</sub></em>. The <em>τ</em> versus <em>σ</em> relationship is not truly linear, but assuming the effective normal force is strong enough, it can be approximated with a linear fit (<a href=#A:Surface-Base-Slice-between-Interslice-Straight-Lines>A: Surface-Base-Slice-between-Interslice-Straight-Lines</a>) where the cohesion <em>c&prime;</em> represents the <em>τ</em> intercept of the fitted line.
 </p>
 </td>
 </tr>
@@ -3460,6 +3467,14 @@ Using <em>N*</em>, a resistive shear force without the influence of interslice f
 <em>R<sub>i</sub> = N*<sub>i</sub>&#8239;tan(φ&prime;<sub>i</sub>)&plus;c&prime;<sub>i</sub>&#8239;b<sub>i</sub>&#8239;sec(α<sub>i</sub>) = ((W<sub>i</sub>&plus;U<sub>t,i</sub>&#8239;cos(β<sub>i</sub>)&plus;Q<sub>i</sub>&#8239;cos(ω<sub>i</sub>))&#8239;cos(α<sub>i</sub>)&plus;(&minus;K<sub>c</sub>&#8239;W<sub>i</sub>&minus;ΔH<sub>i</sub>&plus;U<sub>t,i</sub>&#8239;sin(β<sub>i</sub>)&plus;Q<sub>i</sub>&#8239;sin(ω<sub>i</sub>))&#8239;sin(α<sub>i</sub>)&minus;U<sub>b,i</sub>)&#8239;tan(φ&prime;<sub>i</sub>)&plus;c&prime;<sub>i</sub>&#8239;b<sub>i</sub>&#8239;sec(α<sub>i</sub>)</em>
 </div>
 </div>
+<p class="paragraph">
+This can be further simplified by considering assumptions <a href=#A:Seismic-Force>A: Seismic-Force</a> and <a href=#A:Surface-Load>A: Surface-Load</a>, which state that the seismic coefficient and the external force, respectively, are0 Removing seismic and external forces yields  equation (4):
+</p>
+<div id="Eqn:empty">
+<div class="equation">
+<em>R<sub>i</sub> = ((W<sub>i</sub>&plus;U<sub>t,i</sub>&#8239;cos(β<sub>i</sub>))&#8239;cos(α<sub>i</sub>)&plus;(&minus;ΔH<sub>i</sub>&plus;U<sub>t,i</sub>&#8239;sin(β<sub>i</sub>)&plus;Q<sub>i</sub>&#8239;sin(ω<sub>i</sub>))&#8239;sin(α<sub>i</sub>)&minus;U<sub>b,i</sub>)&#8239;tan(φ&prime;<sub>i</sub>)&plus;c&prime;<sub>i</sub>&#8239;b<sub>i</sub>&#8239;sec(α<sub>i</sub>)</em>
+</div>
+</div>
 <div id="DD:mobShearWO">
 <table class="ddefn">
 <tr>
@@ -3566,7 +3581,7 @@ FIXME: This needs to be filled in
 </table>
 </div>
 <p class="paragraph">
-The mobilized shear force acting on a slice is defined as <em>S</em> from the force equilibrium in <a href=#GD:bsShrFEq>GD: bsShrFEq</a>, also shown in equation (4):
+The mobilized shear force acting on a slice is defined as <em>S</em> from the force equilibrium in <a href=#GD:bsShrFEq>GD: bsShrFEq</a>, also shown in equation (5):
 </p>
 <div id="Eqn:empty">
 <div class="equation">
@@ -3574,7 +3589,7 @@ The mobilized shear force acting on a slice is defined as <em>S</em> from the fo
 </div>
 </div>
 <p class="paragraph">
-The equation is unsolvable, containing the unknown interslice normal force <em>G</em> and interslice shear force <em>X</em>. Consider a force equilibrium without the influence of interslice forces, to obtain the mobilized shear force <em>T</em>, as done in equation (5):
+The equation is unsolvable, containing the unknown interslice normal force <em>G</em> and interslice shear force <em>X</em>. Consider a force equilibrium without the influence of interslice forces, to obtain the mobilized shear force <em>T</em>, as done in equation (6):
 </p>
 <div id="Eqn:empty">
 <div class="equation">
@@ -3582,8 +3597,13 @@ The equation is unsolvable, containing the unknown interslice normal force <em>G
 </div>
 </div>
 <p class="paragraph">
-The values of <em>R</em> and <em>T</em> are now defined completely in terms of the known force property values of <a href=#DD:sliceWght>DD: sliceWght</a> to <a href=#DD:lengthLs>DD: lengthLs</a>.
+The values of <em>T</em> is now defined completely in terms of the known values. This can be further simplified by considering assumptions <a href=#A:Seismic-Force>A: Seismic-Force</a> and <a href=#A:Surface-Load>A: Surface-Load</a>, which state that the seismic coefficient and the external force, respectively, are0 Removing seismic and external forces yields  equation (7):
 </p>
+<div id="Eqn:empty">
+<div class="equation">
+<em>T<sub>i</sub> = (W<sub>i</sub>&plus;U<sub>t,i</sub>&#8239;cos(β<sub>i</sub>))&#8239;sin(α<sub>i</sub>)&minus;(ΔH<sub>i</sub>&plus;U<sub>t,i</sub>&#8239;sin(β<sub>i</sub>))&#8239;cos(α<sub>i</sub>)</em>
+</div>
+</div>
 <div id="DD:fixme1">
 <table class="ddefn">
 <tr>
@@ -4150,7 +4170,7 @@ FIXME: This needs to be filled in
 </table>
 </div>
 <p class="paragraph">
-Taking the last static equation of <a href=#T:equilibrium>T: equilibrium</a> with the moment equilibrium of <a href=#GD:momentEql>GD: momentEql</a> about the midpoint of the base and the assumption of <a href=#GD:normShrR>GD: normShrR</a> results in equation (13):
+From the moment equilibrium of <a href=#GD:momentEql>GD: momentEql</a> with the primary assumption for the Morgenstern-Price method of <a href=#A:Interslice-Norm-Shear-Forces-Linear>A: Interslice-Norm-Shear-Forces-Linear</a> and associated definition <a href=#GD:normShrR>GD: normShrR</a> equation equation (9) can be derived:
 </p>
 <div id="Eqn:empty">
 <div class="equation">
@@ -4200,7 +4220,7 @@ K<sub>c</sub>&#8239;W<sub>i</sub>&#8239;h<sub>i</sub>
 </div>
 </div>
 <p class="paragraph">
-The equation in terms of <em>λ</em> leads to equation (14):
+Rearranging the equation in terms of <em>λ</em> leads to equation (10):
 </p>
 <div id="Eqn:empty">
 <div class="equation">
@@ -4257,7 +4277,7 @@ b<sub>i</sub>
 </div>
 </div>
 <p class="paragraph">
-Taking a summation of each slice, and applying the boundary condition that <em>G<sub>0</sub></em> and <em>G<sub>n</sub></em> are equal to <em>0</em>, a general equation for the constant <em>λ</em> is developed in equation (15), also found in <a href=#IM:nrmShrFor>IM: nrmShrFor</a>:
+Taking a summation of each slice, and applying the boundary condition that <em>G<sub>0</sub></em> and <em>G<sub>n</sub></em> are equal to <em>0</em>, and removing the seismic and external forces due to <a href=#A:Seismic-Force>A: Seismic-Force</a> and <a href=#A:Surface-Load>A: Surface-Load</a>, a general equation for the constant <em>λ</em> is developed in equation (11), also found in <a href=#IM:nrmShrFor>IM: nrmShrFor</a>:
 </p>
 <div id="Eqn:empty">
 <div class="equation">
@@ -4272,7 +4292,7 @@ Taking a summation of each slice, and applying the boundary condition that <em>G
 </div>
 </div>
 <p class="paragraph">
-equation (15) for <em>λ</em>, is a function of the unknown interslice normal force <em>G</em> <a href=#IM:intsliceFs>IM: intsliceFs</a>.
+equation (11) for <em>λ</em>, is a function of the unknown interslice normal force <em>G</em> <a href=#IM:intsliceFs>IM: intsliceFs</a>.
 </p>
 <div id="IM:intsliceFs">
 <table class="idefn">
@@ -4431,7 +4451,7 @@ FIXME: This needs to be filled in
 </table>
 </div>
 <p class="paragraph">
-Taking the normal force equilibrium of <a href=#GD:normForcEq>GD: normForcEq</a> with the effective stress definition from <a href=#T:effStress>T: effStress</a> that <em>N<sub>i</sub> = N&prime;<sub>i</sub>&minus;U<sub>b,i</sub></em>, and the assumption of <a href=#GD:normShrR>GD: normShrR</a> the equilibrium equation can be rewritten as equation (16):
+Substituting the normal force equilibrium of <a href=#GD:normForcEq>GD: normForcEq</a> and the assumption <a href=#A:Interslice-Norm-Shear-Forces-Linear>A: Interslice-Norm-Shear-Forces-Linear</a> represented by <a href=#GD:momentEql>GD: momentEql</a> into the effective normal force definition from <a href=#GD:normShrR>GD: normShrR</a> yields equation equation (12):
 </p>
 <div id="Eqn:empty">
 <div class="equation">
@@ -4928,12 +4948,12 @@ If changes were to be made with regard to the following, a different algorithm w
 <div class="list">
 <p>
 <div id="UC_normshearlinear">
-Normal-And-Shear-Linear-Only: Changes related to <a href=#A:Interslice-Norm-Shear-Forces-Linear>A: Interslice-Norm-Shear-Forces-Linear</a> and <a href=#A:Base-Norm-Shear-Forces-Linear-on-FS>A: Base-Norm-Shear-Forces-Linear-on-FS</a> are not possible due to the dependency of the calculations on the linear relationship between interslice normal and shear forces.
+Normal-And-Shear-Linear-Only: Changes related to <a href=#A:Soil-Layers-Isotropic>A: Soil-Layers-Isotropic</a> and <a href=#A:Interslice-Norm-Shear-Forces-Linear>A: Interslice-Norm-Shear-Forces-Linear</a> are not possible due to the dependency of the calculations on the linear relationship between interslice normal and shear forces.
 </div>
 </p>
 <p>
 <div id="UC_2donly">
-2D-Analysis-Only: <a href=#A:Plane-Strain-Conditions>A: Plane-Strain-Conditions</a> allows for 2D analysis with these models only because stress along z-direction is zero. These models do not take into account stress in the z-direction, and therefore cannot be without manipulation to attempt 3d analysis.
+2D-Analysis-Only: <a href=#A:Effective-Norm-Stress-Large>A: Effective-Norm-Stress-Large</a> allows for 2D analysis with these models only because stress along z-direction is zero. These models do not take into account stress in the z-direction, and therefore cannot be without manipulation to attempt 3d analysis.
 </div>
 </p>
 </div>


### PR DESCRIPTION
When tried to move references in assumptions, found that there are too many inconsistencies, especially many references were not correct in SSP.

After this PR, even though there are still some inconsistencies, but all the references related to Assumptions are correct and complete. Those references should be matching manual version. 

Also, fixed issue #449.