### PR TITLE
SSP Purpose of Document

### DIFF
--- a/code/drasil-example/Drasil/GlassBR/Body.hs
+++ b/code/drasil-example/Drasil/GlassBR/Body.hs
@@ -332,7 +332,7 @@ purpOfDocIntro typeOf progName gvnVar = foldlSent [S "The main", phrase purpose,
   S "necessary to understand" `sAnd` S "verify the" +:+. phrase analysis,
   S "The", short srs, S "is abstract because the", plural content, S "say what",
   phrase problem, S "is being solved" `sC` S "but not how to solve it"]
-  --FIXME: Last sentence is also present in SWHS and NoPCM... pull out?
+  --FIXME: Last sentence is also present in SSP, SWHS and NoPCM... pull out?
 
 {--Scope of Requirements--}
 

--- a/code/drasil-example/Drasil/SSP/Body.hs
+++ b/code/drasil-example/Drasil/SSP/Body.hs
@@ -369,7 +369,12 @@ userChar pname understandings familiarities = foldlSP [
 problem_desc = probDescF EmptyS ssa ending [termi_defi, phys_sys_desc, goal_stmt]
   where ending = foldlSent_ [S "evaluate the", phrase fs, S "of a",
           phrase's slope, phrase slpSrf, S "and identify the",
-          phrase crtSlpSrf, S "of the", phrase slope]
+          phrase crtSlpSrf, S "of the", phrase slope `sC` S "as well as the",
+          phrase intrslce, phrase normForce `sAnd` phrase shearForce,
+          S "along the" +:+. phrase crtSlpSrf, S "It is intended to be",
+          S "used as an educational tool for introducing", phrase slope,
+          S "stability", plural issue `sC` S "and to facilitate the",
+          phrase analysis `sAnd` phrase design, S "of a safe", phrase slope]
 
 -- SECTION 4.1.1 --
 termi_defi = termDefnF Nothing [termi_defi_list]

--- a/code/drasil-example/Drasil/SSP/Body.hs
+++ b/code/drasil-example/Drasil/SSP/Body.hs
@@ -21,14 +21,15 @@ import Drasil.DocLang (DocDesc, DocSection(..), IntroSec(..), IntroSub(..),
   getTraceMapFromTM, getTraceMapFromGD, getTraceMapFromDD, getTraceMapFromIM, getSCSSub,
   goalStmt_label, physSystDescription_label, generateTraceMap')
 
-import qualified Drasil.DocLang.SRS as SRS (inModel, physSyst, assumpt)
+import qualified Drasil.DocLang.SRS as SRS (inModel, physSyst, assumpt, sysCon)
 
 import Data.Drasil.Concepts.Documentation as Doc (analysis, assumption,
-  design, document, effect, element, endUser, environment, goalStmt, inModel, 
-  input_, interest, interest, interface, issue, loss, method_, organization, 
-  physics, problem, product_, property, software, softwareSys, srs, srsDomains,
-  sysCont, system, table_, template, user, value, variable, physSyst, doccon,
-  doccon')
+  definition, design, document, effect, element, endUser, environment, goal,
+  goalStmt, information, inModel, input_, interest, interest, interface, issue,
+  loss, method_, model, organization, physics, problem, product_, property,
+  purpose, requirement, software, softwareSys, srs, srsDomains, sysCont, system,
+  systemConstraint, table_, template, thModel, user, value, variable, physSyst,
+  doccon, doccon')
 import Data.Drasil.Concepts.Education (solidMechanics, undergraduate, educon)
 import Data.Drasil.Concepts.Math (equation, surface, mathcon, mathcon')
 import Data.Drasil.Concepts.PhysicalProperties (mass, physicalcon)
@@ -42,8 +43,9 @@ import Data.Drasil.Quantities.Math as QM (pi_)
 
 import Data.Drasil.People (henryFrankis)
 import Data.Drasil.Phrase (for)
-import Data.Drasil.SentenceStructures (foldlList, SepType(Comma), FoldType(List), 
-  foldlSP, foldlSent, foldlSent_, ofThe, sAnd, sOr, foldlSPCol)
+import Data.Drasil.SentenceStructures (andThe, foldlList, SepType(Comma),
+  FoldType(List), foldlSP, foldlSent, foldlSent_, ofThe, sAnd, sOf, sOr,
+  foldlSPCol)
 import Data.Drasil.SI_Units (degree, metre, newton, pascal, kilogram, second, derived, fundamentals)
 import Data.Drasil.Utils (bulletFlat, bulletNested, enumSimple, noRefsLT)
 
@@ -258,23 +260,22 @@ keySent pname = foldlSent_ [S "a", phrase pname +:+. phrase problem,
 -- SECTION 2.1 --
 -- Purpose of Document automatically generated in IPurpose
 prpsOfDoc_p1 :: Sentence
-prpsOfDoc_p1 = purposeDoc ssa crtSlpSrf fs how introduces analysizes
-  where how = S "assessing the stability of a" +:+ phrase slope +:+
-          phrase design
-        introduces = phrase slope +:+ S "stability" +:+ plural issue
-        analysizes = S "safe" +:+ phrase slope
+prpsOfDoc_p1 = purposeDoc ssp
 
-purposeDoc :: (Idea a, NamedIdea b, NamedIdea c) =>
-              a -> b -> c -> Sentence -> Sentence -> Sentence
-              -> Sentence
-purposeDoc pname what calculates how introduces analysizes =
-  foldlSent [S "The", short pname, phrase program,
-  S "determines the", phrase what `sC` S "and its respective",
-  phrase calculates, S "as a", phrase method_,
-  S "of" +:+. how, S "The", phrase program,
-  S "is intended to be used as an educational tool for",
-  S "introducing", introduces `sC` S "and will facilitate the",
-  phrase analysis `sAnd` phrase design, S "of a", analysizes]
+purposeDoc :: (Idea a) => a -> Sentence
+purposeDoc pname =
+  foldlSent [S "The primary purpose of this", phrase document, S "is to",
+  S "record the", plural requirement `sOf` short pname `andThe` plural model,
+  S "that will be used to meet those" +:+. plural requirement, 
+  at_start' goal `sC` plural assumption `sC` plural thModel `sC` 
+  plural definition `sC` S "and other", phrase model, S "derivation",
+  phrase information, S "are specified" `sC` S "allowing the reader to fully",
+  S "understand" `sAnd` S "verify the", phrase purpose `sAnd` S "scientific",
+  S "basis of" +:+. short pname, S "With the exception of", 
+  plural systemConstraint, S "in", makeRef2S (SRS.sysCon [] []) `sC` S "this",
+  short srs, S "will remain abstract, describing what", phrase problem,
+  S "is being solved, but not how to solve it"] 
+  --FIXME: Last sentence is also present in GlassBR, SWHS and NoPCM... pull out?
 
 -- SECTION 2.2 --
 -- Scope of Requirements automatically generated in IScope

--- a/code/stable/ssp/SRS/SSP_SRS.tex
+++ b/code/stable/ssp/SRS/SSP_SRS.tex
@@ -226,7 +226,7 @@ A slope of geological mass, composed of soil and rock, is subject to the influen
 The following section provides an overview of the Software Requirements Specification (SRS) for a slope stability analysis problem. The developed program will be referred to as the Slope Stability Analysis (SSA) program. This section explains the purpose of this document, the scope of the system, the organization of the document, and the characteristics of the intended reader.
 \subsection{Purpose of Document}
 \label{Sec:DocPurpose}
-The SSA program determines the critical slip surface, and its respective factor of safety as a method of assessing the stability of a slope design. The program is intended to be used as an educational tool for introducing slope stability issues, and will facilitate the analysis and design of a safe slope.
+The primary purpose of this document is to record the requirements of SSP and the models that will be used to meet those requirements. Goals, assumptions, theoretical models, definitions, and other model derivation information are specified, allowing the reader to fully understand and verify the purpose and scientific basis of SSP. With the exception of system constraints in \hyperref[Sec:SysConstraints]{Section: System Constraints}, this SRS will remain abstract, describing what problem is being solved, but not how to solve it.
 This document will be used as a starting point for subsequent development phases, including writing the design specification and the software verification and validation plan. The design document will show how the requirements are to be realized, including decisions on the numerical algorithms and programming environment. The verification and validation plan will show the steps that will be used to increase confidence in the software documentation and the implementation. Although the SRS fits in a series of documents that follow the so-called waterfall model, the actual development process is not constrained in any way. Even when the waterfall model is not followed, as Parnas and Clements point out \cite{parnasClements1986}, the most logical way to present the documentation is still to ``fake'' a rational design process.
 \subsection{Scope of Requirements}
 \label{Sec:ReqsScope}
@@ -278,7 +278,7 @@ There are no system constraints.
 This section first presents the problem description, which gives a high-level view of the problem to be solved. This is followed by the solution characteristics specification, which presents the assumptions, theories, and definitions that are used.
 \subsection{Problem Description}
 \label{Sec:ProbDesc}
-SSA is a computer program developed to evaluate the factor of safety of a slope's slip surface and identify the critical slip surface of the slope.
+SSA is a computer program developed to evaluate the factor of safety of a slope's slip surface and identify the critical slip surface of the slope, as well as the interslice normal force and shear force along the critical slip surface. It is intended to be used as an educational tool for introducing slope stability issues, and to facilitate the analysis and design of a safe slope.
 \subsubsection{Terminology and Definitions}
 \label{Sec:TermDefs}
 This subsection provides a list of terms that are used in the subsequent sections and their meaning, with the purpose of reducing ambiguity and making it easier to correctly understand the requirements.

--- a/code/stable/ssp/Website/SSP_SRS.html
+++ b/code/stable/ssp/Website/SSP_SRS.html
@@ -919,7 +919,7 @@ The following section provides an overview of the Software Requirements Specific
 Purpose of Document
 </h2>
 <p class="paragraph">
-The SSA program determines the critical slip surface, and its respective factor of safety as a method of assessing the stability of a slope design. The program is intended to be used as an educational tool for introducing slope stability issues, and will facilitate the analysis and design of a safe slope.
+The primary purpose of this document is to record the requirements of SSP and the models that will be used to meet those requirements. Goals, assumptions, theoretical models, definitions, and other model derivation information are specified, allowing the reader to fully understand and verify the purpose and scientific basis of SSP. With the exception of system constraints in <a href=#Sec:SysConstraints>Section: System Constraints</a>, this SRS will remain abstract, describing what problem is being solved, but not how to solve it.
 </p>
 <p class="paragraph">
 This document will be used as a starting point for subsequent development phases, including writing the design specification and the software verification and validation plan. The design document will show how the requirements are to be realized, including decisions on the numerical algorithms and programming environment. The verification and validation plan will show the steps that will be used to increase confidence in the software documentation and the implementation. Although the SRS fits in a series of documents that follow the so-called waterfall model, the actual development process is not constrained in any way. Even when the waterfall model is not followed, as Parnas and Clements point out <a href=#parnasClements1986>parnasClements1986</a>, the most logical way to present the documentation is still to &quot;fake&quot; a rational design process.
@@ -1059,7 +1059,7 @@ This section first presents the problem description, which gives a high-level vi
 Problem Description
 </h2>
 <p class="paragraph">
-SSA is a computer program developed to evaluate the factor of safety of a slope's slip surface and identify the critical slip surface of the slope.
+SSA is a computer program developed to evaluate the factor of safety of a slope's slip surface and identify the critical slip surface of the slope, as well as the interslice normal force and shear force along the critical slip surface. It is intended to be used as an educational tool for introducing slope stability issues, and to facilitate the analysis and design of a safe slope.
 </p>
 <div id="Sec:TermDefs">
 <div class="subsubsection">


### PR DESCRIPTION
This PR updates the Purpose of Document section of SSP to match the manual version. Part of the section was moved to the Problem Description (again to match manual).