### PR TITLE
Try catch fix to remove warnings

### DIFF
--- a/code/drasil-code/Language/Drasil/Code/Imperative/GOOL/LanguageRenderer/CSharpRenderer.hs
+++ b/code/drasil-code/Language/Drasil/Code/Imperative/GOOL/LanguageRenderer/CSharpRenderer.hs
@@ -643,7 +643,7 @@ csTryCatch :: Doc -> Doc -> Doc
 csTryCatch tb cb= vcat [
   text "try" <+> lbrace,
   indent tb,
-  rbrace <+> text "catch" <+> parens (text "Exception" <+> text "exc") <+> 
+  rbrace <+> text "catch" <+> 
     lbrace,
   indent cb,
   rbrace]

--- a/code/drasil-code/Language/Drasil/Code/Imperative/GOOL/LanguageRenderer/PythonRenderer.hs
+++ b/code/drasil-code/Language/Drasil/Code/Imperative/GOOL/LanguageRenderer/PythonRenderer.hs
@@ -676,7 +676,7 @@ pyTryCatch :: Doc -> Doc -> Doc
 pyTryCatch tryB catchB = vcat [
   text "try" <+> colon,
   indent tryB,
-  text "except" <+> text "Exception" <+> text "as" <+> text "exc" <+> colon,
+  text "except" <+> text "Exception" <+> colon,
   indent catchB]
 
 pyListSlice :: VarData -> ValData -> 

--- a/code/stable/glassbr/src/csharp/Interpolation.cs
+++ b/code/stable/glassbr/src/csharp/Interpolation.cs
@@ -231,7 +231,7 @@ public class Interpolation {
             outfile.Write(k_2);
             outfile.WriteLine(" in module Interpolation");
             outfile.Close();
-        } catch (Exception exc) {
+        } catch {
             throw new Exception("Interpolation of y failed");
         }
         y_1 = func_lin_interp(x_z_1[j], y_z_1[j], x_z_1[j + 1], y_z_1[j + 1], x);
@@ -352,7 +352,7 @@ public class Interpolation {
                 outfile.Write(k_2);
                 outfile.WriteLine(" in module Interpolation");
                 outfile.Close();
-            } catch (Exception exc) {
+            } catch {
                 continue;
             }
             y_1 = func_lin_interp(x_z_1[j], y_z_1[j], x_z_1[j + 1], y_z_1[j + 1], x);

--- a/code/stable/glassbr/src/python/Interpolation.py
+++ b/code/stable/glassbr/src/python/Interpolation.py
@@ -142,7 +142,7 @@ def func_interpY(filename, x, z):
         print(k_2, end='', file=outfile)
         print(" in module Interpolation", file=outfile)
         outfile.close()
-    except Exception as exc :
+    except Exception :
         raise Exception("Interpolation of y failed")
     y_1 = func_lin_interp(x_z_1[j], y_z_1[j], x_z_1[j + 1], y_z_1[j + 1], x)
     outfile = open("log.txt", "a")
@@ -219,7 +219,7 @@ def func_interpZ(filename, x, y):
             print(k_2, end='', file=outfile)
             print(" in module Interpolation", file=outfile)
             outfile.close()
-        except Exception as exc :
+        except Exception :
             continue
         y_1 = func_lin_interp(x_z_1[j], y_z_1[j], x_z_1[j + 1], y_z_1[j + 1], x)
         outfile = open("log.txt", "a")


### PR DESCRIPTION
This is a quick fix for try catch statements generated by GOOL to not assign the caught exception to a variable. This way compilers won't throw warnings when the variable isn't used, as discussed in #1675.

Now our examples run with no warnings 😄 

Note that Java requires the variable be assigned, but it doesn't throw a warning if it goes unused, so that should be okay.