### PR TITLE
Doxygen Build Improvements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -78,6 +78,8 @@ script:
  - >-
      ci_fstep "CI: Code" make code
  - >-
+     ci_fstep "CI: Doxygen" make doxygen
+ - >-
      ci_fstep "CI: Docs" make docs haddockArgs=\"--no-haddock-deps --no-haddock-hyperlink-source\"
  - >-
      ci_fstep "CI: Graphs" make graphs

--- a/code/Makefile
+++ b/code/Makefile
@@ -161,9 +161,13 @@ tex: $(TEX_EXAMPLES)
 %$(CODE_E_SUFFIX): EXAMPLE=$(shell echo $* | tr a-z A-Z)
 %$(CODE_E_SUFFIX): EDIR=$($(EXAMPLE)_DIR)
 $(filter %$(CODE_E_SUFFIX), $(CODE_EXAMPLES)): %$(CODE_E_SUFFIX): %$(GEN_E_SUFFIX)
-	@EDIR="$(EDIR)" BUILD_FOLDER="$(BUILD_FOLDER)" EXAMPLE_CODE_SUBFOLDER="$(EXAMPLE_CODE_SUBFOLDER)" MAKE="$(MAKE)" "$(SHELL)" "$(SCRIPT_FOLDER)"code_build.sh
+	@EDIR="$(EDIR)" BUILD_FOLDER="$(BUILD_FOLDER)" EXAMPLE_CODE_SUBFOLDER="$(EXAMPLE_CODE_SUBFOLDER)" \
+	TARGET=$(TARGET) MAKE="$(MAKE)" "$(SHELL)" "$(SCRIPT_FOLDER)"code_build.sh
 
 code: $(CODE_EXAMPLES)
+
+doxygen: TARGET=doc
+doxygen: $(CODE_EXAMPLES)
 
 %$(DCP_E_SUFFIX): EXAMPLE=$(shell echo $* | tr a-z A-Z)
 %$(DCP_E_SUFFIX): EDIR=$($(EXAMPLE)_DIR)
@@ -183,7 +187,7 @@ deploy_lite:
 # files appear newer and thus PDF's are regenerated. If you want to "just generate the structure,
 # everything exists," (or you've run `deploy` once already) then `deploy_lite` does just that and is
 # what `deploy.bash` calls. 
-deploy: graphs docs tex
+deploy: graphs docs tex doxygen
 	"$(MAKE)" deploy_lite
 
 

--- a/code/drasil-code/Language/Drasil/Code/Imperative/Doxygen/Import.hs
+++ b/code/drasil-code/Language/Drasil/Code/Imperative/Doxygen/Import.hs
@@ -765,7 +765,7 @@ makeDoxConfig prog opt p =
   text "# messages are off.",
   text "# The default value is: NO.",
   blank,
-  text "QUIET                  = NO",
+  text "QUIET                  = YES",
   blank,
   text "# The WARNINGS tag can be used to turn on/off the warning messages that are",
   text "# generated to standard error (stderr) by doxygen. If WARNINGS is set to YES",

--- a/code/scripts/code_build.sh
+++ b/code/scripts/code_build.sh
@@ -14,7 +14,7 @@ if [ -d "$BUILD_FOLDER$EDIR/$EXAMPLE_CODE_SUBFOLDER" ]; then
   OLD_DIR=$(pwd)
   for d in */; do
     cd "$d"
-    "$MAKE"
+    "$MAKE" $TARGET
     RET=$(( $RET || $? ))
     cd "$OLD_DIR"
   done

--- a/code/scripts/deploy_stage.sh
+++ b/code/scripts/deploy_stage.sh
@@ -74,7 +74,6 @@ copy_examples() {
       for lang in "$example/"src/*; do
         lang_name=$(basename "$lang")
         mkdir -p "$EXAMPLE_DEST$example_name/$DOX_DEST$lang_name"
-        "$MAKE" -C "$lang" doc
         cp -r "$lang/"html/. "$EXAMPLE_DEST$example_name/$DOX_DEST$lang_name/"
       done
       # We don't expose code in deploy. It's more conveneient to link to GitHub's directory

--- a/code/stable/glassbr/src/cpp/doxConfig
+++ b/code/stable/glassbr/src/cpp/doxConfig
@@ -746,7 +746,7 @@ CITE_BIB_FILES         =
 # messages are off.
 # The default value is: NO.
 
-QUIET                  = NO
+QUIET                  = YES
 
 # The WARNINGS tag can be used to turn on/off the warning messages that are
 # generated to standard error (stderr) by doxygen. If WARNINGS is set to YES

--- a/code/stable/glassbr/src/csharp/doxConfig
+++ b/code/stable/glassbr/src/csharp/doxConfig
@@ -746,7 +746,7 @@ CITE_BIB_FILES         =
 # messages are off.
 # The default value is: NO.
 
-QUIET                  = NO
+QUIET                  = YES
 
 # The WARNINGS tag can be used to turn on/off the warning messages that are
 # generated to standard error (stderr) by doxygen. If WARNINGS is set to YES

--- a/code/stable/glassbr/src/java/doxConfig
+++ b/code/stable/glassbr/src/java/doxConfig
@@ -746,7 +746,7 @@ CITE_BIB_FILES         =
 # messages are off.
 # The default value is: NO.
 
-QUIET                  = NO
+QUIET                  = YES
 
 # The WARNINGS tag can be used to turn on/off the warning messages that are
 # generated to standard error (stderr) by doxygen. If WARNINGS is set to YES

--- a/code/stable/glassbr/src/python/doxConfig
+++ b/code/stable/glassbr/src/python/doxConfig
@@ -746,7 +746,7 @@ CITE_BIB_FILES         =
 # messages are off.
 # The default value is: NO.
 
-QUIET                  = NO
+QUIET                  = YES
 
 # The WARNINGS tag can be used to turn on/off the warning messages that are
 # generated to standard error (stderr) by doxygen. If WARNINGS is set to YES

--- a/code/stable/nopcm/src/cpp/doxConfig
+++ b/code/stable/nopcm/src/cpp/doxConfig
@@ -746,7 +746,7 @@ CITE_BIB_FILES         =
 # messages are off.
 # The default value is: NO.
 
-QUIET                  = NO
+QUIET                  = YES
 
 # The WARNINGS tag can be used to turn on/off the warning messages that are
 # generated to standard error (stderr) by doxygen. If WARNINGS is set to YES

--- a/code/stable/nopcm/src/csharp/doxConfig
+++ b/code/stable/nopcm/src/csharp/doxConfig
@@ -746,7 +746,7 @@ CITE_BIB_FILES         =
 # messages are off.
 # The default value is: NO.
 
-QUIET                  = NO
+QUIET                  = YES
 
 # The WARNINGS tag can be used to turn on/off the warning messages that are
 # generated to standard error (stderr) by doxygen. If WARNINGS is set to YES

--- a/code/stable/nopcm/src/java/doxConfig
+++ b/code/stable/nopcm/src/java/doxConfig
@@ -746,7 +746,7 @@ CITE_BIB_FILES         =
 # messages are off.
 # The default value is: NO.
 
-QUIET                  = NO
+QUIET                  = YES
 
 # The WARNINGS tag can be used to turn on/off the warning messages that are
 # generated to standard error (stderr) by doxygen. If WARNINGS is set to YES

--- a/code/stable/nopcm/src/python/doxConfig
+++ b/code/stable/nopcm/src/python/doxConfig
@@ -746,7 +746,7 @@ CITE_BIB_FILES         =
 # messages are off.
 # The default value is: NO.
 
-QUIET                  = NO
+QUIET                  = YES
 
 # The WARNINGS tag can be used to turn on/off the warning messages that are
 # generated to standard error (stderr) by doxygen. If WARNINGS is set to YES

--- a/code/stable/projectile/src/cpp/doxConfig
+++ b/code/stable/projectile/src/cpp/doxConfig
@@ -746,7 +746,7 @@ CITE_BIB_FILES         =
 # messages are off.
 # The default value is: NO.
 
-QUIET                  = NO
+QUIET                  = YES
 
 # The WARNINGS tag can be used to turn on/off the warning messages that are
 # generated to standard error (stderr) by doxygen. If WARNINGS is set to YES

--- a/code/stable/projectile/src/csharp/doxConfig
+++ b/code/stable/projectile/src/csharp/doxConfig
@@ -746,7 +746,7 @@ CITE_BIB_FILES         =
 # messages are off.
 # The default value is: NO.
 
-QUIET                  = NO
+QUIET                  = YES
 
 # The WARNINGS tag can be used to turn on/off the warning messages that are
 # generated to standard error (stderr) by doxygen. If WARNINGS is set to YES

--- a/code/stable/projectile/src/java/doxConfig
+++ b/code/stable/projectile/src/java/doxConfig
@@ -746,7 +746,7 @@ CITE_BIB_FILES         =
 # messages are off.
 # The default value is: NO.
 
-QUIET                  = NO
+QUIET                  = YES
 
 # The WARNINGS tag can be used to turn on/off the warning messages that are
 # generated to standard error (stderr) by doxygen. If WARNINGS is set to YES

--- a/code/stable/projectile/src/python/doxConfig
+++ b/code/stable/projectile/src/python/doxConfig
@@ -746,7 +746,7 @@ CITE_BIB_FILES         =
 # messages are off.
 # The default value is: NO.
 
-QUIET                  = NO
+QUIET                  = YES
 
 # The WARNINGS tag can be used to turn on/off the warning messages that are
 # generated to standard error (stderr) by doxygen. If WARNINGS is set to YES


### PR DESCRIPTION
This PR improves some Doxygen stuff from a build perspective.

This PR addresses Doxygen 404ing on deploy's due to the full path (i.e. /home/travis/JacquesCarette/Drasil/...) and messing with the path when combined with a web URL.

This PR adds the Makefile target `doxygen` to build the doxygen of all examples. We also build the Doxygen in all CI builds now. 

Finally, I've modified the Doxygen config to make the Doxygen output less verbose (@bmaclach) as we compile a lot of Doxygen and I'm trying to keep the number of lines for a full build in Travis <10k to avoid truncation. 