### PR TITLE
PR - Updating .gitignore to ignore stable generated Doxygen output files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,5 @@ __pycache__
 *.fls
 *.fdb_latexmk
 stack.yaml.lock
+/code/stable/*/src/*/html
+/code/stable/*/src/*/latex


### PR DESCRIPTION
Updating .gitignore to ignore stable generated Doxygen output files.
This includes the `html` and `latex` folders that are generated for each example.