### PR TITLE
More code generation de-hardcoding and consistency improvements

### DIFF
--- a/code/drasil-code/Language/Drasil/CodeSpec.hs
+++ b/code/drasil-code/Language/Drasil/CodeSpec.hs
@@ -359,12 +359,12 @@ getExportOutput [] = []
 getExportOutput _ = [("write_output", "OutputFormat")]
 
 getDepsControl :: ModExportMap -> [Def] -> [String]
-getDepsControl mem eo = let dv = Map.lookup "derived_values" mem
+getDepsControl mem eo = let inf = Map.lookup (funcPrefix ++ "get_input") mem
+                            dv = Map.lookup "derived_values" mem
                             ic = Map.lookup "input_constraints" mem
                             wo = Map.lookup "write_output" mem
                             calcs = map (\x -> Map.lookup (codeName x) mem) eo
-  in nub $ catMaybes ([dv, ic, wo] ++ calcs) ++ ["InputParameters",
-                                                 "InputFormat"]
+  in nub $ catMaybes ([inf, dv, ic, wo] ++ calcs) ++ ["InputParameters"]
 
 subsetOf :: (Eq a) => [a] -> [a] -> Bool
 xs `subsetOf` ys = all (`elem` ys) xs

--- a/code/drasil-code/Language/Drasil/CodeSpec.hs
+++ b/code/drasil-code/Language/Drasil/CodeSpec.hs
@@ -92,7 +92,7 @@ codeSpec SI {_sys = sys
       rels = map qtoc (defs' ++ map qdFromDD ddefs) \\ derived
       mods' = prefixFunctions $ packmod "Calculations" (map FCD exOrder) : ms 
       conMap = constraintMap cs
-      mem   = modExportMap chs conMap mods' inputs' const' derived
+      mem   = modExportMap chs conMap mods' inputs' const' derived outs'
       outs' = map codevar outs
       allInputs = nub $ inputs' ++ map codevar derived
       exOrder = getExecOrder rels (allInputs ++ map codevar const') outs' db
@@ -236,14 +236,14 @@ asVC' (FCD cd) = vc'' cd (codeSymb cd) (cd ^. typ)
 -- name of variable/function maps to module name
 type ModExportMap = Map.Map String String
 
-modExportMap :: Choices -> ConstraintMap -> [Mod] -> [Input] -> [Const] -> [Derived] -> ModExportMap
-modExportMap chs cm ms ins _ ds = Map.fromList $ concatMap mpair ms
+modExportMap :: Choices -> ConstraintMap -> [Mod] -> [Input] -> [Const] -> [Derived] -> [Output] -> ModExportMap
+modExportMap chs cm ms ins _ ds outs = Map.fromList $ concatMap mpair ms
   where mpair (Mod n fs) = map fname fs `zip` repeat n
                         ++ map codeName ins `zip` repeat "InputParameters"
                         ++ getExportDerived chs ds
                         ++ getExportConstraints chs (getConstraints cm 
                           (ins ++ map codevar ds))
-                        ++ [ ("write_output", "OutputFormat") ]  -- hardcoded for now
+                        ++ getExportOutput outs
                      --   ++ map codeName consts `zip` repeat "Constants"
                      -- inlining constants for now
           
@@ -354,13 +354,17 @@ getExportConstraints chs _ = [("input_constraints", cMod $ inputStructure chs)]
   where cMod Loose = "InputParameters"
         cMod AsClass = "InputConstraints"
 
+getExportOutput :: [Output] -> [Export]
+getExportOutput [] = []
+getExportOutput _ = [("write_output", "OutputFormat")]
+
 getDepsControl :: ModExportMap -> [Def] -> [String]
 getDepsControl mem eo = let dv = Map.lookup "derived_values" mem
                             ic = Map.lookup "input_constraints" mem
+                            wo = Map.lookup "write_output" mem
                             calcs = map (\x -> Map.lookup (codeName x) mem) eo
-  in nub $ catMaybes ([dv, ic] ++ calcs) ++ ["InputParameters",
-                                             "InputFormat",
-                                             "OutputFormat"]
+  in nub $ catMaybes ([dv, ic, wo] ++ calcs) ++ ["InputParameters",
+                                                 "InputFormat"]
 
 subsetOf :: (Eq a) => [a] -> [a] -> Bool
 xs `subsetOf` ys = all (`elem` ys) xs

--- a/code/stable/glassbr/src/cpp/Control.cpp
+++ b/code/stable/glassbr/src/cpp/Control.cpp
@@ -15,10 +15,10 @@ using std::ofstream;
 
 #include "DerivedValues.hpp"
 #include "InputConstraints.hpp"
+#include "OutputFormat.hpp"
 #include "Calculations.hpp"
 #include "InputParameters.hpp"
 #include "InputFormat.hpp"
-#include "OutputFormat.hpp"
 
 int main(int argc, const char *argv[]) {
     string inputfile = argv[1];

--- a/code/stable/glassbr/src/cpp/Control.cpp
+++ b/code/stable/glassbr/src/cpp/Control.cpp
@@ -13,12 +13,12 @@ using std::vector;
 using std::ifstream;
 using std::ofstream;
 
+#include "InputFormat.hpp"
 #include "DerivedValues.hpp"
 #include "InputConstraints.hpp"
 #include "OutputFormat.hpp"
 #include "Calculations.hpp"
 #include "InputParameters.hpp"
-#include "InputFormat.hpp"
 
 int main(int argc, const char *argv[]) {
     string inputfile = argv[1];

--- a/code/stable/glassbr/src/python/Control.py
+++ b/code/stable/glassbr/src/python/Control.py
@@ -4,10 +4,10 @@ import math
 
 import DerivedValues
 import InputConstraints
+import OutputFormat
 import Calculations
 import InputParameters
 import InputFormat
-import OutputFormat
 
 inputfile = sys.argv[1]
 inParams = InputParameters.InputParameters()

--- a/code/stable/glassbr/src/python/Control.py
+++ b/code/stable/glassbr/src/python/Control.py
@@ -2,12 +2,12 @@ from __future__ import print_function
 import sys
 import math
 
+import InputFormat
 import DerivedValues
 import InputConstraints
 import OutputFormat
 import Calculations
 import InputParameters
-import InputFormat
 
 inputfile = sys.argv[1]
 inParams = InputParameters.InputParameters()

--- a/code/stable/nopcm/src/cpp/Control.cpp
+++ b/code/stable/nopcm/src/cpp/Control.cpp
@@ -13,14 +13,14 @@ using std::vector;
 using std::ifstream;
 using std::ofstream;
 
+#include "InputFormat.hpp"
 #include "InputParameters.hpp"
 #include "OutputFormat.hpp"
-#include "InputFormat.hpp"
 
 int main(int argc, const char *argv[]) {
     string inputfile = argv[1];
     InputParameters inParams = InputParameters();
-    func_get_input(inputfile, inParams);
+    func_get_input(inputfile, A_C, C_W, h_C, T_init, t_final, L, T_C, t_step, rho_W, D, A_tol, R_tol, T_W, E_W);
     input_constraints(A_C, C_W, h_C, T_init, t_final, L, T_C, t_step, rho_W, D, T_W, E_W);
     write_output(T_W, E_W);
     return 0;

--- a/code/stable/nopcm/src/cpp/Control.cpp
+++ b/code/stable/nopcm/src/cpp/Control.cpp
@@ -14,8 +14,8 @@ using std::ifstream;
 using std::ofstream;
 
 #include "InputParameters.hpp"
-#include "InputFormat.hpp"
 #include "OutputFormat.hpp"
+#include "InputFormat.hpp"
 
 int main(int argc, const char *argv[]) {
     string inputfile = argv[1];

--- a/code/stable/nopcm/src/csharp/Control.cs
+++ b/code/stable/nopcm/src/csharp/Control.cs
@@ -8,7 +8,7 @@ public class Control {
     public static void Main(string[] args) {
         string inputfile = args[0];
         InputParameters inParams = new InputParameters();
-        InputFormat.func_get_input(inputfile, inParams);
+        InputFormat.func_get_input(inputfile, A_C, C_W, h_C, T_init, t_final, L, T_C, t_step, rho_W, D, A_tol, R_tol, T_W, E_W);
         InputParameters.input_constraints(A_C, C_W, h_C, T_init, t_final, L, T_C, t_step, rho_W, D, T_W, E_W);
         OutputFormat.write_output(T_W, E_W);
     }

--- a/code/stable/nopcm/src/java/SWHS/Control.java
+++ b/code/stable/nopcm/src/java/SWHS/Control.java
@@ -13,7 +13,7 @@ public class Control {
     public static void main(String[] args) throws Exception {
         String inputfile = args[0];
         InputParameters inParams = new InputParameters();
-        InputFormat.func_get_input(inputfile, inParams);
+        InputFormat.func_get_input(inputfile, A_C, C_W, h_C, T_init, t_final, L, T_C, t_step, rho_W, D, A_tol, R_tol, T_W, E_W);
         InputParameters.input_constraints(A_C, C_W, h_C, T_init, t_final, L, T_C, t_step, rho_W, D, T_W, E_W);
         OutputFormat.write_output(T_W, E_W);
     }

--- a/code/stable/nopcm/src/python/Control.py
+++ b/code/stable/nopcm/src/python/Control.py
@@ -3,8 +3,8 @@ import sys
 import math
 
 import InputParameters
-import InputFormat
 import OutputFormat
+import InputFormat
 
 inputfile = sys.argv[1]
 inParams = InputParameters.InputParameters()

--- a/code/stable/nopcm/src/python/Control.py
+++ b/code/stable/nopcm/src/python/Control.py
@@ -2,13 +2,13 @@ from __future__ import print_function
 import sys
 import math
 
+import InputFormat
 import InputParameters
 import OutputFormat
-import InputFormat
 
 inputfile = sys.argv[1]
 inParams = InputParameters.InputParameters()
-InputFormat.func_get_input(inputfile, inParams)
+InputFormat.func_get_input(inputfile, A_C, C_W, h_C, T_init, t_final, L, T_C, t_step, rho_W, D, A_tol, R_tol, T_W, E_W)
 InputParameters.input_constraints(A_C, C_W, h_C, T_init, t_final, L, T_C, t_step, rho_W, D, T_W, E_W)
 OutputFormat.write_output(T_W, E_W)
 


### PR DESCRIPTION
For the get_input function, I could not do all of the improvements that I've done for the other functions because, unlike the others, get_input is defined explicitly in Drasil and then passed to the code generator. Eventually we will need to generate our input format reading just from the inputs and `Choices`, because sometimes we don't even want it to be a function (for example if the `Loose` input structure is chosen), but that will be a bigger change that will come later. For now, I've made get_input consistent with the others as far as I could, which allowed me to remove the old `fApp` function and replace it with the new one.

This PR is dependent on #1556. That PR should be merged first.