### PR TITLE
PR - Correcting Final Hlint warnings

### DIFF
--- a/code/.hlint.yaml
+++ b/code/.hlint.yaml
@@ -7,8 +7,6 @@
 
 
 # Warnings currently triggered by your code
-- ignore: {name: "Redundant bracket"}
-- ignore: {name: "Use camelCase"}
 
 
 # Specify additional command line arguments

--- a/code/drasil-example/Drasil/GamePhysics/DataDefs.hs
+++ b/code/drasil-example/Drasil/GamePhysics/DataDefs.hs
@@ -49,7 +49,7 @@ ctrOfMass = mkQuantDef posCM ctrOfMassEqn
 
 -- FIXME (Atomic "i") is a horrible hack
 ctrOfMassEqn :: Expr
-ctrOfMassEqn = (sumAll (Atomic "i") (sy massI * sy posI)) / sy mTot
+ctrOfMassEqn = sumAll (Atomic "i") (sy massI * sy posI) / sy mTot
 
 -- DD2 : Linear displacement --
 

--- a/code/drasil-example/Drasil/GlassBR/TMods.hs
+++ b/code/drasil-example/Drasil/GlassBR/TMods.hs
@@ -40,10 +40,10 @@ lrIsSafe = tm (cw lrIsSafeRC)
 
 lrIsSafeRC :: RelationConcept
 lrIsSafeRC = makeRC "safetyLoad" (nounPhraseSP "Safety Load")
-  lrIsSafeDesc ( (sy isSafeLoad) $= (sy tmLRe) $> (sy tmDemand))
+  lrIsSafeDesc (sy isSafeLoad $= sy tmLRe $> sy tmDemand)
 
 lrIsSafeDesc :: Sentence
-lrIsSafeDesc = tModDesc (isSafeLoad) s ending
+lrIsSafeDesc = tModDesc isSafeLoad s ending
   where 
     s = ch isSafeProb +:+ sParen (S "from" +:+ makeRef2S pbIsSafe) `sAnd` ch isSafeLoad
     ending = short lResistance `isThe` phrase lResistance +:+ 
@@ -64,7 +64,7 @@ pbIsSafeRC = makeRC "safetyProbability" (nounPhraseSP "Safety Probability")
   pbIsSafeDesc (sy isSafeProb $= sy probFail $< sy pbTolfail)
 
 pbIsSafeDesc :: Sentence
-pbIsSafeDesc = tModDesc (isSafeProb) s ending
+pbIsSafeDesc = tModDesc isSafeProb s ending
   where 
     s = ch isSafeProb `sAnd` ch isSafeLoad +:+ sParen (S "from" +:+
       makeRef2S lrIsSafe)

--- a/code/drasil-example/Drasil/NoPCM/Assumptions.hs
+++ b/code/drasil-example/Drasil/NoPCM/Assumptions.hs
@@ -36,8 +36,8 @@ assumpS3 =
   S "same throughout the entire", phrase tank]
 
 assumpS4 = 
-  (foldlSent [S "The", phrase wDensity, S "has no spatial variation; that is"
-  `sC` S "it is constant over their entire", phrase vol])
+  foldlSent [S "The", phrase wDensity, S "has no spatial variation; that is"
+  `sC` S "it is constant over their entire", phrase vol]
 
 assumpDWCoW = cic "assumpDWCoW" assumpS4
   "Density-Water-Constant-over-Volume" assumpDom

--- a/code/drasil-example/Drasil/NoPCM/GenDefs.hs
+++ b/code/drasil-example/Drasil/NoPCM/GenDefs.hs
@@ -75,10 +75,10 @@ genDefDesc5 den ma vo = [S "Using the fact that", ch den :+: S "=" :+:
 
 genDefEq1, genDefEq2, genDefEq3, genDefEq4, genDefEq5 :: Expr
 
-genDefEq1 = (negate (intAll (eqSymb vol) ((sy gradient) $. (sy thFluxVect)))) + 
-  (intAll (eqSymb vol) (sy volHtGen)) $=
-  (intAll (eqSymb vol) ((sy density)
-  * (sy QT.heatCapSpec) * pderiv (sy QT.temp) time))
+genDefEq1 = negate (intAll (eqSymb vol) (sy gradient $. sy thFluxVect)) + 
+  intAll (eqSymb vol) (sy volHtGen) $=
+  intAll (eqSymb vol) (sy density
+  * sy QT.heatCapSpec * pderiv (sy QT.temp) time)
 
 genDefEq2 = negate (intAll (eqSymb surface) (sy thFluxVect $. sy uNormalVect)) +
   intAll (eqSymb vol) (sy volHtGen) $= 

--- a/code/drasil-example/Drasil/NoPCM/Requirements.hs
+++ b/code/drasil-example/Drasil/NoPCM/Requirements.hs
@@ -32,7 +32,7 @@ inputInitQuants = iIQConstruct inputInitQuantsTable
 --
 findMassExpr :: Expr
 findMassExpr = sy wMass $= sy wVol * sy wDensity $=
-  (sy pi_ * (((sy diam / 2) $^ 2)) * sy tankLength * sy wDensity)
+  (sy pi_ * ((sy diam / 2) $^ 2) * sy tankLength * sy wDensity)
 
 findMass :: ConceptInstance
 findMass = findMassConstruct inputInitQuants (phrase mass) (makeRef2S eBalanceOnWtr)

--- a/code/drasil-example/Drasil/SWHS/GenDefs.hs
+++ b/code/drasil-example/Drasil/SWHS/GenDefs.hs
@@ -149,10 +149,10 @@ s4_2_3_desc5 den ma vo = [S "Using the fact that", ch den :+: S "=" :+:
 
 s4_2_3_eq1, s4_2_3_eq2, s4_2_3_eq3, s4_2_3_eq4, s4_2_3_eq5 :: Expr
 
-s4_2_3_eq1 = (negate (intAll (eqSymb vol) ((sy gradient) $. (sy thFluxVect)))) + 
-  (intAll (eqSymb vol) (sy volHtGen)) $=
-  (intAll (eqSymb vol) ((sy density)
-  * (sy QT.heatCapSpec) * pderiv (sy QT.temp) time))
+s4_2_3_eq1 = negate (intAll (eqSymb vol) (sy gradient $. sy thFluxVect)) + 
+  intAll (eqSymb vol) (sy volHtGen) $=
+  intAll (eqSymb vol) (sy density
+  * sy QT.heatCapSpec * pderiv (sy QT.temp) time)
 
 s4_2_3_eq2 = negate (intAll (eqSymb surface) (sy thFluxVect $. sy uNormalVect)) +
   intAll (eqSymb vol) (sy volHtGen) $= 

--- a/code/drasil-example/Drasil/SWHS/IMods.hs
+++ b/code/drasil-example/Drasil/SWHS/IMods.hs
@@ -97,7 +97,7 @@ eBalanceOnWtrDerivDesc1 htEnd oa ea htA = [S "To find the", phrase rOfChng `sOf`
   phrase vol, S "being considered" `isThe` (phrase vol `sOf` phrase water), S "in the",
   phrase tank, (E $ sy wVol) `sC` S "which has", phrase mass +:+. ((E $ sy wMass) `sAnd`
   phrase heatCapSpec `sC` (E $ sy htCapW)), atStart heatTrans, S "occurs in the",
-  phrase water, S "from the", phrase coil, S "as", (E $ sy htFluxC),
+  phrase water, S "from the", phrase coil, S "as", E $ sy htFluxC,
   sParen (makeRef2S dd1HtFluxC) :+: htEnd `sC` EmptyS +:+. oa, ea, S "No", phrase heatTrans, S "occurs to", S "outside" `ofThe`
   phrase tank `sC` S "since it has been assumed to be perfectly insulated" +:+.
   sParen (makeRef2S assumpPIT), S "Since the", phrase assumption,
@@ -189,13 +189,13 @@ eBalanceOnWtrDerivEqn5 =
   (sy wMass * sy htCapW)) * (sy tempPCM - sy tempW)
 
 
-eBalanceOnWtrDerivEqn6 = (deriv (sy tempW) time) $= 
-  1 / (sy tauW) * ((sy tempC) - (sy tempW)) +
-  (sy eta) / (sy tauW) * ((sy tempPCM) - (sy tempW))
+eBalanceOnWtrDerivEqn6 = deriv (sy tempW) time $= 
+  1 / sy tauW * (sy tempC - sy tempW) +
+  sy eta / sy tauW * (sy tempPCM - sy tempW)
 
 eBalanceOnWtrDerivEqn7 =  
-  (deriv (sy tempW) time) $= 1 / (sy tauW) * (((sy tempC) - (sy tempW)) +
-  sy eta * ((sy tempPCM) - (sy tempW)))
+  deriv (sy tempW) time $= 1 / sy tauW * ((sy tempC - sy tempW) +
+  sy eta * (sy tempPCM - sy tempW))
 
 eBalanceOnWtr_deriv_eqns__im1 :: [Expr]
 eBalanceOnWtr_deriv_eqns__im1 = [eBalanceOnWtrDerivEqn1, eBalanceOnWtrDerivEqn2,
@@ -399,7 +399,7 @@ htWtrDesc = foldlSent [S "The above", phrase equation, S "is derived using" +:+.
   phrase thermalEnergy) `ofThe` phrase liquid), phrase water, 
   S "relative" `toThe` phrase energy, S "at the initial", phrase temp, 
   sParen (ch tempInit) +:+. sParen (unwrap $ getUnit pcmInitMltE), 
-  (ch htCapW) `isThe` phrase heatCapSpec `sOf` phrase liquid, phrase water,
+  ch htCapW `isThe` phrase heatCapSpec `sOf` phrase liquid, phrase water,
   sParen (unwrap $ getUnit htCapSP) `sAnd` ch wMass `sIs` (phrase mass `ofThe`
   phrase water) +:+. sParen (unwrap $ getUnit wMass), S "The", 
   phrase change `sIn` phrase temp `isThe` S "difference between the", 

--- a/code/drasil-example/Drasil/SWHS/Requirements.hs
+++ b/code/drasil-example/Drasil/SWHS/Requirements.hs
@@ -87,7 +87,7 @@ inputInitQuantsEqn = sy wMass $= sy wVol * sy wDensity $=
   (sy tankVol - sy pcmVol) * sy wDensity $=
   (sy pi_ * ((sy diam / 2) $^ 2) * sy tankLength - sy pcmVol) * sy wDensity -- FIXME: Ref Hack
 
-findMassEqn = (sy pcmMass) $= (sy pcmVol) * (sy pcmDensity) -- FIXME: Ref Hack
+findMassEqn = sy pcmMass $= sy pcmVol * sy pcmDensity -- FIXME: Ref Hack
 --
 checkWithPhysConsts = cic "checkWithPhysConsts" (foldlSent [
   S "Verify that the", plural input_, S "satisfy the required",

--- a/code/website/site.hs
+++ b/code/website/site.hs
@@ -32,14 +32,14 @@ mkExamples :: String -> FilePath -> FilePath -> IO [Example]
 mkExamples repoRoot path srsDir = do
   names <- sort <$> (listDirectory path >>= filterM (\x -> doesDirectoryExist $ path ++ x))
   sources <- mapM (\x -> doesFileExist (path ++ x ++ "/src") >>=
-      \y -> if y then (Just . (++) repoRoot . rstrip) <$> readFile (path ++ x ++ "/src") else return Nothing) names
+      \y -> if y then Just . (++) repoRoot . rstrip <$> readFile (path ++ x ++ "/src") else return Nothing) names
   srss <- mapM (\x -> sort . getSRS <$> listDirectory (srsPath path x srsDir)) names
   return $ map (\(name, source, srs) -> E name source srs) $ zip3 names sources srss
 
 maybeField :: String -> (Item a -> Compiler (Maybe String)) -> Context a
 maybeField s f = Context $ \k _ i -> do
   val <- f i
-  if k == s && (isJust val) then
+  if k == s && isJust val then
     return $ StringField $ fromJust val
   else
     fail $ "maybeField " ++ s ++ " used when really Nothing. Wrap in `$if(" ++ s ++ ")$` block."
@@ -62,7 +62,7 @@ mkExampleCtx exampleDir srsDir =
     example = snd . itemBody
 
 mkGraphs :: FilePath -> IO [FilePath]
-mkGraphs path = (sort . filter (endswith ".pdf")) <$> listDirectory path
+mkGraphs path = sort . filter (endswith ".pdf") <$> listDirectory path
 
 mkGraphCtx :: FilePath -> Context FilePath
 mkGraphCtx graphRoot =


### PR DESCRIPTION
Closes #1249.

Removed all leftover redundant bracket warnings.
`.hlint.yaml` updated.