### PR TITLE
Added damping to terminology and definition section

### DIFF
--- a/code/drasil-data/Data/Drasil/Citations.hs
+++ b/code/drasil-data/Data/Drasil/Citations.hs
@@ -9,7 +9,7 @@ import Data.Drasil.People (dParnas, jRalyte, lLai, nKoothoor, nKraiem,
 ---------------
 
 campidelli, cartesianWiki, koothoor2013, parnas1972, parnasClements1984,
-  parnasClements1986, smithLai2005, lineSource, pointSource :: Citation
+  parnasClements1986, smithLai2005, lineSource, pointSource, dampingSource :: Citation
 
 campidelli = cBooklet
   "Glass-BR Software for the design and risk assessment of glass facades subjected to blast loading"
@@ -67,6 +67,11 @@ pointSource = cMisc
   month May, year 2017]
   "pointSource"
 
+dampingSource = cMisc
+  [author [mononym "Wikipedia Contributors"], title "Damping",
+  howPublishedU "https://en.wikipedia.org/wiki/Damping_ratio",
+  month Jul, year 2019]
+  "dampingSource"
 ------------------------
 -- COMMON CITE-FIELDS --
 ------------------------

--- a/code/drasil-data/Data/Drasil/Concepts/Physics.hs
+++ b/code/drasil-data/Data/Drasil/Concepts/Physics.hs
@@ -9,6 +9,7 @@ import Data.Drasil.Concepts.Documentation (property, value)
 import Data.Drasil.Concepts.Math (xComp, xDir, yComp, yDir)
 import Control.Lens((^.)) --need for parametrization hack
 import qualified Data.Drasil.Quantities.PhysicalProperties as QPP (mass)
+import Data.Drasil.Citations (dampingSource)
 
 physicCon :: [ConceptChunk]
 physicCon = [acceleration, angAccel, angDisp, angVelo, angular, chgInVelocity,
@@ -53,8 +54,9 @@ cohesion = dccWDS "cohesion" (cn "cohesion")
   (S "an attractive" +:+ phrase force +:+ S "between adjacent particles that holds the matter together")
 compression = dccWDS "compression" (cn' "compression")
   (S "a" +:+ phrase stress +:+ S "that causes displacement of the body towards its center")
-damping = dcc "damping" (cn' "damping")
-  "an effect that tends to reduce the amplitude of vibrations"
+damping = dccWDS "damping" (pn' "damping")
+  $ S "an influence within or upon an oscillatory system that has the effect of reducing," +:+
+  S "restricting or preventing its oscillations" +:+ sParen (S "from" +:+ makeRef2S dampingSource)
 displacement = dccWDS "displacement" (cn' "displacement")
   (S "the change in" +:+ (position ^. defn))
 distance = dcc "distance" (cn' "distance")

--- a/code/drasil-example/Drasil/GamePhysics/Body.hs
+++ b/code/drasil-example/Drasil/GamePhysics/Body.hs
@@ -34,7 +34,7 @@ import Data.Drasil.SI_Units (metre, kilogram, second, newton, radian,
 import Data.Drasil.Software.Products (openSource, prodtcon, sciCompS, videoGame)
 
 import qualified Data.Drasil.Concepts.PhysicalProperties as CPP (ctrOfMass, dimension)
-import qualified Data.Drasil.Concepts.Physics as CP (elasticity, physicCon, rigidBody, collision)
+import qualified Data.Drasil.Concepts.Physics as CP (elasticity, physicCon, rigidBody, collision, damping)
 import qualified Data.Drasil.Concepts.Math as CM (cartesian, equation, law,
   mathcon, mathcon', rightHand, line, point)
 import qualified Data.Drasil.Quantities.Physics as QP (force, time)
@@ -335,7 +335,7 @@ probDescIntro = foldlSent_
 -----------------------------------------
 
 terms :: [ConceptChunk]
-terms = [CP.rigidBody, CP.elasticity, CPP.ctrOfMass, CM.cartesian, CM.rightHand, CM.line, CM.point]
+terms = [CP.rigidBody, CP.elasticity, CPP.ctrOfMass, CM.cartesian, CM.rightHand, CM.line, CM.point, CP.damping]
 
 -----------------------------
 -- 4.1.2 : Goal Statements --

--- a/code/drasil-example/Drasil/GamePhysics/References.hs
+++ b/code/drasil-example/Drasil/GamePhysics/References.hs
@@ -4,7 +4,7 @@ module Drasil.GamePhysics.References (chaslesWiki, citations, parnas1972,
 import Language.Drasil
 
 import Data.Drasil.Citations (cartesianWiki, koothoor2013, parnasClements1986,
-  parnas1972, parnasClements1984, smithLai2005, lineSource, pointSource)
+  parnas1972, parnasClements1984, smithLai2005, lineSource, pointSource, dampingSource)
 import Data.Drasil.People (bWaugh, cTitus, dParnas, daAruliah, epWhite, gWilson,
   imMitchell, jBueche, kdHuff, mDavis, mdPlumblet, nChueHong, pWilson, rGuy, shdHaddock)
 
@@ -12,7 +12,7 @@ chaslesWiki, jfBeucheIntro, parnas1978, sciComp2013 :: Citation
 
 citations :: BibRef
 citations = [parnas1978, sciComp2013, parnas1972, parnasClements1984, chaslesWiki,
-  parnasClements1986, koothoor2013, smithLai2005, jfBeucheIntro, cartesianWiki, lineSource, pointSource]
+  parnasClements1986, koothoor2013, smithLai2005, jfBeucheIntro, cartesianWiki, lineSource, pointSource, dampingSource]
 
 --FIXME: check for references made within document
 

--- a/code/stable/gamephysics/SRS/GamePhysics_SRS.tex
+++ b/code/stable/gamephysics/SRS/GamePhysics_SRS.tex
@@ -326,6 +326,7 @@ This subsection provides a list of terms that are used in the subsequent section
 \item{Right-handed coordinate system: A coordinate system where the positive z-axis comes out of the screen..}
 \item{Line: An interval between two points (from \cite{lineSource}).}
 \item{Point: An exact location, it has no size, only position (from \cite{pointSource}).}
+\item{damping: An influence within or upon an oscillatory system that has the effect of reducing, restricting or preventing its oscillations (from \cite{dampingSource}).}
 \end{itemize}
 \subsubsection{Goal Statements}
 \label{Sec:GoalStmt}
@@ -1810,6 +1811,12 @@ author={Wikipedia Contributors},
 title={Cartesian coordinate system},
 howpublished={\url{https://en.wikipedia.org/wiki/Cartesian\_coordinate\_system}},
 month=jun,
+year={2019}}
+@misc{dampingSource,
+author={Wikipedia Contributors},
+title={Damping},
+howpublished={\url{https://en.wikipedia.org/wiki/Damping\_ratio}},
+month=jul,
 year={2019}}
 @article{sciComp2013,
 author={Wilson, Greg and Aruliah, D. A. and Titus, C. and Chue Hong, Neil P. and Davis, Matt and Guy, Richard T. and Haddock, Steven H. D. and Huff, Kathryn D. and Mitchell, Ian M. and Plumblet, Mark D. and Waugh, Ben and White, Ethan P. and Wilson, Paul},

--- a/code/stable/gamephysics/Website/GamePhysics_SRS.html
+++ b/code/stable/gamephysics/Website/GamePhysics_SRS.html
@@ -639,6 +639,9 @@
                   <li>
                     Point: An exact location, it has no size, only position (from <a href=#pointSource>pointSource</a>).
                   </li>
+                  <li>
+                    damping: An influence within or upon an oscillatory system that has the effect of reducing, restricting or preventing its oscillations (from <a href=#dampingSource>dampingSource</a>).
+                  </li>
                 </ul>
               </div>
             </div>
@@ -4586,8 +4589,13 @@
             </div>
           </li>
           <li>
+            <div id="dampingSource">
+              [12]: Wikipedia Contributors. <em>Damping</em>. July, 2019. <a href="https://en.wikipedia.org/wiki/Damping_ratio">https://en.wikipedia.org/wiki/Damping_ratio</a>.
+            </div>
+          </li>
+          <li>
             <div id="sciComp2013">
-              [12]: Wilson, Greg, Aruliah, D. A., Titus, C., Chue Hong, Neil P., Davis, Matt, Guy, Richard T., Haddock, Steven H. D., Huff, Kathryn D., Mitchell, Ian M., Plumblet, Mark D., Waugh, Ben, White, Ethan P., and Wilson, Paul. "Best Practices for Scientific Computing, 2013." <em>PLoS Biol</em>, vol. 12, no. 1, 2013. Print.
+              [13]: Wilson, Greg, Aruliah, D. A., Titus, C., Chue Hong, Neil P., Davis, Matt, Guy, Richard T., Haddock, Steven H. D., Huff, Kathryn D., Mitchell, Ian M., Plumblet, Mark D., Waugh, Ben, White, Ethan P., and Wilson, Paul. "Best Practices for Scientific Computing, 2013." <em>PLoS Biol</em>, vol. 12, no. 1, 2013. Print.
             </div>
           </li>
         </ul>


### PR DESCRIPTION
Files updated:
 drasil-data/Data/Drasil/Citations.hs
 drasil-data/Data/Drasil/Concepts/Physics.hs
  drasil-example/Drasil/GamePhysics/Body.hs
  drasil-example/Drasil/GamePhysics/References.hs
   stable/gamephysics/SRS/GamePhysics_SRS.tex
   stable/gamephysics/Website/GamePhysics_SRS.html
Damping is now listed in Terminologies and definition section, with the wiki source

