### PR TITLE
Update DOC_DIR to check both possible doc paths.

### DIFF
--- a/code/scripts/deploy_stage.sh
+++ b/code/scripts/deploy_stage.sh
@@ -30,7 +30,13 @@ CUR_DIR="$PWD/"
 
 
 copy_docs() {
+  # The doc directory can be in two locations (as of Stack 2.1.1) depending on which arguments are
+  # passed to `stack haddock`. The first directory is when no arguments are specified. The second
+  # is used when `--no-haddock-deps` is passed as an argument.
   DOC_DIR=$(cd "$CUR_DIR" && stack path --local-doc-root)/
+  if [ ! -d "$DOC_DIR" ]; then
+    DOC_DIR=$(cd "$CUR_DIR" && stack path --local-install-root)/doc/
+  fi
   rm -r "$DOC_DEST" >/dev/null 2>&1  # Printing an error message that a directory doesn't exist isn't the most useful.
   mkdir -p "$DOC_DEST"
   cp -r "$DOC_DIR". "$DOC_DEST"


### PR DESCRIPTION
This should really resolve docs not showing in continuous deploy. The previous PR was correct to change the path, however, Stack 2.1.1, for some unknown reason (although verified that it is actually happening by digging through the source), has two docs paths. 

Running `stack haddock` with most arguments (or absence of) usually creates the documentation in `local-doc-root`, however, if `--no-haddock-deps` is specified, haddock builds the documentation in `local-install-root`/doc. I haven't dug far enough into the Stack source to pinpoint the exact reason, but if you run `stack path` locally with Stack 2.1.1, you should see the first three entry paths include one hash, while most of the rest contain another hash. The first three are constructs based on one configuration taking constructor `UseHaddocks` while the rest use `WithoutHaddocks`. Why `--no-haddock-deps` causes an output path change is unknown to me, but I have a feeling it is related to the `UseHaddocks`/`WithoutHaddocks` specification.