### PR TITLE
[Small PR] Moved brackets to avoid $ in drasil-printers

### DIFF
--- a/code/drasil-printers/Language/Drasil/HTML/Helpers.hs
+++ b/code/drasil-printers/Language/Drasil/HTML/Helpers.hs
@@ -132,5 +132,5 @@ cases ps p_expr = render $ (span_tag ["casebr"] "{" $$ div_tag ["cases"]
 makeCases :: [(Expr,Expr)] -> (Expr -> String) -> Doc                 
 makeCases [] _ = empty
 makeCases (p:ps) p_expr = ((span_tag [] (p_expr (fst p) ++ " , " ++
-                            (render $ span_tag ["case"] (p_expr (snd p))))) $$
+                            render (span_tag ["case"] (p_expr (snd p))))) $$
                             makeCases ps p_expr)

--- a/code/drasil-printers/Language/Drasil/HTML/Print.hs
+++ b/code/drasil-printers/Language/Drasil/HTML/Print.hs
@@ -131,7 +131,7 @@ uSymb (L.US ls) = formatu t b
     formatu :: [(L.Symbol,Integer)] -> [(L.Symbol,Integer)] -> String
     formatu [] l = line l
     formatu l [] = intercalate "&sdot;" $ map pow l
-    formatu nu de = line nu ++ "/" ++ (line $ map (second negate) de)
+    formatu nu de = line nu ++ "/" ++ line (map (second negate) de)
     line :: [(L.Symbol,Integer)] -> String
     line []  = ""
     line [x] = pow x
@@ -432,7 +432,7 @@ bookAPA i = bookMLA i --Most items are rendered the same as L.MLA
 bookChicago :: CiteField -> Doc
 bookChicago (Author   p) = p_spec (rendPeople L.rendPersLFM'' p) --L.APA uses middle initals rather than full name
 bookChicago p@(Pages  _) = bookAPA p
-bookChicago (Editor   p) = dot $ p_spec (foldlList $ map (S . L.nameStr) p) <> (text $ toPlural p " ed")
+bookChicago (Editor   p) = dot $ p_spec (foldlList $ map (S . L.nameStr) p) <> text (toPlural p " ed")
 bookChicago i = bookMLA i --Most items are rendered the same as L.MLA
 
 -- for article renderings

--- a/code/drasil-printers/Language/Drasil/Printing/Import.hs
+++ b/code/drasil-printers/Language/Drasil/Printing/Import.hs
@@ -327,7 +327,7 @@ createLayout sm = map (sec sm 0)
 sec :: PrintingInformation -> Int -> Section -> T.LayoutObj
 sec sm depth x@(Section titleLb contents _) = --FIXME: should ShortName be used somewhere?
   let ref = P.S (refAdd x) in
-  T.HDiv [(concat $ replicate depth "sub") ++ "section"]
+  T.HDiv [concat (replicate depth "sub") ++ "section"]
   (T.Header depth (spec sm titleLb) ref :
    map (layout sm depth) contents) ref
 

--- a/code/drasil-printers/Language/Drasil/TeX/Helpers.hs
+++ b/code/drasil-printers/Language/Drasil/TeX/Helpers.hs
@@ -65,13 +65,13 @@ command3 s a0 a1 a2 = pure $ (H.bslash TP.<> text s) TP.<> H.br a0 TP.<> H.br a1
 -- Encapsulate environments
 mkEnv :: String -> D -> D
 mkEnv nm d =
-  (pure $ text ("\\begin" ++ H.brace nm)) $+$ 
+  pure (text ("\\begin" ++ H.brace nm)) $+$ 
   d $+$
-  (pure $ text ("\\end" ++ H.brace nm))
+  pure (text ("\\end" ++ H.brace nm))
 
 -- for defining (LaTeX) macros
 comm :: String -> String -> Maybe String -> D
-comm b1 b2 s1 = command0 "newcommand" <> (pure $ H.br ("\\" ++ b1) TP.<> 
+comm b1 b2 s1 = command0 "newcommand" <> pure (H.br ("\\" ++ b1) TP.<> 
   maybe TP.empty H.sq s1 TP.<> H.br b2)
 
 -- this one is special enough, let this sub-optimal implementation stand
@@ -96,7 +96,7 @@ genSec d
 ref, sref, hyperref, externalref, snref :: String -> D -> D
 sref         = if numberedSections then ref else hyperref
 ref      t   = custRef (t ++ "~\\ref")
-hyperref t x = command0 "hyperref" <> sq x <> br ((pure $ text (t ++ "~")) <> x)
+hyperref t x = command0 "hyperref" <> sq x <> br (pure (text (t ++ "~")) <> x)
 externalref t x = command0 "hyperref" <> br (pure $ text t) <> br empty <>
   br empty <> br x
 snref    r t = command0 "hyperref" <> sq (pure $ text r) <> br t
@@ -105,7 +105,7 @@ href :: String -> String -> D
 href = command2 "href"
 
 custRef :: String -> D -> D
-custRef t x = (pure $ text t) <> br x
+custRef t x = pure (text t) <> br x
 
 cite :: D -> D
 cite = custRef "\\cite"
@@ -195,7 +195,7 @@ hyperConfig :: D
 hyperConfig = command "hypersetup" hyperSettings
 
 useTikz :: D
-useTikz = usepackage "luatex85" $+$ (pure $ text "\\def") <>
+useTikz = usepackage "luatex85" $+$ pure (text "\\def") <>
   command "pgfsysdriver" "pgfsys-pdftex.def" $+$
   -- the above is a workaround..  temporary until TeX packages have been fixed
   usepackage "tikz" $+$ command "usetikzlibrary" "arrows.meta" $+$

--- a/code/drasil-printers/Language/Drasil/TeX/Preamble.hs
+++ b/code/drasil-printers/Language/Drasil/TeX/Preamble.hs
@@ -76,13 +76,13 @@ addDef SymbDescriptionP2 = command1o "setlist" (Just "symbDescription") "noitems
 genPreamble :: [LayoutObj] -> D
 genPreamble los = let (pkgs, defs) = parseDoc los
   in docclass (Just $ (show fontSize) ++ "pt") "article" %%
-     (vcat $ map addPackage pkgs) %% (vcat $ map addDef defs)
+     vcat (map addPackage pkgs) %% vcat (map addDef defs)
 
 parseDoc :: [LayoutObj] -> ([Package], [Def])
 parseDoc los' = 
   ([FontSpec, FullPage, HyperRef, AMSMath, AMSsymb, Mathtools, Unicode] ++ 
-   (nub $ concatMap fst res)
-  , [SymbDescriptionP1, SymbDescriptionP2, SetMathFont] ++ (nub $ concatMap snd res))
+   nub (concatMap fst res)
+  , [SymbDescriptionP1, SymbDescriptionP2, SetMathFont] ++ nub (concatMap snd res))
   where 
     res = map parseDoc' los'
     parseDoc' :: LayoutObj -> ([Package], [Def])

--- a/code/drasil-printers/Language/Drasil/TeX/Print.hs
+++ b/code/drasil-printers/Language/Drasil/TeX/Print.hs
@@ -186,7 +186,7 @@ p_in (x:xs) = p_in [x] ++ " & " ++ p_in xs
 
 cases :: [(Expr,Expr)] -> String
 cases []     = error "Attempt to create case expression without cases"
-cases [p]    = (p_expr $ fst p) ++ ", & " ++ p_expr (snd p)
+cases [p]    = p_expr (fst p) ++ ", & " ++ p_expr (snd p)
 cases (p:ps) = cases [p] ++ "\\\\\n" ++ cases ps
 
 -----------------------------------------------------------------
@@ -196,15 +196,15 @@ cases (p:ps) = cases [p] ++ "\\\\\n" ++ cases ps
 makeTable :: [[Spec]] -> D -> Bool -> D -> D
 makeTable lls r bool t =
   pure (text ("\\begin{" ++ ltab ++ "}" ++ (brace . unwords . anyBig) lls))
-  %% (pure (text "\\toprule"))
+  %% pure (text "\\toprule")
   %% makeRows [head lls]
-  %% (pure (text "\\midrule"))
+  %% pure (text "\\midrule")
   %% pure (text "\\endhead")
   %% makeRows (tail lls)
-  %% (pure (text "\\bottomrule"))
+  %% pure (text "\\bottomrule")
   %% (if bool then caption t else caption empty)
   %% label r
-  %% (pure $ text ("\\end{" ++ ltab ++ "}"))
+  %% pure (text ("\\end{" ++ ltab ++ "}"))
   where ltab = tabType $ anyLong lls
         tabType True  = ltabu
         tabType False = ltable
@@ -333,18 +333,18 @@ makeDefTable _ [] _ = error "Trying to make empty Data Defn"
 makeDefTable sm ps l = vcat [
   pure $ text 
   $ "\\begin{tabular}{p{"++show colAwidth++"\\textwidth} p{"++show colBwidth++"\\textwidth}}",
-  (pure $ text "\\toprule \\textbf{Refname} & \\textbf{") <> l <> (pure $ text "}"), --shortname instead of refname?
-  (pure $ text "\\phantomsection "), label l,
+  pure (text "\\toprule \\textbf{Refname} & \\textbf{") <> l <> pure (text "}"), --shortname instead of refname?
+  pure (text "\\phantomsection "), label l,
   makeDRows sm ps,
   pure $ dbs <+> text ("\\bottomrule \\end{tabular}")
   ]
 
 makeDRows :: PrintingInformation -> [(String,[LayoutObj])] -> D
 makeDRows _  []         = error "No fields to create Defn table"
-makeDRows sm [(f,d)]    = dBoilerplate %% (pure $ text (f ++ " & ")) <>
-  (vcat $ map (`lo` sm) d)
-makeDRows sm ((f,d):ps) = dBoilerplate %% ((pure $ text (f ++ " & ")) <>
-  (vcat $ map (`lo` sm) d))
+makeDRows sm [(f,d)]    = dBoilerplate %% pure (text (f ++ " & ")) <>
+  vcat (map (`lo` sm) d)
+makeDRows sm ((f,d):ps) = dBoilerplate %% (pure (text (f ++ " & ")) <>
+  vcat (map (`lo` sm) d))
                        %% makeDRows sm ps
 dBoilerplate :: D
 dBoilerplate = pure $ dbs <+> text "\\midrule" <+> dbs
@@ -378,7 +378,7 @@ lspec (S s) = pure $ text s
 lspec r = spec r
 
 mlref :: Maybe Label -> D
-mlref = maybe empty $ ((<>) $ pure $ text "\\phantomsection") . label . lspec
+mlref = maybe empty $ (<>) (pure $ text "\\phantomsection") . label . lspec
 
 p_item :: ItemType -> D
 p_item (Flat s) = item $ spec s
@@ -390,7 +390,7 @@ sim_item = map (\(x,y,l) -> item' (spec (x :+: S ":") <> mlref l) $ sp_item y)
         sp_item (Nested t s) = vcat [spec t, makeList s]
 
 def_item :: [(Spec, ItemType,Maybe Label)] -> [D]
-def_item = map (\(x,y,l) -> item $ mlref l <> (spec $ x :+: S " is the " :+: d_item y))
+def_item = map (\(x,y,l) -> item $ mlref l <> spec (x :+: S " is the " :+: d_item y))
   where d_item (Flat s) = s
         d_item (Nested _ _) = error "Cannot use sublists in definitions"
 -----------------------------------------------------------------
@@ -437,15 +437,15 @@ makeGraph ps w h c l =
   vcat $ [ centering,
            pure $ text "\\begin{adjustbox}{max width=\\textwidth}",
            pure $ text "\\begin{tikzpicture}[>=latex,line join=bevel]",
-           (pure $ text "\\tikzstyle{n} = [draw, shape=rectangle, ") <>
-             w <> h <> (pure $ text "font=\\Large, align=center]"),
+           pure (text "\\tikzstyle{n} = [draw, shape=rectangle, ") <>
+             w <> h <> pure (text "font=\\Large, align=center]"),
            pure $ text "\\begin{dot2tex}[dot, codeonly, options=-t raw]",
            pure $ text "digraph G {",
            pure $ text "graph [sep = 0. esep = 0, nodesep = 0.1, ranksep = 2];",
            pure $ text "node [style = \"n\"];"
          ]
-     ++  map (\(a,b) -> (q a) <> (pure $ text " -> ") <> (q b) <>
-                (pure $ text ";")) ps
+     ++  map (\(a,b) -> (q a) <> pure (text " -> ") <> (q b) <>
+                pure (text ";")) ps
      ++  [ pure $ text "}",
            pure $ text "\\end{dot2tex}",
            pure $ text "\\end{tikzpicture}",
@@ -453,7 +453,7 @@ makeGraph ps w h c l =
            caption c,
            label l
          ]
-  where q x = (pure $ text "\"") <> x <> (pure $ text "\"")
+  where q x = pure (text "\"") <> x <> pure (text "\"")
 
 ---------------------------
 -- Bibliography Printing --


### PR DESCRIPTION
As per #1249, fixed the "Move brackets to avoid $" in `drasil-printers`.