### PR TITLE
PR - Remove prefixes from Tiny

### DIFF
--- a/code/drasil-example/Drasil/HGHC/HGHC.hs
+++ b/code/drasil-example/Drasil/HGHC/HGHC.hs
@@ -15,7 +15,7 @@ import Database.Drasil (Block, ChunkDB, SystemInformation(SI), cdb,
   _datadefs, _definitions, _defSequence, _inputs, _kind, _outputs, _quants, 
   _sys, _sysinfodb, _usedinfodb)
 
-import Drasil.HGHC.HeatTransfer (fp, hghc, hghcVarsDD, htInputs, htOutputs, 
+import Drasil.HGHC.HeatTransfer (fp, hghc, dataDefs, htInputs, htOutputs, 
     nuclearPhys, symbols)
 
 import Data.Drasil.SI_Units (siUnits, fundamentals, derived, degree)
@@ -34,7 +34,7 @@ thisSI = SI {
   _quants = symbols,
   _concepts = ([] :: [UnitaryConceptDict]),
   _definitions = ([] :: [QDefinition]),
-  _datadefs = hghcVarsDD,
+  _datadefs = dataDefs,
   _inputs = htInputs,
   _outputs = htOutputs,
   _defSequence = ([] :: [Block QDefinition]),
@@ -68,7 +68,7 @@ thisSRS = [RefSec $
     SSDSec $ SSDProg [
       SSDSolChSpec $ SCSProg [
         DDs [] [Label, Symbol, Units, DefiningEquation,
-          Description Verbose IncludeUnits] hghcVarsDD HideDerivation
+          Description Verbose IncludeUnits] dataDefs HideDerivation
       ]]]
   
 srsBody :: Document

--- a/code/drasil-example/Drasil/HGHC/HeatTransfer.hs
+++ b/code/drasil-example/Drasil/HGHC/HeatTransfer.hs
@@ -14,15 +14,15 @@ symbols = htOutputs ++ htInputs
 dataDefs :: [DataDefinition]
 dataDefs = [htTransCladFuelDD, htTransCladCoolDD]
 
-hghcVars :: [QDefinition]
-hghcVars = [htTransCladFuel, htTransCladCool]
+qDefs :: [QDefinition]
+qDefs = [htTransCladFuel, htTransCladCool]
 
 htVars :: [QuantityDict]
 htVars = [cladThick, coolFilmCond, gapFilmCond, cladCond]
 
 htInputs, htOutputs :: [QuantityDict]
 htInputs = map qw htVars
-htOutputs = map qw hghcVars
+htOutputs = map qw qDefs
 
 cladThick, coolFilmCond, gapFilmCond, cladCond :: QuantityDict
 cladThick    = vc "cladThick"    (cn''' "clad thickness")

--- a/code/drasil-example/Drasil/HGHC/HeatTransfer.hs
+++ b/code/drasil-example/Drasil/HGHC/HeatTransfer.hs
@@ -11,8 +11,8 @@ import Data.Drasil.Units.Thermodynamics (heatTransferCoef)
 symbols :: [QuantityDict]
 symbols = htOutputs ++ htInputs
 
-hghcVarsDD :: [DataDefinition]
-hghcVarsDD = [htTransCladFuelDD, htTransCladCoolDD]
+dataDefs :: [DataDefinition]
+dataDefs = [htTransCladFuelDD, htTransCladCoolDD]
 
 hghcVars :: [QDefinition]
 hghcVars = [htTransCladFuel, htTransCladCool]


### PR DESCRIPTION
Based on #1267. Removing prefixes in Tiny / HGHC to make naming more generic.