### PR TITLE
Ordering for ChunkDB

### DIFF
--- a/code/drasil-docLang/Drasil/DocumentLanguage.hs
+++ b/code/drasil-docLang/Drasil/DocumentLanguage.hs
@@ -266,9 +266,9 @@ mkRefSec si (RefProg c l) = section'' (titleize refmat) [c]
   where
     mkSubRef :: SystemInformation -> RefTab -> Section
     mkSubRef SI {_usedinfodb = db}  TUnits =
-        table_of_units (sortBy comp_unitdefn $ Map.elems $ db ^. unitTable) (tuIntro defaultTUI)
+        table_of_units (sortBy comp_unitdefn $ map fst $ Map.elems $ db ^. unitTable) (tuIntro defaultTUI)
     mkSubRef SI {_usedinfodb = db} (TUnits' con) =
-        table_of_units (sortBy comp_unitdefn $ Map.elems $ db ^. unitTable) (tuIntro con)
+        table_of_units (sortBy comp_unitdefn $ map fst $ Map.elems $ db ^. unitTable) (tuIntro con)
     mkSubRef SI {_quants = v} (TSymb con) =
       SRS.tOfSymb 
       [tsIntro con,
@@ -278,7 +278,7 @@ mkRefSec si (RefProg c l) = section'' (titleize refmat) [c]
                 at_start] []
     mkSubRef SI {_concepts = cccs} (TSymb' f con) = mkTSymb cccs f con
     mkSubRef SI {_usedinfodb = db} TAandA =
-      table_of_abb_and_acronyms $ nub $ Map.elems (db ^. termTable)
+      table_of_abb_and_acronyms $ nub $ map fst $ Map.elems (db ^. termTable)
 
 -- | Helper for creating the table of symbols
 mkTSymb :: (Quantity e, Concept e, Eq e, MayHaveUnit e) =>

--- a/code/drasil-docLang/Drasil/TraceTable.hs
+++ b/code/drasil-docLang/Drasil/TraceTable.hs
@@ -16,8 +16,8 @@ import Language.Drasil.Development (lnames')
 import Drasil.DocumentLanguage
 
 
-traceMap :: (HasUID l) => (l -> [Sentence]) -> [l] -> TraceMap
-traceMap f = Map.fromList . map (\x -> ((x ^. uid), lnames' (f x)))
+traceMap' :: HasUID l => (l -> [Sentence]) -> [l] -> TraceMap
+traceMap' f = traceMap $ lnames' . f
 
 getTraceMapFromDocSec :: [DocSection] -> SSDSec
 getTraceMapFromDocSec ((SSDSec ssd):_)  = ssd
@@ -67,11 +67,11 @@ getSCSSub a = getTraceMapFromSolCh $ getTraceMapFromSSDSub $ getTraceMapFromSSDS
 
 generateTraceMap :: [DocSection] -> TraceMap
 generateTraceMap a = Map.unionsWith (++) [
-  (traceMap extractSFromNotes tt), (traceMap extractSFromNotes gd),
-  (traceMap extractSFromNotes dd), (traceMap extractSFromNotes im),
+  (traceMap' extractSFromNotes tt), (traceMap' extractSFromNotes gd),
+  (traceMap' extractSFromNotes dd), (traceMap' extractSFromNotes im),
   -- Theory models do not have derivations.
-  (traceMap extractSFromDeriv gd),
-  (traceMap extractSFromDeriv dd), (traceMap extractSFromDeriv im)]
+  (traceMap' extractSFromDeriv gd),
+  (traceMap' extractSFromDeriv dd), (traceMap' extractSFromDeriv im)]
   where
     tt = getTraceMapFromTM $ getSCSSub a
     gd = getTraceMapFromGD $ getSCSSub a
@@ -80,4 +80,4 @@ generateTraceMap a = Map.unionsWith (++) [
 
 -- This is a hack as ConceptInstance cannot be collected yet.
 generateTraceMap' :: [ConceptInstance] -> TraceMap
-generateTraceMap' = Map.fromList . map (\x -> ((x ^. uid), lnames' [x ^. defn]))
+generateTraceMap' = traceMap' (\x -> [x ^. defn])

--- a/code/drasil-docLang/Drasil/TraceTable.hs
+++ b/code/drasil-docLang/Drasil/TraceTable.hs
@@ -66,7 +66,7 @@ getSCSSub a = getTraceMapFromSolCh $ getTraceMapFromSSDSub $ getTraceMapFromSSDS
  $ getTraceMapFromDocSec a
 
 generateTraceMap :: [DocSection] -> TraceMap
-generateTraceMap a = Map.unionsWith (++) [
+generateTraceMap a = Map.unionsWith (\(w,x) (y,z) -> (w ++ y, ordering x z)) [
   (traceMap' extractSFromNotes tt), (traceMap' extractSFromNotes gd),
   (traceMap' extractSFromNotes dd), (traceMap' extractSFromNotes im),
   -- Theory models do not have derivations.
@@ -77,6 +77,7 @@ generateTraceMap a = Map.unionsWith (++) [
     gd = getTraceMapFromGD $ getSCSSub a
     im = getTraceMapFromIM $ getSCSSub a
     dd = getTraceMapFromDD $ getSCSSub a
+    ordering a b = if a == b then a else error "Expected ordering between smaller TraceMaps to be the same"
 
 -- This is a hack as ConceptInstance cannot be collected yet.
 generateTraceMap' :: [ConceptInstance] -> TraceMap

--- a/code/drasil-docLang/drasil-docLang.cabal
+++ b/code/drasil-docLang/drasil-docLang.cabal
@@ -1,5 +1,5 @@
 Name:		drasil-docLang
-Version:	0.1.18
+Version:	0.1.19
 Cabal-Version:  >= 1.18
 Author:		Dan Szymczak, Steven Palmer, Jacques Carette, Spencer Smith
 build-type:     Simple
@@ -43,7 +43,7 @@ library
     MissingH >= 1.4.0.1,
     parsec >= 3.1.9,
     data-fix (>= 0.0.4 && <= 1.0),
-    drasil-lang >= 0.1.53,
+    drasil-lang >= 0.1.54,
     drasil-data >= 0.1.9
   default-language: Haskell2010
   ghc-options:      -Wall -Wredundant-constraints

--- a/code/drasil-example/Drasil/GamePhysics/Body.hs
+++ b/code/drasil-example/Drasil/GamePhysics/Body.hs
@@ -132,27 +132,27 @@ game_label = Map.union (generateTraceMap mkSRS) (generateTraceMap' $ likelyChang
 game_refby :: RefbyMap
 game_refby = generateRefbyMap game_label
 
-game_datadefn :: DatadefnMap
-game_datadefn = Map.fromList . map (\x -> (x ^. uid, x)) $ getTraceMapFromDD $ getSCSSub mkSRS
+game_datadefn :: [DataDefinition]
+game_datadefn = getTraceMapFromDD $ getSCSSub mkSRS
 
-game_insmodel :: InsModelMap
-game_insmodel = Map.fromList . map (\x -> (x ^. uid, x)) $ getTraceMapFromIM $ getSCSSub mkSRS
+game_insmodel :: [InstanceModel]
+game_insmodel = getTraceMapFromIM $ getSCSSub mkSRS
 
-game_gendef :: GendefMap
-game_gendef = Map.fromList . map (\x -> (x ^. uid, x)) $ getTraceMapFromGD $ getSCSSub mkSRS
+game_gendef :: [GenDefn]
+game_gendef = getTraceMapFromGD $ getSCSSub mkSRS
 
-game_theory :: TheoryModelMap
-game_theory = Map.fromList . map (\x -> (x ^. uid, x)) $ getTraceMapFromTM $ getSCSSub mkSRS
+game_theory :: [TheoryModel]
+game_theory = getTraceMapFromTM $ getSCSSub mkSRS
 
-game_assump :: AssumptionMap
-game_assump = Map.fromList $ map (\x -> (x ^. uid, x)) newAssumptions
+game_assump :: [AssumpChunk]
+game_assump = newAssumptions
 
-game_concins :: ConceptInstanceMap
-game_concins = Map.fromList $ map (\x -> (x ^. uid, x)) (likelyChangesList' ++ unlikelyChangesList' ++
-  functional_requirements_list')
+game_concins :: [ConceptInstance]
+game_concins = likelyChangesList' ++ unlikelyChangesList' ++
+  functional_requirements_list'
 
-game_section :: SectionMap
-game_section = Map.fromList $ map (\x -> (x ^. uid, x)) game_sec
+game_section :: [Section]
+game_section = game_sec
 
 game_sec :: [Section]
 game_sec = extractSection chipmunkSRS'
@@ -201,12 +201,12 @@ everything = cdb cpSymbolsAll (map nw cpSymbolsAll ++ map nw cpAcronyms ++ map n
   ++ map nw CM.mathcon ++ map nw CM.mathcon')
   (map cw gamephySymbols ++ srsDomains) chipUnits game_label game_refby
   game_datadefn game_insmodel game_gendef game_theory game_assump game_concins
-  game_section (head ([] :: [LabelledContentMap]))
+  game_section []
 
 usedDB :: ChunkDB
 usedDB = cdb (map qw symbTT) (map nw cpSymbolsAll ++ map nw cpAcronyms ++ map nw check_si) ([] :: [ConceptChunk]) check_si
  game_label game_refby game_datadefn game_insmodel game_gendef game_theory game_assump game_concins
- game_section (head ([] :: [LabelledContentMap]))
+ game_section []
 
 printSetting :: PrintingInformation
 printSetting = PI everything defaultConfiguration

--- a/code/drasil-example/Drasil/GlassBR/Body.hs
+++ b/code/drasil-example/Drasil/GlassBR/Body.hs
@@ -94,29 +94,29 @@ glassBR_label = Map.union (generateTraceMap mkSRS) (generateTraceMap' $ likelyCh
 glassBR_refby :: RefbyMap
 glassBR_refby = generateRefbyMap glassBR_label 
 
-glassBR_datadefn :: DatadefnMap
-glassBR_datadefn = Map.fromList . map (\x -> (x ^. uid, x)) $ getTraceMapFromDD $ getSCSSub mkSRS
+glassBR_datadefn :: [DataDefinition]
+glassBR_datadefn = getTraceMapFromDD $ getSCSSub mkSRS
 
-glassBR_insmodel :: InsModelMap
-glassBR_insmodel = Map.fromList . map (\x -> (x ^. uid, x)) $ getTraceMapFromIM $ getSCSSub mkSRS
+glassBR_insmodel :: [InstanceModel]
+glassBR_insmodel = getTraceMapFromIM $ getSCSSub mkSRS
 
-glassBR_gendef :: GendefMap
-glassBR_gendef = Map.fromList . map (\x -> (x ^. uid, x)) $ getTraceMapFromGD $ getSCSSub mkSRS
+glassBR_gendef :: [GenDefn]
+glassBR_gendef = getTraceMapFromGD $ getSCSSub mkSRS
 
-glassBR_theory :: TheoryModelMap
-glassBR_theory = Map.fromList . map (\x -> (x ^. uid, x)) $ getTraceMapFromTM $ getSCSSub mkSRS
+glassBR_theory :: [TheoryModel]
+glassBR_theory = getTraceMapFromTM $ getSCSSub mkSRS
 
-glassBR_assump :: AssumptionMap
-glassBR_assump = Map.fromList $ map (\x -> (x ^. uid, x)) assumptions
+glassBR_assump :: [AssumpChunk]
+glassBR_assump = assumptions
 
-glassBR_concins :: ConceptInstanceMap
-glassBR_concins = Map.fromList $ map (\x -> (x ^. uid, x)) (likelyChgs ++ unlikelyChgs ++ funcReqs)
+glassBR_concins :: [ConceptInstance]
+glassBR_concins = likelyChgs ++ unlikelyChgs ++ funcReqs
 
-glassBR_section :: SectionMap
-glassBR_section = Map.fromList $ map (\x -> (x ^. uid, x)) glassBR_sec
+glassBR_section :: [Section]
+glassBR_section = glassBR_sec
 
-glassBR_labelledcon :: LabelledContentMap
-glassBR_labelledcon = Map.fromList $ map (\x -> (x ^. uid, x)) [inputGlassPropsTable]
+glassBR_labelledcon :: [LabelledContent]
+glassBR_labelledcon = [inputGlassPropsTable]
 
 glassBR_sec :: [Section]
 glassBR_sec = extractSection glassBR_srs

--- a/code/drasil-example/Drasil/GlassBR/TMods.hs
+++ b/code/drasil-example/Drasil/GlassBR/TMods.hs
@@ -24,8 +24,8 @@ gbrTMods = [pbIsSafe, lrIsSafe]
 -- needs to be updated properly.
 -- this is the new function but it still uses the lrIsSafe_RC,
 -- so basically we have to combine the old function with the new function
-glass_concept :: ConceptInstanceMap
-glass_concept = Map.fromList $ map (\x -> (x ^. uid, x)) ([] :: [ConceptInstance])
+glass_concept :: [ConceptInstance]
+glass_concept = []
 
 
 lrIsSafe :: TheoryModel
@@ -33,10 +33,9 @@ lrIsSafe = tm (cw lrIsSafe_RC)
    [qw is_safeLR, qw lRe, qw demand] ([] :: [ConceptChunk])
    [relToQD locSymbMap lrIsSafe_RC] [(sy is_safeLR) $= (sy lRe) $> (sy demand)] [] [makeCite astm2009] 
    "isSafeLR" [lrIsSafeDesc]
-  where locSymbMap = cdb ([] :: [QuantityDict]) ([] :: [IdeaDict]) glassBRsymb ([] :: [UnitDefn]) (head ([] :: [TraceMap])) (head ([] :: [RefbyMap]))
-                       (head ([] :: [DatadefnMap])) (head ([] :: [InsModelMap])) (head ([] :: [GendefMap]))
-                        (head ([] :: [TheoryModelMap])) (head ([] :: [AssumptionMap])) glass_concept (head ([] :: [SectionMap]))
-                        (head ([] :: [LabelledContentMap]))
+   where locSymbMap = cdb ([] :: [QuantityDict]) ([] :: [IdeaDict]) glassBRsymb
+                        ([] :: [UnitDefn]) Map.empty Map.empty [] [] [] [] []
+                        glass_concept [] []
 
 lrIsSafe_RC :: RelationConcept
 lrIsSafe_RC = makeRC "safetyReqLR" (nounPhraseSP "Safety Req-LR")

--- a/code/drasil-example/Drasil/HGHC/HGHC.hs
+++ b/code/drasil-example/Drasil/HGHC/HGHC.hs
@@ -1,5 +1,6 @@
 module Drasil.HGHC.HGHC (srsBody, thisCode, allSymbols, printSetting) where
 
+import qualified Data.Map as Map
 import Language.Drasil hiding (Manual) -- Citation name conflict. FIXME: Move to different namespace
 import Language.Drasil.Code (CodeSpec, codeSpec)
 import Language.Drasil.Development (UnitDefn)
@@ -49,14 +50,12 @@ allSymbols :: ChunkDB
 allSymbols = cdb symbols (map nw symbols ++ map nw doccon ++ map nw fundamentals ++ map nw derived
   ++ [nw fp, nw nuclearPhys, nw hghc, nw degree] ++ map nw doccon')
  ([] :: [ConceptChunk])-- FIXME: Fill in concepts
-  si_units (head ([] :: [TraceMap])) (head ([] :: [RefbyMap]))
-  (head ([] :: [DatadefnMap])) (head ([] :: [InsModelMap])) (head ([] :: [GendefMap])) (head ([] :: [TheoryModelMap]))
-  (head ([] :: [AssumptionMap])) (head ([] :: [ConceptInstanceMap])) (head ([] :: [SectionMap])) (head ([] :: [LabelledContentMap]))
+  si_units Map.empty Map.empty [] [] [] [] [] [] [] []
 
 usedDB :: ChunkDB
-usedDB = cdb ([] :: [QuantityDict]) (map nw symbols ++ map nw check_si) ([] :: [ConceptChunk]) check_si (head ([] :: [TraceMap])) (head ([] :: [RefbyMap]))
-           (head ([] :: [DatadefnMap])) (head ([] :: [InsModelMap])) (head ([] :: [GendefMap])) (head ([] :: [TheoryModelMap]))
-           (head ([] :: [AssumptionMap])) (head ([] :: [ConceptInstanceMap])) (head ([] :: [SectionMap])) (head ([] :: [LabelledContentMap]))
+usedDB = cdb ([] :: [QuantityDict]) (map nw symbols ++ map nw check_si)
+           ([] :: [ConceptChunk]) check_si Map.empty Map.empty [] [] [] [] []
+           [] [] []
 
 printSetting :: PrintingInformation
 printSetting = PI allSymbols defaultConfiguration

--- a/code/drasil-example/Drasil/NoPCM/Body.hs
+++ b/code/drasil-example/Drasil/NoPCM/Body.hs
@@ -178,30 +178,30 @@ nopcm_label = Map.union (generateTraceMap mkSRS)
 nopcm_refby :: RefbyMap
 nopcm_refby = generateRefbyMap nopcm_label
 
-nopcm_datadefn :: DatadefnMap
-nopcm_datadefn = Map.union swhs_datadefn $ Map.fromList . map (\x -> (x ^. uid, x)) $ getTraceMapFromDD $ getSCSSub mkSRS
+nopcm_datadefn :: [DataDefinition]
+nopcm_datadefn = swhs_datadefn ++ (getTraceMapFromDD $ getSCSSub mkSRS)
 
-nopcm_insmodel :: InsModelMap
-nopcm_insmodel = Map.union swhs_insmodel $ Map.fromList . map (\x -> (x ^. uid, x)) $ getTraceMapFromIM $ getSCSSub mkSRS
+nopcm_insmodel :: [InstanceModel]
+nopcm_insmodel = swhs_insmodel ++ (getTraceMapFromIM $ getSCSSub mkSRS)
 
-nopcm_gendef :: GendefMap
-nopcm_gendef = Map.union swhs_gendef $ Map.fromList . map (\x -> (x ^. uid, x)) $ getTraceMapFromGD $ getSCSSub mkSRS
+nopcm_gendef :: [GenDefn]
+nopcm_gendef = swhs_gendef ++ (getTraceMapFromGD $ getSCSSub mkSRS)
 
-nopcm_theory :: TheoryModelMap
-nopcm_theory = Map.union swhs_theory $ Map.fromList . map (\x -> (x ^. uid, x)) $ getTraceMapFromTM $ getSCSSub mkSRS
+nopcm_theory :: [TheoryModel]
+nopcm_theory = swhs_theory ++ (getTraceMapFromTM $ getSCSSub mkSRS)
 
-nopcm_assump :: AssumptionMap
-nopcm_assump = Map.fromList $ map (\x -> (x ^. uid, x)) (assumps_Nopcm_list_new ++ newAssumptions)
+nopcm_assump :: [AssumpChunk]
+nopcm_assump = assumps_Nopcm_list_new ++ newAssumptions
 
-nopcm_concins :: ConceptInstanceMap
-nopcm_concins = Map.fromList $ map (\x -> (x ^. uid, x))
- (reqs ++ [likeChgTCVOD, likeChgTCVOL] ++ likelyChgs ++ [likeChgTLH] ++ unlikelyChgs)
+nopcm_concins :: [ConceptInstance]
+nopcm_concins =
+ reqs ++ [likeChgTCVOD, likeChgTCVOL] ++ likelyChgs ++ [likeChgTLH] ++ unlikelyChgs
 
-nopcm_section :: SectionMap
-nopcm_section = Map.fromList $ map (\x -> (x ^. uid, x)) nopcm_sec
+nopcm_section :: [Section]
+nopcm_section = nopcm_sec
 
-nopcm_labcon :: LabelledContentMap
-nopcm_labcon = Map.fromList $ map (\x -> (x ^. uid, x)) [inputInitQuantsTblabled, dataConstTable1]
+nopcm_labcon :: [LabelledContent]
+nopcm_labcon = [inputInitQuantsTblabled, dataConstTable1]
 
 nopcm_sec :: [Section]
 nopcm_sec = extractSection nopcm_srs

--- a/code/drasil-example/Drasil/SSP/Body.hs
+++ b/code/drasil-example/Drasil/SSP/Body.hs
@@ -150,26 +150,26 @@ ssp_label = Map.union (generateTraceMap mkSRS) (generateTraceMap' $ sspRequireme
 ssp_refby :: RefbyMap
 ssp_refby = generateRefbyMap ssp_label
 
-ssp_datadefn :: DatadefnMap
-ssp_datadefn = Map.fromList . map (\x -> (x ^. uid, x)) $ getTraceMapFromDD $ getSCSSub mkSRS
+ssp_datadefn :: [DataDefinition]
+ssp_datadefn = getTraceMapFromDD $ getSCSSub mkSRS
 
-ssp_insmodel :: InsModelMap
-ssp_insmodel = Map.fromList . map (\x -> (x ^. uid, x)) $ getTraceMapFromIM $ getSCSSub mkSRS
+ssp_insmodel :: [InstanceModel]
+ssp_insmodel = getTraceMapFromIM $ getSCSSub mkSRS
 
-ssp_gendef :: GendefMap
-ssp_gendef = Map.fromList . map (\x -> (x ^. uid, x)) $ getTraceMapFromGD $ getSCSSub mkSRS
+ssp_gendef :: [GenDefn]
+ssp_gendef = getTraceMapFromGD $ getSCSSub mkSRS
 
-ssp_theory :: TheoryModelMap
-ssp_theory = Map.fromList . map (\x -> (x ^. uid, x)) $ getTraceMapFromTM $ getSCSSub mkSRS
+ssp_theory :: [TheoryModel]
+ssp_theory = getTraceMapFromTM $ getSCSSub mkSRS
 
-ssp_assump :: AssumptionMap
-ssp_assump = Map.fromList $ map (\x -> (x ^. uid, x)) newAssumptions
+ssp_assump :: [AssumpChunk]
+ssp_assump = newAssumptions
 
-ssp_concins :: ConceptInstanceMap
-ssp_concins = Map.fromList $ map (\x -> (x ^. uid, x)) (sspRequirements ++ likelyChgs ++ unlikelyChgs)
+ssp_concins :: [ConceptInstance]
+ssp_concins = sspRequirements ++ likelyChgs ++ unlikelyChgs
 
-ssp_section :: SectionMap
-ssp_section = Map.fromList $ map (\x -> (x ^. uid, x)) ssp_sec
+ssp_section :: [Section]
+ssp_section = ssp_sec
 
 ssp_sec :: [Section]
 ssp_sec = extractSection ssp_srs
@@ -195,13 +195,13 @@ sspSymMap = cdb sspSymbols (map nw sspSymbols ++ map nw acronyms ++
   ++ map nw educon ++ map nw compcon ++ [nw algorithm, nw ssp] ++ map nw this_si)
   (map cw sspSymbols ++ srsDomains) this_si ssp_label ssp_refby
   ssp_datadefn ssp_insmodel ssp_gendef ssp_theory ssp_assump ssp_concins
-  ssp_section (head ([] :: [LabelledContentMap]))
+  ssp_section []
 
 usedDB :: ChunkDB
 usedDB = cdb (map qw symbTT) (map nw sspSymbols ++ map nw acronyms ++ map nw check_si)
  ([] :: [ConceptChunk]) check_si ssp_label ssp_refby
  ssp_datadefn ssp_insmodel ssp_gendef ssp_theory ssp_assump ssp_concins
- ssp_section (head ([] :: [LabelledContentMap]))
+ ssp_section []
 
 sspRefDB :: ReferenceDB
 sspRefDB = rdb newAssumptions sspCitations (sspRequirements ++

--- a/code/drasil-example/Drasil/SWHS/Body.hs
+++ b/code/drasil-example/Drasil/SWHS/Body.hs
@@ -219,29 +219,29 @@ swhs_label = Map.union (generateTraceMap mkSRS) (generateTraceMap' $ likelyChgs 
 swhs_refby :: RefbyMap
 swhs_refby = generateRefbyMap swhs_label 
 
-swhs_datadefn :: DatadefnMap
-swhs_datadefn = Map.fromList . map (\x -> (x ^. uid, x)) $ getTraceMapFromDD $ getSCSSub mkSRS
+swhs_datadefn :: [DataDefinition]
+swhs_datadefn = getTraceMapFromDD $ getSCSSub mkSRS
 
-swhs_insmodel :: InsModelMap
-swhs_insmodel = Map.fromList . map (\x -> (x ^. uid, x)) $ getTraceMapFromIM $ getSCSSub mkSRS
+swhs_insmodel :: [InstanceModel]
+swhs_insmodel = getTraceMapFromIM $ getSCSSub mkSRS
 
-swhs_gendef :: GendefMap
-swhs_gendef = Map.fromList . map (\x -> (x ^. uid, x)) $ getTraceMapFromGD $ getSCSSub mkSRS
+swhs_gendef :: [GenDefn]
+swhs_gendef = getTraceMapFromGD $ getSCSSub mkSRS
 
-swhs_theory :: TheoryModelMap
-swhs_theory = Map.fromList . map (\x -> (x ^. uid, x)) $ getTraceMapFromTM $ getSCSSub mkSRS
+swhs_theory :: [TheoryModel]
+swhs_theory = getTraceMapFromTM $ getSCSSub mkSRS
 
-swhs_assump :: AssumptionMap
-swhs_assump = Map.fromList $ map (\x -> (x ^. uid, x)) newAssumptions
+swhs_assump :: [AssumpChunk]
+swhs_assump = newAssumptions
 
-swhs_concins :: ConceptInstanceMap
-swhs_concins = Map.fromList $ map (\x -> (x ^. uid, x)) (likelyChgs ++ unlikelyChgs ++ funcReqs)
+swhs_concins :: [ConceptInstance]
+swhs_concins = likelyChgs ++ unlikelyChgs ++ funcReqs
 
-swhs_section :: SectionMap
-swhs_section = Map.fromList $ map (\x -> (x ^. uid, x)) swhs_sec
+swhs_section :: [Section]
+swhs_section = swhs_sec
 
-swhs_labcon :: LabelledContentMap
-swhs_labcon = Map.fromList $ map (\x -> (x ^. uid, x)) [dataConTable1, inputInitQuantsTblabled]
+swhs_labcon :: [LabelledContent]
+swhs_labcon = [dataConTable1, inputInitQuantsTblabled]
 
 swhs_sec :: [Section]
 swhs_sec = extractSection swhs_srs'

--- a/code/drasil-example/drasil-example.cabal
+++ b/code/drasil-example/drasil-example.cabal
@@ -1,5 +1,5 @@
 Name:		drasil-example
-Version:	0.1.14
+Version:	0.1.16
 Cabal-Version:  >= 1.18
 Author:		Dan Szymczak, Steven Palmer, Jacques Carette, Spencer Smith
 build-type:     Simple
@@ -19,12 +19,12 @@ executable tiny
     mtl >= 2.2.1,
     directory >= 1.2.6.2,
     split >= 0.2.3.1,
-    drasil-lang >= 0.1.53,
+    drasil-lang >= 0.1.54,
     drasil-data >= 0.1.9,
     drasil-code >= 0.1.4,
     drasil-printers >= 0.1.7,
     drasil-gen >= 0.1.2,
-    drasil-docLang >= 0.1.18
+    drasil-docLang >= 0.1.19
   default-language: Haskell2010
   ghc-options:      -Wall -O2 -Wredundant-constraints
 
@@ -53,12 +53,12 @@ executable glassbr
     mtl >= 2.2.1,
     directory >= 1.2.6.2,
     split >= 0.2.3.1,
-    drasil-lang >= 0.1.53,
+    drasil-lang >= 0.1.54,
     drasil-data >= 0.1.7,
     drasil-code >= 0.1.4,
     drasil-printers >= 0.1.5,
     drasil-gen >= 0.1.2,
-    drasil-docLang >= 0.1.13
+    drasil-docLang >= 0.1.19
   default-language: Haskell2010
   ghc-options:      -Wall -Wredundant-constraints
 
@@ -97,12 +97,12 @@ executable nopcm
     mtl >= 2.2.1,
     directory >= 1.2.6.2,
     split >= 0.2.3.1,
-    drasil-lang >= 0.1.53,
+    drasil-lang >= 0.1.54,
     drasil-data >= 0.1.7,
     drasil-code >= 0.1.4,
     drasil-printers >= 0.1.5,
     drasil-gen >= 0.1.2,
-    drasil-docLang >= 0.1.11
+    drasil-docLang >= 0.1.19
   default-language: Haskell2010
   ghc-options:      -Wall -Wredundant-constraints
 
@@ -132,12 +132,12 @@ executable swhs
     pretty >= 1.1.1.1,
     mtl >= 2.2.1,
     directory >= 1.2.6.2,
-    drasil-lang >= 0.1.53,
+    drasil-lang >= 0.1.54,
     drasil-data >= 0.1.7,
     drasil-code >= 0.1.4,
     drasil-printers >= 0.1.5,
     drasil-gen >= 0.1.2,
-    drasil-docLang >= 0.1.11
+    drasil-docLang >= 0.1.19
   default-language: Haskell2010
   ghc-options:      -Wall -Wredundant-constraints
 
@@ -169,12 +169,12 @@ executable ssp
     mtl >= 2.2.1,
     directory >= 1.2.6.2,
     split >= 0.2.3.1,
-    drasil-lang >= 0.1.53,
+    drasil-lang >= 0.1.54,
     drasil-data >= 0.1.7,
     drasil-code >= 0.1.4,
     drasil-printers >= 0.1.5,
     drasil-gen >= 0.1.2,
-    drasil-docLang >= 0.1.11
+    drasil-docLang >= 0.1.19
   default-language: Haskell2010
   ghc-options:      -Wall -Wredundant-constraints
 
@@ -199,12 +199,12 @@ executable chipmunkdocs
     mtl >= 2.2.1,
     directory >= 1.2.6.2,
     split >= 0.2.3.1,
-    drasil-lang >= 0.1.53,
+    drasil-lang >= 0.1.54,
     drasil-data >= 0.1.6,
     drasil-code >= 0.1.4,
     drasil-printers >= 0.1.5,
     drasil-gen >= 0.1.2,
-    drasil-docLang >= 0.1.8
+    drasil-docLang >= 0.1.19
   default-language: Haskell2010
   ghc-options:      -Wall -Wredundant-constraints
 

--- a/code/drasil-lang/Language/Drasil.hs
+++ b/code/drasil-lang/Language/Drasil.hs
@@ -144,7 +144,7 @@ module Language.Drasil (
   , ChunkDB, cdb
   , HasSymbolTable, symbolMap, symbLookup, symbolTable
   , HasTermTable, termLookup, termTable
-  , HasDefinitionTable, conceptMap, defTable, defLookup, labelledconLookup
+  , HasDefinitionTable, conceptMap, traceMap, defTable, defLookup, labelledconLookup
   , HasUnitTable, unitMap, unitTable, collectUnits, LabelledContentMap
   , TraceMap, traceLookup, HasTraceTable(..), generateRefbyMap, RefbyMap
   , refbyLookup, HasRefbyTable(..), DatadefnMap, InsModelMap, AssumptionMap, HasLabelledContent(..)

--- a/code/drasil-lang/Language/Drasil/ChunkDB.hs
+++ b/code/drasil-lang/Language/Drasil/ChunkDB.hs
@@ -171,64 +171,54 @@ class HasLabelledContent s where
 getUnitLup :: HasSymbolTable s => HasUID c => s -> c -> Maybe UnitDefn
 getUnitLup m c = getUnit $ symbLookup (c ^. uid) (m ^. symbolTable)
 
--- | Looks up an uid in the term table. If nothing is found, an error is thrown
-termLookup :: UID -> TermMap -> IdeaDict
-termLookup c m = getT $ Map.lookup c m
-  where getT = maybe (error $ "Term: " ++ c ++ " not found in TermMap") id
+-- | Looks up a UID in a UMap table. If nothing is found an error is thrown
+uMapLookup :: String -> String -> UID -> UMap a -> a
+uMapLookup tys ms u t = getFM $ Map.lookup u t
+  where getFM = maybe (error $ tys ++ ": " ++ u ++ " not found in " ++ ms) id
 
 -- | Looks up an uid in the term table. If nothing is found, an error is thrown
+termLookup :: UID -> TermMap -> IdeaDict
+termLookup = uMapLookup "Term" "TermMap"
+
+-- | Looks up an uid in the unit table. If nothing is found, an error is thrown
 unitLookup :: UID -> UnitMap -> UnitDefn
-unitLookup c m = getT $ Map.lookup c m
-  where getT = maybe (error $ "Unit: " ++ c ++ " not found in UnitMap") id
+unitLookup = uMapLookup "Unit" "UnitMap"
 
 -- | Looks up a uid in the definition table. If nothing is found, an error is thrown.
 defLookup :: UID -> ConceptMap -> ConceptChunk
-defLookup u m = getC $ Map.lookup u m
-  where getC = maybe (error $ "Concept: " ++ u ++ " not found in ConceptMap") id
-
+defLookup = uMapLookup "Concept" "ConceptMap"
 
 -- | Looks up a uid in the datadefinition table. If nothing is found, an error is thrown.
 datadefnLookup :: UID -> DatadefnMap -> DataDefinition
-datadefnLookup u m = getC $ Map.lookup u m
-  where getC = maybe (error $ "DataDefinition: " ++ u ++ " not found in datadefnMap") id
+datadefnLookup = uMapLookup "DataDefinition" "DatadefnMap"
 
-
--- | Looks up a uid in the definition table. If nothing is found, an error is thrown.
+-- | Looks up a uid in the instance model table. If nothing is found, an error is thrown.
 insmodelLookup :: UID -> InsModelMap -> InstanceModel
-insmodelLookup u m = getC $ Map.lookup u m
-  where getC = maybe (error $ "InstanceModel: " ++ u ++ " not found in insModelMap") id
+insmodelLookup = uMapLookup "InstanceModel" "InsModelMap"
 
-
--- | Looks up a uid in the definition table. If nothing is found, an error is thrown.
+-- | Looks up a uid in the general definition table. If nothing is found, an error is thrown.
 gendefLookup :: UID -> GendefMap -> GenDefn
-gendefLookup u m = getC $ Map.lookup u m
-  where getC = maybe (error $ "GeneralDefinition: " ++ u ++ " not found in GendefMap") id
+gendefLookup = uMapLookup "GenDefn" "GenDefnMap" 
 
-
--- | Looks up a uid in the definition table. If nothing is found, an error is thrown.
+-- | Looks up a uid in the theory model table. If nothing is found, an error is thrown.
 theoryModelLookup :: UID -> TheoryModelMap -> TheoryModel
-theoryModelLookup u m = getC $ Map.lookup u m
-  where getC = maybe (error $ "TheoryModel: " ++ u ++ " not found in TheoryModelMap") id
+theoryModelLookup = uMapLookup "TheoryModel" "TheoryModelMap"
 
--- | Looks up a uid in the definition table. If nothing is found, an error is thrown.
+-- | Looks up a uid in the assumption table. If nothing is found, an error is thrown.
 assumptionLookup :: UID -> AssumptionMap -> AssumpChunk
-assumptionLookup u m = getC $ Map.lookup u m
-  where getC = maybe (error $ "Assumption: " ++ u ++ " not found in AssumptionMap") id
+assumptionLookup = uMapLookup "Assumption" "AssumptionMap"
 
--- | Looks up a uid in the definition table. If nothing is found, an error is thrown.
+-- | Looks up a uid in the concept instance table. If nothing is found, an error is thrown.
 conceptinsLookup :: UID -> ConceptInstanceMap -> ConceptInstance
-conceptinsLookup u m = getC $ Map.lookup u m
-  where getC = maybe (error $ "ConceptInstance: " ++ u ++ " not found in conceptInstanceMap") id
+conceptinsLookup = uMapLookup "ConceptInstance" "ConceptInstanceMap"
 
--- | Looks up a uid in the definition table. If nothing is found, an error is thrown.
+-- | Looks up a uid in the section table. If nothing is found, an error is thrown.
 sectionLookup :: UID -> SectionMap -> Section
-sectionLookup u m = getC $ Map.lookup u m
-  where getC = maybe (error $ "Section: " ++ u ++ " not found in sectionMap") id
+sectionLookup = uMapLookup "Section" "SectionMap"
 
 -- | Looks up a uid in the definition table. If nothing is found, an error is thrown.
 labelledconLookup :: UID -> LabelledContentMap -> LabelledContent
-labelledconLookup u m = getC $ Map.lookup u m
-  where getC = maybe (error $ "LabelledContent: " ++ u ++ " not found in LabelledContentMap") id
+labelledconLookup = uMapLookup "LabelledContent" "LabelledContentMap"
 
 -- | Our chunk databases. Should contain all the maps we will need.
 data ChunkDB = CDB { _csymbs :: SymbolMap

--- a/code/drasil-lang/drasil-lang.cabal
+++ b/code/drasil-lang/drasil-lang.cabal
@@ -1,5 +1,5 @@
 Name:		drasil-lang
-Version:	0.1.53
+Version:	0.1.54
 Cabal-Version:  >= 1.18
 Author:		Dan Szymczak, Steven Palmer, Jacques Carette, Spencer Smith
 build-type:     Simple


### PR DESCRIPTION
This PR does two things:
* Abstracts common operations for/involving `ChunkDB` to have one central implementation (more DRY if you will).
* Adds ordering to many of the tables in `ChunkDB`.

The ordering is implemented such that sorting the _values_ of the tables in ascending order should be the identity with the input list. (After slicing off the second element in the tuple).

Currently, nothing uses this ordering and this is "just" an infrastructure PR. The idea behind having an explicit ordering (the input list order) is it allows for control within individual example recipes and it provides a "user-facing" deterministic way in which tables can be transformed into lists (rather than the `Map` default of ascending order of keys –– `UID` –– which as I understand is supposed to be "just" unique and internal).

