### PR TITLE
Automate imports in GOOL

### DIFF
--- a/code/drasil-code/Language/Drasil/Code/Imperative/ConceptMatch.hs
+++ b/code/drasil-code/Language/Drasil/Code/Imperative/ConceptMatch.hs
@@ -5,7 +5,7 @@ module Language.Drasil.Code.Imperative.ConceptMatch (
 import Language.Drasil.CodeSpec (Choices(..), CodeConcept(..), 
   MatchedConceptMap)
 
-import GOOL.Drasil (ProgramSym, ValueSym(..), GS)
+import GOOL.Drasil (ProgramSym, ValueSym(..), FS)
 
 import Prelude hiding (pi)
 import qualified Data.Map as Map (map)
@@ -17,6 +17,6 @@ chooseConcept chs = Map.map (chooseConcept' chs) (conceptMatch chs)
           "ConceptMatchMap"
         chooseConcept' _ cs = head cs
 
-conceptToGOOL :: (ProgramSym repr) => CodeConcept -> GS (repr (Value repr))
+conceptToGOOL :: (ProgramSym repr) => CodeConcept -> FS (repr (Value repr))
 conceptToGOOL Pi = pi
 

--- a/code/drasil-code/Language/Drasil/Code/Imperative/ConceptMatch.hs
+++ b/code/drasil-code/Language/Drasil/Code/Imperative/ConceptMatch.hs
@@ -5,7 +5,7 @@ module Language.Drasil.Code.Imperative.ConceptMatch (
 import Language.Drasil.CodeSpec (Choices(..), CodeConcept(..), 
   MatchedConceptMap)
 
-import GOOL.Drasil (RenderSym, ValueSym(..), GS)
+import GOOL.Drasil (ProgramSym, ValueSym(..), GS)
 
 import Prelude hiding (pi)
 import qualified Data.Map as Map (map)
@@ -17,6 +17,6 @@ chooseConcept chs = Map.map (chooseConcept' chs) (conceptMatch chs)
           "ConceptMatchMap"
         chooseConcept' _ cs = head cs
 
-conceptToGOOL :: (RenderSym repr) => CodeConcept -> GS (repr (Value repr))
+conceptToGOOL :: (ProgramSym repr) => CodeConcept -> GS (repr (Value repr))
 conceptToGOOL Pi = pi
 

--- a/code/drasil-code/Language/Drasil/Code/Imperative/FunctionCalls.hs
+++ b/code/drasil-code/Language/Drasil/Code/Imperative/FunctionCalls.hs
@@ -16,7 +16,7 @@ import Language.Drasil.Chunk.CodeDefinition (CodeDefinition)
 import Language.Drasil.Chunk.CodeQuantity (HasCodeType)
 import Language.Drasil.CodeSpec (CodeSpec(..))
 
-import GOOL.Drasil (RenderSym(..), TypeSym(..), ValueSym(..), 
+import GOOL.Drasil (RenderSym, TypeSym(..), ValueSym(..), 
   StatementSym(..), GS, convType)
 
 import Data.List ((\\), intersect)

--- a/code/drasil-code/Language/Drasil/Code/Imperative/FunctionCalls.hs
+++ b/code/drasil-code/Language/Drasil/Code/Imperative/FunctionCalls.hs
@@ -16,7 +16,7 @@ import Language.Drasil.Chunk.CodeDefinition (CodeDefinition)
 import Language.Drasil.Chunk.CodeQuantity (HasCodeType)
 import Language.Drasil.CodeSpec (CodeSpec(..))
 
-import GOOL.Drasil (RenderSym, TypeSym(..), ValueSym(..), 
+import GOOL.Drasil (ProgramSym, TypeSym(..), ValueSym(..), 
   StatementSym(..), GS, convType)
 
 import Data.List ((\\), intersect)
@@ -25,7 +25,7 @@ import Data.Maybe (maybe, catMaybes)
 import Control.Monad.Reader (Reader, ask)
 import Control.Lens ((^.))
 
-getAllInputCalls :: (RenderSym repr) => Reader DrasilState 
+getAllInputCalls :: (ProgramSym repr) => Reader DrasilState 
   [GS (repr (Statement repr))]
 getAllInputCalls = do
   gi <- getInputCall
@@ -33,21 +33,21 @@ getAllInputCalls = do
   ic <- getConstraintCall
   return $ catMaybes [gi, dv, ic]
 
-getInputCall :: (RenderSym repr) => Reader DrasilState 
+getInputCall :: (ProgramSym repr) => Reader DrasilState 
   (Maybe (GS (repr (Statement repr))))
 getInputCall = getInOutCall "get_input" getInputFormatIns getInputFormatOuts
 
-getDerivedCall :: (RenderSym repr) => Reader DrasilState 
+getDerivedCall :: (ProgramSym repr) => Reader DrasilState 
   (Maybe (GS (repr (Statement repr))))
 getDerivedCall = getInOutCall "derived_values" getDerivedIns getDerivedOuts
 
-getConstraintCall :: (RenderSym repr) => Reader DrasilState 
+getConstraintCall :: (ProgramSym repr) => Reader DrasilState 
   (Maybe (GS (repr (Statement repr))))
 getConstraintCall = do
   val <- getFuncCall "input_constraints" void getConstraintParams
   return $ fmap valState val
 
-getCalcCall :: (RenderSym repr) => CodeDefinition -> Reader DrasilState 
+getCalcCall :: (ProgramSym repr) => CodeDefinition -> Reader DrasilState 
   (Maybe (GS (repr (Statement repr))))
 getCalcCall c = do
   g <- ask
@@ -57,13 +57,13 @@ getCalcCall c = do
   l <- maybeLog v
   return $ fmap (multi . (: l) . varDecDef v) val
 
-getOutputCall :: (RenderSym repr) => Reader DrasilState 
+getOutputCall :: (ProgramSym repr) => Reader DrasilState 
   (Maybe (GS (repr (Statement repr))))
 getOutputCall = do
   val <- getFuncCall "write_output" void getOutputParams
   return $ fmap valState val
 
-getFuncCall :: (RenderSym repr, HasUID c, HasCodeType c, CodeIdea c) => String 
+getFuncCall :: (ProgramSym repr, HasUID c, HasCodeType c, CodeIdea c) => String 
   -> GS (repr (Type repr)) -> Reader DrasilState [c] -> 
   Reader DrasilState (Maybe (GS (repr (Value repr))))
 getFuncCall n t funcPs = do
@@ -76,7 +76,7 @@ getFuncCall n t funcPs = do
         return $ Just val
   getFuncCall' mm
 
-getInOutCall :: (RenderSym repr, HasCodeType c, CodeIdea c, Eq c) => String -> 
+getInOutCall :: (ProgramSym repr, HasCodeType c, CodeIdea c, Eq c) => String -> 
   Reader DrasilState [c] -> Reader DrasilState [c] ->
   Reader DrasilState (Maybe (GS (repr (Statement repr))))
 getInOutCall n inFunc outFunc = do

--- a/code/drasil-code/Language/Drasil/Code/Imperative/FunctionCalls.hs
+++ b/code/drasil-code/Language/Drasil/Code/Imperative/FunctionCalls.hs
@@ -16,8 +16,8 @@ import Language.Drasil.Chunk.CodeDefinition (CodeDefinition)
 import Language.Drasil.Chunk.CodeQuantity (HasCodeType)
 import Language.Drasil.CodeSpec (CodeSpec(..))
 
-import GOOL.Drasil (ProgramSym, TypeSym(..), ValueSym(..), 
-  StatementSym(..), GS, convType)
+import GOOL.Drasil (ProgramSym, TypeSym(..), ValueSym(..), StatementSym(..), 
+  FS, convType)
 
 import Data.List ((\\), intersect)
 import qualified Data.Map as Map (lookup)
@@ -26,7 +26,7 @@ import Control.Monad.Reader (Reader, ask)
 import Control.Lens ((^.))
 
 getAllInputCalls :: (ProgramSym repr) => Reader DrasilState 
-  [GS (repr (Statement repr))]
+  [FS (repr (Statement repr))]
 getAllInputCalls = do
   gi <- getInputCall
   dv <- getDerivedCall
@@ -34,21 +34,21 @@ getAllInputCalls = do
   return $ catMaybes [gi, dv, ic]
 
 getInputCall :: (ProgramSym repr) => Reader DrasilState 
-  (Maybe (GS (repr (Statement repr))))
+  (Maybe (FS (repr (Statement repr))))
 getInputCall = getInOutCall "get_input" getInputFormatIns getInputFormatOuts
 
 getDerivedCall :: (ProgramSym repr) => Reader DrasilState 
-  (Maybe (GS (repr (Statement repr))))
+  (Maybe (FS (repr (Statement repr))))
 getDerivedCall = getInOutCall "derived_values" getDerivedIns getDerivedOuts
 
 getConstraintCall :: (ProgramSym repr) => Reader DrasilState 
-  (Maybe (GS (repr (Statement repr))))
+  (Maybe (FS (repr (Statement repr))))
 getConstraintCall = do
   val <- getFuncCall "input_constraints" void getConstraintParams
   return $ fmap valState val
 
 getCalcCall :: (ProgramSym repr) => CodeDefinition -> Reader DrasilState 
-  (Maybe (GS (repr (Statement repr))))
+  (Maybe (FS (repr (Statement repr))))
 getCalcCall c = do
   g <- ask
   val <- getFuncCall (codeName c) (convType $ codeType c) (getCalcParams c)
@@ -58,14 +58,14 @@ getCalcCall c = do
   return $ fmap (multi . (: l) . varDecDef v) val
 
 getOutputCall :: (ProgramSym repr) => Reader DrasilState 
-  (Maybe (GS (repr (Statement repr))))
+  (Maybe (FS (repr (Statement repr))))
 getOutputCall = do
   val <- getFuncCall "write_output" void getOutputParams
   return $ fmap valState val
 
 getFuncCall :: (ProgramSym repr, HasUID c, HasCodeType c, CodeIdea c) => String 
-  -> GS (repr (Type repr)) -> Reader DrasilState [c] -> 
-  Reader DrasilState (Maybe (GS (repr (Value repr))))
+  -> FS (repr (Type repr)) -> Reader DrasilState [c] -> 
+  Reader DrasilState (Maybe (FS (repr (Value repr))))
 getFuncCall n t funcPs = do
   mm <- getCall n
   let getFuncCall' Nothing = return Nothing
@@ -78,7 +78,7 @@ getFuncCall n t funcPs = do
 
 getInOutCall :: (ProgramSym repr, HasCodeType c, CodeIdea c, Eq c) => String -> 
   Reader DrasilState [c] -> Reader DrasilState [c] ->
-  Reader DrasilState (Maybe (GS (repr (Statement repr))))
+  Reader DrasilState (Maybe (FS (repr (Statement repr))))
 getInOutCall n inFunc outFunc = do
   mm <- getCall n
   let getInOutCall' Nothing = return Nothing

--- a/code/drasil-code/Language/Drasil/Code/Imperative/GenerateGOOL.hs
+++ b/code/drasil-code/Language/Drasil/Code/Imperative/GenerateGOOL.hs
@@ -11,7 +11,7 @@ import Language.Drasil.CodeSpec (CodeSpec(..), CodeSystInfo(..), Comments(..),
 import GOOL.Drasil (Label, ProgramSym, FileSym(..), TypeSym(..), 
   VariableSym(..), ValueSym(..), ValueExpression(..), StatementSym(..), 
   ParameterSym(..), MethodSym(..), StateVarSym(..), ClassSym(..), ModuleSym(..),
-  CodeType(..), GOOLState, GS, FS, MS, lensMStoFS)
+  CodeType(..), GOOLState, FS, MS, lensMStoFS)
 
 import qualified Data.Map as Map (lookup)
 import Data.Maybe (fromMaybe, maybe)

--- a/code/drasil-code/Language/Drasil/Code/Imperative/GenerateGOOL.hs
+++ b/code/drasil-code/Language/Drasil/Code/Imperative/GenerateGOOL.hs
@@ -14,7 +14,7 @@ import GOOL.Drasil (Label, ProgramSym, FileSym(..), TypeSym(..),
   CodeType(..), GOOLState, FS, MS, lensMStoFS)
 
 import qualified Data.Map as Map (lookup)
-import Data.Maybe (fromMaybe, maybe)
+import Data.Maybe (maybe)
 import Control.Lens.Zoom (zoom)
 import Control.Monad.Reader (Reader, ask, withReader)
 
@@ -24,8 +24,7 @@ genModule :: (ProgramSym repr) => Name -> String
   -> Reader DrasilState (FS (repr (RenderFile repr)))
 genModule n desc maybeMs maybeCs = do
   g <- ask
-  let ls = fromMaybe [] (Map.lookup n (dMap $ codeSpec g))
-      updateState = withReader (\s -> s { currentModule = n })
+  let updateState = withReader (\s -> s { currentModule = n })
       -- Below line of code cannot be simplified because authors has a generic type
       as = case csi (codeSpec g) of CSI {authors = a} -> map name a
   cs <- maybe (return []) updateState maybeCs
@@ -35,7 +34,7 @@ genModule n desc maybeMs maybeCs = do
               | CommentFunc `elem` commented g && not (null ms) = docMod "" []  
                   (date g)
               | otherwise                                       = id
-  return $ commMod $ fileDoc $ buildModule n ls ms cs
+  return $ commMod $ fileDoc $ buildModule n ms cs
 
 genDoxConfig :: (AuxiliarySym repr) => String -> GOOLState ->
   Reader DrasilState [repr (Auxiliary repr)]

--- a/code/drasil-code/Language/Drasil/Code/Imperative/GenerateGOOL.hs
+++ b/code/drasil-code/Language/Drasil/Code/Imperative/GenerateGOOL.hs
@@ -8,7 +8,7 @@ import Language.Drasil.Code.Imperative.GOOL.Symantics (AuxiliarySym(..))
 import Language.Drasil.CodeSpec (CodeSpec(..), CodeSystInfo(..), Comments(..), 
   Name)
   
-import GOOL.Drasil (Label, RenderSym, FileSym(..), TypeSym(..), 
+import GOOL.Drasil (Label, ProgramSym, FileSym(..), TypeSym(..), 
   VariableSym(..), ValueSym(..), ValueExpression(..), StatementSym(..), 
   ParameterSym(..), MethodSym(..), StateVarSym(..), ClassSym(..), ModuleSym(..),
   CodeType(..), GOOLState, GS, FS, MS, lensMStoGS)
@@ -18,7 +18,7 @@ import Data.Maybe (fromMaybe, maybe)
 import Control.Lens.Zoom (zoom)
 import Control.Monad.Reader (Reader, ask, withReader)
 
-genModule :: (RenderSym repr) => Name -> String
+genModule :: (ProgramSym repr) => Name -> String
   -> Maybe (Reader DrasilState [MS (repr (Method repr))])
   -> Maybe (Reader DrasilState [FS (repr (Class repr))])
   -> Reader DrasilState (FS (repr (RenderFile repr)))
@@ -45,7 +45,7 @@ genDoxConfig n s = do
       v = doxOutput g
   return [doxConfig n s v | not (null cms)]
 
-publicClass :: (RenderSym repr) => String -> Label -> Maybe Label -> 
+publicClass :: (ProgramSym repr) => String -> Label -> Maybe Label -> 
   [GS (repr (StateVar repr))] -> Reader DrasilState [MS (repr (Method repr))] 
   -> Reader DrasilState (FS (repr (Class repr)))
 publicClass desc n l vs mths = do
@@ -55,7 +55,7 @@ publicClass desc n l vs mths = do
     then docClass desc (pubClass n l vs ms) 
     else pubClass n l vs ms
 
-fApp :: (RenderSym repr) => String -> String -> GS (repr (Type repr)) -> 
+fApp :: (ProgramSym repr) => String -> String -> GS (repr (Type repr)) -> 
   [GS (repr (Value repr))] -> Reader DrasilState (GS (repr (Value repr)))
 fApp m s t vl = do
   g <- ask
@@ -63,7 +63,7 @@ fApp m s t vl = do
   return $ if m /= cm then extFuncApp m s t vl else if Map.lookup s 
     (eMap $ codeSpec g) == Just cm then funcApp s t vl else selfFuncApp m s t vl
 
-fAppInOut :: (RenderSym repr) => String -> String -> [GS (repr (Value repr))] 
+fAppInOut :: (ProgramSym repr) => String -> String -> [GS (repr (Value repr))] 
   -> [GS (repr (Variable repr))] -> [GS (repr (Variable repr))] -> 
   Reader DrasilState (GS (repr (Statement repr)))
 fAppInOut m n ins outs both = do
@@ -73,7 +73,7 @@ fAppInOut m n ins outs both = do
     (eMap $ codeSpec g) == Just cm then inOutCall n ins outs both else 
     selfInOutCall m n ins outs both
 
-mkParam :: (RenderSym repr) => GS (repr (Variable repr)) -> 
+mkParam :: (ProgramSym repr) => GS (repr (Variable repr)) -> 
   MS (repr (Parameter repr))
 mkParam v = zoom lensMStoGS v >>= (\v' -> paramFunc (getType $ variableType v') v)
   where paramFunc (List _) = pointerParam

--- a/code/drasil-code/Language/Drasil/Code/Imperative/GenerateGOOL.hs
+++ b/code/drasil-code/Language/Drasil/Code/Imperative/GenerateGOOL.hs
@@ -8,7 +8,7 @@ import Language.Drasil.Code.Imperative.GOOL.Symantics (AuxiliarySym(..))
 import Language.Drasil.CodeSpec (CodeSpec(..), CodeSystInfo(..), Comments(..), 
   Name)
   
-import GOOL.Drasil (Label, RenderSym(..), TypeSym(..), 
+import GOOL.Drasil (Label, RenderSym, FileSym(..), TypeSym(..), 
   VariableSym(..), ValueSym(..), ValueExpression(..), StatementSym(..), 
   ParameterSym(..), MethodSym(..), StateVarSym(..), ClassSym(..), ModuleSym(..),
   CodeType(..), GOOLState, GS, FS, MS, lensMStoGS)

--- a/code/drasil-code/Language/Drasil/Code/Imperative/GenerateGOOL.hs
+++ b/code/drasil-code/Language/Drasil/Code/Imperative/GenerateGOOL.hs
@@ -11,7 +11,7 @@ import Language.Drasil.CodeSpec (CodeSpec(..), CodeSystInfo(..), Comments(..),
 import GOOL.Drasil (Label, ProgramSym, FileSym(..), TypeSym(..), 
   VariableSym(..), ValueSym(..), ValueExpression(..), StatementSym(..), 
   ParameterSym(..), MethodSym(..), StateVarSym(..), ClassSym(..), ModuleSym(..),
-  CodeType(..), GOOLState, GS, FS, MS, lensMStoGS)
+  CodeType(..), GOOLState, GS, FS, MS, lensMStoFS)
 
 import qualified Data.Map as Map (lookup)
 import Data.Maybe (fromMaybe, maybe)
@@ -46,7 +46,7 @@ genDoxConfig n s = do
   return [doxConfig n s v | not (null cms)]
 
 publicClass :: (ProgramSym repr) => String -> Label -> Maybe Label -> 
-  [GS (repr (StateVar repr))] -> Reader DrasilState [MS (repr (Method repr))] 
+  [FS (repr (StateVar repr))] -> Reader DrasilState [MS (repr (Method repr))] 
   -> Reader DrasilState (FS (repr (Class repr)))
 publicClass desc n l vs mths = do
   g <- ask
@@ -55,17 +55,17 @@ publicClass desc n l vs mths = do
     then docClass desc (pubClass n l vs ms) 
     else pubClass n l vs ms
 
-fApp :: (ProgramSym repr) => String -> String -> GS (repr (Type repr)) -> 
-  [GS (repr (Value repr))] -> Reader DrasilState (GS (repr (Value repr)))
+fApp :: (ProgramSym repr) => String -> String -> FS (repr (Type repr)) -> 
+  [FS (repr (Value repr))] -> Reader DrasilState (FS (repr (Value repr)))
 fApp m s t vl = do
   g <- ask
   let cm = currentModule g
   return $ if m /= cm then extFuncApp m s t vl else if Map.lookup s 
     (eMap $ codeSpec g) == Just cm then funcApp s t vl else selfFuncApp m s t vl
 
-fAppInOut :: (ProgramSym repr) => String -> String -> [GS (repr (Value repr))] 
-  -> [GS (repr (Variable repr))] -> [GS (repr (Variable repr))] -> 
-  Reader DrasilState (GS (repr (Statement repr)))
+fAppInOut :: (ProgramSym repr) => String -> String -> [FS (repr (Value repr))] 
+  -> [FS (repr (Variable repr))] -> [FS (repr (Variable repr))] -> 
+  Reader DrasilState (FS (repr (Statement repr)))
 fAppInOut m n ins outs both = do
   g <- ask
   let cm = currentModule g
@@ -73,9 +73,9 @@ fAppInOut m n ins outs both = do
     (eMap $ codeSpec g) == Just cm then inOutCall n ins outs both else 
     selfInOutCall m n ins outs both
 
-mkParam :: (ProgramSym repr) => GS (repr (Variable repr)) -> 
+mkParam :: (ProgramSym repr) => FS (repr (Variable repr)) -> 
   MS (repr (Parameter repr))
-mkParam v = zoom lensMStoGS v >>= (\v' -> paramFunc (getType $ variableType v') v)
+mkParam v = zoom lensMStoFS v >>= (\v' -> paramFunc (getType $ variableType v') v)
   where paramFunc (List _) = pointerParam
         paramFunc (Object _) = pointerParam
         paramFunc _ = param

--- a/code/drasil-code/Language/Drasil/Code/Imperative/Generator.hs
+++ b/code/drasil-code/Language/Drasil/Code/Imperative/Generator.hs
@@ -17,13 +17,13 @@ import Language.Drasil.Chunk.Code (programName)
 import Language.Drasil.CodeSpec (CodeSpec(..), CodeSystInfo(..), Choices(..), 
   Lang(..), Visibility(..))
 
-import GOOL.Drasil (ProgramSym(..), RenderSym, FileSym(..), ProgData(..), 
-  GS, FS, initialState)
+import GOOL.Drasil (ProgramSym(..), ProgramSym, FileSym(..), ProgData(..), 
+  GS, FS, initialState, unCI)
 
 import System.Directory (setCurrentDirectory, createDirectoryIfMissing, 
   getCurrentDirectory)
 import Control.Monad.Reader (Reader, ask, runReader)
-import Control.Monad.State (runState)
+import Control.Monad.State (evalState, runState)
 
 generator :: String -> [Expr] -> Choices -> CodeSpec -> DrasilState
 generator dt sd chs spec = DrasilState {
@@ -69,8 +69,10 @@ genPackage :: (ProgramSym progRepr, PackageSym packRepr) =>
   Reader DrasilState (packRepr (Package packRepr))
 genPackage unRepr = do
   g <- ask
+  ci <- genProgram
   p <- genProgram
-  let (reprPD, s) = runState p initialState
+  let info = unCI $ evalState ci initialState
+      (reprPD, s) = runState p info
       pd = unRepr reprPD
       n = case codeSpec g of CodeSpec {program = pr} -> programName pr
       m = makefile (commented g) s pd
@@ -86,7 +88,7 @@ genProgram = do
   let n = case codeSpec g of CodeSpec {program = p} -> programName p
   return $ prog n ms
           
-genModules :: (RenderSym repr) => Reader DrasilState [FS (repr (RenderFile repr))]
+genModules :: (ProgramSym repr) => Reader DrasilState [FS (repr (RenderFile repr))]
 genModules = do
   g <- ask
   let s = csi $ codeSpec g

--- a/code/drasil-code/Language/Drasil/Code/Imperative/Generator.hs
+++ b/code/drasil-code/Language/Drasil/Code/Imperative/Generator.hs
@@ -17,13 +17,13 @@ import Language.Drasil.Chunk.Code (programName)
 import Language.Drasil.CodeSpec (CodeSpec(..), CodeSystInfo(..), Choices(..), 
   Lang(..), Visibility(..))
 
-import GOOL.Drasil (ProgramSym(..), RenderSym(..), ProgData(..), GS, FS, 
-  initialState)
+import GOOL.Drasil (ProgramSym(..), RenderSym, FileSym(..), ProgData(..), 
+  GS, FS, initialState)
 
 import System.Directory (setCurrentDirectory, createDirectoryIfMissing, 
   getCurrentDirectory)
 import Control.Monad.Reader (Reader, ask, runReader)
-import Control.Monad.State (evalState, execState)
+import Control.Monad.State (runState)
 
 generator :: String -> [Expr] -> Choices -> CodeSpec -> DrasilState
 generator dt sd chs spec = DrasilState {
@@ -70,8 +70,8 @@ genPackage :: (ProgramSym progRepr, PackageSym packRepr) =>
 genPackage unRepr = do
   g <- ask
   p <- genProgram
-  let s = execState p initialState
-      pd = unRepr $ evalState p initialState
+  let (reprPD, s) = runState p initialState
+      pd = unRepr reprPD
       n = case codeSpec g of CodeSpec {program = pr} -> programName pr
       m = makefile (commented g) s pd
   i <- genSampleInput

--- a/code/drasil-code/Language/Drasil/Code/Imperative/Import.hs
+++ b/code/drasil-code/Language/Drasil/Code/Imperative/Import.hs
@@ -33,7 +33,7 @@ import GOOL.Drasil (Label, ProgramSym, FileSym(..), PermanenceSym(..),
   NumericExpression(..), BooleanExpression(..), ValueExpression(..), 
   FunctionSym(..), SelectorFunction(..), StatementSym(..), 
   ControlStatementSym(..), ScopeSym(..), ParameterSym(..), MethodSym(..), 
-  convType, GS, FS, MS, onStateValue) 
+  convType, FS, MS, onStateValue) 
 import qualified GOOL.Drasil as C (CodeType(List))
 
 import Prelude hiding (sin, cos, tan, log, exp)
@@ -45,8 +45,8 @@ import Control.Monad (liftM2,liftM3)
 import Control.Monad.Reader (Reader, ask)
 import Control.Lens ((^.))
 
-value :: (ProgramSym repr) => UID -> String -> GS (repr (Type repr)) -> 
-  Reader DrasilState (GS (repr (Value repr)))
+value :: (ProgramSym repr) => UID -> String -> FS (repr (Type repr)) -> 
+  Reader DrasilState (FS (repr (Value repr)))
 value u s t = do
   g <- ask
   let cs = codeSpec g
@@ -58,8 +58,8 @@ value u s t = do
     (convExpr . codeEquat) (Map.lookup u mm >>= maybeInline (conStruct g))) 
     (return . conceptToGOOL) (Map.lookup u cm)
 
-variable :: (ProgramSym repr) => String -> GS (repr (Type repr)) -> 
-  Reader DrasilState (GS (repr (Variable repr)))
+variable :: (ProgramSym repr) => String -> FS (repr (Type repr)) -> 
+  Reader DrasilState (FS (repr (Variable repr)))
 variable s t = do
   g <- ask
   let cs = csi $ codeSpec g
@@ -72,7 +72,7 @@ variable s t = do
       else return $ var s t
   
 inputVariable :: (ProgramSym repr) => Structure -> ConstantRepr -> 
-  GS (repr (Variable repr)) -> Reader DrasilState (GS (repr (Variable repr)))
+  FS (repr (Variable repr)) -> Reader DrasilState (FS (repr (Variable repr)))
 inputVariable Unbundled _ v = return v
 inputVariable Bundled Var v = do
   g <- ask
@@ -85,7 +85,7 @@ inputVariable Bundled Const v = do
   classVariable ip v
 
 constVariable :: (ProgramSym repr) => ConstantStructure -> ConstantRepr -> 
-  GS (repr (Variable repr)) -> Reader DrasilState (GS (repr (Variable repr)))
+  FS (repr (Variable repr)) -> Reader DrasilState (FS (repr (Variable repr)))
 constVariable (Store Bundled) Var v = do
   cs <- mkVar (codevar consts)
   return $ cs $-> v
@@ -97,8 +97,8 @@ constVariable WithInputs cr v = do
   inputVariable (inStruct g) cr v
 constVariable _ _ v = return v
 
-classVariable :: (ProgramSym repr) => GS (repr (Variable repr)) -> 
-  GS (repr (Variable repr)) -> Reader DrasilState (GS (repr (Variable repr)))
+classVariable :: (ProgramSym repr) => FS (repr (Variable repr)) -> 
+  FS (repr (Variable repr)) -> Reader DrasilState (FS (repr (Variable repr)))
 classVariable c v = do
   g <- ask
   let checkCurrent m = if currentModule g == m then classVar else extClassVar
@@ -107,43 +107,43 @@ classVariable c v = do
     (eMap $ codeSpec g)) (onStateValue variableType c) v)
 
 mkVal :: (ProgramSym repr, HasUID c, HasCodeType c, CodeIdea c) => c -> 
-  Reader DrasilState (GS (repr (Value repr)))
+  Reader DrasilState (FS (repr (Value repr)))
 mkVal v = value (v ^. uid) (codeName v) (convType $ codeType v)
 
 mkVar :: (ProgramSym repr, HasCodeType c, CodeIdea c) => c -> 
-  Reader DrasilState (GS (repr (Variable repr)))
+  Reader DrasilState (FS (repr (Variable repr)))
 mkVar v = variable (codeName v) (convType $ codeType v)
 
 publicFunc :: (ProgramSym repr, HasUID c, HasCodeType c, CodeIdea c) => 
-  Label -> GS (repr (Type repr)) -> String -> [c] -> Maybe String -> 
-  [GS (repr (Block repr))] -> Reader DrasilState (MS (repr (Method repr)))
+  Label -> FS (repr (Type repr)) -> String -> [c] -> Maybe String -> 
+  [FS (repr (Block repr))] -> Reader DrasilState (MS (repr (Method repr)))
 publicFunc n t = genMethod (function n public static_ t) n
 
 privateMethod :: (ProgramSym repr, HasUID c, HasCodeType c, CodeIdea c) => 
-  Label -> Label -> GS (repr (Type repr)) -> String -> [c] -> Maybe String -> 
-  [GS (repr (Block repr))] -> Reader DrasilState (MS (repr (Method repr)))
+  Label -> Label -> FS (repr (Type repr)) -> String -> [c] -> Maybe String -> 
+  [FS (repr (Block repr))] -> Reader DrasilState (MS (repr (Method repr)))
 privateMethod c n t = genMethod (method n c private dynamic_ t) n
 
 publicInOutFunc :: (ProgramSym repr, HasUID c, HasCodeType c, CodeIdea c, Eq c) 
-  => Label -> String -> [c] -> [c] -> [GS (repr (Block repr))] -> 
+  => Label -> String -> [c] -> [c] -> [FS (repr (Block repr))] -> 
   Reader DrasilState (MS (repr (Method repr)))
 publicInOutFunc n = genInOutFunc (inOutFunc n) (docInOutFunc n) public static_ n
 
 privateInOutMethod :: (ProgramSym repr, HasUID c, HasCodeType c, CodeIdea c,
-  Eq c) => Label -> Label -> String -> [c] -> [c] -> [GS (repr (Block repr))] 
+  Eq c) => Label -> Label -> String -> [c] -> [c] -> [FS (repr (Block repr))] 
   -> Reader DrasilState (MS (repr (Method repr)))
 privateInOutMethod c n = genInOutFunc (inOutMethod n c) (docInOutMethod n c) 
   private dynamic_ n
 
 genConstructor :: (ProgramSym repr, HasUID c, HasCodeType c, CodeIdea c) => 
-  Label -> String -> [c] -> [GS (repr (Block repr))] -> 
+  Label -> String -> [c] -> [FS (repr (Block repr))] -> 
   Reader DrasilState (MS (repr (Method repr)))
 genConstructor n desc p = genMethod (constructor n) n desc p Nothing
 
 genMethod :: (ProgramSym repr, HasUID c, HasCodeType c, CodeIdea c) => 
-  ([MS (repr (Parameter repr))] -> GS (repr (Body repr) )-> 
+  ([MS (repr (Parameter repr))] -> FS (repr (Body repr)) -> 
   MS (repr (Method repr))) -> Label -> String -> [c] -> Maybe String -> 
-  [GS (repr (Block repr))] -> Reader DrasilState (MS (repr (Method repr)))
+  [FS (repr (Block repr))] -> Reader DrasilState (MS (repr (Method repr)))
 genMethod f n desc p r b = do
   g <- ask
   vars <- mapM mkVar p
@@ -155,16 +155,16 @@ genMethod f n desc p r b = do
     then docFunc desc pComms r fn else fn
 
 genInOutFunc :: (ProgramSym repr, HasUID c, HasCodeType c, CodeIdea c, Eq c) => 
-  (repr (Scope repr) -> repr (Permanence repr) -> [GS (repr (Variable repr))] 
-    -> [GS (repr (Variable repr))] -> [GS (repr (Variable repr))] -> 
-    GS (repr (Body repr)) -> MS (repr (Method repr))) -> 
+  (repr (Scope repr) -> repr (Permanence repr) -> [FS (repr (Variable repr))] 
+    -> [FS (repr (Variable repr))] -> [FS (repr (Variable repr))] -> 
+    FS (repr (Body repr)) -> MS (repr (Method repr))) -> 
   (repr (Scope repr) -> repr (Permanence repr) -> String -> 
-    [(String, GS (repr (Variable repr)))] -> 
-    [(String, GS (repr (Variable repr)))] -> 
-    [(String, GS (repr (Variable repr)))] -> GS (repr (Body repr)) -> 
+    [(String, FS (repr (Variable repr)))] -> 
+    [(String, FS (repr (Variable repr)))] -> 
+    [(String, FS (repr (Variable repr)))] -> FS (repr (Body repr)) -> 
     MS (repr (Method repr))) -> 
   repr (Scope repr) -> repr (Permanence repr) -> Label -> String -> [c] -> 
-  [c] -> [GS (repr (Block repr))] -> 
+  [c] -> [FS (repr (Block repr))] -> 
   Reader DrasilState (MS (repr (Method repr)))
 genInOutFunc f docf s pr n desc ins' outs' b = do
   g <- ask
@@ -182,7 +182,7 @@ genInOutFunc f docf s pr n desc ins' outs' b = do
     then docf s pr desc (zip pComms inVs) (zip oComms outVs) (zip 
     bComms bothVs) bod else f s pr inVs outVs bothVs bod
 
-convExpr :: (ProgramSym repr) => Expr -> Reader DrasilState (GS (repr (Value repr)))
+convExpr :: (ProgramSym repr) => Expr -> Reader DrasilState (FS (repr (Value repr)))
 convExpr (Dbl d) = return $ litFloat d
 convExpr (Int i) = return $ litInt i
 convExpr (Str s) = return $ litString s
@@ -239,7 +239,8 @@ renderRealInt s (UpTo (Exc,a))    = sy s $< a
 renderRealInt s (UpFrom (Inc,a))  = sy s $>= a
 renderRealInt s (UpFrom (Exc,a))  = sy s $>  a
 
-unop :: (ProgramSym repr) => UFunc -> (GS (repr (Value repr)) -> GS (repr (Value repr)))
+unop :: (ProgramSym repr) => UFunc -> (FS (repr (Value repr)) -> 
+  FS (repr (Value repr)))
 unop Sqrt = (#/^)
 unop Log  = log
 unop Ln   = ln
@@ -259,8 +260,8 @@ unop Norm = error "unop: Norm not implemented"
 unop Not  = (?!)
 unop Neg  = (#~)
 
-bfunc :: (ProgramSym repr) => BinOp -> (GS (repr (Value repr)) -> 
-  GS (repr (Value repr)) -> GS (repr (Value repr)))
+bfunc :: (ProgramSym repr) => BinOp -> (FS (repr (Value repr)) -> 
+  FS (repr (Value repr)) -> FS (repr (Value repr)))
 bfunc Eq    = (?==)
 bfunc NEq   = (?!=)
 bfunc Gt    = (?>)
@@ -297,7 +298,7 @@ genCalcFunc cdef = do
 data CalcType = CalcAssign | CalcReturn deriving Eq
 
 genCalcBlock :: (ProgramSym repr) => CalcType -> CodeDefinition -> Expr ->
-  Reader DrasilState (GS (repr (Block repr)))
+  Reader DrasilState (FS (repr (Block repr)))
 genCalcBlock t v (Case c e) = genCaseBlock t v c e
 genCalcBlock t v e
     | t == CalcAssign  = fmap block $ liftS $ do { vv <- mkVar v; ee <-
@@ -305,7 +306,7 @@ genCalcBlock t v e
     | otherwise        = block <$> liftS (returnState <$> convExpr e)
 
 genCaseBlock :: (ProgramSym repr) => CalcType -> CodeDefinition -> Completeness 
-  -> [(Expr,Relation)] -> Reader DrasilState (GS (repr (Block repr)))
+  -> [(Expr,Relation)] -> Reader DrasilState (FS (repr (Block repr)))
 genCaseBlock _ _ _ [] = error $ "Case expression with no cases encountered" ++
   " in code generator"
 genCaseBlock t v c cs = do
@@ -333,7 +334,7 @@ genFunc (FDef (FuncDef n desc parms o rd s)) = do
 genFunc (FData (FuncData n desc ddef)) = genDataFunc n desc ddef
 genFunc (FCD cd) = genCalcFunc cd
 
-convStmt :: (ProgramSym repr) => FuncStmt -> Reader DrasilState (GS (repr (Statement repr)))
+convStmt :: (ProgramSym repr) => FuncStmt -> Reader DrasilState (FS (repr (Statement repr)))
 convStmt (FAsg v e) = do
   e' <- convExpr e
   v' <- mkVar v
@@ -388,7 +389,7 @@ genDataFunc nameTitle desc ddef = do
 
 -- this is really ugly!!
 readData :: (ProgramSym repr) => DataDesc -> Reader DrasilState
-  [GS (repr (Block repr))]
+  [FS (repr (Block repr))]
 readData ddef = do
   inD <- mapM inData ddef
   v_filename <- mkVal $ codevar inFileName
@@ -399,7 +400,7 @@ readData ddef = do
     openFileR var_infile v_filename :
     concat inD ++ [
     closeFile v_infile ]]
-  where inData :: (ProgramSym repr) => Data -> Reader DrasilState [GS (repr (Statement repr))]
+  where inData :: (ProgramSym repr) => Data -> Reader DrasilState [FS (repr (Statement repr))]
         inData (Singleton v) = do
             vv <- mkVar v
             l <- maybeLog vv
@@ -426,7 +427,7 @@ readData ddef = do
           return $ readLines ls ++ logs
         ---------------
         lineData :: (ProgramSym repr) => Maybe String -> LinePattern -> 
-          Reader DrasilState [GS (repr (Statement repr))]
+          Reader DrasilState [FS (repr (Statement repr))]
         lineData s p@(Straight _) = do
           vs <- getEntryVars s p
           return [stringListVals vs v_linetokens]
@@ -436,31 +437,31 @@ readData ddef = do
             : appendTemps s ds
         ---------------
         clearTemps :: (ProgramSym repr) => Maybe String -> [DataItem] -> 
-          [GS (repr (Statement repr))]
+          [FS (repr (Statement repr))]
         clearTemps Nothing _ = []
         clearTemps (Just sfx) es = map (clearTemp sfx) es
         ---------------
         clearTemp :: (ProgramSym repr) => String -> DataItem -> 
-          GS (repr (Statement repr))
+          FS (repr (Statement repr))
         clearTemp sfx v = listDecDef (var (codeName v ++ sfx) 
           (listInnerType $ convType $ codeType v)) []
         ---------------
         appendTemps :: (ProgramSym repr) => Maybe String -> [DataItem] -> 
-          [GS (repr (Statement repr))]
+          [FS (repr (Statement repr))]
         appendTemps Nothing _ = []
         appendTemps (Just sfx) es = map (appendTemp sfx) es
         ---------------
         appendTemp :: (ProgramSym repr) => String -> DataItem -> 
-          GS (repr (Statement repr))
+          FS (repr (Statement repr))
         appendTemp sfx v = valState $ listAppend 
           (valueOf $ var (codeName v) (convType $ codeType v)) 
           (valueOf $ var (codeName v ++ sfx) (convType $ codeType v))
         ---------------
         l_line, l_lines, l_linetokens, l_infile, l_i :: Label
         var_line, var_lines, var_linetokens, var_infile, var_i :: 
-          (ProgramSym repr) => GS (repr (Variable repr))
+          (ProgramSym repr) => FS (repr (Variable repr))
         v_line, v_lines, v_linetokens, v_infile, v_i ::
-          (ProgramSym repr) => GS (repr (Value repr))
+          (ProgramSym repr) => FS (repr (Value repr))
         l_line = "line"
         var_line = var l_line string
         v_line = valueOf var_line
@@ -478,12 +479,12 @@ readData ddef = do
         v_i = valueOf var_i
 
 getEntryVars :: (ProgramSym repr) => Maybe String -> LinePattern -> 
-  Reader DrasilState [GS (repr (Variable repr))]
+  Reader DrasilState [FS (repr (Variable repr))]
 getEntryVars s lp = mapM (maybe mkVar (\st v -> variable (codeName v ++ st) 
   (listInnerType $ convType $ codeType v)) s) (getPatternInputs lp)
 
 getEntryVarLogs :: (ProgramSym repr) => LinePattern -> 
-  Reader DrasilState [GS (repr (Statement repr))]
+  Reader DrasilState [FS (repr (Statement repr))]
 getEntryVarLogs lp = do
   vs <- getEntryVars Nothing lp
   logs <- mapM maybeLog vs

--- a/code/drasil-code/Language/Drasil/Code/Imperative/Import.hs
+++ b/code/drasil-code/Language/Drasil/Code/Imperative/Import.hs
@@ -28,8 +28,8 @@ import Language.Drasil.Code.DataDesc (DataItem, LinePattern(Repeat, Straight),
   Data(Line, Lines, JunkData, Singleton), DataDesc, isLine, isLines, getInputs,
   getPatternInputs)
 
-import GOOL.Drasil (Label, RenderSym(..), PermanenceSym(..), BodySym(..), 
-  BlockSym(..), TypeSym(..), VariableSym(..), ValueSym(..), 
+import GOOL.Drasil (Label, RenderSym, FileSym(..), PermanenceSym(..), 
+  BodySym(..), BlockSym(..), TypeSym(..), VariableSym(..), ValueSym(..), 
   NumericExpression(..), BooleanExpression(..), ValueExpression(..), 
   FunctionSym(..), SelectorFunction(..), StatementSym(..), 
   ControlStatementSym(..), ScopeSym(..), ParameterSym(..), MethodSym(..), 

--- a/code/drasil-code/Language/Drasil/Code/Imperative/Import.hs
+++ b/code/drasil-code/Language/Drasil/Code/Imperative/Import.hs
@@ -28,7 +28,7 @@ import Language.Drasil.Code.DataDesc (DataItem, LinePattern(Repeat, Straight),
   Data(Line, Lines, JunkData, Singleton), DataDesc, isLine, isLines, getInputs,
   getPatternInputs)
 
-import GOOL.Drasil (Label, RenderSym, FileSym(..), PermanenceSym(..), 
+import GOOL.Drasil (Label, ProgramSym, FileSym(..), PermanenceSym(..), 
   BodySym(..), BlockSym(..), TypeSym(..), VariableSym(..), ValueSym(..), 
   NumericExpression(..), BooleanExpression(..), ValueExpression(..), 
   FunctionSym(..), SelectorFunction(..), StatementSym(..), 
@@ -45,7 +45,7 @@ import Control.Monad (liftM2,liftM3)
 import Control.Monad.Reader (Reader, ask)
 import Control.Lens ((^.))
 
-value :: (RenderSym repr) => UID -> String -> GS (repr (Type repr)) -> 
+value :: (ProgramSym repr) => UID -> String -> GS (repr (Type repr)) -> 
   Reader DrasilState (GS (repr (Value repr)))
 value u s t = do
   g <- ask
@@ -58,7 +58,7 @@ value u s t = do
     (convExpr . codeEquat) (Map.lookup u mm >>= maybeInline (conStruct g))) 
     (return . conceptToGOOL) (Map.lookup u cm)
 
-variable :: (RenderSym repr) => String -> GS (repr (Type repr)) -> 
+variable :: (ProgramSym repr) => String -> GS (repr (Type repr)) -> 
   Reader DrasilState (GS (repr (Variable repr)))
 variable s t = do
   g <- ask
@@ -71,7 +71,7 @@ variable s t = do
       then constVariable (conStruct g) (conRepr g) ((defFunc $ conRepr g) s t)
       else return $ var s t
   
-inputVariable :: (RenderSym repr) => Structure -> ConstantRepr -> 
+inputVariable :: (ProgramSym repr) => Structure -> ConstantRepr -> 
   GS (repr (Variable repr)) -> Reader DrasilState (GS (repr (Variable repr)))
 inputVariable Unbundled _ v = return v
 inputVariable Bundled Var v = do
@@ -84,7 +84,7 @@ inputVariable Bundled Const v = do
   ip <- mkVar (codevar inParams)
   classVariable ip v
 
-constVariable :: (RenderSym repr) => ConstantStructure -> ConstantRepr -> 
+constVariable :: (ProgramSym repr) => ConstantStructure -> ConstantRepr -> 
   GS (repr (Variable repr)) -> Reader DrasilState (GS (repr (Variable repr)))
 constVariable (Store Bundled) Var v = do
   cs <- mkVar (codevar consts)
@@ -97,7 +97,7 @@ constVariable WithInputs cr v = do
   inputVariable (inStruct g) cr v
 constVariable _ _ v = return v
 
-classVariable :: (RenderSym repr) => GS (repr (Variable repr)) -> 
+classVariable :: (ProgramSym repr) => GS (repr (Variable repr)) -> 
   GS (repr (Variable repr)) -> Reader DrasilState (GS (repr (Variable repr)))
 classVariable c v = do
   g <- ask
@@ -106,41 +106,41 @@ classVariable c v = do
     " missing from export map") checkCurrent (Map.lookup (variableName v') 
     (eMap $ codeSpec g)) (onStateValue variableType c) v)
 
-mkVal :: (RenderSym repr, HasUID c, HasCodeType c, CodeIdea c) => c -> 
+mkVal :: (ProgramSym repr, HasUID c, HasCodeType c, CodeIdea c) => c -> 
   Reader DrasilState (GS (repr (Value repr)))
 mkVal v = value (v ^. uid) (codeName v) (convType $ codeType v)
 
-mkVar :: (RenderSym repr, HasCodeType c, CodeIdea c) => c -> 
+mkVar :: (ProgramSym repr, HasCodeType c, CodeIdea c) => c -> 
   Reader DrasilState (GS (repr (Variable repr)))
 mkVar v = variable (codeName v) (convType $ codeType v)
 
-publicFunc :: (RenderSym repr, HasUID c, HasCodeType c, CodeIdea c) => 
+publicFunc :: (ProgramSym repr, HasUID c, HasCodeType c, CodeIdea c) => 
   Label -> GS (repr (Type repr)) -> String -> [c] -> Maybe String -> 
   [GS (repr (Block repr))] -> Reader DrasilState (MS (repr (Method repr)))
 publicFunc n t = genMethod (function n public static_ t) n
 
-privateMethod :: (RenderSym repr, HasUID c, HasCodeType c, CodeIdea c) => 
+privateMethod :: (ProgramSym repr, HasUID c, HasCodeType c, CodeIdea c) => 
   Label -> Label -> GS (repr (Type repr)) -> String -> [c] -> Maybe String -> 
   [GS (repr (Block repr))] -> Reader DrasilState (MS (repr (Method repr)))
 privateMethod c n t = genMethod (method n c private dynamic_ t) n
 
-publicInOutFunc :: (RenderSym repr, HasUID c, HasCodeType c, CodeIdea c, Eq c) 
+publicInOutFunc :: (ProgramSym repr, HasUID c, HasCodeType c, CodeIdea c, Eq c) 
   => Label -> String -> [c] -> [c] -> [GS (repr (Block repr))] -> 
   Reader DrasilState (MS (repr (Method repr)))
 publicInOutFunc n = genInOutFunc (inOutFunc n) (docInOutFunc n) public static_ n
 
-privateInOutMethod :: (RenderSym repr, HasUID c, HasCodeType c, CodeIdea c,
+privateInOutMethod :: (ProgramSym repr, HasUID c, HasCodeType c, CodeIdea c,
   Eq c) => Label -> Label -> String -> [c] -> [c] -> [GS (repr (Block repr))] 
   -> Reader DrasilState (MS (repr (Method repr)))
 privateInOutMethod c n = genInOutFunc (inOutMethod n c) (docInOutMethod n c) 
   private dynamic_ n
 
-genConstructor :: (RenderSym repr, HasUID c, HasCodeType c, CodeIdea c) => 
+genConstructor :: (ProgramSym repr, HasUID c, HasCodeType c, CodeIdea c) => 
   Label -> String -> [c] -> [GS (repr (Block repr))] -> 
   Reader DrasilState (MS (repr (Method repr)))
 genConstructor n desc p = genMethod (constructor n) n desc p Nothing
 
-genMethod :: (RenderSym repr, HasUID c, HasCodeType c, CodeIdea c) => 
+genMethod :: (ProgramSym repr, HasUID c, HasCodeType c, CodeIdea c) => 
   ([MS (repr (Parameter repr))] -> GS (repr (Body repr) )-> 
   MS (repr (Method repr))) -> Label -> String -> [c] -> Maybe String -> 
   [GS (repr (Block repr))] -> Reader DrasilState (MS (repr (Method repr)))
@@ -154,7 +154,7 @@ genMethod f n desc p r b = do
   return $ if CommentFunc `elem` commented g
     then docFunc desc pComms r fn else fn
 
-genInOutFunc :: (RenderSym repr, HasUID c, HasCodeType c, CodeIdea c, Eq c) => 
+genInOutFunc :: (ProgramSym repr, HasUID c, HasCodeType c, CodeIdea c, Eq c) => 
   (repr (Scope repr) -> repr (Permanence repr) -> [GS (repr (Variable repr))] 
     -> [GS (repr (Variable repr))] -> [GS (repr (Variable repr))] -> 
     GS (repr (Body repr)) -> MS (repr (Method repr))) -> 
@@ -182,7 +182,7 @@ genInOutFunc f docf s pr n desc ins' outs' b = do
     then docf s pr desc (zip pComms inVs) (zip oComms outVs) (zip 
     bComms bothVs) bod else f s pr inVs outVs bothVs bod
 
-convExpr :: (RenderSym repr) => Expr -> Reader DrasilState (GS (repr (Value repr)))
+convExpr :: (ProgramSym repr) => Expr -> Reader DrasilState (GS (repr (Value repr)))
 convExpr (Dbl d) = return $ litFloat d
 convExpr (Int i) = return $ litInt i
 convExpr (Str s) = return $ litString s
@@ -239,7 +239,7 @@ renderRealInt s (UpTo (Exc,a))    = sy s $< a
 renderRealInt s (UpFrom (Inc,a))  = sy s $>= a
 renderRealInt s (UpFrom (Exc,a))  = sy s $>  a
 
-unop :: (RenderSym repr) => UFunc -> (GS (repr (Value repr)) -> GS (repr (Value repr)))
+unop :: (ProgramSym repr) => UFunc -> (GS (repr (Value repr)) -> GS (repr (Value repr)))
 unop Sqrt = (#/^)
 unop Log  = log
 unop Ln   = ln
@@ -259,7 +259,7 @@ unop Norm = error "unop: Norm not implemented"
 unop Not  = (?!)
 unop Neg  = (#~)
 
-bfunc :: (RenderSym repr) => BinOp -> (GS (repr (Value repr)) -> 
+bfunc :: (ProgramSym repr) => BinOp -> (GS (repr (Value repr)) -> 
   GS (repr (Value repr)) -> GS (repr (Value repr)))
 bfunc Eq    = (?==)
 bfunc NEq   = (?!=)
@@ -278,7 +278,7 @@ bfunc Index = listAccess
 
 ------- CALC ----------
 
-genCalcFunc :: (RenderSym repr) => CodeDefinition -> 
+genCalcFunc :: (ProgramSym repr) => CodeDefinition -> 
   Reader DrasilState (MS (repr (Method repr)))
 genCalcFunc cdef = do
   parms <- getCalcParams cdef
@@ -296,7 +296,7 @@ genCalcFunc cdef = do
 
 data CalcType = CalcAssign | CalcReturn deriving Eq
 
-genCalcBlock :: (RenderSym repr) => CalcType -> CodeDefinition -> Expr ->
+genCalcBlock :: (ProgramSym repr) => CalcType -> CodeDefinition -> Expr ->
   Reader DrasilState (GS (repr (Block repr)))
 genCalcBlock t v (Case c e) = genCaseBlock t v c e
 genCalcBlock t v e
@@ -304,7 +304,7 @@ genCalcBlock t v e
       convExpr e; l <- maybeLog vv; return $ multi $ assign vv ee : l}
     | otherwise        = block <$> liftS (returnState <$> convExpr e)
 
-genCaseBlock :: (RenderSym repr) => CalcType -> CodeDefinition -> Completeness 
+genCaseBlock :: (ProgramSym repr) => CalcType -> CodeDefinition -> Completeness 
   -> [(Expr,Relation)] -> Reader DrasilState (GS (repr (Block repr)))
 genCaseBlock _ _ _ [] = error $ "Case expression with no cases encountered" ++
   " in code generator"
@@ -320,11 +320,11 @@ genCaseBlock t v c cs = do
           "Undefined case encountered in function " ++ codeName v
 
 -- medium hacks --
-genModDef :: (RenderSym repr) => Mod -> 
+genModDef :: (ProgramSym repr) => Mod -> 
   Reader DrasilState (FS (repr (RenderFile repr)))
 genModDef (Mod n desc fs) = genModule n desc (Just $ mapM genFunc fs) Nothing
 
-genFunc :: (RenderSym repr) => Func -> Reader DrasilState (MS (repr (Method repr)))
+genFunc :: (ProgramSym repr) => Func -> Reader DrasilState (MS (repr (Method repr)))
 genFunc (FDef (FuncDef n desc parms o rd s)) = do
   g <- ask
   stmts <- mapM convStmt s
@@ -333,7 +333,7 @@ genFunc (FDef (FuncDef n desc parms o rd s)) = do
 genFunc (FData (FuncData n desc ddef)) = genDataFunc n desc ddef
 genFunc (FCD cd) = genCalcFunc cd
 
-convStmt :: (RenderSym repr) => FuncStmt -> Reader DrasilState (GS (repr (Statement repr)))
+convStmt :: (ProgramSym repr) => FuncStmt -> Reader DrasilState (GS (repr (Statement repr)))
 convStmt (FAsg v e) = do
   e' <- convExpr e
   v' <- mkVar v
@@ -379,7 +379,7 @@ convStmt (FAppend a b) = do
   b' <- convExpr b
   return $ valState $ listAppend a' b'
 
-genDataFunc :: (RenderSym repr) => Name -> String -> DataDesc -> 
+genDataFunc :: (ProgramSym repr) => Name -> String -> DataDesc -> 
   Reader DrasilState (MS (repr (Method repr)))
 genDataFunc nameTitle desc ddef = do
   let parms = getInputs ddef
@@ -387,7 +387,7 @@ genDataFunc nameTitle desc ddef = do
   publicFunc nameTitle void desc (codevar inFileName : parms) Nothing bod
 
 -- this is really ugly!!
-readData :: (RenderSym repr) => DataDesc -> Reader DrasilState
+readData :: (ProgramSym repr) => DataDesc -> Reader DrasilState
   [GS (repr (Block repr))]
 readData ddef = do
   inD <- mapM inData ddef
@@ -399,7 +399,7 @@ readData ddef = do
     openFileR var_infile v_filename :
     concat inD ++ [
     closeFile v_infile ]]
-  where inData :: (RenderSym repr) => Data -> Reader DrasilState [GS (repr (Statement repr))]
+  where inData :: (ProgramSym repr) => Data -> Reader DrasilState [GS (repr (Statement repr))]
         inData (Singleton v) = do
             vv <- mkVar v
             l <- maybeLog vv
@@ -425,7 +425,7 @@ readData ddef = do
                   ] ++ lnV)]
           return $ readLines ls ++ logs
         ---------------
-        lineData :: (RenderSym repr) => Maybe String -> LinePattern -> 
+        lineData :: (ProgramSym repr) => Maybe String -> LinePattern -> 
           Reader DrasilState [GS (repr (Statement repr))]
         lineData s p@(Straight _) = do
           vs <- getEntryVars s p
@@ -435,22 +435,22 @@ readData ddef = do
           return $ clearTemps s ds ++ stringListLists vs v_linetokens 
             : appendTemps s ds
         ---------------
-        clearTemps :: (RenderSym repr) => Maybe String -> [DataItem] -> 
+        clearTemps :: (ProgramSym repr) => Maybe String -> [DataItem] -> 
           [GS (repr (Statement repr))]
         clearTemps Nothing _ = []
         clearTemps (Just sfx) es = map (clearTemp sfx) es
         ---------------
-        clearTemp :: (RenderSym repr) => String -> DataItem -> 
+        clearTemp :: (ProgramSym repr) => String -> DataItem -> 
           GS (repr (Statement repr))
         clearTemp sfx v = listDecDef (var (codeName v ++ sfx) 
           (listInnerType $ convType $ codeType v)) []
         ---------------
-        appendTemps :: (RenderSym repr) => Maybe String -> [DataItem] -> 
+        appendTemps :: (ProgramSym repr) => Maybe String -> [DataItem] -> 
           [GS (repr (Statement repr))]
         appendTemps Nothing _ = []
         appendTemps (Just sfx) es = map (appendTemp sfx) es
         ---------------
-        appendTemp :: (RenderSym repr) => String -> DataItem -> 
+        appendTemp :: (ProgramSym repr) => String -> DataItem -> 
           GS (repr (Statement repr))
         appendTemp sfx v = valState $ listAppend 
           (valueOf $ var (codeName v) (convType $ codeType v)) 
@@ -458,9 +458,9 @@ readData ddef = do
         ---------------
         l_line, l_lines, l_linetokens, l_infile, l_i :: Label
         var_line, var_lines, var_linetokens, var_infile, var_i :: 
-          (RenderSym repr) => GS (repr (Variable repr))
+          (ProgramSym repr) => GS (repr (Variable repr))
         v_line, v_lines, v_linetokens, v_infile, v_i ::
-          (RenderSym repr) => GS (repr (Value repr))
+          (ProgramSym repr) => GS (repr (Value repr))
         l_line = "line"
         var_line = var l_line string
         v_line = valueOf var_line
@@ -477,12 +477,12 @@ readData ddef = do
         var_i = var l_i int
         v_i = valueOf var_i
 
-getEntryVars :: (RenderSym repr) => Maybe String -> LinePattern -> 
+getEntryVars :: (ProgramSym repr) => Maybe String -> LinePattern -> 
   Reader DrasilState [GS (repr (Variable repr))]
 getEntryVars s lp = mapM (maybe mkVar (\st v -> variable (codeName v ++ st) 
   (listInnerType $ convType $ codeType v)) s) (getPatternInputs lp)
 
-getEntryVarLogs :: (RenderSym repr) => LinePattern -> 
+getEntryVarLogs :: (ProgramSym repr) => LinePattern -> 
   Reader DrasilState [GS (repr (Statement repr))]
 getEntryVarLogs lp = do
   vs <- getEntryVars Nothing lp

--- a/code/drasil-code/Language/Drasil/Code/Imperative/Logging.hs
+++ b/code/drasil-code/Language/Drasil/Code/Imperative/Logging.hs
@@ -6,27 +6,27 @@ import Language.Drasil.Code.Imperative.State (DrasilState(..))
 import Language.Drasil.CodeSpec hiding (codeSpec, Mod(..))
 
 import GOOL.Drasil (Label, ProgramSym, BodySym(..), BlockSym(..), 
-  TypeSym(..), VariableSym(..), ValueSym(..), StatementSym(..), GS)
+  TypeSym(..), VariableSym(..), ValueSym(..), StatementSym(..), FS)
 
 import Data.Maybe (maybeToList)
 import Control.Applicative ((<$>))
 import Control.Monad.Reader (Reader, ask)
 
-maybeLog :: (ProgramSym repr) => GS (repr (Variable repr)) ->
-  Reader DrasilState [GS (repr (Statement repr))]
+maybeLog :: (ProgramSym repr) => FS (repr (Variable repr)) ->
+  Reader DrasilState [FS (repr (Statement repr))]
 maybeLog v = do
   g <- ask
   l <- chooseLogging (logKind g) v
   return $ maybeToList l
 
-chooseLogging :: (ProgramSym repr) => Logging -> (GS (repr (Variable repr)) -> 
-  Reader DrasilState (Maybe (GS (repr (Statement repr)))))
+chooseLogging :: (ProgramSym repr) => Logging -> (FS (repr (Variable repr)) -> 
+  Reader DrasilState (Maybe (FS (repr (Statement repr)))))
 chooseLogging LogVar v = Just <$> loggedVar v
 chooseLogging LogAll v = Just <$> loggedVar v
 chooseLogging _      _ = return Nothing
 
-loggedVar :: (ProgramSym repr) => GS (repr (Variable repr)) -> 
-  Reader DrasilState (GS (repr (Statement repr)))
+loggedVar :: (ProgramSym repr) => FS (repr (Variable repr)) -> 
+  Reader DrasilState (FS (repr (Statement repr)))
 loggedVar v = do
     g <- ask
     return $ multi [
@@ -37,8 +37,8 @@ loggedVar v = do
       printFileStrLn valLogFile (" in module " ++ currentModule g),
       closeFile valLogFile ]
 
-logBody :: (ProgramSym repr) => Label -> [GS (repr (Variable repr))] -> 
-  [GS (repr (Block repr))] -> Reader DrasilState (GS (repr (Body repr)))
+logBody :: (ProgramSym repr) => Label -> [FS (repr (Variable repr))] -> 
+  [FS (repr (Block repr))] -> Reader DrasilState (FS (repr (Body repr)))
 logBody n vars b = do
   g <- ask
   let loggedBody LogFunc = loggedMethod (logName g) n vars b
@@ -47,8 +47,8 @@ logBody n vars b = do
   return $ body $ loggedBody $ logKind g
 
 loggedMethod :: (ProgramSym repr) => Label -> Label -> 
-  [GS (repr (Variable repr))] -> [GS (repr (Block repr))] -> 
-  [GS (repr (Block repr))]
+  [FS (repr (Variable repr))] -> [FS (repr (Block repr))] -> 
+  [FS (repr (Block repr))]
 loggedMethod lName n vars b = block [
       varDec varLogFile,
       openFileA varLogFile (litString lName),
@@ -67,8 +67,8 @@ loggedMethod lName n vars b = block [
       printFile valLogFile (valueOf v), 
       printFileStrLn valLogFile ", "] ++ printInputs vs
 
-varLogFile :: (ProgramSym repr) => GS (repr (Variable repr))
+varLogFile :: (ProgramSym repr) => FS (repr (Variable repr))
 varLogFile = var "outfile" outfile
 
-valLogFile :: (ProgramSym repr) => GS (repr (Value repr))
+valLogFile :: (ProgramSym repr) => FS (repr (Value repr))
 valLogFile = valueOf varLogFile

--- a/code/drasil-code/Language/Drasil/Code/Imperative/Logging.hs
+++ b/code/drasil-code/Language/Drasil/Code/Imperative/Logging.hs
@@ -5,7 +5,7 @@ module Language.Drasil.Code.Imperative.Logging (
 import Language.Drasil.Code.Imperative.State (DrasilState(..))
 import Language.Drasil.CodeSpec hiding (codeSpec, Mod(..))
 
-import GOOL.Drasil (Label, RenderSym(..), BodySym(..), BlockSym(..), 
+import GOOL.Drasil (Label, RenderSym, BodySym(..), BlockSym(..), 
   TypeSym(..), VariableSym(..), ValueSym(..), StatementSym(..), GS)
 
 import Data.Maybe (maybeToList)

--- a/code/drasil-code/Language/Drasil/Code/Imperative/Logging.hs
+++ b/code/drasil-code/Language/Drasil/Code/Imperative/Logging.hs
@@ -5,27 +5,27 @@ module Language.Drasil.Code.Imperative.Logging (
 import Language.Drasil.Code.Imperative.State (DrasilState(..))
 import Language.Drasil.CodeSpec hiding (codeSpec, Mod(..))
 
-import GOOL.Drasil (Label, RenderSym, BodySym(..), BlockSym(..), 
+import GOOL.Drasil (Label, ProgramSym, BodySym(..), BlockSym(..), 
   TypeSym(..), VariableSym(..), ValueSym(..), StatementSym(..), GS)
 
 import Data.Maybe (maybeToList)
 import Control.Applicative ((<$>))
 import Control.Monad.Reader (Reader, ask)
 
-maybeLog :: (RenderSym repr) => GS (repr (Variable repr)) ->
+maybeLog :: (ProgramSym repr) => GS (repr (Variable repr)) ->
   Reader DrasilState [GS (repr (Statement repr))]
 maybeLog v = do
   g <- ask
   l <- chooseLogging (logKind g) v
   return $ maybeToList l
 
-chooseLogging :: (RenderSym repr) => Logging -> (GS (repr (Variable repr)) -> 
+chooseLogging :: (ProgramSym repr) => Logging -> (GS (repr (Variable repr)) -> 
   Reader DrasilState (Maybe (GS (repr (Statement repr)))))
 chooseLogging LogVar v = Just <$> loggedVar v
 chooseLogging LogAll v = Just <$> loggedVar v
 chooseLogging _      _ = return Nothing
 
-loggedVar :: (RenderSym repr) => GS (repr (Variable repr)) -> 
+loggedVar :: (ProgramSym repr) => GS (repr (Variable repr)) -> 
   Reader DrasilState (GS (repr (Statement repr)))
 loggedVar v = do
     g <- ask
@@ -37,7 +37,7 @@ loggedVar v = do
       printFileStrLn valLogFile (" in module " ++ currentModule g),
       closeFile valLogFile ]
 
-logBody :: (RenderSym repr) => Label -> [GS (repr (Variable repr))] -> 
+logBody :: (ProgramSym repr) => Label -> [GS (repr (Variable repr))] -> 
   [GS (repr (Block repr))] -> Reader DrasilState (GS (repr (Body repr)))
 logBody n vars b = do
   g <- ask
@@ -46,7 +46,7 @@ logBody n vars b = do
       loggedBody _       = b
   return $ body $ loggedBody $ logKind g
 
-loggedMethod :: (RenderSym repr) => Label -> Label -> 
+loggedMethod :: (ProgramSym repr) => Label -> Label -> 
   [GS (repr (Variable repr))] -> [GS (repr (Block repr))] -> 
   [GS (repr (Block repr))]
 loggedMethod lName n vars b = block [
@@ -67,8 +67,8 @@ loggedMethod lName n vars b = block [
       printFile valLogFile (valueOf v), 
       printFileStrLn valLogFile ", "] ++ printInputs vs
 
-varLogFile :: (RenderSym repr) => GS (repr (Variable repr))
+varLogFile :: (ProgramSym repr) => GS (repr (Variable repr))
 varLogFile = var "outfile" outfile
 
-valLogFile :: (RenderSym repr) => GS (repr (Value repr))
+valLogFile :: (ProgramSym repr) => GS (repr (Value repr))
 valLogFile = valueOf varLogFile

--- a/code/drasil-code/Language/Drasil/Code/Imperative/Modules.hs
+++ b/code/drasil-code/Language/Drasil/Code/Imperative/Modules.hs
@@ -32,7 +32,7 @@ import Language.Drasil.CodeSpec (AuxFile(..), CodeSpec(..), CodeSystInfo(..),
   ConstraintBehaviour(..), InputModule(..), Logging(..))
 import Language.Drasil.Printers (Linearity(Linear), exprDoc)
 
-import GOOL.Drasil (RenderSym(..), BodySym(..), BlockSym(..), 
+import GOOL.Drasil (RenderSym, FileSym(..), BodySym(..), BlockSym(..), 
   PermanenceSym(..), TypeSym(..), VariableSym(..), ValueSym(..), 
   BooleanExpression(..), StatementSym(..), ControlStatementSym(..), 
   ScopeSym(..), MethodSym(..), StateVarSym(..), ClassSym(..), ScopeTag(..), 

--- a/code/drasil-gool/GOOL/Drasil.hs
+++ b/code/drasil-gool/GOOL/Drasil.hs
@@ -1,5 +1,5 @@
 -- | re-export smart constructors for external code writing
-module GOOL.Drasil (Label, ProgramSym(..), RenderSym, FileSym(..), 
+module GOOL.Drasil (Label, ProgramSym(..), FileSym(..), 
   PermanenceSym(..), BodySym(..), BlockSym(..), ControlBlockSym(runStrategy), 
   listSlice, TypeSym(..), StatementSym(..), ControlStatementSym(..), 
   VariableSym(..), ValueSym(..), NumericExpression(..), BooleanExpression(..), 
@@ -11,10 +11,10 @@ module GOOL.Drasil (Label, ProgramSym(..), RenderSym, FileSym(..),
   GOOLState(..), GS, FS, MS, lensMStoGS, headers, sources, mainMod, 
   initialState,
   convType, onStateValue, onCodeList,
-  unPC, unJC, unCSC, unCPPC
+  unCI, unPC, unJC, unCSC, unCPPC
 ) where
 
-import GOOL.Drasil.Symantics (Label, ProgramSym(..), RenderSym, FileSym(..),
+import GOOL.Drasil.Symantics (Label, ProgramSym(..), FileSym(..),
   PermanenceSym(..), BodySym(..), BlockSym(..), ControlBlockSym(runStrategy), 
   listSlice, TypeSym(..), StatementSym(..), ControlStatementSym(..), 
   VariableSym(..), ValueSym(..), NumericExpression(..), BooleanExpression(..), 
@@ -31,6 +31,7 @@ import GOOL.Drasil.State (GOOLState(..), GS, FS, MS, lensMStoGS, headers,
 
 import GOOL.Drasil.Helpers (convType, onStateValue, onCodeList)
 
+import GOOL.Drasil.CodeInfo (unCI)
 import GOOL.Drasil.LanguageRenderer.JavaRenderer (unJC)
 import GOOL.Drasil.LanguageRenderer.PythonRenderer (unPC)
 import GOOL.Drasil.LanguageRenderer.CSharpRenderer (unCSC)

--- a/code/drasil-gool/GOOL/Drasil.hs
+++ b/code/drasil-gool/GOOL/Drasil.hs
@@ -1,8 +1,8 @@
 -- | re-export smart constructors for external code writing
-module GOOL.Drasil (Label, ProgramSym(..), RenderSym(..), PermanenceSym(..), 
-  BodySym(..), BlockSym(..), ControlBlockSym(runStrategy), listSlice, 
-  TypeSym(..), StatementSym(..), ControlStatementSym(..), VariableSym(..), 
-  ValueSym(..), NumericExpression(..), BooleanExpression(..), 
+module GOOL.Drasil (Label, ProgramSym(..), RenderSym, FileSym(..), 
+  PermanenceSym(..), BodySym(..), BlockSym(..), ControlBlockSym(runStrategy), 
+  listSlice, TypeSym(..), StatementSym(..), ControlStatementSym(..), 
+  VariableSym(..), ValueSym(..), NumericExpression(..), BooleanExpression(..), 
   ValueExpression(..), Selector(..), FunctionSym(..), SelectorFunction(..), 
   ScopeSym(..), ParameterSym(..), MethodSym(..), StateVarSym(..), ClassSym(..), 
   ModuleSym(..), BlockCommentSym(..), 
@@ -14,7 +14,7 @@ module GOOL.Drasil (Label, ProgramSym(..), RenderSym(..), PermanenceSym(..),
   unPC, unJC, unCSC, unCPPC
 ) where
 
-import GOOL.Drasil.Symantics (Label, ProgramSym(..), RenderSym(..), 
+import GOOL.Drasil.Symantics (Label, ProgramSym(..), RenderSym, FileSym(..),
   PermanenceSym(..), BodySym(..), BlockSym(..), ControlBlockSym(runStrategy), 
   listSlice, TypeSym(..), StatementSym(..), ControlStatementSym(..), 
   VariableSym(..), ValueSym(..), NumericExpression(..), BooleanExpression(..), 

--- a/code/drasil-gool/GOOL/Drasil.hs
+++ b/code/drasil-gool/GOOL/Drasil.hs
@@ -8,7 +8,7 @@ module GOOL.Drasil (Label, ProgramSym(..), FileSym(..),
   ModuleSym(..), BlockCommentSym(..), 
   ScopeTag(..), ProgData(..), FileData(..), ModData(..),
   CodeType(..),
-  GOOLState(..), GS, FS, MS, lensMStoGS, headers, sources, mainMod, 
+  GOOLState(..), GS, FS, MS, lensMStoFS, headers, sources, mainMod, 
   initialState,
   convType, onStateValue, onCodeList,
   unCI, unPC, unJC, unCSC, unCPPC
@@ -26,7 +26,7 @@ import GOOL.Drasil.Data (ScopeTag(..), FileData(..), ModData(..), ProgData(..))
 
 import GOOL.Drasil.CodeType (CodeType(..))
 
-import GOOL.Drasil.State (GOOLState(..), GS, FS, MS, lensMStoGS, headers, 
+import GOOL.Drasil.State (GOOLState(..), GS, FS, MS, lensMStoFS, headers, 
   sources, mainMod, initialState)
 
 import GOOL.Drasil.Helpers (convType, onStateValue, onCodeList)

--- a/code/drasil-gool/GOOL/Drasil/CodeInfo.hs
+++ b/code/drasil-gool/GOOL/Drasil/CodeInfo.hs
@@ -1,0 +1,394 @@
+module GOOL.Drasil.CodeInfo (CodeInfo(..)) where
+
+import GOOL.Drasil.Symantics (Label, ProgramSym(..), RenderSym, 
+  PermanenceSym(..), BodySym(..), BlockSym(..), ControlBlockSym(..), 
+  TypeSym(..), VariableSym(..), ValueSym(..), NumericExpression(..), 
+  BooleanExpression(..), ValueExpression(..), Selector(..), 
+  InternalSelector(..), objMethodCall, FunctionSym(..), SelectorFunction(..),
+  StatementSym(..), ControlStatementSym(..), ScopeSym(..), MethodTypeSym(..),
+  ParameterSym(..), MethodSym(..), StateVarSym(..), ClassSym(..), ModuleSym(..),
+  BlockCommentSym(..))
+
+newtype CodeInfo a = CI {unCI :: a} deriving Eq
+
+instance Functor CodeInfo where
+  fmap f (CI x) = CI (f x)
+
+instance Applicative CodeInfo where
+  pure = CI
+  (CI f) <*> (CI x) = CI (f x)
+
+instance Monad CodeInfo where
+  return = CI
+  CI x >>= f = f x
+
+instance ProgramSym CodeInfo where
+  type Program CodeInfo = GOOLState
+  prog _ _ = get
+
+instance RenderSym CodeInfo
+
+instance FileSym CodeInfo where
+  type RenderFile CodeInfo = FileData
+  fileDoc = G.fileDoc Header cppHdrExt top bottom
+  
+  docMod = G.docMod
+
+  commentedMod cmnt mod = on3StateValues (\m cmt mn -> if mn then m else 
+    on2CodeValues commentedModD m cmt) mod cmnt getCurrMain
+
+instance PermanenceSym CodeInfo where
+  type Permanence CodeInfo = BindData
+  static_ = toCode $ bd Static staticDocD
+  dynamic_ = toCode $ bd Dynamic dynamicDocD
+
+instance BodySym CodeInfo where
+  type Body CodeInfo = Doc
+  body _ = toState $ toCode empty
+  bodyStatements _ = toState $ toCode empty
+  oneLiner _ = toState $ toCode empty
+
+  addComments _ _ = toState $ toCode empty
+
+  bodyDoc = unCI
+
+instance BlockSym CodeInfo where
+  type Block CodeInfo = Doc
+  block _ = toState $ toCode empty
+
+instance TypeSym CodeInfo where
+  type Type CodeInfo = TypeData
+  bool = cppBoolType
+  int = G.int
+  float = G.double
+  char = G.char
+  string = G.string
+  infile = cppInfileType
+  outfile = cppOutfileType
+  listType = G.listType
+  listInnerType = G.listInnerType
+  obj = G.obj
+  enumType = G.enumType
+  iterator = cppIterType . listType dynamic_
+  void = G.void
+
+  getType = cType . unCI
+  getTypeString = typeString . unCI
+  getTypeDoc = typeDoc . unCI
+
+instance ControlBlockSym CodeInfo where
+  runStrategy _ _ _ _ = toState $ toCode empty
+
+  listSlice' _ _ _ _ _ = toState $ toCode empty
+
+instance VariableSym CodeInfo where
+  type Variable CodeInfo = VarData
+  var = G.var
+  staticVar = G.staticVar
+  const _ _ = mkStateVar "" void empty
+  extVar _ _ _ = mkStateVar "" void empty
+  self _ = mkStateVar "" void empty
+  enumVar _ _ = mkStateVar "" void empty
+  classVar _ _ = mkStateVar "" void empty
+  extClassVar _ _ = mkStateVar "" void empty
+  objVar _ _ = mkStateVar "" void empty
+  objVarSelf _ _ = mkStateVar "" void empty
+  listVar _ _ _ = mkStateVar "" void empty
+  listOf _ _ = mkStateVar "" void empty
+  iterVar _ _ = mkStateVar "" void empty
+
+  ($->) _ _ = mkStateVar "" void empty
+  
+  variableBind = varBind . unCI
+  variableName = varName . unCI
+  variableType = onCodeValue varType
+  variableDoc = varDoc . unCI
+
+instance ValueSym CodeInfo where
+  type Value CodeInfo = ValData
+  litTrue = G.litTrue
+  litFalse = G.litFalse
+  litChar = G.litChar
+  litFloat = G.litFloat
+  litInt = G.litInt
+  litString = G.litString
+
+  pi = mkStateVal float (text "M_PI")
+
+  ($:) = enumElement
+
+  valueOf = G.valueOf
+  arg n = G.arg (litInt $ n+1) argsList
+  enumElement en e = mkStateVal (enumType en) (text e)
+  
+  argsList = G.argsList "argv"
+
+  valueType = onCodeValue valType
+  valueDoc = valDoc . unCI
+
+instance NumericExpression CodeInfo where
+  (#~) _ = mkStateVal void empty
+  (#/^) _ = mkStateVal void empty
+  (#|) _ = mkStateVal void empty
+  (#+) _ _ = mkStateVal void empty
+  (#-) _ _ = mkStateVal void empty
+  (#*) _ _ = mkStateVal void empty
+  (#/) _ _ = mkStateVal void empty
+  (#%) _ _ = mkStateVal void empty
+  (#^) _ _ = mkStateVal void empty
+
+  log _ = mkStateVal void empty
+  ln _ = mkStateVal void empty
+  exp _ = mkStateVal void empty
+  sin _ = mkStateVal void empty
+  cos _ = mkStateVal void empty
+  tan _ = mkStateVal void empty
+  csc _ = mkStateVal void empty
+  sec _ = mkStateVal void empty
+  cot _ = mkStateVal void empty
+  arcsin _ = mkStateVal void empty
+  arccos _ = mkStateVal void empty
+  arctan _ = mkStateVal void empty
+  floor _ = mkStateVal void empty
+  ceil _ = mkStateVal void empty
+
+instance BooleanExpression CodeInfo where
+  (?!) _ = mkStateVal void empty
+  (?&&) _ _ = mkStateVal void empty
+  (?||) _ _ = mkStateVal void empty
+
+  (?<) _ _ = mkStateVal void empty
+  (?<=) _ _ = mkStateVal void empty
+  (?>) _ _ = mkStateVal void empty
+  (?>=) _ _ = mkStateVal void empty
+  (?==) _ _ = mkStateVal void empty
+  (?!=) _ _ = mkStateVal void empty
+    
+instance ValueExpression CodeInfo where
+  inlineIf _ _ _ = mkStateVal void empty
+  funcApp _ _ _ = mkStateVal void empty
+  selfFuncApp _ _ _ _ = mkStateVal void empty
+  extFuncApp _ _ _ _ = mkStateVal void empty
+  newObj _ _ = mkStateVal void empty
+  extNewObj _ _ _ = mkStateVal void empty
+
+  exists _ = mkStateVal void empty
+  notNull _ = mkStateVal void empty
+
+instance Selector CodeInfo where
+  objAccess _ _ = mkStateVal void empty
+  ($.) _ _ = mkStateVal void empty
+
+  selfAccess _ _ = mkStateVal void empty
+
+  listIndexExists _ _ = mkStateVal void empty
+  argExists _ = mkStateVal void empty
+  
+  indexOf _ _ = mkStateVal void empty
+  
+instance InternalSelector CodeInfo where
+  objMethodCall' _ _ _ _ = mkStateVal void empty
+  objMethodCallNoParams' _ _ _ = mkStateVal void empty
+
+instance FunctionSym CodeInfo where
+  type Function CodeInfo = FuncData
+  func _ _ _ = funcFromData empty void
+  
+  get _ _ = mkStateVal void empty
+  set _ _ _ = mkStateVal void empty
+
+  listSize _ = mkStateVal void empty
+  listAdd _ _ _ = mkStateVal void empty
+  listAppend _ _ = mkStateVal void empty
+
+  iterBegin _ = mkStateVal void empty
+  iterEnd _ = mkStateVal void empty
+
+instance SelectorFunction CodeInfo where
+  listAccess _ _ = mkStateVal void empty
+  listSet _ _ _ = mkStateVal void empty
+  at _ _ = mkStateVal void empty
+
+instance StatementSym CodeInfo where
+  type Statement CodeInfo = (Doc, Terminator)
+  assign _ _ = emptyState
+  assignToListIndex _ _ _ = emptyState
+  multiAssign _ _ = emptyState
+  (&=) _ _ = emptyState
+  (&-=) _ _ = emptyState
+  (&+=) _ _ = emptyState
+  (&++) _ = emptyState
+  (&~-) _ = emptyState
+
+  varDec = G.varDec static_ dynamic_
+  varDecDef = G.varDecDef
+  listDec _ _ = emptyState
+  listDecDef _ _ = emptyState
+  objDecDef _ _ = emptyState
+  objDecNew _ _ = emptyState
+  extObjDecNew _ _ _ = emptyState
+  objDecNewNoParams _ = emptyState
+  extObjDecNewNoParams _ _ = emptyState
+  constDecDef = G.constDecDef
+
+  print _ = emptyState
+  printLn _ = emptyState
+  printStr _ = emptyState
+  printStrLn _ = emptyState
+
+  printFile _ _ = emptyState
+  printFileLn _ _ = emptyState
+  printFileStr _ _ = emptyState
+  printFileStrLn _ _ = emptyState
+
+  getInput _ = emptyState
+  discardInput = emptyState
+  getFileInput _ _ = emptyState
+  discardFileInput _ = emptyState
+
+  openFileR _ _ = emptyState
+  openFileW _ _ = emptyState
+  openFileA _ _ = emptyState
+  closeFile _ = emptyState
+
+  getFileInputLine _ _ = emptyState
+  discardFileLine _ = emptyState
+  stringSplit _ _ _ = emptyState
+
+  stringListVals _ _ = emptyState
+  stringListLists _ _ = emptyState
+
+  break = emptyState
+  continue = emptyState
+
+  returnState _ = emptyState
+  multiReturn _ = emptyState
+
+  valState _ = emptyState
+
+  comment _ = emptyState
+
+  free _ = emptyState
+
+  throw _ = emptyState
+
+  initState _ _ = emptyState
+  changeState _ _ = emptyState
+
+  initObserverList _ _ = emptyState
+  addObserver _ = emptyState
+
+  inOutCall _ _ _ _ = emptyState
+  selfInOutCall _ _ _ _ _ = emptyState
+  extInOutCall _ _ _ _ _ = emptyState
+
+  multi _ = emptyState
+
+instance ControlStatementSym CodeInfo where
+  ifCond _ _ = emptyState
+  ifNoElse _ = emptyState
+  switch _ _ _ = emptyState
+  switchAsIf _ _ _ = emptyState
+
+  ifExists _ _ _ = emptyState
+
+  for _ _ _ _ = emptyState
+  forRange _ _ _ _ _ = emptyState
+  forEach _ _ _ = emptyState
+  while _ _ = emptyState
+
+  tryCatch _ _ = emptyState
+
+  checkState _ _ _ = emptyState
+
+  notifyObservers _ _ = emptyState
+
+  getFileInputAll _ _ = emptyState
+
+instance ScopeSym CodeInfo where
+  type Scope CodeInfo = (Doc, ScopeTag)
+  private = toCode (privateDocD, Priv)
+  public = toCode (publicDocD, Pub)
+
+instance MethodTypeSym CodeInfo where
+  type MethodType CodeInfo = TypeData
+  mType t = t
+  construct = G.construct
+
+instance ParameterSym CodeInfo where
+  type Parameter CodeInfo = ParamData
+  param = onStateValue (\v -> paramFromData v (paramDocD v)) . zoom lensMStoGS
+  pointerParam = onStateValue (\v -> paramFromData v (cppPointerParamDoc v)) .
+    zoom lensMStoGS
+
+instance MethodSym CodeInfo where
+  type Method CodeInfo = MethodData
+  method = G.method
+  getMethod c v = zoom lensMStoGS v >>= (\v' -> method (getterName $ 
+    variableName v') c public dynamic_ (toState $ variableType v') [] 
+    (toState $ toCode empty))
+  setMethod c v = zoom lensMStoGS v >>= (\v' -> method (setterName $ 
+    variableName v') c public dynamic_ void [param v] (toState $ toCode empty))
+  privMethod = G.privMethod
+  pubMethod = G.pubMethod
+  constructor n = G.constructor n n
+  destructor n vars = on1StateValue1List (\m vs -> toCode $ mthd Pub 
+    (emptyIfEmpty (vcat (map (statementDoc . onCodeValue destructSts) vs)) 
+    (methodDoc m))) (pubMethod ('~':n) n void [] (toState (toCode empty)) :: MS (CodeInfo (Method CodeInfo))) (map (zoom lensMStoGS) vars)
+
+  docMain = mainFunction
+
+  function = G.function
+  mainFunction _ = getPutReturn (setScope Pub) $ toCode $ mthd Pub empty
+
+  docFunc = G.docFunc
+
+  inOutMethod n c = cpphInOut (method n c)
+
+  docInOutMethod n c = G.docInOutFunc (inOutMethod n c)
+
+  inOutFunc n = cpphInOut (function n)
+
+  docInOutFunc n = G.docInOutFunc (inOutFunc n)
+
+instance StateVarSym CodeInfo where
+  type StateVar CodeInfo = StateVarData
+  stateVar s p v = on2StateValues (\dec -> on3CodeValues svd (onCodeValue snd s)
+    (toCode $ stateVarDocD empty (permDoc p) (statementDoc dec)))
+    (state $ varDec v) emptyState
+  stateVarDef _ s p vr vl = on2StateValues (onCodeValue . svd (snd $ unCI s))
+    (cpphStateVarDef empty p vr vl) emptyState
+  constVar _ s vr _ = on2StateValues (\v -> on3CodeValues svd (onCodeValue snd 
+    s) (on3CodeValues (constVarDocD empty) (bindDoc <$> static_) v 
+    endStatement)) vr emptyState
+  privMVar = G.privMVar
+  pubMVar = G.pubMVar
+  pubGVar = G.pubGVar
+
+instance ClassSym CodeInfo where
+  type Class CodeInfo = Doc
+  buildClass n p _ vs mths = on2StateLists (\vars funcs -> cpphClass n p vars 
+    funcs public private blockStart blockEnd endStatement) 
+    (map (zoom lensFStoGS) vs) fs
+    where fs = map (zoom lensFStoMS) $ mths ++ [destructor n vs]
+  enum n es _ = cpphEnum n (enumElementsDocD es enumsEqualInts) blockStart 
+    blockEnd endStatement
+  privClass = G.privClass
+  pubClass = G.pubClass
+
+  docClass = G.docClass
+
+  commentedClass = G.commentedClass
+
+instance ModuleSym CodeInfo where
+  type Module CodeInfo = ModData
+  buildModule n ls = G.buildModule n (map include ls)
+
+instance BlockCommentSym CodeInfo where
+  type BlockComment CodeInfo = Doc
+  blockComment lns = on2CodeValues (blockCmtDoc lns) blockCommentStart 
+    blockCommentEnd
+  docComment = onStateValue (\lns -> on2CodeValues (docCmtDoc lns) 
+    docCommentStart docCommentEnd)
+
+  blockCommentDoc = unCI

--- a/code/drasil-gool/GOOL/Drasil/CodeInfo.hs
+++ b/code/drasil-gool/GOOL/Drasil/CodeInfo.hs
@@ -393,7 +393,7 @@ instance ClassSym CodeInfo where
 
 instance ModuleSym CodeInfo where
   type Module CodeInfo = ()
-  buildModule n _ _ cs = do
+  buildModule n _ cs = do
     sequence_ cs 
     getPutReturn (updateClassMap n) (toCode ())
 

--- a/code/drasil-gool/GOOL/Drasil/Data.hs
+++ b/code/drasil-gool/GOOL/Drasil/Data.hs
@@ -45,13 +45,13 @@ data FuncData = FD {funcType :: TypeData, funcDoc :: Doc}
 fd :: TypeData -> Doc -> FuncData
 fd = FD
 
-data ModData = MD {name :: String, isMainMod :: Bool, modDoc :: Doc}
+data ModData = MD {name :: String, modDoc :: Doc}
 
-md :: String -> Bool -> Doc -> ModData
+md :: String -> Doc -> ModData
 md = MD
 
 updateModDoc :: (Doc -> Doc) -> ModData -> ModData
-updateModDoc f m = md (name m) (isMainMod m) (f $ modDoc m)
+updateModDoc f m = md (name m) (f $ modDoc m)
 
 newtype MethodData = MthD {mthdDoc :: Doc}
 

--- a/code/drasil-gool/GOOL/Drasil/Helpers.hs
+++ b/code/drasil-gool/GOOL/Drasil/Helpers.hs
@@ -10,7 +10,7 @@ import Utils.Drasil (blank)
 
 import qualified GOOL.Drasil.CodeType as C (CodeType(..))
 import qualified GOOL.Drasil.Symantics as S ( 
-  RenderSym, TypeSym(..), PermanenceSym(dynamic_))
+  TypeSym(..), PermanenceSym(dynamic_))
 import GOOL.Drasil.State (GS)
 
 import Prelude hiding ((<>))
@@ -110,7 +110,7 @@ getNestDegree :: Integer -> C.CodeType -> Integer
 getNestDegree n (C.List t) = getNestDegree (n+1) t
 getNestDegree n _ = n
 
-convType :: (S.RenderSym repr) => C.CodeType -> GS (repr (S.Type repr))
+convType :: (S.TypeSym repr) => C.CodeType -> GS (repr (S.Type repr))
 convType C.Boolean = S.bool
 convType C.Integer = S.int
 convType C.Float = S.float

--- a/code/drasil-gool/GOOL/Drasil/Helpers.hs
+++ b/code/drasil-gool/GOOL/Drasil/Helpers.hs
@@ -11,7 +11,7 @@ import Utils.Drasil (blank)
 import qualified GOOL.Drasil.CodeType as C (CodeType(..))
 import qualified GOOL.Drasil.Symantics as S ( 
   TypeSym(..), PermanenceSym(dynamic_))
-import GOOL.Drasil.State (GS)
+import GOOL.Drasil.State (FS)
 
 import Prelude hiding ((<>))
 import Control.Applicative (liftA2, liftA3)
@@ -110,7 +110,7 @@ getNestDegree :: Integer -> C.CodeType -> Integer
 getNestDegree n (C.List t) = getNestDegree (n+1) t
 getNestDegree n _ = n
 
-convType :: (S.TypeSym repr) => C.CodeType -> GS (repr (S.Type repr))
+convType :: (S.TypeSym repr) => C.CodeType -> FS (repr (S.Type repr))
 convType C.Boolean = S.bool
 convType C.Integer = S.int
 convType C.Float = S.float

--- a/code/drasil-gool/GOOL/Drasil/Helpers.hs
+++ b/code/drasil-gool/GOOL/Drasil/Helpers.hs
@@ -31,7 +31,7 @@ hicat :: Doc -> [Doc] -> Doc
 hicat c l = hcat $ intersperse c l
 
 vicat :: Doc -> [Doc] -> Doc
-vicat c = vcat . intersperse c
+vicat c = vcat . intersperse c . filter (not . isEmpty)
 
 vibcat :: [Doc] -> Doc
 vibcat = vicat blank

--- a/code/drasil-gool/GOOL/Drasil/Helpers.hs
+++ b/code/drasil-gool/GOOL/Drasil/Helpers.hs
@@ -10,7 +10,7 @@ import Utils.Drasil (blank)
 
 import qualified GOOL.Drasil.CodeType as C (CodeType(..))
 import qualified GOOL.Drasil.Symantics as S ( 
-  RenderSym(..), TypeSym(..), PermanenceSym(dynamic_))
+  RenderSym, TypeSym(..), PermanenceSym(dynamic_))
 import GOOL.Drasil.State (GS)
 
 import Prelude hiding ((<>))

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer.hs
@@ -35,7 +35,7 @@ module GOOL.Drasil.LanguageRenderer (
 import Utils.Drasil (blank, capitalize, indent, indentList, stringList)
 
 import GOOL.Drasil.CodeType (CodeType(..), isObject)
-import GOOL.Drasil.Symantics (Label, Library, RenderSym(..), BodySym(..), 
+import GOOL.Drasil.Symantics (Label, Library, RenderSym, BodySym(..), 
   PermanenceSym(..), InternalPerm(..), TypeSym(Type, getType, getTypeDoc), 
   UnaryOpSym(..), BinaryOpSym(..), InternalOp(..), VariableSym(..), 
   InternalVariable(..), ValueSym(..), NumericExpression(..), 
@@ -655,7 +655,7 @@ moduleDox desc as date m = (doxFile ++ m) :
 commentedModD :: FileData -> Doc -> FileData
 commentedModD m cmt = updateFileMod (updateModDoc (commentedItem cmt) (fileMod m)) m
 
-docFuncRepr :: (MethodSym repr) => String -> [String] -> [String] -> 
+docFuncRepr :: (RenderSym repr) => String -> [String] -> [String] -> 
   MS (repr (Method repr)) -> MS (repr (Method repr))
 docFuncRepr desc pComms rComms = commentedFunc (docComment $ onStateValue 
   (\ps -> functionDox desc (zip ps pComms) rComms) getParameters)

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer.hs
@@ -9,11 +9,11 @@ module GOOL.Drasil.LanguageRenderer (
   -- * Default Functions available for use in renderers
   packageDocD, fileDoc', moduleDocD, classDocD, enumDocD, enumElementsDocD, 
   enumElementsDocD', multiStateDocD, blockDocD, bodyDocD, outDoc, printDoc, 
-  printFileDocD, destructorError, paramDocD, methodDocD, methodListDocD, 
-  stateVarDocD, constVarDocD, stateVarListDocD, switchDocD, assignDocD, 
-  multiAssignDoc, plusEqualsDocD, plusPlusDocD, listDecDocD, statementDocD, 
-  getTermDoc, returnDocD, commentDocD, freeDocD, mkSt, mkStNoEnd, mkStateVal, 
-  mkVal, mkStateVar, mkVar, mkStaticVar, varDocD, extVarDocD, selfDocD, argDocD,
+  printFileDocD, destructorError, paramDocD, methodDocD, stateVarDocD, 
+  constVarDocD, stateVarListDocD, switchDocD, assignDocD, multiAssignDoc, 
+  plusEqualsDocD, plusPlusDocD, listDecDocD, statementDocD, getTermDoc, 
+  returnDocD, commentDocD, freeDocD, mkSt, mkStNoEnd, mkStateVal, mkVal, 
+  mkStateVar, mkVar, mkStaticVar, varDocD, extVarDocD, selfDocD, argDocD,
   enumElemDocD, classVarCheckStatic, classVarDocD, objVarDocD, funcAppDocD, 
   newObjDocD, newObjDocD', constDecDefDocD, funcDocD, castDocD, 
   listAccessFuncDocD, listSetFuncDocD, objAccessDocD, castObjDocD, includeD, 
@@ -81,10 +81,10 @@ packageDocD n end f = fileD (n ++ "/" ++ filePath f) (updateModDoc
   (fileMod f))
 
 fileDoc' :: Doc -> Doc -> Doc -> Doc
-fileDoc' t m b = vibcat (filter (not . isEmpty) [
+fileDoc' t m b = vibcat [
   t,
   m,
-  b])
+  b]
 
 -----------------------------------------------
 -- 'Default' functions used in the renderers --
@@ -200,10 +200,6 @@ methodDocD n s p t ps b = vcat [
     parens (parameterList ps) <+> lbrace,
   indent (bodyDoc b),
   rbrace]
-
-methodListDocD :: [Doc] -> Doc
-methodListDocD ms = vibcat methods
-  where methods = filter (not . isEmpty) ms
   
 destructorError :: String -> String
 destructorError l = "Destructors not allowed in " ++ l

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer.hs
@@ -13,23 +13,15 @@ module GOOL.Drasil.LanguageRenderer (
   stateVarDocD, constVarDocD, stateVarListDocD, switchDocD, assignDocD, 
   multiAssignDoc, plusEqualsDocD, plusPlusDocD, listDecDocD, listDecDefDocD, 
   statementDocD, getTermDoc, returnDocD, commentDocD, freeDocD, mkSt, mkStNoEnd,
-  unOpPrec, notOpDocD, notOpDocD', negateOpDocD, sqrtOpDocD, sqrtOpDocD', 
-  absOpDocD, absOpDocD', expOpDocD, expOpDocD', sinOpDocD, sinOpDocD', 
-  cosOpDocD, cosOpDocD', tanOpDocD, tanOpDocD', asinOpDocD, asinOpDocD', 
-  acosOpDocD, acosOpDocD', atanOpDocD, atanOpDocD', unOpDocD, unExpr, unExpr', 
-  typeUnExpr, powerPrec, multPrec, andPrec, orPrec, equalOpDocD, notEqualOpDocD,
-  greaterOpDocD, greaterEqualOpDocD, lessOpDocD, lessEqualOpDocD, plusOpDocD, 
-  minusOpDocD, multOpDocD, divideOpDocD, moduloOpDocD, powerOpDocD, andOpDocD, 
-  orOpDocD, binOpDocD, binOpDocD', binExpr, binExpr', typeBinExpr, mkStateVal, 
-  mkVal, mkStateVar, mkVar, mkStaticVar, varDocD, extVarDocD, selfDocD, argDocD,
-  enumElemDocD, classVarCheckStatic, classVarDocD, objVarDocD, funcAppDocD, 
-  newObjDocD, newObjDocD', constDecDefDocD, funcDocD, castDocD, 
-  listAccessFuncDocD, listSetFuncDocD, objAccessDocD, castObjDocD, includeD, 
-  breakDocD, continueDocD, staticDocD, dynamicDocD, bindingError, privateDocD, 
-  publicDocD, blockCmtDoc, docCmtDoc, commentedItem, addCommentsDocD, 
-  functionDox, classDox, moduleDox, commentedModD, docFuncRepr, valueList, 
-  variableList, parameterList, prependToBody, appendToBody, surroundBody, 
-  getterName, setterName, intValue, filterOutObjs
+  mkStateVal, mkVal, mkStateVar, mkVar, mkStaticVar, varDocD, extVarDocD, 
+  selfDocD, argDocD, enumElemDocD, classVarCheckStatic, classVarDocD, 
+  objVarDocD, funcAppDocD, newObjDocD, newObjDocD', constDecDefDocD, funcDocD, 
+  castDocD, listAccessFuncDocD, listSetFuncDocD, objAccessDocD, castObjDocD, 
+  includeD, breakDocD, continueDocD, staticDocD, dynamicDocD, bindingError, 
+  privateDocD, publicDocD, blockCmtDoc, docCmtDoc, commentedItem, 
+  addCommentsDocD, functionDox, classDox, moduleDox, commentedModD, docFuncRepr,
+  valueList, variableList, parameterList, prependToBody, appendToBody, 
+  surroundBody, getterName, setterName, intValue, filterOutObjs
 ) where
 
 import Utils.Drasil (blank, capitalize, indent, indentList, stringList)
@@ -37,25 +29,24 @@ import Utils.Drasil (blank, capitalize, indent, indentList, stringList)
 import GOOL.Drasil.CodeType (CodeType(..), isObject)
 import GOOL.Drasil.Symantics (Label, Library, RenderSym, BodySym(..), 
   PermanenceSym(..), InternalPerm(..), TypeSym(Type, getType, getTypeDoc), 
-  UnaryOpSym(..), BinaryOpSym(..), InternalOp(..), VariableSym(..), 
-  InternalVariable(..), ValueSym(..), NumericExpression(..), 
+  VariableSym(..), InternalVariable(..), ValueSym(..), NumericExpression(..), 
   BooleanExpression(..), InternalValue(..), FunctionSym(..), 
   SelectorFunction(..), InternalStatement(..), StatementSym(..), 
   ControlStatementSym(..), ScopeSym(..), InternalScope(..), ParameterSym(..), 
   InternalParam(..), MethodSym(..), InternalMethod(..), BlockCommentSym(..))
 import qualified GOOL.Drasil.Symantics as S (TypeSym(int))
 import GOOL.Drasil.Data (Terminator(..), FileData(..), fileD, updateFileMod, 
-  updateModDoc, OpData(..), od, TypeData(..), Binding(..), VarData(..))
+  updateModDoc, TypeData(..), Binding(..), VarData(..))
 import GOOL.Drasil.Helpers (hicat, vibcat, vmap, emptyIfEmpty, emptyIfNull,
-  onStateValue, on2StateValues, on3StateValues, getNestDegree)
+  onStateValue, getNestDegree)
 import GOOL.Drasil.State (GS, MS, initialState, getParameters)
 
 import Data.List (last)
 import Control.Monad.State (evalState)
 import Prelude hiding (break,print,last,mod,(<>))
 import Text.PrettyPrint.HughesPJ (Doc, text, empty, render, (<>), (<+>), ($+$),
-  space, brackets, parens, isEmpty, rbrace, lbrace, vcat, 
-  semi, equals, braces, int, comma, colon)
+  space, brackets, parens, isEmpty, rbrace, lbrace, vcat, semi, equals, braces, 
+  int, colon)
 
 ----------------------------------------
 -- Syntax common to several renderers --
@@ -305,190 +296,6 @@ mkSt = flip stateFromData Semi
 mkStNoEnd :: (RenderSym repr) => Doc -> repr (Statement repr)
 mkStNoEnd = flip stateFromData Empty
 
--- Unary Operators --
-
-unOpPrec :: String -> OpData
-unOpPrec = od 9 . text
-
-notOpDocD :: OpData
-notOpDocD = unOpPrec "!"
-
-notOpDocD' :: OpData
-notOpDocD' = unOpPrec "not"
-
-negateOpDocD :: OpData
-negateOpDocD = unOpPrec "-"
-
-sqrtOpDocD :: OpData
-sqrtOpDocD = unOpPrec "sqrt"
-
-sqrtOpDocD' :: OpData
-sqrtOpDocD' = unOpPrec "math.sqrt"
-
-absOpDocD :: OpData
-absOpDocD = unOpPrec "fabs"
-
-absOpDocD' :: OpData
-absOpDocD' = unOpPrec "math.fabs"
-
-expOpDocD :: OpData
-expOpDocD = unOpPrec "exp"
-
-expOpDocD' :: OpData
-expOpDocD' = unOpPrec "math.exp"
-
-sinOpDocD :: OpData
-sinOpDocD = unOpPrec "sin"
-
-sinOpDocD' :: OpData
-sinOpDocD' = unOpPrec "math.sin"
-
-cosOpDocD :: OpData
-cosOpDocD = unOpPrec "cos"
-
-cosOpDocD' :: OpData
-cosOpDocD' = unOpPrec "math.cos"
-
-tanOpDocD :: OpData
-tanOpDocD = unOpPrec "tan"
-
-tanOpDocD' :: OpData
-tanOpDocD' = unOpPrec "math.tan"
-
-asinOpDocD :: OpData
-asinOpDocD = unOpPrec "asin"
-
-asinOpDocD' :: OpData
-asinOpDocD' = unOpPrec "math.asin"
-
-acosOpDocD :: OpData
-acosOpDocD = unOpPrec "acos"
-
-acosOpDocD' :: OpData
-acosOpDocD' = unOpPrec "math.acos"
-
-atanOpDocD :: OpData
-atanOpDocD = unOpPrec "atan"
-
-atanOpDocD' :: OpData
-atanOpDocD' = unOpPrec "math.atan"
-
-unOpDocD :: Doc -> Doc -> Doc
-unOpDocD op v = op <> parens v
-
-unOpDocD' :: Doc -> Doc -> Doc
-unOpDocD' op v = op <> v
-
-unExpr :: (RenderSym repr) => repr (UnaryOp repr) -> GS (repr (Value repr)) -> 
-  GS (repr (Value repr))
-unExpr u = onStateValue (\v -> mkExpr (uOpPrec u) (valueType v) (unOpDocD 
-  (uOpDoc u) (valueDoc v)))
-
-unExpr' :: (RenderSym repr) => repr (UnaryOp repr) -> GS (repr (Value repr)) -> 
-  GS (repr (Value repr))
-unExpr' u = onStateValue (\v -> mkExpr (uOpPrec u) (valueType v) (unOpDocD' 
-  (uOpDoc u) (valueDoc v)))
-
-typeUnExpr :: (RenderSym repr) => repr (UnaryOp repr) -> GS (repr (Type repr))
-  -> GS (repr (Value repr)) -> GS (repr (Value repr))
-typeUnExpr u = on2StateValues (\t -> mkExpr (uOpPrec u) t . unOpDocD (uOpDoc u) 
-  . valueDoc)
-
--- Binary Operators --
-
-compEqualPrec :: String -> OpData
-compEqualPrec = od 4 . text
-
-compPrec :: String -> OpData
-compPrec = od 5 . text
-
-addPrec :: String -> OpData
-addPrec = od 6 . text
-
-multPrec :: String -> OpData
-multPrec = od 7 . text
-
-powerPrec :: String -> OpData
-powerPrec = od 8 . text
-
-andPrec :: String -> OpData 
-andPrec = od 3 . text
-
-orPrec :: String -> OpData
-orPrec = od 2 . text
-
-equalOpDocD :: OpData
-equalOpDocD = compEqualPrec "=="
-
-notEqualOpDocD :: OpData
-notEqualOpDocD = compEqualPrec "!="
-
-greaterOpDocD :: OpData
-greaterOpDocD = compPrec ">"
-
-greaterEqualOpDocD :: OpData
-greaterEqualOpDocD = compPrec ">="
-
-lessOpDocD :: OpData
-lessOpDocD = compPrec "<"
-
-lessEqualOpDocD :: OpData
-lessEqualOpDocD = compPrec "<="
-
-plusOpDocD :: OpData
-plusOpDocD = addPrec "+"
-
-minusOpDocD :: OpData
-minusOpDocD = addPrec "-"
-
-multOpDocD :: OpData
-multOpDocD = multPrec "*"
-
-divideOpDocD :: OpData
-divideOpDocD = multPrec "/"
-
-moduloOpDocD :: OpData
-moduloOpDocD = multPrec "%"
-
-powerOpDocD :: OpData
-powerOpDocD = powerPrec "pow"
-
-andOpDocD :: OpData
-andOpDocD = andPrec "&&"
-
-orOpDocD :: OpData
-orOpDocD = orPrec "||"
-
-binOpDocD :: Doc -> Doc -> Doc -> Doc
-binOpDocD op v1 v2 = v1 <+> op <+> v2
-
-binOpDocD' :: Doc -> Doc -> Doc -> Doc
-binOpDocD' op v1 v2 = op <> parens (v1 <> comma <+> v2)
-
-binExpr :: (RenderSym repr) => repr (BinaryOp repr) -> GS (repr (Value repr)) 
-  -> GS (repr (Value repr)) -> GS (repr (Value repr))
-binExpr b = on2StateValues (\v1 v2 -> mkExpr (bOpPrec b) (numType (valueType v1)
-  (valueType v2)) (binOpDocD (bOpDoc b) (exprParensL b v1 $ valueDoc v1) 
-  (exprParensR b v2 $ valueDoc v2)))
-
-binExpr' :: (RenderSym repr) => repr (BinaryOp repr) -> GS (repr (Value repr))
-  -> GS (repr (Value repr)) -> GS (repr (Value repr))
-binExpr' b = on2StateValues (\v1 v2 -> mkExpr 9 (numType (valueType v1) 
-  (valueType v2)) (binOpDocD' (bOpDoc b) (valueDoc v1) (valueDoc v2)))
-
-numType :: (RenderSym repr) => repr (Type repr) -> repr (Type repr) -> 
-  repr (Type repr)
-numType t1 t2 = numericType (getType t1) (getType t2)
-  where numericType Integer Integer = t1
-        numericType Float _ = t1
-        numericType _ Float = t2
-        numericType _ _ = error "Numeric types required for numeric expression"
-
-typeBinExpr :: (RenderSym repr) => repr (BinaryOp repr) -> GS (repr (Type repr))
-  -> GS (repr (Value repr)) -> GS (repr (Value repr)) -> GS (repr (Value repr))
-typeBinExpr b = on3StateValues (\t v1 v2 -> mkExpr (bOpPrec b) t (binOpDocD 
-  (bOpDoc b) (exprParensL b v1 $ valueDoc v1) (exprParensR b v2 $ valueDoc v2)))
-
 mkStateVal :: (RenderSym repr) => GS (repr (Type repr)) -> Doc -> 
   GS (repr (Value repr))
 mkStateVal t d = onStateValue (\tp -> valFromData Nothing tp d) t
@@ -507,10 +314,6 @@ mkVar = varFromData Dynamic
 mkStaticVar :: (RenderSym repr) => String -> GS (repr (Type repr)) -> Doc -> 
   GS (repr (Variable repr))
 mkStaticVar n t d = onStateValue (\tp -> varFromData Static n tp d) t
-
-mkExpr :: (RenderSym repr) => Int -> repr (Type repr) -> Doc -> 
-  repr (Value repr)
-mkExpr p = valFromData (Just p)
 
 -- Value Printers --
 
@@ -687,15 +490,6 @@ getterName s = "get" ++ capitalize s
 
 setterName :: String -> String
 setterName s = "set" ++ capitalize s
-
-exprParensL :: (RenderSym repr) => repr (BinaryOp repr) -> repr (Value repr) -> 
-  (Doc -> Doc)
-exprParensL o v = if maybe False (< bOpPrec o) (valuePrec v) then parens else id
-
-exprParensR :: (RenderSym repr) => repr (BinaryOp repr) -> repr (Value repr) -> 
-  (Doc -> Doc)
-exprParensR o v = if maybe False (<= bOpPrec o) (valuePrec v) then parens else 
-  id
 
 intValue :: (RenderSym repr) => GS (repr (Value repr)) -> GS (repr (Value repr))
 intValue i = i >>= intValue' . getType . valueType

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer.hs
@@ -11,17 +11,17 @@ module GOOL.Drasil.LanguageRenderer (
   enumElementsDocD', multiStateDocD, blockDocD, bodyDocD, outDoc, printDoc, 
   printFileDocD, destructorError, paramDocD, methodDocD, methodListDocD, 
   stateVarDocD, constVarDocD, stateVarListDocD, switchDocD, assignDocD, 
-  multiAssignDoc, plusEqualsDocD, plusPlusDocD, listDecDocD, listDecDefDocD, 
-  statementDocD, getTermDoc, returnDocD, commentDocD, freeDocD, mkSt, mkStNoEnd,
-  mkStateVal, mkVal, mkStateVar, mkVar, mkStaticVar, varDocD, extVarDocD, 
-  selfDocD, argDocD, enumElemDocD, classVarCheckStatic, classVarDocD, 
-  objVarDocD, funcAppDocD, newObjDocD, newObjDocD', constDecDefDocD, funcDocD, 
-  castDocD, listAccessFuncDocD, listSetFuncDocD, objAccessDocD, castObjDocD, 
-  includeD, breakDocD, continueDocD, staticDocD, dynamicDocD, bindingError, 
-  privateDocD, publicDocD, blockCmtDoc, docCmtDoc, commentedItem, 
-  addCommentsDocD, functionDox, classDox, moduleDox, commentedModD, docFuncRepr,
-  valueList, variableList, parameterList, prependToBody, appendToBody, 
-  surroundBody, getterName, setterName, intValue, filterOutObjs
+  multiAssignDoc, plusEqualsDocD, plusPlusDocD, listDecDocD, statementDocD, 
+  getTermDoc, returnDocD, commentDocD, freeDocD, mkSt, mkStNoEnd, mkStateVal, 
+  mkVal, mkStateVar, mkVar, mkStaticVar, varDocD, extVarDocD, selfDocD, argDocD,
+  enumElemDocD, classVarCheckStatic, classVarDocD, objVarDocD, funcAppDocD, 
+  newObjDocD, newObjDocD', constDecDefDocD, funcDocD, castDocD, 
+  listAccessFuncDocD, listSetFuncDocD, objAccessDocD, castObjDocD, includeD, 
+  breakDocD, continueDocD, staticDocD, dynamicDocD, bindingError, privateDocD, 
+  publicDocD, blockCmtDoc, docCmtDoc, commentedItem, addCommentsDocD, 
+  functionDox, classDox, moduleDox, commentedModD, docFuncRepr, valueList, 
+  variableList, parameterList, prependToBody, appendToBody, surroundBody, 
+  getterName, setterName, intValue, filterOutObjs
 ) where
 
 import Utils.Drasil (blank, capitalize, indent, indentList, stringList)
@@ -45,8 +45,8 @@ import Data.List (last)
 import Control.Monad.State (evalState)
 import Prelude hiding (break,print,last,mod,(<>))
 import Text.PrettyPrint.HughesPJ (Doc, text, empty, render, (<>), (<+>), ($+$),
-  space, brackets, parens, isEmpty, rbrace, lbrace, vcat, semi, equals, braces, 
-  int, colon)
+  space, brackets, parens, isEmpty, rbrace, lbrace, vcat, semi, equals, int, 
+  colon)
 
 ----------------------------------------
 -- Syntax common to several renderers --
@@ -263,11 +263,6 @@ listDecDocD :: (RenderSym repr) => repr (Variable repr) -> repr (Value repr) ->
   Doc
 listDecDocD v n = space <> equals <+> new <+> getTypeDoc (variableType v) 
   <> parens (valueDoc n)
-
-listDecDefDocD :: (RenderSym repr) => repr (Variable repr) -> 
-  [repr (Value repr)] -> Doc
-listDecDefDocD v vs = space <> equals <+> new <+> getTypeDoc (variableType v) 
-  <+> braces (valueList vs)
 
 constDecDefDocD :: (RenderSym repr) => repr (Variable repr) -> 
   repr (Value repr) -> Doc

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer/CSharpRenderer.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer/CSharpRenderer.hs
@@ -612,7 +612,7 @@ instance ModuleSym CSharpCode where
   
 instance InternalMod CSharpCode where
   moduleDoc = modDoc . unCSC
-  modFromData n = G.modFromData n (\d m -> toCode $ md n m d)
+  modFromData n = G.modFromData n (toCode . md n)
   updateModuleDoc f = onCodeValue (updateModDoc f)
 
 instance BlockCommentSym CSharpCode where

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer/CSharpRenderer.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer/CSharpRenderer.hs
@@ -608,7 +608,7 @@ instance InternalClass CSharpCode where
 
 instance ModuleSym CSharpCode where
   type Module CSharpCode = ModData
-  buildModule n _ = G.buildModule' n langImport
+  buildModule n = G.buildModule' n langImport
   
 instance InternalMod CSharpCode where
   moduleDoc = modDoc . unCSC

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer/CSharpRenderer.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer/CSharpRenderer.hs
@@ -116,7 +116,6 @@ instance KeywordSym CSharpCode where
   endStatement = toCode semi
   endStatementLoop = toCode empty
 
-  include _ = toCode $ text "using"
   inherit n = toCode $ colon <+> text n
 
   list _ = toCode $ text "List"

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer/CSharpRenderer.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer/CSharpRenderer.hs
@@ -24,20 +24,18 @@ import GOOL.Drasil.Symantics (Label, ProgramSym(..), RenderSym, FileSym(..),
   InternalClass(..), ModuleSym(..), InternalMod(..), BlockCommentSym(..))
 import GOOL.Drasil.LanguageRenderer (classDocD, multiStateDocD, bodyDocD, 
   outDoc, printFileDocD, destructorError, paramDocD, methodDocD, listDecDocD, 
-  listDecDefDocD, mkSt, breakDocD, continueDocD, unOpPrec, notOpDocD, 
-  negateOpDocD, unExpr, unExpr', typeUnExpr, powerPrec, equalOpDocD, 
-  notEqualOpDocD, greaterOpDocD, greaterEqualOpDocD, lessOpDocD, 
-  lessEqualOpDocD, plusOpDocD, minusOpDocD, multOpDocD, divideOpDocD, 
-  moduloOpDocD, andOpDocD, orOpDocD, binExpr, binExpr', typeBinExpr, mkStateVal,
-  mkVal, mkVar, classVarDocD, objVarDocD, newObjDocD, funcDocD, castDocD, 
-  listSetFuncDocD, castObjDocD, staticDocD, dynamicDocD, bindingError, 
-  privateDocD, publicDocD, dot, new, blockCmtStart, blockCmtEnd, docCmtStart, 
-  doubleSlash, elseIfLabel, inLabel, blockCmtDoc, docCmtDoc, commentedItem, 
-  addCommentsDocD, commentedModD, appendToBody, surroundBody, filterOutObjs)
+  listDecDefDocD, mkSt, breakDocD, continueDocD, mkStateVal, mkVal, mkVar, 
+  classVarDocD, objVarDocD, newObjDocD, funcDocD, castDocD, listSetFuncDocD, 
+  castObjDocD, staticDocD, dynamicDocD, bindingError, privateDocD, publicDocD, 
+  dot, new, blockCmtStart, blockCmtEnd, docCmtStart, doubleSlash, elseIfLabel, 
+  inLabel, blockCmtDoc, docCmtDoc, commentedItem, addCommentsDocD, 
+  commentedModD, appendToBody, surroundBody, filterOutObjs)
 import qualified GOOL.Drasil.LanguageRenderer.LanguagePolymorphic as G (
   oneLiner, block, bool, int, double, char, string, listType, listInnerType,
-  obj, enumType, void, runStrategy, listSlice, var, staticVar, extVar, 
-  self, enumVar, classVar, objVarSelf, listVar, listOf, iterVar, pi, litTrue, 
+  obj, enumType, void, runStrategy, listSlice, notOp, negateOp, equalOp, 
+  notEqualOp, greaterOp, greaterEqualOp, lessOp, lessEqualOp, plusOp, minusOp, 
+  multOp, divideOp, moduloOp, andOp, orOp, var, staticVar, extVar, self, 
+  enumVar, classVar, objVarSelf, listVar, listOf, iterVar, pi, litTrue, 
   litFalse, litChar, litFloat, litInt, litString, valueOf, arg, enumElement, 
   argsList, inlineIf, objAccess, objMethodCall, objMethodCallNoParams, 
   selfAccess, listIndexExists, indexOf, funcApp, selfFuncApp, extFuncApp, 
@@ -56,9 +54,10 @@ import qualified GOOL.Drasil.LanguageRenderer.LanguagePolymorphic as G (
   mainFunction, docFunc, docInOutFunc, intFunc, stateVar, stateVarDef, constVar,
   privMVar, pubMVar, pubGVar, buildClass, enum, privClass, pubClass, docClass, 
   commentedClass, buildModule', modFromData, fileDoc, docMod, fileFromData)
+import GOOL.Drasil.LanguageRenderer.LanguagePolymorphic (unOpPrec, unExpr, unExpr', typeUnExpr, powerPrec, binExpr, binExpr', typeBinExpr)
 import GOOL.Drasil.Data (Terminator(..), ScopeTag(..), FileType(..), 
   FileData(..), fileD, FuncData(..), fd, ModData(..), md, updateModDoc, 
-  MethodData(..), mthd, updateMthdDoc, OpData(..), ParamData(..), pd, 
+  MethodData(..), mthd, updateMthdDoc, OpData(..), od, ParamData(..), pd, 
   updateParamDoc, ProgData(..), progD, TypeData(..), td, ValData(..), vd, 
   updateValDoc, Binding(..), VarData(..), vard)
 import GOOL.Drasil.Helpers (toCode, toState, onCodeValue, onStateValue, 
@@ -195,44 +194,47 @@ instance ControlBlockSym CSharpCode where
 
 instance UnaryOpSym CSharpCode where
   type UnaryOp CSharpCode = OpData
-  notOp = toCode notOpDocD
-  negateOp = toCode negateOpDocD
-  sqrtOp = toCode $ unOpPrec "Math.Sqrt"
-  absOp = toCode $ unOpPrec "Math.Abs"
-  logOp = toCode $ unOpPrec "Math.Log10"
-  lnOp = toCode $ unOpPrec "Math.Log"
-  expOp = toCode $ unOpPrec "Math.Exp"
-  sinOp = toCode $ unOpPrec "Math.Sin"
-  cosOp = toCode $ unOpPrec "Math.Cos"
-  tanOp = toCode $ unOpPrec "Math.Tan"
-  asinOp = toCode $ unOpPrec "Math.Asin"
-  acosOp = toCode $ unOpPrec "Math.Acos"
-  atanOp = toCode $ unOpPrec "Math.Atan"
-  floorOp = toCode $ unOpPrec "Math.Floor"
-  ceilOp = toCode $ unOpPrec "Math.Ceiling"
+  notOp = G.notOp
+  negateOp = G.negateOp
+  sqrtOp = addSystemImport $ unOpPrec "Math.Sqrt"
+  absOp = addSystemImport $ unOpPrec "Math.Abs"
+  logOp = addSystemImport $ unOpPrec "Math.Log10"
+  lnOp = addSystemImport $ unOpPrec "Math.Log"
+  expOp = addSystemImport $ unOpPrec "Math.Exp"
+  sinOp = addSystemImport $ unOpPrec "Math.Sin"
+  cosOp = addSystemImport $ unOpPrec "Math.Cos"
+  tanOp = addSystemImport $ unOpPrec "Math.Tan"
+  asinOp = addSystemImport $ unOpPrec "Math.Asin"
+  acosOp = addSystemImport $ unOpPrec "Math.Acos"
+  atanOp = addSystemImport $ unOpPrec "Math.Atan"
+  floorOp = addSystemImport $ unOpPrec "Math.Floor"
+  ceilOp = addSystemImport $ unOpPrec "Math.Ceiling"
 
 instance BinaryOpSym CSharpCode where
   type BinaryOp CSharpCode = OpData
-  equalOp = toCode equalOpDocD
-  notEqualOp = toCode notEqualOpDocD
-  greaterOp = toCode greaterOpDocD
-  greaterEqualOp = toCode greaterEqualOpDocD
-  lessOp = toCode lessOpDocD
-  lessEqualOp = toCode lessEqualOpDocD
-  plusOp = toCode plusOpDocD
-  minusOp = toCode minusOpDocD
-  multOp = toCode multOpDocD
-  divideOp = toCode divideOpDocD
-  powerOp = toCode $ powerPrec "Math.Pow"
-  moduloOp = toCode moduloOpDocD
-  andOp = toCode andOpDocD
-  orOp = toCode orOpDocD
+  equalOp = G.equalOp
+  notEqualOp = G.notEqualOp
+  greaterOp = G.greaterOp
+  greaterEqualOp = G.greaterEqualOp
+  lessOp = G.lessOp
+  lessEqualOp = G.lessEqualOp
+  plusOp = G.plusOp
+  minusOp = G.minusOp
+  multOp = G.multOp
+  divideOp = G.divideOp
+  powerOp = addSystemImport $ powerPrec "Math.Pow"
+  moduloOp = G.moduloOp
+  andOp = G.andOp
+  orOp = G.orOp
 
 instance InternalOp CSharpCode where
   uOpDoc = opDoc . unCSC
   bOpDoc = opDoc . unCSC
   uOpPrec = opPrec . unCSC
   bOpPrec = opPrec . unCSC
+  
+  uOpFromData p d = toState $ toCode $ od p d
+  bOpFromData p d = toState $ toCode $ od p d
 
 instance VariableSym CSharpCode where
   type Variable CSharpCode = VarData
@@ -614,12 +616,15 @@ instance BlockCommentSym CSharpCode where
 
   blockCommentDoc = unCSC
 
+addSystemImport :: GS a -> GS a
+addSystemImport = (>>) $ modify (addLangImport "System")
+
 csName :: String
 csName = "C#"
 
 cstop :: Doc -> Doc -> Doc
 cstop end inc = vcat [
-  inc <+> text "System" <> end, -- Console, Math
+  inc <+> text "System" <> end, -- Console
   inc <+> text "System.IO" <> end,
   inc <+> text "System.Collections.Generic" <> end]
 

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer/CSharpRenderer.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer/CSharpRenderer.hs
@@ -10,7 +10,7 @@ module GOOL.Drasil.LanguageRenderer.CSharpRenderer (
 import Utils.Drasil (indent)
 
 import GOOL.Drasil.CodeType (CodeType(..))
-import GOOL.Drasil.Symantics (Label, ProgramSym(..), RenderSym(..), 
+import GOOL.Drasil.Symantics (Label, ProgramSym(..), RenderSym, FileSym(..),
   InternalFile(..), KeywordSym(..), PermanenceSym(..), InternalPerm(..), 
   BodySym(..), BlockSym(..), InternalBlock(..), ControlBlockSym(..), 
   TypeSym(..), InternalType(..), UnaryOpSym(..), BinaryOpSym(..), 
@@ -95,7 +95,9 @@ instance ProgramSym CSharpCode where
   type Program CSharpCode = ProgData
   prog n = onStateList (onCodeList (progD n)) . map (zoom lensGStoFS)
 
-instance RenderSym CSharpCode where
+instance RenderSym CSharpCode
+
+instance FileSym CSharpCode where
   type RenderFile CSharpCode = FileData
   fileDoc = G.fileDoc Combined csExt top bottom
 

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer/CSharpRenderer.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer/CSharpRenderer.hs
@@ -174,7 +174,7 @@ instance InternalBlock CSharpCode where
 
 instance TypeSym CSharpCode where
   type Type CSharpCode = TypeData
-  bool = G.bool
+  bool = addSystemImport G.bool
   int = G.int
   float = G.double
   char = G.char
@@ -673,14 +673,16 @@ csFileInput = onStateValue (\f -> mkVal (valueType f) (valueDoc f <> dot <>
 
 csInput :: (RenderSym repr) => FS (repr (Type repr)) -> FS (repr (Value repr)) 
   -> FS (repr (Value repr))
-csInput = on2StateValues (\t inFn -> mkVal t $ text (csInput' (getType t)) <> 
-  parens (valueDoc inFn))
+csInput tp inF = tp >>= (\t -> csInputImport (getType t) $ onStateValue (\inFn 
+  -> mkVal t $ text (csInput' (getType t)) <> parens (valueDoc inFn)) inF)
   where csInput' Integer = "Int32.Parse"
         csInput' Float = "Double.Parse"
         csInput' Boolean = "Boolean.Parse"
         csInput' String = ""
         csInput' Char = "Char.Parse"
         csInput' _ = error "Attempt to read value of unreadable type"
+        csInputImport t = if t `elem` [Integer, Float, Boolean, Char] then 
+          addSystemImport else id
 
 csOpenFileR :: (RenderSym repr) => FS (repr (Value repr)) -> 
   FS (repr (Type repr)) -> FS (repr (Value repr))

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer/CppRenderer.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer/CppRenderer.hs
@@ -11,7 +11,7 @@ module GOOL.Drasil.LanguageRenderer.CppRenderer (
 import Utils.Drasil (blank, indent, indentList)
 
 import GOOL.Drasil.CodeType (CodeType(..))
-import GOOL.Drasil.Symantics (Label, ProgramSym(..), RenderSym(..), 
+import GOOL.Drasil.Symantics (Label, ProgramSym(..), RenderSym, FileSym(..),
   InternalFile(..), KeywordSym(..), PermanenceSym(..), InternalPerm(..), 
   BodySym(..), BlockSym(..), InternalBlock(..), ControlBlockSym(..), 
   TypeSym(..), InternalType(..), UnaryOpSym(..), BinaryOpSym(..), 
@@ -104,7 +104,9 @@ instance (Pair p) => ProgramSym (p CppSrcCode CppHdrCode) where
     p1 <- prog n $ map toState sm ++ map toState fm
     toState $ pair p1 (toCode emptyProg)
 
-instance (Pair p) => RenderSym (p CppSrcCode CppHdrCode) where
+instance (Pair p) => RenderSym (p CppSrcCode CppHdrCode)
+
+instance (Pair p) => FileSym (p CppSrcCode CppHdrCode) where
   type RenderFile (p CppSrcCode CppHdrCode) = FileData
   fileDoc = pair1 fileDoc fileDoc
 
@@ -894,8 +896,10 @@ instance Monad CppSrcCode where
 instance ProgramSym CppSrcCode where
   type Program CppSrcCode = ProgData
   prog n = onStateList (onCodeList (progD n)) . map (zoom lensGStoFS)
+
+instance RenderSym CppSrcCode
   
-instance RenderSym CppSrcCode where
+instance FileSym CppSrcCode where
   type RenderFile CppSrcCode = FileData
   fileDoc = G.fileDoc Source cppSrcExt top bottom
 
@@ -1478,7 +1482,9 @@ instance Monad CppHdrCode where
   return = CPPHC
   CPPHC x >>= f = f x
 
-instance RenderSym CppHdrCode where
+instance RenderSym CppHdrCode
+
+instance FileSym CppHdrCode where
   type RenderFile CppHdrCode = FileData
   fileDoc = G.fileDoc Header cppHdrExt top bottom
   

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer/CppRenderer.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer/CppRenderer.hs
@@ -1049,7 +1049,7 @@ instance BinaryOpSym CppSrcCode where
   minusOp = G.minusOp
   multOp = G.multOp
   divideOp = G.divideOp
-  powerOp = addMathHImport $ G.powerOp
+  powerOp = addMathHImport G.powerOp
   moduloOp = G.moduloOp
   andOp = G.andOp
   orOp = G.orOp

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer/CppRenderer.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer/CppRenderer.hs
@@ -66,9 +66,10 @@ import GOOL.Drasil.Helpers (angles, doubleQuotedText, emptyIfEmpty,
   toCode, toState, onCodeValue, onStateValue, on2CodeValues, 
   on2StateValues, on3CodeValues, on3StateValues, on4CodeValues, onCodeList, 
   onStateList, on2StateLists, on1CodeValue1List, on1StateValue1List)
-import GOOL.Drasil.State (GS, MS, FS, lensGStoFS, lensFStoGS, lensFStoMS, 
-  lensMStoGS, getPutReturn, addLangImport, addModuleImport, addHeaderLangImport,
-  addDefine, setCurrMain, getCurrMain, setScope, getScope, setCurrMainFunc, getCurrMainFunc)
+import GOOL.Drasil.State (FS, MS, lensGStoFS, lensFStoMS, lensMStoFS, 
+  getPutReturn, addLangImport, addModuleImport, addHeaderLangImport, addDefine, 
+  setCurrMain, getCurrMain, setScope, getScope, setCurrMainFunc, 
+  getCurrMainFunc)
 
 import Prelude hiding (break,print,(<>),sin,cos,tan,floor,pi,const,log,exp,mod)
 import Control.Lens.Zoom (zoom)
@@ -575,8 +576,8 @@ instance (Pair p) => MethodTypeSym (p CppSrcCode CppHdrCode) where
 
 instance (Pair p) => ParameterSym (p CppSrcCode CppHdrCode) where
   type Parameter (p CppSrcCode CppHdrCode) = ParamData
-  param = pair1 param param . zoom lensMStoGS
-  pointerParam = pair1 pointerParam pointerParam . zoom lensMStoGS 
+  param = pair1 param param . zoom lensMStoFS
+  pointerParam = pair1 pointerParam pointerParam . zoom lensMStoFS 
 
 instance (Pair p) => InternalParam (p CppSrcCode CppHdrCode) where
   parameterName p = parameterName $ pfst p
@@ -588,60 +589,60 @@ instance (Pair p) => MethodSym (p CppSrcCode CppHdrCode) where
   type Method (p CppSrcCode CppHdrCode) = MethodData
   method n c s p t ps = pairValListVal
     (method n c (pfst s) (pfst p)) (method n c (psnd s) (psnd p))
-    (zoom lensMStoGS t) ps . zoom lensMStoGS
-  getMethod c = pair1 (getMethod c) (getMethod c) . zoom lensMStoGS
-  setMethod c = pair1 (setMethod c) (setMethod c) . zoom lensMStoGS
+    (zoom lensMStoFS t) ps . zoom lensMStoFS
+  getMethod c = pair1 (getMethod c) (getMethod c) . zoom lensMStoFS
+  setMethod c = pair1 (setMethod c) (setMethod c) . zoom lensMStoFS
   privMethod n c t ps = pairValListVal (privMethod n c) (privMethod n c)
-    (zoom lensMStoGS t) ps . zoom lensMStoGS
+    (zoom lensMStoFS t) ps . zoom lensMStoFS
   pubMethod n c t ps = pairValListVal (pubMethod n c) (pubMethod n c)
-    (zoom lensMStoGS t) ps . zoom lensMStoGS
+    (zoom lensMStoFS t) ps . zoom lensMStoFS
   constructor n ps = pair1List1Val (constructor n) (constructor n) ps . 
-    zoom lensMStoGS
-  destructor n = pair1List (destructor n) (destructor n) . map (zoom lensMStoGS)
+    zoom lensMStoFS
+  destructor n = pair1List (destructor n) (destructor n) . map (zoom lensMStoFS)
 
-  docMain = pair1 docMain docMain . zoom lensMStoGS
+  docMain = pair1 docMain docMain . zoom lensMStoFS
 
   function n s p t ps = pairValListVal 
     (function n (pfst s) (pfst p)) (function n (psnd s) (psnd p))
-    (zoom lensMStoGS t) ps . zoom lensMStoGS 
-  mainFunction = pair1 mainFunction mainFunction . zoom lensMStoGS
+    (zoom lensMStoFS t) ps . zoom lensMStoFS 
+  mainFunction = pair1 mainFunction mainFunction . zoom lensMStoFS
 
   docFunc desc pComms rComm = pair1 (docFunc desc pComms rComm) 
     (docFunc desc pComms rComm)
 
   inOutMethod n c s p ins outs both = pair3Lists1Val 
     (inOutMethod n c (pfst s) (pfst p)) (inOutMethod n c (psnd s) (psnd p)) 
-    (map (zoom lensMStoGS) ins) (map (zoom lensMStoGS) outs) 
-    (map (zoom lensMStoGS) both) . zoom lensMStoGS
+    (map (zoom lensMStoFS) ins) (map (zoom lensMStoFS) outs) 
+    (map (zoom lensMStoFS) both) . zoom lensMStoFS
 
   docInOutMethod n c s p desc is os bs = pair3Lists1Val
     (\ins outs both -> docInOutMethod n c (pfst s) (pfst p) desc (zip (map fst 
       is) ins) (zip (map fst os) outs) (zip (map fst bs) both))
     (\ins outs both -> docInOutMethod n c (psnd s) (psnd p) desc (zip (map fst 
       is) ins) (zip (map fst os) outs) (zip (map fst bs) both))
-    (map (zoom lensMStoGS . snd) is) (map (zoom lensMStoGS . snd) os) 
-    (map (zoom lensMStoGS . snd) bs) . zoom lensMStoGS
+    (map (zoom lensMStoFS . snd) is) (map (zoom lensMStoFS . snd) os) 
+    (map (zoom lensMStoFS . snd) bs) . zoom lensMStoFS
 
   inOutFunc n s p ins outs both = pair3Lists1Val
     (inOutFunc n (pfst s) (pfst p)) (inOutFunc n (psnd s) (psnd p))
-    (map (zoom lensMStoGS) ins) (map (zoom lensMStoGS) outs) 
-    (map (zoom lensMStoGS) both) . zoom lensMStoGS
+    (map (zoom lensMStoFS) ins) (map (zoom lensMStoFS) outs) 
+    (map (zoom lensMStoFS) both) . zoom lensMStoFS
 
   docInOutFunc n s p desc is os bs = pair3Lists1Val 
     (\ins outs both -> docInOutFunc n (pfst s) (pfst p) desc (zip (map fst 
       is) ins) (zip (map fst os) outs) (zip (map fst bs) both))
     (\ins outs both -> docInOutFunc n (psnd s) (psnd p) desc (zip (map fst 
       is) ins) (zip (map fst os) outs) (zip (map fst bs) both))
-    (map (zoom lensMStoGS . snd) is) (map (zoom lensMStoGS . snd) os) 
-    (map (zoom lensMStoGS . snd) bs) . zoom lensMStoGS
+    (map (zoom lensMStoFS . snd) is) (map (zoom lensMStoFS . snd) os) 
+    (map (zoom lensMStoFS . snd) bs) . zoom lensMStoFS
   
 instance (Pair p) => InternalMethod (p CppSrcCode CppHdrCode) where
   intMethod m n c s p t ps = pairValListVal
     (intMethod m n c (pfst s) (pfst p)) (intMethod m n c (psnd s) (psnd p))
-    (zoom lensMStoGS t) ps . zoom lensMStoGS
+    (zoom lensMStoFS t) ps . zoom lensMStoFS
   intFunc m n s p t ps = pairValListVal
     (intFunc m n (pfst s) (pfst p)) (intFunc m n (psnd s) (psnd p))
-    (zoom lensMStoGS t) ps . zoom lensMStoGS
+    (zoom lensMStoFS t) ps . zoom lensMStoFS
   commentedFunc = pair2 commentedFunc commentedFunc
     
   methodDoc m = methodDoc $ pfst m
@@ -668,12 +669,12 @@ instance (Pair p) => ClassSym (p CppSrcCode CppHdrCode) where
   buildClass n p s vs fs = pair2Lists 
     (buildClass n p (pfst s)) 
     (buildClass n p (psnd s)) 
-    (map (zoom lensFStoGS) vs) (map (zoom lensFStoMS) fs)
+    vs (map (zoom lensFStoMS) fs)
   enum l ls s = on2StateValues pair (enum l ls $ pfst s) (enum l ls $ psnd s)
   privClass n p vs fs = pair2Lists (privClass n p) (privClass n p)
-    (map (zoom lensFStoGS) vs) (map (zoom lensFStoMS) fs)
+    vs (map (zoom lensFStoMS) fs)
   pubClass n p vs fs = pair2Lists (pubClass n p) (pubClass n p)
-    (map (zoom lensFStoGS) vs) (map (zoom lensFStoMS) fs)
+    vs (map (zoom lensFStoMS) fs)
 
   docClass d = pair1 (docClass d) (docClass d)
 
@@ -1428,11 +1429,11 @@ instance InternalMethod CppSrcCode where
   intMethod m n c s _ t ps b = modify (setScope (snd $ unCPPSC s) . if m then 
     setCurrMain else id) >> on3StateValues (\tp pms bod -> methodFromData (snd 
     $ unCPPSC s) $ cppsMethod n c tp pms bod blockStart blockEnd) (zoom 
-    lensMStoGS t) (sequence ps) (zoom lensMStoGS b)
+    lensMStoFS t) (sequence ps) (zoom lensMStoFS b)
   intFunc m n s _ t ps b = modify (setScope (snd $ unCPPSC s) . if m then 
     setCurrMainFunc m . setCurrMain else id) >> on3StateValues (\tp pms bod -> 
     methodFromData (snd $ unCPPSC s) $ cppsFunction n tp pms bod blockStart 
-    blockEnd) (zoom lensMStoGS t) (sequence ps) (zoom lensMStoGS b)
+    blockEnd) (zoom lensMStoFS t) (sequence ps) (zoom lensMStoFS b)
   commentedFunc = cppCommentedFunc Source
  
   methodDoc = mthdDoc . unCPPSC
@@ -1458,8 +1459,8 @@ instance InternalStateVar CppSrcCode where
 
 instance ClassSym CppSrcCode where
   type Class CppSrcCode = Doc
-  buildClass n _ _ vs fs = on2StateLists cppsClass (map (zoom 
-    lensFStoGS) vs) (map (zoom lensFStoMS) $ fs ++ [destructor n vs])
+  buildClass n _ _ vs fs = on2StateLists cppsClass vs (map (zoom lensFStoMS) $ 
+    fs ++ [destructor n vs])
   enum _ _ _ = toState $ toCode empty
   privClass = G.privClass
   pubClass = G.pubClass
@@ -1946,9 +1947,9 @@ instance MethodTypeSym CppHdrCode where
 
 instance ParameterSym CppHdrCode where
   type Parameter CppHdrCode = ParamData
-  param = onStateValue (\v -> paramFromData v (paramDocD v)) . zoom lensMStoGS
+  param = onStateValue (\v -> paramFromData v (paramDocD v)) . zoom lensMStoFS
   pointerParam = onStateValue (\v -> paramFromData v (cppPointerParamDoc v)) .
-    zoom lensMStoGS
+    zoom lensMStoFS
 
 instance InternalParam CppHdrCode where
   parameterName = variableName . onCodeValue paramVar
@@ -1959,17 +1960,17 @@ instance InternalParam CppHdrCode where
 instance MethodSym CppHdrCode where
   type Method CppHdrCode = MethodData
   method = G.method
-  getMethod c v = zoom lensMStoGS v >>= (\v' -> method (getterName $ 
+  getMethod c v = zoom lensMStoFS v >>= (\v' -> method (getterName $ 
     variableName v') c public dynamic_ (toState $ variableType v') [] 
     (toState $ toCode empty))
-  setMethod c v = zoom lensMStoGS v >>= (\v' -> method (setterName $ 
+  setMethod c v = zoom lensMStoFS v >>= (\v' -> method (setterName $ 
     variableName v') c public dynamic_ void [param v] (toState $ toCode empty))
   privMethod = G.privMethod
   pubMethod = G.pubMethod
   constructor n = G.constructor n n
   destructor n vars = on1StateValue1List (\m vs -> toCode $ mthd Pub 
     (emptyIfEmpty (vcat (map (statementDoc . onCodeValue destructSts) vs)) 
-    (methodDoc m))) (pubMethod ('~':n) n void [] (toState (toCode empty)) :: MS (CppHdrCode (Method CppHdrCode))) (map (zoom lensMStoGS) vars)
+    (methodDoc m))) (pubMethod ('~':n) n void [] (toState (toCode empty)) :: MS (CppHdrCode (Method CppHdrCode))) (map (zoom lensMStoFS) vars)
 
   docMain = mainFunction
 
@@ -1989,7 +1990,7 @@ instance MethodSym CppHdrCode where
 instance InternalMethod CppHdrCode where
   intMethod m n _ s _ t ps _ = modify (setScope (snd $ unCPPHC s) . if m then 
     setCurrMain else id) >> on1StateValue1List (\tp pms -> methodFromData (snd 
-    $ unCPPHC s) $ cpphMethod n tp pms endStatement) (zoom lensMStoGS t) ps
+    $ unCPPHC s) $ cpphMethod n tp pms endStatement) (zoom lensMStoFS t) ps
   intFunc = G.intFunc
   commentedFunc = cppCommentedFunc Header
 
@@ -2017,8 +2018,7 @@ instance InternalStateVar CppHdrCode where
 instance ClassSym CppHdrCode where
   type Class CppHdrCode = Doc
   buildClass n p _ vs mths = on2StateLists (\vars funcs -> cpphClass n p vars 
-    funcs public private blockStart blockEnd endStatement) 
-    (map (zoom lensFStoGS) vs) fs
+    funcs public private blockStart blockEnd endStatement) vs fs
     where fs = map (zoom lensFStoMS) $ mths ++ [destructor n vs]
   enum n es _ = cpphEnum n (enumElementsDocD es enumsEqualInts) blockStart 
     blockEnd endStatement
@@ -2052,17 +2052,17 @@ instance BlockCommentSym CppHdrCode where
   blockCommentDoc = unCPPHC
 
 -- helpers
-toBasicVar :: GS (CppSrcCode (Variable CppSrcCode)) -> 
-  GS (CppSrcCode (Variable CppSrcCode))
+toBasicVar :: FS (CppSrcCode (Variable CppSrcCode)) -> 
+  FS (CppSrcCode (Variable CppSrcCode))
 toBasicVar v = v >>= (\v' -> var (variableName v') (onStateValue variableType v))
 
 isDtor :: Label -> Bool
 isDtor ('~':_) = True
 isDtor _ = False
 
-getParam :: (RenderSym repr) => GS (repr (Variable repr)) -> 
+getParam :: (RenderSym repr) => FS (repr (Variable repr)) -> 
   MS (repr (Parameter repr))
-getParam v = zoom lensMStoGS v >>= (\v' -> getParamFunc ((getType . 
+getParam v = zoom lensMStoFS v >>= (\v' -> getParamFunc ((getType . 
   variableType) v') v)
   where getParamFunc (List _) = pointerParam
         getParamFunc (Object _) = pointerParam
@@ -2073,19 +2073,19 @@ data MethodData = MthD {getMthdScp :: ScopeTag, mthdDoc :: Doc}
 mthd :: ScopeTag -> Doc -> MethodData
 mthd = MthD 
 
-addAlgorithmImport :: GS a -> GS a
+addAlgorithmImport :: FS a -> FS a
 addAlgorithmImport = (>>) $ modify (addLangImport "algorithm")
 
-addFStreamImport :: a -> GS a
+addFStreamImport :: a -> FS a
 addFStreamImport = getPutReturn (addLangImport "fstream")
 
-addIOStreamImport :: GS a -> GS a
+addIOStreamImport :: FS a -> FS a
 addIOStreamImport = (>>) $ modify (addLangImport "iostream")
 
-addMathHImport :: GS a -> GS a
+addMathHImport :: FS a -> FS a
 addMathHImport = (>>) $ modify (addLangImport "math.h")
 
-addLimitsImport :: GS a -> GS a
+addLimitsImport :: FS a -> FS a
 addLimitsImport = (>>) $ modify (addLangImport "limits")
 
 -- convenience
@@ -2142,19 +2142,19 @@ usingNameSpace n Nothing end = text "using namespace" <+> text n <> end
 cppInherit :: Label -> Doc -> Doc
 cppInherit n pub = colon <+> pub <+> text n
 
-cppBoolType :: (RenderSym repr) => GS (repr (Type repr))
+cppBoolType :: (RenderSym repr) => FS (repr (Type repr))
 cppBoolType = toState $ typeFromData Boolean "bool" (text "bool")
 
-cppInfileType :: (RenderSym repr) => GS (repr (Type repr))
+cppInfileType :: (RenderSym repr) => FS (repr (Type repr))
 cppInfileType = addFStreamImport $ typeFromData File "ifstream" 
   (text "ifstream")
 
-cppOutfileType :: (RenderSym repr) => GS (repr (Type repr))
+cppOutfileType :: (RenderSym repr) => FS (repr (Type repr))
 cppOutfileType = addFStreamImport $ typeFromData File "ofstream" 
   (text "ofstream")
 
-cppIterType :: (RenderSym repr) => GS (repr (Type repr)) -> 
-  GS (repr (Type repr))
+cppIterType :: (RenderSym repr) => FS (repr (Type repr)) -> 
+  FS (repr (Type repr))
 cppIterType = onStateValue (\t -> typeFromData (Iterator (getType t)) 
   (getTypeString t ++ "::iterator") (text "std::" <> getTypeDoc t <> text 
   "::iterator"))
@@ -2162,13 +2162,13 @@ cppIterType = onStateValue (\t -> typeFromData (Iterator (getType t))
 cppClassVar :: Doc -> Doc -> Doc
 cppClassVar c v = c <> text "::" <> v
 
-cppSelfFuncApp :: (RenderSym repr) => GS (repr (Variable repr)) -> Label -> 
-  GS (repr (Type repr)) -> [GS (repr (Value repr))] -> GS (repr (Value repr))
+cppSelfFuncApp :: (RenderSym repr) => FS (repr (Variable repr)) -> Label -> 
+  FS (repr (Type repr)) -> [FS (repr (Value repr))] -> FS (repr (Value repr))
 cppSelfFuncApp s n t vs = s >>= 
   (\slf -> funcApp (variableName slf ++ "->" ++ n) t vs)
 
-cppCast :: GS (CppSrcCode (Type CppSrcCode)) -> 
-  GS (CppSrcCode (Value CppSrcCode)) -> GS (CppSrcCode (Value CppSrcCode))
+cppCast :: FS (CppSrcCode (Type CppSrcCode)) -> 
+  FS (CppSrcCode (Value CppSrcCode)) -> FS (CppSrcCode (Value CppSrcCode))
 cppCast t v = join $ on2StateValues (\tp vl -> cppCast' (getType tp) (getType $ 
   valueType vl) tp vl) t v
   where cppCast' Float String _ _ = funcApp "std::stod" float [v]
@@ -2184,8 +2184,8 @@ cppListDecDoc n = parens (valueDoc n)
 cppListDecDefDoc :: (RenderSym repr) => [repr (Value repr)] -> Doc
 cppListDecDefDoc vs = braces (valueList vs)
 
-cppPrint :: (RenderSym repr) => Bool -> GS (repr (Value repr)) -> 
-  GS (repr (Value repr)) -> GS (repr (Statement repr))
+cppPrint :: (RenderSym repr) => Bool -> FS (repr (Value repr)) -> 
+  FS (repr (Value repr)) -> FS (repr (Statement repr))
 cppPrint newLn = on3StateValues (\e printFn v -> mkSt $ valueDoc printFn <+> 
   text "<<" <+> val v (valueDoc v) <+> e) end
   where val v = if maybe False (< 9) (valuePrec v) then parens else id
@@ -2208,8 +2208,8 @@ cppDiscardInput sep inFn = valueDoc inFn <> dot <> text "ignore" <> parens
   (text "std::numeric_limits<std::streamsize>::max()" <> comma <+>
   quotes (text sep))
 
-cppInput :: (RenderSym repr) => repr (Keyword repr) -> GS (repr (Variable repr))
-  -> GS (repr (Value repr)) -> GS (repr (Statement repr))
+cppInput :: (RenderSym repr) => repr (Keyword repr) -> FS (repr (Variable repr))
+  -> FS (repr (Value repr)) -> FS (repr (Statement repr))
 cppInput end vr i = addAlgorithmImport $ addLimitsImport $ on2StateValues 
   (\v inFn -> mkSt $ vcat [valueDoc inFn <+> text ">>" <+> variableDoc v <> 
   keyDoc end, valueDoc inFn <> dot <> 
@@ -2267,7 +2267,7 @@ cppsStateVarDef n cns p vr vl end = if bind p == Static then cns <+> typeDoc
   end else empty
 
 cpphStateVarDef :: (RenderSym repr) => Doc -> repr (Permanence repr) -> 
-  GS (repr (Variable repr)) -> GS (repr (Value repr)) -> GS Doc
+  FS (repr (Variable repr)) -> FS (repr (Value repr)) -> FS Doc
 cpphStateVarDef s p vr vl = onStateValue (stateVarDocD s (permDoc p) .  
   statementDoc) (state $ if binding p == Static then varDec vr else varDecDef 
   vr vl) 
@@ -2313,12 +2313,12 @@ cpphEnum n es bStart bEnd end = classFromData $ toState $ vcat [
   indent es,
   keyDoc bEnd <> keyDoc end]
 
-cppInOutCall :: (Label -> GS (CppSrcCode (Type CppSrcCode)) -> 
-  [GS (CppSrcCode (Value CppSrcCode))] -> GS (CppSrcCode (Value CppSrcCode))) 
-  -> Label -> [GS (CppSrcCode (Value CppSrcCode))] -> 
-  [GS (CppSrcCode (Variable CppSrcCode))] -> 
-  [GS (CppSrcCode (Variable CppSrcCode))] -> 
-  GS (CppSrcCode (Statement CppSrcCode))
+cppInOutCall :: (Label -> FS (CppSrcCode (Type CppSrcCode)) -> 
+  [FS (CppSrcCode (Value CppSrcCode))] -> FS (CppSrcCode (Value CppSrcCode))) 
+  -> Label -> [FS (CppSrcCode (Value CppSrcCode))] -> 
+  [FS (CppSrcCode (Variable CppSrcCode))] -> 
+  [FS (CppSrcCode (Variable CppSrcCode))] -> 
+  FS (CppSrcCode (Statement CppSrcCode))
 cppInOutCall f n ins [out] [] = assign out $ f n (onStateValue variableType out)
   ins
 cppInOutCall f n ins [] [out] = if null (filterOutObjs [out]) 
@@ -2328,13 +2328,13 @@ cppInOutCall f n ins outs both = valState $ f n void (map valueOf both ++ ins
   ++ map valueOf outs)
 
 cppsInOut :: (CppSrcCode (Scope CppSrcCode) -> 
-    CppSrcCode (Permanence CppSrcCode) -> GS (CppSrcCode (Type CppSrcCode)) -> 
+    CppSrcCode (Permanence CppSrcCode) -> FS (CppSrcCode (Type CppSrcCode)) -> 
     [MS (CppSrcCode (Parameter CppSrcCode))] -> 
-    GS (CppSrcCode (Body CppSrcCode)) -> MS (CppSrcCode (Method CppSrcCode)))
+    FS (CppSrcCode (Body CppSrcCode)) -> MS (CppSrcCode (Method CppSrcCode)))
   -> CppSrcCode (Scope CppSrcCode) -> CppSrcCode (Permanence CppSrcCode) -> 
-  [GS (CppSrcCode (Variable CppSrcCode))] ->
-  [GS (CppSrcCode (Variable CppSrcCode))] -> 
-  [GS (CppSrcCode (Variable CppSrcCode))] -> GS (CppSrcCode (Body CppSrcCode)) 
+  [FS (CppSrcCode (Variable CppSrcCode))] ->
+  [FS (CppSrcCode (Variable CppSrcCode))] -> 
+  [FS (CppSrcCode (Variable CppSrcCode))] -> FS (CppSrcCode (Body CppSrcCode)) 
   -> MS (CppSrcCode (Method CppSrcCode))
 cppsInOut f s p ins [v] [] b = f s p (onStateValue variableType v) 
   (cppInOutParams ins [v] []) (on3StateValues (on3CodeValues surroundBody) 
@@ -2346,13 +2346,13 @@ cppsInOut f s p ins [] [v] b = f s p (if null (filterOutObjs [v]) then void
 cppsInOut f s p ins outs both b = f s p void (cppInOutParams ins outs both) b
 
 cpphInOut :: (CppHdrCode (Scope CppHdrCode) -> 
-    CppHdrCode (Permanence CppHdrCode) -> GS (CppHdrCode (Type CppHdrCode)) -> 
+    CppHdrCode (Permanence CppHdrCode) -> FS (CppHdrCode (Type CppHdrCode)) -> 
     [MS (CppHdrCode (Parameter CppHdrCode))] -> 
-    GS (CppHdrCode (Body CppHdrCode)) -> MS (CppHdrCode (Method CppHdrCode))) 
+    FS (CppHdrCode (Body CppHdrCode)) -> MS (CppHdrCode (Method CppHdrCode))) 
   -> CppHdrCode (Scope CppHdrCode) -> CppHdrCode (Permanence CppHdrCode) -> 
-  [GS (CppHdrCode (Variable CppHdrCode))] -> 
-  [GS (CppHdrCode (Variable CppHdrCode))] -> 
-  [GS (CppHdrCode (Variable CppHdrCode))] -> GS (CppHdrCode (Body CppHdrCode)) 
+  [FS (CppHdrCode (Variable CppHdrCode))] -> 
+  [FS (CppHdrCode (Variable CppHdrCode))] -> 
+  [FS (CppHdrCode (Variable CppHdrCode))] -> FS (CppHdrCode (Body CppHdrCode)) 
   -> MS (CppHdrCode (Method CppHdrCode))
 cpphInOut f s p ins [v] [] b = f s p (onStateValue variableType v) 
   (cppInOutParams ins [v] []) b
@@ -2360,8 +2360,8 @@ cpphInOut f s p ins [] [v] b = f s p (if null (filterOutObjs [v]) then void
   else onStateValue variableType v) (cppInOutParams ins [] [v]) b
 cpphInOut f s p ins outs both b = f s p void (cppInOutParams ins outs both) b
 
-cppInOutParams :: (RenderSym repr) => [GS (repr (Variable repr))] -> 
-  [GS (repr (Variable repr))] -> [GS (repr (Variable repr))] -> 
+cppInOutParams :: (RenderSym repr) => [FS (repr (Variable repr))] -> 
+  [FS (repr (Variable repr))] -> [FS (repr (Variable repr))] -> 
   [MS (repr (Parameter repr))]
 cppInOutParams ins [_] [] = map getParam ins
 cppInOutParams ins [] [v] = map getParam $ v : ins

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer/CppRenderer.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer/CppRenderer.hs
@@ -12,13 +12,13 @@ import Utils.Drasil (blank, indent, indentList)
 
 import GOOL.Drasil.CodeType (CodeType(..))
 import GOOL.Drasil.Symantics (Label, ProgramSym(..), RenderSym, FileSym(..),
-  InternalFile(..), KeywordSym(..), PermanenceSym(..), InternalPerm(..), 
-  BodySym(..), BlockSym(..), InternalBlock(..), ControlBlockSym(..), 
-  TypeSym(..), InternalType(..), UnaryOpSym(..), BinaryOpSym(..), 
-  InternalOp(..), VariableSym(..), InternalVariable(..), ValueSym(..), 
-  NumericExpression(..), BooleanExpression(..), ValueExpression(..), 
-  InternalValue(..), Selector(..), InternalSelector(..), objMethodCall, 
-  FunctionSym(..), SelectorFunction(..), InternalFunction(..), 
+  InternalFile(..), KeywordSym(..), ImportSym(..), PermanenceSym(..), 
+  InternalPerm(..), BodySym(..), BlockSym(..), InternalBlock(..), 
+  ControlBlockSym(..), TypeSym(..), InternalType(..), UnaryOpSym(..), 
+  BinaryOpSym(..), InternalOp(..), VariableSym(..), InternalVariable(..), 
+  ValueSym(..), NumericExpression(..), BooleanExpression(..), 
+  ValueExpression(..), InternalValue(..), Selector(..), InternalSelector(..), 
+  objMethodCall, FunctionSym(..), SelectorFunction(..), InternalFunction(..), 
   InternalStatement(..), StatementSym(..), ControlStatementSym(..), 
   ScopeSym(..), InternalScope(..), MethodTypeSym(..), ParameterSym(..), 
   InternalParam(..), MethodSym(..), InternalMethod(..), StateVarSym(..), 
@@ -125,7 +125,6 @@ instance (Pair p) => KeywordSym (p CppSrcCode CppHdrCode) where
   endStatement = pair endStatement endStatement
   endStatementLoop = pair endStatementLoop endStatementLoop
 
-  include n = pair (include n) (include n)
   inherit n = pair (inherit n) (inherit n)
 
   list p = pair (list $ pfst p) (list $ psnd p)
@@ -146,6 +145,13 @@ instance (Pair p) => KeywordSym (p CppSrcCode CppHdrCode) where
   docCommentEnd = pair docCommentEnd docCommentEnd
 
   keyDoc k = keyDoc $ pfst k
+
+instance (Pair p) => ImportSym (p CppSrcCode CppHdrCode) where
+  type Import (p CppSrcCode CppHdrCode) = Doc
+  langImport n = pair (langImport n) (langImport n)
+  modImport n = pair (modImport n) (modImport n)
+
+  importDoc i = importDoc $ pfst i
 
 instance (Pair p) => PermanenceSym (p CppSrcCode CppHdrCode) where
   type Permanence (p CppSrcCode CppHdrCode) = BindData
@@ -922,7 +928,8 @@ instance KeywordSym CppSrcCode where
   endStatement = toCode semi
   endStatementLoop = toCode empty
 
-  include n = toCode $ text "#include" <+> doubleQuotedText (addExt cppHdrExt n)
+  include n = toCode $ text "#include" <+> doubleQuotedText (addExt cppHdrExt 
+    n)
   inherit n = onCodeValue (cppInherit n . fst) public
 
   list _ = toCode $ text "vector"
@@ -943,6 +950,14 @@ instance KeywordSym CppSrcCode where
   docCommentEnd = blockCommentEnd
 
   keyDoc = unCPPSC
+
+instance ImportSym CppSrcCode where
+  type Import CppSrcCode = Doc
+  langImport n = toCode $ text "#include" <+> angles (text n)
+  modImport n = toCode $ text "#include" <+> doubleQuotedText (addExt cppHdrExt 
+    n)
+
+  importDoc = unCPPSC
 
 instance PermanenceSym CppSrcCode where
   type Permanence CppSrcCode = BindData
@@ -1535,6 +1550,14 @@ instance KeywordSym CppHdrCode where
   docCommentEnd = blockCommentEnd
 
   keyDoc = unCPPHC
+
+instance ImportSym CppHdrCode where
+  type Import CppHdrCode = Doc
+  langImport n = toCode $ text "#include" <+> angles (text n)
+  modImport n = toCode $ text "#include" <+> doubleQuotedText (addExt cppHdrExt 
+    n)
+
+  importDoc = unCPPHC
 
 instance PermanenceSym CppHdrCode where
   type Permanence CppHdrCode = BindData

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer/CppRenderer.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer/CppRenderer.hs
@@ -695,8 +695,7 @@ instance (Pair p) => ModuleSym (p CppSrcCode CppHdrCode) where
   
 instance (Pair p) => InternalMod (p CppSrcCode CppHdrCode) where
   moduleDoc m = moduleDoc $ pfst m
-  modFromData n m d = on2StateValues pair (modFromData n m d) (modFromData n m 
-    d)
+  modFromData n d = on2StateValues pair (modFromData n d) (modFromData n d)
   updateModuleDoc f m = pair (updateModuleDoc f $ pfst m) (updateModuleDoc f $ 
     psnd m)
 
@@ -1494,7 +1493,7 @@ instance ModuleSym CppSrcCode where
 
 instance InternalMod CppSrcCode where
   moduleDoc = modDoc . unCPPSC
-  modFromData n = G.modFromData n (\d m -> toCode $ md n m d)
+  modFromData n = G.modFromData n (toCode . md n)
   updateModuleDoc f = onCodeValue (updateModDoc f)
 
 instance BlockCommentSym CppSrcCode where
@@ -2065,7 +2064,7 @@ instance ModuleSym CppHdrCode where
 
 instance InternalMod CppHdrCode where
   moduleDoc = modDoc . unCPPHC
-  modFromData n = G.modFromData n (\d m -> toCode $ md n m d)
+  modFromData n = G.modFromData n (toCode . md n)
   updateModuleDoc f = onCodeValue (updateModDoc f)
 
 instance BlockCommentSym CppHdrCode where

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer/CppRenderer.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer/CppRenderer.hs
@@ -690,7 +690,7 @@ instance (Pair p) => InternalClass (p CppSrcCode CppHdrCode) where
 
 instance (Pair p) => ModuleSym (p CppSrcCode CppHdrCode) where
   type Module (p CppSrcCode CppHdrCode) = ModData
-  buildModule n l ms = pair2Lists (buildModule n l) (buildModule n l) 
+  buildModule n ms = pair2Lists (buildModule n) (buildModule n) 
     (map (zoom lensFStoMS) ms)
   
 instance (Pair p) => InternalMod (p CppSrcCode CppHdrCode) where
@@ -1479,7 +1479,7 @@ instance InternalClass CppSrcCode where
 
 instance ModuleSym CppSrcCode where
   type Module CppSrcCode = ModData
-  buildModule n _ = G.buildModule n ((\ds lis mis us mn -> vibcat [
+  buildModule n = G.buildModule n ((\ds lis mis us mn -> vibcat [
     vcat (map ((text "#define" <+>) . text) ds),
     vcat (map (importDoc . 
       (langImport :: Label -> CppSrcCode (Import CppSrcCode))) lis),
@@ -2051,7 +2051,7 @@ instance InternalClass CppHdrCode where
 
 instance ModuleSym CppHdrCode where
   type Module CppHdrCode = ModData
-  buildModule n _ = G.buildModule n ((\ds lis mis us -> vibcat [
+  buildModule n = G.buildModule n ((\ds lis mis us -> vibcat [
     vcat (map ((text "#define" <+>) . text) ds),
     vcat (map (importDoc . 
       (langImport :: Label -> CppHdrCode (Import CppHdrCode))) lis),

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer/CppRenderer.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer/CppRenderer.hs
@@ -26,21 +26,19 @@ import GOOL.Drasil.Symantics (Label, ProgramSym(..), RenderSym, FileSym(..),
   InternalMod(..), BlockCommentSym(..))
 import GOOL.Drasil.LanguageRenderer (addExt, enumElementsDocD, multiStateDocD, 
   bodyDocD, outDoc, paramDocD, stateVarDocD, constVarDocD, freeDocD, mkSt, 
-  mkStNoEnd, breakDocD, continueDocD, unOpPrec, notOpDocD, negateOpDocD, 
-  sqrtOpDocD, absOpDocD, expOpDocD, sinOpDocD, cosOpDocD, tanOpDocD, asinOpDocD,
-  acosOpDocD, atanOpDocD, unExpr, unExpr', typeUnExpr, equalOpDocD, 
-  notEqualOpDocD, greaterOpDocD, greaterEqualOpDocD, lessOpDocD, 
-  lessEqualOpDocD, plusOpDocD, minusOpDocD, multOpDocD, divideOpDocD, 
-  moduloOpDocD, powerOpDocD, andOpDocD, orOpDocD, binExpr, binExpr', 
-  typeBinExpr, mkStateVal, mkVal, mkStateVar, mkVar, classVarCheckStatic,
-  newObjDocD', castDocD, castObjDocD,  staticDocD, dynamicDocD, privateDocD, 
-  publicDocD, classDec, dot, blockCmtStart, blockCmtEnd, docCmtStart, 
-  doubleSlash, elseIfLabel, blockCmtDoc, docCmtDoc, commentedItem, 
-  addCommentsDocD, functionDox, commentedModD, valueList, parameterList, 
-  appendToBody, surroundBody, getterName, setterName, filterOutObjs)
+  mkStNoEnd, breakDocD, continueDocD, mkStateVal, mkVal, mkStateVar, mkVar, 
+  classVarCheckStatic, newObjDocD', castDocD, castObjDocD, staticDocD, 
+  dynamicDocD, privateDocD, publicDocD, classDec, dot, blockCmtStart, 
+  blockCmtEnd, docCmtStart, doubleSlash, elseIfLabel, blockCmtDoc, docCmtDoc, 
+  commentedItem, addCommentsDocD, functionDox, commentedModD, valueList, 
+  parameterList, appendToBody, surroundBody, getterName, setterName, 
+  filterOutObjs)
 import qualified GOOL.Drasil.LanguageRenderer.LanguagePolymorphic as G (
   oneLiner, block, int, double, char, string, listType, listInnerType, obj, 
-  enumType, void, runStrategy, listSlice, var, staticVar, self, enumVar, objVar,
+  enumType, void, runStrategy, listSlice, notOp, negateOp, sqrtOp, absOp, expOp,
+  sinOp, cosOp, tanOp, asinOp, acosOp, atanOp, equalOp, notEqualOp, greaterOp, 
+  greaterEqualOp, lessOp, lessEqualOp, plusOp, minusOp, multOp, divideOp, 
+  moduloOp, powerOp, andOp, orOp, var, staticVar, self, enumVar, objVar,
   listVar, listOf, litTrue, litFalse, litChar, litFloat, litInt, litString, 
   valueOf, arg, argsList, inlineIf, objAccess, objMethodCall, 
   objMethodCallNoParams, selfAccess, listIndexExists, funcApp, newObj, func, 
@@ -57,6 +55,8 @@ import qualified GOOL.Drasil.LanguageRenderer.LanguagePolymorphic as G (
   docFunc, docInOutFunc, intFunc, privMVar, pubMVar, pubGVar, privClass, 
   pubClass, docClass, commentedClass, buildModule, modFromData, fileDoc, docMod,
   fileFromData)
+import GOOL.Drasil.LanguageRenderer.LanguagePolymorphic (unOpPrec, unExpr, 
+  unExpr', typeUnExpr, binExpr, binExpr', typeBinExpr)
 import GOOL.Drasil.Data (Pair(..), Terminator(..), ScopeTag(..), 
   Binding(..), BindData(..), bd, FileType(..), FileData(..), fileD, 
   FuncData(..), fd, ModData(..), md, updateModDoc, OpData(..), od, 
@@ -220,44 +220,47 @@ instance (Pair p) => ControlBlockSym (p CppSrcCode CppHdrCode) where
 
 instance (Pair p) => UnaryOpSym (p CppSrcCode CppHdrCode) where
   type UnaryOp (p CppSrcCode CppHdrCode) = OpData
-  notOp = pair notOp notOp
-  negateOp = pair negateOp negateOp
-  sqrtOp = pair sqrtOp sqrtOp
-  absOp = pair absOp absOp
-  logOp = pair logOp logOp
-  lnOp = pair lnOp lnOp
-  expOp = pair expOp expOp
-  sinOp = pair sinOp sinOp
-  cosOp = pair cosOp cosOp
-  tanOp = pair tanOp tanOp
-  asinOp = pair asinOp asinOp
-  acosOp = pair acosOp acosOp
-  atanOp = pair atanOp atanOp
-  floorOp = pair floorOp floorOp
-  ceilOp = pair ceilOp ceilOp
+  notOp = on2StateValues pair notOp notOp
+  negateOp = on2StateValues pair negateOp negateOp
+  sqrtOp = on2StateValues pair sqrtOp sqrtOp
+  absOp = on2StateValues pair absOp absOp
+  logOp = on2StateValues pair logOp logOp
+  lnOp = on2StateValues pair lnOp lnOp
+  expOp = on2StateValues pair expOp expOp
+  sinOp = on2StateValues pair sinOp sinOp
+  cosOp = on2StateValues pair cosOp cosOp
+  tanOp = on2StateValues pair tanOp tanOp
+  asinOp = on2StateValues pair asinOp asinOp
+  acosOp = on2StateValues pair acosOp acosOp
+  atanOp = on2StateValues pair atanOp atanOp
+  floorOp = on2StateValues pair floorOp floorOp
+  ceilOp = on2StateValues pair ceilOp ceilOp
 
 instance (Pair p) => BinaryOpSym (p CppSrcCode CppHdrCode) where
   type BinaryOp (p CppSrcCode CppHdrCode) = OpData
-  equalOp = pair equalOp equalOp
-  notEqualOp = pair notEqualOp notEqualOp
-  greaterOp = pair greaterOp greaterOp
-  greaterEqualOp = pair greaterEqualOp greaterEqualOp
-  lessOp = pair lessOp lessOp
-  lessEqualOp = pair lessEqualOp lessEqualOp
-  plusOp = pair plusOp plusOp
-  minusOp = pair minusOp minusOp
-  multOp = pair multOp multOp
-  divideOp = pair divideOp divideOp
-  powerOp = pair powerOp powerOp
-  moduloOp = pair moduloOp moduloOp
-  andOp = pair andOp andOp
-  orOp = pair orOp orOp
+  equalOp = on2StateValues pair equalOp equalOp
+  notEqualOp = on2StateValues pair notEqualOp notEqualOp
+  greaterOp = on2StateValues pair greaterOp greaterOp
+  greaterEqualOp = on2StateValues pair greaterEqualOp greaterEqualOp
+  lessOp = on2StateValues pair lessOp lessOp
+  lessEqualOp = on2StateValues pair lessEqualOp lessEqualOp
+  plusOp = on2StateValues pair plusOp plusOp
+  minusOp = on2StateValues pair minusOp minusOp
+  multOp = on2StateValues pair multOp multOp
+  divideOp = on2StateValues pair divideOp divideOp
+  powerOp = on2StateValues pair powerOp powerOp
+  moduloOp = on2StateValues pair moduloOp moduloOp
+  andOp = on2StateValues pair andOp andOp
+  orOp = on2StateValues pair orOp orOp
 
 instance (Pair p) => InternalOp (p CppSrcCode CppHdrCode) where
   uOpDoc o = uOpDoc $ pfst o
   bOpDoc o = bOpDoc $ pfst o
   uOpPrec o = uOpPrec $ pfst o
   bOpPrec o = bOpPrec $ pfst o
+  
+  uOpFromData p d = on2StateValues pair (uOpFromData p d) (uOpFromData p d)
+  bOpFromData p d = on2StateValues pair (bOpFromData p d) (bOpFromData p d)
 
 instance (Pair p) => VariableSym (p CppSrcCode CppHdrCode) where
   type Variable (p CppSrcCode CppHdrCode) = VarData
@@ -998,44 +1001,47 @@ instance ControlBlockSym CppSrcCode where
 
 instance UnaryOpSym CppSrcCode where
   type UnaryOp CppSrcCode = OpData
-  notOp = toCode notOpDocD
-  negateOp = toCode negateOpDocD
-  sqrtOp = toCode sqrtOpDocD
-  absOp = toCode absOpDocD
-  logOp = toCode $ unOpPrec "log10"
-  lnOp = toCode $ unOpPrec "log"
-  expOp = toCode expOpDocD
-  sinOp = toCode sinOpDocD
-  cosOp = toCode cosOpDocD
-  tanOp = toCode tanOpDocD
-  asinOp = toCode asinOpDocD
-  acosOp = toCode acosOpDocD
-  atanOp = toCode atanOpDocD
-  floorOp = toCode $ unOpPrec "floor"
-  ceilOp = toCode $ unOpPrec "ceil"
+  notOp = G.notOp
+  negateOp = G.negateOp
+  sqrtOp = addMathHImport $ G.sqrtOp
+  absOp = addMathHImport $ G.absOp
+  logOp = addMathHImport $ unOpPrec "log10"
+  lnOp = addMathHImport $ unOpPrec "log"
+  expOp = addMathHImport $ G.expOp
+  sinOp = addMathHImport $ G.sinOp
+  cosOp = addMathHImport $ G.cosOp
+  tanOp = addMathHImport $ G.tanOp
+  asinOp = addMathHImport $ G.asinOp
+  acosOp = addMathHImport $ G.acosOp
+  atanOp = addMathHImport $ G.atanOp
+  floorOp = addMathHImport $ unOpPrec "floor"
+  ceilOp = addMathHImport $ unOpPrec "ceil"
 
 instance BinaryOpSym CppSrcCode where
   type BinaryOp CppSrcCode = OpData
-  equalOp = toCode equalOpDocD
-  notEqualOp = toCode notEqualOpDocD
-  greaterOp = toCode greaterOpDocD
-  greaterEqualOp = toCode greaterEqualOpDocD
-  lessOp = toCode lessOpDocD
-  lessEqualOp = toCode lessEqualOpDocD
-  plusOp = toCode plusOpDocD
-  minusOp = toCode minusOpDocD
-  multOp = toCode multOpDocD
-  divideOp = toCode divideOpDocD
-  powerOp = toCode powerOpDocD
-  moduloOp = toCode moduloOpDocD
-  andOp = toCode andOpDocD
-  orOp = toCode orOpDocD
+  equalOp = G.equalOp
+  notEqualOp = G.notEqualOp
+  greaterOp = G.greaterOp
+  greaterEqualOp = G.greaterEqualOp
+  lessOp = G.lessOp
+  lessEqualOp = G.lessEqualOp
+  plusOp = G.plusOp
+  minusOp = G.minusOp
+  multOp = G.multOp
+  divideOp = G.divideOp
+  powerOp = addMathHImport $ G.powerOp
+  moduloOp = G.moduloOp
+  andOp = G.andOp
+  orOp = G.orOp
 
 instance InternalOp CppSrcCode where
   uOpDoc = opDoc . unCPPSC
   bOpDoc = opDoc . unCPPSC
   uOpPrec = opPrec . unCPPSC
   bOpPrec = opPrec . unCPPSC
+  
+  uOpFromData p d = toState $ toCode $ od p d
+  bOpFromData p d = toState $ toCode $ od p d
 
 instance VariableSym CppSrcCode where
   type Variable CppSrcCode = VarData
@@ -1583,44 +1589,47 @@ instance ControlBlockSym CppHdrCode where
 
 instance UnaryOpSym CppHdrCode where
   type UnaryOp CppHdrCode = OpData
-  notOp = toCode $ od 0 empty
-  negateOp = toCode $ od 0 empty
-  sqrtOp = toCode $ od 0 empty
-  absOp = toCode $ od 0 empty
-  logOp = toCode $ od 0 empty
-  lnOp = toCode $ od 0 empty
-  expOp = toCode $ od 0 empty
-  sinOp = toCode $ od 0 empty
-  cosOp = toCode $ od 0 empty
-  tanOp = toCode $ od 0 empty
-  asinOp = toCode $ od 0 empty
-  acosOp = toCode $ od 0 empty
-  atanOp = toCode $ od 0 empty
-  floorOp = toCode $ od 0 empty
-  ceilOp = toCode $ od 0 empty
+  notOp = uOpFromData 0 empty
+  negateOp = uOpFromData 0 empty
+  sqrtOp = uOpFromData 0 empty
+  absOp = uOpFromData 0 empty
+  logOp = uOpFromData 0 empty
+  lnOp = uOpFromData 0 empty
+  expOp = uOpFromData 0 empty
+  sinOp = uOpFromData 0 empty
+  cosOp = uOpFromData 0 empty
+  tanOp = uOpFromData 0 empty
+  asinOp = uOpFromData 0 empty
+  acosOp = uOpFromData 0 empty
+  atanOp = uOpFromData 0 empty
+  floorOp = uOpFromData 0 empty
+  ceilOp = uOpFromData 0 empty
 
 instance BinaryOpSym CppHdrCode where
   type BinaryOp CppHdrCode = OpData
-  equalOp = toCode $ od 0 empty
-  notEqualOp = toCode $ od 0 empty
-  greaterOp = toCode $ od 0 empty
-  greaterEqualOp = toCode $ od 0 empty
-  lessOp = toCode $ od 0 empty
-  lessEqualOp = toCode $ od 0 empty
-  plusOp = toCode $ od 0 empty
-  minusOp = toCode $ od 0 empty
-  multOp = toCode $ od 0 empty
-  divideOp = toCode $ od 0 empty
-  powerOp = toCode $ od 0 empty
-  moduloOp = toCode $ od 0 empty
-  andOp = toCode $ od 0 empty
-  orOp = toCode $ od 0 empty
+  equalOp = bOpFromData 0 empty
+  notEqualOp = bOpFromData 0 empty
+  greaterOp = bOpFromData 0 empty
+  greaterEqualOp = bOpFromData 0 empty
+  lessOp = bOpFromData 0 empty
+  lessEqualOp = bOpFromData 0 empty
+  plusOp = bOpFromData 0 empty
+  minusOp = bOpFromData 0 empty
+  multOp = bOpFromData 0 empty
+  divideOp = bOpFromData 0 empty
+  powerOp = bOpFromData 0 empty
+  moduloOp = bOpFromData 0 empty
+  andOp = bOpFromData 0 empty
+  orOp = bOpFromData 0 empty
 
 instance InternalOp CppHdrCode where
   uOpDoc = opDoc . unCPPHC
   bOpDoc = opDoc . unCPPHC
   uOpPrec = opPrec . unCPPHC
   bOpPrec = opPrec . unCPPHC
+  
+  uOpFromData p d = toState $ toCode $ od p d
+  bOpFromData p d = toState $ toCode $ od p d
 
 instance VariableSym CppHdrCode where
   type Variable CppHdrCode = VarData
@@ -2035,6 +2044,9 @@ mthd :: ScopeTag -> Doc -> MethodData
 mthd = MthD 
 
 -- convenience
+addMathHImport :: GS a -> GS a
+addMathHImport = (>>) $ modify (addLangImport "math.h")
+
 cppName :: String
 cppName = "C++" 
 

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer/JavaRenderer.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer/JavaRenderer.hs
@@ -24,19 +24,17 @@ import GOOL.Drasil.Symantics (Label, ProgramSym(..), RenderSym, FileSym(..),
   InternalClass(..), ModuleSym(..), InternalMod(..), BlockCommentSym(..))
 import GOOL.Drasil.LanguageRenderer (packageDocD, classDocD, multiStateDocD, 
   bodyDocD, outDoc, printFileDocD, destructorError, paramDocD, listDecDocD, 
-  mkSt, breakDocD, continueDocD, unOpPrec, notOpDocD, negateOpDocD, unExpr, 
-  unExpr', typeUnExpr, powerPrec, equalOpDocD, notEqualOpDocD, greaterOpDocD, 
-  greaterEqualOpDocD, lessOpDocD, lessEqualOpDocD, plusOpDocD, minusOpDocD, 
-  multOpDocD, divideOpDocD, moduloOpDocD, andOpDocD, orOpDocD, binExpr, 
-  binExpr', typeBinExpr, mkStateVal, mkVal, classVarDocD, newObjDocD, castDocD, 
-  castObjDocD, staticDocD, dynamicDocD, bindingError, privateDocD, publicDocD, 
-  dot, new, elseIfLabel, forLabel, blockCmtStart, blockCmtEnd, docCmtStart, 
-  doubleSlash, blockCmtDoc, docCmtDoc, commentedItem, addCommentsDocD, 
-  commentedModD, docFuncRepr, valueList, parameterList, appendToBody, 
-  surroundBody, intValue, filterOutObjs)
+  mkSt, breakDocD, continueDocD, mkStateVal, mkVal, classVarDocD, newObjDocD, 
+  castDocD, castObjDocD, staticDocD, dynamicDocD, bindingError, privateDocD, 
+  publicDocD, dot, new, elseIfLabel, forLabel, blockCmtStart, blockCmtEnd, 
+  docCmtStart, doubleSlash, blockCmtDoc, docCmtDoc, commentedItem, 
+  addCommentsDocD, commentedModD, docFuncRepr, valueList, parameterList, 
+  appendToBody, surroundBody, intValue, filterOutObjs)
 import qualified GOOL.Drasil.LanguageRenderer.LanguagePolymorphic as G (
   oneLiner, block, bool, int, double, char, listType, listInnerType, obj, 
-  enumType, void, runStrategy, listSlice, var, staticVar, extVar, self, enumVar,
+  enumType, void, runStrategy, listSlice, notOp, negateOp, equalOp, notEqualOp, 
+  greaterOp, greaterEqualOp, lessOp, lessEqualOp, plusOp, minusOp, multOp, 
+  divideOp, moduloOp, andOp, orOp, var, staticVar, extVar, self, enumVar,
   classVar, objVar, objVarSelf, listVar, listOf, iterVar, litTrue, litFalse, 
   litChar, litFloat, litInt, litString, pi, valueOf, arg, enumElement, argsList,
   inlineIf, objAccess, objMethodCall, objMethodCallNoParams, selfAccess, 
@@ -56,9 +54,11 @@ import qualified GOOL.Drasil.LanguageRenderer.LanguagePolymorphic as G (
   mainFunction, docFunc, intFunc, stateVar, stateVarDef, constVar, privMVar, 
   pubMVar, pubGVar, buildClass, enum, privClass, pubClass, docClass, 
   commentedClass, buildModule', modFromData, fileDoc, docMod, fileFromData)
+import GOOL.Drasil.LanguageRenderer.LanguagePolymorphic (unOpPrec, unExpr, 
+  unExpr', typeUnExpr, powerPrec, binExpr, binExpr', typeBinExpr)
 import GOOL.Drasil.Data (Terminator(..), ScopeTag(..), FileType(..), 
   FileData(..), fileD, FuncData(..), fd, ModData(..), md, updateModDoc, 
-  MethodData(..), mthd, updateMthdDoc, OpData(..), ParamData(..), pd, 
+  MethodData(..), mthd, updateMthdDoc, OpData(..), od, ParamData(..), pd, 
   ProgData(..), progD, TypeData(..), td, ValData(..), vd, VarData(..), vard)
 import GOOL.Drasil.Helpers (angles, emptyIfNull, toCode, toState, onCodeValue, 
   onStateValue, on2CodeValues, on2StateValues, on3CodeValues, on3StateValues,
@@ -195,44 +195,47 @@ instance ControlBlockSym JavaCode where
 
 instance UnaryOpSym JavaCode where
   type UnaryOp JavaCode = OpData
-  notOp = toCode notOpDocD
-  negateOp = toCode negateOpDocD
-  sqrtOp = toCode $ unOpPrec "Math.sqrt"
-  absOp = toCode $ unOpPrec "Math.abs"
-  logOp = toCode $ unOpPrec "Math.log10"
-  lnOp = toCode $ unOpPrec "Math.log"
-  expOp = toCode $ unOpPrec "Math.exp"
-  sinOp = toCode $ unOpPrec "Math.sin"
-  cosOp = toCode $ unOpPrec "Math.cos"
-  tanOp = toCode $ unOpPrec "Math.tan"
-  asinOp = toCode $ unOpPrec "Math.asin"
-  acosOp = toCode $ unOpPrec "Math.acos"
-  atanOp = toCode $ unOpPrec "Math.atan"
-  floorOp = toCode $ unOpPrec "Math.floor"
-  ceilOp = toCode $ unOpPrec "Math.ceil"
+  notOp = G.notOp
+  negateOp = G.negateOp
+  sqrtOp = unOpPrec "Math.sqrt"
+  absOp = unOpPrec "Math.abs"
+  logOp = unOpPrec "Math.log10"
+  lnOp = unOpPrec "Math.log"
+  expOp = unOpPrec "Math.exp"
+  sinOp = unOpPrec "Math.sin"
+  cosOp = unOpPrec "Math.cos"
+  tanOp = unOpPrec "Math.tan"
+  asinOp = unOpPrec "Math.asin"
+  acosOp = unOpPrec "Math.acos"
+  atanOp = unOpPrec "Math.atan"
+  floorOp = unOpPrec "Math.floor"
+  ceilOp = unOpPrec "Math.ceil"
 
 instance BinaryOpSym JavaCode where
   type BinaryOp JavaCode = OpData
-  equalOp = toCode equalOpDocD
-  notEqualOp = toCode notEqualOpDocD
-  greaterOp = toCode greaterOpDocD
-  greaterEqualOp = toCode greaterEqualOpDocD
-  lessOp = toCode lessOpDocD
-  lessEqualOp = toCode lessEqualOpDocD
-  plusOp = toCode plusOpDocD
-  minusOp = toCode minusOpDocD
-  multOp = toCode multOpDocD
-  divideOp = toCode divideOpDocD
-  powerOp = toCode $ powerPrec "Math.pow"
-  moduloOp = toCode moduloOpDocD
-  andOp = toCode andOpDocD
-  orOp = toCode orOpDocD
+  equalOp = G.equalOp
+  notEqualOp = G.notEqualOp
+  greaterOp = G.greaterOp
+  greaterEqualOp = G.greaterEqualOp
+  lessOp = G.lessOp
+  lessEqualOp = G.lessEqualOp
+  plusOp = G.plusOp
+  minusOp = G.minusOp
+  multOp = G.multOp
+  divideOp = G.divideOp
+  powerOp = powerPrec "Math.pow"
+  moduloOp = G.moduloOp
+  andOp = G.andOp
+  orOp = G.orOp
 
 instance InternalOp JavaCode where
   uOpDoc = opDoc . unJC
   bOpDoc = opDoc . unJC
   uOpPrec = opPrec . unJC
   bOpPrec = opPrec . unJC
+  
+  uOpFromData p d = toState $ toCode $ od p d
+  bOpFromData p d = toState $ toCode $ od p d
 
 instance VariableSym JavaCode where
   type Variable JavaCode = VarData

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer/JavaRenderer.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer/JavaRenderer.hs
@@ -344,7 +344,8 @@ instance ValueExpression JavaCode where
   notNull = G.notNull
 
 instance InternalValue JavaCode where
-  inputFunc = mkStateVal (obj "Scanner") $ parens $ text "new Scanner(System.in)"
+  inputFunc = modify (addLangImport "java.util.Scanner") >> mkStateVal 
+    (obj "Scanner") (parens $ text "new Scanner(System.in)")
   printFunc = mkStateVal void (text "System.out.print")
   printLnFunc = mkStateVal void (text "System.out.println")
   printFileFunc = on2StateValues (\v -> mkVal v . printFileDocD "print" . 

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer/JavaRenderer.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer/JavaRenderer.hs
@@ -118,7 +118,6 @@ instance KeywordSym JavaCode where
   endStatement = toCode semi
   endStatementLoop = toCode empty
 
-  include _ = toCode $ text "import"
   inherit n = toCode $ text "extends" <+> text n
 
   list _ = toCode $ text "ArrayList"

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer/JavaRenderer.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer/JavaRenderer.hs
@@ -619,7 +619,7 @@ instance ModuleSym JavaCode where
   
 instance InternalMod JavaCode where
   moduleDoc = modDoc . unJC
-  modFromData n = G.modFromData n (\d m -> toCode $ md n m d)
+  modFromData n = G.modFromData n (toCode . md n)
   updateModuleDoc f = onCodeValue (updateModDoc f)
 
 instance BlockCommentSym JavaCode where

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer/JavaRenderer.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer/JavaRenderer.hs
@@ -439,8 +439,8 @@ instance StatementSym JavaCode where
   varDecDef = G.varDecDef
   listDec n v = v >>= (\v' -> G.listDec (listDecDocD v') (litInt n) v)
   listDecDef v vs = modify (if null vs then id else addLangImport 
-    "java.util.Arrays") >> objDecNew v (if null vs then [] else [funcApp 
-    "Arrays.asList" (onStateValue variableType v) vs])
+    "java.util.Arrays") >> objDecNew v [funcApp "Arrays.asList" 
+    (onStateValue variableType v) vs | not (null vs)]
   objDecDef = varDecDef
   objDecNew = G.objDecNew
   extObjDecNew _ = objDecNew

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer/JavaRenderer.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer/JavaRenderer.hs
@@ -64,7 +64,7 @@ import GOOL.Drasil.Data (Terminator(..), ScopeTag(..), FileType(..),
 import GOOL.Drasil.Helpers (angles, toCode, toState, onCodeValue, 
   onStateValue, on2CodeValues, on2StateValues, on3CodeValues, on3StateValues,
   onCodeList, onStateList, on1CodeValue1List)
-import GOOL.Drasil.State (GS, FS, MS, lensGStoFS, lensMStoFS, initialState, 
+import GOOL.Drasil.State (FS, MS, lensGStoFS, lensMStoFS, initialState, 
   initialFS, getPutReturn, getPutReturnList, addProgNameToPaths, addLangImport, 
   setCurrMain)
 

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer/JavaRenderer.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer/JavaRenderer.hs
@@ -615,7 +615,7 @@ instance InternalClass JavaCode where
 
 instance ModuleSym JavaCode where
   type Module JavaCode = ModData
-  buildModule n _ = G.buildModule' n langImport
+  buildModule n = G.buildModule' n langImport
   
 instance InternalMod JavaCode where
   moduleDoc = modDoc . unJC

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer/JavaRenderer.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer/JavaRenderer.hs
@@ -439,8 +439,8 @@ instance StatementSym JavaCode where
   varDecDef = G.varDecDef
   listDec n v = v >>= (\v' -> G.listDec (listDecDocD v') (litInt n) v)
   listDecDef v vs = modify (if null vs then id else addLangImport 
-    "java.util.Arrays") >> objDecNew v [funcApp "Arrays.asList" 
-    (onStateValue variableType v) vs]
+    "java.util.Arrays") >> objDecNew v (if null vs then [] else [funcApp 
+    "Arrays.asList" (onStateValue variableType v) vs])
   objDecDef = varDecDef
   objDecNew = G.objDecNew
   extObjDecNew _ = objDecNew

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer/JavaRenderer.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer/JavaRenderer.hs
@@ -10,7 +10,7 @@ module GOOL.Drasil.LanguageRenderer.JavaRenderer (
 import Utils.Drasil (indent)
 
 import GOOL.Drasil.CodeType (CodeType(..), isObject)
-import GOOL.Drasil.Symantics (Label, ProgramSym(..), RenderSym(..), 
+import GOOL.Drasil.Symantics (Label, ProgramSym(..), RenderSym, FileSym(..),
   InternalFile(..), KeywordSym(..), PermanenceSym(..), InternalPerm(..), 
   BodySym(..), BlockSym(..), InternalBlock(..), ControlBlockSym(..), 
   TypeSym(..), InternalType(..), UnaryOpSym(..), BinaryOpSym(..), 
@@ -95,7 +95,9 @@ instance ProgramSym JavaCode where
   prog n fs = getPutReturnList (map (zoom lensGStoFS) fs) (addProgNameToPaths n)
     (on1CodeValue1List (\end -> progD n . map (packageDocD n end)) endStatement)
 
-instance RenderSym JavaCode where
+instance RenderSym JavaCode
+
+instance FileSym JavaCode where
   type RenderFile JavaCode = FileData 
   fileDoc = G.fileDoc Combined jExt top bottom
 

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer/LanguagePolymorphic.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer/LanguagePolymorphic.hs
@@ -84,7 +84,7 @@ import GOOL.Drasil.LanguageRenderer (forLabel, new, observerListName, addExt,
   enumDocD, enumElementsDocD, moduleDocD, fileDoc', docFuncRepr, commentDocD, 
   commentedItem, functionDox, classDox, moduleDox, getterName, setterName, 
   valueList, intValue)
-import GOOL.Drasil.State (GS, FS, MS, lensFStoGS, lensMStoGS, lensFStoMS, 
+import GOOL.Drasil.State (FS, MS, lensFStoGS, lensFStoMS, lensMStoFS, 
   currMain, putAfter, getPutReturnFunc, getPutReturnFunc2, addFile, setMainMod, 
   addLangImport, getLangImports, getModuleImports, setFilePath, getFilePath, 
   setModuleName, getModuleName, getCurrMain, addParameter)
@@ -104,69 +104,69 @@ import qualified Text.PrettyPrint.HughesPJ as D (char, double)
 
 -- Bodies --
 
-oneLiner :: (RenderSym repr) => GS (repr (Statement repr)) -> 
-  GS (repr (Body repr))
+oneLiner :: (RenderSym repr) => FS (repr (Statement repr)) -> 
+  FS (repr (Body repr))
 oneLiner s = bodyStatements [s]
 
 -- Blocks --
 
-block :: (RenderSym repr) => repr (Keyword repr) -> [GS (repr (Statement repr))]
-  -> GS (repr (Block repr))
+block :: (RenderSym repr) => repr (Keyword repr) -> [FS (repr (Statement repr))]
+  -> FS (repr (Block repr))
 block end sts = docBlock $ onStateList (blockDocD (keyDoc end) . map 
   statementDoc) (map S.state sts)
 
 -- Types --
 
-bool :: (RenderSym repr) => GS (repr (Type repr))
+bool :: (RenderSym repr) => FS (repr (Type repr))
 bool = toState $ typeFromData Boolean "Boolean" (text "Boolean")
 
-int :: (RenderSym repr) => GS (repr (Type repr))
+int :: (RenderSym repr) => FS (repr (Type repr))
 int = toState $ typeFromData Integer "int" (text "int")
 
-float :: (RenderSym repr) => GS (repr (Type repr))
+float :: (RenderSym repr) => FS (repr (Type repr))
 float = toState $ typeFromData Float "float" (text "float")
 
-double :: (RenderSym repr) => GS (repr (Type repr))
+double :: (RenderSym repr) => FS (repr (Type repr))
 double = toState $ typeFromData Float "double" (text "double")
 
-char :: (RenderSym repr) => GS (repr (Type repr))
+char :: (RenderSym repr) => FS (repr (Type repr))
 char = toState $ typeFromData Char "char" (text "char")
 
-string :: (RenderSym repr) => GS (repr (Type repr))
+string :: (RenderSym repr) => FS (repr (Type repr))
 string = toState $ typeFromData String "string" (text "string")
 
-fileType :: (RenderSym repr) => GS (repr (Type repr))
+fileType :: (RenderSym repr) => FS (repr (Type repr))
 fileType = toState $ typeFromData File "File" (text "File")
 
-listType :: (RenderSym repr) => repr (Permanence repr) -> GS (repr (Type repr)) 
-  -> GS (repr (Type repr))
+listType :: (RenderSym repr) => repr (Permanence repr) -> FS (repr (Type repr)) 
+  -> FS (repr (Type repr))
 listType p = onStateValue (\t -> typeFromData (List (getType t)) (render 
   (keyDoc $ list p) ++ "<" ++ getTypeString t ++ ">") (keyDoc (list p) <> 
   angles (getTypeDoc t)))
 
-listInnerType :: (RenderSym repr) => GS (repr (Type repr)) -> 
-  GS (repr (Type repr))
+listInnerType :: (RenderSym repr) => FS (repr (Type repr)) -> 
+  FS (repr (Type repr))
 listInnerType t = t >>= (convType . getInnerType . getType)
 
-obj :: (RenderSym repr) => Label -> GS (repr (Type repr))
+obj :: (RenderSym repr) => Label -> FS (repr (Type repr))
 obj n = toState $ typeFromData (Object n) n (text n)
 
-enumType :: (RenderSym repr) => Label -> GS (repr (Type repr))
+enumType :: (RenderSym repr) => Label -> FS (repr (Type repr))
 enumType e = toState $ typeFromData (Enum e) e (text e)
 
-void :: (RenderSym repr) => GS (repr (Type repr))
+void :: (RenderSym repr) => FS (repr (Type repr))
 void = toState $ typeFromData Void "void" (text "void")
 
 -- ControlBlock --
 
-strat :: (RenderSym repr) => GS (repr (Statement repr)) -> GS (repr (Body repr))
-  -> GS (repr (Block repr))
+strat :: (RenderSym repr) => FS (repr (Statement repr)) -> FS (repr (Body repr))
+  -> FS (repr (Block repr))
 strat r bd = docBlock $ on2StateValues (\result b -> vcat [bodyDoc b, 
   statementDoc result]) r bd
 
-runStrategy :: (RenderSym repr) => String -> [(Label, GS (repr (Body repr)))] 
-  -> Maybe (GS (repr (Value repr))) -> Maybe (GS (repr (Variable repr))) -> 
-  GS (repr (Block repr))
+runStrategy :: (RenderSym repr) => String -> [(Label, FS (repr (Body repr)))] 
+  -> Maybe (FS (repr (Value repr))) -> Maybe (FS (repr (Variable repr))) -> 
+  FS (repr (Block repr))
 runStrategy l strats rv av = maybe
   (strError l "RunStrategy called on non-existent strategy") 
   (strat (S.state resultState)) (Map.lookup l (Map.fromList strats))
@@ -175,9 +175,9 @@ runStrategy l strats rv av = maybe
           "Attempt to assign null return to a Value") (v &=) rv
         strError n s = error $ "Strategy '" ++ n ++ "': " ++ s ++ "."
 
-listSlice :: (RenderSym repr) => Maybe (GS (repr (Value repr))) -> 
-  Maybe (GS (repr (Value repr))) -> Maybe (GS (repr (Value repr))) -> 
-  GS (repr (Variable repr)) -> GS (repr (Value repr)) -> GS (repr (Block repr))
+listSlice :: (RenderSym repr) => Maybe (FS (repr (Value repr))) -> 
+  Maybe (FS (repr (Value repr))) -> Maybe (FS (repr (Value repr))) -> 
+  FS (repr (Variable repr)) -> FS (repr (Value repr)) -> FS (repr (Block repr))
 listSlice b e s vnew vold = 
   let l_temp = "temp"
       var_temp = S.var l_temp (onStateValue variableType vnew)
@@ -195,70 +195,70 @@ listSlice b e s vnew vold =
 
 -- Unary Operators --
 
-unOpPrec :: (RenderSym repr) => String -> GS (repr (UnaryOp repr))
+unOpPrec :: (RenderSym repr) => String -> FS (repr (UnaryOp repr))
 unOpPrec = uOpFromData 9 . text
 
-notOp :: (RenderSym repr) => GS (repr (UnaryOp repr))
+notOp :: (RenderSym repr) => FS (repr (UnaryOp repr))
 notOp = unOpPrec "!"
 
-notOp' :: (RenderSym repr) => GS (repr (UnaryOp repr))
+notOp' :: (RenderSym repr) => FS (repr (UnaryOp repr))
 notOp' = unOpPrec "not"
 
-negateOp :: (RenderSym repr) => GS (repr (UnaryOp repr))
+negateOp :: (RenderSym repr) => FS (repr (UnaryOp repr))
 negateOp = unOpPrec "-"
 
-sqrtOp :: (RenderSym repr) => GS (repr (UnaryOp repr))
+sqrtOp :: (RenderSym repr) => FS (repr (UnaryOp repr))
 sqrtOp = unOpPrec "sqrt"
 
-sqrtOp' :: (RenderSym repr) => GS (repr (UnaryOp repr))
+sqrtOp' :: (RenderSym repr) => FS (repr (UnaryOp repr))
 sqrtOp' = addmathImport $ unOpPrec "math.sqrt"
 
-absOp :: (RenderSym repr) => GS (repr (UnaryOp repr))
+absOp :: (RenderSym repr) => FS (repr (UnaryOp repr))
 absOp = unOpPrec "fabs"
 
-absOp' :: (RenderSym repr) => GS (repr (UnaryOp repr))
+absOp' :: (RenderSym repr) => FS (repr (UnaryOp repr))
 absOp' = addmathImport $ unOpPrec "math.fabs"
 
-expOp :: (RenderSym repr) => GS (repr (UnaryOp repr))
+expOp :: (RenderSym repr) => FS (repr (UnaryOp repr))
 expOp = unOpPrec "exp"
 
-expOp' :: (RenderSym repr) => GS (repr (UnaryOp repr))
+expOp' :: (RenderSym repr) => FS (repr (UnaryOp repr))
 expOp' = addmathImport $ unOpPrec "math.exp"
 
-sinOp :: (RenderSym repr) => GS (repr (UnaryOp repr))
+sinOp :: (RenderSym repr) => FS (repr (UnaryOp repr))
 sinOp = unOpPrec "sin"
 
-sinOp' :: (RenderSym repr) => GS (repr (UnaryOp repr))
+sinOp' :: (RenderSym repr) => FS (repr (UnaryOp repr))
 sinOp' = addmathImport $ unOpPrec "math.sin"
 
-cosOp :: (RenderSym repr) => GS (repr (UnaryOp repr))
+cosOp :: (RenderSym repr) => FS (repr (UnaryOp repr))
 cosOp = unOpPrec "cos"
 
-cosOp' :: (RenderSym repr) => GS (repr (UnaryOp repr))
+cosOp' :: (RenderSym repr) => FS (repr (UnaryOp repr))
 cosOp' = addmathImport $ unOpPrec "math.cos"
 
-tanOp :: (RenderSym repr) => GS (repr (UnaryOp repr))
+tanOp :: (RenderSym repr) => FS (repr (UnaryOp repr))
 tanOp = unOpPrec "tan"
 
-tanOp' :: (RenderSym repr) => GS (repr (UnaryOp repr))
+tanOp' :: (RenderSym repr) => FS (repr (UnaryOp repr))
 tanOp' = addmathImport $ unOpPrec "math.tan"
 
-asinOp :: (RenderSym repr) => GS (repr (UnaryOp repr))
+asinOp :: (RenderSym repr) => FS (repr (UnaryOp repr))
 asinOp = unOpPrec "asin"
 
-asinOp' :: (RenderSym repr) => GS (repr (UnaryOp repr))
+asinOp' :: (RenderSym repr) => FS (repr (UnaryOp repr))
 asinOp' = addmathImport $ unOpPrec "math.asin"
 
-acosOp :: (RenderSym repr) => GS (repr (UnaryOp repr))
+acosOp :: (RenderSym repr) => FS (repr (UnaryOp repr))
 acosOp = unOpPrec "acos"
 
-acosOp' :: (RenderSym repr) => GS (repr (UnaryOp repr))
+acosOp' :: (RenderSym repr) => FS (repr (UnaryOp repr))
 acosOp' = addmathImport $ unOpPrec "math.acos"
 
-atanOp :: (RenderSym repr) => GS (repr (UnaryOp repr))
+atanOp :: (RenderSym repr) => FS (repr (UnaryOp repr))
 atanOp = unOpPrec "atan"
 
-atanOp' :: (RenderSym repr) => GS (repr (UnaryOp repr))
+atanOp' :: (RenderSym repr) => FS (repr (UnaryOp repr))
 atanOp' = addmathImport $ unOpPrec "math.atan"
 
 unOpDocD :: Doc -> Doc -> Doc
@@ -267,84 +267,84 @@ unOpDocD op v = op <> parens v
 unOpDocD' :: Doc -> Doc -> Doc
 unOpDocD' op v = op <> v
 
-unExpr :: (RenderSym repr) => GS (repr (UnaryOp repr)) -> GS (repr (Value repr))
-  -> GS (repr (Value repr))
+unExpr :: (RenderSym repr) => FS (repr (UnaryOp repr)) -> FS (repr (Value repr))
+  -> FS (repr (Value repr))
 unExpr = on2StateValues (\u v -> mkExpr (uOpPrec u) (valueType v) (unOpDocD 
   (uOpDoc u) (valueDoc v)))
 
-unExpr' :: (RenderSym repr) => GS (repr (UnaryOp repr)) -> 
-  GS (repr (Value repr)) -> GS (repr (Value repr))
+unExpr' :: (RenderSym repr) => FS (repr (UnaryOp repr)) -> 
+  FS (repr (Value repr)) -> FS (repr (Value repr))
 unExpr' = on2StateValues (\u v -> mkExpr (uOpPrec u) (valueType v) (unOpDocD' 
   (uOpDoc u) (valueDoc v)))
 
-typeUnExpr :: (RenderSym repr) => GS (repr (UnaryOp repr)) -> 
-  GS (repr (Type repr)) -> GS (repr (Value repr)) -> GS (repr (Value repr))
+typeUnExpr :: (RenderSym repr) => FS (repr (UnaryOp repr)) -> 
+  FS (repr (Type repr)) -> FS (repr (Value repr)) -> FS (repr (Value repr))
 typeUnExpr = on3StateValues (\u t -> mkExpr (uOpPrec u) t . unOpDocD (uOpDoc u) 
   . valueDoc)
 
 -- Binary Operators --
 
-compEqualPrec :: (RenderSym repr) => String -> GS (repr (BinaryOp repr))
+compEqualPrec :: (RenderSym repr) => String -> FS (repr (BinaryOp repr))
 compEqualPrec = bOpFromData 4 . text
 
-compPrec :: (RenderSym repr) => String -> GS (repr (BinaryOp repr))
+compPrec :: (RenderSym repr) => String -> FS (repr (BinaryOp repr))
 compPrec = bOpFromData 5 . text
 
-addPrec :: (RenderSym repr) => String -> GS (repr (BinaryOp repr))
+addPrec :: (RenderSym repr) => String -> FS (repr (BinaryOp repr))
 addPrec = bOpFromData 6 . text
 
-multPrec :: (RenderSym repr) => String -> GS (repr (BinaryOp repr))
+multPrec :: (RenderSym repr) => String -> FS (repr (BinaryOp repr))
 multPrec = bOpFromData 7 . text
 
-powerPrec :: (RenderSym repr) => String -> GS (repr (BinaryOp repr))
+powerPrec :: (RenderSym repr) => String -> FS (repr (BinaryOp repr))
 powerPrec = bOpFromData 8 . text
 
-andPrec :: (RenderSym repr) => String -> GS (repr (BinaryOp repr)) 
+andPrec :: (RenderSym repr) => String -> FS (repr (BinaryOp repr)) 
 andPrec = bOpFromData 3 . text
 
-orPrec :: (RenderSym repr) => String -> GS (repr (BinaryOp repr))
+orPrec :: (RenderSym repr) => String -> FS (repr (BinaryOp repr))
 orPrec = bOpFromData 2 . text
 
-equalOp :: (RenderSym repr) => GS (repr (BinaryOp repr))
+equalOp :: (RenderSym repr) => FS (repr (BinaryOp repr))
 equalOp = compEqualPrec "=="
 
-notEqualOp :: (RenderSym repr) => GS (repr (BinaryOp repr))
+notEqualOp :: (RenderSym repr) => FS (repr (BinaryOp repr))
 notEqualOp = compEqualPrec "!="
 
-greaterOp :: (RenderSym repr) => GS (repr (BinaryOp repr))
+greaterOp :: (RenderSym repr) => FS (repr (BinaryOp repr))
 greaterOp = compPrec ">"
 
-greaterEqualOp :: (RenderSym repr) => GS (repr (BinaryOp repr))
+greaterEqualOp :: (RenderSym repr) => FS (repr (BinaryOp repr))
 greaterEqualOp = compPrec ">="
 
-lessOp :: (RenderSym repr) => GS (repr (BinaryOp repr))
+lessOp :: (RenderSym repr) => FS (repr (BinaryOp repr))
 lessOp = compPrec "<"
 
-lessEqualOp :: (RenderSym repr) => GS (repr (BinaryOp repr))
+lessEqualOp :: (RenderSym repr) => FS (repr (BinaryOp repr))
 lessEqualOp = compPrec "<="
 
-plusOp :: (RenderSym repr) => GS (repr (BinaryOp repr))
+plusOp :: (RenderSym repr) => FS (repr (BinaryOp repr))
 plusOp = addPrec "+"
 
-minusOp :: (RenderSym repr) => GS (repr (BinaryOp repr))
+minusOp :: (RenderSym repr) => FS (repr (BinaryOp repr))
 minusOp = addPrec "-"
 
-multOp :: (RenderSym repr) => GS (repr (BinaryOp repr))
+multOp :: (RenderSym repr) => FS (repr (BinaryOp repr))
 multOp = multPrec "*"
 
-divideOp :: (RenderSym repr) => GS (repr (BinaryOp repr))
+divideOp :: (RenderSym repr) => FS (repr (BinaryOp repr))
 divideOp = multPrec "/"
 
-moduloOp :: (RenderSym repr) => GS (repr (BinaryOp repr))
+moduloOp :: (RenderSym repr) => FS (repr (BinaryOp repr))
 moduloOp = multPrec "%"
 
-powerOp :: (RenderSym repr) => GS (repr (BinaryOp repr))
+powerOp :: (RenderSym repr) => FS (repr (BinaryOp repr))
 powerOp = powerPrec "pow"
 
-andOp :: (RenderSym repr) => GS (repr (BinaryOp repr))
+andOp :: (RenderSym repr) => FS (repr (BinaryOp repr))
 andOp = andPrec "&&"
 
-orOp :: (RenderSym repr) => GS (repr (BinaryOp repr))
+orOp :: (RenderSym repr) => FS (repr (BinaryOp repr))
 orOp = orPrec "||"
 
 binOpDocD :: Doc -> Doc -> Doc -> Doc
@@ -353,224 +353,224 @@ binOpDocD op v1 v2 = v1 <+> op <+> v2
 binOpDocD' :: Doc -> Doc -> Doc -> Doc
 binOpDocD' op v1 v2 = op <> parens (v1 <> comma <+> v2)
 
-binExpr :: (RenderSym repr) => GS (repr (BinaryOp repr)) -> 
-  GS (repr (Value repr)) -> GS (repr (Value repr)) -> GS (repr (Value repr))
+binExpr :: (RenderSym repr) => FS (repr (BinaryOp repr)) -> 
+  FS (repr (Value repr)) -> FS (repr (Value repr)) -> FS (repr (Value repr))
 binExpr = on3StateValues (\b v1 v2 -> mkExpr (bOpPrec b) (numType (valueType v1)
   (valueType v2)) (binOpDocD (bOpDoc b) (exprParensL b v1 $ valueDoc v1) 
   (exprParensR b v2 $ valueDoc v2)))
 
-binExpr' :: (RenderSym repr) => GS (repr (BinaryOp repr)) -> 
-  GS (repr (Value repr)) -> GS (repr (Value repr)) -> GS (repr (Value repr))
+binExpr' :: (RenderSym repr) => FS (repr (BinaryOp repr)) -> 
+  FS (repr (Value repr)) -> FS (repr (Value repr)) -> FS (repr (Value repr))
 binExpr' = on3StateValues (\b v1 v2 -> mkExpr 9 (numType (valueType v1) 
   (valueType v2)) (binOpDocD' (bOpDoc b) (valueDoc v1) (valueDoc v2)))
 
-typeBinExpr :: (RenderSym repr) => GS (repr (BinaryOp repr)) -> 
-  GS (repr (Type repr)) -> GS (repr (Value repr)) -> GS (repr (Value repr)) -> 
-  GS (repr (Value repr))
+typeBinExpr :: (RenderSym repr) => FS (repr (BinaryOp repr)) -> 
+  FS (repr (Type repr)) -> FS (repr (Value repr)) -> FS (repr (Value repr)) -> 
+  FS (repr (Value repr))
 typeBinExpr bod tp vl1 vl2 = (\b t v1 v2 -> mkExpr (bOpPrec b) t (binOpDocD 
   (bOpDoc b) (exprParensL b v1 $ valueDoc v1) (exprParensR b v2 $ valueDoc v2)))
   <$> bod <*> tp <*> vl1 <*> vl2 
 
-addmathImport :: GS a -> GS a
+addmathImport :: FS a -> FS a
 addmathImport = (>>) $ modify (addLangImport "math")
 
 -- Variables --
 
-var :: (RenderSym repr) => Label -> GS (repr (Type repr)) -> 
-  GS (repr (Variable repr))
+var :: (RenderSym repr) => Label -> FS (repr (Type repr)) -> 
+  FS (repr (Variable repr))
 var n t = mkStateVar n t (varDocD n)
 
-staticVar :: (RenderSym repr) => Label -> GS (repr (Type repr)) -> 
-  GS (repr (Variable repr))
+staticVar :: (RenderSym repr) => Label -> FS (repr (Type repr)) -> 
+  FS (repr (Variable repr))
 staticVar n t = mkStaticVar n t (varDocD n)
 
-extVar :: (RenderSym repr) => Label -> Label -> GS (repr (Type repr)) -> 
-  GS (repr (Variable repr))
+extVar :: (RenderSym repr) => Label -> Label -> FS (repr (Type repr)) -> 
+  FS (repr (Variable repr))
 extVar l n t = mkStateVar (l ++ "." ++ n) t (extVarDocD l n)
 
-self :: (RenderSym repr) => Label -> GS (repr (Variable repr))
+self :: (RenderSym repr) => Label -> FS (repr (Variable repr))
 self l = mkStateVar "this" (obj l) selfDocD
 
-enumVar :: (RenderSym repr) => Label -> Label -> GS (repr (Variable repr))
+enumVar :: (RenderSym repr) => Label -> Label -> FS (repr (Variable repr))
 enumVar e en = S.var e (enumType en)
 
-classVar :: (RenderSym repr) => (Doc -> Doc -> Doc) -> GS (repr (Type repr)) -> 
-  GS (repr (Variable repr)) -> GS (repr (Variable repr))
+classVar :: (RenderSym repr) => (Doc -> Doc -> Doc) -> FS (repr (Type repr)) -> 
+  FS (repr (Variable repr)) -> FS (repr (Variable repr))
 classVar f = on2StateValues (\c v -> classVarCheckStatic $ varFromData 
   (variableBind v) (getTypeString c ++ "." ++ variableName v) 
   (variableType v) (f (getTypeDoc c) (variableDoc v)))
 
-objVar :: (RenderSym repr) => GS (repr (Variable repr)) -> 
-  GS (repr (Variable repr)) -> GS (repr (Variable repr))
+objVar :: (RenderSym repr) => FS (repr (Variable repr)) -> 
+  FS (repr (Variable repr)) -> FS (repr (Variable repr))
 objVar = on2StateValues (\o v -> mkVar (variableName o ++ "." ++ variableName 
   v) (variableType v) (objVarDocD (variableDoc o) (variableDoc v)))
 
-objVarSelf :: (RenderSym repr) => Label -> GS (repr (Variable repr)) -> 
-  GS (repr (Variable repr))
+objVarSelf :: (RenderSym repr) => Label -> FS (repr (Variable repr)) -> 
+  FS (repr (Variable repr))
 objVarSelf l = S.objVar (S.self l)
 
 listVar :: (RenderSym repr) => Label -> repr (Permanence repr) -> 
-  GS (repr (Type repr)) -> GS (repr (Variable repr))
+  FS (repr (Type repr)) -> FS (repr (Variable repr))
 listVar n p t = S.var n (listType p t)
 
-listOf :: (RenderSym repr) => Label -> GS (repr (Type repr)) -> 
-  GS (repr (Variable repr))
+listOf :: (RenderSym repr) => Label -> FS (repr (Type repr)) -> 
+  FS (repr (Variable repr))
 listOf n = S.listVar n static_
 
-iterVar :: (RenderSym repr) => Label -> GS (repr (Type repr)) -> 
-  GS (repr (Variable repr))
+iterVar :: (RenderSym repr) => Label -> FS (repr (Type repr)) -> 
+  FS (repr (Variable repr))
 iterVar n t = S.var n (iterator t)
 
 -- Values --
 
-litTrue :: (RenderSym repr) => GS (repr (Value repr))
+litTrue :: (RenderSym repr) => FS (repr (Value repr))
 litTrue = mkStateVal S.bool (text "true")
 
-litFalse :: (RenderSym repr) => GS (repr (Value repr))
+litFalse :: (RenderSym repr) => FS (repr (Value repr))
 litFalse = mkStateVal S.bool (text "false")
 
-litChar :: (RenderSym repr) => Char -> GS (repr (Value repr))
+litChar :: (RenderSym repr) => Char -> FS (repr (Value repr))
 litChar c = mkStateVal S.char (quotes $ D.char c)
 
-litFloat :: (RenderSym repr) => Double -> GS (repr (Value repr))
+litFloat :: (RenderSym repr) => Double -> FS (repr (Value repr))
 litFloat f = mkStateVal S.float (D.double f)
 
-litInt :: (RenderSym repr) => Integer -> GS (repr (Value repr))
+litInt :: (RenderSym repr) => Integer -> FS (repr (Value repr))
 litInt i = mkStateVal S.int (integer i)
 
-litString :: (RenderSym repr) => String -> GS (repr (Value repr))
+litString :: (RenderSym repr) => String -> FS (repr (Value repr))
 litString s = mkStateVal S.string (doubleQuotedText s)
 
-pi :: (RenderSym repr) => GS (repr (Value repr))
+pi :: (RenderSym repr) => FS (repr (Value repr))
 pi = mkStateVal S.float (text "Math.PI")
 
-valueOf :: (RenderSym repr) => GS (repr (Variable repr)) -> 
-  GS (repr (Value repr))
+valueOf :: (RenderSym repr) => FS (repr (Variable repr)) -> 
+  FS (repr (Value repr))
 valueOf = onStateValue (\v -> mkVal (variableType v) (variableDoc v))
 
-arg :: (RenderSym repr) => GS (repr (Value repr)) -> GS (repr (Value repr)) ->
-  GS (repr (Value repr))
+arg :: (RenderSym repr) => FS (repr (Value repr)) -> FS (repr (Value repr)) ->
+  FS (repr (Value repr))
 arg = on3StateValues (\s n args -> mkVal s (argDocD n args)) S.string
 
-enumElement :: (RenderSym repr) => Label -> Label -> GS (repr (Value repr))
+enumElement :: (RenderSym repr) => Label -> Label -> FS (repr (Value repr))
 enumElement en e = mkStateVal (enumType en) (enumElemDocD en e)
 
-argsList :: (RenderSym repr) => String -> GS (repr (Value repr))
+argsList :: (RenderSym repr) => String -> FS (repr (Value repr))
 argsList l = mkStateVal (listType static_ S.string) (text l)
 
-inlineIf :: (RenderSym repr) => GS (repr (Value repr)) -> GS (repr (Value repr))
-  -> GS (repr (Value repr)) -> GS (repr (Value repr))
+inlineIf :: (RenderSym repr) => FS (repr (Value repr)) -> FS (repr (Value repr))
+  -> FS (repr (Value repr)) -> FS (repr (Value repr))
 inlineIf = on3StateValues (\c v1 v2 -> valFromData (prec c) (valueType v1) 
   (valueDoc c <+> text "?" <+> valueDoc v1 <+> text ":" <+> valueDoc v2)) 
   where prec cd = valuePrec cd <|> Just 0
 
-funcApp :: (RenderSym repr) => Label -> GS (repr (Type repr)) -> 
-  [GS (repr (Value repr))] -> GS (repr (Value repr))
+funcApp :: (RenderSym repr) => Label -> FS (repr (Type repr)) -> 
+  [FS (repr (Value repr))] -> FS (repr (Value repr))
 funcApp n = on1StateValue1List (\t -> mkVal t . funcAppDocD n)
 
-selfFuncApp :: (RenderSym repr) => GS (repr (Variable repr)) -> Label -> 
-  GS (repr (Type repr)) -> [GS (repr (Value repr))] -> GS (repr (Value repr))
+selfFuncApp :: (RenderSym repr) => FS (repr (Variable repr)) -> Label -> 
+  FS (repr (Type repr)) -> [FS (repr (Value repr))] -> FS (repr (Value repr))
 selfFuncApp s n t vs = s >>= 
   (\slf -> S.funcApp (variableName slf ++ "." ++ n) t vs)
 
-extFuncApp :: (RenderSym repr) => Library -> Label -> GS (repr (Type repr)) -> 
-  [GS (repr (Value repr))] -> GS (repr (Value repr))
+extFuncApp :: (RenderSym repr) => Library -> Label -> FS (repr (Type repr)) -> 
+  [FS (repr (Value repr))] -> FS (repr (Value repr))
 extFuncApp l n = S.funcApp (l ++ "." ++ n)
 
 newObj :: (RenderSym repr) => (repr (Type repr) -> Doc -> Doc) -> 
-  GS (repr (Type repr)) -> [GS (repr (Value repr))] -> GS (repr (Value repr))
+  FS (repr (Type repr)) -> [FS (repr (Value repr))] -> FS (repr (Value repr))
 newObj f = on1StateValue1List (\t -> mkVal t . f t . valueList)
 
-notNull :: (RenderSym repr) => GS (repr (Value repr)) -> GS (repr (Value repr))
+notNull :: (RenderSym repr) => FS (repr (Value repr)) -> FS (repr (Value repr))
 notNull v = v ?!= S.valueOf (S.var "null" $ onStateValue valueType v)
 
-objAccess :: (RenderSym repr) => GS (repr (Value repr)) ->
-  GS (repr (Function repr)) -> GS (repr (Value repr))
+objAccess :: (RenderSym repr) => FS (repr (Value repr)) ->
+  FS (repr (Function repr)) -> FS (repr (Value repr))
 objAccess = on2StateValues (\v f -> mkVal (functionType f) (objAccessDocD 
   (valueDoc v) (functionDoc f)))
 
-objMethodCall :: (RenderSym repr) => Label -> GS (repr (Type repr)) -> 
-  GS (repr (Value repr)) -> [GS (repr (Value repr))] -> GS (repr (Value repr))
+objMethodCall :: (RenderSym repr) => Label -> FS (repr (Type repr)) -> 
+  FS (repr (Value repr)) -> [FS (repr (Value repr))] -> FS (repr (Value repr))
 objMethodCall f t o ps = S.objAccess o (S.func f t ps)
 
-objMethodCallNoParams :: (RenderSym repr) => Label -> GS (repr (Type repr)) -> 
-  GS (repr (Value repr)) -> GS (repr (Value repr))
+objMethodCallNoParams :: (RenderSym repr) => Label -> FS (repr (Type repr)) -> 
+  FS (repr (Value repr)) -> FS (repr (Value repr))
 objMethodCallNoParams f t o = S.objMethodCall t o f []
 
-selfAccess :: (RenderSym repr) => Label -> GS (repr (Function repr)) -> 
-  GS (repr (Value repr))
+selfAccess :: (RenderSym repr) => Label -> FS (repr (Function repr)) -> 
+  FS (repr (Value repr))
 selfAccess l = S.objAccess (S.valueOf $ S.self l)
 
-listIndexExists :: (RenderSym repr) => GS (repr (Value repr)) -> 
-  GS (repr (Value repr)) -> GS (repr (Value repr))
+listIndexExists :: (RenderSym repr) => FS (repr (Value repr)) -> 
+  FS (repr (Value repr)) -> FS (repr (Value repr))
 listIndexExists lst index = S.listSize lst ?> index
 
-indexOf :: (RenderSym repr) => Label -> GS (repr (Value repr)) -> 
-  GS (repr (Value repr)) -> GS (repr (Value repr))
+indexOf :: (RenderSym repr) => Label -> FS (repr (Value repr)) -> 
+  FS (repr (Value repr)) -> FS (repr (Value repr))
 indexOf f l v = S.objAccess l (S.func f S.int [v])
 
 -- Functions --
 
-func :: (RenderSym repr) => Label -> GS (repr (Type repr)) -> 
-  [GS (repr (Value repr))] -> GS (repr (Function repr))
+func :: (RenderSym repr) => Label -> FS (repr (Type repr)) -> 
+  [FS (repr (Value repr))] -> FS (repr (Function repr))
 func l t vs = S.funcApp l t vs >>= ((`funcFromData` t) . funcDocD . valueDoc)
 
-get :: (RenderSym repr) => GS (repr (Value repr)) -> GS (repr (Variable repr)) 
-  -> GS (repr (Value repr))
+get :: (RenderSym repr) => FS (repr (Value repr)) -> FS (repr (Variable repr)) 
+  -> FS (repr (Value repr))
 get v vToGet = v $. S.getFunc vToGet
 
-set :: (RenderSym repr) => GS (repr (Value repr)) -> GS (repr (Variable repr)) 
-  -> GS (repr (Value repr)) -> GS (repr (Value repr))
+set :: (RenderSym repr) => FS (repr (Value repr)) -> FS (repr (Variable repr)) 
+  -> FS (repr (Value repr)) -> FS (repr (Value repr))
 set v vToSet toVal = v $. S.setFunc (onStateValue valueType v) vToSet toVal
 
-listSize :: (RenderSym repr) => GS (repr (Value repr)) -> GS (repr (Value repr))
+listSize :: (RenderSym repr) => FS (repr (Value repr)) -> FS (repr (Value repr))
 listSize v = v $. S.listSizeFunc
 
-listAdd :: (RenderSym repr) => GS (repr (Value repr)) -> GS (repr (Value repr)) 
-  -> GS (repr (Value repr)) -> GS (repr (Value repr))
+listAdd :: (RenderSym repr) => FS (repr (Value repr)) -> FS (repr (Value repr)) 
+  -> FS (repr (Value repr)) -> FS (repr (Value repr))
 listAdd v i vToAdd = v $. S.listAddFunc v i vToAdd
 
-listAppend :: (RenderSym repr) => GS (repr (Value repr)) -> 
-  GS (repr (Value repr)) -> GS (repr (Value repr))
+listAppend :: (RenderSym repr) => FS (repr (Value repr)) -> 
+  FS (repr (Value repr)) -> FS (repr (Value repr))
 listAppend v vToApp = v $. S.listAppendFunc vToApp
 
-iterBegin :: (RenderSym repr) => GS (repr (Value repr)) -> 
-  GS (repr (Value repr))
+iterBegin :: (RenderSym repr) => FS (repr (Value repr)) -> 
+  FS (repr (Value repr))
 iterBegin v = v $. iterBeginFunc (S.listInnerType $ onStateValue valueType v)
 
-iterEnd :: (RenderSym repr) => GS (repr (Value repr)) -> GS (repr (Value repr))
+iterEnd :: (RenderSym repr) => FS (repr (Value repr)) -> FS (repr (Value repr))
 iterEnd v = v $. iterEndFunc (S.listInnerType $ onStateValue valueType v)
 
-listAccess :: (RenderSym repr) => GS (repr (Value repr)) -> 
-  GS (repr (Value repr)) -> GS (repr (Value repr))
+listAccess :: (RenderSym repr) => FS (repr (Value repr)) -> 
+  FS (repr (Value repr)) -> FS (repr (Value repr))
 listAccess v i = v $. S.listAccessFunc (S.listInnerType $ onStateValue 
   valueType v) i
 
-listSet :: (RenderSym repr) => GS (repr (Value repr)) -> GS (repr (Value repr)) 
-  -> GS (repr (Value repr)) -> GS (repr (Value repr))
+listSet :: (RenderSym repr) => FS (repr (Value repr)) -> FS (repr (Value repr)) 
+  -> FS (repr (Value repr)) -> FS (repr (Value repr))
 listSet v i toVal = v $. S.listSetFunc v i toVal
 
-getFunc :: (RenderSym repr) => GS (repr (Variable repr)) -> 
-  GS (repr (Function repr))
+getFunc :: (RenderSym repr) => FS (repr (Variable repr)) -> 
+  FS (repr (Function repr))
 getFunc v = v >>= (\vr -> S.func (getterName $ variableName vr) 
   (toState $ variableType vr) [])
 
-setFunc :: (RenderSym repr) => GS (repr (Type repr)) ->
-  GS (repr (Variable repr)) -> GS (repr (Value repr)) -> 
-  GS (repr (Function repr))
+setFunc :: (RenderSym repr) => FS (repr (Type repr)) ->
+  FS (repr (Variable repr)) -> FS (repr (Value repr)) -> 
+  FS (repr (Function repr))
 setFunc t v toVal = v >>= (\vr -> S.func (setterName $ variableName vr) t 
   [toVal])
 
-listSizeFunc :: (RenderSym repr) => GS (repr (Function repr))
+listSizeFunc :: (RenderSym repr) => FS (repr (Function repr))
 listSizeFunc = S.func "size" S.int []
 
-listAddFunc :: (RenderSym repr) => Label -> GS (repr (Value repr)) -> 
-  GS (repr (Value repr)) -> GS (repr (Function repr))
+listAddFunc :: (RenderSym repr) => Label -> FS (repr (Value repr)) -> 
+  FS (repr (Value repr)) -> FS (repr (Function repr))
 listAddFunc f i v = S.func f (listType static_ $ onStateValue valueType v) 
   [i, v]
 
-listAppendFunc :: (RenderSym repr) => Label -> GS (repr (Value repr)) -> 
-  GS (repr (Function repr))
+listAppendFunc :: (RenderSym repr) => Label -> FS (repr (Value repr)) -> 
+  FS (repr (Function repr))
 listAppendFunc f v = S.func f (listType static_ $ onStateValue valueType v) [v]
 
 iterBeginError :: String -> String
@@ -581,152 +581,152 @@ iterEndError :: String -> String
 iterEndError l = "Attempt to use iterEndFunc in " ++ l ++ ", but " ++ l ++ 
   " has no iterators"
 
-listAccessFunc :: (RenderSym repr) => GS (repr (Type repr)) ->
-  GS (repr (Value repr)) -> GS (repr (Function repr))
+listAccessFunc :: (RenderSym repr) => FS (repr (Type repr)) ->
+  FS (repr (Value repr)) -> FS (repr (Function repr))
 listAccessFunc t v = intValue v >>= ((`funcFromData` t) . listAccessFuncDocD)
 
-listAccessFunc' :: (RenderSym repr) => Label -> GS (repr (Type repr)) -> 
-  GS (repr (Value repr)) -> GS (repr (Function repr))
+listAccessFunc' :: (RenderSym repr) => Label -> FS (repr (Type repr)) -> 
+  FS (repr (Value repr)) -> FS (repr (Function repr))
 listAccessFunc' f t i = S.func f t [intValue i]
 
 listSetFunc :: (RenderSym repr) => (Doc -> Doc -> Doc) -> 
-  GS (repr (Value repr)) -> GS (repr (Value repr)) -> GS (repr (Value repr)) -> 
-  GS (repr (Function repr))
+  FS (repr (Value repr)) -> FS (repr (Value repr)) -> FS (repr (Value repr)) -> 
+  FS (repr (Function repr))
 listSetFunc f v idx setVal = join $ on2StateValues (\i toVal -> funcFromData 
   (f (valueDoc i) (valueDoc toVal)) (onStateValue valueType v)) (intValue idx) 
   setVal
 
 -- Statements --
 
-printSt :: (RenderSym repr) => GS (repr (Value repr)) -> GS (repr (Value repr))
-  -> GS (repr (Statement repr))
+printSt :: (RenderSym repr) => FS (repr (Value repr)) -> FS (repr (Value repr))
+  -> FS (repr (Statement repr))
 printSt = on2StateValues (\p v -> stateFromData (printDoc p v) Semi)
 
-state :: (RenderSym repr) => GS (repr (Statement repr)) -> 
-  GS (repr (Statement repr))
+state :: (RenderSym repr) => FS (repr (Statement repr)) -> 
+  FS (repr (Statement repr))
 state = onStateValue (\s -> stateFromData (statementDoc s <> getTermDoc 
   (statementTerm s)) Empty)
   
-loopState :: (RenderSym repr) => GS (repr (Statement repr)) -> 
-  GS (repr (Statement repr))
+loopState :: (RenderSym repr) => FS (repr (Statement repr)) -> 
+  FS (repr (Statement repr))
 loopState = S.state . setEmpty
 
-emptyState :: (RenderSym repr) => GS (repr (Statement repr))
+emptyState :: (RenderSym repr) => FS (repr (Statement repr))
 emptyState = toState $ stateFromData empty Empty
 
-assign :: (RenderSym repr) => Terminator -> GS (repr (Variable repr)) -> 
-  GS (repr (Value repr)) -> GS (repr (Statement repr))
+assign :: (RenderSym repr) => Terminator -> FS (repr (Variable repr)) -> 
+  FS (repr (Value repr)) -> FS (repr (Statement repr))
 assign t = on2StateValues (\vr vl -> stateFromData (assignDocD vr vl) t)
 
-assignToListIndex :: (RenderSym repr) => GS (repr (Variable repr)) -> 
-  GS (repr (Value repr)) -> GS (repr (Value repr)) -> GS (repr (Statement repr))
+assignToListIndex :: (RenderSym repr) => FS (repr (Variable repr)) -> 
+  FS (repr (Value repr)) -> FS (repr (Value repr)) -> FS (repr (Statement repr))
 assignToListIndex lst index v = S.valState $ S.listSet (S.valueOf lst) index v
 
 multiAssignError :: String -> String
 multiAssignError l = "No multiple assignment statements in " ++ l
 
-decrement :: (RenderSym repr) => GS (repr (Variable repr)) -> 
-  GS (repr (Value repr)) -> GS (repr (Statement repr))
+decrement :: (RenderSym repr) => FS (repr (Variable repr)) -> 
+  FS (repr (Value repr)) -> FS (repr (Statement repr))
 decrement vr vl = vr &= (S.valueOf vr #- vl)
 
-increment :: (RenderSym repr) => GS (repr (Variable repr)) -> 
-  GS (repr (Value repr)) -> GS (repr (Statement repr))
+increment :: (RenderSym repr) => FS (repr (Variable repr)) -> 
+  FS (repr (Value repr)) -> FS (repr (Statement repr))
 increment = on2StateValues (\vr vl -> stateFromData (plusEqualsDocD vr vl) Semi)
 
-increment1 :: (RenderSym repr) => GS (repr (Variable repr)) -> 
-  GS (repr (Statement repr))
+increment1 :: (RenderSym repr) => FS (repr (Variable repr)) -> 
+  FS (repr (Statement repr))
 increment1 = onStateValue (\v -> stateFromData (plusPlusDocD v) Semi)
 
-increment' :: (RenderSym repr) => GS (repr (Variable repr)) -> 
-  GS (repr (Value repr)) -> GS (repr (Statement repr))
+increment' :: (RenderSym repr) => FS (repr (Variable repr)) -> 
+  FS (repr (Value repr)) -> FS (repr (Statement repr))
 increment' vr vl = vr &= S.valueOf vr #+ vl
 
-increment1' :: (RenderSym repr) => GS (repr (Variable repr)) -> 
-  GS (repr (Statement repr))
+increment1' :: (RenderSym repr) => FS (repr (Variable repr)) -> 
+  FS (repr (Statement repr))
 increment1' vr = vr &= S.valueOf vr #+ S.litInt 1
 
-decrement1 :: (RenderSym repr) => GS (repr (Variable repr)) -> 
-  GS (repr (Statement repr))
+decrement1 :: (RenderSym repr) => FS (repr (Variable repr)) -> 
+  FS (repr (Statement repr))
 decrement1 v = v &= (S.valueOf v #- S.litInt 1)
 
 varDec :: (RenderSym repr) => repr (Permanence repr) -> repr (Permanence repr) 
-  -> GS (repr (Variable repr)) -> GS (repr (Statement repr))
+  -> FS (repr (Variable repr)) -> FS (repr (Statement repr))
 varDec s d = onStateValue (\v -> stateFromData (permDoc (bind $ variableBind v) 
   <+> getTypeDoc (variableType v) <+> variableDoc v) Semi)
   where bind Static = s
         bind Dynamic = d
 
-varDecDef :: (RenderSym repr) => GS (repr (Variable repr)) -> 
-  GS (repr (Value repr)) -> GS (repr (Statement repr))
+varDecDef :: (RenderSym repr) => FS (repr (Variable repr)) -> 
+  FS (repr (Value repr)) -> FS (repr (Statement repr))
 varDecDef vr = on2StateValues (\vd vl -> stateFromData (statementDoc vd <+> 
   equals <+> valueDoc vl) Semi) (S.varDec vr)
 
 listDec :: (RenderSym repr) => (repr (Value repr) -> Doc) -> 
-  GS (repr (Value repr)) -> GS (repr (Variable repr)) -> 
-  GS (repr (Statement repr))
+  FS (repr (Value repr)) -> FS (repr (Variable repr)) -> 
+  FS (repr (Statement repr))
 listDec f vl v = on2StateValues (\sz vd -> stateFromData (statementDoc vd <> f 
   sz) Semi) vl (S.varDec v)
 
 listDecDef :: (RenderSym repr) => ([repr (Value repr)] -> Doc) -> 
-  GS (repr (Variable repr)) -> [GS (repr (Value repr))] -> 
-  GS (repr (Statement repr))
+  FS (repr (Variable repr)) -> [FS (repr (Value repr))] -> 
+  FS (repr (Statement repr))
 listDecDef f v = on1StateValue1List (\vd vs -> stateFromData (statementDoc vd 
   <> f vs) Semi) (S.varDec v)
 
-listDecDef' :: (RenderSym repr) => GS (repr (Variable repr)) -> 
-  [GS (repr (Value repr))] -> GS (repr (Statement repr))
+listDecDef' :: (RenderSym repr) => FS (repr (Variable repr)) -> 
+  [FS (repr (Value repr))] -> FS (repr (Statement repr))
 listDecDef' v vals = on3StateValues (\vd vr vs -> stateFromData (statementDoc
   vd <+> equals <+> new <+> getTypeDoc (variableType vr) <+> braces 
   (valueList vs)) Semi) (S.varDec v) v (sequence vals)
 
-objDecNew :: (RenderSym repr) => GS (repr (Variable repr)) -> 
-  [GS (repr (Value repr))] -> GS (repr (Statement repr))
+objDecNew :: (RenderSym repr) => FS (repr (Variable repr)) -> 
+  [FS (repr (Value repr))] -> FS (repr (Statement repr))
 objDecNew v vs = S.varDecDef v (S.newObj (onStateValue variableType v) vs)
 
-objDecNewNoParams :: (RenderSym repr) => GS (repr (Variable repr)) -> 
-  GS (repr (Statement repr))
+objDecNewNoParams :: (RenderSym repr) => FS (repr (Variable repr)) -> 
+  FS (repr (Statement repr))
 objDecNewNoParams v = S.objDecNew v []
 
-constDecDef :: (RenderSym repr) => GS (repr (Variable repr)) -> 
-  GS (repr (Value repr)) -> GS (repr (Statement repr))
+constDecDef :: (RenderSym repr) => FS (repr (Variable repr)) -> 
+  FS (repr (Value repr)) -> FS (repr (Statement repr))
 constDecDef = on2StateValues (\v def -> stateFromData (constDecDefDocD v def) 
   Semi)
 
 discardInput :: (RenderSym repr) => (repr (Value repr) -> Doc) ->
-  GS (repr (Statement repr))
+  FS (repr (Statement repr))
 discardInput f = onStateValue (\infn -> stateFromData (f infn) Semi) inputFunc
 
 discardFileInput :: (RenderSym repr) => (repr (Value repr) -> Doc) -> 
-  GS (repr (Value repr)) -> GS (repr (Statement repr))
+  FS (repr (Value repr)) -> FS (repr (Statement repr))
 discardFileInput f = onStateValue (\v -> stateFromData (f v) Semi)
 
-openFileR :: (RenderSym repr) => (GS (repr (Value repr)) -> 
-  GS (repr (Type repr)) -> GS (repr (Value repr))) -> GS (repr (Variable repr)) 
-  -> GS (repr (Value repr)) -> GS (repr (Statement repr))
+openFileR :: (RenderSym repr) => (FS (repr (Value repr)) -> 
+  FS (repr (Type repr)) -> FS (repr (Value repr))) -> FS (repr (Variable repr)) 
+  -> FS (repr (Value repr)) -> FS (repr (Statement repr))
 openFileR f vr vl = vr &= f vl infile
 
-openFileW :: (RenderSym repr) => (GS (repr (Value repr)) -> 
-  GS (repr (Type repr)) -> GS (repr (Value repr)) -> GS (repr (Value repr))) -> 
-  GS (repr (Variable repr)) -> GS (repr (Value repr)) ->
-  GS (repr (Statement repr))
+openFileW :: (RenderSym repr) => (FS (repr (Value repr)) -> 
+  FS (repr (Type repr)) -> FS (repr (Value repr)) -> FS (repr (Value repr))) -> 
+  FS (repr (Variable repr)) -> FS (repr (Value repr)) ->
+  FS (repr (Statement repr))
 openFileW f vr vl = vr &= f vl outfile S.litFalse
 
-openFileA :: (RenderSym repr) => (GS (repr (Value repr)) -> 
-  GS (repr (Type repr)) -> GS (repr (Value repr)) -> GS (repr (Value repr))) -> 
-  GS (repr (Variable repr)) -> GS (repr (Value repr)) -> 
-  GS (repr (Statement repr))
+openFileA :: (RenderSym repr) => (FS (repr (Value repr)) -> 
+  FS (repr (Type repr)) -> FS (repr (Value repr)) -> FS (repr (Value repr))) -> 
+  FS (repr (Variable repr)) -> FS (repr (Value repr)) -> 
+  FS (repr (Statement repr))
 openFileA f vr vl = vr &= f vl outfile S.litTrue
 
-closeFile :: (RenderSym repr) => Label -> GS (repr (Value repr)) -> 
-  GS (repr (Statement repr))
+closeFile :: (RenderSym repr) => Label -> FS (repr (Value repr)) -> 
+  FS (repr (Statement repr))
 closeFile n f = S.valState $ S.objMethodCallNoParams S.void f n
 
-discardFileLine :: (RenderSym repr) => Label -> GS (repr (Value repr)) -> 
-  GS (repr (Statement repr))
+discardFileLine :: (RenderSym repr) => Label -> FS (repr (Value repr)) -> 
+  FS (repr (Statement repr))
 discardFileLine n f = S.valState $ S.objMethodCallNoParams S.string f n 
 
-stringListVals :: (RenderSym repr) => [GS (repr (Variable repr))] -> 
-  GS (repr (Value repr)) -> GS (repr (Statement repr))
+stringListVals :: (RenderSym repr) => [FS (repr (Variable repr))] -> 
+  FS (repr (Value repr)) -> FS (repr (Statement repr))
 stringListVals vars sl = sl >>= (\slst -> multi $ checkList (getType $ 
   valueType slst))
   where checkList (List String) = assignVals vars 0
@@ -736,8 +736,8 @@ stringListVals vars sl = sl >>= (\slst -> multi $ checkList (getType $
         assignVals (v:vs) n = S.assign v (cast (onStateValue variableType v) 
           (S.listAccess sl (S.litInt n))) : assignVals vs (n+1)
 
-stringListLists :: (RenderSym repr) => [GS (repr (Variable repr))] -> 
-  GS (repr (Value repr)) -> GS (repr (Statement repr))
+stringListLists :: (RenderSym repr) => [FS (repr (Variable repr))] -> 
+  FS (repr (Value repr)) -> FS (repr (Statement repr))
 stringListLists lsts sl = sl >>= (\slst -> checkList (getType $ valueType slst))
   where checkList (List String) = sequence lsts >>= listVals . map (getType . 
           variableType)
@@ -758,41 +758,41 @@ stringListLists lsts sl = sl >>= (\slst -> checkList (getType $ valueType slst))
         var_i = S.var "stringlist_i" S.int
         v_i = S.valueOf var_i
 
-returnState :: (RenderSym repr) => Terminator -> GS (repr (Value repr)) -> 
-  GS (repr (Statement repr))
+returnState :: (RenderSym repr) => Terminator -> FS (repr (Value repr)) -> 
+  FS (repr (Statement repr))
 returnState t = onStateValue (\v -> stateFromData (returnDocD [v]) t)
 
 multiReturnError :: String -> String
 multiReturnError l = "Cannot return multiple values in " ++ l
 
-valState :: (RenderSym repr) => Terminator -> GS (repr (Value repr)) ->
-  GS (repr (Statement repr))
+valState :: (RenderSym repr) => Terminator -> FS (repr (Value repr)) ->
+  FS (repr (Statement repr))
 valState t = onStateValue (\v -> stateFromData (valueDoc v) t)
 
 comment :: (RenderSym repr) => repr (Keyword repr) -> Label -> 
-  GS (repr (Statement repr))
+  FS (repr (Statement repr))
 comment cs c = toState $ stateFromData (commentDocD c (keyDoc cs)) Empty
 
 freeError :: String -> String
 freeError l = "Cannot free variables in " ++ l
 
 throw :: (RenderSym repr) => (repr (Value repr) -> Doc) -> Terminator -> 
-  Label -> GS (repr (Statement repr))
+  Label -> FS (repr (Statement repr))
 throw f t = onStateValue (\msg -> stateFromData (f msg) t) . S.litString
 
-initState :: (RenderSym repr) => Label -> Label -> GS (repr (Statement repr))
+initState :: (RenderSym repr) => Label -> Label -> FS (repr (Statement repr))
 initState fsmName initialState = S.varDecDef (S.var fsmName S.string) 
   (S.litString initialState)
 
-changeState :: (RenderSym repr) => Label -> Label -> GS (repr (Statement repr))
+changeState :: (RenderSym repr) => Label -> Label -> FS (repr (Statement repr))
 changeState fsmName tState = S.var fsmName S.string &= S.litString tState
 
-initObserverList :: (RenderSym repr) => GS (repr (Type repr)) -> 
-  [GS (repr (Value repr))] -> GS (repr (Statement repr))
+initObserverList :: (RenderSym repr) => FS (repr (Type repr)) -> 
+  [FS (repr (Value repr))] -> FS (repr (Statement repr))
 initObserverList t = S.listDecDef (S.var observerListName (S.listType static_ t))
 
-addObserver :: (RenderSym repr) => GS (repr (Value repr)) -> 
-  GS (repr (Statement repr))
+addObserver :: (RenderSym repr) => FS (repr (Value repr)) -> 
+  FS (repr (Statement repr))
 addObserver o = S.valState $ S.listAdd obsList lastelem o
   where obsList = S.valueOf $ observerListName `S.listOf` onStateValue 
           valueType o
@@ -801,8 +801,8 @@ addObserver o = S.valState $ S.listAdd obsList lastelem o
 -- ControlStatements --
 
 ifCond :: (RenderSym repr) => repr (Keyword repr) -> repr (Keyword repr) -> 
-  repr (Keyword repr) -> [(GS (repr (Value repr)), GS (repr (Body repr)))] -> 
-  GS (repr (Body repr)) -> GS (repr (Statement repr))
+  repr (Keyword repr) -> [(FS (repr (Value repr)), FS (repr (Body repr)))] -> 
+  FS (repr (Body repr)) -> FS (repr (Statement repr))
 ifCond _ _ _ [] _ = error "if condition created with no cases"
 ifCond ifst elseif blEnd (c:cs) eBody = 
     let ifStart = keyDoc ifst
@@ -823,30 +823,30 @@ ifCond ifst elseif blEnd (c:cs) eBody =
     in onStateList (\l -> stateFromData (vcat l) Empty)
       (ifSect c : map elseIfSect cs ++ [elseSect])
 
-ifNoElse :: (RenderSym repr) => [(GS (repr (Value repr)), 
-  GS (repr (Body repr)))] -> GS (repr (Statement repr))
+ifNoElse :: (RenderSym repr) => [(FS (repr (Value repr)), 
+  FS (repr (Body repr)))] -> FS (repr (Statement repr))
 ifNoElse bs = S.ifCond bs $ body []
 
-switch :: (RenderSym repr) => GS (repr (Value repr)) -> 
-  [(GS (repr (Value repr)), GS (repr (Body repr)))] -> GS (repr (Body repr)) -> 
-  GS (repr (Statement repr))
+switch :: (RenderSym repr) => FS (repr (Value repr)) -> 
+  [(FS (repr (Value repr)), FS (repr (Body repr)))] -> FS (repr (Body repr)) -> 
+  FS (repr (Statement repr))
 switch v cs = on4StateValues (\b val css de -> stateFromData (switchDocD b val 
   de css) Semi) (S.state break) v (on2StateLists zip (map fst cs) (map snd cs))
 
-switchAsIf :: (RenderSym repr) => GS (repr (Value repr)) -> 
-  [(GS (repr (Value repr)), GS (repr (Body repr)))] -> GS (repr (Body repr)) -> 
-  GS (repr (Statement repr))
+switchAsIf :: (RenderSym repr) => FS (repr (Value repr)) -> 
+  [(FS (repr (Value repr)), FS (repr (Body repr)))] -> FS (repr (Body repr)) -> 
+  FS (repr (Statement repr))
 switchAsIf v cs = S.ifCond cases
   where cases = map (first (v ?==)) cs
 
-ifExists :: (RenderSym repr) => GS (repr (Value repr)) -> GS (repr (Body repr)) 
-  -> GS (repr (Body repr)) -> GS (repr (Statement repr))
+ifExists :: (RenderSym repr) => FS (repr (Value repr)) -> FS (repr (Body repr)) 
+  -> FS (repr (Body repr)) -> FS (repr (Statement repr))
 ifExists v ifBody = S.ifCond [(S.notNull v, ifBody)]
 
 for :: (RenderSym repr) => repr (Keyword repr) -> repr (Keyword repr) -> 
-  GS (repr (Statement repr)) -> GS (repr (Value repr)) -> 
-  GS (repr (Statement repr)) -> GS (repr (Body repr)) -> 
-  GS (repr (Statement repr))
+  FS (repr (Statement repr)) -> FS (repr (Value repr)) -> 
+  FS (repr (Statement repr)) -> FS (repr (Body repr)) -> 
+  FS (repr (Statement repr))
 for bStart bEnd sInit vGuard sUpdate = on4StateValues (\initl guard upd bod -> 
   stateFromData (vcat [
   forLabel <+> parens (statementDoc initl <> semi <+> valueDoc guard <> semi 
@@ -854,15 +854,15 @@ for bStart bEnd sInit vGuard sUpdate = on4StateValues (\initl guard upd bod ->
   indent $ bodyDoc bod,
   keyDoc bEnd]) Empty) (S.loopState sInit) vGuard (S.loopState sUpdate)
 
-forRange :: (RenderSym repr) => GS (repr (Variable repr)) -> 
-  GS (repr (Value repr)) -> GS (repr (Value repr)) -> GS (repr (Value repr)) -> 
-  GS (repr (Body repr)) -> GS (repr (Statement repr))
+forRange :: (RenderSym repr) => FS (repr (Variable repr)) -> 
+  FS (repr (Value repr)) -> FS (repr (Value repr)) -> FS (repr (Value repr)) -> 
+  FS (repr (Body repr)) -> FS (repr (Statement repr))
 forRange i initv finalv stepv = S.for (S.varDecDef i initv) (S.valueOf i ?< 
   finalv) (i &+= stepv)
 
 forEach :: (RenderSym repr) => repr (Keyword repr) -> repr (Keyword repr) -> 
-  repr (Keyword repr) -> repr (Keyword repr) -> GS (repr (Variable repr)) -> 
-  GS (repr (Value repr)) -> GS (repr (Body repr)) -> GS (repr (Statement repr))
+  repr (Keyword repr) -> repr (Keyword repr) -> FS (repr (Variable repr)) -> 
+  FS (repr (Value repr)) -> FS (repr (Body repr)) -> FS (repr (Statement repr))
 forEach bStart bEnd forEachLabel inLbl = on3StateValues (\e v b -> stateFromData
   (vcat [keyDoc forEachLabel <+> parens (getTypeDoc (variableType e) <+> 
     variableDoc e <+> keyDoc inLbl <+> valueDoc v) <+> keyDoc bStart,
@@ -870,22 +870,22 @@ forEach bStart bEnd forEachLabel inLbl = on3StateValues (\e v b -> stateFromData
   keyDoc bEnd]) Empty) 
 
 while :: (RenderSym repr) => repr (Keyword repr) -> repr (Keyword repr) -> 
-  GS (repr (Value repr)) -> GS (repr (Body repr)) -> GS (repr (Statement repr))
+  FS (repr (Value repr)) -> FS (repr (Body repr)) -> FS (repr (Statement repr))
 while bStart bEnd = on2StateValues (\v b -> stateFromData (vcat [
   text "while" <+> parens (valueDoc v) <+> keyDoc bStart,
   indent $ bodyDoc b,
   keyDoc bEnd]) Empty)
 
 tryCatch :: (RenderSym repr) => (repr (Body repr) -> repr (Body repr) -> Doc) ->
-  GS (repr (Body repr)) -> GS (repr (Body repr)) -> GS (repr (Statement repr))
+  FS (repr (Body repr)) -> FS (repr (Body repr)) -> FS (repr (Statement repr))
 tryCatch f = on2StateValues (\tb cb -> stateFromData (f tb cb) Empty)
 
-checkState :: (RenderSym repr) => Label -> [(GS (repr (Value repr)), 
-  GS (repr (Body repr)))] -> GS (repr (Body repr)) -> GS (repr (Statement repr))
+checkState :: (RenderSym repr) => Label -> [(FS (repr (Value repr)), 
+  FS (repr (Body repr)))] -> FS (repr (Body repr)) -> FS (repr (Statement repr))
 checkState l = S.switch (S.valueOf $ S.var l S.string)
 
-notifyObservers :: (RenderSym repr) => GS (repr (Function repr)) -> 
-  GS (repr (Type repr)) -> GS (repr (Statement repr))
+notifyObservers :: (RenderSym repr) => FS (repr (Function repr)) -> 
+  FS (repr (Type repr)) -> FS (repr (Statement repr))
 notifyObservers f t = S.for initv (v_index ?< S.listSize obsList) 
   (var_index &++) notify
   where obsList = S.valueOf $ observerListName `S.listOf` t 
@@ -896,60 +896,60 @@ notifyObservers f t = S.for initv (v_index ?< S.listSize obsList)
 
 -- Methods --
 
-construct :: (RenderSym repr) => Label -> GS (repr (Type repr))
+construct :: (RenderSym repr) => Label -> FS (repr (Type repr))
 construct n = toState $ typeFromData (Object n) n empty
 
 param :: (RenderSym repr) => (repr (Variable repr) -> Doc) -> 
-  GS (repr (Variable repr)) -> MS (repr (Parameter repr))
+  FS (repr (Variable repr)) -> MS (repr (Parameter repr))
 param f = getPutReturnFunc (\s v -> addParameter (variableName v) s) 
-  (\v -> paramFromData v (f v)) . zoom lensMStoGS
+  (\v -> paramFromData v (f v)) . zoom lensMStoFS
 
 method :: (RenderSym repr) => Label -> Label -> repr (Scope repr) -> 
-  repr (Permanence repr) -> GS (repr (Type repr)) -> 
-  [MS (repr (Parameter repr))] -> GS (repr (Body repr)) -> 
+  repr (Permanence repr) -> FS (repr (Type repr)) -> 
+  [MS (repr (Parameter repr))] -> FS (repr (Body repr)) -> 
   MS (repr (Method repr))
 method n c s p t = intMethod False n c s p (mType t)
 
-getMethod :: (RenderSym repr) => Label -> GS (repr (Variable repr)) -> 
+getMethod :: (RenderSym repr) => Label -> FS (repr (Variable repr)) -> 
   MS (repr (Method repr))
-getMethod c v = zoom lensMStoGS v >>= (\vr -> S.method (getterName $ 
+getMethod c v = zoom lensMStoFS v >>= (\vr -> S.method (getterName $ 
     variableName vr) c public dynamic_ (toState $ variableType vr) [] getBody)
     where getBody = S.oneLiner $ S.returnState (S.valueOf $ S.objVarSelf c v)
 
-setMethod :: (RenderSym repr) => Label -> GS (repr (Variable repr)) -> 
+setMethod :: (RenderSym repr) => Label -> FS (repr (Variable repr)) -> 
   MS (repr (Method repr))
-setMethod c v = zoom lensMStoGS v >>= (\vr -> S.method (setterName $ 
+setMethod c v = zoom lensMStoFS v >>= (\vr -> S.method (setterName $ 
   variableName vr) c public dynamic_ S.void [S.param v] setBody)
   where setBody = S.oneLiner $ S.objVarSelf c v &= S.valueOf v
 
-privMethod :: (RenderSym repr) => Label -> Label -> GS (repr (Type repr)) -> 
-  [MS (repr (Parameter repr))] -> GS (repr (Body repr)) -> 
+privMethod :: (RenderSym repr) => Label -> Label -> FS (repr (Type repr)) -> 
+  [MS (repr (Parameter repr))] -> FS (repr (Body repr)) -> 
   MS (repr (Method repr))
 privMethod n c = S.method n c private dynamic_
 
-pubMethod :: (RenderSym repr) => Label -> Label -> GS (repr (Type repr)) -> 
-  [MS (repr (Parameter repr))] -> GS (repr (Body repr)) -> 
+pubMethod :: (RenderSym repr) => Label -> Label -> FS (repr (Type repr)) -> 
+  [MS (repr (Parameter repr))] -> FS (repr (Body repr)) -> 
   MS (repr (Method repr))
 pubMethod n c = S.method n c public dynamic_
 
 constructor :: (RenderSym repr) => Label -> Label -> 
-  [MS (repr (Parameter repr))] -> GS (repr (Body repr)) -> 
+  [MS (repr (Parameter repr))] -> FS (repr (Body repr)) -> 
   MS (repr (Method repr))
 constructor fName n = intMethod False fName n public dynamic_ (S.construct n)
 
-docMain :: (RenderSym repr) => GS (repr (Body repr)) -> MS (repr (Method repr))
+docMain :: (RenderSym repr) => FS (repr (Body repr)) -> MS (repr (Method repr))
 docMain b = commentedFunc (docComment $ toState $ functionDox 
   "Controls the flow of the program" 
   [("args", "List of command-line arguments")] []) (S.mainFunction b)
 
 function :: (RenderSym repr) => Label -> repr (Scope repr) -> 
-  repr (Permanence repr) -> GS (repr (Type repr)) -> 
-  [MS (repr (Parameter repr))] -> GS (repr (Body repr)) -> 
+  repr (Permanence repr) -> FS (repr (Type repr)) -> 
+  [MS (repr (Parameter repr))] -> FS (repr (Body repr)) -> 
   MS (repr (Method repr))
 function n s p t = S.intFunc False n s p (mType t)
 
-mainFunction :: (RenderSym repr) => GS (repr (Type repr)) -> Label -> 
-  GS (repr (Body repr)) -> MS (repr (Method repr))
+mainFunction :: (RenderSym repr) => FS (repr (Type repr)) -> Label -> 
+  FS (repr (Body repr)) -> MS (repr (Method repr))
 mainFunction s n = S.intFunc True n public static_ (mType S.void)
   [S.param (S.var "args" (onStateValue (\argT -> typeFromData (List String) 
   (render (getTypeDoc argT) ++ "[]") (getTypeDoc argT <> text "[]")) s))]
@@ -959,67 +959,66 @@ docFunc :: (RenderSym repr) => String -> [String] -> Maybe String ->
 docFunc desc pComms rComm = docFuncRepr desc pComms (maybeToList rComm)
 
 docInOutFunc :: (RenderSym repr) => (repr (Scope repr) -> repr (Permanence repr)
-    -> [GS (repr (Variable repr))] -> [GS (repr (Variable repr))] -> 
-    [GS (repr (Variable repr))] -> GS (repr (Body repr)) -> 
+    -> [FS (repr (Variable repr))] -> [FS (repr (Variable repr))] -> 
+    [FS (repr (Variable repr))] -> FS (repr (Body repr)) -> 
     MS (repr (Method repr)))
   -> repr (Scope repr) -> repr (Permanence repr) -> String -> 
-  [(String, GS (repr (Variable repr)))] -> [(String, GS (repr (Variable repr)))]
-  -> [(String, GS (repr (Variable repr)))] -> GS (repr (Body repr)) -> 
+  [(String, FS (repr (Variable repr)))] -> [(String, FS (repr (Variable repr)))]
+  -> [(String, FS (repr (Variable repr)))] -> FS (repr (Body repr)) -> 
   MS (repr (Method repr))
 docInOutFunc f s p desc is [o] [] b = docFuncRepr desc (map fst is) [fst o] 
   (f s p (map snd is) [snd o] [] b)
-docInOutFunc f s p desc is [] [both] b = zoom lensMStoGS (snd both) >>= (\bth 
+docInOutFunc f s p desc is [] [both] b = zoom lensMStoFS (snd both) >>= (\bth 
   -> docFuncRepr desc (map fst $ both : is) [fst both | not ((isObject . 
   getType . variableType) bth)] (f s p (map snd is) [] [toState bth] b))
 docInOutFunc f s p desc is os bs b = docFuncRepr desc (map fst $ bs ++ is ++ os)
   [] (f s p (map snd is) (map snd os) (map snd bs) b)
 
 intFunc :: (RenderSym repr) => Bool -> Label -> repr (Scope repr) -> 
-  repr (Permanence repr) -> GS (repr (MethodType repr)) -> 
-  [MS (repr (Parameter repr))] -> GS (repr (Body repr)) -> 
+  repr (Permanence repr) -> FS (repr (MethodType repr)) -> 
+  [MS (repr (Parameter repr))] -> FS (repr (Body repr)) -> 
   MS (repr (Method repr))
 intFunc m n = intMethod m n ""
 
 -- State Variables --
 
 stateVar :: (RenderSym repr) => repr (Scope repr) -> repr (Permanence repr) ->
-  GS (repr (Variable repr)) -> GS (repr (StateVar repr))
+  FS (repr (Variable repr)) -> FS (repr (StateVar repr))
 stateVar s p v = stateVarFromData (onStateValue (stateVarDocD 
   (scopeDoc s) (permDoc p) . statementDoc) (S.state $ S.varDec v))
 
 stateVarDef :: (RenderSym repr) => repr (Scope repr) -> repr (Permanence repr) 
-  -> GS (repr (Variable repr)) -> GS (repr (Value repr)) -> 
-  GS (repr (StateVar repr))
+  -> FS (repr (Variable repr)) -> FS (repr (Value repr)) -> 
+  FS (repr (StateVar repr))
 stateVarDef s p vr vl = stateVarFromData (onStateValue (stateVarDocD 
   (scopeDoc s) (permDoc p) . statementDoc) (S.state $ S.varDecDef vr vl))
 
 constVar :: (RenderSym repr) => Doc -> repr (Scope repr) ->
-  GS (repr (Variable repr)) -> GS (repr (Value repr)) -> GS (repr (StateVar repr))
+  FS (repr (Variable repr)) -> FS (repr (Value repr)) -> FS (repr (StateVar repr))
 constVar p s vr vl = stateVarFromData (onStateValue (stateVarDocD (scopeDoc s) 
   p . statementDoc) (S.state $ S.constDecDef vr vl))
 
-privMVar :: (RenderSym repr) => GS (repr (Variable repr)) -> 
-  GS (repr (StateVar repr))
+privMVar :: (RenderSym repr) => FS (repr (Variable repr)) -> 
+  FS (repr (StateVar repr))
 privMVar = S.stateVar private dynamic_
 
-pubMVar :: (RenderSym repr) => GS (repr (Variable repr)) -> 
-  GS (repr (StateVar repr))
+pubMVar :: (RenderSym repr) => FS (repr (Variable repr)) -> 
+  FS (repr (StateVar repr))
 pubMVar = S.stateVar public dynamic_
 
-pubGVar :: (RenderSym repr) => GS (repr (Variable repr)) -> 
-  GS (repr (StateVar repr))
+pubGVar :: (RenderSym repr) => FS (repr (Variable repr)) -> 
+  FS (repr (StateVar repr))
 pubGVar = S.stateVar public static_
 
 -- Classes --
 
 buildClass :: (RenderSym repr) => (Label -> Doc -> Doc -> Doc -> Doc -> Doc) -> 
   (Label -> repr (Keyword repr)) -> Label -> Maybe Label -> repr (Scope repr) 
-  -> [GS (repr (StateVar repr))] -> 
-  [MS (repr (Method repr))] -> FS (repr (Class repr))
+  -> [FS (repr (StateVar repr))] -> [MS (repr (Method repr))] -> 
+  FS (repr (Class repr))
 buildClass f i n p s vs fs = classFromData (on2StateValues (f n parent 
-  (scopeDoc s)) (onStateList (stateVarListDocD . map stateVarDoc) 
-  (map (zoom lensFStoGS) vs)) (onStateList (methodListDocD . map methodDoc) 
-  (map (zoom lensFStoMS) fs)))
+  (scopeDoc s)) (onStateList (stateVarListDocD . map stateVarDoc) vs)
+  (onStateList (methodListDocD . map methodDoc) (map (zoom lensFStoMS) fs)))
   where parent = case p of Nothing -> empty
                            Just pn -> keyDoc $ i pn
 
@@ -1029,12 +1028,12 @@ enum n es s = classFromData (toState $ enumDocD n (enumElementsDocD es False)
   (scopeDoc s))
 
 privClass :: (RenderSym repr) => Label -> Maybe Label -> 
-  [GS (repr (StateVar repr))] -> 
+  [FS (repr (StateVar repr))] -> 
   [MS (repr (Method repr))] -> FS (repr (Class repr))
 privClass n p = S.buildClass n p private
 
 pubClass :: (RenderSym repr) => Label -> Maybe Label -> 
-  [GS (repr (StateVar repr))] -> [MS (repr (Method repr))] -> 
+  [FS (repr (StateVar repr))] -> [MS (repr (Method repr))] -> 
   FS (repr (Class repr))
 pubClass n p = S.buildClass n p public
 
@@ -1065,7 +1064,7 @@ buildModule' n inc ms cs = S.modFromData n getCurrMain (on3StateValues
     vcat (map (importDoc . inc) mis), 
     vibcat (map classDoc cls)])
   (sequence $ if null ms then cs else pubClass n Nothing [] ms : cs)
-  (zoom lensFStoGS getLangImports) (zoom lensFStoGS getModuleImports))
+  getLangImports getModuleImports)
 
 modFromData :: Label -> (Doc -> Bool -> repr (Module repr)) -> FS Bool -> 
   FS Doc -> FS (repr (Module repr))
@@ -1094,8 +1093,8 @@ fileFromData f ft fp m = getPutReturnFunc2 (\s mdl fpath -> (if isEmpty
 
 -- Helper functions
 
-setEmpty :: (RenderSym repr) => GS (repr (Statement repr)) -> 
-  GS (repr (Statement repr))
+setEmpty :: (RenderSym repr) => FS (repr (Statement repr)) -> 
+  FS (repr (Statement repr))
 setEmpty = onStateValue (\s -> stateFromData (statementDoc s) Empty)
 
 numType :: (RenderSym repr) => repr (Type repr) -> repr (Type repr) -> 

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer/LanguagePolymorphic.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer/LanguagePolymorphic.hs
@@ -75,7 +75,7 @@ import GOOL.Drasil.Data (Binding(..), Terminator(..), FileType)
 import GOOL.Drasil.Helpers (angles, doubleQuotedText, vibcat, emptyIfEmpty, 
   toState, onStateValue, on2StateValues, on3StateValues, on4StateValues, 
   onStateList, on2StateLists, on1StateValue1List, getInnerType, convType)
-import GOOL.Drasil.LanguageRenderer (forLabel, observerListName, addExt, 
+import GOOL.Drasil.LanguageRenderer (forLabel, new, observerListName, addExt, 
   blockDocD, assignDocD, plusEqualsDocD, plusPlusDocD, mkStateVal, mkVal, 
   mkStateVar, mkVar, mkStaticVar, varDocD, extVarDocD, selfDocD, argDocD, 
   enumElemDocD, classVarCheckStatic, objVarDocD, funcAppDocD, objAccessDocD, 
@@ -99,7 +99,7 @@ import Control.Monad.State (modify)
 import Control.Lens ((^.), over)
 import Control.Lens.Zoom (zoom)
 import Text.PrettyPrint.HughesPJ (Doc, text, empty, render, (<>), (<+>), parens,
-  quotes, integer, vcat, semi, comma, equals, isEmpty)
+  braces, quotes, integer, vcat, semi, comma, equals, isEmpty)
 import qualified Text.PrettyPrint.HughesPJ as D (char, double)
 
 -- Bodies --
@@ -673,11 +673,11 @@ listDecDef :: (RenderSym repr) => ([repr (Value repr)] -> Doc) ->
 listDecDef f v = on1StateValue1List (\vd vs -> stateFromData (statementDoc vd 
   <> f vs) Semi) (S.varDec v)
 
-listDecDef' :: (RenderSym repr) => (repr (Variable repr)-> [repr (Value repr)] 
-  -> Doc) -> GS (repr (Variable repr)) -> [GS (repr (Value repr))] -> 
-  GS (repr (Statement repr))
-listDecDef' f v vals = on3StateValues (\vd vr vs -> stateFromData (statementDoc
-  vd <> f vr vs) Semi) (S.varDec v) v (sequence vals)
+listDecDef' :: (RenderSym repr) => GS (repr (Variable repr)) -> 
+  [GS (repr (Value repr))] -> GS (repr (Statement repr))
+listDecDef' v vals = on3StateValues (\vd vr vs -> stateFromData (statementDoc
+  vd <+> equals <+> new <+> getTypeDoc (variableType vr) <+> braces 
+  (valueList vs)) Semi) (S.varDec v) v (sequence vals)
 
 objDecNew :: (RenderSym repr) => GS (repr (Variable repr)) -> 
   [GS (repr (Value repr))] -> GS (repr (Statement repr))

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer/LanguagePolymorphic.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer/LanguagePolymorphic.hs
@@ -86,7 +86,7 @@ import GOOL.Drasil.LanguageRenderer (forLabel, new, observerListName, addExt,
 import GOOL.Drasil.State (FS, MS, lensFStoGS, lensFStoMS, lensMStoFS, 
   currMain, putAfter, getPutReturnFunc, getPutReturnFunc2, addFile, setMainMod, 
   addLangImport, getLangImports, getModuleImports, setFilePath, getFilePath, 
-  setModuleName, getModuleName, getCurrMain, addParameter)
+  setModuleName, getModuleName, addParameter)
 
 import Prelude hiding (break,print,last,mod,pi,(<>))
 import Data.Bifunctor (first)
@@ -1049,24 +1049,24 @@ commentedClass cmt cs = classFromData (on2StateValues (\cmt' cs' ->
 
 buildModule :: (RenderSym repr) => Label -> FS Doc -> [MS (repr (Method repr))] 
   -> [FS (repr (Class repr))] -> FS (repr (Module repr))
-buildModule n imps ms cs = S.modFromData n getCurrMain ((\cls fs is -> 
-  moduleDocD is (vibcat (map classDoc cls)) (vibcat (map methodDoc fs))) <$>
-  sequence cs <*> mapM (zoom lensFStoMS) ms <*> imps)
+buildModule n imps ms cs = S.modFromData n ((\cls fs is -> moduleDocD is 
+  (vibcat (map classDoc cls)) (vibcat (map methodDoc fs))) <$> sequence cs <*> 
+  mapM (zoom lensFStoMS) ms <*> imps)
 
 buildModule' :: (RenderSym repr) => Label -> (String -> repr (Import repr)) -> 
   [MS (repr (Method repr))] -> [FS (repr (Class repr))] -> 
   FS (repr (Module repr))
-buildModule' n inc ms cs = S.modFromData n getCurrMain (on3StateValues 
-  (\cls lis mis -> vibcat [
+buildModule' n inc ms cs = S.modFromData n (on3StateValues (\cls lis mis -> 
+  vibcat [
     vcat (map (importDoc . inc) lis), 
     vcat (map (importDoc . inc) mis), 
     vibcat (map classDoc cls)])
   (sequence $ if null ms then cs else pubClass n Nothing [] ms : cs)
   getLangImports getModuleImports)
 
-modFromData :: Label -> (Doc -> Bool -> repr (Module repr)) -> FS Bool -> 
-  FS Doc -> FS (repr (Module repr))
-modFromData n f m d = putAfter (setModuleName n) (on2StateValues f d m)
+modFromData :: Label -> (Doc -> repr (Module repr)) -> FS Doc -> 
+  FS (repr (Module repr))
+modFromData n f d = putAfter (setModuleName n) (onStateValue f d)
 
 -- Files --
 

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer/LanguagePolymorphic.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer/LanguagePolymorphic.hs
@@ -30,8 +30,8 @@ module GOOL.Drasil.LanguageRenderer.LanguagePolymorphic (fileFromData, oneLiner,
 import Utils.Drasil (indent)
 
 import GOOL.Drasil.CodeType (CodeType(..), isObject)
-import GOOL.Drasil.Symantics (Label, Library, KeywordSym(..),
-  RenderSym(RenderFile, commentedMod), BlockSym(Block), InternalBlock(..), 
+import GOOL.Drasil.Symantics (Label, Library, KeywordSym(..), RenderSym,
+  FileSym(RenderFile, commentedMod), BlockSym(Block), InternalBlock(..), 
   BodySym(Body, body, bodyStatements, bodyDoc), PermanenceSym(..), 
   InternalPerm(..), 
   TypeSym(Type, infile, outfile, iterator, getType, getTypeDoc, getTypeString), 

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer/PythonRenderer.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer/PythonRenderer.hs
@@ -62,7 +62,7 @@ import GOOL.Drasil.Helpers (emptyIfEmpty, toCode, toState, onCodeValue,
   on5StateValues, onCodeList, onStateList, on2StateLists, on1CodeValue1List, 
   on1StateValue1List)
 import GOOL.Drasil.State (GS, MS, lensGStoFS, lensMStoGS, initialState, 
-  addLangImport, setCurrMain)
+  addLangImport, addModuleImport, setCurrMain)
 
 import Prelude hiding (break,print,sin,cos,tan,floor,(<>))
 import Data.Maybe (fromMaybe)

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer/PythonRenderer.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer/PythonRenderer.hs
@@ -640,7 +640,7 @@ instance ModuleSym PythonCode where
 
 instance InternalMod PythonCode where
   moduleDoc = modDoc . unPC
-  modFromData n = G.modFromData n (\d m -> toCode $ md n m d)
+  modFromData n = G.modFromData n (toCode . md n)
   updateModuleDoc f = onCodeValue (updateModDoc f)
 
 instance BlockCommentSym PythonCode where

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer/PythonRenderer.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer/PythonRenderer.hs
@@ -243,7 +243,7 @@ instance VariableSym PythonCode where
   var = G.var
   staticVar = G.staticVar
   const = var
-  extVar = G.extVar
+  extVar l n t = modify (addModuleImport l) >> G.extVar l n t
   self l = mkStateVar "self" (obj l) (text "self")
   enumVar = G.enumVar
   classVar = G.classVar classVarDocD
@@ -330,10 +330,10 @@ instance ValueExpression PythonCode where
   inlineIf = pyInlineIf
   funcApp = G.funcApp
   selfFuncApp c = G.selfFuncApp (self c)
-  extFuncApp = G.extFuncApp
+  extFuncApp l n t ps = modify (addModuleImport l) >> G.extFuncApp l n t ps
   newObj = G.newObj newObjDocD'
-  extNewObj l = on1StateValue1List (\t -> mkVal t . pyExtStateObj l (getTypeDoc 
-    t) . valueList)
+  extNewObj l tp ps = modify (addModuleImport l) >> on1StateValue1List 
+    (\t -> mkVal t . pyExtStateObj l (getTypeDoc t) . valueList) tp ps
 
   exists v = v ?!= valueOf (var "None" void)
   notNull = exists
@@ -435,11 +435,11 @@ instance StatementSym PythonCode where
   listDecDef = on1StateValue1List (\v vs -> mkStNoEnd $ pyListDecDef v vs)
   objDecDef = varDecDef
   objDecNew = G.objDecNew
-  extObjDecNew lib v vs = varDecDef v (extNewObj lib (onStateValue variableType 
-    v) vs)
+  extObjDecNew lib v vs = modify (addModuleImport lib) >> varDecDef v 
+    (extNewObj lib (onStateValue variableType v) vs)
   objDecNewNoParams = G.objDecNewNoParams
-  extObjDecNewNoParams lib v = varDecDef v (extNewObj lib (onStateValue 
-    variableType v) [])
+  extObjDecNewNoParams lib v = modify (addModuleImport lib) >> varDecDef v 
+    (extNewObj lib (onStateValue variableType v) [])
   constDecDef = varDecDef
 
   print = pyOut False Nothing printFunc

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer/PythonRenderer.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer/PythonRenderer.hs
@@ -631,7 +631,7 @@ instance InternalClass PythonCode where
 
 instance ModuleSym PythonCode where
   type Module PythonCode = ModData
-  buildModule n _ = G.buildModule n (on2StateValues (\lis mis -> vibcat [
+  buildModule n = G.buildModule n (on2StateValues (\lis mis -> vibcat [
     vcat (map (importDoc . 
       (langImport :: Label -> PythonCode (Import PythonCode))) lis),
     vcat (map (importDoc . 

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer/PythonRenderer.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer/PythonRenderer.hs
@@ -115,7 +115,6 @@ instance KeywordSym PythonCode where
   endStatement = toCode empty
   endStatementLoop = toCode empty
 
-  include n = toCode $ pyInclude n
   inherit n = toCode $ parens (text n)
 
   list _ = toCode empty
@@ -651,15 +650,11 @@ instance BlockCommentSym PythonCode where
   blockCommentDoc = unPC
 
 -- convenience
-imp, initName :: Label
-imp = "import"
+initName :: Label
 initName = "__init__"
 
 pyName :: String
 pyName = "Python"
-
-pyInclude :: Label -> Doc
-pyInclude n = text imp <+> text n
 
 pyLogOp :: (RenderSym repr) => FS (repr (UnaryOp repr))
 pyLogOp = addmathImport $ unOpPrec "math.log10"

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer/PythonRenderer.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer/PythonRenderer.hs
@@ -24,19 +24,16 @@ import GOOL.Drasil.Symantics (Label, ProgramSym(..), RenderSym, FileSym(..),
   InternalMod(..), BlockCommentSym(..))
 import GOOL.Drasil.LanguageRenderer (enumElementsDocD', multiStateDocD, 
   bodyDocD, outDoc, destructorError, multiAssignDoc, returnDocD, mkStNoEnd,
-  breakDocD, continueDocD, unOpPrec, notOpDocD', negateOpDocD, sqrtOpDocD', 
-  absOpDocD', expOpDocD', sinOpDocD', cosOpDocD', tanOpDocD', asinOpDocD', 
-  acosOpDocD', atanOpDocD', unExpr, unExpr', typeUnExpr, powerPrec, multPrec, 
-  andPrec, orPrec, equalOpDocD, notEqualOpDocD, greaterOpDocD, 
-  greaterEqualOpDocD, lessOpDocD, lessEqualOpDocD, plusOpDocD, minusOpDocD, 
-  multOpDocD, divideOpDocD, moduloOpDocD, binExpr, typeBinExpr, mkStateVal, 
-  mkStateVal, mkVal, mkStateVar, classVarDocD, newObjDocD', 
-  listSetFuncDocD, castObjDocD, dynamicDocD, bindingError, classDec, dot, 
-  forLabel, inLabel, observerListName, commentedItem, addCommentsDocD, 
-  commentedModD, docFuncRepr, valueList, parameterList, surroundBody, 
-  filterOutObjs)
+  breakDocD, continueDocD, mkStateVal, mkVal, mkStateVar, classVarDocD, 
+  newObjDocD', listSetFuncDocD, castObjDocD, dynamicDocD, bindingError, 
+  classDec, dot, forLabel, inLabel, observerListName, commentedItem, 
+  addCommentsDocD, commentedModD, docFuncRepr, valueList, parameterList, 
+  surroundBody, filterOutObjs)
 import qualified GOOL.Drasil.LanguageRenderer.LanguagePolymorphic as G (
-  oneLiner, block, int, float, listInnerType, obj, enumType, runStrategy, var, 
+  oneLiner, block, int, float, listInnerType, obj, enumType, runStrategy, 
+  notOp', negateOp, sqrtOp', absOp', expOp', sinOp', cosOp', tanOp', asinOp', 
+  acosOp', atanOp', equalOp, notEqualOp, greaterOp, greaterEqualOp, lessOp, 
+  lessEqualOp, plusOp, minusOp, multOp, divideOp, moduloOp, var, 
   staticVar, extVar, enumVar, classVar, objVar, objVarSelf, listVar, listOf, 
   iterVar, litChar, litFloat, litInt, litString, valueOf, arg, enumElement, 
   argsList, objAccess, objMethodCall, objMethodCallNoParams, selfAccess, 
@@ -53,16 +50,19 @@ import qualified GOOL.Drasil.LanguageRenderer.LanguagePolymorphic as G (
   constVar, privMVar, pubMVar, pubGVar, buildClass, privClass, pubClass, 
   docClass, commentedClass, buildModule, modFromData, fileDoc, docMod, 
   fileFromData)
+import GOOL.Drasil.LanguageRenderer.LanguagePolymorphic (unOpPrec, unExpr, 
+  unExpr', typeUnExpr, powerPrec, multPrec, andPrec, orPrec, binExpr, 
+  typeBinExpr, addmathImport)
 import GOOL.Drasil.Data (Terminator(..), ScopeTag(..), FileType(..), 
   FileData(..), fileD, FuncData(..), fd, ModData(..), md, updateModDoc, 
-  MethodData(..), mthd, updateMthdDoc, OpData(..), ParamData(..), pd, 
+  MethodData(..), mthd, updateMthdDoc, OpData(..), od, ParamData(..), pd, 
   ProgData(..), progD, TypeData(..), td, ValData(..), vd, VarData(..), vard)
 import GOOL.Drasil.Helpers (emptyIfEmpty, toCode, toState, onCodeValue,
   onStateValue, on2CodeValues, on2StateValues, on3CodeValues, on3StateValues,
   on5StateValues, onCodeList, onStateList, on2StateLists, on1CodeValue1List, 
   on1StateValue1List)
 import GOOL.Drasil.State (GS, MS, lensGStoFS, lensMStoGS, initialState, 
-  setCurrMain)
+  addLangImport, setCurrMain)
 
 import Prelude hiding (break,print,sin,cos,tan,floor,(<>))
 import Data.Maybe (fromMaybe)
@@ -196,44 +196,47 @@ instance ControlBlockSym PythonCode where
 
 instance UnaryOpSym PythonCode where
   type UnaryOp PythonCode = OpData
-  notOp = toCode notOpDocD'
-  negateOp = toCode negateOpDocD
-  sqrtOp = toCode sqrtOpDocD'
-  absOp = toCode absOpDocD'
-  logOp = toCode pyLogOp
-  lnOp = toCode pyLnOp
-  expOp = toCode expOpDocD'
-  sinOp = toCode sinOpDocD'
-  cosOp = toCode cosOpDocD'
-  tanOp = toCode tanOpDocD'
-  asinOp = toCode asinOpDocD'
-  acosOp = toCode acosOpDocD'
-  atanOp = toCode atanOpDocD'
-  floorOp = toCode $ unOpPrec "math.floor"
-  ceilOp = toCode $ unOpPrec "math.ceil"
+  notOp = G.notOp'
+  negateOp = G.negateOp
+  sqrtOp = G.sqrtOp'
+  absOp = G.absOp'
+  logOp = pyLogOp
+  lnOp = pyLnOp
+  expOp = G.expOp'
+  sinOp = G.sinOp'
+  cosOp = G.cosOp'
+  tanOp = G.tanOp'
+  asinOp = G.asinOp'
+  acosOp = G.acosOp'
+  atanOp = G.atanOp'
+  floorOp = addmathImport $ unOpPrec "math.floor"
+  ceilOp = addmathImport $ unOpPrec "math.ceil"
 
 instance BinaryOpSym PythonCode where
   type BinaryOp PythonCode = OpData
-  equalOp = toCode equalOpDocD
-  notEqualOp = toCode notEqualOpDocD
-  greaterOp = toCode greaterOpDocD
-  greaterEqualOp = toCode greaterEqualOpDocD
-  lessOp = toCode lessOpDocD
-  lessEqualOp = toCode lessEqualOpDocD
-  plusOp = toCode plusOpDocD
-  minusOp = toCode minusOpDocD
-  multOp = toCode multOpDocD
-  divideOp = toCode divideOpDocD
-  powerOp = toCode $ powerPrec "**"
-  moduloOp = toCode moduloOpDocD
-  andOp = toCode $ andPrec "and"
-  orOp = toCode $ orPrec "or"
+  equalOp = G.equalOp
+  notEqualOp = G.notEqualOp
+  greaterOp = G.greaterOp
+  greaterEqualOp = G.greaterEqualOp
+  lessOp = G.lessOp
+  lessEqualOp = G.lessEqualOp
+  plusOp = G.plusOp
+  minusOp = G.minusOp
+  multOp = G.multOp
+  divideOp = G.divideOp
+  powerOp = powerPrec "**"
+  moduloOp = G.moduloOp
+  andOp = andPrec "and"
+  orOp = orPrec "or"
 
 instance InternalOp PythonCode where
   uOpDoc = opDoc . unPC
   bOpDoc = opDoc . unPC
   uOpPrec = opPrec . unPC
   bOpPrec = opPrec . unPC
+  
+  uOpFromData p d = toState $ toCode $ od p d
+  bOpFromData p d = toState $ toCode $ od p d
 
 instance VariableSym PythonCode where
   type Variable PythonCode = VarData
@@ -270,14 +273,14 @@ instance ValueSym PythonCode where
   litInt = G.litInt
   litString = G.litString
 
-  pi = mkStateVal float (text "math.pi")
+  pi = addmathImport $ mkStateVal float (text "math.pi")
 
   ($:) = enumElement
 
   valueOf = G.valueOf
   arg n = G.arg (litInt $ n+1) argsList
   enumElement = G.enumElement
-  argsList = G.argsList "sys.argv"
+  argsList = modify (addLangImport "sys") >> G.argsList "sys.argv"
 
   valueType = onCodeValue valType
   valueDoc = valDoc . unPC
@@ -291,7 +294,7 @@ instance NumericExpression PythonCode where
   (#*) = binExpr multOp
   (#/) v1' v2' = join $ on2StateValues (\v1 v2 -> pyDivision (getType $ 
     valueType v1) (getType $ valueType v2) v1' v2') v1' v2'
-    where pyDivision Integer Integer = binExpr (toCode $ multPrec "//")
+    where pyDivision Integer Integer = binExpr (multPrec "//")
           pyDivision _ _ = binExpr divideOp
   (#%) = binExpr moduloOp
   (#^) = binExpr powerOp
@@ -649,11 +652,11 @@ pytop = vcat [   -- There are also imports from the libraries supplied by module
 pyInclude :: Label -> Doc
 pyInclude n = text imp <+> text n
 
-pyLogOp :: OpData
-pyLogOp = unOpPrec "math.log10"
+pyLogOp :: (RenderSym repr) => GS (repr (UnaryOp repr))
+pyLogOp = addmathImport $ unOpPrec "math.log10"
 
-pyLnOp :: OpData
-pyLnOp = unOpPrec "math.log"
+pyLnOp :: (RenderSym repr) => GS (repr (UnaryOp repr))
+pyLnOp = addmathImport $ unOpPrec "math.log"
 
 pyClassVar :: Doc -> Doc -> Doc
 pyClassVar c v = c <> dot <> c <> dot <> v

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer/PythonRenderer.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer/PythonRenderer.hs
@@ -9,7 +9,7 @@ module GOOL.Drasil.LanguageRenderer.PythonRenderer (
 import Utils.Drasil (blank, indent)
 
 import GOOL.Drasil.CodeType (CodeType(..), isObject)
-import GOOL.Drasil.Symantics (Label, ProgramSym(..), RenderSym(..), 
+import GOOL.Drasil.Symantics (Label, ProgramSym(..), RenderSym, FileSym(..),
   InternalFile(..), KeywordSym(..), PermanenceSym(..), InternalPerm(..), 
   BodySym(..), BlockSym(..), InternalBlock(..), ControlBlockSym(..), 
   TypeSym(..), InternalType(..), UnaryOpSym(..), BinaryOpSym(..), 
@@ -93,7 +93,9 @@ instance ProgramSym PythonCode where
   type Program PythonCode = ProgData 
   prog n = onStateList (onCodeList (progD n)) . map (zoom lensGStoFS)
 
-instance RenderSym PythonCode where
+instance RenderSym PythonCode
+
+instance FileSym PythonCode where
   type RenderFile PythonCode = FileData
   fileDoc = G.fileDoc Combined pyExt top bottom
 

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer/PythonRenderer.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer/PythonRenderer.hs
@@ -10,13 +10,13 @@ import Utils.Drasil (blank, indent)
 
 import GOOL.Drasil.CodeType (CodeType(..), isObject)
 import GOOL.Drasil.Symantics (Label, ProgramSym(..), RenderSym, FileSym(..),
-  InternalFile(..), KeywordSym(..), PermanenceSym(..), InternalPerm(..), 
-  BodySym(..), BlockSym(..), InternalBlock(..), ControlBlockSym(..), 
-  TypeSym(..), InternalType(..), UnaryOpSym(..), BinaryOpSym(..), 
-  InternalOp(..), VariableSym(..), InternalVariable(..), ValueSym(..), 
-  NumericExpression(..), BooleanExpression(..), ValueExpression(..), 
-  InternalValue(..), Selector(..), InternalSelector(..), objMethodCall, 
-  FunctionSym(..), SelectorFunction(..), InternalFunction(..), 
+  InternalFile(..), KeywordSym(..), ImportSym(..), PermanenceSym(..), 
+  InternalPerm(..), BodySym(..), BlockSym(..), InternalBlock(..), 
+  ControlBlockSym(..), TypeSym(..), InternalType(..), UnaryOpSym(..), 
+  BinaryOpSym(..), InternalOp(..), VariableSym(..), InternalVariable(..), 
+  ValueSym(..), NumericExpression(..), BooleanExpression(..), 
+  ValueExpression(..), InternalValue(..), Selector(..), InternalSelector(..), 
+  objMethodCall, FunctionSym(..), SelectorFunction(..), InternalFunction(..), 
   InternalStatement(..), StatementSym(..), ControlStatementSym(..), 
   ScopeSym(..), InternalScope(..), MethodTypeSym(..), ParameterSym(..), 
   InternalParam(..), MethodSym(..), InternalMethod(..), StateVarSym(..), 
@@ -135,6 +135,13 @@ instance KeywordSym PythonCode where
   docCommentEnd = toCode empty
 
   keyDoc = unPC
+
+instance ImportSym PythonCode where
+  type Import PythonCode = Doc
+  langImport n = toCode $ text $ "import " ++ n
+  modImport = langImport
+
+  importDoc = unPC
 
 instance PermanenceSym PythonCode where
   type Permanence PythonCode = Doc

--- a/code/drasil-gool/GOOL/Drasil/State.hs
+++ b/code/drasil-gool/GOOL/Drasil/State.hs
@@ -5,10 +5,10 @@ module GOOL.Drasil.State (
   headers, sources, mainMod, currMain, initialState, initialFS, putAfter, 
   getPutReturn, getPutReturnFunc, getPutReturnFunc2, getPutReturnList, addFile, 
   addCombinedHeaderSource, addHeader, addSource, addProgNameToPaths, setMainMod,
-  addLangImport, addModuleImport, setFilePath, getFilePath, setModuleName, 
-  getModuleName, setCurrMain, getCurrMain, addClass, getClasses, updateClassMap,
-  getClassMap, addParameter, getParameters, setScope, getScope, setCurrMainFunc,
-  getCurrMainFunc
+  addLangImport, addModuleImport, addHeaderLangImport, addDefine, setFilePath, 
+  getFilePath, setModuleName, getModuleName, setCurrMain, getCurrMain, addClass,
+  getClasses, updateClassMap, getClassMap, addParameter, getParameters, 
+  setScope, getScope, setCurrMainFunc, getCurrMainFunc
 ) where
 
 import GOOL.Drasil.Data (FileType(..), ScopeTag(..))
@@ -25,7 +25,11 @@ data GOOLState = GS {
   _mainMod :: Maybe FilePath,
   _classMap :: Map String String,
   _langImports :: [String],
-  _moduleImports :: [String]
+  _moduleImports :: [String],
+
+  -- C++ only
+  _headerLangImports :: [String],
+  _defines :: [String]
 } 
 makeLenses ''GOOLState
 
@@ -96,7 +100,10 @@ initialState = GS {
   _mainMod = Nothing,
   _classMap = empty,
   _langImports = [],
-  _moduleImports = []
+  _moduleImports = [],
+
+  _headerLangImports = [],
+  _defines = []
 }
 
 initialFS :: FileState
@@ -188,6 +195,13 @@ addLangImport i = over langImports (\is -> if i `elem` is then i:is else is)
 
 addModuleImport :: String -> GOOLState -> GOOLState
 addModuleImport i = over moduleImports (\is -> if i `elem` is then i:is else is)
+
+addHeaderLangImport :: String -> GOOLState -> GOOLState
+addHeaderLangImport i = over headerLangImports (\is -> if i `elem` is then i:is 
+  else is)
+
+addDefine :: String -> GOOLState -> GOOLState
+addDefine d = over defines (\ds -> if d `elem` ds then d:ds else ds)
 
 setFilePath :: FilePath -> (GOOLState, FileState) -> (GOOLState, FileState)
 setFilePath fp = over _2 (set currFilePath fp)

--- a/code/drasil-gool/GOOL/Drasil/State.hs
+++ b/code/drasil-gool/GOOL/Drasil/State.hs
@@ -5,10 +5,11 @@ module GOOL.Drasil.State (
   headers, sources, mainMod, currMain, initialState, initialFS, putAfter, 
   getPutReturn, getPutReturnFunc, getPutReturnFunc2, getPutReturnList, addFile, 
   addCombinedHeaderSource, addHeader, addSource, addProgNameToPaths, setMainMod,
-  addLangImport, addModuleImport, addHeaderLangImport, addDefine, setFilePath, 
-  getFilePath, setModuleName, getModuleName, setCurrMain, getCurrMain, addClass,
-  getClasses, updateClassMap, getClassMap, addParameter, getParameters, 
-  setScope, getScope, setCurrMainFunc, getCurrMainFunc
+  addLangImport, getLangImports, addModuleImport, getModuleImports, 
+  addHeaderLangImport, addDefine, setFilePath, getFilePath, setModuleName, 
+  getModuleName, setCurrMain, getCurrMain, addClass, getClasses, updateClassMap,
+  getClassMap, addParameter, getParameters, setScope, getScope, setCurrMainFunc,
+  getCurrMainFunc
 ) where
 
 import GOOL.Drasil.Data (FileType(..), ScopeTag(..))
@@ -191,17 +192,23 @@ setMainMod n = over mainMod (\m -> if isNothing m then Just n else error
   "Multiple modules with main methods encountered")
 
 addLangImport :: String -> GOOLState -> GOOLState
-addLangImport i = over langImports (\is -> if i `elem` is then i:is else is)
+addLangImport i = over langImports (\is -> if i `elem` is then is else i:is)
+
+getLangImports :: GS [String]
+getLangImports = gets (^. langImports)
 
 addModuleImport :: String -> GOOLState -> GOOLState
-addModuleImport i = over moduleImports (\is -> if i `elem` is then i:is else is)
+addModuleImport i = over moduleImports (\is -> if i `elem` is then is else i:is)
+
+getModuleImports :: GS [String]
+getModuleImports = gets (^. moduleImports)
 
 addHeaderLangImport :: String -> GOOLState -> GOOLState
-addHeaderLangImport i = over headerLangImports (\is -> if i `elem` is then i:is 
-  else is)
+addHeaderLangImport i = over headerLangImports (\is -> if i `elem` is then is 
+  else i:is)
 
 addDefine :: String -> GOOLState -> GOOLState
-addDefine d = over defines (\ds -> if d `elem` ds then d:ds else ds)
+addDefine d = over defines (\ds -> if d `elem` ds then ds else d:ds)
 
 setFilePath :: FilePath -> (GOOLState, FileState) -> (GOOLState, FileState)
 setFilePath fp = over _2 (set currFilePath fp)

--- a/code/drasil-gool/GOOL/Drasil/State.hs
+++ b/code/drasil-gool/GOOL/Drasil/State.hs
@@ -1,15 +1,16 @@
 {-# LANGUAGE TemplateHaskell #-}
 
 module GOOL.Drasil.State (
-  GS, GOOLState(..), FS, MS, lensFStoGS, lensGStoFS, lensFStoMS, lensMStoGS,  
+  GS, GOOLState(..), FS, MS, lensFStoGS, lensGStoFS, lensFStoMS, lensMStoFS, 
   headers, sources, mainMod, currMain, initialState, initialFS, putAfter, 
   getPutReturn, getPutReturnFunc, getPutReturnFunc2, getPutReturnList, addFile, 
   addCombinedHeaderSource, addHeader, addSource, addProgNameToPaths, setMainMod,
   addLangImport, getLangImports, addModuleImport, getModuleImports, 
-  addHeaderLangImport, addDefine, setFilePath, getFilePath, setModuleName, 
-  getModuleName, setCurrMain, getCurrMain, addClass, getClasses, updateClassMap,
-  getClassMap, addParameter, getParameters, setScope, getScope, setCurrMainFunc,
-  getCurrMainFunc
+  addHeaderLangImport, getHeaderLangImports, addHeaderModImport, 
+  getHeaderModImports, addDefine, getDefines, addHeaderDefine, getHeaderDefines,
+  setFilePath, getFilePath, setModuleName, getModuleName, setCurrMain, 
+  getCurrMain, addClass, getClasses, updateClassMap, getClassMap, addParameter, 
+  getParameters, setScope, getScope, setCurrMainFunc, getCurrMainFunc
 ) where
 
 import GOOL.Drasil.Data (FileType(..), ScopeTag(..))
@@ -47,7 +48,9 @@ data FileState = FS {
 
   -- C++ only
   _headerLangImports :: [String],
-  _defines :: [String]
+  _headerModImports :: [String],
+  _defines :: [String],
+  _headerDefines :: [String]
 }
 makeLenses ''FileState
 
@@ -110,7 +113,9 @@ initialFS = FS {
   _moduleImports = [],
 
   _headerLangImports = [],
-  _defines = []
+  _headerModImports = [],
+  _defines = [],
+  _headerDefines = []
 }
 
 initialMS :: MethodState
@@ -208,8 +213,29 @@ addHeaderLangImport :: String -> (GOOLState, FileState) -> (GOOLState,
 addHeaderLangImport i = over _2 $ over headerLangImports (\is -> if i `elem` is 
   then is else i:is)
 
+getHeaderLangImports :: FS [String]
+getHeaderLangImports = gets ((^. headerLangImports) . snd)
+
+addHeaderModImport :: String -> (GOOLState, FileState) -> (GOOLState, 
+  FileState)
+addHeaderModImport i = over _2 $ over headerModImports (\is -> if i `elem` is 
+  then is else i:is)
+
+getHeaderModImports :: FS [String]
+getHeaderModImports = gets ((^. headerModImports) . snd)
+
 addDefine :: String -> (GOOLState, FileState) -> (GOOLState, FileState)
 addDefine d = over _2 $ over defines (\ds -> if d `elem` ds then ds else d:ds)
+
+getDefines :: FS [String]
+getDefines = gets ((^. defines) . snd)
+
+addHeaderDefine :: String -> (GOOLState, FileState) -> (GOOLState, FileState)
+addHeaderDefine d = over _2 $ over headerDefines (\ds -> if d `elem` ds then ds 
+  else d:ds)
+
+getHeaderDefines :: FS [String]
+getHeaderDefines = gets ((^. headerDefines) . snd)
 
 setFilePath :: FilePath -> (GOOLState, FileState) -> (GOOLState, FileState)
 setFilePath fp = over _2 (set currFilePath fp)

--- a/code/drasil-gool/GOOL/Drasil/State.hs
+++ b/code/drasil-gool/GOOL/Drasil/State.hs
@@ -17,7 +17,7 @@ import Control.Lens (Lens', (^.), lens, makeLenses, over, set)
 import Control.Lens.Tuple (_1, _2)
 import Control.Monad.State (State, get, put, gets)
 import Data.Maybe (isNothing)
-import Data.Map (Map, fromList, empty, union, toList)
+import Data.Map (Map, fromList, empty, union)
 
 data GOOLState = GS {
   _headers :: [FilePath],
@@ -180,8 +180,8 @@ addProgNameToPaths n = over mainMod (fmap f) . over sources (map f) .
   where f = ((n++"/")++)
 
 setMainMod :: String -> GOOLState -> GOOLState
-setMainMod n s = error $ show (toList $ s ^. classMap) -- over mainMod (\m -> if isNothing m then Just n else error 
-  -- "Multiple modules with main methods encountered")
+setMainMod n = over mainMod (\m -> if isNothing m then Just n else error 
+  "Multiple modules with main methods encountered")
 
 addLangImport :: String -> GOOLState -> GOOLState
 addLangImport i = over langImports (\is -> if i `elem` is then i:is else is)

--- a/code/drasil-gool/GOOL/Drasil/State.hs
+++ b/code/drasil-gool/GOOL/Drasil/State.hs
@@ -8,9 +8,10 @@ module GOOL.Drasil.State (
   addLangImport, getLangImports, addModuleImport, getModuleImports, 
   addHeaderLangImport, getHeaderLangImports, addHeaderModImport, 
   getHeaderModImports, addDefine, getDefines, addHeaderDefine, getHeaderDefines,
-  setFilePath, getFilePath, setModuleName, getModuleName, setCurrMain, 
-  getCurrMain, addClass, getClasses, updateClassMap, getClassMap, addParameter, 
-  getParameters, setScope, getScope, setCurrMainFunc, getCurrMainFunc
+  addUsing, getUsing, addHeaderUsing, getHeaderUsing, setFilePath, getFilePath, 
+  setModuleName, getModuleName, setCurrMain, getCurrMain, addClass, getClasses, 
+  updateClassMap, getClassMap, addParameter, getParameters, setScope, getScope, 
+  setCurrMainFunc, getCurrMainFunc
 ) where
 
 import GOOL.Drasil.Data (FileType(..), ScopeTag(..))
@@ -25,7 +26,7 @@ data GOOLState = GS {
   _headers :: [FilePath],
   _sources :: [FilePath],
   _mainMod :: Maybe FilePath,
-  _classMap :: Map String String,
+  _classMap :: Map String String
 } 
 makeLenses ''GOOLState
 
@@ -42,7 +43,7 @@ data FileState = FS {
   _currModName :: String,
   _currFilePath :: FilePath,
   _currMain :: Bool,
-  _currClasses :: [String]
+  _currClasses :: [String],
   _langImports :: [String],
   _moduleImports :: [String],
 
@@ -50,7 +51,9 @@ data FileState = FS {
   _headerLangImports :: [String],
   _headerModImports :: [String],
   _defines :: [String],
-  _headerDefines :: [String]
+  _headerDefines :: [String],
+  _using :: [String],
+  _headerUsing :: [String]
 }
 makeLenses ''FileState
 
@@ -100,7 +103,7 @@ initialState = GS {
   _headers = [],
   _sources = [],
   _mainMod = Nothing,
-  _classMap = empty,
+  _classMap = empty
 }
 
 initialFS :: FileState
@@ -108,14 +111,16 @@ initialFS = FS {
   _currModName = "",
   _currFilePath = "",
   _currMain = False,
-  _currClasses = []
+  _currClasses = [],
   _langImports = [],
   _moduleImports = [],
 
   _headerLangImports = [],
   _headerModImports = [],
   _defines = [],
-  _headerDefines = []
+  _headerDefines = [],
+  _using = [],
+  _headerUsing = []
 }
 
 initialMS :: MethodState
@@ -229,13 +234,26 @@ addDefine d = over _2 $ over defines (\ds -> if d `elem` ds then ds else d:ds)
 
 getDefines :: FS [String]
 getDefines = gets ((^. defines) . snd)
-
+  
 addHeaderDefine :: String -> (GOOLState, FileState) -> (GOOLState, FileState)
 addHeaderDefine d = over _2 $ over headerDefines (\ds -> if d `elem` ds then ds 
   else d:ds)
 
 getHeaderDefines :: FS [String]
 getHeaderDefines = gets ((^. headerDefines) . snd)
+
+addUsing :: String -> (GOOLState, FileState) -> (GOOLState, FileState)
+addUsing u = over _2 $ over using (\us -> if u `elem` us then us else u:us)
+
+getUsing :: FS [String]
+getUsing = gets ((^. using) . snd)
+
+addHeaderUsing :: String -> (GOOLState, FileState) -> (GOOLState, FileState)
+addHeaderUsing u = over _2 $ over headerUsing (\us -> if u `elem` us then us 
+  else u:us)
+
+getHeaderUsing :: FS [String]
+getHeaderUsing = gets ((^. headerUsing) . snd)
 
 setFilePath :: FilePath -> (GOOLState, FileState) -> (GOOLState, FileState)
 setFilePath fp = over _2 (set currFilePath fp)

--- a/code/drasil-gool/GOOL/Drasil/Symantics.hs
+++ b/code/drasil-gool/GOOL/Drasil/Symantics.hs
@@ -36,16 +36,14 @@ class (FileSym repr, InternalBlock repr, InternalClass repr, InternalFile repr,
   InternalValue repr, InternalVariable repr, KeywordSym repr, UnaryOpSym repr, 
   BinaryOpSym repr) => RenderSym repr
 
-class (RenderSym repr) => ProgramSym repr where
+class (FileSym repr) => ProgramSym repr where
   type Program repr
   prog :: Label -> [FS (repr (RenderFile repr))] -> 
     GS (repr (Program repr))
 
-class (ModuleSym repr) => 
-  FileSym repr where 
+class (ModuleSym repr) => FileSym repr where 
   type RenderFile repr
-  fileDoc :: FS (repr (Module repr)) -> 
-    FS (repr (RenderFile repr))
+  fileDoc :: FS (repr (Module repr)) -> FS (repr (RenderFile repr))
 
   -- Module description, list of author names, date as a String, file to comment
   docMod :: String -> [String] -> String -> 

--- a/code/drasil-gool/GOOL/Drasil/Symantics.hs
+++ b/code/drasil-gool/GOOL/Drasil/Symantics.hs
@@ -33,8 +33,8 @@ class (FileSym repr, InternalBlock repr, InternalClass repr, InternalFile repr,
   InternalFunction repr, InternalMethod repr, InternalMod repr, InternalOp repr,
   InternalParam repr, InternalPerm repr, InternalScope repr, 
   InternalStatement repr, InternalStateVar repr, InternalType repr, 
-  InternalValue repr, InternalVariable repr, KeywordSym repr, UnaryOpSym repr, 
-  BinaryOpSym repr) => RenderSym repr
+  InternalValue repr, InternalVariable repr, KeywordSym repr, ImportSym repr, 
+  UnaryOpSym repr, BinaryOpSym repr) => RenderSym repr
 
 class (FileSym repr) => ProgramSym repr where
   type Program repr
@@ -759,7 +759,7 @@ class InternalClass repr where
   classDoc :: repr (Class repr) -> Doc
   classFromData :: FS Doc -> FS (repr (Class repr))
 
-class (ClassSym repr, ImportSym repr) => ModuleSym repr where
+class (ClassSym repr) => ModuleSym repr where
   type Module repr
   buildModule :: Label -> [Library] -> [MS (repr (Method repr))] -> 
     [FS (repr (Class repr))] -> FS (repr (Module repr))

--- a/code/drasil-gool/GOOL/Drasil/Symantics.hs
+++ b/code/drasil-gool/GOOL/Drasil/Symantics.hs
@@ -766,7 +766,7 @@ class (ClassSym repr) => ModuleSym repr where
 
 class InternalMod repr where
   moduleDoc :: repr (Module repr) -> Doc
-  modFromData :: String -> FS Bool -> FS Doc -> FS (repr (Module repr))
+  modFromData :: String -> FS Doc -> FS (repr (Module repr))
   updateModuleDoc :: (Doc -> Doc) -> repr (Module repr) -> repr (Module repr)
     
 class BlockCommentSym repr where

--- a/code/drasil-gool/GOOL/Drasil/Symantics.hs
+++ b/code/drasil-gool/GOOL/Drasil/Symantics.hs
@@ -157,44 +157,47 @@ listSlice vnew vold b e s = listSlice' b e s vnew vold
 
 class UnaryOpSym repr where
   type UnaryOp repr
-  notOp    :: repr (UnaryOp repr)
-  negateOp :: repr (UnaryOp repr)
-  sqrtOp   :: repr (UnaryOp repr)
-  absOp    :: repr (UnaryOp repr)
-  logOp    :: repr (UnaryOp repr)
-  lnOp     :: repr (UnaryOp repr)
-  expOp    :: repr (UnaryOp repr)
-  sinOp    :: repr (UnaryOp repr)
-  cosOp    :: repr (UnaryOp repr)
-  tanOp    :: repr (UnaryOp repr)
-  asinOp   :: repr (UnaryOp repr)
-  acosOp   :: repr (UnaryOp repr)
-  atanOp   :: repr (UnaryOp repr)
-  floorOp  :: repr (UnaryOp repr)
-  ceilOp   :: repr (UnaryOp repr)
+  notOp    :: GS (repr (UnaryOp repr))
+  negateOp :: GS (repr (UnaryOp repr))
+  sqrtOp   :: GS (repr (UnaryOp repr))
+  absOp    :: GS (repr (UnaryOp repr))
+  logOp    :: GS (repr (UnaryOp repr))
+  lnOp     :: GS (repr (UnaryOp repr))
+  expOp    :: GS (repr (UnaryOp repr))
+  sinOp    :: GS (repr (UnaryOp repr))
+  cosOp    :: GS (repr (UnaryOp repr))
+  tanOp    :: GS (repr (UnaryOp repr))
+  asinOp   :: GS (repr (UnaryOp repr))
+  acosOp   :: GS (repr (UnaryOp repr))
+  atanOp   :: GS (repr (UnaryOp repr))
+  floorOp  :: GS (repr (UnaryOp repr))
+  ceilOp   :: GS (repr (UnaryOp repr))
 
 class BinaryOpSym repr where
   type BinaryOp repr
-  equalOp        :: repr (BinaryOp repr)
-  notEqualOp     :: repr (BinaryOp repr)
-  greaterOp      :: repr (BinaryOp repr)
-  greaterEqualOp :: repr (BinaryOp repr)
-  lessOp         :: repr (BinaryOp repr)
-  lessEqualOp    :: repr (BinaryOp repr)
-  plusOp         :: repr (BinaryOp repr)
-  minusOp        :: repr (BinaryOp repr)
-  multOp         :: repr (BinaryOp repr)
-  divideOp       :: repr (BinaryOp repr)
-  powerOp        :: repr (BinaryOp repr)
-  moduloOp       :: repr (BinaryOp repr)
-  andOp          :: repr (BinaryOp repr)
-  orOp           :: repr (BinaryOp repr)
+  equalOp        :: GS (repr (BinaryOp repr))
+  notEqualOp     :: GS (repr (BinaryOp repr))
+  greaterOp      :: GS (repr (BinaryOp repr))
+  greaterEqualOp :: GS (repr (BinaryOp repr))
+  lessOp         :: GS (repr (BinaryOp repr))
+  lessEqualOp    :: GS (repr (BinaryOp repr))
+  plusOp         :: GS (repr (BinaryOp repr))
+  minusOp        :: GS (repr (BinaryOp repr))
+  multOp         :: GS (repr (BinaryOp repr))
+  divideOp       :: GS (repr (BinaryOp repr))
+  powerOp        :: GS (repr (BinaryOp repr))
+  moduloOp       :: GS (repr (BinaryOp repr))
+  andOp          :: GS (repr (BinaryOp repr))
+  orOp           :: GS (repr (BinaryOp repr))
 
 class InternalOp repr where
   uOpDoc :: repr (UnaryOp repr) -> Doc
   bOpDoc :: repr (BinaryOp repr) -> Doc
   uOpPrec :: repr (UnaryOp repr) -> Int
   bOpPrec :: repr (BinaryOp repr) -> Int
+
+  uOpFromData :: Int -> Doc -> GS (repr (UnaryOp repr))
+  bOpFromData :: Int -> Doc -> GS (repr (BinaryOp repr))
 
 class (TypeSym repr) => VariableSym repr where
   type Variable repr

--- a/code/drasil-gool/GOOL/Drasil/Symantics.hs
+++ b/code/drasil-gool/GOOL/Drasil/Symantics.hs
@@ -66,7 +66,6 @@ class (PermanenceSym repr) => KeywordSym repr where
   endStatement     :: repr (Keyword repr)
   endStatementLoop :: repr (Keyword repr)
 
-  include :: Label -> repr (Keyword repr)
   inherit :: Label -> repr (Keyword repr)
 
   list     :: repr (Permanence repr) -> repr (Keyword repr)

--- a/code/drasil-gool/GOOL/Drasil/Symantics.hs
+++ b/code/drasil-gool/GOOL/Drasil/Symantics.hs
@@ -761,7 +761,7 @@ class InternalClass repr where
 
 class (ClassSym repr) => ModuleSym repr where
   type Module repr
-  buildModule :: Label -> [Library] -> [MS (repr (Method repr))] -> 
+  buildModule :: Label -> [MS (repr (Method repr))] -> 
     [FS (repr (Class repr))] -> FS (repr (Module repr))
 
 class InternalMod repr where

--- a/code/drasil-gool/GOOL/Drasil/Symantics.hs
+++ b/code/drasil-gool/GOOL/Drasil/Symantics.hs
@@ -106,38 +106,38 @@ class InternalPerm repr where
 
 class (BlockSym repr) => BodySym repr where
   type Body repr
-  body           :: [GS (repr (Block repr))] -> GS (repr (Body repr))
-  bodyStatements :: [GS (repr (Statement repr))] -> GS (repr (Body repr))
-  oneLiner       :: GS (repr (Statement repr)) -> GS (repr (Body repr))
+  body           :: [FS (repr (Block repr))] -> FS (repr (Body repr))
+  bodyStatements :: [FS (repr (Statement repr))] -> FS (repr (Body repr))
+  oneLiner       :: FS (repr (Statement repr)) -> FS (repr (Body repr))
 
-  addComments :: Label -> GS (repr (Body repr)) -> GS (repr (Body repr))
+  addComments :: Label -> FS (repr (Body repr)) -> FS (repr (Body repr))
 
   bodyDoc :: repr (Body repr) -> Doc
 
 class (StatementSym repr) => BlockSym repr where
   type Block repr
-  block   :: [GS (repr (Statement repr))] -> GS (repr (Block repr))
+  block   :: [FS (repr (Statement repr))] -> FS (repr (Block repr))
 
 class InternalBlock repr where
   blockDoc :: repr (Block repr) -> Doc
-  docBlock :: GS Doc -> GS (repr (Block repr))
+  docBlock :: FS Doc -> FS (repr (Block repr))
 
 class (PermanenceSym repr) => TypeSym repr where
   type Type repr
-  bool          :: GS (repr (Type repr))
-  int           :: GS (repr (Type repr))
-  float         :: GS (repr (Type repr))
-  char          :: GS (repr (Type repr))
-  string        :: GS (repr (Type repr))
-  infile        :: GS (repr (Type repr))
-  outfile       :: GS (repr (Type repr))
-  listType      :: repr (Permanence repr) -> GS (repr (Type repr)) -> 
-    GS (repr (Type repr))
-  listInnerType :: GS (repr (Type repr)) -> GS (repr (Type repr))
-  obj           :: Label -> GS (repr (Type repr))
-  enumType      :: Label -> GS (repr (Type repr))
-  iterator      :: GS (repr (Type repr)) -> GS (repr (Type repr))
-  void          :: GS (repr (Type repr))
+  bool          :: FS (repr (Type repr))
+  int           :: FS (repr (Type repr))
+  float         :: FS (repr (Type repr))
+  char          :: FS (repr (Type repr))
+  string        :: FS (repr (Type repr))
+  infile        :: FS (repr (Type repr))
+  outfile       :: FS (repr (Type repr))
+  listType      :: repr (Permanence repr) -> FS (repr (Type repr)) -> 
+    FS (repr (Type repr))
+  listInnerType :: FS (repr (Type repr)) -> FS (repr (Type repr))
+  obj           :: Label -> FS (repr (Type repr))
+  enumType      :: Label -> FS (repr (Type repr))
+  iterator      :: FS (repr (Type repr)) -> FS (repr (Type repr))
+  void          :: FS (repr (Type repr))
 
   getType :: repr (Type repr) -> CodeType
   getTypeString :: repr (Type repr) -> String
@@ -147,55 +147,55 @@ class InternalType repr where
   typeFromData :: CodeType -> String -> Doc -> repr (Type repr)
 
 class (ControlStatementSym repr) => ControlBlockSym repr where
-  runStrategy     :: Label -> [(Label, GS (repr (Body repr)))] -> 
-    Maybe (GS (repr (Value repr))) -> Maybe (GS (repr (Variable repr))) -> 
-    GS (repr (Block repr))
+  runStrategy     :: Label -> [(Label, FS (repr (Body repr)))] -> 
+    Maybe (FS (repr (Value repr))) -> Maybe (FS (repr (Variable repr))) -> 
+    FS (repr (Block repr))
 
-  listSlice'      :: Maybe (GS (repr (Value repr))) -> 
-    Maybe (GS (repr (Value repr))) -> Maybe (GS (repr (Value repr))) ->
-    GS (repr (Variable repr)) -> GS (repr (Value repr)) -> 
-    GS (repr (Block repr))
+  listSlice'      :: Maybe (FS (repr (Value repr))) -> 
+    Maybe (FS (repr (Value repr))) -> Maybe (FS (repr (Value repr))) ->
+    FS (repr (Variable repr)) -> FS (repr (Value repr)) -> 
+    FS (repr (Block repr))
 
-listSlice :: (ControlBlockSym repr) => GS (repr (Variable repr)) -> 
-  GS (repr (Value repr)) -> Maybe (GS (repr (Value repr))) -> 
-  Maybe (GS (repr (Value repr))) -> Maybe (GS (repr (Value repr))) -> 
-  GS (repr (Block repr))
+listSlice :: (ControlBlockSym repr) => FS (repr (Variable repr)) -> 
+  FS (repr (Value repr)) -> Maybe (FS (repr (Value repr))) -> 
+  Maybe (FS (repr (Value repr))) -> Maybe (FS (repr (Value repr))) -> 
+  FS (repr (Block repr))
 listSlice vnew vold b e s = listSlice' b e s vnew vold
 
 class UnaryOpSym repr where
   type UnaryOp repr
-  notOp    :: GS (repr (UnaryOp repr))
-  negateOp :: GS (repr (UnaryOp repr))
-  sqrtOp   :: GS (repr (UnaryOp repr))
-  absOp    :: GS (repr (UnaryOp repr))
-  logOp    :: GS (repr (UnaryOp repr))
-  lnOp     :: GS (repr (UnaryOp repr))
-  expOp    :: GS (repr (UnaryOp repr))
-  sinOp    :: GS (repr (UnaryOp repr))
-  cosOp    :: GS (repr (UnaryOp repr))
-  tanOp    :: GS (repr (UnaryOp repr))
-  asinOp   :: GS (repr (UnaryOp repr))
-  acosOp   :: GS (repr (UnaryOp repr))
-  atanOp   :: GS (repr (UnaryOp repr))
-  floorOp  :: GS (repr (UnaryOp repr))
-  ceilOp   :: GS (repr (UnaryOp repr))
+  notOp    :: FS (repr (UnaryOp repr))
+  negateOp :: FS (repr (UnaryOp repr))
+  sqrtOp   :: FS (repr (UnaryOp repr))
+  absOp    :: FS (repr (UnaryOp repr))
+  logOp    :: FS (repr (UnaryOp repr))
+  lnOp     :: FS (repr (UnaryOp repr))
+  expOp    :: FS (repr (UnaryOp repr))
+  sinOp    :: FS (repr (UnaryOp repr))
+  cosOp    :: FS (repr (UnaryOp repr))
+  tanOp    :: FS (repr (UnaryOp repr))
+  asinOp   :: FS (repr (UnaryOp repr))
+  acosOp   :: FS (repr (UnaryOp repr))
+  atanOp   :: FS (repr (UnaryOp repr))
+  floorOp  :: FS (repr (UnaryOp repr))
+  ceilOp   :: FS (repr (UnaryOp repr))
 
 class BinaryOpSym repr where
   type BinaryOp repr
-  equalOp        :: GS (repr (BinaryOp repr))
-  notEqualOp     :: GS (repr (BinaryOp repr))
-  greaterOp      :: GS (repr (BinaryOp repr))
-  greaterEqualOp :: GS (repr (BinaryOp repr))
-  lessOp         :: GS (repr (BinaryOp repr))
-  lessEqualOp    :: GS (repr (BinaryOp repr))
-  plusOp         :: GS (repr (BinaryOp repr))
-  minusOp        :: GS (repr (BinaryOp repr))
-  multOp         :: GS (repr (BinaryOp repr))
-  divideOp       :: GS (repr (BinaryOp repr))
-  powerOp        :: GS (repr (BinaryOp repr))
-  moduloOp       :: GS (repr (BinaryOp repr))
-  andOp          :: GS (repr (BinaryOp repr))
-  orOp           :: GS (repr (BinaryOp repr))
+  equalOp        :: FS (repr (BinaryOp repr))
+  notEqualOp     :: FS (repr (BinaryOp repr))
+  greaterOp      :: FS (repr (BinaryOp repr))
+  greaterEqualOp :: FS (repr (BinaryOp repr))
+  lessOp         :: FS (repr (BinaryOp repr))
+  lessEqualOp    :: FS (repr (BinaryOp repr))
+  plusOp         :: FS (repr (BinaryOp repr))
+  minusOp        :: FS (repr (BinaryOp repr))
+  multOp         :: FS (repr (BinaryOp repr))
+  divideOp       :: FS (repr (BinaryOp repr))
+  powerOp        :: FS (repr (BinaryOp repr))
+  moduloOp       :: FS (repr (BinaryOp repr))
+  andOp          :: FS (repr (BinaryOp repr))
+  orOp           :: FS (repr (BinaryOp repr))
 
 class InternalOp repr where
   uOpDoc :: repr (UnaryOp repr) -> Doc
@@ -203,32 +203,32 @@ class InternalOp repr where
   uOpPrec :: repr (UnaryOp repr) -> Int
   bOpPrec :: repr (BinaryOp repr) -> Int
 
-  uOpFromData :: Int -> Doc -> GS (repr (UnaryOp repr))
-  bOpFromData :: Int -> Doc -> GS (repr (BinaryOp repr))
+  uOpFromData :: Int -> Doc -> FS (repr (UnaryOp repr))
+  bOpFromData :: Int -> Doc -> FS (repr (BinaryOp repr))
 
 class (TypeSym repr) => VariableSym repr where
   type Variable repr
-  var          :: Label -> GS (repr (Type repr)) -> GS (repr (Variable repr))
-  staticVar    :: Label -> GS (repr (Type repr)) -> GS (repr (Variable repr))
-  const        :: Label -> GS (repr (Type repr)) -> GS (repr (Variable repr))
-  extVar       :: Library -> Label -> GS (repr (Type repr)) -> 
-    GS (repr (Variable repr))
-  self         :: Label -> GS (repr (Variable repr))
-  classVar     :: GS (repr (Type repr)) -> GS (repr (Variable repr)) -> 
-    GS (repr (Variable repr))
-  extClassVar  :: GS (repr (Type repr)) -> GS (repr (Variable repr)) -> 
-    GS (repr (Variable repr))
-  objVar       :: GS (repr (Variable repr)) -> GS (repr (Variable repr)) -> 
-    GS (repr (Variable repr))
-  objVarSelf   :: Label -> GS (repr (Variable repr)) -> GS (repr (Variable repr))
-  enumVar      :: Label -> Label -> GS (repr (Variable repr))
-  listVar      :: Label -> repr (Permanence repr) -> GS (repr (Type repr)) -> 
-    GS (repr (Variable repr))
-  listOf       :: Label -> GS (repr (Type repr)) -> GS (repr (Variable repr))
+  var          :: Label -> FS (repr (Type repr)) -> FS (repr (Variable repr))
+  staticVar    :: Label -> FS (repr (Type repr)) -> FS (repr (Variable repr))
+  const        :: Label -> FS (repr (Type repr)) -> FS (repr (Variable repr))
+  extVar       :: Library -> Label -> FS (repr (Type repr)) -> 
+    FS (repr (Variable repr))
+  self         :: Label -> FS (repr (Variable repr))
+  classVar     :: FS (repr (Type repr)) -> FS (repr (Variable repr)) -> 
+    FS (repr (Variable repr))
+  extClassVar  :: FS (repr (Type repr)) -> FS (repr (Variable repr)) -> 
+    FS (repr (Variable repr))
+  objVar       :: FS (repr (Variable repr)) -> FS (repr (Variable repr)) -> 
+    FS (repr (Variable repr))
+  objVarSelf   :: Label -> FS (repr (Variable repr)) -> FS (repr (Variable repr))
+  enumVar      :: Label -> Label -> FS (repr (Variable repr))
+  listVar      :: Label -> repr (Permanence repr) -> FS (repr (Type repr)) -> 
+    FS (repr (Variable repr))
+  listOf       :: Label -> FS (repr (Type repr)) -> FS (repr (Variable repr))
   -- Use for iterator variables, i.e. in a forEach loop.
-  iterVar      :: Label -> GS (repr (Type repr)) -> GS (repr (Variable repr))
+  iterVar      :: Label -> FS (repr (Type repr)) -> FS (repr (Variable repr))
 
-  ($->) :: GS (repr (Variable repr)) -> GS (repr (Variable repr)) -> GS (repr (Variable repr))
+  ($->) :: FS (repr (Variable repr)) -> FS (repr (Variable repr)) -> FS (repr (Variable repr))
   infixl 9 $->
 
   variableBind :: repr (Variable repr) -> Binding
@@ -242,70 +242,70 @@ class InternalVariable repr where
 
 class (VariableSym repr) => ValueSym repr where
   type Value repr
-  litTrue   :: GS (repr (Value repr))
-  litFalse  :: GS (repr (Value repr))
-  litChar   :: Char -> GS (repr (Value repr))
-  litFloat  :: Double -> GS (repr (Value repr))
-  litInt    :: Integer -> GS (repr (Value repr))
-  litString :: String -> GS (repr (Value repr))
+  litTrue   :: FS (repr (Value repr))
+  litFalse  :: FS (repr (Value repr))
+  litChar   :: Char -> FS (repr (Value repr))
+  litFloat  :: Double -> FS (repr (Value repr))
+  litInt    :: Integer -> FS (repr (Value repr))
+  litString :: String -> FS (repr (Value repr))
 
-  pi :: GS (repr (Value repr))
+  pi :: FS (repr (Value repr))
 
   --other operators ($)
-  ($:)  :: Label -> Label -> GS (repr (Value repr))
+  ($:)  :: Label -> Label -> FS (repr (Value repr))
   infixl 9 $:
 
-  valueOf       :: GS (repr (Variable repr)) -> GS (repr (Value repr))
+  valueOf       :: FS (repr (Variable repr)) -> FS (repr (Value repr))
 --  global       :: Label -> repr (Value repr)         -- not sure how this one works, but in GOOL it was hardcoded to give an error so I'm leaving it out for now
-  arg          :: Integer -> GS (repr (Value repr))
-  enumElement  :: Label -> Label -> GS (repr (Value repr))
+  arg          :: Integer -> FS (repr (Value repr))
+  enumElement  :: Label -> Label -> FS (repr (Value repr))
 
-  argsList  :: GS (repr (Value repr))
+  argsList  :: FS (repr (Value repr))
 
   valueType :: repr (Value repr) -> repr (Type repr)
   valueDoc :: repr (Value repr) -> Doc
 
 class (ValueSym repr) => 
   NumericExpression repr where
-  (#~)  :: GS (repr (Value repr)) -> GS (repr (Value repr))
+  (#~)  :: FS (repr (Value repr)) -> FS (repr (Value repr))
   infixl 8 #~
-  (#/^) :: GS (repr (Value repr)) -> GS (repr (Value repr))
+  (#/^) :: FS (repr (Value repr)) -> FS (repr (Value repr))
   infixl 7 #/^
-  (#|)  :: GS (repr (Value repr)) -> GS (repr (Value repr))
+  (#|)  :: FS (repr (Value repr)) -> FS (repr (Value repr))
   infixl 7 #|
-  (#+)  :: GS (repr (Value repr)) -> GS (repr (Value repr)) -> 
-    GS (repr (Value repr))
+  (#+)  :: FS (repr (Value repr)) -> FS (repr (Value repr)) -> 
+    FS (repr (Value repr))
   infixl 5 #+
-  (#-)  :: GS (repr (Value repr)) -> GS (repr (Value repr)) -> 
-    GS (repr (Value repr))
+  (#-)  :: FS (repr (Value repr)) -> FS (repr (Value repr)) -> 
+    FS (repr (Value repr))
   infixl 5 #-
-  (#*)  :: GS (repr (Value repr)) -> GS (repr (Value repr)) -> 
-    GS (repr (Value repr))
+  (#*)  :: FS (repr (Value repr)) -> FS (repr (Value repr)) -> 
+    FS (repr (Value repr))
   infixl 6 #*
-  (#/)  :: GS (repr (Value repr)) -> GS (repr (Value repr)) -> 
-    GS (repr (Value repr))
+  (#/)  :: FS (repr (Value repr)) -> FS (repr (Value repr)) -> 
+    FS (repr (Value repr))
   infixl 6 #/
-  (#%)  :: GS (repr (Value repr)) -> GS (repr (Value repr)) -> 
-    GS (repr (Value repr))
+  (#%)  :: FS (repr (Value repr)) -> FS (repr (Value repr)) -> 
+    FS (repr (Value repr))
   infixl 6 #%
-  (#^)  :: GS (repr (Value repr)) -> GS (repr (Value repr)) -> 
-    GS (repr (Value repr))
+  (#^)  :: FS (repr (Value repr)) -> FS (repr (Value repr)) -> 
+    FS (repr (Value repr))
   infixl 7 #^
 
-  log    :: GS (repr (Value repr)) -> GS (repr (Value repr))
-  ln     :: GS (repr (Value repr)) -> GS (repr (Value repr))
-  exp    :: GS (repr (Value repr)) -> GS (repr (Value repr))
-  sin    :: GS (repr (Value repr)) -> GS (repr (Value repr))
-  cos    :: GS (repr (Value repr)) -> GS (repr (Value repr))
-  tan    :: GS (repr (Value repr)) -> GS (repr (Value repr))
-  csc    :: GS (repr (Value repr)) -> GS (repr (Value repr))
-  sec    :: GS (repr (Value repr)) -> GS (repr (Value repr))
-  cot    :: GS (repr (Value repr)) -> GS (repr (Value repr))
-  arcsin :: GS (repr (Value repr)) -> GS (repr (Value repr))
-  arccos :: GS (repr (Value repr)) -> GS (repr (Value repr))
-  arctan :: GS (repr (Value repr)) -> GS (repr (Value repr))
-  floor  :: GS (repr (Value repr)) -> GS (repr (Value repr))
-  ceil   :: GS (repr (Value repr)) -> GS (repr (Value repr))
+  log    :: FS (repr (Value repr)) -> FS (repr (Value repr))
+  ln     :: FS (repr (Value repr)) -> FS (repr (Value repr))
+  exp    :: FS (repr (Value repr)) -> FS (repr (Value repr))
+  sin    :: FS (repr (Value repr)) -> FS (repr (Value repr))
+  cos    :: FS (repr (Value repr)) -> FS (repr (Value repr))
+  tan    :: FS (repr (Value repr)) -> FS (repr (Value repr))
+  csc    :: FS (repr (Value repr)) -> FS (repr (Value repr))
+  sec    :: FS (repr (Value repr)) -> FS (repr (Value repr))
+  cot    :: FS (repr (Value repr)) -> FS (repr (Value repr))
+  arcsin :: FS (repr (Value repr)) -> FS (repr (Value repr))
+  arccos :: FS (repr (Value repr)) -> FS (repr (Value repr))
+  arctan :: FS (repr (Value repr)) -> FS (repr (Value repr))
+  floor  :: FS (repr (Value repr)) -> FS (repr (Value repr))
+  ceil   :: FS (repr (Value repr)) -> FS (repr (Value repr))
 
 -- I considered having two separate classes, BooleanExpressions and BooleanComparisons,
 -- but this would require cyclic constraints, since it is feasible to have
@@ -314,61 +314,61 @@ class (ValueSym repr) =>
 -- 3 functions here, even though they don't really need it.
 class (ValueSym repr, NumericExpression repr) => 
   BooleanExpression repr where
-  (?!)  :: GS (repr (Value repr)) -> GS (repr (Value repr))
+  (?!)  :: FS (repr (Value repr)) -> FS (repr (Value repr))
   infixr 6 ?!
-  (?&&) :: GS (repr (Value repr)) -> GS (repr (Value repr)) -> 
-    GS (repr (Value repr))
+  (?&&) :: FS (repr (Value repr)) -> FS (repr (Value repr)) -> 
+    FS (repr (Value repr))
   infixl 2 ?&&
-  (?||) :: GS (repr (Value repr)) -> GS (repr (Value repr)) -> 
-    GS (repr (Value repr))
+  (?||) :: FS (repr (Value repr)) -> FS (repr (Value repr)) -> 
+    FS (repr (Value repr))
   infixl 1 ?||
 
-  (?<)  :: GS (repr (Value repr)) -> GS (repr (Value repr)) -> 
-    GS (repr (Value repr))
+  (?<)  :: FS (repr (Value repr)) -> FS (repr (Value repr)) -> 
+    FS (repr (Value repr))
   infixl 4 ?<
-  (?<=) :: GS (repr (Value repr)) -> GS (repr (Value repr)) -> 
-    GS (repr (Value repr))
+  (?<=) :: FS (repr (Value repr)) -> FS (repr (Value repr)) -> 
+    FS (repr (Value repr))
   infixl 4 ?<=
-  (?>)  :: GS (repr (Value repr)) -> GS (repr (Value repr)) -> 
-    GS (repr (Value repr))
+  (?>)  :: FS (repr (Value repr)) -> FS (repr (Value repr)) -> 
+    FS (repr (Value repr))
   infixl 4 ?>
-  (?>=) :: GS (repr (Value repr)) -> GS (repr (Value repr)) -> 
-    GS (repr (Value repr))
+  (?>=) :: FS (repr (Value repr)) -> FS (repr (Value repr)) -> 
+    FS (repr (Value repr))
   infixl 4 ?>=
-  (?==) :: GS (repr (Value repr)) -> GS (repr (Value repr)) -> 
-    GS (repr (Value repr))
+  (?==) :: FS (repr (Value repr)) -> FS (repr (Value repr)) -> 
+    FS (repr (Value repr))
   infixl 3 ?==
-  (?!=) :: GS (repr (Value repr)) -> GS (repr (Value repr)) -> 
-    GS (repr (Value repr))
+  (?!=) :: FS (repr (Value repr)) -> FS (repr (Value repr)) -> 
+    FS (repr (Value repr))
   infixl 3 ?!=
 
 class (ValueSym repr, BooleanExpression repr) => 
   ValueExpression repr where -- for values that can include expressions
-  inlineIf     :: GS (repr (Value repr)) -> GS (repr (Value repr)) -> 
-    GS (repr (Value repr)) -> GS (repr (Value repr))
-  funcApp      :: Label -> GS (repr (Type repr)) -> [GS (repr (Value repr))] -> 
-    GS (repr (Value repr))
-  selfFuncApp  :: Label -> Label -> GS (repr (Type repr)) -> 
-    [GS (repr (Value repr))] -> GS (repr (Value repr))
-  extFuncApp   :: Library -> Label -> GS (repr (Type repr)) -> 
-    [GS (repr (Value repr))] -> GS (repr (Value repr))
-  newObj     :: GS (repr (Type repr)) -> [GS (repr (Value repr))] -> 
-    GS (repr (Value repr))
-  extNewObj  :: Library -> GS (repr (Type repr)) -> [GS (repr (Value repr))] -> 
-    GS (repr (Value repr))
+  inlineIf     :: FS (repr (Value repr)) -> FS (repr (Value repr)) -> 
+    FS (repr (Value repr)) -> FS (repr (Value repr))
+  funcApp      :: Label -> FS (repr (Type repr)) -> [FS (repr (Value repr))] -> 
+    FS (repr (Value repr))
+  selfFuncApp  :: Label -> Label -> FS (repr (Type repr)) -> 
+    [FS (repr (Value repr))] -> FS (repr (Value repr))
+  extFuncApp   :: Library -> Label -> FS (repr (Type repr)) -> 
+    [FS (repr (Value repr))] -> FS (repr (Value repr))
+  newObj     :: FS (repr (Type repr)) -> [FS (repr (Value repr))] -> 
+    FS (repr (Value repr))
+  extNewObj  :: Library -> FS (repr (Type repr)) -> [FS (repr (Value repr))] -> 
+    FS (repr (Value repr))
 
-  exists  :: GS (repr (Value repr)) -> GS (repr (Value repr))
-  notNull :: GS (repr (Value repr)) -> GS (repr (Value repr))
+  exists  :: FS (repr (Value repr)) -> FS (repr (Value repr))
+  notNull :: FS (repr (Value repr)) -> FS (repr (Value repr))
 
 class InternalValue repr where
-  inputFunc       :: GS (repr (Value repr))
-  printFunc       :: GS (repr (Value repr))
-  printLnFunc     :: GS (repr (Value repr))
-  printFileFunc   :: GS (repr (Value repr)) -> GS (repr (Value repr))
-  printFileLnFunc :: GS (repr (Value repr)) -> GS (repr (Value repr))
+  inputFunc       :: FS (repr (Value repr))
+  printFunc       :: FS (repr (Value repr))
+  printLnFunc     :: FS (repr (Value repr))
+  printFileFunc   :: FS (repr (Value repr)) -> FS (repr (Value repr))
+  printFileLnFunc :: FS (repr (Value repr)) -> FS (repr (Value repr))
 
-  cast :: GS (repr (Type repr)) -> GS (repr (Value repr)) -> 
-    GS (repr (Value repr))
+  cast :: FS (repr (Type repr)) -> FS (repr (Value repr)) -> 
+    FS (repr (Value repr))
 
   valuePrec :: repr (Value repr) -> Maybe Int
   valFromData :: Maybe Int -> repr (Type repr) -> Doc -> repr (Value repr)
@@ -380,95 +380,95 @@ class InternalValue repr where
 -- then what is the purpose of splitting the typeclasses into smaller typeclasses?
 -- I'm leaving it as is for now, even though I suspect this will change in the future.
 class (FunctionSym repr) => Selector repr where
-  objAccess :: GS (repr (Value repr)) -> GS (repr (Function repr)) -> 
-    GS (repr (Value repr))
-  ($.)      :: GS (repr (Value repr)) -> GS (repr (Function repr)) -> 
-    GS (repr (Value repr))
+  objAccess :: FS (repr (Value repr)) -> FS (repr (Function repr)) -> 
+    FS (repr (Value repr))
+  ($.)      :: FS (repr (Value repr)) -> FS (repr (Function repr)) -> 
+    FS (repr (Value repr))
   infixl 9 $.
 
-  selfAccess :: Label -> GS (repr (Function repr)) -> GS (repr (Value repr))
+  selfAccess :: Label -> FS (repr (Function repr)) -> FS (repr (Value repr))
 
-  listIndexExists :: GS (repr (Value repr)) -> GS (repr (Value repr)) -> 
-    GS (repr (Value repr))
-  argExists       :: Integer -> GS (repr (Value repr))
+  listIndexExists :: FS (repr (Value repr)) -> FS (repr (Value repr)) -> 
+    FS (repr (Value repr))
+  argExists       :: Integer -> FS (repr (Value repr))
 
-  indexOf :: GS (repr (Value repr)) -> GS (repr (Value repr)) -> 
-    GS (repr (Value repr))
+  indexOf :: FS (repr (Value repr)) -> FS (repr (Value repr)) -> 
+    FS (repr (Value repr))
 
 class (FunctionSym repr) => InternalSelector repr where
-  objMethodCall' :: Label -> GS (repr (Type repr)) -> GS (repr (Value repr)) -> 
-    [GS (repr (Value repr))] -> GS (repr (Value repr))
-  objMethodCallNoParams' :: Label -> GS (repr (Type repr)) -> 
-    GS (repr (Value repr)) -> GS (repr (Value repr))
+  objMethodCall' :: Label -> FS (repr (Type repr)) -> FS (repr (Value repr)) -> 
+    [FS (repr (Value repr))] -> FS (repr (Value repr))
+  objMethodCallNoParams' :: Label -> FS (repr (Type repr)) -> 
+    FS (repr (Value repr)) -> FS (repr (Value repr))
 
-objMethodCall :: (InternalSelector repr) => GS (repr (Type repr)) -> 
-  GS (repr (Value repr)) -> Label -> [GS (repr (Value repr))] -> 
-  GS (repr (Value repr))
+objMethodCall :: (InternalSelector repr) => FS (repr (Type repr)) -> 
+  FS (repr (Value repr)) -> Label -> [FS (repr (Value repr))] -> 
+  FS (repr (Value repr))
 objMethodCall t o f = objMethodCall' f t o
 
-objMethodCallNoParams :: (InternalSelector repr) => GS (repr (Type repr)) -> 
-  GS (repr (Value repr)) -> Label -> GS (repr (Value repr))
+objMethodCallNoParams :: (InternalSelector repr) => FS (repr (Type repr)) -> 
+  FS (repr (Value repr)) -> Label -> FS (repr (Value repr))
 objMethodCallNoParams t o f = objMethodCallNoParams' f t o
 
 class (ValueExpression repr) => FunctionSym repr where
   type Function repr
-  func :: Label -> GS (repr (Type repr)) -> [GS (repr (Value repr))] -> 
-    GS (repr (Function repr))
+  func :: Label -> FS (repr (Type repr)) -> [FS (repr (Value repr))] -> 
+    FS (repr (Function repr))
 
-  get :: GS (repr (Value repr)) -> GS (repr (Variable repr)) -> 
-    GS (repr (Value repr))
-  set :: GS (repr (Value repr)) -> GS (repr (Variable repr)) -> 
-    GS (repr (Value repr)) -> GS (repr (Value repr))
+  get :: FS (repr (Value repr)) -> FS (repr (Variable repr)) -> 
+    FS (repr (Value repr))
+  set :: FS (repr (Value repr)) -> FS (repr (Variable repr)) -> 
+    FS (repr (Value repr)) -> FS (repr (Value repr))
 
-  listSize   :: GS (repr (Value repr)) -> GS (repr (Value repr))
-  listAdd    :: GS (repr (Value repr)) -> GS (repr (Value repr)) -> 
-    GS (repr (Value repr)) -> GS (repr (Value repr))
-  listAppend :: GS (repr (Value repr)) -> GS (repr (Value repr)) -> 
-    GS (repr (Value repr))
+  listSize   :: FS (repr (Value repr)) -> FS (repr (Value repr))
+  listAdd    :: FS (repr (Value repr)) -> FS (repr (Value repr)) -> 
+    FS (repr (Value repr)) -> FS (repr (Value repr))
+  listAppend :: FS (repr (Value repr)) -> FS (repr (Value repr)) -> 
+    FS (repr (Value repr))
 
-  iterBegin :: GS (repr (Value repr)) -> GS (repr (Value repr))
-  iterEnd   :: GS (repr (Value repr)) -> GS (repr (Value repr))
+  iterBegin :: FS (repr (Value repr)) -> FS (repr (Value repr))
+  iterEnd   :: FS (repr (Value repr)) -> FS (repr (Value repr))
 
 class (Selector repr, InternalSelector repr) => SelectorFunction repr where
-  listAccess :: GS (repr (Value repr)) -> GS (repr (Value repr)) -> 
-    GS (repr (Value repr))
-  listSet    :: GS (repr (Value repr)) -> GS (repr (Value repr)) -> 
-    GS (repr (Value repr)) -> GS (repr (Value repr))
-  at         :: GS (repr (Value repr)) -> GS (repr (Value repr)) -> 
-    GS (repr (Value repr))
+  listAccess :: FS (repr (Value repr)) -> FS (repr (Value repr)) -> 
+    FS (repr (Value repr))
+  listSet    :: FS (repr (Value repr)) -> FS (repr (Value repr)) -> 
+    FS (repr (Value repr)) -> FS (repr (Value repr))
+  at         :: FS (repr (Value repr)) -> FS (repr (Value repr)) -> 
+    FS (repr (Value repr))
 
 class InternalFunction repr where
-  getFunc        :: GS (repr (Variable repr)) -> GS (repr (Function repr))
-  setFunc        :: GS (repr (Type repr)) -> GS (repr (Variable repr)) -> 
-    GS (repr (Value repr)) -> GS (repr (Function repr))
+  getFunc        :: FS (repr (Variable repr)) -> FS (repr (Function repr))
+  setFunc        :: FS (repr (Type repr)) -> FS (repr (Variable repr)) -> 
+    FS (repr (Value repr)) -> FS (repr (Function repr))
 
-  listSizeFunc       :: GS (repr (Function repr))
-  listAddFunc        :: GS (repr (Value repr)) -> GS (repr (Value repr)) -> 
-    GS (repr (Value repr)) -> GS (repr (Function repr))
-  listAppendFunc         :: GS (repr (Value repr)) -> GS (repr (Function repr))
+  listSizeFunc       :: FS (repr (Function repr))
+  listAddFunc        :: FS (repr (Value repr)) -> FS (repr (Value repr)) -> 
+    FS (repr (Value repr)) -> FS (repr (Function repr))
+  listAppendFunc         :: FS (repr (Value repr)) -> FS (repr (Function repr))
 
-  iterBeginFunc :: GS (repr (Type repr)) -> GS (repr (Function repr))
-  iterEndFunc   :: GS (repr (Type repr)) -> GS (repr (Function repr))
+  iterBeginFunc :: FS (repr (Type repr)) -> FS (repr (Function repr))
+  iterEndFunc   :: FS (repr (Type repr)) -> FS (repr (Function repr))
 
-  listAccessFunc :: GS (repr (Type repr)) -> GS (repr (Value repr)) -> 
-    GS (repr (Function repr))
-  listSetFunc    :: GS (repr (Value repr)) -> GS (repr (Value repr)) -> 
-    GS (repr (Value repr)) -> GS (repr (Function repr))
+  listAccessFunc :: FS (repr (Type repr)) -> FS (repr (Value repr)) -> 
+    FS (repr (Function repr))
+  listSetFunc    :: FS (repr (Value repr)) -> FS (repr (Value repr)) -> 
+    FS (repr (Value repr)) -> FS (repr (Function repr))
 
   functionType :: repr (Function repr) -> repr (Type repr)
   functionDoc :: repr (Function repr) -> Doc
 
-  funcFromData :: Doc -> GS (repr (Type repr)) -> GS (repr (Function repr))
+  funcFromData :: Doc -> FS (repr (Type repr)) -> FS (repr (Function repr))
 
 class InternalStatement repr where
   -- newLn, maybe a file to print to, printFunc, value to print
-  printSt :: Bool -> Maybe (GS (repr (Value repr))) -> GS (repr (Value repr)) 
-    -> GS (repr (Value repr)) -> GS (repr (Statement repr))
+  printSt :: Bool -> Maybe (FS (repr (Value repr))) -> FS (repr (Value repr)) 
+    -> FS (repr (Value repr)) -> FS (repr (Statement repr))
 
-  state     :: GS (repr (Statement repr)) -> GS (repr (Statement repr))
-  loopState :: GS (repr (Statement repr)) -> GS (repr (Statement repr))
+  state     :: FS (repr (Statement repr)) -> FS (repr (Statement repr))
+  loopState :: FS (repr (Statement repr)) -> FS (repr (Statement repr))
 
-  emptyState   :: GS (repr (Statement repr))
+  emptyState   :: FS (repr (Statement repr))
   statementDoc :: repr (Statement repr) -> Doc
   statementTerm :: repr (Statement repr) -> Terminator
 
@@ -476,154 +476,154 @@ class InternalStatement repr where
 
 class (SelectorFunction repr) => StatementSym repr where
   type Statement repr
-  (&=)   :: GS (repr (Variable repr)) -> GS (repr (Value repr)) -> 
-    GS (repr (Statement repr))
+  (&=)   :: FS (repr (Variable repr)) -> FS (repr (Value repr)) -> 
+    FS (repr (Statement repr))
   infixr 1 &=
-  (&-=)  :: GS (repr (Variable repr)) -> GS (repr (Value repr)) -> 
-    GS (repr (Statement repr))
+  (&-=)  :: FS (repr (Variable repr)) -> FS (repr (Value repr)) -> 
+    FS (repr (Statement repr))
   infixl 1 &-=
-  (&+=)  :: GS (repr (Variable repr)) -> GS (repr (Value repr)) -> 
-    GS (repr (Statement repr))
+  (&+=)  :: FS (repr (Variable repr)) -> FS (repr (Value repr)) -> 
+    FS (repr (Statement repr))
   infixl 1 &+=
-  (&++)  :: GS (repr (Variable repr)) -> GS (repr (Statement repr))
+  (&++)  :: FS (repr (Variable repr)) -> FS (repr (Statement repr))
   infixl 8 &++
-  (&~-)  :: GS (repr (Variable repr)) -> GS (repr (Statement repr))
+  (&~-)  :: FS (repr (Variable repr)) -> FS (repr (Statement repr))
   infixl 8 &~-
 
-  assign            :: GS (repr (Variable repr)) -> GS (repr (Value repr)) -> 
-    GS (repr (Statement repr))
-  assignToListIndex :: GS (repr (Variable repr)) -> GS (repr (Value repr)) -> 
-    GS (repr (Value repr)) -> GS (repr (Statement repr))
-  multiAssign       :: [GS (repr (Variable repr))] -> [GS (repr (Value repr))] ->
-    GS (repr (Statement repr)) 
+  assign            :: FS (repr (Variable repr)) -> FS (repr (Value repr)) -> 
+    FS (repr (Statement repr))
+  assignToListIndex :: FS (repr (Variable repr)) -> FS (repr (Value repr)) -> 
+    FS (repr (Value repr)) -> FS (repr (Statement repr))
+  multiAssign       :: [FS (repr (Variable repr))] -> [FS (repr (Value repr))] ->
+    FS (repr (Statement repr)) 
 
-  varDec           :: GS (repr (Variable repr)) -> GS (repr (Statement repr))
-  varDecDef        :: GS (repr (Variable repr)) -> GS (repr (Value repr)) -> 
-    GS (repr (Statement repr))
-  listDec          :: Integer -> GS (repr (Variable repr)) -> 
-    GS (repr (Statement repr))
-  listDecDef       :: GS (repr (Variable repr)) -> [GS (repr (Value repr))] -> 
-    GS (repr (Statement repr))
-  objDecDef        :: GS (repr (Variable repr)) -> GS (repr (Value repr)) -> 
-    GS (repr (Statement repr))
-  objDecNew        :: GS (repr (Variable repr)) -> [GS (repr (Value repr))] -> 
-    GS (repr (Statement repr))
-  extObjDecNew     :: Library -> GS (repr (Variable repr)) -> 
-    [GS (repr (Value repr))] -> GS (repr (Statement repr))
-  objDecNewNoParams    :: GS (repr (Variable repr)) -> GS (repr (Statement repr))
-  extObjDecNewNoParams :: Library -> GS (repr (Variable repr)) -> 
-    GS (repr (Statement repr))
-  constDecDef      :: GS (repr (Variable repr)) -> GS (repr (Value repr)) -> 
-    GS (repr (Statement repr))
+  varDec           :: FS (repr (Variable repr)) -> FS (repr (Statement repr))
+  varDecDef        :: FS (repr (Variable repr)) -> FS (repr (Value repr)) -> 
+    FS (repr (Statement repr))
+  listDec          :: Integer -> FS (repr (Variable repr)) -> 
+    FS (repr (Statement repr))
+  listDecDef       :: FS (repr (Variable repr)) -> [FS (repr (Value repr))] -> 
+    FS (repr (Statement repr))
+  objDecDef        :: FS (repr (Variable repr)) -> FS (repr (Value repr)) -> 
+    FS (repr (Statement repr))
+  objDecNew        :: FS (repr (Variable repr)) -> [FS (repr (Value repr))] -> 
+    FS (repr (Statement repr))
+  extObjDecNew     :: Library -> FS (repr (Variable repr)) -> 
+    [FS (repr (Value repr))] -> FS (repr (Statement repr))
+  objDecNewNoParams    :: FS (repr (Variable repr)) -> FS (repr (Statement repr))
+  extObjDecNewNoParams :: Library -> FS (repr (Variable repr)) -> 
+    FS (repr (Statement repr))
+  constDecDef      :: FS (repr (Variable repr)) -> FS (repr (Value repr)) -> 
+    FS (repr (Statement repr))
 
-  print      :: GS (repr (Value repr)) -> GS (repr (Statement repr))
-  printLn    :: GS (repr (Value repr)) -> GS (repr (Statement repr))
-  printStr   :: String -> GS (repr (Statement repr))
-  printStrLn :: String -> GS (repr (Statement repr))
+  print      :: FS (repr (Value repr)) -> FS (repr (Statement repr))
+  printLn    :: FS (repr (Value repr)) -> FS (repr (Statement repr))
+  printStr   :: String -> FS (repr (Statement repr))
+  printStrLn :: String -> FS (repr (Statement repr))
 
-  printFile      :: GS (repr (Value repr)) -> GS (repr (Value repr)) -> 
-    GS (repr (Statement repr))
-  printFileLn    :: GS (repr (Value repr)) -> GS (repr (Value repr)) -> 
-    GS (repr (Statement repr))
-  printFileStr   :: GS (repr (Value repr)) -> String -> 
-    GS (repr (Statement repr))
-  printFileStrLn :: GS (repr (Value repr)) -> String -> 
-    GS (repr (Statement repr))
+  printFile      :: FS (repr (Value repr)) -> FS (repr (Value repr)) -> 
+    FS (repr (Statement repr))
+  printFileLn    :: FS (repr (Value repr)) -> FS (repr (Value repr)) -> 
+    FS (repr (Statement repr))
+  printFileStr   :: FS (repr (Value repr)) -> String -> 
+    FS (repr (Statement repr))
+  printFileStrLn :: FS (repr (Value repr)) -> String -> 
+    FS (repr (Statement repr))
 
-  getInput         :: GS (repr (Variable repr)) -> GS (repr (Statement repr))
-  discardInput     :: GS (repr (Statement repr))
-  getFileInput     :: GS (repr (Value repr)) -> GS (repr (Variable repr)) -> 
-    GS (repr (Statement repr))
-  discardFileInput :: GS (repr (Value repr)) -> GS (repr (Statement repr))
+  getInput         :: FS (repr (Variable repr)) -> FS (repr (Statement repr))
+  discardInput     :: FS (repr (Statement repr))
+  getFileInput     :: FS (repr (Value repr)) -> FS (repr (Variable repr)) -> 
+    FS (repr (Statement repr))
+  discardFileInput :: FS (repr (Value repr)) -> FS (repr (Statement repr))
 
-  openFileR :: GS (repr (Variable repr)) -> GS (repr (Value repr)) -> 
-    GS (repr (Statement repr))
-  openFileW :: GS (repr (Variable repr)) -> GS (repr (Value repr)) -> 
-    GS (repr (Statement repr))
-  openFileA :: GS (repr (Variable repr)) -> GS (repr (Value repr)) -> 
-    GS (repr (Statement repr))
-  closeFile :: GS (repr (Value repr)) -> GS (repr (Statement repr))
+  openFileR :: FS (repr (Variable repr)) -> FS (repr (Value repr)) -> 
+    FS (repr (Statement repr))
+  openFileW :: FS (repr (Variable repr)) -> FS (repr (Value repr)) -> 
+    FS (repr (Statement repr))
+  openFileA :: FS (repr (Variable repr)) -> FS (repr (Value repr)) -> 
+    FS (repr (Statement repr))
+  closeFile :: FS (repr (Value repr)) -> FS (repr (Statement repr))
 
-  getFileInputLine :: GS (repr (Value repr)) -> GS (repr (Variable repr)) -> 
-    GS (repr (Statement repr))
-  discardFileLine  :: GS (repr (Value repr)) -> GS (repr (Statement repr))
-  stringSplit      :: Char -> GS (repr (Variable repr)) -> 
-    GS (repr (Value repr)) -> GS (repr (Statement repr))
+  getFileInputLine :: FS (repr (Value repr)) -> FS (repr (Variable repr)) -> 
+    FS (repr (Statement repr))
+  discardFileLine  :: FS (repr (Value repr)) -> FS (repr (Statement repr))
+  stringSplit      :: Char -> FS (repr (Variable repr)) -> 
+    FS (repr (Value repr)) -> FS (repr (Statement repr))
 
-  stringListVals :: [GS (repr (Variable repr))] -> GS (repr (Value repr)) -> 
-    GS (repr (Statement repr))
-  stringListLists :: [GS (repr (Variable repr))] -> GS (repr (Value repr)) ->
-    GS (repr (Statement repr))
+  stringListVals :: [FS (repr (Variable repr))] -> FS (repr (Value repr)) -> 
+    FS (repr (Statement repr))
+  stringListLists :: [FS (repr (Variable repr))] -> FS (repr (Value repr)) ->
+    FS (repr (Statement repr))
 
-  break :: GS (repr (Statement repr))
-  continue :: GS (repr (Statement repr))
+  break :: FS (repr (Statement repr))
+  continue :: FS (repr (Statement repr))
 
-  returnState :: GS (repr (Value repr)) -> GS (repr (Statement repr))
-  multiReturn :: [GS (repr (Value repr))] -> GS (repr (Statement repr))
+  returnState :: FS (repr (Value repr)) -> FS (repr (Statement repr))
+  multiReturn :: [FS (repr (Value repr))] -> FS (repr (Statement repr))
 
-  valState :: GS (repr (Value repr)) -> GS (repr (Statement repr))
+  valState :: FS (repr (Value repr)) -> FS (repr (Statement repr))
 
-  comment :: Label -> GS (repr (Statement repr))
+  comment :: Label -> FS (repr (Statement repr))
 
-  free :: GS (repr (Variable repr)) -> GS (repr (Statement repr))
+  free :: FS (repr (Variable repr)) -> FS (repr (Statement repr))
 
-  throw :: Label -> GS (repr (Statement repr))
+  throw :: Label -> FS (repr (Statement repr))
 
-  initState   :: Label -> Label -> GS (repr (Statement repr))
-  changeState :: Label -> Label -> GS (repr (Statement repr))
+  initState   :: Label -> Label -> FS (repr (Statement repr))
+  changeState :: Label -> Label -> FS (repr (Statement repr))
 
-  initObserverList :: GS (repr (Type repr)) -> [GS (repr (Value repr))] -> 
-    GS (repr (Statement repr))
-  addObserver      :: GS (repr (Value repr)) -> GS (repr (Statement repr))
+  initObserverList :: FS (repr (Type repr)) -> [FS (repr (Value repr))] -> 
+    FS (repr (Statement repr))
+  addObserver      :: FS (repr (Value repr)) -> FS (repr (Statement repr))
 
   -- The three lists are inputs, outputs, and both, respectively
-  inOutCall :: Label -> [GS (repr (Value repr))] -> [GS (repr (Variable repr))] 
-    -> [GS (repr (Variable repr))] -> GS (repr (Statement repr))
-  selfInOutCall :: Label -> Label -> [GS (repr (Value repr))] -> 
-    [GS (repr (Variable repr))] -> [GS (repr (Variable repr))] -> 
-    GS (repr (Statement repr))
-  extInOutCall :: Library -> Label -> [GS (repr (Value repr))] ->
-    [GS (repr (Variable repr))] -> [GS (repr (Variable repr))] -> 
-    GS (repr (Statement repr))
+  inOutCall :: Label -> [FS (repr (Value repr))] -> [FS (repr (Variable repr))] 
+    -> [FS (repr (Variable repr))] -> FS (repr (Statement repr))
+  selfInOutCall :: Label -> Label -> [FS (repr (Value repr))] -> 
+    [FS (repr (Variable repr))] -> [FS (repr (Variable repr))] -> 
+    FS (repr (Statement repr))
+  extInOutCall :: Library -> Label -> [FS (repr (Value repr))] ->
+    [FS (repr (Variable repr))] -> [FS (repr (Variable repr))] -> 
+    FS (repr (Statement repr))
 
-  multi     :: [GS (repr (Statement repr))] -> GS (repr (Statement repr))
+  multi     :: [FS (repr (Statement repr))] -> FS (repr (Statement repr))
 
 class (BodySym repr) => ControlStatementSym repr where
-  ifCond     :: [(GS (repr (Value repr)), GS (repr (Body repr)))] -> 
-    GS (repr (Body repr)) -> GS (repr (Statement repr))
-  ifNoElse   :: [(GS (repr (Value repr)), GS (repr (Body repr)))] -> 
-    GS (repr (Statement repr))
-  switch     :: GS (repr (Value repr)) -> [(GS (repr (Value repr)), 
-    GS (repr (Body repr)))] -> GS (repr (Body repr)) -> 
-    GS (repr (Statement repr)) -- is there value in separating Literals into their own type?
-  switchAsIf :: GS (repr (Value repr)) -> [(GS (repr (Value repr)), 
-    GS (repr (Body repr)))] -> GS (repr (Body repr)) -> 
-    GS (repr (Statement repr))
+  ifCond     :: [(FS (repr (Value repr)), FS (repr (Body repr)))] -> 
+    FS (repr (Body repr)) -> FS (repr (Statement repr))
+  ifNoElse   :: [(FS (repr (Value repr)), FS (repr (Body repr)))] -> 
+    FS (repr (Statement repr))
+  switch     :: FS (repr (Value repr)) -> [(FS (repr (Value repr)), 
+    FS (repr (Body repr)))] -> FS (repr (Body repr)) -> 
+    FS (repr (Statement repr)) -- is there value in separating Literals into their own type?
+  switchAsIf :: FS (repr (Value repr)) -> [(FS (repr (Value repr)), 
+    FS (repr (Body repr)))] -> FS (repr (Body repr)) -> 
+    FS (repr (Statement repr))
 
-  ifExists :: GS (repr (Value repr)) -> GS (repr (Body repr)) -> 
-    GS (repr (Body repr)) -> GS (repr (Statement repr))
+  ifExists :: FS (repr (Value repr)) -> FS (repr (Body repr)) -> 
+    FS (repr (Body repr)) -> FS (repr (Statement repr))
 
-  for      :: GS (repr (Statement repr)) -> GS (repr (Value repr)) -> 
-    GS (repr (Statement repr)) -> GS (repr (Body repr)) -> 
-    GS (repr (Statement repr))
-  forRange :: GS (repr (Variable repr)) -> GS (repr (Value repr)) -> 
-    GS (repr (Value repr)) -> GS (repr (Value repr)) -> GS (repr (Body repr)) 
-    -> GS (repr (Statement repr))
-  forEach  :: GS (repr (Variable repr)) -> GS (repr (Value repr)) -> 
-    GS (repr (Body repr)) -> GS (repr (Statement repr))
-  while    :: GS (repr (Value repr)) -> GS (repr (Body repr)) -> 
-    GS (repr (Statement repr)) 
+  for      :: FS (repr (Statement repr)) -> FS (repr (Value repr)) -> 
+    FS (repr (Statement repr)) -> FS (repr (Body repr)) -> 
+    FS (repr (Statement repr))
+  forRange :: FS (repr (Variable repr)) -> FS (repr (Value repr)) -> 
+    FS (repr (Value repr)) -> FS (repr (Value repr)) -> FS (repr (Body repr)) 
+    -> FS (repr (Statement repr))
+  forEach  :: FS (repr (Variable repr)) -> FS (repr (Value repr)) -> 
+    FS (repr (Body repr)) -> FS (repr (Statement repr))
+  while    :: FS (repr (Value repr)) -> FS (repr (Body repr)) -> 
+    FS (repr (Statement repr)) 
 
-  tryCatch :: GS (repr (Body repr)) -> GS (repr (Body repr)) -> 
-    GS (repr (Statement repr))
+  tryCatch :: FS (repr (Body repr)) -> FS (repr (Body repr)) -> 
+    FS (repr (Statement repr))
 
-  checkState      :: Label -> [(GS (repr (Value repr)), GS (repr (Body repr)))] 
-    -> GS (repr (Body repr)) -> GS (repr (Statement repr))
-  notifyObservers :: GS (repr (Function repr)) -> GS (repr (Type repr)) -> 
-    GS (repr (Statement repr))
+  checkState      :: Label -> [(FS (repr (Value repr)), FS (repr (Body repr)))] 
+    -> FS (repr (Body repr)) -> FS (repr (Statement repr))
+  notifyObservers :: FS (repr (Function repr)) -> FS (repr (Type repr)) -> 
+    FS (repr (Statement repr))
 
-  getFileInputAll  :: GS (repr (Value repr)) -> GS (repr (Variable repr)) -> 
-    GS (repr (Statement repr))
+  getFileInputAll  :: FS (repr (Value repr)) -> FS (repr (Variable repr)) -> 
+    FS (repr (Statement repr))
 
 class ScopeSym repr where
   type Scope repr
@@ -635,14 +635,14 @@ class InternalScope repr where
 
 class (TypeSym repr) => MethodTypeSym repr where
   type MethodType repr
-  mType    :: GS (repr (Type repr)) -> GS (repr (MethodType repr))
-  construct :: Label -> GS (repr (MethodType repr))
+  mType    :: FS (repr (Type repr)) -> FS (repr (MethodType repr))
+  construct :: Label -> FS (repr (MethodType repr))
 
 class ParameterSym repr where
   type Parameter repr
-  param :: GS (repr (Variable repr)) -> MS (repr (Parameter repr))
+  param :: FS (repr (Variable repr)) -> MS (repr (Parameter repr))
   -- funcParam  :: Label -> repr (MethodType repr) -> [repr (Parameter repr)] -> repr (Parameter repr) -- not implemented in GOOL
-  pointerParam :: GS (repr (Variable repr)) -> MS (repr (Parameter repr))
+  pointerParam :: FS (repr (Variable repr)) -> MS (repr (Parameter repr))
 
 class InternalParam repr where
   parameterName :: repr (Parameter repr) -> Label
@@ -655,26 +655,26 @@ class (StateVarSym repr, ParameterSym repr, ControlBlockSym repr) =>
   type Method repr
   -- Second label is class name
   method      :: Label -> Label -> repr (Scope repr) -> repr (Permanence repr) 
-    -> GS (repr (Type repr)) -> [MS (repr (Parameter repr))] -> 
-    GS (repr (Body repr)) -> MS (repr (Method repr))
-  getMethod   :: Label -> GS (repr (Variable repr)) -> MS (repr (Method repr))
-  setMethod   :: Label -> GS (repr (Variable repr)) -> MS (repr (Method repr)) 
-  privMethod  :: Label -> Label -> GS (repr (Type repr)) -> 
-    [MS (repr (Parameter repr))] -> GS (repr (Body repr)) -> 
+    -> FS (repr (Type repr)) -> [MS (repr (Parameter repr))] -> 
+    FS (repr (Body repr)) -> MS (repr (Method repr))
+  getMethod   :: Label -> FS (repr (Variable repr)) -> MS (repr (Method repr))
+  setMethod   :: Label -> FS (repr (Variable repr)) -> MS (repr (Method repr)) 
+  privMethod  :: Label -> Label -> FS (repr (Type repr)) -> 
+    [MS (repr (Parameter repr))] -> FS (repr (Body repr)) -> 
     MS (repr (Method repr))
-  pubMethod   :: Label -> Label -> GS (repr (Type repr)) -> 
-    [MS (repr (Parameter repr))] -> GS (repr (Body repr)) -> 
+  pubMethod   :: Label -> Label -> FS (repr (Type repr)) -> 
+    [MS (repr (Parameter repr))] -> FS (repr (Body repr)) -> 
     MS (repr (Method repr))
-  constructor :: Label -> [MS (repr (Parameter repr))] -> GS (repr (Body repr)) 
+  constructor :: Label -> [MS (repr (Parameter repr))] -> FS (repr (Body repr)) 
     -> MS (repr (Method repr))
-  destructor :: Label -> [GS (repr (StateVar repr))] -> MS (repr (Method repr))
+  destructor :: Label -> [FS (repr (StateVar repr))] -> MS (repr (Method repr))
 
-  docMain :: GS (repr (Body repr)) -> MS (repr (Method repr))
+  docMain :: FS (repr (Body repr)) -> MS (repr (Method repr))
 
   function :: Label -> repr (Scope repr) -> repr (Permanence repr) -> 
-    GS (repr (Type repr)) -> [MS (repr (Parameter repr))] -> 
-    GS (repr (Body repr)) -> MS (repr (Method repr))
-  mainFunction  :: GS (repr (Body repr)) -> MS (repr (Method repr))
+    FS (repr (Type repr)) -> [MS (repr (Parameter repr))] -> 
+    FS (repr (Body repr)) -> MS (repr (Method repr))
+  mainFunction  :: FS (repr (Body repr)) -> MS (repr (Method repr))
   -- Parameters are: function description, parameter descriptions, 
   --   return value description if applicable, function
   docFunc :: String -> [String] -> Maybe String -> 
@@ -682,35 +682,35 @@ class (StateVarSym repr, ParameterSym repr, ControlBlockSym repr) =>
 
   -- Second label is class name, rest is same as inOutFunc
   inOutMethod :: Label -> Label -> repr (Scope repr) -> repr (Permanence repr) 
-    -> [GS (repr (Variable repr))] -> [GS (repr (Variable repr))] -> 
-    [GS (repr (Variable repr))] -> GS (repr (Body repr)) -> 
+    -> [FS (repr (Variable repr))] -> [FS (repr (Variable repr))] -> 
+    [FS (repr (Variable repr))] -> FS (repr (Body repr)) -> 
     MS (repr (Method repr))
   -- Second label is class name, rest is same as docInOutFunc
   docInOutMethod :: Label -> Label -> repr (Scope repr) -> 
-    repr (Permanence repr) -> String -> [(String, GS (repr (Variable repr)))] 
-    -> [(String, GS (repr (Variable repr)))] -> 
-    [(String, GS (repr (Variable repr)))] -> GS (repr (Body repr)) -> 
+    repr (Permanence repr) -> String -> [(String, FS (repr (Variable repr)))] 
+    -> [(String, FS (repr (Variable repr)))] -> 
+    [(String, FS (repr (Variable repr)))] -> FS (repr (Body repr)) -> 
     MS (repr (Method repr))
 
   -- The three lists are inputs, outputs, and both, respectively
   inOutFunc :: Label -> repr (Scope repr) -> repr (Permanence repr) -> 
-    [GS (repr (Variable repr))] -> [GS (repr (Variable repr))] -> 
-    [GS (repr (Variable repr))] -> GS (repr (Body repr)) -> 
+    [FS (repr (Variable repr))] -> [FS (repr (Variable repr))] -> 
+    [FS (repr (Variable repr))] -> FS (repr (Body repr)) -> 
     MS (repr (Method repr))
   -- Parameters are: function name, scope, permanence, brief description, input descriptions and variables, output descriptions and variables, descriptions and variables for parameters that are both input and output, function body
   docInOutFunc :: Label -> repr (Scope repr) -> repr (Permanence repr) -> 
-    String -> [(String, GS (repr (Variable repr)))] -> [(String, GS (repr 
-    (Variable repr)))] -> [(String, GS (repr (Variable repr)))] -> 
-    GS (repr (Body repr)) -> MS (repr (Method repr))
+    String -> [(String, FS (repr (Variable repr)))] -> [(String, FS (repr 
+    (Variable repr)))] -> [(String, FS (repr (Variable repr)))] -> 
+    FS (repr (Body repr)) -> MS (repr (Method repr))
 
 class (MethodTypeSym repr, BlockCommentSym repr) => InternalMethod repr where
   intMethod     :: Bool -> Label -> Label -> repr (Scope repr) -> 
-    repr (Permanence repr) -> GS (repr (MethodType repr)) -> 
-    [MS (repr (Parameter repr))] -> GS (repr (Body repr)) -> 
+    repr (Permanence repr) -> FS (repr (MethodType repr)) -> 
+    [MS (repr (Parameter repr))] -> FS (repr (Body repr)) -> 
     MS (repr (Method repr))
   intFunc       :: Bool -> Label -> repr (Scope repr) -> repr (Permanence repr) 
-    -> GS (repr (MethodType repr)) -> [MS (repr (Parameter repr))] -> 
-    GS (repr (Body repr)) -> MS (repr (Method repr))
+    -> FS (repr (MethodType repr)) -> [MS (repr (Parameter repr))] -> 
+    FS (repr (Body repr)) -> MS (repr (Method repr))
   commentedFunc :: MS (repr (BlockComment repr)) -> MS (repr (Method repr)) -> 
     MS (repr (Method repr))
 
@@ -721,32 +721,32 @@ class (ScopeSym repr, PermanenceSym repr, TypeSym repr, StatementSym repr) =>
   StateVarSym repr where
   type StateVar repr
   stateVar :: repr (Scope repr) -> repr (Permanence repr) ->
-    GS (repr (Variable repr)) -> GS (repr (StateVar repr))
+    FS (repr (Variable repr)) -> FS (repr (StateVar repr))
   stateVarDef :: Label -> repr (Scope repr) -> repr (Permanence repr) ->
-    GS (repr (Variable repr)) -> GS (repr (Value repr)) -> 
-    GS (repr (StateVar repr))
-  constVar :: Label -> repr (Scope repr) ->  GS (repr (Variable repr)) -> 
-    GS (repr (Value repr)) -> GS (repr (StateVar repr))
-  privMVar :: GS (repr (Variable repr)) -> GS (repr (StateVar repr))
-  pubMVar  :: GS (repr (Variable repr)) -> GS (repr (StateVar repr))
-  pubGVar  :: GS (repr (Variable repr)) -> GS (repr (StateVar repr))
+    FS (repr (Variable repr)) -> FS (repr (Value repr)) -> 
+    FS (repr (StateVar repr))
+  constVar :: Label -> repr (Scope repr) ->  FS (repr (Variable repr)) -> 
+    FS (repr (Value repr)) -> FS (repr (StateVar repr))
+  privMVar :: FS (repr (Variable repr)) -> FS (repr (StateVar repr))
+  pubMVar  :: FS (repr (Variable repr)) -> FS (repr (StateVar repr))
+  pubGVar  :: FS (repr (Variable repr)) -> FS (repr (StateVar repr))
 
 class InternalStateVar repr where
   stateVarDoc :: repr (StateVar repr) -> Doc
-  stateVarFromData :: GS Doc -> GS (repr (StateVar repr))
+  stateVarFromData :: FS Doc -> FS (repr (StateVar repr))
 
 class (MethodSym repr) => ClassSym repr where
   type Class repr
   buildClass :: Label -> Maybe Label -> repr (Scope repr) -> 
-    [GS (repr (StateVar repr))] -> 
+    [FS (repr (StateVar repr))] -> 
     [MS (repr (Method repr))] -> 
     FS (repr (Class repr))
   enum :: Label -> [Label] -> repr (Scope repr) -> 
     FS (repr (Class repr))
-  privClass :: Label -> Maybe Label -> [GS (repr (StateVar repr))] 
+  privClass :: Label -> Maybe Label -> [FS (repr (StateVar repr))] 
     -> [MS (repr (Method repr))] -> 
     FS (repr (Class repr))
-  pubClass :: Label -> Maybe Label -> [GS (repr (StateVar repr))] 
+  pubClass :: Label -> Maybe Label -> [FS (repr (StateVar repr))] 
     -> [MS (repr (Method repr))] -> 
     FS (repr (Class repr))
 

--- a/code/drasil-gool/GOOL/Drasil/Symantics.hs
+++ b/code/drasil-gool/GOOL/Drasil/Symantics.hs
@@ -3,12 +3,12 @@
 module GOOL.Drasil.Symantics (
   -- Types
   Label, Library,
--- Typeclasses
-  ProgramSym(..), RenderSym, FileSym(..), InternalFile(..),  KeywordSym(..),
-  PermanenceSym(..), InternalPerm(..), BodySym(..), ControlBlockSym(..), 
-  listSlice, BlockSym(..), InternalBlock(..), TypeSym(..), InternalType(..), 
-  UnaryOpSym(..), BinaryOpSym(..), InternalOp(..), VariableSym(..), 
-  InternalVariable(..), ValueSym(..), NumericExpression(..), 
+  -- Typeclasses
+  ProgramSym(..), RenderSym, FileSym(..), InternalFile(..),  KeywordSym(..), 
+  ImportSym(..), PermanenceSym(..), InternalPerm(..), BodySym(..), 
+  ControlBlockSym(..), listSlice, BlockSym(..), InternalBlock(..), TypeSym(..), 
+  InternalType(..), UnaryOpSym(..), BinaryOpSym(..), InternalOp(..), 
+  VariableSym(..), InternalVariable(..), ValueSym(..), NumericExpression(..), 
   BooleanExpression(..), ValueExpression(..), InternalValue(..), 
   Selector(..), InternalSelector(..), objMethodCall, objMethodCallNoParams,
   FunctionSym(..), SelectorFunction(..), InternalFunction(..), 
@@ -87,6 +87,13 @@ class (PermanenceSym repr) => KeywordSym repr where
   docCommentEnd     :: repr (Keyword repr)
 
   keyDoc :: repr (Keyword repr) -> Doc
+
+class ImportSym repr where
+  type Import repr
+  langImport :: Label -> repr (Import repr)
+  modImport :: Label -> repr (Import repr)
+
+  importDoc :: repr (Import repr) -> Doc
 
 class PermanenceSym repr where
   type Permanence repr
@@ -753,7 +760,7 @@ class InternalClass repr where
   classDoc :: repr (Class repr) -> Doc
   classFromData :: FS Doc -> FS (repr (Class repr))
 
-class (ClassSym repr) => ModuleSym repr where
+class (ClassSym repr, ImportSym repr) => ModuleSym repr where
   type Module repr
   buildModule :: Label -> [Library] -> [MS (repr (Method repr))] -> 
     [FS (repr (Class repr))] -> FS (repr (Module repr))

--- a/code/drasil-gool/Test/FileTests.hs
+++ b/code/drasil-gool/Test/FileTests.hs
@@ -1,6 +1,6 @@
 module Test.FileTests (fileTests) where
 
-import GOOL.Drasil (ProgramSym(..), RenderSym, FileSym(..),
+import GOOL.Drasil (ProgramSym(..), FileSym(..),
   PermanenceSym(..), BodySym(..), BlockSym(..), TypeSym(..), 
   StatementSym(..), ControlStatementSym(..), VariableSym(..), ValueSym(..), 
   MethodSym(..), ModuleSym(..), GS, MS)
@@ -9,10 +9,10 @@ import Prelude hiding (return,print,log,exp,sin,cos,tan)
 fileTests :: (ProgramSym repr) => GS (repr (Program repr))
 fileTests = prog "FileTests" [fileDoc (buildModule "FileTests" [] [fileTestMethod] [])]
 
-fileTestMethod :: (RenderSym repr) => MS (repr (Method repr))
+fileTestMethod :: (ProgramSym repr) => MS (repr (Method repr))
 fileTestMethod = mainFunction (body [writeStory, block [readStory], goodBye])
 
-writeStory :: (RenderSym repr) => GS (repr (Block repr))
+writeStory :: (ProgramSym repr) => GS (repr (Block repr))
 writeStory = block [
   varDec $ var "fileToWrite" outfile,
 
@@ -31,11 +31,11 @@ writeStory = block [
   discardFileLine (valueOf $ var "fileToRead" infile),
   listDec 0 (var "fileContents" (listType dynamic_ string))]
 
-readStory :: (RenderSym repr) => GS (repr (Statement repr))
+readStory :: (ProgramSym repr) => GS (repr (Statement repr))
 readStory = getFileInputAll (valueOf $ var "fileToRead" infile) 
   (var "fileContents" (listType dynamic_ string))
 
-goodBye :: (RenderSym repr) => GS (repr (Block repr))
+goodBye :: (ProgramSym repr) => GS (repr (Block repr))
 goodBye = block [
   printLn (valueOf $ var "fileContents" (listType dynamic_ string)), 
   closeFile (valueOf $ var "fileToRead" infile)]

--- a/code/drasil-gool/Test/FileTests.hs
+++ b/code/drasil-gool/Test/FileTests.hs
@@ -1,6 +1,6 @@
 module Test.FileTests (fileTests) where
 
-import GOOL.Drasil (ProgramSym(..), RenderSym(..), 
+import GOOL.Drasil (ProgramSym(..), RenderSym, FileSym(..),
   PermanenceSym(..), BodySym(..), BlockSym(..), TypeSym(..), 
   StatementSym(..), ControlStatementSym(..), VariableSym(..), ValueSym(..), 
   MethodSym(..), ModuleSym(..), GS, MS)

--- a/code/drasil-gool/Test/FileTests.hs
+++ b/code/drasil-gool/Test/FileTests.hs
@@ -7,7 +7,8 @@ import GOOL.Drasil (ProgramSym(..), FileSym(..),
 import Prelude hiding (return,print,log,exp,sin,cos,tan)
 
 fileTests :: (ProgramSym repr) => GS (repr (Program repr))
-fileTests = prog "FileTests" [fileDoc (buildModule "FileTests" [] [fileTestMethod] [])]
+fileTests = prog "FileTests" [fileDoc (buildModule "FileTests" [fileTestMethod] 
+  [])]
 
 fileTestMethod :: (ProgramSym repr) => MS (repr (Method repr))
 fileTestMethod = mainFunction (body [writeStory, block [readStory], goodBye])

--- a/code/drasil-gool/Test/FileTests.hs
+++ b/code/drasil-gool/Test/FileTests.hs
@@ -3,7 +3,7 @@ module Test.FileTests (fileTests) where
 import GOOL.Drasil (ProgramSym(..), FileSym(..),
   PermanenceSym(..), BodySym(..), BlockSym(..), TypeSym(..), 
   StatementSym(..), ControlStatementSym(..), VariableSym(..), ValueSym(..), 
-  MethodSym(..), ModuleSym(..), GS, MS)
+  MethodSym(..), ModuleSym(..), GS, FS, MS)
 import Prelude hiding (return,print,log,exp,sin,cos,tan)
 
 fileTests :: (ProgramSym repr) => GS (repr (Program repr))
@@ -12,7 +12,7 @@ fileTests = prog "FileTests" [fileDoc (buildModule "FileTests" [] [fileTestMetho
 fileTestMethod :: (ProgramSym repr) => MS (repr (Method repr))
 fileTestMethod = mainFunction (body [writeStory, block [readStory], goodBye])
 
-writeStory :: (ProgramSym repr) => GS (repr (Block repr))
+writeStory :: (ProgramSym repr) => FS (repr (Block repr))
 writeStory = block [
   varDec $ var "fileToWrite" outfile,
 
@@ -31,11 +31,11 @@ writeStory = block [
   discardFileLine (valueOf $ var "fileToRead" infile),
   listDec 0 (var "fileContents" (listType dynamic_ string))]
 
-readStory :: (ProgramSym repr) => GS (repr (Statement repr))
+readStory :: (ProgramSym repr) => FS (repr (Statement repr))
 readStory = getFileInputAll (valueOf $ var "fileToRead" infile) 
   (var "fileContents" (listType dynamic_ string))
 
-goodBye :: (ProgramSym repr) => GS (repr (Block repr))
+goodBye :: (ProgramSym repr) => FS (repr (Block repr))
 goodBye = block [
   printLn (valueOf $ var "fileContents" (listType dynamic_ string)), 
   closeFile (valueOf $ var "fileToRead" infile)]

--- a/code/drasil-gool/Test/HelloWorld.hs
+++ b/code/drasil-gool/Test/HelloWorld.hs
@@ -12,8 +12,8 @@ import Test.Helper (helper)
 
 helloWorld :: (ProgramSym repr) => GS (repr (Program repr))
 helloWorld = prog "HelloWorld" [docMod description 
-  ["Brooks MacLachlan"] "" $ fileDoc (buildModule "HelloWorld" ["Helper"] 
-  [helloWorldMain] []), helper]
+  ["Brooks MacLachlan"] "" $ fileDoc (buildModule "HelloWorld" [helloWorldMain] 
+  []), helper]
 
 description :: String
 description = "Tests various GOOL functions. It should run without errors."

--- a/code/drasil-gool/Test/HelloWorld.hs
+++ b/code/drasil-gool/Test/HelloWorld.hs
@@ -2,7 +2,7 @@
 
 module Test.HelloWorld (helloWorld) where
 
-import GOOL.Drasil (ProgramSym(..), RenderSym, FileSym(..), PermanenceSym(..), 
+import GOOL.Drasil (ProgramSym(..), FileSym(..), PermanenceSym(..), 
   BodySym(..), BlockSym(..), listSlice, TypeSym(..), StatementSym(..), 
   ControlStatementSym(..), VariableSym(..), ValueSym(..), NumericExpression(..),
   BooleanExpression(..), ValueExpression(..), Selector(..), FunctionSym(..), 
@@ -18,14 +18,14 @@ helloWorld = prog "HelloWorld" [docMod description
 description :: String
 description = "Tests various GOOL functions. It should run without errors."
 
-helloWorldMain :: (RenderSym repr) => MS (repr (Method repr))
+helloWorldMain :: (ProgramSym repr) => MS (repr (Method repr))
 helloWorldMain = mainFunction (body [ helloInitVariables, 
     helloListSlice,
     block [ifCond [(valueOf (var "b" int) ?>= litInt 6, bodyStatements [varDecDef (var "dummy" string) (litString "dummy")]),
       (valueOf (var "b" int) ?== litInt 5, helloIfBody)] helloElseBody, helloIfExists,
     helloSwitch, helloForLoop, helloWhileLoop, helloForEachLoop, helloTryCatch]])
 
-helloInitVariables :: (RenderSym repr) => GS (repr (Block repr))
+helloInitVariables :: (ProgramSym repr) => GS (repr (Block repr))
 helloInitVariables = block [comment "Initializing variables",
   varDec $ var "a" int, 
   varDecDef (var "b" int) (litInt 5),
@@ -52,12 +52,12 @@ helloInitVariables = block [comment "Initializing variables",
   printLn (valueOf $ var "boringList" (listType dynamic_ bool)),
   listDec 2 $ var "mySlicedList" (listType static_ float)]
 
-helloListSlice :: (RenderSym repr) => GS (repr (Block repr))
+helloListSlice :: (ProgramSym repr) => GS (repr (Block repr))
 helloListSlice = listSlice (var "mySlicedList" (listType static_ float)) 
   (valueOf $ var "myOtherList" (listType static_ float)) (Just (litInt 1)) 
   (Just (litInt 3)) Nothing
 
-helloIfBody :: (RenderSym repr) => GS (repr (Body repr))
+helloIfBody :: (ProgramSym repr) => GS (repr (Body repr))
 helloIfBody = addComments "If body" (body [
   block [
     varDec $ var "c" int,
@@ -125,33 +125,33 @@ helloIfBody = addComments "If body" (body [
     printLn (inlineIf litTrue (litInt 5) (litInt 0)),
     printLn (cot (litFloat 1.0))]])
 
-helloElseBody :: (RenderSym repr) => GS (repr (Body repr))
+helloElseBody :: (ProgramSym repr) => GS (repr (Body repr))
 helloElseBody = bodyStatements [printLn (arg 5)]
 
-helloIfExists :: (RenderSym repr) => GS (repr (Statement repr))
+helloIfExists :: (ProgramSym repr) => GS (repr (Statement repr))
 helloIfExists = ifExists (valueOf $ var "boringList" (listType dynamic_ bool)) 
   (oneLiner (printStrLn "Ew, boring list!")) (oneLiner (printStrLn "Great, no bores!"))
 
-helloSwitch :: (RenderSym repr) => GS (repr (Statement repr))
+helloSwitch :: (ProgramSym repr) => GS (repr (Statement repr))
 helloSwitch = switch (valueOf $ var "a" int) [(litInt 5, oneLiner (var "b" int &= litInt 10)), 
   (litInt 0, oneLiner (var "b" int &= litInt 5))]
   (oneLiner (var "b" int &= litInt 0))
 
-helloForLoop :: (RenderSym repr) => GS (repr (Statement repr))
+helloForLoop :: (ProgramSym repr) => GS (repr (Statement repr))
 helloForLoop = forRange i (litInt 0) (litInt 9) (litInt 1) (oneLiner (printLn 
   (valueOf i)))
   where i = var "i" int
 
-helloWhileLoop :: (RenderSym repr) => GS (repr (Statement repr))
+helloWhileLoop :: (ProgramSym repr) => GS (repr (Statement repr))
 helloWhileLoop = while (valueOf (var "a" int) ?< litInt 13) (bodyStatements 
   [printStrLn "Hello", (&++) (var "a" int)]) 
 
-helloForEachLoop :: (RenderSym repr) => GS (repr (Statement repr))
+helloForEachLoop :: (ProgramSym repr) => GS (repr (Statement repr))
 helloForEachLoop = forEach i (valueOf $ listVar "myOtherList" static_ float) 
   (oneLiner (printLn (extFuncApp "Helper" "doubleAndAdd" float [valueOf i, 
   litFloat 1.0])))
   where i = iterVar "num" float
 
-helloTryCatch :: (RenderSym repr) => GS (repr (Statement repr))
+helloTryCatch :: (ProgramSym repr) => GS (repr (Statement repr))
 helloTryCatch = tryCatch (oneLiner (throw "Good-bye!"))
   (oneLiner (printStrLn "Caught intentional error"))

--- a/code/drasil-gool/Test/HelloWorld.hs
+++ b/code/drasil-gool/Test/HelloWorld.hs
@@ -6,7 +6,7 @@ import GOOL.Drasil (ProgramSym(..), FileSym(..), PermanenceSym(..),
   BodySym(..), BlockSym(..), listSlice, TypeSym(..), StatementSym(..), 
   ControlStatementSym(..), VariableSym(..), ValueSym(..), NumericExpression(..),
   BooleanExpression(..), ValueExpression(..), Selector(..), FunctionSym(..), 
-  SelectorFunction(..), MethodSym(..), ModuleSym(..), GS, MS)
+  SelectorFunction(..), MethodSym(..), ModuleSym(..), GS, FS, MS)
 import Prelude hiding (return,print,log,exp,sin,cos,tan,const)
 import Test.Helper (helper)
 
@@ -25,7 +25,7 @@ helloWorldMain = mainFunction (body [ helloInitVariables,
       (valueOf (var "b" int) ?== litInt 5, helloIfBody)] helloElseBody, helloIfExists,
     helloSwitch, helloForLoop, helloWhileLoop, helloForEachLoop, helloTryCatch]])
 
-helloInitVariables :: (ProgramSym repr) => GS (repr (Block repr))
+helloInitVariables :: (ProgramSym repr) => FS (repr (Block repr))
 helloInitVariables = block [comment "Initializing variables",
   varDec $ var "a" int, 
   varDecDef (var "b" int) (litInt 5),
@@ -52,12 +52,12 @@ helloInitVariables = block [comment "Initializing variables",
   printLn (valueOf $ var "boringList" (listType dynamic_ bool)),
   listDec 2 $ var "mySlicedList" (listType static_ float)]
 
-helloListSlice :: (ProgramSym repr) => GS (repr (Block repr))
+helloListSlice :: (ProgramSym repr) => FS (repr (Block repr))
 helloListSlice = listSlice (var "mySlicedList" (listType static_ float)) 
   (valueOf $ var "myOtherList" (listType static_ float)) (Just (litInt 1)) 
   (Just (litInt 3)) Nothing
 
-helloIfBody :: (ProgramSym repr) => GS (repr (Body repr))
+helloIfBody :: (ProgramSym repr) => FS (repr (Body repr))
 helloIfBody = addComments "If body" (body [
   block [
     varDec $ var "c" int,
@@ -125,33 +125,33 @@ helloIfBody = addComments "If body" (body [
     printLn (inlineIf litTrue (litInt 5) (litInt 0)),
     printLn (cot (litFloat 1.0))]])
 
-helloElseBody :: (ProgramSym repr) => GS (repr (Body repr))
+helloElseBody :: (ProgramSym repr) => FS (repr (Body repr))
 helloElseBody = bodyStatements [printLn (arg 5)]
 
-helloIfExists :: (ProgramSym repr) => GS (repr (Statement repr))
+helloIfExists :: (ProgramSym repr) => FS (repr (Statement repr))
 helloIfExists = ifExists (valueOf $ var "boringList" (listType dynamic_ bool)) 
   (oneLiner (printStrLn "Ew, boring list!")) (oneLiner (printStrLn "Great, no bores!"))
 
-helloSwitch :: (ProgramSym repr) => GS (repr (Statement repr))
+helloSwitch :: (ProgramSym repr) => FS (repr (Statement repr))
 helloSwitch = switch (valueOf $ var "a" int) [(litInt 5, oneLiner (var "b" int &= litInt 10)), 
   (litInt 0, oneLiner (var "b" int &= litInt 5))]
   (oneLiner (var "b" int &= litInt 0))
 
-helloForLoop :: (ProgramSym repr) => GS (repr (Statement repr))
+helloForLoop :: (ProgramSym repr) => FS (repr (Statement repr))
 helloForLoop = forRange i (litInt 0) (litInt 9) (litInt 1) (oneLiner (printLn 
   (valueOf i)))
   where i = var "i" int
 
-helloWhileLoop :: (ProgramSym repr) => GS (repr (Statement repr))
+helloWhileLoop :: (ProgramSym repr) => FS (repr (Statement repr))
 helloWhileLoop = while (valueOf (var "a" int) ?< litInt 13) (bodyStatements 
   [printStrLn "Hello", (&++) (var "a" int)]) 
 
-helloForEachLoop :: (ProgramSym repr) => GS (repr (Statement repr))
+helloForEachLoop :: (ProgramSym repr) => FS (repr (Statement repr))
 helloForEachLoop = forEach i (valueOf $ listVar "myOtherList" static_ float) 
   (oneLiner (printLn (extFuncApp "Helper" "doubleAndAdd" float [valueOf i, 
   litFloat 1.0])))
   where i = iterVar "num" float
 
-helloTryCatch :: (ProgramSym repr) => GS (repr (Statement repr))
+helloTryCatch :: (ProgramSym repr) => FS (repr (Statement repr))
 helloTryCatch = tryCatch (oneLiner (throw "Good-bye!"))
   (oneLiner (printStrLn "Caught intentional error"))

--- a/code/drasil-gool/Test/HelloWorld.hs
+++ b/code/drasil-gool/Test/HelloWorld.hs
@@ -2,12 +2,11 @@
 
 module Test.HelloWorld (helloWorld) where
 
-import GOOL.Drasil (
-  ProgramSym(..), RenderSym(..), PermanenceSym(..), BodySym(..), BlockSym(..), 
-  listSlice, TypeSym(..), StatementSym(..), ControlStatementSym(..),  
-  VariableSym(..), ValueSym(..), NumericExpression(..), BooleanExpression(..), 
-  ValueExpression(..), Selector(..), FunctionSym(..), SelectorFunction(..), 
-  MethodSym(..), ModuleSym(..), GS, MS)
+import GOOL.Drasil (ProgramSym(..), RenderSym, FileSym(..), PermanenceSym(..), 
+  BodySym(..), BlockSym(..), listSlice, TypeSym(..), StatementSym(..), 
+  ControlStatementSym(..), VariableSym(..), ValueSym(..), NumericExpression(..),
+  BooleanExpression(..), ValueExpression(..), Selector(..), FunctionSym(..), 
+  SelectorFunction(..), MethodSym(..), ModuleSym(..), GS, MS)
 import Prelude hiding (return,print,log,exp,sin,cos,tan,const)
 import Test.Helper (helper)
 

--- a/code/drasil-gool/Test/Helper.hs
+++ b/code/drasil-gool/Test/Helper.hs
@@ -7,7 +7,7 @@ import GOOL.Drasil (
 import Prelude hiding (return,print,log,exp,sin,cos,tan)
 
 helper :: (ProgramSym repr) => FS (repr (RenderFile repr))
-helper = fileDoc (buildModule "Helper" [] [doubleAndAdd] [])
+helper = fileDoc (buildModule "Helper" [doubleAndAdd] [])
 
 doubleAndAdd :: (ProgramSym repr) => MS (repr (Method repr))
 doubleAndAdd = docFunc "This function adds two numbers" 

--- a/code/drasil-gool/Test/Helper.hs
+++ b/code/drasil-gool/Test/Helper.hs
@@ -1,7 +1,7 @@
 module Test.Helper (helper) where
 
 import GOOL.Drasil (
-  RenderSym(..), PermanenceSym(..), BodySym(..), TypeSym(..), 
+  RenderSym, FileSym(..), PermanenceSym(..), BodySym(..), TypeSym(..), 
   StatementSym(..), VariableSym(..), ValueSym(..), NumericExpression(..), 
   ScopeSym(..), ParameterSym(..), MethodSym(..), ModuleSym(..), FS, MS)
 import Prelude hiding (return,print,log,exp,sin,cos,tan)

--- a/code/drasil-gool/Test/Helper.hs
+++ b/code/drasil-gool/Test/Helper.hs
@@ -1,15 +1,15 @@
 module Test.Helper (helper) where
 
 import GOOL.Drasil (
-  RenderSym, FileSym(..), PermanenceSym(..), BodySym(..), TypeSym(..), 
+  ProgramSym, FileSym(..), PermanenceSym(..), BodySym(..), TypeSym(..), 
   StatementSym(..), VariableSym(..), ValueSym(..), NumericExpression(..), 
   ScopeSym(..), ParameterSym(..), MethodSym(..), ModuleSym(..), FS, MS)
 import Prelude hiding (return,print,log,exp,sin,cos,tan)
 
-helper :: (RenderSym repr) => FS (repr (RenderFile repr))
+helper :: (ProgramSym repr) => FS (repr (RenderFile repr))
 helper = fileDoc (buildModule "Helper" [] [doubleAndAdd] [])
 
-doubleAndAdd :: (RenderSym repr) => MS (repr (Method repr))
+doubleAndAdd :: (ProgramSym repr) => MS (repr (Method repr))
 doubleAndAdd = docFunc "This function adds two numbers" 
   ["First number to add", "Second number to add"] (Just "Sum") $ 
   function "doubleAndAdd"  public static_ float

--- a/code/drasil-gool/Test/Main.hs
+++ b/code/drasil-gool/Test/Main.hs
@@ -1,12 +1,7 @@
 module Test.Main (main) where
 
-import GOOL.Drasil.Symantics (Label, ProgramSym(..))
-import GOOL.Drasil.LanguageRenderer.JavaRenderer (JavaCode(..))
-import GOOL.Drasil.LanguageRenderer.PythonRenderer (PythonCode(..))
-import GOOL.Drasil.LanguageRenderer.CSharpRenderer (CSharpCode(..))
-import GOOL.Drasil.LanguageRenderer.CppRenderer (unCPPC)
-import GOOL.Drasil.Data (FileData(..), ModData(..), ProgData(..))
-import GOOL.Drasil.State (initialState)
+import GOOL.Drasil (Label, ProgramSym(..), unCI, unJC, unPC, unCSC, unCPPC, 
+  FileData(..), ModData(..), ProgData(..), initialState)
 
 import Text.PrettyPrint.HughesPJ (Doc, render)
 import Control.Monad.State (evalState)
@@ -43,8 +38,8 @@ genCode files = createCodeFiles (concatMap (\p -> replicate (length $ progMods
   p) (progName p)) files) $ makeCode (concatMap progMods files)
 
 classes :: (ProgramSym repr) => (repr (Program repr) -> ProgData) -> [ProgData]
-classes unRepr = map (unRepr . (`evalState` initialState)) [helloWorld, 
-  patternTest, fileTests]
+classes unRepr = zipWith (\p gs -> unRepr (evalState p gs)) [helloWorld, patternTest, fileTests] 
+  (map (unCI . (`evalState` initialState)) [helloWorld, patternTest, fileTests])
 
 -- | Takes code
 makeCode :: [FileData] -> [(FilePath, Doc)]

--- a/code/drasil-gool/Test/Observer.hs
+++ b/code/drasil-gool/Test/Observer.hs
@@ -12,7 +12,7 @@ observerDesc = "This is an arbitrary class acting as an Observer"
 printNum = "printNum"
 
 observer :: (ProgramSym repr) => FS (repr (RenderFile repr))
-observer = fileDoc (buildModule observerName [] [] [docClass observerDesc
+observer = fileDoc (buildModule observerName [] [docClass observerDesc
   helperClass])
 
 x :: (VariableSym repr) => FS (repr (Variable repr))

--- a/code/drasil-gool/Test/Observer.hs
+++ b/code/drasil-gool/Test/Observer.hs
@@ -1,7 +1,7 @@
 module Test.Observer (observer, observerName, printNum, x) where
 
 import GOOL.Drasil (
-  RenderSym(..), PermanenceSym(..), BodySym(..), TypeSym(..), 
+  RenderSym, FileSym(..), PermanenceSym(..), BodySym(..), TypeSym(..), 
   StatementSym(..), VariableSym(..), ValueSym(..), ScopeSym(..), 
   MethodSym(..), StateVarSym(..), ClassSym(..), ModuleSym(..), GS, FS, MS)
 import Prelude hiding (return,print,log,exp,sin,cos,tan)

--- a/code/drasil-gool/Test/Observer.hs
+++ b/code/drasil-gool/Test/Observer.hs
@@ -1,7 +1,7 @@
 module Test.Observer (observer, observerName, printNum, x) where
 
 import GOOL.Drasil (
-  RenderSym, FileSym(..), PermanenceSym(..), BodySym(..), TypeSym(..), 
+  ProgramSym, FileSym(..), PermanenceSym(..), BodySym(..), TypeSym(..), 
   StatementSym(..), VariableSym(..), ValueSym(..), ScopeSym(..), 
   MethodSym(..), StateVarSym(..), ClassSym(..), ModuleSym(..), GS, FS, MS)
 import Prelude hiding (return,print,log,exp,sin,cos,tan)
@@ -11,7 +11,7 @@ observerName = "Observer"
 observerDesc = "This is an arbitrary class acting as an Observer"
 printNum = "printNum"
 
-observer :: (RenderSym repr) => FS (repr (RenderFile repr))
+observer :: (ProgramSym repr) => FS (repr (RenderFile repr))
 observer = fileDoc (buildModule observerName [] [] [docClass observerDesc
   helperClass])
 

--- a/code/drasil-gool/Test/Observer.hs
+++ b/code/drasil-gool/Test/Observer.hs
@@ -3,7 +3,7 @@ module Test.Observer (observer, observerName, printNum, x) where
 import GOOL.Drasil (
   ProgramSym, FileSym(..), PermanenceSym(..), BodySym(..), TypeSym(..), 
   StatementSym(..), VariableSym(..), ValueSym(..), ScopeSym(..), 
-  MethodSym(..), StateVarSym(..), ClassSym(..), ModuleSym(..), GS, FS, MS)
+  MethodSym(..), StateVarSym(..), ClassSym(..), ModuleSym(..), FS, MS)
 import Prelude hiding (return,print,log,exp,sin,cos,tan)
 
 observerName, observerDesc, printNum :: String
@@ -15,10 +15,10 @@ observer :: (ProgramSym repr) => FS (repr (RenderFile repr))
 observer = fileDoc (buildModule observerName [] [] [docClass observerDesc
   helperClass])
 
-x :: (VariableSym repr) => GS (repr (Variable repr))
+x :: (VariableSym repr) => FS (repr (Variable repr))
 x = var "x" int
 
-selfX :: (VariableSym repr) => GS (repr (Variable repr))
+selfX :: (VariableSym repr) => FS (repr (Variable repr))
 selfX = objVarSelf observerName x
 
 helperClass :: (ClassSym repr) => FS (repr (Class repr))

--- a/code/drasil-gool/Test/PatternTest.hs
+++ b/code/drasil-gool/Test/PatternTest.hs
@@ -1,9 +1,9 @@
 module Test.PatternTest (patternTest) where
 
-import GOOL.Drasil (ProgramSym(..), FileSym(..),
-  BodySym(..), BlockSym(..), ControlBlockSym(..), TypeSym(..), 
-  StatementSym(..), ControlStatementSym(..), VariableSym(..), ValueSym(..),
-  ValueExpression(..), FunctionSym(..), MethodSym(..), ModuleSym(..), GS, MS)
+import GOOL.Drasil (ProgramSym(..), FileSym(..), BodySym(..), BlockSym(..), 
+  ControlBlockSym(..), TypeSym(..), StatementSym(..), ControlStatementSym(..), 
+  VariableSym(..), ValueSym(..), ValueExpression(..), FunctionSym(..), 
+  MethodSym(..), ModuleSym(..), GS, FS, MS)
 import Prelude hiding (return,print,log,exp,sin,cos,tan)
 import Test.Observer (observer, observerName, printNum, x)
 
@@ -20,15 +20,15 @@ obs1Name = "obs1"
 obs2Name = "obs2"
 nName = "n"
 
-observerType :: (TypeSym repr) => GS (repr (Type repr))
+observerType :: (TypeSym repr) => FS (repr (Type repr))
 observerType = obj observerName
 
-n, obs1, obs2 :: (VariableSym repr) => GS (repr (Variable repr))
+n, obs1, obs2 :: (VariableSym repr) => FS (repr (Variable repr))
 n = var nName int
 obs1 = var obs1Name observerType
 obs2 = var obs2Name observerType
 
-newObserver :: (ValueExpression repr) => GS (repr (Value repr))
+newObserver :: (ValueExpression repr) => FS (repr (Value repr))
 newObserver = extNewObj observerName observerType []
 
 patternTest :: (ProgramSym repr) => GS (repr (Program repr))

--- a/code/drasil-gool/Test/PatternTest.hs
+++ b/code/drasil-gool/Test/PatternTest.hs
@@ -1,7 +1,6 @@
 module Test.PatternTest (patternTest) where
 
-import GOOL.Drasil (
-  ProgramSym(..), RenderSym(..),
+import GOOL.Drasil (ProgramSym(..), FileSym(..),
   BodySym(..), BlockSym(..), ControlBlockSym(..), TypeSym(..), 
   StatementSym(..), ControlStatementSym(..), VariableSym(..), ValueSym(..),
   ValueExpression(..), FunctionSym(..), MethodSym(..), ModuleSym(..), GS, MS)

--- a/code/drasil-gool/Test/PatternTest.hs
+++ b/code/drasil-gool/Test/PatternTest.hs
@@ -32,7 +32,8 @@ newObserver :: (ValueExpression repr) => FS (repr (Value repr))
 newObserver = extNewObj observerName observerType []
 
 patternTest :: (ProgramSym repr) => GS (repr (Program repr))
-patternTest = prog progName [fileDoc (buildModule progName [observerName] [patternTestMainMethod] []), observer]
+patternTest = prog progName [fileDoc (buildModule progName 
+  [patternTestMainMethod] []), observer]
 
 patternTestMainMethod :: (MethodSym repr) => MS (repr (Method repr))
 patternTestMainMethod = mainFunction (body [block [

--- a/code/drasil-gool/drasil-gool.cabal
+++ b/code/drasil-gool/drasil-gool.cabal
@@ -12,6 +12,7 @@ library
       GOOL.Drasil.CodeType
     , GOOL.Drasil.Data
     , GOOL.Drasil.Helpers
+    , GOOL.Drasil.CodeInfo
     , GOOL.Drasil.LanguageRenderer.LanguagePolymorphic
     , GOOL.Drasil.LanguageRenderer
     , GOOL.Drasil.LanguageRenderer.JavaRenderer
@@ -47,6 +48,7 @@ executable codegenTest
     , GOOL.Drasil.CodeType
     , GOOL.Drasil.Data
     , GOOL.Drasil.Helpers
+    , GOOL.Drasil.CodeInfo
     , GOOL.Drasil.LanguageRenderer.LanguagePolymorphic
     , GOOL.Drasil.LanguageRenderer
     , GOOL.Drasil.LanguageRenderer.JavaRenderer

--- a/code/stable/glassbr/src/cpp/Calculations.cpp
+++ b/code/stable/glassbr/src/cpp/Calculations.cpp
@@ -1,23 +1,14 @@
-#include "Calculations.hpp"
-
-#define _USE_MATH_DEFINES
-#include <algorithm>
-#include <iostream>
-#include <fstream>
-#include <iterator>
-#include <string>
 #include <math.h>
-#include <sstream>
-#include <limits>
-#include <vector>
+#include <iostream>
+#include <string>
+#include <fstream>
+
+#include "Calculations.hpp"
+#include "Interpolation.hpp"
+#include "InputParameters.hpp"
 
 using std::string;
-using std::vector;
-using std::ifstream;
 using std::ofstream;
-
-#include "InputParameters.hpp"
-#include "Interpolation.hpp"
 
 double func_J_tol(InputParameters &inParams) {
     ofstream outfile;

--- a/code/stable/glassbr/src/cpp/Calculations.hpp
+++ b/code/stable/glassbr/src/cpp/Calculations.hpp
@@ -6,15 +6,11 @@
 #define Calculations_h
 
 #include <string>
-#include <vector>
-
-using std::string;
-using std::vector;
-using std::ifstream;
-using std::ofstream;
 
 #include "InputParameters.hpp"
-#include "Interpolation.hpp"
+
+using std::string;
+using std::ofstream;
 
 /** \brief Calculates stress distribution factor (Function) based on Pbtol
     \param inParams structure holding the input values

--- a/code/stable/glassbr/src/cpp/Control.cpp
+++ b/code/stable/glassbr/src/cpp/Control.cpp
@@ -2,28 +2,19 @@
     \author Nikitha Krithnan and W. Spencer Smith
     \brief Controls the flow of the program
 */
-#define _USE_MATH_DEFINES
-#include <algorithm>
 #include <iostream>
-#include <fstream>
-#include <iterator>
 #include <string>
-#include <math.h>
-#include <sstream>
-#include <limits>
-#include <vector>
+#include <fstream>
 
-using std::string;
-using std::vector;
-using std::ifstream;
-using std::ofstream;
-
-#include "InputParameters.hpp"
-#include "InputFormat.hpp"
-#include "DerivedValues.hpp"
-#include "InputConstraints.hpp"
 #include "OutputFormat.hpp"
 #include "Calculations.hpp"
+#include "InputConstraints.hpp"
+#include "DerivedValues.hpp"
+#include "InputFormat.hpp"
+#include "InputParameters.hpp"
+
+using std::string;
+using std::ofstream;
 
 /** \brief Controls the flow of the program
     \param argc Number of command-line arguments

--- a/code/stable/glassbr/src/cpp/DerivedValues.cpp
+++ b/code/stable/glassbr/src/cpp/DerivedValues.cpp
@@ -1,22 +1,13 @@
-#include "DerivedValues.hpp"
-
-#define _USE_MATH_DEFINES
-#include <algorithm>
-#include <iostream>
-#include <fstream>
-#include <iterator>
-#include <string>
 #include <math.h>
-#include <sstream>
-#include <limits>
-#include <vector>
+#include <iostream>
+#include <string>
+#include <fstream>
+
+#include "DerivedValues.hpp"
+#include "InputParameters.hpp"
 
 using std::string;
-using std::vector;
-using std::ifstream;
 using std::ofstream;
-
-#include "InputParameters.hpp"
 
 void derived_values(InputParameters &inParams) {
     ofstream outfile;

--- a/code/stable/glassbr/src/cpp/DerivedValues.hpp
+++ b/code/stable/glassbr/src/cpp/DerivedValues.hpp
@@ -6,14 +6,11 @@
 #define DerivedValues_h
 
 #include <string>
-#include <vector>
-
-using std::string;
-using std::vector;
-using std::ifstream;
-using std::ofstream;
 
 #include "InputParameters.hpp"
+
+using std::string;
+using std::ofstream;
 
 /** \brief Calculates values that can be immediately derived from the inputs
     \param inParams structure holding the input values

--- a/code/stable/glassbr/src/cpp/InputConstraints.cpp
+++ b/code/stable/glassbr/src/cpp/InputConstraints.cpp
@@ -1,22 +1,12 @@
-#include "InputConstraints.hpp"
-
-#define _USE_MATH_DEFINES
-#include <algorithm>
 #include <iostream>
-#include <fstream>
-#include <iterator>
 #include <string>
-#include <math.h>
-#include <sstream>
-#include <limits>
-#include <vector>
+#include <fstream>
+
+#include "InputConstraints.hpp"
+#include "InputParameters.hpp"
 
 using std::string;
-using std::vector;
-using std::ifstream;
 using std::ofstream;
-
-#include "InputParameters.hpp"
 
 void input_constraints(InputParameters &inParams) {
     ofstream outfile;

--- a/code/stable/glassbr/src/cpp/InputConstraints.hpp
+++ b/code/stable/glassbr/src/cpp/InputConstraints.hpp
@@ -6,14 +6,11 @@
 #define InputConstraints_h
 
 #include <string>
-#include <vector>
-
-using std::string;
-using std::vector;
-using std::ifstream;
-using std::ofstream;
 
 #include "InputParameters.hpp"
+
+using std::string;
+using std::ofstream;
 
 /** \brief Verifies that input values satisfy the physical constraints and software constraints
     \param inParams structure holding the input values

--- a/code/stable/glassbr/src/cpp/InputFormat.cpp
+++ b/code/stable/glassbr/src/cpp/InputFormat.cpp
@@ -1,22 +1,15 @@
-#include "InputFormat.hpp"
-
-#define _USE_MATH_DEFINES
 #include <algorithm>
+#include <limits>
 #include <iostream>
 #include <fstream>
-#include <iterator>
 #include <string>
-#include <math.h>
-#include <sstream>
-#include <limits>
-#include <vector>
 
-using std::string;
-using std::vector;
+#include "InputFormat.hpp"
+#include "InputParameters.hpp"
+
 using std::ifstream;
 using std::ofstream;
-
-#include "InputParameters.hpp"
+using std::string;
 
 void get_input(InputParameters &inParams, string filename) {
     ofstream outfile;

--- a/code/stable/glassbr/src/cpp/InputFormat.hpp
+++ b/code/stable/glassbr/src/cpp/InputFormat.hpp
@@ -6,14 +6,12 @@
 #define InputFormat_h
 
 #include <string>
-#include <vector>
-
-using std::string;
-using std::vector;
-using std::ifstream;
-using std::ofstream;
 
 #include "InputParameters.hpp"
+
+using std::ifstream;
+using std::ofstream;
+using std::string;
 
 /** \brief Reads input from a file with the given file name
     \param inParams structure holding the input values

--- a/code/stable/glassbr/src/cpp/InputParameters.hpp
+++ b/code/stable/glassbr/src/cpp/InputParameters.hpp
@@ -6,12 +6,8 @@
 #define InputParameters_h
 
 #include <string>
-#include <vector>
 
 using std::string;
-using std::vector;
-using std::ifstream;
-using std::ofstream;
 
 /** \brief Structure for holding the input values and derived values
 */

--- a/code/stable/glassbr/src/cpp/Interpolation.cpp
+++ b/code/stable/glassbr/src/cpp/Interpolation.cpp
@@ -1,22 +1,14 @@
-#include "Interpolation.hpp"
-
-#define _USE_MATH_DEFINES
-#include <algorithm>
-#include <iostream>
-#include <fstream>
-#include <iterator>
-#include <string>
-#include <math.h>
-#include <sstream>
-#include <limits>
 #include <vector>
+#include <iostream>
+#include <string>
+#include <fstream>
 
-using std::string;
-using std::vector;
-using std::ifstream;
-using std::ofstream;
-
+#include "Interpolation.hpp"
 #include "ReadTable.hpp"
+
+using std::vector;
+using std::string;
+using std::ofstream;
 
 double func_lin_interp(double x_1, double y_1, double x_2, double y_2, double x) {
     ofstream outfile;

--- a/code/stable/glassbr/src/cpp/Interpolation.hpp
+++ b/code/stable/glassbr/src/cpp/Interpolation.hpp
@@ -5,15 +5,12 @@
 #ifndef Interpolation_h
 #define Interpolation_h
 
-#include <string>
 #include <vector>
+#include <string>
 
-using std::string;
 using std::vector;
-using std::ifstream;
+using std::string;
 using std::ofstream;
-
-#include "ReadTable.hpp"
 
 /** \brief Performs linear interpolation
     \param x_1 lower x-coordinate

--- a/code/stable/glassbr/src/cpp/OutputFormat.cpp
+++ b/code/stable/glassbr/src/cpp/OutputFormat.cpp
@@ -1,19 +1,10 @@
+#include <iostream>
+#include <string>
+#include <fstream>
+
 #include "OutputFormat.hpp"
 
-#define _USE_MATH_DEFINES
-#include <algorithm>
-#include <iostream>
-#include <fstream>
-#include <iterator>
-#include <string>
-#include <math.h>
-#include <sstream>
-#include <limits>
-#include <vector>
-
 using std::string;
-using std::vector;
-using std::ifstream;
 using std::ofstream;
 
 void write_output(bool is_safePb, bool is_safeLR, double P_b) {

--- a/code/stable/glassbr/src/cpp/OutputFormat.hpp
+++ b/code/stable/glassbr/src/cpp/OutputFormat.hpp
@@ -6,11 +6,8 @@
 #define OutputFormat_h
 
 #include <string>
-#include <vector>
 
 using std::string;
-using std::vector;
-using std::ifstream;
 using std::ofstream;
 
 /** \brief Writes the output values to output.txt

--- a/code/stable/glassbr/src/cpp/ReadTable.cpp
+++ b/code/stable/glassbr/src/cpp/ReadTable.cpp
@@ -1,20 +1,15 @@
-#include "ReadTable.hpp"
-
-#define _USE_MATH_DEFINES
-#include <algorithm>
+#include <sstream>
 #include <iostream>
 #include <fstream>
-#include <iterator>
-#include <string>
-#include <math.h>
-#include <sstream>
-#include <limits>
 #include <vector>
+#include <string>
 
-using std::string;
-using std::vector;
+#include "ReadTable.hpp"
+
 using std::ifstream;
 using std::ofstream;
+using std::vector;
+using std::string;
 
 void func_read_table(string filename, vector<double> &z_vector, vector<vector<double>> &x_matrix, vector<vector<double>> &y_matrix) {
     ofstream outfile;

--- a/code/stable/glassbr/src/cpp/ReadTable.hpp
+++ b/code/stable/glassbr/src/cpp/ReadTable.hpp
@@ -5,13 +5,13 @@
 #ifndef ReadTable_h
 #define ReadTable_h
 
-#include <string>
 #include <vector>
+#include <string>
 
-using std::string;
-using std::vector;
 using std::ifstream;
 using std::ofstream;
+using std::vector;
+using std::string;
 
 /** \brief Reads glass ASTM data from a file with the given file name
     \param filename name of the input file

--- a/code/stable/glassbr/src/csharp/Calculations.cs
+++ b/code/stable/glassbr/src/csharp/Calculations.cs
@@ -4,7 +4,6 @@
 */
 using System;
 using System.IO;
-using System.Collections.Generic;
 
 public class Calculations {
     

--- a/code/stable/glassbr/src/csharp/Control.cs
+++ b/code/stable/glassbr/src/csharp/Control.cs
@@ -4,7 +4,6 @@
 */
 using System;
 using System.IO;
-using System.Collections.Generic;
 
 public class Control {
     

--- a/code/stable/glassbr/src/csharp/DerivedValues.cs
+++ b/code/stable/glassbr/src/csharp/DerivedValues.cs
@@ -4,7 +4,6 @@
 */
 using System;
 using System.IO;
-using System.Collections.Generic;
 
 public class DerivedValues {
     

--- a/code/stable/glassbr/src/csharp/InputConstraints.cs
+++ b/code/stable/glassbr/src/csharp/InputConstraints.cs
@@ -4,7 +4,6 @@
 */
 using System;
 using System.IO;
-using System.Collections.Generic;
 
 public class InputConstraints {
     

--- a/code/stable/glassbr/src/csharp/InputFormat.cs
+++ b/code/stable/glassbr/src/csharp/InputFormat.cs
@@ -4,7 +4,6 @@
 */
 using System;
 using System.IO;
-using System.Collections.Generic;
 
 public class InputFormat {
     

--- a/code/stable/glassbr/src/csharp/InputParameters.cs
+++ b/code/stable/glassbr/src/csharp/InputParameters.cs
@@ -2,10 +2,6 @@
     \author Nikitha Krithnan and W. Spencer Smith
     \brief Provides the structure for holding input values
 */
-using System;
-using System.IO;
-using System.Collections.Generic;
-
 /** \brief Structure for holding the input values and derived values
 */
 public class InputParameters {

--- a/code/stable/glassbr/src/csharp/Interpolation.cs
+++ b/code/stable/glassbr/src/csharp/Interpolation.cs
@@ -2,9 +2,9 @@
     \author Nikitha Krithnan and W. Spencer Smith
     \brief Provides functions for linear interpolation on three-dimensional data
 */
+using System.Collections.Generic;
 using System;
 using System.IO;
-using System.Collections.Generic;
 
 public class Interpolation {
     

--- a/code/stable/glassbr/src/csharp/OutputFormat.cs
+++ b/code/stable/glassbr/src/csharp/OutputFormat.cs
@@ -2,9 +2,8 @@
     \author Nikitha Krithnan and W. Spencer Smith
     \brief Provides the function for writing outputs
 */
-using System;
 using System.IO;
-using System.Collections.Generic;
+using System;
 
 public class OutputFormat {
     

--- a/code/stable/glassbr/src/java/GlassBR/Calculations.java
+++ b/code/stable/glassbr/src/java/GlassBR/Calculations.java
@@ -4,12 +4,9 @@ package GlassBR;
     \author Nikitha Krithnan and W. Spencer Smith
     \brief Provides functions for calculating the outputs
 */
-import java.util.Arrays;
-import java.util.Scanner;
-import java.io.PrintWriter;
-import java.io.FileWriter;
 import java.io.File;
-import java.util.ArrayList;
+import java.io.FileWriter;
+import java.io.PrintWriter;
 
 public class Calculations {
     

--- a/code/stable/glassbr/src/java/GlassBR/Control.java
+++ b/code/stable/glassbr/src/java/GlassBR/Control.java
@@ -4,12 +4,9 @@ package GlassBR;
     \author Nikitha Krithnan and W. Spencer Smith
     \brief Controls the flow of the program
 */
-import java.util.Arrays;
-import java.util.Scanner;
-import java.io.PrintWriter;
-import java.io.FileWriter;
 import java.io.File;
-import java.util.ArrayList;
+import java.io.FileWriter;
+import java.io.PrintWriter;
 
 public class Control {
     

--- a/code/stable/glassbr/src/java/GlassBR/DerivedValues.java
+++ b/code/stable/glassbr/src/java/GlassBR/DerivedValues.java
@@ -4,12 +4,9 @@ package GlassBR;
     \author Nikitha Krithnan and W. Spencer Smith
     \brief Provides the function for calculating derived values
 */
-import java.util.Arrays;
-import java.util.Scanner;
-import java.io.PrintWriter;
-import java.io.FileWriter;
 import java.io.File;
-import java.util.ArrayList;
+import java.io.FileWriter;
+import java.io.PrintWriter;
 
 public class DerivedValues {
     

--- a/code/stable/glassbr/src/java/GlassBR/InputConstraints.java
+++ b/code/stable/glassbr/src/java/GlassBR/InputConstraints.java
@@ -4,12 +4,9 @@ package GlassBR;
     \author Nikitha Krithnan and W. Spencer Smith
     \brief Provides the function for checking the physical constraints and software constraints on the input
 */
-import java.util.Arrays;
-import java.util.Scanner;
-import java.io.PrintWriter;
-import java.io.FileWriter;
 import java.io.File;
-import java.util.ArrayList;
+import java.io.FileWriter;
+import java.io.PrintWriter;
 
 public class InputConstraints {
     

--- a/code/stable/glassbr/src/java/GlassBR/InputFormat.java
+++ b/code/stable/glassbr/src/java/GlassBR/InputFormat.java
@@ -4,12 +4,10 @@ package GlassBR;
     \author Nikitha Krithnan and W. Spencer Smith
     \brief Provides the function for reading inputs
 */
-import java.util.Arrays;
 import java.util.Scanner;
-import java.io.PrintWriter;
-import java.io.FileWriter;
 import java.io.File;
-import java.util.ArrayList;
+import java.io.FileWriter;
+import java.io.PrintWriter;
 
 public class InputFormat {
     

--- a/code/stable/glassbr/src/java/GlassBR/InputParameters.java
+++ b/code/stable/glassbr/src/java/GlassBR/InputParameters.java
@@ -4,13 +4,6 @@ package GlassBR;
     \author Nikitha Krithnan and W. Spencer Smith
     \brief Provides the structure for holding input values
 */
-import java.util.Arrays;
-import java.util.Scanner;
-import java.io.PrintWriter;
-import java.io.FileWriter;
-import java.io.File;
-import java.util.ArrayList;
-
 /** \brief Structure for holding the input values and derived values
 */
 public class InputParameters {

--- a/code/stable/glassbr/src/java/GlassBR/Interpolation.java
+++ b/code/stable/glassbr/src/java/GlassBR/Interpolation.java
@@ -4,12 +4,10 @@ package GlassBR;
     \author Nikitha Krithnan and W. Spencer Smith
     \brief Provides functions for linear interpolation on three-dimensional data
 */
-import java.util.Arrays;
-import java.util.Scanner;
-import java.io.PrintWriter;
-import java.io.FileWriter;
-import java.io.File;
 import java.util.ArrayList;
+import java.io.File;
+import java.io.FileWriter;
+import java.io.PrintWriter;
 
 public class Interpolation {
     

--- a/code/stable/glassbr/src/java/GlassBR/OutputFormat.java
+++ b/code/stable/glassbr/src/java/GlassBR/OutputFormat.java
@@ -4,12 +4,9 @@ package GlassBR;
     \author Nikitha Krithnan and W. Spencer Smith
     \brief Provides the function for writing outputs
 */
-import java.util.Arrays;
-import java.util.Scanner;
-import java.io.PrintWriter;
-import java.io.FileWriter;
 import java.io.File;
-import java.util.ArrayList;
+import java.io.FileWriter;
+import java.io.PrintWriter;
 
 public class OutputFormat {
     

--- a/code/stable/glassbr/src/java/GlassBR/ReadTable.java
+++ b/code/stable/glassbr/src/java/GlassBR/ReadTable.java
@@ -6,9 +6,9 @@ package GlassBR;
 */
 import java.util.Arrays;
 import java.util.Scanner;
-import java.io.PrintWriter;
-import java.io.FileWriter;
 import java.io.File;
+import java.io.FileWriter;
+import java.io.PrintWriter;
 import java.util.ArrayList;
 
 public class ReadTable {
@@ -57,8 +57,8 @@ public class ReadTable {
         }
         for (int i = 0; i < lines.size(); i += 1) {
             linetokens = new ArrayList<String>(Arrays.asList(lines.get(i).split(",")));
-            ArrayList<Double> x_matrix_temp = new ArrayList<Double> ();
-            ArrayList<Double> y_matrix_temp = new ArrayList<Double> ();
+            ArrayList<Double> x_matrix_temp = new ArrayList<Double>();
+            ArrayList<Double> y_matrix_temp = new ArrayList<Double>();
             for (int stringlist_i = 0; stringlist_i < linetokens.size() / 2; stringlist_i += 1) {
                 x_matrix_temp.add(Double.parseDouble(linetokens.get(stringlist_i * 2 + 0)));
                 y_matrix_temp.add(Double.parseDouble(linetokens.get(stringlist_i * 2 + 1)));

--- a/code/stable/glassbr/src/python/Calculations.py
+++ b/code/stable/glassbr/src/python/Calculations.py
@@ -1,10 +1,8 @@
 ## \file Calculations.py
 # \author Nikitha Krithnan and W. Spencer Smith
 # \brief Provides functions for calculating the outputs
-import sys
 import math
 
-import InputParameters
 import Interpolation
 
 ## \brief Calculates stress distribution factor (Function) based on Pbtol

--- a/code/stable/glassbr/src/python/Control.py
+++ b/code/stable/glassbr/src/python/Control.py
@@ -2,14 +2,13 @@
 # \author Nikitha Krithnan and W. Spencer Smith
 # \brief Controls the flow of the program
 import sys
-import math
 
-import InputParameters
-import InputFormat
-import DerivedValues
-import InputConstraints
 import OutputFormat
 import Calculations
+import InputConstraints
+import DerivedValues
+import InputFormat
+import InputParameters
 
 filename = sys.argv[1]
 outfile = open("log.txt", "a")

--- a/code/stable/glassbr/src/python/DerivedValues.py
+++ b/code/stable/glassbr/src/python/DerivedValues.py
@@ -1,10 +1,7 @@
 ## \file DerivedValues.py
 # \author Nikitha Krithnan and W. Spencer Smith
 # \brief Provides the function for calculating derived values
-import sys
 import math
-
-import InputParameters
 
 ## \brief Calculates values that can be immediately derived from the inputs
 # \param inParams structure holding the input values

--- a/code/stable/glassbr/src/python/InputConstraints.py
+++ b/code/stable/glassbr/src/python/InputConstraints.py
@@ -1,11 +1,6 @@
 ## \file InputConstraints.py
 # \author Nikitha Krithnan and W. Spencer Smith
 # \brief Provides the function for checking the physical constraints and software constraints on the input
-import sys
-import math
-
-import InputParameters
-
 ## \brief Verifies that input values satisfy the physical constraints and software constraints
 # \param inParams structure holding the input values
 def input_constraints(inParams):

--- a/code/stable/glassbr/src/python/InputFormat.py
+++ b/code/stable/glassbr/src/python/InputFormat.py
@@ -1,11 +1,6 @@
 ## \file InputFormat.py
 # \author Nikitha Krithnan and W. Spencer Smith
 # \brief Provides the function for reading inputs
-import sys
-import math
-
-import InputParameters
-
 ## \brief Reads input from a file with the given file name
 # \param inParams structure holding the input values
 # \param filename name of the input file

--- a/code/stable/glassbr/src/python/InputParameters.py
+++ b/code/stable/glassbr/src/python/InputParameters.py
@@ -1,9 +1,6 @@
 ## \file InputParameters.py
 # \author Nikitha Krithnan and W. Spencer Smith
 # \brief Provides the structure for holding input values
-import sys
-import math
-
 ## \brief Structure for holding the input values and derived values
 class InputParameters:
     None

--- a/code/stable/glassbr/src/python/Interpolation.py
+++ b/code/stable/glassbr/src/python/Interpolation.py
@@ -1,9 +1,6 @@
 ## \file Interpolation.py
 # \author Nikitha Krithnan and W. Spencer Smith
 # \brief Provides functions for linear interpolation on three-dimensional data
-import sys
-import math
-
 import ReadTable
 
 ## \brief Performs linear interpolation

--- a/code/stable/glassbr/src/python/OutputFormat.py
+++ b/code/stable/glassbr/src/python/OutputFormat.py
@@ -1,9 +1,6 @@
 ## \file OutputFormat.py
 # \author Nikitha Krithnan and W. Spencer Smith
 # \brief Provides the function for writing outputs
-import sys
-import math
-
 ## \brief Writes the output values to output.txt
 # \param is_safePb probability of glass breakage safety requirement
 # \param is_safeLR 3 second load equivalent resistance safety requirement

--- a/code/stable/glassbr/src/python/ReadTable.py
+++ b/code/stable/glassbr/src/python/ReadTable.py
@@ -1,9 +1,6 @@
 ## \file ReadTable.py
 # \author Nikitha Krithnan and W. Spencer Smith
 # \brief Provides a function for reading glass ASTM data
-import sys
-import math
-
 ## \brief Reads glass ASTM data from a file with the given file name
 # \param filename name of the input file
 # \param z_vector list of z values

--- a/code/stable/nopcm/src/cpp/Constants.cpp
+++ b/code/stable/nopcm/src/cpp/Constants.cpp
@@ -1,21 +1,5 @@
 #include "Constants.hpp"
 
-#define _USE_MATH_DEFINES
-#include <algorithm>
-#include <iostream>
-#include <fstream>
-#include <iterator>
-#include <string>
-#include <math.h>
-#include <sstream>
-#include <limits>
-#include <vector>
-
-using std::string;
-using std::vector;
-using std::ifstream;
-using std::ofstream;
-
 const double Constants::L_min = 0.1;
 const double Constants::L_max = 50;
 const double Constants::rho_W_min = 950;

--- a/code/stable/nopcm/src/cpp/Constants.hpp
+++ b/code/stable/nopcm/src/cpp/Constants.hpp
@@ -5,14 +5,6 @@
 #ifndef Constants_h
 #define Constants_h
 
-#include <string>
-#include <vector>
-
-using std::string;
-using std::vector;
-using std::ifstream;
-using std::ofstream;
-
 /** \brief Structure for holding the constant values
 */
 class Constants {

--- a/code/stable/nopcm/src/cpp/Control.cpp
+++ b/code/stable/nopcm/src/cpp/Control.cpp
@@ -2,25 +2,12 @@
     \author Thulasi Jegatheesan
     \brief Controls the flow of the program
 */
-#define _USE_MATH_DEFINES
-#include <algorithm>
-#include <iostream>
-#include <fstream>
-#include <iterator>
 #include <string>
-#include <math.h>
-#include <sstream>
-#include <limits>
-#include <vector>
+
+#include "OutputFormat.hpp"
+#include "InputParameters.hpp"
 
 using std::string;
-using std::vector;
-using std::ifstream;
-using std::ofstream;
-
-#include "Constants.hpp"
-#include "InputParameters.hpp"
-#include "OutputFormat.hpp"
 
 /** \brief Controls the flow of the program
     \param argc Number of command-line arguments

--- a/code/stable/nopcm/src/cpp/InputParameters.cpp
+++ b/code/stable/nopcm/src/cpp/InputParameters.cpp
@@ -1,22 +1,14 @@
-#include "InputParameters.hpp"
-
-#define _USE_MATH_DEFINES
-#include <algorithm>
 #include <iostream>
-#include <fstream>
-#include <iterator>
-#include <string>
-#include <math.h>
-#include <sstream>
+#include <algorithm>
 #include <limits>
-#include <vector>
+#include <fstream>
+#include <string>
 
-using std::string;
-using std::vector;
-using std::ifstream;
-using std::ofstream;
-
+#include "InputParameters.hpp"
 #include "Constants.hpp"
+
+using std::ifstream;
+using std::string;
 
 void get_input(string filename, double &A_C, double &C_W, double &h_C, double &T_init, double &t_final, double &L, double &T_C, double &t_step, double &rho_W, double &D, double &A_tol, double &R_tol, double &T_W, double &E_W) {
     ifstream infile;

--- a/code/stable/nopcm/src/cpp/InputParameters.hpp
+++ b/code/stable/nopcm/src/cpp/InputParameters.hpp
@@ -6,14 +6,11 @@
 #define InputParameters_h
 
 #include <string>
-#include <vector>
-
-using std::string;
-using std::vector;
-using std::ifstream;
-using std::ofstream;
 
 #include "Constants.hpp"
+
+using std::ifstream;
+using std::string;
 
 /** \brief Reads input from a file with the given file name
     \param filename name of the input file

--- a/code/stable/nopcm/src/cpp/OutputFormat.cpp
+++ b/code/stable/nopcm/src/cpp/OutputFormat.cpp
@@ -1,19 +1,10 @@
+#include <iostream>
+#include <string>
+#include <fstream>
+
 #include "OutputFormat.hpp"
 
-#define _USE_MATH_DEFINES
-#include <algorithm>
-#include <iostream>
-#include <fstream>
-#include <iterator>
-#include <string>
-#include <math.h>
-#include <sstream>
-#include <limits>
-#include <vector>
-
 using std::string;
-using std::vector;
-using std::ifstream;
 using std::ofstream;
 
 void write_output(double T_W, double E_W) {

--- a/code/stable/nopcm/src/cpp/OutputFormat.hpp
+++ b/code/stable/nopcm/src/cpp/OutputFormat.hpp
@@ -6,11 +6,8 @@
 #define OutputFormat_h
 
 #include <string>
-#include <vector>
 
 using std::string;
-using std::vector;
-using std::ifstream;
 using std::ofstream;
 
 /** \brief Writes the output values to output.txt

--- a/code/stable/nopcm/src/csharp/Constants.cs
+++ b/code/stable/nopcm/src/csharp/Constants.cs
@@ -2,10 +2,6 @@
     \author Thulasi Jegatheesan
     \brief Provides the structure for holding constant values
 */
-using System;
-using System.IO;
-using System.Collections.Generic;
-
 /** \brief Structure for holding the constant values
 */
 public class Constants {

--- a/code/stable/nopcm/src/csharp/Control.cs
+++ b/code/stable/nopcm/src/csharp/Control.cs
@@ -2,10 +2,6 @@
     \author Thulasi Jegatheesan
     \brief Controls the flow of the program
 */
-using System;
-using System.IO;
-using System.Collections.Generic;
-
 public class Control {
     
     /** \brief Controls the flow of the program

--- a/code/stable/nopcm/src/csharp/InputParameters.cs
+++ b/code/stable/nopcm/src/csharp/InputParameters.cs
@@ -4,7 +4,6 @@
 */
 using System;
 using System.IO;
-using System.Collections.Generic;
 
 public class InputParameters {
     

--- a/code/stable/nopcm/src/csharp/OutputFormat.cs
+++ b/code/stable/nopcm/src/csharp/OutputFormat.cs
@@ -4,7 +4,6 @@
 */
 using System;
 using System.IO;
-using System.Collections.Generic;
 
 public class OutputFormat {
     

--- a/code/stable/nopcm/src/java/SWHS/Constants.java
+++ b/code/stable/nopcm/src/java/SWHS/Constants.java
@@ -4,13 +4,6 @@ package SWHS;
     \author Thulasi Jegatheesan
     \brief Provides the structure for holding constant values
 */
-import java.util.Arrays;
-import java.util.Scanner;
-import java.io.PrintWriter;
-import java.io.FileWriter;
-import java.io.File;
-import java.util.ArrayList;
-
 /** \brief Structure for holding the constant values
 */
 public class Constants {

--- a/code/stable/nopcm/src/java/SWHS/Control.java
+++ b/code/stable/nopcm/src/java/SWHS/Control.java
@@ -4,13 +4,6 @@ package SWHS;
     \author Thulasi Jegatheesan
     \brief Controls the flow of the program
 */
-import java.util.Arrays;
-import java.util.Scanner;
-import java.io.PrintWriter;
-import java.io.FileWriter;
-import java.io.File;
-import java.util.ArrayList;
-
 public class Control {
     
     /** \brief Controls the flow of the program

--- a/code/stable/nopcm/src/java/SWHS/InputParameters.java
+++ b/code/stable/nopcm/src/java/SWHS/InputParameters.java
@@ -4,12 +4,8 @@ package SWHS;
     \author Thulasi Jegatheesan
     \brief Provides the function for reading inputs and the function for checking the physical constraints and software constraints on the input
 */
-import java.util.Arrays;
-import java.util.Scanner;
-import java.io.PrintWriter;
-import java.io.FileWriter;
 import java.io.File;
-import java.util.ArrayList;
+import java.util.Scanner;
 
 public class InputParameters {
     

--- a/code/stable/nopcm/src/java/SWHS/OutputFormat.java
+++ b/code/stable/nopcm/src/java/SWHS/OutputFormat.java
@@ -4,12 +4,9 @@ package SWHS;
     \author Thulasi Jegatheesan
     \brief Provides the function for writing outputs
 */
-import java.util.Arrays;
-import java.util.Scanner;
-import java.io.PrintWriter;
-import java.io.FileWriter;
 import java.io.File;
-import java.util.ArrayList;
+import java.io.FileWriter;
+import java.io.PrintWriter;
 
 public class OutputFormat {
     

--- a/code/stable/nopcm/src/python/Constants.py
+++ b/code/stable/nopcm/src/python/Constants.py
@@ -1,9 +1,6 @@
 ## \file Constants.py
 # \author Thulasi Jegatheesan
 # \brief Provides the structure for holding constant values
-import sys
-import math
-
 ## \brief Structure for holding the constant values
 class Constants:
     L_min = 0.1

--- a/code/stable/nopcm/src/python/Control.py
+++ b/code/stable/nopcm/src/python/Control.py
@@ -2,11 +2,9 @@
 # \author Thulasi Jegatheesan
 # \brief Controls the flow of the program
 import sys
-import math
 
-import Constants
-import InputParameters
 import OutputFormat
+import InputParameters
 
 filename = sys.argv[1]
 A_C, C_W, h_C, T_init, t_final, L, T_C, t_step, rho_W, D, A_tol, R_tol, T_W, E_W = InputParameters.get_input(filename)

--- a/code/stable/nopcm/src/python/InputParameters.py
+++ b/code/stable/nopcm/src/python/InputParameters.py
@@ -1,9 +1,6 @@
 ## \file InputParameters.py
 # \author Thulasi Jegatheesan
 # \brief Provides the function for reading inputs and the function for checking the physical constraints and software constraints on the input
-import sys
-import math
-
 import Constants
 
 ## \brief Reads input from a file with the given file name

--- a/code/stable/nopcm/src/python/OutputFormat.py
+++ b/code/stable/nopcm/src/python/OutputFormat.py
@@ -1,9 +1,6 @@
 ## \file OutputFormat.py
 # \author Thulasi Jegatheesan
 # \brief Provides the function for writing outputs
-import sys
-import math
-
 ## \brief Writes the output values to output.txt
 # \param T_W temperature of the water: the average kinetic energy of the particles within the water (degreeC)
 # \param E_W change in heat energy in the water: change in thermal energy within the water (J)

--- a/code/stable/projectile/src/cpp/Calculations.cpp
+++ b/code/stable/projectile/src/cpp/Calculations.cpp
@@ -1,22 +1,10 @@
-#include "Calculations.hpp"
-
-#define _USE_MATH_DEFINES
-#include <algorithm>
-#include <iostream>
-#include <fstream>
-#include <iterator>
 #include <string>
 #include <math.h>
-#include <sstream>
-#include <limits>
-#include <vector>
+
+#include "Calculations.hpp"
+#include "InputParameters.hpp"
 
 using std::string;
-using std::vector;
-using std::ifstream;
-using std::ofstream;
-
-#include "InputParameters.hpp"
 
 double func_t_flight(InputParameters &inParams, double g_vect) {
     return 2 * inParams.v_launch * sin(inParams.theta) / g_vect;

--- a/code/stable/projectile/src/cpp/Calculations.hpp
+++ b/code/stable/projectile/src/cpp/Calculations.hpp
@@ -6,14 +6,10 @@
 #define Calculations_h
 
 #include <string>
-#include <vector>
-
-using std::string;
-using std::vector;
-using std::ifstream;
-using std::ofstream;
 
 #include "InputParameters.hpp"
+
+using std::string;
 
 /** \brief Calculates flight duration: the time when the projectile lands (s)
     \param inParams structure holding the input values

--- a/code/stable/projectile/src/cpp/Control.cpp
+++ b/code/stable/projectile/src/cpp/Control.cpp
@@ -2,25 +2,13 @@
     \author Samuel J. Crawford, Brooks MacLachlan, and W. Spencer Smith
     \brief Controls the flow of the program
 */
-#define _USE_MATH_DEFINES
-#include <algorithm>
-#include <iostream>
-#include <fstream>
-#include <iterator>
 #include <string>
-#include <math.h>
-#include <sstream>
-#include <limits>
-#include <vector>
 
-using std::string;
-using std::vector;
-using std::ifstream;
-using std::ofstream;
-
-#include "InputParameters.hpp"
 #include "OutputFormat.hpp"
 #include "Calculations.hpp"
+#include "InputParameters.hpp"
+
+using std::string;
 
 /** \brief Controls the flow of the program
     \param argc Number of command-line arguments

--- a/code/stable/projectile/src/cpp/InputParameters.cpp
+++ b/code/stable/projectile/src/cpp/InputParameters.cpp
@@ -1,20 +1,16 @@
+#define _USE_MATH_DEFINES
+
+#include <math.h>
+#include <iostream>
+#include <algorithm>
+#include <limits>
+#include <fstream>
+#include <string>
+
 #include "InputParameters.hpp"
 
-#define _USE_MATH_DEFINES
-#include <algorithm>
-#include <iostream>
-#include <fstream>
-#include <iterator>
-#include <string>
-#include <math.h>
-#include <sstream>
-#include <limits>
-#include <vector>
-
-using std::string;
-using std::vector;
 using std::ifstream;
-using std::ofstream;
+using std::string;
 
 InputParameters::InputParameters(string filename) {
     this->get_input(filename);

--- a/code/stable/projectile/src/cpp/InputParameters.hpp
+++ b/code/stable/projectile/src/cpp/InputParameters.hpp
@@ -5,13 +5,13 @@
 #ifndef InputParameters_h
 #define InputParameters_h
 
-#include <string>
-#include <vector>
+#define _USE_MATH_DEFINES
 
-using std::string;
-using std::vector;
+#include <math.h>
+#include <string>
+
 using std::ifstream;
-using std::ofstream;
+using std::string;
 
 /** \brief Structure for holding the input values
 */

--- a/code/stable/projectile/src/cpp/OutputFormat.cpp
+++ b/code/stable/projectile/src/cpp/OutputFormat.cpp
@@ -1,20 +1,11 @@
-#include "OutputFormat.hpp"
-
-#define _USE_MATH_DEFINES
-#include <algorithm>
 #include <iostream>
 #include <fstream>
-#include <iterator>
 #include <string>
-#include <math.h>
-#include <sstream>
-#include <limits>
-#include <vector>
 
-using std::string;
-using std::vector;
-using std::ifstream;
+#include "OutputFormat.hpp"
+
 using std::ofstream;
+using std::string;
 
 void write_output(string s, double d_offset) {
     ofstream outputfile;

--- a/code/stable/projectile/src/cpp/OutputFormat.hpp
+++ b/code/stable/projectile/src/cpp/OutputFormat.hpp
@@ -6,12 +6,9 @@
 #define OutputFormat_h
 
 #include <string>
-#include <vector>
 
-using std::string;
-using std::vector;
-using std::ifstream;
 using std::ofstream;
+using std::string;
 
 /** \brief Writes the output values to output.txt
     \param s output message as a string

--- a/code/stable/projectile/src/csharp/Calculations.cs
+++ b/code/stable/projectile/src/csharp/Calculations.cs
@@ -3,8 +3,6 @@
     \brief Provides functions for calculating the outputs
 */
 using System;
-using System.IO;
-using System.Collections.Generic;
 
 public class Calculations {
     

--- a/code/stable/projectile/src/csharp/Control.cs
+++ b/code/stable/projectile/src/csharp/Control.cs
@@ -2,10 +2,6 @@
     \author Samuel J. Crawford, Brooks MacLachlan, and W. Spencer Smith
     \brief Controls the flow of the program
 */
-using System;
-using System.IO;
-using System.Collections.Generic;
-
 public class Control {
     
     /** \brief Controls the flow of the program

--- a/code/stable/projectile/src/csharp/InputParameters.cs
+++ b/code/stable/projectile/src/csharp/InputParameters.cs
@@ -4,7 +4,6 @@
 */
 using System;
 using System.IO;
-using System.Collections.Generic;
 
 /** \brief Structure for holding the input values
 */

--- a/code/stable/projectile/src/csharp/OutputFormat.cs
+++ b/code/stable/projectile/src/csharp/OutputFormat.cs
@@ -4,7 +4,6 @@
 */
 using System;
 using System.IO;
-using System.Collections.Generic;
 
 public class OutputFormat {
     

--- a/code/stable/projectile/src/java/Projectile/Calculations.java
+++ b/code/stable/projectile/src/java/Projectile/Calculations.java
@@ -4,13 +4,6 @@ package Projectile;
     \author Samuel J. Crawford, Brooks MacLachlan, and W. Spencer Smith
     \brief Provides functions for calculating the outputs
 */
-import java.util.Arrays;
-import java.util.Scanner;
-import java.io.PrintWriter;
-import java.io.FileWriter;
-import java.io.File;
-import java.util.ArrayList;
-
 public class Calculations {
     
     /** \brief Calculates flight duration: the time when the projectile lands (s)

--- a/code/stable/projectile/src/java/Projectile/Control.java
+++ b/code/stable/projectile/src/java/Projectile/Control.java
@@ -4,13 +4,6 @@ package Projectile;
     \author Samuel J. Crawford, Brooks MacLachlan, and W. Spencer Smith
     \brief Controls the flow of the program
 */
-import java.util.Arrays;
-import java.util.Scanner;
-import java.io.PrintWriter;
-import java.io.FileWriter;
-import java.io.File;
-import java.util.ArrayList;
-
 public class Control {
     
     /** \brief Controls the flow of the program

--- a/code/stable/projectile/src/java/Projectile/InputParameters.java
+++ b/code/stable/projectile/src/java/Projectile/InputParameters.java
@@ -4,12 +4,8 @@ package Projectile;
     \author Samuel J. Crawford, Brooks MacLachlan, and W. Spencer Smith
     \brief Provides the structure for holding input values
 */
-import java.util.Arrays;
-import java.util.Scanner;
-import java.io.PrintWriter;
-import java.io.FileWriter;
 import java.io.File;
-import java.util.ArrayList;
+import java.util.Scanner;
 
 /** \brief Structure for holding the input values
 */

--- a/code/stable/projectile/src/java/Projectile/OutputFormat.java
+++ b/code/stable/projectile/src/java/Projectile/OutputFormat.java
@@ -4,12 +4,9 @@ package Projectile;
     \author Samuel J. Crawford, Brooks MacLachlan, and W. Spencer Smith
     \brief Provides the function for writing outputs
 */
-import java.util.Arrays;
-import java.util.Scanner;
-import java.io.PrintWriter;
-import java.io.FileWriter;
 import java.io.File;
-import java.util.ArrayList;
+import java.io.FileWriter;
+import java.io.PrintWriter;
 
 public class OutputFormat {
     

--- a/code/stable/projectile/src/python/Calculations.py
+++ b/code/stable/projectile/src/python/Calculations.py
@@ -1,10 +1,7 @@
 ## \file Calculations.py
 # \author Samuel J. Crawford, Brooks MacLachlan, and W. Spencer Smith
 # \brief Provides functions for calculating the outputs
-import sys
 import math
-
-import InputParameters
 
 ## \brief Calculates flight duration: the time when the projectile lands (s)
 # \param inParams structure holding the input values

--- a/code/stable/projectile/src/python/Control.py
+++ b/code/stable/projectile/src/python/Control.py
@@ -2,11 +2,10 @@
 # \author Samuel J. Crawford, Brooks MacLachlan, and W. Spencer Smith
 # \brief Controls the flow of the program
 import sys
-import math
 
-import InputParameters
 import OutputFormat
 import Calculations
+import InputParameters
 
 filename = sys.argv[1]
 inParams = InputParameters.InputParameters(filename)

--- a/code/stable/projectile/src/python/InputParameters.py
+++ b/code/stable/projectile/src/python/InputParameters.py
@@ -1,7 +1,6 @@
 ## \file InputParameters.py
 # \author Samuel J. Crawford, Brooks MacLachlan, and W. Spencer Smith
 # \brief Provides the structure for holding input values
-import sys
 import math
 
 ## \brief Structure for holding the input values

--- a/code/stable/projectile/src/python/OutputFormat.py
+++ b/code/stable/projectile/src/python/OutputFormat.py
@@ -1,9 +1,6 @@
 ## \file OutputFormat.py
 # \author Samuel J. Crawford, Brooks MacLachlan, and W. Spencer Smith
 # \brief Provides the function for writing outputs
-import sys
-import math
-
 ## \brief Writes the output values to output.txt
 # \param s output message as a string
 # \param d_offset distance between the target position and the landing position: the offset between the target position and the landing position (m)


### PR DESCRIPTION
This PR makes GOOL generate import statements automatically based on what is used in the file, removing unnecessary imports from the generated code. 

@JacquesCarette @smiths Some of the imports look messy due to their order (ex. the import for `System.Collections.Generic` appearing before the import for `System` in C#). Also the order is inconsistent between files. What would be an appropriate way to sort the imports? Alphabetically?

#1970 needs to be merged first, ac7ab1b is the first new commit.