### PR TITLE
PR - Updating .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,5 @@ __pycache__
 *.class
 .drasil-min-stack-ver
 */Projectile/output.txt
+*.fls
+*.fdb_latexmk


### PR DESCRIPTION
Minor update so that `.gitignore` ignores generated `.fls` and `.fdb_latexmk` files.