### PR TITLE
GOOL Values hold type information

### DIFF
--- a/code/drasil-code/Language/Drasil/Code/Code.hs
+++ b/code/drasil-code/Language/Drasil/Code/Code.hs
@@ -18,3 +18,4 @@ data CodeType = Boolean
               | List CodeType
               | Iterator CodeType
               | Object String
+              | Void

--- a/code/drasil-code/Language/Drasil/Code/Imperative/Helpers.hs
+++ b/code/drasil-code/Language/Drasil/Code/Imperative/Helpers.hs
@@ -2,10 +2,10 @@
 
 module Language.Drasil.Code.Imperative.Helpers (Pair(..), Terminator (..),
   ScopeTag(..), ModData(..), md, MethodData(..), mthd, StateVarData(..), svd,
-  TypeData(..), td, blank,verticalComma, angles,doubleQuotedText,himap,hicat,vicat,vibcat,vmap,
-  vimap,vibmap, mapPairFst, mapPairSnd, liftA4, liftA5, liftA6, liftA7, liftA8, 
-  liftList, lift2Lists, lift1List, liftPair, lift3Pair, lift4Pair, liftPairFst,
-  liftPairSnd
+  TypeData(..), td, ValData(..), vd, blank,verticalComma, angles,
+  doubleQuotedText,himap,hicat,vicat,vibcat,vmap,vimap,vibmap, mapPairFst, 
+  mapPairSnd, liftA4, liftA5, liftA6, liftA7, liftA8, liftList, lift2Lists,
+  lift1List, liftPair, lift3Pair, lift4Pair, liftPairFst, liftPairSnd
 ) where
 
 import Language.Drasil.Code.Code (CodeType)
@@ -47,6 +47,11 @@ data TypeData = TD {cType :: CodeType, typeDoc :: Doc}
 
 td :: CodeType -> Doc -> TypeData
 td = TD
+
+data ValData = VD {valName :: Maybe String, valType :: TypeData, valDoc :: Doc}
+
+vd :: Maybe String -> TypeData -> Doc -> ValData
+vd = VD
 
 blank :: Doc
 blank = text ""

--- a/code/drasil-code/Language/Drasil/Code/Imperative/Helpers.hs
+++ b/code/drasil-code/Language/Drasil/Code/Imperative/Helpers.hs
@@ -54,6 +54,7 @@ data TypeData = TD {cType :: CodeType, typeDoc :: Doc}
 td :: CodeType -> Doc -> TypeData
 td = TD
 
+-- Maybe String is the String representation of the value
 data ValData = VD {valName :: Maybe String, valType :: TypeData, valDoc :: Doc}
 
 vd :: Maybe String -> TypeData -> Doc -> ValData

--- a/code/drasil-code/Language/Drasil/Code/Imperative/Helpers.hs
+++ b/code/drasil-code/Language/Drasil/Code/Imperative/Helpers.hs
@@ -6,7 +6,7 @@ module Language.Drasil.Code.Imperative.Helpers (Pair(..), Terminator (..),
   angles,doubleQuotedText,himap,hicat,vicat,vibcat,vmap,vimap,vibmap, 
   mapPairFst, mapPairSnd, liftA4, liftA5, liftA6, liftA7, liftA8, liftList, 
   lift2Lists, lift1List, liftPair, lift3Pair, lift4Pair, liftPairFst, 
-  liftPairSnd, convType
+  liftPairSnd, getInnerType, convType
 ) where
 
 import Language.Drasil.Code.Code (CodeType(..))
@@ -145,6 +145,10 @@ liftPairFst (c, n) = fmap (, n) c
 
 liftPairSnd :: Functor f => (a, f b) -> f (a, b)
 liftPairSnd (c, n) = fmap (c ,) n
+
+getInnerType :: CodeType -> CodeType
+getInnerType (List innerT) = innerT
+getInnerType _ = error "Attempt to extract inner type of list from a non-list type" 
 
 convType :: (S.RenderSym repr) => CodeType -> repr (S.StateType repr)
 convType Boolean = S.bool

--- a/code/drasil-code/Language/Drasil/Code/Imperative/Helpers.hs
+++ b/code/drasil-code/Language/Drasil/Code/Imperative/Helpers.hs
@@ -6,11 +6,12 @@ module Language.Drasil.Code.Imperative.Helpers (Pair(..), Terminator (..),
   angles,doubleQuotedText,himap,hicat,vicat,vibcat,vmap,vimap,vibmap, 
   mapPairFst, mapPairSnd, liftA4, liftA5, liftA6, liftA7, liftA8, liftList, 
   lift2Lists, lift1List, liftPair, lift3Pair, lift4Pair, liftPairFst, 
-  liftPairSnd
+  liftPairSnd, convType
 ) where
 
-import Language.Drasil.Code.Code (CodeType)
-import Language.Drasil.Code.Imperative.Symantics (Label)
+import Language.Drasil.Code.Code (CodeType(..))
+import qualified Language.Drasil.Code.Imperative.Symantics as S (Label, 
+  RenderSym(..), StateTypeSym(..), PermanenceSym(dynamic_))
 
 import Prelude hiding ((<>))
 import Control.Applicative (liftA2, liftA3)
@@ -32,9 +33,9 @@ data FuncData = FD {funcType :: TypeData, funcDoc :: Doc}
 fd :: TypeData -> Doc -> FuncData
 fd = FD
 
-data ModData = MD {name :: Label, isMainMod :: Bool, modDoc :: Doc}
+data ModData = MD {name :: S.Label, isMainMod :: Bool, modDoc :: Doc}
 
-md :: Label -> Bool -> Doc -> ModData
+md :: S.Label -> Bool -> Doc -> ModData
 md = MD
 
 data MethodData = MthD {isMainMthd :: Bool, getMthdScp :: ScopeTag, 
@@ -144,3 +145,15 @@ liftPairFst (c, n) = fmap (, n) c
 
 liftPairSnd :: Functor f => (a, f b) -> f (a, b)
 liftPairSnd (c, n) = fmap (c ,) n
+
+convType :: (S.RenderSym repr) => CodeType -> repr (S.StateType repr)
+convType Boolean = S.bool
+convType Integer = S.int
+convType Float = S.float
+convType Char = S.char
+convType String = S.string
+convType (List t) = S.listType S.dynamic_ (convType t)
+convType (Iterator t) = S.iterator $ convType t
+convType (Object n) = S.obj n
+convType Void = S.void
+convType File = error "convType: File ?"

--- a/code/drasil-code/Language/Drasil/Code/Imperative/Helpers.hs
+++ b/code/drasil-code/Language/Drasil/Code/Imperative/Helpers.hs
@@ -1,11 +1,12 @@
 {-# LANGUAGE TupleSections #-}
 
 module Language.Drasil.Code.Imperative.Helpers (Pair(..), Terminator (..),
-  ScopeTag(..), ModData(..), md, MethodData(..), mthd, StateVarData(..), svd,
-  TypeData(..), td, ValData(..), vd, blank,verticalComma, angles,
-  doubleQuotedText,himap,hicat,vicat,vibcat,vmap,vimap,vibmap, mapPairFst, 
-  mapPairSnd, liftA4, liftA5, liftA6, liftA7, liftA8, liftList, lift2Lists,
-  lift1List, liftPair, lift3Pair, lift4Pair, liftPairFst, liftPairSnd
+  ScopeTag(..), FuncData(..), fd, ModData(..), md, MethodData(..), mthd, 
+  StateVarData(..), svd, TypeData(..), td, ValData(..), vd, blank,verticalComma,
+  angles,doubleQuotedText,himap,hicat,vicat,vibcat,vmap,vimap,vibmap, 
+  mapPairFst, mapPairSnd, liftA4, liftA5, liftA6, liftA7, liftA8, liftList, 
+  lift2Lists, lift1List, liftPair, lift3Pair, lift4Pair, liftPairFst, 
+  liftPairSnd
 ) where
 
 import Language.Drasil.Code.Code (CodeType)
@@ -25,6 +26,11 @@ class Pair p where
 data Terminator = Semi | Empty
 
 data ScopeTag = Pub | Priv deriving Eq
+
+data FuncData = FD {funcType :: TypeData, funcDoc :: Doc}
+
+fd :: TypeData -> Doc -> FuncData
+fd = FD
 
 data ModData = MD {name :: Label, isMainMod :: Bool, modDoc :: Doc}
 

--- a/code/drasil-code/Language/Drasil/Code/Imperative/Import.hs
+++ b/code/drasil-code/Language/Drasil/Code/Imperative/Import.hs
@@ -5,8 +5,8 @@ module Language.Drasil.Code.Imperative.Import(generator, generateCode) where
 import Language.Drasil hiding (int, ($.), log, ln, exp,
   sin, cos, tan, csc, sec, cot, arcsin, arccos, arctan)
 import Database.Drasil(ChunkDB, symbLookup, symbolTable)
-import Language.Drasil.Code.Code as C (Code(..), CodeType(List, File, Char, 
-  Float, Object, String, Boolean, Integer, Iterator))
+import Language.Drasil.Code.Code as C (Code(..), CodeType(List, Char, Float, 
+  String, Boolean, Integer))
 import Language.Drasil.Code.Imperative.Symantics (Label,
   PackageSym(..), RenderSym(..), PermanenceSym(..), BodySym(..), BlockSym(..), 
   StateTypeSym(..), ValueSym(..), NumericExpression(..), BooleanExpression(..), 
@@ -17,7 +17,7 @@ import Language.Drasil.Code.Imperative.Build.AST (asFragment, buildAll,
   BuildConfig, buildSingle, cppCompiler, inCodePackage, interp, interpMM, 
   mainModule, mainModuleFile, nativeBinary, osClassDefault, Runnable, withExt)
 import Language.Drasil.Code.Imperative.Build.Import (makeBuild)
-import Language.Drasil.Code.Imperative.Helpers (ModData(..))
+import Language.Drasil.Code.Imperative.Helpers (ModData(..), convType)
 import Language.Drasil.Code.Imperative.LanguageRenderer.JavaRenderer 
   (jNameOpts)
 import Language.Drasil.Code.CodeGeneration (createCodeFiles, makeCode)
@@ -230,8 +230,8 @@ genInputConstraints = do
           sfwrCBody h x)]}) sfwrCs
         hw <- mapM (\x -> do { e <- convExpr x; return $ ifNoElse [((?!) e, 
           physCBody h x)]}) physCs
-        mthd <- publicMethod void "input_constraints" parms (return [block sf, 
-          block hw])
+        mthd <- publicMethod (mState void) "input_constraints" parms (return 
+          [block sf, block hw])
         return $ Just mthd
   genConstraints $ Map.lookup "input_constraints" (eMap $ codeSpec g)
 
@@ -245,8 +245,9 @@ genInputDerived = do
       genDerived Nothing = return Nothing
       genDerived (Just _) = do
         parms <- getDerivedParams
-        inps <- mapM (\x -> genCalcBlock CalcAssign (codeName x) (codeEquat x)) dvals
-        mthd <- publicMethod void "derived_values" parms (return inps)
+        inps <- mapM (\x -> genCalcBlock CalcAssign (codeName x) (convType $ 
+          codeType x) (codeEquat x)) dvals
+        mthd <- publicMethod (mState void) "derived_values" parms (return inps)
         return $ Just mthd
   genDerived $ Map.lookup "derived_values" (eMap $ codeSpec g)
 
@@ -279,7 +280,8 @@ genCalcFunc :: (RenderSym repr) => CodeDefinition -> Reader (State repr) (repr
   (Method repr))
 genCalcFunc cdef = do
   parms <- getCalcParams cdef
-  blck <- genCalcBlock CalcReturn (codeName cdef) (codeEquat cdef)
+  blck <- genCalcBlock CalcReturn (codeName cdef) (convType $ codeType cdef) 
+    (codeEquat cdef)
   publicMethod
     (mState $ convType (codeType cdef))
     (codeName cdef)
@@ -288,19 +290,19 @@ genCalcFunc cdef = do
 
 data CalcType = CalcAssign | CalcReturn deriving Eq
 
-genCalcBlock :: (RenderSym repr) => CalcType -> String -> Expr -> Reader (State
-  repr) (repr (Block repr))
-genCalcBlock t v (Case e) = genCaseBlock t v e
-genCalcBlock t v e
-    | t == CalcAssign  = fmap block $ liftS $ do { vv <- variable v; ee <-
+genCalcBlock :: (RenderSym repr) => CalcType -> String -> 
+  repr (StateType repr) -> Expr -> Reader (State repr) (repr (Block repr))
+genCalcBlock t v st (Case e) = genCaseBlock t v st e
+genCalcBlock t v st e
+    | t == CalcAssign  = fmap block $ liftS $ do { vv <- variable v st; ee <-
       convExpr e; assign' vv ee}
     | otherwise        = block <$> liftS (returnState <$> convExpr e)
 
-genCaseBlock :: (RenderSym repr) => CalcType -> String -> [(Expr,Relation)] ->
-  Reader (State repr) (repr (Block repr))
-genCaseBlock t v cs = do
+genCaseBlock :: (RenderSym repr) => CalcType -> String -> repr (StateType repr) 
+  -> [(Expr,Relation)] -> Reader (State repr) (repr (Block repr))
+genCaseBlock t v st cs = do
   ifs <- mapM (\(e,r) -> liftM2 (,) (convExpr r) (fmap body $ liftS $
-    genCalcBlock t v e)) cs
+    genCalcBlock t v st e)) cs
   return $ block [ifNoElse ifs]
 
 ----- OUTPUT -------
@@ -321,14 +323,14 @@ genOutputFormat = do
       genOutput Nothing = return Nothing
       genOutput (Just _) = do
         let l_outfile = "outputfile"
-            v_outfile = var l_outfile
+            v_outfile = var l_outfile outfile
         parms <- getOutputParams
         outp <- mapM (\x -> do
-          v <- variable $ codeName x
+          v <- variable (codeName x) (convType $ codeType x)
           return [ printFileStr v_outfile (codeName x ++ " = "),
                    printFileLn v_outfile (convType $ codeType x) v
                  ] ) (outputs $ csi $ codeSpec g)
-        mthd <- publicMethod void "write_output" parms (return [block $
+        mthd <- publicMethod (mState void) "write_output" parms (return [block $
           [
           varDec l_outfile outfile,
           openFileW v_outfile (litString "output.txt") ] ++
@@ -370,7 +372,7 @@ loggedMethod :: (RenderSym repr) => Label -> [repr (StateType repr)] ->
   [repr (Block repr)]
 loggedMethod n st l b =
   let l_outfile = "outfile"
-      v_outfile = var l_outfile
+      v_outfile = var l_outfile outfile
   in do
     g <- ask
     rest <- b
@@ -385,7 +387,7 @@ loggedMethod n st l b =
   where
     printParams sts ls v_outfile = multi $
       intersperse (printFileStr v_outfile ", ") $
-      map (\(x,y) -> printFile v_outfile x (var y)) (zip sts ls)
+      map (\(x,y) -> printFile v_outfile x (var y x)) (zip sts ls)
 
 ---- MAIN ---
 
@@ -435,46 +437,47 @@ getInputDecl = do
         (obj "InputParameters") 
   return $ getDecl (inStruct g) (inputs $ codeSpec g)
 
-getFuncCall :: (RenderSym repr) => String -> Reader (State repr) 
-  [ParamData repr] -> Reader (State repr) (Maybe (repr (Value repr)))
-getFuncCall n funcPs = do
+getFuncCall :: (RenderSym repr) => String -> repr (StateType repr) -> 
+  Reader (State repr) [ParamData repr] -> 
+  Reader (State repr) (Maybe (repr (Value repr)))
+getFuncCall n t funcPs = do
   g <- ask
   let getCall Nothing = return Nothing
       getCall (Just m) = do
         ps <- funcPs
         let pvals = getArgs ps
-        val <- fApp m n pvals
+        val <- fApp m n t pvals
         return $ Just val
   getCall $ Map.lookup n (eMap $ codeSpec g)
 
 getInputCall :: (RenderSym repr) => Reader (State repr) 
   (Maybe (repr (Statement repr)))
 getInputCall = do
-  val <- getFuncCall (funcPrefix ++ "get_input") getInputFormatParams
+  val <- getFuncCall (funcPrefix ++ "get_input") void getInputFormatParams
   return $ fmap valState val
 
 getDerivedCall :: (RenderSym repr) => Reader (State repr) 
   (Maybe (repr (Statement repr)))
 getDerivedCall = do
-  val <- getFuncCall "derived_values" getDerivedParams
+  val <- getFuncCall "derived_values" void getDerivedParams
   return $ fmap valState val
 
 getConstraintCall :: (RenderSym repr) => Reader (State repr) 
   (Maybe (repr (Statement repr)))
 getConstraintCall = do
-  val <- getFuncCall "input_constraints" getConstraintParams
+  val <- getFuncCall "input_constraints" void getConstraintParams
   return $ fmap valState val
 
 getCalcCall :: (RenderSym repr) => CodeDefinition -> Reader (State repr) 
   (Maybe (repr (Statement repr)))
 getCalcCall c = do
-  val <- getFuncCall (codeName c) (getCalcParams c)
+  val <- getFuncCall (codeName c) (convType $ codeType c) (getCalcParams c)
   return $ fmap (varDecDef (nopfx $ codeName c) (convType $ codeType c)) val
 
 getOutputCall :: (RenderSym repr) => Reader (State repr) 
   (Maybe (repr (Statement repr)))
 getOutputCall = do
-  val <- getFuncCall "write_output" getOutputParams
+  val <- getFuncCall "write_output" void getOutputParams
   return $ fmap valState val
 
 getInputFormatParams :: (RenderSym repr) => Reader (State repr) [ParamData repr]
@@ -521,7 +524,7 @@ loggedAssign :: (RenderSym repr) => repr (Value repr) ->
   repr (Value repr) -> Reader (State repr) (repr (Statement repr))
 loggedAssign a b =
   let l_outfile = "outfile"
-      v_outfile = var l_outfile
+      v_outfile = var l_outfile outfile
   in do
     g <- ask
     return $ multi [
@@ -538,26 +541,26 @@ loggedAssign a b =
 nopfx :: String -> String
 nopfx s = fromMaybe s (stripPrefix funcPrefix s)
 
-variable :: (RenderSym repr) => String -> Reader (State repr) 
-  (repr (Value repr))
-variable s' = do
+variable :: (RenderSym repr) => String -> repr (StateType repr) -> 
+  Reader (State repr) (repr (Value repr))
+variable s' t' = do
   g <- ask
   let cs = codeSpec g
       mm = constMap cs
-      doit :: (RenderSym repr) => String -> Reader (State repr) 
-        (repr (Value repr))
-      doit s | member s mm =
+      doit :: (RenderSym repr) => String -> repr (StateType repr) -> 
+        Reader (State repr) (repr (Value repr))
+      doit s t | member s mm =
         maybe (error "impossible") (convExpr . codeEquat) (Map.lookup s mm) --extvar "Constants" s
-             | s `elem` map codeName (inputs cs) = return $ var "inParams" $-> 
-               var s
-             | otherwise                         = return $ var s
-  doit s'
+               | s `elem` map codeName (inputs cs) = return $ var "inParams" 
+               (obj "InputParameters") $-> var s t
+               | otherwise                         = return $ var s t
+  doit s' t'
   
-fApp :: (RenderSym repr) => String -> String -> [repr (Value repr)] -> 
-  Reader (State repr) (repr (Value repr))
-fApp m s vl = do
+fApp :: (RenderSym repr) => String -> String -> repr (StateType repr) -> 
+  [repr (Value repr)] -> Reader (State repr) (repr (Value repr))
+fApp m s t vl = do
   g <- ask
-  return $ if m /= currentModule g then extFuncApp m s vl else funcApp s vl
+  return $ if m /= currentModule g then extFuncApp m s t vl else funcApp s t vl
 
 data ParamData repr = PD {
   param :: (ParameterSym repr) => repr (Parameter repr),
@@ -599,18 +602,7 @@ getConstParams :: [CodeChunk] -> [ParamData repr]
 getConstParams _ = []
 
 getArgs :: (RenderSym repr) => [ParamData repr] -> [repr (Value repr)]
-getArgs = map (var . paramName)
-
-convType :: (RenderSym repr) => C.CodeType -> repr (StateType repr)
-convType C.Boolean = bool
-convType C.Integer = int
-convType C.Float = float
-convType C.Char = char
-convType C.String = string
-convType (C.List t) = listType dynamic_ (convType t)
-convType (C.Iterator t) = iterator $ convType t
-convType (C.Object n) = obj n
-convType C.File = error "convType: File ?"
+getArgs = map (\p -> var (paramName p) (paramType p))
 
 convExpr :: (RenderSym repr) => Expr -> Reader (State repr) (repr (Value repr))
 convExpr (Dbl d) = return $ litFloat d
@@ -624,16 +616,18 @@ convExpr (AssocB Or l)  = foldr1 (?||) <$> mapM convExpr l
 convExpr Deriv{} = return $ litString "**convExpr :: Deriv unimplemented**"
 convExpr (C c)   = do
   g <- ask
-  variable $ codeName $ codevar (symbLookup c (symbolTable $ sysinfodb $ csi $
-    codeSpec g))
+  let v = codevar (symbLookup c (symbolTable $ sysinfodb $ csi $ codeSpec g))
+  variable (codeName v) (convType $ codeType v)
 convExpr (FCall (C c) x) = do
   g <- ask
   let info = sysinfodb $ csi $ codeSpec g
       mem = eMap $ codeSpec g
-      funcNm = codeName (codefunc (symbLookup c (symbolTable info)))
+      funcCd = codefunc (symbLookup c (symbolTable info))
+      funcNm = codeName funcCd
+      funcTp = convType $ codeType funcCd
   args <- mapM convExpr x
   maybe (error $ "Call to non-existent function" ++ funcNm) 
-    (\f -> fApp f funcNm args) (Map.lookup funcNm mem)
+    (\f -> fApp f funcNm funcTp args) (Map.lookup funcNm mem)
 convExpr FCall{}   = return $ litString "**convExpr :: FCall unimplemented**"
 convExpr (UnaryOp o u) = fmap (unop o) (convExpr u)
 convExpr (BinaryOp Frac (Int a) (Int b)) =
@@ -714,7 +708,7 @@ bfunc Impl  = error "convExpr :=>"
 bfunc Iff   = error "convExpr :<=>"
 bfunc Dot   = error "convExpr DotProduct"
 bfunc Frac  = (#/)
-bfunc Index = \x y -> x $. listAccess y
+bfunc Index = \x y -> x $. listAccess (listInnerType $ valueType x) y
 
 -- medium hacks --
 genModDef :: (RenderSym repr) => CS.Mod -> Reader (State repr) 
@@ -737,7 +731,8 @@ genFunc (FCD cd) = genCalcFunc cd
 
 convStmt :: (RenderSym repr) => FuncStmt -> Reader (State repr) 
   (repr (Statement repr))
-convStmt (FAsg v e) = convExpr e >>= assign' (var $ codeName v)
+convStmt (FAsg v e) = convExpr e >>= 
+  assign' (var (codeName v) (convType $ codeType v))
 convStmt (FFor v e st) = do
   stmts <- mapM convStmt st
   e' <- convExpr $ getUpperBound e
@@ -781,7 +776,7 @@ genDataFunc :: (RenderSym repr) => Name -> DataDesc -> Reader (State repr)
 genDataFunc nameTitle ddef = do
     parms <- getParams $ getInputs ddef
     inD <- mapM inData ddef
-    publicMethod void nameTitle (PD p_filename string l_filename : parms) $
+    publicMethod (mState void) nameTitle (PD p_filename string l_filename : parms) $
       return [block $ [
       varDec l_infile infile,
       varDec l_line string,
@@ -792,7 +787,7 @@ genDataFunc nameTitle ddef = do
       closeFile v_infile ]]
   where inData :: (RenderSym repr) => Data -> Reader (State repr) [repr (Statement repr)]
         inData (Singleton v) = do
-            vv <- variable $ codeName v
+            vv <- variable (codeName v) (convType $ codeType v)
             return [getFileInput (codeType v) v_infile vv]
         inData JunkData = return [discardFileLine v_infile]
         inData (Line lp d) = do
@@ -804,7 +799,7 @@ genDataFunc nameTitle ddef = do
           return [ getFileInputAll v_infile v_lines,
             forRange l_i (litInt 0) (listSizeAccess v_lines) (litInt 1)
               (bodyStatements $ stringSplit d v_linetokens (v_lines $.
-                listAccess v_i) : lnV)
+                listAccess (listInnerType $ valueType v_lines) v_i) : lnV)
             ]
         inData (Lines lp (Just numLines) d) = do
           lnV <- lineData (Just "_temp") lp
@@ -852,10 +847,12 @@ genDataFunc nameTitle ddef = do
         ---------------
         appendTemp :: (RenderSym repr) => String -> Entry -> 
           Maybe (repr (Statement repr))
-        appendTemp sfx (Entry v) = Just $ valState $ var (codeName v) $. 
-          listAppend (var $ codeName v ++ sfx)
-        appendTemp sfx (ListEntry _ v) = Just $ valState $ var (codeName v) $.
-          listAppend (var $ codeName v ++ sfx)
+        appendTemp sfx (Entry v) = Just $ valState $ var (codeName v) 
+          (convType $ codeType v) $. listAppend (var (codeName v ++ sfx) 
+          (convType $ codeType v))
+        appendTemp sfx (ListEntry _ v) = Just $ valState $ var (codeName v)
+          (convType $ codeType v) $. listAppend (var (codeName v ++ sfx) 
+          (convType $ codeType v))
         appendTemp _ JunkEntry = Nothing
         ---------------
         patternData :: (RenderSym repr) => Maybe String -> [Entry] -> 
@@ -869,16 +866,18 @@ genDataFunc nameTitle ddef = do
         entryData :: (RenderSym repr) => Maybe String -> repr (Value repr) -> 
           Entry -> Reader (State repr) [repr (Statement repr)]
         entryData s tokIndex (Entry v) = do
-          vv <- variable $ codeName v ++ fromMaybe "" s
+          vv <- variable (codeName v ++ fromMaybe "" s) (convType $ codeType v)
           a <- assign' vv $ getCastFunc (codeType v)
-            (v_linetokens $. listAccess tokIndex)
+            (v_linetokens $. listAccess (listInnerType $ 
+              valueType v_linetokens) tokIndex)
           return [a]
         entryData s tokIndex (ListEntry indx v) = do
-          vv <- variable $ codeName v ++ fromMaybe "" s
+          vv <- variable (codeName v ++ fromMaybe "" s) (convType $ codeType v)
           return [
             valState $ vv $. listAppend 
             (getCastFunc (getListType (codeType v) (toInteger $ length indx))
-            (v_linetokens $. listAccess tokIndex))]
+            (v_linetokens $. listAccess (listInnerType $ valueType v_linetokens)
+            tokIndex))]
         entryData _ _ JunkEntry = return []
         ---------------
         l_line, l_lines, l_linetokens, l_infile, l_filename, l_i, l_j :: Label
@@ -886,20 +885,20 @@ genDataFunc nameTitle ddef = do
           (RenderSym repr) => (repr (Value repr))
         p_filename :: (RenderSym repr) => (repr (Parameter repr))
         l_line = "line"
-        v_line = var l_line
+        v_line = var l_line string
         l_lines = "lines"
-        v_lines = var l_lines
+        v_lines = var l_lines (listType static_ string)
         l_linetokens = "linetokens"
-        v_linetokens = var l_linetokens
+        v_linetokens = var l_linetokens (listType static_ string)
         l_infile = "infile"
-        v_infile = var l_infile
+        v_infile = var l_infile infile
         l_filename = "filename"
         p_filename = stateParam l_filename string
-        v_filename = var l_filename
+        v_filename = var l_filename string
         l_i = "i"
-        v_i = var l_i
+        v_i = var l_i int
         l_j = "j"
-        v_j = var l_j
+        v_j = var l_j int
 
 getFileInput :: (RenderSym repr) => C.CodeType -> (repr (Value repr) -> repr
   (Value repr) -> repr (Statement repr))

--- a/code/drasil-code/Language/Drasil/Code/Imperative/Import.hs
+++ b/code/drasil-code/Language/Drasil/Code/Imperative/Import.hs
@@ -527,8 +527,8 @@ loggedAssign a b =
     return $ multi [
       assign a b,
       openFileA v_outfile (litString $ logName g),
-      printFileStr v_outfile ("var '" ++ valName a ++ "' assigned to "),
-      printFile v_outfile (convType $ varType (valName a) (vMap $ codeSpec g))
+      printFileStr v_outfile ("var '" ++ valueName a ++ "' assigned to "),
+      printFile v_outfile (convType $ varType (valueName a) (vMap $ codeSpec g))
         a,
       printFileStrLn v_outfile (" in module " ++ currentModule g),
       closeFile v_outfile ]

--- a/code/drasil-code/Language/Drasil/Code/Imperative/LanguageRenderer.hs
+++ b/code/drasil-code/Language/Drasil/Code/Imperative/LanguageRenderer.hs
@@ -36,9 +36,9 @@ import Utils.Drasil (capitalize, indent, indentList)
 
 import Language.Drasil.Code.Code (CodeType(..))
 import Language.Drasil.Code.Imperative.Symantics (Label, Library)
-import Language.Drasil.Code.Imperative.Helpers (Terminator(..), ModData(..), md,
-  TypeData(..), td, ValData(..), vd, angles,blank, doubleQuotedText,hicat,
-  vibcat,vmap)
+import Language.Drasil.Code.Imperative.Helpers (Terminator(..), FuncData(..), 
+  ModData(..), md, TypeData(..), td, ValData(..), vd, angles,blank, 
+  doubleQuotedText,hicat,vibcat,vmap)
 
 import Data.List (intersperse, last)
 import Prelude hiding (break,print,return,last,mod,(<>))
@@ -581,11 +581,11 @@ listAccessDocD v = brackets $ valDoc v
 listSetDocD :: ValData -> ValData -> Doc
 listSetDocD i v = brackets (valDoc i) <+> equals <+> valDoc v
 
-objAccessDocD :: ValData -> Doc -> Doc
-objAccessDocD v f = valDoc v <> f
+objAccessDocD :: ValData -> FuncData -> Doc
+objAccessDocD v f = valDoc v <> funcDoc f
 
-castObjDocD :: Doc -> ValData -> Doc
-castObjDocD f v = f <> parens (valDoc v)
+castObjDocD :: FuncData -> ValData -> Doc
+castObjDocD f v = funcDoc f <> parens (valDoc v)
 
 -- Keywords --
 

--- a/code/drasil-code/Language/Drasil/Code/Imperative/LanguageRenderer.hs
+++ b/code/drasil-code/Language/Drasil/Code/Imperative/LanguageRenderer.hs
@@ -176,8 +176,8 @@ listTypeDocD t list = td (List (cType t)) (list <> angles (typeDoc t))
 
 -- Method Types --
 
-voidDocD :: Doc
-voidDocD = text "void"
+voidDocD :: TypeData
+voidDocD = td Void (text "void")
 
 constructDocD :: Label -> Doc
 constructDocD _ = empty

--- a/code/drasil-code/Language/Drasil/Code/Imperative/LanguageRenderer.hs
+++ b/code/drasil-code/Language/Drasil/Code/Imperative/LanguageRenderer.hs
@@ -192,9 +192,9 @@ paramListDocD = hicat (text ", ")
 
 -- Method --
 
-methodDocD :: Label -> Doc -> Doc -> Doc -> Doc -> Doc -> Doc
+methodDocD :: Label -> Doc -> Doc -> TypeData -> Doc -> Doc -> Doc
 methodDocD n s p t ps b = vcat [
-  s <+> p <+> t <+> text n <> parens ps <+> lbrace,
+  s <+> p <+> typeDoc t <+> text n <> parens ps <+> lbrace,
   indent b,
   rbrace]
 

--- a/code/drasil-code/Language/Drasil/Code/Imperative/LanguageRenderer.hs
+++ b/code/drasil-code/Language/Drasil/Code/Imperative/LanguageRenderer.hs
@@ -269,7 +269,7 @@ forEachDocD :: Label -> Doc -> Doc -> Doc -> Doc -> TypeData ->
   ValData -> Doc -> Doc
 forEachDocD l blockStart blockEnd iterForEachLabel iterInLabel t v b =
   vcat [iterForEachLabel <+> parens (typeDoc t <+> text l <+> iterInLabel <+> 
-    (valDoc v)) <+> blockStart,
+    valDoc v) <+> blockStart,
   indent b,
   blockEnd]
 

--- a/code/drasil-code/Language/Drasil/Code/Imperative/LanguageRenderer.hs
+++ b/code/drasil-code/Language/Drasil/Code/Imperative/LanguageRenderer.hs
@@ -37,7 +37,8 @@ import Utils.Drasil (capitalize, indent, indentList)
 import Language.Drasil.Code.Code (CodeType(..))
 import Language.Drasil.Code.Imperative.Symantics (Label, Library)
 import Language.Drasil.Code.Imperative.Helpers (Terminator(..), ModData(..), md,
-  TypeData(..), td, angles,blank, doubleQuotedText,hicat,vibcat,vmap)
+  TypeData(..), td, ValData(..), vd, angles,blank, doubleQuotedText,hicat,
+  vibcat,vmap)
 
 import Data.List (intersperse, last)
 import Prelude hiding (break,print,return,last,mod,(<>))
@@ -138,14 +139,14 @@ bodyDocD bs = vibcat blocks
 
 -- IO --
 
-outDocD :: Doc -> (Doc, Maybe String) -> Doc
-outDocD printFn (v, _) = printFn <> parens v
+outDocD :: Doc -> ValData -> Doc
+outDocD printFn v = printFn <> parens (valDoc v)
 
 printListDocD :: Doc -> Doc -> Doc -> Doc -> Doc
 printListDocD open b lastElem close = vcat [open, b, lastElem, close]
 
-printFileDocD :: Label -> (Doc, Maybe String) -> Doc
-printFileDocD fn (f, _) = f <> dot <> text fn
+printFileDocD :: Label -> ValData -> Doc
+printFileDocD fn f = valDoc f <> dot <> text fn
 
 -- Type Printers --
 
@@ -214,15 +215,15 @@ alwaysDel = 4
 
 -- Controls --
 
-ifCondDocD :: Doc -> Doc -> Doc -> Doc -> [((Doc, Maybe String), Doc)] -> Doc
+ifCondDocD :: Doc -> Doc -> Doc -> Doc -> [(ValData, Doc)] -> Doc
 ifCondDocD _ _ _ _ [] = error "if condition created with no cases"
 ifCondDocD ifStart elseIf blockEnd elseBody (c:cs) = 
-  let ifSect ((v, _), b) = vcat [
-        text "if" <+> parens v <+> ifStart,
+  let ifSect (v, b) = vcat [
+        text "if" <+> parens (valDoc v) <+> ifStart,
         indent b,
         blockEnd]
-      elseIfSect ((v, _), b) = vcat [
-        elseIf <+> parens v <+> ifStart,
+      elseIfSect (v, b) = vcat [
+        elseIf <+> parens (valDoc v) <+> ifStart,
         indent b,
         blockEnd]
       elseSect = if isEmpty elseBody then empty else vcat [
@@ -234,11 +235,11 @@ ifCondDocD ifStart elseIf blockEnd elseBody (c:cs) =
     vmap elseIfSect cs,
     elseSect]
 
-switchDocD :: (Doc, Terminator) -> (Doc, Maybe String) -> Doc -> 
-  [((Doc, Maybe String), Doc)] -> Doc
-switchDocD breakState (v, _) defBody cs = 
-  let caseDoc ((l, _), result) = vcat [
-        text "case" <+> l <> colon,
+switchDocD :: (Doc, Terminator) -> ValData -> Doc -> 
+  [(ValData, Doc)] -> Doc
+switchDocD breakState v defBody cs = 
+  let caseDoc (l, result) = vcat [
+        text "case" <+> valDoc l <> colon,
         indentList [
           result,
           fst breakState]]
@@ -248,7 +249,7 @@ switchDocD breakState (v, _) defBody cs =
           defBody,
           fst breakState]]
   in vcat [
-      text "switch" <> parens v <+> lbrace,
+      text "switch" <> parens (valDoc v) <+> lbrace,
       indentList [
         vmap caseDoc cs,
         defaultSection],
@@ -256,25 +257,25 @@ switchDocD breakState (v, _) defBody cs =
 
 -- These signatures wont be quite so horrendous if/when we pass language options
 -- (blockStart, etc.) in as shared environment
-forDocD :: Doc -> Doc -> (Doc, Terminator) -> (Doc, Maybe String) -> 
+forDocD :: Doc -> Doc -> (Doc, Terminator) -> ValData -> 
   (Doc, Terminator) -> Doc -> Doc
-forDocD blockStart blockEnd sInit (vGuard, _) sUpdate b = vcat [
-  forLabel <+> parens (fst sInit <> semi <+> vGuard <> semi <+> fst sUpdate) 
-    <+> blockStart,
+forDocD blockStart blockEnd sInit vGuard sUpdate b = vcat [
+  forLabel <+> parens (fst sInit <> semi <+> valDoc vGuard <> semi <+> 
+    fst sUpdate) <+> blockStart,
   indent b,
   blockEnd]
 
 forEachDocD :: Label -> Doc -> Doc -> Doc -> Doc -> TypeData -> 
-  (Doc, Maybe String) -> Doc -> Doc
-forEachDocD l blockStart blockEnd iterForEachLabel iterInLabel t (v, _) b =
-  vcat [iterForEachLabel <+> parens (typeDoc t <+> text l <+> iterInLabel <+> v) <+>
-    blockStart,
+  ValData -> Doc -> Doc
+forEachDocD l blockStart blockEnd iterForEachLabel iterInLabel t v b =
+  vcat [iterForEachLabel <+> parens (typeDoc t <+> text l <+> iterInLabel <+> 
+    (valDoc v)) <+> blockStart,
   indent b,
   blockEnd]
 
-whileDocD :: Doc -> Doc -> (Doc, Maybe String) -> Doc -> Doc
-whileDocD blockStart blockEnd (v, _) b = vcat [
-  text "while" <+> parens v <+> blockStart,
+whileDocD :: Doc -> Doc -> ValData -> Doc -> Doc
+whileDocD blockStart blockEnd v b = vcat [
+  text "while" <+> parens (valDoc v) <+> blockStart,
   indent b,
   blockEnd]
 
@@ -294,50 +295,51 @@ stratDocD b resultState = vcat [
 
 -- Statements --
 
-assignDocD :: (Doc, Maybe String) -> (Doc, Maybe String) -> Doc
-assignDocD (v1, _) (v2, _) = v1 <+> equals <+> v2
+assignDocD :: ValData -> ValData -> Doc
+assignDocD v1 v2 = valDoc v1 <+> equals <+> valDoc v2
 
-plusEqualsDocD :: (Doc, Maybe String) -> (Doc, Maybe String) -> Doc
-plusEqualsDocD (v1, _) (v2, _) = v1 <+> text "+=" <+> v2
+plusEqualsDocD :: ValData -> ValData -> Doc
+plusEqualsDocD v1 v2 = valDoc v1 <+> text "+=" <+> valDoc v2
 
-plusEqualsDocD' :: (Doc, Maybe String) -> Doc -> (Doc, Maybe String) -> Doc
-plusEqualsDocD' (v1, _) plusOp (v2, _) = v1 <+> equals <+> v1 <+> plusOp <+> v2
+plusEqualsDocD' :: ValData -> Doc -> ValData -> Doc
+plusEqualsDocD' v1 plusOp v2 = valDoc v1 <+> equals <+> valDoc v1 <+> 
+  plusOp <+> valDoc v2
 
-plusPlusDocD :: (Doc, Maybe String) -> Doc
-plusPlusDocD (v, _) = v <> text "++"
+plusPlusDocD :: ValData -> Doc
+plusPlusDocD v = valDoc v <> text "++"
 
-plusPlusDocD' :: (Doc, Maybe String) -> Doc -> Doc
-plusPlusDocD' (v, _) plusOp = v <+> equals <+> v <+> plusOp <+> int 1
+plusPlusDocD' :: ValData -> Doc -> Doc
+plusPlusDocD' v plusOp = valDoc v <+> equals <+> valDoc v <+> plusOp <+> int 1
 
 varDecDocD :: Label -> TypeData -> Doc
 varDecDocD l st = typeDoc st <+> text l
 
-varDecDefDocD :: Label -> TypeData -> (Doc, Maybe String) -> Doc
-varDecDefDocD l st (v, _) = typeDoc st <+> text l <+> equals <+> v
+varDecDefDocD :: Label -> TypeData -> ValData -> Doc
+varDecDefDocD l st v = typeDoc st <+> text l <+> equals <+> valDoc v
 
-listDecDocD :: Label -> (Doc, Maybe String) -> TypeData -> Doc
-listDecDocD l (n, _) st = typeDoc st <+> text l <+> equals <+> new <+> 
-  typeDoc st <> parens n
+listDecDocD :: Label -> ValData -> TypeData -> Doc
+listDecDocD l n st = typeDoc st <+> text l <+> equals <+> new <+> 
+  typeDoc st <> parens (valDoc n)
 
-listDecDefDocD :: Label -> TypeData -> [(Doc, Maybe String)] -> Doc
+listDecDefDocD :: Label -> TypeData -> [ValData] -> Doc
 listDecDefDocD l st vs = typeDoc st <+> text l <+> equals <+> new <+> 
   typeDoc st <+> braces (callFuncParamList vs)
 
-objDecDefDocD :: Label -> TypeData -> (Doc, Maybe String) -> Doc
+objDecDefDocD :: Label -> TypeData -> ValData -> Doc
 objDecDefDocD = varDecDefDocD
 
-constDecDefDocD :: Label -> TypeData -> (Doc, Maybe String) -> Doc -- can this be done without StateType (infer from value)?
-constDecDefDocD l st (v, _) = text "const" <+> typeDoc st <+> text l <+> 
-  equals <+> v
+constDecDefDocD :: Label -> TypeData -> ValData -> Doc -- can this be done without StateType (infer from value)?
+constDecDefDocD l st v = text "const" <+> typeDoc st <+> text l <+> equals <+>
+  valDoc v
 
-returnDocD :: (Doc, Maybe String) -> Doc
-returnDocD (v, _) = text "return" <+> v
+returnDocD :: ValData -> Doc
+returnDocD v = text "return" <+> valDoc v
 
 commentDocD :: Label -> Doc -> Doc
 commentDocD cmt cStart = cStart <+> text cmt
 
-freeDocD :: (Doc, Maybe String) -> Doc
-freeDocD (v, _) = text "delete" <+> v
+freeDocD :: ValData -> Doc
+freeDocD v = text "delete" <+> valDoc v
 
 throwDocD :: Doc -> Doc
 throwDocD errMsg = text "throw new" <+> text "System.ApplicationException" <>
@@ -433,11 +435,11 @@ atanOpDocD = text "atan"
 atanOpDocD' :: Doc
 atanOpDocD' = text "math.atan"
 
-unOpDocD :: Doc -> (Doc, Maybe String) -> Doc
-unOpDocD op (v, _) = op <> parens v
+unOpDocD :: Doc -> Doc -> Doc
+unOpDocD op v = op <> parens v
 
-unExpr :: Doc -> (Doc, Maybe String) -> (Doc, Maybe String)
-unExpr u v = mkVal $ unOpDocD u v
+unExpr :: Doc -> ValData -> ValData
+unExpr u v = mkVal (valType v) (unOpDocD u (valDoc v))
 
 -- Binary Operators --
 
@@ -483,20 +485,20 @@ andOpDocD = text "&&"
 orOpDocD :: Doc
 orOpDocD = text "||"
 
-binOpDocD :: Doc -> (Doc, Maybe String) -> (Doc, Maybe String) -> Doc
-binOpDocD op (v1, _) (v2, _) = parens (v1 <+> op <+> v2)
+binOpDocD :: Doc -> Doc -> Doc -> Doc
+binOpDocD op v1 v2 = parens (v1 <+> op <+> v2)
 
-binOpDocD' :: Doc -> (Doc, Maybe String) -> (Doc, Maybe String) -> Doc
-binOpDocD' op (v1, _) (v2, _) = op <> parens (v1 <> comma <+> v2)
+binOpDocD' :: Doc -> Doc -> Doc -> Doc
+binOpDocD' op v1 v2 = op <> parens (v1 <> comma <+> v2)
   
-binExpr :: Doc -> (Doc, Maybe String) -> (Doc, Maybe String) -> (Doc, Maybe String)
-binExpr b v1 v2 = mkVal $ binOpDocD b v1 v2
+binExpr :: Doc -> ValData -> ValData -> ValData
+binExpr b v1 v2 = mkVal (valType v1) (binOpDocD b (valDoc v1) (valDoc v2))
 
-binExpr' :: Doc -> (Doc, Maybe String) -> (Doc, Maybe String) -> (Doc, Maybe String)
-binExpr' b v1 v2 = mkVal $ binOpDocD' b v1 v2
+binExpr' :: Doc -> ValData -> ValData -> ValData
+binExpr' b v1 v2 = mkVal (valType v1) (binOpDocD' b (valDoc v1) (valDoc v2))
 
-mkVal :: Doc -> (Doc, Maybe String)
-mkVal v = (v, Nothing)
+mkVal :: TypeData -> Doc -> ValData
+mkVal = vd Nothing
 
 -- Literals --
 
@@ -529,24 +531,24 @@ extVarDocD l n = text l <> dot <> text n
 selfDocD :: Doc
 selfDocD = text "this"
 
-argDocD :: (Doc, Maybe String) -> (Doc, Maybe String) -> Doc
-argDocD (n, _) (args, _) = args <> brackets n
+argDocD :: ValData -> ValData -> Doc
+argDocD n args = valDoc args <> brackets (valDoc n)
 
 enumElemDocD :: Label -> Label -> Doc
 enumElemDocD en e = text en <> dot <> text e
 
-objVarDocD :: (Doc, Maybe String) -> (Doc, Maybe String) ->  Doc
-objVarDocD (n1, _) (n2, _) = n1 <> dot <> n2
+objVarDocD :: ValData -> ValData ->  Doc
+objVarDocD n1 n2 = valDoc n1 <> dot <> valDoc n2
 
-inlineIfDocD :: (Doc, Maybe String) -> (Doc, Maybe String) -> 
-  (Doc, Maybe String) -> Doc
-inlineIfDocD (c, _) (v1, _) (v2, _) = parens 
-  (parens c <+> text "?" <+> v1 <+> text ":" <+> v2)
+inlineIfDocD :: ValData -> ValData -> 
+  ValData -> Doc
+inlineIfDocD c v1 v2 = parens 
+  (parens (valDoc c) <+> text "?" <+> valDoc v1 <+> text ":" <+> valDoc v2)
 
-funcAppDocD :: Label -> [(Doc, Maybe String)] -> Doc
+funcAppDocD :: Label -> [ValData] -> Doc
 funcAppDocD n vs = text n <> parens (callFuncParamList vs)
 
-extFuncAppDocD :: Library -> Label -> [(Doc, Maybe String)] -> Doc
+extFuncAppDocD :: Library -> Label -> [ValData] -> Doc
 extFuncAppDocD l n = funcAppDocD (l ++ "." ++ n)
 
 stateObjDocD :: TypeData -> Doc -> Doc
@@ -555,17 +557,17 @@ stateObjDocD st vs = new <+> typeDoc st <> parens vs
 listStateObjDocD :: Doc -> TypeData -> Doc -> Doc
 listStateObjDocD lstObj st vs = lstObj <+> typeDoc st <> parens vs
 
-notNullDocD :: Doc -> (Doc, Maybe String) -> (Doc, Maybe String) -> Doc
-notNullDocD = binOpDocD
+notNullDocD :: Doc -> ValData -> ValData -> Doc
+notNullDocD op v1 v2 = binOpDocD op (valDoc v1) (valDoc v2)
 
-listIndexExistsDocD :: Doc -> (Doc, Maybe String) -> (Doc, Maybe String) -> Doc
-listIndexExistsDocD greater (lst, _) (index, _) = parens (lst <> 
-  text ".Length" <+> greater <+> index) 
+listIndexExistsDocD :: Doc -> ValData -> ValData -> Doc
+listIndexExistsDocD greater lst index = parens (valDoc lst <> 
+  text ".Length" <+> greater <+> valDoc index) 
 
 -- Functions --
 
-funcDocD :: (Doc, Maybe String) -> Doc
-funcDocD (fnApp, _) = dot <> fnApp
+funcDocD :: ValData -> Doc
+funcDocD fnApp = dot <> valDoc fnApp
 
 castDocD :: TypeData -> Doc
 castDocD t = parens $ typeDoc t
@@ -573,17 +575,17 @@ castDocD t = parens $ typeDoc t
 sizeDocD :: Doc
 sizeDocD = dot <> text "Count"
 
-listAccessDocD :: (Doc, Maybe String) -> Doc
-listAccessDocD (v, _) = brackets v
+listAccessDocD :: ValData -> Doc
+listAccessDocD v = brackets $ valDoc v
 
-listSetDocD :: (Doc, Maybe String) -> (Doc, Maybe String) -> Doc
-listSetDocD (i, _) (v, _) = brackets i <+> equals <+> v
+listSetDocD :: ValData -> ValData -> Doc
+listSetDocD i v = brackets (valDoc i) <+> equals <+> valDoc v
 
-objAccessDocD :: (Doc, Maybe String) -> Doc -> Doc
-objAccessDocD (v, _) f = v <> f
+objAccessDocD :: ValData -> Doc -> Doc
+objAccessDocD v f = valDoc v <> f
 
-castObjDocD :: Doc -> (Doc, Maybe String) -> Doc
-castObjDocD f (v, _) = f <> parens v
+castObjDocD :: Doc -> ValData -> Doc
+castObjDocD f v = f <> parens (valDoc v)
 
 -- Keywords --
 
@@ -641,8 +643,8 @@ dashes s l = replicate (l - length s) '-'
 
 -- Helper Functions --
 
-callFuncParamList :: [(Doc, Maybe String)] -> Doc
-callFuncParamList vs = hcat (intersperse (text ", ") (map fst vs))
+callFuncParamList :: [ValData] -> Doc
+callFuncParamList vs = hcat (intersperse (text ", ") (map valDoc vs))
 
 getterName :: String -> String
 getterName s = "Get" ++ capitalize s

--- a/code/drasil-code/Language/Drasil/Code/Imperative/LanguageRenderer.hs
+++ b/code/drasil-code/Language/Drasil/Code/Imperative/LanguageRenderer.hs
@@ -18,17 +18,17 @@ module Language.Drasil.Code.Imperative.LanguageRenderer (
   logOpDocD, logOpDocD', lnOpDocD, lnOpDocD', expOpDocD, expOpDocD', sinOpDocD,
   sinOpDocD', cosOpDocD, cosOpDocD', tanOpDocD, tanOpDocD', asinOpDocD, 
   asinOpDocD', acosOpDocD, acosOpDocD', atanOpDocD, atanOpDocD', unOpDocD, 
-  unExpr, equalOpDocD, notEqualOpDocD, greaterOpDocD, greaterEqualOpDocD, 
-  lessOpDocD, lessEqualOpDocD, plusOpDocD, minusOpDocD, multOpDocD, 
-  divideOpDocD, moduloOpDocD, powerOpDocD, andOpDocD, orOpDocD, binOpDocD, 
-  binOpDocD', binExpr, binExpr', mkVal, litTrueD, litFalseD, litCharD, 
-  litFloatD, litIntD, litStringD, varDocD, extVarDocD, selfDocD, argDocD, 
-  enumElemDocD, objVarDocD, inlineIfDocD, funcAppDocD, extFuncAppDocD, 
-  stateObjDocD, listStateObjDocD, objDecDefDocD, constDecDefDocD, notNullDocD, 
-  listIndexExistsDocD, funcDocD, castDocD, sizeDocD, listAccessDocD, 
-  listSetDocD, objAccessDocD, castObjDocD, includeD, breakDocD, continueDocD, 
-  staticDocD, dynamicDocD, privateDocD, publicDocD, addCommentsDocD, 
-  callFuncParamList, getterName, setterName, setMain, setEmpty, 
+  unExpr, typeUnExpr, equalOpDocD, notEqualOpDocD, greaterOpDocD, 
+  greaterEqualOpDocD, lessOpDocD, lessEqualOpDocD, plusOpDocD, minusOpDocD, 
+  multOpDocD, divideOpDocD, moduloOpDocD, powerOpDocD, andOpDocD, orOpDocD, 
+  binOpDocD, binOpDocD', binExpr, binExpr', typeBinExpr, mkVal, litTrueD, 
+  litFalseD, litCharD, litFloatD, litIntD, litStringD, varDocD, extVarDocD, 
+  selfDocD, argDocD, enumElemDocD, objVarDocD, inlineIfDocD, funcAppDocD, 
+  extFuncAppDocD, stateObjDocD, listStateObjDocD, objDecDefDocD, 
+  constDecDefDocD, notNullDocD, listIndexExistsDocD, funcDocD, castDocD, 
+  sizeDocD, listAccessDocD, listSetDocD, objAccessDocD, castObjDocD, includeD, 
+  breakDocD, continueDocD, staticDocD, dynamicDocD, privateDocD, publicDocD, 
+  addCommentsDocD, callFuncParamList, getterName, setterName, setMain, setEmpty,
   statementsToStateVars
 ) where
 
@@ -441,6 +441,9 @@ unOpDocD op v = op <> parens v
 unExpr :: Doc -> ValData -> ValData
 unExpr u v = mkVal (valType v) (unOpDocD u (valDoc v))
 
+typeUnExpr :: Doc -> TypeData -> ValData -> ValData
+typeUnExpr u t v = mkVal t (unOpDocD u (valDoc v))
+
 -- Binary Operators --
 
 equalOpDocD :: Doc
@@ -496,6 +499,9 @@ binExpr b v1 v2 = mkVal (valType v1) (binOpDocD b (valDoc v1) (valDoc v2))
 
 binExpr' :: Doc -> ValData -> ValData -> ValData
 binExpr' b v1 v2 = mkVal (valType v1) (binOpDocD' b (valDoc v1) (valDoc v2))
+
+typeBinExpr :: Doc -> TypeData -> ValData -> ValData -> ValData
+typeBinExpr b t v1 v2 = mkVal t (binOpDocD b (valDoc v1) (valDoc v2))
 
 mkVal :: TypeData -> Doc -> ValData
 mkVal = vd Nothing

--- a/code/drasil-code/Language/Drasil/Code/Imperative/LanguageRenderer/CSharpRenderer.hs
+++ b/code/drasil-code/Language/Drasil/Code/Imperative/LanguageRenderer/CSharpRenderer.hs
@@ -43,7 +43,7 @@ import Language.Drasil.Code.Imperative.LanguageRenderer (
 import Language.Drasil.Code.Imperative.Helpers (Terminator(..), FuncData(..),  
   fd, ModData(..), md, TypeData(..), td, ValData(..), vd, liftA4, liftA5, 
   liftA6, liftA7, liftList, lift1List, lift3Pair, lift4Pair, liftPairFst, 
-  convType)
+  getInnerType, convType)
 
 import Prelude hiding (break,print,(<>),sin,cos,tan,floor)
 import qualified Data.Map as Map (fromList,lookup)
@@ -133,9 +133,6 @@ instance StateTypeSym CSharpCode where
   outfile = return csOutfileTypeDoc
   listType p st = liftA2 listTypeDocD st (list p)
   listInnerType t = fmap (getInnerType . cType) t >>= convType
-    where getInnerType :: CodeType -> CodeType
-          getInnerType (List innerT) = innerT
-          getInnerType _ = error "Attempt to extract inner type of list from a non-list type" 
   obj t = return $ typeDocD t
   enumType t = return $ typeDocD t
   iterator _ = error "Iterator-type variables do not exist in C#"

--- a/code/drasil-code/Language/Drasil/Code/Imperative/LanguageRenderer/CSharpRenderer.hs
+++ b/code/drasil-code/Language/Drasil/Code/Imperative/LanguageRenderer/CSharpRenderer.hs
@@ -153,10 +153,10 @@ instance ControlBlockSym CSharpCode where
         v_i = var l_i int
     in
       block [
-        listDec l_temp 0 t,
+        listDec l_temp 0 (fmap valType vnew),
         for (varDecDef l_i int (fromMaybe (litInt 0) b)) 
           (v_i ?< fromMaybe (vold $. listSize) e) (maybe (v_i &++) (v_i &+=) s)
-          (oneLiner $ valState $ v_temp $. listAppend (vold $. listAccess (fmap valType vold) v_i)),
+          (oneLiner $ valState $ v_temp $. listAppend (vold $. listAccess t v_i)),
         vnew &= v_temp]
 
 instance UnaryOpSym CSharpCode where
@@ -316,11 +316,11 @@ instance FunctionSym CSharpCode where
   set n v = func (setterName n) (fmap valType v) [v]
 
   listSize = liftA2 fd int (fmap funcDocD (var "Count" int))
-  listAdd i v = func "Insert" (fmap valType v) [i, v]
+  listAdd _ i v = func "Insert" (fmap valType v) [i, v]
   listAppend v = func "Add" (fmap valType v) [v]
 
-  iterBegin = error "Attempt to use iterBegin in C#, but C# has no iterators"
-  iterEnd = error "Attempt to use iterEnd in C#, but C# has no iterators"
+  iterBegin _ = error "Attempt to use iterBegin in C#, but C# has no iterators"
+  iterEnd _ = error "Attempt to use iterEnd in C#, but C# has no iterators"
 
 instance SelectorFunction CSharpCode where
   listAccess t v = liftA2 fd t (fmap listAccessDocD v)
@@ -435,7 +435,7 @@ instance StatementSym CSharpCode where
   changeState fsmName toState = var fsmName string &= litString toState
 
   initObserverList = listDecDef observerListName
-  addObserver t o = valState $ obsList $. listAdd lastelem o
+  addObserver t o = valState $ obsList $. listAdd obsList lastelem o
     where obsList = observerListName `listOf` t
           lastelem = obsList $. listSize
 

--- a/code/drasil-code/Language/Drasil/Code/Imperative/LanguageRenderer/CSharpRenderer.hs
+++ b/code/drasil-code/Language/Drasil/Code/Imperative/LanguageRenderer/CSharpRenderer.hs
@@ -213,7 +213,7 @@ instance ValueSym CSharpCode where
   enumElement en e = return (enumElemDocD en e, Just $ en ++ "." ++ e)
   enumVar = var
   objVar o v = liftPairFst (liftA2 objVarDocD o v, 
-    Just $ valName o ++ "." ++ valName v)
+    Just $ valueName o ++ "." ++ valueName v)
   objVarSelf n = liftPairFst (liftA2 objVarDocD self (var n), 
     Just $ "self." ++ n)
   listVar n _ = var n
@@ -223,7 +223,7 @@ instance ValueSym CSharpCode where
   inputFunc = return (mkVal $ text "Console.ReadLine()")
   argsList = return (mkVal $ text "args")
 
-  valName (CSC (v, s)) = fromMaybe (error $ 
+  valueName (CSC (v, s)) = fromMaybe (error $ 
     "Attempt to print unprintable Value (" ++ render v ++ ")") s
 
 instance NumericExpression CSharpCode where
@@ -283,7 +283,7 @@ instance Selector CSharpCode where
   ($.) = objAccess
 
   objMethodCall o f ps = objAccess o (func f ps)
-  objMethodCallVoid o f = objMethodCall o f []
+  objMethodCallNoParams o f = objMethodCall o f []
 
   selfAccess = objAccess self
 

--- a/code/drasil-code/Language/Drasil/Code/Imperative/LanguageRenderer/CSharpRenderer.hs
+++ b/code/drasil-code/Language/Drasil/Code/Imperative/LanguageRenderer/CSharpRenderer.hs
@@ -42,7 +42,8 @@ import Language.Drasil.Code.Imperative.LanguageRenderer (
   setMain, setEmpty, statementsToStateVars)
 import Language.Drasil.Code.Imperative.Helpers (Terminator(..), FuncData(..),  
   fd, ModData(..), md, TypeData(..), td, ValData(..), vd, liftA4, liftA5, 
-  liftA6, liftA7, liftList, lift1List, lift3Pair, lift4Pair, liftPairFst)
+  liftA6, liftA7, liftList, lift1List, lift3Pair, lift4Pair, liftPairFst, 
+  convType)
 
 import Prelude hiding (break,print,(<>),sin,cos,tan,floor)
 import qualified Data.Map as Map (fromList,lookup)
@@ -131,6 +132,10 @@ instance StateTypeSym CSharpCode where
   infile = return csInfileTypeDoc
   outfile = return csOutfileTypeDoc
   listType p st = liftA2 listTypeDocD st (list p)
+  listInnerType t = fmap (getInnerType . cType) t >>= convType
+    where getInnerType :: CodeType -> CodeType
+          getInnerType (List innerT) = innerT
+          getInnerType _ = error "Attempt to extract inner type of list from a non-list type" 
   obj t = return $ typeDocD t
   enumType t = return $ typeDocD t
   iterator _ = error "Iterator-type variables do not exist in C#"
@@ -230,6 +235,7 @@ instance ValueSym CSharpCode where
   valueName v = fromMaybe 
     (error $ "Attempt to print unprintable Value (" ++ render (valDoc $ unCSC v)
     ++ ")") (valName $ unCSC v)
+  valueType = fmap valType
 
 instance NumericExpression CSharpCode where
   (#~) = liftA2 unExpr negateOp

--- a/code/drasil-code/Language/Drasil/Code/Imperative/LanguageRenderer/CppRenderer.hs
+++ b/code/drasil-code/Language/Drasil/Code/Imperative/LanguageRenderer/CppRenderer.hs
@@ -205,7 +205,7 @@ instance (Pair p) => ValueSym (p CppSrcCode CppHdrCode) where
   inputFunc = pair inputFunc inputFunc
   argsList = pair argsList argsList
 
-  valName v = valName $ pfst v
+  valueName v = valueName $ pfst v
 
 instance (Pair p) => NumericExpression (p CppSrcCode CppHdrCode) where
   (#~) v = pair ((#~) $ pfst v) ((#~) $ psnd v)
@@ -270,8 +270,8 @@ instance (Pair p) => Selector (p CppSrcCode CppHdrCode) where
 
   objMethodCall o f ps = pair (objMethodCall (pfst o) f (map pfst ps)) 
     (objMethodCall (psnd o) f (map psnd ps))
-  objMethodCallVoid o f = pair (objMethodCallVoid (pfst o) f) 
-    (objMethodCallVoid (psnd o) f)
+  objMethodCallNoParams o f = pair (objMethodCallNoParams (pfst o) f) 
+    (objMethodCallNoParams (psnd o) f)
 
   selfAccess f = pair (selfAccess $ pfst f) (selfAccess $ psnd f)
 
@@ -703,8 +703,8 @@ instance ValueSym CppSrcCode where
   arg n = mkVal <$> liftA2 argDocD (litInt (n+1)) argsList
   enumElement _ e = return (text e, Just e)
   enumVar = var
-  objVar o v = liftPairFst (liftA2 objVarDocD o v, Just $ valName o ++ "." ++ 
-    valName v)
+  objVar o v = liftPairFst (liftA2 objVarDocD o v, Just $ valueName o ++ "." ++ 
+    valueName v)
   objVarSelf = var
   listVar n _ = var n
   n `listOf` t = listVar n t
@@ -713,7 +713,7 @@ instance ValueSym CppSrcCode where
   inputFunc = return (mkVal $ text "std::cin")
   argsList = return (mkVal $ text "argv")
 
-  valName (CPPSC (v, s)) = fromMaybe 
+  valueName (CPPSC (v, s)) = fromMaybe 
     (error $ "Attempt to print unprintable Value (" ++ render v ++ ")") s
 
 instance NumericExpression CppSrcCode where
@@ -772,7 +772,7 @@ instance Selector CppSrcCode where
   ($.) = objAccess
 
   objMethodCall o f ps = objAccess o (func f ps)
-  objMethodCallVoid o f = objMethodCall o f []
+  objMethodCallNoParams o f = objMethodCall o f []
 
   selfAccess = objAccess self
 
@@ -1221,7 +1221,7 @@ instance ValueSym CppHdrCode where
   inputFunc = return (mkVal empty)
   argsList = return (mkVal empty)
 
-  valName _ = error "Attempted to extract string from Value for C++ header file"
+  valueName _ = error "Attempted to extract string from Value for C++ header file"
 
 instance NumericExpression CppHdrCode where
   (#~) _ = return (mkVal empty)
@@ -1278,7 +1278,7 @@ instance Selector CppHdrCode where
   ($.) _ _ = return (mkVal empty)
 
   objMethodCall _ _ _ = return (mkVal empty)
-  objMethodCallVoid _ _ = return (mkVal empty)
+  objMethodCallNoParams _ _ = return (mkVal empty)
 
   selfAccess _ = return (mkVal empty)
 

--- a/code/drasil-code/Language/Drasil/Code/Imperative/LanguageRenderer/CppRenderer.hs
+++ b/code/drasil-code/Language/Drasil/Code/Imperative/LanguageRenderer/CppRenderer.hs
@@ -42,7 +42,7 @@ import Language.Drasil.Code.Imperative.Helpers (Pair(..), Terminator(..),
   StateVarData(..), svd, TypeData(..), td, ValData(..), vd, angles, blank, 
   doubleQuotedText, mapPairFst, mapPairSnd, vibcat, liftA4, liftA5, liftA6, 
   liftA8, liftList, lift2Lists, lift1List, lift3Pair, lift4Pair, liftPairFst,
-  convType)
+  getInnerType, convType)
 
 import Prelude hiding (break,print,(<>),sin,cos,tan,floor,const,log,exp)
 import qualified Data.Map as Map (fromList,lookup)
@@ -623,9 +623,6 @@ instance StateTypeSym CppSrcCode where
   outfile = return cppOutfileTypeDoc
   listType p st = liftA2 listTypeDocD st (list p)
   listInnerType t = fmap (getInnerType . cType) t >>= convType
-    where getInnerType :: CodeType -> CodeType
-          getInnerType (List innerT) = innerT
-          getInnerType _ = error "Attempt to extract inner type of list from a non-list type" 
   obj t = return $ typeDocD t
   enumType t = return $ typeDocD t
   iterator t = fmap cppIterTypeDoc (listType dynamic_ t)
@@ -1156,9 +1153,6 @@ instance StateTypeSym CppHdrCode where
   outfile = return cppOutfileTypeDoc
   listType p st = liftA2 listTypeDocD st (list p)
   listInnerType t = fmap (getInnerType . cType) t >>= convType
-    where getInnerType :: CodeType -> CodeType
-          getInnerType (List innerT) = innerT
-          getInnerType _ = error "Attempt to extract inner type of list from a non-list type" 
   obj t = return $ typeDocD t
   enumType t = return $ typeDocD t
   iterator t = fmap cppIterTypeDoc (listType dynamic_ t)

--- a/code/drasil-code/Language/Drasil/Code/Imperative/LanguageRenderer/JavaRenderer.hs
+++ b/code/drasil-code/Language/Drasil/Code/Imperative/LanguageRenderer/JavaRenderer.hs
@@ -289,7 +289,8 @@ instance ValueExpression JavaCode where
     (liftList callFuncParamList vs))
 
   exists = notNull
-  notNull v = liftA2 mkVal bool (liftA3 notNullDocD notEqualOp v (var "null" (fmap valType v)))
+  notNull v = liftA2 mkVal bool (liftA3 notNullDocD notEqualOp v (var "null"
+    (fmap valType v)))
 
 instance Selector JavaCode where
   objAccess v f = liftA2 mkVal (fmap funcType f) (liftA2 objAccessDocD v f)
@@ -426,7 +427,7 @@ instance StatementSym JavaCode where
   getFileInputLine f v = v &= f $. func "nextLine" string []
   discardFileLine f = valState $ f $. func "nextLine" string []
   stringSplit d vnew s = mkSt <$> liftA2 jStringSplit vnew 
-    (funcApp "Arrays.asList" (listType dynamic_ string) 
+    (funcApp "Arrays.asList" (listType static_ string) 
     [s $. func "split" (listType static_ string) [litString [d]]])
 
   break = return (mkSt breakDocD)  -- I could have a JumpSym class with functions for "return $ text "break" and then reference those functions here?
@@ -476,7 +477,7 @@ instance ControlStatementSym JavaCode where
 
   tryCatch tb cb = mkStNoEnd <$> liftA2 jTryCatch tb cb
   
-  checkState l t = switch (var l t)
+  checkState l = switch (var l string)
   notifyObservers ft fn t ps = for initv (var index int ?< 
     (obsList $. listSize)) (var index int &++) notify
     where obsList = observerListName `listOf` t

--- a/code/drasil-code/Language/Drasil/Code/Imperative/LanguageRenderer/JavaRenderer.hs
+++ b/code/drasil-code/Language/Drasil/Code/Imperative/LanguageRenderer/JavaRenderer.hs
@@ -28,17 +28,17 @@ import Language.Drasil.Code.Imperative.LanguageRenderer (
   stateVarListDocD, ifCondDocD, switchDocD, forDocD, forEachDocD, whileDocD, 
   stratDocD, assignDocD, plusEqualsDocD, plusPlusDocD, varDecDocD,
   varDecDefDocD, listDecDocD, objDecDefDocD, statementDocD, returnDocD,
-  commentDocD, mkSt, mkStNoEnd, notOpDocD, negateOpDocD, unExpr, equalOpDocD, 
-  notEqualOpDocD, greaterOpDocD, greaterEqualOpDocD, lessOpDocD, 
+  commentDocD, mkSt, mkStNoEnd, notOpDocD, negateOpDocD, unExpr, typeUnExpr, 
+  equalOpDocD, notEqualOpDocD, greaterOpDocD, greaterEqualOpDocD, lessOpDocD, 
   lessEqualOpDocD, plusOpDocD, minusOpDocD, multOpDocD, divideOpDocD, 
-  moduloOpDocD, andOpDocD, orOpDocD, binExpr, binExpr', mkVal, litTrueD, 
-  litFalseD, litCharD, litFloatD, litIntD, litStringD, varDocD, extVarDocD, 
-  selfDocD, argDocD, enumElemDocD, objVarDocD, inlineIfDocD, funcAppDocD, 
-  extFuncAppDocD, stateObjDocD, listStateObjDocD, notNullDocD, funcDocD, 
-  castDocD, objAccessDocD, castObjDocD, breakDocD, continueDocD, staticDocD, 
-  dynamicDocD, privateDocD, publicDocD, dot, new, forLabel, observerListName,
-  doubleSlash, addCommentsDocD, callFuncParamList, getterName, setterName,
-  setMain, setEmpty, statementsToStateVars)
+  moduloOpDocD, andOpDocD, orOpDocD, binExpr, binExpr', typeBinExpr, mkVal, 
+  litTrueD, litFalseD, litCharD, litFloatD, litIntD, litStringD, varDocD, 
+  extVarDocD, selfDocD, argDocD, enumElemDocD, objVarDocD, inlineIfDocD, 
+  funcAppDocD, extFuncAppDocD, stateObjDocD, listStateObjDocD, notNullDocD, 
+  funcDocD, castDocD, objAccessDocD, castObjDocD, breakDocD, continueDocD, 
+  staticDocD, dynamicDocD, privateDocD, publicDocD, dot, new, forLabel, 
+  observerListName, doubleSlash, addCommentsDocD, callFuncParamList, getterName,
+  setterName, setMain, setEmpty, statementsToStateVars)
 import Language.Drasil.Code.Imperative.Helpers (Terminator(..), FuncData(..), 
   fd, ModData(..), md, TypeData(..), td, ValData(..), vd,  angles, liftA4, 
   liftA5, liftA6, liftA7, liftList, lift1List, lift3Pair, lift4Pair, 
@@ -265,16 +265,16 @@ instance NumericExpression JavaCode where
   ceil = liftA2 unExpr ceilOp
 
 instance BooleanExpression JavaCode where
-  (?!) = liftA2 unExpr notOp
-  (?&&) = liftA3 binExpr andOp
-  (?||) = liftA3 binExpr orOp
+  (?!) = liftA3 typeUnExpr notOp bool
+  (?&&) = liftA4 typeBinExpr andOp bool
+  (?||) = liftA4 typeBinExpr orOp bool
 
-  (?<) = liftA3 binExpr lessOp
-  (?<=) = liftA3 binExpr lessEqualOp
-  (?>) = liftA3 binExpr greaterOp
-  (?>=) = liftA3 binExpr greaterEqualOp
-  (?==) = liftA3 binExpr equalOp
-  (?!=) = liftA3 binExpr notEqualOp
+  (?<) = liftA4 typeBinExpr lessOp bool
+  (?<=) = liftA4 typeBinExpr lessEqualOp bool
+  (?>) = liftA4 typeBinExpr greaterOp bool
+  (?>=) = liftA4 typeBinExpr greaterEqualOp bool
+  (?==) = liftA4 typeBinExpr equalOp bool
+  (?!=) = liftA4 typeBinExpr notEqualOp bool
   
 instance ValueExpression JavaCode where
   inlineIf b v1 v2 = liftA2 mkVal (fmap valType v1) (liftA3 inlineIfDocD b v1 

--- a/code/drasil-code/Language/Drasil/Code/Imperative/LanguageRenderer/JavaRenderer.hs
+++ b/code/drasil-code/Language/Drasil/Code/Imperative/LanguageRenderer/JavaRenderer.hs
@@ -42,7 +42,7 @@ import Language.Drasil.Code.Imperative.LanguageRenderer (
 import Language.Drasil.Code.Imperative.Helpers (Terminator(..), FuncData(..), 
   fd, ModData(..), md, TypeData(..), td, ValData(..), vd,  angles, liftA4, 
   liftA5, liftA6, liftA7, liftList, lift1List, lift3Pair, lift4Pair, 
-  liftPairFst)
+  liftPairFst, convType)
 
 import Prelude hiding (break,print,sin,cos,tan,floor,(<>))
 import qualified Data.Map as Map (fromList,lookup)
@@ -137,6 +137,10 @@ instance StateTypeSym JavaCode where
   infile = return jInfileTypeDoc
   outfile = return jOutfileTypeDoc
   listType p st = liftA2 jListType st (list p)
+  listInnerType t = fmap (getInnerType . cType) t >>= convType
+    where getInnerType :: CodeType -> CodeType
+          getInnerType (List innerT) = innerT
+          getInnerType _ = error "Attempt to extract inner type of list from a non-list type" 
   obj t = return $ typeDocD t
   enumType t = return $ typeDocD t
   iterator _ = error "Iterator-type variables do not exist in Java"
@@ -236,6 +240,7 @@ instance ValueSym JavaCode where
   valueName v = fromMaybe 
     (error $ "Attempt to print unprintable Value (" ++ render (valDoc $ unJC v) 
     ++ ")") (valName $ unJC v)
+  valueType = fmap valType
 
 instance NumericExpression JavaCode where
   (#~) = liftA2 unExpr negateOp

--- a/code/drasil-code/Language/Drasil/Code/Imperative/LanguageRenderer/JavaRenderer.hs
+++ b/code/drasil-code/Language/Drasil/Code/Imperative/LanguageRenderer/JavaRenderer.hs
@@ -218,8 +218,8 @@ instance ValueSym JavaCode where
   arg n = mkVal <$> liftA2 argDocD (litInt n) argsList
   enumElement en e = return (enumElemDocD en e, Just $ en ++ "." ++ e)
   enumVar = var
-  objVar o v = liftPairFst (liftA2 objVarDocD o v, Just $ valName o ++ "." ++ 
-    valName v)
+  objVar o v = liftPairFst (liftA2 objVarDocD o v, Just $ valueName o ++ "." ++ 
+    valueName v)
   objVarSelf = var
   listVar n _ = var n
   n `listOf` t = listVar n t
@@ -228,7 +228,7 @@ instance ValueSym JavaCode where
   inputFunc = return (mkVal $ parens (text "new Scanner(System.in)"))
   argsList = return (mkVal $ text "args")
 
-  valName (JC (v, s)) = fromMaybe 
+  valueName (JC (v, s)) = fromMaybe 
     (error $ "Attempt to print unprintable Value (" ++ render v ++ ")") s
 
 instance NumericExpression JavaCode where
@@ -288,7 +288,7 @@ instance Selector JavaCode where
   ($.) = objAccess
 
   objMethodCall o f ps = objAccess o (func f ps)
-  objMethodCallVoid o f = objMethodCall o f []
+  objMethodCallNoParams o f = objMethodCall o f []
 
   selfAccess = objAccess self
 

--- a/code/drasil-code/Language/Drasil/Code/Imperative/LanguageRenderer/JavaRenderer.hs
+++ b/code/drasil-code/Language/Drasil/Code/Imperative/LanguageRenderer/JavaRenderer.hs
@@ -159,11 +159,10 @@ instance ControlBlockSym JavaCode where
         v_i = var l_i int
     in
       block [
-        listDec l_temp 0 t,
+        listDec l_temp 0 (fmap valType vnew),
         for (varDecDef l_i int (fromMaybe (litInt 0) b)) 
           (v_i ?< fromMaybe (vold $. listSize) e) (maybe (v_i &++) (v_i &+=) s)
-          (oneLiner $ valState $ v_temp $. listAppend (vold $. listAccess (fmap 
-          valType vold) v_i)),
+          (oneLiner $ valState $ v_temp $. listAppend (vold $. listAccess t v_i)),
         vnew &= v_temp]
 
 instance UnaryOpSym JavaCode where
@@ -323,11 +322,11 @@ instance FunctionSym JavaCode where
   set n v = func (setterName n) (fmap valType v) [v]
 
   listSize = func "size" int []
-  listAdd i v = func "add" (listType static_ $ fmap valType v) [i, v]
+  listAdd _ i v = func "add" (listType static_ $ fmap valType v) [i, v]
   listAppend v = func "add" (listType static_ $ fmap valType v) [v]
 
-  iterBegin = error "Attempt to use iterBegin in Java, but Java has no iterators"
-  iterEnd = error "Attempt to use iterEnd in Java, but Java has no iterators"
+  iterBegin _ = error "Attempt to use iterBegin in Java, but Java has no iterators"
+  iterEnd _ = error "Attempt to use iterEnd in Java, but Java has no iterators"
 
 instance SelectorFunction JavaCode where
   listAccess t i = func "get" t [i]
@@ -449,7 +448,7 @@ instance StatementSym JavaCode where
   changeState fsmName toState = var fsmName string &= litString toState
 
   initObserverList = listDecDef observerListName
-  addObserver t o = valState $ obsList $. listAdd lastelem o
+  addObserver t o = valState $ obsList $. listAdd obsList lastelem o
     where obsList = observerListName `listOf` t
           lastelem = obsList $. listSize
 

--- a/code/drasil-code/Language/Drasil/Code/Imperative/LanguageRenderer/JavaRenderer.hs
+++ b/code/drasil-code/Language/Drasil/Code/Imperative/LanguageRenderer/JavaRenderer.hs
@@ -39,9 +39,10 @@ import Language.Drasil.Code.Imperative.LanguageRenderer (
   dynamicDocD, privateDocD, publicDocD, dot, new, forLabel, observerListName,
   doubleSlash, addCommentsDocD, callFuncParamList, getterName, setterName,
   setMain, setEmpty, statementsToStateVars)
-import Language.Drasil.Code.Imperative.Helpers (Terminator(..), ModData(..), md,
-  TypeData(..), td, angles, liftA4, liftA5, liftA6, liftA7, liftList, lift1List,
-  lift3Pair, lift4Pair, liftPairFst)
+import Language.Drasil.Code.Imperative.Helpers (Terminator(..), FuncData(..), 
+  fd, ModData(..), md, TypeData(..), td, ValData(..), vd,  angles, liftA4, 
+  liftA5, liftA6, liftA7, liftList, lift1List, lift3Pair, lift4Pair, 
+  liftPairFst)
 
 import Prelude hiding (break,print,sin,cos,tan,floor,(<>))
 import qualified Data.Map as Map (fromList,lookup)
@@ -139,6 +140,7 @@ instance StateTypeSym JavaCode where
   obj t = return $ typeDocD t
   enumType t = return $ typeDocD t
   iterator _ = error "Iterator-type variables do not exist in Java"
+  void = return voidDocD
 
 instance ControlBlockSym JavaCode where
   runStrategy l strats rv av = maybe
@@ -152,15 +154,16 @@ instance ControlBlockSym JavaCode where
 
   listSlice t vnew vold b e s = 
     let l_temp = "temp"
-        v_temp = var l_temp
+        v_temp = var l_temp (fmap valType vnew)
         l_i = "i_temp"
-        v_i = var l_i
+        v_i = var l_i int
     in
       block [
         listDec l_temp 0 t,
         for (varDecDef l_i int (fromMaybe (litInt 0) b)) 
           (v_i ?< fromMaybe (vold $. listSize) e) (maybe (v_i &++) (v_i &+=) s)
-          (oneLiner $ valState $ v_temp $. listAppend (vold $. listAccess v_i)),
+          (oneLiner $ valState $ v_temp $. listAppend (vold $. listAccess (fmap 
+          valType vold) v_i)),
         vnew &= v_temp]
 
 instance UnaryOpSym JavaCode where
@@ -199,37 +202,41 @@ instance BinaryOpSym JavaCode where
   orOp = return orOpDocD
 
 instance ValueSym JavaCode where
-  -- Maybe String is the String representation of the value
-  type Value JavaCode = (Doc, Maybe String)
-  litTrue = return (litTrueD, Just "true")
-  litFalse = return (litFalseD, Just "false")
-  litChar c = return (litCharD c, Just $ "\'" ++ [c] ++ "\'")
-  litFloat v = return (litFloatD v, Just $ show v)
-  litInt v = return (litIntD v, Just $ show v)
-  litString s = return (litStringD s, Just $ "\"" ++ s ++ "\"")
+  type Value JavaCode = ValData
+  litTrue = liftA2 (vd (Just "true")) bool (return litTrueD)
+  litFalse = liftA2 (vd (Just "false")) bool (return litFalseD)
+  litChar c = liftA2 (vd (Just $ "\'" ++ [c] ++ "\'")) char 
+    (return $ litCharD c)
+  litFloat v = liftA2 (vd (Just $ show v)) float (return $ litFloatD v)
+  litInt v = liftA2 (vd (Just $ show v)) int (return $ litIntD v)
+  litString s = liftA2 (vd (Just $ "\"" ++ s ++ "\"")) string 
+    (return $ litStringD s)
 
   ($->) = objVar
   ($:) = enumElement
 
   const = var
-  var n = return (varDocD n, Just n)
-  extVar l n = return (extVarDocD l n, Just $ l ++ "." ++ n)
-  self = return (selfDocD, Just "this")
-  arg n = mkVal <$> liftA2 argDocD (litInt n) argsList
-  enumElement en e = return (enumElemDocD en e, Just $ en ++ "." ++ e)
-  enumVar = var
-  objVar o v = liftPairFst (liftA2 objVarDocD o v, Just $ valueName o ++ "." ++ 
-    valueName v)
-  objVarSelf = var
-  listVar n _ = var n
-  n `listOf` t = listVar n t
-  iterVar = var
+  var n t = liftA2 (vd (Just n)) t (return $ varDocD n) 
+  extVar l n t = liftA2 (vd (Just $ l ++ "." ++ n)) t (return $ extVarDocD l n)
+  self l = liftA2 (vd (Just "this")) (obj l) (return selfDocD)
+  arg n = liftA2 mkVal string (liftA2 argDocD (litInt n) argsList)
+  enumElement en e = liftA2 (vd (Just $ en ++ "." ++ e)) (obj en) 
+    (return $ enumElemDocD en e)
+  enumVar e en = var e (obj en)
+  objVar o v = liftA2 (vd (Just $ valueName o ++ "." ++ valueName v))
+    (fmap valType v) (liftA2 objVarDocD o v)
+  objVarSelf _ = var
+  listVar n p t = var n (listType p t)
+  n `listOf` t = listVar n static_ t
+  iterVar n t = var n (iterator t)
   
-  inputFunc = return (mkVal $ parens (text "new Scanner(System.in)"))
-  argsList = return (mkVal $ text "args")
+  inputFunc = liftA2 mkVal (obj "Scanner") (return $ parens (
+    text "new Scanner(System.in)"))
+  argsList = liftA2 mkVal (listType static_ string) (return $ text "args")
 
-  valueName (JC (v, s)) = fromMaybe 
-    (error $ "Attempt to print unprintable Value (" ++ render v ++ ")") s
+  valueName v = fromMaybe 
+    (error $ "Attempt to print unprintable Value (" ++ render (valDoc $ unJC v) 
+    ++ ")") (valName $ unJC v)
 
 instance NumericExpression JavaCode where
   (#~) = liftA2 unExpr negateOp
@@ -270,64 +277,65 @@ instance BooleanExpression JavaCode where
   (?!=) = liftA3 binExpr notEqualOp
   
 instance ValueExpression JavaCode where
-  inlineIf b v1 v2 = mkVal <$> liftA3 inlineIfDocD b v1 v2
-  funcApp n vs = mkVal <$> liftList (funcAppDocD n) vs
+  inlineIf b v1 v2 = liftA2 mkVal (fmap valType v1) (liftA3 inlineIfDocD b v1 
+    v2)
+  funcApp n t vs = liftA2 mkVal t (liftList (funcAppDocD n) vs)
   selfFuncApp = funcApp
-  extFuncApp l n vs = mkVal <$> liftList (extFuncAppDocD l n) vs
-  stateObj t vs = mkVal <$> liftA2 stateObjDocD t 
-    (liftList callFuncParamList vs)
+  extFuncApp l n t vs = liftA2 mkVal t (liftList (extFuncAppDocD l n) vs)
+  stateObj t vs = liftA2 mkVal t (liftA2 stateObjDocD t 
+    (liftList callFuncParamList vs))
   extStateObj _ = stateObj
-  listStateObj t vs = mkVal <$> liftA3 listStateObjDocD listObj t 
-    (liftList callFuncParamList vs)
+  listStateObj t vs = liftA2 mkVal t (liftA3 listStateObjDocD listObj t 
+    (liftList callFuncParamList vs))
 
   exists = notNull
-  notNull v = mkVal <$> liftA3 notNullDocD notEqualOp v (var "null")
+  notNull v = liftA2 mkVal bool (liftA3 notNullDocD notEqualOp v (var "null" (fmap valType v)))
 
 instance Selector JavaCode where
-  objAccess v f = mkVal <$> liftA2 objAccessDocD v f
+  objAccess v f = liftA2 mkVal (fmap funcType f) (liftA2 objAccessDocD v f)
   ($.) = objAccess
 
-  objMethodCall o f ps = objAccess o (func f ps)
-  objMethodCallNoParams o f = objMethodCall o f []
+  objMethodCall t o f ps = objAccess o (func f t ps)
+  objMethodCallNoParams t o f = objMethodCall t o f []
 
-  selfAccess = objAccess self
+  selfAccess l = objAccess (self l)
 
   listSizeAccess v = objAccess v listSize
 
-  listIndexExists l i = mkVal <$> liftA3 jListIndexExists greaterOp l i
+  listIndexExists l i = liftA2 mkVal bool (liftA3 jListIndexExists greaterOp l 
+    i)
+  argExists i = objAccess argsList (listAccess string (litInt $ fromIntegral i))
 
-  argExists i = objAccess argsList (listAccess (litInt $ fromIntegral i))
+  indexOf l v = objAccess l (func "indexOf" int [v])
 
-  indexOf l v = objAccess l (fmap funcDocD (funcApp "indexOf" [v]))
+  stringEqual v1 str = objAccess v1 (func "equals" bool [str])
 
-  stringEqual v1 str = objAccess v1 (func "equals" [str])
-
-  castObj f v = mkVal <$> liftA2 castObjDocD f v
-  castStrToFloat v = funcApp "Double.parseDouble" [v]
+  castObj f v = liftA2 mkVal (fmap funcType f) (liftA2 castObjDocD f v)
+  castStrToFloat v = funcApp "Double.parseDouble" float [v]
 
 instance FunctionSym JavaCode where
-  type Function JavaCode = Doc
-  func l vs = fmap funcDocD (funcApp l vs)
-  cast targT _ = fmap castDocD targT
-  castListToInt = fmap funcDocD (funcApp "ordinal" [])
-  get n = fmap funcDocD (funcApp (getterName n) [])
-  set n v = fmap funcDocD (funcApp (setterName n) [v])
+  type Function JavaCode = FuncData
+  func l t vs = liftA2 fd t (fmap funcDocD (funcApp l t vs))
+  cast targT _ = liftA2 fd targT (fmap castDocD targT)
+  castListToInt = func "ordinal" int []
+  get n t = func (getterName n) t []
+  set n v = func (setterName n) (fmap valType v) [v]
 
-  listSize = fmap funcDocD (funcApp "size" [])
-  listAdd i v = fmap funcDocD (funcApp "add" [i, v])
-  listAppend v = fmap funcDocD (funcApp "add" [v])
+  listSize = func "size" int []
+  listAdd i v = func "add" (listType static_ $ fmap valType v) [i, v]
+  listAppend v = func "add" (listType static_ $ fmap valType v) [v]
 
-  iterBegin = fmap funcDocD (funcApp "begin" [])
-  iterEnd = fmap funcDocD (funcApp "end" [])
+  iterBegin = error "Attempt to use iterBegin in Java, but Java has no iterators"
+  iterEnd = error "Attempt to use iterEnd in Java, but Java has no iterators"
 
 instance SelectorFunction JavaCode where
-  listAccess i = fmap funcDocD (funcApp "get" [i])
-  listSet i v = fmap funcDocD (funcApp "set" [i, v])
+  listAccess t i = func "get" t [i]
+  listSet i v = func "set" (listType static_ $ fmap valType v) [i, v]
 
-  listAccessEnum t v = listAccess (castObj (cast int t) v)
+  listAccessEnum et t v = listAccess t (castObj (cast int et) v)
   listSetEnum t i = listSet (castObj (cast int t) i)
 
-  at l = listAccess (var l)
+  at t l = listAccess t (var l int)
 
 instance StatementSym JavaCode where
   -- Terminator determines how statements end
@@ -335,16 +343,10 @@ instance StatementSym JavaCode where
   assign v1 v2 = mkSt <$> liftA2 assignDocD v1 v2
   assignToListIndex lst index v = valState $ lst $. listSet index v
   (&=) = assign
-  (&.=) l = assign (var l)
-  (&=.) v l = assign v (var l)
   (&-=) v1 v2 = v1 &= (v1 #- v2)
-  (&.-=) l v = l &.= (var l #- v)
   (&+=) v1 v2 = mkSt <$> liftA2 plusEqualsDocD v1 v2
-  (&.+=) l v = var l &+= v
   (&++) v = mkSt <$> fmap plusPlusDocD v
-  (&.++) l = (&++) (var l)
   (&~-) v = v &= (v #- litInt 1)
-  (&.~-) l = (&~-) (var l)
 
   varDec l t = mkSt <$> fmap (varDecDocD l) t
   varDecDef l t v = mkSt <$> liftA2 (varDecDefDocD l) t v
@@ -371,28 +373,28 @@ instance StatementSym JavaCode where
     (litString s)
 
   printList t v = multi [state (printStr "["), 
-    for (varDecDef "i" int (litInt 0)) (var "i" ?< 
-      ((v $. listSize) #- litInt 1)) ("i" &.++) 
-      (bodyStatements [print t (v $. listAccess (var "i")), printStr ","]), 
-    state (print t (v $. listAccess ((v $. listSize) #- litInt 1))), 
+    for (varDecDef "i" int (litInt 0)) (var "i" int ?< ((v $. listSize) #- 
+      litInt 1)) (var "i" int &++) (bodyStatements [
+        print t (v $. listAccess t (var "i" int)), printStr ","]), 
+    state (print t (v $. listAccess t ((v $. listSize) #- litInt 1))), 
     printStr "]"]
   printLnList t v = multi [state (printStr "["), 
-    for (varDecDef "i" int (litInt 0)) (var "i" ?< 
-      ((v $. listSize) #- litInt 1)) ("i" &.++) 
-      (bodyStatements [print t (v $. listAccess (var "i")), printStr ","]), 
-    state (print t (v $. listAccess ((v $. listSize) #- litInt 1))), 
+    for (varDecDef "i" int (litInt 0)) (var "i" int ?< ((v $. listSize) #- 
+      litInt 1)) (var "i" int &++) (bodyStatements [
+        print t (v $. listAccess t (var "i" int)), printStr ","]), 
+    state (print t (v $. listAccess t ((v $. listSize) #- litInt 1))), 
     printStrLn "]"]
   printFileList f t v = multi [state (printFileStr f "["), 
-    for (varDecDef "i" int (litInt 0)) (var "i" ?< 
-      ((v $. listSize) #- litInt 1)) ("i" &.++) (bodyStatements 
-      [printFile f t (v $. listAccess (var "i")), printFileStr f ","]), 
-    state (printFile f t (v $. listAccess ((v $. listSize) #- litInt 1))), 
+    for (varDecDef "i" int (litInt 0)) (var "i" int ?< ((v $. listSize) #- 
+      litInt 1)) (var "i" int &++) (bodyStatements [
+        printFile f t (v $. listAccess t (var "i" int)), printFileStr f ","]), 
+    state (printFile f t (v $. listAccess t ((v $. listSize) #- litInt 1))), 
     printFileStr f "]"]
   printFileLnList f t v = multi [state (printFileStr f "["), 
-    for (varDecDef "i" int (litInt 0)) (var "i" ?< 
-      ((v $. listSize) #- litInt 1)) ("i" &.++) (bodyStatements 
-      [printFile f t (v $. listAccess (var "i")), printFileStr f ","]), 
-    state (printFile f t (v $. listAccess ((v $. listSize) #- litInt 1))), 
+    for (varDecDef "i" int (litInt 0)) (var "i" int ?< ((v $. listSize) #- 
+      litInt 1)) (var "i" int &++) (bodyStatements [
+        printFile f t (v $. listAccess t (var "i" int)), printFileStr f ","]), 
+    state (printFile f t (v $. listAccess t ((v $. listSize) #- litInt 1))), 
     printFileStrLn f "]"]
 
   getIntInput v = mkSt <$> liftA3 jInput' (return $ text "Integer.parseInt")
@@ -419,21 +421,21 @@ instance StatementSym JavaCode where
   openFileR f n = mkSt <$> liftA2 jOpenFileR f n
   openFileW f n = mkSt <$> liftA3 jOpenFileWorA f n litFalse
   openFileA f n = mkSt <$> liftA3 jOpenFileWorA f n litTrue
-  closeFile f = valState $ objMethodCall f "close" []
+  closeFile f = valState $ objMethodCall void f "close" []
 
-  getFileInputLine f v = v &= f $. func "nextLine" []
-  discardFileLine f = valState $ f $. func "nextLine" []
-  stringSplit d vnew s = mkSt <$> liftA3 jStringSplit vnew 
-    (listType dynamic_ string) 
-    (funcApp "Arrays.asList" [s $. func "split" [litString [d]]])
+  getFileInputLine f v = v &= f $. func "nextLine" string []
+  discardFileLine f = valState $ f $. func "nextLine" string []
+  stringSplit d vnew s = mkSt <$> liftA2 jStringSplit vnew 
+    (funcApp "Arrays.asList" (listType dynamic_ string) 
+    [s $. func "split" (listType static_ string) [litString [d]]])
 
   break = return (mkSt breakDocD)  -- I could have a JumpSym class with functions for "return $ text "break" and then reference those functions here?
   continue = return (mkSt continueDocD)
 
   returnState v = mkSt <$> fmap returnDocD v
-  returnVar l = mkSt <$> fmap returnDocD (var l)
+  returnVar l t = mkSt <$> fmap returnDocD (var l t)
 
-  valState v = mkSt <$> fmap fst v
+  valState v = mkSt <$> fmap valDoc v
 
   comment cmt = mkStNoEnd <$> fmap (commentDocD cmt) commentStart
 
@@ -443,7 +445,7 @@ instance StatementSym JavaCode where
 
   initState fsmName initialState = varDecDef fsmName string 
     (litString initialState)
-  changeState fsmName toState = fsmName &.= litString toState
+  changeState fsmName toState = var fsmName string &= litString toState
 
   initObserverList = listDecDef observerListName
   addObserver t o = valState $ obsList $. listAdd lastelem o
@@ -466,24 +468,24 @@ instance ControlStatementSym JavaCode where
 
   for sInit vGuard sUpdate b = mkStNoEnd <$> liftA6 forDocD blockStart blockEnd 
     (loopState sInit) vGuard (loopState sUpdate) b
-  forRange i initv finalv stepv = for (varDecDef i int initv) (var i ?< finalv)
-    (i &.+= stepv)
+  forRange i initv finalv stepv = for (varDecDef i int initv) (var i int ?< 
+    finalv) (var i int &+= stepv)
   forEach l t v b = mkStNoEnd <$> liftA7 (forEachDocD l) blockStart blockEnd
     iterForEachLabel iterInLabel t v b
   while v b = mkStNoEnd <$> liftA4 whileDocD blockStart blockEnd v b
 
   tryCatch tb cb = mkStNoEnd <$> liftA2 jTryCatch tb cb
   
-  checkState l = switch (var l)
-  notifyObservers fn t ps = for initv (var index ?< (obsList $. listSize)) 
-    (index &.++) notify
+  checkState l t = switch (var l t)
+  notifyObservers ft fn t ps = for initv (var index int ?< 
+    (obsList $. listSize)) (var index int &++) notify
     where obsList = observerListName `listOf` t
           index = "observerIndex"
           initv = varDecDef index int $ litInt 0
-          notify = oneLiner $ valState $ (obsList $. at index) $. func fn ps
+          notify = oneLiner $ valState $ (obsList $. at int index) $. func fn ft ps
 
-  getFileInputAll f v = while (f $. func "hasNextLine" [])
-    (oneLiner $ valState $ v $. listAppend (f $. func "nextLine" []))
+  getFileInputAll f v = while (f $. func "hasNextLine" bool [])
+    (oneLiner $ valState $ v $. listAppend (f $. func "nextLine" string []))
 
 instance ScopeSym JavaCode where
   type Scope JavaCode = Doc
@@ -493,10 +495,9 @@ instance ScopeSym JavaCode where
   includeScope s = s
 
 instance MethodTypeSym JavaCode where
-  type MethodType JavaCode = Doc
-  mState = fmap typeDoc
-  void = return voidDocD
-  construct n = return $ constructDocD n
+  type MethodType JavaCode = TypeData
+  mState t = t
+  construct n = return $ td (Object n) (constructDocD n)
 
 instance ParameterSym JavaCode where
   type Parameter JavaCode = Doc
@@ -509,10 +510,10 @@ instance MethodSym JavaCode where
   method n _ s p t ps b = liftPairFst (liftA5 (jMethod n) s p t (liftList 
     paramListDocD ps) b, False)
   getMethod n c t = method (getterName n) c public dynamic_ t [] getBody
-    where getBody = oneLiner $ returnState (self $-> var n)
+    where getBody = oneLiner $ returnState (self c $-> var n t)
   setMethod setLbl c paramLbl t = method (setterName setLbl) c public dynamic_ 
     void [stateParam paramLbl t] setBody
-    where setBody = oneLiner $ (self $-> var setLbl) &=. paramLbl
+    where setBody = oneLiner $ (self c $-> var setLbl t) &= var paramLbl t
   mainMethod c b = setMain <$> method "main" c public static_ void 
     [return $ text "String[] args"] b
   privMethod n c = method n c private dynamic_
@@ -585,12 +586,13 @@ jListDecDef l st vs = typeDoc st <+> text l <+> equals <+> new <+>
   where listElements = if isEmpty vs then empty else text "Arrays.asList" <> 
                          parens vs
 
-jConstDecDef :: Label -> TypeData -> (Doc, Maybe String) -> Doc
-jConstDecDef l st (v, _) = text "final" <+> typeDoc st <+> text l <+> equals <+>
-  v
+jConstDecDef :: Label -> TypeData -> ValData -> Doc
+jConstDecDef l st v = text "final" <+> typeDoc st <+> text l <+> equals <+>
+  valDoc v
 
-jThrowDoc :: (Doc, Maybe String) -> Doc
-jThrowDoc (errMsg, _) = text "throw new" <+> text "Exception" <> parens errMsg
+jThrowDoc :: ValData -> Doc
+jThrowDoc errMsg = text "throw new" <+> text "Exception" <> parens (valDoc 
+  errMsg)
 
 jTryCatch :: Doc -> Doc -> Doc
 jTryCatch tb cb = vcat [
@@ -601,35 +603,37 @@ jTryCatch tb cb = vcat [
   indent cb,
   rbrace]
 
-jDiscardInput :: (Doc, Maybe String) -> Doc
-jDiscardInput (inFn, _) = inFn <> dot <> text "next()"
+jDiscardInput :: ValData -> Doc
+jDiscardInput inFn = valDoc inFn <> dot <> text "next()"
 
-jInput :: Doc -> (Doc, Maybe String) -> (Doc, Maybe String) -> Doc
-jInput it (v, _) (inFn, _) = v <+> equals <+> parens (inFn <> dot <> it) -- Changed from original GOOL, original GOOL was wrong.
+jInput :: Doc -> ValData -> ValData -> Doc
+jInput it v inFn = valDoc v <+> equals <+> parens (valDoc inFn <> dot <> it)
 
-jInput' :: Doc -> (Doc, Maybe String) -> (Doc, Maybe String) -> Doc
-jInput' it (v, _) (inFn, _) = v <+> equals <+> it <> parens (inFn <> dot <> 
+jInput' :: Doc -> ValData -> ValData -> Doc
+jInput' it v inFn = valDoc v <+> equals <+> it <> parens (valDoc inFn <> dot <> 
   text "nextLine()")
 
-jOpenFileR :: (Doc, Maybe String) -> (Doc, Maybe String) -> Doc
-jOpenFileR (f, _) (n, _) = f <+> equals <+> new <+> text "Scanner" <> parens 
-  (new <+> text "File" <> parens n)
+jOpenFileR :: ValData -> ValData -> Doc
+jOpenFileR f n = valDoc f <+> equals <+> new <+> text "Scanner" <> parens 
+  (new <+> text "File" <> parens (valDoc n))
 
-jOpenFileWorA :: (Doc, Maybe String) -> (Doc, Maybe String) -> 
-  (Doc, Maybe String) -> Doc
-jOpenFileWorA (f, _) (n, _) (wa, _) = f <+> equals <+> new <+> 
+jOpenFileWorA :: ValData -> ValData -> 
+  ValData -> Doc
+jOpenFileWorA f n wa = valDoc f <+> equals <+> new <+> 
   text "PrintWriter" <> parens (new <+> text "FileWriter" <> parens (new <+> 
-  text "File" <> parens n <> comma <+> wa))
+  text "File" <> parens (valDoc n) <> comma <+> valDoc wa))
 
-jStringSplit :: (Doc, Maybe String) -> TypeData -> (Doc, Maybe String) -> Doc
-jStringSplit (vnew, _) t (s, _) = vnew <+> equals <+> new <+> typeDoc t
-  <> parens s
+jStringSplit :: ValData -> ValData -> Doc
+jStringSplit vnew s = valDoc vnew <+> equals <+> new <+> typeDoc (valType vnew)
+  <> parens (valDoc s)
 
-jMethod :: Label -> Doc -> Doc -> Doc -> Doc -> Doc -> Doc
+jMethod :: Label -> Doc -> Doc -> TypeData -> Doc -> Doc -> Doc
 jMethod n s p t ps b = vcat [
-  s <+> p <+> t <+> text n <> parens ps <+> text "throws Exception" <+> lbrace,
+  s <+> p <+> typeDoc t <+> text n <> parens ps <+> text "throws Exception" <+> 
+    lbrace,
   indent b,
   rbrace]
 
-jListIndexExists :: Doc -> (Doc, Maybe String) -> (Doc, Maybe String) -> Doc
-jListIndexExists greater (lst, _) (index, _) = parens (lst <> text ".length" <+> greater <+> index)
+jListIndexExists :: Doc -> ValData -> ValData -> Doc
+jListIndexExists greater lst index = parens (valDoc lst <> text ".length" <+> 
+  greater <+> valDoc index)

--- a/code/drasil-code/Language/Drasil/Code/Imperative/LanguageRenderer/JavaRenderer.hs
+++ b/code/drasil-code/Language/Drasil/Code/Imperative/LanguageRenderer/JavaRenderer.hs
@@ -42,7 +42,7 @@ import Language.Drasil.Code.Imperative.LanguageRenderer (
 import Language.Drasil.Code.Imperative.Helpers (Terminator(..), FuncData(..), 
   fd, ModData(..), md, TypeData(..), td, ValData(..), vd,  angles, liftA4, 
   liftA5, liftA6, liftA7, liftList, lift1List, lift3Pair, lift4Pair, 
-  liftPairFst, convType)
+  liftPairFst, getInnerType, convType)
 
 import Prelude hiding (break,print,sin,cos,tan,floor,(<>))
 import qualified Data.Map as Map (fromList,lookup)
@@ -138,9 +138,6 @@ instance StateTypeSym JavaCode where
   outfile = return jOutfileTypeDoc
   listType p st = liftA2 jListType st (list p)
   listInnerType t = fmap (getInnerType . cType) t >>= convType
-    where getInnerType :: CodeType -> CodeType
-          getInnerType (List innerT) = innerT
-          getInnerType _ = error "Attempt to extract inner type of list from a non-list type" 
   obj t = return $ typeDocD t
   enumType t = return $ typeDocD t
   iterator _ = error "Iterator-type variables do not exist in Java"

--- a/code/drasil-code/Language/Drasil/Code/Imperative/LanguageRenderer/PythonRenderer.hs
+++ b/code/drasil-code/Language/Drasil/Code/Imperative/LanguageRenderer/PythonRenderer.hs
@@ -429,7 +429,7 @@ instance ControlStatementSym PythonCode where
 
   tryCatch tb cb = mkStNoEnd <$> liftA2 pyTryCatch tb cb
 
-  checkState l t = switch (var l t)
+  checkState l = switch (var l string)
   notifyObservers ft fn t ps = forRange index initv (listSizeAccess obsList) 
     (litInt 1) notify
     where obsList = observerListName `listOf` t

--- a/code/drasil-code/Language/Drasil/Code/Imperative/LanguageRenderer/PythonRenderer.hs
+++ b/code/drasil-code/Language/Drasil/Code/Imperative/LanguageRenderer/PythonRenderer.hs
@@ -297,11 +297,11 @@ instance FunctionSym PythonCode where
     valType v) (fmap fst (assign (var n (fmap valType v)) v))))
 
   listSize = liftA2 fd int (return $ text "len")
-  listAdd i v = func "insert" (listType static_ $ fmap valType v) [i, v]
+  listAdd _ i v = func "insert" (listType static_ $ fmap valType v) [i, v]
   listAppend v = func "append" (listType static_ $ fmap valType v) [v]
 
-  iterBegin = error "Attempt to use iterBegin in Python, but Python has no iterators"
-  iterEnd = error "Attempt to use iterEnd in Python, but Python has no iterators"
+  iterBegin _ = error "Attempt to use iterBegin in Python, but Python has no iterators"
+  iterEnd _ = error "Attempt to use iterEnd in Python, but Python has no iterators"
 
 instance SelectorFunction PythonCode where
   listAccess t v = liftA2 fd t (fmap pyListAccess v)
@@ -401,7 +401,7 @@ instance StatementSym PythonCode where
   changeState fsmName toState = var fsmName string &= litString toState
 
   initObserverList = listDecDef observerListName
-  addObserver t o = valState $ obsList $. listAdd lastelem o
+  addObserver t o = valState $ obsList $. listAdd obsList lastelem o
     where obsList = observerListName `listOf` t
           lastelem = listSizeAccess obsList
 

--- a/code/drasil-code/Language/Drasil/Code/Imperative/LanguageRenderer/PythonRenderer.hs
+++ b/code/drasil-code/Language/Drasil/Code/Imperative/LanguageRenderer/PythonRenderer.hs
@@ -34,7 +34,7 @@ import Language.Drasil.Code.Imperative.LanguageRenderer (
   setterName)
 import Language.Drasil.Code.Imperative.Helpers (Terminator(..), FuncData(..), 
   fd, ModData(..), md, TypeData(..), td, ValData(..), vd, blank, vibcat, liftA4,
-  liftA5, liftList, lift1List, lift4Pair, liftPairFst)
+  liftA5, liftList, lift1List, lift4Pair, liftPairFst, convType)
 
 import Prelude hiding (break,print,sin,cos,tan,floor,(<>))
 import qualified Data.Map as Map (fromList,lookup)
@@ -123,6 +123,10 @@ instance StateTypeSym PythonCode where
   infile = return $ td File empty
   outfile = return $ td File empty
   listType _ t = liftA2 td (fmap (List . cType) t) (return $ brackets empty)
+  listInnerType t = fmap (getInnerType . cType) t >>= convType
+    where getInnerType :: CodeType -> CodeType
+          getInnerType (List innerT) = innerT
+          getInnerType _ = error "Attempt to extract inner type of list from a non-list type" 
   obj t = return $ typeDocD t
   enumType t = return $ typeDocD t
   iterator _ = error "Iterator-type variables do not exist in Python"
@@ -213,6 +217,7 @@ instance ValueSym PythonCode where
   valueName v = fromMaybe 
     (error $ "Attempt to print unprintable Value (" ++ render (valDoc $ unPC v) 
     ++ ")") (valName $ unPC v)
+  valueType = fmap valType
 
 instance NumericExpression PythonCode where
   (#~) = liftA2 unExpr negateOp

--- a/code/drasil-code/Language/Drasil/Code/Imperative/LanguageRenderer/PythonRenderer.hs
+++ b/code/drasil-code/Language/Drasil/Code/Imperative/LanguageRenderer/PythonRenderer.hs
@@ -23,14 +23,15 @@ import Language.Drasil.Code.Imperative.LanguageRenderer (
   methodListDocD, ifCondDocD, stratDocD, assignDocD, plusEqualsDocD', 
   plusPlusDocD', statementDocD, returnDocD, commentDocD, mkStNoEnd, notOpDocD', 
   negateOpDocD, sqrtOpDocD', absOpDocD', expOpDocD', sinOpDocD', cosOpDocD', 
-  tanOpDocD', asinOpDocD', acosOpDocD', atanOpDocD', unExpr, equalOpDocD, 
-  notEqualOpDocD, greaterOpDocD, greaterEqualOpDocD, lessOpDocD, 
+  tanOpDocD', asinOpDocD', acosOpDocD', atanOpDocD', unExpr, typeUnExpr, 
+  equalOpDocD, notEqualOpDocD, greaterOpDocD, greaterEqualOpDocD, lessOpDocD, 
   lessEqualOpDocD, plusOpDocD, minusOpDocD, multOpDocD, divideOpDocD, 
-  moduloOpDocD, binExpr, mkVal, litCharD, litFloatD, litIntD, litStringD, 
-  varDocD, extVarDocD, argDocD, enumElemDocD, objVarDocD, funcAppDocD, 
-  extFuncAppDocD, funcDocD, listSetDocD, objAccessDocD, castObjDocD, breakDocD, 
-  continueDocD, staticDocD, dynamicDocD, classDec, dot, forLabel, 
-  observerListName, addCommentsDocD, callFuncParamList, getterName, setterName)
+  moduloOpDocD, binExpr, typeBinExpr, mkVal, litCharD, litFloatD, litIntD, 
+  litStringD, varDocD, extVarDocD, argDocD, enumElemDocD, objVarDocD, 
+  funcAppDocD, extFuncAppDocD, funcDocD, listSetDocD, objAccessDocD, 
+  castObjDocD, breakDocD, continueDocD, staticDocD, dynamicDocD, classDec, dot, 
+  forLabel, observerListName, addCommentsDocD, callFuncParamList, getterName, 
+  setterName)
 import Language.Drasil.Code.Imperative.Helpers (Terminator(..), FuncData(..), 
   fd, ModData(..), md, TypeData(..), td, ValData(..), vd, blank, vibcat, liftA4,
   liftA5, liftList, lift1List, lift4Pair, liftPairFst)
@@ -240,16 +241,16 @@ instance NumericExpression PythonCode where
   ceil = liftA2 unExpr ceilOp
 
 instance BooleanExpression PythonCode where
-  (?!) = liftA2 unExpr notOp
-  (?&&) = liftA3 binExpr andOp
-  (?||) = liftA3 binExpr orOp
+  (?!) = liftA3 typeUnExpr notOp bool
+  (?&&) = liftA4 typeBinExpr andOp bool
+  (?||) = liftA4 typeBinExpr orOp bool
 
-  (?<) = liftA3 binExpr lessOp
-  (?<=) = liftA3 binExpr lessEqualOp
-  (?>) = liftA3 binExpr greaterOp
-  (?>=) = liftA3 binExpr greaterEqualOp
-  (?==) = liftA3 binExpr equalOp
-  (?!=) = liftA3 binExpr notEqualOp
+  (?<) = liftA4 typeBinExpr lessOp bool
+  (?<=) = liftA4 typeBinExpr lessEqualOp bool
+  (?>) = liftA4 typeBinExpr greaterOp bool
+  (?>=) = liftA4 typeBinExpr greaterEqualOp bool
+  (?==) = liftA4 typeBinExpr equalOp bool
+  (?!=) = liftA4 typeBinExpr notEqualOp bool
 
 instance ValueExpression PythonCode where
   inlineIf b v1 v2 = liftA2 mkVal (fmap valType v1) (liftA3 pyInlineIf b v1 v2)

--- a/code/drasil-code/Language/Drasil/Code/Imperative/LanguageRenderer/PythonRenderer.hs
+++ b/code/drasil-code/Language/Drasil/Code/Imperative/LanguageRenderer/PythonRenderer.hs
@@ -19,22 +19,21 @@ import Language.Drasil.Code.Imperative.Symantics (Label,
   StateVarSym(..), ClassSym(..), ModuleSym(..))
 import Language.Drasil.Code.Imperative.LanguageRenderer (
   fileDoc', enumElementsDocD', multiStateDocD, blockDocD, bodyDocD, 
-  intTypeDocD, floatTypeDocD, typeDocD, voidDocD, constructDocD, 
-  paramListDocD, methodListDocD, ifCondDocD, stratDocD, assignDocD, 
-  plusEqualsDocD', plusPlusDocD', statementDocD, returnDocD, commentDocD,
-  mkStNoEnd, notOpDocD', negateOpDocD, sqrtOpDocD', absOpDocD', expOpDocD',
-  sinOpDocD', cosOpDocD', tanOpDocD', asinOpDocD', acosOpDocD', atanOpDocD', 
-  unExpr, equalOpDocD, notEqualOpDocD, greaterOpDocD, greaterEqualOpDocD, 
-  lessOpDocD, lessEqualOpDocD, plusOpDocD, minusOpDocD, multOpDocD, 
-  divideOpDocD, moduloOpDocD, binExpr, mkVal, litCharD, litFloatD, litIntD, 
-  litStringD, varDocD, extVarDocD, argDocD, enumElemDocD, objVarDocD, 
-  funcAppDocD, extFuncAppDocD, funcDocD, listSetDocD, objAccessDocD, 
-  castObjDocD, breakDocD, continueDocD, staticDocD, dynamicDocD, classDec, dot, 
-  forLabel, observerListName, addCommentsDocD, callFuncParamList, getterName, 
-  setterName)
-import Language.Drasil.Code.Imperative.Helpers (Terminator(..), ModData(..), md,
-  TypeData(..), td, ValData(..), vd, blank, vibcat, liftA4, liftA5, liftList, 
-  lift1List, lift4Pair, liftPairFst)
+  intTypeDocD, floatTypeDocD, typeDocD, constructDocD, paramListDocD, 
+  methodListDocD, ifCondDocD, stratDocD, assignDocD, plusEqualsDocD', 
+  plusPlusDocD', statementDocD, returnDocD, commentDocD, mkStNoEnd, notOpDocD', 
+  negateOpDocD, sqrtOpDocD', absOpDocD', expOpDocD', sinOpDocD', cosOpDocD', 
+  tanOpDocD', asinOpDocD', acosOpDocD', atanOpDocD', unExpr, equalOpDocD, 
+  notEqualOpDocD, greaterOpDocD, greaterEqualOpDocD, lessOpDocD, 
+  lessEqualOpDocD, plusOpDocD, minusOpDocD, multOpDocD, divideOpDocD, 
+  moduloOpDocD, binExpr, mkVal, litCharD, litFloatD, litIntD, litStringD, 
+  varDocD, extVarDocD, argDocD, enumElemDocD, objVarDocD, funcAppDocD, 
+  extFuncAppDocD, funcDocD, listSetDocD, objAccessDocD, castObjDocD, breakDocD, 
+  continueDocD, staticDocD, dynamicDocD, classDec, dot, forLabel, 
+  observerListName, addCommentsDocD, callFuncParamList, getterName, setterName)
+import Language.Drasil.Code.Imperative.Helpers (Terminator(..), FuncData(..), 
+  fd, ModData(..), md, TypeData(..), td, ValData(..), vd, blank, vibcat, liftA4,
+  liftA5, liftList, lift1List, lift4Pair, liftPairFst)
 
 import Prelude hiding (break,print,sin,cos,tan,floor,(<>))
 import qualified Data.Map as Map (fromList,lookup)
@@ -126,6 +125,7 @@ instance StateTypeSym PythonCode where
   obj t = return $ typeDocD t
   enumType t = return $ typeDocD t
   iterator _ = error "Iterator-type variables do not exist in Python"
+  void = return $ td Void (text "NoneType")
 
 instance ControlBlockSym PythonCode where
   runStrategy l strats rv av = maybe
@@ -139,7 +139,7 @@ instance ControlBlockSym PythonCode where
 
   listSlice _ vnew vold b e s = liftA5 pyListSlice vnew vold (getVal b) 
     (getVal e) (getVal s)
-    where getVal = fromMaybe (return (mkVal empty))
+    where getVal = fromMaybe (liftA2 mkVal void (return empty))
 
 instance UnaryOpSym PythonCode where
   type UnaryOp PythonCode = Doc
@@ -196,22 +196,22 @@ instance ValueSym PythonCode where
   self l = liftA2 (vd (Just "self")) (obj l) (return $ text "self")
   arg n = liftA2 mkVal string (liftA2 argDocD (litInt (n + 1)) argsList)
   enumElement en e = liftA2 (vd (Just $ en ++ "." ++ e)) (obj en) 
-    (enumElemDocD en e)
+    (return $ enumElemDocD en e)
   enumVar e en = var e (obj en)
   objVar o v =  liftA2 (vd (Just $ valueName o ++ "." ++ valueName v))
-    (valType v) (liftA2 objVarDocD o v)
-  objVarSelf n t = liftA2 (vd (Just $ "self." ++ n)) t (liftA2 objVarDocD self 
-    (var n t))
+    (fmap valType v) (liftA2 objVarDocD o v)
+  objVarSelf l n t = liftA2 (vd (Just $ "self." ++ n)) t (liftA2 objVarDocD
+    (self l) (var n t))
   listVar n p t = var n (listType p t)
   n `listOf` t = listVar n static_ t
   iterVar n t = var n (iterator t)
 
-  inputFunc = liftA2 mkVal string (text "input()")  -- raw_input() for < Python 3.0
-  argsList = liftA2 mkVal (listType string) text "sys.argv"
+  inputFunc = liftA2 mkVal string (return $ text "input()")  -- raw_input() for < Python 3.0
+  argsList = liftA2 mkVal (listType static_ string) (return $ text "sys.argv")
 
   valueName v = fromMaybe 
-    (error $ "Attempt to print unprintable Value (" ++ render (valDoc v) ++ ")")
-    (valName v)
+    (error $ "Attempt to print unprintable Value (" ++ render (valDoc $ unPC v) 
+    ++ ")") (valName $ unPC v)
 
 instance NumericExpression PythonCode where
   (#~) = liftA2 unExpr negateOp
@@ -262,53 +262,55 @@ instance ValueExpression PythonCode where
     callFuncParamList vs))
   listStateObj t _ = liftA2 mkVal t (fmap typeDoc t)
 
-  exists v = v ?!= var "None" Void
+  exists v = v ?!= var "None" void
   notNull = exists
 
 instance Selector PythonCode where
-  objAccess t v f = liftA2 mkVal t (liftA2 objAccessDocD v f)
+  objAccess v f = liftA2 mkVal (fmap funcType f) (liftA2 objAccessDocD v f)
   ($.) = objAccess 
 
-  objMethodCall t o f ps = objAccess t o (func f ps)
+  objMethodCall t o f ps = objAccess o (func f t ps)
   objMethodCallNoParams t o f = objMethodCall t o f []
 
   selfAccess l = objAccess (self l)
 
-  listSizeAccess v = liftA2 mkVal int liftA2 pyListSizeAccess v listSize
+  listSizeAccess v = liftA2 mkVal int (liftA2 pyListSizeAccess v listSize)
 
   listIndexExists lst index = listSizeAccess lst ?> index
-  argExists i = objAccess string argsList (listAccess (litInt $ fromIntegral i))
+  argExists i = objAccess argsList (listAccess string (litInt $ fromIntegral i))
   
-  indexOf l v = objAccess int l (fmap funcDocD (funcApp "index" [v]))
+  indexOf l v = objAccess l (func "index" int [v])
 
   stringEqual v1 v2 = v1 ?== v2
 
-  castObj t f v = liftA2 mkVal t (liftA2 castObjDocD f v)
-  castStrToFloat = castObj float (cast float string)
+  castObj f v = liftA2 mkVal (fmap funcType f) (liftA2 castObjDocD f v)
+  castStrToFloat = castObj (cast float string)
 
 instance FunctionSym PythonCode where
-  type Function PythonCode = Doc
-  func l vs = fmap funcDocD (funcApp l vs)
-  cast targT _ = fmap typeDoc targT
+  type Function PythonCode = FuncData
+  func l t vs = liftA2 fd t (fmap funcDocD (funcApp l t vs))
+  cast targT _ = liftA2 fd targT (fmap typeDoc targT)
   castListToInt = cast int (listType static_ int)
-  get n = fmap funcDocD (var n)
-  set n v = fmap funcDocD (mkVal . fst <$> assign (var n) v)
+  get n t = liftA2 fd t (fmap funcDocD (var n t))
+  set n v = liftA2 fd (fmap valType v) (fmap funcDocD (liftA2 mkVal (fmap 
+    valType v) (fmap fst (assign (var n (fmap valType v)) v))))
 
-  listSize = return $ text "len"
-  listAdd i v = fmap funcDocD (funcApp "insert" [i, v])
-  listAppend v = fmap funcDocD (funcApp "append" [v])
+  listSize = liftA2 fd int (return $ text "len")
+  listAdd i v = func "insert" (listType static_ $ fmap valType v) [i, v]
+  listAppend v = func "append" (listType static_ $ fmap valType v) [v]
 
-  iterBegin = fmap funcDocD (funcApp "begin" [])
-  iterEnd = fmap funcDocD (funcApp "end" [])
+  iterBegin = error "Attempt to use iterBegin in Python, but Python has no iterators"
+  iterEnd = error "Attempt to use iterEnd in Python, but Python has no iterators"
 
 instance SelectorFunction PythonCode where
-  listAccess = fmap pyListAccess
-  listSet = liftA2 listSetDocD
+  listAccess t v = liftA2 fd t (fmap pyListAccess v)
+  listSet i v = liftA2 fd (listType static_ $ fmap valType v) 
+    (liftA2 listSetDocD i v)
 
-  listAccessEnum _ = listAccess
+  listAccessEnum = listAccess
   listSetEnum t i = listSet (castObj (cast int t) i)
 
-  at l = listAccess (var l)
+  at = listAccess
 
 instance StatementSym PythonCode where
   -- Terminator determines how statements end to end in a separator
@@ -316,16 +318,10 @@ instance StatementSym PythonCode where
   assign v1 v2 = mkStNoEnd <$> liftA2 assignDocD v1 v2
   assignToListIndex lst index v = valState $ lst $. listSet index v
   (&=) = assign
-  (&.=) l = assign (var l)
-  (&=.) v l = assign v (var l)
   (&-=) v1 v2 = v1 &= (v1 #- v2)
-  (&.-=) l v = l &.= (var l #- v)
   (&+=) v1 v2 = mkStNoEnd <$> liftA3 plusEqualsDocD' v1 plusOp v2
-  (&.+=) l v = var l &+= v
   (&++) v = mkStNoEnd <$> liftA2 plusPlusDocD' v plusOp
-  (&.++) l = (&++) (var l)
   (&~-) v = v &= (v #- litInt 1)
-  (&.~-) l = (&~-) (var l)
 
   varDec _ _ = return (mkStNoEnd empty)
   varDecDef l _ v = mkStNoEnd <$> fmap (pyVarDecDef l) v
@@ -340,9 +336,9 @@ instance StatementSym PythonCode where
   constDecDef = varDecDef
 
   print _ v = mkStNoEnd <$> liftA4 pyOut printFunc v (return $ text ", end=''") 
-    (return (mkVal empty))
+    (liftA2 mkVal void (return empty))
   printLn _ v = mkStNoEnd <$> liftA4 pyOut printFunc v (return empty)
-    (return (mkVal empty))
+    (liftA2 mkVal void (return empty))
   printStr s = print string (litString s)
   printStrLn s = printLn string (litString s)
 
@@ -358,47 +354,50 @@ instance StatementSym PythonCode where
   printFileList = printFile
   printFileLnList = printFileLn
 
-  getIntInput v = v &= funcApp "int" [inputFunc]
-  getFloatInput v = v &= funcApp "float" [inputFunc]
+  getIntInput v = v &= funcApp "int" int [inputFunc]
+  getFloatInput v = v &= funcApp "float" float [inputFunc]
   getBoolInput v = v &= inputFunc ?!= litString "0"
-  getStringInput v = v &= objMethodCall inputFunc "rstrip" []
+  getStringInput v = v &= objMethodCall string inputFunc "rstrip" []
   getCharInput v = v &= inputFunc
   discardInput = valState inputFunc
-  getIntFileInput f v = v &= funcApp "int" [objMethodCall f "readline" []]
-  getFloatFileInput f v = v &= funcApp "float" [objMethodCall f "readline" []]
-  getBoolFileInput f v =  v &= (objMethodCall f "readline" [] ?!= litString "0")
-  getStringFileInput f v = v &= objMethodCall (objMethodCall f "readline" []) 
-    "rstrip" []
-  getCharFileInput f v = v &= objMethodCall f "readline" []
-  discardFileInput f = valState (objMethodCall f "readline" [])
+  getIntFileInput f v = v &= funcApp "int" int [objMethodCall string f 
+    "readline" []]
+  getFloatFileInput f v = v &= funcApp "float" float [objMethodCall string f
+    "readline" []]
+  getBoolFileInput f v =  v &= (objMethodCall string f "readline" [] ?!= 
+    litString "0")
+  getStringFileInput f v = v &= objMethodCall string (objMethodCall string f 
+    "readline" []) "rstrip" []
+  getCharFileInput f v = v &= objMethodCall string f "readline" []
+  discardFileInput f = valState (objMethodCall string f "readline" [])
 
-  openFileR f n = f &= funcApp "open" [n, litString "r"]
-  openFileW f n = f &= funcApp "open" [n, litString "w"]
-  openFileA f n = f &= funcApp "open" [n, litString "a"]
-  closeFile f = valState $ objMethodCall f "close" []
+  openFileR f n = f &= funcApp "open" infile [n, litString "r"]
+  openFileW f n = f &= funcApp "open" outfile [n, litString "w"]
+  openFileA f n = f &= funcApp "open" outfile [n, litString "a"]
+  closeFile f = valState $ objMethodCall void f "close" []
 
-  getFileInputLine f v = v &= objMethodCall f "readline" []
-  discardFileLine f = valState $ objMethodCall f "readline" []
-  stringSplit d vnew s = assign vnew (objAccess s 
-    (func "split" [litString [d]]))  
+  getFileInputLine f v = v &= objMethodCall string f "readline" []
+  discardFileLine f = valState $ objMethodCall string f "readline" []
+  stringSplit d vnew s = assign vnew (objAccess s (func "split" 
+    (listType static_ string) [litString [d]]))  
 
   break = return (mkStNoEnd breakDocD)
   continue = return (mkStNoEnd continueDocD)
 
   returnState v = mkStNoEnd <$> fmap returnDocD v
-  returnVar l = mkStNoEnd <$> fmap returnDocD (var l)
+  returnVar l t = mkStNoEnd <$> fmap returnDocD (var l t)
 
-  valState v = mkStNoEnd <$> fmap fst v
+  valState v = mkStNoEnd <$> fmap valDoc v
 
   comment cmt = mkStNoEnd <$> fmap (commentDocD cmt) commentStart
 
-  free v = v &= var "None" Void
+  free v = v &= var "None" void
 
   throw errMsg = mkStNoEnd <$> fmap pyThrow (litString errMsg)
 
   initState fsmName initialState = varDecDef fsmName string 
     (litString initialState)
-  changeState fsmName toState = fsmName &.= litString toState
+  changeState fsmName toState = var fsmName string &= litString toState
 
   initObserverList = listDecDef observerListName
   addObserver t o = valState $ obsList $. listAdd lastelem o
@@ -429,15 +428,17 @@ instance ControlStatementSym PythonCode where
 
   tryCatch tb cb = mkStNoEnd <$> liftA2 pyTryCatch tb cb
 
-  checkState l = switch (var l)
-  notifyObservers fn t ps = forRange index initv (listSizeAccess obsList) 
+  checkState l t = switch (var l t)
+  notifyObservers ft fn t ps = forRange index initv (listSizeAccess obsList) 
     (litInt 1) notify
     where obsList = observerListName `listOf` t
           index = "observerIndex"
           initv = litInt 0
-          notify = oneLiner $ valState $ (obsList $. at index) $. func fn ps
+          notify = oneLiner $ valState $ (obsList $. at t (var index int)) $.
+            func fn ft ps
 
-  getFileInputAll f v = v &= objMethodCall f "readlines" []
+  getFileInputAll f v = v &= objMethodCall (listType static_ string) f 
+    "readlines" []
 
 instance ScopeSym PythonCode where
   type Scope PythonCode = Doc
@@ -447,10 +448,9 @@ instance ScopeSym PythonCode where
   includeScope s = s
 
 instance MethodTypeSym PythonCode where
-  type MethodType PythonCode = Doc
-  mState = fmap typeDoc
-  void = return voidDocD
-  construct n = return $ constructDocD n
+  type MethodType PythonCode = TypeData
+  mState t = t
+  construct n = return $ td (Object n) (constructDocD n)
 
 instance ParameterSym PythonCode where
   type Parameter PythonCode = Doc
@@ -459,13 +459,13 @@ instance ParameterSym PythonCode where
 
 instance MethodSym PythonCode where
   type Method PythonCode = (Doc, Bool)
-  method n _ _ _ _ ps b = liftPairFst (liftA3 (pyMethod n) self (liftList 
+  method n l _ _ _ ps b = liftPairFst (liftA3 (pyMethod n) (self l) (liftList 
     paramListDocD ps) b, False)
   getMethod n c t = method (getterName n) c public dynamic_ t [] getBody
-    where getBody = oneLiner $ returnState (self $-> var n)
+    where getBody = oneLiner $ returnState (self n $-> var n t)
   setMethod setLbl c paramLbl t = method (setterName setLbl) c public dynamic_
-    void [stateParam paramLbl t] setBody
-    where setBody = oneLiner $ (self $-> var setLbl) &=. paramLbl
+    (mState void) [stateParam paramLbl t] setBody
+    where setBody = oneLiner $ (self setLbl $-> var setLbl t) &= var paramLbl t
   mainMethod _ b = liftPairFst (b, True)
   privMethod n c = method n c private dynamic_
   pubMethod n c = method n c public dynamic_
@@ -532,19 +532,19 @@ pyStateObj t vs = typeDoc t <> parens vs
 pyExtStateObj :: Label -> TypeData -> Doc -> Doc
 pyExtStateObj l t vs = text l <> dot <> typeDoc t <> parens vs
 
-pyInlineIf :: (Doc, Maybe String) -> (Doc, Maybe String) -> 
-  (Doc, Maybe String) -> Doc
-pyInlineIf (c, _) (v1, _) (v2, _) = parens $ v1 <+> text "if" <+> c <+> 
-  text "else" <+> v2
+pyInlineIf :: ValData -> ValData -> 
+  ValData -> Doc
+pyInlineIf c v1 v2 = parens $ valDoc v1 <+> text "if" <+> valDoc c <+> 
+  text "else" <+> valDoc v2
 
-pyListSizeAccess :: (Doc, Maybe String) -> Doc -> Doc
-pyListSizeAccess (v, _) f = f <> parens v
+pyListSizeAccess :: ValData -> FuncData -> Doc
+pyListSizeAccess v f = funcDoc f <> parens (valDoc v)
 
 pyStringType :: TypeData
 pyStringType = td String (text "str")
 
-pyVarDecDef :: Label ->  (Doc, Maybe String) -> Doc
-pyVarDecDef l (v, _) = text l <+> equals <+> v
+pyVarDecDef :: Label ->  ValData -> Doc
+pyVarDecDef l v = text l <+> equals <+> valDoc v
 
 pyListDec :: Label -> TypeData -> Doc
 pyListDec l t = text l <+> equals <+> typeDoc t
@@ -552,30 +552,30 @@ pyListDec l t = text l <+> equals <+> typeDoc t
 pyListDecDef :: Label -> Doc -> Doc
 pyListDecDef l vs = text l <+> equals <+> brackets vs
 
-pyOut :: Doc ->  (Doc, Maybe String) -> Doc ->  (Doc, Maybe String) -> Doc
-pyOut prf (v, _) txt (f, _) = prf <> parens (v <> txt <> f)
+pyOut :: Doc ->  ValData -> Doc ->  ValData -> Doc
+pyOut prf v txt f = prf <> parens (valDoc v <> txt <> valDoc f)
 
-pyThrow ::  (Doc, Maybe String) -> Doc
-pyThrow (errMsg, _) = text "raise" <+> text "Exception" <> parens errMsg
+pyThrow ::  ValData -> Doc
+pyThrow errMsg = text "raise" <+> text "Exception" <> parens (valDoc errMsg)
 
-pyListAccess :: (Doc, Maybe String) -> Doc
-pyListAccess (v, _) = brackets v
+pyListAccess :: ValData -> Doc
+pyListAccess v = brackets (valDoc v)
 
-pyForRange :: Label -> Doc ->  (Doc, Maybe String) ->  (Doc, Maybe String) ->
-  (Doc, Maybe String) -> Doc -> Doc
-pyForRange i inLabel (initv, _) (finalv, _) (stepv, _) b = vcat [
-  forLabel <+> text i <+> inLabel <+> text "range" <> parens (initv <> 
-    text ", " <> finalv <> text ", " <> stepv) <> colon,
+pyForRange :: Label -> Doc ->  ValData ->  ValData ->
+  ValData -> Doc -> Doc
+pyForRange i inLabel initv finalv stepv b = vcat [
+  forLabel <+> text i <+> inLabel <+> text "range" <> parens (valDoc initv <> 
+    text ", " <> valDoc finalv <> text ", " <> valDoc stepv) <> colon,
   indent b]
 
-pyForEach :: Label -> Doc -> Doc ->  (Doc, Maybe String) -> Doc -> Doc
-pyForEach i forEachLabel inLabel (lstVar, _) b = vcat [
-  forEachLabel <+> text i <+> inLabel <+> lstVar <> colon,
+pyForEach :: Label -> Doc -> Doc ->  ValData -> Doc -> Doc
+pyForEach i forEachLabel inLabel lstVar b = vcat [
+  forEachLabel <+> text i <+> inLabel <+> valDoc lstVar <> colon,
   indent b]
 
-pyWhile ::  (Doc, Maybe String) -> Doc -> Doc
-pyWhile (v, _) b = vcat [
-  text "while" <+> v <> colon,
+pyWhile ::  ValData -> Doc -> Doc
+pyWhile v b = vcat [
+  text "while" <+> valDoc v <> colon,
   indent b]
 
 pyTryCatch :: Doc -> Doc -> Doc
@@ -585,14 +585,14 @@ pyTryCatch tryB catchB = vcat [
   text "except" <+> text "Exception" <+> text "as" <+> text "exc" <+> colon,
   indent catchB]
 
-pyListSlice :: (Doc, Maybe String) -> (Doc, Maybe String) -> 
-  (Doc, Maybe String) -> (Doc, Maybe String) -> (Doc, Maybe String) -> Doc
-pyListSlice (vnew, _) (vold, _) (b, _) (e, _) (s, _) = vnew <+> equals <+> 
-  vold <> brackets (b <> colon <> e <> colon <> s)
+pyListSlice :: ValData -> ValData -> 
+  ValData -> ValData -> ValData -> Doc
+pyListSlice vnew vold b e s = valDoc vnew <+> equals <+> valDoc vold <> 
+  brackets (valDoc b <> colon <> valDoc e <> colon <> valDoc s)
 
-pyMethod :: Label ->  (Doc, Maybe String) -> Doc -> Doc -> Doc
-pyMethod n (slf, _) ps b = vcat [
-  text "def" <+> text n <> parens (slf <> oneParam <> ps) <> colon,
+pyMethod :: Label ->  ValData -> Doc -> Doc -> Doc
+pyMethod n slf ps b = vcat [
+  text "def" <+> text n <> parens (valDoc slf <> oneParam <> ps) <> colon,
   indent bodyD]
       where oneParam | isEmpty ps = empty
                      | otherwise  = text ", "

--- a/code/drasil-code/Language/Drasil/Code/Imperative/LanguageRenderer/PythonRenderer.hs
+++ b/code/drasil-code/Language/Drasil/Code/Imperative/LanguageRenderer/PythonRenderer.hs
@@ -34,7 +34,7 @@ import Language.Drasil.Code.Imperative.LanguageRenderer (
   setterName)
 import Language.Drasil.Code.Imperative.Helpers (Terminator(..), FuncData(..), 
   fd, ModData(..), md, TypeData(..), td, ValData(..), vd, blank, vibcat, liftA4,
-  liftA5, liftList, lift1List, lift4Pair, liftPairFst, convType)
+  liftA5, liftList, lift1List, lift4Pair, liftPairFst, getInnerType, convType)
 
 import Prelude hiding (break,print,sin,cos,tan,floor,(<>))
 import qualified Data.Map as Map (fromList,lookup)
@@ -124,9 +124,6 @@ instance StateTypeSym PythonCode where
   outfile = return $ td File empty
   listType _ t = liftA2 td (fmap (List . cType) t) (return $ brackets empty)
   listInnerType t = fmap (getInnerType . cType) t >>= convType
-    where getInnerType :: CodeType -> CodeType
-          getInnerType (List innerT) = innerT
-          getInnerType _ = error "Attempt to extract inner type of list from a non-list type" 
   obj t = return $ typeDocD t
   enumType t = return $ typeDocD t
   iterator _ = error "Iterator-type variables do not exist in Python"

--- a/code/drasil-code/Language/Drasil/Code/Imperative/Symantics.hs
+++ b/code/drasil-code/Language/Drasil/Code/Imperative/Symantics.hs
@@ -143,25 +143,26 @@ class (StateTypeSym repr, StateVarSym repr) => ValueSym repr where
   infixl 9 $:
 
 
-  const        :: Label -> repr (Value repr)
-  var          :: Label -> repr (Value repr)
-  extVar       :: Library -> Label -> repr (Value repr)
+  const        :: Label -> repr (StateType repr) -> repr (Value repr)
+  var          :: Label -> repr (StateType repr) -> repr (Value repr)
+  extVar       :: Library -> Label -> repr (StateType repr) -> repr (Value repr)
 --  global       :: Label -> repr (Value repr)         -- not sure how this one works, but in GOOL it was hardcoded to give an error so I'm leaving it out for now
-  self         :: repr (Value repr)
+  self         :: Label -> repr (Value repr)
   arg          :: Integer -> repr (Value repr)
   enumElement  :: Label -> Label -> repr (Value repr)
-  enumVar      :: Label -> repr (Value repr)
+  enumVar      :: Label -> Label -> repr (Value repr)
   objVar       :: repr (Value repr) -> repr (Value repr) -> repr (Value repr)
-  objVarSelf   :: Label -> repr (Value repr)
-  listVar      :: Label -> repr (StateType repr) -> repr (Value repr)
+  objVarSelf   :: Label -> repr (StateType repr) -> repr (Value repr)
+  listVar      :: Label -> repr (Permanence repr) -> repr (StateType repr) -> 
+    repr (Value repr)
   listOf       :: Label -> repr (StateType repr) -> repr (Value repr)
   -- Use for iterator variables, i.e. in a forEach loop.
-  iterVar      :: Label -> repr (Value repr)
+  iterVar      :: Label -> repr (StateType repr) -> repr (Value repr)
 
   inputFunc :: repr (Value repr)
   argsList  :: repr (Value repr)
 
-  valName :: repr (Value repr) -> String -- Function for converting a value to a string of the value's name
+  valueName :: repr (Value repr) -> String -- Function for converting a value to a string of the value's name
 
 class (ValueSym repr, UnaryOpSym repr, BinaryOpSym repr) => 
   NumericExpression repr where
@@ -229,9 +230,12 @@ class (ValueSym repr, NumericExpression repr, BooleanExpression repr) =>
   ValueExpression repr where -- for values that can include expressions
   inlineIf     :: repr (Value repr) -> repr (Value repr) -> repr (Value repr) ->
     repr (Value repr)
-  funcApp      :: Label -> [repr (Value repr)] -> repr (Value repr)
-  selfFuncApp  :: Label -> [repr (Value repr)] -> repr (Value repr)
-  extFuncApp   :: Library -> Label -> [repr (Value repr)] -> repr (Value repr)
+  funcApp      :: Label -> repr (StateType repr) -> [repr (Value repr)] -> 
+    repr (Value repr)
+  selfFuncApp  :: Label -> repr (StateType repr) -> [repr (Value repr)] -> 
+    repr (Value repr)
+  extFuncApp   :: Library -> Label -> repr (StateType repr) -> 
+    [repr (Value repr)] -> repr (Value repr)
   stateObj     :: repr (StateType repr) -> [repr (Value repr)] -> 
     repr (Value repr)
   extStateObj  :: Library -> repr (StateType repr) -> [repr (Value repr)] -> 
@@ -250,15 +254,19 @@ class (ValueSym repr, NumericExpression repr, BooleanExpression repr) =>
 -- I'm leaving it as is for now, even though I suspect this will change in the future.
 class (FunctionSym repr, ValueSym repr, ValueExpression repr) => 
   Selector repr where
-  objAccess :: repr (Value repr) -> repr (Function repr) -> repr (Value repr)
-  ($.)      :: repr (Value repr) -> repr (Function repr) -> repr (Value repr)
+  objAccess :: repr (StateType repr) -> repr (Value repr) -> 
+    repr (Function repr) -> repr (Value repr)
+  ($.)      :: repr (StateType repr) -> repr (Value repr) -> 
+    repr (Function repr) -> repr (Value repr)
   infixl 9 $.
 
-  objMethodCall     :: repr (Value repr) -> Label -> [repr (Value repr)] -> 
-    repr (Value repr)
-  objMethodCallVoid :: repr (Value repr) -> Label -> repr (Value repr)
+  objMethodCall     :: repr (StateType repr) -> repr (Value repr) -> Label -> 
+    [repr (Value repr)] -> repr (Value repr)
+  objMethodCallNoParams :: repr (StateType repr) -> repr (Value repr) -> Label
+    -> repr (Value repr)
 
-  selfAccess :: repr (Function repr) -> repr (Value repr)
+  selfAccess :: Label -> repr (StateType repr) -> repr (Function repr) -> 
+    repr (Value repr)
 
   listSizeAccess     :: repr (Value repr) -> repr (Value repr)
 
@@ -269,8 +277,8 @@ class (FunctionSym repr, ValueSym repr, ValueExpression repr) =>
 
   stringEqual :: repr (Value repr) -> repr (Value repr) -> repr (Value repr)
 
-  castObj        :: repr (Function repr) -> repr (Value repr) -> 
-    repr (Value repr)
+  castObj        :: repr (StateType repr) -> repr (Function repr) -> 
+    repr (Value repr) -> repr (Value repr)
   castStrToFloat :: repr (Value repr) -> repr (Value repr)
 
 class (ValueSym repr, ValueExpression repr) => FunctionSym repr where

--- a/code/drasil-code/Language/Drasil/Code/Imperative/Symantics.hs
+++ b/code/drasil-code/Language/Drasil/Code/Imperative/Symantics.hs
@@ -266,7 +266,7 @@ class (FunctionSym repr, ValueSym repr, ValueExpression repr) =>
 
   selfAccess :: Label -> repr (Function repr) -> repr (Value repr)
 
-  listSizeAccess     :: repr (Value repr) -> repr (Value repr)
+  listSizeAccess :: repr (Value repr) -> repr (Value repr)
 
   listIndexExists :: repr (Value repr) -> repr (Value repr) -> repr (Value repr)
   argExists       :: Integer -> repr (Value repr)
@@ -291,11 +291,11 @@ class (ValueSym repr, ValueExpression repr) => FunctionSym repr where
 
   listSize           :: repr (Function repr)
   listAdd            :: repr (Value repr) -> repr (Value repr) -> 
-    repr (Function repr)
+    repr (Value repr) -> repr (Function repr)
   listAppend         :: repr (Value repr) -> repr (Function repr)
 
-  iterBegin :: repr (Function repr)
-  iterEnd   :: repr (Function repr)
+  iterBegin :: repr (StateType repr) -> repr (Function repr)
+  iterEnd   :: repr (StateType repr) -> repr (Function repr)
 
 class (ValueSym repr, FunctionSym repr, Selector repr) => 
   SelectorFunction repr where
@@ -451,8 +451,8 @@ class (StatementSym repr, BodySym repr) => ControlStatementSym repr where
 
   checkState      :: Label -> [(repr (Value repr), repr (Body repr))] -> 
     repr (Body repr) -> repr (Statement repr)
-  notifyObservers :: repr (StateType repr) -> Label -> repr (StateType repr) -> [repr (Value repr)] -> 
-    repr (Statement repr)
+  notifyObservers :: repr (StateType repr) -> Label -> repr (StateType repr) -> 
+    [repr (Value repr)] -> repr (Statement repr)
 
   getFileInputAll  :: repr (Value repr) -> repr (Value repr) -> 
     repr (Statement repr)

--- a/code/drasil-code/Language/Drasil/Code/Imperative/Symantics.hs
+++ b/code/drasil-code/Language/Drasil/Code/Imperative/Symantics.hs
@@ -303,12 +303,12 @@ class (ValueSym repr, FunctionSym repr, Selector repr) =>
     repr (Function repr)
   listSet    :: repr (Value repr) -> repr (Value repr) -> repr (Function repr)
 
-  listAccessEnum   :: repr(StateType repr) -> repr (Value repr) -> 
-    repr (Function repr)
+  listAccessEnum   :: repr (StateType repr) -> repr (StateType repr) ->
+    repr (Value repr) -> repr (Function repr)
   listSetEnum      :: repr (StateType repr) -> repr (Value repr) -> 
     repr (Value repr) -> repr (Function repr)
 
-  at :: repr (StateType repr) -> repr (Value repr) -> repr (Function repr)
+  at :: repr (StateType repr) -> Label -> repr (Function repr)
 
 class (ValueSym repr, Selector repr, SelectorFunction repr, FunctionSym repr) 
   => StatementSym repr where

--- a/code/drasil-code/Language/Drasil/Code/Imperative/Symantics.hs
+++ b/code/drasil-code/Language/Drasil/Code/Imperative/Symantics.hs
@@ -80,6 +80,7 @@ class (PermanenceSym repr) => StateTypeSym repr where
   infile        :: repr (StateType repr)
   outfile       :: repr (StateType repr)
   listType      :: repr (Permanence repr) -> repr (StateType repr) -> repr (StateType repr)
+  listInnerType :: repr (StateType repr) -> repr (StateType repr)
   obj           :: Label -> repr (StateType repr)
   enumType      :: Label -> repr (StateType repr)
   iterator      :: repr (StateType repr) -> repr (StateType repr)
@@ -164,6 +165,7 @@ class (StateTypeSym repr, StateVarSym repr) => ValueSym repr where
   argsList  :: repr (Value repr)
 
   valueName :: repr (Value repr) -> String -- Function for converting a value to a string of the value's name
+  valueType :: repr (Value repr) -> repr (StateType repr)
 
 class (ValueSym repr, UnaryOpSym repr, BinaryOpSym repr) => 
   NumericExpression repr where

--- a/code/drasil-code/Language/Drasil/Code/Imperative/Symantics.hs
+++ b/code/drasil-code/Language/Drasil/Code/Imperative/Symantics.hs
@@ -449,9 +449,8 @@ class (StatementSym repr, BodySym repr) => ControlStatementSym repr where
 
   tryCatch :: repr (Body repr) -> repr (Body repr) -> repr (Statement repr)
 
-  checkState      :: Label -> repr (StateType repr) -> 
-    [(repr (Value repr), repr (Body repr))] -> repr (Body repr) -> 
-    repr (Statement repr)
+  checkState      :: Label -> [(repr (Value repr), repr (Body repr))] -> 
+    repr (Body repr) -> repr (Statement repr)
   notifyObservers :: repr (StateType repr) -> Label -> repr (StateType repr) -> [repr (Value repr)] -> 
     repr (Statement repr)
 

--- a/code/drasil-code/Test/FileTests.hs
+++ b/code/drasil-code/Test/FileTests.hs
@@ -17,26 +17,28 @@ writeStory :: (RenderSym repr) => repr (Block repr)
 writeStory = block [
   varDecDef "e" int (litInt 5),
   varDec "f" float,
-  "f" &.= castObj (cast float int) (var "e"),
+  var "f" float &= castObj (cast float int) (var "e" int),
   varDec "fileToWrite" outfile,
 
-  openFileW (var "fileToWrite") (litString "testText.txt"),
-  printFile (var "fileToWrite") int (litInt 0),
-  printFileLn (var "fileToWrite") int (litFloat 0.89),
-  printFileStr (var "fileToWrite") "ello",
-  printFileStrLn (var "fileToWrite") "bye",
-  printFileStrLn (var "fileToWrite") "!!",
-  closeFile (var "fileToWrite"),
+  openFileW (var "fileToWrite" outfile) (litString "testText.txt"),
+  printFile (var "fileToWrite" outfile) int (litInt 0),
+  printFileLn (var "fileToWrite" outfile) int (litFloat 0.89),
+  printFileStr (var "fileToWrite" outfile) "ello",
+  printFileStrLn (var "fileToWrite" outfile) "bye",
+  printFileStrLn (var "fileToWrite" outfile) "!!",
+  closeFile (var "fileToWrite" outfile),
 
   varDec "fileToRead" infile,
-  openFileR (var "fileToRead") (litString "testText.txt"),
+  openFileR (var "fileToRead" infile) (litString "testText.txt"),
   varDec "fileLine" string,
-  getFileInputLine (var "fileToRead") (var "fileLine"),
-  discardFileLine (var "fileToRead"),
+  getFileInputLine (var "fileToRead" infile) (var "fileLine" string),
+  discardFileLine (var "fileToRead" infile),
   listDec "fileContents" 0 (listType dynamic_ string)]
 
 readStory :: (RenderSym repr) => repr (Statement repr)
-readStory = getFileInputAll (var "fileToRead") (var "fileContents")
+readStory = getFileInputAll (var "fileToRead" infile) 
+  (var "fileContents" (listType dynamic_ string))
 
 goodBye :: (RenderSym repr) => repr (Block repr)
-goodBye = block [printLnList string (var "fileContents"), closeFile (var "fileToRead")]
+goodBye = block [printLnList string (var "fileContents" 
+  (listType dynamic_ string)), closeFile (var "fileToRead" infile)]

--- a/code/drasil-code/Test/HelloWorld.hs
+++ b/code/drasil-code/Test/HelloWorld.hs
@@ -19,8 +19,8 @@ helloWorld = packMods "HelloWorld" [fileDoc (buildModule "HelloWorld"
 helloWorldMain :: (RenderSym repr) => repr (Method repr)
 helloWorldMain = mainMethod "HelloWorld" (body [ helloInitVariables, 
     helloListSlice,
-    block [ifCond [(var "b" ?>= litInt 6, bodyStatements [varDecDef "dummy" string (litString "dummy")]),
-      (var "b" ?== litInt 5, helloIfBody)] helloElseBody, helloIfExists,
+    block [ifCond [(var "b" int ?>= litInt 6, bodyStatements [varDecDef "dummy" string (litString "dummy")]),
+      (var "b" int ?== litInt 5, helloIfBody)] helloElseBody, helloIfExists,
     helloSwitch, helloForLoop, helloWhileLoop, helloForEachLoop, helloTryCatch]])
 
 helloInitVariables :: (RenderSym repr) => repr (Block repr)
@@ -28,55 +28,56 @@ helloInitVariables = block [comment "Initializing variables",
   varDec "a" int, 
   varDecDef "b" int (litInt 5),
   listDecDef "myOtherList" (listType static_ float) [litFloat 1.0, litFloat 1.5],
-  varDecDef "oneIndex" int (indexOf (var "myOtherList") (litFloat 1.0)),
-  printLn int (var "oneIndex"),
-  "a" &.= listSizeAccess (var "myOtherList"),
-  valState (objAccess (var "myOtherList") (listAdd (litInt 2) (litFloat 2.0))),
-  valState (objAccess (var "myOtherList") (listAppend (litFloat 2.5))),
+  varDecDef "oneIndex" int (indexOf (var "myOtherList" (listType static_ float)) (litFloat 1.0)),
+  printLn int (var "oneIndex" int),
+  var "a" int &= listSizeAccess (var "myOtherList" (listType static_ float)),
+  valState (objAccess (var "myOtherList" (listType static_ float)) (listAdd 
+    (var "myOtherList" (listType static_ float)) (litInt 2) (litFloat 2.0))),
+  valState (objAccess (var "myOtherList" (listType static_ float)) (listAppend (litFloat 2.5))),
   varDec "e" float,
-  "e" &.= objAccess (var "myOtherList") (listAccess (litInt 1)),
-  valState (objAccess (var "myOtherList") (listSet (litInt 1) (litFloat 17.4))),
+  var "e" int &= objAccess (var "myOtherList" (listType static_ float)) (listAccess float (litInt 1)),
+  valState (objAccess (var "myOtherList" (listType static_ float)) (listSet (litInt 1) (litFloat 17.4))),
   listDec "myName" 7 (listType static_ string),
-  stringSplit ' ' (var "myName") (litString "Brooks Mac"),
-  printLnList string (var "myName"),
+  stringSplit ' ' (var "myName" (listType static_ string)) (litString "Brooks Mac"),
+  printLnList string (var "myName" (listType static_ string)),
   listDecDef "boringList" (listType dynamic_ bool) [litFalse, litFalse, litFalse, litFalse, litFalse],
-  printLnList bool (var "boringList"),
+  printLnList bool (var "boringList" (listType dynamic_ bool)),
   listDec "mySlicedList" 2 $ listType static_ float]
 
 helloListSlice :: (RenderSym repr) => repr (Block repr)
-helloListSlice = listSlice (listType static_ float) (var "mySlicedList") (var "myOtherList") (Just (litInt 1)) (Just (litInt 3)) Nothing
+helloListSlice = listSlice (listType static_ float) (var "mySlicedList" (listType static_ float)) (var "myOtherList" (listType static_ float)) (Just (litInt 1)) (Just (litInt 3)) Nothing
 
 helloIfBody :: (RenderSym repr) => repr (Body repr)
 helloIfBody = addComments "If body" (body [
   block [
     varDec "c" int,
     varDec "d" int,
-    assign (var "a") (litInt 5),
-    var "b" &= (var "a" #+ litInt 2),
-    "c" &.= (var "b" #+ litInt 3),
-    var "d" &=. "b",
-    var "d" &-= var "a",
-    "c" &.-= var "d",
-    var "b" &+= litInt 17,
-    "c" &.+= litInt 17,
-    (&++) (var "a"),
-    (&.++) "d",
-    (&~-) (var "c"),
-    (&.~-) "b",
+    assign (var "a" int) (litInt 5),
+    var "b" int &= (var "a" int #+ litInt 2),
+    var "c" int &= (var "b" int #+ litInt 3),
+    var "d" int &= var "b" int,
+    var "d" int &-= var "a" int,
+    var "c" int &-= var "d" int,
+    var "b" int &+= litInt 17,
+    var "c" int &+= litInt 17,
+    (&++) (var "a" int),
+    (&++) (var "d" int),
+    (&~-) (var "c" int),
+    (&~-) (var "b" int),
 
     listDec "myList" 5 (listType static_ int),
     objDecDef "myObj" char (litChar 'o'),
     constDecDef "myConst" string (litString "Imconstant"),
 
-    printLn int (var "a"),
-    printLn int (var "b"),
-    printLn int (var "c"),
-    printLn int (var "d"),
-    printLnList float (var "myOtherList"),
-    printLnList float (var "mySlicedList"),
+    printLn int (var "a" int),
+    printLn int (var "b" int),
+    printLn int (var "c" int),
+    printLn int (var "d" int),
+    printLnList float (var "myOtherList" (listType static_ float)),
+    printLnList float (var "mySlicedList" (listType static_ float)),
     
     printStrLn "Type an int",
-    getIntInput (var "d"),
+    getIntInput (var "d" int),
     printStrLn "Type another",
     discardInput],
   
@@ -110,7 +111,7 @@ helloIfBody = addComments "If body" (body [
     printLn int (litInt 6 #+ (litInt 2 #* litInt 3)),
     printLn float (csc (litFloat 1.0)),
     printLn float (sec (litFloat 1.0)),
-    printLn int (var "a"),
+    printLn int (var "a" int),
     printLn int (inlineIf litTrue (litInt 5) (litInt 0)),
     printLn float (cot (litFloat 1.0))]])
 
@@ -118,22 +119,22 @@ helloElseBody :: (RenderSym repr) => repr (Body repr)
 helloElseBody = bodyStatements [printLn int (arg 5)]
 
 helloIfExists :: (RenderSym repr) => repr (Statement repr)
-helloIfExists = ifExists (var "boringList") (oneLiner (printStrLn "Ew, boring list!")) (oneLiner (printStrLn "Great, no bores!"))
+helloIfExists = ifExists (var "boringList" (listType dynamic_ bool)) (oneLiner (printStrLn "Ew, boring list!")) (oneLiner (printStrLn "Great, no bores!"))
 
 helloSwitch :: (RenderSym repr) => repr (Statement repr)
-helloSwitch = switch (var "a") [(litInt 5, oneLiner ("b" &.= litInt 10)), 
-  (litInt 0, oneLiner ("b" &.= litInt 5))]
-  (oneLiner ("b" &.= litInt 0))
+helloSwitch = switch (var "a" int) [(litInt 5, oneLiner (var "b" int &= litInt 10)), 
+  (litInt 0, oneLiner (var "b" int &= litInt 5))]
+  (oneLiner (var "b" int &= litInt 0))
 
 helloForLoop :: (RenderSym repr) => repr (Statement repr)
-helloForLoop = forRange "i" (litInt 0) (litInt 9) (litInt 1) (oneLiner (printLn int (var "i")))
+helloForLoop = forRange "i" (litInt 0) (litInt 9) (litInt 1) (oneLiner (printLn int (var "i" int)))
 
 helloWhileLoop :: (RenderSym repr) => repr (Statement repr)
-helloWhileLoop = while (var "a" ?< litInt 13) (bodyStatements [printStrLn "Hello", (&.++) "a"]) 
+helloWhileLoop = while (var "a" int ?< litInt 13) (bodyStatements [printStrLn "Hello", (&++) (var "a" int)]) 
 
 helloForEachLoop :: (RenderSym repr) => repr (Statement repr)
-helloForEachLoop = forEach "num" float (listVar "myOtherList" float) 
-  (oneLiner (printLn float (extFuncApp "Helper" "doubleAndAdd" [iterVar "num", litFloat 1.0])))
+helloForEachLoop = forEach "num" float (listVar "myOtherList" static_ float) 
+  (oneLiner (printLn float (extFuncApp "Helper" "doubleAndAdd" float [iterVar "num" float, litFloat 1.0])))
 
 helloTryCatch :: (RenderSym repr) => repr (Statement repr)
 helloTryCatch = tryCatch (oneLiner (throw "Good-bye!"))

--- a/code/drasil-code/Test/Helper.hs
+++ b/code/drasil-code/Test/Helper.hs
@@ -14,6 +14,6 @@ doubleAndAdd = function "doubleAndAdd" public static_ (mState float)
   [stateParam "num1" float, stateParam "num2" float]
   (bodyStatements [
     varDec "doubledSum" float, 
-    "doubledSum" &.= ((litFloat 2.0 #* var "num1") #+ 
-      (litFloat 2.0 #* var "num2")),
+    "doubledSum" &.= ((litFloat 2.0 #* var "num1" float) #+ 
+      (litFloat 2.0 #* var "num2" float)),
     returnVar "doubledSum"])

--- a/code/drasil-code/Test/Helper.hs
+++ b/code/drasil-code/Test/Helper.hs
@@ -14,6 +14,6 @@ doubleAndAdd = function "doubleAndAdd" public static_ (mState float)
   [stateParam "num1" float, stateParam "num2" float]
   (bodyStatements [
     varDec "doubledSum" float, 
-    "doubledSum" &.= ((litFloat 2.0 #* var "num1" float) #+ 
+    var "doubledSum" float &= ((litFloat 2.0 #* var "num1" float) #+ 
       (litFloat 2.0 #* var "num2" float)),
-    returnVar "doubledSum"])
+    returnVar "doubledSum" float])

--- a/code/drasil-code/Test/Observer.hs
+++ b/code/drasil-code/Test/Observer.hs
@@ -13,7 +13,7 @@ helperClass :: (RenderSym repr) => repr (Class repr)
 helperClass = pubClass "Observer" Nothing [stateVar 0 "x" public dynamic_ int] [observerConstructor, printNumMethod]
 
 observerConstructor :: (RenderSym repr) => repr (Method repr)
-observerConstructor = constructor "Observer" [] (oneLiner (assign (objVarSelf "x" int) (litInt 5)))
+observerConstructor = constructor "Observer" [] (oneLiner (assign (objVarSelf "Observer" "x" int) (litInt 5)))
 
 printNumMethod :: (RenderSym repr) => repr (Method repr)
-printNumMethod = method "printNum" "Observer" public dynamic_ void [] (oneLiner (printLn int (objVarSelf "x" int)))
+printNumMethod = method "printNum" "Observer" public dynamic_ (mState void) [] (oneLiner (printLn int (objVarSelf "Observer" "x" int)))

--- a/code/drasil-code/Test/Observer.hs
+++ b/code/drasil-code/Test/Observer.hs
@@ -13,7 +13,7 @@ helperClass :: (RenderSym repr) => repr (Class repr)
 helperClass = pubClass "Observer" Nothing [stateVar 0 "x" public dynamic_ int] [observerConstructor, printNumMethod]
 
 observerConstructor :: (RenderSym repr) => repr (Method repr)
-observerConstructor = constructor "Observer" [] (oneLiner (assign (objVarSelf "x") (litInt 5)))
+observerConstructor = constructor "Observer" [] (oneLiner (assign (objVarSelf "x" int) (litInt 5)))
 
 printNumMethod :: (RenderSym repr) => repr (Method repr)
-printNumMethod = method "printNum" "Observer" public dynamic_ void [] (oneLiner (printLn int (objVarSelf "x")))
+printNumMethod = method "printNum" "Observer" public dynamic_ void [] (oneLiner (printLn int (objVarSelf "x" int)))

--- a/code/drasil-code/Test/PatternTest.hs
+++ b/code/drasil-code/Test/PatternTest.hs
@@ -25,12 +25,12 @@ patternTestMainMethod = mainMethod "PatternTest" (body [block [
   runStrategy "myStrat" 
     [("myStrat", oneLiner (printStrLn "myStrat")), 
       ("yourStrat", oneLiner (printStrLn "yourStrat"))]
-    (Just (litInt 3)) (Just (var "n")),
+    (Just (litInt 3)) (Just (var "n" int)),
 
   block [
     varDecDef "obs1" (obj "Observer") (extStateObj "Observer" (obj "Observer") []), 
     varDecDef "obs2" (obj "Observer") (extStateObj "Observer" (obj "Observer") [])],
   block [
-    initObserverList (listType static_ (obj "Observer")) [var "obs1"], 
-    addObserver (obj "Observer") (var "obs2"),
-    notifyObservers "printNum" (listType static_ (obj "Observer")) []]])
+    initObserverList (listType static_ (obj "Observer")) [var "obs1" (obj "Observer")], 
+    addObserver (obj "Observer") (var "obs2" (obj "Observer")),
+    notifyObservers void "printNum" (listType static_ (obj "Observer")) []]])


### PR DESCRIPTION
This PR addresses #496 by updating the data structure for `Value`s in GOOL to hold information about the value's type.

This change affords us many opportunities for clean-up (i.e. with functions that take a type as a parameter that now may not need to because they can extract the type from the value), most of which I haven't pursued for now, just because this PR is big enough as it is. This PR does just enough to get things to compile, and #1611 will remind me to go back and find places that can now be cleaned up.