### PR TITLE
Extend Mod for ExternalLibrary

### DIFF
--- a/code/drasil-code/Language/Drasil/Code/Imperative/GenerateGOOL.hs
+++ b/code/drasil-code/Language/Drasil/Code/Imperative/GenerateGOOL.hs
@@ -1,5 +1,6 @@
 module Language.Drasil.Code.Imperative.GenerateGOOL (ClassType(..),
-  genModule, genDoxConfig, primaryClass, auxClass, fApp, fAppInOut, mkParam
+  genModuleWithImports, genModule, genDoxConfig, primaryClass, auxClass, fApp, 
+  fAppInOut, mkParam
 ) where
 
 import Language.Drasil
@@ -18,11 +19,11 @@ import qualified Data.Map as Map (lookup)
 import Data.Maybe (catMaybes)
 import Control.Monad.Reader (Reader, ask, withReader)
 
-genModule :: (ProgramSym repr) => Name -> String
+genModuleWithImports :: (ProgramSym repr) => Name -> String -> [String]
   -> [Reader DrasilState (Maybe (MS (repr (Method repr))))]
   -> [Reader DrasilState (Maybe (CS (repr (Class repr))))]
   -> Reader DrasilState (FS (repr (RenderFile repr)))
-genModule n desc maybeMs maybeCs = do
+genModuleWithImports n desc is maybeMs maybeCs = do
   g <- ask
   let updateState = withReader (\s -> s { currentModule = n })
       -- Below line of code cannot be simplified because authors has a generic type
@@ -34,7 +35,13 @@ genModule n desc maybeMs maybeCs = do
               | CommentFunc `elem` commented g && not (null ms) = docMod "" []  
                   (date g)
               | otherwise                                       = id
-  return $ commMod $ fileDoc $ buildModule n [] (catMaybes ms) (catMaybes cs)
+  return $ commMod $ fileDoc $ buildModule n is (catMaybes ms) (catMaybes cs)
+
+genModule :: (ProgramSym repr) => Name -> String
+  -> [Reader DrasilState (Maybe (MS (repr (Method repr))))]
+  -> [Reader DrasilState (Maybe (CS (repr (Class repr))))]
+  -> Reader DrasilState (FS (repr (RenderFile repr)))
+genModule n desc = genModuleWithImports n desc []
 
 genDoxConfig :: (AuxiliarySym repr) => String -> GOOLState ->
   Reader DrasilState [repr (Auxiliary repr)]

--- a/code/drasil-code/Language/Drasil/Code/Imperative/Import.hs
+++ b/code/drasil-code/Language/Drasil/Code/Imperative/Import.hs
@@ -11,8 +11,8 @@ import Language.Drasil hiding (int, log, ln, exp,
 import Database.Drasil (symbResolve)
 import Language.Drasil.Code.Imperative.Comments (paramComment, returnComment)
 import Language.Drasil.Code.Imperative.ConceptMatch (conceptToGOOL)
-import Language.Drasil.Code.Imperative.GenerateGOOL (fApp, genModule, mkParam,
-  primaryClass, auxClass)
+import Language.Drasil.Code.Imperative.GenerateGOOL (auxClass, fApp, 
+  genModuleWithImports, mkParam, primaryClass)
 import Language.Drasil.Code.Imperative.Helpers (getUpperBound, liftS, lookupC)
 import Language.Drasil.Code.Imperative.Logging (maybeLog, logBody)
 import Language.Drasil.Code.Imperative.Parameters (getCalcParams)
@@ -333,13 +333,15 @@ genCaseBlock t v c cs = do
 -- medium hacks --
 genModDef :: (ProgramSym repr) => Mod -> 
   Reader DrasilState (FS (repr (RenderFile repr)))
-genModDef (Mod n desc cs fs) = genModule n desc (map (fmap Just . genFunc) fs) 
+genModDef (Mod n desc is cs fs) = genModuleWithImports n desc is (map (fmap 
+  Just . genFunc) fs) 
   (case cs of [] -> []
-              (cl:cls) -> fmap Just (genClass primaryClass cl) : map (fmap Just . genClass auxClass) cls)
+              (cl:cls) -> fmap Just (genClass primaryClass cl) : 
+                map (fmap Just . genClass auxClass) cls)
 
 genModFuncs :: (ProgramSym repr) => Mod -> 
   [Reader DrasilState (MS (repr (Method repr)))]
-genModFuncs (Mod _ _ _ fs) = map genFunc fs
+genModFuncs (Mod _ _ _ _ fs) = map genFunc fs
 
 genClass :: (ProgramSym repr) => (String -> Label -> Maybe Label -> 
   [CS (repr (StateVar repr))] -> Reader DrasilState [MS (repr (Method repr))] 

--- a/code/drasil-code/Language/Drasil/Code/Imperative/Import.hs
+++ b/code/drasil-code/Language/Drasil/Code/Imperative/Import.hs
@@ -11,7 +11,8 @@ import Language.Drasil hiding (int, log, ln, exp,
 import Database.Drasil (symbResolve)
 import Language.Drasil.Code.Imperative.Comments (paramComment, returnComment)
 import Language.Drasil.Code.Imperative.ConceptMatch (conceptToGOOL)
-import Language.Drasil.Code.Imperative.GenerateGOOL (fApp, genModule, mkParam)
+import Language.Drasil.Code.Imperative.GenerateGOOL (fApp, genModule, mkParam,
+  primaryClass, auxClass)
 import Language.Drasil.Code.Imperative.Helpers (getUpperBound, liftS, lookupC)
 import Language.Drasil.Code.Imperative.Logging (maybeLog, logBody)
 import Language.Drasil.Code.Imperative.Parameters (getCalcParams)
@@ -28,13 +29,15 @@ import Language.Drasil.Code.DataDesc (DataItem, LinePattern(Repeat, Straight),
   getPatternInputs)
 import Language.Drasil.Mod (Func(..), FuncData(..), FuncDef(..), FuncStmt(..), 
   Mod(..), Name, fstdecl)
+import qualified Language.Drasil.Mod as M (Class(..))
 
 import GOOL.Drasil (Label, ProgramSym, FileSym(..), PermanenceSym(..), 
   BodySym(..), BlockSym(..), TypeSym(..), VariableSym(..), ValueSym(..), 
   NumericExpression(..), BooleanExpression(..), ValueExpression(..), 
   FunctionSym(..), SelectorFunction(..), StatementSym(..), 
   ControlStatementSym(..), ScopeSym(..), ParameterSym(..), MethodSym(..), 
-  nonInitConstructor, convType, FS, MS, VS, onStateValue) 
+  StateVarSym(..), ClassSym(..), nonInitConstructor, convType, FS, CS, MS, VS, 
+  onStateValue) 
 import qualified GOOL.Drasil as C (CodeType(List))
 
 import Prelude hiding (sin, cos, tan, log, exp)
@@ -139,6 +142,13 @@ genConstructor :: (ProgramSym repr, HasUID c, HasCodeType c, CodeIdea c) =>
   Label -> String -> [c] -> [MS (repr (Block repr))] -> 
   Reader DrasilState (MS (repr (Method repr)))
 genConstructor n desc p = genMethod nonInitConstructor n desc p Nothing
+
+genInitConstructor :: (ProgramSym repr, HasUID c, HasCodeType c, CodeIdea c) =>
+  Label -> String -> [c] -> 
+  [(VS (repr (Variable repr)), VS (repr (Value repr)))] -> 
+  [MS (repr (Block repr))] -> Reader DrasilState (MS (repr (Method repr)))
+genInitConstructor n desc p is = genMethod (`constructor` is) n desc p 
+  Nothing
 
 genMethod :: (ProgramSym repr, HasUID c, HasCodeType c, CodeIdea c) => 
   ([MS (repr (Parameter repr))] -> MS (repr (Body repr)) -> 
@@ -323,11 +333,20 @@ genCaseBlock t v c cs = do
 -- medium hacks --
 genModDef :: (ProgramSym repr) => Mod -> 
   Reader DrasilState (FS (repr (RenderFile repr)))
-genModDef (Mod n desc fs) = genModule n desc (map (fmap Just . genFunc) fs) []
+genModDef (Mod n desc cs fs) = genModule n desc (map (fmap Just . genFunc) fs) 
+  (case cs of [] -> []
+              (cl:cls) -> fmap Just (genClass primaryClass cl) : map (fmap Just . genClass auxClass) cls)
 
 genModFuncs :: (ProgramSym repr) => Mod -> 
   [Reader DrasilState (MS (repr (Method repr)))]
-genModFuncs (Mod _ _ fs) = map genFunc fs
+genModFuncs (Mod _ _ _ fs) = map genFunc fs
+
+genClass :: (ProgramSym repr) => (String -> Label -> Maybe Label -> 
+  [CS (repr (StateVar repr))] -> Reader DrasilState [MS (repr (Method repr))] 
+  -> Reader DrasilState (CS (repr (Class repr)))) -> M.Class -> 
+  Reader DrasilState (CS (repr (Class repr)))
+genClass f (M.ClassDef n i desc svs ms) = f n desc i (map (\v -> 
+  pubMVar $ var (codeName v) (convType $ codeType v)) svs) (mapM genFunc ms) 
 
 genFunc :: (ProgramSym repr) => Func -> Reader DrasilState (MS (repr (Method repr)))
 genFunc (FDef (FuncDef n desc parms o rd s)) = do
@@ -335,6 +354,15 @@ genFunc (FDef (FuncDef n desc parms o rd s)) = do
   stmts <- mapM convStmt s
   vars <- mapM mkVar (fstdecl (sysinfodb $ csi $ codeSpec g) s \\ parms)
   publicFunc n (convType o) desc parms rd [block $ map varDec vars ++ stmts]
+genFunc (FDef (CtorDef n desc parms i s)) = do
+  g <- ask
+  inits <- mapM (convExpr . snd) i
+  let initvars = map ((\iv -> var (codeName iv) (convType $ codeType iv)) . 
+        fst) i
+  stmts <- mapM convStmt s
+  vars <- mapM mkVar (fstdecl (sysinfodb $ csi $ codeSpec g) s \\ parms)
+  genInitConstructor n desc parms (zip initvars inits) 
+    [block $ map varDec vars ++ stmts]
 genFunc (FData (FuncData n desc ddef)) = genDataFunc n desc ddef
 genFunc (FCD cd) = genCalcFunc cd
 
@@ -350,6 +378,12 @@ convStmt (FAsgIndex v i e) = do
   let vi = arrayElem i v'
   l <- maybeLog vi
   return $ multi $ assign vi e' : l
+convStmt (FAsgObjVar o v e) = do
+  e' <- convExpr e
+  o' <- mkVar o
+  let ov = objVar o' (var (codeName v) (convType $ codeType v))
+  l <- maybeLog ov
+  return $ multi $ assign ov e' : l
 convStmt (FFor v e st) = do
   stmts <- mapM convStmt st
   vari <- mkVar v

--- a/code/drasil-code/Language/Drasil/CodeSpec.hs
+++ b/code/drasil-code/Language/Drasil/CodeSpec.hs
@@ -247,7 +247,7 @@ getAdditionalVars chs ms = map codevar (inFileName
         inParamsVar Unbundled = []
         constsVar (Store Bundled) = [consts]
         constsVar _ = []
-        funcParams (Mod _ _ cs fs) = concatMap getFuncParams (fs ++ 
+        funcParams (Mod _ _ _ cs fs) = concatMap getFuncParams (fs ++ 
           concatMap methods cs)
 
 -- name of variable/function maps to module name
@@ -272,7 +272,7 @@ modExportMap cs@CSI {
     ++ getExpConstraints prn chs (getConstraints (cMap cs) ins)
     ++ getExpInputFormat prn chs extIns
     ++ getExpOutput prn chs (outputs cs)
-  where mpair (Mod n _ cls fs) = (map className cls ++ map fname (fs ++ 
+  where mpair (Mod n _ _ cls fs) = (map className cls ++ map fname (fs ++ 
           concatMap methods cls)) `zip` repeat (defModName m n)
         defModName Unmodular _ = prn
         defModName _ nm = nm

--- a/code/drasil-code/Language/Drasil/CodeSpec.hs
+++ b/code/drasil-code/Language/Drasil/CodeSpec.hs
@@ -15,8 +15,8 @@ import Language.Drasil.Chunk.CodeDefinition (CodeDefinition, qtov, qtoc,
   codeEquat)
 import Language.Drasil.Chunk.CodeQuantity (HasCodeType(ctyp))
 import Language.Drasil.Code.CodeQuantityDicts (inFileName, inParams, consts)
-import Language.Drasil.Mod (Func(..), FuncData(..), FuncDef(..), Mod(..), Name, fname, getFuncParams, packmod, 
-  prefixFunctions)
+import Language.Drasil.Mod (Class(..), Func(..), FuncData(..), FuncDef(..), 
+  Mod(..), Name, fname, getFuncParams, packmod, prefixFunctions)
 
 import GOOL.Drasil (CodeType)
 
@@ -110,7 +110,7 @@ codeSpec SI {_sys = sys
         cMap = constraintMap cs,
         constants = const',
         mods = prefixFunctions $ packmod "Calculations" 
-          "Provides functions for calculating the outputs" 
+          "Provides functions for calculating the outputs" []
           (map FCD exOrder) : ms,
         sysinfodb = db,
         smplData = sd
@@ -220,6 +220,7 @@ convertRel _ _ = error "Conversion failed"
 
 asVC :: Func -> QuantityDict
 asVC (FDef (FuncDef n _ _ _ _ _)) = implVar n (nounPhraseSP n) (Variable n) Real
+asVC (FDef (CtorDef n _ _ _ _)) = implVar n (nounPhraseSP n) (Variable n) Real
 asVC (FData (FuncData n _ _)) = implVar n (nounPhraseSP n) (Variable n) Real
 asVC (FCD _) = error "Can't make QuantityDict from FCD function" -- codeVC cd (codeSymb cd) (cd ^. typ)
 
@@ -233,6 +234,7 @@ asExpr' f = sy $ asVC' f
 -- FIXME: Part of above hack
 asVC' :: Func -> QuantityDict
 asVC' (FDef (FuncDef n _ _ _ _ _)) = vc n (nounPhraseSP n) (Variable n) Real
+asVC' (FDef (CtorDef n _ _ _ _)) = vc n (nounPhraseSP n) (Variable n) Real
 asVC' (FData (FuncData n _ _)) = vc n (nounPhraseSP n) (Variable n) Real
 asVC' (FCD _) = error "Can't make QuantityDict from FCD function" -- vc'' cd (codeSymb cd) (cd ^. typ)
 
@@ -245,7 +247,8 @@ getAdditionalVars chs ms = map codevar (inFileName
         inParamsVar Unbundled = []
         constsVar (Store Bundled) = [consts]
         constsVar _ = []
-        funcParams (Mod _ _ fs) = concatMap getFuncParams fs
+        funcParams (Mod _ _ cs fs) = concatMap getFuncParams (fs ++ 
+          concatMap methods cs)
 
 -- name of variable/function maps to module name
 type ModExportMap = Map.Map String String
@@ -269,7 +272,8 @@ modExportMap cs@CSI {
     ++ getExpConstraints prn chs (getConstraints (cMap cs) ins)
     ++ getExpInputFormat prn chs extIns
     ++ getExpOutput prn chs (outputs cs)
-  where mpair (Mod n _ fs) = map fname fs `zip` repeat (defModName m n)
+  where mpair (Mod n _ cls fs) = (map className cls ++ map fname (fs ++ 
+          concatMap methods cls)) `zip` repeat (defModName m n)
         defModName Unmodular _ = prn
         defModName _ nm = nm
 

--- a/code/drasil-code/Language/Drasil/Mod.hs
+++ b/code/drasil-code/Language/Drasil/Mod.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE GADTs #-}
-module Language.Drasil.Mod (Func(..), FuncData(..), FuncDef(..), FuncStmt(..), 
-  Mod(..), Name, ($:=), ffor, fdec, fname, fstdecl, funcData, funcDef, funcQD, 
+module Language.Drasil.Mod (Class(..), Func(..), FuncData(..), FuncDef(..), 
+  FuncStmt(..), Initializer, Mod(..), Name, ($:=), classDef, classImplements, 
+  ctorDef, ffor, fdec, fname, fstdecl, funcData, funcDef, funcQD, 
   getFuncParams, packmod, prefixFunctions
 ) where
 
@@ -20,10 +21,23 @@ import Data.List ((\\), nub)
 
 type Name = String
 
-data Mod = Mod Name String [Func]
+data Mod = Mod Name String [Class] [Func]
 
-packmod :: Name -> String -> [Func] -> Mod
+packmod :: Name -> String -> [Class] -> [Func] -> Mod
 packmod n = Mod (toPlainName n)
+
+data Class = ClassDef {
+  className :: Name, 
+  implements :: Maybe Name,
+  classDesc :: String,
+  stateVars :: [CodeChunk],
+  methods :: [Func]}
+
+classDef :: Name -> String -> [CodeChunk] -> [Func] -> Class
+classDef n = ClassDef n Nothing
+
+classImplements :: Name -> Name -> String -> [CodeChunk] -> [Func] -> Class
+classImplements n i = ClassDef n (Just i)
      
 data Func = FCD CodeDefinition
           | FDef FuncDef
@@ -40,16 +54,26 @@ funcDef :: (Quantity c, MayHaveUnit c) => Name -> String -> [c] -> Space ->
 funcDef s desc i t returnDesc fs = FDef $ FuncDef (toPlainName s) desc 
   (map quantvar i) (spaceToCodeType t) returnDesc fs 
 
+ctorDef :: Name -> String -> [CodeChunk] -> [Initializer] -> [FuncStmt] -> 
+  FuncDef
+ctorDef = CtorDef
+
 data FuncData where
   FuncData :: Name -> String -> DataDesc -> FuncData
   
 data FuncDef where
+  -- Name, description, parameters, return type, return description, statements
   FuncDef :: Name -> String -> [CodeChunk] -> CodeType -> Maybe String -> 
     [FuncStmt] -> FuncDef
+  CtorDef :: Name -> String -> [CodeChunk] -> [Initializer] -> [FuncStmt] -> 
+    FuncDef
+
+type Initializer = (CodeChunk, Expr)
  
 data FuncStmt where
   FAsg :: CodeChunk -> Expr -> FuncStmt
   FAsgIndex :: CodeChunk -> Integer -> Expr -> FuncStmt
+  FAsgObjVar :: CodeChunk -> CodeChunk -> Expr -> FuncStmt -- Object, field, value
   FFor :: CodeChunk -> Expr -> [FuncStmt] -> FuncStmt
   FForEach :: CodeChunk -> Expr -> [FuncStmt] -> FuncStmt
   FWhile :: Expr -> [FuncStmt] -> FuncStmt
@@ -75,6 +99,7 @@ fdec v  = FDec (quantvar v)
 
 getFuncParams :: Func -> [CodeChunk]
 getFuncParams (FDef (FuncDef _ _ ps _ _ _)) = ps
+getFuncParams (FDef (CtorDef _ _ ps _ _)) = ps
 getFuncParams (FData (FuncData _ _ d)) = getInputs d
 getFuncParams (FCD _) = []
 
@@ -86,6 +111,7 @@ fstdecl ctx fsts = nub (concatMap (fstvars ctx) fsts) \\ nub (concatMap (declare
     fstvars sm (FDecDef cch e) = cch:codevars' e sm
     fstvars sm (FAsg cch e) = cch:codevars' e sm
     fstvars sm (FAsgIndex cch _ e) = cch:codevars' e sm
+    fstvars sm (FAsgObjVar cch _ e) = cch:codevars' e sm
     fstvars sm (FFor cch e fs) = nub (cch : codevars' e sm ++ concatMap (fstvars sm) fs)
     fstvars sm (FForEach cch e fs) = nub (cch : codevars' e sm ++ concatMap (fstvars sm) fs)
     fstvars sm (FWhile e fs) = codevars' e sm ++ concatMap (fstvars sm) fs
@@ -102,6 +128,7 @@ fstdecl ctx fsts = nub (concatMap (fstvars ctx) fsts) \\ nub (concatMap (declare
     declared _  (FDecDef cch _) = [cch]
     declared _  (FAsg _ _) = []
     declared _  FAsgIndex {} = []
+    declared _  FAsgObjVar {} = []
     declared sm (FFor cch _ fs) = cch : concatMap (declared sm) fs
     declared sm (FForEach cch _ fs) = cch : concatMap (declared sm) fs
     declared sm (FWhile _ fs) = concatMap (declared sm) fs
@@ -116,12 +143,13 @@ fstdecl ctx fsts = nub (concatMap (fstvars ctx) fsts) \\ nub (concatMap (declare
 fname :: Func -> Name       
 fname (FCD cd) = codeName cd
 fname (FDef (FuncDef n _ _ _ _ _)) = n
+fname (FDef (CtorDef n _ _ _ _)) = n
 fname (FData (FuncData n _ _)) = n 
 
 prefixFunctions :: [Mod] -> [Mod]
-prefixFunctions = map (\(Mod nm desc fs) -> Mod nm desc $ map pfunc fs)
-  where pfunc f@(FCD _) = f
-        pfunc (FData (FuncData n desc d)) = FData (FuncData (funcPrefix ++ n) 
+prefixFunctions = map (\(Mod nm desc cs fs) -> Mod nm desc cs $ map pfunc fs)
+  where pfunc (FData (FuncData n desc d)) = FData (FuncData (funcPrefix ++ n) 
           desc d)
         pfunc (FDef (FuncDef n desc a t rd f)) = FDef (FuncDef (funcPrefix ++ n)
           desc a t rd f)
+        pfunc f = f

--- a/code/drasil-code/Language/Drasil/Mod.hs
+++ b/code/drasil-code/Language/Drasil/Mod.hs
@@ -2,7 +2,7 @@
 module Language.Drasil.Mod (Class(..), Func(..), FuncData(..), FuncDef(..), 
   FuncStmt(..), Initializer, Mod(..), Name, ($:=), classDef, classImplements, 
   ctorDef, ffor, fdec, fname, fstdecl, funcData, funcDef, funcQD, 
-  getFuncParams, packmod, prefixFunctions
+  getFuncParams, packmod, packmodRequires, prefixFunctions
 ) where
 
 import Language.Drasil
@@ -21,10 +21,14 @@ import Data.List ((\\), nub)
 
 type Name = String
 
-data Mod = Mod Name String [Class] [Func]
+-- Name, description, imports, classes, functions
+data Mod = Mod Name String [String] [Class] [Func]
 
 packmod :: Name -> String -> [Class] -> [Func] -> Mod
-packmod n = Mod (toPlainName n)
+packmod n d = packmodRequires n d []
+
+packmodRequires :: Name -> String -> [String] -> [Class] -> [Func] -> Mod
+packmodRequires n = Mod (toPlainName n)
 
 data Class = ClassDef {
   className :: Name, 
@@ -147,7 +151,7 @@ fname (FDef (CtorDef n _ _ _ _)) = n
 fname (FData (FuncData n _ _)) = n 
 
 prefixFunctions :: [Mod] -> [Mod]
-prefixFunctions = map (\(Mod nm desc cs fs) -> Mod nm desc cs $ map pfunc fs)
+prefixFunctions = map (\(Mod nm desc rs cs fs) -> Mod nm desc rs cs $ map pfunc fs)
   where pfunc (FData (FuncData n desc d)) = FData (FuncData (funcPrefix ++ n) 
           desc d)
         pfunc (FDef (FuncDef n desc a t rd f)) = FDef (FuncDef (funcPrefix ++ n)

--- a/code/drasil-example/Drasil/GlassBR/ModuleDefs.hs
+++ b/code/drasil-example/Drasil/GlassBR/ModuleDefs.hs
@@ -23,7 +23,7 @@ implVars = [v, x_z_1, y_z_1, x_z_2, y_z_2, mat, col,
 
 readTableMod :: Mod
 readTableMod = packmod "ReadTable"
-  "Provides a function for reading glass ASTM data" [readTable]
+  "Provides a function for reading glass ASTM data" [] [readTable]
 
 readTable :: Func
 readTable = funcData "read_table"
@@ -215,5 +215,5 @@ interpZ = funcDef "interpZ"
 
 interpMod :: Mod
 interpMod = packmod "Interpolation" 
-  "Provides functions for linear interpolation on three-dimensional data" 
+  "Provides functions for linear interpolation on three-dimensional data" []
   [linInterpCT, findCT, extractColumnCT, interpY, interpZ]

--- a/code/drasil-example/Drasil/GlassBR/Symbols.hs
+++ b/code/drasil-example/Drasil/GlassBR/Symbols.hs
@@ -18,5 +18,5 @@ symbolsForTable = inputs ++ outputs ++ tmSymbols ++ map qw specParamVals ++
 thisSymbols :: [QuantityDict]
 thisSymbols = map qw iMods
   -- include all module functions as symbols
-  ++ (map asVC (concatMap (\(Mod _ _ _ l) -> l) allMods) \\ symbolsForTable)
+  ++ (map asVC (concatMap (\(Mod _ _ _ _ l) -> l) allMods) \\ symbolsForTable)
   ++ map qw implVars ++ symbolsForTable

--- a/code/drasil-example/Drasil/GlassBR/Symbols.hs
+++ b/code/drasil-example/Drasil/GlassBR/Symbols.hs
@@ -18,5 +18,5 @@ symbolsForTable = inputs ++ outputs ++ tmSymbols ++ map qw specParamVals ++
 thisSymbols :: [QuantityDict]
 thisSymbols = map qw iMods
   -- include all module functions as symbols
-  ++ (map asVC (concatMap (\(Mod _ _ l) -> l) allMods) \\ symbolsForTable)
+  ++ (map asVC (concatMap (\(Mod _ _ _ l) -> l) allMods) \\ symbolsForTable)
   ++ map qw implVars ++ symbolsForTable


### PR DESCRIPTION
This PR adds some new nodes to the `Mod` AST for classes, constructors, and accessing object fields, and added an imports parameter at the module level, all of which are needed for implementing external libraries.

This PR is not dependent on the others. Safe to merge!