### PR TITLE
Consistent constraint lists in GlassBR

### DIFF
--- a/code/drasil-example/Drasil/GlassBR/Unitals.hs
+++ b/code/drasil-example/Drasil/GlassBR/Unitals.hs
@@ -32,8 +32,7 @@ modElas = uc' "modElas" (nounPhraseSP "modulus of elasticity of glass")
 {--}
 
 constrained :: [ConstrainedChunk]
-constrained = map cnstrw inputsWUncrtn ++ map cnstrw inputsWUnitsUncrtn ++ 
-  map cnstrw derivedInsWUnitsUncrtn ++ map cnstrw derivedInsWUncrtn ++ 
+constrained = map cnstrw inputDataConstraints ++ 
   [cnstrw probBr, cnstrw probFail] 
 
 plateLen, plateWidth, charWeight, standOffDist :: UncertQ


### PR DESCRIPTION
This tiny PR closes #1682 by building the `constrained` list in GlassBR from the `inputDataConstraints` list. 

(Yay, a PR that doesn't depend on any others!)