### PR TITLE
Removed constant LDF to fix error in generated code

### DIFF
--- a/code/drasil-example/Drasil/GlassBR/Assumptions.hs
+++ b/code/drasil-example/Drasil/GlassBR/Assumptions.hs
@@ -15,8 +15,9 @@ import Data.Drasil.Concepts.PhysicalProperties (materialProprty)
 import Drasil.GlassBR.Concepts (beam, cantilever, edge, glaSlab, glass, gLassBR, 
   lShareFac, plane, responseTy)
 import Drasil.GlassBR.References (astm2009)
-import Drasil.GlassBR.Unitals (constant_K, constant_LoadDF, constant_LoadDur, 
-  constant_LoadSF, constant_M, constant_ModElas, explosion, lateral, load_dur)
+import Drasil.GlassBR.Unitals (constant_K, constant_LoadDur, 
+  constant_LoadSF, constant_M, constant_ModElas, explosion, lateral, lDurFac,
+  load_dur)
 
 assumptions :: [AssumpChunk] -- For testing
 assumptions = [glassType, glassCondition, explainScenario, standardValues, glassLite, boundaryConditions, 
@@ -46,7 +47,7 @@ boundaryConditions = assump "assumpBC" boundaryConditionsDesc "boundaryCondition
 -- assumpBC           = cic "assumpBC"   boundaryConditionsDesc            "boundaryConditions"  Doc.assumpDom
 responseType       = assump "assumpRT" responseTypeDesc "responseType"
 -- assumpRT           = cic "assumpRT"   responseTypeDesc                  "responseType"        Doc.assumpDom
-ldfConstant        = assump "assumpLDFC" (ldfConstantDesc constant_LoadDF) "ldfConstant"
+ldfConstant        = assump "assumpLDFC" (ldfConstantDesc lDurFac) "ldfConstant"
 -- assumpLDFC         = cic "assumpLDFC" (ldfConstantDesc constant_LoadDF) "ldfConstant"         Doc.assumpDom
 
 glassTypeDesc :: Sentence
@@ -91,7 +92,7 @@ responseTypeDesc :: Sentence
 responseTypeDesc = foldlSent [S "The", phrase responseTy, S "considered in",
   short gLassBR, S "is flexural"]
 
-ldfConstantDesc :: QDefinition -> Sentence
+ldfConstantDesc :: QuantityDict -> Sentence
 ldfConstantDesc mainConcept = foldlSent [S "With", phrase reference, S "to",
   makeRef2S standardValues `sC` S "the", phrase value `sOf`
   phrase mainConcept, sParen (ch mainConcept), S "is a", phrase constant,

--- a/code/drasil-example/Drasil/GlassBR/Unitals.hs
+++ b/code/drasil-example/Drasil/GlassBR/Unitals.hs
@@ -371,15 +371,14 @@ specDeLoad    = dcc "specDeLoad"  (nounPhraseSP "specified design load")
 --Constants--
 
 gbConstants :: [QDefinition]
-gbConstants = [constant_M, constant_K, constant_ModElas, constant_LoadDur, constant_LoadDF, constant_LoadSF]
+gbConstants = [constant_M, constant_K, constant_ModElas, constant_LoadDur, constant_LoadSF]
                 ++ gBRSpecParamVals 
 
-constant_M, constant_K, constant_ModElas, constant_LoadDur, constant_LoadDF, constant_LoadSF :: QDefinition
+constant_M, constant_K, constant_ModElas, constant_LoadDur, constant_LoadSF :: QDefinition
 constant_K       = mkQuantDef sflawParamK  $ dbl 2.86e-53
 constant_M       = mkQuantDef sflawParamM  $ 7
 constant_ModElas = mkQuantDef mod_elas     $ dbl 7.17e10
 constant_LoadDur = mkQuantDef load_dur     $ 3
-constant_LoadDF  = mkQuantDef lDurFac      $ ((sy load_dur) / 60) $^ ((sy sflawParamM) / (16))
 constant_LoadSF  = mkQuantDef loadSF       $ 1
 --Equations--
 


### PR DESCRIPTION
Because LDF was defined as both a constant and a DD in GlassBR, the generated code included this line:
`(3 / 60) ** (7 / 16) = (3 / 60) ** (7 / 16)`
Which is wrong and caused an error. The line should instead be:
`inParams.LDF = (3 / 60) ** (7 / 16)`
After removing the "constant" definition of LDF, the generated code is correct.