### PR TITLE
Use HOAS for GOOL's lambdas

### DIFF
--- a/code/drasil-gool/GOOL/Drasil/CodeInfo.hs
+++ b/code/drasil-gool/GOOL/Drasil/CodeInfo.hs
@@ -202,7 +202,7 @@ instance ValueExpression CodeInfo where
     sequence_ vs
     addExternalConstructorCall l ot
 
-  lambda _ = execute1
+  lambda f p = execute1 (f p)
 
   exists = execute1
   notNull = execute1
@@ -269,7 +269,8 @@ instance StatementSym CodeInfo where
   objDecNewNoParams _ = noInfo
   extObjDecNewNoParams _ _ = noInfo
   constDecDef _ = zoom lensMStoVS . execute1
-  funcDecDef _ _ = zoom lensMStoVS . execute1
+  funcDecDef _ f p = zoom lensMStoVS $ execute1 (f p)
+  binFuncDecDef _ f p1 p2 = zoom lensMStoVS $ execute1 (f p1 p2)
 
   print = zoom lensMStoVS . execute1
   printLn = zoom lensMStoVS . execute1

--- a/code/drasil-gool/Test/SimpleODE.hs
+++ b/code/drasil-gool/Test/SimpleODE.hs
@@ -23,7 +23,7 @@ odeIndepVar = var "t" (listType float)
 
 info :: (StatementSym repr) => ODEInfo repr
 info = odeInfo odeIndepVar odeDepVar [odeConst] (litFloat 0.0) (litFloat 10.0) 
-  (litFloat 1.0) (valueOf odeDepVar #+ valueOf odeConst)
+  (litFloat 1.0) (\_ dv -> valueOf dv #+ valueOf odeConst)
 
 opts :: (StatementSym repr) => ODEOptions repr
 opts = odeOptions RK45 (litFloat 0.001) (litFloat 0.001) (litFloat 1.0)


### PR DESCRIPTION
This PR updates GOOL's `lambda` and `funcDecDef` to accept a function as a parameter. The advantage to this approach is that it ensures the variable used as the parameter to the lambda/function matches with the variable used in the body.

I'm not sure how I feel about this change, though. It was tricky to implement, especially in the C++ Pair instance (which is always a headache to deal with). I'm not sure if what I did in the C++ Pair instance to make it work would be considered a hack. The "job" of the Pair instance is to break down each GOOL method to the source version of that method and the header version of that method. This is the first time we've had functions as parameters to GOOL methods. To break a function-type parameter down into a `CppSrcCode` version of the function, I defined a new function taking a parameter with a `CppSrcCode` type that builds a `Pair` from this parameter by forcing it to have `CppHdrCode` type, passes this `Pair` to the original `Pair`-context function-type parameter, then extracts the `CppSrcCode` component from the result. Then similar to get the `CppHdrCode` version. That explanation is probably confusing, so I'll paste the code for the `Pair` instance `lambda` function:
```
lambda f = pair1 
    (lambda (\v -> pfst <$> f (onStateValue (\v' -> pair v' (srcToHdr v')) v))) -- CppSrcCode version of f
    (lambda (\v -> psnd <$> f (onStateValue (\v' -> pair (hdrToSrc v') v') v))) -- CppHdrCode version of f
```

Another possible disadvantage to this approach is that to map to `lambda` or `funcDecDef` from Drasil, the Drasil data will also need to be in the form of a function. For example, when we get to encoding ODEs, the RHS of the ODE will need to be encoded as `(Quantity c) => c -> c -> Expr` or something similar. And even then, I'm having trouble thinking through how we could possibly translate that to `repr (Variable repr) -> repr (Variable repr) -> repr (Value repr)`.

This PR also adds binary versions of `lambda` and `funcDecDef` called `binLambda` and `binFuncDecDef`. I want to draw attention to the differences in how each is implemented. First off, just for background, `lambda` is for generating anonymous functions whereas `funcDecDef` is for generating named local functions (which in some languages is only possible by assigning anonymous functions to variables). `binLambda` is not truly a GOOL method, but more a smart constructor creating nested lambdas. That means what gets generated is a nested lambda. Perhaps we can use `State` to collapse those into a single lambda. `binFuncDecDef`, on the other hand, is implemented as a new GOOL method and is implemented differently per-language. The types would not allow for nested `funcDecDef`s, so I did it this way instead. But based on this comment https://github.com/JacquesCarette/Drasil/commit/7546192bba93065094cc2e61c41b4037e3aa793e#commitcomment-37007396 I think the way I did it for `binLambda` was the preferred way? I just don't think it can be done without changing the types of `funcDecDef`, which would have ripple effects potentially including needing to throw errors in languages that don't support local functions.

If this PR looks like something we want, I'll move on to doing similar for for-loops. But I'm very hesitant about it. I'm putting a question label on this.