### PR TITLE
Add Missing Quotes to deploy_stage.sh

### DIFF
--- a/code/scripts/deploy_stage.sh
+++ b/code/scripts/deploy_stage.sh
@@ -51,7 +51,7 @@ copy_graphs() {
 copy_examples() {
 	rm -r "$EXAMPLE_DEST"
 	for example in "$CUR_DIR$BUILD_FOLDER"*; do
-		example_name=$(basename $example)
+		example_name=$(basename "$example")
 		mkdir -p "$EXAMPLE_DEST$example_name/$SRS_DEST"
 		if [ -d "$example/"SRS ]; then
 			cp "$example/"SRS/*.pdf "$EXAMPLE_DEST$example_name/$SRS_DEST"


### PR DESCRIPTION
This PR fixes [folder names being prepended to example names when there is a space in a folder along `$PWD`](https://github.com/JacquesCarette/Drasil/issues/1527#issuecomment-502219286) in #1527.