### PR TITLE
Matching concepts to GOOL functions

### DIFF
--- a/code/drasil-code/Language/Drasil/Code.hs
+++ b/code/drasil-code/Language/Drasil/Code.hs
@@ -6,7 +6,8 @@ module Language.Drasil.Code (
   ($:=), Choices(..), CodeSpec(..), CodeSystInfo(..), Comments(..), 
   ConstraintBehaviour(..), Func, FuncStmt(..), ImplementationType(..), Lang(..),
   Logging(LogNone, LogAll), Mod(Mod), Structure(..), ConstantStructure(..), 
-  ConstantRepr(..), InputModule(..), AuxFile(..), Visibility(..),
+  ConstantRepr(..), InputModule(..), CodeConcept(..), matchConcepts, 
+  AuxFile(..), Visibility(..),
   asExpr, asExpr', asVC, asVC', codeSpec, fdec, ffor, funcData, funcDef, 
   packmod, relToQD,
   junkLine, multiLine, repeated, singleLine, singleton,
@@ -30,9 +31,9 @@ import Language.Drasil.Code.DataDesc (junkLine, multiLine, repeated, singleLine,
 import Language.Drasil.CodeSpec (($:=), Choices(..), CodeSpec(..), 
   CodeSystInfo(..), Comments(..), ConstraintBehaviour(..), Func, FuncStmt(..),
   ImplementationType(..), Lang(..), Logging(..), Mod(Mod), Structure(..), 
-  ConstantStructure(..), ConstantRepr(..), InputModule(..), AuxFile(..), 
-  Visibility(..), asExpr, asExpr', asVC, asVC', codeSpec, fdec, ffor, funcData, 
-  funcDef, packmod, relToQD)
+  ConstantStructure(..), ConstantRepr(..), InputModule(..), CodeConcept(..), 
+  matchConcepts, AuxFile(..), Visibility(..), asExpr, asExpr', asVC, asVC', 
+  codeSpec, fdec, ffor, funcData, funcDef, packmod, relToQD)
 
 import Language.Drasil.Code.Imperative.GOOL.Symantics (PackageSym(..))
 

--- a/code/drasil-code/Language/Drasil/Code/Imperative/ConceptMatch.hs
+++ b/code/drasil-code/Language/Drasil/Code/Imperative/ConceptMatch.hs
@@ -1,0 +1,22 @@
+module Language.Drasil.Code.Imperative.ConceptMatch (
+  chooseConcept, conceptToGOOL
+) where
+
+import Language.Drasil.CodeSpec (Choices(..), CodeConcept(..), 
+  MatchedConceptMap)
+
+import GOOL.Drasil (RenderSym, ValueSym(..))
+
+import Prelude hiding (pi)
+import qualified Data.Map as Map (map)
+
+-- Currently we don't have any Choices that would prevent a CodeConcept from being mapped, so we just take the head of the list of CodeConcepts
+chooseConcept :: Choices -> MatchedConceptMap
+chooseConcept chs = Map.map (chooseConcept' chs) (conceptMatch chs)
+  where chooseConcept' _ [] = error $ "Empty list of CodeConcepts in the " ++ 
+          "ConceptMatchMap"
+        chooseConcept' _ cs = head cs
+
+conceptToGOOL :: (RenderSym repr) => CodeConcept -> repr (Value repr)
+conceptToGOOL Pi = pi
+

--- a/code/drasil-code/Language/Drasil/Code/Imperative/Generator.hs
+++ b/code/drasil-code/Language/Drasil/Code/Imperative/Generator.hs
@@ -32,6 +32,7 @@ generator dt sd chs spec = State {
   inMod = inputModule chs,
   logKind  = logging chs,
   commented = comments chs,
+  concMatches = conceptMatch chs,
   auxiliaries = auxFiles chs,
   sampleData = sd,
   -- state

--- a/code/drasil-code/Language/Drasil/Code/Imperative/Generator.hs
+++ b/code/drasil-code/Language/Drasil/Code/Imperative/Generator.hs
@@ -3,6 +3,7 @@ module Language.Drasil.Code.Imperative.Generator (
 ) where
 
 import Language.Drasil
+import Language.Drasil.Code.Imperative.ConceptMatch (chooseConcept)
 import Language.Drasil.Code.Imperative.GenerateGOOL (genDoxConfig)
 import Language.Drasil.Code.Imperative.Import (genModDef)
 import Language.Drasil.Code.Imperative.Modules (chooseInModule, genConstMod, 
@@ -32,7 +33,7 @@ generator dt sd chs spec = State {
   inMod = inputModule chs,
   logKind  = logging chs,
   commented = comments chs,
-  concMatches = conceptMatch chs,
+  concMatches = chooseConcept chs,
   auxiliaries = auxFiles chs,
   sampleData = sd,
   -- state

--- a/code/drasil-code/Language/Drasil/Code/Imperative/Import.hs
+++ b/code/drasil-code/Language/Drasil/Code/Imperative/Import.hs
@@ -9,6 +9,7 @@ import Language.Drasil hiding (int, log, ln, exp,
   sin, cos, tan, csc, sec, cot, arcsin, arccos, arctan)
 import Database.Drasil (symbResolve)
 import Language.Drasil.Code.Imperative.Comments (paramComment, returnComment)
+import Language.Drasil.Code.Imperative.ConceptMatch (conceptToGOOL)
 import Language.Drasil.Code.Imperative.GenerateGOOL (fApp, genModule, mkParam)
 import Language.Drasil.Code.Imperative.Helpers (getUpperBound, liftS, lookupC)
 import Language.Drasil.Code.Imperative.Logging (maybeLog, logBody)
@@ -49,10 +50,12 @@ value u s t = do
   g <- ask
   let cs = codeSpec g
       mm = constMap cs
+      cm = concMatches g
       maybeInline Inline m = Just m
       maybeInline _ _ = Nothing
-  maybe (do { v <- variable s t; return $ valueOf v }) 
-    (convExpr . codeEquat) (Map.lookup u mm >>= maybeInline (conStruct g))
+  maybe (maybe (do { v <- variable s t; return $ valueOf v }) 
+    (convExpr . codeEquat) (Map.lookup u mm >>= maybeInline (conStruct g))) 
+    (return . conceptToGOOL) (Map.lookup u cm)
 
 variable :: (RenderSym repr) => String -> repr (Type repr) -> 
   Reader State (repr (Variable repr))

--- a/code/drasil-code/Language/Drasil/Code/Imperative/Parameters.hs
+++ b/code/drasil-code/Language/Drasil/Code/Imperative/Parameters.hs
@@ -13,7 +13,7 @@ import Language.Drasil.CodeSpec (CodeSpec(..), CodeSystInfo(..), Structure(..),
   constraintvarsandfuncs, getConstraints)
 
 import Data.List (nub, (\\))
-import Data.Map (member)
+import Data.Map (member, notMember)
 import Control.Monad.Reader (Reader, ask)
 import Control.Lens ((^.))
 
@@ -72,7 +72,8 @@ getParams cs' = do
       cnsnts = map codeChunk $ constants $ csi $ codeSpec g
       inpVars = filter (`elem` ins) cs
       conVars = filter (`elem` cnsnts) cs
-      csSubIns = cs \\ (ins ++ cnsnts)
+      csSubIns = filter ((`notMember` concMatches g) . (^. uid)) 
+        (cs \\ (ins ++ cnsnts))
       inVs = getInputVars (inStruct g) Var inpVars
   conVs <- getConstVars (conStruct g) (conRepr g) conVars
   return $ nub $ inVs ++ conVs ++ csSubIns

--- a/code/drasil-code/Language/Drasil/Code/Imperative/State.hs
+++ b/code/drasil-code/Language/Drasil/Code/Imperative/State.hs
@@ -3,8 +3,9 @@ module Language.Drasil.Code.Imperative.State (
 ) where
 
 import Language.Drasil
-import Language.Drasil.CodeSpec (AuxFile, CodeSpec, Comments, ConstantRepr,
-  ConstantStructure, ConstraintBehaviour, InputModule, Logging, Structure)
+import Language.Drasil.CodeSpec (AuxFile, CodeSpec, Comments, ConceptMatchMap, 
+  ConstantRepr, ConstantStructure, ConstraintBehaviour, InputModule, Logging, 
+  Structure)
 
 -- Private State, used to push these options around the generator
 data State = State {
@@ -17,6 +18,7 @@ data State = State {
   logName :: String,
   logKind :: Logging,
   commented :: [Comments],
+  concMatches :: ConceptMatchMap,
   auxiliaries :: [AuxFile],
   sampleData :: [Expr],
   currentModule :: String,

--- a/code/drasil-code/Language/Drasil/Code/Imperative/State.hs
+++ b/code/drasil-code/Language/Drasil/Code/Imperative/State.hs
@@ -3,7 +3,7 @@ module Language.Drasil.Code.Imperative.State (
 ) where
 
 import Language.Drasil
-import Language.Drasil.CodeSpec (AuxFile, CodeSpec, Comments, ConceptMatchMap, 
+import Language.Drasil.CodeSpec (AuxFile, CodeSpec, Comments, MatchedConceptMap,
   ConstantRepr, ConstantStructure, ConstraintBehaviour, InputModule, Logging, 
   Structure)
 
@@ -18,7 +18,7 @@ data State = State {
   logName :: String,
   logKind :: Logging,
   commented :: [Comments],
-  concMatches :: ConceptMatchMap,
+  concMatches :: MatchedConceptMap,
   auxiliaries :: [AuxFile],
   sampleData :: [Expr],
   currentModule :: String,

--- a/code/drasil-code/Language/Drasil/CodeSpec.hs
+++ b/code/drasil-code/Language/Drasil/CodeSpec.hs
@@ -89,7 +89,8 @@ codeSpec SI {_sys = sys
               , _sysinfodb = db
               , sampleData = sd} chs ms = 
   let inputs' = map quantvar ins
-      const' = map qtov cnsts
+      const' = map qtov (filter ((`Map.notMember` conceptMatch chs) . (^. uid)) 
+        cnsts)
       derived = getDerivedInputs ddefs defs' inputs' const' db
       rels = map qtoc ((defs' ++ map qdFromDD ddefs) \\ derived)
       mem   = modExportMap csi' chs

--- a/code/drasil-code/Language/Drasil/CodeSpec.hs
+++ b/code/drasil-code/Language/Drasil/CodeSpec.hs
@@ -166,6 +166,7 @@ data InputModule = Combined
                  | Separated
 
 type ConceptMatchMap = Map.Map UID [CodeConcept]
+type MatchedConceptMap = Map.Map UID CodeConcept
 
 data CodeConcept = Pi
 

--- a/code/drasil-code/Language/Drasil/CodeSpec.hs
+++ b/code/drasil-code/Language/Drasil/CodeSpec.hs
@@ -135,6 +135,7 @@ data Choices = Choices {
   constStructure :: ConstantStructure,
   constRepr :: ConstantRepr,
   inputModule :: InputModule,
+  conceptMatch :: ConceptMatchMap,
   auxFiles :: [AuxFile]
 }
 
@@ -163,6 +164,13 @@ data ConstantRepr = Var | Const
 data InputModule = Combined
                  | Separated
 
+type ConceptMatchMap = Map.Map UID [CodeConcept]
+
+data CodeConcept = Pi
+
+matchConcepts :: (HasUID c) => [c] -> [[CodeConcept]] -> ConceptMatchMap
+matchConcepts cncs cdcs = Map.fromList (zip (map (^. uid) cncs) cdcs)
+
 data AuxFile = SampleInput deriving Eq
              
 data Visibility = Show
@@ -182,6 +190,7 @@ defaultChoices = Choices {
   constStructure = Inline,
   constRepr = Const,
   inputModule = Combined,
+  conceptMatch = matchConcepts ([] :: [QDefinition]) [],
   auxFiles = [SampleInput]
 }
 

--- a/code/drasil-code/drasil-code.cabal
+++ b/code/drasil-code/drasil-code.cabal
@@ -17,6 +17,7 @@ library
     , Language.Drasil.Code.DataDesc
     , Language.Drasil.Code.Imperative.Build.AST
     , Language.Drasil.Code.Imperative.Build.Import
+    , Language.Drasil.Code.Imperative.ConceptMatch
     , Language.Drasil.Code.Imperative.Doxygen.Import
     , Language.Drasil.Code.Imperative.ReadInput
     , Language.Drasil.Code.Imperative.WriteInput

--- a/code/drasil-example/Drasil/GamePhysics/Main.hs
+++ b/code/drasil-example/Drasil/GamePhysics/Main.hs
@@ -1,9 +1,10 @@
 module Main where
 
+-- import Language.Drasil (QDefinition)
 -- import Language.Drasil.Code (Choices(..), CodeSpec, codeSpec, Comments(..), 
 --   ConstraintBehaviour(..), ImplementationType(..), Lang(..), Logging(..), 
 --   Structure(..), ConstantStructure(..), ConstantRepr(..), InputModule(..), 
---   AuxFile(..), Visibility(..))
+--   matchConcepts, AuxFile(..), Visibility(..))
 import Language.Drasil.Generate (gen)
 import Language.Drasil.Printers (DocType(SRS, Website), DocSpec(DocSpec))
 
@@ -26,6 +27,7 @@ import Drasil.GamePhysics.Body (srs, printSetting) -- sysInfo
 --   constStructure   = Inline,
 --   constRepr        = Const,
 --   inputModule      = Combined,
+--   conceptMatch     = matchConcepts ([] :: [QDefinition]) [],
 --   auxFiles         = [SampleInput]
 -- }       
        

--- a/code/drasil-example/Drasil/GlassBR/Main.hs
+++ b/code/drasil-example/Drasil/GlassBR/Main.hs
@@ -1,9 +1,10 @@
 module Main (main) where
 
+import Language.Drasil (QDefinition)
 import Language.Drasil.Code (Choices(..), CodeSpec, codeSpec, Comments(..), 
   ConstraintBehaviour(..), ImplementationType(..), Lang(..), Logging(..), 
   Structure(..), ConstantStructure(..), ConstantRepr(..), InputModule(..), 
-  AuxFile(..), Visibility(..))
+  matchConcepts, AuxFile(..), Visibility(..))
 import Language.Drasil.Generate (gen, genCode)
 import Language.Drasil.Printers (DocSpec(DocSpec), DocType(SRS, Website))
 
@@ -27,6 +28,7 @@ choices = Choices {
   constStructure = Inline,
   constRepr = Const,
   inputModule = Separated,
+  conceptMatch = matchConcepts ([] :: [QDefinition]) [],
   auxFiles = [SampleInput] 
 }
   

--- a/code/drasil-example/Drasil/HGHC/Main.hs
+++ b/code/drasil-example/Drasil/HGHC/Main.hs
@@ -1,9 +1,10 @@
 module Main (main) where
 
+-- import Language.Drasil (QDefinition)
 -- import Language.Drasil.Code (Choices(..), CodeSpec, codeSpec, Comments(..), 
 --   ConstraintBehaviour(..), ImplementationType(..), Lang(..), Logging(..), 
 --   Structure(..), ConstantStructure(..), ConstantRepr(..), InputModule(..), 
---   AuxFile(..), Visibility(..))
+--   matchConcepts, AuxFile(..), Visibility(..))
 import Language.Drasil.Generate (gen)
 import Language.Drasil.Printers (DocType(SRS, Website), DocSpec(DocSpec))
 
@@ -27,6 +28,7 @@ thisChoices = Choices {
   constStructure   = Inline,
   constRepr        = Const,
   inputModule      = Combined,
+  conceptMatch     = matchConcepts ([] :: [QDefinition]) [],
   auxFiles         = [SampleInput] 
 } -}
   

--- a/code/drasil-example/Drasil/NoPCM/Main.hs
+++ b/code/drasil-example/Drasil/NoPCM/Main.hs
@@ -1,9 +1,10 @@
 module Main (main) where
 
+import Language.Drasil (QDefinition)
 import Language.Drasil.Code (Choices(..), CodeSpec, codeSpec, Comments(..),
   ConstraintBehaviour(..), ImplementationType(..), Lang(..), Logging(..), 
   Structure(..), ConstantStructure(..), ConstantRepr(..), InputModule(..), 
-  AuxFile(..), Visibility(..))
+  matchConcepts, AuxFile(..), Visibility(..))
 import Language.Drasil.Generate (gen, genCode)
 import Language.Drasil.Printers (DocType(SRS, Website), DocSpec(DocSpec))
 
@@ -27,6 +28,7 @@ choices = Choices {
   constStructure = Store Bundled,
   constRepr = Const,
   inputModule = Combined,
+  conceptMatch = matchConcepts ([] :: [QDefinition]) [],
   auxFiles = [SampleInput]
 }       
        

--- a/code/drasil-example/Drasil/Projectile/Main.hs
+++ b/code/drasil-example/Drasil/Projectile/Main.hs
@@ -3,9 +3,11 @@ module Main (main) where
 import Language.Drasil.Code (Choices(..), CodeSpec, Comments(..), 
   ConstraintBehaviour(..), ImplementationType(..), Lang(..), Logging(..), 
   Structure(..), ConstantStructure(..), ConstantRepr(..), InputModule(..), 
-  AuxFile(..), Visibility(..), codeSpec)
+  CodeConcept(..), matchConcepts, AuxFile(..), Visibility(..), codeSpec)
 import Language.Drasil.Generate (gen, genCode)
 import Language.Drasil.Printers (DocSpec(DocSpec), DocType(SRS, Website))
+
+import Data.Drasil.Quantities.Math (piConst)
 
 import Drasil.Projectile.Body (printSetting, si, srs)
 
@@ -26,6 +28,7 @@ choices = Choices {
   constStructure = Store Unbundled,
   constRepr = Var,
   inputModule = Separated,
+  conceptMatch = matchConcepts [piConst] [[Pi]],
   auxFiles = [SampleInput]
 }
 

--- a/code/drasil-example/Drasil/SSP/Main.hs
+++ b/code/drasil-example/Drasil/SSP/Main.hs
@@ -1,9 +1,10 @@
 module Main (main) where
 
+-- import Language.Drasil (QDefinition)
 -- import Language.Drasil.Code (Choices(..), CodeSpec, codeSpec, Comments(..), 
 --   ConstraintBehaviour(..), ImplementationType(..), Lang(..), Logging(..), 
 --   Structure(..), ConstantStructure(..), ConstantRepr(..), InputModule(..), 
---   AuxFile(..), Visibility(..))
+--   matchConcepts, AuxFile(..), Visibility(..))
 import Language.Drasil.Generate (gen)
 import Language.Drasil.Printers (DocType(SRS, Website), DocSpec(DocSpec))
 
@@ -26,6 +27,7 @@ import Drasil.SSP.Body (srs, printSetting) -- si
 --   constStructure = Inline,   -- Inline, WithInputs, Store Structure
 --   constRepr = Const,    -- Var, Const
 --   inputModule = Combined,    -- Combined, Separated
+--   conceptMatch = matchConcepts ([] :: [QDefinition]) [],
 --   auxFiles = [SampleInput]
 -- }
        

--- a/code/drasil-example/Drasil/SWHS/Generate.hs
+++ b/code/drasil-example/Drasil/SWHS/Generate.hs
@@ -1,9 +1,10 @@
 module Drasil.SWHS.Generate (generate) where
 
+-- import Language.Drasil (QDefinition)
 -- import Language.Drasil.Code (Choices(..), CodeSpec, codeSpec, Comments(..), 
 --   ConstraintBehaviour(..), ImplementationType(..), Lang(..), Logging(..), 
 --   Structure(..), ConstantStructure(..), ConstantRepr(..), InputModule(..), 
---   AuxFile(..), Visibility(..))
+--   matchConcepts, AuxFile(..), Visibility(..))
 import Language.Drasil.Generate (gen)
 import Language.Drasil.Printers (DocType(SRS, Website), DocSpec(DocSpec))
 
@@ -26,6 +27,7 @@ import Drasil.SWHS.Body (srs, printSetting) -- si
 --   constStructure = Inline,   -- Inline, WithInputs, Store Structure
 --   constRepr = Const,      -- Var, Const
 --   inputModule = Combined,    -- Combined, Separated
+--   conceptMatch = matchConcepts ([] :: [QDefinition]) [],
 --   auxFiles = [SampleInput]
 -- }
 

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer/CSharpRenderer.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer/CSharpRenderer.hs
@@ -52,7 +52,7 @@ import GOOL.Drasil.LanguageRenderer (classDocD, multiStateDocD, bodyDocD,
   blockCmtDoc, docCmtDoc, commentedItem, addCommentsDocD, commentedModD,
   appendToBody, surroundBody, filterOutObjs)
 import qualified GOOL.Drasil.LanguageRenderer.LanguagePolymorphic as G (block, 
-  varDec, varDecDef, listDec, listDecDef, objDecNew, objDecNewNoParams, 
+  pi, varDec, varDecDef, listDec, listDecDef, objDecNew, objDecNewNoParams, 
   construct, comment, ifCond, for, forEach, while, method, getMethod, setMethod,
   privMethod, pubMethod, constructor, docMain, function, mainFunction, docFunc, 
   docInOutFunc, intFunc, stateVar, stateVarDef, constVar, privMVar, pubMVar, 
@@ -254,6 +254,8 @@ instance ValueSym CSharpCode where
   litFloat = litFloatD
   litInt = litIntD
   litString = litStringD
+
+  pi = G.pi
 
   ($:) = enumElement
 

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer/CppRenderer.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer/CppRenderer.hs
@@ -66,7 +66,7 @@ import GOOL.Drasil.Helpers (angles, doubleQuotedText, emptyIfEmpty, mapPairFst,
   mapPairSnd, liftA4, liftA5, liftA8, liftList, lift2Lists, lift1List, 
   checkParams)
 
-import Prelude hiding (break,print,(<>),sin,cos,tan,floor,const,log,exp)
+import Prelude hiding (break,print,(<>),sin,cos,tan,floor,pi,const,log,exp)
 import Data.Maybe (maybeToList)
 import Control.Applicative (Applicative, liftA2, liftA3)
 import Text.PrettyPrint.HughesPJ (Doc, text, (<>), (<+>), braces, parens, comma,
@@ -268,6 +268,8 @@ instance (Pair p) => ValueSym (p CppSrcCode CppHdrCode) where
   litFloat v = pair (litFloat v) (litFloat v)
   litInt v = pair (litInt v) (litInt v)
   litString s = pair (litString s) (litString s)
+
+  pi = pair pi pi
 
   ($:) l1 l2 = pair (($:) l1 l2) (($:) l1 l2)
 
@@ -876,6 +878,8 @@ instance ValueSym CppSrcCode where
   litInt = litIntD
   litString = litStringD
 
+  pi = liftA2 mkVal float (return $ text "M_PI")
+
   ($:) = enumElement
 
   valueOf = valueOfD
@@ -1444,6 +1448,8 @@ instance ValueSym CppHdrCode where
   litInt = litIntD
   litString = litStringD
 
+  pi = liftA2 mkVal float (return $ text "M_PI")
+
   ($:) = enumElement
 
   valueOf = valueOfD
@@ -1828,6 +1834,7 @@ cppstop :: ModData -> Doc -> Doc -> Doc
 cppstop (MD n b _) lst end = vcat [
   if b then empty else inc <+> doubleQuotedText (addExt cppHdrExt n),
   if b then empty else blank,
+  text "#define" <+> text "_USE_MATH_DEFINES", --FIXME: Only include if used (i.e. pi)
   inc <+> angles (text "algorithm"),
   inc <+> angles (text "iostream"),
   inc <+> angles (text "fstream"),

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer/JavaRenderer.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer/JavaRenderer.hs
@@ -51,7 +51,7 @@ import GOOL.Drasil.LanguageRenderer (packageDocD, classDocD, multiStateDocD,
   commentedItem, addCommentsDocD, commentedModD, docFuncRepr, valueList, 
   appendToBody, surroundBody, intValue, filterOutObjs)
 import qualified GOOL.Drasil.LanguageRenderer.LanguagePolymorphic as G (block, 
-  varDec, varDecDef, listDec, listDecDef, objDecNew, objDecNewNoParams, 
+  pi, varDec, varDecDef, listDec, listDecDef, objDecNew, objDecNewNoParams, 
   construct, comment, ifCond, for, forEach, while, method, getMethod, setMethod,
   privMethod, pubMethod, constructor, docMain, function, mainFunction, docFunc, 
   intFunc, stateVar, stateVarDef, constVar, privMVar, pubMVar, pubGVar, 
@@ -254,6 +254,8 @@ instance ValueSym JavaCode where
   litFloat = litFloatD
   litInt = litIntD
   litString = litStringD
+
+  pi = G.pi
 
   ($:) = enumElement
 

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer/LanguagePolymorphic.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer/LanguagePolymorphic.hs
@@ -1,8 +1,8 @@
 {-# LANGUAGE PostfixOperators #-}
 
 -- | The structure for a class of renderers is defined here.
-module GOOL.Drasil.LanguageRenderer.LanguagePolymorphic (
-  block, varDec, varDecDef, listDec, listDecDef, objDecNew, objDecNewNoParams, 
+module GOOL.Drasil.LanguageRenderer.LanguagePolymorphic (block, pi, varDec, 
+  varDecDef, listDec, listDecDef, objDecNew, objDecNewNoParams, 
   comment, ifCond, for, forEach, while, construct, method, getMethod, setMethod,
   privMethod, pubMethod, constructor, docMain, function, mainFunction, docFunc, 
   docInOutFunc, intFunc, stateVar,stateVarDef, constVar, privMVar, pubMVar, 
@@ -16,8 +16,9 @@ import GOOL.Drasil.CodeType (CodeType(..), isObject)
 import GOOL.Drasil.Symantics (Label, KeywordSym(..), 
   RenderSym(RenderFile, commentedMod), InternalFile(..), BlockSym(Block), 
   InternalBlock(..), BodySym(..), PermanenceSym(..), InternalPerm(..), 
-  TypeSym(..), InternalType(..), VariableSym(..), ValueSym(..),
-  ValueExpression(..), InternalStatement(..), 
+  TypeSym(..), InternalType(..), VariableSym(..), 
+  ValueSym(Value, valueOf, valueDoc),
+  ValueExpression(..), InternalValue(..), InternalStatement(..), 
   StatementSym(Statement, (&=), constDecDef, returnState), ScopeSym(..), 
   InternalScope(..), MethodTypeSym(mType), ParameterSym(..), 
   MethodTypeSym(MethodType), MethodSym(Method, inOutFunc), 
@@ -37,7 +38,7 @@ import GOOL.Drasil.LanguageRenderer (forLabel, addExt, blockDocD, stateVarDocD,
   fileDoc', docFuncRepr, commentDocD, commentedItem, functionDox, classDox, 
   moduleDox, getterName, setterName)
 
-import Prelude hiding (break,print,last,mod,(<>))
+import Prelude hiding (break,print,last,mod,pi,(<>))
 import Data.Maybe (maybeToList)
 import Text.PrettyPrint.HughesPJ (Doc, text, empty, render, (<>), (<+>), parens,
   vcat, semi, equals)
@@ -46,6 +47,9 @@ block :: (RenderSym repr) => repr (Keyword repr) -> [repr (Statement repr)] ->
   repr (Block repr)
 block end sts = docBlock $ blockDocD (keyDoc end) (map (statementDoc . state) 
   sts)
+
+pi :: (RenderSym repr) => repr (Value repr)
+pi = valFromData Nothing float (text "Math.PI")
 
 varDec :: (RenderSym repr) => repr (Permanence repr) -> repr (Permanence repr) 
   -> repr (Variable repr) -> repr (Statement repr)

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer/PythonRenderer.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer/PythonRenderer.hs
@@ -252,6 +252,8 @@ instance ValueSym PythonCode where
   litInt = litIntD
   litString = litStringD
 
+  pi = liftA2 mkVal float (return $ text "math.pi")
+
   ($:) = enumElement
 
   valueOf = valueOfD

--- a/code/drasil-gool/GOOL/Drasil/Symantics.hs
+++ b/code/drasil-gool/GOOL/Drasil/Symantics.hs
@@ -208,6 +208,8 @@ class (VariableSym repr) => ValueSym repr where
   litInt    :: Integer -> repr (Value repr)
   litString :: String -> repr (Value repr)
 
+  pi :: repr (Value repr)
+
   --other operators ($)
   ($:)  :: Label -> Label -> repr (Value repr)
   infixl 9 $:

--- a/code/stable/glassbr/src/cpp/Calculations.cpp
+++ b/code/stable/glassbr/src/cpp/Calculations.cpp
@@ -1,5 +1,6 @@
 #include "Calculations.hpp"
 
+#define _USE_MATH_DEFINES
 #include <algorithm>
 #include <iostream>
 #include <fstream>

--- a/code/stable/glassbr/src/cpp/Control.cpp
+++ b/code/stable/glassbr/src/cpp/Control.cpp
@@ -2,6 +2,7 @@
     \author Nikitha Krithnan and W. Spencer Smith
     \brief Controls the flow of the program
 */
+#define _USE_MATH_DEFINES
 #include <algorithm>
 #include <iostream>
 #include <fstream>

--- a/code/stable/glassbr/src/cpp/DerivedValues.cpp
+++ b/code/stable/glassbr/src/cpp/DerivedValues.cpp
@@ -1,5 +1,6 @@
 #include "DerivedValues.hpp"
 
+#define _USE_MATH_DEFINES
 #include <algorithm>
 #include <iostream>
 #include <fstream>

--- a/code/stable/glassbr/src/cpp/InputConstraints.cpp
+++ b/code/stable/glassbr/src/cpp/InputConstraints.cpp
@@ -1,5 +1,6 @@
 #include "InputConstraints.hpp"
 
+#define _USE_MATH_DEFINES
 #include <algorithm>
 #include <iostream>
 #include <fstream>

--- a/code/stable/glassbr/src/cpp/InputFormat.cpp
+++ b/code/stable/glassbr/src/cpp/InputFormat.cpp
@@ -1,5 +1,6 @@
 #include "InputFormat.hpp"
 
+#define _USE_MATH_DEFINES
 #include <algorithm>
 #include <iostream>
 #include <fstream>

--- a/code/stable/glassbr/src/cpp/InputParameters.cpp
+++ b/code/stable/glassbr/src/cpp/InputParameters.cpp
@@ -1,5 +1,6 @@
 #include "InputParameters.hpp"
 
+#define _USE_MATH_DEFINES
 #include <algorithm>
 #include <iostream>
 #include <fstream>

--- a/code/stable/glassbr/src/cpp/Interpolation.cpp
+++ b/code/stable/glassbr/src/cpp/Interpolation.cpp
@@ -1,5 +1,6 @@
 #include "Interpolation.hpp"
 
+#define _USE_MATH_DEFINES
 #include <algorithm>
 #include <iostream>
 #include <fstream>

--- a/code/stable/glassbr/src/cpp/OutputFormat.cpp
+++ b/code/stable/glassbr/src/cpp/OutputFormat.cpp
@@ -1,5 +1,6 @@
 #include "OutputFormat.hpp"
 
+#define _USE_MATH_DEFINES
 #include <algorithm>
 #include <iostream>
 #include <fstream>

--- a/code/stable/glassbr/src/cpp/ReadTable.cpp
+++ b/code/stable/glassbr/src/cpp/ReadTable.cpp
@@ -1,5 +1,6 @@
 #include "ReadTable.hpp"
 
+#define _USE_MATH_DEFINES
 #include <algorithm>
 #include <iostream>
 #include <fstream>

--- a/code/stable/nopcm/src/cpp/Constants.cpp
+++ b/code/stable/nopcm/src/cpp/Constants.cpp
@@ -1,5 +1,6 @@
 #include "Constants.hpp"
 
+#define _USE_MATH_DEFINES
 #include <algorithm>
 #include <iostream>
 #include <fstream>

--- a/code/stable/nopcm/src/cpp/Control.cpp
+++ b/code/stable/nopcm/src/cpp/Control.cpp
@@ -2,6 +2,7 @@
     \author Thulasi Jegatheesan
     \brief Controls the flow of the program
 */
+#define _USE_MATH_DEFINES
 #include <algorithm>
 #include <iostream>
 #include <fstream>

--- a/code/stable/nopcm/src/cpp/InputParameters.cpp
+++ b/code/stable/nopcm/src/cpp/InputParameters.cpp
@@ -1,5 +1,6 @@
 #include "InputParameters.hpp"
 
+#define _USE_MATH_DEFINES
 #include <algorithm>
 #include <iostream>
 #include <fstream>

--- a/code/stable/nopcm/src/cpp/OutputFormat.cpp
+++ b/code/stable/nopcm/src/cpp/OutputFormat.cpp
@@ -1,5 +1,6 @@
 #include "OutputFormat.hpp"
 
+#define _USE_MATH_DEFINES
 #include <algorithm>
 #include <iostream>
 #include <fstream>

--- a/code/stable/projectile/src/cpp/Calculations.cpp
+++ b/code/stable/projectile/src/cpp/Calculations.cpp
@@ -1,5 +1,6 @@
 #include "Calculations.hpp"
 
+#define _USE_MATH_DEFINES
 #include <algorithm>
 #include <iostream>
 #include <fstream>

--- a/code/stable/projectile/src/cpp/Control.cpp
+++ b/code/stable/projectile/src/cpp/Control.cpp
@@ -2,6 +2,7 @@
     \author Samuel J. Crawford, Brooks MacLachlan, and W. Spencer Smith
     \brief Controls the flow of the program
 */
+#define _USE_MATH_DEFINES
 #include <algorithm>
 #include <iostream>
 #include <fstream>
@@ -32,10 +33,9 @@ int main(int argc, const char *argv[]) {
     string filename = argv[1];
     InputParameters inParams = InputParameters();
     double g_vect = 9.8;
-    double pi = 3.14159265;
     double epsilon = 2.0e-2;
     get_input(inParams, filename);
-    input_constraints(inParams, pi);
+    input_constraints(inParams);
     double t_flight = func_t_flight(inParams, g_vect);
     double p_land = func_p_land(inParams, g_vect);
     double d_offset = func_d_offset(inParams, p_land);

--- a/code/stable/projectile/src/cpp/InputConstraints.cpp
+++ b/code/stable/projectile/src/cpp/InputConstraints.cpp
@@ -1,5 +1,6 @@
 #include "InputConstraints.hpp"
 
+#define _USE_MATH_DEFINES
 #include <algorithm>
 #include <iostream>
 #include <fstream>
@@ -17,7 +18,7 @@ using std::ofstream;
 
 #include "InputParameters.hpp"
 
-void input_constraints(InputParameters &inParams, double pi) {
+void input_constraints(InputParameters &inParams) {
     if (!(inParams.v_launch > 0)) {
         std::cout << "Warning: ";
         std::cout << "v_launch has value ";
@@ -27,7 +28,7 @@ void input_constraints(InputParameters &inParams, double pi) {
         std::cout << 0;
         std::cout << "." << std::endl;
     }
-    if (!(0 < inParams.theta && inParams.theta < pi / 2)) {
+    if (!(0 < inParams.theta && inParams.theta < M_PI / 2)) {
         std::cout << "Warning: ";
         std::cout << "theta has value ";
         std::cout << inParams.theta;
@@ -35,7 +36,7 @@ void input_constraints(InputParameters &inParams, double pi) {
         std::cout << "between ";
         std::cout << 0;
         std::cout << " and ";
-        std::cout << (pi / 2);
+        std::cout << (M_PI / 2);
         std::cout << " ((pi)/(2))";
         std::cout << "." << std::endl;
     }

--- a/code/stable/projectile/src/cpp/InputConstraints.hpp
+++ b/code/stable/projectile/src/cpp/InputConstraints.hpp
@@ -17,8 +17,7 @@ using std::ofstream;
 
 /** \brief Verifies that input values satisfy the physical constraints and software constraints
     \param inParams structure holding the input values
-    \param pi ratio of circumference to diameter for any circle: The ratio of a circle's circumference to its diameter
 */
-void input_constraints(InputParameters &inParams, double pi);
+void input_constraints(InputParameters &inParams);
 
 #endif

--- a/code/stable/projectile/src/cpp/InputFormat.cpp
+++ b/code/stable/projectile/src/cpp/InputFormat.cpp
@@ -1,5 +1,6 @@
 #include "InputFormat.hpp"
 
+#define _USE_MATH_DEFINES
 #include <algorithm>
 #include <iostream>
 #include <fstream>

--- a/code/stable/projectile/src/cpp/InputParameters.cpp
+++ b/code/stable/projectile/src/cpp/InputParameters.cpp
@@ -1,5 +1,6 @@
 #include "InputParameters.hpp"
 
+#define _USE_MATH_DEFINES
 #include <algorithm>
 #include <iostream>
 #include <fstream>

--- a/code/stable/projectile/src/cpp/OutputFormat.cpp
+++ b/code/stable/projectile/src/cpp/OutputFormat.cpp
@@ -1,5 +1,6 @@
 #include "OutputFormat.hpp"
 
+#define _USE_MATH_DEFINES
 #include <algorithm>
 #include <iostream>
 #include <fstream>

--- a/code/stable/projectile/src/csharp/Control.cs
+++ b/code/stable/projectile/src/csharp/Control.cs
@@ -16,10 +16,9 @@ public class Control {
         string filename = args[0];
         InputParameters inParams = new InputParameters();
         double g_vect = 9.8;
-        double pi = 3.14159265;
         double epsilon = 2.0e-2;
         InputFormat.get_input(inParams, filename);
-        InputConstraints.input_constraints(inParams, pi);
+        InputConstraints.input_constraints(inParams);
         double t_flight = Calculations.func_t_flight(inParams, g_vect);
         double p_land = Calculations.func_p_land(inParams, g_vect);
         double d_offset = Calculations.func_d_offset(inParams, p_land);

--- a/code/stable/projectile/src/csharp/InputConstraints.cs
+++ b/code/stable/projectile/src/csharp/InputConstraints.cs
@@ -11,9 +11,8 @@ public class InputConstraints {
     
     /** \brief Verifies that input values satisfy the physical constraints and software constraints
         \param inParams structure holding the input values
-        \param pi ratio of circumference to diameter for any circle: The ratio of a circle's circumference to its diameter
     */
-    public static void input_constraints(InputParameters inParams, double pi) {
+    public static void input_constraints(InputParameters inParams) {
         if (!(inParams.v_launch > 0)) {
             Console.Write("Warning: ");
             Console.Write("v_launch has value ");
@@ -23,7 +22,7 @@ public class InputConstraints {
             Console.Write(0);
             Console.WriteLine(".");
         }
-        if (!(0 < inParams.theta && inParams.theta < pi / 2)) {
+        if (!(0 < inParams.theta && inParams.theta < Math.PI / 2)) {
             Console.Write("Warning: ");
             Console.Write("theta has value ");
             Console.Write(inParams.theta);
@@ -31,7 +30,7 @@ public class InputConstraints {
             Console.Write("between ");
             Console.Write(0);
             Console.Write(" and ");
-            Console.Write(pi / 2);
+            Console.Write(Math.PI / 2);
             Console.Write(" ((pi)/(2))");
             Console.WriteLine(".");
         }

--- a/code/stable/projectile/src/java/Projectile/Control.java
+++ b/code/stable/projectile/src/java/Projectile/Control.java
@@ -21,10 +21,9 @@ public class Control {
         String filename = args[0];
         InputParameters inParams = new InputParameters();
         double g_vect = 9.8;
-        double pi = 3.14159265;
         double epsilon = 2.0e-2;
         InputFormat.get_input(inParams, filename);
-        InputConstraints.input_constraints(inParams, pi);
+        InputConstraints.input_constraints(inParams);
         double t_flight = Calculations.func_t_flight(inParams, g_vect);
         double p_land = Calculations.func_p_land(inParams, g_vect);
         double d_offset = Calculations.func_d_offset(inParams, p_land);

--- a/code/stable/projectile/src/java/Projectile/InputConstraints.java
+++ b/code/stable/projectile/src/java/Projectile/InputConstraints.java
@@ -16,9 +16,8 @@ public class InputConstraints {
     
     /** \brief Verifies that input values satisfy the physical constraints and software constraints
         \param inParams structure holding the input values
-        \param pi ratio of circumference to diameter for any circle: The ratio of a circle's circumference to its diameter
     */
-    public static void input_constraints(InputParameters inParams, double pi) throws Exception {
+    public static void input_constraints(InputParameters inParams) throws Exception {
         if (!(inParams.v_launch > 0)) {
             System.out.print("Warning: ");
             System.out.print("v_launch has value ");
@@ -28,7 +27,7 @@ public class InputConstraints {
             System.out.print(0);
             System.out.println(".");
         }
-        if (!(0 < inParams.theta && inParams.theta < pi / 2)) {
+        if (!(0 < inParams.theta && inParams.theta < Math.PI / 2)) {
             System.out.print("Warning: ");
             System.out.print("theta has value ");
             System.out.print(inParams.theta);
@@ -36,7 +35,7 @@ public class InputConstraints {
             System.out.print("between ");
             System.out.print(0);
             System.out.print(" and ");
-            System.out.print(pi / 2);
+            System.out.print(Math.PI / 2);
             System.out.print(" ((pi)/(2))");
             System.out.println(".");
         }

--- a/code/stable/projectile/src/python/Control.py
+++ b/code/stable/projectile/src/python/Control.py
@@ -14,10 +14,9 @@ import Calculations
 filename = sys.argv[1]
 inParams = InputParameters.InputParameters()
 g_vect = 9.8
-pi = 3.14159265
 epsilon = 2.0e-2
 InputFormat.get_input(inParams, filename)
-InputConstraints.input_constraints(inParams, pi)
+InputConstraints.input_constraints(inParams)
 t_flight = Calculations.func_t_flight(inParams, g_vect)
 p_land = Calculations.func_p_land(inParams, g_vect)
 d_offset = Calculations.func_d_offset(inParams, p_land)

--- a/code/stable/projectile/src/python/InputConstraints.py
+++ b/code/stable/projectile/src/python/InputConstraints.py
@@ -9,8 +9,7 @@ import InputParameters
 
 ## \brief Verifies that input values satisfy the physical constraints and software constraints
 # \param inParams structure holding the input values
-# \param pi ratio of circumference to diameter for any circle: The ratio of a circle's circumference to its diameter
-def input_constraints(inParams, pi):
+def input_constraints(inParams):
     if (not(inParams.v_launch > 0)) :
         print("Warning: ", end='')
         print("v_launch has value ", end='')
@@ -19,7 +18,7 @@ def input_constraints(inParams, pi):
         print("above ", end='')
         print(0, end='')
         print(".")
-    if (not(0 < inParams.theta and inParams.theta < pi / 2)) :
+    if (not(0 < inParams.theta and inParams.theta < math.pi / 2)) :
         print("Warning: ", end='')
         print("theta has value ", end='')
         print(inParams.theta, end='')
@@ -27,7 +26,7 @@ def input_constraints(inParams, pi):
         print("between ", end='')
         print(0, end='')
         print(" and ", end='')
-        print(pi / 2, end='')
+        print(math.pi / 2, end='')
         print(" ((pi)/(2))", end='')
         print(".")
     if (not(inParams.p_target > 0)) :


### PR DESCRIPTION
This PR introduces maps to the examples for mapping a concept to a GOOL function, currently only for `pi`, so that we can use a target language's pi variable instead of defining our own. This closes #1862. 

I made it generate the line `#define _USE_MATH_DEFINES` in all C++ source files which allows us to use C++'s pi constant. Ideally we would only generate that line when pi or another constant is actually used, but that will be easier to do after we do something similar for import statements with the `State` monad (#1880), so I'm holding off on that for now.