### PR TITLE
Symbol Sorting Fixes

### DIFF
--- a/code/drasil-lang/Language/Drasil/Symbol.hs
+++ b/code/drasil-lang/Language/Drasil/Symbol.hs
@@ -66,6 +66,13 @@ compsy a (Concat (Atomic "Δ" : y)) =
 compsy (Concat x) (Concat y) = complsy x y
 compsy (Concat a) b = complsy a [b]
 compsy b (Concat a) = complsy [b] a
+-- The next two cases are very specific (but common) patterns where a superscript is added
+-- to some "conceptual" base symbol to add further context. For example: `v_f^{AB}` (expressed in LaTeX
+-- notation for clarity), where `v_f` is a final velocity, and the `^{AB}` adds context that it is the
+-- final velocity between points `A` and `B`. In these cases, the sorting of `v_f^{AB}` should be
+-- following `v_f` as it is logical to place it with its parent concept.
+compsy (Corners [] [] ur [] (Corners [] [] [] lr b)) a = compsy (Corners [] [] ur lr b) a
+compsy a (Corners [] [] ur [] (Corners [] [] [] lr b)) = compsy a (Corners [] [] ur lr b)
 compsy (Corners _ _ u l b) (Corners _ _ u' l' b')  =
   case compsy b b' of
     EQ -> case complsy l l' of

--- a/code/drasil-lang/Language/Drasil/Symbol.hs
+++ b/code/drasil-lang/Language/Drasil/Symbol.hs
@@ -48,78 +48,54 @@ complsy [] _  = LT
 complsy _  [] = GT
 complsy (x : xs) (y : ys) = compsy x y `mappend` complsy xs ys
 
--- The default compare function sorts all the lower case after the upper case
--- Comparation is used twice for each case,
--- Once for making sure they are the same letter, once for case sensitive.
+-- |The default compare function sorts all the lower case after the upper case.
+-- Comparation is used twice for each `Atomic` case,
+-- once for making sure they are the same letter, once for case sensitive.
+-- As far as this comparison is considered, `Δ` is a "decoration" and ignored
+-- unless the compared symbols are the exact same, in which case it is ordered
+-- after the undecorated symbol.
 compsy :: Symbol -> Symbol -> Ordering
-compsy (Concat [x]) (Concat [y]) = compsy x y
-compsy (Concat (Atomic "Δ" : Atomic x : _)) (Atomic y) = 
-  case compare (map toLower x) (map toLower y) of
+compsy (Concat (Atomic "Δ" : x)) y =
+  case compsy (Concat x) y of
     EQ -> GT
     other -> other
-compsy (Concat (Atomic "Δ" : x : _)) y = 
-  case compsy x y of
-    EQ -> GT
-    other -> other
-compsy (Atomic x)  (Concat (Atomic "Δ" : Atomic y : _)) = 
-  case compare (map toLower x) (map toLower y) of
+compsy a (Concat (Atomic "Δ" : y)) =
+  case compsy a (Concat y) of
     EQ -> LT
     other -> other
-compsy a (Concat (Atomic "Δ" : y : _)) = 
-  case compsy a y of
-    EQ -> LT
-    other -> other
-compsy (Concat (x:xs)) (Concat (y : ys)) = compsy x y `mappend` complsy xs ys
+compsy (Concat x) (Concat y) = complsy x y
 compsy (Concat a) b = complsy a [b]
 compsy b (Concat a) = complsy [b] a
-compsy (Corners _ _ u l (Atomic b)) (Corners _ _ u' l' (Atomic b'))  =
-  case compare (map toLower b) (map toLower b') of
-    EQ -> case complsy l l' of
-      EQ -> complsy u u'
-      other -> other
-    other -> other
 compsy (Corners _ _ u l b) (Corners _ _ u' l' b')  =
   case compsy b b' of
     EQ -> case complsy l l' of
       EQ -> complsy u u'
       other -> other
     other -> other
-compsy (Atomic a) (Corners _ _ _ _ (Atomic b)) = 
-  case compare a b of
+compsy a (Corners _ _ _ _ b) =
+  case compsy a b of
     EQ -> LT
-    _  -> case compare (map toLower a) (map toLower b) of
-      EQ -> LT
-      other -> other
-compsy (Corners _ _ _ _ (Atomic b)) (Atomic a) = 
-  case compare b a of
+    other -> other
+compsy (Corners _ _ _ _ b) a =
+  case compsy b a of
     EQ -> GT
-    _  -> case compare (map toLower b) (map toLower a) of
-      EQ -> GT
-      other -> other
-compsy (Corners _ _ _ _ b) a = compsy b a
-compsy a (Corners _ _ _ _ b) = compsy a b
+    other -> other
 compsy (Atop d1 a) (Atop d2 a') = 
   case compsy a a' of
     EQ -> compare d1 d2
     other -> other
-compsy (Atomic a) (Atop _ (Atomic b)) = 
-  case compare a b of
+compsy a (Atop _ b) =
+  case compsy a b of
     EQ -> LT
-    _  -> case compare (map toLower a) (map toLower b) of
-      EQ -> LT
-      other -> other
-compsy (Atop _ (Atomic b)) (Atomic a) = 
- case compare b a of
+    other -> other
+compsy (Atop _ b) a =
+ case compsy b a of
     EQ -> GT
-    _  -> case compare (map toLower b) (map toLower a) of
-      EQ -> GT
-      other -> other
-compsy (Atop _ a)  b           = compsy a b  
-compsy b           (Atop _ a)  = compsy b a
+    other -> other
 compsy (Special a) (Special b) = compare a b
-compsy _           (Special _) = GT
 compsy (Special _) _           = LT
-compsy (Atomic x)  (Atomic y)  = 
+compsy _           (Special _) = GT
+compsy (Atomic x)  (Atomic y)  =
   case compare (map toLower x) (map toLower y) of
     EQ -> compare x y
     other -> other

--- a/code/stable/gamephys/SRS/Chipmunk_SRS.tex
+++ b/code/stable/gamephys/SRS/Chipmunk_SRS.tex
@@ -66,9 +66,9 @@ Symbol & Description & Units
 \endhead
 $\mathbf{a}$ & Acceleration & $\frac{\text{m}}{\text{s}^{2}}$
 \\
-${\mathbf{a}_{i}}$ & The I-Th Body's Acceleration & $\frac{\text{m}}{\text{s}^{2}}$
-\\
 $\mathbf{a}(t)$ & Linear Acceleration & $\frac{\text{m}}{\text{s}^{2}}$
+\\
+${\mathbf{a}_{i}}$ & The I-Th Body's Acceleration & $\frac{\text{m}}{\text{s}^{2}}$
 \\
 ${C_{R}}$ & Coefficient of restitution & --
 \\
@@ -92,9 +92,9 @@ ${\mathbf{I}_{A}}$ & Moment of Inertia Of Rigid Body A & kg$\text{m}^{2}$
 \\
 ${\mathbf{I}_{B}}$ & Moment of Inertia Of Rigid Body B & kg$\text{m}^{2}$
 \\
-$j$ & Impulse (scalar) & Ns
-\\
 $\mathbf{J}$ & Impulse (vector) & Ns
+\\
+$j$ & Impulse (scalar) & Ns
 \\
 $KE$ & Kinetic energy & J
 \\
@@ -128,9 +128,9 @@ ${r_{j}}$ & Distance Between the J-Th Particle and the Axis of Rotation & m
 \\
 $\mathbf{r}$ & Displacement & m
 \\
-${\mathbf{r}_{OB}}$ & Displacement vector between the origin and point B & m
-\\
 $\mathbf{r}(t)$ & Linear Displacement & m
+\\
+${\mathbf{r}_{OB}}$ & Displacement vector between the origin and point B & m
 \\
 $\mathbf{\hat{r}}$ & Displacement unit vector & m
 \\
@@ -138,13 +138,19 @@ $t$ & Time & s
 \\
 ${t_{c}}$ & Denotes the time at collision & s
 \\
-${{\mathbf{v}_{f}}^{AB}}$ & Final Relative Velocity Between Rigid Bodies of A and B & $\frac{\text{m}}{\text{s}}$
+$\mathbf{v}$ & Velocity & $\frac{\text{m}}{\text{s}}$
 \\
-${{\mathbf{v}_{i}}^{AB}}$ & Initial Relative Velocity Between Rigid Bodies of A and B & $\frac{\text{m}}{\text{s}}$
+$Δ\mathbf{v}$ & Change in velocity & $\frac{\text{m}}{\text{s}}$
+\\
+$\mathbf{v}(t)$ & Linear Velocity & $\frac{\text{m}}{\text{s}}$
 \\
 ${\mathbf{v}^{AP}}$ & Velocity Of the Point of Collision P in Body A & $\frac{\text{m}}{\text{s}}$
 \\
 ${\mathbf{v}^{BP}}$ & Velocity Of the Point of Collision P in Body B & $\frac{\text{m}}{\text{s}}$
+\\
+${\mathbf{v}_{1}}$ & Velocity Of the First Body & $\frac{\text{m}}{\text{s}}$
+\\
+${\mathbf{v}_{2}}$ & Velocity Of the Second Body & $\frac{\text{m}}{\text{s}}$
 \\
 ${\mathbf{v}_{A}}$ & Velocity At Point A & $\frac{\text{m}}{\text{s}}$
 \\
@@ -154,23 +160,17 @@ ${\mathbf{v}_{i}}$ & Velocity Of the I-Th Body's Velocity & $\frac{\text{m}}{\te
 \\
 ${\mathbf{v}_{O}}$ & Velocity At Point Origin & $\frac{\text{m}}{\text{s}}$
 \\
-$\mathbf{v}$ & Velocity & $\frac{\text{m}}{\text{s}}$
+${{\mathbf{v}_{f}}^{AB}}$ & Final Relative Velocity Between Rigid Bodies of A and B & $\frac{\text{m}}{\text{s}}$
 \\
-${\mathbf{v}_{1}}$ & Velocity Of the First Body & $\frac{\text{m}}{\text{s}}$
-\\
-${\mathbf{v}_{2}}$ & Velocity Of the Second Body & $\frac{\text{m}}{\text{s}}$
-\\
-$Δ\mathbf{v}$ & Change in velocity & $\frac{\text{m}}{\text{s}}$
-\\
-$\mathbf{v}(t)$ & Linear Velocity & $\frac{\text{m}}{\text{s}}$
+${{\mathbf{v}_{i}}^{AB}}$ & Initial Relative Velocity Between Rigid Bodies of A and B & $\frac{\text{m}}{\text{s}}$
 \\
 $||\mathbf{n}||$ & Length of the Normal Vector & m
+\\
+$||\mathbf{r}||$ & Euclidean norm of the displacement & m
 \\
 $||{\mathbf{r}_{AP}}*\mathbf{n}||$ & Length of the Perpendicular Vector To the Contact Displacement Vector of Rigid Body A & m
 \\
 $||{\mathbf{r}_{BP}}*\mathbf{n}||$ & Length of the Perpendicular Vector To the Contact Displacement Vector of Rigid Body B & m
-\\
-$||\mathbf{r}||$ & Euclidean norm of the displacement & m
 \\
 ${||\mathbf{r}||^{2}}$ & Squared distance & $\text{m}^{2}$
 \\

--- a/code/stable/gamephys/SRS/Chipmunk_SRS.tex
+++ b/code/stable/gamephys/SRS/Chipmunk_SRS.tex
@@ -156,13 +156,13 @@ ${\mathbf{v}_{A}}$ & Velocity At Point A & $\frac{\text{m}}{\text{s}}$
 \\
 ${\mathbf{v}_{B}}$ & Velocity At Point B & $\frac{\text{m}}{\text{s}}$
 \\
-${\mathbf{v}_{i}}$ & Velocity Of the I-Th Body's Velocity & $\frac{\text{m}}{\text{s}}$
-\\
-${\mathbf{v}_{O}}$ & Velocity At Point Origin & $\frac{\text{m}}{\text{s}}$
-\\
 ${{\mathbf{v}_{f}}^{AB}}$ & Final Relative Velocity Between Rigid Bodies of A and B & $\frac{\text{m}}{\text{s}}$
 \\
+${\mathbf{v}_{i}}$ & Velocity Of the I-Th Body's Velocity & $\frac{\text{m}}{\text{s}}$
+\\
 ${{\mathbf{v}_{i}}^{AB}}$ & Initial Relative Velocity Between Rigid Bodies of A and B & $\frac{\text{m}}{\text{s}}$
+\\
+${\mathbf{v}_{O}}$ & Velocity At Point Origin & $\frac{\text{m}}{\text{s}}$
 \\
 $||\mathbf{n}||$ & Length of the Normal Vector & m
 \\

--- a/code/stable/gamephys/Website/Chipmunk_SRS.html
+++ b/code/stable/gamephys/Website/Chipmunk_SRS.html
@@ -305,23 +305,23 @@
                   <td>m/s</td>
                 </tr>
                 <tr>
-                  <td><em><b>v</b><sub>i</sub></em></td>
-                  <td>Velocity Of the I-Th Body's Velocity</td>
-                  <td>m/s</td>
-                </tr>
-                <tr>
-                  <td><em><b>v</b><sub>O</sub></em></td>
-                  <td>Velocity At Point Origin</td>
-                  <td>m/s</td>
-                </tr>
-                <tr>
                   <td><em><b>v</b><sub>f</sub><sup>AB</sup></em></td>
                   <td>Final Relative Velocity Between Rigid Bodies of A and B</td>
                   <td>m/s</td>
                 </tr>
                 <tr>
+                  <td><em><b>v</b><sub>i</sub></em></td>
+                  <td>Velocity Of the I-Th Body's Velocity</td>
+                  <td>m/s</td>
+                </tr>
+                <tr>
                   <td><em><b>v</b><sub>i</sub><sup>AB</sup></em></td>
                   <td>Initial Relative Velocity Between Rigid Bodies of A and B</td>
+                  <td>m/s</td>
+                </tr>
+                <tr>
+                  <td><em><b>v</b><sub>O</sub></em></td>
+                  <td>Velocity At Point Origin</td>
                   <td>m/s</td>
                 </tr>
                 <tr>

--- a/code/stable/gamephys/Website/Chipmunk_SRS.html
+++ b/code/stable/gamephys/Website/Chipmunk_SRS.html
@@ -78,13 +78,13 @@
                   <td>m/s<sup>2</sup></td>
                 </tr>
                 <tr>
-                  <td><em><b>a</b><sub>i</sub></em></td>
-                  <td>The I-Th Body's Acceleration</td>
+                  <td><em><b>a</b>(t)</em></td>
+                  <td>Linear Acceleration</td>
                   <td>m/s<sup>2</sup></td>
                 </tr>
                 <tr>
-                  <td><em><b>a</b>(t)</em></td>
-                  <td>Linear Acceleration</td>
+                  <td><em><b>a</b><sub>i</sub></em></td>
+                  <td>The I-Th Body's Acceleration</td>
                   <td>m/s<sup>2</sup></td>
                 </tr>
                 <tr>
@@ -143,13 +143,13 @@
                   <td>kg&sdot;m<sup>2</sup></td>
                 </tr>
                 <tr>
-                  <td><em>j</em></td>
-                  <td>Impulse (scalar)</td>
+                  <td><em><b>J</b></em></td>
+                  <td>Impulse (vector)</td>
                   <td>N&sdot;s</td>
                 </tr>
                 <tr>
-                  <td><em><b>J</b></em></td>
-                  <td>Impulse (vector)</td>
+                  <td><em>j</em></td>
+                  <td>Impulse (scalar)</td>
                   <td>N&sdot;s</td>
                 </tr>
                 <tr>
@@ -235,13 +235,13 @@
                   <td>m</td>
                 </tr>
                 <tr>
-                  <td><em><b>r</b><sub>OB</sub></em></td>
-                  <td>Displacement vector between the origin and point B</td>
+                  <td><em><b>r</b>(t)</em></td>
+                  <td>Linear Displacement</td>
                   <td>m</td>
                 </tr>
                 <tr>
-                  <td><em><b>r</b>(t)</em></td>
-                  <td>Linear Displacement</td>
+                  <td><em><b>r</b><sub>OB</sub></em></td>
+                  <td>Displacement vector between the origin and point B</td>
                   <td>m</td>
                 </tr>
                 <tr>
@@ -260,13 +260,18 @@
                   <td>s</td>
                 </tr>
                 <tr>
-                  <td><em><b>v</b><sub>f</sub><sup>AB</sup></em></td>
-                  <td>Final Relative Velocity Between Rigid Bodies of A and B</td>
+                  <td><em><b>v</b></em></td>
+                  <td>Velocity</td>
                   <td>m/s</td>
                 </tr>
                 <tr>
-                  <td><em><b>v</b><sub>i</sub><sup>AB</sup></em></td>
-                  <td>Initial Relative Velocity Between Rigid Bodies of A and B</td>
+                  <td><em>Δ<b>v</b></em></td>
+                  <td>Change in velocity</td>
+                  <td>m/s</td>
+                </tr>
+                <tr>
+                  <td><em><b>v</b>(t)</em></td>
+                  <td>Linear Velocity</td>
                   <td>m/s</td>
                 </tr>
                 <tr>
@@ -277,6 +282,16 @@
                 <tr>
                   <td><em><b>v</b><sup>BP</sup></em></td>
                   <td>Velocity Of the Point of Collision P in Body B</td>
+                  <td>m/s</td>
+                </tr>
+                <tr>
+                  <td><em><b>v</b><sub>1</sub></em></td>
+                  <td>Velocity Of the First Body</td>
+                  <td>m/s</td>
+                </tr>
+                <tr>
+                  <td><em><b>v</b><sub>2</sub></em></td>
+                  <td>Velocity Of the Second Body</td>
                   <td>m/s</td>
                 </tr>
                 <tr>
@@ -300,33 +315,23 @@
                   <td>m/s</td>
                 </tr>
                 <tr>
-                  <td><em><b>v</b></em></td>
-                  <td>Velocity</td>
+                  <td><em><b>v</b><sub>f</sub><sup>AB</sup></em></td>
+                  <td>Final Relative Velocity Between Rigid Bodies of A and B</td>
                   <td>m/s</td>
                 </tr>
                 <tr>
-                  <td><em><b>v</b><sub>1</sub></em></td>
-                  <td>Velocity Of the First Body</td>
-                  <td>m/s</td>
-                </tr>
-                <tr>
-                  <td><em><b>v</b><sub>2</sub></em></td>
-                  <td>Velocity Of the Second Body</td>
-                  <td>m/s</td>
-                </tr>
-                <tr>
-                  <td><em>Δ<b>v</b></em></td>
-                  <td>Change in velocity</td>
-                  <td>m/s</td>
-                </tr>
-                <tr>
-                  <td><em><b>v</b>(t)</em></td>
-                  <td>Linear Velocity</td>
+                  <td><em><b>v</b><sub>i</sub><sup>AB</sup></em></td>
+                  <td>Initial Relative Velocity Between Rigid Bodies of A and B</td>
                   <td>m/s</td>
                 </tr>
                 <tr>
                   <td><em>||<b>n</b>||</em></td>
                   <td>Length of the Normal Vector</td>
+                  <td>m</td>
+                </tr>
+                <tr>
+                  <td><em>||<b>r</b>||</em></td>
+                  <td>Euclidean norm of the displacement</td>
                   <td>m</td>
                 </tr>
                 <tr>
@@ -341,11 +346,6 @@
                   <td>
                     Length of the Perpendicular Vector To the Contact Displacement Vector of Rigid Body B
                   </td>
-                  <td>m</td>
-                </tr>
-                <tr>
-                  <td><em>||<b>r</b>||</em></td>
-                  <td>Euclidean norm of the displacement</td>
                   <td>m</td>
                 </tr>
                 <tr>

--- a/code/stable/nopcm/SRS/NoPCM_SRS.tex
+++ b/code/stable/nopcm/SRS/NoPCM_SRS.tex
@@ -110,21 +110,21 @@ $S$ & Surface & $\text{m}^{2}$
 \\
 $T$ & Temperature & ${}^{\circ}$C
 \\
-$t$ & Time & s
-\\
 $ΔT$ & Change in temperature & ${}^{\circ}$C
 \\
 ${T_{C}}$ & Temperature of the heating coil & ${}^{\circ}$C
 \\
 ${T_{env}}$ & Temperature of the environment & ${}^{\circ}$C
 \\
-${t_{final}}$ & Final time & s
-\\
 ${T_{init}}$ & Initial temperature & ${}^{\circ}$C
 \\
-${t_{step}}$ & Time step for simulation & s
-\\
 ${T_{W}}$ & Temperature of the water & ${}^{\circ}$C
+\\
+$t$ & Time & s
+\\
+${t_{final}}$ & Final time & s
+\\
+${t_{step}}$ & Time step for simulation & s
 \\
 $V$ & Volume & $\text{m}^{3}$
 \\
@@ -601,9 +601,9 @@ $L$ & $L>0$ & ${L_{min}}\leq{}L\leq{}{L_{max}}$ & $1.5$ m & 10$\%$
 \\
 ${T_{C}}$ & $0<{T_{C}}<100$ & -- & $50.0$ ${}^{\circ}$C & 10$\%$
 \\
-${t_{final}}$ & ${t_{final}}>0$ & ${t_{final}}<{{t_{final}}^{max}}$ & $50.0\cdot{}10^{3}$ s & 10$\%$
-\\
 ${T_{init}}$ & $0<{T_{init}}<100$ & -- & $40.0$ ${}^{\circ}$C & 10$\%$
+\\
+${t_{final}}$ & ${t_{final}}>0$ & ${t_{final}}<{{t_{final}}^{max}}$ & $50.0\cdot{}10^{3}$ s & 10$\%$
 \\
 ${t_{step}}$ & $0<{t_{step}}<{t_{final}}$ & -- & $0.01$ s & 10$\%$
 \\
@@ -666,9 +666,9 @@ ${R_{tol}}$ & Relative tolerance & --
 \\
 ${T_{C}}$ & Temperature of the heating coil & ${}^{\circ}$C
 \\
-${t_{final}}$ & Final time & s
-\\
 ${T_{init}}$ & Initial temperature & ${}^{\circ}$C
+\\
+${t_{final}}$ & Final time & s
 \\
 ${t_{step}}$ & Time step for simulation & s
 \\

--- a/code/stable/nopcm/Website/NoPCM_SRS.html
+++ b/code/stable/nopcm/Website/NoPCM_SRS.html
@@ -192,11 +192,6 @@
                   <td>&deg;C</td>
                 </tr>
                 <tr>
-                  <td><em>t</em></td>
-                  <td>Time</td>
-                  <td>s</td>
-                </tr>
-                <tr>
                   <td><em>ΔT</em></td>
                   <td>Change in temperature</td>
                   <td>&deg;C</td>
@@ -212,24 +207,29 @@
                   <td>&deg;C</td>
                 </tr>
                 <tr>
-                  <td><em>t<sub>final</sub></em></td>
-                  <td>Final time</td>
-                  <td>s</td>
-                </tr>
-                <tr>
                   <td><em>T<sub>init</sub></em></td>
                   <td>Initial temperature</td>
                   <td>&deg;C</td>
                 </tr>
                 <tr>
-                  <td><em>t<sub>step</sub></em></td>
-                  <td>Time step for simulation</td>
-                  <td>s</td>
-                </tr>
-                <tr>
                   <td><em>T<sub>W</sub></em></td>
                   <td>Temperature of the water</td>
                   <td>&deg;C</td>
+                </tr>
+                <tr>
+                  <td><em>t</em></td>
+                  <td>Time</td>
+                  <td>s</td>
+                </tr>
+                <tr>
+                  <td><em>t<sub>final</sub></em></td>
+                  <td>Final time</td>
+                  <td>s</td>
+                </tr>
+                <tr>
+                  <td><em>t<sub>step</sub></em></td>
+                  <td>Time step for simulation</td>
+                  <td>s</td>
                 </tr>
                 <tr>
                   <td><em>V</em></td>
@@ -1318,21 +1318,21 @@
                       <td>10<em>%</em></td>
                     </tr>
                     <tr>
-                      <td><em>t<sub>final</sub></em></td>
-                      <td><em>t<sub>final</sub>&thinsp;&gt;&thinsp;0</em></td>
-                      <td>
-                        <em>t<sub>final</sub>&thinsp;&lt;&thinsp;t<sub>final</sub><sup>max</sup></em>
-                      </td>
-                      <td><em>50.0&sdot;10<sup>3</sup></em> s</td>
-                      <td>10<em>%</em></td>
-                    </tr>
-                    <tr>
                       <td><em>T<sub>init</sub></em></td>
                       <td>
                         <em>0&thinsp;&lt;&thinsp;T<sub>init</sub>&thinsp;&lt;&thinsp;100</em>
                       </td>
                       <td>--</td>
                       <td><em>40.0</em> &deg;C</td>
+                      <td>10<em>%</em></td>
+                    </tr>
+                    <tr>
+                      <td><em>t<sub>final</sub></em></td>
+                      <td><em>t<sub>final</sub>&thinsp;&gt;&thinsp;0</em></td>
+                      <td>
+                        <em>t<sub>final</sub>&thinsp;&lt;&thinsp;t<sub>final</sub><sup>max</sup></em>
+                      </td>
+                      <td><em>50.0&sdot;10<sup>3</sup></em> s</td>
                       <td>10<em>%</em></td>
                     </tr>
                     <tr>
@@ -1488,14 +1488,14 @@
                   <td>&deg;C</td>
                 </tr>
                 <tr>
-                  <td><em>t<sub>final</sub></em></td>
-                  <td>Final time</td>
-                  <td>s</td>
-                </tr>
-                <tr>
                   <td><em>T<sub>init</sub></em></td>
                   <td>Initial temperature</td>
                   <td>&deg;C</td>
+                </tr>
+                <tr>
+                  <td><em>t<sub>final</sub></em></td>
+                  <td>Final time</td>
+                  <td>s</td>
                 </tr>
                 <tr>
                   <td><em>t<sub>step</sub></em></td>

--- a/code/stable/ssp/SRS/SSP_SRS.tex
+++ b/code/stable/ssp/SRS/SSP_SRS.tex
@@ -84,11 +84,11 @@ ${F_{rot}}$ & Force Causing Rotation: a force in the direction of rotation & N
 \\
 ${F_{S}}$ & Factor of Safety: The global stability metric of a slip surface of a slope, defined as the ratio of resistive shear force to mobilized shear force. & --
 \\
+${{F_{S}}^{min}}$ & Minimum Factor of Safety: The minimum factor of safety associated with the critical slip surface & --
+\\
 ${F_{x}}$ & X-Component of the Force:  & N
 \\
 ${F_{y}}$ & Y-Component of the Force:  & N
-\\
-${{F_{S}}^{min}}$ & Minimum Factor of Safety: The minimum factor of safety associated with the critical slip surface & --
 \\
 $\mathbf{F}$ & Force: An interaction that tends to produce change in the motion of an object & N
 \\

--- a/code/stable/ssp/SRS/SSP_SRS.tex
+++ b/code/stable/ssp/SRS/SSP_SRS.tex
@@ -98,13 +98,13 @@ ${{\mathbf{F}_{x}}^{H}}$ & Sums of the Interslice Normal Water Forces: for each 
 \\
 $\mathbf{f}$ & Interslice Normal to Shear Force Ratio Variation Function: function of distance in the x-direction & --
 \\
-$g$ & Gravitational Acceleration: An expression used in physics to indicate the intensity of a gravitational field & $\frac{\text{m}}{\text{s}^{2}}$
-\\
 $\mathbf{G}$ & Interslice Normal Forces: per meter in the z-direction exerted between each pair of adjacent slices & $\frac{\text{N}}{\text{m}}$
 \\
-$h$ & Height: The distance above a reference point for a point of interest. & m
+$g$ & Gravitational Acceleration: An expression used in physics to indicate the intensity of a gravitational field & $\frac{\text{m}}{\text{s}^{2}}$
 \\
 $\mathbf{H}$ & Interslice Normal Water Forces: per meter in the z-direction exerted in the x-coordinate direction between each pair of adjacent slices & $\frac{\text{N}}{\text{m}}$
+\\
+$h$ & Height: The distance above a reference point for a point of interest. & m
 \\
 $\mathbf{h}$ & Y-Direction Heights of Slices: heights in the y-direction from the base of each slice to the slope surface, at the x-direction midpoint of the slice & m
 \\
@@ -126,23 +126,23 @@ $M$ & Moment: a measure of the tendency of a body to rotate about a specific poi
 \\
 $m$ & Mass: the quantity of matter in a body & kg
 \\
-$n$ & Number of Slices: the slip mass has been divided into & --
-\\
 $\mathbf{N}$ & Normal Forces: total reactive forces per meter in the z-direction for each slice of a soil surface subject to a body resting on it & $\frac{\text{N}}{\text{m}}$
 \\
 $\mathbf{N'}$ & Effective Normal Forces: per meter in the z-direction for each slice of a soil surface, subtracting pore water reactive force from total reactive force & $\frac{\text{N}}{\text{m}}$
 \\
-$P$ & Resistive Shear Force: Mohr Coulomb frictional force that describes the limit of mobilized shear force that can be withstood before failure & N
+$n$ & Number of Slices: the slip mass has been divided into & --
 \\
-$p$ & Pressure: A force exerted over an area & Pa
+$P$ & Resistive Shear Force: Mohr Coulomb frictional force that describes the limit of mobilized shear force that can be withstood before failure & N
 \\
 $\mathbf{P}$ & Resistive Shear Forces: Mohr Coulomb frictional forces per meter in the z-direction for each slice that describes the limit of mobilized shear force the slice can withstand before failure & $\frac{\text{N}}{\text{m}}$
 \\
+$p$ & Pressure: A force exerted over an area & Pa
+\\
 $\mathbf{Q}$ & External Forces: forces per meter in the z-direction acting into the surface from the midpoint of each slice & $\frac{\text{N}}{\text{m}}$
 \\
-$r$ & Length of the Moment Arm: distance between a force causing rotation and the axis of rotation & m
-\\
 $\mathbf{R}$ & Resistive Shear Forces Without the Influence of Interslice Forces: per meter in the z-direction for each slice & $\frac{\text{N}}{\text{m}}$
+\\
+$r$ & Length of the Moment Arm: distance between a force causing rotation and the axis of rotation & m
 \\
 $\mathbf{r}$ & Displacement: The change in An object's location relative to a reference point & m
 \\
@@ -152,23 +152,25 @@ $\mathbf{S}$ & Mobilized Shear Forces: per meter in the z-direction for each sli
 \\
 $\mathbf{T}$ & Mobilized Shear Forces Without the Influence of Interslice Forces: per meter in the z-direction for each slice & $\frac{\text{N}}{\text{m}}$
 \\
-$u$ & Pore Pressure: from water within the soil & Pa
-\\
 ${\mathbf{U}_{b}}$ & Base Hydrostatic Forces: per meter in the z-direction from water pressure within each slice & $\frac{\text{N}}{\text{m}}$
 \\
 ${\mathbf{U}_{t}}$ & Surface Hydrostatic Forces: per meter in the z-direction from water pressure acting into each slice from standing water on the slope surface & $\frac{\text{N}}{\text{m}}$
 \\
-$V$ & Volume: the amount of space that a substance or object occupies. & $\text{m}^{3}$
+$u$ & Pore Pressure: from water within the soil & Pa
 \\
-$v$ & Local Index: used as a bound variable index in calculations & --
+$V$ & Volume: the amount of space that a substance or object occupies. & $\text{m}^{3}$
 \\
 ${\mathbf{V}_{dry}}$ & Volumes of Dry Soil: amount of space occupied by dry soil for each slice & $\text{m}^{3}$
 \\
 ${\mathbf{V}_{sat}}$ & Volumes of Saturated Soil: amount of space occupied by saturated soil for each slice & $\text{m}^{3}$
 \\
+$v$ & Local Index: used as a bound variable index in calculations & --
+\\
 $W$ & Weight: The gravitational force acting on an object & N
 \\
 $\mathbf{W}$ & Weights: downward force per meter in the z-direction on each slice caused by gravity & $\frac{\text{N}}{\text{m}}$
+\\
+$\mathbf{X}$ & Interslice Shear Forces: per meter in the z-direction exerted between adjacent slices & $\frac{\text{N}}{\text{m}}$
 \\
 $x$ & X-Coordinate: in the Cartesian coordinate system & m
 \\
@@ -179,8 +181,6 @@ ${{x_{slip}}^{maxExt}}$ & Maximum Exit X-Coordinate: maximum potential x-coordin
 ${{x_{slip}}^{minEtr}}$ & Minimum Exit X-Coordinate: minimum potential x-coordinate for the entry point of a slip surface & m
 \\
 ${{x_{slip}}^{minExt}}$ & Minimum Exit X-Coordinate: minimum potential x-coordinate for the exit point of a slip surface & m
-\\
-$\mathbf{X}$ & Interslice Shear Forces: per meter in the z-direction exerted between adjacent slices & $\frac{\text{N}}{\text{m}}$
 \\
 ${\mathbf{x}_{cs}},{\mathbf{y}_{cs}}$ & The Set of X and Y Coordinates: describe the vertices of the critical slip surface & m
 \\

--- a/code/stable/ssp/Website/SSP_SRS.html
+++ b/code/stable/ssp/Website/SSP_SRS.html
@@ -186,6 +186,13 @@
                   <td>--</td>
                 </tr>
                 <tr>
+                  <td><em><b>G</b></em></td>
+                  <td>
+                    Interslice Normal Forces: per meter in the z-direction exerted between each pair of adjacent slices
+                  </td>
+                  <td>N/m</td>
+                </tr>
+                <tr>
                   <td><em>g</em></td>
                   <td>
                     Gravitational Acceleration: An expression used in physics to indicate the intensity of a gravitational field
@@ -193,9 +200,9 @@
                   <td>m/s<sup>2</sup></td>
                 </tr>
                 <tr>
-                  <td><em><b>G</b></em></td>
+                  <td><em><b>H</b></em></td>
                   <td>
-                    Interslice Normal Forces: per meter in the z-direction exerted between each pair of adjacent slices
+                    Interslice Normal Water Forces: per meter in the z-direction exerted in the x-coordinate direction between each pair of adjacent slices
                   </td>
                   <td>N/m</td>
                 </tr>
@@ -205,13 +212,6 @@
                     Height: The distance above a reference point for a point of interest.
                   </td>
                   <td>m</td>
-                </tr>
-                <tr>
-                  <td><em><b>H</b></em></td>
-                  <td>
-                    Interslice Normal Water Forces: per meter in the z-direction exerted in the x-coordinate direction between each pair of adjacent slices
-                  </td>
-                  <td>N/m</td>
                 </tr>
                 <tr>
                   <td><em><b>h</b></em></td>
@@ -278,11 +278,6 @@
                   <td>kg</td>
                 </tr>
                 <tr>
-                  <td><em>n</em></td>
-                  <td>Number of Slices: the slip mass has been divided into</td>
-                  <td>--</td>
-                </tr>
-                <tr>
                   <td><em><b>N</b></em></td>
                   <td>
                     Normal Forces: total reactive forces per meter in the z-direction for each slice of a soil surface subject to a body resting on it
@@ -297,16 +292,16 @@
                   <td>N/m</td>
                 </tr>
                 <tr>
+                  <td><em>n</em></td>
+                  <td>Number of Slices: the slip mass has been divided into</td>
+                  <td>--</td>
+                </tr>
+                <tr>
                   <td><em>P</em></td>
                   <td>
                     Resistive Shear Force: Mohr Coulomb frictional force that describes the limit of mobilized shear force that can be withstood before failure
                   </td>
                   <td>N</td>
-                </tr>
-                <tr>
-                  <td><em>p</em></td>
-                  <td>Pressure: A force exerted over an area</td>
-                  <td>Pa</td>
                 </tr>
                 <tr>
                   <td><em><b>P</b></em></td>
@@ -316,9 +311,21 @@
                   <td>N/m</td>
                 </tr>
                 <tr>
+                  <td><em>p</em></td>
+                  <td>Pressure: A force exerted over an area</td>
+                  <td>Pa</td>
+                </tr>
+                <tr>
                   <td><em><b>Q</b></em></td>
                   <td>
                     External Forces: forces per meter in the z-direction acting into the surface from the midpoint of each slice
+                  </td>
+                  <td>N/m</td>
+                </tr>
+                <tr>
+                  <td><em><b>R</b></em></td>
+                  <td>
+                    Resistive Shear Forces Without the Influence of Interslice Forces: per meter in the z-direction for each slice
                   </td>
                   <td>N/m</td>
                 </tr>
@@ -328,13 +335,6 @@
                     Length of the Moment Arm: distance between a force causing rotation and the axis of rotation
                   </td>
                   <td>m</td>
-                </tr>
-                <tr>
-                  <td><em><b>R</b></em></td>
-                  <td>
-                    Resistive Shear Forces Without the Influence of Interslice Forces: per meter in the z-direction for each slice
-                  </td>
-                  <td>N/m</td>
                 </tr>
                 <tr>
                   <td><em><b>r</b></em></td>
@@ -365,11 +365,6 @@
                   <td>N/m</td>
                 </tr>
                 <tr>
-                  <td><em>u</em></td>
-                  <td>Pore Pressure: from water within the soil</td>
-                  <td>Pa</td>
-                </tr>
-                <tr>
                   <td><em><b>U</b><sub>b</sub></em></td>
                   <td>
                     Base Hydrostatic Forces: per meter in the z-direction from water pressure within each slice
@@ -384,18 +379,16 @@
                   <td>N/m</td>
                 </tr>
                 <tr>
+                  <td><em>u</em></td>
+                  <td>Pore Pressure: from water within the soil</td>
+                  <td>Pa</td>
+                </tr>
+                <tr>
                   <td><em>V</em></td>
                   <td>
                     Volume: the amount of space that a substance or object occupies.
                   </td>
                   <td>m<sup>3</sup></td>
-                </tr>
-                <tr>
-                  <td><em>v</em></td>
-                  <td>
-                    Local Index: used as a bound variable index in calculations
-                  </td>
-                  <td>--</td>
                 </tr>
                 <tr>
                   <td><em><b>V</b><sub>dry</sub></em></td>
@@ -412,6 +405,13 @@
                   <td>m<sup>3</sup></td>
                 </tr>
                 <tr>
+                  <td><em>v</em></td>
+                  <td>
+                    Local Index: used as a bound variable index in calculations
+                  </td>
+                  <td>--</td>
+                </tr>
+                <tr>
                   <td><em>W</em></td>
                   <td>Weight: The gravitational force acting on an object</td>
                   <td>N</td>
@@ -420,6 +420,13 @@
                   <td><em><b>W</b></em></td>
                   <td>
                     Weights: downward force per meter in the z-direction on each slice caused by gravity
+                  </td>
+                  <td>N/m</td>
+                </tr>
+                <tr>
+                  <td><em><b>X</b></em></td>
+                  <td>
+                    Interslice Shear Forces: per meter in the z-direction exerted between adjacent slices
                   </td>
                   <td>N/m</td>
                 </tr>
@@ -455,13 +462,6 @@
                     Minimum Exit X-Coordinate: minimum potential x-coordinate for the exit point of a slip surface
                   </td>
                   <td>m</td>
-                </tr>
-                <tr>
-                  <td><em><b>X</b></em></td>
-                  <td>
-                    Interslice Shear Forces: per meter in the z-direction exerted between adjacent slices
-                  </td>
-                  <td>N/m</td>
                 </tr>
                 <tr>
                   <td><em><b>x</b><sub>cs</sub>,<b>y</b><sub>cs</sub></em></td>

--- a/code/stable/ssp/Website/SSP_SRS.html
+++ b/code/stable/ssp/Website/SSP_SRS.html
@@ -141,6 +141,13 @@
                   <td>--</td>
                 </tr>
                 <tr>
+                  <td><em>F<sub>S</sub><sup>min</sup></em></td>
+                  <td>
+                    Minimum Factor of Safety: The minimum factor of safety associated with the critical slip surface
+                  </td>
+                  <td>--</td>
+                </tr>
+                <tr>
                   <td><em>F<sub>x</sub></em></td>
                   <td>X-Component of the Force: </td>
                   <td>N</td>
@@ -149,13 +156,6 @@
                   <td><em>F<sub>y</sub></em></td>
                   <td>Y-Component of the Force: </td>
                   <td>N</td>
-                </tr>
-                <tr>
-                  <td><em>F<sub>S</sub><sup>min</sup></em></td>
-                  <td>
-                    Minimum Factor of Safety: The minimum factor of safety associated with the critical slip surface
-                  </td>
-                  <td>--</td>
                 </tr>
                 <tr>
                   <td><em><b>F</b></em></td>

--- a/code/stable/swhs/SRS/SWHS_SRS.tex
+++ b/code/stable/swhs/SRS/SWHS_SRS.tex
@@ -80,13 +80,13 @@ ${C^{S}}$ & Specific heat capacity of a solid & $\frac{\text{J}}{(\text{kg}{}^{\
 \\
 ${C^{V}}$ & Specific heat capacity of a vapour & $\frac{\text{J}}{(\text{kg}{}^{\circ}\text{C})}$
 \\
-${C_{tol}}$ & Relative tolerance for conservation of energy & --
-\\
-${C_{W}}$ & Specific heat capacity of water & $\frac{\text{J}}{(\text{kg}{}^{\circ}\text{C})}$
-\\
 ${{C_{P}}^{L}}$ & Specific heat capacity of PCM as a liquid & $\frac{\text{J}}{(\text{kg}{}^{\circ}\text{C})}$
 \\
 ${{C_{P}}^{S}}$ & Specific heat capacity of PCM as a solid & $\frac{\text{J}}{(\text{kg}{}^{\circ}\text{C})}$
+\\
+${C_{tol}}$ & Relative tolerance for conservation of energy & --
+\\
+${C_{W}}$ & Specific heat capacity of water & $\frac{\text{J}}{(\text{kg}{}^{\circ}\text{C})}$
 \\
 $D$ & Diameter of tank & m
 \\
@@ -152,21 +152,21 @@ ${T_{init}}$ & Initial temperature & ${}^{\circ}$C
 \\
 ${T_{melt}}$ & Melting point temperature & ${}^{\circ}$C
 \\
+${{T_{melt}}^{P}}$ & Melting point temperature for PCM & ${}^{\circ}$C
+\\
 ${T_{P}}$ & Temperature of the phase change material & ${}^{\circ}$C
 \\
 ${T_{W}}$ & Temperature of the water & ${}^{\circ}$C
-\\
-${{T_{melt}}^{P}}$ & Melting point temperature for PCM & ${}^{\circ}$C
 \\
 $t$ & Time & s
 \\
 ${t_{final}}$ & Final time & s
 \\
-${t_{step}}$ & Time step for simulation & s
-\\
 ${{t_{melt}}^{final}}$ & Time at which melting of PCM ends & s
 \\
 ${{t_{melt}}^{init}}$ & Time at which melting of PCM begins & s
+\\
+${t_{step}}$ & Time step for simulation & s
 \\
 $V$ & Volume & $\text{m}^{3}$
 \\
@@ -188,11 +188,11 @@ ${ρ_{W}}$ & Density of water & $\frac{\text{kg}}{\text{m}^{3}}$
 \\
 $τ$ & Dummy variable for integration over time & s
 \\
-${τ_{W}}$ & ODE parameter for water & s
-\\
 ${{τ_{P}}^{L}}$ & ODE parameter for liquid PCM & s
 \\
 ${{τ_{P}}^{S}}$ & ODE parameter for solid PCM & s
+\\
+${τ_{W}}$ & ODE parameter for water & s
 \\
 $ϕ$ & Melt fraction & --
 \\
@@ -994,11 +994,11 @@ ${A_{C}}$ & ${A_{C}}>0$ & ${A_{C}}\leq{}{{A_{C}}^{max}}$ & $0.12$ $\text{m}^{2}$
 \\
 ${A_{P}}$ & ${A_{P}}>0$ & ${V_{P}}\leq{}{A_{P}}\leq{}\frac{2}{{h_{min}}} {V_{tank}}$ & $1.2$ $\text{m}^{2}$ & 10$\%$
 \\
-${C_{W}}$ & ${C_{W}}>0$ & ${{C_{W}}^{min}}<{C_{W}}<{{C_{W}}^{max}}$ & $4.186\cdot{}10^{3}$ $\frac{\text{J}}{(\text{kg}{}^{\circ}\text{C})}$ & 10$\%$
-\\
 ${{C_{P}}^{L}}$ & ${{C_{P}}^{L}}>0$ & ${{{C_{P}}^{L}}_{min}}<{{C_{P}}^{L}}<{{{C_{P}}^{L}}_{max}}$ & $2.27\cdot{}10^{3}$ $\frac{\text{J}}{(\text{kg}{}^{\circ}\text{C})}$ & 10$\%$
 \\
 ${{C_{P}}^{S}}$ & ${{C_{P}}^{S}}>0$ & ${{{C_{P}}^{S}}_{min}}<{{C_{P}}^{S}}<{{{C_{P}}^{S}}_{max}}$ & $1.76\cdot{}10^{3}$ $\frac{\text{J}}{(\text{kg}{}^{\circ}\text{C})}$ & 10$\%$
+\\
+${C_{W}}$ & ${C_{W}}>0$ & ${{C_{W}}^{min}}<{C_{W}}<{{C_{W}}^{max}}$ & $4.186\cdot{}10^{3}$ $\frac{\text{J}}{(\text{kg}{}^{\circ}\text{C})}$ & 10$\%$
 \\
 $D$ & $D>0$ & -- & $0.412$ m & 10$\%$
 \\
@@ -1090,11 +1090,11 @@ ${A_{P}}$ & Phase change material surface area & $\text{m}^{2}$
 \\
 ${A_{tol}}$ & Absolute tolerance & --
 \\
-${C_{W}}$ & Specific heat capacity of water & $\frac{\text{J}}{(\text{kg}{}^{\circ}\text{C})}$
-\\
 ${{C_{P}}^{L}}$ & Specific heat capacity of PCM as a liquid & $\frac{\text{J}}{(\text{kg}{}^{\circ}\text{C})}$
 \\
 ${{C_{P}}^{S}}$ & Specific heat capacity of PCM as a solid & $\frac{\text{J}}{(\text{kg}{}^{\circ}\text{C})}$
+\\
+${C_{W}}$ & Specific heat capacity of water & $\frac{\text{J}}{(\text{kg}{}^{\circ}\text{C})}$
 \\
 $D$ & Diameter of tank & m
 \\

--- a/code/stable/swhs/SRS/SWHS_SRS.tex
+++ b/code/stable/swhs/SRS/SWHS_SRS.tex
@@ -100,11 +100,11 @@ ${{{E_{P}}_{melt}}^{init}}$ & Change in heat energy in the PCM at the instant wh
 \\
 $g$ & Volumetric heat generation per unit volume & $\frac{\text{W}}{\text{m}^{3}}$
 \\
+${H_{f}}$ & Specific latent heat of fusion & $\frac{\text{J}}{\text{kg}}$
+\\
 $h$ & Convective heat transfer coefficient & $\frac{\text{W}}{(\text{m}^{2}{}^{\circ}\text{C})}$
 \\
 ${h_{C}}$ & Convective heat transfer coefficient between coil and water & $\frac{\text{W}}{(\text{m}^{2}{}^{\circ}\text{C})}$
-\\
-${H_{f}}$ & Specific latent heat of fusion & $\frac{\text{J}}{\text{kg}}$
 \\
 ${h_{min}}$ & Minimum thickness of a sheet of PCM & m
 \\
@@ -122,6 +122,8 @@ $\mathbf{\hat{n}}$ & Unit outward normal vector for a surface & --
 \\
 $Q$ & Latent heat & J
 \\
+${Q_{P}}$ & Latent heat energy added to PCM & J
+\\
 $q$ & Heat flux & $\frac{\text{W}}{\text{m}^{2}}$
 \\
 ${q_{C}}$ & Heat flux into the water from the coil & $\frac{\text{W}}{\text{m}^{2}}$
@@ -132,15 +134,11 @@ ${q_{out}}$ & Heat flux output & $\frac{\text{W}}{\text{m}^{2}}$
 \\
 ${q_{P}}$ & Heat flux into the PCM from water & $\frac{\text{W}}{\text{m}^{2}}$
 \\
-${Q_{P}}$ & Latent heat energy added to PCM & J
-\\
 $\mathbf{q}$ & Thermal flux vector & $\frac{\text{W}}{\text{m}^{2}}$
 \\
 $S$ & Surface & $\text{m}^{2}$
 \\
 $T$ & Temperature & ${}^{\circ}$C
-\\
-$t$ & Time & s
 \\
 $ΔT$ & Change in temperature & ${}^{\circ}$C
 \\
@@ -150,23 +148,25 @@ ${T_{C}}$ & Temperature of the heating coil & ${}^{\circ}$C
 \\
 ${T_{env}}$ & Temperature of the environment & ${}^{\circ}$C
 \\
-${t_{final}}$ & Final time & s
-\\
 ${T_{init}}$ & Initial temperature & ${}^{\circ}$C
 \\
 ${T_{melt}}$ & Melting point temperature & ${}^{\circ}$C
 \\
 ${T_{P}}$ & Temperature of the phase change material & ${}^{\circ}$C
 \\
-${t_{step}}$ & Time step for simulation & s
-\\
 ${T_{W}}$ & Temperature of the water & ${}^{\circ}$C
+\\
+${{T_{melt}}^{P}}$ & Melting point temperature for PCM & ${}^{\circ}$C
+\\
+$t$ & Time & s
+\\
+${t_{final}}$ & Final time & s
+\\
+${t_{step}}$ & Time step for simulation & s
 \\
 ${{t_{melt}}^{final}}$ & Time at which melting of PCM ends & s
 \\
 ${{t_{melt}}^{init}}$ & Time at which melting of PCM begins & s
-\\
-${{T_{melt}}^{P}}$ & Melting point temperature for PCM & ${}^{\circ}$C
 \\
 $V$ & Volume & $\text{m}^{3}$
 \\
@@ -1002,9 +1002,9 @@ ${{C_{P}}^{S}}$ & ${{C_{P}}^{S}}>0$ & ${{{C_{P}}^{S}}_{min}}<{{C_{P}}^{S}}<{{{C_
 \\
 $D$ & $D>0$ & -- & $0.412$ m & 10$\%$
 \\
-${h_{C}}$ & ${h_{C}}>0$ & ${{h_{C}}^{min}}\leq{}{h_{C}}\leq{}{{h_{C}}^{max}}$ & $1.0\cdot{}10^{3}$ $\frac{\text{W}}{(\text{m}^{2}{}^{\circ}\text{C})}$ & 10$\%$
-\\
 ${H_{f}}$ & ${H_{f}}>0$ & ${{H_{f}}_{min}}<{H_{f}}<{{H_{f}}_{max}}$ & $211.6\cdot{}10^{3}$ $\frac{\text{J}}{\text{kg}}$ & 10$\%$
+\\
+${h_{C}}$ & ${h_{C}}>0$ & ${{h_{C}}^{min}}\leq{}{h_{C}}\leq{}{{h_{C}}^{max}}$ & $1.0\cdot{}10^{3}$ $\frac{\text{W}}{(\text{m}^{2}{}^{\circ}\text{C})}$ & 10$\%$
 \\
 ${h_{P}}$ & ${h_{P}}>0$ & ${{h_{P}}^{min}}\leq{}{h_{P}}\leq{}{{h_{P}}^{max}}$ & $1.0\cdot{}10^{3}$ $\frac{\text{W}}{(\text{m}^{2}{}^{\circ}\text{C})}$ & 10$\%$
 \\
@@ -1012,13 +1012,13 @@ $L$ & $L>0$ & ${L_{min}}\leq{}L\leq{}{L_{max}}$ & $1.5$ m & 10$\%$
 \\
 ${T_{C}}$ & $0<{T_{C}}<100$ & -- & $50.0$ ${}^{\circ}$C & 10$\%$
 \\
-${t_{final}}$ & ${t_{final}}>0$ & ${t_{final}}<{{t_{final}}^{max}}$ & $50.0\cdot{}10^{3}$ s & 10$\%$
-\\
 ${T_{init}}$ & $0<{T_{init}}<{T_{melt}}$ & -- & $40.0$ ${}^{\circ}$C & 10$\%$
 \\
-${t_{step}}$ & $0<{t_{step}}<{t_{final}}$ & -- & $0.01$ s & 10$\%$
-\\
 ${{T_{melt}}^{P}}$ & $0<{{T_{melt}}^{P}}<{T_{C}}$ & -- & $44.2$ ${}^{\circ}$C & 10$\%$
+\\
+${t_{final}}$ & ${t_{final}}>0$ & ${t_{final}}<{{t_{final}}^{max}}$ & $50.0\cdot{}10^{3}$ s & 10$\%$
+\\
+${t_{step}}$ & $0<{t_{step}}<{t_{final}}$ & -- & $0.01$ s & 10$\%$
 \\
 ${V_{P}}$ & $0<{V_{P}}<{V_{tank}}$ & ${V_{P}}\geq{}MINFRACT {V_{tank}}$ & $0.05$ $\text{m}^{3}$ & 10$\%$
 \\
@@ -1098,9 +1098,9 @@ ${{C_{P}}^{S}}$ & Specific heat capacity of PCM as a solid & $\frac{\text{J}}{(\
 \\
 $D$ & Diameter of tank & m
 \\
-${h_{C}}$ & Convective heat transfer coefficient between coil and water & $\frac{\text{W}}{(\text{m}^{2}{}^{\circ}\text{C})}$
-\\
 ${H_{f}}$ & Specific latent heat of fusion & $\frac{\text{J}}{\text{kg}}$
+\\
+${h_{C}}$ & Convective heat transfer coefficient between coil and water & $\frac{\text{W}}{(\text{m}^{2}{}^{\circ}\text{C})}$
 \\
 ${h_{P}}$ & Convective heat transfer coefficient between PCM and water & $\frac{\text{W}}{(\text{m}^{2}{}^{\circ}\text{C})}$
 \\
@@ -1110,13 +1110,13 @@ ${R_{tol}}$ & Relative tolerance & --
 \\
 ${T_{C}}$ & Temperature of the heating coil & ${}^{\circ}$C
 \\
-${t_{final}}$ & Final time & s
-\\
 ${T_{init}}$ & Initial temperature & ${}^{\circ}$C
 \\
-${t_{step}}$ & Time step for simulation & s
-\\
 ${{T_{melt}}^{P}}$ & Melting point temperature for PCM & ${}^{\circ}$C
+\\
+${t_{final}}$ & Final time & s
+\\
+${t_{step}}$ & Time step for simulation & s
 \\
 ${V_{P}}$ & Volume of PCM & $\text{m}^{3}$
 \\
@@ -1343,13 +1343,13 @@ ${{{C_{P}}^{S}}_{max}}$ & maximum specific heat capacity of PCM as a solid & $40
 \\
 ${{{C_{P}}^{S}}_{min}}$ & minimum specific heat capacity of PCM as a solid & $100$ & $\frac{\text{J}}{(\text{kg}{}^{\circ}\text{C})}$
 \\
-${{h_{C}}^{max}}$ & maximum convective heat transfer coefficient between coil and water & $10000$ & $\frac{\text{W}}{(\text{m}^{2}{}^{\circ}\text{C})}$
-\\
-${{h_{C}}^{min}}$ & minimum convective heat transfer coefficient between coil and water & $10$ & $\frac{\text{W}}{(\text{m}^{2}{}^{\circ}\text{C})}$
-\\
 ${{H_{f}}_{max}}$ & maximum specific latent heat of fusion & $1000000$ & $\frac{\text{J}}{(\text{kg}{}^{\circ}\text{C})}$
 \\
 ${{H_{f}}_{min}}$ & minimum specific latent heat of fusion & $0$ & $\frac{\text{J}}{(\text{kg}{}^{\circ}\text{C})}$
+\\
+${{h_{C}}^{max}}$ & maximum convective heat transfer coefficient between coil and water & $10000$ & $\frac{\text{W}}{(\text{m}^{2}{}^{\circ}\text{C})}$
+\\
+${{h_{C}}^{min}}$ & minimum convective heat transfer coefficient between coil and water & $10$ & $\frac{\text{W}}{(\text{m}^{2}{}^{\circ}\text{C})}$
 \\
 ${{h_{P}}^{max}}$ & maximum convective heat transfer coefficient between PCM and water & $10000$ & $\frac{\text{W}}{(\text{m}^{2}{}^{\circ}\text{C})}$
 \\

--- a/code/stable/swhs/Website/SWHS_SRS.html
+++ b/code/stable/swhs/Website/SWHS_SRS.html
@@ -171,6 +171,11 @@
                   <td>W/m<sup>3</sup></td>
                 </tr>
                 <tr>
+                  <td><em>H<sub>f</sub></em></td>
+                  <td>Specific latent heat of fusion</td>
+                  <td>J/kg</td>
+                </tr>
+                <tr>
                   <td><em>h</em></td>
                   <td>Convective heat transfer coefficient</td>
                   <td>W/(m<sup>2</sup>&sdot;&deg;C)</td>
@@ -181,11 +186,6 @@
                     Convective heat transfer coefficient between coil and water
                   </td>
                   <td>W/(m<sup>2</sup>&sdot;&deg;C)</td>
-                </tr>
-                <tr>
-                  <td><em>H<sub>f</sub></em></td>
-                  <td>Specific latent heat of fusion</td>
-                  <td>J/kg</td>
                 </tr>
                 <tr>
                   <td><em>h<sub>min</sub></em></td>
@@ -228,6 +228,11 @@
                   <td>J</td>
                 </tr>
                 <tr>
+                  <td><em>Q<sub>P</sub></em></td>
+                  <td>Latent heat energy added to PCM</td>
+                  <td>J</td>
+                </tr>
+                <tr>
                   <td><em>q</em></td>
                   <td>Heat flux</td>
                   <td>W/m<sup>2</sup></td>
@@ -253,11 +258,6 @@
                   <td>W/m<sup>2</sup></td>
                 </tr>
                 <tr>
-                  <td><em>Q<sub>P</sub></em></td>
-                  <td>Latent heat energy added to PCM</td>
-                  <td>J</td>
-                </tr>
-                <tr>
                   <td><em><b>q</b></em></td>
                   <td>Thermal flux vector</td>
                   <td>W/m<sup>2</sup></td>
@@ -271,11 +271,6 @@
                   <td><em>T</em></td>
                   <td>Temperature</td>
                   <td>&deg;C</td>
-                </tr>
-                <tr>
-                  <td><em>t</em></td>
-                  <td>Time</td>
-                  <td>s</td>
                 </tr>
                 <tr>
                   <td><em>ΔT</em></td>
@@ -298,11 +293,6 @@
                   <td>&deg;C</td>
                 </tr>
                 <tr>
-                  <td><em>t<sub>final</sub></em></td>
-                  <td>Final time</td>
-                  <td>s</td>
-                </tr>
-                <tr>
                   <td><em>T<sub>init</sub></em></td>
                   <td>Initial temperature</td>
                   <td>&deg;C</td>
@@ -318,14 +308,29 @@
                   <td>&deg;C</td>
                 </tr>
                 <tr>
-                  <td><em>t<sub>step</sub></em></td>
-                  <td>Time step for simulation</td>
-                  <td>s</td>
-                </tr>
-                <tr>
                   <td><em>T<sub>W</sub></em></td>
                   <td>Temperature of the water</td>
                   <td>&deg;C</td>
+                </tr>
+                <tr>
+                  <td><em>T<sub>melt</sub><sup>P</sup></em></td>
+                  <td>Melting point temperature for PCM</td>
+                  <td>&deg;C</td>
+                </tr>
+                <tr>
+                  <td><em>t</em></td>
+                  <td>Time</td>
+                  <td>s</td>
+                </tr>
+                <tr>
+                  <td><em>t<sub>final</sub></em></td>
+                  <td>Final time</td>
+                  <td>s</td>
+                </tr>
+                <tr>
+                  <td><em>t<sub>step</sub></em></td>
+                  <td>Time step for simulation</td>
+                  <td>s</td>
                 </tr>
                 <tr>
                   <td><em>t<sub>melt</sub><sup>final</sup></em></td>
@@ -336,11 +341,6 @@
                   <td><em>t<sub>melt</sub><sup>init</sup></em></td>
                   <td>Time at which melting of PCM begins</td>
                   <td>s</td>
-                </tr>
-                <tr>
-                  <td><em>T<sub>melt</sub><sup>P</sup></em></td>
-                  <td>Melting point temperature for PCM</td>
-                  <td>&deg;C</td>
                 </tr>
                 <tr>
                   <td><em>V</em></td>
@@ -2394,6 +2394,15 @@
                       <td>10<em>%</em></td>
                     </tr>
                     <tr>
+                      <td><em>H<sub>f</sub></em></td>
+                      <td><em>H<sub>f</sub>&thinsp;&gt;&thinsp;0</em></td>
+                      <td>
+                        <em>H<sub>f</sub><sub>min</sub>&thinsp;&lt;&thinsp;H<sub>f</sub>&thinsp;&lt;&thinsp;H<sub>f</sub><sub>max</sub></em>
+                      </td>
+                      <td><em>211.6&sdot;10<sup>3</sup></em> J/kg</td>
+                      <td>10<em>%</em></td>
+                    </tr>
+                    <tr>
                       <td><em>h<sub>C</sub></em></td>
                       <td><em>h<sub>C</sub>&thinsp;&gt;&thinsp;0</em></td>
                       <td>
@@ -2402,15 +2411,6 @@
                       <td>
                         <em>1.0&sdot;10<sup>3</sup></em> W/(m<sup>2</sup>&sdot;&deg;C)
                       </td>
-                      <td>10<em>%</em></td>
-                    </tr>
-                    <tr>
-                      <td><em>H<sub>f</sub></em></td>
-                      <td><em>H<sub>f</sub>&thinsp;&gt;&thinsp;0</em></td>
-                      <td>
-                        <em>H<sub>f</sub><sub>min</sub>&thinsp;&lt;&thinsp;H<sub>f</sub>&thinsp;&lt;&thinsp;H<sub>f</sub><sub>max</sub></em>
-                      </td>
-                      <td><em>211.6&sdot;10<sup>3</sup></em> J/kg</td>
                       <td>10<em>%</em></td>
                     </tr>
                     <tr>
@@ -2443,15 +2443,6 @@
                       <td>10<em>%</em></td>
                     </tr>
                     <tr>
-                      <td><em>t<sub>final</sub></em></td>
-                      <td><em>t<sub>final</sub>&thinsp;&gt;&thinsp;0</em></td>
-                      <td>
-                        <em>t<sub>final</sub>&thinsp;&lt;&thinsp;t<sub>final</sub><sup>max</sup></em>
-                      </td>
-                      <td><em>50.0&sdot;10<sup>3</sup></em> s</td>
-                      <td>10<em>%</em></td>
-                    </tr>
-                    <tr>
                       <td><em>T<sub>init</sub></em></td>
                       <td>
                         <em>0&thinsp;&lt;&thinsp;T<sub>init</sub>&thinsp;&lt;&thinsp;T<sub>melt</sub></em>
@@ -2461,21 +2452,30 @@
                       <td>10<em>%</em></td>
                     </tr>
                     <tr>
-                      <td><em>t<sub>step</sub></em></td>
-                      <td>
-                        <em>0&thinsp;&lt;&thinsp;t<sub>step</sub>&thinsp;&lt;&thinsp;t<sub>final</sub></em>
-                      </td>
-                      <td>--</td>
-                      <td><em>0.01</em> s</td>
-                      <td>10<em>%</em></td>
-                    </tr>
-                    <tr>
                       <td><em>T<sub>melt</sub><sup>P</sup></em></td>
                       <td>
                         <em>0&thinsp;&lt;&thinsp;T<sub>melt</sub><sup>P</sup>&thinsp;&lt;&thinsp;T<sub>C</sub></em>
                       </td>
                       <td>--</td>
                       <td><em>44.2</em> &deg;C</td>
+                      <td>10<em>%</em></td>
+                    </tr>
+                    <tr>
+                      <td><em>t<sub>final</sub></em></td>
+                      <td><em>t<sub>final</sub>&thinsp;&gt;&thinsp;0</em></td>
+                      <td>
+                        <em>t<sub>final</sub>&thinsp;&lt;&thinsp;t<sub>final</sub><sup>max</sup></em>
+                      </td>
+                      <td><em>50.0&sdot;10<sup>3</sup></em> s</td>
+                      <td>10<em>%</em></td>
+                    </tr>
+                    <tr>
+                      <td><em>t<sub>step</sub></em></td>
+                      <td>
+                        <em>0&thinsp;&lt;&thinsp;t<sub>step</sub>&thinsp;&lt;&thinsp;t<sub>final</sub></em>
+                      </td>
+                      <td>--</td>
+                      <td><em>0.01</em> s</td>
                       <td>10<em>%</em></td>
                     </tr>
                     <tr>
@@ -2684,16 +2684,16 @@
                   <td>m</td>
                 </tr>
                 <tr>
+                  <td><em>H<sub>f</sub></em></td>
+                  <td>Specific latent heat of fusion</td>
+                  <td>J/kg</td>
+                </tr>
+                <tr>
                   <td><em>h<sub>C</sub></em></td>
                   <td>
                     Convective heat transfer coefficient between coil and water
                   </td>
                   <td>W/(m<sup>2</sup>&sdot;&deg;C)</td>
-                </tr>
-                <tr>
-                  <td><em>H<sub>f</sub></em></td>
-                  <td>Specific latent heat of fusion</td>
-                  <td>J/kg</td>
                 </tr>
                 <tr>
                   <td><em>h<sub>P</sub></em></td>
@@ -2716,24 +2716,24 @@
                   <td>&deg;C</td>
                 </tr>
                 <tr>
-                  <td><em>t<sub>final</sub></em></td>
-                  <td>Final time</td>
-                  <td>s</td>
-                </tr>
-                <tr>
                   <td><em>T<sub>init</sub></em></td>
                   <td>Initial temperature</td>
                   <td>&deg;C</td>
                 </tr>
                 <tr>
-                  <td><em>t<sub>step</sub></em></td>
-                  <td>Time step for simulation</td>
-                  <td>s</td>
-                </tr>
-                <tr>
                   <td><em>T<sub>melt</sub><sup>P</sup></em></td>
                   <td>Melting point temperature for PCM</td>
                   <td>&deg;C</td>
+                </tr>
+                <tr>
+                  <td><em>t<sub>final</sub></em></td>
+                  <td>Final time</td>
+                  <td>s</td>
+                </tr>
+                <tr>
+                  <td><em>t<sub>step</sub></em></td>
+                  <td>Time step for simulation</td>
+                  <td>s</td>
                 </tr>
                 <tr>
                   <td><em>V<sub>P</sub></em></td>
@@ -4603,6 +4603,18 @@
               <td>J/(kg&sdot;&deg;C)</td>
             </tr>
             <tr>
+              <td><em>H<sub>f</sub><sub>max</sub></em></td>
+              <td>maximum specific latent heat of fusion</td>
+              <td><em>1000000</em></td>
+              <td>J/(kg&sdot;&deg;C)</td>
+            </tr>
+            <tr>
+              <td><em>H<sub>f</sub><sub>min</sub></em></td>
+              <td>minimum specific latent heat of fusion</td>
+              <td><em>0</em></td>
+              <td>J/(kg&sdot;&deg;C)</td>
+            </tr>
+            <tr>
               <td><em>h<sub>C</sub><sup>max</sup></em></td>
               <td>
                 maximum convective heat transfer coefficient between coil and water
@@ -4617,18 +4629,6 @@
               </td>
               <td><em>10</em></td>
               <td>W/(m<sup>2</sup>&sdot;&deg;C)</td>
-            </tr>
-            <tr>
-              <td><em>H<sub>f</sub><sub>max</sub></em></td>
-              <td>maximum specific latent heat of fusion</td>
-              <td><em>1000000</em></td>
-              <td>J/(kg&sdot;&deg;C)</td>
-            </tr>
-            <tr>
-              <td><em>H<sub>f</sub><sub>min</sub></em></td>
-              <td>minimum specific latent heat of fusion</td>
-              <td><em>0</em></td>
-              <td>J/(kg&sdot;&deg;C)</td>
             </tr>
             <tr>
               <td><em>h<sub>P</sub><sup>max</sup></em></td>

--- a/code/stable/swhs/Website/SWHS_SRS.html
+++ b/code/stable/swhs/Website/SWHS_SRS.html
@@ -119,16 +119,6 @@
                   <td>J/(kg&sdot;&deg;C)</td>
                 </tr>
                 <tr>
-                  <td><em>C<sub>tol</sub></em></td>
-                  <td>Relative tolerance for conservation of energy</td>
-                  <td>--</td>
-                </tr>
-                <tr>
-                  <td><em>C<sub>W</sub></em></td>
-                  <td>Specific heat capacity of water</td>
-                  <td>J/(kg&sdot;&deg;C)</td>
-                </tr>
-                <tr>
                   <td><em>C<sub>P</sub><sup>L</sup></em></td>
                   <td>Specific heat capacity of PCM as a liquid</td>
                   <td>J/(kg&sdot;&deg;C)</td>
@@ -136,6 +126,16 @@
                 <tr>
                   <td><em>C<sub>P</sub><sup>S</sup></em></td>
                   <td>Specific heat capacity of PCM as a solid</td>
+                  <td>J/(kg&sdot;&deg;C)</td>
+                </tr>
+                <tr>
+                  <td><em>C<sub>tol</sub></em></td>
+                  <td>Relative tolerance for conservation of energy</td>
+                  <td>--</td>
+                </tr>
+                <tr>
+                  <td><em>C<sub>W</sub></em></td>
+                  <td>Specific heat capacity of water</td>
                   <td>J/(kg&sdot;&deg;C)</td>
                 </tr>
                 <tr>
@@ -303,6 +303,11 @@
                   <td>&deg;C</td>
                 </tr>
                 <tr>
+                  <td><em>T<sub>melt</sub><sup>P</sup></em></td>
+                  <td>Melting point temperature for PCM</td>
+                  <td>&deg;C</td>
+                </tr>
+                <tr>
                   <td><em>T<sub>P</sub></em></td>
                   <td>Temperature of the phase change material</td>
                   <td>&deg;C</td>
@@ -310,11 +315,6 @@
                 <tr>
                   <td><em>T<sub>W</sub></em></td>
                   <td>Temperature of the water</td>
-                  <td>&deg;C</td>
-                </tr>
-                <tr>
-                  <td><em>T<sub>melt</sub><sup>P</sup></em></td>
-                  <td>Melting point temperature for PCM</td>
                   <td>&deg;C</td>
                 </tr>
                 <tr>
@@ -328,11 +328,6 @@
                   <td>s</td>
                 </tr>
                 <tr>
-                  <td><em>t<sub>step</sub></em></td>
-                  <td>Time step for simulation</td>
-                  <td>s</td>
-                </tr>
-                <tr>
                   <td><em>t<sub>melt</sub><sup>final</sup></em></td>
                   <td>Time at which melting of PCM ends</td>
                   <td>s</td>
@@ -340,6 +335,11 @@
                 <tr>
                   <td><em>t<sub>melt</sub><sup>init</sup></em></td>
                   <td>Time at which melting of PCM begins</td>
+                  <td>s</td>
+                </tr>
+                <tr>
+                  <td><em>t<sub>step</sub></em></td>
+                  <td>Time step for simulation</td>
                   <td>s</td>
                 </tr>
                 <tr>
@@ -393,11 +393,6 @@
                   <td>s</td>
                 </tr>
                 <tr>
-                  <td><em>τ<sub>W</sub></em></td>
-                  <td>ODE parameter for water</td>
-                  <td>s</td>
-                </tr>
-                <tr>
                   <td><em>τ<sub>P</sub><sup>L</sup></em></td>
                   <td>ODE parameter for liquid PCM</td>
                   <td>s</td>
@@ -405,6 +400,11 @@
                 <tr>
                   <td><em>τ<sub>P</sub><sup>S</sup></em></td>
                   <td>ODE parameter for solid PCM</td>
+                  <td>s</td>
+                </tr>
+                <tr>
+                  <td><em>τ<sub>W</sub></em></td>
+                  <td>ODE parameter for water</td>
                   <td>s</td>
                 </tr>
                 <tr>
@@ -2360,15 +2360,6 @@
                       <td>10<em>%</em></td>
                     </tr>
                     <tr>
-                      <td><em>C<sub>W</sub></em></td>
-                      <td><em>C<sub>W</sub>&thinsp;&gt;&thinsp;0</em></td>
-                      <td>
-                        <em>C<sub>W</sub><sup>min</sup>&thinsp;&lt;&thinsp;C<sub>W</sub>&thinsp;&lt;&thinsp;C<sub>W</sub><sup>max</sup></em>
-                      </td>
-                      <td><em>4.186&sdot;10<sup>3</sup></em> J/(kg&sdot;&deg;C)</td>
-                      <td>10<em>%</em></td>
-                    </tr>
-                    <tr>
                       <td><em>C<sub>P</sub><sup>L</sup></em></td>
                       <td><em>C<sub>P</sub><sup>L</sup>&thinsp;&gt;&thinsp;0</em></td>
                       <td>
@@ -2384,6 +2375,15 @@
                         <em>C<sub>P</sub><sup>S</sup><sub>min</sub>&thinsp;&lt;&thinsp;C<sub>P</sub><sup>S</sup>&thinsp;&lt;&thinsp;C<sub>P</sub><sup>S</sup><sub>max</sub></em>
                       </td>
                       <td><em>1.76&sdot;10<sup>3</sup></em> J/(kg&sdot;&deg;C)</td>
+                      <td>10<em>%</em></td>
+                    </tr>
+                    <tr>
+                      <td><em>C<sub>W</sub></em></td>
+                      <td><em>C<sub>W</sub>&thinsp;&gt;&thinsp;0</em></td>
+                      <td>
+                        <em>C<sub>W</sub><sup>min</sup>&thinsp;&lt;&thinsp;C<sub>W</sub>&thinsp;&lt;&thinsp;C<sub>W</sub><sup>max</sup></em>
+                      </td>
+                      <td><em>4.186&sdot;10<sup>3</sup></em> J/(kg&sdot;&deg;C)</td>
                       <td>10<em>%</em></td>
                     </tr>
                     <tr>
@@ -2664,11 +2664,6 @@
                   <td>--</td>
                 </tr>
                 <tr>
-                  <td><em>C<sub>W</sub></em></td>
-                  <td>Specific heat capacity of water</td>
-                  <td>J/(kg&sdot;&deg;C)</td>
-                </tr>
-                <tr>
                   <td><em>C<sub>P</sub><sup>L</sup></em></td>
                   <td>Specific heat capacity of PCM as a liquid</td>
                   <td>J/(kg&sdot;&deg;C)</td>
@@ -2676,6 +2671,11 @@
                 <tr>
                   <td><em>C<sub>P</sub><sup>S</sup></em></td>
                   <td>Specific heat capacity of PCM as a solid</td>
+                  <td>J/(kg&sdot;&deg;C)</td>
+                </tr>
+                <tr>
+                  <td><em>C<sub>W</sub></em></td>
+                  <td>Specific heat capacity of water</td>
                   <td>J/(kg&sdot;&deg;C)</td>
                 </tr>
                 <tr>


### PR DESCRIPTION
This PR addresses some inconsistency when sorting (discovered making innocuous changes on a yet-unpushed branch) where sorting of symbols could change (in the bad way, not the stable sort way) when un-equal items in the input list were in a different order. 

This PR also slightly altered the behaviour of symbol sorting such that having symbols v<sub>i</sub>, v<sub>f</sub><sup>AB</sup>, and v<sub>f</sub> would be sorted as: 
v<sub>f</sub>, v<sub>f</sub><sup>AB</sup>, v<sub>i</sub> instead of the current
v<sub>f</sub>, v<sub>i</sub>, v<sub>f</sub><sup>AB</sup>

If this is an undesirable change, I can back it out.

This PR also spurred two issues involving Symbols: #1605 and #1606.  