### PR TITLE
Fixes for Bundled + Combined choice combination

### DIFF
--- a/code/drasil-code/Language/Drasil/CodeSpec.hs
+++ b/code/drasil-code/Language/Drasil/CodeSpec.hs
@@ -463,22 +463,25 @@ getDepsControl cs mem =
 getDepsDerived :: CodeSystInfo -> ModExportMap -> Choices -> 
   Maybe (String, [String])
 getDepsDerived cs mem chs = if null derivedDeps then Nothing else Just 
-  (derivedMod (inputModule chs), derivedDeps)
-  where derivedDeps = nub $ mapMaybe ((`Map.lookup` mem) . codeName) (concatMap 
-          (flip codevars (sysinfodb cs) . codeEquat) (derivedInputs cs))
+  (thisMod, derivedDeps)
+  where derivedDeps = nub $ filter (/= thisMod) (mapMaybe ((`Map.lookup` mem) . 
+          codeName) (concatMap (flip codevars (sysinfodb cs) . codeEquat) (derivedInputs cs)))
+        thisMod = derivedMod (inputModule chs)
         derivedMod Separated = "DerivedValues"
         derivedMod Combined = "InputParameters"
 
 getDepsConstraints :: CodeSystInfo -> ModExportMap -> Choices -> 
   Maybe (String, [String])
 getDepsConstraints cs mem chs = if null constraintDeps then Nothing else Just 
-  (constraintMod (inputModule chs), constraintDeps)
-  where constraintDeps = nub $ mapMaybe ((`Map.lookup` mem) . codeName) reqdVals
+  (thisMod, constraintDeps)
+  where constraintDeps = nub $ filter (/= thisMod) (mapMaybe ((`Map.lookup` mem)
+          . codeName) reqdVals)
         ins = inputs cs
         cm = cMap cs
         varsList = filter (\i -> Map.member (i ^. uid) cm) ins
         reqdVals = nub $ varsList ++ concatMap (\v -> constraintvarsandfuncs v
           (sysinfodb cs) mem) (getConstraints cm varsList)
+        thisMod = constraintMod (inputModule chs)
         constraintMod Separated = "InputConstraints"
         constraintMod Combined = "InputParameters"
 

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer/CSharpRenderer.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer/CSharpRenderer.hs
@@ -39,7 +39,7 @@ import GOOL.Drasil.LanguageRenderer (classDocD, multiStateDocD, bodyDocD,
   lessEqualOpDocD, plusOpDocD, minusOpDocD, multOpDocD, divideOpDocD, 
   moduloOpDocD, andOpDocD, orOpDocD, binExpr, binExpr', typeBinExpr, mkVal, 
   mkVar, litTrueD, litFalseD, litCharD, litFloatD, litIntD, litStringD, 
-  classVarD, classVarDocD, objVarDocD, inlineIfD, newObjDocD, varD, staticVarD, 
+  classVarDocD, objVarDocD, inlineIfD, newObjDocD, varD, staticVarD, 
   extVarD, selfD, enumVarD, classVarD, objVarSelfD, listVarD, listOfD, iterVarD,
   valueOfD, argD, enumElementD, argsListD, objAccessD, objMethodCallD, 
   objMethodCallNoParamsD, selfAccessD, listIndexExistsD, indexOfD, funcAppD, 
@@ -230,6 +230,7 @@ instance VariableSym CSharpCode where
   self = selfD
   enumVar = enumVarD
   classVar = classVarD classVarDocD
+  extClassVar = classVar
   objVar = liftA2 csObjVar
   objVarSelf = objVarSelfD
   listVar  = listVarD

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer/CppRenderer.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer/CppRenderer.hs
@@ -243,6 +243,8 @@ instance (Pair p) => VariableSym (p CppSrcCode CppHdrCode) where
   self l = pair (self l) (self l)
   enumVar e en = pair (enumVar e en) (enumVar e en)
   classVar c v = pair (classVar (pfst c) (pfst v)) (classVar (psnd c) (psnd v))
+  extClassVar c v = pair (extClassVar (pfst c) (pfst v)) (extClassVar (psnd c) 
+    (psnd v))
   objVar o v = pair (objVar (pfst o) (pfst v)) (objVar (psnd o) (psnd v))
   objVarSelf l v = pair (objVarSelf l $ pfst v) (objVarSelf l $ psnd v)
   listVar n p t = pair (listVar n (pfst p) (pfst t)) (listVar n (psnd p) (psnd t))
@@ -852,6 +854,7 @@ instance VariableSym CppSrcCode where
   classVar c v = classVarCheckStatic (varFromData (variableBind v) 
     (getTypeString c ++ "::" ++ variableName v) (variableType v) 
     (cppClassVar (getTypeDoc c) (variableDoc v)))
+  extClassVar = classVar
   objVar = objVarD
   objVarSelf _ v = liftA2 (mkVar ("this->"++variableName v)) (variableType v) 
     (return $ text "this->" <> variableDoc v)
@@ -1420,6 +1423,7 @@ instance VariableSym CppHdrCode where
   self _ = liftA2 (mkVar "") void (return empty)
   enumVar _ _ = liftA2 (mkVar "") void (return empty)
   classVar _ _ = liftA2 (mkVar "") void (return empty)
+  extClassVar _ _ = liftA2 (mkVar "") void (return empty)
   objVar _ _ = liftA2 (mkVar "") void (return empty)
   objVarSelf _ _ = liftA2 (mkVar "") void (return empty)
   listVar _ _ _ = liftA2 (mkVar "") void (return empty)

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer/JavaRenderer.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer/JavaRenderer.hs
@@ -38,7 +38,7 @@ import GOOL.Drasil.LanguageRenderer (packageDocD, classDocD, multiStateDocD,
   greaterEqualOpDocD, lessOpDocD, lessEqualOpDocD, plusOpDocD, minusOpDocD, 
   multOpDocD, divideOpDocD, moduloOpDocD, andOpDocD, orOpDocD, binExpr, 
   binExpr', typeBinExpr, mkVal, litTrueD, litFalseD, litCharD, litFloatD, 
-  litIntD, litStringD, classVarD, classVarDocD, inlineIfD, newObjDocD, varD, 
+  litIntD, litStringD, classVarDocD, inlineIfD, newObjDocD, varD, 
   staticVarD, extVarD, selfD, enumVarD, classVarD, objVarD, objVarSelfD, 
   listVarD, listOfD, iterVarD, valueOfD, argD, enumElementD, argsListD, 
   objAccessD, objMethodCallD, objMethodCallNoParamsD, selfAccessD, 
@@ -231,6 +231,7 @@ instance VariableSym JavaCode where
   self = selfD
   enumVar = enumVarD
   classVar = classVarD classVarDocD
+  extClassVar = classVar
   objVar = objVarD
   objVarSelf = objVarSelfD
   listVar = listVarD

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer/LanguagePolymorphic.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer/LanguagePolymorphic.hs
@@ -262,8 +262,8 @@ commentedClass cmt cs = classFromData (commentedItem (blockCommentDoc cmt)
 buildModule :: (RenderSym repr) => Label -> [repr (Keyword repr)] -> 
   [repr (Method repr)] -> [repr (Class repr)] -> repr (Module repr)
 buildModule n ls ms cs = modFromData n (any isMainMethod ms) (moduleDocD 
-  (vcat $ map keyDoc ls) (methodListDocD $ map methodDoc ms) 
-  (vibcat $ map classDoc cs))
+  (vcat $ map keyDoc ls) (vibcat $ map classDoc cs) 
+  (methodListDocD $ map methodDoc ms))
 
 buildModule' :: (RenderSym repr) => Label -> [repr (Method repr)] -> 
   [repr (Class repr)] -> repr (Module repr)

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer/PythonRenderer.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer/PythonRenderer.hs
@@ -35,7 +35,7 @@ import GOOL.Drasil.LanguageRenderer (enumElementsDocD', multiStateDocD,
   andPrec, orPrec, equalOpDocD, notEqualOpDocD, greaterOpDocD, 
   greaterEqualOpDocD, lessOpDocD, lessEqualOpDocD, plusOpDocD, minusOpDocD, 
   multOpDocD, divideOpDocD, moduloOpDocD, binExpr, typeBinExpr, mkVal, mkVar, 
-  litCharD, litFloatD, litIntD, litStringD, classVarD, newObjDocD', varD, 
+  litCharD, litFloatD, litIntD, litStringD, classVarDocD, newObjDocD', varD, 
   staticVarD, extVarD, enumVarD, classVarD, objVarD, objVarSelfD, listVarD, 
   listOfD, iterVarD, valueOfD, argD, enumElementD, argsListD, objAccessD, 
   objMethodCallD, objMethodCallNoParamsD, selfAccessD, listIndexExistsD, 
@@ -226,7 +226,8 @@ instance VariableSym PythonCode where
   extVar = extVarD
   self l = liftA2 (mkVar "self") (obj l) (return $ text "self")
   enumVar = enumVarD
-  classVar = classVarD pyClassVar
+  classVar = classVarD classVarDocD
+  extClassVar = classVarD pyClassVar
   objVar = objVarD
   objVarSelf = objVarSelfD
   listVar = listVarD

--- a/code/drasil-gool/GOOL/Drasil/Symantics.hs
+++ b/code/drasil-gool/GOOL/Drasil/Symantics.hs
@@ -177,8 +177,12 @@ class (TypeSym repr, InternalVariable repr) => VariableSym repr where
   extVar       :: Library -> Label -> repr (Type repr) -> 
     repr (Variable repr)
   self         :: Label -> repr (Variable repr)
-  classVar     :: repr (Type repr) -> repr (Variable repr) -> repr (Variable repr)
-  objVar       :: repr (Variable repr) -> repr (Variable repr) -> repr (Variable repr)
+  classVar     :: repr (Type repr) -> repr (Variable repr) -> 
+    repr (Variable repr)
+  extClassVar  :: repr (Type repr) -> repr (Variable repr) -> 
+    repr (Variable repr)
+  objVar       :: repr (Variable repr) -> repr (Variable repr) -> 
+    repr (Variable repr)
   objVarSelf   :: Label -> repr (Variable repr) -> repr (Variable repr)
   enumVar      :: Label -> Label -> repr (Variable repr)
   listVar      :: Label -> repr (Permanence repr) -> repr (Type repr) -> 


### PR DESCRIPTION
I noticed some issues when the `Bundled` and `Combined` options were both chosen. This PR fixes some of the issues:

- Fixes dependency map to not have module dependent on itself (which was causing self-import statements)
- Separates `classVar` into `classVar` and `extClassVar` to correctly handle situation of accessing variable from class where the class is in the same module as the code for accessing
- Changes modules so classes come first, which was causing errors in C++

None of our current examples use this combination of choices, which is why I didn't notice these before (and why there are no changes to stable). There are still more problems with this choice combination, but I'm going to create a separate issue (Edit: #1952 created).