### PR TITLE
Information collection pass in GOOL

### DIFF
--- a/code/drasil-code/Language/Drasil/Code/Imperative/ConceptMatch.hs
+++ b/code/drasil-code/Language/Drasil/Code/Imperative/ConceptMatch.hs
@@ -5,7 +5,7 @@ module Language.Drasil.Code.Imperative.ConceptMatch (
 import Language.Drasil.CodeSpec (Choices(..), CodeConcept(..), 
   MatchedConceptMap)
 
-import GOOL.Drasil (RenderSym, ValueSym(..), GS)
+import GOOL.Drasil (ProgramSym, ValueSym(..), GS)
 
 import Prelude hiding (pi)
 import qualified Data.Map as Map (map)
@@ -17,6 +17,6 @@ chooseConcept chs = Map.map (chooseConcept' chs) (conceptMatch chs)
           "ConceptMatchMap"
         chooseConcept' _ cs = head cs
 
-conceptToGOOL :: (RenderSym repr) => CodeConcept -> GS (repr (Value repr))
+conceptToGOOL :: (ProgramSym repr) => CodeConcept -> GS (repr (Value repr))
 conceptToGOOL Pi = pi
 

--- a/code/drasil-code/Language/Drasil/Code/Imperative/FunctionCalls.hs
+++ b/code/drasil-code/Language/Drasil/Code/Imperative/FunctionCalls.hs
@@ -16,7 +16,7 @@ import Language.Drasil.Chunk.CodeDefinition (CodeDefinition)
 import Language.Drasil.Chunk.CodeQuantity (HasCodeType)
 import Language.Drasil.CodeSpec (CodeSpec(..))
 
-import GOOL.Drasil (RenderSym(..), TypeSym(..), ValueSym(..), 
+import GOOL.Drasil (RenderSym, TypeSym(..), ValueSym(..), 
   StatementSym(..), GS, convType)
 
 import Data.List ((\\), intersect)

--- a/code/drasil-code/Language/Drasil/Code/Imperative/FunctionCalls.hs
+++ b/code/drasil-code/Language/Drasil/Code/Imperative/FunctionCalls.hs
@@ -16,7 +16,7 @@ import Language.Drasil.Chunk.CodeDefinition (CodeDefinition)
 import Language.Drasil.Chunk.CodeQuantity (HasCodeType)
 import Language.Drasil.CodeSpec (CodeSpec(..))
 
-import GOOL.Drasil (RenderSym, TypeSym(..), ValueSym(..), 
+import GOOL.Drasil (ProgramSym, TypeSym(..), ValueSym(..), 
   StatementSym(..), GS, convType)
 
 import Data.List ((\\), intersect)
@@ -25,7 +25,7 @@ import Data.Maybe (maybe, catMaybes)
 import Control.Monad.Reader (Reader, ask)
 import Control.Lens ((^.))
 
-getAllInputCalls :: (RenderSym repr) => Reader DrasilState 
+getAllInputCalls :: (ProgramSym repr) => Reader DrasilState 
   [GS (repr (Statement repr))]
 getAllInputCalls = do
   gi <- getInputCall
@@ -33,21 +33,21 @@ getAllInputCalls = do
   ic <- getConstraintCall
   return $ catMaybes [gi, dv, ic]
 
-getInputCall :: (RenderSym repr) => Reader DrasilState 
+getInputCall :: (ProgramSym repr) => Reader DrasilState 
   (Maybe (GS (repr (Statement repr))))
 getInputCall = getInOutCall "get_input" getInputFormatIns getInputFormatOuts
 
-getDerivedCall :: (RenderSym repr) => Reader DrasilState 
+getDerivedCall :: (ProgramSym repr) => Reader DrasilState 
   (Maybe (GS (repr (Statement repr))))
 getDerivedCall = getInOutCall "derived_values" getDerivedIns getDerivedOuts
 
-getConstraintCall :: (RenderSym repr) => Reader DrasilState 
+getConstraintCall :: (ProgramSym repr) => Reader DrasilState 
   (Maybe (GS (repr (Statement repr))))
 getConstraintCall = do
   val <- getFuncCall "input_constraints" void getConstraintParams
   return $ fmap valState val
 
-getCalcCall :: (RenderSym repr) => CodeDefinition -> Reader DrasilState 
+getCalcCall :: (ProgramSym repr) => CodeDefinition -> Reader DrasilState 
   (Maybe (GS (repr (Statement repr))))
 getCalcCall c = do
   g <- ask
@@ -57,13 +57,13 @@ getCalcCall c = do
   l <- maybeLog v
   return $ fmap (multi . (: l) . varDecDef v) val
 
-getOutputCall :: (RenderSym repr) => Reader DrasilState 
+getOutputCall :: (ProgramSym repr) => Reader DrasilState 
   (Maybe (GS (repr (Statement repr))))
 getOutputCall = do
   val <- getFuncCall "write_output" void getOutputParams
   return $ fmap valState val
 
-getFuncCall :: (RenderSym repr, HasUID c, HasCodeType c, CodeIdea c) => String 
+getFuncCall :: (ProgramSym repr, HasUID c, HasCodeType c, CodeIdea c) => String 
   -> GS (repr (Type repr)) -> Reader DrasilState [c] -> 
   Reader DrasilState (Maybe (GS (repr (Value repr))))
 getFuncCall n t funcPs = do
@@ -76,7 +76,7 @@ getFuncCall n t funcPs = do
         return $ Just val
   getFuncCall' mm
 
-getInOutCall :: (RenderSym repr, HasCodeType c, CodeIdea c, Eq c) => String -> 
+getInOutCall :: (ProgramSym repr, HasCodeType c, CodeIdea c, Eq c) => String -> 
   Reader DrasilState [c] -> Reader DrasilState [c] ->
   Reader DrasilState (Maybe (GS (repr (Statement repr))))
 getInOutCall n inFunc outFunc = do

--- a/code/drasil-code/Language/Drasil/Code/Imperative/GenerateGOOL.hs
+++ b/code/drasil-code/Language/Drasil/Code/Imperative/GenerateGOOL.hs
@@ -8,7 +8,7 @@ import Language.Drasil.Code.Imperative.GOOL.Symantics (AuxiliarySym(..))
 import Language.Drasil.CodeSpec (CodeSpec(..), CodeSystInfo(..), Comments(..), 
   Name)
   
-import GOOL.Drasil (Label, RenderSym, FileSym(..), TypeSym(..), 
+import GOOL.Drasil (Label, ProgramSym, FileSym(..), TypeSym(..), 
   VariableSym(..), ValueSym(..), ValueExpression(..), StatementSym(..), 
   ParameterSym(..), MethodSym(..), StateVarSym(..), ClassSym(..), ModuleSym(..),
   CodeType(..), GOOLState, GS, FS, MS, lensMStoGS)
@@ -18,7 +18,7 @@ import Data.Maybe (fromMaybe, maybe)
 import Control.Lens.Zoom (zoom)
 import Control.Monad.Reader (Reader, ask, withReader)
 
-genModule :: (RenderSym repr) => Name -> String
+genModule :: (ProgramSym repr) => Name -> String
   -> Maybe (Reader DrasilState [MS (repr (Method repr))])
   -> Maybe (Reader DrasilState [FS (repr (Class repr))])
   -> Reader DrasilState (FS (repr (RenderFile repr)))
@@ -45,7 +45,7 @@ genDoxConfig n s = do
       v = doxOutput g
   return [doxConfig n s v | not (null cms)]
 
-publicClass :: (RenderSym repr) => String -> Label -> Maybe Label -> 
+publicClass :: (ProgramSym repr) => String -> Label -> Maybe Label -> 
   [GS (repr (StateVar repr))] -> Reader DrasilState [MS (repr (Method repr))] 
   -> Reader DrasilState (FS (repr (Class repr)))
 publicClass desc n l vs mths = do
@@ -55,7 +55,7 @@ publicClass desc n l vs mths = do
     then docClass desc (pubClass n l vs ms) 
     else pubClass n l vs ms
 
-fApp :: (RenderSym repr) => String -> String -> GS (repr (Type repr)) -> 
+fApp :: (ProgramSym repr) => String -> String -> GS (repr (Type repr)) -> 
   [GS (repr (Value repr))] -> Reader DrasilState (GS (repr (Value repr)))
 fApp m s t vl = do
   g <- ask
@@ -63,7 +63,7 @@ fApp m s t vl = do
   return $ if m /= cm then extFuncApp m s t vl else if Map.lookup s 
     (eMap $ codeSpec g) == Just cm then funcApp s t vl else selfFuncApp m s t vl
 
-fAppInOut :: (RenderSym repr) => String -> String -> [GS (repr (Value repr))] 
+fAppInOut :: (ProgramSym repr) => String -> String -> [GS (repr (Value repr))] 
   -> [GS (repr (Variable repr))] -> [GS (repr (Variable repr))] -> 
   Reader DrasilState (GS (repr (Statement repr)))
 fAppInOut m n ins outs both = do
@@ -73,7 +73,7 @@ fAppInOut m n ins outs both = do
     (eMap $ codeSpec g) == Just cm then inOutCall n ins outs both else 
     selfInOutCall m n ins outs both
 
-mkParam :: (RenderSym repr) => GS (repr (Variable repr)) -> 
+mkParam :: (ProgramSym repr) => GS (repr (Variable repr)) -> 
   MS (repr (Parameter repr))
 mkParam v = zoom lensMStoGS v >>= (\v' -> paramFunc (getType $ variableType v') v)
   where paramFunc (List _) = pointerParam

--- a/code/drasil-code/Language/Drasil/Code/Imperative/GenerateGOOL.hs
+++ b/code/drasil-code/Language/Drasil/Code/Imperative/GenerateGOOL.hs
@@ -8,7 +8,7 @@ import Language.Drasil.Code.Imperative.GOOL.Symantics (AuxiliarySym(..))
 import Language.Drasil.CodeSpec (CodeSpec(..), CodeSystInfo(..), Comments(..), 
   Name)
   
-import GOOL.Drasil (Label, RenderSym(..), TypeSym(..), 
+import GOOL.Drasil (Label, RenderSym, FileSym(..), TypeSym(..), 
   VariableSym(..), ValueSym(..), ValueExpression(..), StatementSym(..), 
   ParameterSym(..), MethodSym(..), StateVarSym(..), ClassSym(..), ModuleSym(..),
   CodeType(..), GOOLState, GS, FS, MS, lensMStoGS)

--- a/code/drasil-code/Language/Drasil/Code/Imperative/Generator.hs
+++ b/code/drasil-code/Language/Drasil/Code/Imperative/Generator.hs
@@ -17,13 +17,13 @@ import Language.Drasil.Chunk.Code (programName)
 import Language.Drasil.CodeSpec (CodeSpec(..), CodeSystInfo(..), Choices(..), 
   Lang(..), Visibility(..))
 
-import GOOL.Drasil (ProgramSym(..), RenderSym, FileSym(..), ProgData(..), 
-  GS, FS, initialState)
+import GOOL.Drasil (ProgramSym(..), ProgramSym, FileSym(..), ProgData(..), 
+  GS, FS, initialState, unCI)
 
 import System.Directory (setCurrentDirectory, createDirectoryIfMissing, 
   getCurrentDirectory)
 import Control.Monad.Reader (Reader, ask, runReader)
-import Control.Monad.State (runState)
+import Control.Monad.State (evalState, runState)
 
 generator :: String -> [Expr] -> Choices -> CodeSpec -> DrasilState
 generator dt sd chs spec = DrasilState {
@@ -69,8 +69,10 @@ genPackage :: (ProgramSym progRepr, PackageSym packRepr) =>
   Reader DrasilState (packRepr (Package packRepr))
 genPackage unRepr = do
   g <- ask
+  ci <- genProgram
   p <- genProgram
-  let (reprPD, s) = runState p initialState
+  let info = unCI $ evalState ci initialState
+      (reprPD, s) = runState p info
       pd = unRepr reprPD
       n = case codeSpec g of CodeSpec {program = pr} -> programName pr
       m = makefile (commented g) s pd
@@ -86,7 +88,7 @@ genProgram = do
   let n = case codeSpec g of CodeSpec {program = p} -> programName p
   return $ prog n ms
           
-genModules :: (RenderSym repr) => Reader DrasilState [FS (repr (RenderFile repr))]
+genModules :: (ProgramSym repr) => Reader DrasilState [FS (repr (RenderFile repr))]
 genModules = do
   g <- ask
   let s = csi $ codeSpec g

--- a/code/drasil-code/Language/Drasil/Code/Imperative/Generator.hs
+++ b/code/drasil-code/Language/Drasil/Code/Imperative/Generator.hs
@@ -17,13 +17,13 @@ import Language.Drasil.Chunk.Code (programName)
 import Language.Drasil.CodeSpec (CodeSpec(..), CodeSystInfo(..), Choices(..), 
   Lang(..), Visibility(..))
 
-import GOOL.Drasil (ProgramSym(..), RenderSym(..), ProgData(..), GS, FS, 
-  initialState)
+import GOOL.Drasil (ProgramSym(..), RenderSym, FileSym(..), ProgData(..), 
+  GS, FS, initialState)
 
 import System.Directory (setCurrentDirectory, createDirectoryIfMissing, 
   getCurrentDirectory)
 import Control.Monad.Reader (Reader, ask, runReader)
-import Control.Monad.State (evalState, execState)
+import Control.Monad.State (runState)
 
 generator :: String -> [Expr] -> Choices -> CodeSpec -> DrasilState
 generator dt sd chs spec = DrasilState {
@@ -70,8 +70,8 @@ genPackage :: (ProgramSym progRepr, PackageSym packRepr) =>
 genPackage unRepr = do
   g <- ask
   p <- genProgram
-  let s = execState p initialState
-      pd = unRepr $ evalState p initialState
+  let (reprPD, s) = runState p initialState
+      pd = unRepr reprPD
       n = case codeSpec g of CodeSpec {program = pr} -> programName pr
       m = makefile (commented g) s pd
   i <- genSampleInput

--- a/code/drasil-code/Language/Drasil/Code/Imperative/Import.hs
+++ b/code/drasil-code/Language/Drasil/Code/Imperative/Import.hs
@@ -28,8 +28,8 @@ import Language.Drasil.Code.DataDesc (DataItem, LinePattern(Repeat, Straight),
   Data(Line, Lines, JunkData, Singleton), DataDesc, isLine, isLines, getInputs,
   getPatternInputs)
 
-import GOOL.Drasil (Label, RenderSym(..), PermanenceSym(..), BodySym(..), 
-  BlockSym(..), TypeSym(..), VariableSym(..), ValueSym(..), 
+import GOOL.Drasil (Label, RenderSym, FileSym(..), PermanenceSym(..), 
+  BodySym(..), BlockSym(..), TypeSym(..), VariableSym(..), ValueSym(..), 
   NumericExpression(..), BooleanExpression(..), ValueExpression(..), 
   FunctionSym(..), SelectorFunction(..), StatementSym(..), 
   ControlStatementSym(..), ScopeSym(..), ParameterSym(..), MethodSym(..), 

--- a/code/drasil-code/Language/Drasil/Code/Imperative/Import.hs
+++ b/code/drasil-code/Language/Drasil/Code/Imperative/Import.hs
@@ -28,7 +28,7 @@ import Language.Drasil.Code.DataDesc (DataItem, LinePattern(Repeat, Straight),
   Data(Line, Lines, JunkData, Singleton), DataDesc, isLine, isLines, getInputs,
   getPatternInputs)
 
-import GOOL.Drasil (Label, RenderSym, FileSym(..), PermanenceSym(..), 
+import GOOL.Drasil (Label, ProgramSym, FileSym(..), PermanenceSym(..), 
   BodySym(..), BlockSym(..), TypeSym(..), VariableSym(..), ValueSym(..), 
   NumericExpression(..), BooleanExpression(..), ValueExpression(..), 
   FunctionSym(..), SelectorFunction(..), StatementSym(..), 
@@ -45,7 +45,7 @@ import Control.Monad (liftM2,liftM3)
 import Control.Monad.Reader (Reader, ask)
 import Control.Lens ((^.))
 
-value :: (RenderSym repr) => UID -> String -> GS (repr (Type repr)) -> 
+value :: (ProgramSym repr) => UID -> String -> GS (repr (Type repr)) -> 
   Reader DrasilState (GS (repr (Value repr)))
 value u s t = do
   g <- ask
@@ -58,7 +58,7 @@ value u s t = do
     (convExpr . codeEquat) (Map.lookup u mm >>= maybeInline (conStruct g))) 
     (return . conceptToGOOL) (Map.lookup u cm)
 
-variable :: (RenderSym repr) => String -> GS (repr (Type repr)) -> 
+variable :: (ProgramSym repr) => String -> GS (repr (Type repr)) -> 
   Reader DrasilState (GS (repr (Variable repr)))
 variable s t = do
   g <- ask
@@ -71,7 +71,7 @@ variable s t = do
       then constVariable (conStruct g) (conRepr g) ((defFunc $ conRepr g) s t)
       else return $ var s t
   
-inputVariable :: (RenderSym repr) => Structure -> ConstantRepr -> 
+inputVariable :: (ProgramSym repr) => Structure -> ConstantRepr -> 
   GS (repr (Variable repr)) -> Reader DrasilState (GS (repr (Variable repr)))
 inputVariable Unbundled _ v = return v
 inputVariable Bundled Var v = do
@@ -84,7 +84,7 @@ inputVariable Bundled Const v = do
   ip <- mkVar (codevar inParams)
   classVariable ip v
 
-constVariable :: (RenderSym repr) => ConstantStructure -> ConstantRepr -> 
+constVariable :: (ProgramSym repr) => ConstantStructure -> ConstantRepr -> 
   GS (repr (Variable repr)) -> Reader DrasilState (GS (repr (Variable repr)))
 constVariable (Store Bundled) Var v = do
   cs <- mkVar (codevar consts)
@@ -97,7 +97,7 @@ constVariable WithInputs cr v = do
   inputVariable (inStruct g) cr v
 constVariable _ _ v = return v
 
-classVariable :: (RenderSym repr) => GS (repr (Variable repr)) -> 
+classVariable :: (ProgramSym repr) => GS (repr (Variable repr)) -> 
   GS (repr (Variable repr)) -> Reader DrasilState (GS (repr (Variable repr)))
 classVariable c v = do
   g <- ask
@@ -106,41 +106,41 @@ classVariable c v = do
     " missing from export map") checkCurrent (Map.lookup (variableName v') 
     (eMap $ codeSpec g)) (onStateValue variableType c) v)
 
-mkVal :: (RenderSym repr, HasUID c, HasCodeType c, CodeIdea c) => c -> 
+mkVal :: (ProgramSym repr, HasUID c, HasCodeType c, CodeIdea c) => c -> 
   Reader DrasilState (GS (repr (Value repr)))
 mkVal v = value (v ^. uid) (codeName v) (convType $ codeType v)
 
-mkVar :: (RenderSym repr, HasCodeType c, CodeIdea c) => c -> 
+mkVar :: (ProgramSym repr, HasCodeType c, CodeIdea c) => c -> 
   Reader DrasilState (GS (repr (Variable repr)))
 mkVar v = variable (codeName v) (convType $ codeType v)
 
-publicFunc :: (RenderSym repr, HasUID c, HasCodeType c, CodeIdea c) => 
+publicFunc :: (ProgramSym repr, HasUID c, HasCodeType c, CodeIdea c) => 
   Label -> GS (repr (Type repr)) -> String -> [c] -> Maybe String -> 
   [GS (repr (Block repr))] -> Reader DrasilState (MS (repr (Method repr)))
 publicFunc n t = genMethod (function n public static_ t) n
 
-privateMethod :: (RenderSym repr, HasUID c, HasCodeType c, CodeIdea c) => 
+privateMethod :: (ProgramSym repr, HasUID c, HasCodeType c, CodeIdea c) => 
   Label -> Label -> GS (repr (Type repr)) -> String -> [c] -> Maybe String -> 
   [GS (repr (Block repr))] -> Reader DrasilState (MS (repr (Method repr)))
 privateMethod c n t = genMethod (method n c private dynamic_ t) n
 
-publicInOutFunc :: (RenderSym repr, HasUID c, HasCodeType c, CodeIdea c, Eq c) 
+publicInOutFunc :: (ProgramSym repr, HasUID c, HasCodeType c, CodeIdea c, Eq c) 
   => Label -> String -> [c] -> [c] -> [GS (repr (Block repr))] -> 
   Reader DrasilState (MS (repr (Method repr)))
 publicInOutFunc n = genInOutFunc (inOutFunc n) (docInOutFunc n) public static_ n
 
-privateInOutMethod :: (RenderSym repr, HasUID c, HasCodeType c, CodeIdea c,
+privateInOutMethod :: (ProgramSym repr, HasUID c, HasCodeType c, CodeIdea c,
   Eq c) => Label -> Label -> String -> [c] -> [c] -> [GS (repr (Block repr))] 
   -> Reader DrasilState (MS (repr (Method repr)))
 privateInOutMethod c n = genInOutFunc (inOutMethod n c) (docInOutMethod n c) 
   private dynamic_ n
 
-genConstructor :: (RenderSym repr, HasUID c, HasCodeType c, CodeIdea c) => 
+genConstructor :: (ProgramSym repr, HasUID c, HasCodeType c, CodeIdea c) => 
   Label -> String -> [c] -> [GS (repr (Block repr))] -> 
   Reader DrasilState (MS (repr (Method repr)))
 genConstructor n desc p = genMethod (constructor n) n desc p Nothing
 
-genMethod :: (RenderSym repr, HasUID c, HasCodeType c, CodeIdea c) => 
+genMethod :: (ProgramSym repr, HasUID c, HasCodeType c, CodeIdea c) => 
   ([MS (repr (Parameter repr))] -> GS (repr (Body repr) )-> 
   MS (repr (Method repr))) -> Label -> String -> [c] -> Maybe String -> 
   [GS (repr (Block repr))] -> Reader DrasilState (MS (repr (Method repr)))
@@ -154,7 +154,7 @@ genMethod f n desc p r b = do
   return $ if CommentFunc `elem` commented g
     then docFunc desc pComms r fn else fn
 
-genInOutFunc :: (RenderSym repr, HasUID c, HasCodeType c, CodeIdea c, Eq c) => 
+genInOutFunc :: (ProgramSym repr, HasUID c, HasCodeType c, CodeIdea c, Eq c) => 
   (repr (Scope repr) -> repr (Permanence repr) -> [GS (repr (Variable repr))] 
     -> [GS (repr (Variable repr))] -> [GS (repr (Variable repr))] -> 
     GS (repr (Body repr)) -> MS (repr (Method repr))) -> 
@@ -182,7 +182,7 @@ genInOutFunc f docf s pr n desc ins' outs' b = do
     then docf s pr desc (zip pComms inVs) (zip oComms outVs) (zip 
     bComms bothVs) bod else f s pr inVs outVs bothVs bod
 
-convExpr :: (RenderSym repr) => Expr -> Reader DrasilState (GS (repr (Value repr)))
+convExpr :: (ProgramSym repr) => Expr -> Reader DrasilState (GS (repr (Value repr)))
 convExpr (Dbl d) = return $ litFloat d
 convExpr (Int i) = return $ litInt i
 convExpr (Str s) = return $ litString s
@@ -239,7 +239,7 @@ renderRealInt s (UpTo (Exc,a))    = sy s $< a
 renderRealInt s (UpFrom (Inc,a))  = sy s $>= a
 renderRealInt s (UpFrom (Exc,a))  = sy s $>  a
 
-unop :: (RenderSym repr) => UFunc -> (GS (repr (Value repr)) -> GS (repr (Value repr)))
+unop :: (ProgramSym repr) => UFunc -> (GS (repr (Value repr)) -> GS (repr (Value repr)))
 unop Sqrt = (#/^)
 unop Log  = log
 unop Ln   = ln
@@ -259,7 +259,7 @@ unop Norm = error "unop: Norm not implemented"
 unop Not  = (?!)
 unop Neg  = (#~)
 
-bfunc :: (RenderSym repr) => BinOp -> (GS (repr (Value repr)) -> 
+bfunc :: (ProgramSym repr) => BinOp -> (GS (repr (Value repr)) -> 
   GS (repr (Value repr)) -> GS (repr (Value repr)))
 bfunc Eq    = (?==)
 bfunc NEq   = (?!=)
@@ -278,7 +278,7 @@ bfunc Index = listAccess
 
 ------- CALC ----------
 
-genCalcFunc :: (RenderSym repr) => CodeDefinition -> 
+genCalcFunc :: (ProgramSym repr) => CodeDefinition -> 
   Reader DrasilState (MS (repr (Method repr)))
 genCalcFunc cdef = do
   parms <- getCalcParams cdef
@@ -296,7 +296,7 @@ genCalcFunc cdef = do
 
 data CalcType = CalcAssign | CalcReturn deriving Eq
 
-genCalcBlock :: (RenderSym repr) => CalcType -> CodeDefinition -> Expr ->
+genCalcBlock :: (ProgramSym repr) => CalcType -> CodeDefinition -> Expr ->
   Reader DrasilState (GS (repr (Block repr)))
 genCalcBlock t v (Case c e) = genCaseBlock t v c e
 genCalcBlock t v e
@@ -304,7 +304,7 @@ genCalcBlock t v e
       convExpr e; l <- maybeLog vv; return $ multi $ assign vv ee : l}
     | otherwise        = block <$> liftS (returnState <$> convExpr e)
 
-genCaseBlock :: (RenderSym repr) => CalcType -> CodeDefinition -> Completeness 
+genCaseBlock :: (ProgramSym repr) => CalcType -> CodeDefinition -> Completeness 
   -> [(Expr,Relation)] -> Reader DrasilState (GS (repr (Block repr)))
 genCaseBlock _ _ _ [] = error $ "Case expression with no cases encountered" ++
   " in code generator"
@@ -320,11 +320,11 @@ genCaseBlock t v c cs = do
           "Undefined case encountered in function " ++ codeName v
 
 -- medium hacks --
-genModDef :: (RenderSym repr) => Mod -> 
+genModDef :: (ProgramSym repr) => Mod -> 
   Reader DrasilState (FS (repr (RenderFile repr)))
 genModDef (Mod n desc fs) = genModule n desc (Just $ mapM genFunc fs) Nothing
 
-genFunc :: (RenderSym repr) => Func -> Reader DrasilState (MS (repr (Method repr)))
+genFunc :: (ProgramSym repr) => Func -> Reader DrasilState (MS (repr (Method repr)))
 genFunc (FDef (FuncDef n desc parms o rd s)) = do
   g <- ask
   stmts <- mapM convStmt s
@@ -333,7 +333,7 @@ genFunc (FDef (FuncDef n desc parms o rd s)) = do
 genFunc (FData (FuncData n desc ddef)) = genDataFunc n desc ddef
 genFunc (FCD cd) = genCalcFunc cd
 
-convStmt :: (RenderSym repr) => FuncStmt -> Reader DrasilState (GS (repr (Statement repr)))
+convStmt :: (ProgramSym repr) => FuncStmt -> Reader DrasilState (GS (repr (Statement repr)))
 convStmt (FAsg v e) = do
   e' <- convExpr e
   v' <- mkVar v
@@ -379,7 +379,7 @@ convStmt (FAppend a b) = do
   b' <- convExpr b
   return $ valState $ listAppend a' b'
 
-genDataFunc :: (RenderSym repr) => Name -> String -> DataDesc -> 
+genDataFunc :: (ProgramSym repr) => Name -> String -> DataDesc -> 
   Reader DrasilState (MS (repr (Method repr)))
 genDataFunc nameTitle desc ddef = do
   let parms = getInputs ddef
@@ -387,7 +387,7 @@ genDataFunc nameTitle desc ddef = do
   publicFunc nameTitle void desc (codevar inFileName : parms) Nothing bod
 
 -- this is really ugly!!
-readData :: (RenderSym repr) => DataDesc -> Reader DrasilState
+readData :: (ProgramSym repr) => DataDesc -> Reader DrasilState
   [GS (repr (Block repr))]
 readData ddef = do
   inD <- mapM inData ddef
@@ -399,7 +399,7 @@ readData ddef = do
     openFileR var_infile v_filename :
     concat inD ++ [
     closeFile v_infile ]]
-  where inData :: (RenderSym repr) => Data -> Reader DrasilState [GS (repr (Statement repr))]
+  where inData :: (ProgramSym repr) => Data -> Reader DrasilState [GS (repr (Statement repr))]
         inData (Singleton v) = do
             vv <- mkVar v
             l <- maybeLog vv
@@ -425,7 +425,7 @@ readData ddef = do
                   ] ++ lnV)]
           return $ readLines ls ++ logs
         ---------------
-        lineData :: (RenderSym repr) => Maybe String -> LinePattern -> 
+        lineData :: (ProgramSym repr) => Maybe String -> LinePattern -> 
           Reader DrasilState [GS (repr (Statement repr))]
         lineData s p@(Straight _) = do
           vs <- getEntryVars s p
@@ -435,22 +435,22 @@ readData ddef = do
           return $ clearTemps s ds ++ stringListLists vs v_linetokens 
             : appendTemps s ds
         ---------------
-        clearTemps :: (RenderSym repr) => Maybe String -> [DataItem] -> 
+        clearTemps :: (ProgramSym repr) => Maybe String -> [DataItem] -> 
           [GS (repr (Statement repr))]
         clearTemps Nothing _ = []
         clearTemps (Just sfx) es = map (clearTemp sfx) es
         ---------------
-        clearTemp :: (RenderSym repr) => String -> DataItem -> 
+        clearTemp :: (ProgramSym repr) => String -> DataItem -> 
           GS (repr (Statement repr))
         clearTemp sfx v = listDecDef (var (codeName v ++ sfx) 
           (listInnerType $ convType $ codeType v)) []
         ---------------
-        appendTemps :: (RenderSym repr) => Maybe String -> [DataItem] -> 
+        appendTemps :: (ProgramSym repr) => Maybe String -> [DataItem] -> 
           [GS (repr (Statement repr))]
         appendTemps Nothing _ = []
         appendTemps (Just sfx) es = map (appendTemp sfx) es
         ---------------
-        appendTemp :: (RenderSym repr) => String -> DataItem -> 
+        appendTemp :: (ProgramSym repr) => String -> DataItem -> 
           GS (repr (Statement repr))
         appendTemp sfx v = valState $ listAppend 
           (valueOf $ var (codeName v) (convType $ codeType v)) 
@@ -458,9 +458,9 @@ readData ddef = do
         ---------------
         l_line, l_lines, l_linetokens, l_infile, l_i :: Label
         var_line, var_lines, var_linetokens, var_infile, var_i :: 
-          (RenderSym repr) => GS (repr (Variable repr))
+          (ProgramSym repr) => GS (repr (Variable repr))
         v_line, v_lines, v_linetokens, v_infile, v_i ::
-          (RenderSym repr) => GS (repr (Value repr))
+          (ProgramSym repr) => GS (repr (Value repr))
         l_line = "line"
         var_line = var l_line string
         v_line = valueOf var_line
@@ -477,12 +477,12 @@ readData ddef = do
         var_i = var l_i int
         v_i = valueOf var_i
 
-getEntryVars :: (RenderSym repr) => Maybe String -> LinePattern -> 
+getEntryVars :: (ProgramSym repr) => Maybe String -> LinePattern -> 
   Reader DrasilState [GS (repr (Variable repr))]
 getEntryVars s lp = mapM (maybe mkVar (\st v -> variable (codeName v ++ st) 
   (listInnerType $ convType $ codeType v)) s) (getPatternInputs lp)
 
-getEntryVarLogs :: (RenderSym repr) => LinePattern -> 
+getEntryVarLogs :: (ProgramSym repr) => LinePattern -> 
   Reader DrasilState [GS (repr (Statement repr))]
 getEntryVarLogs lp = do
   vs <- getEntryVars Nothing lp

--- a/code/drasil-code/Language/Drasil/Code/Imperative/Logging.hs
+++ b/code/drasil-code/Language/Drasil/Code/Imperative/Logging.hs
@@ -5,7 +5,7 @@ module Language.Drasil.Code.Imperative.Logging (
 import Language.Drasil.Code.Imperative.State (DrasilState(..))
 import Language.Drasil.CodeSpec hiding (codeSpec, Mod(..))
 
-import GOOL.Drasil (Label, RenderSym(..), BodySym(..), BlockSym(..), 
+import GOOL.Drasil (Label, RenderSym, BodySym(..), BlockSym(..), 
   TypeSym(..), VariableSym(..), ValueSym(..), StatementSym(..), GS)
 
 import Data.Maybe (maybeToList)

--- a/code/drasil-code/Language/Drasil/Code/Imperative/Logging.hs
+++ b/code/drasil-code/Language/Drasil/Code/Imperative/Logging.hs
@@ -5,27 +5,27 @@ module Language.Drasil.Code.Imperative.Logging (
 import Language.Drasil.Code.Imperative.State (DrasilState(..))
 import Language.Drasil.CodeSpec hiding (codeSpec, Mod(..))
 
-import GOOL.Drasil (Label, RenderSym, BodySym(..), BlockSym(..), 
+import GOOL.Drasil (Label, ProgramSym, BodySym(..), BlockSym(..), 
   TypeSym(..), VariableSym(..), ValueSym(..), StatementSym(..), GS)
 
 import Data.Maybe (maybeToList)
 import Control.Applicative ((<$>))
 import Control.Monad.Reader (Reader, ask)
 
-maybeLog :: (RenderSym repr) => GS (repr (Variable repr)) ->
+maybeLog :: (ProgramSym repr) => GS (repr (Variable repr)) ->
   Reader DrasilState [GS (repr (Statement repr))]
 maybeLog v = do
   g <- ask
   l <- chooseLogging (logKind g) v
   return $ maybeToList l
 
-chooseLogging :: (RenderSym repr) => Logging -> (GS (repr (Variable repr)) -> 
+chooseLogging :: (ProgramSym repr) => Logging -> (GS (repr (Variable repr)) -> 
   Reader DrasilState (Maybe (GS (repr (Statement repr)))))
 chooseLogging LogVar v = Just <$> loggedVar v
 chooseLogging LogAll v = Just <$> loggedVar v
 chooseLogging _      _ = return Nothing
 
-loggedVar :: (RenderSym repr) => GS (repr (Variable repr)) -> 
+loggedVar :: (ProgramSym repr) => GS (repr (Variable repr)) -> 
   Reader DrasilState (GS (repr (Statement repr)))
 loggedVar v = do
     g <- ask
@@ -37,7 +37,7 @@ loggedVar v = do
       printFileStrLn valLogFile (" in module " ++ currentModule g),
       closeFile valLogFile ]
 
-logBody :: (RenderSym repr) => Label -> [GS (repr (Variable repr))] -> 
+logBody :: (ProgramSym repr) => Label -> [GS (repr (Variable repr))] -> 
   [GS (repr (Block repr))] -> Reader DrasilState (GS (repr (Body repr)))
 logBody n vars b = do
   g <- ask
@@ -46,7 +46,7 @@ logBody n vars b = do
       loggedBody _       = b
   return $ body $ loggedBody $ logKind g
 
-loggedMethod :: (RenderSym repr) => Label -> Label -> 
+loggedMethod :: (ProgramSym repr) => Label -> Label -> 
   [GS (repr (Variable repr))] -> [GS (repr (Block repr))] -> 
   [GS (repr (Block repr))]
 loggedMethod lName n vars b = block [
@@ -67,8 +67,8 @@ loggedMethod lName n vars b = block [
       printFile valLogFile (valueOf v), 
       printFileStrLn valLogFile ", "] ++ printInputs vs
 
-varLogFile :: (RenderSym repr) => GS (repr (Variable repr))
+varLogFile :: (ProgramSym repr) => GS (repr (Variable repr))
 varLogFile = var "outfile" outfile
 
-valLogFile :: (RenderSym repr) => GS (repr (Value repr))
+valLogFile :: (ProgramSym repr) => GS (repr (Value repr))
 valLogFile = valueOf varLogFile

--- a/code/drasil-code/Language/Drasil/Code/Imperative/Modules.hs
+++ b/code/drasil-code/Language/Drasil/Code/Imperative/Modules.hs
@@ -32,7 +32,7 @@ import Language.Drasil.CodeSpec (AuxFile(..), CodeSpec(..), CodeSystInfo(..),
   ConstraintBehaviour(..), InputModule(..), Logging(..))
 import Language.Drasil.Printers (Linearity(Linear), exprDoc)
 
-import GOOL.Drasil (RenderSym(..), BodySym(..), BlockSym(..), 
+import GOOL.Drasil (RenderSym, FileSym(..), BodySym(..), BlockSym(..), 
   PermanenceSym(..), TypeSym(..), VariableSym(..), ValueSym(..), 
   BooleanExpression(..), StatementSym(..), ControlStatementSym(..), 
   ScopeSym(..), MethodSym(..), StateVarSym(..), ClassSym(..), ScopeTag(..), 

--- a/code/drasil-gool/GOOL/Drasil.hs
+++ b/code/drasil-gool/GOOL/Drasil.hs
@@ -1,5 +1,5 @@
 -- | re-export smart constructors for external code writing
-module GOOL.Drasil (Label, ProgramSym(..), RenderSym, FileSym(..), 
+module GOOL.Drasil (Label, ProgramSym(..), FileSym(..), 
   PermanenceSym(..), BodySym(..), BlockSym(..), ControlBlockSym(runStrategy), 
   listSlice, TypeSym(..), StatementSym(..), ControlStatementSym(..), 
   VariableSym(..), ValueSym(..), NumericExpression(..), BooleanExpression(..), 
@@ -11,10 +11,10 @@ module GOOL.Drasil (Label, ProgramSym(..), RenderSym, FileSym(..),
   GOOLState(..), GS, FS, MS, lensMStoGS, headers, sources, mainMod, 
   initialState,
   convType, onStateValue, onCodeList,
-  unPC, unJC, unCSC, unCPPC
+  unCI, unPC, unJC, unCSC, unCPPC
 ) where
 
-import GOOL.Drasil.Symantics (Label, ProgramSym(..), RenderSym, FileSym(..),
+import GOOL.Drasil.Symantics (Label, ProgramSym(..), FileSym(..),
   PermanenceSym(..), BodySym(..), BlockSym(..), ControlBlockSym(runStrategy), 
   listSlice, TypeSym(..), StatementSym(..), ControlStatementSym(..), 
   VariableSym(..), ValueSym(..), NumericExpression(..), BooleanExpression(..), 
@@ -31,6 +31,7 @@ import GOOL.Drasil.State (GOOLState(..), GS, FS, MS, lensMStoGS, headers,
 
 import GOOL.Drasil.Helpers (convType, onStateValue, onCodeList)
 
+import GOOL.Drasil.CodeInfo (unCI)
 import GOOL.Drasil.LanguageRenderer.JavaRenderer (unJC)
 import GOOL.Drasil.LanguageRenderer.PythonRenderer (unPC)
 import GOOL.Drasil.LanguageRenderer.CSharpRenderer (unCSC)

--- a/code/drasil-gool/GOOL/Drasil.hs
+++ b/code/drasil-gool/GOOL/Drasil.hs
@@ -1,8 +1,8 @@
 -- | re-export smart constructors for external code writing
-module GOOL.Drasil (Label, ProgramSym(..), RenderSym(..), PermanenceSym(..), 
-  BodySym(..), BlockSym(..), ControlBlockSym(runStrategy), listSlice, 
-  TypeSym(..), StatementSym(..), ControlStatementSym(..), VariableSym(..), 
-  ValueSym(..), NumericExpression(..), BooleanExpression(..), 
+module GOOL.Drasil (Label, ProgramSym(..), RenderSym, FileSym(..), 
+  PermanenceSym(..), BodySym(..), BlockSym(..), ControlBlockSym(runStrategy), 
+  listSlice, TypeSym(..), StatementSym(..), ControlStatementSym(..), 
+  VariableSym(..), ValueSym(..), NumericExpression(..), BooleanExpression(..), 
   ValueExpression(..), Selector(..), FunctionSym(..), SelectorFunction(..), 
   ScopeSym(..), ParameterSym(..), MethodSym(..), StateVarSym(..), ClassSym(..), 
   ModuleSym(..), BlockCommentSym(..), 
@@ -14,7 +14,7 @@ module GOOL.Drasil (Label, ProgramSym(..), RenderSym(..), PermanenceSym(..),
   unPC, unJC, unCSC, unCPPC
 ) where
 
-import GOOL.Drasil.Symantics (Label, ProgramSym(..), RenderSym(..), 
+import GOOL.Drasil.Symantics (Label, ProgramSym(..), RenderSym, FileSym(..),
   PermanenceSym(..), BodySym(..), BlockSym(..), ControlBlockSym(runStrategy), 
   listSlice, TypeSym(..), StatementSym(..), ControlStatementSym(..), 
   VariableSym(..), ValueSym(..), NumericExpression(..), BooleanExpression(..), 

--- a/code/drasil-gool/GOOL/Drasil/CodeInfo.hs
+++ b/code/drasil-gool/GOOL/Drasil/CodeInfo.hs
@@ -1,0 +1,394 @@
+module GOOL.Drasil.CodeInfo (CodeInfo(..)) where
+
+import GOOL.Drasil.Symantics (Label, ProgramSym(..), RenderSym, 
+  PermanenceSym(..), BodySym(..), BlockSym(..), ControlBlockSym(..), 
+  TypeSym(..), VariableSym(..), ValueSym(..), NumericExpression(..), 
+  BooleanExpression(..), ValueExpression(..), Selector(..), 
+  InternalSelector(..), objMethodCall, FunctionSym(..), SelectorFunction(..),
+  StatementSym(..), ControlStatementSym(..), ScopeSym(..), MethodTypeSym(..),
+  ParameterSym(..), MethodSym(..), StateVarSym(..), ClassSym(..), ModuleSym(..),
+  BlockCommentSym(..))
+
+newtype CodeInfo a = CI {unCI :: a} deriving Eq
+
+instance Functor CodeInfo where
+  fmap f (CI x) = CI (f x)
+
+instance Applicative CodeInfo where
+  pure = CI
+  (CI f) <*> (CI x) = CI (f x)
+
+instance Monad CodeInfo where
+  return = CI
+  CI x >>= f = f x
+
+instance ProgramSym CodeInfo where
+  type Program CodeInfo = GOOLState
+  prog _ _ = get
+
+instance RenderSym CodeInfo
+
+instance FileSym CodeInfo where
+  type RenderFile CodeInfo = FileData
+  fileDoc = G.fileDoc Header cppHdrExt top bottom
+  
+  docMod = G.docMod
+
+  commentedMod cmnt mod = on3StateValues (\m cmt mn -> if mn then m else 
+    on2CodeValues commentedModD m cmt) mod cmnt getCurrMain
+
+instance PermanenceSym CodeInfo where
+  type Permanence CodeInfo = BindData
+  static_ = toCode $ bd Static staticDocD
+  dynamic_ = toCode $ bd Dynamic dynamicDocD
+
+instance BodySym CodeInfo where
+  type Body CodeInfo = Doc
+  body _ = toState $ toCode empty
+  bodyStatements _ = toState $ toCode empty
+  oneLiner _ = toState $ toCode empty
+
+  addComments _ _ = toState $ toCode empty
+
+  bodyDoc = unCI
+
+instance BlockSym CodeInfo where
+  type Block CodeInfo = Doc
+  block _ = toState $ toCode empty
+
+instance TypeSym CodeInfo where
+  type Type CodeInfo = TypeData
+  bool = cppBoolType
+  int = G.int
+  float = G.double
+  char = G.char
+  string = G.string
+  infile = cppInfileType
+  outfile = cppOutfileType
+  listType = G.listType
+  listInnerType = G.listInnerType
+  obj = G.obj
+  enumType = G.enumType
+  iterator = cppIterType . listType dynamic_
+  void = G.void
+
+  getType = cType . unCI
+  getTypeString = typeString . unCI
+  getTypeDoc = typeDoc . unCI
+
+instance ControlBlockSym CodeInfo where
+  runStrategy _ _ _ _ = toState $ toCode empty
+
+  listSlice' _ _ _ _ _ = toState $ toCode empty
+
+instance VariableSym CodeInfo where
+  type Variable CodeInfo = VarData
+  var = G.var
+  staticVar = G.staticVar
+  const _ _ = mkStateVar "" void empty
+  extVar _ _ _ = mkStateVar "" void empty
+  self _ = mkStateVar "" void empty
+  enumVar _ _ = mkStateVar "" void empty
+  classVar _ _ = mkStateVar "" void empty
+  extClassVar _ _ = mkStateVar "" void empty
+  objVar _ _ = mkStateVar "" void empty
+  objVarSelf _ _ = mkStateVar "" void empty
+  listVar _ _ _ = mkStateVar "" void empty
+  listOf _ _ = mkStateVar "" void empty
+  iterVar _ _ = mkStateVar "" void empty
+
+  ($->) _ _ = mkStateVar "" void empty
+  
+  variableBind = varBind . unCI
+  variableName = varName . unCI
+  variableType = onCodeValue varType
+  variableDoc = varDoc . unCI
+
+instance ValueSym CodeInfo where
+  type Value CodeInfo = ValData
+  litTrue = G.litTrue
+  litFalse = G.litFalse
+  litChar = G.litChar
+  litFloat = G.litFloat
+  litInt = G.litInt
+  litString = G.litString
+
+  pi = mkStateVal float (text "M_PI")
+
+  ($:) = enumElement
+
+  valueOf = G.valueOf
+  arg n = G.arg (litInt $ n+1) argsList
+  enumElement en e = mkStateVal (enumType en) (text e)
+  
+  argsList = G.argsList "argv"
+
+  valueType = onCodeValue valType
+  valueDoc = valDoc . unCI
+
+instance NumericExpression CodeInfo where
+  (#~) _ = mkStateVal void empty
+  (#/^) _ = mkStateVal void empty
+  (#|) _ = mkStateVal void empty
+  (#+) _ _ = mkStateVal void empty
+  (#-) _ _ = mkStateVal void empty
+  (#*) _ _ = mkStateVal void empty
+  (#/) _ _ = mkStateVal void empty
+  (#%) _ _ = mkStateVal void empty
+  (#^) _ _ = mkStateVal void empty
+
+  log _ = mkStateVal void empty
+  ln _ = mkStateVal void empty
+  exp _ = mkStateVal void empty
+  sin _ = mkStateVal void empty
+  cos _ = mkStateVal void empty
+  tan _ = mkStateVal void empty
+  csc _ = mkStateVal void empty
+  sec _ = mkStateVal void empty
+  cot _ = mkStateVal void empty
+  arcsin _ = mkStateVal void empty
+  arccos _ = mkStateVal void empty
+  arctan _ = mkStateVal void empty
+  floor _ = mkStateVal void empty
+  ceil _ = mkStateVal void empty
+
+instance BooleanExpression CodeInfo where
+  (?!) _ = mkStateVal void empty
+  (?&&) _ _ = mkStateVal void empty
+  (?||) _ _ = mkStateVal void empty
+
+  (?<) _ _ = mkStateVal void empty
+  (?<=) _ _ = mkStateVal void empty
+  (?>) _ _ = mkStateVal void empty
+  (?>=) _ _ = mkStateVal void empty
+  (?==) _ _ = mkStateVal void empty
+  (?!=) _ _ = mkStateVal void empty
+    
+instance ValueExpression CodeInfo where
+  inlineIf _ _ _ = mkStateVal void empty
+  funcApp _ _ _ = mkStateVal void empty
+  selfFuncApp _ _ _ _ = mkStateVal void empty
+  extFuncApp _ _ _ _ = mkStateVal void empty
+  newObj _ _ = mkStateVal void empty
+  extNewObj _ _ _ = mkStateVal void empty
+
+  exists _ = mkStateVal void empty
+  notNull _ = mkStateVal void empty
+
+instance Selector CodeInfo where
+  objAccess _ _ = mkStateVal void empty
+  ($.) _ _ = mkStateVal void empty
+
+  selfAccess _ _ = mkStateVal void empty
+
+  listIndexExists _ _ = mkStateVal void empty
+  argExists _ = mkStateVal void empty
+  
+  indexOf _ _ = mkStateVal void empty
+  
+instance InternalSelector CodeInfo where
+  objMethodCall' _ _ _ _ = mkStateVal void empty
+  objMethodCallNoParams' _ _ _ = mkStateVal void empty
+
+instance FunctionSym CodeInfo where
+  type Function CodeInfo = FuncData
+  func _ _ _ = funcFromData empty void
+  
+  get _ _ = mkStateVal void empty
+  set _ _ _ = mkStateVal void empty
+
+  listSize _ = mkStateVal void empty
+  listAdd _ _ _ = mkStateVal void empty
+  listAppend _ _ = mkStateVal void empty
+
+  iterBegin _ = mkStateVal void empty
+  iterEnd _ = mkStateVal void empty
+
+instance SelectorFunction CodeInfo where
+  listAccess _ _ = mkStateVal void empty
+  listSet _ _ _ = mkStateVal void empty
+  at _ _ = mkStateVal void empty
+
+instance StatementSym CodeInfo where
+  type Statement CodeInfo = (Doc, Terminator)
+  assign _ _ = emptyState
+  assignToListIndex _ _ _ = emptyState
+  multiAssign _ _ = emptyState
+  (&=) _ _ = emptyState
+  (&-=) _ _ = emptyState
+  (&+=) _ _ = emptyState
+  (&++) _ = emptyState
+  (&~-) _ = emptyState
+
+  varDec = G.varDec static_ dynamic_
+  varDecDef = G.varDecDef
+  listDec _ _ = emptyState
+  listDecDef _ _ = emptyState
+  objDecDef _ _ = emptyState
+  objDecNew _ _ = emptyState
+  extObjDecNew _ _ _ = emptyState
+  objDecNewNoParams _ = emptyState
+  extObjDecNewNoParams _ _ = emptyState
+  constDecDef = G.constDecDef
+
+  print _ = emptyState
+  printLn _ = emptyState
+  printStr _ = emptyState
+  printStrLn _ = emptyState
+
+  printFile _ _ = emptyState
+  printFileLn _ _ = emptyState
+  printFileStr _ _ = emptyState
+  printFileStrLn _ _ = emptyState
+
+  getInput _ = emptyState
+  discardInput = emptyState
+  getFileInput _ _ = emptyState
+  discardFileInput _ = emptyState
+
+  openFileR _ _ = emptyState
+  openFileW _ _ = emptyState
+  openFileA _ _ = emptyState
+  closeFile _ = emptyState
+
+  getFileInputLine _ _ = emptyState
+  discardFileLine _ = emptyState
+  stringSplit _ _ _ = emptyState
+
+  stringListVals _ _ = emptyState
+  stringListLists _ _ = emptyState
+
+  break = emptyState
+  continue = emptyState
+
+  returnState _ = emptyState
+  multiReturn _ = emptyState
+
+  valState _ = emptyState
+
+  comment _ = emptyState
+
+  free _ = emptyState
+
+  throw _ = emptyState
+
+  initState _ _ = emptyState
+  changeState _ _ = emptyState
+
+  initObserverList _ _ = emptyState
+  addObserver _ = emptyState
+
+  inOutCall _ _ _ _ = emptyState
+  selfInOutCall _ _ _ _ _ = emptyState
+  extInOutCall _ _ _ _ _ = emptyState
+
+  multi _ = emptyState
+
+instance ControlStatementSym CodeInfo where
+  ifCond _ _ = emptyState
+  ifNoElse _ = emptyState
+  switch _ _ _ = emptyState
+  switchAsIf _ _ _ = emptyState
+
+  ifExists _ _ _ = emptyState
+
+  for _ _ _ _ = emptyState
+  forRange _ _ _ _ _ = emptyState
+  forEach _ _ _ = emptyState
+  while _ _ = emptyState
+
+  tryCatch _ _ = emptyState
+
+  checkState _ _ _ = emptyState
+
+  notifyObservers _ _ = emptyState
+
+  getFileInputAll _ _ = emptyState
+
+instance ScopeSym CodeInfo where
+  type Scope CodeInfo = (Doc, ScopeTag)
+  private = toCode (privateDocD, Priv)
+  public = toCode (publicDocD, Pub)
+
+instance MethodTypeSym CodeInfo where
+  type MethodType CodeInfo = TypeData
+  mType t = t
+  construct = G.construct
+
+instance ParameterSym CodeInfo where
+  type Parameter CodeInfo = ParamData
+  param = onStateValue (\v -> paramFromData v (paramDocD v)) . zoom lensMStoGS
+  pointerParam = onStateValue (\v -> paramFromData v (cppPointerParamDoc v)) .
+    zoom lensMStoGS
+
+instance MethodSym CodeInfo where
+  type Method CodeInfo = MethodData
+  method = G.method
+  getMethod c v = zoom lensMStoGS v >>= (\v' -> method (getterName $ 
+    variableName v') c public dynamic_ (toState $ variableType v') [] 
+    (toState $ toCode empty))
+  setMethod c v = zoom lensMStoGS v >>= (\v' -> method (setterName $ 
+    variableName v') c public dynamic_ void [param v] (toState $ toCode empty))
+  privMethod = G.privMethod
+  pubMethod = G.pubMethod
+  constructor n = G.constructor n n
+  destructor n vars = on1StateValue1List (\m vs -> toCode $ mthd Pub 
+    (emptyIfEmpty (vcat (map (statementDoc . onCodeValue destructSts) vs)) 
+    (methodDoc m))) (pubMethod ('~':n) n void [] (toState (toCode empty)) :: MS (CodeInfo (Method CodeInfo))) (map (zoom lensMStoGS) vars)
+
+  docMain = mainFunction
+
+  function = G.function
+  mainFunction _ = getPutReturn (setScope Pub) $ toCode $ mthd Pub empty
+
+  docFunc = G.docFunc
+
+  inOutMethod n c = cpphInOut (method n c)
+
+  docInOutMethod n c = G.docInOutFunc (inOutMethod n c)
+
+  inOutFunc n = cpphInOut (function n)
+
+  docInOutFunc n = G.docInOutFunc (inOutFunc n)
+
+instance StateVarSym CodeInfo where
+  type StateVar CodeInfo = StateVarData
+  stateVar s p v = on2StateValues (\dec -> on3CodeValues svd (onCodeValue snd s)
+    (toCode $ stateVarDocD empty (permDoc p) (statementDoc dec)))
+    (state $ varDec v) emptyState
+  stateVarDef _ s p vr vl = on2StateValues (onCodeValue . svd (snd $ unCI s))
+    (cpphStateVarDef empty p vr vl) emptyState
+  constVar _ s vr _ = on2StateValues (\v -> on3CodeValues svd (onCodeValue snd 
+    s) (on3CodeValues (constVarDocD empty) (bindDoc <$> static_) v 
+    endStatement)) vr emptyState
+  privMVar = G.privMVar
+  pubMVar = G.pubMVar
+  pubGVar = G.pubGVar
+
+instance ClassSym CodeInfo where
+  type Class CodeInfo = Doc
+  buildClass n p _ vs mths = on2StateLists (\vars funcs -> cpphClass n p vars 
+    funcs public private blockStart blockEnd endStatement) 
+    (map (zoom lensFStoGS) vs) fs
+    where fs = map (zoom lensFStoMS) $ mths ++ [destructor n vs]
+  enum n es _ = cpphEnum n (enumElementsDocD es enumsEqualInts) blockStart 
+    blockEnd endStatement
+  privClass = G.privClass
+  pubClass = G.pubClass
+
+  docClass = G.docClass
+
+  commentedClass = G.commentedClass
+
+instance ModuleSym CodeInfo where
+  type Module CodeInfo = ModData
+  buildModule n ls = G.buildModule n (map include ls)
+
+instance BlockCommentSym CodeInfo where
+  type BlockComment CodeInfo = Doc
+  blockComment lns = on2CodeValues (blockCmtDoc lns) blockCommentStart 
+    blockCommentEnd
+  docComment = onStateValue (\lns -> on2CodeValues (docCmtDoc lns) 
+    docCommentStart docCommentEnd)
+
+  blockCommentDoc = unCI

--- a/code/drasil-gool/GOOL/Drasil/Helpers.hs
+++ b/code/drasil-gool/GOOL/Drasil/Helpers.hs
@@ -10,7 +10,7 @@ import Utils.Drasil (blank)
 
 import qualified GOOL.Drasil.CodeType as C (CodeType(..))
 import qualified GOOL.Drasil.Symantics as S ( 
-  RenderSym, TypeSym(..), PermanenceSym(dynamic_))
+  TypeSym(..), PermanenceSym(dynamic_))
 import GOOL.Drasil.State (GS)
 
 import Prelude hiding ((<>))
@@ -110,7 +110,7 @@ getNestDegree :: Integer -> C.CodeType -> Integer
 getNestDegree n (C.List t) = getNestDegree (n+1) t
 getNestDegree n _ = n
 
-convType :: (S.RenderSym repr) => C.CodeType -> GS (repr (S.Type repr))
+convType :: (S.TypeSym repr) => C.CodeType -> GS (repr (S.Type repr))
 convType C.Boolean = S.bool
 convType C.Integer = S.int
 convType C.Float = S.float

--- a/code/drasil-gool/GOOL/Drasil/Helpers.hs
+++ b/code/drasil-gool/GOOL/Drasil/Helpers.hs
@@ -10,7 +10,7 @@ import Utils.Drasil (blank)
 
 import qualified GOOL.Drasil.CodeType as C (CodeType(..))
 import qualified GOOL.Drasil.Symantics as S ( 
-  RenderSym(..), TypeSym(..), PermanenceSym(dynamic_))
+  RenderSym, TypeSym(..), PermanenceSym(dynamic_))
 import GOOL.Drasil.State (GS)
 
 import Prelude hiding ((<>))

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer.hs
@@ -35,7 +35,7 @@ module GOOL.Drasil.LanguageRenderer (
 import Utils.Drasil (blank, capitalize, indent, indentList, stringList)
 
 import GOOL.Drasil.CodeType (CodeType(..), isObject)
-import GOOL.Drasil.Symantics (Label, Library, RenderSym(..), BodySym(..), 
+import GOOL.Drasil.Symantics (Label, Library, RenderSym, BodySym(..), 
   PermanenceSym(..), InternalPerm(..), TypeSym(Type, getType, getTypeDoc), 
   UnaryOpSym(..), BinaryOpSym(..), InternalOp(..), VariableSym(..), 
   InternalVariable(..), ValueSym(..), NumericExpression(..), 
@@ -655,7 +655,7 @@ moduleDox desc as date m = (doxFile ++ m) :
 commentedModD :: FileData -> Doc -> FileData
 commentedModD m cmt = updateFileMod (updateModDoc (commentedItem cmt) (fileMod m)) m
 
-docFuncRepr :: (MethodSym repr) => String -> [String] -> [String] -> 
+docFuncRepr :: (RenderSym repr) => String -> [String] -> [String] -> 
   MS (repr (Method repr)) -> MS (repr (Method repr))
 docFuncRepr desc pComms rComms = commentedFunc (docComment $ onStateValue 
   (\ps -> functionDox desc (zip ps pComms) rComms) getParameters)

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer/CSharpRenderer.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer/CSharpRenderer.hs
@@ -10,7 +10,7 @@ module GOOL.Drasil.LanguageRenderer.CSharpRenderer (
 import Utils.Drasil (indent)
 
 import GOOL.Drasil.CodeType (CodeType(..))
-import GOOL.Drasil.Symantics (Label, ProgramSym(..), RenderSym(..), 
+import GOOL.Drasil.Symantics (Label, ProgramSym(..), RenderSym, FileSym(..),
   InternalFile(..), KeywordSym(..), PermanenceSym(..), InternalPerm(..), 
   BodySym(..), BlockSym(..), InternalBlock(..), ControlBlockSym(..), 
   TypeSym(..), InternalType(..), UnaryOpSym(..), BinaryOpSym(..), 
@@ -95,7 +95,9 @@ instance ProgramSym CSharpCode where
   type Program CSharpCode = ProgData
   prog n = onStateList (onCodeList (progD n)) . map (zoom lensGStoFS)
 
-instance RenderSym CSharpCode where
+instance RenderSym CSharpCode
+
+instance FileSym CSharpCode where
   type RenderFile CSharpCode = FileData
   fileDoc = G.fileDoc Combined csExt top bottom
 

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer/CppRenderer.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer/CppRenderer.hs
@@ -11,7 +11,7 @@ module GOOL.Drasil.LanguageRenderer.CppRenderer (
 import Utils.Drasil (blank, indent, indentList)
 
 import GOOL.Drasil.CodeType (CodeType(..))
-import GOOL.Drasil.Symantics (Label, ProgramSym(..), RenderSym(..), 
+import GOOL.Drasil.Symantics (Label, ProgramSym(..), RenderSym, FileSym(..),
   InternalFile(..), KeywordSym(..), PermanenceSym(..), InternalPerm(..), 
   BodySym(..), BlockSym(..), InternalBlock(..), ControlBlockSym(..), 
   TypeSym(..), InternalType(..), UnaryOpSym(..), BinaryOpSym(..), 
@@ -104,7 +104,9 @@ instance (Pair p) => ProgramSym (p CppSrcCode CppHdrCode) where
     p1 <- prog n $ map toState sm ++ map toState fm
     toState $ pair p1 (toCode emptyProg)
 
-instance (Pair p) => RenderSym (p CppSrcCode CppHdrCode) where
+instance (Pair p) => RenderSym (p CppSrcCode CppHdrCode)
+
+instance (Pair p) => FileSym (p CppSrcCode CppHdrCode) where
   type RenderFile (p CppSrcCode CppHdrCode) = FileData
   fileDoc = pair1 fileDoc fileDoc
 
@@ -894,8 +896,10 @@ instance Monad CppSrcCode where
 instance ProgramSym CppSrcCode where
   type Program CppSrcCode = ProgData
   prog n = onStateList (onCodeList (progD n)) . map (zoom lensGStoFS)
+
+instance RenderSym CppSrcCode
   
-instance RenderSym CppSrcCode where
+instance FileSym CppSrcCode where
   type RenderFile CppSrcCode = FileData
   fileDoc = G.fileDoc Source cppSrcExt top bottom
 
@@ -1478,7 +1482,9 @@ instance Monad CppHdrCode where
   return = CPPHC
   CPPHC x >>= f = f x
 
-instance RenderSym CppHdrCode where
+instance RenderSym CppHdrCode
+
+instance FileSym CppHdrCode where
   type RenderFile CppHdrCode = FileData
   fileDoc = G.fileDoc Header cppHdrExt top bottom
   

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer/JavaRenderer.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer/JavaRenderer.hs
@@ -10,7 +10,7 @@ module GOOL.Drasil.LanguageRenderer.JavaRenderer (
 import Utils.Drasil (indent)
 
 import GOOL.Drasil.CodeType (CodeType(..), isObject)
-import GOOL.Drasil.Symantics (Label, ProgramSym(..), RenderSym(..), 
+import GOOL.Drasil.Symantics (Label, ProgramSym(..), RenderSym, FileSym(..),
   InternalFile(..), KeywordSym(..), PermanenceSym(..), InternalPerm(..), 
   BodySym(..), BlockSym(..), InternalBlock(..), ControlBlockSym(..), 
   TypeSym(..), InternalType(..), UnaryOpSym(..), BinaryOpSym(..), 
@@ -95,7 +95,9 @@ instance ProgramSym JavaCode where
   prog n fs = getPutReturnList (map (zoom lensGStoFS) fs) (addProgNameToPaths n)
     (on1CodeValue1List (\end -> progD n . map (packageDocD n end)) endStatement)
 
-instance RenderSym JavaCode where
+instance RenderSym JavaCode
+
+instance FileSym JavaCode where
   type RenderFile JavaCode = FileData 
   fileDoc = G.fileDoc Combined jExt top bottom
 

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer/LanguagePolymorphic.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer/LanguagePolymorphic.hs
@@ -30,8 +30,8 @@ module GOOL.Drasil.LanguageRenderer.LanguagePolymorphic (fileFromData, oneLiner,
 import Utils.Drasil (indent)
 
 import GOOL.Drasil.CodeType (CodeType(..), isObject)
-import GOOL.Drasil.Symantics (Label, Library, KeywordSym(..),
-  RenderSym(RenderFile, commentedMod), BlockSym(Block), InternalBlock(..), 
+import GOOL.Drasil.Symantics (Label, Library, KeywordSym(..), RenderSym,
+  FileSym(RenderFile, commentedMod), BlockSym(Block), InternalBlock(..), 
   BodySym(Body, body, bodyStatements, bodyDoc), PermanenceSym(..), 
   InternalPerm(..), 
   TypeSym(Type, infile, outfile, iterator, getType, getTypeDoc, getTypeString), 

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer/PythonRenderer.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer/PythonRenderer.hs
@@ -9,7 +9,7 @@ module GOOL.Drasil.LanguageRenderer.PythonRenderer (
 import Utils.Drasil (blank, indent)
 
 import GOOL.Drasil.CodeType (CodeType(..), isObject)
-import GOOL.Drasil.Symantics (Label, ProgramSym(..), RenderSym(..), 
+import GOOL.Drasil.Symantics (Label, ProgramSym(..), RenderSym, FileSym(..),
   InternalFile(..), KeywordSym(..), PermanenceSym(..), InternalPerm(..), 
   BodySym(..), BlockSym(..), InternalBlock(..), ControlBlockSym(..), 
   TypeSym(..), InternalType(..), UnaryOpSym(..), BinaryOpSym(..), 
@@ -93,7 +93,9 @@ instance ProgramSym PythonCode where
   type Program PythonCode = ProgData 
   prog n = onStateList (onCodeList (progD n)) . map (zoom lensGStoFS)
 
-instance RenderSym PythonCode where
+instance RenderSym PythonCode
+
+instance FileSym PythonCode where
   type RenderFile PythonCode = FileData
   fileDoc = G.fileDoc Combined pyExt top bottom
 

--- a/code/drasil-gool/GOOL/Drasil/State.hs
+++ b/code/drasil-gool/GOOL/Drasil/State.hs
@@ -17,7 +17,7 @@ import Control.Lens (Lens', (^.), lens, makeLenses, over, set)
 import Control.Lens.Tuple (_1, _2)
 import Control.Monad.State (State, get, put, gets)
 import Data.Maybe (isNothing)
-import Data.Map (Map, fromList, empty, union, toList)
+import Data.Map (Map, fromList, empty, union)
 
 data GOOLState = GS {
   _headers :: [FilePath],
@@ -180,8 +180,8 @@ addProgNameToPaths n = over mainMod (fmap f) . over sources (map f) .
   where f = ((n++"/")++)
 
 setMainMod :: String -> GOOLState -> GOOLState
-setMainMod n s = error $ show (toList $ s ^. classMap) -- over mainMod (\m -> if isNothing m then Just n else error 
-  -- "Multiple modules with main methods encountered")
+setMainMod n = over mainMod (\m -> if isNothing m then Just n else error 
+  "Multiple modules with main methods encountered")
 
 addLangImport :: String -> GOOLState -> GOOLState
 addLangImport i = over langImports (\is -> if i `elem` is then i:is else is)

--- a/code/drasil-gool/GOOL/Drasil/Symantics.hs
+++ b/code/drasil-gool/GOOL/Drasil/Symantics.hs
@@ -36,16 +36,14 @@ class (FileSym repr, InternalBlock repr, InternalClass repr, InternalFile repr,
   InternalValue repr, InternalVariable repr, KeywordSym repr, UnaryOpSym repr, 
   BinaryOpSym repr) => RenderSym repr
 
-class (RenderSym repr) => ProgramSym repr where
+class (FileSym repr) => ProgramSym repr where
   type Program repr
   prog :: Label -> [FS (repr (RenderFile repr))] -> 
     GS (repr (Program repr))
 
-class (ModuleSym repr) => 
-  FileSym repr where 
+class (ModuleSym repr) => FileSym repr where 
   type RenderFile repr
-  fileDoc :: FS (repr (Module repr)) -> 
-    FS (repr (RenderFile repr))
+  fileDoc :: FS (repr (Module repr)) -> FS (repr (RenderFile repr))
 
   -- Module description, list of author names, date as a String, file to comment
   docMod :: String -> [String] -> String -> 

--- a/code/drasil-gool/Test/FileTests.hs
+++ b/code/drasil-gool/Test/FileTests.hs
@@ -1,6 +1,6 @@
 module Test.FileTests (fileTests) where
 
-import GOOL.Drasil (ProgramSym(..), RenderSym, FileSym(..),
+import GOOL.Drasil (ProgramSym(..), FileSym(..),
   PermanenceSym(..), BodySym(..), BlockSym(..), TypeSym(..), 
   StatementSym(..), ControlStatementSym(..), VariableSym(..), ValueSym(..), 
   MethodSym(..), ModuleSym(..), GS, MS)
@@ -9,10 +9,10 @@ import Prelude hiding (return,print,log,exp,sin,cos,tan)
 fileTests :: (ProgramSym repr) => GS (repr (Program repr))
 fileTests = prog "FileTests" [fileDoc (buildModule "FileTests" [] [fileTestMethod] [])]
 
-fileTestMethod :: (RenderSym repr) => MS (repr (Method repr))
+fileTestMethod :: (ProgramSym repr) => MS (repr (Method repr))
 fileTestMethod = mainFunction (body [writeStory, block [readStory], goodBye])
 
-writeStory :: (RenderSym repr) => GS (repr (Block repr))
+writeStory :: (ProgramSym repr) => GS (repr (Block repr))
 writeStory = block [
   varDec $ var "fileToWrite" outfile,
 
@@ -31,11 +31,11 @@ writeStory = block [
   discardFileLine (valueOf $ var "fileToRead" infile),
   listDec 0 (var "fileContents" (listType dynamic_ string))]
 
-readStory :: (RenderSym repr) => GS (repr (Statement repr))
+readStory :: (ProgramSym repr) => GS (repr (Statement repr))
 readStory = getFileInputAll (valueOf $ var "fileToRead" infile) 
   (var "fileContents" (listType dynamic_ string))
 
-goodBye :: (RenderSym repr) => GS (repr (Block repr))
+goodBye :: (ProgramSym repr) => GS (repr (Block repr))
 goodBye = block [
   printLn (valueOf $ var "fileContents" (listType dynamic_ string)), 
   closeFile (valueOf $ var "fileToRead" infile)]

--- a/code/drasil-gool/Test/FileTests.hs
+++ b/code/drasil-gool/Test/FileTests.hs
@@ -1,6 +1,6 @@
 module Test.FileTests (fileTests) where
 
-import GOOL.Drasil (ProgramSym(..), RenderSym(..), 
+import GOOL.Drasil (ProgramSym(..), RenderSym, FileSym(..),
   PermanenceSym(..), BodySym(..), BlockSym(..), TypeSym(..), 
   StatementSym(..), ControlStatementSym(..), VariableSym(..), ValueSym(..), 
   MethodSym(..), ModuleSym(..), GS, MS)

--- a/code/drasil-gool/Test/HelloWorld.hs
+++ b/code/drasil-gool/Test/HelloWorld.hs
@@ -2,7 +2,7 @@
 
 module Test.HelloWorld (helloWorld) where
 
-import GOOL.Drasil (ProgramSym(..), RenderSym, FileSym(..), PermanenceSym(..), 
+import GOOL.Drasil (ProgramSym(..), FileSym(..), PermanenceSym(..), 
   BodySym(..), BlockSym(..), listSlice, TypeSym(..), StatementSym(..), 
   ControlStatementSym(..), VariableSym(..), ValueSym(..), NumericExpression(..),
   BooleanExpression(..), ValueExpression(..), Selector(..), FunctionSym(..), 
@@ -18,14 +18,14 @@ helloWorld = prog "HelloWorld" [docMod description
 description :: String
 description = "Tests various GOOL functions. It should run without errors."
 
-helloWorldMain :: (RenderSym repr) => MS (repr (Method repr))
+helloWorldMain :: (ProgramSym repr) => MS (repr (Method repr))
 helloWorldMain = mainFunction (body [ helloInitVariables, 
     helloListSlice,
     block [ifCond [(valueOf (var "b" int) ?>= litInt 6, bodyStatements [varDecDef (var "dummy" string) (litString "dummy")]),
       (valueOf (var "b" int) ?== litInt 5, helloIfBody)] helloElseBody, helloIfExists,
     helloSwitch, helloForLoop, helloWhileLoop, helloForEachLoop, helloTryCatch]])
 
-helloInitVariables :: (RenderSym repr) => GS (repr (Block repr))
+helloInitVariables :: (ProgramSym repr) => GS (repr (Block repr))
 helloInitVariables = block [comment "Initializing variables",
   varDec $ var "a" int, 
   varDecDef (var "b" int) (litInt 5),
@@ -52,12 +52,12 @@ helloInitVariables = block [comment "Initializing variables",
   printLn (valueOf $ var "boringList" (listType dynamic_ bool)),
   listDec 2 $ var "mySlicedList" (listType static_ float)]
 
-helloListSlice :: (RenderSym repr) => GS (repr (Block repr))
+helloListSlice :: (ProgramSym repr) => GS (repr (Block repr))
 helloListSlice = listSlice (var "mySlicedList" (listType static_ float)) 
   (valueOf $ var "myOtherList" (listType static_ float)) (Just (litInt 1)) 
   (Just (litInt 3)) Nothing
 
-helloIfBody :: (RenderSym repr) => GS (repr (Body repr))
+helloIfBody :: (ProgramSym repr) => GS (repr (Body repr))
 helloIfBody = addComments "If body" (body [
   block [
     varDec $ var "c" int,
@@ -125,33 +125,33 @@ helloIfBody = addComments "If body" (body [
     printLn (inlineIf litTrue (litInt 5) (litInt 0)),
     printLn (cot (litFloat 1.0))]])
 
-helloElseBody :: (RenderSym repr) => GS (repr (Body repr))
+helloElseBody :: (ProgramSym repr) => GS (repr (Body repr))
 helloElseBody = bodyStatements [printLn (arg 5)]
 
-helloIfExists :: (RenderSym repr) => GS (repr (Statement repr))
+helloIfExists :: (ProgramSym repr) => GS (repr (Statement repr))
 helloIfExists = ifExists (valueOf $ var "boringList" (listType dynamic_ bool)) 
   (oneLiner (printStrLn "Ew, boring list!")) (oneLiner (printStrLn "Great, no bores!"))
 
-helloSwitch :: (RenderSym repr) => GS (repr (Statement repr))
+helloSwitch :: (ProgramSym repr) => GS (repr (Statement repr))
 helloSwitch = switch (valueOf $ var "a" int) [(litInt 5, oneLiner (var "b" int &= litInt 10)), 
   (litInt 0, oneLiner (var "b" int &= litInt 5))]
   (oneLiner (var "b" int &= litInt 0))
 
-helloForLoop :: (RenderSym repr) => GS (repr (Statement repr))
+helloForLoop :: (ProgramSym repr) => GS (repr (Statement repr))
 helloForLoop = forRange i (litInt 0) (litInt 9) (litInt 1) (oneLiner (printLn 
   (valueOf i)))
   where i = var "i" int
 
-helloWhileLoop :: (RenderSym repr) => GS (repr (Statement repr))
+helloWhileLoop :: (ProgramSym repr) => GS (repr (Statement repr))
 helloWhileLoop = while (valueOf (var "a" int) ?< litInt 13) (bodyStatements 
   [printStrLn "Hello", (&++) (var "a" int)]) 
 
-helloForEachLoop :: (RenderSym repr) => GS (repr (Statement repr))
+helloForEachLoop :: (ProgramSym repr) => GS (repr (Statement repr))
 helloForEachLoop = forEach i (valueOf $ listVar "myOtherList" static_ float) 
   (oneLiner (printLn (extFuncApp "Helper" "doubleAndAdd" float [valueOf i, 
   litFloat 1.0])))
   where i = iterVar "num" float
 
-helloTryCatch :: (RenderSym repr) => GS (repr (Statement repr))
+helloTryCatch :: (ProgramSym repr) => GS (repr (Statement repr))
 helloTryCatch = tryCatch (oneLiner (throw "Good-bye!"))
   (oneLiner (printStrLn "Caught intentional error"))

--- a/code/drasil-gool/Test/HelloWorld.hs
+++ b/code/drasil-gool/Test/HelloWorld.hs
@@ -2,12 +2,11 @@
 
 module Test.HelloWorld (helloWorld) where
 
-import GOOL.Drasil (
-  ProgramSym(..), RenderSym(..), PermanenceSym(..), BodySym(..), BlockSym(..), 
-  listSlice, TypeSym(..), StatementSym(..), ControlStatementSym(..),  
-  VariableSym(..), ValueSym(..), NumericExpression(..), BooleanExpression(..), 
-  ValueExpression(..), Selector(..), FunctionSym(..), SelectorFunction(..), 
-  MethodSym(..), ModuleSym(..), GS, MS)
+import GOOL.Drasil (ProgramSym(..), RenderSym, FileSym(..), PermanenceSym(..), 
+  BodySym(..), BlockSym(..), listSlice, TypeSym(..), StatementSym(..), 
+  ControlStatementSym(..), VariableSym(..), ValueSym(..), NumericExpression(..),
+  BooleanExpression(..), ValueExpression(..), Selector(..), FunctionSym(..), 
+  SelectorFunction(..), MethodSym(..), ModuleSym(..), GS, MS)
 import Prelude hiding (return,print,log,exp,sin,cos,tan,const)
 import Test.Helper (helper)
 

--- a/code/drasil-gool/Test/Helper.hs
+++ b/code/drasil-gool/Test/Helper.hs
@@ -1,7 +1,7 @@
 module Test.Helper (helper) where
 
 import GOOL.Drasil (
-  RenderSym(..), PermanenceSym(..), BodySym(..), TypeSym(..), 
+  RenderSym, FileSym(..), PermanenceSym(..), BodySym(..), TypeSym(..), 
   StatementSym(..), VariableSym(..), ValueSym(..), NumericExpression(..), 
   ScopeSym(..), ParameterSym(..), MethodSym(..), ModuleSym(..), FS, MS)
 import Prelude hiding (return,print,log,exp,sin,cos,tan)

--- a/code/drasil-gool/Test/Helper.hs
+++ b/code/drasil-gool/Test/Helper.hs
@@ -1,15 +1,15 @@
 module Test.Helper (helper) where
 
 import GOOL.Drasil (
-  RenderSym, FileSym(..), PermanenceSym(..), BodySym(..), TypeSym(..), 
+  ProgramSym, FileSym(..), PermanenceSym(..), BodySym(..), TypeSym(..), 
   StatementSym(..), VariableSym(..), ValueSym(..), NumericExpression(..), 
   ScopeSym(..), ParameterSym(..), MethodSym(..), ModuleSym(..), FS, MS)
 import Prelude hiding (return,print,log,exp,sin,cos,tan)
 
-helper :: (RenderSym repr) => FS (repr (RenderFile repr))
+helper :: (ProgramSym repr) => FS (repr (RenderFile repr))
 helper = fileDoc (buildModule "Helper" [] [doubleAndAdd] [])
 
-doubleAndAdd :: (RenderSym repr) => MS (repr (Method repr))
+doubleAndAdd :: (ProgramSym repr) => MS (repr (Method repr))
 doubleAndAdd = docFunc "This function adds two numbers" 
   ["First number to add", "Second number to add"] (Just "Sum") $ 
   function "doubleAndAdd"  public static_ float

--- a/code/drasil-gool/Test/Main.hs
+++ b/code/drasil-gool/Test/Main.hs
@@ -1,12 +1,7 @@
 module Test.Main (main) where
 
-import GOOL.Drasil.Symantics (Label, ProgramSym(..))
-import GOOL.Drasil.LanguageRenderer.JavaRenderer (JavaCode(..))
-import GOOL.Drasil.LanguageRenderer.PythonRenderer (PythonCode(..))
-import GOOL.Drasil.LanguageRenderer.CSharpRenderer (CSharpCode(..))
-import GOOL.Drasil.LanguageRenderer.CppRenderer (unCPPC)
-import GOOL.Drasil.Data (FileData(..), ModData(..), ProgData(..))
-import GOOL.Drasil.State (initialState)
+import GOOL.Drasil (Label, ProgramSym(..), unCI, unJC, unPC, unCSC, unCPPC, 
+  FileData(..), ModData(..), ProgData(..), initialState)
 
 import Text.PrettyPrint.HughesPJ (Doc, render)
 import Control.Monad.State (evalState)
@@ -43,8 +38,8 @@ genCode files = createCodeFiles (concatMap (\p -> replicate (length $ progMods
   p) (progName p)) files) $ makeCode (concatMap progMods files)
 
 classes :: (ProgramSym repr) => (repr (Program repr) -> ProgData) -> [ProgData]
-classes unRepr = map (unRepr . (`evalState` initialState)) [helloWorld, 
-  patternTest, fileTests]
+classes unRepr = zipWith (\p gs -> unRepr (evalState p gs)) [helloWorld, patternTest, fileTests] 
+  (map (unCI . (`evalState` initialState)) [helloWorld, patternTest, fileTests])
 
 -- | Takes code
 makeCode :: [FileData] -> [(FilePath, Doc)]

--- a/code/drasil-gool/Test/Observer.hs
+++ b/code/drasil-gool/Test/Observer.hs
@@ -1,7 +1,7 @@
 module Test.Observer (observer, observerName, printNum, x) where
 
 import GOOL.Drasil (
-  RenderSym(..), PermanenceSym(..), BodySym(..), TypeSym(..), 
+  RenderSym, FileSym(..), PermanenceSym(..), BodySym(..), TypeSym(..), 
   StatementSym(..), VariableSym(..), ValueSym(..), ScopeSym(..), 
   MethodSym(..), StateVarSym(..), ClassSym(..), ModuleSym(..), GS, FS, MS)
 import Prelude hiding (return,print,log,exp,sin,cos,tan)

--- a/code/drasil-gool/Test/Observer.hs
+++ b/code/drasil-gool/Test/Observer.hs
@@ -1,7 +1,7 @@
 module Test.Observer (observer, observerName, printNum, x) where
 
 import GOOL.Drasil (
-  RenderSym, FileSym(..), PermanenceSym(..), BodySym(..), TypeSym(..), 
+  ProgramSym, FileSym(..), PermanenceSym(..), BodySym(..), TypeSym(..), 
   StatementSym(..), VariableSym(..), ValueSym(..), ScopeSym(..), 
   MethodSym(..), StateVarSym(..), ClassSym(..), ModuleSym(..), GS, FS, MS)
 import Prelude hiding (return,print,log,exp,sin,cos,tan)
@@ -11,7 +11,7 @@ observerName = "Observer"
 observerDesc = "This is an arbitrary class acting as an Observer"
 printNum = "printNum"
 
-observer :: (RenderSym repr) => FS (repr (RenderFile repr))
+observer :: (ProgramSym repr) => FS (repr (RenderFile repr))
 observer = fileDoc (buildModule observerName [] [] [docClass observerDesc
   helperClass])
 

--- a/code/drasil-gool/Test/PatternTest.hs
+++ b/code/drasil-gool/Test/PatternTest.hs
@@ -1,7 +1,6 @@
 module Test.PatternTest (patternTest) where
 
-import GOOL.Drasil (
-  ProgramSym(..), RenderSym(..),
+import GOOL.Drasil (ProgramSym(..), FileSym(..),
   BodySym(..), BlockSym(..), ControlBlockSym(..), TypeSym(..), 
   StatementSym(..), ControlStatementSym(..), VariableSym(..), ValueSym(..),
   ValueExpression(..), FunctionSym(..), MethodSym(..), ModuleSym(..), GS, MS)

--- a/code/drasil-gool/drasil-gool.cabal
+++ b/code/drasil-gool/drasil-gool.cabal
@@ -12,6 +12,7 @@ library
       GOOL.Drasil.CodeType
     , GOOL.Drasil.Data
     , GOOL.Drasil.Helpers
+    , GOOL.Drasil.CodeInfo
     , GOOL.Drasil.LanguageRenderer.LanguagePolymorphic
     , GOOL.Drasil.LanguageRenderer
     , GOOL.Drasil.LanguageRenderer.JavaRenderer
@@ -47,6 +48,7 @@ executable codegenTest
     , GOOL.Drasil.CodeType
     , GOOL.Drasil.Data
     , GOOL.Drasil.Helpers
+    , GOOL.Drasil.CodeInfo
     , GOOL.Drasil.LanguageRenderer.LanguagePolymorphic
     , GOOL.Drasil.LanguageRenderer
     , GOOL.Drasil.LanguageRenderer.JavaRenderer


### PR DESCRIPTION
While implementing the automation of the generation of import statements, I discovered I needed an information collection pass for C++ so that we can determine which objects have a type that needs to be imported from another module.

This PR adds the infrastructure for an information collection pass in GOOL. Currently it just creates a map from module names to class names, but we can add to the `CodeInfo` interpretation to store more information as we need it. The pass is also written generically, so the collected information is available to all language renderers.

The actual implementation of automated import statements isn't here, that will be in the next PR.