### PR TITLE
Correct Makefile diffs on Windows

### DIFF
--- a/code/drasil-code/Language/Drasil/Code/Imperative/Import.hs
+++ b/code/drasil-code/Language/Drasil/Code/Imperative/Import.hs
@@ -22,7 +22,6 @@ import Language.Drasil.Code.DataDesc (Ind(WithPattern, WithLine, Explicit),
 import Prelude hiding (log, exp, const)
 import Data.List (intersperse, (\\), stripPrefix)
 import System.Directory (setCurrentDirectory, createDirectoryIfMissing, getCurrentDirectory)
-import System.FilePath ((</>))
 import Data.Map (member)
 import qualified Data.Map as Map (lookup)
 import Data.Maybe (fromMaybe, maybe)
@@ -96,7 +95,7 @@ generateCode chs g =
           let config = makeLangConfig (getLabel x) $ Options Nothing Nothing Nothing $
                        Just "Code"
           createCodeFiles $ makeBuild (unAbs absCode) config $ C.Code $
-            map (if x == Java then \(c,d) -> (prog </> c, d) else id) $
+            map (if x == Java then \(c,d) -> (prog ++ "/" ++ c, d) else id) $
             C.unCode $ makeCode config absCode
           setCurrentDirectory workingDir) $ lang chs
   where prog = case codeSpec g of { CodeSpec {program = pp} -> programName pp }


### PR DESCRIPTION
This is a small PR which (should) close #1272. I have included @bmaclach and @samm82 as reviewers to ensure that it does indeed resolve the issue on Windows.

# What happened?
1. I tried to be "correct" and use the `System.FilePath` provided operator `</>` to join paths when generating code Makefiles. 
2. `System.FilePath` is smart enough to know it's being compiled/run on Windows and replaces `/` path separator used on Unix with the Windows-preferred `\`. 
3. `diff` doesn't care what operating system it is running on and is just comparing text in two files.

# Why this fix is "fine"
Even though `\` is the [preferred separator](http://hackage.haskell.org/package/filepath-1.4.2.1/docs/System-FilePath-Posix.html#v:pathSeparator) on Windows, it still [supports `/`](http://hackage.haskell.org/package/filepath-1.4.2.1/docs/System-FilePath-Posix.html#v:pathSeparators). To further corroborate this documentation is [a .NET CLR doc](https://docs.microsoft.com/en-us/dotnet/api/system.io.path.directoryseparatorchar?view=netframework-4.8#remarks) states, "If you prefer to hard-code the directory separator character, you should use the forward slash (/) character. It is the only recognized directory separator character on Unix systems, as the output from the example shows, and is the AltDirectorySeparatorChar on Windows." And while we are (now) hard-coding `/`, this is more necessitated by `diff` and our testing infrastructure of comparing text output. So while we are not using Windows' preferred separator, this should cover all OS'. 