### PR TITLE
Removing section'' and using section.

### DIFF
--- a/code/drasil-docLang/Drasil/DocumentLanguage.hs
+++ b/code/drasil-docLang/Drasil/DocumentLanguage.hs
@@ -261,7 +261,7 @@ mkSections si l = map doit l
 
 -- | Helper for creating the reference section and subsections
 mkRefSec :: SystemInformation -> RefSec -> Section
-mkRefSec si (RefProg c l) = section'' (titleize refmat) [c]
+mkRefSec si (RefProg c l) = section (titleize refmat) [c]
   (map (mkSubRef si) l) (makeSecRef "RefMat" "Reference Material") --DO NOT CHANGE LABEL OR THINGS WILL BREAK -- see Language.Drasil.Document.Extract
   where
     mkSubRef :: SystemInformation -> RefTab -> Section

--- a/code/drasil-docLang/Drasil/Sections/SolutionCharacterSpec.hs
+++ b/code/drasil-docLang/Drasil/Sections/SolutionCharacterSpec.hs
@@ -251,7 +251,7 @@ render _ symMap item@(SectionModel niname _)
 ------------------------------
 
 genericSect :: SubSec -> Section
-genericSect (SectionModel niname xs) = section'' (pullTitle xs niname) 
+genericSect (SectionModel niname xs) = section (pullTitle xs niname) 
   (pullContents xs) (pullSections xs) (makeSecRef (niname ^. uid) (niname ^. uid)) --FIXME
 
 ------------------------------------------------

--- a/code/drasil-lang/Language/Drasil.hs
+++ b/code/drasil-lang/Language/Drasil.hs
@@ -120,7 +120,7 @@ module Language.Drasil (
   , LabelledContent(..), UnlabelledContent(..), extractSection
   , mkParagraph, mkRawLC
   , llcc, ulcc
-  , section, fig, figWithWidth, section''
+  , section, fig, figWithWidth
   , MaxWidthPercent
   , HasContents(accessContents)
   , RawContent(..)
@@ -206,7 +206,7 @@ import Language.Drasil.Expr.Math (log, ln, sin, cos, tan, sqrt, square, sec,
           sy, deriv, pderiv,
           cross, m2x2, vec2D, dgnl2x2, euclidean, defint, int_all)
 import Language.Drasil.Document (section, fig, figWithWidth
-  , section'', Section(..), SecCons(..) , llcc, ulcc, Document(..)
+  , Section(..), SecCons(..) , llcc, ulcc, Document(..)
   , mkParagraph, mkFig, mkRawLC, extractSection
   , makeTabRef, makeFigRef, makeSecRef, makeLstRef, makeURI)
 import Language.Drasil.Document.Core (Contents(..), ListType(..), ItemType(..), DType(..)

--- a/code/drasil-lang/Language/Drasil/Document.hs
+++ b/code/drasil-lang/Language/Drasil/Document.hs
@@ -73,9 +73,6 @@ mkRawLC x lb = llcc lb x
 section :: Sentence -> [Contents] -> [Section] -> Reference -> Section
 section title intro secs lbe = Section title (map Con intro ++ map Sub secs) lbe
 
-section'' :: Sentence -> [Contents] -> [Section] -> Reference -> Section
-section'' title intro secs lbe = section title intro secs lbe
-
 extractSection :: Document -> [Section]
 extractSection (Document _ _ sec) = concatMap getSec sec
 


### PR DESCRIPTION
Taking the change of section'' to section from #1262 and giving it a separate branch and PR.

section'' calls section completely reusing the parameters making it equivalent and redundant to have a separate function.