### PR TITLE
Update functions to reduce amount of lifting in GOOL's renderers

### DIFF
--- a/code/drasil-gool/GOOL/Drasil/Helpers.hs
+++ b/code/drasil-gool/GOOL/Drasil/Helpers.hs
@@ -2,8 +2,7 @@ module GOOL.Drasil.Helpers (verticalComma, angles, doubleQuotedText, himap,
   hicat, vicat, vibcat, vmap, vimap, vibmap, emptyIfEmpty, emptyIfNull, 
   mapPairFst, mapPairSnd, toCode, toState, onCodeValue, onStateValue, 
   on2CodeValues, on2StateValues, on3CodeValues, on3StateValues, on4CodeValues, 
-  on5CodeValues, on6CodeValues, on7CodeValues, on8CodeValues, onCodeList, 
-  onStateList, on2CodeLists, on2StateLists, on1CodeValue1List, 
+  on5CodeValues, onCodeList, onStateList, on2StateLists, on1CodeValue1List, 
   on1StateValue1List, getInnerType, getNestDegree, convType, checkParams
 ) where
 
@@ -99,27 +98,11 @@ on5CodeValues :: Applicative f => (a -> b -> c -> d -> e -> g) -> f a -> f b ->
   f c -> f d -> f e -> f g
 on5CodeValues f a1 a2 a3 a4 a5 = on4CodeValues f a1 a2 a3 a4 <*> a5
 
-on6CodeValues :: Applicative f => (a -> b -> c -> d -> e -> g -> h) -> f a -> f 
-  b -> f c -> f d -> f e -> f g -> f h
-on6CodeValues f a1 a2 a3 a4 a5 a6 = on5CodeValues f a1 a2 a3 a4 a5 <*> a6
-
-on7CodeValues :: Applicative f => (a -> b -> c -> d -> e -> g -> h -> i) -> f a 
-  -> f b -> f c -> f d -> f e -> f g -> f h -> f i
-on7CodeValues f a1 a2 a3 a4 a5 a6 a7 = on6CodeValues f a1 a2 a3 a4 a5 a6 <*> a7
-
-on8CodeValues :: Applicative f => (a -> b -> c -> d -> e -> g -> h -> i -> j) 
-  -> f a -> f b -> f c -> f d -> f e -> f g -> f h -> f i -> f j
-on8CodeValues f a1 a2 a3 a4 a5 a6 a7 a8 = on7CodeValues f a1 a2 a3 a4 a5 a6 a7 
-  <*> a8
-
 onCodeList :: Monad m => ([a] -> b) -> [m a] -> m b
 onCodeList f as = f <$> sequence as
 
 onStateList :: ([a] -> b) -> [State s a] -> State s b
 onStateList f as = f <$> sequence as
-
-on2CodeLists :: Monad m => ([a] -> [b] -> c) -> [m a] -> [m b] -> m c
-on2CodeLists f as bs = liftA2 f (sequence as) (sequence bs)
 
 on2StateLists :: ([a] -> [b] -> c) -> [State s a] -> [State s b] -> State s c
 on2StateLists f as bs = liftM2 f (sequence as) (sequence bs)

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer.hs
@@ -219,8 +219,8 @@ outDoc newLn printFn v f = outDoc' (getType $ valueType v)
         prStrFn = maybe printStr printFileStr f
         prLnFn = if newLn then maybe printStrLn printFileStrLn f else maybe printStr printFileStr f 
 
-printFileDocD :: Label -> ValData -> Doc
-printFileDocD fn f = valDoc f <> dot <> text fn
+printFileDocD :: Label -> Doc -> Doc
+printFileDocD fn f = f <> dot <> text fn
 
 -- Type Printers --
 
@@ -777,8 +777,8 @@ typeBinExpr :: OpData -> TypeData -> ValData -> ValData -> ValData
 typeBinExpr b t v1 v2 = mkExpr (opPrec b) t (binOpDocD (opDoc b) (exprParensL b 
   v1 $ valDoc v1) (exprParensR b v2 $ valDoc v2))
 
-mkVal :: TypeData -> Doc -> ValData
-mkVal = vd Nothing
+mkVal :: (RenderSym repr) => repr (Type repr) -> Doc -> repr (Value repr)
+mkVal = valFromData Nothing
 
 mkVar :: String -> TypeData -> Doc -> VarData
 mkVar = vard Dynamic
@@ -958,8 +958,8 @@ indexOfD f l v = objAccess l (func f S.int [v])
 funcDocD :: Doc -> Doc
 funcDocD fnApp = dot <> fnApp
 
-castDocD :: TypeData -> Doc
-castDocD t = parens $ typeDoc t
+castDocD :: Doc -> Doc
+castDocD = parens
 
 listAccessFuncDocD :: (RenderSym repr) => repr (Value repr) -> Doc
 listAccessFuncDocD v = brackets $ valueDoc v
@@ -970,8 +970,8 @@ listSetFuncDocD i v = brackets i <+> equals <+> v
 objAccessDocD :: Doc -> Doc -> Doc
 objAccessDocD v f = v <> f
 
-castObjDocD :: Doc -> ValData -> Doc
-castObjDocD t v = t <> parens (valDoc v)
+castObjDocD :: Doc -> Doc -> Doc
+castObjDocD t v = t <> parens v
 
 funcD :: (RenderSym repr) => Label -> repr (Type repr) -> [repr (Value repr)] 
   -> repr (Function repr)

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer.hs
@@ -780,7 +780,8 @@ typeBinExpr b t v1 v2 = mkExpr (opPrec b) t (binOpDocD (opDoc b) (exprParensL b
 mkVal :: (RenderSym repr) => repr (Type repr) -> Doc -> repr (Value repr)
 mkVal = valFromData Nothing
 
-mkVar :: String -> TypeData -> Doc -> VarData
+mkVar :: (RenderSym repr) => String -> repr (Type repr) -> Doc -> 
+  repr (Variable repr)
 mkVar = vard Dynamic
 
 mkStaticVar :: String -> TypeData -> Doc -> VarData

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer.hs
@@ -46,9 +46,9 @@ module GOOL.Drasil.LanguageRenderer (
   iterEndError, listAccessFuncD, listAccessFuncD', listSetFuncD, includeD, 
   breakDocD, continueDocD, staticDocD, dynamicDocD, bindingError, privateDocD, 
   publicDocD, blockCmtDoc, docCmtDoc, commentedItem, addCommentsDocD, 
-  functionDox, classDox, moduleDox, commentedModD, docFuncRepr, valList, 
-  valueList, prependToBody, appendToBody, surroundBody, getterName, setterName, 
-  setEmpty, intValue, filterOutObjs
+  functionDox, classDox, moduleDox, commentedModD, docFuncRepr, 
+  valueList, variableList, prependToBody, appendToBody, surroundBody, 
+  getterName, setterName, setEmpty, intValue, filterOutObjs
 ) where
 
 import Utils.Drasil (blank, capitalize, indent, indentList, stringList)
@@ -375,8 +375,9 @@ assignDocD :: (RenderSym repr) => repr (Variable repr) -> repr (Value repr) ->
   Doc
 assignDocD vr vl = variableDoc vr <+> equals <+> valueDoc vl
 
-multiAssignDoc :: [VarData] -> [ValData] -> Doc
-multiAssignDoc vrs vls = varList vrs <+> equals <+> valList vls
+multiAssignDoc :: (RenderSym repr) => [repr (Variable repr)] -> 
+  [repr (Value repr)] -> Doc
+multiAssignDoc vrs vls = variableList vrs <+> equals <+> valueList vls
 
 plusEqualsDocD :: (RenderSym repr) => repr (Variable repr) -> repr (Value repr) 
   -> Doc
@@ -427,8 +428,8 @@ getTermDoc Empty = empty
 mkSt :: Doc -> (Doc, Terminator)
 mkSt s = (s, Semi)
 
-mkStNoEnd :: Doc -> (Doc, Terminator)
-mkStNoEnd s = (s, Empty)
+mkStNoEnd :: (RenderSym repr) => Doc -> repr (Statement repr)
+mkStNoEnd = flip stateFromData Empty
 
 stringListVals' :: (RenderSym repr) => [repr (Variable repr)] -> 
   repr (Value repr) -> repr (Statement repr)
@@ -782,7 +783,7 @@ mkVal = valFromData Nothing
 
 mkVar :: (RenderSym repr) => String -> repr (Type repr) -> Doc -> 
   repr (Variable repr)
-mkVar = vard Dynamic
+mkVar = varFromData Dynamic
 
 mkStaticVar :: String -> TypeData -> Doc -> VarData
 mkStaticVar = vard Static
@@ -1142,14 +1143,11 @@ docFuncRepr desc pComms rComms = commentedFunc (docComment $ onStateValue
 
 -- Helper Functions --
 
-valList :: [ValData] -> Doc
-valList vs = hcat (intersperse (text ", ") (map valDoc vs))
-
 valueList :: (RenderSym repr) => [repr (Value repr)] -> Doc
 valueList vs = hcat (intersperse (text ", ") (map valueDoc vs))
 
-varList :: [VarData] -> Doc
-varList vs = hcat (intersperse (text ", ") (map varDoc vs))
+variableList :: (RenderSym repr) => [repr (Variable repr)] -> Doc
+variableList vs = hcat (intersperse (text ", ") (map variableDoc vs))
 
 prependToBody :: (Doc, Terminator) -> Doc -> Doc
 prependToBody s b = vcat [fst $ statementDocD s, maybeBlank, b]

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer.hs
@@ -20,7 +20,7 @@ module GOOL.Drasil.LanguageRenderer (
   emptyStateD, assignD, assignToListIndexD, multiAssignError, decrementD, 
   incrementD, decrement1D, increment1D, constDecDefD, discardInputD,
   discardFileInputD, openFileRD, openFileWD, openFileAD, closeFileD, 
-  discardFileLineD, breakD, continueD, returnD, multiReturnError, valStateD, 
+  discardFileLineD, returnD, multiReturnError, valStateD, 
   freeError, throwD, initStateD, changeStateD, initObserverListD, addObserverD, 
   ifNoElseD, switchD, switchAsIfD, ifExistsD, forRangeD, tryCatchD, stratDocD, 
   runStrategyD, listSliceD, checkStateD, notifyObserversD, unOpPrec, notOpDocD, 
@@ -415,8 +415,8 @@ returnDocD vs = text "return" <+> valueList vs
 commentDocD :: Label -> Doc -> Doc
 commentDocD cmt cStart = cStart <+> text cmt
 
-freeDocD :: VarData -> Doc
-freeDocD v = text "delete" <+> text "&" <> varDoc v
+freeDocD :: (RenderSym repr) => repr (Variable repr) -> Doc
+freeDocD v = text "delete" <+> text "&" <> variableDoc v
 
 statementDocD :: (Doc, Terminator) -> (Doc, Terminator)
 statementDocD (s, t) = (s <> getTermDoc t, Empty)
@@ -425,8 +425,8 @@ getTermDoc :: Terminator -> Doc
 getTermDoc Semi = semi
 getTermDoc Empty = empty
 
-mkSt :: Doc -> (Doc, Terminator)
-mkSt s = (s, Semi)
+mkSt :: (RenderSym repr) => Doc -> repr (Statement repr)
+mkSt = flip stateFromData Semi
 
 mkStNoEnd :: (RenderSym repr) => Doc -> repr (Statement repr)
 mkStNoEnd = flip stateFromData Empty
@@ -534,12 +534,6 @@ closeFileD n f = valState $ objMethodCallNoParams void f n
 discardFileLineD :: (RenderSym repr) => Label -> repr (Value repr) -> 
   repr (Statement repr)
 discardFileLineD n f = valState $ objMethodCallNoParams string f n 
-
-breakD :: (RenderSym repr) => Terminator -> repr (Statement repr)
-breakD = stateFromData breakDocD
-
-continueD :: (RenderSym repr) => Terminator -> repr (Statement repr)
-continueD = stateFromData continueDocD
 
 returnD :: (RenderSym repr) => Terminator -> repr (Value repr) -> 
   repr (Statement repr)

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer.hs
@@ -9,16 +9,13 @@ module GOOL.Drasil.LanguageRenderer (
   -- * Default Functions available for use in renderers
   packageDocD, fileDoc', moduleDocD, classDocD, enumDocD, enumElementsDocD, 
   enumElementsDocD', multiStateDocD, blockDocD, bodyDocD, oneLinerD, outDoc, 
-  printDoc, printFileDocD, boolTypeDocD, intTypeDocD, floatTypeDocD, 
-  charTypeDocD, stringTypeDocD, fileTypeDocD, typeDocD, enumTypeDocD, 
-  listTypeDocD, listInnerTypeD, voidDocD, destructorError, paramDocD, 
-  paramListDocD, mkParam, methodDocD, methodListDocD, stateVarDocD, 
-  constVarDocD, stateVarListDocD, switchDocD, assignDocD, multiAssignDoc, 
-  plusEqualsDocD, plusPlusDocD, listDecDocD, 
-  listDecDefDocD, statementDocD, returnDocD, commentDocD, freeDocD, mkSt, 
-  mkStNoEnd, stringListVals', stringListLists', printStD, stateD, loopStateD, 
-  emptyStateD, assignD, assignToListIndexD, multiAssignError, decrementD, 
-  incrementD, decrement1D, increment1D, constDecDefD, discardInputD,
+  printDoc, printFileDocD, destructorError, paramDocD, paramListDocD, mkParam, 
+  methodDocD, methodListDocD, stateVarDocD, constVarDocD, stateVarListDocD, 
+  switchDocD, assignDocD, multiAssignDoc, plusEqualsDocD, plusPlusDocD, 
+  listDecDocD, listDecDefDocD, statementDocD, returnDocD, commentDocD, freeDocD,
+  mkSt, mkStNoEnd, stringListVals', stringListLists', printStD, stateD, 
+  loopStateD, emptyStateD, assignD, assignToListIndexD, multiAssignError, 
+  decrementD, incrementD, decrement1D, increment1D, constDecDefD, discardInputD,
   discardFileInputD, openFileRD, openFileWD, openFileAD, closeFileD, 
   discardFileLineD, returnD, multiReturnError, valStateD, 
   freeError, throwD, initStateD, changeStateD, initObserverListD, addObserverD, 
@@ -66,11 +63,10 @@ import GOOL.Drasil.Symantics (Label, Library, RenderSym(..), BodySym(..),
   MethodSym(..), InternalMethod(..), BlockCommentSym(..))
 import qualified GOOL.Drasil.Symantics as S (TypeSym(char, int))
 import GOOL.Drasil.Data (Terminator(..), FileData(..), fileD, updateFileMod, 
-  updateModDoc, OpData(..), od, ParamData(..), pd, paramName, TypeData(..), td, 
+  updateModDoc, OpData(..), od, ParamData(..), pd, paramName, TypeData(..), 
   Binding(..), VarData(..))
-import GOOL.Drasil.Helpers (angles, doubleQuotedText, hicat, vibcat, vmap, 
-  emptyIfEmpty, emptyIfNull, onStateValue, getInnerType, getNestDegree, 
-  convType)
+import GOOL.Drasil.Helpers (doubleQuotedText, hicat, vibcat, vmap, 
+  emptyIfEmpty, emptyIfNull, onStateValue, getNestDegree)
 import GOOL.Drasil.State (MS, getParameters)
 
 import Data.List (intersperse, last)
@@ -222,47 +218,6 @@ outDoc newLn printFn v f = outDoc' (getType $ valueType v)
 printFileDocD :: Label -> Doc -> Doc
 printFileDocD fn f = f <> dot <> text fn
 
--- Type Printers --
-
-boolTypeDocD :: TypeData
-boolTypeDocD = td Boolean "Boolean" (text "Boolean") -- capital B?
-
-intTypeDocD :: TypeData
-intTypeDocD = td Integer "int" (text "int")
-
-floatTypeDocD :: TypeData
-floatTypeDocD = td Float "float" (text "float")
-
-charTypeDocD :: TypeData
-charTypeDocD = td Char "char" (text "char")
-
-stringTypeDocD :: TypeData
-stringTypeDocD = td String "string" (text "string")
-
-fileTypeDocD :: TypeData
-fileTypeDocD = td File "File" (text "File")
-
-typeDocD :: Label -> TypeData
-typeDocD t = td (Object t) t (text t)
-
-enumTypeDocD :: Label -> TypeData
-enumTypeDocD t = td (Enum t) t (text t)
-
-listTypeDocD :: TypeData -> Doc -> TypeData
-listTypeDocD t lst = td (List (cType t)) 
-  (render lst ++ "<" ++ typeString t ++ ">") (lst <> angles (typeDoc t))
-
-listInnerTypeD :: (RenderSym repr) => repr (Type repr) -> repr (Type repr)
-listInnerTypeD = convType . getInnerType . getType
-
--- Method Types --
-
-voidDocD :: TypeData
-voidDocD = td Void "void" (text "void")
-
-destructorError :: String -> String
-destructorError l = "Destructors not allowed in " ++ l
-
 -- Parameters --
 
 paramDocD :: VarData -> Doc
@@ -285,6 +240,9 @@ methodDocD n s p t ps b = vcat [
 methodListDocD :: [Doc] -> Doc
 methodListDocD ms = vibcat methods
   where methods = filter (not . isEmpty) ms
+  
+destructorError :: String -> String
+destructorError l = "Destructors not allowed in " ++ l
 
 -- StateVar --
 

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer.hs
@@ -34,7 +34,7 @@ module GOOL.Drasil.LanguageRenderer (
   binOpDocD, binOpDocD', binExpr, binExpr', typeBinExpr, mkVal, mkVar,
   mkStaticVar, litTrueD, litFalseD, litCharD, litFloatD, litIntD, litStringD, 
   varDocD, extVarDocD, selfDocD, argDocD, enumElemDocD, classVarCheckStatic, 
-  classVarDocD, objVarDocD, inlineIfD, funcAppDocD, newObjDocD, newObjDocD', 
+  classVarDocD, objVarDocD, funcAppDocD, newObjDocD, newObjDocD', 
   constDecDefDocD, varD, staticVarD, extVarD, selfD, enumVarD, classVarD, 
   objVarD, objVarSelfD, listVarD, listOfD, iterVarD, valueOfD, argD, 
   enumElementD, argsListD, funcAppD, selfFuncAppD, extFuncAppD, newObjD, 
@@ -67,13 +67,12 @@ import GOOL.Drasil.Symantics (Label, Library, RenderSym(..), BodySym(..),
 import qualified GOOL.Drasil.Symantics as S (TypeSym(char, int))
 import GOOL.Drasil.Data (Terminator(..), FileData(..), fileD, updateFileMod, 
   updateModDoc, OpData(..), od, ParamData(..), pd, paramName, TypeData(..), td, 
-  ValData(..), vd, Binding(..), VarData(..))
+  Binding(..), VarData(..))
 import GOOL.Drasil.Helpers (angles, doubleQuotedText, hicat, vibcat, vmap, 
   emptyIfEmpty, emptyIfNull, onStateValue, getInnerType, getNestDegree, 
   convType)
 import GOOL.Drasil.State (MS, getParameters)
 
-import Control.Applicative ((<|>))
 import Data.List (intersperse, last)
 import Data.Bifunctor (first)
 import Data.Map as Map (lookup, fromList)
@@ -837,11 +836,6 @@ classVarDocD c v = c <> dot <> v
 
 objVarDocD :: Doc -> Doc ->  Doc
 objVarDocD n1 n2 = n1 <> dot <> n2
-
-inlineIfD :: ValData -> ValData -> ValData -> ValData
-inlineIfD c v1 v2 = vd prec (valType v1) (valDoc c <+> text "?" <+> 
-  valDoc v1 <+> text ":" <+> valDoc v2)
-  where prec = valPrec c <|> Just 0
 
 funcAppDocD :: (RenderSym repr) => Label -> [repr (Value repr)] -> Doc
 funcAppDocD n vs = text n <> parens (valueList vs)

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer/CSharpRenderer.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer/CSharpRenderer.hs
@@ -23,24 +23,22 @@ import GOOL.Drasil.Symantics (Label, ProgramSym(..), RenderSym(..),
   ClassSym(..), InternalClass(..), ModuleSym(..), InternalMod(..), 
   BlockCommentSym(..))
 import GOOL.Drasil.LanguageRenderer (classDocD, multiStateDocD, bodyDocD, 
-  oneLinerD, outDoc, printFileDocD, boolTypeDocD, intTypeDocD, charTypeDocD, 
-  stringTypeDocD, typeDocD, enumTypeDocD, listTypeDocD, listInnerTypeD, 
-  voidDocD, destructorError, paramDocD, paramListDocD, mkParam, methodDocD, 
-  runStrategyD, listSliceD, checkStateD, notifyObserversD, listDecDocD, 
-  listDecDefDocD, mkSt, stringListVals', stringListLists', printStD, stateD, 
-  loopStateD, emptyStateD, assignD, assignToListIndexD, multiAssignError, 
-  decrementD, incrementD, decrement1D, increment1D, constDecDefD, discardInputD,
-  openFileRD, openFileWD, openFileAD, closeFileD, discardFileLineD, breakDocD, 
-  continueDocD, returnD, multiReturnError, valStateD, freeError, throwD, 
-  initStateD, changeStateD, initObserverListD, addObserverD, ifNoElseD, switchD,
-  switchAsIfD, ifExistsD, forRangeD, tryCatchD, unOpPrec, notOpDocD, 
-  negateOpDocD, unExpr, unExpr', typeUnExpr, powerPrec, equalOpDocD, 
-  notEqualOpDocD, greaterOpDocD, greaterEqualOpDocD, lessOpDocD, 
-  lessEqualOpDocD, plusOpDocD, minusOpDocD, multOpDocD, divideOpDocD, 
-  moduloOpDocD, andOpDocD, orOpDocD, binExpr, binExpr', typeBinExpr, mkVal, 
-  mkVar, litTrueD, litFalseD, litCharD, litFloatD, litIntD, litStringD, 
-  classVarDocD, objVarDocD, newObjDocD, varD, staticVarD, extVarD, selfD, 
-  enumVarD, classVarD, objVarSelfD, listVarD, listOfD, iterVarD,
+  oneLinerD, outDoc, printFileDocD, destructorError, paramDocD, paramListDocD, 
+  mkParam, methodDocD, runStrategyD, listSliceD, checkStateD, notifyObserversD, 
+  listDecDocD, listDecDefDocD, mkSt, stringListVals', stringListLists', 
+  printStD, stateD, loopStateD, emptyStateD, assignD, assignToListIndexD, 
+  multiAssignError, decrementD, incrementD, decrement1D, increment1D, 
+  constDecDefD, discardInputD, openFileRD, openFileWD, openFileAD, closeFileD, 
+  discardFileLineD, breakDocD, continueDocD, returnD, multiReturnError, 
+  valStateD, freeError, throwD, initStateD, changeStateD, initObserverListD, 
+  addObserverD, ifNoElseD, switchD, switchAsIfD, ifExistsD, forRangeD, 
+  tryCatchD, unOpPrec, notOpDocD, negateOpDocD, unExpr, unExpr', typeUnExpr, 
+  powerPrec, equalOpDocD, notEqualOpDocD, greaterOpDocD, greaterEqualOpDocD, 
+  lessOpDocD, lessEqualOpDocD, plusOpDocD, minusOpDocD, multOpDocD, 
+  divideOpDocD, moduloOpDocD, andOpDocD, orOpDocD, binExpr, binExpr', 
+  typeBinExpr, mkVal, mkVar, litTrueD, litFalseD, litCharD, litFloatD, litIntD, 
+  litStringD, classVarDocD, objVarDocD, newObjDocD, varD, staticVarD, extVarD, 
+  selfD, enumVarD, classVarD, objVarSelfD, listVarD, listOfD, iterVarD,
   valueOfD, argD, enumElementD, argsListD, objAccessD, objMethodCallD, 
   objMethodCallNoParamsD, selfAccessD, listIndexExistsD, indexOfD, funcAppD, 
   selfFuncAppD, extFuncAppD, newObjD,notNullD, funcDocD, castDocD, 
@@ -52,7 +50,8 @@ import GOOL.Drasil.LanguageRenderer (classDocD, multiStateDocD, bodyDocD,
   inLabel, blockCmtDoc, docCmtDoc, commentedItem, addCommentsDocD, 
   commentedModD, appendToBody, surroundBody, filterOutObjs)
 import qualified GOOL.Drasil.LanguageRenderer.LanguagePolymorphic as G (
-  fileFromData, block, pi, inlineIf, varDec, varDecDef, listDec, listDecDef, 
+  fileFromData, block, bool, int, double, char, string, listType, listInnerType,
+  obj, enumType, void, pi, inlineIf, varDec, varDecDef, listDec, listDecDef, 
   objDecNew, objDecNewNoParams, construct, comment, ifCond, for, forEach, while,
   method, getMethod, setMethod,privMethod, pubMethod, constructor, docMain, 
   function, mainFunction, docFunc, docInOutFunc, intFunc, stateVar, stateVarDef,
@@ -167,19 +166,19 @@ instance InternalBlock CSharpCode where
 
 instance TypeSym CSharpCode where
   type Type CSharpCode = TypeData
-  bool = toCode boolTypeDocD
-  int = toCode intTypeDocD
-  float = toCode csFloatTypeDoc
-  char = toCode charTypeDocD
-  string = toCode stringTypeDocD
-  infile = toCode csInfileTypeDoc
-  outfile = toCode csOutfileTypeDoc
-  listType p st = on2CodeValues listTypeDocD st (list p)
-  listInnerType = listInnerTypeD
-  obj t = toCode $ typeDocD t
-  enumType t = toCode $ enumTypeDocD t
+  bool = G.bool
+  int = G.int
+  float = G.double
+  char = G.char
+  string = G.string
+  infile = csInfileType
+  outfile = csOutfileType
+  listType = G.listType
+  listInnerType = G.listInnerType
+  obj = G.obj
+  enumType = G.enumType
   iterator t = t
-  void = toCode voidDocD
+  void = G.void
 
   getType = cType . unCSC
   getTypeString = typeString . unCSC
@@ -616,14 +615,11 @@ cstop end inc = vcat [
   inc <+> text "System.Collections" <> end,
   inc <+> text "System.Collections.Generic" <> end]
 
-csFloatTypeDoc :: TypeData
-csFloatTypeDoc = td Float "double" (text "double") -- Same as Java, maybe make a common function
+csInfileType :: (RenderSym repr) => repr (Type repr)
+csInfileType = typeFromData File "StreamReader" (text "StreamReader")
 
-csInfileTypeDoc :: TypeData
-csInfileTypeDoc = td File "StreamReader" (text "StreamReader")
-
-csOutfileTypeDoc :: TypeData
-csOutfileTypeDoc = td File "StreamWriter" (text "StreamWriter")
+csOutfileType :: (RenderSym repr) => repr (Type repr)
+csOutfileType = typeFromData File "StreamWriter" (text "StreamWriter")
 
 csCast :: CSharpCode (Type CSharpCode) -> CSharpCode (Value CSharpCode) -> 
   CSharpCode (Value CSharpCode)

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer/CSharpRenderer.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer/CSharpRenderer.hs
@@ -39,8 +39,8 @@ import GOOL.Drasil.LanguageRenderer (classDocD, multiStateDocD, bodyDocD,
   lessEqualOpDocD, plusOpDocD, minusOpDocD, multOpDocD, divideOpDocD, 
   moduloOpDocD, andOpDocD, orOpDocD, binExpr, binExpr', typeBinExpr, mkVal, 
   mkVar, litTrueD, litFalseD, litCharD, litFloatD, litIntD, litStringD, 
-  classVarDocD, objVarDocD, inlineIfD, newObjDocD, varD, staticVarD, 
-  extVarD, selfD, enumVarD, classVarD, objVarSelfD, listVarD, listOfD, iterVarD,
+  classVarDocD, objVarDocD, newObjDocD, varD, staticVarD, extVarD, selfD, 
+  enumVarD, classVarD, objVarSelfD, listVarD, listOfD, iterVarD,
   valueOfD, argD, enumElementD, argsListD, objAccessD, objMethodCallD, 
   objMethodCallNoParamsD, selfAccessD, listIndexExistsD, indexOfD, funcAppD, 
   selfFuncAppD, extFuncAppD, newObjD,notNullD, funcDocD, castDocD, 
@@ -52,12 +52,12 @@ import GOOL.Drasil.LanguageRenderer (classDocD, multiStateDocD, bodyDocD,
   inLabel, blockCmtDoc, docCmtDoc, commentedItem, addCommentsDocD, 
   commentedModD, appendToBody, surroundBody, filterOutObjs)
 import qualified GOOL.Drasil.LanguageRenderer.LanguagePolymorphic as G (
-  fileFromData, block, pi, varDec, varDecDef, listDec, listDecDef, objDecNew, 
-  objDecNewNoParams, construct, comment, ifCond, for, forEach, while, method, 
-  getMethod, setMethod,privMethod, pubMethod, constructor, docMain, function, 
-  mainFunction, docFunc, docInOutFunc, intFunc, stateVar, stateVarDef, constVar,
-  privMVar, pubMVar, pubGVar, buildClass, enum, privClass, pubClass, docClass, 
-  commentedClass, buildModule', modFromData, fileDoc, docMod)
+  fileFromData, block, pi, inlineIf, varDec, varDecDef, listDec, listDecDef, 
+  objDecNew, objDecNewNoParams, construct, comment, ifCond, for, forEach, while,
+  method, getMethod, setMethod,privMethod, pubMethod, constructor, docMain, 
+  function, mainFunction, docFunc, docInOutFunc, intFunc, stateVar, stateVarDef,
+  constVar, privMVar, pubMVar, pubGVar, buildClass, enum, privClass, pubClass, 
+  docClass, commentedClass, buildModule', modFromData, fileDoc, docMod)
 import GOOL.Drasil.Data (Terminator(..), FileType(..), FileData(..), fileD,
   FuncData(..), fd, ModData(..), md, updateModDoc, MethodData(..), mthd, 
   updateMthdDoc, OpData(..), ParamData(..), updateParamDoc, ProgData(..), progD,
@@ -321,7 +321,7 @@ instance BooleanExpression CSharpCode where
   (?!=) = typeBinExpr notEqualOp bool
   
 instance ValueExpression CSharpCode where
-  inlineIf = on3CodeValues inlineIfD
+  inlineIf = G.inlineIf
   funcApp = funcAppD
   selfFuncApp c = selfFuncAppD (self c)
   extFuncApp = extFuncAppD
@@ -380,7 +380,7 @@ instance InternalFunction CSharpCode where
   getFunc = getFuncD
   setFunc = setFuncD
 
-  listSizeFunc = on2CodeValues fd int (toCode $ funcDocD (text "Count"))
+  listSizeFunc = funcFromData int (funcDocD (text "Count"))
   listAddFunc _ = listAddFuncD "Insert"
   listAppendFunc = listAppendFuncD "Add"
 
@@ -501,9 +501,8 @@ instance ControlStatementSym CSharpCode where
   checkState = checkStateD
   notifyObservers = notifyObserversD
 
-  getFileInputAll f v = while ((f $. on2CodeValues fd bool (toCode $ text 
-    ".EndOfStream")) ?!) (oneLiner $ valState $ listAppend (valueOf v) 
-    (csFileInput f))
+  getFileInputAll f v = while ((f $. funcFromData bool (text ".EndOfStream")) 
+    ?!) (oneLiner $ valState $ listAppend (valueOf v) (csFileInput f))
 
 instance ScopeSym CSharpCode where
   type Scope CSharpCode = Doc

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer/CSharpRenderer.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer/CSharpRenderer.hs
@@ -238,7 +238,7 @@ instance VariableSym CSharpCode where
   enumVar = enumVarD
   classVar = classVarD classVarDocD
   extClassVar = classVar
-  objVar = on2CodeValues csObjVar
+  objVar = csObjVar
   objVarSelf = objVarSelfD
   listVar  = listVarD
   listOf = listOfD 

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer/CSharpRenderer.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer/CSharpRenderer.hs
@@ -689,12 +689,13 @@ csVarDec :: Binding -> CSharpCode (Statement CSharpCode) ->
 csVarDec Static _ = error "Static variables can't be declared locally to a function in C#. Use stateVar to make a static state variable instead."
 csVarDec Dynamic d = d
 
-csObjVar :: VarData -> VarData -> VarData
-csObjVar o v = csObjVar' (varBind v)
+csObjVar :: (RenderSym repr) => repr (Variable repr) -> repr (Variable repr) -> 
+  repr (Variable repr)
+csObjVar o v = csObjVar' (variableBind v)
   where csObjVar' Static = error 
           "Cannot use objVar to access static variables through an object in C#"
-        csObjVar' Dynamic = mkVar (varName o ++ "." ++ varName v) 
-          (varType v) (objVarDocD (varDoc o) (varDoc v))
+        csObjVar' Dynamic = mkVar (variableName o ++ "." ++ variableName v) 
+          (variableType v) (objVarDocD (variableDoc o) (variableDoc v))
 
 csInOut :: (CSharpCode (Scope CSharpCode) -> CSharpCode (Permanence CSharpCode) 
     -> CSharpCode (Type CSharpCode) -> [CSharpCode (Parameter CSharpCode)] -> 

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer/CSharpRenderer.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer/CSharpRenderer.hs
@@ -13,7 +13,7 @@ import GOOL.Drasil.CodeType (CodeType(..))
 import GOOL.Drasil.Symantics (Label, ProgramSym(..), RenderSym(..), 
   InternalFile(..), KeywordSym(..), PermanenceSym(..), InternalPerm(..), 
   BodySym(..), BlockSym(..), InternalBlock(..), ControlBlockSym(..), 
-  TypeSym(..), InternalType(..), UnaryOpSym(..), BinaryOpSym(..), 
+  TypeSym(..), InternalType(..), UnaryOpSym(..), BinaryOpSym(..), InternalOp(..),
   VariableSym(..), InternalVariable(..), ValueSym(..), NumericExpression(..), 
   BooleanExpression(..), ValueExpression(..), InternalValue(..), Selector(..), 
   FunctionSym(..), SelectorFunction(..), InternalFunction(..), 
@@ -64,7 +64,7 @@ import GOOL.Drasil.Data (Terminator(..), FileType(..), FileData(..), fileD,
   TypeData(..), td, ValData(..), vd, updateValDoc, Binding(..), VarData(..), 
   vard)
 import GOOL.Drasil.Helpers (toCode, toState, onCodeValue, onStateValue, 
-  on2CodeValues, on2StateValues, on3CodeValues, on4CodeValues, on5CodeValues, 
+  on2CodeValues, on2StateValues, on3CodeValues, on5CodeValues, 
   onCodeList, onStateList, on1CodeValue1List, checkParams)
 import GOOL.Drasil.State (MS, lensGStoFS, initialState, initialFS, getPutReturn,
   setCurrMain, setParameters)
@@ -228,6 +228,12 @@ instance BinaryOpSym CSharpCode where
   andOp = toCode andOpDocD
   orOp = toCode orOpDocD
 
+instance InternalOp CSharpCode where
+  uOpDoc = opDoc . unCSC
+  bOpDoc = opDoc . unCSC
+  uOpPrec = opPrec . unCSC
+  bOpPrec = opPrec . unCSC
+
 instance VariableSym CSharpCode where
   type Variable CSharpCode = VarData
   var = varD
@@ -277,42 +283,42 @@ instance ValueSym CSharpCode where
   valueDoc = valDoc . unCSC
 
 instance NumericExpression CSharpCode where
-  (#~) = on2CodeValues unExpr' negateOp
-  (#/^) = on2CodeValues unExpr sqrtOp
-  (#|) = on2CodeValues unExpr absOp
-  (#+) = on3CodeValues binExpr plusOp
-  (#-) = on3CodeValues binExpr minusOp
-  (#*) = on3CodeValues binExpr multOp
-  (#/) = on3CodeValues binExpr divideOp
-  (#%) = on3CodeValues binExpr moduloOp
-  (#^) = on3CodeValues binExpr' powerOp
+  (#~) = unExpr' negateOp
+  (#/^) = unExpr sqrtOp
+  (#|) = unExpr absOp
+  (#+) = binExpr plusOp
+  (#-) = binExpr minusOp
+  (#*) = binExpr multOp
+  (#/) = binExpr divideOp
+  (#%) = binExpr moduloOp
+  (#^) = binExpr' powerOp
 
-  log = on2CodeValues unExpr logOp
-  ln = on2CodeValues unExpr lnOp
-  exp = on2CodeValues unExpr expOp
-  sin = on2CodeValues unExpr sinOp
-  cos = on2CodeValues unExpr cosOp
-  tan = on2CodeValues unExpr tanOp
+  log = unExpr logOp
+  ln = unExpr lnOp
+  exp = unExpr expOp
+  sin = unExpr sinOp
+  cos = unExpr cosOp
+  tan = unExpr tanOp
   csc v = litFloat 1.0 #/ sin v
   sec v = litFloat 1.0 #/ cos v
   cot v = litFloat 1.0 #/ tan v
-  arcsin = on2CodeValues unExpr asinOp
-  arccos = on2CodeValues unExpr acosOp
-  arctan = on2CodeValues unExpr atanOp
-  floor = on2CodeValues unExpr floorOp
-  ceil = on2CodeValues unExpr ceilOp
+  arcsin = unExpr asinOp
+  arccos = unExpr acosOp
+  arctan = unExpr atanOp
+  floor = unExpr floorOp
+  ceil = unExpr ceilOp
 
 instance BooleanExpression CSharpCode where
-  (?!) = on3CodeValues typeUnExpr notOp bool
-  (?&&) = on4CodeValues typeBinExpr andOp bool
-  (?||) = on4CodeValues typeBinExpr orOp bool
+  (?!) = typeUnExpr notOp bool
+  (?&&) = typeBinExpr andOp bool
+  (?||) = typeBinExpr orOp bool
 
-  (?<) = on4CodeValues typeBinExpr lessOp bool
-  (?<=) = on4CodeValues typeBinExpr lessEqualOp bool
-  (?>) = on4CodeValues typeBinExpr greaterOp bool
-  (?>=) = on4CodeValues typeBinExpr greaterEqualOp bool
-  (?==) = on4CodeValues typeBinExpr equalOp bool
-  (?!=) = on4CodeValues typeBinExpr notEqualOp bool
+  (?<) = typeBinExpr lessOp bool
+  (?<=) = typeBinExpr lessEqualOp bool
+  (?>) = typeBinExpr greaterOp bool
+  (?>=) = typeBinExpr greaterEqualOp bool
+  (?==) = typeBinExpr equalOp bool
+  (?!=) = typeBinExpr notEqualOp bool
   
 instance ValueExpression CSharpCode where
   inlineIf = on3CodeValues inlineIfD

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer/CSharpRenderer.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer/CSharpRenderer.hs
@@ -27,11 +27,11 @@ import GOOL.Drasil.LanguageRenderer (classDocD, multiStateDocD, bodyDocD,
   stringTypeDocD, typeDocD, enumTypeDocD, listTypeDocD, listInnerTypeD, 
   voidDocD, destructorError, paramDocD, paramListDocD, mkParam, methodDocD, 
   runStrategyD, listSliceD, checkStateD, notifyObserversD, listDecDocD, 
-  listDecDefDocD, stringListVals', stringListLists', printStD, stateD, 
+  listDecDefDocD, mkSt, stringListVals', stringListLists', printStD, stateD, 
   loopStateD, emptyStateD, assignD, assignToListIndexD, multiAssignError, 
   decrementD, incrementD, decrement1D, increment1D, constDecDefD, discardInputD,
-  openFileRD, openFileWD, openFileAD, closeFileD, discardFileLineD, breakD, 
-  continueD, returnD, multiReturnError, valStateD, freeError, throwD, 
+  openFileRD, openFileWD, openFileAD, closeFileD, discardFileLineD, breakDocD, 
+  continueDocD, returnD, multiReturnError, valStateD, freeError, throwD, 
   initStateD, changeStateD, initObserverListD, addObserverD, ifNoElseD, switchD,
   switchAsIfD, ifExistsD, forRangeD, tryCatchD, unOpPrec, notOpDocD, 
   negateOpDocD, unExpr, unExpr', typeUnExpr, powerPrec, equalOpDocD, 
@@ -334,6 +334,7 @@ instance InternalValue CSharpCode where
   
   cast = csCast
   
+  valuePrec = valPrec . unCSC
   valFromData p t d = on2CodeValues (vd p) t (toCode d)
 
 instance Selector CSharpCode where
@@ -450,8 +451,8 @@ instance StatementSym CSharpCode where
   stringListVals = stringListVals'
   stringListLists = stringListLists'
 
-  break = breakD Semi
-  continue = continueD Semi
+  break = mkSt breakDocD
+  continue = mkSt continueDocD
 
   returnState = returnD Semi
   multiReturn _ = error $ multiReturnError csName 

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer/CppRenderer.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer/CppRenderer.hs
@@ -40,7 +40,7 @@ import GOOL.Drasil.LanguageRenderer (addExt, enumElementsDocD, multiStateDocD,
   lessEqualOpDocD, plusOpDocD, minusOpDocD, multOpDocD, divideOpDocD, 
   moduloOpDocD, powerOpDocD, andOpDocD, orOpDocD, binExpr, binExpr', 
   typeBinExpr, mkVal, mkVar, litTrueD, litFalseD, litCharD, litFloatD, litIntD, 
-  litStringD, classVarCheckStatic, inlineIfD, varD, staticVarD, selfD, enumVarD,
+  litStringD, classVarCheckStatic, varD, staticVarD, selfD, enumVarD,
   objVarD, listVarD, listOfD, valueOfD, argD, argsListD, objAccessD, 
   objMethodCallD, objMethodCallNoParamsD, selfAccessD, listIndexExistsD, 
   funcAppD, newObjD, newObjDocD', castDocD, castObjDocD, funcD, getD, setD, 
@@ -52,9 +52,9 @@ import GOOL.Drasil.LanguageRenderer (addExt, enumElementsDocD, multiStateDocD,
   commentedModD, docFuncRepr, valueList, appendToBody, surroundBody, getterName,
   setterName, filterOutObjs)
 import qualified GOOL.Drasil.LanguageRenderer.LanguagePolymorphic as G (
-  fileFromData, block, varDec, varDecDef, listDec, listDecDef, objDecNew, 
-  objDecNewNoParams, construct, comment, ifCond, for, while, method, getMethod, 
-  setMethod, privMethod, pubMethod, constructor, function, docFunc, 
+  fileFromData, block, inlineIf, varDec, varDecDef, listDec, listDecDef, 
+  objDecNew, objDecNewNoParams, construct, comment, ifCond, for, while, method, 
+  getMethod, setMethod, privMethod, pubMethod, constructor, function, docFunc, 
   docInOutFunc, intFunc, privMVar, pubMVar, pubGVar, privClass, pubClass, 
   docClass, commentedClass, buildModule, modFromData, fileDoc, docMod)
 import GOOL.Drasil.Data (Pair(..), Terminator(..), ScopeTag(..), 
@@ -1030,7 +1030,7 @@ instance BooleanExpression CppSrcCode where
   (?!=) = typeBinExpr notEqualOp bool
    
 instance ValueExpression CppSrcCode where
-  inlineIf = on3CodeValues inlineIfD
+  inlineIf = G.inlineIf
   funcApp = funcAppD
   selfFuncApp c = cppSelfFuncApp (self c)
   extFuncApp _ = funcApp
@@ -1642,7 +1642,7 @@ instance Selector CppHdrCode where
 
 instance FunctionSym CppHdrCode where
   type Function CppHdrCode = FuncData
-  func _ _ _ = on2CodeValues fd void (toCode empty)
+  func _ _ _ = funcFromData void empty
   
   get _ _ = mkVal void empty
   set _ _ _ = mkVal void empty
@@ -1660,18 +1660,18 @@ instance SelectorFunction CppHdrCode where
   at _ _ = mkVal void empty
 
 instance InternalFunction CppHdrCode where
-  getFunc _ = on2CodeValues fd void (toCode empty)
-  setFunc _ _ _ = on2CodeValues fd void (toCode empty)
+  getFunc _ = funcFromData void empty
+  setFunc _ _ _ = funcFromData void empty
 
-  listSizeFunc = on2CodeValues fd void (toCode empty)
-  listAddFunc _ _ _ = on2CodeValues fd void (toCode empty)
-  listAppendFunc _ = on2CodeValues fd void (toCode empty)
+  listSizeFunc = funcFromData void empty
+  listAddFunc _ _ _ = funcFromData void empty
+  listAppendFunc _ = funcFromData void empty
 
-  iterBeginFunc _ = on2CodeValues fd void (toCode empty)
-  iterEndFunc _ = on2CodeValues fd void (toCode empty)
+  iterBeginFunc _ = funcFromData void empty
+  iterEndFunc _ = funcFromData void empty
 
-  listAccessFunc _ _ = on2CodeValues fd void (toCode empty)
-  listSetFunc _ _ _ = on2CodeValues fd void (toCode empty)
+  listAccessFunc _ _ = funcFromData void empty
+  listSetFunc _ _ _ = funcFromData void empty
   
   functionType = onCodeValue funcType
   functionDoc = funcDoc . unCPPHC

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer/CppRenderer.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer/CppRenderer.hs
@@ -966,13 +966,13 @@ instance ValueSym CppSrcCode where
   litInt = litIntD
   litString = litStringD
 
-  pi = on2CodeValues mkVal float (toCode $ text "M_PI")
+  pi = mkVal float (text "M_PI")
 
   ($:) = enumElement
 
   valueOf = valueOfD
   arg n = argD (litInt $ n+1) argsList
-  enumElement en e = on2CodeValues mkVal (enumType en) (toCode $ text e)
+  enumElement en e = mkVal (enumType en) (text e)
   
   argsList = argsListD "argv"
 
@@ -1029,11 +1029,11 @@ instance ValueExpression CppSrcCode where
   notNull v = v
 
 instance InternalValue CppSrcCode where
-  inputFunc = on2CodeValues mkVal string (toCode $ text "std::cin")
-  printFunc = on2CodeValues mkVal void (toCode $ text "std::cout")
-  printLnFunc = on2CodeValues mkVal void (toCode $ text "std::cout")
-  printFileFunc f = on2CodeValues mkVal void (onCodeValue valDoc f)
-  printFileLnFunc f = on2CodeValues mkVal void (onCodeValue valDoc f)
+  inputFunc = mkVal string (text "std::cin")
+  printFunc = mkVal void (text "std::cout")
+  printLnFunc = mkVal void (text "std::cout")
+  printFileFunc f = mkVal void (valueDoc f)
+  printFileLnFunc f = mkVal void (valueDoc f)
 
   cast = cppCast
   
@@ -1533,13 +1533,13 @@ instance ValueSym CppHdrCode where
   litInt = litIntD
   litString = litStringD
 
-  pi = on2CodeValues mkVal float (toCode $ text "M_PI")
+  pi = mkVal float (text "M_PI")
 
   ($:) = enumElement
 
   valueOf = valueOfD
   arg n = argD (litInt $ n+1) argsList
-  enumElement en e = on2CodeValues mkVal (enumType en) (toCode $ text e)
+  enumElement en e = mkVal (enumType en) (text e)
   
   argsList = argsListD "argv"
 
@@ -1547,97 +1547,97 @@ instance ValueSym CppHdrCode where
   valueDoc = valDoc . unCPPHC
 
 instance NumericExpression CppHdrCode where
-  (#~) _ = on2CodeValues mkVal void (toCode empty)
-  (#/^) _ = on2CodeValues mkVal void (toCode empty)
-  (#|) _ = on2CodeValues mkVal void (toCode empty)
-  (#+) _ _ = on2CodeValues mkVal void (toCode empty)
-  (#-) _ _ = on2CodeValues mkVal void (toCode empty)
-  (#*) _ _ = on2CodeValues mkVal void (toCode empty)
-  (#/) _ _ = on2CodeValues mkVal void (toCode empty)
-  (#%) _ _ = on2CodeValues mkVal void (toCode empty)
-  (#^) _ _ = on2CodeValues mkVal void (toCode empty)
+  (#~) _ = mkVal void empty
+  (#/^) _ = mkVal void empty
+  (#|) _ = mkVal void empty
+  (#+) _ _ = mkVal void empty
+  (#-) _ _ = mkVal void empty
+  (#*) _ _ = mkVal void empty
+  (#/) _ _ = mkVal void empty
+  (#%) _ _ = mkVal void empty
+  (#^) _ _ = mkVal void empty
 
-  log _ = on2CodeValues mkVal void (toCode empty)
-  ln _ = on2CodeValues mkVal void (toCode empty)
-  exp _ = on2CodeValues mkVal void (toCode empty)
-  sin _ = on2CodeValues mkVal void (toCode empty)
-  cos _ = on2CodeValues mkVal void (toCode empty)
-  tan _ = on2CodeValues mkVal void (toCode empty)
-  csc _ = on2CodeValues mkVal void (toCode empty)
-  sec _ = on2CodeValues mkVal void (toCode empty)
-  cot _ = on2CodeValues mkVal void (toCode empty)
-  arcsin _ = on2CodeValues mkVal void (toCode empty)
-  arccos _ = on2CodeValues mkVal void (toCode empty)
-  arctan _ = on2CodeValues mkVal void (toCode empty)
-  floor _ = on2CodeValues mkVal void (toCode empty)
-  ceil _ = on2CodeValues mkVal void (toCode empty)
+  log _ = mkVal void empty
+  ln _ = mkVal void empty
+  exp _ = mkVal void empty
+  sin _ = mkVal void empty
+  cos _ = mkVal void empty
+  tan _ = mkVal void empty
+  csc _ = mkVal void empty
+  sec _ = mkVal void empty
+  cot _ = mkVal void empty
+  arcsin _ = mkVal void empty
+  arccos _ = mkVal void empty
+  arctan _ = mkVal void empty
+  floor _ = mkVal void empty
+  ceil _ = mkVal void empty
 
 instance BooleanExpression CppHdrCode where
-  (?!) _ = on2CodeValues mkVal void (toCode empty)
-  (?&&) _ _ = on2CodeValues mkVal void (toCode empty)
-  (?||) _ _ = on2CodeValues mkVal void (toCode empty)
+  (?!) _ = mkVal void empty
+  (?&&) _ _ = mkVal void empty
+  (?||) _ _ = mkVal void empty
 
-  (?<) _ _ = on2CodeValues mkVal void (toCode empty)
-  (?<=) _ _ = on2CodeValues mkVal void (toCode empty)
-  (?>) _ _ = on2CodeValues mkVal void (toCode empty)
-  (?>=) _ _ = on2CodeValues mkVal void (toCode empty)
-  (?==) _ _ = on2CodeValues mkVal void (toCode empty)
-  (?!=) _ _ = on2CodeValues mkVal void (toCode empty)
+  (?<) _ _ = mkVal void empty
+  (?<=) _ _ = mkVal void empty
+  (?>) _ _ = mkVal void empty
+  (?>=) _ _ = mkVal void empty
+  (?==) _ _ = mkVal void empty
+  (?!=) _ _ = mkVal void empty
    
 instance ValueExpression CppHdrCode where
-  inlineIf _ _ _ = on2CodeValues mkVal void (toCode empty)
-  funcApp _ _ _ = on2CodeValues mkVal void (toCode empty)
-  selfFuncApp _ _ _ _ = on2CodeValues mkVal void (toCode empty)
-  extFuncApp _ _ _ _ = on2CodeValues mkVal void (toCode empty)
-  newObj _ _ = on2CodeValues mkVal void (toCode empty)
-  extNewObj _ _ _ = on2CodeValues mkVal void (toCode empty)
+  inlineIf _ _ _ = mkVal void empty
+  funcApp _ _ _ = mkVal void empty
+  selfFuncApp _ _ _ _ = mkVal void empty
+  extFuncApp _ _ _ _ = mkVal void empty
+  newObj _ _ = mkVal void empty
+  extNewObj _ _ _ = mkVal void empty
 
-  exists _ = on2CodeValues mkVal void (toCode empty)
-  notNull _ = on2CodeValues mkVal void (toCode empty)
+  exists _ = mkVal void empty
+  notNull _ = mkVal void empty
 
 instance InternalValue CppHdrCode where
-  inputFunc = on2CodeValues mkVal void (toCode empty)
-  printFunc = on2CodeValues mkVal void (toCode empty)
-  printLnFunc = on2CodeValues mkVal void (toCode empty)
-  printFileFunc _ = on2CodeValues mkVal void (toCode empty)
-  printFileLnFunc _ = on2CodeValues mkVal void (toCode empty)
+  inputFunc = mkVal void empty
+  printFunc = mkVal void empty
+  printLnFunc = mkVal void empty
+  printFileFunc _ = mkVal void empty
+  printFileLnFunc _ = mkVal void empty
   
-  cast _ _ = on2CodeValues mkVal void (toCode empty)
+  cast _ _ = mkVal void empty
   
   valFromData p t d = on2CodeValues (vd p) t (toCode d)
 
 instance Selector CppHdrCode where
-  objAccess _ _ = on2CodeValues mkVal void (toCode empty)
-  ($.) _ _ = on2CodeValues mkVal void (toCode empty)
+  objAccess _ _ = mkVal void empty
+  ($.) _ _ = mkVal void empty
 
-  objMethodCall _ _ _ _ = on2CodeValues mkVal void (toCode empty)
-  objMethodCallNoParams _ _ _ = on2CodeValues mkVal void (toCode empty)
+  objMethodCall _ _ _ _ = mkVal void empty
+  objMethodCallNoParams _ _ _ = mkVal void empty
 
-  selfAccess _ _ = on2CodeValues mkVal void (toCode empty)
+  selfAccess _ _ = mkVal void empty
 
-  listIndexExists _ _ = on2CodeValues mkVal void (toCode empty)
-  argExists _ = on2CodeValues mkVal void (toCode empty)
+  listIndexExists _ _ = mkVal void empty
+  argExists _ = mkVal void empty
   
-  indexOf _ _ = on2CodeValues mkVal void (toCode empty)
+  indexOf _ _ = mkVal void empty
 
 instance FunctionSym CppHdrCode where
   type Function CppHdrCode = FuncData
   func _ _ _ = on2CodeValues fd void (toCode empty)
   
-  get _ _ = on2CodeValues mkVal void (toCode empty)
-  set _ _ _ = on2CodeValues mkVal void (toCode empty)
+  get _ _ = mkVal void empty
+  set _ _ _ = mkVal void empty
 
-  listSize _ = on2CodeValues mkVal void (toCode empty)
-  listAdd _ _ _ = on2CodeValues mkVal void (toCode empty)
-  listAppend _ _ = on2CodeValues mkVal void (toCode empty)
+  listSize _ = mkVal void empty
+  listAdd _ _ _ = mkVal void empty
+  listAppend _ _ = mkVal void empty
 
-  iterBegin _ = on2CodeValues mkVal void (toCode empty)
-  iterEnd _ = on2CodeValues mkVal void (toCode empty)
+  iterBegin _ = mkVal void empty
+  iterEnd _ = mkVal void empty
 
 instance SelectorFunction CppHdrCode where
-  listAccess _ _ = on2CodeValues mkVal void (toCode empty)
-  listSet _ _ _ = on2CodeValues mkVal void (toCode empty)
-  at _ _ = on2CodeValues mkVal void (toCode empty)
+  listAccess _ _ = mkVal void empty
+  listSet _ _ _ = mkVal void empty
+  at _ _ = mkVal void empty
 
 instance InternalFunction CppHdrCode where
   getFunc _ = on2CodeValues fd void (toCode empty)
@@ -1986,8 +1986,8 @@ cppCast :: CppSrcCode (Type CppSrcCode) ->
   CppSrcCode (Value CppSrcCode) -> CppSrcCode (Value CppSrcCode)
 cppCast t v = cppCast' (getType t) (getType $ valueType v)
   where cppCast' Float String = funcApp "std::stod" float [v]
-        cppCast' _ _ = on2CodeValues mkVal t $ on2CodeValues castObjDocD 
-          (onCodeValue castDocD t) v
+        cppCast' _ _ = mkVal t $ castObjDocD (castDocD (getTypeDoc t)) 
+          (valueDoc v)
 
 cppListSetDoc :: Doc -> Doc -> Doc
 cppListSetDoc i v = dot <> text "at" <> parens i <+> equals <+> v

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer/CppRenderer.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer/CppRenderer.hs
@@ -14,7 +14,7 @@ import GOOL.Drasil.CodeType (CodeType(..))
 import GOOL.Drasil.Symantics (Label, ProgramSym(..), RenderSym(..), 
   InternalFile(..), KeywordSym(..), PermanenceSym(..), InternalPerm(..), 
   BodySym(..), BlockSym(..), InternalBlock(..), ControlBlockSym(..), 
-  TypeSym(..), InternalType(..), UnaryOpSym(..), BinaryOpSym(..), 
+  TypeSym(..), InternalType(..), UnaryOpSym(..), BinaryOpSym(..), InternalOp(..),
   VariableSym(..), InternalVariable(..), ValueSym(..), NumericExpression(..),
   BooleanExpression(..), ValueExpression(..), InternalValue(..), Selector(..), 
   FunctionSym(..), SelectorFunction(..), InternalFunction(..), 
@@ -243,6 +243,12 @@ instance (Pair p) => BinaryOpSym (p CppSrcCode CppHdrCode) where
   moduloOp = pair moduloOp moduloOp
   andOp = pair andOp andOp
   orOp = pair orOp orOp
+
+instance (Pair p) => InternalOp (p CppSrcCode CppHdrCode) where
+  uOpDoc o = uOpDoc $ pfst o
+  bOpDoc o = bOpDoc $ pfst o
+  uOpPrec o = uOpPrec $ pfst o
+  bOpPrec o = bOpPrec $ pfst o
 
 instance (Pair p) => VariableSym (p CppSrcCode CppHdrCode) where
   type Variable (p CppSrcCode CppHdrCode) = VarData
@@ -928,6 +934,12 @@ instance BinaryOpSym CppSrcCode where
   andOp = toCode andOpDocD
   orOp = toCode orOpDocD
 
+instance InternalOp CppSrcCode where
+  uOpDoc = opDoc . unCPPSC
+  bOpDoc = opDoc . unCPPSC
+  uOpPrec = opPrec . unCPPSC
+  bOpPrec = opPrec . unCPPSC
+
 instance VariableSym CppSrcCode where
   type Variable CppSrcCode = VarData
   var = varD
@@ -980,42 +992,42 @@ instance ValueSym CppSrcCode where
   valueDoc = valDoc . unCPPSC
 
 instance NumericExpression CppSrcCode where
-  (#~) = on2CodeValues unExpr' negateOp
-  (#/^) = on2CodeValues unExpr sqrtOp
-  (#|) = on2CodeValues unExpr absOp
-  (#+) = on3CodeValues binExpr plusOp
-  (#-) = on3CodeValues binExpr minusOp
-  (#*) = on3CodeValues binExpr multOp
-  (#/) = on3CodeValues binExpr divideOp
-  (#%) = on3CodeValues binExpr moduloOp
-  (#^) = on3CodeValues binExpr' powerOp
+  (#~) = unExpr' negateOp
+  (#/^) = unExpr sqrtOp
+  (#|) = unExpr absOp
+  (#+) = binExpr plusOp
+  (#-) = binExpr minusOp
+  (#*) = binExpr multOp
+  (#/) = binExpr divideOp
+  (#%) = binExpr moduloOp
+  (#^) = binExpr' powerOp
 
-  log = on2CodeValues unExpr logOp
-  ln = on2CodeValues unExpr lnOp
-  exp = on2CodeValues unExpr expOp
-  sin = on2CodeValues unExpr sinOp
-  cos = on2CodeValues unExpr cosOp
-  tan = on2CodeValues unExpr tanOp
+  log = unExpr logOp
+  ln = unExpr lnOp
+  exp = unExpr expOp
+  sin = unExpr sinOp
+  cos = unExpr cosOp
+  tan = unExpr tanOp
   csc v = litFloat 1.0 #/ sin v
   sec v = litFloat 1.0 #/ cos v
   cot v = litFloat 1.0 #/ tan v
-  arcsin = on2CodeValues unExpr asinOp
-  arccos = on2CodeValues unExpr acosOp
-  arctan = on2CodeValues unExpr atanOp
-  floor = on2CodeValues unExpr floorOp
-  ceil = on2CodeValues unExpr ceilOp
+  arcsin = unExpr asinOp
+  arccos = unExpr acosOp
+  arctan = unExpr atanOp
+  floor = unExpr floorOp
+  ceil = unExpr ceilOp
 
 instance BooleanExpression CppSrcCode where
-  (?!) = on3CodeValues typeUnExpr notOp bool
-  (?&&) = on4CodeValues typeBinExpr andOp bool
-  (?||) = on4CodeValues typeBinExpr orOp bool
+  (?!) = typeUnExpr notOp bool
+  (?&&) = typeBinExpr andOp bool
+  (?||) = typeBinExpr orOp bool
 
-  (?<) = on4CodeValues typeBinExpr lessOp bool
-  (?<=) = on4CodeValues typeBinExpr lessEqualOp bool
-  (?>) = on4CodeValues typeBinExpr greaterOp bool
-  (?>=) = on4CodeValues typeBinExpr greaterEqualOp bool
-  (?==) = on4CodeValues typeBinExpr equalOp bool
-  (?!=) = on4CodeValues typeBinExpr notEqualOp bool
+  (?<) = typeBinExpr lessOp bool
+  (?<=) = typeBinExpr lessEqualOp bool
+  (?>) = typeBinExpr greaterOp bool
+  (?>=) = typeBinExpr greaterEqualOp bool
+  (?==) = typeBinExpr equalOp bool
+  (?!=) = typeBinExpr notEqualOp bool
    
 instance ValueExpression CppSrcCode where
   inlineIf = on3CodeValues inlineIfD
@@ -1498,6 +1510,12 @@ instance BinaryOpSym CppHdrCode where
   moduloOp = toCode $ od 0 empty
   andOp = toCode $ od 0 empty
   orOp = toCode $ od 0 empty
+
+instance InternalOp CppHdrCode where
+  uOpDoc = opDoc . unCPPHC
+  bOpDoc = opDoc . unCPPHC
+  uOpPrec = opPrec . unCPPHC
+  bOpPrec = opPrec . unCPPHC
 
 instance VariableSym CppHdrCode where
   type Variable CppHdrCode = VarData

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer/CppRenderer.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer/CppRenderer.hs
@@ -1198,7 +1198,7 @@ instance ControlStatementSym CppSrcCode where
   switch = switchD
   switchAsIf = switchAsIfD
 
-  ifExists _ ifBody _ = mkStNoEnd <$> ifBody -- All variables are initialized in C++
+  ifExists _ ifBody _ = mkStNoEnd $ bodyDoc ifBody -- All variables are initialized in C++
 
   for = G.for blockStart blockEnd 
   forRange = forRangeD
@@ -1658,12 +1658,12 @@ instance InternalFunction CppHdrCode where
   funcFromData t d = on2CodeValues fd t (toCode d)
 
 instance InternalStatement CppHdrCode where
-  printSt _ _ _ _ = toCode (mkStNoEnd empty)
+  printSt _ _ _ _ = emptyState
 
   state = stateD
-  loopState _ = toCode (mkStNoEnd empty)
+  loopState _ = emptyState
 
-  emptyState = toCode $ mkStNoEnd empty
+  emptyState = emptyStateD
   statementDoc = fst . unCPPHC
   statementTerm = snd . unCPPHC
   
@@ -1671,99 +1671,99 @@ instance InternalStatement CppHdrCode where
 
 instance StatementSym CppHdrCode where
   type Statement CppHdrCode = (Doc, Terminator)
-  assign _ _ = toCode (mkStNoEnd empty)
-  assignToListIndex _ _ _ = toCode (mkStNoEnd empty)
-  multiAssign _ _ = toCode (mkStNoEnd empty)
-  (&=) _ _ = toCode (mkStNoEnd empty)
-  (&-=) _ _ = toCode (mkStNoEnd empty)
-  (&+=) _ _ = toCode (mkStNoEnd empty)
-  (&++) _ = toCode (mkStNoEnd empty)
-  (&~-) _ = toCode (mkStNoEnd empty)
+  assign _ _ = emptyState
+  assignToListIndex _ _ _ = emptyState
+  multiAssign _ _ = emptyState
+  (&=) _ _ = emptyState
+  (&-=) _ _ = emptyState
+  (&+=) _ _ = emptyState
+  (&++) _ = emptyState
+  (&~-) _ = emptyState
 
   varDec = G.varDec static_ dynamic_
   varDecDef = G.varDecDef
-  listDec _ _ = toCode (mkStNoEnd empty)
-  listDecDef _ _ = toCode (mkStNoEnd empty)
-  objDecDef _ _ = toCode (mkStNoEnd empty)
-  objDecNew _ _ = toCode (mkStNoEnd empty)
-  extObjDecNew _ _ _ = toCode (mkStNoEnd empty)
-  objDecNewNoParams _ = toCode (mkStNoEnd empty)
-  extObjDecNewNoParams _ _ = toCode (mkStNoEnd empty)
+  listDec _ _ = emptyState
+  listDecDef _ _ = emptyState
+  objDecDef _ _ = emptyState
+  objDecNew _ _ = emptyState
+  extObjDecNew _ _ _ = emptyState
+  objDecNewNoParams _ = emptyState
+  extObjDecNewNoParams _ _ = emptyState
   constDecDef = constDecDefD
 
-  print _ = toCode (mkStNoEnd empty)
-  printLn _ = toCode (mkStNoEnd empty)
-  printStr _ = toCode (mkStNoEnd empty)
-  printStrLn _ = toCode (mkStNoEnd empty)
+  print _ = emptyState
+  printLn _ = emptyState
+  printStr _ = emptyState
+  printStrLn _ = emptyState
 
-  printFile _ _ = toCode (mkStNoEnd empty)
-  printFileLn _ _ = toCode (mkStNoEnd empty)
-  printFileStr _ _ = toCode (mkStNoEnd empty)
-  printFileStrLn _ _ = toCode (mkStNoEnd empty)
+  printFile _ _ = emptyState
+  printFileLn _ _ = emptyState
+  printFileStr _ _ = emptyState
+  printFileStrLn _ _ = emptyState
 
-  getInput _ = toCode (mkStNoEnd empty)
-  discardInput = toCode (mkStNoEnd empty)
-  getFileInput _ _ = toCode (mkStNoEnd empty)
-  discardFileInput _ = toCode (mkStNoEnd empty)
+  getInput _ = emptyState
+  discardInput = emptyState
+  getFileInput _ _ = emptyState
+  discardFileInput _ = emptyState
 
-  openFileR _ _ = toCode (mkStNoEnd empty)
-  openFileW _ _ = toCode (mkStNoEnd empty)
-  openFileA _ _ = toCode (mkStNoEnd empty)
-  closeFile _ = toCode (mkStNoEnd empty)
+  openFileR _ _ = emptyState
+  openFileW _ _ = emptyState
+  openFileA _ _ = emptyState
+  closeFile _ = emptyState
 
-  getFileInputLine _ _ = toCode (mkStNoEnd empty)
-  discardFileLine _ = toCode (mkStNoEnd empty)
-  stringSplit _ _ _ = toCode (mkStNoEnd empty)
+  getFileInputLine _ _ = emptyState
+  discardFileLine _ = emptyState
+  stringSplit _ _ _ = emptyState
 
-  stringListVals _ _ = toCode (mkStNoEnd empty)
-  stringListLists _ _ = toCode (mkStNoEnd empty)
+  stringListVals _ _ = emptyState
+  stringListLists _ _ = emptyState
 
-  break = toCode (mkStNoEnd empty)
-  continue = toCode (mkStNoEnd empty)
+  break = emptyState
+  continue = emptyState
 
-  returnState _ = toCode (mkStNoEnd empty)
-  multiReturn _ = toCode (mkStNoEnd empty)
+  returnState _ = emptyState
+  multiReturn _ = emptyState
 
-  valState _ = toCode (mkStNoEnd empty)
+  valState _ = emptyState
 
-  comment _ = toCode (mkStNoEnd empty)
+  comment _ = emptyState
 
-  free _ = toCode (mkStNoEnd empty)
+  free _ = emptyState
 
-  throw _ = toCode (mkStNoEnd empty)
+  throw _ = emptyState
 
-  initState _ _ = toCode (mkStNoEnd empty)
-  changeState _ _ = toCode (mkStNoEnd empty)
+  initState _ _ = emptyState
+  changeState _ _ = emptyState
 
-  initObserverList _ _ = toCode (mkStNoEnd empty)
-  addObserver _ = toCode (mkStNoEnd empty)
+  initObserverList _ _ = emptyState
+  addObserver _ = emptyState
 
-  inOutCall _ _ _ _ = toCode (mkStNoEnd empty)
-  selfInOutCall _ _ _ _ _ = toCode (mkStNoEnd empty)
-  extInOutCall _ _ _ _ _ = toCode (mkStNoEnd empty)
+  inOutCall _ _ _ _ = emptyState
+  selfInOutCall _ _ _ _ _ = emptyState
+  extInOutCall _ _ _ _ _ = emptyState
 
-  multi _ = toCode (mkStNoEnd empty)
+  multi _ = emptyState
 
 instance ControlStatementSym CppHdrCode where
-  ifCond _ _ = toCode (mkStNoEnd empty)
-  ifNoElse _ = toCode (mkStNoEnd empty)
-  switch _ _ _ = toCode (mkStNoEnd empty)
-  switchAsIf _ _ _ = toCode (mkStNoEnd empty)
+  ifCond _ _ = emptyState
+  ifNoElse _ = emptyState
+  switch _ _ _ = emptyState
+  switchAsIf _ _ _ = emptyState
 
-  ifExists _ _ _ = toCode (mkStNoEnd empty)
+  ifExists _ _ _ = emptyState
 
-  for _ _ _ _ = toCode (mkStNoEnd empty)
-  forRange _ _ _ _ _ = toCode (mkStNoEnd empty)
-  forEach _ _ _ = toCode (mkStNoEnd empty)
-  while _ _ = toCode (mkStNoEnd empty)
+  for _ _ _ _ = emptyState
+  forRange _ _ _ _ _ = emptyState
+  forEach _ _ _ = emptyState
+  while _ _ = emptyState
 
-  tryCatch _ _ = toCode (mkStNoEnd empty)
+  tryCatch _ _ = emptyState
 
-  checkState _ _ _ = toCode (mkStNoEnd empty)
+  checkState _ _ _ = emptyState
 
-  notifyObservers _ _ = toCode (mkStNoEnd empty)
+  notifyObservers _ _ = emptyState
 
-  getFileInputAll _ _ = toCode (mkStNoEnd empty)
+  getFileInputAll _ _ = emptyState
 
 instance ScopeSym CppHdrCode where
   type Scope CppHdrCode = (Doc, ScopeTag)

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer/CppRenderer.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer/CppRenderer.hs
@@ -940,12 +940,11 @@ instance VariableSym CppSrcCode where
     (cppClassVar (getTypeDoc c) (variableDoc v)))
   extClassVar = classVar
   objVar = objVarD
-  objVarSelf _ v = on2CodeValues (mkVar ("this->"++variableName v)) 
-    (variableType v) (toCode $ text "this->" <> variableDoc v)
+  objVarSelf _ v = mkVar ("this->"++variableName v) (variableType v) 
+    (text "this->" <> variableDoc v)
   listVar = listVarD
   listOf = listOfD
-  iterVar l t = on2CodeValues (mkVar l) (iterator t) (toCode $ text $ "(*" ++ l 
-    ++ ")")
+  iterVar l t = mkVar l (iterator t) (text $ "(*" ++ l ++ ")")
 
   ($->) = objVar
 
@@ -1502,19 +1501,19 @@ instance VariableSym CppHdrCode where
   type Variable CppHdrCode = VarData
   var = varD 
   staticVar = staticVarD
-  const _ _ = on2CodeValues (mkVar "") void (toCode empty)
-  extVar _ _ _ = on2CodeValues (mkVar "") void (toCode empty)
-  self _ = on2CodeValues (mkVar "") void (toCode empty)
-  enumVar _ _ = on2CodeValues (mkVar "") void (toCode empty)
-  classVar _ _ = on2CodeValues (mkVar "") void (toCode empty)
-  extClassVar _ _ = on2CodeValues (mkVar "") void (toCode empty)
-  objVar _ _ = on2CodeValues (mkVar "") void (toCode empty)
-  objVarSelf _ _ = on2CodeValues (mkVar "") void (toCode empty)
-  listVar _ _ _ = on2CodeValues (mkVar "") void (toCode empty)
-  listOf _ _ = on2CodeValues (mkVar "") void (toCode empty)
-  iterVar _ _ = on2CodeValues (mkVar "") void (toCode empty)
+  const _ _ = mkVar "" void empty
+  extVar _ _ _ = mkVar "" void empty
+  self _ = mkVar "" void empty
+  enumVar _ _ = mkVar "" void empty
+  classVar _ _ = mkVar "" void empty
+  extClassVar _ _ = mkVar "" void empty
+  objVar _ _ = mkVar "" void empty
+  objVarSelf _ _ = mkVar "" void empty
+  listVar _ _ _ = mkVar "" void empty
+  listOf _ _ = mkVar "" void empty
+  iterVar _ _ = mkVar "" void empty
 
-  ($->) _ _ = on2CodeValues (mkVar "") void (toCode empty)
+  ($->) _ _ = mkVar "" void empty
   
   variableBind = varBind . unCPPHC
   variableName = varName . unCPPHC

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer/JavaRenderer.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer/JavaRenderer.hs
@@ -38,7 +38,7 @@ import GOOL.Drasil.LanguageRenderer (packageDocD, classDocD, multiStateDocD,
   greaterEqualOpDocD, lessOpDocD, lessEqualOpDocD, plusOpDocD, minusOpDocD, 
   multOpDocD, divideOpDocD, moduloOpDocD, andOpDocD, orOpDocD, binExpr, 
   binExpr', typeBinExpr, mkVal, litTrueD, litFalseD, litCharD, litFloatD, 
-  litIntD, litStringD, classVarDocD, inlineIfD, newObjDocD, varD, 
+  litIntD, litStringD, classVarDocD, newObjDocD, varD, 
   staticVarD, extVarD, selfD, enumVarD, classVarD, objVarD, objVarSelfD, 
   listVarD, listOfD, iterVarD, valueOfD, argD, enumElementD, argsListD, 
   objAccessD, objMethodCallD, objMethodCallNoParamsD, selfAccessD, 
@@ -52,11 +52,11 @@ import GOOL.Drasil.LanguageRenderer (packageDocD, classDocD, multiStateDocD,
   addCommentsDocD, commentedModD, docFuncRepr, valueList, appendToBody, 
   surroundBody, intValue, filterOutObjs)
 import qualified GOOL.Drasil.LanguageRenderer.LanguagePolymorphic as G (
-  fileFromData, block, pi, varDec, varDecDef, listDec, listDecDef, objDecNew, 
-  objDecNewNoParams, construct, comment, ifCond, for, forEach, while, method, 
-  getMethod, setMethod,privMethod, pubMethod, constructor, docMain, function, 
-  mainFunction, docFunc, intFunc, stateVar, stateVarDef, constVar, privMVar, 
-  pubMVar, pubGVar, buildClass, enum, privClass, pubClass, docClass, 
+  fileFromData, block, pi, inlineIf, varDec, varDecDef, listDec, listDecDef, 
+  objDecNew, objDecNewNoParams, construct, comment, ifCond, for, forEach, while,
+  method, getMethod, setMethod,privMethod, pubMethod, constructor, docMain, 
+  function, mainFunction, docFunc, intFunc, stateVar, stateVarDef, constVar, 
+  privMVar, pubMVar, pubGVar, buildClass, enum, privClass, pubClass, docClass, 
   commentedClass, buildModule', modFromData, fileDoc, docMod)
 import GOOL.Drasil.Data (Terminator(..), FileType(..), FileData(..), fileD, 
   FuncData(..), fd, ModData(..), md, updateModDoc, MethodData(..), mthd, 
@@ -321,7 +321,7 @@ instance BooleanExpression JavaCode where
   (?!=) = typeBinExpr notEqualOp bool
   
 instance ValueExpression JavaCode where
-  inlineIf = on3CodeValues inlineIfD
+  inlineIf = G.inlineIf
   funcApp = funcAppD
   selfFuncApp c = selfFuncAppD (self c)
   extFuncApp = extFuncAppD

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer/JavaRenderer.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer/JavaRenderer.hs
@@ -23,14 +23,13 @@ import GOOL.Drasil.Symantics (Label, ProgramSym(..), RenderSym(..),
   ClassSym(..), InternalClass(..), ModuleSym(..), InternalMod(..), 
   BlockCommentSym(..))
 import GOOL.Drasil.LanguageRenderer (packageDocD, classDocD, multiStateDocD, 
-  bodyDocD, oneLinerD, outDoc, printFileDocD, boolTypeDocD, intTypeDocD, 
-  charTypeDocD, typeDocD, enumTypeDocD, listTypeDocD, listInnerTypeD, voidDocD, 
-  destructorError, paramDocD, paramListDocD, mkParam, runStrategyD, listSliceD, 
-  checkStateD, notifyObserversD, listDecDocD, mkSt, stringListVals', 
-  stringListLists', printStD, stateD, loopStateD, emptyStateD, assignD, 
-  assignToListIndexD, multiAssignError, decrementD, incrementD, decrement1D, 
-  increment1D, discardInputD, discardFileInputD, openFileRD, openFileWD, 
-  openFileAD, closeFileD, discardFileLineD, breakDocD, continueDocD, returnD, 
+  bodyDocD, oneLinerD, outDoc, printFileDocD, destructorError, paramDocD, 
+  paramListDocD, mkParam, runStrategyD, listSliceD, checkStateD, 
+  notifyObserversD, listDecDocD, mkSt, stringListVals', stringListLists', 
+  printStD, stateD, loopStateD, emptyStateD, assignD, assignToListIndexD, 
+  multiAssignError, decrementD, incrementD, decrement1D, increment1D, 
+  discardInputD, discardFileInputD, openFileRD, openFileWD, openFileAD, 
+  closeFileD, discardFileLineD, breakDocD, continueDocD, returnD, 
   multiReturnError, valStateD, freeError, throwD, initStateD, changeStateD, 
   initObserverListD, addObserverD, ifNoElseD, switchD, switchAsIfD, ifExistsD, 
   forRangeD, tryCatchD, unOpPrec, notOpDocD, negateOpDocD, unExpr, unExpr', 
@@ -52,7 +51,8 @@ import GOOL.Drasil.LanguageRenderer (packageDocD, classDocD, multiStateDocD,
   addCommentsDocD, commentedModD, docFuncRepr, valueList, appendToBody, 
   surroundBody, intValue, filterOutObjs)
 import qualified GOOL.Drasil.LanguageRenderer.LanguagePolymorphic as G (
-  fileFromData, block, pi, inlineIf, varDec, varDecDef, listDec, listDecDef, 
+  fileFromData, block, bool, int, double, char, listType, listInnerType, obj, 
+  enumType, void, pi, inlineIf, varDec, varDecDef, listDec, listDecDef, 
   objDecNew, objDecNewNoParams, construct, comment, ifCond, for, forEach, while,
   method, getMethod, setMethod,privMethod, pubMethod, constructor, docMain, 
   function, mainFunction, docFunc, intFunc, stateVar, stateVarDef, constVar, 
@@ -167,19 +167,19 @@ instance InternalBlock JavaCode where
 
 instance TypeSym JavaCode where
   type Type JavaCode = TypeData
-  bool = toCode boolTypeDocD
-  int = toCode intTypeDocD
-  float = toCode jFloatTypeDocD
-  char = toCode charTypeDocD
-  string = toCode jStringTypeDoc
-  infile = toCode jInfileTypeDoc
-  outfile = toCode jOutfileTypeDoc
-  listType p st = on2CodeValues jListType st (list p)
-  listInnerType = listInnerTypeD
-  obj t = toCode $ typeDocD t
-  enumType t = toCode $ enumTypeDocD t
+  bool = G.bool
+  int = G.int
+  float = G.double
+  char = G.char
+  string = jStringType
+  infile = jInfileType
+  outfile = jOutfileType
+  listType = jListType
+  listInnerType = G.listInnerType
+  obj = G.obj
+  enumType = G.enumType
   iterator t = t
-  void = toCode voidDocD
+  void = G.void
 
   getType = cType . unJC
   getTypeString = typeString . unJC
@@ -621,27 +621,28 @@ jtop end inc lst = vcat [
   inc <+> text "java.io.File" <> end,
   inc <+> text ("java.util." ++ render lst) <> end]
 
-jFloatTypeDocD :: TypeData
-jFloatTypeDocD = td Float "double" (text "double")
+jStringType :: (RenderSym repr) => repr (Type repr)
+jStringType = typeFromData String "String" (text "String")
 
-jStringTypeDoc :: TypeData
-jStringTypeDoc = td String "String" (text "String")
+jInfileType :: (RenderSym repr) => repr (Type repr)
+jInfileType = typeFromData File "Scanner" (text "Scanner")
 
-jInfileTypeDoc :: TypeData
-jInfileTypeDoc = td File "Scanner" (text "Scanner")
+jOutfileType :: (RenderSym repr) => repr (Type repr)
+jOutfileType = typeFromData File "PrintWriter" (text "PrintWriter")
 
-jOutfileTypeDoc :: TypeData
-jOutfileTypeDoc = td File "PrintWriter" (text "PrintWriter")
+jListType :: (RenderSym repr) => repr (Permanence repr) -> repr (Type repr) -> 
+  repr (Type repr)
+jListType p t = jListType' (getType t)
+  where jListType' Integer = typeFromData (List Integer) (render lst ++ 
+          "<Integer>") (lst <> angles (text "Integer"))
+        jListType' Float = typeFromData (List Float) (render lst ++ "<Double>") 
+          (lst <> angles (text "Double"))
+        jListType' _ = G.listType p t
+        lst = keyDoc $ list p
 
-jListType :: TypeData -> Doc -> TypeData
-jListType (TD Integer _ _) lst = td (List Integer) (render lst ++ "<Integer>") 
-  (lst <> angles (text "Integer"))
-jListType (TD Float _ _) lst = td (List Float) (render lst ++ "<Double>") 
-  (lst <> angles (text "Double"))
-jListType t lst = listTypeDocD t lst
 
 jArrayType :: JavaCode (Type JavaCode)
-jArrayType = toCode $ td (List $ Object "Object") "Object" (text "Object[]")
+jArrayType = typeFromData (List $ Object "Object") "Object" (text "Object[]")
 
 jEquality :: JavaCode (Value JavaCode) -> JavaCode (Value JavaCode) -> 
   JavaCode (Value JavaCode)

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer/JavaRenderer.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer/JavaRenderer.hs
@@ -13,7 +13,7 @@ import GOOL.Drasil.CodeType (CodeType(..), isObject)
 import GOOL.Drasil.Symantics (Label, ProgramSym(..), RenderSym(..), 
   InternalFile(..), KeywordSym(..), PermanenceSym(..), InternalPerm(..), 
   BodySym(..), BlockSym(..), InternalBlock(..), ControlBlockSym(..), 
-  TypeSym(..), InternalType(..), UnaryOpSym(..), BinaryOpSym(..), 
+  TypeSym(..), InternalType(..), UnaryOpSym(..), BinaryOpSym(..), InternalOp(..),
   VariableSym(..), InternalVariable(..), ValueSym(..), NumericExpression(..), 
   BooleanExpression(..), ValueExpression(..), InternalValue(..), Selector(..), 
   FunctionSym(..), SelectorFunction(..), InternalFunction(..), 
@@ -63,7 +63,7 @@ import GOOL.Drasil.Data (Terminator(..), FileType(..), FileData(..), fileD,
   updateMthdDoc, OpData(..), ParamData(..), ProgData(..), progD, TypeData(..), 
   td, ValData(..), vd, VarData(..), vard)
 import GOOL.Drasil.Helpers (angles, emptyIfNull, toCode, toState, onCodeValue, 
-  onStateValue, on2CodeValues, on2StateValues, on3CodeValues, on4CodeValues, 
+  onStateValue, on2CodeValues, on2StateValues, on3CodeValues, 
   on5CodeValues, onCodeList, on1CodeValue1List, checkParams)
 import GOOL.Drasil.State (MS, lensGStoFS, initialState, initialFS, getPutReturn,
   getPutReturnList, addProgNameToPaths, setCurrMain, setParameters)
@@ -228,6 +228,12 @@ instance BinaryOpSym JavaCode where
   andOp = toCode andOpDocD
   orOp = toCode orOpDocD
 
+instance InternalOp JavaCode where
+  uOpDoc = opDoc . unJC
+  bOpDoc = opDoc . unJC
+  uOpPrec = opPrec . unJC
+  bOpPrec = opPrec . unJC
+
 instance VariableSym JavaCode where
   type Variable JavaCode = VarData
   var = varD
@@ -277,42 +283,42 @@ instance ValueSym JavaCode where
   valueDoc = valDoc . unJC
 
 instance NumericExpression JavaCode where
-  (#~) = on2CodeValues unExpr' negateOp
-  (#/^) = on2CodeValues unExpr sqrtOp
-  (#|) = on2CodeValues unExpr absOp
-  (#+) = on3CodeValues binExpr plusOp
-  (#-) = on3CodeValues binExpr minusOp
-  (#*) = on3CodeValues binExpr multOp
-  (#/) = on3CodeValues binExpr divideOp
-  (#%) = on3CodeValues binExpr moduloOp
-  (#^) = on3CodeValues binExpr' powerOp
+  (#~) = unExpr' negateOp
+  (#/^) = unExpr sqrtOp
+  (#|) = unExpr absOp
+  (#+) = binExpr plusOp
+  (#-) = binExpr minusOp
+  (#*) = binExpr multOp
+  (#/) = binExpr divideOp
+  (#%) = binExpr moduloOp
+  (#^) = binExpr' powerOp
 
-  log = on2CodeValues unExpr logOp
-  ln = on2CodeValues unExpr lnOp
-  exp = on2CodeValues unExpr expOp
-  sin = on2CodeValues unExpr sinOp
-  cos = on2CodeValues unExpr cosOp
-  tan = on2CodeValues unExpr tanOp
+  log = unExpr logOp
+  ln = unExpr lnOp
+  exp = unExpr expOp
+  sin = unExpr sinOp
+  cos = unExpr cosOp
+  tan = unExpr tanOp
   csc v = litFloat 1.0 #/ sin v
   sec v = litFloat 1.0 #/ cos v
   cot v = litFloat 1.0 #/ tan v
-  arcsin = on2CodeValues unExpr asinOp
-  arccos = on2CodeValues unExpr acosOp
-  arctan = on2CodeValues unExpr atanOp
-  floor = on2CodeValues unExpr floorOp
-  ceil = on2CodeValues unExpr ceilOp
+  arcsin = unExpr asinOp
+  arccos = unExpr acosOp
+  arctan = unExpr atanOp
+  floor = unExpr floorOp
+  ceil = unExpr ceilOp
 
 instance BooleanExpression JavaCode where
-  (?!) = on3CodeValues typeUnExpr notOp bool
-  (?&&) = on4CodeValues typeBinExpr andOp bool
-  (?||) = on4CodeValues typeBinExpr orOp bool
+  (?!) = typeUnExpr notOp bool
+  (?&&) = typeBinExpr andOp bool
+  (?||) = typeBinExpr orOp bool
 
-  (?<) = on4CodeValues typeBinExpr lessOp bool
-  (?<=) = on4CodeValues typeBinExpr lessEqualOp bool
-  (?>) = on4CodeValues typeBinExpr greaterOp bool
-  (?>=) = on4CodeValues typeBinExpr greaterEqualOp bool
+  (?<) = typeBinExpr lessOp bool
+  (?<=) = typeBinExpr lessEqualOp bool
+  (?>) = typeBinExpr greaterOp bool
+  (?>=) = typeBinExpr greaterEqualOp bool
   (?==) = jEquality
-  (?!=) = on4CodeValues typeBinExpr notEqualOp bool
+  (?!=) = typeBinExpr notEqualOp bool
   
 instance ValueExpression JavaCode where
   inlineIf = on3CodeValues inlineIfD
@@ -641,7 +647,7 @@ jEquality :: JavaCode (Value JavaCode) -> JavaCode (Value JavaCode) ->
   JavaCode (Value JavaCode)
 jEquality v1 v2 = jEquality' (getType $ valueType v2)
   where jEquality' String = objAccess v1 (func "equals" bool [v2])
-        jEquality' _ = on4CodeValues typeBinExpr equalOp bool v1 v2
+        jEquality' _ = typeBinExpr equalOp bool v1 v2
 
 jCast :: JavaCode (Type JavaCode) -> JavaCode (Value JavaCode) -> 
   JavaCode (Value JavaCode)

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer/LanguagePolymorphic.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer/LanguagePolymorphic.hs
@@ -2,12 +2,12 @@
 
 -- | The structure for a class of renderers is defined here.
 module GOOL.Drasil.LanguageRenderer.LanguagePolymorphic (fileFromData, block, 
-  pi, varDec, varDecDef, listDec, listDecDef, objDecNew, objDecNewNoParams, 
-  comment, ifCond, for, forEach, while, construct, method, getMethod, setMethod,
-  privMethod, pubMethod, constructor, docMain, function, mainFunction, docFunc, 
-  docInOutFunc, intFunc, stateVar,stateVarDef, constVar, privMVar, pubMVar, 
-  pubGVar, buildClass, enum, privClass, pubClass, docClass, commentedClass, 
-  buildModule, buildModule', modFromData, fileDoc, docMod
+  pi, increment, increment1, varDec, varDecDef, listDec, listDecDef, objDecNew, 
+  objDecNewNoParams, comment, ifCond, for, forEach, while, construct, method, 
+  getMethod, setMethod,privMethod, pubMethod, constructor, docMain, function, 
+  mainFunction, docFunc, docInOutFunc, intFunc, stateVar,stateVarDef, constVar, 
+  privMVar, pubMVar, pubGVar, buildClass, enum, privClass, pubClass, docClass, 
+  commentedClass, buildModule, buildModule', modFromData, fileDoc, docMod
 ) where
 
 import Utils.Drasil (indent)
@@ -17,7 +17,7 @@ import GOOL.Drasil.Symantics (Label, KeywordSym(..),
   RenderSym(RenderFile, commentedMod), BlockSym(Block), 
   InternalBlock(..), BodySym(..), PermanenceSym(..), InternalPerm(..), 
   TypeSym(..), InternalType(..), VariableSym(..), 
-  ValueSym(Value, valueOf, valueDoc),
+  ValueSym(Value, litInt, valueOf, valueDoc), NumericExpression(..),
   ValueExpression(..), InternalValue(..), InternalStatement(..), 
   StatementSym(Statement, (&=), constDecDef, returnState), ScopeSym(..), 
   InternalScope(..), MethodTypeSym(mType), ParameterSym(..), 
@@ -57,6 +57,13 @@ block end sts = docBlock $ blockDocD (keyDoc end) (map (statementDoc . state)
 
 pi :: (RenderSym repr) => repr (Value repr)
 pi = valFromData Nothing float (text "Math.PI")
+
+increment :: (RenderSym repr) => repr (Variable repr) -> repr (Value repr) -> 
+  repr (Statement repr)
+increment vr vl = vr &= valueOf vr #+ vl
+
+increment1 :: (RenderSym repr) => repr (Variable repr) -> repr (Statement repr)
+increment1 vr = vr &= valueOf vr #+ litInt 1
 
 varDec :: (RenderSym repr) => repr (Permanence repr) -> repr (Permanence repr) 
   -> repr (Variable repr) -> repr (Statement repr)

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer/LanguagePolymorphic.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer/LanguagePolymorphic.hs
@@ -2,12 +2,13 @@
 
 -- | The structure for a class of renderers is defined here.
 module GOOL.Drasil.LanguageRenderer.LanguagePolymorphic (fileFromData, block, 
-  pi, increment, increment1, varDec, varDecDef, listDec, listDecDef, objDecNew, 
-  objDecNewNoParams, comment, ifCond, for, forEach, while, construct, method, 
-  getMethod, setMethod,privMethod, pubMethod, constructor, docMain, function, 
-  mainFunction, docFunc, docInOutFunc, intFunc, stateVar,stateVarDef, constVar, 
-  privMVar, pubMVar, pubGVar, buildClass, enum, privClass, pubClass, docClass, 
-  commentedClass, buildModule, buildModule', modFromData, fileDoc, docMod
+  pi, inlineIf, increment, increment1, varDec, varDecDef, listDec, listDecDef, 
+  objDecNew, objDecNewNoParams, comment, ifCond, for, forEach, while, construct,
+  method, getMethod, setMethod,privMethod, pubMethod, constructor, docMain, 
+  function, mainFunction, docFunc, docInOutFunc, intFunc, stateVar,stateVarDef, 
+  constVar, privMVar, pubMVar, pubGVar, buildClass, enum, privClass, pubClass, 
+  docClass, commentedClass, buildModule, buildModule', modFromData, fileDoc, 
+  docMod
 ) where
 
 import Utils.Drasil (indent)
@@ -17,8 +18,8 @@ import GOOL.Drasil.Symantics (Label, KeywordSym(..),
   RenderSym(RenderFile, commentedMod), BlockSym(Block), 
   InternalBlock(..), BodySym(..), PermanenceSym(..), InternalPerm(..), 
   TypeSym(..), InternalType(..), VariableSym(..), 
-  ValueSym(Value, litInt, valueOf, valueDoc), NumericExpression(..),
-  ValueExpression(..), InternalValue(..), InternalStatement(..), 
+  ValueSym(Value, litInt, valueOf, valueDoc, valueType), NumericExpression(..),
+  ValueExpression(newObj), InternalValue(..), InternalStatement(..), 
   StatementSym(Statement, (&=), constDecDef, returnState), ScopeSym(..), 
   InternalScope(..), MethodTypeSym(mType), ParameterSym(..), 
   MethodTypeSym(MethodType), MethodSym(Method), 
@@ -45,6 +46,7 @@ import GOOL.Drasil.State (GS, FS, MS, lensFStoGS, lensFStoMS, currMain,
 
 import Prelude hiding (break,print,last,mod,pi,(<>))
 import Data.Maybe (maybeToList)
+import Control.Applicative ((<|>))
 import Control.Lens ((^.), over)
 import Control.Lens.Zoom (zoom)
 import Text.PrettyPrint.HughesPJ (Doc, text, empty, render, (<>), (<+>), parens,
@@ -57,6 +59,12 @@ block end sts = docBlock $ blockDocD (keyDoc end) (map (statementDoc . state)
 
 pi :: (RenderSym repr) => repr (Value repr)
 pi = valFromData Nothing float (text "Math.PI")
+
+inlineIf :: (RenderSym repr) => repr (Value repr) -> repr (Value repr) -> 
+  repr (Value repr) -> repr (Value repr)
+inlineIf c v1 v2 = valFromData prec (valueType v1) (valueDoc c <+> text "?" <+> 
+  valueDoc v1 <+> text ":" <+> valueDoc v2)
+  where prec = valuePrec c <|> Just 0
 
 increment :: (RenderSym repr) => repr (Variable repr) -> repr (Value repr) -> 
   repr (Statement repr)

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer/LanguagePolymorphic.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer/LanguagePolymorphic.hs
@@ -2,13 +2,14 @@
 
 -- | The structure for a class of renderers is defined here.
 module GOOL.Drasil.LanguageRenderer.LanguagePolymorphic (fileFromData, block, 
-  pi, inlineIf, increment, increment1, varDec, varDecDef, listDec, listDecDef, 
-  objDecNew, objDecNewNoParams, comment, ifCond, for, forEach, while, construct,
-  method, getMethod, setMethod,privMethod, pubMethod, constructor, docMain, 
-  function, mainFunction, docFunc, docInOutFunc, intFunc, stateVar,stateVarDef, 
-  constVar, privMVar, pubMVar, pubGVar, buildClass, enum, privClass, pubClass, 
-  docClass, commentedClass, buildModule, buildModule', modFromData, fileDoc, 
-  docMod
+  pi, bool, int, float, double, char, string, fileType, listType, listInnerType,
+  obj, enumType, void, inlineIf, increment, increment1, varDec, varDecDef, 
+  listDec, listDecDef, objDecNew, objDecNewNoParams, comment, ifCond, for, 
+  forEach, while, construct, method, getMethod, setMethod,privMethod, pubMethod,
+  constructor, docMain, function, mainFunction, docFunc, docInOutFunc, intFunc, 
+  stateVar,stateVarDef, constVar, privMVar, pubMVar, pubGVar, buildClass, enum, 
+  privClass, pubClass, docClass, commentedClass, buildModule, buildModule', 
+  modFromData, fileDoc, docMod
 ) where
 
 import Utils.Drasil (indent)
@@ -17,9 +18,10 @@ import GOOL.Drasil.CodeType (CodeType(..), isObject)
 import GOOL.Drasil.Symantics (Label, KeywordSym(..),
   RenderSym(RenderFile, commentedMod), BlockSym(Block), 
   InternalBlock(..), BodySym(..), PermanenceSym(..), InternalPerm(..), 
-  TypeSym(..), InternalType(..), VariableSym(..), 
-  ValueSym(Value, litInt, valueOf, valueDoc, valueType), NumericExpression(..),
-  ValueExpression(newObj), InternalValue(..), InternalStatement(..), 
+  TypeSym(Type, getType, getTypeDoc, getTypeString), InternalType(..), 
+  VariableSym(..), ValueSym(Value, litInt, valueOf, valueDoc, valueType), 
+  NumericExpression(..), ValueExpression(newObj), InternalValue(..), 
+  InternalStatement(..), 
   StatementSym(Statement, (&=), constDecDef, returnState), ScopeSym(..), 
   InternalScope(..), MethodTypeSym(mType), ParameterSym(..), 
   MethodTypeSym(MethodType), MethodSym(Method), 
@@ -28,14 +30,14 @@ import GOOL.Drasil.Symantics (Label, KeywordSym(..),
   InternalClass(..), ModuleSym(Module), InternalMod(moduleDoc, updateModuleDoc),
   BlockComment(..))
 import qualified GOOL.Drasil.Symantics as S (InternalFile(fileFromData), 
-  StatementSym(varDec, varDecDef), MethodTypeSym(construct), 
-  MethodSym(method, mainFunction), InternalMethod(intFunc), 
-  StateVarSym(stateVar), ClassSym(buildClass, commentedClass), 
-  InternalMod(modFromData))
+  TypeSym(float, void), StatementSym(varDec, varDecDef), 
+  MethodTypeSym(construct), MethodSym(method, mainFunction), 
+  InternalMethod(intFunc), StateVarSym(stateVar), 
+  ClassSym(buildClass, commentedClass), InternalMod(modFromData))
 import GOOL.Drasil.Data (Binding(..), Terminator(..), TypeData(..), td, 
   FileType)
-import GOOL.Drasil.Helpers (vibcat, vmap, emptyIfEmpty, toState, onStateValue, 
-  on2StateValues, onStateList)
+import GOOL.Drasil.Helpers (angles, vibcat, vmap, emptyIfEmpty, toState, 
+  onStateValue, on2StateValues, onStateList, getInnerType, convType)
 import GOOL.Drasil.LanguageRenderer (forLabel, addExt, blockDocD, stateVarDocD, 
   stateVarListDocD, methodListDocD, enumDocD, enumElementsDocD, moduleDocD, 
   fileDoc', docFuncRepr, commentDocD, commentedItem, functionDox, classDox, 
@@ -57,8 +59,46 @@ block :: (RenderSym repr) => repr (Keyword repr) -> [repr (Statement repr)] ->
 block end sts = docBlock $ blockDocD (keyDoc end) (map (statementDoc . state) 
   sts)
 
+bool :: (RenderSym repr) => repr (Type repr)
+bool = typeFromData Boolean "Boolean" (text "Boolean")
+
+int :: (RenderSym repr) => repr (Type repr)
+int = typeFromData Integer "int" (text "int")
+
+float :: (RenderSym repr) => repr (Type repr)
+float = typeFromData Float "float" (text "float")
+
+double :: (RenderSym repr) => repr (Type repr)
+double = typeFromData Float "double" (text "double")
+
+char :: (RenderSym repr) => repr (Type repr)
+char = typeFromData Char "char" (text "char")
+
+string :: (RenderSym repr) => repr (Type repr)
+string = typeFromData String "string" (text "string")
+
+fileType :: (RenderSym repr) => repr (Type repr)
+fileType = typeFromData File "File" (text "File")
+
+listType :: (RenderSym repr) => repr (Permanence repr) -> repr (Type repr) -> 
+  repr (Type repr)
+listType p t = typeFromData (List (getType t)) (render (keyDoc $ list p) ++ 
+  "<" ++ getTypeString t ++ ">") (keyDoc (list p) <> angles (getTypeDoc t))
+
+listInnerType :: (RenderSym repr) => repr (Type repr) -> repr (Type repr)
+listInnerType = convType . getInnerType . getType
+
+obj :: (RenderSym repr) => Label -> repr (Type repr)
+obj n = typeFromData (Object n) n (text n)
+
+enumType :: (RenderSym repr) => Label -> repr (Type repr)
+enumType e = typeFromData (Enum e) e (text e)
+
+void :: (RenderSym repr) => repr (Type repr)
+void = typeFromData Void "void" (text "void")
+
 pi :: (RenderSym repr) => repr (Value repr)
-pi = valFromData Nothing float (text "Math.PI")
+pi = valFromData Nothing S.float (text "Math.PI")
 
 inlineIf :: (RenderSym repr) => repr (Value repr) -> repr (Value repr) -> 
   repr (Value repr) -> repr (Value repr)
@@ -172,7 +212,7 @@ getMethod c v = S.method (getterName $ variableName v) c public dynamic_
 
 setMethod :: (RenderSym repr) => Label -> repr (Variable repr) -> 
   MS (repr (Method repr))
-setMethod c v = S.method (setterName $ variableName v) c public dynamic_ void 
+setMethod c v = S.method (setterName $ variableName v) c public dynamic_ S.void 
   [param v] setBody
   where setBody = oneLiner $ objVarSelf c v &= valueOf v
 
@@ -203,7 +243,7 @@ function n s p t = S.intFunc False n s p (mType t)
 
 mainFunction :: (RenderSym repr) => repr (Type repr) -> Label -> 
   repr (Body repr) -> MS (repr (Method repr))
-mainFunction s n = S.intFunc True n public static_ (mType void)
+mainFunction s n = S.intFunc True n public static_ (mType S.void)
   [param (var "args" (typeFromData (List String) (render (getTypeDoc s) ++ 
   "[]") (getTypeDoc s <> text "[]")))]
 

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer/PythonRenderer.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer/PythonRenderer.hs
@@ -22,8 +22,7 @@ import GOOL.Drasil.Symantics (Label, ProgramSym(..), RenderSym(..),
   ClassSym(..), InternalClass(..), ModuleSym(..), InternalMod(..), 
   BlockCommentSym(..))
 import GOOL.Drasil.LanguageRenderer (enumElementsDocD', multiStateDocD, 
-  bodyDocD, oneLinerD, outDoc, intTypeDocD, floatTypeDocD, typeDocD, 
-  enumTypeDocD, listInnerTypeD, destructorError, paramListDocD, mkParam, 
+  bodyDocD, oneLinerD, outDoc, destructorError, paramListDocD, mkParam, 
   runStrategyD, checkStateD, multiAssignDoc, returnDocD, mkStNoEnd, 
   stringListVals', stringListLists', stateD, loopStateD, emptyStateD, assignD, 
   assignToListIndexD, decrementD, decrement1D, closeFileD, discardFileLineD, 
@@ -47,11 +46,11 @@ import GOOL.Drasil.LanguageRenderer (enumElementsDocD', multiStateDocD,
   commentedItem, addCommentsDocD, commentedModD, docFuncRepr, 
   valueList, surroundBody, filterOutObjs)
 import qualified GOOL.Drasil.LanguageRenderer.LanguagePolymorphic as G (
-  fileFromData, block, increment, increment1, comment, ifCond, objDecNew, 
-  objDecNewNoParams, construct, method, getMethod, setMethod, privMethod, 
-  pubMethod, constructor, function, docFunc, stateVarDef, constVar, privMVar, 
-  pubMVar, pubGVar, buildClass, privClass, pubClass, docClass, commentedClass, 
-  buildModule, modFromData, fileDoc, docMod)
+  fileFromData, block, int, float, listInnerType, obj, enumType, increment, 
+  increment1, comment, ifCond, objDecNew, objDecNewNoParams, construct, method, 
+  getMethod, setMethod, privMethod, pubMethod, constructor, function, docFunc, 
+  stateVarDef, constVar, privMVar, pubMVar, pubGVar, buildClass, privClass, 
+  pubClass, docClass, commentedClass, buildModule, modFromData, fileDoc, docMod)
 import GOOL.Drasil.Data (Terminator(..), FileType(..), FileData(..), fileD,
   FuncData(..), fd, ModData(..), md, updateModDoc, MethodData(..), mthd, 
   updateMthdDoc, OpData(..), ParamData(..), ProgData(..), progD, TypeData(..), 
@@ -162,19 +161,19 @@ instance InternalBlock PythonCode where
 
 instance TypeSym PythonCode where
   type Type PythonCode = TypeData
-  bool = toCode $ td Boolean "" empty
-  int = toCode intTypeDocD
-  float = toCode floatTypeDocD
-  char = toCode $ td Char "" empty
-  string = toCode pyStringType
-  infile = toCode $ td File "" empty
-  outfile = toCode $ td File "" empty
-  listType _ t = toCode $ td (List (getType t)) "[]" (brackets empty)
-  listInnerType = listInnerTypeD
-  obj t = toCode $ typeDocD t
-  enumType t = toCode $ enumTypeDocD t
+  bool = typeFromData Boolean "" empty
+  int = G.int
+  float = G.float
+  char = typeFromData Char "" empty
+  string = pyStringType
+  infile = typeFromData File "" empty
+  outfile = typeFromData File "" empty
+  listType _ t = typeFromData (List (getType t)) "[]" (brackets empty)
+  listInnerType = G.listInnerType
+  obj = G.obj
+  enumType = G.enumType
   iterator t = t
-  void = toCode $ td Void "NoneType" (text "NoneType")
+  void = typeFromData Void "NoneType" (text "NoneType")
 
   getType = cType . unPC
   getTypeString = typeString . unPC
@@ -656,8 +655,8 @@ pyInlineIf c v1 v2 = valFromData (valuePrec c) (valueType v1)
 pyListSize :: Doc -> Doc -> Doc
 pyListSize v f = f <> parens v
 
-pyStringType :: TypeData
-pyStringType = td String "str" (text "str")
+pyStringType :: (RenderSym repr) => repr (Type repr)
+pyStringType = typeFromData String "str" (text "str")
 
 pyListDec :: (RenderSym repr) => repr (Variable repr) -> Doc
 pyListDec v = variableDoc v <+> equals <+> getTypeDoc (variableType v)

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer/PythonRenderer.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer/PythonRenderer.hs
@@ -232,7 +232,7 @@ instance VariableSym PythonCode where
   staticVar = staticVarD
   const = var
   extVar = extVarD
-  self l = on2CodeValues (mkVar "self") (obj l) (toCode $ text "self")
+  self l = mkVar "self" (obj l) (text "self")
   enumVar = enumVarD
   classVar = classVarD classVarDocD
   extClassVar = classVarD pyClassVar

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer/PythonRenderer.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer/PythonRenderer.hs
@@ -12,7 +12,7 @@ import GOOL.Drasil.CodeType (CodeType(..), isObject)
 import GOOL.Drasil.Symantics (Label, ProgramSym(..), RenderSym(..), 
   InternalFile(..), KeywordSym(..), PermanenceSym(..), InternalPerm(..), 
   BodySym(..), BlockSym(..), InternalBlock(..), ControlBlockSym(..), 
-  TypeSym(..), InternalType(..), UnaryOpSym(..), BinaryOpSym(..), 
+  TypeSym(..), InternalType(..), UnaryOpSym(..), BinaryOpSym(..), InternalOp(..),
   VariableSym(..), InternalVariable(..), ValueSym(..), NumericExpression(..), 
   BooleanExpression(..), ValueExpression(..), InternalValue(..), Selector(..), 
   FunctionSym(..), SelectorFunction(..), InternalFunction(..), 
@@ -57,7 +57,7 @@ import GOOL.Drasil.Data (Terminator(..), FileType(..), FileData(..), fileD,
   updateMthdDoc, OpData(..), ParamData(..), ProgData(..), progD, TypeData(..), 
   td, ValData(..), vd, VarData(..), vard)
 import GOOL.Drasil.Helpers (emptyIfEmpty, toCode, toState, onCodeValue,
-  onStateValue, on2CodeValues, on2StateValues, on3CodeValues, on4CodeValues, 
+  onStateValue, on2CodeValues, on2StateValues, on3CodeValues, 
   on5CodeValues, onCodeList, onStateList, on1CodeValue1List, checkParams)
 import GOOL.Drasil.State (MS, lensGStoFS, initialState, initialFS, getPutReturn,
   setCurrMain, setParameters)
@@ -225,6 +225,12 @@ instance BinaryOpSym PythonCode where
   andOp = toCode $ andPrec "and"
   orOp = toCode $ orPrec "or"
 
+instance InternalOp PythonCode where
+  uOpDoc = opDoc . unPC
+  bOpDoc = opDoc . unPC
+  uOpPrec = opPrec . unPC
+  bOpPrec = opPrec . unPC
+
 instance VariableSym PythonCode where
   type Variable PythonCode = VarData
   var = varD
@@ -273,45 +279,44 @@ instance ValueSym PythonCode where
   valueDoc = valDoc . unPC
 
 instance NumericExpression PythonCode where
-  (#~) = on2CodeValues unExpr' negateOp
-  (#/^) = on2CodeValues unExpr sqrtOp
-  (#|) = on2CodeValues unExpr absOp
-  (#+) = on3CodeValues binExpr plusOp
-  (#-) = on3CodeValues binExpr minusOp
-  (#*) = on3CodeValues binExpr multOp
+  (#~) = unExpr' negateOp
+  (#/^) = unExpr sqrtOp
+  (#|) = unExpr absOp
+  (#+) = binExpr plusOp
+  (#-) = binExpr minusOp
+  (#*) = binExpr multOp
   (#/) v1 v2 = pyDivision (getType $ valueType v1) (getType $ valueType v2) 
-    where pyDivision Integer Integer = on2CodeValues (binExpr (multPrec "//")) 
-            v1 v2
-          pyDivision _ _ = on3CodeValues binExpr divideOp v1 v2
-  (#%) = on3CodeValues binExpr moduloOp
-  (#^) = on3CodeValues binExpr powerOp
+    where pyDivision Integer Integer = binExpr (toCode $ multPrec "//") v1 v2
+          pyDivision _ _ = binExpr divideOp v1 v2
+  (#%) = binExpr moduloOp
+  (#^) = binExpr powerOp
 
-  log = on2CodeValues unExpr logOp
-  ln = on2CodeValues unExpr lnOp
-  exp = on2CodeValues unExpr expOp
-  sin = on2CodeValues unExpr sinOp
-  cos = on2CodeValues unExpr cosOp
-  tan = on2CodeValues unExpr tanOp
+  log = unExpr logOp
+  ln = unExpr lnOp
+  exp = unExpr expOp
+  sin = unExpr sinOp
+  cos = unExpr cosOp
+  tan = unExpr tanOp
   csc v = litFloat 1.0 #/ sin v
   sec v = litFloat 1.0 #/ cos v
   cot v = litFloat 1.0 #/ tan v
-  arcsin = on2CodeValues unExpr asinOp
-  arccos = on2CodeValues unExpr acosOp
-  arctan = on2CodeValues unExpr atanOp
-  floor = on2CodeValues unExpr floorOp
-  ceil = on2CodeValues unExpr ceilOp
+  arcsin = unExpr asinOp
+  arccos = unExpr acosOp
+  arctan = unExpr atanOp
+  floor = unExpr floorOp
+  ceil = unExpr ceilOp
 
 instance BooleanExpression PythonCode where
-  (?!) = on3CodeValues typeUnExpr notOp bool
-  (?&&) = on4CodeValues typeBinExpr andOp bool
-  (?||) = on4CodeValues typeBinExpr orOp bool
+  (?!) = typeUnExpr notOp bool
+  (?&&) = typeBinExpr andOp bool
+  (?||) = typeBinExpr orOp bool
 
-  (?<) = on4CodeValues typeBinExpr lessOp bool
-  (?<=) = on4CodeValues typeBinExpr lessEqualOp bool
-  (?>) = on4CodeValues typeBinExpr greaterOp bool
-  (?>=) = on4CodeValues typeBinExpr greaterEqualOp bool
-  (?==) = on4CodeValues typeBinExpr equalOp bool
-  (?!=) = on4CodeValues typeBinExpr notEqualOp bool
+  (?<) = typeBinExpr lessOp bool
+  (?<=) = typeBinExpr lessEqualOp bool
+  (?>) = typeBinExpr greaterOp bool
+  (?>=) = typeBinExpr greaterEqualOp bool
+  (?==) = typeBinExpr equalOp bool
+  (?!=) = typeBinExpr notEqualOp bool
 
 instance ValueExpression PythonCode where
   inlineIf = on3CodeValues pyInlineIf

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer/PythonRenderer.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer/PythonRenderer.hs
@@ -27,7 +27,7 @@ import GOOL.Drasil.LanguageRenderer (enumElementsDocD', multiStateDocD,
   runStrategyD, checkStateD, multiAssignDoc, returnDocD, mkStNoEnd, 
   stringListVals', stringListLists', stateD, loopStateD, emptyStateD, assignD, 
   assignToListIndexD, decrementD, decrement1D, closeFileD, discardFileLineD, 
-  breakD, continueD, returnD, valStateD, throwD, initStateD, 
+  breakDocD, continueDocD, returnD, valStateD, throwD, initStateD, 
   changeStateD, initObserverListD, addObserverD, ifNoElseD, switchAsIfD, 
   ifExistsD, tryCatchD, unOpPrec, notOpDocD', negateOpDocD, sqrtOpDocD', 
   absOpDocD', expOpDocD', sinOpDocD', cosOpDocD', tanOpDocD', asinOpDocD', 
@@ -333,6 +333,7 @@ instance InternalValue PythonCode where
   
   cast t v = mkVal t $ castObjDocD (getTypeDoc t) (valueDoc v)
 
+  valuePrec = valPrec . unPC
   valFromData p t d = on2CodeValues (vd p) t (toCode d)
 
 instance Selector PythonCode where
@@ -451,8 +452,8 @@ instance StatementSym PythonCode where
   stringListVals = stringListVals'
   stringListLists = stringListLists'
 
-  break = breakD Empty
-  continue = continueD Empty
+  break = mkStNoEnd breakDocD
+  continue = mkStNoEnd continueDocD
 
   returnState = returnD Empty
   multiReturn [] = error "Attempt to write return statement with no return variables"

--- a/code/drasil-gool/GOOL/Drasil/Symantics.hs
+++ b/code/drasil-gool/GOOL/Drasil/Symantics.hs
@@ -7,14 +7,15 @@ module GOOL.Drasil.Symantics (
   ProgramSym(..), RenderSym(..), InternalFile(..),  KeywordSym(..), 
   PermanenceSym(..), InternalPerm(..), BodySym(..), ControlBlockSym(..), 
   BlockSym(..), InternalBlock(..), TypeSym(..), InternalType(..), 
-  UnaryOpSym(..), BinaryOpSym(..), VariableSym(..), InternalVariable(..), 
-  ValueSym(..), NumericExpression(..), BooleanExpression(..), 
-  ValueExpression(..), InternalValue(..), Selector(..), FunctionSym(..), 
-  SelectorFunction(..), InternalFunction(..), InternalStatement(..), 
-  StatementSym(..), ControlStatementSym(..), ScopeSym(..), InternalScope(..), 
-  MethodTypeSym(..), ParameterSym(..), MethodSym(..), InternalMethod(..), 
-  StateVarSym(..), InternalStateVar(..), ClassSym(..), InternalClass(..), 
-  ModuleSym(..), InternalMod(..), BlockCommentSym(..)
+  UnaryOpSym(..), BinaryOpSym(..), InternalOp(..), VariableSym(..), 
+  InternalVariable(..), ValueSym(..), NumericExpression(..), 
+  BooleanExpression(..), ValueExpression(..), InternalValue(..), 
+  Selector(..), FunctionSym(..), SelectorFunction(..), InternalFunction(..), 
+  InternalStatement(..), StatementSym(..), ControlStatementSym(..), 
+  ScopeSym(..), InternalScope(..), MethodTypeSym(..), ParameterSym(..), 
+  MethodSym(..), InternalMethod(..), StateVarSym(..), InternalStateVar(..), 
+  ClassSym(..), InternalClass(..), ModuleSym(..), InternalMod(..), 
+  BlockCommentSym(..)
 ) where
 
 import GOOL.Drasil.CodeType (CodeType)
@@ -140,7 +141,7 @@ class (ControlStatementSym repr) => ControlBlockSym repr where
     Maybe (repr (Value repr)) -> Maybe (repr (Value repr)) ->
     Maybe (repr (Value repr)) -> repr (Block repr)
 
-class UnaryOpSym repr where
+class (InternalOp repr) => UnaryOpSym repr where
   type UnaryOp repr
   notOp    :: repr (UnaryOp repr)
   negateOp :: repr (UnaryOp repr)
@@ -158,7 +159,7 @@ class UnaryOpSym repr where
   floorOp  :: repr (UnaryOp repr)
   ceilOp   :: repr (UnaryOp repr)
 
-class BinaryOpSym repr where
+class (InternalOp repr) => BinaryOpSym repr where
   type BinaryOp repr
   equalOp        :: repr (BinaryOp repr)
   notEqualOp     :: repr (BinaryOp repr)
@@ -174,6 +175,12 @@ class BinaryOpSym repr where
   moduloOp       :: repr (BinaryOp repr)
   andOp          :: repr (BinaryOp repr)
   orOp           :: repr (BinaryOp repr)
+
+class InternalOp repr where
+  uOpDoc :: repr (UnaryOp repr) -> Doc
+  bOpDoc :: repr (BinaryOp repr) -> Doc
+  uOpPrec :: repr (UnaryOp repr) -> Int
+  bOpPrec :: repr (BinaryOp repr) -> Int
 
 class (TypeSym repr, InternalVariable repr) => VariableSym repr where
   type Variable repr

--- a/code/drasil-gool/GOOL/Drasil/Symantics.hs
+++ b/code/drasil-gool/GOOL/Drasil/Symantics.hs
@@ -323,6 +323,7 @@ class InternalValue repr where
 
   cast :: repr (Type repr) -> repr (Value repr) -> repr (Value repr)
 
+  valuePrec :: repr (Value repr) -> Maybe Int
   valFromData :: Maybe Int -> repr (Type repr) -> Doc -> repr (Value repr)
 
 -- The cyclic constraints issue arises here too. I've constrained this by ValueExpression,


### PR DESCRIPTION
This PR updates various functions to be in the `repr` context, avoiding the need for the renderers to have to lift the functions to work on their parameters, which should make the renderers more readable.