### PR TITLE
Refactor Package Targets Using Stack

### DIFF
--- a/code/Makefile
+++ b/code/Makefile
@@ -12,13 +12,7 @@ SWHS_DIR  = SWHS
 SSP_DIR   = SSP
 GAME_DIR  = Chipmunk
 
-LANG_DIR  = drasil-lang
-CODE_DIR  = drasil-code
-PRINT_DIR = drasil-printers
-GEN_DIR   = drasil-gen
-DATA_DIR  = drasil-data
-DOCL_DIR  = drasil-docLang
-EXAM_DIR  = drasil-example
+PACKAGES = lang code printers gen data docLang example
 
 TINY_EXE  = tiny
 GLASS_EXE = glassbr
@@ -27,7 +21,7 @@ SWHS_EXE  = swhs
 SSP_EXE   = ssp
 GAME_EXE  = chipmunkdocs
 
-DIRS = $(TINY_DIR) $(GLASS_DIR) $(NoPCM_DIR) $(SWHS_DIR) $(SSP_DIR) $(GAME_DIR) $(DATA_DIR) $(LANG_DIR) $(DOCL_DIR) $(EXAM_DIR) $(CODE_DIR) $(GEN_DIR) $(PRINT_DIR)
+DIRS = $(TINY_DIR) $(GLASS_DIR) $(NoPCM_DIR) $(SWHS_DIR) $(SSP_DIR) $(GAME_DIR) $(addprefix drasil-,$(PACKAGES))
 DIFF = diff --strip-trailing-cr --ignore-all-space
 
 TESTS = tiny_diff glassbr_diff nopcm_diff swhs_diff ssp_diff gamephys_diff
@@ -38,7 +32,7 @@ PROFEXEC = +RTS -xc -P
 
 NOISY=no
 
-all: build build_code build_data test
+all: test
 
 test: $(PROGS) $(TESTS)
 	@echo ----------------------------
@@ -54,28 +48,10 @@ debug: stackArgs+=$(PROFALL)
 debug: EXECARGS+=$(PROFEXEC) 
 debug: test
 
-build: FORCE
-	stack install -j2 $(stackArgs) drasil-lang
+build_example: FORCE
+	stack install -j3 --ghc-options -j2 $(stackArgs) drasil-example --dump-logs --interleaved-output
 
-build_code: build
-	stack install -j2 $(stackArgs) drasil-code
-
-build_print: build_code
-	stack install -j2 $(stackArgs) drasil-printers
-
-build_gen: build_print
-	stack install -j2 $(stackArgs) drasil-gen
-
-build_data: build_gen
-	stack install -j2 $(stackArgs) drasil-data
-
-build_docl: build_data
-	stack install -j2 $(stackArgs) drasil-docLang
-
-build_exam: build_docl
-	stack install -j2 $(stackArgs) drasil-example
-
-tiny_build: build_exam
+tiny_build: build_example
 	mkdir -p build/$(TINY_DIR)
 	cd build/$(TINY_DIR) && stack exec -- $(TINY_EXE) $(EXECARGS)
 


### PR DESCRIPTION
Welcome to the first Drasil “Choose Your Own Adventure!”

It’s late, you’re building Drasil. You notice compile times are long when building from scratch. You open your favourite editor and load `Makefile`. What’s this? You notice the package building targets are chained after one another. Oh no! But from the cabal files, you know `drasil-data`, `drasil-printers`, and `drasil-code` only depend on `drasil-lang` and could all be built simultaneously. No time like the present to fix this! But where to go? Where to go?

The Stack docs: This PR
You know Makefiles (probably): #1106

You dive into the Stack docs looking around to see if there’s any way to build all dependencies of a package. After some searching. You find it! Turns out that’s always the case. You edit the Makefile and type `make` into your terminal. The horror! The dependent packages build quietly. This will never do!

After some more combing of the docs you discover the quietness of Stack when building dependent packages is only a default, the `--dump-logs` command exists. It also mentions how --interleaved-output` will prefix the lines with the package being built. What a splendid discovery! After all `-j2` is being passed to `stack install`.

After running `make` again, you see everything is working wonderfully! Everything is building, you even see some command output that `drasil-data` is building at the same time as `drasil-printers`. Great! You try upping the count to `-j3` and see if you can see all three building simultaneously. And sure enough, you do! 

That’s odd though, you spot that, while packages are building concurrently, independent files within packages aren’t! You dive into the GHC docs. Quickly you locate that GHC *ALSO* supports `-jX` commands, but only in `--make` mode. You `grep` the output and notice Stack is running GHC with `--make` and it is not passing a `-jX` argument. A-ha! You add --ghc-options -j2` to the `stack install` command and run `make` one more time. Perfect! You can observe multiple `ghc` instances running within the package!

You do your due diligence to determine what is the best number for `-jX` in ghc options, just to be certain. You boot up a new terminal window and proceed to run the original Makefile, the modified Makefile with just `-j3`, the modified Makefile with `-j3 --ghc-options -j2`, and `-j3 --ghc-options -j4` using the command sequence `stack clean --force-dirty && time make`. Of course it is quite late, so you only run it once for each test. You record the results of the tests as follows:

```
Original:   2m28.370s
Modified:   2m03.998s
M -j2:      1m45.671s
M -j4:      1m51.599s
```

With that you conclude the modified Makefile with `--ghc-options -j2` is the best value. You commit your change and call it a night.

(PS. I think this one is cleaner. And probably the better candidate. I can add the targets back for the other packages similar to the other PR, but have them all use the same Stack args to support building individual packages instead of always forcing examples to be built through make.) 