### PR TITLE
PR - Remove prefixes from NoPCM

### DIFF
--- a/code/drasil-example/Drasil/NoPCM/Body.hs
+++ b/code/drasil-example/Drasil/NoPCM/Body.hs
@@ -191,8 +191,8 @@ iMods = getTraceMapFromIM $ getSCSSub mkSRS
 genDef :: [GenDefn]
 genDef = getTraceMapFromGD $ getSCSSub mkSRS
 
-nopcm_theory :: [TheoryModel]
-nopcm_theory = getTraceMapFromTM $ getSCSSub mkSRS
+theory :: [TheoryModel]
+theory = getTraceMapFromTM $ getSCSSub mkSRS
 
 nopcm_concins :: [ConceptInstance]
 nopcm_concins =
@@ -248,13 +248,13 @@ nopcm_SymbMap = cdb (symbolsAll) (map nw symbols ++ map nw acronyms ++ map nw th
   ++ map nw physicalcon ++ map nw swhsUC ++ [nw srs_swhs, nw algorithm, nw ht_trans] ++ map nw checkSi
   ++ map nw [abs_tol, rel_tol, cons_tol])
   (map cw symbols ++ srsDomains)
-  this_si label refBy dataDefn iMods genDef nopcm_theory
+  this_si label refBy dataDefn iMods genDef theory
   nopcm_concins nopcm_section nopcm_labcon
 
 usedDB :: ChunkDB
 usedDB = cdb (map qw symbTT) (map nw symbols ++ map nw acronyms ++ map nw checkSi)
  ([] :: [ConceptChunk]) checkSi label refBy
- dataDefn iMods genDef nopcm_theory nopcm_concins
+ dataDefn iMods genDef theory nopcm_concins
  nopcm_section nopcm_labcon
 
 printSetting :: PrintingInformation

--- a/code/drasil-example/Drasil/NoPCM/Body.hs
+++ b/code/drasil-example/Drasil/NoPCM/Body.hs
@@ -177,7 +177,7 @@ mkSRS = [RefSec $ RefProg intro
   map Verbatim [specParamVal] ++ [Bibliography]
 
 label :: TraceMap
-label = Map.union (generateTraceMap mkSRS) $ generateTraceMap' nopcm_concins
+label = Map.union (generateTraceMap mkSRS) $ generateTraceMap' concIns
  
 refBy :: RefbyMap
 refBy = generateRefbyMap label
@@ -194,8 +194,8 @@ genDef = getTraceMapFromGD $ getSCSSub mkSRS
 theory :: [TheoryModel]
 theory = getTraceMapFromTM $ getSCSSub mkSRS
 
-nopcm_concins :: [ConceptInstance]
-nopcm_concins =
+concIns :: [ConceptInstance]
+concIns =
  reqs ++ [likeChgTCVOD, likeChgTCVOL] ++ assumptions ++ likelyChgs ++
  [likeChgTLH] ++ unlikelyChgs
 
@@ -231,7 +231,7 @@ nopcm_si = SI {
 }
 
 nopcmRefDB :: ReferenceDB
-nopcmRefDB = rdb referencesRefList nopcm_concins
+nopcmRefDB = rdb referencesRefList concIns
 
 nopcm_code :: CodeSpec
 nopcm_code = codeSpec nopcm_si [inputMod]
@@ -249,12 +249,12 @@ nopcm_SymbMap = cdb (symbolsAll) (map nw symbols ++ map nw acronyms ++ map nw th
   ++ map nw [abs_tol, rel_tol, cons_tol])
   (map cw symbols ++ srsDomains)
   this_si label refBy dataDefn iMods genDef theory
-  nopcm_concins nopcm_section nopcm_labcon
+  concIns nopcm_section nopcm_labcon
 
 usedDB :: ChunkDB
 usedDB = cdb (map qw symbTT) (map nw symbols ++ map nw acronyms ++ map nw checkSi)
  ([] :: [ConceptChunk]) checkSi label refBy
- dataDefn iMods genDef theory nopcm_concins
+ dataDefn iMods genDef theory concIns
  nopcm_section nopcm_labcon
 
 printSetting :: PrintingInformation

--- a/code/drasil-example/Drasil/NoPCM/Body.hs
+++ b/code/drasil-example/Drasil/NoPCM/Body.hs
@@ -98,7 +98,7 @@ this_si :: [UnitDefn]
 this_si = map unitWrapper [metre, kilogram, second] ++ map unitWrapper [centigrade, joule, watt]
 
 checkSi :: [UnitDefn]
-checkSi = collectUnits nopcm_SymbMap symbTT 
+checkSi = collectUnits symbMap symbTT 
 
 -- This contains the list of symbols used throughout the document
 symbols :: [DefinedQuantityDict]
@@ -226,7 +226,7 @@ si = SI {
   _defSequence = [Parallel dd1HtFluxCQD []],
   _constraints = (map cnstrw constraints ++ map cnstrw [temp_W, w_E]),        --constrained
   _constants = [],
-  _sysinfodb = nopcm_SymbMap,
+  _sysinfodb = symbMap,
   _usedinfodb = usedDB,
    refdb = refDB
 }
@@ -241,8 +241,8 @@ code = codeSpec si [inputMod]
 srs :: Document
 srs = mkDoc mkSRS (for) si
 
-nopcm_SymbMap :: ChunkDB
-nopcm_SymbMap = cdb (symbolsAll) (map nw symbols ++ map nw acronyms ++ map nw thermocon
+symbMap :: ChunkDB
+symbMap = cdb (symbolsAll) (map nw symbols ++ map nw acronyms ++ map nw thermocon
   ++ map nw physicscon ++ map nw doccon ++ map nw softwarecon ++ map nw doccon' ++ map nw swhscon
   ++ map nw prodtcon ++ map nw physicCon ++ map nw physicCon' ++ map nw mathcon ++ map nw mathcon'
   ++ map nw specParamValList ++ map nw fundamentals ++ map nw educon ++ map nw derived 
@@ -259,10 +259,10 @@ usedDB = cdb (map qw symbTT) (map nw symbols ++ map nw acronyms ++ map nw checkS
  section labCon
 
 printSetting :: PrintingInformation
-printSetting = PI nopcm_SymbMap defaultConfiguration
+printSetting = PI symbMap defaultConfiguration
 
 symbTT :: [DefinedQuantityDict]
-symbTT = ccss (getDocDesc mkSRS) (egetDocDesc mkSRS) nopcm_SymbMap
+symbTT = ccss (getDocDesc mkSRS) (egetDocDesc mkSRS) symbMap
 
 --------------------------
 --Section 2 : INTRODUCTION

--- a/code/drasil-example/Drasil/NoPCM/Body.hs
+++ b/code/drasil-example/Drasil/NoPCM/Body.hs
@@ -1,6 +1,6 @@
 module Drasil.NoPCM.Body where
 
-import Language.Drasil hiding (constraints)
+import Language.Drasil hiding (constraints, section)
 import Language.Drasil.Code (CodeSpec, codeSpec)
 import Language.Drasil.Printers (PrintingInformation(..), defaultConfiguration)
 import Database.Drasil (Block(Parallel), ChunkDB, RefbyMap, ReferenceDB,
@@ -199,8 +199,8 @@ concIns =
  reqs ++ [likeChgTCVOD, likeChgTCVOL] ++ assumptions ++ likelyChgs ++
  [likeChgTLH] ++ unlikelyChgs
 
-nopcm_section :: [Section]
-nopcm_section = nopcm_sec
+section :: [Section]
+section = nopcm_sec
 
 nopcm_labcon :: [LabelledContent]
 nopcm_labcon = [inputInitQuantsTblabled, dataConstTable1]
@@ -249,13 +249,13 @@ nopcm_SymbMap = cdb (symbolsAll) (map nw symbols ++ map nw acronyms ++ map nw th
   ++ map nw [abs_tol, rel_tol, cons_tol])
   (map cw symbols ++ srsDomains)
   this_si label refBy dataDefn iMods genDef theory
-  concIns nopcm_section nopcm_labcon
+  concIns section nopcm_labcon
 
 usedDB :: ChunkDB
 usedDB = cdb (map qw symbTT) (map nw symbols ++ map nw acronyms ++ map nw checkSi)
  ([] :: [ConceptChunk]) checkSi label refBy
  dataDefn iMods genDef theory concIns
- nopcm_section nopcm_labcon
+ section nopcm_labcon
 
 printSetting :: PrintingInformation
 printSetting = PI nopcm_SymbMap defaultConfiguration

--- a/code/drasil-example/Drasil/NoPCM/Body.hs
+++ b/code/drasil-example/Drasil/NoPCM/Body.hs
@@ -233,8 +233,8 @@ si = SI {
 refDB :: ReferenceDB
 refDB = rdb referencesRefList concIns
 
-nopcm_code :: CodeSpec
-nopcm_code = codeSpec si [inputMod]
+code :: CodeSpec
+code = codeSpec si [inputMod]
 -- Sub interpolation mod into list when possible              ^
 
 nopcm_srs :: Document

--- a/code/drasil-example/Drasil/NoPCM/Body.hs
+++ b/code/drasil-example/Drasil/NoPCM/Body.hs
@@ -86,7 +86,7 @@ import Drasil.NoPCM.Assumptions
 import Drasil.NoPCM.Changes (likelyChgs, unlikelyChgs)
 import Drasil.NoPCM.DataDesc (inputMod)
 import Drasil.NoPCM.Definitions (srs_swhs, ht_trans)
-import Drasil.NoPCM.GenDefs (rocTempSimp, swhsGDs)
+import Drasil.NoPCM.GenDefs (rocTempSimp, genDefs)
 import Drasil.NoPCM.Goals (nopcmGoals)
 import Drasil.NoPCM.IMods (eBalanceOnWtr, instModIntro)
 import qualified Drasil.NoPCM.IMods as NoPCM(iMods)
@@ -157,7 +157,7 @@ mkSRS = [RefSec $ RefProg intro
     , SSDSolChSpec $ SCSProg
       [ Assumptions
       , TMs [] (Label : stdFields) theoretical_models
-      , GDs [] ([Label, Units] ++ stdFields) swhsGDs ShowDerivation
+      , GDs [] ([Label, Units] ++ stdFields) genDefs ShowDerivation
       , DDs [] ([Label, Symbol, Units] ++ stdFields) [dd1HtFluxC] ShowDerivation
       , IMs [instModIntro] ([Label, Input, Output, InConstraints, OutConstraints] ++ stdFields)
         NoPCM.iMods ShowDerivation
@@ -574,7 +574,7 @@ traceTheories = ["T1", "T2"]
 traceTheoriesRef = map makeRef2S theoretical_models
 
 traceGenDefs = ["GD1", "GD2"]
-traceGenDefRef = map makeRef2S swhsGDs
+traceGenDefRef = map makeRef2S genDefs
 
 traceDataDefs = ["DD1"]
 traceDataDefRef = map makeRef2S [dd1HtFluxC]

--- a/code/drasil-example/Drasil/NoPCM/Body.hs
+++ b/code/drasil-example/Drasil/NoPCM/Body.hs
@@ -107,10 +107,10 @@ symbols = pi_ : (map dqdWr nopcm_Units) ++ (map dqdWr nopcm_Constraints)
 resourcePath :: String
 resourcePath = "../../../datafiles/NoPCM/"
   
-nopcm_SymbolsAll :: [QuantityDict] --FIXME: Why is PCM (swhsSymbolsAll) here?
+symbolsAll :: [QuantityDict] --FIXME: Why is PCM (swhsSymbolsAll) here?
                                --Can't generate without SWHS-specific symbols like pcm_HTC and pcm_SA
                                --FOUND LOC OF ERROR: Instance Models
-nopcm_SymbolsAll = map qw symbols ++ (map qw specParamValList) ++ 
+symbolsAll = map qw symbols ++ (map qw specParamValList) ++ 
   (map qw [coil_SA_max]) ++ (map qw [tau_W]) ++ (map qw [eta]) ++
   (map qw [abs_tol, rel_tol, cons_tol])
 
@@ -240,7 +240,7 @@ nopcm_srs :: Document
 nopcm_srs = mkDoc mkSRS (for) nopcm_si
 
 nopcm_SymbMap :: ChunkDB
-nopcm_SymbMap = cdb (nopcm_SymbolsAll) (map nw symbols ++ map nw acronyms ++ map nw thermocon
+nopcm_SymbMap = cdb (symbolsAll) (map nw symbols ++ map nw acronyms ++ map nw thermocon
   ++ map nw physicscon ++ map nw doccon ++ map nw softwarecon ++ map nw doccon' ++ map nw swhscon
   ++ map nw prodtcon ++ map nw physicCon ++ map nw physicCon' ++ map nw mathcon ++ map nw mathcon'
   ++ map nw specParamValList ++ map nw fundamentals ++ map nw educon ++ map nw derived 

--- a/code/drasil-example/Drasil/NoPCM/Body.hs
+++ b/code/drasil-example/Drasil/NoPCM/Body.hs
@@ -175,11 +175,11 @@ mkSRS = [RefSec $ RefProg intro
   (map UlC traceIntro2)) []] ++
   map Verbatim [specParamVal] ++ [Bibliography]
 
-nopcm_label :: TraceMap
-nopcm_label = Map.union (generateTraceMap mkSRS) $ generateTraceMap' nopcm_concins
+label :: TraceMap
+label = Map.union (generateTraceMap mkSRS) $ generateTraceMap' nopcm_concins
  
 nopcm_refby :: RefbyMap
-nopcm_refby = generateRefbyMap nopcm_label
+nopcm_refby = generateRefbyMap label
 
 nopcm_datadefn :: [DataDefinition]
 nopcm_datadefn = getTraceMapFromDD $ getSCSSub mkSRS
@@ -247,12 +247,12 @@ nopcm_SymbMap = cdb (symbolsAll) (map nw symbols ++ map nw acronyms ++ map nw th
   ++ map nw physicalcon ++ map nw swhsUC ++ [nw srs_swhs, nw algorithm, nw ht_trans] ++ map nw checkSi
   ++ map nw [abs_tol, rel_tol, cons_tol])
   (map cw symbols ++ srsDomains)
-  this_si nopcm_label nopcm_refby nopcm_datadefn nopcm_insmodel nopcm_gendef nopcm_theory
+  this_si label nopcm_refby nopcm_datadefn nopcm_insmodel nopcm_gendef nopcm_theory
   nopcm_concins nopcm_section nopcm_labcon
 
 usedDB :: ChunkDB
 usedDB = cdb (map qw symbTT) (map nw symbols ++ map nw acronyms ++ map nw checkSi)
- ([] :: [ConceptChunk]) checkSi nopcm_label nopcm_refby
+ ([] :: [ConceptChunk]) checkSi label nopcm_refby
  nopcm_datadefn nopcm_insmodel nopcm_gendef nopcm_theory nopcm_concins
  nopcm_section nopcm_labcon
 

--- a/code/drasil-example/Drasil/NoPCM/Body.hs
+++ b/code/drasil-example/Drasil/NoPCM/Body.hs
@@ -227,11 +227,11 @@ si = SI {
   _constants = [],
   _sysinfodb = nopcm_SymbMap,
   _usedinfodb = usedDB,
-   refdb = nopcmRefDB
+   refdb = refDB
 }
 
-nopcmRefDB :: ReferenceDB
-nopcmRefDB = rdb referencesRefList concIns
+refDB :: ReferenceDB
+refDB = rdb referencesRefList concIns
 
 nopcm_code :: CodeSpec
 nopcm_code = codeSpec si [inputMod]

--- a/code/drasil-example/Drasil/NoPCM/Body.hs
+++ b/code/drasil-example/Drasil/NoPCM/Body.hs
@@ -99,8 +99,8 @@ checkSi :: [UnitDefn]
 checkSi = collectUnits nopcm_SymbMap symbTT 
 
 -- This contains the list of symbols used throughout the document
-nopcm_Symbols :: [DefinedQuantityDict]
-nopcm_Symbols = pi_ : (map dqdWr nopcm_Units) ++ (map dqdWr nopcm_Constraints)
+symbols :: [DefinedQuantityDict]
+symbols = pi_ : (map dqdWr nopcm_Units) ++ (map dqdWr nopcm_Constraints)
  ++ map dqdWr [temp_W, w_E]
  ++ [gradient, uNormalVect] ++ map dqdWr [surface]
 
@@ -110,7 +110,7 @@ resourcePath = "../../../datafiles/NoPCM/"
 nopcm_SymbolsAll :: [QuantityDict] --FIXME: Why is PCM (swhsSymbolsAll) here?
                                --Can't generate without SWHS-specific symbols like pcm_HTC and pcm_SA
                                --FOUND LOC OF ERROR: Instance Models
-nopcm_SymbolsAll = map qw nopcm_Symbols ++ (map qw specParamValList) ++ 
+nopcm_SymbolsAll = map qw symbols ++ (map qw specParamValList) ++ 
   (map qw [coil_SA_max]) ++ (map qw [tau_W]) ++ (map qw [eta]) ++
   (map qw [abs_tol, rel_tol, cons_tol])
 
@@ -216,7 +216,7 @@ nopcm_si = SI {
   _kind = srs,
   _authors = [thulasi],
   _quants = symbTT,
-  _concepts = nopcm_Symbols,
+  _concepts = symbols,
   _definitions = [dd1HtFluxCQD],          --dataDefs
   _datadefs = [dd1HtFluxC],
   _inputs = (map qw nopcm_Constraints ++ map qw [temp_W, w_E]), --inputs ++ outputs?
@@ -240,18 +240,18 @@ nopcm_srs :: Document
 nopcm_srs = mkDoc mkSRS (for) nopcm_si
 
 nopcm_SymbMap :: ChunkDB
-nopcm_SymbMap = cdb (nopcm_SymbolsAll) (map nw nopcm_Symbols ++ map nw acronyms ++ map nw thermocon
+nopcm_SymbMap = cdb (nopcm_SymbolsAll) (map nw symbols ++ map nw acronyms ++ map nw thermocon
   ++ map nw physicscon ++ map nw doccon ++ map nw softwarecon ++ map nw doccon' ++ map nw swhscon
   ++ map nw prodtcon ++ map nw physicCon ++ map nw physicCon' ++ map nw mathcon ++ map nw mathcon'
   ++ map nw specParamValList ++ map nw fundamentals ++ map nw educon ++ map nw derived 
   ++ map nw physicalcon ++ map nw swhsUC ++ [nw srs_swhs, nw algorithm, nw ht_trans] ++ map nw checkSi
   ++ map nw [abs_tol, rel_tol, cons_tol])
-  (map cw nopcm_Symbols ++ srsDomains)
+  (map cw symbols ++ srsDomains)
   this_si nopcm_label nopcm_refby nopcm_datadefn nopcm_insmodel nopcm_gendef nopcm_theory
   nopcm_concins nopcm_section nopcm_labcon
 
 usedDB :: ChunkDB
-usedDB = cdb (map qw symbTT) (map nw nopcm_Symbols ++ map nw acronyms ++ map nw checkSi)
+usedDB = cdb (map qw symbTT) (map nw symbols ++ map nw acronyms ++ map nw checkSi)
  ([] :: [ConceptChunk]) checkSi nopcm_label nopcm_refby
  nopcm_datadefn nopcm_insmodel nopcm_gendef nopcm_theory nopcm_concins
  nopcm_section nopcm_labcon

--- a/code/drasil-example/Drasil/NoPCM/Body.hs
+++ b/code/drasil-example/Drasil/NoPCM/Body.hs
@@ -1,6 +1,6 @@
 module Drasil.NoPCM.Body where
 
-import Language.Drasil
+import Language.Drasil hiding (constraints)
 import Language.Drasil.Code (CodeSpec, codeSpec)
 import Language.Drasil.Printers (PrintingInformation(..), defaultConfiguration)
 import Database.Drasil (Block(Parallel), ChunkDB, RefbyMap, ReferenceDB,
@@ -100,7 +100,7 @@ checkSi = collectUnits nopcm_SymbMap symbTT
 
 -- This contains the list of symbols used throughout the document
 symbols :: [DefinedQuantityDict]
-symbols = pi_ : (map dqdWr units) ++ (map dqdWr nopcm_Constraints)
+symbols = pi_ : (map dqdWr units) ++ (map dqdWr constraints)
  ++ map dqdWr [temp_W, w_E]
  ++ [gradient, uNormalVect] ++ map dqdWr [surface]
 
@@ -121,8 +121,8 @@ units = map ucw [density, tau, in_SA, out_SA,
   deltaT, temp_env, thFluxVect, time, ht_flux_C,
   vol, w_mass, w_vol, tau_W, QT.sensHeat]
 
-nopcm_Constraints :: [UncertQ]
-nopcm_Constraints =  [coil_SA, htCap_W, coil_HTC, temp_init,
+constraints :: [UncertQ]
+constraints =  [coil_SA, htCap_W, coil_HTC, temp_init,
   time_final, tank_length, temp_C, w_density, diam]
   -- w_E, temp_W
 
@@ -219,10 +219,10 @@ nopcm_si = SI {
   _concepts = symbols,
   _definitions = [dd1HtFluxCQD],          --dataDefs
   _datadefs = [dd1HtFluxC],
-  _inputs = (map qw nopcm_Constraints ++ map qw [temp_W, w_E]), --inputs ++ outputs?
+  _inputs = (map qw constraints ++ map qw [temp_W, w_E]), --inputs ++ outputs?
   _outputs = (map qw [temp_W, w_E]),     --outputs
   _defSequence = [Parallel dd1HtFluxCQD []],
-  _constraints = (map cnstrw nopcm_Constraints ++ map cnstrw [temp_W, w_E]),        --constrained
+  _constraints = (map cnstrw constraints ++ map cnstrw [temp_W, w_E]),        --constrained
   _constants = [],
   _sysinfodb = nopcm_SymbMap,
   _usedinfodb = usedDB,

--- a/code/drasil-example/Drasil/NoPCM/Body.hs
+++ b/code/drasil-example/Drasil/NoPCM/Body.hs
@@ -211,8 +211,8 @@ sec = extractSection nopcm_srs
 stdFields :: Fields
 stdFields = [DefiningEquation, Description Verbose IncludeUnits, Notes, Source, RefBy]
 
-nopcm_si :: SystemInformation
-nopcm_si = SI {
+si :: SystemInformation
+si = SI {
   _sys = srs_swhs,
   _kind = srs,
   _authors = [thulasi],
@@ -234,11 +234,11 @@ nopcmRefDB :: ReferenceDB
 nopcmRefDB = rdb referencesRefList concIns
 
 nopcm_code :: CodeSpec
-nopcm_code = codeSpec nopcm_si [inputMod]
+nopcm_code = codeSpec si [inputMod]
 -- Sub interpolation mod into list when possible              ^
 
 nopcm_srs :: Document
-nopcm_srs = mkDoc mkSRS (for) nopcm_si
+nopcm_srs = mkDoc mkSRS (for) si
 
 nopcm_SymbMap :: ChunkDB
 nopcm_SymbMap = cdb (symbolsAll) (map nw symbols ++ map nw acronyms ++ map nw thermocon
@@ -546,7 +546,7 @@ unlikelyChgsList = mkEnumSimpleD unlikelyChgs
 --Section 7:  TRACEABILITY MATRICES AND GRAPHS
 ----------------------------------------------
 traceTableAll :: LabelledContent
-traceTableAll = generateTraceTable nopcm_si
+traceTableAll = generateTraceTable si
 
 traceRefList :: [LabelledContent]
 traceRefList = [traceTableAll, traceTable1, traceTable2, traceTable3]

--- a/code/drasil-example/Drasil/NoPCM/Body.hs
+++ b/code/drasil-example/Drasil/NoPCM/Body.hs
@@ -87,7 +87,8 @@ import Drasil.NoPCM.DataDesc (inputMod)
 import Drasil.NoPCM.Definitions (srs_swhs, ht_trans)
 import Drasil.NoPCM.GenDefs (rocTempSimp, swhsGDs)
 import Drasil.NoPCM.Goals (nopcmGoals)
-import Drasil.NoPCM.IMods (eBalanceOnWtr, iMods, instModIntro)
+import Drasil.NoPCM.IMods (eBalanceOnWtr, instModIntro)
+import qualified Drasil.NoPCM.IMods as NoPCM(iMods)
 import Drasil.NoPCM.Requirements (funcReqsList, reqs, dataConstListIn)
 import Drasil.NoPCM.Unitals (temp_init)
 
@@ -158,7 +159,7 @@ mkSRS = [RefSec $ RefProg intro
       , GDs [] ([Label, Units] ++ stdFields) swhsGDs ShowDerivation
       , DDs [] ([Label, Symbol, Units] ++ stdFields) [dd1HtFluxC] ShowDerivation
       , IMs [instModIntro] ([Label, Input, Output, InConstraints, OutConstraints] ++ stdFields)
-        iMods ShowDerivation
+        NoPCM.iMods ShowDerivation
       , Constraints EmptyS dataConstraintUncertainty dataContMid
         [dataConstTable1, dataConstTable2]
       , CorrSolnPpties propsDerivNoPCM
@@ -184,8 +185,8 @@ refBy = generateRefbyMap label
 dataDefn :: [DataDefinition]
 dataDefn = getTraceMapFromDD $ getSCSSub mkSRS
 
-nopcm_insmodel :: [InstanceModel]
-nopcm_insmodel = getTraceMapFromIM $ getSCSSub mkSRS
+iMods :: [InstanceModel]
+iMods = getTraceMapFromIM $ getSCSSub mkSRS
 
 nopcm_gendef :: [GenDefn]
 nopcm_gendef = getTraceMapFromGD $ getSCSSub mkSRS
@@ -247,13 +248,13 @@ nopcm_SymbMap = cdb (symbolsAll) (map nw symbols ++ map nw acronyms ++ map nw th
   ++ map nw physicalcon ++ map nw swhsUC ++ [nw srs_swhs, nw algorithm, nw ht_trans] ++ map nw checkSi
   ++ map nw [abs_tol, rel_tol, cons_tol])
   (map cw symbols ++ srsDomains)
-  this_si label refBy dataDefn nopcm_insmodel nopcm_gendef nopcm_theory
+  this_si label refBy dataDefn iMods nopcm_gendef nopcm_theory
   nopcm_concins nopcm_section nopcm_labcon
 
 usedDB :: ChunkDB
 usedDB = cdb (map qw symbTT) (map nw symbols ++ map nw acronyms ++ map nw checkSi)
  ([] :: [ConceptChunk]) checkSi label refBy
- dataDefn nopcm_insmodel nopcm_gendef nopcm_theory nopcm_concins
+ dataDefn iMods nopcm_gendef nopcm_theory nopcm_concins
  nopcm_section nopcm_labcon
 
 printSetting :: PrintingInformation

--- a/code/drasil-example/Drasil/NoPCM/Body.hs
+++ b/code/drasil-example/Drasil/NoPCM/Body.hs
@@ -100,7 +100,7 @@ checkSi = collectUnits nopcm_SymbMap symbTT
 
 -- This contains the list of symbols used throughout the document
 symbols :: [DefinedQuantityDict]
-symbols = pi_ : (map dqdWr nopcm_Units) ++ (map dqdWr nopcm_Constraints)
+symbols = pi_ : (map dqdWr units) ++ (map dqdWr nopcm_Constraints)
  ++ map dqdWr [temp_W, w_E]
  ++ [gradient, uNormalVect] ++ map dqdWr [surface]
 
@@ -114,8 +114,8 @@ symbolsAll = map qw symbols ++ (map qw specParamValList) ++
   (map qw [coil_SA_max]) ++ (map qw [tau_W]) ++ (map qw [eta]) ++
   (map qw [abs_tol, rel_tol, cons_tol])
 
-nopcm_Units :: [UnitaryConceptDict]
-nopcm_Units = map ucw [density, tau, in_SA, out_SA,
+units :: [UnitaryConceptDict]
+units = map ucw [density, tau, in_SA, out_SA,
   htCap_L, QT.htFlux, ht_flux_in, ht_flux_out, vol_ht_gen,
   htTransCoeff, mass, tank_vol, QT.temp, QT.heatCapSpec,
   deltaT, temp_env, thFluxVect, time, ht_flux_C,

--- a/code/drasil-example/Drasil/NoPCM/Body.hs
+++ b/code/drasil-example/Drasil/NoPCM/Body.hs
@@ -181,8 +181,8 @@ label = Map.union (generateTraceMap mkSRS) $ generateTraceMap' nopcm_concins
 refBy :: RefbyMap
 refBy = generateRefbyMap label
 
-nopcm_datadefn :: [DataDefinition]
-nopcm_datadefn = getTraceMapFromDD $ getSCSSub mkSRS
+dataDefn :: [DataDefinition]
+dataDefn = getTraceMapFromDD $ getSCSSub mkSRS
 
 nopcm_insmodel :: [InstanceModel]
 nopcm_insmodel = getTraceMapFromIM $ getSCSSub mkSRS
@@ -247,13 +247,13 @@ nopcm_SymbMap = cdb (symbolsAll) (map nw symbols ++ map nw acronyms ++ map nw th
   ++ map nw physicalcon ++ map nw swhsUC ++ [nw srs_swhs, nw algorithm, nw ht_trans] ++ map nw checkSi
   ++ map nw [abs_tol, rel_tol, cons_tol])
   (map cw symbols ++ srsDomains)
-  this_si label refBy nopcm_datadefn nopcm_insmodel nopcm_gendef nopcm_theory
+  this_si label refBy dataDefn nopcm_insmodel nopcm_gendef nopcm_theory
   nopcm_concins nopcm_section nopcm_labcon
 
 usedDB :: ChunkDB
 usedDB = cdb (map qw symbTT) (map nw symbols ++ map nw acronyms ++ map nw checkSi)
  ([] :: [ConceptChunk]) checkSi label refBy
- nopcm_datadefn nopcm_insmodel nopcm_gendef nopcm_theory nopcm_concins
+ dataDefn nopcm_insmodel nopcm_gendef nopcm_theory nopcm_concins
  nopcm_section nopcm_labcon
 
 printSetting :: PrintingInformation

--- a/code/drasil-example/Drasil/NoPCM/Body.hs
+++ b/code/drasil-example/Drasil/NoPCM/Body.hs
@@ -19,7 +19,8 @@ import Data.Drasil.Concepts.Computation (algorithm)
 import Data.Drasil.Concepts.Documentation as Doc (assumption, content,
   definition, doccon, doccon', document, goal, information, item,
   material_, model, physSyst, problem, property, purpose, reference,
-  requirement, srs, srsDomains, traceyMatrix)
+  requirement, srsDomains, traceyMatrix)
+import qualified Data.Drasil.Concepts.Documentation as Doc (srs)
 import Data.Drasil.IdeaDicts as Doc (inModel, thModel)
 import Data.Drasil.Concepts.Education (educon)
 import Data.Drasil.Concepts.Math (mathcon, mathcon')
@@ -206,7 +207,7 @@ labCon :: [LabelledContent]
 labCon = [inputInitQuantsTblabled, dataConstTable1]
 
 sec :: [Section]
-sec = extractSection nopcm_srs
+sec = extractSection srs
 
 stdFields :: Fields
 stdFields = [DefiningEquation, Description Verbose IncludeUnits, Notes, Source, RefBy]
@@ -214,7 +215,7 @@ stdFields = [DefiningEquation, Description Verbose IncludeUnits, Notes, Source, 
 si :: SystemInformation
 si = SI {
   _sys = srs_swhs,
-  _kind = srs,
+  _kind = Doc.srs,
   _authors = [thulasi],
   _quants = symbTT,
   _concepts = symbols,
@@ -237,8 +238,8 @@ code :: CodeSpec
 code = codeSpec si [inputMod]
 -- Sub interpolation mod into list when possible              ^
 
-nopcm_srs :: Document
-nopcm_srs = mkDoc mkSRS (for) si
+srs :: Document
+srs = mkDoc mkSRS (for) si
 
 nopcm_SymbMap :: ChunkDB
 nopcm_SymbMap = cdb (symbolsAll) (map nw symbols ++ map nw acronyms ++ map nw thermocon
@@ -293,7 +294,7 @@ purpDoc pro = foldlSent [S "The main", phrase purpose, S "of this",
   S "is intended to be used as a", phrase reference,
   S "to provide ad hoc access to all", phrase information,
   S "necessary to understand and verify the" +:+. phrase model, S "The",
-  short srs, S "is abstract because the", plural content, S "say what",
+  short Doc.srs, S "is abstract because the", plural content, S "say what",
   phrase problem, S "is being solved, but do not say how to solve it"]
 
 -------------------------------------

--- a/code/drasil-example/Drasil/NoPCM/Body.hs
+++ b/code/drasil-example/Drasil/NoPCM/Body.hs
@@ -202,8 +202,8 @@ concIns =
 section :: [Section]
 section = nopcm_sec
 
-nopcm_labcon :: [LabelledContent]
-nopcm_labcon = [inputInitQuantsTblabled, dataConstTable1]
+labCon :: [LabelledContent]
+labCon = [inputInitQuantsTblabled, dataConstTable1]
 
 nopcm_sec :: [Section]
 nopcm_sec = extractSection nopcm_srs
@@ -249,13 +249,13 @@ nopcm_SymbMap = cdb (symbolsAll) (map nw symbols ++ map nw acronyms ++ map nw th
   ++ map nw [abs_tol, rel_tol, cons_tol])
   (map cw symbols ++ srsDomains)
   this_si label refBy dataDefn iMods genDef theory
-  concIns section nopcm_labcon
+  concIns section labCon
 
 usedDB :: ChunkDB
 usedDB = cdb (map qw symbTT) (map nw symbols ++ map nw acronyms ++ map nw checkSi)
  ([] :: [ConceptChunk]) checkSi label refBy
  dataDefn iMods genDef theory concIns
- section nopcm_labcon
+ section labCon
 
 printSetting :: PrintingInformation
 printSetting = PI nopcm_SymbMap defaultConfiguration

--- a/code/drasil-example/Drasil/NoPCM/Body.hs
+++ b/code/drasil-example/Drasil/NoPCM/Body.hs
@@ -1,6 +1,6 @@
 module Drasil.NoPCM.Body where
 
-import Language.Drasil hiding (constraints, section)
+import Language.Drasil hiding (constraints, section, sec)
 import Language.Drasil.Code (CodeSpec, codeSpec)
 import Language.Drasil.Printers (PrintingInformation(..), defaultConfiguration)
 import Database.Drasil (Block(Parallel), ChunkDB, RefbyMap, ReferenceDB,
@@ -200,13 +200,13 @@ concIns =
  [likeChgTLH] ++ unlikelyChgs
 
 section :: [Section]
-section = nopcm_sec
+section = sec
 
 labCon :: [LabelledContent]
 labCon = [inputInitQuantsTblabled, dataConstTable1]
 
-nopcm_sec :: [Section]
-nopcm_sec = extractSection nopcm_srs
+sec :: [Section]
+sec = extractSection nopcm_srs
 
 stdFields :: Fields
 stdFields = [DefiningEquation, Description Verbose IncludeUnits, Notes, Source, RefBy]

--- a/code/drasil-example/Drasil/NoPCM/Body.hs
+++ b/code/drasil-example/Drasil/NoPCM/Body.hs
@@ -87,7 +87,7 @@ import Drasil.NoPCM.Changes (likelyChgs, unlikelyChgs)
 import Drasil.NoPCM.DataDesc (inputMod)
 import Drasil.NoPCM.Definitions (srs_swhs, ht_trans)
 import Drasil.NoPCM.GenDefs (rocTempSimp, genDefs)
-import Drasil.NoPCM.Goals (nopcmGoals)
+import Drasil.NoPCM.Goals (goals)
 import Drasil.NoPCM.IMods (eBalanceOnWtr, instModIntro)
 import qualified Drasil.NoPCM.IMods as NoPCM(iMods)
 import Drasil.NoPCM.Requirements (funcReqsList, reqs, dataConstListIn)
@@ -394,7 +394,7 @@ goalStatesIntro te co temw = [phrase te `ofThe` phrase co,
   S "the material" +:+ plural property]
 
 goalStatesList :: [Contents]
-goalStatesList = mkEnumSimpleD nopcmGoals
+goalStatesList = mkEnumSimpleD goals
 
 
 ------------------------------------------------------

--- a/code/drasil-example/Drasil/NoPCM/Body.hs
+++ b/code/drasil-example/Drasil/NoPCM/Body.hs
@@ -178,8 +178,8 @@ mkSRS = [RefSec $ RefProg intro
 label :: TraceMap
 label = Map.union (generateTraceMap mkSRS) $ generateTraceMap' nopcm_concins
  
-nopcm_refby :: RefbyMap
-nopcm_refby = generateRefbyMap label
+refBy :: RefbyMap
+refBy = generateRefbyMap label
 
 nopcm_datadefn :: [DataDefinition]
 nopcm_datadefn = getTraceMapFromDD $ getSCSSub mkSRS
@@ -247,12 +247,12 @@ nopcm_SymbMap = cdb (symbolsAll) (map nw symbols ++ map nw acronyms ++ map nw th
   ++ map nw physicalcon ++ map nw swhsUC ++ [nw srs_swhs, nw algorithm, nw ht_trans] ++ map nw checkSi
   ++ map nw [abs_tol, rel_tol, cons_tol])
   (map cw symbols ++ srsDomains)
-  this_si label nopcm_refby nopcm_datadefn nopcm_insmodel nopcm_gendef nopcm_theory
+  this_si label refBy nopcm_datadefn nopcm_insmodel nopcm_gendef nopcm_theory
   nopcm_concins nopcm_section nopcm_labcon
 
 usedDB :: ChunkDB
 usedDB = cdb (map qw symbTT) (map nw symbols ++ map nw acronyms ++ map nw checkSi)
- ([] :: [ConceptChunk]) checkSi label nopcm_refby
+ ([] :: [ConceptChunk]) checkSi label refBy
  nopcm_datadefn nopcm_insmodel nopcm_gendef nopcm_theory nopcm_concins
  nopcm_section nopcm_labcon
 

--- a/code/drasil-example/Drasil/NoPCM/Body.hs
+++ b/code/drasil-example/Drasil/NoPCM/Body.hs
@@ -188,8 +188,8 @@ dataDefn = getTraceMapFromDD $ getSCSSub mkSRS
 iMods :: [InstanceModel]
 iMods = getTraceMapFromIM $ getSCSSub mkSRS
 
-nopcm_gendef :: [GenDefn]
-nopcm_gendef = getTraceMapFromGD $ getSCSSub mkSRS
+genDef :: [GenDefn]
+genDef = getTraceMapFromGD $ getSCSSub mkSRS
 
 nopcm_theory :: [TheoryModel]
 nopcm_theory = getTraceMapFromTM $ getSCSSub mkSRS
@@ -248,13 +248,13 @@ nopcm_SymbMap = cdb (symbolsAll) (map nw symbols ++ map nw acronyms ++ map nw th
   ++ map nw physicalcon ++ map nw swhsUC ++ [nw srs_swhs, nw algorithm, nw ht_trans] ++ map nw checkSi
   ++ map nw [abs_tol, rel_tol, cons_tol])
   (map cw symbols ++ srsDomains)
-  this_si label refBy dataDefn iMods nopcm_gendef nopcm_theory
+  this_si label refBy dataDefn iMods genDef nopcm_theory
   nopcm_concins nopcm_section nopcm_labcon
 
 usedDB :: ChunkDB
 usedDB = cdb (map qw symbTT) (map nw symbols ++ map nw acronyms ++ map nw checkSi)
  ([] :: [ConceptChunk]) checkSi label refBy
- dataDefn iMods nopcm_gendef nopcm_theory nopcm_concins
+ dataDefn iMods genDef nopcm_theory nopcm_concins
  nopcm_section nopcm_labcon
 
 printSetting :: PrintingInformation

--- a/code/drasil-example/Drasil/NoPCM/DataDesc.hs
+++ b/code/drasil-example/Drasil/NoPCM/DataDesc.hs
@@ -5,10 +5,10 @@ import Drasil.SWHS.Unitals (tank_length, diam, coil_SA, temp_C, w_density,
   htCap_W, coil_HTC, temp_init, tau, time_final, abs_tol, rel_tol, cons_tol)
 
 inputMod :: Mod
-inputMod = Mod "InputFormat" [nopcmInputData]
+inputMod = Mod "InputFormat" [inputData]
 
-nopcmInputData :: Func
-nopcmInputData = funcData "get_inputs"
+inputData :: Func
+inputData = funcData "get_inputs"
   [ junkLine,
     singleton tank_length,
     junkLine,

--- a/code/drasil-example/Drasil/NoPCM/GenDefs.hs
+++ b/code/drasil-example/Drasil/NoPCM/GenDefs.hs
@@ -1,4 +1,4 @@
-module Drasil.NoPCM.GenDefs (rocTempSimp, swhsGDs) where
+module Drasil.NoPCM.GenDefs (rocTempSimp, genDefs) where
 
 import Language.Drasil
 import Theory.Drasil (GenDefn, gdNoRefs)
@@ -24,8 +24,8 @@ import Drasil.SWHS.TMods (consThermE)
 import Drasil.SWHS.Unitals (in_SA, out_SA, vol_ht_gen, thFluxVect, ht_flux_in, 
   ht_flux_out)
 
-swhsGDs :: [GenDefn]
-swhsGDs = [nwtnCooling, rocTempSimp] 
+genDefs :: [GenDefn]
+genDefs = [nwtnCooling, rocTempSimp] 
 
 rocTempSimp :: GenDefn
 rocTempSimp = gdNoRefs rocTempSimpRC (Nothing :: Maybe UnitDefn) roc_temp_simp_deriv 

--- a/code/drasil-example/Drasil/NoPCM/Goals.hs
+++ b/code/drasil-example/Drasil/NoPCM/Goals.hs
@@ -1,8 +1,8 @@
-module Drasil.NoPCM.Goals (nopcmGoals, waterTempGS, waterEnergyGS) where
+module Drasil.NoPCM.Goals (goals, waterTempGS, waterEnergyGS) where
 
 import Language.Drasil
 
 import Drasil.SWHS.Goals (waterTempGS, waterEnergyGS)
 
-nopcmGoals :: [ConceptInstance]
-nopcmGoals = [waterTempGS, waterEnergyGS]
+goals :: [ConceptInstance]
+goals = [waterTempGS, waterEnergyGS]

--- a/code/drasil-example/Drasil/NoPCM/Main.hs
+++ b/code/drasil-example/Drasil/NoPCM/Main.hs
@@ -5,7 +5,7 @@ import Language.Drasil.Code (Choices(..), Comments(..), ConstraintBehaviour(..),
 import Language.Drasil.Generate (gen, genCode)
 import Language.Drasil.Printers (DocType(SRS, Website), DocSpec(DocSpec))
 
-import Drasil.NoPCM.Body (nopcm_srs, code, printSetting)
+import Drasil.NoPCM.Body (srs, code, printSetting)
 
 nopcm_Choices :: Choices
 nopcm_Choices = Choices {
@@ -21,6 +21,6 @@ nopcm_Choices = Choices {
        
 main :: IO ()            
 main = do
-  gen (DocSpec SRS "NoPCM_SRS") nopcm_srs printSetting
-  gen (DocSpec Website "NoPCM_SRS") nopcm_srs printSetting
+  gen (DocSpec SRS "NoPCM_SRS") srs printSetting
+  gen (DocSpec Website "NoPCM_SRS") srs printSetting
   genCode nopcm_Choices code

--- a/code/drasil-example/Drasil/NoPCM/Main.hs
+++ b/code/drasil-example/Drasil/NoPCM/Main.hs
@@ -7,8 +7,8 @@ import Language.Drasil.Printers (DocType(SRS, Website), DocSpec(DocSpec))
 
 import Drasil.NoPCM.Body (srs, code, printSetting)
 
-nopcm_Choices :: Choices
-nopcm_Choices = Choices {
+choices :: Choices
+choices = Choices {
   lang = [Python, Cpp, CSharp, Java],
   impType = Program,
   logFile = "log.txt",
@@ -23,4 +23,4 @@ main :: IO ()
 main = do
   gen (DocSpec SRS "NoPCM_SRS") srs printSetting
   gen (DocSpec Website "NoPCM_SRS") srs printSetting
-  genCode nopcm_Choices code
+  genCode choices code

--- a/code/drasil-example/Drasil/NoPCM/Main.hs
+++ b/code/drasil-example/Drasil/NoPCM/Main.hs
@@ -5,7 +5,7 @@ import Language.Drasil.Code (Choices(..), Comments(..), ConstraintBehaviour(..),
 import Language.Drasil.Generate (gen, genCode)
 import Language.Drasil.Printers (DocType(SRS, Website), DocSpec(DocSpec))
 
-import Drasil.NoPCM.Body (nopcm_srs, nopcm_code, printSetting)
+import Drasil.NoPCM.Body (nopcm_srs, code, printSetting)
 
 nopcm_Choices :: Choices
 nopcm_Choices = Choices {
@@ -23,4 +23,4 @@ main :: IO ()
 main = do
   gen (DocSpec SRS "NoPCM_SRS") nopcm_srs printSetting
   gen (DocSpec Website "NoPCM_SRS") nopcm_srs printSetting
-  genCode nopcm_Choices nopcm_code
+  genCode nopcm_Choices code


### PR DESCRIPTION
Based on #1267. Removing prefixes in NoPCM to make naming more generic.