### PR TITLE
Fix diff tool when used on machines that use CRLF line endings

### DIFF
--- a/code/Makefile
+++ b/code/Makefile
@@ -63,7 +63,7 @@ ALL_EXPANDED_TARGETS = $(foreach P, $(PACKAGE_GEN_TARGET), $($(P)_PACKAGES)) $(f
 #####
 
 # make variables/configuration
-DIFF = diff -r -X ../.gitignore -x '*.txt'
+DIFF = diff --strip-trailing-cr -r -X ../.gitignore -x '*.txt'
 LOG_SUFFIX = _log.log
 MIN_STACK_VER = 1.9.1  # Version which adds --interleaved-output flag
 CACHED_MSV_FILE = .drasil-min-stack-ver


### PR DESCRIPTION
On windows machines, depending on settings, building will generate a lot of non-empty log files because of the additional carriage return at the end of lines.