### PR TITLE
Don't generate empty files when a module is empty

### DIFF
--- a/code/drasil-code/Language/Drasil/Code/Imperative/LanguageRenderer/NewCSharpRenderer.hs
+++ b/code/drasil-code/Language/Drasil/Code/Imperative/LanguageRenderer/NewCSharpRenderer.hs
@@ -64,7 +64,8 @@ instance Monad CSharpCode where
 
 instance PackageSym CSharpCode where
   type Package CSharpCode = ([ModData], Label)
-  packMods n ms = liftPairFst (sequence ms, n)
+  packMods n ms = liftPairFst (sequence mods, n)
+    where mods = filter (not . isEmpty . modDoc . unCSC) ms
 
 instance RenderSym CSharpCode where
   type RenderFile CSharpCode = ModData

--- a/code/drasil-code/Language/Drasil/Code/Imperative/LanguageRenderer/NewCSharpRenderer.hs
+++ b/code/drasil-code/Language/Drasil/Code/Imperative/LanguageRenderer/NewCSharpRenderer.hs
@@ -552,9 +552,7 @@ instance ClassSym CSharpCode where
 instance ModuleSym CSharpCode where
   type Module CSharpCode = ModData
   buildModule n _ vs ms cs = fmap (md n (any (snd . unCSC) ms || 
-    any (snd . unCSC) cs)) (if all (isEmpty . fst . unCSC) cs && all 
-    (isEmpty . fst . unCSC) ms then return empty else 
-    liftList moduleDocD (if null vs && null ms then cs 
+    any (snd . unCSC) cs)) (liftList moduleDocD (if null vs && null ms then cs 
     else pubClass n Nothing (map (liftA4 statementsToStateVars public static_ 
     endStatement) vs) ms : cs))
 

--- a/code/drasil-code/Language/Drasil/Code/Imperative/LanguageRenderer/NewCppRenderer.hs
+++ b/code/drasil-code/Language/Drasil/Code/Imperative/LanguageRenderer/NewCppRenderer.hs
@@ -1102,8 +1102,10 @@ instance ClassSym CppSrcCode where
 instance ModuleSym CppSrcCode where
   type Module CppSrcCode = ModData
   buildModule n l _ ms cs = fmap (md n (any (snd . unCPPSC) cs || 
-    any (isMainMthd . unCPPSC) ms)) (liftA5 cppModuleDoc (liftList vcat (map
-    include l)) (if not (null l) && any (not . isEmpty . fst . unCPPSC) cs then
+    any (isMainMthd . unCPPSC) ms)) (if all (isEmpty . fst . unCPPSC) cs && all 
+    (isEmpty . mthdDoc . unCPPSC) ms then return empty else
+    liftA5 cppModuleDoc (liftList vcat (map include l)) 
+    (if not (null l) && any (not . isEmpty . fst . unCPPSC) cs then
     return blank else return empty) (liftList methodListDocD (map (fmap 
     (\(MthD b _ d) -> (d,b))) ms)) (if (any (not . isEmpty . fst . unCPPSC) cs 
     || (all (isEmpty . fst . unCPPSC) cs && not (null l))) && 

--- a/code/drasil-code/Language/Drasil/Code/Imperative/LanguageRenderer/NewCppRenderer.hs
+++ b/code/drasil-code/Language/Drasil/Code/Imperative/LanguageRenderer/NewCppRenderer.hs
@@ -583,7 +583,8 @@ instance Monad CppSrcCode where
 
 instance PackageSym CppSrcCode where
   type Package CppSrcCode = ([ModData], Label)
-  packMods n ms = liftPairFst (sequence ms, n)
+  packMods n ms = liftPairFst (sequence mods, n)
+    where mods = filter (not . isEmpty . modDoc . unCPPSC) ms
   
 instance RenderSym CppSrcCode where
   type RenderFile CppSrcCode = ModData

--- a/code/drasil-code/Language/Drasil/Code/Imperative/LanguageRenderer/NewCppRenderer.hs
+++ b/code/drasil-code/Language/Drasil/Code/Imperative/LanguageRenderer/NewCppRenderer.hs
@@ -1102,10 +1102,8 @@ instance ClassSym CppSrcCode where
 instance ModuleSym CppSrcCode where
   type Module CppSrcCode = ModData
   buildModule n l _ ms cs = fmap (md n (any (snd . unCPPSC) cs || 
-    any (isMainMthd . unCPPSC) ms)) (if all (isEmpty . fst . unCPPSC) cs && all 
-    (isEmpty . mthdDoc . unCPPSC) ms then return empty else 
-    liftA5 cppModuleDoc (liftList vcat (map include l)) 
-    (if not (null l) && any (not . isEmpty . fst . unCPPSC) cs then
+    any (isMainMthd . unCPPSC) ms)) (liftA5 cppModuleDoc (liftList vcat (map
+    include l)) (if not (null l) && any (not . isEmpty . fst . unCPPSC) cs then
     return blank else return empty) (liftList methodListDocD (map (fmap 
     (\(MthD b _ d) -> (d,b))) ms)) (if (any (not . isEmpty . fst . unCPPSC) cs 
     || (all (isEmpty . fst . unCPPSC) cs && not (null l))) && 

--- a/code/drasil-code/Language/Drasil/Code/Imperative/LanguageRenderer/NewJavaRenderer.hs
+++ b/code/drasil-code/Language/Drasil/Code/Imperative/LanguageRenderer/NewJavaRenderer.hs
@@ -69,7 +69,8 @@ instance Monad JavaCode where
 
 instance PackageSym JavaCode where
   type Package JavaCode = ([ModData], Label)
-  packMods n ms = liftPairFst (mapM (liftA2 (packageDocD n) endStatement) ms, n)
+  packMods n ms = liftPairFst (mapM (liftA2 (packageDocD n) endStatement) mods, n)
+    where mods = filter (not . isEmpty . modDoc . unJC) ms
 
 instance RenderSym JavaCode where
   type RenderFile JavaCode = ModData

--- a/code/drasil-code/Language/Drasil/Code/Imperative/LanguageRenderer/NewJavaRenderer.hs
+++ b/code/drasil-code/Language/Drasil/Code/Imperative/LanguageRenderer/NewJavaRenderer.hs
@@ -564,9 +564,7 @@ instance ClassSym JavaCode where
 instance ModuleSym JavaCode where
   type Module JavaCode = ModData
   buildModule n _ vs ms cs = fmap (md n (any (snd . unJC) ms || 
-    any (snd . unJC) cs)) (if all (isEmpty . fst . unJC) cs && all 
-    (isEmpty . fst . unJC) ms then return empty else 
-    liftList moduleDocD (if null vs && null ms then cs 
+    any (snd . unJC) cs)) (liftList moduleDocD (if null vs && null ms then cs 
     else pubClass n Nothing (map (liftA4 statementsToStateVars public static_
     endStatement) vs) ms : cs))
 

--- a/code/drasil-code/Language/Drasil/Code/Imperative/LanguageRenderer/NewPythonRenderer.hs
+++ b/code/drasil-code/Language/Drasil/Code/Imperative/LanguageRenderer/NewPythonRenderer.hs
@@ -55,7 +55,8 @@ instance Monad PythonCode where
 
 instance PackageSym PythonCode where
   type Package PythonCode = ([ModData], Label)
-  packMods n ms = liftPairFst (sequence ms, n)
+  packMods n ms = liftPairFst (sequence mods, n)
+    where mods = filter (not . isEmpty . modDoc . unPC) ms
 
 instance RenderSym PythonCode where
   type RenderFile PythonCode = ModData

--- a/code/drasil-code/Language/Drasil/Code/Imperative/LanguageRenderer/NewPythonRenderer.hs
+++ b/code/drasil-code/Language/Drasil/Code/Imperative/LanguageRenderer/NewPythonRenderer.hs
@@ -513,7 +513,9 @@ instance ClassSym PythonCode where
 instance ModuleSym PythonCode where
   type Module PythonCode = ModData
   buildModule n ls vs fs cs = fmap (md n (any (snd . unPC) fs || 
-    any (snd . unPC) cs)) (liftA4 pyModule (liftList pyModuleImportList (map 
+    any (snd . unPC) cs)) (if all (isEmpty . fst . unPC) cs && all 
+    (isEmpty . fst . unPC) fs then return empty else
+    liftA4 pyModule (liftList pyModuleImportList (map 
     include ls)) (liftList pyModuleVarList (map state vs)) (liftList 
     methodListDocD fs) (liftList pyModuleClassList cs))
 

--- a/code/drasil-code/Language/Drasil/Code/Imperative/LanguageRenderer/NewPythonRenderer.hs
+++ b/code/drasil-code/Language/Drasil/Code/Imperative/LanguageRenderer/NewPythonRenderer.hs
@@ -513,9 +513,7 @@ instance ClassSym PythonCode where
 instance ModuleSym PythonCode where
   type Module PythonCode = ModData
   buildModule n ls vs fs cs = fmap (md n (any (snd . unPC) fs || 
-    any (snd . unPC) cs)) (if all (isEmpty . fst . unPC) cs && all 
-    (isEmpty . fst . unPC) fs then return empty else 
-    liftA4 pyModule (liftList pyModuleImportList (map 
+    any (snd . unPC) cs)) (liftA4 pyModule (liftList pyModuleImportList (map 
     include ls)) (liftList pyModuleVarList (map state vs)) (liftList 
     methodListDocD fs) (liftList pyModuleClassList cs))
 


### PR DESCRIPTION
My last PR about this succeeded in making modules empty if they had no functions/classes, but I realized an empty file would still be generated. This PR makes it so that empty files do not get generated.