### PR TITLE
Deploy Fix

### DIFF
--- a/code/scripts/deploy_stage.sh
+++ b/code/scripts/deploy_stage.sh
@@ -1,26 +1,26 @@
 if [ -z "$DEPLOY_FOLDER" ]; then
-	echo "Need DEPLOY_FOLDER to know where to stage deploy."
-	exit 1
+  echo "Need DEPLOY_FOLDER to know where to stage deploy."
+  exit 1
 fi
 
 if [ -z "$BUILD_FOLDER" ]; then
-	echo "Missing BUILD_FOLDER."
-	exit 1
+  echo "Missing BUILD_FOLDER."
+  exit 1
 fi
 
 if [ -z "$GRAPH_FOLDER" ]; then
-	echo "Missing GRAPH_FOLDER."
-	exit 1
+  echo "Missing GRAPH_FOLDER."
+  exit 1
 fi
 
 if [ -z "$DEPLOY_CODE_PATH_KV_SEP" ]; then
-	echo "Missing DEPLOY_CODE_PATH_KV_SEP."
-	exit 1
+  echo "Missing DEPLOY_CODE_PATH_KV_SEP."
+  exit 1
 fi
 
 if [ -z "$MAKE" ]; then
-	echo "Missing MAKE. Did you invoke this with \`make deploy(_lite)\`?"
-	exit 1
+  echo "Missing MAKE. Did you invoke this with \`make deploy(_lite)\`?"
+  exit 1
 fi
 
 DOC_DEST=docs/
@@ -44,10 +44,10 @@ copy_docs() {
 }
 
 copy_datafiles() {
-	echo "FIXME: Drasil should copy needed images and resources to the appropriate output directory to avoid needing the entirety of datafiles (for HTML)."
-	rm -r datafiles  >/dev/null 2>&1  # Printing an error message that a directory doesn't exist isn't the most useful.
-	mkdir -p datafiles
-	cp -r "$CUR_DIR"datafiles/. datafiles/
+  echo "FIXME: Drasil should copy needed images and resources to the appropriate output directory to avoid needing the entirety of datafiles (for HTML)."
+  rm -r datafiles  >/dev/null 2>&1  # Printing an error message that a directory doesn't exist isn't the most useful.
+  mkdir -p datafiles
+  cp -r "$CUR_DIR"datafiles/. datafiles/
 }
 
 copy_graphs() {
@@ -57,25 +57,25 @@ copy_graphs() {
 
 copy_examples() {
   if [ -d "$EXAMPLE_DEST" ]; then
-	  rm -r "$EXAMPLE_DEST"
+    rm -r "$EXAMPLE_DEST"
   fi
-	for example in "$CUR_DIR$BUILD_FOLDER"*; do
-		example_name=$(basename "$example")
-		mkdir -p "$EXAMPLE_DEST$example_name/$SRS_DEST"
-		if [ -d "$example/"SRS ]; then
-			cp "$example/"SRS/*.pdf "$EXAMPLE_DEST$example_name/$SRS_DEST"
-		fi
-		if [ -d "$example/"Website/ ]; then
-			cp -r "$example/"Website/. "$EXAMPLE_DEST$example_name/$SRS_DEST"
-		fi
-		if [ -d "$example/"src ]; then
-			# We don't expose code in deploy. It's more conveneient to link to GitHub's directory
-			# We place a stub file which Hakyll will replace.
+  for example in "$CUR_DIR$BUILD_FOLDER"*; do
+    example_name=$(basename "$example")
+    mkdir -p "$EXAMPLE_DEST$example_name/$SRS_DEST"
+    if [ -d "$example/"SRS ]; then
+      cp "$example/"SRS/*.pdf "$EXAMPLE_DEST$example_name/$SRS_DEST"
+    fi
+    if [ -d "$example/"Website/ ]; then
+      cp -r "$example/"Website/. "$EXAMPLE_DEST$example_name/$SRS_DEST"
+    fi
+    if [ -d "$example/"src ]; then
+      # We don't expose code in deploy. It's more conveneient to link to GitHub's directory
+      # We place a stub file which Hakyll will replace.
       REL_PATH=$(cd "$CUR_DIR" && "$MAKE" deploy_code_path | grep "$example_name" | cut -d"$DEPLOY_CODE_PATH_KV_SEP" -f 2-)
       # On a real deploy, `deploy` folder is itself a git repo, thus we need to ensure the path lookup is in the outer Drasil repo.
       ls -d "$(cd "$CUR_DIR" && git rev-parse --show-toplevel)/$REL_PATH"*/ | rev | cut -d/ -f2 | rev | tr '\n' '\0' | xargs -0 printf "$REL_PATH%s\n" > "$EXAMPLE_DEST$example_name/src"
-		fi
-	done
+    fi
+  done
 }
 
 copy_images() {
@@ -84,19 +84,19 @@ copy_images() {
 }
 
 build_website() {
-	cd "$CUR_DIR"website
-	make DEPLOY_FOLDER="$CUR_DIR$DEPLOY_FOLDER" DOCS_FOLDER="$DOC_DEST" EXAMPLES_FOLDER="$EXAMPLE_DEST" \
-	SRS_FOLDER_FRAG="$SRS_DEST" GRAPH_FOLDER="$GRAPH_FOLDER"
-	RET=$?
-	if [ $RET != 0 ]; then
-		echo "Build Failed. Bailing."
-		exit 1
-	fi
-	cd "$CUR_DIR$DEPLOY_FOLDER"
-	cp -r "$CUR_DIR"website/_site/. .
+  cd "$CUR_DIR"website
+  make DEPLOY_FOLDER="$CUR_DIR$DEPLOY_FOLDER" DOCS_FOLDER="$DOC_DEST" EXAMPLES_FOLDER="$EXAMPLE_DEST" \
+  SRS_FOLDER_FRAG="$SRS_DEST" GRAPH_FOLDER="$GRAPH_FOLDER"
+  RET=$?
+  if [ $RET != 0 ]; then
+    echo "Build Failed. Bailing."
+    exit 1
+  fi
+  cd "$CUR_DIR$DEPLOY_FOLDER"
+  cp -r "$CUR_DIR"website/_site/. .
 
-	# src stubs were consumed by site generator; safe to delete those.
-	rm "$EXAMPLE_DEST"*/src
+  # src stubs were consumed by site generator; safe to delete those.
+  rm "$EXAMPLE_DEST"*/src
 }
 
 

--- a/code/scripts/deploy_stage.sh
+++ b/code/scripts/deploy_stage.sh
@@ -72,7 +72,8 @@ copy_examples() {
 			# We don't expose code in deploy. It's more conveneient to link to GitHub's directory
 			# We place a stub file which Hakyll will replace.
       REL_PATH=$(cd "$CUR_DIR" && "$MAKE" deploy_code_path | grep "$example_name" | cut -d"$DEPLOY_CODE_PATH_KV_SEP" -f 2-)
-      ls -d "$(git rev-parse --show-toplevel)/$REL_PATH"*/ | rev | cut -d/ -f2 | rev | tr '\n' '\0' | xargs -0 printf "$REL_PATH%s\n" > "$EXAMPLE_DEST$example_name/src"
+      # On a real deploy, `deploy` folder is itself a git repo, thus we need to ensure the path lookup is in the outer Drasil repo.
+      ls -d "$(cd "$CUR_DIR" && git rev-parse --show-toplevel)/$REL_PATH"*/ | rev | cut -d/ -f2 | rev | tr '\n' '\0' | xargs -0 printf "$REL_PATH%s\n" > "$EXAMPLE_DEST$example_name/src"
 		fi
 	done
 }


### PR DESCRIPTION
This is a small PR relating to a bad way to capture path information I suggested in #1653. The path I suggested works in a staged deploy, but a real deploy has the `deploy` folder as a git repo which is what `rev-parse` picks up. This corrects that oversight. 

This PR addresses the build failure of `master` which only failed due to the deploy failure and not a code failure. Subsequent commits to `master` will pass regardless of other (passing) merges, however deploys will fail until this PR is merged. 