### PR TITLE
Fix a few underfull {h,v}boxs

### DIFF
--- a/code/drasil-printers/Language/Drasil/TeX/Helpers.hs
+++ b/code/drasil-printers/Language/Drasil/TeX/Helpers.hs
@@ -139,7 +139,7 @@ item' bull s = command1oD "item" (Just bull) s
 maketitle, maketoc, newline, newpage, centering :: D
 maketitle = command0 "maketitle"
 maketoc   = command0 "tableofcontents"
-newline   = command0 "newline"
+newline   = command0 "par" <> pure (text "~\n")
 newpage   = command0 "newpage"
 centering = command0 "centering"
 

--- a/code/drasil-printers/Language/Drasil/TeX/Print.hs
+++ b/code/drasil-printers/Language/Drasil/TeX/Print.hs
@@ -205,6 +205,7 @@ makeTable lls r bool t =
   %% (pure (text "\\toprule"))
   %% makeRows [head lls]
   %% (pure (text "\\midrule"))
+  %% pure (text "\\endhead")
   %% makeRows (tail lls)
   %% (pure (text "\\bottomrule"))
   %% (if bool then caption t else empty)
@@ -329,11 +330,11 @@ makeDefn _  [] _ = error "Empty definition"
 makeDefn sm ps l = beginDefn %% makeDefTable sm ps l %% endDefn
 
 beginDefn :: D
-beginDefn = (pure $ text "~") <> newline
-  %% (pure $ text "\\noindent \\begin{minipage}{\\textwidth}")
+beginDefn = newline
+  %% pure (text "\\noindent \\begin{minipage}{\\textwidth}")
 
 endDefn :: D
-endDefn = pure $ text "\\end{minipage}" TP.<> dbs
+endDefn = pure (text "\\end{minipage}")
 
 makeDefTable :: (L.HasSymbolTable s, L.HasTermTable s, L.HasDefinitionTable s,
  HasPrintingOptions s) => s -> [(String,[LayoutObj])] -> D -> D

--- a/code/stable/gamephys/SRS/Chipmunk_SRS.tex
+++ b/code/stable/gamephys/SRS/Chipmunk_SRS.tex
@@ -40,6 +40,7 @@ The unit system used throughout is SI (Système International d'Unités). In add
 Symbol & Description
 \\
 \midrule
+\endhead
 kg & mass (kilogram)
 \\
 m & length (metre)
@@ -61,6 +62,7 @@ The table that follows summarizes the symbols used in this document along with t
 Symbol & Description & Units
 \\
 \midrule
+\endhead
 $\mathbf{a}$ & Acceleration & $\frac{\text{m}}{\text{s}^{2}}$
 \\
 ${\mathbf{a}_{i}}$ & The I-Th Body's Acceleration & $\frac{\text{m}}{\text{s}^{2}}$
@@ -171,6 +173,7 @@ $ϕ$ & Orientation & rad
 Abbreviation & Full Form
 \\
 \midrule
+\endhead
 2D & Two-Dimensional
 \\
 A & Assumption
@@ -309,8 +312,9 @@ This section simplifies the original problem and helps in developing the theoret
 \subsubsection{Theoretical Models}
 \label{Sec:TMs}
 This section focuses on the general equations and laws that Chipmunk2D is based on.
-~\newline
- \noindent \begin{minipage}{\textwidth}
+\par~
+    
+\noindent \begin{minipage}{\textwidth}
 \begin{tabular}{p{0.2\textwidth} p{0.73\textwidth}}
 \toprule \textbf{Refname} & \textbf{TM:NewtonSecLawMot}
 \phantomsection 
@@ -333,9 +337,10 @@ Label & Newton's second law of motion
                                          Source & \\ \midrule \\
                                                   RefBy & 
 \\ \bottomrule \end{tabular}
-\end{minipage}\\
-~\newline
- \noindent \begin{minipage}{\textwidth}
+\end{minipage}
+\par~
+    
+\noindent \begin{minipage}{\textwidth}
 \begin{tabular}{p{0.2\textwidth} p{0.73\textwidth}}
 \toprule \textbf{Refname} & \textbf{TM:NewtonThirdLawMot}
 \phantomsection 
@@ -357,9 +362,10 @@ Label & Newton's third law of motion
                                          Source & \\ \midrule \\
                                                   RefBy & 
 \\ \bottomrule \end{tabular}
-\end{minipage}\\
-~\newline
- \noindent \begin{minipage}{\textwidth}
+\end{minipage}
+\par~
+    
+\noindent \begin{minipage}{\textwidth}
 \begin{tabular}{p{0.2\textwidth} p{0.73\textwidth}}
 \toprule \textbf{Refname} & \textbf{TM:UniversalGravLaw}
 \phantomsection 
@@ -386,9 +392,10 @@ Label & Newton's law of universal gravitation
                                          Source & \\ \midrule \\
                                                   RefBy & 
 \\ \bottomrule \end{tabular}
-\end{minipage}\\
-~\newline
- \noindent \begin{minipage}{\textwidth}
+\end{minipage}
+\par~
+    
+\noindent \begin{minipage}{\textwidth}
 \begin{tabular}{p{0.2\textwidth} p{0.73\textwidth}}
 \toprule \textbf{Refname} & \textbf{TM:ChaslesThm}
 \phantomsection 
@@ -412,9 +419,10 @@ Label & Chasles' theorem
                                          Source & \\ \midrule \\
                                                   RefBy & 
 \\ \bottomrule \end{tabular}
-\end{minipage}\\
-~\newline
- \noindent \begin{minipage}{\textwidth}
+\end{minipage}
+\par~
+    
+\noindent \begin{minipage}{\textwidth}
 \begin{tabular}{p{0.2\textwidth} p{0.73\textwidth}}
 \toprule \textbf{Refname} & \textbf{TM:NewtonSecLawRotMot}
 \phantomsection 
@@ -437,15 +445,16 @@ Label & Newton's second law for rotational motion
                                          Source & \\ \midrule \\
                                                   RefBy & 
 \\ \bottomrule \end{tabular}
-\end{minipage}\\
+\end{minipage}
 \subsubsection{General Definitions}
 \label{Sec:GDs}
 There are no general definitions.
 \subsubsection{Data Definitions}
 \label{Sec:DDs}
 This section collects and defines all the data needed to build the instance models.
-~\newline
- \noindent \begin{minipage}{\textwidth}
+\par~
+    
+\noindent \begin{minipage}{\textwidth}
 \begin{tabular}{p{0.2\textwidth} p{0.73\textwidth}}
 \toprule \textbf{Refname} & \textbf{DD:ctrOfMass}
 \phantomsection 
@@ -474,9 +483,10 @@ Label & Center of Mass
                                                           Source & \\ \midrule \\
                                                                    RefBy & \hyperref[IM:transMot]{IM: transMot} \hyperref[IM:col2D]{IM: col2D}.
 \\ \bottomrule \end{tabular}
-\end{minipage}\\
-~\newline
- \noindent \begin{minipage}{\textwidth}
+\end{minipage}
+\par~
+    
+\noindent \begin{minipage}{\textwidth}
 \begin{tabular}{p{0.2\textwidth} p{0.73\textwidth}}
 \toprule \textbf{Refname} & \textbf{DD:linDisp}
 \phantomsection 
@@ -505,9 +515,10 @@ Label & Linear Displacement
                                                           Source & \\ \midrule \\
                                                                    RefBy & \hyperref[IM:transMot]{IM: transMot}.
 \\ \bottomrule \end{tabular}
-\end{minipage}\\
-~\newline
- \noindent \begin{minipage}{\textwidth}
+\end{minipage}
+\par~
+    
+\noindent \begin{minipage}{\textwidth}
 \begin{tabular}{p{0.2\textwidth} p{0.73\textwidth}}
 \toprule \textbf{Refname} & \textbf{DD:linVel}
 \phantomsection 
@@ -536,9 +547,10 @@ Label & Linear Velocity
                                                           Source & \\ \midrule \\
                                                                    RefBy & \hyperref[IM:transMot]{IM: transMot}.
 \\ \bottomrule \end{tabular}
-\end{minipage}\\
-~\newline
- \noindent \begin{minipage}{\textwidth}
+\end{minipage}
+\par~
+    
+\noindent \begin{minipage}{\textwidth}
 \begin{tabular}{p{0.2\textwidth} p{0.73\textwidth}}
 \toprule \textbf{Refname} & \textbf{DD:linAcc}
 \phantomsection 
@@ -567,9 +579,10 @@ Label & Linear Acceleration
                                                           Source & \\ \midrule \\
                                                                    RefBy & \hyperref[IM:transMot]{IM: transMot}.
 \\ \bottomrule \end{tabular}
-\end{minipage}\\
-~\newline
- \noindent \begin{minipage}{\textwidth}
+\end{minipage}
+\par~
+    
+\noindent \begin{minipage}{\textwidth}
 \begin{tabular}{p{0.2\textwidth} p{0.73\textwidth}}
 \toprule \textbf{Refname} & \textbf{DD:angDisp}
 \phantomsection 
@@ -598,9 +611,10 @@ Label & Angular Displacement
                                                           Source & \\ \midrule \\
                                                                    RefBy & \hyperref[IM:rotMot]{IM: rotMot}.
 \\ \bottomrule \end{tabular}
-\end{minipage}\\
-~\newline
- \noindent \begin{minipage}{\textwidth}
+\end{minipage}
+\par~
+    
+\noindent \begin{minipage}{\textwidth}
 \begin{tabular}{p{0.2\textwidth} p{0.73\textwidth}}
 \toprule \textbf{Refname} & \textbf{DD:angVel}
 \phantomsection 
@@ -629,9 +643,10 @@ Label & Angular Velocity
                                                           Source & \\ \midrule \\
                                                                    RefBy & \hyperref[IM:rotMot]{IM: rotMot}.
 \\ \bottomrule \end{tabular}
-\end{minipage}\\
-~\newline
- \noindent \begin{minipage}{\textwidth}
+\end{minipage}
+\par~
+    
+\noindent \begin{minipage}{\textwidth}
 \begin{tabular}{p{0.2\textwidth} p{0.73\textwidth}}
 \toprule \textbf{Refname} & \textbf{DD:angAccel}
 \phantomsection 
@@ -660,9 +675,10 @@ Label & Angular Acceleration
                                                           Source & \\ \midrule \\
                                                                    RefBy & \hyperref[IM:rotMot]{IM: rotMot}.
 \\ \bottomrule \end{tabular}
-\end{minipage}\\
-~\newline
- \noindent \begin{minipage}{\textwidth}
+\end{minipage}
+\par~
+    
+\noindent \begin{minipage}{\textwidth}
 \begin{tabular}{p{0.2\textwidth} p{0.73\textwidth}}
 \toprule \textbf{Refname} & \textbf{DD:impulse}
 \phantomsection 
@@ -700,9 +716,10 @@ Label & Impulse (scalar)
                                                           Source & \\ \midrule \\
                                                                    RefBy & \hyperref[IM:col2D]{IM: col2D}.
 \\ \bottomrule \end{tabular}
-\end{minipage}\\
-~\newline
- \noindent \begin{minipage}{\textwidth}
+\end{minipage}
+\par~
+    
+\noindent \begin{minipage}{\textwidth}
 \begin{tabular}{p{0.2\textwidth} p{0.73\textwidth}}
 \toprule \textbf{Refname} & \textbf{DD:impulse}
 \phantomsection 
@@ -730,9 +747,10 @@ Label & Velocity At Point B
                                                           Source & \\ \midrule \\
                                                                    RefBy & 
 \\ \bottomrule \end{tabular}
-\end{minipage}\\
-~\newline
- \noindent \begin{minipage}{\textwidth}
+\end{minipage}
+\par~
+    
+\noindent \begin{minipage}{\textwidth}
 \begin{tabular}{p{0.2\textwidth} p{0.73\textwidth}}
 \toprule \textbf{Refname} & \textbf{DD:torque}
 \phantomsection 
@@ -759,12 +777,13 @@ Label & Torque
                                                           Source & \\ \midrule \\
                                                                    RefBy & 
 \\ \bottomrule \end{tabular}
-\end{minipage}\\
+\end{minipage}
 \subsubsection{Instance Models}
 \label{Sec:IMs}
 This section transforms the problem defined in \hyperref[Sec:ProbDesc]{Section: Problem Description} into one which is expressed in mathematical terms. It uses concrete symbols defined in \hyperref[Sec:DDs]{Section: Data Definitions} to replace the abstract symbols in the models identified in \hyperref[Sec:TMs]{Section: Theoretical Models} and \hyperref[Sec:GDs]{Section: General Definitions}.
-~\newline
- \noindent \begin{minipage}{\textwidth}
+\par~
+    
+\noindent \begin{minipage}{\textwidth}
 \begin{tabular}{p{0.2\textwidth} p{0.73\textwidth}}
 \toprule \textbf{Refname} & \textbf{IM:transMot}
 \phantomsection 
@@ -811,9 +830,10 @@ Label & Force on the translational motion of a set of 2d rigid bodies
                                                                                                    Source & \\ \midrule \\
                                                                                                             RefBy & 
 \\ \bottomrule \end{tabular}
-\end{minipage}\\
-~\newline
- \noindent \begin{minipage}{\textwidth}
+\end{minipage}
+\par~
+    
+\noindent \begin{minipage}{\textwidth}
 \begin{tabular}{p{0.2\textwidth} p{0.73\textwidth}}
 \toprule \textbf{Refname} & \textbf{IM:rotMot}
 \phantomsection 
@@ -859,9 +879,10 @@ Label & Force on the rotational motion of a set of 2D rigid body
                                                                                                    Source & \\ \midrule \\
                                                                                                             RefBy & 
 \\ \bottomrule \end{tabular}
-\end{minipage}\\
-~\newline
- \noindent \begin{minipage}{\textwidth}
+\end{minipage}
+\par~
+    
+\noindent \begin{minipage}{\textwidth}
 \begin{tabular}{p{0.2\textwidth} p{0.73\textwidth}}
 \toprule \textbf{Refname} & \textbf{IM:col2D}
 \phantomsection 
@@ -911,7 +932,7 @@ Label & Collisions on 2D rigid bodies
                                                                                                    Source & \\ \midrule \\
                                                                                                             RefBy & 
 \\ \bottomrule \end{tabular}
-\end{minipage}\\
+\end{minipage}
 \subsubsection{Data Constraints}
 \label{Sec:DataConstraints}
 \hyperref[Table:InDataConstraints]{Table:InDataConstraints} and \hyperref[Table:OutDataConstraints]{Table:OutDataConstraints} show the data constraints on the input and output variables, respectively. The column for physical constraints gives the physical limitations on the range of values that can be taken by the variable. The uncertainty column provides an estimate of the confidence with which the physical quantities can be measured. This information would be part of the input if one were performing an uncertainty quantification exercise. The constraints are conservative, to give the user of the model the flexibility to experiment with unusual situations. The column of typical values is intended to provide a feel for a common scenario. FIXME
@@ -920,6 +941,7 @@ Label & Collisions on 2D rigid bodies
 Var & Physical Constraints & Typical Value & Uncert.
 \\
 \midrule
+\endhead
 ${C_{R}}$ & $0\leq{}{C_{R}}\leq{}1$ & $800.0\cdot{}10^{-3}$ & 10.0$\%$
 \\
 $\mathbf{F}$ & -- & $98.1$ N & 10.0$\%$
@@ -951,6 +973,7 @@ $ϕ$ & -- & $\frac{π}{2}$ rad & 10.0$\%$
 Var
 \\
 \midrule
+\endhead
 $\mathbf{p}$
 \\
 $\mathbf{v}$
@@ -1020,6 +1043,7 @@ The purpose of the traceability matrices is to provide easy references on what h
  & \hyperref[reqVPC]{FR: Verify-Physical\_Constraints} & \hyperref[IM:rotMot]{IM: rotMot} & \hyperref[DD:impulse]{DD: impulse} & \hyperref[IM:col2D]{IM: col2D} & \hyperref[IM:transMot]{IM: transMot} & \hyperref[lcIJC]{LC: Include-Joints-Constraints} & \hyperref[lcEC]{LC: Expanded-Collisions} & \hyperref[DD:linVel]{DD: linVel} & \hyperref[DD:linDisp]{DD: linDisp} & \hyperref[DD:linAcc]{DD: linAcc} & \hyperref[lcID]{LC: Include-Dampening} & \hyperref[DD:angVel]{DD: angVel} & \hyperref[DD:angDisp]{DD: angDisp} & \hyperref[DD:angAccel]{DD: angAccel} & \hyperref[DD:ctrOfMass]{DD: ctrOfMass} & \hyperref[TM:NewtonSecLawRotMot]{TM: NewtonSecLawRotMot} & \hyperref[DD:impulse]{DD: impulse} & \hyperref[TM:ChaslesThm]{TM: ChaslesThm}
 \\
 \midrule
+\endhead
 \hyperref[Sec:SolCharSpec]{Section: Solution Characteristics Specification} & X &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  & 
 \\
 \hyperref[DD:angAccel]{DD: angAccel} &  & X &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  & 
@@ -1059,6 +1083,7 @@ The purpose of the traceability matrices is to provide easy references on what h
  & IM1 (\hyperref[IM:transMot]{IM: transMot}) & IM2 (\hyperref[IM:rotMot]{IM: rotMot}) & IM3 (\hyperref[IM:col2D]{IM: col2D}) & R1 (\hyperref[reqSS]{FR: Simulation-Space}) & R4 (\hyperref[reqIIC]{FR: Input-Initial-Conditions}) & R7 (\hyperref[reqISP]{FR: Input-Surface-Properties}) & Data Constraints (\hyperref[Sec:SolCharSpec]{Section: Solution Characteristics Specification})
 \\
 \midrule
+\endhead
 GS1 (\hyperref[Sec:ProbDesc]{Section: Problem Description}) & X &  &  &  &  &  & 
 \\
 GS2 (\hyperref[Sec:ProbDesc]{Section: Problem Description}) &  & X &  &  &  &  & 
@@ -1092,6 +1117,7 @@ R6 (\hyperref[reqDCROT]{FR: Determine-Collision-Response-Over-Time}) &  & X &  &
  & A1 (\hyperref[A:objectTy]{A: objectTy}) & A2 (\hyperref[A:objectDimension]{A: objectDimension}) & A3 (\hyperref[A:coordinateSystemTy]{A: coordinateSystemTy}) & A4 (\hyperref[A:axesDefined]{A: axesDefined}) & A5 (\hyperref[A:collisionType]{A: collisionType}) & A6 (\hyperref[A:dampingInvolvement]{A: dampingInvolvement}) & A7 (\hyperref[A:constraintsAndJointsInvolvement]{A: constraintsAndJointsInvolvement})
 \\
 \midrule
+\endhead
 T1 (\hyperref[TM:NewtonSecLawMot]{TM: NewtonSecLawMot}) &  &  &  &  &  &  & 
 \\
 T2 (\hyperref[TM:NewtonThirdLawMot]{TM: NewtonThirdLawMot}) &  &  &  &  &  &  & 
@@ -1155,6 +1181,7 @@ LC4 (\hyperref[lcEC]{LC: Expanded-Collisions}) &  &  &  &  &  &  & X
  & T1 (\hyperref[TM:NewtonSecLawMot]{TM: NewtonSecLawMot}) & T2 (\hyperref[TM:NewtonThirdLawMot]{TM: NewtonThirdLawMot}) & T3 (\hyperref[TM:UniversalGravLaw]{TM: UniversalGravLaw}) & T4 (\hyperref[TM:ChaslesThm]{TM: ChaslesThm}) & T5 (\hyperref[TM:NewtonSecLawRotMot]{TM: NewtonSecLawRotMot}) & GD1 (\hyperref[Sec:SolCharSpec]{Section: Solution Characteristics Specification}) & GD2 (\hyperref[Sec:SolCharSpec]{Section: Solution Characteristics Specification}) & GD3 (\hyperref[Sec:SolCharSpec]{Section: Solution Characteristics Specification}) & GD4 (\hyperref[Sec:SolCharSpec]{Section: Solution Characteristics Specification}) & GD5 (\hyperref[Sec:SolCharSpec]{Section: Solution Characteristics Specification}) & GD6 (\hyperref[Sec:SolCharSpec]{Section: Solution Characteristics Specification}) & GD7 (\hyperref[Sec:SolCharSpec]{Section: Solution Characteristics Specification}) & DD1 (\hyperref[DD:ctrOfMass]{DD: ctrOfMass}) & DD2 (\hyperref[DD:linDisp]{DD: linDisp}) & DD3 (\hyperref[DD:linVel]{DD: linVel}) & DD4 (\hyperref[DD:linAcc]{DD: linAcc}) & DD5 (\hyperref[DD:angDisp]{DD: angDisp}) & DD6 (\hyperref[DD:angVel]{DD: angVel}) & DD7 (\hyperref[DD:angAccel]{DD: angAccel}) & DD8 (\hyperref[DD:impulse]{DD: impulse}) & IM1 (\hyperref[DD:impulse]{DD: impulse}) & IM2 (\hyperref[DD:torque]{DD: torque}) & IM3 (\hyperref[IM:transMot]{IM: transMot})
 \\
 \midrule
+\endhead
 T1 (\hyperref[TM:NewtonSecLawMot]{TM: NewtonSecLawMot}) &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  & 
 \\
 T2 (\hyperref[TM:NewtonThirdLawMot]{TM: NewtonThirdLawMot}) &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  & 

--- a/code/stable/glassbr/SRS/GlassBR_SRS.tex
+++ b/code/stable/glassbr/SRS/GlassBR_SRS.tex
@@ -40,6 +40,7 @@ The unit system used throughout is SI (Système International d'Unités). In add
 Symbol & Description
 \\
 \midrule
+\endhead
 kg & mass (kilogram)
 \\
 m & length (metre)
@@ -61,6 +62,7 @@ The table that follows summarizes the symbols used in this document along with t
 Symbol & Description & Units
 \\
 \midrule
+\endhead
 $a$ & Plate length (long dimension) & m
 \\
 $AR$ & Aspect ratio & --
@@ -149,6 +151,7 @@ ${w_{TNT}}$ & Explosive mass in equivalent weight of TNT & kg
 Abbreviation & Full Form
 \\
 \midrule
+\endhead
 A & Assumption
 \\
 AN & Annealed
@@ -273,6 +276,7 @@ This section presents the scope of the project. It describes the expected use of
 Actor & Input and Output
 \\
 \midrule
+\endhead
 User & Characteristics of the glass slab and of the blast. Details in \hyperref[Sec:IndividualProdUC]{Section: Individual Product Use Cases}
 \\
 GlassBR & Whether or not the glass slab is safe for the calculated load and supporting calculated values
@@ -374,8 +378,9 @@ This section simplifies the original problem and helps in developing the theoret
 \subsubsection{Theoretical Models}
 \label{Sec:TMs}
 This section focuses on the general equations and laws that GlassBR is based on.
-~\newline
- \noindent \begin{minipage}{\textwidth}
+\par~
+    
+\noindent \begin{minipage}{\textwidth}
 \begin{tabular}{p{0.2\textwidth} p{0.73\textwidth}}
 \toprule \textbf{Refname} & \textbf{TM:isSafePb}
 \phantomsection 
@@ -399,9 +404,10 @@ Label & Safety Req-Pb
                                                   \\ \midrule \\
                                                   RefBy & \hyperref[TM:isSafeLR]{TM: isSafeLR} \hyperref[checkGlassSafety]{FR: Check-Glass-Safety}.
 \\ \bottomrule \end{tabular}
-\end{minipage}\\
-~\newline
- \noindent \begin{minipage}{\textwidth}
+\end{minipage}
+\par~
+    
+\noindent \begin{minipage}{\textwidth}
 \begin{tabular}{p{0.2\textwidth} p{0.73\textwidth}}
 \toprule \textbf{Refname} & \textbf{TM:isSafeLR}
 \phantomsection 
@@ -425,15 +431,16 @@ Label & Safety Req-LR
                                                   \\ \midrule \\
                                                   RefBy & \hyperref[TM:isSafePb]{TM: isSafePb} \hyperref[checkGlassSafety]{FR: Check-Glass-Safety}.
 \\ \bottomrule \end{tabular}
-\end{minipage}\\
+\end{minipage}
 \subsubsection{General Definitions}
 \label{Sec:GDs}
 There are no general definitions.
 \subsubsection{Data Definitions}
 \label{Sec:DDs}
 This section collects and defines all the data needed to build the instance models.
-~\newline
- \noindent \begin{minipage}{\textwidth}
+\par~
+    
+\noindent \begin{minipage}{\textwidth}
 \begin{tabular}{p{0.2\textwidth} p{0.73\textwidth}}
 \toprule \textbf{Refname} & \textbf{DD:risk.fun}
 \phantomsection 
@@ -470,9 +477,10 @@ Label & Risk of failure
                                                                    \\ \midrule \\
                                                                    RefBy & \hyperref[DD:probOfBreak]{DD: probOfBreak}.
 \\ \bottomrule \end{tabular}
-\end{minipage}\\
-~\newline
- \noindent \begin{minipage}{\textwidth}
+\end{minipage}
+\par~
+    
+\noindent \begin{minipage}{\textwidth}
 \begin{tabular}{p{0.2\textwidth} p{0.73\textwidth}}
 \toprule \textbf{Refname} & \textbf{DD:min.thick}
 \phantomsection 
@@ -512,9 +520,10 @@ Label & Minimum thickness
                                                                    \\ \midrule \\
                                                                    RefBy & \hyperref[DD:sdf.tol]{DD: sdf\_tol} \hyperref[DD:risk.fun]{DD: risk\_fun} \hyperref[DD:nFL]{DD: nFL} \hyperref[DD:dimlessLoad]{DD: dimlessLoad}.
 \\ \bottomrule \end{tabular}
-\end{minipage}\\
-~\newline
- \noindent \begin{minipage}{\textwidth}
+\end{minipage}
+\par~
+    
+\noindent \begin{minipage}{\textwidth}
 \begin{tabular}{p{0.2\textwidth} p{0.73\textwidth}}
 \toprule \textbf{Refname} & \textbf{DD:loadDurFactor}
 \phantomsection 
@@ -543,9 +552,10 @@ Label & Load duration factor
                                                                    \\ \midrule \\
                                                                    RefBy & \hyperref[DD:sdf.tol]{DD: sdf\_tol} \hyperref[DD:risk.fun]{DD: risk\_fun}.
 \\ \bottomrule \end{tabular}
-\end{minipage}\\
-~\newline
- \noindent \begin{minipage}{\textwidth}
+\end{minipage}
+\par~
+    
+\noindent \begin{minipage}{\textwidth}
 \begin{tabular}{p{0.2\textwidth} p{0.73\textwidth}}
 \toprule \textbf{Refname} & \textbf{DD:stressDistFac}
 \phantomsection 
@@ -576,9 +586,10 @@ Label & Stress distribution factor (Function)
                                                                    \\ \midrule \\
                                                                    RefBy & \hyperref[DD:risk.fun]{DD: risk\_fun}.
 \\ \bottomrule \end{tabular}
-\end{minipage}\\
-~\newline
- \noindent \begin{minipage}{\textwidth}
+\end{minipage}
+\par~
+    
+\noindent \begin{minipage}{\textwidth}
 \begin{tabular}{p{0.2\textwidth} p{0.73\textwidth}}
 \toprule \textbf{Refname} & \textbf{DD:nFL}
 \phantomsection 
@@ -612,9 +623,10 @@ Label & Non-factored load
                                                                    \\ \midrule \\
                                                                    RefBy & \hyperref[DD:calofCapacity]{DD: calofCapacity} \hyperref[DD:calofCapacity]{DD: calofCapacity}.
 \\ \bottomrule \end{tabular}
-\end{minipage}\\
-~\newline
- \noindent \begin{minipage}{\textwidth}
+\end{minipage}
+\par~
+    
+\noindent \begin{minipage}{\textwidth}
 \begin{tabular}{p{0.2\textwidth} p{0.73\textwidth}}
 \toprule \textbf{Refname} & \textbf{DD:gTF}
 \phantomsection 
@@ -647,9 +659,10 @@ Label & Glass type factor
                                                                    \\ \midrule \\
                                                                    RefBy & \hyperref[DD:calofCapacity]{DD: calofCapacity} \hyperref[DD:calofCapacity]{DD: calofCapacity} \hyperref[DD:dimlessLoad]{DD: dimlessLoad}.
 \\ \bottomrule \end{tabular}
-\end{minipage}\\
-~\newline
- \noindent \begin{minipage}{\textwidth}
+\end{minipage}
+\par~
+    
+\noindent \begin{minipage}{\textwidth}
 \begin{tabular}{p{0.2\textwidth} p{0.73\textwidth}}
 \toprule \textbf{Refname} & \textbf{DD:dimlessLoad}
 \phantomsection 
@@ -686,9 +699,10 @@ Label & Dimensionless load
                                                                    \\ \midrule \\
                                                                    RefBy & \hyperref[DD:stressDistFac]{DD: stressDistFac}.
 \\ \bottomrule \end{tabular}
-\end{minipage}\\
-~\newline
- \noindent \begin{minipage}{\textwidth}
+\end{minipage}
+\par~
+    
+\noindent \begin{minipage}{\textwidth}
 \begin{tabular}{p{0.2\textwidth} p{0.73\textwidth}}
 \toprule \textbf{Refname} & \textbf{DD:tolLoad}
 \phantomsection 
@@ -718,9 +732,10 @@ Label & Tolerable load
                                                                    \\ \midrule \\
                                                                    RefBy & \hyperref[DD:nFL]{DD: nFL}.
 \\ \bottomrule \end{tabular}
-\end{minipage}\\
-~\newline
- \noindent \begin{minipage}{\textwidth}
+\end{minipage}
+\par~
+    
+\noindent \begin{minipage}{\textwidth}
 \begin{tabular}{p{0.2\textwidth} p{0.73\textwidth}}
 \toprule \textbf{Refname} & \textbf{DD:sdf.tol}
 \phantomsection 
@@ -759,9 +774,10 @@ Label & Stress distribution factor (Function) based on Pbtol
                                                                    \\ \midrule \\
                                                                    RefBy & \hyperref[DD:tolLoad]{DD: tolLoad}.
 \\ \bottomrule \end{tabular}
-\end{minipage}\\
-~\newline
- \noindent \begin{minipage}{\textwidth}
+\end{minipage}
+\par~
+    
+\noindent \begin{minipage}{\textwidth}
 \begin{tabular}{p{0.2\textwidth} p{0.73\textwidth}}
 \toprule \textbf{Refname} & \textbf{DD:standOffDist}
 \phantomsection 
@@ -788,9 +804,10 @@ Label & Stand off distance
                                                            \\ \midrule \\
                                                            RefBy & \hyperref[DD:calofCapacity]{DD: calofCapacity} \hyperref[IM:calOfDemand]{IM: calOfDemand}.
 \\ \bottomrule \end{tabular}
-\end{minipage}\\
-~\newline
- \noindent \begin{minipage}{\textwidth}
+\end{minipage}
+\par~
+    
+\noindent \begin{minipage}{\textwidth}
 \begin{tabular}{p{0.2\textwidth} p{0.73\textwidth}}
 \toprule \textbf{Refname} & \textbf{DD:aspect.ratio}
 \phantomsection 
@@ -818,9 +835,10 @@ Label & Aspect ratio
                                                                    \\ \midrule \\
                                                                    RefBy & \hyperref[DD:tolLoad]{DD: tolLoad} \hyperref[DD:stressDistFac]{DD: stressDistFac}.
 \\ \bottomrule \end{tabular}
-\end{minipage}\\
-~\newline
- \noindent \begin{minipage}{\textwidth}
+\end{minipage}
+\par~
+    
+\noindent \begin{minipage}{\textwidth}
 \begin{tabular}{p{0.2\textwidth} p{0.73\textwidth}}
 \toprule \textbf{Refname} & \textbf{DD:probOfBreak}
 \phantomsection 
@@ -847,9 +865,10 @@ Label & Probability of breakage
                                                                    \\ \midrule \\
                                                                    RefBy & \hyperref[TM:isSafePb]{TM: isSafePb}.
 \\ \bottomrule \end{tabular}
-\end{minipage}\\
-~\newline
- \noindent \begin{minipage}{\textwidth}
+\end{minipage}
+\par~
+    
+\noindent \begin{minipage}{\textwidth}
 \begin{tabular}{p{0.2\textwidth} p{0.73\textwidth}}
 \toprule \textbf{Refname} & \textbf{DD:calofCapacity}
 \phantomsection 
@@ -881,9 +900,10 @@ Label & Load resistance
                                                                    \\ \midrule \\
                                                                    RefBy & \hyperref[TM:isSafeLR]{TM: isSafeLR}.
 \\ \bottomrule \end{tabular}
-\end{minipage}\\
-~\newline
- \noindent \begin{minipage}{\textwidth}
+\end{minipage}
+\par~
+    
+\noindent \begin{minipage}{\textwidth}
 \begin{tabular}{p{0.2\textwidth} p{0.73\textwidth}}
 \toprule \textbf{Refname} & \textbf{DD:calofCapacity}
 \phantomsection 
@@ -912,12 +932,13 @@ Label & Applied load (demand)
                                                                    \\ \midrule \\
                                                                    RefBy & \hyperref[TM:isSafeLR]{TM: isSafeLR} \hyperref[DD:dimlessLoad]{DD: dimlessLoad}.
 \\ \bottomrule \end{tabular}
-\end{minipage}\\
+\end{minipage}
 \subsubsection{Instance Models}
 \label{Sec:IMs}
 This section transforms the problem defined in \hyperref[Sec:ProbDesc]{Section: Problem Description} into one which is expressed in mathematical terms. It uses concrete symbols defined in \hyperref[Sec:DDs]{Section: Data Definitions} to replace the abstract symbols in the models identified in \hyperref[Sec:TMs]{Section: Theoretical Models} and \hyperref[Sec:GDs]{Section: General Definitions}.
-~\newline
- \noindent \begin{minipage}{\textwidth}
+\par~
+    
+\noindent \begin{minipage}{\textwidth}
 \begin{tabular}{p{0.2\textwidth} p{0.73\textwidth}}
 \toprule \textbf{Refname} & \textbf{IM:calOfDemand}
 \phantomsection 
@@ -956,7 +977,7 @@ Label & Calculation of Demand
                                                                                                             \\ \midrule \\
                                                                                                             RefBy & 
 \\ \bottomrule \end{tabular}
-\end{minipage}\\
+\end{minipage}
 \subsubsection{Data Constraints}
 \label{Sec:DataConstraints}
 \hyperref[Table:InDataConstraints]{Table:InDataConstraints} and \hyperref[Table:OutDataConstraints]{Table:OutDataConstraints} show the data constraints on the input and output variables, respectively. The column for physical constraints gives the physical limitations on the range of values that can be taken by the variable. The uncertainty column provides an estimate of the confidence with which the physical quantities can be measured. This information would be part of the input if one were performing an uncertainty quantification exercise. The constraints are conservative, to give the user of the model the flexibility to experiment with unusual situations. The column of typical values is intended to provide a feel for a common scenario. \hyperref[Sec:AuxConstants]{Section: Values of Auxiliary Constants} gives the values of the specification parameters used in \hyperref[Table:InDataConstraints]{Table:InDataConstraints}.
@@ -965,6 +986,7 @@ Label & Calculation of Demand
 Var & Physical Constraints & Software Constraints & Typical Value & Uncert.
 \\
 \midrule
+\endhead
 $a$ & $a>0$ and $a\geq{}b$ & ${d_{min}}\leq{}a\leq{}{d_{max}}$ & $1.5$ m & 10.0$\%$
 \\
 $AR$ & $AR\geq{}1$ & $AR\leq{}{AR_{max}}$ & $1.5$ & 10.0$\%$
@@ -988,6 +1010,7 @@ $w$ & $w>0$ & ${w_{min}}\leq{}w\leq{}{w_{max}}$ & $42.0$ kg & 10.0$\%$
 Var & Physical Constraints
 \\
 \midrule
+\endhead
 ${P_{b}}$ & $0<{P_{b}}<1$
 \\
 \bottomrule
@@ -1033,6 +1056,7 @@ This section provides the functional requirements, the business tasks that the s
 Symbol & Description & Units
 \\
 \midrule
+\endhead
 $a$ & Plate length (long dimension) & m
 \\
 $b$ & Plate width (short dimension) & m
@@ -1083,6 +1107,7 @@ The purpose of the traceability matrices is to provide easy references on what h
  & \hyperref[checkInputWithDataCons]{FR: Check-Input-with-Data\_Constraints} & \hyperref[inputGlassProps]{FR: Input-Glass-Props} & \hyperref[DD:tolLoad]{DD: tolLoad} & \hyperref[DD:stressDistFac]{DD: stressDistFac} & \hyperref[accMoreBoundaryConditions]{LC: Accomodate-More-Boundary-Conditions} & \hyperref[calcInternalBlastRisk]{LC: Calculate-Internal-Blask-Risk} & \hyperref[accAlteredGlass]{UC: Accommodate-Altered-Glass} & \hyperref[DD:calofCapacity]{DD: calofCapacity} & \hyperref[DD:dimlessLoad]{DD: dimlessLoad} & \hyperref[accMoreThanSingleLite]{LC: Accomodate-More-than-Single-Lite} & \hyperref[varValsOfmkE]{LC: Variable-Values-of-m,k,E} & \hyperref[DD:loadDurFactor]{DD: loadDurFactor} & \hyperref[considerMoreThanFlexGlass]{LC: Consider-More-than-Flexure-Glass} & \hyperref[DD:sdf.tol]{DD: sdf\_tol} & \hyperref[DD:nFL]{DD: nFL} & \hyperref[TM:isSafeLR]{TM: isSafeLR} & \hyperref[outputValsAndKnownQuants]{FR: Output-Values-and-Known-Quantities} & \hyperref[DD:risk.fun]{DD: risk\_fun} & \hyperref[TM:isSafePb]{TM: isSafePb} & \hyperref[DD:probOfBreak]{DD: probOfBreak} & \hyperref[checkGlassSafety]{FR: Check-Glass-Safety} & \hyperref[DD:calofCapacity]{DD: calofCapacity} & \hyperref[IM:calOfDemand]{IM: calOfDemand}
 \\
 \midrule
+\endhead
 \hyperref[Sec:DataConstraints]{Section: Data Constraints} & X &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  & 
 \\
 \hyperref[Table:InputGlassPropsReqInputs]{Table:InputGlassPropsReqInputs} &  & X &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  & 
@@ -1146,6 +1171,7 @@ The purpose of the traceability matrices is to provide easy references on what h
  & T1 (\hyperref[TM:isSafePb]{TM: isSafePb}) & T2 (\hyperref[TM:isSafeLR]{TM: isSafeLR}) & IM1 (\hyperref[IM:calOfDemand]{IM: calOfDemand}) & IM2 (\hyperref[DD:risk.fun]{DD: risk\_fun}) & IM3 (\hyperref[DD:min.thick]{DD: min\_thick}) & DD1 (\hyperref[DD:loadDurFactor]{DD: loadDurFactor}) & DD2 (\hyperref[DD:stressDistFac]{DD: stressDistFac}) & DD3 (\hyperref[DD:nFL]{DD: nFL}) & DD4 (\hyperref[DD:gTF]{DD: gTF}) & DD5 (\hyperref[DD:dimlessLoad]{DD: dimlessLoad}) & DD6 (\hyperref[DD:tolLoad]{DD: tolLoad}) & DD7 (\hyperref[DD:sdf.tol]{DD: sdf\_tol}) & DD8 (\hyperref[DD:standOffDist]{DD: standOffDist})
 \\
 \midrule
+\endhead
 T1 (\hyperref[TM:isSafePb]{TM: isSafePb}) &  & X & X &  &  &  &  &  &  &  &  &  & 
 \\
 T2 (\hyperref[TM:isSafeLR]{TM: isSafeLR}) & X &  &  & X & X &  &  &  &  &  &  &  & 
@@ -1181,6 +1207,7 @@ DD8 (\hyperref[DD:standOffDist]{DD: standOffDist}) &  &  &  &  &  &  & X &  &  &
  & T1 (\hyperref[TM:isSafePb]{TM: isSafePb}) & T2 (\hyperref[TM:isSafeLR]{TM: isSafeLR}) & IM1 (\hyperref[IM:calOfDemand]{IM: calOfDemand}) & IM2 (\hyperref[DD:risk.fun]{DD: risk\_fun}) & IM3 (\hyperref[DD:min.thick]{DD: min\_thick}) & DD1 (\hyperref[DD:loadDurFactor]{DD: loadDurFactor}) & DD2 (\hyperref[DD:stressDistFac]{DD: stressDistFac}) & DD3 (\hyperref[DD:nFL]{DD: nFL}) & DD4 (\hyperref[DD:gTF]{DD: gTF}) & DD5 (\hyperref[DD:dimlessLoad]{DD: dimlessLoad}) & DD6 (\hyperref[DD:tolLoad]{DD: tolLoad}) & DD7 (\hyperref[DD:sdf.tol]{DD: sdf\_tol}) & DD8 (\hyperref[DD:standOffDist]{DD: standOffDist}) & Data Constraints (\hyperref[Sec:DataConstraints]{Section: Data Constraints}) & R1 (\hyperref[inputGlassProps]{FR: Input-Glass-Props}) & R2 (\hyperref[sysSetValsFollowingAssumps]{FR: System-Set-Values-Following-Assumptions}) & R3 (\hyperref[checkInputWithDataCons]{FR: Check-Input-with-Data\_Constraints}) & R4 (\hyperref[outputValsAndKnownQuants]{FR: Output-Values-and-Known-Quantities}) & R5 (\hyperref[checkGlassSafety]{FR: Check-Glass-Safety}) & R6 (\hyperref[outputQuants]{FR: Output-Quantities})
 \\
 \midrule
+\endhead
 R1 (in \hyperref[inputGlassProps]{FR: Input-Glass-Props}) &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  & 
 \\
 R2 (in \hyperref[sysSetValsFollowingAssumps]{FR: System-Set-Values-Following-Assumptions}) &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  & 
@@ -1202,6 +1229,7 @@ R6 (in \hyperref[outputQuants]{FR: Output-Quantities}) &  &  & X & X & X &  & X 
  & A1 (\hyperref[A:glassType]{A: glassType}) & A2 (\hyperref[A:glassCondition]{A: glassCondition}) & A3 (\hyperref[A:explainScenario]{A: explainScenario}) & A4 (\hyperref[A:standardValues]{A: standardValues}) & A5 (\hyperref[A:glassLite]{A: glassLite}) & A6 (\hyperref[A:boundaryConditions]{A: boundaryConditions}) & A7 (\hyperref[A:responseType]{A: responseType}) & A8 (\hyperref[A:ldfConstant]{A: ldfConstant})
 \\
 \midrule
+\endhead
 T1 (\hyperref[TM:isSafePb]{TM: isSafePb}) &  &  &  &  &  &  &  & 
 \\
 T2 (\hyperref[TM:isSafeLR]{TM: isSafeLR}) &  &  &  &  &  &  &  & 
@@ -1284,6 +1312,7 @@ This section contains the standard values that are used for calculations in Glas
 Symbol & Description & Value & Unit
 \\
 \midrule
+\endhead
 ${AR_{max}}$ & maximum aspect ratio & $5.0$ & --
 \\
 ${d_{max}}$ & maximum value for one of the dimensions of the glass plate & $5.0$ & m

--- a/code/stable/nopcm/SRS/NoPCM_SRS.tex
+++ b/code/stable/nopcm/SRS/NoPCM_SRS.tex
@@ -40,6 +40,7 @@ The unit system used throughout is SI (Système International d'Unités). In add
 Symbol & Description
 \\
 \midrule
+\endhead
 ${}^{\circ}$C & temperature (centigrade)
 \\
 J & energy (joule)
@@ -63,6 +64,7 @@ The table that follows summarizes the symbols used in this document along with t
 Symbol & Description & Units
 \\
 \midrule
+\endhead
 ${A_{C}}$ & Heating coil surface area & $\text{m}^{2}$
 \\
 ${A_{in}}$ & Surface area over which heat is transferred in & $\text{m}^{2}$
@@ -143,6 +145,7 @@ $∇$ & Gradient & --
 Abbreviation & Full Form
 \\
 \midrule
+\endhead
 A & Assumption
 \\
 DD & Data Definition
@@ -312,8 +315,9 @@ This section simplifies the original problem and helps in developing the theoret
 \subsubsection{Theoretical Models}
 \label{Sec:TMs}
 This section focuses on the general equations and laws that SWHS is based on.
-~\newline
- \noindent \begin{minipage}{\textwidth}
+\par~
+    
+\noindent \begin{minipage}{\textwidth}
 \begin{tabular}{p{0.2\textwidth} p{0.73\textwidth}}
 \toprule \textbf{Refname} & \textbf{TM:consThermE}
 \phantomsection 
@@ -341,12 +345,13 @@ Label & Conservation of thermal energy
                                                   \\ \midrule \\
                                                   RefBy & \hyperref[GD:rocTempSimp]{GD: rocTempSimp}.
 \\ \bottomrule \end{tabular}
-\end{minipage}\\
+\end{minipage}
 \subsubsection{General Definitions}
 \label{Sec:GDs}
 This section collects the laws and equations that will be used in deriving the data definitions, which in turn are used to build the instance models.
-~\newline
- \noindent \begin{minipage}{\textwidth}
+\par~
+    
+\noindent \begin{minipage}{\textwidth}
 \begin{tabular}{p{0.2\textwidth} p{0.73\textwidth}}
 \toprule \textbf{Refname} & \textbf{GD:nwtnCooling}
 \phantomsection 
@@ -373,9 +378,10 @@ Label & Newton's law of cooling
                                                           \\ \midrule \\
                                                           RefBy & 
 \\ \bottomrule \end{tabular}
-\end{minipage}\\
-~\newline
- \noindent \begin{minipage}{\textwidth}
+\end{minipage}
+\par~
+    
+\noindent \begin{minipage}{\textwidth}
 \begin{tabular}{p{0.2\textwidth} p{0.73\textwidth}}
 \toprule \textbf{Refname} & \textbf{GD:rocTempSimp}
 \phantomsection 
@@ -405,7 +411,7 @@ Label & Simplified rate of change of temperature
                                          Source & \\ \midrule \\
                                                   RefBy & \hyperref[GD:rocTempSimp]{GD: rocTempSimp} \hyperref[IM:eBalanceOnWtr]{IM: eBalanceOnWtr}.
 \\ \bottomrule \end{tabular}
-\end{minipage}\\
+\end{minipage}
 Detailed derivation of simplified rate of change of temperature.
 Integrating \hyperref[TM:consThermE]{TM: consThermE} over a volume ($V$), we have:
 \begin{displaymath}
@@ -430,8 +436,9 @@ m C \frac{d\,T}{d\,t}={q_{in}} {A_{in}}-{q_{out}} {A_{out}}+g V
 \subsubsection{Data Definitions}
 \label{Sec:DDs}
 This section collects and defines all the data needed to build the instance models.
-~\newline
- \noindent \begin{minipage}{\textwidth}
+\par~
+    
+\noindent \begin{minipage}{\textwidth}
 \begin{tabular}{p{0.2\textwidth} p{0.73\textwidth}}
 \toprule \textbf{Refname} & \textbf{DD:ht.flux.C}
 \phantomsection 
@@ -463,12 +470,13 @@ Label & Heat flux into the water from the coil
                                                                    \\ \midrule \\
                                                                    RefBy & \hyperref[IM:eBalanceOnWtr]{IM: eBalanceOnWtr}.
 \\ \bottomrule \end{tabular}
-\end{minipage}\\
+\end{minipage}
 \subsubsection{Instance Models}
 \label{Sec:IMs}
 This section transforms the problem defined in \hyperref[Sec:ProbDesc]{Section: Problem Description} into one which is expressed in mathematical terms. It uses concrete symbols defined in \hyperref[Sec:DDs]{Section: Data Definitions} to replace the abstract symbols in the models identified in \hyperref[Sec:TMs]{Section: Theoretical Models} and \hyperref[Sec:GDs]{Section: General Definitions}.
-~\newline
- \noindent \begin{minipage}{\textwidth}
+\par~
+    
+\noindent \begin{minipage}{\textwidth}
 \begin{tabular}{p{0.2\textwidth} p{0.73\textwidth}}
 \toprule \textbf{Refname} & \textbf{IM:eBalanceOnWtr}
 \phantomsection 
@@ -505,7 +513,7 @@ Label & Energy balance on water to find the temperature of the water
                                                                                                             \\ \midrule \\
                                                                                                             RefBy & \hyperref[unlikeChgNIHG]{UC: No-Internal-Heat-Generation} \hyperref[reqOIDQ]{FR: Output-Input-Derivied-Quantities} \hyperref[reqFM]{FR: Find-Mass}.
 \\ \bottomrule \end{tabular}
-\end{minipage}\\
+\end{minipage}
 Derivation of the energy balance on water:
 To find the rate of change of ${T_{W}}$, we look at the energy balance on water. The volume being considered is the volume of water ${V_{W}}$, which has mass ${m_{W}}$ and specific heat capacity of water, ${C_{W}}$ . Heat transfer occurs in the water from the coil as ${q_{C}}$, over area ${A_{C}}$. No heat transfer occurs to the outside of the tank, since it has been assumed to be perfectly insulated (\hyperref[A:Charging-Tank-No-Temp-Discharge]{A: Charging-Tank-No-Temp-Discharge}) . Assuming no volumetric heat generation per unit volume (\hyperref[A:No-Internal-Heat-Generation-By-Water]{A: No-Internal-Heat-Generation-By-Water}), $g=0$ . Therefore, the equation for \hyperref[GD:rocTempSimp]{GD: rocTempSimp} can be written as:
 \begin{displaymath}
@@ -523,8 +531,9 @@ Setting ${τ_{W}}$ = ${m_{W}}$ ${C_{W}}$ / ${h_{C}}$ ${A_{C}}$ , Equation (4) ca
 \begin{displaymath}
 \frac{d\,{T_{W}}}{d\,t}=\frac{1}{{τ_{W}}} \left({T_{C}}-{T_{W}}\right)
 \end{displaymath}
-~\newline
- \noindent \begin{minipage}{\textwidth}
+\par~
+    
+\noindent \begin{minipage}{\textwidth}
 \begin{tabular}{p{0.2\textwidth} p{0.73\textwidth}}
 \toprule \textbf{Refname} & \textbf{IM:heatEInWtr}
 \phantomsection 
@@ -560,7 +569,7 @@ Label & Heat energy in the water
                                                                                                             \\ \midrule \\
                                                                                                             RefBy & \hyperref[reqCCHEWT]{FR: Calculate-Change-Heat\_Energy-Water-Time}.
 \\ \bottomrule \end{tabular}
-\end{minipage}\\
+\end{minipage}
 \subsubsection{Data Constraints}
 \label{Sec:DataConstraints}
 \hyperref[Table:InDataConstraints]{Table:InDataConstraints} and \hyperref[Table:OutDataConstraints]{Table:OutDataConstraints} show the data constraints on the input and output variables, respectively. The column for physical constraints gives the physical limitations on the range of values that can be taken by the variable. The uncertainty column provides an estimate of the confidence with which the physical quantities can be measured. This information would be part of the input if one were performing an uncertainty quantification exercise. The constraints are conservative, to give the user of the model the flexibility to experiment with unusual situations. The column of typical values is intended to provide a feel for a common scenario. The column for software constraints restricts the range of inputs to reasonable values.
@@ -569,6 +578,7 @@ Label & Heat energy in the water
 Var & Physical Constraints & Software Constraints & Typical Value & Uncert.
 \\
 \midrule
+\endhead
 ${A_{C}}$ & ${A_{C}}>0$ & ${A_{C}}\leq{}{{A_{C}}^{max}}$ & $120.0\cdot{}10^{-3}$ $\text{m}^{2}$ & 10.0$\%$
 \\
 ${C_{W}}$ & ${C_{W}}>0$ & ${{C_{W}}^{min}}<{C_{W}}<{{C_{W}}^{max}}$ & $4.186\cdot{}10^{3}$ $\frac{\text{J}}{(\text{kg}{}^{\circ}\text{C})}$ & 10.0$\%$
@@ -596,6 +606,7 @@ ${ρ_{W}}$ & ${ρ_{W}}>0$ & ${{ρ_{W}}^{min}}<{ρ_{W}}\leq{}{{ρ_{W}}^{max}}$ & 
 Var & Physical Constraints
 \\
 \midrule
+\endhead
 ${T_{W}}$ & ${T_{init}}\leq{}{T_{W}}\leq{}{T_{C}}$
 \\
 ${E_{W}}$ & ${E_{W}}\geq{}0$
@@ -622,6 +633,7 @@ This section provides the functional requirements, the business tasks that the s
 Symbol & Unit & Description
 \\
 \midrule
+\endhead
 $L$ & m & length of tank
 \\
 $D$ & m & diameter of tank
@@ -669,6 +681,7 @@ The purpose of the traceability matrices is to provide easy references on what h
  & \hyperref[reqCISPC]{FR: Check-Inputs-Satisfy-Physical-Constraints} & \hyperref[reqIIV]{FR: Input-Inital-Values} & \hyperref[IM:heatEInWtr]{IM: heatEInWtr} & \hyperref[IM:eBalanceOnWtr]{IM: eBalanceOnWtr} & \hyperref[likeChgDT]{LC: Discharging-Tank} & \hyperref[GD:rocTempSimp]{GD: rocTempSimp} & \hyperref[GD:nwtnCooling]{GD: nwtnCooling} & \hyperref[DD:ht.flux.C]{DD: ht\_flux\_C} & \hyperref[unlikeChgNIHG]{UC: No-Internal-Heat-Generation} & \hyperref[likeChgTLH]{LC: Tank-Lose-Heat} & \hyperref[TM:consThermE]{TM: consThermE} & \hyperref[likeChgTCVOL]{LC: Temperature-Coil-Variable-Over-Length} & \hyperref[likeChgTCVOD]{LC: Temperature-Coil-Variable-Over-Day} & \hyperref[unlikeChgWFS]{UC: Water-Fixed-States} & \hyperref[reqFM]{FR: Find-Mass} & \hyperref[reqOIDQ]{FR: Output-Input-Derivied-Quantities} & \hyperref[reqCCHEWT]{FR: Calculate-Change-Heat\_Energy-Water-Time}
 \\
 \midrule
+\endhead
 \hyperref[Table:InDataConstraints]{Table:InDataConstraints} & X &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  & 
 \\
 \hyperref[Table:Input-Variable-Requirements]{Table:Input-Variable-Requirements} &  & X &  &  &  &  &  &  &  &  &  &  &  &  &  &  & 
@@ -730,6 +743,7 @@ The purpose of the traceability matrices is to provide easy references on what h
  & T1 (\hyperref[TM:consThermE]{TM: consThermE}) & GD1 (\hyperref[GD:nwtnCooling]{GD: nwtnCooling}) & GD2 (\hyperref[GD:rocTempSimp]{GD: rocTempSimp}) & DD1 (\hyperref[DD:ht.flux.C]{DD: ht\_flux\_C}) & IM1 (\hyperref[IM:eBalanceOnWtr]{IM: eBalanceOnWtr}) & IM2 (\hyperref[IM:heatEInWtr]{IM: heatEInWtr})
 \\
 \midrule
+\endhead
 T1 (\hyperref[TM:consThermE]{TM: consThermE}) &  &  &  &  &  & 
 \\
 GD1 (\hyperref[GD:nwtnCooling]{GD: nwtnCooling}) &  &  &  &  &  & 
@@ -751,6 +765,7 @@ IM2 (\hyperref[IM:heatEInWtr]{IM: heatEInWtr}) &  &  &  &  &  &
  & IM1 (\hyperref[IM:eBalanceOnWtr]{IM: eBalanceOnWtr}) & IM2 (\hyperref[IM:heatEInWtr]{IM: heatEInWtr}) & Data Constraints (\hyperref[Table:InDataConstraints]{Table:InDataConstraints}) & R1 (\hyperref[reqIIV]{FR: Input-Inital-Values}) & R2 (\hyperref[reqFM]{FR: Find-Mass}) & R3 (\hyperref[reqCISPC]{FR: Check-Inputs-Satisfy-Physical-Constraints}) & R4 (\hyperref[reqOIDQ]{FR: Output-Input-Derivied-Quantities}) & R5 (\hyperref[reqCTWOT]{FR: Calculate-Temperature-Water-Over-Time}) & R6 (\hyperref[reqCCHEWT]{FR: Calculate-Change-Heat\_Energy-Water-Time})
 \\
 \midrule
+\endhead
 IM1 (\hyperref[IM:eBalanceOnWtr]{IM: eBalanceOnWtr}) &  &  &  &  &  &  &  &  & 
 \\
 IM2 (\hyperref[IM:heatEInWtr]{IM: heatEInWtr}) &  &  &  &  &  &  &  &  & 
@@ -776,6 +791,7 @@ R6 (\hyperref[reqCCHEWT]{FR: Calculate-Change-Heat\_Energy-Water-Time}) &  & X &
  & A1 (\hyperref[A:Thermal-Energy-Only]{A: Thermal-Energy-Only}) & A2 (\hyperref[A:Heat-Transfer-Coeffs-Constant]{A: Heat-Transfer-Coeffs-Constant}) & A3 (\hyperref[A:Constant-Water-Temp-Across-Tank]{A: Constant-Water-Temp-Across-Tank}) & A4 (\hyperref[A:Density-Water-Constant-over-Volume]{A: Density-Water-Constant-over-Volume}) & A5 (\hyperref[A:Specific-Heat-Energy-Constant-over-Volume]{A: Specific-Heat-Energy-Constant-over-Volume}) & A6 (\hyperref[A:Newton-Law-Convective-Cooling-Coil-Water]{A: Newton-Law-Convective-Cooling-Coil-Water}) & A7 (\hyperref[A:Temp-Heating-Coil-Constant-over-Time]{A: Temp-Heating-Coil-Constant-over-Time}) & A8 (\hyperref[A:Temp-Heating-Coil-Constant-over-Length]{A: Temp-Heating-Coil-Constant-over-Length}) & A9 (\hyperref[A:Charging-Tank-No-Temp-Discharge]{A: Charging-Tank-No-Temp-Discharge}) & A10 (\hyperref[A:Water-Always-Liquid]{A: Water-Always-Liquid}) & A11 (\hyperref[A:Perfect-Insulation-Tank]{A: Perfect-Insulation-Tank}) & A12 (\hyperref[A:No-Internal-Heat-Generation-By-Water]{A: No-Internal-Heat-Generation-By-Water}) & A13 (\hyperref[A:Atmospheric-Pressure-Tank]{A: Atmospheric-Pressure-Tank}) & A14 (\hyperref[A:Volume-Coil-Negligible]{A: Volume-Coil-Negligible})
 \\
 \midrule
+\endhead
 T1 (\hyperref[TM:consThermE]{TM: consThermE}) & X &  &  &  &  &  &  &  &  &  &  &  &  & 
 \\
 GD1 (\hyperref[GD:nwtnCooling]{GD: nwtnCooling}) &  & X &  &  &  &  &  &  &  &  &  &  &  & 
@@ -809,6 +825,7 @@ This section contains the standard values that are used for calculations in SWHS
 Symbol & Description & Value & Unit
 \\
 \midrule
+\endhead
 ${L_{min}}$ & minimum length of tank & $100.0\cdot{}10^{-3}$ & m
 \\
 ${L_{max}}$ & maximum length of tank & $50$ & m

--- a/code/stable/ssp/SRS/SSP_SRS.tex
+++ b/code/stable/ssp/SRS/SSP_SRS.tex
@@ -40,6 +40,7 @@ The unit system used throughout is SI (Système International d'Unités). In add
 Symbol & Description
 \\
 \midrule
+\endhead
 ${}^{\circ}$ & angle (degree)
 \\
 m & length (metre)
@@ -59,6 +60,7 @@ The table that follows summarizes the symbols used in this document along with t
 Symbol & Description & Units
 \\
 \midrule
+\endhead
 $(x,y)$ & Cartesian Position Coordinates: y is considered parallel to the direction of the force of gravity and x is considered perpendicular to y & m
 \\
 $A$ & Area: A part of an object or surface & $\text{m}^{2}$
@@ -191,6 +193,7 @@ ${ℓ_{s}}$ & Length of an Interslice Surface: from slip base to slope surface i
 Abbreviation & Full Form
 \\
 \midrule
+\endhead
 A & Assumption
 \\
 DD & Data Definition
@@ -365,8 +368,9 @@ This section simplifies the original problem and helps in developing the theoret
 \subsubsection{Theoretical Models}
 \label{Sec:TMs}
 This section focuses on the general equations and laws that SSA is based on.
-~\newline
- \noindent \begin{minipage}{\textwidth}
+\par~
+    
+\noindent \begin{minipage}{\textwidth}
 \begin{tabular}{p{0.2\textwidth} p{0.73\textwidth}}
 \toprule \textbf{Refname} & \textbf{TM:factOfSafety}
 \phantomsection 
@@ -390,9 +394,10 @@ Label & Factor of safety
                                                   \\ \midrule \\
                                                   RefBy & \hyperref[GD:mobShr]{GD: mobShr}.
 \\ \bottomrule \end{tabular}
-\end{minipage}\\
-~\newline
- \noindent \begin{minipage}{\textwidth}
+\end{minipage}
+\par~
+    
+\noindent \begin{minipage}{\textwidth}
 \begin{tabular}{p{0.2\textwidth} p{0.73\textwidth}}
 \toprule \textbf{Refname} & \textbf{TM:equilibrium}
 \phantomsection 
@@ -416,9 +421,10 @@ Label & Equilibrium
                                                   \\ \midrule \\
                                                   RefBy & \hyperref[GD:normForcEq]{GD: normForcEq} \hyperref[GD:momentEql]{GD: momentEql} \hyperref[GD:bsShrFEq]{GD: bsShrFEq}.
 \\ \bottomrule \end{tabular}
-\end{minipage}\\
-~\newline
- \noindent \begin{minipage}{\textwidth}
+\end{minipage}
+\par~
+    
+\noindent \begin{minipage}{\textwidth}
 \begin{tabular}{p{0.2\textwidth} p{0.73\textwidth}}
 \toprule \textbf{Refname} & \textbf{TM:mcShrStrgth}
 \phantomsection 
@@ -443,9 +449,10 @@ Label & Mohr-Coulumb shear strength
                                                   \\ \midrule \\
                                                   RefBy & \hyperref[GD:resShr]{GD: resShr}.
 \\ \bottomrule \end{tabular}
-\end{minipage}\\
-~\newline
- \noindent \begin{minipage}{\textwidth}
+\end{minipage}
+\par~
+    
+\noindent \begin{minipage}{\textwidth}
 \begin{tabular}{p{0.2\textwidth} p{0.73\textwidth}}
 \toprule \textbf{Refname} & \textbf{TM:effStress}
 \phantomsection 
@@ -468,12 +475,13 @@ Label & Effective stress
                                                   \\ \midrule \\
                                                   RefBy & \hyperref[GD:resShr]{GD: resShr} \hyperref[GD:effNormF]{GD: effNormF}.
 \\ \bottomrule \end{tabular}
-\end{minipage}\\
+\end{minipage}
 \subsubsection{General Definitions}
 \label{Sec:GDs}
 This section collects the laws and equations that will be used in deriving the data definitions, which in turn are used to build the instance models.
-~\newline
- \noindent \begin{minipage}{\textwidth}
+\par~
+    
+\noindent \begin{minipage}{\textwidth}
 \begin{tabular}{p{0.2\textwidth} p{0.73\textwidth}}
 \toprule \textbf{Refname} & \textbf{GD:normForcEq}
 \phantomsection 
@@ -506,9 +514,10 @@ Label & Normal force equilibrium
                                                   \\ \midrule \\
                                                   RefBy & \hyperref[IM:intsliceFs]{IM: intsliceFs} \hyperref[IM:fctSfty]{IM: fctSfty}.
 \\ \bottomrule \end{tabular}
-\end{minipage}\\
-~\newline
- \noindent \begin{minipage}{\textwidth}
+\end{minipage}
+\par~
+    
+\noindent \begin{minipage}{\textwidth}
 \begin{tabular}{p{0.2\textwidth} p{0.73\textwidth}}
 \toprule \textbf{Refname} & \textbf{GD:bsShrFEq}
 \phantomsection 
@@ -541,9 +550,10 @@ Label & Base shear force equilibrium
                                                   \\ \midrule \\
                                                   RefBy & \hyperref[IM:intsliceFs]{IM: intsliceFs} \hyperref[IM:fctSfty]{IM: fctSfty}.
 \\ \bottomrule \end{tabular}
-\end{minipage}\\
-~\newline
- \noindent \begin{minipage}{\textwidth}
+\end{minipage}
+\par~
+    
+\noindent \begin{minipage}{\textwidth}
 \begin{tabular}{p{0.2\textwidth} p{0.73\textwidth}}
 \toprule \textbf{Refname} & \textbf{GD:resShr}
 \phantomsection 
@@ -571,9 +581,10 @@ Label & Resistive shear force
                                                   \\ \midrule \\
                                                   RefBy & \hyperref[GD:mobShr]{GD: mobShr}.
 \\ \bottomrule \end{tabular}
-\end{minipage}\\
-~\newline
- \noindent \begin{minipage}{\textwidth}
+\end{minipage}
+\par~
+    
+\noindent \begin{minipage}{\textwidth}
 \begin{tabular}{p{0.2\textwidth} p{0.73\textwidth}}
 \toprule \textbf{Refname} & \textbf{GD:mobShr}
 \phantomsection 
@@ -603,9 +614,10 @@ Label & Mobile shear force
                                                   \\ \midrule \\
                                                   RefBy & \hyperref[IM:intsliceFs]{IM: intsliceFs} \hyperref[IM:fctSfty]{IM: fctSfty}.
 \\ \bottomrule \end{tabular}
-\end{minipage}\\
-~\newline
- \noindent \begin{minipage}{\textwidth}
+\end{minipage}
+\par~
+    
+\noindent \begin{minipage}{\textwidth}
 \begin{tabular}{p{0.2\textwidth} p{0.73\textwidth}}
 \toprule \textbf{Refname} & \textbf{GD:effNormF}
 \phantomsection 
@@ -630,9 +642,10 @@ Label & Effective normal force
                                                   \\ \midrule \\
                                                   RefBy & 
 \\ \bottomrule \end{tabular}
-\end{minipage}\\
-~\newline
- \noindent \begin{minipage}{\textwidth}
+\end{minipage}
+\par~
+    
+\noindent \begin{minipage}{\textwidth}
 \begin{tabular}{p{0.2\textwidth} p{0.73\textwidth}}
 \toprule \textbf{Refname} & \textbf{GD:resShearWO}
 \phantomsection 
@@ -665,9 +678,10 @@ Label & Resistive shear force
                                           \\ \midrule \\
                                           RefBy & \hyperref[IM:intsliceFs]{IM: intsliceFs} \hyperref[IM:intsliceFs]{IM: intsliceFs} \hyperref[IM:fctSfty]{IM: fctSfty} \hyperref[IM:fctSfty]{IM: fctSfty}.
 \\ \bottomrule \end{tabular}
-\end{minipage}\\
-~\newline
- \noindent \begin{minipage}{\textwidth}
+\end{minipage}
+\par~
+    
+\noindent \begin{minipage}{\textwidth}
 \begin{tabular}{p{0.2\textwidth} p{0.73\textwidth}}
 \toprule \textbf{Refname} & \textbf{GD:mobShearWO}
 \phantomsection 
@@ -696,9 +710,10 @@ Label & Mobilized shear force
                                           \\ \midrule \\
                                           RefBy & \hyperref[IM:intsliceFs]{IM: intsliceFs} \hyperref[IM:intsliceFs]{IM: intsliceFs} \hyperref[IM:fctSfty]{IM: fctSfty}.
 \\ \bottomrule \end{tabular}
-\end{minipage}\\
-~\newline
- \noindent \begin{minipage}{\textwidth}
+\end{minipage}
+\par~
+    
+\noindent \begin{minipage}{\textwidth}
 \begin{tabular}{p{0.2\textwidth} p{0.73\textwidth}}
 \toprule \textbf{Refname} & \textbf{GD:normShrR}
 \phantomsection 
@@ -723,9 +738,10 @@ Label & Interslice normal/shear relationship
                                                   \\ \midrule \\
                                                   RefBy & \hyperref[IM:nrmShrFor]{IM: nrmShrFor} \hyperref[IM:nrmShrFor]{IM: nrmShrFor} \hyperref[IM:intsliceFs]{IM: intsliceFs} \hyperref[IM:intsliceFs]{IM: intsliceFs} \hyperref[IM:fctSfty]{IM: fctSfty}.
 \\ \bottomrule \end{tabular}
-\end{minipage}\\
-~\newline
- \noindent \begin{minipage}{\textwidth}
+\end{minipage}
+\par~
+    
+\noindent \begin{minipage}{\textwidth}
 \begin{tabular}{p{0.2\textwidth} p{0.73\textwidth}}
 \toprule \textbf{Refname} & \textbf{GD:momentEql}
 \phantomsection 
@@ -760,12 +776,13 @@ Label & Moment equilibrium
                                                   \\ \midrule \\
                                                   RefBy & \hyperref[IM:nrmShrFor]{IM: nrmShrFor} \hyperref[IM:intsliceFs]{IM: intsliceFs}.
 \\ \bottomrule \end{tabular}
-\end{minipage}\\
+\end{minipage}
 \subsubsection{Data Definitions}
 \label{Sec:DDs}
 This section collects and defines all the data needed to build the instance models.
-~\newline
- \noindent \begin{minipage}{\textwidth}
+\par~
+    
+\noindent \begin{minipage}{\textwidth}
 \begin{tabular}{p{0.2\textwidth} p{0.73\textwidth}}
 \toprule \textbf{Refname} & \textbf{DD:sliceWght}
 \phantomsection 
@@ -800,9 +817,10 @@ Label & Weight
                                                            \\ \midrule \\
                                                            RefBy & \hyperref[GD:momentEql]{GD: momentEql}.
 \\ \bottomrule \end{tabular}
-\end{minipage}\\
-~\newline
- \noindent \begin{minipage}{\textwidth}
+\end{minipage}
+\par~
+    
+\noindent \begin{minipage}{\textwidth}
 \begin{tabular}{p{0.2\textwidth} p{0.73\textwidth}}
 \toprule \textbf{Refname} & \textbf{DD:baseWtrF}
 \phantomsection 
@@ -836,9 +854,10 @@ Label & Base hydrostatic force
                                                                    \\ \midrule \\
                                                                    RefBy & 
 \\ \bottomrule \end{tabular}
-\end{minipage}\\
-~\newline
- \noindent \begin{minipage}{\textwidth}
+\end{minipage}
+\par~
+    
+\noindent \begin{minipage}{\textwidth}
 \begin{tabular}{p{0.2\textwidth} p{0.73\textwidth}}
 \toprule \textbf{Refname} & \textbf{DD:surfWtrF}
 \phantomsection 
@@ -872,9 +891,10 @@ Label & Surface hydrostatic force
                                                                    \\ \midrule \\
                                                                    RefBy & 
 \\ \bottomrule \end{tabular}
-\end{minipage}\\
-~\newline
- \noindent \begin{minipage}{\textwidth}
+\end{minipage}
+\par~
+    
+\noindent \begin{minipage}{\textwidth}
 \begin{tabular}{p{0.2\textwidth} p{0.73\textwidth}}
 \toprule \textbf{Refname} & \textbf{DD:intersliceWtrF}
 \phantomsection 
@@ -907,9 +927,10 @@ Label & Interslice water force
                                                            \\ \midrule \\
                                                            RefBy & 
 \\ \bottomrule \end{tabular}
-\end{minipage}\\
-~\newline
- \noindent \begin{minipage}{\textwidth}
+\end{minipage}
+\par~
+    
+\noindent \begin{minipage}{\textwidth}
 \begin{tabular}{p{0.2\textwidth} p{0.73\textwidth}}
 \toprule \textbf{Refname} & \textbf{DD:angleA}
 \phantomsection 
@@ -938,9 +959,10 @@ Label & Angle
                                                                    \\ \midrule \\
                                                                    RefBy & 
 \\ \bottomrule \end{tabular}
-\end{minipage}\\
-~\newline
- \noindent \begin{minipage}{\textwidth}
+\end{minipage}
+\par~
+    
+\noindent \begin{minipage}{\textwidth}
 \begin{tabular}{p{0.2\textwidth} p{0.73\textwidth}}
 \toprule \textbf{Refname} & \textbf{DD:angleB}
 \phantomsection 
@@ -969,9 +991,10 @@ Label & Angle
                                                                    \\ \midrule \\
                                                                    RefBy & 
 \\ \bottomrule \end{tabular}
-\end{minipage}\\
-~\newline
- \noindent \begin{minipage}{\textwidth}
+\end{minipage}
+\par~
+    
+\noindent \begin{minipage}{\textwidth}
 \begin{tabular}{p{0.2\textwidth} p{0.73\textwidth}}
 \toprule \textbf{Refname} & \textbf{DD:lengthB}
 \phantomsection 
@@ -997,9 +1020,10 @@ Label & Base width of a slice
                                                            \\ \midrule \\
                                                            RefBy & 
 \\ \bottomrule \end{tabular}
-\end{minipage}\\
-~\newline
- \noindent \begin{minipage}{\textwidth}
+\end{minipage}
+\par~
+    
+\noindent \begin{minipage}{\textwidth}
 \begin{tabular}{p{0.2\textwidth} p{0.73\textwidth}}
 \toprule \textbf{Refname} & \textbf{DD:lengthLb}
 \phantomsection 
@@ -1028,9 +1052,10 @@ Label & Total base length of a slice
                                                                    \\ \midrule \\
                                                                    RefBy & 
 \\ \bottomrule \end{tabular}
-\end{minipage}\\
-~\newline
- \noindent \begin{minipage}{\textwidth}
+\end{minipage}
+\par~
+    
+\noindent \begin{minipage}{\textwidth}
 \begin{tabular}{p{0.2\textwidth} p{0.73\textwidth}}
 \toprule \textbf{Refname} & \textbf{DD:lengthLs}
 \phantomsection 
@@ -1059,9 +1084,10 @@ Label & Length of an interslice surface
                                                                    \\ \midrule \\
                                                                    RefBy & \hyperref[GD:momentEql]{GD: momentEql}.
 \\ \bottomrule \end{tabular}
-\end{minipage}\\
-~\newline
- \noindent \begin{minipage}{\textwidth}
+\end{minipage}
+\par~
+    
+\noindent \begin{minipage}{\textwidth}
 \begin{tabular}{p{0.2\textwidth} p{0.73\textwidth}}
 \toprule \textbf{Refname} & \textbf{DD:slcHeight}
 \phantomsection 
@@ -1090,9 +1116,10 @@ Label & Y-direction height of a slice
                                                                    \\ \midrule \\
                                                                    RefBy & 
 \\ \bottomrule \end{tabular}
-\end{minipage}\\
-~\newline
- \noindent \begin{minipage}{\textwidth}
+\end{minipage}
+\par~
+    
+\noindent \begin{minipage}{\textwidth}
 \begin{tabular}{p{0.2\textwidth} p{0.73\textwidth}}
 \toprule \textbf{Refname} & \textbf{DD:stress}
 \phantomsection 
@@ -1118,9 +1145,10 @@ Label & Normal stress
                                                            \\ \midrule \\
                                                            RefBy & \hyperref[GD:effNormF]{GD: effNormF}.
 \\ \bottomrule \end{tabular}
-\end{minipage}\\
-~\newline
- \noindent \begin{minipage}{\textwidth}
+\end{minipage}
+\par~
+    
+\noindent \begin{minipage}{\textwidth}
 \begin{tabular}{p{0.2\textwidth} p{0.73\textwidth}}
 \toprule \textbf{Refname} & \textbf{DD:ratioVariation}
 \phantomsection 
@@ -1152,9 +1180,10 @@ Label & Interslice normal to shear force ratio variation function
                                                            \\ \midrule \\
                                                            RefBy & 
 \\ \bottomrule \end{tabular}
-\end{minipage}\\
-~\newline
- \noindent \begin{minipage}{\textwidth}
+\end{minipage}
+\par~
+    
+\noindent \begin{minipage}{\textwidth}
 \begin{tabular}{p{0.2\textwidth} p{0.73\textwidth}}
 \toprule \textbf{Refname} & \textbf{DD:convertFunc1}
 \phantomsection 
@@ -1184,9 +1213,10 @@ Label & First function for incorporating interslice forces into shear force
                                                            \\ \midrule \\
                                                            RefBy & \hyperref[IM:fctSfty]{IM: fctSfty}.
 \\ \bottomrule \end{tabular}
-\end{minipage}\\
-~\newline
- \noindent \begin{minipage}{\textwidth}
+\end{minipage}
+\par~
+    
+\noindent \begin{minipage}{\textwidth}
 \begin{tabular}{p{0.2\textwidth} p{0.73\textwidth}}
 \toprule \textbf{Refname} & \textbf{DD:convertFunc2}
 \phantomsection 
@@ -1217,9 +1247,10 @@ Label & Second function for incorporating interslice forces into shear force
                                                            \\ \midrule \\
                                                            RefBy & \hyperref[IM:fctSfty]{IM: fctSfty}.
 \\ \bottomrule \end{tabular}
-\end{minipage}\\
-~\newline
- \noindent \begin{minipage}{\textwidth}
+\end{minipage}
+\par~
+    
+\noindent \begin{minipage}{\textwidth}
 \begin{tabular}{p{0.2\textwidth} p{0.73\textwidth}}
 \toprule \textbf{Refname} & \textbf{DD:fixme1}
 \phantomsection 
@@ -1244,9 +1275,10 @@ Label & Fixme
                                                   Source & \\ \midrule \\
                                                            RefBy & 
 \\ \bottomrule \end{tabular}
-\end{minipage}\\
-~\newline
- \noindent \begin{minipage}{\textwidth}
+\end{minipage}
+\par~
+    
+\noindent \begin{minipage}{\textwidth}
 \begin{tabular}{p{0.2\textwidth} p{0.73\textwidth}}
 \toprule \textbf{Refname} & \textbf{DD:fixme2}
 \phantomsection 
@@ -1271,12 +1303,13 @@ Label & Fixme
                                                   Source & \\ \midrule \\
                                                            RefBy & 
 \\ \bottomrule \end{tabular}
-\end{minipage}\\
+\end{minipage}
 \subsubsection{Instance Models}
 \label{Sec:IMs}
 This section transforms the problem defined in \hyperref[Sec:ProbDesc]{Section: Problem Description} into one which is expressed in mathematical terms. It uses concrete symbols defined in \hyperref[Sec:DDs]{Section: Data Definitions} to replace the abstract symbols in the models identified in \hyperref[Sec:TMs]{Section: Theoretical Models} and \hyperref[Sec:GDs]{Section: General Definitions}.
-~\newline
- \noindent \begin{minipage}{\textwidth}
+\par~
+    
+\noindent \begin{minipage}{\textwidth}
 \begin{tabular}{p{0.2\textwidth} p{0.73\textwidth}}
 \toprule \textbf{Refname} & \textbf{IM:fctSfty}
 \phantomsection 
@@ -1309,7 +1342,7 @@ Label & Factor of safety
                                                                                                             \\ \midrule \\
                                                                                                             RefBy & \hyperref[IM:intsliceFs]{IM: intsliceFs} \hyperref[IM:fctSfty]{IM: fctSfty}.
 \\ \bottomrule \end{tabular}
-\end{minipage}\\
+\end{minipage}
 The mobilized shear force defined in \hyperref[GD:bsShrFEq]{GD: bsShrFEq} can be substituted into the definition of mobilized shear force based on the factor of safety, from \hyperref[GD:mobShr]{GD: mobShr} yielding equation (1) below:
 \begin{displaymath}
 \left(W_{i}-X_{i-1}+X_{i}+{U_{t,i}} \cos\left(β_{i}\right)+Q_{i} \cos\left(ω_{i}\right)\right) \sin\left(α_{i}\right)-\left(-{K_{c}} W_{i}-G_{i}+G_{i-1}-H_{i}+H_{i-1}+{U_{t,i}} \sin\left(β_{i}\right)+Q_{i} \sin\left(ω_{i}\right)\right) \cos\left(α_{i}\right)=\frac{{N'}_{i} \tan\left(φ'\right)+c' {ℓ_{b,i}}}{{F_{S}}}
@@ -1403,8 +1436,9 @@ Isolating the factor of safety on the left-hand side and using compact notation 
 {F_{S}}=\frac{\displaystyle\sum_{v=1}^{n-1}{R_{v} \displaystyle\prod_{u=i}^{n-1}{Ψ_{u}}}+R_{n}}{\displaystyle\sum_{v=1}^{n-1}{T_{v} \displaystyle\prod_{u=i}^{n-1}{Ψ_{u}}}+T_{n}}
 \end{displaymath}
 ${F_{S}}$ depends on the unknowns $λ$ (\hyperref[IM:nrmShrFor]{IM: nrmShrFor}) and $G$ (\hyperref[IM:intsliceFs]{IM: intsliceFs}).
-~\newline
- \noindent \begin{minipage}{\textwidth}
+\par~
+    
+\noindent \begin{minipage}{\textwidth}
 \begin{tabular}{p{0.2\textwidth} p{0.73\textwidth}}
 \toprule \textbf{Refname} & \textbf{IM:nrmShrFor}
 \phantomsection 
@@ -1464,7 +1498,7 @@ b_{n} G_{n-1} H_{n-1}, & i=1
                                                                                                             \\ \midrule \\
                                                                                                             RefBy & \hyperref[IM:nrmShrFor]{IM: nrmShrFor} \hyperref[IM:intsliceFs]{IM: intsliceFs} \hyperref[IM:fctSfty]{IM: fctSfty}.
 \\ \bottomrule \end{tabular}
-\end{minipage}\\
+\end{minipage}
 From the moment equilibrium of \hyperref[GD:momentEql]{GD: momentEql} with the primary assumption for the Morgenstern-Price method of \hyperref[A:Interslice-Norm-Shear-Forces-Linear]{A: Interslice-Norm-Shear-Forces-Linear} and associated definition \hyperref[GD:normShrR]{GD: normShrR} equation equation (9) can be derived:
 \begin{displaymath}
 0=-G_{i} \left(z_{i}-\frac{b_{i}}{2} \tan\left(α_{i}\right)\right)+G_{i-1} \left(z_{i-1}-\frac{b_{i}}{2} \tan\left(α_{i}\right)\right)-H_{i} \left(z_{i}-\frac{b_{i}}{2} \tan\left(α_{i}\right)\right)+H_{i-1} \left(z_{i-1}-\frac{b_{i}}{2} \tan\left(α_{i}\right)\right)-λ \frac{b_{i}}{2} \left(G_{i} f_{i}+G_{i-1} f_{i-1}\right)+\frac{{K_{c}} W_{i} h_{i}}{2}-{U_{t,i}} \sin\left(β_{i}\right) h_{i}-Q_{i} \sin\left(ω_{i}\right) h_{i}
@@ -1478,8 +1512,9 @@ Taking a summation of each slice, and applying the boundary condition that $G_{0
 λ_{i}=\frac{\displaystyle\sum_{i=1}^{n}{b_{i} \left(SpencerFixme1Please+SpencerFixme2Please\right) \tan\left(α_{i}\right)+h_{i} \left({K_{c}} W_{i}-2 {U_{t,i}} \sin\left(β_{i}\right)-2 Q_{i} \sin\left(ω_{i}\right)\right)}}{\displaystyle\sum_{i=1}^{n}{b_{i} \left(G_{i} f_{i}+G_{i-1} f_{i-1}\right)}}
 \end{displaymath}
 equation (11) for $λ$, is a function of the unknown interslice normal force $G$ \hyperref[IM:intsliceFs]{IM: intsliceFs}.
-~\newline
- \noindent \begin{minipage}{\textwidth}
+\par~
+    
+\noindent \begin{minipage}{\textwidth}
 \begin{tabular}{p{0.2\textwidth} p{0.73\textwidth}}
 \toprule \textbf{Refname} & \textbf{IM:intsliceFs}
 \phantomsection 
@@ -1518,7 +1553,7 @@ Label & Interslice forces
                                                                                                             \\ \midrule \\
                                                                                                             RefBy & \hyperref[IM:nrmShrFor]{IM: nrmShrFor} \hyperref[IM:intsliceFs]{IM: intsliceFs} \hyperref[IM:fctSfty]{IM: fctSfty}.
 \\ \bottomrule \end{tabular}
-\end{minipage}\\
+\end{minipage}
 Substituting the normal force equilibrium of \hyperref[GD:normForcEq]{GD: normForcEq} and the assumption \hyperref[A:Interslice-Norm-Shear-Forces-Linear]{A: Interslice-Norm-Shear-Forces-Linear} represented by \hyperref[GD:momentEql]{GD: momentEql} into the effective normal force definition from \hyperref[GD:normShrR]{GD: normShrR} yields equation equation (12):
 \begin{displaymath}
 {N'}_{i}=\left(W_{i}-λ f_{i-1} G_{i-1}+λ f_{i} G_{i}+{U_{t,i}} \cos\left(β_{i}\right)+Q_{i} \cos\left(ω_{i}\right)\right) \cos\left(α_{i}\right)-\left(-{K_{c}} W_{i}-G_{i}+G_{i-1}-H_{i}+H_{i-1}+{U_{t,i}} \sin\left(β_{i}\right)+Q_{i} \sin\left(ω_{i}\right)\right) \sin\left(α_{i}\right)-{U_{b,i}}
@@ -1542,8 +1577,9 @@ Where $R$ and $T$ are the resistive and mobile shear of the slice, without the i
 G_{i}=\frac{Ψ_{i-1} G_{i-1}+{F_{S}} T_{i}-R_{i}}{Φ_{i}}
 \end{displaymath}
 The constants $Ψ$ and $Φ$ described in equation (20) and equation (19) are functions of the unknowns: the interslice normal/shear force ratio $λ$ (\hyperref[IM:nrmShrFor]{IM: nrmShrFor}) and the factor of safety ${F_{S}}$ (\hyperref[IM:fctSfty]{IM: fctSfty}).
-~\newline
- \noindent \begin{minipage}{\textwidth}
+\par~
+    
+\noindent \begin{minipage}{\textwidth}
 \begin{tabular}{p{0.2\textwidth} p{0.73\textwidth}}
 \toprule \textbf{Refname} & \textbf{IM:crtSlpId}
 \phantomsection 
@@ -1572,7 +1608,7 @@ Label & Critical slip identification
                                                                                                             \\ \midrule \\
                                                                                                             RefBy & 
 \\ \bottomrule \end{tabular}
-\end{minipage}\\
+\end{minipage}
 \subsubsection{Data Constraints}
 \label{Sec:DataConstraints}
 \hyperref[Table:InDataConstraints]{Table:InDataConstraints} and \hyperref[Table:OutDataConstraints]{Table:OutDataConstraints} show the data constraints on the input and output variables, respectively. The column for physical constraints gives the physical limitations on the range of values that can be taken by the variable. The uncertainty column provides an estimate of the confidence with which the physical quantities can be measured. This information would be part of the input if one were performing an uncertainty quantification exercise. The constraints are conservative, to give the user of the model the flexibility to experiment with unusual situations. The column of typical values is intended to provide a feel for a common scenario.
@@ -1581,6 +1617,7 @@ Label & Critical slip identification
 Var & Physical Constraints & Typical Value & Uncert.
 \\
 \midrule
+\endhead
 $c'$ & $c'>0$ & $10.0$ Pa & 10.0$\%$
 \\
 $γ$ & $γ>0$ & $20.0$ $\frac{\text{N}}{\text{m}^{3}}$ & 10.0$\%$
@@ -1600,6 +1637,7 @@ $φ'$ & $0<φ'<90$ & $25.0$ ${}^{\circ}$ & 10.0$\%$
 Var & Physical Constraints
 \\
 \midrule
+\endhead
 ${F_{S}}$ & ${F_{S}}>0$
 \\
 $(x,y)$ & --
@@ -1631,6 +1669,7 @@ This section provides the functional requirements, the business tasks that the s
 Symbol & Unit & Name
 \\
 \midrule
+\endhead
 $(x,y)$ & m & cartesian position coordinates
 \\
 $c'$ & Pa & effective cohesion

--- a/code/stable/swhs/SRS/SWHS_SRS.tex
+++ b/code/stable/swhs/SRS/SWHS_SRS.tex
@@ -40,6 +40,7 @@ The unit system used throughout is SI (Système International d'Unités). In add
 Symbol & Description
 \\
 \midrule
+\endhead
 ${}^{\circ}$C & temperature (centigrade)
 \\
 J & energy (joule)
@@ -63,6 +64,7 @@ The table that follows summarizes the symbols used in this document along with t
 Symbol & Description & Units
 \\
 \midrule
+\endhead
 ${A_{C}}$ & Heating coil surface area & $\text{m}^{2}$
 \\
 ${A_{in}}$ & Surface area over which heat is transferred in & $\text{m}^{2}$
@@ -201,6 +203,7 @@ $∇$ & Gradient & --
 Abbreviation & Full Form
 \\
 \midrule
+\endhead
 A & Assumption
 \\
 DD & Data Definition
@@ -396,8 +399,9 @@ This section simplifies the original problem and helps in developing the theoret
 \subsubsection{Theoretical Models}
 \label{Sec:TMs}
 This section focuses on the general equations and laws that SWHS is based on.
-~\newline
- \noindent \begin{minipage}{\textwidth}
+\par~
+    
+\noindent \begin{minipage}{\textwidth}
 \begin{tabular}{p{0.2\textwidth} p{0.73\textwidth}}
 \toprule \textbf{Refname} & \textbf{TM:consThermE}
 \phantomsection 
@@ -425,9 +429,10 @@ Label & Conservation of thermal energy
                                                   \\ \midrule \\
                                                   RefBy & \hyperref[GD:rocTempSimp]{GD: rocTempSimp}.
 \\ \bottomrule \end{tabular}
-\end{minipage}\\
-~\newline
- \noindent \begin{minipage}{\textwidth}
+\end{minipage}
+\par~
+    
+\noindent \begin{minipage}{\textwidth}
 \begin{tabular}{p{0.2\textwidth} p{0.73\textwidth}}
 \toprule \textbf{Refname} & \textbf{TM:sensHtE}
 \phantomsection 
@@ -461,9 +466,10 @@ Label & Sensible heat energy
                                                   \\ \midrule \\
                                                   RefBy & \hyperref[IM:heatEInWtr]{IM: heatEInWtr} \hyperref[IM:heatEInPCM]{IM: heatEInPCM} \hyperref[IM:heatEInPCM]{IM: heatEInPCM} \hyperref[IM:heatEInPCM]{IM: heatEInPCM}.
 \\ \bottomrule \end{tabular}
-\end{minipage}\\
-~\newline
- \noindent \begin{minipage}{\textwidth}
+\end{minipage}
+\par~
+    
+\noindent \begin{minipage}{\textwidth}
 \begin{tabular}{p{0.2\textwidth} p{0.73\textwidth}}
 \toprule \textbf{Refname} & \textbf{TM:latentHtE}
 \phantomsection 
@@ -487,12 +493,13 @@ Label & Latent heat energy
                                                   \\ \midrule \\
                                                   RefBy & \hyperref[TM:sensHtE]{TM: sensHtE} \hyperref[IM:heatEInPCM]{IM: heatEInPCM}.
 \\ \bottomrule \end{tabular}
-\end{minipage}\\
+\end{minipage}
 \subsubsection{General Definitions}
 \label{Sec:GDs}
 This section collects the laws and equations that will be used in deriving the data definitions, which in turn are used to build the instance models.
-~\newline
- \noindent \begin{minipage}{\textwidth}
+\par~
+    
+\noindent \begin{minipage}{\textwidth}
 \begin{tabular}{p{0.2\textwidth} p{0.73\textwidth}}
 \toprule \textbf{Refname} & \textbf{GD:nwtnCooling}
 \phantomsection 
@@ -519,9 +526,10 @@ Label & Newton's law of cooling
                                                           \\ \midrule \\
                                                           RefBy & 
 \\ \bottomrule \end{tabular}
-\end{minipage}\\
-~\newline
- \noindent \begin{minipage}{\textwidth}
+\end{minipage}
+\par~
+    
+\noindent \begin{minipage}{\textwidth}
 \begin{tabular}{p{0.2\textwidth} p{0.73\textwidth}}
 \toprule \textbf{Refname} & \textbf{GD:rocTempSimp}
 \phantomsection 
@@ -551,7 +559,7 @@ Label & Simplified rate of change of temperature
                                          Source & \\ \midrule \\
                                                   RefBy & \hyperref[GD:rocTempSimp]{GD: rocTempSimp} \hyperref[IM:eBalanceOnWtr]{IM: eBalanceOnWtr} \hyperref[IM:eBalanceOnPCM]{IM: eBalanceOnPCM}.
 \\ \bottomrule \end{tabular}
-\end{minipage}\\
+\end{minipage}
 Detailed derivation of simplified rate of change of temperature :
 Integrating \hyperref[TM:consThermE]{TM: consThermE} over a volume ($V$), we have:
 \begin{displaymath}
@@ -576,8 +584,9 @@ m C \frac{d\,T}{d\,t}={q_{in}} {A_{in}}-{q_{out}} {A_{out}}+g V
 \subsubsection{Data Definitions}
 \label{Sec:DDs}
 This section collects and defines all the data needed to build the instance models.
-~\newline
- \noindent \begin{minipage}{\textwidth}
+\par~
+    
+\noindent \begin{minipage}{\textwidth}
 \begin{tabular}{p{0.2\textwidth} p{0.73\textwidth}}
 \toprule \textbf{Refname} & \textbf{DD:ht.flux.C}
 \phantomsection 
@@ -609,9 +618,10 @@ Label & Heat flux into the water from the coil
                                                                    \\ \midrule \\
                                                                    RefBy & \hyperref[IM:eBalanceOnWtr]{IM: eBalanceOnWtr}.
 \\ \bottomrule \end{tabular}
-\end{minipage}\\
-~\newline
- \noindent \begin{minipage}{\textwidth}
+\end{minipage}
+\par~
+    
+\noindent \begin{minipage}{\textwidth}
 \begin{tabular}{p{0.2\textwidth} p{0.73\textwidth}}
 \toprule \textbf{Refname} & \textbf{DD:ht.flux.P}
 \phantomsection 
@@ -643,9 +653,10 @@ Label & Heat flux into the PCM from water
                                                                    \\ \midrule \\
                                                                    RefBy & \hyperref[IM:eBalanceOnWtr]{IM: eBalanceOnWtr} \hyperref[IM:eBalanceOnPCM]{IM: eBalanceOnPCM}.
 \\ \bottomrule \end{tabular}
-\end{minipage}\\
-~\newline
- \noindent \begin{minipage}{\textwidth}
+\end{minipage}
+\par~
+    
+\noindent \begin{minipage}{\textwidth}
 \begin{tabular}{p{0.2\textwidth} p{0.73\textwidth}}
 \toprule \textbf{Refname} & \textbf{DD:htFusion}
 \phantomsection 
@@ -671,9 +682,10 @@ Label & Specific latent heat of fusion
                                                            \\ \midrule \\
                                                            RefBy & \hyperref[DD:melt.frac]{DD: melt\_frac} \hyperref[TM:latentHtE]{TM: latentHtE} \hyperref[IM:heatEInPCM]{IM: heatEInPCM} \hyperref[IM:eBalanceOnWtr]{IM: eBalanceOnWtr} \hyperref[IM:eBalanceOnWtr]{IM: eBalanceOnWtr}.
 \\ \bottomrule \end{tabular}
-\end{minipage}\\
-~\newline
- \noindent \begin{minipage}{\textwidth}
+\end{minipage}
+\par~
+    
+\noindent \begin{minipage}{\textwidth}
 \begin{tabular}{p{0.2\textwidth} p{0.73\textwidth}}
 \toprule \textbf{Refname} & \textbf{DD:melt.frac}
 \phantomsection 
@@ -702,12 +714,13 @@ Label & Melt fraction
                                                                    \\ \midrule \\
                                                                    RefBy & \hyperref[IM:eBalanceOnWtr]{IM: eBalanceOnWtr} \hyperref[IM:eBalanceOnPCM]{IM: eBalanceOnPCM}.
 \\ \bottomrule \end{tabular}
-\end{minipage}\\
+\end{minipage}
 \subsubsection{Instance Models}
 \label{Sec:IMs}
 This section transforms the problem defined in \hyperref[Sec:ProbDesc]{Section: Problem Description} into one which is expressed in mathematical terms. It uses concrete symbols defined in \hyperref[Sec:DDs]{Section: Data Definitions} to replace the abstract symbols in the models identified in \hyperref[Sec:TMs]{Section: Theoretical Models} and \hyperref[Sec:GDs]{Section: General Definitions}.
-~\newline
- \noindent \begin{minipage}{\textwidth}
+\par~
+    
+\noindent \begin{minipage}{\textwidth}
 \begin{tabular}{p{0.2\textwidth} p{0.73\textwidth}}
 \toprule \textbf{Refname} & \textbf{IM:eBalanceOnWtr}
 \phantomsection 
@@ -746,7 +759,7 @@ Label & Energy balance on water to find the temperature of the water
                                                                                                             \\ \midrule \\
                                                                                                             RefBy & \hyperref[unlikeChgNIHG]{UC: No-Internal-Heat-Generation} \hyperref[outputInputDerivQuants]{FR: Output-Input-Derived-Quantities} \hyperref[outputInputDerivQuants]{FR: Output-Input-Derived-Quantities} \hyperref[findMass]{FR: Find-Mass} \hyperref[IM:eBalanceOnWtr]{IM: eBalanceOnWtr} \hyperref[IM:eBalanceOnPCM]{IM: eBalanceOnPCM} \hyperref[calcTempWtrOverTime]{FR: Calculate-Temperature-Water-Over-Time}.
 \\ \bottomrule \end{tabular}
-\end{minipage}\\
+\end{minipage}
 Derivation of the energy balance on water:
 To find the rate of change of ${T_{W}}$, we look at the energy balance on water. The volume being considered is the volume of water ${V_{W}}$, which has mass of water ${m_{W}}$ and specific heat capacity of water, ${C_{W}}$. ${q_{C}}$ represents the heat transfer into the water from the heating coil and ${q_{P}}$ represents the heat transfer into the PCM from water, over heating coil surface area and phase change material surface area of ${A_{C}}$ and ${A_{P}}$, respectively. No heat transfer occurs to the outside of the tank, since it has been assumed to be perfectly insulated (\hyperref[A:Perfect-Insulation-Tank]{A: Perfect-Insulation-Tank}). Assuming no volumetric heat generation per unit volume (\hyperref[A:No-Internal-Heat-Generation-By-Water-PCM]{A: No-Internal-Heat-Generation-By-Water-PCM}), $g=0$. Therefore, the equation for \hyperref[GD:rocTempSimp]{GD: rocTempSimp} can be written as:
 \begin{displaymath}
@@ -776,8 +789,9 @@ Finally, factoring out $\frac{1}{{τ_{W}}}$ , we are left with the governing ODE
 \begin{displaymath}
 \frac{d\,{T_{W}}}{d\,t}=\frac{1}{{τ_{W}}} \left({T_{C}}-{T_{W}}+η \left({T_{P}}-{T_{W}}\right)\right)
 \end{displaymath}
-~\newline
- \noindent \begin{minipage}{\textwidth}
+\par~
+    
+\noindent \begin{minipage}{\textwidth}
 \begin{tabular}{p{0.2\textwidth} p{0.73\textwidth}}
 \toprule \textbf{Refname} & \textbf{IM:eBalanceOnPCM}
 \phantomsection 
@@ -822,7 +836,7 @@ Label & Energy Balance on PCM to Find T\_p
                                                                                                             \\ \midrule \\
                                                                                                             RefBy & \hyperref[unlikeChgNIHG]{UC: No-Internal-Heat-Generation} \hyperref[unlikeChgNGS]{UC: No-Gaseous-State} \hyperref[outputInputDerivQuants]{FR: Output-Input-Derived-Quantities} \hyperref[outputInputDerivQuants]{FR: Output-Input-Derived-Quantities} \hyperref[findMass]{FR: Find-Mass} \hyperref[IM:eBalanceOnWtr]{IM: eBalanceOnWtr} \hyperref[calcTempPCMOverTime]{FR: Calculate-Temperature-PCM-Over-Time} \hyperref[calcPCMMeltEnd]{FR: Calculate-PCM-Melt-End-Time} \hyperref[calcPCMMeltBegin]{FR: Calculate-PCM-Melt-Begin-Time}.
 \\ \bottomrule \end{tabular}
-\end{minipage}\\
+\end{minipage}
 Detailed derivation of the energy balance on the PCM during  sensible heating phase:
 To find the rate of change of ${T_{P}}$, we look at the energy balance on the PCM. The volume being considered is the volume of PCM, ${V_{P}}$. The derivation that follows is initially for the solid PCM. The mass of phase change material is ${m_{P}}$ and the specific heat capacity of PCM as a solid is ${{C_{P}}^{S}}$. The heat flux into the PCM from water is ${q_{P}}$ over phase change material surface area ${A_{P}}$. There is no heat flux output. Assuming no volumetric heat generation per unit volume (\hyperref[A:No-Internal-Heat-Generation-By-Water-PCM]{A: No-Internal-Heat-Generation-By-Water-PCM}), $g=0$ , the equation for \hyperref[GD:rocTempSimp]{GD: rocTempSimp} can be written as:
 \begin{displaymath}
@@ -843,8 +857,9 @@ Setting ${{τ_{P}}^{S}}$ = ${m_{P}}$ ${{C_{P}}^{S}}$ / ${h_{P}}$ ${A_{P}}$ , thi
 Equation (6) applies for the solid PCM. In the case where all of the PCM is melted, the same derivation applies, except that ${{C_{P}}^{S}}$ is replaced by ${{C_{P}}^{L}}$, and thus ${{τ_{P}}^{S}}$ is replaced by ${{τ_{P}}^{L}}$. Although a small change in surface area would be expected with melting, this is not included, since the volume change of the PCM with melting is assumed to be negligible (\hyperref[A:Volume-Change-Melting-PCM-Negligible]{A: Volume-Change-Melting-PCM-Negligible}).
 In the case where ${T_{P}}={{T_{melt}}^{P}}$ and not all of the PCM is melted, the temperature of the phase change material does not change. Therefore, in this case d ${T_{P}}$ / d $t$ = 0.
 This derivation does not consider the boiling of the PCM, as the PCM is assumed to either be in a solid state or a liquid state (\hyperref[A:No-Gaseous-State-PCM]{A: No-Gaseous-State-PCM}).
-~\newline
- \noindent \begin{minipage}{\textwidth}
+\par~
+    
+\noindent \begin{minipage}{\textwidth}
 \begin{tabular}{p{0.2\textwidth} p{0.73\textwidth}}
 \toprule \textbf{Refname} & \textbf{IM:heatEInWtr}
 \phantomsection 
@@ -880,9 +895,10 @@ Label & Heat energy in the water
                                                                                                             \\ \midrule \\
                                                                                                             RefBy & \hyperref[findMass]{FR: Find-Mass} \hyperref[calcChgHeatEnergyWtrOverTime]{FR: Calculate-Change-Heat\_Energy-Water-Over-Time}.
 \\ \bottomrule \end{tabular}
-\end{minipage}\\
-~\newline
- \noindent \begin{minipage}{\textwidth}
+\end{minipage}
+\par~
+    
+\noindent \begin{minipage}{\textwidth}
 \begin{tabular}{p{0.2\textwidth} p{0.73\textwidth}}
 \toprule \textbf{Refname} & \textbf{IM:heatEInPCM}
 \phantomsection 
@@ -932,7 +948,7 @@ Label & Heat energy in the PCM
                                                                                                             \\ \midrule \\
                                                                                                             RefBy & \hyperref[unlikeChgNGS]{UC: No-Gaseous-State} \hyperref[findMass]{FR: Find-Mass} \hyperref[IM:eBalanceOnPCM]{IM: eBalanceOnPCM} \hyperref[calcChgHeatEnergyPCMOverTime]{FR: Calculate-Change-Heat\_Energy-PCM-Over-Time}.
 \\ \bottomrule \end{tabular}
-\end{minipage}\\
+\end{minipage}
 \subsubsection{Data Constraints}
 \label{Sec:DataConstraints}
 \hyperref[Table:InDataConstraints]{Table:InDataConstraints} and \hyperref[Table:OutDataConstraints]{Table:OutDataConstraints} show the data constraints on the input and output variables, respectively. The column for physical constraints gives the physical limitations on the range of values that can be taken by the variable. The uncertainty column provides an estimate of the confidence with which the physical quantities can be measured. This information would be part of the input if one were performing an uncertainty quantification exercise. The constraints are conservative, to give the user of the model the flexibility to experiment with unusual situations. The column of typical values is intended to provide a feel for a common scenario. The column for software constraints restricts the range of inputs to reasonable values.(*) These quantities cannot be equal to zero, or there will be a divide by zero in the model. (+) These quantities cannot be zero, or there would be freezing (\hyperref[A:PCM-Initially-Solid]{A: PCM-Initially-Solid}). (++) The constraints on the surface area are calculated by considering the surface area to volume ratio. The assumption is that the lowest ratio is 1 and the highest possible is $\frac{2}{{h_{min}}}$, where ${h_{min}}$ is the thickness of a ``sheet'' of PCM. A thin sheet has the greatest surface area to volume ratio. (**) The constraint on the maximum time at the end of the simulation is the total number of seconds in one day.
@@ -941,6 +957,7 @@ Label & Heat energy in the PCM
 Var & Physical Constraints & Software Constraints & Typical Value & Uncert.
 \\
 \midrule
+\endhead
 ${A_{C}}$ & ${A_{C}}>0$ & ${A_{C}}\leq{}{{A_{C}}^{max}}$ & $120.0\cdot{}10^{-3}$ $\text{m}^{2}$ & 10.0$\%$
 \\
 ${A_{P}}$ & ${A_{P}}>0$ & ${V_{P}}\leq{}{A_{P}}\leq{}\frac{2}{{h_{min}}} {V_{tank}}$ & $1.2$ $\text{m}^{2}$ & 10.0$\%$
@@ -984,6 +1001,7 @@ ${ρ_{W}}$ & ${ρ_{W}}>0$ & ${{ρ_{W}}^{min}}<{ρ_{W}}\leq{}{{ρ_{W}}^{max}}$ & 
 Var & Physical Constraints
 \\
 \midrule
+\endhead
 ${T_{W}}$ & ${T_{init}}\leq{}{T_{W}}\leq{}{T_{C}}$
 \\
 ${T_{P}}$ & ${T_{init}}\leq{}{T_{P}}\leq{}{T_{C}}$
@@ -1030,6 +1048,7 @@ This section provides the functional requirements, the business tasks that the s
 Symbol & Unit & Description
 \\
 \midrule
+\endhead
 $L$ & m & length of tank
 \\
 $D$ & m & diameter of tank
@@ -1096,6 +1115,7 @@ The purpose of the traceability matrices is to provide easy references on what h
  & \hyperref[inputInitQuants]{FR: Input-Initial-Quantities} & \hyperref[IM:heatEInWtr]{IM: heatEInWtr} & \hyperref[IM:eBalanceOnWtr]{IM: eBalanceOnWtr} & \hyperref[likeChgDT]{LC: Discharging-Tank} & \hyperref[GD:rocTempSimp]{GD: rocTempSimp} & \hyperref[DD:ht.flux.P]{DD: ht\_flux\_P} & \hyperref[GD:nwtnCooling]{GD: nwtnCooling} & \hyperref[DD:ht.flux.C]{DD: ht\_flux\_C} & \hyperref[unlikeChgWPFS]{UC: Water-PCM-Fixed-States} & \hyperref[unlikeChgNGS]{UC: No-Gaseous-State} & \hyperref[IM:heatEInPCM]{IM: heatEInPCM} & \hyperref[IM:eBalanceOnPCM]{IM: eBalanceOnPCM} & \hyperref[unlikeChgNIHG]{UC: No-Internal-Heat-Generation} & \hyperref[likeChgTLH]{LC: Tank-Lose-Heat} & \hyperref[likeChgDITPW]{LC: Different-Initial-Temps-PCM-Water} & \hyperref[TM:consThermE]{TM: consThermE} & \hyperref[likeChgTCVOL]{LC: Temperature-Coil-Variable-Over-Length} & \hyperref[likeChgTCVOD]{LC: Temperature-Coil-Variable-Over-Day} & \hyperref[likeChgUTP]{LC: Uniform-Temperature-PCM} & \hyperref[outputInputDerivQuants]{FR: Output-Input-Derived-Quantities} & \hyperref[findMass]{FR: Find-Mass} & \hyperref[calcTempPCMOverTime]{FR: Calculate-Temperature-PCM-Over-Time} & \hyperref[calcPCMMeltEnd]{FR: Calculate-PCM-Melt-End-Time} & \hyperref[calcPCMMeltBegin]{FR: Calculate-PCM-Melt-Begin-Time} & \hyperref[calcTempWtrOverTime]{FR: Calculate-Temperature-Water-Over-Time} & \hyperref[calcChgHeatEnergyPCMOverTime]{FR: Calculate-Change-Heat\_Energy-PCM-Over-Time} & \hyperref[calcChgHeatEnergyWtrOverTime]{FR: Calculate-Change-Heat\_Energy-Water-Over-Time} & \hyperref[DD:melt.frac]{DD: melt\_frac} & \hyperref[TM:latentHtE]{TM: latentHtE} & \hyperref[TM:sensHtE]{TM: sensHtE}
 \\
 \midrule
+\endhead
 \hyperref[Table:Input-Variable-Requirements]{Table:Input-Variable-Requirements} & X &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  & 
 \\
 \hyperref[A:Atmospheric-Pressure-Tank]{A: Atmospheric-Pressure-Tank} &  & X & X &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  & 
@@ -1175,6 +1195,7 @@ The purpose of the traceability matrices is to provide easy references on what h
  & T1 (\hyperref[TM:consThermE]{TM: consThermE}) & T2 (\hyperref[TM:sensHtE]{TM: sensHtE}) & T3 (\hyperref[TM:latentHtE]{TM: latentHtE}) & GD1 (\hyperref[GD:nwtnCooling]{GD: nwtnCooling}) & GD2 (\hyperref[GD:rocTempSimp]{GD: rocTempSimp}) & DD1 (\hyperref[DD:ht.flux.C]{DD: ht\_flux\_C}) & DD2 (\hyperref[DD:ht.flux.P]{DD: ht\_flux\_P}) & DD3 (\hyperref[DD:htFusion]{DD: htFusion}) & DD4 (\hyperref[DD:melt.frac]{DD: melt\_frac}) & IM1 (\hyperref[IM:eBalanceOnWtr]{IM: eBalanceOnWtr}) & IM2 (\hyperref[IM:eBalanceOnPCM]{IM: eBalanceOnPCM}) & IM3 (\hyperref[IM:heatEInWtr]{IM: heatEInWtr}) & IM4 (\hyperref[IM:heatEInPCM]{IM: heatEInPCM})
 \\
 \midrule
+\endhead
 T1 (\hyperref[TM:consThermE]{TM: consThermE}) &  &  &  &  &  &  &  &  &  &  &  &  & 
 \\
 T2 (\hyperref[TM:sensHtE]{TM: sensHtE}) &  &  & X &  &  &  &  &  &  &  &  &  & 
@@ -1210,6 +1231,7 @@ IM4 (\hyperref[IM:heatEInPCM]{IM: heatEInPCM}) &  & X & X &  &  &  & X & X & X &
  & IM1 (\hyperref[IM:eBalanceOnWtr]{IM: eBalanceOnWtr}) & IM2 (\hyperref[IM:eBalanceOnPCM]{IM: eBalanceOnPCM}) & IM3 (\hyperref[IM:heatEInWtr]{IM: heatEInWtr}) & IM4 (\hyperref[IM:heatEInPCM]{IM: heatEInPCM}) & Data Constraints (\hyperref[Table:InDataConstraints]{Table:InDataConstraints}) & R1 (\hyperref[inputInitQuants]{FR: Input-Initial-Quantities}) & R2 (\hyperref[findMass]{FR: Find-Mass}) & R3 (\hyperref[checkWithPhysConsts]{FR: Check-Input-with-Physical\_Constraints}) & R4 (\hyperref[outputInputDerivQuants]{FR: Output-Input-Derived-Quantities}) & R5 (\hyperref[calcTempWtrOverTime]{FR: Calculate-Temperature-Water-Over-Time}) & R6 (\hyperref[calcTempPCMOverTime]{FR: Calculate-Temperature-PCM-Over-Time}) & R7 (\hyperref[calcChgHeatEnergyWtrOverTime]{FR: Calculate-Change-Heat\_Energy-Water-Over-Time}) & R8 (\hyperref[calcChgHeatEnergyPCMOverTime]{FR: Calculate-Change-Heat\_Energy-PCM-Over-Time}) & R9 (\hyperref[verifyEnergyOutput]{FR: Verify-Energy-Output-Follow-Conservation-of-Energy}) & R10 (\hyperref[calcPCMMeltBegin]{FR: Calculate-PCM-Melt-Begin-Time}) & R11 (\hyperref[calcPCMMeltEnd]{FR: Calculate-PCM-Melt-End-Time})
 \\
 \midrule
+\endhead
 IM1 (\hyperref[IM:eBalanceOnWtr]{IM: eBalanceOnWtr}) &  & X &  &  &  & X & X &  &  &  &  &  &  &  &  & 
 \\
 IM2 (\hyperref[IM:eBalanceOnPCM]{IM: eBalanceOnPCM}) & X &  &  & X &  & X & X &  &  &  &  &  &  &  &  & 
@@ -1249,6 +1271,7 @@ R11 (\hyperref[calcPCMMeltEnd]{FR: Calculate-PCM-Melt-End-Time}) &  & X &  &  & 
  & A1 (\hyperref[A:Thermal-Energy-Only]{A: Thermal-Energy-Only}) & A2 (\hyperref[A:Heat-Transfer-Coeffs-Constant]{A: Heat-Transfer-Coeffs-Constant}) & A3 (\hyperref[A:Constant-Water-Temp-Across-Tank]{A: Constant-Water-Temp-Across-Tank}) & A4 (\hyperref[A:Temp-PCM-Constant-Across-Volume]{A: Temp-PCM-Constant-Across-Volume}) & A5 (\hyperref[A:Density-Water-PCM-Constant-over-Volume]{A: Density-Water-PCM-Constant-over-Volume}) & A6 (\hyperref[A:Specific-Heat-Energy-Constant-over-Volume]{A: Specific-Heat-Energy-Constant-over-Volume}) & A7 (\hyperref[A:Newton-Law-Convective-Cooling-Coil-Water]{A: Newton-Law-Convective-Cooling-Coil-Water}) & A8 (\hyperref[A:Temp-Heating-Coil-Constant-over-Time]{A: Temp-Heating-Coil-Constant-over-Time}) & A9 (\hyperref[A:Temp-Heating-Coil-Constant-over-Length]{A: Temp-Heating-Coil-Constant-over-Length}) & A10 (\hyperref[A:Law-Convective-Cooling-Water-PCM]{A: Law-Convective-Cooling-Water-PCM}) & A11 (\hyperref[A:Charging-Tank-No-Temp-Discharge]{A: Charging-Tank-No-Temp-Discharge}) & A12 (\hyperref[A:Same-Initial-Temp-Water-PCM]{A: Same-Initial-Temp-Water-PCM}) & A13 (\hyperref[A:PCM-Initially-Solid]{A: PCM-Initially-Solid}) & A14 (\hyperref[A:Water-Always-Liquid]{A: Water-Always-Liquid}) & A15 (\hyperref[A:Perfect-Insulation-Tank]{A: Perfect-Insulation-Tank}) & A16 (\hyperref[A:No-Internal-Heat-Generation-By-Water-PCM]{A: No-Internal-Heat-Generation-By-Water-PCM}) & A17 (\hyperref[A:Volume-Change-Melting-PCM-Negligible]{A: Volume-Change-Melting-PCM-Negligible}) & A18 (\hyperref[A:No-Gaseous-State-PCM]{A: No-Gaseous-State-PCM}) & A19 (\hyperref[A:Atmospheric-Pressure-Tank]{A: Atmospheric-Pressure-Tank})
 \\
 \midrule
+\endhead
 T1 (\hyperref[TM:consThermE]{TM: consThermE}) & X &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  & 
 \\
 T2 (\hyperref[TM:sensHtE]{TM: sensHtE}) &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  & 
@@ -1314,6 +1337,7 @@ This section contains the standard values that are used for calculations in SWHS
 Symbol & Description & Value & Unit
 \\
 \midrule
+\endhead
 ${{C_{W}}^{max}}$ & maximum specific heat capacity of water & $4210$ & $\frac{\text{J}}{(\text{kg}{}^{\circ}\text{C})}$
 \\
 ${{C_{W}}^{min}}$ & minimum specific heat capacity of water & $4170$ & $\frac{\text{J}}{(\text{kg}{}^{\circ}\text{C})}$

--- a/code/stable/tiny/SRS/Tiny_SRS.tex
+++ b/code/stable/tiny/SRS/Tiny_SRS.tex
@@ -33,6 +33,7 @@ The unit system used throughout is SI (Système International d'Unités). In add
 Symbol & Description
 \\
 \midrule
+\endhead
 ${}^{\circ}$C & temperature (centigrade)
 \\
 m & length (metre)
@@ -50,6 +51,7 @@ The table that follows summarizes the symbols used in this document along with t
 Symbol & Description & Units
 \\
 \midrule
+\endhead
 ${h_{b}}$ & Initial coolant film conductance & --
 \\
 ${h_{c}}$ & Convective heat transfer coefficient between clad and coolant & $\frac{\text{W}}{(\text{m}^{2}{}^{\circ}\text{C})}$
@@ -74,8 +76,9 @@ The instance models that govern HGHC are presented in \hyperref[Sec:IMs]{Section
 \subsubsection{Data Definitions}
 \label{Sec:DDs}
 This section collects and defines all the data needed to build the instance models.
-~\newline
- \noindent \begin{minipage}{\textwidth}
+\par~
+    
+\noindent \begin{minipage}{\textwidth}
 \begin{tabular}{p{0.2\textwidth} p{0.73\textwidth}}
 \toprule \textbf{Refname} & \textbf{DD:htTransCladFuel}
 \phantomsection 
@@ -98,9 +101,10 @@ Label & Effective heat transfer coefficient between clad and fuel surface
                                                   \item{${τ_{c}}$ is the clad thickness (Unitless)}
                                                   \end{symbDescription}
 \\ \bottomrule \end{tabular}
-\end{minipage}\\
-~\newline
- \noindent \begin{minipage}{\textwidth}
+\end{minipage}
+\par~
+    
+\noindent \begin{minipage}{\textwidth}
 \begin{tabular}{p{0.2\textwidth} p{0.73\textwidth}}
 \toprule \textbf{Refname} & \textbf{DD:htTransCladCool}
 \phantomsection 
@@ -123,5 +127,5 @@ Label & Convective heat transfer coefficient between clad and coolant
                                                   \item{${τ_{c}}$ is the clad thickness (Unitless)}
                                                   \end{symbDescription}
 \\ \bottomrule \end{tabular}
-\end{minipage}\\
+\end{minipage}
 \end{document}


### PR DESCRIPTION
This is a tiny PR which fixes a few instances of TeX warning of "Underfull \hbox" and "Underfull \vbox".

One instance comes from `longtable` where it [expects a `\endfirsthead` or `\endhead` after the header](https://tex.stackexchange.com/questions/71096/underfull-vbox-in-each-longtable-can-it-be-fixed-or-must-it-be-ignored). I've included a screenshot below of a `longtable` in one of the examples and how it looks with a repeated header after a page break (a choice I have made which can be changed back –– I've included @smiths as a reviewer for this purpose).
<img width="529" alt="screen shot 2019-02-20 at 2 21 34 pm" src="https://user-images.githubusercontent.com/1929800/53118738-c78ff400-351b-11e9-90d3-0bb06022e346.png">


The other comes from [forcing `\\` in a paragraph leaving "unexpected empty space".](https://tex.stackexchange.com/questions/334246/what-does-the-phrase-underfull-hbox-badness-10000-in-paragraph-actually-mea)