### PR TITLE
Input format fixes

### DIFF
--- a/code/drasil-code/Language/Drasil/CodeSpec.hs
+++ b/code/drasil-code/Language/Drasil/CodeSpec.hs
@@ -238,8 +238,7 @@ modExportMap :: [Mod] -> [Input] -> [Const] -> ModExportMap
 modExportMap ms ins _ = Map.fromList $ concatMap mpair ms
   where mpair (Mod n fs) = map fname fs `zip` repeat n
                         ++ map codeName ins `zip` repeat "InputParameters"
-                        ++ [ ("get_input", "InputFormat"),
-                             ("derived_values", "DerivedValues"),
+                        ++ [ ("derived_values", "DerivedValues"),
                              ("input_constraints", "InputConstraints"),
                              ("write_output", "OutputFormat") ]  -- hardcoded for now
                      --   ++ map codeName consts `zip` repeat "Constants"

--- a/code/drasil-example/Drasil/NoPCM/DataDesc.hs
+++ b/code/drasil-example/Drasil/NoPCM/DataDesc.hs
@@ -8,7 +8,7 @@ inputMod :: Mod
 inputMod = Mod "InputFormat" [inputData]
 
 inputData :: Func
-inputData = funcData "get_inputs"
+inputData = funcData "get_input"
   [ junkLine,
     singleton tank_length,
     junkLine,

--- a/code/drasil-example/Drasil/SSP/DataDesc.hs
+++ b/code/drasil-example/Drasil/SSP/DataDesc.hs
@@ -8,7 +8,7 @@ inputMod :: Mod
 inputMod = Mod "InputFormat" [inputData]
 
 inputData :: Func
-inputData = funcData "get_inputs" [
+inputData = funcData "get_input" [
 {- --FIXME: unfinished. Needs more inputs? 
     --Needs way to think of (x,y) as two seperate things
     --number of layers, layer direction

--- a/code/drasil-example/Drasil/SWHS/DataDesc.hs
+++ b/code/drasil-example/Drasil/SWHS/DataDesc.hs
@@ -11,7 +11,7 @@ inputMod :: Mod
 inputMod = Mod "InputFormat" [inputData]
 
 inputData :: Func
-inputData = funcData "get_inputs"
+inputData = funcData "get_input"
   [ junkLine, -- 1
     singleton tank_length,
     junkLine, -- 3

--- a/code/stable/nopcm/src/cpp/InputFormat.cpp
+++ b/code/stable/nopcm/src/cpp/InputFormat.cpp
@@ -17,7 +17,7 @@ using std::vector;
 using std::ifstream;
 using std::ofstream;
 
-void func_get_inputs(string filename, InputParameters &inParams, double τ, double A_tol, double R_tol, double C_tol) {
+void func_get_input(string filename, InputParameters &inParams, double τ, double A_tol, double R_tol, double C_tol) {
     ifstream infile;
     string line;
     vector<string> lines(0);

--- a/code/stable/nopcm/src/cpp/InputFormat.hpp
+++ b/code/stable/nopcm/src/cpp/InputFormat.hpp
@@ -12,6 +12,6 @@ using std::ofstream;
 
 
 
-void func_get_inputs(string filename, InputParameters &inParams, double τ, double A_tol, double R_tol, double C_tol);
+void func_get_input(string filename, InputParameters &inParams, double τ, double A_tol, double R_tol, double C_tol);
 
 #endif

--- a/code/stable/nopcm/src/csharp/Control.cs
+++ b/code/stable/nopcm/src/csharp/Control.cs
@@ -9,7 +9,7 @@ namespace SWHS {
         public static void Main(string[] args) {
             string inputfile = args[0];
             InputParameters inParams = new InputParameters();
-            func_get_input(inputfile, inParams);
+            InputFormat.func_get_input(inputfile, inParams);
             DerivedValues.derived_values(inParams);
             InputConstraints.input_constraints(inParams);
             OutputFormat.write_output(inParams);

--- a/code/stable/nopcm/src/csharp/InputFormat.cs
+++ b/code/stable/nopcm/src/csharp/InputFormat.cs
@@ -6,7 +6,7 @@ using System.Collections.Generic;
 namespace SWHS {
     public class InputFormat {
         
-        public static void func_get_inputs(string filename, InputParameters inParams, double τ, double A_tol, double R_tol, double C_tol) {
+        public static void func_get_input(string filename, InputParameters inParams, double τ, double A_tol, double R_tol, double C_tol) {
             StreamReader infile;
             string line;
             List<string> lines = new List<string>(0);

--- a/code/stable/nopcm/src/java/SWHS/Control.java
+++ b/code/stable/nopcm/src/java/SWHS/Control.java
@@ -12,7 +12,7 @@ public class Control {
     public static void main(String[] args) throws Exception {
         String inputfile = args[0];
         InputParameters inParams = new InputParameters();
-        func_get_input(inputfile, inParams);
+        InputFormat.func_get_input(inputfile, inParams);
         DerivedValues.derived_values(inParams);
         InputConstraints.input_constraints(inParams);
         OutputFormat.write_output(inParams);

--- a/code/stable/nopcm/src/java/SWHS/InputFormat.java
+++ b/code/stable/nopcm/src/java/SWHS/InputFormat.java
@@ -9,7 +9,7 @@ import java.util.Vector;
 
 public class InputFormat {
     
-    public static void func_get_inputs(String filename, InputParameters inParams, double τ, double A_tol, double R_tol, double C_tol) throws Exception {
+    public static void func_get_input(String filename, InputParameters inParams, double τ, double A_tol, double R_tol, double C_tol) throws Exception {
         Scanner infile;
         String line;
         Vector<String> lines = new Vector<String>(0);

--- a/code/stable/nopcm/src/python/Control.py
+++ b/code/stable/nopcm/src/python/Control.py
@@ -11,7 +11,7 @@ import Calculations
 
 inputfile = sys.argv[1]
 inParams = InputParameters.InputParameters()
-func_get_input(inputfile, inParams)
+InputFormat.func_get_input(inputfile, inParams)
 DerivedValues.derived_values(inParams)
 InputConstraints.input_constraints(inParams)
 OutputFormat.write_output(inParams)

--- a/code/stable/nopcm/src/python/InputFormat.py
+++ b/code/stable/nopcm/src/python/InputFormat.py
@@ -4,7 +4,7 @@ import math
 import InputParameters
 
 
-def func_get_inputs(filename, inParams, τ, A_tol, R_tol, C_tol):
+def func_get_input(filename, inParams, τ, A_tol, R_tol, C_tol):
     lines = []
     linetokens = []
     infile = open(filename, "r")


### PR DESCRIPTION
Fixes #1179. The way we are currently set up, the function in the input format module needs to be called "get_input" because we've hardcoded a call to that function in our generate code for the Control module (ideally, we would be able to read the function name from the module and call it, but that would require some design, since there is currently no way to differentiate the InputFormat module from the other modules). Some of the examples had accidentally called the function "get_inputs" instead, so this changes those to "get_input". 

This also removes a hack where the "get_input" function was hardcoded as an export of "InputFormat". That export is read automatically from the list of modules we pass in, so the hack is not needed.