### PR TITLE
Travis Code Building

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,14 +36,19 @@ addons:
   apt:
     packages:
       - libgmp-dev
+      - python3
+      - graphviz
+# TeX Building
       - fonts-lmodern
       - texlive-bibtex-extra
       - texlive-latex-extra
       - texlive-math-extra
       - texlive-xetex
       - texlive-luatex
-      - python3
-      - graphviz
+# Code Building
+      - g++
+      - default-jdk
+      - mono-devel
 
 before_install:
 # Download and unpack the stack executable
@@ -67,6 +72,8 @@ script:
      ci_fstep "CI: Stable" make stackArgs="--no-terminal" NOISY=yes
  - >-
      ci_fstep "CI: TeX" make tex SUMMARIZE_TEX=yes
+ - >-
+     ci_fstep "CI: Code" make code
  - >-
      ci_fstep "CI: Docs" make docs haddockArgs=\"--no-haddock-deps --no-haddock-hyperlink-source\"
  - python3 scripts/pr_label_update.py

--- a/code/Makefile
+++ b/code/Makefile
@@ -167,7 +167,22 @@ tex: $(TEX_EXAMPLES)
 %$(CODE_E_SUFFIX): EXAMPLE=$(shell echo $* | tr a-z A-Z)
 %$(CODE_E_SUFFIX): EDIR=$($(EXAMPLE)_DIR)
 $(filter %$(CODE_E_SUFFIX), $(CODE_EXAMPLES)): %$(CODE_E_SUFFIX): %$(MOVE_DF_E_SUFFIX)
-	EDIR=$(EDIR) BUILD_FOLDER=$(BUILD_FOLDER) EXAMPLE_CODE_SUBFOLDER=$(EXAMPLE_CODE_SUBFOLDER) MAKE="$(MAKE)" "$(SHELL)" $(SCRIPT_FOLDER)code_build.sh
+	@EDIR=$(EDIR) BUILD_FOLDER=$(BUILD_FOLDER) EXAMPLE_CODE_SUBFOLDER=$(EXAMPLE_CODE_SUBFOLDER) MAKE="$(MAKE)" "$(SHELL)" $(SCRIPT_FOLDER)code_build.sh; \
+	# If you're reading this comment because you got NoPCM working, then you should remove everything below this line until the next target. \
+	# (Next line with zero idents) Additionally you should remove the "; \" from the line immediately preceeding the comment on the previous line. \
+	RET=$$?; \
+	if [ $* = $(NOPCM_EXE) ]; then \
+		if [ $$RET != 0 ]; then \
+			echo "$(NOPCM_DIR) failed to compile as expected. Letting it slide...for now."; \
+			exit 0; \
+		else \
+			echo "$(NOPCM_DIR) surprisingly did not fail to compile!"; \
+			echo "Failing this build because you should check the Drasil makefile and alter the code as indicated by the comment for the currently invoked target"; \
+			exit 1; \
+		fi; \
+	else \
+		exit $$RET; \
+	fi
 
 code: $(CODE_EXAMPLES)
 


### PR DESCRIPTION
This PR changes Travis to use the existing `make code` target to build generated code. I've added an extension to the code building rule which checks for NoPCM and allows failed code to "pass" for that example as there are still a few outstanding issues there for that code gen. 

I've also setup a time-bomb in the sense that when NoPCM does compile, `make code` will fail with the message:
```
NoPCM surprisingly did not fail to compile!
Failing this build because you should check the Drasil makefile and alter the code as indicated by the comment for the currently invoked target.
```
and "fails" the build. This is to ensure that when NoPCM can and does compile that to merge those changes in the `Makefile` NoPCM suppression must be removed. 

Currently to indicate that there is non-standard behaviour in place for NoPCM is the message 
`NoPCM failed to compile as expected. Letting it slide...for now.` when `make code` runs and building NoPCM fails.