### PR TITLE
Update `stack path` in deploy to work with Stack 2.1.1.

### DIFF
--- a/code/scripts/deploy_stage.sh
+++ b/code/scripts/deploy_stage.sh
@@ -30,7 +30,7 @@ CUR_DIR="$PWD/"
 
 
 copy_docs() {
-  DOC_DIR=$(stack path | grep local-doc-root | cut -d":" -f2 | sed -e "s/^ //")/
+  DOC_DIR=$(cd "$CUR_DIR" && stack path --local-doc-root)/
   rm -r "$DOC_DEST" >/dev/null 2>&1  # Printing an error message that a directory doesn't exist isn't the most useful.
   mkdir -p "$DOC_DEST"
   cp -r "$DOC_DIR". "$DOC_DEST"


### PR DESCRIPTION
This PR addresses a small issue which arose from Stack 2.1.1. 

The deploy process queries Stack on where to locate the generated Haddock documentation so it can be copied out. This can be done with `stack path` or more specifically `stack path --local-doc-root`. 

In Stack 1.9.3 this can be thought of a `const` function in Haskell (ex. `~/.stack-work/install/x86_64-osx/lts-12.25/8.4.4/doc`). Whereas 2.1.1 makes the paths dependent on the current package (i.e. the closest `stack.yaml` located from the current folder up to the root. Part of the path now includes a hash of some "stuff" (the stuff isn't exactly important, more that it's unique value per-package) creating something such as `~/.stack-work/install/x86_64-linux/1909af6e8860c20f547661cc4672abee7bf8cf3c34948432ed2c47f65e78f513/8.4.4/doc`. 

The CI process downloads and uses the most recent version of Stack so when 2.1.1 was released (in the past few days), the CD process began to have an incorrect path returned because the package directory where `stack path` is queried is not the main `code` folder returning a different hash and thus failing to copy the docs to the deploy folder. 