### PR TITLE
Start to make accessor functions stateful

### DIFF
--- a/code/drasil-gool/GOOL/Drasil/Data.hs
+++ b/code/drasil-gool/GOOL/Drasil/Data.hs
@@ -55,8 +55,8 @@ data ModData = MD {name :: String, isMainMod :: Bool, modDoc :: Doc}
 md :: String -> Bool -> Doc -> ModData
 md = MD
 
-updateModDoc :: Doc -> ModData -> ModData
-updateModDoc d m = md (name m) (isMainMod m) d
+updateModDoc :: (Doc -> Doc) -> ModData -> ModData
+updateModDoc f m = md (name m) (isMainMod m) (f $ modDoc m)
 
 data MethodData = MthD {isMainMthd :: Bool, mthdParams :: [ParamData], 
   mthdDoc :: Doc}

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer.hs
@@ -69,10 +69,8 @@ import GOOL.Drasil.Data (Terminator(..), FileData(..), fileD, updateFileMod,
   ValData(..), vd, Binding(..), VarData(..), vard)
 import GOOL.Drasil.Helpers (angles, doubleQuotedText, hicat, vibcat, vmap, 
   emptyIfEmpty, emptyIfNull, getInnerType, getNestDegree, convType)
-import GOOL.Drasil.State (GOOLState)
 
 import Control.Applicative ((<|>))
-import Control.Monad.State (State)
 import Data.List (intersperse, last)
 import Data.Bifunctor (first)
 import Data.Map as Map (lookup, fromList)
@@ -1083,8 +1081,8 @@ publicDocD = text "public"
 
 -- Comment Functions -- 
 
-blockCmtDoc :: [String] -> Doc -> Doc -> State GOOLState Doc
-blockCmtDoc lns start end = return $ start <+> vcat (map text lns) <+> end
+blockCmtDoc :: [String] -> Doc -> Doc -> Doc
+blockCmtDoc lns start end = start <+> vcat (map text lns) <+> end
 
 docCmtDoc :: Doc -> Doc -> [String] -> Doc
 docCmtDoc start end lns = emptyIfNull lns $

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer.hs
@@ -65,8 +65,8 @@ import GOOL.Drasil.Symantics (Label, Library, RenderSym(..), BodySym(..),
   ParameterSym(..), MethodSym(..), InternalMethod(..), BlockCommentSym(..))
 import qualified GOOL.Drasil.Symantics as S (TypeSym(char, int))
 import GOOL.Drasil.Data (Terminator(..), FileData(..), fileD, updateFileMod, 
-  ModData(..), updateModDoc, OpData(..), od, ParamData(..), pd, TypeData(..), 
-  td, ValData(..), vd, Binding(..), VarData(..), vard)
+  updateModDoc, OpData(..), od, ParamData(..), pd, TypeData(..), td, 
+  ValData(..), vd, Binding(..), VarData(..), vard)
 import GOOL.Drasil.Helpers (angles, doubleQuotedText, hicat, vibcat, vmap, 
   emptyIfEmpty, emptyIfNull, getInnerType, getNestDegree, convType)
 import GOOL.Drasil.State (GOOLState)
@@ -1130,8 +1130,8 @@ moduleDox desc as date m = (doxFile ++ m) :
   [doxDate ++ date | not (null date)] ++ 
   [doxBrief ++ desc | not (null desc)]
 
-commentedModD :: Doc -> FileData -> FileData
-commentedModD cmt m = updateFileMod (updateModDoc (commentedItem cmt) (fileMod m)) m
+commentedModD :: FileData -> Doc -> FileData
+commentedModD m cmt = updateFileMod (updateModDoc (commentedItem cmt) (fileMod m)) m
 
 docFuncRepr :: (MethodSym repr) => String -> [String] -> [String] -> 
   repr (Method repr) -> repr (Method repr)

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer.hs
@@ -1083,11 +1083,11 @@ publicDocD = text "public"
 
 -- Comment Functions -- 
 
-blockCmtDoc :: [String] -> Doc -> Doc -> Doc
-blockCmtDoc lns start end = start <+> vcat (map text lns) <+> end
+blockCmtDoc :: [String] -> Doc -> Doc -> State GOOLState Doc
+blockCmtDoc lns start end = return $ start <+> vcat (map text lns) <+> end
 
-docCmtDoc :: [String] -> Doc -> Doc -> Doc
-docCmtDoc lns start end = emptyIfNull lns $
+docCmtDoc :: Doc -> Doc -> [String] -> Doc
+docCmtDoc start end lns = emptyIfNull lns $
   vcat $ start : map (indent . text) lns ++ [end]
 
 commentedItem :: Doc -> Doc -> Doc
@@ -1130,15 +1130,13 @@ moduleDox desc as date m = (doxFile ++ m) :
   [doxDate ++ date | not (null date)] ++ 
   [doxBrief ++ desc | not (null desc)]
 
-commentedModD :: Doc -> State GOOLState FileData -> State GOOLState FileData
-commentedModD cmt mod = do
-  m <- mod
-  return $ updateFileMod (updateModDoc (commentedItem cmt 
+commentedModD :: Doc -> FileData -> FileData
+commentedModD cmt m = updateFileMod (updateModDoc (commentedItem cmt 
     ((modDoc . fileMod) m)) (fileMod m)) m
 
 docFuncRepr :: (MethodSym repr) => String -> [String] -> [String] -> 
   repr (Method repr) -> repr (Method repr)
-docFuncRepr desc pComms rComms f = commentedFunc (docComment $ functionDox desc
+docFuncRepr desc pComms rComms f = commentedFunc (docComment $ return $ functionDox desc
   (zip (map parameterName (parameters f)) pComms) rComms) f
 
 -- Helper Functions --

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer.hs
@@ -111,8 +111,8 @@ addExt ext nm = nm ++ "." ++ ext
 
 packageDocD :: Label -> Doc -> FileData -> FileData
 packageDocD n end f = fileD (n ++ "/" ++ filePath f) (updateModDoc 
-  (emptyIfEmpty (modDoc $ fileMod f) (vibcat [text "package" <+> text n <> end, 
-  modDoc (fileMod f)])) (fileMod f))
+  (\d -> emptyIfEmpty d (vibcat [text "package" <+> text n <> end, d])) 
+  (fileMod f))
 
 fileDoc' :: Doc -> Doc -> Doc -> Doc
 fileDoc' t m b = vibcat (filter (not . isEmpty) [
@@ -1131,8 +1131,7 @@ moduleDox desc as date m = (doxFile ++ m) :
   [doxBrief ++ desc | not (null desc)]
 
 commentedModD :: Doc -> FileData -> FileData
-commentedModD cmt m = updateFileMod (updateModDoc (commentedItem cmt 
-    ((modDoc . fileMod) m)) (fileMod m)) m
+commentedModD cmt m = updateFileMod (updateModDoc (commentedItem cmt) (fileMod m)) m
 
 docFuncRepr :: (MethodSym repr) => String -> [String] -> [String] -> 
   repr (Method repr) -> repr (Method repr)

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer/CSharpRenderer.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer/CSharpRenderer.hs
@@ -59,7 +59,7 @@ import qualified GOOL.Drasil.LanguageRenderer.LanguagePolymorphic as G (
   privMVar, pubMVar, pubGVar, buildClass, enum, privClass, pubClass, docClass, 
   commentedClass, buildModule', fileDoc, docMod)
 import GOOL.Drasil.Data (Terminator(..), FileType(..), FileData(..), 
-  FuncData(..), fd, ModData(..), md, MethodData(..), mthd, updateMthdDoc, 
+  FuncData(..), fd, ModData(..), md, updateModDoc, MethodData(..), mthd, updateMthdDoc, 
   OpData(..), ParamData(..), updateParamDoc, ProgData(..), progD, TypeData(..), 
   td, ValData(..), vd, updateValDoc, Binding(..), VarData(..), vard)
 import GOOL.Drasil.Helpers (liftA4, liftA5, liftList, lift1List, checkParams)
@@ -94,8 +94,8 @@ instance ProgramSym CSharpCode where
 
 instance RenderSym CSharpCode where
   type RenderFile CSharpCode = State GOOLState FileData
-  fileDoc code = liftA2 passState code (G.fileDoc Combined csExt (top code) 
-    bottom code)
+  fileDoc code = G.fileDoc Combined csExt (top code) 
+    bottom code
 
   docMod = G.docMod
 
@@ -593,6 +593,7 @@ instance InternalMod CSharpCode where
   isMainModule = isMainMod . (`evalState` initialState) . unCSC
   moduleDoc = modDoc . (`evalState` initialState) . unCSC
   modFromData n m d = return $ return $ md n m d
+  updateModuleDoc f = fmap (fmap (updateModDoc f))
 
 instance BlockCommentSym CSharpCode where
   type BlockComment CSharpCode = State GOOLState Doc

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer/CSharpRenderer.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer/CSharpRenderer.hs
@@ -105,7 +105,6 @@ instance InternalFile CSharpCode where
   top _ = liftA2 cstop endStatement (include "")
   bottom = return empty
 
-  getFilePath = filePath . (`evalState` initialState) . unCSC
   fileFromData ft fp = fmap (G.fileFromData ft fp)
 
 instance KeywordSym CSharpCode where

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer/CSharpRenderer.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer/CSharpRenderer.hs
@@ -596,7 +596,8 @@ instance InternalMod CSharpCode where
 
 instance BlockCommentSym CSharpCode where
   type BlockComment CSharpCode = State GOOLState Doc
-  blockComment lns = liftA2 (blockCmtDoc lns) blockCommentStart blockCommentEnd
+  blockComment lns = liftA2 (\bcs bce -> return $ blockCmtDoc lns bcs bce) 
+    blockCommentStart blockCommentEnd
   docComment lns = liftA2 (\dcs dce -> fmap (docCmtDoc dcs dce) lns) 
     docCommentStart docCommentEnd
 

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer/CSharpRenderer.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer/CSharpRenderer.hs
@@ -59,12 +59,12 @@ import qualified GOOL.Drasil.LanguageRenderer.LanguagePolymorphic as G (
   privMVar, pubMVar, pubGVar, buildClass, enum, privClass, pubClass, docClass, 
   commentedClass, buildModule', fileDoc, docMod)
 import GOOL.Drasil.Data (Terminator(..), FileType(..), FileData(..), 
-  FuncData(..), fd, ModData(..), md, updateModDoc, MethodData(..), mthd, updateMthdDoc, 
-  OpData(..), ParamData(..), updateParamDoc, ProgData(..), progD, TypeData(..), 
-  td, ValData(..), vd, updateValDoc, Binding(..), VarData(..), vard)
+  FuncData(..), fd, ModData(..), md, updateModDoc, MethodData(..), mthd, 
+  updateMthdDoc, OpData(..), ParamData(..), updateParamDoc, ProgData(..), progD,
+  TypeData(..), td, ValData(..), vd, updateValDoc, Binding(..), VarData(..), vard)
 import GOOL.Drasil.Helpers (liftA4, liftA5, liftList, lift1List, checkParams)
 import GOOL.Drasil.State (GOOLState, initialState, getPutReturn, 
-  passState, passState2Lists, setMain)
+  passState2Lists, setMain)
 
 import Prelude hiding (break,print,(<>),sin,cos,tan,floor)
 import Control.Applicative (Applicative, liftA2, liftA3)

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer/CSharpRenderer.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer/CSharpRenderer.hs
@@ -99,7 +99,7 @@ instance RenderSym CSharpCode where
 
   docMod = G.docMod
 
-  commentedMod = liftA2 commentedModD
+  commentedMod = liftA2 (liftA2 commentedModD)
 
 instance InternalFile CSharpCode where
   top _ = liftA2 cstop endStatement (include "")
@@ -548,7 +548,8 @@ instance InternalMethod CSharpCode where
     liftA2 (mthd m) (checkParams n <$> sequence ps) (liftA5 (methodDocD n) s p 
     t (liftList paramListDocD ps) b)
   intFunc = G.intFunc
-  commentedFunc cmt = liftA2 (fmap . updateMthdDoc) (fmap commentedItem cmt)
+  commentedFunc cmt = liftA2 (liftA2 updateMthdDoc) (fmap (fmap commentedItem) 
+    cmt)
   
   isMainMethod = isMainMthd . (`evalState` initialState) . unCSC
   methodDoc = mthdDoc . (`evalState` initialState) . unCSC
@@ -579,7 +580,7 @@ instance ClassSym CSharpCode where
 
 instance InternalClass CSharpCode where
   classDoc = (`evalState` initialState) . unCSC
-  classFromData = return . return
+  classFromData = return
 
 instance ModuleSym CSharpCode where
   type Module CSharpCode = State GOOLState ModData
@@ -594,9 +595,10 @@ instance InternalMod CSharpCode where
   modFromData n m d = return $ return $ md n m d
 
 instance BlockCommentSym CSharpCode where
-  type BlockComment CSharpCode = Doc
+  type BlockComment CSharpCode = State GOOLState Doc
   blockComment lns = liftA2 (blockCmtDoc lns) blockCommentStart blockCommentEnd
-  docComment lns = liftA2 (docCmtDoc lns) docCommentStart docCommentEnd
+  docComment lns = liftA2 (\dcs dce -> fmap (docCmtDoc dcs dce) lns) 
+    docCommentStart docCommentEnd
 
   blockCommentDoc = unCSC
 

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer/CppRenderer.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer/CppRenderer.hs
@@ -104,14 +104,13 @@ instance (Pair p) => RenderSym (p CppSrcCode CppHdrCode) where
 
   docMod d a dt m = pair (docMod d a dt $ pfst m) (docMod d a dt $ psnd m)
 
-  commentedMod cmt m = pair (commentedMod (pfst cmt) (pfst m)) 
-    (commentedMod (psnd cmt) (psnd m))
+  commentedMod m cmt = pair (commentedMod (pfst m) (pfst cmt)) 
+    (commentedMod (psnd m) (psnd cmt))
 
 instance (Pair p) => InternalFile (p CppSrcCode CppHdrCode) where
   top m = pair (top $ pfst m) (top $ psnd m)
   bottom = pair bottom bottom
   
-  getFilePath f = getFilePath $ pfst f
   fileFromData ft fp m = pair (fileFromData ft fp $ pfst m) 
     (fileFromData ft fp $ psnd m)
 
@@ -698,6 +697,8 @@ instance (Pair p) => InternalMod (p CppSrcCode CppHdrCode) where
   isMainModule m = isMainModule $ pfst m
   moduleDoc m = moduleDoc $ pfst m
   modFromData n m d = pair (modFromData n m d) (modFromData n m d)
+  updateModuleDoc f m = pair (updateModuleDoc f $ pfst m) (updateModuleDoc f $ 
+    psnd m)
 
 instance (Pair p) => BlockCommentSym (p CppSrcCode CppHdrCode) where
   type BlockComment (p CppSrcCode CppHdrCode) = State GOOLState Doc
@@ -734,14 +735,13 @@ instance RenderSym CppSrcCode where
 
   docMod = G.docMod
 
-  commentedMod cmt m = if (isMainMod . fileMod . (`evalState` initialState) . 
-    unCPPSC) m then liftA2 (liftA2 commentedModD) cmt m else m 
+  commentedMod m cmt = if (isMainMod . fileMod . (`evalState` initialState) . 
+    unCPPSC) m then liftA2 (liftA2 commentedModD) m cmt else m 
 
 instance InternalFile CppSrcCode where
   top m = liftA3 cppstop m (list dynamic_) endStatement
   bottom = return empty
   
-  getFilePath = filePath . (`evalState` initialState) . unCPPSC
   fileFromData ft fp = fmap (G.fileFromData ft fp)
 
 instance KeywordSym CppSrcCode where
@@ -1308,14 +1308,13 @@ instance RenderSym CppHdrCode where
   
   docMod = G.docMod
 
-  commentedMod cmt m = if (isMainMod . fileMod . (`evalState` initialState) . 
-    unCPPHC) m then m else liftA2 (liftA2 commentedModD) cmt m
+  commentedMod m cmt = if (isMainMod . fileMod . (`evalState` initialState) . 
+    unCPPHC) m then m else liftA2 (liftA2 commentedModD) m cmt
 
 instance InternalFile CppHdrCode where
   top m = liftA3 cpphtop m (list dynamic_) endStatement
   bottom = return $ text "#endif"
   
-  getFilePath = filePath . (`evalState` initialState) . unCPPHC
   fileFromData ft fp = fmap (G.fileFromData ft fp)
 
 instance KeywordSym CppHdrCode where

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer/CppRenderer.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer/CppRenderer.hs
@@ -59,14 +59,14 @@ import qualified GOOL.Drasil.LanguageRenderer.LanguagePolymorphic as G (
   docClass, commentedClass, buildModule, fileDoc, docMod)
 import GOOL.Drasil.Data (Pair(..), pairList, Terminator(..), ScopeTag(..), 
   Binding(..), BindData(..), bd, FileType(..), FileData(..), FuncData(..), fd, 
-  ModData(..), md, updateModDoc, OpData(..), od, ParamData(..), pd, ProgData(..), progD, 
-  emptyProg, StateVarData(..), svd, TypeData(..), td, ValData(..), vd, 
-  VarData(..), vard)
+  ModData(..), md, updateModDoc, OpData(..), od, ParamData(..), pd, 
+  ProgData(..), progD, emptyProg, StateVarData(..), svd, TypeData(..), td, 
+  ValData(..), vd, VarData(..), vard)
 import GOOL.Drasil.Helpers (angles, doubleQuotedText, emptyIfEmpty, mapPairFst, 
   mapPairSnd, liftA4, liftA5, liftA8, liftList, lift2Lists, lift1List, 
   checkParams)
 import GOOL.Drasil.State (GOOLState, hasMain, initialState, getPutReturn, 
-  passState, passState2Lists, checkGOOLState, setMain)
+  passState2Lists, checkGOOLState, setMain)
 
 import Prelude hiding (break,print,(<>),sin,cos,tan,floor,pi,const,log,exp)
 import Data.Maybe (maybeToList)

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer/CppRenderer.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer/CppRenderer.hs
@@ -1278,7 +1278,8 @@ instance InternalMod CppSrcCode where
 
 instance BlockCommentSym CppSrcCode where
   type BlockComment CppSrcCode = State GOOLState Doc
-  blockComment lns = liftA2 (blockCmtDoc lns) blockCommentStart blockCommentEnd
+  blockComment lns = liftA2 (\bcs bce -> return $ blockCmtDoc lns bcs bce) 
+    blockCommentStart blockCommentEnd
   docComment lns = liftA2 (\dcs dce -> fmap (docCmtDoc dcs dce) lns) 
     docCommentStart docCommentEnd
 
@@ -1821,7 +1822,8 @@ instance InternalMod CppHdrCode where
 
 instance BlockCommentSym CppHdrCode where
   type BlockComment CppHdrCode = State GOOLState Doc
-  blockComment lns = liftA2 (blockCmtDoc lns) blockCommentStart blockCommentEnd
+  blockComment lns = liftA2 (\bcs bce -> return $ blockCmtDoc lns bcs bce) 
+    blockCommentStart blockCommentEnd
   docComment lns = liftA2 (\dcs dce -> fmap (docCmtDoc dcs dce) lns) 
     docCommentStart docCommentEnd
 

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer/CppRenderer.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer/CppRenderer.hs
@@ -59,7 +59,7 @@ import qualified GOOL.Drasil.LanguageRenderer.LanguagePolymorphic as G (
   docClass, commentedClass, buildModule, fileDoc, docMod)
 import GOOL.Drasil.Data (Pair(..), pairList, Terminator(..), ScopeTag(..), 
   Binding(..), BindData(..), bd, FileType(..), FileData(..), FuncData(..), fd, 
-  ModData(..), md, OpData(..), od, ParamData(..), pd, ProgData(..), progD, 
+  ModData(..), md, updateModDoc, OpData(..), od, ParamData(..), pd, ProgData(..), progD, 
   emptyProg, StateVarData(..), svd, TypeData(..), td, ValData(..), vd, 
   VarData(..), vard)
 import GOOL.Drasil.Helpers (angles, doubleQuotedText, emptyIfEmpty, mapPairFst, 
@@ -729,8 +729,8 @@ instance ProgramSym CppSrcCode where
   
 instance RenderSym CppSrcCode where
   type RenderFile CppSrcCode = State GOOLState FileData
-  fileDoc code = liftA2 passState code (G.fileDoc Source cppSrcExt (top code) 
-    bottom code)
+  fileDoc code = G.fileDoc Source cppSrcExt (top code) 
+    bottom code
 
   docMod = G.docMod
 
@@ -1274,6 +1274,7 @@ instance InternalMod CppSrcCode where
   isMainModule = isMainMod . (`evalState` initialState) . unCPPSC
   moduleDoc = modDoc . (`evalState` initialState) . unCPPSC
   modFromData n m d = return $ return $ md n m d
+  updateModuleDoc f = fmap (fmap (updateModDoc f))
 
 instance BlockCommentSym CppSrcCode where
   type BlockComment CppSrcCode = State GOOLState Doc
@@ -1302,8 +1303,8 @@ instance Monad CppHdrCode where
 
 instance RenderSym CppHdrCode where
   type RenderFile CppHdrCode = State GOOLState FileData
-  fileDoc code = liftA2 passState code (G.fileDoc Header cppHdrExt (top code) 
-    bottom code)
+  fileDoc code = G.fileDoc Header cppHdrExt (top code) 
+    bottom code
   
   docMod = G.docMod
 
@@ -1817,6 +1818,7 @@ instance InternalMod CppHdrCode where
   isMainModule = isMainMod . (`evalState` initialState) . unCPPHC
   moduleDoc = modDoc . (`evalState` initialState) . unCPPHC
   modFromData n m d = return $ return $ md n m d
+  updateModuleDoc f = fmap (fmap (updateModDoc f))
 
 instance BlockCommentSym CppHdrCode where
   type BlockComment CppHdrCode = State GOOLState Doc

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer/JavaRenderer.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer/JavaRenderer.hs
@@ -107,7 +107,6 @@ instance InternalFile JavaCode where
   top _ = liftA3 jtop endStatement (include "") (list static_)
   bottom = return empty
   
-  getFilePath = filePath . (`evalState` initialState) . unJC
   fileFromData ft fp = fmap (G.fileFromData ft fp)
 
 instance KeywordSym JavaCode where

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer/JavaRenderer.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer/JavaRenderer.hs
@@ -101,7 +101,7 @@ instance RenderSym JavaCode where
 
   docMod = G.docMod
 
-  commentedMod = liftA2 commentedModD
+  commentedMod = liftA2 (liftA2 commentedModD)
 
 instance InternalFile JavaCode where
   top _ = liftA3 jtop endStatement (include "") (list static_)
@@ -552,7 +552,8 @@ instance InternalMethod JavaCode where
     liftA2 (mthd m) (checkParams n <$> sequence ps) (liftA5 (jMethod n) s p t 
     (liftList paramListDocD ps) b)
   intFunc = G.intFunc
-  commentedFunc cmt = liftA2 (fmap . updateMthdDoc) (fmap commentedItem cmt)
+  commentedFunc cmt = liftA2 (liftA2 updateMthdDoc) (fmap (fmap commentedItem)
+    cmt)
   
   isMainMethod = isMainMthd . (`evalState` initialState) . unJC
   methodDoc = mthdDoc . (`evalState` initialState) . unJC
@@ -583,7 +584,7 @@ instance ClassSym JavaCode where
 
 instance InternalClass JavaCode where
   classDoc = (`evalState` initialState) . unJC
-  classFromData = return . return
+  classFromData = return
 
 instance ModuleSym JavaCode where
   type Module JavaCode = State GOOLState ModData
@@ -598,9 +599,10 @@ instance InternalMod JavaCode where
   modFromData n m d = return $ return $ md n m d
 
 instance BlockCommentSym JavaCode where
-  type BlockComment JavaCode = Doc
+  type BlockComment JavaCode = State GOOLState Doc
   blockComment lns = liftA2 (blockCmtDoc lns) blockCommentStart blockCommentEnd
-  docComment lns = liftA2 (docCmtDoc lns) docCommentStart docCommentEnd 
+  docComment lns = liftA2 (\dcs dce -> fmap (docCmtDoc dcs dce) lns) 
+    docCommentStart docCommentEnd 
 
   blockCommentDoc = unJC
 

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer/JavaRenderer.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer/JavaRenderer.hs
@@ -59,13 +59,13 @@ import qualified GOOL.Drasil.LanguageRenderer.LanguagePolymorphic as G (
   pubMVar, pubGVar, buildClass, enum, privClass, pubClass, docClass, 
   commentedClass, buildModule', fileDoc, docMod)
 import GOOL.Drasil.Data (Terminator(..), FileType(..), FileData(..), 
-  FuncData(..), fd, ModData(..), md, updateModDoc, MethodData(..), mthd, updateMthdDoc, 
-  OpData(..), ParamData(..), ProgData(..), progD, TypeData(..), td, ValData(..),
-  vd, VarData(..), vard)
+  FuncData(..), fd, ModData(..), md, updateModDoc, MethodData(..), mthd, 
+  updateMthdDoc, OpData(..), ParamData(..), ProgData(..), progD, TypeData(..), 
+  td, ValData(..), vd, VarData(..), vard)
 import GOOL.Drasil.Helpers (angles, emptyIfNull, liftA4, liftA5, liftList, 
   lift1List, checkParams)
 import GOOL.Drasil.State (GOOLState, initialState, getPutReturn, 
-  getPutReturnList, passState, passState2Lists, addProgNameToPaths, setMain)
+  getPutReturnList, passState2Lists, addProgNameToPaths, setMain)
 
 import Prelude hiding (break,print,sin,cos,tan,floor,(<>))
 import Control.Applicative (Applicative, liftA2, liftA3)

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer/JavaRenderer.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer/JavaRenderer.hs
@@ -59,7 +59,7 @@ import qualified GOOL.Drasil.LanguageRenderer.LanguagePolymorphic as G (
   pubMVar, pubGVar, buildClass, enum, privClass, pubClass, docClass, 
   commentedClass, buildModule', fileDoc, docMod)
 import GOOL.Drasil.Data (Terminator(..), FileType(..), FileData(..), 
-  FuncData(..), fd, ModData(..), md, MethodData(..), mthd, updateMthdDoc, 
+  FuncData(..), fd, ModData(..), md, updateModDoc, MethodData(..), mthd, updateMthdDoc, 
   OpData(..), ParamData(..), ProgData(..), progD, TypeData(..), td, ValData(..),
   vd, VarData(..), vard)
 import GOOL.Drasil.Helpers (angles, emptyIfNull, liftA4, liftA5, liftList, 
@@ -96,8 +96,8 @@ instance ProgramSym JavaCode where
 
 instance RenderSym JavaCode where
   type RenderFile JavaCode = State GOOLState FileData 
-  fileDoc code = liftA2 passState code (G.fileDoc Combined jExt (top code) 
-    bottom code)
+  fileDoc code = G.fileDoc Combined jExt (top code) 
+    bottom code
 
   docMod = G.docMod
 
@@ -597,6 +597,7 @@ instance InternalMod JavaCode where
   isMainModule = isMainMod . (`evalState` initialState) . unJC
   moduleDoc = modDoc . (`evalState` initialState) . unJC
   modFromData n m d = return $ return $ md n m d
+  updateModuleDoc f = fmap (fmap (updateModDoc f))
 
 instance BlockCommentSym JavaCode where
   type BlockComment JavaCode = State GOOLState Doc

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer/JavaRenderer.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer/JavaRenderer.hs
@@ -600,7 +600,8 @@ instance InternalMod JavaCode where
 
 instance BlockCommentSym JavaCode where
   type BlockComment JavaCode = State GOOLState Doc
-  blockComment lns = liftA2 (blockCmtDoc lns) blockCommentStart blockCommentEnd
+  blockComment lns = liftA2 (\bcs bce -> return $ blockCmtDoc lns bcs bce) 
+    blockCommentStart blockCommentEnd
   docComment lns = liftA2 (\dcs dce -> fmap (docCmtDoc dcs dce) lns) 
     docCommentStart docCommentEnd 
 

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer/LanguagePolymorphic.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer/LanguagePolymorphic.hs
@@ -177,7 +177,7 @@ constructor :: (RenderSym repr) => Label -> Label -> [repr (Parameter repr)] ->
 constructor fName n = intMethod False fName n public dynamic_ (S.construct n)
 
 docMain :: (RenderSym repr) => repr (Body repr) -> repr (Method repr)
-docMain b = commentedFunc (docComment $ functionDox 
+docMain b = commentedFunc (docComment $ return $ functionDox 
   "Controls the flow of the program" 
   [("args", "List of command-line arguments")] []) (S.mainFunction b)
 
@@ -245,14 +245,14 @@ pubGVar = S.stateVar public static_
 buildClass :: (RenderSym repr) => (Label -> Doc -> Doc -> Doc -> Doc -> Doc) -> 
   (Label -> repr (Keyword repr)) -> Label -> Maybe Label -> repr (Scope repr) 
   -> [repr (StateVar repr)] -> [repr (Method repr)] -> repr (Class repr)
-buildClass f i n p s vs fs = classFromData (f n parent (scopeDoc s) 
+buildClass f i n p s vs fs = classFromData (return $ f n parent (scopeDoc s) 
   (stateVarListDocD (map stateVarDoc vs)) (methodListDocD (map methodDoc fs)))
   where parent = case p of Nothing -> empty
                            Just pn -> keyDoc $ i pn
 
 enum :: (RenderSym repr) => Label -> [Label] -> repr (Scope repr) -> 
   repr (Class repr)
-enum n es s = classFromData (enumDocD n (enumElementsDocD es False) 
+enum n es s = classFromData (return $ enumDocD n (enumElementsDocD es False) 
   (scopeDoc s))
 
 privClass :: (RenderSym repr) => Label -> Maybe Label -> [repr (StateVar repr)] 
@@ -264,12 +264,12 @@ pubClass :: (RenderSym repr) => Label -> Maybe Label -> [repr (StateVar repr)]
 pubClass n p = S.buildClass n p public
 
 docClass :: (RenderSym repr) => String -> repr (Class repr) -> repr (Class repr)
-docClass d = S.commentedClass (docComment $ classDox d)
+docClass d = S.commentedClass (docComment $ return $ classDox d)
 
 commentedClass :: (RenderSym repr) => repr (BlockComment repr) -> 
   repr (Class repr) -> repr (Class repr)
-commentedClass cmt cs = classFromData (commentedItem (blockCommentDoc cmt) 
-  (classDoc cs))
+commentedClass cmt cs = classFromData (fmap (`commentedItem` classDoc cs)
+  (blockCommentDoc cmt))
 
 buildModule :: (RenderSym repr) => Label -> [repr (Keyword repr)] -> 
   [repr (Method repr)] -> [repr (Class repr)] -> repr (Module repr)
@@ -290,4 +290,5 @@ fileDoc ft ext topb botb m = S.fileFromData ft (addExt ext (moduleName m))
 
 docMod :: (RenderSym repr) => String -> [String] -> String -> 
   repr (RenderFile repr) -> repr (RenderFile repr)
-docMod d a dt m = commentedMod (docComment $ moduleDox d a dt $ getFilePath m) m
+docMod d a dt m = commentedMod (docComment $ return $ moduleDox d a dt $ 
+  getFilePath m) m

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer/LanguagePolymorphic.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer/LanguagePolymorphic.hs
@@ -13,7 +13,7 @@ module GOOL.Drasil.LanguageRenderer.LanguagePolymorphic (fileFromData, block,
 import Utils.Drasil (indent)
 
 import GOOL.Drasil.CodeType (CodeType(..), isObject)
-import GOOL.Drasil.Symantics (Label, KeywordSym(..), InternalFile(getFilePath),
+import GOOL.Drasil.Symantics (Label, KeywordSym(..),
   RenderSym(RenderFile, commentedMod), BlockSym(Block), 
   InternalBlock(..), BodySym(..), PermanenceSym(..), InternalPerm(..), 
   TypeSym(..), InternalType(..), VariableSym(..), 
@@ -38,7 +38,7 @@ import GOOL.Drasil.LanguageRenderer (forLabel, addExt, blockDocD, stateVarDocD,
   fileDoc', docFuncRepr, commentDocD, commentedItem, functionDox, classDox, 
   moduleDox, getterName, setterName)
 import GOOL.Drasil.State (GOOLState, hasMain, mainMod, getPutReturnFunc, 
-  addFile, setMainMod)
+  addFile, setMainMod, setFilePath, getFilePath)
 
 import Prelude hiding (break,print,last,mod,pi,(<>))
 import Data.Maybe (maybeToList, isNothing)
@@ -51,7 +51,7 @@ fileFromData :: FileType -> FilePath -> State GOOLState ModData ->
   State GOOLState FileData
 fileFromData ft fp sm = getPutReturnFunc sm (\s m -> (if isEmpty (modDoc m) 
   then id else (if s ^. hasMain && isNothing (s ^. mainMod) then setMainMod fp 
-  else id) . addFile ft fp) s) (fileD fp)
+  else id) . addFile ft fp . setFilePath fp) s) (fileD fp)
 
 block :: (RenderSym repr) => repr (Keyword repr) -> [repr (Statement repr)] -> 
   repr (Block repr)
@@ -285,9 +285,9 @@ buildModule' n ms cs = modFromData n (any isMainMethod ms) (vibcat $ map
 fileDoc :: (RenderSym repr) => FileType -> String -> repr (Block repr) -> 
   repr (Block repr) -> repr (Module repr) -> repr (RenderFile repr)
 fileDoc ft ext topb botb m = S.fileFromData ft (addExt ext (moduleName m)) 
-  (updateModuleDoc (\d -> emptyIfEmpty d (fileDoc' (blockDoc topb) d (blockDoc botb))) m)
+  (updateModuleDoc (\d -> emptyIfEmpty d (fileDoc' (blockDoc topb) d (blockDoc 
+  botb))) m)
 
 docMod :: (RenderSym repr) => String -> [String] -> String -> 
   repr (RenderFile repr) -> repr (RenderFile repr)
-docMod d a dt m = commentedMod (docComment $ return $ moduleDox d a dt $ 
-  getFilePath m) m
+docMod d a dt m = commentedMod m (docComment $ moduleDox d a dt <$> getFilePath)

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer/LanguagePolymorphic.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer/LanguagePolymorphic.hs
@@ -285,8 +285,7 @@ buildModule' n ms cs = modFromData n (any isMainMethod ms) (vibcat $ map
 fileDoc :: (RenderSym repr) => FileType -> String -> repr (Block repr) -> 
   repr (Block repr) -> repr (Module repr) -> repr (RenderFile repr)
 fileDoc ft ext topb botb m = S.fileFromData ft (addExt ext (moduleName m)) 
-  (modFromData (moduleName m) (isMainModule m) (emptyIfEmpty (moduleDoc m) 
-  (fileDoc' (blockDoc topb) (moduleDoc m) (blockDoc botb))))
+  (updateModuleDoc (\d -> emptyIfEmpty d (fileDoc' (blockDoc topb) d (blockDoc botb))) m)
 
 docMod :: (RenderSym repr) => String -> [String] -> String -> 
   repr (RenderFile repr) -> repr (RenderFile repr)

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer/PythonRenderer.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer/PythonRenderer.hs
@@ -53,13 +53,13 @@ import qualified GOOL.Drasil.LanguageRenderer.LanguagePolymorphic as G (
   buildClass, privClass, pubClass, docClass, commentedClass, buildModule, 
   fileDoc, docMod)
 import GOOL.Drasil.Data (Terminator(..), FileType(..), FileData(..), 
-  FuncData(..), fd, ModData(..), md, updateModDoc, MethodData(..), mthd, updateMthdDoc, 
-  OpData(..), ParamData(..), ProgData(..), progD, TypeData(..), td, ValData(..),
-  vd, VarData(..), vard)
+  FuncData(..), fd, ModData(..), md, updateModDoc, MethodData(..), mthd, 
+  updateMthdDoc, OpData(..), ParamData(..), ProgData(..), progD, TypeData(..), 
+  td, ValData(..), vd, VarData(..), vard)
 import GOOL.Drasil.Helpers (emptyIfEmpty, liftA4, liftA5, liftA6, liftList, 
   lift1List, lift2Lists, checkParams)
 import GOOL.Drasil.State (GOOLState, initialState, getPutReturn, 
-  passState, passState2Lists, setMain)
+  passState2Lists, setMain)
 
 import Prelude hiding (break,print,sin,cos,tan,floor,(<>))
 import Data.Maybe (fromMaybe)

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer/PythonRenderer.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer/PythonRenderer.hs
@@ -100,7 +100,6 @@ instance InternalFile PythonCode where
   top _ = return pytop
   bottom = return empty
 
-  getFilePath = filePath . (`evalState` initialState) . unPC
   fileFromData ft fp = fmap (G.fileFromData ft fp)
 
 instance KeywordSym PythonCode where

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer/PythonRenderer.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer/PythonRenderer.hs
@@ -610,7 +610,7 @@ instance InternalMod PythonCode where
 
 instance BlockCommentSym PythonCode where
   type BlockComment PythonCode = State GOOLState Doc
-  blockComment lns = fmap (pyBlockComment lns) commentStart
+  blockComment lns = fmap (return . pyBlockComment lns) commentStart
   docComment lns = liftA2 (\dcs cs -> fmap (pyDocComment dcs cs) lns) docCommentStart commentStart
 
   blockCommentDoc = unPC
@@ -748,8 +748,8 @@ pyInOutCall f n ins outs both = if null rets then valState (f n void (map
   [f n void (map valueOf both ++ ins)]
   where rets = filterOutObjs both ++ outs
 
-pyBlockComment :: [String] -> Doc -> State GOOLState Doc
-pyBlockComment lns cmt = return $ vcat $ map ((<+>) cmt . text) lns
+pyBlockComment :: [String] -> Doc -> Doc
+pyBlockComment lns cmt = vcat $ map ((<+>) cmt . text) lns
 
 pyDocComment :: Doc -> Doc -> [String] -> Doc
 pyDocComment _ _ [] = empty

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer/PythonRenderer.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer/PythonRenderer.hs
@@ -53,7 +53,7 @@ import qualified GOOL.Drasil.LanguageRenderer.LanguagePolymorphic as G (
   buildClass, privClass, pubClass, docClass, commentedClass, buildModule, 
   fileDoc, docMod)
 import GOOL.Drasil.Data (Terminator(..), FileType(..), FileData(..), 
-  FuncData(..), fd, ModData(..), md, MethodData(..), mthd, updateMthdDoc, 
+  FuncData(..), fd, ModData(..), md, updateModDoc, MethodData(..), mthd, updateMthdDoc, 
   OpData(..), ParamData(..), ProgData(..), progD, TypeData(..), td, ValData(..),
   vd, VarData(..), vard)
 import GOOL.Drasil.Helpers (emptyIfEmpty, liftA4, liftA5, liftA6, liftList, 
@@ -90,8 +90,7 @@ instance ProgramSym PythonCode where
 
 instance RenderSym PythonCode where
   type RenderFile PythonCode = State GOOLState FileData
-  fileDoc code = liftA2 passState code (G.fileDoc Combined pyExt (top code) 
-    bottom code)
+  fileDoc code = G.fileDoc Combined pyExt (top code) bottom code
 
   docMod = G.docMod
 
@@ -608,6 +607,7 @@ instance InternalMod PythonCode where
   isMainModule = isMainMod . (`evalState` initialState) . unPC
   moduleDoc = modDoc . (`evalState` initialState) . unPC
   modFromData n m d = return $ return $ md n m d
+  updateModuleDoc f = fmap (fmap (updateModDoc f))
 
 instance BlockCommentSym PythonCode where
   type BlockComment PythonCode = State GOOLState Doc

--- a/code/drasil-gool/GOOL/Drasil/State.hs
+++ b/code/drasil-gool/GOOL/Drasil/State.hs
@@ -7,7 +7,6 @@ module GOOL.Drasil.State (
   addProgNameToPaths, setMain, setMainMod
 ) where
 
-import GOOL.Drasil.Symantics (Label)
 import GOOL.Drasil.Data (FileType(..))
 
 import Control.Lens (makeLenses,over,set)
@@ -86,7 +85,7 @@ addSource fp = over sources (\s -> if fp `elem` s then
 addCombinedHeaderSource :: FilePath -> GOOLState -> GOOLState
 addCombinedHeaderSource fp = addSource fp . addHeader fp 
 
-addProgNameToPaths :: Label -> GOOLState -> GOOLState
+addProgNameToPaths :: String -> GOOLState -> GOOLState
 addProgNameToPaths n = over mainMod (fmap f) . over sources (map f) . 
   over headers (map f)
   where f = ((n++"/")++)

--- a/code/drasil-gool/GOOL/Drasil/State.hs
+++ b/code/drasil-gool/GOOL/Drasil/State.hs
@@ -4,19 +4,21 @@ module GOOL.Drasil.State (
   GOOLState(..), headers, sources, hasMain, mainMod, initialState, getPutReturn,
   getPutReturnFunc, getPutReturnList, passState, passState2Lists, 
   checkGOOLState, addFile, addCombinedHeaderSource, addHeader, addSource, 
-  addProgNameToPaths, setMain, setMainMod
+  addProgNameToPaths, setMain, setMainMod, setFilePath, getFilePath
 ) where
 
 import GOOL.Drasil.Data (FileType(..))
 
-import Control.Lens (makeLenses,over,set)
-import Control.Monad.State (State, get, put)
+import Control.Lens (makeLenses,over,set,(^.))
+import Control.Monad.State (State, get, put, gets)
 
 data GOOLState = GS {
   _headers :: [FilePath],
   _sources :: [FilePath],
   _hasMain :: Bool,
-  _mainMod :: Maybe FilePath
+  _mainMod :: Maybe FilePath,
+
+  _currFilePath :: FilePath
 } 
 makeLenses ''GOOLState
 
@@ -25,7 +27,9 @@ initialState = GS {
   _headers = [],
   _sources = [],
   _hasMain = False,
-  _mainMod = Nothing
+  _mainMod = Nothing,
+
+  _currFilePath = ""
 }
 
 getPutReturn :: (GOOLState -> GOOLState) -> a -> State GOOLState a
@@ -91,8 +95,14 @@ addProgNameToPaths n = over mainMod (fmap f) . over sources (map f) .
   where f = ((n++"/")++)
 
 setMain :: GOOLState -> GOOLState
-setMain = over hasMain (\b -> if b then error "Multiple main functions defined" 
+setMain = over hasMain (\b -> if b then error "Multiple main functions defined"
   else not b)
 
 setMainMod :: String -> GOOLState -> GOOLState
 setMainMod n = set mainMod (Just n)
+
+setFilePath :: FilePath -> GOOLState -> GOOLState
+setFilePath = set currFilePath
+
+getFilePath :: State GOOLState FilePath
+getFilePath = gets (^. currFilePath)

--- a/code/drasil-gool/GOOL/Drasil/Symantics.hs
+++ b/code/drasil-gool/GOOL/Drasil/Symantics.hs
@@ -673,6 +673,7 @@ class InternalMod repr where
   isMainModule :: repr (Module repr) -> Bool
   moduleDoc :: repr (Module repr) -> Doc
   modFromData :: String -> Bool -> Doc -> repr (Module repr)
+  updateModuleDoc :: (Doc -> Doc) -> repr (Module repr) -> repr (Module repr)
     
 class BlockCommentSym repr where
   type BlockComment repr

--- a/code/drasil-gool/GOOL/Drasil/Symantics.hs
+++ b/code/drasil-gool/GOOL/Drasil/Symantics.hs
@@ -19,6 +19,8 @@ module GOOL.Drasil.Symantics (
 
 import GOOL.Drasil.CodeType (CodeType)
 import GOOL.Drasil.Data (Binding, Terminator, FileType)
+import GOOL.Drasil.State (GOOLState)
+import Control.Monad.State (State)
 import Text.PrettyPrint.HughesPJ (Doc)
 
 type Label = String
@@ -658,7 +660,7 @@ class (MethodSym repr, InternalClass repr) => ClassSym repr
 
 class InternalClass repr where
   classDoc :: repr (Class repr) -> Doc
-  classFromData :: Doc -> repr (Class repr)
+  classFromData :: State GOOLState Doc -> repr (Class repr)
 
 class (ClassSym repr, InternalMod repr) => ModuleSym repr where
   type Module repr
@@ -675,6 +677,6 @@ class InternalMod repr where
 class BlockCommentSym repr where
   type BlockComment repr
   blockComment :: [String] -> repr (BlockComment repr)
-  docComment :: [String] -> repr (BlockComment repr)
+  docComment :: State GOOLState [String] -> repr (BlockComment repr)
 
-  blockCommentDoc :: repr (BlockComment repr) -> Doc
+  blockCommentDoc :: repr (BlockComment repr) -> State GOOLState Doc

--- a/code/drasil-gool/GOOL/Drasil/Symantics.hs
+++ b/code/drasil-gool/GOOL/Drasil/Symantics.hs
@@ -39,14 +39,13 @@ class (ModuleSym repr, InternalFile repr) =>
   docMod :: String -> [String] -> String -> repr (RenderFile repr) -> 
     repr (RenderFile repr)
 
-  commentedMod :: repr (BlockComment repr) -> repr (RenderFile repr) ->
+  commentedMod :: repr (RenderFile repr) -> repr (BlockComment repr) -> 
     repr (RenderFile repr)
 
 class InternalFile repr where
   top :: repr (Module repr) -> repr (Block repr)
   bottom :: repr (Block repr)
 
-  getFilePath :: repr (RenderFile repr) -> FilePath
   fileFromData :: FileType -> FilePath -> repr (Module repr) -> 
     repr (RenderFile repr)
 


### PR DESCRIPTION
@JacquesCarette I'm looking for feedback on what I did here, specifically in 323e4ef, before I continue down this path.

I'm trying to do what we talked about here: https://github.com/JacquesCarette/Drasil/pull/1956#issuecomment-552482087

When I updated `getFilePath` to return `State GOOLState FilePath` instead of just `FilePath`, I started getting errors saying that multiple main functions were defined, even though that wasn't the case.

I eventually figured out this was happening because the single `mainFunction` was essentially getting run twice, where the second time was happening in `getFilePath`. It's complicated, but basically since `getFilePath` needed to return the `FilePath` which it gets from reading the passed `FileData`, that required an extra evaluation of the entire passed `Module`. If that doesn't make much sense, here is some Haskell-style pseudocode I put together that shows how the `State` evolves from methods/classes to program, as if it were happening all in one function:
```
theGoolProgram = do
  files <- sequence (
    cmt <- (
      lns <- (
        fp <- (
          file' <- (                           -- ****first evaluation of the passed file****
            mod <- (
              methods <- sequence ()
              classes <- sequence ()
              return $ md n m d
            )
            updatedMod <- return $ md n m d
            s <- get
            put $ setMainMod s mod
            return $ vf mod
          )
          return $ filePath file'
        )
        return $ moduleDox fp
      )
      return $ pyDocComment lns
    )
    file <- (                              -- ****second evaluation of the passed file****
      mod <- (
        methods <- sequence ()
        classes <- sequence ()
        return $ md n m d
      )
      updatedMod <- return $ md n m d
      s <- get
      put $ setMainMod s mod
      return $ vf mod
    )
    return $ commentedModD cmt mod
  )
  return $ progD n files
```

This problem would only get worse as I changed more accessors to be stateful -- each time one was used, it would cause an extra evaluation of the passed value.

To fix this, I decided I should store directly in the `State` any information that we have an accessor for. So, for example, in 323e4ef, I added the "current file path" to the State. Then `getFilePath`, instead of being part of a GOOL typeclass, is just a regular function that reads the current file path from the `State` and returns the result also in `State` (This means that we can only get the current file path instead of getting the file path for any specific `File` we pass in, but our only use case for this function was to get the current file path, so I think that's okay). Then I had to switch the order of the parameters to `commentedMod` so that the `File` came first and the `BlockComment` second -- that way, the evaluation of the `File` updates the current file path in the state, and then the evaluation of the `BlockComment` can read the (up to date) current file path and include it in the comment. It seems unexpectedly fragile that the order of the parameters has such an impact, but maybe that's just something we have to live with when using the `State` monad?

I would do something similar for all of the other accessors, if you think this is the right way to move forward.