### PR TITLE
Implement lambda functions in GOOL

### DIFF
--- a/code/drasil-gool/GOOL/Drasil/CodeInfo.hs
+++ b/code/drasil-gool/GOOL/Drasil/CodeInfo.hs
@@ -99,7 +99,7 @@ instance TypeSym CodeInfo where
   listInnerType _ = noInfo
   obj _ = noInfo
   enumType _ = noInfo
-  funcType _ = noInfo
+  funcType _ _ = noInfo
   iterator _ = noInfo
   void = noInfo
 

--- a/code/drasil-gool/GOOL/Drasil/CodeInfo.hs
+++ b/code/drasil-gool/GOOL/Drasil/CodeInfo.hs
@@ -99,6 +99,7 @@ instance TypeSym CodeInfo where
   listInnerType _ = noInfo
   obj _ = noInfo
   enumType _ = noInfo
+  funcType _ = noInfo
   iterator _ = noInfo
   void = noInfo
 
@@ -203,6 +204,8 @@ instance ValueExpression CodeInfo where
   extFuncApp _ _ _ _ = noInfo
   newObj _ _ = noInfo
   extNewObj _ _ _ = noInfo
+
+  lambda _ _ = noInfo
 
   exists _ = noInfo
   notNull _ = noInfo

--- a/code/drasil-gool/GOOL/Drasil/CodeInfo.hs
+++ b/code/drasil-gool/GOOL/Drasil/CodeInfo.hs
@@ -265,6 +265,7 @@ instance StatementSym CodeInfo where
   objDecNewNoParams _ = noInfo
   extObjDecNewNoParams _ _ = noInfo
   constDecDef _ _ = noInfo
+  funcDecDef _ _ _ = noInfo
 
   print _ = noInfo
   printLn _ = noInfo

--- a/code/drasil-gool/GOOL/Drasil/CodeType.hs
+++ b/code/drasil-gool/GOOL/Drasil/CodeType.hs
@@ -14,7 +14,7 @@ data CodeType = Boolean
               | Iterator CodeType
               | Object String
               | Enum String
-              | Func [CodeType]
+              | Func [CodeType] CodeType
               | Void deriving Eq
 
 isObject :: CodeType -> Bool

--- a/code/drasil-gool/GOOL/Drasil/CodeType.hs
+++ b/code/drasil-gool/GOOL/Drasil/CodeType.hs
@@ -14,6 +14,7 @@ data CodeType = Boolean
               | Iterator CodeType
               | Object String
               | Enum String
+              | Func [CodeType]
               | Void deriving Eq
 
 isObject :: CodeType -> Bool

--- a/code/drasil-gool/GOOL/Drasil/Data.hs
+++ b/code/drasil-gool/GOOL/Drasil/Data.hs
@@ -58,7 +58,7 @@ fileD = FileD
 updateFileMod :: ModData -> FileData -> FileData
 updateFileMod m f = fileD (filePath f) m
 
-data FuncData = FD {funcType :: TypeData, funcDoc :: Doc}
+data FuncData = FD {fType :: TypeData, funcDoc :: Doc}
 
 fd :: TypeData -> Doc -> FuncData
 fd = FD

--- a/code/drasil-gool/GOOL/Drasil/Helpers.hs
+++ b/code/drasil-gool/GOOL/Drasil/Helpers.hs
@@ -107,5 +107,6 @@ convType (C.List t) = S.listType S.dynamic_ (convType t)
 convType (C.Iterator t) = S.iterator $ convType t
 convType (C.Object n) = S.obj n
 convType (C.Enum n) = S.enumType n
+convType (C.Func ps r) = S.funcType (map convType ps) (convType r)
 convType C.Void = S.void
 convType C.File = error "convType: File ?"

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer/CSharpRenderer.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer/CSharpRenderer.hs
@@ -41,22 +41,22 @@ import qualified GOOL.Drasil.LanguageRenderer.LanguagePolymorphic as G (
   litTrue, litFalse, litChar, litFloat, litInt, litString, valueOf, arg, 
   enumElement, argsList, inlineIf, objAccess, objMethodCall, 
   objMethodCallNoParams, selfAccess, listIndexExists, indexOf, funcApp, 
-  selfFuncApp, extFuncApp, newObj, notNull, func, get, set, listSize, listAdd, 
-  listAppend, iterBegin, iterEnd, listAccess, listSet, getFunc, setFunc, 
-  listAddFunc, listAppendFunc, iterBeginError, iterEndError, listAccessFunc, 
-  listSetFunc, printSt, state, loopState, emptyState, assign, assignToListIndex,
-  multiAssignError, decrement, increment, decrement1, increment1, varDec, 
-  varDecDef, listDec, listDecDef', objDecNew, objDecNewNoParams, constDecDef, 
-  discardInput, openFileR, openFileW, openFileA, closeFile, discardFileLine, 
-  stringListVals, stringListLists, returnState, multiReturnError, valState, 
-  comment, freeError, throw, initState, changeState, initObserverList, 
-  addObserver, ifCond, ifNoElse, switch, switchAsIf, ifExists, for, forRange, 
-  forEach, while, tryCatch, checkState, notifyObservers, construct, param, 
-  method, getMethod, setMethod, privMethod, pubMethod, constructor, docMain, 
-  function, mainFunction, docFunc, docInOutFunc, intFunc, stateVar, stateVarDef,
-  constVar, privMVar, pubMVar, pubGVar, buildClass, enum, privClass, pubClass, 
-  docClass, commentedClass, buildModule', modFromData, fileDoc, docMod, 
-  fileFromData)
+  selfFuncApp, extFuncApp, newObj, lambda, notNull, func, get, set, listSize, 
+  listAdd, listAppend, iterBegin, iterEnd, listAccess, listSet, getFunc, 
+  setFunc, listAddFunc, listAppendFunc, iterBeginError, iterEndError, 
+  listAccessFunc, listSetFunc, printSt, state, loopState, emptyState, assign, 
+  assignToListIndex, multiAssignError, decrement, increment, decrement1, 
+  increment1, varDec, varDecDef, listDec, listDecDef', objDecNew, 
+  objDecNewNoParams, constDecDef, discardInput, openFileR, openFileW, openFileA,
+  closeFile, discardFileLine, stringListVals, stringListLists, returnState, 
+  multiReturnError, valState, comment, freeError, throw, initState, changeState,
+  initObserverList, addObserver, ifCond, ifNoElse, switch, switchAsIf, ifExists,
+  for, forRange, forEach, while, tryCatch, checkState, notifyObservers, 
+  construct, param, method, getMethod, setMethod, privMethod, pubMethod, 
+  constructor, docMain, function, mainFunction, docFunc, docInOutFunc, intFunc, 
+  stateVar, stateVarDef, constVar, privMVar, pubMVar, pubGVar, buildClass, enum,
+  privClass, pubClass, docClass, commentedClass, buildModule', modFromData, 
+  fileDoc, docMod, fileFromData)
 import GOOL.Drasil.LanguageRenderer.LanguagePolymorphic (unOpPrec, unExpr, 
   unExpr', typeUnExpr, powerPrec, binExpr, binExpr', typeBinExpr)
 import GOOL.Drasil.Data (Terminator(..), ScopeTag(..), FileType(..), 
@@ -381,6 +381,8 @@ instance ValueExpression CSharpCode where
   newObj = G.newObj newObjDocD
   extNewObj _ = newObj
 
+  lambda = G.lambda csLambda
+
   exists = notNull
   notNull = G.notNull
 
@@ -689,6 +691,10 @@ csInfileType = modifyReturn (addLangImportVS "System.IO") $
 csOutfileType :: (RenderSym repr) => VS (repr (Type repr))
 csOutfileType = modifyReturn (addLangImportVS "System.IO") $ 
   typeFromData File "StreamWriter" (text "StreamWriter")
+
+csLambda :: (RenderSym repr) => [repr (Variable repr)] -> repr (Value repr) -> 
+  Doc
+csLambda ps ex = parens (variableList ps) <+> text "->" <+> valueDoc ex
 
 csCast :: VS (CSharpCode (Type CSharpCode)) -> 
   VS (CSharpCode (Value CSharpCode)) -> VS (CSharpCode (Value CSharpCode))

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer/CSharpRenderer.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer/CSharpRenderer.hs
@@ -214,10 +214,8 @@ instance ControlBlockSym CSharpCode where
         varDecDef sol (extFuncApp "Ode" (csODEMethod $ solveMethod opts) odeT 
         [tInit info, 
         newObj vec [initVal info], 
-        join $ on2StateValues (\idv dpv -> newObj vec [modify 
-          (setODEDepVars [variableName dpv]) >> ode info] >>= (mkStateVal void .
-          (parens (variableList [idv, dpv]) <+> text "=>" <+>) . valueDoc)) 
-          iv dv,
+        lambda [iv, dv] (newObj vec [dv >>= (\dpv -> modify (setODEDepVars 
+          [variableName dpv]) >> ode info)]),
         join $ on2StateValues (\abt rt -> mkStateVal (obj "Options") (new <+> 
           text "Options" <+> braces (text "AbsoluteTolerance" <+> equals <+> 
           valueDoc abt <> comma <+> text "RelativeTolerance" <+> equals <+> 
@@ -694,7 +692,7 @@ csOutfileType = modifyReturn (addLangImportVS "System.IO") $
 
 csLambda :: (RenderSym repr) => [repr (Variable repr)] -> repr (Value repr) -> 
   Doc
-csLambda ps ex = parens (variableList ps) <+> text "->" <+> valueDoc ex
+csLambda ps ex = parens (variableList ps) <+> text "=>" <+> valueDoc ex
 
 csCast :: VS (CSharpCode (Type CSharpCode)) -> 
   VS (CSharpCode (Value CSharpCode)) -> VS (CSharpCode (Value CSharpCode))

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer/CSharpRenderer.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer/CSharpRenderer.hs
@@ -34,28 +34,29 @@ import GOOL.Drasil.LanguageRenderer (new, classDocD, multiStateDocD, bodyDocD,
   variableList, appendToBody, surroundBody)
 import qualified GOOL.Drasil.LanguageRenderer.LanguagePolymorphic as G (
   oneLiner, block, multiBlock, bool, int, double, char, string, listType, 
-  listInnerType, obj, enumType, void, runStrategy, listSlice, notOp, negateOp, 
-  equalOp, notEqualOp, greaterOp, greaterEqualOp, lessOp, lessEqualOp, plusOp, 
-  minusOp, multOp, divideOp, moduloOp, andOp, orOp, var, staticVar, extVar, 
-  self, enumVar, classVar, objVarSelf, listVar, listOf, iterVar, pi, litTrue, 
-  litFalse, litChar, litFloat, litInt, litString, valueOf, arg, enumElement, 
-  argsList, inlineIf, objAccess, objMethodCall, objMethodCallNoParams, 
-  selfAccess, listIndexExists, indexOf, funcApp, selfFuncApp, extFuncApp, 
-  newObj, notNull, func, get, set, listSize, listAdd, listAppend, iterBegin, 
-  iterEnd, listAccess, listSet, getFunc, setFunc, listAddFunc, listAppendFunc, 
-  iterBeginError, iterEndError, listAccessFunc, listSetFunc, printSt, state, 
-  loopState, emptyState, assign, assignToListIndex, multiAssignError, 
-  decrement, increment, decrement1, increment1, varDec, varDecDef, listDec, 
-  listDecDef', objDecNew, objDecNewNoParams,constDecDef, discardInput,
-  openFileR, openFileW, openFileA, closeFile, discardFileLine, stringListVals, 
-  stringListLists, returnState, multiReturnError, valState, comment, freeError, 
-  throw, initState, changeState, initObserverList, addObserver, ifCond, 
-  ifNoElse, switch, switchAsIf, ifExists, for, forRange, forEach, while, 
-  tryCatch, checkState, notifyObservers, construct, param, method, getMethod, 
-  setMethod, privMethod, pubMethod, constructor, docMain, function, 
-  mainFunction, docFunc, docInOutFunc, intFunc, stateVar, stateVarDef, constVar,
-  privMVar, pubMVar, pubGVar, buildClass, enum, privClass, pubClass, docClass, 
-  commentedClass, buildModule', modFromData, fileDoc, docMod, fileFromData)
+  listInnerType, obj, enumType, funcType, void, runStrategy, listSlice, notOp, 
+  negateOp, equalOp, notEqualOp, greaterOp, greaterEqualOp, lessOp, lessEqualOp,
+  plusOp, minusOp, multOp, divideOp, moduloOp, andOp, orOp, var, staticVar, 
+  extVar, self, enumVar, classVar, objVarSelf, listVar, listOf, iterVar, pi, 
+  litTrue, litFalse, litChar, litFloat, litInt, litString, valueOf, arg, 
+  enumElement, argsList, inlineIf, objAccess, objMethodCall, 
+  objMethodCallNoParams, selfAccess, listIndexExists, indexOf, funcApp, 
+  selfFuncApp, extFuncApp, newObj, notNull, func, get, set, listSize, listAdd, 
+  listAppend, iterBegin, iterEnd, listAccess, listSet, getFunc, setFunc, 
+  listAddFunc, listAppendFunc, iterBeginError, iterEndError, listAccessFunc, 
+  listSetFunc, printSt, state, loopState, emptyState, assign, assignToListIndex,
+  multiAssignError, decrement, increment, decrement1, increment1, varDec, 
+  varDecDef, listDec, listDecDef', objDecNew, objDecNewNoParams, constDecDef, 
+  discardInput, openFileR, openFileW, openFileA, closeFile, discardFileLine, 
+  stringListVals, stringListLists, returnState, multiReturnError, valState, 
+  comment, freeError, throw, initState, changeState, initObserverList, 
+  addObserver, ifCond, ifNoElse, switch, switchAsIf, ifExists, for, forRange, 
+  forEach, while, tryCatch, checkState, notifyObservers, construct, param, 
+  method, getMethod, setMethod, privMethod, pubMethod, constructor, docMain, 
+  function, mainFunction, docFunc, docInOutFunc, intFunc, stateVar, stateVarDef,
+  constVar, privMVar, pubMVar, pubGVar, buildClass, enum, privClass, pubClass, 
+  docClass, commentedClass, buildModule', modFromData, fileDoc, docMod, 
+  fileFromData)
 import GOOL.Drasil.LanguageRenderer.LanguagePolymorphic (unOpPrec, unExpr, 
   unExpr', typeUnExpr, powerPrec, binExpr, binExpr', typeBinExpr)
 import GOOL.Drasil.Data (Terminator(..), ScopeTag(..), FileType(..), 
@@ -190,6 +191,7 @@ instance TypeSym CSharpCode where
   listInnerType = G.listInnerType
   obj = G.obj
   enumType = G.enumType
+  funcType = G.funcType
   iterator t = t
   void = G.void
 
@@ -444,7 +446,7 @@ instance InternalFunction CSharpCode where
   listAccessFunc = G.listAccessFunc
   listSetFunc = G.listSetFunc listSetFuncDocD 
     
-  functionType = onCodeValue funcType
+  functionType = onCodeValue fType
   functionDoc = funcDoc . unCSC
 
   funcFromData d = onStateValue (onCodeValue (`fd` d))

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer/CppRenderer.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer/CppRenderer.hs
@@ -47,14 +47,14 @@ import qualified GOOL.Drasil.LanguageRenderer.LanguagePolymorphic as G (
   listSetFunc, state, loopState, emptyState, assign, assignToListIndex, 
   multiAssignError, decrement, increment, decrement1, increment1, varDec, 
   varDecDef, listDec, listDecDef, objDecNew, objDecNewNoParams, constDecDef, 
-  discardInput, discardFileInput, closeFile, stringListVals, stringListLists, 
-  returnState, multiReturnError, valState, comment, throw, initState, 
-  changeState, initObserverList, addObserver, ifCond, ifNoElse, switch, 
-  switchAsIf, for, forRange, while, tryCatch, notifyObservers, construct, param,
-  method, getMethod, setMethod, privMethod, pubMethod, constructor, function, 
-  docFunc, docInOutFunc, intFunc, privMVar, pubMVar, pubGVar, privClass, 
-  pubClass, docClass, commentedClass, buildModule, modFromData, fileDoc, docMod,
-  fileFromData)
+  funcDecDef, discardInput, discardFileInput, closeFile, stringListVals, 
+  stringListLists, returnState, multiReturnError, valState, comment, throw, 
+  initState, changeState, initObserverList, addObserver, ifCond, ifNoElse, 
+  switch, switchAsIf, for, forRange, while, tryCatch, notifyObservers, 
+  construct, param, method, getMethod, setMethod, privMethod, pubMethod, 
+  constructor, function, docFunc, docInOutFunc, intFunc, privMVar, pubMVar, 
+  pubGVar, privClass, pubClass, docClass, commentedClass, buildModule, 
+  modFromData, fileDoc, docMod, fileFromData)
 import GOOL.Drasil.LanguageRenderer.LanguagePolymorphic (unOpPrec, unExpr, 
   unExpr', typeUnExpr, binExpr, binExpr', typeBinExpr)
 import GOOL.Drasil.Data (Pair(..), Terminator(..), ScopeTag(..), 
@@ -561,6 +561,8 @@ instance (Pair p) => StatementSym (p CppSrcCode CppHdrCode) where
     (extObjDecNewNoParams lib) . zoom lensMStoVS
   constDecDef vr vl = pair2 constDecDef constDecDef (zoom lensMStoVS vr) 
     (zoom lensMStoVS vl)
+  funcDecDef v ps r = pairValListVal funcDecDef funcDecDef (zoom lensMStoVS v) 
+    (map (zoom lensMStoVS) ps) (zoom lensMStoVS r)
 
   print = pair1 print print . zoom lensMStoVS
   printLn = pair1 printLn printLn . zoom lensMStoVS
@@ -1413,6 +1415,7 @@ instance StatementSym CppSrcCode where
   objDecNewNoParams = G.objDecNewNoParams
   extObjDecNewNoParams l v = modify (addModuleImport l) >> objDecNewNoParams v
   constDecDef = G.constDecDef
+  funcDecDef = G.funcDecDef
 
   print = outDoc False Nothing printFunc
   printLn = outDoc True Nothing printLnFunc
@@ -2038,6 +2041,7 @@ instance StatementSym CppHdrCode where
   objDecNewNoParams _ = emptyState
   extObjDecNewNoParams _ _ = emptyState
   constDecDef = G.constDecDef
+  funcDecDef _ _ _ = emptyState
 
   print _ = emptyState
   printLn _ = emptyState

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer/CppRenderer.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer/CppRenderer.hs
@@ -207,7 +207,7 @@ instance (Pair p) => TypeSym (p CppSrcCode CppHdrCode) where
   listInnerType = pair1 listInnerType listInnerType
   obj t = on2StateValues pair (obj t) (obj t)
   enumType t = on2StateValues pair (enumType t) (enumType t)
-  funcType = pair1List funcType funcType
+  funcType = pair1List1Val funcType funcType
   iterator = pair1 iterator iterator
   void = on2StateValues pair void void
 

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer/CppRenderer.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer/CppRenderer.hs
@@ -35,11 +35,11 @@ import GOOL.Drasil.LanguageRenderer (addExt, enumElementsDocD, multiStateDocD,
   parameterList, appendToBody, surroundBody, getterName, setterName)
 import qualified GOOL.Drasil.LanguageRenderer.LanguagePolymorphic as G (
   oneLiner, block, multiBlock, int, double, char, string, listType, 
-  listInnerType, obj, enumType, void, runStrategy, listSlice, notOp, negateOp, 
-  sqrtOp, absOp, expOp, sinOp, cosOp, tanOp, asinOp, acosOp, atanOp, equalOp, 
-  notEqualOp, greaterOp, greaterEqualOp, lessOp, lessEqualOp, plusOp, minusOp, 
-  multOp, divideOp, moduloOp, powerOp, andOp, orOp, var, staticVar, self, 
-  enumVar, objVar, listVar, listOf, litTrue, litFalse, litChar, litFloat, 
+  listInnerType, obj, enumType, funcType, void, runStrategy, listSlice, notOp, 
+  negateOp, sqrtOp, absOp, expOp, sinOp, cosOp, tanOp, asinOp, acosOp, atanOp, 
+  equalOp, notEqualOp, greaterOp, greaterEqualOp, lessOp, lessEqualOp, plusOp, 
+  minusOp, multOp, divideOp, moduloOp, powerOp, andOp, orOp, var, staticVar, 
+  self, enumVar, objVar, listVar, listOf, litTrue, litFalse, litChar, litFloat, 
   litInt, litString, valueOf, arg, argsList, inlineIf, objAccess, objMethodCall,
   objMethodCallNoParams, selfAccess, listIndexExists, funcApp, newObj, func, 
   get, set, listSize, listAdd, listAppend, iterBegin, iterEnd, listAccess, 
@@ -207,6 +207,7 @@ instance (Pair p) => TypeSym (p CppSrcCode CppHdrCode) where
   listInnerType = pair1 listInnerType listInnerType
   obj t = on2StateValues pair (obj t) (obj t)
   enumType t = on2StateValues pair (enumType t) (enumType t)
+  funcType = pair1List funcType funcType
   iterator = pair1 iterator iterator
   void = on2StateValues pair void void
 
@@ -1113,6 +1114,7 @@ instance TypeSym CppSrcCode where
   obj n = getClassMap >>= (\cm -> maybe id ((>>) . modify . addModuleImportVS) 
     (Map.lookup n cm) $ G.obj n)
   enumType = G.enumType
+  funcType = G.funcType
   iterator t = modify (addLangImportVS "iterator") >> 
     (cppIterType . listType dynamic_) t
   void = G.void
@@ -1363,7 +1365,7 @@ instance InternalFunction CppSrcCode where
   listAccessFunc = G.listAccessFunc' "at"
   listSetFunc = G.listSetFunc cppListSetDoc
 
-  functionType = onCodeValue funcType
+  functionType = onCodeValue fType
   functionDoc = funcDoc . unCPPSC
   
   funcFromData d = onStateValue (onCodeValue (`fd` d))
@@ -1767,6 +1769,7 @@ instance TypeSym CppHdrCode where
   obj n = getClassMap >>= (\cm -> maybe id ((>>) . modify . addHeaderModImport) 
     (Map.lookup n cm) $ G.obj n)
   enumType = G.enumType
+  funcType = G.funcType
   iterator t = modify (addHeaderLangImport "iterator") >> 
     (cppIterType . listType dynamic_) t
   void = G.void
@@ -1991,7 +1994,7 @@ instance InternalFunction CppHdrCode where
   listAccessFunc _ _ = funcFromData empty void
   listSetFunc _ _ _ = funcFromData empty void
   
-  functionType = onCodeValue funcType
+  functionType = onCodeValue fType
   functionDoc = funcDoc . unCPPHC
   
   funcFromData d = onStateValue (onCodeValue (`fd` d))

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer/JavaRenderer.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer/JavaRenderer.hs
@@ -47,8 +47,8 @@ import qualified GOOL.Drasil.LanguageRenderer.LanguagePolymorphic as G (
   iterEndError, listAccessFunc', printSt, state, loopState, emptyState, assign, 
   assignToListIndex, multiAssignError, decrement, increment, decrement1, 
   increment1, varDec, varDecDef, listDec, objDecNew, objDecNewNoParams, 
-  discardInput, discardFileInput, openFileR, openFileW, openFileA, closeFile, 
-  discardFileLine, stringListVals, stringListLists, returnState, 
+  funcDecDef, discardInput, discardFileInput, openFileR, openFileW, openFileA, 
+  closeFile, discardFileLine, stringListVals, stringListLists, returnState, 
   multiReturnError, valState, comment, freeError, throw, initState, changeState,
   initObserverList, addObserver, ifCond, ifNoElse, switch, switchAsIf, ifExists,
   for, forRange, forEach, while, tryCatch, checkState, notifyObservers, 
@@ -539,6 +539,7 @@ instance StatementSym JavaCode where
   extObjDecNewNoParams _ = objDecNewNoParams
   constDecDef vr' vl' = zoom lensMStoVS $ on2StateValues (\vr vl -> mkSt $ 
     jConstDecDef vr vl) vr' vl'
+  funcDecDef = G.funcDecDef
 
   print = jOut False Nothing printFunc
   printLn = jOut True Nothing printLnFunc

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer/JavaRenderer.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer/JavaRenderer.hs
@@ -30,8 +30,8 @@ import GOOL.Drasil.LanguageRenderer (packageDocD, classDocD, multiStateDocD,
   castDocD, castObjDocD, staticDocD, dynamicDocD, bindingError, privateDocD, 
   publicDocD, dot, new, classDec, elseIfLabel, forLabel, blockCmtStart, 
   blockCmtEnd, docCmtStart, doubleSlash, blockCmtDoc, docCmtDoc, commentedItem, 
-  addCommentsDocD, commentedModD, docFuncRepr, parameterList, appendToBody, 
-  surroundBody, intValue)
+  addCommentsDocD, commentedModD, docFuncRepr, variableList, parameterList, 
+  appendToBody, surroundBody, intValue)
 import qualified GOOL.Drasil.LanguageRenderer.LanguagePolymorphic as G (
   oneLiner, block, multiBlock, bool, int, double, char, listType, listInnerType,
   obj, enumType, funcType, void, runStrategy, listSlice, notOp, negateOp, 
@@ -41,10 +41,10 @@ import qualified GOOL.Drasil.LanguageRenderer.LanguagePolymorphic as G (
   litTrue, litFalse, litChar, litFloat, litInt, litString, pi, valueOf, arg, 
   enumElement, argsList, inlineIf, objAccess, objMethodCall, 
   objMethodCallNoParams, selfAccess, listIndexExists, indexOf, funcApp, 
-  selfFuncApp, extFuncApp, newObj, notNull, func, get, set, listSize, listAdd, 
-  listAppend, iterBegin, iterEnd, listAccess, listSet, getFunc, setFunc, 
-  listSizeFunc, listAddFunc, listAppendFunc, iterBeginError, iterEndError, 
-  listAccessFunc', printSt, state, loopState, emptyState, assign, 
+  selfFuncApp, extFuncApp, newObj, lambda, notNull, func, get, set, listSize, 
+  listAdd, listAppend, iterBegin, iterEnd, listAccess, listSet, getFunc, 
+  setFunc, listSizeFunc, listAddFunc, listAppendFunc, iterBeginError, 
+  iterEndError, listAccessFunc', printSt, state, loopState, emptyState, assign, 
   assignToListIndex, multiAssignError, decrement, increment, decrement1, 
   increment1, varDec, varDecDef, listDec, objDecNew, objDecNewNoParams, 
   discardInput, discardFileInput, openFileR, openFileW, openFileA, closeFile, 
@@ -421,6 +421,8 @@ instance ValueExpression JavaCode where
     modify (maybe id addExceptions (Map.lookup (tp ++ "." ++ tp) mem))
     G.newObj newObjDocD ot vs
   extNewObj _ = newObj
+
+  lambda = G.lambda jLambda
 
   exists = notNull
   notNull = G.notNull
@@ -835,6 +837,10 @@ jEquality :: VS (JavaCode (Value JavaCode)) -> VS (JavaCode (Value JavaCode))
 jEquality v1 v2 = v2 >>= jEquality' . getType . valueType
   where jEquality' String = objAccess v1 (func "equals" bool [v2])
         jEquality' _ = typeBinExpr equalOp bool v1 v2
+
+jLambda :: (RenderSym repr) => [repr (Variable repr)] -> repr (Value repr) -> 
+  Doc
+jLambda ps ex = parens (variableList ps) <+> text "->" <+> valueDoc ex
 
 jCast :: VS (JavaCode (Type JavaCode)) -> VS (JavaCode (Value JavaCode)) -> 
   VS (JavaCode (Value JavaCode))

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer/JavaRenderer.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer/JavaRenderer.hs
@@ -34,26 +34,27 @@ import GOOL.Drasil.LanguageRenderer (packageDocD, classDocD, multiStateDocD,
   surroundBody, intValue)
 import qualified GOOL.Drasil.LanguageRenderer.LanguagePolymorphic as G (
   oneLiner, block, multiBlock, bool, int, double, char, listType, listInnerType,
-  obj, enumType, void, runStrategy, listSlice, notOp, negateOp, equalOp, 
-  notEqualOp, greaterOp, greaterEqualOp, lessOp, lessEqualOp, plusOp, minusOp, 
-  multOp, divideOp, moduloOp, andOp, orOp, var, staticVar, extVar, self, 
-  enumVar, classVar, objVar, objVarSelf, listVar, listOf, iterVar, litTrue, 
-  litFalse, litChar, litFloat, litInt, litString, pi, valueOf, arg, enumElement,
-  argsList, inlineIf, objAccess, objMethodCall, objMethodCallNoParams, 
-  selfAccess, listIndexExists, indexOf, funcApp, selfFuncApp, extFuncApp, 
-  newObj, notNull, func, get, set, listSize, listAdd, listAppend, iterBegin, 
-  iterEnd, listAccess, listSet, getFunc, setFunc, listSizeFunc, listAddFunc, 
-  listAppendFunc, iterBeginError, iterEndError, listAccessFunc', printSt, state,
-  loopState, emptyState, assign, assignToListIndex, multiAssignError, decrement,
-  increment, decrement1, increment1, varDec, varDecDef, listDec, objDecNew, 
-  objDecNewNoParams, discardInput, discardFileInput, openFileR, openFileW, 
-  openFileA, closeFile, discardFileLine, stringListVals, stringListLists, 
-  returnState, multiReturnError, valState, comment, freeError, throw, initState,
-  changeState, initObserverList, addObserver, ifCond, ifNoElse, switch, 
-  switchAsIf, ifExists, for, forRange, forEach, while, tryCatch, checkState, 
-  notifyObservers, construct, param, method, getMethod, setMethod, privMethod, 
-  pubMethod, constructor, docMain, function, mainFunction, docFunc, intFunc, 
-  stateVar, stateVarDef, constVar, privMVar, pubMVar, pubGVar, buildClass, enum,
+  obj, enumType, funcType, void, runStrategy, listSlice, notOp, negateOp, 
+  equalOp, notEqualOp, greaterOp, greaterEqualOp, lessOp, lessEqualOp, plusOp, 
+  minusOp, multOp, divideOp, moduloOp, andOp, orOp, var, staticVar, extVar, 
+  self, enumVar, classVar, objVar, objVarSelf, listVar, listOf, iterVar, 
+  litTrue, litFalse, litChar, litFloat, litInt, litString, pi, valueOf, arg, 
+  enumElement, argsList, inlineIf, objAccess, objMethodCall, 
+  objMethodCallNoParams, selfAccess, listIndexExists, indexOf, funcApp, 
+  selfFuncApp, extFuncApp, newObj, notNull, func, get, set, listSize, listAdd, 
+  listAppend, iterBegin, iterEnd, listAccess, listSet, getFunc, setFunc, 
+  listSizeFunc, listAddFunc, listAppendFunc, iterBeginError, iterEndError, 
+  listAccessFunc', printSt, state, loopState, emptyState, assign, 
+  assignToListIndex, multiAssignError, decrement, increment, decrement1, 
+  increment1, varDec, varDecDef, listDec, objDecNew, objDecNewNoParams, 
+  discardInput, discardFileInput, openFileR, openFileW, openFileA, closeFile, 
+  discardFileLine, stringListVals, stringListLists, returnState, 
+  multiReturnError, valState, comment, freeError, throw, initState, changeState,
+  initObserverList, addObserver, ifCond, ifNoElse, switch, switchAsIf, ifExists,
+  for, forRange, forEach, while, tryCatch, checkState, notifyObservers, 
+  construct, param, method, getMethod, setMethod, privMethod, pubMethod, 
+  constructor, docMain, function, mainFunction, docFunc, intFunc, stateVar, 
+  stateVarDef, constVar, privMVar, pubMVar, pubGVar, buildClass, enum, 
   privClass, pubClass, docClass, commentedClass, buildModule', modFromData, 
   fileDoc, docMod, fileFromData)
 import GOOL.Drasil.LanguageRenderer.LanguagePolymorphic (unOpPrec, unExpr, 
@@ -199,6 +200,7 @@ instance TypeSym JavaCode where
   listInnerType = G.listInnerType
   obj = G.obj
   enumType = G.enumType
+  funcType = G.funcType
   iterator t = t
   void = G.void
 
@@ -492,7 +494,7 @@ instance InternalFunction JavaCode where
   listSetFunc v i toVal = func "set" (onStateValue valueType v) [intValue i, 
     toVal]
 
-  functionType = onCodeValue funcType
+  functionType = onCodeValue fType
   functionDoc = funcDoc . unJC
 
   funcFromData d = onStateValue (onCodeValue (`fd` d))

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer/LanguagePolymorphic.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer/LanguagePolymorphic.hs
@@ -13,7 +13,7 @@ module GOOL.Drasil.LanguageRenderer.LanguagePolymorphic (fileFromData, oneLiner,
   self, enumVar, classVar, objVar, objVarSelf, listVar, listOf, iterVar, 
   litTrue, litFalse, litChar, litFloat, litInt, litString, pi, valueOf, arg, 
   enumElement, argsList, inlineIf, funcApp, selfFuncApp, extFuncApp, newObj, 
-  notNull, objAccess, objMethodCall, objMethodCallNoParams, selfAccess, 
+  lambda, notNull, objAccess, objMethodCall, objMethodCallNoParams, selfAccess, 
   listIndexExists, indexOf, func, get, set, listSize, listAdd, listAppend, 
   iterBegin, iterEnd, listAccess, listSet, getFunc, setFunc, listSizeFunc, 
   listAddFunc, listAppendFunc, iterBeginError, iterEndError, listAccessFunc, 
@@ -492,6 +492,13 @@ newObj f = on1StateValue1List (\t -> mkVal t . f t . valueList)
 
 notNull :: (RenderSym repr) => VS (repr (Value repr)) -> VS (repr (Value repr))
 notNull v = v ?!= S.valueOf (S.var "null" $ onStateValue valueType v)
+
+lambda :: (RenderSym repr) => ([repr (Variable repr)] -> repr (Value repr) -> 
+  Doc) -> [VS (repr (Variable repr))] -> VS (repr (Value repr)) ->
+  VS (repr (Value repr))
+lambda f ps' ex' = sequence ps' >>= (\ps -> ex' >>= (\ex -> funcType (map 
+  (toState . variableType) ps ++ [toState $ valueType ex]) >>= (\ft -> 
+  toState $ valFromData (Just 0) ft (f ps ex))))
 
 objAccess :: (RenderSym repr) => VS (repr (Value repr)) ->
   VS (repr (Function repr)) -> VS (repr (Value repr))

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer/LanguagePolymorphic.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer/LanguagePolymorphic.hs
@@ -161,7 +161,9 @@ enumType :: (RenderSym repr) => Label -> VS (repr (Type repr))
 enumType e = toState $ typeFromData (Enum e) e (text e)
 
 funcType :: (RenderSym repr) => [VS (repr (Type repr))] -> VS (repr (Type repr))
-funcType = onStateList (\sig -> typeFromData (Func (map getType sig)) "" empty)
+  -> VS (repr (Type repr))
+funcType ps' = on2StateValues (\ps r -> typeFromData (Func (map getType ps) 
+  (getType r)) "" empty) (sequence ps')
 
 void :: (RenderSym repr) => VS (repr (Type repr))
 void = toState $ typeFromData Void "void" (text "void")
@@ -497,7 +499,7 @@ lambda :: (RenderSym repr) => ([repr (Variable repr)] -> repr (Value repr) ->
   Doc) -> [VS (repr (Variable repr))] -> VS (repr (Value repr)) ->
   VS (repr (Value repr))
 lambda f ps' ex' = sequence ps' >>= (\ps -> ex' >>= (\ex -> funcType (map 
-  (toState . variableType) ps ++ [toState $ valueType ex]) >>= (\ft -> 
+  (toState . variableType) ps) (toState $ valueType ex) >>= (\ft -> 
   toState $ valFromData (Just 0) ft (f ps ex))))
 
 objAccess :: (RenderSym repr) => VS (repr (Value repr)) ->

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer/LanguagePolymorphic.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer/LanguagePolymorphic.hs
@@ -20,17 +20,17 @@ module GOOL.Drasil.LanguageRenderer.LanguagePolymorphic (fileFromData, oneLiner,
   listAccessFunc', listSetFunc, printSt, state, loopState, emptyState, assign, 
   assignToListIndex, multiAssignError, decrement, increment, increment', 
   increment1, increment1', decrement1, varDec, varDecDef, listDec, listDecDef, 
-  listDecDef', objDecNew, objDecNewNoParams, constDecDef, discardInput, 
-  discardFileInput, openFileR, openFileW, openFileA, closeFile, discardFileLine,
-  stringListVals, stringListLists, returnState, multiReturnError, valState, 
-  comment, freeError, throw, initState, changeState, initObserverList, 
-  addObserver, ifCond, ifNoElse, switch, switchAsIf, ifExists, for, forRange, 
-  forEach, while, tryCatch, checkState, notifyObservers, construct, param, 
-  method, getMethod, setMethod,privMethod, pubMethod, constructor, docMain, 
-  function, mainFunction, docFunc, docInOutFunc, intFunc, stateVar,stateVarDef, 
-  constVar, privMVar, pubMVar, pubGVar, buildClass, enum, privClass, pubClass, 
-  docClass, commentedClass, buildModule, buildModule', modFromData, fileDoc, 
-  docMod
+  listDecDef', objDecNew, objDecNewNoParams, constDecDef, funcDecDef, 
+  discardInput, discardFileInput, openFileR, openFileW, openFileA, closeFile, 
+  discardFileLine, stringListVals, stringListLists, returnState, 
+  multiReturnError, valState, comment, freeError, throw, initState, changeState,
+  initObserverList, addObserver, ifCond, ifNoElse, switch, switchAsIf, ifExists,
+  for, forRange, forEach, while, tryCatch, checkState, notifyObservers, 
+  construct, param, method, getMethod, setMethod,privMethod, pubMethod, 
+  constructor, docMain, function, mainFunction, docFunc, docInOutFunc, intFunc, 
+  stateVar, stateVarDef, constVar, privMVar, pubMVar, pubGVar, buildClass, enum,
+  privClass, pubClass, docClass, commentedClass, buildModule, buildModule', 
+  modFromData, fileDoc, docMod
 ) where
 
 import Utils.Drasil (indent)
@@ -61,8 +61,9 @@ import qualified GOOL.Drasil.Symantics as S (InternalFile(fileFromData),
   TypeSym(bool, int, float, char, string, listType, listInnerType, void), 
   VariableSym(var, self, objVar, objVarSelf, listVar, listOf),
   ValueSym(litTrue, litFalse, litInt, litString, valueOf),
-  ValueExpression(funcApp, newObj, notNull), Selector(objAccess), objMethodCall,
-  objMethodCallNoParams, FunctionSym(func, listSize, listAdd, listAppend),
+  ValueExpression(funcApp, newObj, notNull, lambda), Selector(objAccess), 
+  objMethodCall, objMethodCallNoParams, 
+  FunctionSym(func, listSize, listAdd, listAppend),
   SelectorFunction(listAccess, listSet),
   InternalFunction(getFunc, setFunc, listSizeFunc, listAddFunc, listAppendFunc, 
     listAccessFunc, listSetFunc),
@@ -712,6 +713,11 @@ constDecDef :: (RenderSym repr) => VS (repr (Variable repr)) ->
   VS (repr (Value repr)) -> MS (repr (Statement repr))
 constDecDef vr vl = zoom lensMStoVS $ on2StateValues (\v -> mkSt . 
   constDecDefDocD v) vr vl
+
+funcDecDef :: (RenderSym repr) => VS (repr (Variable repr)) -> 
+  [VS (repr (Variable repr))] -> VS (repr (Value repr)) -> 
+  MS (repr (Statement repr))
+funcDecDef v ps r = S.varDecDef v (S.lambda ps r)
 
 discardInput :: (RenderSym repr) => (repr (Value repr) -> Doc) ->
   MS (repr (Statement repr))

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer/LanguagePolymorphic.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer/LanguagePolymorphic.hs
@@ -3,33 +3,34 @@
 -- | The structure for a class of renderers is defined here.
 module GOOL.Drasil.LanguageRenderer.LanguagePolymorphic (fileFromData, oneLiner,
   block, multiBlock, bool, int, float, double, char, string, fileType, listType,
-  listInnerType, obj, enumType, void, runStrategy, listSlice, unOpPrec, 
-  notOp, notOp', negateOp, sqrtOp, sqrtOp', absOp, absOp', expOp, expOp', sinOp,
-  sinOp', cosOp, cosOp', tanOp, tanOp', asinOp, asinOp', acosOp, acosOp', 
-  atanOp, atanOp', unExpr, unExpr', typeUnExpr, powerPrec, multPrec, andPrec, 
-  orPrec, equalOp, notEqualOp, greaterOp, greaterEqualOp, lessOp, lessEqualOp, 
-  plusOp, minusOp, multOp, divideOp, moduloOp, powerOp, andOp, orOp, binExpr, 
-  binExpr', typeBinExpr, addmathImport, var, staticVar, extVar, self, enumVar, 
-  classVar, objVar, objVarSelf, listVar, listOf, iterVar, litTrue, litFalse, 
-  litChar, litFloat, litInt, litString, pi, valueOf, arg, enumElement, argsList,
-  inlineIf, funcApp, selfFuncApp, extFuncApp, newObj, notNull, objAccess, 
-  objMethodCall, objMethodCallNoParams, selfAccess, listIndexExists, indexOf, 
-  func, get, set, listSize, listAdd, listAppend, iterBegin, iterEnd, listAccess,
-  listSet, getFunc, setFunc, listSizeFunc, listAddFunc, listAppendFunc, 
-  iterBeginError, iterEndError, listAccessFunc, listAccessFunc', listSetFunc, 
-  printSt, state, loopState, emptyState, assign, assignToListIndex, 
-  multiAssignError, decrement, increment, increment', increment1, increment1', 
-  decrement1, varDec, varDecDef, listDec, listDecDef, listDecDef', objDecNew, 
-  objDecNewNoParams, constDecDef, discardInput, discardFileInput, openFileR, 
-  openFileW, openFileA, closeFile, discardFileLine, stringListVals, 
-  stringListLists, returnState, multiReturnError, valState, comment, freeError, 
-  throw, initState, changeState, initObserverList, addObserver, ifCond, 
-  ifNoElse, switch, switchAsIf, ifExists, for, forRange, forEach, while, 
-  tryCatch, checkState, notifyObservers, construct, param, method, getMethod, 
-  setMethod,privMethod, pubMethod, constructor, docMain, function, mainFunction,
-  docFunc, docInOutFunc, intFunc, stateVar,stateVarDef, constVar, privMVar, 
-  pubMVar, pubGVar, buildClass, enum, privClass, pubClass, docClass, 
-  commentedClass, buildModule, buildModule', modFromData, fileDoc, docMod
+  listInnerType, obj, enumType, funcType, void, runStrategy, listSlice, 
+  unOpPrec, notOp, notOp', negateOp, sqrtOp, sqrtOp', absOp, absOp', expOp, 
+  expOp', sinOp, sinOp', cosOp, cosOp', tanOp, tanOp', asinOp, asinOp', acosOp, 
+  acosOp', atanOp, atanOp', unExpr, unExpr', typeUnExpr, powerPrec, multPrec, 
+  andPrec, orPrec, equalOp, notEqualOp, greaterOp, greaterEqualOp, lessOp, 
+  lessEqualOp, plusOp, minusOp, multOp, divideOp, moduloOp, powerOp, andOp, 
+  orOp, binExpr, binExpr', typeBinExpr, addmathImport, var, staticVar, extVar, 
+  self, enumVar, classVar, objVar, objVarSelf, listVar, listOf, iterVar, 
+  litTrue, litFalse, litChar, litFloat, litInt, litString, pi, valueOf, arg, 
+  enumElement, argsList, inlineIf, funcApp, selfFuncApp, extFuncApp, newObj, 
+  notNull, objAccess, objMethodCall, objMethodCallNoParams, selfAccess, 
+  listIndexExists, indexOf, func, get, set, listSize, listAdd, listAppend, 
+  iterBegin, iterEnd, listAccess, listSet, getFunc, setFunc, listSizeFunc, 
+  listAddFunc, listAppendFunc, iterBeginError, iterEndError, listAccessFunc, 
+  listAccessFunc', listSetFunc, printSt, state, loopState, emptyState, assign, 
+  assignToListIndex, multiAssignError, decrement, increment, increment', 
+  increment1, increment1', decrement1, varDec, varDecDef, listDec, listDecDef, 
+  listDecDef', objDecNew, objDecNewNoParams, constDecDef, discardInput, 
+  discardFileInput, openFileR, openFileW, openFileA, closeFile, discardFileLine,
+  stringListVals, stringListLists, returnState, multiReturnError, valState, 
+  comment, freeError, throw, initState, changeState, initObserverList, 
+  addObserver, ifCond, ifNoElse, switch, switchAsIf, ifExists, for, forRange, 
+  forEach, while, tryCatch, checkState, notifyObservers, construct, param, 
+  method, getMethod, setMethod,privMethod, pubMethod, constructor, docMain, 
+  function, mainFunction, docFunc, docInOutFunc, intFunc, stateVar,stateVarDef, 
+  constVar, privMVar, pubMVar, pubGVar, buildClass, enum, privClass, pubClass, 
+  docClass, commentedClass, buildModule, buildModule', modFromData, fileDoc, 
+  docMod
 ) where
 
 import Utils.Drasil (indent)
@@ -158,6 +159,9 @@ obj n = toState $ typeFromData (Object n) n (text n)
 
 enumType :: (RenderSym repr) => Label -> VS (repr (Type repr))
 enumType e = toState $ typeFromData (Enum e) e (text e)
+
+funcType :: (RenderSym repr) => [VS (repr (Type repr))] -> VS (repr (Type repr))
+funcType = onStateList (\sig -> typeFromData (Func (map getType sig)) "" empty)
 
 void :: (RenderSym repr) => VS (repr (Type repr))
 void = toState $ typeFromData Void "void" (text "void")

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer/PythonRenderer.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer/PythonRenderer.hs
@@ -206,12 +206,9 @@ instance ControlBlockSym PythonCode where
     where getVal = fromMaybe (mkStateVal void empty)
 
   solveODE info opts = modify (addLibImport odeLib) >> multiBlock [
-    docBlock $ onStateValue methodDoc $ function "f" public dynamic_ 
-      (onStateValue valueType $ ode info) [param iv, param dv] 
-      (oneLiner $ returnState $ ode info),
     block [
       r &= objMethodCall odeT (extNewObj odeLib odeT 
-      [valueOf $ var fname (onStateValue valueType $ ode info)]) 
+      [lambda [iv, dv] (ode info)]) 
         "set_integrator" (pyODEMethod (solveMethod opts) ++
           [absTol opts >>= (mkStateVal float . (text "atol=" <>) . valueDoc),
           relTol opts >>= (mkStateVal float . (text "rtol=" <>) . valueDoc)]),
@@ -227,8 +224,7 @@ instance ControlBlockSym PythonCode where
         ])
      ]
    ]
-   where fname = "f"
-         odeLib = "scipy.integrate"
+   where odeLib = "scipy.integrate"
          iv = indepVar info
          dv = depVar info
          odeT = obj "ode"

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer/PythonRenderer.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer/PythonRenderer.hs
@@ -487,6 +487,9 @@ instance StatementSym PythonCode where
   extObjDecNewNoParams lib v = modify (addModuleImport lib) >> varDecDef v 
     (extNewObj lib (onStateValue variableType v) [])
   constDecDef = varDecDef
+  funcDecDef v ps r = onStateValue (mkStNoEnd . methodDoc) (zoom lensMStoVS v 
+    >>= (\vr -> function (variableName vr) private dynamic_ 
+    (toState $ variableType vr) (map param ps) (oneLiner $ returnState r)))
 
   print = pyOut False Nothing printFunc
   printLn = pyOut True Nothing printFunc

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer/PythonRenderer.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer/PythonRenderer.hs
@@ -32,8 +32,8 @@ import GOOL.Drasil.LanguageRenderer (enumElementsDocD', multiStateDocD,
   surroundBody)
 import qualified GOOL.Drasil.LanguageRenderer.LanguagePolymorphic as G (
   oneLiner, block, multiBlock, int, float, listInnerType, obj, enumType, 
-  runStrategy, notOp', negateOp, sqrtOp', absOp', expOp', sinOp', cosOp', 
-  tanOp', asinOp', acosOp', atanOp', equalOp, notEqualOp, greaterOp, 
+  funcType, runStrategy, notOp', negateOp, sqrtOp', absOp', expOp', sinOp', 
+  cosOp', tanOp', asinOp', acosOp', atanOp', equalOp, notEqualOp, greaterOp, 
   greaterEqualOp, lessOp, lessEqualOp, plusOp, minusOp, multOp, divideOp, 
   moduloOp, var, staticVar, extVar, enumVar, classVar, objVar, objVarSelf, 
   listVar, listOf, iterVar, litChar, litFloat, litInt, litString, valueOf, arg, 
@@ -187,6 +187,7 @@ instance TypeSym PythonCode where
   listInnerType = G.listInnerType
   obj = G.obj
   enumType = G.enumType
+  funcType = G.funcType
   iterator t = t
   void = toState $ typeFromData Void "NoneType" (text "NoneType")
 
@@ -444,7 +445,7 @@ instance InternalFunction PythonCode where
   listAccessFunc = G.listAccessFunc
   listSetFunc = G.listSetFunc listSetFuncDocD
 
-  functionType = onCodeValue funcType
+  functionType = onCodeValue fType
   functionDoc = funcDoc . unPC
 
   funcFromData d = onStateValue (onCodeValue (`fd` d))

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer/PythonRenderer.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer/PythonRenderer.hs
@@ -28,8 +28,8 @@ import GOOL.Drasil.LanguageRenderer (enumElementsDocD', multiStateDocD,
   breakDocD, continueDocD, mkStateVal, mkVal, mkStateVar, classVarDocD, 
   newObjDocD', listSetFuncDocD, castObjDocD, dynamicDocD, bindingError, 
   classDec, dot, forLabel, inLabel, observerListName, commentedItem, 
-  addCommentsDocD, commentedModD, docFuncRepr, valueList, parameterList, 
-  surroundBody)
+  addCommentsDocD, commentedModD, docFuncRepr, valueList, variableList,
+  parameterList, surroundBody)
 import qualified GOOL.Drasil.LanguageRenderer.LanguagePolymorphic as G (
   oneLiner, block, multiBlock, int, float, listInnerType, obj, enumType, 
   funcType, runStrategy, notOp', negateOp, sqrtOp', absOp', expOp', sinOp', 
@@ -39,17 +39,17 @@ import qualified GOOL.Drasil.LanguageRenderer.LanguagePolymorphic as G (
   listVar, listOf, iterVar, litChar, litFloat, litInt, litString, valueOf, arg, 
   enumElement, argsList, objAccess, objMethodCall, objMethodCallNoParams, 
   selfAccess, listIndexExists, indexOf, funcApp, selfFuncApp, extFuncApp, 
-  newObj, func, get, set, listAdd, listAppend, iterBegin, iterEnd, listAccess, 
-  listSet, getFunc, setFunc, listAddFunc, listAppendFunc, iterBeginError, 
-  iterEndError, listAccessFunc, listSetFunc, state, loopState, emptyState, 
-  assign, assignToListIndex, decrement, increment', increment1', decrement1, 
-  objDecNew, objDecNewNoParams, closeFile, discardFileLine, stringListVals, 
-  stringListLists, returnState, valState, comment, throw, initState, 
-  changeState, initObserverList, addObserver, ifCond, ifNoElse, switchAsIf, 
-  ifExists, tryCatch, checkState, construct, param, method, getMethod, 
-  setMethod, privMethod, pubMethod, constructor, function, docFunc, stateVarDef,
-  constVar, privMVar, pubMVar, pubGVar, buildClass, privClass, pubClass, 
-  docClass, commentedClass, buildModule, modFromData, fileDoc, docMod, 
+  newObj, lambda, func, get, set, listAdd, listAppend, iterBegin, iterEnd, 
+  listAccess, listSet, getFunc, setFunc, listAddFunc, listAppendFunc, 
+  iterBeginError, iterEndError, listAccessFunc, listSetFunc, state, loopState, 
+  emptyState, assign, assignToListIndex, decrement, increment', increment1', 
+  decrement1, objDecNew, objDecNewNoParams, closeFile, discardFileLine, 
+  stringListVals, stringListLists, returnState, valState, comment, throw, 
+  initState, changeState, initObserverList, addObserver, ifCond, ifNoElse, 
+  switchAsIf, ifExists, tryCatch, checkState, construct, param, method, 
+  getMethod, setMethod, privMethod, pubMethod, constructor, function, docFunc, 
+  stateVarDef, constVar, privMVar, pubMVar, pubGVar, buildClass, privClass, 
+  pubClass, docClass, commentedClass, buildModule, modFromData, fileDoc, docMod,
   fileFromData)
 import GOOL.Drasil.LanguageRenderer.LanguagePolymorphic (unOpPrec, unExpr, 
   unExpr', typeUnExpr, powerPrec, multPrec, andPrec, orPrec, binExpr, 
@@ -380,6 +380,8 @@ instance ValueExpression PythonCode where
   newObj = G.newObj newObjDocD'
   extNewObj l tp ps = modify (addModuleImportVS l) >> on1StateValue1List 
     (\t -> mkVal t . pyExtStateObj l (getTypeDoc t) . valueList) tp ps
+
+  lambda = G.lambda pyLambda
 
   exists v = v ?!= valueOf (var "None" void)
   notNull = exists
@@ -727,6 +729,10 @@ pyInlineIf :: (RenderSym repr) => VS (repr (Value repr)) ->
 pyInlineIf = on3StateValues (\c v1 v2 -> valFromData (valuePrec c) 
   (valueType v1) (valueDoc v1 <+> text "if" <+> valueDoc c <+> text "else" <+> 
   valueDoc v2))
+
+pyLambda :: (RenderSym repr) => [repr (Variable repr)] -> repr (Value repr) -> 
+  Doc
+pyLambda ps ex = text "lambda" <+> variableList ps <> colon <+> valueDoc ex
 
 pyListSize :: Doc -> Doc -> Doc
 pyListSize v f = f <> parens v

--- a/code/drasil-gool/GOOL/Drasil/Symantics.hs
+++ b/code/drasil-gool/GOOL/Drasil/Symantics.hs
@@ -523,6 +523,8 @@ class (SelectorFunction repr) => StatementSym repr where
     MS (repr (Statement repr))
   constDecDef      :: VS (repr (Variable repr)) -> VS (repr (Value repr)) -> 
     MS (repr (Statement repr))
+  funcDecDef       :: VS (repr (Variable repr)) -> [VS (repr (Variable repr))] 
+    -> VS (repr (Value repr)) -> MS (repr (Statement repr))
 
   print      :: VS (repr (Value repr)) -> MS (repr (Statement repr))
   printLn    :: VS (repr (Value repr)) -> MS (repr (Statement repr))

--- a/code/drasil-gool/GOOL/Drasil/Symantics.hs
+++ b/code/drasil-gool/GOOL/Drasil/Symantics.hs
@@ -137,7 +137,8 @@ class (PermanenceSym repr) => TypeSym repr where
   listInnerType :: VS (repr (Type repr)) -> VS (repr (Type repr))
   obj           :: Label -> VS (repr (Type repr))
   enumType      :: Label -> VS (repr (Type repr))
-  funcType      :: [VS (repr (Type repr))] -> VS (repr (Type repr))
+  funcType      :: [VS (repr (Type repr))] -> VS (repr (Type repr)) -> 
+    VS (repr (Type repr))
   iterator      :: VS (repr (Type repr)) -> VS (repr (Type repr))
   void          :: VS (repr (Type repr))
 

--- a/code/drasil-gool/GOOL/Drasil/Symantics.hs
+++ b/code/drasil-gool/GOOL/Drasil/Symantics.hs
@@ -137,6 +137,7 @@ class (PermanenceSym repr) => TypeSym repr where
   listInnerType :: VS (repr (Type repr)) -> VS (repr (Type repr))
   obj           :: Label -> VS (repr (Type repr))
   enumType      :: Label -> VS (repr (Type repr))
+  funcType      :: [VS (repr (Type repr))] -> VS (repr (Type repr))
   iterator      :: VS (repr (Type repr)) -> VS (repr (Type repr))
   void          :: VS (repr (Type repr))
 
@@ -358,6 +359,9 @@ class (ValueSym repr, BooleanExpression repr) =>
   newObj     :: VS (repr (Type repr)) -> [VS (repr (Value repr))] -> 
     VS (repr (Value repr))
   extNewObj  :: Library -> VS (repr (Type repr)) -> [VS (repr (Value repr))] -> 
+    VS (repr (Value repr))
+
+  lambda :: [VS (repr (Variable repr))] -> VS (repr (Value repr)) -> 
     VS (repr (Value repr))
 
   exists  :: VS (repr (Value repr)) -> VS (repr (Value repr))


### PR DESCRIPTION
This PR adds a `lambda` function to GOOL for generating anonymous functions, which simplifies `solveODE` for Python and C# somewhat. 