### PR TITLE
mkQuantDef preserves stage-dependent symbols

### DIFF
--- a/code/drasil-example/Drasil/SWHS/Unitals.hs
+++ b/code/drasil-example/Drasil/SWHS/Unitals.hs
@@ -2,7 +2,7 @@ module Drasil.SWHS.Unitals where -- all of this file is exported
 
 import Language.Drasil
 import Language.Drasil.ShortHands
-import Theory.Drasil (mkQuantDef, mkQuantDef')
+import Theory.Drasil (mkQuantDef)
 import Utils.Drasil
 
 import Data.Drasil.Concepts.Documentation (simulation)
@@ -477,12 +477,12 @@ tankLengthMax = mkQuantDef (unitary "tankLengthMax"
 fracMinAux    = mkQuantDef fracMin $ dbl 1.0e-6
 
 -- Used in Constraint 5
-pcmDensityMin = mkQuantDef' (unitary' "pcmDensityMin"
+pcmDensityMin = mkQuantDef (unitary' "pcmDensityMin"
   (nounPhraseSP "minimum density of PCM")
   (staged (sup (eqSymb pcmDensity) (Atomic "min")) (sup (codeSymb pcmDensity) 
   (Atomic "min"))) densityU Rational) 500
 
-pcmDensityMax = mkQuantDef' (unitary' "pcmDensityMax"
+pcmDensityMax = mkQuantDef (unitary' "pcmDensityMax"
   (nounPhraseSP "maximum density of PCM")
   (staged (sup (eqSymb pcmDensity) (Atomic "max")) (sup (codeSymb pcmDensity) 
   (Atomic "max"))) densityU Rational) 20000
@@ -520,12 +520,12 @@ coilSAMax = unitary "coilSAMax"
   (sup (eqSymb coilSA) (Atomic "max")) m_2 Rational
 
 -- Used in Constraint 12
-wDensityMin = mkQuantDef' (unitary' "wDensityMin"
+wDensityMin = mkQuantDef (unitary' "wDensityMin"
   (nounPhraseSP "minimum density of water")
   (staged (sup (eqSymb wDensity) (Atomic "min")) (sup (codeSymb wDensity) 
   (Atomic "min"))) densityU Rational) 950
 
-wDensityMax = mkQuantDef' (unitary' "wDensityMax"
+wDensityMax = mkQuantDef (unitary' "wDensityMax"
   (nounPhraseSP "maximum density of water")
   (staged (sup (eqSymb wDensity) (Atomic "max")) (sup (codeSymb wDensity) 
   (Atomic "max"))) densityU Rational) 1000

--- a/code/drasil-theory/Theory/Drasil.hs
+++ b/code/drasil-theory/Theory/Drasil.hs
@@ -1,7 +1,7 @@
 {- re-export many things to simplify external use -}
 module Theory.Drasil (
   -- DataDefinition
-  DataDefinition, mkQuantDef, mkQuantDef', dd, ddNoRefs, qdFromDD
+  DataDefinition, mkQuantDef, dd, ddNoRefs, qdFromDD
   -- GenDefn
   , GenDefn, gd, gdNoRefs
   -- InstanceModel
@@ -12,7 +12,7 @@ module Theory.Drasil (
   , Theory(..), TheoryModel, tm, tmNoRefs
 ) where
 
-import Theory.Drasil.DataDefinition (DataDefinition, mkQuantDef, mkQuantDef',
+import Theory.Drasil.DataDefinition (DataDefinition, mkQuantDef,
   dd, ddNoRefs, qdFromDD)
 import Theory.Drasil.GenDefn
 import Theory.Drasil.InstanceModel

--- a/code/drasil-theory/Theory/Drasil/DataDefinition.hs
+++ b/code/drasil-theory/Theory/Drasil/DataDefinition.hs
@@ -58,11 +58,5 @@ qdFromDD d = d ^. qd
 -- Used to help make Qdefinitions when uid, term, and symbol come from the same source
 mkQuantDef :: (Quantity c, MayHaveUnit c) => c -> Expr -> QDefinition
 mkQuantDef cncpt equation = datadef $ getUnit cncpt
-  where datadef (Just a) = fromEqn  (cncpt ^. uid) (cncpt ^. term) EmptyS (eqSymb cncpt) a equation
-        datadef Nothing  = fromEqn' (cncpt ^. uid) (cncpt ^. term) EmptyS (eqSymb cncpt) equation
-
--- | For when the symbol changes depending on the stage
-mkQuantDef' :: (Quantity c, MayHaveUnit c) => c -> Expr -> QDefinition
-mkQuantDef' cncpt equation = datadef $ getUnit cncpt
   where datadef (Just a) = fromEqnSt  (cncpt ^. uid) (cncpt ^. term) EmptyS (symbol cncpt) a equation
         datadef Nothing  = fromEqnSt' (cncpt ^. uid) (cncpt ^. term) EmptyS (symbol cncpt) equation


### PR DESCRIPTION
This PR replaces the old `mkQuantDef` with a new one which preserves stage-dependent symbols (previously `mkQuantDef'`). This change was discussed in #1468.