### PR TITLE
Renamed misleading GOOL functions and removed unused functions

### DIFF
--- a/code/drasil-code/Language/Drasil/Code/Imperative/Modules.hs
+++ b/code/drasil-code/Language/Drasil/Code/Imperative/Modules.hs
@@ -82,7 +82,7 @@ getInputDecl = do
       getDecl ([],ins) = do
         vars <- mapM mkVar ins
         return $ Just $ multi $ map varDec vars
-      getDecl (_,[]) = return $ Just $ extObjDecNewVoid cname v_params
+      getDecl (_,[]) = return $ Just $ extObjDecNewNoParams cname v_params
       getDecl _ = error ("Inputs or constants are only partially contained in " 
         ++ cname ++ " class")
       constIns ([],[]) _ = return Nothing
@@ -102,7 +102,7 @@ initConsts = do
       getDecl ([],cs) _ = getDecl' $ partition (flip member (eMap $ codeSpec g) 
         . codeName) cs 
       getDecl _ _ = error "Only some constants associated with Constants module in export map"
-      constCont Var = Just $ extObjDecNewVoid cname v_consts
+      constCont Var = Just $ extObjDecNewNoParams cname v_consts
       constCont Const = Nothing
       getDecl' (_,[]) = return Nothing
       getDecl' ([],cs) = do 

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer.hs
@@ -29,14 +29,14 @@ module GOOL.Drasil.LanguageRenderer (
   binExpr, binExpr', typeBinExpr, mkVal, mkVar, mkStaticVar, litTrueD, 
   litFalseD, litCharD, litFloatD, litIntD, litStringD, varDocD, extVarDocD, 
   selfDocD, argDocD, enumElemDocD, classVarCheckStatic, classVarD, classVarDocD,
-  objVarDocD, inlineIfD, funcAppDocD, extFuncAppDocD, stateObjDocD, 
-  listStateObjDocD, objDecDefDocD, constDecDefDocD, notNullDocD, 
-  listIndexExistsDocD, funcDocD, castDocD, sizeDocD, listAccessFuncDocD, 
-  listSetFuncDocD, objAccessDocD, castObjDocD, includeD, breakDocD, 
-  continueDocD, staticDocD, dynamicDocD, privateDocD, publicDocD, blockCmtDoc, 
-  docCmtDoc, commentedItem, addCommentsDocD, functionDoc, classDoc, moduleDoc, 
-  docFuncRepr, valList, prependToBody, appendToBody, surroundBody, getterName, 
-  setterName, setMainMethod, setEmpty, intValue, filterOutObjs
+  objVarDocD, inlineIfD, funcAppDocD, extFuncAppDocD, newObjDocD, 
+  objDecDefDocD, constDecDefDocD, notNullDocD, listIndexExistsDocD, funcDocD, 
+  castDocD, sizeDocD, listAccessFuncDocD, listSetFuncDocD, objAccessDocD, 
+  castObjDocD, includeD, breakDocD, continueDocD, staticDocD, dynamicDocD, 
+  privateDocD, publicDocD, blockCmtDoc, docCmtDoc, commentedItem, 
+  addCommentsDocD, functionDoc, classDoc, moduleDoc, docFuncRepr, valList, 
+  prependToBody, appendToBody, surroundBody, getterName, setterName, 
+  setMainMethod, setEmpty, intValue, filterOutObjs
 ) where
 
 import Utils.Drasil (blank, capitalize, indent, indentList, stringList)
@@ -726,11 +726,8 @@ funcAppDocD n vs = text n <> parens (valList vs)
 extFuncAppDocD :: Library -> Label -> [ValData] -> Doc
 extFuncAppDocD l n = funcAppDocD (l ++ "." ++ n)
 
-stateObjDocD :: TypeData -> Doc -> Doc
-stateObjDocD st vs = new <+> typeDoc st <> parens vs
-
-listStateObjDocD :: Doc -> TypeData -> Doc -> Doc
-listStateObjDocD lstObj st vs = lstObj <+> typeDoc st <> parens vs
+newObjDocD :: TypeData -> Doc -> Doc
+newObjDocD st vs = new <+> typeDoc st <> parens vs
 
 notNullDocD :: OpData -> ValData -> ValData -> Doc
 notNullDocD op v1 v2 = binOpDocD (opDoc op) (valDoc v1) (valDoc v2)

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer/CSharpRenderer.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer/CSharpRenderer.hs
@@ -37,11 +37,10 @@ import GOOL.Drasil.LanguageRenderer (addExt,
   mkVar, mkStaticVar, litTrueD, litFalseD, litCharD, litFloatD, litIntD, 
   litStringD, varDocD, extVarDocD, selfDocD, argDocD, enumElemDocD, 
   classVarCheckStatic, classVarD, classVarDocD, objVarDocD, inlineIfD, 
-  funcAppDocD, extFuncAppDocD, stateObjDocD, listStateObjDocD, notNullDocD, 
-  funcDocD, castDocD, listSetFuncDocD, listAccessFuncDocD, objAccessDocD, 
-  castObjDocD, breakDocD, continueDocD, staticDocD, dynamicDocD, privateDocD, 
-  publicDocD, dot, new, blockCmtStart, blockCmtEnd, docCmtStart, 
-  observerListName, doubleSlash, 
+  funcAppDocD, extFuncAppDocD, newObjDocD, notNullDocD, funcDocD, castDocD, 
+  listSetFuncDocD, listAccessFuncDocD, objAccessDocD, castObjDocD, breakDocD, 
+  continueDocD, staticDocD, dynamicDocD, privateDocD, publicDocD, dot, new, 
+  blockCmtStart, blockCmtEnd, docCmtStart, observerListName, doubleSlash, 
   blockCmtDoc, docCmtDoc, commentedItem, addCommentsDocD, functionDoc, classDoc,
   moduleDoc, docFuncRepr, valList, appendToBody, surroundBody, getterName, 
   setterName, setMainMethod, setEmpty, intValue, filterOutObjs)
@@ -106,7 +105,6 @@ instance KeywordSym CSharpCode where
   inherit = return colon
 
   list _ = return $ text "List"
-  listObj = return new
 
   blockStart = return lbrace
   blockEnd = return rbrace
@@ -308,10 +306,8 @@ instance ValueExpression CSharpCode where
   funcApp n t vs = liftA2 mkVal t (liftList (funcAppDocD n) vs)
   selfFuncApp = funcApp
   extFuncApp l n t vs = liftA2 mkVal t (liftList (extFuncAppDocD l n) vs)
-  stateObj t vs = liftA2 mkVal t (liftA2 stateObjDocD t (liftList valList vs))
-  extStateObj _ = stateObj
-  listStateObj t vs = liftA2 mkVal t (liftA3 listStateObjDocD listObj t 
-    (liftList valList vs))
+  newObj t vs = liftA2 mkVal t (liftA2 newObjDocD t (liftList valList vs))
+  extNewObj _ = newObj
 
   exists = notNull
   notNull v = liftA2 mkVal bool (liftA3 notNullDocD notEqualOp v (valueOf (var
@@ -404,11 +400,11 @@ instance StatementSym CSharpCode where
   objDecDef v def = csVarDec (variableBind v) $ mkSt <$> liftA4 objDecDefDocD v 
     def static_ dynamic_ 
   objDecNew v vs = csVarDec (variableBind v) $ mkSt <$> liftA4 objDecDefDocD v 
-    (stateObj (variableType v) vs) static_ dynamic_ 
+    (newObj (variableType v) vs) static_ dynamic_ 
   extObjDecNew _ = objDecNew
-  objDecNewVoid v = csVarDec (variableBind v) $ mkSt <$> liftA4 objDecDefDocD v 
-    (stateObj (variableType v) []) static_ dynamic_ 
-  extObjDecNewVoid _ = objDecNewVoid
+  objDecNewNoParams v = csVarDec (variableBind v) $ mkSt <$> liftA4 objDecDefDocD v 
+    (newObj (variableType v) []) static_ dynamic_ 
+  extObjDecNewNoParams _ = objDecNewNoParams
   constDecDef v def = mkSt <$> liftA2 constDecDefDocD v def
 
   print v = outDoc False printFunc v Nothing
@@ -433,7 +429,7 @@ instance StatementSym CSharpCode where
 
   getFileInputLine = getFileInput
   discardFileLine f = valState $ fmap csFileInput f
-  stringSplit d vnew s = assign vnew $ listStateObj (listType dynamic_ string) 
+  stringSplit d vnew s = assign vnew $ newObj (listType dynamic_ string) 
     [s $. func "Split" (listType static_ string) [litChar d]]
 
   stringListVals = stringListVals'

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer/CppRenderer.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer/CppRenderer.hs
@@ -106,7 +106,6 @@ instance (Pair p) => KeywordSym (p CppSrcCode CppHdrCode) where
   inherit = pair inherit inherit
 
   list p = pair (list $ pfst p) (list $ psnd p)
-  listObj = pair listObj listObj
 
   blockStart = pair blockStart blockStart
   blockEnd = pair blockEnd blockEnd
@@ -298,12 +297,10 @@ instance (Pair p) => ValueExpression (p CppSrcCode CppHdrCode) where
     (selfFuncApp n (psnd t) (map psnd vs))
   extFuncApp l n t vs = pair (extFuncApp l n (pfst t) (map pfst vs)) 
     (extFuncApp l n (psnd t) (map psnd vs))
-  stateObj t vs = pair (stateObj (pfst t) (map pfst vs)) (stateObj (psnd t) 
+  newObj t vs = pair (newObj (pfst t) (map pfst vs)) (newObj (psnd t) 
     (map psnd vs))
-  extStateObj l t vs = pair (extStateObj l (pfst t) (map pfst vs)) 
-    (extStateObj l (psnd t) (map psnd vs))
-  listStateObj t vs = pair (listStateObj (pfst t) (map pfst vs)) 
-    (listStateObj (psnd t) (map psnd vs))
+  extNewObj l t vs = pair (extNewObj l (pfst t) (map pfst vs)) 
+    (extNewObj l (psnd t) (map psnd vs))
 
   exists v = pair (exists $ pfst v) (exists $ psnd v)
   notNull v = pair (notNull $ pfst v) (notNull $ psnd v)
@@ -411,9 +408,9 @@ instance (Pair p) => StatementSym (p CppSrcCode CppHdrCode) where
     (psnd v) (map psnd vs))
   extObjDecNew lib v vs = pair (extObjDecNew lib (pfst v) (map pfst vs)) 
     (extObjDecNew lib (psnd v) (map psnd vs))
-  objDecNewVoid v = pair (objDecNewVoid $ pfst v) (objDecNewVoid $ psnd v)
-  extObjDecNewVoid lib v = pair (extObjDecNewVoid lib $ pfst v) 
-    (extObjDecNewVoid lib $ psnd v)
+  objDecNewNoParams v = pair (objDecNewNoParams $ pfst v) (objDecNewNoParams $ psnd v)
+  extObjDecNewNoParams lib v = pair (extObjDecNewNoParams lib $ pfst v) 
+    (extObjDecNewNoParams lib $ psnd v)
   constDecDef v def = pair (constDecDef (pfst v) (pfst def)) (constDecDef 
     (psnd v) (psnd def))
 
@@ -670,7 +667,6 @@ instance KeywordSym CppSrcCode where
   inherit = return colon
 
   list _ = return $ text "vector"
-  listObj = return empty
 
   blockStart = return lbrace
   blockEnd = return rbrace
@@ -874,9 +870,8 @@ instance ValueExpression CppSrcCode where
   funcApp n t vs = liftA2 mkVal t (liftList (funcAppDocD n) vs)
   selfFuncApp = funcApp
   extFuncApp _ = funcApp
-  stateObj t vs = liftA2 mkVal t (liftA2 cppStateObjDoc t (liftList valList vs))
-  extStateObj _ = stateObj
-  listStateObj = stateObj
+  newObj t vs = liftA2 mkVal t (liftA2 cppStateObjDoc t (liftList valList vs))
+  extNewObj _ = newObj
 
   exists = notNull
   notNull v = v
@@ -968,12 +963,12 @@ instance StatementSym CppSrcCode where
     (bindDoc <$> static_) (bindDoc <$> dynamic_) 
   objDecDef v def = mkSt <$> liftA4 objDecDefDocD v def (bindDoc <$> static_) 
     (bindDoc <$> dynamic_) 
-  objDecNew v vs = mkSt <$> liftA4 objDecDefDocD v (stateObj (variableType v) 
+  objDecNew v vs = mkSt <$> liftA4 objDecDefDocD v (newObj (variableType v) 
     vs) (bindDoc <$> static_) (bindDoc <$> dynamic_) 
   extObjDecNew _ = objDecNew
-  objDecNewVoid v = mkSt <$> liftA4 objDecDefDocD v (stateObj (variableType v) 
+  objDecNewNoParams v = mkSt <$> liftA4 objDecDefDocD v (newObj (variableType v) 
     []) (bindDoc <$> static_) (bindDoc <$> dynamic_) 
-  extObjDecNewVoid _ = objDecNewVoid
+  extObjDecNewNoParams _ = objDecNewNoParams
   constDecDef v def = mkSt <$> liftA2 constDecDefDocD v def
 
   print v = outDoc False printFunc v Nothing
@@ -1259,7 +1254,6 @@ instance KeywordSym CppHdrCode where
   inherit = return colon
 
   list _ = return $ text "vector"
-  listObj = return empty
 
   blockStart = return lbrace
   blockEnd = return rbrace
@@ -1440,9 +1434,8 @@ instance ValueExpression CppHdrCode where
   funcApp _ _ _ = liftA2 mkVal void (return empty)
   selfFuncApp _ _ _ = liftA2 mkVal void (return empty)
   extFuncApp _ _ _ _ = liftA2 mkVal void (return empty)
-  stateObj _ _ = liftA2 mkVal void (return empty)
-  extStateObj _ _ _ = liftA2 mkVal void (return empty)
-  listStateObj _ _ = liftA2 mkVal void (return empty)
+  newObj _ _ = liftA2 mkVal void (return empty)
+  extNewObj _ _ _ = liftA2 mkVal void (return empty)
 
   exists _ = liftA2 mkVal void (return empty)
   notNull _ = liftA2 mkVal void (return empty)
@@ -1530,8 +1523,8 @@ instance StatementSym CppHdrCode where
   objDecDef _ _ = return (mkStNoEnd empty)
   objDecNew _ _ = return (mkStNoEnd empty)
   extObjDecNew _ _ _ = return (mkStNoEnd empty)
-  objDecNewVoid _ = return (mkStNoEnd empty)
-  extObjDecNewVoid _ _ = return (mkStNoEnd empty)
+  objDecNewNoParams _ = return (mkStNoEnd empty)
+  extObjDecNewNoParams _ _ = return (mkStNoEnd empty)
   constDecDef v def = mkSt <$> liftA2 constDecDefDocD v def
 
   print _ = return (mkStNoEnd empty)

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer/JavaRenderer.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer/JavaRenderer.hs
@@ -36,14 +36,13 @@ import GOOL.Drasil.LanguageRenderer (addExt,
   binExpr', typeBinExpr, mkVal, mkVar, mkStaticVar, litTrueD, litFalseD, 
   litCharD, litFloatD, litIntD, litStringD, varDocD, extVarDocD, selfDocD, 
   argDocD, enumElemDocD, classVarCheckStatic, classVarD, classVarDocD, 
-  objVarDocD, inlineIfD, funcAppDocD, extFuncAppDocD, stateObjDocD, 
-  listStateObjDocD, notNullDocD, funcDocD, castDocD, objAccessDocD, castObjDocD,
-  breakDocD, continueDocD, staticDocD, dynamicDocD, privateDocD, publicDocD, 
-  dot, new, forLabel, blockCmtStart, blockCmtEnd, docCmtStart, observerListName,
-  doubleSlash, blockCmtDoc, 
-  docCmtDoc, commentedItem, addCommentsDocD, functionDoc, classDoc, moduleDoc, 
-  docFuncRepr, valList, appendToBody, surroundBody, getterName, setterName, 
-  setMainMethod, setEmpty, intValue, filterOutObjs)
+  objVarDocD, inlineIfD, funcAppDocD, extFuncAppDocD, newObjDocD, notNullDocD, 
+  funcDocD, castDocD, objAccessDocD, castObjDocD, breakDocD, continueDocD, 
+  staticDocD, dynamicDocD, privateDocD, publicDocD, dot, new, forLabel, 
+  blockCmtStart, blockCmtEnd, docCmtStart, observerListName, doubleSlash, 
+  blockCmtDoc, docCmtDoc, commentedItem, addCommentsDocD, functionDoc, classDoc,
+  moduleDoc, docFuncRepr, valList, appendToBody, surroundBody, getterName, 
+  setterName, setMainMethod, setEmpty, intValue, filterOutObjs)
 import GOOL.Drasil.Data (Terminator(..), 
   FileData(..), file, updateFileMod, FuncData(..), fd, ModData(..), md, 
   updateModDoc, MethodData(..), mthd, OpData(..), ParamData(..), pd, 
@@ -105,7 +104,6 @@ instance KeywordSym JavaCode where
   inherit = return $ text "extends"
 
   list _ = return $ text "ArrayList"
-  listObj = return new
 
   blockStart = return lbrace
   blockEnd = return rbrace
@@ -307,10 +305,8 @@ instance ValueExpression JavaCode where
   funcApp n t vs = liftA2 mkVal t (liftList (funcAppDocD n) vs)
   selfFuncApp = funcApp
   extFuncApp l n t vs = liftA2 mkVal t (liftList (extFuncAppDocD l n) vs)
-  stateObj t vs = liftA2 mkVal t (liftA2 stateObjDocD t (liftList valList vs))
-  extStateObj _ = stateObj
-  listStateObj t vs = liftA2 mkVal t (liftA3 listStateObjDocD listObj t 
-    (liftList valList vs))
+  newObj t vs = liftA2 mkVal t (liftA2 newObjDocD t (liftList valList vs))
+  extNewObj _ = newObj
 
   exists = notNull
   notNull v = liftA2 mkVal bool (liftA3 notNullDocD notEqualOp v (valueOf (var 
@@ -400,12 +396,12 @@ instance StatementSym JavaCode where
   listDecDef v vs = mkSt <$> liftA4 jListDecDef v (liftList valList vs) static_ 
     dynamic_ 
   objDecDef v def = mkSt <$> liftA4 objDecDefDocD v def static_ dynamic_ 
-  objDecNew v vs = mkSt <$> liftA4 objDecDefDocD v (stateObj (variableType v) 
+  objDecNew v vs = mkSt <$> liftA4 objDecDefDocD v (newObj (variableType v) 
     vs) static_ dynamic_ 
   extObjDecNew _ = objDecNew
-  objDecNewVoid v = mkSt <$> liftA4 objDecDefDocD v (stateObj (variableType v) 
+  objDecNewNoParams v = mkSt <$> liftA4 objDecDefDocD v (newObj (variableType v) 
     []) static_ dynamic_ 
-  extObjDecNewVoid _ = objDecNewVoid
+  extObjDecNewNoParams _ = objDecNewNoParams
   constDecDef v def = mkSt <$> liftA2 jConstDecDef v def
 
   print v = outDoc False printFunc v Nothing

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer/PythonRenderer.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer/PythonRenderer.hs
@@ -99,7 +99,6 @@ instance KeywordSym PythonCode where
   inherit = return empty
 
   list _ = return empty
-  listObj = return empty
 
   blockStart = return colon
   blockEnd = return empty
@@ -292,10 +291,9 @@ instance ValueExpression PythonCode where
   funcApp n t vs = liftA2 mkVal t (liftList (funcAppDocD n) vs)
   selfFuncApp = funcApp
   extFuncApp l n t vs = liftA2 mkVal t (liftList (extFuncAppDocD l n) vs)
-  stateObj t vs = liftA2 mkVal t (liftA2 pyStateObj t (liftList valList vs))
-  extStateObj l t vs = liftA2 mkVal t (liftA2 (pyExtStateObj l) t (liftList 
+  newObj t vs = liftA2 mkVal t (liftA2 pyStateObj t (liftList valList vs))
+  extNewObj l t vs = liftA2 mkVal t (liftA2 (pyExtStateObj l) t (liftList 
     valList vs))
-  listStateObj t _ = liftA2 mkVal t (fmap typeDoc t)
 
   exists v = v ?!= valueOf (var "None" void)
   notNull = exists
@@ -384,10 +382,10 @@ instance StatementSym PythonCode where
   listDec _ v = mkStNoEnd <$> fmap pyListDec v
   listDecDef v vs = mkStNoEnd <$> liftA2 pyListDecDef v (liftList valList vs)
   objDecDef = varDecDef
-  objDecNew v vs = varDecDef v (stateObj (variableType v) vs)
-  extObjDecNew lib v vs = varDecDef v (extStateObj lib (variableType v) vs)
-  objDecNewVoid v = varDecDef v (stateObj (variableType v) [])
-  extObjDecNewVoid lib v = varDecDef v (extStateObj lib (variableType v) [])
+  objDecNew v vs = varDecDef v (newObj (variableType v) vs)
+  extObjDecNew lib v vs = varDecDef v (extNewObj lib (variableType v) vs)
+  objDecNewNoParams v = varDecDef v (newObj (variableType v) [])
+  extObjDecNewNoParams lib v = varDecDef v (extNewObj lib (variableType v) [])
   constDecDef = varDecDef
 
   print v = pyOut False printFunc v Nothing

--- a/code/drasil-gool/GOOL/Drasil/Symantics.hs
+++ b/code/drasil-gool/GOOL/Drasil/Symantics.hs
@@ -51,7 +51,6 @@ class (ValueSym repr, PermanenceSym repr) => KeywordSym repr where
   inherit :: repr (Keyword repr)
 
   list     :: repr (Permanence repr) -> repr (Keyword repr)
-  listObj  :: repr (Keyword repr)
 
   blockStart :: repr (Keyword repr)
   blockEnd   :: repr (Keyword repr)
@@ -275,11 +274,9 @@ class (ValueSym repr, NumericExpression repr, BooleanExpression repr) =>
     repr (Value repr)
   extFuncApp   :: Library -> Label -> repr (StateType repr) -> 
     [repr (Value repr)] -> repr (Value repr)
-  stateObj     :: repr (StateType repr) -> [repr (Value repr)] -> 
+  newObj     :: repr (StateType repr) -> [repr (Value repr)] -> 
     repr (Value repr)
-  extStateObj  :: Library -> repr (StateType repr) -> [repr (Value repr)] -> 
-    repr (Value repr)
-  listStateObj :: repr (StateType repr) -> [repr (Value repr)] -> 
+  extNewObj  :: Library -> repr (StateType repr) -> [repr (Value repr)] -> 
     repr (Value repr)
 
   exists  :: repr (Value repr) -> repr (Value repr)
@@ -403,8 +400,8 @@ class (ValueSym repr, Selector repr, SelectorFunction repr, FunctionSym repr,
     repr (Statement repr)
   extObjDecNew     :: Library -> repr (Variable repr) -> 
     [repr (Value repr)] -> repr (Statement repr)
-  objDecNewVoid    :: repr (Variable repr) -> repr (Statement repr)
-  extObjDecNewVoid :: Library -> repr (Variable repr) -> repr (Statement repr)
+  objDecNewNoParams    :: repr (Variable repr) -> repr (Statement repr)
+  extObjDecNewNoParams :: Library -> repr (Variable repr) -> repr (Statement repr)
   constDecDef      :: repr (Variable repr) -> repr (Value repr) -> 
     repr (Statement repr)
 

--- a/code/drasil-gool/Test/PatternTest.hs
+++ b/code/drasil-gool/Test/PatternTest.hs
@@ -28,8 +28,8 @@ patternTestMainMethod = mainMethod "PatternTest" (body [block [
     (Just (litInt 3)) (Just (var "n" int)),
 
   block [
-    varDecDef (var "obs1" (obj "Observer")) (extStateObj "Observer" (obj "Observer") []), 
-    varDecDef (var "obs2" (obj "Observer")) (extStateObj "Observer" (obj "Observer") [])],
+    varDecDef (var "obs1" (obj "Observer")) (extNewObj "Observer" (obj "Observer") []), 
+    varDecDef (var "obs2" (obj "Observer")) (extNewObj "Observer" (obj "Observer") [])],
   block [
     initObserverList (listType static_ (obj "Observer")) [valueOf $ var "obs1" (obj "Observer")], 
     addObserver (valueOf $ var "obs2" (obj "Observer")),


### PR DESCRIPTION
Small PR that renames some GOOL functions that were poorly named and removes a couple that were not used and served no purpose.