### PR TITLE
Don't generate useless files

### DIFF
--- a/code/drasil-code/Language/Drasil/Code/Imperative/LanguageRenderer/NewCSharpRenderer.hs
+++ b/code/drasil-code/Language/Drasil/Code/Imperative/LanguageRenderer/NewCSharpRenderer.hs
@@ -47,7 +47,7 @@ import qualified Data.Map as Map (fromList,lookup)
 import Data.Maybe (fromMaybe)
 import Control.Applicative (Applicative, liftA2, liftA3)
 import Text.PrettyPrint.HughesPJ (Doc, text, (<>), (<+>), parens, comma, empty,
-  equals, semi, vcat, lbrace, rbrace, colon, render)
+  equals, semi, vcat, lbrace, rbrace, colon, render, isEmpty)
 
 newtype CSharpCode a = CSC {unCSC :: a}
 
@@ -69,7 +69,8 @@ instance PackageSym CSharpCode where
 instance RenderSym CSharpCode where
   type RenderFile CSharpCode = ModData
   fileDoc code = liftA3 md (fmap name code) (fmap isMainMod code) 
-    (liftA3 fileDoc' (top code) (fmap modDoc code) bottom)
+    (if isEmpty (modDoc (unCSC code)) then return empty else
+    liftA3 fileDoc' (top code) (fmap modDoc code) bottom)
   top _ = liftA2 cstop endStatement (include "")
   bottom = return empty
 

--- a/code/drasil-code/Language/Drasil/Code/Imperative/LanguageRenderer/NewCppRenderer.hs
+++ b/code/drasil-code/Language/Drasil/Code/Imperative/LanguageRenderer/NewCppRenderer.hs
@@ -584,11 +584,12 @@ instance Monad CppSrcCode where
 instance PackageSym CppSrcCode where
   type Package CppSrcCode = ([ModData], Label)
   packMods n ms = liftPairFst (sequence ms, n)
-
+  
 instance RenderSym CppSrcCode where
   type RenderFile CppSrcCode = ModData
   fileDoc code = liftA3 md (fmap name code) (fmap isMainMod code)
-    (liftA3 fileDoc' (top code) (fmap modDoc code) bottom)
+    (if isEmpty (modDoc (unCPPSC code)) then return empty else
+    liftA3 fileDoc' (top code) (fmap modDoc code) bottom)
   top m = liftA3 cppstop m (list dynamic) endStatement
   bottom = return empty
 

--- a/code/drasil-code/Language/Drasil/Code/Imperative/LanguageRenderer/NewJavaRenderer.hs
+++ b/code/drasil-code/Language/Drasil/Code/Imperative/LanguageRenderer/NewJavaRenderer.hs
@@ -74,7 +74,8 @@ instance PackageSym JavaCode where
 instance RenderSym JavaCode where
   type RenderFile JavaCode = ModData
   fileDoc code = liftA3 md (fmap name code) (fmap isMainMod code) 
-    (liftA3 fileDoc' (top code) (fmap modDoc code) bottom)
+    (if isEmpty (modDoc (unJC code)) then return empty else
+    liftA3 fileDoc' (top code) (fmap modDoc code) bottom)
   top _ = liftA3 jtop endStatement (include "") (list static)
   bottom = return empty
 

--- a/code/drasil-code/Language/Drasil/Code/Imperative/LanguageRenderer/NewPythonRenderer.hs
+++ b/code/drasil-code/Language/Drasil/Code/Imperative/LanguageRenderer/NewPythonRenderer.hs
@@ -60,7 +60,8 @@ instance PackageSym PythonCode where
 instance RenderSym PythonCode where
   type RenderFile PythonCode = ModData
   fileDoc code = liftA3 md (fmap name code) (fmap isMainMod code) 
-    (liftA3 fileDoc' (top code) (fmap modDoc code) bottom)
+    (if isEmpty (modDoc (unPC code)) then return empty else
+    liftA3 fileDoc' (top code) (fmap modDoc code) bottom)
   top _ = return pytop
   bottom = return empty
 


### PR DESCRIPTION
This PR updates all of our language renderers such that, if a file's main contents are empty, the file doesn't get generated. (Previously we would still generate a file with the "top" and "bottom" portions but nothing in between, i.e. just a file with imports, which was useless).