### PR TITLE
Separating out internal GOOL functions

### DIFF
--- a/code/drasil-code/Language/Drasil/Code/Imperative/LanguageRenderer.hs
+++ b/code/drasil-code/Language/Drasil/Code/Imperative/LanguageRenderer.hs
@@ -42,7 +42,7 @@ import Utils.Drasil (capitalize, indent, indentList)
 import Language.Drasil.Code.Code (CodeType(..))
 import Language.Drasil.Code.Imperative.Symantics (Label, Library,
   RenderSym(..), BodySym(..), StateTypeSym(getType, listInnerType), 
-  ValueSym(..), NumericExpression(..), BooleanExpression(..), Selector(..), 
+  ValueSym(..), NumericExpression(..), BooleanExpression(..), InternalValue(..),
   FunctionSym(..), SelectorFunction(..), StatementSym(..), 
   ControlStatementSym(..), ParameterSym(..), MethodSym(..), BlockCommentSym(..))
 import qualified Language.Drasil.Code.Imperative.Symantics as S (StateTypeSym(int))

--- a/code/drasil-code/Language/Drasil/Code/Imperative/LanguageRenderer.hs
+++ b/code/drasil-code/Language/Drasil/Code/Imperative/LanguageRenderer.hs
@@ -43,8 +43,9 @@ import Language.Drasil.Code.Code (CodeType(..))
 import Language.Drasil.Code.Imperative.Symantics (Label, Library,
   RenderSym(..), BodySym(..), StateTypeSym(getType, listInnerType), 
   ValueSym(..), NumericExpression(..), BooleanExpression(..), InternalValue(..),
-  FunctionSym(..), SelectorFunction(..), InternalStatement(..), StatementSym(..), 
-  ControlStatementSym(..), ParameterSym(..), MethodSym(..), BlockCommentSym(..))
+  FunctionSym(..), SelectorFunction(..), InternalStatement(..), 
+  StatementSym(..), ControlStatementSym(..), ParameterSym(..), MethodSym(..), 
+  BlockCommentSym(..))
 import qualified Language.Drasil.Code.Imperative.Symantics as S (StateTypeSym(int))
 import Language.Drasil.Code.Imperative.Data (Terminator(..), FuncData(..), 
   ModData(..), md, MethodData(..), ParamData(..), pd, TypeData(..), td, 

--- a/code/drasil-code/Language/Drasil/Code/Imperative/LanguageRenderer.hs
+++ b/code/drasil-code/Language/Drasil/Code/Imperative/LanguageRenderer.hs
@@ -43,7 +43,7 @@ import Language.Drasil.Code.Code (CodeType(..))
 import Language.Drasil.Code.Imperative.Symantics (Label, Library,
   RenderSym(..), BodySym(..), StateTypeSym(getType, listInnerType), 
   ValueSym(..), NumericExpression(..), BooleanExpression(..), InternalValue(..),
-  FunctionSym(..), SelectorFunction(..), StatementSym(..), 
+  FunctionSym(..), SelectorFunction(..), InternalStatement(..), StatementSym(..), 
   ControlStatementSym(..), ParameterSym(..), MethodSym(..), BlockCommentSym(..))
 import qualified Language.Drasil.Code.Imperative.Symantics as S (StateTypeSym(int))
 import Language.Drasil.Code.Imperative.Data (Terminator(..), FuncData(..), 

--- a/code/drasil-code/Language/Drasil/Code/Imperative/LanguageRenderer/CSharpRenderer.hs
+++ b/code/drasil-code/Language/Drasil/Code/Imperative/LanguageRenderer/CSharpRenderer.hs
@@ -15,7 +15,8 @@ import Language.Drasil.Code.Imperative.Symantics (Label,
   BodySym(..), BlockSym(..), ControlBlockSym(..), StateTypeSym(..),
   UnaryOpSym(..), BinaryOpSym(..), ValueSym(..), NumericExpression(..), 
   BooleanExpression(..), ValueExpression(..), InternalValue(..), Selector(..), 
-  FunctionSym(..), SelectorFunction(..), InternalFunction(..), StatementSym(..), 
+  FunctionSym(..), SelectorFunction(..), InternalFunction(..), 
+  InternalStatement(..), StatementSym(..), 
   ControlStatementSym(..), ScopeSym(..), MethodTypeSym(..), ParameterSym(..), 
   MethodSym(..), StateVarSym(..), ClassSym(..), ModuleSym(..), 
   BlockCommentSym(..))
@@ -365,6 +366,12 @@ instance InternalFunction CSharpCode where
 
   atFunc t l = listAccessFunc t (var l int)
 
+instance InternalStatement CSharpCode where
+  printSt _ p v _ = mkSt <$> liftA2 printDoc p v
+  
+  state = fmap statementDocD
+  loopState = fmap (statementDocD . setEmpty)
+
 instance StatementSym CSharpCode where
   type Statement CSharpCode = (Doc, Terminator)
   assign v1 v2 = mkSt <$> liftA2 assignDocD v1 v2
@@ -386,8 +393,6 @@ instance StatementSym CSharpCode where
   objDecNewVoid v = mkSt <$> liftA2 objDecDefDocD v (stateObj (valueType v) [])
   extObjDecNewVoid _ = objDecNewVoid
   constDecDef v def = mkSt <$> liftA2 constDecDefDocD v def
-
-  printSt _ p v _ = mkSt <$> liftA2 printDoc p v
 
   print v = outDoc False printFunc v Nothing
   printLn v = outDoc True printLnFunc v Nothing
@@ -442,8 +447,6 @@ instance StatementSym CSharpCode where
   inOutCall = csInOutCall funcApp
   extInOutCall m = csInOutCall (extFuncApp m)
 
-  state = fmap statementDocD
-  loopState = fmap (statementDocD . setEmpty)
   multi = lift1List multiStateDocD endStatement
 
 instance ControlStatementSym CSharpCode where

--- a/code/drasil-code/Language/Drasil/Code/Imperative/LanguageRenderer/CSharpRenderer.hs
+++ b/code/drasil-code/Language/Drasil/Code/Imperative/LanguageRenderer/CSharpRenderer.hs
@@ -11,14 +11,14 @@ import Utils.Drasil (indent)
 
 import Language.Drasil.Code.Code (CodeType(..))
 import Language.Drasil.Code.Imperative.Symantics (Label,
-  PackageSym(..), RenderSym(..), KeywordSym(..), PermanenceSym(..),
-  BodySym(..), BlockSym(..), ControlBlockSym(..), StateTypeSym(..),
-  UnaryOpSym(..), BinaryOpSym(..), ValueSym(..), NumericExpression(..), 
-  BooleanExpression(..), ValueExpression(..), InternalValue(..), Selector(..), 
-  FunctionSym(..), SelectorFunction(..), InternalFunction(..), 
-  InternalStatement(..), StatementSym(..), 
-  ControlStatementSym(..), ScopeSym(..), InternalScope(..), MethodTypeSym(..), ParameterSym(..), 
-  MethodSym(..), StateVarSym(..), ClassSym(..), ModuleSym(..), 
+  PackageSym(..), RenderSym(..), InternalFile(..), KeywordSym(..), 
+  PermanenceSym(..), BodySym(..), BlockSym(..), ControlBlockSym(..), 
+  StateTypeSym(..), UnaryOpSym(..), BinaryOpSym(..), ValueSym(..), 
+  NumericExpression(..), BooleanExpression(..), ValueExpression(..), 
+  InternalValue(..), Selector(..), FunctionSym(..), SelectorFunction(..), 
+  InternalFunction(..), InternalStatement(..), StatementSym(..), 
+  ControlStatementSym(..), ScopeSym(..), InternalScope(..), MethodTypeSym(..), 
+  ParameterSym(..), MethodSym(..), StateVarSym(..), ClassSym(..), ModuleSym(..),
   BlockCommentSym(..))
 import Language.Drasil.Code.Imperative.LanguageRenderer (
   fileDoc', moduleDocD, classDocD, enumDocD,
@@ -88,8 +88,6 @@ instance RenderSym CSharpCode where
   fileDoc code = liftA3 md (fmap name code) (fmap isMainMod code) 
     (liftA2 emptyIfEmpty (fmap modDoc code) $
       liftA3 fileDoc' (top code) (fmap modDoc code) bottom)
-  top _ = liftA2 cstop endStatement (include "")
-  bottom = return empty
 
   docMod d m = commentedMod (docComment $ moduleDoc d (moduleName m) csExt) m
 
@@ -97,6 +95,10 @@ instance RenderSym CSharpCode where
     (liftA2 commentedItem cmt (fmap modDoc m))
     
   moduleName m = name (unCSC m)
+
+instance InternalFile CSharpCode where
+  top _ = liftA2 cstop endStatement (include "")
+  bottom = return empty
 
 instance KeywordSym CSharpCode where
   type Keyword CSharpCode = Doc

--- a/code/drasil-code/Language/Drasil/Code/Imperative/LanguageRenderer/CSharpRenderer.hs
+++ b/code/drasil-code/Language/Drasil/Code/Imperative/LanguageRenderer/CSharpRenderer.hs
@@ -17,7 +17,7 @@ import Language.Drasil.Code.Imperative.Symantics (Label,
   BooleanExpression(..), ValueExpression(..), InternalValue(..), Selector(..), 
   FunctionSym(..), SelectorFunction(..), InternalFunction(..), 
   InternalStatement(..), StatementSym(..), 
-  ControlStatementSym(..), ScopeSym(..), MethodTypeSym(..), ParameterSym(..), 
+  ControlStatementSym(..), ScopeSym(..), InternalScope(..), MethodTypeSym(..), ParameterSym(..), 
   MethodSym(..), StateVarSym(..), ClassSym(..), ModuleSym(..), 
   BlockCommentSym(..))
 import Language.Drasil.Code.Imperative.LanguageRenderer (
@@ -486,6 +486,7 @@ instance ScopeSym CSharpCode where
   private = return privateDocD
   public = return publicDocD
 
+instance InternalScope CSharpCode where
   includeScope s = s
 
 instance MethodTypeSym CSharpCode where

--- a/code/drasil-code/Language/Drasil/Code/Imperative/LanguageRenderer/CSharpRenderer.hs
+++ b/code/drasil-code/Language/Drasil/Code/Imperative/LanguageRenderer/CSharpRenderer.hs
@@ -14,8 +14,8 @@ import Language.Drasil.Code.Imperative.Symantics (Label,
   PackageSym(..), RenderSym(..), KeywordSym(..), PermanenceSym(..),
   BodySym(..), BlockSym(..), ControlBlockSym(..), StateTypeSym(..),
   UnaryOpSym(..), BinaryOpSym(..), ValueSym(..), NumericExpression(..), 
-  BooleanExpression(..), ValueExpression(..), Selector(..), FunctionSym(..), 
-  SelectorFunction(..), StatementSym(..), 
+  BooleanExpression(..), ValueExpression(..), InternalValue(..), Selector(..), 
+  FunctionSym(..), SelectorFunction(..), StatementSym(..), 
   ControlStatementSym(..), ScopeSym(..), MethodTypeSym(..), ParameterSym(..), 
   MethodSym(..), StateVarSym(..), ClassSym(..), ModuleSym(..), 
   BlockCommentSym(..))
@@ -311,6 +311,9 @@ instance ValueExpression CSharpCode where
   notNull v = liftA2 mkVal bool (liftA3 notNullDocD notEqualOp v (var "null" 
     (fmap valType v)))
 
+instance InternalValue CSharpCode where
+  cast = csCast
+
 instance Selector CSharpCode where
   objAccess v f = liftA2 mkVal (fmap funcType f) (liftA2 objAccessDocD v f)
   ($.) = objAccess
@@ -325,8 +328,6 @@ instance Selector CSharpCode where
   argExists i = listAccess argsList (litInt $ fromIntegral i)
 
   indexOf l v = objAccess l (func "IndexOf" int [v])
-
-  cast = csCast
 
 instance FunctionSym CSharpCode where
   type Function CSharpCode = FuncData

--- a/code/drasil-code/Language/Drasil/Code/Imperative/LanguageRenderer/CSharpRenderer.hs
+++ b/code/drasil-code/Language/Drasil/Code/Imperative/LanguageRenderer/CSharpRenderer.hs
@@ -249,11 +249,6 @@ instance ValueSym CSharpCode where
   n `listOf` t = listVar n static_ t
   iterVar n t = var n (iterator t)
   
-  inputFunc = liftA2 mkVal string (return $ text "Console.ReadLine()")
-  printFunc = liftA2 mkVal void (return $ text "Console.Write")
-  printLnFunc = liftA2 mkVal void (return $ text "Console.WriteLine")
-  printFileFunc f = liftA2 mkVal void (fmap (printFileDocD "Write") f)
-  printFileLnFunc f = liftA2 mkVal void (fmap (printFileDocD "WriteLine") f)
   argsList = liftA2 mkVal (listType static_ string) (return $ text "args")
 
   valueName v = fromMaybe 
@@ -315,6 +310,12 @@ instance ValueExpression CSharpCode where
     (fmap valType v)))
 
 instance InternalValue CSharpCode where
+  inputFunc = liftA2 mkVal string (return $ text "Console.ReadLine()")
+  printFunc = liftA2 mkVal void (return $ text "Console.Write")
+  printLnFunc = liftA2 mkVal void (return $ text "Console.WriteLine")
+  printFileFunc f = liftA2 mkVal void (fmap (printFileDocD "Write") f)
+  printFileLnFunc f = liftA2 mkVal void (fmap (printFileDocD "WriteLine") f)
+  
   cast = csCast
 
 instance Selector CSharpCode where

--- a/code/drasil-code/Language/Drasil/Code/Imperative/LanguageRenderer/CppRenderer.hs
+++ b/code/drasil-code/Language/Drasil/Code/Imperative/LanguageRenderer/CppRenderer.hs
@@ -230,11 +230,6 @@ instance (Pair p) => ValueSym (p CppSrcCode CppHdrCode) where
   n `listOf` t = pair (n `listOf` pfst t) (n `listOf` psnd t)
   iterVar l t = pair (iterVar l $ pfst t) (iterVar l $ psnd t)
   
-  inputFunc = pair inputFunc inputFunc
-  printFunc = pair printFunc printFunc
-  printLnFunc = pair printLnFunc printLnFunc
-  printFileFunc v = pair (printFileFunc $ pfst v) (printFileFunc $ psnd v)
-  printFileLnFunc v = pair (printFileLnFunc $ pfst v) (printFileLnFunc $ psnd v)
   argsList = pair argsList argsList
 
   valueName v = valueName $ pfst v
@@ -298,6 +293,12 @@ instance (Pair p) => ValueExpression (p CppSrcCode CppHdrCode) where
   notNull v = pair (notNull $ pfst v) (notNull $ psnd v)
   
 instance (Pair p) => InternalValue (p CppSrcCode CppHdrCode) where
+  inputFunc = pair inputFunc inputFunc
+  printFunc = pair printFunc printFunc
+  printLnFunc = pair printLnFunc printLnFunc
+  printFileFunc v = pair (printFileFunc $ pfst v) (printFileFunc $ psnd v)
+  printFileLnFunc v = pair (printFileLnFunc $ pfst v) (printFileLnFunc $ psnd v)
+
   cast t v = pair (cast (pfst t) (pfst v)) (cast (psnd t) (psnd v))
 
 instance (Pair p) => Selector (p CppSrcCode CppHdrCode) where
@@ -785,11 +786,6 @@ instance ValueSym CppSrcCode where
   n `listOf` t = listVar n static_ t
   iterVar l t = liftA2 mkVal (iterator t) (return $ text $ "(*" ++ l ++ ")")
   
-  inputFunc = liftA2 mkVal string (return $ text "std::cin")
-  printFunc = liftA2 mkVal void (return $ text "std::cout")
-  printLnFunc = liftA2 mkVal void (return $ text "std::cout")
-  printFileFunc f = liftA2 mkVal void (fmap valDoc f) -- is this right?
-  printFileLnFunc f = liftA2 mkVal void (fmap valDoc f)
   argsList = liftA2 mkVal (listType static_ string) (return $ text "argv")
 
   valueName v = fromMaybe 
@@ -849,6 +845,12 @@ instance ValueExpression CppSrcCode where
   notNull v = v
 
 instance InternalValue CppSrcCode where
+  inputFunc = liftA2 mkVal string (return $ text "std::cin")
+  printFunc = liftA2 mkVal void (return $ text "std::cout")
+  printLnFunc = liftA2 mkVal void (return $ text "std::cout")
+  printFileFunc f = liftA2 mkVal void (fmap valDoc f) -- is this right?
+  printFileLnFunc f = liftA2 mkVal void (fmap valDoc f)
+
   cast = cppCast
 
 instance Selector CppSrcCode where
@@ -1319,11 +1321,6 @@ instance ValueSym CppHdrCode where
   listOf _ _ = liftA2 mkVal void (return empty)
   iterVar _ _ = liftA2 mkVal void (return empty)
   
-  inputFunc = liftA2 mkVal void (return empty)
-  printFunc = liftA2 mkVal void (return empty)
-  printLnFunc = liftA2 mkVal void (return empty)
-  printFileFunc _ = liftA2 mkVal void (return empty)
-  printFileLnFunc _ = liftA2 mkVal void (return empty)
   argsList = liftA2 mkVal void (return empty)
 
   valueName v = fromMaybe 
@@ -1382,6 +1379,12 @@ instance ValueExpression CppHdrCode where
   notNull _ = liftA2 mkVal void (return empty)
 
 instance InternalValue CppHdrCode where
+  inputFunc = liftA2 mkVal void (return empty)
+  printFunc = liftA2 mkVal void (return empty)
+  printLnFunc = liftA2 mkVal void (return empty)
+  printFileFunc _ = liftA2 mkVal void (return empty)
+  printFileLnFunc _ = liftA2 mkVal void (return empty)
+  
   cast _ _ = liftA2 mkVal void (return empty)
 
 instance Selector CppHdrCode where

--- a/code/drasil-code/Language/Drasil/Code/Imperative/LanguageRenderer/CppRenderer.hs
+++ b/code/drasil-code/Language/Drasil/Code/Imperative/LanguageRenderer/CppRenderer.hs
@@ -18,7 +18,7 @@ import Language.Drasil.Code.Imperative.Symantics (Label,
   BooleanExpression(..), ValueExpression(..), InternalValue(..), Selector(..), 
   FunctionSym(..), SelectorFunction(..), InternalFunction(..), 
   InternalStatement(..), StatementSym(..), 
-  ControlStatementSym(..), ScopeSym(..), MethodTypeSym(..), ParameterSym(..), 
+  ControlStatementSym(..), ScopeSym(..), InternalScope(..), MethodTypeSym(..), ParameterSym(..), 
   MethodSym(..), StateVarSym(..), ClassSym(..), ModuleSym(..), 
   BlockCommentSym(..))
 import Language.Drasil.Code.Imperative.LanguageRenderer (
@@ -509,6 +509,7 @@ instance (Pair p) => ScopeSym (p CppSrcCode CppHdrCode) where
   private = pair private private
   public = pair public public
 
+instance (Pair p) => InternalScope (p CppSrcCode CppHdrCode) where
   includeScope s = pair (includeScope $ pfst s) (includeScope $ psnd s)
 
 instance (Pair p) => MethodTypeSym (p CppSrcCode CppHdrCode) where
@@ -1035,6 +1036,7 @@ instance ScopeSym CppSrcCode where
   private = return (privateDocD, Priv)
   public = return (publicDocD, Pub)
 
+instance InternalScope CppSrcCode where
   includeScope _ = return (empty, Priv)
 
 instance MethodTypeSym CppSrcCode where
@@ -1531,6 +1533,7 @@ instance ScopeSym CppHdrCode where
   private = return (privateDocD, Priv)
   public = return (publicDocD, Pub)
 
+instance InternalScope CppHdrCode where
   includeScope _ = return (empty, Priv)
 
 instance MethodTypeSym CppHdrCode where

--- a/code/drasil-code/Language/Drasil/Code/Imperative/LanguageRenderer/CppRenderer.hs
+++ b/code/drasil-code/Language/Drasil/Code/Imperative/LanguageRenderer/CppRenderer.hs
@@ -12,14 +12,14 @@ import Utils.Drasil (indent, indentList)
 
 import Language.Drasil.Code.Code (CodeType(..))
 import Language.Drasil.Code.Imperative.Symantics (Label,
-  PackageSym(..), RenderSym(..), KeywordSym(..), PermanenceSym(..),
-  BodySym(..), BlockSym(..), ControlBlockSym(..), StateTypeSym(..),
-  UnaryOpSym(..), BinaryOpSym(..), ValueSym(..), NumericExpression(..), 
-  BooleanExpression(..), ValueExpression(..), InternalValue(..), Selector(..), 
-  FunctionSym(..), SelectorFunction(..), InternalFunction(..), 
-  InternalStatement(..), StatementSym(..), 
-  ControlStatementSym(..), ScopeSym(..), InternalScope(..), MethodTypeSym(..), ParameterSym(..), 
-  MethodSym(..), StateVarSym(..), ClassSym(..), ModuleSym(..), 
+  PackageSym(..), RenderSym(..), InternalFile(..), KeywordSym(..), 
+  PermanenceSym(..), BodySym(..), BlockSym(..), ControlBlockSym(..), 
+  StateTypeSym(..), UnaryOpSym(..), BinaryOpSym(..), ValueSym(..), 
+  NumericExpression(..), BooleanExpression(..), ValueExpression(..), 
+  InternalValue(..), Selector(..), FunctionSym(..), SelectorFunction(..), 
+  InternalFunction(..), InternalStatement(..), StatementSym(..), 
+  ControlStatementSym(..), ScopeSym(..), InternalScope(..), MethodTypeSym(..), 
+  ParameterSym(..), MethodSym(..), StateVarSym(..), ClassSym(..), ModuleSym(..),
   BlockCommentSym(..))
 import Language.Drasil.Code.Imperative.LanguageRenderer (
   fileDoc', enumElementsDocD, multiStateDocD, blockDocD, bodyDocD, outDoc,
@@ -86,8 +86,6 @@ instance (Pair p) => PackageSym (p CppSrcCode CppHdrCode) where
 instance (Pair p) => RenderSym (p CppSrcCode CppHdrCode) where
   type RenderFile (p CppSrcCode CppHdrCode) = ModData
   fileDoc code = pair (fileDoc $ pfst code) (fileDoc $ psnd code)
-  top m = pair (top $ pfst m) (top $ psnd m)
-  bottom = pair bottom bottom
 
   docMod d m = pair (docMod d $ pfst m) (docMod d $ psnd m)
 
@@ -95,6 +93,10 @@ instance (Pair p) => RenderSym (p CppSrcCode CppHdrCode) where
     (commentedMod (psnd cmt) (psnd m))
 
   moduleName m = moduleName $ pfst m
+
+instance (Pair p) => InternalFile (p CppSrcCode CppHdrCode) where
+  top m = pair (top $ pfst m) (top $ psnd m)
+  bottom = pair bottom bottom
 
 instance (Pair p) => KeywordSym (p CppSrcCode CppHdrCode) where
   type Keyword (p CppSrcCode CppHdrCode) = Doc
@@ -624,8 +626,6 @@ instance RenderSym CppSrcCode where
   fileDoc code = liftA3 md (fmap name code) (fmap isMainMod code)
     (liftA2 emptyIfEmpty (fmap modDoc code) $
       liftA3 fileDoc' (top code) (fmap modDoc code) bottom)
-  top m = liftA3 cppstop m (list dynamic_) endStatement
-  bottom = return empty
 
   docMod d m = commentedMod (docComment $ moduleDoc d (moduleName m) cppSrcExt) m
 
@@ -633,6 +633,10 @@ instance RenderSym CppSrcCode where
     (fmap isMainMod m) (liftA2 commentedItem cmt (fmap modDoc m)) else m 
     
   moduleName m = name (unCPPSC m)
+
+instance InternalFile CppSrcCode where
+  top m = liftA3 cppstop m (list dynamic_) endStatement
+  bottom = return empty
   
 instance KeywordSym CppSrcCode where
   type Keyword CppSrcCode = Doc
@@ -1176,8 +1180,6 @@ instance RenderSym CppHdrCode where
   fileDoc code = liftA3 md (fmap name code) (fmap isMainMod code) 
     (liftA2 emptyIfEmpty (fmap modDoc code) $
       liftA3 fileDoc' (top code) (fmap modDoc code) bottom)
-  top m = liftA3 cpphtop m (list dynamic_) endStatement
-  bottom = return $ text "#endif"
   
   docMod d m = commentedMod (docComment $ moduleDoc d (moduleName m) cppHdrExt) m
 
@@ -1186,6 +1188,10 @@ instance RenderSym CppHdrCode where
     (liftA2 commentedItem cmt (fmap modDoc m))
     
   moduleName m = name (unCPPHC m)
+
+instance InternalFile CppHdrCode where
+  top m = liftA3 cpphtop m (list dynamic_) endStatement
+  bottom = return $ text "#endif"
 
 instance KeywordSym CppHdrCode where
   type Keyword CppHdrCode = Doc

--- a/code/drasil-code/Language/Drasil/Code/Imperative/LanguageRenderer/JavaRenderer.hs
+++ b/code/drasil-code/Language/Drasil/Code/Imperative/LanguageRenderer/JavaRenderer.hs
@@ -11,14 +11,14 @@ import Utils.Drasil (indent)
 
 import Language.Drasil.Code.Code (CodeType(..))
 import Language.Drasil.Code.Imperative.Symantics (Label,
-  PackageSym(..), RenderSym(..), KeywordSym(..), PermanenceSym(..),
-  BodySym(..), BlockSym(..), ControlBlockSym(..), StateTypeSym(..),
-  UnaryOpSym(..), BinaryOpSym(..), ValueSym(..), NumericExpression(..), 
-  BooleanExpression(..), ValueExpression(..), InternalValue(..), Selector(..), 
-  FunctionSym(..), SelectorFunction(..), InternalFunction(..), 
-  InternalStatement(..), StatementSym(..), 
-  ControlStatementSym(..), ScopeSym(..), InternalScope(..), MethodTypeSym(..), ParameterSym(..), 
-  MethodSym(..), StateVarSym(..), ClassSym(..), ModuleSym(..), 
+  PackageSym(..), RenderSym(..), InternalFile(..), KeywordSym(..),
+  PermanenceSym(..), BodySym(..), BlockSym(..), ControlBlockSym(..), 
+  StateTypeSym(..), UnaryOpSym(..), BinaryOpSym(..), ValueSym(..), 
+  NumericExpression(..), BooleanExpression(..), ValueExpression(..), 
+  InternalValue(..), Selector(..), FunctionSym(..), SelectorFunction(..),
+  InternalFunction(..), InternalStatement(..), StatementSym(..), 
+  ControlStatementSym(..), ScopeSym(..), InternalScope(..), MethodTypeSym(..), 
+  ParameterSym(..), MethodSym(..), StateVarSym(..), ClassSym(..), ModuleSym(..),
   BlockCommentSym(..))
 import Language.Drasil.Code.Imperative.Build.AST (includeExt, 
   NameOpts(NameOpts), packSep)
@@ -93,8 +93,6 @@ instance RenderSym JavaCode where
   fileDoc code = liftA3 md (fmap name code) (fmap isMainMod code) 
     (liftA2 emptyIfEmpty (fmap modDoc code) $
       liftA3 fileDoc' (top code) (fmap modDoc code) bottom)
-  top _ = liftA3 jtop endStatement (include "") (list static_)
-  bottom = return empty
 
   docMod d m = commentedMod (docComment $ moduleDoc d (moduleName m) jExt) m
 
@@ -102,6 +100,10 @@ instance RenderSym JavaCode where
     (liftA2 commentedItem cmt (fmap modDoc m))
 
   moduleName m = name (unJC m)
+
+instance InternalFile JavaCode where
+  top _ = liftA3 jtop endStatement (include "") (list static_)
+  bottom = return empty
 
 instance KeywordSym JavaCode where
   type Keyword JavaCode = Doc

--- a/code/drasil-code/Language/Drasil/Code/Imperative/LanguageRenderer/JavaRenderer.hs
+++ b/code/drasil-code/Language/Drasil/Code/Imperative/LanguageRenderer/JavaRenderer.hs
@@ -17,7 +17,7 @@ import Language.Drasil.Code.Imperative.Symantics (Label,
   BooleanExpression(..), ValueExpression(..), InternalValue(..), Selector(..), 
   FunctionSym(..), SelectorFunction(..), InternalFunction(..), 
   InternalStatement(..), StatementSym(..), 
-  ControlStatementSym(..), ScopeSym(..), MethodTypeSym(..), ParameterSym(..), 
+  ControlStatementSym(..), ScopeSym(..), InternalScope(..), MethodTypeSym(..), ParameterSym(..), 
   MethodSym(..), StateVarSym(..), ClassSym(..), ModuleSym(..), 
   BlockCommentSym(..))
 import Language.Drasil.Code.Imperative.Build.AST (includeExt, 
@@ -493,6 +493,7 @@ instance ScopeSym JavaCode where
   private = return privateDocD
   public = return publicDocD
 
+instance InternalScope JavaCode where
   includeScope s = s
 
 instance MethodTypeSym JavaCode where

--- a/code/drasil-code/Language/Drasil/Code/Imperative/LanguageRenderer/JavaRenderer.hs
+++ b/code/drasil-code/Language/Drasil/Code/Imperative/LanguageRenderer/JavaRenderer.hs
@@ -15,7 +15,8 @@ import Language.Drasil.Code.Imperative.Symantics (Label,
   BodySym(..), BlockSym(..), ControlBlockSym(..), StateTypeSym(..),
   UnaryOpSym(..), BinaryOpSym(..), ValueSym(..), NumericExpression(..), 
   BooleanExpression(..), ValueExpression(..), InternalValue(..), Selector(..), 
-  FunctionSym(..), SelectorFunction(..), InternalFunction(..), StatementSym(..), 
+  FunctionSym(..), SelectorFunction(..), InternalFunction(..), 
+  InternalStatement(..), StatementSym(..), 
   ControlStatementSym(..), ScopeSym(..), MethodTypeSym(..), ParameterSym(..), 
   MethodSym(..), StateVarSym(..), ClassSym(..), ModuleSym(..), 
   BlockCommentSym(..))
@@ -369,6 +370,12 @@ instance InternalFunction JavaCode where
 
   atFunc t l = listAccessFunc t (var l int)
 
+instance InternalStatement JavaCode where
+  printSt _ p v _ = mkSt <$> liftA2 printDoc p v
+
+  state = fmap statementDocD
+  loopState = fmap (statementDocD . setEmpty)
+
 instance StatementSym JavaCode where
   -- Terminator determines how statements end
   type Statement JavaCode = (Doc, Terminator)
@@ -391,8 +398,6 @@ instance StatementSym JavaCode where
   objDecNewVoid v = mkSt <$> liftA2 objDecDefDocD v (stateObj (valueType v) [])
   extObjDecNewVoid _ = objDecNewVoid
   constDecDef v def = mkSt <$> liftA2 jConstDecDef v def
-
-  printSt _ p v _ = mkSt <$> liftA2 printDoc p v
 
   print v = outDoc False printFunc v Nothing
   printLn v = outDoc True printLnFunc v Nothing
@@ -449,8 +454,6 @@ instance StatementSym JavaCode where
   inOutCall = jInOutCall funcApp
   extInOutCall m = jInOutCall (extFuncApp m)
 
-  state = fmap statementDocD
-  loopState = fmap (statementDocD . setEmpty)
   multi = lift1List multiStateDocD endStatement
 
 instance ControlStatementSym JavaCode where

--- a/code/drasil-code/Language/Drasil/Code/Imperative/LanguageRenderer/JavaRenderer.hs
+++ b/code/drasil-code/Language/Drasil/Code/Imperative/LanguageRenderer/JavaRenderer.hs
@@ -253,12 +253,6 @@ instance ValueSym JavaCode where
   n `listOf` t = listVar n static_ t
   iterVar n t = var n (iterator t)
   
-  inputFunc = liftA2 mkVal (obj "Scanner") (return $ parens (
-    text "new Scanner(System.in)"))
-  printFunc = liftA2 mkVal void (return $ text "System.out.print")
-  printLnFunc = liftA2 mkVal void (return $ text "System.out.println")
-  printFileFunc f = liftA2 mkVal void (fmap (printFileDocD "print") f)
-  printFileLnFunc f = liftA2 mkVal void (fmap (printFileDocD "println") f)
   argsList = liftA2 mkVal (listType static_ string) (return $ text "args")
 
   valueName v = fromMaybe 
@@ -320,6 +314,13 @@ instance ValueExpression JavaCode where
     (fmap valType v)))
 
 instance InternalValue JavaCode where
+  inputFunc = liftA2 mkVal (obj "Scanner") (return $ parens (
+    text "new Scanner(System.in)"))
+  printFunc = liftA2 mkVal void (return $ text "System.out.print")
+  printLnFunc = liftA2 mkVal void (return $ text "System.out.println")
+  printFileFunc f = liftA2 mkVal void (fmap (printFileDocD "print") f)
+  printFileLnFunc f = liftA2 mkVal void (fmap (printFileDocD "println") f)
+  
   cast = jCast
 
 instance Selector JavaCode where

--- a/code/drasil-code/Language/Drasil/Code/Imperative/LanguageRenderer/JavaRenderer.hs
+++ b/code/drasil-code/Language/Drasil/Code/Imperative/LanguageRenderer/JavaRenderer.hs
@@ -14,8 +14,8 @@ import Language.Drasil.Code.Imperative.Symantics (Label,
   PackageSym(..), RenderSym(..), KeywordSym(..), PermanenceSym(..),
   BodySym(..), BlockSym(..), ControlBlockSym(..), StateTypeSym(..),
   UnaryOpSym(..), BinaryOpSym(..), ValueSym(..), NumericExpression(..), 
-  BooleanExpression(..), ValueExpression(..), Selector(..), FunctionSym(..), 
-  SelectorFunction(..), StatementSym(..), 
+  BooleanExpression(..), ValueExpression(..), InternalValue(..), Selector(..), 
+  FunctionSym(..), SelectorFunction(..), StatementSym(..), 
   ControlStatementSym(..), ScopeSym(..), MethodTypeSym(..), ParameterSym(..), 
   MethodSym(..), StateVarSym(..), ClassSym(..), ModuleSym(..), 
   BlockCommentSym(..))
@@ -316,6 +316,9 @@ instance ValueExpression JavaCode where
   notNull v = liftA2 mkVal bool (liftA3 notNullDocD notEqualOp v (var "null"
     (fmap valType v)))
 
+instance InternalValue JavaCode where
+  cast = jCast
+
 instance Selector JavaCode where
   objAccess v f = liftA2 mkVal (fmap funcType f) (liftA2 objAccessDocD v f)
   ($.) = objAccess
@@ -330,8 +333,6 @@ instance Selector JavaCode where
   argExists i = listAccess argsList (litInt $ fromIntegral i)
 
   indexOf l v = objAccess l (func "indexOf" int [v])
-
-  cast = jCast
 
 instance FunctionSym JavaCode where
   type Function JavaCode = FuncData

--- a/code/drasil-code/Language/Drasil/Code/Imperative/LanguageRenderer/PythonRenderer.hs
+++ b/code/drasil-code/Language/Drasil/Code/Imperative/LanguageRenderer/PythonRenderer.hs
@@ -16,7 +16,7 @@ import Language.Drasil.Code.Imperative.Symantics (Label,
   BooleanExpression(..), ValueExpression(..), InternalValue(..), Selector(..), 
   FunctionSym(..), SelectorFunction(..), InternalFunction(..), 
   InternalStatement(..), StatementSym(..), 
-  ControlStatementSym(..), ScopeSym(..), MethodTypeSym(..), ParameterSym(..), 
+  ControlStatementSym(..), ScopeSym(..), InternalScope(..), MethodTypeSym(..), ParameterSym(..), 
   MethodSym(..), StateVarSym(..), ClassSym(..), ModuleSym(..), 
   BlockCommentSym(..))
 import Language.Drasil.Code.Imperative.LanguageRenderer (fileDoc', 
@@ -471,6 +471,7 @@ instance ScopeSym PythonCode where
   private = return empty
   public = return empty
 
+instance InternalScope PythonCode where
   includeScope s = s
 
 instance MethodTypeSym PythonCode where

--- a/code/drasil-code/Language/Drasil/Code/Imperative/LanguageRenderer/PythonRenderer.hs
+++ b/code/drasil-code/Language/Drasil/Code/Imperative/LanguageRenderer/PythonRenderer.hs
@@ -231,11 +231,6 @@ instance ValueSym PythonCode where
   n `listOf` t = listVar n static_ t
   iterVar n t = var n (iterator t)
 
-  inputFunc = liftA2 mkVal string (return $ text "input()")  -- raw_input() for < Python 3.0
-  printFunc = liftA2 mkVal void (return $ text "print")
-  printLnFunc = liftA2 mkVal void (return empty)
-  printFileFunc _ = liftA2 mkVal void (return empty)
-  printFileLnFunc _ = liftA2 mkVal void (return empty)
   argsList = liftA2 mkVal (listType static_ string) (return $ text "sys.argv")
 
   valueName v = fromMaybe 
@@ -297,6 +292,12 @@ instance ValueExpression PythonCode where
   notNull = exists
 
 instance InternalValue PythonCode where
+  inputFunc = liftA2 mkVal string (return $ text "input()")  -- raw_input() for < Python 3.0
+  printFunc = liftA2 mkVal void (return $ text "print")
+  printLnFunc = liftA2 mkVal void (return empty)
+  printFileFunc _ = liftA2 mkVal void (return empty)
+  printFileLnFunc _ = liftA2 mkVal void (return empty)
+  
   cast t v = liftA2 mkVal t $ liftA2 castObjDocD (fmap typeDoc t) v
 
 instance Selector PythonCode where

--- a/code/drasil-code/Language/Drasil/Code/Imperative/LanguageRenderer/PythonRenderer.hs
+++ b/code/drasil-code/Language/Drasil/Code/Imperative/LanguageRenderer/PythonRenderer.hs
@@ -10,14 +10,14 @@ import Utils.Drasil (indent)
 
 import Language.Drasil.Code.Code (CodeType(..))
 import Language.Drasil.Code.Imperative.Symantics (Label,
-  PackageSym(..), RenderSym(..), KeywordSym(..), PermanenceSym(..),
-  BodySym(..), BlockSym(..), ControlBlockSym(..), StateTypeSym(..),
-  UnaryOpSym(..), BinaryOpSym(..), ValueSym(..), NumericExpression(..), 
-  BooleanExpression(..), ValueExpression(..), InternalValue(..), Selector(..), 
-  FunctionSym(..), SelectorFunction(..), InternalFunction(..), 
-  InternalStatement(..), StatementSym(..), 
-  ControlStatementSym(..), ScopeSym(..), InternalScope(..), MethodTypeSym(..), ParameterSym(..), 
-  MethodSym(..), StateVarSym(..), ClassSym(..), ModuleSym(..), 
+  PackageSym(..), RenderSym(..), InternalFile(..), KeywordSym(..), 
+  PermanenceSym(..), BodySym(..), BlockSym(..), ControlBlockSym(..), 
+  StateTypeSym(..), UnaryOpSym(..), BinaryOpSym(..), ValueSym(..), 
+  NumericExpression(..), BooleanExpression(..), ValueExpression(..), 
+  InternalValue(..), Selector(..), FunctionSym(..), SelectorFunction(..), 
+  InternalFunction(..), InternalStatement(..), StatementSym(..), 
+  ControlStatementSym(..), ScopeSym(..), InternalScope(..), MethodTypeSym(..),
+  ParameterSym(..), MethodSym(..), StateVarSym(..), ClassSym(..), ModuleSym(..),
   BlockCommentSym(..))
 import Language.Drasil.Code.Imperative.LanguageRenderer (fileDoc', 
   enumElementsDocD', multiStateDocD, blockDocD, bodyDocD, outDoc, intTypeDocD, 
@@ -79,8 +79,6 @@ instance RenderSym PythonCode where
   fileDoc code = liftA3 md (fmap name code) (fmap isMainMod code) 
     (liftA2 emptyIfEmpty (fmap modDoc code) $
       liftA3 fileDoc' (top code) (fmap modDoc code) bottom)
-  top _ = return pytop
-  bottom = return empty
 
   docMod d m = commentedMod (docComment $ moduleDoc d (moduleName m) pyExt) m
 
@@ -88,6 +86,10 @@ instance RenderSym PythonCode where
     (liftA2 commentedItem cmt (fmap modDoc m))
 
   moduleName m = name (unPC m)
+
+instance InternalFile PythonCode where
+  top _ = return pytop
+  bottom = return empty
 
 instance KeywordSym PythonCode where
   type Keyword PythonCode = Doc

--- a/code/drasil-code/Language/Drasil/Code/Imperative/LanguageRenderer/PythonRenderer.hs
+++ b/code/drasil-code/Language/Drasil/Code/Imperative/LanguageRenderer/PythonRenderer.hs
@@ -13,8 +13,8 @@ import Language.Drasil.Code.Imperative.Symantics (Label,
   PackageSym(..), RenderSym(..), KeywordSym(..), PermanenceSym(..),
   BodySym(..), BlockSym(..), ControlBlockSym(..), StateTypeSym(..),
   UnaryOpSym(..), BinaryOpSym(..), ValueSym(..), NumericExpression(..), 
-  BooleanExpression(..), ValueExpression(..), Selector(..), FunctionSym(..), 
-  SelectorFunction(..), StatementSym(..), 
+  BooleanExpression(..), ValueExpression(..), InternalValue(..), Selector(..), 
+  FunctionSym(..), SelectorFunction(..), StatementSym(..), 
   ControlStatementSym(..), ScopeSym(..), MethodTypeSym(..), ParameterSym(..), 
   MethodSym(..), StateVarSym(..), ClassSym(..), ModuleSym(..), 
   BlockCommentSym(..))
@@ -293,6 +293,9 @@ instance ValueExpression PythonCode where
   exists v = v ?!= var "None" void
   notNull = exists
 
+instance InternalValue PythonCode where
+  cast t v = liftA2 mkVal t $ liftA2 castObjDocD (fmap typeDoc t) v
+
 instance Selector PythonCode where
   objAccess v f = liftA2 mkVal (fmap funcType f) (liftA2 objAccessDocD v f)
   ($.) = objAccess 
@@ -306,8 +309,6 @@ instance Selector PythonCode where
   argExists i = listAccess argsList (litInt $ fromIntegral i)
   
   indexOf l v = objAccess l (func "index" int [v])
-
-  cast t v = liftA2 mkVal t $ liftA2 castObjDocD (fmap typeDoc t) v
 
 instance FunctionSym PythonCode where
   type Function PythonCode = FuncData

--- a/code/drasil-code/Language/Drasil/Code/Imperative/Symantics.hs
+++ b/code/drasil-code/Language/Drasil/Code/Imperative/Symantics.hs
@@ -176,11 +176,6 @@ class (StateTypeSym repr, StateVarSym repr) => ValueSym repr where
   -- Use for iterator variables, i.e. in a forEach loop.
   iterVar      :: Label -> repr (StateType repr) -> repr (Value repr)
 
-  inputFunc :: repr (Value repr)
-  printFunc       :: repr (Value repr)
-  printLnFunc     :: repr (Value repr)
-  printFileFunc   :: repr (Value repr) -> repr (Value repr)
-  printFileLnFunc :: repr (Value repr) -> repr (Value repr)
   argsList  :: repr (Value repr)
 
   valueName :: repr (Value repr) -> String -- Function for converting a value to a string of the value's name
@@ -270,6 +265,12 @@ class (ValueSym repr, NumericExpression repr, BooleanExpression repr) =>
   notNull :: repr (Value repr) -> repr (Value repr)
 
 class (ValueExpression repr) => InternalValue repr where
+  inputFunc       :: repr (Value repr)
+  printFunc       :: repr (Value repr)
+  printLnFunc     :: repr (Value repr)
+  printFileFunc   :: repr (Value repr) -> repr (Value repr)
+  printFileLnFunc :: repr (Value repr) -> repr (Value repr)
+
   cast :: repr (StateType repr) -> repr (Value repr) -> repr (Value repr)
 
 -- The cyclic constraints issue arises here too. I've constrained this by ValueExpression,

--- a/code/drasil-code/Language/Drasil/Code/Imperative/Symantics.hs
+++ b/code/drasil-code/Language/Drasil/Code/Imperative/Symantics.hs
@@ -8,7 +8,7 @@ module Language.Drasil.Code.Imperative.Symantics (
   BodySym(..), ControlBlockSym(..), BlockSym(..), StateTypeSym(..), 
   UnaryOpSym(..), BinaryOpSym(..), ValueSym(..), NumericExpression(..), 
   BooleanExpression(..), ValueExpression(..), InternalValue(..), Selector(..), 
-  FunctionSym(..), SelectorFunction(..), StatementSym(..), 
+  FunctionSym(..), SelectorFunction(..), InternalFunction(..), StatementSym(..), 
   ControlStatementSym(..), ScopeSym(..), MethodTypeSym(..), ParameterSym(..), 
   MethodSym(..), StateVarSym(..), ClassSym(..), ModuleSym(..), 
   BlockCommentSym(..)
@@ -296,17 +296,6 @@ class (ValueSym repr, ValueExpression repr) => FunctionSym repr where
   type Function repr
   func           :: Label -> repr (StateType repr) -> [repr (Value repr)] -> 
     repr (Function repr)
-  getFunc        :: repr (Value repr) -> repr (Function repr)
-  setFunc        :: repr (StateType repr) -> repr (Value repr) -> 
-    repr (Value repr) -> repr (Function repr)
-
-  listSizeFunc       :: repr (Function repr)
-  listAddFunc        :: repr (Value repr) -> repr (Value repr) -> 
-    repr (Value repr) -> repr (Function repr)
-  listAppendFunc         :: repr (Value repr) -> repr (Function repr)
-
-  iterBeginFunc :: repr (StateType repr) -> repr (Function repr)
-  iterEndFunc   :: repr (StateType repr) -> repr (Function repr)
 
   get :: repr (Value repr) -> repr (Value repr) -> repr (Value repr)
   set :: repr (Value repr) -> repr (Value repr) -> repr (Value repr) -> 
@@ -322,17 +311,30 @@ class (ValueSym repr, ValueExpression repr) => FunctionSym repr where
 
 class (ValueSym repr, InternalValue repr, FunctionSym repr, Selector repr) => 
   SelectorFunction repr where
+  listAccess :: repr (Value repr) -> repr (Value repr) -> repr (Value repr)
+  listSet    :: repr (Value repr) -> repr (Value repr) -> repr (Value repr) ->
+    repr (Value repr)
+  at         :: repr (Value repr) -> Label -> repr (Value repr)
+
+class (ValueSym repr, InternalValue repr) => InternalFunction repr where
+  getFunc        :: repr (Value repr) -> repr (Function repr)
+  setFunc        :: repr (StateType repr) -> repr (Value repr) -> 
+    repr (Value repr) -> repr (Function repr)
+
+  listSizeFunc       :: repr (Function repr)
+  listAddFunc        :: repr (Value repr) -> repr (Value repr) -> 
+    repr (Value repr) -> repr (Function repr)
+  listAppendFunc         :: repr (Value repr) -> repr (Function repr)
+
+  iterBeginFunc :: repr (StateType repr) -> repr (Function repr)
+  iterEndFunc   :: repr (StateType repr) -> repr (Function repr)
+
   listAccessFunc :: repr (StateType repr) -> repr (Value repr) -> 
     repr (Function repr)
   listSetFunc    :: repr (Value repr) -> repr (Value repr) -> 
     repr (Value repr) -> repr (Function repr)
 
   atFunc :: repr (StateType repr) -> Label -> repr (Function repr)
-
-  listAccess :: repr (Value repr) -> repr (Value repr) -> repr (Value repr)
-  listSet    :: repr (Value repr) -> repr (Value repr) -> repr (Value repr) ->
-    repr (Value repr)
-  at         :: repr (Value repr) -> Label -> repr (Value repr)
 
 class (ValueSym repr, Selector repr, SelectorFunction repr, FunctionSym repr) 
   => StatementSym repr where

--- a/code/drasil-code/Language/Drasil/Code/Imperative/Symantics.hs
+++ b/code/drasil-code/Language/Drasil/Code/Imperative/Symantics.hs
@@ -4,14 +4,14 @@ module Language.Drasil.Code.Imperative.Symantics (
   -- Types
   Label, Library,
   -- Typeclasses
-  PackageSym(..), RenderSym(..), KeywordSym(..), PermanenceSym(..),
-  BodySym(..), ControlBlockSym(..), BlockSym(..), StateTypeSym(..), 
-  UnaryOpSym(..), BinaryOpSym(..), ValueSym(..), NumericExpression(..), 
-  BooleanExpression(..), ValueExpression(..), InternalValue(..), Selector(..), 
-  FunctionSym(..), SelectorFunction(..), InternalFunction(..), 
-  InternalStatement(..), StatementSym(..), 
-  ControlStatementSym(..), ScopeSym(..), InternalScope(..), MethodTypeSym(..), ParameterSym(..), 
-  MethodSym(..), StateVarSym(..), ClassSym(..), ModuleSym(..), 
+  PackageSym(..), RenderSym(..), InternalFile(..), KeywordSym(..), 
+  PermanenceSym(..), BodySym(..), ControlBlockSym(..), BlockSym(..), 
+  StateTypeSym(..), UnaryOpSym(..), BinaryOpSym(..), ValueSym(..), 
+  NumericExpression(..), BooleanExpression(..), ValueExpression(..), 
+  InternalValue(..), Selector(..), FunctionSym(..), SelectorFunction(..), 
+  InternalFunction(..), InternalStatement(..), StatementSym(..), 
+  ControlStatementSym(..), ScopeSym(..), InternalScope(..), MethodTypeSym(..), 
+  ParameterSym(..), MethodSym(..), StateVarSym(..), ClassSym(..), ModuleSym(..),
   BlockCommentSym(..)
 ) where
 
@@ -24,11 +24,10 @@ class (RenderSym repr) => PackageSym repr where
   type Package repr 
   packMods :: Label -> [repr (RenderFile repr)] -> repr (Package repr)
 
-class (ModuleSym repr, ControlBlockSym repr) => RenderSym repr where
+class (ModuleSym repr, ControlBlockSym repr, InternalFile repr) => 
+  RenderSym repr where 
   type RenderFile repr
   fileDoc :: repr (Module repr) -> repr (RenderFile repr)
-  top :: repr (Module repr) -> repr (Block repr)
-  bottom :: repr (Block repr)
 
   docMod :: String -> repr (RenderFile repr) -> repr (RenderFile repr)
 
@@ -36,6 +35,10 @@ class (ModuleSym repr, ControlBlockSym repr) => RenderSym repr where
     repr (RenderFile repr)
 
   moduleName :: repr (RenderFile repr) -> String
+
+class (ModuleSym repr) => InternalFile repr where
+  top :: repr (Module repr) -> repr (Block repr)
+  bottom :: repr (Block repr)
 
 class (ValueSym repr, PermanenceSym repr) => KeywordSym repr where
   type Keyword repr

--- a/code/drasil-code/Language/Drasil/Code/Imperative/Symantics.hs
+++ b/code/drasil-code/Language/Drasil/Code/Imperative/Symantics.hs
@@ -10,7 +10,7 @@ module Language.Drasil.Code.Imperative.Symantics (
   BooleanExpression(..), ValueExpression(..), InternalValue(..), Selector(..), 
   FunctionSym(..), SelectorFunction(..), InternalFunction(..), 
   InternalStatement(..), StatementSym(..), 
-  ControlStatementSym(..), ScopeSym(..), MethodTypeSym(..), ParameterSym(..), 
+  ControlStatementSym(..), ScopeSym(..), InternalScope(..), MethodTypeSym(..), ParameterSym(..), 
   MethodSym(..), StateVarSym(..), ClassSym(..), ModuleSym(..), 
   BlockCommentSym(..)
 ) where
@@ -481,6 +481,7 @@ class ScopeSym repr where
   private :: repr (Scope repr)
   public  :: repr (Scope repr)
 
+class (ScopeSym repr) => InternalScope repr where
   includeScope :: repr (Scope repr) -> repr (Scope repr)
 
 class MethodTypeSym repr where
@@ -535,8 +536,8 @@ class (ScopeSym repr, MethodTypeSym repr, ParameterSym repr, StateVarSym repr,
 
   parameters :: repr (Method repr) -> [repr (Parameter repr)]
 
-class (ScopeSym repr, PermanenceSym repr, StateTypeSym repr) => 
-  StateVarSym repr where
+class (ScopeSym repr, InternalScope repr, PermanenceSym repr, StateTypeSym repr)
+   => StateVarSym repr where
   type StateVar repr
   stateVar :: Int -> repr (Scope repr) -> repr (Permanence repr) ->
     repr (Value repr) -> repr (StateVar repr)

--- a/code/drasil-code/Language/Drasil/Code/Imperative/Symantics.hs
+++ b/code/drasil-code/Language/Drasil/Code/Imperative/Symantics.hs
@@ -7,8 +7,8 @@ module Language.Drasil.Code.Imperative.Symantics (
   PackageSym(..), RenderSym(..), KeywordSym(..), PermanenceSym(..),
   BodySym(..), ControlBlockSym(..), BlockSym(..), StateTypeSym(..), 
   UnaryOpSym(..), BinaryOpSym(..), ValueSym(..), NumericExpression(..), 
-  BooleanExpression(..), ValueExpression(..), Selector(..), FunctionSym(..), 
-  SelectorFunction(..), StatementSym(..), 
+  BooleanExpression(..), ValueExpression(..), InternalValue(..), Selector(..), 
+  FunctionSym(..), SelectorFunction(..), StatementSym(..), 
   ControlStatementSym(..), ScopeSym(..), MethodTypeSym(..), ParameterSym(..), 
   MethodSym(..), StateVarSym(..), ClassSym(..), ModuleSym(..), 
   BlockCommentSym(..)
@@ -265,6 +265,9 @@ class (ValueSym repr, NumericExpression repr, BooleanExpression repr) =>
   exists  :: repr (Value repr) -> repr (Value repr)
   notNull :: repr (Value repr) -> repr (Value repr)
 
+class (ValueExpression repr) => InternalValue repr where
+  cast :: repr (StateType repr) -> repr (Value repr) -> repr (Value repr)
+
 -- The cyclic constraints issue arises here too. I've constrained this by ValueExpression,
 -- but really one might want one of these values as part of an expression, so the
 -- constraint would have to go both ways. I'm not sure what the solution is for
@@ -288,8 +291,6 @@ class (FunctionSym repr, ValueSym repr, ValueExpression repr) =>
   argExists       :: Integer -> repr (Value repr)
 
   indexOf :: repr (Value repr) -> repr (Value repr) -> repr (Value repr)
-
-  cast :: repr (StateType repr) -> repr (Value repr) -> repr (Value repr)
 
 class (ValueSym repr, ValueExpression repr) => FunctionSym repr where
   type Function repr
@@ -319,7 +320,7 @@ class (ValueSym repr, ValueExpression repr) => FunctionSym repr where
   iterBegin :: repr (Value repr) -> repr (Value repr)
   iterEnd   :: repr (Value repr) -> repr (Value repr)
 
-class (ValueSym repr, FunctionSym repr, Selector repr) => 
+class (ValueSym repr, InternalValue repr, FunctionSym repr, Selector repr) => 
   SelectorFunction repr where
   listAccessFunc :: repr (StateType repr) -> repr (Value repr) -> 
     repr (Function repr)

--- a/code/drasil-code/Language/Drasil/Code/Imperative/Symantics.hs
+++ b/code/drasil-code/Language/Drasil/Code/Imperative/Symantics.hs
@@ -8,7 +8,8 @@ module Language.Drasil.Code.Imperative.Symantics (
   BodySym(..), ControlBlockSym(..), BlockSym(..), StateTypeSym(..), 
   UnaryOpSym(..), BinaryOpSym(..), ValueSym(..), NumericExpression(..), 
   BooleanExpression(..), ValueExpression(..), InternalValue(..), Selector(..), 
-  FunctionSym(..), SelectorFunction(..), InternalFunction(..), StatementSym(..), 
+  FunctionSym(..), SelectorFunction(..), InternalFunction(..), 
+  InternalStatement(..), StatementSym(..), 
   ControlStatementSym(..), ScopeSym(..), MethodTypeSym(..), ParameterSym(..), 
   MethodSym(..), StateVarSym(..), ClassSym(..), ModuleSym(..), 
   BlockCommentSym(..)
@@ -336,8 +337,16 @@ class (ValueSym repr, InternalValue repr) => InternalFunction repr where
 
   atFunc :: repr (StateType repr) -> Label -> repr (Function repr)
 
-class (ValueSym repr, Selector repr, SelectorFunction repr, FunctionSym repr) 
-  => StatementSym repr where
+class (Selector repr) => InternalStatement repr where
+  -- newLn, printFunc, value to print, maybe a file to print to 
+  printSt :: Bool -> repr (Value repr) -> repr (Value repr) -> 
+    Maybe (repr (Value repr)) -> repr (Statement repr)
+
+  state     :: repr (Statement repr) -> repr (Statement repr)
+  loopState :: repr (Statement repr) -> repr (Statement repr)
+
+class (ValueSym repr, Selector repr, SelectorFunction repr, FunctionSym repr,
+  InternalFunction repr, InternalStatement repr) => StatementSym repr where
   type Statement repr
   (&=)   :: repr (Value repr) -> repr (Value repr) -> repr (Statement repr)
   infixr 1 &=
@@ -373,9 +382,6 @@ class (ValueSym repr, Selector repr, SelectorFunction repr, FunctionSym repr)
   extObjDecNewVoid :: Library -> repr (Value repr) -> repr (Statement repr)
   constDecDef      :: repr (Value repr) -> repr (Value repr) -> 
     repr (Statement repr)
-
-  -- newLn, printFunc, value to print, maybe a file to print to 
-  printSt :: Bool -> repr (Value repr) -> repr (Value repr) -> Maybe (repr (Value repr)) -> repr (Statement repr)
 
   print      :: repr (Value repr) -> repr (Statement repr)
   printLn    :: repr (Value repr) -> repr (Statement repr)
@@ -438,8 +444,6 @@ class (ValueSym repr, Selector repr, SelectorFunction repr, FunctionSym repr)
   extInOutCall :: Library -> Label -> [repr (Value repr)] ->
     [repr (Value repr)] -> repr (Statement repr)
 
-  state     :: repr (Statement repr) -> repr (Statement repr)
-  loopState :: repr (Statement repr) -> repr (Statement repr)
   multi     :: [repr (Statement repr)] -> repr (Statement repr)
 
 class (StatementSym repr, BodySym repr) => ControlStatementSym repr where

--- a/code/drasil-code/Test/FileTests.hs
+++ b/code/drasil-code/Test/FileTests.hs
@@ -1,8 +1,8 @@
 module Test.FileTests (fileTests) where
 
 import Language.Drasil.Code (PackageSym(..), RenderSym(..), PermanenceSym(..),
-  BodySym(..), BlockSym(..), StateTypeSym(..), 
-  StatementSym(..), ControlStatementSym(..), ValueSym(..), Selector(..),
+  BodySym(..), BlockSym(..), StateTypeSym(..), StatementSym(..), 
+  ControlStatementSym(..), ValueSym(..),
   MethodSym(..), ModuleSym(..))
 import Prelude hiding (return,print,log,exp,sin,cos,tan)
 
@@ -15,9 +15,6 @@ fileTestMethod = mainMethod "FileTests" (body [writeStory, block [readStory],
 
 writeStory :: (RenderSym repr) => repr (Block repr)
 writeStory = block [
-  varDecDef (var "e" int) (litInt 5),
-  varDec $ var "f" float,
-  var "f" float &= cast float (var "e" int),
   varDec $ var "fileToWrite" outfile,
 
   openFileW (var "fileToWrite" outfile) (litString "testText.txt"),


### PR DESCRIPTION
This PR closes #1688 by separating many of GOOL's functions into "Internal" classes that do not get exported from the drasil-code subpackage.