### PR TITLE
Fix scoping of cd call in code_build.

### DIFF
--- a/code/scripts/code_build.sh
+++ b/code/scripts/code_build.sh
@@ -10,8 +10,8 @@ fi
 RET=0
 
 if [ -d "$BUILD_FOLDER$EDIR/$EXAMPLE_CODE_SUBFOLDER" ]; then
-  $OLD_DIR=$(pwd)
   cd "$BUILD_FOLDER$EDIR/$EXAMPLE_CODE_SUBFOLDER"
+  OLD_DIR=$(pwd)
   for d in */; do
     cd "$d"
     "$MAKE"


### PR DESCRIPTION
This is a small PR that corrects a regression in the `code_build.sh` script which caused the mechanism used to invoke the `Makefile` in each subdirectory of `src` to fail.