### PR TITLE
PR - Removing double period from GamePhysics References

### DIFF
--- a/code/drasil-example/Drasil/GamePhysics/References.hs
+++ b/code/drasil-example/Drasil/GamePhysics/References.hs
@@ -16,7 +16,7 @@ citations = [parnas1978, sciComp2013, parnas1972, parnasClements1984,
 --FIXME: check for references made within document
 
 parnas1978 = cInProceedings [dParnas]
-    "Designing Software for Ease of Extension and Contraction."
+    "Designing Software for Ease of Extension and Contraction"
     "ICSE '78: Proceedings of the 3rd international conference on Software engineering" 
     1978 [pages [264,277]] "parnas1978"
 

--- a/code/stable/gamephys/SRS/Chipmunk_SRS.tex
+++ b/code/stable/gamephys/SRS/Chipmunk_SRS.tex
@@ -1557,7 +1557,7 @@ pages={"1053-1058"}}
 
 @inproceedings{parnas1978,
 author={Parnas, David L.},
-title={Designing Software for Ease of Extension and Contraction.},
+title={Designing Software for Ease of Extension and Contraction},
 booktitle={ICSE '78: Proceedings of the 3rd international conference on Software engineering},
 year={1978},
 pages={"264-277"}}

--- a/code/stable/gamephys/Website/Chipmunk_SRS.html
+++ b/code/stable/gamephys/Website/Chipmunk_SRS.html
@@ -4652,7 +4652,7 @@
           </li>
           <li>
             <div id="parnas1978">
-              [4]: Parnas, David L. "Designing Software for Ease of Extension and Contraction.." <em>ICSE '78: Proceedings of the 3rd international conference on Software engineering</em>. 1978. pp. 264&ndash;277.
+              [4]: Parnas, David L. "Designing Software for Ease of Extension and Contraction." <em>ICSE '78: Proceedings of the 3rd international conference on Software engineering</em>. 1978. pp. 264&ndash;277.
             </div>
           </li>
           <li>


### PR DESCRIPTION
Closes #1722.
The cause of the HTML double period was due to a period appearing in the string in `References.hs`.

The HTML version probably adds a period after the title field, hence the double period.

The Latex seems to realize there is a period and not add another. But when a period is not present, Latex will render a new period outside of the quotations in the PDF. The original appeared within the quotations, which was inconsistent with the rest.