### PR TITLE
SSP Interslice Force Ratio Variation Function DD

### DIFF
--- a/code/drasil-data/Data/Drasil/Citations.hs
+++ b/code/drasil-data/Data/Drasil/Citations.hs
@@ -40,9 +40,9 @@ parnasClements1986 = cArticle [dParnas, pcClements]
 
 smithLai2005 = cInProceedings [spencerSmith, lLai]
   "A new requirements template for scientific computing"
-  ("Proceedings of the First International Workshop on" ++
-  "Situational Requirements Engineering Processes - Methods," ++
-  "Techniques and Tools to Support Situation-Specific Requirements" ++
+  ("Proceedings of the First International Workshop on " ++
+  "Situational Requirements Engineering Processes - Methods, " ++
+  "Techniques and Tools to Support Situation-Specific Requirements " ++
   "Engineering Processes, SREP'05") 2005
   [ editor [pjAgerfalk, nKraiem, jRalyte], address "Paris, France"
   , pages [107,121], 

--- a/code/drasil-data/Data/Drasil/Concepts/Math.hs
+++ b/code/drasil-data/Data/Drasil/Concepts/Math.hs
@@ -8,7 +8,7 @@ import Data.Drasil.Phrase(of_)
 mathcon :: [ConceptChunk]
 mathcon = [angle, area, calculation, diameter, equation, euclidN, euclidSpace, gradient, 
   graph, law, matrix, norm, normal, normalV, number, orient, parameter, perp, 
-  perpV, probability, shape, surArea, surface, unit_, unitV, vector, rate, 
+  perpV, pi_, probability, shape, surArea, surface, unit_, unitV, vector, rate, 
   change, rOfChng, constraint]
 
 mathcon' :: [CI]
@@ -16,7 +16,7 @@ mathcon' = [pde, ode, de]
 
 angle, area, calculation, diameter, equation, euclidN, euclidSpace, gradient, 
   graph, law, matrix, norm, normal, normalV, number, orient, parameter, perp, 
-  perpV, probability, shape, surArea, surface, unit_, unitV, vector, rate, 
+  perpV, pi_, probability, shape, surArea, surface, unit_, unitV, vector, rate, 
   change, rOfChng, constraint :: ConceptChunk
 
 pde, ode, de :: CI
@@ -43,6 +43,7 @@ number       = dcc "number"       (cn' "number")                  "A mathematica
 parameter    = dcc "parameter"    (cn' "parameter")               "A quantity whose value is selected depending on particular circumstances"
 --FIXME: Should "parameter" be in math?
 perp         = dcc "perp"         (cn' "perpendicular")           "At right angles"
+pi_          = dcc "pi"           (cn' "circumference to diameter ratio")                                                                         "The ratio of a circle's circumference to its diameter"
 probability  = dcc "probability"  (cnIES "probability")           "The likelihood of an event to occur"
 rate         = dcc "rate"         (cn' "rate")                    "Ratio that compares two quantities having different units of measure"
 shape        = dcc "shape"        (cn' "shape")                   "The outline of an area or figure"

--- a/code/drasil-data/Data/Drasil/Quantities/Math.hs
+++ b/code/drasil-data/Data/Drasil/Quantities/Math.hs
@@ -4,21 +4,19 @@ import Language.Drasil
 import Language.Drasil.ShortHands
 
 import Data.Drasil.Concepts.Math as CM (area, diameter, euclidN, gradient, 
-    normalV, orient, perpV, surArea, surface, unitV)
+    normalV, orient, perpV, pi_, surArea, surface, unitV)
 import Data.Drasil.SI_Units (metre, m_2, radian)
 
-gradient, normalVect, unitVect, euclidNorm, perpVect, uNormalVect :: DefinedQuantityDict
+gradient, normalVect, unitVect, euclidNorm, perpVect, pi_, uNormalVect :: DefinedQuantityDict
 
 gradient    = dqd' CM.gradient (const $ lNabla)        Real Nothing
 normalVect  = dqd' CM.normalV  (const $ vec $ lN)      Real Nothing
 uNormalVect = dqd' CM.normalV  (const $ vec $ hat lN)  Real Nothing
 unitVect    = dqd' CM.unitV    (const $ vec $ hat lI)  Real Nothing
 perpVect    = dqd' CM.perpV    (const $ vec $ lN)      Real Nothing
+pi_         = dqd' CM.pi_      (const $ lPi)           Real Nothing
 euclidNorm  = dqd' CM.euclidN  (const $ Concat [Atomic "||", (vec lR), Atomic "||"])
                                                         Real Nothing  
-
-pi_ :: QuantityDict
-pi_         = mkQuant "pi"   (pn "pi") lPi              Real Nothing Nothing
 
 area, diameter, surface, surArea, orientation :: UnitalChunk
 

--- a/code/drasil-example/Drasil/GamePhysics/Body.hs
+++ b/code/drasil-example/Drasil/GamePhysics/Body.hs
@@ -55,7 +55,7 @@ import qualified Data.Drasil.Concepts.Physics as CP (rigidBody, elasticity,
   cartesian, friction, rightHand, collision, space, physicCon)
 import qualified Data.Drasil.Concepts.Math as CM (equation, surface, law, mathcon, mathcon')
 import Data.Drasil.Software.Products (prodtcon)
-import qualified Data.Drasil.Quantities.Math as QM (orientation)
+import qualified Data.Drasil.Quantities.Math as QM (orientation, pi_)
 import qualified Data.Drasil.Quantities.PhysicalProperties as QPP (mass)
 import qualified Data.Drasil.Quantities.Physics as QP (angularVelocity, force, 
   linearVelocity, position, time, velocity)
@@ -195,7 +195,7 @@ chipUnits :: [UnitDefn] -- FIXME
 chipUnits = map unitWrapper [metre, kilogram, second] ++ map unitWrapper [newton, radian]
 
 everything :: ChunkDB
-everything = cdb cpSymbolsAll (map nw cpSymbolsAll ++ map nw cpAcronyms ++ map nw prodtcon
+everything = cdb (cpSymbolsAll ++ map qw [QM.pi_]) (map nw cpSymbolsAll ++ map nw [QM.pi_] ++ map nw cpAcronyms ++ map nw prodtcon
   ++ map nw softwarecon ++ map nw doccon ++ map nw doccon' ++ map nw CP.physicCon
   ++ map nw educon ++ [nw algorithm] ++ map nw derived ++ map nw fundamentals
   ++ map nw CM.mathcon ++ map nw CM.mathcon')
@@ -204,7 +204,7 @@ everything = cdb cpSymbolsAll (map nw cpSymbolsAll ++ map nw cpAcronyms ++ map n
   game_section []
 
 usedDB :: ChunkDB
-usedDB = cdb (map qw symbTT) (map nw cpSymbolsAll ++ map nw cpAcronyms ++ map nw check_si) ([] :: [ConceptChunk]) check_si
+usedDB = cdb (map qw (symbTT ++ [QM.pi_])) (map nw cpSymbolsAll ++ map nw [QM.pi_] ++ map nw cpAcronyms ++ map nw check_si) ([] :: [ConceptChunk]) check_si
  game_label game_refby game_datadefn game_insmodel game_gendef game_theory game_assump game_concins
  game_section []
 

--- a/code/drasil-example/Drasil/GamePhysics/Unitals.hs
+++ b/code/drasil-example/Drasil/GamePhysics/Unitals.hs
@@ -37,8 +37,7 @@ gamephyUnitSymbs = map ucw cpUnits ++ map ucw [iVect, jVect, normalVect,
 
 cpSymbols, cpSymbolsAll, inputSymbols, outputSymbols :: [QuantityDict]
 
--- FIXME: pi hack
-cpSymbolsAll = cpSymbols ++ inputSymbols ++ outputSymbols ++ [QM.pi_]
+cpSymbolsAll = cpSymbols ++ inputSymbols ++ outputSymbols
 
 cpSymbols = (map qw cpUnits) ++ 
   (map qw cpUnitless) ++ 

--- a/code/drasil-example/Drasil/SSP/Body.hs
+++ b/code/drasil-example/Drasil/SSP/Body.hs
@@ -38,6 +38,7 @@ import Data.Drasil.Concepts.Software (accuracy, correctness, maintainability,
 import Data.Drasil.Concepts.SolidMechanics (normForce, shearForce, solidcon)
 import Data.Drasil.Concepts.Computation (compcon, algorithm)
 import Data.Drasil.Software.Products (sciCompS, prodtcon)
+import Data.Drasil.Quantities.Math as QM (pi_)
 
 import Data.Drasil.People (henryFrankis)
 import Data.Drasil.Phrase (for)
@@ -187,7 +188,7 @@ ssppriorityNFReqs = [correctness, understandability, reusability,
 
 -- SYMBOL MAP HELPERS --
 sspSymMap :: ChunkDB
-sspSymMap = cdb sspSymbols (map nw sspSymbols ++ map nw acronyms ++
+sspSymMap = cdb (map qw sspSymbols ++ [QM.pi_]) (map nw sspSymbols ++ map nw acronyms ++ map nw [QM.pi_] ++
   map nw doccon ++ map nw prodtcon ++ map nw sspdef ++ map nw sspdef'
   ++ map nw softwarecon ++ map nw physicCon ++ map nw mathcon
   ++ map nw mathcon' ++ map nw solidcon ++ map nw physicalcon
@@ -198,7 +199,7 @@ sspSymMap = cdb sspSymbols (map nw sspSymbols ++ map nw acronyms ++
   ssp_section []
 
 usedDB :: ChunkDB
-usedDB = cdb (map qw symbTT) (map nw sspSymbols ++ map nw acronyms ++ map nw check_si)
+usedDB = cdb (map qw symbTT ++ [QM.pi_]) (map nw sspSymbols ++ map nw acronyms ++ map nw [QM.pi_] ++ map nw check_si)
  ([] :: [ConceptChunk]) check_si ssp_label ssp_refby
  ssp_datadefn ssp_insmodel ssp_gendef ssp_theory ssp_assump ssp_concins
  ssp_section []

--- a/code/drasil-example/Drasil/SSP/Body.hs
+++ b/code/drasil-example/Drasil/SSP/Body.hs
@@ -188,18 +188,18 @@ ssppriorityNFReqs = [correctness, understandability, reusability,
 
 -- SYMBOL MAP HELPERS --
 sspSymMap :: ChunkDB
-sspSymMap = cdb (map qw sspSymbols ++ [QM.pi_]) (map nw sspSymbols ++ map nw acronyms ++ map nw [QM.pi_] ++
+sspSymMap = cdb (map qw (sspSymbols ++ [QM.pi_])) (map nw sspSymbols ++ map nw acronyms ++
   map nw doccon ++ map nw prodtcon ++ map nw sspdef ++ map nw sspdef'
   ++ map nw softwarecon ++ map nw physicCon ++ map nw mathcon
   ++ map nw mathcon' ++ map nw solidcon ++ map nw physicalcon
   ++ map nw doccon' ++ map nw derived ++ map nw fundamentals
   ++ map nw educon ++ map nw compcon ++ [nw algorithm, nw ssp] ++ map nw this_si)
-  (map cw sspSymbols ++ srsDomains) this_si ssp_label ssp_refby
+  (map cw sspSymbols ++ map cw [QM.pi_] ++ srsDomains) this_si ssp_label ssp_refby
   ssp_datadefn ssp_insmodel ssp_gendef ssp_theory ssp_assump ssp_concins
   ssp_section []
 
 usedDB :: ChunkDB
-usedDB = cdb (map qw symbTT ++ [QM.pi_]) (map nw sspSymbols ++ map nw acronyms ++ map nw [QM.pi_] ++ map nw check_si)
+usedDB = cdb (map qw (symbTT ++ [QM.pi_])) (map nw sspSymbols ++ map nw acronyms ++ map nw check_si)
  ([] :: [ConceptChunk]) check_si ssp_label ssp_refby
  ssp_datadefn ssp_insmodel ssp_gendef ssp_theory ssp_assump ssp_concins
  ssp_section []

--- a/code/drasil-example/Drasil/SSP/DataDefs.hs
+++ b/code/drasil-example/Drasil/SSP/DataDefs.hs
@@ -10,13 +10,14 @@ import Language.Drasil
  -- ofThe', sAnd)
 
 import Data.Drasil.Concepts.Math (equation, surface)
+import Data.Drasil.Quantities.Math as QM (pi_)
 import Data.Drasil.SentenceStructures (sAnd)
 import Drasil.SSP.Assumptions (newA9)
 import Drasil.SSP.References (chen2005, fredlund1977, karchewski2012, 
   huston2008)
 import Drasil.SSP.Unitals (baseAngle, baseHydroForce, baseLngth, baseWthX, 
-  dryWeight, earthqkLoadFctr, fricAngle, fs, genericF, genericA, 
-  impLoadAngle, intNormForce, intShrForce, inx, inxi, inxiM1, midpntHght, 
+  constF, dryWeight, fricAngle, fs, genericF, genericA, 
+  intNormForce, indxn, inx, inxi, inxiM1, midpntHght, 
   mobShrC, normStress, normToShear, satWeight, scalFunc, shrResC, slcWght, 
   slipDist, slipHght, slopeDist, slopeHght, surfAngle, surfHydroForce, surfLngth, ufixme1, ufixme2, waterHght, waterWeight, watrForce)
 
@@ -26,7 +27,7 @@ import Drasil.SSP.Unitals (baseAngle, baseHydroForce, baseLngth, baseWthX,
 
 dataDefns :: [DataDefinition]
 dataDefns = [sliceWght, baseWtrF, surfWtrF, intersliceWtrF, angleA, angleB, 
-  lengthB, lengthLb, lengthLs, slcHeight, stressDD,
+  lengthB, lengthLb, lengthLs, slcHeight, stressDD, ratioVariation,
   convertFunc1, convertFunc2, fixme1, fixme2]
 
 --DD1
@@ -200,6 +201,22 @@ stressQD = mkQuantDef normStress stressEqn
 
 stressEqn :: Expr
 stressEqn = (sy genericF) / (sy genericA)
+
+--DD12
+
+ratioVariation :: DataDefinition
+ratioVariation = mkDD ratioVarQD [fredlund1977] [{-Derivation-}] 
+  "ratioVariation" []
+
+ratioVarQD :: QDefinition
+ratioVarQD = mkQuantDef scalFunc ratioVarEqn
+
+ratioVarEqn :: Expr
+ratioVarEqn = case_ [case1, case2]
+  where case1 = (1, (sy constF))
+
+        case2 = (sin ((sy QM.pi_) * (((inxi slipDist) - (idx (sy slipDist) 0)) /
+                ((indxn slipDist) - (idx (sy slipDist) 0)))), UnaryOp Not (sy constF))
 
 --DD13
 

--- a/code/drasil-example/Drasil/SSP/Unitals.hs
+++ b/code/drasil-example/Drasil/SSP/Unitals.hs
@@ -320,7 +320,8 @@ constF, earthqkLoadFctr, normToShear, scalFunc, numbSlices,
   minFunction, index, varblU, varblV, ufixme1, ufixme2 :: DefinedQuantityDict
 
 constF = dqd' (dcc "const_f" (nounPhraseSP $ "decision on f") 
-  ("boolean that determines the form of f: constant if true, or a half-sine if false")) (const (Atomic "const_f")) Boolean Nothing
+  ("boolean decision on which form of f the user desires: constant if true," ++
+  " or half-sine if false")) (const (Atomic "const_f")) Boolean Nothing
 
 earthqkLoadFctr = dqd' (dcc "K_c" (nounPhraseSP $ "earthquake load factor")
   ("proportionality factor of force that " ++
@@ -331,7 +332,8 @@ normToShear = dqd' (dcc "lambda"
   (nounPhraseSP $ "interslice normal/shear force ratio")
   ("applied to all interslices")) (const lLambda) Real Nothing
 
-scalFunc = dqd' (dcc "f_i" (nounPhraseSP $ "scaling function")
+scalFunc = dqd' (dcc "f_i" (nounPhraseSP $ "interslice normal to shear " ++
+  "force ratio variation function")
   ("magnitude of interslice forces as a function " ++
   "of the x coordinate" ++ fisi ++ "; can be constant or a half-sine"))
   (const lF) Real Nothing 

--- a/code/stable/ssp/SRS/SSP_SRS.tex
+++ b/code/stable/ssp/SRS/SSP_SRS.tex
@@ -71,7 +71,9 @@ ${C2_{i}}$ & Interslice Shear Force Function: the shear force at the interslice 
 \\
 $c'$ & Effective Cohesion: internal pressure that sticks particles of soil together & Pa
 \\
-$f$ & Scaling Function: magnitude of interslice forces as a function of the x coordinatefor interslice index i; can be constant or a half-sine & --
+$const_f$ & Decision on F: boolean decision on which form of f the user desires: constant if true, or half-sine if false & --
+\\
+$f$ & Interslice Normal to Shear Force Ratio Variation Function: magnitude of interslice forces as a function of the x coordinatefor interslice index i; can be constant or a half-sine & --
 \\
 ${F_{S}}$ & Factor of Safety: The global stability of a surface in a slope & --
 \\
@@ -158,6 +160,8 @@ ${γ_{w}}$ & Unit Weight of Water: The weight of one cubic meter of water. & $\f
 $λ$ & Interslice Normal/shear Force Ratio: applied to all interslices & --
 \\
 $μ$ & Pore Pressure: from water within the soil & Pa
+\\
+$π$ & Circumference to Diameter Ratio: The ratio of a circle's circumference to its diameter & --
 \\
 $σ$ & Normal Stress: The stress exerted perpendicular to the plane of the object & Pa
 \\
@@ -682,7 +686,7 @@ Label & Interslice normal/shear relationship
                    Description & \begin{symbDescription}
                                  \item{$X$ is the interslice shear force (N)}
                                  \item{$λ$ is the interslice normal/shear force ratio (Unitless)}
-                                 \item{$f$ is the scaling function (Unitless)}
+                                 \item{$f$ is the interslice normal to shear force ratio variation function (Unitless)}
                                  \item{$G$ is the interslice normal force (N)}
                                  \end{symbDescription}
                                  \\ \midrule \\
@@ -1091,6 +1095,40 @@ Label & Normal stress
 ~\newline
  \noindent \begin{minipage}{\textwidth}
 \begin{tabular}{p{0.2\textwidth} p{0.73\textwidth}}
+\toprule \textbf{Refname} & \textbf{DD:ratioVariation}
+\phantomsection 
+\label{DD:ratioVariation}
+\\ \midrule \\
+Label & Interslice normal to shear force ratio variation function
+        \\ \midrule \\
+        Symbol & $f$
+                 \\ \midrule \\
+                 Units & Unitless
+                         \\ \midrule \\
+                         Equation & \begin{dmath}
+                                    f=\begin{cases}
+1, & const_f\\
+\sin\left(π \frac{{x_{slip,i}}-{x_{slip,0}}}{{x_{slip,n}}-{x_{slip,0}}}\right), & \neg{}const_f
+\end{cases}
+                                    \end{dmath}
+                                    \\ \midrule \\
+                                    Description & \begin{symbDescription}
+                                                  \item{$f$ is the interslice normal to shear force ratio variation function (Unitless)}
+                                                  \item{$π$ is the circumference to diameter ratio (Unitless)}
+                                                  \item{${x_{slip}}$ is the x ordinate (m)}
+                                                  \item{$i$ is the index (Unitless)}
+                                                  \item{$n$ is the number of slices (Unitless)}
+                                                  \item{$const_f$ is the decision on f (Unitless)}
+                                                  \end{symbDescription}
+                                                  \\ \midrule \\
+                                                  Source & \cite{fredlund1977}
+                                                           \\ \midrule \\
+                                                           RefBy & 
+\\ \bottomrule \end{tabular}
+\end{minipage}\\
+~\newline
+ \noindent \begin{minipage}{\textwidth}
+\begin{tabular}{p{0.2\textwidth} p{0.73\textwidth}}
 \toprule \textbf{Refname} & \textbf{DD:convertFunc1}
 \phantomsection 
 \label{DD:convertFunc1}
@@ -1108,7 +1146,7 @@ Label & First function for incorporating interslice forces into shear force
                                     Description & \begin{symbDescription}
                                                   \item{$Φ$ is the first function for incorporating interslice forces into shear force (N)}
                                                   \item{$λ$ is the interslice normal/shear force ratio (Unitless)}
-                                                  \item{$f$ is the scaling function (Unitless)}
+                                                  \item{$f$ is the interslice normal to shear force ratio variation function (Unitless)}
                                                   \item{$i$ is the index (Unitless)}
                                                   \item{$α$ is the angle (${}^{\circ}$)}
                                                   \item{$φ'$ is the effective angle of friction (${}^{\circ}$)}
@@ -1140,7 +1178,7 @@ Label & Second function for incorporating interslice forces into shear force
                                     Description & \begin{symbDescription}
                                                   \item{$Ψ$ is the second function for incorporating interslice forces into shear force (N)}
                                                   \item{$λ$ is the interslice normal/shear force ratio (Unitless)}
-                                                  \item{$f$ is the scaling function (Unitless)}
+                                                  \item{$f$ is the interslice normal to shear force ratio variation function (Unitless)}
                                                   \item{$i$ is the index (Unitless)}
                                                   \item{$α$ is the angle (${}^{\circ}$)}
                                                   \item{$φ'$ is the effective angle of friction (${}^{\circ}$)}
@@ -1389,7 +1427,7 @@ b_{n} G_{n-1} H_{n-1}, & i=1
                                                                                            \item{$ω$ is the angle (${}^{\circ}$)}
                                                                                            \item{$n$ is the number of slices (Unitless)}
                                                                                            \item{${C2_{i}}$ is the interslice shear force function (Nm)}
-                                                                                           \item{$f$ is the scaling function (Unitless)}
+                                                                                           \item{$f$ is the interslice normal to shear force ratio variation function (Unitless)}
                                                                                            \item{$λ$ is the interslice normal/shear force ratio (Unitless)}
                                                                                            \end{symbDescription}
                                                                                            \\ \midrule \\
@@ -1659,7 +1697,7 @@ pages={"272-278"}}
 @inproceedings{smithLai2005,
 author={Smith, W. Spencer and Lai, Lei},
 title={A new requirements template for scientific computing},
-booktitle={Proceedings of the First International Workshop onSituational Requirements Engineering Processes - Methods,Techniques and Tools to Support Situation-Specific RequirementsEngineering Processes, SREP'05},
+booktitle={Proceedings of the First International Workshop on Situational Requirements Engineering Processes - Methods, Techniques and Tools to Support Situation-Specific Requirements Engineering Processes, SREP'05},
 year={2005},
 editor={Agerfalk, PJ and Kraiem, N. and Ralyte, J.},
 address={Paris, France},

--- a/code/stable/ssp/Website/SSP_SRS.html
+++ b/code/stable/ssp/Website/SSP_SRS.html
@@ -170,10 +170,21 @@ Pa
 </tr>
 <tr>
 <td>
+<em>const_f</em>
+</td>
+<td>
+Decision on F: boolean decision on which form of f the user desires: constant if true, or half-sine if false
+</td>
+<td>
+--
+</td>
+</tr>
+<tr>
+<td>
 <em>f</em>
 </td>
 <td>
-Scaling Function: magnitude of interslice forces as a function of the x coordinatefor interslice index i; can be constant or a half-sine
+Interslice Normal to Shear Force Ratio Variation Function: magnitude of interslice forces as a function of the x coordinatefor interslice index i; can be constant or a half-sine
 </td>
 <td>
 --
@@ -650,6 +661,17 @@ Pore Pressure: from water within the soil
 </td>
 <td>
 Pa
+</td>
+</tr>
+<tr>
+<td>
+<em>π</em>
+</td>
+<td>
+Circumference to Diameter Ratio: The ratio of a circle's circumference to its diameter
+</td>
+<td>
+--
 </td>
 </tr>
 <tr>
@@ -2143,7 +2165,7 @@ Description
 <em>λ</em> is the interslice normal/shear force ratio (Unitless)
 </li>
 <li>
-<em>f</em> is the scaling function (Unitless)
+<em>f</em> is the interslice normal to shear force ratio variation function (Unitless)
 </li>
 <li>
 <em>G</em> is the interslice normal force (N)
@@ -3477,6 +3499,118 @@ RefBy
 </tr>
 </table>
 </div>
+<div id="DD:ratioVariation">
+<table class="ddefn">
+<tr>
+<th>
+Label
+</th>
+<td>
+<p class="paragraph">
+Interslice normal to shear force ratio variation function
+</p>
+</td>
+</tr>
+<tr>
+<th>
+Symbol
+</th>
+<td>
+<p class="paragraph">
+<em>f</em>
+</p>
+</td>
+</tr>
+<tr>
+<th>
+Units
+</th>
+<td>
+<p class="paragraph">
+Unitless
+</p>
+</td>
+</tr>
+<tr>
+<th>
+Equation
+</th>
+<td>
+<div class="equation">
+<em>f = <span class="casebr">
+{
+</span>
+<div class="cases">
+<span>
+1 , <span class="case">
+const_f
+</span>
+</span>
+<span>
+sin(π&#8239;<div class="fraction">
+<span class="fup">
+x<sub>slip,i</sub>&minus;x<sub>slip,0</sub>
+</span>
+<span class="fdn">
+x<sub>slip,n</sub>&minus;x<sub>slip,0</sub>
+</span>
+</div>) , <span class="case">
+&not;const_f
+</span>
+</span>
+</div></em>
+</div>
+</td>
+</tr>
+<tr>
+<th>
+Description
+</th>
+<td>
+<ul class="hide-list-style-no-indent">
+<li>
+<em>f</em> is the interslice normal to shear force ratio variation function (Unitless)
+</li>
+<li>
+<em>π</em> is the circumference to diameter ratio (Unitless)
+</li>
+<li>
+<em>x<sub>slip</sub></em> is the x ordinate (m)
+</li>
+<li>
+<em>i</em> is the index (Unitless)
+</li>
+<li>
+<em>n</em> is the number of slices (Unitless)
+</li>
+<li>
+<em>const_f</em> is the decision on f (Unitless)
+</li>
+</ul>
+</td>
+</tr>
+<tr>
+<th>
+Source
+</th>
+<td>
+<p class="paragraph">
+<a href=#fredlund1977>fredlund1977</a>
+</p>
+</td>
+</tr>
+<tr>
+<th>
+RefBy
+</th>
+<td>
+<p class="paragraph">
+
+</p>
+</td>
+</tr>
+</table>
+</div>
 <div id="DD:convertFunc1">
 <table class="ddefn">
 <tr>
@@ -3532,7 +3666,7 @@ Description
 <em>λ</em> is the interslice normal/shear force ratio (Unitless)
 </li>
 <li>
-<em>f</em> is the scaling function (Unitless)
+<em>f</em> is the interslice normal to shear force ratio variation function (Unitless)
 </li>
 <li>
 <em>i</em> is the index (Unitless)
@@ -3633,7 +3767,7 @@ Description
 <em>λ</em> is the interslice normal/shear force ratio (Unitless)
 </li>
 <li>
-<em>f</em> is the scaling function (Unitless)
+<em>f</em> is the interslice normal to shear force ratio variation function (Unitless)
 </li>
 <li>
 <em>i</em> is the index (Unitless)
@@ -4337,7 +4471,7 @@ Description
 <em>C2<sub>i</sub></em> is the interslice shear force function (N&sdot;m)
 </li>
 <li>
-<em>f</em> is the scaling function (Unitless)
+<em>f</em> is the interslice normal to shear force ratio variation function (Unitless)
 </li>
 <li>
 <em>λ</em> is the interslice normal/shear force ratio (Unitless)
@@ -5193,7 +5327,7 @@ References
 </li>
 <li>
 <div id="smithLai2005">
-[7]: Smith, W. Spencer and Lai, Lei. "A new requirements template for scientific computing." <em>Proceedings of the First International Workshop onSituational Requirements Engineering Processes - Methods,Techniques and Tools to Support Situation-Specific RequirementsEngineering Processes, SREP'05</em>. Edited by PJ Agerfalk, N. Kraiem, and J. Ralyte, Paris, France: 2005. pp. 107&ndash;121. In conjunction with 13th IEEE International Requirements Engineering Conference,
+[7]: Smith, W. Spencer and Lai, Lei. "A new requirements template for scientific computing." <em>Proceedings of the First International Workshop on Situational Requirements Engineering Processes - Methods, Techniques and Tools to Support Situation-Specific Requirements Engineering Processes, SREP'05</em>. Edited by PJ Agerfalk, N. Kraiem, and J. Ralyte, Paris, France: 2005. pp. 107&ndash;121. In conjunction with 13th IEEE International Requirements Engineering Conference,
 </div>
 </li>
 <li>


### PR DESCRIPTION
This pull request:

- adds a DD to the SSP example for the interslice force ratio variation function
- changes pi_ to a `DefinedQuantityDict` so that it can be used in said DD
- fixes the small bug where spaces were removed from a citation which accidentally got merged before