### PR TITLE
Automate Physical System Description

### DIFF
--- a/code/drasil-docLang/Drasil/DocLang.hs
+++ b/code/drasil-docLang/Drasil/DocLang.hs
@@ -25,7 +25,7 @@ module Drasil.DocLang (
     reqF, mkInputPropsTable, mkQRTuple, mkQRTupleRef, mkValsSourceTable, 
     -- Sections.SpecificSystemDescription
     assumpF, dataConstraintUncertainty, dataDefnF, goalStmtF, inDataConstTbl, 
-    inModelF, outDataConstTbl, physSystDesc, probDescF, termDefnF, specSysDescr,
+    inModelF, outDataConstTbl, probDescF, termDefnF, specSysDescr,
     -- Sections.Stakeholders
     -- Sections.TableOfAbbAndAcronyms
     -- Sections.TableOfSymbols
@@ -41,8 +41,7 @@ module Drasil.DocLang (
     getTraceMapFromTM, getTraceMapFromGD,
     getTraceMapFromDD, getTraceMapFromIM, getSCSSub, generateTraceMap',
    -- Labels
-    goalStmtLabel, solutionLabel, characteristicsLabel,
-    physSystDescriptionLabel
+    goalStmtLabel, solutionLabel, characteristicsLabel
     ) where 
 
 import Drasil.DocumentLanguage (AppndxSec(..), AuxConstntSec(..), 
@@ -66,7 +65,7 @@ import Drasil.Sections.Requirements (reqF, mkInputPropsTable, mkQRTuple, mkQRTup
     mkValsSourceTable)
 import Drasil.Sections.SpecificSystemDescription (assumpF, 
     dataConstraintUncertainty, dataDefnF, goalStmtF, inDataConstTbl, inModelF, 
-    outDataConstTbl, physSystDesc, probDescF, termDefnF, specSysDescr)
+    outDataConstTbl, probDescF, termDefnF, specSysDescr)
 --import Drasil.Sections.Stakeholders
 --import Drasil.Sections.TableOfAbbAndAcronyms
 --import Drasil.Sections.TableOfSymbols
@@ -79,5 +78,4 @@ import Drasil.ExtractDocDesc (getDocDesc, egetDocDesc, ciGetDocDesc)
 import Drasil.TraceTable (generateTraceMap, getTraceMapFromTM, getTraceMapFromGD,
     getTraceMapFromDD, getTraceMapFromIM, getSCSSub, generateTraceMap')
 -- Commented out modules aren't used - uncomment if this changes
-import Drasil.DocumentLanguage.Labels (goalStmtLabel, solutionLabel, characteristicsLabel,
-    physSystDescriptionLabel)
+import Drasil.DocumentLanguage.Labels (goalStmtLabel, solutionLabel, characteristicsLabel)

--- a/code/drasil-docLang/Drasil/DocumentLanguage.hs
+++ b/code/drasil-docLang/Drasil/DocumentLanguage.hs
@@ -34,7 +34,7 @@ import qualified Drasil.Sections.Introduction as Intro (charIntRdrF,
   introductionSection, orgSec, purposeOfDoc, scopeOfRequirements)
 import qualified Drasil.Sections.Requirements as R (reqF, fReqF, nfReqF)
 import qualified Drasil.Sections.SpecificSystemDescription as SSD (assumpF,
-  datConF, dataDefnF, genDefnF, goalStmtF, inModelF, probDescF,
+  datConF, dataDefnF, genDefnF, goalStmtF, inModelF, physSystDesc, probDescF,
   solutionCharSpecIntro, specSysDescr, thModF)
 import qualified Drasil.Sections.Stakeholders as Stk (stakehldrGeneral,
   stakeholderIntro, tClientF, tCustomerF)
@@ -170,7 +170,9 @@ data SSDSub where
 data ProblemDescription where
   PDProg :: Sentence -> [Section] -> [PDSub] -> ProblemDescription
 
+-- | Problem Description subsections
 data PDSub where
+  PhySysDesc :: (Idea a) => a -> [Sentence] -> LabelledContent -> [Contents] -> PDSub
   Goals :: [Sentence] -> [ConceptInstance] -> PDSub
 
 -- | Solution Characteristics Specification section
@@ -420,7 +422,8 @@ mkSSDSec si (SSDProg l) =
 
 mkSSDProb :: SystemInformation -> ProblemDescription -> Section
 mkSSDProb _ (PDProg prob subSec subPD) = SSD.probDescF prob (subSec ++ map mkSubPD subPD)
-  where mkSubPD (Goals ins g) = SSD.goalStmtF ins (mkEnumSimpleD g)
+  where mkSubPD (PhySysDesc prog parts dif extra) = SSD.physSystDesc prog parts dif extra
+        mkSubPD (Goals ins g) = SSD.goalStmtF ins (mkEnumSimpleD g)
 
 mkSolChSpec :: SystemInformation -> SolChSpec -> Section
 mkSolChSpec si (SCSProg l) =

--- a/code/drasil-docLang/Drasil/DocumentLanguage/Labels.hs
+++ b/code/drasil-docLang/Drasil/DocumentLanguage/Labels.hs
@@ -1,9 +1,7 @@
 {-# Language Rank2Types #-}
-module Drasil.DocumentLanguage.Labels
-  where
+module Drasil.DocumentLanguage.Labels where
 
-import Language.Drasil
-
+import Language.Drasil (Reference, makeLstRef)
 
 goalStmtLabel :: Reference
 goalStmtLabel = makeLstRef "goalStmt" "goalStmt"
@@ -13,6 +11,3 @@ solutionLabel = makeLstRef "solution" "solution"
 
 characteristicsLabel :: Reference
 characteristicsLabel = makeLstRef "characteristics" "characteristics"
-
-physSystDescriptionLabel :: Reference
-physSystDescriptionLabel = makeLstRef "physSystDescription" "physSystDescription"

--- a/code/drasil-docLang/Drasil/Sections/SpecificSystemDescription.hs
+++ b/code/drasil-docLang/Drasil/Sections/SpecificSystemDescription.hs
@@ -30,7 +30,6 @@ import Data.Drasil.Concepts.Math (equation)
 import Data.Drasil.IdeaDicts (inModel, thModel)
 
 import qualified Drasil.DocLang.SRS as SRS
-import Drasil.DocumentLanguage.Labels (physSystDescriptionLabel)
 
 import Control.Lens ((^.))
 
@@ -67,7 +66,7 @@ physSystDesc :: (Idea a) => a -> [Sentence] -> LabelledContent -> [Contents] -> 
 physSystDesc progName parts fg other = SRS.physSyst (intro : bullets : LlC fg : other) []
   where intro = mkParagraph $ foldlSentCol [S "The", phrase physicalSystem `sOf` short progName `sC`
                 S "as shown in", makeRef2S fg `sC` S "includes the following", plural element]
-        bullets = LlC $ enumSimple physSystDescriptionLabel 1 (short physSyst) parts
+        bullets = enumSimpleU 1 (short physSyst) parts
 
 --List all the given inputs. Might be possible to use ofThe combinator from utils.hs
 goalStmtF :: [Sentence] -> [Contents] -> Section

--- a/code/drasil-docLang/Drasil/Sections/SpecificSystemDescription.hs
+++ b/code/drasil-docLang/Drasil/Sections/SpecificSystemDescription.hs
@@ -22,14 +22,15 @@ import Utils.Drasil
 import Data.Drasil.Concepts.Documentation (assumption, column, constraint,
   datum, datumConstraint, definition, element, general, goalStmt, information,
   input_, limitation, model, output_, physical, physicalConstraint, physicalSystem,
-  problem, problemDescription, purpose, quantity, requirement, scope, section_,
-  softwareConstraint, solutionCharacteristic, specification, symbol_, system,
-  theory, typUnc, uncertainty, user, value, variable)
+  physSyst, problem, problemDescription, purpose, quantity, requirement, scope,
+  section_, softwareConstraint, solutionCharacteristic, specification, symbol_,
+  system, theory, typUnc, uncertainty, user, value, variable)
 import Data.Drasil.Concepts.Math (equation)
 
 import Data.Drasil.IdeaDicts (inModel, thModel)
 
 import qualified Drasil.DocLang.SRS as SRS
+import Drasil.DocumentLanguage.Labels (physSystDescriptionLabel)
 
 import Control.Lens ((^.))
 
@@ -62,12 +63,11 @@ termDefnF end otherContents = SRS.termAndDefn (intro : otherContents) []
                     S "understand the", plural requirement :+: lastF end]
 
 --general introduction for Physical System Description
-physSystDesc :: Sentence -> LabelledContent -> [Contents] -> Section
-physSystDesc progName fg otherContents = SRS.physSyst (intro:otherContents) []
-  where intro = mkParagraph $ foldlSentCol
-                [S "The", phrase physicalSystem, S "of", progName `sC`
-                S "as shown in", makeRef2S fg `sC` S "includes the following", 
-                plural element]
+physSystDesc :: (Idea a) => a -> [Sentence] -> LabelledContent -> [Contents] -> Section
+physSystDesc progName parts fg other = SRS.physSyst (intro : bullets : LlC fg : other) []
+  where intro = mkParagraph $ foldlSentCol [S "The", phrase physicalSystem `sOf` short progName `sC`
+                S "as shown in", makeRef2S fg `sC` S "includes the following", plural element]
+        bullets = LlC $ enumSimple physSystDescriptionLabel 1 (short physSyst) parts
 
 --List all the given inputs. Might be possible to use ofThe combinator from utils.hs
 goalStmtF :: [Sentence] -> [Contents] -> Section

--- a/code/drasil-example/Drasil/GlassBR/Body.hs
+++ b/code/drasil-example/Drasil/GlassBR/Body.hs
@@ -16,28 +16,25 @@ import Utils.Drasil
 import Drasil.DocLang (AppndxSec(..), AuxConstntSec(..), DerivationDisplay(..), 
   DocDesc, DocSection(..), Field(..), Fields, GSDSec(GSDProg2), GSDSub(..), 
   InclUnits(IncludeUnits), IntroSec(IntroProg), IntroSub(IChar, IOrgSec, IPurpose, IScope), 
-  LCsSec'(..), ProblemDescription(..), PDSub(Goals), RefSec(RefProg),
+  LCsSec'(..), ProblemDescription(..), PDSub(..), RefSec(RefProg),
   RefTab(TAandA, TUnits), ReqrmntSec(..), ReqsSub(..), SCSSub(..),
   SSDSec(..), SSDSub(..), SolChSpec(..), StkhldrSec(StkhldrProg2), 
   StkhldrSub(Client, Cstmr), TraceabilitySec(TraceabilityProg), 
   TSIntro(SymbOrder, TSPurpose), UCsSec(..), Verbosity(Verbose),
-  dataConstraintUncertainty, inDataConstTbl, intro, mkDoc, 
-  outDataConstTbl, physSystDesc, termDefnF, tsymb, generateTraceMap,
-  getTraceMapFromTM, getTraceMapFromGD, getTraceMapFromDD, getTraceMapFromIM,
-  getSCSSub, traceMatStandard, characteristicsLabel, physSystDescriptionLabel,
-  generateTraceMap')
+  dataConstraintUncertainty, inDataConstTbl, intro, mkDoc, outDataConstTbl,
+  termDefnF, tsymb, generateTraceMap, getTraceMapFromTM, getTraceMapFromGD,
+  getTraceMapFromDD, getTraceMapFromIM, getSCSSub, traceMatStandard,
+  characteristicsLabel, generateTraceMap')
 
-import qualified Drasil.DocLang.SRS as SRS (reference, valsOfAuxCons,
-  assumpt, inModel)
+import qualified Drasil.DocLang.SRS as SRS (reference, valsOfAuxCons, assumpt, inModel)
 
 import Data.Drasil.Concepts.Computation (computerApp, inDatum, inParam, compcon, algorithm)
 import Data.Drasil.Concepts.Documentation as Doc (analysis, appendix, aspect,
   assumption, characteristic, company, condition, content, dataConst, datum,
   definition, doccon, doccon', document, emphasis, environment, goal,
-  information, input_, interface, model, organization, physical, physSyst,
-  problem, product_, purpose, reference, software, softwareConstraint,
-  softwareSys, srsDomains, standard, sysCont, system, template, term_, user,
-  value, variable)
+  information, input_, interface, model, organization, physical, problem,
+  product_, purpose, reference, software, softwareConstraint, softwareSys,
+  srsDomains, standard, sysCont, system, template, term_, user, value, variable)
 import qualified Data.Drasil.Concepts.Documentation as Doc (srs, code)
 import Data.Drasil.IdeaDicts as Doc (inModel, thModel)
 import qualified Data.Drasil.IdeaDicts as Doc (dataDefn)
@@ -154,7 +151,9 @@ mkSRS = [RefSec $ RefProg intro [TUnits, tsymb [TSPurpose, SymbOrder], TAandA],
     UsrChars [userCharacteristicsIntro], SystCons [] [] ],
   SSDSec $
     SSDProg
-      [SSDProblem $ PDProg prob [termsAndDesc, physSystDescription] [Goals goalInputs goals],
+      [SSDProblem $ PDProg prob [termsAndDesc]
+        [ PhySysDesc glassBR physSystParts physSystFig []
+        , Goals goalInputs goals],
        SSDSolChSpec $ SCSProg
         [ Assumptions
         , TMs [] (Label : stdFields) tMods
@@ -206,10 +205,6 @@ systInfo = SI {
    refdb       = refDB
 }
   --FIXME: All named ideas, not just acronyms.
-
-termsAndDesc, physSystDescription :: Section
-
-physSystDescriptionList, appdxIntro :: Contents
 
 inputDataConstraints, outputDataConstraints :: LabelledContent
 
@@ -384,30 +379,18 @@ prob = foldlSent_ [S "efficiently" `sAnd` S "correctly predict whether a",
 
 {--Terminology and Definitions--}
 
+termsAndDesc :: Section
 termsAndDesc = termDefnF (Just (S "All" `sOf` S "the" +:+ plural term_ +:+
   S "are extracted from" +:+ makeCiteS astm2009 `sIn`
   makeRef2S (SRS.reference ([]::[Contents]) ([]::[Section])))) [termsAndDescBullets]
 
 {--Physical System Description--}
 
-physSystDescription = physSystDesc glassBR physSystDescriptionListPhysys physSystFig []
-
-physSystDescriptionList = LlC $ enumSimple physSystDescriptionLabel 1 (short physSyst) physSystDescriptionListPhysys
-
---"Dead" knowledge?
-physSystDescriptionListPhysys :: [Sentence]
-physSystDescriptionListPhysys1 :: Sentence
-physSystDescriptionListPhysys2 :: NamedIdea n => n -> Sentence
-
-physSystDescriptionListPhysys = [physSystDescriptionListPhysys1, physSystDescriptionListPhysys2 ptOfExplsn]
-
-physSystDescriptionListPhysys1 = S "The" +:+. phrase glaSlab
-
-physSystDescriptionListPhysys2 imprtntElem = foldlSent [S "The"
-  +:+. phrase imprtntElem, S "Where the", phrase bomb `sC`
-  S "or", (blast ^. defn) `sC` S "is located. The", phrase sD
-  `isThe` phrase distance, S "between the", phrase imprtntElem `sAnd`
-  S "the glass"]
+physSystParts :: [Sentence]
+physSystParts = [S "The" +:+. phrase glaSlab,
+  foldlSent [S "The" +:+. phrase ptOfExplsn, S "Where the", phrase bomb `sC`
+  S "or", (blast ^. defn) `sC` S "is located. The", phrase sD `isThe`
+  phrase distance, S "between the", phrase ptOfExplsn `sAnd` S "the glass"]]
 
 {--Goal Statements--}
 
@@ -453,6 +436,7 @@ traceabilityMatrices = traceMatStandard systInfo
 
 {--APPENDIX--}
 
+appdxIntro :: Contents
 appdxIntro = foldlSP [
   S "This", phrase appendix, S "holds the", plural graph,
   sParen (makeRef2S demandVsSDFig `sAnd` makeRef2S dimlessloadVsARFig),

--- a/code/drasil-example/Drasil/GlassBR/Body.hs
+++ b/code/drasil-example/Drasil/GlassBR/Body.hs
@@ -390,8 +390,7 @@ termsAndDesc = termDefnF (Just (S "All" `sOf` S "the" +:+ plural term_ +:+
 
 {--Physical System Description--}
 
-physSystDescription = physSystDesc (short glassBR) physSystFig 
-  [physSystDescriptionList, LlC physSystFig]
+physSystDescription = physSystDesc glassBR physSystDescriptionListPhysys physSystFig []
 
 physSystDescriptionList = LlC $ enumSimple physSystDescriptionLabel 1 (short physSyst) physSystDescriptionListPhysys
 

--- a/code/drasil-example/Drasil/NoPCM/Body.hs
+++ b/code/drasil-example/Drasil/NoPCM/Body.hs
@@ -17,7 +17,7 @@ import Data.Drasil.People (thulasi)
 import Data.Drasil.Concepts.Computation (algorithm)
 import Data.Drasil.Concepts.Documentation as Doc (assumption, content,
   definition, doccon, doccon', document, goal, information, material_, model,
-  physSyst, problem, property, purpose, reference, srsDomains)
+  problem, property, purpose, reference, srsDomains)
 import qualified Data.Drasil.Concepts.Documentation as Doc (srs)
 import Data.Drasil.IdeaDicts as Doc (inModel, thModel)
 import Data.Drasil.Concepts.Education (educon)
@@ -53,7 +53,7 @@ import Drasil.DocLang (DocDesc, Fields, Field(..), Verbosity(Verbose),
   inDataConstTbl, intro, mkDoc, mkEnumSimpleD, outDataConstTbl, physSystDesc,
   termDefnF, tsymb, getDocDesc, egetDocDesc, generateTraceMap, getTraceMapFromTM,
   getTraceMapFromGD, getTraceMapFromDD, getTraceMapFromIM, getSCSSub,
-  physSystDescriptionLabel, generateTraceMap', traceMatStandard)
+  generateTraceMap', traceMatStandard)
 
 -- Since NoPCM is a simplified version of SWHS, the file is to be built off
 -- of the SWHS libraries.  If the source for something cannot be found in
@@ -354,17 +354,15 @@ termsAndDefnsBullets = UlC $ ulcc $ Enumeration $ Bullet $ noRefs $
   atStart x :+: S ":" +:+ (x ^. defn))
   [htFlux, heatCapSpec, thermalConduction, transient]
   
-physSystDescription = physSystDesc (getAcc progName) figTank
-  [physSystDescList, LlC figTank]
+physSystDescription = physSystDesc progName physSystDescList figTank []
 
 figTank :: LabelledContent
 figTank = llcc (makeFigRef "Tank") $ fig (atStart sWHT `sC` S "with" +:+ phrase htFlux +:+
   S "from" +:+ phrase coil `sOf` ch htFluxC)
   $ resourcePath ++ "TankWaterOnly.png"
 
-physSystDescList :: Contents
-physSystDescList = LlC $ enumSimple physSystDescriptionLabel 1 (short physSyst) $ map foldlSent_
-  [physSyst1 tank water, physSyst2 coil tank htFluxC]
+physSystDescList :: [Sentence]
+physSystDescList = map foldlSent_ [physSyst1 tank water, physSyst2 coil tank htFluxC]
 
 goalInputs :: [Sentence]
 goalInputs = [phrase temp `ofThe` phrase coil,

--- a/code/drasil-example/Drasil/NoPCM/Body.hs
+++ b/code/drasil-example/Drasil/NoPCM/Body.hs
@@ -49,9 +49,9 @@ import Drasil.DocLang (DocDesc, Fields, Field(..), Verbosity(Verbose),
   IntroSub(IOrgSec, IScope, IChar, IPurpose), Literature(Lit, Doc'),
   ReqrmntSec(..), ReqsSub(..), RefSec(RefProg), RefTab(TAandA, TUnits),
   TraceabilitySec(TraceabilityProg), TSIntro(SymbOrder, SymbConvention, TSPurpose),
-  ProblemDescription(PDProg), PDSub(Goals), dataConstraintUncertainty,
-  inDataConstTbl, intro, mkDoc, mkEnumSimpleD, outDataConstTbl, physSystDesc,
-  termDefnF, tsymb, getDocDesc, egetDocDesc, generateTraceMap, getTraceMapFromTM,
+  ProblemDescription(PDProg), PDSub(..), dataConstraintUncertainty,
+  inDataConstTbl, intro, mkDoc, mkEnumSimpleD, outDataConstTbl, termDefnF,
+  tsymb, getDocDesc, egetDocDesc, generateTraceMap, getTraceMapFromTM,
   getTraceMapFromGD, getTraceMapFromDD, getTraceMapFromIM, getSCSSub,
   generateTraceMap', traceMatStandard)
 
@@ -112,8 +112,6 @@ units = map ucw [density, tau, inSA, outSA,
   deltaT, tempEnv, thFluxVect, time, htFluxC,
   vol, wMass, wVol, tauW, QT.sensHeat]
 
-termsAndDefns, physSystDescription :: Section
-
 -------------------
 --INPUT INFORMATION
 -------------------
@@ -141,7 +139,9 @@ mkSRS = [RefSec $ RefProg intro
     ],
   SSDSec $
     SSDProg
-    [ SSDProblem   $ PDProg  probDescIntro [termsAndDefns, physSystDescription] [Goals goalInputs goals]
+    [ SSDProblem   $ PDProg  probDescIntro [termsAndDefns]
+      [ PhySysDesc progName physSystParts figTank []
+      , Goals goalInputs goals]
     , SSDSolChSpec $ SCSProg
       [ Assumptions
       , TMs [] (Label : stdFields) theoreticalModels
@@ -346,6 +346,7 @@ orgDocEnd im_ od pro = foldlSent_ [S "The", phrase im_,
 probDescIntro :: Sentence
 probDescIntro = foldlSent_ [S "investigate the heating" `sOf` phrase water, S "in a", phrase sWHT]
 
+termsAndDefns :: Section
 termsAndDefns = termDefnF Nothing [termsAndDefnsBullets]
 
 termsAndDefnsBullets :: Contents
@@ -354,15 +355,13 @@ termsAndDefnsBullets = UlC $ ulcc $ Enumeration $ Bullet $ noRefs $
   atStart x :+: S ":" +:+ (x ^. defn))
   [htFlux, heatCapSpec, thermalConduction, transient]
   
-physSystDescription = physSystDesc progName physSystDescList figTank []
-
 figTank :: LabelledContent
 figTank = llcc (makeFigRef "Tank") $ fig (atStart sWHT `sC` S "with" +:+ phrase htFlux +:+
   S "from" +:+ phrase coil `sOf` ch htFluxC)
   $ resourcePath ++ "TankWaterOnly.png"
 
-physSystDescList :: [Sentence]
-physSystDescList = map foldlSent_ [physSyst1 tank water, physSyst2 coil tank htFluxC]
+physSystParts :: [Sentence]
+physSystParts = map foldlSent_ [physSyst1 tank water, physSyst2 coil tank htFluxC]
 
 goalInputs :: [Sentence]
 goalInputs = [phrase temp `ofThe` phrase coil,

--- a/code/drasil-example/Drasil/SSP/Body.hs
+++ b/code/drasil-example/Drasil/SSP/Body.hs
@@ -20,18 +20,18 @@ import Drasil.DocLang (DocDesc, DocSection(..), IntroSec(..), IntroSub(..),
   Verbosity(..), InclUnits(..), DerivationDisplay(..), SolChSpec(..),
   SCSSub(..), GSDSec(..), GSDSub(..), TraceabilitySec(TraceabilityProg),
   ReqrmntSec(..), ReqsSub(..), AuxConstntSec(..), ProblemDescription(PDProg),
-  PDSub(Goals), dataConstraintUncertainty, intro, mkDoc,
-  termDefnF, tsymb'', getDocDesc, egetDocDesc, generateTraceMap,
-  getTraceMapFromTM, getTraceMapFromGD, getTraceMapFromDD, getTraceMapFromIM,
-  getSCSSub, physSystDescriptionLabel, generateTraceMap', traceMatStandard)
+  PDSub(..), dataConstraintUncertainty, intro, mkDoc, termDefnF, tsymb'',
+  getDocDesc, egetDocDesc, generateTraceMap, getTraceMapFromTM,
+  getTraceMapFromGD, getTraceMapFromDD, getTraceMapFromIM, getSCSSub,
+  generateTraceMap', traceMatStandard)
 
-import qualified Drasil.DocLang.SRS as SRS (inModel, physSyst, assumpt, sysCon,
+import qualified Drasil.DocLang.SRS as SRS (inModel, assumpt, sysCon,
   genDefn, dataDefn, datCon)
 
 import Data.Drasil.Concepts.Documentation as Doc (analysis, assumption,
   constant, constraint, definition, document, effect, endUser, environment,
   goal, information, input_, interest, loss, method_, model, organization,
-  physical, physics, physSyst, problem, purpose, requirement, software,
+  physical, physics, problem, purpose, requirement, software,
   softwareSys, srsDomains, symbol_, sysCont, system, systemConstraint,
   template, type_, user, value, variable, doccon, doccon')
 import qualified Data.Drasil.Concepts.Documentation as Doc (srs)
@@ -71,14 +71,6 @@ import Drasil.SSP.Requirements (funcReqs, funcReqTables, nonFuncReqs, propsDeriv
 import Drasil.SSP.TMods (tMods)
 import Drasil.SSP.Unitals (effCohesion, fricAngle, fs, index, 
   constrained, inputs, outputs, symbols)
-
---type declarations for sections--
-
-tableOfSymbIntro :: [TSIntro]
-
-termsDefs, physSysDesc :: Section
-termsDefsList, physSysIntro, physSysConv, 
-  physSysDescBullets, physSysFbd :: Contents
 
 --Document Setup--
 thisSi :: [UnitDefn]
@@ -128,7 +120,9 @@ mkSRS = [RefSec $ RefProg intro
       UsrChars [userCharIntro], SystCons [sysConstraints] []],
     SSDSec $
       SSDProg
-        [ SSDProblem   $ PDProg prob [termsDefs, physSysDesc] [Goals goalsInputs goals]
+        [ SSDProblem $ PDProg prob [termsDefs]
+          [ PhySysDesc ssp physSystParts figPhysSyst physSystContents 
+          , Goals goalsInputs goals]
         , SSDSolChSpec $ SCSProg
           [Assumptions
           , TMs [] (Label : stdFields) tMods
@@ -226,7 +220,7 @@ symbTT = ccss (getDocDesc mkSRS) (egetDocDesc mkSRS) symMap
 
 -- SECTION 1.2 --
 --automatically generated in mkSRS using the intro below
-
+tableOfSymbIntro :: [TSIntro]
 tableOfSymbIntro = [TSPurpose, TypogConvention [Verb $ foldlSent_
   [plural value, S "with a subscript", ch index, S "implies that the",
   phrase value, S "will be taken at and analyzed at a", phrase slice
@@ -393,8 +387,10 @@ From when solution was used in Problem Description:
 -}
 
 -- SECTION 4.1.1 --
+termsDefs :: Section
 termsDefs = termDefnF Nothing [termsDefsList]
 
+termsDefsList :: Contents
 termsDefsList = UlC $ ulcc $ Enumeration $ Simple $ noRefsLT $
   map (\x -> (titleize x, Flat $ x ^. defn))
   [fsConcept, slpSrf, crtSlpSrf, waterTable, stress, strain, normForce,
@@ -404,52 +400,10 @@ termsDefsList = UlC $ ulcc $ Enumeration $ Simple $ noRefsLT $
   -- except for fsConcept, crtSlpSrf & plnStrn which are in defs.hs
 
 -- SECTION 4.1.2 --
-physSysDesc = SRS.physSyst
-  [physSysIntro, physSysDescBullets, LlC figPhysSyst, physSysConv,
-   LlC figIndexConv, physSysFbd, LlC figForceActing] []
-
-physSysIntro = physSystIntro ssp figPhysSyst
-
-physSystIntro :: (Idea a, HasShortName d, Referable d) => a -> d -> Contents
-physSystIntro what indexref = foldlSPCol [S "The", introduceAbb physSyst `sOf`
-  short what `sC` S "as shown in", makeRef2S indexref `sC` 
-  S "includes the following elements"]
-
-physSysConv = physSystConvention morPrice morgenstern1965 slope how 
-  index slice intrslce figIndexConv
-  where how = S "as a series of vertical" +:+ plural slice
-
-physSystConvention :: (NamedIdea a, HasShortName b, Referable b, NamedIdea c,
-  NamedIdea d, HasSymbol d, NamedIdea e, NamedIdea f, HasShortName g, 
-  Referable g) => a -> b -> c -> Sentence -> d -> e -> f -> g -> Contents
-physSystConvention anlsys refr what how ix ixd intrfce indexref = foldlSP [
-  atStart anlsys, phrase analysis, makeRef2S refr, S "of the", phrase what, 
-  S "involves representing the", phrase what +:+. how, S "As shown in",
-  makeRef2S indexref `sC` S "the", phrase ix, ch ix, S "is used to denote a",
-  phrase value, S "for a single", phrase ixd `sC` S "and an", phrase intrfce, 
-  phrase value, S "at a given", phrase ix, ch ix, S "refers to the",
-  phrase value, S "between", phrase ixd, ch ix `sAnd` S "adjacent", phrase ixd,
-  E $ sy ix + 1]
-
-physSysDescBullets = LlC $ enumSimple physSystDescriptionLabel 1 (short Doc.physSyst) physSystDescriptionListPhysys
-
-physSystDescriptionListPhysys :: [Sentence]
-physSystDescriptionListPhysys1 :: Sentence
-physSystDescriptionListPhysys2 :: Sentence
-
-physSystDescriptionListPhysys = [physSystDescriptionListPhysys1, physSystDescriptionListPhysys2]
-
-physSystDescriptionListPhysys1 = foldlSent [S "A", phrase slope, 
-  S "comprised of one", phrase soilLyr]
-
-physSystDescriptionListPhysys2 = foldlSent [S "A", phrase waterTable `sC` 
-  S "which may or may not exist"]
-
-physSysFbd = foldlSP [S "A", phrase fbd, S "of the", 
-  plural force, S "acting on a", phrase slice, 
-  S "is displayed in" +:+. makeRef2S figForceActing, S "The specific",
-  plural force `sAnd` plural symbol_, S "will be discussed in detail in",
-  makeRef2S (SRS.genDefn [] []) `sAnd` makeRef2S (SRS.dataDefn [] [])]
+physSystParts :: [Sentence]
+physSystParts = map foldlSent [
+  [S "A", phrase slope, S "comprised of one", phrase soilLyr],
+  [S "A", phrase waterTable `sC` S "which may or may not exist"]]
 
 figPhysSyst :: LabelledContent
 figPhysSyst = llcc (makeFigRef "PhysicalSystem") $
@@ -457,10 +411,29 @@ figPhysSyst = llcc (makeFigRef "PhysicalSystem") $
   S "by", short ssp `sC` S "where the dashed line represents the",
   phrase waterTable]) (resourcePath ++ "PhysSyst.png")
 
+physSystContents :: [Contents]
+physSystContents = [physSysConv, LlC figIndexConv, physSysFbd, LlC figForceActing]
+
+physSysConv :: Contents
+physSysConv = foldlSP [atStart morPrice, phrase analysis, makeRef2S morgenstern1965,
+  S "of the", phrase slope,  S "involves representing the", phrase slope,
+  S "as a series of vertical" +:+. plural slice, S "As shown in",
+  makeRef2S figIndexConv `sC` S "the", phrase index, ch index, S "is used to denote a",
+  phrase value, S "for a single", phrase slice `sC` S "and an", phrase intrslce, 
+  phrase value, S "at a given", phrase index, ch index, S "refers to the",
+  phrase value, S "between", phrase slice, ch index `sAnd` S "adjacent", phrase slice,
+  E $ sy index + 1]
+
 figIndexConv :: LabelledContent
 figIndexConv = llcc (makeFigRef "IndexConvention") $ 
   fig (foldlSent_ [S "Index convention for", phrase slice `sAnd` 
   phrase intrslce, plural value]) (resourcePath ++ "IndexConvention.png")
+
+physSysFbd :: Contents
+physSysFbd = foldlSP [S "A", phrase fbd, S "of the", plural force, S "acting on a",
+  phrase slice `sIs` S "displayed in" +:+. makeRef2S figForceActing, S "The specific",
+  plural force `sAnd` plural symbol_, S "will be discussed in detail in",
+  makeRef2S (SRS.genDefn [] []) `sAnd` makeRef2S (SRS.dataDefn [] [])]
 
 figForceActing :: LabelledContent
 figForceActing = llcc (makeFigRef "ForceDiagram") $

--- a/code/drasil-example/Drasil/SWHS/Body.hs
+++ b/code/drasil-example/Drasil/SWHS/Body.hs
@@ -343,17 +343,17 @@ tAndDMap c = Flat $ foldlSent [atStart c +: EmptyS, c ^. defn]
 -----------------------------------------
 
 physSystDescription :: Section
-physSystDescription = physSystDesc (short progName) figTank [physSystDescList, LlC figTank]
+physSystDescription = physSystDesc progName systDescList figTank []
 
 -- Above paragraph is general except for progName and figure. However, not
 -- every example has a physical system. Also, the SSP example is different, so
 -- this paragraph can not be abstracted out as is.
 
 physSystDescList :: Contents
-physSystDescList = LlC $ enumSimple physSystDescriptionLabel 1 (short physSyst) $ map foldlSent_ systDescList
+physSystDescList = LlC $ enumSimple physSystDescriptionLabel 1 (short physSyst) $ systDescList
 
-systDescList :: [[Sentence]]
-systDescList = [physSyst1 tank water, physSyst2 coil tank htFluxC,
+systDescList :: [Sentence]
+systDescList = map foldlSent_ [physSyst1 tank water, physSyst2 coil tank htFluxC,
   physSyst3 phsChgMtrl tank htFluxP]
 
 -----------------------------

--- a/code/drasil-example/Drasil/SWHS/Body.hs
+++ b/code/drasil-example/Drasil/SWHS/Body.hs
@@ -20,20 +20,19 @@ import Drasil.DocLang (AuxConstntSec (AuxConsProg), DocDesc, DocSection (..),
   ReqrmntSec(..), ReqsSub(..), SSDSub(..), SolChSpec (SCSProg), SSDSec(..), 
   InclUnits(..), DerivationDisplay(..), SCSSub(..), Verbosity(..),
   TraceabilitySec(TraceabilityProg), LCsSec(..), UCsSec(..),
-  GSDSec(..), GSDSub(..), ProblemDescription(PDProg), PDSub(Goals),
+  GSDSec(..), GSDSub(..), ProblemDescription(PDProg), PDSub(..),
   dataConstraintUncertainty, intro, mkDoc, mkEnumSimpleD, outDataConstTbl,
-  physSystDesc, termDefnF, tsymb'', getDocDesc, egetDocDesc,
-  ciGetDocDesc, generateTraceMap, generateTraceMap', getTraceMapFromTM,
-  getTraceMapFromGD, getTraceMapFromDD, getTraceMapFromIM, getSCSSub,
-  physSystDescriptionLabel, traceMatStandard)
+  termDefnF, tsymb'', getDocDesc, egetDocDesc, ciGetDocDesc, generateTraceMap,
+  generateTraceMap', getTraceMapFromTM, getTraceMapFromGD, getTraceMapFromDD,
+  getTraceMapFromIM, getSCSSub, traceMatStandard)
 import qualified Drasil.DocLang.SRS as SRS (likeChg, unlikeChg, inModel)
 
 import Data.Drasil.Concepts.Thermodynamics (thermocon)
 import Data.Drasil.Concepts.Documentation as Doc (assumption, column, condition,
   constraint, content, datum, definition, document, environment, goalStmt,
-  information, input_, model, organization, output_, physical, physics, physSyst,
-  problem, property, purpose, quantity, reference, software, softwareSys, srs,
-  srsDomains, sysCont, system, user, value, variable, doccon, doccon')
+  information, input_, model, organization, output_, physical, physics, problem,
+  property, purpose, quantity, reference, software, softwareSys, srs, srsDomains,
+  sysCont, system, user, value, variable, doccon, doccon')
 import Data.Drasil.IdeaDicts as Doc (inModel, thModel)
 import Data.Drasil.Concepts.Computation (compcon, algorithm)
 import Data.Drasil.Concepts.Education (calculus, educon, engineering)
@@ -171,7 +170,9 @@ mkSRS = [RefSec $ RefProg intro [
     ],
   SSDSec $
     SSDProg 
-      [ SSDProblem   $ PDProg  probDescIntro [termsAndDefns, physSystDescription] [Goals goalInputs goals]
+      [ SSDProblem $ PDProg probDescIntro [termsAndDefns]
+        [ PhySysDesc progName physSystParts figTank []
+        , Goals goalInputs goals]
       , SSDSolChSpec $ SCSProg
         [ Assumptions
         , TMs [] (Label : stdFields) [consThermE, sensHtE, latentHtE]
@@ -342,19 +343,26 @@ tAndDMap c = Flat $ foldlSent [atStart c +: EmptyS, c ^. defn]
 -- 4.1.2 : Physical System Description --
 -----------------------------------------
 
-physSystDescription :: Section
-physSystDescription = physSystDesc progName systDescList figTank []
+physSystParts :: [Sentence]
+physSystParts = map foldlSent_ [physSyst1 tank water, physSyst2 coil tank htFluxC,
+  [short phsChgMtrl, S "suspended in" +:+. phrase tank,
+  sParen (ch htFluxP +:+ S "represents the" +:+. phrase htFluxP)]]
 
--- Above paragraph is general except for progName and figure. However, not
--- every example has a physical system. Also, the SSP example is different, so
--- this paragraph can not be abstracted out as is.
+physSyst1 :: ConceptChunk -> ConceptChunk -> [Sentence]
+physSyst1 ta wa = [atStart ta, S "containing" +:+. phrase wa]
 
-physSystDescList :: Contents
-physSystDescList = LlC $ enumSimple physSystDescriptionLabel 1 (short physSyst) $ systDescList
+physSyst2 :: ConceptChunk -> ConceptChunk -> UnitalChunk -> [Sentence]
+physSyst2 co ta hfc = [atStart co, S "at bottom of" +:+. phrase ta,
+  sParen (ch hfc +:+ S "represents the" +:+. phrase hfc)]
 
-systDescList :: [Sentence]
-systDescList = map foldlSent_ [physSyst1 tank water, physSyst2 coil tank htFluxC,
-  physSyst3 phsChgMtrl tank htFluxP]
+-- Structure of list would be same between examples but content is completely
+-- different
+
+figTank :: LabelledContent
+figTank = llcc (makeFigRef "Tank") $ fig (
+  foldlSent_ [atStart sWHT `sC` S "with", phrase htFluxC `sOf`
+  ch htFluxC `sAnd` phrase htFluxP `sOf` ch htFluxP])
+  $ resourcePath ++ "Tank.png"
 
 -----------------------------
 -- 4.1.3 : Goal Statements --
@@ -734,26 +742,6 @@ probDescIntro = foldlSent_ [S "investigate the effect" `sOf` S "employing",
 -----------------------------------------
 -- 4.1.2 : Physical System Description --
 -----------------------------------------
-
-physSyst1 :: ConceptChunk -> ConceptChunk -> [Sentence]
-physSyst1 ta wa = [atStart ta, S "containing" +:+. phrase wa]
---
-physSyst2 :: ConceptChunk -> ConceptChunk -> UnitalChunk -> [Sentence]
-physSyst2 co ta hfc = [atStart co, S "at bottom of" +:+. phrase ta,
-  sParen (ch hfc +:+ S "represents the" +:+. phrase hfc)]
---
-physSyst3 :: CI -> ConceptChunk -> UnitalChunk -> [Sentence]
-physSyst3 pcmat ta hfp = [short pcmat, S "suspended in" +:+. phrase ta,
-  sParen (ch hfp +:+ S "represents the" +:+. phrase hfp)]
-
--- Structure of list would be same between examples but content is completely
--- different
-
-figTank :: LabelledContent
-figTank = llcc (makeFigRef "Tank") $ fig (
-  foldlSent_ [atStart sWHT `sC` S "with", phrase htFluxC, S "of",
-  ch htFluxC `sAnd` phrase htFluxP, S "of", ch htFluxP])
-  $ resourcePath ++ "Tank.png"
 
 -----------------------------
 -- 4.1.3 : Goal Statements --

--- a/code/stable/ssp/SRS/SSP_SRS.tex
+++ b/code/stable/ssp/SRS/SSP_SRS.tex
@@ -373,7 +373,7 @@ This subsection provides a list of terms that are used in the subsequent section
 \end{itemize}
 \subsubsection{Physical System Description}
 \label{Sec:PhysSyst}
-The Physical System Description (PS) of SSP, as shown in \hyperref[Figure:PhysicalSystem]{Fig:PhysicalSystem}, includes the following elements:
+The physical system of SSP, as shown in \hyperref[Figure:PhysicalSystem]{Fig:PhysicalSystem}, includes the following elements:
 \begin{itemize}
 \item[PS1:]A slope comprised of one soil layer.
 \item[PS2:]A water table, which may or may not exist.

--- a/code/stable/ssp/Website/SSP_SRS.html
+++ b/code/stable/ssp/Website/SSP_SRS.html
@@ -938,7 +938,7 @@
               <div class="subsubsection">
                 <h3>Physical System Description</h3>
                 <p class="paragraph">
-                  The Physical System Description (PS) of SSP, as shown in <a href=#Figure:PhysicalSystem>Fig:PhysicalSystem</a>, includes the following elements:
+                  The physical system of SSP, as shown in <a href=#Figure:PhysicalSystem>Fig:PhysicalSystem</a>, includes the following elements:
                 </p>
                 <div class="list">
                   <p>PS1: A slope comprised of one soil layer.</p>


### PR DESCRIPTION
In the same vein as #1600, the Physical System Description section is now automated in `docLang`.