### PR TITLE
Removes Assumption from Backend

### DIFF
--- a/code/drasil-docLang/Drasil/ExtractDocDesc.hs
+++ b/code/drasil-docLang/Drasil/ExtractDocDesc.hs
@@ -186,7 +186,6 @@ getCon (Paragraph s)       = [s]
 getCon (EqnBlock _)      = []
 getCon (Enumeration lst)   = getLT lst
 getCon (Figure l _ _)    = [l]
-getCon (Assumption _ b)  = [b]
 getCon (Bib bref)          = getBib bref
 getCon (Graph [(s1, s2)] _ _ l) = s1 : s2 : [l]
 getCon (Defini _ []) = []

--- a/code/drasil-docLang/drasil-docLang.cabal
+++ b/code/drasil-docLang/drasil-docLang.cabal
@@ -1,5 +1,5 @@
 Name:		drasil-docLang
-Version:	0.1.21
+Version:	0.1.22
 Cabal-Version:  >= 1.18
 Author:		Dan Szymczak, Steven Palmer, Jacques Carette, Spencer Smith
 build-type:     Simple
@@ -43,7 +43,7 @@ library
     MissingH >= 1.4.0.1,
     parsec >= 3.1.9,
     data-fix (>= 0.0.4 && <= 1.0),
-    drasil-lang >= 0.1.58,
+    drasil-lang >= 0.1.59,
     drasil-data >= 0.1.9
   default-language: Haskell2010
   ghc-options:      -Wall -Wredundant-constraints

--- a/code/drasil-example/drasil-example.cabal
+++ b/code/drasil-example/drasil-example.cabal
@@ -1,5 +1,5 @@
 Name:		drasil-example
-Version:	0.1.18
+Version:	0.1.19
 Cabal-Version:  >= 1.18
 Author:		Dan Szymczak, Steven Palmer, Jacques Carette, Spencer Smith
 build-type:     Simple
@@ -23,8 +23,8 @@ executable tiny
     drasil-data >= 0.1.9,
     drasil-code >= 0.1.4,
     drasil-printers >= 0.1.7,
-    drasil-gen >= 0.1.2,
-    drasil-docLang >= 0.1.21
+    drasil-gen >= 0.1.3,
+    drasil-docLang >= 0.1.22
   default-language: Haskell2010
   ghc-options:      -Wall -O2 -Wredundant-constraints
 
@@ -57,8 +57,8 @@ executable glassbr
     drasil-data >= 0.1.10,
     drasil-code >= 0.1.4,
     drasil-printers >= 0.1.5,
-    drasil-gen >= 0.1.2,
-    drasil-docLang >= 0.1.21
+    drasil-gen >= 0.1.3,
+    drasil-docLang >= 0.1.22
   default-language: Haskell2010
   ghc-options:      -Wall -Wredundant-constraints
 
@@ -101,8 +101,8 @@ executable nopcm
     drasil-data >= 0.1.7,
     drasil-code >= 0.1.4,
     drasil-printers >= 0.1.5,
-    drasil-gen >= 0.1.2,
-    drasil-docLang >= 0.1.21
+    drasil-gen >= 0.1.3,
+    drasil-docLang >= 0.1.22
   default-language: Haskell2010
   ghc-options:      -Wall -Wredundant-constraints
 
@@ -136,8 +136,8 @@ executable swhs
     drasil-data >= 0.1.7,
     drasil-code >= 0.1.4,
     drasil-printers >= 0.1.5,
-    drasil-gen >= 0.1.2,
-    drasil-docLang >= 0.1.21
+    drasil-gen >= 0.1.3,
+    drasil-docLang >= 0.1.22
   default-language: Haskell2010
   ghc-options:      -Wall -Wredundant-constraints
 
@@ -173,8 +173,8 @@ executable ssp
     drasil-data >= 0.1.7,
     drasil-code >= 0.1.4,
     drasil-printers >= 0.1.5,
-    drasil-gen >= 0.1.2,
-    drasil-docLang >= 0.1.21
+    drasil-gen >= 0.1.3,
+    drasil-docLang >= 0.1.22
   default-language: Haskell2010
   ghc-options:      -Wall -Wredundant-constraints
 
@@ -203,8 +203,8 @@ executable chipmunkdocs
     drasil-data >= 0.1.6,
     drasil-code >= 0.1.4,
     drasil-printers >= 0.1.5,
-    drasil-gen >= 0.1.2,
-    drasil-docLang >= 0.1.21
+    drasil-gen >= 0.1.3,
+    drasil-docLang >= 0.1.22
   default-language: Haskell2010
   ghc-options:      -Wall -Wredundant-constraints
 

--- a/code/drasil-gen/drasil-gen.cabal
+++ b/code/drasil-gen/drasil-gen.cabal
@@ -1,5 +1,5 @@
 Name:		  drasil-gen
-Version:	0.1.2
+Version:	0.1.3
 Cabal-Version:  >= 1.18
 Author:		Dan Szymczak, Steven Palmer, Jacques Carette, Spencer Smith
 build-type:     Simple
@@ -19,9 +19,9 @@ library
     split >= 0.2.3.1,
     MissingH >= 1.4.0.1,
     parsec >= 3.1.9,
-    drasil-lang >= 0.1.53,
+    drasil-lang >= 0.1.59,
     drasil-code >= 0.1.4,
-    drasil-printers >= 0.1.5
+    drasil-printers >= 0.1.8
   default-language: Haskell2010
   ghc-options:      -Wall -Wredundant-constraints
 

--- a/code/drasil-lang/Language/Drasil/Document/Core.hs
+++ b/code/drasil-lang/Language/Drasil/Document/Core.hs
@@ -10,7 +10,6 @@ import Language.Drasil.Expr (Expr)
 import Language.Drasil.Label.Type (LblType(RP), IRefProg, name, raw, (+::+))
 import Language.Drasil.RefProg(Reference)
 import Language.Drasil.Sentence (Sentence)
-import Language.Drasil.UID (UID)
 
 import Control.Lens ((^.), makeLenses, Lens', set, view)
 
@@ -63,7 +62,6 @@ data RawContent = Table [Sentence] [[Sentence]] Title Bool
                | Enumeration ListType -- ^ Lists
                | Defini DType [(Identifier, [Contents])]
                | Figure Lbl Filepath MaxWidthPercent -- ^ Should use relative file path.
-               | Assumption UID Sentence -- FIXME: hack, remove
                | Bib BibRef
                | Graph [(Sentence, Sentence)] (Maybe Width) (Maybe Height) Lbl
                -- ^ TODO: Fill this one in.
@@ -102,7 +100,6 @@ refLabelledCon (Table _ _ _ _)       = raw "Table:" +::+ name
 refLabelledCon (Figure _ _ _)        = raw "Fig:" +::+ name
 refLabelledCon (Graph _ _ _ _)       = raw "Fig:" +::+ name
 refLabelledCon (Defini _ _)          = raw "Def:" +::+ name
-refLabelledCon (Assumption _ _)      = raw "Assump:" +::+ name
 refLabelledCon (EqnBlock _)          = raw "EqnB:" +::+ name
 refLabelledCon (Enumeration _)       = raw "Lst:" +::+ name 
 refLabelledCon (Paragraph _)         = error "Shouldn't reference paragraphs"

--- a/code/drasil-lang/drasil-lang.cabal
+++ b/code/drasil-lang/drasil-lang.cabal
@@ -1,5 +1,5 @@
 Name:		drasil-lang
-Version:	0.1.58
+Version:	0.1.59
 Cabal-Version:  >= 1.18
 Author:		Dan Szymczak, Steven Palmer, Jacques Carette, Spencer Smith
 build-type:     Simple

--- a/code/drasil-printers/Language/Drasil/HTML/Print.hs
+++ b/code/drasil-printers/Language/Drasil/HTML/Print.hs
@@ -37,7 +37,7 @@ import Language.Drasil.Printing.Citation (CiteField(Year, Number, Volume, Title,
   Citation(Cite), BibRef)
 import Language.Drasil.Printing.LayoutObj (Tags, Document(Document),
   LayoutObj(Graph, Bib, List, Header, Figure, Definition, Table, EqnBlock, Paragraph, 
-  HDiv, ALUR))
+  HDiv))
 import Language.Drasil.Printing.Helpers (comm, dot, paren, sufxer, sqbrac)
 import Language.Drasil.Printing.PrintingInformation (PrintingInformation)
 
@@ -71,8 +71,6 @@ printLO (Definition dt ssPs l) = makeDefn dt ssPs (p_spec l)
 printLO (Header n contents _)  = h (n + 1) $ p_spec contents -- FIXME
 printLO (List t)               = makeList t
 printLO (Figure r c f wp)      = makeFigure (p_spec r) (p_spec c) (text f) wp
-printLO (ALUR _ x l i)         = wrap "ul" ["hide-list-style"] $
-  makeRefList (p_spec x) (p_spec l) (p_spec i)
 printLO (Bib bib)              = makeBib bib
 printLO (Graph _ _ _ _ _)      = empty -- FIXME
 

--- a/code/drasil-printers/Language/Drasil/Printing/Import.hs
+++ b/code/drasil-printers/Language/Drasil/Printing/Import.hs
@@ -343,10 +343,6 @@ layLabelled sm x@(LblC _ (EqnBlock c))          = T.HDiv ["equation"]
 layLabelled sm x@(LblC _ (Figure c f wp))     = T.Figure 
   (P.S $ getRefAdd x)
   (spec sm c) f wp
-layLabelled sm x@(LblC c (Assumption _ b))        = T.ALUR T.Assumption
-  (spec sm b)
-  (P.S $ getRefAdd x)
-  (spec sm $ getShortName c)
 layLabelled sm x@(LblC _ (Graph ps w h t))    = T.Graph 
   (map (\(y,z) -> (spec sm y, spec sm z)) ps) w h (spec sm t)
   (P.S $ getRefAdd x)
@@ -367,8 +363,6 @@ layUnlabelled sm (Paragraph c)          = T.Paragraph (spec sm c)
 layUnlabelled sm (EqnBlock c)         = T.HDiv ["equation"] [T.EqnBlock (P.E (expr c sm))] P.EmptyS
 layUnlabelled sm (Enumeration cs)       = T.List $ makeL sm cs
 layUnlabelled sm (Figure c f wp)    = T.Figure (P.S "nolabel2") (spec sm c) f wp
-layUnlabelled sm (Assumption _ b)       = T.ALUR T.Assumption
-  (spec sm b) (P.S "nolabel4") (P.S "nolabel4b")
 layUnlabelled sm (Graph ps w h t)   = T.Graph (map (\(y,z) -> (spec sm y, spec sm z)) ps)
                                w h (spec sm t) (P.S "nolabel6")
 layUnlabelled sm (Defini dtyp pairs)  = T.Definition dtyp (layPairs pairs) (P.S "nolabel7")
@@ -416,7 +410,3 @@ makeL sm (Definitions ps) = P.Definitions $ map (\(x,y,z) -> (spec sm x, item sm
 item :: PrintingInformation -> ItemType -> P.ItemType
 item sm (Flat i)     = P.Flat $ spec sm i
 item sm (Nested t s) = P.Nested (spec sm t) (makeL sm s)
-
--- | Helper for getting a short name
-getShortName :: HasShortName c => c -> Sentence
-getShortName = S . getStringSN . shortname

--- a/code/drasil-printers/Language/Drasil/Printing/LayoutObj.hs
+++ b/code/drasil-printers/Language/Drasil/Printing/LayoutObj.hs
@@ -17,7 +17,6 @@ type Height   = Float
 type Filepath = String
 type Caption  = Spec
 
-data ALUR = Assumption | LikelyChange | UnlikelyChange | Requirement
 data LayoutObj = 
      Table Tags [[Spec]] Label Bool Caption
    | Header Depth Title Label
@@ -26,7 +25,6 @@ data LayoutObj =
    | Definition DType [(String,[LayoutObj])] Label
    | List ListType
    | Figure Label Caption Filepath MaxWidthPercent
-   | ALUR ALUR Contents Label Label -- two labels?
    | Graph [(Spec, Spec)] (Maybe Width) (Maybe Height) Caption Label
    | HDiv Tags [LayoutObj] Label
    -- this shouldn't be here, it should have been expanded.

--- a/code/drasil-printers/Language/Drasil/TeX/Preamble.hs
+++ b/code/drasil-printers/Language/Drasil/TeX/Preamble.hs
@@ -3,11 +3,10 @@ module Language.Drasil.TeX.Preamble (genPreamble) where
 import Data.List (nub)
 
 import Language.Drasil.Printing.LayoutObj (LayoutObj(Paragraph, Header, Bib, Graph, 
-  List, EqnBlock, Figure, ALUR, Table, Definition, HDiv), 
-  ALUR(LikelyChange, UnlikelyChange, Assumption, Requirement))
+  List, EqnBlock, Figure, Table, Definition, HDiv))
 import Language.Drasil.TeX.Monad (D, vcat, (%%))
 import Language.Drasil.TeX.Helpers (docclass, command, command0, command1o, command3, 
-  comm, count, usepackage)
+  usepackage)
 
 import Language.Drasil.Config (hyperSettings, fontSize, bibFname)
 
@@ -60,11 +59,7 @@ addPackage FontSpec  = usepackage "fontspec"
 addPackage Unicode   = usepackage "unicode-math"
 addPackage EnumItem  = usepackage "enumitem"
 
-data Def = AssumpCounter
-         | LCCounter
-         | ReqCounter
-         | UCCounter
-         | Bibliography
+data Def = Bibliography
          | TabuLine
          | SetMathFont
          | SymbDescriptionP1
@@ -72,14 +67,6 @@ data Def = AssumpCounter
          deriving Eq
 
 addDef :: Def -> D
-addDef AssumpCounter = count "assumpnum" %%
-                       comm "atheassumpnum" "A\\theassumpnum" Nothing
-addDef LCCounter     = count "lcnum" %%
-                       comm "lcthelcnum" "LC\\thelcnum" Nothing
-addDef ReqCounter    = count "reqnum" %%
-                       comm "rthereqnum" "R\\thereqnum" Nothing
-addDef UCCounter     = count "ucnum" %%
-                       comm "uctheucnum" "UC\\theucnum" Nothing
 addDef Bibliography  = command "bibliography" bibFname
 addDef TabuLine      = command0 "global\\tabulinesep=1mm"
 addDef SetMathFont   = command "setmathfont" "Latin Modern Math"
@@ -111,10 +98,6 @@ parseDoc los' =
       let dd = concat $ map snd res1 in
       (Tabu:LongTable:BookTabs:pp,TabuLine:dd)
     parseDoc' (Figure _ _ _ _) = ([Graphics,Caption],[])
-    parseDoc' (ALUR Requirement _ _ _) = ([], [ReqCounter])
-    parseDoc' (ALUR Assumption _ _ _) = ([], [AssumpCounter])
-    parseDoc' (ALUR LikelyChange _ _ _) = ([], [LCCounter])
-    parseDoc' (ALUR UnlikelyChange _ _ _) = ([], [UCCounter])
     parseDoc' (Graph _ _ _ _ _) = ([Caption,Tikz,Dot2Tex,AdjustBox],[])
     parseDoc' (Bib _) = ([FileContents,BibLaTeX,URL],[Bibliography])
     parseDoc' (Header _ _ _) = ([], [])

--- a/code/drasil-printers/Language/Drasil/TeX/Print.hs
+++ b/code/drasil-printers/Language/Drasil/TeX/Print.hs
@@ -29,9 +29,8 @@ import Language.Drasil.Printing.Citation (HP(Verb, URL), CiteField(HowPublished,
   Year, Volume, Type, Title, Series, School, Publisher, Organization, Pages,
   Month, Number, Note, Journal, Editor, Chapter, Institution, Edition, BookTitle,
   Author, Address), Citation(Cite), BibRef)
-import Language.Drasil.Printing.LayoutObj (LayoutObj(Graph, Bib, ALUR, Figure, Definition,
-  List, Table, EqnBlock, Paragraph, Header, HDiv), Document(Document), 
-  ALUR(LikelyChange, UnlikelyChange, Assumption, Requirement))
+import Language.Drasil.Printing.LayoutObj (LayoutObj(Graph, Bib, Figure, Definition,
+  List, Table, EqnBlock, Paragraph, Header, HDiv), Document(Document))
 import qualified Language.Drasil.Printing.Import as I
 import Language.Drasil.Printing.Helpers hiding (paren, sqbrac)
 import Language.Drasil.TeX.Helpers (label, caption, centering, mkEnv, item', description,
@@ -63,10 +62,6 @@ lo (Table _ rows r bl t) _  = toText $ makeTable rows (spec r) bl (spec t)
 lo (Definition _ ssPs l) sm  = toText $ makeDefn sm ssPs $ spec l
 lo (List l)               _  = toText $ makeList l
 lo (Figure r c f wp)      _  = toText $ makeFigure (spec r) (spec c) f wp
-lo (ALUR Requirement n l _)    _  = toText $ makeReq (spec n) (spec l)
-lo (ALUR Assumption n l _)     _  = toText $ makeAssump (spec n) (spec l)
-lo (ALUR LikelyChange n l _)   _  = toText $ makeLC (spec n) (spec l)
-lo (ALUR UnlikelyChange n l _) _  = toText $ makeUC (spec n) (spec l)
 lo (Bib bib)            sm = toText $ makeBib sm bib
 lo (Graph ps w h c l)   _  = toText $ makeGraph
   (map (\(a,b) -> (spec a, spec b)) ps)
@@ -428,22 +423,6 @@ makeFigure r c f wp =
 -----------------------------------------------------------------
 ------------------ MODULE PRINTING----------------------------
 -----------------------------------------------------------------
-
-makeReq :: D -> D -> D
-makeReq n l = description $ item' ((pure $ text ("\\refstepcounter{reqnum}"
-  ++ "\\rthereqnum")) <> label l <> (pure $ text ":")) n
-
-makeAssump :: D -> D -> D
-makeAssump n l = description $ item' ((pure $ text ("\\refstepcounter{assumpnum}"
-  ++ "\\atheassumpnum")) <> label l <> (pure $ text ":")) n
-
-makeLC :: D -> D -> D
-makeLC n l = description $ item' ((pure $ text ("\\refstepcounter{lcnum}"
-  ++ "\\lcthelcnum")) <> label l <> (pure $ text ":")) n
-
-makeUC :: D -> D -> D
-makeUC n l = description $ item' ((pure $ text ("\\refstepcounter{ucnum}"
-  ++ "\\uctheucnum")) <> label l <> (pure $ text ":")) n
 
 makeGraph :: [(D,D)] -> D -> D -> D -> D -> D
 makeGraph ps w h c l =

--- a/code/drasil-printers/drasil-printers.cabal
+++ b/code/drasil-printers/drasil-printers.cabal
@@ -1,5 +1,5 @@
 Name:		drasil-printers
-Version:	0.1.7
+Version:	0.1.8
 Cabal-Version:  >= 1.18
 Author:		Dan Szymczak, Steven Palmer, Jacques Carette, Spencer Smith
 build-type:     Simple
@@ -42,7 +42,7 @@ library
     MissingH >= 1.4.0.1,
     parsec >= 3.1.9,
     data-fix (>= 0.0.4 && <= 1.0),
-    drasil-lang >= 0.1.53
+    drasil-lang >= 0.1.59
   default-language: Haskell2010
   ghc-options:      -Wall -Wredundant-constraints
 


### PR DESCRIPTION
This PR builds on #1091 by removing the `Assumption` from `Document` in lang and `ALUR` (and friends) from printers. 

This PR is requesting to merge onto QDef-in-InstMod. 
The build failures are again from the build failures on base QDef-in-InstMod.