### PR TITLE
PR - Rename static and dynamic

### DIFF
--- a/code/drasil-code/Language/Drasil/Code/Imperative/AST.hs
+++ b/code/drasil-code/Language/Drasil/Code/Imperative/AST.hs
@@ -168,7 +168,7 @@ data BaseType = Boolean | Integer | Float | Character | String | FileType Mode
     deriving (Eq, Show)
 data StateType = List Permanence StateType | Base BaseType | Type Label | Iterator StateType | EnumType Label
     deriving (Eq, Show)
-data Permanence = StaticCon | Dynamic
+data Permanence = StaticCon | DynamicCon
     deriving (Eq, Show)
 data MethodType = MState StateType
                 | Void
@@ -218,7 +218,7 @@ infile = Base $ FileType Read
 outfile = Base $ FileType Write
 
 listT :: StateType -> StateType
-listT = List Dynamic
+listT = List DynamicCon
 
 obj :: Label -> StateType
 obj = Type
@@ -277,22 +277,22 @@ privClass :: Label -> Maybe Label -> [StateVar] -> [Method] -> Class
 privClass n p= Class n p Private
 
 privMVar :: Int -> StateType -> Label -> StateVar
-privMVar del t n = StateVar n Private Dynamic t del
+privMVar del t n = StateVar n Private DynamicCon t del
 
 pubMVar :: Int -> StateType -> Label -> StateVar
-pubMVar del t n = StateVar n Public Dynamic t del
+pubMVar del t n = StateVar n Public DynamicCon t del
 
 pubGVar :: Int -> StateType -> Label -> StateVar
 pubGVar del t n = StateVar n Public StaticCon t del
 
 privMethod :: MethodType -> Label -> [Parameter] -> Body -> Method
-privMethod t n = Method n Private Dynamic t
+privMethod t n = Method n Private DynamicCon t
 
 pubMethod :: MethodType -> Label -> [Parameter] -> Body -> Method
-pubMethod t n = Method n Public Dynamic t
+pubMethod t n = Method n Public DynamicCon t
 
 constructor :: Label -> [Parameter] -> Body -> Method
-constructor n = Method n Public Dynamic (Construct n)
+constructor n = Method n Public DynamicCon (Construct n)
 
 mainMethod :: Body -> Method
 mainMethod = MainMethod
@@ -502,7 +502,7 @@ listDec :: Permanence -> Label -> StateType -> Int -> Statement
 listDec lt n t s = DeclState $ ListDec lt n t s
 
 listDec' :: Label -> StateType -> Int -> Statement
-listDec' n t s = DeclState $ ListDec Dynamic n t s
+listDec' n t s = DeclState $ ListDec DynamicCon n t s
 
 listDecValues :: Label -> StateType -> [Value] -> Statement
 listDecValues n t vs = DeclState $ ListDecValues StaticCon n t vs
@@ -758,9 +758,9 @@ convertToClass Enum{} = error "convertToClass: Cannot convert Enum-type Class to
 convertToClass c = c
 
 convertToMethod :: Method -> Method
-convertToMethod (GetMethod n t) = Method (getterName n) Public Dynamic t [] getBody
+convertToMethod (GetMethod n t) = Method (getterName n) Public DynamicCon t [] getBody
     where getBody = oneLiner $ return (Self $-> var n)
-convertToMethod (SetMethod n p@(StateParam pn _)) = Method (setterName n) Public Dynamic Void [p] setBody
+convertToMethod (SetMethod n p@(StateParam pn _)) = Method (setterName n) Public DynamicCon Void [p] setBody
     where setBody = oneLiner $ Self $-> var n &=. pn
 convertToMethod (MainMethod b) = Method "main" Public StaticCon Void [] b
 convertToMethod t = t

--- a/code/drasil-code/Language/Drasil/Code/Imperative/AST.hs
+++ b/code/drasil-code/Language/Drasil/Code/Imperative/AST.hs
@@ -168,7 +168,7 @@ data BaseType = Boolean | Integer | Float | Character | String | FileType Mode
     deriving (Eq, Show)
 data StateType = List Permanence StateType | Base BaseType | Type Label | Iterator StateType | EnumType Label
     deriving (Eq, Show)
-data Permanence = Static | Dynamic
+data Permanence = StaticCon | Dynamic
     deriving (Eq, Show)
 data MethodType = MState StateType
                 | Void
@@ -283,7 +283,7 @@ pubMVar :: Int -> StateType -> Label -> StateVar
 pubMVar del t n = StateVar n Public Dynamic t del
 
 pubGVar :: Int -> StateType -> Label -> StateVar
-pubGVar del t n = StateVar n Public Static t del
+pubGVar del t n = StateVar n Public StaticCon t del
 
 privMethod :: MethodType -> Label -> [Parameter] -> Body -> Method
 privMethod t n = Method n Private Dynamic t
@@ -505,7 +505,7 @@ listDec' :: Label -> StateType -> Int -> Statement
 listDec' n t s = DeclState $ ListDec Dynamic n t s
 
 listDecValues :: Label -> StateType -> [Value] -> Statement
-listDecValues n t vs = DeclState $ ListDecValues Static n t vs
+listDecValues n t vs = DeclState $ ListDecValues StaticCon n t vs
 
 listOf :: Label -> StateType -> Value
 l `listOf` s = ListVar l s
@@ -762,7 +762,7 @@ convertToMethod (GetMethod n t) = Method (getterName n) Public Dynamic t [] getB
     where getBody = oneLiner $ return (Self $-> var n)
 convertToMethod (SetMethod n p@(StateParam pn _)) = Method (setterName n) Public Dynamic Void [p] setBody
     where setBody = oneLiner $ Self $-> var n &=. pn
-convertToMethod (MainMethod b) = Method "main" Public Static Void [] b
+convertToMethod (MainMethod b) = Method "main" Public StaticCon Void [] b
 convertToMethod t = t
 
 -- | Takes a "find" Value (old), a "replace" Value (new),
@@ -897,15 +897,15 @@ addToMethod :: [Method] -> [Method] -> [Method]
 addToMethod f = (++ map fToM f)
 
 fToM :: Method -> Method
-fToM (Method l _ _ t ps b) = Method l Public Static t ps b
+fToM (Method l _ _ t ps b) = Method l Public StaticCon t ps b
 fToM m = m
 
 addToSV :: [Declaration] -> [StateVar] -> [StateVar]
 addToSV d sv = sv ++ map dToSV d
 
 dToSV :: Declaration -> StateVar
-dToSV (VarDec l s) = StateVar l Public Static s 0
-dToSV (VarDecDef l s _) = StateVar l Public Static s 0
-dToSV (ListDec p l s _) = StateVar l Public Static (List p s) 0
-dToSV (ObjDecDef l s _) = StateVar l Public Static s 0
+dToSV (VarDec l s) = StateVar l Public StaticCon s 0
+dToSV (VarDecDef l s _) = StateVar l Public StaticCon s 0
+dToSV (ListDec p l s _) = StateVar l Public StaticCon (List p s) 0
+dToSV (ObjDecDef l s _) = StateVar l Public StaticCon s 0
 dToSV _ = error "Not implemented"

--- a/code/drasil-code/Language/Drasil/Code/Imperative/Import.hs
+++ b/code/drasil-code/Language/Drasil/Code/Imperative/Import.hs
@@ -538,7 +538,7 @@ convType C.Integer = int
 convType C.Float = float
 convType C.Char = char
 convType C.String = string
-convType (C.List t) = getListTypeFunc t dynamic
+convType (C.List t) = getListTypeFunc t dynamicRepr
 convType (C.Object n) = obj n
 convType C.File = error "convType: File ?"
 
@@ -694,7 +694,7 @@ convStmt (FTry t c) = do
   return $ tryCatch (bodyStatements stmt1) (bodyStatements stmt2)
 convStmt FContinue = return continue
 convStmt (FDec v (C.List t)) = return $ listDec (codeName v) 0 
-  (getListTypeFunc t dynamic)
+  (getListTypeFunc t dynamicRepr)
 convStmt (FDec v t) = return $ varDec (codeName v) (convType t)
 convStmt (FProcCall n l) = do
   e' <- convExpr (FCall (asExpr n) l)
@@ -725,8 +725,8 @@ genDataFunc nameTitle ddef = do
       return [block $ [
       varDec l_infile infile,
       varDec l_line string,
-      listDec l_lines 0 (listType dynamic string),
-      listDec l_linetokens 0 (listType dynamic string),
+      listDec l_lines 0 (listType dynamicRepr string),
+      listDec l_linetokens 0 (listType dynamicRepr string),
       openFileR v_infile v_filename ] ++
       concat inD ++ [
       closeFile v_infile ]]

--- a/code/drasil-code/Language/Drasil/Code/Imperative/Import.hs
+++ b/code/drasil-code/Language/Drasil/Code/Imperative/Import.hs
@@ -107,7 +107,7 @@ publicMethod :: (RenderSym repr) => repr (MethodType repr) -> Label -> [repr
   [repr (Block repr)] -> Reader (State repr) (repr (Method repr))
 publicMethod mt l pl st v u = do
   g <- ask
-  genMethodCall public static (commented g) (logKind g) mt l pl st v u
+  genMethodCall public staticRepr (commented g) (logKind g) mt l pl st v u
 
 generateCode :: (PackageSym repr) => Lang -> [repr (Package repr) -> 
   ([ModData], Label)] -> State repr -> IO ()

--- a/code/drasil-code/Language/Drasil/Code/Imperative/LanguageRenderer.hs
+++ b/code/drasil-code/Language/Drasil/Code/Imperative/LanguageRenderer.hs
@@ -423,7 +423,7 @@ patternDocD c (Strategy (RunStrategy n (Strats strats r) v)) =
     where resultState = case v of Nothing    -> empty
                                   Just vari  -> case r of Nothing  -> error $ "Strategy '" ++ n ++ "': Attempt to assign null return to a Value."
                                                           Just res -> assignDoc c $ Assign vari res
-patternDocD c (Observer (InitObserverList t os)) = declarationDoc c $ ListDecValues Dynamic observerListName t os
+patternDocD c (Observer (InitObserverList t os)) = declarationDoc c $ ListDecValues DynamicCon observerListName t os
 patternDocD c (Observer (AddObserver t o)) = valueDoc c $ obsList $. ListAdd last o
     where obsList = observerListName `listOf` t
           last = obsList $. ListSize
@@ -458,7 +458,7 @@ scopeDocD Public = text "public"
 
 permanence :: Permanence -> Doc
 permanence StaticCon = text "static"
-permanence Dynamic = empty
+permanence DynamicCon = empty
 
 stateDocD :: Config -> StateVar -> Doc
 stateDocD c (StateVar n s p t _) = includeScope c s <+> permanence p <+> stateType c t Dec <+> text n <> endStatement c
@@ -514,7 +514,7 @@ methodDocD c _ _ (Method n s p t ps b) = vcat [
     scopeDoc c s <+> perm p <> methodTypeDoc c t <+> text n <> parens (paramListDoc c ps) <+> lbrace,
     oneTab $ bodyDoc c b,
     rbrace]
-  where perm Dynamic = empty
+  where perm DynamicCon = empty
         perm StaticCon  = text "static "
 methodDocD c _ _ (MainMethod b) = vcat [
     scopeDoc c Public <+> text "static" <+> methodTypeDoc c Void <+> text "Main" <> parens (text "string[] args") <+> lbrace,
@@ -604,7 +604,7 @@ complexDocD _ _ = error "No default implementation for ComplexState"
 
 addDefaultCtor :: Config -> Label -> Label -> [Method] -> [Method]
 addDefaultCtor _ modName ctorName fs =
-    case find ctor fs of Nothing   -> Method ctorName Public Dynamic (Construct modName) [] [] : fs
+    case find ctor fs of Nothing   -> Method ctorName Public DynamicCon (Construct modName) [] [] : fs
                          _ -> fs
     where ctor (Method _ _ _ (Construct _) _ _) = True
           ctor _ = False

--- a/code/drasil-code/Language/Drasil/Code/Imperative/LanguageRenderer.hs
+++ b/code/drasil-code/Language/Drasil/Code/Imperative/LanguageRenderer.hs
@@ -457,7 +457,7 @@ scopeDocD Private = text "private"
 scopeDocD Public = text "public"
 
 permanence :: Permanence -> Doc
-permanence Static = text "static"
+permanence StaticCon = text "static"
 permanence Dynamic = empty
 
 stateDocD :: Config -> StateVar -> Doc
@@ -515,7 +515,7 @@ methodDocD c _ _ (Method n s p t ps b) = vcat [
     oneTab $ bodyDoc c b,
     rbrace]
   where perm Dynamic = empty
-        perm Static  = text "static "
+        perm StaticCon  = text "static "
 methodDocD c _ _ (MainMethod b) = vcat [
     scopeDoc c Public <+> text "static" <+> methodTypeDoc c Void <+> text "Main" <> parens (text "string[] args") <+> lbrace,
     oneTab $ bodyDoc c b,

--- a/code/drasil-code/Language/Drasil/Code/Imperative/LanguageRenderer/GOOLRenderer.hs
+++ b/code/drasil-code/Language/Drasil/Code/Imperative/LanguageRenderer/GOOLRenderer.hs
@@ -55,7 +55,7 @@ goolConfig options c =
         inputFunc        = text "Input",
         iterForEachLabel = text "ForEach",
         iterInLabel      = empty,
-        list             = \case Static  -> text "List Static"
+        list             = \case StaticCon  -> text "List Static"
                                  Dynamic -> text "List Dynamic",
         listObj          = empty,
         clsDec           = empty,
@@ -172,7 +172,7 @@ conditionalDoc' c (Switch v cs b) = text "switch" <+> parens (valueDoc c v) <+> 
 declarationDoc' :: Config -> Declaration -> Doc
 declarationDoc' c (VarDec n t) = text "varDec" <+> lbl n <+> stateType c t Dec
 declarationDoc' c (ListDec lt n t s) = text "listDec" <+> listTypeDoc lt <+> lbl n <+> stateType c t Dec <+> int s
-declarationDoc' c (ListDecValues Static n t vs) = text "listDecValues" <+> lbl n <+> stateType c t Dec <+> hsList (valueDoc c) vs
+declarationDoc' c (ListDecValues StaticCon n t vs) = text "listDecValues" <+> lbl n <+> stateType c t Dec <+> hsList (valueDoc c) vs
 declarationDoc' c (ListDecValues lt n t vs) = text "DeclState $ ListDecValues" <+> listTypeDoc lt <+> lbl n <+> stateType c t Dec <+> hsList (valueDoc c) vs
 declarationDoc' c (VarDecDef n t v) = text "varDecDef" <+> lbl n <+> stateType c t Dec <+> valueDoc c v
 declarationDoc' c (ObjDecDef n t v) = text "objDecDef" <+> lbl n <+> stateType c t Dec <+> valueDoc c v
@@ -225,7 +225,7 @@ iterationDoc' c (While v b) = vcat [
 iterationDoc' c i = iterationDocD c i
 
 listTypeDoc :: Permanence -> Doc
-listTypeDoc Static = text "Static"
+listTypeDoc StaticCon = text "Static"
 listTypeDoc Dynamic = text "Dynamic"
 
 litDoc' :: Literal -> Doc
@@ -317,9 +317,9 @@ scopeDoc' Public = text "Public"
 stateDoc' :: Config -> StateVar -> Doc
 stateDoc' c (StateVar n s p t del) = text v <+> delp <+> stateType c t Dec <+> lbl n
     where v = case (s,p) of (Public, Dynamic) -> "pubMVar"
-                            (Public, Static)  -> "pubGVar"
+                            (Public, StaticCon)  -> "pubGVar"
                             (Private, Dynamic) -> "privMVar"
-                            (Private, Static) -> "privGVar"
+                            (Private, StaticCon) -> "privGVar"
           delp | del == alwaysDel = text "alwaysDel"
                | del == neverDel = text "neverDel"
                | otherwise = int del

--- a/code/drasil-code/Language/Drasil/Code/Imperative/LanguageRenderer/GOOLRenderer.hs
+++ b/code/drasil-code/Language/Drasil/Code/Imperative/LanguageRenderer/GOOLRenderer.hs
@@ -56,7 +56,7 @@ goolConfig options c =
         iterForEachLabel = text "ForEach",
         iterInLabel      = empty,
         list             = \case StaticCon  -> text "List Static"
-                                 Dynamic -> text "List Dynamic",
+                                 DynamicCon -> text "List Dynamic",
         listObj          = empty,
         clsDec           = empty,
         package          = \p -> vcat [
@@ -226,7 +226,7 @@ iterationDoc' c i = iterationDocD c i
 
 listTypeDoc :: Permanence -> Doc
 listTypeDoc StaticCon = text "Static"
-listTypeDoc Dynamic = text "Dynamic"
+listTypeDoc DynamicCon = text "Dynamic"
 
 litDoc' :: Literal -> Doc
 litDoc' = parens . litDoc''
@@ -316,9 +316,9 @@ scopeDoc' Public = text "Public"
 
 stateDoc' :: Config -> StateVar -> Doc
 stateDoc' c (StateVar n s p t del) = text v <+> delp <+> stateType c t Dec <+> lbl n
-    where v = case (s,p) of (Public, Dynamic) -> "pubMVar"
+    where v = case (s,p) of (Public, DynamicCon) -> "pubMVar"
                             (Public, StaticCon)  -> "pubGVar"
-                            (Private, Dynamic) -> "privMVar"
+                            (Private, DynamicCon) -> "privMVar"
                             (Private, StaticCon) -> "privGVar"
           delp | del == alwaysDel = text "alwaysDel"
                | del == neverDel = text "neverDel"

--- a/code/drasil-code/Language/Drasil/Code/Imperative/LanguageRenderer/JavaRenderer.hs
+++ b/code/drasil-code/Language/Drasil/Code/Imperative/LanguageRenderer/JavaRenderer.hs
@@ -195,7 +195,7 @@ methodDoc' c _ _ (Method n s p t ps b) = vcat [
     oneTab $ bodyDoc c b,  -- all methods throw exception for now,  FIX ME.
     rbrace]
   where perm Dynamic = empty
-        perm Static  = text "static "
+        perm StaticCon  = text "static "
         --throwState False = empty
         --throwState True  = text " throws Exception"
 methodDoc' c _ _ (MainMethod b) = vcat [

--- a/code/drasil-code/Language/Drasil/Code/Imperative/LanguageRenderer/JavaRenderer.hs
+++ b/code/drasil-code/Language/Drasil/Code/Imperative/LanguageRenderer/JavaRenderer.hs
@@ -124,7 +124,7 @@ jtop c _ p _ = vcat [
     include c "java.util.Scanner" <> endStatement c,
     include c "java.io.PrintWriter" <> endStatement c,
     include c "java.io.File" <> endStatement c,
-    include c ("java.util." ++ render (list c Dynamic)) <> endStatement c
+    include c ("java.util." ++ render (list c DynamicCon)) <> endStatement c
     ]
 
 jbody :: Config -> a -> Label -> Module -> Doc
@@ -194,7 +194,7 @@ methodDoc' c _ _ (Method n s p t ps b) = vcat [
     scopeDoc c s <+> perm p <> methodTypeDoc c t <+> text n <> parens (paramListDoc c ps) <+> text "throws Exception" <+> lbrace,
     oneTab $ bodyDoc c b,  -- all methods throw exception for now,  FIX ME.
     rbrace]
-  where perm Dynamic = empty
+  where perm DynamicCon = empty
         perm StaticCon  = text "static "
         --throwState False = empty
         --throwState True  = text " throws Exception"
@@ -257,7 +257,7 @@ complexDoc' c (ListSlice st vnew vold b e s) = let l_temp = "temp"
          getS Nothing v = (&++) v
          getS (Just n) v = v &+= n
 complexDoc' c (StringSplit vnew s d) = valueDoc c vnew <+> equals <+> new 
-  <+> stateType c (List Dynamic string) Dec <> parens (funcAppDoc c "Arrays.asList" [s $. Func "split" [litString [d]]]) 
+  <+> stateType c (List DynamicCon string) Dec <> parens (funcAppDoc c "Arrays.asList" [s $. Func "split" [litString [d]]]) 
   <> semi
 
 --helpers

--- a/code/drasil-code/Language/Drasil/Code/Imperative/LanguageRenderer/NewCSharpRenderer.hs
+++ b/code/drasil-code/Language/Drasil/Code/Imperative/LanguageRenderer/NewCSharpRenderer.hs
@@ -102,7 +102,7 @@ instance KeywordSym CSharpCode where
 
 instance PermanenceSym CSharpCode where
   type Permanence CSharpCode = Doc
-  static = return staticDocD
+  staticRepr = return staticDocD
   dynamic = return dynamicDocD
 
 instance BodySym CSharpCode where
@@ -310,7 +310,7 @@ instance FunctionSym CSharpCode where
   type Function CSharpCode = Doc
   func l vs = fmap funcDocD (funcApp l vs)
   cast targT _ = fmap castDocD targT
-  castListToInt = cast (listType static int) int
+  castListToInt = cast (listType staticRepr int) int
   get n = fmap funcDocD (funcApp (getterName n) [])
   set n v = fmap funcDocD (funcApp (setterName n) [v])
 
@@ -518,7 +518,7 @@ instance MethodSym CSharpCode where
   setMethod setLbl c paramLbl t = method (setterName setLbl) c public dynamic 
     void [stateParam paramLbl t] setBody
     where setBody = oneLiner $ (self $-> var setLbl) &=. paramLbl
-  mainMethod c b = setMain <$> method "Main" c public static void 
+  mainMethod c b = setMain <$> method "Main" c public staticRepr void 
     [return $ text "string[] args"] b
   privMethod n c = method n c private dynamic
   pubMethod n c = method n c public dynamic
@@ -532,7 +532,7 @@ instance StateVarSym CSharpCode where
   stateVar _ l s p t = liftA4 (stateVarDocD l) (includeScope s) p t endStatement
   privMVar del l = stateVar del l private dynamic
   pubMVar del l = stateVar del l public dynamic
-  pubGVar del l = stateVar del l public static
+  pubGVar del l = stateVar del l public staticRepr
   listStateVar = stateVar
 
 instance ClassSym CSharpCode where
@@ -551,7 +551,7 @@ instance ModuleSym CSharpCode where
   type Module CSharpCode = ModData
   buildModule n _ vs ms cs = fmap (md n (any (snd . unCSC) ms || 
     any (snd . unCSC) cs)) (liftList moduleDocD (if null vs && null ms then cs 
-    else pubClass n Nothing (map (liftA4 statementsToStateVars public static 
+    else pubClass n Nothing (map (liftA4 statementsToStateVars public staticRepr 
     endStatement) vs) ms : cs))
 
 cstop :: Doc -> Doc -> Doc

--- a/code/drasil-code/Language/Drasil/Code/Imperative/LanguageRenderer/NewCSharpRenderer.hs
+++ b/code/drasil-code/Language/Drasil/Code/Imperative/LanguageRenderer/NewCSharpRenderer.hs
@@ -103,7 +103,7 @@ instance KeywordSym CSharpCode where
 instance PermanenceSym CSharpCode where
   type Permanence CSharpCode = Doc
   staticRepr = return staticDocD
-  dynamic = return dynamicDocD
+  dynamicRepr = return dynamicDocD
 
 instance BodySym CSharpCode where
   type Body CSharpCode = Doc
@@ -129,7 +129,7 @@ instance StateTypeSym CSharpCode where
   listType p st = liftA2 listTypeDocD st (list p)
   intListType p = listType p int
   floatListType p = listType p float
-  boolListType = listType dynamic bool
+  boolListType = listType dynamicRepr bool
   obj t = return $ typeDocD t
   enumType t = return $ typeDocD t
   iterator _ = error "Iterator-type variables do not exist in C#"
@@ -429,7 +429,7 @@ instance StatementSym CSharpCode where
 
   getFileInputLine = getStringFileInput
   discardFileLine f = valState $ fmap csFileInput f
-  stringSplit d vnew s = assign vnew $ listStateObj (listType dynamic string) 
+  stringSplit d vnew s = assign vnew $ listStateObj (listType dynamicRepr string) 
     [s $. func "Split" [litChar d]]
 
   break = return (mkSt breakDocD)
@@ -513,16 +513,16 @@ instance MethodSym CSharpCode where
   type Method CSharpCode = (Doc, Bool)
   method n _ s p t ps b = liftPairFst (liftA5 (methodDocD n) s p t 
     (liftList paramListDocD ps) b, False)
-  getMethod n c t = method (getterName n) c public dynamic t [] getBody
+  getMethod n c t = method (getterName n) c public dynamicRepr t [] getBody
     where getBody = oneLiner $ returnState (self $-> var n)
-  setMethod setLbl c paramLbl t = method (setterName setLbl) c public dynamic 
+  setMethod setLbl c paramLbl t = method (setterName setLbl) c public dynamicRepr 
     void [stateParam paramLbl t] setBody
     where setBody = oneLiner $ (self $-> var setLbl) &=. paramLbl
   mainMethod c b = setMain <$> method "Main" c public staticRepr void 
     [return $ text "string[] args"] b
-  privMethod n c = method n c private dynamic
-  pubMethod n c = method n c public dynamic
-  constructor n = method n n public dynamic (construct n)
+  privMethod n c = method n c private dynamicRepr
+  pubMethod n c = method n c public dynamicRepr
+  constructor n = method n n public dynamicRepr (construct n)
   destructor _ _ = error "Destructors not allowed in C#"
 
   function n = method n ""
@@ -530,8 +530,8 @@ instance MethodSym CSharpCode where
 instance StateVarSym CSharpCode where
   type StateVar CSharpCode = Doc
   stateVar _ l s p t = liftA4 (stateVarDocD l) (includeScope s) p t endStatement
-  privMVar del l = stateVar del l private dynamic
-  pubMVar del l = stateVar del l public dynamic
+  privMVar del l = stateVar del l private dynamicRepr
+  pubMVar del l = stateVar del l public dynamicRepr
   pubGVar del l = stateVar del l public staticRepr
   listStateVar = stateVar
 

--- a/code/drasil-code/Language/Drasil/Code/Imperative/LanguageRenderer/NewCppRenderer.hs
+++ b/code/drasil-code/Language/Drasil/Code/Imperative/LanguageRenderer/NewCppRenderer.hs
@@ -102,7 +102,7 @@ instance (Pair p) => KeywordSym (p CppSrcCode CppHdrCode) where
 instance (Pair p) => PermanenceSym (p CppSrcCode CppHdrCode) where
   type Permanence (p CppSrcCode CppHdrCode) = Doc
   staticRepr = pair staticRepr staticRepr
-  dynamic = pair dynamic dynamic
+  dynamicRepr = pair dynamicRepr dynamicRepr
 
 instance (Pair p) => BodySym (p CppSrcCode CppHdrCode) where
   type Body (p CppSrcCode CppHdrCode) = Doc
@@ -589,7 +589,7 @@ instance RenderSym CppSrcCode where
   type RenderFile CppSrcCode = ModData
   fileDoc code = liftA3 md (fmap name code) (fmap isMainMod code)
     (liftA3 fileDoc' (top code) (fmap modDoc code) bottom)
-  top m = liftA3 cppstop m (list dynamic) endStatement
+  top m = liftA3 cppstop m (list dynamicRepr) endStatement
   bottom = return empty
 
 instance KeywordSym CppSrcCode where
@@ -622,7 +622,7 @@ instance KeywordSym CppSrcCode where
 instance PermanenceSym CppSrcCode where
   type Permanence CppSrcCode = Doc
   staticRepr = return staticDocD
-  dynamic = return dynamicDocD
+  dynamicRepr = return dynamicDocD
 
 instance BodySym CppSrcCode where
   type Body CppSrcCode = Doc
@@ -648,10 +648,10 @@ instance StateTypeSym CppSrcCode where
   listType p st = liftA2 listTypeDocD st (list p)
   intListType p = listType p int
   floatListType p = listType p float
-  boolListType = listType dynamic bool
+  boolListType = listType dynamicRepr bool
   obj t = return $ typeDocD t
   enumType t = return $ typeDocD t
-  iterator t = fmap cppIterTypeDoc (listType dynamic t)
+  iterator t = fmap cppIterTypeDoc (listType dynamicRepr t)
 
 instance ControlBlockSym CppSrcCode where
   runStrategy l strats rv av = maybe
@@ -1046,16 +1046,16 @@ instance MethodSym CppSrcCode where
   type Method CppSrcCode = MethodData
   method n c s _ t ps b = liftA2 (mthd False) (fmap snd s) (liftA5 
     (cppsMethod n c) t (liftList paramListDocD ps) b blockStart blockEnd)
-  getMethod n c t = method (getterName n) c public dynamic t [] getBody
+  getMethod n c t = method (getterName n) c public dynamicRepr t [] getBody
     where getBody = oneLiner $ returnState (self $-> var n)
-  setMethod setLbl c paramLbl t = method (setterName setLbl) c public dynamic 
+  setMethod setLbl c paramLbl t = method (setterName setLbl) c public dynamicRepr 
     void [stateParam paramLbl t] setBody
     where setBody = oneLiner $ (self $-> var setLbl) &=. paramLbl
   mainMethod _ b = fmap (mthd True Pub) (liftA4 cppMainMethod int b blockStart 
     blockEnd)
-  privMethod n c = method n c private dynamic
-  pubMethod n c = method n c public dynamic
-  constructor n = method n n public dynamic (construct n)
+  privMethod n c = method n c private dynamicRepr
+  pubMethod n c = method n c public dynamicRepr
+  constructor n = method n n public dynamicRepr (construct n)
   destructor n vs = 
     let i = "i"
         deleteStatements = map (fmap destructSts) vs
@@ -1072,8 +1072,8 @@ instance StateVarSym CppSrcCode where
   stateVar del l s p t = liftA3 svd (fmap snd s) (liftA4 (stateVarDocD l) 
     (fst <$> includeScope s) p t endStatement) (if del < alwaysDel then
     return (mkStNoEnd empty) else free $ var l)
-  privMVar del l = stateVar del l private dynamic
-  pubMVar del l = stateVar del l public dynamic
+  privMVar del l = stateVar del l private dynamicRepr
+  pubMVar del l = stateVar del l public dynamicRepr
   pubGVar del l = stateVar del l public staticRepr
   listStateVar del l s p t = 
     let i = "i"
@@ -1135,7 +1135,7 @@ instance RenderSym CppHdrCode where
   fileDoc code = liftA3 md (fmap name code) (fmap isMainMod code) 
     (if isEmpty (modDoc (unCPPHC code)) then return empty else 
     liftA3 fileDoc' (top code) (fmap modDoc code) bottom)
-  top m = liftA3 cpphtop m (list dynamic) endStatement
+  top m = liftA3 cpphtop m (list dynamicRepr) endStatement
   bottom = return $ text "#endif"
 
 instance KeywordSym CppHdrCode where
@@ -1168,7 +1168,7 @@ instance KeywordSym CppHdrCode where
 instance PermanenceSym CppHdrCode where
   type Permanence CppHdrCode = Doc
   staticRepr = return staticDocD
-  dynamic = return dynamicDocD
+  dynamicRepr = return dynamicDocD
 
 instance BodySym CppHdrCode where
   type Body CppHdrCode = Doc
@@ -1194,10 +1194,10 @@ instance StateTypeSym CppHdrCode where
   listType p st = liftA2 listTypeDocD st (list p)
   intListType p = listType p int
   floatListType p = listType p float
-  boolListType = listType dynamic bool
+  boolListType = listType dynamicRepr bool
   obj t = return $ typeDocD t
   enumType t = return $ typeDocD t
-  iterator t = fmap cppIterTypeDoc (listType dynamic t)
+  iterator t = fmap cppIterTypeDoc (listType dynamicRepr t)
 
 instance ControlBlockSym CppHdrCode where
   runStrategy _ _ _ _ = return empty
@@ -1514,13 +1514,13 @@ instance MethodSym CppHdrCode where
   type Method CppHdrCode = MethodData
   method n _ s _ t ps _ = liftA2 (mthd False) (fmap snd s) 
     (liftA3 (cpphMethod n) t (liftList paramListDocD ps) endStatement)
-  getMethod n c t = method (getterName n) c public dynamic t [] (return empty)
-  setMethod setLbl c paramLbl t = method (setterName setLbl) c public dynamic 
+  getMethod n c t = method (getterName n) c public dynamicRepr t [] (return empty)
+  setMethod setLbl c paramLbl t = method (setterName setLbl) c public dynamicRepr 
     void [stateParam paramLbl t] (return empty)
   mainMethod _ _ = return (mthd True Pub empty)
-  privMethod n c = method n c private dynamic
-  pubMethod n c = method n c public dynamic
-  constructor n = method n n public dynamic (construct n)
+  privMethod n c = method n c private dynamicRepr
+  pubMethod n c = method n c public dynamicRepr
+  constructor n = method n n public dynamicRepr (construct n)
   destructor n _ = pubMethod ('~':n) n void [] (return empty)
 
   function n = method n ""
@@ -1529,8 +1529,8 @@ instance StateVarSym CppHdrCode where
   type StateVar CppHdrCode = StateVarData
   stateVar _ l s p t = liftA3 svd (fmap snd s) (liftA4 (stateVarDocD l) 
     (fmap fst (includeScope s)) p t endStatement) (return (mkStNoEnd empty))
-  privMVar del l = stateVar del l private dynamic
-  pubMVar del l = stateVar del l public dynamic
+  privMVar del l = stateVar del l private dynamicRepr
+  pubMVar del l = stateVar del l public dynamicRepr
   pubGVar del l = stateVar del l public staticRepr
   listStateVar = stateVar
 

--- a/code/drasil-code/Language/Drasil/Code/Imperative/LanguageRenderer/NewCppRenderer.hs
+++ b/code/drasil-code/Language/Drasil/Code/Imperative/LanguageRenderer/NewCppRenderer.hs
@@ -101,7 +101,7 @@ instance (Pair p) => KeywordSym (p CppSrcCode CppHdrCode) where
 
 instance (Pair p) => PermanenceSym (p CppSrcCode CppHdrCode) where
   type Permanence (p CppSrcCode CppHdrCode) = Doc
-  static = pair static static
+  staticRepr = pair staticRepr staticRepr
   dynamic = pair dynamic dynamic
 
 instance (Pair p) => BodySym (p CppSrcCode CppHdrCode) where
@@ -621,7 +621,7 @@ instance KeywordSym CppSrcCode where
 
 instance PermanenceSym CppSrcCode where
   type Permanence CppSrcCode = Doc
-  static = return staticDocD
+  staticRepr = return staticDocD
   dynamic = return dynamicDocD
 
 instance BodySym CppSrcCode where
@@ -827,7 +827,7 @@ instance FunctionSym CppSrcCode where
   type Function CppSrcCode = Doc
   func l vs = fmap funcDocD (funcApp l vs)
   cast targT _ = fmap castDocD targT
-  castListToInt = cast (listType static int) int
+  castListToInt = cast (listType staticRepr int) int
   get n = fmap funcDocD (funcApp (getterName n) [])
   set n v = fmap funcDocD (funcApp (setterName n) [v])
 
@@ -1074,7 +1074,7 @@ instance StateVarSym CppSrcCode where
     return (mkStNoEnd empty) else free $ var l)
   privMVar del l = stateVar del l private dynamic
   pubMVar del l = stateVar del l public dynamic
-  pubGVar del l = stateVar del l public static
+  pubGVar del l = stateVar del l public staticRepr
   listStateVar del l s p t = 
     let i = "i"
         guard = var i ?< (var l $. listSize)
@@ -1167,7 +1167,7 @@ instance KeywordSym CppHdrCode where
 
 instance PermanenceSym CppHdrCode where
   type Permanence CppHdrCode = Doc
-  static = return staticDocD
+  staticRepr = return staticDocD
   dynamic = return dynamicDocD
 
 instance BodySym CppHdrCode where
@@ -1531,7 +1531,7 @@ instance StateVarSym CppHdrCode where
     (fmap fst (includeScope s)) p t endStatement) (return (mkStNoEnd empty))
   privMVar del l = stateVar del l private dynamic
   pubMVar del l = stateVar del l public dynamic
-  pubGVar del l = stateVar del l public static
+  pubGVar del l = stateVar del l public staticRepr
   listStateVar = stateVar
 
 instance ClassSym CppHdrCode where

--- a/code/drasil-code/Language/Drasil/Code/Imperative/LanguageRenderer/NewJavaRenderer.hs
+++ b/code/drasil-code/Language/Drasil/Code/Imperative/LanguageRenderer/NewJavaRenderer.hs
@@ -108,7 +108,7 @@ instance KeywordSym JavaCode where
 instance PermanenceSym JavaCode where
   type Permanence JavaCode = Doc
   staticRepr = return staticDocD
-  dynamic = return dynamicDocD
+  dynamicRepr = return dynamicDocD
 
 instance BodySym JavaCode where
   type Body JavaCode = Doc
@@ -134,7 +134,7 @@ instance StateTypeSym JavaCode where
   listType p st = liftA2 listTypeDocD st (list p)
   intListType p = fmap jIntListTypeDoc (list p)
   floatListType p = fmap jFloatListTypeDoc (list p)
-  boolListType = listType dynamic bool
+  boolListType = listType dynamicRepr bool
   obj t = return $ typeDocD t
   enumType t = return $ typeDocD t
   iterator _ = error "Iterator-type variables do not exist in Java"
@@ -441,7 +441,7 @@ instance StatementSym JavaCode where
   getFileInputLine f v = v &= f $. func "nextLine" []
   discardFileLine f = valState $ f $. func "nextLine" []
   stringSplit d vnew s = mkSt <$> liftA3 jStringSplit vnew 
-    (listType dynamic string) 
+    (listType dynamicRepr string) 
     (funcApp "Arrays.asList" [s $. func "split" [litString [d]]])
 
   break = return (mkSt breakDocD)  -- I could have a JumpSym class with functions for "return $ text "break" and then reference those functions here?
@@ -525,16 +525,16 @@ instance MethodSym JavaCode where
   type Method JavaCode = (Doc, Bool)
   method n _ s p t ps b = liftPairFst (liftA5 (jMethod n) s p t (liftList 
     paramListDocD ps) b, False)
-  getMethod n c t = method (getterName n) c public dynamic t [] getBody
+  getMethod n c t = method (getterName n) c public dynamicRepr t [] getBody
     where getBody = oneLiner $ returnState (self $-> var n)
-  setMethod setLbl c paramLbl t = method (setterName setLbl) c public dynamic 
+  setMethod setLbl c paramLbl t = method (setterName setLbl) c public dynamicRepr 
     void [stateParam paramLbl t] setBody
     where setBody = oneLiner $ (self $-> var setLbl) &=. paramLbl
   mainMethod c b = setMain <$> method "main" c public staticRepr void 
     [return $ text "String[] args"] b
-  privMethod n c = method n c private dynamic
-  pubMethod n c = method n c public dynamic
-  constructor n = method n n public dynamic (construct n)
+  privMethod n c = method n c private dynamicRepr
+  pubMethod n c = method n c public dynamicRepr
+  constructor n = method n n public dynamicRepr (construct n)
   destructor _ _ = error "Destructors not allowed in Java"
 
   function n = method n ""
@@ -542,8 +542,8 @@ instance MethodSym JavaCode where
 instance StateVarSym JavaCode where
   type StateVar JavaCode = Doc
   stateVar _ l s p t = liftA4 (stateVarDocD l) (includeScope s) p t endStatement
-  privMVar del l = stateVar del l private dynamic
-  pubMVar del l = stateVar del l public dynamic
+  privMVar del l = stateVar del l private dynamicRepr
+  pubMVar del l = stateVar del l public dynamicRepr
   pubGVar del l = stateVar del l public staticRepr
   listStateVar = stateVar
 

--- a/code/drasil-code/Language/Drasil/Code/Imperative/LanguageRenderer/NewJavaRenderer.hs
+++ b/code/drasil-code/Language/Drasil/Code/Imperative/LanguageRenderer/NewJavaRenderer.hs
@@ -75,7 +75,7 @@ instance RenderSym JavaCode where
   type RenderFile JavaCode = ModData
   fileDoc code = liftA3 md (fmap name code) (fmap isMainMod code) 
     (liftA3 fileDoc' (top code) (fmap modDoc code) bottom)
-  top _ = liftA3 jtop endStatement (include "") (list static)
+  top _ = liftA3 jtop endStatement (include "") (list staticRepr)
   bottom = return empty
 
 instance KeywordSym JavaCode where
@@ -107,7 +107,7 @@ instance KeywordSym JavaCode where
 
 instance PermanenceSym JavaCode where
   type Permanence JavaCode = Doc
-  static = return staticDocD
+  staticRepr = return staticDocD
   dynamic = return dynamicDocD
 
 instance BodySym JavaCode where
@@ -530,7 +530,7 @@ instance MethodSym JavaCode where
   setMethod setLbl c paramLbl t = method (setterName setLbl) c public dynamic 
     void [stateParam paramLbl t] setBody
     where setBody = oneLiner $ (self $-> var setLbl) &=. paramLbl
-  mainMethod c b = setMain <$> method "main" c public static void 
+  mainMethod c b = setMain <$> method "main" c public staticRepr void 
     [return $ text "String[] args"] b
   privMethod n c = method n c private dynamic
   pubMethod n c = method n c public dynamic
@@ -544,7 +544,7 @@ instance StateVarSym JavaCode where
   stateVar _ l s p t = liftA4 (stateVarDocD l) (includeScope s) p t endStatement
   privMVar del l = stateVar del l private dynamic
   pubMVar del l = stateVar del l public dynamic
-  pubGVar del l = stateVar del l public static
+  pubGVar del l = stateVar del l public staticRepr
   listStateVar = stateVar
 
 instance ClassSym JavaCode where
@@ -563,7 +563,7 @@ instance ModuleSym JavaCode where
   type Module JavaCode = ModData
   buildModule n _ vs ms cs = fmap (md n (any (snd . unJC) ms || 
     any (snd . unJC) cs)) (liftList moduleDocD (if null vs && null ms then cs 
-    else pubClass n Nothing (map (liftA4 statementsToStateVars public static
+    else pubClass n Nothing (map (liftA4 statementsToStateVars public staticRepr
     endStatement) vs) ms : cs))
 
 enumsEqualInts :: Bool

--- a/code/drasil-code/Language/Drasil/Code/Imperative/LanguageRenderer/NewPythonRenderer.hs
+++ b/code/drasil-code/Language/Drasil/Code/Imperative/LanguageRenderer/NewPythonRenderer.hs
@@ -93,7 +93,7 @@ instance KeywordSym PythonCode where
 
 instance PermanenceSym PythonCode where
   type Permanence PythonCode = Doc
-  static = return staticDocD
+  staticRepr = return staticDocD
   dynamic = return dynamicDocD
 
 instance BodySym PythonCode where
@@ -291,7 +291,7 @@ instance FunctionSym PythonCode where
   type Function PythonCode = Doc
   func l vs = fmap funcDocD (funcApp l vs)
   cast targT _ = targT
-  castListToInt = cast int (listType static int)
+  castListToInt = cast int (listType staticRepr int)
   get n = fmap funcDocD (var n)
   set n v = fmap funcDocD (mkVal . fst <$> assign (var n) v)
 
@@ -341,7 +341,7 @@ instance StatementSym PythonCode where
 
   varDec _ _ = return (mkStNoEnd empty)
   varDecDef l _ v = mkStNoEnd <$> fmap (pyVarDecDef l) v
-  listDec l _ t = mkStNoEnd <$> fmap (pyListDec l) (listType static t)
+  listDec l _ t = mkStNoEnd <$> fmap (pyListDec l) (listType staticRepr t)
   listDecDef l _ vs = mkStNoEnd <$> fmap (pyListDecDef l) (liftList 
     callFuncParamList vs)
   objDecDef = varDecDef
@@ -493,7 +493,7 @@ instance StateVarSym PythonCode where
   stateVar _ _ _ _ _ = return empty
   privMVar del l = stateVar del l private dynamic
   pubMVar del l = stateVar del l public dynamic
-  pubGVar del l = stateVar del l public static
+  pubGVar del l = stateVar del l public staticRepr
   listStateVar = stateVar
 
 instance ClassSym PythonCode where

--- a/code/drasil-code/Language/Drasil/Code/Imperative/LanguageRenderer/NewPythonRenderer.hs
+++ b/code/drasil-code/Language/Drasil/Code/Imperative/LanguageRenderer/NewPythonRenderer.hs
@@ -94,7 +94,7 @@ instance KeywordSym PythonCode where
 instance PermanenceSym PythonCode where
   type Permanence PythonCode = Doc
   staticRepr = return staticDocD
-  dynamic = return dynamicDocD
+  dynamicRepr = return dynamicDocD
 
 instance BodySym PythonCode where
   type Body PythonCode = Doc
@@ -473,15 +473,15 @@ instance MethodSym PythonCode where
   type Method PythonCode = (Doc, Bool)
   method n _ _ _ _ ps b = liftPairFst (liftA3 (pyMethod n) self (liftList 
     paramListDocD ps) b, False)
-  getMethod n c t = method (getterName n) c public dynamic t [] getBody
+  getMethod n c t = method (getterName n) c public dynamicRepr t [] getBody
     where getBody = oneLiner $ returnState (self $-> var n)
-  setMethod setLbl c paramLbl t = method (setterName setLbl) c public dynamic
+  setMethod setLbl c paramLbl t = method (setterName setLbl) c public dynamicRepr
     void [stateParam paramLbl t] setBody
     where setBody = oneLiner $ (self $-> var setLbl) &=. paramLbl
   mainMethod _ b = liftPairFst (b, True)
-  privMethod n c = method n c private dynamic
-  pubMethod n c = method n c public dynamic
-  constructor n = method initName n public dynamic (construct n)
+  privMethod n c = method n c private dynamicRepr
+  pubMethod n c = method n c public dynamicRepr
+  constructor n = method initName n public dynamicRepr (construct n)
   destructor _ _ = error "Destructors not allowed in Python"
 
 
@@ -491,8 +491,8 @@ instance MethodSym PythonCode where
 instance StateVarSym PythonCode where
   type StateVar PythonCode = Doc
   stateVar _ _ _ _ _ = return empty
-  privMVar del l = stateVar del l private dynamic
-  pubMVar del l = stateVar del l public dynamic
+  privMVar del l = stateVar del l private dynamicRepr
+  pubMVar del l = stateVar del l public dynamicRepr
   pubGVar del l = stateVar del l public staticRepr
   listStateVar = stateVar
 

--- a/code/drasil-code/Language/Drasil/Code/Imperative/LanguageRenderer/ObjectiveCRenderer.hs
+++ b/code/drasil-code/Language/Drasil/Code/Imperative/LanguageRenderer/ObjectiveCRenderer.hs
@@ -62,7 +62,7 @@ objcConfig options c =
         iterForEachLabel = empty,
         iterInLabel      = text "in",
         list             = \case StaticCon  -> text staticListType
-                                 Dynamic -> text "NSMutableArray",
+                                 DynamicCon -> text "NSMutableArray",
         listObj          = empty,
         clsDec           = text "@" <> classDec,
         package          = const empty,
@@ -349,9 +349,9 @@ valueDoc' c (ObjAccess v f@(ListAdd _ e@(Var _ _))) = vcat [
 valueDoc' _ Self = text "self"
 valueDoc' c (StateObj _ t@(List lt _) [s]) = brackets (alloc c t <> innerFuncAppDoc c init size)
     where init = case lt of StaticCon  -> defaultInit
-                            Dynamic -> "initWithCapacity"
+                            DynamicCon -> "initWithCapacity"
           size = case lt of StaticCon  -> []
-                            Dynamic -> [s]
+                            DynamicCon -> [s]
 valueDoc' c (StateObj _ t@(List _ _) _) = brackets (alloc c t <> innerFuncAppDoc c defaultInit [])
 valueDoc' c (StateObj _ t vs) = brackets (funcDoc c (Cast t t) <+> alloc c t <> innerFuncAppDoc c sagaInit vs) -- cast needs fixing
 valueDoc' c (Arg i) = nsFromCString c $ argsListAccess c i
@@ -373,7 +373,7 @@ destructor _ vs =
         releaseStatements = concatMap (\(StateVar lbl _ _ _ _) -> [ValState (var lbl $. Func release [])]) releaseVars
         releaseBlock = if null releaseVars then [] else [Block releaseStatements]
         deallocBody = releaseBlock ++ oneLiner (ValState (super $. Func dealloc []))
-    in Method dealloc Public Dynamic Void [] deallocBody
+    in Method dealloc Public DynamicCon Void [] deallocBody
 
 alloc :: Config -> StateType -> Doc
 alloc c t = brackets (stateType c t Def <> innerFuncAppDoc c "alloc" [])

--- a/code/drasil-code/Language/Drasil/Code/Imperative/LanguageRenderer/ObjectiveCRenderer.hs
+++ b/code/drasil-code/Language/Drasil/Code/Imperative/LanguageRenderer/ObjectiveCRenderer.hs
@@ -61,7 +61,7 @@ objcConfig options c =
         inputFunc        = text "scanf",
         iterForEachLabel = empty,
         iterInLabel      = text "in",
-        list             = \case Static  -> text staticListType
+        list             = \case StaticCon  -> text staticListType
                                  Dynamic -> text "NSMutableArray",
         listObj          = empty,
         clsDec           = text "@" <> classDec,
@@ -348,9 +348,9 @@ valueDoc' c (ObjAccess v f@(ListAdd _ e@(Var _ _))) = vcat [
     objAccessDoc c e (Func release [])]
 valueDoc' _ Self = text "self"
 valueDoc' c (StateObj _ t@(List lt _) [s]) = brackets (alloc c t <> innerFuncAppDoc c init size)
-    where init = case lt of Static  -> defaultInit
+    where init = case lt of StaticCon  -> defaultInit
                             Dynamic -> "initWithCapacity"
-          size = case lt of Static  -> []
+          size = case lt of StaticCon  -> []
                             Dynamic -> [s]
 valueDoc' c (StateObj _ t@(List _ _) _) = brackets (alloc c t <> innerFuncAppDoc c defaultInit [])
 valueDoc' c (StateObj _ t vs) = brackets (funcDoc c (Cast t t) <+> alloc c t <> innerFuncAppDoc c sagaInit vs) -- cast needs fixing

--- a/code/drasil-code/Language/Drasil/Code/Imperative/New.hs
+++ b/code/drasil-code/Language/Drasil/Code/Imperative/New.hs
@@ -56,7 +56,7 @@ class (ValueSym repr, PermanenceSym repr) => KeywordSym repr where
 class PermanenceSym repr where
   type Permanence repr
   staticRepr  :: repr (Permanence repr)
-  dynamic :: repr (Permanence repr)
+  dynamicRepr :: repr (Permanence repr)
 
 class (BlockSym repr) => BodySym repr where
   type Body repr

--- a/code/drasil-code/Language/Drasil/Code/Imperative/New.hs
+++ b/code/drasil-code/Language/Drasil/Code/Imperative/New.hs
@@ -55,7 +55,7 @@ class (ValueSym repr, PermanenceSym repr) => KeywordSym repr where
 
 class PermanenceSym repr where
   type Permanence repr
-  static  :: repr (Permanence repr)
+  staticRepr  :: repr (Permanence repr)
   dynamic :: repr (Permanence repr)
 
 class (BlockSym repr) => BodySym repr where


### PR DESCRIPTION
Based on #1468.

Renaming `static` to help avoid new Hlint errors.
Renaming `dynamic` for consistency.