### PR TITLE
Added momentum to physics.hs to be used later in GamePhysics

### DIFF
--- a/code/drasil-data/Data/Drasil/Concepts/Physics.hs
+++ b/code/drasil-data/Data/Drasil/Concepts/Physics.hs
@@ -8,6 +8,7 @@ import Data.Drasil.IdeaDicts (mathematics, physics)
 import Data.Drasil.Concepts.Documentation (property, value)
 import Data.Drasil.Concepts.Math (xComp, xDir, yComp, yDir)
 import Control.Lens((^.)) --need for parametrization hack
+import qualified Data.Drasil.Quantities.PhysicalProperties as QPP (mass)
 
 physicCon :: [ConceptChunk]
 physicCon = [acceleration, angAccel, angDisp, angVelo, angular, chgInVelocity,
@@ -19,7 +20,7 @@ physicCon = [acceleration, angAccel, angDisp, angVelo, angular, chgInVelocity,
   momentOfInertia, position, potEnergy, pressure, restitutionCoef, rectilinear,
   rigidBody, scalarAccel, scalarPos, space, speed, strain, stress, tension,
   time, torque, velocity, weight, xAccel, xConstAccel, xDist, xPos, xVel,
-  yAccel, yConstAccel, yDist, yPos, yVel]
+  yAccel, yConstAccel, yDist, yPos, yVel, momentum]
 
 physicCon' :: [CI]
 physicCon' = [oneD, twoD, threeD]
@@ -33,7 +34,7 @@ acceleration, angAccel, angDisp, angVelo, angular, chgInVelocity, cohesion,
   pressure, rectilinear, restitutionCoef, rigidBody, scalarAccel, scalarPos,
   space, speed, strain, stress, tension, time, torque, velocity, weight,
   xAccel, xConstAccel, xDist, xPos, xVel, yAccel, yConstAccel, yDist,
-  yPos, yVel :: ConceptChunk
+  yPos, yVel, momentum :: ConceptChunk
 
 oneD, twoD, threeD :: CI
 oneD   = commonIdeaWithDict "oneD"   (cn "one-dimensional")   "1D" [mathematics, physics]
@@ -88,6 +89,9 @@ linear = dcc "linear" (cn' "linear")
   "arranged in or extending along a straight or nearly straight line"
 mechEnergy = dcc "mechEnergy" (cn "mechanical energy")
   "the energy that comes from motion and position"
+momentum = dccWDS "momentum" (cn "momentum")
+  ( S "the quantity of motion" `sOf` S "a moving body, measured as a product" `sOf` phrase QPP.mass `sAnd`
+   phrase velocity)
 position = dcc "position" (cn' "position")
   "an object's location relative to a reference point"
 potEnergy = dccWDS "potEnergy" (cn "potential energy")

--- a/code/drasil-data/Data/Drasil/Quantities/Physics.hs
+++ b/code/drasil-data/Data/Drasil/Quantities/Physics.hs
@@ -9,7 +9,7 @@ import qualified Data.Drasil.Concepts.Physics as CP (acceleration, angAccel,
   kEnergy, linAccel, linDisp, linVelo, momentOfInertia, position, potEnergy,
   pressure, restitutionCoef, scalarAccel, scalarPos, speed, time, torque,
   velocity, weight, xAccel, xConstAccel, xDist, xPos, xVel, yAccel, yConstAccel,
-  yDist,  yPos, yVel)
+  yDist,  yPos, yVel, momentum)
 
 import Data.Drasil.SI_Units (joule, metre, newton, pascal, radian, second)
 import Data.Drasil.Units.Physics (accelU, angAccelU, angVelU, gravConstU, 
@@ -27,7 +27,7 @@ physicscon = [acceleration, angularAccel, angularDisplacement, angularVelocity,
   linearAccel, linearDisplacement, linearVelocity, momentOfInertia, position,
   potEnergy, pressure, scalarAccel, scalarPos, speed, time, torque, velocity,
   weight, xAccel, xConstAccel, xDist, xPos, xVel, yAccel, yConstAccel, yDist,
-  yPos, yVel]
+  yPos, yVel, momentum]
 
 acceleration, angularAccel, angularDisplacement, angularVelocity, chgInVelocity,
   constAccel, constAccelV, displacement, distance, energy, fSpeed, fVel, force,
@@ -35,7 +35,7 @@ acceleration, angularAccel, angularDisplacement, angularVelocity, chgInVelocity,
   impulseV, ixPos, ixVel, iyPos, iyVel, kEnergy, linearAccel, linearDisplacement,
   linearVelocity, momentOfInertia, position, potEnergy, pressure, scalarAccel,
   scalarPos, speed, time, torque, velocity, weight, xAccel, xConstAccel, xDist,
-  xPos, xVel, yAccel, yConstAccel, yDist, yPos, yVel :: UnitalChunk
+  xPos, xVel, yAccel, yConstAccel, yDist, yPos, yVel, momentum :: UnitalChunk
 
 acceleration         = uc CP.acceleration (vec lA) accelU
 angularAccel         = uc CP.angAccel lAlpha angAccelU
@@ -57,6 +57,7 @@ linearAccel          = uc CP.linAccel (Concat [vec lA, Label "(", lT, Label ")"]
 linearDisplacement   = uc CP.linDisp  (Concat [vec lR, Label "(", lT, Label ")"]) metre
 linearVelocity       = uc CP.linVelo  (Concat [vec lV, Label "(", lT, Label ")"]) velU
 momentOfInertia      = uc CP.momentOfInertia (vec cI) momtInertU
+momentum             = uc CP.momentum (vec cP) impulseU
 position             = uc CP.position (vec lP) metre
 potEnergy            = uc CP.potEnergy (Concat [cP, cE]) joule
 pressure             = uc CP.pressure lP pascal


### PR DESCRIPTION
Added momentum in physics.hs. This will be required in some GDefs in other PRs coming soon.
Note: It will not be displayed in Table of Symbols (.html doc) yet, since it hasn't been used anywhere in GamePhysics SRS.

Please review changes in code.