### PR TITLE
Code generation - Fixing duplicate constraints

### DIFF
--- a/code/drasil-code/Language/Drasil/Chunk/Code.hs
+++ b/code/drasil-code/Language/Drasil/Chunk/Code.hs
@@ -137,7 +137,7 @@ physLookup :: (Quantity q) => ConstraintMap -> q -> (q,[Constraint])
 physLookup m q = constraintLookup' q m (filter isPhysC)
 
 sfwrLookup :: (Quantity q) => ConstraintMap -> q -> (q,[Constraint])
-sfwrLookup m q = constraintLookup' q m (filter isPhysC)
+sfwrLookup m q = constraintLookup' q m (filter isSfwrC)
 
 constraintLookup' :: (Quantity q) => q -> ConstraintMap
                       -> ([Constraint] -> [Constraint]) -> (q , [Constraint])


### PR DESCRIPTION
This tiny PR fixes a bug where code for physical constraints was being generated twice and code for software constraints was not being generated at all.