### PR TITLE
Add GOOL methods for calling functions with named arguments

### DIFF
--- a/code/drasil-gool/GOOL/Drasil/CodeInfo.hs
+++ b/code/drasil-gool/GOOL/Drasil/CodeInfo.hs
@@ -193,6 +193,8 @@ instance BooleanExpression CodeInfo where
 instance ValueExpression CodeInfo where
   inlineIf = execute3
   funcApp n _ _ = addCurrModCall n
+  funcAppNamedArgs n _ _ = addCurrModCall n
+  funcAppMixedArgs n _ _ _ = addCurrModCall n
   selfFuncApp n _ _ = addCurrModCall n
   extFuncApp l n _ _ = addExternalCall l n
   newObj ot vs = do

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer/CSharpRenderer.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer/CSharpRenderer.hs
@@ -41,23 +41,24 @@ import qualified GOOL.Drasil.LanguageRenderer.LanguagePolymorphic as G (
   objVarSelf, listVar, listOf, arrayElem, iterVar, pi, litTrue, litFalse, 
   litChar, litFloat, litInt, litString, valueOf, arg, enumElement, argsList, 
   inlineIf, objAccess, objMethodCall, objMethodCallNoParams, selfAccess, 
-  listIndexExists, indexOf, funcApp, selfFuncApp, extFuncApp, newObj, lambda, 
-  notNull, func, get, set, listSize, listAdd, listAppend, iterBegin, iterEnd, 
-  listAccess, listSet, getFunc, setFunc, listAddFunc, listAppendFunc, 
-  iterBeginError, iterEndError, listAccessFunc, listSetFunc, printSt, state, 
-  loopState, emptyState, assign, assignToListIndex, multiAssignError, decrement,
-  increment, decrement1, increment1, varDec, varDecDef, listDec, listDecDef', 
-  arrayDec, arrayDecDef, objDecNew, objDecNewNoParams, extObjDecNew, 
-  extObjDecNewNoParams, constDecDef, discardInput, openFileR, openFileW, 
-  openFileA, closeFile, discardFileLine, stringListVals, stringListLists, 
-  returnState, multiReturnError, valState, comment, freeError, throw, initState,
-  changeState, initObserverList, addObserver, ifCond, ifNoElse, switch, 
-  switchAsIf, ifExists, for, forRange, forEach, while, tryCatch, checkState, 
-  notifyObservers, construct, param, method, getMethod, setMethod, privMethod, 
-  pubMethod, constructor, docMain, function, mainFunction, docFunc, 
-  docInOutFunc, intFunc, stateVar, stateVarDef, constVar, privMVar, pubMVar, 
-  pubGVar, buildClass, enum, implementingClass, docClass, commentedClass, 
-  intClass, buildModule', modFromData, fileDoc, docMod, fileFromData)
+  listIndexExists, indexOf, funcApp, funcAppMixedArgs, selfFuncApp, extFuncApp, 
+  newObj, lambda, notNull, func, get, set, listSize, listAdd, listAppend, 
+  iterBegin, iterEnd, listAccess, listSet, getFunc, setFunc, listAddFunc, 
+  listAppendFunc, iterBeginError, iterEndError, listAccessFunc, listSetFunc, 
+  printSt, state, loopState, emptyState, assign, assignToListIndex, 
+  multiAssignError, decrement, increment, decrement1, increment1, varDec, 
+  varDecDef, listDec, listDecDef', arrayDec, arrayDecDef, objDecNew, 
+  objDecNewNoParams, extObjDecNew, extObjDecNewNoParams, constDecDef, 
+  discardInput, openFileR, openFileW, openFileA, closeFile, discardFileLine, 
+  stringListVals, stringListLists, returnState, multiReturnError, valState, 
+  comment, freeError, throw, initState, changeState, initObserverList, 
+  addObserver, ifCond, ifNoElse, switch, switchAsIf, ifExists, for, forRange, 
+  forEach, while, tryCatch, checkState, notifyObservers, construct, param, 
+  method, getMethod, setMethod, privMethod, pubMethod, constructor, docMain, 
+  function, mainFunction, docFunc, docInOutFunc, intFunc, stateVar, 
+  stateVarDef, constVar, privMVar, pubMVar, pubGVar, buildClass, enum, 
+  implementingClass, docClass, commentedClass, intClass, buildModule', 
+  modFromData, fileDoc, docMod, fileFromData)
 import GOOL.Drasil.LanguageRenderer.LanguagePolymorphic (unOpPrec, unExpr, 
   unExpr', typeUnExpr, powerPrec, binExpr, binExpr', typeBinExpr)
 import GOOL.Drasil.Data (Terminator(..), ScopeTag(..), FileType(..), 
@@ -79,7 +80,7 @@ import Control.Monad (join)
 import Control.Monad.State (modify)
 import Data.List (elemIndex, intercalate)
 import Text.PrettyPrint.HughesPJ (Doc, text, (<>), (<+>), ($$), parens, empty,
-  semi, vcat, lbrace, rbrace, colon)
+  semi, vcat, lbrace, rbrace, colon, space)
 
 csExt :: String
 csExt = "cs"
@@ -383,6 +384,8 @@ instance BooleanExpression CSharpCode where
 instance ValueExpression CSharpCode where
   inlineIf = G.inlineIf
   funcApp = G.funcApp
+  funcAppNamedArgs n t = funcAppMixedArgs n t []
+  funcAppMixedArgs = G.funcAppMixedArgs (colon <> space)
   selfFuncApp = G.selfFuncApp self
   extFuncApp = G.extFuncApp
   newObj = G.newObj newObjDocD

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer/JavaRenderer.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer/JavaRenderer.hs
@@ -41,23 +41,24 @@ import qualified GOOL.Drasil.LanguageRenderer.LanguagePolymorphic as G (
   listOf, arrayElem, iterVar, litTrue, litFalse, litChar, litFloat, litInt, 
   litString, pi, valueOf, arg, enumElement, argsList, inlineIf, objAccess, 
   objMethodCall, objMethodCallNoParams, selfAccess, listIndexExists, indexOf, 
-  funcApp, selfFuncApp, extFuncApp, newObj, lambda, notNull, func, get, set, 
-  listSize, listAdd, listAppend, iterBegin, iterEnd, listAccess, listSet, 
-  getFunc, setFunc, listSizeFunc, listAddFunc, listAppendFunc, iterBeginError, 
-  iterEndError, listAccessFunc', printSt, state, loopState, emptyState, assign, 
-  assignToListIndex, multiAssignError, decrement, increment, decrement1, 
-  increment1, varDec, varDecDef, listDec, arrayDec, arrayDecDef, objDecNew, 
-  objDecNewNoParams, extObjDecNew, extObjDecNewNoParams, funcDecDef, 
-  discardInput, discardFileInput, openFileR, openFileW, openFileA, closeFile, 
-  discardFileLine, stringListVals, stringListLists, returnState, 
-  multiReturnError, valState, comment, freeError, throw, initState, changeState,
-  initObserverList, addObserver, ifCond, ifNoElse, switch, switchAsIf, ifExists,
-  for, forRange, forEach, while, tryCatch, checkState, notifyObservers, 
-  construct, param, method, getMethod, setMethod, privMethod, pubMethod, 
-  constructor, docMain, function, mainFunction, docFunc, intFunc, stateVar, 
-  stateVarDef, constVar, privMVar, pubMVar, pubGVar, buildClass, enum, 
-  extraClass, implementingClass, docClass, commentedClass, intClass,
-  buildModule', modFromData, fileDoc, docMod, fileFromData)
+  funcApp, namedArgError, selfFuncApp, extFuncApp, newObj, lambda, notNull, 
+  func, get, set, listSize, listAdd, listAppend, iterBegin, iterEnd, 
+  listAccess, listSet, getFunc, setFunc, listSizeFunc, listAddFunc, 
+  listAppendFunc, iterBeginError, iterEndError, listAccessFunc', printSt, 
+  state, loopState, emptyState, assign, assignToListIndex, multiAssignError, 
+  decrement, increment, decrement1, increment1, varDec, varDecDef, listDec, 
+  arrayDec, arrayDecDef, objDecNew, objDecNewNoParams, extObjDecNew, 
+  extObjDecNewNoParams, funcDecDef, discardInput, discardFileInput, openFileR, 
+  openFileW, openFileA, closeFile, discardFileLine, stringListVals, 
+  stringListLists, returnState, multiReturnError, valState, comment, freeError, 
+  throw, initState, changeState, initObserverList, addObserver, ifCond, 
+  ifNoElse, switch, switchAsIf, ifExists, for, forRange, forEach, while, 
+  tryCatch, checkState, notifyObservers, construct, param, method, getMethod, 
+  setMethod, privMethod, pubMethod, constructor, docMain, function, 
+  mainFunction, docFunc, intFunc, stateVar, stateVarDef, constVar, privMVar, 
+  pubMVar, pubGVar, buildClass, enum, extraClass, implementingClass, docClass, 
+  commentedClass, intClass, buildModule', modFromData, fileDoc, docMod, 
+  fileFromData)
 import GOOL.Drasil.LanguageRenderer.LanguagePolymorphic (unOpPrec, unExpr, 
   unExpr', typeUnExpr, powerPrec, binExpr, binExpr', typeBinExpr)
 import GOOL.Drasil.Data (Terminator(..), ScopeTag(..), FileType(..), 
@@ -392,6 +393,8 @@ instance ValueExpression JavaCode where
   -- functions implicitly calls these functions in the Java renderer, so we 
   -- also check here to add the exceptions from the called function to the map
   funcApp n t vs = addCallExcsCurrMod n >> G.funcApp n t vs
+  funcAppNamedArgs = error $ G.namedArgError jName
+  funcAppMixedArgs = error $ G.namedArgError jName
   selfFuncApp n t vs = addCallExcsCurrMod n >> G.selfFuncApp self n t vs
   extFuncApp l n t vs = do
     mem <- getMethodExcMap

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer/PythonRenderer.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer/PythonRenderer.hs
@@ -39,16 +39,17 @@ import qualified GOOL.Drasil.LanguageRenderer.LanguagePolymorphic as G (
   objVarSelf, listVar, listOf, arrayElem, iterVar, litChar, litFloat, litInt, 
   litString, valueOf, arg, enumElement, argsList, objAccess, objMethodCall, 
   objMethodCallNoParams, selfAccess, listIndexExists, indexOf, funcApp, 
-  selfFuncApp, extFuncApp, newObj, lambda, func, get, set, listAdd, listAppend, 
-  iterBegin, iterEnd, listAccess, listSet, getFunc, setFunc, listAddFunc, 
-  listAppendFunc, iterBeginError, iterEndError, listAccessFunc, listSetFunc, 
-  state, loopState, emptyState, assign, assignToListIndex, decrement, 
-  increment', increment1', decrement1, objDecNew, objDecNewNoParams, closeFile, 
-  discardFileLine, stringListVals, stringListLists, returnState, valState, 
-  comment, throw, initState, changeState, initObserverList, addObserver, ifCond,
-  ifNoElse, switchAsIf, ifExists, tryCatch, checkState, construct, param, 
-  method, getMethod, setMethod, privMethod, pubMethod, constructor, function, 
-  docFunc, stateVarDef, constVar, privMVar, pubMVar, pubGVar, buildClass, 
+  funcAppMixedArgs, selfFuncApp, extFuncApp, newObj, lambda, func, get, set, 
+  listAdd, listAppend, iterBegin, iterEnd, listAccess, listSet, getFunc, 
+  setFunc, listAddFunc, listAppendFunc, iterBeginError, iterEndError, 
+  listAccessFunc, listSetFunc, state, loopState, emptyState, assign, 
+  assignToListIndex, decrement, increment', increment1', decrement1, objDecNew, 
+  objDecNewNoParams, closeFile, discardFileLine, stringListVals, 
+  stringListLists, returnState, valState, comment, throw, initState, 
+  changeState, initObserverList, addObserver, ifCond, ifNoElse, switchAsIf, 
+  ifExists, tryCatch, checkState, construct, param, method, getMethod, 
+  setMethod, privMethod, pubMethod, constructor, function, docFunc, 
+  stateVarDef, constVar, privMVar, pubMVar, pubGVar, buildClass, 
   implementingClass, docClass, commentedClass, intClass, buildModule, 
   modFromData, fileDoc, docMod, fileFromData)
 import GOOL.Drasil.LanguageRenderer.LanguagePolymorphic (unOpPrec, unExpr, 
@@ -379,6 +380,8 @@ instance BooleanExpression PythonCode where
 instance ValueExpression PythonCode where
   inlineIf = pyInlineIf
   funcApp = G.funcApp
+  funcAppNamedArgs n t = funcAppMixedArgs n t []
+  funcAppMixedArgs = G.funcAppMixedArgs equals 
   selfFuncApp = G.selfFuncApp self
   extFuncApp l n t ps = modify (addModuleImportVS l) >> G.extFuncApp l n t ps
   newObj = G.newObj newObjDocD'

--- a/code/drasil-gool/GOOL/Drasil/Symantics.hs
+++ b/code/drasil-gool/GOOL/Drasil/Symantics.hs
@@ -358,7 +358,13 @@ class (ValueSym repr, BooleanExpression repr) =>
     VS (repr (Value repr)) -> VS (repr (Value repr))
   funcApp      :: Label -> VS (repr (Type repr)) -> [VS (repr (Value repr))] -> 
     VS (repr (Value repr))
-  selfFuncApp  :: Label -> VS (repr (Type repr)) -> 
+  funcAppNamedArgs :: Label -> VS (repr (Type repr)) -> 
+    [(VS (repr (Variable repr)), VS (repr (Value repr)))] -> 
+    VS (repr (Value repr))
+  funcAppMixedArgs :: Label -> VS (repr (Type repr)) -> [VS (repr (Value repr))]
+    -> [(VS (repr (Variable repr)), VS (repr (Value repr)))] -> 
+    VS (repr (Value repr))
+  selfFuncApp :: Label -> VS (repr (Type repr)) -> 
     [VS (repr (Value repr))] -> VS (repr (Value repr))
   extFuncApp   :: Library -> Label -> VS (repr (Type repr)) -> 
     [VS (repr (Value repr))] -> VS (repr (Value repr))


### PR DESCRIPTION
This PR contributes to #2008. I know this is likely to require further changes, but wanted to get this in as a foundation for further discussion.

Specifically, it was discussed in the issue creating new GOOL classes to hold these new methods, and then not implementing those classes for languages that don't support named arguments, but I have not done that yet because we want Drasil's generator to be fully language-generic, and adding user-facing classes that may not be implemented by some languages would exclude those languages as possible instances of the generic `repr` in GOOL's generator.