### PR TITLE
Initializer lists in GOOL

### DIFF
--- a/code/drasil-code/Language/Drasil/Code/Imperative/ConceptMatch.hs
+++ b/code/drasil-code/Language/Drasil/Code/Imperative/ConceptMatch.hs
@@ -5,7 +5,7 @@ module Language.Drasil.Code.Imperative.ConceptMatch (
 import Language.Drasil.CodeSpec (Choices(..), CodeConcept(..), 
   MatchedConceptMap)
 
-import GOOL.Drasil (ProgramSym, ValueSym(..), MS)
+import GOOL.Drasil (ProgramSym, ValueSym(..), VS)
 
 import Prelude hiding (pi)
 import qualified Data.Map as Map (map)
@@ -17,6 +17,6 @@ chooseConcept chs = Map.map (chooseConcept' chs) (conceptMatch chs)
           "ConceptMatchMap"
         chooseConcept' _ cs = head cs
 
-conceptToGOOL :: (ProgramSym repr) => CodeConcept -> MS (repr (Value repr))
+conceptToGOOL :: (ProgramSym repr) => CodeConcept -> VS (repr (Value repr))
 conceptToGOOL Pi = pi
 

--- a/code/drasil-code/Language/Drasil/Code/Imperative/FunctionCalls.hs
+++ b/code/drasil-code/Language/Drasil/Code/Imperative/FunctionCalls.hs
@@ -17,7 +17,7 @@ import Language.Drasil.Chunk.CodeQuantity (HasCodeType)
 import Language.Drasil.CodeSpec (CodeSpec(..))
 
 import GOOL.Drasil (ProgramSym, TypeSym(..), ValueSym(..), StatementSym(..), 
-  MS, convType)
+  MS, VS, convType)
 
 import Data.List ((\\), intersect)
 import qualified Data.Map as Map (lookup)
@@ -64,8 +64,8 @@ getOutputCall = do
   return $ fmap valState val
 
 getFuncCall :: (ProgramSym repr, HasUID c, HasCodeType c, CodeIdea c) => String 
-  -> MS (repr (Type repr)) -> Reader DrasilState [c] -> 
-  Reader DrasilState (Maybe (MS (repr (Value repr))))
+  -> VS (repr (Type repr)) -> Reader DrasilState [c] -> 
+  Reader DrasilState (Maybe (VS (repr (Value repr))))
 getFuncCall n t funcPs = do
   mm <- getCall n
   let getFuncCall' Nothing = return Nothing

--- a/code/drasil-code/Language/Drasil/Code/Imperative/Modules.hs
+++ b/code/drasil-code/Language/Drasil/Code/Imperative/Modules.hs
@@ -36,7 +36,7 @@ import GOOL.Drasil (ProgramSym, FileSym(..), BodySym(..), BlockSym(..),
   PermanenceSym(..), TypeSym(..), VariableSym(..), ValueSym(..), 
   BooleanExpression(..), StatementSym(..), ControlStatementSym(..), 
   ScopeSym(..), MethodSym(..), StateVarSym(..), ClassSym(..), ScopeTag(..), 
-  convType, FS, CS, MS)
+  convType, FS, CS, MS, VS)
 
 import Prelude hiding (print)
 import Data.List (intersperse, intercalate, partition)
@@ -164,7 +164,7 @@ genInputModCombined = do
   liftS $ genMod ic
 
 constVarFunc :: (ProgramSym repr) => ConstantRepr -> String ->
-  (MS (repr (Variable repr)) -> MS (repr (Value repr)) -> 
+  (VS (repr (Variable repr)) -> VS (repr (Value repr)) -> 
   CS (repr (StateVar repr)))
 constVarFunc Var n = stateVarDef n public dynamic_
 constVarFunc Const n = constVar n public

--- a/code/drasil-gool/GOOL/Drasil.hs
+++ b/code/drasil-gool/GOOL/Drasil.hs
@@ -10,7 +10,7 @@ module GOOL.Drasil (Label, ProgramSym(..), FileSym(..),
   odeOptions, ODEMethod(..),
   ScopeTag(..), ProgData(..), FileData(..), ModData(..),
   CodeType(..),
-  GOOLState(..), GS, FS, CS, MS, headers, sources, mainMod, 
+  GOOLState(..), GS, FS, CS, MS, VS, lensMStoVS, headers, sources, mainMod, 
   initialState,
   convType, onStateValue, onCodeList,
   unCI, unPC, unJC, unCSC, unCPPC
@@ -29,8 +29,8 @@ import GOOL.Drasil.Data (ScopeTag(..), FileData(..), ModData(..), ProgData(..))
 
 import GOOL.Drasil.CodeType (CodeType(..))
 
-import GOOL.Drasil.State (GOOLState(..), GS, FS, CS, MS, headers, 
-  sources, mainMod, initialState)
+import GOOL.Drasil.State (GOOLState(..), GS, FS, CS, MS, VS, lensMStoVS, 
+  headers, sources, mainMod, initialState)
 
 import GOOL.Drasil.Helpers (convType, onStateValue, onCodeList)
 

--- a/code/drasil-gool/GOOL/Drasil/Helpers.hs
+++ b/code/drasil-gool/GOOL/Drasil/Helpers.hs
@@ -10,7 +10,7 @@ import Utils.Drasil (blank)
 import qualified GOOL.Drasil.CodeType as C (CodeType(..))
 import qualified GOOL.Drasil.Symantics as S ( 
   TypeSym(..), PermanenceSym(dynamic_))
-import GOOL.Drasil.State (MS)
+import GOOL.Drasil.State (VS)
 
 import Prelude hiding ((<>))
 import Control.Applicative (liftA2, liftA3)
@@ -97,7 +97,7 @@ getNestDegree :: Integer -> C.CodeType -> Integer
 getNestDegree n (C.List t) = getNestDegree (n+1) t
 getNestDegree n _ = n
 
-convType :: (S.TypeSym repr) => C.CodeType -> MS (repr (S.Type repr))
+convType :: (S.TypeSym repr) => C.CodeType -> VS (repr (S.Type repr))
 convType C.Boolean = S.bool
 convType C.Integer = S.int
 convType C.Float = S.float

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer/CSharpRenderer.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer/CSharpRenderer.hs
@@ -66,9 +66,9 @@ import GOOL.Drasil.Data (Terminator(..), ScopeTag(..), FileType(..),
 import GOOL.Drasil.Helpers (toCode, toState, onCodeValue, onStateValue, 
   on2CodeValues, on2StateValues, on3CodeValues, on3StateValues, onCodeList, 
   onStateList, on1CodeValue1List)
-import GOOL.Drasil.State (MS, lensGStoFS, modifyReturn, tempStateChange, 
-  addLangImport, addLibImport, getClassName, setCurrMain, setODEDepVars, 
-  getODEDepVars)
+import GOOL.Drasil.State (MS, VS, lensGStoFS, lensMStoVS, modifyReturn, 
+  tempStateChange, addLangImport, addLangImportVS, addLibImport, getClassName, 
+  setCurrMain, setODEDepVars, getODEDepVars)
 
 import Prelude hiding (break,print,(<>),sin,cos,tan,floor)
 import Control.Lens.Zoom (zoom)
@@ -185,7 +185,7 @@ instance TypeSym CSharpCode where
   string = G.string
   infile = csInfileType
   outfile = csOutfileType
-  listType p t = modify (addLangImport "System.Collections.Generic") >> 
+  listType p t = modify (addLangImportVS "System.Collections.Generic") >> 
     G.listType p t
   listInnerType = G.listInnerType
   obj = G.obj
@@ -472,10 +472,11 @@ instance StatementSym CSharpCode where
   (&++) = G.increment1
   (&~-) = G.decrement1
 
-  varDec v = v >>= (\v' -> csVarDec (variableBind v') $ G.varDec static_ 
-    dynamic_ v)
+  varDec v = zoom lensMStoVS v >>= (\v' -> csVarDec (variableBind v') $ 
+    G.varDec static_ dynamic_ v)
   varDecDef = G.varDecDef
-  listDec n v = v >>= (\v' -> G.listDec (listDecDocD v') (litInt n) v)
+  listDec n v = zoom lensMStoVS v >>= (\v' -> G.listDec (listDecDocD v') 
+    (litInt n) v)
   listDecDef = G.listDecDef'
   objDecDef = varDecDef
   objDecNew = G.objDecNew
@@ -569,7 +570,7 @@ instance InternalScope CSharpCode where
 
 instance MethodTypeSym CSharpCode where
   type MethodType CSharpCode = TypeData
-  mType t = t
+  mType = zoom lensMStoVS 
   construct = G.construct
 
 instance ParameterSym CSharpCode where
@@ -665,8 +666,8 @@ instance BlockCommentSym CSharpCode where
 
   blockCommentDoc = unCSC
 
-addSystemImport :: MS a -> MS a
-addSystemImport = (>>) $ modify (addLangImport "System")
+addSystemImport :: VS a -> VS a
+addSystemImport = (>>) $ modify (addLangImportVS "System")
 
 csName :: String
 csName = "C#"
@@ -679,16 +680,16 @@ csODEMethod _ = error "Chosen ODE method unavailable in C#"
 csImport :: Label -> CSharpCode (Keyword CSharpCode) -> Doc
 csImport n end = text ("using " ++ n) <> keyDoc end
 
-csInfileType :: (RenderSym repr) => MS (repr (Type repr))
-csInfileType = modifyReturn (addLangImport "System.IO") $ 
+csInfileType :: (RenderSym repr) => VS (repr (Type repr))
+csInfileType = modifyReturn (addLangImportVS "System.IO") $ 
   typeFromData File "StreamReader" (text "StreamReader")
 
-csOutfileType :: (RenderSym repr) => MS (repr (Type repr))
-csOutfileType = modifyReturn (addLangImport "System.IO") $ 
+csOutfileType :: (RenderSym repr) => VS (repr (Type repr))
+csOutfileType = modifyReturn (addLangImportVS "System.IO") $ 
   typeFromData File "StreamWriter" (text "StreamWriter")
 
-csCast :: MS (CSharpCode (Type CSharpCode)) -> 
-  MS (CSharpCode (Value CSharpCode)) -> MS (CSharpCode (Value CSharpCode))
+csCast :: VS (CSharpCode (Type CSharpCode)) -> 
+  VS (CSharpCode (Value CSharpCode)) -> VS (CSharpCode (Value CSharpCode))
 csCast t v = join $ on2StateValues (\tp vl -> csCast' (getType tp) (getType $ 
   valueType vl) tp vl) t v
   where csCast' Float String _ _ = funcApp "Double.Parse" float [v]
@@ -711,13 +712,13 @@ csTryCatch tb cb = vcat [
 csDiscardInput :: (RenderSym repr) => repr (Value repr) -> Doc
 csDiscardInput = valueDoc
 
-csFileInput :: (RenderSym repr) => MS (repr (Value repr)) -> 
-  MS (repr (Value repr))
+csFileInput :: (RenderSym repr) => VS (repr (Value repr)) -> 
+  VS (repr (Value repr))
 csFileInput = onStateValue (\f -> mkVal (valueType f) (valueDoc f <> dot <> 
   text "ReadLine()"))
 
-csInput :: (RenderSym repr) => MS (repr (Type repr)) -> MS (repr (Value repr)) 
-  -> MS (repr (Value repr))
+csInput :: (RenderSym repr) => VS (repr (Type repr)) -> VS (repr (Value repr)) 
+  -> VS (repr (Value repr))
 csInput tp inF = tp >>= (\t -> csInputImport (getType t) $ onStateValue (\inFn 
   -> mkVal t $ text (csInput' (getType t)) <> parens (valueDoc inFn)) inF)
   where csInput' Integer = "Int32.Parse"
@@ -729,12 +730,12 @@ csInput tp inF = tp >>= (\t -> csInputImport (getType t) $ onStateValue (\inFn
         csInputImport t = if t `elem` [Integer, Float, Boolean, Char] then 
           addSystemImport else id
 
-csOpenFileR :: (RenderSym repr) => MS (repr (Value repr)) -> 
-  MS (repr (Type repr)) -> MS (repr (Value repr))
+csOpenFileR :: (RenderSym repr) => VS (repr (Value repr)) -> 
+  VS (repr (Type repr)) -> VS (repr (Value repr))
 csOpenFileR n r = newObj r [n]
 
-csOpenFileWorA :: (RenderSym repr) => MS (repr (Value repr)) -> 
-  MS (repr (Type repr)) -> MS (repr (Value repr)) -> MS (repr (Value repr))
+csOpenFileWorA :: (RenderSym repr) => VS (repr (Value repr)) -> 
+  VS (repr (Type repr)) -> VS (repr (Value repr)) -> VS (repr (Value repr))
 csOpenFileWorA n w a = newObj w [n, a] 
 
 csRef :: Doc -> Doc
@@ -743,11 +744,11 @@ csRef p = text "ref" <+> p
 csOut :: Doc -> Doc
 csOut p = text "out" <+> p
 
-csInOutCall :: (Label -> MS (CSharpCode (Type CSharpCode)) -> 
-  [MS (CSharpCode (Value CSharpCode))] -> MS (CSharpCode (Value CSharpCode)))
-  -> Label -> [MS (CSharpCode (Value CSharpCode))] -> 
-  [MS (CSharpCode (Variable CSharpCode))] -> 
-  [MS (CSharpCode (Variable CSharpCode))] -> 
+csInOutCall :: (Label -> VS (CSharpCode (Type CSharpCode)) -> 
+  [VS (CSharpCode (Value CSharpCode))] -> VS (CSharpCode (Value CSharpCode)))
+  -> Label -> [VS (CSharpCode (Value CSharpCode))] -> 
+  [VS (CSharpCode (Variable CSharpCode))] -> 
+  [VS (CSharpCode (Variable CSharpCode))] -> 
   MS (CSharpCode (Statement CSharpCode))
 csInOutCall f n ins [out] [] = assign out $ f n (onStateValue variableType out) 
   ins
@@ -771,13 +772,13 @@ csObjVar o v = csObjVar' (variableBind v)
           (variableType v) (objVarDocD (variableDoc o) (variableDoc v))
 
 csInOut :: (CSharpCode (Scope CSharpCode) -> CSharpCode (Permanence CSharpCode) 
-    -> MS (CSharpCode (Type CSharpCode)) -> 
+    -> VS (CSharpCode (Type CSharpCode)) -> 
     [MS (CSharpCode (Parameter CSharpCode))] 
     -> MS (CSharpCode (Body CSharpCode)) -> MS (CSharpCode (Method CSharpCode)))
   -> CSharpCode (Scope CSharpCode) -> CSharpCode (Permanence CSharpCode) -> 
-  [MS (CSharpCode (Variable CSharpCode))] -> 
-  [MS (CSharpCode (Variable CSharpCode))] -> 
-  [MS (CSharpCode (Variable CSharpCode))] -> 
+  [VS (CSharpCode (Variable CSharpCode))] -> 
+  [VS (CSharpCode (Variable CSharpCode))] -> 
+  [VS (CSharpCode (Variable CSharpCode))] -> 
   MS (CSharpCode (Body CSharpCode)) -> MS (CSharpCode (Method CSharpCode))
 csInOut f s p ins [v] [] b = f s p (onStateValue variableType v) (map param ins)
   (on3StateValues (on3CodeValues surroundBody) (varDec v) b (returnState $ 

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer/CSharpRenderer.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer/CSharpRenderer.hs
@@ -67,7 +67,7 @@ import GOOL.Drasil.Helpers (toCode, toState, onCodeValue, onStateValue,
   on2CodeValues, on2StateValues, on3CodeValues, on3StateValues, onCodeList, 
   onStateList, on1CodeValue1List)
 import GOOL.Drasil.State (MS, VS, lensGStoFS, lensMStoVS, modifyReturn, 
-  tempStateChange, addLangImport, addLangImportVS, addLibImport, getClassName, 
+  addLangImport, addLangImportVS, addLibImport, getClassName, 
   setCurrMain, setODEDepVars, getODEDepVars)
 
 import Prelude hiding (break,print,(<>),sin,cos,tan,floor)
@@ -212,8 +212,8 @@ instance ControlBlockSym CSharpCode where
         varDecDef sol (extFuncApp "Ode" (csODEMethod $ solveMethod opts) odeT 
         [tInit info, 
         newObj vec [initVal info], 
-        join $ on2StateValues (\idv dpv -> newObj vec [tempStateChange 
-          (setODEDepVars [variableName dpv]) (ode info)] >>= (mkStateVal void .
+        join $ on2StateValues (\idv dpv -> newObj vec [modify 
+          (setODEDepVars [variableName dpv]) >> ode info] >>= (mkStateVal void .
           (parens (variableList [idv, dpv]) <+> text "=>" <+>) . valueDoc)) 
           iv dv,
         join $ on2StateValues (\abt rt -> mkStateVal (obj "Options") (new <+> 

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer/CSharpRenderer.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer/CSharpRenderer.hs
@@ -67,8 +67,8 @@ import GOOL.Drasil.Helpers (toCode, toState, onCodeValue, onStateValue,
   on2CodeValues, on2StateValues, on3CodeValues, on3StateValues, onCodeList, 
   onStateList, on1CodeValue1List)
 import GOOL.Drasil.State (MS, VS, lensGStoFS, lensMStoVS, modifyReturn, 
-  addLangImport, addLangImportVS, addLibImport, getClassName, 
-  setCurrMain, setODEDepVars, getODEDepVars)
+  addLangImport, addLangImportVS, addLibImport, getClassName, setCurrMain, 
+  setODEDepVars, getODEDepVars)
 
 import Prelude hiding (break,print,(<>),sin,cos,tan,floor)
 import Control.Lens.Zoom (zoom)

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer/CppRenderer.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer/CppRenderer.hs
@@ -66,16 +66,21 @@ import GOOL.Drasil.Helpers (angles, doubleQuotedText, hicat, vibcat,
   emptyIfEmpty, toCode, toState, onCodeValue, onStateValue, on2CodeValues, 
   on2StateValues, on3CodeValues, on3StateValues, onCodeList, onStateList, 
   on2StateLists, on1CodeValue1List, on1StateValue1List)
-import GOOL.Drasil.State (GOOLState, CS, MS, VS, lensGStoFS, lensFStoCS, lensFStoMS, lensFStoVS,
-  lensCStoMS, lensCStoVS, lensMStoCS, lensMStoVS, lensVStoMS, initialState, initialFS, modifyReturn, 
-  addODEFilePaths, addODEFile, getODEFiles, addLangImport, 
-  addLangImportVS, getLangImports, addLibImport, getLibImports, addModuleImport, addModuleImportVS,
+import GOOL.Drasil.State (GOOLState, CS, MS, VS, lensGStoFS, lensFStoCS, 
+  lensFStoMS, lensFStoVS, lensCStoMS, lensCStoVS, lensMStoCS, lensMStoVS, 
+  lensVStoMS, initialState, initialFS, modifyReturn, addODEFilePaths, 
+  addODEFile, getODEFiles, addLangImport, addLangImportVS, getLangImports, 
+  addLibImport, getLibImports, addModuleImport, addModuleImportVS,
   getModuleImports, addHeaderLangImport, getHeaderLangImports, 
   addHeaderModImport, getHeaderLibImports, getHeaderModImports, addDefine, 
   getDefines, addHeaderDefine, getHeaderDefines, addUsing, getUsing, 
   addHeaderUsing, getHeaderUsing, setClassName, getClassName, setCurrMain, 
   getCurrMain, getClassMap, setScope, getScope, setCurrMainFunc, 
-  getCurrMainFunc, setODEOthVars, getODEOthVars, setConstructorParams, getConstructorParams, addSelfAssignment, getSelfAssignments, setLeftAssignment, getLeftAssignment, setAssignedSelfVar, getAssignedSelfVar, setRightAssignment, getRightAssignment, addVariableAssigned, getVariablesAssigned)
+  getCurrMainFunc, setODEOthVars, getODEOthVars, setConstructorParams, 
+  getConstructorParams, addSelfAssignment, getSelfAssignments, 
+  setLeftAssignment, getLeftAssignment, setAssignedSelfVar, getAssignedSelfVar, 
+  setRightAssignment, getRightAssignment, addVariableAssigned, 
+  getVariablesAssigned)
 
 import Prelude hiding (break,print,(<>),sin,cos,tan,floor,pi,const,log,exp,mod)
 import Control.Lens.Zoom (zoom)

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer/CppRenderer.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer/CppRenderer.hs
@@ -68,7 +68,7 @@ import GOOL.Drasil.Helpers (angles, doubleQuotedText, vibcat, emptyIfEmpty,
   on1CodeValue1List, on1StateValue1List)
 import GOOL.Drasil.State (GOOLState, CS, MS, VS, lensGStoFS, lensFStoCS, lensFStoMS, lensFStoVS,
   lensCStoMS, lensCStoVS, lensMStoCS, lensMStoVS, initialState, initialFS, modifyReturn, 
-  tempStateChange, addODEFilePaths, addODEFile, getODEFiles, addLangImport, 
+  addODEFilePaths, addODEFile, getODEFiles, addLangImport, 
   addLangImportVS, getLangImports, addLibImport, getLibImports, addModuleImport, addModuleImportVS,
   getModuleImports, addHeaderLangImport, getHeaderLangImports, 
   addHeaderModImport, getHeaderLibImports, getHeaderModImports, addDefine, 
@@ -2311,16 +2311,16 @@ cppODEFile info f p = (fl, fst s)
               tElem = var t $ innerVarType idpv
               dvptr = var ('&':n) (onStateValue variableType dv)
               dvElemPtr = var ('&':n) (innerVarType dpv)
-              othVars = map (tempStateChange (setODEOthVars (map variableName 
-                ovs))) ovars
+              othVars = map (modify (setODEOthVars (map variableName 
+                ovs)) >>) ovars
           in fileDoc (buildModule cn [] [pubClass cn Nothing 
             (pubMVar dv : map privMVar othVars) 
             [constructor (map param othVars) (bodyStatements (map (\v -> 
               objVarSelf v &= valueOf v) othVars)),
             pubMethod "operator()" void [param $ var n $ innerVarType dpv, 
               param $ var ('&':dn) float, param tElem] 
-              (oneLiner $ var dn float &= tempStateChange (setODEOthVars 
-              (map variableName ovs)) (ode info))], 
+              (oneLiner $ var dn float &= (modify (setODEOthVars 
+              (map variableName ovs)) >> ode info))], 
           pubClass ("Populate_" ++ n) Nothing [pubMVar dvptr] 
             [f info,
             pubMethod "operator()" void [param dvElemPtr, param tElem] 

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer/CppRenderer.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer/CppRenderer.hs
@@ -66,16 +66,16 @@ import GOOL.Drasil.Helpers (angles, doubleQuotedText, vibcat, emptyIfEmpty,
   toCode, toState, onCodeValue, onStateValue, on2CodeValues, on2StateValues, 
   on3CodeValues, on3StateValues, onCodeList, onStateList, on2StateLists, 
   on1CodeValue1List, on1StateValue1List)
-import GOOL.Drasil.State (GOOLState, CS, MS, lensGStoFS, lensFStoCS, lensFStoMS,
-  lensCStoMS, lensMStoCS, initialState, initialFS, modifyReturn, 
+import GOOL.Drasil.State (GOOLState, CS, MS, VS, lensGStoFS, lensFStoCS, lensFStoMS, lensFStoVS,
+  lensCStoMS, lensCStoVS, lensMStoCS, lensMStoVS, initialState, initialFS, modifyReturn, 
   tempStateChange, addODEFilePaths, addODEFile, getODEFiles, addLangImport, 
-  getLangImports, addLibImport, getLibImports, addModuleImport, 
+  addLangImportVS, getLangImports, addLibImport, getLibImports, addModuleImport, addModuleImportVS,
   getModuleImports, addHeaderLangImport, getHeaderLangImports, 
   addHeaderModImport, getHeaderLibImports, getHeaderModImports, addDefine, 
   getDefines, addHeaderDefine, getHeaderDefines, addUsing, getUsing, 
   addHeaderUsing, getHeaderUsing, setClassName, getClassName, setCurrMain, 
   getCurrMain, getClassMap, setScope, getScope, setCurrMainFunc, 
-  getCurrMainFunc, setODEOthVars, getODEOthVars)
+  getCurrMainFunc, setODEOthVars, getODEOthVars, setConstructorParams)
 
 import Prelude hiding (break,print,(<>),sin,cos,tan,floor,pi,const,log,exp,mod)
 import Control.Lens.Zoom (zoom)
@@ -227,23 +227,24 @@ instance (Pair p) => ControlBlockSym (p CppSrcCode CppHdrCode) where
     (\s -> runStrategy l (zip (map fst strats) s) (fmap (onStateValue psnd) rv) 
       (fmap (onStateValue psnd) av)) (map snd strats)
 
-  listSlice' b e s = pair2 
+  listSlice' b e s vr vl = pair2 
     (listSlice' (fmap (onStateValue pfst) b) (fmap (onStateValue pfst) e) 
-      (fmap (onStateValue pfst) s)) 
+      (fmap (onStateValue pfst) s))
     (listSlice' (fmap (onStateValue psnd) b) (fmap (onStateValue psnd) e) 
-      (fmap (onStateValue psnd) s))
+      (fmap (onStateValue psnd) s)) 
+    (zoom lensMStoVS vr) (zoom lensMStoVS vl)
 
   solveODE info opts = do
-    piv <- indepVar info
-    pdv <- depVar info
-    povs <- sequence $ otherVars info
-    pti <- tInit info
-    ptf <- tFinal info
-    pinitv <- initVal info
-    pode <- ode info
-    patol <- absTol opts
-    prtol <- relTol opts
-    pss <- stepSize opts
+    piv <- zoom lensMStoVS $ indepVar info
+    pdv <- zoom lensMStoVS $ depVar info
+    povs <- mapM (zoom lensMStoVS) $ otherVars info
+    pti <- zoom lensMStoVS $ tInit info
+    ptf <- zoom lensMStoVS $ tFinal info
+    pinitv <- zoom lensMStoVS $ initVal info
+    pode <- zoom lensMStoVS $ ode info
+    patol <- zoom lensMStoVS $ absTol opts
+    prtol <- zoom lensMStoVS $ relTol opts
+    pss <- zoom lensMStoVS $ stepSize opts
     let m = solveMethod opts
         iv1 = toState $ pfst piv
         iv2 = toState $ psnd piv
@@ -271,21 +272,21 @@ instance (Pair p) => ControlBlockSym (p CppSrcCode CppHdrCode) where
         solveODEHdr :: ODEInfo CppHdrCode -> ODEOptions CppHdrCode -> 
           MS (CppHdrCode (Block CppHdrCode))
         solveODEHdr = solveODE
-        odeInfoSrc :: MS (CppSrcCode (Variable CppSrcCode)) -> MS (CppSrcCode (Variable CppSrcCode)) -> 
-          [MS (CppSrcCode (Variable CppSrcCode))] -> MS (CppSrcCode (Value CppSrcCode)) -> 
-          MS (CppSrcCode (Value CppSrcCode)) -> MS (CppSrcCode (Value CppSrcCode)) -> 
-          MS (CppSrcCode (Value CppSrcCode)) -> ODEInfo CppSrcCode
+        odeInfoSrc :: VS (CppSrcCode (Variable CppSrcCode)) -> VS (CppSrcCode (Variable CppSrcCode)) -> 
+          [VS (CppSrcCode (Variable CppSrcCode))] -> VS (CppSrcCode (Value CppSrcCode)) -> 
+          VS (CppSrcCode (Value CppSrcCode)) -> VS (CppSrcCode (Value CppSrcCode)) -> 
+          VS (CppSrcCode (Value CppSrcCode)) -> ODEInfo CppSrcCode
         odeInfoSrc = odeInfo
-        odeOptionsSrc :: ODEMethod -> MS (CppSrcCode (Value CppSrcCode)) -> 
-          MS (CppSrcCode (Value CppSrcCode)) -> MS (CppSrcCode (Value CppSrcCode)) -> ODEOptions CppSrcCode
+        odeOptionsSrc :: ODEMethod -> VS (CppSrcCode (Value CppSrcCode)) -> 
+          VS (CppSrcCode (Value CppSrcCode)) -> VS (CppSrcCode (Value CppSrcCode)) -> ODEOptions CppSrcCode
         odeOptionsSrc = odeOptions
-        odeInfoHdr :: MS (CppHdrCode (Variable CppHdrCode)) -> MS (CppHdrCode (Variable CppHdrCode)) -> 
-          [MS (CppHdrCode (Variable CppHdrCode))] -> MS (CppHdrCode (Value CppHdrCode)) -> 
-          MS (CppHdrCode (Value CppHdrCode)) -> MS (CppHdrCode (Value CppHdrCode)) -> 
-          MS (CppHdrCode (Value CppHdrCode)) -> ODEInfo CppHdrCode
+        odeInfoHdr :: VS (CppHdrCode (Variable CppHdrCode)) -> VS (CppHdrCode (Variable CppHdrCode)) -> 
+          [VS (CppHdrCode (Variable CppHdrCode))] -> VS (CppHdrCode (Value CppHdrCode)) -> 
+          VS (CppHdrCode (Value CppHdrCode)) -> VS (CppHdrCode (Value CppHdrCode)) -> 
+          VS (CppHdrCode (Value CppHdrCode)) -> ODEInfo CppHdrCode
         odeInfoHdr = odeInfo
-        odeOptionsHdr :: ODEMethod -> MS (CppHdrCode (Value CppHdrCode)) -> 
-          MS (CppHdrCode (Value CppHdrCode)) -> MS (CppHdrCode (Value CppHdrCode)) -> ODEOptions CppHdrCode
+        odeOptionsHdr :: ODEMethod -> VS (CppHdrCode (Value CppHdrCode)) -> 
+          VS (CppHdrCode (Value CppHdrCode)) -> VS (CppHdrCode (Value CppHdrCode)) -> ODEOptions CppHdrCode
         odeOptionsHdr = odeOptions
     p1 <- solveODESrc
       (odeInfoSrc iv1 dv1 ovs1 ti1 tf1 initv1 ode1)
@@ -506,9 +507,10 @@ instance (Pair p) => InternalFunction (p CppSrcCode CppHdrCode) where
 
 instance (Pair p) => InternalStatement (p CppSrcCode CppHdrCode) where
   -- Another Maybe/State combination
-  printSt nl f = pair2
+  printSt nl f p v = pair2
     (printSt nl (fmap (onStateValue pfst) f)) 
-    (printSt nl (fmap (onStateValue psnd) f))
+    (printSt nl (fmap (onStateValue psnd) f)) 
+    (zoom lensMStoVS p) (zoom lensMStoVS v)
     
   state = pair1 state state
   loopState = pair1 loopState loopState
@@ -521,66 +523,87 @@ instance (Pair p) => InternalStatement (p CppSrcCode CppHdrCode) where
 
 instance (Pair p) => StatementSym (p CppSrcCode CppHdrCode) where
   type Statement (p CppSrcCode CppHdrCode) = (Doc, Terminator)
-  assign = pair2 assign assign
-  assignToListIndex = pair3 assignToListIndex assignToListIndex
-  multiAssign = pair2Lists multiAssign multiAssign
-  (&=) = pair2 (&=) (&=)
-  (&-=) = pair2 (&-=) (&-=)
-  (&+=) = pair2 (&+=) (&+=)
-  (&++) = pair1 (&++) (&++)
-  (&~-) = pair1 (&~-) (&~-)
+  assign vr vl = pair2 assign assign (zoom lensMStoVS vr) (zoom lensMStoVS vl)
+  assignToListIndex lst i v = pair3 assignToListIndex assignToListIndex 
+    (zoom lensMStoVS lst) (zoom lensMStoVS i) (zoom lensMStoVS v)
+  multiAssign vrs vls = pair2Lists multiAssign multiAssign 
+    (map (zoom lensMStoVS) vrs) (map (zoom lensMStoVS) vls)
+  (&=) vr vl = pair2 (&=) (&=) (zoom lensMStoVS vr) (zoom lensMStoVS vl)
+  (&-=) vr vl = pair2 (&-=) (&-=) (zoom lensMStoVS vr) (zoom lensMStoVS vl)
+  (&+=) vr vl = pair2 (&+=) (&+=) (zoom lensMStoVS vr) (zoom lensMStoVS vl)
+  (&++) vl = pair1 (&++) (&++) (zoom lensMStoVS vl)
+  (&~-) vl = pair1 (&~-) (&~-) (zoom lensMStoVS vl)
 
-  varDec = pair1 varDec varDec
-  varDecDef = pair2 varDecDef varDecDef
-  listDec n = pair1 (listDec n) (listDec n)
-  listDecDef = pair1Val1List listDecDef listDecDef
-  objDecDef = pair2 objDecDef objDecDef
-  objDecNew = pair1Val1List objDecNew objDecNew
-  extObjDecNew lib = pair1Val1List (extObjDecNew lib) (extObjDecNew lib)
-  objDecNewNoParams = pair1 objDecNewNoParams objDecNewNoParams
+  varDec vr = pair1 varDec varDec (zoom lensMStoVS vr)
+  varDecDef vr vl = pair2 varDecDef varDecDef (zoom lensMStoVS vr) 
+    (zoom lensMStoVS vl)
+  listDec n vr = pair1 (listDec n) (listDec n) (zoom lensMStoVS vr)
+  listDecDef vr vs = pair1Val1List listDecDef listDecDef (zoom lensMStoVS vr) 
+    (map (zoom lensMStoVS) vs)
+  objDecDef o v = pair2 objDecDef objDecDef (zoom lensMStoVS o) 
+    (zoom lensMStoVS v)
+  objDecNew vr vs = pair1Val1List objDecNew objDecNew (zoom lensMStoVS vr) 
+    (map (zoom lensMStoVS) vs)
+  extObjDecNew lib vr vs = pair1Val1List (extObjDecNew lib) (extObjDecNew lib) 
+    (zoom lensMStoVS vr) (map (zoom lensMStoVS) vs)
+  objDecNewNoParams = pair1 objDecNewNoParams objDecNewNoParams . 
+    zoom lensMStoVS
   extObjDecNewNoParams lib = pair1 
     (extObjDecNewNoParams lib) 
-    (extObjDecNewNoParams lib)
-  constDecDef = pair2 constDecDef constDecDef
+    (extObjDecNewNoParams lib) . zoom lensMStoVS
+  constDecDef vr vl = pair2 constDecDef constDecDef (zoom lensMStoVS vr) 
+    (zoom lensMStoVS vl)
 
-  print = pair1 print print
-  printLn = pair1 printLn printLn
+  print = pair1 print print . zoom lensMStoVS
+  printLn = pair1 printLn printLn . zoom lensMStoVS
   printStr s = on2StateValues pair (printStr s) (printStr s)
   printStrLn s = on2StateValues pair (printStrLn s) (printStrLn s)
 
-  printFile = pair2 printFile printFile 
-  printFileLn = pair2 printFileLn printFileLn
-  printFileStr f s = pair1 (`printFileStr` s) (`printFileStr` s) f
-  printFileStrLn f s = pair1 (`printFileStrLn` s) (`printFileStrLn` s) f
+  printFile f v = pair2 printFile printFile (zoom lensMStoVS f) 
+    (zoom lensMStoVS v)
+  printFileLn f v = pair2 printFileLn printFileLn (zoom lensMStoVS f) 
+    (zoom lensMStoVS v)
+  printFileStr f s = pair1 (`printFileStr` s) (`printFileStr` s) 
+    (zoom lensMStoVS f)
+  printFileStrLn f s = pair1 (`printFileStrLn` s) (`printFileStrLn` s) 
+    (zoom lensMStoVS f)
 
-  getInput = pair1 getInput getInput
+  getInput = pair1 getInput getInput . zoom lensMStoVS
   discardInput = on2StateValues pair discardInput discardInput
-  getFileInput = pair2 getFileInput getFileInput
-  discardFileInput = pair1 discardFileInput discardFileInput
+  getFileInput f v = pair2 getFileInput getFileInput (zoom lensMStoVS f) 
+    (zoom lensMStoVS v)
+  discardFileInput = pair1 discardFileInput discardFileInput . zoom lensMStoVS
 
-  openFileR = pair2 openFileR openFileR
-  openFileW = pair2 openFileW openFileW
-  openFileA = pair2 openFileA openFileA
-  closeFile = pair1 closeFile closeFile
+  openFileR f v = pair2 openFileR openFileR (zoom lensMStoVS f) 
+    (zoom lensMStoVS v)
+  openFileW f v = pair2 openFileW openFileW (zoom lensMStoVS f) 
+    (zoom lensMStoVS v)
+  openFileA f v = pair2 openFileA openFileA (zoom lensMStoVS f) 
+    (zoom lensMStoVS v)
+  closeFile = pair1 closeFile closeFile . zoom lensMStoVS
 
-  getFileInputLine = pair2 getFileInputLine getFileInputLine
-  discardFileLine = pair1 discardFileLine discardFileLine
-  stringSplit d = pair2 (stringSplit d) (stringSplit d)
+  getFileInputLine f v = pair2 getFileInputLine getFileInputLine 
+    (zoom lensMStoVS f) (zoom lensMStoVS v)
+  discardFileLine = pair1 discardFileLine discardFileLine . zoom lensMStoVS
+  stringSplit d vnew s = pair2 (stringSplit d) (stringSplit d) 
+    (zoom lensMStoVS vnew) (zoom lensMStoVS s)
 
-  stringListVals = pair1List1Val stringListVals stringListVals
-  stringListLists = pair1List1Val stringListLists stringListLists
+  stringListVals vars sl = pair1List1Val stringListVals stringListVals
+    (map (zoom lensMStoVS) vars) (zoom lensMStoVS sl)
+  stringListLists lsts sl = pair1List1Val stringListLists stringListLists
+    (map (zoom lensMStoVS) lsts) (zoom lensMStoVS sl)
 
   break = on2StateValues pair break break
   continue = on2StateValues pair continue continue
 
-  returnState = pair1 returnState returnState
-  multiReturn = pair1List multiReturn multiReturn
+  returnState = pair1 returnState returnState . zoom lensMStoVS
+  multiReturn = pair1List multiReturn multiReturn . map (zoom lensMStoVS)
 
-  valState = pair1 valState valState
+  valState = pair1 valState valState . zoom lensMStoVS
 
   comment cmt = on2StateValues pair (comment cmt) (comment cmt)
 
-  free = pair1 free free
+  free = pair1 free free . zoom lensMStoVS
 
   throw errMsg = on2StateValues pair (throw errMsg) (throw errMsg)
 
@@ -589,47 +612,60 @@ instance (Pair p) => StatementSym (p CppSrcCode CppHdrCode) where
   changeState fsmName postState = on2StateValues pair 
     (changeState fsmName postState) (changeState fsmName postState)
 
-  initObserverList = pair1Val1List initObserverList initObserverList
-  addObserver = pair1 addObserver addObserver
+  initObserverList t vs = pair1Val1List initObserverList initObserverList 
+    (zoom lensMStoVS t) (map (zoom lensMStoVS) vs)
+  addObserver = pair1 addObserver addObserver . zoom lensMStoVS
 
-  inOutCall n = pair3Lists (inOutCall n) (inOutCall n)
-  selfInOutCall n = pair3Lists (selfInOutCall n) (selfInOutCall n)
-  extInOutCall m n = pair3Lists (extInOutCall m n) (extInOutCall m n) 
+  inOutCall n is os bs = pair3Lists (inOutCall n) (inOutCall n) 
+    (map (zoom lensMStoVS) is) (map (zoom lensMStoVS) os) 
+    (map (zoom lensMStoVS) bs)
+  selfInOutCall n is os bs = pair3Lists (selfInOutCall n) (selfInOutCall n)
+    (map (zoom lensMStoVS) is) (map (zoom lensMStoVS) os) 
+    (map (zoom lensMStoVS) bs)
+  extInOutCall m n is os bs = pair3Lists (extInOutCall m n) (extInOutCall m n) 
+    (map (zoom lensMStoVS) is) (map (zoom lensMStoVS) os) 
+    (map (zoom lensMStoVS) bs)
 
   multi = pair1List multi multi
 
 instance (Pair p) => ControlStatementSym (p CppSrcCode CppHdrCode) where
   ifCond bs = pair2Lists1Val
     (\cs bods -> ifCond (zip cs bods)) 
-    (\cs bods -> ifCond (zip cs bods)) (map fst bs) (map snd bs)
+    (\cs bods -> ifCond (zip cs bods)) 
+    (map (zoom lensMStoVS . fst) bs) (map snd bs)
   ifNoElse bs = pair2Lists
     (\cs bods -> ifNoElse (zip cs bods))
-    (\cs bods -> ifNoElse (zip cs bods)) (map fst bs) (map snd bs) 
+    (\cs bods -> ifNoElse (zip cs bods)) 
+    (map (zoom lensMStoVS . fst) bs) (map snd bs) 
   switch v cs = pairVal2ListsVal 
     (\s cv cb -> switch s (zip cv cb))
     (\s cv cb -> switch s (zip cv cb))
-    v (map fst cs) (map snd cs)
+    (zoom lensMStoVS v) (map (zoom lensMStoVS . fst) cs) (map snd cs)
   switchAsIf v cs = pairVal2ListsVal
     (\s cv cb -> switchAsIf s (zip cv cb))
     (\s cv cb -> switchAsIf s (zip cv cb))
-    v (map fst cs) (map snd cs)
+    (zoom lensMStoVS v) (map (zoom lensMStoVS . fst) cs) (map snd cs)
 
-  ifExists = pair3 ifExists ifExists
+  ifExists v = pair3 ifExists ifExists (zoom lensMStoVS v)
 
-  for = pair4 for for
-  forRange = pair5 forRange forRange
-  forEach = pair3 forEach forEach
-  while = pair2 while while
+  for i initv = pair4 for for i (zoom lensMStoVS initv)
+  forRange i initv finalv stepv = pair5 forRange forRange (zoom lensMStoVS i) 
+    (zoom lensMStoVS initv) (zoom lensMStoVS finalv) (zoom lensMStoVS stepv)
+  forEach e v = pair3 forEach forEach (zoom lensMStoVS e) (zoom lensMStoVS v)
+  while v = pair2 while while (zoom lensMStoVS v)
 
   tryCatch = pair2 tryCatch tryCatch
 
   checkState l vs = pair2Lists1Val
     (\sts bods -> checkState l (zip sts bods))
-    (\sts bods -> checkState l (zip sts bods)) (map fst vs) (map snd vs)
+    (\sts bods -> checkState l (zip sts bods)) 
+    (map (zoom lensMStoVS . fst) vs) (map snd vs)
 
-  notifyObservers = pair2 notifyObservers notifyObservers
+  notifyObservers f t = pair2 notifyObservers notifyObservers 
+    (zoom lensMStoVS f) (zoom lensMStoVS t)
 
-  getFileInputAll = pair2 getFileInputAll getFileInputAll
+  getFileInputAll f v = pair2 getFileInputAll getFileInputAll 
+    (zoom lensMStoVS f) (zoom lensMStoVS v)
 
 instance (Pair p) => ScopeSym (p CppSrcCode CppHdrCode) where
   type Scope (p CppSrcCode CppHdrCode) = (Doc, ScopeTag)
@@ -641,13 +677,13 @@ instance (Pair p) => InternalScope (p CppSrcCode CppHdrCode) where
 
 instance (Pair p) => MethodTypeSym (p CppSrcCode CppHdrCode) where
   type MethodType (p CppSrcCode CppHdrCode) = TypeData
-  mType = pair1 mType mType
+  mType = pair1 mType mType . zoom lensMStoVS
   construct n = on2StateValues pair (construct n) (construct n)
 
 instance (Pair p) => ParameterSym (p CppSrcCode CppHdrCode) where
   type Parameter (p CppSrcCode CppHdrCode) = ParamData
-  param = pair1 param param
-  pointerParam = pair1 pointerParam pointerParam
+  param = pair1 param param . zoom lensMStoVS
+  pointerParam = pair1 pointerParam pointerParam . zoom lensMStoVS
 
 instance (Pair p) => InternalParam (p CppSrcCode CppHdrCode) where
   parameterName p = parameterName $ pfst p
@@ -657,43 +693,53 @@ instance (Pair p) => InternalParam (p CppSrcCode CppHdrCode) where
 
 instance (Pair p) => MethodSym (p CppSrcCode CppHdrCode) where
   type Method (p CppSrcCode CppHdrCode) = MethodData
-  method n s p = pairValListVal
-    (method n (pfst s) (pfst p)) (method n (psnd s) (psnd p))
-  getMethod = pair1 getMethod getMethod
-  setMethod = pair1 setMethod setMethod
-  privMethod n = pairValListVal (privMethod n) (privMethod n)
-  pubMethod n = pairValListVal (pubMethod n) (pubMethod n)
+  method n s p t = pairValListVal
+    (method n (pfst s) (pfst p)) (method n (psnd s) (psnd p)) 
+    (zoom lensMStoVS t)
+  getMethod = pair1 getMethod getMethod . zoom lensMStoVS
+  setMethod = pair1 setMethod setMethod . zoom lensMStoVS
+  privMethod n t = pairValListVal (privMethod n) (privMethod n) 
+    (zoom lensMStoVS t)
+  pubMethod n t = pairValListVal (pubMethod n) (pubMethod n) 
+    (zoom lensMStoVS t)
   constructor = pair1List1Val constructor constructor
   destructor = pair1List destructor destructor . map (zoom lensMStoCS)
 
   docMain = pair1 docMain docMain
 
-  function n s p = pairValListVal 
-    (function n (pfst s) (pfst p)) (function n (psnd s) (psnd p))
+  function n s p t = pairValListVal 
+    (function n (pfst s) (pfst p)) (function n (psnd s) (psnd p)) 
+    (zoom lensMStoVS t)
   mainFunction = pair1 mainFunction mainFunction
 
   docFunc desc pComms rComm = pair1 (docFunc desc pComms rComm) 
     (docFunc desc pComms rComm)
 
-  inOutMethod n s p = pair3Lists1Val 
+  inOutMethod n s p is os bs = pair3Lists1Val 
     (inOutMethod n (pfst s) (pfst p)) (inOutMethod n (psnd s) (psnd p)) 
+    (map (zoom lensMStoVS) is) (map (zoom lensMStoVS) os) 
+    (map (zoom lensMStoVS) bs)
 
   docInOutMethod n s p desc is os bs = pair3Lists1Val
     (\ins outs both -> docInOutMethod n (pfst s) (pfst p) desc (zip (map fst 
       is) ins) (zip (map fst os) outs) (zip (map fst bs) both))
     (\ins outs both -> docInOutMethod n (psnd s) (psnd p) desc (zip (map fst 
       is) ins) (zip (map fst os) outs) (zip (map fst bs) both))
-    (map snd is) (map snd os) (map snd bs)
+    (map (zoom lensMStoVS . snd) is) (map (zoom lensMStoVS . snd) os) 
+    (map (zoom lensMStoVS . snd) bs)
 
-  inOutFunc n s p = pair3Lists1Val
+  inOutFunc n s p is os bs = pair3Lists1Val
     (inOutFunc n (pfst s) (pfst p)) (inOutFunc n (psnd s) (psnd p))
+    (map (zoom lensMStoVS) is) (map (zoom lensMStoVS) os) 
+    (map (zoom lensMStoVS) bs)
 
   docInOutFunc n s p desc is os bs = pair3Lists1Val 
     (\ins outs both -> docInOutFunc n (pfst s) (pfst p) desc (zip (map fst 
       is) ins) (zip (map fst os) outs) (zip (map fst bs) both))
     (\ins outs both -> docInOutFunc n (psnd s) (psnd p) desc (zip (map fst 
       is) ins) (zip (map fst os) outs) (zip (map fst bs) both))
-    (map snd is) (map snd os) (map snd bs)
+    (map (zoom lensMStoVS . snd) is) (map (zoom lensMStoVS . snd) os) 
+    (map (zoom lensMStoVS . snd) bs)
   
 instance (Pair p) => InternalMethod (p CppSrcCode CppHdrCode) where
   intMethod m n s p = pairValListVal
@@ -708,15 +754,15 @@ instance (Pair p) => InternalMethod (p CppSrcCode CppHdrCode) where
 instance (Pair p) => StateVarSym (p CppSrcCode CppHdrCode) where
   type StateVar (p CppSrcCode CppHdrCode) = StateVarData
   stateVar s p = pair1 (stateVar (pfst s) (pfst p)) (stateVar (psnd s) (psnd p))
-    . zoom lensCStoMS
+    . zoom lensCStoVS
   stateVarDef n s p vr vl = pair2
     (stateVarDef n (pfst s) (pfst p)) 
-    (stateVarDef n (psnd s) (psnd p)) (zoom lensCStoMS vr) (zoom lensCStoMS vl)
+    (stateVarDef n (psnd s) (psnd p)) (zoom lensCStoVS vr) (zoom lensCStoVS vl)
   constVar n s vr vl = pair2 (constVar n (pfst s)) (constVar n (psnd s))
-    (zoom lensCStoMS vr) (zoom lensCStoMS vl)
-  privMVar = pair1 privMVar privMVar . zoom lensCStoMS
-  pubMVar = pair1 pubMVar pubMVar . zoom lensCStoMS
-  pubGVar = pair1 pubGVar pubGVar . zoom lensCStoMS
+    (zoom lensCStoVS vr) (zoom lensCStoVS vl)
+  privMVar = pair1 privMVar privMVar . zoom lensCStoVS
+  pubMVar = pair1 pubMVar pubMVar . zoom lensCStoVS
+  pubGVar = pair1 pubGVar pubGVar . zoom lensCStoVS
 
 instance (Pair p) => InternalStateVar (p CppSrcCode CppHdrCode) where
   stateVarDoc v = stateVarDoc $ pfst v
@@ -1054,16 +1100,16 @@ instance TypeSym CppSrcCode where
   int = G.int
   float = G.double
   char = G.char
-  string = modify (addUsing "string" . addLangImport "string") >> G.string
+  string = modify (addUsing "string" . addLangImportVS "string") >> G.string
   infile = modify (addUsing "ifstream") >> cppInfileType
   outfile = modify (addUsing "ofstream") >> cppOutfileType
-  listType p t = modify (addUsing lst . addLangImport lst) >> G.listType p t
+  listType p t = modify (addUsing lst . addLangImportVS lst) >> G.listType p t
     where lst = render $ keyDoc (list p)
   listInnerType = G.listInnerType
-  obj n = getClassMap >>= (\cm -> maybe id ((>>) . modify . addModuleImport) 
+  obj n = getClassMap >>= (\cm -> maybe id ((>>) . modify . addModuleImportVS) 
     (Map.lookup n cm) $ G.obj n)
   enumType = G.enumType
-  iterator t = modify (addLangImport "iterator") >> 
+  iterator t = modify (addLangImportVS "iterator") >> 
     (cppIterType . listType dynamic_) t
   void = G.void
 
@@ -1082,7 +1128,7 @@ instance ControlBlockSym CppSrcCode where
   solveODE info opts = let (fl, s) = cppODEFile info cppsODEFunc dynamic_
                            dv = depVar info
     in modify (addODEFilePaths s . addODEFile (unCPPSC fl) . addLibImport 
-    "boost/numeric/odeint") >> (dv >>= (\dpv -> 
+    "boost/numeric/odeint") >> (zoom lensMStoVS dv >>= (\dpv -> 
       let odeClassName = variableName dpv ++ "_ODE"
           odeVar = var "ode" (obj odeClassName)
           currVal = var "currVal" (listInnerType $ toState $ variableType dpv)
@@ -1147,14 +1193,14 @@ instance VariableSym CppSrcCode where
   var = G.var
   staticVar = G.staticVar
   const = var
-  extVar l n t = modify (addModuleImport l) >> var n t
+  extVar l n t = modify (addModuleImportVS l) >> var n t
   self = G.self
   enumVar = G.enumVar
   classVar = on2StateValues (\c v -> classVarCheckStatic (varFromData 
     (variableBind v) (getTypeString c ++ "::" ++ variableName v) 
     (variableType v) (cppClassVar (getTypeDoc c) (variableDoc v))))
   extClassVar c v = join $ on2StateValues (\t cm -> maybe id ((>>) . modify . 
-    addModuleImport) (Map.lookup (getTypeString t) cm) $ 
+    addModuleImportVS) (Map.lookup (getTypeString t) cm) $ 
     classVar (toState t) v) c getClassMap
   objVar o v = join $ on3StateValues (\ovs ob vr -> if (variableName ob ++ "." 
     ++ variableName vr) `elem` ovs then toState vr else G.objVar (toState ob) 
@@ -1240,9 +1286,9 @@ instance ValueExpression CppSrcCode where
   inlineIf = G.inlineIf
   funcApp = G.funcApp
   selfFuncApp = cppSelfFuncApp self
-  extFuncApp l n t vs = modify (addModuleImport l) >> funcApp n t vs
+  extFuncApp l n t vs = modify (addModuleImportVS l) >> funcApp n t vs
   newObj = G.newObj newObjDocD'
-  extNewObj l t vs = modify (addModuleImport l) >> newObj t vs
+  extNewObj l t vs = modify (addModuleImportVS l) >> newObj t vs
 
   exists = notNull
   notNull v = v
@@ -1267,7 +1313,7 @@ instance Selector CppSrcCode where
   listIndexExists = G.listIndexExists
   argExists i = listAccess argsList (litInt $ fromIntegral i)
   
-  indexOf l v = addAlgorithmImport $ funcApp "find" int 
+  indexOf l v = addAlgorithmImportVS $ funcApp "find" int 
     [iterBegin l, iterEnd l, v] #- iterBegin l
   
 instance InternalSelector CppSrcCode where
@@ -1365,13 +1411,16 @@ instance StatementSym CppSrcCode where
   discardFileInput f = addAlgorithmImport $ addLimitsImport $ 
     G.discardFileInput (cppDiscardInput " ") f
 
-  openFileR = on2StateValues (\f v -> mkSt $ cppOpenFile "std::fstream::in" f v)
-  openFileW = on2StateValues (\f v -> mkSt $ cppOpenFile "std::fstream::out" f v)
-  openFileA = on2StateValues (\f v -> mkSt $ cppOpenFile "std::fstream::app" f v)
-  closeFile = G.closeFile "close"
+  openFileR f' v' = zoom lensMStoVS $ on2StateValues (\f v -> mkSt $ 
+    cppOpenFile "std::fstream::in" f v) f' v'
+  openFileW f' v' = zoom lensMStoVS $ on2StateValues (\f v -> mkSt $ 
+    cppOpenFile "std::fstream::out" f v) f' v' 
+  openFileA f' v' = zoom lensMStoVS $ on2StateValues (\f v -> mkSt $ 
+    cppOpenFile "std::fstream::app" f v) f' v'
+  closeFile = G.closeFile "close" 
 
   getFileInputLine f v = valState $ funcApp "std::getline" string [f, valueOf v]
-  discardFileLine f = addLimitsImport $ onStateValue (mkSt .
+  discardFileLine f = addLimitsImport $ zoom lensMStoVS $ onStateValue (mkSt .
     cppDiscardInput "\\n") f
   stringSplit d vnew s = let l_ss = "ss"
                              var_ss = var l_ss (obj "std::stringstream")
@@ -1402,7 +1451,7 @@ instance StatementSym CppSrcCode where
 
   comment = G.comment commentStart
 
-  free = onStateValue (mkSt . freeDocD)
+  free = onStateValue (mkSt . freeDocD) . zoom lensMStoVS
 
   throw = G.throw cppThrowDoc Semi
 
@@ -1456,7 +1505,7 @@ instance InternalScope CppSrcCode where
 
 instance MethodTypeSym CppSrcCode where
   type MethodType CppSrcCode = TypeData
-  mType t = t
+  mType = zoom lensMStoVS
   construct = G.construct
 
 instance ParameterSym CppSrcCode where
@@ -1477,7 +1526,8 @@ instance MethodSym CppSrcCode where
   setMethod = G.setMethod
   privMethod = G.privMethod
   pubMethod = G.pubMethod
-  constructor ps b = getClassName >>= (\n -> G.constructor n ps b)
+  constructor ps b = sequence ps >>= (\pms -> modify (setConstructorParams (map 
+    parameterName pms)) >> getClassName >>= (\n -> G.constructor n ps b))
   destructor vs = 
     let i = var "i" int
         deleteStatements = map (onStateValue (onCodeValue destructSts) . 
@@ -1531,11 +1581,11 @@ instance StateVarSym CppSrcCode where
     empty)) $ zoom lensCStoMS emptyState
   stateVarDef n s p v vl = on3StateValues (\vr val -> on3CodeValues svd 
     (onCodeValue snd s) (cppsStateVarDef n empty <$> p <*> vr <*> val <*>
-    endStatement)) (zoom lensCStoMS v) (zoom lensCStoMS vl) 
+    endStatement)) (zoom lensCStoVS v) (zoom lensCStoVS vl) 
     (zoom lensCStoMS emptyState)
   constVar n s v vl = on3StateValues (\vr val -> on3CodeValues svd (onCodeValue 
     snd s) (cppsStateVarDef n (text "const") <$> static_ <*> vr <*> val <*>
-    endStatement)) (zoom lensCStoMS v) (zoom lensCStoMS vl) 
+    endStatement)) (zoom lensCStoVS v) (zoom lensCStoVS vl) 
     (zoom lensCStoMS emptyState)
   privMVar = G.privMVar
   pubMVar = G.pubMVar
@@ -2050,13 +2100,14 @@ instance InternalScope CppHdrCode where
 
 instance MethodTypeSym CppHdrCode where
   type MethodType CppHdrCode = TypeData
-  mType t = t
+  mType = zoom lensMStoVS
   construct = G.construct
 
 instance ParameterSym CppHdrCode where
   type Parameter CppHdrCode = ParamData
-  param = onStateValue (\v -> paramFromData v (paramDocD v))
-  pointerParam = onStateValue (\v -> paramFromData v (cppPointerParamDoc v))
+  param = onStateValue (\v -> paramFromData v (paramDocD v)) . zoom lensMStoVS
+  pointerParam = onStateValue (\v -> paramFromData v (cppPointerParamDoc v)) .
+    zoom lensMStoVS
 
 instance InternalParam CppHdrCode where
   parameterName = variableName . onCodeValue paramVar
@@ -2067,10 +2118,10 @@ instance InternalParam CppHdrCode where
 instance MethodSym CppHdrCode where
   type Method CppHdrCode = MethodData
   method = G.method
-  getMethod v = v >>= (\v' -> method (getterName $ variableName v') public 
-    dynamic_ (toState $ variableType v') [] (toState $ toCode empty))
-  setMethod v = v >>= (\v' -> method (setterName $ variableName v') public 
-    dynamic_ void [param v] (toState $ toCode empty))
+  getMethod v = zoom lensMStoVS v >>= (\v' -> method (getterName $ variableName 
+    v') public dynamic_ (toState $ variableType v') [] (toState $ toCode empty))
+  setMethod v = zoom lensMStoVS v >>= (\v' -> method (setterName $ variableName 
+    v') public dynamic_ void [param v] (toState $ toCode empty))
   privMethod = G.privMethod
   pubMethod = G.pubMethod
   constructor ps b = getClassName >>= (\n -> G.constructor n ps b)
@@ -2114,7 +2165,7 @@ instance StateVarSym CppHdrCode where
     (cpphStateVarDef empty p vr vl) (zoom lensCStoMS emptyState)
   constVar _ s vr _ = on2StateValues (\v -> on3CodeValues svd (onCodeValue snd 
     s) (on3CodeValues (constVarDocD empty) (bindDoc <$> static_) v 
-    endStatement)) (zoom lensCStoMS vr) (zoom lensCStoMS emptyState)
+    endStatement)) (zoom lensCStoVS vr) (zoom lensCStoMS emptyState)
   privMVar = G.privMVar
   pubMVar = G.pubMVar
   pubGVar = G.pubGVar
@@ -2171,17 +2222,18 @@ instance BlockCommentSym CppHdrCode where
   blockCommentDoc = unCPPHC
 
 -- helpers
-toBasicVar :: MS (CppSrcCode (Variable CppSrcCode)) -> 
-  MS (CppSrcCode (Variable CppSrcCode))
+toBasicVar :: VS (CppSrcCode (Variable CppSrcCode)) -> 
+  VS (CppSrcCode (Variable CppSrcCode))
 toBasicVar v = v >>= (\v' -> var (variableName v') (onStateValue variableType v))
 
 isDtor :: Label -> Bool
 isDtor ('~':_) = True
 isDtor _ = False
 
-getParam :: (RenderSym repr) => MS (repr (Variable repr)) -> 
+getParam :: (RenderSym repr) => VS (repr (Variable repr)) -> 
   MS (repr (Parameter repr))
-getParam v = v >>= (\v' -> getParamFunc ((getType . variableType) v') v)
+getParam v = zoom lensMStoVS v >>= (\v' -> getParamFunc ((getType . 
+  variableType) v') v)
   where getParamFunc (List _) = pointerParam
         getParamFunc (Object _) = pointerParam
         getParamFunc _ = param
@@ -2191,17 +2243,23 @@ data MethodData = MthD {getMthdScp :: ScopeTag, mthdDoc :: Doc}
 mthd :: ScopeTag -> Doc -> MethodData
 mthd = MthD 
 
+algorithmImport :: String
+algorithmImport = "algorithm"
+
 addAlgorithmImport :: MS a -> MS a
-addAlgorithmImport = (>>) $ modify (addLangImport "algorithm")
+addAlgorithmImport = (>>) $ modify (addLangImport algorithmImport)
 
-addFStreamImport :: a -> MS a
-addFStreamImport = modifyReturn (addLangImport "fstream")
+addAlgorithmImportVS :: VS a -> VS a
+addAlgorithmImportVS = (>>) $ modify (addLangImportVS algorithmImport)
 
-addIOStreamImport :: MS a -> MS a
-addIOStreamImport = (>>) $ modify (addLangImport "iostream")
+addFStreamImport :: a -> VS a
+addFStreamImport = modifyReturn (addLangImportVS "fstream")
 
-addMathHImport :: MS a -> MS a
-addMathHImport = (>>) $ modify (addLangImport "math.h")
+addIOStreamImport :: VS a -> VS a
+addIOStreamImport = (>>) $ modify (addLangImportVS "iostream")
+
+addMathHImport :: VS a -> VS a
+addMathHImport = (>>) $ modify (addLangImportVS "math.h")
 
 addLimitsImport :: MS a -> MS a
 addLimitsImport = (>>) $ modify (addLangImport "limits")
@@ -2220,7 +2278,7 @@ odeNameSpace :: String
 odeNameSpace = "boost::numeric::odeint::"
 
 cppODEMethod :: ODEInfo CppSrcCode -> ODEOptions CppSrcCode -> 
-  MS (CppSrcCode (Value CppSrcCode))
+  VS (CppSrcCode (Value CppSrcCode))
 cppODEMethod info opts = listInnerType (onStateValue variableType $ depVar info)
   >>= (\dpt -> 
   let rkdp5 = "runge_kutta_dopri5"  
@@ -2268,18 +2326,18 @@ cppODEFile info f p = (fl, fst s)
             pubMethod "operator()" void [param dvElemPtr, param tElem] 
               (oneLiner $ valState $ listAppend (valueOf $ objVarSelf dv) 
               (valueOf dv))]]))
-          (zoom lensFStoMS olddv) (zoom lensFStoMS oldiv) (mapM (zoom lensFStoMS) ovars)
+          (zoom lensFStoVS olddv) (zoom lensFStoVS oldiv) (mapM (zoom lensFStoVS) ovars)
 
 -- Need src and hdr versions of this function until I teach this renderer about
 -- initializer lists
 cppsODEFunc :: ODEInfo CppSrcCode -> MS (CppSrcCode (Method CppSrcCode))
-cppsODEFunc info = depVar info >>= (\dpv -> on2StateValues (\n v -> 
-  methodFromData Pub (text (n ++ "::" ++ n) <+> parens (parameterDoc v) <+> 
-  colon <+> variableDoc dpv <> parens (variableDoc dpv) <+> braces empty)) 
+cppsODEFunc info = zoom lensMStoVS (depVar info) >>= (\dpv -> on2StateValues 
+  (\n v -> methodFromData Pub (text (n ++ "::" ++ n) <+> parens (parameterDoc v)
+  <+> colon <+> variableDoc dpv <> parens (variableDoc dpv) <+> braces empty)) 
   getClassName (param $ var ('&':variableName dpv) (toState $ variableType dpv)))
 
 cpphODEFunc :: ODEInfo CppHdrCode -> MS (CppHdrCode (Method CppHdrCode))
-cpphODEFunc info = dv >>= (\dpv -> 
+cpphODEFunc info = zoom lensMStoVS dv >>= (\dpv -> 
   constructor [param $ var ('&':variableName dpv) (toState $ variableType dpv)]
   (oneLiner $ objVarSelf dv &= valueOf dv))
   where dv = depVar info
@@ -2299,19 +2357,19 @@ usingNameSpace n Nothing end = text "using namespace" <+> text n <> keyDoc end
 cppInherit :: Label -> Doc -> Doc
 cppInherit n pub = colon <+> pub <+> text n
 
-cppBoolType :: (RenderSym repr) => MS (repr (Type repr))
+cppBoolType :: (RenderSym repr) => VS (repr (Type repr))
 cppBoolType = toState $ typeFromData Boolean "bool" (text "bool")
 
-cppInfileType :: (RenderSym repr) => MS (repr (Type repr))
+cppInfileType :: (RenderSym repr) => VS (repr (Type repr))
 cppInfileType = addFStreamImport $ typeFromData File "ifstream" 
   (text "ifstream")
 
-cppOutfileType :: (RenderSym repr) => MS (repr (Type repr))
+cppOutfileType :: (RenderSym repr) => VS (repr (Type repr))
 cppOutfileType = addFStreamImport $ typeFromData File "ofstream" 
   (text "ofstream")
 
-cppIterType :: (RenderSym repr) => MS (repr (Type repr)) -> 
-  MS (repr (Type repr))
+cppIterType :: (RenderSym repr) => VS (repr (Type repr)) -> 
+  VS (repr (Type repr))
 cppIterType = onStateValue (\t -> typeFromData (Iterator (getType t)) 
   (getTypeString t ++ "::iterator") (text "std::" <> getTypeDoc t <> text 
   "::iterator"))
@@ -2319,13 +2377,13 @@ cppIterType = onStateValue (\t -> typeFromData (Iterator (getType t))
 cppClassVar :: Doc -> Doc -> Doc
 cppClassVar c v = c <> text "::" <> v
 
-cppSelfFuncApp :: (RenderSym repr) => MS (repr (Variable repr)) -> Label -> 
-  MS (repr (Type repr)) -> [MS (repr (Value repr))] -> MS (repr (Value repr))
+cppSelfFuncApp :: (RenderSym repr) => VS (repr (Variable repr)) -> Label -> 
+  VS (repr (Type repr)) -> [VS (repr (Value repr))] -> VS (repr (Value repr))
 cppSelfFuncApp s n t vs = s >>= 
   (\slf -> funcApp (variableName slf ++ "->" ++ n) t vs)
 
-cppCast :: MS (CppSrcCode (Type CppSrcCode)) -> 
-  MS (CppSrcCode (Value CppSrcCode)) -> MS (CppSrcCode (Value CppSrcCode))
+cppCast :: VS (CppSrcCode (Type CppSrcCode)) -> 
+  VS (CppSrcCode (Value CppSrcCode)) -> VS (CppSrcCode (Value CppSrcCode))
 cppCast t v = join $ on2StateValues (\tp vl -> cppCast' (getType tp) (getType $ 
   valueType vl) tp vl) t v
   where cppCast' Float String _ _ = funcApp "std::stod" float [v]
@@ -2341,10 +2399,10 @@ cppListDecDoc n = parens (valueDoc n)
 cppListDecDefDoc :: (RenderSym repr) => [repr (Value repr)] -> Doc
 cppListDecDefDoc vs = braces (valueList vs)
 
-cppPrint :: (RenderSym repr) => Bool -> MS (repr (Value repr)) -> 
-  MS (repr (Value repr)) -> MS (repr (Statement repr))
-cppPrint newLn = on3StateValues (\e printFn v -> mkSt $ valueDoc printFn <+> 
-  text "<<" <+> val v (valueDoc v) <+> e) end
+cppPrint :: (RenderSym repr) => Bool -> VS (repr (Value repr)) -> 
+  VS (repr (Value repr)) -> MS (repr (Statement repr))
+cppPrint newLn  pf vl = zoom lensMStoVS $ on3StateValues (\e printFn v -> mkSt 
+  $ valueDoc printFn <+> text "<<" <+> val v (valueDoc v) <+> e) end pf vl
   where val v = if maybe False (< 9) (valuePrec v) then parens else id
         end = if newLn then addIOStreamImport (toState $ text "<<" <+> 
           text "std::endl") else toState empty
@@ -2365,11 +2423,11 @@ cppDiscardInput sep inFn = valueDoc inFn <> dot <> text "ignore" <> parens
   (text "std::numeric_limits<std::streamsize>::max()" <> comma <+>
   quotes (text sep))
 
-cppInput :: (RenderSym repr) => repr (Keyword repr) -> MS (repr (Variable repr))
-  -> MS (repr (Value repr)) -> MS (repr (Statement repr))
-cppInput end vr i = addAlgorithmImport $ addLimitsImport $ on2StateValues 
-  (\v inFn -> mkSt $ vcat [valueDoc inFn <+> text ">>" <+> variableDoc v <> 
-  keyDoc end, valueDoc inFn <> dot <> 
+cppInput :: (RenderSym repr) => repr (Keyword repr) -> VS (repr (Variable repr))
+  -> VS (repr (Value repr)) -> MS (repr (Statement repr))
+cppInput end vr i = addAlgorithmImport $ addLimitsImport $ zoom lensMStoVS $ 
+  on2StateValues (\v inFn -> mkSt $ vcat [valueDoc inFn <+> text ">>" <+> 
+  variableDoc v <> keyDoc end, valueDoc inFn <> dot <> 
     text "ignore(std::numeric_limits<std::streamsize>::max(), '\\n')"]) vr i
 
 cppOpenFile :: (RenderSym repr) => Label -> repr (Variable repr) -> 
@@ -2424,7 +2482,7 @@ cppsStateVarDef n cns p vr vl end = if bind p == Static then cns <+> typeDoc
   end else empty
 
 cpphStateVarDef :: (RenderSym repr) => Doc -> repr (Permanence repr) -> 
-  MS (repr (Variable repr)) -> MS (repr (Value repr)) -> CS Doc
+  VS (repr (Variable repr)) -> VS (repr (Value repr)) -> CS Doc
 cpphStateVarDef s p vr vl = onStateValue (stateVarDocD s (permDoc p) .  
   statementDoc) (zoom lensCStoMS $ state $ if binding p == Static then varDec 
   vr else varDecDef vr vl) 
@@ -2469,11 +2527,11 @@ cpphEnum n es bStart bEnd end = classFromData $ toState $ vcat [
   indent es,
   keyDoc bEnd <> keyDoc end]
 
-cppInOutCall :: (Label -> MS (CppSrcCode (Type CppSrcCode)) -> 
-  [MS (CppSrcCode (Value CppSrcCode))] -> MS (CppSrcCode (Value CppSrcCode))) 
-  -> Label -> [MS (CppSrcCode (Value CppSrcCode))] -> 
-  [MS (CppSrcCode (Variable CppSrcCode))] -> 
-  [MS (CppSrcCode (Variable CppSrcCode))] -> 
+cppInOutCall :: (Label -> VS (CppSrcCode (Type CppSrcCode)) -> 
+  [VS (CppSrcCode (Value CppSrcCode))] -> VS (CppSrcCode (Value CppSrcCode))) 
+  -> Label -> [VS (CppSrcCode (Value CppSrcCode))] -> 
+  [VS (CppSrcCode (Variable CppSrcCode))] -> 
+  [VS (CppSrcCode (Variable CppSrcCode))] -> 
   MS (CppSrcCode (Statement CppSrcCode))
 cppInOutCall f n ins [out] [] = assign out $ f n (onStateValue variableType out)
   ins
@@ -2483,13 +2541,13 @@ cppInOutCall f n ins outs both = valState $ f n void (map valueOf both ++ ins
   ++ map valueOf outs)
 
 cppsInOut :: (CppSrcCode (Scope CppSrcCode) -> 
-    CppSrcCode (Permanence CppSrcCode) -> MS (CppSrcCode (Type CppSrcCode)) -> 
+    CppSrcCode (Permanence CppSrcCode) -> VS (CppSrcCode (Type CppSrcCode)) -> 
     [MS (CppSrcCode (Parameter CppSrcCode))] -> 
     MS (CppSrcCode (Body CppSrcCode)) -> MS (CppSrcCode (Method CppSrcCode)))
   -> CppSrcCode (Scope CppSrcCode) -> CppSrcCode (Permanence CppSrcCode) -> 
-  [MS (CppSrcCode (Variable CppSrcCode))] ->
-  [MS (CppSrcCode (Variable CppSrcCode))] -> 
-  [MS (CppSrcCode (Variable CppSrcCode))] -> MS (CppSrcCode (Body CppSrcCode)) 
+  [VS (CppSrcCode (Variable CppSrcCode))] ->
+  [VS (CppSrcCode (Variable CppSrcCode))] -> 
+  [VS (CppSrcCode (Variable CppSrcCode))] -> MS (CppSrcCode (Body CppSrcCode)) 
   -> MS (CppSrcCode (Method CppSrcCode))
 cppsInOut f s p ins [v] [] b = f s p (onStateValue variableType v) 
   (cppInOutParams ins [v] []) (on3StateValues (on3CodeValues surroundBody) 
@@ -2500,13 +2558,13 @@ cppsInOut f s p ins [] [v] b = f s p (onStateValue variableType v)
 cppsInOut f s p ins outs both b = f s p void (cppInOutParams ins outs both) b
 
 cpphInOut :: (CppHdrCode (Scope CppHdrCode) -> 
-    CppHdrCode (Permanence CppHdrCode) -> MS (CppHdrCode (Type CppHdrCode)) -> 
+    CppHdrCode (Permanence CppHdrCode) -> VS (CppHdrCode (Type CppHdrCode)) -> 
     [MS (CppHdrCode (Parameter CppHdrCode))] -> 
     MS (CppHdrCode (Body CppHdrCode)) -> MS (CppHdrCode (Method CppHdrCode))) 
   -> CppHdrCode (Scope CppHdrCode) -> CppHdrCode (Permanence CppHdrCode) -> 
-  [MS (CppHdrCode (Variable CppHdrCode))] -> 
-  [MS (CppHdrCode (Variable CppHdrCode))] -> 
-  [MS (CppHdrCode (Variable CppHdrCode))] -> MS (CppHdrCode (Body CppHdrCode)) 
+  [VS (CppHdrCode (Variable CppHdrCode))] -> 
+  [VS (CppHdrCode (Variable CppHdrCode))] -> 
+  [VS (CppHdrCode (Variable CppHdrCode))] -> MS (CppHdrCode (Body CppHdrCode)) 
   -> MS (CppHdrCode (Method CppHdrCode))
 cpphInOut f s p ins [v] [] b = f s p (onStateValue variableType v) 
   (cppInOutParams ins [v] []) b
@@ -2514,8 +2572,8 @@ cpphInOut f s p ins [] [v] b = f s p (onStateValue variableType v)
   (cppInOutParams ins [] [v]) b
 cpphInOut f s p ins outs both b = f s p void (cppInOutParams ins outs both) b
 
-cppInOutParams :: (RenderSym repr) => [MS (repr (Variable repr))] -> 
-  [MS (repr (Variable repr))] -> [MS (repr (Variable repr))] -> 
+cppInOutParams :: (RenderSym repr) => [VS (repr (Variable repr))] -> 
+  [VS (repr (Variable repr))] -> [VS (repr (Variable repr))] -> 
   [MS (repr (Parameter repr))]
 cppInOutParams ins [_] [] = map getParam ins
 cppInOutParams ins [] [v] = map getParam $ v : ins

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer/JavaRenderer.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer/JavaRenderer.hs
@@ -67,12 +67,14 @@ import GOOL.Drasil.Helpers (angles, vibcat, emptyIfNull, toCode, toState,
   onCodeValue, onStateValue, on2CodeValues, on2StateValues, on3CodeValues, 
   on3StateValues, onCodeList, onStateList, on2StateLists, on1CodeValue1List, 
   on1StateValue1List)
-import GOOL.Drasil.State (GOOLState, MS, VS, lensGStoFS, lensFStoVS, lensCStoMS, lensMStoFS, lensMStoVS, lensVStoFS, initialState, initialFS, modifyReturn, modifyReturnFunc, 
-  addODEFilePaths, addProgNameToPaths, addODEFile, getODEFiles,
-  addLangImport, addLangImportVS, addExceptionImports, addLibImport, addLibImports, 
-  getModuleName, setClassName, getClassName, setCurrMain, setODEDepVars, 
-  getODEDepVars, setODEOthVars, getODEOthVars, setOutputsDeclared, 
-  isOutputsDeclared, getExceptions, getMethodExcMap, addExceptions)
+import GOOL.Drasil.State (GOOLState, MS, VS, lensGStoFS, lensFStoVS, lensCStoMS,
+  lensMStoFS, lensMStoVS, lensVStoFS, initialState, initialFS, modifyReturn, 
+  modifyReturnFunc, addODEFilePaths, addProgNameToPaths, addODEFile, 
+  getODEFiles, addLangImport, addLangImportVS, addExceptionImports, 
+  addLibImport, addLibImports, getModuleName, setClassName, getClassName, 
+  setCurrMain, setODEDepVars, getODEDepVars, setODEOthVars, getODEOthVars, 
+  setOutputsDeclared, isOutputsDeclared, getExceptions, getMethodExcMap, 
+  addExceptions)
 
 import Prelude hiding (break,print,sin,cos,tan,floor,(<>))
 import Control.Lens.Zoom (zoom)

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer/JavaRenderer.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer/JavaRenderer.hs
@@ -68,7 +68,7 @@ import GOOL.Drasil.Helpers (angles, vibcat, emptyIfNull, toCode, toState,
   on3StateValues, onCodeList, onStateList, on2StateLists, on1CodeValue1List, 
   on1StateValue1List)
 import GOOL.Drasil.State (GOOLState, MS, VS, lensGStoFS, lensFStoVS, lensCStoMS, lensMStoFS, lensMStoVS, lensVStoFS, initialState, initialFS, modifyReturn, modifyReturnFunc, 
-  tempStateChange, addODEFilePaths, addProgNameToPaths, addODEFile, getODEFiles,
+  addODEFilePaths, addProgNameToPaths, addODEFile, getODEFiles,
   addLangImport, addLangImportVS, addExceptionImports, addLibImport, addLibImports, 
   getModuleName, setClassName, getClassName, setCurrMain, setODEDepVars, 
   getODEDepVars, setODEOthVars, getODEOthVars, setOutputsDeclared, 
@@ -760,8 +760,8 @@ jODEFile info = (unJC fl, fst s)
           let n = variableName dpv
               cn = n ++ "_ODE"
               dn = "d" ++ n 
-              othVars = map (tempStateChange (setODEOthVars (map variableName 
-                ovs))) ovars
+              othVars = map (modify (setODEOthVars (map variableName 
+                ovs)) >>) ovars
           in fileDoc (buildModule cn [] [zoom lensCStoMS (modify (addLibImport 
             (odeImport ++ fode))) >> modify (setClassName cn) >> classFromData 
             (on2StateLists (\svars mths 
@@ -780,9 +780,9 @@ jODEFile info = (unJC fl, fst s)
                 litInt 1),
               pubMethod "computeDerivatives" void (map param [var "t" float, 
                 var n (toState dblArray), var dn (toState dblArray)]) (oneLiner 
-                $ var (dn ++ "[0]") float &= tempStateChange (setODEDepVars 
+                $ var (dn ++ "[0]") float &= (modify (setODEDepVars 
                 [variableName dpv, dn] . setODEOthVars (map variableName ovs)) 
-                (ode info))]))])) 
+                >> ode info))]))])) 
             (zoom lensFStoVS dv) (map (zoom lensFStoVS) ovars)
 
 jName :: String

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer/PythonRenderer.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer/PythonRenderer.hs
@@ -62,9 +62,9 @@ import GOOL.Drasil.Helpers (vibcat, emptyIfEmpty, toCode, toState, onCodeValue,
   onStateValue, on2CodeValues, on2StateValues, on3CodeValues, on3StateValues,
   onCodeList, onStateList, on2StateLists, on1CodeValue1List, on1StateValue1List)
 import GOOL.Drasil.State (MS, VS, lensGStoFS, lensMStoVS, lensVStoMS, 
-  addLangImportVS, getLangImports, 
-  addLibImport, getLibImports, addModuleImport, addModuleImportVS, getModuleImports, setClassName, 
-  getClassName, setCurrMain, getClassMap)
+  addLangImportVS, getLangImports, addLibImport, getLibImports, addModuleImport,
+  addModuleImportVS, getModuleImports, setClassName, getClassName, setCurrMain, 
+  getClassMap)
 
 import Prelude hiding (break,print,sin,cos,tan,floor,(<>))
 import Data.Maybe (fromMaybe)

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer/PythonRenderer.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer/PythonRenderer.hs
@@ -61,8 +61,9 @@ import GOOL.Drasil.Data (Terminator(..), ScopeTag(..), FileType(..),
 import GOOL.Drasil.Helpers (vibcat, emptyIfEmpty, toCode, toState, onCodeValue,
   onStateValue, on2CodeValues, on2StateValues, on3CodeValues, on3StateValues,
   onCodeList, onStateList, on2StateLists, on1CodeValue1List, on1StateValue1List)
-import GOOL.Drasil.State (MS, lensGStoFS, addLangImport, getLangImports, 
-  addLibImport, getLibImports, addModuleImport, getModuleImports, setClassName, 
+import GOOL.Drasil.State (MS, VS, lensGStoFS, lensMStoVS, lensVStoMS, 
+  addLangImportVS, getLangImports, 
+  addLibImport, getLibImports, addModuleImport, addModuleImportVS, getModuleImports, setClassName, 
   getClassName, setCurrMain, getClassMap)
 
 import Prelude hiding (break,print,sin,cos,tan,floor,(<>))
@@ -199,8 +200,8 @@ instance InternalType PythonCode where
 instance ControlBlockSym PythonCode where
   runStrategy = G.runStrategy
 
-  listSlice' b e s vnew vold = docBlock $ pyListSlice vnew vold (getVal b) 
-    (getVal e) (getVal s)
+  listSlice' b e s vnew vold = docBlock $ zoom lensMStoVS $ pyListSlice vnew 
+    vold (getVal b) (getVal e) (getVal s)
     where getVal = fromMaybe (mkStateVal void empty)
 
   solveODE info opts = modify (addLibImport odeLib) >> multiBlock [
@@ -285,12 +286,12 @@ instance VariableSym PythonCode where
   var = G.var
   staticVar = G.staticVar
   const = var
-  extVar l n t = modify (addModuleImport l) >> G.extVar l n t
-  self = getClassName >>= (\l -> mkStateVar "self" (obj l) (text "self"))
+  extVar l n t = modify (addModuleImportVS l) >> G.extVar l n t
+  self = zoom lensVStoMS getClassName >>= (\l -> mkStateVar "self" (obj l) (text "self"))
   enumVar = G.enumVar
   classVar = G.classVar classVarDocD
   extClassVar c v = join $ on2StateValues (\t cm -> maybe id ((>>) . modify . 
-    addModuleImport) (Map.lookup (getTypeString t) cm) $ 
+    addModuleImportVS) (Map.lookup (getTypeString t) cm) $ 
     G.classVar pyClassVar (toState t) v) c getClassMap
   objVar = G.objVar
   objVarSelf = G.objVarSelf
@@ -324,7 +325,7 @@ instance ValueSym PythonCode where
   valueOf = G.valueOf
   arg n = G.arg (litInt $ n+1) argsList
   enumElement = G.enumElement
-  argsList = modify (addLangImport "sys") >> G.argsList "sys.argv"
+  argsList = modify (addLangImportVS "sys") >> G.argsList "sys.argv"
 
   valueType = onCodeValue valType
   valueDoc = valDoc . unPC
@@ -374,9 +375,9 @@ instance ValueExpression PythonCode where
   inlineIf = pyInlineIf
   funcApp = G.funcApp
   selfFuncApp = G.selfFuncApp self
-  extFuncApp l n t ps = modify (addModuleImport l) >> G.extFuncApp l n t ps
+  extFuncApp l n t ps = modify (addModuleImportVS l) >> G.extFuncApp l n t ps
   newObj = G.newObj newObjDocD'
-  extNewObj l tp ps = modify (addModuleImport l) >> on1StateValue1List 
+  extNewObj l tp ps = modify (addModuleImportVS l) >> on1StateValue1List 
     (\t -> mkVal t . pyExtStateObj l (getTypeDoc t) . valueList) tp ps
 
   exists v = v ?!= valueOf (var "None" void)
@@ -449,8 +450,8 @@ instance InternalFunction PythonCode where
   funcFromData d = onStateValue (onCodeValue (`fd` d))
 
 instance InternalStatement PythonCode where
-  printSt nl f = on3StateValues (\f' p' v' -> mkStNoEnd $ pyPrint nl p' v' f') 
-    (fromMaybe (mkStateVal void empty) f)
+  printSt nl f p v = zoom lensMStoVS $ on3StateValues (\f' p' v' -> mkStNoEnd $ 
+    pyPrint nl p' v' f') (fromMaybe (mkStateVal void empty) f) p v
 
   state = G.state
   loopState = G.loopState
@@ -466,7 +467,8 @@ instance StatementSym PythonCode where
   type Statement PythonCode = (Doc, Terminator)
   assign = G.assign Empty
   assignToListIndex = G.assignToListIndex
-  multiAssign = on2StateLists (\vrs vls -> mkStNoEnd (multiAssignDoc vrs vls))
+  multiAssign vars vals = zoom lensMStoVS $ on2StateLists (\vrs vls -> 
+    mkStNoEnd (multiAssignDoc vrs vls)) vars vals
   (&=) = assign
   (&-=) = G.decrement
   (&+=) = G.increment'
@@ -475,8 +477,9 @@ instance StatementSym PythonCode where
 
   varDec _ = toState $ mkStNoEnd empty
   varDecDef = assign
-  listDec _ = onStateValue (mkStNoEnd . pyListDec)
-  listDecDef = on1StateValue1List (\v vs -> mkStNoEnd $ pyListDecDef v vs)
+  listDec _ v = zoom lensMStoVS $ onStateValue (mkStNoEnd . pyListDec) v
+  listDecDef v' vs' = zoom lensMStoVS $ on1StateValue1List (\v vs -> mkStNoEnd 
+    $ pyListDecDef v vs) v' vs'
   objDecDef = varDecDef
   objDecNew = G.objDecNew
   extObjDecNew lib v vs = modify (addModuleImport lib) >> varDecDef v 
@@ -519,7 +522,7 @@ instance StatementSym PythonCode where
 
   returnState = G.returnState Empty
   multiReturn [] = error "Attempt to write return statement with no return variables"
-  multiReturn vs = onStateList (mkStNoEnd . returnDocD) vs
+  multiReturn vs = zoom lensMStoVS $ onStateList (mkStNoEnd . returnDocD) vs
 
   valState = G.valState Empty
 
@@ -552,11 +555,14 @@ instance ControlStatementSym PythonCode where
   for _ _ _ _ = error $ "Classic for loops not available in Python, please " ++
     "use forRange, forEach, or while instead"
   forRange it initval finalval step bod = (\i initv finalv stepv b -> mkStNoEnd 
-    (pyForRange iterInLabel i initv finalv stepv b))
-    <$> it <*> initval <*> finalval <*> step <*> bod
-  forEach = on3StateValues (\i v b -> mkStNoEnd (pyForEach iterForEachLabel 
-    iterInLabel i v b))
-  while = on2StateValues (\v b -> mkStNoEnd (pyWhile v b))
+    (pyForRange iterInLabel i initv finalv stepv b)) <$> zoom lensMStoVS it <*> 
+    zoom lensMStoVS initval <*> zoom lensMStoVS finalval <*> 
+    zoom lensMStoVS step <*> bod
+  forEach i' v' = on3StateValues (\i v b -> mkStNoEnd (pyForEach 
+    iterForEachLabel iterInLabel i v b)) 
+    (zoom lensMStoVS i') (zoom lensMStoVS v')
+  while v' = on2StateValues (\v b -> mkStNoEnd (pyWhile v b)) 
+    (zoom lensMStoVS v')
 
   tryCatch = G.tryCatch pyTryCatch
 
@@ -581,7 +587,7 @@ instance InternalScope PythonCode where
 
 instance MethodTypeSym PythonCode where
   type MethodType PythonCode = TypeData
-  mType t = t
+  mType = zoom lensMStoVS
   construct = G.construct
 
 instance ParameterSym PythonCode where
@@ -623,7 +629,7 @@ instance MethodSym PythonCode where
 instance InternalMethod PythonCode where
   intMethod m n _ _ _ ps b = modify (if m then setCurrMain else id) >> 
     on3StateValues (\sl pms bd -> methodFromData Pub $ pyMethod n sl pms bd) 
-    self (sequence ps) b 
+    (zoom lensMStoVS self) (sequence ps) b 
   intFunc m n _ _ _ ps b = modify (if m then setCurrMain else id) >>
     on1StateValue1List (\bd pms -> methodFromData Pub $ pyFunction n pms bd) 
     b ps
@@ -694,19 +700,19 @@ initName = "__init__"
 pyName :: String
 pyName = "Python"
 
-pyODEMethod :: ODEMethod -> [MS (PythonCode (Value PythonCode))]
+pyODEMethod :: ODEMethod -> [VS (PythonCode (Value PythonCode))]
 pyODEMethod RK45 = [litString "dopri5"]
 pyODEMethod BDF = [litString "vode", 
-  (litString "bdf" :: MS (PythonCode (Value PythonCode))) >>= 
+  (litString "bdf" :: VS (PythonCode (Value PythonCode))) >>= 
   (mkStateVal string . (text "method=" <>) . valueDoc)]
 pyODEMethod Adams = [litString "vode", 
-  (litString "adams" :: MS (PythonCode (Value PythonCode))) >>= 
+  (litString "adams" :: VS (PythonCode (Value PythonCode))) >>= 
   (mkStateVal string . (text "method=" <>) . valueDoc)]
 
-pyLogOp :: (RenderSym repr) => MS (repr (UnaryOp repr))
+pyLogOp :: (RenderSym repr) => VS (repr (UnaryOp repr))
 pyLogOp = addmathImport $ unOpPrec "math.log10"
 
-pyLnOp :: (RenderSym repr) => MS (repr (UnaryOp repr))
+pyLnOp :: (RenderSym repr) => VS (repr (UnaryOp repr))
 pyLnOp = addmathImport $ unOpPrec "math.log"
 
 pyClassVar :: Doc -> Doc -> Doc
@@ -715,8 +721,8 @@ pyClassVar c v = c <> dot <> c <> dot <> v
 pyExtStateObj :: Label -> Doc -> Doc -> Doc
 pyExtStateObj l t vs = text l <> dot <> t <> parens vs
 
-pyInlineIf :: (RenderSym repr) => MS (repr (Value repr)) -> 
-  MS (repr (Value repr)) -> MS (repr (Value repr)) -> MS (repr (Value repr))
+pyInlineIf :: (RenderSym repr) => VS (repr (Value repr)) -> 
+  VS (repr (Value repr)) -> VS (repr (Value repr)) -> VS (repr (Value repr))
 pyInlineIf = on3StateValues (\c v1 v2 -> valFromData (valuePrec c) 
   (valueType v1) (valueDoc v1 <+> text "if" <+> valueDoc c <+> text "else" <+> 
   valueDoc v2))
@@ -724,7 +730,7 @@ pyInlineIf = on3StateValues (\c v1 v2 -> valFromData (valuePrec c)
 pyListSize :: Doc -> Doc -> Doc
 pyListSize v f = f <> parens v
 
-pyStringType :: (RenderSym repr) => MS (repr (Type repr))
+pyStringType :: (RenderSym repr) => VS (repr (Type repr))
 pyStringType = toState $ typeFromData String "str" (text "str")
 
 pyListDec :: (RenderSym repr) => repr (Variable repr) -> Doc
@@ -740,14 +746,14 @@ pyPrint newLn prf v f = valueDoc prf <> parens (valueDoc v <> nl <> fl)
   where nl = if newLn then empty else text ", end=''"
         fl = emptyIfEmpty (valueDoc f) $ text ", file=" <> valueDoc f
 
-pyOut :: (RenderSym repr) => Bool -> Maybe (MS (repr (Value repr))) -> 
-  MS (repr (Value repr)) -> MS (repr (Value repr)) -> MS (repr (Statement repr))
-pyOut newLn f printFn v = v >>= pyOut' . getType . valueType
+pyOut :: (RenderSym repr) => Bool -> Maybe (VS (repr (Value repr))) -> 
+  VS (repr (Value repr)) -> VS (repr (Value repr)) -> MS (repr (Statement repr))
+pyOut newLn f printFn v = zoom lensMStoVS v >>= pyOut' . getType . valueType
   where pyOut' (List _) = printSt newLn f printFn v
         pyOut' _ = outDoc newLn f printFn v
 
-pyInput :: MS (PythonCode (Value PythonCode)) ->
-  MS (PythonCode (Variable PythonCode)) -> 
+pyInput :: VS (PythonCode (Value PythonCode)) ->
+  VS (PythonCode (Variable PythonCode)) -> 
   MS (PythonCode (Statement PythonCode))
 pyInput inSrc v = v &= (v >>= pyInput' . getType . variableType)
   where pyInput' Integer = funcApp "int" int [inSrc]
@@ -788,9 +794,9 @@ pyTryCatch tryB catchB = vcat [
   text "except" <+> text "Exception" <+> colon,
   indent $ bodyDoc catchB]
 
-pyListSlice :: (RenderSym repr) => MS (repr (Variable repr)) -> 
-  MS (repr (Value repr)) -> MS (repr (Value repr)) -> MS (repr (Value repr)) -> 
-  MS (repr (Value repr)) -> MS Doc
+pyListSlice :: (RenderSym repr) => VS (repr (Variable repr)) -> 
+  VS (repr (Value repr)) -> VS (repr (Value repr)) -> VS (repr (Value repr)) -> 
+  VS (repr (Value repr)) -> VS Doc
 pyListSlice vn vo beg end step = (\vnew vold b e s -> variableDoc vnew <+> 
   equals <+> valueDoc vold <> brackets (valueDoc b <> colon <> valueDoc e <> 
   colon <> valueDoc s)) <$> vn <*> vo <*> beg <*> end <*> step
@@ -822,11 +828,11 @@ pyClass n pn s vs fs = vcat [
                 | isEmpty fs = vs
                 | otherwise = vcat [vs, blank, fs]
 
-pyInOutCall :: (Label -> MS (PythonCode (Type PythonCode)) -> 
-  [MS (PythonCode (Value PythonCode))] -> MS (PythonCode (Value PythonCode))) 
-  -> Label -> [MS (PythonCode (Value PythonCode))] -> 
-  [MS (PythonCode (Variable PythonCode))] -> 
-  [MS (PythonCode (Variable PythonCode))] -> 
+pyInOutCall :: (Label -> VS (PythonCode (Type PythonCode)) -> 
+  [VS (PythonCode (Value PythonCode))] -> VS (PythonCode (Value PythonCode))) 
+  -> Label -> [VS (PythonCode (Value PythonCode))] -> 
+  [VS (PythonCode (Variable PythonCode))] -> 
+  [VS (PythonCode (Variable PythonCode))] -> 
   MS (PythonCode (Statement PythonCode))
 pyInOutCall f n ins [] [] = valState $ f n void ins
 pyInOutCall f n ins outs both = multiAssign rets [f n void (map valueOf both ++ 
@@ -842,13 +848,13 @@ pyDocComment (l:lns) start mid = vcat $ start <+> text l : map ((<+>) mid .
   text) lns
 
 pyInOut :: (PythonCode (Scope PythonCode) -> PythonCode (Permanence PythonCode) 
-    -> MS (PythonCode (Type PythonCode)) -> 
+    -> VS (PythonCode (Type PythonCode)) -> 
     [MS (PythonCode (Parameter PythonCode))] 
     -> MS (PythonCode (Body PythonCode)) -> MS (PythonCode (Method PythonCode)))
   -> PythonCode (Scope PythonCode) -> PythonCode (Permanence PythonCode) -> 
-  [MS (PythonCode (Variable PythonCode))] -> 
-  [MS (PythonCode (Variable PythonCode))] -> 
-  [MS (PythonCode (Variable PythonCode))] -> MS (PythonCode (Body PythonCode)) 
+  [VS (PythonCode (Variable PythonCode))] -> 
+  [VS (PythonCode (Variable PythonCode))] -> 
+  [VS (PythonCode (Variable PythonCode))] -> MS (PythonCode (Body PythonCode)) 
   -> MS (PythonCode (Method PythonCode))
 pyInOut f s p ins [] [] b = f s p void (map param ins) b
 pyInOut f s p ins outs both b = f s p void (map param $ both ++ ins) 
@@ -857,12 +863,12 @@ pyInOut f s p ins outs both b = f s p void (map param $ both ++ ins)
   where rets = both ++ outs
 
 pyDocInOut :: (RenderSym repr) => (repr (Scope repr) -> repr (Permanence repr) 
-    -> [MS (repr (Variable repr))] -> [MS (repr (Variable repr))] -> 
-    [MS (repr (Variable repr))] -> MS (repr (Body repr)) -> 
+    -> [VS (repr (Variable repr))] -> [VS (repr (Variable repr))] -> 
+    [VS (repr (Variable repr))] -> MS (repr (Body repr)) -> 
     MS (repr (Method repr)))
   -> repr (Scope repr) -> repr (Permanence repr) -> String -> 
-  [(String, MS (repr (Variable repr)))] -> [(String, MS (repr (Variable repr)))]
-  -> [(String, MS (repr (Variable repr)))] -> MS (repr (Body repr)) -> 
+  [(String, VS (repr (Variable repr)))] -> [(String, VS (repr (Variable repr)))]
+  -> [(String, VS (repr (Variable repr)))] -> MS (repr (Body repr)) -> 
   MS (repr (Method repr))
 pyDocInOut f s p desc is os bs b = docFuncRepr desc (map fst $ bs ++ is)
   (map fst $ bs ++ os) (f s p (map snd is) (map snd os) (map snd bs) b)

--- a/code/drasil-gool/GOOL/Drasil/State.hs
+++ b/code/drasil-gool/GOOL/Drasil/State.hs
@@ -1,21 +1,28 @@
 {-# LANGUAGE TemplateHaskell #-}
 
 module GOOL.Drasil.State (
-  GS, GOOLState(..), FS, CS, MS, VS, lensFStoGS, lensGStoFS, lensFStoCS, lensFStoMS, lensFStoVS, lensCStoMS, lensMStoCS, lensCStoVS, lensMStoFS, lensMStoVS, lensVStoFS, lensVStoMS, headers, sources, mainMod, currMain, 
+  GS, GOOLState(..), FS, CS, MS, VS, lensFStoGS, lensGStoFS, lensFStoCS, 
+  lensFStoMS, lensFStoVS, lensCStoMS, lensMStoCS, lensCStoVS, lensMStoFS,
+  lensMStoVS, lensVStoFS, lensVStoMS, headers, sources, mainMod, currMain, 
   initialState, initialFS, modifyReturn, modifyReturnFunc, modifyReturnFunc2, 
-  modifyReturnList, addODEFilePaths, addFile, 
-  addCombinedHeaderSource, addHeader, addSource, addProgNameToPaths, setMainMod,
-  addODEFile, getODEFiles, addLangImport, addLangImportVS, addExceptionImports, getLangImports, 
-  addLibImport, addLibImports, getLibImports, addModuleImport, addModuleImportVS, getModuleImports,
-  addHeaderLangImport, getHeaderLangImports, addHeaderLibImport, 
-  getHeaderLibImports, addHeaderModImport, getHeaderModImports, addDefine, 
-  getDefines, addHeaderDefine, getHeaderDefines, addUsing, getUsing, 
-  addHeaderUsing, getHeaderUsing, setFilePath, getFilePath, setModuleName, 
-  getModuleName, setClassName, getClassName, setCurrMain, getCurrMain, addClass,
-  getClasses, updateClassMap, getClassMap, updateMethodExcMap, getMethodExcMap,
-  addParameter, getParameters, setOutputsDeclared, isOutputsDeclared, addException, 
-  addExceptions, getExceptions, setScope, getScope, setCurrMainFunc, 
-  getCurrMainFunc, setConstructorParams, getConstructorParams, addSelfAssignment, getSelfAssignments, setODEDepVars, getODEDepVars, setODEOthVars, getODEOthVars, setLeftAssignment, getLeftAssignment, setAssignedSelfVar, getAssignedSelfVar, setRightAssignment, getRightAssignment, addVariableAssigned, getVariablesAssigned
+  modifyReturnList, addODEFilePaths, addFile, addCombinedHeaderSource, 
+  addHeader, addSource, addProgNameToPaths, setMainMod,addODEFile, getODEFiles, 
+  addLangImport, addLangImportVS, addExceptionImports, getLangImports, 
+  addLibImport, addLibImports, getLibImports, addModuleImport, 
+  addModuleImportVS, getModuleImports, addHeaderLangImport, 
+  getHeaderLangImports, addHeaderLibImport, getHeaderLibImports, 
+  addHeaderModImport, getHeaderModImports, addDefine, getDefines, 
+  addHeaderDefine, getHeaderDefines, addUsing, getUsing, addHeaderUsing, 
+  getHeaderUsing, setFilePath, getFilePath, setModuleName, getModuleName, 
+  setClassName, getClassName, setCurrMain, getCurrMain, addClass, getClasses, 
+  updateClassMap, getClassMap, updateMethodExcMap, getMethodExcMap,  
+  addParameter, getParameters, setOutputsDeclared, isOutputsDeclared, 
+  addException, addExceptions, getExceptions, setScope, getScope, 
+  setCurrMainFunc, getCurrMainFunc, setConstructorParams, getConstructorParams, 
+  addSelfAssignment, getSelfAssignments, setODEDepVars, getODEDepVars, 
+  setODEOthVars, getODEOthVars, setLeftAssignment, getLeftAssignment, 
+  setAssignedSelfVar, getAssignedSelfVar, setRightAssignment, 
+  getRightAssignment, addVariableAssigned, getVariablesAssigned
 ) where
 
 import GOOL.Drasil.Data (FileType(..), ScopeTag(..), Exception(..), FileData)

--- a/code/drasil-gool/GOOL/Drasil/Symantics.hs
+++ b/code/drasil-gool/GOOL/Drasil/Symantics.hs
@@ -22,7 +22,7 @@ module GOOL.Drasil.Symantics (
 
 import GOOL.Drasil.CodeType (CodeType)
 import GOOL.Drasil.Data (Binding, Terminator, FileType, ScopeTag)
-import GOOL.Drasil.State (GS, FS, CS, MS)
+import GOOL.Drasil.State (GS, FS, CS, MS, VS)
 
 import Control.Monad.State (State)
 import Text.PrettyPrint.HughesPJ (Doc)
@@ -125,20 +125,20 @@ class InternalBlock repr where
 
 class (PermanenceSym repr) => TypeSym repr where
   type Type repr
-  bool          :: MS (repr (Type repr))
-  int           :: MS (repr (Type repr))
-  float         :: MS (repr (Type repr))
-  char          :: MS (repr (Type repr))
-  string        :: MS (repr (Type repr))
-  infile        :: MS (repr (Type repr))
-  outfile       :: MS (repr (Type repr))
-  listType      :: repr (Permanence repr) -> MS (repr (Type repr)) -> 
-    MS (repr (Type repr))
-  listInnerType :: MS (repr (Type repr)) -> MS (repr (Type repr))
-  obj           :: Label -> MS (repr (Type repr))
-  enumType      :: Label -> MS (repr (Type repr))
-  iterator      :: MS (repr (Type repr)) -> MS (repr (Type repr))
-  void          :: MS (repr (Type repr))
+  bool          :: VS (repr (Type repr))
+  int           :: VS (repr (Type repr))
+  float         :: VS (repr (Type repr))
+  char          :: VS (repr (Type repr))
+  string        :: VS (repr (Type repr))
+  infile        :: VS (repr (Type repr))
+  outfile       :: VS (repr (Type repr))
+  listType      :: repr (Permanence repr) -> VS (repr (Type repr)) -> 
+    VS (repr (Type repr))
+  listInnerType :: VS (repr (Type repr)) -> VS (repr (Type repr))
+  obj           :: Label -> VS (repr (Type repr))
+  enumType      :: Label -> VS (repr (Type repr))
+  iterator      :: VS (repr (Type repr)) -> VS (repr (Type repr))
+  void          :: VS (repr (Type repr))
 
   getType :: repr (Type repr) -> CodeType
   getTypeString :: repr (Type repr) -> String
@@ -149,56 +149,56 @@ class InternalType repr where
 
 class (ControlStatementSym repr) => ControlBlockSym repr where
   runStrategy     :: Label -> [(Label, MS (repr (Body repr)))] -> 
-    Maybe (MS (repr (Value repr))) -> Maybe (MS (repr (Variable repr))) -> 
+    Maybe (VS (repr (Value repr))) -> Maybe (VS (repr (Variable repr))) -> 
     MS (repr (Block repr))
 
-  listSlice'      :: Maybe (MS (repr (Value repr))) -> 
-    Maybe (MS (repr (Value repr))) -> Maybe (MS (repr (Value repr))) ->
-    MS (repr (Variable repr)) -> MS (repr (Value repr)) -> 
+  listSlice'      :: Maybe (VS (repr (Value repr))) -> 
+    Maybe (VS (repr (Value repr))) -> Maybe (VS (repr (Value repr))) ->
+    VS (repr (Variable repr)) -> VS (repr (Value repr)) -> 
     MS (repr (Block repr))
 
   solveODE :: ODEInfo repr -> ODEOptions repr -> MS (repr (Block repr))
   
-listSlice :: (ControlBlockSym repr) => MS (repr (Variable repr)) -> 
-  MS (repr (Value repr)) -> Maybe (MS (repr (Value repr))) -> 
-  Maybe (MS (repr (Value repr))) -> Maybe (MS (repr (Value repr))) -> 
+listSlice :: (ControlBlockSym repr) => VS (repr (Variable repr)) -> 
+  VS (repr (Value repr)) -> Maybe (VS (repr (Value repr))) -> 
+  Maybe (VS (repr (Value repr))) -> Maybe (VS (repr (Value repr))) -> 
   MS (repr (Block repr))
 listSlice vnew vold b e s = listSlice' b e s vnew vold
 
 class UnaryOpSym repr where
   type UnaryOp repr
-  notOp    :: MS (repr (UnaryOp repr))
-  negateOp :: MS (repr (UnaryOp repr))
-  sqrtOp   :: MS (repr (UnaryOp repr))
-  absOp    :: MS (repr (UnaryOp repr))
-  logOp    :: MS (repr (UnaryOp repr))
-  lnOp     :: MS (repr (UnaryOp repr))
-  expOp    :: MS (repr (UnaryOp repr))
-  sinOp    :: MS (repr (UnaryOp repr))
-  cosOp    :: MS (repr (UnaryOp repr))
-  tanOp    :: MS (repr (UnaryOp repr))
-  asinOp   :: MS (repr (UnaryOp repr))
-  acosOp   :: MS (repr (UnaryOp repr))
-  atanOp   :: MS (repr (UnaryOp repr))
-  floorOp  :: MS (repr (UnaryOp repr))
-  ceilOp   :: MS (repr (UnaryOp repr))
+  notOp    :: VS (repr (UnaryOp repr))
+  negateOp :: VS (repr (UnaryOp repr))
+  sqrtOp   :: VS (repr (UnaryOp repr))
+  absOp    :: VS (repr (UnaryOp repr))
+  logOp    :: VS (repr (UnaryOp repr))
+  lnOp     :: VS (repr (UnaryOp repr))
+  expOp    :: VS (repr (UnaryOp repr))
+  sinOp    :: VS (repr (UnaryOp repr))
+  cosOp    :: VS (repr (UnaryOp repr))
+  tanOp    :: VS (repr (UnaryOp repr))
+  asinOp   :: VS (repr (UnaryOp repr))
+  acosOp   :: VS (repr (UnaryOp repr))
+  atanOp   :: VS (repr (UnaryOp repr))
+  floorOp  :: VS (repr (UnaryOp repr))
+  ceilOp   :: VS (repr (UnaryOp repr))
 
 class BinaryOpSym repr where
   type BinaryOp repr
-  equalOp        :: MS (repr (BinaryOp repr))
-  notEqualOp     :: MS (repr (BinaryOp repr))
-  greaterOp      :: MS (repr (BinaryOp repr))
-  greaterEqualOp :: MS (repr (BinaryOp repr))
-  lessOp         :: MS (repr (BinaryOp repr))
-  lessEqualOp    :: MS (repr (BinaryOp repr))
-  plusOp         :: MS (repr (BinaryOp repr))
-  minusOp        :: MS (repr (BinaryOp repr))
-  multOp         :: MS (repr (BinaryOp repr))
-  divideOp       :: MS (repr (BinaryOp repr))
-  powerOp        :: MS (repr (BinaryOp repr))
-  moduloOp       :: MS (repr (BinaryOp repr))
-  andOp          :: MS (repr (BinaryOp repr))
-  orOp           :: MS (repr (BinaryOp repr))
+  equalOp        :: VS (repr (BinaryOp repr))
+  notEqualOp     :: VS (repr (BinaryOp repr))
+  greaterOp      :: VS (repr (BinaryOp repr))
+  greaterEqualOp :: VS (repr (BinaryOp repr))
+  lessOp         :: VS (repr (BinaryOp repr))
+  lessEqualOp    :: VS (repr (BinaryOp repr))
+  plusOp         :: VS (repr (BinaryOp repr))
+  minusOp        :: VS (repr (BinaryOp repr))
+  multOp         :: VS (repr (BinaryOp repr))
+  divideOp       :: VS (repr (BinaryOp repr))
+  powerOp        :: VS (repr (BinaryOp repr))
+  moduloOp       :: VS (repr (BinaryOp repr))
+  andOp          :: VS (repr (BinaryOp repr))
+  orOp           :: VS (repr (BinaryOp repr))
 
 class InternalOp repr where
   uOpDoc :: repr (UnaryOp repr) -> Doc
@@ -206,32 +206,32 @@ class InternalOp repr where
   uOpPrec :: repr (UnaryOp repr) -> Int
   bOpPrec :: repr (BinaryOp repr) -> Int
 
-  uOpFromData :: Int -> Doc -> MS (repr (UnaryOp repr))
-  bOpFromData :: Int -> Doc -> MS (repr (BinaryOp repr))
+  uOpFromData :: Int -> Doc -> VS (repr (UnaryOp repr))
+  bOpFromData :: Int -> Doc -> VS (repr (BinaryOp repr))
 
 class (TypeSym repr) => VariableSym repr where
   type Variable repr
-  var          :: Label -> MS (repr (Type repr)) -> MS (repr (Variable repr))
-  staticVar    :: Label -> MS (repr (Type repr)) -> MS (repr (Variable repr))
-  const        :: Label -> MS (repr (Type repr)) -> MS (repr (Variable repr))
-  extVar       :: Library -> Label -> MS (repr (Type repr)) -> 
-    MS (repr (Variable repr))
-  self         :: MS (repr (Variable repr))
-  classVar     :: MS (repr (Type repr)) -> MS (repr (Variable repr)) -> 
-    MS (repr (Variable repr))
-  extClassVar  :: MS (repr (Type repr)) -> MS (repr (Variable repr)) -> 
-    MS (repr (Variable repr))
-  objVar       :: MS (repr (Variable repr)) -> MS (repr (Variable repr)) -> 
-    MS (repr (Variable repr))
-  objVarSelf   :: MS (repr (Variable repr)) -> MS (repr (Variable repr))
-  enumVar      :: Label -> Label -> MS (repr (Variable repr))
-  listVar      :: Label -> repr (Permanence repr) -> MS (repr (Type repr)) -> 
-    MS (repr (Variable repr))
-  listOf       :: Label -> MS (repr (Type repr)) -> MS (repr (Variable repr))
+  var          :: Label -> VS (repr (Type repr)) -> VS (repr (Variable repr))
+  staticVar    :: Label -> VS (repr (Type repr)) -> VS (repr (Variable repr))
+  const        :: Label -> VS (repr (Type repr)) -> VS (repr (Variable repr))
+  extVar       :: Library -> Label -> VS (repr (Type repr)) -> 
+    VS (repr (Variable repr))
+  self         :: VS (repr (Variable repr))
+  classVar     :: VS (repr (Type repr)) -> VS (repr (Variable repr)) -> 
+    VS (repr (Variable repr))
+  extClassVar  :: VS (repr (Type repr)) -> VS (repr (Variable repr)) -> 
+    VS (repr (Variable repr))
+  objVar       :: VS (repr (Variable repr)) -> VS (repr (Variable repr)) -> 
+    VS (repr (Variable repr))
+  objVarSelf   :: VS (repr (Variable repr)) -> VS (repr (Variable repr))
+  enumVar      :: Label -> Label -> VS (repr (Variable repr))
+  listVar      :: Label -> repr (Permanence repr) -> VS (repr (Type repr)) -> 
+    VS (repr (Variable repr))
+  listOf       :: Label -> VS (repr (Type repr)) -> VS (repr (Variable repr))
   -- Use for iterator variables, i.e. in a forEach loop.
-  iterVar      :: Label -> MS (repr (Type repr)) -> MS (repr (Variable repr))
+  iterVar      :: Label -> VS (repr (Type repr)) -> VS (repr (Variable repr))
 
-  ($->) :: MS (repr (Variable repr)) -> MS (repr (Variable repr)) -> MS (repr (Variable repr))
+  ($->) :: VS (repr (Variable repr)) -> VS (repr (Variable repr)) -> VS (repr (Variable repr))
   infixl 9 $->
 
   variableBind :: repr (Variable repr) -> Binding
@@ -245,70 +245,70 @@ class InternalVariable repr where
 
 class (VariableSym repr) => ValueSym repr where
   type Value repr
-  litTrue   :: MS (repr (Value repr))
-  litFalse  :: MS (repr (Value repr))
-  litChar   :: Char -> MS (repr (Value repr))
-  litFloat  :: Double -> MS (repr (Value repr))
-  litInt    :: Integer -> MS (repr (Value repr))
-  litString :: String -> MS (repr (Value repr))
+  litTrue   :: VS (repr (Value repr))
+  litFalse  :: VS (repr (Value repr))
+  litChar   :: Char -> VS (repr (Value repr))
+  litFloat  :: Double -> VS (repr (Value repr))
+  litInt    :: Integer -> VS (repr (Value repr))
+  litString :: String -> VS (repr (Value repr))
 
-  pi :: MS (repr (Value repr))
+  pi :: VS (repr (Value repr))
 
   --other operators ($)
-  ($:)  :: Label -> Label -> MS (repr (Value repr))
+  ($:)  :: Label -> Label -> VS (repr (Value repr))
   infixl 9 $:
 
-  valueOf       :: MS (repr (Variable repr)) -> MS (repr (Value repr))
+  valueOf       :: VS (repr (Variable repr)) -> VS (repr (Value repr))
 --  global       :: Label -> repr (Value repr)         -- not sure how this one works, but in GOOL it was hardcoded to give an error so I'm leaving it out for now
-  arg          :: Integer -> MS (repr (Value repr))
-  enumElement  :: Label -> Label -> MS (repr (Value repr))
+  arg          :: Integer -> VS (repr (Value repr))
+  enumElement  :: Label -> Label -> VS (repr (Value repr))
 
-  argsList  :: MS (repr (Value repr))
+  argsList  :: VS (repr (Value repr))
 
   valueType :: repr (Value repr) -> repr (Type repr)
   valueDoc :: repr (Value repr) -> Doc
 
 class (ValueSym repr) => 
   NumericExpression repr where
-  (#~)  :: MS (repr (Value repr)) -> MS (repr (Value repr))
+  (#~)  :: VS (repr (Value repr)) -> VS (repr (Value repr))
   infixl 8 #~
-  (#/^) :: MS (repr (Value repr)) -> MS (repr (Value repr))
+  (#/^) :: VS (repr (Value repr)) -> VS (repr (Value repr))
   infixl 7 #/^
-  (#|)  :: MS (repr (Value repr)) -> MS (repr (Value repr))
+  (#|)  :: VS (repr (Value repr)) -> VS (repr (Value repr))
   infixl 7 #|
-  (#+)  :: MS (repr (Value repr)) -> MS (repr (Value repr)) -> 
-    MS (repr (Value repr))
+  (#+)  :: VS (repr (Value repr)) -> VS (repr (Value repr)) -> 
+    VS (repr (Value repr))
   infixl 5 #+
-  (#-)  :: MS (repr (Value repr)) -> MS (repr (Value repr)) -> 
-    MS (repr (Value repr))
+  (#-)  :: VS (repr (Value repr)) -> VS (repr (Value repr)) -> 
+    VS (repr (Value repr))
   infixl 5 #-
-  (#*)  :: MS (repr (Value repr)) -> MS (repr (Value repr)) -> 
-    MS (repr (Value repr))
+  (#*)  :: VS (repr (Value repr)) -> VS (repr (Value repr)) -> 
+    VS (repr (Value repr))
   infixl 6 #*
-  (#/)  :: MS (repr (Value repr)) -> MS (repr (Value repr)) -> 
-    MS (repr (Value repr))
+  (#/)  :: VS (repr (Value repr)) -> VS (repr (Value repr)) -> 
+    VS (repr (Value repr))
   infixl 6 #/
-  (#%)  :: MS (repr (Value repr)) -> MS (repr (Value repr)) -> 
-    MS (repr (Value repr))
+  (#%)  :: VS (repr (Value repr)) -> VS (repr (Value repr)) -> 
+    VS (repr (Value repr))
   infixl 6 #%
-  (#^)  :: MS (repr (Value repr)) -> MS (repr (Value repr)) -> 
-    MS (repr (Value repr))
+  (#^)  :: VS (repr (Value repr)) -> VS (repr (Value repr)) -> 
+    VS (repr (Value repr))
   infixl 7 #^
 
-  log    :: MS (repr (Value repr)) -> MS (repr (Value repr))
-  ln     :: MS (repr (Value repr)) -> MS (repr (Value repr))
-  exp    :: MS (repr (Value repr)) -> MS (repr (Value repr))
-  sin    :: MS (repr (Value repr)) -> MS (repr (Value repr))
-  cos    :: MS (repr (Value repr)) -> MS (repr (Value repr))
-  tan    :: MS (repr (Value repr)) -> MS (repr (Value repr))
-  csc    :: MS (repr (Value repr)) -> MS (repr (Value repr))
-  sec    :: MS (repr (Value repr)) -> MS (repr (Value repr))
-  cot    :: MS (repr (Value repr)) -> MS (repr (Value repr))
-  arcsin :: MS (repr (Value repr)) -> MS (repr (Value repr))
-  arccos :: MS (repr (Value repr)) -> MS (repr (Value repr))
-  arctan :: MS (repr (Value repr)) -> MS (repr (Value repr))
-  floor  :: MS (repr (Value repr)) -> MS (repr (Value repr))
-  ceil   :: MS (repr (Value repr)) -> MS (repr (Value repr))
+  log    :: VS (repr (Value repr)) -> VS (repr (Value repr))
+  ln     :: VS (repr (Value repr)) -> VS (repr (Value repr))
+  exp    :: VS (repr (Value repr)) -> VS (repr (Value repr))
+  sin    :: VS (repr (Value repr)) -> VS (repr (Value repr))
+  cos    :: VS (repr (Value repr)) -> VS (repr (Value repr))
+  tan    :: VS (repr (Value repr)) -> VS (repr (Value repr))
+  csc    :: VS (repr (Value repr)) -> VS (repr (Value repr))
+  sec    :: VS (repr (Value repr)) -> VS (repr (Value repr))
+  cot    :: VS (repr (Value repr)) -> VS (repr (Value repr))
+  arcsin :: VS (repr (Value repr)) -> VS (repr (Value repr))
+  arccos :: VS (repr (Value repr)) -> VS (repr (Value repr))
+  arctan :: VS (repr (Value repr)) -> VS (repr (Value repr))
+  floor  :: VS (repr (Value repr)) -> VS (repr (Value repr))
+  ceil   :: VS (repr (Value repr)) -> VS (repr (Value repr))
 
 -- I considered having two separate classes, BooleanExpressions and BooleanComparisons,
 -- but this would require cyclic constraints, since it is feasible to have
@@ -317,61 +317,61 @@ class (ValueSym repr) =>
 -- 3 functions here, even though they don't really need it.
 class (ValueSym repr, NumericExpression repr) => 
   BooleanExpression repr where
-  (?!)  :: MS (repr (Value repr)) -> MS (repr (Value repr))
+  (?!)  :: VS (repr (Value repr)) -> VS (repr (Value repr))
   infixr 6 ?!
-  (?&&) :: MS (repr (Value repr)) -> MS (repr (Value repr)) -> 
-    MS (repr (Value repr))
+  (?&&) :: VS (repr (Value repr)) -> VS (repr (Value repr)) -> 
+    VS (repr (Value repr))
   infixl 2 ?&&
-  (?||) :: MS (repr (Value repr)) -> MS (repr (Value repr)) -> 
-    MS (repr (Value repr))
+  (?||) :: VS (repr (Value repr)) -> VS (repr (Value repr)) -> 
+    VS (repr (Value repr))
   infixl 1 ?||
 
-  (?<)  :: MS (repr (Value repr)) -> MS (repr (Value repr)) -> 
-    MS (repr (Value repr))
+  (?<)  :: VS (repr (Value repr)) -> VS (repr (Value repr)) -> 
+    VS (repr (Value repr))
   infixl 4 ?<
-  (?<=) :: MS (repr (Value repr)) -> MS (repr (Value repr)) -> 
-    MS (repr (Value repr))
+  (?<=) :: VS (repr (Value repr)) -> VS (repr (Value repr)) -> 
+    VS (repr (Value repr))
   infixl 4 ?<=
-  (?>)  :: MS (repr (Value repr)) -> MS (repr (Value repr)) -> 
-    MS (repr (Value repr))
+  (?>)  :: VS (repr (Value repr)) -> VS (repr (Value repr)) -> 
+    VS (repr (Value repr))
   infixl 4 ?>
-  (?>=) :: MS (repr (Value repr)) -> MS (repr (Value repr)) -> 
-    MS (repr (Value repr))
+  (?>=) :: VS (repr (Value repr)) -> VS (repr (Value repr)) -> 
+    VS (repr (Value repr))
   infixl 4 ?>=
-  (?==) :: MS (repr (Value repr)) -> MS (repr (Value repr)) -> 
-    MS (repr (Value repr))
+  (?==) :: VS (repr (Value repr)) -> VS (repr (Value repr)) -> 
+    VS (repr (Value repr))
   infixl 3 ?==
-  (?!=) :: MS (repr (Value repr)) -> MS (repr (Value repr)) -> 
-    MS (repr (Value repr))
+  (?!=) :: VS (repr (Value repr)) -> VS (repr (Value repr)) -> 
+    VS (repr (Value repr))
   infixl 3 ?!=
 
 class (ValueSym repr, BooleanExpression repr) => 
   ValueExpression repr where -- for values that can include expressions
-  inlineIf     :: MS (repr (Value repr)) -> MS (repr (Value repr)) -> 
-    MS (repr (Value repr)) -> MS (repr (Value repr))
-  funcApp      :: Label -> MS (repr (Type repr)) -> [MS (repr (Value repr))] -> 
-    MS (repr (Value repr))
-  selfFuncApp  :: Label -> MS (repr (Type repr)) -> 
-    [MS (repr (Value repr))] -> MS (repr (Value repr))
-  extFuncApp   :: Library -> Label -> MS (repr (Type repr)) -> 
-    [MS (repr (Value repr))] -> MS (repr (Value repr))
-  newObj     :: MS (repr (Type repr)) -> [MS (repr (Value repr))] -> 
-    MS (repr (Value repr))
-  extNewObj  :: Library -> MS (repr (Type repr)) -> [MS (repr (Value repr))] -> 
-    MS (repr (Value repr))
+  inlineIf     :: VS (repr (Value repr)) -> VS (repr (Value repr)) -> 
+    VS (repr (Value repr)) -> VS (repr (Value repr))
+  funcApp      :: Label -> VS (repr (Type repr)) -> [VS (repr (Value repr))] -> 
+    VS (repr (Value repr))
+  selfFuncApp  :: Label -> VS (repr (Type repr)) -> 
+    [VS (repr (Value repr))] -> VS (repr (Value repr))
+  extFuncApp   :: Library -> Label -> VS (repr (Type repr)) -> 
+    [VS (repr (Value repr))] -> VS (repr (Value repr))
+  newObj     :: VS (repr (Type repr)) -> [VS (repr (Value repr))] -> 
+    VS (repr (Value repr))
+  extNewObj  :: Library -> VS (repr (Type repr)) -> [VS (repr (Value repr))] -> 
+    VS (repr (Value repr))
 
-  exists  :: MS (repr (Value repr)) -> MS (repr (Value repr))
-  notNull :: MS (repr (Value repr)) -> MS (repr (Value repr))
+  exists  :: VS (repr (Value repr)) -> VS (repr (Value repr))
+  notNull :: VS (repr (Value repr)) -> VS (repr (Value repr))
 
 class InternalValue repr where
-  inputFunc       :: MS (repr (Value repr))
-  printFunc       :: MS (repr (Value repr))
-  printLnFunc     :: MS (repr (Value repr))
-  printFileFunc   :: MS (repr (Value repr)) -> MS (repr (Value repr))
-  printFileLnFunc :: MS (repr (Value repr)) -> MS (repr (Value repr))
+  inputFunc       :: VS (repr (Value repr))
+  printFunc       :: VS (repr (Value repr))
+  printLnFunc     :: VS (repr (Value repr))
+  printFileFunc   :: VS (repr (Value repr)) -> VS (repr (Value repr))
+  printFileLnFunc :: VS (repr (Value repr)) -> VS (repr (Value repr))
 
-  cast :: MS (repr (Type repr)) -> MS (repr (Value repr)) -> 
-    MS (repr (Value repr))
+  cast :: VS (repr (Type repr)) -> VS (repr (Value repr)) -> 
+    VS (repr (Value repr))
 
   valuePrec :: repr (Value repr) -> Maybe Int
   valFromData :: Maybe Int -> repr (Type repr) -> Doc -> repr (Value repr)
@@ -383,90 +383,90 @@ class InternalValue repr where
 -- then what is the purpose of splitting the typeclasses into smaller typeclasses?
 -- I'm leaving it as is for now, even though I suspect this will change in the future.
 class (FunctionSym repr) => Selector repr where
-  objAccess :: MS (repr (Value repr)) -> MS (repr (Function repr)) -> 
-    MS (repr (Value repr))
-  ($.)      :: MS (repr (Value repr)) -> MS (repr (Function repr)) -> 
-    MS (repr (Value repr))
+  objAccess :: VS (repr (Value repr)) -> VS (repr (Function repr)) -> 
+    VS (repr (Value repr))
+  ($.)      :: VS (repr (Value repr)) -> VS (repr (Function repr)) -> 
+    VS (repr (Value repr))
   infixl 9 $.
 
-  selfAccess :: MS (repr (Function repr)) -> MS (repr (Value repr))
+  selfAccess :: VS (repr (Function repr)) -> VS (repr (Value repr))
 
-  listIndexExists :: MS (repr (Value repr)) -> MS (repr (Value repr)) -> 
-    MS (repr (Value repr))
-  argExists       :: Integer -> MS (repr (Value repr))
+  listIndexExists :: VS (repr (Value repr)) -> VS (repr (Value repr)) -> 
+    VS (repr (Value repr))
+  argExists       :: Integer -> VS (repr (Value repr))
 
-  indexOf :: MS (repr (Value repr)) -> MS (repr (Value repr)) -> 
-    MS (repr (Value repr))
+  indexOf :: VS (repr (Value repr)) -> VS (repr (Value repr)) -> 
+    VS (repr (Value repr))
 
 class (FunctionSym repr) => InternalSelector repr where
-  objMethodCall' :: Label -> MS (repr (Type repr)) -> MS (repr (Value repr)) -> 
-    [MS (repr (Value repr))] -> MS (repr (Value repr))
-  objMethodCallNoParams' :: Label -> MS (repr (Type repr)) -> 
-    MS (repr (Value repr)) -> MS (repr (Value repr))
+  objMethodCall' :: Label -> VS (repr (Type repr)) -> VS (repr (Value repr)) -> 
+    [VS (repr (Value repr))] -> VS (repr (Value repr))
+  objMethodCallNoParams' :: Label -> VS (repr (Type repr)) -> 
+    VS (repr (Value repr)) -> VS (repr (Value repr))
 
-objMethodCall :: (InternalSelector repr) => MS (repr (Type repr)) -> 
-  MS (repr (Value repr)) -> Label -> [MS (repr (Value repr))] -> 
-  MS (repr (Value repr))
+objMethodCall :: (InternalSelector repr) => VS (repr (Type repr)) -> 
+  VS (repr (Value repr)) -> Label -> [VS (repr (Value repr))] -> 
+  VS (repr (Value repr))
 objMethodCall t o f = objMethodCall' f t o
 
-objMethodCallNoParams :: (InternalSelector repr) => MS (repr (Type repr)) -> 
-  MS (repr (Value repr)) -> Label -> MS (repr (Value repr))
+objMethodCallNoParams :: (InternalSelector repr) => VS (repr (Type repr)) -> 
+  VS (repr (Value repr)) -> Label -> VS (repr (Value repr))
 objMethodCallNoParams t o f = objMethodCallNoParams' f t o
 
 class (ValueExpression repr) => FunctionSym repr where
   type Function repr
-  func :: Label -> MS (repr (Type repr)) -> [MS (repr (Value repr))] -> 
-    MS (repr (Function repr))
+  func :: Label -> VS (repr (Type repr)) -> [VS (repr (Value repr))] -> 
+    VS (repr (Function repr))
 
-  get :: MS (repr (Value repr)) -> MS (repr (Variable repr)) -> 
-    MS (repr (Value repr))
-  set :: MS (repr (Value repr)) -> MS (repr (Variable repr)) -> 
-    MS (repr (Value repr)) -> MS (repr (Value repr))
+  get :: VS (repr (Value repr)) -> VS (repr (Variable repr)) -> 
+    VS (repr (Value repr))
+  set :: VS (repr (Value repr)) -> VS (repr (Variable repr)) -> 
+    VS (repr (Value repr)) -> VS (repr (Value repr))
 
-  listSize   :: MS (repr (Value repr)) -> MS (repr (Value repr))
-  listAdd    :: MS (repr (Value repr)) -> MS (repr (Value repr)) -> 
-    MS (repr (Value repr)) -> MS (repr (Value repr))
-  listAppend :: MS (repr (Value repr)) -> MS (repr (Value repr)) -> 
-    MS (repr (Value repr))
+  listSize   :: VS (repr (Value repr)) -> VS (repr (Value repr))
+  listAdd    :: VS (repr (Value repr)) -> VS (repr (Value repr)) -> 
+    VS (repr (Value repr)) -> VS (repr (Value repr))
+  listAppend :: VS (repr (Value repr)) -> VS (repr (Value repr)) -> 
+    VS (repr (Value repr))
 
-  iterBegin :: MS (repr (Value repr)) -> MS (repr (Value repr))
-  iterEnd   :: MS (repr (Value repr)) -> MS (repr (Value repr))
+  iterBegin :: VS (repr (Value repr)) -> VS (repr (Value repr))
+  iterEnd   :: VS (repr (Value repr)) -> VS (repr (Value repr))
 
 class (Selector repr, InternalSelector repr) => SelectorFunction repr where
-  listAccess :: MS (repr (Value repr)) -> MS (repr (Value repr)) -> 
-    MS (repr (Value repr))
-  listSet    :: MS (repr (Value repr)) -> MS (repr (Value repr)) -> 
-    MS (repr (Value repr)) -> MS (repr (Value repr))
-  at         :: MS (repr (Value repr)) -> MS (repr (Value repr)) -> 
-    MS (repr (Value repr))
+  listAccess :: VS (repr (Value repr)) -> VS (repr (Value repr)) -> 
+    VS (repr (Value repr))
+  listSet    :: VS (repr (Value repr)) -> VS (repr (Value repr)) -> 
+    VS (repr (Value repr)) -> VS (repr (Value repr))
+  at         :: VS (repr (Value repr)) -> VS (repr (Value repr)) -> 
+    VS (repr (Value repr))
 
 class InternalFunction repr where
-  getFunc        :: MS (repr (Variable repr)) -> MS (repr (Function repr))
-  setFunc        :: MS (repr (Type repr)) -> MS (repr (Variable repr)) -> 
-    MS (repr (Value repr)) -> MS (repr (Function repr))
+  getFunc        :: VS (repr (Variable repr)) -> VS (repr (Function repr))
+  setFunc        :: VS (repr (Type repr)) -> VS (repr (Variable repr)) -> 
+    VS (repr (Value repr)) -> VS (repr (Function repr))
 
-  listSizeFunc       :: MS (repr (Function repr))
-  listAddFunc        :: MS (repr (Value repr)) -> MS (repr (Value repr)) -> 
-    MS (repr (Value repr)) -> MS (repr (Function repr))
-  listAppendFunc         :: MS (repr (Value repr)) -> MS (repr (Function repr))
+  listSizeFunc       :: VS (repr (Function repr))
+  listAddFunc        :: VS (repr (Value repr)) -> VS (repr (Value repr)) -> 
+    VS (repr (Value repr)) -> VS (repr (Function repr))
+  listAppendFunc         :: VS (repr (Value repr)) -> VS (repr (Function repr))
 
-  iterBeginFunc :: MS (repr (Type repr)) -> MS (repr (Function repr))
-  iterEndFunc   :: MS (repr (Type repr)) -> MS (repr (Function repr))
+  iterBeginFunc :: VS (repr (Type repr)) -> VS (repr (Function repr))
+  iterEndFunc   :: VS (repr (Type repr)) -> VS (repr (Function repr))
 
-  listAccessFunc :: MS (repr (Type repr)) -> MS (repr (Value repr)) -> 
-    MS (repr (Function repr))
-  listSetFunc    :: MS (repr (Value repr)) -> MS (repr (Value repr)) -> 
-    MS (repr (Value repr)) -> MS (repr (Function repr))
+  listAccessFunc :: VS (repr (Type repr)) -> VS (repr (Value repr)) -> 
+    VS (repr (Function repr))
+  listSetFunc    :: VS (repr (Value repr)) -> VS (repr (Value repr)) -> 
+    VS (repr (Value repr)) -> VS (repr (Function repr))
 
   functionType :: repr (Function repr) -> repr (Type repr)
   functionDoc :: repr (Function repr) -> Doc
 
-  funcFromData :: Doc -> MS (repr (Type repr)) -> MS (repr (Function repr))
+  funcFromData :: Doc -> VS (repr (Type repr)) -> VS (repr (Function repr))
 
 class InternalStatement repr where
   -- newLn, maybe a file to print to, printFunc, value to print
-  printSt :: Bool -> Maybe (MS (repr (Value repr))) -> MS (repr (Value repr)) 
-    -> MS (repr (Value repr)) -> MS (repr (Statement repr))
+  printSt :: Bool -> Maybe (VS (repr (Value repr))) -> VS (repr (Value repr)) 
+    -> VS (repr (Value repr)) -> MS (repr (Statement repr))
 
   state     :: MS (repr (Statement repr)) -> MS (repr (Statement repr))
   loopState :: MS (repr (Statement repr)) -> MS (repr (Statement repr))
@@ -479,153 +479,153 @@ class InternalStatement repr where
 
 class (SelectorFunction repr) => StatementSym repr where
   type Statement repr
-  (&=)   :: MS (repr (Variable repr)) -> MS (repr (Value repr)) -> 
+  (&=)   :: VS (repr (Variable repr)) -> VS (repr (Value repr)) -> 
     MS (repr (Statement repr))
   infixr 1 &=
-  (&-=)  :: MS (repr (Variable repr)) -> MS (repr (Value repr)) -> 
+  (&-=)  :: VS (repr (Variable repr)) -> VS (repr (Value repr)) -> 
     MS (repr (Statement repr))
   infixl 1 &-=
-  (&+=)  :: MS (repr (Variable repr)) -> MS (repr (Value repr)) -> 
+  (&+=)  :: VS (repr (Variable repr)) -> VS (repr (Value repr)) -> 
     MS (repr (Statement repr))
   infixl 1 &+=
-  (&++)  :: MS (repr (Variable repr)) -> MS (repr (Statement repr))
+  (&++)  :: VS (repr (Variable repr)) -> MS (repr (Statement repr))
   infixl 8 &++
-  (&~-)  :: MS (repr (Variable repr)) -> MS (repr (Statement repr))
+  (&~-)  :: VS (repr (Variable repr)) -> MS (repr (Statement repr))
   infixl 8 &~-
 
-  assign            :: MS (repr (Variable repr)) -> MS (repr (Value repr)) -> 
+  assign            :: VS (repr (Variable repr)) -> VS (repr (Value repr)) -> 
     MS (repr (Statement repr))
-  assignToListIndex :: MS (repr (Variable repr)) -> MS (repr (Value repr)) -> 
-    MS (repr (Value repr)) -> MS (repr (Statement repr))
-  multiAssign       :: [MS (repr (Variable repr))] -> [MS (repr (Value repr))] ->
+  assignToListIndex :: VS (repr (Variable repr)) -> VS (repr (Value repr)) -> 
+    VS (repr (Value repr)) -> MS (repr (Statement repr))
+  multiAssign       :: [VS (repr (Variable repr))] -> [VS (repr (Value repr))] ->
     MS (repr (Statement repr)) 
 
-  varDec           :: MS (repr (Variable repr)) -> MS (repr (Statement repr))
-  varDecDef        :: MS (repr (Variable repr)) -> MS (repr (Value repr)) -> 
+  varDec           :: VS (repr (Variable repr)) -> MS (repr (Statement repr))
+  varDecDef        :: VS (repr (Variable repr)) -> VS (repr (Value repr)) -> 
     MS (repr (Statement repr))
-  listDec          :: Integer -> MS (repr (Variable repr)) -> 
+  listDec          :: Integer -> VS (repr (Variable repr)) -> 
     MS (repr (Statement repr))
-  listDecDef       :: MS (repr (Variable repr)) -> [MS (repr (Value repr))] -> 
+  listDecDef       :: VS (repr (Variable repr)) -> [VS (repr (Value repr))] -> 
     MS (repr (Statement repr))
-  objDecDef        :: MS (repr (Variable repr)) -> MS (repr (Value repr)) -> 
+  objDecDef        :: VS (repr (Variable repr)) -> VS (repr (Value repr)) -> 
     MS (repr (Statement repr))
-  objDecNew        :: MS (repr (Variable repr)) -> [MS (repr (Value repr))] -> 
+  objDecNew        :: VS (repr (Variable repr)) -> [VS (repr (Value repr))] -> 
     MS (repr (Statement repr))
-  extObjDecNew     :: Library -> MS (repr (Variable repr)) -> 
-    [MS (repr (Value repr))] -> MS (repr (Statement repr))
-  objDecNewNoParams    :: MS (repr (Variable repr)) -> MS (repr (Statement repr))
-  extObjDecNewNoParams :: Library -> MS (repr (Variable repr)) -> 
+  extObjDecNew     :: Library -> VS (repr (Variable repr)) -> 
+    [VS (repr (Value repr))] -> MS (repr (Statement repr))
+  objDecNewNoParams    :: VS (repr (Variable repr)) -> MS (repr (Statement repr))
+  extObjDecNewNoParams :: Library -> VS (repr (Variable repr)) -> 
     MS (repr (Statement repr))
-  constDecDef      :: MS (repr (Variable repr)) -> MS (repr (Value repr)) -> 
+  constDecDef      :: VS (repr (Variable repr)) -> VS (repr (Value repr)) -> 
     MS (repr (Statement repr))
 
-  print      :: MS (repr (Value repr)) -> MS (repr (Statement repr))
-  printLn    :: MS (repr (Value repr)) -> MS (repr (Statement repr))
+  print      :: VS (repr (Value repr)) -> MS (repr (Statement repr))
+  printLn    :: VS (repr (Value repr)) -> MS (repr (Statement repr))
   printStr   :: String -> MS (repr (Statement repr))
   printStrLn :: String -> MS (repr (Statement repr))
 
-  printFile      :: MS (repr (Value repr)) -> MS (repr (Value repr)) -> 
+  printFile      :: VS (repr (Value repr)) -> VS (repr (Value repr)) -> 
     MS (repr (Statement repr))
-  printFileLn    :: MS (repr (Value repr)) -> MS (repr (Value repr)) -> 
+  printFileLn    :: VS (repr (Value repr)) -> VS (repr (Value repr)) -> 
     MS (repr (Statement repr))
-  printFileStr   :: MS (repr (Value repr)) -> String -> 
+  printFileStr   :: VS (repr (Value repr)) -> String -> 
     MS (repr (Statement repr))
-  printFileStrLn :: MS (repr (Value repr)) -> String -> 
+  printFileStrLn :: VS (repr (Value repr)) -> String -> 
     MS (repr (Statement repr))
 
-  getInput         :: MS (repr (Variable repr)) -> MS (repr (Statement repr))
+  getInput         :: VS (repr (Variable repr)) -> MS (repr (Statement repr))
   discardInput     :: MS (repr (Statement repr))
-  getFileInput     :: MS (repr (Value repr)) -> MS (repr (Variable repr)) -> 
+  getFileInput     :: VS (repr (Value repr)) -> VS (repr (Variable repr)) -> 
     MS (repr (Statement repr))
-  discardFileInput :: MS (repr (Value repr)) -> MS (repr (Statement repr))
+  discardFileInput :: VS (repr (Value repr)) -> MS (repr (Statement repr))
 
-  openFileR :: MS (repr (Variable repr)) -> MS (repr (Value repr)) -> 
+  openFileR :: VS (repr (Variable repr)) -> VS (repr (Value repr)) -> 
     MS (repr (Statement repr))
-  openFileW :: MS (repr (Variable repr)) -> MS (repr (Value repr)) -> 
+  openFileW :: VS (repr (Variable repr)) -> VS (repr (Value repr)) -> 
     MS (repr (Statement repr))
-  openFileA :: MS (repr (Variable repr)) -> MS (repr (Value repr)) -> 
+  openFileA :: VS (repr (Variable repr)) -> VS (repr (Value repr)) -> 
     MS (repr (Statement repr))
-  closeFile :: MS (repr (Value repr)) -> MS (repr (Statement repr))
+  closeFile :: VS (repr (Value repr)) -> MS (repr (Statement repr))
 
-  getFileInputLine :: MS (repr (Value repr)) -> MS (repr (Variable repr)) -> 
+  getFileInputLine :: VS (repr (Value repr)) -> VS (repr (Variable repr)) -> 
     MS (repr (Statement repr))
-  discardFileLine  :: MS (repr (Value repr)) -> MS (repr (Statement repr))
-  stringSplit      :: Char -> MS (repr (Variable repr)) -> 
-    MS (repr (Value repr)) -> MS (repr (Statement repr))
+  discardFileLine  :: VS (repr (Value repr)) -> MS (repr (Statement repr))
+  stringSplit      :: Char -> VS (repr (Variable repr)) -> 
+    VS (repr (Value repr)) -> MS (repr (Statement repr))
 
-  stringListVals :: [MS (repr (Variable repr))] -> MS (repr (Value repr)) -> 
+  stringListVals :: [VS (repr (Variable repr))] -> VS (repr (Value repr)) -> 
     MS (repr (Statement repr))
-  stringListLists :: [MS (repr (Variable repr))] -> MS (repr (Value repr)) ->
+  stringListLists :: [VS (repr (Variable repr))] -> VS (repr (Value repr)) ->
     MS (repr (Statement repr))
 
   break :: MS (repr (Statement repr))
   continue :: MS (repr (Statement repr))
 
-  returnState :: MS (repr (Value repr)) -> MS (repr (Statement repr))
-  multiReturn :: [MS (repr (Value repr))] -> MS (repr (Statement repr))
+  returnState :: VS (repr (Value repr)) -> MS (repr (Statement repr))
+  multiReturn :: [VS (repr (Value repr))] -> MS (repr (Statement repr))
 
-  valState :: MS (repr (Value repr)) -> MS (repr (Statement repr))
+  valState :: VS (repr (Value repr)) -> MS (repr (Statement repr))
 
   comment :: Label -> MS (repr (Statement repr))
 
-  free :: MS (repr (Variable repr)) -> MS (repr (Statement repr))
+  free :: VS (repr (Variable repr)) -> MS (repr (Statement repr))
 
   throw :: Label -> MS (repr (Statement repr))
 
   initState   :: Label -> Label -> MS (repr (Statement repr))
   changeState :: Label -> Label -> MS (repr (Statement repr))
 
-  initObserverList :: MS (repr (Type repr)) -> [MS (repr (Value repr))] -> 
+  initObserverList :: VS (repr (Type repr)) -> [VS (repr (Value repr))] -> 
     MS (repr (Statement repr))
-  addObserver      :: MS (repr (Value repr)) -> MS (repr (Statement repr))
+  addObserver      :: VS (repr (Value repr)) -> MS (repr (Statement repr))
 
   -- The three lists are inputs, outputs, and both, respectively
-  inOutCall :: Label -> [MS (repr (Value repr))] -> [MS (repr (Variable repr))] 
-    -> [MS (repr (Variable repr))] -> MS (repr (Statement repr))
-  selfInOutCall :: Label -> [MS (repr (Value repr))] -> 
-    [MS (repr (Variable repr))] -> [MS (repr (Variable repr))] -> 
+  inOutCall :: Label -> [VS (repr (Value repr))] -> [VS (repr (Variable repr))] 
+    -> [VS (repr (Variable repr))] -> MS (repr (Statement repr))
+  selfInOutCall :: Label -> [VS (repr (Value repr))] -> 
+    [VS (repr (Variable repr))] -> [VS (repr (Variable repr))] -> 
     MS (repr (Statement repr))
-  extInOutCall :: Library -> Label -> [MS (repr (Value repr))] ->
-    [MS (repr (Variable repr))] -> [MS (repr (Variable repr))] -> 
+  extInOutCall :: Library -> Label -> [VS (repr (Value repr))] ->
+    [VS (repr (Variable repr))] -> [VS (repr (Variable repr))] -> 
     MS (repr (Statement repr))
 
   multi     :: [MS (repr (Statement repr))] -> MS (repr (Statement repr))
 
 class (BodySym repr) => ControlStatementSym repr where
-  ifCond     :: [(MS (repr (Value repr)), MS (repr (Body repr)))] -> 
+  ifCond     :: [(VS (repr (Value repr)), MS (repr (Body repr)))] -> 
     MS (repr (Body repr)) -> MS (repr (Statement repr))
-  ifNoElse   :: [(MS (repr (Value repr)), MS (repr (Body repr)))] -> 
+  ifNoElse   :: [(VS (repr (Value repr)), MS (repr (Body repr)))] -> 
     MS (repr (Statement repr))
-  switch     :: MS (repr (Value repr)) -> [(MS (repr (Value repr)), 
+  switch     :: VS (repr (Value repr)) -> [(VS (repr (Value repr)), 
     MS (repr (Body repr)))] -> MS (repr (Body repr)) -> 
     MS (repr (Statement repr)) -- is there value in separating Literals into their own type?
-  switchAsIf :: MS (repr (Value repr)) -> [(MS (repr (Value repr)), 
+  switchAsIf :: VS (repr (Value repr)) -> [(VS (repr (Value repr)), 
     MS (repr (Body repr)))] -> MS (repr (Body repr)) -> 
     MS (repr (Statement repr))
 
-  ifExists :: MS (repr (Value repr)) -> MS (repr (Body repr)) -> 
+  ifExists :: VS (repr (Value repr)) -> MS (repr (Body repr)) -> 
     MS (repr (Body repr)) -> MS (repr (Statement repr))
 
-  for      :: MS (repr (Statement repr)) -> MS (repr (Value repr)) -> 
+  for      :: MS (repr (Statement repr)) -> VS (repr (Value repr)) -> 
     MS (repr (Statement repr)) -> MS (repr (Body repr)) -> 
     MS (repr (Statement repr))
-  forRange :: MS (repr (Variable repr)) -> MS (repr (Value repr)) -> 
-    MS (repr (Value repr)) -> MS (repr (Value repr)) -> MS (repr (Body repr)) 
+  forRange :: VS (repr (Variable repr)) -> VS (repr (Value repr)) -> 
+    VS (repr (Value repr)) -> VS (repr (Value repr)) -> MS (repr (Body repr)) 
     -> MS (repr (Statement repr))
-  forEach  :: MS (repr (Variable repr)) -> MS (repr (Value repr)) -> 
+  forEach  :: VS (repr (Variable repr)) -> VS (repr (Value repr)) -> 
     MS (repr (Body repr)) -> MS (repr (Statement repr))
-  while    :: MS (repr (Value repr)) -> MS (repr (Body repr)) -> 
+  while    :: VS (repr (Value repr)) -> MS (repr (Body repr)) -> 
     MS (repr (Statement repr)) 
 
   tryCatch :: MS (repr (Body repr)) -> MS (repr (Body repr)) -> 
     MS (repr (Statement repr))
 
-  checkState      :: Label -> [(MS (repr (Value repr)), MS (repr (Body repr)))] 
+  checkState      :: Label -> [(VS (repr (Value repr)), MS (repr (Body repr)))] 
     -> MS (repr (Body repr)) -> MS (repr (Statement repr))
-  notifyObservers :: MS (repr (Function repr)) -> MS (repr (Type repr)) -> 
+  notifyObservers :: VS (repr (Function repr)) -> VS (repr (Type repr)) -> 
     MS (repr (Statement repr))
 
-  getFileInputAll  :: MS (repr (Value repr)) -> MS (repr (Variable repr)) -> 
+  getFileInputAll  :: VS (repr (Value repr)) -> VS (repr (Variable repr)) -> 
     MS (repr (Statement repr))
 
 class ScopeSym repr where
@@ -638,14 +638,14 @@ class InternalScope repr where
 
 class (TypeSym repr) => MethodTypeSym repr where
   type MethodType repr
-  mType    :: MS (repr (Type repr)) -> MS (repr (MethodType repr))
+  mType    :: VS (repr (Type repr)) -> MS (repr (MethodType repr))
   construct :: Label -> MS (repr (MethodType repr))
 
 class ParameterSym repr where
   type Parameter repr
-  param :: MS (repr (Variable repr)) -> MS (repr (Parameter repr))
+  param :: VS (repr (Variable repr)) -> MS (repr (Parameter repr))
   -- funcParam  :: Label -> repr (MethodType repr) -> [repr (Parameter repr)] -> repr (Parameter repr) -- not implemented in GOOL
-  pointerParam :: MS (repr (Variable repr)) -> MS (repr (Parameter repr))
+  pointerParam :: VS (repr (Variable repr)) -> MS (repr (Parameter repr))
 
 class InternalParam repr where
   parameterName :: repr (Parameter repr) -> Label
@@ -657,13 +657,13 @@ class (StateVarSym repr, ParameterSym repr, ControlBlockSym repr) =>
   MethodSym repr where
   type Method repr
   method      :: Label -> repr (Scope repr) -> repr (Permanence repr) 
-    -> MS (repr (Type repr)) -> [MS (repr (Parameter repr))] -> 
+    -> VS (repr (Type repr)) -> [MS (repr (Parameter repr))] -> 
     MS (repr (Body repr)) -> MS (repr (Method repr))
-  getMethod   :: MS (repr (Variable repr)) -> MS (repr (Method repr))
-  setMethod   :: MS (repr (Variable repr)) -> MS (repr (Method repr)) 
-  privMethod  :: Label -> MS (repr (Type repr)) -> [MS (repr (Parameter repr))] 
+  getMethod   :: VS (repr (Variable repr)) -> MS (repr (Method repr))
+  setMethod   :: VS (repr (Variable repr)) -> MS (repr (Method repr)) 
+  privMethod  :: Label -> VS (repr (Type repr)) -> [MS (repr (Parameter repr))] 
     -> MS (repr (Body repr)) -> MS (repr (Method repr))
-  pubMethod   :: Label -> MS (repr (Type repr)) -> [MS (repr (Parameter repr))] 
+  pubMethod   :: Label -> VS (repr (Type repr)) -> [MS (repr (Parameter repr))] 
     -> MS (repr (Body repr)) -> MS (repr (Method repr))
   constructor :: [MS (repr (Parameter repr))] -> MS (repr (Body repr)) 
     -> MS (repr (Method repr))
@@ -672,7 +672,7 @@ class (StateVarSym repr, ParameterSym repr, ControlBlockSym repr) =>
   docMain :: MS (repr (Body repr)) -> MS (repr (Method repr))
 
   function :: Label -> repr (Scope repr) -> repr (Permanence repr) -> 
-    MS (repr (Type repr)) -> [MS (repr (Parameter repr))] -> 
+    VS (repr (Type repr)) -> [MS (repr (Parameter repr))] -> 
     MS (repr (Body repr)) -> MS (repr (Method repr))
   mainFunction  :: MS (repr (Body repr)) -> MS (repr (Method repr))
   -- Parameters are: function description, parameter descriptions, 
@@ -681,24 +681,24 @@ class (StateVarSym repr, ParameterSym repr, ControlBlockSym repr) =>
     MS (repr (Method repr)) -> MS (repr (Method repr))
 
   inOutMethod :: Label -> repr (Scope repr) -> repr (Permanence repr) -> 
-    [MS (repr (Variable repr))] -> [MS (repr (Variable repr))] -> 
-    [MS (repr (Variable repr))] -> MS (repr (Body repr)) -> 
+    [VS (repr (Variable repr))] -> [VS (repr (Variable repr))] -> 
+    [VS (repr (Variable repr))] -> MS (repr (Body repr)) -> 
     MS (repr (Method repr))
   docInOutMethod :: Label -> repr (Scope repr) -> repr (Permanence repr) -> 
-    String -> [(String, MS (repr (Variable repr)))] -> 
-    [(String, MS (repr (Variable repr)))] -> 
-    [(String, MS (repr (Variable repr)))] -> MS (repr (Body repr)) -> 
+    String -> [(String, VS (repr (Variable repr)))] -> 
+    [(String, VS (repr (Variable repr)))] -> 
+    [(String, VS (repr (Variable repr)))] -> MS (repr (Body repr)) -> 
     MS (repr (Method repr))
 
   -- The three lists are inputs, outputs, and both, respectively
   inOutFunc :: Label -> repr (Scope repr) -> repr (Permanence repr) -> 
-    [MS (repr (Variable repr))] -> [MS (repr (Variable repr))] -> 
-    [MS (repr (Variable repr))] -> MS (repr (Body repr)) -> 
+    [VS (repr (Variable repr))] -> [VS (repr (Variable repr))] -> 
+    [VS (repr (Variable repr))] -> MS (repr (Body repr)) -> 
     MS (repr (Method repr))
   -- Parameters are: function name, scope, permanence, brief description, input descriptions and variables, output descriptions and variables, descriptions and variables for parameters that are both input and output, function body
   docInOutFunc :: Label -> repr (Scope repr) -> repr (Permanence repr) -> 
-    String -> [(String, MS (repr (Variable repr)))] -> [(String, 
-    MS (repr (Variable repr)))] -> [(String, MS (repr (Variable repr)))] -> 
+    String -> [(String, VS (repr (Variable repr)))] -> [(String, 
+    VS (repr (Variable repr)))] -> [(String, VS (repr (Variable repr)))] -> 
     MS (repr (Body repr)) -> MS (repr (Method repr))
 
 class (MethodTypeSym repr, BlockCommentSym repr) => InternalMethod repr where
@@ -718,15 +718,15 @@ class (ScopeSym repr, PermanenceSym repr, TypeSym repr, StatementSym repr) =>
   StateVarSym repr where
   type StateVar repr
   stateVar :: repr (Scope repr) -> repr (Permanence repr) ->
-    MS (repr (Variable repr)) -> CS (repr (StateVar repr))
+    VS (repr (Variable repr)) -> CS (repr (StateVar repr))
   stateVarDef :: Label -> repr (Scope repr) -> repr (Permanence repr) ->
-    MS (repr (Variable repr)) -> MS (repr (Value repr)) -> 
+    VS (repr (Variable repr)) -> VS (repr (Value repr)) -> 
     CS (repr (StateVar repr))
-  constVar :: Label -> repr (Scope repr) ->  MS (repr (Variable repr)) -> 
-    MS (repr (Value repr)) -> CS (repr (StateVar repr))
-  privMVar :: MS (repr (Variable repr)) -> CS (repr (StateVar repr))
-  pubMVar  :: MS (repr (Variable repr)) -> CS (repr (StateVar repr))
-  pubGVar  :: MS (repr (Variable repr)) -> CS (repr (StateVar repr))
+  constVar :: Label -> repr (Scope repr) ->  VS (repr (Variable repr)) -> 
+    VS (repr (Value repr)) -> CS (repr (StateVar repr))
+  privMVar :: VS (repr (Variable repr)) -> CS (repr (StateVar repr))
+  pubMVar  :: VS (repr (Variable repr)) -> CS (repr (StateVar repr))
+  pubGVar  :: VS (repr (Variable repr)) -> CS (repr (StateVar repr))
 
 class InternalStateVar repr where
   stateVarDoc :: repr (StateVar repr) -> Doc
@@ -772,30 +772,30 @@ class BlockCommentSym repr where
 -- Data
 
 data ODEInfo repr = ODEInfo {
-  indepVar :: MS (repr (Variable repr)),
-  depVar :: MS (repr (Variable repr)),
-  otherVars :: [MS (repr (Variable repr))],
-  tInit :: MS (repr (Value repr)),
-  tFinal :: MS (repr (Value repr)),
-  initVal :: MS (repr (Value repr)),
-  ode :: MS (repr (Value repr))
+  indepVar :: VS (repr (Variable repr)),
+  depVar :: VS (repr (Variable repr)),
+  otherVars :: [VS (repr (Variable repr))],
+  tInit :: VS (repr (Value repr)),
+  tFinal :: VS (repr (Value repr)),
+  initVal :: VS (repr (Value repr)),
+  ode :: VS (repr (Value repr))
 }
 
-odeInfo :: MS (repr (Variable repr)) -> MS (repr (Variable repr)) -> 
-  [MS (repr (Variable repr))] -> MS (repr (Value repr)) -> 
-  MS (repr (Value repr)) -> MS (repr (Value repr)) -> MS (repr (Value repr)) -> 
+odeInfo :: VS (repr (Variable repr)) -> VS (repr (Variable repr)) -> 
+  [VS (repr (Variable repr))] -> VS (repr (Value repr)) -> 
+  VS (repr (Value repr)) -> VS (repr (Value repr)) -> VS (repr (Value repr)) -> 
   ODEInfo repr
 odeInfo = ODEInfo
 
 data ODEOptions repr = ODEOptions {
   solveMethod :: ODEMethod,
-  absTol :: MS (repr (Value repr)),
-  relTol :: MS (repr (Value repr)),
-  stepSize :: MS (repr (Value repr))
+  absTol :: VS (repr (Value repr)),
+  relTol :: VS (repr (Value repr)),
+  stepSize :: VS (repr (Value repr))
 }
 
-odeOptions :: ODEMethod -> MS (repr (Value repr)) -> MS (repr (Value repr)) -> 
-  MS (repr (Value repr)) -> ODEOptions repr
+odeOptions :: ODEMethod -> VS (repr (Value repr)) -> VS (repr (Value repr)) -> 
+  VS (repr (Value repr)) -> ODEOptions repr
 odeOptions = ODEOptions
 
 data ODEMethod = RK45 | BDF | Adams

--- a/code/drasil-gool/Test/Observer.hs
+++ b/code/drasil-gool/Test/Observer.hs
@@ -3,7 +3,7 @@ module Test.Observer (observer, observerName, printNum, x) where
 import GOOL.Drasil (
   ProgramSym, FileSym(..), PermanenceSym(..), BodySym(..), TypeSym(..), 
   StatementSym(..), VariableSym(..), ValueSym(..), ScopeSym(..), 
-  MethodSym(..), StateVarSym(..), ClassSym(..), ModuleSym(..), FS, CS, MS)
+  MethodSym(..), StateVarSym(..), ClassSym(..), ModuleSym(..), FS, CS, MS, VS)
 import Prelude hiding (return,print,log,exp,sin,cos,tan)
 
 observerName, observerDesc, printNum :: String
@@ -15,10 +15,10 @@ observer :: (ProgramSym repr) => FS (repr (RenderFile repr))
 observer = fileDoc (buildModule observerName [] [docClass observerDesc
   helperClass])
 
-x :: (VariableSym repr) => MS (repr (Variable repr))
+x :: (VariableSym repr) => VS (repr (Variable repr))
 x = var "x" int
 
-selfX :: (VariableSym repr) => MS (repr (Variable repr))
+selfX :: (VariableSym repr) => VS (repr (Variable repr))
 selfX = objVarSelf x
 
 helperClass :: (ClassSym repr) => CS (repr (Class repr))

--- a/code/drasil-gool/Test/PatternTest.hs
+++ b/code/drasil-gool/Test/PatternTest.hs
@@ -3,7 +3,7 @@ module Test.PatternTest (patternTest) where
 import GOOL.Drasil (ProgramSym(..), FileSym(..), BodySym(..), BlockSym(..), 
   ControlBlockSym(..), TypeSym(..), StatementSym(..), ControlStatementSym(..), 
   VariableSym(..), ValueSym(..), ValueExpression(..), FunctionSym(..), 
-  MethodSym(..), ModuleSym(..), GS, MS)
+  MethodSym(..), ModuleSym(..), GS, MS, VS)
 import Prelude hiding (return,print,log,exp,sin,cos,tan)
 import Test.Observer (observer, observerName, printNum, x)
 
@@ -20,15 +20,15 @@ obs1Name = "obs1"
 obs2Name = "obs2"
 nName = "n"
 
-observerType :: (TypeSym repr) => MS (repr (Type repr))
+observerType :: (TypeSym repr) => VS (repr (Type repr))
 observerType = obj observerName
 
-n, obs1, obs2 :: (VariableSym repr) => MS (repr (Variable repr))
+n, obs1, obs2 :: (VariableSym repr) => VS (repr (Variable repr))
 n = var nName int
 obs1 = var obs1Name observerType
 obs2 = var obs2Name observerType
 
-newObserver :: (ValueExpression repr) => MS (repr (Value repr))
+newObserver :: (ValueExpression repr) => VS (repr (Value repr))
 newObserver = extNewObj observerName observerType []
 
 patternTest :: (ProgramSym repr) => GS (repr (Program repr))

--- a/code/drasil-gool/Test/SimpleODE.hs
+++ b/code/drasil-gool/Test/SimpleODE.hs
@@ -4,7 +4,7 @@ import GOOL.Drasil (
   ProgramSym(..), FileSym(..), PermanenceSym(..), BodySym(..), BlockSym(..), 
   TypeSym(..), ControlBlockSym(..), StatementSym(..), VariableSym(..), 
   ValueSym(..), NumericExpression(..), MethodSym(..), ModuleSym(..), ODEInfo, 
-  odeInfo, ODEOptions, odeOptions, ODEMethod(RK45), GS, MS)
+  odeInfo, ODEOptions, odeOptions, ODEMethod(RK45), GS, MS, VS)
 import Prelude hiding (return,print,log,exp,sin,cos,tan)
 
 simpleODE :: (ProgramSym repr) => GS (repr (Program repr))
@@ -17,7 +17,7 @@ simpleODEMain = mainFunction (body [block [varDecDef odeConst (litFloat 3.5)],
   block [print $ valueOf odeDepVar]])
 
 odeConst, odeDepVar, odeIndepVar :: (VariableSym repr) =>
-  MS (repr (Variable repr))
+  VS (repr (Variable repr))
 odeConst = var "c" float
 odeDepVar = var "T" (listType dynamic_ float)
 odeIndepVar = var "t" (listType dynamic_ float)


### PR DESCRIPTION
This PR updates GOOL's C++ renderer to use state to detect when there are statements in a constructor body that can be replaced with an initializer list. I first needed to add a new level of local state, `ValueState`. When a constructor includes an assignment where the left side is a state variable and the right side is an expression where any variable in the expression is a parameter of the constructor, then instead of printing out the statement normally we add it to the initializer list. With initializer lists built in to the renderer now, the C++ ODE implementation was simplified somewhat.

This PR closes #1991.