### PR TITLE
mkQuantDef fix

### DIFF
--- a/code/drasil-theory/Theory/Drasil/DataDefinition.hs
+++ b/code/drasil-theory/Theory/Drasil/DataDefinition.hs
@@ -58,12 +58,12 @@ qdFromDD d = d ^. qd
 -- Used to help make Qdefinitions when uid, term, and symbol come from the same source
 mkQuantDef :: (Quantity c, MayHaveUnit c) => c -> Expr -> QDefinition
 mkQuantDef c e = datadef $ getUnit c
-  where datadef (Just a) = fromEqnSt  (c ^. uid) (c ^. term) EmptyS (symbol c) Real a e
-        datadef Nothing  = fromEqnSt' (c ^. uid) (c ^. term) EmptyS (symbol c) Real e
+  where datadef (Just a) = fromEqnSt  (c ^. uid) (c ^. term) EmptyS (symbol c) (c^.typ) a e
+        datadef Nothing  = fromEqnSt' (c ^. uid) (c ^. term) EmptyS (symbol c) (c^.typ) e
 
 -- Used to help make Qdefinitions when uid and symbol come from the same source, with the term is separate
 mkQuantDef' :: (Quantity c, MayHaveUnit c) => c -> NP -> Expr -> QDefinition
 mkQuantDef' c t e = datadef $ getUnit c
-  where datadef (Just a) = fromEqnSt  (c ^. uid) t EmptyS (symbol c) Real a e
-        datadef Nothing  = fromEqnSt' (c ^. uid) t EmptyS (symbol c) Real e
+  where datadef (Just a) = fromEqnSt  (c ^. uid) t EmptyS (symbol c) (c^.typ) a e
+        datadef Nothing  = fromEqnSt' (c ^. uid) t EmptyS (symbol c) (c^.typ) e
 

--- a/code/stable/glassbr/src/cpp/InputParameters.hpp
+++ b/code/stable/glassbr/src/cpp/InputParameters.hpp
@@ -25,7 +25,7 @@ class InputParameters {
         double SD_z;
         double h;
         double LDF;
-        double GTF;
+        int GTF;
         double SD;
         double AR;
         double w_TNT;

--- a/code/stable/glassbr/src/csharp/InputParameters.cs
+++ b/code/stable/glassbr/src/csharp/InputParameters.cs
@@ -17,7 +17,7 @@ public class InputParameters {
     public double SD_z;
     public double h;
     public double LDF;
-    public double GTF;
+    public int GTF;
     public double SD;
     public double AR;
     public double w_TNT;

--- a/code/stable/glassbr/src/java/GlassBR/InputParameters.java
+++ b/code/stable/glassbr/src/java/GlassBR/InputParameters.java
@@ -19,7 +19,7 @@ public class InputParameters {
     public double SD_z;
     public double h;
     public double LDF;
-    public double GTF;
+    public int GTF;
     public double SD;
     public double AR;
     public double w_TNT;


### PR DESCRIPTION
I noticed one of GlassBR's variables had type `double` when it was supposed to be `int`. Traced it back to `mkQuantDef`, which was overwriting all types to be `Real`.