### PR TITLE
SSP Characteristics of Intended Reader

### DIFF
--- a/code/drasil-docLang/Drasil/DocumentLanguage.hs
+++ b/code/drasil-docLang/Drasil/DocumentLanguage.hs
@@ -136,7 +136,7 @@ data IntroSec = IntroProg Sentence Sentence [IntroSub]
 data IntroSub where
   IPurpose :: Sentence -> IntroSub
   IScope   :: Sentence -> Sentence -> IntroSub
-  IChar    :: Sentence -> Sentence -> Sentence -> IntroSub
+  IChar    :: Sentence -> Sentence -> Sentence -> Sentence -> IntroSub
   IOrgSec  :: Sentence -> CI -> Section -> Sentence -> IntroSub
 
 {--}
@@ -392,8 +392,8 @@ mkIntroSec si (IntroProg probIntro progDefn l) =
     mkSubIntro _ (IPurpose intro) = Intro.purposeOfDoc intro
     mkSubIntro SI {_sys = sys} (IScope main intendedPurp) =
       Intro.scopeOfRequirements main sys intendedPurp
-    mkSubIntro SI {_sys = sys} (IChar know understand appStandd) =
-      Intro.charIntRdrF know understand sys appStandd (SRS.userChar [] [])
+    mkSubIntro SI {_sys = sys} (IChar know understand appStandd asset) =
+      Intro.charIntRdrF know understand sys appStandd asset (SRS.userChar [] [])
     mkSubIntro _ (IOrgSec i b s t)  = Intro.orgSec i b s t
     -- FIXME: s should be "looked up" using "b" once we have all sections being generated
 

--- a/code/drasil-docLang/Drasil/ExtractDocDesc.hs
+++ b/code/drasil-docLang/Drasil/ExtractDocDesc.hs
@@ -267,7 +267,7 @@ getIntrosec (IntroProg s1 s2 is) = [s1] ++ [s2] ++ concatMap getIntroSub is
 getIntroSub :: IntroSub -> [Sentence]
 getIntroSub (IPurpose s) = [s]
 getIntroSub (IScope s1 s2) = [s1] ++ [s2]
-getIntroSub (IChar s1 s2 s3) = [s1] ++ [s2] ++ [s3]
+getIntroSub (IChar s1 s2 s3 s4) = [s1] ++ [s2] ++ [s3] ++ [s4]
 getIntroSub (IOrgSec s1 _ _ s2) = [s1] ++ [s2]
 
 getStk :: StkhldrSec -> [Sentence]
@@ -387,7 +387,7 @@ ciGetIntro (IntroProg _ _ insub) = concatMap ciGetIntroSub insub
 ciGetIntroSub :: IntroSub -> [CI]
 ciGetIntroSub (IPurpose _)        = []
 ciGetIntroSub (IScope   _ _)      = []
-ciGetIntroSub (IChar    _ _ _)    = []
+ciGetIntroSub (IChar    _ _ _ _)  = []
 ciGetIntroSub (IOrgSec  _ ci _ _) = [ci]
 
 ciGetStk :: StkhldrSec -> [CI]

--- a/code/drasil-docLang/Drasil/Sections/Introduction.hs
+++ b/code/drasil-docLang/Drasil/Sections/Introduction.hs
@@ -90,9 +90,9 @@ scopeOfRequirements mainRequirement programName intendedPurpose = SRS.scpOfReq [
 -- appStandd
 -- r
 charIntRdrF :: (Idea a) => 
-  Sentence -> Sentence -> a -> Sentence -> Section -> Section
-charIntRdrF know und progName appStandd r = 
-  SRS.charOfIR (intReaderIntro know und progName appStandd r) []
+  Sentence -> Sentence -> a -> Sentence -> Sentence -> Section -> Section
+charIntRdrF know und progName appStandd asset r = 
+  SRS.charOfIR (intReaderIntro know und progName appStandd asset r) []
 
 --paragraph called by charIntRdrF
 -- topic1     - sentence the reader should have knowledge in
@@ -100,13 +100,13 @@ charIntRdrF know und progName appStandd r =
 -- stdrd      - sentence of the standards the reader should be familiar with
 -- sectionRef - reference to user characteristic section
 intReaderIntro :: (Idea a) => 
-  Sentence -> Sentence -> a -> Sentence -> Section -> [Contents]
-intReaderIntro EmptyS topic2 progName stdrd sectionRef = 
+  Sentence -> Sentence -> a -> Sentence -> Sentence -> Section -> [Contents]
+intReaderIntro EmptyS topic2 progName stdrd asset sectionRef = 
   [foldlSP [S "Reviewers of this",
   (phrase documentation), S "should have an understanding of" +:+. topic2 :+:
-  stdrd, S "The", (plural user), S "of", (short progName),
+  stdrd, S "An understanding of" +:+ asset +:+. S "would be an asset", S "The", (plural user), S "of", (short progName),
   S "can have a lower level of expertise, as explained in", (makeRef2S sectionRef)]]
-intReaderIntro topic1 topic2 progName stdrd sectionRef = 
+intReaderIntro topic1 topic2 progName stdrd EmptyS sectionRef = 
   [foldlSP [S "Reviewers of this",
   (phrase documentation), S "should have a strong knowledge in" +:+. topic1,
   S "The reviewers should also have an understanding of" +:+. topic2 :+:

--- a/code/drasil-example/Drasil/GamePhysics/Body.hs
+++ b/code/drasil-example/Drasil/GamePhysics/Body.hs
@@ -89,7 +89,7 @@ mkSRS = RefSec (RefProg intro [TUnits, tsymb tableOfSymbols, TAandA]) :
     IntroProg para1_introduction_intro (short chipmunk) 
   [IPurpose (para1_purpose_of_document_intro),
    IScope scope_of_requirements_intro_p1 scope_of_requirements_intro_p2, 
-   IChar (S "rigid body dynamics") (phrase highSchoolCalculus) (EmptyS), 
+   IChar (S "rigid body dynamics") (phrase highSchoolCalculus) (EmptyS) (EmptyS), 
    IOrgSec organization_of_documents_intro inModel (SRS.inModel [] []) EmptyS]) :
    GSDSec (GSDProg2 [SysCntxt [sysCtxIntro, LlC sysCtxFig1, sysCtxDesc, sysCtxList],
     UsrChars [user_characteristics_intro], SystCons [] [] ]) :

--- a/code/drasil-example/Drasil/GlassBR/Body.hs
+++ b/code/drasil-example/Drasil/GlassBR/Body.hs
@@ -153,7 +153,7 @@ mkSRS = RefSec (RefProg intro [TUnits, tsymb [TSPurpose, SymbOrder], TAandA]) :
       (short gLassBR)
     [IPurpose (purpOfDocIntro document gLassBR glaSlab),
      IScope incScoR endScoR,
-     IChar (rdrKnldgbleIn glBreakage blastRisk) undIR appStanddIR,
+     IChar (rdrKnldgbleIn glBreakage blastRisk) undIR appStanddIR EmptyS,
      IOrgSec orgOfDocIntro dataDefn (SRS.inModel [] []) orgOfDocIntroEnd]) :
   StkhldrSec
     (StkhldrProg2

--- a/code/drasil-example/Drasil/NoPCM/Body.hs
+++ b/code/drasil-example/Drasil/NoPCM/Body.hs
@@ -143,7 +143,7 @@ mkSRS = RefSec (RefProg intro
   [IPurpose (purpDoc progName),
   IScope (scopeReqStart thermal_analysis sWHT) (scopeReqEnd temp thermal_energy
     water),
-  IChar (charReader1 ht_trans_theo) (charReader2 M.de) EmptyS,
+  IChar (charReader1 ht_trans_theo) (charReader2 M.de) EmptyS EmptyS,
   IOrgSec orgDocIntro inModel (SRS.inModel [] []) (orgDocEnd inModel M.ode progName)]) :
   Verbatim genSystDesc:
   SSDSec 

--- a/code/drasil-example/Drasil/SSP/Body.hs
+++ b/code/drasil-example/Drasil/SSP/Body.hs
@@ -53,7 +53,8 @@ import Drasil.SSP.Changes (likelyChgs, likelyChanges_SRS, unlikelyChgs,
 import Drasil.SSP.DataDefs (dataDefns)
 import Drasil.SSP.DataDesc (sspInputMod)
 import Drasil.SSP.Defs (acronyms, crtSlpSrf, fs_concept, intrslce, itslPrpty, 
-  morPrice, mtrlPrpty, plnStrn, slice, slope, slpSrf, soil, soilLyr, ssa, ssp, sspdef,
+  morPrice, mtrlPrpty, plnStrn, slice, slope, slpSrf, soil, soilLyr, 
+  soilMechanics, ssa, ssp, sspdef,
   sspdef')
 import Drasil.SSP.GenDefs (generalDefinitions)
 import Drasil.SSP.Goals (sspGoals)
@@ -113,9 +114,10 @@ mkSRS = RefSec (RefProg intro
   IntroSec (IntroProg startIntro kSent
     [IPurpose prpsOfDoc_p1
     , IScope scpIncl scpEnd
-    , IChar (phrase solidMechanics)
-      (phrase undergraduate +:+ S "level 4" +:+ phrase Doc.physics)
-      EmptyS
+    , IChar EmptyS
+      (phrase undergraduate +:+ S "level 4" +:+ phrase Doc.physics `sAnd`
+      phrase undergraduate +:+ S "level 2 or higher" +:+ phrase solidMechanics)
+      EmptyS (phrase soilMechanics)
     , IOrgSec orgSecStart inModel (SRS.inModel [] [])  orgSecEnd]) :
     --FIXME: issue #235
     (GSDSec $ GSDProg2 [SysCntxt [sysCtxIntro, LlC sysCtxFig1, sysCtxDesc, sysCtxList], 

--- a/code/drasil-example/Drasil/SSP/Defs.hs
+++ b/code/drasil-example/Drasil/SSP/Defs.hs
@@ -5,6 +5,7 @@ import Data.Drasil.Concepts.Documentation (assumption, dataDefn, genDefn,
   goalStmt, inModel, likelyChg, physSyst, property, requirement, safety, srs,
   thModel, typUnc, unlikelyChg)
 import Data.Drasil.Concepts.Math (surface)
+import Data.Drasil.Concepts.Education (mechanics)
 
 import Data.Drasil.Phrase(of_'', compoundNC)
 import Data.Drasil.IdeaDicts hiding (dataDefn)
@@ -20,7 +21,7 @@ ssp = commonIdeaWithDict "ssp" (cn' "slope stability problem") "SSP"   [civilEng
 
 sspdef :: [NamedChunk]
 sspdef = [factor, soil, material, intrslce, slip, slope, slice, morPrice, rgFnElm,
-  slpSrf, soilPrpty, mtrlPrpty, itslPrpty, slopeSrf, soilLyr]
+  slpSrf, soilPrpty, mtrlPrpty, itslPrpty, slopeSrf, soilLyr, soilMechanics]
 
 sspdef' :: [ConceptChunk]
 sspdef' = [crtSlpSrf, plnStrn, fs_concept]
@@ -39,13 +40,15 @@ soil     = nc "soil"       (cn  "soil")
 morPrice = nc "morPrice"   (cn  "morgenstern price")
 rgFnElm  = nc "rgFnElm"    (cn' "rigid finite element")
 
-slpSrf, soilPrpty, mtrlPrpty, itslPrpty, slopeSrf, soilLyr :: NamedChunk
-slpSrf    = compoundNC slip surface
-soilPrpty = compoundNC soil     property
-mtrlPrpty = compoundNC material property
-itslPrpty = compoundNC intrslce property
-slopeSrf  = compoundNC slope surface
-soilLyr   = compoundNC soil (nc "layer" (cn' "layer"))
+slpSrf, soilPrpty, mtrlPrpty, itslPrpty, slopeSrf, soilLyr, 
+  soilMechanics :: NamedChunk
+slpSrf        = compoundNC slip surface
+soilPrpty     = compoundNC soil     property
+mtrlPrpty     = compoundNC material property
+itslPrpty     = compoundNC intrslce property
+slopeSrf      = compoundNC slope surface
+soilLyr       = compoundNC soil (nc "layer" (cn' "layer"))
+soilMechanics = compoundNC soil mechanics
 
 crtSlpSrf, plnStrn, fs_concept :: ConceptChunk
 --FIXME: move to Concepts/soldMechanics.hs? They are too specific though

--- a/code/drasil-example/Drasil/SWHS/Body.hs
+++ b/code/drasil-example/Drasil/SWHS/Body.hs
@@ -167,7 +167,7 @@ mkSRS = RefSec (RefProg intro [
     [IPurpose (purpDoc swhs_pcm progName),
      IScope (scopeReqs1 CT.thermal_analysis tank_pcm) 
        (scopeReqs2 temp CT.thermal_energy water phsChgMtrl sWHT),
-     IChar (charReader1 CT.ht_trans_theo) (charReader2 de) (EmptyS),
+     IChar (charReader1 CT.ht_trans_theo) (charReader2 de) (EmptyS) (EmptyS),
      IOrgSec orgDocIntro inModel (SRS.inModel [] [])
        (orgDocEnd swhs_pcm progName)]):
   Verbatim genSystDesc:

--- a/code/stable/ssp/SRS/SSP_SRS.tex
+++ b/code/stable/ssp/SRS/SSP_SRS.tex
@@ -233,7 +233,7 @@ This document will be used as a starting point for subsequent development phases
 The scope of the requirements includes stability analysis of a 2 dimensional slope, composed of homogeneous soil layers. Given the appropriate inputs, SSA identifies the most likely failure surface within the possible input range, and finds the factor of safety for the slope.
 \subsection{Characteristics of Intended Reader}
 \label{Sec:ReaderChars}
-Reviewers of this documentation should have a strong knowledge in solid mechanics. The reviewers should also have an understanding of undergraduate level 4 physics. The users of SSA can have a lower level of expertise, as explained in \hyperref[Sec:UserChars]{Section: User Characteristics}.
+Reviewers of this documentation should have an understanding of undergraduate level 4 physics and undergraduate level 2 or higher solid mechanics. An understanding of soil mechanics would be an asset. The users of SSA can have a lower level of expertise, as explained in \hyperref[Sec:UserChars]{Section: User Characteristics}.
 \subsection{Organization of Document}
 \label{Sec:DocOrg}
 The organization of this document follows the template for an SRS for scientific computing software proposed by Koothoor as well as Smith and Lai. The presentation follows the standard pattern of presenting goals, theories, definitions, and assumptions. For readers that would like a more bottom up approach, they can start reading the instance models in \hyperref[Sec:IMs]{Section: Instance Models} and trace back to find any additional information they require.

--- a/code/stable/ssp/Website/SSP_SRS.html
+++ b/code/stable/ssp/Website/SSP_SRS.html
@@ -942,7 +942,7 @@ The scope of the requirements includes stability analysis of a 2 dimensional slo
 Characteristics of Intended Reader
 </h2>
 <p class="paragraph">
-Reviewers of this documentation should have a strong knowledge in solid mechanics. The reviewers should also have an understanding of undergraduate level 4 physics. The users of SSA can have a lower level of expertise, as explained in <a href=#Sec:UserChars>Section: User Characteristics</a>.
+Reviewers of this documentation should have an understanding of undergraduate level 4 physics and undergraduate level 2 or higher solid mechanics. An understanding of soil mechanics would be an asset. The users of SSA can have a lower level of expertise, as explained in <a href=#Sec:UserChars>Section: User Characteristics</a>.
 </p>
 </div>
 </div>


### PR DESCRIPTION
This updates how the Characteristics of Intended Reader section is built, allowing for the inclusion of topics that "would be an asset" if understood. This allowed the section in SSP to match the manual version. The change was done in such a way that the text in other examples did not change, though in the future we likely want to make this consistent between examples (issue about this on its way).