### PR TITLE
Clean up code related to file extensions

### DIFF
--- a/code/drasil-code/Language/Drasil/Code/Imperative/Build/Import.hs
+++ b/code/drasil-code/Language/Drasil/Code/Imperative/Build/Import.hs
@@ -54,7 +54,7 @@ renderExt _ (OtherExt e) = e
 
 getMainModule :: [FileData] -> Label
 getMainModule c = mainName $ filter (isMainMod . fileMod) c
-  where mainName [FileD _ m] = name m
+  where mainName [FileD _ _ m] = name m
         mainName _ = error "Expected a single main module."
 
 getCompilerInput :: BuildDependencies -> [String] -> PackData -> [MakeString]

--- a/code/drasil-code/Language/Drasil/Code/Imperative/Build/Import.hs
+++ b/code/drasil-code/Language/Drasil/Code/Imperative/Build/Import.hs
@@ -4,9 +4,8 @@ module Language.Drasil.Code.Imperative.Build.Import (
 
 import Language.Drasil.CodeSpec (Comments)
 import Language.Drasil.Code.Code (Code(..))
-import Language.Drasil.Code.Imperative.Symantics (Label)
-import Language.Drasil.Code.Imperative.Data (FileData(..), ModData(..), 
-  PackData(..))
+import Language.Drasil.Code.Imperative.Data (FileData(..), isSource, isHeader, 
+  ModData(..), PackData(..))
 import Language.Drasil.Code.Imperative.Build.AST (BuildConfig(BuildConfig),
   BuildDependencies(..), Ext(..), includeExt, NameOpts, nameOpts, packSep,
   Runnable(Runnable), BuildName(..), RunType(..))
@@ -16,60 +15,60 @@ import Build.Drasil ((+:+), genMake, makeS, MakeString, mkFile, mkRule,
   mkCheckedCommand, mkFreeVar, RuleTransformer(makeRule))
 
 import Control.Applicative (liftA2)
-import Data.List (isInfixOf)
-import Data.List.Utils (endswith)
 import Data.Maybe (maybe, maybeToList)
+import System.FilePath.Posix (takeExtension, takeBaseName)
 
-data CodeHarness = Ch (Maybe BuildConfig) Runnable [String] PackData [Comments]
+data CodeHarness = Ch (Maybe BuildConfig) Runnable PackData [Comments]
 
 instance RuleTransformer CodeHarness where
-  makeRule (Ch b r e m cms) = [
-    mkRule buildTarget (map (const $ renderBuildName e m nameOpts nm) $ maybeToList b) []
+  makeRule (Ch b r m cms) = [
+    mkRule buildTarget (map (const $ renderBuildName m nameOpts nm) $ maybeToList b) []
     ] ++
     maybe [] (\(BuildConfig comp bt) -> [
-    mkFile (renderBuildName e m nameOpts nm) (map (makeS . filePath) (packMods m)) [
-      mkCheckedCommand $ foldr (+:+) mempty $ comp (getCompilerInput bt e m) $
-        renderBuildName e m nameOpts nm
+    mkFile (renderBuildName m nameOpts nm) (map (makeS . filePath) (packMods m)) [
+      mkCheckedCommand $ foldr (+:+) mempty $ comp (getCompilerInput bt m) $
+        renderBuildName m nameOpts nm
       ]
     ]) b ++ [
     mkRule (makeS "run") [buildTarget] [
-      mkCheckedCommand $ buildRunTarget (renderBuildName e m no nm) ty +:+ mkFreeVar "RUNARGS"
+      mkCheckedCommand $ buildRunTarget (renderBuildName m no nm) ty +:+ mkFreeVar "RUNARGS"
       ]
     ] ++ [
-    mkRule (makeS "doc") (getCommentedFiles e (packMods m)) 
+    mkRule (makeS "doc") (getCommentedFiles (packMods m)) 
       [mkCheckedCommand $ makeS $ "doxygen " ++ doxConfigName] | not (null cms)
     ] where
       (Runnable nm no ty) = r
       buildTarget = makeS "build"
 
-renderBuildName :: [String] -> PackData -> NameOpts -> BuildName -> MakeString
-renderBuildName _ p _ BMain = makeS $ getMainModule (packMods p)
-renderBuildName _ p _ BPackName = makeS (packName p)
-renderBuildName ext p o (BPack a) = renderBuildName ext p o BPackName <> makeS(packSep o) <> renderBuildName ext p o a
-renderBuildName ext p o (BWithExt a e) = renderBuildName ext p o a <> if includeExt o then renderExt ext e else makeS ""
+renderBuildName :: PackData -> NameOpts -> BuildName -> MakeString
+renderBuildName p _ BMain = makeS $ takeBaseName $ getMainModule p
+renderBuildName p _ BPackName = makeS (packName p)
+renderBuildName p o (BPack a) = renderBuildName p o BPackName <> 
+  makeS (packSep o) <> renderBuildName p o a
+renderBuildName p o (BWithExt a e) = renderBuildName p o a <> 
+  if includeExt o then renderExt e (getMainModule p) else makeS ""
 
-renderExt :: [String] -> Ext -> MakeString
-renderExt e CodeExt = makeS $ last e
-renderExt _ (OtherExt e) = e
+renderExt :: Ext -> FilePath -> MakeString
+renderExt CodeExt f = makeS $ takeExtension f
+renderExt (OtherExt e) _ = e
 
-getMainModule :: [FileData] -> Label
-getMainModule c = mainName $ filter (isMainMod . fileMod) c
-  where mainName [FileD _ _ m] = name m
+getMainModule :: PackData -> FilePath
+getMainModule p = mainName $ filter (isMainMod . fileMod) (packMods p)
+  where mainName [FileD _ fp _] = fp
         mainName _ = error "Expected a single main module."
 
-getCompilerInput :: BuildDependencies -> [String] -> PackData -> [MakeString]
-getCompilerInput BcSource e p = map makeS $ filter (endswith $ last e) $ map 
-  filePath $ packMods p
-getCompilerInput (BcSingle n) e p = [renderBuildName e p nameOpts n]
+getCompilerInput :: BuildDependencies -> PackData -> [MakeString]
+getCompilerInput BcSource p = map (makeS . filePath) $ filter isSource $ 
+  packMods p
+getCompilerInput (BcSingle n) p = [renderBuildName p nameOpts n]
 
-getCommentedFiles :: [String] -> [FileData] -> [MakeString]
-getCommentedFiles e fs = map makeS (doxConfigName : filter (liftA2 (||) 
-  (isInfixOf (getMainModule fs)) (endswith (head e))) (map filePath fs))
+getCommentedFiles :: [FileData] -> [MakeString]
+getCommentedFiles fs = map makeS (doxConfigName : map filePath (filter (liftA2 
+  (||) (isMainMod . fileMod) isHeader) fs))
 
 buildRunTarget :: MakeString -> RunType -> MakeString
 buildRunTarget fn Standalone = makeS "./" <> fn
 buildRunTarget fn (Interpreter i) = i +:+ fn
 
-makeBuild :: PackData -> Maybe BuildConfig -> Runnable -> [String] -> 
-  [Comments] -> Code
-makeBuild m b r e cms = Code [("Makefile", genMake [Ch b r e m cms])]
+makeBuild :: PackData -> Maybe BuildConfig -> Runnable -> [Comments] -> Code
+makeBuild m b r cms = Code [("Makefile", genMake [Ch b r m cms])]

--- a/code/drasil-code/Language/Drasil/Code/Imperative/Data.hs
+++ b/code/drasil-code/Language/Drasil/Code/Imperative/Data.hs
@@ -1,13 +1,14 @@
 module Language.Drasil.Code.Imperative.Data (Pair(..), pairList,
   Terminator(..), ScopeTag(..), FileType(..), AuxData(..), ad, FileData(..), 
-  fileD, srcFile, hdrFile, updateFileMod, FuncData(..), fd, ModData(..), md, 
-  updateModDoc, MethodData(..), mthd, PackData(..), packD, ParamData(..), pd, 
-  updateParamDoc, StateVarData(..), svd, TypeData(..), td, ValData(..), vd, 
-  updateValDoc, VarData(..), vard
+  fileD, file, srcFile, hdrFile, isSource, isHeader, updateFileMod, 
+  FuncData(..), fd, ModData(..), md, updateModDoc, MethodData(..), mthd, 
+  PackData(..), packD, ParamData(..), pd, updateParamDoc, StateVarData(..), svd,
+  TypeData(..), td, ValData(..), vd, updateValDoc, VarData(..), vard
 ) where
 
 import Language.Drasil.Code.Code (CodeType)
 
+import Control.Applicative (liftA2)
 import Prelude hiding ((<>))
 import Text.PrettyPrint.HughesPJ (Doc)
 
@@ -25,7 +26,7 @@ data Terminator = Semi | Empty
 
 data ScopeTag = Pub | Priv deriving Eq
 
-data FileType = Source | Header
+data FileType = Combined | Source | Header deriving Eq
 
 data AuxData = AD {auxFilePath :: FilePath, auxDoc :: Doc}
 
@@ -41,11 +42,20 @@ instance Eq FileData where
 fileD :: FileType -> String -> ModData -> FileData
 fileD = FileD
 
+file :: String -> ModData -> FileData
+file = FileD Combined
+
 srcFile :: String -> ModData -> FileData
 srcFile = FileD Source
 
 hdrFile :: String -> ModData -> FileData
 hdrFile = FileD Header
+
+isSource :: FileData -> Bool
+isSource = liftA2 (||) (Source ==) (Combined ==) . fileType
+
+isHeader :: FileData -> Bool
+isHeader = liftA2 (||) (Header ==) (Combined ==) . fileType
 
 updateFileMod :: ModData -> FileData -> FileData
 updateFileMod m f = fileD (fileType f) (filePath f) m

--- a/code/drasil-code/Language/Drasil/Code/Imperative/Data.hs
+++ b/code/drasil-code/Language/Drasil/Code/Imperative/Data.hs
@@ -1,9 +1,9 @@
 module Language.Drasil.Code.Imperative.Data (Pair(..), pairList,
-  Terminator (..), ScopeTag(..), AuxData(..), ad, FileData(..), fileD, 
-  updateFileMod, FuncData(..), fd, ModData(..), md, updateModDoc, 
-  MethodData(..), mthd, PackData(..), packD, ParamData(..), pd, updateParamDoc, 
-  StateVarData(..), svd, TypeData(..), td, ValData(..), vd, updateValDoc, 
-  VarData(..), vard
+  Terminator(..), ScopeTag(..), FileType(..), AuxData(..), ad, FileData(..), 
+  fileD, srcFile, hdrFile, updateFileMod, FuncData(..), fd, ModData(..), md, 
+  updateModDoc, MethodData(..), mthd, PackData(..), packD, ParamData(..), pd, 
+  updateParamDoc, StateVarData(..), svd, TypeData(..), td, ValData(..), vd, 
+  updateValDoc, VarData(..), vard
 ) where
 
 import Language.Drasil.Code.Code (CodeType)
@@ -25,21 +25,30 @@ data Terminator = Semi | Empty
 
 data ScopeTag = Pub | Priv deriving Eq
 
+data FileType = Source | Header
+
 data AuxData = AD {auxFilePath :: FilePath, auxDoc :: Doc}
 
 ad :: String -> Doc -> AuxData
 ad = AD
 
-data FileData = FileD {filePath :: FilePath, fileMod :: ModData}
+data FileData = FileD {fileType :: FileType, filePath :: FilePath,
+  fileMod :: ModData}
 
 instance Eq FileData where
-  FileD p1 _ == FileD p2 _ = p1 == p2
+  FileD _ p1 _ == FileD _ p2 _ = p1 == p2
 
-fileD :: String -> ModData -> FileData
+fileD :: FileType -> String -> ModData -> FileData
 fileD = FileD
 
+srcFile :: String -> ModData -> FileData
+srcFile = FileD Source
+
+hdrFile :: String -> ModData -> FileData
+hdrFile = FileD Header
+
 updateFileMod :: ModData -> FileData -> FileData
-updateFileMod m f = fileD (filePath f) m
+updateFileMod m f = fileD (fileType f) (filePath f) m
 
 data FuncData = FD {funcType :: TypeData, funcDoc :: Doc}
 

--- a/code/drasil-code/Language/Drasil/Code/Imperative/Import.hs
+++ b/code/drasil-code/Language/Drasil/Code/Imperative/Import.hs
@@ -21,14 +21,7 @@ import Language.Drasil.Code.Imperative.Build.AST (asFragment, buildAll,
 import Language.Drasil.Code.Imperative.Build.Import (makeBuild)
 import Language.Drasil.Code.Imperative.Data (PackData(..))
 import Language.Drasil.Code.Imperative.Helpers (convType, getStr)
-import Language.Drasil.Code.Imperative.LanguageRenderer.CppRenderer 
-  (cppExts)
-import Language.Drasil.Code.Imperative.LanguageRenderer.CSharpRenderer 
-  (csExts)
-import Language.Drasil.Code.Imperative.LanguageRenderer.JavaRenderer 
-  (jExts, jNameOpts)
-import Language.Drasil.Code.Imperative.LanguageRenderer.PythonRenderer 
-  (pyExts)
+import Language.Drasil.Code.Imperative.LanguageRenderer.JavaRenderer (jNameOpts)
 import Language.Drasil.Code.CodeGeneration (createCodeFiles, makeCode)
 import Language.Drasil.Chunk.Code (CodeChunk, CodeDefinition, codeName,
   codeType, codevar, codefunc, codeEquat, funcPrefix, physLookup, sfwrLookup,
@@ -155,7 +148,7 @@ generateCode l unRepr g =
   where pckg = runReader genPackage g
         code = makeCode (packMods $ unRepr pckg) (packAux $ unRepr pckg)
         makefile = makeBuild (unRepr pckg) (getBuildConfig l) 
-          (getRunnable l) (getExt l) (commented g)
+          (getRunnable l) (commented g)
 
 genPackage :: (PackageSym repr) => Reader (State repr) (repr (Package repr))
 genPackage = do
@@ -181,12 +174,6 @@ getDir Cpp = "cpp"
 getDir CSharp = "csharp"
 getDir Java = "java"
 getDir Python = "python"
-
-getExt :: Lang -> [Label]
-getExt Java = jExts
-getExt Python = pyExts
-getExt CSharp = csExts
-getExt Cpp = cppExts
 
 getRunnable :: Lang -> Runnable
 getRunnable Java = interp (flip withExt ".class" $ inCodePackage mainModule) 

--- a/code/drasil-code/Language/Drasil/Code/Imperative/LanguageRenderer.hs
+++ b/code/drasil-code/Language/Drasil/Code/Imperative/LanguageRenderer.hs
@@ -88,8 +88,8 @@ addExt ext nm = nm ++ "." ++ ext
 ----------------------------------
 
 packageDocD :: Label -> Doc -> FileData -> FileData
-packageDocD n end f = fileD (n ++ "/" ++ filePath f) (updateModDoc (vibcat [
-  text "package" <+> text n <> end, modDoc (fileMod f)]) (fileMod f))
+packageDocD n end f = fileD (fileType f) (n ++ "/" ++ filePath f) (updateModDoc 
+  (vibcat [text "package" <+> text n <> end, modDoc (fileMod f)]) (fileMod f))
 
 fileDoc' :: Doc -> Doc -> Doc -> Doc
 fileDoc' t m b = vibcat [

--- a/code/drasil-code/Language/Drasil/Code/Imperative/LanguageRenderer.hs
+++ b/code/drasil-code/Language/Drasil/Code/Imperative/LanguageRenderer.hs
@@ -764,7 +764,7 @@ classDoc :: String -> [String]
 classDoc desc = [doxBrief ++ desc | not (null desc)]
 
 moduleDoc :: String -> String -> String -> [String]
-moduleDoc desc m ext = (doxFile ++ m ++ ext) : 
+moduleDoc desc m ext = (doxFile ++ addExt ext m) : 
   [doxBrief ++ desc | not (null desc)]
 
 docFuncRepr :: (MethodSym repr) => String -> [String] -> repr (Method repr) -> 

--- a/code/drasil-code/Language/Drasil/Code/Imperative/LanguageRenderer/CSharpRenderer.hs
+++ b/code/drasil-code/Language/Drasil/Code/Imperative/LanguageRenderer/CSharpRenderer.hs
@@ -45,7 +45,7 @@ import Language.Drasil.Code.Imperative.LanguageRenderer (addExt,
   moduleDoc, docFuncRepr, valList, surroundBody, getterName, setterName, 
   setMain, setMainMethod,setEmpty, intValue)
 import Language.Drasil.Code.Imperative.Data (Terminator(..), AuxData(..), ad, 
-  FileData(..), fileD, updateFileMod, FuncData(..), fd, ModData(..), md, 
+  FileData(..), srcFile, updateFileMod, FuncData(..), fd, ModData(..), md, 
   updateModDoc, MethodData(..), mthd, PackData(..), packD, ParamData(..), pd, 
   updateParamDoc, TypeData(..), td, ValData(..), vd, updateValDoc, VarData(..), 
   vard)
@@ -91,7 +91,7 @@ instance PackageSym CSharpCode where
 
 instance RenderSym CSharpCode where
   type RenderFile CSharpCode = FileData
-  fileDoc code = liftA2 fileD (fmap (addExt "cs" . name) code) (liftA2 
+  fileDoc code = liftA2 srcFile (fmap (addExt "cs" . name) code) (liftA2 
     updateModDoc (liftA2 emptyIfEmpty (fmap modDoc code) $ liftA3 fileDoc' 
     (top code) (fmap modDoc code) bottom) code)
 

--- a/code/drasil-code/Language/Drasil/Code/Imperative/LanguageRenderer/CSharpRenderer.hs
+++ b/code/drasil-code/Language/Drasil/Code/Imperative/LanguageRenderer/CSharpRenderer.hs
@@ -4,7 +4,7 @@
 -- | The logic to render C# code is contained in this module
 module Language.Drasil.Code.Imperative.LanguageRenderer.CSharpRenderer (
   -- * C# Code Configuration -- defines syntax of all C# code
-  CSharpCode(..), csExts
+  CSharpCode(..)
 ) where
 
 import Utils.Drasil (indent)
@@ -62,11 +62,8 @@ import Control.Applicative (Applicative, liftA2, liftA3)
 import Text.PrettyPrint.HughesPJ (Doc, text, (<>), (<+>), parens, comma, empty,
   semi, vcat, lbrace, rbrace, colon, isEmpty)
 
-csExts :: [String]
-csExts = [csExt]
-
 csExt :: String
-csExt = ".cs"
+csExt = "cs"
 
 newtype CSharpCode a = CSC {unCSC :: a} deriving Eq
 
@@ -91,7 +88,7 @@ instance PackageSym CSharpCode where
 
 instance RenderSym CSharpCode where
   type RenderFile CSharpCode = FileData
-  fileDoc code = liftA2 file (fmap (addExt "cs" . name) code) (liftA2 
+  fileDoc code = liftA2 file (fmap (addExt csExt . name) code) (liftA2 
     updateModDoc (liftA2 emptyIfEmpty (fmap modDoc code) $ liftA3 fileDoc' 
     (top code) (fmap modDoc code) bottom) code)
 

--- a/code/drasil-code/Language/Drasil/Code/Imperative/LanguageRenderer/CSharpRenderer.hs
+++ b/code/drasil-code/Language/Drasil/Code/Imperative/LanguageRenderer/CSharpRenderer.hs
@@ -45,7 +45,7 @@ import Language.Drasil.Code.Imperative.LanguageRenderer (addExt,
   moduleDoc, docFuncRepr, valList, surroundBody, getterName, setterName, 
   setMain, setMainMethod,setEmpty, intValue)
 import Language.Drasil.Code.Imperative.Data (Terminator(..), AuxData(..), ad, 
-  FileData(..), srcFile, updateFileMod, FuncData(..), fd, ModData(..), md, 
+  FileData(..), file, updateFileMod, FuncData(..), fd, ModData(..), md, 
   updateModDoc, MethodData(..), mthd, PackData(..), packD, ParamData(..), pd, 
   updateParamDoc, TypeData(..), td, ValData(..), vd, updateValDoc, VarData(..), 
   vard)
@@ -91,7 +91,7 @@ instance PackageSym CSharpCode where
 
 instance RenderSym CSharpCode where
   type RenderFile CSharpCode = FileData
-  fileDoc code = liftA2 srcFile (fmap (addExt "cs" . name) code) (liftA2 
+  fileDoc code = liftA2 file (fmap (addExt "cs" . name) code) (liftA2 
     updateModDoc (liftA2 emptyIfEmpty (fmap modDoc code) $ liftA3 fileDoc' 
     (top code) (fmap modDoc code) bottom) code)
 

--- a/code/drasil-code/Language/Drasil/Code/Imperative/LanguageRenderer/CppRenderer.hs
+++ b/code/drasil-code/Language/Drasil/Code/Imperative/LanguageRenderer/CppRenderer.hs
@@ -44,7 +44,7 @@ import Language.Drasil.Code.Imperative.LanguageRenderer (addExt,
   functionDoc, classDoc, moduleDoc, docFuncRepr, valList, appendToBody, 
   surroundBody, getterName, setterName, setEmpty, intValue)
 import Language.Drasil.Code.Imperative.Data (Pair(..), pairList, Terminator(..),
-  ScopeTag (..), AuxData(..), ad, FileData(..), fileD, updateFileMod, 
+  ScopeTag (..), AuxData(..), ad, FileData(..), srcFile, hdrFile, updateFileMod,
   FuncData(..), fd, ModData(..), md, updateModDoc, PackData(..), packD, 
   ParamData(..), pd, StateVarData(..), svd, TypeData(..), td, ValData(..), 
   VarData(..), vard)
@@ -651,7 +651,7 @@ instance PackageSym CppSrcCode where
   
 instance RenderSym CppSrcCode where
   type RenderFile CppSrcCode = FileData
-  fileDoc code = liftA2 fileD (fmap (addExt "cpp" . name) code) (liftA2 
+  fileDoc code = liftA2 srcFile (fmap (addExt "cpp" . name) code) (liftA2 
     updateModDoc (liftA2 emptyIfEmpty (fmap modDoc code) $ liftA3 fileDoc' 
     (top code) (fmap modDoc code) bottom) code)
 
@@ -1231,7 +1231,7 @@ instance PackageSym CppHdrCode where
 
 instance RenderSym CppHdrCode where
   type RenderFile CppHdrCode = FileData
-  fileDoc code = liftA2 fileD (fmap (addExt "hpp" . name) code) (liftA2 
+  fileDoc code = liftA2 hdrFile (fmap (addExt "hpp" . name) code) (liftA2 
     updateModDoc (liftA2 emptyIfEmpty (fmap modDoc code) $ liftA3 fileDoc' 
     (top code) (fmap modDoc code) bottom) code)
   

--- a/code/drasil-code/Language/Drasil/Code/Imperative/LanguageRenderer/CppRenderer.hs
+++ b/code/drasil-code/Language/Drasil/Code/Imperative/LanguageRenderer/CppRenderer.hs
@@ -5,7 +5,7 @@
 -- | The logic to render C++ code is contained in this module
 module Language.Drasil.Code.Imperative.LanguageRenderer.CppRenderer (
   -- * C++ Code Configuration -- defines syntax of all C++ code
-  CppSrcCode(..), CppHdrCode(..), CppCode(..), cppExts, unCPPC
+  CppSrcCode(..), CppHdrCode(..), CppCode(..), unCPPC
 ) where
 
 import Utils.Drasil (indent, indentList)
@@ -44,10 +44,10 @@ import Language.Drasil.Code.Imperative.LanguageRenderer (addExt,
   functionDoc, classDoc, moduleDoc, docFuncRepr, valList, appendToBody, 
   surroundBody, getterName, setterName, setEmpty, intValue)
 import Language.Drasil.Code.Imperative.Data (Pair(..), pairList, Terminator(..),
-  ScopeTag (..), AuxData(..), ad, FileData(..), srcFile, hdrFile, updateFileMod,
-  FuncData(..), fd, ModData(..), md, updateModDoc, PackData(..), packD, 
-  ParamData(..), pd, StateVarData(..), svd, TypeData(..), td, ValData(..), 
-  VarData(..), vard)
+  ScopeTag (..), AuxData(..), ad, FileData(..), srcFile, hdrFile, isHeader, 
+  updateFileMod, FuncData(..), fd, ModData(..), md, updateModDoc, PackData(..), 
+  packD, ParamData(..), pd, StateVarData(..), svd, TypeData(..), td, 
+  ValData(..), VarData(..), vard)
 import Language.Drasil.Code.Imperative.Doxygen.Import (makeDoxConfig)
 import Language.Drasil.Code.Imperative.Helpers (angles, blank, doubleQuotedText,
   emptyIfEmpty, mapPairFst, mapPairSnd, vibcat, liftA4, liftA5, liftA6, liftA8,
@@ -56,19 +56,15 @@ import Language.Drasil.Code.Imperative.Helpers (angles, blank, doubleQuotedText,
 
 import Prelude hiding (break,print,(<>),sin,cos,tan,floor,const,log,exp)
 import Data.List (nub)
-import Data.List.Utils (endswith)
 import qualified Data.Map as Map (fromList,lookup)
 import Data.Maybe (fromMaybe)
 import Control.Applicative (Applicative, liftA2, liftA3)
 import Text.PrettyPrint.HughesPJ (Doc, text, (<>), (<+>), braces, parens, comma,
   empty, equals, semi, vcat, lbrace, rbrace, quotes, render, colon, isEmpty)
 
-cppExts :: [String]
-cppExts = [cppHdrExt, cppSrcExt]
-
 cppHdrExt, cppSrcExt :: String
-cppHdrExt = ".hpp"
-cppSrcExt = ".cpp"
+cppHdrExt = "hpp"
+cppSrcExt = "cpp"
 
 data CppCode x y a = CPPC {src :: x a, hdr :: y a}
 
@@ -646,12 +642,12 @@ instance PackageSym CppSrcCode where
     where mods = filter (not . isEmpty . modDoc . fileMod . unCPPSC) ms
 
   packDox n ms = package n ms [doxConfig n (filter ((\f -> 
-    (isMainMod (fileMod f) || endswith cppHeaderExt (filePath f)) && 
+    (isMainMod (fileMod f) || isHeader f) && 
     not (isEmpty (modDoc (fileMod f))))  . unCPPSC) ms)]
   
 instance RenderSym CppSrcCode where
   type RenderFile CppSrcCode = FileData
-  fileDoc code = liftA2 srcFile (fmap (addExt "cpp" . name) code) (liftA2 
+  fileDoc code = liftA2 srcFile (fmap (addExt cppSrcExt . name) code) (liftA2 
     updateModDoc (liftA2 emptyIfEmpty (fmap modDoc code) $ liftA3 fileDoc' 
     (top code) (fmap modDoc code) bottom) code)
 
@@ -678,7 +674,7 @@ instance KeywordSym CppSrcCode where
   endStatement = return semi
   endStatementLoop = return empty
 
-  include n = return $ text "#include" <+> doubleQuotedText (n ++ cppHeaderExt)
+  include n = return $ text "#include" <+> doubleQuotedText (addExt cppHdrExt n)
   inherit = return colon
 
   list _ = return $ text "vector"
@@ -1231,7 +1227,7 @@ instance PackageSym CppHdrCode where
 
 instance RenderSym CppHdrCode where
   type RenderFile CppHdrCode = FileData
-  fileDoc code = liftA2 hdrFile (fmap (addExt "hpp" . name) code) (liftA2 
+  fileDoc code = liftA2 hdrFile (fmap (addExt cppHdrExt . name) code) (liftA2 
     updateModDoc (liftA2 emptyIfEmpty (fmap modDoc code) $ liftA3 fileDoc' 
     (top code) (fmap modDoc code) bottom) code)
   
@@ -1258,7 +1254,7 @@ instance KeywordSym CppHdrCode where
   endStatement = return semi
   endStatementLoop = return empty
 
-  include n = return $ text "#include" <+> doubleQuotedText (n ++ cppHeaderExt)
+  include n = return $ text "#include" <+> doubleQuotedText (addExt cppHdrExt n)
   inherit = return colon
 
   list _ = return $ text "vector"
@@ -1729,12 +1725,9 @@ setMainMethod (MthD _ s ps d) = MthD True s ps d
 enumsEqualInts :: Bool
 enumsEqualInts = False
 
-cppHeaderExt :: Label
-cppHeaderExt = ".hpp"
-
 cppstop :: ModData -> Doc -> Doc -> Doc
 cppstop (MD n b _) lst end = vcat [
-  if b then empty else inc <+> doubleQuotedText (n ++ cppHeaderExt),
+  if b then empty else inc <+> doubleQuotedText (addExt cppHdrExt n),
   if b then empty else blank,
   inc <+> angles (text "algorithm"),
   inc <+> angles (text "iostream"),

--- a/code/drasil-code/Language/Drasil/Code/Imperative/LanguageRenderer/JavaRenderer.hs
+++ b/code/drasil-code/Language/Drasil/Code/Imperative/LanguageRenderer/JavaRenderer.hs
@@ -45,7 +45,7 @@ import Language.Drasil.Code.Imperative.LanguageRenderer (addExt,
   functionDoc, classDoc, moduleDoc, docFuncRepr, valList, surroundBody, 
   getterName, setterName, setMain, setMainMethod, setEmpty, intValue)
 import Language.Drasil.Code.Imperative.Data (Terminator(..), AuxData(..), ad, 
-  FileData(..), srcFile, updateFileMod, FuncData(..), fd, ModData(..), md, 
+  FileData(..), file, updateFileMod, FuncData(..), fd, ModData(..), md, 
   updateModDoc, MethodData(..), mthd, ParamData(..), pd, PackData(..), packD, 
   TypeData(..), td, ValData(..), vd, VarData(..), vard)
 import Language.Drasil.Code.Imperative.Doxygen.Import (makeDoxConfig)
@@ -96,7 +96,7 @@ instance PackageSym JavaCode where
 
 instance RenderSym JavaCode where
   type RenderFile JavaCode = FileData
-  fileDoc code = liftA2 srcFile (fmap (addExt "java" . name) code) (liftA2 
+  fileDoc code = liftA2 file (fmap (addExt "java" . name) code) (liftA2 
     updateModDoc (liftA2 emptyIfEmpty (fmap modDoc code) $ liftA3 fileDoc' 
     (top code) (fmap modDoc code) bottom) code)
 

--- a/code/drasil-code/Language/Drasil/Code/Imperative/LanguageRenderer/JavaRenderer.hs
+++ b/code/drasil-code/Language/Drasil/Code/Imperative/LanguageRenderer/JavaRenderer.hs
@@ -45,7 +45,7 @@ import Language.Drasil.Code.Imperative.LanguageRenderer (addExt,
   functionDoc, classDoc, moduleDoc, docFuncRepr, valList, surroundBody, 
   getterName, setterName, setMain, setMainMethod, setEmpty, intValue)
 import Language.Drasil.Code.Imperative.Data (Terminator(..), AuxData(..), ad, 
-  FileData(..), fileD, updateFileMod, FuncData(..), fd, ModData(..), md, 
+  FileData(..), srcFile, updateFileMod, FuncData(..), fd, ModData(..), md, 
   updateModDoc, MethodData(..), mthd, ParamData(..), pd, PackData(..), packD, 
   TypeData(..), td, ValData(..), vd, VarData(..), vard)
 import Language.Drasil.Code.Imperative.Doxygen.Import (makeDoxConfig)
@@ -96,7 +96,7 @@ instance PackageSym JavaCode where
 
 instance RenderSym JavaCode where
   type RenderFile JavaCode = FileData
-  fileDoc code = liftA2 fileD (fmap (addExt "java" . name) code) (liftA2 
+  fileDoc code = liftA2 srcFile (fmap (addExt "java" . name) code) (liftA2 
     updateModDoc (liftA2 emptyIfEmpty (fmap modDoc code) $ liftA3 fileDoc' 
     (top code) (fmap modDoc code) bottom) code)
 

--- a/code/drasil-code/Language/Drasil/Code/Imperative/LanguageRenderer/JavaRenderer.hs
+++ b/code/drasil-code/Language/Drasil/Code/Imperative/LanguageRenderer/JavaRenderer.hs
@@ -4,7 +4,7 @@
 -- | The logic to render Java code is contained in this module
 module Language.Drasil.Code.Imperative.LanguageRenderer.JavaRenderer (
   -- * Java Code Configuration -- defines syntax of all Java code
-  JavaCode(..), jExts, jNameOpts
+  JavaCode(..), jNameOpts
 ) where
 
 import Utils.Drasil (indent)
@@ -60,11 +60,8 @@ import Control.Applicative (Applicative, liftA2, liftA3)
 import Text.PrettyPrint.HughesPJ (Doc, text, (<>), (<+>), parens, empty, equals,
   semi, vcat, lbrace, rbrace, render, colon, comma, isEmpty, render)
 
-jExts :: [String]
-jExts = [jExt]
-
 jExt :: String
-jExt = ".java"
+jExt = "java"
 
 jNameOpts :: NameOpts
 jNameOpts = NameOpts {
@@ -96,7 +93,7 @@ instance PackageSym JavaCode where
 
 instance RenderSym JavaCode where
   type RenderFile JavaCode = FileData
-  fileDoc code = liftA2 file (fmap (addExt "java" . name) code) (liftA2 
+  fileDoc code = liftA2 file (fmap (addExt jExt . name) code) (liftA2 
     updateModDoc (liftA2 emptyIfEmpty (fmap modDoc code) $ liftA3 fileDoc' 
     (top code) (fmap modDoc code) bottom) code)
 

--- a/code/drasil-code/Language/Drasil/Code/Imperative/LanguageRenderer/PythonRenderer.hs
+++ b/code/drasil-code/Language/Drasil/Code/Imperative/LanguageRenderer/PythonRenderer.hs
@@ -37,7 +37,7 @@ import Language.Drasil.Code.Imperative.LanguageRenderer (addExt, fileDoc',
   addCommentsDocD, classDoc, moduleDoc, docFuncRepr, valList, appendToBody, 
   getterName, setterName)
 import Language.Drasil.Code.Imperative.Data (Terminator(..), AuxData(..), ad, 
-  FileData(..), fileD, updateFileMod, FuncData(..), fd, ModData(..), md, 
+  FileData(..), srcFile, updateFileMod, FuncData(..), fd, ModData(..), md, 
   updateModDoc, MethodData(..), mthd, PackData(..), packD, ParamData(..), 
   TypeData(..), td, ValData(..), VarData(..), vard)
 import Language.Drasil.Code.Imperative.Doxygen.Import (makeDoxConfig)
@@ -81,7 +81,7 @@ instance PackageSym PythonCode where
 
 instance RenderSym PythonCode where
   type RenderFile PythonCode = FileData
-  fileDoc code = liftA2 fileD (fmap (addExt "py" . name) code) (liftA2 
+  fileDoc code = liftA2 srcFile (fmap (addExt "py" . name) code) (liftA2 
     updateModDoc (liftA2 emptyIfEmpty (fmap modDoc code) $ liftA3 fileDoc' 
     (top code) (fmap modDoc code) bottom) code)
 

--- a/code/drasil-code/Language/Drasil/Code/Imperative/LanguageRenderer/PythonRenderer.hs
+++ b/code/drasil-code/Language/Drasil/Code/Imperative/LanguageRenderer/PythonRenderer.hs
@@ -3,7 +3,7 @@
 -- | The logic to render Python code is contained in this module
 module Language.Drasil.Code.Imperative.LanguageRenderer.PythonRenderer (
   -- * Python Code Configuration -- defines syntax of all Python code
-  PythonCode(..), pyExts
+  PythonCode(..)
 ) where
 
 import Utils.Drasil (indent)
@@ -52,11 +52,8 @@ import Control.Applicative (Applicative, liftA2, liftA3)
 import Text.PrettyPrint.HughesPJ (Doc, text, (<>), (<+>), ($+$), parens, empty,
   equals, vcat, colon, brackets, isEmpty)
 
-pyExts :: [String]
-pyExts = [pyExt]
-
 pyExt :: String
-pyExt = ".py"
+pyExt = "py"
 
 newtype PythonCode a = PC {unPC :: a}
 
@@ -81,7 +78,7 @@ instance PackageSym PythonCode where
 
 instance RenderSym PythonCode where
   type RenderFile PythonCode = FileData
-  fileDoc code = liftA2 file (fmap (addExt "py" . name) code) (liftA2 
+  fileDoc code = liftA2 file (fmap (addExt pyExt . name) code) (liftA2 
     updateModDoc (liftA2 emptyIfEmpty (fmap modDoc code) $ liftA3 fileDoc' 
     (top code) (fmap modDoc code) bottom) code)
 

--- a/code/drasil-code/Language/Drasil/Code/Imperative/LanguageRenderer/PythonRenderer.hs
+++ b/code/drasil-code/Language/Drasil/Code/Imperative/LanguageRenderer/PythonRenderer.hs
@@ -37,7 +37,7 @@ import Language.Drasil.Code.Imperative.LanguageRenderer (addExt, fileDoc',
   addCommentsDocD, classDoc, moduleDoc, docFuncRepr, valList, appendToBody, 
   getterName, setterName)
 import Language.Drasil.Code.Imperative.Data (Terminator(..), AuxData(..), ad, 
-  FileData(..), srcFile, updateFileMod, FuncData(..), fd, ModData(..), md, 
+  FileData(..), file, updateFileMod, FuncData(..), fd, ModData(..), md, 
   updateModDoc, MethodData(..), mthd, PackData(..), packD, ParamData(..), 
   TypeData(..), td, ValData(..), VarData(..), vard)
 import Language.Drasil.Code.Imperative.Doxygen.Import (makeDoxConfig)
@@ -81,7 +81,7 @@ instance PackageSym PythonCode where
 
 instance RenderSym PythonCode where
   type RenderFile PythonCode = FileData
-  fileDoc code = liftA2 srcFile (fmap (addExt "py" . name) code) (liftA2 
+  fileDoc code = liftA2 file (fmap (addExt "py" . name) code) (liftA2 
     updateModDoc (liftA2 emptyIfEmpty (fmap modDoc code) $ liftA3 fileDoc' 
     (top code) (fmap modDoc code) bottom) code)
 


### PR DESCRIPTION
Now that GOOL constructs file paths (#1747), old code for getting file extensions and passing them around various functions was now obsolete and/or redundant. This PR cleans this code up so that file extensions are defined once in GOOL and thereafter read from file paths rather than passed as parameters.