### PR TITLE
Fixing GlassBR codegen by making constants doubles

### DIFF
--- a/code/drasil-code/Language/Drasil/Code/Imperative/Import.hs
+++ b/code/drasil-code/Language/Drasil/Code/Imperative/Import.hs
@@ -11,7 +11,7 @@ import Language.Drasil.Code.Imperative.LanguageRenderer (Options(..))
 import Language.Drasil.Code.Imperative.Parsers.ConfigParser (pythonLabel, cppLabel, cSharpLabel, javaLabel)
 import Language.Drasil.Code.CodeGeneration (createCodeFiles, makeCode)
 import Language.Drasil.Chunk.Code (CodeChunk, CodeDefinition, codeName, codeType, 
-  codevar, codefunc, codeEquat, funcPrefix, physLookup, sfwrLookup, programName)
+  codevar, codeEquat, funcPrefix, physLookup, sfwrLookup, programName)
 import Language.Drasil.CodeSpec hiding (codeSpec, Mod(..))
 import qualified Language.Drasil.CodeSpec as CS (Mod(..))
 import Language.Drasil.Code.DataDesc (Ind(WithPattern, WithLine, Explicit), 

--- a/code/drasil-example/Drasil/GlassBR/Unitals.hs
+++ b/code/drasil-example/Drasil/GlassBR/Unitals.hs
@@ -376,9 +376,9 @@ gbConstants = [constant_M, constant_K, constant_ModElas, constant_LoadDur, const
 
 constant_M, constant_K, constant_ModElas, constant_LoadDur, constant_LoadSF :: QDefinition
 constant_K       = mkQuantDef sflawParamK  $ dbl 2.86e-53
-constant_M       = mkQuantDef sflawParamM  $ 7
+constant_M       = mkQuantDef sflawParamM  $ dbl 7
 constant_ModElas = mkQuantDef mod_elas     $ dbl 7.17e10
-constant_LoadDur = mkQuantDef load_dur     $ 3
+constant_LoadDur = mkQuantDef load_dur     $ dbl 3
 constant_LoadSF  = mkQuantDef loadSF       $ 1
 --Equations--
 

--- a/code/stable/glassbr/SRS/GlassBR_SRS.tex
+++ b/code/stable/glassbr/SRS/GlassBR_SRS.tex
@@ -1326,13 +1326,13 @@ $k$ & surface flaw parameter & $28.6\cdot{}10^{-54}$ & $\frac{\text{m}^{12}}{\te
 \\
 $LSF$ & load share factor & $1$ & --
 \\
-$m$ & surface flaw parameter & $7$ & $\frac{\text{m}^{12}}{\text{N}^{7}}$
+$m$ & surface flaw parameter & $7.0$ & $\frac{\text{m}^{12}}{\text{N}^{7}}$
 \\
 ${SD_{max}}$ & maximum stand off distance permissible for input & $130.0$ & m
 \\
 ${SD_{min}}$ & minimum stand off distance permissible for input & $6.0$ & m
 \\
-${t_{d}}$ & duration of load & $3$ & s
+${t_{d}}$ & duration of load & $3.0$ & s
 \\
 ${w_{max}}$ & maximum permissible input charge weight & $910.0$ & kg
 \\

--- a/code/stable/glassbr/Website/GlassBR_SRS.html
+++ b/code/stable/glassbr/Website/GlassBR_SRS.html
@@ -8115,7 +8115,7 @@ load share factor
 surface flaw parameter
 </td>
 <td>
-<em>7</em>
+<em>7.0</em>
 </td>
 <td>
 m<sup>12</sup>/N<sup>7</sup>
@@ -8157,7 +8157,7 @@ m
 duration of load
 </td>
 <td>
-<em>3</em>
+<em>3.0</em>
 </td>
 <td>
 s


### PR DESCRIPTION
This PR fixes the issue where Python was outputting a different value for GlassBR than Java and the other languages. The problem was the following expression in Java:

`inParams.LDF = Math.pow(3 / 60, 7 / 16);`

3 and 7 are the constants `load_dur` and `sflawParamM`, which default to `Int`s. Then the expression above does integer division, so `inParams.LDF` gets assigned the value 1.

Defining these constants as doubles fixes the issue.