### PR TITLE
Zoom into and out of MethodState

### DIFF
--- a/code/drasil-code/Language/Drasil/Code/Imperative/Comments.hs
+++ b/code/drasil-code/Language/Drasil/Code/Imperative/Comments.hs
@@ -4,7 +4,7 @@ module Language.Drasil.Code.Imperative.Comments (
 
 import Language.Drasil
 import Database.Drasil (defTable)
-import Language.Drasil.Code.Imperative.State (State(..))
+import Language.Drasil.Code.Imperative.State (DrasilState(..))
 import Language.Drasil.CodeSpec (CodeSpec(..), CodeSystInfo(..))
 import Language.Drasil.Printers (Linearity(Linear), sentenceDoc, unitDoc)
 
@@ -16,14 +16,14 @@ import Control.Lens (view)
 import Text.PrettyPrint.HughesPJ (Doc, (<+>), colon, empty, parens, render, 
   text)
 
-getTermDoc :: (NamedIdea c) => UID -> Map UID c -> Reader State Doc
+getTermDoc :: (NamedIdea c) => UID -> Map UID c -> Reader DrasilState Doc
 getTermDoc cname m = do
   g <- ask
   let db = sysinfodb $ csi $ codeSpec g
   return $ (maybe (text "No description given") (sentenceDoc db 
     Implementation Linear . phraseNP . view term) . Map.lookup cname) m
 
-getDefnDoc :: UID -> Reader State Doc
+getDefnDoc :: UID -> Reader DrasilState Doc
 getDefnDoc cname = do
   g <- ask
   let db = sysinfodb $ csi $ codeSpec g
@@ -35,20 +35,20 @@ getUnitsDoc cname m = maybe empty (parens . unitDoc Linear . usymb)
   (Map.lookup cname m >>= getUnit)
 
 getComment :: (NamedIdea c, MayHaveUnit c) => UID -> Map UID c -> 
-  Reader State String
+  Reader DrasilState String
 getComment l m = do
   t <- getTermDoc l m
   d <- getDefnDoc l
   let u = getUnitsDoc l m
   return $ render $ (t <> d) <+> u
 
-paramComment :: UID -> Reader State String
+paramComment :: UID -> Reader DrasilState String
 paramComment l = do
   g <- ask
   let m = vMap $ codeSpec g
   getComment l m
 
-returnComment :: UID -> Reader State String
+returnComment :: UID -> Reader DrasilState String
 returnComment l = do
   g <- ask
   let m = fMap $ codeSpec g

--- a/code/drasil-code/Language/Drasil/Code/Imperative/Descriptions.hs
+++ b/code/drasil-code/Language/Drasil/Code/Imperative/Descriptions.hs
@@ -8,7 +8,7 @@ module Language.Drasil.Code.Imperative.Descriptions (
 import Utils.Drasil (stringList)
 
 import Language.Drasil
-import Language.Drasil.Code.Imperative.State (State(..))
+import Language.Drasil.Code.Imperative.State (DrasilState(..))
 import Language.Drasil.Chunk.Code (CodeIdea(codeName))
 import Language.Drasil.CodeSpec (CodeSpec(..), CodeSystInfo(..), 
   InputModule(..), Structure(..))
@@ -17,10 +17,10 @@ import Data.Map (member)
 import qualified Data.Map as Map (filter, lookup, elems)
 import Control.Monad.Reader (Reader, ask)
 
-modDesc :: Reader State [String] -> Reader State String
+modDesc :: Reader DrasilState [String] -> Reader DrasilState String
 modDesc = fmap ((++) "Provides " . stringList)
 
-inputParametersDesc :: Reader State [String]
+inputParametersDesc :: Reader DrasilState [String]
 inputParametersDesc = do
   g <- ask
   ifDesc <- inputFormatDesc
@@ -34,7 +34,7 @@ inputParametersDesc = do
       inDesc Unbundled = [""]
   return $ ipDesc im
 
-inputConstructorDesc :: Reader State String
+inputConstructorDesc :: Reader DrasilState String
 inputConstructorDesc = do
   g <- ask
   pAndS <- physAndSfwrCons
@@ -50,21 +50,21 @@ inputConstructorDesc = do
     idDesc (member "derived_values" dm),
     icDesc (member "input_constraints" dm)]
 
-inputFormatDesc :: Reader State String
+inputFormatDesc :: Reader DrasilState String
 inputFormatDesc = do
   g <- ask
   let ifDesc Nothing = ""
       ifDesc _ = "the function for reading inputs"
   return $ ifDesc $ Map.lookup "get_input" (eMap $ codeSpec g)
 
-derivedValuesDesc :: Reader State String
+derivedValuesDesc :: Reader DrasilState String
 derivedValuesDesc = do
   g <- ask
   let dvDesc Nothing = ""
       dvDesc _ = "the function for calculating derived values"
   return $ dvDesc $ Map.lookup "derived_values" (eMap $ codeSpec g)
 
-inputConstraintsDesc :: Reader State String
+inputConstraintsDesc :: Reader DrasilState String
 inputConstraintsDesc = do
   g <- ask
   pAndS <- physAndSfwrCons
@@ -73,7 +73,7 @@ inputConstraintsDesc = do
         " on the input"
   return $ icDesc $ Map.lookup "input_constraints" (eMap $ codeSpec g)
 
-constModDesc :: Reader State String
+constModDesc :: Reader DrasilState String
 constModDesc = do
   g <- ask
   let cDesc [] = ""
@@ -81,14 +81,14 @@ constModDesc = do
   return $ cDesc $ filter (flip member (eMap $ codeSpec g) . codeName) 
     (constants $ csi $ codeSpec g)
 
-outputFormatDesc :: Reader State String
+outputFormatDesc :: Reader DrasilState String
 outputFormatDesc = do
   g <- ask
   let ofDesc Nothing = ""
       ofDesc _ = "the function for writing outputs"
   return $ ofDesc $ Map.lookup "write_output" (eMap $ codeSpec g)
 
-inputClassDesc :: Reader State String
+inputClassDesc :: Reader DrasilState String
 inputClassDesc = do
   g <- ask
   let cname = "InputParameters"
@@ -106,7 +106,7 @@ inputClassDesc = do
       cVs _ = "constant values"
   return $ inClassD $ inputs $ csi $ codeSpec g
 
-constClassDesc :: Reader State String
+constClassDesc :: Reader DrasilState String
 constClassDesc = do
   g <- ask
   let ccDesc [] = ""
@@ -114,14 +114,14 @@ constClassDesc = do
   return $ ccDesc $ filter (flip member (eMap $ codeSpec g) . codeName) 
     (constants $ csi $ codeSpec g)
 
-inFmtFuncDesc :: Reader State String
+inFmtFuncDesc :: Reader DrasilState String
 inFmtFuncDesc = do
   g <- ask
   let ifDesc Nothing = ""
       ifDesc _ = "Reads input from a file with the given file name"
   return $ ifDesc $ Map.lookup "get_input" (defMap $ codeSpec g)
 
-inConsFuncDesc :: Reader State String
+inConsFuncDesc :: Reader DrasilState String
 inConsFuncDesc = do
   g <- ask
   pAndS <- physAndSfwrCons
@@ -129,7 +129,7 @@ inConsFuncDesc = do
       icDesc _ = "Verifies that input values satisfy the " ++ pAndS
   return $ icDesc $ Map.lookup "input_constraints" (defMap $ codeSpec g)
 
-dvFuncDesc :: Reader State String
+dvFuncDesc :: Reader DrasilState String
 dvFuncDesc = do
   g <- ask
   let dvDesc Nothing = ""
@@ -137,14 +137,14 @@ dvFuncDesc = do
         " inputs"
   return $ dvDesc $ Map.lookup "derived_values" (defMap $ codeSpec g)
 
-woFuncDesc :: Reader State String
+woFuncDesc :: Reader DrasilState String
 woFuncDesc = do
   g <- ask
   let woDesc Nothing = ""
       woDesc _ = "Writes the output values to output.txt"
   return $ woDesc $ Map.lookup "write_output" (defMap $ codeSpec g)
 
-physAndSfwrCons :: Reader State String
+physAndSfwrCons :: Reader DrasilState String
 physAndSfwrCons = do
   g <- ask
   let cns = concat $ Map.elems (cMap $ csi $ codeSpec g)

--- a/code/drasil-code/Language/Drasil/Code/Imperative/GenerateGOOL.hs
+++ b/code/drasil-code/Language/Drasil/Code/Imperative/GenerateGOOL.hs
@@ -3,7 +3,7 @@ module Language.Drasil.Code.Imperative.GenerateGOOL (
 ) where
 
 import Language.Drasil
-import Language.Drasil.Code.Imperative.State (State(..))
+import Language.Drasil.Code.Imperative.State (DrasilState(..))
 import Language.Drasil.Code.Imperative.GOOL.Symantics (AuxiliarySym(..))
 import Language.Drasil.CodeSpec (CodeSpec(..), CodeSystInfo(..), Comments(..), 
   Name)
@@ -18,9 +18,9 @@ import Data.Maybe (fromMaybe, maybe)
 import Control.Monad.Reader (Reader, ask, withReader)
 
 genModule :: (RenderSym repr) => Name -> String
-  -> Maybe (Reader State [GS (repr (Method repr))])
-  -> Maybe (Reader State [GS (repr (Class repr))])
-  -> Reader State (GS (repr (RenderFile repr)))
+  -> Maybe (Reader DrasilState [GS (repr (Method repr))])
+  -> Maybe (Reader DrasilState [GS (repr (Class repr))])
+  -> Reader DrasilState (GS (repr (RenderFile repr)))
 genModule n desc maybeMs maybeCs = do
   g <- ask
   let ls = fromMaybe [] (Map.lookup n (dMap $ codeSpec g))
@@ -37,7 +37,7 @@ genModule n desc maybeMs maybeCs = do
   return $ commMod $ fileDoc $ buildModule n ls ms cs
 
 genDoxConfig :: (AuxiliarySym repr) => String -> GOOLState ->
-  Reader State [repr (Auxiliary repr)]
+  Reader DrasilState [repr (Auxiliary repr)]
 genDoxConfig n s = do
   g <- ask
   let cms = commented g
@@ -45,8 +45,8 @@ genDoxConfig n s = do
   return [doxConfig n s v | not (null cms)]
 
 publicClass :: (RenderSym repr) => String -> Label -> Maybe Label -> 
-  [GS (repr (StateVar repr))] -> Reader State [GS (repr (Method repr))] -> 
-  Reader State (GS (repr (Class repr)))
+  [GS (repr (StateVar repr))] -> Reader DrasilState [GS (repr (Method repr))] -> 
+  Reader DrasilState (GS (repr (Class repr)))
 publicClass desc n l vs mths = do
   g <- ask
   ms <- mths
@@ -55,7 +55,7 @@ publicClass desc n l vs mths = do
     else pubClass n l vs ms
 
 fApp :: (RenderSym repr) => String -> String -> repr (Type repr) -> 
-  [repr (Value repr)] -> Reader State (repr (Value repr))
+  [repr (Value repr)] -> Reader DrasilState (repr (Value repr))
 fApp m s t vl = do
   g <- ask
   let cm = currentModule g
@@ -64,7 +64,7 @@ fApp m s t vl = do
 
 fAppInOut :: (RenderSym repr) => String -> String -> [repr (Value repr)] -> 
   [repr (Variable repr)] -> [repr (Variable repr)] -> 
-  Reader State (repr (Statement repr))
+  Reader DrasilState (repr (Statement repr))
 fAppInOut m n ins outs both = do
   g <- ask
   let cm = currentModule g

--- a/code/drasil-code/Language/Drasil/Code/Imperative/GenerateGOOL.hs
+++ b/code/drasil-code/Language/Drasil/Code/Imperative/GenerateGOOL.hs
@@ -11,14 +11,14 @@ import Language.Drasil.CodeSpec (CodeSpec(..), CodeSystInfo(..), Comments(..),
 import GOOL.Drasil (Label, RenderSym(..), TypeSym(..), 
   VariableSym(..), ValueSym(..), ValueExpression(..), StatementSym(..), 
   ParameterSym(..), MethodSym(..), StateVarSym(..), ClassSym(..), ModuleSym(..),
-  CodeType(..), GOOLState, GS)
+  CodeType(..), GOOLState, GS, MS)
 
 import qualified Data.Map as Map (lookup)
 import Data.Maybe (fromMaybe, maybe)
 import Control.Monad.Reader (Reader, ask, withReader)
 
 genModule :: (RenderSym repr) => Name -> String
-  -> Maybe (Reader DrasilState [GS (repr (Method repr))])
+  -> Maybe (Reader DrasilState [MS (repr (Method repr))])
   -> Maybe (Reader DrasilState [GS (repr (Class repr))])
   -> Reader DrasilState (GS (repr (RenderFile repr)))
 genModule n desc maybeMs maybeCs = do
@@ -45,7 +45,7 @@ genDoxConfig n s = do
   return [doxConfig n s v | not (null cms)]
 
 publicClass :: (RenderSym repr) => String -> Label -> Maybe Label -> 
-  [GS (repr (StateVar repr))] -> Reader DrasilState [GS (repr (Method repr))] -> 
+  [GS (repr (StateVar repr))] -> Reader DrasilState [MS (repr (Method repr))] -> 
   Reader DrasilState (GS (repr (Class repr)))
 publicClass desc n l vs mths = do
   g <- ask

--- a/code/drasil-code/Language/Drasil/Code/Imperative/GenerateGOOL.hs
+++ b/code/drasil-code/Language/Drasil/Code/Imperative/GenerateGOOL.hs
@@ -11,16 +11,16 @@ import Language.Drasil.CodeSpec (CodeSpec(..), CodeSystInfo(..), Comments(..),
 import GOOL.Drasil (Label, RenderSym(..), TypeSym(..), 
   VariableSym(..), ValueSym(..), ValueExpression(..), StatementSym(..), 
   ParameterSym(..), MethodSym(..), StateVarSym(..), ClassSym(..), ModuleSym(..),
-  CodeType(..), GOOLState)
+  CodeType(..), GOOLState, GS)
 
 import qualified Data.Map as Map (lookup)
 import Data.Maybe (fromMaybe, maybe)
 import Control.Monad.Reader (Reader, ask, withReader)
 
 genModule :: (RenderSym repr) => Name -> String
-  -> Maybe (Reader State [repr (Method repr)])
-  -> Maybe (Reader State [repr (Class repr)])
-  -> Reader State (repr (RenderFile repr))
+  -> Maybe (Reader State [GS (repr (Method repr))])
+  -> Maybe (Reader State [GS (repr (Class repr))])
+  -> Reader State (GS (repr (RenderFile repr)))
 genModule n desc maybeMs maybeCs = do
   g <- ask
   let ls = fromMaybe [] (Map.lookup n (dMap $ codeSpec g))
@@ -45,8 +45,8 @@ genDoxConfig n s = do
   return [doxConfig n s v | not (null cms)]
 
 publicClass :: (RenderSym repr) => String -> Label -> Maybe Label -> 
-  [repr (StateVar repr)] -> Reader State [repr (Method repr)] -> 
-  Reader State (repr (Class repr))
+  [GS (repr (StateVar repr))] -> Reader State [GS (repr (Method repr))] -> 
+  Reader State (GS (repr (Class repr)))
 publicClass desc n l vs mths = do
   g <- ask
   ms <- mths

--- a/code/drasil-code/Language/Drasil/Code/Imperative/Generator.hs
+++ b/code/drasil-code/Language/Drasil/Code/Imperative/Generator.hs
@@ -1,5 +1,5 @@
 module Language.Drasil.Code.Imperative.Generator (
-  State(..), generator, generateCode
+  generator, generateCode
 ) where
 
 import Language.Drasil
@@ -8,7 +8,7 @@ import Language.Drasil.Code.Imperative.GenerateGOOL (genDoxConfig)
 import Language.Drasil.Code.Imperative.Import (genModDef)
 import Language.Drasil.Code.Imperative.Modules (chooseInModule, genConstMod, 
   genMain, genOutputMod, genSampleInput)
-import Language.Drasil.Code.Imperative.State (State(..))
+import Language.Drasil.Code.Imperative.State (DrasilState(..))
 import Language.Drasil.Code.Imperative.GOOL.Symantics (PackageSym(..), 
   AuxiliarySym(..))
 import Language.Drasil.Code.Imperative.GOOL.Data (PackData(..))
@@ -25,8 +25,8 @@ import System.Directory (setCurrentDirectory, createDirectoryIfMissing,
 import Control.Monad.Reader (Reader, ask, runReader)
 import Control.Monad.State (evalState, execState)
 
-generator :: String -> [Expr] -> Choices -> CodeSpec -> State
-generator dt sd chs spec = State {
+generator :: String -> [Expr] -> Choices -> CodeSpec -> DrasilState
+generator dt sd chs spec = DrasilState {
   -- constants
   codeSpec = spec,
   date = showDate $ dates chs,
@@ -53,7 +53,7 @@ generator dt sd chs spec = State {
 
 generateCode :: (ProgramSym progRepr, PackageSym packRepr) => Lang -> 
   (progRepr (Program progRepr) -> ProgData) -> (packRepr (Package packRepr) -> 
-  PackData) -> State -> IO ()
+  PackData) -> DrasilState -> IO ()
 generateCode l unReprProg unReprPack g = do 
   workingDir <- getCurrentDirectory
   createDirectoryIfMissing False (getDir l)
@@ -66,7 +66,7 @@ generateCode l unReprProg unReprPack g = do
 
 genPackage :: (ProgramSym progRepr, PackageSym packRepr) => 
   (progRepr (Program progRepr) -> ProgData) -> 
-  Reader State (packRepr (Package packRepr))
+  Reader DrasilState (packRepr (Package packRepr))
 genPackage unRepr = do
   g <- ask
   p <- genProgram
@@ -78,7 +78,7 @@ genPackage unRepr = do
   d <- genDoxConfig n s
   return $ package pd (m:i++d)
 
-genProgram :: (ProgramSym repr) => Reader State (GS (repr (Program repr)))
+genProgram :: (ProgramSym repr) => Reader DrasilState (GS (repr (Program repr)))
 genProgram = do
   g <- ask
   ms <- genModules
@@ -86,7 +86,7 @@ genProgram = do
   let n = case codeSpec g of CodeSpec {program = p} -> programName p
   return $ prog n ms
           
-genModules :: (RenderSym repr) => Reader State [GS (repr (RenderFile repr))]
+genModules :: (RenderSym repr) => Reader DrasilState [GS (repr (RenderFile repr))]
 genModules = do
   g <- ask
   let s = csi $ codeSpec g

--- a/code/drasil-code/Language/Drasil/Code/Imperative/Generator.hs
+++ b/code/drasil-code/Language/Drasil/Code/Imperative/Generator.hs
@@ -24,7 +24,6 @@ import System.Directory (setCurrentDirectory, createDirectoryIfMissing,
   getCurrentDirectory)
 import Control.Monad.Reader (Reader, ask, runReader)
 import Control.Monad.State (evalState, execState)
-import qualified Control.Monad.State as S (State)
 
 generator :: String -> [Expr] -> Choices -> CodeSpec -> State
 generator dt sd chs spec = State {
@@ -53,7 +52,7 @@ generator dt sd chs spec = State {
         showDate Hide = ""
 
 generateCode :: (ProgramSym progRepr, PackageSym packRepr) => Lang -> 
-  (progRepr (Program progRepr) -> S.State GOOLState ProgData) -> (packRepr (Package packRepr) -> 
+  (progRepr (Program progRepr) -> ProgData) -> (packRepr (Package packRepr) -> 
   PackData) -> State -> IO ()
 generateCode l unReprProg unReprPack g = do 
   workingDir <- getCurrentDirectory
@@ -66,7 +65,7 @@ generateCode l unReprProg unReprPack g = do
           unReprPack pckg)
 
 genPackage :: (ProgramSym progRepr, PackageSym packRepr) => 
-  (progRepr (Program progRepr) -> S.State GOOLState ProgData) -> 
+  (progRepr (Program progRepr) -> ProgData) -> 
   Reader State (packRepr (Package packRepr))
 genPackage unRepr = do
   g <- ask

--- a/code/drasil-code/Language/Drasil/Code/Imperative/Generator.hs
+++ b/code/drasil-code/Language/Drasil/Code/Imperative/Generator.hs
@@ -17,7 +17,7 @@ import Language.Drasil.Chunk.Code (programName)
 import Language.Drasil.CodeSpec (CodeSpec(..), CodeSystInfo(..), Choices(..), 
   Lang(..), Visibility(..))
 
-import GOOL.Drasil (ProgramSym(..), RenderSym(..), ProgData(..), GOOLState, 
+import GOOL.Drasil (ProgramSym(..), RenderSym(..), ProgData(..), GS, 
   initialState)
 
 import System.Directory (setCurrentDirectory, createDirectoryIfMissing, 
@@ -70,16 +70,15 @@ genPackage :: (ProgramSym progRepr, PackageSym packRepr) =>
 genPackage unRepr = do
   g <- ask
   p <- genProgram
-  let sp = unRepr p   
-      s = execState sp initialState
-      pd = evalState sp initialState
+  let s = execState p initialState
+      pd = unRepr $ evalState p initialState
       n = case codeSpec g of CodeSpec {program = pr} -> programName pr
       m = makefile (commented g) s pd
   i <- genSampleInput
   d <- genDoxConfig n s
   return $ package pd (m:i++d)
 
-genProgram :: (ProgramSym repr) => Reader State (repr (Program repr))
+genProgram :: (ProgramSym repr) => Reader State (GS (repr (Program repr)))
 genProgram = do
   g <- ask
   ms <- genModules
@@ -87,7 +86,7 @@ genProgram = do
   let n = case codeSpec g of CodeSpec {program = p} -> programName p
   return $ prog n ms
           
-genModules :: (RenderSym repr) => Reader State [repr (RenderFile repr)]
+genModules :: (RenderSym repr) => Reader State [GS (repr (RenderFile repr))]
 genModules = do
   g <- ask
   let s = csi $ codeSpec g

--- a/code/drasil-code/Language/Drasil/Code/Imperative/Helpers.hs
+++ b/code/drasil-code/Language/Drasil/Code/Imperative/Helpers.hs
@@ -4,7 +4,7 @@ module Language.Drasil.Code.Imperative.Helpers (
 
 import Language.Drasil
 import Database.Drasil (symbResolve)
-import Language.Drasil.Code.Imperative.State (State(..))
+import Language.Drasil.Code.Imperative.State (DrasilState(..))
 import Language.Drasil.CodeSpec (CodeSpec(..), CodeSystInfo(..))
 
 import Control.Monad.Reader (Reader)
@@ -16,5 +16,5 @@ getUpperBound :: Expr -> Expr
 getUpperBound (BinaryOp Lt _ b) = b
 getUpperBound _ = error "Attempt to get upper bound of invalid expression"
 
-lookupC :: State -> UID -> QuantityDict
+lookupC :: DrasilState -> UID -> QuantityDict
 lookupC g = symbResolve (sysinfodb $ csi $ codeSpec g)

--- a/code/drasil-code/Language/Drasil/Code/Imperative/Import.hs
+++ b/code/drasil-code/Language/Drasil/Code/Imperative/Import.hs
@@ -33,7 +33,7 @@ import GOOL.Drasil (Label, RenderSym(..), PermanenceSym(..), BodySym(..),
   NumericExpression(..), BooleanExpression(..), ValueExpression(..), 
   FunctionSym(..), SelectorFunction(..), StatementSym(..), 
   ControlStatementSym(..), ScopeSym(..), ParameterSym(..), MethodSym(..), 
-  convType, GS) 
+  convType, GS, MS) 
 import qualified GOOL.Drasil as C (CodeType(List))
 
 import Prelude hiding (sin, cos, tan, log, exp)
@@ -116,34 +116,34 @@ mkVar v = variable (codeName v) (convType $ codeType v)
 
 publicFunc :: (RenderSym repr, HasUID c, HasCodeType c, CodeIdea c) => 
   Label -> repr (Type repr) -> String -> [c] -> Maybe String -> 
-  [repr (Block repr)] -> Reader DrasilState (GS (repr (Method repr)))
+  [repr (Block repr)] -> Reader DrasilState (MS (repr (Method repr)))
 publicFunc n t = genMethod (function n public static_ t) n
 
 privateMethod :: (RenderSym repr, HasUID c, HasCodeType c, CodeIdea c) => 
   Label -> Label -> repr (Type repr) -> String -> [c] -> Maybe String -> 
-  [repr (Block repr)] -> Reader DrasilState (GS (repr (Method repr)))
+  [repr (Block repr)] -> Reader DrasilState (MS (repr (Method repr)))
 privateMethod c n t = genMethod (method n c private dynamic_ t) n
 
 publicInOutFunc :: (RenderSym repr, HasUID c, HasCodeType c, CodeIdea c, Eq c) 
   => Label -> String -> [c] -> [c] -> [repr (Block repr)] -> 
-  Reader DrasilState (GS (repr (Method repr)))
+  Reader DrasilState (MS (repr (Method repr)))
 publicInOutFunc n = genInOutFunc (inOutFunc n) (docInOutFunc n) public static_ n
 
 privateInOutMethod :: (RenderSym repr, HasUID c, HasCodeType c, CodeIdea c,
   Eq c) => Label -> Label -> String -> [c] -> [c] -> [repr (Block repr)] -> 
-  Reader DrasilState (GS (repr (Method repr)))
+  Reader DrasilState (MS (repr (Method repr)))
 privateInOutMethod c n = genInOutFunc (inOutMethod n c) (docInOutMethod n c) 
   private dynamic_ n
 
 genConstructor :: (RenderSym repr, HasUID c, HasCodeType c, CodeIdea c) => 
   Label -> String -> [c] -> [repr (Block repr)] -> 
-  Reader DrasilState (GS (repr (Method repr)))
+  Reader DrasilState (MS (repr (Method repr)))
 genConstructor n desc p = genMethod (constructor n) n desc p Nothing
 
 genMethod :: (RenderSym repr, HasUID c, HasCodeType c, CodeIdea c) => 
-  ([repr (Parameter repr)] -> repr (Body repr) -> GS (repr (Method repr))) -> 
+  ([repr (Parameter repr)] -> repr (Body repr) -> MS (repr (Method repr))) -> 
   Label -> String -> [c] -> Maybe String -> [repr (Block repr)] -> 
-  Reader DrasilState (GS (repr (Method repr)))
+  Reader DrasilState (MS (repr (Method repr)))
 genMethod f n desc p r b = do
   g <- ask
   vars <- mapM mkVar p
@@ -157,13 +157,13 @@ genMethod f n desc p r b = do
 genInOutFunc :: (RenderSym repr, HasUID c, HasCodeType c, CodeIdea c, Eq c) => 
   (repr (Scope repr) -> repr (Permanence repr) -> [repr (Variable repr)] -> 
     [repr (Variable repr)] -> [repr (Variable repr)] -> repr (Body repr) -> 
-    GS (repr (Method repr))) -> 
+    MS (repr (Method repr))) -> 
   (repr (Scope repr) -> repr (Permanence repr) -> String -> 
     [(String, repr (Variable repr))] -> [(String, repr (Variable repr))] -> 
     [(String, repr (Variable repr))] -> repr (Body repr) -> 
-    GS (repr (Method repr))) -> 
+    MS (repr (Method repr))) -> 
   repr (Scope repr) -> repr (Permanence repr) -> Label -> String -> [c] -> 
-  [c] -> [repr (Block repr)] -> Reader DrasilState (GS (repr (Method repr)))
+  [c] -> [repr (Block repr)] -> Reader DrasilState (MS (repr (Method repr)))
 genInOutFunc f docf s pr n desc ins' outs' b = do
   g <- ask
   let ins = ins' \\ outs'
@@ -277,7 +277,7 @@ bfunc Index = listAccess
 ------- CALC ----------
 
 genCalcFunc :: (RenderSym repr) => CodeDefinition -> 
-  Reader DrasilState (GS (repr (Method repr)))
+  Reader DrasilState (MS (repr (Method repr)))
 genCalcFunc cdef = do
   parms <- getCalcParams cdef
   let nm = codeName cdef
@@ -322,7 +322,7 @@ genModDef :: (RenderSym repr) => Mod ->
   Reader DrasilState (GS (repr (RenderFile repr)))
 genModDef (Mod n desc fs) = genModule n desc (Just $ mapM genFunc fs) Nothing
 
-genFunc :: (RenderSym repr) => Func -> Reader DrasilState (GS (repr (Method repr)))
+genFunc :: (RenderSym repr) => Func -> Reader DrasilState (MS (repr (Method repr)))
 genFunc (FDef (FuncDef n desc parms o rd s)) = do
   g <- ask
   stmts <- mapM convStmt s
@@ -378,7 +378,7 @@ convStmt (FAppend a b) = do
   return $ valState $ listAppend a' b'
 
 genDataFunc :: (RenderSym repr) => Name -> String -> DataDesc -> 
-  Reader DrasilState (GS (repr (Method repr)))
+  Reader DrasilState (MS (repr (Method repr)))
 genDataFunc nameTitle desc ddef = do
   let parms = getInputs ddef
   bod <- readData ddef

--- a/code/drasil-code/Language/Drasil/Code/Imperative/Import.hs
+++ b/code/drasil-code/Language/Drasil/Code/Imperative/Import.hs
@@ -33,7 +33,7 @@ import GOOL.Drasil (Label, RenderSym(..), PermanenceSym(..), BodySym(..),
   NumericExpression(..), BooleanExpression(..), ValueExpression(..), 
   FunctionSym(..), SelectorFunction(..), StatementSym(..), 
   ControlStatementSym(..), ScopeSym(..), ParameterSym(..), MethodSym(..), 
-  convType) 
+  convType, GS) 
 import qualified GOOL.Drasil as C (CodeType(List))
 
 import Prelude hiding (sin, cos, tan, log, exp)
@@ -116,34 +116,34 @@ mkVar v = variable (codeName v) (convType $ codeType v)
 
 publicFunc :: (RenderSym repr, HasUID c, HasCodeType c, CodeIdea c) => 
   Label -> repr (Type repr) -> String -> [c] -> Maybe String -> 
-  [repr (Block repr)] -> Reader State (repr (Method repr))
+  [repr (Block repr)] -> Reader State (GS (repr (Method repr)))
 publicFunc n t = genMethod (function n public static_ t) n
 
 privateMethod :: (RenderSym repr, HasUID c, HasCodeType c, CodeIdea c) => 
   Label -> Label -> repr (Type repr) -> String -> [c] -> Maybe String -> 
-  [repr (Block repr)] -> Reader State (repr (Method repr))
+  [repr (Block repr)] -> Reader State (GS (repr (Method repr)))
 privateMethod c n t = genMethod (method n c private dynamic_ t) n
 
 publicInOutFunc :: (RenderSym repr, HasUID c, HasCodeType c, CodeIdea c, Eq c) 
   => Label -> String -> [c] -> [c] -> [repr (Block repr)] -> 
-  Reader State (repr (Method repr))
+  Reader State (GS (repr (Method repr)))
 publicInOutFunc n = genInOutFunc (inOutFunc n) (docInOutFunc n) public static_ n
 
 privateInOutMethod :: (RenderSym repr, HasUID c, HasCodeType c, CodeIdea c,
   Eq c) => Label -> Label -> String -> [c] -> [c] -> [repr (Block repr)] -> 
-  Reader State (repr (Method repr))
+  Reader State (GS (repr (Method repr)))
 privateInOutMethod c n = genInOutFunc (inOutMethod n c) (docInOutMethod n c) 
   private dynamic_ n
 
 genConstructor :: (RenderSym repr, HasUID c, HasCodeType c, CodeIdea c) => 
   Label -> String -> [c] -> [repr (Block repr)] -> 
-  Reader State (repr (Method repr))
+  Reader State (GS (repr (Method repr)))
 genConstructor n desc p = genMethod (constructor n) n desc p Nothing
 
 genMethod :: (RenderSym repr, HasUID c, HasCodeType c, CodeIdea c) => 
-  ([repr (Parameter repr)] -> repr (Body repr) -> repr (Method repr)) -> 
+  ([repr (Parameter repr)] -> repr (Body repr) -> GS (repr (Method repr))) -> 
   Label -> String -> [c] -> Maybe String -> [repr (Block repr)] -> 
-  Reader State (repr (Method repr))
+  Reader State (GS (repr (Method repr)))
 genMethod f n desc p r b = do
   g <- ask
   vars <- mapM mkVar p
@@ -157,12 +157,13 @@ genMethod f n desc p r b = do
 genInOutFunc :: (RenderSym repr, HasUID c, HasCodeType c, CodeIdea c, Eq c) => 
   (repr (Scope repr) -> repr (Permanence repr) -> [repr (Variable repr)] -> 
     [repr (Variable repr)] -> [repr (Variable repr)] -> repr (Body repr) -> 
-    repr (Method repr)) -> 
+    GS (repr (Method repr))) -> 
   (repr (Scope repr) -> repr (Permanence repr) -> String -> 
     [(String, repr (Variable repr))] -> [(String, repr (Variable repr))] -> 
-    [(String, repr (Variable repr))] -> repr (Body repr) -> repr (Method repr)) 
-  -> repr (Scope repr) -> repr (Permanence repr) -> Label -> String -> [c] -> 
-  [c] -> [repr (Block repr)] -> Reader State (repr (Method repr))
+    [(String, repr (Variable repr))] -> repr (Body repr) -> 
+    GS (repr (Method repr))) -> 
+  repr (Scope repr) -> repr (Permanence repr) -> Label -> String -> [c] -> 
+  [c] -> [repr (Block repr)] -> Reader State (GS (repr (Method repr)))
 genInOutFunc f docf s pr n desc ins' outs' b = do
   g <- ask
   let ins = ins' \\ outs'
@@ -275,8 +276,8 @@ bfunc Index = listAccess
 
 ------- CALC ----------
 
-genCalcFunc :: (RenderSym repr) => CodeDefinition -> Reader State (repr
-  (Method repr))
+genCalcFunc :: (RenderSym repr) => CodeDefinition -> 
+  Reader State (GS (repr (Method repr)))
 genCalcFunc cdef = do
   parms <- getCalcParams cdef
   let nm = codeName cdef
@@ -317,10 +318,11 @@ genCaseBlock t v c cs = do
           "Undefined case encountered in function " ++ codeName v
 
 -- medium hacks --
-genModDef :: (RenderSym repr) => Mod -> Reader State (repr (RenderFile repr))
+genModDef :: (RenderSym repr) => Mod -> 
+  Reader State (GS (repr (RenderFile repr)))
 genModDef (Mod n desc fs) = genModule n desc (Just $ mapM genFunc fs) Nothing
 
-genFunc :: (RenderSym repr) => Func -> Reader State (repr (Method repr))
+genFunc :: (RenderSym repr) => Func -> Reader State (GS (repr (Method repr)))
 genFunc (FDef (FuncDef n desc parms o rd s)) = do
   g <- ask
   stmts <- mapM convStmt s
@@ -376,7 +378,7 @@ convStmt (FAppend a b) = do
   return $ valState $ listAppend a' b'
 
 genDataFunc :: (RenderSym repr) => Name -> String -> DataDesc -> 
-  Reader State (repr (Method repr))
+  Reader State (GS (repr (Method repr)))
 genDataFunc nameTitle desc ddef = do
   let parms = getInputs ddef
   bod <- readData ddef

--- a/code/drasil-code/Language/Drasil/Code/Imperative/Logging.hs
+++ b/code/drasil-code/Language/Drasil/Code/Imperative/Logging.hs
@@ -2,7 +2,7 @@ module Language.Drasil.Code.Imperative.Logging (
   maybeLog, logBody, loggedMethod, varLogFile
 ) where
 
-import Language.Drasil.Code.Imperative.State (State(..))
+import Language.Drasil.Code.Imperative.State (DrasilState(..))
 import Language.Drasil.CodeSpec hiding (codeSpec, Mod(..))
 
 import GOOL.Drasil (Label, RenderSym(..), BodySym(..), BlockSym(..), 
@@ -13,20 +13,20 @@ import Control.Applicative ((<$>))
 import Control.Monad.Reader (Reader, ask)
 
 maybeLog :: (RenderSym repr) => repr (Variable repr) ->
-  Reader State [repr (Statement repr)]
+  Reader DrasilState [repr (Statement repr)]
 maybeLog v = do
   g <- ask
   l <- chooseLogging (logKind g) v
   return $ maybeToList l
 
 chooseLogging :: (RenderSym repr) => Logging -> (repr (Variable repr) -> 
-  Reader State (Maybe (repr (Statement repr))))
+  Reader DrasilState (Maybe (repr (Statement repr))))
 chooseLogging LogVar v = Just <$> loggedVar v
 chooseLogging LogAll v = Just <$> loggedVar v
 chooseLogging _      _ = return Nothing
 
 loggedVar :: (RenderSym repr) => repr (Variable repr) -> 
-  Reader State (repr (Statement repr))
+  Reader DrasilState (repr (Statement repr))
 loggedVar v = do
     g <- ask
     return $ multi [
@@ -37,7 +37,7 @@ loggedVar v = do
       closeFile valLogFile ]
 
 logBody :: (RenderSym repr) => Label -> [repr (Variable repr)] -> 
-  [repr (Block repr)] -> Reader State (repr (Body repr))
+  [repr (Block repr)] -> Reader DrasilState (repr (Body repr))
 logBody n vars b = do
   g <- ask
   let loggedBody LogFunc = loggedMethod (logName g) n vars b

--- a/code/drasil-code/Language/Drasil/Code/Imperative/Modules.hs
+++ b/code/drasil-code/Language/Drasil/Code/Imperative/Modules.hs
@@ -36,7 +36,7 @@ import GOOL.Drasil (RenderSym(..), BodySym(..), BlockSym(..),
   PermanenceSym(..), TypeSym(..), VariableSym(..), ValueSym(..), 
   BooleanExpression(..), StatementSym(..), ControlStatementSym(..), 
   ScopeSym(..), MethodSym(..), StateVarSym(..), ClassSym(..), ScopeTag(..), 
-  convType)
+  convType, GS)
 
 import Prelude hiding (print)
 import Data.List (intersperse, intercalate, partition)
@@ -50,11 +50,11 @@ import Text.PrettyPrint.HughesPJ (render)
 
 ---- MAIN ---
 
-genMain :: (RenderSym repr) => Reader State (repr (RenderFile repr))
+genMain :: (RenderSym repr) => Reader State (GS (repr (RenderFile repr)))
 genMain = genModule "Control" "Controls the flow of the program" 
   (Just $ liftS genMainFunc) Nothing
 
-genMainFunc :: (RenderSym repr) => Reader State (repr (Method repr))
+genMainFunc :: (RenderSym repr) => Reader State (GS (repr (Method repr)))
 genMainFunc = do
     g <- ask
     v_filename <- mkVar $ codevar inFileName
@@ -126,12 +126,12 @@ initLogFileVar _ = []
 ------- INPUT ----------
 
 chooseInModule :: (RenderSym repr) => InputModule -> Reader State 
-  [repr (RenderFile repr)]
+  [GS (repr (RenderFile repr))]
 chooseInModule Combined = genInputModCombined
 chooseInModule Separated = genInputModSeparated
 
 genInputModSeparated :: (RenderSym repr) => 
-  Reader State [repr (RenderFile repr)]
+  Reader State [GS (repr (RenderFile repr))]
 genInputModSeparated = do
   ipDesc <- modDesc inputParametersDesc
   ifDesc <- modDesc (liftS inputFormatDesc)
@@ -147,12 +147,13 @@ genInputModSeparated = do
     genModule "InputConstraints" icDesc 
       (Just $ fmap maybeToList (genInputConstraints Pub)) Nothing]
 
-genInputModCombined :: (RenderSym repr) => Reader State [repr (RenderFile repr)]
+genInputModCombined :: (RenderSym repr) => 
+  Reader State [GS (repr (RenderFile repr))]
 genInputModCombined = do
   ipDesc <- modDesc inputParametersDesc
   let cname = "InputParameters"
-      genMod :: (RenderSym repr) => Maybe (repr (Class repr)) ->
-        Reader State (repr (RenderFile repr))
+      genMod :: (RenderSym repr) => Maybe (GS (repr (Class repr))) ->
+        Reader State (GS (repr (RenderFile repr)))
       genMod Nothing = genModule cname ipDesc (Just $ concat <$> mapM (fmap 
         maybeToList) [genInputFormat Pub, genInputDerived 
         Pub, genInputConstraints Pub]) 
@@ -162,11 +163,12 @@ genInputModCombined = do
   liftS $ genMod ic
 
 constVarFunc :: (RenderSym repr) => ConstantRepr -> String ->
-  (repr (Variable repr) -> repr (Value repr) -> repr (StateVar repr))
+  (repr (Variable repr) -> repr (Value repr) -> GS (repr (StateVar repr)))
 constVarFunc Var n = stateVarDef n public dynamic_
 constVarFunc Const n = constVar n public
 
-genInputClass :: (RenderSym repr) => Reader State (Maybe (repr (Class repr)))
+genInputClass :: (RenderSym repr) => 
+  Reader State (Maybe (GS (repr (Class repr))))
 genInputClass = do
   g <- ask
   let ins = inputs $ csi $ codeSpec g
@@ -175,14 +177,15 @@ genInputClass = do
       filt :: (CodeIdea c) => [c] -> [c]
       filt = filter (flip member (Map.filter (cname ==) (eMap $ codeSpec g)) . 
         codeName)
-      methods :: (RenderSym repr) => InputModule -> Reader State [repr (Method repr)]
+      methods :: (RenderSym repr) => InputModule -> 
+        Reader State [GS (repr (Method repr))]
       methods Separated = return []
       methods Combined = concat <$> mapM (fmap maybeToList) 
         [genInputConstructor, genInputFormat Priv, 
         genInputDerived Priv, 
         genInputConstraints Priv]
       genClass :: (RenderSym repr) => [CodeChunk] -> [CodeDefinition] -> 
-        Reader State (Maybe (repr (Class repr)))
+        Reader State (Maybe (GS (repr (Class repr))))
       genClass [] [] = return Nothing
       genClass inps csts = do
         vals <- mapM (convExpr . codeEquat) csts
@@ -197,7 +200,7 @@ genInputClass = do
   genClass (filt ins) (filt cs)
 
 genInputConstructor :: (RenderSym repr) => Reader State 
-  (Maybe (repr (Method repr)))
+  (Maybe (GS (repr (Method repr))))
 genInputConstructor = do
   g <- ask
   let dm = defMap $ codeSpec g
@@ -213,14 +216,14 @@ genInputConstructor = do
     "input_constraints"]
 
 genInputDerived :: (RenderSym repr) => ScopeTag -> 
-  Reader State (Maybe (repr (Method repr)))
+  Reader State (Maybe (GS (repr (Method repr))))
 genInputDerived s = do
   g <- ask
   let dvals = derivedInputs $ csi $ codeSpec g
       getFunc Pub = publicInOutFunc
       getFunc Priv = privateInOutMethod "InputParameters"
       genDerived :: (RenderSym repr) => Maybe String -> Reader State 
-        (Maybe (repr (Method repr)))
+        (Maybe (GS (repr (Method repr))))
       genDerived Nothing = return Nothing
       genDerived (Just _) = do
         ins <- getDerivedIns
@@ -232,14 +235,14 @@ genInputDerived s = do
   genDerived $ Map.lookup "derived_values" (defMap $ codeSpec g)
 
 genInputConstraints :: (RenderSym repr) => ScopeTag ->
-  Reader State (Maybe (repr (Method repr)))
+  Reader State (Maybe (GS (repr (Method repr))))
 genInputConstraints s = do
   g <- ask
   let cm = cMap $ csi $ codeSpec g
       getFunc Pub = publicFunc
       getFunc Priv = privateMethod "InputParameters"
       genConstraints :: (RenderSym repr) => Maybe String -> Reader State 
-        (Maybe (repr (Method repr)))
+        (Maybe (GS (repr (Method repr))))
       genConstraints Nothing = return Nothing
       genConstraints (Just _) = do
         h <- ask
@@ -343,14 +346,14 @@ printExpr e db = [printStr $ " (" ++ render (exprDoc db Implementation Linear e)
   ++ ")"]
 
 genInputFormat :: (RenderSym repr) => ScopeTag -> 
-  Reader State (Maybe (repr (Method repr)))
+  Reader State (Maybe (GS (repr (Method repr))))
 genInputFormat s = do
   g <- ask
   dd <- genDataDesc
   let getFunc Pub = publicInOutFunc
       getFunc Priv = privateInOutMethod "InputParameters"
       genInFormat :: (RenderSym repr) => Maybe String -> Reader State 
-        (Maybe (repr (Method repr)))
+        (Maybe (GS (repr (Method repr))))
       genInFormat Nothing = return Nothing
       genInFormat (Just _) = do
         ins <- getInputFormatIns
@@ -376,19 +379,20 @@ genSampleInput = do
 
 ----- CONSTANTS -----
 
-genConstMod :: (RenderSym repr) => Reader State [repr (RenderFile repr)]
+genConstMod :: (RenderSym repr) => Reader State [GS (repr (RenderFile repr))]
 genConstMod = do
   cDesc <- modDesc $ liftS constModDesc
   liftS $ genModule "Constants" cDesc Nothing (Just $ fmap maybeToList 
     genConstClass)
 
-genConstClass :: (RenderSym repr) => Reader State (Maybe (repr (Class repr)))
+genConstClass :: (RenderSym repr) => 
+  Reader State (Maybe (GS (repr (Class repr))))
 genConstClass = do
   g <- ask
   let cs = constants $ csi $ codeSpec g
       cname = "Constants"
       genClass :: (RenderSym repr) => [CodeDefinition] -> Reader State (Maybe 
-        (repr (Class repr)))
+        (GS (repr (Class repr))))
       genClass [] = return Nothing 
       genClass vs = do
         vals <- mapM (convExpr . codeEquat) vs 
@@ -402,7 +406,7 @@ genConstClass = do
 
 ----- OUTPUT -------
 
-genOutputMod :: (RenderSym repr) => Reader State [repr (RenderFile repr)]
+genOutputMod :: (RenderSym repr) => Reader State [GS (repr (RenderFile repr))]
 genOutputMod = do
   outformat <- genOutputFormat
   ofDesc <- modDesc $ liftS outputFormatDesc
@@ -410,11 +414,12 @@ genOutputMod = do
   liftS $ genModule "OutputFormat" ofDesc
     (Just $ return outf) Nothing
 
-genOutputFormat :: (RenderSym repr) => Reader State (Maybe (repr (Method repr)))
+genOutputFormat :: (RenderSym repr) => 
+  Reader State (Maybe (GS (repr (Method repr))))
 genOutputFormat = do
   g <- ask
   let genOutput :: (RenderSym repr) => Maybe String -> Reader State 
-        (Maybe (repr (Method repr)))
+        (Maybe (GS (repr (Method repr))))
       genOutput Nothing = return Nothing
       genOutput (Just _) = do
         let l_outfile = "outputfile"

--- a/code/drasil-code/Language/Drasil/Code/Imperative/Modules.hs
+++ b/code/drasil-code/Language/Drasil/Code/Imperative/Modules.hs
@@ -36,7 +36,7 @@ import GOOL.Drasil (RenderSym(..), BodySym(..), BlockSym(..),
   PermanenceSym(..), TypeSym(..), VariableSym(..), ValueSym(..), 
   BooleanExpression(..), StatementSym(..), ControlStatementSym(..), 
   ScopeSym(..), MethodSym(..), StateVarSym(..), ClassSym(..), ScopeTag(..), 
-  convType, GS)
+  convType, GS, MS)
 
 import Prelude hiding (print)
 import Data.List (intersperse, intercalate, partition)
@@ -54,7 +54,7 @@ genMain :: (RenderSym repr) => Reader DrasilState (GS (repr (RenderFile repr)))
 genMain = genModule "Control" "Controls the flow of the program" 
   (Just $ liftS genMainFunc) Nothing
 
-genMainFunc :: (RenderSym repr) => Reader DrasilState (GS (repr (Method repr)))
+genMainFunc :: (RenderSym repr) => Reader DrasilState (MS (repr (Method repr)))
 genMainFunc = do
     g <- ask
     v_filename <- mkVar $ codevar inFileName
@@ -178,7 +178,7 @@ genInputClass = do
       filt = filter (flip member (Map.filter (cname ==) (eMap $ codeSpec g)) . 
         codeName)
       methods :: (RenderSym repr) => InputModule -> 
-        Reader DrasilState [GS (repr (Method repr))]
+        Reader DrasilState [MS (repr (Method repr))]
       methods Separated = return []
       methods Combined = concat <$> mapM (fmap maybeToList) 
         [genInputConstructor, genInputFormat Priv, 
@@ -200,7 +200,7 @@ genInputClass = do
   genClass (filt ins) (filt cs)
 
 genInputConstructor :: (RenderSym repr) => Reader DrasilState 
-  (Maybe (GS (repr (Method repr))))
+  (Maybe (MS (repr (Method repr))))
 genInputConstructor = do
   g <- ask
   let dm = defMap $ codeSpec g
@@ -216,14 +216,14 @@ genInputConstructor = do
     "input_constraints"]
 
 genInputDerived :: (RenderSym repr) => ScopeTag -> 
-  Reader DrasilState (Maybe (GS (repr (Method repr))))
+  Reader DrasilState (Maybe (MS (repr (Method repr))))
 genInputDerived s = do
   g <- ask
   let dvals = derivedInputs $ csi $ codeSpec g
       getFunc Pub = publicInOutFunc
       getFunc Priv = privateInOutMethod "InputParameters"
       genDerived :: (RenderSym repr) => Maybe String -> Reader DrasilState 
-        (Maybe (GS (repr (Method repr))))
+        (Maybe (MS (repr (Method repr))))
       genDerived Nothing = return Nothing
       genDerived (Just _) = do
         ins <- getDerivedIns
@@ -235,14 +235,14 @@ genInputDerived s = do
   genDerived $ Map.lookup "derived_values" (defMap $ codeSpec g)
 
 genInputConstraints :: (RenderSym repr) => ScopeTag ->
-  Reader DrasilState (Maybe (GS (repr (Method repr))))
+  Reader DrasilState (Maybe (MS (repr (Method repr))))
 genInputConstraints s = do
   g <- ask
   let cm = cMap $ csi $ codeSpec g
       getFunc Pub = publicFunc
       getFunc Priv = privateMethod "InputParameters"
       genConstraints :: (RenderSym repr) => Maybe String -> Reader DrasilState 
-        (Maybe (GS (repr (Method repr))))
+        (Maybe (MS (repr (Method repr))))
       genConstraints Nothing = return Nothing
       genConstraints (Just _) = do
         h <- ask
@@ -346,14 +346,14 @@ printExpr e db = [printStr $ " (" ++ render (exprDoc db Implementation Linear e)
   ++ ")"]
 
 genInputFormat :: (RenderSym repr) => ScopeTag -> 
-  Reader DrasilState (Maybe (GS (repr (Method repr))))
+  Reader DrasilState (Maybe (MS (repr (Method repr))))
 genInputFormat s = do
   g <- ask
   dd <- genDataDesc
   let getFunc Pub = publicInOutFunc
       getFunc Priv = privateInOutMethod "InputParameters"
       genInFormat :: (RenderSym repr) => Maybe String -> Reader DrasilState 
-        (Maybe (GS (repr (Method repr))))
+        (Maybe (MS (repr (Method repr))))
       genInFormat Nothing = return Nothing
       genInFormat (Just _) = do
         ins <- getInputFormatIns
@@ -415,11 +415,11 @@ genOutputMod = do
     (Just $ return outf) Nothing
 
 genOutputFormat :: (RenderSym repr) => 
-  Reader DrasilState (Maybe (GS (repr (Method repr))))
+  Reader DrasilState (Maybe (MS (repr (Method repr))))
 genOutputFormat = do
   g <- ask
   let genOutput :: (RenderSym repr) => Maybe String -> Reader DrasilState 
-        (Maybe (GS (repr (Method repr))))
+        (Maybe (MS (repr (Method repr))))
       genOutput Nothing = return Nothing
       genOutput (Just _) = do
         let l_outfile = "outputfile"

--- a/code/drasil-code/Language/Drasil/Code/Imperative/Parameters.hs
+++ b/code/drasil-code/Language/Drasil/Code/Imperative/Parameters.hs
@@ -4,7 +4,7 @@ module Language.Drasil.Code.Imperative.Parameters(getInConstructorParams,
 ) where
 
 import Language.Drasil 
-import Language.Drasil.Code.Imperative.State (State(..))
+import Language.Drasil.Code.Imperative.State (DrasilState(..))
 import Language.Drasil.Chunk.Code (CodeChunk, CodeIdea(codeChunk), codevar)
 import Language.Drasil.Chunk.CodeDefinition (CodeDefinition, codeEquat)
 import Language.Drasil.Code.CodeQuantityDicts (inFileName, inParams, consts)
@@ -17,7 +17,7 @@ import Data.Map (member, notMember)
 import Control.Monad.Reader (Reader, ask)
 import Control.Lens ((^.))
 
-getInConstructorParams :: Reader State [CodeChunk]
+getInConstructorParams :: Reader DrasilState [CodeChunk]
 getInConstructorParams = do
   g <- ask
   let getCParams False = []
@@ -25,7 +25,7 @@ getInConstructorParams = do
   getParams $ getCParams $ member "InputParameters" (eMap $ codeSpec g) && 
     member "get_input" (defMap $ codeSpec g)
 
-getInputFormatIns :: Reader State [CodeChunk]
+getInputFormatIns :: Reader DrasilState [CodeChunk]
 getInputFormatIns = do
   g <- ask
   let getIns :: Structure -> InputModule -> [CodeChunk]
@@ -33,12 +33,12 @@ getInputFormatIns = do
       getIns _ _ = []
   getParams $ codevar inFileName : getIns (inStruct g) (inMod g)
 
-getInputFormatOuts :: Reader State [CodeChunk]
+getInputFormatOuts :: Reader DrasilState [CodeChunk]
 getInputFormatOuts = do
   g <- ask
   getParams $ extInputs $ csi $ codeSpec g
 
-getDerivedIns :: Reader State [CodeChunk]
+getDerivedIns :: Reader DrasilState [CodeChunk]
 getDerivedIns = do
   g <- ask
   let s = csi $ codeSpec g
@@ -46,12 +46,12 @@ getDerivedIns = do
       reqdVals = concatMap (flip codevars (sysinfodb s) . codeEquat) dvals
   getParams reqdVals
 
-getDerivedOuts :: Reader State [CodeChunk]
+getDerivedOuts :: Reader DrasilState [CodeChunk]
 getDerivedOuts = do
   g <- ask
   getParams $ map codeChunk $ derivedInputs $ csi $ codeSpec g
 
-getConstraintParams :: Reader State [CodeChunk]
+getConstraintParams :: Reader DrasilState [CodeChunk]
 getConstraintParams = do 
   g <- ask
   let cm = cMap $ csi $ codeSpec g
@@ -62,17 +62,17 @@ getConstraintParams = do
         mem) (getConstraints cm varsList)
   getParams reqdVals
 
-getCalcParams :: CodeDefinition -> Reader State [CodeChunk]
+getCalcParams :: CodeDefinition -> Reader DrasilState [CodeChunk]
 getCalcParams c = do
   g <- ask
   getParams $ codevars' (codeEquat c) $ sysinfodb $ csi $ codeSpec g
 
-getOutputParams :: Reader State [CodeChunk]
+getOutputParams :: Reader DrasilState [CodeChunk]
 getOutputParams = do
   g <- ask
   getParams $ outputs $ csi $ codeSpec g
 
-getParams :: (CodeIdea c) => [c] -> Reader State [CodeChunk]
+getParams :: (CodeIdea c) => [c] -> Reader DrasilState [CodeChunk]
 getParams cs' = do
   g <- ask
   let cs = map codeChunk cs'
@@ -87,7 +87,7 @@ getParams cs' = do
   return $ nub $ inVs ++ conVs ++ csSubIns
 
 getInputVars :: Structure -> ConstantRepr -> [CodeChunk] -> 
-  Reader State [CodeChunk]
+  Reader DrasilState [CodeChunk]
 getInputVars _ _ [] = return []
 getInputVars Unbundled _ cs = return cs
 getInputVars Bundled Var _ = do
@@ -98,7 +98,7 @@ getInputVars Bundled Var _ = do
 getInputVars Bundled Const _ = return []
 
 getConstVars :: ConstantStructure -> ConstantRepr -> [CodeChunk] -> 
-  Reader State [CodeChunk]
+  Reader DrasilState [CodeChunk]
 getConstVars _ _ [] = return []
 getConstVars (Store Unbundled) _ cs = return cs
 getConstVars (Store Bundled) Var _ = return [codevar consts]

--- a/code/drasil-code/Language/Drasil/Code/Imperative/State.hs
+++ b/code/drasil-code/Language/Drasil/Code/Imperative/State.hs
@@ -1,5 +1,5 @@
 module Language.Drasil.Code.Imperative.State (
-  State(..)
+  DrasilState(..)
 ) where
 
 import Language.Drasil
@@ -8,7 +8,7 @@ import Language.Drasil.CodeSpec (AuxFile, CodeSpec, Comments, Verbosity,
   InputModule, Logging, Structure)
 
 -- Private State, used to push these options around the generator
-data State = State {
+data DrasilState = DrasilState {
   codeSpec :: CodeSpec,
   date :: String,
   inStruct :: Structure,

--- a/code/drasil-gool/GOOL/Drasil.hs
+++ b/code/drasil-gool/GOOL/Drasil.hs
@@ -8,7 +8,7 @@ module GOOL.Drasil (Label, ProgramSym(..), RenderSym(..), PermanenceSym(..),
   BlockCommentSym(..), 
   ScopeTag(..), ProgData(..), FileData(..), ModData(..),
   CodeType(..),
-  GOOLState(..), GS, headers, sources, mainMod, initialState,
+  GOOLState(..), GS, MS, headers, sources, mainMod, initialState,
   convType, liftList,
   unPC, unJC, unCSC, unCPPC
 ) where
@@ -25,7 +25,7 @@ import GOOL.Drasil.Data (ScopeTag(..), FileData(..), ModData(..), ProgData(..))
 
 import GOOL.Drasil.CodeType (CodeType(..))
 
-import GOOL.Drasil.State (GOOLState(..), GS, headers, sources, mainMod, 
+import GOOL.Drasil.State (GOOLState(..), GS, MS, headers, sources, mainMod, 
   initialState)
 
 import GOOL.Drasil.Helpers (convType, liftList)

--- a/code/drasil-gool/GOOL/Drasil.hs
+++ b/code/drasil-gool/GOOL/Drasil.hs
@@ -8,7 +8,7 @@ module GOOL.Drasil (Label, ProgramSym(..), RenderSym(..), PermanenceSym(..),
   BlockCommentSym(..), 
   ScopeTag(..), ProgData(..), FileData(..), ModData(..),
   CodeType(..),
-  GOOLState(..), headers, sources, mainMod, initialState,
+  GOOLState(..), GS, headers, sources, mainMod, initialState,
   convType, liftList,
   unPC, unJC, unCSC, unCPPC
 ) where
@@ -25,7 +25,7 @@ import GOOL.Drasil.Data (ScopeTag(..), FileData(..), ModData(..), ProgData(..))
 
 import GOOL.Drasil.CodeType (CodeType(..))
 
-import GOOL.Drasil.State (GOOLState(..), headers, sources, mainMod, 
+import GOOL.Drasil.State (GOOLState(..), GS, headers, sources, mainMod, 
   initialState)
 
 import GOOL.Drasil.Helpers (convType, liftList)

--- a/code/drasil-gool/GOOL/Drasil/Data.hs
+++ b/code/drasil-gool/GOOL/Drasil/Data.hs
@@ -55,8 +55,8 @@ data ModData = MD {name :: String, isMainMod :: Bool, modDoc :: Doc}
 md :: String -> Bool -> Doc -> ModData
 md = MD
 
-updateModDoc :: Doc -> ModData -> ModData
-updateModDoc d m = md (name m) (isMainMod m) d
+updateModDoc :: (Doc -> Doc) -> ModData -> ModData
+updateModDoc f m = md (name m) (isMainMod m) (f $ modDoc m)
 
 data MethodData = MthD {isMainMthd :: Bool, mthdParams :: [ParamData], 
   mthdDoc :: Doc}

--- a/code/drasil-gool/GOOL/Drasil/Data.hs
+++ b/code/drasil-gool/GOOL/Drasil/Data.hs
@@ -63,8 +63,8 @@ newtype MethodData = MthD {mthdDoc :: Doc}
 mthd :: Doc -> MethodData
 mthd = MthD 
 
-updateMthdDoc :: (Doc -> Doc) -> MethodData -> MethodData
-updateMthdDoc f m = mthd ((f . mthdDoc) m)
+updateMthdDoc :: MethodData -> (Doc -> Doc) -> MethodData
+updateMthdDoc m f = mthd ((f . mthdDoc) m)
 
 data OpData = OD {opPrec :: Int, opDoc :: Doc}
 

--- a/code/drasil-gool/GOOL/Drasil/Data.hs
+++ b/code/drasil-gool/GOOL/Drasil/Data.hs
@@ -58,13 +58,13 @@ md = MD
 updateModDoc :: (Doc -> Doc) -> ModData -> ModData
 updateModDoc f m = md (name m) (isMainMod m) (f $ modDoc m)
 
-data MethodData = MthD {mthdParams :: [ParamData], mthdDoc :: Doc}
+newtype MethodData = MthD {mthdDoc :: Doc}
 
-mthd :: [ParamData] -> Doc -> MethodData
+mthd :: Doc -> MethodData
 mthd = MthD 
 
 updateMthdDoc :: (Doc -> Doc) -> MethodData -> MethodData
-updateMthdDoc f m = mthd (mthdParams m) ((f . mthdDoc) m)
+updateMthdDoc f m = mthd ((f . mthdDoc) m)
 
 data OpData = OD {opPrec :: Int, opDoc :: Doc}
 

--- a/code/drasil-gool/GOOL/Drasil/Data.hs
+++ b/code/drasil-gool/GOOL/Drasil/Data.hs
@@ -1,4 +1,4 @@
-module GOOL.Drasil.Data (Pair(..), pairList, Terminator(..), ScopeTag(..), 
+module GOOL.Drasil.Data (Pair(..), Terminator(..), ScopeTag(..), 
   FileType(..), BindData(..), bd, FileData(..), fileD, updateFileMod, 
   FuncData(..), fd, ModData(..), md, updateModDoc, MethodData(..), mthd, 
   updateMthdDoc, OpData(..), od, ParamData(..), pd, paramName, updateParamDoc, 
@@ -15,11 +15,6 @@ class Pair p where
   pfst :: p x y a -> x a
   psnd :: p x y b -> y b
   pair :: x a -> y a -> p x y a
-
-pairList :: (Pair p) => [x a] -> [y a] -> [p x y a]
-pairList [] _ = []
-pairList _ [] = []
-pairList (x:xs) (y:ys) = pair x y : pairList xs ys
  
 data Terminator = Semi | Empty
 

--- a/code/drasil-gool/GOOL/Drasil/Data.hs
+++ b/code/drasil-gool/GOOL/Drasil/Data.hs
@@ -58,14 +58,13 @@ md = MD
 updateModDoc :: (Doc -> Doc) -> ModData -> ModData
 updateModDoc f m = md (name m) (isMainMod m) (f $ modDoc m)
 
-data MethodData = MthD {isMainMthd :: Bool, mthdParams :: [ParamData], 
-  mthdDoc :: Doc}
+data MethodData = MthD {mthdParams :: [ParamData], mthdDoc :: Doc}
 
-mthd :: Bool -> [ParamData] -> Doc -> MethodData
+mthd :: [ParamData] -> Doc -> MethodData
 mthd = MthD 
 
 updateMthdDoc :: (Doc -> Doc) -> MethodData -> MethodData
-updateMthdDoc f m = mthd (isMainMthd m) (mthdParams m) ((f . mthdDoc) m)
+updateMthdDoc f m = mthd (mthdParams m) ((f . mthdDoc) m)
 
 data OpData = OD {opPrec :: Int, opDoc :: Doc}
 

--- a/code/drasil-gool/GOOL/Drasil/Data.hs
+++ b/code/drasil-gool/GOOL/Drasil/Data.hs
@@ -1,7 +1,7 @@
 module GOOL.Drasil.Data (Pair(..), pairList, Terminator(..), ScopeTag(..), 
   FileType(..), BindData(..), bd, FileData(..), fileD, updateFileMod, 
   FuncData(..), fd, ModData(..), md, updateModDoc, MethodData(..), mthd, 
-  updateMthdDoc, OpData(..), od, ParamData(..), pd, updateParamDoc, 
+  updateMthdDoc, OpData(..), od, ParamData(..), pd, paramName, updateParamDoc, 
   ProgData(..), progD, emptyProg, StateVarData(..), svd, TypeData(..), td, 
   ValData(..), vd, updateValDoc, Binding(..), VarData(..), vard
 ) where
@@ -78,6 +78,9 @@ instance Eq ParamData where
 
 pd :: VarData -> Doc -> ParamData
 pd = PD 
+
+paramName :: ParamData -> String
+paramName = varName . paramVar
 
 updateParamDoc :: (Doc -> Doc) -> ParamData -> ParamData
 updateParamDoc f v = pd (paramVar v) ((f . paramDoc) v)

--- a/code/drasil-gool/GOOL/Drasil/Helpers.hs
+++ b/code/drasil-gool/GOOL/Drasil/Helpers.hs
@@ -1,13 +1,15 @@
 module GOOL.Drasil.Helpers (verticalComma, angles, doubleQuotedText, himap,
   hicat, vicat, vibcat, vmap, vimap, vibmap, emptyIfEmpty, emptyIfNull, 
-  mapPairFst, mapPairSnd, liftA4, liftA5, liftA6, liftA7, liftA8, liftList, 
-  lift2Lists, lift1List, getInnerType, getNestDegree, convType, checkParams
+  mapPairFst, mapPairSnd, toCode, onStateValue, liftA4, liftA5, liftA6, liftA7, 
+  liftA8, liftList, lift2Lists, lift1List, getInnerType, getNestDegree, 
+  convType, checkParams
 ) where
 
 import Utils.Drasil (blank)
 
 import qualified GOOL.Drasil.CodeType as C (CodeType(..))
 import GOOL.Drasil.Data (ParamData)
+import GOOL.Drasil.State (GS)
 import qualified GOOL.Drasil.Symantics as S ( 
   RenderSym(..), TypeSym(..), PermanenceSym(dynamic_))
 
@@ -58,6 +60,12 @@ mapPairFst f (a, c) = (f a, c)
 
 mapPairSnd :: (a -> b) -> (c, a) -> (c, b)
 mapPairSnd f (c, b) = (c, f b)
+
+toCode :: (Monad repr) => a -> repr a
+toCode = return
+
+onStateValue :: (a -> b) -> GS a -> GS b
+onStateValue = fmap
 
 liftA4 :: Applicative f => (a -> b -> c -> d -> e) -> f a -> f b -> f c -> 
   f d -> f e

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer.hs
@@ -62,7 +62,7 @@ import GOOL.Drasil.Symantics (Label, Library, RenderSym(..), BodySym(..),
   BooleanExpression(..), ValueExpression(..), InternalValue(..), Selector(..), 
   FunctionSym(..), SelectorFunction(..), InternalFunction(..), 
   InternalStatement(..), StatementSym(..), ControlStatementSym(..), 
-  ParameterSym(..), MethodSym(..), InternalMethod(..), BlockCommentSym(..))
+  MethodSym(..), InternalMethod(..), BlockCommentSym(..))
 import qualified GOOL.Drasil.Symantics as S (TypeSym(char, int))
 import GOOL.Drasil.Data (Terminator(..), FileData(..), fileD, updateFileMod, 
   updateModDoc, OpData(..), od, ParamData(..), pd, paramName, TypeData(..), td, 

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer.hs
@@ -69,10 +69,8 @@ import GOOL.Drasil.Data (Terminator(..), FileData(..), fileD, updateFileMod,
   ValData(..), vd, Binding(..), VarData(..), vard)
 import GOOL.Drasil.Helpers (angles, doubleQuotedText, hicat, vibcat, vmap, 
   emptyIfEmpty, emptyIfNull, getInnerType, getNestDegree, convType)
-import GOOL.Drasil.State (GOOLState)
 
 import Control.Applicative ((<|>))
-import Control.Monad.State (State)
 import Data.List (intersperse, last)
 import Data.Bifunctor (first)
 import Data.Map as Map (lookup, fromList)
@@ -1083,8 +1081,8 @@ publicDocD = text "public"
 
 -- Comment Functions -- 
 
-blockCmtDoc :: [String] -> Doc -> Doc -> State GOOLState Doc
-blockCmtDoc lns start end = return $ start <+> vcat (map text lns) <+> end
+blockCmtDoc :: [String] -> Doc -> Doc -> Doc
+blockCmtDoc lns start end = start <+> vcat (map text lns) <+> end
 
 docCmtDoc :: Doc -> Doc -> [String] -> Doc
 docCmtDoc start end lns = emptyIfNull lns $

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer.hs
@@ -69,10 +69,9 @@ import GOOL.Drasil.Data (Terminator(..), FileData(..), fileD, updateFileMod,
   ValData(..), vd, Binding(..), VarData(..), vard)
 import GOOL.Drasil.Helpers (angles, doubleQuotedText, hicat, vibcat, vmap, 
   emptyIfEmpty, emptyIfNull, getInnerType, getNestDegree, convType)
-import GOOL.Drasil.State (MS, lensGStoMS, getParameters)
+import GOOL.Drasil.State (MS, getParameters)
 
 import Control.Applicative ((<|>))
-import Control.Lens.Zoom (zoom)
 import Data.List (intersperse, last)
 import Data.Bifunctor (first)
 import Data.Map as Map (lookup, fromList)
@@ -1137,7 +1136,7 @@ docFuncRepr :: (MethodSym repr) => String -> [String] -> [String] ->
   MS (repr (Method repr)) -> MS (repr (Method repr))
 docFuncRepr desc pComms rComms = commentedFunc (docComment $ fmap 
   (\ps -> functionDox desc (zip (map paramName ps) pComms) rComms) 
-  (zoom lensGStoMS getParameters))
+  getParameters)
 
 -- Helper Functions --
 

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer.hs
@@ -69,9 +69,10 @@ import GOOL.Drasil.Data (Terminator(..), FileData(..), fileD, updateFileMod,
   ValData(..), vd, Binding(..), VarData(..), vard)
 import GOOL.Drasil.Helpers (angles, doubleQuotedText, hicat, vibcat, vmap, 
   emptyIfEmpty, emptyIfNull, getInnerType, getNestDegree, convType)
-import GOOL.Drasil.State (GS, getParameters)
+import GOOL.Drasil.State (MS, lensGStoMS, getParameters)
 
 import Control.Applicative ((<|>))
+import Control.Lens.Zoom (zoom)
 import Data.List (intersperse, last)
 import Data.Bifunctor (first)
 import Data.Map as Map (lookup, fromList)
@@ -1133,10 +1134,10 @@ commentedModD :: FileData -> Doc -> FileData
 commentedModD m cmt = updateFileMod (updateModDoc (commentedItem cmt) (fileMod m)) m
 
 docFuncRepr :: (MethodSym repr) => String -> [String] -> [String] -> 
-  GS (repr (Method repr)) -> GS (repr (Method repr))
+  MS (repr (Method repr)) -> MS (repr (Method repr))
 docFuncRepr desc pComms rComms = commentedFunc (docComment $ fmap 
   (\ps -> functionDox desc (zip (map paramName ps) pComms) rComms) 
-  getParameters)
+  (zoom lensGStoMS getParameters))
 
 -- Helper Functions --
 

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer.hs
@@ -69,8 +69,10 @@ import GOOL.Drasil.Data (Terminator(..), FileData(..), fileD, updateFileMod,
   ValData(..), vd, Binding(..), VarData(..), vard)
 import GOOL.Drasil.Helpers (angles, doubleQuotedText, hicat, vibcat, vmap, 
   emptyIfEmpty, emptyIfNull, getInnerType, getNestDegree, convType)
+import GOOL.Drasil.State (GOOLState)
 
 import Control.Applicative ((<|>))
+import Control.Monad.State (State)
 import Data.List (intersperse, last)
 import Data.Bifunctor (first)
 import Data.Map as Map (lookup, fromList)
@@ -1132,9 +1134,9 @@ commentedModD :: FileData -> Doc -> FileData
 commentedModD m cmt = updateFileMod (updateModDoc (commentedItem cmt) (fileMod m)) m
 
 docFuncRepr :: (MethodSym repr) => String -> [String] -> [String] -> 
-  repr (Method repr) -> repr (Method repr)
-docFuncRepr desc pComms rComms f = commentedFunc (docComment $ return $ functionDox desc
-  (zip (map parameterName (parameters f)) pComms) rComms) f
+  State GOOLState (repr (Method repr)) -> State GOOLState (repr (Method repr))
+docFuncRepr desc pComms rComms fn = commentedFunc (docComment $ fmap 
+  (\f -> functionDox desc (zip (map parameterName (parameters f)) pComms) rComms) fn) fn
 
 -- Helper Functions --
 

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer.hs
@@ -65,8 +65,8 @@ import GOOL.Drasil.Symantics (Label, Library, RenderSym(..), BodySym(..),
   ParameterSym(..), MethodSym(..), InternalMethod(..), BlockCommentSym(..))
 import qualified GOOL.Drasil.Symantics as S (TypeSym(char, int))
 import GOOL.Drasil.Data (Terminator(..), FileData(..), fileD, updateFileMod, 
-  ModData(..), updateModDoc, OpData(..), od, ParamData(..), pd, TypeData(..), 
-  td, ValData(..), vd, Binding(..), VarData(..), vard)
+  updateModDoc, OpData(..), od, ParamData(..), pd, TypeData(..), td, 
+  ValData(..), vd, Binding(..), VarData(..), vard)
 import GOOL.Drasil.Helpers (angles, doubleQuotedText, hicat, vibcat, vmap, 
   emptyIfEmpty, emptyIfNull, getInnerType, getNestDegree, convType)
 import GOOL.Drasil.State (GOOLState)
@@ -1130,8 +1130,8 @@ moduleDox desc as date m = (doxFile ++ m) :
   [doxDate ++ date | not (null date)] ++ 
   [doxBrief ++ desc | not (null desc)]
 
-commentedModD :: Doc -> FileData -> FileData
-commentedModD cmt m = updateFileMod (updateModDoc (commentedItem cmt) (fileMod m)) m
+commentedModD :: FileData -> Doc -> FileData
+commentedModD m cmt = updateFileMod (updateModDoc (commentedItem cmt) (fileMod m)) m
 
 docFuncRepr :: (MethodSym repr) => String -> [String] -> [String] -> 
   repr (Method repr) -> repr (Method repr)

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer.hs
@@ -65,11 +65,11 @@ import GOOL.Drasil.Symantics (Label, Library, RenderSym(..), BodySym(..),
   ParameterSym(..), MethodSym(..), InternalMethod(..), BlockCommentSym(..))
 import qualified GOOL.Drasil.Symantics as S (TypeSym(char, int))
 import GOOL.Drasil.Data (Terminator(..), FileData(..), fileD, updateFileMod, 
-  updateModDoc, OpData(..), od, ParamData(..), pd, TypeData(..), td, 
+  updateModDoc, OpData(..), od, ParamData(..), pd, paramName, TypeData(..), td, 
   ValData(..), vd, Binding(..), VarData(..), vard)
 import GOOL.Drasil.Helpers (angles, doubleQuotedText, hicat, vibcat, vmap, 
   emptyIfEmpty, emptyIfNull, getInnerType, getNestDegree, convType)
-import GOOL.Drasil.State (GS)
+import GOOL.Drasil.State (GS, getParameters)
 
 import Control.Applicative ((<|>))
 import Data.List (intersperse, last)
@@ -1134,8 +1134,9 @@ commentedModD m cmt = updateFileMod (updateModDoc (commentedItem cmt) (fileMod m
 
 docFuncRepr :: (MethodSym repr) => String -> [String] -> [String] -> 
   GS (repr (Method repr)) -> GS (repr (Method repr))
-docFuncRepr desc pComms rComms fn = commentedFunc (docComment $ fmap 
-  (\f -> functionDox desc (zip (map parameterName (parameters f)) pComms) rComms) fn) fn
+docFuncRepr desc pComms rComms = commentedFunc (docComment $ fmap 
+  (\ps -> functionDox desc (zip (map paramName ps) pComms) rComms) 
+  getParameters)
 
 -- Helper Functions --
 

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer.hs
@@ -1084,8 +1084,8 @@ publicDocD = text "public"
 blockCmtDoc :: [String] -> Doc -> Doc -> Doc
 blockCmtDoc lns start end = start <+> vcat (map text lns) <+> end
 
-docCmtDoc :: Doc -> Doc -> [String] -> Doc
-docCmtDoc start end lns = emptyIfNull lns $
+docCmtDoc :: [String] -> Doc -> Doc -> Doc
+docCmtDoc lns start end = emptyIfNull lns $
   vcat $ start : map (indent . text) lns ++ [end]
 
 commentedItem :: Doc -> Doc -> Doc

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer.hs
@@ -1083,11 +1083,11 @@ publicDocD = text "public"
 
 -- Comment Functions -- 
 
-blockCmtDoc :: [String] -> Doc -> Doc -> Doc
-blockCmtDoc lns start end = start <+> vcat (map text lns) <+> end
+blockCmtDoc :: [String] -> Doc -> Doc -> State GOOLState Doc
+blockCmtDoc lns start end = return $ start <+> vcat (map text lns) <+> end
 
-docCmtDoc :: [String] -> Doc -> Doc -> Doc
-docCmtDoc lns start end = emptyIfNull lns $
+docCmtDoc :: Doc -> Doc -> [String] -> Doc
+docCmtDoc start end lns = emptyIfNull lns $
   vcat $ start : map (indent . text) lns ++ [end]
 
 commentedItem :: Doc -> Doc -> Doc
@@ -1130,15 +1130,13 @@ moduleDox desc as date m = (doxFile ++ m) :
   [doxDate ++ date | not (null date)] ++ 
   [doxBrief ++ desc | not (null desc)]
 
-commentedModD :: Doc -> State GOOLState FileData -> State GOOLState FileData
-commentedModD cmt mod = do
-  m <- mod
-  return $ updateFileMod (updateModDoc (commentedItem cmt 
+commentedModD :: Doc -> FileData -> FileData
+commentedModD cmt m = updateFileMod (updateModDoc (commentedItem cmt 
     ((modDoc . fileMod) m)) (fileMod m)) m
 
 docFuncRepr :: (MethodSym repr) => String -> [String] -> [String] -> 
   repr (Method repr) -> repr (Method repr)
-docFuncRepr desc pComms rComms f = commentedFunc (docComment $ functionDox desc
+docFuncRepr desc pComms rComms f = commentedFunc (docComment $ return $ functionDox desc
   (zip (map parameterName (parameters f)) pComms) rComms) f
 
 -- Helper Functions --

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer.hs
@@ -111,8 +111,8 @@ addExt ext nm = nm ++ "." ++ ext
 
 packageDocD :: Label -> Doc -> FileData -> FileData
 packageDocD n end f = fileD (n ++ "/" ++ filePath f) (updateModDoc 
-  (emptyIfEmpty (modDoc $ fileMod f) (vibcat [text "package" <+> text n <> end, 
-  modDoc (fileMod f)])) (fileMod f))
+  (\d -> emptyIfEmpty d (vibcat [text "package" <+> text n <> end, d])) 
+  (fileMod f))
 
 fileDoc' :: Doc -> Doc -> Doc -> Doc
 fileDoc' t m b = vibcat (filter (not . isEmpty) [
@@ -1131,8 +1131,7 @@ moduleDox desc as date m = (doxFile ++ m) :
   [doxBrief ++ desc | not (null desc)]
 
 commentedModD :: Doc -> FileData -> FileData
-commentedModD cmt m = updateFileMod (updateModDoc (commentedItem cmt 
-    ((modDoc . fileMod) m)) (fileMod m)) m
+commentedModD cmt m = updateFileMod (updateModDoc (commentedItem cmt) (fileMod m)) m
 
 docFuncRepr :: (MethodSym repr) => String -> [String] -> [String] -> 
   repr (Method repr) -> repr (Method repr)

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer.hs
@@ -69,10 +69,9 @@ import GOOL.Drasil.Data (Terminator(..), FileData(..), fileD, updateFileMod,
   ValData(..), vd, Binding(..), VarData(..), vard)
 import GOOL.Drasil.Helpers (angles, doubleQuotedText, hicat, vibcat, vmap, 
   emptyIfEmpty, emptyIfNull, getInnerType, getNestDegree, convType)
-import GOOL.Drasil.State (GOOLState)
+import GOOL.Drasil.State (GS)
 
 import Control.Applicative ((<|>))
-import Control.Monad.State (State)
 import Data.List (intersperse, last)
 import Data.Bifunctor (first)
 import Data.Map as Map (lookup, fromList)
@@ -1134,7 +1133,7 @@ commentedModD :: FileData -> Doc -> FileData
 commentedModD m cmt = updateFileMod (updateModDoc (commentedItem cmt) (fileMod m)) m
 
 docFuncRepr :: (MethodSym repr) => String -> [String] -> [String] -> 
-  State GOOLState (repr (Method repr)) -> State GOOLState (repr (Method repr))
+  GS (repr (Method repr)) -> GS (repr (Method repr))
 docFuncRepr desc pComms rComms fn = commentedFunc (docComment $ fmap 
   (\f -> functionDox desc (zip (map parameterName (parameters f)) pComms) rComms) fn) fn
 

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer/CSharpRenderer.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer/CSharpRenderer.hs
@@ -548,6 +548,7 @@ instance InternalMethod CSharpCode where
     cmt)
   
   methodDoc = mthdDoc . unCSC
+  methodFromData _ = return . mthd []
 
 instance StateVarSym CSharpCode where
   type StateVar CSharpCode = Doc

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer/CSharpRenderer.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer/CSharpRenderer.hs
@@ -585,7 +585,7 @@ instance ModuleSym CSharpCode where
   
 instance InternalMod CSharpCode where
   moduleDoc = modDoc . unCSC
-  modFromData n = G.modFromData n (\m d -> return $ md n m d)
+  modFromData n = G.modFromData n (\d m -> return $ md n m d)
   updateModuleDoc f = fmap (fmap (updateModDoc f))
 
 instance BlockCommentSym CSharpCode where

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer/CSharpRenderer.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer/CSharpRenderer.hs
@@ -541,14 +541,14 @@ instance MethodSym CSharpCode where
 
 instance InternalMethod CSharpCode where
   intMethod m n _ s p t ps b = getPutReturn (setParameters (map unCSC ps) . 
-    if m then setCurrMain m . setMain else id) $ liftA2 mthd (checkParams n <$> 
-    sequence ps) (liftA5 (methodDocD n) s p t (liftList paramListDocD ps) b)
+    if m then setCurrMain m . setMain else id) $ fmap mthd (liftA5 (methodDocD 
+    n) s p t (liftList (paramListDocD . checkParams n) ps) b)
   intFunc = G.intFunc
   commentedFunc cmt = liftA2 (liftA2 updateMthdDoc) (fmap (fmap commentedItem) 
     cmt)
   
   methodDoc = mthdDoc . unCSC
-  methodFromData _ = return . mthd []
+  methodFromData _ = return . mthd
 
 instance StateVarSym CSharpCode where
   type StateVar CSharpCode = Doc

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer/CSharpRenderer.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer/CSharpRenderer.hs
@@ -62,7 +62,8 @@ import GOOL.Drasil.Data (Terminator(..), FileType(..), FileData(..), fileD,
   FuncData(..), fd, ModData(..), md, updateModDoc, MethodData(..), mthd, 
   updateMthdDoc, OpData(..), ParamData(..), updateParamDoc, ProgData(..), progD,
   TypeData(..), td, ValData(..), vd, updateValDoc, Binding(..), VarData(..), vard)
-import GOOL.Drasil.Helpers (liftA4, liftA5, liftList, lift1List, checkParams)
+import GOOL.Drasil.Helpers (toCode, onStateValue, liftA4, liftA5, liftList, 
+  lift1List, checkParams)
 import GOOL.Drasil.State (GS, initialState, putAfter, getPutReturn, setMain, 
   setCurrMain, setParameters)
 
@@ -577,7 +578,7 @@ instance ClassSym CSharpCode where
 
 instance InternalClass CSharpCode where
   classDoc = unCSC
-  classFromData = fmap return
+  classFromData = onStateValue toCode
 
 instance ModuleSym CSharpCode where
   type Module CSharpCode = ModData

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer/CSharpRenderer.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer/CSharpRenderer.hs
@@ -582,16 +582,16 @@ instance InternalClass CSharpCode where
   classFromData = fmap return
 
 instance ModuleSym CSharpCode where
-  type Module CSharpCode = State GOOLState ModData
-  buildModule n _ ms cs = liftA3 passState2Lists (sequence ms) (sequence cs) 
+  type Module CSharpCode = ModData
+  buildModule n _ ms cs = passState2Lists (sequence ms) (sequence cs) 
     (G.buildModule' n ms cs)
     
-  moduleName = name . (`evalState` initialState) . unCSC
+  moduleName = name . unCSC
   
 instance InternalMod CSharpCode where
-  isMainModule = isMainMod . (`evalState` initialState) . unCSC
-  moduleDoc = modDoc . (`evalState` initialState) . unCSC
-  modFromData n m d = return $ return $ md n m d
+  isMainModule = isMainMod . unCSC
+  moduleDoc = modDoc . unCSC
+  modFromData n = liftA2 (\m d -> return $ md n m d)
   updateModuleDoc f = fmap (fmap (updateModDoc f))
 
 instance BlockCommentSym CSharpCode where

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer/CSharpRenderer.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer/CSharpRenderer.hs
@@ -63,8 +63,8 @@ import GOOL.Drasil.Data (Terminator(..), FileType(..), FileData(..), fileD,
   updateMthdDoc, OpData(..), ParamData(..), updateParamDoc, ProgData(..), progD,
   TypeData(..), td, ValData(..), vd, updateValDoc, Binding(..), VarData(..), vard)
 import GOOL.Drasil.Helpers (liftA4, liftA5, liftList, lift1List, checkParams)
-import GOOL.Drasil.State (GS, initialState, getPutReturn, setMain, setCurrMain, 
-  setParameters)
+import GOOL.Drasil.State (GS, initialState, putAfter, getPutReturn, setMain, 
+  setCurrMain, setParameters)
 
 import Prelude hiding (break,print,(<>),sin,cos,tan,floor)
 import Control.Applicative (Applicative, liftA2, liftA3)
@@ -90,7 +90,7 @@ instance Monad CSharpCode where
 
 instance ProgramSym CSharpCode where
   type Program CSharpCode = ProgData
-  prog n = liftList (liftList (progD n))
+  prog n = liftList (liftList (progD n)) . map (putAfter $ setCurrMain False)
 
 instance RenderSym CSharpCode where
   type RenderFile CSharpCode = FileData

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer/CSharpRenderer.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer/CSharpRenderer.hs
@@ -64,7 +64,7 @@ import GOOL.Drasil.Data (Terminator(..), FileType(..), FileData(..), fileD,
   TypeData(..), td, ValData(..), vd, updateValDoc, Binding(..), VarData(..), vard)
 import GOOL.Drasil.Helpers (liftA4, liftA5, liftList, lift1List, checkParams)
 import GOOL.Drasil.State (GS, initialState, getPutReturn, 
-  passState2Lists, setMain)
+  passState2Lists, setMain, setCurrMain)
 
 import Prelude hiding (break,print,(<>),sin,cos,tan,floor)
 import Control.Applicative (Applicative, liftA2, liftA3)
@@ -543,14 +543,13 @@ instance MethodSym CSharpCode where
   parameters m = map return $ (mthdParams . unCSC) m
 
 instance InternalMethod CSharpCode where
-  intMethod m n _ s p t ps b = (if m then getPutReturn setMain else return) $ 
-    liftA2 (mthd m) (checkParams n <$> sequence ps) (liftA5 (methodDocD n) s p 
-    t (liftList paramListDocD ps) b)
+  intMethod m n _ s p t ps b = (if m then getPutReturn (setCurrMain m . setMain)
+    else return) $  liftA2 mthd (checkParams n <$> sequence ps) (liftA5 
+    (methodDocD n) s p t (liftList paramListDocD ps) b)
   intFunc = G.intFunc
   commentedFunc cmt = liftA2 (liftA2 updateMthdDoc) (fmap (fmap commentedItem) 
     cmt)
   
-  isMainMethod = isMainMthd . unCSC
   methodDoc = mthdDoc . unCSC
 
 instance StateVarSym CSharpCode where

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer/CSharpRenderer.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer/CSharpRenderer.hs
@@ -59,7 +59,7 @@ import qualified GOOL.Drasil.LanguageRenderer.LanguagePolymorphic as G (
   privMVar, pubMVar, pubGVar, buildClass, enum, privClass, pubClass, docClass, 
   commentedClass, buildModule', fileDoc, docMod)
 import GOOL.Drasil.Data (Terminator(..), FileType(..), FileData(..), 
-  FuncData(..), fd, ModData(..), md, MethodData(..), mthd, updateMthdDoc, 
+  FuncData(..), fd, ModData(..), md, updateModDoc, MethodData(..), mthd, updateMthdDoc, 
   OpData(..), ParamData(..), updateParamDoc, ProgData(..), progD, TypeData(..), 
   td, ValData(..), vd, updateValDoc, Binding(..), VarData(..), vard)
 import GOOL.Drasil.Helpers (liftA4, liftA5, liftList, lift1List, checkParams)
@@ -94,8 +94,8 @@ instance ProgramSym CSharpCode where
 
 instance RenderSym CSharpCode where
   type RenderFile CSharpCode = State GOOLState FileData
-  fileDoc code = liftA2 passState code (G.fileDoc Combined csExt (top code) 
-    bottom code)
+  fileDoc code = G.fileDoc Combined csExt (top code) 
+    bottom code
 
   docMod = G.docMod
 
@@ -593,6 +593,7 @@ instance InternalMod CSharpCode where
   isMainModule = isMainMod . (`evalState` initialState) . unCSC
   moduleDoc = modDoc . (`evalState` initialState) . unCSC
   modFromData n m d = return $ return $ md n m d
+  updateModuleDoc f = fmap (fmap (updateModDoc f))
 
 instance BlockCommentSym CSharpCode where
   type BlockComment CSharpCode = State GOOLState Doc

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer/CSharpRenderer.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer/CSharpRenderer.hs
@@ -69,6 +69,7 @@ import GOOL.Drasil.State (GS, initialState, putAfter, getPutReturn, setMain,
 import Prelude hiding (break,print,(<>),sin,cos,tan,floor)
 import Control.Applicative (Applicative, liftA2, liftA3)
 import Control.Monad.State (evalState)
+import Control.Monad (liftM2)
 import Text.PrettyPrint.HughesPJ (Doc, text, (<>), (<+>), parens, comma, empty,
   semi, vcat, lbrace, rbrace, colon)
 
@@ -105,7 +106,7 @@ instance InternalFile CSharpCode where
   top _ = liftA2 cstop endStatement (include "")
   bottom = return empty
 
-  fileFromData = G.fileFromData (\fp m -> fmap (fileD fp) m)
+  fileFromData = G.fileFromData (\m fp -> fmap (fileD fp) m)
 
 instance KeywordSym CSharpCode where
   type Keyword CSharpCode = Doc
@@ -544,8 +545,8 @@ instance InternalMethod CSharpCode where
     if m then setCurrMain m . setMain else id) $ fmap mthd (liftA5 (methodDocD 
     n) s p t (liftList (paramListDocD . checkParams n) ps) b)
   intFunc = G.intFunc
-  commentedFunc cmt = liftA2 (liftA2 updateMthdDoc) (fmap (fmap commentedItem) 
-    cmt)
+  commentedFunc cmt m = liftM2 (liftA2 updateMthdDoc) m 
+    (fmap (fmap commentedItem) cmt)
   
   methodDoc = mthdDoc . unCSC
   methodFromData _ = return . mthd

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer/CSharpRenderer.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer/CSharpRenderer.hs
@@ -69,7 +69,6 @@ import GOOL.Drasil.State (MS, lensMStoGS, initialState, putAfter, getPutReturn,
 
 import Prelude hiding (break,print,(<>),sin,cos,tan,floor)
 import Control.Lens (over)
-import Control.Lens.Zoom (zoom)
 import Control.Applicative (Applicative, liftA2, liftA3)
 import Control.Monad.State (evalState)
 import Control.Monad (liftM2)
@@ -549,7 +548,7 @@ instance InternalMethod CSharpCode where
     (liftA5 (methodDocD n) s p t (liftList (paramListDocD . checkParams n) ps) b)
   intFunc = G.intFunc
   commentedFunc cmt m = liftM2 (liftA2 updateMthdDoc) m 
-    (fmap (fmap commentedItem) (zoom lensMStoGS cmt))
+    (fmap (fmap commentedItem) cmt)
   
   methodDoc = mthdDoc . unCSC
   methodFromData _ = return . mthd

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer/CSharpRenderer.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer/CSharpRenderer.hs
@@ -63,12 +63,12 @@ import GOOL.Drasil.Data (Terminator(..), FileType(..), FileData(..), fileD,
   updateMthdDoc, OpData(..), ParamData(..), updateParamDoc, ProgData(..), progD,
   TypeData(..), td, ValData(..), vd, updateValDoc, Binding(..), VarData(..), vard)
 import GOOL.Drasil.Helpers (liftA4, liftA5, liftList, lift1List, checkParams)
-import GOOL.Drasil.State (GOOLState, initialState, getPutReturn, 
+import GOOL.Drasil.State (GS, initialState, getPutReturn, 
   passState2Lists, setMain)
 
 import Prelude hiding (break,print,(<>),sin,cos,tan,floor)
 import Control.Applicative (Applicative, liftA2, liftA3)
-import Control.Monad.State (State, evalState)
+import Control.Monad.State (evalState)
 import Text.PrettyPrint.HughesPJ (Doc, text, (<>), (<+>), parens, comma, empty,
   semi, vcat, lbrace, rbrace, colon)
 
@@ -698,11 +698,11 @@ csObjVar o v = csObjVar' (varBind v)
 csInOut :: (CSharpCode (Scope CSharpCode) -> CSharpCode (Permanence CSharpCode) 
     -> CSharpCode (Type CSharpCode) -> [CSharpCode (Parameter CSharpCode)] -> 
     CSharpCode (Body CSharpCode) -> 
-    State GOOLState (CSharpCode (Method CSharpCode)))
+    GS (CSharpCode (Method CSharpCode)))
   -> CSharpCode (Scope CSharpCode) -> CSharpCode (Permanence CSharpCode) -> 
   [CSharpCode (Variable CSharpCode)] -> [CSharpCode (Variable CSharpCode)] -> 
   [CSharpCode (Variable CSharpCode)] -> CSharpCode (Body CSharpCode) -> 
-  State GOOLState (CSharpCode (Method CSharpCode))
+  GS (CSharpCode (Method CSharpCode))
 csInOut f s p ins [v] [] b = f s p (variableType v) (map param ins)
   (liftA3 surroundBody (varDec v) b (returnState $ valueOf v))
 csInOut f s p ins [] [v] b = f s p (if null (filterOutObjs [v]) then void 

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer/CSharpRenderer.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer/CSharpRenderer.hs
@@ -89,7 +89,7 @@ instance Monad CSharpCode where
   CSC x >>= f = f x
 
 instance ProgramSym CSharpCode where
-  type Program CSharpCode = State GOOLState ProgData
+  type Program CSharpCode = ProgData
   prog n = liftList (liftList (progD n))
 
 instance RenderSym CSharpCode where

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer/CSharpRenderer.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer/CSharpRenderer.hs
@@ -63,8 +63,8 @@ import GOOL.Drasil.Data (Terminator(..), FileType(..), FileData(..), fileD,
   updateMthdDoc, OpData(..), ParamData(..), updateParamDoc, ProgData(..), progD,
   TypeData(..), td, ValData(..), vd, updateValDoc, Binding(..), VarData(..), vard)
 import GOOL.Drasil.Helpers (liftA4, liftA5, liftList, lift1List, checkParams)
-import GOOL.Drasil.State (GS, initialState, getPutReturn, 
-  passState2Lists, setMain, setCurrMain)
+import GOOL.Drasil.State (GS, initialState, getPutReturn, passState2Lists, 
+  setMain, setCurrMain, setParameters)
 
 import Prelude hiding (break,print,(<>),sin,cos,tan,floor)
 import Control.Applicative (Applicative, liftA2, liftA3)
@@ -512,7 +512,6 @@ instance ParameterSym CSharpCode where
   param = fmap (mkParam paramDocD)
   pointerParam = param
 
-  parameterName = variableName . fmap paramVar
   parameterType = variableType . fmap paramVar
 
 instance MethodSym CSharpCode where
@@ -539,13 +538,11 @@ instance MethodSym CSharpCode where
   inOutFunc n = csInOut (function n)
 
   docInOutFunc n = G.docInOutFunc (inOutFunc n)
-  
-  parameters m = map return $ (mthdParams . unCSC) m
 
 instance InternalMethod CSharpCode where
-  intMethod m n _ s p t ps b = (if m then getPutReturn (setCurrMain m . setMain)
-    else return) $  liftA2 mthd (checkParams n <$> sequence ps) (liftA5 
-    (methodDocD n) s p t (liftList paramListDocD ps) b)
+  intMethod m n _ s p t ps b = getPutReturn (setParameters (map unCSC ps) . 
+    if m then setCurrMain m . setMain else id) $ liftA2 mthd (checkParams n <$> 
+    sequence ps) (liftA5 (methodDocD n) s p t (liftList paramListDocD ps) b)
   intFunc = G.intFunc
   commentedFunc cmt = liftA2 (liftA2 updateMthdDoc) (fmap (fmap commentedItem) 
     cmt)

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer/CSharpRenderer.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer/CSharpRenderer.hs
@@ -583,8 +583,7 @@ instance InternalClass CSharpCode where
 
 instance ModuleSym CSharpCode where
   type Module CSharpCode = ModData
-  buildModule n _ ms cs = passState2Lists (sequence ms) (sequence cs) 
-    (G.buildModule' n ms cs)
+  buildModule n _ ms cs = passState2Lists ms cs (G.buildModule' n ms cs)
     
   moduleName = name . unCSC
   

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer/CSharpRenderer.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer/CSharpRenderer.hs
@@ -595,11 +595,10 @@ instance InternalMod CSharpCode where
   updateModuleDoc f = fmap (fmap (updateModDoc f))
 
 instance BlockCommentSym CSharpCode where
-  type BlockComment CSharpCode = State GOOLState Doc
-  blockComment lns = liftA2 (\bcs bce -> return $ blockCmtDoc lns bcs bce) 
-    blockCommentStart blockCommentEnd
-  docComment lns = liftA2 (\dcs dce -> fmap (docCmtDoc dcs dce) lns) 
-    docCommentStart docCommentEnd
+  type BlockComment CSharpCode = Doc
+  blockComment lns = liftA2 (blockCmtDoc lns) blockCommentStart blockCommentEnd
+  docComment = fmap (\lns -> liftA2 (docCmtDoc lns) docCommentStart 
+    docCommentEnd)
 
   blockCommentDoc = unCSC
 

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer/CSharpRenderer.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer/CSharpRenderer.hs
@@ -105,7 +105,6 @@ instance InternalFile CSharpCode where
   top _ = liftA2 cstop endStatement (include "")
   bottom = return empty
 
-  getFilePath = filePath . (`evalState` initialState) . unCSC
   fileFromData ft fp = fmap (G.fileFromData ft fp)
 
 instance KeywordSym CSharpCode where

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer/CSharpRenderer.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer/CSharpRenderer.hs
@@ -567,7 +567,7 @@ instance InternalStateVar CSharpCode where
   stateVarFromData = return . return
 
 instance ClassSym CSharpCode where
-  type Class CSharpCode = State GOOLState Doc
+  type Class CSharpCode = Doc
   buildClass = G.buildClass classDocD inherit
   enum = G.enum
   privClass = G.privClass
@@ -578,8 +578,8 @@ instance ClassSym CSharpCode where
   commentedClass = G.commentedClass
 
 instance InternalClass CSharpCode where
-  classDoc = (`evalState` initialState) . unCSC
-  classFromData = return
+  classDoc = unCSC
+  classFromData = fmap return
 
 instance ModuleSym CSharpCode where
   type Module CSharpCode = State GOOLState ModData

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer/CSharpRenderer.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer/CSharpRenderer.hs
@@ -63,8 +63,8 @@ import GOOL.Drasil.Data (Terminator(..), FileType(..), FileData(..), fileD,
   updateMthdDoc, OpData(..), ParamData(..), updateParamDoc, ProgData(..), progD,
   TypeData(..), td, ValData(..), vd, updateValDoc, Binding(..), VarData(..), vard)
 import GOOL.Drasil.Helpers (liftA4, liftA5, liftList, lift1List, checkParams)
-import GOOL.Drasil.State (GS, initialState, getPutReturn, passState2Lists, 
-  setMain, setCurrMain, setParameters)
+import GOOL.Drasil.State (GS, initialState, getPutReturn, setMain, setCurrMain, 
+  setParameters)
 
 import Prelude hiding (break,print,(<>),sin,cos,tan,floor)
 import Control.Applicative (Applicative, liftA2, liftA3)
@@ -579,7 +579,7 @@ instance InternalClass CSharpCode where
 
 instance ModuleSym CSharpCode where
   type Module CSharpCode = ModData
-  buildModule n _ ms cs = passState2Lists ms cs (G.buildModule' n ms cs)
+  buildModule n _ = G.buildModule' n
   
 instance InternalMod CSharpCode where
   moduleDoc = modDoc . unCSC

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer/CSharpRenderer.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer/CSharpRenderer.hs
@@ -64,10 +64,12 @@ import GOOL.Drasil.Data (Terminator(..), FileType(..), FileData(..), fileD,
   TypeData(..), td, ValData(..), vd, updateValDoc, Binding(..), VarData(..), vard)
 import GOOL.Drasil.Helpers (toCode, onStateValue, liftA4, liftA5, liftList, 
   lift1List, checkParams)
-import GOOL.Drasil.State (GS, initialState, putAfter, getPutReturn, setMain, 
-  setCurrMain, setParameters)
+import GOOL.Drasil.State (MS, lensMStoGS, initialState, putAfter, getPutReturn, 
+  setMain, setCurrMain, setParameters)
 
 import Prelude hiding (break,print,(<>),sin,cos,tan,floor)
+import Control.Lens (over)
+import Control.Lens.Zoom (zoom)
 import Control.Applicative (Applicative, liftA2, liftA3)
 import Control.Monad.State (evalState)
 import Control.Monad (liftM2)
@@ -543,11 +545,11 @@ instance MethodSym CSharpCode where
 
 instance InternalMethod CSharpCode where
   intMethod m n _ s p t ps b = getPutReturn (setParameters (map unCSC ps) . 
-    if m then setCurrMain m . setMain else id) $ fmap mthd (liftA5 (methodDocD 
-    n) s p t (liftList (paramListDocD . checkParams n) ps) b)
+    if m then over lensMStoGS (setCurrMain m) . setMain else id) $ fmap mthd 
+    (liftA5 (methodDocD n) s p t (liftList (paramListDocD . checkParams n) ps) b)
   intFunc = G.intFunc
   commentedFunc cmt m = liftM2 (liftA2 updateMthdDoc) m 
-    (fmap (fmap commentedItem) cmt)
+    (fmap (fmap commentedItem) (zoom lensMStoGS cmt))
   
   methodDoc = mthdDoc . unCSC
   methodFromData _ = return . mthd
@@ -694,11 +696,11 @@ csObjVar o v = csObjVar' (varBind v)
 csInOut :: (CSharpCode (Scope CSharpCode) -> CSharpCode (Permanence CSharpCode) 
     -> CSharpCode (Type CSharpCode) -> [CSharpCode (Parameter CSharpCode)] -> 
     CSharpCode (Body CSharpCode) -> 
-    GS (CSharpCode (Method CSharpCode)))
+    MS (CSharpCode (Method CSharpCode)))
   -> CSharpCode (Scope CSharpCode) -> CSharpCode (Permanence CSharpCode) -> 
   [CSharpCode (Variable CSharpCode)] -> [CSharpCode (Variable CSharpCode)] -> 
   [CSharpCode (Variable CSharpCode)] -> CSharpCode (Body CSharpCode) -> 
-  GS (CSharpCode (Method CSharpCode))
+  MS (CSharpCode (Method CSharpCode))
 csInOut f s p ins [v] [] b = f s p (variableType v) (map param ins)
   (liftA3 surroundBody (varDec v) b (returnState $ valueOf v))
 csInOut f s p ins [] [v] b = f s p (if null (filterOutObjs [v]) then void 

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer/CSharpRenderer.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer/CSharpRenderer.hs
@@ -100,7 +100,7 @@ instance RenderSym CSharpCode where
 
   docMod = G.docMod
 
-  commentedMod = liftA2 (liftA2 commentedModD)
+  commentedMod cmt m = liftM2 (liftA2 commentedModD) m cmt
 
 instance InternalFile CSharpCode where
   top _ = liftA2 cstop endStatement (include "")

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer/CSharpRenderer.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer/CSharpRenderer.hs
@@ -596,7 +596,8 @@ instance InternalMod CSharpCode where
 
 instance BlockCommentSym CSharpCode where
   type BlockComment CSharpCode = State GOOLState Doc
-  blockComment lns = liftA2 (blockCmtDoc lns) blockCommentStart blockCommentEnd
+  blockComment lns = liftA2 (\bcs bce -> return $ blockCmtDoc lns bcs bce) 
+    blockCommentStart blockCommentEnd
   docComment lns = liftA2 (\dcs dce -> fmap (docCmtDoc dcs dce) lns) 
     docCommentStart docCommentEnd
 

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer/CSharpRenderer.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer/CSharpRenderer.hs
@@ -58,7 +58,7 @@ import qualified GOOL.Drasil.LanguageRenderer.LanguagePolymorphic as G (
   mainFunction, docFunc, docInOutFunc, intFunc, stateVar, stateVarDef, constVar,
   privMVar, pubMVar, pubGVar, buildClass, enum, privClass, pubClass, docClass, 
   commentedClass, buildModule', fileDoc, docMod)
-import GOOL.Drasil.Data (Terminator(..), FileType(..), FileData(..), 
+import GOOL.Drasil.Data (Terminator(..), FileType(..), FileData(..), fileD,
   FuncData(..), fd, ModData(..), md, updateModDoc, MethodData(..), mthd, 
   updateMthdDoc, OpData(..), ParamData(..), updateParamDoc, ProgData(..), progD,
   TypeData(..), td, ValData(..), vd, updateValDoc, Binding(..), VarData(..), vard)
@@ -93,8 +93,8 @@ instance ProgramSym CSharpCode where
   prog n = liftList (liftList (progD n))
 
 instance RenderSym CSharpCode where
-  type RenderFile CSharpCode = State GOOLState FileData
-  fileDoc code = G.fileDoc Combined csExt (top code) 
+  type RenderFile CSharpCode = FileData
+  fileDoc code = G.fileDoc Combined csExt (top $ evalState code initialState) 
     bottom code
 
   docMod = G.docMod
@@ -105,7 +105,7 @@ instance InternalFile CSharpCode where
   top _ = liftA2 cstop endStatement (include "")
   bottom = return empty
 
-  fileFromData ft fp = fmap (G.fileFromData ft fp)
+  fileFromData = G.fileFromData (\fp m -> fmap (fileD fp) m)
 
 instance KeywordSym CSharpCode where
   type Keyword CSharpCode = Doc

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer/CSharpRenderer.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer/CSharpRenderer.hs
@@ -57,7 +57,7 @@ import qualified GOOL.Drasil.LanguageRenderer.LanguagePolymorphic as G (
   getMethod, setMethod,privMethod, pubMethod, constructor, docMain, function, 
   mainFunction, docFunc, docInOutFunc, intFunc, stateVar, stateVarDef, constVar,
   privMVar, pubMVar, pubGVar, buildClass, enum, privClass, pubClass, docClass, 
-  commentedClass, buildModule', fileDoc, docMod)
+  commentedClass, buildModule', modFromData, fileDoc, docMod)
 import GOOL.Drasil.Data (Terminator(..), FileType(..), FileData(..), fileD,
   FuncData(..), fd, ModData(..), md, updateModDoc, MethodData(..), mthd, 
   updateMthdDoc, OpData(..), ParamData(..), updateParamDoc, ProgData(..), progD,
@@ -584,13 +584,10 @@ instance InternalClass CSharpCode where
 instance ModuleSym CSharpCode where
   type Module CSharpCode = ModData
   buildModule n _ ms cs = passState2Lists ms cs (G.buildModule' n ms cs)
-    
-  moduleName = name . unCSC
   
 instance InternalMod CSharpCode where
-  isMainModule = isMainMod . unCSC
   moduleDoc = modDoc . unCSC
-  modFromData n = liftA2 (\m d -> return $ md n m d)
+  modFromData n = G.modFromData n (\m d -> return $ md n m d)
   updateModuleDoc f = fmap (fmap (updateModDoc f))
 
 instance BlockCommentSym CSharpCode where

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer/CSharpRenderer.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer/CSharpRenderer.hs
@@ -554,7 +554,7 @@ instance InternalMethod CSharpCode where
   methodDoc = mthdDoc . unCSC
 
 instance StateVarSym CSharpCode where
-  type StateVar CSharpCode = State GOOLState Doc
+  type StateVar CSharpCode = Doc
   stateVar = G.stateVar
   stateVarDef _ = G.stateVarDef
   constVar _ = G.constVar empty
@@ -563,7 +563,7 @@ instance StateVarSym CSharpCode where
   pubGVar = G.pubGVar
 
 instance InternalStateVar CSharpCode where
-  stateVarDoc = (`evalState` initialState) . unCSC
+  stateVarDoc = unCSC
   stateVarFromData = return . return
 
 instance ClassSym CSharpCode where

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer/CSharpRenderer.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer/CSharpRenderer.hs
@@ -59,12 +59,12 @@ import qualified GOOL.Drasil.LanguageRenderer.LanguagePolymorphic as G (
   privMVar, pubMVar, pubGVar, buildClass, enum, privClass, pubClass, docClass, 
   commentedClass, buildModule', fileDoc, docMod)
 import GOOL.Drasil.Data (Terminator(..), FileType(..), FileData(..), 
-  FuncData(..), fd, ModData(..), md, updateModDoc, MethodData(..), mthd, updateMthdDoc, 
-  OpData(..), ParamData(..), updateParamDoc, ProgData(..), progD, TypeData(..), 
-  td, ValData(..), vd, updateValDoc, Binding(..), VarData(..), vard)
+  FuncData(..), fd, ModData(..), md, updateModDoc, MethodData(..), mthd, 
+  updateMthdDoc, OpData(..), ParamData(..), updateParamDoc, ProgData(..), progD,
+  TypeData(..), td, ValData(..), vd, updateValDoc, Binding(..), VarData(..), vard)
 import GOOL.Drasil.Helpers (liftA4, liftA5, liftList, lift1List, checkParams)
 import GOOL.Drasil.State (GOOLState, initialState, getPutReturn, 
-  passState, passState2Lists, setMain)
+  passState2Lists, setMain)
 
 import Prelude hiding (break,print,(<>),sin,cos,tan,floor)
 import Control.Applicative (Applicative, liftA2, liftA3)

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer/CSharpRenderer.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer/CSharpRenderer.hs
@@ -99,7 +99,7 @@ instance RenderSym CSharpCode where
 
   docMod = G.docMod
 
-  commentedMod = liftA2 commentedModD
+  commentedMod = liftA2 (liftA2 commentedModD)
 
 instance InternalFile CSharpCode where
   top _ = liftA2 cstop endStatement (include "")
@@ -548,7 +548,8 @@ instance InternalMethod CSharpCode where
     liftA2 (mthd m) (checkParams n <$> sequence ps) (liftA5 (methodDocD n) s p 
     t (liftList paramListDocD ps) b)
   intFunc = G.intFunc
-  commentedFunc cmt = liftA2 (fmap . updateMthdDoc) (fmap commentedItem cmt)
+  commentedFunc cmt = liftA2 (liftA2 updateMthdDoc) (fmap (fmap commentedItem) 
+    cmt)
   
   isMainMethod = isMainMthd . (`evalState` initialState) . unCSC
   methodDoc = mthdDoc . (`evalState` initialState) . unCSC
@@ -579,7 +580,7 @@ instance ClassSym CSharpCode where
 
 instance InternalClass CSharpCode where
   classDoc = (`evalState` initialState) . unCSC
-  classFromData = return . return
+  classFromData = return
 
 instance ModuleSym CSharpCode where
   type Module CSharpCode = State GOOLState ModData
@@ -594,9 +595,10 @@ instance InternalMod CSharpCode where
   modFromData n m d = return $ return $ md n m d
 
 instance BlockCommentSym CSharpCode where
-  type BlockComment CSharpCode = Doc
+  type BlockComment CSharpCode = State GOOLState Doc
   blockComment lns = liftA2 (blockCmtDoc lns) blockCommentStart blockCommentEnd
-  docComment lns = liftA2 (docCmtDoc lns) docCommentStart docCommentEnd
+  docComment lns = liftA2 (\dcs dce -> fmap (docCmtDoc dcs dce) lns) 
+    docCommentStart docCommentEnd
 
   blockCommentDoc = unCSC
 

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer/CppRenderer.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer/CppRenderer.hs
@@ -73,6 +73,7 @@ import Data.Maybe (maybeToList)
 import Control.Lens ((^.))
 import Control.Applicative (Applicative, liftA2, liftA3)
 import Control.Monad.State (evalState)
+import Control.Monad (liftM3)
 import qualified Control.Monad.State as S (get)
 import Text.PrettyPrint.HughesPJ (Doc, text, (<>), (<+>), braces, parens, comma,
   empty, equals, semi, vcat, lbrace, rbrace, quotes, render, colon, isEmpty)
@@ -109,7 +110,7 @@ instance (Pair p) => RenderSym (p CppSrcCode CppHdrCode) where
 
   docMod d a dt m = pair1 m (docMod d a dt) (docMod d a dt)
 
-  commentedMod m cmt = pair2 m cmt commentedMod commentedMod
+  commentedMod cmt m = pair2 cmt m commentedMod commentedMod
 
 instance (Pair p) => InternalFile (p CppSrcCode CppHdrCode) where
   top m = pair (top $ pfst m) (top $ psnd m)
@@ -785,8 +786,8 @@ instance RenderSym CppSrcCode where
 
   docMod = G.docMod
 
-  commentedMod = liftA3 (\mn m cmt-> if mn then liftA2 commentedModD m cmt else 
-    m) getCurrMain
+  commentedMod cmnt mod = liftM3 (\m cmt mn -> if mn then liftA2 commentedModD 
+    m cmt else m) mod cmnt getCurrMain
 
 instance InternalFile CppSrcCode where
   top m = liftA3 cppstop m (list dynamic_) endStatement
@@ -1351,8 +1352,8 @@ instance RenderSym CppHdrCode where
   
   docMod = G.docMod
 
-  commentedMod = liftA3 (\mn m cmt -> if mn then m else liftA2 
-    commentedModD m cmt) getCurrMain
+  commentedMod cmnt mod = liftM3 (\m cmt mn -> if mn then m else liftA2 
+    commentedModD m cmt) mod cmnt getCurrMain
 
 instance InternalFile CppHdrCode where
   top m = liftA3 cpphtop m (list dynamic_) endStatement

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer/CppRenderer.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer/CppRenderer.hs
@@ -65,14 +65,14 @@ import GOOL.Drasil.Data (Pair(..), pairList, Terminator(..), ScopeTag(..),
 import GOOL.Drasil.Helpers (angles, doubleQuotedText, emptyIfEmpty, mapPairFst, 
   mapPairSnd, liftA4, liftA5, liftA8, liftList, lift2Lists, lift1List, 
   checkParams)
-import GOOL.Drasil.State (GOOLState, hasMain, initialState, getPutReturn, 
+import GOOL.Drasil.State (GS, hasMain, initialState, getPutReturn, 
   passState2Lists, checkGOOLState, setMain)
 
 import Prelude hiding (break,print,(<>),sin,cos,tan,floor,pi,const,log,exp)
 import Data.Maybe (maybeToList)
 import Control.Lens ((^.))
 import Control.Applicative (Applicative, liftA2, liftA3)
-import Control.Monad.State (State, evalState)
+import Control.Monad.State (evalState)
 import Text.PrettyPrint.HughesPJ (Doc, text, (<>), (<+>), braces, parens, comma,
   empty, equals, semi, vcat, lbrace, rbrace, quotes, render, colon, isEmpty)
 
@@ -1745,7 +1745,7 @@ instance MethodSym CppHdrCode where
   constructor n = G.constructor n n
   destructor n = lift1List (\m vs -> return $ mthd False Pub [] 
     (emptyIfEmpty (vcat (map (statementDoc . fmap destructSts) vs)) 
-    (methodDoc m))) ((pubMethod ('~':n) n void [] (return empty)) :: State GOOLState (CppHdrCode (Method CppHdrCode)))
+    (methodDoc m))) ((pubMethod ('~':n) n void [] (return empty)) :: GS (CppHdrCode (Method CppHdrCode)))
 
   docMain = mainFunction
 
@@ -2058,11 +2058,11 @@ cppInOutCall f n ins outs both = valState $ f n void (map valueOf both ++ ins
 cppsInOut :: (CppSrcCode (Scope CppSrcCode) -> 
     CppSrcCode (Permanence CppSrcCode) -> CppSrcCode (Type CppSrcCode) -> 
     [CppSrcCode (Parameter CppSrcCode)] -> CppSrcCode (Body CppSrcCode) -> 
-    State GOOLState (CppSrcCode (Method CppSrcCode)))
+    GS (CppSrcCode (Method CppSrcCode)))
   -> CppSrcCode (Scope CppSrcCode) -> CppSrcCode (Permanence CppSrcCode) -> 
   [CppSrcCode (Variable CppSrcCode)] -> [CppSrcCode (Variable CppSrcCode)] -> 
   [CppSrcCode (Variable CppSrcCode)] -> CppSrcCode (Body CppSrcCode) -> 
-  State GOOLState (CppSrcCode (Method CppSrcCode))
+  GS (CppSrcCode (Method CppSrcCode))
 cppsInOut f s p ins [v] [] b = f s p (variableType v) (map (fmap getParam) ins) 
   (liftA3 surroundBody (varDec v) b (returnState $ valueOf v))
 cppsInOut f s p ins [] [v] b = f s p (if null (filterOutObjs [v]) then void 
@@ -2075,11 +2075,11 @@ cppsInOut f s p ins outs both b = f s p void (map pointerParam both
 cpphInOut :: (CppHdrCode (Scope CppHdrCode) -> 
     CppHdrCode (Permanence CppHdrCode) -> CppHdrCode (Type CppHdrCode) -> 
     [CppHdrCode (Parameter CppHdrCode)] -> CppHdrCode (Body CppHdrCode) -> 
-    State GOOLState (CppHdrCode (Method CppHdrCode))) 
+    GS (CppHdrCode (Method CppHdrCode))) 
   -> CppHdrCode (Scope CppHdrCode) -> CppHdrCode (Permanence CppHdrCode) -> 
   [CppHdrCode (Variable CppHdrCode)] -> [CppHdrCode (Variable CppHdrCode)] -> 
   [CppHdrCode (Variable CppHdrCode)] -> CppHdrCode (Body CppHdrCode) -> 
-  State GOOLState (CppHdrCode (Method CppHdrCode))
+  GS (CppHdrCode (Method CppHdrCode))
 cpphInOut f s p ins [v] [] b = f s p (variableType v) (map (fmap getParam) ins) 
   b
 cpphInOut f s p ins [] [v] b = f s p (if null (filterOutObjs [v]) then void 

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer/CppRenderer.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer/CppRenderer.hs
@@ -104,14 +104,13 @@ instance (Pair p) => RenderSym (p CppSrcCode CppHdrCode) where
 
   docMod d a dt m = pair (docMod d a dt $ pfst m) (docMod d a dt $ psnd m)
 
-  commentedMod cmt m = pair (commentedMod (pfst cmt) (pfst m)) 
-    (commentedMod (psnd cmt) (psnd m))
+  commentedMod m cmt = pair (commentedMod (pfst m) (pfst cmt)) 
+    (commentedMod (psnd m) (psnd cmt))
 
 instance (Pair p) => InternalFile (p CppSrcCode CppHdrCode) where
   top m = pair (top $ pfst m) (top $ psnd m)
   bottom = pair bottom bottom
   
-  getFilePath f = getFilePath $ pfst f
   fileFromData ft fp m = pair (fileFromData ft fp $ pfst m) 
     (fileFromData ft fp $ psnd m)
 
@@ -698,6 +697,8 @@ instance (Pair p) => InternalMod (p CppSrcCode CppHdrCode) where
   isMainModule m = isMainModule $ pfst m
   moduleDoc m = moduleDoc $ pfst m
   modFromData n m d = pair (modFromData n m d) (modFromData n m d)
+  updateModuleDoc f m = pair (updateModuleDoc f $ pfst m) (updateModuleDoc f $ 
+    psnd m)
 
 instance (Pair p) => BlockCommentSym (p CppSrcCode CppHdrCode) where
   type BlockComment (p CppSrcCode CppHdrCode) = State GOOLState Doc
@@ -734,14 +735,13 @@ instance RenderSym CppSrcCode where
 
   docMod = G.docMod
 
-  commentedMod cmt m = if (isMainMod . fileMod . (`evalState` initialState) . 
-    unCPPSC) m then liftA2 (liftA2 commentedModD) cmt m else m 
+  commentedMod m cmt = if (isMainMod . fileMod . (`evalState` initialState) . 
+    unCPPSC) m then liftA2 (liftA2 commentedModD) m cmt else m 
 
 instance InternalFile CppSrcCode where
   top m = liftA3 cppstop m (list dynamic_) endStatement
   bottom = return empty
   
-  getFilePath = filePath . (`evalState` initialState) . unCPPSC
   fileFromData ft fp = fmap (G.fileFromData ft fp)
 
 instance KeywordSym CppSrcCode where
@@ -1308,14 +1308,13 @@ instance RenderSym CppHdrCode where
   
   docMod = G.docMod
 
-  commentedMod cmt m = if (isMainMod . fileMod . (`evalState` initialState) . 
-    unCPPHC) m then m else liftA2 (liftA2 commentedModD) cmt m
+  commentedMod m cmt = if (isMainMod . fileMod . (`evalState` initialState) . 
+    unCPPHC) m then m else liftA2 (liftA2 commentedModD) m cmt
 
 instance InternalFile CppHdrCode where
   top m = liftA3 cpphtop m (list dynamic_) endStatement
   bottom = return $ text "#endif"
   
-  getFilePath = filePath . (`evalState` initialState) . unCPPHC
   fileFromData ft fp = fmap (G.fileFromData ft fp)
 
 instance KeywordSym CppHdrCode where

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer/CppRenderer.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer/CppRenderer.hs
@@ -63,8 +63,8 @@ import GOOL.Drasil.Data (Pair(..), Terminator(..), ScopeTag(..),
   ParamData(..), pd, ProgData(..), progD, emptyProg, StateVarData(..), svd, 
   TypeData(..), td, ValData(..), vd, VarData(..), vard)
 import GOOL.Drasil.Helpers (angles, doubleQuotedText, emptyIfEmpty, mapPairFst, 
-  mapPairSnd, liftA4, liftA5, liftA8, liftList, lift2Lists, lift1List, 
-  checkParams)
+  mapPairSnd, toCode, onStateValue, liftA4, liftA5, liftA8, liftList, 
+  lift2Lists, lift1List, checkParams)
 import GOOL.Drasil.State (GS, initialState, putAfter, getPutReturn, setMain, 
   setCurrMain, getCurrMain, setParameters, setScope, getScope, setCurrMainFunc, 
   getCurrMainFunc)
@@ -1310,7 +1310,7 @@ instance ClassSym CppSrcCode where
 
 instance InternalClass CppSrcCode where
   classDoc = unCPPSC
-  classFromData = fmap return
+  classFromData = onStateValue toCode
 
 instance ModuleSym CppSrcCode where
   type Module CppSrcCode = ModData
@@ -1845,7 +1845,7 @@ instance ClassSym CppHdrCode where
 
 instance InternalClass CppHdrCode where
   classDoc = unCPPHC
-  classFromData = fmap return
+  classFromData = onStateValue toCode
 
 instance ModuleSym CppHdrCode where
   type Module CppHdrCode = ModData

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer/CppRenderer.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer/CppRenderer.hs
@@ -59,14 +59,14 @@ import qualified GOOL.Drasil.LanguageRenderer.LanguagePolymorphic as G (
   docClass, commentedClass, buildModule, fileDoc, docMod)
 import GOOL.Drasil.Data (Pair(..), pairList, Terminator(..), ScopeTag(..), 
   Binding(..), BindData(..), bd, FileType(..), FileData(..), FuncData(..), fd, 
-  ModData(..), md, updateModDoc, OpData(..), od, ParamData(..), pd, ProgData(..), progD, 
-  emptyProg, StateVarData(..), svd, TypeData(..), td, ValData(..), vd, 
-  VarData(..), vard)
+  ModData(..), md, updateModDoc, OpData(..), od, ParamData(..), pd, 
+  ProgData(..), progD, emptyProg, StateVarData(..), svd, TypeData(..), td, 
+  ValData(..), vd, VarData(..), vard)
 import GOOL.Drasil.Helpers (angles, doubleQuotedText, emptyIfEmpty, mapPairFst, 
   mapPairSnd, liftA4, liftA5, liftA8, liftList, lift2Lists, lift1List, 
   checkParams)
 import GOOL.Drasil.State (GOOLState, hasMain, initialState, getPutReturn, 
-  passState, passState2Lists, checkGOOLState, setMain)
+  passState2Lists, checkGOOLState, setMain)
 
 import Prelude hiding (break,print,(<>),sin,cos,tan,floor,pi,const,log,exp)
 import Data.Maybe (maybeToList)

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer/CppRenderer.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer/CppRenderer.hs
@@ -701,7 +701,7 @@ instance (Pair p) => InternalMod (p CppSrcCode CppHdrCode) where
     psnd m)
 
 instance (Pair p) => BlockCommentSym (p CppSrcCode CppHdrCode) where
-  type BlockComment (p CppSrcCode CppHdrCode) = State GOOLState Doc
+  type BlockComment (p CppSrcCode CppHdrCode) = Doc
   blockComment lns = pair (blockComment lns) (blockComment lns)
   docComment lns = pair (docComment lns) (docComment lns)
 
@@ -1277,11 +1277,10 @@ instance InternalMod CppSrcCode where
   updateModuleDoc f = fmap (fmap (updateModDoc f))
 
 instance BlockCommentSym CppSrcCode where
-  type BlockComment CppSrcCode = State GOOLState Doc
-  blockComment lns = liftA2 (\bcs bce -> return $ blockCmtDoc lns bcs bce) 
-    blockCommentStart blockCommentEnd
-  docComment lns = liftA2 (\dcs dce -> fmap (docCmtDoc dcs dce) lns) 
-    docCommentStart docCommentEnd
+  type BlockComment CppSrcCode = Doc
+  blockComment lns = liftA2 (blockCmtDoc lns) blockCommentStart blockCommentEnd
+  docComment = fmap (\lns -> liftA2 (docCmtDoc lns) docCommentStart 
+    docCommentEnd)
 
   blockCommentDoc = unCPPSC
 
@@ -1821,11 +1820,10 @@ instance InternalMod CppHdrCode where
   updateModuleDoc f = fmap (fmap (updateModDoc f))
 
 instance BlockCommentSym CppHdrCode where
-  type BlockComment CppHdrCode = State GOOLState Doc
-  blockComment lns = liftA2 (\bcs bce -> return $ blockCmtDoc lns bcs bce) 
-    blockCommentStart blockCommentEnd
-  docComment lns = liftA2 (\dcs dce -> fmap (docCmtDoc dcs dce) lns) 
-    docCommentStart docCommentEnd
+  type BlockComment CppHdrCode = Doc
+  blockComment lns = liftA2 (blockCmtDoc lns) blockCommentStart blockCommentEnd
+  docComment = fmap (\lns -> liftA2 (docCmtDoc lns) docCommentStart 
+    docCommentEnd)
 
   blockCommentDoc = unCPPHC
 

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer/CppRenderer.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer/CppRenderer.hs
@@ -1278,7 +1278,8 @@ instance InternalMod CppSrcCode where
 
 instance BlockCommentSym CppSrcCode where
   type BlockComment CppSrcCode = State GOOLState Doc
-  blockComment lns = liftA2 (blockCmtDoc lns) blockCommentStart blockCommentEnd
+  blockComment lns = liftA2 (\bcs bce -> return $ blockCmtDoc lns bcs bce) 
+    blockCommentStart blockCommentEnd
   docComment lns = liftA2 (\dcs dce -> fmap (docCmtDoc dcs dce) lns) 
     docCommentStart docCommentEnd
 
@@ -1821,7 +1822,8 @@ instance InternalMod CppHdrCode where
 
 instance BlockCommentSym CppHdrCode where
   type BlockComment CppHdrCode = State GOOLState Doc
-  blockComment lns = liftA2 (blockCmtDoc lns) blockCommentStart blockCommentEnd
+  blockComment lns = liftA2 (\bcs bce -> return $ blockCmtDoc lns bcs bce) 
+    blockCommentStart blockCommentEnd
   docComment lns = liftA2 (\dcs dce -> fmap (docCmtDoc dcs dce) lns) 
     docCommentStart docCommentEnd
 

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer/CppRenderer.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer/CppRenderer.hs
@@ -56,7 +56,7 @@ import qualified GOOL.Drasil.LanguageRenderer.LanguagePolymorphic as G (
   objDecNewNoParams, construct, comment, ifCond, for, while, method, getMethod, 
   setMethod, privMethod, pubMethod, constructor, function, docFunc, 
   docInOutFunc, intFunc, privMVar, pubMVar, pubGVar, privClass, pubClass, 
-  docClass, commentedClass, buildModule, fileDoc, docMod)
+  docClass, commentedClass, buildModule, modFromData, fileDoc, docMod)
 import GOOL.Drasil.Data (Pair(..), pairList, Terminator(..), ScopeTag(..), 
   Binding(..), BindData(..), bd, FileType(..), FileData(..), fileD, 
   FuncData(..), fd, ModData(..), md, updateModDoc, OpData(..), od, 
@@ -699,11 +699,8 @@ instance (Pair p) => ModuleSym (p CppSrcCode CppHdrCode) where
   buildModule n l ms cs = liftA2 pair (buildModule n l (map (fmap pfst) ms) 
     (map (fmap pfst) cs)) (buildModule n l (map (fmap psnd) ms) (map (fmap psnd)
     cs))
-
-  moduleName m = moduleName $ pfst m
   
 instance (Pair p) => InternalMod (p CppSrcCode CppHdrCode) where
-  isMainModule m = isMainModule $ pfst m
   moduleDoc m = moduleDoc $ pfst m
   modFromData n m d = liftA2 pair (modFromData n m d) (modFromData n m d)
   updateModuleDoc f m = liftA2 pair (updateModuleDoc f $ fmap pfst m) 
@@ -1277,13 +1274,10 @@ instance ModuleSym CppSrcCode where
   type Module CppSrcCode = ModData
   buildModule n ls ms cs = passState2Lists ms cs
     (G.buildModule n (map include ls) ms cs)
-    
-  moduleName = name . unCPPSC
 
 instance InternalMod CppSrcCode where
-  isMainModule = isMainMod . unCPPSC
   moduleDoc = modDoc . unCPPSC
-  modFromData n = liftA2 (\m d -> return $ md n m d)
+  modFromData n = G.modFromData n (\m d -> return $ md n m d)
   updateModuleDoc f = fmap (fmap (updateModDoc f))
 
 instance BlockCommentSym CppSrcCode where
@@ -1821,13 +1815,10 @@ instance ModuleSym CppHdrCode where
   type Module CppHdrCode = ModData
   buildModule n ls ms cs = passState2Lists ms cs
     (G.buildModule n (map include ls) ms cs)
-      
-  moduleName = name . unCPPHC
 
 instance InternalMod CppHdrCode where
-  isMainModule = isMainMod . unCPPHC
   moduleDoc = modDoc . unCPPHC
-  modFromData n = liftA2 (\m d -> return $ md n m d)
+  modFromData n = G.modFromData n (\m d -> return $ md n m d)
   updateModuleDoc f = fmap (fmap (updateModDoc f))
 
 instance BlockCommentSym CppHdrCode where

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer/CppRenderer.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer/CppRenderer.hs
@@ -693,18 +693,19 @@ instance (Pair p) => InternalClass (p CppSrcCode CppHdrCode) where
   classFromData d = pair (classFromData d) (classFromData d)
 
 instance (Pair p) => ModuleSym (p CppSrcCode CppHdrCode) where
-  type Module (p CppSrcCode CppHdrCode) = State GOOLState ModData
-  buildModule n l ms cs = pair (buildModule n l (map pfst ms) (map pfst cs)) 
-    (buildModule n l (map psnd ms) (map psnd cs))
+  type Module (p CppSrcCode CppHdrCode) = ModData
+  buildModule n l ms cs = liftA2 pair (buildModule n l (map (fmap pfst) ms) 
+    (map (fmap pfst) cs)) (buildModule n l (map (fmap psnd) ms) (map (fmap psnd)
+    cs))
 
   moduleName m = moduleName $ pfst m
   
 instance (Pair p) => InternalMod (p CppSrcCode CppHdrCode) where
   isMainModule m = isMainModule $ pfst m
   moduleDoc m = moduleDoc $ pfst m
-  modFromData n m d = pair (modFromData n m d) (modFromData n m d)
-  updateModuleDoc f m = pair (updateModuleDoc f $ pfst m) (updateModuleDoc f $ 
-    psnd m)
+  modFromData n m d = liftA2 pair (modFromData n m d) (modFromData n m d)
+  updateModuleDoc f m = liftA2 pair (updateModuleDoc f $ fmap pfst m) 
+    (updateModuleDoc f $ fmap psnd m)
 
 instance (Pair p) => BlockCommentSym (p CppSrcCode CppHdrCode) where
   type BlockComment (p CppSrcCode CppHdrCode) = Doc
@@ -1270,16 +1271,16 @@ instance InternalClass CppSrcCode where
   classFromData = fmap return
 
 instance ModuleSym CppSrcCode where
-  type Module CppSrcCode = State GOOLState ModData
-  buildModule n ls ms cs = liftA3 passState2Lists (sequence ms) (sequence cs) 
+  type Module CppSrcCode = ModData
+  buildModule n ls ms cs = passState2Lists (sequence ms) (sequence cs) 
     (G.buildModule n (map include ls) ms cs)
     
-  moduleName = name . (`evalState` initialState) . unCPPSC
+  moduleName = name . unCPPSC
 
 instance InternalMod CppSrcCode where
-  isMainModule = isMainMod . (`evalState` initialState) . unCPPSC
-  moduleDoc = modDoc . (`evalState` initialState) . unCPPSC
-  modFromData n m d = return $ return $ md n m d
+  isMainModule = isMainMod . unCPPSC
+  moduleDoc = modDoc . unCPPSC
+  modFromData n = liftA2 (\m d -> return $ md n m d)
   updateModuleDoc f = fmap (fmap (updateModDoc f))
 
 instance BlockCommentSym CppSrcCode where
@@ -1814,16 +1815,16 @@ instance InternalClass CppHdrCode where
   classFromData = fmap return
 
 instance ModuleSym CppHdrCode where
-  type Module CppHdrCode = State GOOLState ModData
-  buildModule n ls ms cs = liftA3 passState2Lists (sequence ms) (sequence cs) 
+  type Module CppHdrCode = ModData
+  buildModule n ls ms cs = passState2Lists (sequence ms) (sequence cs) 
     (G.buildModule n (map include ls) ms cs)
       
-  moduleName = name . (`evalState` initialState) . unCPPHC
+  moduleName = name . unCPPHC
 
 instance InternalMod CppHdrCode where
-  isMainModule = isMainMod . (`evalState` initialState) . unCPPHC
-  moduleDoc = modDoc . (`evalState` initialState) . unCPPHC
-  modFromData n m d = return $ return $ md n m d
+  isMainModule = isMainMod . unCPPHC
+  moduleDoc = modDoc . unCPPHC
+  modFromData n = liftA2 (\m d -> return $ md n m d)
   updateModuleDoc f = fmap (fmap (updateModDoc f))
 
 instance BlockCommentSym CppHdrCode where

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer/CppRenderer.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer/CppRenderer.hs
@@ -94,9 +94,9 @@ hdrToSrc :: CppHdrCode a -> CppSrcCode a
 hdrToSrc (CPPHC a) = CPPSC a
 
 instance (Pair p) => ProgramSym (p CppSrcCode CppHdrCode) where
-  type Program (p CppSrcCode CppHdrCode) = State GOOLState ProgData
-  prog n ms = pair (prog n $ map (hdrToSrc . psnd) ms ++ map pfst ms) 
-    (return (return emptyProg))
+  type Program (p CppSrcCode CppHdrCode) = ProgData
+  prog n ms = liftA2 pair (prog n $ map (fmap (hdrToSrc . psnd)) ms ++ map 
+    (fmap pfst ms) (return (return emptyProg)))
 
 instance (Pair p) => RenderSym (p CppSrcCode CppHdrCode) where
   type RenderFile (p CppSrcCode CppHdrCode) = FileData
@@ -734,7 +734,7 @@ instance Monad CppSrcCode where
   CPPSC x >>= f = f x
 
 instance ProgramSym CppSrcCode where
-  type Program CppSrcCode = State GOOLState ProgData
+  type Program CppSrcCode = ProgData
   prog n = liftList (liftList (progD n))
   
 instance RenderSym CppSrcCode where

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer/CppRenderer.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer/CppRenderer.hs
@@ -594,59 +594,63 @@ instance (Pair p) => ParameterSym (p CppSrcCode CppHdrCode) where
   parameterType p = pair (parameterType $ pfst p) (parameterType $ psnd p)
 
 instance (Pair p) => MethodSym (p CppSrcCode CppHdrCode) where
-  type Method (p CppSrcCode CppHdrCode) = State GOOLState MethodData
-  method n c s p t ps b = pair (method n c (pfst s) (pfst p) (pfst t) (map pfst
-    ps) (pfst b)) (method n c (psnd s) (psnd p) (psnd t) (map psnd ps) (psnd b))
-  getMethod c v = pair (getMethod c $ pfst v) (getMethod c $ psnd v) 
-  setMethod c v = pair (setMethod c $ pfst v) (setMethod c $ psnd v)
-  privMethod n c t ps b = pair (privMethod n c (pfst t) (map pfst ps) (pfst b))
-    (privMethod n c (psnd t) (map psnd ps) (psnd b))
-  pubMethod n c t ps b = pair (pubMethod n c (pfst t) (map pfst ps) (pfst b)) 
-    (pubMethod n c (psnd t) (map psnd ps) (psnd b))
-  constructor n ps b = pair (constructor n (map pfst ps) (pfst b))
+  type Method (p CppSrcCode CppHdrCode) = MethodData
+  method n c s p t ps b = liftA2 pair (method n c (pfst s) (pfst p) (pfst t) 
+    (map pfst ps) (pfst b)) (method n c (psnd s) (psnd p) (psnd t) (map psnd ps)
+    (psnd b))
+  getMethod c v = liftA2 pair (getMethod c $ pfst v) (getMethod c $ psnd v) 
+  setMethod c v = liftA2 pair (setMethod c $ pfst v) (setMethod c $ psnd v)
+  privMethod n c t ps b = liftA2 pair (privMethod n c (pfst t) (map pfst ps) 
+    (pfst b)) (privMethod n c (psnd t) (map psnd ps) (psnd b))
+  pubMethod n c t ps b = liftA2 pair (pubMethod n c (pfst t) (map pfst ps) 
+    (pfst b)) (pubMethod n c (psnd t) (map psnd ps) (psnd b))
+  constructor n ps b = liftA2 pair (constructor n (map pfst ps) (pfst b))
     (constructor n (map psnd ps) (psnd b))
-  destructor n vs = pair (destructor n $ map pfst vs) 
+  destructor n vs = liftA2 pair (destructor n $ map pfst vs) 
     (destructor n $ map psnd vs)
 
-  docMain b = pair (docMain $ pfst b) (docMain $ psnd b)
+  docMain b = liftA2 pair (docMain $ pfst b) (docMain $ psnd b)
 
-  function n s p t ps b = pair (function n (pfst s) (pfst p) (pfst t) (map pfst
-    ps) (pfst b)) (function n (psnd s) (psnd p) (psnd t) (map psnd ps) (psnd b))
-  mainFunction b = pair (mainFunction $ pfst b) (mainFunction $ psnd b)
+  function n s p t ps b = liftA2 pair (function n (pfst s) (pfst p) (pfst t) 
+    (map pfst ps) (pfst b)) (function n (psnd s) (psnd p) (psnd t) (map psnd ps)
+    (psnd b))
+  mainFunction b = liftA2 pair (mainFunction $ pfst b) (mainFunction $ psnd b)
 
-  docFunc desc pComms rComm f = pair (docFunc desc pComms rComm $ pfst f) 
-    (docFunc desc pComms rComm $ psnd f)
+  docFunc desc pComms rComm f = liftA2 pair (docFunc desc pComms rComm $ fmap 
+    pfst f) (docFunc desc pComms rComm $ fmap psnd f)
 
-  inOutMethod n c s p ins outs both b = pair (inOutMethod n c (pfst s) (pfst p) 
-    (map pfst ins) (map pfst outs) (map pfst both) (pfst b)) (inOutMethod n c 
-    (psnd s) (psnd p) (map psnd ins) (map psnd outs) (map psnd both) (psnd b))
+  inOutMethod n c s p ins outs both b = liftA2 pair (inOutMethod n c (pfst s) 
+    (pfst p) (map pfst ins) (map pfst outs) (map pfst both) (pfst b)) 
+    (inOutMethod n c (psnd s) (psnd p) (map psnd ins) (map psnd outs) (map psnd 
+    both) (psnd b))
 
-  docInOutMethod n c s p desc is os bs b = pair (docInOutMethod n c (pfst s) 
+  docInOutMethod n c s p desc is os bs b = liftA2 pair (docInOutMethod n c 
+    (pfst s) (pfst p) desc (map (mapPairSnd pfst) is) (map (mapPairSnd pfst) os)
+    (map (mapPairSnd pfst) bs) (pfst b)) (docInOutMethod n c (psnd s) (psnd p) 
+    desc (map (mapPairSnd psnd) is) (map (mapPairSnd psnd) os) (map (mapPairSnd 
+    psnd) bs) (psnd b))
+
+  inOutFunc n s p ins outs both b = liftA2 pair (inOutFunc n (pfst s) (pfst p) 
+    (map pfst ins) (map pfst outs) (map pfst both) (pfst b)) (inOutFunc n (psnd 
+    s) (psnd p) (map psnd ins) (map psnd outs) (map psnd both) (psnd b))
+
+  docInOutFunc n s p desc is os bs b = liftA2 pair (docInOutFunc n (pfst s) 
     (pfst p) desc (map (mapPairSnd pfst) is) (map (mapPairSnd pfst) os) (map 
-    (mapPairSnd pfst) bs) (pfst b)) (docInOutMethod n c (psnd s) (psnd p) desc 
-    (map (mapPairSnd psnd) is) (map (mapPairSnd psnd) os) (map (mapPairSnd psnd)
-    bs) (psnd b))
-
-  inOutFunc n s p ins outs both b = pair (inOutFunc n (pfst s) (pfst p) (map
-    pfst ins) (map pfst outs) (map pfst both) (pfst b)) (inOutFunc n (psnd s) 
-    (psnd p) (map psnd ins) (map psnd outs) (map psnd both) (psnd b))
-
-  docInOutFunc n s p desc is os bs b = pair (docInOutFunc n (pfst s) (pfst p) 
-    desc (map (mapPairSnd pfst) is) (map (mapPairSnd pfst) os) (map (mapPairSnd 
-    pfst) bs) (pfst b)) (docInOutFunc n (psnd s) (psnd p) desc (map (mapPairSnd 
-    psnd) is) (map (mapPairSnd psnd) os) (map (mapPairSnd psnd) bs) (psnd b))
+    (mapPairSnd pfst) bs) (pfst b)) (docInOutFunc n (psnd s) (psnd p) desc (map 
+    (mapPairSnd psnd) is) (map (mapPairSnd psnd) os) (map (mapPairSnd psnd) bs) 
+    (psnd b))
 
   parameters m = pairList (parameters $ pfst m) (parameters $ psnd m)
 
 instance (Pair p) => InternalMethod (p CppSrcCode CppHdrCode) where
-  intMethod m n c s p t ps b = pair (intMethod m n c (pfst s) (pfst p) (pfst t) 
-    (map pfst ps) (pfst b)) (intMethod m n c (psnd s) (psnd p) (psnd t) 
+  intMethod m n c s p t ps b = liftA2 pair (intMethod m n c (pfst s) (pfst p) 
+    (pfst t) (map pfst ps) (pfst b)) (intMethod m n c (psnd s) (psnd p) (psnd t)
     (map psnd ps) (psnd b))
-  intFunc m n s p t ps b = pair (intFunc m n (pfst s) (pfst p) (pfst t) (map 
-    pfst ps) (pfst b)) (intFunc m n (psnd s) (psnd p) (psnd t) (map psnd ps) 
-    (psnd b))
-  commentedFunc cmt fn = pair (commentedFunc (pfst cmt) (pfst fn)) 
-    (commentedFunc (psnd cmt) (psnd fn)) 
+  intFunc m n s p t ps b = liftA2 pair (intFunc m n (pfst s) (pfst p) (pfst t) 
+    (map pfst ps) (pfst b)) (intFunc m n (psnd s) (psnd p) (psnd t) (map psnd 
+    ps) (psnd b))
+  commentedFunc cmt fn = liftA2 pair (commentedFunc (fmap pfst cmt) (fmap pfst 
+    fn)) (commentedFunc (fmap psnd cmt) (fmap psnd fn)) 
     
   isMainMethod m = isMainMethod $ pfst m
   methodDoc m = methodDoc $ pfst m
@@ -1176,7 +1180,7 @@ instance ParameterSym CppSrcCode where
   parameterType = variableType . fmap paramVar
 
 instance MethodSym CppSrcCode where
-  type Method CppSrcCode = State GOOLState MethodData
+  type Method CppSrcCode = MethodData
   method = G.method
   getMethod = G.getMethod
   setMethod = G.setMethod
@@ -1215,22 +1219,22 @@ instance MethodSym CppSrcCode where
 
   docInOutFunc n = G.docInOutFunc (inOutFunc n)
 
-  parameters m = map return $ (mthdParams . (`evalState` initialState) . unCPPSC) m
+  parameters m = map return $ (mthdParams . unCPPSC) m
 
 instance InternalMethod CppSrcCode where
-  intMethod m n c s _ t ps b = (if m then getPutReturn setMain else return) <$>
+  intMethod m n c s _ t ps b = (if m then getPutReturn setMain else return) $
     liftA3 (mthd m) (fmap snd s) (checkParams n <$> sequence ps) (liftA5 
     (cppsMethod n c) t (liftList paramListDocD ps) b blockStart blockEnd)
-  intFunc m n s _ t ps b = (if m then getPutReturn setMain else return) <$> 
+  intFunc m n s _ t ps b = (if m then getPutReturn setMain else return) $ 
     liftA3 (mthd m) (fmap snd s) (checkParams n <$> sequence ps) (liftA5 
     (cppsFunction n) t (liftList paramListDocD ps) b blockStart blockEnd)
-  commentedFunc cmt fn = liftA3 (checkGOOLState (^. hasMain)) fn (liftA3 
-    (\scp pms -> fmap (mthd (isMainMethod fn) scp pms)) (fmap (getMthdScp . 
-    (`evalState` initialState)) fn) (fmap (mthdParams . (`evalState` 
-    initialState)) fn) (fmap (fmap (`commentedItem` methodDoc fn)) cmt)) fn
+  commentedFunc cmt fn = checkGOOLState (^. hasMain) fn (liftA4
+    (\m scp pms -> fmap (mthd m scp pms)) (fmap isMainMethod fn)
+    (fmap (getMthdScp . unCPPSC) fn) (fmap (mthdParams . unCPPSC) fn) 
+    (liftA2 (\f -> fmap (`commentedItem` methodDoc f)) fn cmt)) fn
  
-  isMainMethod = isMainMthd . (`evalState` initialState) . unCPPSC
-  methodDoc = mthdDoc . (`evalState` initialState) . unCPPSC
+  isMainMethod = isMainMthd . unCPPSC
+  methodDoc = mthdDoc . unCPPSC
 
 instance StateVarSym CppSrcCode where
   type StateVar CppSrcCode = State GOOLState StateVarData
@@ -1724,7 +1728,7 @@ instance ParameterSym CppHdrCode where
   parameterType = variableType . fmap paramVar
 
 instance MethodSym CppHdrCode where
-  type Method CppHdrCode = State GOOLState MethodData
+  type Method CppHdrCode = MethodData
   method = G.method
   getMethod c v = method (getterName $ variableName v) c public dynamic_ 
     (variableType v) [] (return empty)
@@ -1753,20 +1757,20 @@ instance MethodSym CppHdrCode where
 
   docInOutFunc n = G.docInOutFunc (inOutFunc n)
     
-  parameters m = map return $ (mthdParams . (`evalState` initialState) . unCPPHC) m
+  parameters m = map return $ (mthdParams . unCPPHC) m
 
 instance InternalMethod CppHdrCode where
-  intMethod m n _ s _ t ps _ = (if m then getPutReturn setMain else return) <$>
+  intMethod m n _ s _ t ps _ = (if m then getPutReturn setMain else return) $
     liftA3 (mthd m) (fmap snd s) (checkParams n <$> sequence ps) (liftA3 
     (cpphMethod n) t (liftList paramListDocD ps) endStatement)
   intFunc = G.intFunc
-  commentedFunc cmt fn = liftA3 (checkGOOLState (^. hasMain)) fn fn $ liftA3 
-    (\scp pms -> fmap (mthd (isMainMethod fn) scp pms)) (fmap (getMthdScp . 
-    (`evalState` initialState)) fn) (fmap (mthdParams . (`evalState` 
-    initialState)) fn) (fmap (fmap (`commentedItem` methodDoc fn)) cmt)
+  commentedFunc cmt fn = checkGOOLState (^. hasMain) fn fn $ liftA4 
+    (\m scp pms -> fmap (mthd m scp pms)) (fmap isMainMethod fn)
+    (fmap (getMthdScp . unCPPHC) fn) (fmap (mthdParams . unCPPHC) fn) 
+    (liftA2 (\f -> fmap (`commentedItem` methodDoc f)) fn cmt)
 
-  isMainMethod = isMainMthd . (`evalState` initialState) . unCPPHC
-  methodDoc = mthdDoc . (`evalState` initialState) . unCPPHC
+  isMainMethod = isMainMthd . unCPPHC
+  methodDoc = mthdDoc . unCPPHC
 
 instance StateVarSym CppHdrCode where
   type StateVar CppHdrCode = State GOOLState StateVarData
@@ -2052,11 +2056,11 @@ cppInOutCall f n ins outs both = valState $ f n void (map valueOf both ++ ins
 cppsInOut :: (CppSrcCode (Scope CppSrcCode) -> 
     CppSrcCode (Permanence CppSrcCode) -> CppSrcCode (Type CppSrcCode) -> 
     [CppSrcCode (Parameter CppSrcCode)] -> CppSrcCode (Body CppSrcCode) -> 
-    CppSrcCode (Method CppSrcCode)) 
+    State GOOLState (CppSrcCode (Method CppSrcCode)))
   -> CppSrcCode (Scope CppSrcCode) -> CppSrcCode (Permanence CppSrcCode) -> 
   [CppSrcCode (Variable CppSrcCode)] -> [CppSrcCode (Variable CppSrcCode)] -> 
   [CppSrcCode (Variable CppSrcCode)] -> CppSrcCode (Body CppSrcCode) -> 
-  CppSrcCode (Method CppSrcCode)
+  State GOOLState (CppSrcCode (Method CppSrcCode))
 cppsInOut f s p ins [v] [] b = f s p (variableType v) (map (fmap getParam) ins) 
   (liftA3 surroundBody (varDec v) b (returnState $ valueOf v))
 cppsInOut f s p ins [] [v] b = f s p (if null (filterOutObjs [v]) then void 
@@ -2069,11 +2073,11 @@ cppsInOut f s p ins outs both b = f s p void (map pointerParam both
 cpphInOut :: (CppHdrCode (Scope CppHdrCode) -> 
     CppHdrCode (Permanence CppHdrCode) -> CppHdrCode (Type CppHdrCode) -> 
     [CppHdrCode (Parameter CppHdrCode)] -> CppHdrCode (Body CppHdrCode) -> 
-    CppHdrCode (Method CppHdrCode)) 
+    State GOOLState (CppHdrCode (Method CppHdrCode))) 
   -> CppHdrCode (Scope CppHdrCode) -> CppHdrCode (Permanence CppHdrCode) -> 
   [CppHdrCode (Variable CppHdrCode)] -> [CppHdrCode (Variable CppHdrCode)] -> 
   [CppHdrCode (Variable CppHdrCode)] -> CppHdrCode (Body CppHdrCode) -> 
-  CppHdrCode (Method CppHdrCode)
+  State GOOLState (CppHdrCode (Method CppHdrCode))
 cpphInOut f s p ins [v] [] b = f s p (variableType v) (map (fmap getParam) ins) 
   b
 cpphInOut f s p ins [] [v] b = f s p (if null (filterOutObjs [v]) then void 

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer/CppRenderer.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer/CppRenderer.hs
@@ -70,6 +70,7 @@ import GOOL.Drasil.State (GS, hasMain, initialState, putAfter, getPutReturn,
   getParameters, setScope, getScope)
 
 import Prelude hiding (break,print,(<>),sin,cos,tan,floor,pi,const,log,exp,mod)
+import qualified Prelude as P (const)
 import Data.Maybe (maybeToList)
 import Control.Lens ((^.))
 import Control.Applicative (Applicative, liftA2, liftA3)
@@ -1273,9 +1274,9 @@ instance InternalMethod CppSrcCode where
     setParameters (map unCPPSC ps) . if m then setCurrMain m . setMain else id) 
     $ liftA3 mthd (fmap snd s) (checkParams n <$> sequence ps) (liftA5 
     (cppsFunction n) t (liftList paramListDocD ps) b blockStart blockEnd)
-  commentedFunc cmt fn = checkGOOLState (^. hasMain) fn (liftA3
+  commentedFunc cmt fn = checkGOOLState (^. hasMain) fn (\f -> liftA3
     (\scp pms -> fmap (mthd scp pms)) getScope getParameters 
-    (liftA2 (\f -> fmap (`commentedItem` methodDoc f)) fn cmt)) fn
+    (fmap (fmap (`commentedItem` methodDoc f)) cmt)) (P.const fn)
  
   methodDoc = mthdDoc . unCPPSC
 
@@ -1800,9 +1801,9 @@ instance InternalMethod CppHdrCode where
     $ liftA3 mthd (fmap snd s) (checkParams n <$> sequence ps) (liftA3 
     (cpphMethod n) t (liftList paramListDocD ps) endStatement)
   intFunc = G.intFunc
-  commentedFunc cmt fn = checkGOOLState (^. hasMain) fn fn $ liftA3 
-    (\scp pms -> fmap (mthd scp pms)) getScope getParameters 
-    (liftA2 (\f -> fmap (`commentedItem` methodDoc f)) fn cmt)
+  commentedFunc cmt fn = checkGOOLState (^. hasMain) fn (P.const fn) $ \f -> 
+    liftA3 (\scp pms -> fmap (mthd scp pms)) getScope getParameters 
+    (fmap (fmap (`commentedItem` methodDoc f)) cmt)
 
   methodDoc = mthdDoc . unCPPHC
 

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer/CppRenderer.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer/CppRenderer.hs
@@ -792,7 +792,7 @@ instance InternalFile CppSrcCode where
   top m = liftA3 cppstop m (list dynamic_) endStatement
   bottom = return empty
   
-  fileFromData = G.fileFromData (\fp m -> fmap (fileD fp) m)
+  fileFromData = G.fileFromData (\m fp -> fmap (fileD fp) m)
 
 instance KeywordSym CppSrcCode where
   type Keyword CppSrcCode = Doc
@@ -1358,7 +1358,7 @@ instance InternalFile CppHdrCode where
   top m = liftA3 cpphtop m (list dynamic_) endStatement
   bottom = return $ text "#endif"
   
-  fileFromData = G.fileFromData (\fp m -> fmap (fileD fp) m)
+  fileFromData = G.fileFromData (\m fp -> fmap (fileD fp) m)
 
 instance KeywordSym CppHdrCode where
   type Keyword CppHdrCode = Doc

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer/CppRenderer.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer/CppRenderer.hs
@@ -65,7 +65,7 @@ import GOOL.Drasil.Data (Pair(..), Terminator(..), ScopeTag(..),
 import GOOL.Drasil.Helpers (angles, doubleQuotedText, emptyIfEmpty, mapPairFst, 
   mapPairSnd, toCode, onStateValue, liftA4, liftA5, liftA8, liftList, 
   lift2Lists, lift1List, checkParams)
-import GOOL.Drasil.State (GS, MS, lensGStoMS, lensMStoGS, initialState, 
+import GOOL.Drasil.State (MS, lensGStoMS, lensMStoGS, initialState, 
   putAfter, getPutReturn, setMain, setCurrMain, getCurrMain, setParameters, 
   setScope, getScope, setCurrMainFunc, getCurrMainFunc)
 
@@ -650,7 +650,7 @@ instance (Pair p) => InternalMethod (p CppSrcCode CppHdrCode) where
   intFunc m n s p t ps b = liftA2 pair (intFunc m n (pfst s) (pfst p) (pfst t) 
     (map pfst ps) (pfst b)) (intFunc m n (psnd s) (psnd p) (psnd t) (map psnd 
     ps) (psnd b))
-  commentedFunc cmt fn = pair2 (zoom lensMStoGS cmt) fn commentedFunc 
+  commentedFunc cmt fn = pair2 cmt fn commentedFunc 
     commentedFunc
     
   methodDoc m = methodDoc $ pfst m
@@ -2037,13 +2037,13 @@ cpphMethod n t ps end = (if isDtor n then empty else typeDoc t) <+> text n <>
   parens ps <> end
 
 cppCommentedFunc :: (RenderSym repr) => FileType -> 
-  GS (repr (BlockComment repr)) -> MS (repr (Method repr)) -> 
+  MS (repr (BlockComment repr)) -> MS (repr (Method repr)) -> 
   MS (repr (Method repr))
 cppCommentedFunc ft cmt fn = do
   f <- fn
   mn <- getCurrMainFunc
   scp <- getScope
-  cmnt <- zoom lensMStoGS cmt
+  cmnt <- cmt
   let cf = return (methodFromData scp $ commentedItem (blockCommentDoc cmnt) $ 
         methodDoc f)
       ret Source = if mn then cf else fn

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer/CppRenderer.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer/CppRenderer.hs
@@ -656,20 +656,20 @@ instance (Pair p) => InternalMethod (p CppSrcCode CppHdrCode) where
   methodDoc m = methodDoc $ pfst m
 
 instance (Pair p) => StateVarSym (p CppSrcCode CppHdrCode) where
-  type StateVar (p CppSrcCode CppHdrCode) = State GOOLState StateVarData
-  stateVar s p v = pair (stateVar (pfst s) (pfst p) (pfst v))
+  type StateVar (p CppSrcCode CppHdrCode) = StateVarData
+  stateVar s p v = liftA2 pair (stateVar (pfst s) (pfst p) (pfst v))
     (stateVar (psnd s) (psnd p) (psnd v))
-  stateVarDef n s p vr vl = pair (stateVarDef n (pfst s) (pfst p) (pfst vr) 
-    (pfst vl)) (stateVarDef n (psnd s) (psnd p) (psnd vr) (psnd vl))
-  constVar n s vr vl = pair (constVar n (pfst s) (pfst vr) (pfst vl)) 
+  stateVarDef n s p vr vl = liftA2 pair (stateVarDef n (pfst s) (pfst p) 
+    (pfst vr) (pfst vl)) (stateVarDef n (psnd s) (psnd p) (psnd vr) (psnd vl))
+  constVar n s vr vl = liftA2 pair (constVar n (pfst s) (pfst vr) (pfst vl)) 
     (constVar n (psnd s) (psnd vr) (psnd vl))
-  privMVar v = pair (privMVar $ pfst v) (privMVar $ psnd v)
-  pubMVar v = pair (pubMVar $ pfst v) (pubMVar $ psnd v)
-  pubGVar v = pair (pubGVar $ pfst v) (pubGVar $ psnd v)
+  privMVar v = liftA2 pair (privMVar $ pfst v) (privMVar $ psnd v)
+  pubMVar v = liftA2 pair (pubMVar $ pfst v) (pubMVar $ psnd v)
+  pubGVar v = liftA2 pair (pubGVar $ pfst v) (pubGVar $ psnd v)
 
 instance (Pair p) => InternalStateVar (p CppSrcCode CppHdrCode) where
   stateVarDoc v = stateVarDoc $ pfst v
-  stateVarFromData d = pair (stateVarFromData d) (stateVarFromData d)
+  stateVarFromData d = liftA2 pair (stateVarFromData d) (stateVarFromData d)
 
 instance (Pair p) => ClassSym (p CppSrcCode CppHdrCode) where
   type Class (p CppSrcCode CppHdrCode) = State GOOLState Doc
@@ -1237,18 +1237,18 @@ instance InternalMethod CppSrcCode where
   methodDoc = mthdDoc . unCPPSC
 
 instance StateVarSym CppSrcCode where
-  type StateVar CppSrcCode = State GOOLState StateVarData
-  stateVar s _ _ = return <$> liftA3 svd (fmap snd s) (return empty) emptyState
-  stateVarDef n s p vr vl = return <$> liftA3 svd (fmap snd s) (liftA4 
+  type StateVar CppSrcCode = StateVarData
+  stateVar s _ _ = return $ liftA3 svd (fmap snd s) (return empty) emptyState
+  stateVarDef n s p vr vl = return $ liftA3 svd (fmap snd s) (liftA4 
     (cppsStateVarDef n empty) p vr vl endStatement) emptyState
-  constVar n s vr vl = return <$> liftA3 svd (fmap snd s) (liftA4 
+  constVar n s vr vl = return $ liftA3 svd (fmap snd s) (liftA4 
     (cppsStateVarDef n (text "const")) static_ vr vl endStatement) emptyState
   privMVar = G.privMVar
   pubMVar = G.pubMVar
   pubGVar = G.pubGVar
 
 instance InternalStateVar CppSrcCode where
-  stateVarDoc = stVarDoc . (`evalState` initialState) . unCPPSC
+  stateVarDoc = stVarDoc . unCPPSC
   stateVarFromData = error "stateVarFromData unimplemented in C++"
 
 instance ClassSym CppSrcCode where
@@ -1773,19 +1773,19 @@ instance InternalMethod CppHdrCode where
   methodDoc = mthdDoc . unCPPHC
 
 instance StateVarSym CppHdrCode where
-  type StateVar CppHdrCode = State GOOLState StateVarData
-  stateVar s p v = return <$> liftA3 svd (fmap snd s) (return $ stateVarDocD 
+  type StateVar CppHdrCode = StateVarData
+  stateVar s p v = return $ liftA3 svd (fmap snd s) (return $ stateVarDocD 
     empty (permDoc p) (statementDoc (state $ varDec v))) emptyState
-  stateVarDef _ s p vr vl = return <$> liftA3 svd (fmap snd s) (return $ 
+  stateVarDef _ s p vr vl = return $ liftA3 svd (fmap snd s) (return $ 
     cpphStateVarDef empty p vr vl) emptyState
-  constVar _ s v _ = return <$> liftA3 svd (fmap snd s) (liftA3 (constVarDocD 
+  constVar _ s v _ = return $ liftA3 svd (fmap snd s) (liftA3 (constVarDocD 
     empty) (bindDoc <$> static_) v endStatement) emptyState
   privMVar = G.privMVar
   pubMVar = G.pubMVar
   pubGVar = G.pubGVar
 
 instance InternalStateVar CppHdrCode where
-  stateVarDoc = stVarDoc . (`evalState` initialState) . unCPPHC
+  stateVarDoc = stVarDoc . unCPPHC
   stateVarFromData = error "stateVarFromData unimplemented in C++"
 
 instance ClassSym CppHdrCode where

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer/CppRenderer.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer/CppRenderer.hs
@@ -98,7 +98,7 @@ hdrToSrc (CPPHC a) = CPPSC a
 instance (Pair p) => ProgramSym (p CppSrcCode CppHdrCode) where
   type Program (p CppSrcCode CppHdrCode) = ProgData
   prog n mods = do
-    m <- sequence mods
+    m <-  mapM (putAfter $ setCurrMain False) mods
     let fm = map pfst m
         sm = map (hdrToSrc . psnd) m
     p1 <- prog n $ map return sm ++ map return fm
@@ -1317,7 +1317,7 @@ instance ModuleSym CppSrcCode where
 
 instance InternalMod CppSrcCode where
   moduleDoc = modDoc . unCPPSC
-  modFromData n = G.modFromData n (\m d -> return $ md n m d)
+  modFromData n = G.modFromData n (\d m -> return $ md n m d)
   updateModuleDoc f = fmap (fmap (updateModDoc f))
 
 instance BlockCommentSym CppSrcCode where
@@ -1852,7 +1852,7 @@ instance ModuleSym CppHdrCode where
 
 instance InternalMod CppHdrCode where
   moduleDoc = modDoc . unCPPHC
-  modFromData n = G.modFromData n (\m d -> return $ md n m d)
+  modFromData n = G.modFromData n (\d m -> return $ md n m d)
   updateModuleDoc f = fmap (fmap (updateModDoc f))
 
 instance BlockCommentSym CppHdrCode where

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer/CppRenderer.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer/CppRenderer.hs
@@ -736,10 +736,10 @@ pair1List :: (Pair p) => [GS (p CppSrcCode CppHdrCode a)] ->
   ([GS (CppHdrCode a)] -> GS (CppHdrCode b)) -> GS (p CppSrcCode CppHdrCode b)
 pair1List stv srcf hdrf = do
   v <- sequence stv
-  let fv = map (return . pfst) v
-      sv = map (return . psnd) v
-  p1 <- srcf fv
-  p2 <- hdrf sv
+  let fl = map (return . pfst) v
+      sl = map (return . psnd) v
+  p1 <- srcf fl
+  p2 <- hdrf sl
   return $ pair p1 p2
 
 pair2Lists :: (Pair p) => [GS (p CppSrcCode CppHdrCode a)] -> 
@@ -750,12 +750,12 @@ pair2Lists :: (Pair p) => [GS (p CppSrcCode CppHdrCode a)] ->
 pair2Lists stv1 stv2 srcf hdrf = do
   v1 <- sequence stv1
   v2 <- sequence stv2
-  let fv1 = map (return . pfst) v1
-      sv1 = map (return . psnd) v1
-      fv2 = map (return . pfst) v2
-      sv2 = map (return . psnd) v2
-  p1 <- srcf fv1 fv2
-  p2 <- hdrf sv1 sv2
+  let fl1 = map (return . pfst) v1
+      sl1 = map (return . psnd) v1
+      fl2 = map (return . pfst) v2
+      sl2 = map (return . psnd) v2
+  p1 <- srcf fl1 fl2
+  p2 <- hdrf sl1 sl2
   return $ pair p1 p2
 
 -----------------

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer/CppRenderer.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer/CppRenderer.hs
@@ -59,7 +59,7 @@ import qualified GOOL.Drasil.LanguageRenderer.LanguagePolymorphic as G (
   docClass, commentedClass, buildModule, fileDoc, docMod)
 import GOOL.Drasil.Data (Pair(..), pairList, Terminator(..), ScopeTag(..), 
   Binding(..), BindData(..), bd, FileType(..), FileData(..), FuncData(..), fd, 
-  ModData(..), md, OpData(..), od, ParamData(..), pd, ProgData(..), progD, 
+  ModData(..), md, updateModDoc, OpData(..), od, ParamData(..), pd, ProgData(..), progD, 
   emptyProg, StateVarData(..), svd, TypeData(..), td, ValData(..), vd, 
   VarData(..), vard)
 import GOOL.Drasil.Helpers (angles, doubleQuotedText, emptyIfEmpty, mapPairFst, 
@@ -729,8 +729,8 @@ instance ProgramSym CppSrcCode where
   
 instance RenderSym CppSrcCode where
   type RenderFile CppSrcCode = State GOOLState FileData
-  fileDoc code = liftA2 passState code (G.fileDoc Source cppSrcExt (top code) 
-    bottom code)
+  fileDoc code = G.fileDoc Source cppSrcExt (top code) 
+    bottom code
 
   docMod = G.docMod
 
@@ -1274,6 +1274,7 @@ instance InternalMod CppSrcCode where
   isMainModule = isMainMod . (`evalState` initialState) . unCPPSC
   moduleDoc = modDoc . (`evalState` initialState) . unCPPSC
   modFromData n m d = return $ return $ md n m d
+  updateModuleDoc f = fmap (fmap (updateModDoc f))
 
 instance BlockCommentSym CppSrcCode where
   type BlockComment CppSrcCode = State GOOLState Doc
@@ -1302,8 +1303,8 @@ instance Monad CppHdrCode where
 
 instance RenderSym CppHdrCode where
   type RenderFile CppHdrCode = State GOOLState FileData
-  fileDoc code = liftA2 passState code (G.fileDoc Header cppHdrExt (top code) 
-    bottom code)
+  fileDoc code = G.fileDoc Header cppHdrExt (top code) 
+    bottom code
   
   docMod = G.docMod
 
@@ -1817,6 +1818,7 @@ instance InternalMod CppHdrCode where
   isMainModule = isMainMod . (`evalState` initialState) . unCPPHC
   moduleDoc = modDoc . (`evalState` initialState) . unCPPHC
   modFromData n m d = return $ return $ md n m d
+  updateModuleDoc f = fmap (fmap (updateModDoc f))
 
 instance BlockCommentSym CppHdrCode where
   type BlockComment CppHdrCode = State GOOLState Doc

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer/CppRenderer.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer/CppRenderer.hs
@@ -57,7 +57,7 @@ import qualified GOOL.Drasil.LanguageRenderer.LanguagePolymorphic as G (
   setMethod, privMethod, pubMethod, constructor, function, docFunc, 
   docInOutFunc, intFunc, privMVar, pubMVar, pubGVar, privClass, pubClass, 
   docClass, commentedClass, buildModule, modFromData, fileDoc, docMod)
-import GOOL.Drasil.Data (Pair(..), pairList, Terminator(..), ScopeTag(..), 
+import GOOL.Drasil.Data (Pair(..), Terminator(..), ScopeTag(..), 
   Binding(..), BindData(..), bd, FileType(..), FileData(..), fileD, 
   FuncData(..), fd, ModData(..), md, updateModDoc, OpData(..), od, 
   ParamData(..), pd, ProgData(..), progD, emptyProg, StateVarData(..), svd, 
@@ -66,7 +66,7 @@ import GOOL.Drasil.Helpers (angles, doubleQuotedText, emptyIfEmpty, mapPairFst,
   mapPairSnd, liftA4, liftA5, liftA8, liftList, lift2Lists, lift1List, 
   checkParams)
 import GOOL.Drasil.State (GS, hasMain, initialState, getPutReturn, 
-  passState2Lists, checkGOOLState, setMain, setCurrMain, setParameters)
+  checkGOOLState, setMain, setCurrMain, setParameters)
 
 import Prelude hiding (break,print,(<>),sin,cos,tan,floor,pi,const,log,exp)
 import Data.Maybe (maybeToList)
@@ -1266,8 +1266,7 @@ instance InternalClass CppSrcCode where
 
 instance ModuleSym CppSrcCode where
   type Module CppSrcCode = ModData
-  buildModule n ls ms cs = passState2Lists ms cs
-    (G.buildModule n (map include ls) ms cs)
+  buildModule n ls = G.buildModule n (map include ls)
 
 instance InternalMod CppSrcCode where
   moduleDoc = modDoc . unCPPSC
@@ -1804,8 +1803,7 @@ instance InternalClass CppHdrCode where
 
 instance ModuleSym CppHdrCode where
   type Module CppHdrCode = ModData
-  buildModule n ls ms cs = passState2Lists ms cs
-    (G.buildModule n (map include ls) ms cs)
+  buildModule n ls = G.buildModule n (map include ls)
 
 instance InternalMod CppHdrCode where
   moduleDoc = modDoc . unCPPHC

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer/JavaRenderer.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer/JavaRenderer.hs
@@ -57,7 +57,7 @@ import qualified GOOL.Drasil.LanguageRenderer.LanguagePolymorphic as G (
   getMethod, setMethod,privMethod, pubMethod, constructor, docMain, function, 
   mainFunction, docFunc, intFunc, stateVar, stateVarDef, constVar, privMVar, 
   pubMVar, pubGVar, buildClass, enum, privClass, pubClass, docClass, 
-  commentedClass, buildModule', fileDoc, docMod)
+  commentedClass, buildModule', modFromData, fileDoc, docMod)
 import GOOL.Drasil.Data (Terminator(..), FileType(..), FileData(..), fileD, 
   FuncData(..), fd, ModData(..), md, updateModDoc, MethodData(..), mthd, 
   updateMthdDoc, OpData(..), ParamData(..), ProgData(..), progD, TypeData(..), 
@@ -588,13 +588,10 @@ instance InternalClass JavaCode where
 instance ModuleSym JavaCode where
   type Module JavaCode = ModData
   buildModule n _ ms cs = passState2Lists ms cs (G.buildModule' n ms cs)
-
-  moduleName = name . unJC
   
 instance InternalMod JavaCode where
-  isMainModule = isMainMod . unJC
   moduleDoc = modDoc . unJC
-  modFromData n = liftA2 (\m d -> return $ md n m d)
+  modFromData n = G.modFromData n (\m d -> return $ md n m d)
   updateModuleDoc f = fmap (fmap (updateModDoc f))
 
 instance BlockCommentSym JavaCode where

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer/JavaRenderer.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer/JavaRenderer.hs
@@ -103,7 +103,7 @@ instance RenderSym JavaCode where
 
   docMod = G.docMod
 
-  commentedMod = liftA2 (liftA2 commentedModD)
+  commentedMod cmt m = liftM2 (liftA2 commentedModD) m cmt
 
 instance InternalFile JavaCode where
   top _ = liftA3 jtop endStatement (include "") (list static_)

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer/JavaRenderer.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer/JavaRenderer.hs
@@ -546,14 +546,14 @@ instance MethodSym JavaCode where
 
 instance InternalMethod JavaCode where
   intMethod m n _ s p t ps b = getPutReturn (setParameters (map unJC ps) . 
-    if m then setCurrMain m . setMain else id) $ liftA2 mthd (checkParams n <$> 
-    sequence ps) (liftA5 (jMethod n) s p t (liftList paramListDocD ps) b)
+    if m then setCurrMain m . setMain else id) $ fmap mthd (liftA5 (jMethod n) 
+    s p t (liftList (paramListDocD . checkParams n) ps) b)
   intFunc = G.intFunc
   commentedFunc cmt = liftA2 (liftA2 updateMthdDoc) (fmap (fmap commentedItem)
     cmt)
   
   methodDoc = mthdDoc . unJC
-  methodFromData _ = return . mthd []
+  methodFromData _ = return . mthd
 
 instance StateVarSym JavaCode where
   type StateVar JavaCode = Doc

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer/JavaRenderer.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer/JavaRenderer.hs
@@ -599,11 +599,10 @@ instance InternalMod JavaCode where
   updateModuleDoc f = fmap (fmap (updateModDoc f))
 
 instance BlockCommentSym JavaCode where
-  type BlockComment JavaCode = State GOOLState Doc
-  blockComment lns = liftA2 (\bcs bce -> return $ blockCmtDoc lns bcs bce) 
-    blockCommentStart blockCommentEnd
-  docComment lns = liftA2 (\dcs dce -> fmap (docCmtDoc dcs dce) lns) 
-    docCommentStart docCommentEnd 
+  type BlockComment JavaCode = Doc
+  blockComment lns = liftA2 (blockCmtDoc lns) blockCommentStart blockCommentEnd
+  docComment = fmap (\lns -> liftA2 (docCmtDoc lns) docCommentStart 
+    docCommentEnd)
 
   blockCommentDoc = unJC
 

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer/JavaRenderer.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer/JavaRenderer.hs
@@ -587,8 +587,7 @@ instance InternalClass JavaCode where
 
 instance ModuleSym JavaCode where
   type Module JavaCode = ModData
-  buildModule n _ ms cs = passState2Lists (sequence ms) (sequence cs) 
-    (G.buildModule' n ms cs)
+  buildModule n _ ms cs = passState2Lists ms cs (G.buildModule' n ms cs)
 
   moduleName = name . unJC
   

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer/JavaRenderer.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer/JavaRenderer.hs
@@ -64,8 +64,8 @@ import GOOL.Drasil.Data (Terminator(..), FileType(..), FileData(..), fileD,
   td, ValData(..), vd, VarData(..), vard)
 import GOOL.Drasil.Helpers (angles, emptyIfNull, liftA4, liftA5, liftList, 
   lift1List, checkParams)
-import GOOL.Drasil.State (GS, initialState, getPutReturn, getPutReturnList, 
-  addProgNameToPaths, setMain, setCurrMain, setParameters)
+import GOOL.Drasil.State (GS, initialState, putAfter, getPutReturn, 
+  getPutReturnList, addProgNameToPaths, setMain, setCurrMain, setParameters)
 
 import Prelude hiding (break,print,sin,cos,tan,floor,(<>))
 import Control.Applicative (Applicative, liftA2, liftA3)
@@ -91,8 +91,9 @@ instance Monad JavaCode where
 
 instance ProgramSym JavaCode where
   type Program JavaCode = ProgData
-  prog n fs = getPutReturnList fs (addProgNameToPaths n) (lift1List (\end -> 
-    progD n . map (packageDocD n end)) endStatement)
+  prog n fs = getPutReturnList (map (putAfter $ setCurrMain False) fs) 
+    (addProgNameToPaths n) (lift1List (\end -> progD n . 
+    map (packageDocD n end)) endStatement)
 
 instance RenderSym JavaCode where
   type RenderFile JavaCode = FileData 

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer/JavaRenderer.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer/JavaRenderer.hs
@@ -107,7 +107,6 @@ instance InternalFile JavaCode where
   top _ = liftA3 jtop endStatement (include "") (list static_)
   bottom = return empty
   
-  getFilePath = filePath . (`evalState` initialState) . unJC
   fileFromData ft fp = fmap (G.fileFromData ft fp)
 
 instance KeywordSym JavaCode where

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer/JavaRenderer.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer/JavaRenderer.hs
@@ -70,6 +70,7 @@ import GOOL.Drasil.State (GS, initialState, putAfter, getPutReturn,
 import Prelude hiding (break,print,sin,cos,tan,floor,(<>))
 import Control.Applicative (Applicative, liftA2, liftA3)
 import Control.Monad.State (evalState)
+import Control.Monad (liftM2)
 import Text.PrettyPrint.HughesPJ (Doc, text, (<>), (<+>), parens, empty, space, 
   equals, semi, vcat, lbrace, rbrace, render, colon, comma, render)
 
@@ -108,7 +109,7 @@ instance InternalFile JavaCode where
   top _ = liftA3 jtop endStatement (include "") (list static_)
   bottom = return empty
   
-  fileFromData = G.fileFromData (\fp m -> fmap (fileD fp) m)
+  fileFromData = G.fileFromData (\m fp -> fmap (fileD fp) m)
 
 instance KeywordSym JavaCode where
   type Keyword JavaCode = Doc
@@ -549,8 +550,8 @@ instance InternalMethod JavaCode where
     if m then setCurrMain m . setMain else id) $ fmap mthd (liftA5 (jMethod n) 
     s p t (liftList (paramListDocD . checkParams n) ps) b)
   intFunc = G.intFunc
-  commentedFunc cmt = liftA2 (liftA2 updateMthdDoc) (fmap (fmap commentedItem)
-    cmt)
+  commentedFunc cmt m = liftM2 (liftA2 updateMthdDoc) m 
+    (fmap (fmap commentedItem) cmt)
   
   methodDoc = mthdDoc . unJC
   methodFromData _ = return . mthd

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer/JavaRenderer.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer/JavaRenderer.hs
@@ -62,8 +62,8 @@ import GOOL.Drasil.Data (Terminator(..), FileType(..), FileData(..), fileD,
   FuncData(..), fd, ModData(..), md, updateModDoc, MethodData(..), mthd, 
   updateMthdDoc, OpData(..), ParamData(..), ProgData(..), progD, TypeData(..), 
   td, ValData(..), vd, VarData(..), vard)
-import GOOL.Drasil.Helpers (angles, emptyIfNull, liftA4, liftA5, liftList, 
-  lift1List, checkParams)
+import GOOL.Drasil.Helpers (angles, emptyIfNull, toCode, onStateValue, liftA4, 
+  liftA5, liftList, lift1List, checkParams)
 import GOOL.Drasil.State (GS, initialState, putAfter, getPutReturn, 
   getPutReturnList, addProgNameToPaths, setMain, setCurrMain, setParameters)
 
@@ -582,7 +582,7 @@ instance ClassSym JavaCode where
 
 instance InternalClass JavaCode where
   classDoc = unJC
-  classFromData = fmap return
+  classFromData = onStateValue toCode
 
 instance ModuleSym JavaCode where
   type Module JavaCode = ModData

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer/JavaRenderer.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer/JavaRenderer.hs
@@ -64,10 +64,12 @@ import GOOL.Drasil.Data (Terminator(..), FileType(..), FileData(..), fileD,
   td, ValData(..), vd, VarData(..), vard)
 import GOOL.Drasil.Helpers (angles, emptyIfNull, toCode, onStateValue, liftA4, 
   liftA5, liftList, lift1List, checkParams)
-import GOOL.Drasil.State (GS, initialState, putAfter, getPutReturn, 
+import GOOL.Drasil.State (MS, lensMStoGS, initialState, putAfter, getPutReturn, 
   getPutReturnList, addProgNameToPaths, setMain, setCurrMain, setParameters)
 
 import Prelude hiding (break,print,sin,cos,tan,floor,(<>))
+import Control.Lens (over)
+import Control.Lens.Zoom (zoom)
 import Control.Applicative (Applicative, liftA2, liftA3)
 import Control.Monad.State (evalState)
 import Control.Monad (liftM2)
@@ -547,11 +549,11 @@ instance MethodSym JavaCode where
 
 instance InternalMethod JavaCode where
   intMethod m n _ s p t ps b = getPutReturn (setParameters (map unJC ps) . 
-    if m then setCurrMain m . setMain else id) $ fmap mthd (liftA5 (jMethod n) 
-    s p t (liftList (paramListDocD . checkParams n) ps) b)
+    if m then over lensMStoGS (setCurrMain m) . setMain else id) $ fmap mthd 
+    (liftA5 (jMethod n) s p t (liftList (paramListDocD . checkParams n) ps) b)
   intFunc = G.intFunc
   commentedFunc cmt m = liftM2 (liftA2 updateMthdDoc) m 
-    (fmap (fmap commentedItem) cmt)
+    (fmap (fmap commentedItem) (zoom lensMStoGS cmt))
   
   methodDoc = mthdDoc . unJC
   methodFromData _ = return . mthd
@@ -740,11 +742,11 @@ jInOutCall f n ins outs both = fCall rets
 
 jInOut :: (JavaCode (Scope JavaCode) -> JavaCode (Permanence JavaCode) -> 
     JavaCode (Type JavaCode) -> [JavaCode (Parameter JavaCode)] -> 
-    JavaCode (Body JavaCode) -> GS (JavaCode (Method JavaCode))) 
+    JavaCode (Body JavaCode) -> MS (JavaCode (Method JavaCode))) 
   -> JavaCode (Scope JavaCode) -> JavaCode (Permanence JavaCode) -> 
   [JavaCode (Variable JavaCode)] -> [JavaCode (Variable JavaCode)] -> 
   [JavaCode (Variable JavaCode)] -> JavaCode (Body JavaCode) -> 
-  GS (JavaCode (Method JavaCode))
+  MS (JavaCode (Method JavaCode))
 jInOut f s p ins [] [] b = f s p void (map param ins) b
 jInOut f s p ins [v] [] b = f s p (variableType v) 
   (map param ins) (liftA3 surroundBody (varDec v) b (returnState $ 
@@ -774,11 +776,11 @@ jInOut f s p ins outs both b = f s p (returnTp rets)
 jDocInOut :: (RenderSym repr) => (repr (Scope repr) -> repr (Permanence repr) 
     -> [repr (Variable repr)] -> [repr (Variable repr)] -> 
     [repr (Variable repr)] -> repr (Body repr) -> 
-    GS (repr (Method repr)))
+    MS (repr (Method repr)))
   -> repr (Scope repr) -> repr (Permanence repr) -> String -> 
   [(String, repr (Variable repr))] -> [(String, repr (Variable repr))] -> 
   [(String, repr (Variable repr))] -> repr (Body repr) -> 
-  GS (repr (Method repr))
+  MS (repr (Method repr))
 jDocInOut f s p desc is [] [] b = docFuncRepr desc (map fst is) [] 
   (f s p (map snd is) [] [] b)
 jDocInOut f s p desc is [o] [] b = docFuncRepr desc (map fst is) [fst o] 

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer/JavaRenderer.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer/JavaRenderer.hs
@@ -65,7 +65,7 @@ import GOOL.Drasil.Data (Terminator(..), FileType(..), FileData(..), fileD,
 import GOOL.Drasil.Helpers (angles, emptyIfNull, liftA4, liftA5, liftList, 
   lift1List, checkParams)
 import GOOL.Drasil.State (GS, initialState, getPutReturn, 
-  getPutReturnList, passState2Lists, addProgNameToPaths, setMain)
+  getPutReturnList, passState2Lists, addProgNameToPaths, setMain, setCurrMain)
 
 import Prelude hiding (break,print,sin,cos,tan,floor,(<>))
 import Control.Applicative (Applicative, liftA2, liftA3)
@@ -547,14 +547,13 @@ instance MethodSym JavaCode where
   parameters m = map return $ (mthdParams . unJC) m
 
 instance InternalMethod JavaCode where
-  intMethod m n _ s p t ps b = (if m then getPutReturn setMain else return) $ 
-    liftA2 (mthd m) (checkParams n <$> sequence ps) (liftA5 (jMethod n) s p t 
-    (liftList paramListDocD ps) b)
+  intMethod m n _ s p t ps b = (if m then getPutReturn (setCurrMain m . setMain)
+    else return) $ liftA2 mthd (checkParams n <$> sequence ps) (liftA5 
+    (jMethod n) s p t (liftList paramListDocD ps) b)
   intFunc = G.intFunc
   commentedFunc cmt = liftA2 (liftA2 updateMthdDoc) (fmap (fmap commentedItem)
     cmt)
   
-  isMainMethod = isMainMthd . unJC
   methodDoc = mthdDoc . unJC
 
 instance StateVarSym JavaCode where

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer/JavaRenderer.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer/JavaRenderer.hs
@@ -558,7 +558,7 @@ instance InternalMethod JavaCode where
   methodDoc = mthdDoc . unJC
 
 instance StateVarSym JavaCode where
-  type StateVar JavaCode = State GOOLState Doc
+  type StateVar JavaCode = Doc
   stateVar = G.stateVar
   stateVarDef _ = G.stateVarDef
   constVar _ = G.constVar (permDoc (static_ :: JavaCode (Permanence JavaCode)))
@@ -567,7 +567,7 @@ instance StateVarSym JavaCode where
   pubGVar = G.pubGVar
 
 instance InternalStateVar JavaCode where
-  stateVarDoc = (`evalState` initialState) . unJC
+  stateVarDoc = unJC
   stateVarFromData = return . return
 
 instance ClassSym JavaCode where

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer/JavaRenderer.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer/JavaRenderer.hs
@@ -101,7 +101,7 @@ instance RenderSym JavaCode where
 
   docMod = G.docMod
 
-  commentedMod = liftA2 commentedModD
+  commentedMod = liftA2 (liftA2 commentedModD)
 
 instance InternalFile JavaCode where
   top _ = liftA3 jtop endStatement (include "") (list static_)
@@ -552,7 +552,8 @@ instance InternalMethod JavaCode where
     liftA2 (mthd m) (checkParams n <$> sequence ps) (liftA5 (jMethod n) s p t 
     (liftList paramListDocD ps) b)
   intFunc = G.intFunc
-  commentedFunc cmt = liftA2 (fmap . updateMthdDoc) (fmap commentedItem cmt)
+  commentedFunc cmt = liftA2 (liftA2 updateMthdDoc) (fmap (fmap commentedItem)
+    cmt)
   
   isMainMethod = isMainMthd . (`evalState` initialState) . unJC
   methodDoc = mthdDoc . (`evalState` initialState) . unJC
@@ -583,7 +584,7 @@ instance ClassSym JavaCode where
 
 instance InternalClass JavaCode where
   classDoc = (`evalState` initialState) . unJC
-  classFromData = return . return
+  classFromData = return
 
 instance ModuleSym JavaCode where
   type Module JavaCode = State GOOLState ModData
@@ -598,9 +599,10 @@ instance InternalMod JavaCode where
   modFromData n m d = return $ return $ md n m d
 
 instance BlockCommentSym JavaCode where
-  type BlockComment JavaCode = Doc
+  type BlockComment JavaCode = State GOOLState Doc
   blockComment lns = liftA2 (blockCmtDoc lns) blockCommentStart blockCommentEnd
-  docComment lns = liftA2 (docCmtDoc lns) docCommentStart docCommentEnd 
+  docComment lns = liftA2 (\dcs dce -> fmap (docCmtDoc dcs dce) lns) 
+    docCommentStart docCommentEnd 
 
   blockCommentDoc = unJC
 

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer/JavaRenderer.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer/JavaRenderer.hs
@@ -59,13 +59,13 @@ import qualified GOOL.Drasil.LanguageRenderer.LanguagePolymorphic as G (
   pubMVar, pubGVar, buildClass, enum, privClass, pubClass, docClass, 
   commentedClass, buildModule', fileDoc, docMod)
 import GOOL.Drasil.Data (Terminator(..), FileType(..), FileData(..), 
-  FuncData(..), fd, ModData(..), md, updateModDoc, MethodData(..), mthd, updateMthdDoc, 
-  OpData(..), ParamData(..), ProgData(..), progD, TypeData(..), td, ValData(..),
-  vd, VarData(..), vard)
+  FuncData(..), fd, ModData(..), md, updateModDoc, MethodData(..), mthd, 
+  updateMthdDoc, OpData(..), ParamData(..), ProgData(..), progD, TypeData(..), 
+  td, ValData(..), vd, VarData(..), vard)
 import GOOL.Drasil.Helpers (angles, emptyIfNull, liftA4, liftA5, liftList, 
   lift1List, checkParams)
 import GOOL.Drasil.State (GOOLState, initialState, getPutReturn, 
-  getPutReturnList, passState, passState2Lists, addProgNameToPaths, setMain)
+  getPutReturnList, passState2Lists, addProgNameToPaths, setMain)
 
 import Prelude hiding (break,print,sin,cos,tan,floor,(<>))
 import Control.Applicative (Applicative, liftA2, liftA3)

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer/JavaRenderer.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer/JavaRenderer.hs
@@ -553,6 +553,7 @@ instance InternalMethod JavaCode where
     cmt)
   
   methodDoc = mthdDoc . unJC
+  methodFromData _ = return . mthd []
 
 instance StateVarSym JavaCode where
   type StateVar JavaCode = Doc

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer/JavaRenderer.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer/JavaRenderer.hs
@@ -59,7 +59,7 @@ import qualified GOOL.Drasil.LanguageRenderer.LanguagePolymorphic as G (
   pubMVar, pubGVar, buildClass, enum, privClass, pubClass, docClass, 
   commentedClass, buildModule', fileDoc, docMod)
 import GOOL.Drasil.Data (Terminator(..), FileType(..), FileData(..), 
-  FuncData(..), fd, ModData(..), md, MethodData(..), mthd, updateMthdDoc, 
+  FuncData(..), fd, ModData(..), md, updateModDoc, MethodData(..), mthd, updateMthdDoc, 
   OpData(..), ParamData(..), ProgData(..), progD, TypeData(..), td, ValData(..),
   vd, VarData(..), vard)
 import GOOL.Drasil.Helpers (angles, emptyIfNull, liftA4, liftA5, liftList, 
@@ -96,8 +96,8 @@ instance ProgramSym JavaCode where
 
 instance RenderSym JavaCode where
   type RenderFile JavaCode = State GOOLState FileData 
-  fileDoc code = liftA2 passState code (G.fileDoc Combined jExt (top code) 
-    bottom code)
+  fileDoc code = G.fileDoc Combined jExt (top code) 
+    bottom code
 
   docMod = G.docMod
 
@@ -597,6 +597,7 @@ instance InternalMod JavaCode where
   isMainModule = isMainMod . (`evalState` initialState) . unJC
   moduleDoc = modDoc . (`evalState` initialState) . unJC
   modFromData n m d = return $ return $ md n m d
+  updateModuleDoc f = fmap (fmap (updateModDoc f))
 
 instance BlockCommentSym JavaCode where
   type BlockComment JavaCode = State GOOLState Doc

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer/JavaRenderer.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer/JavaRenderer.hs
@@ -571,7 +571,7 @@ instance InternalStateVar JavaCode where
   stateVarFromData = return . return
 
 instance ClassSym JavaCode where
-  type Class JavaCode = State GOOLState Doc
+  type Class JavaCode = Doc
   buildClass = G.buildClass classDocD inherit
   enum = G.enum
   privClass = G.privClass
@@ -582,8 +582,8 @@ instance ClassSym JavaCode where
   commentedClass = G.commentedClass
 
 instance InternalClass JavaCode where
-  classDoc = (`evalState` initialState) . unJC
-  classFromData = return
+  classDoc = unJC
+  classFromData = fmap return
 
 instance ModuleSym JavaCode where
   type Module JavaCode = State GOOLState ModData

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer/JavaRenderer.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer/JavaRenderer.hs
@@ -69,7 +69,6 @@ import GOOL.Drasil.State (MS, lensMStoGS, initialState, putAfter, getPutReturn,
 
 import Prelude hiding (break,print,sin,cos,tan,floor,(<>))
 import Control.Lens (over)
-import Control.Lens.Zoom (zoom)
 import Control.Applicative (Applicative, liftA2, liftA3)
 import Control.Monad.State (evalState)
 import Control.Monad (liftM2)
@@ -553,7 +552,7 @@ instance InternalMethod JavaCode where
     (liftA5 (jMethod n) s p t (liftList (paramListDocD . checkParams n) ps) b)
   intFunc = G.intFunc
   commentedFunc cmt m = liftM2 (liftA2 updateMthdDoc) m 
-    (fmap (fmap commentedItem) (zoom lensMStoGS cmt))
+    (fmap (fmap commentedItem) cmt)
   
   methodDoc = mthdDoc . unJC
   methodFromData _ = return . mthd

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer/JavaRenderer.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer/JavaRenderer.hs
@@ -90,9 +90,9 @@ instance Monad JavaCode where
   JC x >>= f = f x
 
 instance ProgramSym JavaCode where
-  type Program JavaCode = State GOOLState ProgData
-  prog n = lift1List (\end fs -> getPutReturnList fs (addProgNameToPaths n) 
-    (progD n . map (packageDocD n end))) endStatement
+  type Program JavaCode = ProgData
+  prog n fs = getPutReturnList fs (addProgNameToPaths n) (lift1List (\end -> 
+    progD n . map (packageDocD n end)) endStatement)
 
 instance RenderSym JavaCode where
   type RenderFile JavaCode = FileData 

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer/JavaRenderer.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer/JavaRenderer.hs
@@ -600,7 +600,8 @@ instance InternalMod JavaCode where
 
 instance BlockCommentSym JavaCode where
   type BlockComment JavaCode = State GOOLState Doc
-  blockComment lns = liftA2 (blockCmtDoc lns) blockCommentStart blockCommentEnd
+  blockComment lns = liftA2 (\bcs bce -> return $ blockCmtDoc lns bcs bce) 
+    blockCommentStart blockCommentEnd
   docComment lns = liftA2 (\dcs dce -> fmap (docCmtDoc dcs dce) lns) 
     docCommentStart docCommentEnd 
 

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer/JavaRenderer.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer/JavaRenderer.hs
@@ -64,12 +64,12 @@ import GOOL.Drasil.Data (Terminator(..), FileType(..), FileData(..), fileD,
   td, ValData(..), vd, VarData(..), vard)
 import GOOL.Drasil.Helpers (angles, emptyIfNull, liftA4, liftA5, liftList, 
   lift1List, checkParams)
-import GOOL.Drasil.State (GOOLState, initialState, getPutReturn, 
+import GOOL.Drasil.State (GS, initialState, getPutReturn, 
   getPutReturnList, passState2Lists, addProgNameToPaths, setMain)
 
 import Prelude hiding (break,print,sin,cos,tan,floor,(<>))
 import Control.Applicative (Applicative, liftA2, liftA3)
-import Control.Monad.State (State, evalState)
+import Control.Monad.State (evalState)
 import Text.PrettyPrint.HughesPJ (Doc, text, (<>), (<+>), parens, empty, space, 
   equals, semi, vcat, lbrace, rbrace, render, colon, comma, render)
 
@@ -744,11 +744,11 @@ jInOutCall f n ins outs both = fCall rets
 
 jInOut :: (JavaCode (Scope JavaCode) -> JavaCode (Permanence JavaCode) -> 
     JavaCode (Type JavaCode) -> [JavaCode (Parameter JavaCode)] -> 
-    JavaCode (Body JavaCode) -> State GOOLState (JavaCode (Method JavaCode))) 
+    JavaCode (Body JavaCode) -> GS (JavaCode (Method JavaCode))) 
   -> JavaCode (Scope JavaCode) -> JavaCode (Permanence JavaCode) -> 
   [JavaCode (Variable JavaCode)] -> [JavaCode (Variable JavaCode)] -> 
   [JavaCode (Variable JavaCode)] -> JavaCode (Body JavaCode) -> 
-  State GOOLState (JavaCode (Method JavaCode))
+  GS (JavaCode (Method JavaCode))
 jInOut f s p ins [] [] b = f s p void (map param ins) b
 jInOut f s p ins [v] [] b = f s p (variableType v) 
   (map param ins) (liftA3 surroundBody (varDec v) b (returnState $ 
@@ -778,11 +778,11 @@ jInOut f s p ins outs both b = f s p (returnTp rets)
 jDocInOut :: (RenderSym repr) => (repr (Scope repr) -> repr (Permanence repr) 
     -> [repr (Variable repr)] -> [repr (Variable repr)] -> 
     [repr (Variable repr)] -> repr (Body repr) -> 
-    State GOOLState (repr (Method repr)))
+    GS (repr (Method repr)))
   -> repr (Scope repr) -> repr (Permanence repr) -> String -> 
   [(String, repr (Variable repr))] -> [(String, repr (Variable repr))] -> 
   [(String, repr (Variable repr))] -> repr (Body repr) -> 
-  State GOOLState (repr (Method repr))
+  GS (repr (Method repr))
 jDocInOut f s p desc is [] [] b = docFuncRepr desc (map fst is) [] 
   (f s p (map snd is) [] [] b)
 jDocInOut f s p desc is [o] [] b = docFuncRepr desc (map fst is) [fst o] 

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer/JavaRenderer.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer/JavaRenderer.hs
@@ -64,8 +64,8 @@ import GOOL.Drasil.Data (Terminator(..), FileType(..), FileData(..), fileD,
   td, ValData(..), vd, VarData(..), vard)
 import GOOL.Drasil.Helpers (angles, emptyIfNull, liftA4, liftA5, liftList, 
   lift1List, checkParams)
-import GOOL.Drasil.State (GS, initialState, getPutReturn, 
-  getPutReturnList, passState2Lists, addProgNameToPaths, setMain, setCurrMain)
+import GOOL.Drasil.State (GS, initialState, getPutReturn, getPutReturnList, 
+  passState2Lists, addProgNameToPaths, setMain, setCurrMain, setParameters)
 
 import Prelude hiding (break,print,sin,cos,tan,floor,(<>))
 import Control.Applicative (Applicative, liftA2, liftA3)
@@ -516,7 +516,6 @@ instance ParameterSym JavaCode where
   param = fmap (mkParam paramDocD)
   pointerParam = param
 
-  parameterName = variableName . fmap paramVar
   parameterType = variableType . fmap paramVar
 
 instance MethodSym JavaCode where
@@ -543,13 +542,11 @@ instance MethodSym JavaCode where
   inOutFunc n = jInOut (function n)
     
   docInOutFunc n = jDocInOut (inOutFunc n)
-    
-  parameters m = map return $ (mthdParams . unJC) m
 
 instance InternalMethod JavaCode where
-  intMethod m n _ s p t ps b = (if m then getPutReturn (setCurrMain m . setMain)
-    else return) $ liftA2 mthd (checkParams n <$> sequence ps) (liftA5 
-    (jMethod n) s p t (liftList paramListDocD ps) b)
+  intMethod m n _ s p t ps b = getPutReturn (setParameters (map unJC ps) . 
+    if m then setCurrMain m . setMain else id) $ liftA2 mthd (checkParams n <$> 
+    sequence ps) (liftA5 (jMethod n) s p t (liftList paramListDocD ps) b)
   intFunc = G.intFunc
   commentedFunc cmt = liftA2 (liftA2 updateMthdDoc) (fmap (fmap commentedItem)
     cmt)

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer/JavaRenderer.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer/JavaRenderer.hs
@@ -58,7 +58,7 @@ import qualified GOOL.Drasil.LanguageRenderer.LanguagePolymorphic as G (
   mainFunction, docFunc, intFunc, stateVar, stateVarDef, constVar, privMVar, 
   pubMVar, pubGVar, buildClass, enum, privClass, pubClass, docClass, 
   commentedClass, buildModule', fileDoc, docMod)
-import GOOL.Drasil.Data (Terminator(..), FileType(..), FileData(..), 
+import GOOL.Drasil.Data (Terminator(..), FileType(..), FileData(..), fileD, 
   FuncData(..), fd, ModData(..), md, updateModDoc, MethodData(..), mthd, 
   updateMthdDoc, OpData(..), ParamData(..), ProgData(..), progD, TypeData(..), 
   td, ValData(..), vd, VarData(..), vard)
@@ -95,8 +95,8 @@ instance ProgramSym JavaCode where
     (progD n . map (packageDocD n end))) endStatement
 
 instance RenderSym JavaCode where
-  type RenderFile JavaCode = State GOOLState FileData 
-  fileDoc code = G.fileDoc Combined jExt (top code) 
+  type RenderFile JavaCode = FileData 
+  fileDoc code = G.fileDoc Combined jExt (top $ evalState code initialState) 
     bottom code
 
   docMod = G.docMod
@@ -107,7 +107,7 @@ instance InternalFile JavaCode where
   top _ = liftA3 jtop endStatement (include "") (list static_)
   bottom = return empty
   
-  fileFromData ft fp = fmap (G.fileFromData ft fp)
+  fileFromData = G.fileFromData (\fp m -> fmap (fileD fp) m)
 
 instance KeywordSym JavaCode where
   type Keyword JavaCode = Doc

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer/JavaRenderer.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer/JavaRenderer.hs
@@ -65,7 +65,7 @@ import GOOL.Drasil.Data (Terminator(..), FileType(..), FileData(..), fileD,
 import GOOL.Drasil.Helpers (angles, emptyIfNull, liftA4, liftA5, liftList, 
   lift1List, checkParams)
 import GOOL.Drasil.State (GS, initialState, getPutReturn, getPutReturnList, 
-  passState2Lists, addProgNameToPaths, setMain, setCurrMain, setParameters)
+  addProgNameToPaths, setMain, setCurrMain, setParameters)
 
 import Prelude hiding (break,print,sin,cos,tan,floor,(<>))
 import Control.Applicative (Applicative, liftA2, liftA3)
@@ -583,7 +583,7 @@ instance InternalClass JavaCode where
 
 instance ModuleSym JavaCode where
   type Module JavaCode = ModData
-  buildModule n _ ms cs = passState2Lists ms cs (G.buildModule' n ms cs)
+  buildModule n _ = G.buildModule' n
   
 instance InternalMod JavaCode where
   moduleDoc = modDoc . unJC

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer/JavaRenderer.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer/JavaRenderer.hs
@@ -590,7 +590,7 @@ instance ModuleSym JavaCode where
   
 instance InternalMod JavaCode where
   moduleDoc = modDoc . unJC
-  modFromData n = G.modFromData n (\m d -> return $ md n m d)
+  modFromData n = G.modFromData n (\d m -> return $ md n m d)
   updateModuleDoc f = fmap (fmap (updateModDoc f))
 
 instance BlockCommentSym JavaCode where

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer/JavaRenderer.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer/JavaRenderer.hs
@@ -586,16 +586,16 @@ instance InternalClass JavaCode where
   classFromData = fmap return
 
 instance ModuleSym JavaCode where
-  type Module JavaCode = State GOOLState ModData
-  buildModule n _ ms cs = liftA3 passState2Lists (sequence ms) (sequence cs) 
+  type Module JavaCode = ModData
+  buildModule n _ ms cs = passState2Lists (sequence ms) (sequence cs) 
     (G.buildModule' n ms cs)
 
-  moduleName = name . (`evalState` initialState) . unJC
+  moduleName = name . unJC
   
 instance InternalMod JavaCode where
-  isMainModule = isMainMod . (`evalState` initialState) . unJC
-  moduleDoc = modDoc . (`evalState` initialState) . unJC
-  modFromData n m d = return $ return $ md n m d
+  isMainModule = isMainMod . unJC
+  moduleDoc = modDoc . unJC
+  modFromData n = liftA2 (\m d -> return $ md n m d)
   updateModuleDoc f = fmap (fmap (updateModDoc f))
 
 instance BlockCommentSym JavaCode where

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer/LanguagePolymorphic.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer/LanguagePolymorphic.hs
@@ -305,9 +305,9 @@ docMod :: (RenderSym repr) => String -> [String] -> String ->
   GS (repr (RenderFile repr)) -> GS (repr (RenderFile repr))
 docMod d a dt m = commentedMod m (docComment $ moduleDox d a dt <$> getFilePath)
 
-fileFromData :: (RenderSym repr) => (FilePath -> repr (Module repr) -> 
+fileFromData :: (RenderSym repr) => (repr (Module repr) -> FilePath -> 
   repr (RenderFile repr)) -> FileType -> GS FilePath -> GS (repr (Module repr)) 
   -> GS (repr (RenderFile repr))
-fileFromData f ft fp m = getPutReturnFunc2 fp m (\s fpath mdl -> (if isEmpty 
+fileFromData f ft fp m = getPutReturnFunc2 m fp (\s mdl fpath -> (if isEmpty 
   (moduleDoc mdl) then id else (if s ^. hasMain && isNothing (s ^. mainMod) 
   then setMainMod fpath else id) . addFile ft fpath . setFilePath fpath) s) f

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer/LanguagePolymorphic.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer/LanguagePolymorphic.hs
@@ -221,30 +221,32 @@ intFunc :: (RenderSym repr) => Bool -> Label -> repr (Scope repr) ->
 intFunc m n = intMethod m n ""
 
 stateVar :: (RenderSym repr) => repr (Scope repr) -> repr (Permanence repr) ->
-  repr (Variable repr) -> repr (StateVar repr)
+  repr (Variable repr) -> State GOOLState (repr (StateVar repr))
 stateVar s p v = stateVarFromData $ stateVarDocD (scopeDoc s) (permDoc p) 
   (statementDoc (state $ S.varDec v))
 
 stateVarDef :: (RenderSym repr) => repr (Scope repr) -> repr (Permanence repr) 
-  -> repr (Variable repr) -> repr (Value repr) -> repr (StateVar repr)
+  -> repr (Variable repr) -> repr (Value repr) -> 
+  State GOOLState (repr (StateVar repr))
 stateVarDef s p vr vl = stateVarFromData $ stateVarDocD (scopeDoc s) (permDoc p)
   (statementDoc (state $ S.varDecDef vr vl))
 
 constVar :: (RenderSym repr) => Doc -> repr (Scope repr) ->
-  repr (Variable repr) -> repr (Value repr) -> repr (StateVar repr)
+  repr (Variable repr) -> repr (Value repr) -> 
+  State GOOLState (repr (StateVar repr))
 constVar p s vr vl = stateVarFromData $ stateVarDocD (scopeDoc s) p 
   (statementDoc (state $ constDecDef vr vl))
 
 privMVar :: (RenderSym repr) => repr (Variable repr) -> 
-  repr (StateVar repr)
+  State GOOLState (repr (StateVar repr))
 privMVar = S.stateVar private dynamic_
 
 pubMVar :: (RenderSym repr) => repr (Variable repr) -> 
-  repr (StateVar repr)
+  State GOOLState (repr (StateVar repr))
 pubMVar = S.stateVar public dynamic_
 
 pubGVar :: (RenderSym repr) => repr (Variable repr) -> 
-  repr (StateVar repr)
+  State GOOLState (repr (StateVar repr))
 pubGVar = S.stateVar public static_
 
 buildClass :: (RenderSym repr) => (Label -> Doc -> Doc -> Doc -> Doc -> Doc) -> 

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer/LanguagePolymorphic.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer/LanguagePolymorphic.hs
@@ -40,7 +40,7 @@ import GOOL.Drasil.LanguageRenderer (forLabel, addExt, blockDocD, stateVarDocD,
   moduleDox, getterName, setterName)
 import GOOL.Drasil.State (GS, hasMain, mainMod, putAfter, getPutReturnFunc2,
   addFile, setMainMod, setFilePath, getFilePath, setModuleName, getModuleName, 
-  setCurrMain, getCurrMain)
+  getCurrMain)
 
 import Prelude hiding (break,print,last,mod,pi,(<>))
 import Data.Maybe (maybeToList, isNothing)
@@ -293,8 +293,7 @@ buildModule' n ms cs = S.modFromData n getCurrMain (liftList (vibcat . map
 
 modFromData :: Label -> (Bool -> Doc -> repr (Module repr)) -> GS Bool -> 
   GS Doc -> GS (repr (Module repr))
-modFromData n f m d = putAfter (setCurrMain False . setModuleName n) 
-  (liftA2 f m d)
+modFromData n f m d = putAfter (setModuleName n) (liftA2 f m d)
 
 fileDoc :: (RenderSym repr) => FileType -> String -> repr (Block repr) -> 
   repr (Block repr) -> GS (repr (Module repr)) -> GS (repr (RenderFile repr))

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer/LanguagePolymorphic.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer/LanguagePolymorphic.hs
@@ -177,7 +177,7 @@ constructor :: (RenderSym repr) => Label -> Label -> [repr (Parameter repr)] ->
 constructor fName n = intMethod False fName n public dynamic_ (S.construct n)
 
 docMain :: (RenderSym repr) => repr (Body repr) -> repr (Method repr)
-docMain b = commentedFunc (docComment $ functionDox 
+docMain b = commentedFunc (docComment $ return $ functionDox 
   "Controls the flow of the program" 
   [("args", "List of command-line arguments")] []) (S.mainFunction b)
 
@@ -245,14 +245,14 @@ pubGVar = S.stateVar public static_
 buildClass :: (RenderSym repr) => (Label -> Doc -> Doc -> Doc -> Doc -> Doc) -> 
   (Label -> repr (Keyword repr)) -> Label -> Maybe Label -> repr (Scope repr) 
   -> [repr (StateVar repr)] -> [repr (Method repr)] -> repr (Class repr)
-buildClass f i n p s vs fs = classFromData (f n parent (scopeDoc s) 
+buildClass f i n p s vs fs = classFromData (return $ f n parent (scopeDoc s) 
   (stateVarListDocD (map stateVarDoc vs)) (methodListDocD (map methodDoc fs)))
   where parent = case p of Nothing -> empty
                            Just pn -> keyDoc $ i pn
 
 enum :: (RenderSym repr) => Label -> [Label] -> repr (Scope repr) -> 
   repr (Class repr)
-enum n es s = classFromData (enumDocD n (enumElementsDocD es False) 
+enum n es s = classFromData (return $ enumDocD n (enumElementsDocD es False) 
   (scopeDoc s))
 
 privClass :: (RenderSym repr) => Label -> Maybe Label -> [repr (StateVar repr)] 
@@ -264,12 +264,12 @@ pubClass :: (RenderSym repr) => Label -> Maybe Label -> [repr (StateVar repr)]
 pubClass n p = S.buildClass n p public
 
 docClass :: (RenderSym repr) => String -> repr (Class repr) -> repr (Class repr)
-docClass d = S.commentedClass (docComment $ classDox d)
+docClass d = S.commentedClass (docComment $ return $ classDox d)
 
 commentedClass :: (RenderSym repr) => repr (BlockComment repr) -> 
   repr (Class repr) -> repr (Class repr)
-commentedClass cmt cs = classFromData (commentedItem (blockCommentDoc cmt) 
-  (classDoc cs))
+commentedClass cmt cs = classFromData (fmap (`commentedItem` classDoc cs)
+  (blockCommentDoc cmt))
 
 buildModule :: (RenderSym repr) => Label -> [repr (Keyword repr)] -> 
   [repr (Method repr)] -> [repr (Class repr)] -> repr (Module repr)
@@ -290,4 +290,5 @@ fileDoc ft ext topb botb m = S.fileFromData ft (addExt ext (moduleName m))
 
 docMod :: (RenderSym repr) => String -> [String] -> String -> 
   repr (RenderFile repr) -> repr (RenderFile repr)
-docMod d a dt m = commentedMod (docComment $ moduleDox d a dt $ getFilePath m) m
+docMod d a dt m = commentedMod (docComment $ return $ moduleDox d a dt $ 
+  getFilePath m) m

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer/LanguagePolymorphic.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer/LanguagePolymorphic.hs
@@ -46,6 +46,7 @@ import Prelude hiding (break,print,last,mod,pi,(<>))
 import Data.Maybe (maybeToList, isNothing)
 import Control.Lens ((^.))
 import Control.Applicative (liftA2)
+import Control.Monad (liftM2)
 import Text.PrettyPrint.HughesPJ (Doc, text, empty, render, (<>), (<+>), parens,
   vcat, semi, equals, isEmpty)
 
@@ -291,9 +292,9 @@ buildModule' :: (RenderSym repr) => Label -> [GS (repr (Method repr))] ->
 buildModule' n ms cs = S.modFromData n getCurrMain (liftList (vibcat . map 
   classDoc) (if null ms then cs else pubClass n Nothing [] ms : cs))
 
-modFromData :: Label -> (Bool -> Doc -> repr (Module repr)) -> GS Bool -> 
+modFromData :: Label -> (Doc -> Bool -> repr (Module repr)) -> GS Bool -> 
   GS Doc -> GS (repr (Module repr))
-modFromData n f m d = putAfter (setModuleName n) (liftA2 f m d)
+modFromData n f m d = putAfter (setModuleName n) (liftM2 f d m)
 
 fileDoc :: (RenderSym repr) => FileType -> String -> repr (Block repr) -> 
   repr (Block repr) -> GS (repr (Module repr)) -> GS (repr (RenderFile repr))

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer/LanguagePolymorphic.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer/LanguagePolymorphic.hs
@@ -266,10 +266,10 @@ pubClass n p = S.buildClass n p public
 docClass :: (RenderSym repr) => String -> repr (Class repr) -> repr (Class repr)
 docClass d = S.commentedClass (docComment $ return $ classDox d)
 
-commentedClass :: (RenderSym repr) => repr (BlockComment repr) -> 
-  repr (Class repr) -> repr (Class repr)
-commentedClass cmt cs = classFromData (fmap (`commentedItem` classDoc cs)
-  (blockCommentDoc cmt))
+commentedClass :: (RenderSym repr) => State GOOLState (repr (BlockComment repr))
+  -> repr (Class repr) -> repr (Class repr)
+commentedClass cmt cs = classFromData (fmap ((`commentedItem` classDoc cs) . 
+  blockCommentDoc) cmt)
 
 buildModule :: (RenderSym repr) => Label -> [repr (Keyword repr)] -> 
   [repr (Method repr)] -> [repr (Class repr)] -> repr (Module repr)

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer/LanguagePolymorphic.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer/LanguagePolymorphic.hs
@@ -303,7 +303,7 @@ fileDoc ft ext topb botb m = S.fileFromData ft (fmap (addExt ext) getModuleName)
 
 docMod :: (RenderSym repr) => String -> [String] -> String -> 
   GS (repr (RenderFile repr)) -> GS (repr (RenderFile repr))
-docMod d a dt m = commentedMod m (docComment $ moduleDox d a dt <$> getFilePath)
+docMod d a dt = commentedMod (docComment $ moduleDox d a dt <$> getFilePath)
 
 fileFromData :: (RenderSym repr) => (repr (Module repr) -> FilePath -> 
   repr (RenderFile repr)) -> FileType -> GS FilePath -> GS (repr (Module repr)) 

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer/LanguagePolymorphic.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer/LanguagePolymorphic.hs
@@ -13,7 +13,7 @@ module GOOL.Drasil.LanguageRenderer.LanguagePolymorphic (fileFromData, block,
 import Utils.Drasil (indent)
 
 import GOOL.Drasil.CodeType (CodeType(..), isObject)
-import GOOL.Drasil.Symantics (Label, KeywordSym(..), InternalFile(getFilePath),
+import GOOL.Drasil.Symantics (Label, KeywordSym(..),
   RenderSym(RenderFile, commentedMod), BlockSym(Block), 
   InternalBlock(..), BodySym(..), PermanenceSym(..), InternalPerm(..), 
   TypeSym(..), InternalType(..), VariableSym(..), 
@@ -38,7 +38,7 @@ import GOOL.Drasil.LanguageRenderer (forLabel, addExt, blockDocD, stateVarDocD,
   fileDoc', docFuncRepr, commentDocD, commentedItem, functionDox, classDox, 
   moduleDox, getterName, setterName)
 import GOOL.Drasil.State (GOOLState, hasMain, mainMod, getPutReturnFunc, 
-  addFile, setMainMod)
+  addFile, setMainMod, setFilePath, getFilePath)
 
 import Prelude hiding (break,print,last,mod,pi,(<>))
 import Data.Maybe (maybeToList, isNothing)
@@ -51,7 +51,7 @@ fileFromData :: FileType -> FilePath -> State GOOLState ModData ->
   State GOOLState FileData
 fileFromData ft fp sm = getPutReturnFunc sm (\s m -> (if isEmpty (modDoc m) 
   then id else (if s ^. hasMain && isNothing (s ^. mainMod) then setMainMod fp 
-  else id) . addFile ft fp) s) (fileD fp)
+  else id) . addFile ft fp . setFilePath fp) s) (fileD fp)
 
 block :: (RenderSym repr) => repr (Keyword repr) -> [repr (Statement repr)] -> 
   repr (Block repr)
@@ -285,9 +285,9 @@ buildModule' n ms cs = modFromData n (any isMainMethod ms) (vibcat $ map
 fileDoc :: (RenderSym repr) => FileType -> String -> repr (Block repr) -> 
   repr (Block repr) -> repr (Module repr) -> repr (RenderFile repr)
 fileDoc ft ext topb botb m = S.fileFromData ft (addExt ext (moduleName m)) 
-  (updateModuleDoc (\d -> emptyIfEmpty d (fileDoc' (blockDoc topb) d (blockDoc botb))) m)
+  (updateModuleDoc (\d -> emptyIfEmpty d (fileDoc' (blockDoc topb) d (blockDoc 
+  botb))) m)
 
 docMod :: (RenderSym repr) => String -> [String] -> String -> 
   repr (RenderFile repr) -> repr (RenderFile repr)
-docMod d a dt m = commentedMod (docComment $ return $ moduleDox d a dt $ 
-  getFilePath m) m
+docMod d a dt m = commentedMod m (docComment $ moduleDox d a dt <$> getFilePath)

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer/LanguagePolymorphic.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer/LanguagePolymorphic.hs
@@ -285,8 +285,7 @@ buildModule' n ms cs = modFromData n (any isMainMethod ms) (vibcat $ map
 fileDoc :: (RenderSym repr) => FileType -> String -> repr (Block repr) -> 
   repr (Block repr) -> repr (Module repr) -> repr (RenderFile repr)
 fileDoc ft ext topb botb m = S.fileFromData ft (addExt ext (moduleName m)) 
-  (modFromData (moduleName m) (isMainModule m) (emptyIfEmpty (moduleDoc m) 
-  (fileDoc' (blockDoc topb) (moduleDoc m) (blockDoc botb))))
+  (updateModuleDoc (\d -> emptyIfEmpty d (fileDoc' (blockDoc topb) d (blockDoc botb))) m)
 
 docMod :: (RenderSym repr) => String -> [String] -> String -> 
   repr (RenderFile repr) -> repr (RenderFile repr)

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer/PythonRenderer.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer/PythonRenderer.hs
@@ -85,7 +85,7 @@ instance Monad PythonCode where
   PC x >>= f = f x
 
 instance ProgramSym PythonCode where
-  type Program PythonCode = State GOOLState ProgData 
+  type Program PythonCode = ProgData 
   prog n = liftList (liftList (progD n))
 
 instance RenderSym PythonCode where

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer/PythonRenderer.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer/PythonRenderer.hs
@@ -540,7 +540,7 @@ instance MethodSym PythonCode where
 
   function = G.function
   mainFunction = getPutReturn (setParameters [] . setCurrMain True . setMain) . 
-    fmap (mthd [])
+    fmap mthd
 
   docFunc = G.docFunc
 
@@ -554,16 +554,15 @@ instance MethodSym PythonCode where
 
 instance InternalMethod PythonCode where
   intMethod m n l _ _ _ ps b = getPutReturn (setParameters (map unPC ps) . 
-    if m then setCurrMain m . setMain else id) $ liftA2 mthd (checkParams n <$> 
-    sequence ps) (liftA3 (pyMethod n) (self l) (liftList paramListDocD ps) b)
+    if m then setCurrMain m . setMain else id) $ fmap mthd (liftA3 (pyMethod n) (self l) (liftList (paramListDocD . checkParams n) ps) b)
   intFunc m n _ _ _ ps b = getPutReturn (setParameters (map unPC ps) . 
-    if m then setCurrMain m . setMain else id) $ liftA2 mthd (checkParams n <$> 
-    sequence ps) (liftA2 (pyFunction n) (liftList paramListDocD ps) b)
+    if m then setCurrMain m . setMain else id) $ fmap mthd (liftA2 
+    (pyFunction n) (liftList (paramListDocD . checkParams n) ps) b)
   commentedFunc cmt = liftA2 (liftA2 updateMthdDoc) (fmap (fmap commentedItem) 
     cmt)
 
   methodDoc = mthdDoc . unPC
-  methodFromData _ = return . mthd []
+  methodFromData _ = return . mthd
 
 instance StateVarSym PythonCode where
   type StateVar PythonCode = Doc

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer/PythonRenderer.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer/PythonRenderer.hs
@@ -52,7 +52,7 @@ import qualified GOOL.Drasil.LanguageRenderer.LanguagePolymorphic as G (
   function, docFunc, stateVarDef, constVar, privMVar, pubMVar, pubGVar, 
   buildClass, privClass, pubClass, docClass, commentedClass, buildModule, 
   fileDoc, docMod)
-import GOOL.Drasil.Data (Terminator(..), FileType(..), FileData(..), 
+import GOOL.Drasil.Data (Terminator(..), FileType(..), FileData(..), fileD,
   FuncData(..), fd, ModData(..), md, updateModDoc, MethodData(..), mthd, 
   updateMthdDoc, OpData(..), ParamData(..), ProgData(..), progD, TypeData(..), 
   td, ValData(..), vd, VarData(..), vard)
@@ -89,8 +89,10 @@ instance ProgramSym PythonCode where
   prog n = liftList (liftList (progD n))
 
 instance RenderSym PythonCode where
-  type RenderFile PythonCode = State GOOLState FileData
-  fileDoc code = G.fileDoc Combined pyExt (top code) bottom code
+  type RenderFile PythonCode = FileData
+  -- temporary evalState until I add more state
+  fileDoc code = G.fileDoc Combined pyExt (top $ evalState code initialState)
+    bottom code
 
   docMod = G.docMod
 
@@ -100,7 +102,7 @@ instance InternalFile PythonCode where
   top _ = return pytop
   bottom = return empty
 
-  fileFromData ft fp = fmap (G.fileFromData ft fp)
+  fileFromData = G.fileFromData (\fp m -> fmap (fileD fp) m)
 
 instance KeywordSym PythonCode where
   type Keyword PythonCode = Doc

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer/PythonRenderer.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer/PythonRenderer.hs
@@ -58,8 +58,8 @@ import GOOL.Drasil.Data (Terminator(..), FileType(..), FileData(..), fileD,
   td, ValData(..), vd, VarData(..), vard)
 import GOOL.Drasil.Helpers (emptyIfEmpty, liftA4, liftA5, liftA6, liftList, 
   lift1List, lift2Lists, checkParams)
-import GOOL.Drasil.State (GS, initialState, getPutReturn, passState2Lists, 
-  setMain, setCurrMain, setParameters)
+import GOOL.Drasil.State (GS, initialState, getPutReturn, setMain, setCurrMain, 
+  setParameters)
 
 import Prelude hiding (break,print,sin,cos,tan,floor,(<>))
 import Data.Maybe (fromMaybe)
@@ -596,8 +596,7 @@ instance InternalClass PythonCode where
 
 instance ModuleSym PythonCode where
   type Module PythonCode = ModData
-  buildModule n ls ms cs = passState2Lists ms cs 
-    (G.buildModule n (map include ls) ms cs)
+  buildModule n ls = G.buildModule n (map include ls)
 
 instance InternalMod PythonCode where
   moduleDoc = modDoc . unPC

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer/PythonRenderer.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer/PythonRenderer.hs
@@ -58,8 +58,8 @@ import GOOL.Drasil.Data (Terminator(..), FileType(..), FileData(..), fileD,
   td, ValData(..), vd, VarData(..), vard)
 import GOOL.Drasil.Helpers (emptyIfEmpty, liftA4, liftA5, liftA6, liftList, 
   lift1List, lift2Lists, checkParams)
-import GOOL.Drasil.State (GS, initialState, getPutReturn, 
-  passState2Lists, setMain, setCurrMain)
+import GOOL.Drasil.State (GS, initialState, getPutReturn, passState2Lists, 
+  setMain, setCurrMain, setParameters)
 
 import Prelude hiding (break,print,sin,cos,tan,floor,(<>))
 import Data.Maybe (fromMaybe)
@@ -524,7 +524,6 @@ instance ParameterSym PythonCode where
   param = fmap (mkParam varDoc)
   pointerParam = param
 
-  parameterName = variableName . fmap paramVar
   parameterType = variableType . fmap paramVar
 
 instance MethodSym PythonCode where
@@ -540,7 +539,8 @@ instance MethodSym PythonCode where
   docMain = mainFunction
 
   function = G.function
-  mainFunction = getPutReturn (setCurrMain True . setMain) . fmap (mthd [])
+  mainFunction = getPutReturn (setParameters [] . setCurrMain True . setMain) . 
+    fmap (mthd [])
 
   docFunc = G.docFunc
 
@@ -552,15 +552,13 @@ instance MethodSym PythonCode where
 
   docInOutFunc n = pyDocInOut (inOutFunc n)
 
-  parameters m = map return $ (mthdParams . unPC) m
-
 instance InternalMethod PythonCode where
-  intMethod m n l _ _ _ ps b = (if m then getPutReturn (setCurrMain m . setMain)
-    else return) $ liftA2 mthd (checkParams n <$> sequence ps) (liftA3 
-    (pyMethod n) (self l) (liftList paramListDocD ps) b)
-  intFunc m n _ _ _ ps b = (if m then getPutReturn (setCurrMain m . setMain) 
-    else return) $ liftA2 mthd (checkParams n <$> sequence ps) (liftA2 
-    (pyFunction n) (liftList paramListDocD ps) b)
+  intMethod m n l _ _ _ ps b = getPutReturn (setParameters (map unPC ps) . 
+    if m then setCurrMain m . setMain else id) $ liftA2 mthd (checkParams n <$> 
+    sequence ps) (liftA3 (pyMethod n) (self l) (liftList paramListDocD ps) b)
+  intFunc m n _ _ _ ps b = getPutReturn (setParameters (map unPC ps) . 
+    if m then setCurrMain m . setMain else id) $ liftA2 mthd (checkParams n <$> 
+    sequence ps) (liftA2 (pyFunction n) (liftList paramListDocD ps) b)
   commentedFunc cmt = liftA2 (liftA2 updateMthdDoc) (fmap (fmap commentedItem) 
     cmt)
 

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer/PythonRenderer.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer/PythonRenderer.hs
@@ -601,7 +601,7 @@ instance ModuleSym PythonCode where
 
 instance InternalMod PythonCode where
   moduleDoc = modDoc . unPC
-  modFromData n = G.modFromData n (\m d -> return $ md n m d)
+  modFromData n = G.modFromData n (\d m -> return $ md n m d)
   updateModuleDoc f = fmap (fmap (updateModDoc f))
 
 instance BlockCommentSym PythonCode where

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer/PythonRenderer.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer/PythonRenderer.hs
@@ -64,7 +64,6 @@ import GOOL.Drasil.State (MS, lensMStoGS, initialState, putAfter, getPutReturn,
 import Prelude hiding (break,print,sin,cos,tan,floor,(<>))
 import Data.Maybe (fromMaybe)
 import Control.Lens (over)
-import Control.Lens.Zoom (zoom)
 import Control.Applicative (Applicative, liftA2, liftA3)
 import Control.Monad.State (evalState)
 import Control.Monad (liftM2)
@@ -563,7 +562,7 @@ instance InternalMethod PythonCode where
     if m then over lensMStoGS (setCurrMain m) . setMain else id) $ fmap mthd 
     (liftA2 (pyFunction n) (liftList (paramListDocD . checkParams n) ps) b)
   commentedFunc cmt m = liftM2 (liftA2 updateMthdDoc) m 
-    (fmap (fmap commentedItem) (zoom lensMStoGS cmt))
+    (fmap (fmap commentedItem) cmt)
 
   methodDoc = mthdDoc . unPC
   methodFromData _ = return . mthd

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer/PythonRenderer.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer/PythonRenderer.hs
@@ -51,7 +51,7 @@ import qualified GOOL.Drasil.LanguageRenderer.LanguagePolymorphic as G (
   comment, method, getMethod, setMethod, privMethod, pubMethod, constructor, 
   function, docFunc, stateVarDef, constVar, privMVar, pubMVar, pubGVar, 
   buildClass, privClass, pubClass, docClass, commentedClass, buildModule, 
-  fileDoc, docMod)
+  modFromData, fileDoc, docMod)
 import GOOL.Drasil.Data (Terminator(..), FileType(..), FileData(..), fileD,
   FuncData(..), fd, ModData(..), md, updateModDoc, MethodData(..), mthd, 
   updateMthdDoc, OpData(..), ParamData(..), ProgData(..), progD, TypeData(..), 
@@ -602,12 +602,9 @@ instance ModuleSym PythonCode where
   buildModule n ls ms cs = passState2Lists ms cs 
     (G.buildModule n (map include ls) ms cs)
 
-  moduleName = name . unPC
-
 instance InternalMod PythonCode where
-  isMainModule = isMainMod . unPC
   moduleDoc = modDoc . unPC
-  modFromData n = liftA2 (\m d -> return $ md n m d)
+  modFromData n = G.modFromData n (\m d -> return $ md n m d)
   updateModuleDoc f = fmap (fmap (updateModDoc f))
 
 instance BlockCommentSym PythonCode where

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer/PythonRenderer.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer/PythonRenderer.hs
@@ -599,7 +599,7 @@ instance InternalClass PythonCode where
 
 instance ModuleSym PythonCode where
   type Module PythonCode = ModData
-  buildModule n ls ms cs = passState2Lists (sequence ms) (sequence cs) 
+  buildModule n ls ms cs = passState2Lists ms cs 
     (G.buildModule n (map include ls) ms cs)
 
   moduleName = name . unPC

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer/PythonRenderer.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer/PythonRenderer.hs
@@ -58,13 +58,13 @@ import GOOL.Drasil.Data (Terminator(..), FileType(..), FileData(..), fileD,
   td, ValData(..), vd, VarData(..), vard)
 import GOOL.Drasil.Helpers (emptyIfEmpty, liftA4, liftA5, liftA6, liftList, 
   lift1List, lift2Lists, checkParams)
-import GOOL.Drasil.State (GOOLState, initialState, getPutReturn, 
+import GOOL.Drasil.State (GS, initialState, getPutReturn, 
   passState2Lists, setMain)
 
 import Prelude hiding (break,print,sin,cos,tan,floor,(<>))
 import Data.Maybe (fromMaybe)
 import Control.Applicative (Applicative, liftA2, liftA3)
-import Control.Monad.State (State, evalState)
+import Control.Monad.State (evalState)
 import Text.PrettyPrint.HughesPJ (Doc, text, (<>), (<+>), parens, empty, equals,
   vcat, colon, brackets, isEmpty)
 
@@ -762,11 +762,11 @@ pyDocComment (l:lns) start mid = vcat $ start <+> text l : map ((<+>) mid .
 pyInOut :: (PythonCode (Scope PythonCode) -> PythonCode (Permanence PythonCode) 
     -> PythonCode (Type PythonCode) -> [PythonCode (Parameter PythonCode)] -> 
     PythonCode (Body PythonCode) -> 
-    State GOOLState (PythonCode (Method PythonCode)))
+    GS (PythonCode (Method PythonCode)))
   -> PythonCode (Scope PythonCode) -> PythonCode (Permanence PythonCode) -> 
   [PythonCode (Variable PythonCode)] -> [PythonCode (Variable PythonCode)] -> 
   [PythonCode (Variable PythonCode)] -> PythonCode (Body PythonCode) -> 
-  State GOOLState (PythonCode (Method PythonCode))
+  GS (PythonCode (Method PythonCode))
 pyInOut f s p ins [] [] b = f s p void (map param ins) b
 pyInOut f s p ins outs both b = f s p void (map param $ both ++ ins) 
   (if null rets then b else liftA3 surroundBody (multi $ map varDec outs) b 
@@ -776,11 +776,11 @@ pyInOut f s p ins outs both b = f s p void (map param $ both ++ ins)
 pyDocInOut :: (RenderSym repr) => (repr (Scope repr) -> repr (Permanence repr) 
     -> [repr (Variable repr)] -> [repr (Variable repr)] -> 
     [repr (Variable repr)] -> repr (Body repr) -> 
-    State GOOLState (repr (Method repr)))
+    GS (repr (Method repr)))
   -> repr (Scope repr) -> repr (Permanence repr) -> String -> 
   [(String, repr (Variable repr))] -> [(String, repr (Variable repr))] -> 
   [(String, repr (Variable repr))] -> repr (Body repr) -> 
-  State GOOLState (repr (Method repr))
+  GS (repr (Method repr))
 pyDocInOut f s p desc is os bs b = docFuncRepr desc (map fst $ bs ++ is)
   (map fst $ bRets ++ os) (f s p (map snd is) (map snd os) (map snd bs) b)
   where bRets = filter (not . isObject . getType . variableType . snd) bs

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer/PythonRenderer.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer/PythonRenderer.hs
@@ -596,16 +596,16 @@ instance InternalClass PythonCode where
   classFromData = fmap return
 
 instance ModuleSym PythonCode where
-  type Module PythonCode = State GOOLState ModData
-  buildModule n ls ms cs = liftA3 passState2Lists (sequence ms) (sequence cs) 
+  type Module PythonCode = ModData
+  buildModule n ls ms cs = passState2Lists (sequence ms) (sequence cs) 
     (G.buildModule n (map include ls) ms cs)
 
-  moduleName = name . (`evalState` initialState) . unPC
+  moduleName = name . unPC
 
 instance InternalMod PythonCode where
-  isMainModule = isMainMod . (`evalState` initialState) . unPC
-  moduleDoc = modDoc . (`evalState` initialState) . unPC
-  modFromData n m d = return $ return $ md n m d
+  isMainModule = isMainMod . unPC
+  moduleDoc = modDoc . unPC
+  modFromData n = liftA2 (\m d -> return $ md n m d)
   updateModuleDoc f = fmap (fmap (updateModDoc f))
 
 instance BlockCommentSym PythonCode where

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer/PythonRenderer.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer/PythonRenderer.hs
@@ -53,13 +53,13 @@ import qualified GOOL.Drasil.LanguageRenderer.LanguagePolymorphic as G (
   buildClass, privClass, pubClass, docClass, commentedClass, buildModule, 
   fileDoc, docMod)
 import GOOL.Drasil.Data (Terminator(..), FileType(..), FileData(..), 
-  FuncData(..), fd, ModData(..), md, updateModDoc, MethodData(..), mthd, updateMthdDoc, 
-  OpData(..), ParamData(..), ProgData(..), progD, TypeData(..), td, ValData(..),
-  vd, VarData(..), vard)
+  FuncData(..), fd, ModData(..), md, updateModDoc, MethodData(..), mthd, 
+  updateMthdDoc, OpData(..), ParamData(..), ProgData(..), progD, TypeData(..), 
+  td, ValData(..), vd, VarData(..), vard)
 import GOOL.Drasil.Helpers (emptyIfEmpty, liftA4, liftA5, liftA6, liftList, 
   lift1List, lift2Lists, checkParams)
 import GOOL.Drasil.State (GOOLState, initialState, getPutReturn, 
-  passState, passState2Lists, setMain)
+  passState2Lists, setMain)
 
 import Prelude hiding (break,print,sin,cos,tan,floor,(<>))
 import Data.Maybe (fromMaybe)

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer/PythonRenderer.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer/PythonRenderer.hs
@@ -580,7 +580,7 @@ instance InternalStateVar PythonCode where
   stateVarFromData = return . return
 
 instance ClassSym PythonCode where
-  type Class PythonCode = State GOOLState Doc
+  type Class PythonCode = Doc
   buildClass = G.buildClass pyClass inherit
   enum n es s = classFromData (return $ pyClass n empty (scopeDoc s)
     (enumElementsDocD' es) empty)
@@ -592,8 +592,8 @@ instance ClassSym PythonCode where
   commentedClass = G.commentedClass
 
 instance InternalClass PythonCode where
-  classDoc = (`evalState` initialState) . unPC
-  classFromData = return
+  classDoc = unPC
+  classFromData = fmap return
 
 instance ModuleSym PythonCode where
   type Module PythonCode = State GOOLState ModData

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer/PythonRenderer.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer/PythonRenderer.hs
@@ -609,9 +609,10 @@ instance InternalMod PythonCode where
   updateModuleDoc f = fmap (fmap (updateModDoc f))
 
 instance BlockCommentSym PythonCode where
-  type BlockComment PythonCode = State GOOLState Doc
-  blockComment lns = fmap (return . pyBlockComment lns) commentStart
-  docComment lns = liftA2 (\dcs cs -> fmap (pyDocComment dcs cs) lns) docCommentStart commentStart
+  type BlockComment PythonCode = Doc
+  blockComment lns = fmap (pyBlockComment lns) commentStart
+  docComment = fmap (\lns -> liftA2 (pyDocComment lns) docCommentStart 
+    commentStart)
 
   blockCommentDoc = unPC
 
@@ -751,9 +752,9 @@ pyInOutCall f n ins outs both = if null rets then valState (f n void (map
 pyBlockComment :: [String] -> Doc -> Doc
 pyBlockComment lns cmt = vcat $ map ((<+>) cmt . text) lns
 
-pyDocComment :: Doc -> Doc -> [String] -> Doc
-pyDocComment _ _ [] = empty
-pyDocComment start mid (l:lns) = vcat $ start <+> text l : map ((<+>) mid . 
+pyDocComment :: [String] -> Doc -> Doc -> Doc
+pyDocComment [] _ _ = empty
+pyDocComment (l:lns) start mid = vcat $ start <+> text l : map ((<+>) mid . 
   text) lns
 
 pyInOut :: (PythonCode (Scope PythonCode) -> PythonCode (Permanence PythonCode) 

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer/PythonRenderer.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer/PythonRenderer.hs
@@ -100,7 +100,6 @@ instance InternalFile PythonCode where
   top _ = return pytop
   bottom = return empty
 
-  getFilePath = filePath . (`evalState` initialState) . unPC
   fileFromData ft fp = fmap (G.fileFromData ft fp)
 
 instance KeywordSym PythonCode where

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer/PythonRenderer.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer/PythonRenderer.hs
@@ -65,6 +65,7 @@ import Prelude hiding (break,print,sin,cos,tan,floor,(<>))
 import Data.Maybe (fromMaybe)
 import Control.Applicative (Applicative, liftA2, liftA3)
 import Control.Monad.State (evalState)
+import Control.Monad (liftM2)
 import Text.PrettyPrint.HughesPJ (Doc, text, (<>), (<+>), parens, empty, equals,
   vcat, colon, brackets, isEmpty)
 
@@ -102,7 +103,7 @@ instance InternalFile PythonCode where
   top _ = return pytop
   bottom = return empty
 
-  fileFromData = G.fileFromData (\fp m -> fmap (fileD fp) m)
+  fileFromData = G.fileFromData (\m fp -> fmap (fileD fp) m)
 
 instance KeywordSym PythonCode where
   type Keyword PythonCode = Doc
@@ -558,8 +559,8 @@ instance InternalMethod PythonCode where
   intFunc m n _ _ _ ps b = getPutReturn (setParameters (map unPC ps) . 
     if m then setCurrMain m . setMain else id) $ fmap mthd (liftA2 
     (pyFunction n) (liftList (paramListDocD . checkParams n) ps) b)
-  commentedFunc cmt = liftA2 (liftA2 updateMthdDoc) (fmap (fmap commentedItem) 
-    cmt)
+  commentedFunc cmt m = liftM2 (liftA2 updateMthdDoc) m 
+    (fmap (fmap commentedItem) cmt)
 
   methodDoc = mthdDoc . unPC
   methodFromData _ = return . mthd

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer/PythonRenderer.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer/PythonRenderer.hs
@@ -58,8 +58,8 @@ import GOOL.Drasil.Data (Terminator(..), FileType(..), FileData(..), fileD,
   td, ValData(..), vd, VarData(..), vard)
 import GOOL.Drasil.Helpers (emptyIfEmpty, liftA4, liftA5, liftA6, liftList, 
   lift1List, lift2Lists, checkParams)
-import GOOL.Drasil.State (GS, initialState, getPutReturn, setMain, setCurrMain, 
-  setParameters)
+import GOOL.Drasil.State (GS, initialState, putAfter, getPutReturn, setMain, 
+  setCurrMain, setParameters)
 
 import Prelude hiding (break,print,sin,cos,tan,floor,(<>))
 import Data.Maybe (fromMaybe)
@@ -86,7 +86,7 @@ instance Monad PythonCode where
 
 instance ProgramSym PythonCode where
   type Program PythonCode = ProgData 
-  prog n = liftList (liftList (progD n))
+  prog n = liftList (liftList (progD n)) . map (putAfter $ setCurrMain False)
 
 instance RenderSym PythonCode where
   type RenderFile PythonCode = FileData

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer/PythonRenderer.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer/PythonRenderer.hs
@@ -97,7 +97,7 @@ instance RenderSym PythonCode where
 
   docMod = G.docMod
 
-  commentedMod = liftA2 (liftA2 commentedModD)
+  commentedMod cmt m = liftM2 (liftA2 commentedModD) m cmt
 
 instance InternalFile PythonCode where
   top _ = return pytop

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer/PythonRenderer.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer/PythonRenderer.hs
@@ -610,7 +610,7 @@ instance InternalMod PythonCode where
 
 instance BlockCommentSym PythonCode where
   type BlockComment PythonCode = State GOOLState Doc
-  blockComment lns = fmap (pyBlockComment lns) commentStart
+  blockComment lns = fmap (return . pyBlockComment lns) commentStart
   docComment lns = liftA2 (\dcs cs -> fmap (pyDocComment dcs cs) lns) docCommentStart commentStart
 
   blockCommentDoc = unPC
@@ -748,8 +748,8 @@ pyInOutCall f n ins outs both = if null rets then valState (f n void (map
   [f n void (map valueOf both ++ ins)]
   where rets = filterOutObjs both ++ outs
 
-pyBlockComment :: [String] -> Doc -> State GOOLState Doc
-pyBlockComment lns cmt = return $ vcat $ map ((<+>) cmt . text) lns
+pyBlockComment :: [String] -> Doc -> Doc
+pyBlockComment lns cmt = vcat $ map ((<+>) cmt . text) lns
 
 pyDocComment :: Doc -> Doc -> [String] -> Doc
 pyDocComment _ _ [] = empty

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer/PythonRenderer.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer/PythonRenderer.hs
@@ -53,7 +53,7 @@ import qualified GOOL.Drasil.LanguageRenderer.LanguagePolymorphic as G (
   buildClass, privClass, pubClass, docClass, commentedClass, buildModule, 
   fileDoc, docMod)
 import GOOL.Drasil.Data (Terminator(..), FileType(..), FileData(..), 
-  FuncData(..), fd, ModData(..), md, MethodData(..), mthd, updateMthdDoc, 
+  FuncData(..), fd, ModData(..), md, updateModDoc, MethodData(..), mthd, updateMthdDoc, 
   OpData(..), ParamData(..), ProgData(..), progD, TypeData(..), td, ValData(..),
   vd, VarData(..), vard)
 import GOOL.Drasil.Helpers (emptyIfEmpty, liftA4, liftA5, liftA6, liftList, 
@@ -90,8 +90,7 @@ instance ProgramSym PythonCode where
 
 instance RenderSym PythonCode where
   type RenderFile PythonCode = State GOOLState FileData
-  fileDoc code = liftA2 passState code (G.fileDoc Combined pyExt (top code) 
-    bottom code)
+  fileDoc code = G.fileDoc Combined pyExt (top code) bottom code
 
   docMod = G.docMod
 
@@ -608,6 +607,7 @@ instance InternalMod PythonCode where
   isMainModule = isMainMod . (`evalState` initialState) . unPC
   moduleDoc = modDoc . (`evalState` initialState) . unPC
   modFromData n m d = return $ return $ md n m d
+  updateModuleDoc f = fmap (fmap (updateModDoc f))
 
 instance BlockCommentSym PythonCode where
   type BlockComment PythonCode = State GOOLState Doc

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer/PythonRenderer.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer/PythonRenderer.hs
@@ -563,6 +563,7 @@ instance InternalMethod PythonCode where
     cmt)
 
   methodDoc = mthdDoc . unPC
+  methodFromData _ = return . mthd []
 
 instance StateVarSym PythonCode where
   type StateVar PythonCode = Doc

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer/PythonRenderer.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer/PythonRenderer.hs
@@ -56,8 +56,8 @@ import GOOL.Drasil.Data (Terminator(..), FileType(..), FileData(..), fileD,
   FuncData(..), fd, ModData(..), md, updateModDoc, MethodData(..), mthd, 
   updateMthdDoc, OpData(..), ParamData(..), ProgData(..), progD, TypeData(..), 
   td, ValData(..), vd, VarData(..), vard)
-import GOOL.Drasil.Helpers (emptyIfEmpty, liftA4, liftA5, liftA6, liftList, 
-  lift1List, lift2Lists, checkParams)
+import GOOL.Drasil.Helpers (emptyIfEmpty, toCode, onStateValue, liftA4, liftA5, 
+  liftA6, liftList, lift1List, lift2Lists, checkParams)
 import GOOL.Drasil.State (GS, initialState, putAfter, getPutReturn, setMain, 
   setCurrMain, setParameters)
 
@@ -593,7 +593,7 @@ instance ClassSym PythonCode where
 
 instance InternalClass PythonCode where
   classDoc = unPC
-  classFromData = fmap return
+  classFromData = onStateValue toCode
 
 instance ModuleSym PythonCode where
   type Module PythonCode = ModData

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer/PythonRenderer.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer/PythonRenderer.hs
@@ -566,7 +566,7 @@ instance InternalMethod PythonCode where
   methodDoc = mthdDoc . unPC
 
 instance StateVarSym PythonCode where
-  type StateVar PythonCode = State GOOLState Doc
+  type StateVar PythonCode = Doc
   stateVar _ _ _ = return (return empty)
   stateVarDef _ = G.stateVarDef
   constVar _ = G.constVar (permDoc 
@@ -576,7 +576,7 @@ instance StateVarSym PythonCode where
   pubGVar = G.pubGVar
 
 instance InternalStateVar PythonCode where
-  stateVarDoc = (`evalState` initialState) . unPC
+  stateVarDoc = unPC
   stateVarFromData = return . return
 
 instance ClassSym PythonCode where

--- a/code/drasil-gool/GOOL/Drasil/State.hs
+++ b/code/drasil-gool/GOOL/Drasil/State.hs
@@ -2,9 +2,9 @@
 
 module GOOL.Drasil.State (
   GOOLState(..), headers, sources, hasMain, mainMod, initialState, getPutReturn,
-  getPutReturnFunc, getPutReturnList, passState, passState2Lists, 
-  checkGOOLState, addFile, addCombinedHeaderSource, addHeader, addSource, 
-  addProgNameToPaths, setMain, setMainMod, setFilePath, getFilePath
+  getPutReturnFunc, getPutReturnFunc2, getPutReturnList, passState, 
+  passState2Lists, checkGOOLState, addFile, addCombinedHeaderSource, addHeader, 
+  addSource, addProgNameToPaths, setMain, setMainMod, setFilePath, getFilePath
 ) where
 
 import GOOL.Drasil.Data (FileType(..))
@@ -45,6 +45,15 @@ getPutReturnFunc st sf vf = do
   s <- get
   put $ sf s v
   return $ vf v
+
+getPutReturnFunc2 :: State GOOLState c -> State GOOLState b -> 
+  (GOOLState -> c -> b -> GOOLState) -> (c -> b -> a) -> State GOOLState a
+getPutReturnFunc2 st1 st2 sf vf = do
+  v1 <- st1
+  v2 <- st2
+  s <- get
+  put $ sf s v1 v2
+  return $ vf v1 v2
 
 getPutReturnList :: [State GOOLState b] -> (GOOLState -> GOOLState) -> 
   ([b] -> a) -> State GOOLState a

--- a/code/drasil-gool/GOOL/Drasil/State.hs
+++ b/code/drasil-gool/GOOL/Drasil/State.hs
@@ -2,10 +2,10 @@
 
 module GOOL.Drasil.State (
   GS, GOOLState(..), headers, sources, hasMain, mainMod, initialState, 
-  getPutReturn, getPutReturnFunc, getPutReturnFunc2, getPutReturnList, 
+  getPut, getPutReturn, getPutReturnFunc, getPutReturnFunc2, getPutReturnList, 
   passState, passState2Lists, checkGOOLState, addFile, addCombinedHeaderSource, 
   addHeader, addSource, addProgNameToPaths, setMain, setMainMod, setFilePath, 
-  getFilePath
+  getFilePath, setModuleName, getModuleName
 ) where
 
 import GOOL.Drasil.Data (FileType(..))
@@ -19,7 +19,8 @@ data GOOLState = GS {
   _hasMain :: Bool,
   _mainMod :: Maybe FilePath,
 
-  _currFilePath :: FilePath
+  _currFilePath :: FilePath,
+  _currModName :: String
 } 
 makeLenses ''GOOLState
 
@@ -32,8 +33,15 @@ initialState = GS {
   _hasMain = False,
   _mainMod = Nothing,
 
-  _currFilePath = ""
+  _currFilePath = "",
+  _currModName = ""
 }
+
+getPut :: (GOOLState -> GOOLState) -> GS a -> GS a
+getPut sf v = do
+  s <- get
+  put $ sf s
+  v
 
 getPutReturn :: (GOOLState -> GOOLState) -> a -> GS a
 getPutReturn sf v = do
@@ -118,3 +126,9 @@ setFilePath = set currFilePath
 
 getFilePath :: GS FilePath
 getFilePath = gets (^. currFilePath)
+
+setModuleName :: String -> GOOLState -> GOOLState
+setModuleName = set currModName
+
+getModuleName :: GS String
+getModuleName = gets (^. currModName)

--- a/code/drasil-gool/GOOL/Drasil/State.hs
+++ b/code/drasil-gool/GOOL/Drasil/State.hs
@@ -7,7 +7,6 @@ module GOOL.Drasil.State (
   addProgNameToPaths, setMain, setMainMod
 ) where
 
-import GOOL.Drasil.Symantics (Label)
 import GOOL.Drasil.Data (FileType(..))
 
 import Control.Lens (makeLenses,over,set)
@@ -86,7 +85,7 @@ addSource fp = over sources (\s -> if fp `elem` s then
 addCombinedHeaderSource :: FilePath -> GOOLState -> GOOLState
 addCombinedHeaderSource fp = addSource fp . addHeader fp 
 
-addProgNameToPaths :: Label -> GOOLState -> GOOLState
+addProgNameToPaths :: String -> GOOLState -> GOOLState
 addProgNameToPaths n = over mainMod (fmap f) . over sources (map f) . 
   over headers (map f)
   where f = ((n++"/")++)

--- a/code/drasil-gool/GOOL/Drasil/State.hs
+++ b/code/drasil-gool/GOOL/Drasil/State.hs
@@ -6,10 +6,10 @@ module GOOL.Drasil.State (
   passState, passState2Lists, checkGOOLState, addFile, addCombinedHeaderSource, 
   addHeader, addSource, addProgNameToPaths, setMain, setMainMod, setFilePath, 
   getFilePath, setModuleName, getModuleName, setCurrMain, getCurrMain, 
-  setParameters, getParameters
+  setParameters, getParameters, setScope, getScope
 ) where
 
-import GOOL.Drasil.Data (FileType(..), ParamData)
+import GOOL.Drasil.Data (FileType(..), ParamData, ScopeTag(..))
 
 import Control.Lens (makeLenses,over,set,(^.))
 import Control.Monad.State (State, get, put, gets)
@@ -23,7 +23,8 @@ data GOOLState = GS {
   _currFilePath :: FilePath,
   _currModName :: String,
   _currMain :: Bool,
-  _currParameters :: [ParamData]
+  _currParameters :: [ParamData],
+  _currScope :: ScopeTag
 } 
 makeLenses ''GOOLState
 
@@ -39,7 +40,8 @@ initialState = GS {
   _currFilePath = "",
   _currModName = "",
   _currMain = False,
-  _currParameters = []
+  _currParameters = [],
+  _currScope = Priv
 }
 
 putAfter :: (GOOLState -> GOOLState) -> GS a -> GS a
@@ -148,3 +150,9 @@ setParameters = set currParameters
 
 getParameters :: GS [ParamData]
 getParameters = gets (^. currParameters)
+
+setScope :: ScopeTag -> GOOLState -> GOOLState
+setScope = set currScope
+
+getScope :: GS ScopeTag
+getScope = gets (^. currScope)

--- a/code/drasil-gool/GOOL/Drasil/State.hs
+++ b/code/drasil-gool/GOOL/Drasil/State.hs
@@ -6,7 +6,8 @@ module GOOL.Drasil.State (
   passState, passState2Lists, checkGOOLState, addFile, addCombinedHeaderSource, 
   addHeader, addSource, addProgNameToPaths, setMain, setMainMod, setFilePath, 
   getFilePath, setModuleName, getModuleName, setCurrMain, getCurrMain, 
-  setParameters, getParameters, setScope, getScope
+  setParameters, getParameters, setScope, getScope, setCurrMainFunc, 
+  getCurrMainFunc
 ) where
 
 import GOOL.Drasil.Data (FileType(..), ParamData, ScopeTag(..), paramName)
@@ -24,7 +25,10 @@ data GOOLState = GS {
   _currModName :: String,
   _currMain :: Bool,
   _currParameters :: [ParamData],
-  _currScope :: ScopeTag
+  
+  -- Only used for C++
+  _currScope :: ScopeTag,
+  _currMainFunc :: Bool
 } 
 makeLenses ''GOOLState
 
@@ -41,7 +45,9 @@ initialState = GS {
   _currModName = "",
   _currMain = False,
   _currParameters = [],
-  _currScope = Priv
+
+  _currScope = Priv,
+  _currMainFunc = False
 }
 
 putAfter :: (GOOLState -> GOOLState) -> GS a -> GS a
@@ -156,3 +162,9 @@ setScope = set currScope
 
 getScope :: GS ScopeTag
 getScope = gets (^. currScope)
+
+setCurrMainFunc :: Bool -> GOOLState -> GOOLState
+setCurrMainFunc = set currMainFunc
+
+getCurrMainFunc :: GS Bool
+getCurrMainFunc = gets (^. currMainFunc)

--- a/code/drasil-gool/GOOL/Drasil/State.hs
+++ b/code/drasil-gool/GOOL/Drasil/State.hs
@@ -5,10 +5,11 @@ module GOOL.Drasil.State (
   getPut, getPutReturn, getPutReturnFunc, getPutReturnFunc2, getPutReturnList, 
   passState, passState2Lists, checkGOOLState, addFile, addCombinedHeaderSource, 
   addHeader, addSource, addProgNameToPaths, setMain, setMainMod, setFilePath, 
-  getFilePath, setModuleName, getModuleName, setCurrMain, getCurrMain
+  getFilePath, setModuleName, getModuleName, setCurrMain, getCurrMain, 
+  setParameters, getParameters
 ) where
 
-import GOOL.Drasil.Data (FileType(..))
+import GOOL.Drasil.Data (FileType(..), ParamData)
 
 import Control.Lens (makeLenses,over,set,(^.))
 import Control.Monad.State (State, get, put, gets)
@@ -21,7 +22,8 @@ data GOOLState = GS {
 
   _currFilePath :: FilePath,
   _currModName :: String,
-  _currMain :: Bool
+  _currMain :: Bool,
+  _currParameters :: [ParamData]
 } 
 makeLenses ''GOOLState
 
@@ -36,7 +38,8 @@ initialState = GS {
 
   _currFilePath = "",
   _currModName = "",
-  _currMain = False
+  _currMain = False,
+  _currParameters = []
 }
 
 getPut :: (GOOLState -> GOOLState) -> GS a -> GS a
@@ -140,3 +143,9 @@ setCurrMain = set currMain
 
 getCurrMain :: GS Bool
 getCurrMain = gets (^. currMain)
+
+setParameters :: [ParamData] -> GOOLState -> GOOLState
+setParameters = set currParameters
+
+getParameters :: GS [ParamData]
+getParameters = gets (^. currParameters)

--- a/code/drasil-gool/GOOL/Drasil/State.hs
+++ b/code/drasil-gool/GOOL/Drasil/State.hs
@@ -3,14 +3,13 @@
 module GOOL.Drasil.State (
   GS, GOOLState(..), headers, sources, hasMain, mainMod, initialState, 
   putAfter, getPutReturn, getPutReturnFunc, getPutReturnFunc2, getPutReturnList,
-  passState, passState2Lists, checkGOOLState, addFile, addCombinedHeaderSource, 
-  addHeader, addSource, addProgNameToPaths, setMain, setMainMod, setFilePath, 
-  getFilePath, setModuleName, getModuleName, setCurrMain, getCurrMain, 
-  setParameters, getParameters, setScope, getScope, setCurrMainFunc, 
-  getCurrMainFunc
+  addFile, addCombinedHeaderSource, addHeader, addSource, addProgNameToPaths, 
+  setMain, setMainMod, setFilePath, getFilePath, setModuleName, getModuleName, 
+  setCurrMain, getCurrMain, setParameters, getParameters, setScope, getScope, 
+  setCurrMainFunc, getCurrMainFunc
 ) where
 
-import GOOL.Drasil.Data (FileType(..), ParamData, ScopeTag(..), paramName)
+import GOOL.Drasil.Data (FileType(..), ParamData, ScopeTag(..))
 
 import Control.Lens (makeLenses,over,set,(^.))
 import Control.Monad.State (State, get, put, gets)
@@ -86,25 +85,6 @@ getPutReturnList l sf vf = do
   put $ sf s
   return $ vf v
 
-passState :: GS a -> GS b -> GS b
-passState s v = do
-  _ <- s
-  v
-
-passState2Lists :: [GS a] -> [GS b] -> 
-  GS c -> GS c
-passState2Lists l1 l2 v = do
-  sequence_ l1
-  sequence_ l2
-  v 
-
-checkGOOLState :: (GOOLState -> Bool) -> GS b -> (b -> GS a) 
-  -> (b -> GS a) -> GS a
-checkGOOLState f st ifv elsev = do
-  v <- st
-  s <- get
-  if f s then ifv v else elsev v
-
 addFile :: FileType -> FilePath -> GOOLState -> GOOLState
 addFile Combined = addCombinedHeaderSource
 addFile Source = addSource
@@ -127,8 +107,8 @@ addProgNameToPaths n = over mainMod (fmap f) . over sources (map f) .
   where f = ((n++"/")++)
 
 setMain :: GOOLState -> GOOLState
-setMain s = over hasMain (\b -> if b then error $ "Multiple main functions defined" ++ show (s ^. headers) ++ show (s ^. sources) ++ show (s ^. hasMain) ++ show (s ^. mainMod) ++ s ^. currFilePath ++ s ^. currModName ++ show (s ^. currMain) ++ show (map paramName $ s ^. currParameters)
-  else not b) s
+setMain = over hasMain (\b -> if b then error "Multiple main functions defined"
+  else not b)
 
 setMainMod :: String -> GOOLState -> GOOLState
 setMainMod n = set mainMod (Just n)

--- a/code/drasil-gool/GOOL/Drasil/State.hs
+++ b/code/drasil-gool/GOOL/Drasil/State.hs
@@ -5,7 +5,7 @@ module GOOL.Drasil.State (
   getPut, getPutReturn, getPutReturnFunc, getPutReturnFunc2, getPutReturnList, 
   passState, passState2Lists, checkGOOLState, addFile, addCombinedHeaderSource, 
   addHeader, addSource, addProgNameToPaths, setMain, setMainMod, setFilePath, 
-  getFilePath, setModuleName, getModuleName
+  getFilePath, setModuleName, getModuleName, setCurrMain, getCurrMain
 ) where
 
 import GOOL.Drasil.Data (FileType(..))
@@ -20,7 +20,8 @@ data GOOLState = GS {
   _mainMod :: Maybe FilePath,
 
   _currFilePath :: FilePath,
-  _currModName :: String
+  _currModName :: String,
+  _currMain :: Bool
 } 
 makeLenses ''GOOLState
 
@@ -34,7 +35,8 @@ initialState = GS {
   _mainMod = Nothing,
 
   _currFilePath = "",
-  _currModName = ""
+  _currModName = "",
+  _currMain = False
 }
 
 getPut :: (GOOLState -> GOOLState) -> GS a -> GS a
@@ -132,3 +134,9 @@ setModuleName = set currModName
 
 getModuleName :: GS String
 getModuleName = gets (^. currModName)
+
+setCurrMain :: Bool -> GOOLState -> GOOLState
+setCurrMain = set currMain
+
+getCurrMain :: GS Bool
+getCurrMain = gets (^. currMain)

--- a/code/drasil-gool/GOOL/Drasil/State.hs
+++ b/code/drasil-gool/GOOL/Drasil/State.hs
@@ -2,7 +2,7 @@
 
 module GOOL.Drasil.State (
   GS, GOOLState(..), headers, sources, hasMain, mainMod, initialState, 
-  getPut, getPutReturn, getPutReturnFunc, getPutReturnFunc2, getPutReturnList, 
+  putAfter, getPutReturn, getPutReturnFunc, getPutReturnFunc2, getPutReturnList,
   passState, passState2Lists, checkGOOLState, addFile, addCombinedHeaderSource, 
   addHeader, addSource, addProgNameToPaths, setMain, setMainMod, setFilePath, 
   getFilePath, setModuleName, getModuleName, setCurrMain, getCurrMain, 
@@ -42,11 +42,10 @@ initialState = GS {
   _currParameters = []
 }
 
-getPut :: (GOOLState -> GOOLState) -> GS a -> GS a
-getPut sf v = do
-  s <- get
-  put $ sf s
-  v
+putAfter :: (GOOLState -> GOOLState) -> GS a -> GS a
+putAfter sf sv = do
+  v <- sv
+  getPutReturn sf v
 
 getPutReturn :: (GOOLState -> GOOLState) -> a -> GS a
 getPutReturn sf v = do

--- a/code/drasil-gool/GOOL/Drasil/State.hs
+++ b/code/drasil-gool/GOOL/Drasil/State.hs
@@ -4,19 +4,21 @@ module GOOL.Drasil.State (
   GOOLState(..), headers, sources, hasMain, mainMod, initialState, getPutReturn,
   getPutReturnFunc, getPutReturnList, passState, passState2Lists, 
   checkGOOLState, addFile, addCombinedHeaderSource, addHeader, addSource, 
-  addProgNameToPaths, setMain, setMainMod
+  addProgNameToPaths, setMain, setMainMod, setFilePath, getFilePath
 ) where
 
 import GOOL.Drasil.Data (FileType(..))
 
-import Control.Lens (makeLenses,over,set)
-import Control.Monad.State (State, get, put)
+import Control.Lens (makeLenses,over,set,(^.))
+import Control.Monad.State (State, get, put, gets)
 
 data GOOLState = GS {
   _headers :: [FilePath],
   _sources :: [FilePath],
   _hasMain :: Bool,
-  _mainMod :: Maybe FilePath
+  _mainMod :: Maybe FilePath,
+
+  _currFilePath :: FilePath
 } 
 makeLenses ''GOOLState
 
@@ -25,7 +27,9 @@ initialState = GS {
   _headers = [],
   _sources = [],
   _hasMain = False,
-  _mainMod = Nothing
+  _mainMod = Nothing,
+
+  _currFilePath = ""
 }
 
 getPutReturn :: (GOOLState -> GOOLState) -> a -> State GOOLState a
@@ -91,8 +95,14 @@ addProgNameToPaths n = over mainMod (fmap f) . over sources (map f) .
   where f = ((n++"/")++)
 
 setMain :: GOOLState -> GOOLState
-setMain = over hasMain (\b -> if b then error "Multiple main functions defined" 
+setMain = over hasMain (\b -> if b then error "Multiple main functions defined"
   else not b)
 
 setMainMod :: String -> GOOLState -> GOOLState
 setMainMod n = set mainMod (Just n)
+
+setFilePath :: FilePath -> GOOLState -> GOOLState
+setFilePath = set currFilePath
+
+getFilePath :: State GOOLState FilePath
+getFilePath = gets (^. currFilePath)

--- a/code/drasil-gool/GOOL/Drasil/Symantics.hs
+++ b/code/drasil-gool/GOOL/Drasil/Symantics.hs
@@ -33,21 +33,25 @@ class (RenderSym repr) => ProgramSym repr where
 class (ModuleSym repr, InternalFile repr) => 
   RenderSym repr where 
   type RenderFile repr
-  fileDoc :: repr (Module repr) -> repr (RenderFile repr)
+  fileDoc :: State GOOLState (repr (Module repr)) -> 
+    State GOOLState (repr (RenderFile repr))
 
   -- Module description, list of author names, date as a String, file to comment
-  docMod :: String -> [String] -> String -> repr (RenderFile repr) -> 
-    repr (RenderFile repr)
+  docMod :: String -> [String] -> String -> 
+    State GOOLState (repr (RenderFile repr)) -> 
+    State GOOLState (repr (RenderFile repr))
 
-  commentedMod :: repr (RenderFile repr) -> 
-    State GOOLState (repr (BlockComment repr)) -> repr (RenderFile repr)
+  commentedMod :: State GOOLState (repr (RenderFile repr)) -> 
+    State GOOLState (repr (BlockComment repr)) -> 
+    State GOOLState (repr (RenderFile repr))
 
 class InternalFile repr where
   top :: repr (Module repr) -> repr (Block repr)
   bottom :: repr (Block repr)
 
-  fileFromData :: FileType -> FilePath -> repr (Module repr) -> 
-    repr (RenderFile repr)
+  fileFromData :: FileType -> State GOOLState FilePath -> 
+    State GOOLState (repr (Module repr)) -> 
+    State GOOLState (repr (RenderFile repr))
 
 class (PermanenceSym repr) => KeywordSym repr where
   type Keyword repr

--- a/code/drasil-gool/GOOL/Drasil/Symantics.hs
+++ b/code/drasil-gool/GOOL/Drasil/Symantics.hs
@@ -651,21 +651,27 @@ class (MethodSym repr, InternalClass repr) => ClassSym repr
   where
   type Class repr
   buildClass :: Label -> Maybe Label -> repr (Scope repr) -> 
-    [repr (StateVar repr)] -> [repr (Method repr)] -> repr (Class repr)
-  enum :: Label -> [Label] -> repr (Scope repr) -> repr (Class repr)
-  privClass :: Label -> Maybe Label -> [repr (StateVar repr)] -> 
-    [repr (Method repr)] -> repr (Class repr)
-  pubClass :: Label -> Maybe Label -> [repr (StateVar repr)] -> 
-    [repr (Method repr)] -> repr (Class repr)
+    [State GOOLState (repr (StateVar repr))] -> 
+    [State GOOLState (repr (Method repr))] -> 
+    State GOOLState (repr (Class repr))
+  enum :: Label -> [Label] -> repr (Scope repr) -> 
+    State GOOLState (repr (Class repr))
+  privClass :: Label -> Maybe Label -> [State GOOLState (repr (StateVar repr))] 
+    -> [State GOOLState (repr (Method repr))] -> 
+    State GOOLState (repr (Class repr))
+  pubClass :: Label -> Maybe Label -> [State GOOLState (repr (StateVar repr))] 
+    -> [State GOOLState (repr (Method repr))] -> 
+    State GOOLState (repr (Class repr))
 
-  docClass :: String -> repr (Class repr) -> repr (Class repr)
+  docClass :: String -> State GOOLState (repr (Class repr)) ->
+    State GOOLState (repr (Class repr))
 
   commentedClass :: State GOOLState (repr (BlockComment repr)) -> 
-    repr (Class repr) -> repr (Class repr)
+    State GOOLState (repr (Class repr)) -> State GOOLState (repr (Class repr))
 
 class InternalClass repr where
   classDoc :: repr (Class repr) -> Doc
-  classFromData :: State GOOLState Doc -> repr (Class repr)
+  classFromData :: State GOOLState Doc -> State GOOLState (repr (Class repr))
 
 class (ClassSym repr, InternalMod repr) => ModuleSym repr where
   type Module repr
@@ -677,7 +683,7 @@ class (ClassSym repr, InternalMod repr) => ModuleSym repr where
 class InternalMod repr where
   isMainModule :: repr (Module repr) -> Bool
   moduleDoc :: repr (Module repr) -> Doc
-  modFromData :: String -> Bool -> Doc -> repr (Module repr)
+  modFromData :: String -> Bool -> State GOOLState Doc -> repr (Module repr)
   updateModuleDoc :: (Doc -> Doc) -> repr (Module repr) -> repr (Module repr)
     
 class BlockCommentSym repr where

--- a/code/drasil-gool/GOOL/Drasil/Symantics.hs
+++ b/code/drasil-gool/GOOL/Drasil/Symantics.hs
@@ -565,61 +565,66 @@ class (StateVarSym repr, ParameterSym repr, ControlBlockSym repr,
   InternalMethod repr) => MethodSym repr where
   type Method repr
   -- Second label is class name
-  method      :: Label -> Label -> repr (Scope repr) -> 
-    repr (Permanence repr) -> repr (Type repr) -> 
-    [repr (Parameter repr)] -> repr (Body repr) -> repr (Method repr)
-  getMethod   :: Label -> repr (Variable repr) -> repr (Method repr)
-  setMethod   :: Label -> repr (Variable repr) -> repr (Method repr) 
-  privMethod  :: Label -> Label -> repr (Type repr) -> 
-    [repr (Parameter repr)] -> repr (Body repr) -> repr (Method repr)
-  pubMethod   :: Label -> Label -> repr (Type repr) -> 
-    [repr (Parameter repr)] -> repr (Body repr) -> repr (Method repr)
+  method      :: Label -> Label -> repr (Scope repr) -> repr (Permanence repr) 
+    -> repr (Type repr) -> [repr (Parameter repr)] -> repr (Body repr) -> 
+    State GOOLState (repr (Method repr))
+  getMethod   :: Label -> repr (Variable repr) -> 
+    State GOOLState (repr (Method repr))
+  setMethod   :: Label -> repr (Variable repr) -> 
+    State GOOLState (repr (Method repr)) 
+  privMethod  :: Label -> Label -> repr (Type repr) -> [repr (Parameter repr)] 
+    -> repr (Body repr) -> State GOOLState (repr (Method repr))
+  pubMethod   :: Label -> Label -> repr (Type repr) -> [repr (Parameter repr)] 
+    -> repr (Body repr) -> State GOOLState (repr (Method repr))
   constructor :: Label -> [repr (Parameter repr)] -> repr (Body repr) -> 
-    repr (Method repr)
-  destructor :: Label -> [repr (StateVar repr)] -> repr (Method repr)
+    State GOOLState (repr (Method repr))
+  destructor :: Label -> [repr (StateVar repr)] -> 
+    State GOOLState (repr (Method repr))
 
-  docMain :: repr (Body repr) -> repr (Method repr)
+  docMain :: repr (Body repr) -> State GOOLState (repr (Method repr))
 
   function :: Label -> repr (Scope repr) -> repr (Permanence repr) -> 
     repr (Type repr) -> [repr (Parameter repr)] -> repr (Body repr) -> 
-    repr (Method repr) 
-  mainFunction  :: repr (Body repr) -> repr (Method repr)
+    State GOOLState (repr (Method repr))
+  mainFunction  :: repr (Body repr) -> State GOOLState (repr (Method repr))
   -- Parameters are: function description, parameter descriptions, 
   --   return value description if applicable, function
-  docFunc :: String -> [String] -> Maybe String -> repr (Method repr) -> repr (Method repr) 
+  docFunc :: String -> [String] -> Maybe String -> 
+    State GOOLState (repr (Method repr)) -> State GOOLState (repr (Method repr))
 
   -- Second label is class name, rest is same as inOutFunc
   inOutMethod :: Label -> Label -> repr (Scope repr) -> repr (Permanence repr) 
     -> [repr (Variable repr)] -> [repr (Variable repr)] -> 
-    [repr (Variable repr)] -> repr (Body repr) -> repr (Method repr)
+    [repr (Variable repr)] -> repr (Body repr) -> 
+    State GOOLState (repr (Method repr))
   -- Second label is class name, rest is same as docInOutFunc
   docInOutMethod :: Label -> Label -> repr (Scope repr) -> 
     repr (Permanence repr) -> String -> [(String, repr (Variable repr))] -> 
     [(String, repr (Variable repr))] -> [(String, repr (Variable repr))] -> 
-    repr (Body repr) -> repr (Method repr)
+    repr (Body repr) -> State GOOLState (repr (Method repr))
 
   -- The three lists are inputs, outputs, and both, respectively
   inOutFunc :: Label -> repr (Scope repr) -> repr (Permanence repr) -> 
     [repr (Variable repr)] -> [repr (Variable repr)] -> [repr (Variable repr)] 
-    -> repr (Body repr) -> repr (Method repr)
+    -> repr (Body repr) -> State GOOLState (repr (Method repr))
   -- Parameters are: function name, scope, permanence, brief description, input descriptions and variables, output descriptions and variables, descriptions and variables for parameters that are both input and output, function body
   docInOutFunc :: Label -> repr (Scope repr) -> repr (Permanence repr) -> 
     String -> [(String, repr (Variable repr))] -> [(String, repr 
     (Variable repr))] -> [(String, repr (Variable repr))] -> repr (Body repr)
-    -> repr (Method repr)
+    -> State GOOLState (repr (Method repr))
 
   parameters :: repr (Method repr) -> [repr (Parameter repr)]
 
 class (MethodTypeSym repr, BlockCommentSym repr) => 
   InternalMethod repr where
   intMethod      :: Bool -> Label -> Label -> repr (Scope repr) -> 
-    repr (Permanence repr) -> repr (MethodType repr) -> 
-    [repr (Parameter repr)] -> repr (Body repr) -> repr (Method repr)
+    repr (Permanence repr) -> repr (MethodType repr) -> [repr (Parameter repr)] 
+    -> repr (Body repr) -> State GOOLState (repr (Method repr))
   intFunc      :: Bool -> Label -> repr (Scope repr) -> repr (Permanence repr) 
     -> repr (MethodType repr) -> [repr (Parameter repr)] -> repr (Body repr) -> 
-    repr (Method repr)
+    State GOOLState (repr (Method repr))
   commentedFunc :: State GOOLState (repr (BlockComment repr)) -> 
-    repr (Method repr) -> repr (Method repr)
+    State GOOLState (repr (Method repr)) -> State GOOLState (repr (Method repr))
 
   isMainMethod :: repr (Method repr) -> Bool
   methodDoc :: repr (Method repr) -> Doc

--- a/code/drasil-gool/GOOL/Drasil/Symantics.hs
+++ b/code/drasil-gool/GOOL/Drasil/Symantics.hs
@@ -673,6 +673,7 @@ class InternalMod repr where
   isMainModule :: repr (Module repr) -> Bool
   moduleDoc :: repr (Module repr) -> Doc
   modFromData :: String -> Bool -> Doc -> repr (Module repr)
+  updateModuleDoc :: (Doc -> Doc) -> repr (Module repr) -> repr (Module repr)
     
 class BlockCommentSym repr where
   type BlockComment repr

--- a/code/drasil-gool/GOOL/Drasil/Symantics.hs
+++ b/code/drasil-gool/GOOL/Drasil/Symantics.hs
@@ -583,7 +583,7 @@ class (StateVarSym repr, ParameterSym repr, ControlBlockSym repr,
     -> repr (Body repr) -> State GOOLState (repr (Method repr))
   constructor :: Label -> [repr (Parameter repr)] -> repr (Body repr) -> 
     State GOOLState (repr (Method repr))
-  destructor :: Label -> [repr (StateVar repr)] -> 
+  destructor :: Label -> [State GOOLState (repr (StateVar repr))] -> 
     State GOOLState (repr (Method repr))
 
   docMain :: repr (Body repr) -> State GOOLState (repr (Method repr))

--- a/code/drasil-gool/GOOL/Drasil/Symantics.hs
+++ b/code/drasil-gool/GOOL/Drasil/Symantics.hs
@@ -19,6 +19,8 @@ module GOOL.Drasil.Symantics (
 
 import GOOL.Drasil.CodeType (CodeType)
 import GOOL.Drasil.Data (Binding, Terminator, FileType)
+import GOOL.Drasil.State (GOOLState)
+import Control.Monad.State (State)
 import Text.PrettyPrint.HughesPJ (Doc)
 
 type Label = String
@@ -658,7 +660,7 @@ class (MethodSym repr, InternalClass repr) => ClassSym repr
 
 class InternalClass repr where
   classDoc :: repr (Class repr) -> Doc
-  classFromData :: Doc -> repr (Class repr)
+  classFromData :: State GOOLState Doc -> repr (Class repr)
 
 class (ClassSym repr, InternalMod repr) => ModuleSym repr where
   type Module repr
@@ -675,6 +677,6 @@ class InternalMod repr where
 class BlockCommentSym repr where
   type BlockComment repr
   blockComment :: [String] -> repr (BlockComment repr)
-  docComment :: [String] -> repr (BlockComment repr)
+  docComment :: State GOOLState [String] -> repr (BlockComment repr)
 
-  blockCommentDoc :: repr (BlockComment repr) -> Doc
+  blockCommentDoc :: repr (BlockComment repr) -> State GOOLState Doc

--- a/code/drasil-gool/GOOL/Drasil/Symantics.hs
+++ b/code/drasil-gool/GOOL/Drasil/Symantics.hs
@@ -562,7 +562,6 @@ class ParameterSym repr where
   -- funcParam  :: Label -> repr (MethodType repr) -> [repr (Parameter repr)] -> repr (Parameter repr) -- not implemented in GOOL
   pointerParam :: repr (Variable repr) -> repr (Parameter repr)
 
-  parameterName :: repr (Parameter repr) -> String
   parameterType :: repr (Parameter repr) -> repr (Type repr)
 
 class (StateVarSym repr, ParameterSym repr, ControlBlockSym repr, 
@@ -617,8 +616,6 @@ class (StateVarSym repr, ParameterSym repr, ControlBlockSym repr,
     (Variable repr))] -> [(String, repr (Variable repr))] -> repr (Body repr)
     -> GS (repr (Method repr))
 
-  parameters :: repr (Method repr) -> [repr (Parameter repr)]
-
 class (MethodTypeSym repr, BlockCommentSym repr) => 
   InternalMethod repr where
   intMethod      :: Bool -> Label -> Label -> repr (Scope repr) -> 
@@ -629,7 +626,7 @@ class (MethodTypeSym repr, BlockCommentSym repr) =>
     GS (repr (Method repr))
   commentedFunc :: GS (repr (BlockComment repr)) -> 
     GS (repr (Method repr)) -> GS (repr (Method repr))
-    
+
   methodDoc :: repr (Method repr) -> Doc
 
 class (ScopeSym repr, PermanenceSym repr, TypeSym repr, StatementSym repr,

--- a/code/drasil-gool/GOOL/Drasil/Symantics.hs
+++ b/code/drasil-gool/GOOL/Drasil/Symantics.hs
@@ -20,6 +20,8 @@ module GOOL.Drasil.Symantics (
 import GOOL.Drasil.CodeType (CodeType)
 import GOOL.Drasil.Data (Binding, Terminator, FileType, ScopeTag)
 import GOOL.Drasil.State (GS, MS)
+
+import Control.Monad.State (State)
 import Text.PrettyPrint.HughesPJ (Doc)
 
 type Label = String
@@ -623,7 +625,7 @@ class (MethodTypeSym repr, BlockCommentSym repr) =>
   intFunc      :: Bool -> Label -> repr (Scope repr) -> repr (Permanence repr) 
     -> repr (MethodType repr) -> [repr (Parameter repr)] -> repr (Body repr) -> 
     MS (repr (Method repr))
-  commentedFunc :: GS (repr (BlockComment repr)) -> MS (repr (Method repr)) -> 
+  commentedFunc :: MS (repr (BlockComment repr)) -> MS (repr (Method repr)) -> 
     MS (repr (Method repr))
 
   methodDoc :: repr (Method repr) -> Doc
@@ -687,6 +689,6 @@ class InternalMod repr where
 class BlockCommentSym repr where
   type BlockComment repr
   blockComment :: [String] -> repr (BlockComment repr)
-  docComment :: GS [String] -> GS (repr (BlockComment repr))
+  docComment :: State a [String] -> State a (repr (BlockComment repr))
 
   blockCommentDoc :: repr (BlockComment repr) -> Doc

--- a/code/drasil-gool/GOOL/Drasil/Symantics.hs
+++ b/code/drasil-gool/GOOL/Drasil/Symantics.hs
@@ -633,18 +633,19 @@ class (ScopeSym repr, PermanenceSym repr, TypeSym repr, StatementSym repr,
   InternalStateVar repr) => StateVarSym repr where
   type StateVar repr
   stateVar :: repr (Scope repr) -> repr (Permanence repr) ->
-    repr (Variable repr) -> repr (StateVar repr)
+    repr (Variable repr) -> State GOOLState (repr (StateVar repr))
   stateVarDef :: Label -> repr (Scope repr) -> repr (Permanence repr) ->
-    repr (Variable repr) -> repr (Value repr) -> repr (StateVar repr)
+    repr (Variable repr) -> repr (Value repr) -> 
+    State GOOLState (repr (StateVar repr))
   constVar :: Label -> repr (Scope repr) ->  repr (Variable repr) -> 
-    repr (Value repr) -> repr (StateVar repr)
-  privMVar :: repr (Variable repr) -> repr (StateVar repr)
-  pubMVar  :: repr (Variable repr) -> repr (StateVar repr)
-  pubGVar  :: repr (Variable repr) -> repr (StateVar repr)
+    repr (Value repr) -> State GOOLState (repr (StateVar repr))
+  privMVar :: repr (Variable repr) -> State GOOLState (repr (StateVar repr))
+  pubMVar  :: repr (Variable repr) -> State GOOLState (repr (StateVar repr))
+  pubGVar  :: repr (Variable repr) -> State GOOLState (repr (StateVar repr))
 
 class InternalStateVar repr where
   stateVarDoc :: repr (StateVar repr) -> Doc
-  stateVarFromData :: Doc -> repr (StateVar repr)
+  stateVarFromData :: Doc -> State GOOLState (repr (StateVar repr))
 
 class (MethodSym repr, InternalClass repr) => ClassSym repr 
   where

--- a/code/drasil-gool/GOOL/Drasil/Symantics.hs
+++ b/code/drasil-gool/GOOL/Drasil/Symantics.hs
@@ -629,8 +629,7 @@ class (MethodTypeSym repr, BlockCommentSym repr) =>
     GS (repr (Method repr))
   commentedFunc :: GS (repr (BlockComment repr)) -> 
     GS (repr (Method repr)) -> GS (repr (Method repr))
-
-  isMainMethod :: repr (Method repr) -> Bool
+    
   methodDoc :: repr (Method repr) -> Doc
 
 class (ScopeSym repr, PermanenceSym repr, TypeSym repr, StatementSym repr,
@@ -679,14 +678,12 @@ class InternalClass repr where
 
 class (ClassSym repr, InternalMod repr) => ModuleSym repr where
   type Module repr
-  buildModule :: Label -> [Library] -> [GS (repr (Method repr))] 
-    -> [GS (repr (Class repr))] -> 
-    GS (repr (Module repr))
+  buildModule :: Label -> [Library] -> [GS (repr (Method repr))] -> 
+    [GS (repr (Class repr))] -> GS (repr (Module repr))
 
 class InternalMod repr where
   moduleDoc :: repr (Module repr) -> Doc
-  modFromData :: String -> GS Bool -> GS Doc -> 
-    GS (repr (Module repr))
+  modFromData :: String -> GS Bool -> GS Doc -> GS (repr (Module repr))
   updateModuleDoc :: (Doc -> Doc) -> GS (repr (Module repr)) -> 
     GS (repr (Module repr))
     

--- a/code/drasil-gool/GOOL/Drasil/Symantics.hs
+++ b/code/drasil-gool/GOOL/Drasil/Symantics.hs
@@ -675,16 +675,19 @@ class InternalClass repr where
 
 class (ClassSym repr, InternalMod repr) => ModuleSym repr where
   type Module repr
-  buildModule :: Label -> [Library] -> [repr (Method repr)] -> 
-    [repr (Class repr)] -> repr (Module repr)
+  buildModule :: Label -> [Library] -> [State GOOLState (repr (Method repr))] 
+    -> [State GOOLState (repr (Class repr))] -> 
+    State GOOLState (repr (Module repr))
     
   moduleName :: repr (Module repr) -> String
 
 class InternalMod repr where
   isMainModule :: repr (Module repr) -> Bool
   moduleDoc :: repr (Module repr) -> Doc
-  modFromData :: String -> Bool -> State GOOLState Doc -> repr (Module repr)
-  updateModuleDoc :: (Doc -> Doc) -> repr (Module repr) -> repr (Module repr)
+  modFromData :: String -> State GOOLState Bool -> State GOOLState Doc -> 
+    State GOOLState (repr (Module repr))
+  updateModuleDoc :: (Doc -> Doc) -> State GOOLState (repr (Module repr)) -> 
+    State GOOLState (repr (Module repr))
     
 class BlockCommentSym repr where
   type BlockComment repr

--- a/code/drasil-gool/GOOL/Drasil/Symantics.hs
+++ b/code/drasil-gool/GOOL/Drasil/Symantics.hs
@@ -682,11 +682,8 @@ class (ClassSym repr, InternalMod repr) => ModuleSym repr where
   buildModule :: Label -> [Library] -> [GS (repr (Method repr))] 
     -> [GS (repr (Class repr))] -> 
     GS (repr (Module repr))
-    
-  moduleName :: repr (Module repr) -> String
 
 class InternalMod repr where
-  isMainModule :: repr (Module repr) -> Bool
   moduleDoc :: repr (Module repr) -> Doc
   modFromData :: String -> GS Bool -> GS Doc -> 
     GS (repr (Module repr))

--- a/code/drasil-gool/GOOL/Drasil/Symantics.hs
+++ b/code/drasil-gool/GOOL/Drasil/Symantics.hs
@@ -28,7 +28,8 @@ type Library = String
 
 class (RenderSym repr) => ProgramSym repr where
   type Program repr
-  prog :: Label -> [repr (RenderFile repr)] -> repr (Program repr)
+  prog :: Label -> [State GOOLState (repr (RenderFile repr))] -> 
+    State GOOLState (repr (Program repr))
 
 class (ModuleSym repr, InternalFile repr) => 
   RenderSym repr where 

--- a/code/drasil-gool/GOOL/Drasil/Symantics.hs
+++ b/code/drasil-gool/GOOL/Drasil/Symantics.hs
@@ -18,7 +18,7 @@ module GOOL.Drasil.Symantics (
 ) where
 
 import GOOL.Drasil.CodeType (CodeType)
-import GOOL.Drasil.Data (Binding, Terminator, FileType)
+import GOOL.Drasil.Data (Binding, Terminator, FileType, ScopeTag)
 import GOOL.Drasil.State (GS)
 import Text.PrettyPrint.HughesPJ (Doc)
 
@@ -624,10 +624,11 @@ class (MethodTypeSym repr, BlockCommentSym repr) =>
   intFunc      :: Bool -> Label -> repr (Scope repr) -> repr (Permanence repr) 
     -> repr (MethodType repr) -> [repr (Parameter repr)] -> repr (Body repr) -> 
     GS (repr (Method repr))
-  commentedFunc :: GS (repr (BlockComment repr)) -> 
-    GS (repr (Method repr)) -> GS (repr (Method repr))
+  commentedFunc :: GS (repr (BlockComment repr)) -> GS (repr (Method repr)) -> 
+    GS (repr (Method repr))
 
   methodDoc :: repr (Method repr) -> Doc
+  methodFromData :: ScopeTag -> Doc -> repr (Method repr)
 
 class (ScopeSym repr, PermanenceSym repr, TypeSym repr, StatementSym repr,
   InternalStateVar repr) => StateVarSym repr where

--- a/code/drasil-gool/GOOL/Drasil/Symantics.hs
+++ b/code/drasil-gool/GOOL/Drasil/Symantics.hs
@@ -19,7 +19,7 @@ module GOOL.Drasil.Symantics (
 
 import GOOL.Drasil.CodeType (CodeType)
 import GOOL.Drasil.Data (Binding, Terminator, FileType, ScopeTag)
-import GOOL.Drasil.State (GS)
+import GOOL.Drasil.State (GS, MS)
 import Text.PrettyPrint.HughesPJ (Doc)
 
 type Label = String
@@ -569,62 +569,62 @@ class (StateVarSym repr, ParameterSym repr, ControlBlockSym repr,
   -- Second label is class name
   method      :: Label -> Label -> repr (Scope repr) -> repr (Permanence repr) 
     -> repr (Type repr) -> [repr (Parameter repr)] -> repr (Body repr) -> 
-    GS (repr (Method repr))
+    MS (repr (Method repr))
   getMethod   :: Label -> repr (Variable repr) -> 
-    GS (repr (Method repr))
+    MS (repr (Method repr))
   setMethod   :: Label -> repr (Variable repr) -> 
-    GS (repr (Method repr)) 
+    MS (repr (Method repr)) 
   privMethod  :: Label -> Label -> repr (Type repr) -> [repr (Parameter repr)] 
-    -> repr (Body repr) -> GS (repr (Method repr))
+    -> repr (Body repr) -> MS (repr (Method repr))
   pubMethod   :: Label -> Label -> repr (Type repr) -> [repr (Parameter repr)] 
-    -> repr (Body repr) -> GS (repr (Method repr))
+    -> repr (Body repr) -> MS (repr (Method repr))
   constructor :: Label -> [repr (Parameter repr)] -> repr (Body repr) -> 
-    GS (repr (Method repr))
+    MS (repr (Method repr))
   destructor :: Label -> [GS (repr (StateVar repr))] -> 
-    GS (repr (Method repr))
+    MS (repr (Method repr))
 
-  docMain :: repr (Body repr) -> GS (repr (Method repr))
+  docMain :: repr (Body repr) -> MS (repr (Method repr))
 
   function :: Label -> repr (Scope repr) -> repr (Permanence repr) -> 
     repr (Type repr) -> [repr (Parameter repr)] -> repr (Body repr) -> 
-    GS (repr (Method repr))
-  mainFunction  :: repr (Body repr) -> GS (repr (Method repr))
+    MS (repr (Method repr))
+  mainFunction  :: repr (Body repr) -> MS (repr (Method repr))
   -- Parameters are: function description, parameter descriptions, 
   --   return value description if applicable, function
   docFunc :: String -> [String] -> Maybe String -> 
-    GS (repr (Method repr)) -> GS (repr (Method repr))
+    MS (repr (Method repr)) -> MS (repr (Method repr))
 
   -- Second label is class name, rest is same as inOutFunc
   inOutMethod :: Label -> Label -> repr (Scope repr) -> repr (Permanence repr) 
     -> [repr (Variable repr)] -> [repr (Variable repr)] -> 
     [repr (Variable repr)] -> repr (Body repr) -> 
-    GS (repr (Method repr))
+    MS (repr (Method repr))
   -- Second label is class name, rest is same as docInOutFunc
   docInOutMethod :: Label -> Label -> repr (Scope repr) -> 
     repr (Permanence repr) -> String -> [(String, repr (Variable repr))] -> 
     [(String, repr (Variable repr))] -> [(String, repr (Variable repr))] -> 
-    repr (Body repr) -> GS (repr (Method repr))
+    repr (Body repr) -> MS (repr (Method repr))
 
   -- The three lists are inputs, outputs, and both, respectively
   inOutFunc :: Label -> repr (Scope repr) -> repr (Permanence repr) -> 
     [repr (Variable repr)] -> [repr (Variable repr)] -> [repr (Variable repr)] 
-    -> repr (Body repr) -> GS (repr (Method repr))
+    -> repr (Body repr) -> MS (repr (Method repr))
   -- Parameters are: function name, scope, permanence, brief description, input descriptions and variables, output descriptions and variables, descriptions and variables for parameters that are both input and output, function body
   docInOutFunc :: Label -> repr (Scope repr) -> repr (Permanence repr) -> 
     String -> [(String, repr (Variable repr))] -> [(String, repr 
     (Variable repr))] -> [(String, repr (Variable repr))] -> repr (Body repr)
-    -> GS (repr (Method repr))
+    -> MS (repr (Method repr))
 
 class (MethodTypeSym repr, BlockCommentSym repr) => 
   InternalMethod repr where
   intMethod      :: Bool -> Label -> Label -> repr (Scope repr) -> 
     repr (Permanence repr) -> repr (MethodType repr) -> [repr (Parameter repr)] 
-    -> repr (Body repr) -> GS (repr (Method repr))
+    -> repr (Body repr) -> MS (repr (Method repr))
   intFunc      :: Bool -> Label -> repr (Scope repr) -> repr (Permanence repr) 
     -> repr (MethodType repr) -> [repr (Parameter repr)] -> repr (Body repr) -> 
-    GS (repr (Method repr))
-  commentedFunc :: GS (repr (BlockComment repr)) -> GS (repr (Method repr)) -> 
-    GS (repr (Method repr))
+    MS (repr (Method repr))
+  commentedFunc :: GS (repr (BlockComment repr)) -> MS (repr (Method repr)) -> 
+    MS (repr (Method repr))
 
   methodDoc :: repr (Method repr) -> Doc
   methodFromData :: ScopeTag -> Doc -> repr (Method repr)
@@ -652,15 +652,15 @@ class (MethodSym repr, InternalClass repr) => ClassSym repr
   type Class repr
   buildClass :: Label -> Maybe Label -> repr (Scope repr) -> 
     [GS (repr (StateVar repr))] -> 
-    [GS (repr (Method repr))] -> 
+    [MS (repr (Method repr))] -> 
     GS (repr (Class repr))
   enum :: Label -> [Label] -> repr (Scope repr) -> 
     GS (repr (Class repr))
   privClass :: Label -> Maybe Label -> [GS (repr (StateVar repr))] 
-    -> [GS (repr (Method repr))] -> 
+    -> [MS (repr (Method repr))] -> 
     GS (repr (Class repr))
   pubClass :: Label -> Maybe Label -> [GS (repr (StateVar repr))] 
-    -> [GS (repr (Method repr))] -> 
+    -> [MS (repr (Method repr))] -> 
     GS (repr (Class repr))
 
   docClass :: String -> GS (repr (Class repr)) ->
@@ -675,7 +675,7 @@ class InternalClass repr where
 
 class (ClassSym repr, InternalMod repr) => ModuleSym repr where
   type Module repr
-  buildModule :: Label -> [Library] -> [GS (repr (Method repr))] -> 
+  buildModule :: Label -> [Library] -> [MS (repr (Method repr))] -> 
     [GS (repr (Class repr))] -> GS (repr (Module repr))
 
 class InternalMod repr where

--- a/code/drasil-gool/GOOL/Drasil/Symantics.hs
+++ b/code/drasil-gool/GOOL/Drasil/Symantics.hs
@@ -39,14 +39,13 @@ class (ModuleSym repr, InternalFile repr) =>
   docMod :: String -> [String] -> String -> repr (RenderFile repr) -> 
     repr (RenderFile repr)
 
-  commentedMod :: repr (BlockComment repr) -> repr (RenderFile repr) ->
+  commentedMod :: repr (RenderFile repr) -> repr (BlockComment repr) -> 
     repr (RenderFile repr)
 
 class InternalFile repr where
   top :: repr (Module repr) -> repr (Block repr)
   bottom :: repr (Block repr)
 
-  getFilePath :: repr (RenderFile repr) -> FilePath
   fileFromData :: FileType -> FilePath -> repr (Module repr) -> 
     repr (RenderFile repr)
 

--- a/code/drasil-gool/GOOL/Drasil/Symantics.hs
+++ b/code/drasil-gool/GOOL/Drasil/Symantics.hs
@@ -41,9 +41,8 @@ class (ModuleSym repr, InternalFile repr) =>
     GS (repr (RenderFile repr)) -> 
     GS (repr (RenderFile repr))
 
-  commentedMod :: GS (repr (RenderFile repr)) -> 
-    GS (repr (BlockComment repr)) -> 
-    GS (repr (RenderFile repr))
+  commentedMod :: GS (repr (BlockComment repr)) -> GS (repr (RenderFile repr)) 
+    -> GS (repr (RenderFile repr))
 
 class InternalFile repr where
   top :: repr (Module repr) -> repr (Block repr)

--- a/code/drasil-gool/GOOL/Drasil/Symantics.hs
+++ b/code/drasil-gool/GOOL/Drasil/Symantics.hs
@@ -39,8 +39,8 @@ class (ModuleSym repr, InternalFile repr) =>
   docMod :: String -> [String] -> String -> repr (RenderFile repr) -> 
     repr (RenderFile repr)
 
-  commentedMod :: repr (RenderFile repr) -> repr (BlockComment repr) -> 
-    repr (RenderFile repr)
+  commentedMod :: repr (RenderFile repr) -> 
+    State GOOLState (repr (BlockComment repr)) -> repr (RenderFile repr)
 
 class InternalFile repr where
   top :: repr (Module repr) -> repr (Block repr)
@@ -618,8 +618,8 @@ class (MethodTypeSym repr, BlockCommentSym repr) =>
   intFunc      :: Bool -> Label -> repr (Scope repr) -> repr (Permanence repr) 
     -> repr (MethodType repr) -> [repr (Parameter repr)] -> repr (Body repr) -> 
     repr (Method repr)
-  commentedFunc :: repr (BlockComment repr) -> repr (Method repr) -> 
-    repr (Method repr)
+  commentedFunc :: State GOOLState (repr (BlockComment repr)) -> 
+    repr (Method repr) -> repr (Method repr)
 
   isMainMethod :: repr (Method repr) -> Bool
   methodDoc :: repr (Method repr) -> Doc
@@ -654,8 +654,8 @@ class (MethodSym repr, InternalClass repr) => ClassSym repr
 
   docClass :: String -> repr (Class repr) -> repr (Class repr)
 
-  commentedClass :: repr (BlockComment repr) -> repr (Class repr) -> 
-    repr (Class repr)
+  commentedClass :: State GOOLState (repr (BlockComment repr)) -> 
+    repr (Class repr) -> repr (Class repr)
 
 class InternalClass repr where
   classDoc :: repr (Class repr) -> Doc
@@ -677,6 +677,6 @@ class InternalMod repr where
 class BlockCommentSym repr where
   type BlockComment repr
   blockComment :: [String] -> repr (BlockComment repr)
-  docComment :: State GOOLState [String] -> repr (BlockComment repr)
+  docComment :: State GOOLState [String] -> State GOOLState (repr (BlockComment repr))
 
-  blockCommentDoc :: repr (BlockComment repr) -> State GOOLState Doc
+  blockCommentDoc :: repr (BlockComment repr) -> Doc

--- a/code/drasil-gool/GOOL/Drasil/Symantics.hs
+++ b/code/drasil-gool/GOOL/Drasil/Symantics.hs
@@ -19,8 +19,7 @@ module GOOL.Drasil.Symantics (
 
 import GOOL.Drasil.CodeType (CodeType)
 import GOOL.Drasil.Data (Binding, Terminator, FileType)
-import GOOL.Drasil.State (GOOLState)
-import Control.Monad.State (State)
+import GOOL.Drasil.State (GS)
 import Text.PrettyPrint.HughesPJ (Doc)
 
 type Label = String
@@ -28,31 +27,31 @@ type Library = String
 
 class (RenderSym repr) => ProgramSym repr where
   type Program repr
-  prog :: Label -> [State GOOLState (repr (RenderFile repr))] -> 
-    State GOOLState (repr (Program repr))
+  prog :: Label -> [GS (repr (RenderFile repr))] -> 
+    GS (repr (Program repr))
 
 class (ModuleSym repr, InternalFile repr) => 
   RenderSym repr where 
   type RenderFile repr
-  fileDoc :: State GOOLState (repr (Module repr)) -> 
-    State GOOLState (repr (RenderFile repr))
+  fileDoc :: GS (repr (Module repr)) -> 
+    GS (repr (RenderFile repr))
 
   -- Module description, list of author names, date as a String, file to comment
   docMod :: String -> [String] -> String -> 
-    State GOOLState (repr (RenderFile repr)) -> 
-    State GOOLState (repr (RenderFile repr))
+    GS (repr (RenderFile repr)) -> 
+    GS (repr (RenderFile repr))
 
-  commentedMod :: State GOOLState (repr (RenderFile repr)) -> 
-    State GOOLState (repr (BlockComment repr)) -> 
-    State GOOLState (repr (RenderFile repr))
+  commentedMod :: GS (repr (RenderFile repr)) -> 
+    GS (repr (BlockComment repr)) -> 
+    GS (repr (RenderFile repr))
 
 class InternalFile repr where
   top :: repr (Module repr) -> repr (Block repr)
   bottom :: repr (Block repr)
 
-  fileFromData :: FileType -> State GOOLState FilePath -> 
-    State GOOLState (repr (Module repr)) -> 
-    State GOOLState (repr (RenderFile repr))
+  fileFromData :: FileType -> GS FilePath -> 
+    GS (repr (Module repr)) -> 
+    GS (repr (RenderFile repr))
 
 class (PermanenceSym repr) => KeywordSym repr where
   type Keyword repr
@@ -572,51 +571,51 @@ class (StateVarSym repr, ParameterSym repr, ControlBlockSym repr,
   -- Second label is class name
   method      :: Label -> Label -> repr (Scope repr) -> repr (Permanence repr) 
     -> repr (Type repr) -> [repr (Parameter repr)] -> repr (Body repr) -> 
-    State GOOLState (repr (Method repr))
+    GS (repr (Method repr))
   getMethod   :: Label -> repr (Variable repr) -> 
-    State GOOLState (repr (Method repr))
+    GS (repr (Method repr))
   setMethod   :: Label -> repr (Variable repr) -> 
-    State GOOLState (repr (Method repr)) 
+    GS (repr (Method repr)) 
   privMethod  :: Label -> Label -> repr (Type repr) -> [repr (Parameter repr)] 
-    -> repr (Body repr) -> State GOOLState (repr (Method repr))
+    -> repr (Body repr) -> GS (repr (Method repr))
   pubMethod   :: Label -> Label -> repr (Type repr) -> [repr (Parameter repr)] 
-    -> repr (Body repr) -> State GOOLState (repr (Method repr))
+    -> repr (Body repr) -> GS (repr (Method repr))
   constructor :: Label -> [repr (Parameter repr)] -> repr (Body repr) -> 
-    State GOOLState (repr (Method repr))
-  destructor :: Label -> [State GOOLState (repr (StateVar repr))] -> 
-    State GOOLState (repr (Method repr))
+    GS (repr (Method repr))
+  destructor :: Label -> [GS (repr (StateVar repr))] -> 
+    GS (repr (Method repr))
 
-  docMain :: repr (Body repr) -> State GOOLState (repr (Method repr))
+  docMain :: repr (Body repr) -> GS (repr (Method repr))
 
   function :: Label -> repr (Scope repr) -> repr (Permanence repr) -> 
     repr (Type repr) -> [repr (Parameter repr)] -> repr (Body repr) -> 
-    State GOOLState (repr (Method repr))
-  mainFunction  :: repr (Body repr) -> State GOOLState (repr (Method repr))
+    GS (repr (Method repr))
+  mainFunction  :: repr (Body repr) -> GS (repr (Method repr))
   -- Parameters are: function description, parameter descriptions, 
   --   return value description if applicable, function
   docFunc :: String -> [String] -> Maybe String -> 
-    State GOOLState (repr (Method repr)) -> State GOOLState (repr (Method repr))
+    GS (repr (Method repr)) -> GS (repr (Method repr))
 
   -- Second label is class name, rest is same as inOutFunc
   inOutMethod :: Label -> Label -> repr (Scope repr) -> repr (Permanence repr) 
     -> [repr (Variable repr)] -> [repr (Variable repr)] -> 
     [repr (Variable repr)] -> repr (Body repr) -> 
-    State GOOLState (repr (Method repr))
+    GS (repr (Method repr))
   -- Second label is class name, rest is same as docInOutFunc
   docInOutMethod :: Label -> Label -> repr (Scope repr) -> 
     repr (Permanence repr) -> String -> [(String, repr (Variable repr))] -> 
     [(String, repr (Variable repr))] -> [(String, repr (Variable repr))] -> 
-    repr (Body repr) -> State GOOLState (repr (Method repr))
+    repr (Body repr) -> GS (repr (Method repr))
 
   -- The three lists are inputs, outputs, and both, respectively
   inOutFunc :: Label -> repr (Scope repr) -> repr (Permanence repr) -> 
     [repr (Variable repr)] -> [repr (Variable repr)] -> [repr (Variable repr)] 
-    -> repr (Body repr) -> State GOOLState (repr (Method repr))
+    -> repr (Body repr) -> GS (repr (Method repr))
   -- Parameters are: function name, scope, permanence, brief description, input descriptions and variables, output descriptions and variables, descriptions and variables for parameters that are both input and output, function body
   docInOutFunc :: Label -> repr (Scope repr) -> repr (Permanence repr) -> 
     String -> [(String, repr (Variable repr))] -> [(String, repr 
     (Variable repr))] -> [(String, repr (Variable repr))] -> repr (Body repr)
-    -> State GOOLState (repr (Method repr))
+    -> GS (repr (Method repr))
 
   parameters :: repr (Method repr) -> [repr (Parameter repr)]
 
@@ -624,12 +623,12 @@ class (MethodTypeSym repr, BlockCommentSym repr) =>
   InternalMethod repr where
   intMethod      :: Bool -> Label -> Label -> repr (Scope repr) -> 
     repr (Permanence repr) -> repr (MethodType repr) -> [repr (Parameter repr)] 
-    -> repr (Body repr) -> State GOOLState (repr (Method repr))
+    -> repr (Body repr) -> GS (repr (Method repr))
   intFunc      :: Bool -> Label -> repr (Scope repr) -> repr (Permanence repr) 
     -> repr (MethodType repr) -> [repr (Parameter repr)] -> repr (Body repr) -> 
-    State GOOLState (repr (Method repr))
-  commentedFunc :: State GOOLState (repr (BlockComment repr)) -> 
-    State GOOLState (repr (Method repr)) -> State GOOLState (repr (Method repr))
+    GS (repr (Method repr))
+  commentedFunc :: GS (repr (BlockComment repr)) -> 
+    GS (repr (Method repr)) -> GS (repr (Method repr))
 
   isMainMethod :: repr (Method repr) -> Bool
   methodDoc :: repr (Method repr) -> Doc
@@ -638,65 +637,65 @@ class (ScopeSym repr, PermanenceSym repr, TypeSym repr, StatementSym repr,
   InternalStateVar repr) => StateVarSym repr where
   type StateVar repr
   stateVar :: repr (Scope repr) -> repr (Permanence repr) ->
-    repr (Variable repr) -> State GOOLState (repr (StateVar repr))
+    repr (Variable repr) -> GS (repr (StateVar repr))
   stateVarDef :: Label -> repr (Scope repr) -> repr (Permanence repr) ->
     repr (Variable repr) -> repr (Value repr) -> 
-    State GOOLState (repr (StateVar repr))
+    GS (repr (StateVar repr))
   constVar :: Label -> repr (Scope repr) ->  repr (Variable repr) -> 
-    repr (Value repr) -> State GOOLState (repr (StateVar repr))
-  privMVar :: repr (Variable repr) -> State GOOLState (repr (StateVar repr))
-  pubMVar  :: repr (Variable repr) -> State GOOLState (repr (StateVar repr))
-  pubGVar  :: repr (Variable repr) -> State GOOLState (repr (StateVar repr))
+    repr (Value repr) -> GS (repr (StateVar repr))
+  privMVar :: repr (Variable repr) -> GS (repr (StateVar repr))
+  pubMVar  :: repr (Variable repr) -> GS (repr (StateVar repr))
+  pubGVar  :: repr (Variable repr) -> GS (repr (StateVar repr))
 
 class InternalStateVar repr where
   stateVarDoc :: repr (StateVar repr) -> Doc
-  stateVarFromData :: Doc -> State GOOLState (repr (StateVar repr))
+  stateVarFromData :: Doc -> GS (repr (StateVar repr))
 
 class (MethodSym repr, InternalClass repr) => ClassSym repr 
   where
   type Class repr
   buildClass :: Label -> Maybe Label -> repr (Scope repr) -> 
-    [State GOOLState (repr (StateVar repr))] -> 
-    [State GOOLState (repr (Method repr))] -> 
-    State GOOLState (repr (Class repr))
+    [GS (repr (StateVar repr))] -> 
+    [GS (repr (Method repr))] -> 
+    GS (repr (Class repr))
   enum :: Label -> [Label] -> repr (Scope repr) -> 
-    State GOOLState (repr (Class repr))
-  privClass :: Label -> Maybe Label -> [State GOOLState (repr (StateVar repr))] 
-    -> [State GOOLState (repr (Method repr))] -> 
-    State GOOLState (repr (Class repr))
-  pubClass :: Label -> Maybe Label -> [State GOOLState (repr (StateVar repr))] 
-    -> [State GOOLState (repr (Method repr))] -> 
-    State GOOLState (repr (Class repr))
+    GS (repr (Class repr))
+  privClass :: Label -> Maybe Label -> [GS (repr (StateVar repr))] 
+    -> [GS (repr (Method repr))] -> 
+    GS (repr (Class repr))
+  pubClass :: Label -> Maybe Label -> [GS (repr (StateVar repr))] 
+    -> [GS (repr (Method repr))] -> 
+    GS (repr (Class repr))
 
-  docClass :: String -> State GOOLState (repr (Class repr)) ->
-    State GOOLState (repr (Class repr))
+  docClass :: String -> GS (repr (Class repr)) ->
+    GS (repr (Class repr))
 
-  commentedClass :: State GOOLState (repr (BlockComment repr)) -> 
-    State GOOLState (repr (Class repr)) -> State GOOLState (repr (Class repr))
+  commentedClass :: GS (repr (BlockComment repr)) -> 
+    GS (repr (Class repr)) -> GS (repr (Class repr))
 
 class InternalClass repr where
   classDoc :: repr (Class repr) -> Doc
-  classFromData :: State GOOLState Doc -> State GOOLState (repr (Class repr))
+  classFromData :: GS Doc -> GS (repr (Class repr))
 
 class (ClassSym repr, InternalMod repr) => ModuleSym repr where
   type Module repr
-  buildModule :: Label -> [Library] -> [State GOOLState (repr (Method repr))] 
-    -> [State GOOLState (repr (Class repr))] -> 
-    State GOOLState (repr (Module repr))
+  buildModule :: Label -> [Library] -> [GS (repr (Method repr))] 
+    -> [GS (repr (Class repr))] -> 
+    GS (repr (Module repr))
     
   moduleName :: repr (Module repr) -> String
 
 class InternalMod repr where
   isMainModule :: repr (Module repr) -> Bool
   moduleDoc :: repr (Module repr) -> Doc
-  modFromData :: String -> State GOOLState Bool -> State GOOLState Doc -> 
-    State GOOLState (repr (Module repr))
-  updateModuleDoc :: (Doc -> Doc) -> State GOOLState (repr (Module repr)) -> 
-    State GOOLState (repr (Module repr))
+  modFromData :: String -> GS Bool -> GS Doc -> 
+    GS (repr (Module repr))
+  updateModuleDoc :: (Doc -> Doc) -> GS (repr (Module repr)) -> 
+    GS (repr (Module repr))
     
 class BlockCommentSym repr where
   type BlockComment repr
   blockComment :: [String] -> repr (BlockComment repr)
-  docComment :: State GOOLState [String] -> State GOOLState (repr (BlockComment repr))
+  docComment :: GS [String] -> GS (repr (BlockComment repr))
 
   blockCommentDoc :: repr (BlockComment repr) -> Doc

--- a/code/drasil-gool/Test/FileTests.hs
+++ b/code/drasil-gool/Test/FileTests.hs
@@ -3,14 +3,13 @@ module Test.FileTests (fileTests) where
 import GOOL.Drasil (ProgramSym(..), RenderSym(..), 
   PermanenceSym(..), BodySym(..), BlockSym(..), TypeSym(..), 
   StatementSym(..), ControlStatementSym(..), VariableSym(..), ValueSym(..), 
-  MethodSym(..), ModuleSym(..), GOOLState)
-import Control.Monad.State (State)
+  MethodSym(..), ModuleSym(..), GS)
 import Prelude hiding (return,print,log,exp,sin,cos,tan)
 
-fileTests :: (ProgramSym repr) => State GOOLState (repr (Program repr))
+fileTests :: (ProgramSym repr) => GS (repr (Program repr))
 fileTests = prog "FileTests" [fileDoc (buildModule "FileTests" [] [fileTestMethod] [])]
 
-fileTestMethod :: (RenderSym repr) => State GOOLState (repr (Method repr))
+fileTestMethod :: (RenderSym repr) => GS (repr (Method repr))
 fileTestMethod = mainFunction (body [writeStory, block [readStory], goodBye])
 
 writeStory :: (RenderSym repr) => repr (Block repr)

--- a/code/drasil-gool/Test/FileTests.hs
+++ b/code/drasil-gool/Test/FileTests.hs
@@ -3,13 +3,13 @@ module Test.FileTests (fileTests) where
 import GOOL.Drasil (ProgramSym(..), RenderSym(..), 
   PermanenceSym(..), BodySym(..), BlockSym(..), TypeSym(..), 
   StatementSym(..), ControlStatementSym(..), VariableSym(..), ValueSym(..), 
-  MethodSym(..), ModuleSym(..), GS)
+  MethodSym(..), ModuleSym(..), GS, MS)
 import Prelude hiding (return,print,log,exp,sin,cos,tan)
 
 fileTests :: (ProgramSym repr) => GS (repr (Program repr))
 fileTests = prog "FileTests" [fileDoc (buildModule "FileTests" [] [fileTestMethod] [])]
 
-fileTestMethod :: (RenderSym repr) => GS (repr (Method repr))
+fileTestMethod :: (RenderSym repr) => MS (repr (Method repr))
 fileTestMethod = mainFunction (body [writeStory, block [readStory], goodBye])
 
 writeStory :: (RenderSym repr) => repr (Block repr)

--- a/code/drasil-gool/Test/FileTests.hs
+++ b/code/drasil-gool/Test/FileTests.hs
@@ -3,13 +3,14 @@ module Test.FileTests (fileTests) where
 import GOOL.Drasil (ProgramSym(..), RenderSym(..), 
   PermanenceSym(..), BodySym(..), BlockSym(..), TypeSym(..), 
   StatementSym(..), ControlStatementSym(..), VariableSym(..), ValueSym(..), 
-  MethodSym(..), ModuleSym(..))
+  MethodSym(..), ModuleSym(..), GOOLState)
+import Control.Monad.State (State)
 import Prelude hiding (return,print,log,exp,sin,cos,tan)
 
-fileTests :: (ProgramSym repr) => repr (Program repr)
+fileTests :: (ProgramSym repr) => State GOOLState (repr (Program repr))
 fileTests = prog "FileTests" [fileDoc (buildModule "FileTests" [] [fileTestMethod] [])]
 
-fileTestMethod :: (RenderSym repr) => repr (Method repr)
+fileTestMethod :: (RenderSym repr) => State GOOLState (repr (Method repr))
 fileTestMethod = mainFunction (body [writeStory, block [readStory], goodBye])
 
 writeStory :: (RenderSym repr) => repr (Block repr)

--- a/code/drasil-gool/Test/HelloWorld.hs
+++ b/code/drasil-gool/Test/HelloWorld.hs
@@ -8,11 +8,12 @@ import GOOL.Drasil (
   StatementSym(..), ControlStatementSym(..),  VariableSym(..), ValueSym(..), 
   NumericExpression(..), BooleanExpression(..), ValueExpression(..), 
   Selector(..), FunctionSym(..), SelectorFunction(..), MethodSym(..), 
-  ModuleSym(..))
+  ModuleSym(..), GOOLState)
+import Control.Monad.State (State)
 import Prelude hiding (return,print,log,exp,sin,cos,tan,const)
 import Test.Helper (helper)
 
-helloWorld :: (ProgramSym repr) => repr (Program repr)
+helloWorld :: (ProgramSym repr) => State GOOLState (repr (Program repr))
 helloWorld = prog "HelloWorld" [docMod description 
   ["Brooks MacLachlan"] "" $ fileDoc (buildModule "HelloWorld" ["Helper"] 
   [helloWorldMain] []), helper]
@@ -20,7 +21,7 @@ helloWorld = prog "HelloWorld" [docMod description
 description :: String
 description = "Tests various GOOL functions. It should run without errors."
 
-helloWorldMain :: (RenderSym repr) => repr (Method repr)
+helloWorldMain :: (RenderSym repr) => State GOOLState (repr (Method repr))
 helloWorldMain = mainFunction (body [ helloInitVariables, 
     helloListSlice,
     block [ifCond [(valueOf (var "b" int) ?>= litInt 6, bodyStatements [varDecDef (var "dummy" string) (litString "dummy")]),

--- a/code/drasil-gool/Test/HelloWorld.hs
+++ b/code/drasil-gool/Test/HelloWorld.hs
@@ -8,7 +8,7 @@ import GOOL.Drasil (
   StatementSym(..), ControlStatementSym(..),  VariableSym(..), ValueSym(..), 
   NumericExpression(..), BooleanExpression(..), ValueExpression(..), 
   Selector(..), FunctionSym(..), SelectorFunction(..), MethodSym(..), 
-  ModuleSym(..), GS)
+  ModuleSym(..), GS, MS)
 import Prelude hiding (return,print,log,exp,sin,cos,tan,const)
 import Test.Helper (helper)
 
@@ -20,7 +20,7 @@ helloWorld = prog "HelloWorld" [docMod description
 description :: String
 description = "Tests various GOOL functions. It should run without errors."
 
-helloWorldMain :: (RenderSym repr) => GS (repr (Method repr))
+helloWorldMain :: (RenderSym repr) => MS (repr (Method repr))
 helloWorldMain = mainFunction (body [ helloInitVariables, 
     helloListSlice,
     block [ifCond [(valueOf (var "b" int) ?>= litInt 6, bodyStatements [varDecDef (var "dummy" string) (litString "dummy")]),

--- a/code/drasil-gool/Test/HelloWorld.hs
+++ b/code/drasil-gool/Test/HelloWorld.hs
@@ -8,12 +8,11 @@ import GOOL.Drasil (
   StatementSym(..), ControlStatementSym(..),  VariableSym(..), ValueSym(..), 
   NumericExpression(..), BooleanExpression(..), ValueExpression(..), 
   Selector(..), FunctionSym(..), SelectorFunction(..), MethodSym(..), 
-  ModuleSym(..), GOOLState)
-import Control.Monad.State (State)
+  ModuleSym(..), GS)
 import Prelude hiding (return,print,log,exp,sin,cos,tan,const)
 import Test.Helper (helper)
 
-helloWorld :: (ProgramSym repr) => State GOOLState (repr (Program repr))
+helloWorld :: (ProgramSym repr) => GS (repr (Program repr))
 helloWorld = prog "HelloWorld" [docMod description 
   ["Brooks MacLachlan"] "" $ fileDoc (buildModule "HelloWorld" ["Helper"] 
   [helloWorldMain] []), helper]
@@ -21,7 +20,7 @@ helloWorld = prog "HelloWorld" [docMod description
 description :: String
 description = "Tests various GOOL functions. It should run without errors."
 
-helloWorldMain :: (RenderSym repr) => State GOOLState (repr (Method repr))
+helloWorldMain :: (RenderSym repr) => GS (repr (Method repr))
 helloWorldMain = mainFunction (body [ helloInitVariables, 
     helloListSlice,
     block [ifCond [(valueOf (var "b" int) ?>= litInt 6, bodyStatements [varDecDef (var "dummy" string) (litString "dummy")]),

--- a/code/drasil-gool/Test/Helper.hs
+++ b/code/drasil-gool/Test/Helper.hs
@@ -1,15 +1,16 @@
 module Test.Helper (helper) where
 
-import GOOL.Drasil.Symantics (
+import GOOL.Drasil (
   RenderSym(..), PermanenceSym(..), BodySym(..), TypeSym(..), 
   StatementSym(..), VariableSym(..), ValueSym(..), NumericExpression(..), 
-  ScopeSym(..), ParameterSym(..), MethodSym(..), ModuleSym(..))
+  ScopeSym(..), ParameterSym(..), MethodSym(..), ModuleSym(..), GOOLState)
+import Control.Monad.State (State)
 import Prelude hiding (return,print,log,exp,sin,cos,tan)
 
-helper :: (RenderSym repr) => repr (RenderFile repr)
+helper :: (RenderSym repr) => State GOOLState (repr (RenderFile repr))
 helper = fileDoc (buildModule "Helper" [] [doubleAndAdd] [])
 
-doubleAndAdd :: (RenderSym repr) => repr (Method repr)
+doubleAndAdd :: (RenderSym repr) => State GOOLState (repr (Method repr))
 doubleAndAdd = docFunc "This function adds two numbers" 
   ["First number to add", "Second number to add"] (Just "Sum") $ 
   function "doubleAndAdd"  public static_ float

--- a/code/drasil-gool/Test/Helper.hs
+++ b/code/drasil-gool/Test/Helper.hs
@@ -3,14 +3,13 @@ module Test.Helper (helper) where
 import GOOL.Drasil (
   RenderSym(..), PermanenceSym(..), BodySym(..), TypeSym(..), 
   StatementSym(..), VariableSym(..), ValueSym(..), NumericExpression(..), 
-  ScopeSym(..), ParameterSym(..), MethodSym(..), ModuleSym(..), GOOLState)
-import Control.Monad.State (State)
+  ScopeSym(..), ParameterSym(..), MethodSym(..), ModuleSym(..), GS)
 import Prelude hiding (return,print,log,exp,sin,cos,tan)
 
-helper :: (RenderSym repr) => State GOOLState (repr (RenderFile repr))
+helper :: (RenderSym repr) => GS (repr (RenderFile repr))
 helper = fileDoc (buildModule "Helper" [] [doubleAndAdd] [])
 
-doubleAndAdd :: (RenderSym repr) => State GOOLState (repr (Method repr))
+doubleAndAdd :: (RenderSym repr) => GS (repr (Method repr))
 doubleAndAdd = docFunc "This function adds two numbers" 
   ["First number to add", "Second number to add"] (Just "Sum") $ 
   function "doubleAndAdd"  public static_ float

--- a/code/drasil-gool/Test/Helper.hs
+++ b/code/drasil-gool/Test/Helper.hs
@@ -3,13 +3,13 @@ module Test.Helper (helper) where
 import GOOL.Drasil (
   RenderSym(..), PermanenceSym(..), BodySym(..), TypeSym(..), 
   StatementSym(..), VariableSym(..), ValueSym(..), NumericExpression(..), 
-  ScopeSym(..), ParameterSym(..), MethodSym(..), ModuleSym(..), GS)
+  ScopeSym(..), ParameterSym(..), MethodSym(..), ModuleSym(..), GS, MS)
 import Prelude hiding (return,print,log,exp,sin,cos,tan)
 
 helper :: (RenderSym repr) => GS (repr (RenderFile repr))
 helper = fileDoc (buildModule "Helper" [] [doubleAndAdd] [])
 
-doubleAndAdd :: (RenderSym repr) => GS (repr (Method repr))
+doubleAndAdd :: (RenderSym repr) => MS (repr (Method repr))
 doubleAndAdd = docFunc "This function adds two numbers" 
   ["First number to add", "Second number to add"] (Just "Sum") $ 
   function "doubleAndAdd"  public static_ float

--- a/code/drasil-gool/Test/Main.hs
+++ b/code/drasil-gool/Test/Main.hs
@@ -6,10 +6,10 @@ import GOOL.Drasil.LanguageRenderer.PythonRenderer (PythonCode(..))
 import GOOL.Drasil.LanguageRenderer.CSharpRenderer (CSharpCode(..))
 import GOOL.Drasil.LanguageRenderer.CppRenderer (unCPPC)
 import GOOL.Drasil.Data (FileData(..), ModData(..), ProgData(..))
-import GOOL.Drasil.State (GOOLState, initialState)
+import GOOL.Drasil.State (initialState)
 
 import Text.PrettyPrint.HughesPJ (Doc, render)
-import Control.Monad.State (State, evalState)
+import Control.Monad.State (evalState)
 import System.Directory (setCurrentDirectory, createDirectoryIfMissing, getCurrentDirectory)
 import System.FilePath.Posix (takeDirectory)
 import System.IO (hClose, hPutStrLn, openFile, IOMode(WriteMode))
@@ -42,8 +42,8 @@ genCode :: [ProgData] -> IO()
 genCode files = createCodeFiles (concatMap (\p -> replicate (length $ progMods 
   p) (progName p)) files) $ makeCode (concatMap progMods files)
 
-classes :: (ProgramSym repr) => (repr (Program repr) -> State GOOLState ProgData) -> [ProgData]
-classes unRepr = map ((`evalState` initialState) . unRepr) [helloWorld, 
+classes :: (ProgramSym repr) => (repr (Program repr) -> ProgData) -> [ProgData]
+classes unRepr = map (unRepr . (`evalState` initialState)) [helloWorld, 
   patternTest, fileTests]
 
 -- | Takes code

--- a/code/drasil-gool/Test/Observer.hs
+++ b/code/drasil-gool/Test/Observer.hs
@@ -3,7 +3,7 @@ module Test.Observer (observer, observerName, printNum, x) where
 import GOOL.Drasil (
   RenderSym(..), PermanenceSym(..), BodySym(..), TypeSym(..), 
   StatementSym(..), VariableSym(..), ValueSym(..), ScopeSym(..), 
-  MethodSym(..), StateVarSym(..), ClassSym(..), ModuleSym(..), GS)
+  MethodSym(..), StateVarSym(..), ClassSym(..), ModuleSym(..), GS, MS)
 import Prelude hiding (return,print,log,exp,sin,cos,tan)
 
 observerName, observerDesc, printNum :: String
@@ -26,10 +26,10 @@ helperClass = pubClass observerName Nothing [stateVar public dynamic_ x]
   [observerConstructor, printNumMethod, getMethod observerName x, 
   setMethod observerName x]
 
-observerConstructor :: (MethodSym repr) => GS (repr (Method repr))
+observerConstructor :: (MethodSym repr) => MS (repr (Method repr))
 observerConstructor = constructor observerName [] $ oneLiner $ assign selfX 
   (litInt 5)
 
-printNumMethod :: (MethodSym repr) => GS (repr (Method repr))
+printNumMethod :: (MethodSym repr) => MS (repr (Method repr))
 printNumMethod = method printNum observerName public dynamic_ void [] $
   oneLiner $ printLn $ valueOf selfX

--- a/code/drasil-gool/Test/Observer.hs
+++ b/code/drasil-gool/Test/Observer.hs
@@ -1,9 +1,10 @@
 module Test.Observer (observer, observerName, printNum, x) where
 
-import GOOL.Drasil.Symantics (
+import GOOL.Drasil (
   RenderSym(..), PermanenceSym(..), BodySym(..), TypeSym(..), 
   StatementSym(..), VariableSym(..), ValueSym(..), ScopeSym(..), 
-  MethodSym(..), StateVarSym(..), ClassSym(..), ModuleSym(..))
+  MethodSym(..), StateVarSym(..), ClassSym(..), ModuleSym(..), GOOLState)
+import Control.Monad.State (State)
 import Prelude hiding (return,print,log,exp,sin,cos,tan)
 
 observerName, observerDesc, printNum :: String
@@ -11,7 +12,7 @@ observerName = "Observer"
 observerDesc = "This is an arbitrary class acting as an Observer"
 printNum = "printNum"
 
-observer :: (RenderSym repr) => repr (RenderFile repr)
+observer :: (RenderSym repr) => State GOOLState (repr (RenderFile repr))
 observer = fileDoc (buildModule observerName [] [] [docClass observerDesc
   helperClass])
 
@@ -21,15 +22,15 @@ x = var "x" int
 selfX :: (VariableSym repr) => repr (Variable repr)
 selfX = objVarSelf observerName x
 
-helperClass :: (ClassSym repr) => repr (Class repr)
+helperClass :: (ClassSym repr) => State GOOLState (repr (Class repr))
 helperClass = pubClass observerName Nothing [stateVar public dynamic_ x]
   [observerConstructor, printNumMethod, getMethod observerName x, 
   setMethod observerName x]
 
-observerConstructor :: (MethodSym repr) => repr (Method repr)
+observerConstructor :: (MethodSym repr) => State GOOLState (repr (Method repr))
 observerConstructor = constructor observerName [] $ oneLiner $ assign selfX 
   (litInt 5)
 
-printNumMethod :: (MethodSym repr) => repr (Method repr)
+printNumMethod :: (MethodSym repr) => State GOOLState (repr (Method repr))
 printNumMethod = method printNum observerName public dynamic_ void [] $
   oneLiner $ printLn $ valueOf selfX

--- a/code/drasil-gool/Test/Observer.hs
+++ b/code/drasil-gool/Test/Observer.hs
@@ -3,8 +3,7 @@ module Test.Observer (observer, observerName, printNum, x) where
 import GOOL.Drasil (
   RenderSym(..), PermanenceSym(..), BodySym(..), TypeSym(..), 
   StatementSym(..), VariableSym(..), ValueSym(..), ScopeSym(..), 
-  MethodSym(..), StateVarSym(..), ClassSym(..), ModuleSym(..), GOOLState)
-import Control.Monad.State (State)
+  MethodSym(..), StateVarSym(..), ClassSym(..), ModuleSym(..), GS)
 import Prelude hiding (return,print,log,exp,sin,cos,tan)
 
 observerName, observerDesc, printNum :: String
@@ -12,7 +11,7 @@ observerName = "Observer"
 observerDesc = "This is an arbitrary class acting as an Observer"
 printNum = "printNum"
 
-observer :: (RenderSym repr) => State GOOLState (repr (RenderFile repr))
+observer :: (RenderSym repr) => GS (repr (RenderFile repr))
 observer = fileDoc (buildModule observerName [] [] [docClass observerDesc
   helperClass])
 
@@ -22,15 +21,15 @@ x = var "x" int
 selfX :: (VariableSym repr) => repr (Variable repr)
 selfX = objVarSelf observerName x
 
-helperClass :: (ClassSym repr) => State GOOLState (repr (Class repr))
+helperClass :: (ClassSym repr) => GS (repr (Class repr))
 helperClass = pubClass observerName Nothing [stateVar public dynamic_ x]
   [observerConstructor, printNumMethod, getMethod observerName x, 
   setMethod observerName x]
 
-observerConstructor :: (MethodSym repr) => State GOOLState (repr (Method repr))
+observerConstructor :: (MethodSym repr) => GS (repr (Method repr))
 observerConstructor = constructor observerName [] $ oneLiner $ assign selfX 
   (litInt 5)
 
-printNumMethod :: (MethodSym repr) => State GOOLState (repr (Method repr))
+printNumMethod :: (MethodSym repr) => GS (repr (Method repr))
 printNumMethod = method printNum observerName public dynamic_ void [] $
   oneLiner $ printLn $ valueOf selfX

--- a/code/drasil-gool/Test/PatternTest.hs
+++ b/code/drasil-gool/Test/PatternTest.hs
@@ -4,7 +4,8 @@ import GOOL.Drasil (
   ProgramSym(..), RenderSym(..),
   BodySym(..), BlockSym(..), ControlBlockSym(..), TypeSym(..), 
   StatementSym(..), ControlStatementSym(..), VariableSym(..), ValueSym(..),
-  ValueExpression(..), FunctionSym(..), MethodSym(..), ModuleSym(..))
+  ValueExpression(..), FunctionSym(..), MethodSym(..), ModuleSym(..), GOOLState)
+import Control.Monad.State (State)
 import Prelude hiding (return,print,log,exp,sin,cos,tan)
 import Test.Observer (observer, observerName, printNum, x)
 
@@ -32,10 +33,10 @@ obs2 = var obs2Name observerType
 newObserver :: (ValueExpression repr) => repr (Value repr)
 newObserver = extNewObj observerName observerType []
 
-patternTest :: (ProgramSym repr) => repr (Program repr)
+patternTest :: (ProgramSym repr) => State GOOLState (repr (Program repr))
 patternTest = prog progName [fileDoc (buildModule progName [observerName] [patternTestMainMethod] []), observer]
 
-patternTestMainMethod :: (MethodSym repr) => repr (Method repr)
+patternTestMainMethod :: (MethodSym repr) => State GOOLState (repr (Method repr))
 patternTestMainMethod = mainFunction (body [block [
   varDec n,
   initState fsmName offState, 

--- a/code/drasil-gool/Test/PatternTest.hs
+++ b/code/drasil-gool/Test/PatternTest.hs
@@ -4,7 +4,7 @@ import GOOL.Drasil (
   ProgramSym(..), RenderSym(..),
   BodySym(..), BlockSym(..), ControlBlockSym(..), TypeSym(..), 
   StatementSym(..), ControlStatementSym(..), VariableSym(..), ValueSym(..),
-  ValueExpression(..), FunctionSym(..), MethodSym(..), ModuleSym(..), GS)
+  ValueExpression(..), FunctionSym(..), MethodSym(..), ModuleSym(..), GS, MS)
 import Prelude hiding (return,print,log,exp,sin,cos,tan)
 import Test.Observer (observer, observerName, printNum, x)
 
@@ -35,7 +35,7 @@ newObserver = extNewObj observerName observerType []
 patternTest :: (ProgramSym repr) => GS (repr (Program repr))
 patternTest = prog progName [fileDoc (buildModule progName [observerName] [patternTestMainMethod] []), observer]
 
-patternTestMainMethod :: (MethodSym repr) => GS (repr (Method repr))
+patternTestMainMethod :: (MethodSym repr) => MS (repr (Method repr))
 patternTestMainMethod = mainFunction (body [block [
   varDec n,
   initState fsmName offState, 

--- a/code/drasil-gool/Test/PatternTest.hs
+++ b/code/drasil-gool/Test/PatternTest.hs
@@ -4,8 +4,7 @@ import GOOL.Drasil (
   ProgramSym(..), RenderSym(..),
   BodySym(..), BlockSym(..), ControlBlockSym(..), TypeSym(..), 
   StatementSym(..), ControlStatementSym(..), VariableSym(..), ValueSym(..),
-  ValueExpression(..), FunctionSym(..), MethodSym(..), ModuleSym(..), GOOLState)
-import Control.Monad.State (State)
+  ValueExpression(..), FunctionSym(..), MethodSym(..), ModuleSym(..), GS)
 import Prelude hiding (return,print,log,exp,sin,cos,tan)
 import Test.Observer (observer, observerName, printNum, x)
 
@@ -33,10 +32,10 @@ obs2 = var obs2Name observerType
 newObserver :: (ValueExpression repr) => repr (Value repr)
 newObserver = extNewObj observerName observerType []
 
-patternTest :: (ProgramSym repr) => State GOOLState (repr (Program repr))
+patternTest :: (ProgramSym repr) => GS (repr (Program repr))
 patternTest = prog progName [fileDoc (buildModule progName [observerName] [patternTestMainMethod] []), observer]
 
-patternTestMainMethod :: (MethodSym repr) => State GOOLState (repr (Method repr))
+patternTestMainMethod :: (MethodSym repr) => GS (repr (Method repr))
 patternTestMainMethod = mainFunction (body [block [
   varDec n,
   initState fsmName offState, 


### PR DESCRIPTION
This PR splits `MethodState` off of `GOOLState`, where `MethodState` holds state that is local to `Method`s. We use `zoom` to lift `State GOOLState` type values to `State (GOOLState, MethodState)` type values, and also to lift `State (GOOLState, MethodState)` type values back into `State GOOLState` type values. Which means I had to build lenses going both ways, and to get from `State GOOLState` to `State (GOOLState, MethodState)` the lens is sort of backwards -- it "focuses in" on something even bigger than what it starts with, which sounds impossible, but works because when we need to lift "something" without `MethodState` into a computation with `MethodState` we can just initialize the `MethodState` for the "something" however we want, because it doesn't actually care what its `MethodState` is, only that its type does include `MethodState`! I'm kind of amazed that this works! 

Another thing that happened was I initially switched all `Method` types to use `MethodState`, and left all other types to just use `GOOLState`. But the `BlockComment` passed to `commentedFunc` needs to read `MethodState` to get the parameter names, and since I had left it only with `GOOLState` it couldn't do that, and the documentation for parameters disappeared. I was hesitant to switch the `BlockComment` to use `MethodState` to fix this problem because `BlockComment`s in general aren't specifically related to `Method`s. But then I realized that, since we switched the order of the monads, I can make the `BlockComment` passed to `commentedFunc` use `MethodState` while keeping `BlockComment`s passed to other functions using `GOOLState`! I just had to make the constructor for the `BlockComment` generic on the type of State it has, which worked like a charm. In other words, I'm really happy with how nicely all these changes worked out :)

I'll be curious to see how this scales up, if in the future we have more types of local state beyond just `MethodState` (even now, it probably makes sense to add `ModuleState` for the `currModName` field and/or `FileState` for the `currFilePath` field). I think we will still be able to make everything work, though we will likely have to build a whole bunch of lenses for transitioning between all the different types of State.

This PR depends on #1959, so that should be merged first. The new commits for this PR start with 
60398ab.