### PR TITLE
Add Makefile (run Target) For Generated Code

### DIFF
--- a/code/drasil-build/Build/Drasil.hs
+++ b/code/drasil-build/Build/Drasil.hs
@@ -1,7 +1,10 @@
 module Build.Drasil (
   -- Make
     -- AST
-    Type(Phony, TeX)
+    Command(C)
+  , CommandOpts(IgnoreReturnCode)
+  , Rule(R)
+  , Type(Abstract, File)
     -- Import
   , RuleTransformer(makeRule)
     -- Print
@@ -9,6 +12,6 @@ module Build.Drasil (
   )
   where
 
-import Build.Drasil.Make.AST (Type(Phony, TeX))
+import Build.Drasil.Make.AST (Command(C), CommandOpts(IgnoreReturnCode), Rule(R), Type(Abstract, File))
 import Build.Drasil.Make.Import (RuleTransformer(makeRule))
 import Build.Drasil.Make.Print (genMake)

--- a/code/drasil-build/Build/Drasil.hs
+++ b/code/drasil-build/Build/Drasil.hs
@@ -1,10 +1,7 @@
 module Build.Drasil (
   -- Make
     -- AST
-    Command(C)
-  , CommandOpts(IgnoreReturnCode)
-  , Rule(R)
-  , Type(Abstract, File)
+    Command, mkCheckedCommand, mkCommand, mkFile, mkRule, Rule
     -- Import
   , RuleTransformer(makeRule)
     -- Print
@@ -12,6 +9,7 @@ module Build.Drasil (
   )
   where
 
-import Build.Drasil.Make.AST (Command(C), CommandOpts(IgnoreReturnCode), Rule(R), Type(Abstract, File))
+import Build.Drasil.Make.AST (Command, mkCheckedCommand, mkCommand, mkFile,
+  mkRule, Rule)
 import Build.Drasil.Make.Import (RuleTransformer(makeRule))
 import Build.Drasil.Make.Print (genMake)

--- a/code/drasil-build/Build/Drasil/Make/AST.hs
+++ b/code/drasil-build/Build/Drasil/Make/AST.hs
@@ -3,11 +3,15 @@ module Build.Drasil.Make.AST where
 
 newtype Makefile = M [Rule]
 
-type Rule = (Type, Target, [Dependencies])
+data Rule = R Target [Dependencies] Type [Command]
 
-data Type = Phony
-          | TeX
-          | Code
+data Command = C String [CommandOpts]
+
+data CommandOpts =
+  IgnoreReturnCode deriving Eq
+
+data Type = Abstract
+          | File
 
 type Target = String
 type Dependencies = Target

--- a/code/drasil-build/Build/Drasil/Make/AST.hs
+++ b/code/drasil-build/Build/Drasil/Make/AST.hs
@@ -11,7 +11,7 @@ data CommandOpts =
   IgnoreReturnCode deriving Eq
 
 data Type = Abstract
-          | File
+          | File deriving Eq
 
 type Target = String
 type Dependencies = Target

--- a/code/drasil-build/Build/Drasil/Make/AST.hs
+++ b/code/drasil-build/Build/Drasil/Make/AST.hs
@@ -15,3 +15,19 @@ data Type = Abstract
 
 type Target = String
 type Dependencies = Target
+
+-- | Creates a Rule which results in a file being created
+mkFile :: Target -> [Dependencies] -> [Command] -> Rule
+mkFile t d c = R t d File c
+
+-- | Creates an abstract Rule not associated to a specific file
+mkRule :: Target -> [Dependencies] -> [Command] -> Rule
+mkRule t d c = R t d Abstract c
+
+-- | Creates a Command which fails the make process if it does not return zero
+mkCheckedCommand :: String -> Command
+mkCheckedCommand = flip C []
+
+-- | Creates a command which executes and ignores the return code
+mkCommand :: String -> Command
+mkCommand = flip C [IgnoreReturnCode]

--- a/code/drasil-build/Build/Drasil/Make/Print.hs
+++ b/code/drasil-build/Build/Drasil/Make/Print.hs
@@ -4,7 +4,8 @@ import Prelude hiding ((<>))
 import Data.List (elem)
 import Text.PrettyPrint (Doc, empty, text, (<>), (<+>), ($+$), ($$), hsep, vcat)
 
-import Build.Drasil.Make.AST (Command(C), CommandOpts(IgnoreReturnCode), Dependencies, Makefile(M), Rule(R), Target, Type(Abstract))
+import Build.Drasil.Make.AST (Command(C), CommandOpts(IgnoreReturnCode),
+  Dependencies, Makefile(M), Rule(R), Target, Type(Abstract))
 import Build.Drasil.Make.Import (RuleTransformer, toMake)
 import Build.Drasil.Make.Helpers (addCommonFeatures, tab)
 
@@ -14,7 +15,8 @@ genMake = build . toMake
 
 -- | Renders the makefile rules
 build :: Makefile -> Doc
-build (M rules) = addCommonFeatures $ (vcat $ map (\x -> printRule x $+$ text "") rules) $$ printPhony rules
+build (M rules) = addCommonFeatures $
+  (vcat $ map (\x -> printRule x $+$ text "") rules) $$ printPhony rules
 
 -- | Renders specific makefile rules. Called by 'build'
 printRule :: Rule -> Doc
@@ -22,7 +24,8 @@ printRule (R t d _ c) = printTarget t d $+$ (printCmds c)
 
 -- | Gathers all rules to abstract targets and tags them as phony.
 printPhony :: [Rule] -> Doc
-printPhony = (<+>) (text ".PHONY:") . hsep . map (\(R t _ _ _) -> text t) . filter (\(R _ _ t _) -> t == Abstract)
+printPhony = (<+>) (text ".PHONY:") . hsep . map (\(R t _ _ _) -> text t) .
+  filter (\(R _ _ t _) -> t == Abstract)
 
 -- | Renders targets with their dependencies
 printTarget :: Target -> [Dependencies] -> Doc

--- a/code/drasil-build/Build/Drasil/Make/Print.hs
+++ b/code/drasil-build/Build/Drasil/Make/Print.hs
@@ -1,9 +1,10 @@
 module Build.Drasil.Make.Print where
 
 import Prelude hiding ((<>))
+import Data.List (elem)
 import Text.PrettyPrint (Doc, empty, text, (<>), (<+>), ($+$), hsep, vcat) 
 
-import Build.Drasil.Make.AST (Type(Phony, TeX), Target, Dependencies, Rule, Makefile(M))
+import Build.Drasil.Make.AST (Command(C), CommandOpts(IgnoreReturnCode), Dependencies, Makefile(M), Rule(R), Target)
 import Build.Drasil.Make.Import (RuleTransformer, toMake)
 import Build.Drasil.Make.Helpers (addCommonFeatures, tab)
 
@@ -17,24 +18,14 @@ build (M rules) = addCommonFeatures $ vcat $ map (\x -> printRule x $+$ text "")
 
 -- | Renders specific makefile rules. Called by 'build'
 printRule :: Rule -> Doc
-printRule (Phony, nameLb, deps) = text (".PHONY: " ++ nameLb) $+$
-                                  printTarget nameLb deps
-printRule (TeX, nameLb, _)      = printTarget (nameLb ++ ".pdf") [(nameLb ++ ".tex")] $+$
-                                  printLatexCmd nameLb
-printRule _                     = error "Unimplemented makefile rule"
-
+printRule (R t d ty c) = printTarget t d $+$ (printCmds c)
 
 -- | Renders targets with their dependencies
 printTarget :: Target -> [Dependencies] -> Doc
-printTarget nameLb deps = text (nameLb ++ ": ") <+> hsep (map text deps)
+printTarget nameLb deps = text (nameLb ++ ":") <+> hsep (map text deps)
 
-lualatex :: Target -> Doc
-lualatex = text . (++) "lualatex $(TEXFLAGS) "
+printCmd :: Command -> Doc
+printCmd (C c opts) = tab <> (text $ (if IgnoreReturnCode `elem` opts then "-" else "") ++ c)
 
-bibtex :: Target -> Doc
-bibtex = text . (++) "-bibtex $(BIBTEXFLAGS) "
-
--- | Renders LaTeX commands in the makefile
-printLatexCmd :: Target -> Doc
-printLatexCmd t = foldr (\x -> (tab <> x t $+$)) empty
-  [lualatex, bibtex, lualatex, lualatex]
+printCmds :: [Command] -> Doc
+printCmds = foldr (($+$) . printCmd) empty

--- a/code/drasil-build/Build/Drasil/Make/Print.hs
+++ b/code/drasil-build/Build/Drasil/Make/Print.hs
@@ -2,9 +2,9 @@ module Build.Drasil.Make.Print where
 
 import Prelude hiding ((<>))
 import Data.List (elem)
-import Text.PrettyPrint (Doc, empty, text, (<>), (<+>), ($+$), hsep, vcat) 
+import Text.PrettyPrint (Doc, empty, text, (<>), (<+>), ($+$), ($$), hsep, vcat)
 
-import Build.Drasil.Make.AST (Command(C), CommandOpts(IgnoreReturnCode), Dependencies, Makefile(M), Rule(R), Target)
+import Build.Drasil.Make.AST (Command(C), CommandOpts(IgnoreReturnCode), Dependencies, Makefile(M), Rule(R), Target, Type(Abstract))
 import Build.Drasil.Make.Import (RuleTransformer, toMake)
 import Build.Drasil.Make.Helpers (addCommonFeatures, tab)
 
@@ -14,18 +14,22 @@ genMake = build . toMake
 
 -- | Renders the makefile rules
 build :: Makefile -> Doc
-build (M rules) = addCommonFeatures $ vcat $ map (\x -> printRule x $+$ text "") rules
+build (M rules) = addCommonFeatures $ (vcat $ map (\x -> printRule x $+$ text "") rules) $$ printPhony rules
 
 -- | Renders specific makefile rules. Called by 'build'
 printRule :: Rule -> Doc
-printRule (R t d ty c) = printTarget t d $+$ (printCmds c)
+printRule (R t d _ c) = printTarget t d $+$ (printCmds c)
+
+-- | Gathers all rules to abstract targets and tags them as phony.
+printPhony :: [Rule] -> Doc
+printPhony = (<+>) (text ".PHONY:") . hsep . map (\(R t _ _ _) -> text t) . filter (\(R _ _ t _) -> t == Abstract)
 
 -- | Renders targets with their dependencies
 printTarget :: Target -> [Dependencies] -> Doc
 printTarget nameLb deps = text (nameLb ++ ":") <+> hsep (map text deps)
 
 printCmd :: Command -> Doc
-printCmd (C c opts) = tab <> (text $ (if IgnoreReturnCode `elem` opts then "-" else "") ++ c)
+printCmd (C c opts) = text $ (if IgnoreReturnCode `elem` opts then "-" else "") ++ c
 
 printCmds :: [Command] -> Doc
-printCmds = foldr (($+$) . printCmd) empty
+printCmds = foldr (($+$) . (<>) tab . printCmd) empty

--- a/code/drasil-code/Language/Drasil/Code/Code.hs
+++ b/code/drasil-code/Language/Drasil/Code/Code.hs
@@ -7,7 +7,7 @@ module Language.Drasil.Code.Code (
 import Text.PrettyPrint.HughesPJ (Doc)
 
 -- | Represents the generated code as a list of file names and rendered code pairs
-newtype Code = Code [(FilePath, Doc)]
+newtype Code = Code { unCode :: [(FilePath, Doc)]}
 
 data CodeType = Boolean
               | Integer

--- a/code/drasil-code/Language/Drasil/Code/CodeGeneration.hs
+++ b/code/drasil-code/Language/Drasil/Code/CodeGeneration.hs
@@ -2,6 +2,7 @@
 module Language.Drasil.Code.CodeGeneration (
     -- * Preparing the code files
     makeCode,
+    makeLangConfig,
     
     -- * Creating the code files
     createCodeFiles
@@ -24,7 +25,8 @@ import Data.Function (fix)
 import Data.List (intercalate)
 import qualified Data.Map as Map (fromList,keys,lookup,Map)
 import System.IO (hPutStrLn, hClose, openFile, IOMode(WriteMode))
-import Text.PrettyPrint.HughesPJ (Doc,render)
+import Text.PrettyPrint.HughesPJ (Doc, render)
+
 
 -- | Map of (label,config) pairs for all supported languages.
 langs :: Map.Map String (Options -> Config -> Config)
@@ -38,14 +40,16 @@ langs = Map.fromList[
     (luaLabel, luaConfig)
   ]
 
--- | Takes a language parameter, a set of optional parameters, and a list of module names, and passes an 'AbstractCode' to the required rendering function, which produces a 'Code'
-makeCode :: String -> Options -> AbstractCode -> Code
-makeCode l options code  =
-    -- First, if we have gen-time globals, instantiate them
+-- | Translates an AbstractCode to Code using the language of the passed Config
+makeCode :: Config -> AbstractCode -> Code
+makeCode = renderCode
+
+makeLangConfig :: String -> Options -> Config
+makeLangConfig l options =
     case Map.lookup l langs of
-        Just c  -> renderCode (fix $ c options) code
+        Just c  -> fix $ c options
         Nothing -> error errStr
-          where errStr = "GOOL.CodeGeneration.makeCode: must supply "
+          where errStr = "GOOL.CodeGeneration.makeLangConfig: must supply "
                          ++ (listLabels $ Map.keys langs)
                          ++ " for the \"Generation Language\" option in the configuration file"
 
@@ -59,6 +63,7 @@ listLabels ns = intercalate ", " (init ns) ++ ", or " ++ last ns
 -- | Creates the requested 'Code' by producing files
 createCodeFiles :: Code -> IO ()
 createCodeFiles (Code cs) = mapM_ createCodeFile cs
+
 
 createCodeFile :: (FilePath, Doc) -> IO ()
 createCodeFile (path, code) = do

--- a/code/drasil-code/Language/Drasil/Code/Imperative/AST.hs
+++ b/code/drasil-code/Language/Drasil/Code/Imperative/AST.hs
@@ -218,7 +218,7 @@ type FunctionDecl = Method
 type VarDecl = Declaration
 data Module = Mod Label [Library] [VarDecl] [FunctionDecl] [Class]
 data Package = Pack Label [Module]
-newtype AbstractCode = AbsCode Package
+newtype AbstractCode = AbsCode {unAbs :: Package}
 
 ---------------------------
 -- Convenience Functions --

--- a/code/drasil-code/Language/Drasil/Code/Imperative/Build/AST.hs
+++ b/code/drasil-code/Language/Drasil/Code/Imperative/Build/AST.hs
@@ -1,0 +1,47 @@
+module Language.Drasil.Code.Imperative.Build.AST where
+
+data RunType = Standalone
+             | Interpreter String
+
+data RunName = RMain
+              | RPackName
+              | RPack RunName
+              | RWithExt RunName Ext
+              | RLit String
+              | RConcat RunName RunName
+
+data Ext = CodeExt
+         | OtherExt String
+
+data Runnable = Runnable RunName NameOpts RunType
+
+data NameOpts = NameOpts {
+  packSep :: String,
+  includeExt :: Bool
+}
+
+nameOpts :: NameOpts
+nameOpts = NameOpts {
+  packSep = "/",
+  includeExt = True
+}
+
+type InterpreterCommand = String
+
+nativeBinary :: Runnable
+nativeBinary = Runnable (RConcat RPackName $ RLit "$(TARGET_EXTENSION)") nameOpts Standalone
+
+interp :: RunName -> NameOpts -> InterpreterCommand -> Runnable
+interp r n i = Runnable r n $ Interpreter i
+
+interpMM :: InterpreterCommand -> Runnable
+interpMM = Runnable (RWithExt RMain CodeExt) nameOpts . Interpreter
+
+mainModule :: RunName
+mainModule = RMain
+
+inCodePackage :: RunName -> RunName
+inCodePackage = RPack
+
+withExt :: RunName -> String -> RunName
+withExt r = RWithExt r . OtherExt

--- a/code/drasil-code/Language/Drasil/Code/Imperative/Build/Import.hs
+++ b/code/drasil-code/Language/Drasil/Code/Imperative/Build/Import.hs
@@ -1,8 +1,22 @@
-module Language.Drasil.Code.Imperative.Build.Import where
+module Language.Drasil.Code.Imperative.Build.Import (
+  makeBuild
+) where
 
+import Language.Drasil.Code.Code (Code(..))
 import Language.Drasil.Code.Imperative.AST (Label, Module(Mod), notMainModule, Package(Pack))
-import Language.Drasil.Code.Imperative.Build.AST (Ext(..), includeExt, NameOpts, packSep, RunName(..), RunType(..))
-import Language.Drasil.Code.Imperative.LanguageRenderer (Config, ext)
+import Language.Drasil.Code.Imperative.Build.AST (Ext(..), includeExt, NameOpts, packSep, Runnable(Runnable), RunName(..), RunType(..))
+import Language.Drasil.Code.Imperative.LanguageRenderer (Config, ext, runnable)
+
+import Build.Drasil (RuleTransformer(makeRule), genMake, mkRule, mkCheckedCommand)
+
+data CodeHarness = Ch Config Package
+
+instance RuleTransformer CodeHarness where
+  makeRule (Ch c m) = [
+    mkRule "run" [] [
+      mkCheckedCommand $ (buildRunTarget (renderRunName c m no nm) ty) ++ " $(RUNARGS)"
+      ]
+    ] where (Runnable nm no ty) = runnable c
 
 renderRunName :: Config -> Package -> NameOpts -> RunName -> String
 renderRunName c p o (RConcat a b) = (renderRunName c p o a) ++ (renderRunName c p o b)
@@ -24,3 +38,6 @@ getMainModule c = mainName $ filter (not . notMainModule) c
 buildRunTarget :: String -> RunType -> String
 buildRunTarget fn Standalone = "./" ++ fn
 buildRunTarget fn (Interpreter i) = unwords [i, fn]
+
+makeBuild :: Package -> Config -> Code -> Code
+makeBuild m p (Code c) = Code $ ("Makefile", genMake [Ch p m]) : c

--- a/code/drasil-code/Language/Drasil/Code/Imperative/Build/Import.hs
+++ b/code/drasil-code/Language/Drasil/Code/Imperative/Build/Import.hs
@@ -1,0 +1,26 @@
+module Language.Drasil.Code.Imperative.Build.Import where
+
+import Language.Drasil.Code.Imperative.AST (Label, Module(Mod), notMainModule, Package(Pack))
+import Language.Drasil.Code.Imperative.Build.AST (Ext(..), includeExt, NameOpts, packSep, RunName(..), RunType(..))
+import Language.Drasil.Code.Imperative.LanguageRenderer (Config, ext)
+
+renderRunName :: Config -> Package -> NameOpts -> RunName -> String
+renderRunName c p o (RConcat a b) = (renderRunName c p o a) ++ (renderRunName c p o b)
+renderRunName _ _ _ (RLit s) = s
+renderRunName _ (Pack _ m) _ RMain = getMainModule m
+renderRunName _ (Pack l _) _ RPackName = l
+renderRunName c p o (RPack a) = (renderRunName c p o RPackName) ++ (packSep o) ++ renderRunName c p o a
+renderRunName c p o (RWithExt a e) = renderRunName c p o a ++ if includeExt o then renderExt c e else ""
+
+renderExt :: Config -> Ext -> String
+renderExt c CodeExt = ext c
+renderExt _ (OtherExt e) = e
+
+getMainModule :: [Module] -> Label
+getMainModule c = mainName $ filter (not . notMainModule) c
+  where mainName [(Mod a _ _ _ _)] = a
+        mainName _ = error $ "Expected a single main module."
+
+buildRunTarget :: String -> RunType -> String
+buildRunTarget fn Standalone = "./" ++ fn
+buildRunTarget fn (Interpreter i) = unwords [i, fn]

--- a/code/drasil-code/Language/Drasil/Code/Imperative/Import.hs
+++ b/code/drasil-code/Language/Drasil/Code/Imperative/Import.hs
@@ -2,14 +2,14 @@
 module Language.Drasil.Code.Imperative.Import(generator, generateCode) where
 
 import Language.Drasil hiding (int)
-import Language.Drasil.Code.Code as C (CodeType(List, File, Char, Float, Object, 
-  String, Boolean, Integer))
+import Language.Drasil.Code.Code as C (Code(..), CodeType(List, File, Char,
+  Float, Object, String, Boolean, Integer))
 import Language.Drasil.Code.Imperative.AST as I hiding ((&=), State, assign, return, 
   Not, Tan, Cos, Sin, Exp, Abs, Log, Ln, And, Or)
 import qualified Language.Drasil.Code.Imperative.AST as I (assign, return)
 import Language.Drasil.Code.Imperative.LanguageRenderer (Options(..))
 import Language.Drasil.Code.Imperative.Parsers.ConfigParser (pythonLabel, cppLabel, cSharpLabel, javaLabel)
-import Language.Drasil.Code.CodeGeneration (createCodeFiles, makeCode)
+import Language.Drasil.Code.CodeGeneration (createCodeFiles, makeCode, makeLangConfig)
 import Language.Drasil.Chunk.Code (CodeChunk, CodeDefinition, codeName, codeType, 
   codevar, codefunc, codeEquat, funcPrefix, physLookup, sfwrLookup, programName)
 import Language.Drasil.CodeSpec hiding (codeSpec, Mod(..))
@@ -21,6 +21,7 @@ import Language.Drasil.Code.DataDesc (Ind(WithPattern, WithLine, Explicit),
 import Prelude hiding (log, exp, const)
 import Data.List (intersperse, (\\), stripPrefix)
 import System.Directory (setCurrentDirectory, createDirectoryIfMissing, getCurrentDirectory)
+import System.FilePath ((</>))
 import Data.Map (member)
 import qualified Data.Map as Map (lookup)
 import Data.Maybe (fromMaybe, maybe)
@@ -91,14 +92,15 @@ generateCode chs g =
           createDirectoryIfMissing False (getDir x)
           setCurrentDirectory (getDir x)
           when (x == Java) $ createDirectoryIfMissing False prog
-          when (x == Java) $ setCurrentDirectory prog
-          createCodeFiles $ makeCode
-            (getLabel x)
-            (Options Nothing Nothing Nothing (Just "Code"))
-            (toAbsCode prog modules)
-          setCurrentDirectory workingDir) (lang $ chs)
+          let config = makeLangConfig (getLabel x) $ Options Nothing Nothing Nothing $
+                       Just "Code"
+          createCodeFiles $ C.Code $
+            map (if x == Java then \(c,d) -> (prog </> c, d) else id) $
+            C.unCode $ makeCode config absCode
+          setCurrentDirectory workingDir) $ lang chs
   where prog = case codeSpec g of { CodeSpec {program = pp} -> programName pp }
         modules = runReader genModules g
+        absCode = toAbsCode prog modules
 
 genModules :: Reader State [Module]
 genModules = do
@@ -108,7 +110,7 @@ genModules = do
   inp    <- chooseInStructure $ inStruct g
   out    <- genOutputMod $ outputs s
   moddef <- traverse genModDef (mods s) -- hack ?
-  return $ (mn : inp ++ out ++ moddef)
+  return $ mn : inp ++ out ++ moddef
 
 -- private utilities used in generateCode
 getLabel, getDir :: Lang -> String

--- a/code/drasil-code/Language/Drasil/Code/Imperative/Import.hs
+++ b/code/drasil-code/Language/Drasil/Code/Imperative/Import.hs
@@ -7,6 +7,7 @@ import Language.Drasil.Code.Code as C (Code(..), CodeType(List, File, Char,
 import Language.Drasil.Code.Imperative.AST as I hiding ((&=), State, assign, return, 
   Not, Tan, Cos, Sin, Exp, Abs, Log, Ln, And, Or)
 import qualified Language.Drasil.Code.Imperative.AST as I (assign, return)
+import Language.Drasil.Code.Imperative.Build.Import (makeBuild)
 import Language.Drasil.Code.Imperative.LanguageRenderer (Options(..))
 import Language.Drasil.Code.Imperative.Parsers.ConfigParser (pythonLabel, cppLabel, cSharpLabel, javaLabel)
 import Language.Drasil.Code.CodeGeneration (createCodeFiles, makeCode, makeLangConfig)
@@ -94,7 +95,7 @@ generateCode chs g =
           when (x == Java) $ createDirectoryIfMissing False prog
           let config = makeLangConfig (getLabel x) $ Options Nothing Nothing Nothing $
                        Just "Code"
-          createCodeFiles $ C.Code $
+          createCodeFiles $ makeBuild (unAbs absCode) config $ C.Code $
             map (if x == Java then \(c,d) -> (prog </> c, d) else id) $
             C.unCode $ makeCode config absCode
           setCurrentDirectory workingDir) $ lang chs

--- a/code/drasil-code/Language/Drasil/Code/Imperative/LanguageRenderer.hs
+++ b/code/drasil-code/Language/Drasil/Code/Imperative/LanguageRenderer.hs
@@ -28,6 +28,7 @@ import Language.Drasil.Code.Code (Code(..))
 import Language.Drasil.Code.Imperative.AST
   hiding (body,comment,bool,int,float,char,string,cases,tryBody,catchBody,guard,
           update,strats)
+import Language.Drasil.Code.Imperative.Build.AST (Runnable)
 import Language.Drasil.Code.Imperative.Helpers (angles,blank,doubleQuotedText,oneTab,
                             oneTabbed,himap,vibcat,vmap,vibmap)
 
@@ -51,6 +52,7 @@ data StatementLocation = Loop | NoLoop
 data DecDef = Dec | Def
 data FileType = Header | Source
 
+
 -- | Configuration record (explicit dictionary) for a language
 data Config = Config {
     renderCode :: AbstractCode -> Code,
@@ -62,6 +64,7 @@ data Config = Config {
     enumsEqualInts :: Bool,     --whether Enum elements should explictly be set equal to their ordinal integers (in the default enumElementsDoc implementation)
     ext :: Label,
     dir :: Label,
+    runnable :: Runnable,
     fileName :: Module -> String,
     include :: Label -> Doc,
     includeScope :: Scope -> Doc,

--- a/code/drasil-code/Language/Drasil/Code/Imperative/LanguageRenderer/CSharpRenderer.hs
+++ b/code/drasil-code/Language/Drasil/Code/Imperative/LanguageRenderer/CSharpRenderer.hs
@@ -6,6 +6,7 @@ module Language.Drasil.Code.Imperative.LanguageRenderer.CSharpRenderer (
 
 import Language.Drasil.Code.Code (Code(..))
 import Language.Drasil.Code.Imperative.AST hiding (body,comment,bool,int,float,char)
+import Language.Drasil.Code.Imperative.Build.AST (nativeBinary)
 import Language.Drasil.Code.Imperative.LanguageRenderer (Config(Config), FileType(Source),
   DecDef(Dec, Def), getEnv, complexDoc, inputDoc, ioDoc, functionListDoc, functionDoc, unOpDoc,
   valueDoc, methodTypeDoc, methodDoc, methodListDoc, statementDoc, stateDoc, stateListDoc,
@@ -23,7 +24,7 @@ import Language.Drasil.Code.Imperative.LanguageRenderer (Config(Config), FileTyp
   doubleSlash, retDocD, patternDocD, clsDecListDocD, clsDecDocD, funcAppDocD, enumElementsDocD,
   litDocD, callFuncParamListD, bodyDocD, blockDocD, binOpDocD,
   classDec, namespaceD, includeD, fileNameD, functionDocD, new, printDocD, objVarDocD,
-  classDocD, exceptionDocD, exprDocD'', declarationDocD, conditionalDocD)
+  classDocD, exceptionDocD, exprDocD'', declarationDocD, conditionalDocD, runnable)
 import Language.Drasil.Code.Imperative.Helpers (oneTab, vibmap)
 
 import Prelude hiding (print,(<>))
@@ -42,6 +43,7 @@ csharpConfig _ c =
         enumsEqualInts   = False,
         ext              = ".cs",
         dir              = "csharp",
+        runnable         = nativeBinary,
         fileName         = fileNameD c,
         include          = includeD "using",
         includeScope     = scopeDoc c,

--- a/code/drasil-code/Language/Drasil/Code/Imperative/LanguageRenderer/CppRenderer.hs
+++ b/code/drasil-code/Language/Drasil/Code/Imperative/LanguageRenderer/CppRenderer.hs
@@ -8,6 +8,7 @@ module Language.Drasil.Code.Imperative.LanguageRenderer.CppRenderer (
 import Language.Drasil.Code.Code (Code(..))
 import Language.Drasil.Code.Imperative.AST
   hiding (body, comment, bool, int, float, char, tryBody, catchBody, initState, guard, update)
+import Language.Drasil.Code.Imperative.Build.AST (nativeBinary)
 import Language.Drasil.Code.Imperative.LanguageRenderer (Config(Config), FileType(Source, Header),
   DecDef(Dec, Def), getEnv, complexDoc, inputDoc, ioDoc, functionListDoc, functionDoc, unOpDoc, 
   valueDoc, methodTypeDoc, methodDoc, methodListDoc, statementDoc, stateDoc, stateListDoc,
@@ -24,7 +25,7 @@ import Language.Drasil.Code.Imperative.LanguageRenderer (Config(Config), FileTyp
   functionListDocD, methodTypeDocD, unOpDocD, statementDocD, scopeDocD, stateDocD, stateListDocD,
   doubleSlash, retDocD, patternDocD, clsDecListDocD, clsDecDocD, funcAppDocD, enumElementsDocD,
   exprDocD', litDocD, conditionalDocD'', callFuncParamListD, bodyDocD, blockDocD, binOpDocD,
-  classDec, namespaceD, includeD, fileNameD, cpplist)
+  classDec, namespaceD, includeD, fileNameD, cpplist, runnable)
 import Language.Drasil.Code.Imperative.Helpers (blank, oneTab, oneTabbed, vmap, vibmap)
 
 import Prelude hiding (break, print, return,(<>))
@@ -48,6 +49,7 @@ cppConfig options c =
         enumsEqualInts   = False,
         ext              = ".cpp",
         dir              = "cpp",
+        runnable         = nativeBinary,
         fileName         = fileNameD c,
         include          = includeD "#include",
         includeScope     = const empty,

--- a/code/drasil-code/Language/Drasil/Code/Imperative/LanguageRenderer/GOOLRenderer.hs
+++ b/code/drasil-code/Language/Drasil/Code/Imperative/LanguageRenderer/GOOLRenderer.hs
@@ -7,6 +7,7 @@ module Language.Drasil.Code.Imperative.LanguageRenderer.GOOLRenderer (
 
 import Language.Drasil.Code.Code (Code(..))
 import Language.Drasil.Code.Imperative.AST hiding (body,comment,bool,int,float,char)
+import Language.Drasil.Code.Imperative.Build.AST (nativeBinary)
 import Language.Drasil.Code.Imperative.LanguageRenderer (Config(Config), FileType(Source),
   DecDef(Dec), getEnv, complexDoc, inputDoc, ioDoc, functionListDoc, functionDoc, unOpDoc,
   valueDoc, methodTypeDoc, methodDoc, methodListDoc, statementDoc, stateDoc, stateListDoc,
@@ -20,7 +21,7 @@ import Language.Drasil.Code.Imperative.LanguageRenderer (Config(Config), FileTyp
   renderCode, argsList, Options, ioDocD, StatementLocation(NoLoop), inputDocD,
   valueDocD, iterationDocD, fileCode, functionListDocD, statementDocD, 
   retDocD, patternDocD, includeD, fileNameD, complexDocD, 
-  conditionalDocD, functionDocD, hsModule)
+  conditionalDocD, functionDocD, hsModule, runnable)
 import Language.Drasil.Code.Imperative.Helpers (blank,oneTab,oneTabbed,
                             doubleQuotedText,verticalComma,himap,vibcat,vibmap)
 
@@ -45,6 +46,7 @@ goolConfig options c =
         enumsEqualInts   = False,
         ext              = ".hs",
         dir              = "gool",
+        runnable         = nativeBinary,
         fileName         = fileNameD c,
         include          = includeD "import",
         includeScope     = const empty,

--- a/code/drasil-code/Language/Drasil/Code/Imperative/LanguageRenderer/JavaRenderer.hs
+++ b/code/drasil-code/Language/Drasil/Code/Imperative/LanguageRenderer/JavaRenderer.hs
@@ -6,6 +6,8 @@ module Language.Drasil.Code.Imperative.LanguageRenderer.JavaRenderer (
 
 import Language.Drasil.Code.Code (Code(..))
 import Language.Drasil.Code.Imperative.AST hiding (body,comment,bool,int,float,char)
+import Language.Drasil.Code.Imperative.Build.AST (includeExt, inCodePackage, interp, mainModule,
+  NameOpts(NameOpts), packSep, withExt)
 import Language.Drasil.Code.Imperative.LanguageRenderer (Config(Config), FileType(Source),
   DecDef(Dec, Def), getEnv, complexDoc, inputDoc, ioDoc, functionListDoc, functionDoc, unOpDoc,
   valueDoc, methodTypeDoc, methodDoc, methodListDoc, statementDoc, stateDoc, stateListDoc,
@@ -23,7 +25,8 @@ import Language.Drasil.Code.Imperative.LanguageRenderer (Config(Config), FileTyp
   doubleSlash, retDocD, patternDocD, clsDecListDocD, clsDecDocD, funcAppDocD, enumElementsDocD,
   litDocD, conditionalDocD'', callFuncParamListD, bodyDocD, blockDocD, binOpDocD,
   classDec, includeD, fileNameD, new, exprDocD'', declarationDocD,
-  typeOfLit, functionDocD, printDocD, objVarDocD, classDocD, forLabel, javalist)
+  typeOfLit, functionDocD, printDocD, objVarDocD, classDocD, forLabel, javalist,
+  runnable)
 import Language.Drasil.Code.Imperative.Helpers (blank,angles,oneTab,vibmap)
 
 import Prelude hiding (break,print,(<>))
@@ -48,6 +51,7 @@ javaConfig options c =
         enumsEqualInts   = False,
         ext              = ".java",
         dir              = "java",
+        runnable         = interp (flip withExt ".class" $ inCodePackage mainModule) jNameOpts "java",
         fileName         = fileNameD c,
         include          = includeD "import",
         includeScope     = (scopeDoc c),
@@ -86,6 +90,13 @@ javaConfig options c =
     }
 
 -- short names, packaged up above (and used below)
+
+jNameOpts :: NameOpts
+jNameOpts = NameOpts {
+  packSep = ".",
+  includeExt = False
+}
+
 renderCode' :: Config -> AbstractCode -> Code
 renderCode' c (AbsCode p) = Code $ fileCode c p Source (ext c)
 

--- a/code/drasil-code/Language/Drasil/Code/Imperative/LanguageRenderer/LuaRenderer.hs
+++ b/code/drasil-code/Language/Drasil/Code/Imperative/LanguageRenderer/LuaRenderer.hs
@@ -7,6 +7,7 @@ module Language.Drasil.Code.Imperative.LanguageRenderer.LuaRenderer (
 import Language.Drasil.Code.Code (Code(..))
 import Language.Drasil.Code.Imperative.AST 
   hiding (body,comment,bool,int,float,char,forBody,tryBody,catchBody)
+import Language.Drasil.Code.Imperative.Build.AST (interpMM)
 import Language.Drasil.Code.Imperative.LanguageRenderer (Config(Config), FileType(Source),
   DecDef(Dec, Def), getEnv, complexDoc, inputDoc, ioDoc, functionListDoc, functionDoc, unOpDoc,
   valueDoc, methodTypeDoc, methodDoc, methodListDoc, statementDoc, stateDoc, stateListDoc,
@@ -25,7 +26,7 @@ import Language.Drasil.Code.Imperative.LanguageRenderer (Config(Config), FileTyp
   litDocD, callFuncParamListD, bodyDocD, blockDocD, binOpDocD,
   fileNameD, forLabel, declarationDocD,
   typeOfLit, conditionalDocD', fixCtorNames, complexDocD, functionDocD, printDocD, exprDocD,
-  assignDocD', unOpDocD')
+  assignDocD', unOpDocD', runnable)
 import Language.Drasil.Code.Imperative.Helpers (blank,oneTab,oneTabbed,vmap,vibmap)
 
 import Prelude hiding (break,print,return,(<>))
@@ -45,6 +46,7 @@ luaConfig _ c =
         enumsEqualInts   = True,
         ext              = ".lua",
         dir              = "lua",
+        runnable         = interpMM "lua",
         fileName         = fileNameD c,
         include          = include',
         includeScope     = const empty,

--- a/code/drasil-code/Language/Drasil/Code/Imperative/LanguageRenderer/ObjectiveCRenderer.hs
+++ b/code/drasil-code/Language/Drasil/Code/Imperative/LanguageRenderer/ObjectiveCRenderer.hs
@@ -9,6 +9,7 @@ import Language.Drasil.Code.Code (Code(..))
 import Language.Drasil.Code.Imperative.AST 
   hiding (body,comment,bool,int,float,char,tryBody,catchBody,initState,guard,
           update,forBody)
+import Language.Drasil.Code.Imperative.Build.AST (nativeBinary)
 import Language.Drasil.Code.Imperative.LanguageRenderer (Config(Config), FileType(Source, Header),
   DecDef(Dec, Def), getEnv, complexDoc, inputDoc, ioDoc, functionListDoc, functionDoc, unOpDoc,
   valueDoc, methodTypeDoc, methodDoc, methodListDoc, statementDoc, stateDoc, stateListDoc,
@@ -26,7 +27,7 @@ import Language.Drasil.Code.Imperative.LanguageRenderer (Config(Config), FileTyp
   doubleSlash, retDocD, patternDocD, clsDecListDocD, clsDecDocD, enumElementsDocD,
   exprDocD', litDocD, conditionalDocD'', bodyDocD, blockDocD, binOpDocD,
   classDec, includeD, fileNameD, addDefaultCtor, fixCtorNames, complexDocD,
-  functionDocD, objVarDocD, objcstaticlist)
+  functionDocD, objVarDocD, objcstaticlist, runnable)
 import Language.Drasil.Code.Imperative.Helpers (blank,oneTab,oneTabbed,
                                             doubleQuotedText,himap,vmap,vibmap)
 
@@ -51,6 +52,7 @@ objcConfig options c =
         enumsEqualInts   = False,
         ext              = ".m",
         dir              = "obj-c",
+        runnable         = nativeBinary,
         fileName         = fileNameD c,
         include          = includeD "#import",
         includeScope     = const $ empty,

--- a/code/drasil-code/Language/Drasil/Code/Imperative/LanguageRenderer/PythonRenderer.hs
+++ b/code/drasil-code/Language/Drasil/Code/Imperative/LanguageRenderer/PythonRenderer.hs
@@ -7,6 +7,7 @@ module Language.Drasil.Code.Imperative.LanguageRenderer.PythonRenderer (
 import Language.Drasil.Code.Code (Code(..))
 import Language.Drasil.Code.Imperative.AST 
   hiding (body,comment,bool,int,float,char,guard,update)
+import Language.Drasil.Code.Imperative.Build.AST (interpMM)
 import Language.Drasil.Code.Imperative.LanguageRenderer (Config(Config), FileType(Source),
   DecDef(Dec, Def), getEnv, complexDoc, inputDoc, ioDoc, functionListDoc, functionDoc, unOpDoc,
   valueDoc, methodTypeDoc, methodDoc, methodListDoc, statementDoc, stateDoc, stateListDoc,
@@ -24,7 +25,7 @@ import Language.Drasil.Code.Imperative.LanguageRenderer (Config(Config), FileTyp
   retDocD, patternDocD, clsDecListDocD, clsDecDocD, funcAppDocD, 
   litDocD, callFuncParamListD, bodyDocD, blockDocD, binOpDocD,
   classDec, fileNameD, forLabel, exprDocD, declarationDocD,
-  typeOfLit, fixCtorNames, unOpDocD', conditionalDocD', assignDocD')
+  typeOfLit, fixCtorNames, unOpDocD', conditionalDocD', assignDocD', runnable)
 import Language.Drasil.Code.Imperative.Helpers (blank,oneTab)
 
 import Data.List (intersperse)
@@ -44,6 +45,7 @@ pythonConfig _ c =
         enumsEqualInts   = True,
         ext              = ".py",
         dir              = "python",
+        runnable         = interpMM "python",
         fileName         = fileNameD c,
         include          = include',
         includeScope     = const empty,

--- a/code/drasil-code/drasil-code.cabal
+++ b/code/drasil-code/drasil-code.cabal
@@ -13,6 +13,8 @@ library
     , Language.Drasil.Code.Code
     , Language.Drasil.Code.DataDesc
     , Language.Drasil.Code.Imperative.AST
+    , Language.Drasil.Code.Imperative.Build.AST
+    , Language.Drasil.Code.Imperative.Build.Import
     , Language.Drasil.Code.Imperative.Helpers
     , Language.Drasil.Code.Imperative.Import
     , Language.Drasil.Code.Imperative.LanguageRenderer

--- a/code/drasil-code/drasil-code.cabal
+++ b/code/drasil-code/drasil-code.cabal
@@ -36,6 +36,7 @@ library
     pretty >= 1.1.1.1,
     mtl >= 2.2.1,
     directory >= 1.2.6.2,
+    filepath >= 1.4.2,
     split >= 0.2.3.1,
     MissingH >= 1.4.0.1,
     parsec >= 3.1.9,

--- a/code/drasil-code/drasil-code.cabal
+++ b/code/drasil-code/drasil-code.cabal
@@ -40,7 +40,8 @@ library
     split >= 0.2.3.1,
     MissingH >= 1.4.0.1,
     parsec >= 3.1.9,
-    drasil-lang >= 0.1.52
+    drasil-lang >= 0.1.52,
+    drasil-build >= 0.1.0
   default-language: Haskell2010
   ghc-options:      -Wall -Wredundant-constraints
 

--- a/code/drasil-code/stack.yaml
+++ b/code/drasil-code/stack.yaml
@@ -38,6 +38,7 @@ resolver: lts-11.2
 packages:
 - .
 - ../drasil-lang
+- ../drasil-build
 # Dependency packages to be pulled from upstream that are not in the resolver
 # (e.g., acme-missiles-0.3)
 # extra-deps: []

--- a/code/drasil-printers/Language/Drasil/Output/Formats.hs
+++ b/code/drasil-printers/Language/Drasil/Output/Formats.hs
@@ -1,7 +1,8 @@
 -- | Defines output formats for the different documents we can generate
 module Language.Drasil.Output.Formats where
 
-import Build.Drasil (Command(C), CommandOpts(IgnoreReturnCode), Rule(R), RuleTransformer(makeRule), Type(File))
+import Data.Char (toLower)
+import Build.Drasil (Command(C), CommandOpts(IgnoreReturnCode), Rule(R), RuleTransformer(makeRule), Type(Abstract, File))
 
 -- | When choosing your document, you must specify the filename for
 -- the generated output (specified /without/ a file extension)
@@ -17,7 +18,9 @@ bibtex = (flip C) [IgnoreReturnCode] . (++) "bibtex $(BIBTEXFLAGS) "
 
 instance RuleTransformer DocSpec where
   makeRule (DocSpec Website _) = []
-  makeRule (DocSpec _ fn) = [R (fn ++ ".pdf") [fn ++ ".tex"] File $ map ($ fn) [lualatex, bibtex, lualatex, lualatex]]
+  makeRule (DocSpec dt fn) = [
+    R (map toLower $ show dt) [fn ++ ".pdf"] Abstract [],
+    R (fn ++ ".pdf") [fn ++ ".tex"] File $ map ($ fn) [lualatex, bibtex, lualatex, lualatex]]
 
 instance Show DocType where
   show SRS      = "SRS"

--- a/code/drasil-printers/Language/Drasil/Output/Formats.hs
+++ b/code/drasil-printers/Language/Drasil/Output/Formats.hs
@@ -2,7 +2,7 @@
 module Language.Drasil.Output.Formats where
 
 import Data.Char (toLower)
-import Build.Drasil (Command(C), CommandOpts(IgnoreReturnCode), Rule(R), RuleTransformer(makeRule), Type(Abstract, File))
+import Build.Drasil (Command, mkCheckedCommand, mkCommand, mkFile, mkRule, RuleTransformer(makeRule))
 
 -- | When choosing your document, you must specify the filename for
 -- the generated output (specified /without/ a file extension)
@@ -12,15 +12,15 @@ data DocType = SRS | MG | MIS | Website
 
 data DocSpec = DocSpec DocType Filename
 
-lualatex, bibtex :: String -> Command
-lualatex = (flip C) [] . (++) "lualatex $(TEXFLAGS) "
-bibtex = (flip C) [IgnoreReturnCode] . (++) "bibtex $(BIBTEXFLAGS) "
-
 instance RuleTransformer DocSpec where
   makeRule (DocSpec Website _) = []
   makeRule (DocSpec dt fn) = [
-    R (map toLower $ show dt) [fn ++ ".pdf"] Abstract [],
-    R (fn ++ ".pdf") [fn ++ ".tex"] File $ map ($ fn) [lualatex, bibtex, lualatex, lualatex]]
+    mkRule (map toLower $ show dt) [fn ++ ".pdf"] [],
+    mkFile (fn ++ ".pdf") [fn ++ ".tex"] $
+      map ($ fn) [lualatex, bibtex, lualatex, lualatex]] where
+        lualatex, bibtex :: String -> Command
+        lualatex = mkCheckedCommand . (++) "lualatex $(TEXFLAGS) "
+        bibtex = mkCommand . (++) "bibtex $(BIBTEXFLAGS) "
 
 instance Show DocType where
   show SRS      = "SRS"

--- a/code/drasil-printers/Language/Drasil/Output/Formats.hs
+++ b/code/drasil-printers/Language/Drasil/Output/Formats.hs
@@ -1,7 +1,7 @@
 -- | Defines output formats for the different documents we can generate
 module Language.Drasil.Output.Formats where
 
-import Build.Drasil (RuleTransformer(makeRule), Type(Phony, TeX))
+import Build.Drasil (Command(C), CommandOpts(IgnoreReturnCode), Rule(R), RuleTransformer(makeRule), Type(File))
 
 -- | When choosing your document, you must specify the filename for
 -- the generated output (specified /without/ a file extension)
@@ -11,11 +11,13 @@ data DocType = SRS | MG | MIS | Website
 
 data DocSpec = DocSpec DocType Filename
 
+lualatex, bibtex :: String -> Command
+lualatex = (flip C) [] . (++) "lualatex $(TEXFLAGS) "
+bibtex = (flip C) [IgnoreReturnCode] . (++) "bibtex $(BIBTEXFLAGS) "
+
 instance RuleTransformer DocSpec where
-  makeRule (DocSpec SRS fn)     = [(Phony, "srs", [fn ++ ".pdf"]), (TeX, fn, [])]
-  makeRule (DocSpec MG  fn)     = [(Phony, "mg" , [fn ++ ".pdf"]), (TeX, fn, [])]
-  makeRule (DocSpec MIS fn)     = [(Phony, "mis", [fn ++ ".pdf"]), (TeX, fn, [])]
-  makeRule (DocSpec Website _)  = []
+  makeRule (DocSpec Website _) = []
+  makeRule (DocSpec _ fn) = [R (fn ++ ".pdf") [fn ++ ".tex"] File $ map ($ fn) [lualatex, bibtex, lualatex, lualatex]]
 
 instance Show DocType where
   show SRS      = "SRS"


### PR DESCRIPTION
This PR adds support to drasil-code to create a `Makefile` for each language when code for that language is generated.

Currently it only exposes a `run` target which is useless (for most languages) without a build target. The build target will be added in the next pull request.

This PR builds on #1227.