### PR TITLE
Correct examples not being "clean" on continuous deploy.

### DIFF
--- a/code/scripts/deploy_stage.sh
+++ b/code/scripts/deploy_stage.sh
@@ -49,6 +49,7 @@ copy_graphs() {
 }
 
 copy_examples() {
+	rm -r "$EXAMPLE_DEST"
 	for example in "$CUR_DIR$BUILD_FOLDER"*; do
 		example_name=$(basename $example)
 		mkdir -p "$EXAMPLE_DEST$example_name/$SRS_DEST"


### PR DESCRIPTION
Small PR to fix a bug that turned up on/with the website as the result of #1533. The deploy process doesn't clean the "examples" directory of the existing commit when updating contents so `Projectile_SRS.*` remains in the deploy branch. This PR addresses that.