### PR TITLE
Update functions to take variables instead of labels

### DIFF
--- a/code/drasil-code/Language/Drasil/Code/Imperative/Import.hs
+++ b/code/drasil-code/Language/Drasil/Code/Imperative/Import.hs
@@ -305,8 +305,9 @@ convStmt (FAsg v e) = do
   return $ multi $ assign v' e' : l
 convStmt (FFor v e st) = do
   stmts <- mapM convStmt st
+  vari <- mkVar v
   e' <- convExpr $ getUpperBound e
-  return $ forRange (codeName v) (litInt 0) e' (litInt 1) (bodyStatements stmts)
+  return $ forRange vari (litInt 0) e' (litInt 1) (bodyStatements stmts)
 convStmt (FWhile e st) = do
   stmts <- mapM convStmt st
   e' <- convExpr e
@@ -378,10 +379,10 @@ readData ddef = do
           lnV <- lineData (Just "_temp") lp
           logs <- getEntryVarLogs lp
           let readLines Nothing = [getFileInputAll v_infile var_lines,
-                forRange l_i (litInt 0) (listSize v_lines) (litInt 1)
+                forRange var_i (litInt 0) (listSize v_lines) (litInt 1)
                   (bodyStatements $ stringSplit d var_linetokens (
                   listAccess v_lines v_i) : lnV)]
-              readLines (Just numLines) = [forRange l_i (litInt 0) 
+              readLines (Just numLines) = [forRange var_i (litInt 0) 
                 (litInt numLines) (litInt 1)
                 (bodyStatements $
                   [getFileInputLine v_infile var_line,
@@ -421,7 +422,7 @@ readData ddef = do
           (valueOf $ var (codeName v ++ sfx) (convType $ codeType v))
         ---------------
         l_line, l_lines, l_linetokens, l_infile, l_i :: Label
-        var_line, var_lines, var_linetokens, var_infile :: 
+        var_line, var_lines, var_linetokens, var_infile, var_i :: 
           (RenderSym repr) => repr (Variable repr)
         v_line, v_lines, v_linetokens, v_infile, v_i ::
           (RenderSym repr) => repr (Value repr)
@@ -438,7 +439,8 @@ readData ddef = do
         var_infile = var l_infile infile
         v_infile = valueOf var_infile
         l_i = "i"
-        v_i = valueOf $ var l_i int
+        var_i = var l_i int
+        v_i = valueOf var_i
 
 getEntryVars :: (RenderSym repr) => Maybe String -> LinePattern -> 
   Reader State [repr (Variable repr)]

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer.hs
@@ -331,11 +331,11 @@ forDocD bStart bEnd sInit vGuard sUpdate b = vcat [
   indent b,
   bEnd]
 
-forEachDocD :: Label -> Doc -> Doc -> Doc -> Doc -> TypeData -> ValData -> Doc 
-  -> Doc
-forEachDocD l bStart bEnd forEachLabel inLabel t v b =
-  vcat [forEachLabel <+> parens (typeDoc t <+> text l <+> inLabel <+> valDoc v) 
-    <+> bStart,
+forEachDocD :: VarData -> Doc -> Doc -> Doc -> Doc -> TypeData -> ValData -> 
+  Doc -> Doc
+forEachDocD e bStart bEnd forEachLabel inLabel t v b =
+  vcat [forEachLabel <+> parens (typeDoc t <+> varDoc e <+> inLabel <+> 
+    valDoc v) <+> bStart,
   indent b,
   bEnd]
 
@@ -450,15 +450,15 @@ stringListLists' lsts sl = checkList (getType $ valueType sl)
         listVals (List _:vs) = listVals vs
         listVals _ = error 
           "All values passed to stringListLists must have list types"
-        loop = forRange l_i (litInt 0) (listSize sl #/ numLists) (litInt 1)
+        loop = forRange var_i (litInt 0) (listSize sl #/ numLists) (litInt 1)
           (bodyStatements $ appendLists (map valueOf lsts) 0)
         appendLists [] _ = []
         appendLists (v:vs) n = valState (listAppend v (cast (listInnerType $ 
           valueType v) (listAccess sl ((v_i #* numLists) #+ litInt n)))) 
           : appendLists vs (n+1)
         numLists = litInt (toInteger $ length lsts)
-        l_i = "stringlist_i"
-        v_i = valueOf $ var l_i S.int
+        var_i = var "stringlist_i" S.int
+        v_i = valueOf var_i
         
 
 -- Unary Operators --

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer/PythonRenderer.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer/PythonRenderer.hs
@@ -44,8 +44,8 @@ import GOOL.Drasil.Data (Terminator(..),
   ParamData(..), ProgData(..), progD, TypeData(..), td, ValData(..), vd,
   VarData(..), vard)
 import GOOL.Drasil.Helpers (vibcat, 
-  emptyIfEmpty, liftA4, liftA5, liftList, lift1List, lift2Lists, lift4Pair, 
-  liftPair, liftPairFst, getInnerType, convType, checkParams)
+  emptyIfEmpty, liftA4, liftA5, liftA6, liftList, lift1List, lift2Lists, 
+  lift4Pair, liftPair, liftPairFst, getInnerType, convType, checkParams)
 
 import Prelude hiding (break,print,sin,cos,tan,floor,(<>))
 import qualified Data.Map as Map (fromList,lookup)
@@ -146,7 +146,7 @@ instance StateTypeSym PythonCode where
   listInnerType t = fmap (getInnerType . cType) t >>= convType
   obj t = return $ typeDocD t
   enumType t = return $ enumTypeDocD t
-  iterator _ = error "Iterator-type variables do not exist in Python"
+  iterator t = t
   void = return $ td Void "NoneType" (text "NoneType")
 
   getType = cType . unPC
@@ -341,7 +341,7 @@ instance FunctionSym PythonCode where
 instance SelectorFunction PythonCode where
   listAccess v i = v $. listAccessFunc (listInnerType $ valueType v) i
   listSet v i toVal = v $. listSetFunc v i toVal
-  at v l = listAccess v (valueOf $ var l int)
+  at = listAccess
 
 instance InternalFunction PythonCode where
   getFunc v = func (getterName $ variableName v) (variableType v) []
@@ -357,8 +357,6 @@ instance InternalFunction PythonCode where
   listAccessFunc t v = liftA2 fd t (fmap listAccessFuncDocD v)
   listSetFunc v i toVal = liftA2 fd (valueType v) 
     (liftA2 listSetFuncDocD i toVal)
-
-  atFunc t l = listAccessFunc t (valueOf $ var l int)
 
 instance InternalStatement PythonCode where
   printSt nl p v f = mkStNoEnd <$> liftA3 (pyPrint nl) p v 
@@ -459,9 +457,9 @@ instance ControlStatementSym PythonCode where
 
   for _ _ _ _ = error $ "Classic for loops not available in Python, please " ++
     "use forRange, forEach, or while instead"
-  forRange i initv finalv stepv b = mkStNoEnd <$> liftA5 (pyForRange i) 
+  forRange i initv finalv stepv b = mkStNoEnd <$> liftA6 pyForRange i
     iterInLabel initv finalv stepv b
-  forEach l v b = mkStNoEnd <$> liftA4 (pyForEach l) iterForEachLabel 
+  forEach e v b = mkStNoEnd <$> liftA5 pyForEach e iterForEachLabel 
     iterInLabel v b
   while v b = mkStNoEnd <$> liftA2 pyWhile v b
 
@@ -471,9 +469,9 @@ instance ControlStatementSym PythonCode where
   notifyObservers f t = forRange index initv (listSize obsList) 
     (litInt 1) notify
     where obsList = valueOf $ observerListName `listOf` t
-          index = "observerIndex"
+          index = var "observerIndex" int
           initv = litInt 0
-          notify = oneLiner $ valState $ at obsList index $. f
+          notify = oneLiner $ valState $ at obsList (valueOf index) $. f
 
   getFileInputAll f v = v &= objMethodCall (listType static_ string) f
     "readlines" []
@@ -650,16 +648,16 @@ pyInput inSrc v = v &= pyInput' (getType $ variableType v)
 pyThrow ::  ValData -> Doc
 pyThrow errMsg = text "raise" <+> text "Exception" <> parens (valDoc errMsg)
 
-pyForRange :: Label -> Doc ->  ValData ->  ValData ->
+pyForRange :: VarData -> Doc ->  ValData ->  ValData ->
   ValData -> Doc -> Doc
 pyForRange i inLabel initv finalv stepv b = vcat [
-  forLabel <+> text i <+> inLabel <+> text "range" <> parens (valDoc initv <> 
+  forLabel <+> varDoc i <+> inLabel <+> text "range" <> parens (valDoc initv <> 
     text ", " <> valDoc finalv <> text ", " <> valDoc stepv) <> colon,
   indent b]
 
-pyForEach :: Label -> Doc -> Doc ->  ValData -> Doc -> Doc
+pyForEach :: VarData -> Doc -> Doc ->  ValData -> Doc -> Doc
 pyForEach i forEachLabel inLabel lstVar b = vcat [
-  forEachLabel <+> text i <+> inLabel <+> valDoc lstVar <> colon,
+  forEachLabel <+> varDoc i <+> inLabel <+> valDoc lstVar <> colon,
   indent b]
 
 pyWhile ::  ValData -> Doc -> Doc

--- a/code/drasil-gool/GOOL/Drasil/Symantics.hs
+++ b/code/drasil-gool/GOOL/Drasil/Symantics.hs
@@ -340,7 +340,7 @@ class (ValueSym repr, InternalValue repr, FunctionSym repr, Selector repr) =>
   listAccess :: repr (Value repr) -> repr (Value repr) -> repr (Value repr)
   listSet    :: repr (Value repr) -> repr (Value repr) -> 
     repr (Value repr) -> repr (Value repr)
-  at         :: repr (Value repr) -> Label -> repr (Value repr)
+  at         :: repr (Value repr) -> repr (Value repr) -> repr (Value repr)
 
 class (ValueSym repr, InternalValue repr) => InternalFunction repr where
   getFunc        :: repr (Variable repr) -> repr (Function repr)
@@ -359,8 +359,6 @@ class (ValueSym repr, InternalValue repr) => InternalFunction repr where
     repr (Function repr)
   listSetFunc    :: repr (Value repr) -> repr (Value repr) -> 
     repr (Value repr) -> repr (Function repr)
-
-  atFunc :: repr (StateType repr) -> Label -> repr (Function repr)
 
 class (Selector repr) => InternalStatement repr where
   -- newLn, printFunc, value to print, maybe a file to print to 
@@ -488,9 +486,9 @@ class (StatementSym repr, BodySym repr) => ControlStatementSym repr where
 
   for      :: repr (Statement repr) -> repr (Value repr) -> 
     repr (Statement repr) -> repr (Body repr) -> repr (Statement repr)
-  forRange :: Label -> repr (Value repr) -> repr (Value repr) -> 
+  forRange :: repr (Variable repr) -> repr (Value repr) -> repr (Value repr) -> 
     repr (Value repr) -> repr (Body repr) -> repr (Statement repr)
-  forEach  :: Label -> repr (Value repr) -> repr (Body repr) -> 
+  forEach  :: repr (Variable repr) -> repr (Value repr) -> repr (Body repr) -> 
     repr (Statement repr)
   while    :: repr (Value repr) -> repr (Body repr) -> repr (Statement repr) 
 

--- a/code/drasil-gool/Test/HelloWorld.hs
+++ b/code/drasil-gool/Test/HelloWorld.hs
@@ -140,16 +140,19 @@ helloSwitch = switch (valueOf $ var "a" int) [(litInt 5, oneLiner (var "b" int &
   (oneLiner (var "b" int &= litInt 0))
 
 helloForLoop :: (RenderSym repr) => repr (Statement repr)
-helloForLoop = forRange "i" (litInt 0) (litInt 9) (litInt 1) (oneLiner (printLn (valueOf $ var "i" int)))
+helloForLoop = forRange i (litInt 0) (litInt 9) (litInt 1) (oneLiner (printLn 
+  (valueOf i)))
+  where i = var "i" int
 
 helloWhileLoop :: (RenderSym repr) => repr (Statement repr)
 helloWhileLoop = while (valueOf (var "a" int) ?< litInt 13) (bodyStatements 
   [printStrLn "Hello", (&++) (var "a" int)]) 
 
 helloForEachLoop :: (RenderSym repr) => repr (Statement repr)
-helloForEachLoop = forEach "num" (valueOf $ listVar "myOtherList" static_ float) 
-  (oneLiner (printLn (extFuncApp "Helper" "doubleAndAdd" float [valueOf $ 
-  iterVar "num" float, litFloat 1.0])))
+helloForEachLoop = forEach i (valueOf $ listVar "myOtherList" static_ float) 
+  (oneLiner (printLn (extFuncApp "Helper" "doubleAndAdd" float [valueOf i, 
+  litFloat 1.0])))
+  where i = iterVar "num" float
 
 helloTryCatch :: (RenderSym repr) => repr (Statement repr)
 helloTryCatch = tryCatch (oneLiner (throw "Good-bye!"))


### PR DESCRIPTION
Another small GOOL PR. Changes some functions that took a `Label` to instead take a full `Variable`. 

The reason for this is that some functions (like `forEach`) that took a `Label` instead of a full `Variable` were originally intended to save the user the trouble of defining the full `Variable`, but really they will need to define the full `Variable` anyway (for example, when the variable is used in the body of the `forEach`), so having to pass the `Label` is not any more efficient and actually makes things inconsistent because the user would have to remember where they need to use a full `Variable` and where to just use a `Label`.