### PR TITLE
PR - Remove prefixes from GamePhysics

### DIFF
--- a/code/drasil-example/Drasil/GamePhysics/Body.hs
+++ b/code/drasil-example/Drasil/GamePhysics/Body.hs
@@ -169,14 +169,14 @@ sysInfo = SI {
   _constants = [],
   _sysinfodb = everything,
   _usedinfodb = usedDB,
-   refdb = cpRefDB
+   refdb = refDB
 }
 
 symbTT :: [DefinedQuantityDict]
 symbTT = ccss (getDocDesc mkSRS) (egetDocDesc mkSRS) everything
 
-cpRefDB :: ReferenceDB
-cpRefDB = rdb cpCitations concIns
+refDB :: ReferenceDB
+refDB = rdb cpCitations concIns
 
 --FIXME: All named ideas, not just acronyms.
 

--- a/code/drasil-example/Drasil/GamePhysics/Body.hs
+++ b/code/drasil-example/Drasil/GamePhysics/Body.hs
@@ -78,7 +78,7 @@ auths :: Sentence
 auths = S $ manyNames authors
 
 srs :: Document
-srs = mkDoc mkSRS for' chipmunkSysInfo
+srs = mkDoc mkSRS for' sysInfo
 
 checkSi :: [UnitDefn] -- FIXME
 checkSi = collectUnits everything symbTT 
@@ -153,8 +153,8 @@ stdFields = [DefiningEquation, Description Verbose IncludeUnits, Notes, Source, 
 
     --FIXME: Need to be able to print defn for gravitational constant.
 
-chipmunkSysInfo :: SystemInformation
-chipmunkSysInfo = SI {
+sysInfo :: SystemInformation
+sysInfo = SI {
   _sys = chipmunk,
   _kind = Doc.srs,
   _authors = authors,
@@ -203,7 +203,7 @@ printSetting :: PrintingInformation
 printSetting = PI everything defaultConfiguration
 
 chipCode :: CodeSpec
-chipCode = codeSpec chipmunkSysInfo []
+chipCode = codeSpec sysInfo []
 
 resourcePath :: String
 resourcePath = "../../../datafiles/GamePhysics/"
@@ -594,7 +594,7 @@ off_the_shelf_solutions_3dlist = LlC $ enumBullet solutionLabel [
 -- SECTION 8 : Traceability Matrices and Graph    --
 -----------------------------------------------------
 traceTable1 :: LabelledContent
-traceTable1 = generateTraceTable chipmunkSysInfo
+traceTable1 = generateTraceTable sysInfo
 
 traceabilityMatricesAndGraph :: Section
 traceabilityMatricesAndGraph = traceMGF [traceMatTabReqGoalOther, traceMatTabAssump,

--- a/code/drasil-example/Drasil/GamePhysics/Body.hs
+++ b/code/drasil-example/Drasil/GamePhysics/Body.hs
@@ -180,8 +180,8 @@ refDB = rdb cpCitations concIns
 
 --FIXME: All named ideas, not just acronyms.
 
-chipUnits :: [UnitDefn] -- FIXME
-chipUnits = map unitWrapper [metre, kilogram, second, joule] ++ map unitWrapper [newton, radian]
+units :: [UnitDefn] -- FIXME
+units = map unitWrapper [metre, kilogram, second, joule] ++ map unitWrapper [newton, radian]
 
 everything :: ChunkDB
 everything = cdb (map qw iModelsNew ++ map qw cpSymbolsAll) (map nw cpSymbolsAll
@@ -189,7 +189,7 @@ everything = cdb (map qw iModelsNew ++ map qw cpSymbolsAll) (map nw cpSymbolsAll
   ++ map nw softwarecon ++ map nw doccon ++ map nw doccon'
   ++ map nw CP.physicCon ++ map nw educon ++ [nw algorithm] ++ map nw derived
   ++ map nw fundamentals ++ map nw CM.mathcon ++ map nw CM.mathcon')
-  (map cw gamephySymbols ++ srsDomains ++ map cw iModelsNew) chipUnits
+  (map cw gamephySymbols ++ srsDomains ++ map cw iModelsNew) units
   label refBy dataDefs iMods genDef theory
   concIns section []
 

--- a/code/drasil-example/Drasil/GamePhysics/Body.hs
+++ b/code/drasil-example/Drasil/GamePhysics/Body.hs
@@ -1,6 +1,6 @@
 module Drasil.GamePhysics.Body where
 
-import Language.Drasil hiding (Vector, organization)
+import Language.Drasil hiding (Vector, organization, section)
 import Language.Drasil.Code (CodeSpec, codeSpec)
 import Language.Drasil.Printers (PrintingInformation(..), defaultConfiguration)
 import Database.Drasil (ChunkDB, RefbyMap, ReferenceDB, SystemInformation(SI),
@@ -142,8 +142,8 @@ concIns :: [ConceptInstance]
 concIns = assumptions ++ likelyChangesList' ++ unlikelyChangesList' ++
   funcReqs
 
-gameSection :: [Section]
-gameSection = gameSec
+section :: [Section]
+section = gameSec
 
 gameSec :: [Section]
 gameSec = extractSection srs
@@ -191,12 +191,12 @@ everything = cdb (map qw iModelsNew ++ map qw cpSymbolsAll) (map nw cpSymbolsAll
   ++ map nw fundamentals ++ map nw CM.mathcon ++ map nw CM.mathcon')
   (map cw gamephySymbols ++ srsDomains ++ map cw iModelsNew) chipUnits
   label refBy dataDefs iMods genDef theory
-  concIns gameSection []
+  concIns section []
 
 usedDB :: ChunkDB
 usedDB = cdb (map qw symbTT) (map nw cpSymbolsAll ++ map nw cpAcronyms
  ++ map nw checkSi) ([] :: [ConceptChunk]) checkSi label refBy
- dataDefs iMods genDef theory concIns gameSection
+ dataDefs iMods genDef theory concIns section
  []
 
 printSetting :: PrintingInformation

--- a/code/drasil-example/Drasil/GamePhysics/Body.hs
+++ b/code/drasil-example/Drasil/GamePhysics/Body.hs
@@ -121,7 +121,7 @@ mkSRS = [RefSec $ RefProg intro [TUnits, tsymb tableOfSymbols, TAandA],
       where tableOfSymbols = [TSPurpose, TypogConvention[Vector Bold], SymbOrder]
 
 label :: TraceMap
-label = Map.union (generateTraceMap mkSRS) $ generateTraceMap' gameConcins
+label = Map.union (generateTraceMap mkSRS) $ generateTraceMap' concIns
 
 refBy :: RefbyMap
 refBy = generateRefbyMap label
@@ -138,8 +138,8 @@ genDef = getTraceMapFromGD $ getSCSSub mkSRS
 theory :: [TheoryModel]
 theory = getTraceMapFromTM $ getSCSSub mkSRS
 
-gameConcins :: [ConceptInstance]
-gameConcins = assumptions ++ likelyChangesList' ++ unlikelyChangesList' ++
+concIns :: [ConceptInstance]
+concIns = assumptions ++ likelyChangesList' ++ unlikelyChangesList' ++
   funcReqs
 
 gameSection :: [Section]
@@ -176,7 +176,7 @@ symbTT :: [DefinedQuantityDict]
 symbTT = ccss (getDocDesc mkSRS) (egetDocDesc mkSRS) everything
 
 cpRefDB :: ReferenceDB
-cpRefDB = rdb cpCitations gameConcins
+cpRefDB = rdb cpCitations concIns
 
 --FIXME: All named ideas, not just acronyms.
 
@@ -191,12 +191,12 @@ everything = cdb (map qw iModelsNew ++ map qw cpSymbolsAll) (map nw cpSymbolsAll
   ++ map nw fundamentals ++ map nw CM.mathcon ++ map nw CM.mathcon')
   (map cw gamephySymbols ++ srsDomains ++ map cw iModelsNew) chipUnits
   label refBy dataDefs iMods genDef theory
-  gameConcins gameSection []
+  concIns gameSection []
 
 usedDB :: ChunkDB
 usedDB = cdb (map qw symbTT) (map nw cpSymbolsAll ++ map nw cpAcronyms
  ++ map nw checkSi) ([] :: [ConceptChunk]) checkSi label refBy
- dataDefs iMods genDef theory gameConcins gameSection
+ dataDefs iMods genDef theory concIns gameSection
  []
 
 printSetting :: PrintingInformation

--- a/code/drasil-example/Drasil/GamePhysics/Body.hs
+++ b/code/drasil-example/Drasil/GamePhysics/Body.hs
@@ -126,8 +126,8 @@ label = Map.union (generateTraceMap mkSRS) $ generateTraceMap' gameConcins
 refBy :: RefbyMap
 refBy = generateRefbyMap label
 
-gameDatadefn :: [DataDefinition]
-gameDatadefn = getTraceMapFromDD $ getSCSSub mkSRS
+dataDefs :: [DataDefinition]
+dataDefs = getTraceMapFromDD $ getSCSSub mkSRS
 
 gameInsmodel :: [InstanceModel]
 gameInsmodel = getTraceMapFromIM $ getSCSSub mkSRS
@@ -190,13 +190,13 @@ everything = cdb (map qw iModelsNew ++ map qw cpSymbolsAll) (map nw cpSymbolsAll
   ++ map nw CP.physicCon ++ map nw educon ++ [nw algorithm] ++ map nw derived
   ++ map nw fundamentals ++ map nw CM.mathcon ++ map nw CM.mathcon')
   (map cw gamephySymbols ++ srsDomains ++ map cw iModelsNew) chipUnits
-  label refBy gameDatadefn gameInsmodel gameGendef gameTheory
+  label refBy dataDefs gameInsmodel gameGendef gameTheory
   gameConcins gameSection []
 
 usedDB :: ChunkDB
 usedDB = cdb (map qw symbTT) (map nw cpSymbolsAll ++ map nw cpAcronyms
  ++ map nw checkSi) ([] :: [ConceptChunk]) checkSi label refBy
- gameDatadefn gameInsmodel gameGendef gameTheory gameConcins gameSection
+ dataDefs gameInsmodel gameGendef gameTheory gameConcins gameSection
  []
 
 printSetting :: PrintingInformation

--- a/code/drasil-example/Drasil/GamePhysics/Body.hs
+++ b/code/drasil-example/Drasil/GamePhysics/Body.hs
@@ -132,8 +132,8 @@ dataDefs = getTraceMapFromDD $ getSCSSub mkSRS
 iMods :: [InstanceModel]
 iMods = getTraceMapFromIM $ getSCSSub mkSRS
 
-gameGendef :: [GenDefn]
-gameGendef = getTraceMapFromGD $ getSCSSub mkSRS
+genDef :: [GenDefn]
+genDef = getTraceMapFromGD $ getSCSSub mkSRS
 
 gameTheory :: [TheoryModel]
 gameTheory = getTraceMapFromTM $ getSCSSub mkSRS
@@ -190,13 +190,13 @@ everything = cdb (map qw iModelsNew ++ map qw cpSymbolsAll) (map nw cpSymbolsAll
   ++ map nw CP.physicCon ++ map nw educon ++ [nw algorithm] ++ map nw derived
   ++ map nw fundamentals ++ map nw CM.mathcon ++ map nw CM.mathcon')
   (map cw gamephySymbols ++ srsDomains ++ map cw iModelsNew) chipUnits
-  label refBy dataDefs iMods gameGendef gameTheory
+  label refBy dataDefs iMods genDef gameTheory
   gameConcins gameSection []
 
 usedDB :: ChunkDB
 usedDB = cdb (map qw symbTT) (map nw cpSymbolsAll ++ map nw cpAcronyms
  ++ map nw checkSi) ([] :: [ConceptChunk]) checkSi label refBy
- dataDefs iMods gameGendef gameTheory gameConcins gameSection
+ dataDefs iMods genDef gameTheory gameConcins gameSection
  []
 
 printSetting :: PrintingInformation

--- a/code/drasil-example/Drasil/GamePhysics/Body.hs
+++ b/code/drasil-example/Drasil/GamePhysics/Body.hs
@@ -30,9 +30,10 @@ import Data.Drasil.Concepts.Documentation as Doc (assumption, concept,
   goalStmt, guide, information, input_, interface, item, model, object,
   organization, physical, physicalSim, physics, problem, problemDescription,
   product_, project, quantity, realtime, reference, requirement, section_,
-  simulation, software, softwareSys, srs, srsDomains, system, systemConstraint,
+  simulation, software, softwareSys, srsDomains, system, systemConstraint,
   sysCont, task, template, termAndDef, traceyMatrix, user, userCharacteristic,
   doccon, doccon')
+import qualified Data.Drasil.Concepts.Documentation as Doc (srs)
 import Data.Drasil.IdeaDicts as Doc (dataDefn, genDefn, inModel, thModel)
 import Data.Drasil.Concepts.Education (frstYr, highSchoolCalculus,
   highSchoolPhysics, educon)
@@ -76,8 +77,8 @@ authors = [alex, luthfi]
 auths :: Sentence
 auths = S $ manyNames authors
 
-chipmunkSRS' :: Document
-chipmunkSRS' = mkDoc mkSRS for' chipmunkSysInfo
+srs :: Document
+srs = mkDoc mkSRS for' chipmunkSysInfo
 
 checkSi :: [UnitDefn] -- FIXME
 checkSi = collectUnits everything symbTT 
@@ -145,7 +146,7 @@ gameSection :: [Section]
 gameSection = gameSec
 
 gameSec :: [Section]
-gameSec = extractSection chipmunkSRS'
+gameSec = extractSection srs
 
 stdFields :: Fields
 stdFields = [DefiningEquation, Description Verbose IncludeUnits, Notes, Source, RefBy]
@@ -155,7 +156,7 @@ stdFields = [DefiningEquation, Description Verbose IncludeUnits, Notes, Source, 
 chipmunkSysInfo :: SystemInformation
 chipmunkSysInfo = SI {
   _sys = chipmunk,
-  _kind = srs,
+  _kind = Doc.srs,
   _authors = authors,
   _quants = symbTT, 
   _concepts = ([] :: [DefinedQuantityDict]),
@@ -280,7 +281,7 @@ organizationOfDocumentsIntro :: Sentence
 
 organizationOfDocumentsIntro = foldlSent 
   [S "The", (phrase organization), S "of this", (phrase document), 
-  S "follows the", phrase template, S "for an", (getAcc srs), S "for", 
+  S "follows the", phrase template, S "for an", (getAcc Doc.srs), S "for", 
   (phrase sciCompS), S "proposed by", makeCiteS parnas1972 `sAnd` 
   makeCiteS parnasClements1984]
 

--- a/code/drasil-example/Drasil/GamePhysics/Body.hs
+++ b/code/drasil-example/Drasil/GamePhysics/Body.hs
@@ -58,7 +58,7 @@ import Drasil.GamePhysics.Assumptions(assumptions)
 import Drasil.GamePhysics.Changes (unlikelyChangesList', unlikelyChangeswithIntro,
  likelyChangesListwithIntro, likelyChangesList')
 import Drasil.GamePhysics.Concepts (chipmunk, acronyms, twoD)
-import Drasil.GamePhysics.DataDefs (qDefs, cpQDefs, dataDefns)
+import Drasil.GamePhysics.DataDefs (qDefs, blockQDefs, dataDefns)
 import Drasil.GamePhysics.Goals (goals)
 import Drasil.GamePhysics.IMods (iModelsNew, instModIntro)
 import Drasil.GamePhysics.References (cpCitations, parnas1972, parnasClements1984)
@@ -164,7 +164,7 @@ sysInfo = SI {
   _datadefs = dataDefns,
   _inputs = inputSymbols,
   _outputs = outputSymbols, 
-  _defSequence = cpQDefs,
+  _defSequence = blockQDefs,
   _constraints = cpInputConstraints,
   _constants = [],
   _sysinfodb = everything,

--- a/code/drasil-example/Drasil/GamePhysics/Body.hs
+++ b/code/drasil-example/Drasil/GamePhysics/Body.hs
@@ -65,7 +65,7 @@ import Drasil.GamePhysics.References (citations, parnas1972, parnasClements1984)
 import Drasil.GamePhysics.Requirements (funcReqsContent, funcReqs, nonfuncReqs,
     propsDeriv, requirements)
 import Drasil.GamePhysics.TMods (tModsNew)
-import Drasil.GamePhysics.Unitals (symbolsAll, cpOutputConstraints,
+import Drasil.GamePhysics.Unitals (symbolsAll, outputConstraints,
   inputSymbols, outputSymbols, inputConstraints, defSymbols)
 
 import Control.Lens ((^.))
@@ -102,7 +102,7 @@ mkSRS = [RefSec $ RefProg intro [TUnits, tsymb tableOfSymbols, TAandA],
         , IMs [instModIntro] ([Label, Input, Output, InConstraints, OutConstraints] ++ stdFields)
           iModelsNew ShowDerivation
         , Constraints EmptyS dataConstraintUncertainty (S "FIXME")
-            [inDataConstTbl inputConstraints, outDataConstTbl cpOutputConstraints]
+            [inDataConstTbl inputConstraints, outDataConstTbl outputConstraints]
         , CorrSolnPpties propsDeriv
         ]
       ],

--- a/code/drasil-example/Drasil/GamePhysics/Body.hs
+++ b/code/drasil-example/Drasil/GamePhysics/Body.hs
@@ -61,7 +61,7 @@ import Drasil.GamePhysics.Concepts (chipmunk, acronyms, twoD)
 import Drasil.GamePhysics.DataDefs (qDefs, blockQDefs, dataDefns)
 import Drasil.GamePhysics.Goals (goals)
 import Drasil.GamePhysics.IMods (iModelsNew, instModIntro)
-import Drasil.GamePhysics.References (cpCitations, parnas1972, parnasClements1984)
+import Drasil.GamePhysics.References (citations, parnas1972, parnasClements1984)
 import Drasil.GamePhysics.Requirements (funcReqsContent, funcReqs, nonfuncReqs,
     propsDeriv, requirements)
 import Drasil.GamePhysics.TMods (cpTModsNew)
@@ -176,7 +176,7 @@ symbTT :: [DefinedQuantityDict]
 symbTT = ccss (getDocDesc mkSRS) (egetDocDesc mkSRS) everything
 
 refDB :: ReferenceDB
-refDB = rdb cpCitations concIns
+refDB = rdb citations concIns
 
 --FIXME: All named ideas, not just acronyms.
 

--- a/code/drasil-example/Drasil/GamePhysics/Body.hs
+++ b/code/drasil-example/Drasil/GamePhysics/Body.hs
@@ -66,7 +66,7 @@ import Drasil.GamePhysics.Requirements (funcReqsContent, funcReqs, nonfuncReqs,
     propsDeriv, requirements)
 import Drasil.GamePhysics.TMods (tModsNew)
 import Drasil.GamePhysics.Unitals (symbolsAll, cpOutputConstraints,
-  inputSymbols, outputSymbols, cpInputConstraints, defSymbols)
+  inputSymbols, outputSymbols, inputConstraints, defSymbols)
 
 import Control.Lens ((^.))
 import qualified Data.Map as Map
@@ -102,7 +102,7 @@ mkSRS = [RefSec $ RefProg intro [TUnits, tsymb tableOfSymbols, TAandA],
         , IMs [instModIntro] ([Label, Input, Output, InConstraints, OutConstraints] ++ stdFields)
           iModelsNew ShowDerivation
         , Constraints EmptyS dataConstraintUncertainty (S "FIXME")
-            [inDataConstTbl cpInputConstraints, outDataConstTbl cpOutputConstraints]
+            [inDataConstTbl inputConstraints, outDataConstTbl cpOutputConstraints]
         , CorrSolnPpties propsDeriv
         ]
       ],
@@ -165,7 +165,7 @@ sysInfo = SI {
   _inputs = inputSymbols,
   _outputs = outputSymbols, 
   _defSequence = blockQDefs,
-  _constraints = cpInputConstraints,
+  _constraints = inputConstraints,
   _constants = [],
   _sysinfodb = everything,
   _usedinfodb = usedDB,

--- a/code/drasil-example/Drasil/GamePhysics/Body.hs
+++ b/code/drasil-example/Drasil/GamePhysics/Body.hs
@@ -120,11 +120,11 @@ mkSRS = [RefSec $ RefProg intro [TUnits, tsymb tableOfSymbols, TAandA],
     Bibliography]
       where tableOfSymbols = [TSPurpose, TypogConvention[Vector Bold], SymbOrder]
 
-gameLabel :: TraceMap
-gameLabel = Map.union (generateTraceMap mkSRS) $ generateTraceMap' gameConcins
+label :: TraceMap
+label = Map.union (generateTraceMap mkSRS) $ generateTraceMap' gameConcins
 
 gameRefby :: RefbyMap
-gameRefby = generateRefbyMap gameLabel
+gameRefby = generateRefbyMap label
 
 gameDatadefn :: [DataDefinition]
 gameDatadefn = getTraceMapFromDD $ getSCSSub mkSRS
@@ -190,12 +190,12 @@ everything = cdb (map qw iModelsNew ++ map qw cpSymbolsAll) (map nw cpSymbolsAll
   ++ map nw CP.physicCon ++ map nw educon ++ [nw algorithm] ++ map nw derived
   ++ map nw fundamentals ++ map nw CM.mathcon ++ map nw CM.mathcon')
   (map cw gamephySymbols ++ srsDomains ++ map cw iModelsNew) chipUnits
-  gameLabel gameRefby gameDatadefn gameInsmodel gameGendef gameTheory
+  label gameRefby gameDatadefn gameInsmodel gameGendef gameTheory
   gameConcins gameSection []
 
 usedDB :: ChunkDB
 usedDB = cdb (map qw symbTT) (map nw cpSymbolsAll ++ map nw cpAcronyms
- ++ map nw checkSi) ([] :: [ConceptChunk]) checkSi gameLabel gameRefby
+ ++ map nw checkSi) ([] :: [ConceptChunk]) checkSi label gameRefby
  gameDatadefn gameInsmodel gameGendef gameTheory gameConcins gameSection
  []
 

--- a/code/drasil-example/Drasil/GamePhysics/Body.hs
+++ b/code/drasil-example/Drasil/GamePhysics/Body.hs
@@ -202,8 +202,8 @@ usedDB = cdb (map qw symbTT) (map nw cpSymbolsAll ++ map nw cpAcronyms
 printSetting :: PrintingInformation
 printSetting = PI everything defaultConfiguration
 
-chipCode :: CodeSpec
-chipCode = codeSpec sysInfo []
+code :: CodeSpec
+code = codeSpec sysInfo []
 
 resourcePath :: String
 resourcePath = "../../../datafiles/GamePhysics/"

--- a/code/drasil-example/Drasil/GamePhysics/Body.hs
+++ b/code/drasil-example/Drasil/GamePhysics/Body.hs
@@ -65,7 +65,7 @@ import Drasil.GamePhysics.References (citations, parnas1972, parnasClements1984)
 import Drasil.GamePhysics.Requirements (funcReqsContent, funcReqs, nonfuncReqs,
     propsDeriv, requirements)
 import Drasil.GamePhysics.TMods (tModsNew)
-import Drasil.GamePhysics.Unitals (cpSymbolsAll, cpOutputConstraints,
+import Drasil.GamePhysics.Unitals (symbolsAll, cpOutputConstraints,
   inputSymbols, outputSymbols, cpInputConstraints, defSymbols)
 
 import Control.Lens ((^.))
@@ -184,7 +184,7 @@ units :: [UnitDefn] -- FIXME
 units = map unitWrapper [metre, kilogram, second, joule] ++ map unitWrapper [newton, radian]
 
 everything :: ChunkDB
-everything = cdb (map qw iModelsNew ++ map qw cpSymbolsAll) (map nw cpSymbolsAll
+everything = cdb (map qw iModelsNew ++ map qw symbolsAll) (map nw symbolsAll
   ++ map nw acronyms ++ map nw prodtcon ++ map nw iModelsNew
   ++ map nw softwarecon ++ map nw doccon ++ map nw doccon'
   ++ map nw CP.physicCon ++ map nw educon ++ [nw algorithm] ++ map nw derived
@@ -194,7 +194,7 @@ everything = cdb (map qw iModelsNew ++ map qw cpSymbolsAll) (map nw cpSymbolsAll
   concIns section []
 
 usedDB :: ChunkDB
-usedDB = cdb (map qw symbTT) (map nw cpSymbolsAll ++ map nw acronyms
+usedDB = cdb (map qw symbTT) (map nw symbolsAll ++ map nw acronyms
  ++ map nw checkSi) ([] :: [ConceptChunk]) checkSi label refBy
  dataDefs iMods genDef theory concIns section
  []

--- a/code/drasil-example/Drasil/GamePhysics/Body.hs
+++ b/code/drasil-example/Drasil/GamePhysics/Body.hs
@@ -57,7 +57,7 @@ import qualified Data.Drasil.Quantities.Physics as QP (force, time)
 import Drasil.GamePhysics.Assumptions(assumptions)
 import Drasil.GamePhysics.Changes (unlikelyChangesList', unlikelyChangeswithIntro,
  likelyChangesListwithIntro, likelyChangesList')
-import Drasil.GamePhysics.Concepts (chipmunk, cpAcronyms, twoD)
+import Drasil.GamePhysics.Concepts (chipmunk, acronyms, twoD)
 import Drasil.GamePhysics.DataDefs (cpDDefs, cpQDefs, dataDefns)
 import Drasil.GamePhysics.Goals (goals)
 import Drasil.GamePhysics.IMods (iModelsNew, instModIntro)
@@ -185,7 +185,7 @@ units = map unitWrapper [metre, kilogram, second, joule] ++ map unitWrapper [new
 
 everything :: ChunkDB
 everything = cdb (map qw iModelsNew ++ map qw cpSymbolsAll) (map nw cpSymbolsAll
-  ++ map nw cpAcronyms ++ map nw prodtcon ++ map nw iModelsNew
+  ++ map nw acronyms ++ map nw prodtcon ++ map nw iModelsNew
   ++ map nw softwarecon ++ map nw doccon ++ map nw doccon'
   ++ map nw CP.physicCon ++ map nw educon ++ [nw algorithm] ++ map nw derived
   ++ map nw fundamentals ++ map nw CM.mathcon ++ map nw CM.mathcon')
@@ -194,7 +194,7 @@ everything = cdb (map qw iModelsNew ++ map qw cpSymbolsAll) (map nw cpSymbolsAll
   concIns section []
 
 usedDB :: ChunkDB
-usedDB = cdb (map qw symbTT) (map nw cpSymbolsAll ++ map nw cpAcronyms
+usedDB = cdb (map qw symbTT) (map nw cpSymbolsAll ++ map nw acronyms
  ++ map nw checkSi) ([] :: [ConceptChunk]) checkSi label refBy
  dataDefs iMods genDef theory concIns section
  []

--- a/code/drasil-example/Drasil/GamePhysics/Body.hs
+++ b/code/drasil-example/Drasil/GamePhysics/Body.hs
@@ -66,7 +66,7 @@ import Drasil.GamePhysics.Requirements (funcReqsContent, funcReqs, nonfuncReqs,
     propsDeriv, requirements)
 import Drasil.GamePhysics.TMods (tModsNew)
 import Drasil.GamePhysics.Unitals (cpSymbolsAll, cpOutputConstraints,
-  inputSymbols, outputSymbols, cpInputConstraints, gamephySymbols)
+  inputSymbols, outputSymbols, cpInputConstraints, symbols)
 
 import Control.Lens ((^.))
 import qualified Data.Map as Map
@@ -189,7 +189,7 @@ everything = cdb (map qw iModelsNew ++ map qw cpSymbolsAll) (map nw cpSymbolsAll
   ++ map nw softwarecon ++ map nw doccon ++ map nw doccon'
   ++ map nw CP.physicCon ++ map nw educon ++ [nw algorithm] ++ map nw derived
   ++ map nw fundamentals ++ map nw CM.mathcon ++ map nw CM.mathcon')
-  (map cw gamephySymbols ++ srsDomains ++ map cw iModelsNew) units
+  (map cw symbols ++ srsDomains ++ map cw iModelsNew) units
   label refBy dataDefs iMods genDef theory
   concIns section []
 

--- a/code/drasil-example/Drasil/GamePhysics/Body.hs
+++ b/code/drasil-example/Drasil/GamePhysics/Body.hs
@@ -1,6 +1,6 @@
 module Drasil.GamePhysics.Body where
 
-import Language.Drasil hiding (Vector, organization, section)
+import Language.Drasil hiding (Vector, organization, section, sec)
 import Language.Drasil.Code (CodeSpec, codeSpec)
 import Language.Drasil.Printers (PrintingInformation(..), defaultConfiguration)
 import Database.Drasil (ChunkDB, RefbyMap, ReferenceDB, SystemInformation(SI),
@@ -143,10 +143,10 @@ concIns = assumptions ++ likelyChangesList' ++ unlikelyChangesList' ++
   funcReqs
 
 section :: [Section]
-section = gameSec
+section = sec
 
-gameSec :: [Section]
-gameSec = extractSection srs
+sec :: [Section]
+sec = extractSection srs
 
 stdFields :: Fields
 stdFields = [DefiningEquation, Description Verbose IncludeUnits, Notes, Source, RefBy]

--- a/code/drasil-example/Drasil/GamePhysics/Body.hs
+++ b/code/drasil-example/Drasil/GamePhysics/Body.hs
@@ -123,8 +123,8 @@ mkSRS = [RefSec $ RefProg intro [TUnits, tsymb tableOfSymbols, TAandA],
 label :: TraceMap
 label = Map.union (generateTraceMap mkSRS) $ generateTraceMap' gameConcins
 
-gameRefby :: RefbyMap
-gameRefby = generateRefbyMap label
+refBy :: RefbyMap
+refBy = generateRefbyMap label
 
 gameDatadefn :: [DataDefinition]
 gameDatadefn = getTraceMapFromDD $ getSCSSub mkSRS
@@ -190,12 +190,12 @@ everything = cdb (map qw iModelsNew ++ map qw cpSymbolsAll) (map nw cpSymbolsAll
   ++ map nw CP.physicCon ++ map nw educon ++ [nw algorithm] ++ map nw derived
   ++ map nw fundamentals ++ map nw CM.mathcon ++ map nw CM.mathcon')
   (map cw gamephySymbols ++ srsDomains ++ map cw iModelsNew) chipUnits
-  label gameRefby gameDatadefn gameInsmodel gameGendef gameTheory
+  label refBy gameDatadefn gameInsmodel gameGendef gameTheory
   gameConcins gameSection []
 
 usedDB :: ChunkDB
 usedDB = cdb (map qw symbTT) (map nw cpSymbolsAll ++ map nw cpAcronyms
- ++ map nw checkSi) ([] :: [ConceptChunk]) checkSi label gameRefby
+ ++ map nw checkSi) ([] :: [ConceptChunk]) checkSi label refBy
  gameDatadefn gameInsmodel gameGendef gameTheory gameConcins gameSection
  []
 

--- a/code/drasil-example/Drasil/GamePhysics/Body.hs
+++ b/code/drasil-example/Drasil/GamePhysics/Body.hs
@@ -66,7 +66,7 @@ import Drasil.GamePhysics.Requirements (funcReqsContent, funcReqs, nonfuncReqs,
     propsDeriv, requirements)
 import Drasil.GamePhysics.TMods (tModsNew)
 import Drasil.GamePhysics.Unitals (cpSymbolsAll, cpOutputConstraints,
-  inputSymbols, outputSymbols, cpInputConstraints, symbols)
+  inputSymbols, outputSymbols, cpInputConstraints, defSymbols)
 
 import Control.Lens ((^.))
 import qualified Data.Map as Map
@@ -189,7 +189,7 @@ everything = cdb (map qw iModelsNew ++ map qw cpSymbolsAll) (map nw cpSymbolsAll
   ++ map nw softwarecon ++ map nw doccon ++ map nw doccon'
   ++ map nw CP.physicCon ++ map nw educon ++ [nw algorithm] ++ map nw derived
   ++ map nw fundamentals ++ map nw CM.mathcon ++ map nw CM.mathcon')
-  (map cw symbols ++ srsDomains ++ map cw iModelsNew) units
+  (map cw defSymbols ++ srsDomains ++ map cw iModelsNew) units
   label refBy dataDefs iMods genDef theory
   concIns section []
 
@@ -462,9 +462,9 @@ goalStatement4Inputs = [QP.position, QM.orientation, QP.linearVelocity,
   QP.angularVelocity]
 
 goal_statements_G_collision = goalStatementStruct (plural physicalProperty)
-  (goalStatement4Inputs) --fixme input symbols
+  (goalStatement4Inputs) --fixme input defSymbols
   EmptyS (S "of")
-  (goalStatement4Inputs) --fixme input symbols
+  (goalStatement4Inputs) --fixme input defSymbols
   CP.rigidBody (S "the new") (S "of the" +:+ (plural CP.rigidBody) +:+
   S "that have undergone a" +:+ (phrase CP.collision))-}
 

--- a/code/drasil-example/Drasil/GamePhysics/Body.hs
+++ b/code/drasil-example/Drasil/GamePhysics/Body.hs
@@ -135,8 +135,8 @@ iMods = getTraceMapFromIM $ getSCSSub mkSRS
 genDef :: [GenDefn]
 genDef = getTraceMapFromGD $ getSCSSub mkSRS
 
-gameTheory :: [TheoryModel]
-gameTheory = getTraceMapFromTM $ getSCSSub mkSRS
+theory :: [TheoryModel]
+theory = getTraceMapFromTM $ getSCSSub mkSRS
 
 gameConcins :: [ConceptInstance]
 gameConcins = assumptions ++ likelyChangesList' ++ unlikelyChangesList' ++
@@ -190,13 +190,13 @@ everything = cdb (map qw iModelsNew ++ map qw cpSymbolsAll) (map nw cpSymbolsAll
   ++ map nw CP.physicCon ++ map nw educon ++ [nw algorithm] ++ map nw derived
   ++ map nw fundamentals ++ map nw CM.mathcon ++ map nw CM.mathcon')
   (map cw gamephySymbols ++ srsDomains ++ map cw iModelsNew) chipUnits
-  label refBy dataDefs iMods genDef gameTheory
+  label refBy dataDefs iMods genDef theory
   gameConcins gameSection []
 
 usedDB :: ChunkDB
 usedDB = cdb (map qw symbTT) (map nw cpSymbolsAll ++ map nw cpAcronyms
  ++ map nw checkSi) ([] :: [ConceptChunk]) checkSi label refBy
- dataDefs iMods genDef gameTheory gameConcins gameSection
+ dataDefs iMods genDef theory gameConcins gameSection
  []
 
 printSetting :: PrintingInformation

--- a/code/drasil-example/Drasil/GamePhysics/Body.hs
+++ b/code/drasil-example/Drasil/GamePhysics/Body.hs
@@ -129,8 +129,8 @@ refBy = generateRefbyMap label
 dataDefs :: [DataDefinition]
 dataDefs = getTraceMapFromDD $ getSCSSub mkSRS
 
-gameInsmodel :: [InstanceModel]
-gameInsmodel = getTraceMapFromIM $ getSCSSub mkSRS
+iMods :: [InstanceModel]
+iMods = getTraceMapFromIM $ getSCSSub mkSRS
 
 gameGendef :: [GenDefn]
 gameGendef = getTraceMapFromGD $ getSCSSub mkSRS
@@ -190,13 +190,13 @@ everything = cdb (map qw iModelsNew ++ map qw cpSymbolsAll) (map nw cpSymbolsAll
   ++ map nw CP.physicCon ++ map nw educon ++ [nw algorithm] ++ map nw derived
   ++ map nw fundamentals ++ map nw CM.mathcon ++ map nw CM.mathcon')
   (map cw gamephySymbols ++ srsDomains ++ map cw iModelsNew) chipUnits
-  label refBy dataDefs gameInsmodel gameGendef gameTheory
+  label refBy dataDefs iMods gameGendef gameTheory
   gameConcins gameSection []
 
 usedDB :: ChunkDB
 usedDB = cdb (map qw symbTT) (map nw cpSymbolsAll ++ map nw cpAcronyms
  ++ map nw checkSi) ([] :: [ConceptChunk]) checkSi label refBy
- dataDefs gameInsmodel gameGendef gameTheory gameConcins gameSection
+ dataDefs iMods gameGendef gameTheory gameConcins gameSection
  []
 
 printSetting :: PrintingInformation

--- a/code/drasil-example/Drasil/GamePhysics/Body.hs
+++ b/code/drasil-example/Drasil/GamePhysics/Body.hs
@@ -64,7 +64,7 @@ import Drasil.GamePhysics.IMods (iModelsNew, instModIntro)
 import Drasil.GamePhysics.References (citations, parnas1972, parnasClements1984)
 import Drasil.GamePhysics.Requirements (funcReqsContent, funcReqs, nonfuncReqs,
     propsDeriv, requirements)
-import Drasil.GamePhysics.TMods (cpTModsNew)
+import Drasil.GamePhysics.TMods (tModsNew)
 import Drasil.GamePhysics.Unitals (cpSymbolsAll, cpOutputConstraints,
   inputSymbols, outputSymbols, cpInputConstraints, gamephySymbols)
 
@@ -96,7 +96,7 @@ mkSRS = [RefSec $ RefProg intro [TUnits, tsymb tableOfSymbols, TAandA],
    SSDSec $ SSDProg [SSDSubVerb problemDescriptionSection
       , SSDSolChSpec $ SCSProg
         [ Assumptions
-        , TMs [] (Label : stdFields) cpTModsNew
+        , TMs [] (Label : stdFields) tModsNew
         , GDs [] [] [] HideDerivation -- No Gen Defs for Gamephysics
         , DDs [] ([Label, Symbol, Units] ++ stdFields) dataDefns ShowDerivation
         , IMs [instModIntro] ([Label, Input, Output, InConstraints, OutConstraints] ++ stdFields)
@@ -629,7 +629,7 @@ traceMatInstaModel = ["IM1", "IM2", "IM3"]
 traceMatInstaModelRef = map makeRef2S iModelsNew
 
 traceMatTheoryModel = ["T1", "T2", "T3", "T4", "T5"]
-traceMatTheoryModelRef = map makeRef2S cpTModsNew
+traceMatTheoryModelRef = map makeRef2S tModsNew
 
 traceMatDataDef = ["DD1","DD2","DD3","DD4","DD5","DD6","DD7","DD8"]
 traceMatDataDefRef = map makeRef2S dataDefns

--- a/code/drasil-example/Drasil/GamePhysics/Body.hs
+++ b/code/drasil-example/Drasil/GamePhysics/Body.hs
@@ -58,7 +58,7 @@ import Drasil.GamePhysics.Assumptions(assumptions)
 import Drasil.GamePhysics.Changes (unlikelyChangesList', unlikelyChangeswithIntro,
  likelyChangesListwithIntro, likelyChangesList')
 import Drasil.GamePhysics.Concepts (chipmunk, acronyms, twoD)
-import Drasil.GamePhysics.DataDefs (cpDDefs, cpQDefs, dataDefns)
+import Drasil.GamePhysics.DataDefs (qDefs, cpQDefs, dataDefns)
 import Drasil.GamePhysics.Goals (goals)
 import Drasil.GamePhysics.IMods (iModelsNew, instModIntro)
 import Drasil.GamePhysics.References (cpCitations, parnas1972, parnasClements1984)
@@ -160,7 +160,7 @@ sysInfo = SI {
   _authors = authors,
   _quants = symbTT, 
   _concepts = ([] :: [DefinedQuantityDict]),
-  _definitions = cpDDefs,
+  _definitions = qDefs,
   _datadefs = dataDefns,
   _inputs = inputSymbols,
   _outputs = outputSymbols, 

--- a/code/drasil-example/Drasil/GamePhysics/Concepts.hs
+++ b/code/drasil-example/Drasil/GamePhysics/Concepts.hs
@@ -1,4 +1,4 @@
-module Drasil.GamePhysics.Concepts (centreMass, twoD, chipmunk, cpAcronyms) where
+module Drasil.GamePhysics.Concepts (centreMass, twoD, chipmunk, acronyms) where
 
 import Language.Drasil
 import Data.Drasil.Concepts.Documentation (assumption, goalStmt, likelyChg,
@@ -10,8 +10,8 @@ import Data.Drasil.IdeaDicts (dataDefn, genDefn, inModel, physics, thModel)
 
 centreMass, chipmunk :: CI
 
-cpAcronyms :: [CI]
-cpAcronyms = [assumption, centreMass, dataDefn, genDefn, goalStmt,
+acronyms :: [CI]
+acronyms = [assumption, centreMass, dataDefn, genDefn, goalStmt,
     inModel, likelyChg, ode, requirement, srs, thModel, twoD, chipmunk,
     typUnc, unlikelyChg]
 

--- a/code/drasil-example/Drasil/GamePhysics/DataDefs.hs
+++ b/code/drasil-example/Drasil/GamePhysics/DataDefs.hs
@@ -1,4 +1,4 @@
-module Drasil.GamePhysics.DataDefs (cpDDefs, cpQDefs, dataDefns,
+module Drasil.GamePhysics.DataDefs (qDefs, cpQDefs, dataDefns,
   ctrOfMassDD, linDispDD, linVelDD, linAccDD, angDispDD,
   angVelDD, angAccelDD, impulseDD, torqueDD, kEnergyDD, coeffRestitutionDD, reVelInCollDD) where
 
@@ -31,12 +31,12 @@ dataDefns :: [DataDefinition]
 dataDefns = [ctrOfMassDD, linDispDD, linVelDD, linAccDD, angDispDD,
  angVelDD, angAccelDD, impulseDD, chaslesDD, torqueDD, kEnergyDD, coeffRestitutionDD, reVelInCollDD]
 
-cpDDefs :: [QDefinition]
-cpDDefs = [ctrOfMass, linDisp, linVel, linAcc, angDisp,
+qDefs :: [QDefinition]
+qDefs = [ctrOfMass, linDisp, linVel, linAcc, angDisp,
   angVel, angAccel, impulse, chasles, torque, kEnergy, coeffRestitution]
 
 cpQDefs :: [Block QDefinition]
-cpQDefs = map (\x -> Parallel x []) cpDDefs
+cpQDefs = map (\x -> Parallel x []) qDefs
 -- DD1 : Centre of mass --
 
 ctrOfMassDD :: DataDefinition

--- a/code/drasil-example/Drasil/GamePhysics/DataDefs.hs
+++ b/code/drasil-example/Drasil/GamePhysics/DataDefs.hs
@@ -1,4 +1,4 @@
-module Drasil.GamePhysics.DataDefs (qDefs, cpQDefs, dataDefns,
+module Drasil.GamePhysics.DataDefs (qDefs, blockQDefs, dataDefns,
   ctrOfMassDD, linDispDD, linVelDD, linAccDD, angDispDD,
   angVelDD, angAccelDD, impulseDD, torqueDD, kEnergyDD, coeffRestitutionDD, reVelInCollDD) where
 
@@ -35,8 +35,8 @@ qDefs :: [QDefinition]
 qDefs = [ctrOfMass, linDisp, linVel, linAcc, angDisp,
   angVel, angAccel, impulse, chasles, torque, kEnergy, coeffRestitution]
 
-cpQDefs :: [Block QDefinition]
-cpQDefs = map (\x -> Parallel x []) qDefs
+blockQDefs :: [Block QDefinition]
+blockQDefs = map (\x -> Parallel x []) qDefs
 -- DD1 : Centre of mass --
 
 ctrOfMassDD :: DataDefinition

--- a/code/drasil-example/Drasil/GamePhysics/GDef.hs
+++ b/code/drasil-example/Drasil/GamePhysics/GDef.hs
@@ -4,7 +4,7 @@
 -- so it is not actually 'plugged in'.  The definitions in here
 -- may not type check anymore!
 -- %%%%%%%%%%%%%%%%%%%%%%%%%%
-module Drasil.GamePhysics.GDefs (cpGDefs) where
+module Drasil.GamePhysics.GDefs (genDefs) where
 
 import Language.Drasil
 import Data.Drasil.Concepts.Physics (rigidBody)
@@ -13,8 +13,8 @@ import Data.Drasil.Utils (foldlSent)
 
 ----- General Models -----
 
-cpGDefs :: [RelationConcept]
---cpGDefs = []
+genDefs :: [RelationConcept]
+--genDefs = []
 
 impulseGDef :: RelationConcept
 impulseGDef = makeRC "impulse" (nounPhraseSP "Impulse") 

--- a/code/drasil-example/Drasil/GamePhysics/Main.hs
+++ b/code/drasil-example/Drasil/GamePhysics/Main.hs
@@ -5,7 +5,7 @@ import Language.Drasil.Code (Choices(..), Comments(..), ConstraintBehaviour(..),
 import Language.Drasil.Generate (gen)
 import Language.Drasil.Printers (DocType(SRS, Website), DocSpec(DocSpec))
 
-import Drasil.GamePhysics.Body (chipmunkSRS', printSetting)
+import Drasil.GamePhysics.Body (srs, printSetting)
 
 chipChoices :: Choices
 chipChoices = Choices {
@@ -21,5 +21,5 @@ chipChoices = Choices {
        
 main :: IO ()
 main = do
-  gen (DocSpec SRS "Chipmunk_SRS") chipmunkSRS'  printSetting
-  gen (DocSpec Website "Chipmunk_SRS") chipmunkSRS' printSetting
+  gen (DocSpec SRS "Chipmunk_SRS") srs  printSetting
+  gen (DocSpec Website "Chipmunk_SRS") srs printSetting

--- a/code/drasil-example/Drasil/GamePhysics/Main.hs
+++ b/code/drasil-example/Drasil/GamePhysics/Main.hs
@@ -7,8 +7,8 @@ import Language.Drasil.Printers (DocType(SRS, Website), DocSpec(DocSpec))
 
 import Drasil.GamePhysics.Body (srs, printSetting)
 
-chipChoices :: Choices
-chipChoices = Choices {
+choices :: Choices
+choices = Choices {
   lang             = [Python, Cpp, CSharp, Java],
   impType          = Library,
   logFile          = "log.txt",

--- a/code/drasil-example/Drasil/GamePhysics/References.hs
+++ b/code/drasil-example/Drasil/GamePhysics/References.hs
@@ -1,4 +1,4 @@
-module Drasil.GamePhysics.References (cpCitations, parnas1972, parnasClements1984) where
+module Drasil.GamePhysics.References (citations, parnas1972, parnasClements1984) where
 
 import Language.Drasil
 
@@ -9,8 +9,8 @@ import Data.Drasil.People (bWaugh, cTitus, dParnas, daAruliah, epWhite,
 
 parnas1978, sciComp2013, jfBeucheIntro :: Citation
 
-cpCitations :: BibRef
-cpCitations = [parnas1978, sciComp2013, parnas1972, parnasClements1984,
+citations :: BibRef
+citations = [parnas1978, sciComp2013, parnas1972, parnasClements1984,
   parnasClements1986, koothoor2013, smithLai2005, jfBeucheIntro]
 
 --FIXME: check for references made within document

--- a/code/drasil-example/Drasil/GamePhysics/TMods.hs
+++ b/code/drasil-example/Drasil/GamePhysics/TMods.hs
@@ -1,4 +1,4 @@
-module Drasil.GamePhysics.TMods (cpTMods, t2NewtonTL_new, 
+module Drasil.GamePhysics.TMods (tMods, t2NewtonTL_new, 
 t3NewtonLUG_new, t4ChaslesThm_new, t5NewtonSLR_new, cpTModsNew) where
 
 import Language.Drasil
@@ -20,8 +20,8 @@ import qualified Data.Drasil.Theories.Physics as TP (newtonSL, newtonSLRC)
 
 ----- Theoretical Models -----
 
-cpTMods :: [RelationConcept]
-cpTMods = [TP.newtonSLRC, newtonTL, newtonLUG, chaslesThm, newtonSLR]
+tMods :: [RelationConcept]
+tMods = [TP.newtonSLRC, newtonTL, newtonLUG, chaslesThm, newtonSLR]
 
 cpTModsNew :: [TheoryModel]
 cpTModsNew = [TP.newtonSL, t2NewtonTL_new, t3NewtonLUG_new, 

--- a/code/drasil-example/Drasil/GamePhysics/TMods.hs
+++ b/code/drasil-example/Drasil/GamePhysics/TMods.hs
@@ -1,5 +1,5 @@
 module Drasil.GamePhysics.TMods (tMods, t2NewtonTL_new, 
-t3NewtonLUG_new, t4ChaslesThm_new, t5NewtonSLR_new, cpTModsNew) where
+t3NewtonLUG_new, t4ChaslesThm_new, t5NewtonSLR_new, tModsNew) where
 
 import Language.Drasil
 import Prelude hiding (id)
@@ -23,8 +23,8 @@ import qualified Data.Drasil.Theories.Physics as TP (newtonSL, newtonSLRC)
 tMods :: [RelationConcept]
 tMods = [TP.newtonSLRC, newtonTL, newtonLUG, chaslesThm, newtonSLR]
 
-cpTModsNew :: [TheoryModel]
-cpTModsNew = [TP.newtonSL, t2NewtonTL_new, t3NewtonLUG_new, 
+tModsNew :: [TheoryModel]
+tModsNew = [TP.newtonSL, t2NewtonTL_new, t3NewtonLUG_new, 
   t4ChaslesThm_new, t5NewtonSLR_new]
 
 -- T1 : Newton's second law of motion --

--- a/code/drasil-example/Drasil/GamePhysics/Unitals.hs
+++ b/code/drasil-example/Drasil/GamePhysics/Unitals.hs
@@ -19,7 +19,7 @@ import Data.Drasil.Units.Physics (accelU, angVelU, impulseU, momtInertU,
 import Control.Lens((^.))
 
 defSymbols :: [DefinedQuantityDict]
-defSymbols = (map dqdWr unitSymbs) ++ (map dqdWr cpInputConstraints) ++
+defSymbols = (map dqdWr unitSymbs) ++ (map dqdWr inputConstraints) ++
   (map dqdWr cpOutputConstraints)
 
 unitSymbs :: [UnitaryConceptDict]
@@ -41,7 +41,7 @@ symbolsAll = symbols ++ inputSymbols ++ outputSymbols
 
 symbols = (map qw unitalChunks) ++ 
   (map qw unitless) ++ 
-  (map qw cpInputConstraints)
+  (map qw inputConstraints)
 
 inputSymbols = map qw [QP.position, QP.velocity, QP.force, QM.orientation, 
   QP.angularVelocity, QP.linearVelocity, QP.gravitationalConst, QPP.mass, 
@@ -268,8 +268,8 @@ numParticles = vc "n" (nounPhraseSP "number of particles in a rigid body") lN In
 lengthCons, massCons, mmntOfInCons, gravAccelCons, posCons, orientCons,
   angVeloCons, forceCons, torqueCons, veloCons, restCoefCons :: ConstrConcept
 
-cpInputConstraints :: [UncertQ]
-cpInputConstraints = map (`uq` defaultUncrt)
+inputConstraints :: [UncertQ]
+inputConstraints = map (`uq` defaultUncrt)
   [lengthCons, massCons, mmntOfInCons, gravAccelCons, posCons, orientCons,
   veloCons, angVeloCons, forceCons, torqueCons, restCoefCons]
 

--- a/code/drasil-example/Drasil/GamePhysics/Unitals.hs
+++ b/code/drasil-example/Drasil/GamePhysics/Unitals.hs
@@ -23,7 +23,7 @@ defSymbols = (map dqdWr unitSymbs) ++ (map dqdWr cpInputConstraints) ++
   (map dqdWr cpOutputConstraints)
 
 unitSymbs :: [UnitaryConceptDict]
-unitSymbs = map ucw cpUnits ++ map ucw [iVect, jVect, normalVect,
+unitSymbs = map ucw unitalChunks ++ map ucw [iVect, jVect, normalVect,
  force_1, force_2, forceI, mass_1, mass_2, dispUnit, 
   dispNorm, sqrDist, velA, velB, velO, rOB, angVelA, angVelB,
   posCM, massI, posI, accI, mTot, velI, torqueI, timeC, initRelVel, 
@@ -39,7 +39,7 @@ symbols, symbolsAll, inputSymbols, outputSymbols :: [QuantityDict]
 
 symbolsAll = symbols ++ inputSymbols ++ outputSymbols
 
-symbols = (map qw cpUnits) ++ 
+symbols = (map qw unitalChunks) ++ 
   (map qw cpUnitless) ++ 
   (map qw cpInputConstraints)
 
@@ -51,8 +51,8 @@ outputSymbols = map qw [QP.position, QP.velocity, QM.orientation,
   QP.angularVelocity]
 
 
-cpUnits :: [UnitalChunk]
-cpUnits = [QP.acceleration, QP.angularAccel, QP.gravitationalAccel, 
+unitalChunks :: [UnitalChunk]
+unitalChunks = [QP.acceleration, QP.angularAccel, QP.gravitationalAccel, 
   QP.impulseV, QP.impulseS, iVect, jVect, normalVect, QP.distance, QP.displacement, 
   QP.time, QP.angularDisplacement, posCM, posI, massI, mTot, accI, velI,
   QP.linearDisplacement, QP.linearVelocity, QP.linearAccel, initRelVel, normalLen,

--- a/code/drasil-example/Drasil/GamePhysics/Unitals.hs
+++ b/code/drasil-example/Drasil/GamePhysics/Unitals.hs
@@ -20,7 +20,7 @@ import Control.Lens((^.))
 
 defSymbols :: [DefinedQuantityDict]
 defSymbols = (map dqdWr unitSymbs) ++ (map dqdWr inputConstraints) ++
-  (map dqdWr cpOutputConstraints)
+  (map dqdWr outputConstraints)
 
 unitSymbs :: [UnitaryConceptDict]
 unitSymbs = map ucw unitalChunks ++ map ucw [iVect, jVect, normalVect,
@@ -273,8 +273,8 @@ inputConstraints = map (`uq` defaultUncrt)
   [lengthCons, massCons, mmntOfInCons, gravAccelCons, posCons, orientCons,
   veloCons, angVeloCons, forceCons, torqueCons, restCoefCons]
 
-cpOutputConstraints :: [UncertQ]
-cpOutputConstraints = map (`uq` defaultUncrt) 
+outputConstraints :: [UncertQ]
+outputConstraints = map (`uq` defaultUncrt) 
   [posCons, veloCons, orientCons, angVeloCons]
 
 nonNegativeConstraint :: Constraint -- should be pulled out and put somewhere for generic constraints

--- a/code/drasil-example/Drasil/GamePhysics/Unitals.hs
+++ b/code/drasil-example/Drasil/GamePhysics/Unitals.hs
@@ -18,8 +18,8 @@ import Data.Drasil.Units.Physics (accelU, angVelU, impulseU, momtInertU,
 
 import Control.Lens((^.))
 
-symbols :: [DefinedQuantityDict]
-symbols = (map dqdWr unitSymbs) ++ (map dqdWr cpInputConstraints) ++
+defSymbols :: [DefinedQuantityDict]
+defSymbols = (map dqdWr unitSymbs) ++ (map dqdWr cpInputConstraints) ++
   (map dqdWr cpOutputConstraints)
 
 unitSymbs :: [UnitaryConceptDict]

--- a/code/drasil-example/Drasil/GamePhysics/Unitals.hs
+++ b/code/drasil-example/Drasil/GamePhysics/Unitals.hs
@@ -40,7 +40,7 @@ symbols, symbolsAll, inputSymbols, outputSymbols :: [QuantityDict]
 symbolsAll = symbols ++ inputSymbols ++ outputSymbols
 
 symbols = (map qw unitalChunks) ++ 
-  (map qw cpUnitless) ++ 
+  (map qw unitless) ++ 
   (map qw cpInputConstraints)
 
 inputSymbols = map qw [QP.position, QP.velocity, QP.force, QM.orientation, 
@@ -255,8 +255,8 @@ massB      = rigidParam "B" cB
 -- CHUNKS WITHOUT UNITS --
 --------------------------
 
-cpUnitless :: [QuantityDict]
-cpUnitless = qw QM.pi_ : [numParticles]
+unitless :: [QuantityDict]
+unitless = qw QM.pi_ : [numParticles]
 
 numParticles :: QuantityDict
 numParticles = vc "n" (nounPhraseSP "number of particles in a rigid body") lN Integer

--- a/code/drasil-example/Drasil/GamePhysics/Unitals.hs
+++ b/code/drasil-example/Drasil/GamePhysics/Unitals.hs
@@ -35,9 +35,9 @@ unitSymbs = map ucw cpUnits ++ map ucw [iVect, jVect, normalVect,
 -- TABLE OF SYMBOLS --
 ----------------------
 
-symbols, cpSymbolsAll, inputSymbols, outputSymbols :: [QuantityDict]
+symbols, symbolsAll, inputSymbols, outputSymbols :: [QuantityDict]
 
-cpSymbolsAll = symbols ++ inputSymbols ++ outputSymbols
+symbolsAll = symbols ++ inputSymbols ++ outputSymbols
 
 symbols = (map qw cpUnits) ++ 
   (map qw cpUnitless) ++ 

--- a/code/drasil-example/Drasil/GamePhysics/Unitals.hs
+++ b/code/drasil-example/Drasil/GamePhysics/Unitals.hs
@@ -35,11 +35,11 @@ unitSymbs = map ucw cpUnits ++ map ucw [iVect, jVect, normalVect,
 -- TABLE OF SYMBOLS --
 ----------------------
 
-cpSymbols, cpSymbolsAll, inputSymbols, outputSymbols :: [QuantityDict]
+symbols, cpSymbolsAll, inputSymbols, outputSymbols :: [QuantityDict]
 
-cpSymbolsAll = cpSymbols ++ inputSymbols ++ outputSymbols
+cpSymbolsAll = symbols ++ inputSymbols ++ outputSymbols
 
-cpSymbols = (map qw cpUnits) ++ 
+symbols = (map qw cpUnits) ++ 
   (map qw cpUnitless) ++ 
   (map qw cpInputConstraints)
 

--- a/code/drasil-example/Drasil/GamePhysics/Unitals.hs
+++ b/code/drasil-example/Drasil/GamePhysics/Unitals.hs
@@ -18,8 +18,8 @@ import Data.Drasil.Units.Physics (accelU, angVelU, impulseU, momtInertU,
 
 import Control.Lens((^.))
 
-gamephySymbols :: [DefinedQuantityDict]
-gamephySymbols = (map dqdWr gamephyUnitSymbs) ++ (map dqdWr cpInputConstraints) ++
+symbols :: [DefinedQuantityDict]
+symbols = (map dqdWr gamephyUnitSymbs) ++ (map dqdWr cpInputConstraints) ++
   (map dqdWr cpOutputConstraints)
 
 gamephyUnitSymbs :: [UnitaryConceptDict]

--- a/code/drasil-example/Drasil/GamePhysics/Unitals.hs
+++ b/code/drasil-example/Drasil/GamePhysics/Unitals.hs
@@ -19,11 +19,11 @@ import Data.Drasil.Units.Physics (accelU, angVelU, impulseU, momtInertU,
 import Control.Lens((^.))
 
 symbols :: [DefinedQuantityDict]
-symbols = (map dqdWr gamephyUnitSymbs) ++ (map dqdWr cpInputConstraints) ++
+symbols = (map dqdWr unitSymbs) ++ (map dqdWr cpInputConstraints) ++
   (map dqdWr cpOutputConstraints)
 
-gamephyUnitSymbs :: [UnitaryConceptDict]
-gamephyUnitSymbs = map ucw cpUnits ++ map ucw [iVect, jVect, normalVect,
+unitSymbs :: [UnitaryConceptDict]
+unitSymbs = map ucw cpUnits ++ map ucw [iVect, jVect, normalVect,
  force_1, force_2, forceI, mass_1, mass_2, dispUnit, 
   dispNorm, sqrDist, velA, velB, velO, rOB, angVelA, angVelB,
   posCM, massI, posI, accI, mTot, velI, torqueI, timeC, initRelVel, 


### PR DESCRIPTION
Based on #1267. Removing prefixes in GamePhysics to make naming more generic.