### PR TITLE
Add State to Parameters in GOOL

### DIFF
--- a/code/drasil-code/Language/Drasil/Code/Imperative/GenerateGOOL.hs
+++ b/code/drasil-code/Language/Drasil/Code/Imperative/GenerateGOOL.hs
@@ -72,7 +72,8 @@ fAppInOut m n ins outs both = do
     (eMap $ codeSpec g) == Just cm then inOutCall n ins outs both else 
     selfInOutCall m n ins outs both
 
-mkParam :: (RenderSym repr) => repr (Variable repr) -> repr (Parameter repr)
+mkParam :: (RenderSym repr) => repr (Variable repr) -> 
+  MS (repr (Parameter repr))
 mkParam v = paramFunc (getType $ variableType v) v
   where paramFunc (List _) = pointerParam
         paramFunc (Object _) = pointerParam

--- a/code/drasil-code/Language/Drasil/Code/Imperative/Import.hs
+++ b/code/drasil-code/Language/Drasil/Code/Imperative/Import.hs
@@ -141,8 +141,8 @@ genConstructor :: (RenderSym repr, HasUID c, HasCodeType c, CodeIdea c) =>
 genConstructor n desc p = genMethod (constructor n) n desc p Nothing
 
 genMethod :: (RenderSym repr, HasUID c, HasCodeType c, CodeIdea c) => 
-  ([repr (Parameter repr)] -> repr (Body repr) -> MS (repr (Method repr))) -> 
-  Label -> String -> [c] -> Maybe String -> [repr (Block repr)] -> 
+  ([MS (repr (Parameter repr))] -> repr (Body repr) -> MS (repr (Method repr))) 
+  -> Label -> String -> [c] -> Maybe String -> [repr (Block repr)] -> 
   Reader DrasilState (MS (repr (Method repr)))
 genMethod f n desc p r b = do
   g <- ask

--- a/code/drasil-gool/GOOL/Drasil/Helpers.hs
+++ b/code/drasil-gool/GOOL/Drasil/Helpers.hs
@@ -2,8 +2,8 @@ module GOOL.Drasil.Helpers (verticalComma, angles, doubleQuotedText, himap,
   hicat, vicat, vibcat, vmap, vimap, vibmap, emptyIfEmpty, emptyIfNull, 
   mapPairFst, mapPairSnd, toCode, toState, onCodeValue, onStateValue, 
   on2CodeValues, on2StateValues, on3CodeValues, on3StateValues, on4CodeValues, 
-  on5CodeValues, onCodeList, onStateList, on2StateLists, on1CodeValue1List, 
-  on1StateValue1List, getInnerType, getNestDegree, convType
+  onCodeList, onStateList, on2StateLists, on1CodeValue1List, on1StateValue1List,
+  getInnerType, getNestDegree, convType
 ) where
 
 import Utils.Drasil (blank)
@@ -92,10 +92,6 @@ on3StateValues = liftM3
 on4CodeValues :: Applicative f => (a -> b -> c -> d -> e) -> f a -> f b -> f c 
   -> f d -> f e
 on4CodeValues f a1 a2 a3 a4 = liftA3 f a1 a2 a3 <*> a4
-
-on5CodeValues :: Applicative f => (a -> b -> c -> d -> e -> g) -> f a -> f b -> 
-  f c -> f d -> f e -> f g
-on5CodeValues f a1 a2 a3 a4 a5 = on4CodeValues f a1 a2 a3 a4 <*> a5
 
 onCodeList :: Monad m => ([a] -> b) -> [m a] -> m b
 onCodeList f as = f <$> sequence as

--- a/code/drasil-gool/GOOL/Drasil/Helpers.hs
+++ b/code/drasil-gool/GOOL/Drasil/Helpers.hs
@@ -3,13 +3,12 @@ module GOOL.Drasil.Helpers (verticalComma, angles, doubleQuotedText, himap,
   mapPairFst, mapPairSnd, toCode, toState, onCodeValue, onStateValue, 
   on2CodeValues, on2StateValues, on3CodeValues, on3StateValues, on4CodeValues, 
   on5CodeValues, onCodeList, onStateList, on2StateLists, on1CodeValue1List, 
-  on1StateValue1List, getInnerType, getNestDegree, convType, checkParams
+  on1StateValue1List, getInnerType, getNestDegree, convType
 ) where
 
 import Utils.Drasil (blank)
 
 import qualified GOOL.Drasil.CodeType as C (CodeType(..))
-import GOOL.Drasil.Data (ParamData)
 import qualified GOOL.Drasil.Symantics as S ( 
   RenderSym(..), TypeSym(..), PermanenceSym(dynamic_))
 
@@ -17,7 +16,7 @@ import Prelude hiding ((<>))
 import Control.Applicative (liftA2, liftA3)
 import Control.Monad (liftM2, liftM3)
 import Control.Monad.State (State)
-import Data.List (intersperse, nub)
+import Data.List (intersperse)
 import Text.PrettyPrint.HughesPJ (Doc, vcat, hcat, text, char, doubleQuotes, 
   (<>), comma, punctuate, empty, isEmpty)
 
@@ -133,7 +132,3 @@ convType (C.Object n) = S.obj n
 convType (C.Enum n) = S.enumType n
 convType C.Void = S.void
 convType C.File = error "convType: File ?"
-
-checkParams :: String -> [ParamData] -> [ParamData]
-checkParams n ps = if length ps == length (nub ps) then ps else error 
-  ("Duplicate parameters encountered in function " ++ n ++ ".")

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer.hs
@@ -9,7 +9,7 @@ module GOOL.Drasil.LanguageRenderer (
   -- * Default Functions available for use in renderers
   packageDocD, fileDoc', moduleDocD, classDocD, enumDocD, enumElementsDocD, 
   enumElementsDocD', multiStateDocD, blockDocD, bodyDocD, oneLinerD, outDoc, 
-  printDoc, printFileDocD, destructorError, paramDocD, paramListDocD, mkParam, 
+  printDoc, printFileDocD, destructorError, paramDocD, paramListDocD, 
   methodDocD, methodListDocD, stateVarDocD, constVarDocD, stateVarListDocD, 
   switchDocD, assignDocD, multiAssignDoc, plusEqualsDocD, plusPlusDocD, 
   listDecDocD, listDecDefDocD, statementDocD, returnDocD, commentDocD, freeDocD,
@@ -63,8 +63,8 @@ import GOOL.Drasil.Symantics (Label, Library, RenderSym(..), BodySym(..),
   MethodSym(..), InternalMethod(..), BlockCommentSym(..))
 import qualified GOOL.Drasil.Symantics as S (TypeSym(char, int))
 import GOOL.Drasil.Data (Terminator(..), FileData(..), fileD, updateFileMod, 
-  updateModDoc, OpData(..), od, ParamData(..), pd, paramName, TypeData(..), 
-  Binding(..), VarData(..))
+  updateModDoc, OpData(..), od, ParamData(..), TypeData(..), Binding(..), 
+  VarData(..))
 import GOOL.Drasil.Helpers (doubleQuotedText, hicat, vibcat, vmap, 
   emptyIfEmpty, emptyIfNull, onStateValue, getNestDegree)
 import GOOL.Drasil.State (MS, getParameters)
@@ -220,14 +220,11 @@ printFileDocD fn f = f <> dot <> text fn
 
 -- Parameters --
 
-paramDocD :: VarData -> Doc
-paramDocD v = typeDoc (varType v) <+> varDoc v
+paramDocD :: (RenderSym repr) => repr (Variable repr) -> Doc
+paramDocD v = getTypeDoc (variableType v) <+> variableDoc v
 
 paramListDocD :: [ParamData] -> Doc
 paramListDocD = hicat (text ", ") . map paramDoc
-
-mkParam :: (VarData -> Doc) -> VarData -> ParamData
-mkParam f v = pd v (f v)
 
 -- Method --
 
@@ -1087,8 +1084,7 @@ commentedModD m cmt = updateFileMod (updateModDoc (commentedItem cmt) (fileMod m
 docFuncRepr :: (MethodSym repr) => String -> [String] -> [String] -> 
   MS (repr (Method repr)) -> MS (repr (Method repr))
 docFuncRepr desc pComms rComms = commentedFunc (docComment $ onStateValue 
-  (\ps -> functionDox desc (zip (map paramName ps) pComms) rComms) 
-  getParameters)
+  (\ps -> functionDox desc (zip ps pComms) rComms) getParameters)
 
 -- Helper Functions --
 

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer.hs
@@ -9,13 +9,13 @@ module GOOL.Drasil.LanguageRenderer (
   -- * Default Functions available for use in renderers
   packageDocD, fileDoc', moduleDocD, classDocD, enumDocD, enumElementsDocD, 
   enumElementsDocD', multiStateDocD, blockDocD, bodyDocD, oneLinerD, outDoc, 
-  printDoc, printFileDocD, destructorError, paramDocD, paramListDocD, 
-  methodDocD, methodListDocD, stateVarDocD, constVarDocD, stateVarListDocD, 
-  switchDocD, assignDocD, multiAssignDoc, plusEqualsDocD, plusPlusDocD, 
-  listDecDocD, listDecDefDocD, statementDocD, returnDocD, commentDocD, freeDocD,
-  mkSt, mkStNoEnd, stringListVals', stringListLists', printStD, stateD, 
-  loopStateD, emptyStateD, assignD, assignToListIndexD, multiAssignError, 
-  decrementD, incrementD, decrement1D, increment1D, constDecDefD, discardInputD,
+  printDoc, printFileDocD, destructorError, paramDocD, methodDocD, 
+  methodListDocD, stateVarDocD, constVarDocD, stateVarListDocD, switchDocD, 
+  assignDocD, multiAssignDoc, plusEqualsDocD, plusPlusDocD, listDecDocD, 
+  listDecDefDocD, statementDocD, returnDocD, commentDocD, freeDocD, mkSt, 
+  mkStNoEnd, stringListVals', stringListLists', printStD, stateD, loopStateD, 
+  emptyStateD, assignD, assignToListIndexD, multiAssignError, decrementD, 
+  incrementD, decrement1D, increment1D, constDecDefD, discardInputD,
   discardFileInputD, openFileRD, openFileWD, openFileAD, closeFileD, 
   discardFileLineD, returnD, multiReturnError, valStateD, 
   freeError, throwD, initStateD, changeStateD, initObserverListD, addObserverD, 
@@ -43,8 +43,8 @@ module GOOL.Drasil.LanguageRenderer (
   iterEndError, listAccessFuncD, listAccessFuncD', listSetFuncD, includeD, 
   breakDocD, continueDocD, staticDocD, dynamicDocD, bindingError, privateDocD, 
   publicDocD, blockCmtDoc, docCmtDoc, commentedItem, addCommentsDocD, 
-  functionDox, classDox, moduleDox, commentedModD, docFuncRepr, 
-  valueList, variableList, prependToBody, appendToBody, surroundBody, 
+  functionDox, classDox, moduleDox, commentedModD, docFuncRepr, valueList, 
+  variableList, parameterList, prependToBody, appendToBody, surroundBody, 
   getterName, setterName, setEmpty, intValue, filterOutObjs
 ) where
 
@@ -52,7 +52,7 @@ import Utils.Drasil (blank, capitalize, indent, indentList, stringList)
 
 import GOOL.Drasil.CodeType (CodeType(..), isObject)
 import GOOL.Drasil.Symantics (Label, Library, RenderSym(..), BodySym(..), 
-  BlockSym(..), InternalBlock(..), PermanenceSym(..),
+  BlockSym(..), InternalBlock(..), PermanenceSym(..), InternalPerm(..),
   TypeSym(Type, getType, getTypeString, getTypeDoc, bool, float, string, infile,
     outfile, listType, listInnerType, obj, enumType, iterator, void), 
   UnaryOpSym(..), BinaryOpSym(..), InternalOp(..), VariableSym(..), 
@@ -60,23 +60,23 @@ import GOOL.Drasil.Symantics (Label, Library, RenderSym(..), BodySym(..),
   BooleanExpression(..), ValueExpression(..), InternalValue(..), Selector(..), 
   FunctionSym(..), SelectorFunction(..), InternalFunction(..), 
   InternalStatement(..), StatementSym(..), ControlStatementSym(..), 
+  ScopeSym(..), InternalScope(..), ParameterSym(..), InternalParam(..), 
   MethodSym(..), InternalMethod(..), BlockCommentSym(..))
 import qualified GOOL.Drasil.Symantics as S (TypeSym(char, int))
 import GOOL.Drasil.Data (Terminator(..), FileData(..), fileD, updateFileMod, 
-  updateModDoc, OpData(..), od, ParamData(..), TypeData(..), Binding(..), 
-  VarData(..))
+  updateModDoc, OpData(..), od, TypeData(..), Binding(..), VarData(..))
 import GOOL.Drasil.Helpers (doubleQuotedText, hicat, vibcat, vmap, 
   emptyIfEmpty, emptyIfNull, onStateValue, getNestDegree)
 import GOOL.Drasil.State (MS, getParameters)
 
-import Data.List (intersperse, last)
+import Data.List (last)
 import Data.Bifunctor (first)
 import Data.Map as Map (lookup, fromList)
 import Data.Maybe (fromMaybe)
 import Prelude hiding (break,print,last,mod,(<>))
 import Text.PrettyPrint.HughesPJ (Doc, text, empty, render, (<>), (<+>), ($+$),
   space, brackets, parens, isEmpty, rbrace, lbrace, vcat, char, double, quotes, 
-  integer, semi, equals, braces, int, comma, colon, hcat)
+  integer, semi, equals, braces, int, comma, colon)
 
 ----------------------------------------
 -- Syntax common to several renderers --
@@ -223,15 +223,15 @@ printFileDocD fn f = f <> dot <> text fn
 paramDocD :: (RenderSym repr) => repr (Variable repr) -> Doc
 paramDocD v = getTypeDoc (variableType v) <+> variableDoc v
 
-paramListDocD :: [ParamData] -> Doc
-paramListDocD = hicat (text ", ") . map paramDoc
-
 -- Method --
 
-methodDocD :: Label -> Doc -> Doc -> TypeData -> Doc -> Doc -> Doc
+methodDocD :: (RenderSym repr) => Label -> repr (Scope repr) -> 
+  repr (Permanence repr) -> repr (Type repr) -> [repr (Parameter repr)] -> 
+  repr (Body repr) -> Doc
 methodDocD n s p t ps b = vcat [
-  s <+> p <+> typeDoc t <+> text n <> parens ps <+> lbrace,
-  indent b,
+  scopeDoc s <+> permDoc p <+> getTypeDoc t <+> text n <> 
+    parens (parameterList ps) <+> lbrace,
+  indent (bodyDoc b),
   rbrace]
 
 methodListDocD :: [Doc] -> Doc
@@ -1089,10 +1089,13 @@ docFuncRepr desc pComms rComms = commentedFunc (docComment $ onStateValue
 -- Helper Functions --
 
 valueList :: (RenderSym repr) => [repr (Value repr)] -> Doc
-valueList vs = hcat (intersperse (text ", ") (map valueDoc vs))
+valueList = hicat (text ", ") . map valueDoc
 
 variableList :: (RenderSym repr) => [repr (Variable repr)] -> Doc
-variableList vs = hcat (intersperse (text ", ") (map variableDoc vs))
+variableList = hicat (text ", ") . map variableDoc
+
+parameterList :: (RenderSym repr) => [repr (Parameter repr)] -> Doc
+parameterList = hicat (text ", ") . map parameterDoc
 
 prependToBody :: (Doc, Terminator) -> Doc -> Doc
 prependToBody s b = vcat [fst $ statementDocD s, maybeBlank, b]

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer/CSharpRenderer.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer/CSharpRenderer.hs
@@ -23,32 +23,32 @@ import GOOL.Drasil.Symantics (Label, ProgramSym(..), RenderSym(..),
   StateVarSym(..), InternalStateVar(..), ClassSym(..), InternalClass(..), 
   ModuleSym(..), InternalMod(..), BlockCommentSym(..))
 import GOOL.Drasil.LanguageRenderer (classDocD, multiStateDocD, bodyDocD, 
-  oneLinerD, outDoc, printFileDocD, destructorError, paramDocD, paramListDocD, 
-  methodDocD, runStrategyD, listSliceD, checkStateD, notifyObserversD, 
-  listDecDocD, listDecDefDocD, mkSt, stringListVals', stringListLists', 
-  printStD, stateD, loopStateD, emptyStateD, assignD, assignToListIndexD, 
-  multiAssignError, decrementD, incrementD, decrement1D, increment1D, 
-  constDecDefD, discardInputD, openFileRD, openFileWD, openFileAD, closeFileD, 
-  discardFileLineD, breakDocD, continueDocD, returnD, multiReturnError, 
-  valStateD, freeError, throwD, initStateD, changeStateD, initObserverListD, 
-  addObserverD, ifNoElseD, switchD, switchAsIfD, ifExistsD, forRangeD, 
-  tryCatchD, unOpPrec, notOpDocD, negateOpDocD, unExpr, unExpr', typeUnExpr, 
-  powerPrec, equalOpDocD, notEqualOpDocD, greaterOpDocD, greaterEqualOpDocD, 
-  lessOpDocD, lessEqualOpDocD, plusOpDocD, minusOpDocD, multOpDocD, 
-  divideOpDocD, moduloOpDocD, andOpDocD, orOpDocD, binExpr, binExpr', 
-  typeBinExpr, mkVal, mkVar, litTrueD, litFalseD, litCharD, litFloatD, litIntD, 
-  litStringD, classVarDocD, objVarDocD, newObjDocD, varD, staticVarD, extVarD, 
-  selfD, enumVarD, classVarD, objVarSelfD, listVarD, listOfD, iterVarD,
-  valueOfD, argD, enumElementD, argsListD, objAccessD, objMethodCallD, 
-  objMethodCallNoParamsD, selfAccessD, listIndexExistsD, indexOfD, funcAppD, 
-  selfFuncAppD, extFuncAppD, newObjD,notNullD, funcDocD, castDocD, 
-  listSetFuncDocD, castObjDocD, funcD, getD, setD, listSizeD, listAddD, 
-  listAppendD, iterBeginD, iterEndD, listAccessD, listSetD, getFuncD, setFuncD, 
-  listAddFuncD, listAppendFuncD, iterBeginError, iterEndError, listAccessFuncD, 
-  listSetFuncD, staticDocD, dynamicDocD, bindingError, privateDocD, publicDocD, 
-  dot, new, blockCmtStart, blockCmtEnd, docCmtStart, doubleSlash, elseIfLabel, 
-  inLabel, blockCmtDoc, docCmtDoc, commentedItem, addCommentsDocD, 
-  commentedModD, appendToBody, surroundBody, filterOutObjs)
+  oneLinerD, outDoc, printFileDocD, destructorError, paramDocD, methodDocD, 
+  runStrategyD, listSliceD, checkStateD, notifyObserversD, listDecDocD, 
+  listDecDefDocD, mkSt, stringListVals', stringListLists', printStD, stateD, 
+  loopStateD, emptyStateD, assignD, assignToListIndexD, multiAssignError, 
+  decrementD, incrementD, decrement1D, increment1D, constDecDefD, discardInputD,
+  openFileRD, openFileWD, openFileAD, closeFileD, discardFileLineD, breakDocD, 
+  continueDocD, returnD, multiReturnError, valStateD, freeError, throwD, 
+  initStateD, changeStateD, initObserverListD, addObserverD, ifNoElseD, switchD,
+  switchAsIfD, ifExistsD, forRangeD, tryCatchD, unOpPrec, notOpDocD, 
+  negateOpDocD, unExpr, unExpr', typeUnExpr, powerPrec, equalOpDocD, 
+  notEqualOpDocD, greaterOpDocD, greaterEqualOpDocD, lessOpDocD, 
+  lessEqualOpDocD, plusOpDocD, minusOpDocD, multOpDocD, divideOpDocD, 
+  moduloOpDocD, andOpDocD, orOpDocD, binExpr, binExpr', typeBinExpr, mkVal, 
+  mkVar, litTrueD, litFalseD, litCharD, litFloatD, litIntD, litStringD, 
+  classVarDocD, objVarDocD, newObjDocD, varD, staticVarD, extVarD, selfD, 
+  enumVarD, classVarD, objVarSelfD, listVarD, listOfD, iterVarD, valueOfD, argD,
+  enumElementD, argsListD, objAccessD, objMethodCallD, objMethodCallNoParamsD, 
+  selfAccessD, listIndexExistsD, indexOfD, funcAppD, selfFuncAppD, extFuncAppD, 
+  newObjD, notNullD, funcDocD, castDocD, listSetFuncDocD, castObjDocD, funcD, 
+  getD, setD, listSizeD, listAddD, listAppendD, iterBeginD, iterEndD, 
+  listAccessD, listSetD, getFuncD, setFuncD, listAddFuncD, listAppendFuncD, 
+  iterBeginError, iterEndError, listAccessFuncD, listSetFuncD, staticDocD, 
+  dynamicDocD, bindingError, privateDocD, publicDocD, dot, new, blockCmtStart, 
+  blockCmtEnd, docCmtStart, doubleSlash, elseIfLabel, inLabel, blockCmtDoc, 
+  docCmtDoc, commentedItem, addCommentsDocD, commentedModD, appendToBody, 
+  surroundBody, filterOutObjs)
 import qualified GOOL.Drasil.LanguageRenderer.LanguagePolymorphic as G (
   fileFromData, block, bool, int, double, char, string, listType, listInnerType,
   obj, enumType, void, pi, inlineIf, varDec, varDecDef, listDec, listDecDef, 
@@ -58,14 +58,14 @@ import qualified GOOL.Drasil.LanguageRenderer.LanguagePolymorphic as G (
   stateVarDef, constVar, privMVar, pubMVar, pubGVar, buildClass, enum, 
   privClass, pubClass, docClass, commentedClass, buildModule', modFromData, 
   fileDoc, docMod)
-import GOOL.Drasil.Data (Terminator(..), FileType(..), FileData(..), fileD,
-  FuncData(..), fd, ModData(..), md, updateModDoc, MethodData(..), mthd, 
-  updateMthdDoc, OpData(..), ParamData(..), pd, updateParamDoc, ProgData(..), 
-  progD, TypeData(..), td, ValData(..), vd, updateValDoc, Binding(..), 
-  VarData(..), vard)
+import GOOL.Drasil.Data (Terminator(..), ScopeTag(..), FileType(..), 
+  FileData(..), fileD, FuncData(..), fd, ModData(..), md, updateModDoc, 
+  MethodData(..), mthd, updateMthdDoc, OpData(..), ParamData(..), pd, 
+  updateParamDoc, ProgData(..), progD, TypeData(..), td, ValData(..), vd, 
+  updateValDoc, Binding(..), VarData(..), vard)
 import GOOL.Drasil.Helpers (toCode, toState, onCodeValue, onStateValue, 
-  on2CodeValues, on2StateValues, on3CodeValues, on5CodeValues, 
-  onCodeList, onStateList, on1CodeValue1List)
+  on2CodeValues, on2StateValues, on3CodeValues, onCodeList, onStateList, 
+  on1CodeValue1List)
 import GOOL.Drasil.State (MS, lensGStoFS, initialState, initialFS,
   getPutReturnList, setCurrMain)
 
@@ -525,6 +525,7 @@ instance ParameterSym CSharpCode where
 instance InternalParam CSharpCode where
   parameterName = variableName . onCodeValue paramVar
   parameterType = variableType . onCodeValue paramVar
+  parameterDoc = paramDoc . unCSC
   paramFromData v d = on2CodeValues pd v (toCode d)
 
 instance MethodSym CSharpCode where
@@ -554,8 +555,7 @@ instance MethodSym CSharpCode where
 
 instance InternalMethod CSharpCode where
   intMethod m n _ s p t ps b = getPutReturnList ps (if m then setCurrMain else 
-    id) (\pms -> onCodeValue mthd (on5CodeValues (methodDocD n) s p t 
-    (onCodeList paramListDocD pms) b))
+    id) (\pms -> methodFromData Pub $ methodDocD n s p t pms b)
   intFunc = G.intFunc
   commentedFunc cmt m = on2StateValues (on2CodeValues updateMthdDoc) m 
     (onStateValue (onCodeValue commentedItem) cmt)

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer/CppRenderer.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer/CppRenderer.hs
@@ -24,14 +24,14 @@ import GOOL.Drasil.Symantics (Label, ProgramSym(..), RenderSym(..),
   StateVarSym(..), InternalStateVar(..), ClassSym(..), InternalClass(..), 
   ModuleSym(..), InternalMod(..), BlockCommentSym(..))
 import GOOL.Drasil.LanguageRenderer (addExt, enumElementsDocD, multiStateDocD, 
-  bodyDocD, oneLinerD, outDoc, paramDocD, paramListDocD, stateVarDocD, 
-  constVarDocD, runStrategyD, listSliceD, notifyObserversD, freeDocD, mkSt, 
-  mkStNoEnd, stringListVals', stringListLists', stateD, loopStateD, emptyStateD,
-  assignD, assignToListIndexD, multiAssignError, decrementD, incrementD, 
-  decrement1D, increment1D, constDecDefD, discardInputD, discardFileInputD, 
-  closeFileD, breakDocD, continueDocD, returnD, multiReturnError, valStateD, 
-  throwD, initStateD, changeStateD, initObserverListD, addObserverD, ifNoElseD, 
-  switchD, switchAsIfD, forRangeD, tryCatchD, unOpPrec, notOpDocD, negateOpDocD,
+  bodyDocD, oneLinerD, outDoc, paramDocD, stateVarDocD, constVarDocD, 
+  runStrategyD, listSliceD, notifyObserversD, freeDocD, mkSt, mkStNoEnd, 
+  stringListVals', stringListLists', stateD, loopStateD, emptyStateD, assignD, 
+  assignToListIndexD, multiAssignError, decrementD, incrementD, decrement1D, 
+  increment1D, constDecDefD, discardInputD, discardFileInputD, closeFileD, 
+  breakDocD, continueDocD, returnD, multiReturnError, valStateD, throwD, 
+  initStateD, changeStateD, initObserverListD, addObserverD, ifNoElseD, switchD,
+  switchAsIfD, forRangeD, tryCatchD, unOpPrec, notOpDocD, negateOpDocD,
   sqrtOpDocD, absOpDocD, expOpDocD, sinOpDocD, cosOpDocD, tanOpDocD, asinOpDocD,
   acosOpDocD, atanOpDocD, unExpr, unExpr', typeUnExpr, equalOpDocD, 
   notEqualOpDocD, greaterOpDocD, greaterEqualOpDocD, lessOpDocD, 
@@ -47,8 +47,8 @@ import GOOL.Drasil.LanguageRenderer (addExt, enumElementsDocD, multiStateDocD,
   listSetFuncD, staticDocD, dynamicDocD, privateDocD, publicDocD, classDec, dot,
   blockCmtStart, blockCmtEnd, docCmtStart, doubleSlash, elseIfLabel, 
   blockCmtDoc, docCmtDoc, commentedItem, addCommentsDocD, functionDox, 
-  commentedModD, valueList, appendToBody, surroundBody, getterName,
-  setterName, filterOutObjs)
+  commentedModD, valueList, parameterList, appendToBody, surroundBody, 
+  getterName, setterName, filterOutObjs)
 import qualified GOOL.Drasil.LanguageRenderer.LanguagePolymorphic as G (
   fileFromData, block, int, double, char, string, listType, listInnerType, obj, 
   enumType, void, inlineIf, varDec, varDecDef, listDec, listDecDef, objDecNew, 
@@ -63,8 +63,8 @@ import GOOL.Drasil.Data (Pair(..), Terminator(..), ScopeTag(..),
   TypeData(..), td, ValData(..), vd, VarData(..), vard)
 import GOOL.Drasil.Helpers (angles, doubleQuotedText, emptyIfEmpty, mapPairFst, 
   mapPairSnd, toCode, toState, onCodeValue, onStateValue, on2CodeValues, 
-  on2StateValues, on3CodeValues, on3StateValues, on4CodeValues, on5CodeValues, 
-  onCodeList, onStateList, on2StateLists, on1CodeValue1List, on1StateValue1List)
+  on2StateValues, on3CodeValues, on3StateValues, on4CodeValues, onCodeList, 
+  onStateList, on2StateLists, on1CodeValue1List, on1StateValue1List)
 import GOOL.Drasil.State (MS, FS, lensGStoFS, lensFStoGS, lensFStoMS, 
   lensMStoGS, initialState, initialFS, getPutReturn, getPutReturnList, 
   setCurrMain, getCurrMain, setScope, getScope, setCurrMainFunc, 
@@ -605,6 +605,7 @@ instance (Pair p) => ParameterSym (p CppSrcCode CppHdrCode) where
 instance (Pair p) => InternalParam (p CppSrcCode CppHdrCode) where
   parameterName p = parameterName $ pfst p
   parameterType p = pair (parameterType $ pfst p) (parameterType $ psnd p)
+  parameterDoc p = parameterDoc $ pfst p
   paramFromData v d = pair (paramFromData (pfst v) d) (paramFromData (psnd v) d)
 
 instance (Pair p) => MethodSym (p CppSrcCode CppHdrCode) where
@@ -646,7 +647,6 @@ instance (Pair p) => MethodSym (p CppSrcCode CppHdrCode) where
     os) (map (mapPairSnd pfst) bs) (pfst b)) (docInOutMethod n c (psnd s) (psnd 
     p) desc (map (mapPairSnd psnd) is) (map (mapPairSnd psnd) os) (map 
     (mapPairSnd psnd) bs) (psnd b))
-  
 
   inOutFunc n s p ins outs both b = on2StateValues pair (inOutFunc n (pfst s) 
     (pfst p) (map pfst ins) (map pfst outs) (map pfst both) (pfst b)) 
@@ -659,7 +659,6 @@ instance (Pair p) => MethodSym (p CppSrcCode CppHdrCode) where
     (map (mapPairSnd psnd) is) (map (mapPairSnd psnd) os) (map (mapPairSnd psnd)
     bs) (psnd b))
   
-
 instance (Pair p) => InternalMethod (p CppSrcCode CppHdrCode) where
   intMethod m n c s p t ps b = pair1List ps (\pms -> intMethod m n c (pfst s) 
     (pfst p) (pfst t) pms (pfst b)) (\pms -> intMethod m n c (psnd s) (psnd p)
@@ -1258,6 +1257,7 @@ instance ParameterSym CppSrcCode where
 instance InternalParam CppSrcCode where
   parameterName = variableName . onCodeValue paramVar
   parameterType = variableType . onCodeValue paramVar
+  parameterDoc = paramDoc . unCPPSC
   paramFromData v d = on2CodeValues pd v (toCode d)
 
 instance MethodSym CppSrcCode where
@@ -1304,13 +1304,11 @@ instance MethodSym CppSrcCode where
 
 instance InternalMethod CppSrcCode where
   intMethod m n c s _ t ps b = getPutReturnList ps (setScope (snd $ unCPPSC s) .
-    if m then setCurrMain else id) (\pms -> on2CodeValues mthd (onCodeValue snd 
-    s) (on5CodeValues (cppsMethod n c) t (onCodeList paramListDocD pms) b 
-    blockStart blockEnd))
+    if m then setCurrMain else id) (\pms -> methodFromData (snd $ unCPPSC s) $
+    cppsMethod n c t pms b blockStart blockEnd)
   intFunc m n s _ t ps b = getPutReturnList ps (setScope (snd $ unCPPSC s) . 
-    if m then setCurrMainFunc m . setCurrMain else id) (\pms -> on2CodeValues 
-    mthd (onCodeValue snd s) (on5CodeValues (cppsFunction n) t (onCodeList 
-    paramListDocD pms) b blockStart blockEnd))
+    if m then setCurrMainFunc m . setCurrMain else id) (\pms -> methodFromData 
+    (snd $ unCPPSC s) $ cppsFunction n t pms b blockStart blockEnd)
   commentedFunc = cppCommentedFunc Source
  
   methodDoc = mthdDoc . unCPPSC
@@ -1813,6 +1811,7 @@ instance ParameterSym CppHdrCode where
 instance InternalParam CppHdrCode where
   parameterName = variableName . onCodeValue paramVar
   parameterType = variableType . onCodeValue paramVar
+  parameterDoc = paramDoc . unCPPHC
   paramFromData v d = on2CodeValues pd v (toCode d)
 
 instance MethodSym CppHdrCode where
@@ -1846,9 +1845,8 @@ instance MethodSym CppHdrCode where
 
 instance InternalMethod CppHdrCode where
   intMethod m n _ s _ t ps _ = getPutReturnList ps (setScope (snd $ unCPPHC s) 
-    . if m then setCurrMain else id) (\pms -> on2CodeValues mthd (onCodeValue 
-    snd s) (on3CodeValues (cpphMethod n) t (onCodeList paramListDocD pms) 
-    endStatement))
+    . if m then setCurrMain else id) (\pms -> methodFromData (snd $ unCPPHC s) $
+    cpphMethod n t pms endStatement)
   intFunc = G.intFunc
   commentedFunc = cppCommentedFunc Header
 
@@ -2058,23 +2056,28 @@ cppOpenFile mode f n = variableDoc f <> dot <> text "open" <>
 cppPointerParamDoc :: (RenderSym repr) => repr (Variable repr) -> Doc
 cppPointerParamDoc v = getTypeDoc (variableType v) <+> text "&" <> variableDoc v
 
-cppsMethod :: Label -> Label -> TypeData -> Doc -> Doc -> Doc -> Doc -> Doc
-cppsMethod n c t ps b bStart bEnd = emptyIfEmpty b $ vcat [ttype <+> text c <> 
-  text "::" <> text n <> parens ps <+> bStart,
-  indent b,
-  bEnd]
+cppsMethod :: (RenderSym repr) => Label -> Label -> repr (Type repr) -> 
+  [repr (Parameter repr)] -> repr (Body repr) -> repr (Keyword repr) -> 
+  repr (Keyword repr) -> Doc
+cppsMethod n c t ps b bStart bEnd = emptyIfEmpty (bodyDoc b) $ vcat [ttype <+> 
+  text c <> text "::" <> text n <> parens (parameterList ps) <+> keyDoc bStart,
+  indent (bodyDoc b),
+  keyDoc bEnd]
   where ttype | isDtor n = empty
-              | otherwise = typeDoc t
+              | otherwise = getTypeDoc t
 
-cppsFunction :: Label -> TypeData -> Doc -> Doc -> Doc -> Doc -> Doc
+cppsFunction :: (RenderSym repr) => Label -> repr (Type repr) -> 
+  [repr (Parameter repr)] -> repr (Body repr) -> repr (Keyword repr) -> 
+  repr (Keyword repr) -> Doc
 cppsFunction n t ps b bStart bEnd = vcat [
-  typeDoc t <+> text n <> parens ps <+> bStart,
-  indent b,
-  bEnd]
+  getTypeDoc t <+> text n <> parens (parameterList ps) <+> keyDoc bStart,
+  indent (bodyDoc b),
+  keyDoc bEnd]
 
-cpphMethod :: Label -> TypeData -> Doc -> Doc -> Doc
-cpphMethod n t ps end = (if isDtor n then empty else typeDoc t) <+> text n <> 
-  parens ps <> end
+cpphMethod :: (RenderSym repr) => Label -> repr (Type repr) ->
+  [repr (Parameter repr)] -> repr (Keyword repr) -> Doc
+cpphMethod n t ps end = (if isDtor n then empty else getTypeDoc t) <+> text n 
+  <> parens (parameterList ps) <> keyDoc end
 
 cppCommentedFunc :: (RenderSym repr) => FileType -> 
   MS (repr (BlockComment repr)) -> MS (repr (Method repr)) -> 
@@ -2161,8 +2164,8 @@ cppsInOut :: (CppSrcCode (Scope CppSrcCode) ->
   [CppSrcCode (Variable CppSrcCode)] -> [CppSrcCode (Variable CppSrcCode)] -> 
   [CppSrcCode (Variable CppSrcCode)] -> CppSrcCode (Body CppSrcCode) -> 
   MS (CppSrcCode (Method CppSrcCode))
-cppsInOut f s p ins [v] [] b = f s p (variableType v) (cppInOutParams ins [v] [])
-  (on3CodeValues surroundBody (varDec v) b (returnState $ valueOf v))
+cppsInOut f s p ins [v] [] b = f s p (variableType v) (cppInOutParams ins [v] 
+  []) (on3CodeValues surroundBody (varDec v) b (returnState $ valueOf v))
 cppsInOut f s p ins [] [v] b = f s p (if null (filterOutObjs [v]) then void 
   else variableType v) (cppInOutParams ins [] [v]) (if null (filterOutObjs [v]) 
   then b else on2CodeValues appendToBody b (returnState $ valueOf v))
@@ -2176,13 +2179,16 @@ cpphInOut :: (CppHdrCode (Scope CppHdrCode) ->
   [CppHdrCode (Variable CppHdrCode)] -> [CppHdrCode (Variable CppHdrCode)] -> 
   [CppHdrCode (Variable CppHdrCode)] -> CppHdrCode (Body CppHdrCode) -> 
   MS (CppHdrCode (Method CppHdrCode))
-cpphInOut f s p ins [v] [] b = f s p (variableType v) (cppInOutParams ins [v] []) b
+cpphInOut f s p ins [v] [] b = f s p (variableType v) (cppInOutParams ins [v] 
+  []) b
 cpphInOut f s p ins [] [v] b = f s p (if null (filterOutObjs [v]) then void 
   else variableType v) (cppInOutParams ins [] [v]) b
 cpphInOut f s p ins outs both b = f s p void (cppInOutParams ins outs both) b
 
 cppInOutParams :: (RenderSym repr) => [repr (Variable repr)] -> 
-  [repr (Variable repr)] -> [repr (Variable repr)] -> [MS (repr (Parameter repr))]
+  [repr (Variable repr)] -> [repr (Variable repr)] -> 
+  [MS (repr (Parameter repr))]
 cppInOutParams ins [_] [] = map getParam ins
 cppInOutParams ins [] [v] = map getParam $ v : ins
-cppInOutParams ins outs both = map pointerParam both ++ map getParam ins ++ map pointerParam outs
+cppInOutParams ins outs both = map pointerParam both ++ map getParam ins ++ 
+  map pointerParam outs

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer/JavaRenderer.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer/JavaRenderer.hs
@@ -13,60 +13,59 @@ import GOOL.Drasil.CodeType (CodeType(..), isObject)
 import GOOL.Drasil.Symantics (Label, ProgramSym(..), RenderSym(..), 
   InternalFile(..), KeywordSym(..), PermanenceSym(..), InternalPerm(..), 
   BodySym(..), BlockSym(..), InternalBlock(..), ControlBlockSym(..), 
-  TypeSym(..), InternalType(..), UnaryOpSym(..), BinaryOpSym(..), InternalOp(..),
-  VariableSym(..), InternalVariable(..), ValueSym(..), NumericExpression(..), 
-  BooleanExpression(..), ValueExpression(..), InternalValue(..), Selector(..), 
-  FunctionSym(..), SelectorFunction(..), InternalFunction(..), 
-  InternalStatement(..), StatementSym(..), ControlStatementSym(..), 
-  ScopeSym(..), InternalScope(..), MethodTypeSym(..), ParameterSym(..), 
-  MethodSym(..), InternalMethod(..), StateVarSym(..), InternalStateVar(..), 
-  ClassSym(..), InternalClass(..), ModuleSym(..), InternalMod(..), 
-  BlockCommentSym(..))
+  TypeSym(..), InternalType(..), UnaryOpSym(..), BinaryOpSym(..), 
+  InternalOp(..), VariableSym(..), InternalVariable(..), ValueSym(..), 
+  NumericExpression(..), BooleanExpression(..), ValueExpression(..), 
+  InternalValue(..), Selector(..), FunctionSym(..), SelectorFunction(..), 
+  InternalFunction(..), InternalStatement(..), StatementSym(..), 
+  ControlStatementSym(..), ScopeSym(..), InternalScope(..), MethodTypeSym(..), 
+  ParameterSym(..), InternalParam(..), MethodSym(..), InternalMethod(..), 
+  StateVarSym(..), InternalStateVar(..), ClassSym(..), InternalClass(..), 
+  ModuleSym(..), InternalMod(..), BlockCommentSym(..))
 import GOOL.Drasil.LanguageRenderer (packageDocD, classDocD, multiStateDocD, 
   bodyDocD, oneLinerD, outDoc, printFileDocD, destructorError, paramDocD, 
-  paramListDocD, mkParam, runStrategyD, listSliceD, checkStateD, 
-  notifyObserversD, listDecDocD, mkSt, stringListVals', stringListLists', 
-  printStD, stateD, loopStateD, emptyStateD, assignD, assignToListIndexD, 
-  multiAssignError, decrementD, incrementD, decrement1D, increment1D, 
-  discardInputD, discardFileInputD, openFileRD, openFileWD, openFileAD, 
-  closeFileD, discardFileLineD, breakDocD, continueDocD, returnD, 
-  multiReturnError, valStateD, freeError, throwD, initStateD, changeStateD, 
-  initObserverListD, addObserverD, ifNoElseD, switchD, switchAsIfD, ifExistsD, 
-  forRangeD, tryCatchD, unOpPrec, notOpDocD, negateOpDocD, unExpr, unExpr', 
-  typeUnExpr, powerPrec, equalOpDocD, notEqualOpDocD, greaterOpDocD, 
-  greaterEqualOpDocD, lessOpDocD, lessEqualOpDocD, plusOpDocD, minusOpDocD, 
-  multOpDocD, divideOpDocD, moduloOpDocD, andOpDocD, orOpDocD, binExpr, 
-  binExpr', typeBinExpr, mkVal, litTrueD, litFalseD, litCharD, litFloatD, 
-  litIntD, litStringD, classVarDocD, newObjDocD, varD, 
-  staticVarD, extVarD, selfD, enumVarD, classVarD, objVarD, objVarSelfD, 
-  listVarD, listOfD, iterVarD, valueOfD, argD, enumElementD, argsListD, 
-  objAccessD, objMethodCallD, objMethodCallNoParamsD, selfAccessD, 
-  listIndexExistsD, indexOfD, funcAppD, selfFuncAppD, extFuncAppD, newObjD, 
-  notNullD, castDocD, castObjDocD, funcD, getD, setD, listSizeD, listAddD, 
-  listAppendD, iterBeginD, iterEndD, listAccessD, listSetD, getFuncD, setFuncD, 
-  listSizeFuncD, listAddFuncD, listAppendFuncD, iterBeginError, iterEndError, 
-  listAccessFuncD', staticDocD, dynamicDocD, bindingError, privateDocD, 
-  publicDocD, dot, new, elseIfLabel, forLabel, blockCmtStart, blockCmtEnd, 
-  docCmtStart, doubleSlash, blockCmtDoc, docCmtDoc, commentedItem, 
-  addCommentsDocD, commentedModD, docFuncRepr, valueList, appendToBody, 
-  surroundBody, intValue, filterOutObjs)
+  paramListDocD, runStrategyD, listSliceD, checkStateD, notifyObserversD, 
+  listDecDocD, mkSt, stringListVals', stringListLists', printStD, stateD, 
+  loopStateD, emptyStateD, assignD, assignToListIndexD, multiAssignError, 
+  decrementD, incrementD, decrement1D, increment1D, discardInputD, 
+  discardFileInputD, openFileRD, openFileWD, openFileAD, closeFileD, 
+  discardFileLineD, breakDocD, continueDocD, returnD, multiReturnError, 
+  valStateD, freeError, throwD, initStateD, changeStateD, initObserverListD, 
+  addObserverD, ifNoElseD, switchD, switchAsIfD, ifExistsD, forRangeD, 
+  tryCatchD, unOpPrec, notOpDocD, negateOpDocD, unExpr, unExpr', typeUnExpr, 
+  powerPrec, equalOpDocD, notEqualOpDocD, greaterOpDocD, greaterEqualOpDocD, 
+  lessOpDocD, lessEqualOpDocD, plusOpDocD, minusOpDocD, multOpDocD, 
+  divideOpDocD, moduloOpDocD, andOpDocD, orOpDocD, binExpr, binExpr', 
+  typeBinExpr, mkVal, litTrueD, litFalseD, litCharD, litFloatD, litIntD, 
+  litStringD, classVarDocD, newObjDocD, varD, staticVarD, extVarD, selfD, 
+  enumVarD, classVarD, objVarD, objVarSelfD, listVarD, listOfD, iterVarD, 
+  valueOfD, argD, enumElementD, argsListD, objAccessD, objMethodCallD, 
+  objMethodCallNoParamsD, selfAccessD, listIndexExistsD, indexOfD, funcAppD, 
+  selfFuncAppD, extFuncAppD, newObjD, notNullD, castDocD, castObjDocD, funcD, 
+  getD, setD, listSizeD, listAddD, listAppendD, iterBeginD, iterEndD, 
+  listAccessD, listSetD, getFuncD, setFuncD, listSizeFuncD, listAddFuncD, 
+  listAppendFuncD, iterBeginError, iterEndError, listAccessFuncD', staticDocD, 
+  dynamicDocD, bindingError, privateDocD, publicDocD, dot, new, elseIfLabel, 
+  forLabel, blockCmtStart, blockCmtEnd, docCmtStart, doubleSlash, blockCmtDoc, 
+  docCmtDoc, commentedItem, addCommentsDocD, commentedModD, docFuncRepr, 
+  valueList, appendToBody, surroundBody, intValue, filterOutObjs)
 import qualified GOOL.Drasil.LanguageRenderer.LanguagePolymorphic as G (
   fileFromData, block, bool, int, double, char, listType, listInnerType, obj, 
   enumType, void, pi, inlineIf, varDec, varDecDef, listDec, listDecDef, 
   objDecNew, objDecNewNoParams, construct, comment, ifCond, for, forEach, while,
-  method, getMethod, setMethod,privMethod, pubMethod, constructor, docMain, 
-  function, mainFunction, docFunc, intFunc, stateVar, stateVarDef, constVar, 
-  privMVar, pubMVar, pubGVar, buildClass, enum, privClass, pubClass, docClass, 
-  commentedClass, buildModule', modFromData, fileDoc, docMod)
+  param, method, getMethod, setMethod, privMethod, pubMethod, constructor, 
+  docMain, function, mainFunction, docFunc, intFunc, stateVar, stateVarDef, 
+  constVar, privMVar, pubMVar, pubGVar, buildClass, enum, privClass, pubClass, 
+  docClass, commentedClass, buildModule', modFromData, fileDoc, docMod)
 import GOOL.Drasil.Data (Terminator(..), FileType(..), FileData(..), fileD, 
   FuncData(..), fd, ModData(..), md, updateModDoc, MethodData(..), mthd, 
   updateMthdDoc, OpData(..), ParamData(..), ProgData(..), progD, TypeData(..), 
   td, ValData(..), vd, VarData(..), vard)
 import GOOL.Drasil.Helpers (angles, emptyIfNull, toCode, toState, onCodeValue, 
   onStateValue, on2CodeValues, on2StateValues, on3CodeValues, 
-  on5CodeValues, onCodeList, on1CodeValue1List, checkParams)
+  on5CodeValues, onCodeList, on1CodeValue1List)
 import GOOL.Drasil.State (MS, lensGStoFS, initialState, initialFS, getPutReturn,
-  getPutReturnList, addProgNameToPaths, setCurrMain, setParameters)
+  getPutReturnList, addProgNameToPaths, setCurrMain)
 
 import Prelude hiding (break,print,sin,cos,tan,floor,(<>))
 import Control.Lens.Zoom (zoom)
@@ -521,10 +520,13 @@ instance MethodTypeSym JavaCode where
 
 instance ParameterSym JavaCode where
   type Parameter JavaCode = ParamData
-  param = onCodeValue (mkParam paramDocD)
+  param = G.param paramDocD
   pointerParam = param
 
+instance InternalParam JavaCode where
+  parameterName = variableName . onCodeValue paramVar
   parameterType = variableType . onCodeValue paramVar
+  paramFromData v d = on2CodeValues pd v (toCode d)
 
 instance MethodSym JavaCode where
   type Method JavaCode = MethodData
@@ -552,9 +554,9 @@ instance MethodSym JavaCode where
   docInOutFunc n = jDocInOut (inOutFunc n)
 
 instance InternalMethod JavaCode where
-  intMethod m n _ s p t ps b = getPutReturn (setParameters (map unJC ps) . 
-    if m then setCurrMain else id) $ onCodeValue mthd (on5CodeValues (jMethod n)
-    s p t (onCodeList (paramListDocD . checkParams n) ps) b)
+  intMethod m n _ s p t ps b = getPutReturn (if m then setCurrMain else id) $ 
+    onCodeValue mthd (on5CodeValues (jMethod n) s p t (onCodeList 
+    paramListDocD ps) b)
   intFunc = G.intFunc
   commentedFunc cmt m = on2StateValues (on2CodeValues updateMthdDoc) m 
     (onStateValue (onCodeValue commentedItem) cmt)

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer/JavaRenderer.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer/JavaRenderer.hs
@@ -24,31 +24,31 @@ import GOOL.Drasil.Symantics (Label, ProgramSym(..), RenderSym(..),
   ModuleSym(..), InternalMod(..), BlockCommentSym(..))
 import GOOL.Drasil.LanguageRenderer (packageDocD, classDocD, multiStateDocD, 
   bodyDocD, oneLinerD, outDoc, printFileDocD, destructorError, paramDocD, 
-  paramListDocD, runStrategyD, listSliceD, checkStateD, notifyObserversD, 
-  listDecDocD, mkSt, stringListVals', stringListLists', printStD, stateD, 
-  loopStateD, emptyStateD, assignD, assignToListIndexD, multiAssignError, 
-  decrementD, incrementD, decrement1D, increment1D, discardInputD, 
-  discardFileInputD, openFileRD, openFileWD, openFileAD, closeFileD, 
-  discardFileLineD, breakDocD, continueDocD, returnD, multiReturnError, 
-  valStateD, freeError, throwD, initStateD, changeStateD, initObserverListD, 
-  addObserverD, ifNoElseD, switchD, switchAsIfD, ifExistsD, forRangeD, 
-  tryCatchD, unOpPrec, notOpDocD, negateOpDocD, unExpr, unExpr', typeUnExpr, 
-  powerPrec, equalOpDocD, notEqualOpDocD, greaterOpDocD, greaterEqualOpDocD, 
-  lessOpDocD, lessEqualOpDocD, plusOpDocD, minusOpDocD, multOpDocD, 
-  divideOpDocD, moduloOpDocD, andOpDocD, orOpDocD, binExpr, binExpr', 
-  typeBinExpr, mkVal, litTrueD, litFalseD, litCharD, litFloatD, litIntD, 
-  litStringD, classVarDocD, newObjDocD, varD, staticVarD, extVarD, selfD, 
-  enumVarD, classVarD, objVarD, objVarSelfD, listVarD, listOfD, iterVarD, 
-  valueOfD, argD, enumElementD, argsListD, objAccessD, objMethodCallD, 
-  objMethodCallNoParamsD, selfAccessD, listIndexExistsD, indexOfD, funcAppD, 
-  selfFuncAppD, extFuncAppD, newObjD, notNullD, castDocD, castObjDocD, funcD, 
-  getD, setD, listSizeD, listAddD, listAppendD, iterBeginD, iterEndD, 
-  listAccessD, listSetD, getFuncD, setFuncD, listSizeFuncD, listAddFuncD, 
-  listAppendFuncD, iterBeginError, iterEndError, listAccessFuncD', staticDocD, 
-  dynamicDocD, bindingError, privateDocD, publicDocD, dot, new, elseIfLabel, 
-  forLabel, blockCmtStart, blockCmtEnd, docCmtStart, doubleSlash, blockCmtDoc, 
-  docCmtDoc, commentedItem, addCommentsDocD, commentedModD, docFuncRepr, 
-  valueList, appendToBody, surroundBody, intValue, filterOutObjs)
+  runStrategyD, listSliceD, checkStateD, notifyObserversD, listDecDocD, mkSt, 
+  stringListVals', stringListLists', printStD, stateD, loopStateD, emptyStateD, 
+  assignD, assignToListIndexD, multiAssignError, decrementD, incrementD, 
+  decrement1D, increment1D, discardInputD, discardFileInputD, openFileRD, 
+  openFileWD, openFileAD, closeFileD, discardFileLineD, breakDocD, continueDocD,
+  returnD, multiReturnError, valStateD, freeError, throwD, initStateD, 
+  changeStateD, initObserverListD, addObserverD, ifNoElseD, switchD, 
+  switchAsIfD, ifExistsD, forRangeD, tryCatchD, unOpPrec, notOpDocD, 
+  negateOpDocD, unExpr, unExpr', typeUnExpr, powerPrec, equalOpDocD, 
+  notEqualOpDocD, greaterOpDocD, greaterEqualOpDocD, lessOpDocD, 
+  lessEqualOpDocD, plusOpDocD, minusOpDocD, multOpDocD, divideOpDocD, 
+  moduloOpDocD, andOpDocD, orOpDocD, binExpr, binExpr', typeBinExpr, mkVal, 
+  litTrueD, litFalseD, litCharD, litFloatD, litIntD, litStringD, classVarDocD, 
+  newObjDocD, varD, staticVarD, extVarD, selfD, enumVarD, classVarD, objVarD, 
+  objVarSelfD, listVarD, listOfD, iterVarD, valueOfD, argD, enumElementD, 
+  argsListD, objAccessD, objMethodCallD, objMethodCallNoParamsD, selfAccessD, 
+  listIndexExistsD, indexOfD, funcAppD, selfFuncAppD, extFuncAppD, newObjD, 
+  notNullD, castDocD, castObjDocD, funcD, getD, setD, listSizeD, listAddD, 
+  listAppendD, iterBeginD, iterEndD, listAccessD, listSetD, getFuncD, setFuncD, 
+  listSizeFuncD, listAddFuncD, listAppendFuncD, iterBeginError, iterEndError, 
+  listAccessFuncD', staticDocD, dynamicDocD, bindingError, privateDocD, 
+  publicDocD, dot, new, elseIfLabel, forLabel, blockCmtStart, blockCmtEnd, 
+  docCmtStart, doubleSlash, blockCmtDoc, docCmtDoc, commentedItem, 
+  addCommentsDocD, commentedModD, docFuncRepr, valueList, parameterList, 
+  appendToBody, surroundBody, intValue, filterOutObjs)
 import qualified GOOL.Drasil.LanguageRenderer.LanguagePolymorphic as G (
   fileFromData, block, bool, int, double, char, listType, listInnerType, obj, 
   enumType, void, pi, inlineIf, varDec, varDecDef, listDec, listDecDef, 
@@ -57,13 +57,13 @@ import qualified GOOL.Drasil.LanguageRenderer.LanguagePolymorphic as G (
   docMain, function, mainFunction, docFunc, intFunc, stateVar, stateVarDef, 
   constVar, privMVar, pubMVar, pubGVar, buildClass, enum, privClass, pubClass, 
   docClass, commentedClass, buildModule', modFromData, fileDoc, docMod)
-import GOOL.Drasil.Data (Terminator(..), FileType(..), FileData(..), fileD, 
-  FuncData(..), fd, ModData(..), md, updateModDoc, MethodData(..), mthd, 
-  updateMthdDoc, OpData(..), ParamData(..), pd, ProgData(..), progD, 
-  TypeData(..), td, ValData(..), vd, VarData(..), vard)
+import GOOL.Drasil.Data (Terminator(..), ScopeTag(..), FileType(..), 
+  FileData(..), fileD, FuncData(..), fd, ModData(..), md, updateModDoc, 
+  MethodData(..), mthd, updateMthdDoc, OpData(..), ParamData(..), pd, 
+  ProgData(..), progD, TypeData(..), td, ValData(..), vd, VarData(..), vard)
 import GOOL.Drasil.Helpers (angles, emptyIfNull, toCode, toState, onCodeValue, 
   onStateValue, on2CodeValues, on2StateValues, on3CodeValues, 
-  on5CodeValues, onCodeList, on1CodeValue1List)
+  onCodeList, on1CodeValue1List)
 import GOOL.Drasil.State (MS, lensGStoFS, initialState, initialFS,
   getPutReturnList, addProgNameToPaths, setCurrMain)
 
@@ -526,6 +526,7 @@ instance ParameterSym JavaCode where
 instance InternalParam JavaCode where
   parameterName = variableName . onCodeValue paramVar
   parameterType = variableType . onCodeValue paramVar
+  parameterDoc = paramDoc . unJC
   paramFromData v d = on2CodeValues pd v (toCode d)
 
 instance MethodSym JavaCode where
@@ -555,8 +556,7 @@ instance MethodSym JavaCode where
 
 instance InternalMethod JavaCode where
   intMethod m n _ s p t ps b = getPutReturnList ps (if m then setCurrMain else 
-    id) (\pms -> onCodeValue mthd (on5CodeValues (jMethod n) s p t (onCodeList 
-    paramListDocD pms) b))
+    id) (\pms -> methodFromData Pub $ jMethod n s p t pms b)
   intFunc = G.intFunc
   commentedFunc cmt m = on2StateValues (on2CodeValues updateMthdDoc) m 
     (onStateValue (onCodeValue commentedItem) cmt)
@@ -723,11 +723,13 @@ jStringSplit :: (RenderSym repr) => repr (Variable repr) -> repr (Value repr)
 jStringSplit vnew s = variableDoc vnew <+> equals <+> new <+> getTypeDoc 
   (variableType vnew) <> parens (valueDoc s)
 
-jMethod :: Label -> Doc -> Doc -> TypeData -> Doc -> Doc -> Doc
+jMethod :: (RenderSym repr) => Label -> repr (Scope repr) -> 
+  repr (Permanence repr) -> repr (Type repr) -> [repr (Parameter repr)] -> 
+  repr (Body repr) -> Doc
 jMethod n s p t ps b = vcat [
-  s <+> p <+> typeDoc t <+> text n <> parens ps <+> text "throws Exception" <+> 
-    lbrace,
-  indent b,
+  scopeDoc s <+> permDoc p <+> getTypeDoc t <+> text n <> 
+    parens (parameterList ps) <+> text "throws Exception" <+> lbrace,
+  indent $ bodyDoc b,
   rbrace]
 
 jAssignFromArray :: Int -> [JavaCode (Variable JavaCode)] -> 

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer/JavaRenderer.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer/JavaRenderer.hs
@@ -59,12 +59,12 @@ import qualified GOOL.Drasil.LanguageRenderer.LanguagePolymorphic as G (
   docClass, commentedClass, buildModule', modFromData, fileDoc, docMod)
 import GOOL.Drasil.Data (Terminator(..), FileType(..), FileData(..), fileD, 
   FuncData(..), fd, ModData(..), md, updateModDoc, MethodData(..), mthd, 
-  updateMthdDoc, OpData(..), ParamData(..), ProgData(..), progD, TypeData(..), 
-  td, ValData(..), vd, VarData(..), vard)
+  updateMthdDoc, OpData(..), ParamData(..), pd, ProgData(..), progD, 
+  TypeData(..), td, ValData(..), vd, VarData(..), vard)
 import GOOL.Drasil.Helpers (angles, emptyIfNull, toCode, toState, onCodeValue, 
   onStateValue, on2CodeValues, on2StateValues, on3CodeValues, 
   on5CodeValues, onCodeList, on1CodeValue1List)
-import GOOL.Drasil.State (MS, lensGStoFS, initialState, initialFS, getPutReturn,
+import GOOL.Drasil.State (MS, lensGStoFS, initialState, initialFS,
   getPutReturnList, addProgNameToPaths, setCurrMain)
 
 import Prelude hiding (break,print,sin,cos,tan,floor,(<>))
@@ -554,9 +554,9 @@ instance MethodSym JavaCode where
   docInOutFunc n = jDocInOut (inOutFunc n)
 
 instance InternalMethod JavaCode where
-  intMethod m n _ s p t ps b = getPutReturn (if m then setCurrMain else id) $ 
-    onCodeValue mthd (on5CodeValues (jMethod n) s p t (onCodeList 
-    paramListDocD ps) b)
+  intMethod m n _ s p t ps b = getPutReturnList ps (if m then setCurrMain else 
+    id) (\pms -> onCodeValue mthd (on5CodeValues (jMethod n) s p t (onCodeList 
+    paramListDocD pms) b))
   intFunc = G.intFunc
   commentedFunc cmt m = on2StateValues (on2CodeValues updateMthdDoc) m 
     (onStateValue (onCodeValue commentedItem) cmt)
@@ -753,7 +753,7 @@ jInOutCall f n ins outs both = fCall rets
           (f n jArrayType (map valueOf both ++ ins)) : jAssignFromArray 0 xs
 
 jInOut :: (JavaCode (Scope JavaCode) -> JavaCode (Permanence JavaCode) -> 
-    JavaCode (Type JavaCode) -> [JavaCode (Parameter JavaCode)] -> 
+    JavaCode (Type JavaCode) -> [MS (JavaCode (Parameter JavaCode))] -> 
     JavaCode (Body JavaCode) -> MS (JavaCode (Method JavaCode))) 
   -> JavaCode (Scope JavaCode) -> JavaCode (Permanence JavaCode) -> 
   [JavaCode (Variable JavaCode)] -> [JavaCode (Variable JavaCode)] -> 

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer/PythonRenderer.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer/PythonRenderer.hs
@@ -54,13 +54,13 @@ import qualified GOOL.Drasil.LanguageRenderer.LanguagePolymorphic as G (
   fileDoc, docMod)
 import GOOL.Drasil.Data (Terminator(..), FileType(..), FileData(..), fileD,
   FuncData(..), fd, ModData(..), md, updateModDoc, MethodData(..), mthd, 
-  updateMthdDoc, OpData(..), ParamData(..), ProgData(..), progD, TypeData(..), 
-  td, ValData(..), vd, VarData(..), vard)
+  updateMthdDoc, OpData(..), ParamData(..), pd, ProgData(..), progD, 
+  TypeData(..), td, ValData(..), vd, VarData(..), vard)
 import GOOL.Drasil.Helpers (emptyIfEmpty, toCode, toState, onCodeValue,
   onStateValue, on2CodeValues, on2StateValues, on3CodeValues, 
   onCodeList, onStateList, on1CodeValue1List)
 import GOOL.Drasil.State (MS, lensGStoFS, initialState, initialFS, getPutReturn,
-  setCurrMain)
+  getPutReturnList, setCurrMain)
 
 import Prelude hiding (break,print,sin,cos,tan,floor,(<>))
 import Data.Maybe (fromMaybe)
@@ -561,12 +561,12 @@ instance MethodSym PythonCode where
   docInOutFunc n = pyDocInOut (inOutFunc n)
 
 instance InternalMethod PythonCode where
-  intMethod m n l _ _ _ ps b = getPutReturn (if m then setCurrMain else id) $ 
-    onCodeValue mthd (on3CodeValues (pyMethod n) (self l) (onCodeList 
-    paramListDocD ps) b)
-  intFunc m n _ _ _ ps b = getPutReturn (if m then setCurrMain else id) $ 
-    onCodeValue mthd (on2CodeValues (pyFunction n) (onCodeList paramListDocD ps)
-    b)
+  intMethod m n l _ _ _ ps b = getPutReturnList ps (if m then setCurrMain else 
+    id) (\pms -> onCodeValue mthd (on3CodeValues (pyMethod n) (self l) 
+    (onCodeList paramListDocD pms) b))
+  intFunc m n _ _ _ ps b = getPutReturnList ps (if m then setCurrMain else id) 
+    (\pms -> onCodeValue mthd (on2CodeValues (pyFunction n) (onCodeList 
+    paramListDocD pms) b))
   commentedFunc cmt m = on2StateValues (on2CodeValues updateMthdDoc) m 
     (onStateValue (onCodeValue commentedItem) cmt)
 
@@ -769,9 +769,8 @@ pyDocComment (l:lns) start mid = vcat $ start <+> text l : map ((<+>) mid .
   text) lns
 
 pyInOut :: (PythonCode (Scope PythonCode) -> PythonCode (Permanence PythonCode) 
-    -> PythonCode (Type PythonCode) -> [PythonCode (Parameter PythonCode)] -> 
-    PythonCode (Body PythonCode) -> 
-    MS (PythonCode (Method PythonCode)))
+    -> PythonCode (Type PythonCode) -> [MS (PythonCode (Parameter PythonCode))] 
+    -> PythonCode (Body PythonCode) -> MS (PythonCode (Method PythonCode)))
   -> PythonCode (Scope PythonCode) -> PythonCode (Permanence PythonCode) -> 
   [PythonCode (Variable PythonCode)] -> [PythonCode (Variable PythonCode)] -> 
   [PythonCode (Variable PythonCode)] -> PythonCode (Body PythonCode) -> 

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer/PythonRenderer.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer/PythonRenderer.hs
@@ -22,29 +22,28 @@ import GOOL.Drasil.Symantics (Label, ProgramSym(..), RenderSym(..),
   StateVarSym(..), InternalStateVar(..), ClassSym(..), InternalClass(..), 
   ModuleSym(..), InternalMod(..), BlockCommentSym(..))
 import GOOL.Drasil.LanguageRenderer (enumElementsDocD', multiStateDocD, 
-  bodyDocD, oneLinerD, outDoc, destructorError, paramListDocD, runStrategyD, 
-  checkStateD, multiAssignDoc, returnDocD, mkStNoEnd, stringListVals', 
-  stringListLists', stateD, loopStateD, emptyStateD, assignD, 
-  assignToListIndexD, decrementD, decrement1D, closeFileD, discardFileLineD, 
-  breakDocD, continueDocD, returnD, valStateD, throwD, initStateD, 
-  changeStateD, initObserverListD, addObserverD, ifNoElseD, switchAsIfD, 
-  ifExistsD, tryCatchD, unOpPrec, notOpDocD', negateOpDocD, sqrtOpDocD', 
-  absOpDocD', expOpDocD', sinOpDocD', cosOpDocD', tanOpDocD', asinOpDocD', 
-  acosOpDocD', atanOpDocD', unExpr, unExpr', typeUnExpr, powerPrec, multPrec, 
-  andPrec, orPrec, equalOpDocD, notEqualOpDocD, greaterOpDocD, 
-  greaterEqualOpDocD, lessOpDocD, lessEqualOpDocD, plusOpDocD, minusOpDocD, 
-  multOpDocD, divideOpDocD, moduloOpDocD, binExpr, typeBinExpr, mkVal, mkVar, 
-  litCharD, litFloatD, litIntD, litStringD, classVarDocD, newObjDocD', varD, 
-  staticVarD, extVarD, enumVarD, classVarD, objVarD, objVarSelfD, listVarD, 
-  listOfD, iterVarD, valueOfD, argD, enumElementD, argsListD, objAccessD, 
-  objMethodCallD, objMethodCallNoParamsD, selfAccessD, listIndexExistsD, 
-  indexOfD, funcAppD, selfFuncAppD, extFuncAppD, newObjD, listSetFuncDocD, 
-  castObjDocD, funcD, getD, setD, listAddD, listAppendD, iterBeginD, iterEndD, 
-  listAccessD, listSetD, getFuncD, setFuncD, listAddFuncD, listAppendFuncD, 
-  iterBeginError, iterEndError, listAccessFuncD, listSetFuncD, dynamicDocD, 
-  bindingError, classDec, dot, forLabel, inLabel, observerListName, 
-  commentedItem, addCommentsDocD, commentedModD, docFuncRepr, 
-  valueList, surroundBody, filterOutObjs)
+  bodyDocD, oneLinerD, outDoc, destructorError, runStrategyD, checkStateD, 
+  multiAssignDoc, returnDocD, mkStNoEnd, stringListVals', stringListLists', 
+  stateD, loopStateD, emptyStateD, assignD, assignToListIndexD, decrementD, 
+  decrement1D, closeFileD, discardFileLineD, breakDocD, continueDocD, returnD, 
+  valStateD, throwD, initStateD, changeStateD, initObserverListD, addObserverD, 
+  ifNoElseD, switchAsIfD, ifExistsD, tryCatchD, unOpPrec, notOpDocD', 
+  negateOpDocD, sqrtOpDocD', absOpDocD', expOpDocD', sinOpDocD', cosOpDocD', 
+  tanOpDocD', asinOpDocD', acosOpDocD', atanOpDocD', unExpr, unExpr', 
+  typeUnExpr, powerPrec, multPrec, andPrec, orPrec, equalOpDocD, notEqualOpDocD,
+  greaterOpDocD, greaterEqualOpDocD, lessOpDocD, lessEqualOpDocD, plusOpDocD, 
+  minusOpDocD, multOpDocD, divideOpDocD, moduloOpDocD, binExpr, typeBinExpr, 
+  mkVal, mkVar, litCharD, litFloatD, litIntD, litStringD, classVarDocD, 
+  newObjDocD', varD, staticVarD, extVarD, enumVarD, classVarD, objVarD, 
+  objVarSelfD, listVarD, listOfD, iterVarD, valueOfD, argD, enumElementD, 
+  argsListD, objAccessD, objMethodCallD, objMethodCallNoParamsD, selfAccessD, 
+  listIndexExistsD, indexOfD, funcAppD, selfFuncAppD, extFuncAppD, newObjD, 
+  listSetFuncDocD, castObjDocD, funcD, getD, setD, listAddD, listAppendD, 
+  iterBeginD, iterEndD, listAccessD, listSetD, getFuncD, setFuncD, listAddFuncD,
+  listAppendFuncD, iterBeginError, iterEndError, listAccessFuncD, listSetFuncD, 
+  dynamicDocD, bindingError, classDec, dot, forLabel, inLabel, observerListName,
+  commentedItem, addCommentsDocD, commentedModD, docFuncRepr, valueList, 
+  parameterList, surroundBody, filterOutObjs)
 import qualified GOOL.Drasil.LanguageRenderer.LanguagePolymorphic as G (
   fileFromData, block, int, float, listInnerType, obj, enumType, increment, 
   increment1, comment, ifCond, objDecNew, objDecNewNoParams, construct, param, 
@@ -52,10 +51,10 @@ import qualified GOOL.Drasil.LanguageRenderer.LanguagePolymorphic as G (
   docFunc, stateVarDef, constVar, privMVar, pubMVar, pubGVar, buildClass, 
   privClass, pubClass, docClass, commentedClass, buildModule, modFromData, 
   fileDoc, docMod)
-import GOOL.Drasil.Data (Terminator(..), FileType(..), FileData(..), fileD,
-  FuncData(..), fd, ModData(..), md, updateModDoc, MethodData(..), mthd, 
-  updateMthdDoc, OpData(..), ParamData(..), pd, ProgData(..), progD, 
-  TypeData(..), td, ValData(..), vd, VarData(..), vard)
+import GOOL.Drasil.Data (Terminator(..), ScopeTag(..), FileType(..), 
+  FileData(..), fileD, FuncData(..), fd, ModData(..), md, updateModDoc, 
+  MethodData(..), mthd, updateMthdDoc, OpData(..), ParamData(..), pd, 
+  ProgData(..), progD, TypeData(..), td, ValData(..), vd, VarData(..), vard)
 import GOOL.Drasil.Helpers (emptyIfEmpty, toCode, toState, onCodeValue,
   onStateValue, on2CodeValues, on2StateValues, on3CodeValues, 
   onCodeList, onStateList, on1CodeValue1List)
@@ -533,6 +532,7 @@ instance ParameterSym PythonCode where
 instance InternalParam PythonCode where
   parameterName = variableName . onCodeValue paramVar
   parameterType = variableType . onCodeValue paramVar
+  parameterDoc = paramDoc . unPC
   paramFromData v d = on2CodeValues pd v (toCode d)
 
 instance MethodSym PythonCode where
@@ -562,11 +562,9 @@ instance MethodSym PythonCode where
 
 instance InternalMethod PythonCode where
   intMethod m n l _ _ _ ps b = getPutReturnList ps (if m then setCurrMain else 
-    id) (\pms -> onCodeValue mthd (on3CodeValues (pyMethod n) (self l) 
-    (onCodeList paramListDocD pms) b))
+    id) (\pms -> methodFromData Pub $ pyMethod n (self l) pms b)
   intFunc m n _ _ _ ps b = getPutReturnList ps (if m then setCurrMain else id) 
-    (\pms -> onCodeValue mthd (on2CodeValues (pyFunction n) (onCodeList 
-    paramListDocD pms) b))
+    (\pms -> methodFromData Pub $ pyFunction n pms b)
   commentedFunc cmt m = on2StateValues (on2CodeValues updateMthdDoc) m 
     (onStateValue (onCodeValue commentedItem) cmt)
 
@@ -726,20 +724,23 @@ pyListSlice :: (RenderSym repr) => repr (Variable repr) -> repr (Value repr) ->
 pyListSlice vnew vold b e s = variableDoc vnew <+> equals <+> valueDoc vold <> 
   brackets (valueDoc b <> colon <> valueDoc e <> colon <> valueDoc s)
 
-pyMethod :: Label -> VarData -> Doc -> Doc -> Doc
+pyMethod :: (RenderSym repr) => Label -> repr (Variable repr) -> 
+  [repr (Parameter repr)] -> repr (Body repr) -> Doc
 pyMethod n slf ps b = vcat [
-  text "def" <+> text n <> parens (varDoc slf <> oneParam <> ps) <> colon,
+  text "def" <+> text n <> parens (variableDoc slf <> oneParam <> pms) <> colon,
   indent bodyD]
-      where oneParam = emptyIfEmpty ps $ text ", "
-            bodyD | isEmpty b = text "None"
-                  | otherwise = b
+      where pms = parameterList ps
+            oneParam = emptyIfEmpty pms $ text ", "
+            bodyD | isEmpty (bodyDoc b) = text "None"
+                  | otherwise = bodyDoc b
 
-pyFunction :: Label -> Doc -> Doc -> Doc
+pyFunction :: (RenderSym repr) => Label -> [repr (Parameter repr)] -> 
+  repr (Body repr) -> Doc
 pyFunction n ps b = vcat [
-  text "def" <+> text n <> parens ps <> colon,
+  text "def" <+> text n <> parens (parameterList ps) <> colon,
   indent bodyD]
-  where bodyD | isEmpty b = text "None"
-              | otherwise = b
+  where bodyD | isEmpty (bodyDoc b) = text "None"
+              | otherwise = bodyDoc b
 
 pyClass :: Label -> Doc -> Doc -> Doc -> Doc -> Doc
 pyClass n pn s vs fs = vcat [

--- a/code/drasil-gool/GOOL/Drasil/State.hs
+++ b/code/drasil-gool/GOOL/Drasil/State.hs
@@ -6,11 +6,11 @@ module GOOL.Drasil.State (
   getPutReturn, getPutReturnFunc, getPutReturnFunc2, getPutReturnList, addFile, 
   addCombinedHeaderSource, addHeader, addSource, addProgNameToPaths, setMainMod,
   setFilePath, getFilePath, setModuleName, getModuleName, setCurrMain, 
-  getCurrMain, setParameters, getParameters, setScope, getScope, 
+  getCurrMain, addParameter, getParameters, setScope, getScope, 
   setCurrMainFunc, getCurrMainFunc
 ) where
 
-import GOOL.Drasil.Data (FileType(..), ParamData, ScopeTag(..))
+import GOOL.Drasil.Data (FileType(..), ScopeTag(..))
 
 import Control.Lens (Lens', (^.), lens, makeLenses, over, set)
 import Control.Lens.Tuple (_1, _2)
@@ -25,7 +25,7 @@ data GOOLState = GS {
 makeLenses ''GOOLState
 
 data MethodState = MS {
-  _currParameters :: [ParamData],
+  _currParameters :: [String],
   
   -- Only used for C++
   _currScope :: ScopeTag,
@@ -193,11 +193,12 @@ setCurrMain = over _2 (over _1 (over currMain (\b -> if b then error
 getCurrMain :: FS Bool
 getCurrMain = gets ((^. currMain) . snd)
 
-setParameters :: [ParamData] -> (GOOLState, (FileState, MethodState)) -> 
+addParameter :: String -> (GOOLState, (FileState, MethodState)) -> 
   (GOOLState, (FileState, MethodState))
-setParameters ps = over _2 $ over _2 $ set currParameters ps
+addParameter p = over _2 $ over _2 $ over currParameters (\ps -> if p `elem` 
+  ps then error $ "Function has duplicate parameter: " ++ p else ps ++ [p])
 
-getParameters :: MS [ParamData]
+getParameters :: MS [String]
 getParameters = gets ((^. currParameters) . snd . snd)
 
 setScope :: ScopeTag -> (GOOLState, (FileState, MethodState)) -> 

--- a/code/drasil-gool/GOOL/Drasil/Symantics.hs
+++ b/code/drasil-gool/GOOL/Drasil/Symantics.hs
@@ -13,9 +13,9 @@ module GOOL.Drasil.Symantics (
   Selector(..), FunctionSym(..), SelectorFunction(..), InternalFunction(..), 
   InternalStatement(..), StatementSym(..), ControlStatementSym(..), 
   ScopeSym(..), InternalScope(..), MethodTypeSym(..), ParameterSym(..), 
-  MethodSym(..), InternalMethod(..), StateVarSym(..), InternalStateVar(..), 
-  ClassSym(..), InternalClass(..), ModuleSym(..), InternalMod(..), 
-  BlockCommentSym(..)
+  InternalParam(..), MethodSym(..), InternalMethod(..), StateVarSym(..), 
+  InternalStateVar(..), ClassSym(..), InternalClass(..), ModuleSym(..), 
+  InternalMod(..), BlockCommentSym(..)
 ) where
 
 import GOOL.Drasil.CodeType (CodeType)
@@ -565,38 +565,38 @@ class (TypeSym repr) => MethodTypeSym repr where
   mType    :: repr (Type repr) -> repr (MethodType repr)
   construct :: Label -> repr (MethodType repr)
 
-class ParameterSym repr where
+class (InternalParam repr) => ParameterSym repr where
   type Parameter repr
-  param :: repr (Variable repr) -> repr (Parameter repr)
+  param :: repr (Variable repr) -> MS (repr (Parameter repr))
   -- funcParam  :: Label -> repr (MethodType repr) -> [repr (Parameter repr)] -> repr (Parameter repr) -- not implemented in GOOL
-  pointerParam :: repr (Variable repr) -> repr (Parameter repr)
+  pointerParam :: repr (Variable repr) -> MS (repr (Parameter repr))
 
+class InternalParam repr where
+  parameterName :: repr (Parameter repr) -> Label
   parameterType :: repr (Parameter repr) -> repr (Type repr)
+  paramFromData :: repr (Variable repr) -> Doc -> repr (Parameter repr)
 
 class (StateVarSym repr, ParameterSym repr, ControlBlockSym repr, 
   InternalMethod repr) => MethodSym repr where
   type Method repr
   -- Second label is class name
   method      :: Label -> Label -> repr (Scope repr) -> repr (Permanence repr) 
-    -> repr (Type repr) -> [repr (Parameter repr)] -> repr (Body repr) -> 
+    -> repr (Type repr) -> [MS (repr (Parameter repr))] -> repr (Body repr) -> 
     MS (repr (Method repr))
-  getMethod   :: Label -> repr (Variable repr) -> 
+  getMethod   :: Label -> repr (Variable repr) -> MS (repr (Method repr))
+  setMethod   :: Label -> repr (Variable repr) -> MS (repr (Method repr)) 
+  privMethod  :: Label -> Label -> repr (Type repr) -> 
+    [MS (repr (Parameter repr))] -> repr (Body repr) -> MS (repr (Method repr))
+  pubMethod   :: Label -> Label -> repr (Type repr) -> 
+    [MS (repr (Parameter repr))] -> repr (Body repr) -> MS (repr (Method repr))
+  constructor :: Label -> [MS (repr (Parameter repr))] -> repr (Body repr) -> 
     MS (repr (Method repr))
-  setMethod   :: Label -> repr (Variable repr) -> 
-    MS (repr (Method repr)) 
-  privMethod  :: Label -> Label -> repr (Type repr) -> [repr (Parameter repr)] 
-    -> repr (Body repr) -> MS (repr (Method repr))
-  pubMethod   :: Label -> Label -> repr (Type repr) -> [repr (Parameter repr)] 
-    -> repr (Body repr) -> MS (repr (Method repr))
-  constructor :: Label -> [repr (Parameter repr)] -> repr (Body repr) -> 
-    MS (repr (Method repr))
-  destructor :: Label -> [GS (repr (StateVar repr))] -> 
-    MS (repr (Method repr))
+  destructor :: Label -> [GS (repr (StateVar repr))] -> MS (repr (Method repr))
 
   docMain :: repr (Body repr) -> MS (repr (Method repr))
 
   function :: Label -> repr (Scope repr) -> repr (Permanence repr) -> 
-    repr (Type repr) -> [repr (Parameter repr)] -> repr (Body repr) -> 
+    repr (Type repr) -> [MS (repr (Parameter repr))] -> repr (Body repr) -> 
     MS (repr (Method repr))
   mainFunction  :: repr (Body repr) -> MS (repr (Method repr))
   -- Parameters are: function description, parameter descriptions, 
@@ -627,12 +627,12 @@ class (StateVarSym repr, ParameterSym repr, ControlBlockSym repr,
 
 class (MethodTypeSym repr, BlockCommentSym repr) => 
   InternalMethod repr where
-  intMethod      :: Bool -> Label -> Label -> repr (Scope repr) -> 
-    repr (Permanence repr) -> repr (MethodType repr) -> [repr (Parameter repr)] 
-    -> repr (Body repr) -> MS (repr (Method repr))
-  intFunc      :: Bool -> Label -> repr (Scope repr) -> repr (Permanence repr) 
-    -> repr (MethodType repr) -> [repr (Parameter repr)] -> repr (Body repr) -> 
-    MS (repr (Method repr))
+  intMethod     :: Bool -> Label -> Label -> repr (Scope repr) -> 
+    repr (Permanence repr) -> repr (MethodType repr) -> 
+    [MS (repr (Parameter repr))] -> repr (Body repr) -> MS (repr (Method repr))
+  intFunc       :: Bool -> Label -> repr (Scope repr) -> repr (Permanence repr) 
+    -> repr (MethodType repr) -> [MS (repr (Parameter repr))] -> 
+    repr (Body repr) -> MS (repr (Method repr))
   commentedFunc :: MS (repr (BlockComment repr)) -> MS (repr (Method repr)) -> 
     MS (repr (Method repr))
 

--- a/code/drasil-gool/GOOL/Drasil/Symantics.hs
+++ b/code/drasil-gool/GOOL/Drasil/Symantics.hs
@@ -574,6 +574,7 @@ class (InternalParam repr) => ParameterSym repr where
 class InternalParam repr where
   parameterName :: repr (Parameter repr) -> Label
   parameterType :: repr (Parameter repr) -> repr (Type repr)
+  parameterDoc  :: repr (Parameter repr) -> Doc
   paramFromData :: repr (Variable repr) -> Doc -> repr (Parameter repr)
 
 class (StateVarSym repr, ParameterSym repr, ControlBlockSym repr, 


### PR DESCRIPTION
This PR makes GOOL `Parameter`s stateful, where during the state transition an error is thrown if multiple parameters for a given function are the same. This was previously handled by a `checkParams` function, but now that it is handled by State, it enabled some simplifications to the messy `intMethod` and `intFunc` function implementations in the renderers.

@JacquesCarette I discovered while working on this that if the source and header instances of a GOOL function just call other GOOL functions exactly the same way, our `Pair` instance for that function can just do those calls directly, instead of breaking down the pair, dispatching to the two instances, and then putting the results back together in a pair. For example, both instances of `docInOutFunc` are defined as `docInOutFunc n = G.docInOutFunc (inOutFunc n)`. So, whereas the `Pair` instance is currently:
```
docInOutFunc n s p desc is os bs b = on2StateValues pair (docInOutFunc n 
    (pfst s) (pfst p) desc (map (mapPairSnd pfst) is) (map (mapPairSnd pfst) os)
    (map (mapPairSnd pfst) bs) (pfst b)) (docInOutFunc n (psnd s) (psnd p) desc 
    (map (mapPairSnd psnd) is) (map (mapPairSnd psnd) os) (map (mapPairSnd psnd)
    bs) (psnd b))
```
We can instead make it the same as the other instances: `docInOutFunc n = G.docInOutFunc (inOutFunc n)`.

Do you think we should do this? Though it would simplify the `Pair` instance, I can think of two reasons not to do this:
1. Even if we do it, we still need to duplicate the instances in `CppSrcCode` and `CppHdrCode` because we can't just leave those instances blank (would get warnings or errors if we did).
2. This would make the `Pair` instance less re-usable. Currently, if we ever implement another language renderer that needs 2 files for every module, we can just copy and paste the same `Pair` instance we already have and just find and replace `CppSrcCode` and `CppHdrCode` with the right types. But if we made this change, then these instances may also need to be re-defined for the new language.

---

Nobody is obligated to read the rest of this comment, but it is a story about a big roadblock I ran into during this PR that I wanted to record because it is the single most confusing thing that I've gone through since I started programming. 

After adding `State` to the parameters, I was hitting the error in C++ saying that a function had duplicate parameters. Since none of our functions in our examples actually have duplicate parameters (and since the other target languages were not hitting this error), the only explanation was that in C++ for some reason the state transitions for adding the parameters to the state were happening twice. Just to test, I changed it so only the source code half of the C++ renderer would be used, and the error went away. So something in the `Pair` instance was causing the error. My first thought was that this was happening because the `CppSrcCode` instance and `CppHdrCode` instance were both doing the state transitions. I had originally hoped that the two instances would be able to do state transitions in parallel, but upon further investigation it became clear why that wasn't happening, and that they needed to be done in series. The solution then seemed clear: I had to update `CppHdrCode` instances to not repeat the state transitions, since they would already be done by `CppSrcCode`. So that's what I did.

Only I was still getting the same error. At this point I was very confused. Since the `CppHdrCode` instance was not doing the state transitions anymore, the only way this could be happening was if the `CppSrcCode` state transitions were running twice. But I had already tested running the `CppSrcCode` half alone, and everything had worked! So the `Pair` instance was somehow causing the `CppSrcCode` instances to run twice. I investigated further and uncovered more details: The error was only happening for functions defined with `inOutFunc`, and only happening when comments were turned on. So `inOutFunc` and `docFunc` worked fine, but `docInOutFunc` hit the error. I continued, and things got even more confusing. Even though the state transitions had already been removed from the `CppHdrCode` instance, I found that if I updated the `CppHdrCode` instance of `docInOutFunc` to just do nothing (i.e. return an empty function), the error went away. So it was as if the `CppHdrCode` instance had somehow been calling the `CppSrcCode` instance, though this made no sense as that would have surely led to type errors if it were happening. And indeed, I hardcoded some errors into functions in both instances and found that the `CppHdrCode` ones were being called as expected, and the `CppSrcCode` ones were not being called by the `CppHdrCode` instance (which I confirmed by updating the `CppSrcCode` instance of `docInOutFunc` to do nothing). So everything seemed to be working normally, but I was still hitting the duplicate parameters error. Somehow, the mere presence of a meaningful `CppHdrCode` instance for `docInOutFunc`, even one that did not perform state transitions, was causing the `Pair` instance to run the `CppSrcCode` half twice.

So many of my observations were contradicting each other, and I was as confused as I ever remember being since I started programming. I finally stumbled upon a potential solution -- I noticed the `CppSrcCode` and `CppHdrCode` instances for `docInOutFunc` were the same, in that they each called (their corresponding instance of) `inOutFunc` and then `commentedFunc`. It occurred to me that for higher-level functions where both instances are formed by calling lower-level functions in the same way, couldn't I just do that behaviour directly in the `Pair` instance, instead of extracting each half of the pair, feeding it to its corresponding instance, and then re-combining the results into a pair? Turned out the answer was yes. Updating the `Pair` instance of `docInOutFunc` to just do what the other instances were doing directly (and with some minor modifications to related functions), the error finally went away.

But I wasn't satisfied, because I still didn't understand what had caused the error in the first place, and my solution was more of a workaround than a real fix. So I reverted that fix, and went through the code, following the path `docInOutFunc` would take with a fine-toothed comb, and comparing it to the (working) `docFunc`. Finally, I found an oddity. In `cppCommentedFunc`, we had:
https://github.com/JacquesCarette/Drasil/blob/d642ccbdb7c2e5f28697d8f1868a34948dd2cc95/code/drasil-gool/GOOL/Drasil/LanguageRenderer/CppRenderer.hs#L2067-L2080
The line `f <- fn` is what was supposed to trigger the state transitions for the passed `Method`, including adding the parameters to the state, but if you look at the `if-then-else` conditions you see that there are some cases where `cppCommentedFunc` just returns `fn`. In those cases, `f` is never used, so, if I understood Haskell's laziness correctly, that would mean those state transitions would never truly happen. So, even though my bug was that the state transitions were happening twice, I had found a reason why they would be happening 0 times. Another contradiction, but this was a bug I should fix nonetheless, so I updated `cppCommentedFunc` to return `toState f` instead of `fn` in those cases, so that `f` would actually be used and the associated state transitions would be forced to happen. And, lo and behold, the error went away. My best guess is that the fact that the state transitions were not being run at this point was leading to a scenario higher up where the state was expected to be further along than it really was. I still don't have a full understanding of why I was getting the error, and especially why my test where I updated the `CppHdrCode` instance to do nothing miraculously made the error not get hit despite having seemingly nothing to do with it, but I am at least confident I found and fixed a bug that was causing it, so I can move on.


