### PR TITLE
Add tex target to Makefile

### DIFF
--- a/code/Makefile
+++ b/code/Makefile
@@ -26,6 +26,7 @@ GAMEPHYS_EXE  = chipmunkdocs
 
 EXAMPLES = tiny glassbr nopcm swhs ssp gamephys
 BUILD_EXAMPLES = $(addsuffix _build, $(EXAMPLES))
+TEX_EXAMPLES = $(addsuffix _tex, $(EXAMPLES))
 
 DIRS = $(foreach dir, $(addsuffix _DIR,$(shell echo $(EXAMPLES) | tr a-z A-Z)), $($(dir))) $(DPACKAGES)
 DIFF = diff --strip-trailing-cr --ignore-all-space
@@ -85,6 +86,13 @@ docs: $(DOCS_PACKAGES)
 
 $(filter %-docs, $(DOCS_PACKAGES)): %-docs: FORCE
 	stack haddock drasil-$* $(haddockArgs)
+
+%_tex: EXAMPLE=$(shell echo $* | tr a-z A-Z)
+%_tex: EDIR=$($(EXAMPLE)_DIR)
+$(filter %_tex, $(TEX_EXAMPLES)): %_tex: %_build
+	cd ./build/$(EDIR)/SRS/ && $(MAKE) TEXFLAGS=--interaction=nonstopmode
+
+tex: $(TEX_EXAMPLES)
 
 clean: clean_build
 	- stack clean

--- a/code/drasil-printers/Language/Drasil/Make/Print.hs
+++ b/code/drasil-printers/Language/Drasil/Make/Print.hs
@@ -1,7 +1,7 @@
 module Language.Drasil.Make.Print where
 
 import Prelude hiding ((<>))
-import Text.PrettyPrint (Doc, text, (<>), (<+>), ($+$), hsep, vcat) 
+import Text.PrettyPrint (Doc, empty, text, (<>), (<+>), ($+$), hsep, vcat) 
 
 import Language.Drasil.Output.Formats (DocSpec(..))
 import Language.Drasil.Make.AST (Type(Phony, TeX), Target, Dependencies, Rule, Makefile(M))
@@ -30,9 +30,13 @@ printRule _                     = error "Unimplemented makefile rule"
 printTarget :: Target -> [Dependencies] -> Doc
 printTarget nameLb deps = text (nameLb ++ ": ") <+> hsep (map text deps)
 
+lualatex :: Target -> Doc
+lualatex = text . (++) "lualatex $(TEXFLAGS) "
+
+bibtex :: Target -> Doc
+bibtex = text . (++) "-bibtex $(TEXFLAGS) "
+
 -- | Renders LaTeX commands in the makefile
 printLatexCmd :: Target -> Doc
-printLatexCmd t =   tab <> text ("lualatex " ++ t) $+$
-                    tab <> text ("-bibtex " ++ t) $+$
-                    tab <> text ("lualatex " ++ t) $+$
-                    tab <> text ("lualatex " ++ t)
+printLatexCmd t = foldr (\x -> (tab <> x t $+$)) empty
+  [lualatex, bibtex, lualatex, lualatex]


### PR DESCRIPTION
This PR adds build targets to the Makefile to build the tex for all examples. As a part of this, I added a `TEXFLAGS` variable to the Makefiles generated by Drasil which the Drasil Makefile uses to ensure a build failure doesn't halt for user input. This PR does not enable building the LaTeX during Travis builds.