### PR TITLE
Make drasil-build More Abstract.

### DIFF
--- a/code/drasil-build/Build/Drasil.hs
+++ b/code/drasil-build/Build/Drasil.hs
@@ -1,7 +1,10 @@
 module Build.Drasil (
   -- Make
     -- AST
-    Type(Phony, TeX)
+    Command(C)
+  , CommandOpts(IgnoreReturnCode)
+  , Rule(R)
+  , Type(Abstract, File)
     -- Import
   , RuleTransformer(makeRule)
     -- Print
@@ -9,6 +12,6 @@ module Build.Drasil (
   )
   where
 
-import Build.Drasil.Make.AST (Type(Phony, TeX))
+import Build.Drasil.Make.AST (Command(C), CommandOpts(IgnoreReturnCode), Rule(R), Type(Abstract, File))
 import Build.Drasil.Make.Import (RuleTransformer(makeRule))
 import Build.Drasil.Make.Print (genMake)

--- a/code/drasil-build/Build/Drasil.hs
+++ b/code/drasil-build/Build/Drasil.hs
@@ -1,10 +1,7 @@
 module Build.Drasil (
   -- Make
     -- AST
-    Command(C)
-  , CommandOpts(IgnoreReturnCode)
-  , Rule(R)
-  , Type(Abstract, File)
+    Command, mkCheckedCommand, mkCommand, mkFile, mkRule, Rule
     -- Import
   , RuleTransformer(makeRule)
     -- Print
@@ -12,6 +9,7 @@ module Build.Drasil (
   )
   where
 
-import Build.Drasil.Make.AST (Command(C), CommandOpts(IgnoreReturnCode), Rule(R), Type(Abstract, File))
+import Build.Drasil.Make.AST (Command, mkCheckedCommand, mkCommand, mkFile,
+  mkRule, Rule)
 import Build.Drasil.Make.Import (RuleTransformer(makeRule))
 import Build.Drasil.Make.Print (genMake)

--- a/code/drasil-build/Build/Drasil/Make/AST.hs
+++ b/code/drasil-build/Build/Drasil/Make/AST.hs
@@ -3,11 +3,15 @@ module Build.Drasil.Make.AST where
 
 newtype Makefile = M [Rule]
 
-type Rule = (Type, Target, [Dependencies])
+data Rule = R Target [Dependencies] Type [Command]
 
-data Type = Phony
-          | TeX
-          | Code
+data Command = C String [CommandOpts]
+
+data CommandOpts =
+  IgnoreReturnCode deriving Eq
+
+data Type = Abstract
+          | File
 
 type Target = String
 type Dependencies = Target

--- a/code/drasil-build/Build/Drasil/Make/AST.hs
+++ b/code/drasil-build/Build/Drasil/Make/AST.hs
@@ -11,7 +11,7 @@ data CommandOpts =
   IgnoreReturnCode deriving Eq
 
 data Type = Abstract
-          | File
+          | File deriving Eq
 
 type Target = String
 type Dependencies = Target

--- a/code/drasil-build/Build/Drasil/Make/AST.hs
+++ b/code/drasil-build/Build/Drasil/Make/AST.hs
@@ -15,3 +15,19 @@ data Type = Abstract
 
 type Target = String
 type Dependencies = Target
+
+-- | Creates a Rule which results in a file being created
+mkFile :: Target -> [Dependencies] -> [Command] -> Rule
+mkFile t d c = R t d File c
+
+-- | Creates an abstract Rule not associated to a specific file
+mkRule :: Target -> [Dependencies] -> [Command] -> Rule
+mkRule t d c = R t d Abstract c
+
+-- | Creates a Command which fails the make process if it does not return zero
+mkCheckedCommand :: String -> Command
+mkCheckedCommand = flip C []
+
+-- | Creates a command which executes and ignores the return code
+mkCommand :: String -> Command
+mkCommand = flip C [IgnoreReturnCode]

--- a/code/drasil-build/Build/Drasil/Make/Print.hs
+++ b/code/drasil-build/Build/Drasil/Make/Print.hs
@@ -4,7 +4,8 @@ import Prelude hiding ((<>))
 import Data.List (elem)
 import Text.PrettyPrint (Doc, empty, text, (<>), (<+>), ($+$), ($$), hsep, vcat)
 
-import Build.Drasil.Make.AST (Command(C), CommandOpts(IgnoreReturnCode), Dependencies, Makefile(M), Rule(R), Target, Type(Abstract))
+import Build.Drasil.Make.AST (Command(C), CommandOpts(IgnoreReturnCode),
+  Dependencies, Makefile(M), Rule(R), Target, Type(Abstract))
 import Build.Drasil.Make.Import (RuleTransformer, toMake)
 import Build.Drasil.Make.Helpers (addCommonFeatures, tab)
 
@@ -14,7 +15,8 @@ genMake = build . toMake
 
 -- | Renders the makefile rules
 build :: Makefile -> Doc
-build (M rules) = addCommonFeatures $ (vcat $ map (\x -> printRule x $+$ text "") rules) $$ printPhony rules
+build (M rules) = addCommonFeatures $
+  (vcat $ map (\x -> printRule x $+$ text "") rules) $$ printPhony rules
 
 -- | Renders specific makefile rules. Called by 'build'
 printRule :: Rule -> Doc
@@ -22,7 +24,8 @@ printRule (R t d _ c) = printTarget t d $+$ (printCmds c)
 
 -- | Gathers all rules to abstract targets and tags them as phony.
 printPhony :: [Rule] -> Doc
-printPhony = (<+>) (text ".PHONY:") . hsep . map (\(R t _ _ _) -> text t) . filter (\(R _ _ t _) -> t == Abstract)
+printPhony = (<+>) (text ".PHONY:") . hsep . map (\(R t _ _ _) -> text t) .
+  filter (\(R _ _ t _) -> t == Abstract)
 
 -- | Renders targets with their dependencies
 printTarget :: Target -> [Dependencies] -> Doc

--- a/code/drasil-build/Build/Drasil/Make/Print.hs
+++ b/code/drasil-build/Build/Drasil/Make/Print.hs
@@ -1,9 +1,10 @@
 module Build.Drasil.Make.Print where
 
 import Prelude hiding ((<>))
+import Data.List (elem)
 import Text.PrettyPrint (Doc, empty, text, (<>), (<+>), ($+$), hsep, vcat) 
 
-import Build.Drasil.Make.AST (Type(Phony, TeX), Target, Dependencies, Rule, Makefile(M))
+import Build.Drasil.Make.AST (Command(C), CommandOpts(IgnoreReturnCode), Dependencies, Makefile(M), Rule(R), Target)
 import Build.Drasil.Make.Import (RuleTransformer, toMake)
 import Build.Drasil.Make.Helpers (addCommonFeatures, tab)
 
@@ -17,24 +18,14 @@ build (M rules) = addCommonFeatures $ vcat $ map (\x -> printRule x $+$ text "")
 
 -- | Renders specific makefile rules. Called by 'build'
 printRule :: Rule -> Doc
-printRule (Phony, nameLb, deps) = text (".PHONY: " ++ nameLb) $+$
-                                  printTarget nameLb deps
-printRule (TeX, nameLb, _)      = printTarget (nameLb ++ ".pdf") [(nameLb ++ ".tex")] $+$
-                                  printLatexCmd nameLb
-printRule _                     = error "Unimplemented makefile rule"
-
+printRule (R t d ty c) = printTarget t d $+$ (printCmds c)
 
 -- | Renders targets with their dependencies
 printTarget :: Target -> [Dependencies] -> Doc
-printTarget nameLb deps = text (nameLb ++ ": ") <+> hsep (map text deps)
+printTarget nameLb deps = text (nameLb ++ ":") <+> hsep (map text deps)
 
-lualatex :: Target -> Doc
-lualatex = text . (++) "lualatex $(TEXFLAGS) "
+printCmd :: Command -> Doc
+printCmd (C c opts) = tab <> (text $ (if IgnoreReturnCode `elem` opts then "-" else "") ++ c)
 
-bibtex :: Target -> Doc
-bibtex = text . (++) "-bibtex $(BIBTEXFLAGS) "
-
--- | Renders LaTeX commands in the makefile
-printLatexCmd :: Target -> Doc
-printLatexCmd t = foldr (\x -> (tab <> x t $+$)) empty
-  [lualatex, bibtex, lualatex, lualatex]
+printCmds :: [Command] -> Doc
+printCmds = foldr (($+$) . printCmd) empty

--- a/code/drasil-build/Build/Drasil/Make/Print.hs
+++ b/code/drasil-build/Build/Drasil/Make/Print.hs
@@ -2,9 +2,9 @@ module Build.Drasil.Make.Print where
 
 import Prelude hiding ((<>))
 import Data.List (elem)
-import Text.PrettyPrint (Doc, empty, text, (<>), (<+>), ($+$), hsep, vcat) 
+import Text.PrettyPrint (Doc, empty, text, (<>), (<+>), ($+$), ($$), hsep, vcat)
 
-import Build.Drasil.Make.AST (Command(C), CommandOpts(IgnoreReturnCode), Dependencies, Makefile(M), Rule(R), Target)
+import Build.Drasil.Make.AST (Command(C), CommandOpts(IgnoreReturnCode), Dependencies, Makefile(M), Rule(R), Target, Type(Abstract))
 import Build.Drasil.Make.Import (RuleTransformer, toMake)
 import Build.Drasil.Make.Helpers (addCommonFeatures, tab)
 
@@ -14,18 +14,22 @@ genMake = build . toMake
 
 -- | Renders the makefile rules
 build :: Makefile -> Doc
-build (M rules) = addCommonFeatures $ vcat $ map (\x -> printRule x $+$ text "") rules
+build (M rules) = addCommonFeatures $ (vcat $ map (\x -> printRule x $+$ text "") rules) $$ printPhony rules
 
 -- | Renders specific makefile rules. Called by 'build'
 printRule :: Rule -> Doc
-printRule (R t d ty c) = printTarget t d $+$ (printCmds c)
+printRule (R t d _ c) = printTarget t d $+$ (printCmds c)
+
+-- | Gathers all rules to abstract targets and tags them as phony.
+printPhony :: [Rule] -> Doc
+printPhony = (<+>) (text ".PHONY:") . hsep . map (\(R t _ _ _) -> text t) . filter (\(R _ _ t _) -> t == Abstract)
 
 -- | Renders targets with their dependencies
 printTarget :: Target -> [Dependencies] -> Doc
 printTarget nameLb deps = text (nameLb ++ ":") <+> hsep (map text deps)
 
 printCmd :: Command -> Doc
-printCmd (C c opts) = tab <> (text $ (if IgnoreReturnCode `elem` opts then "-" else "") ++ c)
+printCmd (C c opts) = text $ (if IgnoreReturnCode `elem` opts then "-" else "") ++ c
 
 printCmds :: [Command] -> Doc
-printCmds = foldr (($+$) . printCmd) empty
+printCmds = foldr (($+$) . (<>) tab . printCmd) empty

--- a/code/drasil-printers/Language/Drasil/Output/Formats.hs
+++ b/code/drasil-printers/Language/Drasil/Output/Formats.hs
@@ -1,7 +1,8 @@
 -- | Defines output formats for the different documents we can generate
 module Language.Drasil.Output.Formats where
 
-import Build.Drasil (Command(C), CommandOpts(IgnoreReturnCode), Rule(R), RuleTransformer(makeRule), Type(File))
+import Data.Char (toLower)
+import Build.Drasil (Command(C), CommandOpts(IgnoreReturnCode), Rule(R), RuleTransformer(makeRule), Type(Abstract, File))
 
 -- | When choosing your document, you must specify the filename for
 -- the generated output (specified /without/ a file extension)
@@ -17,7 +18,9 @@ bibtex = (flip C) [IgnoreReturnCode] . (++) "bibtex $(BIBTEXFLAGS) "
 
 instance RuleTransformer DocSpec where
   makeRule (DocSpec Website _) = []
-  makeRule (DocSpec _ fn) = [R (fn ++ ".pdf") [fn ++ ".tex"] File $ map ($ fn) [lualatex, bibtex, lualatex, lualatex]]
+  makeRule (DocSpec dt fn) = [
+    R (map toLower $ show dt) [fn ++ ".pdf"] Abstract [],
+    R (fn ++ ".pdf") [fn ++ ".tex"] File $ map ($ fn) [lualatex, bibtex, lualatex, lualatex]]
 
 instance Show DocType where
   show SRS      = "SRS"

--- a/code/drasil-printers/Language/Drasil/Output/Formats.hs
+++ b/code/drasil-printers/Language/Drasil/Output/Formats.hs
@@ -2,7 +2,7 @@
 module Language.Drasil.Output.Formats where
 
 import Data.Char (toLower)
-import Build.Drasil (Command(C), CommandOpts(IgnoreReturnCode), Rule(R), RuleTransformer(makeRule), Type(Abstract, File))
+import Build.Drasil (Command, mkCheckedCommand, mkCommand, mkFile, mkRule, RuleTransformer(makeRule))
 
 -- | When choosing your document, you must specify the filename for
 -- the generated output (specified /without/ a file extension)
@@ -12,15 +12,15 @@ data DocType = SRS | MG | MIS | Website
 
 data DocSpec = DocSpec DocType Filename
 
-lualatex, bibtex :: String -> Command
-lualatex = (flip C) [] . (++) "lualatex $(TEXFLAGS) "
-bibtex = (flip C) [IgnoreReturnCode] . (++) "bibtex $(BIBTEXFLAGS) "
-
 instance RuleTransformer DocSpec where
   makeRule (DocSpec Website _) = []
   makeRule (DocSpec dt fn) = [
-    R (map toLower $ show dt) [fn ++ ".pdf"] Abstract [],
-    R (fn ++ ".pdf") [fn ++ ".tex"] File $ map ($ fn) [lualatex, bibtex, lualatex, lualatex]]
+    mkRule (map toLower $ show dt) [fn ++ ".pdf"] [],
+    mkFile (fn ++ ".pdf") [fn ++ ".tex"] $
+      map ($ fn) [lualatex, bibtex, lualatex, lualatex]] where
+        lualatex, bibtex :: String -> Command
+        lualatex = mkCheckedCommand . (++) "lualatex $(TEXFLAGS) "
+        bibtex = mkCommand . (++) "bibtex $(BIBTEXFLAGS) "
 
 instance Show DocType where
   show SRS      = "SRS"

--- a/code/drasil-printers/Language/Drasil/Output/Formats.hs
+++ b/code/drasil-printers/Language/Drasil/Output/Formats.hs
@@ -1,7 +1,7 @@
 -- | Defines output formats for the different documents we can generate
 module Language.Drasil.Output.Formats where
 
-import Build.Drasil (RuleTransformer(makeRule), Type(Phony, TeX))
+import Build.Drasil (Command(C), CommandOpts(IgnoreReturnCode), Rule(R), RuleTransformer(makeRule), Type(File))
 
 -- | When choosing your document, you must specify the filename for
 -- the generated output (specified /without/ a file extension)
@@ -11,11 +11,13 @@ data DocType = SRS | MG | MIS | Website
 
 data DocSpec = DocSpec DocType Filename
 
+lualatex, bibtex :: String -> Command
+lualatex = (flip C) [] . (++) "lualatex $(TEXFLAGS) "
+bibtex = (flip C) [IgnoreReturnCode] . (++) "bibtex $(BIBTEXFLAGS) "
+
 instance RuleTransformer DocSpec where
-  makeRule (DocSpec SRS fn)     = [(Phony, "srs", [fn ++ ".pdf"]), (TeX, fn, [])]
-  makeRule (DocSpec MG  fn)     = [(Phony, "mg" , [fn ++ ".pdf"]), (TeX, fn, [])]
-  makeRule (DocSpec MIS fn)     = [(Phony, "mis", [fn ++ ".pdf"]), (TeX, fn, [])]
-  makeRule (DocSpec Website _)  = []
+  makeRule (DocSpec Website _) = []
+  makeRule (DocSpec _ fn) = [R (fn ++ ".pdf") [fn ++ ".tex"] File $ map ($ fn) [lualatex, bibtex, lualatex, lualatex]]
 
 instance Show DocType where
   show SRS      = "SRS"


### PR DESCRIPTION
This PR adds smart constructors and removes the knowledge-heavy targets like Phony and TeX from drasil-build.