### PR TITLE
Traceability Matrix Showed Items Tweak

### DIFF
--- a/code/drasil-docLang/Drasil/DocumentLanguage/TraceabilityMatrix.hs
+++ b/code/drasil-docLang/Drasil/DocumentLanguage/TraceabilityMatrix.hs
@@ -83,7 +83,7 @@ ensureItems u [] = error $ "Expected non-empty matrix dimension for traceability
 ensureItems _ l = l
 
 layoutUIDs :: [TraceViewCat] -> ChunkDB -> [UID] -> [UID]
-layoutUIDs a c e = concatMap (\x -> x e c) a
+layoutUIDs a c e = filter (`elem` (Map.keys $ c ^. traceTable)) $ concatMap (\x -> x e c) a
 
 traceViewFilt :: HasUID a => (a -> Bool) -> Getting (UMap a) ChunkDB (UMap a) -> TraceViewCat
 traceViewFilt f table _ = map (^. uid) . filter f . asOrderedList . (^. table)


### PR DESCRIPTION
This PR is a tiny tweak. It alters the behaviour of the traceability matrix to not take quite everything from `ChunkDB`. Only those which appear in the SRS itself. As you may notice, no stable changes. That's because we use everything in the `ChunkDB`. This is more an "in case" for the future if something is filtered to not be included in the SRS then it will also not show in the traceability matrix.