### PR TITLE
Quote Variables

### DIFF
--- a/code/Makefile
+++ b/code/Makefile
@@ -77,10 +77,10 @@ debug: EXECARGS+=$(PROFEXEC)
 debug: test
 
 check_stack:
-	 @MIN_STACK_VER=$(MIN_STACK_VER) CACHED_MSV_FILE=$(CACHED_MSV_FILE) $(SHELL) $(SCRIPT_FOLDER)check_stack.sh
+	 @MIN_STACK_VER=$(MIN_STACK_VER) CACHED_MSV_FILE=$(CACHED_MSV_FILE) "$(SHELL)" $(SCRIPT_FOLDER)check_stack.sh
 
 $(filter %$(BUILD_P_SUFFIX), $(BUILD_PACKAGES)): %$(BUILD_P_SUFFIX): check_stack
-	stack install -j3 $(stackArgs) drasil-$* --dump-logs --interleaved-output
+	stack install -j3 $(stackArgs) "drasil-$*" --dump-logs --interleaved-output
 
 packages: $(BUILD_PACKAGES)
 
@@ -95,13 +95,13 @@ $(filter %$(GEN_E_SUFFIX), $(GEN_EXAMPLES)): %$(GEN_E_SUFFIX): example$(BUILD_P_
 %$(TEST_E_SUFFIX): EDIR=$($(EXAMPLE)_DIR)
 $(filter %$(TEST_E_SUFFIX), $(TEST_EXAMPLES)): %$(TEST_E_SUFFIX): %$(GEN_E_SUFFIX)
 	@mkdir -p $(LOG_FOLDER)
-	- $(DIFF) ./stable/$*/ $(BUILD_FOLDER)$(EDIR)/ > $(LOG_FOLDER)$(EDIR)$(LOG_SUFFIX) 2>&1
+	- $(DIFF) "stable/$*/" $(BUILD_FOLDER)$(EDIR)/ > $(LOG_FOLDER)$(EDIR)$(LOG_SUFFIX) 2>&1
 
 test: $(GEN_EXAMPLES) $(TEST_EXAMPLES)
 	@echo ----------------------------
 	@echo Make complete, checking logs
 	@echo ----------------------------
-	@LOG_FOLDER=$(LOG_FOLDER) LOG_SUFFIX=$(LOG_SUFFIX) NOISY=$(NOISY) $(SHELL) $(SCRIPT_FOLDER)log_check.sh
+	@LOG_FOLDER=$(LOG_FOLDER) LOG_SUFFIX=$(LOG_SUFFIX) NOISY=$(NOISY) "$(SHELL)" $(SCRIPT_FOLDER)log_check.sh
 
 $(filter %$(MOVE_DF_E_SUFFIX), $(MOVE_DF_EXAMPLES)): %$(MOVE_DF_E_SUFFIX): %$(GEN_E_SUFFIX)
 
@@ -114,26 +114,26 @@ $(GLASSBR_EXE)$(MOVE_DF_E_SUFFIX): $(GLASSBR_EXE)$(GEN_E_SUFFIX)
 prog: $(MOVE_DF_EXAMPLES)
 
 $(filter %$(DOC_P_SUFFIX), $(DOC_PACKAGES)): %$(DOC_P_SUFFIX): check_stack
-	stack haddock drasil-$* $(haddockArgs)
+	stack haddock "drasil-$*" $(haddockArgs)
 
 docs: $(DOC_PACKAGES)
 
 %$(TEX_E_SUFFIX): EXAMPLE=$(shell echo $* | tr a-z A-Z)
 %$(TEX_E_SUFFIX): EDIR=$($(EXAMPLE)_DIR)
 $(filter %$(TEX_E_SUFFIX), $(TEX_EXAMPLES)): %$(TEX_E_SUFFIX): %$(GEN_E_SUFFIX)
-	EDIR=$(EDIR) BUILD_FOLDER=$(BUILD_FOLDER) SUMMARIZE_TEX=$(SUMMARIZE_TEX) MAKE=$(MAKE) $(SHELL) $(SCRIPT_FOLDER)tex_build.sh
+	EDIR=$(EDIR) BUILD_FOLDER=$(BUILD_FOLDER) SUMMARIZE_TEX=$(SUMMARIZE_TEX) MAKE="$(MAKE)" "$(SHELL)" $(SCRIPT_FOLDER)tex_build.sh
 
 tex: $(TEX_EXAMPLES)
 
 %$(CODE_E_SUFFIX): EXAMPLE=$(shell echo $* | tr a-z A-Z)
 %$(CODE_E_SUFFIX): EDIR=$($(EXAMPLE)_DIR)
 $(filter %$(CODE_E_SUFFIX), $(CODE_EXAMPLES)): %$(CODE_E_SUFFIX): %$(MOVE_DF_E_SUFFIX)
-	EDIR=$(EDIR) BUILD_FOLDER=$(BUILD_FOLDER) EXAMPLE_CODE_SUBFOLDER=$(EXAMPLE_CODE_SUBFOLDER) MAKE=$(MAKE) $(SHELL) $(SCRIPT_FOLDER)code_build.sh
+	EDIR=$(EDIR) BUILD_FOLDER=$(BUILD_FOLDER) EXAMPLE_CODE_SUBFOLDER=$(EXAMPLE_CODE_SUBFOLDER) MAKE="$(MAKE)" "$(SHELL)" $(SCRIPT_FOLDER)code_build.sh
 
 code: $(CODE_EXAMPLES)
 
 $(filter $(CLEAN_GF_PREFIX)%, $(CLEAN_FOLDERS)): $(CLEAN_GF_PREFIX)%:
-	- rm -r ./$*
+	- rm -r "./$*"
 
 clean: $(CLEAN_FOLDERS)
 	- stack clean

--- a/code/drasil-code/Language/Drasil/Code/Imperative/Build/AST.hs
+++ b/code/drasil-code/Language/Drasil/Code/Imperative/Build/AST.hs
@@ -61,7 +61,7 @@ withExt :: BuildName -> String -> BuildName
 withExt b = BWithExt b . OtherExt
 
 cCompiler :: String
-cCompiler = "$(CC)"
+cCompiler = "\"$(CC)\""
 
 cppCompiler :: String
-cppCompiler = "$(CXX)"
+cppCompiler = "\"$(CXX)\""

--- a/code/scripts/ci_functions.bash
+++ b/code/scripts/ci_functions.bash
@@ -31,11 +31,11 @@ ci_fstep() {
 
   shift 1
 
-  local fold_id=$(echo $label | sed "s/[^A-Za-z_]/_/g")
+  local fold_id=$(echo "$label" | sed "s/[^A-Za-z_]/_/g")
 
   travis_fold "start" $fold_id
   echo -e "$ANSI_YELLOW$label$ANSI_RESET"
-  $SHELL $(shopt | grep -E "on$" | cut -f1 | sed -E "s/^([^ ]*) *$/-O \1/g") -c "source $ALL_FUNCTIONS_FILE; $*"
+  "$SHELL" $(shopt | grep -E "on$" | cut -f1 | sed -E "s/^([^ ]*) *$/-O \1/g") -c "source \"$ALL_FUNCTIONS_FILE\"; $*"
   local ret=$?
   travis_fold "end" $fold_id
   echo -e "$ANSI_CLEAR"

--- a/code/scripts/code_build.sh
+++ b/code/scripts/code_build.sh
@@ -10,12 +10,13 @@ fi
 RET=0
 
 if [ -d "$BUILD_FOLDER$EDIR/$EXAMPLE_CODE_SUBFOLDER" ]; then
+  $OLD_DIR=$(pwd)
   cd "$BUILD_FOLDER$EDIR/$EXAMPLE_CODE_SUBFOLDER"
   for d in */; do
     cd "$d"
-    $MAKE
+    "$MAKE"
     RET=$(( $RET || $? ))
-    cd ../
+    cd "$OLD_DIR"
   done
 fi
 exit $RET

--- a/code/scripts/log_check.sh
+++ b/code/scripts/log_check.sh
@@ -10,7 +10,7 @@ fi
 errors="no"
 exitval=0
 
-for logfile in $LOG_FOLDER*$LOG_SUFFIX; do
+for logfile in "$LOG_FOLDER"*"$LOG_SUFFIX"; do
   if [ -s "$logfile" ]; then
     echo "-------------------------------------------"
     echo "- $logfile IS NOT EMPTY -- DIFFERENCE"

--- a/code/scripts/tex_build.sh
+++ b/code/scripts/tex_build.sh
@@ -21,7 +21,7 @@ fi
 GEN_NAME_SUFFIX=_SRS
 
 cd "$BUILD_FOLDER$EDIR"/SRS/
-$MAKE TEXFLAGS=--interaction="$IMODE" BIBTEXFLAGS="$BIFLAGS"
+"$MAKE" TEXFLAGS=--interaction="$IMODE" BIBTEXFLAGS="$BIFLAGS"
 RET=$?
 
 if [ "$SUMMARIZE_TEX" = "yes" ]; then

--- a/code/stable/glassbr/src/cpp/Makefile
+++ b/code/stable/glassbr/src/cpp/Makefile
@@ -16,7 +16,7 @@ endif
 build: GlassBR$(TARGET_EXTENSION)
 
 GlassBR$(TARGET_EXTENSION): InputParameters.hpp DerivedValues.hpp InputConstraints.hpp OutputFormat.hpp Calculations.hpp ReadTable.hpp InputFormat.hpp Interpolation.hpp Control.cpp InputParameters.cpp DerivedValues.cpp InputConstraints.cpp OutputFormat.cpp Calculations.cpp ReadTable.cpp InputFormat.cpp Interpolation.cpp
-	$(CXX) Control.cpp InputParameters.cpp DerivedValues.cpp InputConstraints.cpp OutputFormat.cpp Calculations.cpp ReadTable.cpp InputFormat.cpp Interpolation.cpp --std=c++11 -o GlassBR$(TARGET_EXTENSION)
+	"$(CXX)" Control.cpp InputParameters.cpp DerivedValues.cpp InputConstraints.cpp OutputFormat.cpp Calculations.cpp ReadTable.cpp InputFormat.cpp Interpolation.cpp --std=c++11 -o GlassBR$(TARGET_EXTENSION)
 
 run: build
 	./GlassBR$(TARGET_EXTENSION) $(RUNARGS)

--- a/code/stable/nopcm/src/cpp/Makefile
+++ b/code/stable/nopcm/src/cpp/Makefile
@@ -16,7 +16,7 @@ endif
 build: SWHS$(TARGET_EXTENSION)
 
 SWHS$(TARGET_EXTENSION): InputParameters.hpp OutputFormat.hpp Calculations.hpp InputFormat.hpp Control.cpp InputParameters.cpp OutputFormat.cpp Calculations.cpp InputFormat.cpp
-	$(CXX) Control.cpp InputParameters.cpp OutputFormat.cpp Calculations.cpp InputFormat.cpp --std=c++11 -o SWHS$(TARGET_EXTENSION)
+	"$(CXX)" Control.cpp InputParameters.cpp OutputFormat.cpp Calculations.cpp InputFormat.cpp --std=c++11 -o SWHS$(TARGET_EXTENSION)
 
 run: build
 	./SWHS$(TARGET_EXTENSION) $(RUNARGS)


### PR DESCRIPTION
This PR is a fix for #1367. It ensures variables in the `Makefile` and associated shell scripts properly use quotes to avoid delimiting lists on ` `. 

In shell scripts: generally quote anything that could have a space.
In `Makefile`: quote any variable which is not defined in the `Makefile` and comes from an "external" source (ex. `MAKE`, `SHELL`.) 

Strictly speaking I'm not certain `MAKE` is strictly necessary, however it is a path so it's safer to escape it now so it is unlikely to cause problems.

Additionally, `CC` and `CXX` are also paths created by `make` so I've rolled those changes into this PR as a precaution as well.