### PR TITLE
Clearer printing of doubles

### DIFF
--- a/code/drasil-printers/Language/Drasil/Printing/Import.hs
+++ b/code/drasil-printers/Language/Drasil/Printing/Import.hs
@@ -58,6 +58,7 @@ mulExpr []       sm     = [expr' sm (precA Mul) (Int 1)]
 -- and decimal point position and a counter and exponent
 digitsProcess :: [Integer] -> Int -> Int -> Integer -> [P.Expr]
 digitsProcess [0] _ _ _ = [P.Int 0, P.MO P.Point, P.Int 0]
+digitsProcess ds pos coun (-3) = [P.Int 0, P.MO P.Point] ++ replicate (3 - pos) (P.Int 0) ++ map P.Int ds
 digitsProcess (hd:tl) pos coun ex 
   | pos /= coun = P.Int hd : digitsProcess tl pos (coun + 1) ex
   | ex /= 0 = [P.MO P.Point, P.Int hd] ++ map P.Int tl ++ [P.MO P.Dot, P.Int 10, P.Sup $ P.Int ex]
@@ -78,17 +79,9 @@ digitsProcess [] pos coun ex
 -- https://en.wikipedia.org/wiki/Scientific_notation
 processExpo :: Int -> (Int, Int)
 processExpo a 
-  | a == 0 = (3, -3)
-  | a == 1 = (1, 0)
-  | a == 2 = (2, 0)
-  | a == -1 = (2, -3) 
-  | a == -2 = (1, -3)
-  | a > 0 && mod (a-1)  3 == 0 = (1, a-1)
-  | a > 0 && mod (a-1)  3 == 1 = (2, a-2)
-  | a > 0 && mod (a-1)  3 == 2 = (3, a-3)
-  | a < 0 && mod (-a) 3 == 0 = (3, a-3)
-  | a < 0 && mod (-a) 3 == 1 = (2, a-2)
-  | a < 0 && mod (-a) 3 == 2 = (1, a-1)
+  | mod (a-1)  3 == 0 = (1, a-1)
+  | mod (a-1)  3 == 1 = (2, a-2)
+  | mod (a-1)  3 == 2 = (3, a-3)
   | otherwise = error "The cases of processExpo should be exhaustive!"
 
 -- | expr translation function from Drasil to layout AST

--- a/code/drasil-printers/Language/Drasil/Printing/Import.hs
+++ b/code/drasil-printers/Language/Drasil/Printing/Import.hs
@@ -58,7 +58,7 @@ mulExpr []       sm     = [expr' sm (precA Mul) (Int 1)]
 -- and decimal point position and a counter and exponent
 digitsProcess :: [Integer] -> Int -> Int -> Integer -> [P.Expr]
 digitsProcess [0] _ _ _ = [P.Int 0, P.MO P.Point, P.Int 0]
-digitsProcess ds pos coun (-3) = [P.Int 0, P.MO P.Point] ++ replicate (3 - pos) (P.Int 0) ++ map P.Int ds
+digitsProcess ds pos _ (-3) = [P.Int 0, P.MO P.Point] ++ replicate (3 - pos) (P.Int 0) ++ map P.Int ds
 digitsProcess (hd:tl) pos coun ex 
   | pos /= coun = P.Int hd : digitsProcess tl pos (coun + 1) ex
   | ex /= 0 = [P.MO P.Point, P.Int hd] ++ map P.Int tl ++ [P.MO P.Dot, P.Int 10, P.Sup $ P.Int ex]

--- a/code/stable/gamephys/SRS/Chipmunk_SRS.tex
+++ b/code/stable/gamephys/SRS/Chipmunk_SRS.tex
@@ -1063,7 +1063,7 @@ Var & Physical Constraints & Typical Value & Uncert.
 \\
 \midrule
 \endhead
-${C_{R}}$ & $0\leq{}{C_{R}}\leq{}1$ & $800.0\cdot{}10^{-3}$ & 10$\%$
+${C_{R}}$ & $0\leq{}{C_{R}}\leq{}1$ & $0.8$ & 10$\%$
 \\
 $\mathbf{F}$ & -- & $98.1$ N & 10$\%$
 \\
@@ -1075,7 +1075,7 @@ $L$ & $L\geq{}0$ & $44.2$ m & 10$\%$
 \\
 $m$ & $m\geq{}0$ & $56.2$ kg & 10$\%$
 \\
-$\mathbf{p}$ & -- & $412.0\cdot{}10^{-3}$ m & 10$\%$
+$\mathbf{p}$ & -- & $0.412$ m & 10$\%$
 \\
 $\mathbf{v}$ & -- & $2.51$ $\frac{\text{m}}{\text{s}}$ & 10$\%$
 \\

--- a/code/stable/gamephys/Website/Chipmunk_SRS.html
+++ b/code/stable/gamephys/Website/Chipmunk_SRS.html
@@ -2027,7 +2027,7 @@ This instance model is based on our assumptions regarding rigid body <a href=#as
 <td>
 <em>0&thinsp;&le;&thinsp;C<sub>R</sub>&thinsp;&le;&thinsp;1</em>
 </td>
-<td><em>800.0&sdot;10<sup>-3</sup></em></td>
+<td><em>0.8</em></td>
 <td>10<em>%</em></td>
 </tr>
 <tr>
@@ -2063,7 +2063,7 @@ This instance model is based on our assumptions regarding rigid body <a href=#as
 <tr>
 <td><em><b>p</b></em></td>
 <td>--</td>
-<td><em>412.0&sdot;10<sup>-3</sup></em> m</td>
+<td><em>0.412</em> m</td>
 <td>10<em>%</em></td>
 </tr>
 <tr>

--- a/code/stable/glassbr/SRS/GlassBR_SRS.tex
+++ b/code/stable/glassbr/SRS/GlassBR_SRS.tex
@@ -1039,7 +1039,7 @@ $AR$ & $AR\geq{}1$ & $AR\leq{}{AR_{max}}$ & $1.5$ & 10$\%$
 \\
 $b$ & $0<b\leq{}a$ & ${d_{min}}\leq{}b\leq{}{d_{max}}$ & $1.2$ m & 10$\%$
 \\
-${P_{btol}}$ & $0<{P_{btol}}<1$ & -- & $8.0\cdot{}10^{-3}$ & 0.1$\%$
+${P_{btol}}$ & $0<{P_{btol}}<1$ & -- & $0.008$ & 0.1$\%$
 \\
 $SD$ & $SD>0$ & ${SD_{min}}\leq{}SD\leq{}{SD_{max}}$ & $45.0$ m & 10$\%$
 \\
@@ -1434,7 +1434,7 @@ ${AR_{max}}$ & maximum aspect ratio & $5.0$ & --
 \\
 ${d_{max}}$ & maximum value for one of the dimensions of the glass plate & $5.0$ & m
 \\
-${d_{min}}$ & minimum value for one of the dimensions of the glass plate & $100.0\cdot{}10^{-3}$ & m
+${d_{min}}$ & minimum value for one of the dimensions of the glass plate & $0.1$ & m
 \\
 $E$ & modulus of elasticity of glass & $71.7\cdot{}10^{9}$ & Pa
 \\

--- a/code/stable/glassbr/Website/GlassBR_SRS.html
+++ b/code/stable/glassbr/Website/GlassBR_SRS.html
@@ -2033,7 +2033,7 @@ If <em>is-safeLR</em>, the glass is considered safe. <em>is-safePb</em> (from <a
 <em>0&thinsp;&lt;&thinsp;P<sub>btol</sub>&thinsp;&lt;&thinsp;1</em>
 </td>
 <td>--</td>
-<td><em>8.0&sdot;10<sup>-3</sup></em></td>
+<td><em>0.008</em></td>
 <td>0.1<em>%</em></td>
 </tr>
 <tr>
@@ -4428,7 +4428,7 @@ This section contains the standard values that are used for calculations in Glas
 <tr>
 <td><em>d<sub>min</sub></em></td>
 <td>minimum value for one of the dimensions of the glass plate</td>
-<td><em>100.0&sdot;10<sup>-3</sup></em></td>
+<td><em>0.1</em></td>
 <td>m</td>
 </tr>
 <tr>

--- a/code/stable/nopcm/SRS/NoPCM_SRS.tex
+++ b/code/stable/nopcm/SRS/NoPCM_SRS.tex
@@ -590,11 +590,11 @@ Var & Physical Constraints & Software Constraints & Typical Value & Uncert.
 \\
 \midrule
 \endhead
-${A_{C}}$ & ${A_{C}}>0$ & ${A_{C}}\leq{}{{A_{C}}^{max}}$ & $120.0\cdot{}10^{-3}$ $\text{m}^{2}$ & 10$\%$
+${A_{C}}$ & ${A_{C}}>0$ & ${A_{C}}\leq{}{{A_{C}}^{max}}$ & $0.12$ $\text{m}^{2}$ & 10$\%$
 \\
 ${C_{W}}$ & ${C_{W}}>0$ & ${{C_{W}}^{min}}<{C_{W}}<{{C_{W}}^{max}}$ & $4.186\cdot{}10^{3}$ $\frac{\text{J}}{(\text{kg}{}^{\circ}\text{C})}$ & 10$\%$
 \\
-$D$ & $D>0$ & -- & $412.0\cdot{}10^{-3}$ m & 10$\%$
+$D$ & $D>0$ & -- & $0.412$ m & 10$\%$
 \\
 ${h_{C}}$ & ${h_{C}}>0$ & ${{h_{C}}^{min}}\leq{}{h_{C}}\leq{}{{h_{C}}^{max}}$ & $1.0\cdot{}10^{3}$ $\frac{\text{W}}{(\text{m}^{2}{}^{\circ}\text{C})}$ & 10$\%$
 \\
@@ -606,7 +606,7 @@ ${t_{final}}$ & ${t_{final}}>0$ & ${t_{final}}<{{t_{final}}^{max}}$ & $50.0\cdot
 \\
 ${T_{init}}$ & $0<{T_{init}}<100$ & -- & $40.0$ ${}^{\circ}$C & 10$\%$
 \\
-${t_{step}}$ & $0<{t_{step}}<{t_{final}}$ & -- & $10.0\cdot{}10^{-3}$ s & 10$\%$
+${t_{step}}$ & $0<{t_{step}}<{t_{final}}$ & -- & $0.01$ s & 10$\%$
 \\
 ${ρ_{W}}$ & ${ρ_{W}}>0$ & ${{ρ_{W}}^{min}}<{ρ_{W}}\leq{}{{ρ_{W}}^{max}}$ & $1.0\cdot{}10^{3}$ $\frac{\text{kg}}{\text{m}^{3}}$ & 10$\%$
 \\
@@ -862,7 +862,7 @@ ${{h_{C}}^{min}}$ & minimum convective heat transfer coefficient between coil an
 \\
 ${L_{max}}$ & maximum length of tank & $50$ & m
 \\
-${L_{min}}$ & minimum length of tank & $100.0\cdot{}10^{-3}$ & m
+${L_{min}}$ & minimum length of tank & $0.1$ & m
 \\
 ${{t_{final}}^{max}}$ & maximum final time & $86400$ & s
 \\

--- a/code/stable/nopcm/Website/NoPCM_SRS.html
+++ b/code/stable/nopcm/Website/NoPCM_SRS.html
@@ -1264,7 +1264,7 @@ The above equation is derived using <a href=#TM:sensHtE>TM: sensHtE</a>. <em>E<s
 <td>
 <em>A<sub>C</sub>&thinsp;&le;&thinsp;A<sub>C</sub><sup>max</sup></em>
 </td>
-<td><em>120.0&sdot;10<sup>-3</sup></em> m<sup>2</sup></td>
+<td><em>0.12</em> m<sup>2</sup></td>
 <td>10<em>%</em></td>
 </tr>
 <tr>
@@ -1280,7 +1280,7 @@ The above equation is derived using <a href=#TM:sensHtE>TM: sensHtE</a>. <em>E<s
 <td><em>D</em></td>
 <td><em>D&thinsp;&gt;&thinsp;0</em></td>
 <td>--</td>
-<td><em>412.0&sdot;10<sup>-3</sup></em> m</td>
+<td><em>0.412</em> m</td>
 <td>10<em>%</em></td>
 </tr>
 <tr>
@@ -1336,7 +1336,7 @@ The above equation is derived using <a href=#TM:sensHtE>TM: sensHtE</a>. <em>E<s
 <em>0&thinsp;&lt;&thinsp;t<sub>step</sub>&thinsp;&lt;&thinsp;t<sub>final</sub></em>
 </td>
 <td>--</td>
-<td><em>10.0&sdot;10<sup>-3</sup></em> s</td>
+<td><em>0.01</em> s</td>
 <td>10<em>%</em></td>
 </tr>
 <tr>
@@ -2648,7 +2648,7 @@ minimum convective heat transfer coefficient between coil and water
 <tr>
 <td><em>L<sub>min</sub></em></td>
 <td>minimum length of tank</td>
-<td><em>100.0&sdot;10<sup>-3</sup></em></td>
+<td><em>0.1</em></td>
 <td>m</td>
 </tr>
 <tr>

--- a/code/stable/swhs/SRS/SWHS_SRS.tex
+++ b/code/stable/swhs/SRS/SWHS_SRS.tex
@@ -991,7 +991,7 @@ Var & Physical Constraints & Software Constraints & Typical Value & Uncert.
 \\
 \midrule
 \endhead
-${A_{C}}$ & ${A_{C}}>0$ & ${A_{C}}\leq{}{{A_{C}}^{max}}$ & $120.0\cdot{}10^{-3}$ $\text{m}^{2}$ & 10$\%$
+${A_{C}}$ & ${A_{C}}>0$ & ${A_{C}}\leq{}{{A_{C}}^{max}}$ & $0.12$ $\text{m}^{2}$ & 10$\%$
 \\
 ${A_{P}}$ & ${A_{P}}>0$ & ${V_{P}}\leq{}{A_{P}}\leq{}\frac{2}{{h_{min}}} {V_{tank}}$ & $1.2$ $\text{m}^{2}$ & 10$\%$
 \\
@@ -1001,7 +1001,7 @@ ${{C_{P}}^{L}}$ & ${{C_{P}}^{L}}>0$ & ${{{C_{P}}^{L}}_{min}}<{{C_{P}}^{L}}<{{{C_
 \\
 ${{C_{P}}^{S}}$ & ${{C_{P}}^{S}}>0$ & ${{{C_{P}}^{S}}_{min}}<{{C_{P}}^{S}}<{{{C_{P}}^{S}}_{max}}$ & $1.76\cdot{}10^{3}$ $\frac{\text{J}}{(\text{kg}{}^{\circ}\text{C})}$ & 10$\%$
 \\
-$D$ & $D>0$ & -- & $412.0\cdot{}10^{-3}$ m & 10$\%$
+$D$ & $D>0$ & -- & $0.412$ m & 10$\%$
 \\
 ${h_{C}}$ & ${h_{C}}>0$ & ${{h_{C}}^{min}}\leq{}{h_{C}}\leq{}{{h_{C}}^{max}}$ & $1.0\cdot{}10^{3}$ $\frac{\text{W}}{(\text{m}^{2}{}^{\circ}\text{C})}$ & 10$\%$
 \\
@@ -1017,11 +1017,11 @@ ${t_{final}}$ & ${t_{final}}>0$ & ${t_{final}}<{{t_{final}}^{max}}$ & $50.0\cdot
 \\
 ${T_{init}}$ & $0<{T_{init}}<{T_{melt}}$ & -- & $40.0$ ${}^{\circ}$C & 10$\%$
 \\
-${t_{step}}$ & $0<{t_{step}}<{t_{final}}$ & -- & $10.0\cdot{}10^{-3}$ s & 10$\%$
+${t_{step}}$ & $0<{t_{step}}<{t_{final}}$ & -- & $0.01$ s & 10$\%$
 \\
 ${{T_{melt}}^{P}}$ & $0<{{T_{melt}}^{P}}<{T_{C}}$ & -- & $44.2$ ${}^{\circ}$C & 10$\%$
 \\
-${V_{P}}$ & $0<{V_{P}}<{V_{tank}}$ & ${V_{P}}\geq{}MINFRACT {V_{tank}}$ & $50.0\cdot{}10^{-3}$ $\text{m}^{3}$ & 10$\%$
+${V_{P}}$ & $0<{V_{P}}<{V_{tank}}$ & ${V_{P}}\geq{}MINFRACT {V_{tank}}$ & $0.05$ $\text{m}^{3}$ & 10$\%$
 \\
 ${ρ_{P}}$ & ${ρ_{P}}>0$ & ${{ρ_{P}}^{min}}<{ρ_{P}}<{{ρ_{P}}^{max}}$ & $1.007\cdot{}10^{3}$ $\frac{\text{kg}}{\text{m}^{3}}$ & 10$\%$
 \\
@@ -1429,7 +1429,7 @@ ${{h_{P}}^{min}}$ & minimum convective heat transfer coefficient between PCM and
 \\
 ${L_{max}}$ & maximum length of tank & $50$ & m
 \\
-${L_{min}}$ & minimum length of tank & $100.0\cdot{}10^{-3}$ & m
+${L_{min}}$ & minimum length of tank & $0.1$ & m
 \\
 $MINFRACT$ & minimum fraction of the tank volume taken up by the PCM & $1.0\cdot{}10^{-6}$ & --
 \\

--- a/code/stable/swhs/Website/SWHS_SRS.html
+++ b/code/stable/swhs/Website/SWHS_SRS.html
@@ -2318,7 +2318,7 @@ The above equation is derived using <a href=#TM:sensHtE>TM: sensHtE</a> and <a h
 <td>
 <em>A<sub>C</sub>&thinsp;&le;&thinsp;A<sub>C</sub><sup>max</sup></em>
 </td>
-<td><em>120.0&sdot;10<sup>-3</sup></em> m<sup>2</sup></td>
+<td><em>0.12</em> m<sup>2</sup></td>
 <td>10<em>%</em></td>
 </tr>
 <tr>
@@ -2366,7 +2366,7 @@ The above equation is derived using <a href=#TM:sensHtE>TM: sensHtE</a> and <a h
 <td><em>D</em></td>
 <td><em>D&thinsp;&gt;&thinsp;0</em></td>
 <td>--</td>
-<td><em>412.0&sdot;10<sup>-3</sup></em> m</td>
+<td><em>0.412</em> m</td>
 <td>10<em>%</em></td>
 </tr>
 <tr>
@@ -2442,7 +2442,7 @@ The above equation is derived using <a href=#TM:sensHtE>TM: sensHtE</a> and <a h
 <em>0&thinsp;&lt;&thinsp;t<sub>step</sub>&thinsp;&lt;&thinsp;t<sub>final</sub></em>
 </td>
 <td>--</td>
-<td><em>10.0&sdot;10<sup>-3</sup></em> s</td>
+<td><em>0.01</em> s</td>
 <td>10<em>%</em></td>
 </tr>
 <tr>
@@ -2462,7 +2462,7 @@ The above equation is derived using <a href=#TM:sensHtE>TM: sensHtE</a> and <a h
 <td>
 <em>V<sub>P</sub>&thinsp;&ge;&thinsp;MINFRACT&#8239;V<sub>tank</sub></em>
 </td>
-<td><em>50.0&sdot;10<sup>-3</sup></em> m<sup>3</sup></td>
+<td><em>0.05</em> m<sup>3</sup></td>
 <td>10<em>%</em></td>
 </tr>
 <tr>
@@ -5558,7 +5558,7 @@ minimum convective heat transfer coefficient between PCM and water
 <tr>
 <td><em>L<sub>min</sub></em></td>
 <td>minimum length of tank</td>
-<td><em>100.0&sdot;10<sup>-3</sup></em></td>
+<td><em>0.1</em></td>
 <td>m</td>
 </tr>
 <tr>


### PR DESCRIPTION
This PR updates printing of doubles such that values between 0 and 0.001 (inclusive) get printed directly, without any scientific notation. This is as discussed in https://github.com/JacquesCarette/Drasil/pull/1496#discussion_r291226461 (printing of numbers between 0 and 1000 was already how we want it, so no changes there).