### PR TITLE
Implemented TypeData instead of pair for types in GOOL

### DIFF
--- a/code/drasil-code/Language/Drasil/Code/Imperative/Helpers.hs
+++ b/code/drasil-code/Language/Drasil/Code/Imperative/Helpers.hs
@@ -2,12 +2,13 @@
 
 module Language.Drasil.Code.Imperative.Helpers (Pair(..), Terminator (..),
   ScopeTag(..), ModData(..), md, MethodData(..), mthd, StateVarData(..), svd,
-  blank,verticalComma, angles,doubleQuotedText,himap,hicat,vicat,vibcat,vmap,
+  TypeData(..), td, blank,verticalComma, angles,doubleQuotedText,himap,hicat,vicat,vibcat,vmap,
   vimap,vibmap, mapPairFst, mapPairSnd, liftA4, liftA5, liftA6, liftA7, liftA8, 
   liftList, lift2Lists, lift1List, liftPair, lift3Pair, lift4Pair, liftPairFst,
   liftPairSnd
 ) where
 
+import Language.Drasil.Code.Code (CodeType)
 import Language.Drasil.Code.Imperative.Symantics (Label)
 
 import Prelude hiding ((<>))
@@ -41,6 +42,11 @@ data StateVarData = SVD {getStVarScp :: ScopeTag, stVarDoc :: Doc,
 
 svd :: ScopeTag -> Doc -> (Doc, Terminator) -> StateVarData
 svd = SVD
+
+data TypeData = TD {cType :: CodeType, typeDoc :: Doc}
+
+td :: CodeType -> Doc -> TypeData
+td = TD
 
 blank :: Doc
 blank = text ""

--- a/code/drasil-code/Language/Drasil/Code/Imperative/LanguageRenderer.hs
+++ b/code/drasil-code/Language/Drasil/Code/Imperative/LanguageRenderer.hs
@@ -38,7 +38,7 @@ import Utils.Drasil (capitalize, indent, indentList)
 import Language.Drasil.Code.Code (CodeType(..))
 import Language.Drasil.Code.Imperative.Symantics (Label, Library)
 import Language.Drasil.Code.Imperative.Helpers (Terminator(..), ModData(..), md,
-  angles,blank, doubleQuotedText,hicat,vibcat,vmap)
+  TypeData(..), td, angles,blank, doubleQuotedText,hicat,vibcat,vmap)
 
 import Data.List (intersperse, last)
 import Prelude hiding (break,print,return,last,mod,(<>))
@@ -150,29 +150,29 @@ printFileDocD fn (f, _) = f <> dot <> text fn
 
 -- Type Printers --
 
-boolTypeDocD :: (Doc, CodeType)
-boolTypeDocD = (text "Boolean", Boolean) -- capital B?
+boolTypeDocD :: TypeData
+boolTypeDocD = td Boolean (text "Boolean") -- capital B?
 
-intTypeDocD :: (Doc, CodeType)
-intTypeDocD = (text "int", Integer)
+intTypeDocD :: TypeData
+intTypeDocD = td Integer (text "int")
 
-floatTypeDocD :: (Doc, CodeType)
-floatTypeDocD = (text "float", Float)
+floatTypeDocD :: TypeData
+floatTypeDocD = td Float (text "float")
 
-charTypeDocD :: (Doc, CodeType)
-charTypeDocD = (text "char", Char)
+charTypeDocD :: TypeData
+charTypeDocD = td Char (text "char")
 
-stringTypeDocD :: (Doc, CodeType)
-stringTypeDocD = (text "string", String)
+stringTypeDocD :: TypeData
+stringTypeDocD = td String (text "string")
 
-fileTypeDocD :: (Doc, CodeType)
-fileTypeDocD = (text "File", File)
+fileTypeDocD :: TypeData
+fileTypeDocD = td File (text "File")
 
-typeDocD :: Label -> (Doc, CodeType)
-typeDocD t = (text t, Object t)
+typeDocD :: Label -> TypeData
+typeDocD t = td (Object t) (text t)
 
-listTypeDocD :: (Doc, CodeType) -> Doc -> (Doc, CodeType)
-listTypeDocD (td, t) list = (list <> angles td, List t)
+listTypeDocD :: TypeData -> Doc -> TypeData
+listTypeDocD (TD t tdoc) list = td (List t) (list <> angles tdoc)
 
 -- Method Types --
 
@@ -184,8 +184,8 @@ constructDocD _ = empty
 
 -- Parameters --
 
-stateParamDocD :: Label -> (Doc, CodeType) -> Doc
-stateParamDocD n (t, _) = t <+> text n
+stateParamDocD :: Label -> TypeData -> Doc
+stateParamDocD n (TD _ t) = t <+> text n
 
 paramListDocD :: [Doc] -> Doc
 paramListDocD = hicat (text ", ")
@@ -204,8 +204,8 @@ methodListDocD ms = vibcat methods
 
 -- StateVar --
 
-stateVarDocD :: Label -> Doc -> Doc -> (Doc, CodeType) -> Doc -> Doc
-stateVarDocD l s p (t, _) end = s <+> p <+> t <+> text l <> end
+stateVarDocD :: Label -> Doc -> Doc -> TypeData -> Doc -> Doc
+stateVarDocD l s p (TD _ t) end = s <+> p <+> t <+> text l <> end
 
 stateVarListDocD :: [Doc] -> Doc
 stateVarListDocD = vcat
@@ -265,9 +265,9 @@ forDocD blockStart blockEnd sInit (vGuard, _) sUpdate b = vcat [
   indent b,
   blockEnd]
 
-forEachDocD :: Label -> Doc -> Doc -> Doc -> Doc -> (Doc, CodeType) -> 
+forEachDocD :: Label -> Doc -> Doc -> Doc -> Doc -> TypeData -> 
   (Doc, Maybe String) -> Doc -> Doc
-forEachDocD l blockStart blockEnd iterForEachLabel iterInLabel (t, _) (v, _) b =
+forEachDocD l blockStart blockEnd iterForEachLabel iterInLabel (TD _ t) (v, _) b =
   vcat [iterForEachLabel <+> parens (t <+> text l <+> iterInLabel <+> v) <+>
     blockStart,
   indent b,
@@ -310,24 +310,24 @@ plusPlusDocD (v, _) = v <> text "++"
 plusPlusDocD' :: (Doc, Maybe String) -> Doc -> Doc
 plusPlusDocD' (v, _) plusOp = v <+> equals <+> v <+> plusOp <+> int 1
 
-varDecDocD :: Label -> (Doc, CodeType) -> Doc
-varDecDocD l (st, _) = st <+> text l
+varDecDocD :: Label -> TypeData -> Doc
+varDecDocD l (TD _ st) = st <+> text l
 
-varDecDefDocD :: Label -> (Doc, CodeType) -> (Doc, Maybe String) -> Doc
-varDecDefDocD l (st, _) (v, _) = st <+> text l <+> equals <+> v
+varDecDefDocD :: Label -> TypeData -> (Doc, Maybe String) -> Doc
+varDecDefDocD l (TD _ st) (v, _) = st <+> text l <+> equals <+> v
 
-listDecDocD :: Label -> (Doc, Maybe String) -> (Doc, CodeType) -> Doc
-listDecDocD l (n, _) (st, _) = st <+> text l <+> equals <+> new <+> st <> parens n
+listDecDocD :: Label -> (Doc, Maybe String) -> TypeData -> Doc
+listDecDocD l (n, _) (TD _ st) = st <+> text l <+> equals <+> new <+> st <> parens n
 
-listDecDefDocD :: Label -> (Doc, CodeType) -> [(Doc, Maybe String)] -> Doc
-listDecDefDocD l (st, _) vs = st <+> text l <+> equals <+> new <+> st <+> 
+listDecDefDocD :: Label -> TypeData -> [(Doc, Maybe String)] -> Doc
+listDecDefDocD l (TD _ st) vs = st <+> text l <+> equals <+> new <+> st <+> 
   braces (callFuncParamList vs)
 
-objDecDefDocD :: Label -> (Doc, CodeType) -> (Doc, Maybe String) -> Doc
+objDecDefDocD :: Label -> TypeData -> (Doc, Maybe String) -> Doc
 objDecDefDocD = varDecDefDocD
 
-constDecDefDocD :: Label -> (Doc, CodeType) -> (Doc, Maybe String) -> Doc -- can this be done without StateType (infer from value)?
-constDecDefDocD l (st, _) (v, _) = text "const" <+> st <+> text l <+> equals <+> v
+constDecDefDocD :: Label -> TypeData -> (Doc, Maybe String) -> Doc -- can this be done without StateType (infer from value)?
+constDecDefDocD l (TD _ st) (v, _) = text "const" <+> st <+> text l <+> equals <+> v
 
 returnDocD :: (Doc, Maybe String) -> Doc
 returnDocD (v, _) = text "return" <+> v
@@ -560,11 +560,11 @@ funcAppDocD n vs = text n <> parens (callFuncParamList vs)
 extFuncAppDocD :: Library -> Label -> [(Doc, Maybe String)] -> Doc
 extFuncAppDocD l n = funcAppDocD (l ++ "." ++ n)
 
-stateObjDocD :: (Doc, CodeType) -> Doc -> Doc
-stateObjDocD (st, _) vs = new <+> st <> parens vs
+stateObjDocD :: TypeData -> Doc -> Doc
+stateObjDocD (TD _ st) vs = new <+> st <> parens vs
 
-listStateObjDocD :: Doc -> (Doc, CodeType) -> Doc -> Doc
-listStateObjDocD lstObj (st, _) vs = lstObj <+> st <> parens vs
+listStateObjDocD :: Doc -> TypeData -> Doc -> Doc
+listStateObjDocD lstObj (TD _ st) vs = lstObj <+> st <> parens vs
 
 notNullDocD :: Doc -> (Doc, Maybe String) -> (Doc, Maybe String) -> Doc
 notNullDocD = binOpDocD
@@ -578,8 +578,8 @@ listIndexExistsDocD greater (lst, _) (index, _) = parens (lst <>
 funcDocD :: (Doc, Maybe String) -> Doc
 funcDocD (fnApp, _) = dot <> fnApp
 
-castDocD :: (Doc, CodeType) -> Doc
-castDocD (t, _) = parens t
+castDocD :: TypeData -> Doc
+castDocD (TD _ t) = parens t
 
 sizeDocD :: Doc
 sizeDocD = dot <> text "Count"

--- a/code/drasil-code/Language/Drasil/Code/Imperative/LanguageRenderer.hs
+++ b/code/drasil-code/Language/Drasil/Code/Imperative/LanguageRenderer.hs
@@ -172,7 +172,7 @@ typeDocD :: Label -> TypeData
 typeDocD t = td (Object t) (text t)
 
 listTypeDocD :: TypeData -> Doc -> TypeData
-listTypeDocD (TD t tdoc) list = td (List t) (list <> angles tdoc)
+listTypeDocD t list = td (List (cType t)) (list <> angles (typeDoc t))
 
 -- Method Types --
 
@@ -185,7 +185,7 @@ constructDocD _ = empty
 -- Parameters --
 
 stateParamDocD :: Label -> TypeData -> Doc
-stateParamDocD n (TD _ t) = t <+> text n
+stateParamDocD n t = typeDoc t <+> text n
 
 paramListDocD :: [Doc] -> Doc
 paramListDocD = hicat (text ", ")
@@ -205,7 +205,7 @@ methodListDocD ms = vibcat methods
 -- StateVar --
 
 stateVarDocD :: Label -> Doc -> Doc -> TypeData -> Doc -> Doc
-stateVarDocD l s p (TD _ t) end = s <+> p <+> t <+> text l <> end
+stateVarDocD l s p t end = s <+> p <+> typeDoc t <+> text l <> end
 
 stateVarListDocD :: [Doc] -> Doc
 stateVarListDocD = vcat
@@ -267,8 +267,8 @@ forDocD blockStart blockEnd sInit (vGuard, _) sUpdate b = vcat [
 
 forEachDocD :: Label -> Doc -> Doc -> Doc -> Doc -> TypeData -> 
   (Doc, Maybe String) -> Doc -> Doc
-forEachDocD l blockStart blockEnd iterForEachLabel iterInLabel (TD _ t) (v, _) b =
-  vcat [iterForEachLabel <+> parens (t <+> text l <+> iterInLabel <+> v) <+>
+forEachDocD l blockStart blockEnd iterForEachLabel iterInLabel t (v, _) b =
+  vcat [iterForEachLabel <+> parens (typeDoc t <+> text l <+> iterInLabel <+> v) <+>
     blockStart,
   indent b,
   blockEnd]
@@ -311,23 +311,25 @@ plusPlusDocD' :: (Doc, Maybe String) -> Doc -> Doc
 plusPlusDocD' (v, _) plusOp = v <+> equals <+> v <+> plusOp <+> int 1
 
 varDecDocD :: Label -> TypeData -> Doc
-varDecDocD l (TD _ st) = st <+> text l
+varDecDocD l st = typeDoc st <+> text l
 
 varDecDefDocD :: Label -> TypeData -> (Doc, Maybe String) -> Doc
-varDecDefDocD l (TD _ st) (v, _) = st <+> text l <+> equals <+> v
+varDecDefDocD l st (v, _) = typeDoc st <+> text l <+> equals <+> v
 
 listDecDocD :: Label -> (Doc, Maybe String) -> TypeData -> Doc
-listDecDocD l (n, _) (TD _ st) = st <+> text l <+> equals <+> new <+> st <> parens n
+listDecDocD l (n, _) st = typeDoc st <+> text l <+> equals <+> new <+> 
+  typeDoc st <> parens n
 
 listDecDefDocD :: Label -> TypeData -> [(Doc, Maybe String)] -> Doc
-listDecDefDocD l (TD _ st) vs = st <+> text l <+> equals <+> new <+> st <+> 
-  braces (callFuncParamList vs)
+listDecDefDocD l st vs = typeDoc st <+> text l <+> equals <+> new <+> 
+  typeDoc st <+> braces (callFuncParamList vs)
 
 objDecDefDocD :: Label -> TypeData -> (Doc, Maybe String) -> Doc
 objDecDefDocD = varDecDefDocD
 
 constDecDefDocD :: Label -> TypeData -> (Doc, Maybe String) -> Doc -- can this be done without StateType (infer from value)?
-constDecDefDocD l (TD _ st) (v, _) = text "const" <+> st <+> text l <+> equals <+> v
+constDecDefDocD l st (v, _) = text "const" <+> typeDoc st <+> text l <+> 
+  equals <+> v
 
 returnDocD :: (Doc, Maybe String) -> Doc
 returnDocD (v, _) = text "return" <+> v
@@ -561,10 +563,10 @@ extFuncAppDocD :: Library -> Label -> [(Doc, Maybe String)] -> Doc
 extFuncAppDocD l n = funcAppDocD (l ++ "." ++ n)
 
 stateObjDocD :: TypeData -> Doc -> Doc
-stateObjDocD (TD _ st) vs = new <+> st <> parens vs
+stateObjDocD st vs = new <+> typeDoc st <> parens vs
 
 listStateObjDocD :: Doc -> TypeData -> Doc -> Doc
-listStateObjDocD lstObj (TD _ st) vs = lstObj <+> st <> parens vs
+listStateObjDocD lstObj st vs = lstObj <+> typeDoc st <> parens vs
 
 notNullDocD :: Doc -> (Doc, Maybe String) -> (Doc, Maybe String) -> Doc
 notNullDocD = binOpDocD
@@ -579,7 +581,7 @@ funcDocD :: (Doc, Maybe String) -> Doc
 funcDocD (fnApp, _) = dot <> fnApp
 
 castDocD :: TypeData -> Doc
-castDocD (TD _ t) = parens t
+castDocD t = parens $ typeDoc t
 
 sizeDocD :: Doc
 sizeDocD = dot <> text "Count"

--- a/code/drasil-code/Language/Drasil/Code/Imperative/LanguageRenderer/CSharpRenderer.hs
+++ b/code/drasil-code/Language/Drasil/Code/Imperative/LanguageRenderer/CSharpRenderer.hs
@@ -42,8 +42,8 @@ import Language.Drasil.Code.Imperative.LanguageRenderer (
   addCommentsDocD, callFuncParamList, getterName, setterName, setMain, setEmpty,
   statementsToStateVars)
 import Language.Drasil.Code.Imperative.Helpers (Terminator(..), ModData(..), md,
-  liftA4, liftA5, liftA6, liftA7, liftList, lift1List, lift3Pair, lift4Pair, 
-  liftPairFst)
+  TypeData(..), td, liftA4, liftA5, liftA6, liftA7, liftList, lift1List, 
+  lift3Pair, lift4Pair, liftPairFst)
 
 import Prelude hiding (break,print,(<>),sin,cos,tan,floor)
 import qualified Data.Map as Map (fromList,lookup)
@@ -123,7 +123,7 @@ instance BlockSym CSharpCode where
   block sts = lift1List blockDocD endStatement (map (fmap fst . state) sts)
 
 instance StateTypeSym CSharpCode where
-  type StateType CSharpCode = (Doc, CodeType)
+  type StateType CSharpCode = TypeData
   bool = return boolTypeDocD
   int = return intTypeDocD
   float = return csFloatTypeDoc
@@ -489,7 +489,7 @@ instance ScopeSym CSharpCode where
 
 instance MethodTypeSym CSharpCode where
   type MethodType CSharpCode = Doc
-  mState = fmap fst
+  mState = fmap typeDoc
   void = return voidDocD
   construct n = return $ constructDocD n
 
@@ -551,14 +551,14 @@ cstop end inc = vcat [
   inc <+> text "System.Collections" <> end,
   inc <+> text "System.Collections.Generic" <> end]
 
-csFloatTypeDoc :: (Doc, CodeType)
-csFloatTypeDoc = (text "double", Float) -- Same as Java, maybe make a common function
+csFloatTypeDoc :: TypeData
+csFloatTypeDoc = td Float (text "double") -- Same as Java, maybe make a common function
 
-csInfileTypeDoc :: (Doc, CodeType)
-csInfileTypeDoc = (text "StreamReader", File)
+csInfileTypeDoc :: TypeData
+csInfileTypeDoc = td File (text "StreamReader")
 
-csOutfileTypeDoc :: (Doc, CodeType)
-csOutfileTypeDoc = (text "StreamWriter", File)
+csOutfileTypeDoc :: TypeData
+csOutfileTypeDoc = td File (text "StreamWriter")
 
 csThrowDoc :: (Doc, Maybe String) -> Doc
 csThrowDoc (errMsg, _) = text "throw new" <+> text "Exception" <> parens errMsg
@@ -581,10 +581,10 @@ csInput it (v, _) (inFn, _) = v <+> equals <+> text it <> parens inFn
 csFileInput :: (Doc, Maybe String) -> (Doc, Maybe String)
 csFileInput (f, s) = (f <> dot <> text "ReadLine()", s)
 
-csOpenFileR :: (Doc, Maybe String) -> (Doc, Maybe String) -> (Doc, CodeType) -> Doc
-csOpenFileR (f, _) (n, _) (r, _) = f <+> equals <+> new <+> r <> parens n
+csOpenFileR :: (Doc, Maybe String) -> (Doc, Maybe String) -> TypeData -> Doc
+csOpenFileR (f, _) (n, _) (TD _ r) = f <+> equals <+> new <+> r <> parens n
 
-csOpenFileWorA :: (Doc, Maybe String) -> (Doc, Maybe String) -> (Doc, CodeType) 
+csOpenFileWorA :: (Doc, Maybe String) -> (Doc, Maybe String) -> TypeData 
   -> (Doc, Maybe String) -> Doc
-csOpenFileWorA (f, _) (n, _) (w, _) (a, _) = f <+> equals <+> new <+> w <> parens 
+csOpenFileWorA (f, _) (n, _) (TD _ w) (a, _) = f <+> equals <+> new <+> w <> parens 
   (n <> comma <+> a)

--- a/code/drasil-code/Language/Drasil/Code/Imperative/LanguageRenderer/CSharpRenderer.hs
+++ b/code/drasil-code/Language/Drasil/Code/Imperative/LanguageRenderer/CSharpRenderer.hs
@@ -582,9 +582,9 @@ csFileInput :: (Doc, Maybe String) -> (Doc, Maybe String)
 csFileInput (f, s) = (f <> dot <> text "ReadLine()", s)
 
 csOpenFileR :: (Doc, Maybe String) -> (Doc, Maybe String) -> TypeData -> Doc
-csOpenFileR (f, _) (n, _) (TD _ r) = f <+> equals <+> new <+> r <> parens n
+csOpenFileR (f, _) (n, _) r = f <+> equals <+> new <+> typeDoc r <> parens n
 
 csOpenFileWorA :: (Doc, Maybe String) -> (Doc, Maybe String) -> TypeData 
   -> (Doc, Maybe String) -> Doc
-csOpenFileWorA (f, _) (n, _) (TD _ w) (a, _) = f <+> equals <+> new <+> w <> parens 
-  (n <> comma <+> a)
+csOpenFileWorA (f, _) (n, _) w (a, _) = f <+> equals <+> new <+> typeDoc w <> 
+  parens (n <> comma <+> a)

--- a/code/drasil-code/Language/Drasil/Code/Imperative/LanguageRenderer/CppRenderer.hs
+++ b/code/drasil-code/Language/Drasil/Code/Imperative/LanguageRenderer/CppRenderer.hs
@@ -1581,20 +1581,20 @@ cppOutfileTypeDoc :: TypeData
 cppOutfileTypeDoc = td File (text "ofstream")
 
 cppIterTypeDoc :: TypeData -> TypeData
-cppIterTypeDoc (TD t tdoc) = td (Iterator t) (text "std::" <> tdoc <>
+cppIterTypeDoc t = td (Iterator (cType t)) (text "std::" <> typeDoc t <>
   text "::iterator")
 
 cppStateObjDoc :: TypeData -> Doc -> Doc
-cppStateObjDoc (TD _ t) ps = t <> parens ps
+cppStateObjDoc t ps = typeDoc t <> parens ps
 
 cppListSetDoc :: (Doc, Maybe String) -> (Doc, Maybe String) -> Doc
 cppListSetDoc (i, _) (v, _) = dot <> text "at" <> parens i <+> equals <+> v
 
 cppListDecDoc :: Label -> (Doc, Maybe String) -> TypeData -> Doc
-cppListDecDoc l (n, _) (TD _ t) = t <+> text l <> parens n
+cppListDecDoc l (n, _) t = typeDoc t <+> text l <> parens n
 
 cppListDecDefDoc :: Label -> TypeData -> Doc -> Doc
-cppListDecDefDoc l (TD _ t) vs = t <+> text l <> braces vs
+cppListDecDefDoc l t vs = typeDoc t <+> text l <> braces vs
 
 cppPrintDocD :: Bool -> Doc -> (Doc, Maybe String) -> Doc
 cppPrintDocD newLn printFn (v, _) = printFn <+> text "<<" <+> v <+> end
@@ -1627,7 +1627,7 @@ cppOpenFile mode (f, _) (n, _) = f <> dot <> text "open" <>
   parens (n <> comma <+> text mode)
 
 cppPointerParamDoc :: Label -> TypeData  -> Doc
-cppPointerParamDoc n (TD _ t) = t <+> text "&" <> text n
+cppPointerParamDoc n t = typeDoc t <+> text "&" <> text n
 
 cppsMethod :: Label -> Label -> Doc -> Doc -> Doc -> Doc -> Doc -> Doc
 cppsMethod n c t ps b bStart bEnd = vcat [ttype <+> text c <> text "::" <> 
@@ -1647,8 +1647,8 @@ cpphMethod n t ps end | isDtor n = text n <> parens ps <> end
                       | otherwise = t <+> text n <> parens ps <> end
 
 cppMainMethod :: TypeData  -> Doc -> Doc -> Doc -> Doc
-cppMainMethod (TD _ t) b bStart bEnd = vcat [
-  t <+> text "main" <> parens (text "int argc, const char *argv[]") <+> bStart,
+cppMainMethod t b bStart bEnd = vcat [
+  typeDoc t <+> text "main" <> parens (text "int argc, const char *argv[]") <+> bStart,
   indent b,
   blank,
   indent $ text "return 0;",

--- a/code/drasil-code/Language/Drasil/Code/Imperative/LanguageRenderer/JavaRenderer.hs
+++ b/code/drasil-code/Language/Drasil/Code/Imperative/LanguageRenderer/JavaRenderer.hs
@@ -41,7 +41,7 @@ import Language.Drasil.Code.Imperative.LanguageRenderer (
   doubleSlash, addCommentsDocD, callFuncParamList, getterName, setterName,
   setMain, setEmpty, statementsToStateVars)
 import Language.Drasil.Code.Imperative.Helpers (Terminator(..), ModData(..), md,
-  angles, liftA4, liftA5, liftA6, liftA7, liftList, lift1List, 
+  TypeData(..), td, angles, liftA4, liftA5, liftA6, liftA7, liftList, lift1List,
   lift3Pair, lift4Pair, liftPairFst)
 
 import Prelude hiding (break,print,sin,cos,tan,floor,(<>))
@@ -128,7 +128,7 @@ instance BlockSym JavaCode where
   block sts = lift1List blockDocD endStatement (map (fmap fst .state) sts)
 
 instance StateTypeSym JavaCode where
-  type StateType JavaCode = (Doc, CodeType)
+  type StateType JavaCode = TypeData
   bool = return boolTypeDocD
   int = return intTypeDocD
   float = return jFloatTypeDocD
@@ -501,7 +501,7 @@ instance ScopeSym JavaCode where
 
 instance MethodTypeSym JavaCode where
   type MethodType JavaCode = Doc
-  mState = fmap fst
+  mState = fmap typeDoc
   void = return voidDocD
   construct n = return $ constructDocD n
 
@@ -569,31 +569,32 @@ jtop end inc lst = vcat [
   inc <+> text "java.io.File" <> end,
   inc <+> text ("java.util." ++ render lst) <> end]
 
-jFloatTypeDocD :: (Doc, CodeType)
-jFloatTypeDocD = (text "double", Float)
+jFloatTypeDocD :: TypeData
+jFloatTypeDocD = td Float (text "double")
 
-jStringTypeDoc :: (Doc, CodeType)
-jStringTypeDoc = (text "String", String)
+jStringTypeDoc :: TypeData
+jStringTypeDoc = td String (text "String")
 
-jInfileTypeDoc :: (Doc, CodeType)
-jInfileTypeDoc = (text "Scanner", File)
+jInfileTypeDoc :: TypeData
+jInfileTypeDoc = td File (text "Scanner")
 
-jOutfileTypeDoc :: (Doc, CodeType)
-jOutfileTypeDoc = (text "PrintWriter", File)
+jOutfileTypeDoc :: TypeData
+jOutfileTypeDoc = td File (text "PrintWriter")
 
-jListType :: (Doc, CodeType) -> Doc -> (Doc, CodeType)
-jListType (_, Integer) lst = (lst <> angles (text "Integer"), List Integer)
-jListType (_, Float) lst = (lst <> angles (text "Double"), List Float)
+jListType :: TypeData -> Doc -> TypeData
+jListType (TD Integer _) lst = td (List Integer) (lst <> angles (text "Integer"))
+jListType (TD Float _) lst = td (List Float) (lst <> angles (text "Double"))
 jListType t lst = listTypeDocD t lst
 
-jListDecDef :: Label -> (Doc, CodeType) -> Doc -> Doc
-jListDecDef l (st, _) vs = st <+> text l <+> equals <+> new <+> st <+> parens
+jListDecDef :: Label -> TypeData -> Doc -> Doc
+jListDecDef l (TD _ st) vs = st <+> text l <+> equals <+> new <+> st <+> parens
   listElements
   where listElements = if isEmpty vs then empty else text "Arrays.asList" <> 
                          parens vs
 
-jConstDecDef :: Label -> (Doc, CodeType) -> (Doc, Maybe String) -> Doc
-jConstDecDef l (st, _) (v, _) = text "final" <+> st <+> text l <+> equals <+> v
+jConstDecDef :: Label -> TypeData -> (Doc, Maybe String) -> Doc
+jConstDecDef l (TD _ st) (v, _) = text "final" <+> st <+> text l <+> equals <+>
+  v
 
 jThrowDoc :: (Doc, Maybe String) -> Doc
 jThrowDoc (errMsg, _) = text "throw new" <+> text "Exception" <> parens errMsg
@@ -627,8 +628,8 @@ jOpenFileWorA (f, _) (n, _) (wa, _) = f <+> equals <+> new <+>
   text "PrintWriter" <> parens (new <+> text "FileWriter" <> parens (new <+> 
   text "File" <> parens n <> comma <+> wa))
 
-jStringSplit :: (Doc, Maybe String) -> (Doc, CodeType) -> (Doc, Maybe String) -> Doc
-jStringSplit (vnew, _) (t, _) (s, _) = vnew <+> equals <+> new <+> t
+jStringSplit :: (Doc, Maybe String) -> TypeData -> (Doc, Maybe String) -> Doc
+jStringSplit (vnew, _) (TD _ t) (s, _) = vnew <+> equals <+> new <+> t
   <> parens s
 
 jMethod :: Label -> Doc -> Doc -> Doc -> Doc -> Doc -> Doc

--- a/code/drasil-code/Language/Drasil/Code/Imperative/LanguageRenderer/JavaRenderer.hs
+++ b/code/drasil-code/Language/Drasil/Code/Imperative/LanguageRenderer/JavaRenderer.hs
@@ -587,13 +587,13 @@ jListType (TD Float _) lst = td (List Float) (lst <> angles (text "Double"))
 jListType t lst = listTypeDocD t lst
 
 jListDecDef :: Label -> TypeData -> Doc -> Doc
-jListDecDef l (TD _ st) vs = st <+> text l <+> equals <+> new <+> st <+> parens
-  listElements
+jListDecDef l st vs = typeDoc st <+> text l <+> equals <+> new <+> 
+  typeDoc st <+> parens listElements
   where listElements = if isEmpty vs then empty else text "Arrays.asList" <> 
                          parens vs
 
 jConstDecDef :: Label -> TypeData -> (Doc, Maybe String) -> Doc
-jConstDecDef l (TD _ st) (v, _) = text "final" <+> st <+> text l <+> equals <+>
+jConstDecDef l st (v, _) = text "final" <+> typeDoc st <+> text l <+> equals <+>
   v
 
 jThrowDoc :: (Doc, Maybe String) -> Doc
@@ -629,7 +629,7 @@ jOpenFileWorA (f, _) (n, _) (wa, _) = f <+> equals <+> new <+>
   text "File" <> parens n <> comma <+> wa))
 
 jStringSplit :: (Doc, Maybe String) -> TypeData -> (Doc, Maybe String) -> Doc
-jStringSplit (vnew, _) (TD _ t) (s, _) = vnew <+> equals <+> new <+> t
+jStringSplit (vnew, _) t (s, _) = vnew <+> equals <+> new <+> typeDoc t
   <> parens s
 
 jMethod :: Label -> Doc -> Doc -> Doc -> Doc -> Doc -> Doc

--- a/code/drasil-code/Language/Drasil/Code/Imperative/LanguageRenderer/PythonRenderer.hs
+++ b/code/drasil-code/Language/Drasil/Code/Imperative/LanguageRenderer/PythonRenderer.hs
@@ -529,10 +529,10 @@ pyLnOp :: Doc
 pyLnOp = text "math.log"
 
 pyStateObj :: TypeData -> Doc -> Doc
-pyStateObj (TD _ t) vs = t <> parens vs
+pyStateObj t vs = typeDoc t <> parens vs
 
 pyExtStateObj :: Label -> TypeData -> Doc -> Doc
-pyExtStateObj l (TD _ t) vs = text l <> dot <> t <> parens vs
+pyExtStateObj l t vs = text l <> dot <> typeDoc t <> parens vs
 
 pyInlineIf :: (Doc, Maybe String) -> (Doc, Maybe String) -> 
   (Doc, Maybe String) -> Doc
@@ -549,7 +549,7 @@ pyVarDecDef :: Label ->  (Doc, Maybe String) -> Doc
 pyVarDecDef l (v, _) = text l <+> equals <+> v
 
 pyListDec :: Label -> TypeData -> Doc
-pyListDec l (TD _ t) = text l <+> equals <+> t
+pyListDec l t = text l <+> equals <+> typeDoc t
 
 pyListDecDef :: Label -> Doc -> Doc
 pyListDecDef l vs = text l <+> equals <+> brackets vs

--- a/code/drasil-code/Language/Drasil/Code/Imperative/LanguageRenderer/PythonRenderer.hs
+++ b/code/drasil-code/Language/Drasil/Code/Imperative/LanguageRenderer/PythonRenderer.hs
@@ -33,8 +33,8 @@ import Language.Drasil.Code.Imperative.LanguageRenderer (
   staticDocD, dynamicDocD, classDec, dot, forLabel, observerListName,
   addCommentsDocD, callFuncParamList, getterName, setterName)
 import Language.Drasil.Code.Imperative.Helpers (Terminator(..), ModData(..), md,
-  blank, vibcat, liftA4, liftA5, liftList, lift1List, lift4Pair, 
-  liftPairFst, liftPairSnd)
+  TypeData(..), td, blank, vibcat, liftA4, liftA5, liftList, lift1List, 
+  lift4Pair, liftPairFst)
 
 import Prelude hiding (break,print,sin,cos,tan,floor,(<>))
 import qualified Data.Map as Map (fromList,lookup)
@@ -114,15 +114,15 @@ instance BlockSym PythonCode where
   block sts = lift1List blockDocD endStatement (map (fmap fst . state) sts)
 
 instance StateTypeSym PythonCode where
-  type StateType PythonCode = (Doc, CodeType)
-  bool = return (empty, Boolean)
+  type StateType PythonCode = TypeData
+  bool = return $ td Boolean empty
   int = return intTypeDocD
   float = return floatTypeDocD
-  char = return (empty, Char)
+  char = return $ td Char empty
   string = return pyStringType
-  infile = return (empty, File)
-  outfile = return (empty, File)
-  listType _ t = liftPairSnd (brackets empty, fmap (List . snd) t)
+  infile = return $ td File empty
+  outfile = return $ td File empty
+  listType _ t = liftA2 td (fmap (List . cType) t) (return $ brackets empty)
   obj t = return $ typeDocD t
   enumType t = return $ typeDocD t
   iterator _ = error "Iterator-type variables do not exist in Python"
@@ -262,7 +262,7 @@ instance ValueExpression PythonCode where
     vs)
   extStateObj l t vs = mkVal <$> liftA2 (pyExtStateObj l) t (liftList 
     callFuncParamList vs)
-  listStateObj t _ = mkVal <$> fmap fst t
+  listStateObj t _ = mkVal <$> fmap typeDoc t
 
   exists v = v ?!= var "None"
   notNull = exists
@@ -291,7 +291,7 @@ instance Selector PythonCode where
 instance FunctionSym PythonCode where
   type Function PythonCode = Doc
   func l vs = fmap funcDocD (funcApp l vs)
-  cast targT _ = fmap fst targT
+  cast targT _ = fmap typeDoc targT
   castListToInt = cast int (listType static_ int)
   get n = fmap funcDocD (var n)
   set n v = fmap funcDocD (mkVal . fst <$> assign (var n) v)
@@ -450,7 +450,7 @@ instance ScopeSym PythonCode where
 
 instance MethodTypeSym PythonCode where
   type MethodType PythonCode = Doc
-  mState = fmap fst
+  mState = fmap typeDoc
   void = return voidDocD
   construct n = return $ constructDocD n
 
@@ -528,11 +528,11 @@ pyLogOp = text "math.log10"
 pyLnOp :: Doc
 pyLnOp = text "math.log"
 
-pyStateObj :: (Doc, CodeType) -> Doc -> Doc
-pyStateObj (t, _) vs = t <> parens vs
+pyStateObj :: TypeData -> Doc -> Doc
+pyStateObj (TD _ t) vs = t <> parens vs
 
-pyExtStateObj :: Label -> (Doc, CodeType) -> Doc -> Doc
-pyExtStateObj l (t, _) vs = text l <> dot <> t <> parens vs
+pyExtStateObj :: Label -> TypeData -> Doc -> Doc
+pyExtStateObj l (TD _ t) vs = text l <> dot <> t <> parens vs
 
 pyInlineIf :: (Doc, Maybe String) -> (Doc, Maybe String) -> 
   (Doc, Maybe String) -> Doc
@@ -542,14 +542,14 @@ pyInlineIf (c, _) (v1, _) (v2, _) = parens $ v1 <+> text "if" <+> c <+>
 pyListSizeAccess :: (Doc, Maybe String) -> Doc -> Doc
 pyListSizeAccess (v, _) f = f <> parens v
 
-pyStringType :: (Doc, CodeType)
-pyStringType = (text "str", String)
+pyStringType :: TypeData
+pyStringType = td String (text "str")
 
 pyVarDecDef :: Label ->  (Doc, Maybe String) -> Doc
 pyVarDecDef l (v, _) = text l <+> equals <+> v
 
-pyListDec :: Label -> (Doc, CodeType) -> Doc
-pyListDec l (t, _) = text l <+> equals <+> t
+pyListDec :: Label -> TypeData -> Doc
+pyListDec l (TD _ t) = text l <+> equals <+> t
 
 pyListDecDef :: Label -> Doc -> Doc
 pyListDecDef l vs = text l <+> equals <+> brackets vs


### PR DESCRIPTION
As suggested by @JacquesCarette in #1581, this PR replaces the pair for types in GOOL with a new data structure. 