### PR TITLE
Fix Stable

### DIFF
--- a/code/stable/ssp/SRS/SSP_SRS.tex
+++ b/code/stable/ssp/SRS/SSP_SRS.tex
@@ -613,9 +613,9 @@ Label & Mobile shear force
 \\ \midrule \\
 Label & Effective normal force
         \\ \midrule \\
-        Equation & \begin{dmath}
+        Equation & \begin{displaymath}
                    {N'}_{i}=N_{i}-{U_{b,i}}
-                   \end{dmath}
+                   \end{displaymath}
                    \\ \midrule \\
                    Description & \begin{symbDescription}
                                  \item{$N'$ is the effective normal force (N)}


### PR DESCRIPTION
This PR fixes a "merge miss" between the last SSP merge (#1111) and the merge of Building TeX (#1114) where a new `dmath` was introduced to SSP and not changed to `displaymath`.