### PR TITLE
Remove Statements from GOOL Modules

### DIFF
--- a/code/drasil-code/Language/Drasil/Code/Imperative/Import.hs
+++ b/code/drasil-code/Language/Drasil/Code/Imperative/Import.hs
@@ -201,7 +201,7 @@ genInputModNoClass :: (RenderSym repr) => Reader (State repr)
 genInputModNoClass = do
   inpDer    <- genInputDerived
   inpConstr <- genInputConstraints
-  return [ buildModule "InputParameters" [] []
+  return [ buildModule "InputParameters" []
            (catMaybes [inpDer, inpConstr])
            []
          ]
@@ -447,7 +447,7 @@ genModule n maybeMs maybeCs = do
       updateState = withReader (\s -> s { currentModule = n })
   cs <- maybe (return []) updateState maybeCs
   ms <- maybe (return []) updateState maybeMs
-  return $ buildModule n ls [] ms cs
+  return $ buildModule n ls ms cs
 
 
 genMain :: (RenderSym repr) => Reader (State repr) (repr (Module repr))

--- a/code/drasil-code/Language/Drasil/Code/Imperative/LanguageRenderer.hs
+++ b/code/drasil-code/Language/Drasil/Code/Imperative/LanguageRenderer.hs
@@ -29,7 +29,7 @@ module Language.Drasil.Code.Imperative.LanguageRenderer (
   sizeDocD, listAccessDocD, listSetDocD, objAccessDocD, castObjDocD, includeD, 
   breakDocD, continueDocD, staticDocD, dynamicDocD, privateDocD, publicDocD, 
   addCommentsDocD, valList, prependToBody, appendToBody, surroundBody, 
-  getterName, setterName, setMain, setEmpty, statementsToStateVars
+  getterName, setterName, setMain, setEmpty
 ) where
 
 import Utils.Drasil (capitalize, indent, indentList)
@@ -677,7 +677,3 @@ setMain (d, _) = (d, True)
 
 setEmpty :: (Doc, Terminator) -> (Doc, Terminator)
 setEmpty (d, _) = (d, Empty)
-
--- Hack because modules accept Statement representations of their state variables. Modules should be redesigned/rethought
-statementsToStateVars :: Doc -> Doc -> Doc -> (Doc, Terminator) -> Doc
-statementsToStateVars s p end (v, _) = s <+> p <+> v <> end

--- a/code/drasil-code/Language/Drasil/Code/Imperative/LanguageRenderer/CSharpRenderer.hs
+++ b/code/drasil-code/Language/Drasil/Code/Imperative/LanguageRenderer/CSharpRenderer.hs
@@ -39,7 +39,7 @@ import Language.Drasil.Code.Imperative.LanguageRenderer (
   listAccessDocD, objAccessDocD, castObjDocD, breakDocD, continueDocD, 
   staticDocD, dynamicDocD, privateDocD, publicDocD, dot, new, observerListName,
   doubleSlash, addCommentsDocD, valList, surroundBody, getterName, setterName, 
-  setMain, setEmpty, statementsToStateVars)
+  setMain, setEmpty)
 import Language.Drasil.Code.Imperative.Helpers (Terminator(..), FuncData(..),  
   fd, ModData(..), md, TypeData(..), td, ValData(..), vd, updateValDoc, liftA4, 
   liftA5, liftA6, liftA7, liftList, lift1List, lift3Pair, lift4Pair, 
@@ -547,10 +547,9 @@ instance ClassSym CSharpCode where
 
 instance ModuleSym CSharpCode where
   type Module CSharpCode = ModData
-  buildModule n _ vs ms cs = fmap (md n (any (snd . unCSC) ms || 
-    any (snd . unCSC) cs)) (liftList moduleDocD (if null vs && null ms then cs 
-    else pubClass n Nothing (map (liftA4 statementsToStateVars public static_ 
-    endStatement) vs) ms : cs))
+  buildModule n _ ms cs = fmap (md n (any (snd . unCSC) ms || 
+    any (snd . unCSC) cs)) (liftList moduleDocD (if null ms then cs 
+    else pubClass n Nothing [] ms : cs))
 
 cstop :: Doc -> Doc -> Doc
 cstop end inc = vcat [

--- a/code/drasil-code/Language/Drasil/Code/Imperative/LanguageRenderer/CppRenderer.hs
+++ b/code/drasil-code/Language/Drasil/Code/Imperative/LanguageRenderer/CppRenderer.hs
@@ -547,8 +547,8 @@ instance (Pair p) => ClassSym (p CppSrcCode CppHdrCode) where
 
 instance (Pair p) => ModuleSym (p CppSrcCode CppHdrCode) where
   type Module (p CppSrcCode CppHdrCode) = ModData
-  buildModule n l vs ms cs = pair (buildModule n l (map pfst vs) (map pfst ms) 
-    (map pfst cs)) (buildModule n l (map psnd vs) (map psnd ms) (map psnd cs))
+  buildModule n l ms cs = pair (buildModule n l (map pfst ms) (map pfst cs)) 
+    (buildModule n l (map psnd ms) (map psnd cs))
 
 -----------------
 -- Source File --
@@ -1079,7 +1079,7 @@ instance ClassSym CppSrcCode where
 
 instance ModuleSym CppSrcCode where
   type Module CppSrcCode = ModData
-  buildModule n l _ ms cs = fmap (md n (any (snd . unCPPSC) cs || 
+  buildModule n l ms cs = fmap (md n (any (snd . unCPPSC) cs || 
     any (isMainMthd . unCPPSC) ms)) (if all (isEmpty . fst . unCPPSC) cs && all 
     (isEmpty . mthdDoc . unCPPSC) ms then return empty else
     liftA5 cppModuleDoc (liftList vcat (map include l)) 
@@ -1519,7 +1519,7 @@ instance ClassSym CppHdrCode where
 
 instance ModuleSym CppHdrCode where
   type Module CppHdrCode = ModData
-  buildModule n l _ ms cs = fmap (md n (any (snd . unCPPHC) cs || 
+  buildModule n l ms cs = fmap (md n (any (snd . unCPPHC) cs || 
     any (snd . unCPPHC) methods)) (if all (isEmpty . fst . unCPPHC) cs && all 
     (isEmpty . mthdDoc . unCPPHC) ms then return empty else liftA5 cppModuleDoc
     (liftList vcat (map include l)) (if not (null l) && any 

--- a/code/drasil-code/Language/Drasil/Code/Imperative/LanguageRenderer/JavaRenderer.hs
+++ b/code/drasil-code/Language/Drasil/Code/Imperative/LanguageRenderer/JavaRenderer.hs
@@ -38,7 +38,7 @@ import Language.Drasil.Code.Imperative.LanguageRenderer (
   funcDocD, castDocD, objAccessDocD, castObjDocD, breakDocD, continueDocD, 
   staticDocD, dynamicDocD, privateDocD, publicDocD, dot, new, forLabel, 
   observerListName, doubleSlash, addCommentsDocD, valList, surroundBody, 
-  getterName, setterName, setMain, setEmpty, statementsToStateVars)
+  getterName, setterName, setMain, setEmpty)
 import Language.Drasil.Code.Imperative.Helpers (Terminator(..), FuncData(..), 
   fd, ModData(..), md, TypeData(..), td, ValData(..), vd,  angles, liftA4, 
   liftA5, liftA6, liftA7, liftList, lift1List, lift3Pair, lift4Pair, 
@@ -567,10 +567,9 @@ instance ClassSym JavaCode where
 
 instance ModuleSym JavaCode where
   type Module JavaCode = ModData
-  buildModule n _ vs ms cs = fmap (md n (any (snd . unJC) ms || 
-    any (snd . unJC) cs)) (liftList moduleDocD (if null vs && null ms then cs 
-    else pubClass n Nothing (map (liftA4 statementsToStateVars public static_
-    endStatement) vs) ms : cs))
+  buildModule n _ ms cs = fmap (md n (any (snd . unJC) ms || 
+    any (snd . unJC) cs)) (liftList moduleDocD (if null ms then cs 
+    else pubClass n Nothing [] ms : cs))
 
 enumsEqualInts :: Bool
 enumsEqualInts = False

--- a/code/drasil-code/Language/Drasil/Code/Imperative/LanguageRenderer/PythonRenderer.hs
+++ b/code/drasil-code/Language/Drasil/Code/Imperative/LanguageRenderer/PythonRenderer.hs
@@ -510,12 +510,11 @@ instance ClassSym PythonCode where
 
 instance ModuleSym PythonCode where
   type Module PythonCode = ModData
-  buildModule n ls vs fs cs = fmap (md n (any (snd . unPC) fs || 
+  buildModule n ls fs cs = fmap (md n (any (snd . unPC) fs || 
     any (snd . unPC) cs)) (if all (isEmpty . fst . unPC) cs && all 
     (isEmpty . fst . unPC) fs then return empty else
-    liftA4 pyModule (liftList pyModuleImportList (map 
-    include ls)) (liftList pyModuleVarList (map state vs)) (liftList 
-    methodListDocD fs) (liftList pyModuleClassList cs))
+    liftA3 pyModule (liftList pyModuleImportList (map include ls)) 
+    (liftList methodListDocD fs) (liftList pyModuleClassList cs))
 
 -- convenience
 imp, incl, initName :: Label
@@ -628,22 +627,16 @@ pyClass n pn fs = vcat [
 pyModuleImportList :: [Doc] -> Doc
 pyModuleImportList = vcat
 
-pyModuleVarList :: [(Doc, Terminator)] -> Doc
-pyModuleVarList vs = vcat (map fst vs)
-
 pyModuleClassList :: [(Doc, Bool)] -> Doc
 pyModuleClassList cs = vibcat $ map fst cs 
 
-pyModule :: Doc -> Doc -> Doc -> Doc -> Doc
-pyModule ls vs fs cs =
+pyModule :: Doc -> Doc -> Doc -> Doc
+pyModule ls fs cs =
   libs $+$
-  vars $+$
   funcs $+$
   cs
   where libs | isEmpty ls = empty
              | otherwise  = ls $+$ blank
-        vars | isEmpty vs = empty
-             | otherwise  = vs $+$ blank
         funcs | isEmpty fs = empty
               | otherwise  = fs $+$ blank
 

--- a/code/drasil-code/Language/Drasil/Code/Imperative/Symantics.hs
+++ b/code/drasil-code/Language/Drasil/Code/Imperative/Symantics.hs
@@ -539,5 +539,5 @@ class (StateVarSym repr, MethodSym repr) => ClassSym repr where
 
 class (ClassSym repr) => ModuleSym repr where
   type Module repr
-  buildModule :: Label -> [Library] -> [repr (Statement repr)] -> 
-    [repr (Method repr)] -> [repr (Class repr)] -> repr (Module repr)
+  buildModule :: Label -> [Library] -> [repr (Method repr)] -> 
+    [repr (Class repr)] -> repr (Module repr)

--- a/code/drasil-code/Test/FileTests.hs
+++ b/code/drasil-code/Test/FileTests.hs
@@ -7,7 +7,7 @@ import Language.Drasil.Code (PackageSym(..), RenderSym(..), PermanenceSym(..),
 import Prelude hiding (return,print,log,exp,sin,cos,tan)
 
 fileTests :: (PackageSym repr) => repr (Package repr)
-fileTests = packMods "FileTests" [fileDoc (buildModule "FileTests" [] [] [fileTestMethod] [])]
+fileTests = packMods "FileTests" [fileDoc (buildModule "FileTests" [] [fileTestMethod] [])]
 
 fileTestMethod :: (RenderSym repr) => repr (Method repr)
 fileTestMethod = mainMethod "FileTests" (body [writeStory, block [readStory], 

--- a/code/drasil-code/Test/HelloWorld.hs
+++ b/code/drasil-code/Test/HelloWorld.hs
@@ -14,7 +14,7 @@ import Test.Helper (helper)
 
 helloWorld :: (PackageSym repr) => repr (Package repr)
 helloWorld = packMods "HelloWorld" [fileDoc (buildModule "HelloWorld" 
-  ["Helper"] [] [helloWorldMain] []), helper]
+  ["Helper"] [helloWorldMain] []), helper]
 
 helloWorldMain :: (RenderSym repr) => repr (Method repr)
 helloWorldMain = mainMethod "HelloWorld" (body [ helloInitVariables, 

--- a/code/drasil-code/Test/Helper.hs
+++ b/code/drasil-code/Test/Helper.hs
@@ -7,7 +7,7 @@ import Language.Drasil.Code.Imperative.Symantics (
 import Prelude hiding (return,print,log,exp,sin,cos,tan)
 
 helper :: (RenderSym repr) => repr (RenderFile repr)
-helper = fileDoc (buildModule "Helper" [] [] [doubleAndAdd] [])
+helper = fileDoc (buildModule "Helper" [] [doubleAndAdd] [])
 
 doubleAndAdd :: (RenderSym repr) => repr (Method repr)
 doubleAndAdd = function "doubleAndAdd" public static_ (mState float) 

--- a/code/drasil-code/Test/Observer.hs
+++ b/code/drasil-code/Test/Observer.hs
@@ -7,7 +7,7 @@ import Language.Drasil.Code.Imperative.Symantics (
 import Prelude hiding (return,print,log,exp,sin,cos,tan)
 
 observer :: (RenderSym repr) => repr (RenderFile repr)
-observer = fileDoc (buildModule "Observer" [] [] [] [helperClass])
+observer = fileDoc (buildModule "Observer" [] [] [helperClass])
 
 helperClass :: (RenderSym repr) => repr (Class repr)
 helperClass = pubClass "Observer" Nothing [stateVar 0 "x" public dynamic_ int] [observerConstructor, printNumMethod]

--- a/code/drasil-code/Test/PatternTest.hs
+++ b/code/drasil-code/Test/PatternTest.hs
@@ -9,7 +9,7 @@ import Prelude hiding (return,print,log,exp,sin,cos,tan)
 import Test.Observer (observer)
 
 patternTest :: (PackageSym repr) => repr (Package repr)
-patternTest = packMods "PatternTest" [fileDoc (buildModule "PatternTest" ["Observer"] [] [patternTestMainMethod] []), observer]
+patternTest = packMods "PatternTest" [fileDoc (buildModule "PatternTest" ["Observer"] [patternTestMainMethod] []), observer]
 
 patternTestMainMethod :: (RenderSym repr) => repr (Method repr)
 patternTestMainMethod = mainMethod "PatternTest" (body [block [


### PR DESCRIPTION
This PR updates the GOOL constructor for modules to not take a list of `Statement`s, which closes #1517.