### PR TITLE
Fix for missing imports in GlassBR generated code

### DIFF
--- a/code/drasil-code/Language/Drasil/Code/Imperative/Import.hs
+++ b/code/drasil-code/Language/Drasil/Code/Imperative/Import.hs
@@ -456,7 +456,7 @@ convExpr  (FCall (C c) x)  = do
   let info = sysinfodb $ codeSpec g
   args <- mapM convExpr x
 
-  fApp (codeName (codefunc (symbLookup c (symbolTable info)))) args
+  fApp (codeName (codevar (symbLookup c (symbolTable info)))) args
 convExpr FCall{}   = return $ litString "**convExpr :: FCall unimplemented**"
 convExpr (UnaryOp o u) = fmap (unop o) (convExpr u)
 convExpr (BinaryOp Frac (Int a) (Int b)) =

--- a/code/drasil-code/Language/Drasil/CodeSpec.hs
+++ b/code/drasil-code/Language/Drasil/CodeSpec.hs
@@ -5,7 +5,7 @@ import Language.Drasil
 import Language.Drasil.Development (dep, names')
 
 import Language.Drasil.Chunk.Code (CodeChunk, CodeDefinition, CodeIdea, ConstraintMap,
-  codevar, codeEquat, funcPrefix, codeName, spaceToCodeType, toCodeName, constraintMap,
+  codevar, codefunc, codeEquat, funcPrefix, codeName, spaceToCodeType, toCodeName, constraintMap,
   qtov, qtoc, symbToCodeName, codeType)
 import Language.Drasil.Code.Code (CodeType)
 import Language.Drasil.Code.DataDesc (DataDesc, getInputs)
@@ -252,16 +252,12 @@ modDepMap sm mem ms  = Map.fromList $ map (\(Mod n _) -> n) ms `zip` map getModD
                                        ("DerivedValues", [ "InputParameters" ] ),
                                        ("InputConstraints", [ "InputParameters" ] )]  -- hardcoded for now
                                                                           -- will fix later
-  where getModDep (Mod name' funcs) = 
+  where getModDep (Mod name' funcs) =
           delete name' $ nub $ concatMap getDep (concatMap fdep funcs)
         getDep n = maybeToList (Map.lookup n mem)
         fdep (FCD cd) = codeName cd:map codeName (codevars  (codeEquat cd) sm)
-        fdep (FDef (FuncDef _ i _ fs)) = concatMap fcallname fs ++ (map codeName (i ++ concatMap (fstdep sm ) fs))
+        fdep (FDef (FuncDef _ i _ fs)) = map codeName (i ++ concatMap (fstdep sm ) fs)
         fdep (FData (FuncData _ d)) = map codeName $ getInputs d   
-
-fcallname :: FuncStmt -> [String]
-fcallname (FProcCall f _ ) = [funcPrefix ++ (fname f)]
-fcallname _ = []
 
 fstdep :: ChunkDB -> FuncStmt -> [CodeChunk]
 fstdep _  (FDec cch _) = [cch]
@@ -273,7 +269,7 @@ fstdep sm (FRet e)  = codevars  e sm
 fstdep sm (FTry tfs cfs) = concatMap (fstdep sm ) tfs ++ concatMap (fstdep sm ) cfs
 fstdep _  (FThrow _) = [] -- is this right?
 fstdep _  (FContinue) = []
-fstdep sm (FProcCall _ l)  = concatMap (`codevars` sm) l
+fstdep sm (FProcCall f l)  = (codefunc (asVC f)) : (concatMap (`codevars` sm) l)
 fstdep sm (FAppend a b)  = nub (codevars  a sm ++ codevars  b sm)
 
 fstdecl :: ChunkDB -> [FuncStmt] -> [CodeChunk]
@@ -340,7 +336,7 @@ getExecOrder d k' n' sm  = getExecOrder' [] d k' (n' \\ k')
                         ++ " and Knowns as " ++ (show $ map (^. uid) k) )
               else getExecOrder' (ord ++ new) (defs' \\ new) kNew nNew
   
-subsetOf :: (Eq a) => [a] -> [a] -> Bool  
+subsetOf :: (Eq a) => [a] -> [a] -> Bool
 xs `subsetOf` ys = all (`elem` ys) xs
 
 -- | Get a list of CodeChunks from an equation

--- a/code/drasil-code/Language/Drasil/CodeSpec.hs
+++ b/code/drasil-code/Language/Drasil/CodeSpec.hs
@@ -220,8 +220,8 @@ asExpr' f = sy $ asVC' f
 
 -- FIXME: Part of above hack
 asVC' :: Func -> QuantityDict
-asVC' (FDef (FuncDef n _ _ _)) = vc n (nounPhraseSP n) (Atomic n) Real
-asVC' (FData (FuncData n _)) = vc n (nounPhraseSP n) (Atomic n) Real
+asVC' (FDef (FuncDef n _ _ _)) = vc n (nounPhraseSP n) (Atomic (funcPrefix++n)) Real
+asVC' (FData (FuncData n _)) = vc n (nounPhraseSP n) (Atomic (funcPrefix++n)) Real
 asVC' (FCD cd) = vc'' cd (codeSymb cd) (cd ^. typ)
 
 

--- a/code/drasil-code/Language/Drasil/CodeSpec.hs
+++ b/code/drasil-code/Language/Drasil/CodeSpec.hs
@@ -256,10 +256,14 @@ modDepMap sm mem ms  = Map.fromList $ map (\(Mod n _) -> n) ms `zip` map getModD
           delete name' $ nub $ concatMap getDep (concatMap fdep funcs)
         getDep n = maybeToList (Map.lookup n mem)
         fdep (FCD cd) = codeName cd:map codeName (codevars  (codeEquat cd) sm)
-        fdep (FDef (FuncDef _ i _ fs)) = map codeName (i ++ concatMap (fstdep sm ) fs)
+        fdep (FDef (FuncDef _ i _ fs)) = concatMap fcallname fs ++ (map codeName (i ++ concatMap (fstdep sm ) fs))
         fdep (FData (FuncData _ d)) = map codeName $ getInputs d   
 
-fstdep :: ChunkDB -> FuncStmt ->[CodeChunk]
+fcallname :: FuncStmt -> [String]
+fcallname (FProcCall f _ ) = [funcPrefix ++ (fname f)]
+fcallname _ = []
+
+fstdep :: ChunkDB -> FuncStmt -> [CodeChunk]
 fstdep _  (FDec cch _) = [cch]
 fstdep sm (FAsg cch e) = cch:codevars e sm
 fstdep sm (FFor cch e fs) = delete cch $ nub (codevars  e sm ++ concatMap (fstdep sm ) fs)

--- a/code/stable/glassbr/SRS/GlassBR_SRS.tex
+++ b/code/stable/glassbr/SRS/GlassBR_SRS.tex
@@ -77,15 +77,15 @@ ${d_{min}}$ & Minimum value for one of the dimensions of the glass plate & m
 \\
 $E$ & Modulus of elasticity of glass & Pa
 \\
+$func_interpY$ & InterpY & --
+\\
+$func_interpZ$ & InterpZ & --
+\\
 $g$ & Glass type $g\in{}\{AN,FT,HS\}$ & --
 \\
 $GTF$ & Glass type factor & --
 \\
 $h$ & Minimum thickness & m
-\\
-$interpY$ & InterpY & --
-\\
-$interpZ$ & InterpZ & --
 \\
 $is-safeLR$ & Variable that is assigned true when load resistance (capacity) is greater than load (demand) & --
 \\
@@ -534,12 +534,12 @@ Label & Stress distribution factor (Function)
                  Units & Unitless
                          \\ \midrule \\
                          Equation & \begin{displaymath}
-                                    J=interpZ\left(SDF.txt,AR,\hat{q}\right)
+                                    J=func_interpZ\left(SDF.txt,AR,\hat{q}\right)
                                     \end{displaymath}
                                     \\ \midrule \\
                                     Description & \begin{symbDescription}
                                                   \item{$J$ is the stress distribution factor (Function) (Unitless)}
-                                                  \item{$interpZ$ is the interpZ (Unitless)}
+                                                  \item{$func_interpZ$ is the interpZ (Unitless)}
                                                   \item{$AR$ is the aspect ratio (Unitless)}
                                                   \item{$\hat{q}$ is the dimensionless load (Unitless)}
                                                   \end{symbDescription}
@@ -681,12 +681,12 @@ Label & Tolerable load
                  Units & Unitless
                          \\ \midrule \\
                          Equation & \begin{displaymath}
-                                    {\hat{q}_{tol}}=interpY\left(SDF.txt,AR,{J_{tol}}\right)
+                                    {\hat{q}_{tol}}=func_interpY\left(SDF.txt,AR,{J_{tol}}\right)
                                     \end{displaymath}
                                     \\ \midrule \\
                                     Description & \begin{symbDescription}
                                                   \item{${\hat{q}_{tol}}$ is the tolerable load (Unitless)}
-                                                  \item{$interpY$ is the interpY (Unitless)}
+                                                  \item{$func_interpY$ is the interpY (Unitless)}
                                                   \item{$AR$ is the aspect ratio (Unitless)}
                                                   \item{${J_{tol}}$ is the stress distribution factor (Function) based on Pbtol (Unitless)}
                                                   \end{symbDescription}
@@ -910,12 +910,12 @@ Label & Applied load (demand)
                  Units & Pa
                          \\ \midrule \\
                          Equation & \begin{displaymath}
-                                    q=interpY\left(TSD.txt,SD,{w_{TNT}}\right)
+                                    q=func_interpY\left(TSD.txt,SD,{w_{TNT}}\right)
                                     \end{displaymath}
                                     \\ \midrule \\
                                     Description & \begin{symbDescription}
                                                   \item{$q$ is the applied load (demand) (Pa)}
-                                                  \item{$interpY$ is the interpY (Unitless)}
+                                                  \item{$func_interpY$ is the interpY (Unitless)}
                                                   \item{$SD$ is the stand off distance (m)}
                                                   \item{${w_{TNT}}$ is the explosive mass in equivalent weight of TNT (kg)}
                                                   \end{symbDescription}
@@ -956,12 +956,12 @@ Label & Calculation of Demand
                                              \\ \midrule \\
                                              Output Constraints & \\ \midrule \\
                                                                   Equation & \begin{displaymath}
-                                                                             q=interpY\left(TSD.txt,SD,{w_{TNT}}\right)
+                                                                             q=func_interpY\left(TSD.txt,SD,{w_{TNT}}\right)
                                                                              \end{displaymath}
                                                                              \\ \midrule \\
                                                                              Description & \begin{symbDescription}
                                                                                            \item{$q$ is the applied load (demand) (Pa)}
-                                                                                           \item{$interpY$ is the interpY (Unitless)}
+                                                                                           \item{$func_interpY$ is the interpY (Unitless)}
                                                                                            \item{$SD$ is the stand off distance (m)}
                                                                                            \item{${w_{TNT}}$ is the explosive mass in equivalent weight of TNT (kg)}
                                                                                            \end{symbDescription}

--- a/code/stable/glassbr/Website/GlassBR_SRS.html
+++ b/code/stable/glassbr/Website/GlassBR_SRS.html
@@ -200,6 +200,28 @@ Pa
 </tr>
 <tr>
 <td>
+<em>func_interpY</em>
+</td>
+<td>
+InterpY
+</td>
+<td>
+--
+</td>
+</tr>
+<tr>
+<td>
+<em>func_interpZ</em>
+</td>
+<td>
+InterpZ
+</td>
+<td>
+--
+</td>
+</tr>
+<tr>
+<td>
 <em>g</em>
 </td>
 <td>
@@ -229,28 +251,6 @@ Minimum thickness
 </td>
 <td>
 m
-</td>
-</tr>
-<tr>
-<td>
-<em>interpY</em>
-</td>
-<td>
-InterpY
-</td>
-<td>
---
-</td>
-</tr>
-<tr>
-<td>
-<em>interpZ</em>
-</td>
-<td>
-InterpZ
-</td>
-<td>
---
 </td>
 </tr>
 <tr>
@@ -1752,7 +1752,7 @@ Equation
 </th>
 <td>
 <div class="equation">
-<em>J = interpZ(SDF.txt,AR,q&#770;)</em>
+<em>J = func_interpZ(SDF.txt,AR,q&#770;)</em>
 </div>
 </td>
 </tr>
@@ -1766,7 +1766,7 @@ Description
 <em>J</em> is the stress distribution factor (Function) (Unitless)
 </li>
 <li>
-<em>interpZ</em> is the interpZ (Unitless)
+<em>func_interpZ</em> is the interpZ (Unitless)
 </li>
 <li>
 <em>AR</em> is the aspect ratio (Unitless)
@@ -2210,7 +2210,7 @@ Equation
 </th>
 <td>
 <div class="equation">
-<em>q&#770;<sub>tol</sub> = interpY(SDF.txt,AR,J<sub>tol</sub>)</em>
+<em>q&#770;<sub>tol</sub> = func_interpY(SDF.txt,AR,J<sub>tol</sub>)</em>
 </div>
 </td>
 </tr>
@@ -2224,7 +2224,7 @@ Description
 <em>q&#770;<sub>tol</sub></em> is the tolerable load (Unitless)
 </li>
 <li>
-<em>interpY</em> is the interpY (Unitless)
+<em>func_interpY</em> is the interpY (Unitless)
 </li>
 <li>
 <em>AR</em> is the aspect ratio (Unitless)
@@ -2903,7 +2903,7 @@ Equation
 </th>
 <td>
 <div class="equation">
-<em>q = interpY(TSD.txt,SD,w<sub>TNT</sub>)</em>
+<em>q = func_interpY(TSD.txt,SD,w<sub>TNT</sub>)</em>
 </div>
 </td>
 </tr>
@@ -2917,7 +2917,7 @@ Description
 <em>q</em> is the applied load (demand) (Pa)
 </li>
 <li>
-<em>interpY</em> is the interpY (Unitless)
+<em>func_interpY</em> is the interpY (Unitless)
 </li>
 <li>
 <em>SD</em> is the stand off distance (m)
@@ -3031,7 +3031,7 @@ Equation
 </th>
 <td>
 <div class="equation">
-<em>q = interpY(TSD.txt,SD,w<sub>TNT</sub>)</em>
+<em>q = func_interpY(TSD.txt,SD,w<sub>TNT</sub>)</em>
 </div>
 </td>
 </tr>
@@ -3045,7 +3045,7 @@ Description
 <em>q</em> is the applied load (demand) (Pa)
 </li>
 <li>
-<em>interpY</em> is the interpY (Unitless)
+<em>func_interpY</em> is the interpY (Unitless)
 </li>
 <li>
 <em>SD</em> is the stand off distance (m)


### PR DESCRIPTION
This PR restores some imports that were missing in the generated GlassBR code. The problems were:

- The procedure being called in an `FProcCall` was not being recognized as a dependency for the module
- When functions are used in definitions as `Expr`, they weren't being recognized as dependencies because they were missing the "func_" prefix.