### PR TITLE
More minor GOOL improvements

### DIFF
--- a/code/drasil-code/Language/Drasil/Code/Imperative/FunctionCalls.hs
+++ b/code/drasil-code/Language/Drasil/Code/Imperative/FunctionCalls.hs
@@ -15,7 +15,7 @@ import Language.Drasil.Chunk.CodeDefinition (CodeDefinition)
 import Language.Drasil.Chunk.CodeQuantity (HasCodeType)
 import Language.Drasil.CodeSpec (CodeSpec(..))
 
-import GOOL.Drasil (RenderSym(..), StateTypeSym(..), ValueSym(..), 
+import GOOL.Drasil (RenderSym(..), TypeSym(..), ValueSym(..), 
   StatementSym(..), convType)
 
 import Data.List ((\\), intersect)
@@ -54,7 +54,7 @@ getOutputCall = do
   return $ fmap valState val
 
 getFuncCall :: (RenderSym repr, HasUID c, HasCodeType c, CodeIdea c) => String 
-  -> repr (StateType repr) -> Reader State [c] -> 
+  -> repr (Type repr) -> Reader State [c] -> 
   Reader State (Maybe (repr (Value repr)))
 getFuncCall n t funcPs = do
   g <- ask

--- a/code/drasil-code/Language/Drasil/Code/Imperative/GenerateGOOL.hs
+++ b/code/drasil-code/Language/Drasil/Code/Imperative/GenerateGOOL.hs
@@ -8,7 +8,7 @@ import Language.Drasil.Code.Imperative.GOOL.Symantics (AuxiliarySym(..))
 import Language.Drasil.CodeSpec (CodeSpec(..), CodeSystInfo(..), Comments(..), 
   Name)
   
-import GOOL.Drasil (Label, RenderSym(..), StateTypeSym(..), 
+import GOOL.Drasil (Label, RenderSym(..), TypeSym(..), 
   VariableSym(..), ValueSym(..), ValueExpression(..), StatementSym(..), 
   ParameterSym(..), MethodSym(..), StateVarSym(..), ClassSym(..), ModuleSym(..),
   CodeType(..), ProgData)
@@ -52,7 +52,7 @@ publicClass desc n l vs ms = do
     then docClass desc (pubClass n l vs ms) 
     else pubClass n l vs ms
 
-fApp :: (RenderSym repr) => String -> String -> repr (StateType repr) -> 
+fApp :: (RenderSym repr) => String -> String -> repr (Type repr) -> 
   [repr (Value repr)] -> Reader State (repr (Value repr))
 fApp m s t vl = do
   g <- ask

--- a/code/drasil-code/Language/Drasil/Code/Imperative/GenerateGOOL.hs
+++ b/code/drasil-code/Language/Drasil/Code/Imperative/GenerateGOOL.hs
@@ -70,4 +70,4 @@ mkParam :: (RenderSym repr) => repr (Variable repr) -> repr (Parameter repr)
 mkParam v = paramFunc (getType $ variableType v) v
   where paramFunc (List _) = pointerParam
         paramFunc (Object _) = pointerParam
-        paramFunc _ = stateParam
+        paramFunc _ = param

--- a/code/drasil-code/Language/Drasil/Code/Imperative/Import.hs
+++ b/code/drasil-code/Language/Drasil/Code/Imperative/Import.hs
@@ -30,8 +30,8 @@ import GOOL.Drasil (Label, RenderSym(..), PermanenceSym(..), BodySym(..),
   BlockSym(..), StateTypeSym(..), VariableSym(..), ValueSym(..), 
   NumericExpression(..), BooleanExpression(..), ValueExpression(..), 
   FunctionSym(..), SelectorFunction(..), StatementSym(..), 
-  ControlStatementSym(..), ScopeSym(..), MethodTypeSym(..), ParameterSym(..),
-  MethodSym(..), convType) 
+  ControlStatementSym(..), ScopeSym(..), ParameterSym(..), MethodSym(..), 
+  convType) 
 import qualified GOOL.Drasil as C (CodeType(List))
 
 import Prelude hiding (sin, cos, tan, log, exp)
@@ -99,7 +99,7 @@ mkVar :: (RenderSym repr, HasCodeType c, CodeIdea c) => c ->
 mkVar v = variable (codeName v) (convType $ codeType v)
 
 publicMethod :: (RenderSym repr, HasUID c, HasCodeType c, CodeIdea c) => 
-  repr (MethodType repr) -> Label -> String -> [c] -> Maybe String -> 
+  repr (StateType repr) -> Label -> String -> [c] -> Maybe String -> 
   [repr (Block repr)] -> Reader State (repr (Method repr))
 publicMethod t n = genMethod (function n public static_ t) n
 
@@ -251,7 +251,7 @@ genCalcFunc cdef = do
   blck <- genCalcBlock CalcReturn cdef (codeEquat cdef)
   desc <- returnComment $ cdef ^. uid
   publicMethod
-    (mState tp)
+    tp
     nm
     ("Calculates " ++ desc)
     parms
@@ -292,8 +292,7 @@ genFunc (FDef (FuncDef n desc parms o rd s)) = do
   g <- ask
   stmts <- mapM convStmt s
   vars <- mapM mkVar (fstdecl (sysinfodb $ csi $ codeSpec g) s \\ parms)
-  publicMethod (mState $ convType o) n desc parms rd [block $ map varDec 
-    vars ++ stmts]
+  publicMethod (convType o) n desc parms rd [block $ map varDec vars ++ stmts]
 genFunc (FData (FuncData n desc ddef)) = genDataFunc n desc ddef
 genFunc (FCD cd) = genCalcFunc cd
 
@@ -347,8 +346,7 @@ genDataFunc :: (RenderSym repr) => Name -> String -> DataDesc ->
 genDataFunc nameTitle desc ddef = do
   let parms = getInputs ddef
   bod <- readData ddef
-  publicMethod (mState void) nameTitle desc (codevar inFileName : parms) 
-    Nothing bod
+  publicMethod void nameTitle desc (codevar inFileName : parms) Nothing bod
 
 -- this is really ugly!!
 readData :: (RenderSym repr) => DataDesc -> Reader State

--- a/code/drasil-code/Language/Drasil/Code/Imperative/Import.hs
+++ b/code/drasil-code/Language/Drasil/Code/Imperative/Import.hs
@@ -27,7 +27,7 @@ import Language.Drasil.Code.DataDesc (DataItem, LinePattern(Repeat, Straight),
   getPatternInputs)
 
 import GOOL.Drasil (Label, RenderSym(..), PermanenceSym(..), BodySym(..), 
-  BlockSym(..), StateTypeSym(..), VariableSym(..), ValueSym(..), 
+  BlockSym(..), TypeSym(..), VariableSym(..), ValueSym(..), 
   NumericExpression(..), BooleanExpression(..), ValueExpression(..), 
   FunctionSym(..), SelectorFunction(..), StatementSym(..), 
   ControlStatementSym(..), ScopeSym(..), ParameterSym(..), MethodSym(..), 
@@ -43,7 +43,7 @@ import Control.Monad (liftM2,liftM3)
 import Control.Monad.Reader (Reader, ask)
 import Control.Lens ((^.))
 
-value :: (RenderSym repr) => UID -> String -> repr (StateType repr) -> 
+value :: (RenderSym repr) => UID -> String -> repr (Type repr) -> 
   Reader State (repr (Value repr))
 value u s t = do
   g <- ask
@@ -54,7 +54,7 @@ value u s t = do
   maybe (do { v <- variable s t; return $ valueOf v }) 
     (convExpr . codeEquat) (Map.lookup u mm >>= maybeInline (conStruct g))
 
-variable :: (RenderSym repr) => String -> repr (StateType repr) -> 
+variable :: (RenderSym repr) => String -> repr (Type repr) -> 
   Reader State (repr (Variable repr))
 variable s t = do
   g <- ask
@@ -99,7 +99,7 @@ mkVar :: (RenderSym repr, HasCodeType c, CodeIdea c) => c ->
 mkVar v = variable (codeName v) (convType $ codeType v)
 
 publicMethod :: (RenderSym repr, HasUID c, HasCodeType c, CodeIdea c) => 
-  repr (StateType repr) -> Label -> String -> [c] -> Maybe String -> 
+  repr (Type repr) -> Label -> String -> [c] -> Maybe String -> 
   [repr (Block repr)] -> Reader State (repr (Method repr))
 publicMethod t n = genMethod (function n public static_ t) n
 

--- a/code/drasil-code/Language/Drasil/Code/Imperative/Logging.hs
+++ b/code/drasil-code/Language/Drasil/Code/Imperative/Logging.hs
@@ -6,7 +6,7 @@ import Language.Drasil.Code.Imperative.State (State(..))
 import Language.Drasil.CodeSpec hiding (codeSpec, Mod(..))
 
 import GOOL.Drasil (Label, RenderSym(..), BodySym(..), BlockSym(..), 
-  StateTypeSym(..), VariableSym(..), ValueSym(..), StatementSym(..))
+  TypeSym(..), VariableSym(..), ValueSym(..), StatementSym(..))
 
 import Data.Maybe (maybeToList)
 import Control.Applicative ((<$>))

--- a/code/drasil-code/Language/Drasil/Code/Imperative/Modules.hs
+++ b/code/drasil-code/Language/Drasil/Code/Imperative/Modules.hs
@@ -33,8 +33,8 @@ import Language.Drasil.Printers (Linearity(Linear), exprDoc)
 
 import GOOL.Drasil (RenderSym(..), BodySym(..), BlockSym(..), PermanenceSym(..),
   StateTypeSym(..), VariableSym(..), ValueSym(..), BooleanExpression(..), 
-  StatementSym(..), ControlStatementSym(..), ScopeSym(..), MethodTypeSym(..), 
-  MethodSym(..), StateVarSym(..), ClassSym(..), convType)
+  StatementSym(..), ControlStatementSym(..), ScopeSym(..), MethodSym(..), 
+  StateVarSym(..), ClassSym(..), convType)
 
 import Prelude hiding (print)
 import Data.List (intersperse, intercalate, partition)
@@ -223,7 +223,7 @@ genInputConstraints = do
         sf <- sfwrCBody sfwrCs
         hw <- physCBody physCs
         desc <- inConsFuncDesc
-        mthd <- publicMethod (mState void) "input_constraints" desc parms 
+        mthd <- publicMethod void "input_constraints" desc parms 
           Nothing [block sf, block hw]
         return $ Just mthd
   genConstraints $ Map.lookup "input_constraints" (eMap $ codeSpec g)
@@ -397,7 +397,7 @@ genOutputFormat = do
                    printFileLn v_outfile v
                  ] ) (outputs $ csi $ codeSpec g)
         desc <- woFuncDesc
-        mthd <- publicMethod (mState void) "write_output" desc parms Nothing 
+        mthd <- publicMethod void "write_output" desc parms Nothing 
           [block $ [
           varDec var_outfile,
           openFileW var_outfile (litString "output.txt") ] ++

--- a/code/drasil-code/Language/Drasil/Code/Imperative/Modules.hs
+++ b/code/drasil-code/Language/Drasil/Code/Imperative/Modules.hs
@@ -64,8 +64,8 @@ genMainFunc = do
     ic <- getConstraintCall
     varDef <- mapM getCalcCall (execOrder $ csi $ codeSpec g)
     wo <- getOutputCall
-    return $ (if CommentFunc `elem` commented g then docMain else mainMethod)
-      "" $ bodyStatements $
+    return $ (if CommentFunc `elem` commented g then docMain else mainFunction)
+      $ bodyStatements $
       initLogFileVar (logKind g) ++
       varDecDef v_filename (arg 0) : logInFile ++
       catMaybes ([ip, co, gi, dv, ic] ++ varDef ++ [wo])

--- a/code/drasil-code/Language/Drasil/Code/Imperative/Modules.hs
+++ b/code/drasil-code/Language/Drasil/Code/Imperative/Modules.hs
@@ -32,7 +32,7 @@ import Language.Drasil.CodeSpec (AuxFile(..), CodeSpec(..), CodeSystInfo(..),
 import Language.Drasil.Printers (Linearity(Linear), exprDoc)
 
 import GOOL.Drasil (RenderSym(..), BodySym(..), BlockSym(..), PermanenceSym(..),
-  StateTypeSym(..), VariableSym(..), ValueSym(..), BooleanExpression(..), 
+  TypeSym(..), VariableSym(..), ValueSym(..), BooleanExpression(..), 
   StatementSym(..), ControlStatementSym(..), ScopeSym(..), MethodSym(..), 
   StateVarSym(..), ClassSym(..), convType)
 

--- a/code/drasil-gool/GOOL/Drasil.hs
+++ b/code/drasil-gool/GOOL/Drasil.hs
@@ -1,6 +1,6 @@
 -- | re-export smart constructors for external code writing
 module GOOL.Drasil (Label, ProgramSym(..), RenderSym(..), PermanenceSym(..), 
-  BodySym(..), BlockSym(..), ControlBlockSym(..), StateTypeSym(..), 
+  BodySym(..), BlockSym(..), ControlBlockSym(..), TypeSym(..), 
   StatementSym(..), ControlStatementSym(..), VariableSym(..), ValueSym(..), 
   NumericExpression(..), BooleanExpression(..), ValueExpression(..), 
   Selector(..), FunctionSym(..), SelectorFunction(..), ScopeSym(..), 
@@ -14,7 +14,7 @@ module GOOL.Drasil (Label, ProgramSym(..), RenderSym(..), PermanenceSym(..),
 
 import GOOL.Drasil.Symantics (Label, ProgramSym(..), RenderSym(..), 
   PermanenceSym(..), BodySym(..), BlockSym(..), ControlBlockSym(..), 
-  StateTypeSym(..), StatementSym(..), ControlStatementSym(..), VariableSym(..), 
+  TypeSym(..), StatementSym(..), ControlStatementSym(..), VariableSym(..), 
   ValueSym(..), NumericExpression(..), BooleanExpression(..), 
   ValueExpression(..), Selector(..), FunctionSym(..), SelectorFunction(..), 
   ScopeSym(..), ParameterSym(..), MethodSym(..), StateVarSym(..), ClassSym(..), 

--- a/code/drasil-gool/GOOL/Drasil.hs
+++ b/code/drasil-gool/GOOL/Drasil.hs
@@ -4,8 +4,8 @@ module GOOL.Drasil (Label, ProgramSym(..), RenderSym(..), PermanenceSym(..),
   StatementSym(..), ControlStatementSym(..), VariableSym(..), ValueSym(..), 
   NumericExpression(..), BooleanExpression(..), ValueExpression(..), 
   Selector(..), FunctionSym(..), SelectorFunction(..), ScopeSym(..), 
-  MethodTypeSym(..), ParameterSym(..), MethodSym(..), StateVarSym(..), 
-  ClassSym(..), ModuleSym(..), BlockCommentSym(..), 
+  ParameterSym(..), MethodSym(..), StateVarSym(..), ClassSym(..), ModuleSym(..),
+  BlockCommentSym(..), 
   ProgData(..), FileData(..), isSource, isHeader, ModData(..),
   CodeType(..),
   convType, liftList,
@@ -17,8 +17,8 @@ import GOOL.Drasil.Symantics (Label, ProgramSym(..), RenderSym(..),
   StateTypeSym(..), StatementSym(..), ControlStatementSym(..), VariableSym(..), 
   ValueSym(..), NumericExpression(..), BooleanExpression(..), 
   ValueExpression(..), Selector(..), FunctionSym(..), SelectorFunction(..), 
-  ScopeSym(..), MethodTypeSym(..), ParameterSym(..), MethodSym(..), 
-  StateVarSym(..), ClassSym(..), ModuleSym(..), BlockCommentSym(..))
+  ScopeSym(..), ParameterSym(..), MethodSym(..), StateVarSym(..), ClassSym(..), 
+  ModuleSym(..), BlockCommentSym(..))
 
 import GOOL.Drasil.Data (FileData(..), ModData(..), ProgData(..), 
   isHeader, isSource)

--- a/code/drasil-gool/GOOL/Drasil/Helpers.hs
+++ b/code/drasil-gool/GOOL/Drasil/Helpers.hs
@@ -12,7 +12,7 @@ import Utils.Drasil (blank)
 import qualified GOOL.Drasil.CodeType as C (CodeType(..))
 import GOOL.Drasil.Data (ParamData)
 import qualified GOOL.Drasil.Symantics as S ( 
-  RenderSym(..), StateTypeSym(..), PermanenceSym(dynamic_))
+  RenderSym(..), TypeSym(..), PermanenceSym(dynamic_))
 
 import Prelude hiding ((<>))
 import Control.Applicative (liftA2, liftA3)
@@ -113,7 +113,7 @@ getNestDegree :: Integer -> C.CodeType -> Integer
 getNestDegree n (C.List t) = getNestDegree (n+1) t
 getNestDegree n _ = n
 
-convType :: (S.RenderSym repr) => C.CodeType -> repr (S.StateType repr)
+convType :: (S.RenderSym repr) => C.CodeType -> repr (S.Type repr)
 convType C.Boolean = S.bool
 convType C.Integer = S.int
 convType C.Float = S.float

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer.hs
@@ -11,7 +11,7 @@ module GOOL.Drasil.LanguageRenderer (
   enumElementsDocD', multiStateDocD, blockDocD, bodyDocD, outDoc, printDoc,
   printFileDocD, boolTypeDocD, intTypeDocD, floatTypeDocD, charTypeDocD, 
   stringTypeDocD, fileTypeDocD, typeDocD, enumTypeDocD, listTypeDocD, voidDocD, 
-  constructDocD, stateParamDocD, paramListDocD, mkParam, methodDocD, 
+  constructDocD, paramDocD, paramListDocD, mkParam, methodDocD, 
   methodListDocD, stateVarDocD, stateVarDefDocD, constVarDocD, stateVarListDocD,
   alwaysDel, ifCondDocD, switchDocD, forDocD, forEachDocD, whileDocD, 
   tryCatchDocD, assignDocD, multiAssignDoc, plusEqualsDocD, plusEqualsDocD', 
@@ -240,8 +240,8 @@ constructDocD _ = empty
 
 -- Parameters --
 
-stateParamDocD :: VarData -> Doc
-stateParamDocD v = typeDoc (varType v) <+> varDoc v
+paramDocD :: VarData -> Doc
+paramDocD v = typeDoc (varType v) <+> varDoc v
 
 paramListDocD :: [ParamData] -> Doc
 paramListDocD = hicat (text ", ") . map paramDoc

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer.hs
@@ -44,12 +44,12 @@ import Utils.Drasil (blank, capitalize, indent, indentList, stringList)
 import GOOL.Drasil.CodeType (CodeType(..), isObject)
 import GOOL.Drasil.Symantics (Label, Library,
   RenderSym(..), BodySym(..), 
-  StateTypeSym(StateType, getType, getTypeString, getTypeDoc, listInnerType), 
+  TypeSym(Type, getType, getTypeString, getTypeDoc, listInnerType), 
   VariableSym(..), ValueSym(..), NumericExpression(..), BooleanExpression(..), 
   InternalValue(..), FunctionSym(..), SelectorFunction(..), 
   InternalStatement(..), StatementSym(..), ControlStatementSym(..), 
   ParameterSym(..), MethodSym(..), InternalMethod(..), BlockCommentSym(..))
-import qualified GOOL.Drasil.Symantics as S (StateTypeSym(int))
+import qualified GOOL.Drasil.Symantics as S (TypeSym(int))
 import GOOL.Drasil.Data (Terminator(..), FileData(..), 
   fileD, FuncData(..), ModData(..), updateModDoc, MethodData(..), OpData(..), 
   od, ParamData(..), pd, TypeData(..), td, ValData(..), vd, Binding(..), 
@@ -703,7 +703,7 @@ classVarCheckStatic v = classVarCS (variableBind v)
           "classVar can only be used to access static variables"
         classVarCS Static = v
 
-classVarD :: (VariableSym repr) => repr (StateType repr) -> 
+classVarD :: (VariableSym repr) => repr (Type repr) -> 
   repr (Variable repr) -> (Doc -> Doc -> Doc) -> repr (Variable repr)
 classVarD c v f = varFromData (variableBind v) 
   (getTypeString c ++ "." ++ variableName v) 

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer.hs
@@ -48,7 +48,7 @@ import GOOL.Drasil.Symantics (Label, Library,
   VariableSym(..), ValueSym(..), NumericExpression(..), BooleanExpression(..), 
   InternalValue(..), FunctionSym(..), SelectorFunction(..), 
   InternalStatement(..), StatementSym(..), ControlStatementSym(..), 
-  ParameterSym(..), MethodSym(..), BlockCommentSym(..))
+  ParameterSym(..), MethodSym(..), InternalMethod(..), BlockCommentSym(..))
 import qualified GOOL.Drasil.Symantics as S (StateTypeSym(int))
 import GOOL.Drasil.Data (Terminator(..), FileData(..), 
   fileD, FuncData(..), ModData(..), updateModDoc, MethodData(..), OpData(..), 

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer/CSharpRenderer.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer/CSharpRenderer.hs
@@ -13,7 +13,7 @@ import GOOL.Drasil.CodeType (CodeType(..), isObject)
 import GOOL.Drasil.Symantics (Label,
   ProgramSym(..), RenderSym(..), InternalFile(..),
   KeywordSym(..), PermanenceSym(..), BodySym(..), BlockSym(..), 
-  ControlBlockSym(..), StateTypeSym(..), UnaryOpSym(..), BinaryOpSym(..), 
+  ControlBlockSym(..), TypeSym(..), UnaryOpSym(..), BinaryOpSym(..), 
   VariableSym(..), ValueSym(..), NumericExpression(..), BooleanExpression(..), 
   ValueExpression(..), InternalValue(..), Selector(..), FunctionSym(..), 
   SelectorFunction(..), InternalFunction(..), InternalStatement(..), 
@@ -140,8 +140,8 @@ instance BlockSym CSharpCode where
   type Block CSharpCode = Doc
   block sts = lift1List blockDocD endStatement (map (fmap fst . state) sts)
 
-instance StateTypeSym CSharpCode where
-  type StateType CSharpCode = TypeData
+instance TypeSym CSharpCode where
+  type Type CSharpCode = TypeData
   bool = return boolTypeDocD
   int = return intTypeDocD
   float = return csFloatTypeDoc
@@ -630,7 +630,7 @@ csInfileTypeDoc = td File "StreamReader" (text "StreamReader")
 csOutfileTypeDoc :: TypeData
 csOutfileTypeDoc = td File "StreamWriter" (text "StreamWriter")
 
-csCast :: CSharpCode (StateType CSharpCode) -> CSharpCode (Value CSharpCode) -> 
+csCast :: CSharpCode (Type CSharpCode) -> CSharpCode (Value CSharpCode) -> 
   CSharpCode (Value CSharpCode)
 csCast t v = csCast' (getType t) (getType $ valueType v)
   where csCast' Float String = funcApp "Double.Parse" float [v]
@@ -679,7 +679,7 @@ csRef p = text "ref" <+> p
 csOut :: Doc -> Doc
 csOut p = text "out" <+> p
 
-csInOutCall :: (Label -> CSharpCode (StateType CSharpCode) -> 
+csInOutCall :: (Label -> CSharpCode (Type CSharpCode) -> 
   [CSharpCode (Value CSharpCode)] -> CSharpCode (Value CSharpCode)) -> Label -> 
   [CSharpCode (Value CSharpCode)] -> [CSharpCode (Variable CSharpCode)] -> 
   [CSharpCode (Variable CSharpCode)] -> CSharpCode (Statement CSharpCode)

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer/CSharpRenderer.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer/CSharpRenderer.hs
@@ -510,7 +510,7 @@ instance InternalScope CSharpCode where
 
 instance MethodTypeSym CSharpCode where
   type MethodType CSharpCode = TypeData
-  mState t = t
+  mType t = t
   construct n = return $ td (Object n) n (constructDocD n)
 
 instance ParameterSym CSharpCode where
@@ -524,7 +524,7 @@ instance ParameterSym CSharpCode where
 instance MethodSym CSharpCode where
   type Method CSharpCode = MethodData
   method n _ s p t ps b = liftA2 (mthd False) (checkParams n <$> sequence ps) 
-    (liftA5 (methodDocD n) s p (mState t) (liftList paramListDocD ps) b)
+    (liftA5 (methodDocD n) s p (mType t) (liftList paramListDocD ps) b)
   getMethod c v = method (getterName $ variableName v) c public dynamic_ 
     (variableType v) [] getBody
     where getBody = oneLiner $ returnState (valueOf $ self c $-> v)
@@ -540,7 +540,7 @@ instance MethodSym CSharpCode where
     "Controls the flow of the program" 
     [("args", "List of command-line arguments")] []) (mainFunction b)
  
-  function n s p t = intFunc n s p (mState t)
+  function n s p t = intFunc n s p (mType t)
   mainFunction b = setMainMethod <$> function "Main" public static_ void 
     [liftA2 pd (var "args" (listType static_ string)) 
     (return $ text "string[] args")] b

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer/CSharpRenderer.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer/CSharpRenderer.hs
@@ -24,7 +24,7 @@ import GOOL.Drasil.LanguageRenderer (addExt,
   fileDoc', moduleDocD, classDocD, enumDocD, enumElementsDocD, multiStateDocD,
   blockDocD, bodyDocD, printDoc, outDoc, printFileDocD, boolTypeDocD, 
   intTypeDocD, charTypeDocD, stringTypeDocD, typeDocD, enumTypeDocD, 
-  listTypeDocD, voidDocD, constructDocD, stateParamDocD, paramListDocD, mkParam,
+  listTypeDocD, voidDocD, constructDocD, paramDocD, paramListDocD, mkParam,
   methodDocD, methodListDocD, stateVarDocD, stateVarDefDocD, stateVarListDocD, 
   ifCondDocD, switchDocD, forDocD, forEachDocD, whileDocD, stratDocD, 
   assignDocD, plusEqualsDocD, plusPlusDocD, varDecDocD, varDecDefDocD, 
@@ -515,8 +515,8 @@ instance MethodTypeSym CSharpCode where
 
 instance ParameterSym CSharpCode where
   type Parameter CSharpCode = ParamData
-  stateParam = fmap (mkParam stateParamDocD)
-  pointerParam = stateParam
+  param = fmap (mkParam paramDocD)
+  pointerParam = param
 
   parameterName = variableName . fmap paramVar
   parameterType = variableType . fmap paramVar
@@ -529,7 +529,7 @@ instance MethodSym CSharpCode where
     (mState $ variableType v) [] getBody
     where getBody = oneLiner $ returnState (valueOf $ self c $-> v)
   setMethod c v = method (setterName $ variableName v) c public dynamic_ 
-    (mState void) [stateParam v] setBody
+    (mState void) [param v] setBody
     where setBody = oneLiner $ (self c $-> v) &= valueOf v
   privMethod n c = method n c private dynamic_
   pubMethod n c = method n c public dynamic_
@@ -548,15 +548,15 @@ instance MethodSym CSharpCode where
   docFunc desc pComms rComm = docFuncRepr desc pComms (maybeToList rComm)
 
   inOutFunc n s p ins [v] [] b = function n s p (mState $ variableType v) 
-    (map stateParam ins) (liftA3 surroundBody (varDec v) b (returnState $ 
+    (map param ins) (liftA3 surroundBody (varDec v) b (returnState $ 
     valueOf v))
   inOutFunc n s p ins [] [v] b = function n s p (if null (filterOutObjs [v]) 
-    then mState void else mState $ variableType v) (map stateParam $ v : ins) 
+    then mState void else mState $ variableType v) (map param $ v : ins) 
     (if null (filterOutObjs [v]) then b else liftA2 appendToBody b 
     (returnState $ valueOf v))
   inOutFunc n s p ins outs both b = function n s p (mState void) (map (fmap 
-    (updateParamDoc csRef) . stateParam) both ++ map stateParam ins ++ 
-    map (fmap (updateParamDoc csOut) . stateParam) outs) b
+    (updateParamDoc csRef) . param) both ++ map param ins ++ 
+    map (fmap (updateParamDoc csOut) . param) outs) b
 
   docInOutFunc n s p desc is [o] [] b = docFuncRepr desc (map fst is) [fst o] 
     (inOutFunc n s p (map snd is) [snd o] [] b)

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer/CSharpRenderer.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer/CSharpRenderer.hs
@@ -531,19 +531,19 @@ instance MethodSym CSharpCode where
   setMethod c v = method (setterName $ variableName v) c public dynamic_ 
     (mState void) [stateParam v] setBody
     where setBody = oneLiner $ (self c $-> v) &= valueOf v
-  mainMethod c b = setMainMethod <$> method "Main" c public static_ 
-    (mState void) [liftA2 pd (var "args" (listType static_ string)) 
-    (return $ text "string[] args")] b
   privMethod n c = method n c private dynamic_
   pubMethod n c = method n c public dynamic_
   constructor n = method n n public dynamic_ (construct n)
   destructor _ _ = error "Destructors not allowed in C#"
 
-  docMain c b = commentedFunc (docComment $ functionDoc 
+  docMain b = commentedFunc (docComment $ functionDoc 
     "Controls the flow of the program" 
-    [("args", "List of command-line arguments")] []) (mainMethod c b)
+    [("args", "List of command-line arguments")] []) (mainFunction b)
 
   function n = method n ""
+  mainFunction b = setMainMethod <$> function "Main" public static_ 
+    (mState void) [liftA2 pd (var "args" (listType static_ string)) 
+    (return $ text "string[] args")] b
 
   docFunc desc pComms rComm = docFuncRepr desc pComms (maybeToList rComm)
 

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer/CppRenderer.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer/CppRenderer.hs
@@ -24,7 +24,7 @@ import GOOL.Drasil.Symantics (Label,
 import GOOL.Drasil.LanguageRenderer (addExt,
   fileDoc', enumElementsDocD, multiStateDocD, blockDocD, bodyDocD, outDoc,
   intTypeDocD, charTypeDocD, stringTypeDocD, typeDocD, enumTypeDocD, 
-  listTypeDocD, voidDocD, constructDocD, stateParamDocD, paramListDocD, mkParam,
+  listTypeDocD, voidDocD, constructDocD, paramDocD, paramListDocD, mkParam,
   methodListDocD, stateVarDocD, stateVarDefDocD, constVarDocD, alwaysDel, 
   ifCondDocD, switchDocD, forDocD, whileDocD, stratDocD, assignDocD, 
   plusEqualsDocD, plusPlusDocD, varDecDocD, varDecDefDocD, objDecDefDocD, 
@@ -539,7 +539,7 @@ instance (Pair p) => MethodTypeSym (p CppSrcCode CppHdrCode) where
 
 instance (Pair p) => ParameterSym (p CppSrcCode CppHdrCode) where
   type Parameter (p CppSrcCode CppHdrCode) = ParamData
-  stateParam v = pair (stateParam $ pfst v) (stateParam $ psnd v)
+  param v = pair (param $ pfst v) (param $ psnd v)
   pointerParam v = pair (pointerParam $ pfst v) (pointerParam $ psnd v)
 
   parameterName p = parameterName $ pfst p
@@ -1100,7 +1100,7 @@ instance MethodTypeSym CppSrcCode where
 
 instance ParameterSym CppSrcCode where
   type Parameter CppSrcCode = ParamData
-  stateParam = fmap (mkParam stateParamDocD)
+  param = fmap (mkParam paramDocD)
   pointerParam = fmap (mkParam cppPointerParamDoc)
 
   parameterName = variableName . fmap paramVar
@@ -1115,7 +1115,7 @@ instance MethodSym CppSrcCode where
     (mState $ variableType v) [] getBody
     where getBody = oneLiner $ returnState (valueOf $ self c $-> v)
   setMethod c v = method (setterName $ variableName v) c public dynamic_ 
-    (mState void) [stateParam v] setBody
+    (mState void) [param v] setBody
     where setBody = oneLiner $ (self c $-> v) &= valueOf v
   privMethod n c = method n c private dynamic_
   pubMethod n c = method n c public dynamic_
@@ -1138,7 +1138,7 @@ instance MethodSym CppSrcCode where
     sequence ps) (liftA5 (cppsFunction n) t (liftList paramListDocD ps) b 
     blockStart blockEnd)
   mainFunction b = setMainMethod <$> function "main" public static_ int 
-    [stateParam $ var "argc" int, 
+    [param $ var "argc" int, 
     liftA2 pd (var "argv" (listType static_ string)) 
     (return $ text "const char *argv[]")] 
     (liftA2 appendToBody b (returnState $ litInt 0))
@@ -1622,7 +1622,7 @@ instance MethodTypeSym CppHdrCode where
 
 instance ParameterSym CppHdrCode where
   type Parameter CppHdrCode = ParamData
-  stateParam = fmap (mkParam stateParamDocD)
+  param = fmap (mkParam paramDocD)
   pointerParam = fmap (mkParam cppPointerParamDoc)
 
   parameterName = variableName . fmap paramVar
@@ -1636,7 +1636,7 @@ instance MethodSym CppHdrCode where
   getMethod c v = method (getterName $ variableName v) c public dynamic_ 
     (mState $ variableType v) [] (return empty)
   setMethod c v = method (setterName $ variableName v) c public dynamic_ 
-    (mState void) [stateParam v] (return empty)
+    (mState void) [param v] (return empty)
   privMethod n c = method n c private dynamic_
   pubMethod n c = method n c public dynamic_
   constructor n = method n n public dynamic_ (construct n)
@@ -1733,7 +1733,7 @@ getParam :: VarData -> ParamData
 getParam v = mkParam (getParamFunc ((cType . varType) v)) v
   where getParamFunc (List _) = cppPointerParamDoc
         getParamFunc (Object _) = cppPointerParamDoc
-        getParamFunc _ = stateParamDocD
+        getParamFunc _ = paramDocD
  
 data MethodData = MthD {isMainMthd :: Bool, getMthdScp :: ScopeTag, 
   mthdParams :: [ParamData], mthdDoc :: Doc}

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer/CppRenderer.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer/CppRenderer.hs
@@ -14,7 +14,7 @@ import GOOL.Drasil.CodeType (CodeType(..), isObject)
 import GOOL.Drasil.Symantics (Label,
   ProgramSym(..), RenderSym(..), InternalFile(..),
   KeywordSym(..), PermanenceSym(..), BodySym(..), BlockSym(..), 
-  ControlBlockSym(..), StateTypeSym(..), UnaryOpSym(..), BinaryOpSym(..), 
+  ControlBlockSym(..), TypeSym(..), UnaryOpSym(..), BinaryOpSym(..), 
   VariableSym(..), ValueSym(..), NumericExpression(..), BooleanExpression(..), 
   ValueExpression(..), InternalValue(..), Selector(..), FunctionSym(..), 
   SelectorFunction(..), InternalFunction(..), InternalStatement(..), 
@@ -141,8 +141,8 @@ instance (Pair p) => BlockSym (p CppSrcCode CppHdrCode) where
   type Block (p CppSrcCode CppHdrCode) = Doc
   block sts = pair (block $ map pfst sts) (block $ map psnd sts)
 
-instance (Pair p) => StateTypeSym (p CppSrcCode CppHdrCode) where
-  type StateType (p CppSrcCode CppHdrCode) = TypeData
+instance (Pair p) => TypeSym (p CppSrcCode CppHdrCode) where
+  type Type (p CppSrcCode CppHdrCode) = TypeData
   bool = pair bool bool
   int = pair int int
   float = pair float float
@@ -710,8 +710,8 @@ instance BlockSym CppSrcCode where
   type Block CppSrcCode = Doc
   block sts = lift1List blockDocD endStatement (map (fmap fst . state) sts)
 
-instance StateTypeSym CppSrcCode where
-  type StateType CppSrcCode = TypeData
+instance TypeSym CppSrcCode where
+  type Type CppSrcCode = TypeData
   bool = return cppBoolTypeDoc
   int = return intTypeDocD
   float = return cppFloatTypeDoc
@@ -1302,8 +1302,8 @@ instance BlockSym CppHdrCode where
   type Block CppHdrCode = Doc
   block _ = return empty
 
-instance StateTypeSym CppHdrCode where
-  type StateType CppHdrCode = TypeData
+instance TypeSym CppHdrCode where
+  type Type CppHdrCode = TypeData
   bool = return cppBoolTypeDoc
   int = return intTypeDocD
   float = return cppFloatTypeDoc
@@ -1821,7 +1821,7 @@ cppClassVar c v = c <> text "::" <> v
 cppStateObjDoc :: TypeData -> Doc -> Doc
 cppStateObjDoc t ps = typeDoc t <> parens ps
 
-cppCast :: CppSrcCode (StateType CppSrcCode) -> 
+cppCast :: CppSrcCode (Type CppSrcCode) -> 
   CppSrcCode (Value CppSrcCode) -> CppSrcCode (Value CppSrcCode)
 cppCast t v = cppCast' (getType t) (getType $ valueType v)
   where cppCast' Float String = funcApp "std::stod" float [v]
@@ -1954,7 +1954,7 @@ cppModuleDoc ls blnk1 fs blnk2 cs = vcat [
   blnk2,
   fs]
 
-cppInOutCall :: (Label -> CppSrcCode (StateType CppSrcCode) -> 
+cppInOutCall :: (Label -> CppSrcCode (Type CppSrcCode) -> 
   [CppSrcCode (Value CppSrcCode)] -> CppSrcCode (Value CppSrcCode)) -> Label -> 
   [CppSrcCode (Value CppSrcCode)] -> [CppSrcCode (Variable CppSrcCode)] -> 
   [CppSrcCode (Variable CppSrcCode)] -> CppSrcCode (Statement CppSrcCode)

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer/CppRenderer.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer/CppRenderer.hs
@@ -534,7 +534,7 @@ instance (Pair p) => InternalScope (p CppSrcCode CppHdrCode) where
 
 instance (Pair p) => MethodTypeSym (p CppSrcCode CppHdrCode) where
   type MethodType (p CppSrcCode CppHdrCode) = TypeData
-  mState t = pair (mState $ pfst t) (mState $ psnd t)
+  mType t = pair (mType $ pfst t) (mType $ psnd t)
   construct n = pair (construct n) (construct n)
 
 instance (Pair p) => ParameterSym (p CppSrcCode CppHdrCode) where
@@ -1101,7 +1101,7 @@ instance InternalScope CppSrcCode where
 
 instance MethodTypeSym CppSrcCode where
   type MethodType CppSrcCode = TypeData
-  mState t = t
+  mType t = t
   construct n = return $ td (Object n) n (constructDocD n)
 
 instance ParameterSym CppSrcCode where
@@ -1114,7 +1114,7 @@ instance ParameterSym CppSrcCode where
 
 instance MethodSym CppSrcCode where
   type Method CppSrcCode = MethodData
-  method n c s p t = intMethod n c s p (mState t)
+  method n c s p t = intMethod n c s p (mType t)
   getMethod c v = method (getterName $ variableName v) c public dynamic_ 
     (variableType v) [] getBody
     where getBody = oneLiner $ returnState (valueOf $ self c $-> v)
@@ -1138,7 +1138,7 @@ instance MethodSym CppSrcCode where
     [("argc", "Number of command-line arguments"),
     ("argv", "List of command-line arguments")] ["exit code"]) (mainFunction b)
 
-  function n s p t = intFunc n s p (mState t)
+  function n s p t = intFunc n s p (mType t)
   mainFunction b = setMainMethod <$> function "main" public static_ int 
     [param $ var "argc" int, 
     liftA2 pd (var "argv" (listType static_ string)) 
@@ -1626,7 +1626,7 @@ instance InternalScope CppHdrCode where
 
 instance MethodTypeSym CppHdrCode where
   type MethodType CppHdrCode = TypeData
-  mState t = t
+  mType t = t
   construct n = return $ td (Object n) n (constructDocD n)
 
 instance ParameterSym CppHdrCode where
@@ -1639,7 +1639,7 @@ instance ParameterSym CppHdrCode where
 
 instance MethodSym CppHdrCode where
   type Method CppHdrCode = MethodData
-  method n c s p t = intMethod n c s p (mState t)
+  method n c s p t = intMethod n c s p (mType t)
   getMethod c v = method (getterName $ variableName v) c public dynamic_ 
     (variableType v) [] (return empty)
   setMethod c v = method (setterName $ variableName v) c public dynamic_ void 
@@ -1651,7 +1651,7 @@ instance MethodSym CppHdrCode where
 
   docMain = mainFunction
 
-  function n s p t = intFunc n s p (mState t)
+  function n s p t = intFunc n s p (mType t)
   mainFunction _ = return (mthd True Pub [] empty)
 
   docFunc desc pComms rComm = docFuncRepr desc pComms (maybeToList rComm)

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer/JavaRenderer.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer/JavaRenderer.hs
@@ -24,7 +24,7 @@ import GOOL.Drasil.LanguageRenderer (addExt,
   packageDocD, fileDoc', moduleDocD, classDocD, enumDocD, enumElementsDocD, 
   multiStateDocD, blockDocD, bodyDocD, outDoc, printDoc, printFileDocD, 
   boolTypeDocD, intTypeDocD, charTypeDocD, typeDocD, enumTypeDocD, listTypeDocD,
-  voidDocD, constructDocD, stateParamDocD, paramListDocD, mkParam, 
+  voidDocD, constructDocD, paramDocD, paramListDocD, mkParam, 
   methodListDocD, stateVarDocD, stateVarDefDocD, stateVarListDocD, ifCondDocD, 
   switchDocD, forDocD, forEachDocD, whileDocD, stratDocD, assignDocD, 
   plusEqualsDocD, plusPlusDocD, varDecDocD, varDecDefDocD, listDecDocD, 
@@ -513,8 +513,8 @@ instance MethodTypeSym JavaCode where
 
 instance ParameterSym JavaCode where
   type Parameter JavaCode = ParamData
-  stateParam = fmap (mkParam stateParamDocD)
-  pointerParam = stateParam
+  param = fmap (mkParam paramDocD)
+  pointerParam = param
 
   parameterName = variableName . fmap paramVar
   parameterType = variableType . fmap paramVar
@@ -527,7 +527,7 @@ instance MethodSym JavaCode where
     (mState $ variableType v) [] getBody
     where getBody = oneLiner $ returnState (valueOf $ self c $-> v)
   setMethod c v = method (setterName $ variableName v) c public dynamic_ 
-    (mState void) [stateParam v] setBody
+    (mState void) [param v] setBody
     where setBody = oneLiner $ (self c $-> v) &= valueOf v
   privMethod n c = method n c private dynamic_
   pubMethod n c = method n c public dynamic_
@@ -545,17 +545,17 @@ instance MethodSym JavaCode where
 
   docFunc desc pComms rComm = docFuncRepr desc pComms (maybeToList rComm)
 
-  inOutFunc n s p ins [] [] b = function n s p (mState void) (map stateParam 
+  inOutFunc n s p ins [] [] b = function n s p (mState void) (map param 
     ins) b
   inOutFunc n s p ins [v] [] b = function n s p (mState $ variableType v) 
-    (map stateParam ins) (liftA3 surroundBody (varDec v) b (returnState $ 
+    (map param ins) (liftA3 surroundBody (varDec v) b (returnState $ 
     valueOf v))
   inOutFunc n s p ins [] [v] b = function n s p (if null (filterOutObjs [v]) 
-    then mState void else mState $ variableType v) (map stateParam $ v : ins) 
+    then mState void else mState $ variableType v) (map param $ v : ins) 
     (if null (filterOutObjs [v]) then b else liftA2 appendToBody b 
     (returnState $ valueOf v))
   inOutFunc n s p ins outs both b = function n s p (returnTp rets)
-    (map stateParam $ both ++ ins) (liftA3 surroundBody decls b (returnSt rets))
+    (map param $ both ++ ins) (liftA3 surroundBody decls b (returnSt rets))
     where returnTp [x] = mState $ variableType x
           returnTp _ = jArrayType
           returnSt [x] = returnState $ valueOf x

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer/JavaRenderer.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer/JavaRenderer.hs
@@ -13,7 +13,7 @@ import GOOL.Drasil.CodeType (CodeType(..), isObject)
 import GOOL.Drasil.Symantics (Label,
   ProgramSym(..), RenderSym(..), InternalFile(..), 
   KeywordSym(..), PermanenceSym(..), BodySym(..), BlockSym(..), 
-  ControlBlockSym(..), StateTypeSym(..), UnaryOpSym(..), BinaryOpSym(..), 
+  ControlBlockSym(..), TypeSym(..), UnaryOpSym(..), BinaryOpSym(..), 
   VariableSym(..), ValueSym(..), NumericExpression(..), BooleanExpression(..), 
   ValueExpression(..), InternalValue(..), Selector(..), FunctionSym(..), 
   SelectorFunction(..), InternalFunction(..), InternalStatement(..), 
@@ -139,8 +139,8 @@ instance BlockSym JavaCode where
   type Block JavaCode = Doc
   block sts = lift1List blockDocD endStatement (map (fmap fst .state) sts)
 
-instance StateTypeSym JavaCode where
-  type StateType JavaCode = TypeData
+instance TypeSym JavaCode where
+  type Type JavaCode = TypeData
   bool = return boolTypeDocD
   int = return intTypeDocD
   float = return jFloatTypeDocD
@@ -666,7 +666,7 @@ jListType (TD Float _ _) lst = td (List Float) (render lst ++ "<Double>")
   (lst <> angles (text "Double"))
 jListType t lst = listTypeDocD t lst
 
-jArrayType :: JavaCode (StateType JavaCode)
+jArrayType :: JavaCode (Type JavaCode)
 jArrayType = return $ td (List $ Object "Object") "Object" (text "Object[]")
 
 jEquality :: JavaCode (Value JavaCode) -> JavaCode (Value JavaCode) -> 
@@ -675,7 +675,7 @@ jEquality v1 v2 = jEquality' (getType $ valueType v2)
   where jEquality' String = objAccess v1 (func "equals" bool [v2])
         jEquality' _ = liftA4 typeBinExpr equalOp bool v1 v2
 
-jCast :: JavaCode (StateType JavaCode) -> JavaCode (Value JavaCode) -> 
+jCast :: JavaCode (Type JavaCode) -> JavaCode (Value JavaCode) -> 
   JavaCode (Value JavaCode)
 jCast t v = jCast' (getType t) (getType $ valueType v)
   where jCast' Float String = funcApp "Double.parseDouble" float [v]
@@ -745,7 +745,7 @@ jAssignFromArray c (v:vs) = (v &= cast (variableType v)
   (valueOf (var ("outputs[" ++ show c ++ "]") (variableType v))))
   : jAssignFromArray (c+1) vs
 
-jInOutCall :: (Label -> JavaCode (StateType JavaCode) -> 
+jInOutCall :: (Label -> JavaCode (Type JavaCode) -> 
   [JavaCode (Value JavaCode)] -> JavaCode (Value JavaCode)) -> Label -> 
   [JavaCode (Value JavaCode)] -> [JavaCode (Variable JavaCode)] -> 
   [JavaCode (Variable JavaCode)] -> JavaCode (Statement JavaCode)

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer/JavaRenderer.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer/JavaRenderer.hs
@@ -529,19 +529,19 @@ instance MethodSym JavaCode where
   setMethod c v = method (setterName $ variableName v) c public dynamic_ 
     (mState void) [stateParam v] setBody
     where setBody = oneLiner $ (self c $-> v) &= valueOf v
-  mainMethod c b = setMainMethod <$> method "main" c public static_ 
-    (mState void) [liftA2 pd (var "args" (listType static_ string)) 
-    (return $ text "String[] args")] b
   privMethod n c = method n c private dynamic_
   pubMethod n c = method n c public dynamic_
   constructor n = method n n public dynamic_ (construct n)
   destructor _ _ = error "Destructors not allowed in Java"
 
-  docMain c b = commentedFunc (docComment $ functionDoc 
+  docMain b = commentedFunc (docComment $ functionDoc 
     "Controls the flow of the program" 
-    [("args", "List of command-line arguments")] []) (mainMethod c b)
+    [("args", "List of command-line arguments")] []) (mainFunction b)
 
   function n = method n ""
+  mainFunction b = setMainMethod <$> function "main" public static_ 
+    (mState void) [liftA2 pd (var "args" (listType static_ string)) 
+    (return $ text "String[] args")] b
 
   docFunc desc pComms rComm = docFuncRepr desc pComms (maybeToList rComm)
 

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer/JavaRenderer.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer/JavaRenderer.hs
@@ -508,7 +508,7 @@ instance InternalScope JavaCode where
 
 instance MethodTypeSym JavaCode where
   type MethodType JavaCode = TypeData
-  mState t = t
+  mType t = t
   construct n = return $ td (Object n) n (constructDocD n)
 
 instance ParameterSym JavaCode where
@@ -521,7 +521,7 @@ instance ParameterSym JavaCode where
 
 instance MethodSym JavaCode where
   type Method JavaCode = MethodData
-  method n l s p t = intMethod n l s p (mState t)
+  method n l s p t = intMethod n l s p (mType t)
   getMethod c v = method (getterName $ variableName v) c public dynamic_ 
     (variableType v) [] getBody
     where getBody = oneLiner $ returnState (valueOf $ self c $-> v)
@@ -537,7 +537,7 @@ instance MethodSym JavaCode where
     "Controls the flow of the program" 
     [("args", "List of command-line arguments")] []) (mainFunction b)
 
-  function n s p t = intFunc n s p (mState t)
+  function n s p t = intFunc n s p (mType t)
   mainFunction b = setMainMethod <$> function "main" public static_ void 
     [liftA2 pd (var "args" (listType static_ string)) 
     (return $ text "String[] args")] b

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer/PythonRenderer.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer/PythonRenderer.hs
@@ -12,7 +12,7 @@ import GOOL.Drasil.CodeType (CodeType(..), isObject)
 import GOOL.Drasil.Symantics (Label,
   ProgramSym(..), RenderSym(..), InternalFile(..),
   KeywordSym(..), PermanenceSym(..), BodySym(..), BlockSym(..), 
-  ControlBlockSym(..), StateTypeSym(..), UnaryOpSym(..), BinaryOpSym(..), 
+  ControlBlockSym(..), TypeSym(..), UnaryOpSym(..), BinaryOpSym(..), 
   VariableSym(..), ValueSym(..), NumericExpression(..), BooleanExpression(..), 
   ValueExpression(..), InternalValue(..), Selector(..), FunctionSym(..), 
   SelectorFunction(..), InternalFunction(..), InternalStatement(..), 
@@ -133,8 +133,8 @@ instance BlockSym PythonCode where
   type Block PythonCode = Doc
   block sts = lift1List blockDocD endStatement (map (fmap fst . state) sts)
 
-instance StateTypeSym PythonCode where
-  type StateType PythonCode = TypeData
+instance TypeSym PythonCode where
+  type Type PythonCode = TypeData
   bool = return $ td Boolean "" empty
   int = return intTypeDocD
   float = return floatTypeDocD
@@ -719,7 +719,7 @@ pyModule ls fs cs =
   where libs = emptyIfEmpty ls $ ls $+$ blank
         funcs = emptyIfEmpty fs $ fs $+$ blank
 
-pyInOutCall :: (Label -> PythonCode (StateType PythonCode) -> 
+pyInOutCall :: (Label -> PythonCode (Type PythonCode) -> 
   [PythonCode (Value PythonCode)] -> PythonCode (Value PythonCode)) -> Label -> 
   [PythonCode (Value PythonCode)] -> [PythonCode (Variable PythonCode)] -> 
   [PythonCode (Variable PythonCode)] -> PythonCode (Statement PythonCode)

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer/PythonRenderer.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer/PythonRenderer.hs
@@ -493,8 +493,8 @@ instance MethodTypeSym PythonCode where
 
 instance ParameterSym PythonCode where
   type Parameter PythonCode = ParamData
-  stateParam = fmap (mkParam varDoc)
-  pointerParam = stateParam
+  param = fmap (mkParam varDoc)
+  pointerParam = param
 
   parameterName = variableName . fmap paramVar
   parameterType = variableType . fmap paramVar
@@ -507,7 +507,7 @@ instance MethodSym PythonCode where
     (mState $ variableType v) [] getBody
     where getBody = oneLiner $ returnState (valueOf $ self c $-> v)
   setMethod c v = method (setterName $ variableName v) c public dynamic_
-    (mState void) [stateParam v] setBody
+    (mState void) [param v] setBody
     where setBody = oneLiner $ (self c $-> v) &= valueOf v
   privMethod n c = method n c private dynamic_
   pubMethod n c = method n c public dynamic_
@@ -522,10 +522,10 @@ instance MethodSym PythonCode where
 
   docFunc desc pComms rComm = docFuncRepr desc pComms (maybeToList rComm)
 
-  inOutFunc n s p ins [] [] b = function n s p (mState void) (map stateParam 
+  inOutFunc n s p ins [] [] b = function n s p (mState void) (map param 
     ins) b
   inOutFunc n s p ins outs both b = function n s p (mState void) (map 
-    stateParam $ both ++ ins) (if null rets then b else liftA3 surroundBody 
+    param $ both ++ ins) (if null rets then b else liftA3 surroundBody 
     (multi $ map varDec outs) b (multiReturn $ map valueOf rets))
     where rets = filterOutObjs both ++ outs
 

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer/PythonRenderer.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer/PythonRenderer.hs
@@ -17,8 +17,8 @@ import GOOL.Drasil.Symantics (Label,
   ValueExpression(..), InternalValue(..), Selector(..), FunctionSym(..), 
   SelectorFunction(..), InternalFunction(..), InternalStatement(..), 
   StatementSym(..), ControlStatementSym(..), ScopeSym(..), InternalScope(..), 
-  MethodTypeSym(..), ParameterSym(..), MethodSym(..), StateVarSym(..), 
-  ClassSym(..), ModuleSym(..), BlockCommentSym(..))
+  MethodTypeSym(..), ParameterSym(..), MethodSym(..), InternalMethod(..),
+  StateVarSym(..), ClassSym(..), ModuleSym(..), BlockCommentSym(..))
 import GOOL.Drasil.LanguageRenderer (addExt, fileDoc', 
   enumElementsDocD', multiStateDocD, blockDocD, bodyDocD, outDoc, intTypeDocD, 
   floatTypeDocD, typeDocD, enumTypeDocD, constructDocD, paramListDocD, mkParam,
@@ -501,30 +501,27 @@ instance ParameterSym PythonCode where
 
 instance MethodSym PythonCode where
   type Method PythonCode = MethodData
-  method n l _ _ _ ps b = liftA2 (mthd False) (checkParams n <$> sequence ps) 
-    (liftA3 (pyMethod n) (self l) (liftList paramListDocD ps) b)
+  method n c s p t = intMethod n c s p (mState t)
   getMethod c v = method (getterName $ variableName v) c public dynamic_ 
-    (mState $ variableType v) [] getBody
+    (variableType v) [] getBody
     where getBody = oneLiner $ returnState (valueOf $ self c $-> v)
-  setMethod c v = method (setterName $ variableName v) c public dynamic_
-    (mState void) [param v] setBody
+  setMethod c v = method (setterName $ variableName v) c public dynamic_ void 
+    [param v] setBody
     where setBody = oneLiner $ (self c $-> v) &= valueOf v
   privMethod n c = method n c private dynamic_
   pubMethod n c = method n c public dynamic_
-  constructor n = method initName n public dynamic_ (construct n)
+  constructor n = intMethod initName n public dynamic_ (construct n)
   destructor _ _ = error "Destructors not allowed in Python"
 
   docMain = mainFunction
 
-  function n _ _ _ ps b = liftA2 (mthd False) (checkParams n <$> sequence ps) 
-    (liftA2 (pyFunction n) (liftList paramListDocD ps) b)
+  function n s p t = intFunc n s p (mState t)
   mainFunction = fmap (mthd True [])
 
   docFunc desc pComms rComm = docFuncRepr desc pComms (maybeToList rComm)
 
-  inOutFunc n s p ins [] [] b = function n s p (mState void) (map param 
-    ins) b
-  inOutFunc n s p ins outs both b = function n s p (mState void) (map 
+  inOutFunc n s p ins [] [] b = function n s p void (map param ins) b
+  inOutFunc n s p ins outs both b = function n s p void (map 
     param $ both ++ ins) (if null rets then b else liftA3 surroundBody 
     (multi $ map varDec outs) b (multiReturn $ map valueOf rets))
     where rets = filterOutObjs both ++ outs
@@ -534,10 +531,15 @@ instance MethodSym PythonCode where
     bs) b)
     where bRets = filter (not . isObject . getType . variableType . snd) bs
 
+  parameters m = map return $ (mthdParams . unPC) m
+
+instance InternalMethod PythonCode where
+  intMethod n l _ _ _ ps b = liftA2 (mthd False) (checkParams n <$> sequence ps)
+    (liftA3 (pyMethod n) (self l) (liftList paramListDocD ps) b)
+  intFunc n _ _ _ ps b = liftA2 (mthd False) (checkParams n <$> sequence ps) 
+    (liftA2 (pyFunction n) (liftList paramListDocD ps) b)
   commentedFunc cmt fn = liftA3 mthd (fmap isMainMthd fn) (fmap mthdParams fn)
     (liftA2 commentedItem cmt (fmap mthdDoc fn))
-
-  parameters m = map return $ (mthdParams . unPC) m
 
 instance StateVarSym PythonCode where
   type StateVar PythonCode = Doc

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer/PythonRenderer.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer/PythonRenderer.hs
@@ -509,16 +509,16 @@ instance MethodSym PythonCode where
   setMethod c v = method (setterName $ variableName v) c public dynamic_
     (mState void) [stateParam v] setBody
     where setBody = oneLiner $ (self c $-> v) &= valueOf v
-  mainMethod _ = fmap (mthd True [])
   privMethod n c = method n c private dynamic_
   pubMethod n c = method n c public dynamic_
   constructor n = method initName n public dynamic_ (construct n)
   destructor _ _ = error "Destructors not allowed in Python"
 
-  docMain = mainMethod
+  docMain = mainFunction
 
   function n _ _ _ ps b = liftA2 (mthd False) (checkParams n <$> sequence ps) 
     (liftA2 (pyFunction n) (liftList paramListDocD ps) b)
+  mainFunction = fmap (mthd True [])
 
   docFunc desc pComms rComm = docFuncRepr desc pComms (maybeToList rComm)
 

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer/PythonRenderer.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer/PythonRenderer.hs
@@ -488,7 +488,7 @@ instance InternalScope PythonCode where
 
 instance MethodTypeSym PythonCode where
   type MethodType PythonCode = TypeData
-  mState t = t
+  mType t = t
   construct n = return $ td (Object n) n (constructDocD n)
 
 instance ParameterSym PythonCode where
@@ -501,7 +501,7 @@ instance ParameterSym PythonCode where
 
 instance MethodSym PythonCode where
   type Method PythonCode = MethodData
-  method n c s p t = intMethod n c s p (mState t)
+  method n c s p t = intMethod n c s p (mType t)
   getMethod c v = method (getterName $ variableName v) c public dynamic_ 
     (variableType v) [] getBody
     where getBody = oneLiner $ returnState (valueOf $ self c $-> v)
@@ -515,7 +515,7 @@ instance MethodSym PythonCode where
 
   docMain = mainFunction
 
-  function n s p t = intFunc n s p (mState t)
+  function n s p t = intFunc n s p (mType t)
   mainFunction = fmap (mthd True [])
 
   docFunc desc pComms rComm = docFuncRepr desc pComms (maybeToList rComm)

--- a/code/drasil-gool/GOOL/Drasil/Symantics.hs
+++ b/code/drasil-gool/GOOL/Drasil/Symantics.hs
@@ -519,7 +519,7 @@ class MethodTypeSym repr where
 
 class ParameterSym repr where
   type Parameter repr
-  stateParam :: repr (Variable repr) -> repr (Parameter repr)
+  param :: repr (Variable repr) -> repr (Parameter repr)
   -- funcParam  :: Label -> repr (MethodType repr) -> [repr (Parameter repr)] -> repr (Parameter repr) -- not implemented in GOOL
   pointerParam :: repr (Variable repr) -> repr (Parameter repr)
 

--- a/code/drasil-gool/GOOL/Drasil/Symantics.hs
+++ b/code/drasil-gool/GOOL/Drasil/Symantics.hs
@@ -514,7 +514,7 @@ class (ScopeSym repr) => InternalScope repr where
 
 class MethodTypeSym repr where
   type MethodType repr
-  mState    :: repr (StateType repr) -> repr (MethodType repr)
+  mType    :: repr (StateType repr) -> repr (MethodType repr)
   construct :: Label -> repr (MethodType repr)
 
 class ParameterSym repr where

--- a/code/drasil-gool/GOOL/Drasil/Symantics.hs
+++ b/code/drasil-gool/GOOL/Drasil/Symantics.hs
@@ -535,7 +535,6 @@ class (ScopeSym repr, MethodTypeSym repr, ParameterSym repr, StateVarSym repr,
     [repr (Parameter repr)] -> repr (Body repr) -> repr (Method repr)
   getMethod   :: Label -> repr (Variable repr) -> repr (Method repr)
   setMethod   :: Label -> repr (Variable repr) -> repr (Method repr) 
-  mainMethod  :: Label -> repr (Body repr) -> repr (Method repr)
   privMethod  :: Label -> Label -> repr (MethodType repr) -> 
     [repr (Parameter repr)] -> repr (Body repr) -> repr (Method repr)
   pubMethod   :: Label -> Label -> repr (MethodType repr) -> 
@@ -544,11 +543,12 @@ class (ScopeSym repr, MethodTypeSym repr, ParameterSym repr, StateVarSym repr,
     repr (Method repr)
   destructor :: Label -> [repr (StateVar repr)] -> repr (Method repr)
 
-  docMain :: Label -> repr (Body repr) -> repr (Method repr)
+  docMain :: repr (Body repr) -> repr (Method repr)
 
   function :: Label -> repr (Scope repr) -> repr (Permanence repr) -> 
     repr (MethodType repr) -> [repr (Parameter repr)] -> repr (Body repr) -> 
     repr (Method repr) 
+  mainFunction  :: repr (Body repr) -> repr (Method repr)
   -- Parameters are: function description, parameter descriptions, 
   --   return value description if applicable, function
   docFunc :: String -> [String] -> Maybe String -> repr (Method repr) -> repr (Method repr) 

--- a/code/drasil-gool/GOOL/Drasil/Symantics.hs
+++ b/code/drasil-gool/GOOL/Drasil/Symantics.hs
@@ -11,8 +11,8 @@ module GOOL.Drasil.Symantics (
   ValueExpression(..), InternalValue(..), Selector(..), FunctionSym(..), 
   SelectorFunction(..), InternalFunction(..), InternalStatement(..), 
   StatementSym(..), ControlStatementSym(..), ScopeSym(..), InternalScope(..), 
-  MethodTypeSym(..), ParameterSym(..), MethodSym(..), StateVarSym(..), 
-  ClassSym(..), ModuleSym(..), BlockCommentSym(..)
+  MethodTypeSym(..), ParameterSym(..), MethodSym(..), InternalMethod(..),
+  StateVarSym(..), ClassSym(..), ModuleSym(..), BlockCommentSym(..)
 ) where
 
 import GOOL.Drasil.CodeType (CodeType)
@@ -527,17 +527,17 @@ class ParameterSym repr where
   parameterType :: repr (Parameter repr) -> repr (StateType repr)
 
 class (ScopeSym repr, MethodTypeSym repr, ParameterSym repr, StateVarSym repr,
-  BodySym repr, BlockCommentSym repr) => MethodSym repr where
+  BodySym repr, InternalMethod repr) => MethodSym repr where
   type Method repr
   -- Second label is class name
   method      :: Label -> Label -> repr (Scope repr) -> 
-    repr (Permanence repr) -> repr (MethodType repr) -> 
+    repr (Permanence repr) -> repr (StateType repr) -> 
     [repr (Parameter repr)] -> repr (Body repr) -> repr (Method repr)
   getMethod   :: Label -> repr (Variable repr) -> repr (Method repr)
   setMethod   :: Label -> repr (Variable repr) -> repr (Method repr) 
-  privMethod  :: Label -> Label -> repr (MethodType repr) -> 
+  privMethod  :: Label -> Label -> repr (StateType repr) -> 
     [repr (Parameter repr)] -> repr (Body repr) -> repr (Method repr)
-  pubMethod   :: Label -> Label -> repr (MethodType repr) -> 
+  pubMethod   :: Label -> Label -> repr (StateType repr) -> 
     [repr (Parameter repr)] -> repr (Body repr) -> repr (Method repr)
   constructor :: Label -> [repr (Parameter repr)] -> repr (Body repr) -> 
     repr (Method repr)
@@ -546,7 +546,7 @@ class (ScopeSym repr, MethodTypeSym repr, ParameterSym repr, StateVarSym repr,
   docMain :: repr (Body repr) -> repr (Method repr)
 
   function :: Label -> repr (Scope repr) -> repr (Permanence repr) -> 
-    repr (MethodType repr) -> [repr (Parameter repr)] -> repr (Body repr) -> 
+    repr (StateType repr) -> [repr (Parameter repr)] -> repr (Body repr) -> 
     repr (Method repr) 
   mainFunction  :: repr (Body repr) -> repr (Method repr)
   -- Parameters are: function description, parameter descriptions, 
@@ -563,10 +563,19 @@ class (ScopeSym repr, MethodTypeSym repr, ParameterSym repr, StateVarSym repr,
     (Variable repr))] -> [(String, repr (Variable repr))] -> repr (Body repr)
     -> repr (Method repr)
 
+  parameters :: repr (Method repr) -> [repr (Parameter repr)]
+
+class (ScopeSym repr, MethodTypeSym repr, ParameterSym repr, StateVarSym repr,
+  BodySym repr, BlockCommentSym repr) => InternalMethod repr where
+  intMethod      :: Label -> Label -> repr (Scope repr) -> 
+    repr (Permanence repr) -> repr (MethodType repr) -> 
+    [repr (Parameter repr)] -> repr (Body repr) -> repr (Method repr)
+  intFunc      :: Label -> repr (Scope repr) -> repr (Permanence repr) -> 
+    repr (MethodType repr) -> [repr (Parameter repr)] -> repr (Body repr) -> 
+    repr (Method repr)
   commentedFunc :: repr (BlockComment repr) -> repr (Method repr) -> 
     repr (Method repr)
-
-  parameters :: repr (Method repr) -> [repr (Parameter repr)]
+  
 
 class (ScopeSym repr, InternalScope repr, PermanenceSym repr, StateTypeSym repr,
   StatementSym repr) => StateVarSym repr where

--- a/code/drasil-gool/GOOL/Drasil/Symantics.hs
+++ b/code/drasil-gool/GOOL/Drasil/Symantics.hs
@@ -6,7 +6,7 @@ module GOOL.Drasil.Symantics (
   -- Typeclasses
   ProgramSym(..), RenderSym(..), InternalFile(..),  KeywordSym(..), 
   PermanenceSym(..), BodySym(..), ControlBlockSym(..), BlockSym(..), 
-  StateTypeSym(..), UnaryOpSym(..), BinaryOpSym(..), VariableSym(..), 
+  TypeSym(..), UnaryOpSym(..), BinaryOpSym(..), VariableSym(..), 
   ValueSym(..), NumericExpression(..), BooleanExpression(..), 
   ValueExpression(..), InternalValue(..), Selector(..), FunctionSym(..), 
   SelectorFunction(..), InternalFunction(..), InternalStatement(..), 
@@ -85,25 +85,25 @@ class (StatementSym repr) => BlockSym repr where
   type Block repr
   block   :: [repr (Statement repr)] -> repr (Block repr)
 
-class (PermanenceSym repr) => StateTypeSym repr where
-  type StateType repr
-  bool          :: repr (StateType repr)
-  int           :: repr (StateType repr)
-  float         :: repr (StateType repr)
-  char          :: repr (StateType repr)
-  string        :: repr (StateType repr)
-  infile        :: repr (StateType repr)
-  outfile       :: repr (StateType repr)
-  listType      :: repr (Permanence repr) -> repr (StateType repr) -> repr (StateType repr)
-  listInnerType :: repr (StateType repr) -> repr (StateType repr)
-  obj           :: Label -> repr (StateType repr)
-  enumType      :: Label -> repr (StateType repr)
-  iterator      :: repr (StateType repr) -> repr (StateType repr)
-  void          :: repr (StateType repr)
+class (PermanenceSym repr) => TypeSym repr where
+  type Type repr
+  bool          :: repr (Type repr)
+  int           :: repr (Type repr)
+  float         :: repr (Type repr)
+  char          :: repr (Type repr)
+  string        :: repr (Type repr)
+  infile        :: repr (Type repr)
+  outfile       :: repr (Type repr)
+  listType      :: repr (Permanence repr) -> repr (Type repr) -> repr (Type repr)
+  listInnerType :: repr (Type repr) -> repr (Type repr)
+  obj           :: Label -> repr (Type repr)
+  enumType      :: Label -> repr (Type repr)
+  iterator      :: repr (Type repr) -> repr (Type repr)
+  void          :: repr (Type repr)
 
-  getType :: repr (StateType repr) -> CodeType
-  getTypeString :: repr (StateType repr) -> String
-  getTypeDoc :: repr (StateType repr) -> Doc
+  getType :: repr (Type repr) -> CodeType
+  getTypeString :: repr (Type repr) -> String
+  getTypeDoc :: repr (Type repr) -> Doc
 
 class (BodySym repr, ControlStatementSym repr) => ControlBlockSym repr where
   runStrategy     :: Label -> [(Label, repr (Body repr))] -> 
@@ -149,34 +149,34 @@ class BinaryOpSym repr where
   andOp          :: repr (BinaryOp repr)
   orOp           :: repr (BinaryOp repr)
 
-class (StateTypeSym repr) => VariableSym repr where
+class (TypeSym repr) => VariableSym repr where
   type Variable repr
-  var          :: Label -> repr (StateType repr) -> repr (Variable repr)
-  staticVar    :: Label -> repr (StateType repr) -> repr (Variable repr)
-  const        :: Label -> repr (StateType repr) -> repr (Variable repr)
-  extVar       :: Library -> Label -> repr (StateType repr) -> 
+  var          :: Label -> repr (Type repr) -> repr (Variable repr)
+  staticVar    :: Label -> repr (Type repr) -> repr (Variable repr)
+  const        :: Label -> repr (Type repr) -> repr (Variable repr)
+  extVar       :: Library -> Label -> repr (Type repr) -> 
     repr (Variable repr)
   self         :: Label -> repr (Variable repr)
-  classVar     :: repr (StateType repr) -> repr (Variable repr) -> repr (Variable repr)
+  classVar     :: repr (Type repr) -> repr (Variable repr) -> repr (Variable repr)
   objVar       :: repr (Variable repr) -> repr (Variable repr) -> repr (Variable repr)
-  objVarSelf   :: Label -> Label -> repr (StateType repr) -> 
+  objVarSelf   :: Label -> Label -> repr (Type repr) -> 
     repr (Variable repr)
   enumVar      :: Label -> Label -> repr (Variable repr)
-  listVar      :: Label -> repr (Permanence repr) -> repr (StateType repr) -> 
+  listVar      :: Label -> repr (Permanence repr) -> repr (Type repr) -> 
     repr (Variable repr)
-  listOf       :: Label -> repr (StateType repr) -> repr (Variable repr)
+  listOf       :: Label -> repr (Type repr) -> repr (Variable repr)
   -- Use for iterator variables, i.e. in a forEach loop.
-  iterVar      :: Label -> repr (StateType repr) -> repr (Variable repr)
+  iterVar      :: Label -> repr (Type repr) -> repr (Variable repr)
 
   ($->) :: repr (Variable repr) -> repr (Variable repr) -> repr (Variable repr)
   infixl 9 $->
 
   variableBind :: repr (Variable repr) -> Binding
   variableName :: repr (Variable repr) -> String
-  variableType :: repr (Variable repr) -> repr (StateType repr)
+  variableType :: repr (Variable repr) -> repr (Type repr)
   variableDoc  :: repr (Variable repr) -> Doc
 
-  varFromData :: Binding -> String -> repr (StateType repr) -> Doc -> 
+  varFromData :: Binding -> String -> repr (Type repr) -> Doc -> 
     repr (Variable repr)
 
 class (VariableSym repr) => ValueSym repr where
@@ -199,7 +199,7 @@ class (VariableSym repr) => ValueSym repr where
 
   argsList  :: repr (Value repr)
 
-  valueType :: repr (Value repr) -> repr (StateType repr)
+  valueType :: repr (Value repr) -> repr (Type repr)
   valueDoc :: repr (Value repr) -> Doc
 
 class (ValueSym repr, UnaryOpSym repr, BinaryOpSym repr) => 
@@ -269,17 +269,17 @@ class (ValueSym repr, NumericExpression repr, BooleanExpression repr) =>
   ValueExpression repr where -- for values that can include expressions
   inlineIf     :: repr (Value repr) -> repr (Value repr) -> repr (Value repr) ->
     repr (Value repr)
-  funcApp      :: Label -> repr (StateType repr) -> [repr (Value repr)] -> 
+  funcApp      :: Label -> repr (Type repr) -> [repr (Value repr)] -> 
     repr (Value repr)
-  selfFuncApp  :: Label -> repr (StateType repr) -> [repr (Value repr)] -> 
+  selfFuncApp  :: Label -> repr (Type repr) -> [repr (Value repr)] -> 
     repr (Value repr)
-  extFuncApp   :: Library -> Label -> repr (StateType repr) -> 
+  extFuncApp   :: Library -> Label -> repr (Type repr) -> 
     [repr (Value repr)] -> repr (Value repr)
-  stateObj     :: repr (StateType repr) -> [repr (Value repr)] -> 
+  stateObj     :: repr (Type repr) -> [repr (Value repr)] -> 
     repr (Value repr)
-  extStateObj  :: Library -> repr (StateType repr) -> [repr (Value repr)] -> 
+  extStateObj  :: Library -> repr (Type repr) -> [repr (Value repr)] -> 
     repr (Value repr)
-  listStateObj :: repr (StateType repr) -> [repr (Value repr)] -> 
+  listStateObj :: repr (Type repr) -> [repr (Value repr)] -> 
     repr (Value repr)
 
   exists  :: repr (Value repr) -> repr (Value repr)
@@ -292,7 +292,7 @@ class (ValueExpression repr) => InternalValue repr where
   printFileFunc   :: repr (Value repr) -> repr (Value repr)
   printFileLnFunc :: repr (Value repr) -> repr (Value repr)
 
-  cast :: repr (StateType repr) -> repr (Value repr) -> repr (Value repr)
+  cast :: repr (Type repr) -> repr (Value repr) -> repr (Value repr)
 
 -- The cyclic constraints issue arises here too. I've constrained this by ValueExpression,
 -- but really one might want one of these values as part of an expression, so the
@@ -306,9 +306,9 @@ class (FunctionSym repr, ValueSym repr, ValueExpression repr) =>
   ($.)      :: repr (Value repr) -> repr (Function repr) -> repr (Value repr)
   infixl 9 $.
 
-  objMethodCall     :: repr (StateType repr) -> repr (Value repr) -> Label -> 
+  objMethodCall     :: repr (Type repr) -> repr (Value repr) -> Label -> 
     [repr (Value repr)] -> repr (Value repr)
-  objMethodCallNoParams :: repr (StateType repr) -> repr (Value repr) -> Label
+  objMethodCallNoParams :: repr (Type repr) -> repr (Value repr) -> Label
     -> repr (Value repr)
 
   selfAccess :: Label -> repr (Function repr) -> repr (Value repr)
@@ -320,7 +320,7 @@ class (FunctionSym repr, ValueSym repr, ValueExpression repr) =>
 
 class (ValueSym repr, ValueExpression repr) => FunctionSym repr where
   type Function repr
-  func           :: Label -> repr (StateType repr) -> [repr (Value repr)] -> 
+  func           :: Label -> repr (Type repr) -> [repr (Value repr)] -> 
     repr (Function repr)
 
   get :: repr (Value repr) -> repr (Variable repr) -> repr (Value repr)
@@ -344,7 +344,7 @@ class (ValueSym repr, InternalValue repr, FunctionSym repr, Selector repr) =>
 
 class (ValueSym repr, InternalValue repr) => InternalFunction repr where
   getFunc        :: repr (Variable repr) -> repr (Function repr)
-  setFunc        :: repr (StateType repr) -> repr (Variable repr) -> 
+  setFunc        :: repr (Type repr) -> repr (Variable repr) -> 
     repr (Value repr) -> repr (Function repr)
 
   listSizeFunc       :: repr (Function repr)
@@ -352,15 +352,15 @@ class (ValueSym repr, InternalValue repr) => InternalFunction repr where
     repr (Value repr) -> repr (Function repr)
   listAppendFunc         :: repr (Value repr) -> repr (Function repr)
 
-  iterBeginFunc :: repr (StateType repr) -> repr (Function repr)
-  iterEndFunc   :: repr (StateType repr) -> repr (Function repr)
+  iterBeginFunc :: repr (Type repr) -> repr (Function repr)
+  iterEndFunc   :: repr (Type repr) -> repr (Function repr)
 
-  listAccessFunc :: repr (StateType repr) -> repr (Value repr) -> 
+  listAccessFunc :: repr (Type repr) -> repr (Value repr) -> 
     repr (Function repr)
   listSetFunc    :: repr (Value repr) -> repr (Value repr) -> 
     repr (Value repr) -> repr (Function repr)
 
-  atFunc :: repr (StateType repr) -> Label -> repr (Function repr)
+  atFunc :: repr (Type repr) -> Label -> repr (Function repr)
 
 class (Selector repr) => InternalStatement repr where
   -- newLn, printFunc, value to print, maybe a file to print to 
@@ -462,7 +462,7 @@ class (ValueSym repr, Selector repr, SelectorFunction repr, FunctionSym repr,
   initState   :: Label -> Label -> repr (Statement repr)
   changeState :: Label -> Label -> repr (Statement repr)
 
-  initObserverList :: repr (StateType repr) -> [repr (Value repr)] -> 
+  initObserverList :: repr (Type repr) -> [repr (Value repr)] -> 
     repr (Statement repr)
   addObserver      :: repr (Value repr) -> repr (Statement repr)
 
@@ -498,7 +498,7 @@ class (StatementSym repr, BodySym repr) => ControlStatementSym repr where
 
   checkState      :: Label -> [(repr (Value repr), repr (Body repr))] -> 
     repr (Body repr) -> repr (Statement repr)
-  notifyObservers :: repr (Function repr) -> repr (StateType repr) -> 
+  notifyObservers :: repr (Function repr) -> repr (Type repr) -> 
     repr (Statement repr)
 
   getFileInputAll  :: repr (Value repr) -> repr (Variable repr) -> 
@@ -514,7 +514,7 @@ class (ScopeSym repr) => InternalScope repr where
 
 class MethodTypeSym repr where
   type MethodType repr
-  mType    :: repr (StateType repr) -> repr (MethodType repr)
+  mType    :: repr (Type repr) -> repr (MethodType repr)
   construct :: Label -> repr (MethodType repr)
 
 class ParameterSym repr where
@@ -524,20 +524,20 @@ class ParameterSym repr where
   pointerParam :: repr (Variable repr) -> repr (Parameter repr)
 
   parameterName :: repr (Parameter repr) -> String
-  parameterType :: repr (Parameter repr) -> repr (StateType repr)
+  parameterType :: repr (Parameter repr) -> repr (Type repr)
 
 class (ScopeSym repr, MethodTypeSym repr, ParameterSym repr, StateVarSym repr,
   BodySym repr, InternalMethod repr) => MethodSym repr where
   type Method repr
   -- Second label is class name
   method      :: Label -> Label -> repr (Scope repr) -> 
-    repr (Permanence repr) -> repr (StateType repr) -> 
+    repr (Permanence repr) -> repr (Type repr) -> 
     [repr (Parameter repr)] -> repr (Body repr) -> repr (Method repr)
   getMethod   :: Label -> repr (Variable repr) -> repr (Method repr)
   setMethod   :: Label -> repr (Variable repr) -> repr (Method repr) 
-  privMethod  :: Label -> Label -> repr (StateType repr) -> 
+  privMethod  :: Label -> Label -> repr (Type repr) -> 
     [repr (Parameter repr)] -> repr (Body repr) -> repr (Method repr)
-  pubMethod   :: Label -> Label -> repr (StateType repr) -> 
+  pubMethod   :: Label -> Label -> repr (Type repr) -> 
     [repr (Parameter repr)] -> repr (Body repr) -> repr (Method repr)
   constructor :: Label -> [repr (Parameter repr)] -> repr (Body repr) -> 
     repr (Method repr)
@@ -546,7 +546,7 @@ class (ScopeSym repr, MethodTypeSym repr, ParameterSym repr, StateVarSym repr,
   docMain :: repr (Body repr) -> repr (Method repr)
 
   function :: Label -> repr (Scope repr) -> repr (Permanence repr) -> 
-    repr (StateType repr) -> [repr (Parameter repr)] -> repr (Body repr) -> 
+    repr (Type repr) -> [repr (Parameter repr)] -> repr (Body repr) -> 
     repr (Method repr) 
   mainFunction  :: repr (Body repr) -> repr (Method repr)
   -- Parameters are: function description, parameter descriptions, 
@@ -577,7 +577,7 @@ class (ScopeSym repr, MethodTypeSym repr, ParameterSym repr, StateVarSym repr,
     repr (Method repr)
   
 
-class (ScopeSym repr, InternalScope repr, PermanenceSym repr, StateTypeSym repr,
+class (ScopeSym repr, InternalScope repr, PermanenceSym repr, TypeSym repr,
   StatementSym repr) => StateVarSym repr where
   type StateVar repr
   stateVar :: Int -> repr (Scope repr) -> repr (Permanence repr) ->

--- a/code/drasil-gool/Test/FileTests.hs
+++ b/code/drasil-gool/Test/FileTests.hs
@@ -1,7 +1,7 @@
 module Test.FileTests (fileTests) where
 
 import GOOL.Drasil (ProgramSym(..), RenderSym(..), 
-  PermanenceSym(..), BodySym(..), BlockSym(..), StateTypeSym(..), 
+  PermanenceSym(..), BodySym(..), BlockSym(..), TypeSym(..), 
   StatementSym(..), ControlStatementSym(..), VariableSym(..), ValueSym(..), 
   MethodSym(..), ModuleSym(..))
 import Prelude hiding (return,print,log,exp,sin,cos,tan)

--- a/code/drasil-gool/Test/FileTests.hs
+++ b/code/drasil-gool/Test/FileTests.hs
@@ -10,8 +10,7 @@ fileTests :: (ProgramSym repr) => repr (Program repr)
 fileTests = prog "FileTests" [fileDoc (buildModule "FileTests" [] [fileTestMethod] [])]
 
 fileTestMethod :: (RenderSym repr) => repr (Method repr)
-fileTestMethod = mainMethod "FileTests" (body [writeStory, block [readStory], 
-  goodBye])
+fileTestMethod = mainFunction (body [writeStory, block [readStory], goodBye])
 
 writeStory :: (RenderSym repr) => repr (Block repr)
 writeStory = block [

--- a/code/drasil-gool/Test/HelloWorld.hs
+++ b/code/drasil-gool/Test/HelloWorld.hs
@@ -4,7 +4,7 @@ module Test.HelloWorld (helloWorld) where
 
 import GOOL.Drasil (
   ProgramSym(..), RenderSym(..), PermanenceSym(..),
-  BodySym(..), BlockSym(..), ControlBlockSym(..), StateTypeSym(..), 
+  BodySym(..), BlockSym(..), ControlBlockSym(..), TypeSym(..), 
   StatementSym(..), ControlStatementSym(..),  VariableSym(..), ValueSym(..), 
   NumericExpression(..), BooleanExpression(..), ValueExpression(..), 
   Selector(..), FunctionSym(..), SelectorFunction(..), MethodSym(..), 

--- a/code/drasil-gool/Test/HelloWorld.hs
+++ b/code/drasil-gool/Test/HelloWorld.hs
@@ -21,7 +21,7 @@ description :: String
 description = "Tests various GOOL functions. It should run without errors."
 
 helloWorldMain :: (RenderSym repr) => repr (Method repr)
-helloWorldMain = mainMethod "HelloWorld" (body [ helloInitVariables, 
+helloWorldMain = mainFunction (body [ helloInitVariables, 
     helloListSlice,
     block [ifCond [(valueOf (var "b" int) ?>= litInt 6, bodyStatements [varDecDef (var "dummy" string) (litString "dummy")]),
       (valueOf (var "b" int) ?== litInt 5, helloIfBody)] helloElseBody, helloIfExists,

--- a/code/drasil-gool/Test/Helper.hs
+++ b/code/drasil-gool/Test/Helper.hs
@@ -1,7 +1,7 @@
 module Test.Helper (helper) where
 
 import GOOL.Drasil.Symantics (
-  RenderSym(..), PermanenceSym(..), BodySym(..), StateTypeSym(..), 
+  RenderSym(..), PermanenceSym(..), BodySym(..), TypeSym(..), 
   StatementSym(..), VariableSym(..), ValueSym(..), NumericExpression(..), 
   ScopeSym(..), ParameterSym(..), MethodSym(..), ModuleSym(..))
 import Prelude hiding (return,print,log,exp,sin,cos,tan)

--- a/code/drasil-gool/Test/Helper.hs
+++ b/code/drasil-gool/Test/Helper.hs
@@ -3,8 +3,7 @@ module Test.Helper (helper) where
 import GOOL.Drasil.Symantics (
   RenderSym(..), PermanenceSym(..), BodySym(..), StateTypeSym(..), 
   StatementSym(..), VariableSym(..), ValueSym(..), NumericExpression(..), 
-  ScopeSym(..), MethodTypeSym(..), ParameterSym(..), MethodSym(..), 
-  ModuleSym(..))
+  ScopeSym(..), ParameterSym(..), MethodSym(..), ModuleSym(..))
 import Prelude hiding (return,print,log,exp,sin,cos,tan)
 
 helper :: (RenderSym repr) => repr (RenderFile repr)
@@ -13,7 +12,7 @@ helper = fileDoc (buildModule "Helper" [] [doubleAndAdd] [])
 doubleAndAdd :: (RenderSym repr) => repr (Method repr)
 doubleAndAdd = docFunc "This function adds two numbers" 
   ["First number to add", "Second number to add"] (Just "Sum") $ 
-  function "doubleAndAdd"  public static_ (mState float) 
+  function "doubleAndAdd"  public static_ float
   [param $ var "num1" float, param $ var "num2" float]
   (bodyStatements [
     varDec $ var "doubledSum" float, 

--- a/code/drasil-gool/Test/Helper.hs
+++ b/code/drasil-gool/Test/Helper.hs
@@ -14,7 +14,7 @@ doubleAndAdd :: (RenderSym repr) => repr (Method repr)
 doubleAndAdd = docFunc "This function adds two numbers" 
   ["First number to add", "Second number to add"] (Just "Sum") $ 
   function "doubleAndAdd"  public static_ (mState float) 
-  [stateParam $ var "num1" float, stateParam $ var "num2" float]
+  [param $ var "num1" float, param $ var "num2" float]
   (bodyStatements [
     varDec $ var "doubledSum" float, 
     var "doubledSum" float &= ((litFloat 2.0 #* valueOf (var "num1" float)) #+ 

--- a/code/drasil-gool/Test/Observer.hs
+++ b/code/drasil-gool/Test/Observer.hs
@@ -1,7 +1,7 @@
 module Test.Observer (observer) where
 
 import GOOL.Drasil.Symantics (
-  RenderSym(..), PermanenceSym(..), BodySym(..), StateTypeSym(..), 
+  RenderSym(..), PermanenceSym(..), BodySym(..), TypeSym(..), 
   StatementSym(..), VariableSym(..), ValueSym(..), ScopeSym(..), 
   MethodSym(..), StateVarSym(..), ClassSym(..), ModuleSym(..))
 import Prelude hiding (return,print,log,exp,sin,cos,tan)

--- a/code/drasil-gool/Test/Observer.hs
+++ b/code/drasil-gool/Test/Observer.hs
@@ -3,8 +3,7 @@ module Test.Observer (observer) where
 import GOOL.Drasil.Symantics (
   RenderSym(..), PermanenceSym(..), BodySym(..), StateTypeSym(..), 
   StatementSym(..), VariableSym(..), ValueSym(..), ScopeSym(..), 
-  MethodTypeSym(..), MethodSym(..), StateVarSym(..), ClassSym(..), 
-  ModuleSym(..))
+  MethodSym(..), StateVarSym(..), ClassSym(..), ModuleSym(..))
 import Prelude hiding (return,print,log,exp,sin,cos,tan)
 
 observer :: (RenderSym repr) => repr (RenderFile repr)
@@ -20,4 +19,5 @@ observerConstructor :: (RenderSym repr) => repr (Method repr)
 observerConstructor = constructor "Observer" [] (oneLiner (assign (objVarSelf "Observer" "x" int) (litInt 5)))
 
 printNumMethod :: (RenderSym repr) => repr (Method repr)
-printNumMethod = method "printNum" "Observer" public dynamic_ (mState void) [] (oneLiner (printLn (valueOf $ objVarSelf "Observer" "x" int)))
+printNumMethod = method "printNum" "Observer" public dynamic_ void [] 
+  (oneLiner (printLn (valueOf $ objVarSelf "Observer" "x" int)))

--- a/code/drasil-gool/Test/PatternTest.hs
+++ b/code/drasil-gool/Test/PatternTest.hs
@@ -12,7 +12,7 @@ patternTest :: (ProgramSym repr) => repr (Program repr)
 patternTest = prog "PatternTest" [fileDoc (buildModule "PatternTest" ["Observer"] [patternTestMainMethod] []), observer]
 
 patternTestMainMethod :: (RenderSym repr) => repr (Method repr)
-patternTestMainMethod = mainMethod "PatternTest" (body [block [
+patternTestMainMethod = mainFunction (body [block [
   varDec $ var "n" int,
   initState "myFSM" "Off", 
   changeState "myFSM" "On",

--- a/code/drasil-gool/Test/PatternTest.hs
+++ b/code/drasil-gool/Test/PatternTest.hs
@@ -2,7 +2,7 @@ module Test.PatternTest (patternTest) where
 
 import GOOL.Drasil (
   ProgramSym(..), RenderSym(..), PermanenceSym(..),
-  BodySym(..), BlockSym(..), ControlBlockSym(..), StateTypeSym(..), 
+  BodySym(..), BlockSym(..), ControlBlockSym(..), TypeSym(..), 
   StatementSym(..), ControlStatementSym(..), VariableSym(..), ValueSym(..),
   ValueExpression(..), FunctionSym(..), MethodSym(..), ModuleSym(..))
 import Prelude hiding (return,print,log,exp,sin,cos,tan)


### PR DESCRIPTION
In this PR:

- Renaming more things. A lot of GOOL functions/types had "state" in the name which I never really understood before but I now think was a relic of GOOL's original focus on state machines, and so I am now giving better names to these things
- Updating functions for generating methods/functions to take a `Type` instead of a `MethodType`. The `MethodType` distinction is useful, but only internally, so there's no need to expose it and complicate the user-facing interface of GOOL.