### PR TITLE
SSP Scope of Requirements

### DIFF
--- a/code/drasil-data/Data/Drasil/Concepts/Physics.hs
+++ b/code/drasil-data/Data/Drasil/Concepts/Physics.hs
@@ -143,4 +143,4 @@ angular = dcc "angular" (cn' "angular")
 damping = dcc "damping" (cn' "damping")
   "An effect that tends to reduce the amplitude of vibrations"
 
-twoD = commonIdeaWithDict "twoD" (cn "two-dimensional") "2D" [physics]
+twoD = commonIdeaWithDict "twoD" (pn "two-dimensional") "2D" [physics]

--- a/code/drasil-data/Data/Drasil/Concepts/Physics.hs
+++ b/code/drasil-data/Data/Drasil/Concepts/Physics.hs
@@ -4,11 +4,13 @@ module Data.Drasil.Concepts.Physics
   , momentOfInertia, force, impulseS, impulseV, displacement
   , gravitationalAccel, gravitationalConst, position, distance
   , time, torque, fbd, angular, linear, tension, compression, stress, strain
-  , angDisp, angVelo, angAccel, linDisp, linVelo, linAccel, joint, damping, physicCon
+  , angDisp, angVelo, angAccel, linDisp, linVelo, linAccel, joint, damping
+  , twoD, physicCon, physicCon'
   ) where
 --This is obviously a bad name, but for now it will do until we come
 --  up with a better one.
 import Language.Drasil
+import Data.Drasil.IdeaDicts (physics)
 import Control.Lens((^.)) --need for parametrization hack
 
 physicCon :: [ConceptChunk]
@@ -20,6 +22,9 @@ physicCon = [rigidBody, velocity, friction, elasticity, energy, mech_energy, col
   strain, angDisp, angVelo, angAccel, linDisp, linVelo, linAccel, 
   joint, damping, pressure]
 
+physicCon' :: [CI]
+physicCon' = [twoD]
+
 rigidBody, velocity, friction, elasticity, energy, mech_energy, collision, space,
   cartesian, rightHand, restitutionCoef, acceleration,
   momentOfInertia, force, impulseS, impulseV, displacement,
@@ -27,6 +32,8 @@ rigidBody, velocity, friction, elasticity, energy, mech_energy, collision, space
   time, torque, fbd, linear, angular, tension, compression, stress, 
   strain, angDisp, angVelo, angAccel, linDisp, linVelo, linAccel, 
   joint, damping, pressure :: ConceptChunk
+
+twoD :: CI
 
 rigidBody    = dcc "rigidBody" (cnIES "rigid body") 
   "A solid body in which deformation is neglected."
@@ -135,3 +142,5 @@ angular = dcc "angular" (cn' "angular")
 
 damping = dcc "damping" (cn' "damping")
   "An effect that tends to reduce the amplitude of vibrations"
+
+twoD = commonIdeaWithDict "twoD" (cn "two-dimensional") "2D" [physics]

--- a/code/drasil-docLang/Drasil/Sections/Introduction.hs
+++ b/code/drasil-docLang/Drasil/Sections/Introduction.hs
@@ -10,8 +10,8 @@ import Data.Drasil.Concepts.Documentation as Doc (goal, organization, thModel, i
   system, model, design, intReader, srs, characteristic, designDoc, decision, environment,
   vavPlan, softwareDoc, implementation, softwareVAV, desSpec)
 import Data.Drasil.Citations (parnasClements1986)
-import Data.Drasil.SentenceStructures (FoldType(List), SepType(Comma), foldlList, foldlsC, foldlSP,
-  ofThe, ofThe', refineChain)
+import Data.Drasil.SentenceStructures (FoldType(List), SepType(Comma),
+  foldlList, foldlsC, foldlSP, ofThe, ofThe', refineChain)
 
 -----------------------
 --     Constants     --
@@ -78,10 +78,13 @@ purposeOfDoc purposeOfProgramParagraph = SRS.prpsOfDoc
 -- programName      - the name of the program
 -- intendedPurpose  - the intended purpose of the program
 scopeOfRequirements :: (Idea a, CommonIdea a) => Sentence -> a -> Sentence -> Section
-scopeOfRequirements mainRequirement programName intendedPurpose = SRS.scpOfReq [intro] []
-  where intro = foldlSP [(phrase scope) `ofThe'` (plural requirement),
-                S "includes" +:+. mainRequirement, S "Given the appropriate inputs,",
-                short programName +:+ intendedPurpose]
+scopeOfRequirements mainRequirement _ EmptyS = SRS.scpOfReq [scpBody] []
+  where scpBody = foldlSP [(phrase scope) `ofThe'` (plural requirement),
+                  S "includes", mainRequirement]
+scopeOfRequirements mainRequirement programName intendedPurpose = SRS.scpOfReq [scpBody] []
+  where scpBody = foldlSP [(phrase scope) `ofThe'` (plural requirement),
+                  S "includes" +:+. mainRequirement, S "Given the appropriate",
+                  S "inputs" `sC` short programName +:+ intendedPurpose]
 
 -- | constructor for characteristics of the intended reader subsection
 -- know

--- a/code/drasil-example/Drasil/GamePhysics/Body.hs
+++ b/code/drasil-example/Drasil/GamePhysics/Body.hs
@@ -52,7 +52,7 @@ import Data.Drasil.Utils (makeTMatrix, itemRefToSent,
 
 import qualified Data.Drasil.Concepts.PhysicalProperties as CPP (ctrOfMass, dimension)
 import qualified Data.Drasil.Concepts.Physics as CP (rigidBody, elasticity, 
-  cartesian, friction, rightHand, collision, space, physicCon)
+  cartesian, friction, rightHand, collision, space, physicCon, physicCon')
 import qualified Data.Drasil.Concepts.Math as CM (equation, surface, law, mathcon, mathcon')
 import Data.Drasil.Software.Products (prodtcon)
 import qualified Data.Drasil.Quantities.Math as QM (orientation, pi_)
@@ -196,7 +196,8 @@ chipUnits = map unitWrapper [metre, kilogram, second] ++ map unitWrapper [newton
 
 everything :: ChunkDB
 everything = cdb (cpSymbolsAll ++ map qw [QM.pi_]) (map nw cpSymbolsAll ++ map nw [QM.pi_] ++ map nw cpAcronyms ++ map nw prodtcon
-  ++ map nw softwarecon ++ map nw doccon ++ map nw doccon' ++ map nw CP.physicCon
+  ++ map nw softwarecon ++ map nw doccon ++ map nw doccon' 
+  ++ map nw CP.physicCon ++ map nw CP.physicCon'
   ++ map nw educon ++ [nw algorithm] ++ map nw derived ++ map nw fundamentals
   ++ map nw CM.mathcon ++ map nw CM.mathcon')
   (map cw gamephySymbols ++ srsDomains) chipUnits game_label game_refby

--- a/code/drasil-example/Drasil/GamePhysics/Concepts.hs
+++ b/code/drasil-example/Drasil/GamePhysics/Concepts.hs
@@ -4,10 +4,11 @@ import Language.Drasil
 import Data.Drasil.Concepts.Documentation (assumption, dataDefn, genDefn, 
     goalStmt, inModel, likelyChg, requirement, srs, thModel, typUnc, unlikelyChg)
 import Data.Drasil.Concepts.Math (ode)
+import Data.Drasil.Concepts.Physics (twoD)
 import Data.Drasil.IdeaDicts (physics)
 ----- Acronyms -----
 
-centreMass, twoD, chipmunk :: CI
+centreMass, chipmunk :: CI
 
 cpAcronyms :: [CI]
 cpAcronyms = [assumption, centreMass, dataDefn, genDefn, goalStmt,
@@ -20,6 +21,5 @@ cent_mass = nounPhrase' "centre of mass" "centres of mass"
   (Replace (S "centre of mass"))
 
 centreMass    = commonIdeaWithDict "centreMass" cent_mass              "CM"   [physics]
-twoD          = commonIdeaWithDict "twoD"       (pn "Two-Dimensional") "2D"   [physics]
 
 chipmunk = commonIdeaWithDict "chipmunk"      (pn "Chipmunk2D game physics library")    "Chipmunk2D"  [physics]

--- a/code/drasil-example/Drasil/NoPCM/Body.hs
+++ b/code/drasil-example/Drasil/NoPCM/Body.hs
@@ -24,7 +24,7 @@ import Data.Drasil.Concepts.Thermodynamics (ener_src, thermal_analysis, temp,
   thermal_energy, ht_trans_theo, ht_flux, heat_cap_spec, thermal_conduction,
   thermocon)
 import Data.Drasil.Concepts.PhysicalProperties (physicalcon)
-import Data.Drasil.Concepts.Physics (physicCon)
+import Data.Drasil.Concepts.Physics (physicCon, physicCon')
 import Data.Drasil.Concepts.Computation (algorithm)
 import qualified Data.Drasil.Quantities.Thermodynamics as QT (temp,
   heat_cap_spec, ht_flux)
@@ -246,7 +246,8 @@ nopcm_srs = mkDoc mkSRS (for) nopcm_si
 nopcm_SymbMap :: ChunkDB
 nopcm_SymbMap = cdb (nopcm_SymbolsAll) (map nw nopcm_Symbols ++ map nw acronyms ++ map nw thermocon
   ++ map nw physicscon ++ map nw doccon ++ map nw softwarecon ++ map nw doccon' ++ map nw swhscon
-  ++ map nw prodtcon ++ map nw physicCon ++ map nw mathcon ++ map nw mathcon' ++ map nw specParamValList
+  ++ map nw prodtcon ++ map nw physicCon ++ map nw physicCon' 
+  ++ map nw mathcon ++ map nw mathcon' ++ map nw specParamValList
   ++ map nw fundamentals ++ map nw derived ++ map nw physicalcon ++ map nw swhsUC ++ [nw srs_swhs, nw algorithm,
   nw ht_trans] ++ map nw check_si)
  (map cw nopcm_Symbols ++ srsDomains)

--- a/code/drasil-example/Drasil/SSP/Body.hs
+++ b/code/drasil-example/Drasil/SSP/Body.hs
@@ -55,16 +55,9 @@ import Drasil.SSP.Changes (likelyChgs, likelyChanges_SRS, unlikelyChgs,
   unlikelyChanges_SRS)
 import Drasil.SSP.DataDefs (dataDefns)
 import Drasil.SSP.DataDesc (sspInputMod)
-<<<<<<< HEAD
 import Drasil.SSP.Defs (acronyms, crtSlpSrf, factor, fs_concept, intrslce, 
-  itslPrpty, layer, morPrice, mtrlPrpty, plnStrn, slice, slope, slpSrf, soil,
-  soilPrpty, ssa, ssp, sspdef, sspdef')
-=======
-import Drasil.SSP.Defs (acronyms, crtSlpSrf, fs_concept, intrslce, itslPrpty, 
-  morPrice, mtrlPrpty, plnStrn, slice, slip, slope, slpSrf, soil, soilLyr, 
-  soilMechanics, ssa, ssp, sspdef,
-  sspdef')
->>>>>>> master
+  itslPrpty, layer, morPrice, mtrlPrpty, plnStrn, slice, slip, slope, slpSrf,
+  soil, soilLyr, soilMechanics, soilPrpty, ssa, ssp, sspdef, sspdef')
 import Drasil.SSP.GenDefs (generalDefinitions)
 import Drasil.SSP.Goals (sspGoals)
 import Drasil.SSP.IMods (sspIMods)

--- a/code/drasil-example/Drasil/SSP/Body.hs
+++ b/code/drasil-example/Drasil/SSP/Body.hs
@@ -32,7 +32,8 @@ import Data.Drasil.Concepts.Documentation as Doc (analysis, assumption,
 import Data.Drasil.Concepts.Education (solidMechanics, undergraduate, educon)
 import Data.Drasil.Concepts.Math (equation, surface, mathcon, mathcon')
 import Data.Drasil.Concepts.PhysicalProperties (mass, physicalcon)
-import Data.Drasil.Concepts.Physics (fbd, force, strain, stress, physicCon)
+import Data.Drasil.Concepts.Physics (fbd, force, strain, stress, twoD,
+  physicCon, physicCon')
 import Data.Drasil.Concepts.Software (accuracy, correctness, maintainability, 
   program, reusability, understandability, softwarecon, performance)
 import Data.Drasil.Concepts.SolidMechanics (normForce, shearForce, solidcon)
@@ -190,8 +191,8 @@ ssppriorityNFReqs = [correctness, understandability, reusability,
 sspSymMap :: ChunkDB
 sspSymMap = cdb (map qw (sspSymbols ++ [QM.pi_])) (map nw sspSymbols ++ map nw acronyms ++
   map nw doccon ++ map nw prodtcon ++ map nw sspdef ++ map nw sspdef'
-  ++ map nw softwarecon ++ map nw physicCon ++ map nw mathcon
-  ++ map nw mathcon' ++ map nw solidcon ++ map nw physicalcon
+  ++ map nw softwarecon ++ map nw physicCon ++ map nw physicCon' 
+  ++ map nw mathcon ++ map nw mathcon' ++ map nw solidcon ++ map nw physicalcon
   ++ map nw doccon' ++ map nw derived ++ map nw fundamentals
   ++ map nw educon ++ map nw compcon ++ [nw algorithm, nw ssp] ++ map nw this_si)
   (map cw sspSymbols ++ map cw [QM.pi_] ++ srsDomains) this_si ssp_label ssp_refby
@@ -279,7 +280,8 @@ purposeDoc pname what calculates how introduces analysizes =
 -- SECTION 2.2 --
 -- Scope of Requirements automatically generated in IScope
 scpIncl :: Sentence
-scpIncl = S "stability analysis of a 2 dimensional" +:+ phrase slope `sC`
+scpIncl = S "stability analysis of a" +:+ introduceAbb twoD +:+ 
+  phrase slope `sC`
   S "composed of homogeneous" +:+ plural soilLyr
 
 -- SECTION 2.3 --

--- a/code/drasil-example/Drasil/SSP/Body.hs
+++ b/code/drasil-example/Drasil/SSP/Body.hs
@@ -24,15 +24,15 @@ import Drasil.DocLang (DocDesc, DocSection(..), IntroSec(..), IntroSub(..),
 import qualified Drasil.DocLang.SRS as SRS (inModel, physSyst, assumpt)
 
 import Data.Drasil.Concepts.Documentation as Doc (analysis, assumption,
-  design, document, effect, element, endUser, environment, goalStmt, inModel, 
-  input_, interest, interest, interface, issue, loss, method_, organization, 
-  physics, problem, product_, property, software, softwareSys, srs, srsDomains,
-  sysCont, system, table_, template, user, value, variable, physSyst, doccon,
-  doccon')
+  constant, design, document, effect, element, endUser, environment,
+  goalStmt, inModel, input_, interest, interest, interface, issue, loss, 
+  method_, organization, physics, problem, product_, property, software, 
+  softwareSys, srs, srsDomains, sysCont, system, table_, template, user,
+  value, variable, physSyst, doccon, doccon')
 import Data.Drasil.Concepts.Education (solidMechanics, undergraduate, educon)
 import Data.Drasil.Concepts.Math (equation, surface, mathcon, mathcon')
-import Data.Drasil.Concepts.PhysicalProperties (mass, physicalcon)
-import Data.Drasil.Concepts.Physics (fbd, force, strain, stress, twoD,
+import Data.Drasil.Concepts.PhysicalProperties (dimension, mass, physicalcon)
+import Data.Drasil.Concepts.Physics (fbd, force, strain, stress, time, twoD,
   physicCon, physicCon')
 import Data.Drasil.Concepts.Software (accuracy, correctness, maintainability, 
   program, reusability, understandability, softwarecon, performance)
@@ -53,9 +53,9 @@ import Drasil.SSP.Changes (likelyChgs, likelyChanges_SRS, unlikelyChgs,
   unlikelyChanges_SRS)
 import Drasil.SSP.DataDefs (dataDefns)
 import Drasil.SSP.DataDesc (sspInputMod)
-import Drasil.SSP.Defs (acronyms, crtSlpSrf, fs_concept, intrslce, itslPrpty, 
-  morPrice, mtrlPrpty, plnStrn, slice, slope, slpSrf, soil, soilLyr, ssa, ssp, sspdef,
-  sspdef')
+import Drasil.SSP.Defs (acronyms, crtSlpSrf, factor, fs_concept, intrslce, 
+  itslPrpty, layer, morPrice, mtrlPrpty, plnStrn, slice, slope, slpSrf, soil,
+  soilPrpty, ssa, ssp, sspdef, sspdef')
 import Drasil.SSP.GenDefs (generalDefinitions)
 import Drasil.SSP.Goals (sspGoals)
 import Drasil.SSP.IMods (sspIMods)
@@ -281,8 +281,11 @@ purposeDoc pname what calculates how introduces analysizes =
 -- Scope of Requirements automatically generated in IScope
 scpIncl :: Sentence
 scpIncl = S "stability analysis of a" +:+ introduceAbb twoD +:+ 
-  phrase slope `sC`
-  S "composed of homogeneous" +:+ plural soilLyr
+  phrase soil +:+ S "mass" `sC` S "composed of a single homogeneous" +:+ phrase layer +:+ S "with" +:+ phrase constant +:+. plural mtrlPrpty +:+ S "The" +:+
+  phrase soil +:+ S "mass is assumed to extend infinitely in the third" +:+. phrase dimension +:+ S "The" +:+ phrase analysis +:+ S "will be at an" +:+
+  S "instant in" +:+ phrase time :+: S ";" +:+ plural factor +:+ S "that" +:+
+  S "may change the" +:+ plural soilPrpty +:+ S "over" +:+ phrase time +:+
+  S "will not be considered"
 
 -- SECTION 2.3 --
 -- Characteristics of the Intended Reader generated in IChar

--- a/code/drasil-example/Drasil/SSP/Body.hs
+++ b/code/drasil-example/Drasil/SSP/Body.hs
@@ -112,7 +112,7 @@ mkSRS = RefSec (RefProg intro
   [TUnits, tsymb'' table_of_symbol_intro TAD, TAandA]) :
   IntroSec (IntroProg startIntro kSent
     [IPurpose prpsOfDoc_p1
-    , IScope scpIncl scpEnd
+    , IScope scpIncl EmptyS
     , IChar (phrase solidMechanics)
       (phrase undergraduate +:+ S "level 4" +:+ phrase Doc.physics)
       EmptyS
@@ -278,13 +278,9 @@ purposeDoc pname what calculates how introduces analysizes =
 
 -- SECTION 2.2 --
 -- Scope of Requirements automatically generated in IScope
-scpIncl, scpEnd :: Sentence
+scpIncl :: Sentence
 scpIncl = S "stability analysis of a 2 dimensional" +:+ phrase slope `sC`
   S "composed of homogeneous" +:+ plural soilLyr
-scpEnd  = S "identifies the most likely failure" +:+
-  phrase surface +:+ S "within the possible" +:+ phrase input_ +:+ 
-  S "range" `sC` S "and finds the" +:+ phrase fs +:+ S "for the" +:+
-  phrase slope
 
 -- SECTION 2.3 --
 -- Characteristics of the Intended Reader generated in IChar

--- a/code/drasil-example/Drasil/SSP/Defs.hs
+++ b/code/drasil-example/Drasil/SSP/Defs.hs
@@ -5,15 +5,16 @@ import Data.Drasil.Concepts.Documentation (assumption, dataDefn, genDefn,
   goalStmt, inModel, likelyChg, physSyst, property, requirement, safety, srs,
   thModel, typUnc, unlikelyChg)
 import Data.Drasil.Concepts.Math (surface)
+import Data.Drasil.Concepts.Physics (twoD)
 
 import Data.Drasil.Phrase(of_'', compoundNC)
 import Data.Drasil.IdeaDicts hiding (dataDefn)
 
 ----Acronyms-----
 acronyms :: [CI]
-acronyms = [assumption, dataDefn, genDefn, goalStmt, inModel, likelyChg,
+acronyms = [twoD, assumption, dataDefn, genDefn, goalStmt, inModel, likelyChg,
   physSyst, requirement, srs, ssa, thModel, typUnc, unlikelyChg]
-  
+
 ssa, ssp :: CI
 ssa = commonIdeaWithDict "ssa" (cnIS "slope stability analysis") "SSA" [civilEng]
 ssp = commonIdeaWithDict "ssp" (cn' "slope stability problem") "SSP"   [civilEng]

--- a/code/drasil-example/Drasil/SSP/Defs.hs
+++ b/code/drasil-example/Drasil/SSP/Defs.hs
@@ -20,15 +20,16 @@ ssa = commonIdeaWithDict "ssa" (cnIS "slope stability analysis") "SSA" [civilEng
 ssp = commonIdeaWithDict "ssp" (cn' "slope stability problem") "SSP"   [civilEng]
 
 sspdef :: [NamedChunk]
-sspdef = [factor, soil, material, intrslce, slip, slope, slice, morPrice, rgFnElm,
+sspdef = [factor, soil, material, intrslce, layer, slip, slope, slice, morPrice, rgFnElm,
   slpSrf, soilPrpty, mtrlPrpty, itslPrpty, slopeSrf, soilLyr]
 
 sspdef' :: [ConceptChunk]
 sspdef' = [crtSlpSrf, plnStrn, fs_concept]
 
 ----Other Common Phrases----
-soil, material, intrslce, slip, slope, slice, morPrice, rgFnElm :: NamedChunk
+soil, layer, material, intrslce, slip, slope, slice, morPrice, rgFnElm :: NamedChunk
 intrslce = nc "interslice" (cn' "interslice")
+layer    = nc "layer"      (cn' "layer")
 material = nc "material"   (cn' "material")
 slice    = nc "slice"      (cn' "slice")
 slip     = nc "slip"       (cn  "slip") --FIXME: verb (escape or get loose from (a means of restraint))/noun 
@@ -46,7 +47,7 @@ soilPrpty = compoundNC soil     property
 mtrlPrpty = compoundNC material property
 itslPrpty = compoundNC intrslce property
 slopeSrf  = compoundNC slope surface
-soilLyr   = compoundNC soil (nc "layer" (cn' "layer"))
+soilLyr   = compoundNC soil layer
 
 crtSlpSrf, plnStrn, fs_concept :: ConceptChunk
 --FIXME: move to Concepts/soldMechanics.hs? They are too specific though

--- a/code/drasil-example/Drasil/SWHS/Body.hs
+++ b/code/drasil-example/Drasil/SWHS/Body.hs
@@ -37,7 +37,7 @@ import Data.Drasil.Concepts.Computation (compcon, algorithm)
 import Data.Drasil.Concepts.Math (de, equation, ode, unit_, mathcon, mathcon')
 import Data.Drasil.Concepts.Software (program, softwarecon, performance, correctness, verifiability,
   understandability, reusability, maintainability)
-import Data.Drasil.Concepts.Physics (physicCon)
+import Data.Drasil.Concepts.Physics (physicCon, physicCon')
 import Data.Drasil.Concepts.PhysicalProperties (physicalcon)
 import Data.Drasil.Software.Products (sciCompS, compPro, prodtcon)
 import Data.Drasil.Quantities.Math (gradient, surface, uNormalVect, surArea)
@@ -120,7 +120,8 @@ swhsSymMap :: ChunkDB
 swhsSymMap = cdb swhsSymbolsAll (map nw swhsSymbols ++ map nw acronymsFull
   ++ map nw thermocon ++ map nw this_si ++ map nw [m_2, m_3]
   ++ map nw physicscon ++ map nw doccon ++ map nw softwarecon ++ map nw doccon' ++ map nw swhscon
-  ++ map nw prodtcon ++ map nw physicCon ++ map nw mathcon ++ map nw mathcon' ++ map nw specParamValList
+  ++ map nw prodtcon ++ map nw physicCon ++ map nw physicCon' 
+  ++ map nw mathcon ++ map nw mathcon' ++ map nw specParamValList
   ++ map nw fundamentals ++ map nw derived ++ map nw physicalcon ++ map nw swhsUC
   ++ [nw swhs_pcm, nw algorithm] ++ map nw compcon)
   (map cw swhsSymbols ++ srsDomains) (this_si ++ [m_2, m_3]) swhs_label swhs_refby

--- a/code/stable/gamephys/SRS/Chipmunk_SRS.tex
+++ b/code/stable/gamephys/SRS/Chipmunk_SRS.tex
@@ -174,7 +174,7 @@ Abbreviation & Full Form
 \\
 \midrule
 \endhead
-2D & Two-Dimensional
+2D & two-dimensional
 \\
 A & Assumption
 \\
@@ -313,7 +313,7 @@ This section simplifies the original problem and helps in developing the theoret
 \label{Sec:TMs}
 This section focuses on the general equations and laws that Chipmunk2D is based on.
 \par~
-    
+
 \noindent \begin{minipage}{\textwidth}
 \begin{tabular}{p{0.2\textwidth} p{0.73\textwidth}}
 \toprule \textbf{Refname} & \textbf{TM:NewtonSecLawMot}
@@ -339,7 +339,7 @@ Label & Newton's second law of motion
 \\ \bottomrule \end{tabular}
 \end{minipage}
 \par~
-    
+
 \noindent \begin{minipage}{\textwidth}
 \begin{tabular}{p{0.2\textwidth} p{0.73\textwidth}}
 \toprule \textbf{Refname} & \textbf{TM:NewtonThirdLawMot}
@@ -364,7 +364,7 @@ Label & Newton's third law of motion
 \\ \bottomrule \end{tabular}
 \end{minipage}
 \par~
-    
+
 \noindent \begin{minipage}{\textwidth}
 \begin{tabular}{p{0.2\textwidth} p{0.73\textwidth}}
 \toprule \textbf{Refname} & \textbf{TM:UniversalGravLaw}
@@ -394,7 +394,7 @@ Label & Newton's law of universal gravitation
 \\ \bottomrule \end{tabular}
 \end{minipage}
 \par~
-    
+
 \noindent \begin{minipage}{\textwidth}
 \begin{tabular}{p{0.2\textwidth} p{0.73\textwidth}}
 \toprule \textbf{Refname} & \textbf{TM:ChaslesThm}
@@ -421,7 +421,7 @@ Label & Chasles' theorem
 \\ \bottomrule \end{tabular}
 \end{minipage}
 \par~
-    
+
 \noindent \begin{minipage}{\textwidth}
 \begin{tabular}{p{0.2\textwidth} p{0.73\textwidth}}
 \toprule \textbf{Refname} & \textbf{TM:NewtonSecLawRotMot}
@@ -453,7 +453,7 @@ There are no general definitions.
 \label{Sec:DDs}
 This section collects and defines all the data needed to build the instance models.
 \par~
-    
+
 \noindent \begin{minipage}{\textwidth}
 \begin{tabular}{p{0.2\textwidth} p{0.73\textwidth}}
 \toprule \textbf{Refname} & \textbf{DD:ctrOfMass}
@@ -485,7 +485,7 @@ Label & Center of Mass
 \\ \bottomrule \end{tabular}
 \end{minipage}
 \par~
-    
+
 \noindent \begin{minipage}{\textwidth}
 \begin{tabular}{p{0.2\textwidth} p{0.73\textwidth}}
 \toprule \textbf{Refname} & \textbf{DD:linDisp}
@@ -517,7 +517,7 @@ Label & Linear Displacement
 \\ \bottomrule \end{tabular}
 \end{minipage}
 \par~
-    
+
 \noindent \begin{minipage}{\textwidth}
 \begin{tabular}{p{0.2\textwidth} p{0.73\textwidth}}
 \toprule \textbf{Refname} & \textbf{DD:linVel}
@@ -549,7 +549,7 @@ Label & Linear Velocity
 \\ \bottomrule \end{tabular}
 \end{minipage}
 \par~
-    
+
 \noindent \begin{minipage}{\textwidth}
 \begin{tabular}{p{0.2\textwidth} p{0.73\textwidth}}
 \toprule \textbf{Refname} & \textbf{DD:linAcc}
@@ -581,7 +581,7 @@ Label & Linear Acceleration
 \\ \bottomrule \end{tabular}
 \end{minipage}
 \par~
-    
+
 \noindent \begin{minipage}{\textwidth}
 \begin{tabular}{p{0.2\textwidth} p{0.73\textwidth}}
 \toprule \textbf{Refname} & \textbf{DD:angDisp}
@@ -613,7 +613,7 @@ Label & Angular Displacement
 \\ \bottomrule \end{tabular}
 \end{minipage}
 \par~
-    
+
 \noindent \begin{minipage}{\textwidth}
 \begin{tabular}{p{0.2\textwidth} p{0.73\textwidth}}
 \toprule \textbf{Refname} & \textbf{DD:angVel}
@@ -645,7 +645,7 @@ Label & Angular Velocity
 \\ \bottomrule \end{tabular}
 \end{minipage}
 \par~
-    
+
 \noindent \begin{minipage}{\textwidth}
 \begin{tabular}{p{0.2\textwidth} p{0.73\textwidth}}
 \toprule \textbf{Refname} & \textbf{DD:angAccel}
@@ -677,7 +677,7 @@ Label & Angular Acceleration
 \\ \bottomrule \end{tabular}
 \end{minipage}
 \par~
-    
+
 \noindent \begin{minipage}{\textwidth}
 \begin{tabular}{p{0.2\textwidth} p{0.73\textwidth}}
 \toprule \textbf{Refname} & \textbf{DD:impulse}
@@ -718,7 +718,7 @@ Label & Impulse (scalar)
 \\ \bottomrule \end{tabular}
 \end{minipage}
 \par~
-    
+
 \noindent \begin{minipage}{\textwidth}
 \begin{tabular}{p{0.2\textwidth} p{0.73\textwidth}}
 \toprule \textbf{Refname} & \textbf{DD:chalses}
@@ -749,7 +749,7 @@ Label & Velocity At Point B
 \\ \bottomrule \end{tabular}
 \end{minipage}
 \par~
-    
+
 \noindent \begin{minipage}{\textwidth}
 \begin{tabular}{p{0.2\textwidth} p{0.73\textwidth}}
 \toprule \textbf{Refname} & \textbf{DD:torque}
@@ -782,7 +782,7 @@ Label & Torque
 \label{Sec:IMs}
 This section transforms the problem defined in \hyperref[Sec:ProbDesc]{Section: Problem Description} into one which is expressed in mathematical terms. It uses concrete symbols defined in \hyperref[Sec:DDs]{Section: Data Definitions} to replace the abstract symbols in the models identified in \hyperref[Sec:TMs]{Section: Theoretical Models} and \hyperref[Sec:GDs]{Section: General Definitions}.
 \par~
-    
+
 \noindent \begin{minipage}{\textwidth}
 \begin{tabular}{p{0.2\textwidth} p{0.73\textwidth}}
 \toprule \textbf{Refname} & \textbf{IM:transMot}
@@ -832,7 +832,7 @@ Label & Force on the translational motion of a set of 2d rigid bodies
 \\ \bottomrule \end{tabular}
 \end{minipage}
 \par~
-    
+
 \noindent \begin{minipage}{\textwidth}
 \begin{tabular}{p{0.2\textwidth} p{0.73\textwidth}}
 \toprule \textbf{Refname} & \textbf{IM:rotMot}
@@ -881,7 +881,7 @@ Label & Force on the rotational motion of a set of 2D rigid body
 \\ \bottomrule \end{tabular}
 \end{minipage}
 \par~
-    
+
 \noindent \begin{minipage}{\textwidth}
 \begin{tabular}{p{0.2\textwidth} p{0.73\textwidth}}
 \toprule \textbf{Refname} & \textbf{IM:col2D}

--- a/code/stable/gamephys/Website/Chipmunk_SRS.html
+++ b/code/stable/gamephys/Website/Chipmunk_SRS.html
@@ -684,7 +684,7 @@ Full Form
 2D
 </td>
 <td>
-Two-Dimensional
+two-dimensional
 </td>
 </tr>
 <tr>

--- a/code/stable/ssp/SRS/SSP_SRS.tex
+++ b/code/stable/ssp/SRS/SSP_SRS.tex
@@ -191,6 +191,8 @@ ${ℓ_{s}}$ & Length of an Interslice Surface: from slip base to slope surface i
 Abbreviation & Full Form
 \\
 \midrule
+2D & Two-Dimensional
+\\
 A & Assumption
 \\
 DD & Data Definition
@@ -230,7 +232,7 @@ The SSA program determines the critical slip surface, and its respective factor 
 This document will be used as a starting point for subsequent development phases, including writing the design specification and the software verification and validation plan. The design document will show how the requirements are to be realized, including decisions on the numerical algorithms and programming environment. The verification and validation plan will show the steps that will be used to increase confidence in the software documentation and the implementation. Although the SRS fits in a series of documents that follow the so-called waterfall model, the actual development process is not constrained in any way. Even when the waterfall model is not followed, as Parnas and Clements point out \cite{parnasClements1986}, the most logical way to present the documentation is still to ``fake'' a rational design process.
 \subsection{Scope of Requirements}
 \label{Sec:ReqsScope}
-The scope of the requirements includes stability analysis of a 2 dimensional slope, composed of homogeneous soil layers. Given the appropriate inputs, SSA identifies the most likely failure surface within the possible input range, and finds the factor of safety for the slope.
+The scope of the requirements includes stability analysis of a Two-Dimensional (2D) soil mass, composed of a single homogeneous layer with constant material properties. The soil mass is assumed to extend infinitely in the third dimension. The analysis will be at an instant in time; factors that may change the soil properties over time will not be considered.
 \subsection{Characteristics of Intended Reader}
 \label{Sec:ReaderChars}
 Reviewers of this documentation should have a strong knowledge in solid mechanics. The reviewers should also have an understanding of undergraduate level 4 physics. The users of SSA can have a lower level of expertise, as explained in \hyperref[Sec:UserChars]{Section: User Characteristics}.

--- a/code/stable/ssp/SRS/SSP_SRS.tex
+++ b/code/stable/ssp/SRS/SSP_SRS.tex
@@ -193,7 +193,8 @@ ${ℓ_{s}}$ & Length of an Interslice Surface: from slip base to slope surface i
 Abbreviation & Full Form
 \\
 \midrule
-2D & Two-Dimensional
+\endhead
+2D & two-dimensional
 \\
 A & Assumption
 \\
@@ -234,7 +235,7 @@ The primary purpose of this document is to record the requirements of SSP and th
 This document will be used as a starting point for subsequent development phases, including writing the design specification and the software verification and validation plan. The design document will show how the requirements are to be realized, including decisions on the numerical algorithms and programming environment. The verification and validation plan will show the steps that will be used to increase confidence in the software documentation and the implementation. Although the SRS fits in a series of documents that follow the so-called waterfall model, the actual development process is not constrained in any way. Even when the waterfall model is not followed, as Parnas and Clements point out \cite{parnasClements1986}, the most logical way to present the documentation is still to ``fake'' a rational design process.
 \subsection{Scope of Requirements}
 \label{Sec:ReqsScope}
-The scope of the requirements includes stability analysis of a Two-Dimensional (2D) soil mass, composed of a single homogeneous layer with constant material properties. The soil mass is assumed to extend infinitely in the third dimension. The analysis will be at an instant in time; factors that may change the soil properties over time will not be considered.
+The scope of the requirements includes stability analysis of a two-dimensional (2D) soil mass, composed of a single homogeneous layer with constant material properties. The soil mass is assumed to extend infinitely in the third dimension. The analysis will be at an instant in time; factors that may change the soil properties over time will not be considered.
 \subsection{Characteristics of Intended Reader}
 \label{Sec:ReaderChars}
 Reviewers of this documentation should have an understanding of undergraduate level 4 physics and undergraduate level 2 or higher solid mechanics. An understanding of soil mechanics would be an asset. The users of SSA can have a lower level of expertise, as explained in \hyperref[Sec:UserChars]{Section: User Characteristics}.
@@ -370,7 +371,7 @@ This section simplifies the original problem and helps in developing the theoret
 \label{Sec:TMs}
 This section focuses on the general equations and laws that SSA is based on.
 \par~
-    
+
 \noindent \begin{minipage}{\textwidth}
 \begin{tabular}{p{0.2\textwidth} p{0.73\textwidth}}
 \toprule \textbf{Refname} & \textbf{TM:factOfSafety}
@@ -397,7 +398,7 @@ Label & Factor of safety
 \\ \bottomrule \end{tabular}
 \end{minipage}
 \par~
-    
+
 \noindent \begin{minipage}{\textwidth}
 \begin{tabular}{p{0.2\textwidth} p{0.73\textwidth}}
 \toprule \textbf{Refname} & \textbf{TM:equilibrium}
@@ -424,7 +425,7 @@ Label & Equilibrium
 \\ \bottomrule \end{tabular}
 \end{minipage}
 \par~
-    
+
 \noindent \begin{minipage}{\textwidth}
 \begin{tabular}{p{0.2\textwidth} p{0.73\textwidth}}
 \toprule \textbf{Refname} & \textbf{TM:mcShrStrgth}
@@ -452,7 +453,7 @@ Label & Mohr-Coulumb shear strength
 \\ \bottomrule \end{tabular}
 \end{minipage}
 \par~
-    
+
 \noindent \begin{minipage}{\textwidth}
 \begin{tabular}{p{0.2\textwidth} p{0.73\textwidth}}
 \toprule \textbf{Refname} & \textbf{TM:effStress}
@@ -481,7 +482,7 @@ Label & Effective stress
 \label{Sec:GDs}
 This section collects the laws and equations that will be used in deriving the data definitions, which in turn are used to build the instance models.
 \par~
-    
+
 \noindent \begin{minipage}{\textwidth}
 \begin{tabular}{p{0.2\textwidth} p{0.73\textwidth}}
 \toprule \textbf{Refname} & \textbf{GD:normForcEq}
@@ -517,7 +518,7 @@ Label & Normal force equilibrium
 \\ \bottomrule \end{tabular}
 \end{minipage}
 \par~
-    
+
 \noindent \begin{minipage}{\textwidth}
 \begin{tabular}{p{0.2\textwidth} p{0.73\textwidth}}
 \toprule \textbf{Refname} & \textbf{GD:bsShrFEq}
@@ -553,7 +554,7 @@ Label & Base shear force equilibrium
 \\ \bottomrule \end{tabular}
 \end{minipage}
 \par~
-    
+
 \noindent \begin{minipage}{\textwidth}
 \begin{tabular}{p{0.2\textwidth} p{0.73\textwidth}}
 \toprule \textbf{Refname} & \textbf{GD:resShr}
@@ -584,7 +585,7 @@ Label & Resistive shear force
 \\ \bottomrule \end{tabular}
 \end{minipage}
 \par~
-    
+
 \noindent \begin{minipage}{\textwidth}
 \begin{tabular}{p{0.2\textwidth} p{0.73\textwidth}}
 \toprule \textbf{Refname} & \textbf{GD:mobShr}
@@ -617,7 +618,7 @@ Label & Mobile shear force
 \\ \bottomrule \end{tabular}
 \end{minipage}
 \par~
-    
+
 \noindent \begin{minipage}{\textwidth}
 \begin{tabular}{p{0.2\textwidth} p{0.73\textwidth}}
 \toprule \textbf{Refname} & \textbf{GD:effNormF}
@@ -645,7 +646,7 @@ Label & Effective normal force
 \\ \bottomrule \end{tabular}
 \end{minipage}
 \par~
-    
+
 \noindent \begin{minipage}{\textwidth}
 \begin{tabular}{p{0.2\textwidth} p{0.73\textwidth}}
 \toprule \textbf{Refname} & \textbf{GD:resShearWO}
@@ -681,7 +682,7 @@ Label & Resistive shear force
 \\ \bottomrule \end{tabular}
 \end{minipage}
 \par~
-    
+
 \noindent \begin{minipage}{\textwidth}
 \begin{tabular}{p{0.2\textwidth} p{0.73\textwidth}}
 \toprule \textbf{Refname} & \textbf{GD:mobShearWO}
@@ -713,7 +714,7 @@ Label & Mobilized shear force
 \\ \bottomrule \end{tabular}
 \end{minipage}
 \par~
-    
+
 \noindent \begin{minipage}{\textwidth}
 \begin{tabular}{p{0.2\textwidth} p{0.73\textwidth}}
 \toprule \textbf{Refname} & \textbf{GD:normShrR}
@@ -741,7 +742,7 @@ Label & Interslice normal/shear relationship
 \\ \bottomrule \end{tabular}
 \end{minipage}
 \par~
-    
+
 \noindent \begin{minipage}{\textwidth}
 \begin{tabular}{p{0.2\textwidth} p{0.73\textwidth}}
 \toprule \textbf{Refname} & \textbf{GD:momentEql}
@@ -782,7 +783,7 @@ Label & Moment equilibrium
 \label{Sec:DDs}
 This section collects and defines all the data needed to build the instance models.
 \par~
-    
+
 \noindent \begin{minipage}{\textwidth}
 \begin{tabular}{p{0.2\textwidth} p{0.73\textwidth}}
 \toprule \textbf{Refname} & \textbf{DD:sliceWght}
@@ -820,7 +821,7 @@ Label & Weight
 \\ \bottomrule \end{tabular}
 \end{minipage}
 \par~
-    
+
 \noindent \begin{minipage}{\textwidth}
 \begin{tabular}{p{0.2\textwidth} p{0.73\textwidth}}
 \toprule \textbf{Refname} & \textbf{DD:baseWtrF}
@@ -857,7 +858,7 @@ Label & Base hydrostatic force
 \\ \bottomrule \end{tabular}
 \end{minipage}
 \par~
-    
+
 \noindent \begin{minipage}{\textwidth}
 \begin{tabular}{p{0.2\textwidth} p{0.73\textwidth}}
 \toprule \textbf{Refname} & \textbf{DD:surfWtrF}
@@ -894,7 +895,7 @@ Label & Surface hydrostatic force
 \\ \bottomrule \end{tabular}
 \end{minipage}
 \par~
-    
+
 \noindent \begin{minipage}{\textwidth}
 \begin{tabular}{p{0.2\textwidth} p{0.73\textwidth}}
 \toprule \textbf{Refname} & \textbf{DD:intersliceWtrF}
@@ -930,7 +931,7 @@ Label & Interslice water force
 \\ \bottomrule \end{tabular}
 \end{minipage}
 \par~
-    
+
 \noindent \begin{minipage}{\textwidth}
 \begin{tabular}{p{0.2\textwidth} p{0.73\textwidth}}
 \toprule \textbf{Refname} & \textbf{DD:angleA}
@@ -962,7 +963,7 @@ Label & Angle
 \\ \bottomrule \end{tabular}
 \end{minipage}
 \par~
-    
+
 \noindent \begin{minipage}{\textwidth}
 \begin{tabular}{p{0.2\textwidth} p{0.73\textwidth}}
 \toprule \textbf{Refname} & \textbf{DD:angleB}
@@ -994,7 +995,7 @@ Label & Angle
 \\ \bottomrule \end{tabular}
 \end{minipage}
 \par~
-    
+
 \noindent \begin{minipage}{\textwidth}
 \begin{tabular}{p{0.2\textwidth} p{0.73\textwidth}}
 \toprule \textbf{Refname} & \textbf{DD:lengthB}
@@ -1023,7 +1024,7 @@ Label & Base width of a slice
 \\ \bottomrule \end{tabular}
 \end{minipage}
 \par~
-    
+
 \noindent \begin{minipage}{\textwidth}
 \begin{tabular}{p{0.2\textwidth} p{0.73\textwidth}}
 \toprule \textbf{Refname} & \textbf{DD:lengthLb}
@@ -1055,7 +1056,7 @@ Label & Total base length of a slice
 \\ \bottomrule \end{tabular}
 \end{minipage}
 \par~
-    
+
 \noindent \begin{minipage}{\textwidth}
 \begin{tabular}{p{0.2\textwidth} p{0.73\textwidth}}
 \toprule \textbf{Refname} & \textbf{DD:lengthLs}
@@ -1087,7 +1088,7 @@ Label & Length of an interslice surface
 \\ \bottomrule \end{tabular}
 \end{minipage}
 \par~
-    
+
 \noindent \begin{minipage}{\textwidth}
 \begin{tabular}{p{0.2\textwidth} p{0.73\textwidth}}
 \toprule \textbf{Refname} & \textbf{DD:slcHeight}
@@ -1119,7 +1120,7 @@ Label & Y-direction height of a slice
 \\ \bottomrule \end{tabular}
 \end{minipage}
 \par~
-    
+
 \noindent \begin{minipage}{\textwidth}
 \begin{tabular}{p{0.2\textwidth} p{0.73\textwidth}}
 \toprule \textbf{Refname} & \textbf{DD:stress}
@@ -1148,7 +1149,7 @@ Label & Normal stress
 \\ \bottomrule \end{tabular}
 \end{minipage}
 \par~
-    
+
 \noindent \begin{minipage}{\textwidth}
 \begin{tabular}{p{0.2\textwidth} p{0.73\textwidth}}
 \toprule \textbf{Refname} & \textbf{DD:ratioVariation}
@@ -1183,7 +1184,7 @@ Label & Interslice normal to shear force ratio variation function
 \\ \bottomrule \end{tabular}
 \end{minipage}
 \par~
-    
+
 \noindent \begin{minipage}{\textwidth}
 \begin{tabular}{p{0.2\textwidth} p{0.73\textwidth}}
 \toprule \textbf{Refname} & \textbf{DD:convertFunc1}
@@ -1216,7 +1217,7 @@ Label & First function for incorporating interslice forces into shear force
 \\ \bottomrule \end{tabular}
 \end{minipage}
 \par~
-    
+
 \noindent \begin{minipage}{\textwidth}
 \begin{tabular}{p{0.2\textwidth} p{0.73\textwidth}}
 \toprule \textbf{Refname} & \textbf{DD:convertFunc2}
@@ -1250,7 +1251,7 @@ Label & Second function for incorporating interslice forces into shear force
 \\ \bottomrule \end{tabular}
 \end{minipage}
 \par~
-    
+
 \noindent \begin{minipage}{\textwidth}
 \begin{tabular}{p{0.2\textwidth} p{0.73\textwidth}}
 \toprule \textbf{Refname} & \textbf{DD:fixme1}
@@ -1278,7 +1279,7 @@ Label & Fixme
 \\ \bottomrule \end{tabular}
 \end{minipage}
 \par~
-    
+
 \noindent \begin{minipage}{\textwidth}
 \begin{tabular}{p{0.2\textwidth} p{0.73\textwidth}}
 \toprule \textbf{Refname} & \textbf{DD:fixme2}
@@ -1309,7 +1310,7 @@ Label & Fixme
 \label{Sec:IMs}
 This section transforms the problem defined in \hyperref[Sec:ProbDesc]{Section: Problem Description} into one which is expressed in mathematical terms. It uses concrete symbols defined in \hyperref[Sec:DDs]{Section: Data Definitions} to replace the abstract symbols in the models identified in \hyperref[Sec:TMs]{Section: Theoretical Models} and \hyperref[Sec:GDs]{Section: General Definitions}.
 \par~
-    
+
 \noindent \begin{minipage}{\textwidth}
 \begin{tabular}{p{0.2\textwidth} p{0.73\textwidth}}
 \toprule \textbf{Refname} & \textbf{IM:fctSfty}
@@ -1438,7 +1439,7 @@ Isolating the factor of safety on the left-hand side and using compact notation 
 \end{displaymath}
 ${F_{S}}$ depends on the unknowns $λ$ (\hyperref[IM:nrmShrFor]{IM: nrmShrFor}) and $G$ (\hyperref[IM:intsliceFs]{IM: intsliceFs}).
 \par~
-    
+
 \noindent \begin{minipage}{\textwidth}
 \begin{tabular}{p{0.2\textwidth} p{0.73\textwidth}}
 \toprule \textbf{Refname} & \textbf{IM:nrmShrFor}
@@ -1514,7 +1515,7 @@ Taking a summation of each slice, and applying the boundary condition that $G_{0
 \end{displaymath}
 equation (11) for $λ$, is a function of the unknown interslice normal force $G$ \hyperref[IM:intsliceFs]{IM: intsliceFs}.
 \par~
-    
+
 \noindent \begin{minipage}{\textwidth}
 \begin{tabular}{p{0.2\textwidth} p{0.73\textwidth}}
 \toprule \textbf{Refname} & \textbf{IM:intsliceFs}
@@ -1579,7 +1580,7 @@ G_{i}=\frac{Ψ_{i-1} G_{i-1}+{F_{S}} T_{i}-R_{i}}{Φ_{i}}
 \end{displaymath}
 The constants $Ψ$ and $Φ$ described in equation (20) and equation (19) are functions of the unknowns: the interslice normal/shear force ratio $λ$ (\hyperref[IM:nrmShrFor]{IM: nrmShrFor}) and the factor of safety ${F_{S}}$ (\hyperref[IM:fctSfty]{IM: fctSfty}).
 \par~
-    
+
 \noindent \begin{minipage}{\textwidth}
 \begin{tabular}{p{0.2\textwidth} p{0.73\textwidth}}
 \toprule \textbf{Refname} & \textbf{IM:crtSlpId}

--- a/code/stable/ssp/Website/SSP_SRS.html
+++ b/code/stable/ssp/Website/SSP_SRS.html
@@ -797,7 +797,7 @@ Full Form
 2D
 </td>
 <td>
-Two-Dimensional
+two-dimensional
 </td>
 </tr>
 <tr>
@@ -940,7 +940,7 @@ This document will be used as a starting point for subsequent development phases
 Scope of Requirements
 </h2>
 <p class="paragraph">
-The scope of the requirements includes stability analysis of a Two-Dimensional (2D) soil mass, composed of a single homogeneous layer with constant material properties. The soil mass is assumed to extend infinitely in the third dimension. The analysis will be at an instant in time; factors that may change the soil properties over time will not be considered.
+The scope of the requirements includes stability analysis of a two-dimensional (2D) soil mass, composed of a single homogeneous layer with constant material properties. The soil mass is assumed to extend infinitely in the third dimension. The analysis will be at an instant in time; factors that may change the soil properties over time will not be considered.
 </p>
 </div>
 </div>

--- a/code/stable/ssp/Website/SSP_SRS.html
+++ b/code/stable/ssp/Website/SSP_SRS.html
@@ -794,6 +794,14 @@ Full Form
 </tr>
 <tr>
 <td>
+2D
+</td>
+<td>
+Two-Dimensional
+</td>
+</tr>
+<tr>
+<td>
 A
 </td>
 <td>
@@ -932,7 +940,7 @@ This document will be used as a starting point for subsequent development phases
 Scope of Requirements
 </h2>
 <p class="paragraph">
-The scope of the requirements includes stability analysis of a 2 dimensional slope, composed of homogeneous soil layers. Given the appropriate inputs, SSA identifies the most likely failure surface within the possible input range, and finds the factor of safety for the slope.
+The scope of the requirements includes stability analysis of a Two-Dimensional (2D) soil mass, composed of a single homogeneous layer with constant material properties. The soil mass is assumed to extend infinitely in the third dimension. The analysis will be at an instant in time; factors that may change the soil properties over time will not be considered.
 </p>
 </div>
 </div>


### PR DESCRIPTION
This updates the Scope of Requirements section of SSP to match the manual version. Also adds a "2D" CI to Data.Drasil since it is now used in multiple examples and is generic.