### PR TITLE
Minor simplification for forEachDocD

### DIFF
--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer.hs
@@ -331,11 +331,10 @@ forDocD bStart bEnd sInit vGuard sUpdate b = vcat [
   indent b,
   bEnd]
 
-forEachDocD :: VarData -> Doc -> Doc -> Doc -> Doc -> TypeData -> ValData -> 
-  Doc -> Doc
-forEachDocD e bStart bEnd forEachLabel inLabel t v b =
-  vcat [forEachLabel <+> parens (typeDoc t <+> varDoc e <+> inLabel <+> 
-    valDoc v) <+> bStart,
+forEachDocD :: VarData -> Doc -> Doc -> Doc -> Doc -> ValData -> Doc -> Doc
+forEachDocD e bStart bEnd forEachLabel inLabel v b =
+  vcat [forEachLabel <+> parens (typeDoc (varType e) <+> varDoc e <+> inLabel 
+    <+> valDoc v) <+> bStart,
   indent b,
   bEnd]
 

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer/CSharpRenderer.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer/CSharpRenderer.hs
@@ -50,7 +50,7 @@ import GOOL.Drasil.Data (Terminator(..),
   ParamData(..), pd, updateParamDoc, ProgData(..), progD, TypeData(..), td, 
   ValData(..), updateValDoc, Binding(..), VarData(..), vard)
 import GOOL.Drasil.Helpers (emptyIfEmpty, liftA4, 
-  liftA5, liftA6, liftA8, liftList, lift1List, lift3Pair, lift4Pair,
+  liftA5, liftA6, liftA7, liftList, lift1List, lift3Pair, lift4Pair,
   liftPair, liftPairFst, getInnerType, convType, checkParams)
 
 import Prelude hiding (break,print,(<>),sin,cos,tan,floor)
@@ -474,8 +474,8 @@ instance ControlStatementSym CSharpCode where
     (loopState sInit) vGuard (loopState sUpdate) b
   forRange i initv finalv stepv = for (varDecDef i initv) 
     (valueOf i ?< finalv) (i &+= stepv)
-  forEach e v b = mkStNoEnd <$> liftA8 forEachDocD e blockStart blockEnd 
-    iterForEachLabel iterInLabel (listInnerType $ valueType v) v b
+  forEach e v b = mkStNoEnd <$> liftA7 forEachDocD e blockStart blockEnd 
+    iterForEachLabel iterInLabel v b
   while v b = mkStNoEnd <$> liftA4 whileDocD blockStart blockEnd v b
 
   tryCatch tb cb = mkStNoEnd <$> liftA2 csTryCatch tb cb

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer/JavaRenderer.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer/JavaRenderer.hs
@@ -49,7 +49,7 @@ import GOOL.Drasil.Data (Terminator(..),
   ProgData(..), progD, TypeData(..), td, ValData(..), 
   VarData(..), vard)
 import GOOL.Drasil.Helpers (angles, emptyIfEmpty, 
-  liftA4, liftA5, liftA6, liftA8, liftList, lift1List, lift3Pair, 
+  liftA4, liftA5, liftA6, liftA7, liftList, lift1List, lift3Pair, 
   lift4Pair, liftPair, liftPairFst, getInnerType, convType, checkParams)
 
 import Prelude hiding (break,print,sin,cos,tan,floor,(<>))
@@ -473,8 +473,8 @@ instance ControlStatementSym JavaCode where
     (loopState sInit) vGuard (loopState sUpdate) b
   forRange i initv finalv stepv = for (varDecDef i initv) 
     (valueOf i ?< finalv) (i &+= stepv)
-  forEach e v b = mkStNoEnd <$> liftA8 forEachDocD e blockStart blockEnd
-    iterForEachLabel iterInLabel (listInnerType $ valueType v) v b
+  forEach e v b = mkStNoEnd <$> liftA7 forEachDocD e blockStart blockEnd
+    iterForEachLabel iterInLabel v b
   while v b = mkStNoEnd <$> liftA4 whileDocD blockStart blockEnd v b
 
   tryCatch tb cb = mkStNoEnd <$> liftA2 jTryCatch tb cb


### PR DESCRIPTION
Tiny PR which removes a no longer needed parameter from `forEachDocD`, enabled because we now pass a full variable to `forEach` instead of just a label.