### PR TITLE
Add CodeGen Makefile Targets

### DIFF
--- a/code/Makefile
+++ b/code/Makefile
@@ -27,6 +27,7 @@ GAMEPHYS_EXE  = chipmunkdocs
 EXAMPLES = tiny glassbr nopcm swhs ssp gamephys
 BUILD_EXAMPLES = $(addsuffix _build, $(EXAMPLES))
 TEX_EXAMPLES = $(addsuffix _tex, $(EXAMPLES))
+CODE_EXAMPLES = $(addsuffix _code, $(EXAMPLES))
 
 DIRS = $(foreach dir, $(addsuffix _DIR,$(shell echo $(EXAMPLES) | tr a-z A-Z)), $($(dir))) $(DPACKAGES)
 DIFF = diff --strip-trailing-cr --ignore-all-space
@@ -99,6 +100,13 @@ $(filter %_tex, $(TEX_EXAMPLES)): %_tex: %_build
 	EDIR=$(EDIR) EPREF=$(EPREF) SUMMARIZE_TEX=$(SUMMARIZE_TEX) MAKE=$(MAKE) sh ./tex_build.sh
 
 tex: $(TEX_EXAMPLES)
+
+%_code: EXAMPLE=$(shell echo $* | tr a-z A-Z)
+%_code: EDIR=$($(EXAMPLE)_DIR)
+$(filter %_code, $(CODE_EXAMPLES)): %_code: %_build
+	EDIR=$(EDIR) MAKE=$(MAKE) sh ./code_build.sh
+
+code: $(CODE_EXAMPLES)
 
 clean: clean_build
 	- stack clean

--- a/code/code_build.sh
+++ b/code/code_build.sh
@@ -1,0 +1,21 @@
+if [ -z "$EDIR" ]; then
+	echo "Missing EDIR.";
+	exit 1;
+fi;
+if [ -z "$MAKE" ]; then
+	echo "Missing MAKE.";
+	exit 1;
+fi;
+
+RET=0;
+
+if [ -d "./build/$EDIR/src" ]; then
+	cd "./build/$EDIR/src";
+	for d in */; do
+		cd "$d";
+		$MAKE;
+		RET=$(( $RET || $? ));
+		cd ../;
+	done; \
+fi
+exit $RET;


### PR DESCRIPTION
This is a small PR which adds `<example>_code` targets to the (main Drasil) Makefile to invoke the Makefile generated with each language through codegen. 

This PR does not enable code compilation in CI. That PR will occur once generated code compilation is successful on the `ll_travis_code_building` branch.