### PR TITLE
Minor Naming Fixes in docLang

### DIFF
--- a/code/drasil-docLang/Drasil/DocLang.hs
+++ b/code/drasil-docLang/Drasil/DocLang.hs
@@ -9,7 +9,7 @@ module Drasil.DocLang (
   AppndxSec(..), AuxConstntSec(..), DerivationDisplay(..), Emphasis(..),
   OffShelfSolnsSec(..), GSDSec(..), GSDSub(UsrChars, SystCons, SysCntxt),
   IntroSec(..), IntroSub(..), LFunc(..), Literature(Doc', Lit,Manual),
-  RefSec(..), RefTab(..), StkhldrSec(StkhldrProg2), StkhldrSub(Client, Cstmr),
+  RefSec(..), RefTab(..), StkhldrSec(..), StkhldrSub(Client, Cstmr),
   TConvention(..), TraceabilitySec(TraceabilityProg), TSIntro(..), TUIntro(..),
   -- DocumentLanguage.Definitions
   Field(..), Fields, InclUnits(IncludeUnits), Verbosity(Verbose), ddefn,
@@ -46,7 +46,7 @@ import Drasil.DocumentLanguage (mkDoc, tsymb, tsymb'', tunit, tunit')
 import Drasil.DocumentLanguage.Core (AppndxSec(..), AuxConstntSec(..),
   DerivationDisplay(..), Emphasis(..), OffShelfSolnsSec(..), GSDSec(..),
   GSDSub(UsrChars, SystCons, SysCntxt), IntroSec(..), IntroSub(..), LFunc(..),
-  Literature(Doc', Lit,Manual), RefSec(..), RefTab(..), StkhldrSec(StkhldrProg2),
+  Literature(Doc', Lit,Manual), RefSec(..), RefTab(..), StkhldrSec(..),
   StkhldrSub(Client, Cstmr), TConvention(..), TraceabilitySec(TraceabilityProg),
   TSIntro(..), TUIntro(..))
 import Drasil.DocumentLanguage.Definitions (Field(..), Fields, InclUnits(IncludeUnits),

--- a/code/drasil-docLang/Drasil/DocLang.hs
+++ b/code/drasil-docLang/Drasil/DocLang.hs
@@ -7,7 +7,7 @@ module Drasil.DocLang (
   mkDoc, tsymb, tsymb'', tunit, tunit',
   -- DocumentLanguage.Core
   AppndxSec(..), AuxConstntSec(..), DerivationDisplay(..), Emphasis(..),
-  OffShelfSolnsSec(..), GSDSec(GSDProg2), GSDSub(UsrChars, SystCons, SysCntxt),
+  OffShelfSolnsSec(..), GSDSec(..), GSDSub(UsrChars, SystCons, SysCntxt),
   IntroSec(..), IntroSub(..), LFunc(..), Literature(Doc', Lit,Manual),
   RefSec(..), RefTab(..), StkhldrSec(StkhldrProg2), StkhldrSub(Client, Cstmr),
   TConvention(..), TraceabilitySec(TraceabilityProg), TSIntro(..), TUIntro(..),
@@ -44,7 +44,7 @@ import Drasil.DocDecl (SRSDecl, DocSection(..), ReqrmntSec(..), ReqsSub(..),
   SolChSpec(..))
 import Drasil.DocumentLanguage (mkDoc, tsymb, tsymb'', tunit, tunit')
 import Drasil.DocumentLanguage.Core (AppndxSec(..), AuxConstntSec(..),
-  DerivationDisplay(..), Emphasis(..), OffShelfSolnsSec(..), GSDSec(GSDProg2),
+  DerivationDisplay(..), Emphasis(..), OffShelfSolnsSec(..), GSDSec(..),
   GSDSub(UsrChars, SystCons, SysCntxt), IntroSec(..), IntroSub(..), LFunc(..),
   Literature(Doc', Lit,Manual), RefSec(..), RefTab(..), StkhldrSec(StkhldrProg2),
   StkhldrSub(Client, Cstmr), TConvention(..), TraceabilitySec(TraceabilityProg),

--- a/code/drasil-docLang/Drasil/DocumentLanguage.hs
+++ b/code/drasil-docLang/Drasil/DocumentLanguage.hs
@@ -37,7 +37,7 @@ import qualified Drasil.DocLang.SRS as SRS (appendix, dataDefn, genDefn,
   genSysDes, inModel, likeChg, unlikeChg, probDesc, reference, solCharSpec,
   stakeholder, thModel, tOfSymb, tOfUnit, userChar, offShelfSol)
 import qualified Drasil.Sections.AuxiliaryConstants as AC (valsOfAuxConstantsF)
-import qualified Drasil.Sections.GeneralSystDesc as GSD (genSysF, genSysIntro,
+import qualified Drasil.Sections.GeneralSystDesc as GSD (genSysIntro,
   systCon, usrCharsF, sysContxt)
 import qualified Drasil.Sections.Introduction as Intro (charIntRdrF,
   introductionSection, orgSec, purposeOfDoc, scopeOfRequirements)
@@ -228,8 +228,7 @@ mkStkhldrSec (StkhldrProg2 l) = SRS.stakeholder [Stk.stakeholderIntro] $ map mkS
 
 -- | Helper for making the 'General System Description' section
 mkGSDSec :: GSDSec -> Section
-mkGSDSec (GSDProg cntxt uI cnstrnts systSubSec) = GSD.genSysF cntxt uI cnstrnts systSubSec
-mkGSDSec (GSDProg2 l) = SRS.genSysDes [GSD.genSysIntro] $ map mkSubs l
+mkGSDSec (GSDProg l) = SRS.genSysDes [GSD.genSysIntro] $ map mkSubs l
    where
      mkSubs :: GSDSub -> Section
      mkSubs (SysCntxt cs)            = GSD.sysContxt cs

--- a/code/drasil-docLang/Drasil/DocumentLanguage.hs
+++ b/code/drasil-docLang/Drasil/DocumentLanguage.hs
@@ -45,8 +45,8 @@ import qualified Drasil.Sections.Requirements as R (reqF, fReqF, nfReqF)
 import qualified Drasil.Sections.SpecificSystemDescription as SSD (assumpF,
   datConF, dataDefnF, genDefnF, goalStmtF, inModelF, physSystDesc, probDescF,
   propCorSolF, solutionCharSpecIntro, specSysDescr, termDefnF, thModF)
-import qualified Drasil.Sections.Stakeholders as Stk (stakehldrGeneral,
-  stakeholderIntro, tClientF, tCustomerF)
+import qualified Drasil.Sections.Stakeholders as Stk (stakeholderIntro,
+  tClientF, tCustomerF)
 import qualified Drasil.DocumentLanguage.TraceabilityMatrix as TM (traceMGF,
   generateTraceTableView)
 
@@ -219,8 +219,7 @@ mkIntroSec si (IntroProg probIntro progDefn l) =
 
 -- | Helper for making the 'Stakeholders' section
 mkStkhldrSec :: StkhldrSec -> Section
-mkStkhldrSec (StkhldrProg key details) = Stk.stakehldrGeneral key details
-mkStkhldrSec (StkhldrProg2 l) = SRS.stakeholder [Stk.stakeholderIntro] $ map mkSubs l
+mkStkhldrSec (StkhldrProg l) = SRS.stakeholder [Stk.stakeholderIntro] $ map mkSubs l
   where
     mkSubs :: StkhldrSub -> Section
     mkSubs (Client kWrd details) = Stk.tClientF kWrd details

--- a/code/drasil-docLang/Drasil/DocumentLanguage/Core.hs
+++ b/code/drasil-docLang/Drasil/DocumentLanguage/Core.hs
@@ -113,8 +113,7 @@ data StkhldrSub where
 
 {--}
 
-data GSDSec = GSDProg [Section] Contents [Contents] [Section]
-            | GSDProg2 [GSDSub]
+newtype GSDSec = GSDProg [GSDSub]
 
 data GSDSub where
   SysCntxt   :: [Contents] -> GSDSub --FIXME: partially automate
@@ -248,8 +247,7 @@ instance Multiplate DLPlate where
     stk (StkhldrProg2 progs) = StkhldrProg2 <$> traverse (stkSub p) progs
     stk' (Client c s) = Client <$> pure c <*> pure s
     stk' (Cstmr c) = Cstmr <$> pure c
-    gs (GSDProg s1 c labcon s2) = GSDProg <$> pure s1 <*> pure c <*> pure labcon <*> pure s2
-    gs (GSDProg2 x) = GSDProg2 <$> traverse (gsdSub p) x
+    gs (GSDProg x) = GSDProg <$> traverse (gsdSub p) x
     gs' (SysCntxt c) = SysCntxt <$> pure c
     gs' (UsrChars c) = UsrChars <$> pure c
     gs' (SystCons c s) = SystCons <$> pure c <*> pure s

--- a/code/drasil-docLang/Drasil/DocumentLanguage/Core.hs
+++ b/code/drasil-docLang/Drasil/DocumentLanguage/Core.hs
@@ -104,7 +104,7 @@ data IntroSub where
 {--}
 
 -- | Stakeholders section
-data StkhldrSec = StkhldrProg CI Sentence | StkhldrProg2 [StkhldrSub]
+newtype StkhldrSec = StkhldrProg [StkhldrSub]
 
 -- | Stakeholders subsections
 data StkhldrSub where
@@ -243,8 +243,7 @@ instance Multiplate DLPlate where
     intro' (IScope s) = IScope <$> pure s
     intro' (IChar s1 s2 s3) = IChar <$> pure s1 <*> pure s2 <*> pure s3
     intro' (IOrgSec s1 c sect s2) = IOrgSec <$> pure s1 <*> pure c <*> pure sect <*> pure s2
-    stk (StkhldrProg c s) = StkhldrProg <$> pure c <*> pure s
-    stk (StkhldrProg2 progs) = StkhldrProg2 <$> traverse (stkSub p) progs
+    stk (StkhldrProg progs) = StkhldrProg <$> traverse (stkSub p) progs
     stk' (Client c s) = Client <$> pure c <*> pure s
     stk' (Cstmr c) = Cstmr <$> pure c
     gs (GSDProg x) = GSDProg <$> traverse (gsdSub p) x

--- a/code/drasil-docLang/Drasil/ExtractDocDesc.hs
+++ b/code/drasil-docLang/Drasil/ExtractDocDesc.hs
@@ -96,9 +96,6 @@ sentencePlate f = appendPlate (secConPlate (f . concatMap getCon') $ f . concatM
       (IScope s) -> [s]
       (IChar s1 s2 s3) -> concat [s1, s2, s3]
       (IOrgSec s1 _ _ s2) -> [s1, s2],
-    stkSec = Constant . f <$> \case
-      (StkhldrProg _ s) -> [s]
-      _ -> [],
     stkSub = Constant . f <$> \case
       (Client _ s) -> [s]
       (Cstmr _) -> [],
@@ -217,9 +214,6 @@ ciPlate = preorderFold $ purePlate {
   introSub = Constant <$> \case
     (IOrgSec _ ci _ _) -> [ci]
     _ -> [],
-  stkSec = Constant <$> \case
-    (StkhldrProg ci _) -> [ci]
-    (StkhldrProg2 _) -> [],
   stkSub = Constant <$> \case
    (Client ci _) -> [ci]
    (Cstmr ci) -> [ci],

--- a/code/drasil-docLang/Drasil/ExtractDocDesc.hs
+++ b/code/drasil-docLang/Drasil/ExtractDocDesc.hs
@@ -18,9 +18,8 @@ secConPlate mCon mSec = preorderFold $ purePlate {
   introSub = Constant <$> \case
     (IOrgSec _ _ s _) -> mSec [s]
     _ -> mempty,
-  gsdSec = Constant <$> \case
-    (GSDProg s1 c1 c2 s2) -> mconcat [mSec s1, mCon [c1], mCon c2, mSec s2]
-    (GSDProg2 _) -> mempty,
+  --gsdSec = Constant <$> \case
+  --  (GSDProg _) -> mempty,
   gsdSub = Constant <$> \case
     (SysCntxt c) -> mCon c
     (UsrChars c) -> mCon c

--- a/code/drasil-docLang/Drasil/Sections/GeneralSystDesc.hs
+++ b/code/drasil-docLang/Drasil/Sections/GeneralSystDesc.hs
@@ -5,17 +5,14 @@ import Utils.Drasil
 
 import Data.Drasil.Concepts.Documentation (interface, system, environment,
   userCharacteristic, systemConstraint, information, section_)
-import qualified Drasil.DocLang.SRS as SRS (genSysDes, userChar, sysCon, sysCont)
+import qualified Drasil.DocLang.SRS as SRS (sysCon, sysCont, userChar)
 
 --generalized general system description introduction
 genSysIntro :: Contents
-genSysIntro = foldlSP
-              [S "This", phrase section_, S "provides general",
-              phrase information, S "about the" +:+. phrase system, S "It",
-              S "identifies", S "the", plural interface, S "between the", 
-              phrase system `andIts` phrase environment `sC` S "describes the", 
-              plural userCharacteristic `sC` S "and lists the", 
-              plural systemConstraint]
+genSysIntro = foldlSP [S "This", phrase section_, S "provides general",
+  phrase information, S "about the" +:+. phrase system, S "It identifies the",
+  plural interface, S "between the", phrase system `andIts` phrase environment `sC`
+  S "describes the", plural userCharacteristic `sC` S "and lists the", plural systemConstraint]
 
 --User Characeristics
 usrCharsF :: [Contents] -> Section

--- a/code/drasil-docLang/Drasil/Sections/GeneralSystDesc.hs
+++ b/code/drasil-docLang/Drasil/Sections/GeneralSystDesc.hs
@@ -7,11 +7,6 @@ import Data.Drasil.Concepts.Documentation (interface, system, environment,
   userCharacteristic, systemConstraint, information, section_)
 import qualified Drasil.DocLang.SRS as SRS (genSysDes, userChar, sysCon, sysCont)
 
--- wrapper for general system description
-genSysF :: [Section] -> Contents -> [Contents] -> [Section] -> Section
-genSysF sCntxt userIntro cnstrnts systSubSec = SRS.genSysDes [genSysIntro]
-  (sCntxt ++ [usrCharsF [userIntro], systCon cnstrnts systSubSec])
-
 --generalized general system description introduction
 genSysIntro :: Contents
 genSysIntro = foldlSP

--- a/code/drasil-docLang/Drasil/Sections/Stakeholders.hs
+++ b/code/drasil-docLang/Drasil/Sections/Stakeholders.hs
@@ -1,26 +1,17 @@
-module Drasil.Sections.Stakeholders 
-  ( stakehldrGeneral
-    , tClientF
-    , tCustomerF
-    , stakeholderIntro
-  ) where
+module Drasil.Sections.Stakeholders (stakeholderIntro, tClientF, tCustomerF) where
 
 import Language.Drasil
 import Utils.Drasil
 
 import qualified Drasil.DocLang.SRS as SRS
-import Data.Drasil.Concepts.Documentation (section_, stakeholder, interest, product_, client,
-  customer, endUser)
-
-stakehldrGeneral :: (Idea a) => a -> Sentence -> Section
-stakehldrGeneral kWord clientDetails = SRS.stakeholder [stakeholderIntro] subs
-  where subs = [tClientF kWord clientDetails, tCustomerF kWord]
+import Data.Drasil.Concepts.Documentation (client, customer, endUser, interest,
+  product_, section_, stakeholder)
 
 -- general stakeholders introduction
 stakeholderIntro :: Contents
 stakeholderIntro = foldlSP [S "This", phrase section_,
             S "describes the" +: plural stakeholder, S "the people who have an",
-            phrase interest, S "in", phraseNP $ the product_]
+            phrase interest `sIn` phraseNP (the product_)]
 
 tClientF :: (Idea a) => a -> Sentence ->  Section
 tClientF kWord details = SRS.theClient [clientIntro kWord details] []
@@ -36,4 +27,4 @@ tCustomerF kWord = SRS.theCustomer [customerIntro kWord] []
 
 customerIntro :: (Idea a) => a -> Contents
 customerIntro kWord = foldlSP [atStartNP' $ the customer,
-  S "are the", phrase endUser, S "of", short kWord]
+  S "are the", phrase endUser `sOf` short kWord]

--- a/code/drasil-example/Drasil/GamePhysics/Body.hs
+++ b/code/drasil-example/Drasil/GamePhysics/Body.hs
@@ -68,7 +68,7 @@ mkSRS = [RefSec $ RefProg intro [TUnits, tsymb tableOfSymbols, TAandA],
    IScope scope,
    IChar [] [S "rigid body dynamics", phrase highSchoolCalculus] [],
    IOrgSec organizationOfDocumentsIntro inModel (SRS.inModel [] []) EmptyS],
-   GSDSec $ GSDProg2 [
+   GSDSec $ GSDProg [
     SysCntxt [sysCtxIntro, LlC sysCtxFig1, sysCtxDesc, sysCtxList],
     UsrChars [userCharacteristicsIntro], SystCons [] []],
    SSDSec $ SSDProg

--- a/code/drasil-example/Drasil/GlassBR/Body.hs
+++ b/code/drasil-example/Drasil/GlassBR/Body.hs
@@ -11,8 +11,8 @@ import Database.Drasil (ChunkDB, ReferenceDB, SystemInformation(SI),
 import Theory.Drasil (Theory(defined_fun, defined_quant))
 import Utils.Drasil
 
-import Drasil.DocLang (AppndxSec(..), AuxConstntSec(..), DerivationDisplay(..), 
-  DocSection(..), Field(..), Fields, GSDSec(GSDProg2), GSDSub(..),
+import Drasil.DocLang (AppndxSec(..), AuxConstntSec(..), DerivationDisplay(..),
+  DocSection(..), Field(..), Fields, GSDSec(..), GSDSub(..),
   InclUnits(IncludeUnits), IntroSec(IntroProg), IntroSub(IChar, IOrgSec, IPurpose, IScope), 
   ProblemDescription(..), PDSub(..), RefSec(RefProg), RefTab(TAandA, TUnits),
   ReqrmntSec(..), ReqsSub(..), SCSSub(..), SRSDecl, SSDSec(..), SSDSub(..),
@@ -108,7 +108,7 @@ mkSRS = [RefSec $ RefProg intro [TUnits, tsymb [TSPurpose, SymbOrder], TAandA],
       [Client glassBR $ S "a" +:+ phrase company
         +:+ S "named Entuitive. It is developed by Dr." +:+ (S $ name mCampidelli),
       Cstmr glassBR],
-  GSDSec $ GSDProg2 [SysCntxt [sysCtxIntro, LlC sysCtxFig, sysCtxDesc, sysCtxList],
+  GSDSec $ GSDProg [SysCntxt [sysCtxIntro, LlC sysCtxFig, sysCtxDesc, sysCtxList],
     UsrChars [userCharacteristicsIntro], SystCons [] [] ],
   SSDSec $
     SSDProg

--- a/code/drasil-example/Drasil/GlassBR/Body.hs
+++ b/code/drasil-example/Drasil/GlassBR/Body.hs
@@ -16,7 +16,7 @@ import Drasil.DocLang (AppndxSec(..), AuxConstntSec(..), DerivationDisplay(..),
   InclUnits(IncludeUnits), IntroSec(IntroProg), IntroSub(IChar, IOrgSec, IPurpose, IScope), 
   ProblemDescription(..), PDSub(..), RefSec(RefProg), RefTab(TAandA, TUnits),
   ReqrmntSec(..), ReqsSub(..), SCSSub(..), SRSDecl, SSDSec(..), SSDSub(..),
-  SolChSpec(..), StkhldrSec(StkhldrProg2), StkhldrSub(Client, Cstmr),
+  SolChSpec(..), StkhldrSec(..), StkhldrSub(Client, Cstmr),
   TraceabilitySec(TraceabilityProg), TSIntro(SymbOrder, TSPurpose),
   Verbosity(Verbose), auxSpecSent, characteristicsLabel, intro, mkDoc,
   termDefnF', tsymb, traceMatStandard)
@@ -104,7 +104,7 @@ mkSRS = [RefSec $ RefProg intro [TUnits, tsymb [TSPurpose, SymbOrder], TAandA],
      IChar [] (undIR ++ appStanddIR) [],
      IOrgSec orgOfDocIntro Doc.dataDefn (SRS.inModel [] []) orgOfDocIntroEnd],
   StkhldrSec $
-    StkhldrProg2
+    StkhldrProg
       [Client glassBR $ S "a" +:+ phrase company
         +:+ S "named Entuitive. It is developed by Dr." +:+ (S $ name mCampidelli),
       Cstmr glassBR],

--- a/code/drasil-example/Drasil/NoPCM/Body.hs
+++ b/code/drasil-example/Drasil/NoPCM/Body.hs
@@ -125,7 +125,7 @@ mkSRS = [RefSec $ RefProg intro
     , IChar [] charsOfReader []
     , IOrgSec orgDocIntro inModel (SRS.inModel [] []) orgDocEnd
     ],
-  GSDSec $ GSDProg2 
+  GSDSec $ GSDProg
     [ SysCntxt [sysCntxtDesc progName, LlC sysCntxtFig, sysCntxtRespIntro progName, systContRespBullets]
     , UsrChars [userChars progName]
     , SystCons [] []

--- a/code/drasil-example/Drasil/NoPCM/Body.hs
+++ b/code/drasil-example/Drasil/NoPCM/Body.hs
@@ -125,11 +125,12 @@ mkSRS = [RefSec $ RefProg intro
     , IChar [] charsOfReader []
     , IOrgSec orgDocIntro inModel (SRS.inModel [] []) orgDocEnd
     ],
-  GSDSec $ GSDProg
-    [ SysCntxt [sysCntxtDesc progName, LlC sysCntxtFig, sysCntxtRespIntro progName, systContRespBullets]
-    , UsrChars [userChars progName]
-    , SystCons [] []
-    ],
+  GSDSec $
+    GSDProg
+      [ SysCntxt [sysCntxtDesc progName, LlC sysCntxtFig, sysCntxtRespIntro progName, systContRespBullets]
+      , UsrChars [userChars progName]
+      , SystCons [] []
+      ],
   SSDSec $
     SSDProg
     [ SSDProblem $ PDProg probDescIntro []

--- a/code/drasil-example/Drasil/SSP/Body.hs
+++ b/code/drasil-example/Drasil/SSP/Body.hs
@@ -98,36 +98,39 @@ mkSRS :: SRSDecl
 mkSRS = [RefSec $ RefProg intro
   [TUnits, tsymb'' tableOfSymbIntro TAD, TAandA],
   IntroSec $ IntroProg startIntro kSent
-    [IPurpose prpsOfDoc_p1
+    [ IPurpose prpsOfDoc_p1
     , IScope scope
     , IChar []
         [phrase undergraduate +:+ S "level 4" +:+ phrase Doc.physics,
         phrase undergraduate +:+ S "level 2 or higher" +:+ phrase solidMechanics]
         [phrase soilMechanics]
-    , IOrgSec orgSecStart inModel (SRS.inModel [] []) orgSecEnd],
+    , IOrgSec orgSecStart inModel (SRS.inModel [] []) orgSecEnd
+    ],
     --FIXME: issue #235
-    GSDSec $ GSDProg2 [SysCntxt [sysCtxIntro, LlC sysCtxFig1, sysCtxDesc, sysCtxList],
-      UsrChars [userCharIntro], SystCons [sysConstraints] []],
-    SSDSec $
-      SSDProg
-        [ SSDProblem $ PDProg prob []
-          [ TermsAndDefs Nothing terms
-          , PhySysDesc ssp physSystParts figPhysSyst physSystContents 
-          , Goals goalsInputs]
-        , SSDSolChSpec $ SCSProg
-          [Assumptions
-          , TMs [] (Label : stdFields)
-          , GDs [] ([Label, Units] ++ stdFields) ShowDerivation
-          , DDs [] ([Label, Symbol, Units] ++ stdFields) ShowDerivation
-          , IMs instModIntro ([Label, Input, Output, InConstraints, OutConstraints] ++ stdFields) ShowDerivation
-          , Constraints EmptyS inputsWUncrtn --FIXME: issue #295
-          , CorrSolnPpties outputs []
-          ]
-        ],
-    ReqrmntSec $ ReqsProg [
-    FReqsSub funcReqTables,
-    NonFReqsSub
-  ],
+  GSDSec $ GSDProg
+    [ SysCntxt [sysCtxIntro, LlC sysCtxFig1, sysCtxDesc, sysCtxList]
+    , UsrChars [userCharIntro], SystCons [sysConstraints] []
+    ],
+  SSDSec $
+    SSDProg
+      [ SSDProblem $ PDProg prob []
+        [ TermsAndDefs Nothing terms
+        , PhySysDesc ssp physSystParts figPhysSyst physSystContents 
+        , Goals goalsInputs]
+      , SSDSolChSpec $ SCSProg
+        [Assumptions
+        , TMs [] (Label : stdFields)
+        , GDs [] ([Label, Units] ++ stdFields) ShowDerivation
+        , DDs [] ([Label, Symbol, Units] ++ stdFields) ShowDerivation
+        , IMs instModIntro ([Label, Input, Output, InConstraints, OutConstraints] ++ stdFields) ShowDerivation
+        , Constraints EmptyS inputsWUncrtn --FIXME: issue #295
+        , CorrSolnPpties outputs []
+        ]
+      ],
+  ReqrmntSec $ ReqsProg
+    [ FReqsSub funcReqTables
+    , NonFReqsSub
+    ],
   LCsSec,
   UCsSec,
   TraceabilitySec $ TraceabilityProg $ traceMatStandard si,

--- a/code/drasil-example/Drasil/SWHS/Body.hs
+++ b/code/drasil-example/Drasil/SWHS/Body.hs
@@ -133,7 +133,7 @@ mkSRS = [RefSec $ RefProg intro [
      IChar [] charsOfReader [],
      IOrgSec orgDocIntro inModel (SRS.inModel [] []) orgDocEnd
     ],
-  GSDSec $ GSDProg2 
+  GSDSec $ GSDProg
     [ SysCntxt [sysCntxtDesc progName, LlC sysCntxtFig, sysCntxtRespIntro progName, systContRespBullets]
     , UsrChars [userChars progName]
     , SystCons [] []


### PR DESCRIPTION
Fixed names of `GSDProg` and `StkhldrProg`, as outlined in #1602.