### PR TITLE
GOOL Cleanup

### DIFF
--- a/code/drasil-gool/GOOL/Drasil/CodeInfo.hs
+++ b/code/drasil-gool/GOOL/Drasil/CodeInfo.hs
@@ -12,7 +12,7 @@ import GOOL.Drasil.Symantics (ProgramSym(..), FileSym(..), PermanenceSym(..),
 import GOOL.Drasil.CodeType (CodeType(Void))
 import GOOL.Drasil.Data (Binding(Dynamic), ScopeTag(..))
 import GOOL.Drasil.Helpers (toCode, toState)
-import GOOL.Drasil.State (GOOLState, lensGStoFS, getPutReturn, addClass, 
+import GOOL.Drasil.State (GOOLState, lensGStoFS, modifyReturn, addClass, 
   updateClassMap)
 
 import Control.Monad.State (State)
@@ -376,12 +376,12 @@ instance StateVarSym CodeInfo where
 
 instance ClassSym CodeInfo where
   type Class CodeInfo = ()
-  buildClass n _ s _ _ = if unCI s == Pub then getPutReturn (addClass n) 
+  buildClass n _ s _ _ = if unCI s == Pub then modifyReturn (addClass n) 
     (toCode ()) else noInfo 
-  enum n _ s = if unCI s == Pub then getPutReturn (addClass n) (toCode ()) else 
+  enum n _ s = if unCI s == Pub then modifyReturn (addClass n) (toCode ()) else 
     noInfo 
   privClass _ _ _ _ = noInfo
-  pubClass n _ _ _ = getPutReturn (addClass n) (toCode ())
+  pubClass n _ _ _ = modifyReturn (addClass n) (toCode ())
 
   docClass _ c = do
     _ <- c
@@ -395,7 +395,7 @@ instance ModuleSym CodeInfo where
   type Module CodeInfo = ()
   buildModule n _ cs = do
     sequence_ cs 
-    getPutReturn (updateClassMap n) (toCode ())
+    modifyReturn (updateClassMap n) (toCode ())
 
 instance BlockCommentSym CodeInfo where
   type BlockComment CodeInfo = ()

--- a/code/drasil-gool/GOOL/Drasil/Helpers.hs
+++ b/code/drasil-gool/GOOL/Drasil/Helpers.hs
@@ -1,9 +1,8 @@
 module GOOL.Drasil.Helpers (angles, doubleQuotedText, hicat, vicat, vibcat, 
   vmap, vimap, emptyIfEmpty, emptyIfNull, toCode, toState, onCodeValue, 
   onStateValue, on2CodeValues, on2StateValues, on3CodeValues, on3StateValues, 
-  on4CodeValues, on4StateValues, on5StateValues, onCodeList, onStateList, 
-  on2StateLists, on1CodeValue1List, on1StateValue1List, getInnerType, 
-  getNestDegree, convType
+  onCodeList, onStateList, on2StateLists, on1CodeValue1List, 
+  on1StateValue1List, getInnerType, getNestDegree, convType
 ) where
 
 import Utils.Drasil (blank)
@@ -15,7 +14,7 @@ import GOOL.Drasil.State (MS)
 
 import Prelude hiding ((<>))
 import Control.Applicative (liftA2, liftA3)
-import Control.Monad (liftM2, liftM3, liftM4, liftM5)
+import Control.Monad (liftM2, liftM3)
 import Control.Monad.State (State)
 import Data.List (intersperse)
 import Text.PrettyPrint.HughesPJ (Doc, vcat, hcat, text, char, doubleQuotes, 
@@ -74,18 +73,6 @@ on3CodeValues = liftA3
 on3StateValues :: (a -> b -> c -> d) -> State s a -> State s b -> State s c ->
   State s d
 on3StateValues = liftM3
-
-on4CodeValues :: Applicative f => (a -> b -> c -> d -> e) -> f a -> f b -> f c 
-  -> f d -> f e
-on4CodeValues f a1 a2 a3 a4 = liftA3 f a1 a2 a3 <*> a4
-
-on4StateValues :: (a -> b -> c -> d -> e) -> State s a -> State s b -> 
-  State s c -> State s d -> State s e
-on4StateValues = liftM4
-
-on5StateValues :: (a -> b -> c -> d -> e -> f) -> State s a -> State s b -> 
-  State s c -> State s d -> State s e -> State s f
-on5StateValues = liftM5
 
 onCodeList :: Monad m => ([a] -> b) -> [m a] -> m b
 onCodeList f as = f <$> sequence as

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer/CSharpRenderer.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer/CSharpRenderer.hs
@@ -64,7 +64,7 @@ import GOOL.Drasil.Data (Terminator(..), ScopeTag(..), FileType(..),
 import GOOL.Drasil.Helpers (toCode, toState, onCodeValue, onStateValue, 
   on2CodeValues, on2StateValues, on3CodeValues, on3StateValues, onCodeList, 
   onStateList, on1CodeValue1List)
-import GOOL.Drasil.State (MS, lensGStoFS, getPutReturn, addLangImport, 
+import GOOL.Drasil.State (MS, lensGStoFS, modifyReturn, addLangImport, 
   setCurrMain)
 
 import Prelude hiding (break,print,(<>),sin,cos,tan,floor)
@@ -634,11 +634,11 @@ csImport :: Label -> CSharpCode (Keyword CSharpCode) -> Doc
 csImport n end = text ("using " ++ n) <> keyDoc end
 
 csInfileType :: (RenderSym repr) => MS (repr (Type repr))
-csInfileType = getPutReturn (addLangImport "System.IO") $ 
+csInfileType = modifyReturn (addLangImport "System.IO") $ 
   typeFromData File "StreamReader" (text "StreamReader")
 
 csOutfileType :: (RenderSym repr) => MS (repr (Type repr))
-csOutfileType = getPutReturn (addLangImport "System.IO") $ 
+csOutfileType = modifyReturn (addLangImport "System.IO") $ 
   typeFromData File "StreamWriter" (text "StreamWriter")
 
 csCast :: MS (CSharpCode (Type CSharpCode)) -> 

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer/CppRenderer.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer/CppRenderer.hs
@@ -66,7 +66,7 @@ import GOOL.Drasil.Helpers (angles, doubleQuotedText, vibcat, emptyIfEmpty,
   on2StateValues, on3CodeValues, on3StateValues, on4CodeValues, onCodeList, 
   onStateList, on2StateLists, on1CodeValue1List, on1StateValue1List)
 import GOOL.Drasil.State (FS, MS, lensGStoFS, lensFStoMS, lensMStoFS, 
-  modifyReturn, addLangImport, getLangImports, addModuleImport, 
+  getPutReturn, addLangImport, getLangImports, addModuleImport, 
   getModuleImports, addHeaderLangImport, getHeaderLangImports, 
   addHeaderModImport, getHeaderModImports, addDefine, getDefines,
   addHeaderDefine, getHeaderDefines, addUsing, getUsing, addHeaderUsing, 
@@ -517,10 +517,10 @@ instance (Pair p) => StatementSym (p CppSrcCode CppHdrCode) where
 
   throw errMsg = on2StateValues pair (throw errMsg) (throw errMsg)
 
-  initState fsmName iState = on2StateValues pair (initState fsmName iState) 
-    (initState fsmName iState)
-  changeState fsmName postState = on2StateValues pair (changeState fsmName 
-    postState) (changeState fsmName postState)
+  initState fsmName iState = on2StateValues pair 
+    (initState fsmName iState) (initState fsmName iState)
+  changeState fsmName postState = on2StateValues pair 
+    (changeState fsmName postState) (changeState fsmName postState)
 
   initObserverList = pair1Val1List initObserverList initObserverList
   addObserver = pair1 addObserver addObserver
@@ -684,8 +684,8 @@ instance (Pair p) => ModuleSym (p CppSrcCode CppHdrCode) where
 instance (Pair p) => InternalMod (p CppSrcCode CppHdrCode) where
   moduleDoc m = moduleDoc $ pfst m
   modFromData n d = on2StateValues pair (modFromData n d) (modFromData n d)
-  updateModuleDoc f m = pair (updateModuleDoc f $ pfst m) (updateModuleDoc f $ 
-    psnd m)
+  updateModuleDoc f m = pair 
+    (updateModuleDoc f $ pfst m) (updateModuleDoc f $ psnd m)
 
 instance (Pair p) => BlockCommentSym (p CppSrcCode CppHdrCode) where
   type BlockComment (p CppSrcCode CppHdrCode) = Doc
@@ -1982,7 +1982,7 @@ instance MethodSym CppHdrCode where
   docMain = mainFunction
 
   function = G.function
-  mainFunction _ = modifyReturn (setScope Pub) $ toCode $ mthd Pub empty
+  mainFunction _ = getPutReturn (setScope Pub) $ toCode $ mthd Pub empty
 
   docFunc = G.docFunc
 
@@ -2093,7 +2093,7 @@ addAlgorithmImport :: MS a -> MS a
 addAlgorithmImport = (>>) $ modify (addLangImport "algorithm")
 
 addFStreamImport :: a -> MS a
-addFStreamImport = modifyReturn (addLangImport "fstream")
+addFStreamImport = getPutReturn (addLangImport "fstream")
 
 addIOStreamImport :: MS a -> MS a
 addIOStreamImport = (>>) $ modify (addLangImport "iostream")

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer/CppRenderer.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer/CppRenderer.hs
@@ -62,11 +62,11 @@ import GOOL.Drasil.Data (Pair(..), Terminator(..), ScopeTag(..),
   ParamData(..), pd, ProgData(..), progD, emptyProg, StateVarData(..), svd, 
   TypeData(..), td, ValData(..), vd, VarData(..), vard)
 import GOOL.Drasil.Helpers (angles, doubleQuotedText, vibcat, emptyIfEmpty, 
-  toCode, toState, onCodeValue, onStateValue, on2CodeValues, 
-  on2StateValues, on3CodeValues, on3StateValues, on4CodeValues, onCodeList, 
-  onStateList, on2StateLists, on1CodeValue1List, on1StateValue1List)
+  toCode, toState, onCodeValue, onStateValue, on2CodeValues, on2StateValues, 
+  on3CodeValues, on3StateValues, onCodeList, onStateList, on2StateLists, 
+  on1CodeValue1List, on1StateValue1List)
 import GOOL.Drasil.State (FS, MS, lensGStoFS, lensFStoMS, lensMStoFS, 
-  getPutReturn, addLangImport, getLangImports, addModuleImport, 
+  modifyReturn, addLangImport, getLangImports, addModuleImport, 
   getModuleImports, addHeaderLangImport, getHeaderLangImports, 
   addHeaderModImport, getHeaderModImports, addDefine, getDefines,
   addHeaderDefine, getHeaderDefines, addUsing, getUsing, addHeaderUsing, 
@@ -1437,11 +1437,11 @@ instance StateVarSym CppSrcCode where
   stateVar s _ _ = onStateValue (on3CodeValues svd (onCodeValue snd s) (toCode 
     empty)) $ zoom lensFStoMS emptyState
   stateVarDef n s p v vl = on3StateValues (\vr val -> on3CodeValues svd 
-    (onCodeValue snd s) (on4CodeValues (cppsStateVarDef n empty) p vr val 
+    (onCodeValue snd s) (cppsStateVarDef n empty <$> p <*> vr <*> val <*>
     endStatement)) (zoom lensFStoMS v) (zoom lensFStoMS vl) 
     (zoom lensFStoMS emptyState)
   constVar n s v vl = on3StateValues (\vr val -> on3CodeValues svd (onCodeValue 
-    snd s) (on4CodeValues (cppsStateVarDef n (text "const")) static_ vr val 
+    snd s) (cppsStateVarDef n (text "const") <$> static_ <*> vr <*> val <*>
     endStatement)) (zoom lensFStoMS v) (zoom lensFStoMS vl) 
     (zoom lensFStoMS emptyState)
   privMVar = G.privMVar
@@ -1982,7 +1982,7 @@ instance MethodSym CppHdrCode where
   docMain = mainFunction
 
   function = G.function
-  mainFunction _ = getPutReturn (setScope Pub) $ toCode $ mthd Pub empty
+  mainFunction _ = modifyReturn (setScope Pub) $ toCode $ mthd Pub empty
 
   docFunc = G.docFunc
 
@@ -2093,7 +2093,7 @@ addAlgorithmImport :: MS a -> MS a
 addAlgorithmImport = (>>) $ modify (addLangImport "algorithm")
 
 addFStreamImport :: a -> MS a
-addFStreamImport = getPutReturn (addLangImport "fstream")
+addFStreamImport = modifyReturn (addLangImport "fstream")
 
 addIOStreamImport :: MS a -> MS a
 addIOStreamImport = (>>) $ modify (addLangImport "iostream")

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer/CppRenderer.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer/CppRenderer.hs
@@ -66,7 +66,7 @@ import GOOL.Drasil.Helpers (angles, doubleQuotedText, vibcat, emptyIfEmpty,
   on2StateValues, on3CodeValues, on3StateValues, on4CodeValues, onCodeList, 
   onStateList, on2StateLists, on1CodeValue1List, on1StateValue1List)
 import GOOL.Drasil.State (FS, MS, lensGStoFS, lensFStoMS, lensMStoFS, 
-  getPutReturn, addLangImport, getLangImports, addModuleImport, 
+  modifyReturn, addLangImport, getLangImports, addModuleImport, 
   getModuleImports, addHeaderLangImport, getHeaderLangImports, 
   addHeaderModImport, getHeaderModImports, addDefine, getDefines,
   addHeaderDefine, getHeaderDefines, addUsing, getUsing, addHeaderUsing, 
@@ -1982,7 +1982,7 @@ instance MethodSym CppHdrCode where
   docMain = mainFunction
 
   function = G.function
-  mainFunction _ = getPutReturn (setScope Pub) $ toCode $ mthd Pub empty
+  mainFunction _ = modifyReturn (setScope Pub) $ toCode $ mthd Pub empty
 
   docFunc = G.docFunc
 
@@ -2093,7 +2093,7 @@ addAlgorithmImport :: MS a -> MS a
 addAlgorithmImport = (>>) $ modify (addLangImport "algorithm")
 
 addFStreamImport :: a -> MS a
-addFStreamImport = getPutReturn (addLangImport "fstream")
+addFStreamImport = modifyReturn (addLangImport "fstream")
 
 addIOStreamImport :: MS a -> MS a
 addIOStreamImport = (>>) $ modify (addLangImport "iostream")

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer/JavaRenderer.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer/JavaRenderer.hs
@@ -64,7 +64,7 @@ import GOOL.Drasil.Data (Terminator(..), ScopeTag(..), FileType(..),
 import GOOL.Drasil.Helpers (angles, toCode, toState, onCodeValue, 
   onStateValue, on2CodeValues, on2StateValues, on3CodeValues, on3StateValues,
   onCodeList, onStateList, on1CodeValue1List)
-import GOOL.Drasil.State (MS, lensGStoFS, getPutReturn, getPutReturnList, 
+import GOOL.Drasil.State (MS, lensGStoFS, modifyReturn, modifyReturnList, 
   addProgNameToPaths, addLangImport, setCurrMain, setOutputsDeclared, 
   isOutputsDeclared)
 
@@ -94,7 +94,7 @@ instance Monad JavaCode where
 
 instance ProgramSym JavaCode where
   type Program JavaCode = ProgData
-  prog n fs = getPutReturnList (map (zoom lensGStoFS) fs) (addProgNameToPaths n)
+  prog n fs = modifyReturnList (map (zoom lensGStoFS) fs) (addProgNameToPaths n)
     (on1CodeValue1List (\end -> progD n . map (packageDocD n end)) endStatement)
 
 instance RenderSym JavaCode
@@ -641,11 +641,11 @@ jStringType :: (RenderSym repr) => MS (repr (Type repr))
 jStringType = toState $ typeFromData String "String" (text "String")
 
 jInfileType :: (RenderSym repr) => MS (repr (Type repr))
-jInfileType = getPutReturn (addLangImport "java.util.Scanner") $ 
+jInfileType = modifyReturn (addLangImport "java.util.Scanner") $ 
   typeFromData File "Scanner" (text "Scanner")
 
 jOutfileType :: (RenderSym repr) => MS (repr (Type repr))
-jOutfileType = getPutReturn (addLangImport "java.io.PrintWriter") $ 
+jOutfileType = modifyReturn (addLangImport "java.io.PrintWriter") $ 
   typeFromData File "PrintWriter" (text "PrintWriter")
 
 jListType :: (RenderSym repr) => repr (Permanence repr) -> MS (repr (Type repr))
@@ -665,11 +665,11 @@ jArrayType = toState $ typeFromData (List $ Object "Object") "Object"
   (text "Object[]")
 
 jFileType :: (RenderSym repr) => MS (repr (Type repr))
-jFileType = getPutReturn (addLangImport "java.io.File") $ typeFromData File 
+jFileType = modifyReturn (addLangImport "java.io.File") $ typeFromData File 
   "File" (text "File")
 
 jFileWriterType :: (RenderSym repr) => MS (repr (Type repr))
-jFileWriterType = getPutReturn (addLangImport "java.io.FileWriter") $ 
+jFileWriterType = modifyReturn (addLangImport "java.io.FileWriter") $ 
   typeFromData File "FileWriter" (text "FileWriter")
 
 jEquality :: MS (JavaCode (Value JavaCode)) -> MS (JavaCode (Value JavaCode)) 

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer/LanguagePolymorphic.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer/LanguagePolymorphic.hs
@@ -83,7 +83,7 @@ import GOOL.Drasil.LanguageRenderer (forLabel, new, observerListName, addExt,
   printDoc, returnDocD, getTermDoc, switchDocD, stateVarDocD, stateVarListDocD, 
   enumDocD, enumElementsDocD, fileDoc', docFuncRepr, commentDocD, commentedItem,
   functionDox, classDox, moduleDox, getterName, setterName, valueList, intValue)
-import GOOL.Drasil.State (FS, MS, lensFStoGS, lensFStoMS, currMain, modifyAfter, 
+import GOOL.Drasil.State (FS, MS, lensFStoGS, lensFStoMS, currMain, modifyAfter,
   modifyReturnFunc, modifyReturnFunc2, addFile, setMainMod, addLangImport, 
   getLangImports, getModuleImports, setFilePath, getFilePath, setModuleName, 
   getModuleName, addParameter)

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer/LanguagePolymorphic.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer/LanguagePolymorphic.hs
@@ -83,8 +83,8 @@ import GOOL.Drasil.LanguageRenderer (forLabel, new, observerListName, addExt,
   getTermDoc, switchDocD, stateVarDocD, stateVarListDocD, enumDocD, 
   enumElementsDocD, fileDoc', docFuncRepr, commentDocD, commentedItem, 
   functionDox, classDox, moduleDox, getterName, setterName, valueList, intValue)
-import GOOL.Drasil.State (FS, MS, lensFStoGS, lensFStoMS, currMain, putAfter, 
-  getPutReturnFunc, getPutReturnFunc2, addFile, setMainMod, addLangImport, 
+import GOOL.Drasil.State (FS, MS, lensFStoGS, lensFStoMS, currMain, modifyAfter, 
+  modifyReturnFunc, modifyReturnFunc2, addFile, setMainMod, addLangImport, 
   getLangImports, getModuleImports, setFilePath, getFilePath, setModuleName, 
   getModuleName, addParameter)
 
@@ -900,7 +900,7 @@ construct n = toState $ typeFromData (Object n) n empty
 
 param :: (RenderSym repr) => (repr (Variable repr) -> Doc) -> 
   MS (repr (Variable repr)) -> MS (repr (Parameter repr))
-param f = getPutReturnFunc (\s v -> addParameter (variableName v) s) 
+param f = modifyReturnFunc (\v s -> addParameter (variableName v) s) 
   (\v -> paramFromData v (f v))
 
 method :: (RenderSym repr) => Label -> Label -> repr (Scope repr) -> 
@@ -1067,7 +1067,7 @@ buildModule' n inc ms cs = S.modFromData n (on3StateValues (\cls lis mis ->
 
 modFromData :: Label -> (Doc -> repr (Module repr)) -> FS Doc -> 
   FS (repr (Module repr))
-modFromData n f d = putAfter (setModuleName n) (onStateValue f d)
+modFromData n f d = modifyAfter (setModuleName n) (onStateValue f d)
 
 -- Files --
 
@@ -1085,7 +1085,7 @@ docMod d a dt = commentedMod (docComment $ moduleDox d a dt <$> getFilePath)
 fileFromData :: (RenderSym repr) => (repr (Module repr) -> FilePath -> 
   repr (RenderFile repr)) -> FileType -> FS FilePath -> 
   FS (repr (Module repr)) -> FS (repr (RenderFile repr))
-fileFromData f ft fp m = getPutReturnFunc2 (\s mdl fpath -> (if isEmpty 
+fileFromData f ft fp m = modifyReturnFunc2 (\mdl fpath s -> (if isEmpty 
   (moduleDoc mdl) then id else (if snd s ^. currMain then over lensFStoGS 
   (setMainMod fpath) else id) . over lensFStoGS (addFile ft fpath) . 
   setFilePath fpath) s) f m fp 

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer/LanguagePolymorphic.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer/LanguagePolymorphic.hs
@@ -76,12 +76,12 @@ import GOOL.Drasil.Helpers (angles, doubleQuotedText, vibcat, emptyIfEmpty,
   toState, onStateValue, on2StateValues, on3StateValues, on4StateValues, 
   onStateList, on2StateLists, on1StateValue1List, getInnerType, convType)
 import GOOL.Drasil.LanguageRenderer (forLabel, new, observerListName, addExt, 
-  moduleDocD, blockDocD, assignDocD, plusEqualsDocD, plusPlusDocD, mkStateVal, 
-  mkVal, mkStateVar, mkVar, mkStaticVar, varDocD, extVarDocD, selfDocD, argDocD,
-  enumElemDocD, classVarCheckStatic, objVarDocD, funcAppDocD, objAccessDocD, 
-  funcDocD, listAccessFuncDocD, constDecDefDocD, printDoc, returnDocD, 
-  getTermDoc, switchDocD, stateVarDocD, stateVarListDocD, enumDocD, 
-  enumElementsDocD, fileDoc', docFuncRepr, commentDocD, commentedItem, 
+  moduleDocD, blockDocD, assignDocD, plusEqualsDocD, plusPlusDocD, mkSt, 
+  mkStNoEnd, mkStateVal, mkVal, mkStateVar, mkVar, mkStaticVar, varDocD, 
+  extVarDocD, selfDocD, argDocD, enumElemDocD, classVarCheckStatic, objVarDocD, 
+  funcAppDocD, objAccessDocD, funcDocD, listAccessFuncDocD, constDecDefDocD, 
+  printDoc, returnDocD, getTermDoc, switchDocD, stateVarDocD, stateVarListDocD, 
+  enumDocD, enumElementsDocD, fileDoc', docFuncRepr, commentDocD, commentedItem,
   functionDox, classDox, moduleDox, getterName, setterName, valueList, intValue)
 import GOOL.Drasil.State (FS, MS, lensFStoGS, lensFStoMS, currMain, modifyAfter, 
   modifyReturnFunc, modifyReturnFunc2, addFile, setMainMod, addLangImport, 
@@ -599,19 +599,19 @@ listSetFunc f v idx setVal = join $ on2StateValues (\i toVal -> funcFromData
 
 printSt :: (RenderSym repr) => MS (repr (Value repr)) -> MS (repr (Value repr))
   -> MS (repr (Statement repr))
-printSt = on2StateValues (\p v -> stateFromData (printDoc p v) Semi)
+printSt = on2StateValues (\p -> mkSt . printDoc p)
 
 state :: (RenderSym repr) => MS (repr (Statement repr)) -> 
   MS (repr (Statement repr))
-state = onStateValue (\s -> stateFromData (statementDoc s <> getTermDoc 
-  (statementTerm s)) Empty)
+state = onStateValue (\s -> mkStNoEnd (statementDoc s <> getTermDoc 
+  (statementTerm s)))
   
 loopState :: (RenderSym repr) => MS (repr (Statement repr)) -> 
   MS (repr (Statement repr))
 loopState = S.state . setEmpty
 
 emptyState :: (RenderSym repr) => MS (repr (Statement repr))
-emptyState = toState $ stateFromData empty Empty
+emptyState = toState $ mkStNoEnd empty
 
 assign :: (RenderSym repr) => Terminator -> MS (repr (Variable repr)) -> 
   MS (repr (Value repr)) -> MS (repr (Statement repr))
@@ -630,11 +630,11 @@ decrement vr vl = vr &= (S.valueOf vr #- vl)
 
 increment :: (RenderSym repr) => MS (repr (Variable repr)) -> 
   MS (repr (Value repr)) -> MS (repr (Statement repr))
-increment = on2StateValues (\vr vl -> stateFromData (plusEqualsDocD vr vl) Semi)
+increment = on2StateValues (\vr -> mkSt . plusEqualsDocD vr)
 
 increment1 :: (RenderSym repr) => MS (repr (Variable repr)) -> 
   MS (repr (Statement repr))
-increment1 = onStateValue (\v -> stateFromData (plusPlusDocD v) Semi)
+increment1 = onStateValue (mkSt . plusPlusDocD)
 
 increment' :: (RenderSym repr) => MS (repr (Variable repr)) -> 
   MS (repr (Value repr)) -> MS (repr (Statement repr))
@@ -650,33 +650,33 @@ decrement1 v = v &= (S.valueOf v #- S.litInt 1)
 
 varDec :: (RenderSym repr) => repr (Permanence repr) -> repr (Permanence repr) 
   -> MS (repr (Variable repr)) -> MS (repr (Statement repr))
-varDec s d = onStateValue (\v -> stateFromData (permDoc (bind $ variableBind v) 
-  <+> getTypeDoc (variableType v) <+> variableDoc v) Semi)
+varDec s d = onStateValue (\v -> mkSt (permDoc (bind $ variableBind v) 
+  <+> getTypeDoc (variableType v) <+> variableDoc v))
   where bind Static = s
         bind Dynamic = d
 
 varDecDef :: (RenderSym repr) => MS (repr (Variable repr)) -> 
   MS (repr (Value repr)) -> MS (repr (Statement repr))
-varDecDef vr = on2StateValues (\vd vl -> stateFromData (statementDoc vd <+> 
-  equals <+> valueDoc vl) Semi) (S.varDec vr)
+varDecDef vr = on2StateValues (\vd vl -> mkSt (statementDoc vd <+> equals <+> 
+  valueDoc vl)) (S.varDec vr)
 
 listDec :: (RenderSym repr) => (repr (Value repr) -> Doc) -> 
   MS (repr (Value repr)) -> MS (repr (Variable repr)) -> 
   MS (repr (Statement repr))
-listDec f vl v = on2StateValues (\sz vd -> stateFromData (statementDoc vd <> f 
-  sz) Semi) vl (S.varDec v)
+listDec f vl v = on2StateValues (\sz vd -> mkSt (statementDoc vd <> f 
+  sz)) vl (S.varDec v)
 
 listDecDef :: (RenderSym repr) => ([repr (Value repr)] -> Doc) -> 
   MS (repr (Variable repr)) -> [MS (repr (Value repr))] -> 
   MS (repr (Statement repr))
-listDecDef f v = on1StateValue1List (\vd vs -> stateFromData (statementDoc vd 
-  <> f vs) Semi) (S.varDec v)
+listDecDef f v = on1StateValue1List (\vd vs -> mkSt (statementDoc vd <> f vs)) 
+  (S.varDec v)
 
 listDecDef' :: (RenderSym repr) => MS (repr (Variable repr)) -> 
   [MS (repr (Value repr))] -> MS (repr (Statement repr))
-listDecDef' v vals = on3StateValues (\vd vr vs -> stateFromData (statementDoc
+listDecDef' v vals = on3StateValues (\vd vr vs -> mkSt (statementDoc
   vd <+> equals <+> new <+> getTypeDoc (variableType vr) <+> braces 
-  (valueList vs)) Semi) (S.varDec v) v (sequence vals)
+  (valueList vs))) (S.varDec v) v (sequence vals)
 
 objDecNew :: (RenderSym repr) => MS (repr (Variable repr)) -> 
   [MS (repr (Value repr))] -> MS (repr (Statement repr))
@@ -688,16 +688,15 @@ objDecNewNoParams v = S.objDecNew v []
 
 constDecDef :: (RenderSym repr) => MS (repr (Variable repr)) -> 
   MS (repr (Value repr)) -> MS (repr (Statement repr))
-constDecDef = on2StateValues (\v def -> stateFromData (constDecDefDocD v def) 
-  Semi)
+constDecDef = on2StateValues (\v -> mkSt . constDecDefDocD v)
 
 discardInput :: (RenderSym repr) => (repr (Value repr) -> Doc) ->
   MS (repr (Statement repr))
-discardInput f = onStateValue (\infn -> stateFromData (f infn) Semi) inputFunc
+discardInput f = onStateValue (mkSt . f) inputFunc
 
 discardFileInput :: (RenderSym repr) => (repr (Value repr) -> Doc) -> 
   MS (repr (Value repr)) -> MS (repr (Statement repr))
-discardFileInput f = onStateValue (\v -> stateFromData (f v) Semi)
+discardFileInput f = onStateValue (mkSt . f)
 
 openFileR :: (RenderSym repr) => (MS (repr (Value repr)) -> 
   MS (repr (Type repr)) -> MS (repr (Value repr))) -> MS (repr (Variable repr)) 
@@ -770,7 +769,7 @@ valState t = onStateValue (\v -> stateFromData (valueDoc v) t)
 
 comment :: (RenderSym repr) => repr (Keyword repr) -> Label -> 
   MS (repr (Statement repr))
-comment cs c = toState $ stateFromData (commentDocD c (keyDoc cs)) Empty
+comment cs c = toState $ mkStNoEnd (commentDocD c (keyDoc cs))
 
 freeError :: String -> String
 freeError l = "Cannot free variables in " ++ l
@@ -819,7 +818,7 @@ ifCond ifst elseif blEnd (c:cs) eBody =
           text "else" <+> ifStart,
           indent $ bodyDoc bd,
           bEnd]) eBody
-    in onStateList (\l -> stateFromData (vcat l) Empty)
+    in onStateList (mkStNoEnd . vcat)
       (ifSect c : map elseIfSect cs ++ [elseSect])
 
 ifNoElse :: (RenderSym repr) => [(MS (repr (Value repr)), 
@@ -829,8 +828,8 @@ ifNoElse bs = S.ifCond bs $ body []
 switch :: (RenderSym repr) => MS (repr (Value repr)) -> 
   [(MS (repr (Value repr)), MS (repr (Body repr)))] -> MS (repr (Body repr)) -> 
   MS (repr (Statement repr))
-switch v cs = on4StateValues (\b val css de -> stateFromData (switchDocD b val 
-  de css) Semi) (S.state break) v (on2StateLists zip (map fst cs) (map snd cs))
+switch v cs = on4StateValues (\b val css de -> mkSt (switchDocD b val de css)) 
+  (S.state break) v (on2StateLists zip (map fst cs) (map snd cs))
 
 switchAsIf :: (RenderSym repr) => MS (repr (Value repr)) -> 
   [(MS (repr (Value repr)), MS (repr (Body repr)))] -> MS (repr (Body repr)) -> 
@@ -847,11 +846,11 @@ for :: (RenderSym repr) => repr (Keyword repr) -> repr (Keyword repr) ->
   MS (repr (Statement repr)) -> MS (repr (Body repr)) -> 
   MS (repr (Statement repr))
 for bStart bEnd sInit vGuard sUpdate = on4StateValues (\initl guard upd bod -> 
-  stateFromData (vcat [
+  mkStNoEnd (vcat [
   forLabel <+> parens (statementDoc initl <> semi <+> valueDoc guard <> semi 
     <+> statementDoc upd) <+> keyDoc bStart,
   indent $ bodyDoc bod,
-  keyDoc bEnd]) Empty) (S.loopState sInit) vGuard (S.loopState sUpdate)
+  keyDoc bEnd])) (S.loopState sInit) vGuard (S.loopState sUpdate)
 
 forRange :: (RenderSym repr) => MS (repr (Variable repr)) -> 
   MS (repr (Value repr)) -> MS (repr (Value repr)) -> MS (repr (Value repr)) -> 
@@ -862,22 +861,22 @@ forRange i initv finalv stepv = S.for (S.varDecDef i initv) (S.valueOf i ?<
 forEach :: (RenderSym repr) => repr (Keyword repr) -> repr (Keyword repr) -> 
   repr (Keyword repr) -> repr (Keyword repr) -> MS (repr (Variable repr)) -> 
   MS (repr (Value repr)) -> MS (repr (Body repr)) -> MS (repr (Statement repr))
-forEach bStart bEnd forEachLabel inLbl = on3StateValues (\e v b -> stateFromData
+forEach bStart bEnd forEachLabel inLbl = on3StateValues (\e v b -> mkStNoEnd
   (vcat [keyDoc forEachLabel <+> parens (getTypeDoc (variableType e) <+> 
     variableDoc e <+> keyDoc inLbl <+> valueDoc v) <+> keyDoc bStart,
   indent $ bodyDoc b,
-  keyDoc bEnd]) Empty) 
+  keyDoc bEnd])) 
 
 while :: (RenderSym repr) => repr (Keyword repr) -> repr (Keyword repr) -> 
   MS (repr (Value repr)) -> MS (repr (Body repr)) -> MS (repr (Statement repr))
-while bStart bEnd = on2StateValues (\v b -> stateFromData (vcat [
+while bStart bEnd = on2StateValues (\v b -> mkStNoEnd (vcat [
   text "while" <+> parens (valueDoc v) <+> keyDoc bStart,
   indent $ bodyDoc b,
-  keyDoc bEnd]) Empty)
+  keyDoc bEnd]))
 
 tryCatch :: (RenderSym repr) => (repr (Body repr) -> repr (Body repr) -> Doc) ->
   MS (repr (Body repr)) -> MS (repr (Body repr)) -> MS (repr (Statement repr))
-tryCatch f = on2StateValues (\tb cb -> stateFromData (f tb cb) Empty)
+tryCatch f = on2StateValues (\tb -> mkStNoEnd . f tb)
 
 checkState :: (RenderSym repr) => Label -> [(MS (repr (Value repr)), 
   MS (repr (Body repr)))] -> MS (repr (Body repr)) -> MS (repr (Statement repr))
@@ -1094,7 +1093,7 @@ fileFromData f ft fp m = modifyReturnFunc2 (\mdl fpath s -> (if isEmpty
 
 setEmpty :: (RenderSym repr) => MS (repr (Statement repr)) -> 
   MS (repr (Statement repr))
-setEmpty = onStateValue (\s -> stateFromData (statementDoc s) Empty)
+setEmpty = onStateValue (mkStNoEnd . statementDoc)
 
 numType :: (RenderSym repr) => repr (Type repr) -> repr (Type repr) -> 
   repr (Type repr)

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer/LanguagePolymorphic.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer/LanguagePolymorphic.hs
@@ -73,8 +73,8 @@ import qualified GOOL.Drasil.Symantics as S (InternalFile(fileFromData),
   InternalMod(modFromData))
 import GOOL.Drasil.Data (Binding(..), Terminator(..), FileType)
 import GOOL.Drasil.Helpers (angles, doubleQuotedText, vibcat, emptyIfEmpty, 
-  toState, onStateValue, on2StateValues, on3StateValues, on4StateValues, 
-  onStateList, on2StateLists, on1StateValue1List, getInnerType, convType)
+  toState, onStateValue, on2StateValues, on3StateValues, onStateList, 
+  on2StateLists, on1StateValue1List, getInnerType, convType)
 import GOOL.Drasil.LanguageRenderer (forLabel, new, observerListName, addExt, 
   moduleDocD, blockDocD, assignDocD, plusEqualsDocD, plusPlusDocD, mkSt, 
   mkStNoEnd, mkStateVal, mkVal, mkStateVar, mkVar, mkStaticVar, varDocD, 
@@ -828,8 +828,8 @@ ifNoElse bs = S.ifCond bs $ body []
 switch :: (RenderSym repr) => MS (repr (Value repr)) -> 
   [(MS (repr (Value repr)), MS (repr (Body repr)))] -> MS (repr (Body repr)) -> 
   MS (repr (Statement repr))
-switch v cs = on4StateValues (\b val css de -> mkSt (switchDocD b val de css)) 
-  (S.state break) v (on2StateLists zip (map fst cs) (map snd cs))
+switch v cs bod = (\b val css de -> mkSt (switchDocD b val de css)) <$>
+  S.state break <*> v <*> on2StateLists zip (map fst cs) (map snd cs) <*> bod
 
 switchAsIf :: (RenderSym repr) => MS (repr (Value repr)) -> 
   [(MS (repr (Value repr)), MS (repr (Body repr)))] -> MS (repr (Body repr)) -> 
@@ -845,12 +845,11 @@ for :: (RenderSym repr) => repr (Keyword repr) -> repr (Keyword repr) ->
   MS (repr (Statement repr)) -> MS (repr (Value repr)) -> 
   MS (repr (Statement repr)) -> MS (repr (Body repr)) -> 
   MS (repr (Statement repr))
-for bStart bEnd sInit vGuard sUpdate = on4StateValues (\initl guard upd bod -> 
-  mkStNoEnd (vcat [
-  forLabel <+> parens (statementDoc initl <> semi <+> valueDoc guard <> semi 
-    <+> statementDoc upd) <+> keyDoc bStart,
+for bStart bEnd sInit vGuard sUpdate b = (\initl guard upd bod -> mkStNoEnd 
+  (vcat [forLabel <+> parens (statementDoc initl <> semi <+> valueDoc guard <> 
+    semi <+> statementDoc upd) <+> keyDoc bStart,
   indent $ bodyDoc bod,
-  keyDoc bEnd])) (S.loopState sInit) vGuard (S.loopState sUpdate)
+  keyDoc bEnd])) <$> S.loopState sInit <*> vGuard <*> S.loopState sUpdate <*> b
 
 forRange :: (RenderSym repr) => MS (repr (Variable repr)) -> 
   MS (repr (Value repr)) -> MS (repr (Value repr)) -> MS (repr (Value repr)) -> 

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer/PythonRenderer.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer/PythonRenderer.hs
@@ -59,8 +59,7 @@ import GOOL.Drasil.Data (Terminator(..), ScopeTag(..), FileType(..),
   ProgData(..), progD, TypeData(..), td, ValData(..), vd, VarData(..), vard)
 import GOOL.Drasil.Helpers (vibcat, emptyIfEmpty, toCode, toState, onCodeValue,
   onStateValue, on2CodeValues, on2StateValues, on3CodeValues, on3StateValues,
-  on5StateValues, onCodeList, onStateList, on2StateLists, on1CodeValue1List, 
-  on1StateValue1List)
+  onCodeList, onStateList, on2StateLists, on1CodeValue1List, on1StateValue1List)
 import GOOL.Drasil.State (MS, lensGStoFS, addLangImport, getLangImports, 
   addModuleImport, getModuleImports, setCurrMain, getClassMap)
 
@@ -516,8 +515,9 @@ instance ControlStatementSym PythonCode where
 
   for _ _ _ _ = error $ "Classic for loops not available in Python, please " ++
     "use forRange, forEach, or while instead"
-  forRange = on5StateValues (\i initv finalv stepv b -> mkStNoEnd (pyForRange 
-    iterInLabel i initv finalv stepv b))
+  forRange it initval finalval step bod = (\i initv finalv stepv b -> mkStNoEnd 
+    (pyForRange iterInLabel i initv finalv stepv b))
+    <$> it <*> initval <*> finalval <*> step <*> bod
   forEach = on3StateValues (\i v b -> mkStNoEnd (pyForEach iterForEachLabel 
     iterInLabel i v b))
   while = on2StateValues (\v b -> mkStNoEnd (pyWhile v b))
@@ -744,9 +744,9 @@ pyTryCatch tryB catchB = vcat [
 pyListSlice :: (RenderSym repr) => MS (repr (Variable repr)) -> 
   MS (repr (Value repr)) -> MS (repr (Value repr)) -> MS (repr (Value repr)) -> 
   MS (repr (Value repr)) -> MS Doc
-pyListSlice = on5StateValues (\vnew vold b e s -> variableDoc vnew <+> equals 
-  <+> valueDoc vold <> brackets (valueDoc b <> colon <> valueDoc e <> colon <> 
-  valueDoc s))
+pyListSlice vn vo beg end step = (\vnew vold b e s -> variableDoc vnew <+> 
+  equals <+> valueDoc vold <> brackets (valueDoc b <> colon <> valueDoc e <> 
+  colon <> valueDoc s)) <$> vn <*> vo <*> beg <*> end <*> step
 
 pyMethod :: (RenderSym repr) => Label -> repr (Variable repr) -> 
   [repr (Parameter repr)] -> repr (Body repr) -> Doc


### PR DESCRIPTION
This does some small clean-up/simplifications in GOOL:

- Replacing the sequence of `get` then `put` for a `State` monad with `modify`, a built-in function that does `get` and `put`. 
- Replacing `stateFromData ... Semi` with `mkSt` and `stateFromData ... Empty` with `mkStNoEnd`
- Reformat C++ pair instance for better readability
- Use `<$>` and `<*>` for lifts when there are more than 3 parameters