### PR TITLE
Fix Warnings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -45,7 +45,7 @@ install:
 script:
  - cd code
  - curl -sSL https://raw.github.com/ndmitchell/hlint/master/misc/run.sh | sh -s .
- - make stackArgs="--no-terminal" NOISY=yes
+ - make stackArgs="--no-terminal" NOISY=yes GHCFLAGS=-Werror
  - make tex SUMMARIZE_TEX=yes
  - make docs haddockArgs="--no-haddock-deps"
 

--- a/code/Makefile
+++ b/code/Makefile
@@ -37,6 +37,10 @@ PROGS =  $(addsuffix _prog, $(EXAMPLES))
 PROFALL = --executable-profiling --library-profiling
 PROFEXEC = +RTS -xc -P
 
+GHCTHREADS += 2
+override GHCFLAGS += -Wall -j$(GHCTHREADS)
+override stackArgs += --ghc-options="$(GHCFLAGS)"
+
 NOISY=no
 SUMMARIZE_TEX=no
 
@@ -57,7 +61,7 @@ debug: EXECARGS+=$(PROFEXEC)
 debug: test
 
 $(filter build_%, $(BUILD_PACKAGES)): build_%: FORCE
-	stack install -j3 --ghc-options -j2 $(stackArgs) drasil-$* --dump-logs --interleaved-output
+	stack install -j3 $(stackArgs) drasil-$* --dump-logs --interleaved-output
 
 %_build: EXAMPLE=$(shell echo $* | tr a-z A-Z)
 %_build: EDIR=$($(EXAMPLE)_DIR)

--- a/code/drasil-example/Drasil/GamePhysics/DataDefs.hs
+++ b/code/drasil-example/Drasil/GamePhysics/DataDefs.hs
@@ -15,7 +15,7 @@ import qualified Data.Drasil.Concepts.Physics as CP (rigidBody)
 import qualified Data.Drasil.Quantities.Physics as QP (angularAccel, 
   angularDisplacement, angularVelocity, displacement, impulseS, linearAccel, 
   linearDisplacement, linearVelocity, position, restitutionCoef, time, velocity,
-  impulseV, force, torque, kEnergy, energy)
+  force, torque, kEnergy, energy)
 import qualified Data.Drasil.Quantities.PhysicalProperties as QPP (mass)
 import Data.Drasil.SentenceStructures (foldlSent)
 

--- a/code/drasil-example/Drasil/GamePhysics/Unitals.hs
+++ b/code/drasil-example/Drasil/GamePhysics/Unitals.hs
@@ -3,7 +3,7 @@ module Drasil.GamePhysics.Unitals where
 import Language.Drasil
 import Language.Drasil.ShortHands
 
-import Data.Drasil.SI_Units(kilogram, metre, m_2, newton, second, joule)
+import Data.Drasil.SI_Units(kilogram, metre, m_2, newton, second)
 import qualified Data.Drasil.Concepts.Physics as CP (rigidBody)
 import qualified Data.Drasil.Quantities.Physics as QP (acceleration, 
   angularAccel, angularDisplacement, angularVelocity, displacement, distance, 

--- a/code/drasil-example/Drasil/GlassBR/Body.hs
+++ b/code/drasil-example/Drasil/GlassBR/Body.hs
@@ -29,9 +29,9 @@ import Data.Drasil.Concepts.Documentation as Doc (analysis, appendix, aspect,
   dataConst, dataDefn, definition, document, emphasis, environment, figure, 
   goal, goalStmt, implementation, information, inModel, input_, interface, item, 
   likelyChg, model, organization, output_, physicalSystem, physSyst, problem, 
-  product_, purpose, reference, requirement, reviewer, section_, software, 
-  softwareSys, srs, srsDomains, standard, sysCont, system, template, term_,
-  theory, thModel, traceyMatrix, user, userInput, value, doccon, doccon')
+  product_, purpose, reference, requirement, section_, software, softwareSys,
+  srs, srsDomains, standard, sysCont, system, template, term_, thModel,
+  traceyMatrix, user, userInput, value, doccon, doccon')
 import Data.Drasil.Concepts.Education as Edu(civilEng, scndYrCalculus, structuralMechanics,
   educon)
 import Data.Drasil.Concepts.Math (graph, parameter, mathcon, mathcon')

--- a/code/drasil-example/Drasil/NoPCM/Body.hs
+++ b/code/drasil-example/Drasil/NoPCM/Body.hs
@@ -17,7 +17,7 @@ import Data.Drasil.Concepts.Documentation as Doc (inModel,
   document, goal, purpose, funcReqDom, srsDomains, doccon, doccon', material_)
 
 import qualified Data.Drasil.Concepts.Math as M (ode, de, unit_, equation)
-import Data.Drasil.Concepts.Education (calculus, educon, engineering)
+import Data.Drasil.Concepts.Education (educon)
 import Data.Drasil.Concepts.Software (program, softwarecon, performance)
 import Data.Drasil.Phrase (for)
 import Data.Drasil.Concepts.Thermodynamics (ener_src, thermal_analysis, temp,

--- a/code/drasil-example/Drasil/SSP/Body.hs
+++ b/code/drasil-example/Drasil/SSP/Body.hs
@@ -24,12 +24,12 @@ import qualified Drasil.DocLang.SRS as SRS (inModel, physSyst, assumpt, sysCon,
   genDefn, dataDefn, datCon)
 
 import Data.Drasil.Concepts.Documentation as Doc (analysis, assumption,
-  constant, constraint, definition, design, document, effect, element, endUser,
+  constant, constraint, definition, design, document, effect, endUser,
   environment, goal, goalStmt, information, inModel, input_, interest, 
-  interface, issue, loss, method_, model, organization, physical, physics,
-  problem, product_, property, purpose, requirement, software, softwareSys, srs,
-  srsDomains, symbol_, sysCont, system, systemConstraint, table_, template, 
-  thModel, type_, user, value, variable, physSyst, doccon, doccon')
+  issue, loss, method_, model, organization, physical, physics, problem,
+  purpose, requirement, software, softwareSys, srs, srsDomains, symbol_,
+  sysCont, system, systemConstraint, template, thModel, type_, user, value,
+  variable, physSyst, doccon, doccon')
 import Data.Drasil.Concepts.Education (solidMechanics, undergraduate, educon)
 import Data.Drasil.Concepts.Math (equation, shape, surface, mathcon, mathcon',
   number)
@@ -58,7 +58,7 @@ import Drasil.SSP.Changes (likelyChgs, likelyChanges_SRS, unlikelyChgs,
 import Drasil.SSP.DataDefs (dataDefns)
 import Drasil.SSP.DataDesc (sspInputMod)
 import Drasil.SSP.Defs (acronyms, crtSlpSrf, effFandS, factor, fs_concept, 
-  intrslce, itslPrpty, layer, morPrice, mtrlPrpty, plnStrn, slice, slip, slope,
+  intrslce, layer, morPrice, mtrlPrpty, plnStrn, slice, slip, slope,
   slpSrf, soil, soilLyr, soilMechanics, soilPrpty, ssa, ssp, sspdef, sspdef',
   waterTable)
 import Drasil.SSP.GenDefs (generalDefinitions)
@@ -67,7 +67,7 @@ import Drasil.SSP.IMods (sspIMods)
 import Drasil.SSP.References (sspCitations, morgenstern1965)
 import Drasil.SSP.Requirements (sspRequirements, sspInputDataTable)
 import Drasil.SSP.TMods (factOfSafety, equilibrium, mcShrStrgth, effStress)
-import Drasil.SSP.Unitals (effCohesion, fricAngle, fs, index, numbSlices, 
+import Drasil.SSP.Unitals (effCohesion, fricAngle, fs, index, 
   sspConstrained, sspInputs, sspOutputs, sspSymbols)
 
 --type declarations for sections--
@@ -404,7 +404,7 @@ phys_sys_intro = physSystIntro ssp fig_physsyst
 
 physSystIntro :: (Idea a, HasShortName d, Referable d) => a -> d -> Contents
 physSystIntro what indexref = foldlSPCol [S "The", introduceAbb physSyst, S "of",
-  short ssp `sC` S "as shown in", makeRef2S indexref `sC` 
+  short what `sC` S "as shown in", makeRef2S indexref `sC` 
   S "includes the following elements"]
 
 phys_sys_convention = physSystConvention morPrice morgenstern1965 slope how 

--- a/code/drasil-example/Drasil/SSP/Goals.hs
+++ b/code/drasil-example/Drasil/SSP/Goals.hs
@@ -4,7 +4,7 @@ import Language.Drasil
 
 import Data.Drasil.SentenceStructures (andThe)
 
-import Drasil.SSP.Defs (crtSlpSrf, fs_concept, slice, slope, slpSrf)
+import Drasil.SSP.Defs (crtSlpSrf, fs_concept, slice, slope)
 import Drasil.SSP.Unitals (intNormForce, intShrForce)
 
 -----------


### PR DESCRIPTION
This PR does a few things:
* Fixes existing warnings
* Exposes `GHCFLAGS` in the `Makefile`
* Enables `-Wall` when building. (No new warnings were exposed by this)
* Enables `-Werror` on Travis with `-Wall`