### PR TITLE
Construct file paths within GOOL

### DIFF
--- a/code/drasil-code/Language/Drasil/Code/CodeGeneration.hs
+++ b/code/drasil-code/Language/Drasil/Code/CodeGeneration.hs
@@ -10,6 +10,8 @@ import Language.Drasil.Code.Code (Code(..))
 import Language.Drasil.Code.Imperative.Data (FileData(..), ModData(modDoc))
 
 import Text.PrettyPrint.HughesPJ (Doc,render)
+import System.Directory (createDirectoryIfMissing)
+import System.FilePath.Posix (takeDirectory)
 import System.IO (hPutStrLn, hClose, openFile, IOMode(WriteMode))
 
 -- | Takes code
@@ -28,6 +30,7 @@ createCodeFiles (Code cs) = mapM_ createCodeFile cs
 
 createCodeFile :: (FilePath, Doc) -> IO ()
 createCodeFile (path, code) = do
+  createDirectoryIfMissing True (takeDirectory path)
   h <- openFile path WriteMode
   hPutStrLn h (render code)
   hClose h

--- a/code/drasil-code/Language/Drasil/Code/CodeGeneration.hs
+++ b/code/drasil-code/Language/Drasil/Code/CodeGeneration.hs
@@ -7,20 +7,15 @@ module Language.Drasil.Code.CodeGeneration (
 ) where
 
 import Language.Drasil.Code.Code (Code(..))
-import Language.Drasil.Code.Imperative.Symantics
-import Language.Drasil.Code.Imperative.Data (ModData(..))
+import Language.Drasil.Code.Imperative.Data (FileData(..), ModData(modDoc))
 
 import Text.PrettyPrint.HughesPJ (Doc,render)
 import System.IO (hPutStrLn, hClose, openFile, IOMode(WriteMode))
 
--- | Takes code and extensions
-makeCode :: [[ModData]] -> [Label] -> Code
-makeCode files exts = Code
-  [(nm, contents) | (MD nm _ contents) <- concat [map (applyExt ext) files' 
-    | (files', ext) <- zip files exts]]
-
-applyExt :: Label -> ModData -> ModData
-applyExt ext (MD n b d) = MD (n ++ ext) b d
+-- | Takes code
+makeCode :: [[FileData]] -> Code
+makeCode files = Code $ zip (map filePath $ concat files) 
+  (map (modDoc . fileMod) $ concat files)
 
 ------------------
 -- IO Functions --

--- a/code/drasil-code/Language/Drasil/Code/Imperative/Data.hs
+++ b/code/drasil-code/Language/Drasil/Code/Imperative/Data.hs
@@ -1,7 +1,8 @@
 module Language.Drasil.Code.Imperative.Data (Pair(..), pairList,
-  Terminator (..), ScopeTag(..), FuncData(..), fd, ModData(..), md, 
-  MethodData(..), mthd, ParamData(..), pd, updateParamDoc, StateVarData(..), 
-  svd, TypeData(..), td, ValData(..), vd, updateValDoc, VarData(..), vard
+  Terminator (..), ScopeTag(..), FileData(..), fileD, updateFileMod, 
+  FuncData(..), fd, ModData(..), md, updateModDoc, MethodData(..), mthd, 
+  ParamData(..), pd, updateParamDoc, StateVarData(..), svd, TypeData(..), td,
+  ValData(..), vd, updateValDoc, VarData(..), vard
 ) where
 
 import Language.Drasil.Code.Code (CodeType)
@@ -23,6 +24,14 @@ data Terminator = Semi | Empty
 
 data ScopeTag = Pub | Priv deriving Eq
 
+data FileData = FileD {filePath :: String, fileMod :: ModData}
+
+fileD :: String -> ModData -> FileData
+fileD = FileD
+
+updateFileMod :: ModData -> FileData -> FileData
+updateFileMod m f = fileD (filePath f) m
+
 data FuncData = FD {funcType :: TypeData, funcDoc :: Doc}
 
 fd :: TypeData -> Doc -> FuncData
@@ -32,6 +41,9 @@ data ModData = MD {name :: String, isMainMod :: Bool, modDoc :: Doc}
 
 md :: String -> Bool -> Doc -> ModData
 md = MD
+
+updateModDoc :: Doc -> ModData -> ModData
+updateModDoc d m = md (name m) (isMainMod m) d
 
 data MethodData = MthD {isMainMthd :: Bool, mthdParams :: [ParamData], 
   mthdDoc :: Doc}

--- a/code/drasil-code/Language/Drasil/Code/Imperative/Import.hs
+++ b/code/drasil-code/Language/Drasil/Code/Imperative/Import.hs
@@ -7,7 +7,7 @@ import Utils.Drasil (stringList)
 import Language.Drasil hiding (int, ($.), log, ln, exp,
   sin, cos, tan, csc, sec, cot, arcsin, arccos, arctan)
 import Database.Drasil(ChunkDB, symbLookup, symbolTable)
-import Language.Drasil.Code.Code as C (Code(..), CodeType(List))
+import Language.Drasil.Code.Code as C (CodeType(List))
 import Language.Drasil.Code.Imperative.Symantics (Label,
   PackageSym(..), RenderSym(..), PermanenceSym(..), BodySym(..), BlockSym(..), 
   StateTypeSym(..), VariableSym(..), ValueSym(..), NumericExpression(..), 
@@ -19,7 +19,7 @@ import Language.Drasil.Code.Imperative.Build.AST (asFragment, buildAll,
   BuildConfig, buildSingle, cppCompiler, inCodePackage, interp, interpMM, 
   mainModule, mainModuleFile, nativeBinary, osClassDefault, Runnable, withExt)
 import Language.Drasil.Code.Imperative.Build.Import (makeBuild)
-import Language.Drasil.Code.Imperative.Data (ModData(..))
+import Language.Drasil.Code.Imperative.Data (FileData(..))
 import Language.Drasil.Code.Imperative.Helpers (convType, getStr)
 import Language.Drasil.Code.Imperative.LanguageRenderer.CppRenderer 
   (cppExts)
@@ -145,15 +145,14 @@ publicClass desc n l vs ms = do
     else pubClass n l vs ms
 
 generateCode :: (PackageSym repr) => Lang -> [repr (Package repr) -> 
-  ([ModData], Label)] -> State repr -> IO ()
+  ([FileData], Label)] -> State repr -> IO ()
 generateCode l unRepr g =
   do workingDir <- getCurrentDirectory
      createDirectoryIfMissing False (getDir l)
      setCurrentDirectory (getDir l)
      when (l == Java) $ createDirectoryIfMissing False prog
-     createCodeFiles $ makeBuild (last unRepr pckg) (getBuildConfig l) (getRunnable l) (getExt l) $ C.Code $
-            map (if l == Java then \(c,d) -> (prog ++ "/" ++ c, d) else id) $
-            C.unCode $ makeCode (map (fst . ($ pckg)) unRepr) (getExt l)
+     createCodeFiles $ makeBuild (last unRepr pckg) (getBuildConfig l)   
+       (getRunnable l) (getExt l) $ makeCode (map (fst . ($ pckg)) unRepr)
      setCurrentDirectory workingDir
   where prog = case codeSpec g of { CodeSpec {program = pp} -> programName pp }
         pckg = runReader (genPackage prog) g

--- a/code/drasil-code/Language/Drasil/Code/Imperative/Import.hs
+++ b/code/drasil-code/Language/Drasil/Code/Imperative/Import.hs
@@ -46,7 +46,7 @@ import Data.Map (member)
 import qualified Data.Map as Map (lookup, elems)
 import Data.Maybe (fromMaybe, maybe, maybeToList, catMaybes, mapMaybe)
 import Control.Applicative ((<$>))
-import Control.Monad (when,liftM2,liftM3)
+import Control.Monad (liftM2,liftM3)
 import Control.Monad.Reader (Reader, ask, runReader, withReader)
 import Control.Lens ((^.), view)
 import qualified Prelude as P ((<>))
@@ -150,7 +150,6 @@ generateCode l unRepr g =
   do workingDir <- getCurrentDirectory
      createDirectoryIfMissing False (getDir l)
      setCurrentDirectory (getDir l)
-     when (l == Java) $ createDirectoryIfMissing False prog
      createCodeFiles $ makeBuild (last unRepr pckg) (getBuildConfig l)   
        (getRunnable l) (getExt l) $ makeCode (map (fst . ($ pckg)) unRepr)
      setCurrentDirectory workingDir

--- a/code/drasil-code/Language/Drasil/Code/Imperative/LanguageRenderer.hs
+++ b/code/drasil-code/Language/Drasil/Code/Imperative/LanguageRenderer.hs
@@ -4,7 +4,7 @@
 module Language.Drasil.Code.Imperative.LanguageRenderer (
   -- * Common Syntax
   classDec, dot, doubleSlash, forLabel, new, blockCmtStart, blockCmtEnd,
-  docCmtStart, observerListName,
+  docCmtStart, observerListName, addExt,
   
   -- * Default Functions available for use in renderers
   packageDocD, fileDoc', moduleDocD, classDocD, enumDocD, enumElementsDocD, 
@@ -47,9 +47,9 @@ import Language.Drasil.Code.Imperative.Symantics (Label, Library,
   InternalStatement(..), StatementSym(..), ControlStatementSym(..), 
   ParameterSym(..), MethodSym(..), BlockCommentSym(..))
 import qualified Language.Drasil.Code.Imperative.Symantics as S (StateTypeSym(int))
-import Language.Drasil.Code.Imperative.Data (Terminator(..), FuncData(..), 
-  ModData(..), md, MethodData(..), ParamData(..), pd, TypeData(..), td, 
-  ValData(..), vd, VarData(..))
+import Language.Drasil.Code.Imperative.Data (Terminator(..), FileData(..), 
+  fileD, FuncData(..), ModData(..), updateModDoc, MethodData(..), 
+  ParamData(..), pd, TypeData(..), td, ValData(..), vd, VarData(..))
 import Language.Drasil.Code.Imperative.Helpers (angles,blank, doubleQuotedText,
   hicat,vibcat,vmap, emptyIfEmpty, emptyIfNull, getNestDegree)
 
@@ -77,13 +77,16 @@ docCmtStart = text "/**"
 observerListName :: Label
 observerListName = "observerList"
 
+addExt :: String -> String -> String
+addExt ext nm = nm ++ "." ++ ext
+
 ----------------------------------
 -- Functions for rendering code --
 ----------------------------------
 
-packageDocD :: Label -> Doc -> ModData -> ModData
-packageDocD n end (MD l b m) = md l b (vibcat [text "package" <+> text n <> end,
-  m])
+packageDocD :: Label -> Doc -> FileData -> FileData
+packageDocD n end f = fileD (n ++ "/" ++ filePath f) (updateModDoc (vibcat [
+  text "package" <+> text n <> end, modDoc (fileMod f)]) (fileMod f))
 
 fileDoc' :: Doc -> Doc -> Doc -> Doc
 fileDoc' t m b = vibcat [

--- a/code/drasil-code/Language/Drasil/Code/Imperative/LanguageRenderer/CSharpRenderer.hs
+++ b/code/drasil-code/Language/Drasil/Code/Imperative/LanguageRenderer/CSharpRenderer.hs
@@ -20,7 +20,7 @@ import Language.Drasil.Code.Imperative.Symantics (Label,
   StatementSym(..), ControlStatementSym(..), ScopeSym(..), InternalScope(..), 
   MethodTypeSym(..), ParameterSym(..), MethodSym(..), StateVarSym(..), 
   ClassSym(..), ModuleSym(..), BlockCommentSym(..))
-import Language.Drasil.Code.Imperative.LanguageRenderer (
+import Language.Drasil.Code.Imperative.LanguageRenderer (addExt,
   fileDoc', moduleDocD, classDocD, enumDocD,
   enumElementsDocD, multiStateDocD, blockDocD, bodyDocD, printDoc, outDoc,
   printFileDocD, boolTypeDocD, intTypeDocD, charTypeDocD, stringTypeDocD, 
@@ -44,9 +44,10 @@ import Language.Drasil.Code.Imperative.LanguageRenderer (
   docCmtDoc, commentedItem, addCommentsDocD, functionDoc, classDoc, moduleDoc, 
   docFuncRepr, valList, surroundBody, getterName, setterName, setMain, 
   setMainMethod,setEmpty, intValue)
-import Language.Drasil.Code.Imperative.Data (Terminator(..), FuncData(..),  
-  fd, ModData(..), md, MethodData(..), mthd, ParamData(..), pd, updateParamDoc, 
-  TypeData(..), td, ValData(..), vd, updateValDoc, VarData(..), vard)
+import Language.Drasil.Code.Imperative.Data (Terminator(..), FileData(..), 
+  fileD, updateFileMod, FuncData(..), fd, ModData(..), md, updateModDoc, 
+  MethodData(..), mthd, ParamData(..), pd, updateParamDoc, TypeData(..), td,
+  ValData(..), vd, updateValDoc, VarData(..), vard)
 import Language.Drasil.Code.Imperative.Helpers (emptyIfEmpty, liftA4, liftA5, 
   liftA6, liftList, lift1List, lift3Pair, lift4Pair, liftPair, liftPairFst, 
   getInnerType, convType)
@@ -79,22 +80,21 @@ instance Monad CSharpCode where
   CSC x >>= f = f x
 
 instance PackageSym CSharpCode where
-  type Package CSharpCode = ([ModData], Label)
+  type Package CSharpCode = ([FileData], Label)
   packMods n ms = liftPairFst (sequence mods, n)
-    where mods = filter (not . isEmpty . modDoc . unCSC) ms
+    where mods = filter (not . isEmpty . modDoc . fileMod . unCSC) ms
 
 instance RenderSym CSharpCode where
-  type RenderFile CSharpCode = ModData
-  fileDoc code = liftA3 md (fmap name code) (fmap isMainMod code) 
-    (liftA2 emptyIfEmpty (fmap modDoc code) $
-      liftA3 fileDoc' (top code) (fmap modDoc code) bottom)
+  type RenderFile CSharpCode = FileData
+  fileDoc code = liftA2 fileD (fmap (addExt "cs" . name) code) (liftA2 
+    updateModDoc (liftA2 emptyIfEmpty (fmap modDoc code) $ liftA3 fileDoc' 
+    (top code) (fmap modDoc code) bottom) code)
 
-  docMod d m = commentedMod (docComment $ moduleDoc d (moduleName m) csExt) m
+  docMod d m = commentedMod (docComment $ moduleDoc d (moduleName 
+    (fmap fileMod m)) csExt) m
 
-  commentedMod cmt m = liftA3 md (fmap name m) (fmap isMainMod m) 
-    (liftA2 commentedItem cmt (fmap modDoc m))
-    
-  moduleName m = name (unCSC m)
+  commentedMod cmt m = liftA2 updateFileMod (liftA2 updateModDoc
+    (liftA2 commentedItem cmt (fmap (modDoc . fileMod) m)) (fmap fileMod m)) m
 
 instance InternalFile CSharpCode where
   top _ = liftA2 cstop endStatement (include "")
@@ -585,6 +585,8 @@ instance ModuleSym CSharpCode where
   buildModule n _ ms cs = fmap (md n (any (isMainMthd . unCSC) ms || 
     any (snd . unCSC) cs)) (liftList moduleDocD (if null ms then cs 
     else pubClass n Nothing [] ms : cs))
+    
+  moduleName m = name (unCSC m)
 
 instance BlockCommentSym CSharpCode where
   type BlockComment CSharpCode = Doc

--- a/code/drasil-code/Language/Drasil/Code/Imperative/LanguageRenderer/JavaRenderer.hs
+++ b/code/drasil-code/Language/Drasil/Code/Imperative/LanguageRenderer/JavaRenderer.hs
@@ -22,7 +22,7 @@ import Language.Drasil.Code.Imperative.Symantics (Label,
   ClassSym(..), ModuleSym(..), BlockCommentSym(..))
 import Language.Drasil.Code.Imperative.Build.AST (includeExt, 
   NameOpts(NameOpts), packSep)
-import Language.Drasil.Code.Imperative.LanguageRenderer ( 
+import Language.Drasil.Code.Imperative.LanguageRenderer (addExt,
   packageDocD, fileDoc', moduleDocD, classDocD, enumDocD, enumElementsDocD, 
   multiStateDocD, blockDocD, bodyDocD, outDoc, printDoc, printFileDocD, 
   boolTypeDocD, intTypeDocD, charTypeDocD, typeDocD, enumTypeDocD, listTypeDocD,
@@ -44,9 +44,10 @@ import Language.Drasil.Code.Imperative.LanguageRenderer (
   blockCmtDoc, docCmtDoc, commentedItem, addCommentsDocD, functionDoc, classDoc,
   moduleDoc, docFuncRepr, valList, surroundBody, getterName, setterName, 
   setMain, setMainMethod, setEmpty, intValue)
-import Language.Drasil.Code.Imperative.Data (Terminator(..), FuncData(..), 
-  fd, ModData(..), md, MethodData(..), mthd, ParamData(..), pd, TypeData(..), 
-  td, ValData(..), vd, VarData(..), vard)
+import Language.Drasil.Code.Imperative.Data (Terminator(..), FileData(..), 
+  fileD, updateFileMod, FuncData(..), fd, ModData(..), md, updateModDoc, 
+  MethodData(..), mthd, ParamData(..), pd, TypeData(..), td, ValData(..), vd, 
+  VarData(..), vard)
 import Language.Drasil.Code.Imperative.Helpers (angles, emptyIfEmpty, 
   liftA4, liftA5, liftA6, liftList, lift1List, lift3Pair, lift4Pair, liftPair, 
   liftPairFst, getInnerType, convType)
@@ -84,22 +85,21 @@ instance Monad JavaCode where
   JC x >>= f = f x
 
 instance PackageSym JavaCode where
-  type Package JavaCode = ([ModData], Label)
+  type Package JavaCode = ([FileData], Label)
   packMods n ms = liftPairFst (mapM (liftA2 (packageDocD n) endStatement) mods, n)
-    where mods = filter (not . isEmpty . modDoc . unJC) ms
+    where mods = filter (not . isEmpty . modDoc . fileMod . unJC) ms
 
 instance RenderSym JavaCode where
-  type RenderFile JavaCode = ModData
-  fileDoc code = liftA3 md (fmap name code) (fmap isMainMod code) 
-    (liftA2 emptyIfEmpty (fmap modDoc code) $
-      liftA3 fileDoc' (top code) (fmap modDoc code) bottom)
+  type RenderFile JavaCode = FileData
+  fileDoc code = liftA2 fileD (fmap (addExt "java" . name) code) (liftA2 
+    updateModDoc (liftA2 emptyIfEmpty (fmap modDoc code) $ liftA3 fileDoc' 
+    (top code) (fmap modDoc code) bottom) code)
 
-  docMod d m = commentedMod (docComment $ moduleDoc d (moduleName m) jExt) m
+  docMod d m = commentedMod (docComment $ moduleDoc d (moduleName 
+    (fmap fileMod m)) jExt) m
 
-  commentedMod cmt m = liftA3 md (fmap name m) (fmap isMainMod m) 
-    (liftA2 commentedItem cmt (fmap modDoc m))
-
-  moduleName m = name (unJC m)
+  commentedMod cmt m = liftA2 updateFileMod (liftA2 updateModDoc
+    (liftA2 commentedItem cmt (fmap (modDoc . fileMod) m)) (fmap fileMod m)) m
 
 instance InternalFile JavaCode where
   top _ = liftA3 jtop endStatement (include "") (list static_)
@@ -600,6 +600,8 @@ instance ModuleSym JavaCode where
   buildModule n _ ms cs = fmap (md n (any (isMainMthd . unJC) ms || 
     any (snd . unJC) cs)) (liftList moduleDocD (if null ms then cs 
     else pubClass n Nothing [] ms : cs))
+
+  moduleName m = name (unJC m)
 
 instance BlockCommentSym JavaCode where
   type BlockComment JavaCode = Doc

--- a/code/drasil-code/Language/Drasil/Code/Imperative/Symantics.hs
+++ b/code/drasil-code/Language/Drasil/Code/Imperative/Symantics.hs
@@ -35,8 +35,6 @@ class (ModuleSym repr, ControlBlockSym repr, InternalFile repr) =>
   commentedMod :: repr (BlockComment repr) -> repr (RenderFile repr) ->
     repr (RenderFile repr)
 
-  moduleName :: repr (RenderFile repr) -> String
-
 class (ModuleSym repr) => InternalFile repr where
   top :: repr (Module repr) -> repr (Block repr)
   bottom :: repr (Block repr)
@@ -585,6 +583,8 @@ class (ClassSym repr) => ModuleSym repr where
   type Module repr
   buildModule :: Label -> [Library] -> [repr (Method repr)] -> 
     [repr (Class repr)] -> repr (Module repr)
+    
+  moduleName :: repr (Module repr) -> String
     
 class BlockCommentSym repr where
   type BlockComment repr

--- a/code/drasil-code/Test/Main.hs
+++ b/code/drasil-code/Test/Main.hs
@@ -5,7 +5,7 @@ import Language.Drasil.Code.Imperative.LanguageRenderer.JavaRenderer (JavaCode(.
 import Language.Drasil.Code.Imperative.LanguageRenderer.PythonRenderer (PythonCode(..))
 import Language.Drasil.Code.Imperative.LanguageRenderer.CSharpRenderer (CSharpCode(..))
 import Language.Drasil.Code.Imperative.LanguageRenderer.CppRenderer (CppSrcCode(..), CppHdrCode(..))
-import Language.Drasil.Code.Imperative.Data (ModData(..))
+import Language.Drasil.Code.Imperative.Data (FileData(..), ModData(..))
 import Text.PrettyPrint.HughesPJ (Doc, render)
 import System.Directory (setCurrentDirectory, createDirectoryIfMissing, getCurrentDirectory)
 import System.IO (hClose, hPutStrLn, openFile, IOMode(WriteMode))
@@ -19,37 +19,32 @@ main = do
   workingDir <- getCurrentDirectory
   createDirectoryIfMissing False "java"
   setCurrentDirectory "java"
-  genCode (classes unJC) [".java"]
+  genCode (classes unJC)
   setCurrentDirectory workingDir
   createDirectoryIfMissing False "python"
   setCurrentDirectory "python"
-  genCode (classes unPC) [".py"]
+  genCode (classes unPC)
   setCurrentDirectory workingDir 
   createDirectoryIfMissing False "csharp"
   setCurrentDirectory "csharp"
-  genCode (classes unCSC) [".cs"]
+  genCode (classes unCSC)
   setCurrentDirectory workingDir
   createDirectoryIfMissing False "cpp"
   setCurrentDirectory "cpp"
-  genCode (classes unCPPSC) [".cpp"]
-  genCode (classes unCPPHC) [".hpp"]
+  genCode (classes unCPPSC)
+  genCode (classes unCPPHC)
   setCurrentDirectory workingDir
     
-genCode :: [([ModData], Label)] -> [Label] -> IO()
-genCode files exts = createCodeFiles (concatMap (\(ms, l) -> replicate (length ms) l) files) $ makeCode (concatMap fst files) exts
+genCode :: [([FileData], Label)] -> IO()
+genCode files = createCodeFiles (concatMap (\(ms, l) -> replicate (length ms) l) files) $ makeCode (concatMap fst files)
 
-classes :: (PackageSym repr) => (repr (Package repr) -> ([ModData], Label)) -> [([ModData], Label)]
+classes :: (PackageSym repr) => (repr (Package repr) -> ([FileData], Label)) -> [([FileData], Label)]
 classes unRepr = map unRepr [helloWorld, patternTest, fileTests]
 
--- | Takes code and extensions
-makeCode :: [ModData] -> [Label] -> [(FilePath, Doc)]
-makeCode files exts =
-    [(nm ++ ext, file) | (nm, (file, ext)) <- zip (repeatListElems (length exts) (map name files)) (zip (map modDoc files) (cycle exts))]
-
-repeatListElems :: Int -> [a] -> [a]
-repeatListElems _ [] = []
-repeatListElems 1 xs = xs
-repeatListElems n (x:xs) = replicate n x ++ repeatListElems n xs
+-- | Takes code
+makeCode :: [FileData] -> [(FilePath, Doc)]
+makeCode files = zip (map filePath files)
+  (map (modDoc . fileMod) files)
 
 ------------------
 -- IO Functions --

--- a/code/drasil-code/Test/Main.hs
+++ b/code/drasil-code/Test/Main.hs
@@ -8,6 +8,7 @@ import Language.Drasil.Code.Imperative.LanguageRenderer.CppRenderer (CppSrcCode(
 import Language.Drasil.Code.Imperative.Data (FileData(..), ModData(..))
 import Text.PrettyPrint.HughesPJ (Doc, render)
 import System.Directory (setCurrentDirectory, createDirectoryIfMissing, getCurrentDirectory)
+import System.FilePath.Posix (takeDirectory)
 import System.IO (hClose, hPutStrLn, openFile, IOMode(WriteMode))
 import Prelude hiding (return,print,log,exp,sin,cos,tan)
 import Test.HelloWorld (helloWorld)
@@ -58,6 +59,7 @@ createCodeFile :: (Label, (FilePath, Doc)) -> IO ()
 createCodeFile (n, (path, code)) = do
     createDirectoryIfMissing False n
     setCurrentDirectory n
+    createDirectoryIfMissing True (takeDirectory path)
     h <- openFile path WriteMode
     hPutStrLn h (render code)
     hClose h


### PR DESCRIPTION
This PR closes #1745, updating GOOL to construct file paths for the files it generates, and removing some checks for specific languages in our generator.