### PR TITLE
PR - More useful names in SWHS and NoPCM GenDefs

### DIFF
--- a/code/drasil-example/Drasil/NoPCM/GenDefs.hs
+++ b/code/drasil-example/Drasil/NoPCM/GenDefs.hs
@@ -37,7 +37,7 @@ rocTempSimpDeriv =
 rocTempSimpDerivSent :: [Sentence]
 rocTempSimpDerivSent = map foldlSentCol [
   rocTempDerivInteg consThermE vol,
-  genDefDesc2 gaussDiv surface vol thFluxVect uNormalVect unit_,
+  rocTempDerivGauss gaussDiv surface vol thFluxVect uNormalVect unit_,
   genDefDesc3 vol volHtGen,
   genDefDesc4 htFluxIn htFluxOut inSA outSA density QT.heatCapSpec
     QT.temp vol [makeRef2S assumpCWTAT, makeRef2S assumpDWCoW, makeRef2S assumpSHECoW],
@@ -47,9 +47,9 @@ rocTempDerivInteg :: (HasShortName x, Referable x) => x -> UnitalChunk -> [Sente
 rocTempDerivInteg t1c vo =
   [S "Integrating", makeRef2S t1c, S "over a", phrase vo, sParen (ch vo) `sC` S "we have"]
 
-genDefDesc2 :: (Quantity b, Quantity e) => ConceptChunk -> b -> UnitalChunk ->
+rocTempDerivGauss :: (Quantity b, Quantity e) => ConceptChunk -> b -> UnitalChunk ->
   UnitalChunk -> e -> ConceptChunk -> [Sentence]
-genDefDesc2 gad su vo tfv unv un =
+rocTempDerivGauss gad su vo tfv unv un =
   [S "Applying", titleize gad, S "to the first term over",
   (phrase su +:+ ch su `ofThe` phrase vo) `sC` S "with",
   ch tfv, S "as the", phrase tfv, S "for the",

--- a/code/drasil-example/Drasil/NoPCM/GenDefs.hs
+++ b/code/drasil-example/Drasil/NoPCM/GenDefs.hs
@@ -73,7 +73,7 @@ rocTempDerivDens :: UnitalChunk -> UnitalChunk -> UnitalChunk -> [Sentence]
 rocTempDerivDens den ma vo = [S "Using the fact that", ch den :+: S "=" :+:
   ch ma :+: S "/" :+: ch vo `sC` S "(2) can be written as"]
 
-rocTempDerivIntegEq, rocTempDerivGaussEq, rocTempDerivArbVolEq, rocTempDerivConsFlxEq, genDefEq5 :: Expr
+rocTempDerivIntegEq, rocTempDerivGaussEq, rocTempDerivArbVolEq, rocTempDerivConsFlxEq, rocTempDerivDensEq :: Expr
 
 rocTempDerivIntegEq = negate (intAll (eqSymb vol) (sy gradient $. sy thFluxVect)) + 
   intAll (eqSymb vol) (sy volHtGen) $=
@@ -93,10 +93,10 @@ rocTempDerivConsFlxEq = sy density * sy QT.heatCapSpec * sy vol * deriv
   (sy QT.temp) time $= sy htFluxIn * sy inSA - sy htFluxOut *
   sy outSA + sy volHtGen * sy vol
 
-genDefEq5 = sy mass * sy QT.heatCapSpec * deriv (sy QT.temp)
+rocTempDerivDensEq = sy mass * sy QT.heatCapSpec * deriv (sy QT.temp)
   time $= sy htFluxIn * sy inSA - sy htFluxOut
   * sy outSA + sy volHtGen * sy vol
 
 rocTempSimpDerivEqns :: [Expr]
 rocTempSimpDerivEqns = [rocTempDerivIntegEq, rocTempDerivGaussEq, rocTempDerivArbVolEq, rocTempDerivConsFlxEq,
-  genDefEq5]
+  rocTempDerivDensEq]

--- a/code/drasil-example/Drasil/NoPCM/GenDefs.hs
+++ b/code/drasil-example/Drasil/NoPCM/GenDefs.hs
@@ -73,7 +73,7 @@ rocTempDerivDens :: UnitalChunk -> UnitalChunk -> UnitalChunk -> [Sentence]
 rocTempDerivDens den ma vo = [S "Using the fact that", ch den :+: S "=" :+:
   ch ma :+: S "/" :+: ch vo `sC` S "(2) can be written as"]
 
-rocTempDerivIntegEq, rocTempDerivGaussEq, rocTempDerivArbVolEq, genDefEq4, genDefEq5 :: Expr
+rocTempDerivIntegEq, rocTempDerivGaussEq, rocTempDerivArbVolEq, rocTempDerivConsFlxEq, genDefEq5 :: Expr
 
 rocTempDerivIntegEq = negate (intAll (eqSymb vol) (sy gradient $. sy thFluxVect)) + 
   intAll (eqSymb vol) (sy volHtGen) $=
@@ -89,7 +89,7 @@ rocTempDerivArbVolEq = sy htFluxIn * sy inSA - sy htFluxOut *
   sy outSA + sy volHtGen * sy vol $= 
   intAll (eqSymb vol) (sy density * sy QT.heatCapSpec * pderiv (sy QT.temp) time)
 
-genDefEq4 = sy density * sy QT.heatCapSpec * sy vol * deriv
+rocTempDerivConsFlxEq = sy density * sy QT.heatCapSpec * sy vol * deriv
   (sy QT.temp) time $= sy htFluxIn * sy inSA - sy htFluxOut *
   sy outSA + sy volHtGen * sy vol
 
@@ -98,5 +98,5 @@ genDefEq5 = sy mass * sy QT.heatCapSpec * deriv (sy QT.temp)
   * sy outSA + sy volHtGen * sy vol
 
 rocTempSimpDerivEqns :: [Expr]
-rocTempSimpDerivEqns = [rocTempDerivIntegEq, rocTempDerivGaussEq, rocTempDerivArbVolEq, genDefEq4,
+rocTempSimpDerivEqns = [rocTempDerivIntegEq, rocTempDerivGaussEq, rocTempDerivArbVolEq, rocTempDerivConsFlxEq,
   genDefEq5]

--- a/code/drasil-example/Drasil/NoPCM/GenDefs.hs
+++ b/code/drasil-example/Drasil/NoPCM/GenDefs.hs
@@ -36,15 +36,15 @@ rocTempSimpDeriv =
 
 rocTempSimpDerivSent :: [Sentence]
 rocTempSimpDerivSent = map foldlSentCol [
-  genDefDesc1 consThermE vol,
+  rocTempDerivInteg consThermE vol,
   genDefDesc2 gaussDiv surface vol thFluxVect uNormalVect unit_,
   genDefDesc3 vol volHtGen,
   genDefDesc4 htFluxIn htFluxOut inSA outSA density QT.heatCapSpec
     QT.temp vol [makeRef2S assumpCWTAT, makeRef2S assumpDWCoW, makeRef2S assumpSHECoW],
   genDefDesc5 density mass vol]
 
-genDefDesc1 :: (HasShortName x, Referable x) => x -> UnitalChunk -> [Sentence]
-genDefDesc1 t1c vo =
+rocTempDerivInteg :: (HasShortName x, Referable x) => x -> UnitalChunk -> [Sentence]
+rocTempDerivInteg t1c vo =
   [S "Integrating", makeRef2S t1c, S "over a", phrase vo, sParen (ch vo) `sC` S "we have"]
 
 genDefDesc2 :: (Quantity b, Quantity e) => ConceptChunk -> b -> UnitalChunk ->

--- a/code/drasil-example/Drasil/NoPCM/GenDefs.hs
+++ b/code/drasil-example/Drasil/NoPCM/GenDefs.hs
@@ -73,14 +73,14 @@ rocTempDerivDens :: UnitalChunk -> UnitalChunk -> UnitalChunk -> [Sentence]
 rocTempDerivDens den ma vo = [S "Using the fact that", ch den :+: S "=" :+:
   ch ma :+: S "/" :+: ch vo `sC` S "(2) can be written as"]
 
-rocTempDerivIntegEq, genDefEq2, genDefEq3, genDefEq4, genDefEq5 :: Expr
+rocTempDerivIntegEq, rocTempDerivGaussEq, genDefEq3, genDefEq4, genDefEq5 :: Expr
 
 rocTempDerivIntegEq = negate (intAll (eqSymb vol) (sy gradient $. sy thFluxVect)) + 
   intAll (eqSymb vol) (sy volHtGen) $=
   intAll (eqSymb vol) (sy density
   * sy QT.heatCapSpec * pderiv (sy QT.temp) time)
 
-genDefEq2 = negate (intAll (eqSymb surface) (sy thFluxVect $. sy uNormalVect)) +
+rocTempDerivGaussEq = negate (intAll (eqSymb surface) (sy thFluxVect $. sy uNormalVect)) +
   intAll (eqSymb vol) (sy volHtGen) $= 
   intAll (eqSymb vol)
   (sy density * sy QT.heatCapSpec * pderiv (sy QT.temp) time)
@@ -98,5 +98,5 @@ genDefEq5 = sy mass * sy QT.heatCapSpec * deriv (sy QT.temp)
   * sy outSA + sy volHtGen * sy vol
 
 rocTempSimpDerivEqns :: [Expr]
-rocTempSimpDerivEqns = [rocTempDerivIntegEq, genDefEq2, genDefEq3, genDefEq4,
+rocTempSimpDerivEqns = [rocTempDerivIntegEq, rocTempDerivGaussEq, genDefEq3, genDefEq4,
   genDefEq5]

--- a/code/drasil-example/Drasil/NoPCM/GenDefs.hs
+++ b/code/drasil-example/Drasil/NoPCM/GenDefs.hs
@@ -73,7 +73,7 @@ rocTempDerivDens :: UnitalChunk -> UnitalChunk -> UnitalChunk -> [Sentence]
 rocTempDerivDens den ma vo = [S "Using the fact that", ch den :+: S "=" :+:
   ch ma :+: S "/" :+: ch vo `sC` S "(2) can be written as"]
 
-rocTempDerivIntegEq, rocTempDerivGaussEq, genDefEq3, genDefEq4, genDefEq5 :: Expr
+rocTempDerivIntegEq, rocTempDerivGaussEq, rocTempDerivArbVolEq, genDefEq4, genDefEq5 :: Expr
 
 rocTempDerivIntegEq = negate (intAll (eqSymb vol) (sy gradient $. sy thFluxVect)) + 
   intAll (eqSymb vol) (sy volHtGen) $=
@@ -85,7 +85,7 @@ rocTempDerivGaussEq = negate (intAll (eqSymb surface) (sy thFluxVect $. sy uNorm
   intAll (eqSymb vol)
   (sy density * sy QT.heatCapSpec * pderiv (sy QT.temp) time)
 
-genDefEq3 = sy htFluxIn * sy inSA - sy htFluxOut *
+rocTempDerivArbVolEq = sy htFluxIn * sy inSA - sy htFluxOut *
   sy outSA + sy volHtGen * sy vol $= 
   intAll (eqSymb vol) (sy density * sy QT.heatCapSpec * pderiv (sy QT.temp) time)
 
@@ -98,5 +98,5 @@ genDefEq5 = sy mass * sy QT.heatCapSpec * deriv (sy QT.temp)
   * sy outSA + sy volHtGen * sy vol
 
 rocTempSimpDerivEqns :: [Expr]
-rocTempSimpDerivEqns = [rocTempDerivIntegEq, rocTempDerivGaussEq, genDefEq3, genDefEq4,
+rocTempSimpDerivEqns = [rocTempDerivIntegEq, rocTempDerivGaussEq, rocTempDerivArbVolEq, genDefEq4,
   genDefEq5]

--- a/code/drasil-example/Drasil/NoPCM/GenDefs.hs
+++ b/code/drasil-example/Drasil/NoPCM/GenDefs.hs
@@ -39,7 +39,7 @@ rocTempSimpDerivSent = map foldlSentCol [
   rocTempDerivInteg consThermE vol,
   rocTempDerivGauss gaussDiv surface vol thFluxVect uNormalVect unit_,
   rocTempDerivArbVol vol volHtGen,
-  genDefDesc4 htFluxIn htFluxOut inSA outSA density QT.heatCapSpec
+  rocTempDerivConsFlx htFluxIn htFluxOut inSA outSA density QT.heatCapSpec
     QT.temp vol [makeRef2S assumpCWTAT, makeRef2S assumpDWCoW, makeRef2S assumpSHECoW],
   genDefDesc5 density mass vol]
 
@@ -60,10 +60,10 @@ rocTempDerivArbVol :: UnitalChunk -> UnitalChunk -> [Sentence]
 rocTempDerivArbVol vo vhg = [S "We consider an arbitrary" +:+. phrase vo, S "The",
   phrase vhg, S "is assumed constant. Then (1) can be written as"]
 
-genDefDesc4 :: UnitalChunk -> UnitalChunk -> UnitalChunk -> UnitalChunk ->
+rocTempDerivConsFlx :: UnitalChunk -> UnitalChunk -> UnitalChunk -> UnitalChunk ->
   UnitalChunk -> UnitalChunk -> UnitalChunk -> UnitalChunk ->
   [Sentence] -> [Sentence]
-genDefDesc4 hfi hfo iS oS den hcs te vo assumps = [S "Where", ch hfi `sC`
+rocTempDerivConsFlx hfi hfo iS oS den hcs te vo assumps = [S "Where", ch hfi `sC`
   ch hfo `sC` ch iS `sC` S "and", ch oS, S "are explained in" +:+.
   makeRef2S rocTempSimp, S "Assuming", ch den `sC` ch hcs `sAnd` ch te,
   S "are constant over the", phrase vo `sC` S "which is true in our case by",

--- a/code/drasil-example/Drasil/NoPCM/GenDefs.hs
+++ b/code/drasil-example/Drasil/NoPCM/GenDefs.hs
@@ -38,7 +38,7 @@ rocTempSimpDerivSent :: [Sentence]
 rocTempSimpDerivSent = map foldlSentCol [
   rocTempDerivInteg consThermE vol,
   rocTempDerivGauss gaussDiv surface vol thFluxVect uNormalVect unit_,
-  genDefDesc3 vol volHtGen,
+  rocTempDerivArbVol vol volHtGen,
   genDefDesc4 htFluxIn htFluxOut inSA outSA density QT.heatCapSpec
     QT.temp vol [makeRef2S assumpCWTAT, makeRef2S assumpDWCoW, makeRef2S assumpSHECoW],
   genDefDesc5 density mass vol]
@@ -56,8 +56,8 @@ rocTempDerivGauss gad su vo tfv unv un =
   phrase su `sAnd` ch unv, S "as a", phrase un,
   S "outward", phrase unv, S "for a", phrase su]
 
-genDefDesc3 :: UnitalChunk -> UnitalChunk -> [Sentence]
-genDefDesc3 vo vhg = [S "We consider an arbitrary" +:+. phrase vo, S "The",
+rocTempDerivArbVol :: UnitalChunk -> UnitalChunk -> [Sentence]
+rocTempDerivArbVol vo vhg = [S "We consider an arbitrary" +:+. phrase vo, S "The",
   phrase vhg, S "is assumed constant. Then (1) can be written as"]
 
 genDefDesc4 :: UnitalChunk -> UnitalChunk -> UnitalChunk -> UnitalChunk ->

--- a/code/drasil-example/Drasil/NoPCM/GenDefs.hs
+++ b/code/drasil-example/Drasil/NoPCM/GenDefs.hs
@@ -73,9 +73,9 @@ rocTempDerivDens :: UnitalChunk -> UnitalChunk -> UnitalChunk -> [Sentence]
 rocTempDerivDens den ma vo = [S "Using the fact that", ch den :+: S "=" :+:
   ch ma :+: S "/" :+: ch vo `sC` S "(2) can be written as"]
 
-genDefEq1, genDefEq2, genDefEq3, genDefEq4, genDefEq5 :: Expr
+rocTempDerivIntegEq, genDefEq2, genDefEq3, genDefEq4, genDefEq5 :: Expr
 
-genDefEq1 = negate (intAll (eqSymb vol) (sy gradient $. sy thFluxVect)) + 
+rocTempDerivIntegEq = negate (intAll (eqSymb vol) (sy gradient $. sy thFluxVect)) + 
   intAll (eqSymb vol) (sy volHtGen) $=
   intAll (eqSymb vol) (sy density
   * sy QT.heatCapSpec * pderiv (sy QT.temp) time)
@@ -98,5 +98,5 @@ genDefEq5 = sy mass * sy QT.heatCapSpec * deriv (sy QT.temp)
   * sy outSA + sy volHtGen * sy vol
 
 rocTempSimpDerivEqns :: [Expr]
-rocTempSimpDerivEqns = [genDefEq1, genDefEq2, genDefEq3, genDefEq4,
+rocTempSimpDerivEqns = [rocTempDerivIntegEq, genDefEq2, genDefEq3, genDefEq4,
   genDefEq5]

--- a/code/drasil-example/Drasil/NoPCM/GenDefs.hs
+++ b/code/drasil-example/Drasil/NoPCM/GenDefs.hs
@@ -41,7 +41,7 @@ rocTempSimpDerivSent = map foldlSentCol [
   rocTempDerivArbVol vol volHtGen,
   rocTempDerivConsFlx htFluxIn htFluxOut inSA outSA density QT.heatCapSpec
     QT.temp vol [makeRef2S assumpCWTAT, makeRef2S assumpDWCoW, makeRef2S assumpSHECoW],
-  genDefDesc5 density mass vol]
+  rocTempDerivDens density mass vol]
 
 rocTempDerivInteg :: (HasShortName x, Referable x) => x -> UnitalChunk -> [Sentence]
 rocTempDerivInteg t1c vo =
@@ -69,8 +69,8 @@ rocTempDerivConsFlx hfi hfo iS oS den hcs te vo assumps = [S "Where", ch hfi `sC
   S "are constant over the", phrase vo `sC` S "which is true in our case by",
   foldlList Comma List assumps `sC` S "we have"]
 
-genDefDesc5 :: UnitalChunk -> UnitalChunk -> UnitalChunk -> [Sentence]
-genDefDesc5 den ma vo = [S "Using the fact that", ch den :+: S "=" :+:
+rocTempDerivDens :: UnitalChunk -> UnitalChunk -> UnitalChunk -> [Sentence]
+rocTempDerivDens den ma vo = [S "Using the fact that", ch den :+: S "=" :+:
   ch ma :+: S "/" :+: ch vo `sC` S "(2) can be written as"]
 
 genDefEq1, genDefEq2, genDefEq3, genDefEq4, genDefEq5 :: Expr

--- a/code/drasil-example/Drasil/SWHS/GenDefs.hs
+++ b/code/drasil-example/Drasil/SWHS/GenDefs.hs
@@ -150,14 +150,14 @@ rocTempDerivDens :: UnitalChunk -> UnitalChunk -> UnitalChunk -> [Sentence]
 rocTempDerivDens den ma vo = [S "Using the fact that", ch den :+: S "=" :+:
   ch ma :+: S "/" :+: ch vo `sC` S "(2) can be written as"]
 
-rocTempDerivIntegEq, s4_2_3_eq2, s4_2_3_eq3, s4_2_3_eq4, s4_2_3_eq5 :: Expr
+rocTempDerivIntegEq, rocTempDerivGaussEq, s4_2_3_eq3, s4_2_3_eq4, s4_2_3_eq5 :: Expr
 
 rocTempDerivIntegEq = negate (intAll (eqSymb vol) (sy gradient $. sy thFluxVect)) + 
   intAll (eqSymb vol) (sy volHtGen) $=
   intAll (eqSymb vol) (sy density
   * sy QT.heatCapSpec * pderiv (sy QT.temp) time)
 
-s4_2_3_eq2 = negate (intAll (eqSymb surface) (sy thFluxVect $. sy uNormalVect)) +
+rocTempDerivGaussEq = negate (intAll (eqSymb surface) (sy thFluxVect $. sy uNormalVect)) +
   intAll (eqSymb vol) (sy volHtGen) $= 
   intAll (eqSymb vol)
   (sy density * sy QT.heatCapSpec * pderiv (sy QT.temp) time)
@@ -175,5 +175,5 @@ s4_2_3_eq5 = sy mass * sy QT.heatCapSpec * deriv (sy QT.temp)
   * sy outSA + sy volHtGen * sy vol
 
 rocTempSimpDerivEqns :: [Expr]
-rocTempSimpDerivEqns = [rocTempDerivIntegEq, s4_2_3_eq2, s4_2_3_eq3, s4_2_3_eq4,
+rocTempSimpDerivEqns = [rocTempDerivIntegEq, rocTempDerivGaussEq, s4_2_3_eq3, s4_2_3_eq4,
   s4_2_3_eq5]

--- a/code/drasil-example/Drasil/SWHS/GenDefs.hs
+++ b/code/drasil-example/Drasil/SWHS/GenDefs.hs
@@ -115,7 +115,7 @@ rocTempSimpDerivSent = map foldlSentCol [
   rocTempDerivConsFlx htFluxIn htFluxOut inSA outSA density QT.heatCapSpec
     QT.temp vol [makeRef2S assumpCWTAT, makeRef2S assumpTPCAV,
                  makeRef2S assumpDWPCoV, makeRef2S assumpSHECoV],
-  s4_2_3_desc5 density mass vol]
+  rocTempDerivDens density mass vol]
 
 rocTempDerivInteg :: (HasShortName x, Referable x) => x -> UnitalChunk -> [Sentence]
 rocTempDerivInteg t1c vo =
@@ -146,8 +146,8 @@ rocTempDerivConsFlx hfi hfo iS oS den hcs te vo assumps = [S "Where", ch hfi `sC
   S "are constant over the", phrase vo `sC` S "which is true in our case by",
   foldlList Comma List assumps `sC` S "we have"]
 
-s4_2_3_desc5 :: UnitalChunk -> UnitalChunk -> UnitalChunk -> [Sentence]
-s4_2_3_desc5 den ma vo = [S "Using the fact that", ch den :+: S "=" :+:
+rocTempDerivDens :: UnitalChunk -> UnitalChunk -> UnitalChunk -> [Sentence]
+rocTempDerivDens den ma vo = [S "Using the fact that", ch den :+: S "=" :+:
   ch ma :+: S "/" :+: ch vo `sC` S "(2) can be written as"]
 
 s4_2_3_eq1, s4_2_3_eq2, s4_2_3_eq3, s4_2_3_eq4, s4_2_3_eq5 :: Expr

--- a/code/drasil-example/Drasil/SWHS/GenDefs.hs
+++ b/code/drasil-example/Drasil/SWHS/GenDefs.hs
@@ -150,7 +150,7 @@ rocTempDerivDens :: UnitalChunk -> UnitalChunk -> UnitalChunk -> [Sentence]
 rocTempDerivDens den ma vo = [S "Using the fact that", ch den :+: S "=" :+:
   ch ma :+: S "/" :+: ch vo `sC` S "(2) can be written as"]
 
-rocTempDerivIntegEq, rocTempDerivGaussEq, s4_2_3_eq3, s4_2_3_eq4, s4_2_3_eq5 :: Expr
+rocTempDerivIntegEq, rocTempDerivGaussEq, rocTempDerivArbVolEq, s4_2_3_eq4, s4_2_3_eq5 :: Expr
 
 rocTempDerivIntegEq = negate (intAll (eqSymb vol) (sy gradient $. sy thFluxVect)) + 
   intAll (eqSymb vol) (sy volHtGen) $=
@@ -162,7 +162,7 @@ rocTempDerivGaussEq = negate (intAll (eqSymb surface) (sy thFluxVect $. sy uNorm
   intAll (eqSymb vol)
   (sy density * sy QT.heatCapSpec * pderiv (sy QT.temp) time)
 
-s4_2_3_eq3 = sy htFluxIn * sy inSA - sy htFluxOut *
+rocTempDerivArbVolEq = sy htFluxIn * sy inSA - sy htFluxOut *
   sy outSA + sy volHtGen * sy vol $= 
   intAll (eqSymb vol) (sy density * sy QT.heatCapSpec * pderiv (sy QT.temp) time)
 
@@ -175,5 +175,5 @@ s4_2_3_eq5 = sy mass * sy QT.heatCapSpec * deriv (sy QT.temp)
   * sy outSA + sy volHtGen * sy vol
 
 rocTempSimpDerivEqns :: [Expr]
-rocTempSimpDerivEqns = [rocTempDerivIntegEq, rocTempDerivGaussEq, s4_2_3_eq3, s4_2_3_eq4,
+rocTempSimpDerivEqns = [rocTempDerivIntegEq, rocTempDerivGaussEq, rocTempDerivArbVolEq, s4_2_3_eq4,
   s4_2_3_eq5]

--- a/code/drasil-example/Drasil/SWHS/GenDefs.hs
+++ b/code/drasil-example/Drasil/SWHS/GenDefs.hs
@@ -110,7 +110,7 @@ rocTempSimpDeriv =
 rocTempSimpDerivSent :: [Sentence]
 rocTempSimpDerivSent = map foldlSentCol [
   rocTempDerivInteg consThermE vol,
-  s4_2_3_desc2 gaussDiv surface vol thFluxVect uNormalVect unit_,
+  rocTempDerivGauss gaussDiv surface vol thFluxVect uNormalVect unit_,
   s4_2_3_desc3 vol volHtGen,
   s4_2_3_desc4 htFluxIn htFluxOut inSA outSA density QT.heatCapSpec
     QT.temp vol [makeRef2S assumpCWTAT, makeRef2S assumpTPCAV,
@@ -121,9 +121,9 @@ rocTempDerivInteg :: (HasShortName x, Referable x) => x -> UnitalChunk -> [Sente
 rocTempDerivInteg t1c vo =
   [S "Integrating", makeRef2S t1c, S "over a", phrase vo, sParen (ch vo) `sC` S "we have"]
 
-s4_2_3_desc2 :: (NamedIdea b, HasSymbol b) => ConceptChunk -> b -> UnitalChunk -> UnitalChunk ->
+rocTempDerivGauss :: (NamedIdea b, HasSymbol b) => ConceptChunk -> b -> UnitalChunk -> UnitalChunk ->
   DefinedQuantityDict -> ConceptChunk -> [Sentence]
-s4_2_3_desc2 cchn su vo tfv unv un =
+rocTempDerivGauss cchn su vo tfv unv un =
   [S "Applying", titleize cchn, S "to the first term over",
   (phrase su +:+ ch su `ofThe` phrase vo) `sC` S "with",
   ch tfv, S "as the", phrase tfv, S "for the",

--- a/code/drasil-example/Drasil/SWHS/GenDefs.hs
+++ b/code/drasil-example/Drasil/SWHS/GenDefs.hs
@@ -111,7 +111,7 @@ rocTempSimpDerivSent :: [Sentence]
 rocTempSimpDerivSent = map foldlSentCol [
   rocTempDerivInteg consThermE vol,
   rocTempDerivGauss gaussDiv surface vol thFluxVect uNormalVect unit_,
-  s4_2_3_desc3 vol volHtGen,
+  rocTempDerivArbVol vol volHtGen,
   s4_2_3_desc4 htFluxIn htFluxOut inSA outSA density QT.heatCapSpec
     QT.temp vol [makeRef2S assumpCWTAT, makeRef2S assumpTPCAV,
                  makeRef2S assumpDWPCoV, makeRef2S assumpSHECoV],
@@ -130,8 +130,8 @@ rocTempDerivGauss cchn su vo tfv unv un =
   phrase su `sAnd` ch unv, S "as a", phrase un,
   S "outward", phrase unv, S "for a", phrase su]
 
-s4_2_3_desc3 :: UnitalChunk -> UnitalChunk -> [Sentence]
-s4_2_3_desc3 vo vhg = [S "We consider an arbitrary" +:+. phrase vo, S "The",
+rocTempDerivArbVol :: UnitalChunk -> UnitalChunk -> [Sentence]
+rocTempDerivArbVol vo vhg = [S "We consider an arbitrary" +:+. phrase vo, S "The",
   phrase vhg, S "is assumed constant. Then (1) can be written as"]
 
 s4_2_3_desc4 :: UnitalChunk -> UnitalChunk -> UnitalChunk -> UnitalChunk ->

--- a/code/drasil-example/Drasil/SWHS/GenDefs.hs
+++ b/code/drasil-example/Drasil/SWHS/GenDefs.hs
@@ -150,9 +150,9 @@ rocTempDerivDens :: UnitalChunk -> UnitalChunk -> UnitalChunk -> [Sentence]
 rocTempDerivDens den ma vo = [S "Using the fact that", ch den :+: S "=" :+:
   ch ma :+: S "/" :+: ch vo `sC` S "(2) can be written as"]
 
-s4_2_3_eq1, s4_2_3_eq2, s4_2_3_eq3, s4_2_3_eq4, s4_2_3_eq5 :: Expr
+rocTempDerivIntegEq, s4_2_3_eq2, s4_2_3_eq3, s4_2_3_eq4, s4_2_3_eq5 :: Expr
 
-s4_2_3_eq1 = negate (intAll (eqSymb vol) (sy gradient $. sy thFluxVect)) + 
+rocTempDerivIntegEq = negate (intAll (eqSymb vol) (sy gradient $. sy thFluxVect)) + 
   intAll (eqSymb vol) (sy volHtGen) $=
   intAll (eqSymb vol) (sy density
   * sy QT.heatCapSpec * pderiv (sy QT.temp) time)
@@ -175,5 +175,5 @@ s4_2_3_eq5 = sy mass * sy QT.heatCapSpec * deriv (sy QT.temp)
   * sy outSA + sy volHtGen * sy vol
 
 rocTempSimpDerivEqns :: [Expr]
-rocTempSimpDerivEqns = [s4_2_3_eq1, s4_2_3_eq2, s4_2_3_eq3, s4_2_3_eq4,
+rocTempSimpDerivEqns = [rocTempDerivIntegEq, s4_2_3_eq2, s4_2_3_eq3, s4_2_3_eq4,
   s4_2_3_eq5]

--- a/code/drasil-example/Drasil/SWHS/GenDefs.hs
+++ b/code/drasil-example/Drasil/SWHS/GenDefs.hs
@@ -112,7 +112,7 @@ rocTempSimpDerivSent = map foldlSentCol [
   rocTempDerivInteg consThermE vol,
   rocTempDerivGauss gaussDiv surface vol thFluxVect uNormalVect unit_,
   rocTempDerivArbVol vol volHtGen,
-  s4_2_3_desc4 htFluxIn htFluxOut inSA outSA density QT.heatCapSpec
+  rocTempDerivConsFlx htFluxIn htFluxOut inSA outSA density QT.heatCapSpec
     QT.temp vol [makeRef2S assumpCWTAT, makeRef2S assumpTPCAV,
                  makeRef2S assumpDWPCoV, makeRef2S assumpSHECoV],
   s4_2_3_desc5 density mass vol]
@@ -134,10 +134,10 @@ rocTempDerivArbVol :: UnitalChunk -> UnitalChunk -> [Sentence]
 rocTempDerivArbVol vo vhg = [S "We consider an arbitrary" +:+. phrase vo, S "The",
   phrase vhg, S "is assumed constant. Then (1) can be written as"]
 
-s4_2_3_desc4 :: UnitalChunk -> UnitalChunk -> UnitalChunk -> UnitalChunk ->
+rocTempDerivConsFlx :: UnitalChunk -> UnitalChunk -> UnitalChunk -> UnitalChunk ->
   UnitalChunk -> UnitalChunk -> UnitalChunk -> UnitalChunk ->
   [Sentence] -> [Sentence]
-s4_2_3_desc4 hfi hfo iS oS den hcs te vo assumps = [S "Where", ch hfi `sC`
+rocTempDerivConsFlx hfi hfo iS oS den hcs te vo assumps = [S "Where", ch hfi `sC`
   ch hfo `sC` ch iS `sC` S "and", ch oS, S "are explained in" +:+.
   makeRef2S rocTempSimp, S "The integral over the", phrase surface, 
   S "could be simplified because the thermal flux is assumed constant over",

--- a/code/drasil-example/Drasil/SWHS/GenDefs.hs
+++ b/code/drasil-example/Drasil/SWHS/GenDefs.hs
@@ -109,7 +109,7 @@ rocTempSimpDeriv =
 
 rocTempSimpDerivSent :: [Sentence]
 rocTempSimpDerivSent = map foldlSentCol [
-  s4_2_3_desc1 consThermE vol,
+  rocTempDerivInteg consThermE vol,
   s4_2_3_desc2 gaussDiv surface vol thFluxVect uNormalVect unit_,
   s4_2_3_desc3 vol volHtGen,
   s4_2_3_desc4 htFluxIn htFluxOut inSA outSA density QT.heatCapSpec
@@ -117,8 +117,8 @@ rocTempSimpDerivSent = map foldlSentCol [
                  makeRef2S assumpDWPCoV, makeRef2S assumpSHECoV],
   s4_2_3_desc5 density mass vol]
 
-s4_2_3_desc1 :: (HasShortName x, Referable x) => x -> UnitalChunk -> [Sentence]
-s4_2_3_desc1 t1c vo =
+rocTempDerivInteg :: (HasShortName x, Referable x) => x -> UnitalChunk -> [Sentence]
+rocTempDerivInteg t1c vo =
   [S "Integrating", makeRef2S t1c, S "over a", phrase vo, sParen (ch vo) `sC` S "we have"]
 
 s4_2_3_desc2 :: (NamedIdea b, HasSymbol b) => ConceptChunk -> b -> UnitalChunk -> UnitalChunk ->

--- a/code/drasil-example/Drasil/SWHS/GenDefs.hs
+++ b/code/drasil-example/Drasil/SWHS/GenDefs.hs
@@ -150,7 +150,7 @@ rocTempDerivDens :: UnitalChunk -> UnitalChunk -> UnitalChunk -> [Sentence]
 rocTempDerivDens den ma vo = [S "Using the fact that", ch den :+: S "=" :+:
   ch ma :+: S "/" :+: ch vo `sC` S "(2) can be written as"]
 
-rocTempDerivIntegEq, rocTempDerivGaussEq, rocTempDerivArbVolEq, s4_2_3_eq4, s4_2_3_eq5 :: Expr
+rocTempDerivIntegEq, rocTempDerivGaussEq, rocTempDerivArbVolEq, rocTempDerivConsFlxEq, s4_2_3_eq5 :: Expr
 
 rocTempDerivIntegEq = negate (intAll (eqSymb vol) (sy gradient $. sy thFluxVect)) + 
   intAll (eqSymb vol) (sy volHtGen) $=
@@ -166,7 +166,7 @@ rocTempDerivArbVolEq = sy htFluxIn * sy inSA - sy htFluxOut *
   sy outSA + sy volHtGen * sy vol $= 
   intAll (eqSymb vol) (sy density * sy QT.heatCapSpec * pderiv (sy QT.temp) time)
 
-s4_2_3_eq4 = sy density * sy QT.heatCapSpec * sy vol * deriv
+rocTempDerivConsFlxEq = sy density * sy QT.heatCapSpec * sy vol * deriv
   (sy QT.temp) time $= sy htFluxIn * sy inSA - sy htFluxOut *
   sy outSA + sy volHtGen * sy vol
 
@@ -175,5 +175,5 @@ s4_2_3_eq5 = sy mass * sy QT.heatCapSpec * deriv (sy QT.temp)
   * sy outSA + sy volHtGen * sy vol
 
 rocTempSimpDerivEqns :: [Expr]
-rocTempSimpDerivEqns = [rocTempDerivIntegEq, rocTempDerivGaussEq, rocTempDerivArbVolEq, s4_2_3_eq4,
+rocTempSimpDerivEqns = [rocTempDerivIntegEq, rocTempDerivGaussEq, rocTempDerivArbVolEq, rocTempDerivConsFlxEq,
   s4_2_3_eq5]

--- a/code/drasil-example/Drasil/SWHS/GenDefs.hs
+++ b/code/drasil-example/Drasil/SWHS/GenDefs.hs
@@ -150,7 +150,7 @@ rocTempDerivDens :: UnitalChunk -> UnitalChunk -> UnitalChunk -> [Sentence]
 rocTempDerivDens den ma vo = [S "Using the fact that", ch den :+: S "=" :+:
   ch ma :+: S "/" :+: ch vo `sC` S "(2) can be written as"]
 
-rocTempDerivIntegEq, rocTempDerivGaussEq, rocTempDerivArbVolEq, rocTempDerivConsFlxEq, s4_2_3_eq5 :: Expr
+rocTempDerivIntegEq, rocTempDerivGaussEq, rocTempDerivArbVolEq, rocTempDerivConsFlxEq, rocTempDerivDensEq :: Expr
 
 rocTempDerivIntegEq = negate (intAll (eqSymb vol) (sy gradient $. sy thFluxVect)) + 
   intAll (eqSymb vol) (sy volHtGen) $=
@@ -170,10 +170,10 @@ rocTempDerivConsFlxEq = sy density * sy QT.heatCapSpec * sy vol * deriv
   (sy QT.temp) time $= sy htFluxIn * sy inSA - sy htFluxOut *
   sy outSA + sy volHtGen * sy vol
 
-s4_2_3_eq5 = sy mass * sy QT.heatCapSpec * deriv (sy QT.temp)
+rocTempDerivDensEq = sy mass * sy QT.heatCapSpec * deriv (sy QT.temp)
   time $= sy htFluxIn * sy inSA - sy htFluxOut
   * sy outSA + sy volHtGen * sy vol
 
 rocTempSimpDerivEqns :: [Expr]
 rocTempSimpDerivEqns = [rocTempDerivIntegEq, rocTempDerivGaussEq, rocTempDerivArbVolEq, rocTempDerivConsFlxEq,
-  s4_2_3_eq5]
+  rocTempDerivDensEq]


### PR DESCRIPTION
Closes #1409 and closes #1417.

Renaming of derivation sentences and equations in SWHS and NoPCM GenDefs. Old names were hardcoded and non-meaningful.