### PR TITLE
GOOL Class state

### DIFF
--- a/code/drasil-code/Language/Drasil/Code/Imperative/GenerateGOOL.hs
+++ b/code/drasil-code/Language/Drasil/Code/Imperative/GenerateGOOL.hs
@@ -59,7 +59,7 @@ fApp m s t vl = do
   g <- ask
   let cm = currentModule g
   return $ if m /= cm then extFuncApp m s t vl else if Map.lookup s 
-    (eMap $ codeSpec g) == Just cm then funcApp s t vl else selfFuncApp m s t vl
+    (eMap $ codeSpec g) == Just cm then funcApp s t vl else selfFuncApp s t vl
 
 fAppInOut :: (ProgramSym repr) => String -> String -> [MS (repr (Value repr))] 
   -> [MS (repr (Variable repr))] -> [MS (repr (Variable repr))] -> 
@@ -69,7 +69,7 @@ fAppInOut m n ins outs both = do
   let cm = currentModule g
   return $ if m /= cm then extInOutCall m n ins outs both else if Map.lookup n
     (eMap $ codeSpec g) == Just cm then inOutCall n ins outs both else 
-    selfInOutCall m n ins outs both
+    selfInOutCall n ins outs both
 
 mkParam :: (ProgramSym repr) => MS (repr (Variable repr)) -> 
   MS (repr (Parameter repr))

--- a/code/drasil-code/Language/Drasil/Code/Imperative/GenerateGOOL.hs
+++ b/code/drasil-code/Language/Drasil/Code/Imperative/GenerateGOOL.hs
@@ -11,7 +11,7 @@ import Language.Drasil.CodeSpec (CodeSpec(..), CodeSystInfo(..), Comments(..),
 import GOOL.Drasil (Label, ProgramSym, FileSym(..), TypeSym(..), 
   VariableSym(..), ValueSym(..), ValueExpression(..), StatementSym(..), 
   ParameterSym(..), MethodSym(..), StateVarSym(..), ClassSym(..), ModuleSym(..),
-  CodeType(..), GOOLState, FS, MS)
+  CodeType(..), GOOLState, FS, CS, MS)
 
 import qualified Data.Map as Map (lookup)
 import Data.Maybe (maybe)
@@ -19,7 +19,7 @@ import Control.Monad.Reader (Reader, ask, withReader)
 
 genModule :: (ProgramSym repr) => Name -> String
   -> Maybe (Reader DrasilState [MS (repr (Method repr))])
-  -> Maybe (Reader DrasilState [FS (repr (Class repr))])
+  -> Maybe (Reader DrasilState [CS (repr (Class repr))])
   -> Reader DrasilState (FS (repr (RenderFile repr)))
 genModule n desc maybeMs maybeCs = do
   g <- ask
@@ -44,8 +44,8 @@ genDoxConfig n s = do
   return [doxConfig n s v | not (null cms)]
 
 publicClass :: (ProgramSym repr) => String -> Label -> Maybe Label -> 
-  [FS (repr (StateVar repr))] -> Reader DrasilState [MS (repr (Method repr))] 
-  -> Reader DrasilState (FS (repr (Class repr)))
+  [CS (repr (StateVar repr))] -> Reader DrasilState [MS (repr (Method repr))] 
+  -> Reader DrasilState (CS (repr (Class repr)))
 publicClass desc n l vs mths = do
   g <- ask
   ms <- mths

--- a/code/drasil-code/Language/Drasil/Code/Imperative/Import.hs
+++ b/code/drasil-code/Language/Drasil/Code/Imperative/Import.hs
@@ -79,7 +79,7 @@ inputVariable Bundled Var v = do
   let inModName = "InputParameters"
   ip <- mkVar (codevar inParams)
   return $ if currentModule g == inModName && Map.member inModName 
-    (eMap $ codeSpec g) then objVarSelf inModName v else ip $-> v
+    (eMap $ codeSpec g) then objVarSelf v else ip $-> v
 inputVariable Bundled Const v = do
   ip <- mkVar (codevar inParams)
   classVariable ip v
@@ -120,9 +120,9 @@ publicFunc :: (ProgramSym repr, HasUID c, HasCodeType c, CodeIdea c) =>
 publicFunc n t = genMethod (function n public static_ t) n
 
 privateMethod :: (ProgramSym repr, HasUID c, HasCodeType c, CodeIdea c) => 
-  Label -> Label -> MS (repr (Type repr)) -> String -> [c] -> Maybe String -> 
+  Label -> MS (repr (Type repr)) -> String -> [c] -> Maybe String -> 
   [MS (repr (Block repr))] -> Reader DrasilState (MS (repr (Method repr)))
-privateMethod c n t = genMethod (method n c private dynamic_ t) n
+privateMethod n t = genMethod (method n private dynamic_ t) n
 
 publicInOutFunc :: (ProgramSym repr, HasUID c, HasCodeType c, CodeIdea c, Eq c) 
   => Label -> String -> [c] -> [c] -> [MS (repr (Block repr))] -> 
@@ -130,15 +130,15 @@ publicInOutFunc :: (ProgramSym repr, HasUID c, HasCodeType c, CodeIdea c, Eq c)
 publicInOutFunc n = genInOutFunc (inOutFunc n) (docInOutFunc n) public static_ n
 
 privateInOutMethod :: (ProgramSym repr, HasUID c, HasCodeType c, CodeIdea c,
-  Eq c) => Label -> Label -> String -> [c] -> [c] -> [MS (repr (Block repr))] 
+  Eq c) => Label -> String -> [c] -> [c] -> [MS (repr (Block repr))] 
   -> Reader DrasilState (MS (repr (Method repr)))
-privateInOutMethod c n = genInOutFunc (inOutMethod n c) (docInOutMethod n c) 
+privateInOutMethod n = genInOutFunc (inOutMethod n) (docInOutMethod n) 
   private dynamic_ n
 
 genConstructor :: (ProgramSym repr, HasUID c, HasCodeType c, CodeIdea c) => 
   Label -> String -> [c] -> [MS (repr (Block repr))] -> 
   Reader DrasilState (MS (repr (Method repr)))
-genConstructor n desc p = genMethod (constructor n) n desc p Nothing
+genConstructor n desc p = genMethod constructor n desc p Nothing
 
 genMethod :: (ProgramSym repr, HasUID c, HasCodeType c, CodeIdea c) => 
   ([MS (repr (Parameter repr))] -> MS (repr (Body repr)) -> 

--- a/code/drasil-code/Language/Drasil/Code/Imperative/Modules.hs
+++ b/code/drasil-code/Language/Drasil/Code/Imperative/Modules.hs
@@ -36,7 +36,7 @@ import GOOL.Drasil (ProgramSym, FileSym(..), BodySym(..), BlockSym(..),
   PermanenceSym(..), TypeSym(..), VariableSym(..), ValueSym(..), 
   BooleanExpression(..), StatementSym(..), ControlStatementSym(..), 
   ScopeSym(..), MethodSym(..), StateVarSym(..), ClassSym(..), ScopeTag(..), 
-  convType, FS, MS)
+  convType, FS, CS, MS)
 
 import Prelude hiding (print)
 import Data.List (intersperse, intercalate, partition)
@@ -153,7 +153,7 @@ genInputModCombined :: (ProgramSym repr) =>
 genInputModCombined = do
   ipDesc <- modDesc inputParametersDesc
   let cname = "InputParameters"
-      genMod :: (ProgramSym repr) => Maybe (FS (repr (Class repr))) ->
+      genMod :: (ProgramSym repr) => Maybe (CS (repr (Class repr))) ->
         Reader DrasilState (FS (repr (RenderFile repr)))
       genMod Nothing = genModule cname ipDesc (Just $ concat <$> mapM (fmap 
         maybeToList) [genInputFormat Pub, genInputDerived 
@@ -165,12 +165,12 @@ genInputModCombined = do
 
 constVarFunc :: (ProgramSym repr) => ConstantRepr -> String ->
   (MS (repr (Variable repr)) -> MS (repr (Value repr)) -> 
-  FS (repr (StateVar repr)))
+  CS (repr (StateVar repr)))
 constVarFunc Var n = stateVarDef n public dynamic_
 constVarFunc Const n = constVar n public
 
 genInputClass :: (ProgramSym repr) => 
-  Reader DrasilState (Maybe (FS (repr (Class repr))))
+  Reader DrasilState (Maybe (CS (repr (Class repr))))
 genInputClass = do
   g <- ask
   let ins = inputs $ csi $ codeSpec g
@@ -187,7 +187,7 @@ genInputClass = do
         genInputDerived Priv, 
         genInputConstraints Priv]
       genClass :: (ProgramSym repr) => [CodeChunk] -> [CodeDefinition] -> 
-        Reader DrasilState (Maybe (FS (repr (Class repr))))
+        Reader DrasilState (Maybe (CS (repr (Class repr))))
       genClass [] [] = return Nothing
       genClass inps csts = do
         vals <- mapM (convExpr . codeEquat) csts
@@ -389,13 +389,13 @@ genConstMod = do
     genConstClass)
 
 genConstClass :: (ProgramSym repr) => 
-  Reader DrasilState (Maybe (FS (repr (Class repr))))
+  Reader DrasilState (Maybe (CS (repr (Class repr))))
 genConstClass = do
   g <- ask
   let cs = constants $ csi $ codeSpec g
       cname = "Constants"
       genClass :: (ProgramSym repr) => [CodeDefinition] -> Reader DrasilState (Maybe 
-        (FS (repr (Class repr))))
+        (CS (repr (Class repr))))
       genClass [] = return Nothing 
       genClass vs = do
         vals <- mapM (convExpr . codeEquat) vs 

--- a/code/drasil-code/Language/Drasil/Code/Imperative/Modules.hs
+++ b/code/drasil-code/Language/Drasil/Code/Imperative/Modules.hs
@@ -223,7 +223,7 @@ genInputDerived s = do
   g <- ask
   let dvals = derivedInputs $ csi $ codeSpec g
       getFunc Pub = publicInOutFunc
-      getFunc Priv = privateInOutMethod "InputParameters"
+      getFunc Priv = privateInOutMethod
       genDerived :: (ProgramSym repr) => Maybe String -> Reader DrasilState 
         (Maybe (MS (repr (Method repr))))
       genDerived Nothing = return Nothing
@@ -242,7 +242,7 @@ genInputConstraints s = do
   g <- ask
   let cm = cMap $ csi $ codeSpec g
       getFunc Pub = publicFunc
-      getFunc Priv = privateMethod "InputParameters"
+      getFunc Priv = privateMethod
       genConstraints :: (ProgramSym repr) => Maybe String -> Reader DrasilState 
         (Maybe (MS (repr (Method repr))))
       genConstraints Nothing = return Nothing
@@ -354,7 +354,7 @@ genInputFormat s = do
   g <- ask
   dd <- genDataDesc
   let getFunc Pub = publicInOutFunc
-      getFunc Priv = privateInOutMethod "InputParameters"
+      getFunc Priv = privateInOutMethod
       genInFormat :: (ProgramSym repr) => Maybe String -> Reader DrasilState 
         (Maybe (MS (repr (Method repr))))
       genInFormat Nothing = return Nothing

--- a/code/drasil-gool/GOOL/Drasil.hs
+++ b/code/drasil-gool/GOOL/Drasil.hs
@@ -8,7 +8,7 @@ module GOOL.Drasil (Label, ProgramSym(..), FileSym(..),
   ModuleSym(..), BlockCommentSym(..), 
   ScopeTag(..), ProgData(..), FileData(..), ModData(..),
   CodeType(..),
-  GOOLState(..), GS, FS, MS, headers, sources, mainMod, 
+  GOOLState(..), GS, FS, CS, MS, headers, sources, mainMod, 
   initialState,
   convType, onStateValue, onCodeList,
   unCI, unPC, unJC, unCSC, unCPPC
@@ -26,7 +26,7 @@ import GOOL.Drasil.Data (ScopeTag(..), FileData(..), ModData(..), ProgData(..))
 
 import GOOL.Drasil.CodeType (CodeType(..))
 
-import GOOL.Drasil.State (GOOLState(..), GS, FS, MS, headers, 
+import GOOL.Drasil.State (GOOLState(..), GS, FS, CS, MS, headers, 
   sources, mainMod, initialState)
 
 import GOOL.Drasil.Helpers (convType, onStateValue, onCodeList)

--- a/code/drasil-gool/GOOL/Drasil/CodeInfo.hs
+++ b/code/drasil-gool/GOOL/Drasil/CodeInfo.hs
@@ -107,12 +107,12 @@ instance VariableSym CodeInfo where
   staticVar _ _ = noInfo
   const _ _ = noInfo
   extVar _ _ _ = noInfo
-  self _ = noInfo
+  self = noInfo
   enumVar _ _ = noInfo
   classVar _ _ = noInfo
   extClassVar _ _ = noInfo
   objVar _ _ = noInfo
-  objVarSelf _ _ = noInfo
+  objVarSelf _ = noInfo
   listVar _ _ _ = noInfo
   listOf _ _ = noInfo
   iterVar _ _ = noInfo
@@ -187,7 +187,7 @@ instance BooleanExpression CodeInfo where
 instance ValueExpression CodeInfo where
   inlineIf _ _ _ = noInfo
   funcApp _ _ _ = noInfo
-  selfFuncApp _ _ _ _ = noInfo
+  selfFuncApp _ _ _ = noInfo
   extFuncApp _ _ _ _ = noInfo
   newObj _ _ = noInfo
   extNewObj _ _ _ = noInfo
@@ -199,7 +199,7 @@ instance Selector CodeInfo where
   objAccess _ _ = noInfo
   ($.) _ _ = noInfo
 
-  selfAccess _ _ = noInfo
+  selfAccess _ = noInfo
 
   listIndexExists _ _ = noInfo
   argExists _ = noInfo
@@ -299,7 +299,7 @@ instance StatementSym CodeInfo where
   addObserver _ = noInfo
 
   inOutCall _ _ _ _ = noInfo
-  selfInOutCall _ _ _ _ _ = noInfo
+  selfInOutCall _ _ _ _ = noInfo
   extInOutCall _ _ _ _ _ = noInfo
 
   multi _ = noInfo
@@ -342,13 +342,13 @@ instance ParameterSym CodeInfo where
 
 instance MethodSym CodeInfo where
   type Method CodeInfo = ()
-  method _ _ _ _ _ _ _ = noInfo
-  getMethod _ _ = noInfo
-  setMethod _ _ = noInfo
-  privMethod _ _ _ _ _ = noInfo
-  pubMethod _ _ _ _ _ = noInfo
-  constructor _ _ _ = noInfo
-  destructor _ _ = noInfo
+  method _ _ _ _ _ _ = noInfo
+  getMethod _ = noInfo
+  setMethod _ = noInfo
+  privMethod _ _ _ _ = noInfo
+  pubMethod _ _ _ _ = noInfo
+  constructor _ _ = noInfo
+  destructor _ = noInfo
 
   docMain _ = noInfo
 
@@ -357,9 +357,9 @@ instance MethodSym CodeInfo where
 
   docFunc _ _ _ _ = noInfo
 
-  inOutMethod _ _ _ _ _ _ _ _= noInfo
+  inOutMethod _ _ _ _ _ _ _= noInfo
 
-  docInOutMethod _ _ _ _ _ _ _ _ _ = noInfo
+  docInOutMethod _ _ _ _ _ _ _ _ = noInfo
 
   inOutFunc _ _ _ _ _ _ _ = noInfo
 

--- a/code/drasil-gool/GOOL/Drasil/CodeInfo.hs
+++ b/code/drasil-gool/GOOL/Drasil/CodeInfo.hs
@@ -12,8 +12,8 @@ import GOOL.Drasil.Symantics (ProgramSym(..), FileSym(..), PermanenceSym(..),
 import GOOL.Drasil.CodeType (CodeType(Void))
 import GOOL.Drasil.Data (Binding(Dynamic), ScopeTag(..))
 import GOOL.Drasil.Helpers (toCode, toState)
-import GOOL.Drasil.State (GOOLState, lensGStoFS, modifyReturn, addClass, 
-  updateClassMap)
+import GOOL.Drasil.State (GOOLState, lensGStoFS, lensFStoCS, modifyReturn, 
+  addClass, updateClassMap)
 
 import Control.Monad.State (State)
 import qualified Control.Monad.State as S (get)
@@ -394,7 +394,7 @@ instance ClassSym CodeInfo where
 instance ModuleSym CodeInfo where
   type Module CodeInfo = ()
   buildModule n _ cs = do
-    sequence_ cs 
+    mapM_ (zoom lensFStoCS) cs 
     modifyReturn (updateClassMap n) (toCode ())
 
 instance BlockCommentSym CodeInfo where

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer/CppRenderer.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer/CppRenderer.hs
@@ -278,12 +278,12 @@ instance (Pair p) => VariableSym (p CppSrcCode CppHdrCode) where
   staticVar n = pair1 (staticVar n) (staticVar n)
   const n = pair1 (const n) (const n)
   extVar l n = pair1 (extVar l n) (extVar l n)
-  self l = on2StateValues pair (self l) (self l)
+  self = on2StateValues pair self self
   enumVar e en = on2StateValues pair (enumVar e en) (enumVar e en)
   classVar = pair2 classVar classVar
   extClassVar = pair2 extClassVar extClassVar
   objVar = pair2 objVar objVar
-  objVarSelf l = pair1 (objVarSelf l) (objVarSelf l)
+  objVarSelf = pair1 objVarSelf objVarSelf
   listVar n p = pair1 (listVar n (pfst p)) (listVar n (psnd p))
   listOf n = pair1 (n `listOf`) (n `listOf`)
   iterVar l = pair1 (iterVar l) (iterVar l)
@@ -362,7 +362,7 @@ instance (Pair p) => BooleanExpression (p CppSrcCode CppHdrCode) where
 instance (Pair p) => ValueExpression (p CppSrcCode CppHdrCode) where
   inlineIf = pair3 inlineIf inlineIf
   funcApp n = pair1Val1List (funcApp n) (funcApp n)
-  selfFuncApp c n = pair1Val1List (selfFuncApp c n) (selfFuncApp c n)
+  selfFuncApp n = pair1Val1List (selfFuncApp n) (selfFuncApp n)
   extFuncApp l n = pair1Val1List (extFuncApp l n) (extFuncApp l n)
   newObj = pair1Val1List newObj newObj
   extNewObj l = pair1Val1List (extNewObj l) (extNewObj l)
@@ -386,7 +386,7 @@ instance (Pair p) => Selector (p CppSrcCode CppHdrCode) where
   objAccess = pair2 objAccess objAccess
   ($.) = pair2 ($.) ($.)
 
-  selfAccess l = pair1 (selfAccess l) (selfAccess l)
+  selfAccess = pair1 selfAccess selfAccess
 
   listIndexExists = pair2 listIndexExists listIndexExists
   argExists i = on2StateValues pair (argExists i) (argExists i)
@@ -526,7 +526,7 @@ instance (Pair p) => StatementSym (p CppSrcCode CppHdrCode) where
   addObserver = pair1 addObserver addObserver
 
   inOutCall n = pair3Lists (inOutCall n) (inOutCall n)
-  selfInOutCall c n = pair3Lists (selfInOutCall c n) (selfInOutCall c n)
+  selfInOutCall n = pair3Lists (selfInOutCall n) (selfInOutCall n)
   extInOutCall m n = pair3Lists (extInOutCall m n) (extInOutCall m n) 
 
   multi = pair1List multi multi
@@ -590,14 +590,14 @@ instance (Pair p) => InternalParam (p CppSrcCode CppHdrCode) where
 
 instance (Pair p) => MethodSym (p CppSrcCode CppHdrCode) where
   type Method (p CppSrcCode CppHdrCode) = MethodData
-  method n c s p = pairValListVal
-    (method n c (pfst s) (pfst p)) (method n c (psnd s) (psnd p))
-  getMethod c = pair1 (getMethod c) (getMethod c)
-  setMethod c = pair1 (setMethod c) (setMethod c)
-  privMethod n c = pairValListVal (privMethod n c) (privMethod n c)
-  pubMethod n c = pairValListVal (pubMethod n c) (pubMethod n c)
-  constructor n = pair1List1Val (constructor n) (constructor n)
-  destructor n = pair1List (destructor n) (destructor n) . map (zoom lensMStoCS)
+  method n s p = pairValListVal
+    (method n (pfst s) (pfst p)) (method n (psnd s) (psnd p))
+  getMethod = pair1 getMethod getMethod
+  setMethod = pair1 setMethod setMethod
+  privMethod n = pairValListVal (privMethod n) (privMethod n)
+  pubMethod n = pairValListVal (pubMethod n) (pubMethod n)
+  constructor = pair1List1Val constructor constructor
+  destructor = pair1List destructor destructor . map (zoom lensMStoCS)
 
   docMain = pair1 docMain docMain
 
@@ -608,13 +608,13 @@ instance (Pair p) => MethodSym (p CppSrcCode CppHdrCode) where
   docFunc desc pComms rComm = pair1 (docFunc desc pComms rComm) 
     (docFunc desc pComms rComm)
 
-  inOutMethod n c s p = pair3Lists1Val 
-    (inOutMethod n c (pfst s) (pfst p)) (inOutMethod n c (psnd s) (psnd p)) 
+  inOutMethod n s p = pair3Lists1Val 
+    (inOutMethod n (pfst s) (pfst p)) (inOutMethod n (psnd s) (psnd p)) 
 
-  docInOutMethod n c s p desc is os bs = pair3Lists1Val
-    (\ins outs both -> docInOutMethod n c (pfst s) (pfst p) desc (zip (map fst 
+  docInOutMethod n s p desc is os bs = pair3Lists1Val
+    (\ins outs both -> docInOutMethod n (pfst s) (pfst p) desc (zip (map fst 
       is) ins) (zip (map fst os) outs) (zip (map fst bs) both))
-    (\ins outs both -> docInOutMethod n c (psnd s) (psnd p) desc (zip (map fst 
+    (\ins outs both -> docInOutMethod n (psnd s) (psnd p) desc (zip (map fst 
       is) ins) (zip (map fst os) outs) (zip (map fst bs) both))
     (map snd is) (map snd os) (map snd bs)
 
@@ -629,8 +629,8 @@ instance (Pair p) => MethodSym (p CppSrcCode CppHdrCode) where
     (map snd is) (map snd os) (map snd bs)
   
 instance (Pair p) => InternalMethod (p CppSrcCode CppHdrCode) where
-  intMethod m n c s p = pairValListVal
-    (intMethod m n c (pfst s) (pfst p)) (intMethod m n c (psnd s) (psnd p))
+  intMethod m n s p = pairValListVal
+    (intMethod m n (pfst s) (pfst p)) (intMethod m n (psnd s) (psnd p))
   intFunc m n s p = pairValListVal
     (intFunc m n (pfst s) (pfst p)) (intFunc m n (psnd s) (psnd p))
   commentedFunc = pair2 commentedFunc commentedFunc
@@ -1069,7 +1069,7 @@ instance VariableSym CppSrcCode where
     addModuleImport) (Map.lookup (getTypeString t) cm) $ 
     classVar (toState t) v) c getClassMap
   objVar = G.objVar
-  objVarSelf _ = onStateValue (\v -> mkVar ("this->"++variableName v) 
+  objVarSelf = onStateValue (\v -> mkVar ("this->"++variableName v) 
     (variableType v) (text "this->" <> variableDoc v))
   listVar = G.listVar
   listOf = G.listOf
@@ -1149,7 +1149,7 @@ instance BooleanExpression CppSrcCode where
 instance ValueExpression CppSrcCode where
   inlineIf = G.inlineIf
   funcApp = G.funcApp
-  selfFuncApp c = cppSelfFuncApp (self c)
+  selfFuncApp = cppSelfFuncApp self
   extFuncApp l n t vs = modify (addModuleImport l) >> funcApp n t vs
   newObj = G.newObj newObjDocD'
   extNewObj l t vs = modify (addModuleImport l) >> newObj t vs
@@ -1323,7 +1323,7 @@ instance StatementSym CppSrcCode where
   addObserver = G.addObserver
 
   inOutCall = cppInOutCall funcApp
-  selfInOutCall c = cppInOutCall (selfFuncApp c)
+  selfInOutCall = cppInOutCall selfFuncApp
   extInOutCall m = cppInOutCall (extFuncApp m)
 
   multi = onStateList (on1CodeValue1List multiStateDocD endStatement)
@@ -1387,8 +1387,8 @@ instance MethodSym CppSrcCode where
   setMethod = G.setMethod
   privMethod = G.privMethod
   pubMethod = G.pubMethod
-  constructor n = G.constructor n n
-  destructor n vs = 
+  constructor ps b = getClassName >>= (\n -> G.constructor n ps b)
+  destructor vs = 
     let i = var "i" int
         deleteStatements = map (onStateValue (onCodeValue destructSts) . 
           zoom lensMStoCS) vs
@@ -1396,7 +1396,7 @@ instance MethodSym CppSrcCode where
         dbody = on2StateValues (on2CodeValues emptyIfEmpty)
           (onStateList (onCodeList (vcat . map fst)) deleteStatements) $
           bodyStatements $ loopIndexDec : deleteStatements
-    in pubMethod ('~':n) n void [] dbody
+    in getClassName >>= (\n -> pubMethod ('~':n) void [] dbody)
 
   docMain b = commentedFunc (docComment $ toState $ functionDox 
     "Controls the flow of the program" 
@@ -1413,16 +1413,16 @@ instance MethodSym CppSrcCode where
 
   docFunc = G.docFunc
 
-  inOutMethod n c = cppsInOut (method n c)
+  inOutMethod n = cppsInOut (method n)
 
-  docInOutMethod n c = G.docInOutFunc (inOutMethod n c)
+  docInOutMethod n = G.docInOutFunc (inOutMethod n)
 
   inOutFunc n = cppsInOut (function n)
 
   docInOutFunc n = G.docInOutFunc (inOutFunc n)
 
 instance InternalMethod CppSrcCode where
-  intMethod m n _ s _ t ps b = modify (setScope (snd $ unCPPSC s) . if m then 
+  intMethod m n s _ t ps b = modify (setScope (snd $ unCPPSC s) . if m then 
     setCurrMain else id) >> (\c tp pms bod -> methodFromData 
     (snd $ unCPPSC s) $ cppsMethod n c tp pms bod blockStart blockEnd) <$>
     getClassName <*> t <*> sequence ps <*> b
@@ -1458,7 +1458,7 @@ instance InternalStateVar CppSrcCode where
 instance ClassSym CppSrcCode where
   type Class CppSrcCode = Doc
   buildClass n _ _ vs fs = modify (setClassName n) >> on2StateLists cppsClass 
-    vs (map (zoom lensCStoMS) $ fs ++ [destructor n vs])
+    vs (map (zoom lensCStoMS) $ fs ++ [destructor vs])
   enum _ _ _ = toState $ toCode empty
   privClass = G.privClass
   pubClass = G.pubClass
@@ -1678,12 +1678,12 @@ instance VariableSym CppHdrCode where
   staticVar = G.staticVar
   const _ _ = mkStateVar "" void empty
   extVar _ _ _ = mkStateVar "" void empty
-  self _ = mkStateVar "" void empty
+  self = mkStateVar "" void empty
   enumVar _ _ = mkStateVar "" void empty
   classVar _ _ = mkStateVar "" void empty
   extClassVar _ _ = mkStateVar "" void empty
   objVar _ _ = mkStateVar "" void empty
-  objVarSelf _ _ = mkStateVar "" void empty
+  objVarSelf _ = mkStateVar "" void empty
   listVar _ _ _ = mkStateVar "" void empty
   listOf _ _ = mkStateVar "" void empty
   iterVar _ _ = mkStateVar "" void empty
@@ -1762,7 +1762,7 @@ instance BooleanExpression CppHdrCode where
 instance ValueExpression CppHdrCode where
   inlineIf _ _ _ = mkStateVal void empty
   funcApp _ _ _ = mkStateVal void empty
-  selfFuncApp _ _ _ _ = mkStateVal void empty
+  selfFuncApp _ _ _ = mkStateVal void empty
   extFuncApp _ _ _ _ = mkStateVal void empty
   newObj _ _ = mkStateVal void empty
   extNewObj _ _ _ = mkStateVal void empty
@@ -1786,7 +1786,7 @@ instance Selector CppHdrCode where
   objAccess _ _ = mkStateVal void empty
   ($.) _ _ = mkStateVal void empty
 
-  selfAccess _ _ = mkStateVal void empty
+  selfAccess _ = mkStateVal void empty
 
   listIndexExists _ _ = mkStateVal void empty
   argExists _ = mkStateVal void empty
@@ -1917,7 +1917,7 @@ instance StatementSym CppHdrCode where
   addObserver _ = emptyState
 
   inOutCall _ _ _ _ = emptyState
-  selfInOutCall _ _ _ _ _ = emptyState
+  selfInOutCall _ _ _ _ = emptyState
   extInOutCall _ _ _ _ _ = emptyState
 
   multi _ = emptyState
@@ -1970,17 +1970,18 @@ instance InternalParam CppHdrCode where
 instance MethodSym CppHdrCode where
   type Method CppHdrCode = MethodData
   method = G.method
-  getMethod c v = v >>= (\v' -> method (getterName $ 
-    variableName v') c public dynamic_ (toState $ variableType v') [] 
-    (toState $ toCode empty))
-  setMethod c v = v >>= (\v' -> method (setterName $ 
-    variableName v') c public dynamic_ void [param v] (toState $ toCode empty))
+  getMethod v = v >>= (\v' -> method (getterName $ variableName v') public 
+    dynamic_ (toState $ variableType v') [] (toState $ toCode empty))
+  setMethod v = v >>= (\v' -> method (setterName $ variableName v') public 
+    dynamic_ void [param v] (toState $ toCode empty))
   privMethod = G.privMethod
   pubMethod = G.pubMethod
-  constructor n = G.constructor n n
-  destructor n vars = on1StateValue1List (\m vs -> toCode $ mthd Pub 
+  constructor ps b = getClassName >>= (\n -> G.constructor n ps b)
+  destructor vars = on1StateValue1List (\m vs -> toCode $ mthd Pub 
     (emptyIfEmpty (vcat (map (statementDoc . onCodeValue destructSts) vs)) 
-    (methodDoc m))) (pubMethod ('~':n) n void [] (toState (toCode empty)) :: MS (CppHdrCode (Method CppHdrCode))) (map (zoom lensMStoCS) vars)
+    (methodDoc m))) (getClassName >>= (\n -> pubMethod ('~':n) void [] 
+    (toState (toCode empty)) :: MS (CppHdrCode (Method CppHdrCode)))) 
+    (map (zoom lensMStoCS) vars)
 
   docMain = mainFunction
 
@@ -1989,16 +1990,16 @@ instance MethodSym CppHdrCode where
 
   docFunc = G.docFunc
 
-  inOutMethod n c = cpphInOut (method n c)
+  inOutMethod n = cpphInOut (method n)
 
-  docInOutMethod n c = G.docInOutFunc (inOutMethod n c)
+  docInOutMethod n = G.docInOutFunc (inOutMethod n)
 
   inOutFunc n = cpphInOut (function n)
 
   docInOutFunc n = G.docInOutFunc (inOutFunc n)
 
 instance InternalMethod CppHdrCode where
-  intMethod m n _ s _ t ps _ = modify (setScope (snd $ unCPPHC s) . if m then 
+  intMethod m n s _ t ps _ = modify (setScope (snd $ unCPPHC s) . if m then 
     setCurrMain else id) >> on1StateValue1List (\tp pms -> methodFromData (snd 
     $ unCPPHC s) $ cpphMethod n tp pms endStatement) t ps
   intFunc = G.intFunc
@@ -2030,7 +2031,7 @@ instance ClassSym CppHdrCode where
   buildClass n p _ vs mths = modify (setClassName n) >> on2StateLists 
     (\vars funcs -> cpphClass n p vars funcs public private blockStart blockEnd 
     endStatement) vs fs
-    where fs = map (zoom lensCStoMS) $ mths ++ [destructor n vs]
+    where fs = map (zoom lensCStoMS) $ mths ++ [destructor vs]
   enum n es _ = modify (setClassName n) >> cpphEnum n (enumElementsDocD es 
     enumsEqualInts) blockStart blockEnd endStatement
   privClass = G.privClass

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer/LanguagePolymorphic.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer/LanguagePolymorphic.hs
@@ -86,7 +86,8 @@ import GOOL.Drasil.LanguageRenderer (forLabel, new, observerListName, addExt,
 import GOOL.Drasil.State (FS, CS, MS, lensFStoGS, lensFStoCS, lensFStoMS, 
   lensCStoMS, currMain, modifyAfter, modifyReturnFunc, modifyReturnFunc2, 
   addFile, setMainMod, addLangImport, getLangImports, getModuleImports, 
-  setFilePath, getFilePath, setModuleName, getModuleName, addParameter)
+  setFilePath, getFilePath, setModuleName, getModuleName, setClassName, 
+  addParameter)
 
 import Prelude hiding (break,print,last,mod,pi,(<>))
 import Data.Bifunctor (first)
@@ -1014,16 +1015,17 @@ buildClass :: (RenderSym repr) => (Label -> Doc -> Doc -> Doc -> Doc -> Doc) ->
   (Label -> repr (Keyword repr)) -> Label -> Maybe Label -> repr (Scope repr) 
   -> [CS (repr (StateVar repr))] -> [MS (repr (Method repr))] -> 
   CS (repr (Class repr))
-buildClass f i n p s vs fs = classFromData (on2StateValues (f n parent 
-  (scopeDoc s)) (onStateList (stateVarListDocD . map stateVarDoc) vs)
-  (onStateList (vibcat . map methodDoc) (map (zoom lensCStoMS) fs)))
+buildClass f i n p s vs fs = modify (setClassName n) >> classFromData 
+  (on2StateValues (f n parent (scopeDoc s)) (onStateList (stateVarListDocD . 
+  map stateVarDoc) vs) (onStateList (vibcat . map methodDoc) (map (zoom 
+  lensCStoMS) fs)))
   where parent = case p of Nothing -> empty
                            Just pn -> keyDoc $ i pn
 
 enum :: (RenderSym repr) => Label -> [Label] -> repr (Scope repr) -> 
   CS (repr (Class repr))
-enum n es s = classFromData (toState $ enumDocD n (enumElementsDocD es False) 
-  (scopeDoc s))
+enum n es s = modify (setClassName n) >> classFromData (toState $ enumDocD n 
+  (enumElementsDocD es False) (scopeDoc s))
 
 privClass :: (RenderSym repr) => Label -> Maybe Label -> 
   [CS (repr (StateVar repr))] -> 

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer/PythonRenderer.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer/PythonRenderer.hs
@@ -61,7 +61,8 @@ import GOOL.Drasil.Helpers (vibcat, emptyIfEmpty, toCode, toState, onCodeValue,
   onStateValue, on2CodeValues, on2StateValues, on3CodeValues, on3StateValues,
   onCodeList, onStateList, on2StateLists, on1CodeValue1List, on1StateValue1List)
 import GOOL.Drasil.State (MS, lensGStoFS, addLangImport, getLangImports, 
-  addModuleImport, getModuleImports, setCurrMain, getClassMap)
+  addModuleImport, getModuleImports, setClassName, getClassName, setCurrMain, 
+  getClassMap)
 
 import Prelude hiding (break,print,sin,cos,tan,floor,(<>))
 import Data.Maybe (fromMaybe)
@@ -585,9 +586,9 @@ instance MethodSym PythonCode where
   docInOutFunc n = pyDocInOut (inOutFunc n)
 
 instance InternalMethod PythonCode where
-  intMethod m n l _ _ _ ps b = modify (if m then setCurrMain else id) >> 
+  intMethod m n _ _ _ _ ps b = modify (if m then setCurrMain else id) >> 
     on3StateValues (\sl pms bd -> methodFromData Pub $ pyMethod n sl pms bd) 
-    (self l) (sequence ps) b 
+    (getClassName >>= self) (sequence ps) b 
   intFunc m n _ _ _ ps b = modify (if m then setCurrMain else id) >>
     on1StateValue1List (\bd pms -> methodFromData Pub $ pyFunction n pms bd) 
     b ps
@@ -614,8 +615,8 @@ instance InternalStateVar PythonCode where
 instance ClassSym PythonCode where
   type Class PythonCode = Doc
   buildClass = G.buildClass pyClass inherit
-  enum n es s = classFromData (toState $ pyClass n empty (scopeDoc s)
-    (enumElementsDocD' es) empty)
+  enum n es s = modify (setClassName n) >> classFromData (toState $ pyClass n 
+    empty (scopeDoc s) (enumElementsDocD' es) empty)
   privClass = G.privClass
   pubClass = G.pubClass
 

--- a/code/drasil-gool/GOOL/Drasil/State.hs
+++ b/code/drasil-gool/GOOL/Drasil/State.hs
@@ -325,8 +325,8 @@ setClassName :: String -> ((GOOLState, FileState), ClassState) ->
   ((GOOLState, FileState), ClassState)
 setClassName n = over _2 (set currClassName n)
 
-getClassName :: CS String
-getClassName = gets ((^. currClassName) . snd)
+getClassName :: MS String
+getClassName = gets ((^. currClassName) . snd . fst)
 
 setCurrMain :: (((GOOLState, FileState), ClassState), MethodState) -> 
   (((GOOLState, FileState), ClassState), MethodState)

--- a/code/drasil-gool/GOOL/Drasil/State.hs
+++ b/code/drasil-gool/GOOL/Drasil/State.hs
@@ -1,15 +1,16 @@
 {-# LANGUAGE TemplateHaskell #-}
 
 module GOOL.Drasil.State (
-  GS, GOOLState(..), FS, MS, lensFStoGS, lensGStoFS, lensFStoMS, lensMStoFS, 
-  headers, sources, mainMod, currMain, initialState, initialFS, modifyAfter, 
-  modifyReturn, modifyReturnFunc, modifyReturnFunc2, modifyReturnList, addFile, 
-  addCombinedHeaderSource, addHeader, addSource, addProgNameToPaths, setMainMod,
-  addLangImport, getLangImports, addModuleImport, getModuleImports, 
-  addHeaderLangImport, getHeaderLangImports, addHeaderModImport, 
-  getHeaderModImports, addDefine, getDefines, addHeaderDefine, getHeaderDefines,
-  addUsing, getUsing, addHeaderUsing, getHeaderUsing, setFilePath, getFilePath, 
-  setModuleName, getModuleName, setCurrMain, getCurrMain, addClass, getClasses, 
+  GS, GOOLState(..), FS, CS, MS, lensFStoGS, lensGStoFS, lensFStoCS, lensFStoMS,
+  lensCStoMS, lensMStoCS, headers, sources, mainMod, currMain, initialState, 
+  initialFS, modifyAfter, modifyReturn, modifyReturnFunc, modifyReturnFunc2, 
+  modifyReturnList, addFile, addCombinedHeaderSource, addHeader, addSource, 
+  addProgNameToPaths, setMainMod, addLangImport, getLangImports, 
+  addModuleImport, getModuleImports, addHeaderLangImport, getHeaderLangImports, 
+  addHeaderModImport, getHeaderModImports, addDefine, getDefines, 
+  addHeaderDefine, getHeaderDefines, addUsing, getUsing, addHeaderUsing, 
+  getHeaderUsing, setFilePath, getFilePath, setModuleName, getModuleName, 
+  setClassName, getClassName, setCurrMain, getCurrMain, addClass, getClasses, 
   updateClassMap, getClassMap, addParameter, getParameters, setOutputsDeclared, 
   isOutputsDeclared, setScope, getScope, setCurrMainFunc, getCurrMainFunc
 ) where
@@ -43,6 +44,11 @@ data MethodState = MS {
 }
 makeLenses ''MethodState
 
+newtype ClassState = CS {
+  _currClassName :: String
+}
+makeLenses ''ClassState
+
 data FileState = FS {
   _currModName :: String,
   _currFilePath :: FilePath,
@@ -63,7 +69,8 @@ makeLenses ''FileState
 
 type GS = State GOOLState
 type FS = State (GOOLState, FileState)
-type MS = State ((GOOLState, FileState), MethodState)
+type CS = State ((GOOLState, FileState), ClassState)
+type MS = State (((GOOLState, FileState), ClassState), MethodState)
 
 -------------------------------
 ---- Lenses between States ----
@@ -83,20 +90,50 @@ lensGStoFS = lens getFSfromGS setFSfromGS
 lensFStoGS :: Lens' (GOOLState, FileState) GOOLState
 lensFStoGS = _1
 
+-- FS - CS --
+
+getCSfromFS :: (GOOLState, FileState) -> ((GOOLState, FileState), ClassState)
+getCSfromFS fs = (fs, initialCS)
+
+setCSfromFS :: (GOOLState, FileState) -> ((GOOLState, FileState), ClassState) 
+  -> (GOOLState, FileState)
+setCSfromFS _ (fs, _) = fs 
+
+lensFStoCS :: Lens' (GOOLState, FileState) ((GOOLState, FileState), ClassState)
+lensFStoCS = lens getCSfromFS setCSfromFS
+
 -- FS - MS --
 
-getMSfromFS :: (GOOLState, FileState) -> ((GOOLState, FileState), MethodState)
-getMSfromFS (gs, fs) = ((gs, fs), initialMS)
+getMSfromFS :: (GOOLState, FileState) -> 
+  (((GOOLState, FileState), ClassState), MethodState)
+getMSfromFS (gs, fs) = (((gs, fs), initialCS), initialMS)
 
-setMSfromFS :: (GOOLState, FileState) -> ((GOOLState, FileState), MethodState)
-  -> (GOOLState, FileState)
-setMSfromFS _ (fs, _) = fs
+setMSfromFS :: (GOOLState, FileState) -> 
+  (((GOOLState, FileState), ClassState), MethodState) -> (GOOLState, FileState)
+setMSfromFS _ ((fs, _), _) = fs
 
-lensFStoMS :: Lens' (GOOLState, FileState) ((GOOLState, FileState), MethodState)
+lensFStoMS :: Lens' (GOOLState, FileState) 
+  (((GOOLState, FileState), ClassState), MethodState)
 lensFStoMS = lens getMSfromFS setMSfromFS
 
-lensMStoFS :: Lens' ((GOOLState, FileState), MethodState) (GOOLState, FileState)
-lensMStoFS = _1
+-- CS - MS --
+
+getMSfromCS :: ((GOOLState, FileState), ClassState) -> 
+  (((GOOLState, FileState), ClassState), MethodState)
+getMSfromCS cs = (cs, initialMS)
+
+setMSfromCS :: ((GOOLState, FileState), ClassState) -> 
+  (((GOOLState, FileState), ClassState), MethodState) -> 
+  ((GOOLState, FileState), ClassState)
+setMSfromCS _ (cs, _) = cs
+
+lensCStoMS :: Lens' ((GOOLState, FileState), ClassState) 
+  (((GOOLState, FileState), ClassState), MethodState)
+lensCStoMS = lens getMSfromCS setMSfromCS
+
+lensMStoCS :: Lens' (((GOOLState, FileState), ClassState), MethodState)
+  ((GOOLState, FileState), ClassState)
+lensMStoCS = _1
 
 -------------------------------
 ------- Initial States -------
@@ -125,6 +162,11 @@ initialFS = FS {
   _headerDefines = [],
   _using = [],
   _headerUsing = []
+}
+
+initialCS :: ClassState
+initialCS = CS {
+  _currClassName = ""
 }
 
 initialMS :: MethodState
@@ -201,66 +243,68 @@ setMainMod :: String -> GOOLState -> GOOLState
 setMainMod n = over mainMod (\m -> if isNothing m then Just n else error 
   "Multiple modules with main methods encountered")
 
-addLangImport :: String -> ((GOOLState, FileState), MethodState) -> 
-  ((GOOLState, FileState), MethodState)
-addLangImport i = over _1 $ over _2 $ over langImports (\is -> if i `elem` is 
-  then is else sort $ i:is)
+addLangImport :: String -> (((GOOLState, FileState), ClassState), MethodState) 
+  -> (((GOOLState, FileState), ClassState), MethodState)
+addLangImport i = over _1 $ over _1 $ over _2 $ over langImports (\is -> 
+  if i `elem` is then is else sort $ i:is)
 
 getLangImports :: FS [String]
 getLangImports = gets ((^. langImports) . snd)
 
-addModuleImport :: String -> ((GOOLState, FileState), MethodState) -> 
-  ((GOOLState, FileState), MethodState)
-addModuleImport i = over _1 $ over _2 $ over moduleImports (\is -> 
+addModuleImport :: String -> (((GOOLState, FileState), ClassState), MethodState)
+  -> (((GOOLState, FileState), ClassState), MethodState)
+addModuleImport i = over _1 $ over _1 $ over _2 $ over moduleImports (\is -> 
   if i `elem` is then is else sort $ i:is)
 
 getModuleImports :: FS [String]
 getModuleImports = gets ((^. moduleImports) . snd)
 
-addHeaderLangImport :: String -> ((GOOLState, FileState), MethodState) -> 
-  ((GOOLState, FileState), MethodState)
-addHeaderLangImport i = over _1 $ over _2 $ over headerLangImports (\is -> 
-  if i `elem` is then is else sort $ i:is)
+addHeaderLangImport :: String -> 
+  (((GOOLState, FileState), ClassState), MethodState) -> 
+  (((GOOLState, FileState), ClassState), MethodState)
+addHeaderLangImport i = over _1 $ over _1 $ over _2 $ over headerLangImports 
+  (\is -> if i `elem` is then is else sort $ i:is)
 
 getHeaderLangImports :: FS [String]
 getHeaderLangImports = gets ((^. headerLangImports) . snd)
 
-addHeaderModImport :: String -> ((GOOLState, FileState), MethodState) -> 
-  ((GOOLState, FileState), MethodState)
-addHeaderModImport i = over _1 $ over _2 $ over headerModImports (\is -> 
-  if i `elem` is then is else sort $ i:is)
+addHeaderModImport :: String -> 
+  (((GOOLState, FileState), ClassState), MethodState) -> 
+  (((GOOLState, FileState), ClassState), MethodState)
+addHeaderModImport i = over _1 $ over _1 $ over _2 $ over headerModImports 
+  (\is -> if i `elem` is then is else sort $ i:is)
 
 getHeaderModImports :: FS [String]
 getHeaderModImports = gets ((^. headerModImports) . snd)
 
-addDefine :: String -> ((GOOLState, FileState), MethodState) -> 
-  ((GOOLState, FileState), MethodState)
-addDefine d = over _1 $ over _2 $ over defines (\ds -> if d `elem` ds then ds 
-  else sort $ d:ds)
+addDefine :: String -> (((GOOLState, FileState), ClassState), MethodState) -> 
+  (((GOOLState, FileState), ClassState), MethodState)
+addDefine d = over _1 $ over _1 $ over _2 $ over defines (\ds -> if d `elem` ds 
+  then ds else sort $ d:ds)
 
 getDefines :: FS [String]
 getDefines = gets ((^. defines) . snd)
   
-addHeaderDefine :: String -> ((GOOLState, FileState), MethodState) -> 
-  ((GOOLState, FileState), MethodState)
-addHeaderDefine d = over _1 $ over _2 $ over headerDefines (\ds -> 
+addHeaderDefine :: String -> (((GOOLState, FileState), ClassState), MethodState)
+  -> (((GOOLState, FileState), ClassState), MethodState)
+addHeaderDefine d = over _1 $ over _1 $ over _2 $ over headerDefines (\ds -> 
   if d `elem` ds then ds else sort $ d:ds)
 
 getHeaderDefines :: FS [String]
 getHeaderDefines = gets ((^. headerDefines) . snd)
 
-addUsing :: String -> ((GOOLState, FileState), MethodState) -> 
-  ((GOOLState, FileState), MethodState)
-addUsing u = over _1 $ over _2 $ over using (\us -> if u `elem` us then us else 
-  sort $ u:us)
+addUsing :: String -> (((GOOLState, FileState), ClassState), MethodState) -> 
+  (((GOOLState, FileState), ClassState), MethodState)
+addUsing u = over _1 $ over _1 $ over _2 $ over using (\us -> if u `elem` us 
+  then us else sort $ u:us)
 
 getUsing :: FS [String]
 getUsing = gets ((^. using) . snd)
 
-addHeaderUsing :: String -> ((GOOLState, FileState), MethodState) -> 
-  ((GOOLState, FileState), MethodState)
-addHeaderUsing u = over _1 $ over _2 $ over headerUsing (\us -> if u `elem` us 
-  then us else sort $ u:us)
+addHeaderUsing :: String -> (((GOOLState, FileState), ClassState), MethodState) 
+  -> (((GOOLState, FileState), ClassState), MethodState)
+addHeaderUsing u = over _1 $ over _1 $ over _2 $ over headerUsing (\us -> 
+  if u `elem` us then us else sort $ u:us)
 
 getHeaderUsing :: FS [String]
 getHeaderUsing = gets ((^. headerUsing) . snd)
@@ -277,17 +321,25 @@ setModuleName n = over _2 (set currModName n)
 getModuleName :: FS String
 getModuleName = gets ((^. currModName) . snd)
 
-setCurrMain :: ((GOOLState, FileState), MethodState) -> 
-  ((GOOLState, FileState), MethodState)
-setCurrMain = over _1 (over _2 (over currMain (\b -> if b then error 
-  "Multiple main functions defined" else not b)))
+setClassName :: String -> ((GOOLState, FileState), ClassState) -> 
+  ((GOOLState, FileState), ClassState)
+setClassName n = over _2 (set currClassName n)
+
+getClassName :: CS String
+getClassName = gets ((^. currClassName) . snd)
+
+setCurrMain :: (((GOOLState, FileState), ClassState), MethodState) -> 
+  (((GOOLState, FileState), ClassState), MethodState)
+setCurrMain = over _1 $ over _1 $ over _2 $ over currMain (\b -> if b then 
+  error "Multiple main functions defined" else not b)
 
 getCurrMain :: FS Bool
 getCurrMain = gets ((^. currMain) . snd)
 
-addClass :: String -> (GOOLState, FileState) -> (GOOLState, FileState)
-addClass c = over _2 (over currClasses (\cs -> if c `elem` cs then error
-  "Multiple classes with same name in same file" else c:cs))
+addClass :: String -> ((GOOLState, FileState), ClassState) -> (
+  (GOOLState, FileState), ClassState)
+addClass c = over _1 $ over _2 $ over currClasses (\cs -> if c `elem` cs then 
+  error "Multiple classes with same name in same file" else c:cs)
 
 getClasses :: FS [String]
 getClasses = gets ((^. currClasses) . snd)
@@ -297,32 +349,32 @@ updateClassMap n (gs, fs) = over _1 (over classMap (union (fromList $
   zip (repeat n) (fs ^. currClasses)))) (gs, fs)
 
 getClassMap :: MS (Map String String)
-getClassMap = gets ((^. classMap) . fst . fst)
+getClassMap = gets ((^. classMap) . fst . fst . fst)
 
-addParameter :: String -> ((GOOLState, FileState), MethodState) -> 
-  ((GOOLState, FileState), MethodState)
+addParameter :: String -> (((GOOLState, FileState), ClassState), MethodState) 
+  -> (((GOOLState, FileState), ClassState), MethodState)
 addParameter p = over _2 $ over currParameters (\ps -> if p `elem` ps then 
   error $ "Function has duplicate parameter: " ++ p else ps ++ [p])
 
 getParameters :: MS [String]
 getParameters = gets ((^. currParameters) . snd)
 
-setOutputsDeclared :: ((GOOLState, FileState), MethodState) -> 
-  ((GOOLState, FileState), MethodState)
+setOutputsDeclared :: (((GOOLState, FileState), ClassState), MethodState) -> 
+  (((GOOLState, FileState), ClassState), MethodState)
 setOutputsDeclared = over _2 $ set outputsDeclared True
 
 isOutputsDeclared :: MS Bool
 isOutputsDeclared = gets ((^. outputsDeclared) . snd)
 
-setScope :: ScopeTag -> ((GOOLState, FileState), MethodState) -> 
-  ((GOOLState, FileState), MethodState)
+setScope :: ScopeTag -> (((GOOLState, FileState), ClassState), MethodState) -> 
+  (((GOOLState, FileState), ClassState), MethodState)
 setScope scp = over _2 $ set currScope scp
 
 getScope :: MS ScopeTag
 getScope = gets ((^. currScope) . snd)
 
-setCurrMainFunc :: Bool -> ((GOOLState, FileState), MethodState) -> 
-  ((GOOLState, FileState), MethodState)
+setCurrMainFunc :: Bool -> (((GOOLState, FileState), ClassState), MethodState) 
+  -> (((GOOLState, FileState), ClassState), MethodState)
 setCurrMainFunc m = over _2 $ set currMainFunc m
 
 getCurrMainFunc :: MS Bool

--- a/code/drasil-gool/GOOL/Drasil/Symantics.hs
+++ b/code/drasil-gool/GOOL/Drasil/Symantics.hs
@@ -21,7 +21,7 @@ module GOOL.Drasil.Symantics (
 
 import GOOL.Drasil.CodeType (CodeType)
 import GOOL.Drasil.Data (Binding, Terminator, FileType, ScopeTag)
-import GOOL.Drasil.State (GS, FS, MS)
+import GOOL.Drasil.State (GS, FS, CS, MS)
 
 import Control.Monad.State (State)
 import Text.PrettyPrint.HughesPJ (Doc)
@@ -666,7 +666,7 @@ class (StateVarSym repr, ParameterSym repr, ControlBlockSym repr) =>
     MS (repr (Method repr))
   constructor :: Label -> [MS (repr (Parameter repr))] -> MS (repr (Body repr)) 
     -> MS (repr (Method repr))
-  destructor :: Label -> [FS (repr (StateVar repr))] -> MS (repr (Method repr))
+  destructor :: Label -> [CS (repr (StateVar repr))] -> MS (repr (Method repr))
 
   docMain :: MS (repr (Body repr)) -> MS (repr (Method repr))
 
@@ -720,49 +720,44 @@ class (ScopeSym repr, PermanenceSym repr, TypeSym repr, StatementSym repr) =>
   StateVarSym repr where
   type StateVar repr
   stateVar :: repr (Scope repr) -> repr (Permanence repr) ->
-    MS (repr (Variable repr)) -> FS (repr (StateVar repr))
+    MS (repr (Variable repr)) -> CS (repr (StateVar repr))
   stateVarDef :: Label -> repr (Scope repr) -> repr (Permanence repr) ->
     MS (repr (Variable repr)) -> MS (repr (Value repr)) -> 
-    FS (repr (StateVar repr))
+    CS (repr (StateVar repr))
   constVar :: Label -> repr (Scope repr) ->  MS (repr (Variable repr)) -> 
-    MS (repr (Value repr)) -> FS (repr (StateVar repr))
-  privMVar :: MS (repr (Variable repr)) -> FS (repr (StateVar repr))
-  pubMVar  :: MS (repr (Variable repr)) -> FS (repr (StateVar repr))
-  pubGVar  :: MS (repr (Variable repr)) -> FS (repr (StateVar repr))
+    MS (repr (Value repr)) -> CS (repr (StateVar repr))
+  privMVar :: MS (repr (Variable repr)) -> CS (repr (StateVar repr))
+  pubMVar  :: MS (repr (Variable repr)) -> CS (repr (StateVar repr))
+  pubGVar  :: MS (repr (Variable repr)) -> CS (repr (StateVar repr))
 
 class InternalStateVar repr where
   stateVarDoc :: repr (StateVar repr) -> Doc
-  stateVarFromData :: FS Doc -> FS (repr (StateVar repr))
+  stateVarFromData :: CS Doc -> CS (repr (StateVar repr))
 
 class (MethodSym repr) => ClassSym repr where
   type Class repr
   buildClass :: Label -> Maybe Label -> repr (Scope repr) -> 
-    [FS (repr (StateVar repr))] -> 
-    [MS (repr (Method repr))] -> 
-    FS (repr (Class repr))
-  enum :: Label -> [Label] -> repr (Scope repr) -> 
-    FS (repr (Class repr))
-  privClass :: Label -> Maybe Label -> [FS (repr (StateVar repr))] 
-    -> [MS (repr (Method repr))] -> 
-    FS (repr (Class repr))
-  pubClass :: Label -> Maybe Label -> [FS (repr (StateVar repr))] 
-    -> [MS (repr (Method repr))] -> 
-    FS (repr (Class repr))
+    [CS (repr (StateVar repr))] -> [MS (repr (Method repr))] -> 
+    CS (repr (Class repr))
+  enum :: Label -> [Label] -> repr (Scope repr) -> CS (repr (Class repr))
+  privClass :: Label -> Maybe Label -> [CS (repr (StateVar repr))] 
+    -> [MS (repr (Method repr))] -> CS (repr (Class repr))
+  pubClass :: Label -> Maybe Label -> [CS (repr (StateVar repr))] 
+    -> [MS (repr (Method repr))] -> CS (repr (Class repr))
 
-  docClass :: String -> FS (repr (Class repr)) ->
-    FS (repr (Class repr))
+  docClass :: String -> CS (repr (Class repr)) -> CS (repr (Class repr))
 
-  commentedClass :: FS (repr (BlockComment repr)) -> 
-    FS (repr (Class repr)) -> FS (repr (Class repr))
+  commentedClass :: CS (repr (BlockComment repr)) -> 
+    CS (repr (Class repr)) -> CS (repr (Class repr))
 
 class InternalClass repr where
   classDoc :: repr (Class repr) -> Doc
-  classFromData :: FS Doc -> FS (repr (Class repr))
+  classFromData :: CS Doc -> CS (repr (Class repr))
 
 class (ClassSym repr) => ModuleSym repr where
   type Module repr
   buildModule :: Label -> [MS (repr (Method repr))] -> 
-    [FS (repr (Class repr))] -> FS (repr (Module repr))
+    [CS (repr (Class repr))] -> FS (repr (Module repr))
 
 class InternalMod repr where
   moduleDoc :: repr (Module repr) -> Doc

--- a/code/drasil-gool/GOOL/Drasil/Symantics.hs
+++ b/code/drasil-gool/GOOL/Drasil/Symantics.hs
@@ -212,14 +212,14 @@ class (TypeSym repr) => VariableSym repr where
   const        :: Label -> MS (repr (Type repr)) -> MS (repr (Variable repr))
   extVar       :: Library -> Label -> MS (repr (Type repr)) -> 
     MS (repr (Variable repr))
-  self         :: Label -> MS (repr (Variable repr))
+  self         :: MS (repr (Variable repr))
   classVar     :: MS (repr (Type repr)) -> MS (repr (Variable repr)) -> 
     MS (repr (Variable repr))
   extClassVar  :: MS (repr (Type repr)) -> MS (repr (Variable repr)) -> 
     MS (repr (Variable repr))
   objVar       :: MS (repr (Variable repr)) -> MS (repr (Variable repr)) -> 
     MS (repr (Variable repr))
-  objVarSelf   :: Label -> MS (repr (Variable repr)) -> MS (repr (Variable repr))
+  objVarSelf   :: MS (repr (Variable repr)) -> MS (repr (Variable repr))
   enumVar      :: Label -> Label -> MS (repr (Variable repr))
   listVar      :: Label -> repr (Permanence repr) -> MS (repr (Type repr)) -> 
     MS (repr (Variable repr))
@@ -347,7 +347,7 @@ class (ValueSym repr, BooleanExpression repr) =>
     MS (repr (Value repr)) -> MS (repr (Value repr))
   funcApp      :: Label -> MS (repr (Type repr)) -> [MS (repr (Value repr))] -> 
     MS (repr (Value repr))
-  selfFuncApp  :: Label -> Label -> MS (repr (Type repr)) -> 
+  selfFuncApp  :: Label -> MS (repr (Type repr)) -> 
     [MS (repr (Value repr))] -> MS (repr (Value repr))
   extFuncApp   :: Library -> Label -> MS (repr (Type repr)) -> 
     [MS (repr (Value repr))] -> MS (repr (Value repr))
@@ -385,7 +385,7 @@ class (FunctionSym repr) => Selector repr where
     MS (repr (Value repr))
   infixl 9 $.
 
-  selfAccess :: Label -> MS (repr (Function repr)) -> MS (repr (Value repr))
+  selfAccess :: MS (repr (Function repr)) -> MS (repr (Value repr))
 
   listIndexExists :: MS (repr (Value repr)) -> MS (repr (Value repr)) -> 
     MS (repr (Value repr))
@@ -578,7 +578,7 @@ class (SelectorFunction repr) => StatementSym repr where
   -- The three lists are inputs, outputs, and both, respectively
   inOutCall :: Label -> [MS (repr (Value repr))] -> [MS (repr (Variable repr))] 
     -> [MS (repr (Variable repr))] -> MS (repr (Statement repr))
-  selfInOutCall :: Label -> Label -> [MS (repr (Value repr))] -> 
+  selfInOutCall :: Label -> [MS (repr (Value repr))] -> 
     [MS (repr (Variable repr))] -> [MS (repr (Variable repr))] -> 
     MS (repr (Statement repr))
   extInOutCall :: Library -> Label -> [MS (repr (Value repr))] ->
@@ -652,21 +652,18 @@ class InternalParam repr where
 class (StateVarSym repr, ParameterSym repr, ControlBlockSym repr) => 
   MethodSym repr where
   type Method repr
-  -- Second label is class name
-  method      :: Label -> Label -> repr (Scope repr) -> repr (Permanence repr) 
+  method      :: Label -> repr (Scope repr) -> repr (Permanence repr) 
     -> MS (repr (Type repr)) -> [MS (repr (Parameter repr))] -> 
     MS (repr (Body repr)) -> MS (repr (Method repr))
-  getMethod   :: Label -> MS (repr (Variable repr)) -> MS (repr (Method repr))
-  setMethod   :: Label -> MS (repr (Variable repr)) -> MS (repr (Method repr)) 
-  privMethod  :: Label -> Label -> MS (repr (Type repr)) -> 
-    [MS (repr (Parameter repr))] -> MS (repr (Body repr)) -> 
-    MS (repr (Method repr))
-  pubMethod   :: Label -> Label -> MS (repr (Type repr)) -> 
-    [MS (repr (Parameter repr))] -> MS (repr (Body repr)) -> 
-    MS (repr (Method repr))
-  constructor :: Label -> [MS (repr (Parameter repr))] -> MS (repr (Body repr)) 
+  getMethod   :: MS (repr (Variable repr)) -> MS (repr (Method repr))
+  setMethod   :: MS (repr (Variable repr)) -> MS (repr (Method repr)) 
+  privMethod  :: Label -> MS (repr (Type repr)) -> [MS (repr (Parameter repr))] 
+    -> MS (repr (Body repr)) -> MS (repr (Method repr))
+  pubMethod   :: Label -> MS (repr (Type repr)) -> [MS (repr (Parameter repr))] 
+    -> MS (repr (Body repr)) -> MS (repr (Method repr))
+  constructor :: [MS (repr (Parameter repr))] -> MS (repr (Body repr)) 
     -> MS (repr (Method repr))
-  destructor :: Label -> [CS (repr (StateVar repr))] -> MS (repr (Method repr))
+  destructor :: [CS (repr (StateVar repr))] -> MS (repr (Method repr))
 
   docMain :: MS (repr (Body repr)) -> MS (repr (Method repr))
 
@@ -679,15 +676,13 @@ class (StateVarSym repr, ParameterSym repr, ControlBlockSym repr) =>
   docFunc :: String -> [String] -> Maybe String -> 
     MS (repr (Method repr)) -> MS (repr (Method repr))
 
-  -- Second label is class name, rest is same as inOutFunc
-  inOutMethod :: Label -> Label -> repr (Scope repr) -> repr (Permanence repr) 
-    -> [MS (repr (Variable repr))] -> [MS (repr (Variable repr))] -> 
+  inOutMethod :: Label -> repr (Scope repr) -> repr (Permanence repr) -> 
+    [MS (repr (Variable repr))] -> [MS (repr (Variable repr))] -> 
     [MS (repr (Variable repr))] -> MS (repr (Body repr)) -> 
     MS (repr (Method repr))
-  -- Second label is class name, rest is same as docInOutFunc
-  docInOutMethod :: Label -> Label -> repr (Scope repr) -> 
-    repr (Permanence repr) -> String -> [(String, MS (repr (Variable repr)))] 
-    -> [(String, MS (repr (Variable repr)))] -> 
+  docInOutMethod :: Label -> repr (Scope repr) -> repr (Permanence repr) -> 
+    String -> [(String, MS (repr (Variable repr)))] -> 
+    [(String, MS (repr (Variable repr)))] -> 
     [(String, MS (repr (Variable repr)))] -> MS (repr (Body repr)) -> 
     MS (repr (Method repr))
 
@@ -703,10 +698,9 @@ class (StateVarSym repr, ParameterSym repr, ControlBlockSym repr) =>
     MS (repr (Body repr)) -> MS (repr (Method repr))
 
 class (MethodTypeSym repr, BlockCommentSym repr) => InternalMethod repr where
-  intMethod     :: Bool -> Label -> Label -> repr (Scope repr) -> 
-    repr (Permanence repr) -> MS (repr (MethodType repr)) -> 
-    [MS (repr (Parameter repr))] -> MS (repr (Body repr)) -> 
-    MS (repr (Method repr))
+  intMethod     :: Bool -> Label -> repr (Scope repr) -> repr (Permanence repr) 
+    -> MS (repr (MethodType repr)) -> [MS (repr (Parameter repr))] -> 
+    MS (repr (Body repr)) -> MS (repr (Method repr))
   intFunc       :: Bool -> Label -> repr (Scope repr) -> repr (Permanence repr) 
     -> MS (repr (MethodType repr)) -> [MS (repr (Parameter repr))] -> 
     MS (repr (Body repr)) -> MS (repr (Method repr))

--- a/code/drasil-gool/Test/Observer.hs
+++ b/code/drasil-gool/Test/Observer.hs
@@ -3,7 +3,7 @@ module Test.Observer (observer, observerName, printNum, x) where
 import GOOL.Drasil (
   ProgramSym, FileSym(..), PermanenceSym(..), BodySym(..), TypeSym(..), 
   StatementSym(..), VariableSym(..), ValueSym(..), ScopeSym(..), 
-  MethodSym(..), StateVarSym(..), ClassSym(..), ModuleSym(..), FS, MS)
+  MethodSym(..), StateVarSym(..), ClassSym(..), ModuleSym(..), FS, CS, MS)
 import Prelude hiding (return,print,log,exp,sin,cos,tan)
 
 observerName, observerDesc, printNum :: String
@@ -21,7 +21,7 @@ x = var "x" int
 selfX :: (VariableSym repr) => MS (repr (Variable repr))
 selfX = objVarSelf observerName x
 
-helperClass :: (ClassSym repr) => FS (repr (Class repr))
+helperClass :: (ClassSym repr) => CS (repr (Class repr))
 helperClass = pubClass observerName Nothing [stateVar public dynamic_ x]
   [observerConstructor, printNumMethod, getMethod observerName x, 
   setMethod observerName x]

--- a/code/drasil-gool/Test/Observer.hs
+++ b/code/drasil-gool/Test/Observer.hs
@@ -19,17 +19,16 @@ x :: (VariableSym repr) => MS (repr (Variable repr))
 x = var "x" int
 
 selfX :: (VariableSym repr) => MS (repr (Variable repr))
-selfX = objVarSelf observerName x
+selfX = objVarSelf x
 
 helperClass :: (ClassSym repr) => CS (repr (Class repr))
 helperClass = pubClass observerName Nothing [stateVar public dynamic_ x]
-  [observerConstructor, printNumMethod, getMethod observerName x, 
-  setMethod observerName x]
+  [observerConstructor, printNumMethod, getMethod x, setMethod x]
 
 observerConstructor :: (MethodSym repr) => MS (repr (Method repr))
-observerConstructor = constructor observerName [] $ oneLiner $ assign selfX 
+observerConstructor = constructor [] $ oneLiner $ assign selfX 
   (litInt 5)
 
 printNumMethod :: (MethodSym repr) => MS (repr (Method repr))
-printNumMethod = method printNum observerName public dynamic_ void [] $
+printNumMethod = method printNum public dynamic_ void [] $
   oneLiner $ printLn $ valueOf selfX


### PR DESCRIPTION
This PR adds `ClassState` to GOOL, which stores the current class name. A whole bunch of functions required the class name to be passed as a parameter, but now it can just be read from the state.