### PR TITLE
[Small PR] Moved brackets to avoid $ in drasil-code

### DIFF
--- a/code/drasil-code/Language/Drasil/Code/Imperative/Build/Import.hs
+++ b/code/drasil-code/Language/Drasil/Code/Imperative/Build/Import.hs
@@ -20,12 +20,12 @@ instance RuleTransformer CodeHarness where
     mkRule "build" (map (const $ renderBuildName c m nameOpts nm) $ maybeToList $
       buildConfig c) []
     ] ++
-    (maybe [] (\(BuildConfig comp bt) -> [
+    maybe [] (\(BuildConfig comp bt) -> [
     mkFile (renderBuildName c m nameOpts nm) (map fst code) [
       mkCheckedCommand $ unwords $ comp (getCompilerInput bt c m co) $
         renderBuildName c m nameOpts nm
       ]
-    ]) $ buildConfig c) ++ [
+    ]) (buildConfig c) ++ [
     mkRule "run" ["build"] [
       mkCheckedCommand $ (buildRunTarget (renderBuildName c m no nm) ty) ++ " $(RUNARGS)"
       ]

--- a/code/drasil-code/Language/Drasil/Code/Imperative/Import.hs
+++ b/code/drasil-code/Language/Drasil/Code/Imperative/Import.hs
@@ -370,8 +370,8 @@ variable s' = do
       doit :: String -> Reader State Value
       doit s | member s mm =
         maybe (error "impossible") (convExpr . codeEquat) (Map.lookup s mm) --extvar "Constants" s
-             | s `elem` (map codeName $ inputs cs) = return $ (var "inParams")$->(var s)
-             | otherwise                        = return $ var s
+             | s `elem` map codeName (inputs cs) = return $ (var "inParams")$->(var s)
+             | otherwise                         = return $ var s
   doit s'
   
 fApp :: String -> [Value] -> Reader State Value
@@ -461,7 +461,7 @@ convExpr  (FCall (C c) x)  = do
 convExpr FCall{}   = return $ litString "**convExpr :: FCall unimplemented**"
 convExpr (UnaryOp o u) = fmap (unop o) (convExpr u)
 convExpr (BinaryOp Frac (Int a) (Int b)) =
-  return $ (litFloat $ fromIntegral a) #/ (litFloat $ fromIntegral b) -- hack to deal with integer division
+  return $ litFloat (fromIntegral a) #/ litFloat (fromIntegral b) -- hack to deal with integer division
 convExpr  (BinaryOp o a b)  = liftM2 (bfunc o) (convExpr a) (convExpr b)
 convExpr  (Case l)      = doit l -- FIXME this is sub-optimal
   where
@@ -626,7 +626,7 @@ genDataFunc nameTitle ddef = do
         lineData (Straight p) lineNo = patternData p lineNo (litInt 0)
         lineData (Repeat p Nothing) lineNo = do
           pat <- patternData p lineNo v_j
-          return [ for (varDecDef l_j int (litInt 0)) (v_j ?< (v_linetokens I.$.listSize #/ (litInt $ toInteger $ length p))I.$.(cast int float)) (v_j &++)
+          return [ for (varDecDef l_j int (litInt 0)) (v_j ?< (v_linetokens I.$.listSize #/ litInt (toInteger $ length p))I.$.(cast int float)) (v_j &++)
               ( body pat )
             ]
         lineData (Repeat p (Just numPat)) lineNo = do
@@ -664,13 +664,13 @@ genDataFunc nameTitle ddef = do
           where len = toInteger $ length indx
         checkIndex' [] _ _ _ _ _ = []
         checkIndex' ((Explicit i):is) n l p v s =
-          ( while (v I.$.listSize ?<= (litInt i)) $ body [ valStmt $ v I.$.(listExtend $ listType' s n) ] )
-          : checkIndex' is (n-1) l p (v I.$.(listAccess $ litInt i)) s
+            while (v I.$.listSize ?<= (litInt i)) (body [ valStmt $ v I.$. listExtend (listType' s n) ])
+          : checkIndex' is (n-1) l p (v I.$. listAccess (litInt i)) s
         checkIndex' (WithLine:is) n l p v s =
-          ( while (v I.$.listSize ?<= l) $ body [ valStmt $ v I.$.(listExtend $ listType' s n ) ] )
+            while (v I.$.listSize ?<= l)          (body [ valStmt $ v I.$. listExtend (listType' s n) ])
           : checkIndex' is (n-1) l p (v I.$.(listAccess l)) s
         checkIndex' (WithPattern:is) n l p v s =
-          ( while (v I.$.listSize ?<= p) $ body [ valStmt $ v I.$.(listExtend $ listType' s n ) ] )
+            while (v I.$.listSize ?<= p)          (body [ valStmt $ v I.$. listExtend (listType' s n) ])
           : checkIndex' is (n-1) l p (v I.$.(listAccess p)) s
         ---------------
         listType :: C.CodeType -> Integer -> I.StateType

--- a/code/drasil-code/Language/Drasil/Code/Imperative/LanguageRenderer.hs
+++ b/code/drasil-code/Language/Drasil/Code/Imperative/LanguageRenderer.hs
@@ -207,7 +207,7 @@ bodyDocD c = (vibmap bdc) . filter (not . isEmpty . bdc)
 blockDocD :: Config -> Block -> Doc
 blockDocD c (Block ss) = vmap (statementDoc c NoLoop) statements
     where docOf = statementDoc c NoLoop
-          notNullStatement s = (not $ isEmpty $ docOf s) && (render (docOf s) /= render (end c NoLoop))
+          notNullStatement s = not (isEmpty $ docOf s) && (render (docOf s) /= render (end c NoLoop))
           statements = filter notNullStatement ss
     
 callFuncParamListD :: Config -> [Value] -> Doc

--- a/code/drasil-code/Language/Drasil/Code/Imperative/LanguageRenderer/CSharpRenderer.hs
+++ b/code/drasil-code/Language/Drasil/Code/Imperative/LanguageRenderer/CSharpRenderer.hs
@@ -158,7 +158,7 @@ complexDoc' c (ReadLine f Nothing) = statementDoc c NoLoop (valStmt $ f$.(Func "
 complexDoc' c (ReadLine f (Just v)) = statementDoc c NoLoop (v &= f$.(Func "ReadLine" []))
 complexDoc' c (ReadAll f v) = 
   bodyDoc c $ oneLiner $
-    while ((?!) f$->(var "EndOfStream")) (oneLiner $ valStmt $ v$.(listAppend $ f$.(Func "ReadLine" [])))
+    while ((?!) f$->(var "EndOfStream")) (oneLiner $ valStmt $ v $. listAppend (f $.(Func "ReadLine" [])))
 
 complexDoc' c (ListSlice st vnew vold b e s) = let l_temp = "temp"
                                                    v_temp = var l_temp

--- a/code/drasil-code/Language/Drasil/Code/Imperative/LanguageRenderer/CppRenderer.hs
+++ b/code/drasil-code/Language/Drasil/Code/Imperative/LanguageRenderer/CppRenderer.hs
@@ -384,7 +384,7 @@ complexDoc' c (StringSplit vnew s d) =    let l_ss = "ss"
   
   
 ioDoc' :: Config -> IOSt -> Doc
-ioDoc' c (OpenFile f n m) = valueDoc c f <> dot <> text "open" <> (parens $ valueDoc c n <> text ", " <> modeType m) <> semi
+ioDoc' c (OpenFile f n m) = valueDoc c f <> dot <> text "open" <> parens (valueDoc c n <> text ", " <> modeType m) <> semi
   where modeType Read = text "std::fstream::in"
         modeType Write = text "std::fstream::out | std::fstream::app"
 ioDoc' c io = ioDocD c io

--- a/code/drasil-code/Language/Drasil/Code/Imperative/LanguageRenderer/JavaRenderer.hs
+++ b/code/drasil-code/Language/Drasil/Code/Imperative/LanguageRenderer/JavaRenderer.hs
@@ -232,7 +232,7 @@ complexDoc' :: Config -> Complex -> Doc
 complexDoc' c (ReadLine f Nothing) = statementDoc c NoLoop (valStmt $ f$.(Func "nextLine" []))
 complexDoc' c (ReadLine f (Just v)) = statementDoc c NoLoop (v &= f$.(Func "nextLine" []))
 complexDoc' c (ReadAll f v) = statementDoc c NoLoop $
-  while (f$.(Func "hasNextLine" [])) (oneLiner $ valStmt $ v$.(listAppend $ f$.(Func "nextLine" [])))    
+  while (f$.(Func "hasNextLine" [])) (oneLiner $ valStmt $ v $. listAppend (f $.(Func "nextLine" [])))    
 complexDoc' c (ListSlice st vnew vold b e s) = let l_temp = "temp"
                                                    v_temp = var l_temp
                                                    l_i = "i_temp"

--- a/code/drasil-code/Language/Drasil/Code/Imperative/LanguageRenderer/ObjectiveCRenderer.hs
+++ b/code/drasil-code/Language/Drasil/Code/Imperative/LanguageRenderer/ObjectiveCRenderer.hs
@@ -372,7 +372,7 @@ destructor _ vs =
         releaseVars = concatMap checkDelPriority vs
         releaseStatements = concatMap (\(StateVar lbl _ _ _ _) -> [ValState $ (var lbl $. Func release [])]) releaseVars
         releaseBlock = if null releaseVars then [] else [Block releaseStatements]
-        deallocBody = releaseBlock ++ (oneLiner $ ValState (super $. Func dealloc []))
+        deallocBody = releaseBlock ++ oneLiner (ValState (super $. Func dealloc []))
     in Method dealloc Public Dynamic Void [] deallocBody
 
 alloc :: Config -> StateType -> Doc

--- a/code/drasil-code/Language/Drasil/Code/Imperative/LanguageRenderer/PythonRenderer.hs
+++ b/code/drasil-code/Language/Drasil/Code/Imperative/LanguageRenderer/PythonRenderer.hs
@@ -119,17 +119,17 @@ pytop _ _ _ m =
     text "import math" 
   ] 
   $+$
-  (vcat $ map (\x -> text "import" <+> text x) (libs m))
+  vcat (map (\x -> text "import" <+> text x) (libs m))
       
 
 
 pybody :: Config -> FileType -> Label -> Module -> Doc
 pybody c f p (Mod _ _ vs fs cs) = 
-  (vcat $ map (statementDoc c NoLoop . DeclState) vs)
+  vcat (map (statementDoc c NoLoop . DeclState) vs)
   $+$ blank $+$
   functionListDoc c f p fs
   $+$ blank $+$
-  (vcat $ intersperse blank (map (classDoc c f p) (fixCtorNames initName cs))) 
+  vcat (intersperse blank (map (classDoc c f p) (fixCtorNames initName cs))) 
 
 -- code doc functions
 binOpDoc' :: BinaryOp -> Doc
@@ -301,8 +301,8 @@ complexDoc' c (ReadLine f (Just v)) = statementDoc c NoLoop (v &= objMethodCall 
 complexDoc' c (ReadLine f Nothing)  = statementDoc c NoLoop (valStmt $ objMethodCall f "readline" [])
 complexDoc' c (ReadAll f v) = statementDoc c NoLoop (v &= objMethodCall f "readlines" [])
 complexDoc' c (ListSlice _ vnew vold b e s) = 
-  valueDoc c vnew <+> equals <+> valueDoc c vold <> (brackets $ 
-  getVal b <> colon <> getVal e <> colon <> getVal s)
+  valueDoc c vnew <+> equals <+> valueDoc c vold <> 
+  brackets (getVal b <> colon <> getVal e <> colon <> getVal s)
     where getVal Nothing  = empty
           getVal (Just v) = valueDoc c v
 complexDoc' c (StringSplit vnew s d) = 

--- a/code/drasil-code/Language/Drasil/Code/Imperative/Parsers/ConfigParser.hs
+++ b/code/drasil-code/Language/Drasil/Code/Imperative/Parsers/ConfigParser.hs
@@ -75,7 +75,7 @@ parseConfig :: Parser Configuration
 parseConfig = do
     whiteSpace
     config <- permute $ Config <$$> (try parseLang)
-                               <|?> (Nothing, Just `liftM` (try $ parseOption "ExampleImplementation"))
+                               <|?> (Nothing, Just `liftM` try (parseOption "ExampleImplementation"))
                                <||> (try parseOptions)
     -- parsing the options above always fails (puts Nothing in all Options fields, even if they have been specified), for some reason. Fix it by trying again:
     permute $ Config (genLang config) (exImp config) <$$> try parseOptions
@@ -88,10 +88,10 @@ parseLang = do
     identifier
 
 parseOptions :: Parser Options
-parseOptions = permute $ Options <$?> (Nothing, Just `liftM` (try $ parseOption "JavaListType"))
-                                 <|?> (Nothing, Just `liftM` (try $ parseOption "CppListType"))
-                                 <|?> (Nothing, Just `liftM` (try $ parseOption "ObjCStaticListType"))
-                                 <|?> (Nothing, Just `liftM` (try $ parseOption "GOOLHsModule"))
+parseOptions = permute $ Options <$?> (Nothing, Just `liftM` try (parseOption "JavaListType"))
+                                 <|?> (Nothing, Just `liftM` try (parseOption "CppListType"))
+                                 <|?> (Nothing, Just `liftM` try (parseOption "ObjCStaticListType"))
+                                 <|?> (Nothing, Just `liftM` try (parseOption "GOOLHsModule"))
 
 parseOption :: String -> Parser String
 parseOption opt = do


### PR DESCRIPTION
As per #1249, fixed the "Move brackets to avoid $" in `drasil-code`.