### PR TITLE
Introduce Multiplate for DocDesc

### DIFF
--- a/code/drasil-docLang/Drasil/ExtractDocDesc.hs
+++ b/code/drasil-docLang/Drasil/ExtractDocDesc.hs
@@ -309,47 +309,18 @@ ciGetDocDesc :: DocDesc -> [CI]
 ciGetDocDesc = concatMap ciGetDocSec
 
 ciGetDocSec :: DocSection -> [CI]
-ciGetDocSec RefSec{}            = []
-ciGetDocSec (IntroSec intro)    = ciGetIntro intro
-ciGetDocSec (StkhldrSec stk)    = ciGetStk stk
-ciGetDocSec GSDSec{}            = []
-ciGetDocSec (SSDSec ssd)        = ciGetSSD ssd
-ciGetDocSec ReqrmntSec{}        = []
-ciGetDocSec LCsSec{}            = []
-ciGetDocSec LCsSec'{}           = []
-ciGetDocSec UCsSec{}            = []
-ciGetDocSec TraceabilitySec{}   = []
-ciGetDocSec (AuxConstntSec aux) = ciGetAux aux
-ciGetDocSec Bibliography        = []
-ciGetDocSec AppndxSec{}         = []
-ciGetDocSec ExistingSolnSec{}   = []
+ciGetDocSec = foldFor docSec ciPlate
 
-ciGetIntro :: IntroSec -> [CI]
-ciGetIntro (IntroProg _ _ insub) = concatMap ciGetIntroSub insub
-
-ciGetIntroSub :: IntroSub -> [CI]
-ciGetIntroSub IPurpose{}          = []
-ciGetIntroSub IScope{}            = []
-ciGetIntroSub IChar{}             = []
-ciGetIntroSub (IOrgSec  _ ci _ _) = [ci]
-
-ciGetStk :: StkhldrSec -> [CI]
-ciGetStk (StkhldrProg  ci _)   = [ci]
-ciGetStk (StkhldrProg2 stksub) = concatMap ciGetStkSub stksub
-
-ciGetStkSub :: StkhldrSub -> [CI]
-ciGetStkSub (Client ci1 _) = [ci1]
-ciGetStkSub (Cstmr ci2)    = [ci2]
-
-ciGetSSD :: SSDSec -> [CI]
-ciGetSSD (SSDProg ssdsub) = concatMap ciGetSSDSub ssdsub
-
-ciGetSSDSub :: SSDSub -> [CI]
-ciGetSSDSub (SSDProblem pd) = ciGetProbDesc pd
-ciGetSSDSub SSDSolChSpec{}  = []
-
-ciGetProbDesc :: ProblemDescription -> [CI]
-ciGetProbDesc PDProg{} = []
-
-ciGetAux :: AuxConstntSec -> [CI]
-ciGetAux (AuxConsProg ci _) = [ci]
+ciPlate :: DLPlate (Constant [CI])
+ciPlate = preorderFold $ purePlate {
+  introSub = Constant <$> \case
+    (IOrgSec _ ci _ _) -> [ci]
+    _ -> [],
+  stkSec = Constant <$> \case
+    (StkhldrProg ci _) -> [ci]
+    (StkhldrProg2 _) -> [],
+  stkSub = Constant <$> \case
+   (Client ci _) -> [ci]
+   (Cstmr ci) -> [ci],
+   auxConsSec = Constant <$> \(AuxConsProg ci _) -> [ci]
+}

--- a/code/drasil-docLang/Drasil/ExtractDocDesc.hs
+++ b/code/drasil-docLang/Drasil/ExtractDocDesc.hs
@@ -6,6 +6,95 @@ import Language.Drasil hiding (Manual, Vector, Verb)
 import Theory.Drasil (DataDefinition, GenDefn, InstanceModel, Theory(..), TheoryModel)
 import Data.List(transpose)
 
+import Data.Generics.Multiplate (Multiplate(multiplate, mkPlate))
+
+data DLPlate f = DLPlate {
+  docSec :: DocSection -> f DocSection,
+  refSec :: RefSec -> f RefSec,
+  introSec :: IntroSec -> f IntroSec,
+  introSub :: IntroSub -> f IntroSub,
+  stkSec :: StkhldrSec -> f StkhldrSec,
+  stkSub :: StkhldrSub -> f StkhldrSub,
+  gsdSec :: GSDSec -> f GSDSec,
+  gsdSub :: GSDSub -> f GSDSub,
+  ssdSec :: SSDSec -> f SSDSec,
+  ssdSub :: SSDSub -> f SSDSub,
+  pdSec :: ProblemDescription -> f ProblemDescription,
+  pdSub :: PDSub -> f PDSub,
+  scsSub :: SCSSub -> f SCSSub,
+  reqSec :: ReqrmntSec -> f ReqrmntSec,
+  reqSub :: ReqsSub -> f ReqsSub,
+  lcsSec :: LCsSec -> f LCsSec,
+  lcsSec' :: LCsSec' -> f LCsSec',
+  ucsSec :: UCsSec -> f UCsSec,
+  traceSec :: TraceabilitySec -> f TraceabilitySec,
+  existSolnSec :: ExistingSolnSec -> f ExistingSolnSec,
+  auxConsSec :: AuxConstntSec -> f AuxConstntSec,
+  appendSec :: AppndxSec -> f AppndxSec
+}
+
+instance Multiplate DLPlate where
+  multiplate p = DLPlate ds res intro intro' stk stk' gs gs' ss ss' pd pd' sc
+    rs rs' lcp lcp' ucp ts es acs aps where
+    res (RefProg c x) = RefProg <$> pure c <*> pure x
+    ds (IntroSec x) = IntroSec <$> introSec p x
+    ds (StkhldrSec x) = StkhldrSec <$> stkSec p x
+    ds (GSDSec x) = GSDSec <$> gsdSec p x
+    ds (SSDSec x) = SSDSec <$> ssdSec p x
+    ds (ReqrmntSec x) = ReqrmntSec <$> reqSec p x
+    ds (LCsSec x) = LCsSec <$> lcsSec p x
+    ds (LCsSec' x) = LCsSec' <$> lcsSec' p x
+    ds (UCsSec x) = UCsSec <$> ucsSec p x
+    ds (TraceabilitySec x) = TraceabilitySec <$> traceSec p x
+    ds (ExistingSolnSec x) = ExistingSolnSec <$> existSolnSec p x
+    ds (AuxConstntSec x) = AuxConstntSec <$> auxConsSec p x
+    ds (AppndxSec x) = AppndxSec <$> appendSec p x
+    ds x = pure x
+
+    intro (IntroProg s1 s2 progs) = IntroProg <$> pure s1 <*> pure s2 <*>
+      traverse (introSub p) progs
+    intro' (IPurpose s) = IPurpose <$> pure s
+    intro' (IScope s1 s2) = IScope <$> pure s1 <*> pure s2
+    intro' (IChar s1 s2 s3) = IChar <$> pure s1 <*> pure s2 <*> pure s3
+    intro' (IOrgSec s1 c sect s2) = IOrgSec <$> pure s1 <*> pure c <*> pure sect <*> pure s2
+    stk (StkhldrProg c s) = StkhldrProg <$> pure c <*> pure s
+    stk (StkhldrProg2 progs) = StkhldrProg2 <$> traverse (stkSub p) progs
+    stk' (Client c s) = Client <$> pure c <*> pure s
+    stk' (Cstmr c) = Cstmr <$> pure c
+    gs (GSDProg s1 c labcon s2) = GSDProg <$> pure s1 <*> pure c <*> pure labcon <*> pure s2
+    gs (GSDProg2 x) = GSDProg2 <$> traverse (gsdSub p) x
+    gs' (SysCntxt c) = SysCntxt <$> pure c
+    gs' (UsrChars c) = UsrChars <$> pure c
+    gs' (SystCons c s) = SystCons <$> pure c <*> pure s
+    ss (SSDProg progs) = SSDProg <$> traverse (ssdSub p) progs
+    ss' (SSDProblem prog) = SSDProblem <$> pdSec p prog
+    ss' (SSDSolChSpec (SCSProg spec)) = SSDSolChSpec . SCSProg <$> traverse (scsSub p) spec
+    pd (PDProg s sect progs) = PDProg <$> pure s <*> pure sect <*> traverse (pdSub p) progs
+    pd' (Goals s ci) = Goals <$> pure s <*> pure ci
+    pd' (PhySysDesc nm s lc c) = PhySysDesc <$> pure nm <*> pure s <*> pure lc <*> pure c
+    sc Assumptions = pure Assumptions
+    sc (TMs s f t) = TMs <$> pure s <*> pure f <*> pure t
+    sc (GDs s f g d) = GDs <$> pure s <*> pure f <*> pure g <*> pure d
+    sc (DDs s f dd d) = DDs <$> pure s <*> pure f <*> pure dd <*> pure d
+    sc (IMs s f i d) = IMs <$> pure s <*> pure f <*> pure i <*> pure d
+    sc (Constraints s1 s2 s3 l) = Constraints <$> pure s1 <*> pure s2 <*> pure s3 <*> pure l
+    sc (CorrSolnPpties c) = CorrSolnPpties <$> pure c
+    rs (ReqsProg reqs) = ReqsProg <$> traverse (reqSub p) reqs
+    rs' (FReqsSub ci con) = FReqsSub <$> pure ci <*> pure con
+    rs' (NonFReqsSub c) = NonFReqsSub <$> pure c
+    lcp (LCsProg c) = LCsProg <$> pure c
+    lcp' (LCsProg' c) = LCsProg' <$> pure c
+    ucp (UCsProg c) = UCsProg <$> pure c
+    ts (TraceabilityProg llc sen con sect) = TraceabilityProg <$> pure llc <*>
+      pure sen <*> pure con <*> pure sect
+    es (ExistSolnProg contents) = ExistSolnProg <$> pure contents
+    acs (AuxConsProg ci qdef) = AuxConsProg <$> pure ci <*> pure qdef
+    aps (AppndxProg con) = AppndxProg <$> pure con
+  mkPlate b = DLPlate (b docSec) (b refSec) (b introSec) (b introSub) (b stkSec)
+    (b stkSub) (b gsdSec) (b gsdSub) (b ssdSec) (b ssdSub) (b pdSec) (b pdSub)
+    (b scsSub) (b reqSec) (b reqSub) (b lcsSec) (b lcsSec') (b ucsSec)
+    (b traceSec) (b existSolnSec) (b auxConsSec) (b appendSec)
+
 egetDocDesc :: DocDesc -> [Expr]
 egetDocDesc = concatMap egetDocSec
 

--- a/code/drasil-docLang/drasil-docLang.cabal
+++ b/code/drasil-docLang/drasil-docLang.cabal
@@ -40,6 +40,8 @@ library
     split >= 0.2.3.1,
     MissingH >= 1.4.0.1,
     parsec >= 3.1.9,
+    transformers >= 0.4.2.0,
+    multiplate >= 0.0.2,
     data-fix (>= 0.0.4 && <= 1.0),
     drasil-lang >= 0.1.59,
     drasil-data >= 0.1.12,

--- a/code/stack.yaml
+++ b/code/stack.yaml
@@ -50,7 +50,8 @@ packages:
 
 # Dependency packages to be pulled from upstream that are not in the resolver
 # (e.g., acme-missiles-0.3)
-extra-deps: []
+extra-deps:
+- multiplate-0.0.3@sha256:5d2ffc50d23c55008100b7a8b70f77b5fcce08c6f23822c5a6adc5b5b9356a32
 
 # Override default flag values for local packages and extra-deps
 flags: {}


### PR DESCRIPTION
This PR adds the infrastructure for a multiplate of `DocDesc` in docLang. Currently, it is used for the `cigetDocDesc`, `egetDocDesc`, and `getDocDesc` docLang passes. 

The plate infrastructure (and few configurable plates — ie. `secConPlate` and `sentencePlate`) should ideally lower the effort required to add new passes and further increase consistency within docLang. 