### PR TITLE
Switched to [Reference] for Source Fields of Chunks

### DIFF
--- a/code/drasil-data/Data/Drasil/SentenceStructures.hs
+++ b/code/drasil-data/Data/Drasil/SentenceStructures.hs
@@ -15,7 +15,6 @@ module Data.Drasil.SentenceStructures
   , fmtPhys, fmtSfwr, typUncr
   , mkTableFromColumns
   , EnumType(..), WrapType(..), SepType(..), FoldType(..)
-  , getSource'
   ) where
 
 import Language.Drasil
@@ -240,7 +239,3 @@ fmtSfwr c = foldlList Comma List $ map (E . constraintToExpr c) $ filter isSfwrC
 replaceEmptyS :: Sentence -> Sentence
 replaceEmptyS EmptyS = none
 replaceEmptyS s = s
-
--- | Get the source citations (if any)
-getSource' :: HasCitation c => c -> Sentence
-getSource' c = foldlList Comma List $ map makeCiteS $ c ^. getCitations

--- a/code/drasil-docLang/Drasil/DocumentLanguage/Definitions.hs
+++ b/code/drasil-docLang/Drasil/DocumentLanguage/Definitions.hs
@@ -162,7 +162,7 @@ mkGDField g _ l@DefiningEquation fs = (show l, [eqUnR' $ g ^. relat]) : fs
 mkGDField g m l@(Description v u) fs = (show l,
   (buildDescription v u (g ^. relat) m) []) : fs
 mkGDField g m l@RefBy fs = (show l, [mkParagraph $ helperRefs g m]) : fs --FIXME: fill this in
-mkGDField g _ l@Source fs = (show l, [mkParagraph $ getSource' g]) : fs
+mkGDField g _ l@Source fs = (show l, helperSources $ g ^. getReferences) : fs
 mkGDField g _ l@Notes fs = nonEmpty fs (\ss -> (show l, map mkParagraph ss) : fs) (g ^. getNotes)
 mkGDField _ _ l _ = error $ "Label " ++ show l ++ " not supported for gen defs"
 

--- a/code/drasil-docLang/Drasil/DocumentLanguage/Definitions.hs
+++ b/code/drasil-docLang/Drasil/DocumentLanguage/Definitions.hs
@@ -173,7 +173,7 @@ mkIMField i _ l@DefiningEquation fs = (show l, [eqUnR' $ i ^. relat]) : fs
 mkIMField i m l@(Description v u) fs = (show l,
   foldr (\x -> buildDescription v u x m) [] [i ^. relat]) : fs
 mkIMField i m l@RefBy fs = (show l, [mkParagraph $ helperRefs i m]) : fs --FIXME: fill this in
-mkIMField i _ l@Source fs = (show l, [mkParagraph $ getSource' i]) : fs
+mkIMField i _ l@Source fs = (show l, helperSources $ i ^. getReferences) : fs
 mkIMField i _ l@Output fs = (show l, [mkParagraph x]) : fs
   where x = P . eqSymb $ i ^. imOutput
 mkIMField i _ l@Input fs = 

--- a/code/drasil-docLang/Drasil/DocumentLanguage/Definitions.hs
+++ b/code/drasil-docLang/Drasil/DocumentLanguage/Definitions.hs
@@ -20,7 +20,7 @@ import Control.Lens ((^.))
 import Language.Drasil
 
 import Data.Drasil.Utils (eqUnR')
-import Data.Drasil.SentenceStructures (SepType(Comma), FoldType(List), foldlList, foldlSent, getSource')
+import Data.Drasil.SentenceStructures (SepType(Comma), FoldType(List), foldlList, foldlSent)
 
 import Drasil.DocumentLanguage.Units (toSentenceUnitless)
 

--- a/code/drasil-example/Drasil/GlassBR/DataDefs.hs
+++ b/code/drasil-example/Drasil/GlassBR/DataDefs.hs
@@ -52,8 +52,8 @@ riskQD = mkQuantDef risk_fun risk_eq
 
 risk :: DataDefinition
 risk = mkDD riskQD 
-  [astm2009, beasonEtAl1998 {- FIXME +:+ sParen (S "Eq. 4-5") -},
-  campidelli {- FIXME +:+ sParen (S "Eq. 14") -}] 
+  (map makeCite [astm2009, beasonEtAl1998 {- FIXME +:+ sParen (S "Eq. 4-5") -},
+  campidelli {- FIXME +:+ sParen (S "Eq. 14") -}])
   [{-derivation-}] "risk_fun"
   [aGrtrThanB, hRef, ldfRef, jRef]
 
@@ -70,7 +70,7 @@ hFromtQD :: QDefinition
 hFromtQD = mkQuantDef min_thick hFromt_eq
 
 hFromt :: DataDefinition
-hFromt = mkDD hFromtQD [astm2009] [{-derivation-}] "min_thick" [hMin]
+hFromt = mkDD hFromtQD [makeCite astm2009] [{-derivation-}] "min_thick" [hMin]
 
 --DD3-- (#749)
 
@@ -81,7 +81,7 @@ loadDFQD :: QDefinition
 loadDFQD = mkQuantDef lDurFac loadDF_eq
 
 loadDF :: DataDefinition
-loadDF = mkDD loadDFQD [astm2009] [{-derivation-}] "loadDurFactor" [makeRef2S assumpSV,
+loadDF = mkDD loadDFQD [makeCite astm2009] [{-derivation-}] "loadDurFactor" [makeRef2S assumpSV,
   makeRef2S assumpLDFC]
 
 --DD4--
@@ -95,7 +95,7 @@ strDisFacQD :: QDefinition
 strDisFacQD = mkQuantDef stressDistFac strDisFac_eq
 
 strDisFac :: DataDefinition
-strDisFac = mkDD strDisFacQD [astm2009] [{-derivation-}] "stressDistFac"
+strDisFac = mkDD strDisFacQD [makeCite astm2009] [{-derivation-}] "stressDistFac"
   [jRef2, qHtRef, arRef]
 
 --DD5--
@@ -108,7 +108,7 @@ nonFLQD :: QDefinition
 nonFLQD = mkQuantDef nonFactorL nonFL_eq
 
 nonFL :: DataDefinition
-nonFL = mkDD nonFLQD [astm2009] [{-derivation-}] "nFL"
+nonFL = mkDD nonFLQD [makeCite astm2009] [{-derivation-}] "nFL"
   (aGrtrThanB : hRef : qHtTlTolRef : [makeRef2S assumpSV])
 
 --DD6--
@@ -123,7 +123,7 @@ glaTyFacQD :: QDefinition
 glaTyFacQD = mkQuantDef gTF glaTyFac_eq
 
 glaTyFac :: DataDefinition
-glaTyFac = mkDD glaTyFacQD [astm2009] [{-derivation-}] "gTF"
+glaTyFac = mkDD glaTyFacQD [makeCite astm2009] [{-derivation-}] "gTF"
   [anGlass, ftGlass, hsGlass]
 
 --DD7--
@@ -136,7 +136,7 @@ dimLLQD :: QDefinition
 dimLLQD = mkQuantDef dimlessLoad dimLL_eq
 
 dimLL :: DataDefinition
-dimLL = mkDD dimLLQD [astm2009, campidelli {- +:+ sParen (S "Eq. 7") -}] [{-derivation-}] "dimlessLoad"
+dimLL = mkDD dimLLQD (map makeCite [astm2009, campidelli {- +:+ sParen (S "Eq. 7") -}]) [{-derivation-}] "dimlessLoad"
   [qRef , aGrtrThanB , hRef, gtfRef, glassLiteRef, makeRef2S assumpSV]
 
 --DD8--
@@ -149,7 +149,7 @@ tolPreQD :: QDefinition
 tolPreQD = mkQuantDef tolLoad tolPre_eq
 
 tolPre :: DataDefinition
-tolPre = mkDD tolPreQD [astm2009] [{-derivation-}] "tolLoad"
+tolPre = mkDD tolPreQD [makeCite astm2009] [{-derivation-}] "tolLoad"
   [qHtTlExtra]
 
 --DD9--
@@ -164,7 +164,7 @@ tolStrDisFacQD :: QDefinition
 tolStrDisFacQD = mkQuantDef sdf_tol tolStrDisFac_eq
 
 tolStrDisFac :: DataDefinition
-tolStrDisFac = mkDD tolStrDisFacQD [astm2009] [{-derivation-}] "sdf_tol"
+tolStrDisFac = mkDD tolStrDisFacQD [makeCite astm2009] [{-derivation-}] "sdf_tol"
   (jtolRelToPbtol : aGrtrThanB : hRef : ldfRef : pbTolUsr : [makeRef2S assumpSV])
 
 --DD10--
@@ -176,7 +176,7 @@ standOffDisQD :: QDefinition
 standOffDisQD = mkQuantDef standOffDist standOffDis_eq
 
 standOffDis :: DataDefinition
-standOffDis = mkDD standOffDisQD [astm2009] [{-derivation-}] "standOffDist" []
+standOffDis = mkDD standOffDisQD [makeCite astm2009] [{-derivation-}] "standOffDist" []
 
 --DD11--
 
@@ -187,7 +187,7 @@ aspRatQD :: QDefinition
 aspRatQD = mkQuantDef aspect_ratio aspRat_eq
 
 aspRat :: DataDefinition
-aspRat = mkDD aspRatQD [astm2009] [{-derivation-}] "aspect_ratio" [aGrtrThanB]
+aspRat = mkDD aspRatQD [makeCite astm2009] [{-derivation-}] "aspect_ratio" [aGrtrThanB]
 
 --DD12--
 eqTNTW_eq :: Expr
@@ -197,7 +197,7 @@ eqTNTWQD :: QDefinition
 eqTNTWQD = mkQuantDef eqTNTWeight eqTNTW_eq
 
 eqTNTWDD :: DataDefinition
-eqTNTWDD = mkDD eqTNTWQD [astm2009] [] "eqTNTW" []
+eqTNTWDD = mkDD eqTNTWQD [makeCite astm2009] [] "eqTNTW" []
 
 --DD13--
 probOfBreak_eq :: Expr
@@ -207,7 +207,7 @@ probOfBreakQD :: QDefinition
 probOfBreakQD = mkQuantDef prob_br probOfBreak_eq
 
 probOfBreak :: DataDefinition
-probOfBreak = mkDD probOfBreakQD [astm2009, beasonEtAl1998] [{-derivation-}] "probOfBreak" [glassBreak]
+probOfBreak = mkDD probOfBreakQD (map makeCite [astm2009, beasonEtAl1998]) [{-derivation-}] "probOfBreak" [glassBreak]
 
 --DD14--
 calofCapacity_eq :: Expr
@@ -217,7 +217,7 @@ calofCapacityQD :: QDefinition
 calofCapacityQD = mkQuantDef lRe calofCapacity_eq
 
 calofCapacity :: DataDefinition
-calofCapacity = mkDD calofCapacityQD [astm2009] [{-derivation-}] "calofCapacity" capacityS
+calofCapacity = mkDD calofCapacityQD [makeCite astm2009] [{-derivation-}] "calofCapacity" capacityS
 
 --DD15--
 calofDemand_eq :: Expr
@@ -227,7 +227,7 @@ calofDemandQD :: QDefinition
 calofDemandQD = mkQuantDef demand calofDemand_eq
 
 calofDemand :: DataDefinition
-calofDemand = mkDD calofDemandQD [astm2009] [{-derivation-}] "calofDemand" [calofDemandDesc]
+calofDemand = mkDD calofDemandQD [makeCite astm2009] [{-derivation-}] "calofDemand" [calofDemandDesc]
 
 
 --Additional Notes--

--- a/code/drasil-example/Drasil/GlassBR/IMods.hs
+++ b/code/drasil-example/Drasil/GlassBR/IMods.hs
@@ -28,7 +28,7 @@ glassBRsymb = map dqdWr [plate_len, plate_width, char_weight, standOffDist] ++
 calofDemandi :: InstanceModel
 calofDemandi = im' calofDemand_RCi [qw demand, qw eqTNTWeight, qw standOffDist]
   [sy demand $> 0, sy eqTNTWeight $> 0, sy standOffDist $> 0] (qw demand) []
-  [astm2009] "calOfDemand"
+  [makeCite astm2009] "calOfDemand"
   [calofDemandDesc]
 
 calofDemand_RCi :: RelationConcept

--- a/code/drasil-example/Drasil/NoPCM/IMods.hs
+++ b/code/drasil-example/Drasil/NoPCM/IMods.hs
@@ -37,7 +37,7 @@ eBalanceOnWtr = im'' eBalanceOnWtr_rc [qw temp_C, qw temp_init, qw time_final,
   qw coil_SA, qw coil_HTC, qw htCap_W, qw w_mass] 
   [sy temp_init $<= sy temp_C] (qw temp_W) 
   --Tw(0) cannot be presented, there is one more constraint Tw(0) = Tinit
-  [0 $< sy time $< sy time_final] [koothoor2013 {- +:+ sParen (S "with PCM removed")-} ] 
+  [0 $< sy time $< sy time_final] [makeCite koothoor2013 {- +:+ sParen (S "with PCM removed")-} ] 
   eBalanceOnWtrDeriv "eBalanceOnWtr" [balWtrDesc]
 
 eBalanceOnWtr_rc :: RelationConcept

--- a/code/drasil-example/Drasil/SSP/DataDefs.hs
+++ b/code/drasil-example/Drasil/SSP/DataDefs.hs
@@ -40,7 +40,7 @@ dataDefns = [sliceWght, baseWtrF, surfWtrF, intersliceWtrF, angleA, angleB,
 --DD1
 
 sliceWght :: DataDefinition
-sliceWght = mkDD sliceWghtQD [fredlund1977] [{-Derivation-}] "sliceWght" 
+sliceWght = mkDD sliceWghtQD [makeCite fredlund1977] [{-Derivation-}] "sliceWght" 
   [sliceWghtNotes]
 --FIXME: fill empty lists in
 
@@ -64,7 +64,7 @@ sliceWghtNotes = foldlSent [S "This", phrase equation, S "is based on the",
 --DD2
 
 baseWtrF :: DataDefinition
-baseWtrF = mkDD baseWtrFQD [fredlund1977] [{-Derivation-}] "baseWtrF"
+baseWtrF = mkDD baseWtrFQD [makeCite fredlund1977] [{-Derivation-}] "baseWtrF"
   [bsWtrFNotes]
 --FIXME: fill empty lists in
 
@@ -84,7 +84,7 @@ bsWtrFNotes = foldlSent [S "This", phrase equation, S "is based on the",
 --DD3
 
 surfWtrF :: DataDefinition
-surfWtrF = mkDD srfWtrFQD [fredlund1977] [{-Derivation-}] "surfWtrF"
+surfWtrF = mkDD srfWtrFQD [makeCite fredlund1977] [{-Derivation-}] "surfWtrF"
   [srfWtrFNotes]
 --FIXME: fill empty lists in
 
@@ -104,7 +104,7 @@ srfWtrFNotes = foldlSent [S "This", phrase equation, S "is based on the",
 --DD4
 
 intersliceWtrF :: DataDefinition
-intersliceWtrF = mkDD intersliceWtrFQD [fredlund1977] [{-Derivation-}] "intersliceWtrF"
+intersliceWtrF = mkDD intersliceWtrFQD [makeCite fredlund1977] [{-Derivation-}] "intersliceWtrF"
   []--Notes
 --FIXME: fill empty lists in
 
@@ -125,7 +125,7 @@ intersliceWtrFEqn = case_ [case1,case2,case3]
 --DD5
 
 angleA :: DataDefinition
-angleA = mkDD angleAQD [fredlund1977] [{-Derivation-}] "angleA" 
+angleA = mkDD angleAQD [makeCite fredlund1977] [{-Derivation-}] "angleA" 
   [angleANotes]
 --FIXME: fill empty lists in
 
@@ -144,7 +144,7 @@ angleANotes = foldlSent [S "This", phrase equation, S "is based on the",
 --DD6
 
 angleB :: DataDefinition
-angleB = mkDD angleBQD [fredlund1977] [{-Derivation-}] "angleB"
+angleB = mkDD angleBQD [makeCite fredlund1977] [{-Derivation-}] "angleB"
   [angleBNotes]--Notes
 --FIXME: fill empty lists in
 
@@ -163,7 +163,7 @@ angleBNotes = foldlSent [S "This", phrase equation, S "is based on the",
 --DD7
 
 lengthB :: DataDefinition
-lengthB = mkDD lengthBQD [fredlund1977] [{-Derivation-}] "lengthB" []--Notes
+lengthB = mkDD lengthBQD [makeCite fredlund1977] [{-Derivation-}] "lengthB" []--Notes
 --FIXME: fill empty lists in
 
 lengthBQD :: QDefinition
@@ -175,7 +175,7 @@ lengthBEqn = inxi slipDist - inx slipDist (-1)
 --DD8
 
 lengthLb :: DataDefinition
-lengthLb = mkDD lengthLbQD [fredlund1977] [{-Derivation-}] "lengthLb"
+lengthLb = mkDD lengthLbQD [makeCite fredlund1977] [{-Derivation-}] "lengthLb"
   [lengthLbNotes]--Notes
 --FIXME: fill empty lists in
 
@@ -192,7 +192,7 @@ lengthLbNotes = foldlSent [ch baseWthX, S "is defined in",
 --DD9
 
 lengthLs :: DataDefinition
-lengthLs = mkDD lengthLsQD [fredlund1977] [{-Derivation-}] "lengthLs"
+lengthLs = mkDD lengthLsQD [makeCite fredlund1977] [{-Derivation-}] "lengthLs"
   [lengthLsNotes]--Notes
 --FIXME: fill empty lists in
 
@@ -209,7 +209,7 @@ lengthLsNotes = foldlSent [ch baseWthX, S "is defined in",
 --DD10
 
 slcHeight :: DataDefinition
-slcHeight = mkDD slcHeightQD [fredlund1977] [{-Derivation-}] "slcHeight"
+slcHeight = mkDD slcHeightQD [makeCite fredlund1977] [{-Derivation-}] "slcHeight"
   slcHeightNotes
 
 slcHeightQD :: QDefinition
@@ -229,7 +229,7 @@ slcHeightNotes = [S "This" +:+ (phrase equation) +:+ S "is based on the" +:+
 --DD11 
 
 stressDD :: DataDefinition
-stressDD = mkDD stressQD [huston2008] [{-Derivation-}] "stress" []
+stressDD = mkDD stressQD [makeCite huston2008] [{-Derivation-}] "stress" []
 
 stressQD :: QDefinition
 stressQD = mkQuantDef totStress stressEqn
@@ -240,7 +240,7 @@ stressEqn = (sy genericF) / (sy genericA)
 --DD12
 
 ratioVariation :: DataDefinition
-ratioVariation = mkDD ratioVarQD [fredlund1977] [{-Derivation-}] 
+ratioVariation = mkDD ratioVarQD [makeCite fredlund1977] [{-Derivation-}] 
   "ratioVariation" []
 
 ratioVarQD :: QDefinition
@@ -256,7 +256,7 @@ ratioVarEqn = case_ [case1, case2]
 --DD13
 
 convertFunc1 :: DataDefinition
-convertFunc1 = mkDD convertFunc1QD [chen2005, karchewski2012] [{-Derivation-}]
+convertFunc1 = mkDD convertFunc1QD (map makeCite [chen2005, karchewski2012]) [{-Derivation-}]
   "convertFunc1" [convertFunc1Notes]
 
 convertFunc1QD :: QDefinition
@@ -274,7 +274,7 @@ convertFunc1Notes = foldlSent [ch scalFunc, S "is defined in", makeRef2S ratioVa
 --DD14
 
 convertFunc2 :: DataDefinition
-convertFunc2 = mkDD convertFunc2QD [chen2005, karchewski2012] [{-Derivation-}]
+convertFunc2 = mkDD convertFunc2QD (map makeCite [chen2005, karchewski2012]) [{-Derivation-}]
   "convertFunc2" [convertFunc2Notes]
 
 convertFunc2QD :: QDefinition
@@ -350,17 +350,17 @@ sliceHghtRightDD = mkDD sliceHghtRightQD [{-References-}] [{-Derivation-}]
   "sliceHghtRightDD" []--Notes
 sliceHghtLeftDD = mkDD sliceHghtLeftQD [{-References-}] [{-Derivation-}] 
   "sliceHghtLeftDD" []--Notes
-slcWghtRDD = mkDD slcWghtRQD [fredlund1977] [{-Derivation-}] 
+slcWghtRDD = mkDD slcWghtRQD [makeCite fredlund1977] [{-Derivation-}] 
   "slcWghtRDD" [slcWghtNotes]
-slcWghtLDD = mkDD slcWghtLQD [fredlund1977] [{-Derivation-}] 
+slcWghtLDD = mkDD slcWghtLQD [makeCite fredlund1977] [{-Derivation-}] 
   "slcWghtRDD" [slcWghtNotes]
-baseWtrFRDD = mkDD baseWtrFRQD [fredlund1977] [{-Derivation-}] 
+baseWtrFRDD = mkDD baseWtrFRQD [makeCite fredlund1977] [{-Derivation-}] 
   "baseWtrFRDD" [baseWtrFNotes]
-baseWtrFLDD = mkDD baseWtrFLQD [fredlund1977] [{-Derivation-}] 
+baseWtrFLDD = mkDD baseWtrFLQD [makeCite fredlund1977] [{-Derivation-}] 
   "baseWtrFLDD" [baseWtrFNotes]
-surfWtrFRDD = mkDD surfWtrFRQD [fredlund1977] [{-Derivation-}] 
+surfWtrFRDD = mkDD surfWtrFRQD [makeCite fredlund1977] [{-Derivation-}] 
   "surfWtrFRDD" [surfWtrFNotes]
-surfWtrFLDD = mkDD surfWtrFLQD [fredlund1977] [{-Derivation-}] 
+surfWtrFLDD = mkDD surfWtrFLQD [makeCite fredlund1977] [{-Derivation-}] 
   "surfWtrFLDD" [surfWtrFNotes]
 
 nrmForceSumQD :: QDefinition

--- a/code/drasil-example/Drasil/SSP/GenDefs.hs
+++ b/code/drasil-example/Drasil/SSP/GenDefs.hs
@@ -43,23 +43,23 @@ generalDefinitions = [normForcEqGD, bsShrFEqGD, resShrGD, mobShrGD,
 
 normForcEqGD, bsShrFEqGD, resShrGD, mobShrGD, effNormFGD, resShearWOGD, mobShearWOGD, normShrRGD, momentEqlGD :: GenDefn
 normForcEqGD = gd' normForcEq (getUnit totNrmForce)   [nmFEq_deriv]    
-  [chen2005]                   "normForcEq"  [nmFEq_desc]
+  [makeCite chen2005]                      "normForcEq"  [nmFEq_desc]
 bsShrFEqGD   = gd' bsShrFEq   (getUnit mobShrI)       [bShFEq_deriv]
-  [chen2005]                   "bsShrFEq"    [bShFEq_desc]
+  [makeCite chen2005]                      "bsShrFEq"    [bShFEq_desc]
 resShrGD     = gd' resShr     (getUnit shrResI)       [resShr_deriv]   
-  [chen2005]                   "resShr"      [resShr_desc]
+  [makeCite chen2005]                      "resShr"      [resShr_desc]
 mobShrGD     = gd' mobShr     (getUnit mobShrI)       [mobShr_deriv]   
-  [chen2005]                   "mobShr"      [mobShr_desc]
+  [makeCite chen2005]                      "mobShr"      [mobShr_desc]
 effNormFGD   = gd' effNormF   (getUnit nrmFSubWat)    [effNormF_deriv] 
-  [chen2005]                   "effNormF"    [effNormF_desc]
+  [makeCite chen2005]                      "effNormF"    [effNormF_desc]
 resShearWOGD = gd' resShearWO (getUnit shearRNoIntsl) []         
-  [chen2005, karchewski2012]   "resShearWO"  [resShearWO_desc]
+  (map makeCite[chen2005, karchewski2012]) "resShearWO"  [resShearWO_desc]
 mobShearWOGD = gd' mobShearWO (getUnit shearFNoIntsl) []
-  [chen2005, karchewski2012]   "mobShearWO"  [mobShearWO_desc]
+  (map makeCite[chen2005, karchewski2012]) "mobShearWO"  [mobShearWO_desc]
 normShrRGD   = gd' normShrR   (getUnit intShrForce)   [] 
-  [chen2005]                   "normShrR"    [nmShrR_desc]
+  [makeCite chen2005]                      "normShrR"    [nmShrR_desc]
 momentEqlGD  = gd' momentEql  (Just newton)           [momEql_deriv]  
-  [chen2005]                   "momentEql"   [momEql_desc]
+  [makeCite chen2005]                      "momentEql"   [momEql_desc]
 
 --
 normForcEq :: RelationConcept

--- a/code/drasil-example/Drasil/SSP/IMods.hs
+++ b/code/drasil-example/Drasil/SSP/IMods.hs
@@ -53,7 +53,7 @@ sspIMods = [fctSfty, nrmShrFor, nrmShrForNum, nrmShrForDen, intsliceFs, crtSlpId
 
 fctSfty :: InstanceModel
 fctSfty = im'' fctSfty_rc [qw slopeDist, qw slopeHght, qw waterHght, qw effCohesion, qw fricAngle, qw dryWeight, qw satWeight, qw waterWeight, qw slipDist, qw slipHght, qw constF]
-  [] (qw fs) [] [chen2005, karchewski2012] fctSftyDeriv "fctSfty" [fcSfty_desc]
+  [] (qw fs) [] (map makeCite [chen2005, karchewski2012]) fctSftyDeriv "fctSfty" [fcSfty_desc]
 
 fctSfty_rc :: RelationConcept
 fctSfty_rc = makeRC "fctSfty_rc" factorOfSafety fcSfty_desc fcSfty_rel -- fctSftyL
@@ -370,7 +370,7 @@ fctSftyDerivEqn18 = sy fs * (idx (sy mobShrC) (sy numbSlices - int 1) *
 nrmShrFor :: InstanceModel
 nrmShrFor = im'' nrmShrFor_rc [qw slopeDist, qw slopeHght, qw waterHght, 
   qw waterWeight, qw slipDist, qw slipHght, qw constF]
-  [] (qw normToShear) [] [chen2005, karchewski2012] nrmShrDeriv "nrmShrFor" 
+  [] (qw normToShear) [] (map makeCite [chen2005, karchewski2012]) nrmShrDeriv "nrmShrFor" 
   [nrmShrF_desc]
 
 nrmShrFor_rc :: RelationConcept
@@ -454,7 +454,7 @@ nrmShrDerivEqn4 = inxi normToShear $= sum1toN
 nrmShrForNum :: InstanceModel
 nrmShrForNum = im'' nrmShrForNum_rc [qw slopeDist, qw slopeHght, qw waterHght, 
   qw waterWeight, qw slipDist, qw slipHght]
-  [] (qw nrmShearNum) [] [chen2005, karchewski2012] nrmShrFNum_deriv 
+  [] (qw nrmShearNum) [] (map makeCite [chen2005, karchewski2012]) nrmShrFNum_deriv 
   "nrmShrForNum" [nrmShrFNum_desc]
 
 nrmShrForNum_rc :: RelationConcept
@@ -492,7 +492,7 @@ nrmShrFNum_desc = foldlSent [ch baseWthX, S "is defined in",
 
 nrmShrForDen :: InstanceModel
 nrmShrForDen = im'' nrmShrForDen_rc [qw slipDist, qw constF]
-  [] (qw nrmShearDen) [] [chen2005, karchewski2012] nrmShrFDen_deriv 
+  [] (qw nrmShearDen) [] (map makeCite [chen2005, karchewski2012]) nrmShrFDen_deriv
   "nrmShrForDen" [nrmShrFDen_desc]
 
 nrmShrForDen_rc :: RelationConcept
@@ -522,7 +522,7 @@ nrmShrFDen_desc = foldlSent [ch baseWthX, S "is defined in",
 
 intsliceFs :: InstanceModel
 intsliceFs = im'' intsliceFs_rc [qw slopeDist, qw slopeHght, qw waterHght, qw effCohesion, qw fricAngle, qw dryWeight, qw satWeight, qw waterWeight, qw slipDist, qw slipHght, qw constF]
-  [] (qw intNormForce) [] [chen2005] intrSlcDeriv "intsliceFs" [sliceFs_desc]
+  [] (qw intNormForce) [] [makeCite chen2005] intrSlcDeriv "intsliceFs" [sliceFs_desc]
 
 intsliceFs_rc :: RelationConcept
 intsliceFs_rc = makeRC "intsliceFs_rc" (nounPhraseSP "interslice normal forces")
@@ -583,7 +583,7 @@ intrSlcDerivEqn = (inxi intNormForce) $=
 crtSlpId :: InstanceModel
 crtSlpId = im' crtSlpId_rc [qw slopeDist, qw slopeHght, qw waterDist, 
   qw waterHght, qw effCohesion, qw fricAngle, qw dryWeight, qw satWeight,
-  qw waterWeight, qw constF] [] (qw fs_min) [] [li2010] "crtSlpId" 
+  qw waterWeight, qw constF] [] (qw fs_min) [] [makeCite li2010] "crtSlpId" 
   [crtSlpId_desc]
 
 crtSlpId_rc :: RelationConcept

--- a/code/drasil-example/Drasil/SWHS/DataDefs.hs
+++ b/code/drasil-example/Drasil/SWHS/DataDefs.hs
@@ -37,7 +37,7 @@ htFluxCEqn :: Expr
 htFluxCEqn = (sy coil_HTC) * ((sy temp_C) - apply1 temp_W time)
 
 dd1HtFluxC :: DataDefinition
-dd1HtFluxC = mkDD dd1HtFluxCQD [koothoor2013] [] "ht_flux_C"
+dd1HtFluxC = mkDD dd1HtFluxCQD [makeCite koothoor2013] [] "ht_flux_C"
   [makeRef2S assumpLCCCW, makeRef2S assumpTHCCoT, makeRef2S assumpTHCCoL]
 
 --Can't include info in description beyond definition of variables?
@@ -50,7 +50,7 @@ htFluxPEqn :: Expr
 htFluxPEqn = (sy pcm_HTC) * (apply1 temp_W time - apply1 temp_PCM time)
 
 dd2HtFluxP :: DataDefinition
-dd2HtFluxP = mkDD dd2HtFluxPQD [koothoor2013] [] "ht_flux_P"
+dd2HtFluxP = mkDD dd2HtFluxPQD [makeCite koothoor2013] [] "ht_flux_P"
   [makeRef2S assumpCWTAT, makeRef2S assumpTPCAV, makeRef2S assumpLCCWP]
 
 ----
@@ -63,7 +63,7 @@ balanceSolidPCMEqn = ((sy pcm_mass) * (sy htCap_S_P)) /
   ((sy pcm_HTC) * (sy pcm_SA))
 
 ddBalanceSolidPCM :: DataDefinition
-ddBalanceSolidPCM = mkDD ddBalanceSolidPCMQD [lightstone2012] []
+ddBalanceSolidPCM = mkDD ddBalanceSolidPCMQD [makeCite lightstone2012] []
   "balanceSolidPCM" []
 
 ----
@@ -76,7 +76,7 @@ balanceLiquidPCMEqn = ((sy pcm_mass) * (sy htCap_L_P)) /
   ((sy pcm_HTC) * (sy pcm_SA))
 
 ddBalanceLiquidPCM :: DataDefinition
-ddBalanceLiquidPCM = mkDD ddBalanceLiquidPCMQD [lightstone2012] []
+ddBalanceLiquidPCM = mkDD ddBalanceLiquidPCMQD [makeCite lightstone2012] []
   "balanceLiquidPCM" []
 
 ----
@@ -89,7 +89,7 @@ htFusionEqn = (sy latent_heat) / (sy mass)
 
 -- FIXME: need to allow page references in references.
 dd3HtFusion :: DataDefinition
-dd3HtFusion = mkDD dd3HtFusionQD [bueche1986 {- +:+ sParen (S "pg. 282") -} ]
+dd3HtFusion = mkDD dd3HtFusionQD [makeCite bueche1986 {- +:+ sParen (S "pg. 282") -} ]
   [] "htFusion" []
 
 ----
@@ -107,7 +107,7 @@ melt_frac_eqn :: Expr
 melt_frac_eqn = (sy latentE_P) / ((sy htFusion) * (sy pcm_mass))
 
 dd4MeltFrac :: DataDefinition
-dd4MeltFrac = mkDD dd4MeltFracQD [koothoor2013] [] "melt_frac"
+dd4MeltFrac = mkDD dd4MeltFracQD [makeCite koothoor2013] [] "melt_frac"
  [makeRef2S dd3HtFusion]
 
 --Need to add units to data definition descriptions

--- a/code/drasil-example/Drasil/SWHS/GenDefs.hs
+++ b/code/drasil-example/Drasil/SWHS/GenDefs.hs
@@ -41,7 +41,7 @@ swhsGDs = [nwtnCooling, rocTempSimp]
 -- FIXME: page reference
 nwtnCooling, rocTempSimp :: GenDefn
 nwtnCooling = gd' nwtnCoolingRC (Just thermal_flux) ([] :: Derivation) 
-  [incroperaEtAl2007 {- +:+ sParen (S "pg. 8") -}] "nwtnCooling" [nwtnCooling_desc]
+  [makeCite incroperaEtAl2007 {- +:+ sParen (S "pg. 8") -}] "nwtnCooling" [nwtnCooling_desc]
 rocTempSimp = gd' rocTempSimpRC (Nothing :: Maybe UnitDefn) roc_temp_simp_deriv [] -- FIXME: no sources
                  "rocTempSimp" [rocTempSimp_desc]
 

--- a/code/drasil-example/Drasil/SWHS/IMods.hs
+++ b/code/drasil-example/Drasil/SWHS/IMods.hs
@@ -36,7 +36,7 @@ eBalanceOnWtr :: InstanceModel
 eBalanceOnWtr = im'' eBalanceOnWtr_rc [qw w_mass, qw htCap_W, qw coil_HTC, qw pcm_SA,
  qw pcm_HTC, qw coil_SA, qw temp_PCM, qw time_final, qw temp_C, qw temp_init]
   [sy temp_init $< sy temp_C] (qw temp_W)
-   [0 $< sy time $< sy time_final] [koothoor2013] eBalanceOnWtrDeriv
+   [0 $< sy time $< sy time_final] [makeCite koothoor2013] eBalanceOnWtrDeriv
    "eBalanceOnWtr" [balWtrDesc]
 
 eBalanceOnWtr_rc :: RelationConcept
@@ -201,7 +201,7 @@ eBalanceOnPCM :: InstanceModel
 eBalanceOnPCM = im'' eBalanceOnPCM_rc [qw temp_melt_P, qw time_final, qw temp_init, qw pcm_SA,
  qw pcm_HTC, qw pcm_mass, qw htCap_S_P, qw htCap_L_P]
   [sy temp_init $< sy temp_melt_P] (qw temp_PCM)
-   [0 $< sy time $< sy time_final] [koothoor2013] eBalanceOnPCMDeriv 
+   [0 $< sy time $< sy time_final] [makeCite koothoor2013] eBalanceOnPCMDeriv 
    "eBalanceOnPCM" [balPCMDesc_note]
 
 eBalanceOnPCM_rc :: RelationConcept
@@ -374,7 +374,7 @@ eBalanceOnPCM_deriv_eqns__im2 = [eBalanceOnPCM_Eqn1, eBalanceOnPCM_Eqn2,
 ---------
 heatEInWtr :: InstanceModel
 heatEInWtr = im'' heatEInWtr_rc [qw temp_init, qw w_mass, qw htCap_W, qw w_mass] 
-  [] (qw w_E) [0 $< sy time $< sy time_final] [koothoor2013] [] "heatEInWtr"
+  [] (qw w_E) [0 $< sy time $< sy time_final] [makeCite koothoor2013] [] "heatEInWtr"
   [htWtrDesc]
 
 heatEInWtr_rc :: RelationConcept
@@ -408,7 +408,7 @@ heatEInPCM :: InstanceModel
 heatEInPCM = im' heatEInPCM_rc [qw temp_melt_P, qw time_final, qw temp_init, qw pcm_SA,
  qw pcm_HTC, qw pcm_mass, qw htCap_S_P, qw htCap_L_P, qw temp_PCM, qw htFusion, qw t_init_melt]
   [sy temp_init $< sy temp_melt_P] (qw pcm_E)
-  [0 $< sy time $< sy time_final] [koothoor2013]
+  [0 $< sy time $< sy time_final] [makeCite koothoor2013]
   "heatEInPCM" [htPCMDesc]
 
 heatEInPCM_rc :: RelationConcept

--- a/code/drasil-lang/Language/Drasil/Chunk/DataDefinition.hs
+++ b/code/drasil-lang/Language/Drasil/Chunk/DataDefinition.hs
@@ -3,20 +3,19 @@ module Language.Drasil.Chunk.DataDefinition where
 
 import Control.Lens(makeLenses, (^.), view)
 import Data.Drasil.IdeaDicts (dataDefn)
-import Language.Drasil.Chunk.Citation (Citation)
 import Language.Drasil.Chunk.CommonIdea (prependAbrv)
 import Language.Drasil.Chunk.Eq (QDefinition, fromEqn, fromEqn')
 import Language.Drasil.Classes.Core (HasUID(uid), HasShortName(shortname),
   HasRefAddress(getRefAdd), HasSymbol(symbol))
-import Language.Drasil.Classes.Document (HasCitation(getCitations))
 import Language.Drasil.Classes (NamedIdea(term), Idea(getA),
   DefiningExpr(defnExpr), Quantity, HasSpace(typ), HasDerivation(derivations),
   HasAdditionalNotes(getNotes), ConceptDomain(cdom), CommonIdea(abrv),
-  Referable(refAdd, renderRef))
+  HasReference(getReferences), Referable(refAdd, renderRef))
 import Language.Drasil.Derivation (Derivation)
 import Language.Drasil.Chunk.UnitDefn (MayHaveUnit(getUnit))
 import Language.Drasil.Expr (Expr)
 import Language.Drasil.Label.Type (LblType(RP), prepend)
+import Language.Drasil.RefProg (Reference)
 import Language.Drasil.Sentence (Sentence(EmptyS))
 import Language.Drasil.ShortName (ShortName, shortname')
 import Language.Drasil.Symbol.Helpers (eqSymb)
@@ -32,7 +31,7 @@ data ScopeType =
 -- It also has attributes like derivation, source, etc.
 data DataDefinition = DatDef { _qd :: QDefinition
                              , _scp :: ScopeType
-                             , _cit :: [Citation]
+                             , _ref :: [Reference]
                              , _deri :: Derivation
                              , lbl :: ShortName
                              , ra :: String
@@ -47,7 +46,7 @@ instance HasSpace           DataDefinition where typ = qd . typ
 instance HasSymbol          DataDefinition where symbol e = symbol (e^.qd)
 instance Quantity           DataDefinition where 
 instance DefiningExpr       DataDefinition where defnExpr = qd . defnExpr
-instance HasCitation        DataDefinition where getCitations = cit
+instance HasReference       DataDefinition where getReferences = ref
 instance Eq                 DataDefinition where a == b = (a ^. uid) == (b ^. uid)
 instance HasDerivation      DataDefinition where derivations = deri
 instance HasAdditionalNotes DataDefinition where getNotes = notes
@@ -61,7 +60,7 @@ instance Referable DataDefinition where
   renderRef l = RP (prepend $ abrv l) (getRefAdd l)
 
 -- | Smart constructor for data definitions 
-mkDD :: QDefinition -> [Citation] -> Derivation -> String -> [Sentence] -> DataDefinition
+mkDD :: QDefinition -> [Reference] -> Derivation -> String -> [Sentence] -> DataDefinition
 mkDD a b c d = DatDef a Global b c (shortname' d) (prependAbrv dataDefn d)
 
 qdFromDD :: DataDefinition -> QDefinition

--- a/code/drasil-lang/Language/Drasil/Chunk/GenDefn.hs
+++ b/code/drasil-lang/Language/Drasil/Chunk/GenDefn.hs
@@ -6,15 +6,14 @@ import Language.Drasil.Classes.Core (HasUID(uid), HasShortName(shortname),
 import Language.Drasil.Classes (NamedIdea(term), Idea(getA),
   Definition(defn), ConceptDomain(cdom), IsUnit,
   ExprRelat(relat), HasDerivation(derivations), Referable(refAdd, renderRef),
-  HasAdditionalNotes(getNotes), CommonIdea(abrv))
-import Language.Drasil.Classes.Document (HasCitation(getCitations))
+  HasAdditionalNotes(getNotes), CommonIdea(abrv), HasReference(getReferences))
 import Data.Drasil.IdeaDicts (gendef)
-import Language.Drasil.Chunk.Citation (Citation) 
 import Language.Drasil.Chunk.CommonIdea (prependAbrv)
 import Language.Drasil.Chunk.Relation (RelationConcept)
 import Language.Drasil.Label.Type (LblType(RP), prepend)
 import Language.Drasil.Derivation (Derivation)
 import Language.Drasil.Chunk.UnitDefn (unitWrapper, UnitDefn, MayHaveUnit(getUnit))
+import Language.Drasil.RefProg (Reference)
 import Language.Drasil.Sentence (Sentence)
 import Language.Drasil.ShortName (ShortName, shortname')
 
@@ -24,7 +23,7 @@ import Control.Lens (makeLenses, view)
 data GenDefn = GD { _relC  :: RelationConcept
                   , gdUnit :: Maybe UnitDefn                  
                   , _deri  :: Derivation
-                  , _cit   :: [Citation]
+                  , _ref   :: [Reference]
                   , _sn    :: ShortName
                   , _ra    :: String -- RefAddr
                   , _notes :: [Sentence]
@@ -38,7 +37,7 @@ instance Definition         GenDefn where defn = relC . defn
 instance ConceptDomain      GenDefn where cdom = cdom . view relC
 instance ExprRelat          GenDefn where relat = relC . relat
 instance HasDerivation      GenDefn where derivations = deri
-instance HasCitation        GenDefn where getCitations = cit
+instance HasReference       GenDefn where getReferences = ref
 instance HasShortName       GenDefn where shortname = view sn
 instance HasRefAddress      GenDefn where getRefAdd = view ra
 instance HasAdditionalNotes GenDefn where getNotes = notes
@@ -49,9 +48,9 @@ instance Referable          GenDefn where
   renderRef l = RP (prepend $ abrv l) (getRefAdd l)
 
 gd' :: (IsUnit u) => RelationConcept -> Maybe u ->
-  Derivation -> [Citation] -> String -> [Sentence] -> GenDefn
-gd' r u derivs ref sn_ = 
-  GD r (fmap unitWrapper u) derivs ref (shortname' sn_) (prependAbrv gendef sn_)
+  Derivation -> [Reference] -> String -> [Sentence] -> GenDefn
+gd' r u derivs refs sn_ = 
+  GD r (fmap unitWrapper u) derivs refs (shortname' sn_) (prependAbrv gendef sn_)
 
-gd'' :: RelationConcept -> [Citation] -> String -> [Sentence] -> GenDefn
-gd'' r ref sn_ = GD r Nothing  [] ref (shortname' sn_) (prependAbrv gendef sn_)
+gd'' :: RelationConcept -> [Reference] -> String -> [Sentence] -> GenDefn
+gd'' r refs sn_ = GD r Nothing  [] refs (shortname' sn_) (prependAbrv gendef sn_)

--- a/code/drasil-lang/Language/Drasil/Chunk/InstanceModel.hs
+++ b/code/drasil-lang/Language/Drasil/Chunk/InstanceModel.hs
@@ -7,15 +7,13 @@ module Language.Drasil.Chunk.InstanceModel
   ) where
 
 import Data.Drasil.IdeaDicts (instanceMod)
-import Language.Drasil.Chunk.Citation (Citation)
 import Language.Drasil.Chunk.CommonIdea (prependAbrv)
 import Language.Drasil.Chunk.Relation (RelationConcept)
 import Language.Drasil.Chunk.Quantity (QuantityDict)
 import Language.Drasil.Classes.Core (HasUID(uid), HasShortName(shortname),
   HasRefAddress(getRefAdd), HasSymbol(symbol))
-import Language.Drasil.Classes.Document (HasCitation(getCitations))
 import Language.Drasil.Classes (NamedIdea(term), Idea(getA),
-  Quantity, HasSpace(typ),
+  Quantity, HasSpace(typ), HasReference(getReferences),
   HasDerivation(derivations),  HasAdditionalNotes(getNotes), ExprRelat(relat),
   ConceptDomain(cdom), CommonIdea(abrv), Definition(defn),
   Referable(refAdd, renderRef))
@@ -23,6 +21,7 @@ import Language.Drasil.Chunk.UnitDefn (MayHaveUnit(getUnit))
 import Language.Drasil.Derivation (Derivation)
 import Language.Drasil.Label.Type (LblType(RP), prepend)
 import Language.Drasil.Expr (Relation)
+import Language.Drasil.RefProg (Reference)
 import Language.Drasil.Sentence (Sentence)
 import Language.Drasil.ShortName (ShortName, shortname')
 
@@ -44,7 +43,7 @@ data InstanceModel = IM { _rc :: RelationConcept
                         , _inCons :: InputConstraints
                         , _imOutput :: Output
                         , _outCons :: OutputConstraints
-                        , _cit :: [Citation]
+                        , _ref :: [Reference]
                         , _deri :: Derivation
                         ,  lb :: ShortName
                         ,  ra :: String
@@ -59,7 +58,7 @@ instance Definition         InstanceModel where defn = rc . defn
 instance ConceptDomain      InstanceModel where cdom = cdom . view rc
 instance ExprRelat          InstanceModel where relat = rc . relat
 instance HasDerivation      InstanceModel where derivations = deri
-instance HasCitation        InstanceModel where getCitations = cit
+instance HasReference       InstanceModel where getReferences = ref
 instance HasShortName       InstanceModel where shortname = lb
 instance HasRefAddress      InstanceModel where getRefAdd = ra
 instance HasAdditionalNotes InstanceModel where getNotes = notes
@@ -74,12 +73,12 @@ instance Referable          InstanceModel where
 
 -- | Smart constructor for instance models; no derivations
 im' :: RelationConcept -> Inputs -> InputConstraints -> Output -> 
-  OutputConstraints -> [Citation] -> String -> [Sentence] -> InstanceModel
+  OutputConstraints -> [Reference] -> String -> [Sentence] -> InstanceModel
 im' rcon i ic o oc src lbe =
   IM rcon i ic o oc src [] (shortname' lbe) (prependAbrv instanceMod lbe)
 
 -- | im but with everything defined
 im'' :: RelationConcept -> Inputs -> InputConstraints -> Output -> 
-  OutputConstraints -> [Citation] -> Derivation -> String -> [Sentence] -> InstanceModel
+  OutputConstraints -> [Reference] -> Derivation -> String -> [Sentence] -> InstanceModel
 im'' rcon i ic o oc src der sn = 
   IM rcon i ic o oc src der (shortname' sn) (prependAbrv instanceMod sn)

--- a/code/stable/gamephys/Website/Chipmunk_SRS.html
+++ b/code/stable/gamephys/Website/Chipmunk_SRS.html
@@ -1182,6 +1182,9 @@ The net force <em><b>F</b></em> (N) on a rigid body is proportional to the accel
 Source
 </th>
 <td>
+<p class="paragraph">
+
+</p>
 </td>
 </tr>
 <tr>
@@ -1248,6 +1251,9 @@ Every action has an equal and opposite reaction. In other words, the force <em><
 Source
 </th>
 <td>
+<p class="paragraph">
+
+</p>
 </td>
 </tr>
 <tr>
@@ -1350,6 +1356,9 @@ Two rigid bodies in the universe attract each other with a force <em><b>F</b></e
 Source
 </th>
 <td>
+<p class="paragraph">
+
+</p>
 </td>
 </tr>
 <tr>
@@ -1422,6 +1431,9 @@ The linear velocity <em><b>v</b><sub>B</sub></em> (m/s) of any point B in a rigi
 Source
 </th>
 <td>
+<p class="paragraph">
+
+</p>
 </td>
 </tr>
 <tr>
@@ -1491,6 +1503,9 @@ The net torque <em>τ</em> (N&sdot;m) on a rigid body is proportional to its ang
 Source
 </th>
 <td>
+<p class="paragraph">
+
+</p>
 </td>
 </tr>
 <tr>


### PR DESCRIPTION
As part of #947, DDs, GD, and IMs now take `[Reference]` instead of `[Citation]`, since `Reference`s are a superset of `Citation`s. (TMs already used `[Reference]` since there is a TM in an example with a `Reference` that is an external link, not a `Citation`.)