### PR TITLE
Don't use object initializer for C# ODE

### DIFF
--- a/code/drasil-code/Language/Drasil/Code.hs
+++ b/code/drasil-code/Language/Drasil/Code.hs
@@ -6,8 +6,8 @@ module Language.Drasil.Code (
   ($:=), Choices(..), CodeSpec(..), CodeSystInfo(..), Comments(..), 
   Verbosity(..), ConstraintBehaviour(..), Func, FuncStmt(..), 
   ImplementationType(..), Lang(..), Logging(LogNone, LogAll), Mod(Mod), 
-  Structure(..), ConstantStructure(..), ConstantRepr(..), InputModule(..), 
-  CodeConcept(..), matchConcepts, AuxFile(..), Visibility(..),
+  Modularity(..), Structure(..), ConstantStructure(..), ConstantRepr(..), 
+  InputModule(..), CodeConcept(..), matchConcepts, AuxFile(..), Visibility(..),
   asExpr, asExpr', asVC, asVC', codeSpec, fdec, ffor, funcData, funcDef, 
   packmod, relToQD,
   junkLine, multiLine, repeated, singleLine, singleton,
@@ -31,9 +31,10 @@ import Language.Drasil.Code.DataDesc (junkLine, multiLine, repeated, singleLine,
 import Language.Drasil.CodeSpec (($:=), Choices(..), CodeSpec(..), 
   CodeSystInfo(..), Comments(..), Verbosity(..), ConstraintBehaviour(..), Func, 
   FuncStmt(..), ImplementationType(..), Lang(..), Logging(..), Mod(Mod), 
-  Structure(..), ConstantStructure(..), ConstantRepr(..), InputModule(..), 
-  CodeConcept(..), matchConcepts, AuxFile(..), Visibility(..), asExpr, asExpr', 
-  asVC, asVC', codeSpec, fdec, ffor, funcData, funcDef, packmod, relToQD)
+  Modularity(..), Structure(..), ConstantStructure(..), ConstantRepr(..), 
+  InputModule(..), CodeConcept(..), matchConcepts, AuxFile(..), Visibility(..), 
+  asExpr, asExpr', asVC, asVC', codeSpec, fdec, ffor, funcData, funcDef, 
+  packmod, relToQD)
 
 import Language.Drasil.Code.Imperative.GOOL.Symantics (PackageSym(..))
 

--- a/code/drasil-code/Language/Drasil/Code/Imperative/Comments.hs
+++ b/code/drasil-code/Language/Drasil/Code/Imperative/Comments.hs
@@ -4,7 +4,7 @@ module Language.Drasil.Code.Imperative.Comments (
 
 import Language.Drasil
 import Database.Drasil (defTable)
-import Language.Drasil.Code.Imperative.State (DrasilState(..))
+import Language.Drasil.Code.Imperative.DrasilState (DrasilState(..))
 import Language.Drasil.CodeSpec (CodeSpec(..), CodeSystInfo(..))
 import Language.Drasil.Printers (Linearity(Linear), sentenceDoc, unitDoc)
 

--- a/code/drasil-code/Language/Drasil/Code/Imperative/Descriptions.hs
+++ b/code/drasil-code/Language/Drasil/Code/Imperative/Descriptions.hs
@@ -44,11 +44,11 @@ inputConstructorDesc = do
       idDesc True = "calculating derived values"
       icDesc False = ""
       icDesc True = "checking " ++ pAndS ++ " on the input"
-      dm = defMap $ codeSpec g
+      dl = defList $ codeSpec g
   return $ "Initializes input object by " ++ stringList [ 
-    ifDesc (member "get_input" dm),
-    idDesc (member "derived_values" dm),
-    icDesc (member "input_constraints" dm)]
+    ifDesc ("get_input" `elem` dl),
+    idDesc ("derived_values" `elem` dl),
+    icDesc ("input_constraints" `elem` dl)]
 
 inputFormatDesc :: Reader DrasilState String
 inputFormatDesc = do
@@ -95,12 +95,12 @@ inputClassDesc = do
       inClassD [] = ""
       inClassD _ = "Structure for holding the " ++ stringList [
         inPs $ extInputs $ csi $ codeSpec g,
-        dVs $ Map.lookup "derived_values" (defMap $ codeSpec g),
+        dVs $ "derived_values" `elem` defList (codeSpec g),
         cVs $ filter (flip member (Map.filter (cname ==) 
           (eMap $ codeSpec g)) . codeName) (constants $ csi $ codeSpec g)]
       inPs [] = ""
       inPs _ = "input values"
-      dVs Nothing = ""
+      dVs False = ""
       dVs _ = "derived values"
       cVs [] = ""
       cVs _ = "constant values"
@@ -117,32 +117,32 @@ constClassDesc = do
 inFmtFuncDesc :: Reader DrasilState String
 inFmtFuncDesc = do
   g <- ask
-  let ifDesc Nothing = ""
+  let ifDesc False = ""
       ifDesc _ = "Reads input from a file with the given file name"
-  return $ ifDesc $ Map.lookup "get_input" (defMap $ codeSpec g)
+  return $ ifDesc $ "get_input" `elem` defList (codeSpec g)
 
 inConsFuncDesc :: Reader DrasilState String
 inConsFuncDesc = do
   g <- ask
   pAndS <- physAndSfwrCons
-  let icDesc Nothing = ""
+  let icDesc False = ""
       icDesc _ = "Verifies that input values satisfy the " ++ pAndS
-  return $ icDesc $ Map.lookup "input_constraints" (defMap $ codeSpec g)
+  return $ icDesc $ "input_constraints" `elem` defList (codeSpec g)
 
 dvFuncDesc :: Reader DrasilState String
 dvFuncDesc = do
   g <- ask
-  let dvDesc Nothing = ""
+  let dvDesc False = ""
       dvDesc _ = "Calculates values that can be immediately derived from the" ++
         " inputs"
-  return $ dvDesc $ Map.lookup "derived_values" (defMap $ codeSpec g)
+  return $ dvDesc $ "derived_values" `elem` defList (codeSpec g)
 
 woFuncDesc :: Reader DrasilState String
 woFuncDesc = do
   g <- ask
-  let woDesc Nothing = ""
+  let woDesc False = ""
       woDesc _ = "Writes the output values to output.txt"
-  return $ woDesc $ Map.lookup "write_output" (defMap $ codeSpec g)
+  return $ woDesc $ "write_output" `elem` defList (codeSpec g)
 
 physAndSfwrCons :: Reader DrasilState String
 physAndSfwrCons = do

--- a/code/drasil-code/Language/Drasil/Code/Imperative/Descriptions.hs
+++ b/code/drasil-code/Language/Drasil/Code/Imperative/Descriptions.hs
@@ -8,7 +8,7 @@ module Language.Drasil.Code.Imperative.Descriptions (
 import Utils.Drasil (stringList)
 
 import Language.Drasil
-import Language.Drasil.Code.Imperative.DrasilState (DrasilState(..))
+import Language.Drasil.Code.Imperative.DrasilState (DrasilState(..), inMod)
 import Language.Drasil.Chunk.Code (CodeIdea(codeName))
 import Language.Drasil.CodeSpec (CodeSpec(..), CodeSystInfo(..), 
   InputModule(..), Structure(..))

--- a/code/drasil-code/Language/Drasil/Code/Imperative/Descriptions.hs
+++ b/code/drasil-code/Language/Drasil/Code/Imperative/Descriptions.hs
@@ -8,7 +8,7 @@ module Language.Drasil.Code.Imperative.Descriptions (
 import Utils.Drasil (stringList)
 
 import Language.Drasil
-import Language.Drasil.Code.Imperative.State (DrasilState(..))
+import Language.Drasil.Code.Imperative.DrasilState (DrasilState(..))
 import Language.Drasil.Chunk.Code (CodeIdea(codeName))
 import Language.Drasil.CodeSpec (CodeSpec(..), CodeSystInfo(..), 
   InputModule(..), Structure(..))

--- a/code/drasil-code/Language/Drasil/Code/Imperative/DrasilState.hs
+++ b/code/drasil-code/Language/Drasil/Code/Imperative/DrasilState.hs
@@ -23,6 +23,7 @@ data DrasilState = DrasilState {
   auxiliaries :: [AuxFile],
   sampleData :: [Expr],
   currentModule :: String,
+  currentClass :: String,
 
   onSfwrC :: ConstraintBehaviour,
   onPhysC :: ConstraintBehaviour

--- a/code/drasil-code/Language/Drasil/Code/Imperative/DrasilState.hs
+++ b/code/drasil-code/Language/Drasil/Code/Imperative/DrasilState.hs
@@ -1,16 +1,17 @@
-module Language.Drasil.Code.Imperative.State (
+module Language.Drasil.Code.Imperative.DrasilState (
   DrasilState(..)
 ) where
 
 import Language.Drasil
-import Language.Drasil.CodeSpec (AuxFile, CodeSpec, Comments, Verbosity, 
-  MatchedConceptMap, ConstantRepr, ConstantStructure, ConstraintBehaviour, 
-  InputModule, Logging, Structure)
+import Language.Drasil.CodeSpec (AuxFile, CodeSpec, Modularity, Comments, 
+  Verbosity, MatchedConceptMap, ConstantRepr, ConstantStructure, 
+  ConstraintBehaviour, InputModule, Logging, Structure)
 
 -- Private State, used to push these options around the generator
 data DrasilState = DrasilState {
   codeSpec :: CodeSpec,
   date :: String,
+  modular :: Modularity,
   inStruct :: Structure,
   conStruct :: ConstantStructure,
   conRepr :: ConstantRepr,

--- a/code/drasil-code/Language/Drasil/Code/Imperative/DrasilState.hs
+++ b/code/drasil-code/Language/Drasil/Code/Imperative/DrasilState.hs
@@ -1,11 +1,11 @@
 module Language.Drasil.Code.Imperative.DrasilState (
-  DrasilState(..)
+  DrasilState(..), inMod
 ) where
 
 import Language.Drasil
-import Language.Drasil.CodeSpec (AuxFile, CodeSpec, Modularity, Comments, 
+import Language.Drasil.CodeSpec (AuxFile, CodeSpec, Modularity(..), Comments, 
   Verbosity, MatchedConceptMap, ConstantRepr, ConstantStructure, 
-  ConstraintBehaviour, InputModule, Logging, Structure)
+  ConstraintBehaviour, InputModule(..), Logging, Structure)
 
 -- Private State, used to push these options around the generator
 data DrasilState = DrasilState {
@@ -15,7 +15,6 @@ data DrasilState = DrasilState {
   inStruct :: Structure,
   conStruct :: ConstantStructure,
   conRepr :: ConstantRepr,
-  inMod :: InputModule,
   logName :: String,
   logKind :: Logging,
   commented :: [Comments],
@@ -28,3 +27,8 @@ data DrasilState = DrasilState {
   onSfwrC :: ConstraintBehaviour,
   onPhysC :: ConstraintBehaviour
 }
+
+inMod :: DrasilState -> InputModule
+inMod ds = inMod' $ modular ds
+  where inMod' Unmodular = Combined
+        inMod' (Modular im) = im

--- a/code/drasil-code/Language/Drasil/Code/Imperative/FunctionCalls.hs
+++ b/code/drasil-code/Language/Drasil/Code/Imperative/FunctionCalls.hs
@@ -10,7 +10,7 @@ import Language.Drasil.Code.Imperative.Logging (maybeLog)
 import Language.Drasil.Code.Imperative.Parameters (getCalcParams, 
   getConstraintParams, getDerivedIns, getDerivedOuts, getInputFormatIns, 
   getInputFormatOuts, getOutputParams)
-import Language.Drasil.Code.Imperative.State (DrasilState(..))
+import Language.Drasil.Code.Imperative.DrasilState (DrasilState(..))
 import Language.Drasil.Chunk.Code (CodeIdea(codeName), codeType)
 import Language.Drasil.Chunk.CodeDefinition (CodeDefinition)
 import Language.Drasil.Chunk.CodeQuantity (HasCodeType)

--- a/code/drasil-code/Language/Drasil/Code/Imperative/FunctionCalls.hs
+++ b/code/drasil-code/Language/Drasil/Code/Imperative/FunctionCalls.hs
@@ -22,6 +22,7 @@ import GOOL.Drasil (ProgramSym, TypeSym(..), ValueSym(..), StatementSym(..),
 import Data.List ((\\), intersect)
 import qualified Data.Map as Map (lookup)
 import Data.Maybe (maybe, catMaybes)
+import Control.Applicative ((<|>))
 import Control.Monad.Reader (Reader, ask)
 import Control.Lens ((^.))
 
@@ -100,6 +101,7 @@ getCall n = do
         codeSpec g)
       getCallExported m = return m
       getCallInClass Nothing = return Nothing
-      getCallInClass (Just c) = if c == currc then return (Just c) 
+      getCallInClass (Just c) = if c == currc then return $ Map.lookup c (eMap 
+        $ codeSpec g) <|> error (c ++ " class missing from export map")
         else return Nothing
   getCallExported $ Map.lookup n (eMap $ codeSpec g)

--- a/code/drasil-code/Language/Drasil/Code/Imperative/FunctionCalls.hs
+++ b/code/drasil-code/Language/Drasil/Code/Imperative/FunctionCalls.hs
@@ -95,10 +95,11 @@ getInOutCall n inFunc outFunc = do
 getCall :: String -> Reader DrasilState (Maybe String)
 getCall n = do
   g <- ask
-  let getCallExported Nothing = getCallDefined (Map.lookup n $ defMap $ 
+  let currc = currentClass g
+      getCallExported Nothing = getCallInClass (Map.lookup n $ clsMap $ 
         codeSpec g)
       getCallExported m = return m
-      getCallDefined Nothing = return Nothing
-      getCallDefined (Just m) = if m == currentModule g then return (Just m)
+      getCallInClass Nothing = return Nothing
+      getCallInClass (Just c) = if c == currc then return (Just c) 
         else return Nothing
   getCallExported $ Map.lookup n (eMap $ codeSpec g)

--- a/code/drasil-code/Language/Drasil/Code/Imperative/GenerateGOOL.hs
+++ b/code/drasil-code/Language/Drasil/Code/Imperative/GenerateGOOL.hs
@@ -3,7 +3,7 @@ module Language.Drasil.Code.Imperative.GenerateGOOL (
 ) where
 
 import Language.Drasil
-import Language.Drasil.Code.Imperative.State (DrasilState(..))
+import Language.Drasil.Code.Imperative.DrasilState (DrasilState(..))
 import Language.Drasil.Code.Imperative.GOOL.Symantics (AuxiliarySym(..))
 import Language.Drasil.CodeSpec (CodeSpec(..), CodeSystInfo(..), Comments(..), 
   Name)

--- a/code/drasil-code/Language/Drasil/Code/Imperative/Generator.hs
+++ b/code/drasil-code/Language/Drasil/Code/Imperative/Generator.hs
@@ -8,7 +8,7 @@ import Language.Drasil.Code.Imperative.GenerateGOOL (genDoxConfig)
 import Language.Drasil.Code.Imperative.Import (genModDef)
 import Language.Drasil.Code.Imperative.Modules (chooseInModule, genConstMod, 
   genMain, genOutputMod, genSampleInput)
-import Language.Drasil.Code.Imperative.State (DrasilState(..))
+import Language.Drasil.Code.Imperative.DrasilState (DrasilState(..))
 import Language.Drasil.Code.Imperative.GOOL.Symantics (PackageSym(..), 
   AuxiliarySym(..))
 import Language.Drasil.Code.Imperative.GOOL.Data (PackData(..))
@@ -30,6 +30,7 @@ generator dt sd chs spec = DrasilState {
   -- constants
   codeSpec = spec,
   date = showDate $ dates chs,
+  modular = modularity chs,
   inStruct = inputStructure chs,
   conStruct = constStructure chs,
   conRepr = constRepr chs,

--- a/code/drasil-code/Language/Drasil/Code/Imperative/Generator.hs
+++ b/code/drasil-code/Language/Drasil/Code/Imperative/Generator.hs
@@ -108,7 +108,7 @@ genUnmodular = do
     (map (fmap Just) (genMainFunc : concatMap genModFuncs (mods s)) ++ 
     ((if cls then [] else [genInputFormat Pub, genInputDerived Pub, 
       genInputConstraints Pub]) ++ [genOutputFormat])) 
-    ([genInputClass | cls] ++ [genConstClass])
+    [genInputClass Priv, genConstClass Priv]
           
 genModules :: (ProgramSym repr) => 
   Reader DrasilState [FS (repr (RenderFile repr))]

--- a/code/drasil-code/Language/Drasil/Code/Imperative/Generator.hs
+++ b/code/drasil-code/Language/Drasil/Code/Imperative/Generator.hs
@@ -75,7 +75,7 @@ genPackage unRepr = do
   let info = unCI $ evalState ci initialState
       (reprPD, s) = runState p info
       pd = unRepr reprPD
-      n = pName $ codeSpec g
+      n = pName $ csi $ codeSpec g
       m = makefile (commented g) s pd
   i <- genSampleInput
   d <- genDoxConfig n s
@@ -85,7 +85,7 @@ genProgram :: (ProgramSym repr) => Reader DrasilState (GS (repr (Program repr)))
 genProgram = do
   g <- ask
   ms <- chooseModules $ modular g
-  let n = pName $ codeSpec g
+  let n = pName $ csi $ codeSpec g
   return $ prog n ms
 
 chooseModules :: (ProgramSym repr) => Modularity -> 
@@ -98,7 +98,7 @@ genUnmodular :: (ProgramSym repr) =>
 genUnmodular = do
   g <- ask
   let s = csi $ codeSpec g
-      n = pName $ codeSpec g
+      n = pName $ csi $ codeSpec g
   genModule n ("Contains the entire " ++ n ++ " program")
     (map (fmap Just) (genMainFunc : concatMap genModFuncs (mods s)) ++ 
     [genOutputFormat]) [genInputClass, genConstClass]

--- a/code/drasil-code/Language/Drasil/Code/Imperative/Generator.hs
+++ b/code/drasil-code/Language/Drasil/Code/Imperative/Generator.hs
@@ -43,6 +43,7 @@ generator dt sd chs spec = DrasilState {
   sampleData = sd,
   -- state
   currentModule = "",
+  currentClass = "",
 
   -- next depend on chs
   logName = logFile chs,

--- a/code/drasil-code/Language/Drasil/Code/Imperative/Generator.hs
+++ b/code/drasil-code/Language/Drasil/Code/Imperative/Generator.hs
@@ -15,7 +15,6 @@ import Language.Drasil.Code.Imperative.GOOL.Symantics (PackageSym(..),
   AuxiliarySym(..))
 import Language.Drasil.Code.Imperative.GOOL.Data (PackData(..))
 import Language.Drasil.Code.CodeGeneration (createCodeFiles, makeCode)
-import Language.Drasil.Chunk.Code (programName)
 import Language.Drasil.CodeSpec (CodeSpec(..), CodeSystInfo(..), Choices(..), 
   Lang(..), Modularity(..), Visibility(..))
 
@@ -76,8 +75,7 @@ genPackage unRepr = do
   let info = unCI $ evalState ci initialState
       (reprPD, s) = runState p info
       pd = unRepr reprPD
-      -- Below line of code cannot be simplified because program has a generic type
-      n = case codeSpec g of CodeSpec {program = pr} -> programName pr
+      n = pName $ codeSpec g
       m = makefile (commented g) s pd
   i <- genSampleInput
   d <- genDoxConfig n s
@@ -87,8 +85,7 @@ genProgram :: (ProgramSym repr) => Reader DrasilState (GS (repr (Program repr)))
 genProgram = do
   g <- ask
   ms <- chooseModules $ modular g
-  -- Below line of code cannot be simplified because program has a generic type
-  let n = case codeSpec g of CodeSpec {program = p} -> programName p
+  let n = pName $ codeSpec g
   return $ prog n ms
 
 chooseModules :: (ProgramSym repr) => Modularity -> 
@@ -101,8 +98,7 @@ genUnmodular :: (ProgramSym repr) =>
 genUnmodular = do
   g <- ask
   let s = csi $ codeSpec g
-      -- Below line of code cannot be simplified because program has a generic type
-      n = case codeSpec g of CodeSpec {program = p} -> programName p
+      n = pName $ codeSpec g
   genModule n ("Contains the entire " ++ n ++ " program")
     (map (fmap Just) (genMainFunc : concatMap genModFuncs (mods s)) ++ 
     [genOutputFormat]) [genInputClass, genConstClass]

--- a/code/drasil-code/Language/Drasil/Code/Imperative/Generator.hs
+++ b/code/drasil-code/Language/Drasil/Code/Imperative/Generator.hs
@@ -8,7 +8,7 @@ import Language.Drasil.Code.Imperative.GenerateGOOL (genDoxConfig)
 import Language.Drasil.Code.Imperative.Import (genModDef)
 import Language.Drasil.Code.Imperative.Modules (chooseInModule, genConstMod, 
   genMain, genOutputMod, genSampleInput)
-import Language.Drasil.Code.Imperative.DrasilState (DrasilState(..))
+import Language.Drasil.Code.Imperative.DrasilState (DrasilState(..), inMod)
 import Language.Drasil.Code.Imperative.GOOL.Symantics (PackageSym(..), 
   AuxiliarySym(..))
 import Language.Drasil.Code.Imperative.GOOL.Data (PackData(..))
@@ -34,7 +34,6 @@ generator dt sd chs spec = DrasilState {
   inStruct = inputStructure chs,
   conStruct = constStructure chs,
   conRepr = constRepr chs,
-  inMod = inputModule chs,
   logKind  = logging chs,
   commented = comments chs,
   doxOutput = doxVerbosity chs,

--- a/code/drasil-code/Language/Drasil/Code/Imperative/Helpers.hs
+++ b/code/drasil-code/Language/Drasil/Code/Imperative/Helpers.hs
@@ -4,7 +4,7 @@ module Language.Drasil.Code.Imperative.Helpers (
 
 import Language.Drasil
 import Database.Drasil (symbResolve)
-import Language.Drasil.Code.Imperative.State (DrasilState(..))
+import Language.Drasil.Code.Imperative.DrasilState (DrasilState(..))
 import Language.Drasil.CodeSpec (CodeSpec(..), CodeSystInfo(..))
 
 import Control.Monad.Reader (Reader)

--- a/code/drasil-code/Language/Drasil/Code/Imperative/Import.hs
+++ b/code/drasil-code/Language/Drasil/Code/Imperative/Import.hs
@@ -15,7 +15,7 @@ import Language.Drasil.Code.Imperative.GenerateGOOL (fApp, genModule, mkParam)
 import Language.Drasil.Code.Imperative.Helpers (getUpperBound, liftS, lookupC)
 import Language.Drasil.Code.Imperative.Logging (maybeLog, logBody)
 import Language.Drasil.Code.Imperative.Parameters (getCalcParams)
-import Language.Drasil.Code.Imperative.State (DrasilState(..))
+import Language.Drasil.Code.Imperative.DrasilState (DrasilState(..))
 import Language.Drasil.Chunk.Code (CodeIdea(codeName), codeType, codevar, 
   quantvar, quantfunc)
 import Language.Drasil.Chunk.CodeDefinition (CodeDefinition, codeEquat)

--- a/code/drasil-code/Language/Drasil/Code/Imperative/Import.hs
+++ b/code/drasil-code/Language/Drasil/Code/Imperative/Import.hs
@@ -323,7 +323,7 @@ genCaseBlock t v c cs = do
 -- medium hacks --
 genModDef :: (ProgramSym repr) => Mod -> 
   Reader DrasilState (FS (repr (RenderFile repr)))
-genModDef (Mod n desc fs) = genModule n desc (Just $ mapM genFunc fs) Nothing
+genModDef (Mod n desc fs) = genModule n desc (map (fmap Just . genFunc) fs) []
 
 genFunc :: (ProgramSym repr) => Func -> Reader DrasilState (MS (repr (Method repr)))
 genFunc (FDef (FuncDef n desc parms o rd s)) = do

--- a/code/drasil-code/Language/Drasil/Code/Imperative/Import.hs
+++ b/code/drasil-code/Language/Drasil/Code/Imperative/Import.hs
@@ -38,7 +38,7 @@ import qualified GOOL.Drasil as C (CodeType(List))
 
 import Prelude hiding (sin, cos, tan, log, exp)
 import Data.List ((\\), intersect)
-import qualified Data.Map as Map (lookup, member)
+import qualified Data.Map as Map (lookup)
 import Data.Maybe (maybe)
 import Control.Applicative ((<$>))
 import Control.Monad (liftM2,liftM3)
@@ -76,10 +76,9 @@ inputVariable :: (ProgramSym repr) => Structure -> ConstantRepr ->
 inputVariable Unbundled _ v = return v
 inputVariable Bundled Var v = do
   g <- ask
-  let inModName = "InputParameters"
+  let inClsName = "InputParameters"
   ip <- mkVar (codevar inParams)
-  return $ if currentModule g == inModName && Map.member inModName 
-    (eMap $ codeSpec g) then objVarSelf v else ip $-> v
+  return $ if currentClass g == inClsName then objVarSelf v else ip $-> v
 inputVariable Bundled Const v = do
   ip <- mkVar (codevar inParams)
   classVariable ip v

--- a/code/drasil-code/Language/Drasil/Code/Imperative/Import.hs
+++ b/code/drasil-code/Language/Drasil/Code/Imperative/Import.hs
@@ -3,7 +3,7 @@
 module Language.Drasil.Code.Imperative.Import (
   publicFunc, privateMethod, publicInOutFunc, privateInOutMethod, 
   genConstructor, mkVar, mkVal, convExpr, genCalcBlock, CalcType(..), genModDef,
-  readData, renderC
+  genModFuncs, readData, renderC
 ) where
 
 import Language.Drasil hiding (int, log, ln, exp,
@@ -324,6 +324,10 @@ genCaseBlock t v c cs = do
 genModDef :: (ProgramSym repr) => Mod -> 
   Reader DrasilState (FS (repr (RenderFile repr)))
 genModDef (Mod n desc fs) = genModule n desc (map (fmap Just . genFunc) fs) []
+
+genModFuncs :: (ProgramSym repr) => Mod -> 
+  [Reader DrasilState (MS (repr (Method repr)))]
+genModFuncs (Mod _ _ fs) = map genFunc fs
 
 genFunc :: (ProgramSym repr) => Func -> Reader DrasilState (MS (repr (Method repr)))
 genFunc (FDef (FuncDef n desc parms o rd s)) = do

--- a/code/drasil-code/Language/Drasil/Code/Imperative/Logging.hs
+++ b/code/drasil-code/Language/Drasil/Code/Imperative/Logging.hs
@@ -2,7 +2,7 @@ module Language.Drasil.Code.Imperative.Logging (
   maybeLog, logBody, loggedMethod, varLogFile
 ) where
 
-import Language.Drasil.Code.Imperative.State (DrasilState(..))
+import Language.Drasil.Code.Imperative.DrasilState (DrasilState(..))
 import Language.Drasil.CodeSpec hiding (codeSpec, Mod(..))
 
 import GOOL.Drasil (Label, ProgramSym, BodySym(..), BlockSym(..), 

--- a/code/drasil-code/Language/Drasil/Code/Imperative/Modules.hs
+++ b/code/drasil-code/Language/Drasil/Code/Imperative/Modules.hs
@@ -87,7 +87,7 @@ getInputDecl = do
       getDecl ([],ins) = do
         vars <- mapM mkVar ins
         return $ Just $ multi $ map varDec vars
-      getDecl ((i:_),[]) = return $ Just $ (if currentModule g == 
+      getDecl (i:_,[]) = return $ Just $ (if currentModule g == 
         eMap (codeSpec g) ! codeName i then objDecNew 
         else extObjDecNew cname) v_params cps
       getDecl _ = error ("Inputs or constants are only partially contained in " 
@@ -108,7 +108,7 @@ initConsts = do
       getDecl _ Inline = return Nothing
       getDecl _ WithInputs = return Nothing
       getDecl ([],[]) _ = return Nothing
-      getDecl ((c:_),[]) _ = asks (constCont c . conRepr)
+      getDecl (c:_,[]) _ = asks (constCont c . conRepr)
       getDecl ([],cs) _ = do 
         vars <- mapM mkVar cs
         vals <- mapM (convExpr . codeEquat) cs

--- a/code/drasil-code/Language/Drasil/Code/Imperative/Modules.hs
+++ b/code/drasil-code/Language/Drasil/Code/Imperative/Modules.hs
@@ -19,7 +19,7 @@ import Language.Drasil.Code.Imperative.Logging (maybeLog, varLogFile)
 import Language.Drasil.Code.Imperative.Parameters (getConstraintParams, 
   getDerivedIns, getDerivedOuts, getInConstructorParams, getInputFormatIns, 
   getInputFormatOuts, getOutputParams)
-import Language.Drasil.Code.Imperative.State (DrasilState(..))
+import Language.Drasil.Code.Imperative.DrasilState (DrasilState(..))
 import Language.Drasil.Code.Imperative.GOOL.Symantics (AuxiliarySym(..))
 import Language.Drasil.Chunk.Code (CodeIdea(codeName, codeChunk), CodeChunk, 
   codeType, codevar, physLookup, sfwrLookup)

--- a/code/drasil-code/Language/Drasil/Code/Imperative/Modules.hs
+++ b/code/drasil-code/Language/Drasil/Code/Imperative/Modules.hs
@@ -172,8 +172,10 @@ genInputClass = do
       cs = constants $ csi $ codeSpec g
       cname = "InputParameters"
       filt :: (CodeIdea c) => [c] -> [c]
-      filt = filter (flip member (Map.filter (cname ==) (eMap $ codeSpec g)) . 
-        codeName)
+      filt = filter (flip member (eMap $ codeSpec g) . codeName)
+      includedConstants :: (CodeIdea c) => ConstantStructure -> [c] -> [c]
+      includedConstants WithInputs = filt
+      includedConstants _ = id
       methods :: (ProgramSym repr) => InputModule -> 
         Reader DrasilState [MS (repr (Method repr))]
       methods Separated = return []
@@ -194,7 +196,7 @@ genInputClass = do
         c <- publicClass icDesc cname Nothing (inputVars ++ constVars) 
           (methods $ inMod g)
         return $ Just c
-  genClass (filt ins) (filt cs)
+  genClass (filt ins) (includedConstants (conStruct g) cs)
 
 genInputConstructor :: (ProgramSym repr) => Reader DrasilState 
   (Maybe (MS (repr (Method repr))))

--- a/code/drasil-code/Language/Drasil/Code/Imperative/Modules.hs
+++ b/code/drasil-code/Language/Drasil/Code/Imperative/Modules.hs
@@ -1,6 +1,7 @@
 module Language.Drasil.Code.Imperative.Modules (
-  genMain, genMainFunc, chooseInModule, genInputClass, genConstMod, 
-  genConstClass, genOutputMod, genOutputFormat, genSampleInput
+  genMain, genMainFunc, chooseInModule, genInputClass, genInputDerived, 
+  genInputConstraints, genInputFormat, genConstMod, genConstClass, genOutputMod,
+  genOutputFormat, genSampleInput
 ) where
 
 import Language.Drasil
@@ -175,8 +176,8 @@ genInputClass = withReader (\s -> s {currentClass = cname}) $ do
       filt :: (CodeIdea c) => [c] -> [c]
       filt = filter (flip member (eMap $ codeSpec g) . codeName)
       includedConstants :: (CodeIdea c) => ConstantStructure -> [c] -> [c]
-      includedConstants WithInputs = filt
-      includedConstants _ = id
+      includedConstants WithInputs cs' = filt cs'
+      includedConstants _ _ = []
       methods :: (ProgramSym repr) => InputModule -> 
         Reader DrasilState [MS (repr (Method repr))]
       methods Separated = return []
@@ -400,8 +401,8 @@ genConstClass = withReader (\s -> s {currentClass = cname}) $ do
         cDesc <- constClassDesc
         cls <- publicClass cDesc cname Nothing constVars (return [])
         return $ Just cls
-  genClass $ filter (flip member (Map.filter (cname ==) (eMap $ codeSpec g)) . 
-    codeName) cs
+  genClass $ filter (flip member (Map.filter (cname ==) (clsMap $ codeSpec g)) 
+    . codeName) cs
   where cname = "Constants"
 
 ----- OUTPUT -------

--- a/code/drasil-code/Language/Drasil/Code/Imperative/Modules.hs
+++ b/code/drasil-code/Language/Drasil/Code/Imperative/Modules.hs
@@ -19,7 +19,7 @@ import Language.Drasil.Code.Imperative.Logging (maybeLog, varLogFile)
 import Language.Drasil.Code.Imperative.Parameters (getConstraintParams, 
   getDerivedIns, getDerivedOuts, getInConstructorParams, getInputFormatIns, 
   getInputFormatOuts, getOutputParams)
-import Language.Drasil.Code.Imperative.DrasilState (DrasilState(..))
+import Language.Drasil.Code.Imperative.DrasilState (DrasilState(..), inMod)
 import Language.Drasil.Code.Imperative.GOOL.Symantics (AuxiliarySym(..))
 import Language.Drasil.Chunk.Code (CodeIdea(codeName, codeChunk), CodeChunk, 
   codeType, codevar, physLookup, sfwrLookup)

--- a/code/drasil-code/Language/Drasil/Code/Imperative/Modules.hs
+++ b/code/drasil-code/Language/Drasil/Code/Imperative/Modules.hs
@@ -43,7 +43,7 @@ import GOOL.Drasil (ProgramSym, FileSym(..), BodySym(..), BlockSym(..),
 
 import Prelude hiding (print)
 import Data.List (intersperse, intercalate, partition)
-import Data.Map (member, findWithDefault)
+import Data.Map ((!), member)
 import qualified Data.Map as Map (lookup, filter)
 import Data.Maybe (maybeToList, catMaybes)
 import Control.Applicative ((<$>))
@@ -88,7 +88,7 @@ getInputDecl = do
         vars <- mapM mkVar ins
         return $ Just $ multi $ map varDec vars
       getDecl ((i:_),[]) = return $ Just $ (if currentModule g == 
-        findWithDefault "" (codeName i) (eMap $ codeSpec g) then objDecNew 
+        eMap (codeSpec g) ! codeName i then objDecNew 
         else extObjDecNew cname) v_params cps
       getDecl _ = error ("Inputs or constants are only partially contained in " 
         ++ "a class")
@@ -116,8 +116,9 @@ initConsts = do
         return $ Just $ multi $ zipWith (defFunc $ conRepr g) vars vals ++ 
           concat logs
       getDecl _ _ = error "Only some constants present in export map"
-      constCont c Var = Just $ (if currentModule g == findWithDefault "" 
-        (codeName c) (eMap $ codeSpec g) then objDecNewNoParams else extObjDecNewNoParams cname) v_consts
+      constCont c Var = Just $ (if currentModule g == eMap (codeSpec g) ! 
+        codeName c then objDecNewNoParams else extObjDecNewNoParams cname) 
+        v_consts
       constCont _ Const = Nothing
       defFunc Var = varDecDef
       defFunc Const = constDecDef

--- a/code/drasil-code/Language/Drasil/Code/Imperative/Modules.hs
+++ b/code/drasil-code/Language/Drasil/Code/Imperative/Modules.hs
@@ -106,8 +106,8 @@ initConsts = do
   v_consts <- mkVar (codevar consts)
   let cname = "Constants"
       getDecl _ Inline = return Nothing
-      getDecl _ WithInputs = return Nothing
       getDecl ([],[]) _ = return Nothing
+      getDecl (_,[]) WithInputs = return Nothing
       getDecl (c:_,[]) _ = asks (constCont c . conRepr)
       getDecl ([],cs) _ = do 
         vars <- mapM mkVar cs

--- a/code/drasil-code/Language/Drasil/Code/Imperative/Modules.hs
+++ b/code/drasil-code/Language/Drasil/Code/Imperative/Modules.hs
@@ -1,5 +1,6 @@
 module Language.Drasil.Code.Imperative.Modules (
-  genMain, chooseInModule, genConstMod, genOutputMod, genSampleInput
+  genMain, genMainFunc, chooseInModule, genInputClass, genConstMod, 
+  genConstClass, genOutputMod, genOutputFormat, genSampleInput
 ) where
 
 import Language.Drasil

--- a/code/drasil-code/Language/Drasil/Code/Imperative/Parameters.hs
+++ b/code/drasil-code/Language/Drasil/Code/Imperative/Parameters.hs
@@ -28,7 +28,7 @@ getInConstructorParams = do
   let getCParams False = []
       getCParams True = [codevar inFileName]
   getParams In $ getCParams $ member "InputParameters" (eMap $ codeSpec g) && 
-    member "get_input" (defMap $ codeSpec g)
+    member "get_input" (clsMap $ codeSpec g)
 
 getInputFormatIns :: Reader DrasilState [CodeChunk]
 getInputFormatIns = do
@@ -97,9 +97,8 @@ getInputVars _ _ _ [] = return []
 getInputVars _ Unbundled _ cs = return cs
 getInputVars pt Bundled Var _ = do
   g <- ask
-  let mname = "InputParameters"
-  return [codevar inParams | not (currentModule g == mname && member mname 
-    (eMap $ codeSpec g)) && isIn pt]
+  let cname = "InputParameters"
+  return [codevar inParams | currentClass g /= cname && isIn pt]
 getInputVars _ Bundled Const _ = return []
 
 getConstVars :: ParamType -> ConstantStructure -> ConstantRepr -> [CodeChunk] 

--- a/code/drasil-code/Language/Drasil/Code/Imperative/Parameters.hs
+++ b/code/drasil-code/Language/Drasil/Code/Imperative/Parameters.hs
@@ -4,7 +4,7 @@ module Language.Drasil.Code.Imperative.Parameters(getInConstructorParams,
 ) where
 
 import Language.Drasil 
-import Language.Drasil.Code.Imperative.State (DrasilState(..))
+import Language.Drasil.Code.Imperative.DrasilState (DrasilState(..))
 import Language.Drasil.Chunk.Code (CodeChunk, CodeIdea(codeChunk), codevar)
 import Language.Drasil.Chunk.CodeDefinition (CodeDefinition, codeEquat)
 import Language.Drasil.Code.CodeQuantityDicts (inFileName, inParams, consts)

--- a/code/drasil-code/Language/Drasil/Code/Imperative/Parameters.hs
+++ b/code/drasil-code/Language/Drasil/Code/Imperative/Parameters.hs
@@ -4,7 +4,7 @@ module Language.Drasil.Code.Imperative.Parameters(getInConstructorParams,
 ) where
 
 import Language.Drasil 
-import Language.Drasil.Code.Imperative.DrasilState (DrasilState(..))
+import Language.Drasil.Code.Imperative.DrasilState (DrasilState(..), inMod)
 import Language.Drasil.Chunk.Code (CodeChunk, CodeIdea(codeChunk), codevar)
 import Language.Drasil.Chunk.CodeDefinition (CodeDefinition, codeEquat)
 import Language.Drasil.Code.CodeQuantityDicts (inFileName, inParams, consts)

--- a/code/drasil-code/Language/Drasil/CodeSpec.hs
+++ b/code/drasil-code/Language/Drasil/CodeSpec.hs
@@ -9,8 +9,8 @@ import Language.Drasil.Development (dep, names', namesRI)
 import Theory.Drasil (DataDefinition, qdFromDD)
 
 import Language.Drasil.Chunk.Code (CodeChunk, CodeIdea(codeChunk), 
-  ConstraintMap, codevar, quantvar, quantfunc, funcPrefix, codeName,
-  constraintMap)
+  ConstraintMap, programName, codevar, quantvar, quantfunc, funcPrefix, 
+  codeName, constraintMap)
 import Language.Drasil.Chunk.CodeDefinition (CodeDefinition, qtov, qtoc, 
   codeEquat)
 import Language.Drasil.Chunk.CodeQuantity (HasCodeType(ctyp))
@@ -56,8 +56,8 @@ data CodeSystInfo where
   } -> CodeSystInfo
 
 data CodeSpec where
-  CodeSpec :: CommonIdea a => {
-  program :: a,
+  CodeSpec :: {
+  pName :: Name,
   relations :: [Def],
   fMap :: FunctionMap,
   vMap :: VarMap,
@@ -113,7 +113,7 @@ codeSpec SI {_sys = sys
         smplData = sd
       }
   in  CodeSpec {
-        program = sys,
+        pName = programName sys,
         relations = rels,
         fMap = assocToMap rels,
         vMap = assocToMap (map quantvar q ++ getAdditionalVars chs (mods csi')),

--- a/code/drasil-code/Language/Drasil/CodeSpec.hs
+++ b/code/drasil-code/Language/Drasil/CodeSpec.hs
@@ -125,6 +125,7 @@ codeSpec SI {_sys = sys
 
 data Choices = Choices {
   lang :: [Lang],
+  modularity :: Modularity,
   impType :: ImplementationType,
   logFile :: String,
   logging :: Logging,
@@ -140,6 +141,8 @@ data Choices = Choices {
   conceptMatch :: ConceptMatchMap,
   auxFiles :: [AuxFile]
 }
+
+data Modularity = Modular | Unmodular
 
 data ImplementationType = Library
                         | Program
@@ -184,6 +187,7 @@ data Visibility = Show
 defaultChoices :: Choices
 defaultChoices = Choices {
   lang = [Python],
+  modularity = Modular,
   impType = Program,
   logFile = "log.txt",
   logging = LogNone,

--- a/code/drasil-code/Language/Drasil/CodeSpec.hs
+++ b/code/drasil-code/Language/Drasil/CodeSpec.hs
@@ -137,12 +137,11 @@ data Choices = Choices {
   inputStructure :: Structure,
   constStructure :: ConstantStructure,
   constRepr :: ConstantRepr,
-  inputModule :: InputModule,
   conceptMatch :: ConceptMatchMap,
   auxFiles :: [AuxFile]
 }
 
-data Modularity = Modular | Unmodular
+data Modularity = Modular InputModule | Unmodular
 
 data ImplementationType = Library
                         | Program
@@ -184,10 +183,15 @@ data AuxFile = SampleInput deriving Eq
 data Visibility = Show
                 | Hide
 
+inputModule :: Choices -> InputModule
+inputModule c = inputModule' $ modularity c
+  where inputModule' Unmodular = Combined
+        inputModule' (Modular im) = im
+
 defaultChoices :: Choices
 defaultChoices = Choices {
   lang = [Python],
-  modularity = Modular,
+  modularity = Modular Combined,
   impType = Program,
   logFile = "log.txt",
   logging = LogNone,
@@ -199,7 +203,6 @@ defaultChoices = Choices {
   inputStructure = Bundled,
   constStructure = Inline,
   constRepr = Const,
-  inputModule = Combined,
   conceptMatch = matchConcepts ([] :: [QDefinition]) [],
   auxFiles = [SampleInput]
 }

--- a/code/drasil-code/Language/Drasil/CodeSpec.hs
+++ b/code/drasil-code/Language/Drasil/CodeSpec.hs
@@ -413,7 +413,7 @@ getDefInput :: Name -> Choices -> [Input] -> [ModDef]
 getDefInput _ _ [] = []
 getDefInput prn chs ins = inExp (modularity chs) (inputStructure chs) 
   where inExp _ Unbundled = []
-        inExp Unmodular _ = (ipName, prn) : inVarDefs prn
+        inExp Unmodular Bundled = (ipName, prn) : inVarDefs prn
         inExp (Modular Separated) Bundled = inVarDefs ipName
         inExp (Modular Combined) Bundled = (ipName , ipName) : inVarDefs ipName
         inVarDefs n = map codeName ins `zip` repeat n

--- a/code/drasil-code/drasil-code.cabal
+++ b/code/drasil-code/drasil-code.cabal
@@ -39,7 +39,7 @@ library
     , Language.Drasil.Code.Imperative.Logging
     , Language.Drasil.Code.Imperative.Modules
     , Language.Drasil.Code.Imperative.Parameters
-    , Language.Drasil.Code.Imperative.State
+    , Language.Drasil.Code.Imperative.DrasilState
     , Language.Drasil.Code.CodeGeneration
     , Language.Drasil.CodeSpec
 

--- a/code/drasil-example/Drasil/GamePhysics/Main.hs
+++ b/code/drasil-example/Drasil/GamePhysics/Main.hs
@@ -3,8 +3,9 @@ module Main where
 -- import Language.Drasil (QDefinition)
 -- import Language.Drasil.Code (Choices(..), CodeSpec, codeSpec, Comments(..), 
 --   Verbosity(..), ConstraintBehaviour(..), ImplementationType(..), Lang(..), 
---   Logging(..), Structure(..), ConstantStructure(..), ConstantRepr(..), 
---   InputModule(..), matchConcepts, AuxFile(..), Visibility(..))
+--   Logging(..), Modularity(..), Structure(..), ConstantStructure(..), 
+--   ConstantRepr(..), InputModule(..), matchConcepts, AuxFile(..), 
+--   Visibility(..))
 import Language.Drasil.Generate (gen)
 import Language.Drasil.Printers (DocType(SRS, Website), DocSpec(DocSpec))
 
@@ -16,6 +17,7 @@ import Drasil.GamePhysics.Body (srs, printSetting) -- sysInfo
 -- choices :: Choices
 -- choices = Choices {
 --   lang             = [Python, Cpp, CSharp, Java],
+--   modularity       = Modular,
 --   impType          = Library,
 --   logFile          = "log.txt",
 --   logging          = LogNone,

--- a/code/drasil-example/Drasil/GamePhysics/Main.hs
+++ b/code/drasil-example/Drasil/GamePhysics/Main.hs
@@ -17,7 +17,7 @@ import Drasil.GamePhysics.Body (srs, printSetting) -- sysInfo
 -- choices :: Choices
 -- choices = Choices {
 --   lang             = [Python, Cpp, CSharp, Java],
---   modularity       = Modular,
+--   modularity       = Modular Combined,
 --   impType          = Library,
 --   logFile          = "log.txt",
 --   logging          = LogNone,
@@ -29,7 +29,6 @@ import Drasil.GamePhysics.Body (srs, printSetting) -- sysInfo
 --   inputStructure   = Unbundled,
 --   constStructure   = Inline,
 --   constRepr        = Const,
---   inputModule      = Combined,
 --   conceptMatch     = matchConcepts ([] :: [QDefinition]) [],
 --   auxFiles         = [SampleInput]
 -- }       

--- a/code/drasil-example/Drasil/GlassBR/Main.hs
+++ b/code/drasil-example/Drasil/GlassBR/Main.hs
@@ -3,8 +3,8 @@ module Main (main) where
 import Language.Drasil (QDefinition)
 import Language.Drasil.Code (Choices(..), CodeSpec, codeSpec, Comments(..), 
   Verbosity(..), ConstraintBehaviour(..), ImplementationType(..), Lang(..), 
-  Logging(..), Structure(..), ConstantStructure(..), ConstantRepr(..), 
-  InputModule(..), matchConcepts, AuxFile(..), Visibility(..))
+  Logging(..), Modularity(..), Structure(..), ConstantStructure(..), 
+  ConstantRepr(..), InputModule(..), matchConcepts, AuxFile(..), Visibility(..))
 import Language.Drasil.Generate (gen, genCode)
 import Language.Drasil.Printers (DocSpec(DocSpec), DocType(SRS, Website))
 
@@ -17,6 +17,7 @@ code = codeSpec si choices allMods
 choices :: Choices
 choices = Choices {
   lang = [Python, Cpp, CSharp, Java],
+  modularity = Modular,
   impType = Program,
   logFile = "log.txt",
   logging = LogAll,

--- a/code/drasil-example/Drasil/GlassBR/Main.hs
+++ b/code/drasil-example/Drasil/GlassBR/Main.hs
@@ -17,7 +17,7 @@ code = codeSpec si choices allMods
 choices :: Choices
 choices = Choices {
   lang = [Python, Cpp, CSharp, Java],
-  modularity = Modular,
+  modularity = Modular Separated,
   impType = Program,
   logFile = "log.txt",
   logging = LogAll,
@@ -29,7 +29,6 @@ choices = Choices {
   inputStructure = Bundled,
   constStructure = Inline,
   constRepr = Const,
-  inputModule = Separated,
   conceptMatch = matchConcepts ([] :: [QDefinition]) [],
   auxFiles = [SampleInput] 
 }

--- a/code/drasil-example/Drasil/HGHC/Main.hs
+++ b/code/drasil-example/Drasil/HGHC/Main.hs
@@ -18,7 +18,7 @@ import Drasil.HGHC.Body (srs, printSetting) --thisSI
 thisChoices :: Choices
 thisChoices = Choices {
   lang             = [Python, Cpp, CSharp, Java],
-  modularity       = Modular,
+  modularity       = Modular Combined,
   impType          = Program,
   logFile          = "log.txt",
   logging          = LogNone,
@@ -30,7 +30,6 @@ thisChoices = Choices {
   inputStructure   = Bundled,
   constStructure   = Inline,
   constRepr        = Const,
-  inputModule      = Combined,
   conceptMatch     = matchConcepts ([] :: [QDefinition]) [],
   auxFiles         = [SampleInput] 
 } -}

--- a/code/drasil-example/Drasil/HGHC/Main.hs
+++ b/code/drasil-example/Drasil/HGHC/Main.hs
@@ -3,8 +3,9 @@ module Main (main) where
 -- import Language.Drasil (QDefinition)
 -- import Language.Drasil.Code (Choices(..), CodeSpec, codeSpec, Comments(..), 
 --   Verbosity(..), ConstraintBehaviour(..), ImplementationType(..), Lang(..), 
---   Logging(..), Structure(..), ConstantStructure(..), ConstantRepr(..), 
---   InputModule(..), matchConcepts, AuxFile(..), Visibility(..))
+--   Logging(..), Modularity(..), Structure(..), ConstantStructure(..), 
+--   ConstantRepr(..), InputModule(..), matchConcepts, AuxFile(..), 
+--   Visibility(..))
 import Language.Drasil.Generate (gen)
 import Language.Drasil.Printers (DocType(SRS, Website), DocSpec(DocSpec))
 
@@ -17,6 +18,7 @@ import Drasil.HGHC.Body (srs, printSetting) --thisSI
 thisChoices :: Choices
 thisChoices = Choices {
   lang             = [Python, Cpp, CSharp, Java],
+  modularity       = Modular,
   impType          = Program,
   logFile          = "log.txt",
   logging          = LogNone,

--- a/code/drasil-example/Drasil/NoPCM/Main.hs
+++ b/code/drasil-example/Drasil/NoPCM/Main.hs
@@ -3,8 +3,8 @@ module Main (main) where
 import Language.Drasil (QDefinition)
 import Language.Drasil.Code (Choices(..), CodeSpec, codeSpec, Comments(..),
   Verbosity(..), ConstraintBehaviour(..), ImplementationType(..), Lang(..), 
-  Logging(..), Structure(..), ConstantStructure(..), ConstantRepr(..), 
-  InputModule(..), matchConcepts, AuxFile(..), Visibility(..))
+  Logging(..), Modularity(..), Structure(..), ConstantStructure(..), 
+  ConstantRepr(..), InputModule(..), matchConcepts, AuxFile(..), Visibility(..))
 import Language.Drasil.Generate (gen, genCode)
 import Language.Drasil.Printers (DocType(SRS, Website), DocSpec(DocSpec))
 
@@ -17,6 +17,7 @@ code = codeSpec si choices []
 choices :: Choices
 choices = Choices {
   lang = [Python, Cpp, CSharp, Java],
+  modularity = Modular,
   impType = Program,
   logFile = "log.txt",
   logging = LogNone,

--- a/code/drasil-example/Drasil/NoPCM/Main.hs
+++ b/code/drasil-example/Drasil/NoPCM/Main.hs
@@ -17,7 +17,7 @@ code = codeSpec si choices []
 choices :: Choices
 choices = Choices {
   lang = [Python, Cpp, CSharp, Java],
-  modularity = Modular,
+  modularity = Modular Combined,
   impType = Program,
   logFile = "log.txt",
   logging = LogNone,
@@ -29,7 +29,6 @@ choices = Choices {
   inputStructure = Unbundled,
   constStructure = Store Bundled,
   constRepr = Const,
-  inputModule = Combined,
   conceptMatch = matchConcepts ([] :: [QDefinition]) [],
   auxFiles = [SampleInput]
 }       

--- a/code/drasil-example/Drasil/Projectile/Main.hs
+++ b/code/drasil-example/Drasil/Projectile/Main.hs
@@ -18,7 +18,7 @@ code = codeSpec si choices []
 choices :: Choices
 choices = Choices {
   lang = [Python, Cpp, CSharp, Java],
-  modularity = Modular,
+  modularity = Modular Combined,
   impType = Program,
   logFile = "log.txt",
   logging = LogNone,
@@ -30,7 +30,6 @@ choices = Choices {
   inputStructure = Bundled,
   constStructure = Store Unbundled,
   constRepr = Var,
-  inputModule = Combined,
   conceptMatch = matchConcepts [piConst] [[Pi]],
   auxFiles = [SampleInput]
 }

--- a/code/drasil-example/Drasil/Projectile/Main.hs
+++ b/code/drasil-example/Drasil/Projectile/Main.hs
@@ -2,9 +2,9 @@ module Main (main) where
 
 import Language.Drasil.Code (Choices(..), CodeSpec, Comments(..), 
   Verbosity(..), ConstraintBehaviour(..), ImplementationType(..), Lang(..), 
-  Logging(..), Structure(..), ConstantStructure(..), ConstantRepr(..), 
-  InputModule(..), CodeConcept(..), matchConcepts, AuxFile(..), Visibility(..), 
-  codeSpec)
+  Logging(..), Modularity(..), Structure(..), ConstantStructure(..), 
+  ConstantRepr(..), InputModule(..), CodeConcept(..), matchConcepts, 
+  AuxFile(..), Visibility(..), codeSpec)
 import Language.Drasil.Generate (gen, genCode)
 import Language.Drasil.Printers (DocSpec(DocSpec), DocType(SRS, Website))
 
@@ -18,6 +18,7 @@ code = codeSpec si choices []
 choices :: Choices
 choices = Choices {
   lang = [Python, Cpp, CSharp, Java],
+  modularity = Modular,
   impType = Program,
   logFile = "log.txt",
   logging = LogNone,

--- a/code/drasil-example/Drasil/SSP/Main.hs
+++ b/code/drasil-example/Drasil/SSP/Main.hs
@@ -17,7 +17,7 @@ import Drasil.SSP.Body (srs, printSetting) -- si
 -- choices :: Choices
 -- choices = Choices {
 --   lang = [Python, Cpp, CSharp, Java],
---   modularity = Modular,
+--   modularity = Modular Combined,
 --   impType = Program,
 --   logFile = "log.txt",
 --   logging = LogNone,         -- LogNone, LogFunc
@@ -29,7 +29,6 @@ import Drasil.SSP.Body (srs, printSetting) -- si
 --   inputStructure = Unbundled,    -- Unbundled, Bundled
 --   constStructure = Inline,   -- Inline, WithInputs, Store Structure
 --   constRepr = Const,    -- Var, Const
---   inputModule = Combined,    -- Combined, Separated
 --   conceptMatch = matchConcepts ([] :: [QDefinition]) [],
 --   auxFiles = [SampleInput]
 -- }

--- a/code/drasil-example/Drasil/SSP/Main.hs
+++ b/code/drasil-example/Drasil/SSP/Main.hs
@@ -3,8 +3,9 @@ module Main (main) where
 -- import Language.Drasil (QDefinition)
 -- import Language.Drasil.Code (Choices(..), CodeSpec, codeSpec, Comments(..), 
 --   Verbosity(..), ConstraintBehaviour(..), ImplementationType(..), Lang(..), 
---   Logging(..), Structure(..), ConstantStructure(..), ConstantRepr(..), 
---   InputModule(..), matchConcepts, AuxFile(..), Visibility(..))
+--   Logging(..), Modularity(..), Structure(..), ConstantStructure(..), 
+--   ConstantRepr(..), InputModule(..), matchConcepts, AuxFile(..), 
+--   Visibility(..))
 import Language.Drasil.Generate (gen)
 import Language.Drasil.Printers (DocType(SRS, Website), DocSpec(DocSpec))
 
@@ -16,6 +17,7 @@ import Drasil.SSP.Body (srs, printSetting) -- si
 -- choices :: Choices
 -- choices = Choices {
 --   lang = [Python, Cpp, CSharp, Java],
+--   modularity = Modular,
 --   impType = Program,
 --   logFile = "log.txt",
 --   logging = LogNone,         -- LogNone, LogFunc

--- a/code/drasil-example/Drasil/SWHS/Generate.hs
+++ b/code/drasil-example/Drasil/SWHS/Generate.hs
@@ -17,7 +17,7 @@ import Drasil.SWHS.Body (srs, printSetting) -- si
 -- choices :: Choices
 -- choices = Choices {
 --   lang = [Python, Cpp, CSharp, Java],
---   modularity = Modular,
+--   modularity = Modular Combined,
 --   impType = Program,
 --   logFile = "log.txt",
 --   logging = LogNone,         -- LogNone, LogFunc
@@ -29,7 +29,6 @@ import Drasil.SWHS.Body (srs, printSetting) -- si
 --   inputStructure = Unbundled,    -- Unbundled, Bundled
 --   constStructure = Inline,   -- Inline, WithInputs, Store Structure
 --   constRepr = Const,      -- Var, Const
---   inputModule = Combined,    -- Combined, Separated
 --   conceptMatch = matchConcepts ([] :: [QDefinition]) [],
 --   auxFiles = [SampleInput]
 -- }

--- a/code/drasil-example/Drasil/SWHS/Generate.hs
+++ b/code/drasil-example/Drasil/SWHS/Generate.hs
@@ -3,8 +3,9 @@ module Drasil.SWHS.Generate (generate) where
 -- import Language.Drasil (QDefinition)
 -- import Language.Drasil.Code (Choices(..), CodeSpec, codeSpec, Comments(..), 
 --   Verbosity(..), ConstraintBehaviour(..), ImplementationType(..), Lang(..),  
---   Logging(..), Structure(..), ConstantStructure(..), ConstantRepr(..), 
---   InputModule(..), matchConcepts, AuxFile(..), Visibility(..))
+--   Logging(..), Modularity(..), Structure(..), ConstantStructure(..), 
+--   ConstantRepr(..), InputModule(..), matchConcepts, AuxFile(..), 
+--   Visibility(..))
 import Language.Drasil.Generate (gen)
 import Language.Drasil.Printers (DocType(SRS, Website), DocSpec(DocSpec))
 
@@ -16,6 +17,7 @@ import Drasil.SWHS.Body (srs, printSetting) -- si
 -- choices :: Choices
 -- choices = Choices {
 --   lang = [Python, Cpp, CSharp, Java],
+--   modularity = Modular,
 --   impType = Program,
 --   logFile = "log.txt",
 --   logging = LogNone,         -- LogNone, LogFunc

--- a/code/drasil-gool/GOOL/Drasil/Data.hs
+++ b/code/drasil-gool/GOOL/Drasil/Data.hs
@@ -1,5 +1,5 @@
 module GOOL.Drasil.Data (Pair(..), Terminator(..), ScopeTag(..), FileType(..), 
-  Exception(..), exception, stdExc, BindData(..), bd, FileData(..), 
+  isSource, Exception(..), exception, stdExc, BindData(..), bd, FileData(..), 
   fileD, updateFileMod, FuncData(..), fd, ModData(..), md, updateModDoc, 
   MethodData(..), mthd, updateMthdDoc, OpData(..), od, ParamData(..), pd, 
   paramName, updateParamDoc, ProgData(..), progD, emptyProg, StateVarData(..), 
@@ -22,6 +22,10 @@ data Terminator = Semi | Empty
 data ScopeTag = Pub | Priv deriving Eq
 
 data FileType = Combined | Source | Header deriving Eq
+
+isSource :: FileType -> Bool
+isSource Header = False
+isSource _ = True
 
 data Binding = Static | Dynamic deriving Eq
 

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer/CSharpRenderer.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer/CSharpRenderer.hs
@@ -69,7 +69,7 @@ import GOOL.Drasil.Helpers (toCode, toState, onCodeValue, onStateValue,
   on2CodeValues, on2StateValues, on3CodeValues, on3StateValues, onCodeList, 
   onStateList, on1CodeValue1List)
 import GOOL.Drasil.State (MS, VS, lensGStoFS, lensMStoVS, modifyReturn, 
-  addLangImport, addLangImportVS, addLibImport, getClassName, 
+  addLangImport, addLangImportVS, addLibImport, setFileType, getClassName, 
   setCurrMain, setODEDepVars, getODEDepVars)
 
 import Prelude hiding (break,print,(<>),sin,cos,tan,floor)
@@ -105,9 +105,9 @@ instance RenderSym CSharpCode
 
 instance FileSym CSharpCode where
   type RenderFile CSharpCode = FileData
-  fileDoc = G.fileDoc Combined csExt top bottom
+  fileDoc m = modify (setFileType Combined) >> G.fileDoc csExt top bottom m
 
-  docMod = G.docMod
+  docMod = G.docMod csExt
 
   commentedMod cmt m = on2StateValues (on2CodeValues commentedModD) m cmt
 

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer/CSharpRenderer.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer/CSharpRenderer.hs
@@ -578,6 +578,7 @@ instance ScopeSym CSharpCode where
 
 instance InternalScope CSharpCode where
   scopeDoc = unCSC
+  scopeFromData _ = toCode
 
 instance MethodTypeSym CSharpCode where
   type MethodType CSharpCode = TypeData
@@ -648,7 +649,7 @@ instance ClassSym CSharpCode where
   type Class CSharpCode = Doc
   buildClass = G.buildClass classDocD inherit
   enum = G.enum
-  privClass = G.privClass
+  privClass = pubClass
   pubClass = G.pubClass
   implementingClass = G.implementingClass classDocD implements
 

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer/CSharpRenderer.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer/CSharpRenderer.hs
@@ -36,7 +36,7 @@ import qualified GOOL.Drasil.LanguageRenderer.LanguagePolymorphic as G (
   oneLiner, multiBody, block, multiBlock, bool, int, double, char, string, 
   listType, arrayType, listInnerType, obj, enumType, funcType, void, 
   runStrategy, listSlice, notOp, negateOp, equalOp, notEqualOp, greaterOp, 
-  greaterEqualOp, lessOp, lessEqualOp, plusOp, minusOp, multOp, divideOp, 
+  greaterEqualOp, lessOp, lessEqualOp,plusOp, minusOp, multOp, divideOp, 
   moduloOp, andOp, orOp, var, staticVar, extVar, self, enumVar, classVar, 
   objVarSelf, listVar, listOf, arrayElem, iterVar, pi, litTrue, litFalse, 
   litChar, litFloat, litInt, litString, valueOf, arg, enumElement, argsList, 
@@ -47,17 +47,17 @@ import qualified GOOL.Drasil.LanguageRenderer.LanguagePolymorphic as G (
   iterBeginError, iterEndError, listAccessFunc, listSetFunc, printSt, state, 
   loopState, emptyState, assign, assignToListIndex, multiAssignError, decrement,
   increment, decrement1, increment1, varDec, varDecDef, listDec, listDecDef', 
-  arrayDec, arrayDecDef, objDecNew, objDecNewNoParams, constDecDef, 
-  discardInput, openFileR, openFileW, openFileA, closeFile, discardFileLine, 
-  stringListVals, stringListLists, returnState, multiReturnError, valState, 
-  comment, freeError, throw, initState, changeState, initObserverList, 
-  addObserver, ifCond, ifNoElse, switch, switchAsIf, ifExists, for, forRange, 
-  forEach, while, tryCatch, checkState, notifyObservers, construct, param, 
-  method, getMethod, setMethod, privMethod, pubMethod, constructor, docMain, 
-  function, mainFunction, docFunc, docInOutFunc, intFunc, stateVar, stateVarDef,
-  constVar, privMVar, pubMVar, pubGVar, buildClass, enum, privClass, pubClass, 
-  implementingClass, docClass, commentedClass, buildModule', modFromData, 
-  fileDoc, docMod, fileFromData)
+  arrayDec, arrayDecDef, objDecNew, objDecNewNoParams, extObjDecNew, 
+  extObjDecNewNoParams, constDecDef, discardInput, openFileR, openFileW, 
+  openFileA, closeFile, discardFileLine, stringListVals, stringListLists, 
+  returnState, multiReturnError, valState, comment, freeError, throw, initState,
+  changeState, initObserverList, addObserver, ifCond, ifNoElse, switch, 
+  switchAsIf, ifExists, for, forRange, forEach, while, tryCatch, checkState, 
+  notifyObservers, construct, param, method, getMethod, setMethod, privMethod, 
+  pubMethod, constructor, docMain, function, mainFunction, docFunc, 
+  docInOutFunc, intFunc, stateVar, stateVarDef, constVar, privMVar, pubMVar, 
+  pubGVar, buildClass, enum, pubClass, implementingClass, docClass, 
+  commentedClass, buildModule', modFromData, fileDoc, docMod, fileFromData)
 import GOOL.Drasil.LanguageRenderer.LanguagePolymorphic (unOpPrec, unExpr, 
   unExpr', typeUnExpr, powerPrec, binExpr, binExpr', typeBinExpr)
 import GOOL.Drasil.Data (Terminator(..), ScopeTag(..), FileType(..), 
@@ -490,9 +490,9 @@ instance StatementSym CSharpCode where
   arrayDecDef = G.arrayDecDef
   objDecDef = varDecDef
   objDecNew = G.objDecNew
-  extObjDecNew _ = objDecNew
+  extObjDecNew = G.extObjDecNew
   objDecNewNoParams = G.objDecNewNoParams
-  extObjDecNewNoParams _ = objDecNewNoParams
+  extObjDecNewNoParams = G.extObjDecNewNoParams
   constDecDef = G.constDecDef
   funcDecDef = csFuncDecDef blockStart blockEnd
 

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer/CppRenderer.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer/CppRenderer.hs
@@ -1658,15 +1658,15 @@ instance InternalClass CppSrcCode where
 
 instance ModuleSym CppSrcCode where
   type Module CppSrcCode = ModData
-  buildModule n = G.buildModule n ((\ds lis libis mis us mn -> vibcat [
-    if mn then empty else importDoc $ mi n,
+  buildModule n ms cs = G.buildModule n ((\ds lis libis mis us mn -> vibcat [
+    if mn && length ms + length cs == 1 then empty else importDoc $ mi n,
     vcat (map ((text "#define" <+>) . text) ds),
     vcat (map (importDoc . li) lis),
     vcat (map (importDoc . mi) (libis ++ mis)),
     vcat (map (\i -> usingNameSpace "std" (Just i) 
       (endStatement :: CppSrcCode (Keyword CppSrcCode))) us)]) 
     <$> getDefines <*> getLangImports <*> getLibImports <*> getModuleImports 
-    <*> getUsing <*> getCurrMain)
+    <*> getUsing <*> getCurrMain) ms cs
     where mi, li :: Label -> CppSrcCode (Import CppSrcCode)
           mi = modImport
           li = langImport

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer/CppRenderer.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer/CppRenderer.hs
@@ -694,6 +694,7 @@ instance (Pair p) => ScopeSym (p CppSrcCode CppHdrCode) where
 
 instance (Pair p) => InternalScope (p CppSrcCode CppHdrCode) where
   scopeDoc s = scopeDoc $ pfst s
+  scopeFromData s d = pair (scopeFromData s d) (scopeFromData s d)
 
 instance (Pair p) => MethodTypeSym (p CppSrcCode CppHdrCode) where
   type MethodType (p CppSrcCode CppHdrCode) = TypeData
@@ -1547,6 +1548,7 @@ instance ScopeSym CppSrcCode where
 
 instance InternalScope CppSrcCode where
   scopeDoc = fst . unCPPSC
+  scopeFromData s d = toCode (d, s)
 
 instance MethodTypeSym CppSrcCode where
   type MethodType CppSrcCode = TypeData
@@ -2157,6 +2159,7 @@ instance ScopeSym CppHdrCode where
 
 instance InternalScope CppHdrCode where
   scopeDoc = fst . unCPPHC
+  scopeFromData s d = toCode (d, s)
 
 instance MethodTypeSym CppHdrCode where
   type MethodType CppHdrCode = TypeData

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer/CppRenderer.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer/CppRenderer.hs
@@ -1666,7 +1666,7 @@ instance ModuleSym CppSrcCode where
     vcat (map (\i -> usingNameSpace "std" (Just i) 
       (endStatement :: CppSrcCode (Keyword CppSrcCode))) us)]) 
     <$> getDefines <*> getLangImports <*> getLibImports <*> getModuleImports 
-    <*> getUsing <*> getCurrMain) ms cs
+    <*> getUsing <*> getCurrMain) (toState empty) ms cs
     where mi, li :: Label -> CppSrcCode (Import CppSrcCode)
           mi = modImport
           li = langImport
@@ -2269,7 +2269,7 @@ instance ModuleSym CppHdrCode where
     vcat (map (\i -> usingNameSpace "std" (Just i) 
       (endStatement :: CppHdrCode (Keyword CppHdrCode))) us)]) 
     <$> getHeaderDefines <*> getHeaderLangImports <*> getHeaderLibImports <*> 
-    getHeaderModImports <*> getHeaderUsing)
+    getHeaderModImports <*> getHeaderUsing) (toState empty)
     where mi, li :: Label -> CppHdrCode (Import CppHdrCode)
           mi = modImport
           li = langImport

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer/CppRenderer.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer/CppRenderer.hs
@@ -48,14 +48,15 @@ import qualified GOOL.Drasil.LanguageRenderer.LanguagePolymorphic as G (
   listAccessFunc', listSetFunc, state, loopState, emptyState, assign, 
   assignToListIndex, multiAssignError, decrement, increment, decrement1, 
   increment1, varDec, varDecDef, listDec, listDecDef, objDecNew, 
-  objDecNewNoParams, constDecDef, funcDecDef, discardInput, discardFileInput, 
-  closeFile, stringListVals, stringListLists, returnState, multiReturnError, 
-  valState, comment, throw, initState, changeState, initObserverList, 
-  addObserver, ifCond, ifNoElse, switch, switchAsIf, for, forRange, while, 
-  tryCatch, notifyObservers, construct, param, method, getMethod, setMethod, 
-  privMethod, pubMethod, constructor, function, docFunc, docInOutFunc, intFunc, 
-  privMVar, pubMVar, pubGVar, privClass, pubClass, docClass, commentedClass, 
-  buildModule, modFromData, fileDoc, docMod, fileFromData)
+  objDecNewNoParams, extObjDecNew, extObjDecNewNoParams, constDecDef, 
+  funcDecDef, discardInput, discardFileInput, closeFile, stringListVals, 
+  stringListLists, returnState, multiReturnError, valState, comment, throw, 
+  initState, changeState, initObserverList, addObserver, ifCond, ifNoElse, 
+  switch, switchAsIf, for, forRange, while, tryCatch, notifyObservers, 
+  construct, param, method, getMethod, setMethod, privMethod, pubMethod, 
+  constructor, function, docFunc, docInOutFunc, intFunc, privMVar, pubMVar, 
+  pubGVar, privClass, pubClass, docClass, commentedClass, buildModule, 
+  modFromData, fileDoc, docMod, fileFromData)
 import GOOL.Drasil.LanguageRenderer.LanguagePolymorphic (unOpPrec, unExpr, 
   unExpr', typeUnExpr, binExpr, binExpr', typeBinExpr)
 import GOOL.Drasil.Data (Pair(..), Terminator(..), ScopeTag(..), 
@@ -77,11 +78,7 @@ import GOOL.Drasil.State (GOOLState, CS, MS, VS, lensGStoFS, lensFStoCS,
   getDefines, addHeaderDefine, getHeaderDefines, addUsing, getUsing, 
   addHeaderUsing, getHeaderUsing, setFileType, setClassName, getClassName, 
   setCurrMain, getCurrMain, getClassMap, setScope, getScope, setCurrMainFunc, 
-  getCurrMainFunc, setODEOthVars, getODEOthVars, setConstructorParams, 
-  getConstructorParams, addSelfAssignment, getSelfAssignments, 
-  setLeftAssignment, getLeftAssignment, setAssignedSelfVar, getAssignedSelfVar, 
-  setRightAssignment, getRightAssignment, addVariableAssigned, 
-  getVariablesAssigned)
+  getCurrMainFunc, setODEOthVars, getODEOthVars)
 
 import Prelude hiding (break,print,(<>),sin,cos,tan,floor,pi,const,log,exp,mod)
 import Control.Lens.Zoom (zoom)
@@ -89,8 +86,9 @@ import Control.Applicative (Applicative)
 import Control.Monad (join)
 import Control.Monad.State (State, modify, runState)
 import qualified Data.Map as Map (lookup)
-import Text.PrettyPrint.HughesPJ (Doc, text, (<>), (<+>), braces, parens, comma,
-  empty, equals, semi, vcat, lbrace, rbrace, quotes, render, colon, isEmpty)
+import Text.PrettyPrint.HughesPJ (Doc, text, (<>), (<+>), hcat, brackets, 
+  braces, parens, comma, empty, equals, semi, vcat, lbrace, rbrace, quotes, 
+  render, colon, isEmpty)
 
 cppHdrExt, cppSrcExt :: String
 cppHdrExt = "hpp"
@@ -1434,9 +1432,9 @@ instance StatementSym CppSrcCode where
     (mapM (zoom lensMStoVS) vals)
   objDecDef = varDecDef
   objDecNew = G.objDecNew
-  extObjDecNew l v vs = modify (addModuleImport l) >> objDecNew v vs
+  extObjDecNew = G.extObjDecNew
   objDecNewNoParams = G.objDecNewNoParams
-  extObjDecNewNoParams l v = modify (addModuleImport l) >> objDecNewNoParams v
+  extObjDecNewNoParams = G.extObjDecNewNoParams
   constDecDef = G.constDecDef
   funcDecDef = G.funcDecDef
 

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer/JavaRenderer.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer/JavaRenderer.hs
@@ -72,10 +72,10 @@ import GOOL.Drasil.State (GOOLState, MS, VS, lensGStoFS, lensFStoVS, lensCStoMS,
   lensMStoFS, lensMStoVS, lensVStoFS, initialState, initialFS, modifyReturn, 
   modifyReturnFunc, addODEFilePaths, addProgNameToPaths, addODEFiles, 
   getODEFiles, addLangImport, addLangImportVS, addExceptionImports, 
-  addLibImport, addLibImports, getModuleName, getClassName, setCurrMain, 
-  setODEDepVars, getODEDepVars, setODEOthVars, getODEOthVars, 
-  setOutputsDeclared, isOutputsDeclared, getExceptions, getMethodExcMap, 
-  addExceptions)
+  addLibImport, addLibImports, getModuleName, setFileType, setClassName, 
+  getClassName, setCurrMain, setODEDepVars, getODEDepVars, setODEOthVars, 
+  getODEOthVars, setOutputsDeclared, isOutputsDeclared, getExceptions, 
+  getMethodExcMap, addExceptions)
 
 import Prelude hiding (break,print,sin,cos,tan,floor,(<>))
 import Control.Lens.Zoom (zoom)
@@ -114,9 +114,9 @@ instance RenderSym JavaCode
 
 instance FileSym JavaCode where
   type RenderFile JavaCode = FileData 
-  fileDoc = G.fileDoc Combined jExt top bottom
+  fileDoc m = modify (setFileType Combined) >> G.fileDoc jExt top bottom m
 
-  docMod = G.docMod
+  docMod = G.docMod jExt
 
   commentedMod cmt m = on2StateValues (on2CodeValues commentedModD) m cmt
 

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer/JavaRenderer.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer/JavaRenderer.hs
@@ -392,10 +392,9 @@ instance ValueExpression JavaCode where
     modify (maybe id addExceptions (Map.lookup (cm ++ "." ++ n) mem))
     G.funcApp n t vs
   selfFuncApp n t vs = do
-    slf <- self :: VS (JavaCode (Variable JavaCode))
+    cm <- zoom lensVStoFS getModuleName
     mem <- getMethodExcMap
-    let tp = getTypeString (variableType slf)
-    modify (maybe id addExceptions (Map.lookup (tp ++ "." ++ n) mem))
+    modify (maybe id addExceptions (Map.lookup (cm ++ "." ++ n) mem))
     G.selfFuncApp self n t vs
   extFuncApp l n t vs = do
     mem <- getMethodExcMap
@@ -614,6 +613,7 @@ instance ScopeSym JavaCode where
 
 instance InternalScope JavaCode where
   scopeDoc = unJC
+  scopeFromData _ = toCode
 
 instance MethodTypeSym JavaCode where
   type MethodType JavaCode = TypeData

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer/JavaRenderer.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer/JavaRenderer.hs
@@ -47,17 +47,17 @@ import qualified GOOL.Drasil.LanguageRenderer.LanguagePolymorphic as G (
   iterEndError, listAccessFunc', printSt, state, loopState, emptyState, assign, 
   assignToListIndex, multiAssignError, decrement, increment, decrement1, 
   increment1, varDec, varDecDef, listDec, arrayDec, arrayDecDef, objDecNew, 
-  objDecNewNoParams, funcDecDef, discardInput, discardFileInput, openFileR, 
-  openFileW, openFileA, closeFile, discardFileLine, stringListVals, 
-  stringListLists, returnState, multiReturnError, valState, comment, freeError, 
-  throw, initState, changeState, initObserverList, addObserver, ifCond, 
-  ifNoElse, switch, switchAsIf, ifExists, for, forRange, forEach, while, 
-  tryCatch, checkState, notifyObservers, construct, param, method, getMethod, 
-  setMethod, privMethod, pubMethod, constructor, docMain, function, 
-  mainFunction, docFunc, intFunc, stateVar, stateVarDef, constVar, privMVar, 
-  pubMVar, pubGVar, buildClass, enum, privClass, pubClass, implementingClass, 
-  docClass, commentedClass, buildModule', modFromData, fileDoc, docMod, 
-  fileFromData)
+  objDecNewNoParams, extObjDecNew, extObjDecNewNoParams, funcDecDef, 
+  discardInput, discardFileInput, openFileR, openFileW, openFileA, closeFile, 
+  discardFileLine, stringListVals, stringListLists, returnState, 
+  multiReturnError, valState, comment, freeError, throw, initState, changeState,
+  initObserverList, addObserver, ifCond, ifNoElse, switch, switchAsIf, ifExists,
+  for, forRange, forEach, while, tryCatch, checkState, notifyObservers, 
+  construct, param, method, getMethod, setMethod, privMethod, pubMethod, 
+  constructor, docMain, function, mainFunction, docFunc, intFunc, stateVar, 
+  stateVarDef, constVar, privMVar, pubMVar, pubGVar, buildClass, enum, 
+  privClass, pubClass, implementingClass, docClass, commentedClass, 
+  buildModule', modFromData, fileDoc, docMod, fileFromData)
 import GOOL.Drasil.LanguageRenderer.LanguagePolymorphic (unOpPrec, unExpr, 
   unExpr', typeUnExpr, powerPrec, binExpr, binExpr', typeBinExpr)
 import GOOL.Drasil.Data (Terminator(..), ScopeTag(..), FileType(..), 
@@ -72,10 +72,10 @@ import GOOL.Drasil.State (GOOLState, MS, VS, lensGStoFS, lensFStoVS, lensCStoMS,
   lensMStoFS, lensMStoVS, lensVStoFS, initialState, initialFS, modifyReturn, 
   modifyReturnFunc, addODEFilePaths, addProgNameToPaths, addODEFiles, 
   getODEFiles, addLangImport, addLangImportVS, addExceptionImports, 
-  addLibImport, addLibImports, getModuleName, setFileType, setClassName, 
-  getClassName, setCurrMain, setODEDepVars, getODEDepVars, setODEOthVars, 
-  getODEOthVars, setOutputsDeclared, isOutputsDeclared, getExceptions, 
-  getMethodExcMap, addExceptions)
+  addLibImport, addLibImports, getModuleName, setFileType, getClassName, 
+  setCurrMain, setODEDepVars, getODEDepVars, setODEOthVars, getODEOthVars, 
+  setOutputsDeclared, isOutputsDeclared, getExceptions, getMethodExcMap, 
+  addExceptions)
 
 import Prelude hiding (break,print,sin,cos,tan,floor,(<>))
 import Control.Lens.Zoom (zoom)
@@ -386,27 +386,24 @@ instance BooleanExpression JavaCode where
   
 instance ValueExpression JavaCode where
   inlineIf = G.inlineIf
-  funcApp n t vs = do
-    cm <- zoom lensVStoFS getModuleName
-    mem <- getMethodExcMap
-    modify (maybe id addExceptions (Map.lookup (cm ++ "." ++ n) mem))
-    G.funcApp n t vs
-  selfFuncApp n t vs = do
-    cm <- zoom lensVStoFS getModuleName
-    mem <- getMethodExcMap
-    modify (maybe id addExceptions (Map.lookup (cm ++ "." ++ n) mem))
-    G.selfFuncApp self n t vs
+  -- Exceptions from function/method calls should already be in the exception 
+  -- map from the CodeInfo pass, but it's possible that one of the higher-level 
+  -- functions implicitly calls these functions in the Java renderer, so we 
+  -- also check here to add the exceptions from the called function to the map
+  funcApp n t vs = addCallExcsCurrMod n >> G.funcApp n t vs
+  selfFuncApp n t vs = addCallExcsCurrMod n >> G.selfFuncApp self n t vs
   extFuncApp l n t vs = do
     mem <- getMethodExcMap
     modify (maybe id addExceptions (Map.lookup (l ++ "." ++ n) mem))
     G.extFuncApp l n t vs
-  newObj ot vs = do
+  newObj ot vs = addConstructorCallExcsCurrMod ot (\t -> G.newObj newObjDocD t
+    vs)
+  extNewObj l ot vs = do
     t <- ot
     mem <- getMethodExcMap
     let tp = getTypeString t
-    modify (maybe id addExceptions (Map.lookup (tp ++ "." ++ tp) mem))
-    G.newObj newObjDocD ot vs
-  extNewObj _ = newObj
+    modify (maybe id addExceptions (Map.lookup (l ++ "." ++ tp) mem))
+    newObj (toState t) vs
 
   lambda = G.lambda jLambda
 
@@ -522,9 +519,9 @@ instance StatementSym JavaCode where
   arrayDecDef = G.arrayDecDef
   objDecDef = varDecDef
   objDecNew = G.objDecNew
-  extObjDecNew _ = objDecNew
+  extObjDecNew = G.extObjDecNew
   objDecNewNoParams = G.objDecNewNoParams
-  extObjDecNewNoParams _ = objDecNewNoParams
+  extObjDecNewNoParams = G.extObjDecNewNoParams
   constDecDef vr' vl' = zoom lensMStoVS $ on2StateValues (\vr vl -> mkSt $ 
     jConstDecDef vr vl) vr' vl'
   funcDecDef = G.funcDecDef
@@ -988,3 +985,19 @@ jDocInOut f s p desc is os bs b = docFuncRepr desc (map fst $ bs ++ is)
   rets (f s p (map snd is) (map snd os) (map snd bs) b)
   where rets = "array containing the following values:" : map fst bs ++ 
           map fst os
+
+addCallExcsCurrMod :: String -> VS ()
+addCallExcsCurrMod n = do
+  cm <- zoom lensVStoFS getModuleName
+  mem <- getMethodExcMap
+  modify (maybe id addExceptions (Map.lookup (cm ++ "." ++ n) mem))
+
+addConstructorCallExcsCurrMod :: (RenderSym repr) => VS (repr (Type repr)) -> 
+  (VS (repr (Type repr)) -> VS (repr (Value repr))) -> VS (repr (Value repr))
+addConstructorCallExcsCurrMod ot f = do
+  t <- ot
+  cm <- zoom lensVStoFS getModuleName
+  mem <- getMethodExcMap
+  let tp = getTypeString t
+  modify (maybe id addExceptions (Map.lookup (cm ++ "." ++ tp) mem))
+  f (toState t)

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer/LanguagePolymorphic.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer/LanguagePolymorphic.hs
@@ -21,17 +21,17 @@ module GOOL.Drasil.LanguageRenderer.LanguagePolymorphic (fileFromData, oneLiner,
   listSetFunc, printSt, state, loopState, emptyState, assign, assignToListIndex,
   multiAssignError, decrement, increment, increment', increment1, increment1', 
   decrement1, varDec, varDecDef, listDec, listDecDef, listDecDef', arrayDec, 
-  arrayDecDef, objDecNew, objDecNewNoParams, constDecDef, funcDecDef, 
-  discardInput, discardFileInput, openFileR, openFileW, openFileA, closeFile, 
-  discardFileLine, stringListVals, stringListLists, returnState, 
-  multiReturnError, valState, comment, freeError, throw, initState, changeState,
-  initObserverList, addObserver, ifCond, ifNoElse, switch, switchAsIf, ifExists,
-  for, forRange, forEach, while, tryCatch, checkState, notifyObservers, 
-  construct, param, method, getMethod, setMethod,privMethod, pubMethod, 
-  constructor, docMain, function, mainFunction, docFunc, docInOutFunc, intFunc, 
-  stateVar, stateVarDef, constVar, privMVar, pubMVar, pubGVar, buildClass, enum,
-  privClass, pubClass, implementingClass, docClass, commentedClass, buildModule,
-  buildModule', modFromData, fileDoc, docMod
+  arrayDecDef, objDecNew, objDecNewNoParams, extObjDecNew, extObjDecNewNoParams,
+  constDecDef, funcDecDef, discardInput, discardFileInput, openFileR, openFileW,
+  openFileA, closeFile, discardFileLine, stringListVals, stringListLists, 
+  returnState, multiReturnError, valState, comment, freeError, throw, initState,
+  changeState, initObserverList, addObserver, ifCond, ifNoElse, switch, 
+  switchAsIf, ifExists, for, forRange, forEach, while, tryCatch, checkState, 
+  notifyObservers, construct, param, method, getMethod, setMethod,privMethod, 
+  pubMethod, constructor, docMain, function, mainFunction, docFunc, 
+  docInOutFunc, intFunc, stateVar, stateVarDef, constVar, privMVar, pubMVar, 
+  pubGVar, buildClass, enum, privClass, pubClass, implementingClass, docClass, 
+  commentedClass, buildModule, buildModule', modFromData, fileDoc, docMod
 ) where
 
 import Utils.Drasil (indent)
@@ -62,15 +62,15 @@ import qualified GOOL.Drasil.Symantics as S (InternalFile(fileFromData),
   TypeSym(bool, int, float, char, string, listType, listInnerType, void), 
   VariableSym(var, self, objVar, objVarSelf, listVar, listOf),
   ValueSym(litTrue, litFalse, litInt, litString, valueOf),
-  ValueExpression(funcApp, newObj, notNull, lambda), Selector(objAccess), 
-  objMethodCall, objMethodCallNoParams, 
+  ValueExpression(funcApp, newObj, extNewObj, notNull, lambda), 
+  Selector(objAccess), objMethodCall, objMethodCallNoParams, 
   FunctionSym(func, listSize, listAdd, listAppend),
   SelectorFunction(listAccess, listSet),
   InternalFunction(getFunc, setFunc, listSizeFunc, listAddFunc, listAppendFunc, 
     listAccessFunc, listSetFunc),
   InternalStatement(state, loopState, emptyState), 
   StatementSym(assign, varDec, varDecDef, listDec, listDecDef, objDecNew, 
-    constDecDef, valState, returnState),
+    extObjDecNew, constDecDef, valState, returnState),
   ControlStatementSym(ifCond, for, forRange, switch), MethodTypeSym(construct), 
   ParameterSym(param), MethodSym(method, mainFunction), InternalMethod(intFunc),
   StateVarSym(stateVar), ClassSym(buildClass, commentedClass), 
@@ -734,6 +734,15 @@ objDecNew v vs = S.varDecDef v (S.newObj (onStateValue variableType v) vs)
 objDecNewNoParams :: (RenderSym repr) => VS (repr (Variable repr)) -> 
   MS (repr (Statement repr))
 objDecNewNoParams v = S.objDecNew v []
+
+extObjDecNew :: (RenderSym repr) => Library -> VS (repr (Variable repr)) -> 
+  [VS (repr (Value repr))] -> MS (repr (Statement repr))
+extObjDecNew l v vs = S.varDecDef v (S.extNewObj l (onStateValue variableType v)
+  vs)
+
+extObjDecNewNoParams :: (RenderSym repr) => Library -> VS (repr (Variable repr))
+  -> MS (repr (Statement repr))
+extObjDecNewNoParams l v = S.extObjDecNew l v []
 
 constDecDef :: (RenderSym repr) => VS (repr (Variable repr)) -> 
   VS (repr (Value repr)) -> MS (repr (Statement repr))

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer/LanguagePolymorphic.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer/LanguagePolymorphic.hs
@@ -1120,11 +1120,12 @@ commentedClass cmt cs = classFromData (on2StateValues (\cmt' cs' ->
 
 -- Modules --
 
-buildModule :: (RenderSym repr) => Label -> FS Doc -> [MS (repr (Method repr))] 
-  -> [CS (repr (Class repr))] -> FS (repr (Module repr))
-buildModule n imps ms cs = S.modFromData n ((\cls fs is -> moduleDocD is 
-  (vibcat (map classDoc cls)) (vibcat (map methodDoc fs))) <$> 
-  mapM (zoom lensFStoCS) cs <*> mapM (zoom lensFStoMS) ms <*> imps)
+buildModule :: (RenderSym repr) => Label -> FS Doc -> FS Doc -> 
+  [MS (repr (Method repr))] -> [CS (repr (Class repr))] -> 
+  FS (repr (Module repr))
+buildModule n imps bot ms cs = S.modFromData n ((\cls fs is bt -> 
+  moduleDocD is (vibcat (map classDoc cls)) (vibcat (map methodDoc fs ++ [bt])))
+  <$> mapM (zoom lensFStoCS) cs <*> mapM (zoom lensFStoMS) ms <*> imps <*> bot)
 
 buildModule' :: (RenderSym repr) => Label -> (String -> repr (Import repr)) -> 
   [MS (repr (Method repr))] -> [CS (repr (Class repr))] -> 

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer/LanguagePolymorphic.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer/LanguagePolymorphic.hs
@@ -75,7 +75,7 @@ import qualified GOOL.Drasil.Symantics as S (InternalFile(fileFromData),
   ParameterSym(param), MethodSym(method, mainFunction), InternalMethod(intFunc),
   StateVarSym(stateVar), ClassSym(buildClass, commentedClass), 
   InternalMod(modFromData))
-import GOOL.Drasil.Data (Binding(..), Terminator(..), isSource)
+import GOOL.Drasil.Data (Binding(..), ScopeTag(..), Terminator(..), isSource)
 import GOOL.Drasil.Helpers (angles, doubleQuotedText, vibcat, emptyIfEmpty, 
   toState, onStateValue, on2StateValues, on3StateValues, onStateList, 
   on2StateLists, on1StateValue1List, getInnerType, convType)
@@ -1093,7 +1093,7 @@ enum n es s = modify (setClassName n) >> classFromData (toState $ enumDocD n
 privClass :: (RenderSym repr) => Label -> Maybe Label -> 
   [CS (repr (StateVar repr))] -> 
   [MS (repr (Method repr))] -> CS (repr (Class repr))
-privClass n p = S.buildClass n p private
+privClass n p = S.buildClass n p (scopeFromData Priv empty)
 
 pubClass :: (RenderSym repr) => Label -> Maybe Label -> 
   [CS (repr (StateVar repr))] -> [MS (repr (Method repr))] -> 

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer/PythonRenderer.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer/PythonRenderer.hs
@@ -64,7 +64,7 @@ import GOOL.Drasil.Helpers (vibcat, emptyIfEmpty, toCode, toState, onCodeValue,
 import GOOL.Drasil.State (MS, VS, lensGStoFS, lensMStoVS, lensVStoMS, 
   addLangImportVS, getLangImports, addLibImport, getLibImports, addModuleImport,
   addModuleImportVS, getModuleImports, setFileType, setClassName, getClassName, 
-  setCurrMain, getClassMap)
+  setCurrMain, getClassMap, setMainDoc, getMainDoc)
 
 import Prelude hiding (break,print,sin,cos,tan,floor,(<>))
 import Data.Maybe (fromMaybe)
@@ -625,7 +625,11 @@ instance MethodSym PythonCode where
   docMain = mainFunction
 
   function = G.function
-  mainFunction b = modify setCurrMain >> onStateValue (onCodeValue mthd) b
+  mainFunction b = do
+    modify setCurrMain
+    bod <- b
+    modify (setMainDoc $ bodyDoc bod)
+    toState $ toCode $ mthd empty
 
   docFunc = G.docFunc
 
@@ -690,7 +694,7 @@ instance ModuleSym PythonCode where
       (langImport :: Label -> PythonCode (Import PythonCode))) libis),
     vcat (map (importDoc . 
       (modImport :: Label -> PythonCode (Import PythonCode))) mis)]) 
-    getLangImports getLibImports getModuleImports)
+    getLangImports getLibImports getModuleImports) getMainDoc
 
 instance InternalMod PythonCode where
   moduleDoc = modDoc . unPC
@@ -888,4 +892,3 @@ pyDocInOut :: (RenderSym repr) => (repr (Scope repr) -> repr (Permanence repr)
   MS (repr (Method repr))
 pyDocInOut f s p desc is os bs b = docFuncRepr desc (map fst $ bs ++ is)
   (map fst $ bs ++ os) (f s p (map snd is) (map snd os) (map snd bs) b)
-  

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer/PythonRenderer.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer/PythonRenderer.hs
@@ -63,8 +63,8 @@ import GOOL.Drasil.Helpers (vibcat, emptyIfEmpty, toCode, toState, onCodeValue,
   onCodeList, onStateList, on2StateLists, on1CodeValue1List, on1StateValue1List)
 import GOOL.Drasil.State (MS, VS, lensGStoFS, lensMStoVS, lensVStoMS, 
   addLangImportVS, getLangImports, addLibImport, getLibImports, addModuleImport,
-  addModuleImportVS, getModuleImports, setClassName, getClassName, setCurrMain, 
-  getClassMap)
+  addModuleImportVS, getModuleImports, setFileType, setClassName, getClassName, 
+  setCurrMain, getClassMap)
 
 import Prelude hiding (break,print,sin,cos,tan,floor,(<>))
 import Data.Maybe (fromMaybe)
@@ -101,9 +101,9 @@ instance RenderSym PythonCode
 
 instance FileSym PythonCode where
   type RenderFile PythonCode = FileData
-  fileDoc = G.fileDoc Combined pyExt top bottom
+  fileDoc m = modify (setFileType Combined) >> G.fileDoc pyExt top bottom m
 
-  docMod = G.docMod
+  docMod = G.docMod pyExt
 
   commentedMod cmt m = on2StateValues (on2CodeValues commentedModD) m cmt
 

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer/PythonRenderer.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer/PythonRenderer.hs
@@ -595,6 +595,7 @@ instance ScopeSym PythonCode where
 
 instance InternalScope PythonCode where
   scopeDoc = unPC
+  scopeFromData _ = toCode
 
 instance MethodTypeSym PythonCode where
   type MethodType PythonCode = TypeData

--- a/code/drasil-gool/GOOL/Drasil/State.hs
+++ b/code/drasil-gool/GOOL/Drasil/State.hs
@@ -4,22 +4,25 @@ module GOOL.Drasil.State (
   GS, GOOLState(..), FS, CS, MS, VS, lensFStoGS, lensGStoFS, lensFStoCS, 
   lensFStoMS, lensFStoVS, lensCStoMS, lensMStoCS, lensCStoVS, lensMStoFS, 
   lensMStoVS, lensVStoFS, lensVStoMS, headers, sources, mainMod, currMain, 
-  initialState, initialFS, modifyReturn, modifyReturnFunc, modifyReturnFunc2, 
-  modifyReturnList, addODEFilePaths, addFile, addCombinedHeaderSource, 
-  addHeader, addSource, addProgNameToPaths, setMainMod, addODEFiles, 
-  getODEFiles, addLangImport, addLangImportVS, addExceptionImports, 
+  currFileType, initialState, initialFS, modifyReturn, modifyReturnFunc, 
+  modifyReturnFunc2, modifyReturnList, addODEFilePaths, addFile, 
+  addCombinedHeaderSource, addHeader, addSource, addProgNameToPaths, setMainMod,
+  addODEFiles, getODEFiles, addLangImport, addLangImportVS, addExceptionImports,
   getLangImports, addLibImport, addLibImports, getLibImports, addModuleImport, 
   addModuleImportVS, getModuleImports, addHeaderLangImport, 
   getHeaderLangImports, addHeaderLibImport, getHeaderLibImports, 
   addHeaderModImport, getHeaderModImports, addDefine, getDefines, 
   addHeaderDefine, getHeaderDefines, addUsing, getUsing, addHeaderUsing, 
-  getHeaderUsing, setFilePath, getFilePath, setModuleName, getModuleName, 
-  setClassName, getClassName, setCurrMain, getCurrMain, addClass, getClasses, 
-  updateClassMap, getClassMap, updateMethodExcMap, getMethodExcMap, 
-  addParameter, getParameters, setODEDepVars, getODEDepVars, setODEOthVars, 
-  getODEOthVars, setOutputsDeclared, isOutputsDeclared, addException, 
-  addExceptions, getExceptions, setScope, getScope, setCurrMainFunc, 
-  getCurrMainFunc
+  getHeaderUsing, setFileType, setModuleName, getModuleName, setClassName, 
+  getClassName, setCurrMain, getCurrMain, addClass, getClasses, updateClassMap, 
+  getClassMap, updateMethodExcMap, getMethodExcMap, addParameter, getParameters,
+  setOutputsDeclared, isOutputsDeclared, addException, addExceptions, 
+  getExceptions, setScope, getScope, setCurrMainFunc, getCurrMainFunc, 
+  setConstructorParams, getConstructorParams, addSelfAssignment, 
+  getSelfAssignments, setODEDepVars, getODEDepVars, setODEOthVars, 
+  getODEOthVars, setLeftAssignment, getLeftAssignment, setAssignedSelfVar, 
+  getAssignedSelfVar, setRightAssignment, getRightAssignment, 
+  addVariableAssigned, getVariablesAssigned
 ) where
 
 import GOOL.Drasil.Data (FileType(..), ScopeTag(..), Exception(..), FileData)
@@ -63,7 +66,7 @@ makeLenses ''ClassState
 
 data FileState = FS {
   _currModName :: String,
-  _currFilePath :: FilePath,
+  _currFileType :: FileType,
   _currMain :: Bool,
   _currClasses :: [String],
   _langImports :: [String],
@@ -232,7 +235,7 @@ initialState = GS {
 initialFS :: FileState
 initialFS = FS {
   _currModName = "",
-  _currFilePath = "",
+  _currFileType = Combined,
   _currMain = False,
   _currClasses = [],
   _langImports = [],
@@ -451,11 +454,8 @@ addHeaderUsing u = over (_1 . _1 . _1 . _2 . headerUsing) (\us ->
 getHeaderUsing :: FS [String]
 getHeaderUsing = gets ((^. headerUsing) . snd)
 
-setFilePath :: FilePath -> (GOOLState, FileState) -> (GOOLState, FileState)
-setFilePath fp = over _2 (set currFilePath fp)
-
-getFilePath :: FS FilePath
-getFilePath = gets ((^. currFilePath) . snd)
+setFileType :: FileType -> (GOOLState, FileState) -> (GOOLState, FileState)
+setFileType ft = over _2 (set currFileType ft)
 
 setModuleName :: String -> (GOOLState, FileState) -> (GOOLState, FileState)
 setModuleName n = over _2 (set currModName n)

--- a/code/drasil-gool/GOOL/Drasil/Symantics.hs
+++ b/code/drasil-gool/GOOL/Drasil/Symantics.hs
@@ -652,6 +652,7 @@ class ScopeSym repr where
 
 class InternalScope repr where
   scopeDoc :: repr (Scope repr) -> Doc
+  scopeFromData :: ScopeTag -> Doc -> repr (Scope repr)
 
 class (TypeSym repr) => MethodTypeSym repr where
   type MethodType repr

--- a/code/drasil-gool/GOOL/Drasil/Symantics.hs
+++ b/code/drasil-gool/GOOL/Drasil/Symantics.hs
@@ -21,7 +21,7 @@ module GOOL.Drasil.Symantics (
 ) where
 
 import GOOL.Drasil.CodeType (CodeType)
-import GOOL.Drasil.Data (Binding, Terminator, FileType, ScopeTag)
+import GOOL.Drasil.Data (Binding, Terminator, ScopeTag)
 import GOOL.Drasil.State (GS, FS, CS, MS, VS)
 
 import Control.Monad.State (State)
@@ -58,8 +58,7 @@ class InternalFile repr where
   top :: repr (Module repr) -> repr (Block repr)
   bottom :: repr (Block repr)
 
-  fileFromData :: FileType -> FS FilePath -> 
-    FS (repr (Module repr)) -> 
+  fileFromData :: FS FilePath -> FS (repr (Module repr)) -> 
     FS (repr (RenderFile repr))
 
 class (PermanenceSym repr) => KeywordSym repr where

--- a/code/stable/glassbr/src/java/GlassBR/Calculations.java
+++ b/code/stable/glassbr/src/java/GlassBR/Calculations.java
@@ -5,6 +5,7 @@ package GlassBR;
     \brief Provides functions for calculating the outputs
 */
 import java.io.File;
+import java.io.FileNotFoundException;
 import java.io.FileWriter;
 import java.io.IOException;
 import java.io.PrintWriter;
@@ -31,7 +32,7 @@ public class Calculations {
         \param inParams structure holding the input values
         \return applied load (demand): 3 second duration equivalent pressure (Pa)
     */
-    public static double func_q(InputParameters inParams) throws Exception, IOException {
+    public static double func_q(InputParameters inParams) throws Exception, FileNotFoundException, IOException {
         PrintWriter outfile;
         outfile = new PrintWriter(new FileWriter(new File("log.txt"), true));
         outfile.println("function func_q called with inputs: {");
@@ -68,7 +69,7 @@ public class Calculations {
         \param J_tol stress distribution factor (Function) based on Pbtol
         \return tolerable load
     */
-    public static double func_q_hat_tol(InputParameters inParams, double J_tol) throws Exception, IOException {
+    public static double func_q_hat_tol(InputParameters inParams, double J_tol) throws Exception, FileNotFoundException, IOException {
         PrintWriter outfile;
         outfile = new PrintWriter(new FileWriter(new File("log.txt"), true));
         outfile.println("function func_q_hat_tol called with inputs: {");
@@ -88,7 +89,7 @@ public class Calculations {
         \param q_hat dimensionless load
         \return stress distribution factor (Function)
     */
-    public static double func_J(InputParameters inParams, double q_hat) throws Exception, IOException {
+    public static double func_J(InputParameters inParams, double q_hat) throws Exception, FileNotFoundException, IOException {
         PrintWriter outfile;
         outfile = new PrintWriter(new FileWriter(new File("log.txt"), true));
         outfile.println("function func_J called with inputs: {");

--- a/code/stable/projectile/src/java/Projectile/Control.java
+++ b/code/stable/projectile/src/java/Projectile/Control.java
@@ -4,6 +4,7 @@ package Projectile;
     \author Samuel J. Crawford, Brooks MacLachlan, and W. Spencer Smith
     \brief Controls the flow of the program
 */
+import java.io.FileNotFoundException;
 import java.io.IOException;
 
 public class Control {
@@ -11,7 +12,7 @@ public class Control {
     /** \brief Controls the flow of the program
         \param args List of command-line arguments
     */
-    public static void main(String[] args) throws IOException {
+    public static void main(String[] args) throws FileNotFoundException, IOException {
         String filename = args[0];
         InputParameters inParams = new InputParameters(filename);
         double g_vect = 9.8;


### PR DESCRIPTION
This small PR just updates the `solveODE` code for C# to not use an object initializer.

#2005 should be merged first. The only new commit is 3c130ef.

Closes #1989.