### PR TITLE
Moment and axis added to Drasil

### DIFF
--- a/code/drasil-data/Data/Drasil/Concepts/Math.hs
+++ b/code/drasil-data/Data/Drasil/Concepts/Math.hs
@@ -10,7 +10,7 @@ import Control.Lens ((^.))
 
 mathcon :: [ConceptChunk]
 
-mathcon = [angle, area, calculation, cartesian, centre, change, constraint, diameter,
+mathcon = [angle, area, axis, calculation, cartesian, centre, change, constraint, diameter,
   equation, euclidN, euclidSpace, gradient, graph, law, line, matrix, norm, normal,
   normalV, number, orient, parameter, perp, perpV, pi_, point, probability, rOfChng,
   rate, rightHand, shape, surArea, surface, unitV, unit_, vector, xAxis, xCoord, xComp,
@@ -19,7 +19,7 @@ mathcon = [angle, area, calculation, cartesian, centre, change, constraint, diam
 mathcon' :: [CI]
 mathcon' = [de, leftSide, ode, pde, rightSide]
 
-angle, area, calculation, cartesian, centre, change, constraint, diameter, equation,
+angle, area, axis, calculation, cartesian, centre, change, constraint, diameter, equation,
   euclidN, euclidSpace, gradient, graph, law, line, matrix, norm, normal, normalV,
   number, orient, parameter, perp, perpV, pi_, point, probability, rOfChng, rate,
   rightHand, shape, surArea, surface, unitV, unit_, vector, xAxis, xCoord, xComp, xDir,
@@ -28,6 +28,7 @@ angle, area, calculation, cartesian, centre, change, constraint, diameter, equat
 
 angle       = dcc "angle"        (cn' "angle")                   "the amount of rotation needed to bring one line or plane into coincidence with another"
 area        = dcc "area"         (cn' "area")                    "a part of an object or surface"
+axis        = dcc "axis"         (cn' "axis")                    "a fixed reference line for the measurement of coordinates" 
 calculation = dcc "calculation"  (cn' "calculation")             "a mathematical determination of the size or number of something"
 cartesian   = dccWDS "cartesian" (pn' "Cartesian coordinate system") $ S "a coordinate system that specifies each point uniquely in a plane by a set" `sOf`
                                                                   S "numerical coordinates, which are the signed distances to the point from" +:+
@@ -44,7 +45,7 @@ euclidSpace  = dcc "euclidSpace"  (cn' "Euclidean")               ("Denoting the
 gradient     = dcc "gradient"     (cn' "gradient")                "degree of steepness of a graph at any point"
 graph        = dcc "graph"        (cn' "graph")                   "A diagram showing the relation between variable quantities"
 law          = dcc "law"          (cn' "law")                     "a generalization based on a fact or event perceived to be recurrent"
-line         = dccWDS "line"      (pn' "Line")                    $ S "An interval between two points" +:+
+line         = dccWDS "line"      (pn' "line")                    $ S "An interval between two points" +:+
                                                                   sParen (S "from" +:+ makeRef2S lineSource)
 matrix       = dcc "matrix"       (cnICES "matrix")               ("A rectangular array of quantities or expressions in rows and columns that" ++
                                                                  "is treated as a single entity and manipulated according to particular rules")
@@ -56,7 +57,7 @@ parameter   = dcc "parameter"    (cn' "parameter")               "a quantity who
 --FIXME: Should "parameter" be in math?
 perp         = dcc "perp"         (cn' "perpendicular")           "At right angles"
 pi_          = dcc "pi"           (cn' "ratio of circumference to diameter for any circle") "The ratio of a circle's circumference to its diameter"
-point        = dccWDS "point"     (pn' "Point")                   $ S "An exact location, it has no size, only position" +:+
+point        = dccWDS "point"     (pn' "point")                   $ S "An exact location, it has no size, only position" +:+
                                                                   sParen (S "from" +:+ makeRef2S pointSource)
 probability  = dcc "probability"  (cnIES "probability")           "The likelihood of an event to occur"
 rate         = dcc "rate"         (cn' "rate")                    "Ratio that compares two quantities having different units of measure"

--- a/code/drasil-data/Data/Drasil/Concepts/Physics.hs
+++ b/code/drasil-data/Data/Drasil/Concepts/Physics.hs
@@ -6,7 +6,7 @@ import Utils.Drasil
 
 import Data.Drasil.IdeaDicts (mathematics, physics)
 import Data.Drasil.Concepts.Documentation (property, value)
-import Data.Drasil.Concepts.Math (xComp, xDir, yComp, yDir)
+import Data.Drasil.Concepts.Math (xComp, xDir, yComp, yDir, point)
 import Control.Lens((^.)) --need for parametrization hack
 import qualified Data.Drasil.Quantities.PhysicalProperties as QPP (mass)
 import Data.Drasil.Citations (dampingSource)
@@ -21,7 +21,7 @@ physicCon = [acceleration, angAccel, angDisp, angVelo, angular, chgInVelocity,
   momentOfInertia, position, potEnergy, pressure, restitutionCoef, rectilinear,
   rigidBody, scalarAccel, scalarPos, space, speed, strain, stress, tension,
   time, torque, velocity, weight, xAccel, xConstAccel, xDist, xPos, xVel,
-  yAccel, yConstAccel, yDist, yPos, yVel, momentum]
+  yAccel, yConstAccel, yDist, yPos, yVel, momentum, moment]
 
 physicCon' :: [CI]
 physicCon' = [oneD, twoD, threeD]
@@ -35,7 +35,7 @@ acceleration, angAccel, angDisp, angVelo, angular, chgInVelocity, cohesion,
   pressure, rectilinear, restitutionCoef, rigidBody, scalarAccel, scalarPos,
   space, speed, strain, stress, tension, time, torque, velocity, weight,
   xAccel, xConstAccel, xDist, xPos, xVel, yAccel, yConstAccel, yDist,
-  yPos, yVel, momentum :: ConceptChunk
+  yPos, yVel, momentum, moment :: ConceptChunk
 
 oneD, twoD, threeD :: CI
 oneD   = commonIdeaWithDict "oneD"   (cn "one-dimensional")   "1D" [mathematics, physics]
@@ -94,6 +94,8 @@ mechEnergy = dcc "mechEnergy" (cn "mechanical energy")
 momentum = dccWDS "momentum" (cn "momentum")
   ( S "the quantity of motion" `sOf` S "a moving body, measured as a product" `sOf` phrase QPP.mass `sAnd`
    phrase velocity)
+moment = dccWDS "moment" (cn' "moment")
+  (S "A measure of the tendency of a body to rotate about a specific" +:+ phrase point `sOr` S "axis")
 position = dcc "position" (cn' "position")
   "an object's location relative to a reference point"
 potEnergy = dccWDS "potEnergy" (cn "potential energy")

--- a/code/drasil-data/Data/Drasil/Quantities/Physics.hs
+++ b/code/drasil-data/Data/Drasil/Quantities/Physics.hs
@@ -9,7 +9,7 @@ import qualified Data.Drasil.Concepts.Physics as CP (acceleration, angAccel,
   kEnergy, linAccel, linDisp, linVelo, momentOfInertia, position, potEnergy,
   pressure, restitutionCoef, scalarAccel, scalarPos, speed, time, torque,
   velocity, weight, xAccel, xConstAccel, xDist, xPos, xVel, yAccel, yConstAccel,
-  yDist,  yPos, yVel, momentum)
+  yDist,  yPos, yVel, momentum, moment)
 
 import Data.Drasil.SI_Units (joule, metre, newton, pascal, radian, second)
 import Data.Drasil.Units.Physics (accelU, angAccelU, angVelU, gravConstU, 
@@ -27,7 +27,7 @@ physicscon = [acceleration, angularAccel, angularDisplacement, angularVelocity,
   linearAccel, linearDisplacement, linearVelocity, momentOfInertia, position,
   potEnergy, pressure, scalarAccel, scalarPos, speed, time, torque, velocity,
   weight, xAccel, xConstAccel, xDist, xPos, xVel, yAccel, yConstAccel, yDist,
-  yPos, yVel, momentum]
+  yPos, yVel, momentum, moment]
 
 acceleration, angularAccel, angularDisplacement, angularVelocity, chgInVelocity,
   constAccel, constAccelV, displacement, distance, energy, fSpeed, fVel, force,
@@ -35,7 +35,7 @@ acceleration, angularAccel, angularDisplacement, angularVelocity, chgInVelocity,
   impulseV, ixPos, ixVel, iyPos, iyVel, kEnergy, linearAccel, linearDisplacement,
   linearVelocity, momentOfInertia, position, potEnergy, pressure, scalarAccel,
   scalarPos, speed, time, torque, velocity, weight, xAccel, xConstAccel, xDist,
-  xPos, xVel, yAccel, yConstAccel, yDist, yPos, yVel, momentum :: UnitalChunk
+  xPos, xVel, yAccel, yConstAccel, yDist, yPos, yVel, momentum, moment :: UnitalChunk
 
 acceleration         = uc CP.acceleration (vec lA) accelU
 angularAccel         = uc CP.angAccel lAlpha angAccelU
@@ -58,6 +58,7 @@ linearDisplacement   = uc CP.linDisp  (Concat [vec lR, Label "(", lT, Label ")"]
 linearVelocity       = uc CP.linVelo  (Concat [vec lV, Label "(", lT, Label ")"]) velU
 momentOfInertia      = uc CP.momentOfInertia (vec cI) momtInertU
 momentum             = uc CP.momentum (vec cP) impulseU
+moment               = uc CP.moment   (vec cM) torqueU
 position             = uc CP.position (vec lP) metre
 potEnergy            = uc CP.potEnergy (Concat [cP, cE]) joule
 pressure             = uc CP.pressure lP pascal

--- a/code/stable/gamephysics/SRS/GamePhysics_SRS.tex
+++ b/code/stable/gamephysics/SRS/GamePhysics_SRS.tex
@@ -324,8 +324,8 @@ This subsection provides a list of terms that are used in the subsequent section
 \item{Centre of mass: The mean location of the distribution of mass of the object.}
 \item{Cartesian coordinate system: A coordinate system that specifies each point uniquely in a plane by a set of numerical coordinates, which are the signed distances to the point from two fixed perpendicular oriented lines, measured in the same unit of length (from \cite{cartesianWiki}).}
 \item{Right-handed coordinate system: A coordinate system where the positive z-axis comes out of the screen..}
-\item{Line: An interval between two points (from \cite{lineSource}).}
-\item{Point: An exact location, it has no size, only position (from \cite{pointSource}).}
+\item{line: An interval between two points (from \cite{lineSource}).}
+\item{point: An exact location, it has no size, only position (from \cite{pointSource}).}
 \item{damping: An influence within or upon an oscillatory system that has the effect of reducing, restricting or preventing its oscillations (from \cite{dampingSource}).}
 \end{itemize}
 \subsubsection{Goal Statements}

--- a/code/stable/gamephysics/Website/GamePhysics_SRS.html
+++ b/code/stable/gamephysics/Website/GamePhysics_SRS.html
@@ -636,10 +636,10 @@
                     Right-handed coordinate system: A coordinate system where the positive z-axis comes out of the screen..
                   </li>
                   <li>
-                    Line: An interval between two points (from <a href=#lineSource>lineSource</a>).
+                    line: An interval between two points (from <a href=#lineSource>lineSource</a>).
                   </li>
                   <li>
-                    Point: An exact location, it has no size, only position (from <a href=#pointSource>pointSource</a>).
+                    point: An exact location, it has no size, only position (from <a href=#pointSource>pointSource</a>).
                   </li>
                   <li>
                     damping: An influence within or upon an oscillatory system that has the effect of reducing, restricting or preventing its oscillations (from <a href=#dampingSource>dampingSource</a>).


### PR DESCRIPTION
Added Moment.hs in physics.hs
In this PR, I also added 'axis' in maths.hs as I noticed it's not defined anywhere in Drasil.

@bmaclach, you can use 'moment' after this PR is merged.

 Torque = Moment? 