### PR TITLE
Fixing code generation for log and ln

### DIFF
--- a/code/drasil-code/Language/Drasil/Code/Imperative/LanguageRenderer/CSharpRenderer.hs
+++ b/code/drasil-code/Language/Drasil/Code/Imperative/LanguageRenderer/CSharpRenderer.hs
@@ -124,7 +124,8 @@ unOpDoc' :: UnaryOp -> Doc
 unOpDoc' SquareRoot = text "Math.Sqrt"
 unOpDoc' Abs = text "Math.Abs"
 unOpDoc' Exp = text "Math.Exp"
-unOpDoc' Log = text "Math.Log"
+unOpDoc' Ln  = text "Math.Log"
+unOpDoc' Log = text "Math.Log10"
 unOpDoc' op = unOpDocD op
 
 objAccessDoc' :: Config -> Value -> Function -> Doc

--- a/code/drasil-code/Language/Drasil/Code/Imperative/LanguageRenderer/CppRenderer.hs
+++ b/code/drasil-code/Language/Drasil/Code/Imperative/LanguageRenderer/CppRenderer.hs
@@ -80,7 +80,7 @@ cppConfig options c =
         clsDecDoc = clsDecDocD c, clsDecListDoc = clsDecListDocD c, classDoc = classDoc' c, objAccessDoc = objAccessDoc' c,
         objVarDoc = objVarDoc' c, paramDoc = paramDoc' c, paramListDoc = paramListDocD c, patternDoc = patternDocD c, printDoc = printDoc' c, retDoc = retDocD c, scopeDoc = scopeDocD,
         stateDoc = stateDocD c, stateListDoc = stateListDocD c, statementDoc = statementDocD c, methodDoc = methodDoc' c,
-        methodListDoc = methodListDoc' c, methodTypeDoc = methodTypeDocD c, unOpDoc = unOpDocD, valueDoc = valueDoc' c,
+        methodListDoc = methodListDoc' c, methodTypeDoc = methodTypeDocD c, unOpDoc = unOpDoc', valueDoc = valueDoc' c,
         functionDoc = functionDoc' c, functionListDoc = functionListDocD c,
         ioDoc = ioDoc' c,inputDoc = inputDoc' c,
         complexDoc = complexDoc' c,
@@ -299,6 +299,11 @@ functionDoc' c ft m f = methodDoc c ft m f
 methodListDoc' :: Config -> FileType -> Label -> [Method] -> Doc
 methodListDoc' c f@(Header) m fs = vmap (methodDoc c f m) fs
 methodListDoc' c f m fs = methodListDocD c f m fs
+
+unOpDoc' :: UnaryOp -> Doc
+unOpDoc' Ln = text "log"
+unOpDoc' Log = text "log10"
+unOpDoc' op = unOpDocD op
 
 valueDoc' :: Config -> Value -> Doc
 valueDoc' _ (EnumElement _ e) = text e

--- a/code/drasil-code/Language/Drasil/Code/Imperative/LanguageRenderer/JavaRenderer.hs
+++ b/code/drasil-code/Language/Drasil/Code/Imperative/LanguageRenderer/JavaRenderer.hs
@@ -206,7 +206,8 @@ methodDoc' c f m t = methodDocD c f m t
 unOpDoc' :: UnaryOp -> Doc
 unOpDoc' SquareRoot = text "Math.sqrt"
 unOpDoc' Abs = text "Math.abs"
-unOpDoc' Log = text "Math.log"
+unOpDoc' Ln = text "Math.log"
+unOpDoc' Log = text "Math.log10"
 unOpDoc' Exp = text "Math.exp"
 unOpDoc' op = unOpDocD op
 


### PR DESCRIPTION
Languages were generating "log" and "ln" for log and ln when they should generate "log10" and "log", respectively. This fixes an error with compiling the generated code so that @Mornix can continue his work.