### PR TITLE
Check Stack Version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,4 @@ Main
 *.pyc
 __pycache__
 *.class
+.drasil-min-stack-ver

--- a/code/Makefile
+++ b/code/Makefile
@@ -45,7 +45,13 @@ override stackArgs += --ghc-options="$(GHCFLAGS)"
 NOISY=no
 SUMMARIZE_TEX=no
 
+MIN_STACK_VER = 1.9.1  # Version which adds --interleaved-output flag
+CACHED_MSV_FILE = .drasil-min-stack-ver
+
 all: test
+
+check_stack: FORCE
+	 @MIN_STACK_VER=$(MIN_STACK_VER) CACHED_MSV_FILE=$(CACHED_MSV_FILE) sh check_stack.sh
 
 test: $(PROGS) $(TESTS)
 	@echo ----------------------------
@@ -61,7 +67,7 @@ debug: stackArgs+=$(PROFALL)
 debug: EXECARGS+=$(PROFEXEC) 
 debug: test
 
-$(filter build_%, $(BUILD_PACKAGES)): build_%: FORCE
+$(filter build_%, $(BUILD_PACKAGES)): build_%: check_stack
 	stack install -j3 $(stackArgs) drasil-$* --dump-logs --interleaved-output
 
 %_build: EXAMPLE=$(shell echo $* | tr a-z A-Z)
@@ -90,7 +96,7 @@ glassbr_prog: glassbr_build
 
 docs: $(DOCS_PACKAGES)
 
-$(filter %-docs, $(DOCS_PACKAGES)): %-docs: FORCE
+$(filter %-docs, $(DOCS_PACKAGES)): %-docs: check_stack
 	stack haddock drasil-$* $(haddockArgs)
 
 %_tex: EXAMPLE=$(shell echo $* | tr a-z A-Z)
@@ -110,6 +116,7 @@ code: $(CODE_EXAMPLES)
 
 clean: clean_build
 	- stack clean
+	- rm $(CACHED_MSV_FILE)
 
 clean_build: clean_logs
 	- rm -r ./build

--- a/code/check_stack.sh
+++ b/code/check_stack.sh
@@ -1,0 +1,61 @@
+if [ -z $MIN_STACK_VER ]; then
+  echo "Missing MIN_STACK_VER"
+  exit 1
+fi
+
+if [ -z "$CACHED_MSV_FILE" ]; then
+  echo "Missing CACHED_MSV_FILE"
+  exit 1
+fi
+
+if [ -f "$CACHED_MSV_FILE" ]; then
+  # Fast exit
+  CACHED=$(cat "$CACHED_MSV_FILE")
+  if [ $CACHED = $MIN_STACK_VER ]; then
+    exit 0
+  fi
+fi
+
+command -v stack > /dev/null
+
+RET=$?  # "which" returns 1 if binary not found
+if [ $RET -eq 1 ]; then
+  echo "Couldn't find \`stack\`."
+  echo "Stack can be installed from https://www.haskellstack.org/"
+  exit 1
+fi
+
+CURRENT_VER=$(stack --numeric-version)
+
+MSV_SPACE=$(echo $MIN_STACK_VER | tr "." " ")
+MSV_LEN=$(echo $MSV_SPACE | wc -w)
+CV_SPACE=$(echo $CURRENT_VER | tr "." " ")
+CV_LEN=$(echo $CV_SPACE | wc -w)
+
+VALID_VERSION=yes
+for i in $(seq 1 $MSV_LEN); do
+  if [ $i -gt $CV_LEN ]; then
+    VALID_VERSION=no
+    break
+  fi
+
+  CVV=$(echo $CV_SPACE | cut -d" " -f$i)
+  MSVV=$(echo $MSV_SPACE | cut -d" " -f$i)
+  if [ $CVV -ne $MSVV ]; then
+    if [ $CVV -lt $MSVV ]; then
+      VALID_VERSION=no
+    fi
+    break
+  fi
+done
+
+if [ $VALID_VERSION = "yes" ]; then
+  echo $MIN_STACK_VER > "$CACHED_MSV_FILE"
+  exit 0
+else
+  echo "It appears your version of stack is out of date."
+  echo "Minimum required version: $MIN_STACK_VER"
+  echo "Current version: $CURRENT_VER"
+  echo "Considering running \`stack upgrade\` to update stack."
+  exit 1
+fi


### PR DESCRIPTION
This PR adds a check when any target (except `clean`) using `stack` is invoked, which detects if `stack` exists and is of at least a certain version. 

The script aims to be generally "invisible". Once a system meets our minimum version, the "result" is stored in a hidden file as a way to avoid checking every time and only when our minimum version changes. Moreover, `stack` is not checked for `clean` because we are removing files and in the likely case where someone has just downloaded the repo and doesn't have `stack` then there would be no build artifacts to delete. Finally, `clean` removes the hidden file as a way to remain true to its name and remove build artifacts.