### PR TITLE
Makefile Variables

### DIFF
--- a/code/drasil-build/Build/Drasil.hs
+++ b/code/drasil-build/Build/Drasil.hs
@@ -5,7 +5,7 @@ module Build.Drasil (
     -- Import
   , RuleTransformer(makeRule)
     -- MakeString
-  , (+:+), makeS, MakeString
+  , (+:+), makeS, MakeString, mkFreeVar, mkImplicitVar, mkWindowsVar
     -- Print
   , genMake
   )
@@ -13,5 +13,6 @@ module Build.Drasil (
 
 import Build.Drasil.Make.AST (Command, mkCheckedCommand, mkCommand, mkFile, mkRule, Rule)
 import Build.Drasil.Make.Import (RuleTransformer(makeRule))
-import Build.Drasil.Make.MakeString ((+:+), makeS, MakeString)
+import Build.Drasil.Make.MakeString ((+:+), makeS, MakeString, mkFreeVar, mkImplicitVar,
+  mkWindowsVar)
 import Build.Drasil.Make.Print (genMake)

--- a/code/drasil-build/Build/Drasil.hs
+++ b/code/drasil-build/Build/Drasil.hs
@@ -4,12 +4,14 @@ module Build.Drasil (
     Command, mkCheckedCommand, mkCommand, mkFile, mkRule, Rule
     -- Import
   , RuleTransformer(makeRule)
+    -- MakeString
+  , (+:+), makeS, MakeString
     -- Print
   , genMake
   )
   where
 
-import Build.Drasil.Make.AST (Command, mkCheckedCommand, mkCommand, mkFile,
-  mkRule, Rule)
+import Build.Drasil.Make.AST (Command, mkCheckedCommand, mkCommand, mkFile, mkRule, Rule)
 import Build.Drasil.Make.Import (RuleTransformer(makeRule))
+import Build.Drasil.Make.MakeString ((+:+), makeS, MakeString)
 import Build.Drasil.Make.Print (genMake)

--- a/code/drasil-build/Build/Drasil/Make/AST.hs
+++ b/code/drasil-build/Build/Drasil/Make/AST.hs
@@ -1,11 +1,12 @@
 -- | Makefile abstract syntax tree
 module Build.Drasil.Make.AST where
+import Build.Drasil.Make.MakeString (MakeString)
 
 newtype Makefile = M [Rule]
 
-data Rule = R Target [Dependencies] Type [Command]
+data Rule = R Target Dependencies Type [Command]
 
-data Command = C String [CommandOpts]
+data Command = C MakeString [CommandOpts]
 
 data CommandOpts =
   IgnoreReturnCode deriving Eq
@@ -13,21 +14,21 @@ data CommandOpts =
 data Type = Abstract
           | File deriving Eq
 
-type Target = String
-type Dependencies = Target
+type Target = MakeString
+type Dependencies = [Target]
 
 -- | Creates a Rule which results in a file being created
-mkFile :: Target -> [Dependencies] -> [Command] -> Rule
+mkFile :: Target -> Dependencies -> [Command] -> Rule
 mkFile t d = R t d File
 
 -- | Creates an abstract Rule not associated to a specific file
-mkRule :: Target -> [Dependencies] -> [Command] -> Rule
+mkRule :: Target -> Dependencies -> [Command] -> Rule
 mkRule t d = R t d Abstract
 
 -- | Creates a Command which fails the make process if it does not return zero
-mkCheckedCommand :: String -> Command
+mkCheckedCommand :: MakeString -> Command
 mkCheckedCommand = flip C []
 
 -- | Creates a command which executes and ignores the return code
-mkCommand :: String -> Command
+mkCommand :: MakeString -> Command
 mkCommand = flip C [IgnoreReturnCode]

--- a/code/drasil-build/Build/Drasil/Make/Helpers.hs
+++ b/code/drasil-build/Build/Drasil/Make/Helpers.hs
@@ -4,7 +4,7 @@ import Build.Drasil.Make.AST (Command(C), Rule(R))
 import Build.Drasil.Make.MakeString (MakeString(Mc, Mr, Mv), MVar(Free, Implicit, Os))
 
 import Data.List (nubBy)
-import Text.PrettyPrint (Doc, nest, text, vcat, ($+$))
+import Text.PrettyPrint (Doc, empty, nest, text, vcat, ($+$))
 
 ($=) :: MVar -> String -> Doc
 a $= b = text $ varName a ++ "=" ++ b
@@ -26,21 +26,16 @@ defineOsVars f m = msIndent $ vcat $ map (\x -> x $= f x) m
 
 -- | Helper for rendering OS-specific variables
 osDefinitions :: [MVar] -> Doc
+osDefinitions [] = empty
 osDefinitions m =
   text "ifeq \"$(OS)\" \"Windows_NT\"" $+$
-  msIndent (text "TARGET_EXTENSION=.exe") $+$
-  msIndent (text "RM=del") $+$
   defineOsVars win m $+$
   text "else" $+$
   msIndent (vcat [text "UNAME_S := $(shell uname -s)",
     text "ifeq ($(UNAME_S), Linux)",
-    msIndent $ text "TARGET_EXTENSION=",
-    msIndent $ text "RM=rm",
     defineOsVars linux m,
     text "endif",
     text "ifeq ($(UNAME_S), Darwin)",
-    msIndent $ text "TARGET_EXTENSION=",
-    msIndent $ text "RM=rm",
     defineOsVars mac m,
     text "endif"]) $+$
   text "endif" $+$

--- a/code/drasil-build/Build/Drasil/Make/Helpers.hs
+++ b/code/drasil-build/Build/Drasil/Make/Helpers.hs
@@ -1,24 +1,25 @@
 module Build.Drasil.Make.Helpers where
 
-import Text.PrettyPrint (Doc, text, ($+$))
+import Text.PrettyPrint (Doc, nest, text, vcat, ($+$))
 
--- | Helper for rendering OS-specific extensions
+-- | Helper for rendering OS-specific variables
 osDefinitions :: Doc
-osDefinitions = text "ifeq \"$(OS)\" \"Windows_NT\"" $+$
-                text "\tTARGET_EXTENSION=.exe" $+$
-                text "\tRM=del" $+$
-                text "else" $+$
-                text "\tUNAME_S := $(shell uname -s)" $+$
-                text "\tifeq ($(UNAME_S), Linux)" $+$
-                text "\t\tTARGET_EXTENSION=" $+$
-                text "\t\tRM=rm" $+$
-                text "\tendif" $+$
-                text "\tifeq ($(UNAME_S), Darwin)" $+$
-                text "\t\tTARGET_EXTENSION=" $+$
-                text "\t\tRM=rm" $+$
-                text "\tendif" $+$
-                text "endif" $+$
-                text ""
+osDefinitions =
+  text "ifeq \"$(OS)\" \"Windows_NT\"" $+$
+  msIndent (text "TARGET_EXTENSION=.exe") $+$
+  msIndent (text "RM=del") $+$
+  text "else" $+$
+  msIndent (vcat [text "UNAME_S := $(shell uname -s)",
+    text "ifeq ($(UNAME_S), Linux)",
+    msIndent $ text "TARGET_EXTENSION=",
+    msIndent $ text "RM=rm",
+    text "endif",
+    text "ifeq ($(UNAME_S), Darwin)",
+    msIndent $ text "TARGET_EXTENSION=",
+    msIndent $ text "RM=rm",
+    text "endif"]) $+$
+  text "endif" $+$
+  text ""
 
 -- | Helper for prepending common features to a Makefile
 addCommonFeatures :: Doc -> Doc
@@ -26,3 +27,7 @@ addCommonFeatures m = osDefinitions $+$ m
 
 tab :: Doc
 tab = text "\t"
+
+-- | Makefile Syntax Indent (i.e. non recipes)
+msIndent :: Doc -> Doc
+msIndent = nest 4

--- a/code/drasil-build/Build/Drasil/Make/Helpers.hs
+++ b/code/drasil-build/Build/Drasil/Make/Helpers.hs
@@ -1,30 +1,79 @@
 module Build.Drasil.Make.Helpers where
 
+import Build.Drasil.Make.AST (Command(C), Rule(R))
+import Build.Drasil.Make.MakeString (MakeString(Mc, Mr, Mv), MVar(Free, Implicit, Os))
+
+import Data.List (nubBy)
 import Text.PrettyPrint (Doc, nest, text, vcat, ($+$))
 
+($=) :: MVar -> String -> Doc
+a $= b = text $ varName a ++ "=" ++ b
+
+win :: MVar -> String
+win (Os _ w _ _) = w
+win _ = error "Expected Os Variable"
+
+mac :: MVar -> String
+mac (Os _ _ m _) = m
+mac _ = error "Expected Os Variable"
+
+linux :: MVar -> String
+linux (Os _ _ _ l) = l
+linux _ = error "Expected Os Variable"
+
+defineOsVars :: (MVar -> String) -> [MVar] -> Doc
+defineOsVars f m = msIndent $ vcat $ map (\x -> x $= f x) m
+
 -- | Helper for rendering OS-specific variables
-osDefinitions :: Doc
-osDefinitions =
+osDefinitions :: [MVar] -> Doc
+osDefinitions m =
   text "ifeq \"$(OS)\" \"Windows_NT\"" $+$
   msIndent (text "TARGET_EXTENSION=.exe") $+$
   msIndent (text "RM=del") $+$
+  defineOsVars win m $+$
   text "else" $+$
   msIndent (vcat [text "UNAME_S := $(shell uname -s)",
     text "ifeq ($(UNAME_S), Linux)",
     msIndent $ text "TARGET_EXTENSION=",
     msIndent $ text "RM=rm",
+    defineOsVars linux m,
     text "endif",
     text "ifeq ($(UNAME_S), Darwin)",
     msIndent $ text "TARGET_EXTENSION=",
     msIndent $ text "RM=rm",
+    defineOsVars mac m,
     text "endif"]) $+$
   text "endif" $+$
   text ""
 
--- | Helper for prepending common features to a Makefile
-addCommonFeatures :: Doc -> Doc
-addCommonFeatures m = osDefinitions $+$ m
+-- | Deduplicates a list of variables and ensures duplicate variables have the same definition
+uniqueVars :: [MVar] -> [MVar]
+uniqueVars = nubBy (\x y -> varName x == varName y && (x == y ||
+        error ("Found disparate variable definitions for " ++ varName x)))
 
+varName :: MVar -> String
+varName (Free s) = s
+varName (Implicit s) = s
+varName (Os s _ _ _) = s
+
+-- | Extracts variables from a Makefile rule
+extractVars :: Rule -> [MVar]
+extractVars (R t d _ cs) = concatMap getVars $ t : d ++ map (\(C s _) -> s) cs
+
+getVars :: MakeString -> [MVar]
+getVars (Mr _) = []
+getVars (Mv v) = [v]
+getVars (Mc a b) = getVars a ++ getVars b
+
+isOsVar :: MVar -> Bool
+isOsVar Os{} = True
+isOsVar _ = False
+
+-- | Helper for prepending common features to a Makefile
+addCommonFeatures :: [Rule] -> Doc -> Doc
+addCommonFeatures r m = osDefinitions (filter isOsVar $ uniqueVars $ concatMap extractVars r) $+$ m
+
+-- | Recipes must be indented with tabs
 tab :: Doc
 tab = text "\t"
 

--- a/code/drasil-build/Build/Drasil/Make/Import.hs
+++ b/code/drasil-build/Build/Drasil/Make/Import.hs
@@ -7,7 +7,7 @@ class RuleTransformer c where
 
 -- | Creates a Makefile (calls 'makeRules')
 toMake :: RuleTransformer c => [c] -> Makefile
-toMake rl = M $ makeRules rl
+toMake = M . makeRules
 
 -- | Helper for creating make rules for different document types
 makeRules :: RuleTransformer c => [c] -> [Rule]

--- a/code/drasil-build/Build/Drasil/Make/Import.hs
+++ b/code/drasil-build/Build/Drasil/Make/Import.hs
@@ -1,6 +1,6 @@
 module Build.Drasil.Make.Import where
 
-import Build.Drasil.Make.AST (Rule, Makefile(M))
+import Build.Drasil.Make.AST (Makefile(M), Rule)
 
 class RuleTransformer c where
   makeRule :: c -> [Rule]

--- a/code/drasil-build/Build/Drasil/Make/MakeString.hs
+++ b/code/drasil-build/Build/Drasil/Make/MakeString.hs
@@ -1,6 +1,10 @@
 module Build.Drasil.Make.MakeString where
 
+type VarName = String
+type VarVal = String
+
 data MakeString = Mr String
+                | Mv MVar
                 | Mc MakeString MakeString
 
 instance Semigroup MakeString where
@@ -14,9 +18,29 @@ a +:+ (Mr "") = a
 (Mr "") +:+ b = b
 a +:+ b = a <> Mr " " <> b
 
+data MVar = Os VarName VarVal VarVal VarVal
+          | Implicit VarName
+          | Free VarName
+          deriving Eq
+
 renderMS :: MakeString -> String
 renderMS (Mr s) = s
+renderMS (Mv v) = renderVar (\x -> "$(" ++ x ++ ")") v
 renderMS (Mc a b) = renderMS a ++ renderMS b
+
+renderVar :: (String -> String) -> MVar -> String
+renderVar f (Os nm _ _ _) = f nm
+renderVar f (Implicit nm) = "\"" ++ f nm ++ "\""
+renderVar f (Free nm) = f nm
 
 makeS :: String -> MakeString
 makeS = Mr
+
+mkWindowsVar :: VarName -> VarVal -> VarVal -> MakeString
+mkWindowsVar n w e = Mv $ Os n w e e
+
+mkImplicitVar :: VarName -> MakeString
+mkImplicitVar = Mv . Implicit
+
+mkFreeVar :: VarName -> MakeString
+mkFreeVar = Mv . Free

--- a/code/drasil-build/Build/Drasil/Make/MakeString.hs
+++ b/code/drasil-build/Build/Drasil/Make/MakeString.hs
@@ -1,0 +1,22 @@
+module Build.Drasil.Make.MakeString where
+
+data MakeString = Mr String
+                | Mc MakeString MakeString
+
+instance Semigroup MakeString where
+  (<>) = Mc
+
+instance Monoid MakeString where
+  mempty = Mr ""
+
+(+:+) :: MakeString -> MakeString -> MakeString
+a +:+ (Mr "") = a
+(Mr "") +:+ b = b
+a +:+ b = a <> Mr " " <> b
+
+renderMS :: MakeString -> String
+renderMS (Mr s) = s
+renderMS (Mc a b) = renderMS a ++ renderMS b
+
+makeS :: String -> MakeString
+makeS = Mr

--- a/code/drasil-build/Build/Drasil/Make/Print.hs
+++ b/code/drasil-build/Build/Drasil/Make/Print.hs
@@ -16,7 +16,7 @@ genMake = build . toMake
 
 -- | Renders the makefile rules
 build :: Makefile -> Doc
-build (M rules) = addCommonFeatures $
+build (M rules) = addCommonFeatures rules $
   vcat (map (\x -> printRule x $+$ text "") rules) $$ printPhony rules
 
 -- | Renders specific makefile rules. Called by 'build'

--- a/code/drasil-build/Build/Drasil/Make/Print.hs
+++ b/code/drasil-build/Build/Drasil/Make/Print.hs
@@ -6,8 +6,9 @@ import Text.PrettyPrint (Doc, empty, text, (<>), (<+>), ($+$), ($$), hsep, vcat)
 
 import Build.Drasil.Make.AST (Command(C), CommandOpts(IgnoreReturnCode),
   Dependencies, Makefile(M), Rule(R), Target, Type(Abstract))
-import Build.Drasil.Make.Import (RuleTransformer, toMake)
 import Build.Drasil.Make.Helpers (addCommonFeatures, tab)
+import Build.Drasil.Make.Import (RuleTransformer, toMake)
+import Build.Drasil.Make.MakeString (renderMS)
 
 -- | Generates the makefile by calling 'build' after 'toMake'
 genMake :: RuleTransformer c => [c] -> Doc
@@ -24,15 +25,15 @@ printRule (R t d _ c) = printTarget t d $+$ printCmds c
 
 -- | Gathers all rules to abstract targets and tags them as phony.
 printPhony :: [Rule] -> Doc
-printPhony = (<+>) (text ".PHONY:") . hsep . map (\(R t _ _ _) -> text t) .
+printPhony = (<+>) (text ".PHONY:") . hsep . map (\(R t _ _ _) -> text $ renderMS t) .
   filter (\(R _ _ t _) -> t == Abstract)
 
 -- | Renders targets with their dependencies
-printTarget :: Target -> [Dependencies] -> Doc
-printTarget nameLb deps = text (nameLb ++ ":") <+> hsep (map text deps)
+printTarget :: Target -> Dependencies -> Doc
+printTarget nameLb deps = text (renderMS nameLb ++ ":") <+> hsep (map (text . renderMS) deps)
 
 printCmd :: Command -> Doc
-printCmd (C c opts) = text $ (if IgnoreReturnCode `elem` opts then "-" else "") ++ c
+printCmd (C c opts) = text $ (if IgnoreReturnCode `elem` opts then "-" else "") ++ renderMS c
 
 printCmds :: [Command] -> Doc
 printCmds = foldr (($+$) . (<>) tab . printCmd) empty

--- a/code/drasil-build/drasil-build.cabal
+++ b/code/drasil-build/drasil-build.cabal
@@ -1,5 +1,5 @@
 Name:		  drasil-build
-Version:	0.1.0
+Version:	0.1.1
 Cabal-Version:  >= 1.18
 Author:		Dan Szymczak, Steven Palmer, Jacques Carette, Spencer Smith
 build-type:     Simple
@@ -12,6 +12,7 @@ library
     Build.Drasil.Make.AST,
     Build.Drasil.Make.Helpers,
     Build.Drasil.Make.Import,
+    Build.Drasil.Make.MakeString,
     Build.Drasil.Make.Print
 
   Build-Depends:

--- a/code/drasil-code/Language/Drasil/Code/Imperative/Build/AST.hs
+++ b/code/drasil-code/Language/Drasil/Code/Imperative/Build/AST.hs
@@ -1,5 +1,5 @@
 module Language.Drasil.Code.Imperative.Build.AST where
-import Build.Drasil (makeS, MakeString)
+import Build.Drasil (makeS, MakeString, mkImplicitVar, mkWindowsVar)
 
 type CommandFragment = MakeString
 
@@ -39,6 +39,9 @@ type InterpreterCommand = String
 asFragment :: String -> CommandFragment
 asFragment = makeS
 
+osClassDefault :: String -> String -> String -> CommandFragment
+osClassDefault = mkWindowsVar
+
 buildAll :: ([CommandFragment] -> CommandFragment -> BuildCommand) -> Maybe BuildConfig
 buildAll = Just . flip BuildConfig BcSource
 
@@ -46,7 +49,8 @@ buildSingle :: ([CommandFragment] -> CommandFragment -> BuildCommand) -> BuildNa
 buildSingle f = Just . BuildConfig f . BcSingle
 
 nativeBinary :: Runnable
-nativeBinary = Runnable (BWithExt BPackName $ OtherExt $ makeS "$(TARGET_EXTENSION)") nameOpts Standalone
+nativeBinary = Runnable (BWithExt BPackName $ OtherExt $
+  osClassDefault "TARGET_EXTENSION" ".exe" "") nameOpts Standalone
 
 interp :: BuildName -> NameOpts -> InterpreterCommand -> Runnable
 interp b n = Runnable b n . Interpreter . makeS
@@ -67,7 +71,7 @@ withExt :: BuildName -> String -> BuildName
 withExt b = BWithExt b . OtherExt . makeS
 
 cCompiler :: CommandFragment
-cCompiler = makeS "\"$(CC)\""
+cCompiler = mkImplicitVar "CC"
 
 cppCompiler :: CommandFragment
-cppCompiler = makeS "\"$(CXX)\""
+cppCompiler = mkImplicitVar "CXX"

--- a/code/drasil-code/Language/Drasil/Code/Imperative/Build/Import.hs
+++ b/code/drasil-code/Language/Drasil/Code/Imperative/Build/Import.hs
@@ -12,7 +12,7 @@ import Language.Drasil.Code.Imperative.LanguageRenderer (Config, buildConfig,
   ext, runnable)
 
 import Build.Drasil ((+:+), genMake, makeS, MakeString, mkFile, mkRule,
-  mkCheckedCommand, RuleTransformer(makeRule))
+  mkCheckedCommand, mkFreeVar, RuleTransformer(makeRule))
 
 import Data.List.Utils (endswith)
 import Data.Maybe (maybe, maybeToList)
@@ -31,7 +31,7 @@ instance RuleTransformer CodeHarness where
       ]
     ]) (buildConfig c) ++ [
     mkRule (makeS "run") [buildTarget] [
-      mkCheckedCommand $ buildRunTarget (renderBuildName c m no nm) ty +:+ makeS "$(RUNARGS)"
+      mkCheckedCommand $ buildRunTarget (renderBuildName c m no nm) ty +:+ mkFreeVar "RUNARGS"
       ]
     ] where
       (Runnable nm no ty) = runnable c

--- a/code/drasil-code/Language/Drasil/Code/Imperative/Build/Import.hs
+++ b/code/drasil-code/Language/Drasil/Code/Imperative/Build/Import.hs
@@ -3,42 +3,48 @@ module Language.Drasil.Code.Imperative.Build.Import (
 ) where
 
 import Language.Drasil.Code.Code (Code(..))
-import Language.Drasil.Code.Imperative.AST (Label, Module(Mod), notMainModule, Package(Pack))
+import Language.Drasil.Code.Imperative.AST (Label, Module(Mod), notMainModule,
+  Package(Pack))
 import Language.Drasil.Code.Imperative.Build.AST (BuildConfig(BuildConfig),
   BuildDependencies(..), Ext(..), includeExt, NameOpts, nameOpts, packSep,
   Runnable(Runnable), BuildName(..), RunType(..))
-import Language.Drasil.Code.Imperative.LanguageRenderer (Config, buildConfig, ext, runnable)
+import Language.Drasil.Code.Imperative.LanguageRenderer (Config, buildConfig,
+  ext, runnable)
 
-import Build.Drasil (RuleTransformer(makeRule), genMake, mkFile, mkRule, mkCheckedCommand)
+import Build.Drasil ((+:+), genMake, makeS, MakeString, mkFile, mkRule,
+  mkCheckedCommand, RuleTransformer(makeRule))
 
+import Data.List.Utils (endswith)
 import Data.Maybe (maybe, maybeToList)
 
 data CodeHarness = Ch Config Package Code
 
 instance RuleTransformer CodeHarness where
   makeRule (Ch c m co@(Code code)) = [
-    mkRule "build" (map (const $ renderBuildName c m nameOpts nm) $ maybeToList $
+    mkRule buildTarget (map (const $ renderBuildName c m nameOpts nm) $ maybeToList $
       buildConfig c) []
     ] ++
     maybe [] (\(BuildConfig comp bt) -> [
-    mkFile (renderBuildName c m nameOpts nm) (map fst code) [
-      mkCheckedCommand $ unwords $ comp (getCompilerInput bt c m co) $
+    mkFile (renderBuildName c m nameOpts nm) (map (makeS . fst) code) [
+      mkCheckedCommand $ foldr (+:+) mempty $ comp (getCompilerInput bt c m co) $
         renderBuildName c m nameOpts nm
       ]
     ]) (buildConfig c) ++ [
-    mkRule "run" ["build"] [
-      mkCheckedCommand $ buildRunTarget (renderBuildName c m no nm) ty ++ " $(RUNARGS)"
+    mkRule (makeS "run") [buildTarget] [
+      mkCheckedCommand $ buildRunTarget (renderBuildName c m no nm) ty +:+ makeS "$(RUNARGS)"
       ]
-    ] where (Runnable nm no ty) = runnable c
+    ] where
+      (Runnable nm no ty) = runnable c
+      buildTarget = makeS "build"
 
-renderBuildName :: Config -> Package -> NameOpts -> BuildName -> String
-renderBuildName _ (Pack _ m) _ BMain = getMainModule m
-renderBuildName _ (Pack l _) _ BPackName = l
-renderBuildName c p o (BPack a) = renderBuildName c p o BPackName ++ packSep o ++ renderBuildName c p o a
-renderBuildName c p o (BWithExt a e) = renderBuildName c p o a ++ if includeExt o then renderExt c e else ""
+renderBuildName :: Config -> Package -> NameOpts -> BuildName -> MakeString
+renderBuildName _ (Pack _ m) _ BMain = makeS $ getMainModule m
+renderBuildName _ (Pack l _) _ BPackName = makeS l
+renderBuildName c p o (BPack a) = renderBuildName c p o BPackName <> makeS (packSep o) <> renderBuildName c p o a
+renderBuildName c p o (BWithExt a e) = renderBuildName c p o a <> if includeExt o then renderExt c e else makeS ""
 
-renderExt :: Config -> Ext -> String
-renderExt c CodeExt = ext c
+renderExt :: Config -> Ext -> MakeString
+renderExt c CodeExt = makeS $ ext c
 renderExt _ (OtherExt e) = e
 
 getMainModule :: [Module] -> Label
@@ -46,13 +52,14 @@ getMainModule c = mainName $ filter (not . notMainModule) c
   where mainName [Mod a _ _ _ _] = a
         mainName _ = error "Expected a single main module."
 
-getCompilerInput :: BuildDependencies -> Config -> Package -> Code -> [String]
-getCompilerInput BcAll _ _ a = map fst $ unCode a
+getCompilerInput :: BuildDependencies -> Config -> Package -> Code -> [MakeString]
+getCompilerInput BcSource c _ a = map makeS $ filter (endswith (ext c)) $ map fst $ unCode a
 getCompilerInput (BcSingle n) c p _ = [renderBuildName c p nameOpts n]
 
-buildRunTarget :: String -> RunType -> String
-buildRunTarget fn Standalone = "./" ++ fn
-buildRunTarget fn (Interpreter i) = unwords [i, fn]
+
+buildRunTarget :: MakeString -> RunType -> MakeString
+buildRunTarget fn Standalone = makeS "./" <> fn
+buildRunTarget fn (Interpreter i) = i +:+ fn
 
 makeBuild :: Package -> Config -> Code -> Code
 makeBuild m p code@(Code c) = Code $ ("Makefile", genMake [Ch p m code]) : c

--- a/code/drasil-code/Language/Drasil/Code/Imperative/LanguageRenderer/CSharpRenderer.hs
+++ b/code/drasil-code/Language/Drasil/Code/Imperative/LanguageRenderer/CSharpRenderer.hs
@@ -6,7 +6,7 @@ module Language.Drasil.Code.Imperative.LanguageRenderer.CSharpRenderer (
 
 import Language.Drasil.Code.Code (Code(..))
 import Language.Drasil.Code.Imperative.AST hiding (body,comment,bool,int,float,char)
-import Language.Drasil.Code.Imperative.Build.AST (asFragment, buildAll, nativeBinary)
+import Language.Drasil.Code.Imperative.Build.AST (asFragment, buildAll, nativeBinary, osClassDefault)
 import Language.Drasil.Code.Imperative.LanguageRenderer (Config(Config), FileType(Source),
   DecDef(Dec, Def), getEnv, complexDoc, inputDoc, ioDoc, functionListDoc, functionDoc, unOpDoc,
   valueDoc, methodTypeDoc, methodDoc, methodListDoc, statementDoc, stateDoc, stateListDoc,
@@ -46,7 +46,7 @@ csharpConfig _ c =
         enumsEqualInts   = False,
         ext              = ".cs",
         dir              = "csharp",
-        buildConfig      = buildAll $ \i o -> asFragment "mcs" : i ++ [asFragment "-out:" P.<> o],
+        buildConfig      = buildAll $ \i o -> [osClassDefault "CSC" "csc" "mcs", asFragment "-out:" P.<> o] ++ i,
         runnable         = nativeBinary,
         fileName         = fileNameD c,
         include          = includeD "using",

--- a/code/drasil-code/Language/Drasil/Code/Imperative/LanguageRenderer/CSharpRenderer.hs
+++ b/code/drasil-code/Language/Drasil/Code/Imperative/LanguageRenderer/CSharpRenderer.hs
@@ -6,7 +6,7 @@ module Language.Drasil.Code.Imperative.LanguageRenderer.CSharpRenderer (
 
 import Language.Drasil.Code.Code (Code(..))
 import Language.Drasil.Code.Imperative.AST hiding (body,comment,bool,int,float,char)
-import Language.Drasil.Code.Imperative.Build.AST (buildAll, nativeBinary)
+import Language.Drasil.Code.Imperative.Build.AST (asFragment, buildAll, nativeBinary)
 import Language.Drasil.Code.Imperative.LanguageRenderer (Config(Config), FileType(Source),
   DecDef(Dec, Def), getEnv, complexDoc, inputDoc, ioDoc, functionListDoc, functionDoc, unOpDoc,
   valueDoc, methodTypeDoc, methodDoc, methodListDoc, statementDoc, stateDoc, stateListDoc,
@@ -28,6 +28,8 @@ import Language.Drasil.Code.Imperative.LanguageRenderer (Config(Config), FileTyp
   buildConfig, runnable)
 import Language.Drasil.Code.Imperative.Helpers (oneTab, vibmap)
 
+import qualified Prelude as P ((<>))
+
 import Prelude hiding (print,(<>))
 import Text.PrettyPrint.HughesPJ (Doc, text, (<>), (<+>), semi, parens, equals, vcat, doubleQuotes,
   render, rbrace, lbrace, empty, colon)
@@ -44,7 +46,7 @@ csharpConfig _ c =
         enumsEqualInts   = False,
         ext              = ".cs",
         dir              = "csharp",
-        buildConfig      = buildAll $ \i o -> ["mcs", unwords i, "-out:" ++ o],
+        buildConfig      = buildAll $ \i o -> asFragment "mcs" : i ++ [asFragment "-out:" P.<> o],
         runnable         = nativeBinary,
         fileName         = fileNameD c,
         include          = includeD "using",

--- a/code/drasil-code/Language/Drasil/Code/Imperative/LanguageRenderer/CppRenderer.hs
+++ b/code/drasil-code/Language/Drasil/Code/Imperative/LanguageRenderer/CppRenderer.hs
@@ -8,7 +8,7 @@ module Language.Drasil.Code.Imperative.LanguageRenderer.CppRenderer (
 import Language.Drasil.Code.Code (Code(..))
 import Language.Drasil.Code.Imperative.AST
   hiding (body, comment, bool, int, float, char, tryBody, catchBody, initState, guard, update)
-import Language.Drasil.Code.Imperative.Build.AST (buildAll, cppCompiler, nativeBinary)
+import Language.Drasil.Code.Imperative.Build.AST (asFragment, buildAll, cppCompiler, nativeBinary)
 import Language.Drasil.Code.Imperative.LanguageRenderer (Config(Config), FileType(Source, Header),
   DecDef(Dec, Def), getEnv, complexDoc, inputDoc, ioDoc, functionListDoc, functionDoc, unOpDoc, 
   valueDoc, methodTypeDoc, methodDoc, methodListDoc, statementDoc, stateDoc, stateListDoc,
@@ -28,8 +28,7 @@ import Language.Drasil.Code.Imperative.LanguageRenderer (Config(Config), FileTyp
   classDec, namespaceD, includeD, fileNameD, cpplist, buildConfig, runnable)
 import Language.Drasil.Code.Imperative.Helpers (blank, oneTab, oneTabbed, vmap, vibmap)
 
-import Prelude hiding (break, print, return,(<>))
-import Data.List.Utils (endswith)
+import Prelude hiding (break, print, return, (<>))
 import Text.PrettyPrint.HughesPJ hiding (Str)
 
 validListTypes :: [Label]
@@ -50,8 +49,7 @@ cppConfig options c =
         enumsEqualInts   = False,
         ext              = ".cpp",
         dir              = "cpp",
-        buildConfig      = buildAll $ \i o -> [cppCompiler, unwords $
-          filter (not . endswith ".hpp") i, "--std=c++11", "-o", o],
+        buildConfig      = buildAll $ \i o -> cppCompiler : i ++ map asFragment ["--std=c++11", "-o"] ++ [o],
         runnable         = nativeBinary,
         fileName         = fileNameD c,
         include          = includeD "#include",

--- a/code/drasil-code/Language/Drasil/Code/Imperative/LanguageRenderer/JavaRenderer.hs
+++ b/code/drasil-code/Language/Drasil/Code/Imperative/LanguageRenderer/JavaRenderer.hs
@@ -6,7 +6,7 @@ module Language.Drasil.Code.Imperative.LanguageRenderer.JavaRenderer (
 
 import Language.Drasil.Code.Code (Code(..))
 import Language.Drasil.Code.Imperative.AST hiding (body,comment,bool,int,float,char)
-import Language.Drasil.Code.Imperative.Build.AST (buildSingle, includeExt, inCodePackage, interp, mainModule,
+import Language.Drasil.Code.Imperative.Build.AST (asFragment, buildSingle, includeExt, inCodePackage, interp, mainModule,
   mainModuleFile, NameOpts(NameOpts), packSep, withExt)
 import Language.Drasil.Code.Imperative.LanguageRenderer (Config(Config), FileType(Source),
   DecDef(Dec, Def), getEnv, complexDoc, inputDoc, ioDoc, functionListDoc, functionDoc, unOpDoc,
@@ -51,7 +51,8 @@ javaConfig options c =
         enumsEqualInts   = False,
         ext              = ".java",
         dir              = "java",
-        buildConfig      = buildSingle (\i _ -> ["javac", unwords i]) $ inCodePackage mainModuleFile,
+        buildConfig      = buildSingle (\i _ -> asFragment "javac" : i) $
+          inCodePackage mainModuleFile,
         runnable         = interp (flip withExt ".class" $ inCodePackage mainModule) jNameOpts "java",
         fileName         = fileNameD c,
         include          = includeD "import",

--- a/code/drasil-code/Language/Drasil/Code/Imperative/LanguageRenderer/ObjectiveCRenderer.hs
+++ b/code/drasil-code/Language/Drasil/Code/Imperative/LanguageRenderer/ObjectiveCRenderer.hs
@@ -9,7 +9,7 @@ import Language.Drasil.Code.Code (Code(..))
 import Language.Drasil.Code.Imperative.AST 
   hiding (body,comment,bool,int,float,char,tryBody,catchBody,initState,guard,
           update,forBody)
-import Language.Drasil.Code.Imperative.Build.AST (buildAll, cCompiler, nativeBinary)
+import Language.Drasil.Code.Imperative.Build.AST (asFragment, buildAll, cCompiler, nativeBinary)
 import Language.Drasil.Code.Imperative.LanguageRenderer (Config(Config), FileType(Source, Header),
   DecDef(Dec, Def), getEnv, complexDoc, inputDoc, ioDoc, functionListDoc, functionDoc, unOpDoc,
   valueDoc, methodTypeDoc, methodDoc, methodListDoc, statementDoc, stateDoc, stateListDoc,
@@ -52,7 +52,7 @@ objcConfig options c =
         enumsEqualInts   = False,
         ext              = ".m",
         dir              = "obj-c",
-        buildConfig      = buildAll $ \i o -> [cCompiler, unwords i, "-o", o],
+        buildConfig      = buildAll $ \i o -> cCompiler : i ++ [asFragment "-o", o],
         runnable         = nativeBinary,
         fileName         = fileNameD c,
         include          = includeD "#import",

--- a/code/drasil-code/drasil-code.cabal
+++ b/code/drasil-code/drasil-code.cabal
@@ -1,5 +1,5 @@
 Name:		  drasil-code
-Version:	0.1.5
+Version:	0.1.6
 Cabal-Version:  >= 1.18
 Author:		Dan Szymczak, Steven Palmer, Jacques Carette, Spencer Smith
 build-type:     Simple
@@ -41,7 +41,7 @@ library
     MissingH >= 1.4.0.1,
     parsec >= 3.1.9,
     drasil-lang >= 0.1.52,
-    drasil-build >= 0.1.0,
+    drasil-build >= 0.1.1,
     drasil-theory >= 0.1.0,
     drasil-database >= 0.1.0
   default-language: Haskell2010

--- a/code/drasil-printers/Language/Drasil/Output/Formats.hs
+++ b/code/drasil-printers/Language/Drasil/Output/Formats.hs
@@ -2,7 +2,8 @@
 module Language.Drasil.Output.Formats where
 
 import Data.Char (toLower)
-import Build.Drasil (Command, mkCheckedCommand, mkCommand, mkFile, mkRule, RuleTransformer(makeRule))
+import Build.Drasil ((+:+), Command, makeS, mkCheckedCommand, mkCommand,
+  mkFile, mkRule, RuleTransformer(makeRule))
 
 -- | When choosing your document, you must specify the filename for
 -- the generated output (specified /without/ a file extension)
@@ -15,12 +16,13 @@ data DocSpec = DocSpec DocType Filename
 instance RuleTransformer DocSpec where
   makeRule (DocSpec Website _) = []
   makeRule (DocSpec dt fn) = [
-    mkRule (map toLower $ show dt) [fn ++ ".pdf"] [],
-    mkFile (fn ++ ".pdf") [fn ++ ".tex"] $
+    mkRule (makeS $ map toLower $ show dt) [pdfName] [],
+    mkFile pdfName [makeS $ fn ++ ".tex"] $
       map ($ fn) [lualatex, bibtex, lualatex, lualatex]] where
         lualatex, bibtex :: String -> Command
-        lualatex = mkCheckedCommand . (++) "lualatex $(TEXFLAGS) "
-        bibtex = mkCommand . (++) "bibtex $(BIBTEXFLAGS) "
+        lualatex = mkCheckedCommand . (+:+) (makeS "lualatex $(TEXFLAGS)") . makeS
+        bibtex = mkCommand . (+:+) (makeS "bibtex $(BIBTEXFLAGS)") . makeS
+        pdfName = makeS $ fn ++ ".pdf"
 
 instance Show DocType where
   show SRS      = "SRS"

--- a/code/drasil-printers/Language/Drasil/Output/Formats.hs
+++ b/code/drasil-printers/Language/Drasil/Output/Formats.hs
@@ -2,7 +2,7 @@
 module Language.Drasil.Output.Formats where
 
 import Data.Char (toLower)
-import Build.Drasil ((+:+), Command, makeS, mkCheckedCommand, mkCommand,
+import Build.Drasil ((+:+), Command, makeS, mkCheckedCommand, mkCommand, mkFreeVar,
   mkFile, mkRule, RuleTransformer(makeRule))
 
 -- | When choosing your document, you must specify the filename for
@@ -20,8 +20,8 @@ instance RuleTransformer DocSpec where
     mkFile pdfName [makeS $ fn ++ ".tex"] $
       map ($ fn) [lualatex, bibtex, lualatex, lualatex]] where
         lualatex, bibtex :: String -> Command
-        lualatex = mkCheckedCommand . (+:+) (makeS "lualatex $(TEXFLAGS)") . makeS
-        bibtex = mkCommand . (+:+) (makeS "bibtex $(BIBTEXFLAGS)") . makeS
+        lualatex = mkCheckedCommand . (+:+) (makeS "lualatex" +:+ mkFreeVar "TEXFLAGS") . makeS
+        bibtex = mkCommand . (+:+) (makeS "bibtex" +:+ mkFreeVar "BIBTEXFLAGS") . makeS
         pdfName = makeS $ fn ++ ".pdf"
 
 instance Show DocType where

--- a/code/drasil-printers/drasil-printers.cabal
+++ b/code/drasil-printers/drasil-printers.cabal
@@ -1,5 +1,5 @@
 Name:		drasil-printers
-Version:	0.1.8
+Version:	0.1.9
 Cabal-Version:  >= 1.18
 Author:		Dan Szymczak, Steven Palmer, Jacques Carette, Spencer Smith
 build-type:     Simple
@@ -40,7 +40,7 @@ library
     data-fix (>= 0.0.4 && <= 1.0),
     drasil-lang >= 0.1.59,
     drasil-data >= 0.1.11,
-    drasil-build >= 0.1.0,
+    drasil-build >= 0.1.1,
     drasil-database >= 0.1.0
   default-language: Haskell2010
   ghc-options:      -Wall -Wredundant-constraints

--- a/code/stable/gamephys/SRS/Makefile
+++ b/code/stable/gamephys/SRS/Makefile
@@ -1,16 +1,16 @@
 ifeq "$(OS)" "Windows_NT"
-	TARGET_EXTENSION=.exe
-	RM=del
+    TARGET_EXTENSION=.exe
+    RM=del
 else
-	UNAME_S := $(shell uname -s)
-	ifeq ($(UNAME_S), Linux)
-		TARGET_EXTENSION=
-		RM=rm
-	endif
-	ifeq ($(UNAME_S), Darwin)
-		TARGET_EXTENSION=
-		RM=rm
-	endif
+    UNAME_S := $(shell uname -s)
+    ifeq ($(UNAME_S), Linux)
+        TARGET_EXTENSION=
+        RM=rm
+    endif
+    ifeq ($(UNAME_S), Darwin)
+        TARGET_EXTENSION=
+        RM=rm
+    endif
 endif
 
 srs: Chipmunk_SRS.pdf

--- a/code/stable/gamephys/SRS/Makefile
+++ b/code/stable/gamephys/SRS/Makefile
@@ -1,18 +1,3 @@
-ifeq "$(OS)" "Windows_NT"
-    TARGET_EXTENSION=.exe
-    RM=del
-else
-    UNAME_S := $(shell uname -s)
-    ifeq ($(UNAME_S), Linux)
-        TARGET_EXTENSION=
-        RM=rm
-    endif
-    ifeq ($(UNAME_S), Darwin)
-        TARGET_EXTENSION=
-        RM=rm
-    endif
-endif
-
 srs: Chipmunk_SRS.pdf
 
 Chipmunk_SRS.pdf: Chipmunk_SRS.tex

--- a/code/stable/glassbr/SRS/Makefile
+++ b/code/stable/glassbr/SRS/Makefile
@@ -1,16 +1,16 @@
 ifeq "$(OS)" "Windows_NT"
-	TARGET_EXTENSION=.exe
-	RM=del
+    TARGET_EXTENSION=.exe
+    RM=del
 else
-	UNAME_S := $(shell uname -s)
-	ifeq ($(UNAME_S), Linux)
-		TARGET_EXTENSION=
-		RM=rm
-	endif
-	ifeq ($(UNAME_S), Darwin)
-		TARGET_EXTENSION=
-		RM=rm
-	endif
+    UNAME_S := $(shell uname -s)
+    ifeq ($(UNAME_S), Linux)
+        TARGET_EXTENSION=
+        RM=rm
+    endif
+    ifeq ($(UNAME_S), Darwin)
+        TARGET_EXTENSION=
+        RM=rm
+    endif
 endif
 
 srs: GlassBR_SRS.pdf

--- a/code/stable/glassbr/SRS/Makefile
+++ b/code/stable/glassbr/SRS/Makefile
@@ -1,18 +1,3 @@
-ifeq "$(OS)" "Windows_NT"
-    TARGET_EXTENSION=.exe
-    RM=del
-else
-    UNAME_S := $(shell uname -s)
-    ifeq ($(UNAME_S), Linux)
-        TARGET_EXTENSION=
-        RM=rm
-    endif
-    ifeq ($(UNAME_S), Darwin)
-        TARGET_EXTENSION=
-        RM=rm
-    endif
-endif
-
 srs: GlassBR_SRS.pdf
 
 GlassBR_SRS.pdf: GlassBR_SRS.tex

--- a/code/stable/glassbr/src/cpp/Makefile
+++ b/code/stable/glassbr/src/cpp/Makefile
@@ -1,16 +1,16 @@
 ifeq "$(OS)" "Windows_NT"
-	TARGET_EXTENSION=.exe
-	RM=del
+    TARGET_EXTENSION=.exe
+    RM=del
 else
-	UNAME_S := $(shell uname -s)
-	ifeq ($(UNAME_S), Linux)
-		TARGET_EXTENSION=
-		RM=rm
-	endif
-	ifeq ($(UNAME_S), Darwin)
-		TARGET_EXTENSION=
-		RM=rm
-	endif
+    UNAME_S := $(shell uname -s)
+    ifeq ($(UNAME_S), Linux)
+        TARGET_EXTENSION=
+        RM=rm
+    endif
+    ifeq ($(UNAME_S), Darwin)
+        TARGET_EXTENSION=
+        RM=rm
+    endif
 endif
 
 build: GlassBR$(TARGET_EXTENSION)

--- a/code/stable/glassbr/src/cpp/Makefile
+++ b/code/stable/glassbr/src/cpp/Makefile
@@ -1,17 +1,11 @@
 ifeq "$(OS)" "Windows_NT"
     TARGET_EXTENSION=.exe
-    RM=del
-    TARGET_EXTENSION=.exe
 else
     UNAME_S := $(shell uname -s)
     ifeq ($(UNAME_S), Linux)
         TARGET_EXTENSION=
-        RM=rm
-        TARGET_EXTENSION=
     endif
     ifeq ($(UNAME_S), Darwin)
-        TARGET_EXTENSION=
-        RM=rm
         TARGET_EXTENSION=
     endif
 endif

--- a/code/stable/glassbr/src/cpp/Makefile
+++ b/code/stable/glassbr/src/cpp/Makefile
@@ -1,15 +1,18 @@
 ifeq "$(OS)" "Windows_NT"
     TARGET_EXTENSION=.exe
     RM=del
+    TARGET_EXTENSION=.exe
 else
     UNAME_S := $(shell uname -s)
     ifeq ($(UNAME_S), Linux)
         TARGET_EXTENSION=
         RM=rm
+        TARGET_EXTENSION=
     endif
     ifeq ($(UNAME_S), Darwin)
         TARGET_EXTENSION=
         RM=rm
+        TARGET_EXTENSION=
     endif
 endif
 

--- a/code/stable/glassbr/src/csharp/Makefile
+++ b/code/stable/glassbr/src/csharp/Makefile
@@ -1,16 +1,16 @@
 ifeq "$(OS)" "Windows_NT"
-	TARGET_EXTENSION=.exe
-	RM=del
+    TARGET_EXTENSION=.exe
+    RM=del
 else
-	UNAME_S := $(shell uname -s)
-	ifeq ($(UNAME_S), Linux)
-		TARGET_EXTENSION=
-		RM=rm
-	endif
-	ifeq ($(UNAME_S), Darwin)
-		TARGET_EXTENSION=
-		RM=rm
-	endif
+    UNAME_S := $(shell uname -s)
+    ifeq ($(UNAME_S), Linux)
+        TARGET_EXTENSION=
+        RM=rm
+    endif
+    ifeq ($(UNAME_S), Darwin)
+        TARGET_EXTENSION=
+        RM=rm
+    endif
 endif
 
 build: GlassBR$(TARGET_EXTENSION)

--- a/code/stable/glassbr/src/csharp/Makefile
+++ b/code/stable/glassbr/src/csharp/Makefile
@@ -1,19 +1,22 @@
 ifeq "$(OS)" "Windows_NT"
     TARGET_EXTENSION=.exe
+    CSC=csc
 else
     UNAME_S := $(shell uname -s)
     ifeq ($(UNAME_S), Linux)
         TARGET_EXTENSION=
+        CSC=mcs
     endif
     ifeq ($(UNAME_S), Darwin)
         TARGET_EXTENSION=
+        CSC=mcs
     endif
 endif
 
 build: GlassBR$(TARGET_EXTENSION)
 
 GlassBR$(TARGET_EXTENSION): Control.cs InputParameters.cs DerivedValues.cs InputConstraints.cs OutputFormat.cs Calculations.cs ReadTable.cs InputFormat.cs Interpolation.cs
-	mcs Control.cs InputParameters.cs DerivedValues.cs InputConstraints.cs OutputFormat.cs Calculations.cs ReadTable.cs InputFormat.cs Interpolation.cs -out:GlassBR$(TARGET_EXTENSION)
+	$(CSC) -out:GlassBR$(TARGET_EXTENSION) Control.cs InputParameters.cs DerivedValues.cs InputConstraints.cs OutputFormat.cs Calculations.cs ReadTable.cs InputFormat.cs Interpolation.cs
 
 run: build
 	./GlassBR$(TARGET_EXTENSION) $(RUNARGS)

--- a/code/stable/glassbr/src/csharp/Makefile
+++ b/code/stable/glassbr/src/csharp/Makefile
@@ -1,17 +1,11 @@
 ifeq "$(OS)" "Windows_NT"
     TARGET_EXTENSION=.exe
-    RM=del
-    TARGET_EXTENSION=.exe
 else
     UNAME_S := $(shell uname -s)
     ifeq ($(UNAME_S), Linux)
         TARGET_EXTENSION=
-        RM=rm
-        TARGET_EXTENSION=
     endif
     ifeq ($(UNAME_S), Darwin)
-        TARGET_EXTENSION=
-        RM=rm
         TARGET_EXTENSION=
     endif
 endif

--- a/code/stable/glassbr/src/csharp/Makefile
+++ b/code/stable/glassbr/src/csharp/Makefile
@@ -1,15 +1,18 @@
 ifeq "$(OS)" "Windows_NT"
     TARGET_EXTENSION=.exe
     RM=del
+    TARGET_EXTENSION=.exe
 else
     UNAME_S := $(shell uname -s)
     ifeq ($(UNAME_S), Linux)
         TARGET_EXTENSION=
         RM=rm
+        TARGET_EXTENSION=
     endif
     ifeq ($(UNAME_S), Darwin)
         TARGET_EXTENSION=
         RM=rm
+        TARGET_EXTENSION=
     endif
 endif
 

--- a/code/stable/glassbr/src/java/Makefile
+++ b/code/stable/glassbr/src/java/Makefile
@@ -1,18 +1,3 @@
-ifeq "$(OS)" "Windows_NT"
-    TARGET_EXTENSION=.exe
-    RM=del
-else
-    UNAME_S := $(shell uname -s)
-    ifeq ($(UNAME_S), Linux)
-        TARGET_EXTENSION=
-        RM=rm
-    endif
-    ifeq ($(UNAME_S), Darwin)
-        TARGET_EXTENSION=
-        RM=rm
-    endif
-endif
-
 build: GlassBR/Control.class
 
 GlassBR/Control.class: GlassBR/Control.java GlassBR/InputParameters.java GlassBR/DerivedValues.java GlassBR/InputConstraints.java GlassBR/OutputFormat.java GlassBR/Calculations.java GlassBR/ReadTable.java GlassBR/InputFormat.java GlassBR/Interpolation.java

--- a/code/stable/glassbr/src/java/Makefile
+++ b/code/stable/glassbr/src/java/Makefile
@@ -1,16 +1,16 @@
 ifeq "$(OS)" "Windows_NT"
-	TARGET_EXTENSION=.exe
-	RM=del
+    TARGET_EXTENSION=.exe
+    RM=del
 else
-	UNAME_S := $(shell uname -s)
-	ifeq ($(UNAME_S), Linux)
-		TARGET_EXTENSION=
-		RM=rm
-	endif
-	ifeq ($(UNAME_S), Darwin)
-		TARGET_EXTENSION=
-		RM=rm
-	endif
+    UNAME_S := $(shell uname -s)
+    ifeq ($(UNAME_S), Linux)
+        TARGET_EXTENSION=
+        RM=rm
+    endif
+    ifeq ($(UNAME_S), Darwin)
+        TARGET_EXTENSION=
+        RM=rm
+    endif
 endif
 
 build: GlassBR/Control.class

--- a/code/stable/glassbr/src/python/Makefile
+++ b/code/stable/glassbr/src/python/Makefile
@@ -1,16 +1,16 @@
 ifeq "$(OS)" "Windows_NT"
-	TARGET_EXTENSION=.exe
-	RM=del
+    TARGET_EXTENSION=.exe
+    RM=del
 else
-	UNAME_S := $(shell uname -s)
-	ifeq ($(UNAME_S), Linux)
-		TARGET_EXTENSION=
-		RM=rm
-	endif
-	ifeq ($(UNAME_S), Darwin)
-		TARGET_EXTENSION=
-		RM=rm
-	endif
+    UNAME_S := $(shell uname -s)
+    ifeq ($(UNAME_S), Linux)
+        TARGET_EXTENSION=
+        RM=rm
+    endif
+    ifeq ($(UNAME_S), Darwin)
+        TARGET_EXTENSION=
+        RM=rm
+    endif
 endif
 
 build:

--- a/code/stable/glassbr/src/python/Makefile
+++ b/code/stable/glassbr/src/python/Makefile
@@ -1,18 +1,3 @@
-ifeq "$(OS)" "Windows_NT"
-    TARGET_EXTENSION=.exe
-    RM=del
-else
-    UNAME_S := $(shell uname -s)
-    ifeq ($(UNAME_S), Linux)
-        TARGET_EXTENSION=
-        RM=rm
-    endif
-    ifeq ($(UNAME_S), Darwin)
-        TARGET_EXTENSION=
-        RM=rm
-    endif
-endif
-
 build:
 
 run: build

--- a/code/stable/nopcm/SRS/Makefile
+++ b/code/stable/nopcm/SRS/Makefile
@@ -1,18 +1,3 @@
-ifeq "$(OS)" "Windows_NT"
-    TARGET_EXTENSION=.exe
-    RM=del
-else
-    UNAME_S := $(shell uname -s)
-    ifeq ($(UNAME_S), Linux)
-        TARGET_EXTENSION=
-        RM=rm
-    endif
-    ifeq ($(UNAME_S), Darwin)
-        TARGET_EXTENSION=
-        RM=rm
-    endif
-endif
-
 srs: NoPCM_SRS.pdf
 
 NoPCM_SRS.pdf: NoPCM_SRS.tex

--- a/code/stable/nopcm/SRS/Makefile
+++ b/code/stable/nopcm/SRS/Makefile
@@ -1,16 +1,16 @@
 ifeq "$(OS)" "Windows_NT"
-	TARGET_EXTENSION=.exe
-	RM=del
+    TARGET_EXTENSION=.exe
+    RM=del
 else
-	UNAME_S := $(shell uname -s)
-	ifeq ($(UNAME_S), Linux)
-		TARGET_EXTENSION=
-		RM=rm
-	endif
-	ifeq ($(UNAME_S), Darwin)
-		TARGET_EXTENSION=
-		RM=rm
-	endif
+    UNAME_S := $(shell uname -s)
+    ifeq ($(UNAME_S), Linux)
+        TARGET_EXTENSION=
+        RM=rm
+    endif
+    ifeq ($(UNAME_S), Darwin)
+        TARGET_EXTENSION=
+        RM=rm
+    endif
 endif
 
 srs: NoPCM_SRS.pdf

--- a/code/stable/nopcm/src/cpp/Makefile
+++ b/code/stable/nopcm/src/cpp/Makefile
@@ -1,16 +1,16 @@
 ifeq "$(OS)" "Windows_NT"
-	TARGET_EXTENSION=.exe
-	RM=del
+    TARGET_EXTENSION=.exe
+    RM=del
 else
-	UNAME_S := $(shell uname -s)
-	ifeq ($(UNAME_S), Linux)
-		TARGET_EXTENSION=
-		RM=rm
-	endif
-	ifeq ($(UNAME_S), Darwin)
-		TARGET_EXTENSION=
-		RM=rm
-	endif
+    UNAME_S := $(shell uname -s)
+    ifeq ($(UNAME_S), Linux)
+        TARGET_EXTENSION=
+        RM=rm
+    endif
+    ifeq ($(UNAME_S), Darwin)
+        TARGET_EXTENSION=
+        RM=rm
+    endif
 endif
 
 build: SWHS$(TARGET_EXTENSION)

--- a/code/stable/nopcm/src/cpp/Makefile
+++ b/code/stable/nopcm/src/cpp/Makefile
@@ -1,17 +1,11 @@
 ifeq "$(OS)" "Windows_NT"
     TARGET_EXTENSION=.exe
-    RM=del
-    TARGET_EXTENSION=.exe
 else
     UNAME_S := $(shell uname -s)
     ifeq ($(UNAME_S), Linux)
         TARGET_EXTENSION=
-        RM=rm
-        TARGET_EXTENSION=
     endif
     ifeq ($(UNAME_S), Darwin)
-        TARGET_EXTENSION=
-        RM=rm
         TARGET_EXTENSION=
     endif
 endif

--- a/code/stable/nopcm/src/cpp/Makefile
+++ b/code/stable/nopcm/src/cpp/Makefile
@@ -1,15 +1,18 @@
 ifeq "$(OS)" "Windows_NT"
     TARGET_EXTENSION=.exe
     RM=del
+    TARGET_EXTENSION=.exe
 else
     UNAME_S := $(shell uname -s)
     ifeq ($(UNAME_S), Linux)
         TARGET_EXTENSION=
         RM=rm
+        TARGET_EXTENSION=
     endif
     ifeq ($(UNAME_S), Darwin)
         TARGET_EXTENSION=
         RM=rm
+        TARGET_EXTENSION=
     endif
 endif
 

--- a/code/stable/nopcm/src/csharp/Makefile
+++ b/code/stable/nopcm/src/csharp/Makefile
@@ -1,16 +1,16 @@
 ifeq "$(OS)" "Windows_NT"
-	TARGET_EXTENSION=.exe
-	RM=del
+    TARGET_EXTENSION=.exe
+    RM=del
 else
-	UNAME_S := $(shell uname -s)
-	ifeq ($(UNAME_S), Linux)
-		TARGET_EXTENSION=
-		RM=rm
-	endif
-	ifeq ($(UNAME_S), Darwin)
-		TARGET_EXTENSION=
-		RM=rm
-	endif
+    UNAME_S := $(shell uname -s)
+    ifeq ($(UNAME_S), Linux)
+        TARGET_EXTENSION=
+        RM=rm
+    endif
+    ifeq ($(UNAME_S), Darwin)
+        TARGET_EXTENSION=
+        RM=rm
+    endif
 endif
 
 build: SWHS$(TARGET_EXTENSION)

--- a/code/stable/nopcm/src/csharp/Makefile
+++ b/code/stable/nopcm/src/csharp/Makefile
@@ -1,17 +1,11 @@
 ifeq "$(OS)" "Windows_NT"
     TARGET_EXTENSION=.exe
-    RM=del
-    TARGET_EXTENSION=.exe
 else
     UNAME_S := $(shell uname -s)
     ifeq ($(UNAME_S), Linux)
         TARGET_EXTENSION=
-        RM=rm
-        TARGET_EXTENSION=
     endif
     ifeq ($(UNAME_S), Darwin)
-        TARGET_EXTENSION=
-        RM=rm
         TARGET_EXTENSION=
     endif
 endif

--- a/code/stable/nopcm/src/csharp/Makefile
+++ b/code/stable/nopcm/src/csharp/Makefile
@@ -1,19 +1,22 @@
 ifeq "$(OS)" "Windows_NT"
     TARGET_EXTENSION=.exe
+    CSC=csc
 else
     UNAME_S := $(shell uname -s)
     ifeq ($(UNAME_S), Linux)
         TARGET_EXTENSION=
+        CSC=mcs
     endif
     ifeq ($(UNAME_S), Darwin)
         TARGET_EXTENSION=
+        CSC=mcs
     endif
 endif
 
 build: SWHS$(TARGET_EXTENSION)
 
 SWHS$(TARGET_EXTENSION): Control.cs InputParameters.cs OutputFormat.cs Calculations.cs InputFormat.cs
-	mcs Control.cs InputParameters.cs OutputFormat.cs Calculations.cs InputFormat.cs -out:SWHS$(TARGET_EXTENSION)
+	$(CSC) -out:SWHS$(TARGET_EXTENSION) Control.cs InputParameters.cs OutputFormat.cs Calculations.cs InputFormat.cs
 
 run: build
 	./SWHS$(TARGET_EXTENSION) $(RUNARGS)

--- a/code/stable/nopcm/src/csharp/Makefile
+++ b/code/stable/nopcm/src/csharp/Makefile
@@ -1,15 +1,18 @@
 ifeq "$(OS)" "Windows_NT"
     TARGET_EXTENSION=.exe
     RM=del
+    TARGET_EXTENSION=.exe
 else
     UNAME_S := $(shell uname -s)
     ifeq ($(UNAME_S), Linux)
         TARGET_EXTENSION=
         RM=rm
+        TARGET_EXTENSION=
     endif
     ifeq ($(UNAME_S), Darwin)
         TARGET_EXTENSION=
         RM=rm
+        TARGET_EXTENSION=
     endif
 endif
 

--- a/code/stable/nopcm/src/java/Makefile
+++ b/code/stable/nopcm/src/java/Makefile
@@ -1,16 +1,16 @@
 ifeq "$(OS)" "Windows_NT"
-	TARGET_EXTENSION=.exe
-	RM=del
+    TARGET_EXTENSION=.exe
+    RM=del
 else
-	UNAME_S := $(shell uname -s)
-	ifeq ($(UNAME_S), Linux)
-		TARGET_EXTENSION=
-		RM=rm
-	endif
-	ifeq ($(UNAME_S), Darwin)
-		TARGET_EXTENSION=
-		RM=rm
-	endif
+    UNAME_S := $(shell uname -s)
+    ifeq ($(UNAME_S), Linux)
+        TARGET_EXTENSION=
+        RM=rm
+    endif
+    ifeq ($(UNAME_S), Darwin)
+        TARGET_EXTENSION=
+        RM=rm
+    endif
 endif
 
 build: SWHS/Control.class

--- a/code/stable/nopcm/src/java/Makefile
+++ b/code/stable/nopcm/src/java/Makefile
@@ -1,18 +1,3 @@
-ifeq "$(OS)" "Windows_NT"
-    TARGET_EXTENSION=.exe
-    RM=del
-else
-    UNAME_S := $(shell uname -s)
-    ifeq ($(UNAME_S), Linux)
-        TARGET_EXTENSION=
-        RM=rm
-    endif
-    ifeq ($(UNAME_S), Darwin)
-        TARGET_EXTENSION=
-        RM=rm
-    endif
-endif
-
 build: SWHS/Control.class
 
 SWHS/Control.class: SWHS/Control.java SWHS/InputParameters.java SWHS/OutputFormat.java SWHS/Calculations.java SWHS/InputFormat.java

--- a/code/stable/nopcm/src/python/Makefile
+++ b/code/stable/nopcm/src/python/Makefile
@@ -1,16 +1,16 @@
 ifeq "$(OS)" "Windows_NT"
-	TARGET_EXTENSION=.exe
-	RM=del
+    TARGET_EXTENSION=.exe
+    RM=del
 else
-	UNAME_S := $(shell uname -s)
-	ifeq ($(UNAME_S), Linux)
-		TARGET_EXTENSION=
-		RM=rm
-	endif
-	ifeq ($(UNAME_S), Darwin)
-		TARGET_EXTENSION=
-		RM=rm
-	endif
+    UNAME_S := $(shell uname -s)
+    ifeq ($(UNAME_S), Linux)
+        TARGET_EXTENSION=
+        RM=rm
+    endif
+    ifeq ($(UNAME_S), Darwin)
+        TARGET_EXTENSION=
+        RM=rm
+    endif
 endif
 
 build:

--- a/code/stable/nopcm/src/python/Makefile
+++ b/code/stable/nopcm/src/python/Makefile
@@ -1,18 +1,3 @@
-ifeq "$(OS)" "Windows_NT"
-    TARGET_EXTENSION=.exe
-    RM=del
-else
-    UNAME_S := $(shell uname -s)
-    ifeq ($(UNAME_S), Linux)
-        TARGET_EXTENSION=
-        RM=rm
-    endif
-    ifeq ($(UNAME_S), Darwin)
-        TARGET_EXTENSION=
-        RM=rm
-    endif
-endif
-
 build:
 
 run: build

--- a/code/stable/projectile/SRS/Makefile
+++ b/code/stable/projectile/SRS/Makefile
@@ -1,18 +1,3 @@
-ifeq "$(OS)" "Windows_NT"
-    TARGET_EXTENSION=.exe
-    RM=del
-else
-    UNAME_S := $(shell uname -s)
-    ifeq ($(UNAME_S), Linux)
-        TARGET_EXTENSION=
-        RM=rm
-    endif
-    ifeq ($(UNAME_S), Darwin)
-        TARGET_EXTENSION=
-        RM=rm
-    endif
-endif
-
 srs: Projectile_SRS.pdf
 
 Projectile_SRS.pdf: Projectile_SRS.tex

--- a/code/stable/projectile/SRS/Makefile
+++ b/code/stable/projectile/SRS/Makefile
@@ -1,16 +1,16 @@
 ifeq "$(OS)" "Windows_NT"
-	TARGET_EXTENSION=.exe
-	RM=del
+    TARGET_EXTENSION=.exe
+    RM=del
 else
-	UNAME_S := $(shell uname -s)
-	ifeq ($(UNAME_S), Linux)
-		TARGET_EXTENSION=
-		RM=rm
-	endif
-	ifeq ($(UNAME_S), Darwin)
-		TARGET_EXTENSION=
-		RM=rm
-	endif
+    UNAME_S := $(shell uname -s)
+    ifeq ($(UNAME_S), Linux)
+        TARGET_EXTENSION=
+        RM=rm
+    endif
+    ifeq ($(UNAME_S), Darwin)
+        TARGET_EXTENSION=
+        RM=rm
+    endif
 endif
 
 srs: Projectile_SRS.pdf

--- a/code/stable/ssp/SRS/Makefile
+++ b/code/stable/ssp/SRS/Makefile
@@ -1,16 +1,16 @@
 ifeq "$(OS)" "Windows_NT"
-	TARGET_EXTENSION=.exe
-	RM=del
+    TARGET_EXTENSION=.exe
+    RM=del
 else
-	UNAME_S := $(shell uname -s)
-	ifeq ($(UNAME_S), Linux)
-		TARGET_EXTENSION=
-		RM=rm
-	endif
-	ifeq ($(UNAME_S), Darwin)
-		TARGET_EXTENSION=
-		RM=rm
-	endif
+    UNAME_S := $(shell uname -s)
+    ifeq ($(UNAME_S), Linux)
+        TARGET_EXTENSION=
+        RM=rm
+    endif
+    ifeq ($(UNAME_S), Darwin)
+        TARGET_EXTENSION=
+        RM=rm
+    endif
 endif
 
 srs: SSP_SRS.pdf

--- a/code/stable/ssp/SRS/Makefile
+++ b/code/stable/ssp/SRS/Makefile
@@ -1,18 +1,3 @@
-ifeq "$(OS)" "Windows_NT"
-    TARGET_EXTENSION=.exe
-    RM=del
-else
-    UNAME_S := $(shell uname -s)
-    ifeq ($(UNAME_S), Linux)
-        TARGET_EXTENSION=
-        RM=rm
-    endif
-    ifeq ($(UNAME_S), Darwin)
-        TARGET_EXTENSION=
-        RM=rm
-    endif
-endif
-
 srs: SSP_SRS.pdf
 
 SSP_SRS.pdf: SSP_SRS.tex

--- a/code/stable/swhs/SRS/Makefile
+++ b/code/stable/swhs/SRS/Makefile
@@ -1,18 +1,3 @@
-ifeq "$(OS)" "Windows_NT"
-    TARGET_EXTENSION=.exe
-    RM=del
-else
-    UNAME_S := $(shell uname -s)
-    ifeq ($(UNAME_S), Linux)
-        TARGET_EXTENSION=
-        RM=rm
-    endif
-    ifeq ($(UNAME_S), Darwin)
-        TARGET_EXTENSION=
-        RM=rm
-    endif
-endif
-
 srs: SWHS_SRS.pdf
 
 SWHS_SRS.pdf: SWHS_SRS.tex

--- a/code/stable/swhs/SRS/Makefile
+++ b/code/stable/swhs/SRS/Makefile
@@ -1,16 +1,16 @@
 ifeq "$(OS)" "Windows_NT"
-	TARGET_EXTENSION=.exe
-	RM=del
+    TARGET_EXTENSION=.exe
+    RM=del
 else
-	UNAME_S := $(shell uname -s)
-	ifeq ($(UNAME_S), Linux)
-		TARGET_EXTENSION=
-		RM=rm
-	endif
-	ifeq ($(UNAME_S), Darwin)
-		TARGET_EXTENSION=
-		RM=rm
-	endif
+    UNAME_S := $(shell uname -s)
+    ifeq ($(UNAME_S), Linux)
+        TARGET_EXTENSION=
+        RM=rm
+    endif
+    ifeq ($(UNAME_S), Darwin)
+        TARGET_EXTENSION=
+        RM=rm
+    endif
 endif
 
 srs: SWHS_SRS.pdf

--- a/code/stable/template/SRS/Makefile
+++ b/code/stable/template/SRS/Makefile
@@ -1,18 +1,3 @@
-ifeq "$(OS)" "Windows_NT"
-    TARGET_EXTENSION=.exe
-    RM=del
-else
-    UNAME_S := $(shell uname -s)
-    ifeq ($(UNAME_S), Linux)
-        TARGET_EXTENSION=
-        RM=rm
-    endif
-    ifeq ($(UNAME_S), Darwin)
-        TARGET_EXTENSION=
-        RM=rm
-    endif
-endif
-
 srs: Projectile_SRS.pdf
 
 Projectile_SRS.pdf: Projectile_SRS.tex

--- a/code/stable/template/SRS/Makefile
+++ b/code/stable/template/SRS/Makefile
@@ -1,16 +1,16 @@
 ifeq "$(OS)" "Windows_NT"
-	TARGET_EXTENSION=.exe
-	RM=del
+    TARGET_EXTENSION=.exe
+    RM=del
 else
-	UNAME_S := $(shell uname -s)
-	ifeq ($(UNAME_S), Linux)
-		TARGET_EXTENSION=
-		RM=rm
-	endif
-	ifeq ($(UNAME_S), Darwin)
-		TARGET_EXTENSION=
-		RM=rm
-	endif
+    UNAME_S := $(shell uname -s)
+    ifeq ($(UNAME_S), Linux)
+        TARGET_EXTENSION=
+        RM=rm
+    endif
+    ifeq ($(UNAME_S), Darwin)
+        TARGET_EXTENSION=
+        RM=rm
+    endif
 endif
 
 srs: Projectile_SRS.pdf

--- a/code/stable/tiny/SRS/Makefile
+++ b/code/stable/tiny/SRS/Makefile
@@ -1,16 +1,16 @@
 ifeq "$(OS)" "Windows_NT"
-	TARGET_EXTENSION=.exe
-	RM=del
+    TARGET_EXTENSION=.exe
+    RM=del
 else
-	UNAME_S := $(shell uname -s)
-	ifeq ($(UNAME_S), Linux)
-		TARGET_EXTENSION=
-		RM=rm
-	endif
-	ifeq ($(UNAME_S), Darwin)
-		TARGET_EXTENSION=
-		RM=rm
-	endif
+    UNAME_S := $(shell uname -s)
+    ifeq ($(UNAME_S), Linux)
+        TARGET_EXTENSION=
+        RM=rm
+    endif
+    ifeq ($(UNAME_S), Darwin)
+        TARGET_EXTENSION=
+        RM=rm
+    endif
 endif
 
 srs: Tiny_SRS.pdf

--- a/code/stable/tiny/SRS/Makefile
+++ b/code/stable/tiny/SRS/Makefile
@@ -1,18 +1,3 @@
-ifeq "$(OS)" "Windows_NT"
-    TARGET_EXTENSION=.exe
-    RM=del
-else
-    UNAME_S := $(shell uname -s)
-    ifeq ($(UNAME_S), Linux)
-        TARGET_EXTENSION=
-        RM=rm
-    endif
-    ifeq ($(UNAME_S), Darwin)
-        TARGET_EXTENSION=
-        RM=rm
-    endif
-endif
-
 srs: Tiny_SRS.pdf
 
 Tiny_SRS.pdf: Tiny_SRS.tex


### PR DESCRIPTION
This PR introduces a (more) dynamic form of Makefile variables. Gone are the days of hardcoding `"$(VAR)"` places. Makefiles no longer contain variables which aren't used, and don't print the OS preamble if not needed. 

This PR also addresses #1298 by added an OS variable for a default C# compiler based on platform. I've added @bmaclach as a reviewer to ensure `csc` works as expected in the `Makefile` on Windows.

Closes #1298