### PR TITLE
Non-Functional Requirements as formatted lists

### DIFF
--- a/code/drasil-data/Data/Drasil/Concepts/Documentation.hs
+++ b/code/drasil-data/Data/Drasil/Concepts/Documentation.hs
@@ -297,6 +297,10 @@ reqDom = ccs (mkIdea "reqDom" (requirement ^. term) $ Just "R") EmptyS [srsDom]
 funcReqDom :: ConceptChunk
 funcReqDom = ccs (mkIdea "funcReqDom" (functionalRequirement ^. term) $ Just "FR") EmptyS [reqDom]
 
+nonFuncReqDom :: ConceptChunk
+nonFuncReqDom = ccs (mkIdea "nonFuncReqDom" (nonfunctionalRequirement ^. term) $
+  Just "NFR") EmptyS [reqDom]
+
 chgProbDom :: ConceptChunk
 chgProbDom = ccs (nc "chgProbDom" $ cn' "change") EmptyS [srsDom]
 

--- a/code/drasil-data/Data/Drasil/Concepts/Documentation.hs
+++ b/code/drasil-data/Data/Drasil/Concepts/Documentation.hs
@@ -311,7 +311,8 @@ unlikeChgDom :: ConceptChunk
 unlikeChgDom = ccs (mkIdea "unlikeChgDom" (unlikelyChg ^. term) $ Just "UC") EmptyS [chgProbDom]
 -- | List of domains for SRS
 srsDomains :: [ConceptChunk]
-srsDomains = [reqDom, funcReqDom, assumpDom, likeChgDom, unlikeChgDom]
+srsDomains = [reqDom, funcReqDom, nonFuncReqDom, assumpDom, likeChgDom, 
+  unlikeChgDom]
 
 -- FIXME: fterms is here instead of Utils because of cyclic import
 -- | Apply a binary function to the terms of two named ideas, instead of to the named

--- a/code/drasil-docLang/Drasil/DocumentLanguage.hs
+++ b/code/drasil-docLang/Drasil/DocumentLanguage.hs
@@ -28,7 +28,7 @@ import qualified Drasil.Sections.GeneralSystDesc as GSD (genSysF, genSysIntro,
   systCon, usrCharsF, sysContxt)
 import qualified Drasil.Sections.Introduction as Intro (charIntRdrF,
   introductionSection, orgSec, purposeOfDoc, scopeOfRequirements)
-import qualified Drasil.Sections.Requirements as R (fReqF, nonFuncReqF, reqF)
+import qualified Drasil.Sections.Requirements as R (fReqF, nonFuncReqF, nonFuncReqF', reqF)
 import qualified Drasil.Sections.ScopeOfTheProject as SotP (scopeOfTheProjF)
 import qualified Drasil.Sections.SpecificSystemDescription as SSD (assumpF,
   datConF, dataDefnF, genDefnF, inModelF, probDescF, solutionCharSpecIntro, 
@@ -199,7 +199,8 @@ newtype ReqrmntSec = ReqsProg [ReqsSub]
 
 data ReqsSub where
   FReqsSub :: [Contents] -> ReqsSub --FIXME: Should be ReqChunks?
-  NonFReqsSub :: [ConceptChunk] -> [ConceptChunk] -> Sentence -> Sentence -> ReqsSub
+  NonFReqsSub :: [ConceptChunk] -> [ConceptChunk] -> Sentence -> Sentence -> ReqsSub --FIXME: Remove this in favour of NonFReqsSub' when all examples have migrated over to using NonFReqsSub'
+  NonFReqsSub' :: [ConceptChunk] -> [ConceptInstance] -> Sentence -> Sentence -> ReqsSub
 
 {--}
 
@@ -498,6 +499,7 @@ mkReqrmntSec (ReqsProg l) = R.reqF $ map mkSubs l
     mkSubs :: ReqsSub -> Section
     mkSubs (FReqsSub reqs) = R.fReqF reqs
     mkSubs (NonFReqsSub noPrrty prrty rsn explain) = R.nonFuncReqF noPrrty prrty rsn explain
+    mkSubs (NonFReqsSub' noPrrty nfrs rsn explain) = R.nonFuncReqF' noPrrty (mkEnumSimpleD nfrs) rsn explain
 
 {--}
 

--- a/code/drasil-docLang/Drasil/ExtractDocDesc.hs
+++ b/code/drasil-docLang/Drasil/ExtractDocDesc.hs
@@ -112,6 +112,7 @@ egetSSDSub (SSDSolChSpec s) = egetSol s
 egetReqSub :: ReqsSub -> [Expr]
 egetReqSub (FReqsSub c) = concatMap egetCon' c
 egetReqSub NonFReqsSub{} = []
+egetReqSub NonFReqsSub'{} = []
 
 egetFunc :: LFunc -> [Expr]
 egetFunc Term         = []
@@ -347,6 +348,8 @@ getReq (ReqsProg rs) = concatMap getReqSub rs
 getReqSub :: ReqsSub -> [Sentence]
 getReqSub (FReqsSub c) = concatMap getCon' c
 getReqSub (NonFReqsSub cc1 cc2 s1 s2) = (map (^. defn) cc1) ++ (map (^. defn) cc2)
+  ++ [s1, s2]
+getReqSub (NonFReqsSub' cc1 cc2 s1 s2) = (map (^. defn) cc1) ++ (map (^. defn) cc2)
   ++ [s1, s2]
 
 getLcs :: LCsSec -> [Sentence]

--- a/code/drasil-docLang/Drasil/Sections/Requirements.hs
+++ b/code/drasil-docLang/Drasil/Sections/Requirements.hs
@@ -1,5 +1,5 @@
 module Drasil.Sections.Requirements
-  (fReqF, reqF, nonFuncReqF) where
+  (fReqF, reqF, nonFuncReqF, nonFuncReqF') where
 
 import Language.Drasil
 
@@ -33,11 +33,18 @@ reqIntro = mkParagraph reqIntroS
 nonFuncReqF :: (Concept c) => [c] -> [c] -> Sentence -> Sentence -> Section
 nonFuncReqF noPriority priority_ reason_ explanation_ = SRS.nonfuncReq
   [nonFuncReq (map phrase noPriority) (map phrase priority_) reason_ explanation_] []
+
+nonFuncReqF' :: (Concept c) => [c] -> [Contents] -> Sentence -> Sentence -> Section
+nonFuncReqF' noPriority nfrs reason_ explanation_ = SRS.nonfuncReq
+  ((nonFuncReq' (map phrase noPriority) nfrs reason_ explanation_) : nfrs) []
         
 -- generalized non-functional requirements paragraph: list of non-priority requirements, list of priority requirements,
 -- reason for initial priority choice, explanation for how priority choice can be achieved.
 nonFuncReq :: [Sentence] -> [Sentence] -> Sentence -> Sentence -> Contents
 nonFuncReq noPriority priority_ reason_ explanation_ = mkParagraph $ reason_ `sC` (listO explanation_ noPriority priority_)
+
+nonFuncReq' :: [Sentence] -> [Contents] -> Sentence -> Sentence -> Contents
+nonFuncReq' noPriority priority_ reason_ explanation_ = mkParagraph $ reason_ `sC` (listO' explanation_ noPriority priority_)
 
 listO :: Sentence -> [Sentence] -> [Sentence] -> Sentence
 listO explanation_ [] [] = S "so there are no" +:+ (plural priority) +:+ explanation_
@@ -45,7 +52,18 @@ listO explanation_ [] priority_ = S "so" +:+ head priority_ +:+ S "is a high" +:
 listO explanation_ [s] priority_ = S "so" +:+ s +:+ S "is not a" +:+. phrase priority +:+ explanation_ +:+ S "Rather than" +:+ s `sC` S "the" +:+. listT priority_
 listO explanation_ s priority_ = S "so" +:+ foldlList Comma List s +:+ S "are not" +:+. (plural priority) +:+ explanation_ +:+ S "Rather, the" +:+. listT priority_
 
+listO' :: Sentence -> [Sentence] -> [Contents] -> Sentence
+listO' explanation_ [] [] = S "so there are no" +:+ (plural priority) +:+ explanation_
+listO' explanation_ []  priority_ = S "so all" +:+ (plural nonfunctionalRequirement) +:+ S "are given equal" +:+ phrase priority +:+ explanation_ +:+ S "The" +:+. listT' priority_
+listO' explanation_ [s] priority_ = S "so" +:+ s +:+ S "is not a" +:+. phrase priority +:+ explanation_ +:+ S "Rather than" +:+ s `sC` S "the" +:+. listT' priority_
+listO' explanation_ s priority_ = S "so" +:+ foldlList Comma List s +:+ S "are not" +:+. (plural priority) +:+ explanation_ +:+ S "Rather, the" +:+. listT' priority_
+
 listT :: [Sentence] -> Sentence
 listT [] = (phrase program) +:+ S "does not possess a" +:+ (phrase priority) +:+ (phrase nonfunctionalRequirement)
 listT [s] = (phrase nonfunctionalRequirement) +:+ (phrase priority) +:+ S "is" +:+ s
 listT s = (phrase nonfunctionalRequirement) +:+ (plural priority) +:+ S "are" +:+ foldlList Comma List s
+
+listT' :: [Contents] -> Sentence
+listT' [] = (phrase program) +:+ S "does not possess a" +:+ (phrase priority) +:+ (phrase nonfunctionalRequirement)
+listT' [_] = (phrase nonfunctionalRequirement) +:+ (phrase priority) +:+ S "is:"
+listT' _ = (phrase nonfunctionalRequirement) +:+ (plural priority) +:+ S "are:"


### PR DESCRIPTION
This PR sets up the DocumentLanguage to render the non-functional requirements as a formatted list, similar to the list for functional requirements (discussed in #1223). I've kept all the old functions so nothing breaks. Once we migrate all examples to using this new constructor for non-functional requirements, we can remove the old functions.

This also adds the nonFuncReqDom which will be needed to create `ConceptInstance`s out of the non-functional requirements.