### PR TITLE
Add ProgramSym typeclass to GOOL

### DIFF
--- a/code/drasil-code/Language/Drasil/Code.hs
+++ b/code/drasil-code/Language/Drasil/Code.hs
@@ -7,7 +7,7 @@ module Language.Drasil.Code (
   Mod(Mod), Structure(..), InputModule(..),
   asExpr, asExpr', asVC, asVC', codeSpec, fdec, ffor, funcData, funcDef, packmod, relToQD,
   junkLine, multiLine, repeated, singleLine, singleton,
-  PackageSym(..), RenderSym(..), 
+  PackageSym(..), ProgramSym(..), RenderSym(..), 
   PermanenceSym(..), BodySym(..), BlockSym(..), ControlBlockSym(..), 
   StateTypeSym(..), StatementSym(..), ControlStatementSym(..), VariableSym(..),
   ValueSym(..), NumericExpression(..), BooleanExpression(..), 
@@ -34,12 +34,12 @@ import Language.Drasil.CodeSpec (($:=), Choices(..), CodeSpec, Comments(..),
   packmod, relToQD,
   )
 
-import Language.Drasil.Code.Imperative.Symantics (PackageSym(..), RenderSym(..), 
-  PermanenceSym(..), BodySym(..), BlockSym(..), ControlBlockSym(..), 
-  StateTypeSym(..), StatementSym(..), ControlStatementSym(..), VariableSym(..), 
-  ValueSym(..), NumericExpression(..), BooleanExpression(..), 
-  ValueExpression(..), Selector(..), FunctionSym(..), SelectorFunction(..),
-  MethodSym(..), ModuleSym(..), BlockCommentSym(..))
+import Language.Drasil.Code.Imperative.Symantics (PackageSym(..), 
+  ProgramSym(..), RenderSym(..), PermanenceSym(..), BodySym(..), BlockSym(..), 
+  ControlBlockSym(..), StateTypeSym(..), StatementSym(..), 
+  ControlStatementSym(..), VariableSym(..), ValueSym(..), NumericExpression(..),
+  BooleanExpression(..), ValueExpression(..), Selector(..), FunctionSym(..), 
+  SelectorFunction(..), MethodSym(..), ModuleSym(..), BlockCommentSym(..))
 
 import Language.Drasil.Code.Imperative.Data (ModData(..))
 

--- a/code/drasil-code/Language/Drasil/Code/Imperative/Build/Import.hs
+++ b/code/drasil-code/Language/Drasil/Code/Imperative/Build/Import.hs
@@ -5,7 +5,7 @@ module Language.Drasil.Code.Imperative.Build.Import (
 import Language.Drasil.CodeSpec (Comments)
 import Language.Drasil.Code.Code (Code(..))
 import Language.Drasil.Code.Imperative.Data (FileData(..), isSource, isHeader, 
-  ModData(..), PackData(..))
+  ModData(..), ProgData(..))
 import Language.Drasil.Code.Imperative.Build.AST (BuildConfig(BuildConfig),
   BuildDependencies(..), Ext(..), includeExt, NameOpts, nameOpts, packSep,
   Runnable(Runnable), BuildName(..), RunType(..))
@@ -18,14 +18,16 @@ import Control.Applicative (liftA2)
 import Data.Maybe (maybe, maybeToList)
 import System.FilePath.Posix (takeExtension, takeBaseName)
 
-data CodeHarness = Ch (Maybe BuildConfig) Runnable PackData [Comments]
+data CodeHarness = Ch (Maybe BuildConfig) Runnable ProgData [Comments]
 
 instance RuleTransformer CodeHarness where
   makeRule (Ch b r m cms) = [
-    mkRule buildTarget (map (const $ renderBuildName m nameOpts nm) $ maybeToList b) []
+    mkRule buildTarget (map (const $ renderBuildName m nameOpts nm) 
+      $ maybeToList b) []
     ] ++
     maybe [] (\(BuildConfig comp bt) -> [
-    mkFile (renderBuildName m nameOpts nm) (map (makeS . filePath) (packMods m)) [
+    mkFile (renderBuildName m nameOpts nm) (map (makeS . filePath) (progMods m))
+      [
       mkCheckedCommand $ foldr (+:+) mempty $ comp (getCompilerInput bt m) $
         renderBuildName m nameOpts nm
       ]
@@ -34,15 +36,15 @@ instance RuleTransformer CodeHarness where
       mkCheckedCommand $ buildRunTarget (renderBuildName m no nm) ty +:+ mkFreeVar "RUNARGS"
       ]
     ] ++ [
-    mkRule (makeS "doc") (getCommentedFiles (packMods m)) 
+    mkRule (makeS "doc") (getCommentedFiles (progMods m))
       [mkCheckedCommand $ makeS $ "doxygen " ++ doxConfigName] | not (null cms)
     ] where
       (Runnable nm no ty) = r
       buildTarget = makeS "build"
 
-renderBuildName :: PackData -> NameOpts -> BuildName -> MakeString
+renderBuildName :: ProgData -> NameOpts -> BuildName -> MakeString
 renderBuildName p _ BMain = makeS $ takeBaseName $ getMainModule p
-renderBuildName p _ BPackName = makeS (packName p)
+renderBuildName p _ BPackName = makeS (progName p)
 renderBuildName p o (BPack a) = renderBuildName p o BPackName <> 
   makeS (packSep o) <> renderBuildName p o a
 renderBuildName p o (BWithExt a e) = renderBuildName p o a <> 
@@ -52,14 +54,14 @@ renderExt :: Ext -> FilePath -> MakeString
 renderExt CodeExt f = makeS $ takeExtension f
 renderExt (OtherExt e) _ = e
 
-getMainModule :: PackData -> FilePath
-getMainModule p = mainName $ filter (isMainMod . fileMod) (packMods p)
+getMainModule :: ProgData -> FilePath
+getMainModule p = mainName $ filter (isMainMod . fileMod) (progMods p)
   where mainName [FileD _ fp _] = fp
         mainName _ = error "Expected a single main module."
 
-getCompilerInput :: BuildDependencies -> PackData -> [MakeString]
+getCompilerInput :: BuildDependencies -> ProgData -> [MakeString]
 getCompilerInput BcSource p = map (makeS . filePath) $ filter isSource $ 
-  packMods p
+  progMods p
 getCompilerInput (BcSingle n) p = [renderBuildName p nameOpts n]
 
 getCommentedFiles :: [FileData] -> [MakeString]
@@ -70,5 +72,5 @@ buildRunTarget :: MakeString -> RunType -> MakeString
 buildRunTarget fn Standalone = makeS "./" <> fn
 buildRunTarget fn (Interpreter i) = i +:+ fn
 
-makeBuild :: PackData -> Maybe BuildConfig -> Runnable -> [Comments] -> Code
+makeBuild :: ProgData -> Maybe BuildConfig -> Runnable -> [Comments] -> Code
 makeBuild m b r cms = Code [("Makefile", genMake [Ch b r m cms])]

--- a/code/drasil-code/Language/Drasil/Code/Imperative/Data.hs
+++ b/code/drasil-code/Language/Drasil/Code/Imperative/Data.hs
@@ -1,8 +1,9 @@
 module Language.Drasil.Code.Imperative.Data (Pair(..), pairList,
-  Terminator(..), ScopeTag(..), FileType(..), AuxData(..), ad, FileData(..), 
-  fileD, file, srcFile, hdrFile, isSource, isHeader, updateFileMod, 
-  FuncData(..), fd, ModData(..), md, updateModDoc, MethodData(..), mthd, 
-  OpData(..), od, PackData(..), packD, ParamData(..), pd, updateParamDoc, 
+  Terminator(..), ScopeTag(..), FileType(..), AuxData(..), ad, emptyAux, 
+  FileData(..), fileD, file, srcFile, hdrFile, isSource, isHeader, 
+  updateFileMod, FuncData(..), fd, ModData(..), md, updateModDoc, 
+  MethodData(..), mthd, OpData(..), od, PackData(..), packD, emptyPack, 
+  ParamData(..), pd, updateParamDoc, ProgData(..), progD, emptyProg, 
   StateVarData(..), svd, TypeData(..), td, ValData(..), vd, updateValDoc, 
   VarData(..), vard
 ) where
@@ -11,7 +12,7 @@ import Language.Drasil.Code.Code (CodeType)
 
 import Control.Applicative (liftA2)
 import Prelude hiding ((<>))
-import Text.PrettyPrint.HughesPJ (Doc)
+import Text.PrettyPrint.HughesPJ (Doc, empty, isEmpty)
 
 class Pair p where
   pfst :: p x y a -> x a
@@ -33,6 +34,9 @@ data AuxData = AD {auxFilePath :: FilePath, auxDoc :: Doc}
 
 ad :: String -> Doc -> AuxData
 ad = AD
+
+emptyAux :: AuxData
+emptyAux = ad "" empty
 
 data FileData = FileD {fileType :: FileType, filePath :: FilePath,
   fileMod :: ModData}
@@ -85,11 +89,13 @@ data OpData = OD {opPrec :: Int, opDoc :: Doc}
 od :: Int -> Doc -> OpData
 od = OD
 
-data PackData = PackD {packName :: String, packMods :: [FileData], 
-  packAux :: [AuxData]}
+data PackData = PackD {packProg :: ProgData, packAux :: [AuxData]}
 
-packD :: String -> [FileData] -> [AuxData] -> PackData
+packD :: ProgData -> [AuxData] -> PackData
 packD = PackD
+
+emptyPack :: PackData
+emptyPack = packD emptyProg []
 
 data ParamData = PD {paramName :: String, paramType :: TypeData, 
   paramDoc :: Doc}
@@ -102,6 +108,14 @@ pd = PD
 
 updateParamDoc :: (Doc -> Doc) -> ParamData -> ParamData
 updateParamDoc f v = pd (paramName v) (paramType v) ((f . paramDoc) v)
+
+data ProgData = ProgD {progName :: String, progMods :: [FileData]}
+
+progD :: String -> [FileData] -> ProgData
+progD n fs = ProgD n (filter (not . isEmpty . modDoc . fileMod) fs)
+
+emptyProg :: ProgData
+emptyProg = progD "" []
 
 data StateVarData = SVD {getStVarScp :: ScopeTag, stVarDoc :: Doc, 
   destructSts :: (Doc, Terminator)}

--- a/code/drasil-code/Language/Drasil/Code/Imperative/Doxygen/Import.hs
+++ b/code/drasil-code/Language/Drasil/Code/Imperative/Doxygen/Import.hs
@@ -2,16 +2,21 @@ module Language.Drasil.Code.Imperative.Doxygen.Import (
   makeDoxConfig
 ) where
 
+import Language.Drasil.Code.Imperative.Data (ProgData(..), FileData(..), 
+  ModData(..), isHeader)
 import Language.Drasil.Code.Imperative.Helpers (blank)
 
 import Data.List (intersperse)
-import Text.PrettyPrint.HughesPJ (Doc, (<+>), text, hcat, vcat)
+import Text.PrettyPrint.HughesPJ (Doc, (<+>), isEmpty, text, hcat, vcat)
 
 type OptimizeChoice = Doc
 type ProjName = String
 
-makeDoxConfig :: ProjName -> OptimizeChoice -> [FilePath] -> Doc
-makeDoxConfig prog opt fs = vcat [
+makeDoxConfig :: ProjName -> OptimizeChoice -> ProgData -> Doc
+makeDoxConfig prog opt p = 
+  let fs = map filePath (filter (\f -> not (isEmpty $ modDoc $ fileMod f) && 
+             (isMainMod (fileMod f) || isHeader f)) (progMods p))
+  in vcat [
   text "# Doxyfile 1.8.15",
   blank,
   text "# This file describes the settings to be used by the documentation system",

--- a/code/drasil-code/Language/Drasil/Code/Imperative/Import.hs
+++ b/code/drasil-code/Language/Drasil/Code/Imperative/Import.hs
@@ -9,17 +9,17 @@ import Language.Drasil hiding (int, ($.), log, ln, exp,
 import Database.Drasil(ChunkDB, symbLookup, symbolTable)
 import Language.Drasil.Code.Code as C (Code(..), CodeType(List))
 import Language.Drasil.Code.Imperative.Symantics (Label, PackageSym(..), 
-  RenderSym(..), PermanenceSym(..), BodySym(..), BlockSym(..),
-  StateTypeSym(..), VariableSym(..), ValueSym(..), NumericExpression(..), 
-  BooleanExpression(..), ValueExpression(..), FunctionSym(..), 
-  SelectorFunction(..), StatementSym(..), ControlStatementSym(..), ScopeSym(..),
-  MethodTypeSym(..), ParameterSym(..), MethodSym(..), StateVarSym(..), 
-  ClassSym(..), ModuleSym(..))
+  ProgramSym(..), RenderSym(..), AuxiliarySym(..), PermanenceSym(..), 
+  BodySym(..), BlockSym(..), StateTypeSym(..), VariableSym(..), ValueSym(..),
+  NumericExpression(..), BooleanExpression(..), ValueExpression(..), 
+  FunctionSym(..), SelectorFunction(..), StatementSym(..), 
+  ControlStatementSym(..), ScopeSym(..), MethodTypeSym(..), ParameterSym(..),
+  MethodSym(..), StateVarSym(..), ClassSym(..), ModuleSym(..))
 import Language.Drasil.Code.Imperative.Build.AST (asFragment, buildAll,    
   BuildConfig, buildSingle, cppCompiler, inCodePackage, interp, interpMM, 
   mainModule, mainModuleFile, nativeBinary, osClassDefault, Runnable, withExt)
 import Language.Drasil.Code.Imperative.Build.Import (makeBuild)
-import Language.Drasil.Code.Imperative.Data (PackData(..))
+import Language.Drasil.Code.Imperative.Data (PackData(..), ProgData(..))
 import Language.Drasil.Code.Imperative.Helpers (convType)
 import Language.Drasil.Code.Imperative.LanguageRenderer.JavaRenderer (jNameOpts)
 import Language.Drasil.Code.CodeGeneration (createCodeFiles, makeCode)
@@ -149,17 +149,32 @@ generateCode l unRepr g =
      createCodeFiles $ C.Code $ concatMap C.unCode [code, makefile]
      setCurrentDirectory workingDir
   where pckg = runReader genPackage g
-        code = makeCode (packMods $ unRepr pckg) (packAux $ unRepr pckg)
-        makefile = makeBuild (unRepr pckg) (getBuildConfig l) 
+        code = makeCode (progMods $ packProg $ unRepr pckg) (packAux $ unRepr 
+          pckg)
+        makefile = makeBuild (packProg $ unRepr pckg) (getBuildConfig l) 
           (getRunnable l) (commented g)
 
 genPackage :: (PackageSym repr) => Reader (State repr) (repr (Package repr))
 genPackage = do
   g <- ask
+  p <- genProgram
+  let n = case codeSpec g of CodeSpec {program = pr} -> programName pr
+  a <- genDoxConfig n p
+  return $ package p a
+
+genDoxConfig :: (AuxiliarySym repr) => String -> repr (Program repr) ->
+  Reader (State repr) [repr (Auxiliary repr)]
+genDoxConfig n p = do
+  g <- ask
+  let cms = commented g
+  return $ if null cms then [] else [doxConfig n p]
+
+genProgram :: (ProgramSym repr) => Reader (State repr) (repr (Program repr))
+genProgram = do
+  g <- ask
   ms <- genModules
   let n = case codeSpec g of CodeSpec {program = p} -> programName p
-      cms = commented g
-  return $ if null cms then package n ms [] else packDox n ms
+  return $ prog n ms
 
 genModules :: (RenderSym repr) => Reader (State repr) [repr (RenderFile repr)]
 genModules = do

--- a/code/drasil-code/Language/Drasil/Code/Imperative/Import.hs
+++ b/code/drasil-code/Language/Drasil/Code/Imperative/Import.hs
@@ -167,7 +167,7 @@ genDoxConfig :: (AuxiliarySym repr) => String -> repr (Program repr) ->
 genDoxConfig n p = do
   g <- ask
   let cms = commented g
-  return $ if null cms then [] else [doxConfig n p]
+  return [doxConfig n p | not (null cms)]
 
 genProgram :: (ProgramSym repr) => Reader (State repr) (repr (Program repr))
 genProgram = do

--- a/code/drasil-code/Language/Drasil/Code/Imperative/LanguageRenderer.hs
+++ b/code/drasil-code/Language/Drasil/Code/Imperative/LanguageRenderer.hs
@@ -90,7 +90,8 @@ addExt ext nm = nm ++ "." ++ ext
 
 packageDocD :: Label -> Doc -> FileData -> FileData
 packageDocD n end f = fileD (fileType f) (n ++ "/" ++ filePath f) (updateModDoc 
-  (vibcat [text "package" <+> text n <> end, modDoc (fileMod f)]) (fileMod f))
+  (emptyIfEmpty (modDoc $ fileMod f) (vibcat [text "package" <+> text n <> end, 
+  modDoc (fileMod f)])) (fileMod f))
 
 fileDoc' :: Doc -> Doc -> Doc -> Doc
 fileDoc' t m b = vibcat [

--- a/code/drasil-code/Language/Drasil/Code/Imperative/LanguageRenderer/CSharpRenderer.hs
+++ b/code/drasil-code/Language/Drasil/Code/Imperative/LanguageRenderer/CSharpRenderer.hs
@@ -11,10 +11,10 @@ import Utils.Drasil (indent)
 
 import Language.Drasil.Code.Code (CodeType(..))
 import Language.Drasil.Code.Imperative.Symantics (Label, PackageSym(..), 
-  RenderSym(..), InternalFile(..), AuxiliarySym(..), KeywordSym(..), 
-  PermanenceSym(..), BodySym(..), BlockSym(..), ControlBlockSym(..), 
-  StateTypeSym(..), UnaryOpSym(..), BinaryOpSym(..), VariableSym(..), 
-  ValueSym(..), NumericExpression(..), BooleanExpression(..), 
+  ProgramSym(..), RenderSym(..), InternalFile(..), AuxiliarySym(..), 
+  KeywordSym(..), PermanenceSym(..), BodySym(..), BlockSym(..), 
+  ControlBlockSym(..), StateTypeSym(..), UnaryOpSym(..), BinaryOpSym(..), 
+  VariableSym(..), ValueSym(..), NumericExpression(..), BooleanExpression(..), 
   ValueExpression(..), InternalValue(..), Selector(..), FunctionSym(..), 
   SelectorFunction(..), InternalFunction(..), InternalStatement(..), 
   StatementSym(..), ControlStatementSym(..), ScopeSym(..), InternalScope(..), 
@@ -47,19 +47,18 @@ import Language.Drasil.Code.Imperative.LanguageRenderer (addExt,
 import Language.Drasil.Code.Imperative.Data (Terminator(..), AuxData(..), ad, 
   FileData(..), file, updateFileMod, FuncData(..), fd, ModData(..), md, 
   updateModDoc, MethodData(..), mthd, OpData(..), PackData(..), packD, 
-  ParamData(..), pd, updateParamDoc, TypeData(..), td, ValData(..),
-  updateValDoc, VarData(..), vard)
+  ParamData(..), pd, updateParamDoc, ProgData(..), progD, TypeData(..), td, 
+  ValData(..), updateValDoc, VarData(..), vard)
 import Language.Drasil.Code.Imperative.Doxygen.Import (makeDoxConfig)
 import Language.Drasil.Code.Imperative.Helpers (emptyIfEmpty, liftA4, liftA5, 
-  liftA6, liftA7, liftList, lift1List, lift2Lists, lift3Pair, lift4Pair,
+  liftA6, liftA7, liftList, lift1List, lift3Pair, lift4Pair,
   liftPair, liftPairFst, getInnerType, convType, checkParams)
-
 import Prelude hiding (break,print,(<>),sin,cos,tan,floor)
 import qualified Data.Map as Map (fromList,lookup)
 import Data.Maybe (fromMaybe)
 import Control.Applicative (Applicative, liftA2, liftA3)
 import Text.PrettyPrint.HughesPJ (Doc, text, (<>), (<+>), parens, comma, empty,
-  semi, vcat, lbrace, rbrace, colon, isEmpty)
+  semi, vcat, lbrace, rbrace, colon)
 
 csExt :: String
 csExt = "cs"
@@ -79,11 +78,11 @@ instance Monad CSharpCode where
 
 instance PackageSym CSharpCode where
   type Package CSharpCode = PackData
-  package n ms = lift2Lists (packD n) mods
-    where mods = filter (not . isEmpty . modDoc . fileMod . unCSC) ms
+  package = lift1List packD
 
-  packDox n ms = package n ms [doxConfig n mods]
-    where mods = filter (not . isEmpty . modDoc . fileMod . unCSC) ms
+instance ProgramSym CSharpCode where
+  type Program CSharpCode = ProgData
+  prog n = liftList (progD n)
 
 instance RenderSym CSharpCode where
   type RenderFile CSharpCode = FileData
@@ -103,8 +102,8 @@ instance InternalFile CSharpCode where
 
 instance AuxiliarySym CSharpCode where
   type Auxiliary CSharpCode = AuxData
-  doxConfig prog fs = fmap (ad doxConfigName) (lift1List (makeDoxConfig prog)
-    optimizeDox (map (fmap filePath) fs))
+  doxConfig pName p = fmap (ad doxConfigName) (liftA2 (makeDoxConfig pName)
+    optimizeDox p)
 
   optimizeDox = return $ text "NO"
 

--- a/code/drasil-code/Language/Drasil/Code/Imperative/LanguageRenderer/CppRenderer.hs
+++ b/code/drasil-code/Language/Drasil/Code/Imperative/LanguageRenderer/CppRenderer.hs
@@ -12,10 +12,10 @@ import Utils.Drasil (indent, indentList)
 
 import Language.Drasil.Code.Code (CodeType(..))
 import Language.Drasil.Code.Imperative.Symantics (Label, PackageSym(..), 
-  RenderSym(..), InternalFile(..), AuxiliarySym(..), KeywordSym(..), 
-  PermanenceSym(..), BodySym(..), BlockSym(..), ControlBlockSym(..), 
-  StateTypeSym(..), UnaryOpSym(..), BinaryOpSym(..), VariableSym(..), 
-  ValueSym(..), NumericExpression(..), BooleanExpression(..), 
+  ProgramSym(..), RenderSym(..), InternalFile(..), AuxiliarySym(..), 
+  KeywordSym(..), PermanenceSym(..), BodySym(..), BlockSym(..), 
+  ControlBlockSym(..), StateTypeSym(..), UnaryOpSym(..), BinaryOpSym(..), 
+  VariableSym(..), ValueSym(..), NumericExpression(..), BooleanExpression(..), 
   ValueExpression(..), InternalValue(..), Selector(..), FunctionSym(..), 
   SelectorFunction(..), InternalFunction(..), InternalStatement(..), 
   StatementSym(..), ControlStatementSym(..), ScopeSym(..), InternalScope(..), 
@@ -44,10 +44,11 @@ import Language.Drasil.Code.Imperative.LanguageRenderer (addExt,
   functionDoc, classDoc, moduleDoc, docFuncRepr, valList, appendToBody, 
   surroundBody, getterName, setterName, setEmpty, intValue)
 import Language.Drasil.Code.Imperative.Data (Pair(..), pairList, Terminator(..),
-  ScopeTag (..), AuxData(..), ad, FileData(..), srcFile, hdrFile, isHeader, 
+  ScopeTag(..), AuxData(..), ad, emptyAux, FileData(..), srcFile, hdrFile, 
   updateFileMod, FuncData(..), fd, ModData(..), md, updateModDoc, OpData(..), 
-  od, PackData(..), packD, ParamData(..), pd, StateVarData(..), svd, 
-  TypeData(..), td, ValData(..), VarData(..), vard)
+  od, PackData(..), packD, emptyPack, ParamData(..), pd, ProgData(..), progD, 
+  emptyProg, StateVarData(..), svd, TypeData(..), td, ValData(..), VarData(..), 
+  vard)
 import Language.Drasil.Code.Imperative.Doxygen.Import (makeDoxConfig)
 import Language.Drasil.Code.Imperative.Helpers (angles, blank, doubleQuotedText,
   emptyIfEmpty, mapPairFst, mapPairSnd, vibcat, liftA4, liftA5, liftA6, liftA8,
@@ -80,11 +81,12 @@ hdrToSrc (CPPHC a) = CPPSC a
 
 instance (Pair p) => PackageSym (p CppSrcCode CppHdrCode) where
   type Package (p CppSrcCode CppHdrCode) = PackData
-  package n ms aux = pair (package n (map (hdrToSrc . psnd) ms ++ map pfst ms) 
-    (map (hdrToSrc . psnd) aux ++ map pfst aux)) (return $ packD "" [] [])
+  package p aux = pair (package (pfst p) (map pfst aux)) (return emptyPack)
 
-  packDox n ms = pair (packDox n (map (hdrToSrc . psnd) ms ++ map pfst ms)) 
-    (return $ packD "" [] [])
+instance (Pair p) => ProgramSym (p CppSrcCode CppHdrCode) where
+  type Program (p CppSrcCode CppHdrCode) = ProgData
+  prog n ms = pair (prog n $ map (hdrToSrc . psnd) ms ++ map pfst ms) 
+    (return emptyProg)
 
 instance (Pair p) => RenderSym (p CppSrcCode CppHdrCode) where
   type RenderFile (p CppSrcCode CppHdrCode) = FileData
@@ -101,9 +103,9 @@ instance (Pair p) => InternalFile (p CppSrcCode CppHdrCode) where
 
 instance (Pair p) => AuxiliarySym (p CppSrcCode CppHdrCode) where
   type Auxiliary (p CppSrcCode CppHdrCode) = AuxData
-  doxConfig p fs = pair (doxConfig p $ map pfst fs) (doxConfig p $ map psnd fs)
+  doxConfig pName p = pair (doxConfig pName $ pfst p) (return emptyAux)
 
-  optimizeDox = pair optimizeDox optimizeDox
+  optimizeDox = pair optimizeDox (return empty)
 
 instance (Pair p) => KeywordSym (p CppSrcCode CppHdrCode) where
   type Keyword (p CppSrcCode CppHdrCode) = Doc
@@ -638,12 +640,11 @@ instance Monad CppSrcCode where
 
 instance PackageSym CppSrcCode where
   type Package CppSrcCode = PackData
-  package n ms = lift2Lists (packD n) mods
-    where mods = filter (not . isEmpty . modDoc . fileMod . unCPPSC) ms
+  package = lift1List packD
 
-  packDox n ms = package n ms [doxConfig n (filter ((\f -> 
-    (isMainMod (fileMod f) || isHeader f) && 
-    not (isEmpty (modDoc (fileMod f))))  . unCPPSC) ms)]
+instance ProgramSym CppSrcCode where
+  type Program CppSrcCode = ProgData
+  prog n = liftList (progD n)
   
 instance RenderSym CppSrcCode where
   type RenderFile CppSrcCode = FileData
@@ -664,8 +665,8 @@ instance InternalFile CppSrcCode where
 
 instance AuxiliarySym CppSrcCode where
   type Auxiliary CppSrcCode = AuxData
-  doxConfig prog fs = fmap (ad doxConfigName) (lift1List (makeDoxConfig prog)
-    optimizeDox (map (fmap filePath) fs))
+  doxConfig pName p = fmap (ad doxConfigName) (liftA2 (makeDoxConfig pName)
+    optimizeDox p)
 
   optimizeDox = return $ text "NO"
   
@@ -1220,13 +1221,6 @@ instance Monad CppHdrCode where
   return = CPPHC
   CPPHC x >>= f = f x
 
-instance PackageSym CppHdrCode where
-  type Package CppHdrCode = PackData
-  package n ms = lift2Lists (packD n) mods
-    where mods = filter (not . isEmpty . modDoc . fileMod . unCPPHC) ms
-
-  packDox n ms = package n ms [doxConfig n ms]
-
 instance RenderSym CppHdrCode where
   type RenderFile CppHdrCode = FileData
   fileDoc code = liftA2 hdrFile (fmap (addExt cppHdrExt . name) code) (liftA2 
@@ -1243,13 +1237,6 @@ instance RenderSym CppHdrCode where
 instance InternalFile CppHdrCode where
   top m = liftA3 cpphtop m (list dynamic_) endStatement
   bottom = return $ text "#endif"
-
-instance AuxiliarySym CppHdrCode where
-  type Auxiliary CppHdrCode = AuxData
-  doxConfig prog fs = fmap (ad doxConfigName) (lift1List (makeDoxConfig prog)
-    optimizeDox (map (fmap filePath) fs))
-
-  optimizeDox = return $ text "NO"
 
 instance KeywordSym CppHdrCode where
   type Keyword CppHdrCode = Doc

--- a/code/drasil-code/Language/Drasil/Code/Imperative/LanguageRenderer/JavaRenderer.hs
+++ b/code/drasil-code/Language/Drasil/Code/Imperative/LanguageRenderer/JavaRenderer.hs
@@ -11,10 +11,10 @@ import Utils.Drasil (indent)
 
 import Language.Drasil.Code.Code (CodeType(..))
 import Language.Drasil.Code.Imperative.Symantics (Label, PackageSym(..), 
-  RenderSym(..), InternalFile(..), AuxiliarySym(..), KeywordSym(..),
-  PermanenceSym(..), BodySym(..), BlockSym(..), ControlBlockSym(..), 
-  StateTypeSym(..), UnaryOpSym(..), BinaryOpSym(..), VariableSym(..), 
-  ValueSym(..), NumericExpression(..), BooleanExpression(..), 
+  ProgramSym(..), RenderSym(..), InternalFile(..), AuxiliarySym(..), 
+  KeywordSym(..), PermanenceSym(..), BodySym(..), BlockSym(..), 
+  ControlBlockSym(..), StateTypeSym(..), UnaryOpSym(..), BinaryOpSym(..), 
+  VariableSym(..), ValueSym(..), NumericExpression(..), BooleanExpression(..), 
   ValueExpression(..), InternalValue(..), Selector(..), FunctionSym(..), 
   SelectorFunction(..), InternalFunction(..), InternalStatement(..), 
   StatementSym(..), ControlStatementSym(..), ScopeSym(..), InternalScope(..), 
@@ -48,18 +48,18 @@ import Language.Drasil.Code.Imperative.LanguageRenderer (addExt,
 import Language.Drasil.Code.Imperative.Data (Terminator(..), AuxData(..), ad, 
   FileData(..), file, updateFileMod, FuncData(..), fd, ModData(..), md, 
   updateModDoc, MethodData(..), mthd, OpData(..), ParamData(..), pd, 
-  PackData(..), packD, TypeData(..), td, ValData(..), VarData(..), vard)
+  PackData(..), packD, ProgData(..), progD, TypeData(..), td, ValData(..), 
+  VarData(..), vard)
 import Language.Drasil.Code.Imperative.Doxygen.Import (makeDoxConfig)
 import Language.Drasil.Code.Imperative.Helpers (angles, emptyIfEmpty, 
-  liftA4, liftA5, liftA6, liftA7, liftList, lift1List, lift2Lists, lift3Pair, 
+  liftA4, liftA5, liftA6, liftA7, liftList, lift1List, lift3Pair, 
   lift4Pair, liftPair, liftPairFst, getInnerType, convType, checkParams)
-
 import Prelude hiding (break,print,sin,cos,tan,floor,(<>))
 import qualified Data.Map as Map (fromList,lookup)
 import Data.Maybe (fromMaybe)
 import Control.Applicative (Applicative, liftA2, liftA3)
 import Text.PrettyPrint.HughesPJ (Doc, text, (<>), (<+>), parens, empty, equals,
-  semi, vcat, lbrace, rbrace, render, colon, comma, isEmpty, render)
+  semi, vcat, lbrace, rbrace, render, colon, comma, render)
 
 jExt :: String
 jExt = "java"
@@ -85,12 +85,11 @@ instance Monad JavaCode where
 
 instance PackageSym JavaCode where
   type Package JavaCode = PackData
-  package n ms = lift2Lists (packD n) (map (liftA2 (packageDocD n) endStatement) mods)
-    where mods = filter (not . isEmpty . modDoc . fileMod . unJC) ms
+  package = lift1List packD
 
-  packDox n ms = lift2Lists (packD n) pMods [doxConfig n pMods]
-    where pMods = map (liftA2 (packageDocD n) endStatement) mods
-          mods = filter (not . isEmpty . modDoc . fileMod . unJC) ms
+instance ProgramSym JavaCode where
+  type Program JavaCode = ProgData
+  prog n ms = liftList (progD n) (map (liftA2 (packageDocD n) endStatement) ms)
 
 instance RenderSym JavaCode where
   type RenderFile JavaCode = FileData
@@ -110,8 +109,8 @@ instance InternalFile JavaCode where
 
 instance AuxiliarySym JavaCode where
   type Auxiliary JavaCode = AuxData
-  doxConfig prog fs = fmap (ad doxConfigName) (lift1List (makeDoxConfig prog)
-    optimizeDox (map (fmap filePath) fs))
+  doxConfig pName p = fmap (ad doxConfigName) (liftA2 (makeDoxConfig pName)
+    optimizeDox p)
 
   optimizeDox = return $ text "YES"
 

--- a/code/drasil-code/Language/Drasil/Code/Imperative/LanguageRenderer/PythonRenderer.hs
+++ b/code/drasil-code/Language/Drasil/Code/Imperative/LanguageRenderer/PythonRenderer.hs
@@ -10,10 +10,10 @@ import Utils.Drasil (indent)
 
 import Language.Drasil.Code.Code (CodeType(..))
 import Language.Drasil.Code.Imperative.Symantics (Label, PackageSym(..), 
-  RenderSym(..), InternalFile(..), AuxiliarySym(..), KeywordSym(..), 
-  PermanenceSym(..), BodySym(..), BlockSym(..), ControlBlockSym(..), 
-  StateTypeSym(..), UnaryOpSym(..), BinaryOpSym(..), VariableSym(..), 
-  ValueSym(..), NumericExpression(..), BooleanExpression(..), 
+  ProgramSym(..), RenderSym(..), InternalFile(..), AuxiliarySym(..), 
+  KeywordSym(..), PermanenceSym(..), BodySym(..), BlockSym(..), 
+  ControlBlockSym(..), StateTypeSym(..), UnaryOpSym(..), BinaryOpSym(..), 
+  VariableSym(..), ValueSym(..), NumericExpression(..), BooleanExpression(..), 
   ValueExpression(..), InternalValue(..), Selector(..), FunctionSym(..), 
   SelectorFunction(..), InternalFunction(..), InternalStatement(..), 
   StatementSym(..), ControlStatementSym(..), ScopeSym(..), InternalScope(..), 
@@ -39,7 +39,8 @@ import Language.Drasil.Code.Imperative.LanguageRenderer (addExt, fileDoc',
 import Language.Drasil.Code.Imperative.Data (Terminator(..), AuxData(..), ad, 
   FileData(..), file, updateFileMod, FuncData(..), fd, ModData(..), md, 
   updateModDoc, MethodData(..), mthd, OpData(..), PackData(..), packD, 
-  ParamData(..), TypeData(..), td, ValData(..), vd, VarData(..), vard)
+  ParamData(..), ProgData(..), progD, TypeData(..), td, ValData(..), vd,
+  VarData(..), vard)
 import Language.Drasil.Code.Imperative.Doxygen.Import (makeDoxConfig)
 import Language.Drasil.Code.Imperative.Helpers (blank, vibcat, emptyIfEmpty, 
   liftA4, liftA5, liftList, lift1List, lift2Lists, lift4Pair, liftPair, 
@@ -70,11 +71,11 @@ instance Monad PythonCode where
 
 instance PackageSym PythonCode where
   type Package PythonCode = PackData
-  package n ms = lift2Lists (packD n) mods
-    where mods = filter (not . isEmpty . modDoc . fileMod . unPC) ms
+  package = lift1List packD
 
-  packDox n ms = package n ms [doxConfig n mods]
-    where mods = filter (not . isEmpty . modDoc . fileMod . unPC) ms
+instance ProgramSym PythonCode where
+  type Program PythonCode = ProgData
+  prog n = liftList (progD n)
 
 instance RenderSym PythonCode where
   type RenderFile PythonCode = FileData
@@ -94,8 +95,8 @@ instance InternalFile PythonCode where
 
 instance AuxiliarySym PythonCode where
   type Auxiliary PythonCode = AuxData
-  doxConfig prog fs = fmap (ad doxConfigName) (lift1List (makeDoxConfig prog)
-    optimizeDox (map (fmap filePath) fs))
+  doxConfig pName p = fmap (ad doxConfigName) (liftA2 (makeDoxConfig pName)
+    optimizeDox p)
 
   optimizeDox = return $ text "YES"
 

--- a/code/drasil-code/Language/Drasil/Code/Imperative/Symantics.hs
+++ b/code/drasil-code/Language/Drasil/Code/Imperative/Symantics.hs
@@ -4,15 +4,16 @@ module Language.Drasil.Code.Imperative.Symantics (
   -- Types
   Label, Library,
   -- Typeclasses
-  PackageSym(..), RenderSym(..), InternalFile(..), AuxiliarySym(..), 
-  KeywordSym(..), PermanenceSym(..), BodySym(..), ControlBlockSym(..), 
-  BlockSym(..), StateTypeSym(..), UnaryOpSym(..), BinaryOpSym(..), 
-  VariableSym(..), ValueSym(..), NumericExpression(..), BooleanExpression(..), 
-  ValueExpression(..), InternalValue(..), Selector(..), FunctionSym(..), 
-  SelectorFunction(..), InternalFunction(..), InternalStatement(..), 
-  StatementSym(..), ControlStatementSym(..), ScopeSym(..), InternalScope(..), 
-  MethodTypeSym(..), ParameterSym(..), MethodSym(..), StateVarSym(..), 
-  ClassSym(..), ModuleSym(..), BlockCommentSym(..)
+  PackageSym(..), ProgramSym(..), RenderSym(..), InternalFile(..), 
+  AuxiliarySym(..), KeywordSym(..), PermanenceSym(..), BodySym(..), 
+  ControlBlockSym(..), BlockSym(..), StateTypeSym(..), UnaryOpSym(..), 
+  BinaryOpSym(..), VariableSym(..), ValueSym(..), NumericExpression(..), 
+  BooleanExpression(..), ValueExpression(..), InternalValue(..), Selector(..), 
+  FunctionSym(..), SelectorFunction(..), InternalFunction(..), 
+  InternalStatement(..), StatementSym(..), ControlStatementSym(..), 
+  ScopeSym(..), InternalScope(..), MethodTypeSym(..), ParameterSym(..), 
+  MethodSym(..), StateVarSym(..), ClassSym(..), ModuleSym(..), 
+  BlockCommentSym(..)
 ) where
 
 import Language.Drasil.Code.Code (CodeType)
@@ -21,12 +22,14 @@ import Text.PrettyPrint.HughesPJ (Doc)
 type Label = String
 type Library = String
 
-class (RenderSym repr, AuxiliarySym repr) => PackageSym repr where
+class (ProgramSym repr, AuxiliarySym repr) => PackageSym repr where
   type Package repr 
-  package :: Label -> [repr (RenderFile repr)] -> [repr (Auxiliary repr)] -> 
+  package :: repr (Program repr) -> [repr (Auxiliary repr)] -> 
     repr (Package repr)
 
-  packDox :: Label -> [repr (RenderFile repr)] -> repr (Package repr)
+class (RenderSym repr) => ProgramSym repr where
+  type Program repr
+  prog :: Label -> [repr (RenderFile repr)] -> repr (Program repr)
 
 class (ModuleSym repr, ControlBlockSym repr, InternalFile repr) => 
   RenderSym repr where 
@@ -44,7 +47,7 @@ class (ModuleSym repr) => InternalFile repr where
 
 class (KeywordSym repr, RenderSym repr) => AuxiliarySym repr where
   type Auxiliary repr
-  doxConfig :: String -> [repr (RenderFile repr)] -> repr (Auxiliary repr)
+  doxConfig :: String -> repr (Program repr) -> repr (Auxiliary repr)
 
   optimizeDox :: repr (Keyword repr)
 

--- a/code/drasil-code/Test/FileTests.hs
+++ b/code/drasil-code/Test/FileTests.hs
@@ -1,13 +1,13 @@
 module Test.FileTests (fileTests) where
 
-import Language.Drasil.Code (PackageSym(..), RenderSym(..), PermanenceSym(..),
-  BodySym(..), BlockSym(..), StateTypeSym(..), StatementSym(..), 
-  ControlStatementSym(..), VariableSym(..), ValueSym(..), MethodSym(..), 
-  ModuleSym(..))
+import Language.Drasil.Code (PackageSym(..), ProgramSym(..), RenderSym(..), 
+  PermanenceSym(..), BodySym(..), BlockSym(..), StateTypeSym(..), 
+  StatementSym(..), ControlStatementSym(..), VariableSym(..), ValueSym(..), 
+  MethodSym(..), ModuleSym(..))
 import Prelude hiding (return,print,log,exp,sin,cos,tan)
 
 fileTests :: (PackageSym repr) => repr (Package repr)
-fileTests = package "FileTests" [fileDoc (buildModule "FileTests" [] [fileTestMethod] [])] []
+fileTests = package (prog "FileTests" [fileDoc (buildModule "FileTests" [] [fileTestMethod] [])]) []
 
 fileTestMethod :: (RenderSym repr) => repr (Method repr)
 fileTestMethod = mainMethod "FileTests" (body [writeStory, block [readStory], 

--- a/code/drasil-code/Test/HelloWorld.hs
+++ b/code/drasil-code/Test/HelloWorld.hs
@@ -3,7 +3,7 @@
 module Test.HelloWorld (helloWorld) where
 
 import Language.Drasil.Code (
-  PackageSym(..), RenderSym(..), PermanenceSym(..),
+  PackageSym(..), ProgramSym(..), RenderSym(..), PermanenceSym(..),
   BodySym(..), BlockSym(..), ControlBlockSym(..), StateTypeSym(..), 
   StatementSym(..), ControlStatementSym(..),  VariableSym(..), ValueSym(..), 
   NumericExpression(..), BooleanExpression(..), ValueExpression(..), 
@@ -13,8 +13,8 @@ import Prelude hiding (return,print,log,exp,sin,cos,tan,const)
 import Test.Helper (helper)
 
 helloWorld :: (PackageSym repr) => repr (Package repr)
-helloWorld = package "HelloWorld" [docMod description $ 
-  fileDoc (buildModule "HelloWorld" ["Helper"] [helloWorldMain] []), helper] []
+helloWorld = package (prog "HelloWorld" [docMod description $ 
+  fileDoc (buildModule "HelloWorld" ["Helper"] [helloWorldMain] []), helper]) []
 
 description :: String
 description = "Tests various GOOL functions. It should run without errors."

--- a/code/drasil-code/Test/Main.hs
+++ b/code/drasil-code/Test/Main.hs
@@ -4,9 +4,9 @@ import Language.Drasil.Code.Imperative.Symantics (Label, PackageSym(..))
 import Language.Drasil.Code.Imperative.LanguageRenderer.JavaRenderer (JavaCode(..))
 import Language.Drasil.Code.Imperative.LanguageRenderer.PythonRenderer (PythonCode(..))
 import Language.Drasil.Code.Imperative.LanguageRenderer.CSharpRenderer (CSharpCode(..))
-import Language.Drasil.Code.Imperative.LanguageRenderer.CppRenderer (CppSrcCode(..), CppHdrCode(..))
+import Language.Drasil.Code.Imperative.LanguageRenderer.CppRenderer (unCPPC)
 import Language.Drasil.Code.Imperative.Data (FileData(..), ModData(..), 
-  PackData(..))
+  PackData(..), ProgData(..))
 import Text.PrettyPrint.HughesPJ (Doc, render)
 import System.Directory (setCurrentDirectory, createDirectoryIfMissing, getCurrentDirectory)
 import System.FilePath.Posix (takeDirectory)
@@ -33,13 +33,13 @@ main = do
   setCurrentDirectory workingDir
   createDirectoryIfMissing False "cpp"
   setCurrentDirectory "cpp"
-  genCode (classes unCPPSC)
-  genCode (classes unCPPHC)
+  genCode (classes unCPPC)
   setCurrentDirectory workingDir
     
 genCode :: [PackData] -> IO()
-genCode files = createCodeFiles (concatMap (\p -> replicate (length $ packMods 
-  p) (packName p)) files) $ makeCode (concatMap packMods files)
+genCode files = createCodeFiles (concatMap (\p -> replicate (length $ progMods $
+  packProg p) (progName $ packProg p)) files) $ makeCode (concatMap (progMods . packProg) 
+  files)
 
 classes :: (PackageSym repr) => (repr (Package repr) -> PackData) -> [PackData]
 classes unRepr = map unRepr [helloWorld, patternTest, fileTests]

--- a/code/drasil-code/Test/PatternTest.hs
+++ b/code/drasil-code/Test/PatternTest.hs
@@ -1,7 +1,7 @@
 module Test.PatternTest (patternTest) where
 
 import Language.Drasil.Code (
-  PackageSym(..), RenderSym(..), PermanenceSym(..),
+  PackageSym(..), ProgramSym(..), RenderSym(..), PermanenceSym(..),
   BodySym(..), BlockSym(..), ControlBlockSym(..), StateTypeSym(..), 
   StatementSym(..), ControlStatementSym(..), VariableSym(..), ValueSym(..),
   ValueExpression(..), FunctionSym(..), MethodSym(..), ModuleSym(..))
@@ -9,7 +9,7 @@ import Prelude hiding (return,print,log,exp,sin,cos,tan)
 import Test.Observer (observer)
 
 patternTest :: (PackageSym repr) => repr (Package repr)
-patternTest = package "PatternTest" [fileDoc (buildModule "PatternTest" ["Observer"] [patternTestMainMethod] []), observer] []
+patternTest = package (prog "PatternTest" [fileDoc (buildModule "PatternTest" ["Observer"] [patternTestMainMethod] []), observer]) []
 
 patternTestMainMethod :: (RenderSym repr) => repr (Method repr)
 patternTestMainMethod = mainMethod "PatternTest" (body [block [


### PR DESCRIPTION
Auxiliary files like the doxygen config need to know the finalized list of code files in the `Package`. Previously the list passed in to the `package` function was not final -- the function filtered and sometimes modified the list. This led me to create the `packDox` function which builds the auxiliary doxygen config file at the same time as the package. It wouldn't be feasible to continue creating similar functions for every type of auxiliary file we generate, so this PR adds a `ProgramSym` typeclass where code files get finalized/bundled before getting passed to `package`, removing the need for specialized functions like `packDox`.  