### PR TITLE
Refactor Package Build Targets 

### DIFF
--- a/code/Makefile
+++ b/code/Makefile
@@ -12,13 +12,15 @@ SWHS_DIR  = SWHS
 SSP_DIR   = SSP
 GAME_DIR  = Chipmunk
 
-LANG_DIR  = drasil-lang
-CODE_DIR  = drasil-code
-PRINT_DIR = drasil-printers
-GEN_DIR   = drasil-gen
-DATA_DIR  = drasil-data
-DOCL_DIR  = drasil-docLang
-EXAM_DIR  = drasil-example
+PACKAGES = lang code printers gen data docLang example
+
+LANG_DEPS =
+CODE_DEPS = lang
+PRINTERS_DEPS = lang
+GEN_DEPS = lang code printers
+DATA_DEPS = lang
+DOCLANG_DEPS = lang data
+EXAMPLE_DEPS = lang data docLang gen printers code
 
 TINY_EXE  = tiny
 GLASS_EXE = glassbr
@@ -27,7 +29,7 @@ SWHS_EXE  = swhs
 SSP_EXE   = ssp
 GAME_EXE  = chipmunkdocs
 
-DIRS = $(TINY_DIR) $(GLASS_DIR) $(NoPCM_DIR) $(SWHS_DIR) $(SSP_DIR) $(GAME_DIR) $(DATA_DIR) $(LANG_DIR) $(DOCL_DIR) $(EXAM_DIR) $(CODE_DIR) $(GEN_DIR) $(PRINT_DIR)
+DIRS = $(TINY_DIR) $(GLASS_DIR) $(NoPCM_DIR) $(SWHS_DIR) $(SSP_DIR) $(GAME_DIR) $(addprefix drasil-,$(PACKAGES))
 DIFF = diff --strip-trailing-cr --ignore-all-space
 
 TESTS = tiny_diff glassbr_diff nopcm_diff swhs_diff ssp_diff gamephys_diff
@@ -38,7 +40,7 @@ PROFEXEC = +RTS -xc -P
 
 NOISY=no
 
-all: build build_code build_data test
+all: test
 
 test: $(PROGS) $(TESTS)
 	@echo ----------------------------
@@ -54,28 +56,18 @@ debug: stackArgs+=$(PROFALL)
 debug: EXECARGS+=$(PROFEXEC) 
 debug: test
 
-build: FORCE
-	stack install -j2 $(stackArgs) drasil-lang
+build_lang_deps: $(addprefix build_, $(LANG_DEPS))
+build_data_deps: $(addprefix build_, $(DATA_DEPS))
+build_code_deps: $(addprefix build_, $(CODE_DEPS))
+build_printers_deps: $(addprefix build_, $(PRINTERS_DEPS))
+build_gen_deps: $(addprefix build_, $(GEN_DEPS))
+build_docLang_deps: $(addprefix build_, $(DOCLANG_DEPS))
+build_example_deps: $(addprefix build_, $(EXAMPLE_DEPS))
 
-build_code: build
-	stack install -j2 $(stackArgs) drasil-code
+build_%: FORCE build_%_deps
+	stack install --ghc-options -j2 $(stackArgs) drasil-$*
 
-build_print: build_code
-	stack install -j2 $(stackArgs) drasil-printers
-
-build_gen: build_print
-	stack install -j2 $(stackArgs) drasil-gen
-
-build_data: build_gen
-	stack install -j2 $(stackArgs) drasil-data
-
-build_docl: build_data
-	stack install -j2 $(stackArgs) drasil-docLang
-
-build_exam: build_docl
-	stack install -j2 $(stackArgs) drasil-example
-
-tiny_build: build_exam
+tiny_build: build_example
 	mkdir -p build/$(TINY_DIR)
 	cd build/$(TINY_DIR) && stack exec -- $(TINY_EXE) $(EXECARGS)
 


### PR DESCRIPTION
Welcome to the first Drasil “Choose Your Own Adventure!”

It’s late, you’re building Drasil. You notice compile times are long when building from scratch. You open your favourite editor and load `Makefile`. What’s this? You notice the package building targets are chained after one another. Oh no! But from the cabal files, you know `drasil-data`, `drasil-printers`, and `drasil-code` only depend on `drasil-lang` and could all be built simultaneously. No time like the present to fix this! But where to go? Where to go?

The Stack docs: #1107
You know Makefiles (probably): This PR

You know Makefiles. You don’t need to rely on Stack to figure out dependencies for you. You can do that yourself! You quickly change the Makefile to pattern match on which module it is building and pull the dependencies, matching the ones listed in the cabal file. You run `make` in your terminal. You see everything still works. You re-run make, but this time adding `-j2`. You see the fruits of your labour, both files from `drasil-data` and `drasil-code` are interleaved. 

That’s odd though, you spot that, while packages are building concurrently, independent files within packages aren’t! You dive into the GHC docs. Quickly you locate that GHC *ALSO* supports `-jX` commands, but only in `--make` mode. You `grep` the output and notice Stack is running GHC with `--make` and it is not passing a `-jX` argument. A-ha! You add `--ghc-options -j2` to the `stack install` command and run `make` one more time. Perfect! You can observe multiple `ghc` instances running within the package! You see from a quick doc check that a plain `-jX` to `stack` allows Stack to build multiple packages concurrently. Bah! You don’t need that! You have the power of make to do that for you! You remove the non-ghc-option `-j2` from `stack install`.

You decide with these multiple `-jX` flags that you should test to see which combinations result in the best build time. Of course the `-jX` passed to make is user configurable and won’t make a difference in your commit. But you will know, and that’s all that matters. You record the build times of the unaltered `Makefile` and combinations formatted as AxB with the command `stack clean --force-dirty && time make -jA` where B is the value passed to `--ghc-options` in the `Makefile`. You record the combinations:

```
Original: 2m28.370s
M1x1:     2m21.717s
M2x1:     1m54.152s
M3x1:     1m55.136s
M1x2:     2m01.516s
M2x2:     1m38.894s
M3x2:     1m56.999s
```

That’s enough combinations for now. You decide that `--ghc-options -j2` is the better combination and that passing `-j2` to make minimized the time spent building. You’re tired. You commit your changes and call it a night.