### PR TITLE
Python CodeGen Fixes

### DIFF
--- a/code/drasil-code/Language/Drasil/Code/Imperative/LanguageRenderer/PythonRenderer.hs
+++ b/code/drasil-code/Language/Drasil/Code/Imperative/LanguageRenderer/PythonRenderer.hs
@@ -253,6 +253,8 @@ valueDoc' c (StateObj l t vs) = prefixLib l <> stateType c t Def <> parens (call
         prefixLib (Just lib) = text lib <> dot
 valueDoc' c v@(Arg _) = valueDocD' c v
 valueDoc' c (FuncApp (Just l) n vs) = funcAppDoc c (l ++ "." ++ n) vs
+valueDoc' c (Condi cond te ee) = parens (valueDoc' c te <+> text "if" <+>
+          parens (valueDoc' c cond) <+> text "else" <+> valueDoc' c ee)
 valueDoc' c v = valueDocD c v
 
 functionDoc' :: Config -> FileType -> Label -> Method -> Doc

--- a/code/drasil-code/Language/Drasil/Code/Imperative/LanguageRenderer/PythonRenderer.hs
+++ b/code/drasil-code/Language/Drasil/Code/Imperative/LanguageRenderer/PythonRenderer.hs
@@ -76,7 +76,7 @@ pythonConfig _ c =
         stateDoc = stateDocD c, stateListDoc = stateListDocD c, statementDoc = statementDocD c, methodDoc = methodDoc' c,
         methodListDoc = methodListDocD c, methodTypeDoc = methodTypeDocD c, 
         functionListDoc = functionListDocD c, functionDoc = functionDoc' c,
-        unOpDoc = unOpDocD', valueDoc = valueDoc' c, ioDoc = ioDoc' c,
+        unOpDoc = unOpDocD'', valueDoc = valueDoc' c, ioDoc = ioDoc' c,
         inputDoc = inputDoc' c,
         complexDoc = complexDoc' c,
         getEnv = const $ error "getEnv for pythong not yet implemented"
@@ -87,6 +87,11 @@ imp, incl, initName :: Label
 imp = "import*"
 incl = "from"
 initName = "__init__"
+
+unOpDocD'' :: UnaryOp -> Doc
+unOpDocD'' Ln = text "math.log"
+unOpDocD'' Log = text "math.log10"
+unOpDocD'' op = unOpDocD' op
 
 -- short names, packaged up above (and used below)
 renderCode' :: Config -> AbstractCode -> Code


### PR DESCRIPTION
This PR corrects Python ternaries in the existing GOOL implementation as indicated by #1183.

In the process of the ternary fix, I noticed the logarithm functions used in Python were incorrect and corrected ln => `math.log` and log => `math.log10`.