### PR TITLE
Misc TeX (Related) Fixes

### DIFF
--- a/code/drasil-example/Drasil/GamePhysics/DataDefs.hs
+++ b/code/drasil-example/Drasil/GamePhysics/DataDefs.hs
@@ -218,7 +218,7 @@ dd8descr = (impulseScl ^. term) +:+ S "used to determine" +:+
 -}
 ------------------------DD9 Chasles Theorem----------------------------------
 chaslesDD :: DataDefinition
-chaslesDD = mkDD chasles [{-- References --}] [{-- Derivation --}] "impulse"
+chaslesDD = mkDD chasles [{-- References --}] [{-- Derivation --}] "chalses"
   [chaslesThmDesc]
 
 chasles :: QDefinition

--- a/code/drasil-example/Drasil/GlassBR/DataDefs.hs
+++ b/code/drasil-example/Drasil/GlassBR/DataDefs.hs
@@ -215,7 +215,7 @@ calofDemandQD :: QDefinition
 calofDemandQD = mkQuantDef demand calofDemand_eq
 
 calofDemand :: DataDefinition
-calofDemand = mkDD calofDemandQD [astm2009] [{-derivation-}] "calofCapacity" (calofDemandDesc : [])
+calofDemand = mkDD calofDemandQD [astm2009] [{-derivation-}] "calofDemand" [calofDemandDesc]
 
 
 --Additional Notes--

--- a/code/drasil-printers/Language/Drasil/TeX/Helpers.hs
+++ b/code/drasil-printers/Language/Drasil/TeX/Helpers.hs
@@ -93,10 +93,12 @@ genSec d
       TP.<> (if (not numberedSections) then text "*" else TP.empty) 
 
 -- For references
-ref, sref, hyperref, snref :: String -> D -> D
+ref, sref, hyperref, externalref, snref :: String -> D -> D
 sref         = if numberedSections then ref else hyperref
 ref      t x = custRef (t ++ "~\\ref") x
 hyperref t x = command0 "hyperref" <> sq x <> br ((pure $ text (t ++ "~")) <> x)
+externalref t x = command0 "hyperref" <> br (pure $ text t) <> br empty <>
+  br empty <> br x
 snref    r t = command0 "hyperref" <> sq (pure $ text r) <> br t
 
 href :: String -> String -> D

--- a/code/drasil-printers/Language/Drasil/TeX/Print.hs
+++ b/code/drasil-printers/Language/Drasil/TeX/Print.hs
@@ -36,7 +36,7 @@ import qualified Language.Drasil.Printing.Import as I
 import Language.Drasil.Printing.Helpers hiding (paren, sqbrac)
 import Language.Drasil.TeX.Helpers (label, caption, centering, mkEnv, item', description,
   includegraphics, center, figure, item, symbDescription, enumerate, itemize, toEqn, empty,
-  newline, superscript, parens, fraction, quote,
+  newline, superscript, parens, fraction, quote, externalref,
   snref, cite, sec, newpage, maketoc, maketitle, document, author, title)
 import Language.Drasil.TeX.Monad (D, MathContext(Curr, Math, Text), vcat, (%%),
   toMath, switch, unPL, lub, hpunctuate, toText, ($+$), runPrint)
@@ -268,7 +268,7 @@ spec (Sp s) = pure $ text $ unPL $ L.special s
 spec HARDNL = pure $ text "\\newline"
 spec (Ref Internal r sn)  = snref r $ spec sn
 spec (Ref Cite2 r _)      = cite $ pure $ text r
-spec (Ref External r sn)  = snref r $ spec sn
+spec (Ref External r sn)  = externalref r $ spec sn
 spec EmptyS                 = empty
 spec (Quote q)              = quote $ spec q
 

--- a/code/stable/gamephys/SRS/Chipmunk_SRS.tex
+++ b/code/stable/gamephys/SRS/Chipmunk_SRS.tex
@@ -286,7 +286,7 @@ The instance models that govern Chipmunk2D are presented in \hyperref[Sec:IMs]{S
 \label{Sec:Assumps}
 This section simplifies the original problem and helps in developing the theoretical model by filling in the missing information for the physical system. The numbers given in the square brackets refer to the Theoretical Models \hyperref[Sec:TMs]{Section: Theoretical Models}, General Definitions \hyperref[Sec:GDs]{Section: General Definitions}, Data Definitions \hyperref[Sec:DDs]{Section: Data Definitions}, Instance Models \hyperref[Sec:IMs]{Section: Instance Models}, Likely Changes \hyperref[Sec:LCs]{Section: Likely Changes}, or Unlikely Changes \hyperref[Sec:UCs]{Section: Unlikely Changes}, in which the respective assumption is used.
 \begin{description}
-\item[\refstepcounter{assumpnum}\atheassumpnum\label{A:objectTy}:]All objects are rigid bodies. \hyperref[DD:impulse]{DD: impulse} \hyperref[IM:transMot]{IM: transMot} \hyperref[IM:rotMot]{IM: rotMot} \hyperref[DD:ctrOfMass]{DD: ctrOfMass} \hyperref[DD:linVel]{DD: linVel} \hyperref[DD:linDisp]{DD: linDisp} \hyperref[DD:linAcc]{DD: linAcc} \hyperref[DD:impulse]{DD: impulse} \hyperref[IM:col2D]{IM: col2D} \hyperref[TM:ChaslesThm]{TM: ChaslesThm} \hyperref[DD:angVel]{DD: angVel} \hyperref[DD:angDisp]{DD: angDisp} \hyperref[DD:angAccel]{DD: angAccel}.
+\item[\refstepcounter{assumpnum}\atheassumpnum\label{A:objectTy}:]All objects are rigid bodies. \hyperref[DD:chalses]{DD: chalses} \hyperref[IM:transMot]{IM: transMot} \hyperref[IM:rotMot]{IM: rotMot} \hyperref[DD:ctrOfMass]{DD: ctrOfMass} \hyperref[DD:linVel]{DD: linVel} \hyperref[DD:linDisp]{DD: linDisp} \hyperref[DD:linAcc]{DD: linAcc} \hyperref[DD:impulse]{DD: impulse} \hyperref[IM:col2D]{IM: col2D} \hyperref[TM:ChaslesThm]{TM: ChaslesThm} \hyperref[DD:angVel]{DD: angVel} \hyperref[DD:angDisp]{DD: angDisp} \hyperref[DD:angAccel]{DD: angAccel}.
 \end{description}
 \begin{description}
 \item[\refstepcounter{assumpnum}\atheassumpnum\label{A:objectDimension}:]All objects are 2D. \hyperref[IM:transMot]{IM: transMot} \hyperref[IM:rotMot]{IM: rotMot} \hyperref[DD:ctrOfMass]{DD: ctrOfMass} \hyperref[TM:NewtonSecLawRotMot]{TM: NewtonSecLawRotMot} \hyperref[DD:linVel]{DD: linVel} \hyperref[DD:linDisp]{DD: linDisp} \hyperref[DD:linAcc]{DD: linAcc} \hyperref[DD:impulse]{DD: impulse} \hyperref[IM:col2D]{IM: col2D} \hyperref[DD:angVel]{DD: angVel} \hyperref[DD:angDisp]{DD: angDisp} \hyperref[DD:angAccel]{DD: angAccel}.
@@ -704,9 +704,9 @@ Label & Impulse (scalar)
 ~\newline
  \noindent \begin{minipage}{\textwidth}
 \begin{tabular}{p{0.2\textwidth} p{0.73\textwidth}}
-\toprule \textbf{Refname} & \textbf{DD:impulse}
+\toprule \textbf{Refname} & \textbf{DD:chalses}
 \phantomsection 
-\label{DD:impulse}
+\label{DD:chalses}
 \\ \midrule \\
 Label & Velocity At Point B
         \\ \midrule \\
@@ -1017,7 +1017,7 @@ Free open source 3D game physics libraries include:
 The purpose of the traceability matrices is to provide easy references on what has to be additionally modified if a certain component is changed. Every time a component is changed, the items in the column of that component that are marked with an ``X'' should be modified as well. \hyperref[Table:Tracey]{Table:Tracey} shows the dependencies of goal statements, requirements, instance models, and data constraints with each other. \hyperref[Table:TraceyReqGoalsOther]{Table:TraceyReqGoalsOther} shows the dependencies of theoretical models, general definitions, data definitions, instance models, and on the assumptions. \hyperref[Table:TraceyAssumpsOther]{Table:TraceyAssumpsOther} shows the dependencies of theoretical models, general definitions, data definitions, and instance models on each other.
 \begin{longtable}{l l l l l l l l l l l l l l l l l l l}
 \toprule
- & \hyperref[reqVPC]{FR: Verify-Physical\_Constraints} & \hyperref[IM:rotMot]{IM: rotMot} & \hyperref[DD:impulse]{DD: impulse} & \hyperref[IM:col2D]{IM: col2D} & \hyperref[IM:transMot]{IM: transMot} & \hyperref[lcIJC]{LC: Include-Joints-Constraints} & \hyperref[lcEC]{LC: Expanded-Collisions} & \hyperref[DD:linVel]{DD: linVel} & \hyperref[DD:linDisp]{DD: linDisp} & \hyperref[DD:linAcc]{DD: linAcc} & \hyperref[lcID]{LC: Include-Dampening} & \hyperref[DD:angVel]{DD: angVel} & \hyperref[DD:angDisp]{DD: angDisp} & \hyperref[DD:angAccel]{DD: angAccel} & \hyperref[DD:ctrOfMass]{DD: ctrOfMass} & \hyperref[TM:NewtonSecLawRotMot]{TM: NewtonSecLawRotMot} & \hyperref[DD:impulse]{DD: impulse} & \hyperref[TM:ChaslesThm]{TM: ChaslesThm}
+ & \hyperref[reqVPC]{FR: Verify-Physical\_Constraints} & \hyperref[IM:rotMot]{IM: rotMot} & \hyperref[DD:impulse]{DD: impulse} & \hyperref[IM:col2D]{IM: col2D} & \hyperref[IM:transMot]{IM: transMot} & \hyperref[lcIJC]{LC: Include-Joints-Constraints} & \hyperref[lcEC]{LC: Expanded-Collisions} & \hyperref[DD:linVel]{DD: linVel} & \hyperref[DD:linDisp]{DD: linDisp} & \hyperref[DD:linAcc]{DD: linAcc} & \hyperref[lcID]{LC: Include-Dampening} & \hyperref[DD:angVel]{DD: angVel} & \hyperref[DD:angDisp]{DD: angDisp} & \hyperref[DD:angAccel]{DD: angAccel} & \hyperref[DD:ctrOfMass]{DD: ctrOfMass} & \hyperref[TM:NewtonSecLawRotMot]{TM: NewtonSecLawRotMot} & \hyperref[DD:chalses]{DD: chalses} & \hyperref[TM:ChaslesThm]{TM: ChaslesThm}
 \\
 \midrule
 \hyperref[Sec:SolCharSpec]{Section: Solution Characteristics Specification} & X &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  & 
@@ -1132,7 +1132,7 @@ DD7 (\hyperref[DD:angAccel]{DD: angAccel}) & X & X &  &  &  & X &
 \\
 DD8 (\hyperref[DD:impulse]{DD: impulse}) & X & X &  & X & X &  & 
 \\
-IM1 (\hyperref[DD:impulse]{DD: impulse}) & X & X &  &  &  & X & X
+IM1 (\hyperref[DD:chalses]{DD: chalses}) & X & X &  &  &  & X & X
 \\
 IM2 (\hyperref[DD:torque]{DD: torque}) & X & X &  & X &  & X & X
 \\
@@ -1152,7 +1152,7 @@ LC4 (\hyperref[lcEC]{LC: Expanded-Collisions}) &  &  &  &  &  &  & X
 \end{longtable}
 \begin{longtable}{l l l l l l l l l l l l l l l l l l l l l l l l}
 \toprule
- & T1 (\hyperref[TM:NewtonSecLawMot]{TM: NewtonSecLawMot}) & T2 (\hyperref[TM:NewtonThirdLawMot]{TM: NewtonThirdLawMot}) & T3 (\hyperref[TM:UniversalGravLaw]{TM: UniversalGravLaw}) & T4 (\hyperref[TM:ChaslesThm]{TM: ChaslesThm}) & T5 (\hyperref[TM:NewtonSecLawRotMot]{TM: NewtonSecLawRotMot}) & GD1 (\hyperref[Sec:SolCharSpec]{Section: Solution Characteristics Specification}) & GD2 (\hyperref[Sec:SolCharSpec]{Section: Solution Characteristics Specification}) & GD3 (\hyperref[Sec:SolCharSpec]{Section: Solution Characteristics Specification}) & GD4 (\hyperref[Sec:SolCharSpec]{Section: Solution Characteristics Specification}) & GD5 (\hyperref[Sec:SolCharSpec]{Section: Solution Characteristics Specification}) & GD6 (\hyperref[Sec:SolCharSpec]{Section: Solution Characteristics Specification}) & GD7 (\hyperref[Sec:SolCharSpec]{Section: Solution Characteristics Specification}) & DD1 (\hyperref[DD:ctrOfMass]{DD: ctrOfMass}) & DD2 (\hyperref[DD:linDisp]{DD: linDisp}) & DD3 (\hyperref[DD:linVel]{DD: linVel}) & DD4 (\hyperref[DD:linAcc]{DD: linAcc}) & DD5 (\hyperref[DD:angDisp]{DD: angDisp}) & DD6 (\hyperref[DD:angVel]{DD: angVel}) & DD7 (\hyperref[DD:angAccel]{DD: angAccel}) & DD8 (\hyperref[DD:impulse]{DD: impulse}) & IM1 (\hyperref[DD:impulse]{DD: impulse}) & IM2 (\hyperref[DD:torque]{DD: torque}) & IM3 (\hyperref[IM:transMot]{IM: transMot})
+ & T1 (\hyperref[TM:NewtonSecLawMot]{TM: NewtonSecLawMot}) & T2 (\hyperref[TM:NewtonThirdLawMot]{TM: NewtonThirdLawMot}) & T3 (\hyperref[TM:UniversalGravLaw]{TM: UniversalGravLaw}) & T4 (\hyperref[TM:ChaslesThm]{TM: ChaslesThm}) & T5 (\hyperref[TM:NewtonSecLawRotMot]{TM: NewtonSecLawRotMot}) & GD1 (\hyperref[Sec:SolCharSpec]{Section: Solution Characteristics Specification}) & GD2 (\hyperref[Sec:SolCharSpec]{Section: Solution Characteristics Specification}) & GD3 (\hyperref[Sec:SolCharSpec]{Section: Solution Characteristics Specification}) & GD4 (\hyperref[Sec:SolCharSpec]{Section: Solution Characteristics Specification}) & GD5 (\hyperref[Sec:SolCharSpec]{Section: Solution Characteristics Specification}) & GD6 (\hyperref[Sec:SolCharSpec]{Section: Solution Characteristics Specification}) & GD7 (\hyperref[Sec:SolCharSpec]{Section: Solution Characteristics Specification}) & DD1 (\hyperref[DD:ctrOfMass]{DD: ctrOfMass}) & DD2 (\hyperref[DD:linDisp]{DD: linDisp}) & DD3 (\hyperref[DD:linVel]{DD: linVel}) & DD4 (\hyperref[DD:linAcc]{DD: linAcc}) & DD5 (\hyperref[DD:angDisp]{DD: angDisp}) & DD6 (\hyperref[DD:angVel]{DD: angVel}) & DD7 (\hyperref[DD:angAccel]{DD: angAccel}) & DD8 (\hyperref[DD:impulse]{DD: impulse}) & IM1 (\hyperref[DD:chalses]{DD: chalses}) & IM2 (\hyperref[DD:torque]{DD: torque}) & IM3 (\hyperref[IM:transMot]{IM: transMot})
 \\
 \midrule
 T1 (\hyperref[TM:NewtonSecLawMot]{TM: NewtonSecLawMot}) &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  & 
@@ -1195,7 +1195,7 @@ DD7 (\hyperref[DD:angAccel]{DD: angAccel}) &  &  &  &  &  &  &  &  &  &  &  &  &
 \\
 DD8 (\hyperref[DD:impulse]{DD: impulse}) &  &  &  & X &  & X &  &  & X & X &  & X &  &  &  &  &  &  &  &  &  &  & X
 \\
-IM1 (\hyperref[DD:impulse]{DD: impulse}) & X &  &  &  &  &  &  & X &  &  &  &  & X & X & X & X &  &  &  &  &  &  & 
+IM1 (\hyperref[DD:chalses]{DD: chalses}) & X &  &  &  &  &  &  & X &  &  &  &  & X & X & X & X &  &  &  &  &  &  & 
 \\
 IM2 (\hyperref[DD:torque]{DD: torque}) &  &  &  &  & X &  &  &  &  &  &  &  & X & X & X & X &  &  &  &  &  &  & 
 \\

--- a/code/stable/gamephys/Website/Chipmunk_SRS.html
+++ b/code/stable/gamephys/Website/Chipmunk_SRS.html
@@ -1027,7 +1027,7 @@ This section simplifies the original problem and helps in developing the theoret
 <ul class="hide-list-style">
 <li>
 <div id="A:objectTy">
-objectTy: All objects are rigid bodies. <a href=#DD:impulse>DD: impulse</a> <a href=#IM:transMot>IM: transMot</a> <a href=#IM:rotMot>IM: rotMot</a> <a href=#DD:ctrOfMass>DD: ctrOfMass</a> <a href=#DD:linVel>DD: linVel</a> <a href=#DD:linDisp>DD: linDisp</a> <a href=#DD:linAcc>DD: linAcc</a> <a href=#DD:impulse>DD: impulse</a> <a href=#IM:col2D>IM: col2D</a> <a href=#TM:ChaslesThm>TM: ChaslesThm</a> <a href=#DD:angVel>DD: angVel</a> <a href=#DD:angDisp>DD: angDisp</a> <a href=#DD:angAccel>DD: angAccel</a>.
+objectTy: All objects are rigid bodies. <a href=#DD:chalses>DD: chalses</a> <a href=#IM:transMot>IM: transMot</a> <a href=#IM:rotMot>IM: rotMot</a> <a href=#DD:ctrOfMass>DD: ctrOfMass</a> <a href=#DD:linVel>DD: linVel</a> <a href=#DD:linDisp>DD: linDisp</a> <a href=#DD:linAcc>DD: linAcc</a> <a href=#DD:impulse>DD: impulse</a> <a href=#IM:col2D>IM: col2D</a> <a href=#TM:ChaslesThm>TM: ChaslesThm</a> <a href=#DD:angVel>DD: angVel</a> <a href=#DD:angDisp>DD: angDisp</a> <a href=#DD:angAccel>DD: angAccel</a>.
 </div>
 </li>
 </ul>
@@ -2376,7 +2376,7 @@ RefBy
 </tr>
 </table>
 </div>
-<div id="DD:impulse">
+<div id="DD:chalses">
 <table class="ddefn">
 <tr>
 <th>
@@ -3456,7 +3456,7 @@ The purpose of the traceability matrices is to provide easy references on what h
 <a href=#TM:NewtonSecLawRotMot>TM: NewtonSecLawRotMot</a>
 </th>
 <th>
-<a href=#DD:impulse>DD: impulse</a>
+<a href=#DD:chalses>DD: chalses</a>
 </th>
 <th>
 <a href=#TM:ChaslesThm>TM: ChaslesThm</a>
@@ -5247,7 +5247,7 @@ X
 </tr>
 <tr>
 <td>
-IM1 (<a href=#DD:impulse>DD: impulse</a>)
+IM1 (<a href=#DD:chalses>DD: chalses</a>)
 </td>
 <td>
 X
@@ -5499,7 +5499,7 @@ DD7 (<a href=#DD:angAccel>DD: angAccel</a>)
 DD8 (<a href=#DD:impulse>DD: impulse</a>)
 </th>
 <th>
-IM1 (<a href=#DD:impulse>DD: impulse</a>)
+IM1 (<a href=#DD:chalses>DD: chalses</a>)
 </th>
 <th>
 IM2 (<a href=#DD:torque>DD: torque</a>)
@@ -6990,7 +6990,7 @@ X
 </tr>
 <tr>
 <td>
-IM1 (<a href=#DD:impulse>DD: impulse</a>)
+IM1 (<a href=#DD:chalses>DD: chalses</a>)
 </td>
 <td>
 X
@@ -7265,7 +7265,7 @@ References
 </li>
 <li>
 <div id="smithLai2005">
-[7]: Smith, W. Spencer and Lai, Lei. "A new requirements template for scientific computing." <em>Proceedings of the First International Workshop onSituational Requirements Engineering Processes - Methods,Techniques and Tools to Support Situation-Specific RequirementsEngineering Processes, SREP'05</em>. Edited by PJ Agerfalk, N. Kraiem, and J. Ralyte, Paris, France: 2005. pp. 107&ndash;121. In conjunction with 13th IEEE International Requirements Engineering Conference,
+[7]: Smith, W. Spencer and Lai, Lei. "A new requirements template for scientific computing." <em>Proceedings of the First International Workshop on Situational Requirements Engineering Processes - Methods, Techniques and Tools to Support Situation-Specific Requirements Engineering Processes, SREP'05</em>. Edited by PJ Agerfalk, N. Kraiem, and J. Ralyte, Paris, France: 2005. pp. 107&ndash;121. In conjunction with 13th IEEE International Requirements Engineering Conference,
 </div>
 </li>
 <li>

--- a/code/stable/glassbr/SRS/GlassBR_SRS.tex
+++ b/code/stable/glassbr/SRS/GlassBR_SRS.tex
@@ -419,7 +419,7 @@ Label & Safety Req-LR
                                  \item{$q$ is the applied load (demand) (Pa)}
                                  \end{symbDescription}
                                  \\ \midrule \\
-                                 Notes & If $is-safeLR$, the glass is considered safe. $is-safePb$ (from \hyperref[TM:isSafePb]{TM: isSafePb}) and $is-safeLR$ are either both True or both False. LR is the load resistance (also called capacity), as defined in \hyperref[DD:calofCapacity]{DD: calofCapacity}. $q$ (also referred as the Demand) is the 3 second duration equivalent pressure, as defined in \hyperref[DD:calofCapacity]{DD: calofCapacity}.
+                                 Notes & If $is-safeLR$, the glass is considered safe. $is-safePb$ (from \hyperref[TM:isSafePb]{TM: isSafePb}) and $is-safeLR$ are either both True or both False. LR is the load resistance (also called capacity), as defined in \hyperref[DD:calofCapacity]{DD: calofCapacity}. $q$ (also referred as the Demand) is the 3 second duration equivalent pressure, as defined in \hyperref[DD:calofDemand]{DD: calofDemand}.
                                          \\ \midrule \\
                                          Source & \cite{astm2009}
                                                   \\ \midrule \\
@@ -675,7 +675,7 @@ Label & Dimensionless load
                                                   \item{$GTF$ is the glass type factor (Unitless)}
                                                   \end{symbDescription}
                                                   \\ \midrule \\
-                                                  Notes & $q$ is the 3 second equivalent pressure, as given in \hyperref[DD:calofCapacity]{DD: calofCapacity}.
+                                                  Notes & $q$ is the 3 second equivalent pressure, as given in \hyperref[DD:calofDemand]{DD: calofDemand}.
                                                           $a$, $b$ are dimensions of the plate, where ($a\geq{}b$).
                                                           $h$ is the minimum thickness, which is based on the nominal thicknesses as shown in \hyperref[DD:min.thick]{DD: min\_thick}.
                                                           $GTF$ is the glass type factor, as given by \hyperref[DD:gTF]{DD: gTF}.
@@ -786,7 +786,7 @@ Label & Stand off distance
                                                   \\ \midrule \\
                                                   Source & \cite{astm2009}
                                                            \\ \midrule \\
-                                                           RefBy & \hyperref[DD:calofCapacity]{DD: calofCapacity} \hyperref[IM:calOfDemand]{IM: calOfDemand}.
+                                                           RefBy & \hyperref[DD:calofDemand]{DD: calofDemand} \hyperref[IM:calOfDemand]{IM: calOfDemand}.
 \\ \bottomrule \end{tabular}
 \end{minipage}\\
 ~\newline
@@ -885,9 +885,9 @@ Label & Load resistance
 ~\newline
  \noindent \begin{minipage}{\textwidth}
 \begin{tabular}{p{0.2\textwidth} p{0.73\textwidth}}
-\toprule \textbf{Refname} & \textbf{DD:calofCapacity}
+\toprule \textbf{Refname} & \textbf{DD:calofDemand}
 \phantomsection 
-\label{DD:calofCapacity}
+\label{DD:calofDemand}
 \\ \midrule \\
 Label & Applied load (demand)
         \\ \midrule \\
@@ -1080,7 +1080,7 @@ This problem is small in size and relatively simple, so performance is not a pri
 The purpose of the traceability matrices is to provide easy references on what has to be additionally modified if a certain component is changed. Every time a component is changed, the items in the column of that component that are marked with an ``X'' should be modified as well. \hyperref[Table:Tracey]{Table:Tracey} shows the dependencies of theoretical models, instance models, and data definitions with each other. \hyperref[Table:TraceyItemSecs]{Table:TraceyItemSecs} shows the dependencies of requirements on theoretical models, instance models, data definitions, and data constraints. \hyperref[Table:TraceyReqsItems]{Table:TraceyReqsItems} shows the dependencies of theoretical models, instance models, data definitions, likely changes and requirements on the assumptions.
 \begin{longtable}{l l l l l l l l l l l l l l l l l l l l l l l l}
 \toprule
- & \hyperref[checkInputWithDataCons]{FR: Check-Input-with-Data\_Constraints} & \hyperref[inputGlassProps]{FR: Input-Glass-Props} & \hyperref[DD:tolLoad]{DD: tolLoad} & \hyperref[DD:stressDistFac]{DD: stressDistFac} & \hyperref[accMoreBoundaryConditions]{LC: Accomodate-More-Boundary-Conditions} & \hyperref[calcInternalBlastRisk]{LC: Calculate-Internal-Blask-Risk} & \hyperref[accAlteredGlass]{UC: Accommodate-Altered-Glass} & \hyperref[DD:calofCapacity]{DD: calofCapacity} & \hyperref[DD:dimlessLoad]{DD: dimlessLoad} & \hyperref[accMoreThanSingleLite]{LC: Accomodate-More-than-Single-Lite} & \hyperref[varValsOfmkE]{LC: Variable-Values-of-m,k,E} & \hyperref[DD:loadDurFactor]{DD: loadDurFactor} & \hyperref[considerMoreThanFlexGlass]{LC: Consider-More-than-Flexure-Glass} & \hyperref[DD:sdf.tol]{DD: sdf\_tol} & \hyperref[DD:nFL]{DD: nFL} & \hyperref[TM:isSafeLR]{TM: isSafeLR} & \hyperref[outputValsAndKnownQuants]{FR: Output-Values-and-Known-Quantities} & \hyperref[DD:risk.fun]{DD: risk\_fun} & \hyperref[TM:isSafePb]{TM: isSafePb} & \hyperref[DD:probOfBreak]{DD: probOfBreak} & \hyperref[checkGlassSafety]{FR: Check-Glass-Safety} & \hyperref[DD:calofCapacity]{DD: calofCapacity} & \hyperref[IM:calOfDemand]{IM: calOfDemand}
+ & \hyperref[checkInputWithDataCons]{FR: Check-Input-with-Data\_Constraints} & \hyperref[inputGlassProps]{FR: Input-Glass-Props} & \hyperref[DD:tolLoad]{DD: tolLoad} & \hyperref[DD:stressDistFac]{DD: stressDistFac} & \hyperref[accMoreBoundaryConditions]{LC: Accomodate-More-Boundary-Conditions} & \hyperref[calcInternalBlastRisk]{LC: Calculate-Internal-Blask-Risk} & \hyperref[accAlteredGlass]{UC: Accommodate-Altered-Glass} & \hyperref[DD:calofCapacity]{DD: calofCapacity} & \hyperref[DD:dimlessLoad]{DD: dimlessLoad} & \hyperref[accMoreThanSingleLite]{LC: Accomodate-More-than-Single-Lite} & \hyperref[varValsOfmkE]{LC: Variable-Values-of-m,k,E} & \hyperref[DD:loadDurFactor]{DD: loadDurFactor} & \hyperref[considerMoreThanFlexGlass]{LC: Consider-More-than-Flexure-Glass} & \hyperref[DD:sdf.tol]{DD: sdf\_tol} & \hyperref[DD:nFL]{DD: nFL} & \hyperref[TM:isSafeLR]{TM: isSafeLR} & \hyperref[outputValsAndKnownQuants]{FR: Output-Values-and-Known-Quantities} & \hyperref[DD:risk.fun]{DD: risk\_fun} & \hyperref[TM:isSafePb]{TM: isSafePb} & \hyperref[DD:probOfBreak]{DD: probOfBreak} & \hyperref[checkGlassSafety]{FR: Check-Glass-Safety} & \hyperref[DD:calofDemand]{DD: calofDemand} & \hyperref[IM:calOfDemand]{IM: calOfDemand}
 \\
 \midrule
 \hyperref[Sec:DataConstraints]{Section: Data Constraints} & X &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  & 
@@ -1103,7 +1103,7 @@ The purpose of the traceability matrices is to provide easy references on what h
 \\
 \hyperref[A:standardValues]{A: standardValues} &  &  &  &  &  &  &  &  & X &  & X & X &  & X & X &  &  &  &  &  &  &  & 
 \\
-\hyperref[DD:calofCapacity]{DD: calofCapacity} &  &  &  &  &  &  &  &  & X &  &  &  &  &  &  & X &  &  &  &  &  &  & 
+\hyperref[DD:calofDemand]{DD: calofDemand} &  &  &  &  &  &  &  &  & X &  &  &  &  &  &  & X &  &  &  &  &  &  & 
 \\
 \hyperref[DD:dimlessLoad]{DD: dimlessLoad} &  &  &  & X &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  & 
 \\

--- a/code/stable/glassbr/Website/GlassBR_SRS.html
+++ b/code/stable/glassbr/Website/GlassBR_SRS.html
@@ -1323,7 +1323,7 @@ Notes
 </th>
 <td>
 <p class="paragraph">
-If <em>is-safeLR</em>, the glass is considered safe. <em>is-safePb</em> (from <a href=#TM:isSafePb>TM: isSafePb</a>) and <em>is-safeLR</em> are either both True or both False. LR is the load resistance (also called capacity), as defined in <a href=#DD:calofCapacity>DD: calofCapacity</a>. <em>q</em> (also referred as the Demand) is the 3 second duration equivalent pressure, as defined in <a href=#DD:calofCapacity>DD: calofCapacity</a>.
+If <em>is-safeLR</em>, the glass is considered safe. <em>is-safePb</em> (from <a href=#TM:isSafePb>TM: isSafePb</a>) and <em>is-safeLR</em> are either both True or both False. LR is the load resistance (also called capacity), as defined in <a href=#DD:calofCapacity>DD: calofCapacity</a>. <em>q</em> (also referred as the Demand) is the 3 second duration equivalent pressure, as defined in <a href=#DD:calofDemand>DD: calofDemand</a>.
 </p>
 </td>
 </tr>
@@ -2181,7 +2181,7 @@ Notes
 </th>
 <td>
 <p class="paragraph">
-<em>q</em> is the 3 second equivalent pressure, as given in <a href=#DD:calofCapacity>DD: calofCapacity</a>.
+<em>q</em> is the 3 second equivalent pressure, as given in <a href=#DD:calofDemand>DD: calofDemand</a>.
 </p>
 <p class="paragraph">
 <em>a</em>, <em>b</em> are dimensions of the plate, where (<em>a&thinsp;&ge;&thinsp;b</em>).
@@ -2545,7 +2545,7 @@ RefBy
 </th>
 <td>
 <p class="paragraph">
-<a href=#DD:calofCapacity>DD: calofCapacity</a> <a href=#IM:calOfDemand>IM: calOfDemand</a>.
+<a href=#DD:calofDemand>DD: calofDemand</a> <a href=#IM:calOfDemand>IM: calOfDemand</a>.
 </p>
 </td>
 </tr>
@@ -2843,7 +2843,7 @@ RefBy
 </tr>
 </table>
 </div>
-<div id="DD:calofCapacity">
+<div id="DD:calofDemand">
 <table class="ddefn">
 <tr>
 <th>
@@ -3618,7 +3618,7 @@ The purpose of the traceability matrices is to provide easy references on what h
 <a href=#checkGlassSafety>FR: Check-Glass-Safety</a>
 </th>
 <th>
-<a href=#DD:calofCapacity>DD: calofCapacity</a>
+<a href=#DD:calofDemand>DD: calofDemand</a>
 </th>
 <th>
 <a href=#IM:calOfDemand>IM: calOfDemand</a>
@@ -4366,7 +4366,7 @@ X
 </tr>
 <tr>
 <td>
-<a href=#DD:calofCapacity>DD: calofCapacity</a>
+<a href=#DD:calofDemand>DD: calofDemand</a>
 </td>
 <td>
 

--- a/code/stable/nopcm/SRS/NoPCM_SRS.tex
+++ b/code/stable/nopcm/SRS/NoPCM_SRS.tex
@@ -337,7 +337,7 @@ Label & Conservation of thermal energy
                                  \\ \midrule \\
                                  Notes & The above equation gives the law of conservation of energy for transient heat transfer in a material of specific heat capacity $C$ ($\frac{\text{J}}{(\text{kg}{}^{\circ}\text{C})}$) and density, $ρ$ ($\frac{\text{kg}}{\text{m}^{3}}$), where $\mathbf{q}$ is the thermal flux vector ($\frac{\text{W}}{\text{m}^{2}}$), $g$ is the volumetric heat generation per unit volume ($\frac{\text{W}}{\text{m}^{3}}$), $T$ is the temperature (${}^{\circ}$C), $t$ is time (s), and $∇$ is the degree of steepness of a graph at any point. For this equation to apply, other forms of energy, such as mechanical energy, are assumed to be negligible in the system (\hyperref[A:Thermal-Energy-Only]{A: Thermal-Energy-Only}).
                                          \\ \midrule \\
-                                         Source & \hyperref[http://www.efunda.com/formulae/heat_transfer/conduction/overview_cond.cfm]{Fourier Law of Heat Conduction and Heat Equation}
+                                         Source & \hyperref{http://www.efunda.com/formulae/heat_transfer/conduction/overview_cond.cfm}{}{}{Fourier Law of Heat Conduction and Heat Equation}
                                                   \\ \midrule \\
                                                   RefBy & \hyperref[GD:rocTempSimp]{GD: rocTempSimp}.
 \\ \bottomrule \end{tabular}

--- a/code/stable/swhs/SRS/SWHS_SRS.tex
+++ b/code/stable/swhs/SRS/SWHS_SRS.tex
@@ -421,7 +421,7 @@ Label & Conservation of thermal energy
                                  \\ \midrule \\
                                  Notes & The above equation gives the law of conservation of energy for transient heat transfer in a material of specific heat capacity $C$ ($\frac{\text{J}}{(\text{kg}{}^{\circ}\text{C})}$) and density, $ρ$ ($\frac{\text{kg}}{\text{m}^{3}}$), where $\mathbf{q}$ is the thermal flux vector ($\frac{\text{W}}{\text{m}^{2}}$), $g$ is the volumetric heat generation per unit volume ($\frac{\text{W}}{\text{m}^{3}}$), $T$ is the temperature (${}^{\circ}$C), $t$ is time (s), and $∇$ is the degree of steepness of a graph at any point. For this equation to apply, other forms of energy, such as mechanical energy, are assumed to be negligible in the system (\hyperref[A:Thermal-Energy-Only]{A: Thermal-Energy-Only}).
                                          \\ \midrule \\
-                                         Source & \hyperref[http://www.efunda.com/formulae/heat_transfer/conduction/overview_cond.cfm]{Fourier Law of Heat Conduction and Heat Equation}
+                                         Source & \hyperref{http://www.efunda.com/formulae/heat_transfer/conduction/overview_cond.cfm}{}{}{Fourier Law of Heat Conduction and Heat Equation}
                                                   \\ \midrule \\
                                                   RefBy & \hyperref[GD:rocTempSimp]{GD: rocTempSimp}.
 \\ \bottomrule \end{tabular}
@@ -457,7 +457,7 @@ Label & Sensible heat energy
                                  \\ \midrule \\
                                  Notes & $E$ is the change in sensible heat energy (J). ${C^{S}}$, ${C^{L}}$, ${C^{V}}$ are the specific heat capacity of a solid, specific heat capacity of a liquid, and specific heat capacity of a vapour, respectively ($\frac{\text{J}}{(\text{kg}{}^{\circ}\text{C})}$). $m$ is the mass (kg). $T$ is the temperature (${}^{\circ}$C), and $ΔT$ is the change in temperature (${}^{\circ}$C). ${T_{melt}}$ and ${T_{boil}}$ are the melting point temperature and boiling point temperature, respectively (${}^{\circ}$C). Sensible heating occurs as long as the material does not reach a temperature where a phase change occurs. A phase change occurs if $T$=${T_{boil}}$ or $T$= ${T_{melt}}$. If this is the case, refer to \hyperref[TM:latentHtE]{TM: latentHtE}, Latent heat energy.
                                          \\ \midrule \\
-                                         Source & \hyperref[http://en.wikipedia.org/wiki/Sensible_heat]{Definition of Sensible Heat}
+                                         Source & \hyperref{http://en.wikipedia.org/wiki/Sensible_heat}{}{}{Definition of Sensible Heat}
                                                   \\ \midrule \\
                                                   RefBy & \hyperref[IM:heatEInWtr]{IM: heatEInWtr} \hyperref[IM:heatEInPCM]{IM: heatEInPCM} \hyperref[IM:heatEInPCM]{IM: heatEInPCM} \hyperref[IM:heatEInPCM]{IM: heatEInPCM}.
 \\ \bottomrule \end{tabular}
@@ -483,7 +483,7 @@ Label & Latent heat energy
                                  \\ \midrule \\
                                  Notes & $Q$ is the change in thermal energy (J), latent heat energy. $Q\left(t\right)=\int_{0}^{t}{\frac{d\,Q\left(τ\right)}{d\,τ}}\,dτ$ is the rate of change of $Q$ with respect to time $τ$ (s). $t$ is the time (s) elapsed, as long as the phase change is not complete. The status of the phase change depends on the melt fraction, \hyperref[DD:htFusion]{DD: htFusion}. ${T_{melt}}$ and ${T_{boil}}$ are the melting point temperature and boiling point temperature, respectively (${}^{\circ}$C). Latent heating stops when all material has changed to the new phase.
                                          \\ \midrule \\
-                                         Source & \hyperref[http://en.wikipedia.org/wiki/Latent_heat]{Definition of Latent Heat}
+                                         Source & \hyperref{http://en.wikipedia.org/wiki/Latent_heat}{}{}{Definition of Latent Heat}
                                                   \\ \midrule \\
                                                   RefBy & \hyperref[TM:sensHtE]{TM: sensHtE} \hyperref[IM:heatEInPCM]{IM: heatEInPCM}.
 \\ \bottomrule \end{tabular}


### PR DESCRIPTION
This PR fixes two issues pointed out through compilation of TeX. 

1. Duplicate labels in Gamephys and GlassBR.
2. External (website) references had slightly incorrect syntax and thus did not render as a link.