### PR TITLE
Add local FileState to GOOL

### DIFF
--- a/code/drasil-code/Language/Drasil/Code/Imperative/GenerateGOOL.hs
+++ b/code/drasil-code/Language/Drasil/Code/Imperative/GenerateGOOL.hs
@@ -11,7 +11,7 @@ import Language.Drasil.CodeSpec (CodeSpec(..), CodeSystInfo(..), Comments(..),
 import GOOL.Drasil (Label, RenderSym(..), TypeSym(..), 
   VariableSym(..), ValueSym(..), ValueExpression(..), StatementSym(..), 
   ParameterSym(..), MethodSym(..), StateVarSym(..), ClassSym(..), ModuleSym(..),
-  CodeType(..), GOOLState, GS, MS)
+  CodeType(..), GOOLState, GS, FS, MS)
 
 import qualified Data.Map as Map (lookup)
 import Data.Maybe (fromMaybe, maybe)
@@ -20,7 +20,7 @@ import Control.Monad.Reader (Reader, ask, withReader)
 genModule :: (RenderSym repr) => Name -> String
   -> Maybe (Reader DrasilState [MS (repr (Method repr))])
   -> Maybe (Reader DrasilState [GS (repr (Class repr))])
-  -> Reader DrasilState (GS (repr (RenderFile repr)))
+  -> Reader DrasilState (FS (repr (RenderFile repr)))
 genModule n desc maybeMs maybeCs = do
   g <- ask
   let ls = fromMaybe [] (Map.lookup n (dMap $ codeSpec g))

--- a/code/drasil-code/Language/Drasil/Code/Imperative/GenerateGOOL.hs
+++ b/code/drasil-code/Language/Drasil/Code/Imperative/GenerateGOOL.hs
@@ -19,7 +19,7 @@ import Control.Monad.Reader (Reader, ask, withReader)
 
 genModule :: (RenderSym repr) => Name -> String
   -> Maybe (Reader DrasilState [MS (repr (Method repr))])
-  -> Maybe (Reader DrasilState [GS (repr (Class repr))])
+  -> Maybe (Reader DrasilState [FS (repr (Class repr))])
   -> Reader DrasilState (FS (repr (RenderFile repr)))
 genModule n desc maybeMs maybeCs = do
   g <- ask
@@ -45,8 +45,8 @@ genDoxConfig n s = do
   return [doxConfig n s v | not (null cms)]
 
 publicClass :: (RenderSym repr) => String -> Label -> Maybe Label -> 
-  [GS (repr (StateVar repr))] -> Reader DrasilState [MS (repr (Method repr))] -> 
-  Reader DrasilState (GS (repr (Class repr)))
+  [GS (repr (StateVar repr))] -> Reader DrasilState [MS (repr (Method repr))] 
+  -> Reader DrasilState (FS (repr (Class repr)))
 publicClass desc n l vs mths = do
   g <- ask
   ms <- mths

--- a/code/drasil-code/Language/Drasil/Code/Imperative/Generator.hs
+++ b/code/drasil-code/Language/Drasil/Code/Imperative/Generator.hs
@@ -17,7 +17,7 @@ import Language.Drasil.Chunk.Code (programName)
 import Language.Drasil.CodeSpec (CodeSpec(..), CodeSystInfo(..), Choices(..), 
   Lang(..), Visibility(..))
 
-import GOOL.Drasil (ProgramSym(..), RenderSym(..), ProgData(..), GS, 
+import GOOL.Drasil (ProgramSym(..), RenderSym(..), ProgData(..), GS, FS, 
   initialState)
 
 import System.Directory (setCurrentDirectory, createDirectoryIfMissing, 
@@ -86,7 +86,7 @@ genProgram = do
   let n = case codeSpec g of CodeSpec {program = p} -> programName p
   return $ prog n ms
           
-genModules :: (RenderSym repr) => Reader DrasilState [GS (repr (RenderFile repr))]
+genModules :: (RenderSym repr) => Reader DrasilState [FS (repr (RenderFile repr))]
 genModules = do
   g <- ask
   let s = csi $ codeSpec g

--- a/code/drasil-code/Language/Drasil/Code/Imperative/Import.hs
+++ b/code/drasil-code/Language/Drasil/Code/Imperative/Import.hs
@@ -33,7 +33,7 @@ import GOOL.Drasil (Label, RenderSym(..), PermanenceSym(..), BodySym(..),
   NumericExpression(..), BooleanExpression(..), ValueExpression(..), 
   FunctionSym(..), SelectorFunction(..), StatementSym(..), 
   ControlStatementSym(..), ScopeSym(..), ParameterSym(..), MethodSym(..), 
-  convType, GS, MS) 
+  convType, FS, MS) 
 import qualified GOOL.Drasil as C (CodeType(List))
 
 import Prelude hiding (sin, cos, tan, log, exp)
@@ -319,7 +319,7 @@ genCaseBlock t v c cs = do
 
 -- medium hacks --
 genModDef :: (RenderSym repr) => Mod -> 
-  Reader DrasilState (GS (repr (RenderFile repr)))
+  Reader DrasilState (FS (repr (RenderFile repr)))
 genModDef (Mod n desc fs) = genModule n desc (Just $ mapM genFunc fs) Nothing
 
 genFunc :: (RenderSym repr) => Func -> Reader DrasilState (MS (repr (Method repr)))

--- a/code/drasil-code/Language/Drasil/Code/Imperative/Modules.hs
+++ b/code/drasil-code/Language/Drasil/Code/Imperative/Modules.hs
@@ -152,7 +152,7 @@ genInputModCombined :: (RenderSym repr) =>
 genInputModCombined = do
   ipDesc <- modDesc inputParametersDesc
   let cname = "InputParameters"
-      genMod :: (RenderSym repr) => Maybe (GS (repr (Class repr))) ->
+      genMod :: (RenderSym repr) => Maybe (FS (repr (Class repr))) ->
         Reader DrasilState (FS (repr (RenderFile repr)))
       genMod Nothing = genModule cname ipDesc (Just $ concat <$> mapM (fmap 
         maybeToList) [genInputFormat Pub, genInputDerived 
@@ -168,7 +168,7 @@ constVarFunc Var n = stateVarDef n public dynamic_
 constVarFunc Const n = constVar n public
 
 genInputClass :: (RenderSym repr) => 
-  Reader DrasilState (Maybe (GS (repr (Class repr))))
+  Reader DrasilState (Maybe (FS (repr (Class repr))))
 genInputClass = do
   g <- ask
   let ins = inputs $ csi $ codeSpec g
@@ -185,7 +185,7 @@ genInputClass = do
         genInputDerived Priv, 
         genInputConstraints Priv]
       genClass :: (RenderSym repr) => [CodeChunk] -> [CodeDefinition] -> 
-        Reader DrasilState (Maybe (GS (repr (Class repr))))
+        Reader DrasilState (Maybe (FS (repr (Class repr))))
       genClass [] [] = return Nothing
       genClass inps csts = do
         vals <- mapM (convExpr . codeEquat) csts
@@ -386,13 +386,13 @@ genConstMod = do
     genConstClass)
 
 genConstClass :: (RenderSym repr) => 
-  Reader DrasilState (Maybe (GS (repr (Class repr))))
+  Reader DrasilState (Maybe (FS (repr (Class repr))))
 genConstClass = do
   g <- ask
   let cs = constants $ csi $ codeSpec g
       cname = "Constants"
       genClass :: (RenderSym repr) => [CodeDefinition] -> Reader DrasilState (Maybe 
-        (GS (repr (Class repr))))
+        (FS (repr (Class repr))))
       genClass [] = return Nothing 
       genClass vs = do
         vals <- mapM (convExpr . codeEquat) vs 

--- a/code/drasil-code/Language/Drasil/Code/Imperative/Modules.hs
+++ b/code/drasil-code/Language/Drasil/Code/Imperative/Modules.hs
@@ -36,7 +36,7 @@ import GOOL.Drasil (RenderSym(..), BodySym(..), BlockSym(..),
   PermanenceSym(..), TypeSym(..), VariableSym(..), ValueSym(..), 
   BooleanExpression(..), StatementSym(..), ControlStatementSym(..), 
   ScopeSym(..), MethodSym(..), StateVarSym(..), ClassSym(..), ScopeTag(..), 
-  convType, GS, MS)
+  convType, GS, FS, MS)
 
 import Prelude hiding (print)
 import Data.List (intersperse, intercalate, partition)
@@ -50,7 +50,7 @@ import Text.PrettyPrint.HughesPJ (render)
 
 ---- MAIN ---
 
-genMain :: (RenderSym repr) => Reader DrasilState (GS (repr (RenderFile repr)))
+genMain :: (RenderSym repr) => Reader DrasilState (FS (repr (RenderFile repr)))
 genMain = genModule "Control" "Controls the flow of the program" 
   (Just $ liftS genMainFunc) Nothing
 
@@ -126,12 +126,12 @@ initLogFileVar _ = []
 ------- INPUT ----------
 
 chooseInModule :: (RenderSym repr) => InputModule -> Reader DrasilState 
-  [GS (repr (RenderFile repr))]
+  [FS (repr (RenderFile repr))]
 chooseInModule Combined = genInputModCombined
 chooseInModule Separated = genInputModSeparated
 
 genInputModSeparated :: (RenderSym repr) => 
-  Reader DrasilState [GS (repr (RenderFile repr))]
+  Reader DrasilState [FS (repr (RenderFile repr))]
 genInputModSeparated = do
   ipDesc <- modDesc inputParametersDesc
   ifDesc <- modDesc (liftS inputFormatDesc)
@@ -148,12 +148,12 @@ genInputModSeparated = do
       (Just $ fmap maybeToList (genInputConstraints Pub)) Nothing]
 
 genInputModCombined :: (RenderSym repr) => 
-  Reader DrasilState [GS (repr (RenderFile repr))]
+  Reader DrasilState [FS (repr (RenderFile repr))]
 genInputModCombined = do
   ipDesc <- modDesc inputParametersDesc
   let cname = "InputParameters"
       genMod :: (RenderSym repr) => Maybe (GS (repr (Class repr))) ->
-        Reader DrasilState (GS (repr (RenderFile repr)))
+        Reader DrasilState (FS (repr (RenderFile repr)))
       genMod Nothing = genModule cname ipDesc (Just $ concat <$> mapM (fmap 
         maybeToList) [genInputFormat Pub, genInputDerived 
         Pub, genInputConstraints Pub]) 
@@ -379,7 +379,7 @@ genSampleInput = do
 
 ----- CONSTANTS -----
 
-genConstMod :: (RenderSym repr) => Reader DrasilState [GS (repr (RenderFile repr))]
+genConstMod :: (RenderSym repr) => Reader DrasilState [FS (repr (RenderFile repr))]
 genConstMod = do
   cDesc <- modDesc $ liftS constModDesc
   liftS $ genModule "Constants" cDesc Nothing (Just $ fmap maybeToList 
@@ -406,7 +406,7 @@ genConstClass = do
 
 ----- OUTPUT -------
 
-genOutputMod :: (RenderSym repr) => Reader DrasilState [GS (repr (RenderFile repr))]
+genOutputMod :: (RenderSym repr) => Reader DrasilState [FS (repr (RenderFile repr))]
 genOutputMod = do
   outformat <- genOutputFormat
   ofDesc <- modDesc $ liftS outputFormatDesc

--- a/code/drasil-gool/GOOL/Drasil.hs
+++ b/code/drasil-gool/GOOL/Drasil.hs
@@ -8,7 +8,7 @@ module GOOL.Drasil (Label, ProgramSym(..), RenderSym(..), PermanenceSym(..),
   BlockCommentSym(..), 
   ScopeTag(..), ProgData(..), FileData(..), ModData(..),
   CodeType(..),
-  GOOLState(..), GS, MS, headers, sources, mainMod, initialState,
+  GOOLState(..), GS, FS, MS, headers, sources, mainMod, initialState,
   convType, onCodeList,
   unPC, unJC, unCSC, unCPPC
 ) where
@@ -25,8 +25,8 @@ import GOOL.Drasil.Data (ScopeTag(..), FileData(..), ModData(..), ProgData(..))
 
 import GOOL.Drasil.CodeType (CodeType(..))
 
-import GOOL.Drasil.State (GOOLState(..), GS, MS, headers, sources, mainMod, 
-  initialState)
+import GOOL.Drasil.State (GOOLState(..), GS, FS, MS, headers, sources, 
+  mainMod, initialState)
 
 import GOOL.Drasil.Helpers (convType, onCodeList)
 

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer/CSharpRenderer.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer/CSharpRenderer.hs
@@ -66,11 +66,10 @@ import GOOL.Drasil.Data (Terminator(..), FileType(..), FileData(..), fileD,
 import GOOL.Drasil.Helpers (toCode, toState, onCodeValue, onStateValue, 
   on2CodeValues, on2StateValues, on3CodeValues, on4CodeValues, on5CodeValues, 
   onCodeList, onStateList, on1CodeValue1List, checkParams)
-import GOOL.Drasil.State (MS, lensGStoFS, lensMStoGS, initialState, initialFS, putAfter, getPutReturn, 
-  setMain, setCurrMain, setParameters)
+import GOOL.Drasil.State (MS, lensGStoFS, initialState, initialFS, getPutReturn,
+  setCurrMain, setParameters)
 
 import Prelude hiding (break,print,(<>),sin,cos,tan,floor)
-import Control.Lens (over)
 import Control.Lens.Zoom (zoom)
 import Control.Applicative (Applicative)
 import Control.Monad.State (evalState)
@@ -95,8 +94,7 @@ instance Monad CSharpCode where
 
 instance ProgramSym CSharpCode where
   type Program CSharpCode = ProgData
-  prog n = onStateList (onCodeList (progD n)) . map (putAfter (setCurrMain 
-    False) . zoom lensGStoFS)
+  prog n = onStateList (onCodeList (progD n)) . map (zoom lensGStoFS)
 
 instance RenderSym CSharpCode where
   type RenderFile CSharpCode = FileData
@@ -550,9 +548,8 @@ instance MethodSym CSharpCode where
 
 instance InternalMethod CSharpCode where
   intMethod m n _ s p t ps b = getPutReturn (setParameters (map unCSC ps) . 
-    if m then over lensMStoGS (setCurrMain m) . setMain else id) $ onCodeValue 
-    mthd (on5CodeValues (methodDocD n) s p t (onCodeList (paramListDocD . 
-    checkParams n) ps) b)
+    if m then setCurrMain else id) $ onCodeValue mthd (on5CodeValues 
+    (methodDocD n) s p t (onCodeList (paramListDocD . checkParams n) ps) b)
   intFunc = G.intFunc
   commentedFunc cmt m = on2StateValues (on2CodeValues updateMthdDoc) m 
     (onStateValue (onCodeValue commentedItem) cmt)

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer/CSharpRenderer.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer/CSharpRenderer.hs
@@ -66,11 +66,12 @@ import GOOL.Drasil.Data (Terminator(..), FileType(..), FileData(..), fileD,
 import GOOL.Drasil.Helpers (toCode, toState, onCodeValue, onStateValue, 
   on2CodeValues, on2StateValues, on3CodeValues, on4CodeValues, on5CodeValues, 
   onCodeList, onStateList, on1CodeValue1List, checkParams)
-import GOOL.Drasil.State (MS, lensMStoGS, initialState, putAfter, getPutReturn, 
+import GOOL.Drasil.State (MS, lensGStoFS, lensMStoGS, initialState, initialFS, putAfter, getPutReturn, 
   setMain, setCurrMain, setParameters)
 
 import Prelude hiding (break,print,(<>),sin,cos,tan,floor)
 import Control.Lens (over)
+import Control.Lens.Zoom (zoom)
 import Control.Applicative (Applicative)
 import Control.Monad.State (evalState)
 import Text.PrettyPrint.HughesPJ (Doc, text, (<>), (<+>), parens, comma, empty,
@@ -94,13 +95,13 @@ instance Monad CSharpCode where
 
 instance ProgramSym CSharpCode where
   type Program CSharpCode = ProgData
-  prog n = onStateList (onCodeList (progD n)) . map (putAfter $ setCurrMain 
-    False)
+  prog n = onStateList (onCodeList (progD n)) . map (putAfter (setCurrMain 
+    False) . zoom lensGStoFS)
 
 instance RenderSym CSharpCode where
   type RenderFile CSharpCode = FileData
-  fileDoc code = G.fileDoc Combined csExt (top $ evalState code initialState) 
-    bottom code
+  fileDoc code = G.fileDoc Combined csExt (top $ evalState code (initialState,
+    initialFS)) bottom code
 
   docMod = G.docMod
 

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer/CppRenderer.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer/CppRenderer.hs
@@ -67,14 +67,13 @@ import GOOL.Drasil.Helpers (angles, doubleQuotedText, emptyIfEmpty, mapPairFst,
   on2StateValues, on3CodeValues, on3StateValues, on4CodeValues, on5CodeValues, 
   on8CodeValues, onCodeList, onStateList, on2CodeLists, on2StateLists, 
   on1CodeValue1List, on1StateValue1List, checkParams)
-import GOOL.Drasil.State (MS, lensGStoFS, lensFStoGS, lensFStoMS, lensGStoMS, 
-  lensMStoGS, initialState, initialFS, putAfter, getPutReturn, setMain, 
-  setCurrMain, getCurrMain, setParameters, setScope, getScope, setCurrMainFunc, 
-  getCurrMainFunc)
+import GOOL.Drasil.State (MS, lensGStoFS, lensFStoGS, lensFStoMS, lensMStoGS, 
+  initialState, initialFS, getPutReturn, setCurrMain, getCurrMain, 
+  setParameters, setScope, getScope, setCurrMainFunc, getCurrMainFunc)
 
 import Prelude hiding (break,print,(<>),sin,cos,tan,floor,pi,const,log,exp,mod)
 import Data.Maybe (maybeToList)
-import Control.Lens (Lens', over)
+import Control.Lens (Lens')
 import Control.Lens.Zoom (zoom)
 import Control.Applicative (Applicative)
 import Control.Monad.State (State, evalState)
@@ -101,7 +100,7 @@ hdrToSrc (CPPHC a) = CPPSC a
 instance (Pair p) => ProgramSym (p CppSrcCode CppHdrCode) where
   type Program (p CppSrcCode CppHdrCode) = ProgData
   prog n mods = do
-    m <-  mapM (putAfter (setCurrMain False) . zoom lensGStoFS) mods
+    m <-  mapM (zoom lensGStoFS) mods
     let fm = map pfst m
         sm = map (hdrToSrc . psnd) m
     p1 <- prog n $ map toState sm ++ map toState fm
@@ -682,13 +681,13 @@ instance (Pair p) => InternalStateVar (p CppSrcCode CppHdrCode) where
 
 instance (Pair p) => ClassSym (p CppSrcCode CppHdrCode) where
   type Class (p CppSrcCode CppHdrCode) = Doc
-  buildClass n p s vs fs = pair2Lists vs (map (zoom lensGStoMS) fs) 
-    (buildClass n p (pfst s)) (buildClass n p (psnd s))
+  buildClass n p s vs fs = pair2Lists (map (zoom lensFStoGS) vs) (map (zoom 
+    lensFStoMS) fs) (buildClass n p (pfst s)) (buildClass n p (psnd s))
   enum l ls s = on2StateValues pair (enum l ls $ pfst s) (enum l ls $ psnd s)
-  privClass n p vs fs = pair2Lists vs (map (zoom lensGStoMS) fs) 
-    (privClass n p) (privClass n p)
-  pubClass n p vs fs = pair2Lists vs (map (zoom lensGStoMS) fs) 
-    (pubClass n p) (pubClass n p)
+  privClass n p vs fs = pair2Lists (map (zoom lensFStoGS) vs) (map (zoom 
+    lensFStoMS) fs) (privClass n p) (privClass n p)
+  pubClass n p vs fs = pair2Lists (map (zoom lensFStoGS) vs) (map (zoom 
+    lensFStoMS) fs) (pubClass n p) (pubClass n p)
 
   docClass d c = pair1 c (docClass d) (docClass d)
 
@@ -700,9 +699,8 @@ instance (Pair p) => InternalClass (p CppSrcCode CppHdrCode) where
 
 instance (Pair p) => ModuleSym (p CppSrcCode CppHdrCode) where
   type Module (p CppSrcCode CppHdrCode) = ModData
-  buildModule n l ms cs = pair2Lists (map (zoom lensFStoMS . putAfter 
-    (setCurrMainFunc False)) ms) (map (zoom lensFStoGS) cs) (buildModule n l) 
-    (buildModule n l)
+  buildModule n l ms cs = pair2Lists (map (zoom lensFStoMS) ms) cs 
+    (buildModule n l) (buildModule n l)
   
 instance (Pair p) => InternalMod (p CppSrcCode CppHdrCode) where
   moduleDoc m = moduleDoc $ pfst m
@@ -804,7 +802,7 @@ instance RenderSym CppSrcCode where
   docMod = G.docMod
 
   commentedMod cmnt mod = on3StateValues (\m cmt mn -> if mn then on2CodeValues 
-    commentedModD m cmt else m) mod cmnt (zoom lensFStoGS getCurrMain)
+    commentedModD m cmt else m) mod cmnt getCurrMain
 
 instance InternalFile CppSrcCode where
   top m = on3CodeValues cppstop m (list dynamic_) endStatement
@@ -1286,15 +1284,14 @@ instance MethodSym CppSrcCode where
 
 instance InternalMethod CppSrcCode where
   intMethod m n c s _ t ps b = getPutReturn (setScope (snd $ unCPPSC s) .
-    setParameters (map unCPPSC ps) . if m then over lensMStoGS (setCurrMain m) 
-    . setMain else id) $ on2CodeValues mthd (onCodeValue snd s) (on5CodeValues 
-    (cppsMethod n c) t (onCodeList (paramListDocD . checkParams n) ps) b 
-    blockStart blockEnd)
+    setParameters (map unCPPSC ps) . if m then setCurrMain else id) $ 
+    on2CodeValues mthd (onCodeValue snd s) (on5CodeValues (cppsMethod n c) t 
+    (onCodeList (paramListDocD . checkParams n) ps) b blockStart blockEnd)
   intFunc m n s _ t ps b = getPutReturn (setScope (snd $ unCPPSC s) . 
-    setParameters (map unCPPSC ps) . if m then setCurrMainFunc m . over
-    lensMStoGS (setCurrMain m) . setMain else id) $ on2CodeValues mthd 
-    (onCodeValue snd s) (on5CodeValues (cppsFunction n) t (onCodeList 
-    (paramListDocD . checkParams n) ps) b blockStart blockEnd)
+    setParameters (map unCPPSC ps) . if m then setCurrMainFunc m . setCurrMain 
+    else id) $ on2CodeValues mthd (onCodeValue snd s) (on5CodeValues 
+    (cppsFunction n) t (onCodeList (paramListDocD . checkParams n) ps) b 
+    blockStart blockEnd)
   commentedFunc = cppCommentedFunc Source
  
   methodDoc = mthdDoc . unCPPSC
@@ -1319,8 +1316,8 @@ instance InternalStateVar CppSrcCode where
 
 instance ClassSym CppSrcCode where
   type Class CppSrcCode = Doc
-  buildClass n _ _ vs fs = on2StateLists (on2CodeLists cppsClass) vs
-    (map (zoom lensGStoMS) $ fs ++ [destructor n vs])
+  buildClass n _ _ vs fs = on2StateLists (on2CodeLists cppsClass) (map (zoom 
+    lensFStoGS) vs) (map (zoom lensFStoMS) $ fs ++ [destructor n vs])
   enum _ _ _ = toState $ toCode empty
   privClass = G.privClass
   pubClass = G.pubClass
@@ -1376,7 +1373,7 @@ instance RenderSym CppHdrCode where
   docMod = G.docMod
 
   commentedMod cmnt mod = on3StateValues (\m cmt mn -> if mn then m else 
-    on2CodeValues commentedModD m cmt) mod cmnt (zoom lensFStoGS getCurrMain)
+    on2CodeValues commentedModD m cmt) mod cmnt getCurrMain
 
 instance InternalFile CppHdrCode where
   top m = on3CodeValues cpphtop m (list dynamic_) endStatement
@@ -1820,10 +1817,9 @@ instance MethodSym CppHdrCode where
 
 instance InternalMethod CppHdrCode where
   intMethod m n _ s _ t ps _ = getPutReturn (setScope (snd $ unCPPHC s) . 
-    setParameters (map unCPPHC ps) . if m then over lensMStoGS (setCurrMain m) 
-    . setMain else id) $ on2CodeValues mthd (onCodeValue snd s) (on3CodeValues 
-    (cpphMethod n) t (onCodeList (paramListDocD . checkParams n) ps) 
-    endStatement)
+    setParameters (map unCPPHC ps) . if m then setCurrMain else id) $ 
+    on2CodeValues mthd (onCodeValue snd s) (on3CodeValues (cpphMethod n) t 
+    (onCodeList (paramListDocD . checkParams n) ps) endStatement)
   intFunc = G.intFunc
   commentedFunc = cppCommentedFunc Header
 
@@ -1854,10 +1850,10 @@ instance ClassSym CppHdrCode where
     (cpphClass n) (on2CodeLists (cpphVarsFuncsList Pub) vars funcs) 
     (on2CodeLists (cpphVarsFuncsList Priv) vars funcs) 
     (onCodeValue fst public) (onCodeValue fst private) parent blockStart 
-    blockEnd endStatement) vs fs
+    blockEnd endStatement) (map (zoom lensFStoGS) vs) fs
     where parent = case p of Nothing -> toCode empty
                              Just pn -> inherit pn
-          fs = map (zoom lensGStoMS) $ mths ++ [destructor n vs]
+          fs = map (zoom lensFStoMS) $ mths ++ [destructor n vs]
   enum n es _ = toState $ on4CodeValues (cpphEnum n) (toCode $ enumElementsDocD 
     es enumsEqualInts) blockStart blockEnd endStatement
   privClass = G.privClass

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer/JavaRenderer.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer/JavaRenderer.hs
@@ -65,11 +65,12 @@ import GOOL.Drasil.Data (Terminator(..), FileType(..), FileData(..), fileD,
 import GOOL.Drasil.Helpers (angles, emptyIfNull, toCode, toState, onCodeValue, 
   onStateValue, on2CodeValues, on2StateValues, on3CodeValues, on4CodeValues, 
   on5CodeValues, onCodeList, on1CodeValue1List, checkParams)
-import GOOL.Drasil.State (MS, lensMStoGS, initialState, putAfter, getPutReturn, 
+import GOOL.Drasil.State (MS, lensGStoFS, lensMStoGS, initialState, initialFS, putAfter, getPutReturn, 
   getPutReturnList, addProgNameToPaths, setMain, setCurrMain, setParameters)
 
 import Prelude hiding (break,print,sin,cos,tan,floor,(<>))
 import Control.Lens (over)
+import Control.Lens.Zoom (zoom)
 import Control.Applicative (Applicative)
 import Control.Monad.State (evalState)
 import Text.PrettyPrint.HughesPJ (Doc, text, (<>), (<+>), parens, empty, space, 
@@ -93,14 +94,15 @@ instance Monad JavaCode where
 
 instance ProgramSym JavaCode where
   type Program JavaCode = ProgData
-  prog n fs = getPutReturnList (map (putAfter $ setCurrMain False) fs) 
+  prog n fs = getPutReturnList (map (putAfter (setCurrMain False) . 
+    zoom lensGStoFS) fs) 
     (addProgNameToPaths n) (on1CodeValue1List (\end -> progD n . 
     map (packageDocD n end)) endStatement)
 
 instance RenderSym JavaCode where
   type RenderFile JavaCode = FileData 
-  fileDoc code = G.fileDoc Combined jExt (top $ evalState code initialState) 
-    bottom code
+  fileDoc code = G.fileDoc Combined jExt (top $ evalState code (initialState,
+    initialFS)) bottom code
 
   docMod = G.docMod
 

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer/JavaRenderer.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer/JavaRenderer.hs
@@ -65,11 +65,10 @@ import GOOL.Drasil.Data (Terminator(..), FileType(..), FileData(..), fileD,
 import GOOL.Drasil.Helpers (angles, emptyIfNull, toCode, toState, onCodeValue, 
   onStateValue, on2CodeValues, on2StateValues, on3CodeValues, on4CodeValues, 
   on5CodeValues, onCodeList, on1CodeValue1List, checkParams)
-import GOOL.Drasil.State (MS, lensGStoFS, lensMStoGS, initialState, initialFS, putAfter, getPutReturn, 
-  getPutReturnList, addProgNameToPaths, setMain, setCurrMain, setParameters)
+import GOOL.Drasil.State (MS, lensGStoFS, initialState, initialFS, getPutReturn,
+  getPutReturnList, addProgNameToPaths, setCurrMain, setParameters)
 
 import Prelude hiding (break,print,sin,cos,tan,floor,(<>))
-import Control.Lens (over)
 import Control.Lens.Zoom (zoom)
 import Control.Applicative (Applicative)
 import Control.Monad.State (evalState)
@@ -94,10 +93,8 @@ instance Monad JavaCode where
 
 instance ProgramSym JavaCode where
   type Program JavaCode = ProgData
-  prog n fs = getPutReturnList (map (putAfter (setCurrMain False) . 
-    zoom lensGStoFS) fs) 
-    (addProgNameToPaths n) (on1CodeValue1List (\end -> progD n . 
-    map (packageDocD n end)) endStatement)
+  prog n fs = getPutReturnList (map (zoom lensGStoFS) fs) (addProgNameToPaths n)
+    (on1CodeValue1List (\end -> progD n . map (packageDocD n end)) endStatement)
 
 instance RenderSym JavaCode where
   type RenderFile JavaCode = FileData 
@@ -552,9 +549,8 @@ instance MethodSym JavaCode where
 
 instance InternalMethod JavaCode where
   intMethod m n _ s p t ps b = getPutReturn (setParameters (map unJC ps) . 
-    if m then over lensMStoGS (setCurrMain m) . setMain else id) $ onCodeValue 
-    mthd (on5CodeValues (jMethod n) s p t (onCodeList (paramListDocD . 
-    checkParams n) ps) b)
+    if m then setCurrMain else id) $ onCodeValue mthd (on5CodeValues (jMethod n)
+    s p t (onCodeList (paramListDocD . checkParams n) ps) b)
   intFunc = G.intFunc
   commentedFunc cmt m = on2StateValues (on2CodeValues updateMthdDoc) m 
     (onStateValue (onCodeValue commentedItem) cmt)

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer/LanguagePolymorphic.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer/LanguagePolymorphic.hs
@@ -39,12 +39,12 @@ import GOOL.Drasil.LanguageRenderer (forLabel, addExt, blockDocD, stateVarDocD,
   stateVarListDocD, methodListDocD, enumDocD, enumElementsDocD, moduleDocD, 
   fileDoc', docFuncRepr, commentDocD, commentedItem, functionDox, classDox, 
   moduleDox, getterName, setterName)
-import GOOL.Drasil.State (GS, FS, MS, lensFStoGS, lensFStoMS, lensGStoMS, 
-  hasMain, mainMod, putAfter, getPutReturnFunc2, addFile, setMainMod, 
-  setFilePath, getFilePath, setModuleName, getModuleName, getCurrMain)
+import GOOL.Drasil.State (GS, FS, MS, lensFStoGS, lensFStoMS, currMain, 
+  putAfter, getPutReturnFunc2, addFile, setMainMod, setFilePath, getFilePath, 
+  setModuleName, getModuleName, getCurrMain)
 
 import Prelude hiding (break,print,last,mod,pi,(<>))
-import Data.Maybe (maybeToList, isNothing)
+import Data.Maybe (maybeToList)
 import Control.Lens ((^.), over)
 import Control.Lens.Zoom (zoom)
 import Text.PrettyPrint.HughesPJ (Doc, text, empty, render, (<>), (<+>), parens,
@@ -249,55 +249,52 @@ pubGVar = S.stateVar public static_
 buildClass :: (RenderSym repr) => (Label -> Doc -> Doc -> Doc -> Doc -> Doc) -> 
   (Label -> repr (Keyword repr)) -> Label -> Maybe Label -> repr (Scope repr) 
   -> [GS (repr (StateVar repr))] -> 
-  [MS (repr (Method repr))] -> GS (repr (Class repr))
+  [MS (repr (Method repr))] -> FS (repr (Class repr))
 buildClass f i n p s vs fs = classFromData (on2StateValues (f n parent 
-  (scopeDoc s)) (onStateList (stateVarListDocD . map stateVarDoc) vs) 
-  (onStateList (methodListDocD . map methodDoc) (map (zoom lensGStoMS) fs)))
+  (scopeDoc s)) (onStateList (stateVarListDocD . map stateVarDoc) (map (zoom lensFStoGS) vs)) 
+  (onStateList (methodListDocD . map methodDoc) (map (zoom lensFStoMS) fs)))
   where parent = case p of Nothing -> empty
                            Just pn -> keyDoc $ i pn
 
 enum :: (RenderSym repr) => Label -> [Label] -> repr (Scope repr) -> 
-  GS (repr (Class repr))
+  FS (repr (Class repr))
 enum n es s = classFromData (toState $ enumDocD n (enumElementsDocD es False) 
   (scopeDoc s))
 
 privClass :: (RenderSym repr) => Label -> Maybe Label -> 
   [GS (repr (StateVar repr))] -> 
-  [MS (repr (Method repr))] -> GS (repr (Class repr))
+  [MS (repr (Method repr))] -> FS (repr (Class repr))
 privClass n p = S.buildClass n p private
 
 pubClass :: (RenderSym repr) => Label -> Maybe Label -> 
   [GS (repr (StateVar repr))] -> [MS (repr (Method repr))] -> 
-  GS (repr (Class repr))
+  FS (repr (Class repr))
 pubClass n p = S.buildClass n p public
 
-docClass :: (RenderSym repr) => String -> GS (repr (Class repr))
-  -> GS (repr (Class repr))
+docClass :: (RenderSym repr) => String -> FS (repr (Class repr))
+  -> FS (repr (Class repr))
 docClass d = S.commentedClass (docComment $ toState $ classDox d)
 
-commentedClass :: (RenderSym repr) => GS (repr (BlockComment repr))
-  -> GS (repr (Class repr)) -> GS (repr (Class repr))
+commentedClass :: (RenderSym repr) => FS (repr (BlockComment repr))
+  -> FS (repr (Class repr)) -> FS (repr (Class repr))
 commentedClass cmt cs = classFromData (on2StateValues (\cmt' cs' -> 
   commentedItem (blockCommentDoc cmt') (classDoc cs')) cmt cs)
 
 buildModule :: (RenderSym repr) => Label -> [repr (Keyword repr)] -> 
-  [MS (repr (Method repr))] -> [GS (repr (Class repr))] -> 
+  [MS (repr (Method repr))] -> [FS (repr (Class repr))] -> 
   FS (repr (Module repr))
 buildModule n ls ms cs = S.modFromData n getCurrMain (on2StateValues 
-  (moduleDocD (vcat $ map keyDoc ls)) (onStateList (vibcat . map classDoc) (map 
-  (zoom lensFStoGS) cs)) (onStateList (methodListDocD . map methodDoc) (map 
-  (zoom lensFStoMS) ms)))
+  (moduleDocD (vcat $ map keyDoc ls)) (onStateList (vibcat . map classDoc) cs) 
+  (onStateList (methodListDocD . map methodDoc) (map (zoom lensFStoMS) ms)))
 
 buildModule' :: (RenderSym repr) => Label -> [MS (repr (Method repr))] -> 
-  [GS (repr (Class repr))] -> FS (repr (Module repr))
+  [FS (repr (Class repr))] -> FS (repr (Module repr))
 buildModule' n ms cs = S.modFromData n getCurrMain (onStateList (vibcat . map 
-  classDoc) (map (zoom lensFStoGS) (if null ms then cs else pubClass n 
-  Nothing [] ms : cs)))
+  classDoc) (if null ms then cs else pubClass n Nothing [] ms : cs))
 
-modFromData :: Label -> (Doc -> Bool -> repr (Module repr)) -> GS Bool -> 
+modFromData :: Label -> (Doc -> Bool -> repr (Module repr)) -> FS Bool -> 
   FS Doc -> FS (repr (Module repr))
-modFromData n f m d = putAfter (setModuleName n) (on2StateValues f d (zoom   
-  lensFStoGS m))
+modFromData n f m d = putAfter (setModuleName n) (on2StateValues f d m)
 
 fileDoc :: (RenderSym repr) => FileType -> String -> repr (Block repr) -> 
   repr (Block repr) -> FS (repr (Module repr)) -> FS (repr (RenderFile repr))
@@ -313,5 +310,4 @@ fileFromData :: (RenderSym repr) => (repr (Module repr) -> FilePath ->
   repr (RenderFile repr)) -> FileType -> FS FilePath -> 
   FS (repr (Module repr)) -> FS (repr (RenderFile repr))
 fileFromData f ft fp m = getPutReturnFunc2 m fp (\s mdl fpath -> (if isEmpty 
-  (moduleDoc mdl) then id else (if fst s ^. hasMain && isNothing (fst s ^. 
-  mainMod) then over lensFStoGS (setMainMod fpath) else id) . over lensFStoGS (addFile ft fpath) . setFilePath fpath) s) f
+  (moduleDoc mdl) then id else (if snd s ^. currMain then over lensFStoGS (setMainMod fpath) else id) . over lensFStoGS (addFile ft fpath) . setFilePath fpath) s) f

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer/PythonRenderer.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer/PythonRenderer.hs
@@ -60,12 +60,13 @@ import GOOL.Drasil.Helpers (emptyIfEmpty, toCode, toState, onCodeValue,
   onStateValue, on2CodeValues, on2StateValues, on3CodeValues, on4CodeValues, 
   on5CodeValues, on6CodeValues, onCodeList, onStateList, on1CodeValue1List, 
   on2CodeLists, checkParams)
-import GOOL.Drasil.State (MS, lensMStoGS, initialState, putAfter, getPutReturn, 
+import GOOL.Drasil.State (MS, lensGStoFS, lensMStoGS, initialState, initialFS, putAfter, getPutReturn, 
   setMain, setCurrMain, setParameters)
 
 import Prelude hiding (break,print,sin,cos,tan,floor,(<>))
 import Data.Maybe (fromMaybe)
 import Control.Lens (over)
+import Control.Lens.Zoom (zoom)
 import Control.Applicative (Applicative)
 import Control.Monad.State (evalState)
 import Text.PrettyPrint.HughesPJ (Doc, text, (<>), (<+>), parens, empty, equals,
@@ -89,14 +90,14 @@ instance Monad PythonCode where
 
 instance ProgramSym PythonCode where
   type Program PythonCode = ProgData 
-  prog n = onStateList (onCodeList (progD n)) . map (putAfter $ setCurrMain 
-    False)
+  prog n = onStateList (onCodeList (progD n)) . map (putAfter (setCurrMain 
+    False) . zoom lensGStoFS)
 
 instance RenderSym PythonCode where
   type RenderFile PythonCode = FileData
   -- temporary evalState until I add more state
-  fileDoc code = G.fileDoc Combined pyExt (top $ evalState code initialState)
-    bottom code
+  fileDoc code = G.fileDoc Combined pyExt (top $ evalState code 
+    (initialState, initialFS)) bottom code
 
   docMod = G.docMod
 

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer/PythonRenderer.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer/PythonRenderer.hs
@@ -60,12 +60,11 @@ import GOOL.Drasil.Helpers (emptyIfEmpty, toCode, toState, onCodeValue,
   onStateValue, on2CodeValues, on2StateValues, on3CodeValues, on4CodeValues, 
   on5CodeValues, on6CodeValues, onCodeList, onStateList, on1CodeValue1List, 
   on2CodeLists, checkParams)
-import GOOL.Drasil.State (MS, lensGStoFS, lensMStoGS, initialState, initialFS, putAfter, getPutReturn, 
-  setMain, setCurrMain, setParameters)
+import GOOL.Drasil.State (MS, lensGStoFS, initialState, initialFS, getPutReturn,
+  setCurrMain, setParameters)
 
 import Prelude hiding (break,print,sin,cos,tan,floor,(<>))
 import Data.Maybe (fromMaybe)
-import Control.Lens (over)
 import Control.Lens.Zoom (zoom)
 import Control.Applicative (Applicative)
 import Control.Monad.State (evalState)
@@ -90,8 +89,7 @@ instance Monad PythonCode where
 
 instance ProgramSym PythonCode where
   type Program PythonCode = ProgData 
-  prog n = onStateList (onCodeList (progD n)) . map (putAfter (setCurrMain 
-    False) . zoom lensGStoFS)
+  prog n = onStateList (onCodeList (progD n)) . map (zoom lensGStoFS)
 
 instance RenderSym PythonCode where
   type RenderFile PythonCode = FileData
@@ -546,8 +544,8 @@ instance MethodSym PythonCode where
   docMain = mainFunction
 
   function = G.function
-  mainFunction = getPutReturn (setParameters [] . over lensMStoGS (setCurrMain 
-    True) . setMain) . onCodeValue mthd
+  mainFunction = getPutReturn (setParameters [] . setCurrMain) . onCodeValue 
+    mthd
 
   docFunc = G.docFunc
 
@@ -561,13 +559,11 @@ instance MethodSym PythonCode where
 
 instance InternalMethod PythonCode where
   intMethod m n l _ _ _ ps b = getPutReturn (setParameters (map unPC ps) . 
-    if m then over lensMStoGS (setCurrMain m) . setMain else id) $ onCodeValue 
-    mthd (on3CodeValues (pyMethod n) (self l) (onCodeList (paramListDocD . 
-    checkParams n) ps) b)
+    if m then setCurrMain else id) $ onCodeValue mthd (on3CodeValues (pyMethod 
+    n) (self l) (onCodeList (paramListDocD . checkParams n) ps) b)
   intFunc m n _ _ _ ps b = getPutReturn (setParameters (map unPC ps) . 
-    if m then over lensMStoGS (setCurrMain m) . setMain else id) $ onCodeValue 
-    mthd (on2CodeValues (pyFunction n) (onCodeList (paramListDocD . checkParams 
-    n) ps) b)
+    if m then setCurrMain else id) $ onCodeValue mthd (on2CodeValues 
+    (pyFunction n) (onCodeList (paramListDocD . checkParams n) ps) b)
   commentedFunc cmt m = on2StateValues (on2CodeValues updateMthdDoc) m 
     (onStateValue (onCodeValue commentedItem) cmt)
 

--- a/code/drasil-gool/GOOL/Drasil/Symantics.hs
+++ b/code/drasil-gool/GOOL/Drasil/Symantics.hs
@@ -19,7 +19,7 @@ module GOOL.Drasil.Symantics (
 
 import GOOL.Drasil.CodeType (CodeType)
 import GOOL.Drasil.Data (Binding, Terminator, FileType, ScopeTag)
-import GOOL.Drasil.State (GS, MS)
+import GOOL.Drasil.State (GS, FS, MS)
 
 import Control.Monad.State (State)
 import Text.PrettyPrint.HughesPJ (Doc)
@@ -29,30 +29,30 @@ type Library = String
 
 class (RenderSym repr) => ProgramSym repr where
   type Program repr
-  prog :: Label -> [GS (repr (RenderFile repr))] -> 
+  prog :: Label -> [FS (repr (RenderFile repr))] -> 
     GS (repr (Program repr))
 
 class (ModuleSym repr, InternalFile repr) => 
   RenderSym repr where 
   type RenderFile repr
-  fileDoc :: GS (repr (Module repr)) -> 
-    GS (repr (RenderFile repr))
+  fileDoc :: FS (repr (Module repr)) -> 
+    FS (repr (RenderFile repr))
 
   -- Module description, list of author names, date as a String, file to comment
   docMod :: String -> [String] -> String -> 
-    GS (repr (RenderFile repr)) -> 
-    GS (repr (RenderFile repr))
+    FS (repr (RenderFile repr)) -> 
+    FS (repr (RenderFile repr))
 
-  commentedMod :: GS (repr (BlockComment repr)) -> GS (repr (RenderFile repr)) 
-    -> GS (repr (RenderFile repr))
+  commentedMod :: FS (repr (BlockComment repr)) -> FS (repr (RenderFile repr)) 
+    -> FS (repr (RenderFile repr))
 
 class InternalFile repr where
   top :: repr (Module repr) -> repr (Block repr)
   bottom :: repr (Block repr)
 
-  fileFromData :: FileType -> GS FilePath -> 
-    GS (repr (Module repr)) -> 
-    GS (repr (RenderFile repr))
+  fileFromData :: FileType -> FS FilePath -> 
+    FS (repr (Module repr)) -> 
+    FS (repr (RenderFile repr))
 
 class (PermanenceSym repr) => KeywordSym repr where
   type Keyword repr
@@ -678,13 +678,13 @@ class InternalClass repr where
 class (ClassSym repr, InternalMod repr) => ModuleSym repr where
   type Module repr
   buildModule :: Label -> [Library] -> [MS (repr (Method repr))] -> 
-    [GS (repr (Class repr))] -> GS (repr (Module repr))
+    [GS (repr (Class repr))] -> FS (repr (Module repr))
 
 class InternalMod repr where
   moduleDoc :: repr (Module repr) -> Doc
-  modFromData :: String -> GS Bool -> GS Doc -> GS (repr (Module repr))
-  updateModuleDoc :: (Doc -> Doc) -> GS (repr (Module repr)) -> 
-    GS (repr (Module repr))
+  modFromData :: String -> GS Bool -> FS Doc -> FS (repr (Module repr))
+  updateModuleDoc :: (Doc -> Doc) -> FS (repr (Module repr)) -> 
+    FS (repr (Module repr))
     
 class BlockCommentSym repr where
   type BlockComment repr

--- a/code/drasil-gool/GOOL/Drasil/Symantics.hs
+++ b/code/drasil-gool/GOOL/Drasil/Symantics.hs
@@ -655,34 +655,34 @@ class (MethodSym repr, InternalClass repr) => ClassSym repr
   buildClass :: Label -> Maybe Label -> repr (Scope repr) -> 
     [GS (repr (StateVar repr))] -> 
     [MS (repr (Method repr))] -> 
-    GS (repr (Class repr))
+    FS (repr (Class repr))
   enum :: Label -> [Label] -> repr (Scope repr) -> 
-    GS (repr (Class repr))
+    FS (repr (Class repr))
   privClass :: Label -> Maybe Label -> [GS (repr (StateVar repr))] 
     -> [MS (repr (Method repr))] -> 
-    GS (repr (Class repr))
+    FS (repr (Class repr))
   pubClass :: Label -> Maybe Label -> [GS (repr (StateVar repr))] 
     -> [MS (repr (Method repr))] -> 
-    GS (repr (Class repr))
+    FS (repr (Class repr))
 
-  docClass :: String -> GS (repr (Class repr)) ->
-    GS (repr (Class repr))
+  docClass :: String -> FS (repr (Class repr)) ->
+    FS (repr (Class repr))
 
-  commentedClass :: GS (repr (BlockComment repr)) -> 
-    GS (repr (Class repr)) -> GS (repr (Class repr))
+  commentedClass :: FS (repr (BlockComment repr)) -> 
+    FS (repr (Class repr)) -> FS (repr (Class repr))
 
 class InternalClass repr where
   classDoc :: repr (Class repr) -> Doc
-  classFromData :: GS Doc -> GS (repr (Class repr))
+  classFromData :: FS Doc -> FS (repr (Class repr))
 
 class (ClassSym repr, InternalMod repr) => ModuleSym repr where
   type Module repr
   buildModule :: Label -> [Library] -> [MS (repr (Method repr))] -> 
-    [GS (repr (Class repr))] -> FS (repr (Module repr))
+    [FS (repr (Class repr))] -> FS (repr (Module repr))
 
 class InternalMod repr where
   moduleDoc :: repr (Module repr) -> Doc
-  modFromData :: String -> GS Bool -> FS Doc -> FS (repr (Module repr))
+  modFromData :: String -> FS Bool -> FS Doc -> FS (repr (Module repr))
   updateModuleDoc :: (Doc -> Doc) -> FS (repr (Module repr)) -> 
     FS (repr (Module repr))
     

--- a/code/drasil-gool/Test/Helper.hs
+++ b/code/drasil-gool/Test/Helper.hs
@@ -3,10 +3,10 @@ module Test.Helper (helper) where
 import GOOL.Drasil (
   RenderSym(..), PermanenceSym(..), BodySym(..), TypeSym(..), 
   StatementSym(..), VariableSym(..), ValueSym(..), NumericExpression(..), 
-  ScopeSym(..), ParameterSym(..), MethodSym(..), ModuleSym(..), GS, MS)
+  ScopeSym(..), ParameterSym(..), MethodSym(..), ModuleSym(..), FS, MS)
 import Prelude hiding (return,print,log,exp,sin,cos,tan)
 
-helper :: (RenderSym repr) => GS (repr (RenderFile repr))
+helper :: (RenderSym repr) => FS (repr (RenderFile repr))
 helper = fileDoc (buildModule "Helper" [] [doubleAndAdd] [])
 
 doubleAndAdd :: (RenderSym repr) => MS (repr (Method repr))

--- a/code/drasil-gool/Test/Observer.hs
+++ b/code/drasil-gool/Test/Observer.hs
@@ -3,7 +3,7 @@ module Test.Observer (observer, observerName, printNum, x) where
 import GOOL.Drasil (
   RenderSym(..), PermanenceSym(..), BodySym(..), TypeSym(..), 
   StatementSym(..), VariableSym(..), ValueSym(..), ScopeSym(..), 
-  MethodSym(..), StateVarSym(..), ClassSym(..), ModuleSym(..), GS, FS, MS)
+  MethodSym(..), StateVarSym(..), ClassSym(..), ModuleSym(..), FS, MS)
 import Prelude hiding (return,print,log,exp,sin,cos,tan)
 
 observerName, observerDesc, printNum :: String

--- a/code/drasil-gool/Test/Observer.hs
+++ b/code/drasil-gool/Test/Observer.hs
@@ -21,7 +21,7 @@ x = var "x" int
 selfX :: (VariableSym repr) => repr (Variable repr)
 selfX = objVarSelf observerName x
 
-helperClass :: (ClassSym repr) => GS (repr (Class repr))
+helperClass :: (ClassSym repr) => FS (repr (Class repr))
 helperClass = pubClass observerName Nothing [stateVar public dynamic_ x]
   [observerConstructor, printNumMethod, getMethod observerName x, 
   setMethod observerName x]

--- a/code/drasil-gool/Test/Observer.hs
+++ b/code/drasil-gool/Test/Observer.hs
@@ -3,7 +3,7 @@ module Test.Observer (observer, observerName, printNum, x) where
 import GOOL.Drasil (
   RenderSym(..), PermanenceSym(..), BodySym(..), TypeSym(..), 
   StatementSym(..), VariableSym(..), ValueSym(..), ScopeSym(..), 
-  MethodSym(..), StateVarSym(..), ClassSym(..), ModuleSym(..), GS, MS)
+  MethodSym(..), StateVarSym(..), ClassSym(..), ModuleSym(..), GS, FS, MS)
 import Prelude hiding (return,print,log,exp,sin,cos,tan)
 
 observerName, observerDesc, printNum :: String
@@ -11,7 +11,7 @@ observerName = "Observer"
 observerDesc = "This is an arbitrary class acting as an Observer"
 printNum = "printNum"
 
-observer :: (RenderSym repr) => GS (repr (RenderFile repr))
+observer :: (RenderSym repr) => FS (repr (RenderFile repr))
 observer = fileDoc (buildModule observerName [] [] [docClass observerDesc
   helperClass])
 


### PR DESCRIPTION
This PR splits some more state off of `GOOLState` into a new local state type, `FileState`. `GOOLState` now contains only fields that apply globally to the `Program`, all local state has been separated.

