### PR TITLE
Improve list printing in Java

### DIFF
--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer/JavaRenderer.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer/JavaRenderer.hs
@@ -418,15 +418,15 @@ instance StatementSym JavaCode where
   extObjDecNewNoParams _ = objDecNewNoParams
   constDecDef v def = mkSt <$> liftA2 jConstDecDef v def
 
-  print v = outDoc False printFunc v Nothing
-  printLn v = outDoc True printLnFunc v Nothing
-  printStr s = outDoc False printFunc (litString s) Nothing
-  printStrLn s = outDoc True printLnFunc (litString s) Nothing
+  print v = jOut False printFunc v Nothing
+  printLn v = jOut True printLnFunc v Nothing
+  printStr s = jOut False printFunc (litString s) Nothing
+  printStrLn s = jOut True printLnFunc (litString s) Nothing
 
-  printFile f v = outDoc False (printFileFunc f) v (Just f)
-  printFileLn f v = outDoc True (printFileLnFunc f) v (Just f)
-  printFileStr f s = outDoc False (printFileFunc f) (litString s) (Just f)
-  printFileStrLn f s = outDoc True (printFileLnFunc f) (litString s) (Just f)
+  printFile f v = jOut False (printFileFunc f) v (Just f)
+  printFileLn f v = jOut True (printFileLnFunc f) v (Just f)
+  printFileStr f s = jOut False (printFileFunc f) (litString s) (Just f)
+  printFileStrLn f s = jOut True (printFileLnFunc f) (litString s) (Just f)
 
   getInput v = v &= liftA2 jInput (variableType v) inputFunc
   discardInput = discardInputD jDiscardInput
@@ -700,6 +700,13 @@ jTryCatch tb cb = vcat [
     lbrace,
   indent $ bodyDoc cb,
   rbrace]
+
+jOut :: (RenderSym repr) => Bool -> repr (Value repr) -> repr (Value repr) 
+  -> Maybe (repr (Value repr)) -> repr (Statement repr)
+jOut newLn printFn v f = jOut' (getType $ valueType v)
+  where jOut' (List (Object _)) = outDoc newLn printFn v f
+        jOut' (List _) = printSt newLn printFn v f
+        jOut' _ = outDoc newLn printFn v f
 
 jDiscardInput :: (RenderSym repr) => repr (Value repr) -> Doc
 jDiscardInput inFn = valueDoc inFn <> dot <> text "next()"

--- a/code/stable/glassbr/src/java/GlassBR/Interpolation.java
+++ b/code/stable/glassbr/src/java/GlassBR/Interpolation.java
@@ -56,15 +56,7 @@ public class Interpolation {
         outfile = new PrintWriter(new FileWriter(new File("log.txt"), true));
         outfile.println("function func_find called with inputs: {");
         outfile.print("  arr = ");
-        outfile.print("[");
-        for (int list_i1 = 0; list_i1 < arr.size() - 1; list_i1++) {
-            outfile.print(arr.get(list_i1));
-            outfile.print(", ");
-        }
-        if (arr.size() > 0) {
-            outfile.print(arr.get(arr.size() - 1));
-        }
-        outfile.print("]");
+        outfile.print(arr);
         outfile.println(", ");
         outfile.print("  v = ");
         outfile.println(v);
@@ -89,31 +81,7 @@ public class Interpolation {
         outfile = new PrintWriter(new FileWriter(new File("log.txt"), true));
         outfile.println("function func_extractColumn called with inputs: {");
         outfile.print("  mat = ");
-        outfile.print("[");
-        for (int list_i2 = 0; list_i2 < mat.size() - 1; list_i2++) {
-            outfile.print("[");
-            for (int list_i1 = 0; list_i1 < mat.get(list_i2).size() - 1; list_i1++) {
-                outfile.print(mat.get(list_i2).get(list_i1));
-                outfile.print(", ");
-            }
-            if (mat.get(list_i2).size() > 0) {
-                outfile.print(mat.get(list_i2).get(mat.get(list_i2).size() - 1));
-            }
-            outfile.print("]");
-            outfile.print(", ");
-        }
-        if (mat.size() > 0) {
-            outfile.print("[");
-            for (int list_i1 = 0; list_i1 < mat.get(mat.size() - 1).size() - 1; list_i1++) {
-                outfile.print(mat.get(mat.size() - 1).get(list_i1));
-                outfile.print(", ");
-            }
-            if (mat.get(mat.size() - 1).size() > 0) {
-                outfile.print(mat.get(mat.size() - 1).get(mat.get(mat.size() - 1).size() - 1));
-            }
-            outfile.print("]");
-        }
-        outfile.print("]");
+        outfile.print(mat);
         outfile.println(", ");
         outfile.print("  j = ");
         outfile.println(j);
@@ -170,57 +138,25 @@ public class Interpolation {
         x_z_1 = func_extractColumn(x_matrix, i);
         outfile = new PrintWriter(new FileWriter(new File("log.txt"), true));
         outfile.print("var 'x_z_1' assigned to ");
-        outfile.print("[");
-        for (int list_i1 = 0; list_i1 < x_z_1.size() - 1; list_i1++) {
-            outfile.print(x_z_1.get(list_i1));
-            outfile.print(", ");
-        }
-        if (x_z_1.size() > 0) {
-            outfile.print(x_z_1.get(x_z_1.size() - 1));
-        }
-        outfile.print("]");
+        outfile.print(x_z_1);
         outfile.println(" in module Interpolation");
         outfile.close();
         y_z_1 = func_extractColumn(y_matrix, i);
         outfile = new PrintWriter(new FileWriter(new File("log.txt"), true));
         outfile.print("var 'y_z_1' assigned to ");
-        outfile.print("[");
-        for (int list_i1 = 0; list_i1 < y_z_1.size() - 1; list_i1++) {
-            outfile.print(y_z_1.get(list_i1));
-            outfile.print(", ");
-        }
-        if (y_z_1.size() > 0) {
-            outfile.print(y_z_1.get(y_z_1.size() - 1));
-        }
-        outfile.print("]");
+        outfile.print(y_z_1);
         outfile.println(" in module Interpolation");
         outfile.close();
         x_z_2 = func_extractColumn(x_matrix, i + 1);
         outfile = new PrintWriter(new FileWriter(new File("log.txt"), true));
         outfile.print("var 'x_z_2' assigned to ");
-        outfile.print("[");
-        for (int list_i1 = 0; list_i1 < x_z_2.size() - 1; list_i1++) {
-            outfile.print(x_z_2.get(list_i1));
-            outfile.print(", ");
-        }
-        if (x_z_2.size() > 0) {
-            outfile.print(x_z_2.get(x_z_2.size() - 1));
-        }
-        outfile.print("]");
+        outfile.print(x_z_2);
         outfile.println(" in module Interpolation");
         outfile.close();
         y_z_2 = func_extractColumn(y_matrix, i + 1);
         outfile = new PrintWriter(new FileWriter(new File("log.txt"), true));
         outfile.print("var 'y_z_2' assigned to ");
-        outfile.print("[");
-        for (int list_i1 = 0; list_i1 < y_z_2.size() - 1; list_i1++) {
-            outfile.print(y_z_2.get(list_i1));
-            outfile.print(", ");
-        }
-        if (y_z_2.size() > 0) {
-            outfile.print(y_z_2.get(y_z_2.size() - 1));
-        }
-        outfile.print("]");
+        outfile.print(y_z_2);
         outfile.println(" in module Interpolation");
         outfile.close();
         try {
@@ -291,57 +227,25 @@ public class Interpolation {
             x_z_1 = func_extractColumn(x_matrix, i);
             outfile = new PrintWriter(new FileWriter(new File("log.txt"), true));
             outfile.print("var 'x_z_1' assigned to ");
-            outfile.print("[");
-            for (int list_i1 = 0; list_i1 < x_z_1.size() - 1; list_i1++) {
-                outfile.print(x_z_1.get(list_i1));
-                outfile.print(", ");
-            }
-            if (x_z_1.size() > 0) {
-                outfile.print(x_z_1.get(x_z_1.size() - 1));
-            }
-            outfile.print("]");
+            outfile.print(x_z_1);
             outfile.println(" in module Interpolation");
             outfile.close();
             y_z_1 = func_extractColumn(y_matrix, i);
             outfile = new PrintWriter(new FileWriter(new File("log.txt"), true));
             outfile.print("var 'y_z_1' assigned to ");
-            outfile.print("[");
-            for (int list_i1 = 0; list_i1 < y_z_1.size() - 1; list_i1++) {
-                outfile.print(y_z_1.get(list_i1));
-                outfile.print(", ");
-            }
-            if (y_z_1.size() > 0) {
-                outfile.print(y_z_1.get(y_z_1.size() - 1));
-            }
-            outfile.print("]");
+            outfile.print(y_z_1);
             outfile.println(" in module Interpolation");
             outfile.close();
             x_z_2 = func_extractColumn(x_matrix, i + 1);
             outfile = new PrintWriter(new FileWriter(new File("log.txt"), true));
             outfile.print("var 'x_z_2' assigned to ");
-            outfile.print("[");
-            for (int list_i1 = 0; list_i1 < x_z_2.size() - 1; list_i1++) {
-                outfile.print(x_z_2.get(list_i1));
-                outfile.print(", ");
-            }
-            if (x_z_2.size() > 0) {
-                outfile.print(x_z_2.get(x_z_2.size() - 1));
-            }
-            outfile.print("]");
+            outfile.print(x_z_2);
             outfile.println(" in module Interpolation");
             outfile.close();
             y_z_2 = func_extractColumn(y_matrix, i + 1);
             outfile = new PrintWriter(new FileWriter(new File("log.txt"), true));
             outfile.print("var 'y_z_2' assigned to ");
-            outfile.print("[");
-            for (int list_i1 = 0; list_i1 < y_z_2.size() - 1; list_i1++) {
-                outfile.print(y_z_2.get(list_i1));
-                outfile.print(", ");
-            }
-            if (y_z_2.size() > 0) {
-                outfile.print(y_z_2.get(y_z_2.size() - 1));
-            }
-            outfile.print("]");
+            outfile.print(y_z_2);
             outfile.println(" in module Interpolation");
             outfile.close();
             try {

--- a/code/stable/glassbr/src/java/GlassBR/ReadTable.java
+++ b/code/stable/glassbr/src/java/GlassBR/ReadTable.java
@@ -28,69 +28,13 @@ public class ReadTable {
         outfile.print(filename);
         outfile.println(", ");
         outfile.print("  z_vector = ");
-        outfile.print("[");
-        for (int list_i1 = 0; list_i1 < z_vector.size() - 1; list_i1++) {
-            outfile.print(z_vector.get(list_i1));
-            outfile.print(", ");
-        }
-        if (z_vector.size() > 0) {
-            outfile.print(z_vector.get(z_vector.size() - 1));
-        }
-        outfile.print("]");
+        outfile.print(z_vector);
         outfile.println(", ");
         outfile.print("  x_matrix = ");
-        outfile.print("[");
-        for (int list_i2 = 0; list_i2 < x_matrix.size() - 1; list_i2++) {
-            outfile.print("[");
-            for (int list_i1 = 0; list_i1 < x_matrix.get(list_i2).size() - 1; list_i1++) {
-                outfile.print(x_matrix.get(list_i2).get(list_i1));
-                outfile.print(", ");
-            }
-            if (x_matrix.get(list_i2).size() > 0) {
-                outfile.print(x_matrix.get(list_i2).get(x_matrix.get(list_i2).size() - 1));
-            }
-            outfile.print("]");
-            outfile.print(", ");
-        }
-        if (x_matrix.size() > 0) {
-            outfile.print("[");
-            for (int list_i1 = 0; list_i1 < x_matrix.get(x_matrix.size() - 1).size() - 1; list_i1++) {
-                outfile.print(x_matrix.get(x_matrix.size() - 1).get(list_i1));
-                outfile.print(", ");
-            }
-            if (x_matrix.get(x_matrix.size() - 1).size() > 0) {
-                outfile.print(x_matrix.get(x_matrix.size() - 1).get(x_matrix.get(x_matrix.size() - 1).size() - 1));
-            }
-            outfile.print("]");
-        }
-        outfile.print("]");
+        outfile.print(x_matrix);
         outfile.println(", ");
         outfile.print("  y_matrix = ");
-        outfile.print("[");
-        for (int list_i2 = 0; list_i2 < y_matrix.size() - 1; list_i2++) {
-            outfile.print("[");
-            for (int list_i1 = 0; list_i1 < y_matrix.get(list_i2).size() - 1; list_i1++) {
-                outfile.print(y_matrix.get(list_i2).get(list_i1));
-                outfile.print(", ");
-            }
-            if (y_matrix.get(list_i2).size() > 0) {
-                outfile.print(y_matrix.get(list_i2).get(y_matrix.get(list_i2).size() - 1));
-            }
-            outfile.print("]");
-            outfile.print(", ");
-        }
-        if (y_matrix.size() > 0) {
-            outfile.print("[");
-            for (int list_i1 = 0; list_i1 < y_matrix.get(y_matrix.size() - 1).size() - 1; list_i1++) {
-                outfile.print(y_matrix.get(y_matrix.size() - 1).get(list_i1));
-                outfile.print(", ");
-            }
-            if (y_matrix.get(y_matrix.size() - 1).size() > 0) {
-                outfile.print(y_matrix.get(y_matrix.size() - 1).get(y_matrix.get(y_matrix.size() - 1).size() - 1));
-            }
-            outfile.print("]");
-        }
-        outfile.println("]");
+        outfile.println(y_matrix);
         outfile.println("  }");
         outfile.close();
         
@@ -106,15 +50,7 @@ public class ReadTable {
         }
         outfile = new PrintWriter(new FileWriter(new File("log.txt"), true));
         outfile.print("var 'z_vector' assigned to ");
-        outfile.print("[");
-        for (int list_i1 = 0; list_i1 < z_vector.size() - 1; list_i1++) {
-            outfile.print(z_vector.get(list_i1));
-            outfile.print(", ");
-        }
-        if (z_vector.size() > 0) {
-            outfile.print(z_vector.get(z_vector.size() - 1));
-        }
-        outfile.print("]");
+        outfile.print(z_vector);
         outfile.println(" in module ReadTable");
         outfile.close();
         while (infile.hasNextLine()) {
@@ -133,60 +69,12 @@ public class ReadTable {
         }
         outfile = new PrintWriter(new FileWriter(new File("log.txt"), true));
         outfile.print("var 'x_matrix' assigned to ");
-        outfile.print("[");
-        for (int list_i2 = 0; list_i2 < x_matrix.size() - 1; list_i2++) {
-            outfile.print("[");
-            for (int list_i1 = 0; list_i1 < x_matrix.get(list_i2).size() - 1; list_i1++) {
-                outfile.print(x_matrix.get(list_i2).get(list_i1));
-                outfile.print(", ");
-            }
-            if (x_matrix.get(list_i2).size() > 0) {
-                outfile.print(x_matrix.get(list_i2).get(x_matrix.get(list_i2).size() - 1));
-            }
-            outfile.print("]");
-            outfile.print(", ");
-        }
-        if (x_matrix.size() > 0) {
-            outfile.print("[");
-            for (int list_i1 = 0; list_i1 < x_matrix.get(x_matrix.size() - 1).size() - 1; list_i1++) {
-                outfile.print(x_matrix.get(x_matrix.size() - 1).get(list_i1));
-                outfile.print(", ");
-            }
-            if (x_matrix.get(x_matrix.size() - 1).size() > 0) {
-                outfile.print(x_matrix.get(x_matrix.size() - 1).get(x_matrix.get(x_matrix.size() - 1).size() - 1));
-            }
-            outfile.print("]");
-        }
-        outfile.print("]");
+        outfile.print(x_matrix);
         outfile.println(" in module ReadTable");
         outfile.close();
         outfile = new PrintWriter(new FileWriter(new File("log.txt"), true));
         outfile.print("var 'y_matrix' assigned to ");
-        outfile.print("[");
-        for (int list_i2 = 0; list_i2 < y_matrix.size() - 1; list_i2++) {
-            outfile.print("[");
-            for (int list_i1 = 0; list_i1 < y_matrix.get(list_i2).size() - 1; list_i1++) {
-                outfile.print(y_matrix.get(list_i2).get(list_i1));
-                outfile.print(", ");
-            }
-            if (y_matrix.get(list_i2).size() > 0) {
-                outfile.print(y_matrix.get(list_i2).get(y_matrix.get(list_i2).size() - 1));
-            }
-            outfile.print("]");
-            outfile.print(", ");
-        }
-        if (y_matrix.size() > 0) {
-            outfile.print("[");
-            for (int list_i1 = 0; list_i1 < y_matrix.get(y_matrix.size() - 1).size() - 1; list_i1++) {
-                outfile.print(y_matrix.get(y_matrix.size() - 1).get(list_i1));
-                outfile.print(", ");
-            }
-            if (y_matrix.get(y_matrix.size() - 1).size() > 0) {
-                outfile.print(y_matrix.get(y_matrix.size() - 1).get(y_matrix.get(y_matrix.size() - 1).size() - 1));
-            }
-            outfile.print("]");
-        }
-        outfile.print("]");
+        outfile.print(y_matrix);
         outfile.println(" in module ReadTable");
         outfile.close();
         infile.close();


### PR DESCRIPTION
This PR updates GOOL's java renderer to print lists simply by passing the list to Java's basic print function, contributing to #1940. The loop structure used previously is not actually needed in Java.