### PR TITLE
[Small PR] Fixed display of Perc for Expr

### DIFF
--- a/code/drasil-printers/Language/Drasil/Printing/Import.hs
+++ b/code/drasil-printers/Language/Drasil/Printing/Import.hs
@@ -90,17 +90,17 @@ expr (Dbl d)           sm = case sm ^. getSetting of
   Engineering -> P.Row $ digitsProcess (map toInteger $ fst $ floatToDigits 10 d)
      (fst $ processExpo $ snd $ floatToDigits 10 d) 0
      (toInteger $ snd $ processExpo $ snd $ floatToDigits 10 d)
-  Scientific           ->  P.Dbl d
+  Scientific  ->  P.Dbl d
 expr (Int i)            _ = P.Int i
 expr (Str s)            _ = P.Str s
-expr (Perc a b)         _ = P.Row [P.Dbl val, P.MO P.Perc]
+expr (Perc a b)        sm = P.Row [expr (Dbl val) sm, P.MO P.Perc]
   where
     val = fromIntegral a / (10 ** fromIntegral (b - 2))
 expr (AssocB And l)    sm = P.Row $ intersperse (P.MO P.And) $ map (expr' sm (precB And)) l
 expr (AssocB Or l)     sm = P.Row $ intersperse (P.MO P.Or ) $ map (expr' sm (precB Or)) l
 expr (AssocA Add l)    sm = P.Row $ intersperse (P.MO P.Add) $ map (expr' sm (precA Add)) l
 expr (AssocA Mul l)    sm = P.Row $ mulExpr l sm
-expr (Deriv Part a b) sm =
+expr (Deriv Part a b)  sm =
   P.Div (P.Row [P.Spec Partial, P.Spc P.Thin, expr a sm])
         (P.Row [P.Spec Partial, P.Spc P.Thin,
                 symbol $ eqSymb $ symbLookup b $ symbolTable $ sm ^. ckdb])

--- a/code/stable/nopcm/SRS/NoPCM_SRS.tex
+++ b/code/stable/nopcm/SRS/NoPCM_SRS.tex
@@ -814,7 +814,7 @@ Symbol & Description & Value & Unit
 \endhead
 ${{A_{C}}^{max}}$ & maximum surface area of coil & $100000$ & $\text{m}^{2}$
 \\
-${C_{tol}}$ & relative tolerance for conservation of energy & $1.0e-3\%$ & --
+${C_{tol}}$ & relative tolerance for conservation of energy & $0.001\%$ & --
 \\
 ${{C_{W}}^{max}}$ & maximum specific heat capacity of water & $4210$ & $\frac{\text{J}}{(\text{kg}{}^{\circ}\text{C})}$
 \\

--- a/code/stable/nopcm/Website/NoPCM_SRS.html
+++ b/code/stable/nopcm/Website/NoPCM_SRS.html
@@ -2231,7 +2231,7 @@
             <tr>
               <td><em>C<sub>tol</sub></em></td>
               <td>relative tolerance for conservation of energy</td>
-              <td><em>1.0e-3%</em></td>
+              <td><em>0.001%</em></td>
               <td>--</td>
             </tr>
             <tr>

--- a/code/stable/swhs/SRS/SWHS_SRS.tex
+++ b/code/stable/swhs/SRS/SWHS_SRS.tex
@@ -1329,7 +1329,7 @@ Symbol & Description & Value & Unit
 \endhead
 ${{A_{C}}^{max}}$ & maximum surface area of coil & $100000$ & $\text{m}^{2}$
 \\
-${C_{tol}}$ & relative tolerance for conservation of energy & $1.0e-3\%$ & --
+${C_{tol}}$ & relative tolerance for conservation of energy & $0.001\%$ & --
 \\
 ${{C_{W}}^{max}}$ & maximum specific heat capacity of water & $4210$ & $\frac{\text{J}}{(\text{kg}{}^{\circ}\text{C})}$
 \\

--- a/code/stable/swhs/Website/SWHS_SRS.html
+++ b/code/stable/swhs/Website/SWHS_SRS.html
@@ -4563,7 +4563,7 @@
             <tr>
               <td><em>C<sub>tol</sub></em></td>
               <td>relative tolerance for conservation of energy</td>
-              <td><em>1.0e-3%</em></td>
+              <td><em>0.001%</em></td>
               <td>--</td>
             </tr>
             <tr>


### PR DESCRIPTION
As per #1575, the `Dbl` portion of a `Perc` is now displayed properly.