### PR TITLE
Choice for Doxygen output verbosity

### DIFF
--- a/code/drasil-code/Language/Drasil/Code.hs
+++ b/code/drasil-code/Language/Drasil/Code.hs
@@ -4,10 +4,10 @@ module Language.Drasil.Code (
   generator, generateCode,
   readWithDataDesc, sampleInputDD,
   ($:=), Choices(..), CodeSpec(..), CodeSystInfo(..), Comments(..), 
-  ConstraintBehaviour(..), Func, FuncStmt(..), ImplementationType(..), Lang(..),
-  Logging(LogNone, LogAll), Mod(Mod), Structure(..), ConstantStructure(..), 
-  ConstantRepr(..), InputModule(..), CodeConcept(..), matchConcepts, 
-  AuxFile(..), Visibility(..),
+  Verbosity(..), ConstraintBehaviour(..), Func, FuncStmt(..), 
+  ImplementationType(..), Lang(..), Logging(LogNone, LogAll), Mod(Mod), 
+  Structure(..), ConstantStructure(..), ConstantRepr(..), InputModule(..), 
+  CodeConcept(..), matchConcepts, AuxFile(..), Visibility(..),
   asExpr, asExpr', asVC, asVC', codeSpec, fdec, ffor, funcData, funcDef, 
   packmod, relToQD,
   junkLine, multiLine, repeated, singleLine, singleton,
@@ -29,11 +29,11 @@ import Language.Drasil.Code.DataDesc (junkLine, multiLine, repeated, singleLine,
   singleton)
 
 import Language.Drasil.CodeSpec (($:=), Choices(..), CodeSpec(..), 
-  CodeSystInfo(..), Comments(..), ConstraintBehaviour(..), Func, FuncStmt(..),
-  ImplementationType(..), Lang(..), Logging(..), Mod(Mod), Structure(..), 
-  ConstantStructure(..), ConstantRepr(..), InputModule(..), CodeConcept(..), 
-  matchConcepts, AuxFile(..), Visibility(..), asExpr, asExpr', asVC, asVC', 
-  codeSpec, fdec, ffor, funcData, funcDef, packmod, relToQD)
+  CodeSystInfo(..), Comments(..), Verbosity(..), ConstraintBehaviour(..), Func, 
+  FuncStmt(..), ImplementationType(..), Lang(..), Logging(..), Mod(Mod), 
+  Structure(..), ConstantStructure(..), ConstantRepr(..), InputModule(..), 
+  CodeConcept(..), matchConcepts, AuxFile(..), Visibility(..), asExpr, asExpr', 
+  asVC, asVC', codeSpec, fdec, ffor, funcData, funcDef, packmod, relToQD)
 
 import Language.Drasil.Code.Imperative.GOOL.Symantics (PackageSym(..))
 

--- a/code/drasil-code/Language/Drasil/Code/Imperative/Doxygen/Import.hs
+++ b/code/drasil-code/Language/Drasil/Code/Imperative/Doxygen/Import.hs
@@ -1,10 +1,12 @@
 module Language.Drasil.Code.Imperative.Doxygen.Import (
-  makeDoxConfig
+  makeDoxConfig, yes, no
 ) where
 
 import Utils.Drasil (blank)
 
 import GOOL.Drasil (ProgData(..), FileData(..), ModData(..), isHeader)
+
+import Language.Drasil.CodeSpec (Verbosity(..))
 
 import Data.List (intersperse)
 import Text.PrettyPrint.HughesPJ (Doc, (<+>), isEmpty, text, hcat, vcat)
@@ -12,8 +14,16 @@ import Text.PrettyPrint.HughesPJ (Doc, (<+>), isEmpty, text, hcat, vcat)
 type OptimizeChoice = Doc
 type ProjName = String
 
-makeDoxConfig :: ProjName -> ProgData -> OptimizeChoice -> Doc
-makeDoxConfig prog p opt = 
+yes, no :: Doc
+yes = text "YES"
+no = text "NO"
+
+verbosityToDoc :: Verbosity -> Doc
+verbosityToDoc Verbose = no
+verbosityToDoc Quiet = yes
+
+makeDoxConfig :: ProjName -> ProgData -> OptimizeChoice -> Verbosity -> Doc
+makeDoxConfig prog p opt v = 
   let fs = map filePath (filter (\f -> not (isEmpty $ modDoc $ fileMod f) && 
              (isMainMod (fileMod f) || isHeader f)) (progMods p))
   in vcat [
@@ -765,7 +775,7 @@ makeDoxConfig prog p opt =
   text "# messages are off.",
   text "# The default value is: NO.",
   blank,
-  text "QUIET                  = YES",
+  text "QUIET                  =" <+> verbosityToDoc v,
   blank,
   text "# The WARNINGS tag can be used to turn on/off the warning messages that are",
   text "# generated to standard error (stderr) by doxygen. If WARNINGS is set to YES",

--- a/code/drasil-code/Language/Drasil/Code/Imperative/GOOL/LanguageRenderer/CSharpRenderer.hs
+++ b/code/drasil-code/Language/Drasil/Code/Imperative/GOOL/LanguageRenderer/CSharpRenderer.hs
@@ -15,12 +15,13 @@ import Language.Drasil.Code.Imperative.GOOL.Data (AuxData(..), ad, PackData(..),
   packD)
 import Language.Drasil.Code.Imperative.Build.AST (BuildConfig, Runnable, 
   asFragment, buildAll, nativeBinary, osClassDefault)
+import Language.Drasil.Code.Imperative.Doxygen.Import (no)
 
 import GOOL.Drasil (liftList)
 
 import Prelude hiding (break,print,(<>),sin,cos,tan,floor)
 import qualified Prelude as P ((<>))
-import Text.PrettyPrint.HughesPJ (Doc, text)
+import Text.PrettyPrint.HughesPJ (Doc)
 
 newtype CSharpProject a = CSP {unCSP :: a}
 
@@ -45,7 +46,7 @@ instance AuxiliarySym CSharpProject where
   doxConfig = G.doxConfig optimizeDox
   sampleInput = G.sampleInput
 
-  optimizeDox = return $ text "NO"
+  optimizeDox = return no
 
   makefile = G.makefile csBuildConfig csRunnable
 

--- a/code/drasil-code/Language/Drasil/Code/Imperative/GOOL/LanguageRenderer/CppRenderer.hs
+++ b/code/drasil-code/Language/Drasil/Code/Imperative/GOOL/LanguageRenderer/CppRenderer.hs
@@ -16,11 +16,12 @@ import Language.Drasil.Code.Imperative.GOOL.Data (AuxData(..), ad,
   PackData(..), packD)
 import Language.Drasil.Code.Imperative.Build.AST (BuildConfig, Runnable, 
   asFragment, buildAll, cppCompiler, nativeBinary)
+import Language.Drasil.Code.Imperative.Doxygen.Import (no)
 
 import GOOL.Drasil (liftList)
 
 import Prelude hiding (break,print,(<>),sin,cos,tan,floor,const,log,exp)
-import Text.PrettyPrint.HughesPJ (Doc, text)
+import Text.PrettyPrint.HughesPJ (Doc)
 
 newtype CppProject a = CPPP {unCPPP :: a}
 
@@ -45,7 +46,7 @@ instance AuxiliarySym CppProject where
   doxConfig = G.doxConfig optimizeDox
   sampleInput = G.sampleInput
 
-  optimizeDox = return $ text "NO"
+  optimizeDox = return no
   
   makefile = G.makefile cppBuildConfig cppRunnable
   

--- a/code/drasil-code/Language/Drasil/Code/Imperative/GOOL/LanguageRenderer/JavaRenderer.hs
+++ b/code/drasil-code/Language/Drasil/Code/Imperative/GOOL/LanguageRenderer/JavaRenderer.hs
@@ -16,11 +16,12 @@ import Language.Drasil.Code.Imperative.GOOL.Data (AuxData(..), ad, PackData(..),
 import Language.Drasil.Code.Imperative.Build.AST (BuildConfig, Runnable, 
   NameOpts(NameOpts), asFragment, buildSingle, includeExt, inCodePackage, 
   interp, mainModule, mainModuleFile, packSep, withExt)
+import Language.Drasil.Code.Imperative.Doxygen.Import (yes)
 
 import GOOL.Drasil (liftList)
 
 import Prelude hiding (break,print,sin,cos,tan,floor,(<>))
-import Text.PrettyPrint.HughesPJ (Doc, text)
+import Text.PrettyPrint.HughesPJ (Doc)
 
 jNameOpts :: NameOpts
 jNameOpts = NameOpts {
@@ -51,7 +52,7 @@ instance AuxiliarySym JavaProject where
   doxConfig = G.doxConfig optimizeDox
   sampleInput = G.sampleInput
 
-  optimizeDox = return $ text "YES"
+  optimizeDox = return yes
 
   makefile = G.makefile jBuildConfig jRunnable
 

--- a/code/drasil-code/Language/Drasil/Code/Imperative/GOOL/LanguageRenderer/LanguagePolymorphic.hs
+++ b/code/drasil-code/Language/Drasil/Code/Imperative/GOOL/LanguageRenderer/LanguagePolymorphic.hs
@@ -9,7 +9,7 @@ import Database.Drasil (ChunkDB)
 
 import GOOL.Drasil (ProgData)
 
-import Language.Drasil.CodeSpec (Comments)
+import Language.Drasil.CodeSpec (Comments, Verbosity)
 import Language.Drasil.Code.DataDesc (DataDesc)
 import Language.Drasil.Code.Imperative.Doxygen.Import (makeDoxConfig)
 import Language.Drasil.Code.Imperative.Build.AST (BuildConfig, Runnable)
@@ -21,9 +21,9 @@ import Language.Drasil.Code.Imperative.GOOL.Symantics (
   AuxiliarySym(Auxiliary, AuxHelper, auxHelperDoc, auxFromData))
 
 doxConfig :: (AuxiliarySym repr) => repr (AuxHelper repr) -> String -> ProgData 
-  -> repr (Auxiliary repr)
-doxConfig opt pName p = auxFromData doxConfigName (makeDoxConfig pName p 
-  (auxHelperDoc opt))
+  -> Verbosity -> repr (Auxiliary repr)
+doxConfig opt pName p v = auxFromData doxConfigName (makeDoxConfig pName p 
+  (auxHelperDoc opt) v)
 
 sampleInput :: (AuxiliarySym repr) => ChunkDB -> DataDesc -> [Expr] -> 
   repr (Auxiliary repr)

--- a/code/drasil-code/Language/Drasil/Code/Imperative/GOOL/LanguageRenderer/PythonRenderer.hs
+++ b/code/drasil-code/Language/Drasil/Code/Imperative/GOOL/LanguageRenderer/PythonRenderer.hs
@@ -13,11 +13,12 @@ import qualified
 import Language.Drasil.Code.Imperative.GOOL.Data (AuxData(..), ad, PackData(..),
   packD)
 import Language.Drasil.Code.Imperative.Build.AST (Runnable, interpMM)
+import Language.Drasil.Code.Imperative.Doxygen.Import (yes)
 
 import GOOL.Drasil (liftList)
 
 import Prelude hiding (break,print,sin,cos,tan,floor,(<>))
-import Text.PrettyPrint.HughesPJ (Doc, text)
+import Text.PrettyPrint.HughesPJ (Doc)
 
 newtype PythonProject a = PP {unPP :: a}
 
@@ -42,7 +43,7 @@ instance AuxiliarySym PythonProject where
   doxConfig = G.doxConfig optimizeDox
   sampleInput = G.sampleInput
 
-  optimizeDox = return $ text "YES"
+  optimizeDox = return yes
 
   makefile = G.makefile Nothing pyRunnable
 

--- a/code/drasil-code/Language/Drasil/Code/Imperative/GOOL/Symantics.hs
+++ b/code/drasil-code/Language/Drasil/Code/Imperative/GOOL/Symantics.hs
@@ -8,7 +8,7 @@ module Language.Drasil.Code.Imperative.GOOL.Symantics (
 import Language.Drasil (Expr)
 import Database.Drasil (ChunkDB)
 import Language.Drasil.Code.DataDesc (DataDesc)
-import Language.Drasil.CodeSpec (Comments)
+import Language.Drasil.CodeSpec (Comments, Verbosity)
 
 import GOOL.Drasil (ProgData)
 
@@ -21,7 +21,7 @@ class (AuxiliarySym repr) => PackageSym repr where
 class AuxiliarySym repr where
   type Auxiliary repr
   type AuxHelper repr
-  doxConfig :: String -> ProgData -> repr (Auxiliary repr)
+  doxConfig :: String -> ProgData -> Verbosity -> repr (Auxiliary repr)
   sampleInput :: ChunkDB -> DataDesc -> [Expr] -> repr (Auxiliary repr)
 
   optimizeDox :: repr (AuxHelper repr)

--- a/code/drasil-code/Language/Drasil/Code/Imperative/GenerateGOOL.hs
+++ b/code/drasil-code/Language/Drasil/Code/Imperative/GenerateGOOL.hs
@@ -41,7 +41,8 @@ genDoxConfig :: (AuxiliarySym repr) => String -> ProgData ->
 genDoxConfig n p = do
   g <- ask
   let cms = commented g
-  return [doxConfig n p | not (null cms)]
+      v = doxOutput g
+  return [doxConfig n p v | not (null cms)]
 
 publicClass :: (RenderSym repr) => String -> Label -> Maybe Label -> 
   [repr (StateVar repr)] -> [repr (Method repr)] -> 

--- a/code/drasil-code/Language/Drasil/Code/Imperative/Generator.hs
+++ b/code/drasil-code/Language/Drasil/Code/Imperative/Generator.hs
@@ -33,6 +33,7 @@ generator dt sd chs spec = State {
   inMod = inputModule chs,
   logKind  = logging chs,
   commented = comments chs,
+  doxOutput = doxVerbosity chs,
   concMatches = chooseConcept chs,
   auxiliaries = auxFiles chs,
   sampleData = sd,

--- a/code/drasil-code/Language/Drasil/Code/Imperative/State.hs
+++ b/code/drasil-code/Language/Drasil/Code/Imperative/State.hs
@@ -3,9 +3,9 @@ module Language.Drasil.Code.Imperative.State (
 ) where
 
 import Language.Drasil
-import Language.Drasil.CodeSpec (AuxFile, CodeSpec, Comments, MatchedConceptMap,
-  ConstantRepr, ConstantStructure, ConstraintBehaviour, InputModule, Logging, 
-  Structure)
+import Language.Drasil.CodeSpec (AuxFile, CodeSpec, Comments, Verbosity, 
+  MatchedConceptMap, ConstantRepr, ConstantStructure, ConstraintBehaviour, 
+  InputModule, Logging, Structure)
 
 -- Private State, used to push these options around the generator
 data State = State {
@@ -18,6 +18,7 @@ data State = State {
   logName :: String,
   logKind :: Logging,
   commented :: [Comments],
+  doxOutput :: Verbosity,
   concMatches :: MatchedConceptMap,
   auxiliaries :: [AuxFile],
   sampleData :: [Expr],

--- a/code/drasil-code/Language/Drasil/CodeSpec.hs
+++ b/code/drasil-code/Language/Drasil/CodeSpec.hs
@@ -129,6 +129,7 @@ data Choices = Choices {
   logFile :: String,
   logging :: Logging,
   comments :: [Comments],
+  doxVerbosity :: Verbosity,
   dates :: Visibility,
   onSfwrConstraint :: ConstraintBehaviour,
   onPhysConstraint :: ConstraintBehaviour,
@@ -151,6 +152,8 @@ data Logging = LogNone
 data Comments = CommentFunc
               | CommentClass
               | CommentMod deriving Eq
+
+data Verbosity = Verbose | Quiet
              
 data ConstraintBehaviour = Warning
                          | Exception
@@ -185,6 +188,7 @@ defaultChoices = Choices {
   logFile = "log.txt",
   logging = LogNone,
   comments = [],
+  doxVerbosity = Verbose,
   dates = Hide,
   onSfwrConstraint = Exception,
   onPhysConstraint = Warning,

--- a/code/drasil-example/Drasil/GamePhysics/Main.hs
+++ b/code/drasil-example/Drasil/GamePhysics/Main.hs
@@ -2,9 +2,9 @@ module Main where
 
 -- import Language.Drasil (QDefinition)
 -- import Language.Drasil.Code (Choices(..), CodeSpec, codeSpec, Comments(..), 
---   ConstraintBehaviour(..), ImplementationType(..), Lang(..), Logging(..), 
---   Structure(..), ConstantStructure(..), ConstantRepr(..), InputModule(..), 
---   matchConcepts, AuxFile(..), Visibility(..))
+--   Verbosity(..), ConstraintBehaviour(..), ImplementationType(..), Lang(..), 
+--   Logging(..), Structure(..), ConstantStructure(..), ConstantRepr(..), 
+--   InputModule(..), matchConcepts, AuxFile(..), Visibility(..))
 import Language.Drasil.Generate (gen)
 import Language.Drasil.Printers (DocType(SRS, Website), DocSpec(DocSpec))
 
@@ -20,6 +20,7 @@ import Drasil.GamePhysics.Body (srs, printSetting) -- sysInfo
 --   logFile          = "log.txt",
 --   logging          = LogNone,
 --   comments         = CommentNone,
+--   doxVerbosity     = Quiet,
 --   dates            = Hide,
 --   onSfwrConstraint = Warning,
 --   onPhysConstraint = Warning,

--- a/code/drasil-example/Drasil/GlassBR/Main.hs
+++ b/code/drasil-example/Drasil/GlassBR/Main.hs
@@ -2,9 +2,9 @@ module Main (main) where
 
 import Language.Drasil (QDefinition)
 import Language.Drasil.Code (Choices(..), CodeSpec, codeSpec, Comments(..), 
-  ConstraintBehaviour(..), ImplementationType(..), Lang(..), Logging(..), 
-  Structure(..), ConstantStructure(..), ConstantRepr(..), InputModule(..), 
-  matchConcepts, AuxFile(..), Visibility(..))
+  Verbosity(..), ConstraintBehaviour(..), ImplementationType(..), Lang(..), 
+  Logging(..), Structure(..), ConstantStructure(..), ConstantRepr(..), 
+  InputModule(..), matchConcepts, AuxFile(..), Visibility(..))
 import Language.Drasil.Generate (gen, genCode)
 import Language.Drasil.Printers (DocSpec(DocSpec), DocType(SRS, Website))
 
@@ -21,6 +21,7 @@ choices = Choices {
   logFile = "log.txt",
   logging = LogAll,
   comments = [CommentFunc, CommentClass, CommentMod],
+  doxVerbosity = Quiet,
   dates = Hide,
   onSfwrConstraint = Exception,
   onPhysConstraint = Exception,

--- a/code/drasil-example/Drasil/HGHC/Main.hs
+++ b/code/drasil-example/Drasil/HGHC/Main.hs
@@ -2,9 +2,9 @@ module Main (main) where
 
 -- import Language.Drasil (QDefinition)
 -- import Language.Drasil.Code (Choices(..), CodeSpec, codeSpec, Comments(..), 
---   ConstraintBehaviour(..), ImplementationType(..), Lang(..), Logging(..), 
---   Structure(..), ConstantStructure(..), ConstantRepr(..), InputModule(..), 
---   matchConcepts, AuxFile(..), Visibility(..))
+--   Verbosity(..), ConstraintBehaviour(..), ImplementationType(..), Lang(..), 
+--   Logging(..), Structure(..), ConstantStructure(..), ConstantRepr(..), 
+--   InputModule(..), matchConcepts, AuxFile(..), Visibility(..))
 import Language.Drasil.Generate (gen)
 import Language.Drasil.Printers (DocType(SRS, Website), DocSpec(DocSpec))
 
@@ -21,6 +21,7 @@ thisChoices = Choices {
   logFile          = "log.txt",
   logging          = LogNone,
   comments         = [], 
+  doxVerbosity     = Quiet,
   dates            = Hide,
   onSfwrConstraint = Warning,
   onPhysConstraint = Warning,

--- a/code/drasil-example/Drasil/NoPCM/Main.hs
+++ b/code/drasil-example/Drasil/NoPCM/Main.hs
@@ -2,9 +2,9 @@ module Main (main) where
 
 import Language.Drasil (QDefinition)
 import Language.Drasil.Code (Choices(..), CodeSpec, codeSpec, Comments(..),
-  ConstraintBehaviour(..), ImplementationType(..), Lang(..), Logging(..), 
-  Structure(..), ConstantStructure(..), ConstantRepr(..), InputModule(..), 
-  matchConcepts, AuxFile(..), Visibility(..))
+  Verbosity(..), ConstraintBehaviour(..), ImplementationType(..), Lang(..), 
+  Logging(..), Structure(..), ConstantStructure(..), ConstantRepr(..), 
+  InputModule(..), matchConcepts, AuxFile(..), Visibility(..))
 import Language.Drasil.Generate (gen, genCode)
 import Language.Drasil.Printers (DocType(SRS, Website), DocSpec(DocSpec))
 
@@ -21,6 +21,7 @@ choices = Choices {
   logFile = "log.txt",
   logging = LogNone,
   comments = [CommentFunc, CommentClass, CommentMod],
+  doxVerbosity = Quiet,
   dates = Hide,
   onSfwrConstraint = Warning,
   onPhysConstraint = Warning,

--- a/code/drasil-example/Drasil/Projectile/Main.hs
+++ b/code/drasil-example/Drasil/Projectile/Main.hs
@@ -1,9 +1,10 @@
 module Main (main) where
 
 import Language.Drasil.Code (Choices(..), CodeSpec, Comments(..), 
-  ConstraintBehaviour(..), ImplementationType(..), Lang(..), Logging(..), 
-  Structure(..), ConstantStructure(..), ConstantRepr(..), InputModule(..), 
-  CodeConcept(..), matchConcepts, AuxFile(..), Visibility(..), codeSpec)
+  Verbosity(..), ConstraintBehaviour(..), ImplementationType(..), Lang(..), 
+  Logging(..), Structure(..), ConstantStructure(..), ConstantRepr(..), 
+  InputModule(..), CodeConcept(..), matchConcepts, AuxFile(..), Visibility(..), 
+  codeSpec)
 import Language.Drasil.Generate (gen, genCode)
 import Language.Drasil.Printers (DocSpec(DocSpec), DocType(SRS, Website))
 
@@ -21,6 +22,7 @@ choices = Choices {
   logFile = "log.txt",
   logging = LogNone,
   comments = [CommentFunc, CommentClass, CommentMod],
+  doxVerbosity = Quiet,
   dates = Hide,
   onSfwrConstraint = Warning,
   onPhysConstraint = Warning,

--- a/code/drasil-example/Drasil/SSP/Main.hs
+++ b/code/drasil-example/Drasil/SSP/Main.hs
@@ -2,9 +2,9 @@ module Main (main) where
 
 -- import Language.Drasil (QDefinition)
 -- import Language.Drasil.Code (Choices(..), CodeSpec, codeSpec, Comments(..), 
---   ConstraintBehaviour(..), ImplementationType(..), Lang(..), Logging(..), 
---   Structure(..), ConstantStructure(..), ConstantRepr(..), InputModule(..), 
---   matchConcepts, AuxFile(..), Visibility(..))
+--   Verbosity(..), ConstraintBehaviour(..), ImplementationType(..), Lang(..), 
+--   Logging(..), Structure(..), ConstantStructure(..), ConstantRepr(..), 
+--   InputModule(..), matchConcepts, AuxFile(..), Visibility(..))
 import Language.Drasil.Generate (gen)
 import Language.Drasil.Printers (DocType(SRS, Website), DocSpec(DocSpec))
 
@@ -20,6 +20,7 @@ import Drasil.SSP.Body (srs, printSetting) -- si
 --   logFile = "log.txt",
 --   logging = LogNone,         -- LogNone, LogFunc
 --   comments = [],    -- CommentFunc, CommentClass, CommentMod
+--   doxVerbosity = Quiet, -- Verbose, Quiet
 --   dates = Hide,      -- Show, Hide
 --   onSfwrConstraint = Warning,  -- Warning, Exception
 --   onPhysConstraint = Warning,  -- Warning, Exception

--- a/code/drasil-example/Drasil/SWHS/Generate.hs
+++ b/code/drasil-example/Drasil/SWHS/Generate.hs
@@ -2,9 +2,9 @@ module Drasil.SWHS.Generate (generate) where
 
 -- import Language.Drasil (QDefinition)
 -- import Language.Drasil.Code (Choices(..), CodeSpec, codeSpec, Comments(..), 
---   ConstraintBehaviour(..), ImplementationType(..), Lang(..), Logging(..), 
---   Structure(..), ConstantStructure(..), ConstantRepr(..), InputModule(..), 
---   matchConcepts, AuxFile(..), Visibility(..))
+--   Verbosity(..), ConstraintBehaviour(..), ImplementationType(..), Lang(..),  
+--   Logging(..), Structure(..), ConstantStructure(..), ConstantRepr(..), 
+--   InputModule(..), matchConcepts, AuxFile(..), Visibility(..))
 import Language.Drasil.Generate (gen)
 import Language.Drasil.Printers (DocType(SRS, Website), DocSpec(DocSpec))
 
@@ -20,6 +20,7 @@ import Drasil.SWHS.Body (srs, printSetting) -- si
 --   logFile = "log.txt",
 --   logging = LogNone,         -- LogNone, LogFunc
 --   comments = [],    -- CommentFunc, CommentClass, CommentMod
+--   doxVerbosity = Quiet, -- Verbose, Quiet
 --   dates = Hide,     -- Show, Hide
 --   onSfwrConstraint = Warning,  -- Warning, Exception
 --   onPhysConstraint = Warning,  -- Warning, Exception


### PR DESCRIPTION
This PR closes #1871 by adding a `Choice` for the verbosity of Doxygen's output when building the PDFs. It is currently set to `QUIET` for all examples so our Travis logs don't get too big.