### PR TITLE
Graph Checks

### DIFF
--- a/code/Makefile
+++ b/code/Makefile
@@ -126,9 +126,9 @@ test: $(GEN_EXAMPLES) $(TEST_EXAMPLES)
 graphmod: check_stack
 	stack install dotgen graphmod
 
-$(filter %$(GRAPH_P_SUFFIX), $(GRAPH_PACKAGES)): %$(GRAPH_P_SUFFIX): graphmod
+$(filter %$(GRAPH_P_SUFFIX), $(GRAPH_PACKAGES)): %$(GRAPH_P_SUFFIX): check_stack graphmod
 	@mkdir -p $(GRAPH_FOLDER)
-	find "drasil-$*" -name '*.hs' -print | grep -v stack | xargs graphmod -q -p --no-cluster | dot -Tpdf > $(GRAPH_FOLDER)drasil-"$*".pdf
+	find "drasil-$*" -name '*.hs' -print | grep -v stack | xargs stack exec -- graphmod -q -p --no-cluster | dot -Tpdf > $(GRAPH_FOLDER)drasil-"$*".pdf
 
 graphs: $(GRAPH_PACKAGES)
 ###

--- a/code/Makefile
+++ b/code/Makefile
@@ -96,6 +96,9 @@ debug: test
 check_stack:
 	 @MIN_STACK_VER=$(MIN_STACK_VER) CACHED_MSV_FILE=$(CACHED_MSV_FILE) "$(SHELL)" $(SCRIPT_FOLDER)check_stack.sh
 
+check_dot:
+	@BIN=dot DOWNLOAD_LOCATION=https://www.graphviz.org/download/ "$(SHELL)" $(SCRIPT_FOLDER)check_binary.sh
+
 packages: $(BUILD_PACKAGES)
 
 # Actually build all the packages
@@ -126,7 +129,7 @@ test: $(GEN_EXAMPLES) $(TEST_EXAMPLES)
 graphmod: check_stack
 	stack install dotgen graphmod
 
-$(filter %$(GRAPH_P_SUFFIX), $(GRAPH_PACKAGES)): %$(GRAPH_P_SUFFIX): check_stack graphmod
+$(filter %$(GRAPH_P_SUFFIX), $(GRAPH_PACKAGES)): %$(GRAPH_P_SUFFIX): check_stack check_dot graphmod
 	@mkdir -p $(GRAPH_FOLDER)
 	find "drasil-$*" -name '*.hs' -print | grep -v stack | xargs stack exec -- graphmod -q -p --no-cluster | dot -Tpdf > $(GRAPH_FOLDER)drasil-"$*".pdf
 

--- a/code/scripts/check_binary.sh
+++ b/code/scripts/check_binary.sh
@@ -1,0 +1,18 @@
+if [ -z "$BIN" ]; then
+  echo "Missing BIN"
+  exit 1
+fi
+
+if [ -z "$DOWNLOAD_LOCATION" ]; then
+  echo "Missing DOWNLOAD_LOCATION"
+  exit 1
+fi
+
+command -v "$BIN" > /dev/null
+
+RET=$?  # "command" returns 1 if binary not found
+if [ $RET -eq 1 ]; then
+  echo "Couldn't find \`$BIN\`."
+  echo "It can be installed from $DOWNLOAD_LOCATION"
+  exit 1
+fi

--- a/code/scripts/check_stack.sh
+++ b/code/scripts/check_stack.sh
@@ -16,12 +16,9 @@ if [ -f "$CACHED_MSV_FILE" ]; then
   fi
 fi
 
-command -v stack > /dev/null
-
-RET=$?  # "which" returns 1 if binary not found
-if [ $RET -eq 1 ]; then
-  echo "Couldn't find \`stack\`."
-  echo "Stack can be installed from https://www.haskellstack.org/"
+BIN=stack DOWNLOAD_LOCATION=https://www.haskellstack.org/ "$SHELL" scripts/check_binary.sh
+RET=$?
+if [ $RET -ne 0 ]; then
   exit 1
 fi
 


### PR DESCRIPTION
This PR makes a few tweaks to graph gen related things.

It adds a check for `dot` being installed. (Baking the solution to #1386 into the build process). It also "expands" `graphmod` to `stack exec -- graphmod` as we know we have `stack` and it is more permissive than requiring `~/.local/bin` on `PATH`.