### PR TITLE
Automate "throws Exception" in Java

### DIFF
--- a/code/drasil-gool/GOOL/Drasil/CodeInfo.hs
+++ b/code/drasil-gool/GOOL/Drasil/CodeInfo.hs
@@ -10,7 +10,8 @@ import GOOL.Drasil.Symantics (ProgramSym(..), FileSym(..), PermanenceSym(..),
   MethodTypeSym(..), ParameterSym(..), MethodSym(..), StateVarSym(..), 
   ClassSym(..), ModuleSym(..), BlockCommentSym(..))
 import GOOL.Drasil.CodeType (CodeType(Void))
-import GOOL.Drasil.Data (Binding(Dynamic), ScopeTag(..))
+import GOOL.Drasil.Data (Binding(Dynamic), ScopeTag(..), Exception(..),
+  exception, stdExc)
 import GOOL.Drasil.Helpers (toCode, toState)
 import GOOL.Drasil.State (GOOLState, MS, lensGStoFS, lensFStoCS, lensFStoMS, 
   lensCStoMS, lensMStoFS, modifyReturn, setClassName, setModuleName, 
@@ -275,10 +276,10 @@ instance StatementSym CodeInfo where
   getFileInput _ _ = noInfo
   discardFileInput _ = noInfo
 
-  openFileR _ _ = modifyReturn (addException "java.io.FileNotFoundException") 
+  openFileR _ _ = modifyReturn (addException fnfExc) 
     (toCode ())
-  openFileW _ _ = modifyReturn (addException "java.io.IOException") (toCode ())
-  openFileA _ _ = modifyReturn (addException "java.io.IOException") (toCode ())
+  openFileW _ _ = modifyReturn (addException ioExc) (toCode ())
+  openFileA _ _ = modifyReturn (addException ioExc) (toCode ())
   closeFile _ = noInfo
 
   getFileInputLine _ _ = noInfo
@@ -300,7 +301,7 @@ instance StatementSym CodeInfo where
 
   free _ = noInfo
 
-  throw _ = modifyReturn (addException "Exception") (toCode ())
+  throw _ = modifyReturn (addException genericExc) (toCode ())
 
   initState _ _ = noInfo
   changeState _ _ = noInfo
@@ -449,6 +450,11 @@ instance BlockCommentSym CodeInfo where
 
 
 -- Helpers
+
+fnfExc, ioExc, genericExc :: Exception
+fnfExc = exception "java.io" "FileNotFoundException"
+ioExc = exception "java.io" "IOException"
+genericExc = stdExc "Exception"
 
 updateMEM :: String -> MS (CodeInfo (Body CodeInfo)) -> 
   MS (CodeInfo (Method CodeInfo))

--- a/code/drasil-gool/GOOL/Drasil/Data.hs
+++ b/code/drasil-gool/GOOL/Drasil/Data.hs
@@ -1,9 +1,10 @@
-module GOOL.Drasil.Data (Pair(..), Terminator(..), ScopeTag(..), 
-  FileType(..), BindData(..), bd, FileData(..), fileD, updateFileMod, 
-  FuncData(..), fd, ModData(..), md, updateModDoc, MethodData(..), mthd, 
-  updateMthdDoc, OpData(..), od, ParamData(..), pd, paramName, updateParamDoc, 
-  ProgData(..), progD, emptyProg, StateVarData(..), svd, TypeData(..), td, 
-  ValData(..), vd, updateValDoc, Binding(..), VarData(..), vard
+module GOOL.Drasil.Data (Pair(..), Terminator(..), ScopeTag(..), FileType(..), 
+  Exception(..), exception, stdExc, BindData(..), bd, FileData(..), 
+  fileD, updateFileMod, FuncData(..), fd, ModData(..), md, updateModDoc, 
+  MethodData(..), mthd, updateMthdDoc, OpData(..), od, ParamData(..), pd, 
+  paramName, updateParamDoc, ProgData(..), progD, emptyProg, StateVarData(..), 
+  svd, TypeData(..), td, ValData(..), vd, updateValDoc, Binding(..), 
+  VarData(..), vard
 ) where
 
 import GOOL.Drasil.CodeType (CodeType)
@@ -23,6 +24,23 @@ data ScopeTag = Pub | Priv deriving Eq
 data FileType = Combined | Source | Header deriving Eq
 
 data Binding = Static | Dynamic deriving Eq
+
+data Exception = Exc {
+  loc :: String,
+  exc :: String
+}
+
+instance Eq Exception where
+  (Exc l1 e1) == (Exc l2 e2) = l1 == l2 && e1 == e2
+
+instance Show Exception where
+  show (Exc l e) = l ++ "." ++ e
+
+exception :: String -> String -> Exception
+exception = Exc
+
+stdExc :: String -> Exception
+stdExc = Exc ""
 
 data BindData = BD {bind :: Binding, bindDoc :: Doc}
 

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer/JavaRenderer.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer/JavaRenderer.hs
@@ -61,18 +61,21 @@ import GOOL.Drasil.Data (Terminator(..), ScopeTag(..), FileType(..),
   FileData(..), fileD, FuncData(..), fd, ModData(..), md, updateModDoc, 
   MethodData(..), mthd, updateMthdDoc, OpData(..), od, ParamData(..), pd, 
   ProgData(..), progD, TypeData(..), td, ValData(..), vd, VarData(..), vard)
-import GOOL.Drasil.Helpers (angles, toCode, toState, onCodeValue, 
+import GOOL.Drasil.Helpers (angles, emptyIfNull, toCode, toState, onCodeValue, 
   onStateValue, on2CodeValues, on2StateValues, on3CodeValues, on3StateValues,
   onCodeList, onStateList, on1CodeValue1List)
-import GOOL.Drasil.State (MS, lensGStoFS, modifyReturn, modifyReturnList, 
-  addProgNameToPaths, addLangImport, getClassName, setCurrMain, 
-  setOutputsDeclared, isOutputsDeclared)
+import GOOL.Drasil.State (MS, lensGStoFS, lensMStoFS, modifyReturn, 
+  modifyReturnList, addProgNameToPaths, addLangImport, getModuleName, 
+  getClassName, setCurrMain, setOutputsDeclared, isOutputsDeclared, 
+  addExceptions, getExceptions, getMethodExcMap)
 
 import Prelude hiding (break,print,sin,cos,tan,floor,(<>))
 import Control.Lens.Zoom (zoom)
 import Control.Applicative (Applicative)
 import Control.Monad (join)
 import Control.Monad.State (modify)
+import qualified Data.Map as Map (lookup)
+import Data.List (nub, intercalate)
 import Text.PrettyPrint.HughesPJ (Doc, text, (<>), (<+>), parens, empty, 
   equals, semi, vcat, lbrace, rbrace, render, colon, render)
 
@@ -333,10 +336,27 @@ instance BooleanExpression JavaCode where
   
 instance ValueExpression JavaCode where
   inlineIf = G.inlineIf
-  funcApp = G.funcApp
-  selfFuncApp = G.selfFuncApp self
-  extFuncApp = G.extFuncApp
-  newObj = G.newObj newObjDocD
+  funcApp n t vs = do
+    cm <- zoom lensMStoFS getModuleName
+    mem <- getMethodExcMap
+    modify (maybe id addExceptions (Map.lookup (cm ++ "." ++ n) mem))
+    G.funcApp n t vs
+  selfFuncApp n t vs = do
+    slf <- self :: MS (JavaCode (Variable JavaCode))
+    mem <- getMethodExcMap
+    let tp = getTypeString (variableType slf)
+    modify (maybe id addExceptions (Map.lookup (tp ++ "." ++ n) mem))
+    G.selfFuncApp self n t vs
+  extFuncApp l n t vs = do
+    mem <- getMethodExcMap
+    modify (maybe id addExceptions (Map.lookup (l ++ "." ++ n) mem))
+    G.extFuncApp l n t vs
+  newObj ot vs = do
+    t <- ot
+    mem <- getMethodExcMap
+    let tp = getTypeString t
+    modify (maybe id addExceptions (Map.lookup (tp ++ "." ++ tp) mem))
+    G.newObj newObjDocD ot vs
   extNewObj _ = newObj
 
   exists = notNull
@@ -369,7 +389,12 @@ instance Selector JavaCode where
   indexOf = G.indexOf "indexOf"
 
 instance InternalSelector JavaCode where
-  objMethodCall' = G.objMethodCall
+  objMethodCall' f t o ps = do
+    ob <- o
+    mem <- getMethodExcMap
+    let tp = getTypeString (valueType ob)
+    modify (maybe id addExceptions (Map.lookup (tp ++ "." ++ f) mem))
+    G.objMethodCall f t o ps
   objMethodCallNoParams' = G.objMethodCallNoParams
 
 instance FunctionSym JavaCode where
@@ -576,8 +601,10 @@ instance MethodSym JavaCode where
 
 instance InternalMethod JavaCode where
   intMethod m n s p t ps b = modify (if m then setCurrMain else id) >> 
-    on3StateValues (\tp pms bd -> methodFromData Pub $ jMethod n s p tp pms bd) 
-    t (sequence ps) b
+    (\tp pms bd mem es cn -> methodFromData Pub $ jMethod n (maybe es (nub . 
+    (++ es)) (Map.lookup (key cn n) mem)) s p tp pms bd) <$> t <*> sequence ps 
+    <*> b <*> getMethodExcMap <*> getExceptions <*> getClassName
+    where key cnm nm = if null cnm then nm else cnm ++ "." ++ nm
   intFunc = G.intFunc
   commentedFunc cmt m = on2StateValues (on2CodeValues updateMthdDoc) m 
     (onStateValue (onCodeValue commentedItem) cmt)
@@ -741,12 +768,13 @@ jStringSplit :: (RenderSym repr) => MS (repr (Variable repr)) ->
 jStringSplit = on2StateValues (\vnew s -> variableDoc vnew <+> equals <+> new 
   <+> getTypeDoc (variableType vnew) <> parens (valueDoc s))
 
-jMethod :: (RenderSym repr) => Label -> repr (Scope repr) -> 
+jMethod :: (RenderSym repr) => Label -> [String] -> repr (Scope repr) -> 
   repr (Permanence repr) -> repr (Type repr) -> [repr (Parameter repr)] -> 
   repr (Body repr) -> Doc
-jMethod n s p t ps b = vcat [
+jMethod n es s p t ps b = vcat [
   scopeDoc s <+> permDoc p <+> getTypeDoc t <+> text n <> 
-    parens (parameterList ps) <+> text "throws Exception" <+> lbrace,
+    parens (parameterList ps) <+> emptyIfNull es (text "throws" <+> 
+    text  (intercalate ", " es)) <+> lbrace,
   indent $ bodyDoc b,
   rbrace]
 

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer/LanguagePolymorphic.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer/LanguagePolymorphic.hs
@@ -84,7 +84,7 @@ import GOOL.Drasil.LanguageRenderer (forLabel, new, observerListName, addExt,
   enumDocD, enumElementsDocD, fileDoc', docFuncRepr, commentDocD, commentedItem,
   functionDox, classDox, moduleDox, getterName, setterName, valueList, intValue)
 import GOOL.Drasil.State (FS, CS, MS, lensFStoGS, lensFStoCS, lensFStoMS, 
-  lensCStoMS, currMain, modifyAfter, modifyReturnFunc, modifyReturnFunc2, 
+  lensCStoMS, currMain, modifyReturnFunc, modifyReturnFunc2, 
   addFile, setMainMod, addLangImport, getLangImports, getModuleImports, 
   setFilePath, getFilePath, setModuleName, getModuleName, setClassName,
   getClassName, addParameter)
@@ -1067,7 +1067,7 @@ buildModule' n inc ms cs = S.modFromData n (on3StateValues (\cls lis mis ->
 
 modFromData :: Label -> (Doc -> repr (Module repr)) -> FS Doc -> 
   FS (repr (Module repr))
-modFromData n f d = modifyAfter (setModuleName n) (onStateValue f d)
+modFromData n f d = modify (setModuleName n) >> onStateValue f d
 
 -- Files --
 

--- a/code/stable/glassbr/src/java/GlassBR/Calculations.java
+++ b/code/stable/glassbr/src/java/GlassBR/Calculations.java
@@ -6,6 +6,7 @@ package GlassBR;
 */
 import java.io.File;
 import java.io.FileWriter;
+import java.io.IOException;
 import java.io.PrintWriter;
 
 public class Calculations {
@@ -14,7 +15,7 @@ public class Calculations {
         \param inParams structure holding the input values
         \return stress distribution factor (Function) based on Pbtol
     */
-    public static double func_J_tol(InputParameters inParams) throws Exception {
+    public static double func_J_tol(InputParameters inParams) throws IOException {
         PrintWriter outfile;
         outfile = new PrintWriter(new FileWriter(new File("log.txt"), true));
         outfile.println("function func_J_tol called with inputs: {");
@@ -30,7 +31,7 @@ public class Calculations {
         \param inParams structure holding the input values
         \return applied load (demand): 3 second duration equivalent pressure (Pa)
     */
-    public static double func_q(InputParameters inParams) throws Exception {
+    public static double func_q(InputParameters inParams) throws Exception, IOException {
         PrintWriter outfile;
         outfile = new PrintWriter(new FileWriter(new File("log.txt"), true));
         outfile.println("function func_q called with inputs: {");
@@ -47,7 +48,7 @@ public class Calculations {
         \param q applied load (demand): 3 second duration equivalent pressure (Pa)
         \return dimensionless load
     */
-    public static double func_q_hat(InputParameters inParams, double q) throws Exception {
+    public static double func_q_hat(InputParameters inParams, double q) throws IOException {
         PrintWriter outfile;
         outfile = new PrintWriter(new FileWriter(new File("log.txt"), true));
         outfile.println("function func_q_hat called with inputs: {");
@@ -67,7 +68,7 @@ public class Calculations {
         \param J_tol stress distribution factor (Function) based on Pbtol
         \return tolerable load
     */
-    public static double func_q_hat_tol(InputParameters inParams, double J_tol) throws Exception {
+    public static double func_q_hat_tol(InputParameters inParams, double J_tol) throws Exception, IOException {
         PrintWriter outfile;
         outfile = new PrintWriter(new FileWriter(new File("log.txt"), true));
         outfile.println("function func_q_hat_tol called with inputs: {");
@@ -87,7 +88,7 @@ public class Calculations {
         \param q_hat dimensionless load
         \return stress distribution factor (Function)
     */
-    public static double func_J(InputParameters inParams, double q_hat) throws Exception {
+    public static double func_J(InputParameters inParams, double q_hat) throws Exception, IOException {
         PrintWriter outfile;
         outfile = new PrintWriter(new FileWriter(new File("log.txt"), true));
         outfile.println("function func_J called with inputs: {");
@@ -107,7 +108,7 @@ public class Calculations {
         \param q_hat_tol tolerable load
         \return non-factored load: three second duration uniform load associated with a probability of breakage less than or equal to 8 lites per 1000 for monolithic AN glass (Pa)
     */
-    public static double func_NFL(InputParameters inParams, double q_hat_tol) throws Exception {
+    public static double func_NFL(InputParameters inParams, double q_hat_tol) throws IOException {
         PrintWriter outfile;
         outfile = new PrintWriter(new FileWriter(new File("log.txt"), true));
         outfile.println("function func_NFL called with inputs: {");
@@ -127,7 +128,7 @@ public class Calculations {
         \param J stress distribution factor (Function)
         \return risk of failure
     */
-    public static double func_B(InputParameters inParams, double J) throws Exception {
+    public static double func_B(InputParameters inParams, double J) throws IOException {
         PrintWriter outfile;
         outfile = new PrintWriter(new FileWriter(new File("log.txt"), true));
         outfile.println("function func_B called with inputs: {");
@@ -147,7 +148,7 @@ public class Calculations {
         \param NFL non-factored load: three second duration uniform load associated with a probability of breakage less than or equal to 8 lites per 1000 for monolithic AN glass (Pa)
         \return load resistance: the uniform lateral load that a glass construction can sustain based upon a given probability of breakage and load duration as defined in (pp. 1 and 53) Ref: astm2009 (Pa)
     */
-    public static double func_LR(InputParameters inParams, double NFL) throws Exception {
+    public static double func_LR(InputParameters inParams, double NFL) throws IOException {
         PrintWriter outfile;
         outfile = new PrintWriter(new FileWriter(new File("log.txt"), true));
         outfile.println("function func_LR called with inputs: {");
@@ -167,7 +168,7 @@ public class Calculations {
         \param q applied load (demand): 3 second duration equivalent pressure (Pa)
         \return 3 second load equivalent resistance safety requirement
     */
-    public static Boolean func_is_safeLR(double LR, double q) throws Exception {
+    public static Boolean func_is_safeLR(double LR, double q) throws IOException {
         PrintWriter outfile;
         outfile = new PrintWriter(new FileWriter(new File("log.txt"), true));
         outfile.println("function func_is_safeLR called with inputs: {");
@@ -186,7 +187,7 @@ public class Calculations {
         \param B risk of failure
         \return probability of breakage: the fraction of glass lites or plies that would break at the first occurrence of a specified load and duration, typically expressed in lites per 1000 (Ref: astm2016)
     */
-    public static double func_P_b(double B) throws Exception {
+    public static double func_P_b(double B) throws IOException {
         PrintWriter outfile;
         outfile = new PrintWriter(new FileWriter(new File("log.txt"), true));
         outfile.println("function func_P_b called with inputs: {");
@@ -203,7 +204,7 @@ public class Calculations {
         \param P_b probability of breakage: the fraction of glass lites or plies that would break at the first occurrence of a specified load and duration, typically expressed in lites per 1000 (Ref: astm2016)
         \return probability of glass breakage safety requirement
     */
-    public static Boolean func_is_safePb(InputParameters inParams, double P_b) throws Exception {
+    public static Boolean func_is_safePb(InputParameters inParams, double P_b) throws IOException {
         PrintWriter outfile;
         outfile = new PrintWriter(new FileWriter(new File("log.txt"), true));
         outfile.println("function func_is_safePb called with inputs: {");

--- a/code/stable/glassbr/src/java/GlassBR/Control.java
+++ b/code/stable/glassbr/src/java/GlassBR/Control.java
@@ -5,7 +5,9 @@ package GlassBR;
     \brief Controls the flow of the program
 */
 import java.io.File;
+import java.io.FileNotFoundException;
 import java.io.FileWriter;
+import java.io.IOException;
 import java.io.PrintWriter;
 
 public class Control {
@@ -13,7 +15,7 @@ public class Control {
     /** \brief Controls the flow of the program
         \param args List of command-line arguments
     */
-    public static void main(String[] args) throws Exception {
+    public static void main(String[] args) throws Exception, FileNotFoundException, IOException {
         PrintWriter outfile;
         String filename = args[0];
         outfile = new PrintWriter(new FileWriter(new File("log.txt"), true));

--- a/code/stable/glassbr/src/java/GlassBR/DerivedValues.java
+++ b/code/stable/glassbr/src/java/GlassBR/DerivedValues.java
@@ -6,6 +6,7 @@ package GlassBR;
 */
 import java.io.File;
 import java.io.FileWriter;
+import java.io.IOException;
 import java.io.PrintWriter;
 
 public class DerivedValues {
@@ -13,7 +14,7 @@ public class DerivedValues {
     /** \brief Calculates values that can be immediately derived from the inputs
         \param inParams structure holding the input values
     */
-    public static void derived_values(InputParameters inParams) throws Exception {
+    public static void derived_values(InputParameters inParams) throws Exception, IOException {
         PrintWriter outfile;
         outfile = new PrintWriter(new FileWriter(new File("log.txt"), true));
         outfile.println("function derived_values called with inputs: {");

--- a/code/stable/glassbr/src/java/GlassBR/InputConstraints.java
+++ b/code/stable/glassbr/src/java/GlassBR/InputConstraints.java
@@ -6,6 +6,7 @@ package GlassBR;
 */
 import java.io.File;
 import java.io.FileWriter;
+import java.io.IOException;
 import java.io.PrintWriter;
 
 public class InputConstraints {
@@ -13,7 +14,7 @@ public class InputConstraints {
     /** \brief Verifies that input values satisfy the physical constraints and software constraints
         \param inParams structure holding the input values
     */
-    public static void input_constraints(InputParameters inParams) throws Exception {
+    public static void input_constraints(InputParameters inParams) throws Exception, IOException {
         PrintWriter outfile;
         outfile = new PrintWriter(new FileWriter(new File("log.txt"), true));
         outfile.println("function input_constraints called with inputs: {");

--- a/code/stable/glassbr/src/java/GlassBR/InputFormat.java
+++ b/code/stable/glassbr/src/java/GlassBR/InputFormat.java
@@ -5,7 +5,9 @@ package GlassBR;
     \brief Provides the function for reading inputs
 */
 import java.io.File;
+import java.io.FileNotFoundException;
 import java.io.FileWriter;
+import java.io.IOException;
 import java.io.PrintWriter;
 import java.util.Scanner;
 
@@ -15,7 +17,7 @@ public class InputFormat {
         \param filename name of the input file
         \param inParams structure holding the input values
     */
-    public static void get_input(String filename, InputParameters inParams) throws Exception {
+    public static void get_input(String filename, InputParameters inParams) throws FileNotFoundException, IOException {
         PrintWriter outfile;
         outfile = new PrintWriter(new FileWriter(new File("log.txt"), true));
         outfile.println("function get_input called with inputs: {");

--- a/code/stable/glassbr/src/java/GlassBR/Interpolation.java
+++ b/code/stable/glassbr/src/java/GlassBR/Interpolation.java
@@ -5,7 +5,9 @@ package GlassBR;
     \brief Provides functions for linear interpolation on three-dimensional data
 */
 import java.io.File;
+import java.io.FileNotFoundException;
 import java.io.FileWriter;
+import java.io.IOException;
 import java.io.PrintWriter;
 import java.util.ArrayList;
 
@@ -19,7 +21,7 @@ public class Interpolation {
         \param x x-coordinate to interpolate at
         \return y value interpolated at given x value
     */
-    public static double func_lin_interp(double x_1, double y_1, double x_2, double y_2, double x) throws Exception {
+    public static double func_lin_interp(double x_1, double y_1, double x_2, double y_2, double x) throws IOException {
         PrintWriter outfile;
         outfile = new PrintWriter(new FileWriter(new File("log.txt"), true));
         outfile.println("function func_lin_interp called with inputs: {");
@@ -48,7 +50,7 @@ public class Interpolation {
         \param v value whose index will be found
         \return index of given value in given array
     */
-    public static int func_find(ArrayList<Double> arr, double v) throws Exception {
+    public static int func_find(ArrayList<Double> arr, double v) throws Exception, IOException {
         PrintWriter outfile;
         outfile = new PrintWriter(new FileWriter(new File("log.txt"), true));
         outfile.println("function func_find called with inputs: {");
@@ -73,7 +75,7 @@ public class Interpolation {
         \param j index
         \return column of the given matrix at the given index
     */
-    public static ArrayList<Double> func_extractColumn(ArrayList<ArrayList<Double>> mat, int j) throws Exception {
+    public static ArrayList<Double> func_extractColumn(ArrayList<ArrayList<Double>> mat, int j) throws IOException {
         PrintWriter outfile;
         outfile = new PrintWriter(new FileWriter(new File("log.txt"), true));
         outfile.println("function func_extractColumn called with inputs: {");
@@ -98,7 +100,7 @@ public class Interpolation {
         \param z z-coordinate to interpolate at
         \return y value interpolated at given x and z values
     */
-    public static double func_interpY(String filename, double x, double z) throws Exception {
+    public static double func_interpY(String filename, double x, double z) throws Exception, FileNotFoundException, IOException {
         PrintWriter outfile;
         outfile = new PrintWriter(new FileWriter(new File("log.txt"), true));
         outfile.println("function func_interpY called with inputs: {");
@@ -193,7 +195,7 @@ public class Interpolation {
         \param y y-coordinate to interpolate at
         \return z value interpolated at given x and y values
     */
-    public static double func_interpZ(String filename, double x, double y) throws Exception {
+    public static double func_interpZ(String filename, double x, double y) throws Exception, FileNotFoundException, IOException {
         PrintWriter outfile;
         outfile = new PrintWriter(new FileWriter(new File("log.txt"), true));
         outfile.println("function func_interpZ called with inputs: {");

--- a/code/stable/glassbr/src/java/GlassBR/OutputFormat.java
+++ b/code/stable/glassbr/src/java/GlassBR/OutputFormat.java
@@ -6,6 +6,7 @@ package GlassBR;
 */
 import java.io.File;
 import java.io.FileWriter;
+import java.io.IOException;
 import java.io.PrintWriter;
 
 public class OutputFormat {
@@ -15,7 +16,7 @@ public class OutputFormat {
         \param is_safeLR 3 second load equivalent resistance safety requirement
         \param P_b probability of breakage: the fraction of glass lites or plies that would break at the first occurrence of a specified load and duration, typically expressed in lites per 1000 (Ref: astm2016)
     */
-    public static void write_output(Boolean is_safePb, Boolean is_safeLR, double P_b) throws Exception {
+    public static void write_output(Boolean is_safePb, Boolean is_safeLR, double P_b) throws IOException {
         PrintWriter outfile;
         outfile = new PrintWriter(new FileWriter(new File("log.txt"), true));
         outfile.println("function write_output called with inputs: {");

--- a/code/stable/glassbr/src/java/GlassBR/ReadTable.java
+++ b/code/stable/glassbr/src/java/GlassBR/ReadTable.java
@@ -5,7 +5,9 @@ package GlassBR;
     \brief Provides a function for reading glass ASTM data
 */
 import java.io.File;
+import java.io.FileNotFoundException;
 import java.io.FileWriter;
+import java.io.IOException;
 import java.io.PrintWriter;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -19,7 +21,7 @@ public class ReadTable {
         \param x_matrix lists of x values at different z values
         \param y_matrix lists of y values at different z values
     */
-    public static void func_read_table(String filename, ArrayList<Double> z_vector, ArrayList<ArrayList<Double>> x_matrix, ArrayList<ArrayList<Double>> y_matrix) throws Exception {
+    public static void func_read_table(String filename, ArrayList<Double> z_vector, ArrayList<ArrayList<Double>> x_matrix, ArrayList<ArrayList<Double>> y_matrix) throws FileNotFoundException, IOException {
         PrintWriter outfile;
         outfile = new PrintWriter(new FileWriter(new File("log.txt"), true));
         outfile.println("function func_read_table called with inputs: {");

--- a/code/stable/nopcm/src/java/SWHS/Control.java
+++ b/code/stable/nopcm/src/java/SWHS/Control.java
@@ -4,12 +4,15 @@ package SWHS;
     \author Thulasi Jegatheesan
     \brief Controls the flow of the program
 */
+import java.io.FileNotFoundException;
+import java.io.IOException;
+
 public class Control {
     
     /** \brief Controls the flow of the program
         \param args List of command-line arguments
     */
-    public static void main(String[] args) throws Exception {
+    public static void main(String[] args) throws FileNotFoundException, IOException {
         String filename = args[0];
         double A_C;
         double C_W;

--- a/code/stable/nopcm/src/java/SWHS/InputParameters.java
+++ b/code/stable/nopcm/src/java/SWHS/InputParameters.java
@@ -5,6 +5,7 @@ package SWHS;
     \brief Provides the function for reading inputs and the function for checking the physical constraints and software constraints on the input
 */
 import java.io.File;
+import java.io.FileNotFoundException;
 import java.util.Scanner;
 
 public class InputParameters {
@@ -27,7 +28,7 @@ public class InputParameters {
         \return temperature of the water: the average kinetic energy of the particles within the water (degreeC)
         \return change in heat energy in the water: change in thermal energy within the water (J)
     */
-    public static Object[] get_input(String filename) throws Exception {
+    public static Object[] get_input(String filename) throws FileNotFoundException {
         double A_C;
         double C_W;
         double h_C;
@@ -107,7 +108,7 @@ public class InputParameters {
         \param T_W temperature of the water: the average kinetic energy of the particles within the water (degreeC)
         \param E_W change in heat energy in the water: change in thermal energy within the water (J)
     */
-    public static void input_constraints(double A_C, double C_W, double h_C, double T_init, double t_final, double L, double T_C, double t_step, double rho_W, double D, double T_W, double E_W) throws Exception {
+    public static void input_constraints(double A_C, double C_W, double h_C, double T_init, double t_final, double L, double T_C, double t_step, double rho_W, double D, double T_W, double E_W) {
         if (!(A_C <= Constants.A_C_max)) {
             System.out.print("Warning: ");
             System.out.print("A_C has value ");

--- a/code/stable/nopcm/src/java/SWHS/OutputFormat.java
+++ b/code/stable/nopcm/src/java/SWHS/OutputFormat.java
@@ -6,6 +6,7 @@ package SWHS;
 */
 import java.io.File;
 import java.io.FileWriter;
+import java.io.IOException;
 import java.io.PrintWriter;
 
 public class OutputFormat {
@@ -14,7 +15,7 @@ public class OutputFormat {
         \param T_W temperature of the water: the average kinetic energy of the particles within the water (degreeC)
         \param E_W change in heat energy in the water: change in thermal energy within the water (J)
     */
-    public static void write_output(double T_W, double E_W) throws Exception {
+    public static void write_output(double T_W, double E_W) throws IOException {
         PrintWriter outputfile;
         outputfile = new PrintWriter(new FileWriter(new File("output.txt"), false));
         outputfile.print("T_W = ");

--- a/code/stable/projectile/src/java/Projectile/Calculations.java
+++ b/code/stable/projectile/src/java/Projectile/Calculations.java
@@ -11,7 +11,7 @@ public class Calculations {
         \param g_vect gravitational acceleration (m/s^2)
         \return flight duration: the time when the projectile lands (s)
     */
-    public static double func_t_flight(InputParameters inParams, double g_vect) throws Exception {
+    public static double func_t_flight(InputParameters inParams, double g_vect) {
         return 2 * inParams.v_launch * Math.sin(inParams.theta) / g_vect;
     }
     
@@ -20,7 +20,7 @@ public class Calculations {
         \param g_vect gravitational acceleration (m/s^2)
         \return landing position: the distance from the launcher to the final position of the projectile (m)
     */
-    public static double func_p_land(InputParameters inParams, double g_vect) throws Exception {
+    public static double func_p_land(InputParameters inParams, double g_vect) {
         return 2 * Math.pow(inParams.v_launch, 2) * Math.sin(inParams.theta) * Math.cos(inParams.theta) / g_vect;
     }
     
@@ -29,7 +29,7 @@ public class Calculations {
         \param p_land landing position: the distance from the launcher to the final position of the projectile (m)
         \return distance between the target position and the landing position: the offset between the target position and the landing position (m)
     */
-    public static double func_d_offset(InputParameters inParams, double p_land) throws Exception {
+    public static double func_d_offset(InputParameters inParams, double p_land) {
         return p_land - inParams.p_target;
     }
     
@@ -39,7 +39,7 @@ public class Calculations {
         \param d_offset distance between the target position and the landing position: the offset between the target position and the landing position (m)
         \return output message as a string
     */
-    public static String func_s(InputParameters inParams, double epsilon, double d_offset) throws Exception {
+    public static String func_s(InputParameters inParams, double epsilon, double d_offset) {
         if (Math.abs(d_offset / inParams.p_target) < epsilon) {
             return "The target was hit.";
         }

--- a/code/stable/projectile/src/java/Projectile/Control.java
+++ b/code/stable/projectile/src/java/Projectile/Control.java
@@ -4,12 +4,14 @@ package Projectile;
     \author Samuel J. Crawford, Brooks MacLachlan, and W. Spencer Smith
     \brief Controls the flow of the program
 */
+import java.io.IOException;
+
 public class Control {
     
     /** \brief Controls the flow of the program
         \param args List of command-line arguments
     */
-    public static void main(String[] args) throws Exception {
+    public static void main(String[] args) throws IOException {
         String filename = args[0];
         InputParameters inParams = new InputParameters(filename);
         double g_vect = 9.8;

--- a/code/stable/projectile/src/java/Projectile/InputParameters.java
+++ b/code/stable/projectile/src/java/Projectile/InputParameters.java
@@ -5,6 +5,7 @@ package Projectile;
     \brief Provides the structure for holding input values
 */
 import java.io.File;
+import java.io.FileNotFoundException;
 import java.util.Scanner;
 
 /** \brief Structure for holding the input values
@@ -17,7 +18,7 @@ public class InputParameters {
     /** \brief Initializes input object by reading inputs and checking physical constraints and software constraints on the input
         \param filename name of the input file
     */
-    public InputParameters(String filename) throws Exception {
+    public InputParameters(String filename) throws FileNotFoundException {
         this.get_input(filename);
         this.input_constraints();
     }
@@ -25,7 +26,7 @@ public class InputParameters {
     /** \brief Reads input from a file with the given file name
         \param filename name of the input file
     */
-    private void get_input(String filename) throws Exception {
+    private void get_input(String filename) throws FileNotFoundException {
         Scanner infile;
         infile = new Scanner(new File(filename));
         infile.nextLine();
@@ -39,7 +40,7 @@ public class InputParameters {
     
     /** \brief Verifies that input values satisfy the physical constraints and software constraints
     */
-    private void input_constraints() throws Exception {
+    private void input_constraints() {
         if (!(this.v_launch > 0)) {
             System.out.print("Warning: ");
             System.out.print("v_launch has value ");

--- a/code/stable/projectile/src/java/Projectile/OutputFormat.java
+++ b/code/stable/projectile/src/java/Projectile/OutputFormat.java
@@ -6,6 +6,7 @@ package Projectile;
 */
 import java.io.File;
 import java.io.FileWriter;
+import java.io.IOException;
 import java.io.PrintWriter;
 
 public class OutputFormat {
@@ -14,7 +15,7 @@ public class OutputFormat {
         \param s output message as a string
         \param d_offset distance between the target position and the landing position: the offset between the target position and the landing position (m)
     */
-    public static void write_output(String s, double d_offset) throws Exception {
+    public static void write_output(String s, double d_offset) throws IOException {
         PrintWriter outputfile;
         outputfile = new PrintWriter(new FileWriter(new File("output.txt"), false));
         outputfile.print("s = ");


### PR DESCRIPTION
This PR updates GOOL's Java renderer so that we no longer generate "throws Exception" for every single method. Instead we use state to keep track of which exceptions are thrown by a given function, and declare only those that we need.

This change was necessary for my work on ODE solvers to compile, which is why I'm doing it now.