### PR TITLE
GOOL Doubles

### DIFF
--- a/code/drasil-code/Language/Drasil/Code/Code.hs
+++ b/code/drasil-code/Language/Drasil/Code/Code.hs
@@ -16,9 +16,9 @@ newtype Code = Code { unCode :: [(FilePath, Doc)]}
 spaceToCodeType :: S.Space -> CodeType
 spaceToCodeType S.Integer       = Integer
 spaceToCodeType S.Natural       = Integer
-spaceToCodeType S.Radians       = Float
-spaceToCodeType S.Real          = Float
-spaceToCodeType S.Rational      = Float
+spaceToCodeType S.Radians       = Double
+spaceToCodeType S.Real          = Double
+spaceToCodeType S.Rational      = Double
 spaceToCodeType S.Boolean       = Boolean
 spaceToCodeType S.Char          = Char
 spaceToCodeType S.String        = String

--- a/code/drasil-code/Language/Drasil/Code/Imperative/Import.hs
+++ b/code/drasil-code/Language/Drasil/Code/Imperative/Import.hs
@@ -193,7 +193,7 @@ genInOutFunc f docf s pr n desc ins' outs' b = do
     bComms bothVs) bod else f s pr inVs outVs bothVs bod
 
 convExpr :: (ProgramSym repr) => Expr -> Reader DrasilState (VS (repr (Value repr)))
-convExpr (Dbl d) = return $ litFloat d
+convExpr (Dbl d) = return $ litFloat (realToFrac d)
 convExpr (Int i) = return $ litInt i
 convExpr (Str s) = return $ litString s
 convExpr (Perc a b) = return $ litFloat $ fromIntegral a / (10 ** fromIntegral b)

--- a/code/drasil-code/Language/Drasil/Code/Imperative/Import.hs
+++ b/code/drasil-code/Language/Drasil/Code/Imperative/Import.hs
@@ -193,10 +193,10 @@ genInOutFunc f docf s pr n desc ins' outs' b = do
     bComms bothVs) bod else f s pr inVs outVs bothVs bod
 
 convExpr :: (ProgramSym repr) => Expr -> Reader DrasilState (VS (repr (Value repr)))
-convExpr (Dbl d) = return $ litFloat (realToFrac d)
+convExpr (Dbl d) = return $ litDouble d
 convExpr (Int i) = return $ litInt i
 convExpr (Str s) = return $ litString s
-convExpr (Perc a b) = return $ litFloat $ fromIntegral a / (10 ** fromIntegral b)
+convExpr (Perc a b) = return $ litDouble $ fromIntegral a / (10 ** fromIntegral b)
 convExpr (AssocA Add l) = foldl1 (#+)  <$> mapM convExpr l
 convExpr (AssocA Mul l) = foldl1 (#*)  <$> mapM convExpr l
 convExpr (AssocB And l) = foldl1 (?&&) <$> mapM convExpr l
@@ -226,7 +226,7 @@ convExpr (New c x) = do
   return $ newObj funcTp args
 convExpr (UnaryOp o u) = fmap (unop o) (convExpr u)
 convExpr (BinaryOp Frac (Int a) (Int b)) =
-  return $ litFloat (fromIntegral a) #/ litFloat (fromIntegral b) -- hack to deal with integer division
+  return $ litDouble (fromIntegral a) #/ litDouble (fromIntegral b) -- hack to deal with integer division
 convExpr (BinaryOp o a b)  = liftM2 (bfunc o) (convExpr a) (convExpr b)
 convExpr (Case c l)      = doit l -- FIXME this is sub-optimal
   where

--- a/code/drasil-code/Language/Drasil/Code/Imperative/ReadInput.hs
+++ b/code/drasil-code/Language/Drasil/Code/Imperative/ReadInput.hs
@@ -48,6 +48,7 @@ sampleInputDD cs = junkLine : intersperse junkLine (map dataDesc cs)
 strAsExpr :: C.CodeType -> String -> Expr
 strAsExpr C.Integer s = int (read s :: Integer)
 strAsExpr C.Float s = dbl (read s :: Double)
+strAsExpr C.Double s = dbl (read s :: Double)
 strAsExpr C.String s = str s
 strAsExpr _ _ = error "strAsExpr should only be called on integers, floats, or strings"
 

--- a/code/drasil-gool/GOOL/Drasil/CodeInfo.hs
+++ b/code/drasil-gool/GOOL/Drasil/CodeInfo.hs
@@ -76,6 +76,7 @@ instance TypeSym CodeInfo where
   bool = noInfoType
   int = noInfoType
   float = noInfoType
+  double = noInfoType
   char = noInfoType
   string = noInfoType
   infile = noInfoType

--- a/code/drasil-gool/GOOL/Drasil/CodeInfo.hs
+++ b/code/drasil-gool/GOOL/Drasil/CodeInfo.hs
@@ -136,6 +136,7 @@ instance ValueSym CodeInfo where
   litTrue = noInfo
   litFalse = noInfo
   litChar _ = noInfo
+  litDouble _ = noInfo
   litFloat _ = noInfo
   litInt _ = noInfo
   litString _ = noInfo

--- a/code/drasil-gool/GOOL/Drasil/CodeType.hs
+++ b/code/drasil-gool/GOOL/Drasil/CodeType.hs
@@ -7,6 +7,7 @@ module GOOL.Drasil.CodeType (
 data CodeType = Boolean
               | Integer
               | Float
+              | Double
               | Char
               | String
               | File

--- a/code/drasil-gool/GOOL/Drasil/Helpers.hs
+++ b/code/drasil-gool/GOOL/Drasil/Helpers.hs
@@ -101,6 +101,7 @@ convType :: (S.TypeSym repr) => C.CodeType -> VS (repr (S.Type repr))
 convType C.Boolean = S.bool
 convType C.Integer = S.int
 convType C.Float = S.float
+convType C.Double = S.double
 convType C.Char = S.char
 convType C.String = S.string
 convType (C.List t) = S.listType (convType t)

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer/CSharpRenderer.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer/CSharpRenderer.hs
@@ -39,28 +39,29 @@ import qualified GOOL.Drasil.LanguageRenderer.LanguagePolymorphic as G (
   greaterEqualOp, lessOp, lessEqualOp,plusOp, minusOp, multOp, divideOp, 
   moduloOp, andOp, orOp, var, staticVar, extVar, self, enumVar, classVar, 
   objVarSelf, listVar, listOf, arrayElem, iterVar, pi, litTrue, litFalse, 
-  litChar, litFloat, litInt, litString, valueOf, arg, enumElement, argsList, 
-  inlineIf, objAccess, objMethodCall, objMethodCallNoParams, selfAccess, 
-  listIndexExists, indexOf, funcApp, funcAppMixedArgs, selfFuncApp, extFuncApp, 
-  newObj, lambda, notNull, func, get, set, listSize, listAdd, listAppend, 
-  iterBegin, iterEnd, listAccess, listSet, getFunc, setFunc, listAddFunc, 
-  listAppendFunc, iterBeginError, iterEndError, listAccessFunc, listSetFunc, 
-  printSt, state, loopState, emptyState, assign, assignToListIndex, 
-  multiAssignError, decrement, increment, decrement1, increment1, varDec, 
-  varDecDef, listDec, listDecDef', arrayDec, arrayDecDef, objDecNew, 
-  objDecNewNoParams, extObjDecNew, extObjDecNewNoParams, constDecDef, 
-  discardInput, openFileR, openFileW, openFileA, closeFile, discardFileLine, 
-  stringListVals, stringListLists, returnState, multiReturnError, valState, 
-  comment, freeError, throw, initState, changeState, initObserverList, 
-  addObserver, ifCond, ifNoElse, switch, switchAsIf, ifExists, for, forRange, 
-  forEach, while, tryCatch, checkState, notifyObservers, construct, param, 
-  method, getMethod, setMethod, privMethod, pubMethod, constructor, docMain, 
-  function, mainFunction, docFunc, docInOutFunc, intFunc, stateVar, 
-  stateVarDef, constVar, privMVar, pubMVar, pubGVar, buildClass, enum, 
-  implementingClass, docClass, commentedClass, intClass, buildModule', 
-  modFromData, fileDoc, docMod, fileFromData)
+  litChar, litDouble, litFloat, litInt, litString, valueOf, arg, enumElement, 
+  argsList, inlineIf, objAccess, objMethodCall, objMethodCallNoParams, 
+  selfAccess, listIndexExists, indexOf, funcApp, funcAppMixedArgs, selfFuncApp, 
+  extFuncApp, newObj, lambda, notNull, func, get, set, listSize, listAdd, 
+  listAppend, iterBegin, iterEnd, listAccess, listSet, getFunc, setFunc, 
+  listAddFunc, listAppendFunc, iterBeginError, iterEndError, listAccessFunc, 
+  listSetFunc, printSt, state, loopState, emptyState, assign, 
+  assignToListIndex, multiAssignError, decrement, increment, decrement1, 
+  increment1, varDec, varDecDef, listDec, listDecDef', arrayDec, arrayDecDef, 
+  objDecNew, objDecNewNoParams, extObjDecNew, extObjDecNewNoParams, 
+  constDecDef, discardInput, openFileR, openFileW, openFileA, closeFile, 
+  discardFileLine, stringListVals, stringListLists, returnState, 
+  multiReturnError, valState, comment, freeError, throw, initState, 
+  changeState, initObserverList, addObserver, ifCond, ifNoElse, switch, 
+  switchAsIf, ifExists, for, forRange, forEach, while, tryCatch, checkState, 
+  notifyObservers, construct, param, method, getMethod, setMethod, privMethod, 
+  pubMethod, constructor, docMain, function, mainFunction, docFunc, 
+  docInOutFunc, intFunc, stateVar, stateVarDef, constVar, privMVar, pubMVar, 
+  pubGVar, buildClass, enum, implementingClass, docClass, commentedClass, 
+  intClass, buildModule', modFromData, fileDoc, docMod, fileFromData)
 import GOOL.Drasil.LanguageRenderer.LanguagePolymorphic (unOpPrec, unExpr, 
-  unExpr', typeUnExpr, powerPrec, binExpr, binExpr', typeBinExpr)
+  unExpr', unExprNumDbl, typeUnExpr, powerPrec, binExpr, binExprNumDbl', 
+  typeBinExpr)
 import GOOL.Drasil.Data (Terminator(..), ScopeTag(..), FileType(..), 
   FileData(..), fileD, FuncData(..), fd, ModData(..), md, updateModDoc, 
   MethodData(..), mthd, updateMthdDoc, OpData(..), od, ParamData(..), pd, 
@@ -325,6 +326,7 @@ instance ValueSym CSharpCode where
   litTrue = G.litTrue
   litFalse = G.litFalse
   litChar = G.litChar
+  litDouble = G.litDouble
   litFloat = G.litFloat
   litInt = G.litInt
   litString = G.litString
@@ -346,27 +348,27 @@ instance ValueSym CSharpCode where
 
 instance NumericExpression CSharpCode where
   (#~) = unExpr' negateOp
-  (#/^) = unExpr sqrtOp
+  (#/^) = unExprNumDbl sqrtOp
   (#|) = unExpr absOp
   (#+) = binExpr plusOp
   (#-) = binExpr minusOp
   (#*) = binExpr multOp
   (#/) = binExpr divideOp
   (#%) = binExpr moduloOp
-  (#^) = binExpr' powerOp
+  (#^) = binExprNumDbl' powerOp
 
-  log = unExpr logOp
-  ln = unExpr lnOp
-  exp = unExpr expOp
-  sin = unExpr sinOp
-  cos = unExpr cosOp
-  tan = unExpr tanOp
+  log = unExprNumDbl logOp
+  ln = unExprNumDbl lnOp
+  exp = unExprNumDbl expOp
+  sin = unExprNumDbl sinOp
+  cos = unExprNumDbl cosOp
+  tan = unExprNumDbl tanOp
   csc v = litFloat 1.0 #/ sin v
   sec v = litFloat 1.0 #/ cos v
   cot v = litFloat 1.0 #/ tan v
-  arcsin = unExpr asinOp
-  arccos = unExpr acosOp
-  arctan = unExpr atanOp
+  arcsin = unExprNumDbl asinOp
+  arccos = unExprNumDbl acosOp
+  arctan = unExprNumDbl atanOp
   floor = unExpr floorOp
   ceil = unExpr ceilOp
 
@@ -755,7 +757,7 @@ csInput :: (RenderSym repr) => VS (repr (Type repr)) -> VS (repr (Value repr))
 csInput tp inF = tp >>= (\t -> csInputImport (getType t) $ onStateValue (\inFn 
   -> mkVal t $ text (csInput' (getType t)) <> parens (valueDoc inFn)) inF)
   where csInput' Integer = "Int32.Parse"
-        csInput' Float = "Float.Parse"
+        csInput' Float = "Single.Parse"
         csInput' Double = "Double.Parse"
         csInput' Boolean = "Boolean.Parse"
         csInput' String = ""

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer/CSharpRenderer.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer/CSharpRenderer.hs
@@ -33,8 +33,8 @@ import GOOL.Drasil.LanguageRenderer (classDocD, multiStateDocD, bodyDocD,
   inLabel, blockCmtDoc, docCmtDoc, commentedItem, addCommentsDocD, 
   commentedModD, variableList, appendToBody, surroundBody)
 import qualified GOOL.Drasil.LanguageRenderer.LanguagePolymorphic as G (
-  oneLiner, multiBody, block, multiBlock, bool, int, double, char, string, 
-  listType, arrayType, listInnerType, obj, enumType, funcType, void, 
+  oneLiner, multiBody, block, multiBlock, bool, int, float, double, char, 
+  string, listType, arrayType, listInnerType, obj, enumType, funcType, void, 
   runStrategy, listSlice, notOp, negateOp, equalOp, notEqualOp, greaterOp, 
   greaterEqualOp, lessOp, lessEqualOp,plusOp, minusOp, multOp, divideOp, 
   moduloOp, andOp, orOp, var, staticVar, extVar, self, enumVar, classVar, 
@@ -188,7 +188,8 @@ instance TypeSym CSharpCode where
   type Type CSharpCode = TypeData
   bool = addSystemImport G.bool
   int = G.int
-  float = G.double
+  float = G.float
+  double = G.double
   char = G.char
   string = G.string
   infile = csInfileType

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer/CSharpRenderer.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer/CSharpRenderer.hs
@@ -716,7 +716,8 @@ csCast :: VS (CSharpCode (Type CSharpCode)) ->
   VS (CSharpCode (Value CSharpCode)) -> VS (CSharpCode (Value CSharpCode))
 csCast t v = join $ on2StateValues (\tp vl -> csCast' (getType tp) (getType $ 
   valueType vl) tp vl) t v
-  where csCast' Float String _ _ = funcApp "Double.Parse" float [v]
+  where csCast' Double String _ _ = funcApp "Double.Parse" double [v]
+        csCast' Float String _ _ = funcApp "Single.Parse" float [v]
         csCast' _ _ tp vl = mkStateVal t (castObjDocD (castDocD (getTypeDoc 
           tp)) (valueDoc vl))
 
@@ -754,13 +755,14 @@ csInput :: (RenderSym repr) => VS (repr (Type repr)) -> VS (repr (Value repr))
 csInput tp inF = tp >>= (\t -> csInputImport (getType t) $ onStateValue (\inFn 
   -> mkVal t $ text (csInput' (getType t)) <> parens (valueDoc inFn)) inF)
   where csInput' Integer = "Int32.Parse"
-        csInput' Float = "Double.Parse"
+        csInput' Float = "Float.Parse"
+        csInput' Double = "Double.Parse"
         csInput' Boolean = "Boolean.Parse"
         csInput' String = ""
         csInput' Char = "Char.Parse"
         csInput' _ = error "Attempt to read value of unreadable type"
-        csInputImport t = if t `elem` [Integer, Float, Boolean, Char] then 
-          addSystemImport else id
+        csInputImport t = if t `elem` [Integer, Float, Double, Boolean, Char] 
+          then addSystemImport else id
 
 csOpenFileR :: (RenderSym repr) => VS (repr (Value repr)) -> 
   VS (repr (Type repr)) -> VS (repr (Value repr))

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer/CSharpRenderer.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer/CSharpRenderer.hs
@@ -35,27 +35,27 @@ import GOOL.Drasil.LanguageRenderer (classDocD, multiStateDocD, bodyDocD,
 import qualified GOOL.Drasil.LanguageRenderer.LanguagePolymorphic as G (
   oneLiner, multiBody, block, multiBlock, bool, int, float, double, char, 
   string, listType, arrayType, listInnerType, obj, enumType, funcType, void, 
-  runStrategy, listSlice, notOp, negateOp, equalOp, notEqualOp, greaterOp, 
-  greaterEqualOp, lessOp, lessEqualOp,plusOp, minusOp, multOp, divideOp, 
-  moduloOp, andOp, orOp, var, staticVar, extVar, self, enumVar, classVar, 
-  objVarSelf, listVar, listOf, arrayElem, iterVar, pi, litTrue, litFalse, 
-  litChar, litDouble, litFloat, litInt, litString, valueOf, arg, enumElement, 
-  argsList, inlineIf, objAccess, objMethodCall, objMethodCallNoParams, 
-  selfAccess, listIndexExists, indexOf, funcApp, funcAppMixedArgs, selfFuncApp, 
-  extFuncApp, newObj, lambda, notNull, func, get, set, listSize, listAdd, 
-  listAppend, iterBegin, iterEnd, listAccess, listSet, getFunc, setFunc, 
-  listAddFunc, listAppendFunc, iterBeginError, iterEndError, listAccessFunc, 
-  listSetFunc, printSt, state, loopState, emptyState, assign, 
-  assignToListIndex, multiAssignError, decrement, increment, decrement1, 
-  increment1, varDec, varDecDef, listDec, listDecDef', arrayDec, arrayDecDef, 
-  objDecNew, objDecNewNoParams, extObjDecNew, extObjDecNewNoParams, 
-  constDecDef, discardInput, openFileR, openFileW, openFileA, closeFile, 
-  discardFileLine, stringListVals, stringListLists, returnState, 
-  multiReturnError, valState, comment, freeError, throw, initState, 
-  changeState, initObserverList, addObserver, ifCond, ifNoElse, switch, 
-  switchAsIf, ifExists, for, forRange, forEach, while, tryCatch, checkState, 
-  notifyObservers, construct, param, method, getMethod, setMethod, privMethod, 
-  pubMethod, constructor, docMain, function, mainFunction, docFunc, 
+  runStrategy, listSlice, notOp, csc, sec, cot, negateOp, equalOp, notEqualOp, 
+  greaterOp, greaterEqualOp, lessOp, lessEqualOp,plusOp, minusOp, multOp, 
+  divideOp, moduloOp, andOp, orOp, var, staticVar, extVar, self, enumVar, 
+  classVar, objVarSelf, listVar, listOf, arrayElem, iterVar, pi, litTrue, 
+  litFalse, litChar, litDouble, litFloat, litInt, litString, valueOf, arg, 
+  enumElement, argsList, inlineIf, objAccess, objMethodCall, 
+  objMethodCallNoParams, selfAccess, listIndexExists, indexOf, funcApp, 
+  funcAppMixedArgs, selfFuncApp, extFuncApp, newObj, lambda, notNull, func, 
+  get, set, listSize, listAdd, listAppend, iterBegin, iterEnd, listAccess, 
+  listSet, getFunc, setFunc, listAddFunc, listAppendFunc, iterBeginError, 
+  iterEndError, listAccessFunc, listSetFunc, printSt, state, loopState, 
+  emptyState, assign, assignToListIndex, multiAssignError, decrement, 
+  increment, decrement1, increment1, varDec, varDecDef, listDec, listDecDef', 
+  arrayDec, arrayDecDef, objDecNew, objDecNewNoParams, extObjDecNew, 
+  extObjDecNewNoParams, constDecDef, discardInput, openFileR, openFileW, 
+  openFileA, closeFile, discardFileLine, stringListVals, stringListLists, 
+  returnState, multiReturnError, valState, comment, freeError, throw, 
+  initState, changeState, initObserverList, addObserver, ifCond, ifNoElse, 
+  switch, switchAsIf, ifExists, for, forRange, forEach, while, tryCatch, 
+  checkState, notifyObservers, construct, param, method, getMethod, setMethod, 
+  privMethod, pubMethod, constructor, docMain, function, mainFunction, docFunc, 
   docInOutFunc, intFunc, stateVar, stateVarDef, constVar, privMVar, pubMVar, 
   pubGVar, buildClass, enum, implementingClass, docClass, commentedClass, 
   intClass, buildModule', modFromData, fileDoc, docMod, fileFromData)
@@ -363,9 +363,9 @@ instance NumericExpression CSharpCode where
   sin = unExprNumDbl sinOp
   cos = unExprNumDbl cosOp
   tan = unExprNumDbl tanOp
-  csc v = litFloat 1.0 #/ sin v
-  sec v = litFloat 1.0 #/ cos v
-  cot v = litFloat 1.0 #/ tan v
+  csc = G.csc
+  sec = G.sec
+  cot = G.cot
   arcsin = unExprNumDbl asinOp
   arccos = unExprNumDbl acosOp
   arctan = unExprNumDbl atanOp

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer/CppRenderer.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer/CppRenderer.hs
@@ -1303,7 +1303,7 @@ instance ValueSym CppSrcCode where
   litString = G.litString
 
   pi = modify (addDefine "_USE_MATH_DEFINES") >> addMathHImport (mkStateVal 
-    float (text "M_PI"))
+    double (text "M_PI"))
 
   ($:) = enumElement
 
@@ -1951,7 +1951,7 @@ instance ValueSym CppHdrCode where
   litString = G.litString
 
   pi = modify (addHeaderDefine "_USE_MATH_DEFINES" . addHeaderLangImport 
-    "math.h") >> mkStateVal float (text "M_PI")
+    "math.h") >> mkStateVal double (text "M_PI")
 
   ($:) = enumElement
 
@@ -2487,7 +2487,8 @@ cppCast :: VS (CppSrcCode (Type CppSrcCode)) ->
   VS (CppSrcCode (Value CppSrcCode)) -> VS (CppSrcCode (Value CppSrcCode))
 cppCast t v = join $ on2StateValues (\tp vl -> cppCast' (getType tp) (getType $ 
   valueType vl) tp vl) t v
-  where cppCast' Float String _ _ = funcApp "std::stod" float [v]
+  where cppCast' Double String _ _ = funcApp "std::stod" double [v]
+        cppCast' Float String _ _ = funcApp "std::stof" float [v]
         cppCast' _ _ tp vl = mkStateVal t (castObjDocD (castDocD 
           (getTypeDoc tp)) (valueDoc vl))
 

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer/CppRenderer.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer/CppRenderer.hs
@@ -40,14 +40,15 @@ import qualified GOOL.Drasil.LanguageRenderer.LanguagePolymorphic as G (
   listSlice, notOp, negateOp, sqrtOp, absOp, expOp, sinOp, cosOp, tanOp, 
   asinOp, acosOp, atanOp, equalOp, notEqualOp, greaterOp, greaterEqualOp, 
   lessOp, lessEqualOp, plusOp, minusOp, multOp, divideOp, moduloOp, powerOp, 
-  andOp, orOp, var, staticVar, self, enumVar, objVar, listVar, listOf, arrayElem, litTrue, litFalse, litChar,
-  litFloat, litInt, litString, valueOf, arg, argsList, inlineIf, objAccess, 
-  objMethodCall, objMethodCallNoParams, selfAccess, listIndexExists, funcApp, 
-  namedArgError, newObj, lambda, func, get, set, listSize, listAdd, listAppend, 
-  iterBegin, iterEnd, listAccess, listSet, getFunc, setFunc, listSizeFunc, 
-  listAppendFunc, listAccessFunc', listSetFunc, state, loopState, emptyState, 
-  assign, assignToListIndex, multiAssignError, decrement, increment, 
-  decrement1, increment1, varDec, varDecDef, listDec, listDecDef, objDecNew, 
+  andOp, orOp, var, staticVar, self, enumVar, objVar, listVar, listOf, 
+  arrayElem, litTrue, litFalse, litChar, litDouble, litFloat, litInt, 
+  litString, valueOf, arg, argsList, inlineIf, objAccess, objMethodCall, 
+  objMethodCallNoParams, selfAccess, listIndexExists, funcApp, namedArgError, 
+  newObj, lambda, func, get, set, listSize, listAdd, listAppend, iterBegin, 
+  iterEnd, listAccess, listSet, getFunc, setFunc, listSizeFunc, listAppendFunc, 
+  listAccessFunc', listSetFunc, state, loopState, emptyState, assign, 
+  assignToListIndex, multiAssignError, decrement, increment, decrement1, 
+  increment1, varDec, varDecDef, listDec, listDecDef, objDecNew, 
   objDecNewNoParams, extObjDecNew, extObjDecNewNoParams, constDecDef, 
   funcDecDef, discardInput, discardFileInput, closeFile, stringListVals, 
   stringListLists, returnState, multiReturnError, valState, comment, throw, 
@@ -386,6 +387,7 @@ instance (Pair p) => ValueSym (p CppSrcCode CppHdrCode) where
   litTrue = on2StateValues pair litTrue litTrue
   litFalse = on2StateValues pair litFalse litFalse
   litChar c = on2StateValues pair (litChar c) (litChar c)
+  litDouble v = on2StateValues pair (litDouble v) (litDouble v)
   litFloat v = on2StateValues pair (litFloat v) (litFloat v)
   litInt v =on2StateValues  pair (litInt v) (litInt v)
   litString s = on2StateValues pair (litString s) (litString s)
@@ -1298,6 +1300,7 @@ instance ValueSym CppSrcCode where
   litTrue = G.litTrue
   litFalse = G.litFalse
   litChar = G.litChar
+  litDouble = G.litDouble
   litFloat = G.litFloat
   litInt = G.litInt
   litString = G.litString
@@ -1946,6 +1949,7 @@ instance ValueSym CppHdrCode where
   litTrue = G.litTrue
   litFalse = G.litFalse
   litChar = G.litChar
+  litDouble = G.litDouble
   litFloat = G.litFloat
   litInt = G.litInt
   litString = G.litString

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer/CppRenderer.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer/CppRenderer.hs
@@ -35,12 +35,12 @@ import GOOL.Drasil.LanguageRenderer (addExt, enumElementsDocD, multiStateDocD,
   commentedItem, addCommentsDocD, functionDox, commentedModD, valueList, 
   parameterList, appendToBody, surroundBody, getterName, setterName)
 import qualified GOOL.Drasil.LanguageRenderer.LanguagePolymorphic as G (
-  oneLiner, multiBody, block, multiBlock, int, double, char, string, listType, 
-  listInnerType, obj, enumType, funcType, void, runStrategy, listSlice, notOp, 
-  negateOp, sqrtOp, absOp, expOp, sinOp, cosOp, tanOp, asinOp, acosOp, atanOp, 
-  equalOp, notEqualOp, greaterOp, greaterEqualOp, lessOp, lessEqualOp, plusOp, 
-  minusOp, multOp, divideOp, moduloOp, powerOp, andOp, orOp, var, staticVar, 
-  self, enumVar, objVar, listVar, listOf, arrayElem, litTrue, litFalse, litChar,
+  oneLiner, multiBody, block, multiBlock, int, float, double, char, string, 
+  listType, listInnerType, obj, enumType, funcType, void, runStrategy, 
+  listSlice, notOp, negateOp, sqrtOp, absOp, expOp, sinOp, cosOp, tanOp, 
+  asinOp, acosOp, atanOp, equalOp, notEqualOp, greaterOp, greaterEqualOp, 
+  lessOp, lessEqualOp, plusOp, minusOp, multOp, divideOp, moduloOp, powerOp, 
+  andOp, orOp, var, staticVar, self, enumVar, objVar, listVar, listOf, arrayElem, litTrue, litFalse, litChar,
   litFloat, litInt, litString, valueOf, arg, argsList, inlineIf, objAccess, 
   objMethodCall, objMethodCallNoParams, selfAccess, listIndexExists, funcApp, 
   namedArgError, newObj, lambda, func, get, set, listSize, listAdd, listAppend, 
@@ -204,6 +204,7 @@ instance (Pair p) => TypeSym (p CppSrcCode CppHdrCode) where
   bool = on2StateValues pair bool bool
   int = on2StateValues pair int int
   float = on2StateValues pair float float
+  double = on2StateValues pair double double
   char = on2StateValues pair char char
   string = on2StateValues pair string string
   infile = on2StateValues pair infile infile
@@ -1165,7 +1166,8 @@ instance TypeSym CppSrcCode where
   type Type CppSrcCode = TypeData
   bool = cppBoolType
   int = G.int
-  float = G.double
+  float = G.float
+  double = G.double
   char = G.char
   string = modify (addUsing "string" . addLangImportVS "string") >> G.string
   infile = modify (addUsing "ifstream") >> cppInfileType
@@ -1830,7 +1832,8 @@ instance TypeSym CppHdrCode where
   type Type CppHdrCode = TypeData
   bool = cppBoolType
   int = G.int
-  float = G.double
+  float = G.float
+  double = G.double
   char = G.char
   string = modify (addHeaderUsing "string" . addHeaderLangImport "string") >> 
     G.string

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer/CppRenderer.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer/CppRenderer.hs
@@ -38,17 +38,17 @@ import qualified GOOL.Drasil.LanguageRenderer.LanguagePolymorphic as G (
   oneLiner, multiBody, block, multiBlock, int, float, double, char, string, 
   listType, listInnerType, obj, enumType, funcType, void, runStrategy, 
   listSlice, notOp, negateOp, sqrtOp, absOp, expOp, sinOp, cosOp, tanOp, 
-  asinOp, acosOp, atanOp, equalOp, notEqualOp, greaterOp, greaterEqualOp, 
-  lessOp, lessEqualOp, plusOp, minusOp, multOp, divideOp, moduloOp, powerOp, 
-  andOp, orOp, var, staticVar, self, enumVar, objVar, listVar, listOf, 
-  arrayElem, litTrue, litFalse, litChar, litDouble, litFloat, litInt, 
-  litString, valueOf, arg, argsList, inlineIf, objAccess, objMethodCall, 
-  objMethodCallNoParams, selfAccess, listIndexExists, funcApp, namedArgError, 
-  newObj, lambda, func, get, set, listSize, listAdd, listAppend, iterBegin, 
-  iterEnd, listAccess, listSet, getFunc, setFunc, listSizeFunc, listAppendFunc, 
-  listAccessFunc', listSetFunc, state, loopState, emptyState, assign, 
-  assignToListIndex, multiAssignError, decrement, increment, decrement1, 
-  increment1, varDec, varDecDef, listDec, listDecDef, objDecNew, 
+  asinOp, acosOp, atanOp, csc, sec, cot, equalOp, notEqualOp, greaterOp, 
+  greaterEqualOp, lessOp, lessEqualOp, plusOp, minusOp, multOp, divideOp, 
+  moduloOp, powerOp, andOp, orOp, var, staticVar, self, enumVar, objVar, 
+  listVar, listOf, arrayElem, litTrue, litFalse, litChar, litDouble, litFloat, 
+  litInt, litString, valueOf, arg, argsList, inlineIf, objAccess, 
+  objMethodCall, objMethodCallNoParams, selfAccess, listIndexExists, funcApp, 
+  namedArgError, newObj, lambda, func, get, set, listSize, listAdd, listAppend, 
+  iterBegin, iterEnd, listAccess, listSet, getFunc, setFunc, listSizeFunc, 
+  listAppendFunc, listAccessFunc', listSetFunc, state, loopState, emptyState, 
+  assign, assignToListIndex, multiAssignError, decrement, increment, 
+  decrement1, increment1, varDec, varDecDef, listDec, listDecDef, objDecNew, 
   objDecNewNoParams, extObjDecNew, extObjDecNewNoParams, constDecDef, 
   funcDecDef, discardInput, discardFileInput, closeFile, stringListVals, 
   stringListLists, returnState, multiReturnError, valState, comment, throw, 
@@ -1336,9 +1336,9 @@ instance NumericExpression CppSrcCode where
   sin = unExpr sinOp
   cos = unExpr cosOp
   tan = unExpr tanOp
-  csc v = litFloat 1.0 #/ sin v
-  sec v = litFloat 1.0 #/ cos v
-  cot v = litFloat 1.0 #/ tan v
+  csc = G.csc
+  sec = G.sec
+  cot = G.cot
   arcsin = unExpr asinOp
   arccos = unExpr acosOp
   arctan = unExpr atanOp

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer/JavaRenderer.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer/JavaRenderer.hs
@@ -815,8 +815,10 @@ jListType l t = modify (addLangImportVS $ "java.util." ++ render lst) >>
   (t >>= (jListType' . getType))
   where jListType' Integer = toState $ typeFromData (List Integer) (render lst 
           ++ "<Integer>") (lst <> angles (text "Integer"))
-        jListType' Float = toState $ typeFromData (List Float) (render lst ++ "<Double>") 
-          (lst <> angles (text "Double"))
+        jListType' Float = toState $ typeFromData (List Float) 
+          (render lst ++ "<Float>") (lst <> angles (text "Float"))
+        jListType' Double = toState $ typeFromData (List Double) 
+          (render lst ++ "<Double>") (lst <> angles (text "Double"))
         jListType' _ = G.listType l t
         lst = keyDoc l
 
@@ -845,7 +847,8 @@ jCast :: VS (JavaCode (Type JavaCode)) -> VS (JavaCode (Value JavaCode)) ->
   VS (JavaCode (Value JavaCode))
 jCast t v = join $ on2StateValues (\tp vl -> jCast' (getType tp) (getType $ 
   valueType vl) tp vl) t v
-  where jCast' Float String _ _ = funcApp "Double.parseDouble" float [v]
+  where jCast' Double String _ _ = funcApp "Double.parseDouble" double [v]
+        jCast' Float String _ _ = funcApp "Float.parseFloat" float [v]
         jCast' Integer (Enum _) _ _ = v $. func "ordinal" int []
         jCast' _ _ tp vl = mkStateVal t (castObjDocD (castDocD (getTypeDoc 
           tp)) (valueDoc vl))
@@ -883,8 +886,10 @@ jInput :: (RenderSym repr) => VS (repr (Type repr)) -> VS (repr (Value repr))
 jInput = on2StateValues (\t -> mkVal t . jInput' (getType t))
   where jInput' Integer inFn = text "Integer.parseInt" <> parens (valueDoc inFn 
           <> dot <> text "nextLine()")
-        jInput' Float inFn = text "Double.parseDouble" <> parens (valueDoc inFn 
+        jInput' Float inFn = text "Float.parseFloat" <> parens (valueDoc inFn 
           <> dot <> text "nextLine()")
+        jInput' Double inFn = text "Double.parseDouble" <> parens (valueDoc 
+          inFn <> dot <> text "nextLine()")
         jInput' Boolean inFn = valueDoc inFn <> dot <> text "nextBoolean()"
         jInput' String inFn = valueDoc inFn <> dot <> text "nextLine()"
         jInput' Char inFn = valueDoc inFn <> dot <> text "next().charAt(0)"

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer/JavaRenderer.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer/JavaRenderer.hs
@@ -35,11 +35,11 @@ import GOOL.Drasil.LanguageRenderer (packageDocD, classDocD, multiStateDocD,
 import qualified GOOL.Drasil.LanguageRenderer.LanguagePolymorphic as G (
   oneLiner, multiBody, block, multiBlock, bool, int, float, double, char, 
   listType, arrayType, listInnerType, obj, enumType, funcType, void, 
-  runStrategy, listSlice, notOp, negateOp, equalOp, notEqualOp, greaterOp, 
-  greaterEqualOp, lessOp, lessEqualOp, plusOp, minusOp, multOp, divideOp, 
-  moduloOp, andOp, orOp, var, staticVar, extVar, self, enumVar, classVar, 
-  objVar, objVarSelf, listVar, listOf, arrayElem, iterVar, litTrue, litFalse, 
-  litChar, litDouble, litFloat, litInt, litString, pi, valueOf, arg, 
+  runStrategy, listSlice, notOp, csc, sec, cot, negateOp, equalOp, notEqualOp, 
+  greaterOp, greaterEqualOp, lessOp, lessEqualOp, plusOp, minusOp, multOp, 
+  divideOp, moduloOp, andOp, orOp, var, staticVar, extVar, self, enumVar, 
+  classVar, objVar, objVarSelf, listVar, listOf, arrayElem, iterVar, litTrue, 
+  litFalse, litChar, litDouble, litFloat, litInt, litString, pi, valueOf, arg, 
   enumElement, argsList, inlineIf, objAccess, objMethodCall, 
   objMethodCallNoParams, selfAccess, listIndexExists, indexOf, funcApp, 
   namedArgError, selfFuncApp, extFuncApp, newObj, lambda, notNull, func, get, 
@@ -368,9 +368,9 @@ instance NumericExpression JavaCode where
   sin = unExprNumDbl sinOp
   cos = unExprNumDbl cosOp
   tan = unExprNumDbl tanOp
-  csc v = litFloat 1.0 #/ sin v
-  sec v = litFloat 1.0 #/ cos v
-  cot v = litFloat 1.0 #/ tan v
+  csc = G.csc
+  sec = G.sec
+  cot = G.cot
   arcsin = unExprNumDbl asinOp
   arccos = unExprNumDbl acosOp
   arctan = unExprNumDbl atanOp

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer/JavaRenderer.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer/JavaRenderer.hs
@@ -38,30 +38,30 @@ import qualified GOOL.Drasil.LanguageRenderer.LanguagePolymorphic as G (
   runStrategy, listSlice, notOp, negateOp, equalOp, notEqualOp, greaterOp, 
   greaterEqualOp, lessOp, lessEqualOp, plusOp, minusOp, multOp, divideOp, 
   moduloOp, andOp, orOp, var, staticVar, extVar, self, enumVar, classVar, 
-  objVar, objVarSelf, listVar, 
-  listOf, arrayElem, iterVar, litTrue, litFalse, litChar, litFloat, litInt, 
-  litString, pi, valueOf, arg, enumElement, argsList, inlineIf, objAccess, 
-  objMethodCall, objMethodCallNoParams, selfAccess, listIndexExists, indexOf, 
-  funcApp, namedArgError, selfFuncApp, extFuncApp, newObj, lambda, notNull, 
-  func, get, set, listSize, listAdd, listAppend, iterBegin, iterEnd, 
-  listAccess, listSet, getFunc, setFunc, listSizeFunc, listAddFunc, 
-  listAppendFunc, iterBeginError, iterEndError, listAccessFunc', printSt, 
-  state, loopState, emptyState, assign, assignToListIndex, multiAssignError, 
-  decrement, increment, decrement1, increment1, varDec, varDecDef, listDec, 
-  arrayDec, arrayDecDef, objDecNew, objDecNewNoParams, extObjDecNew, 
-  extObjDecNewNoParams, funcDecDef, discardInput, discardFileInput, openFileR, 
-  openFileW, openFileA, closeFile, discardFileLine, stringListVals, 
-  stringListLists, returnState, multiReturnError, valState, comment, freeError, 
-  throw, initState, changeState, initObserverList, addObserver, ifCond, 
-  ifNoElse, switch, switchAsIf, ifExists, for, forRange, forEach, while, 
-  tryCatch, checkState, notifyObservers, construct, param, method, getMethod, 
-  setMethod, privMethod, pubMethod, constructor, docMain, function, 
-  mainFunction, docFunc, intFunc, stateVar, stateVarDef, constVar, privMVar, 
-  pubMVar, pubGVar, buildClass, enum, extraClass, implementingClass, docClass, 
-  commentedClass, intClass, buildModule', modFromData, fileDoc, docMod, 
-  fileFromData)
+  objVar, objVarSelf, listVar, listOf, arrayElem, iterVar, litTrue, litFalse, 
+  litChar, litDouble, litFloat, litInt, litString, pi, valueOf, arg, 
+  enumElement, argsList, inlineIf, objAccess, objMethodCall, 
+  objMethodCallNoParams, selfAccess, listIndexExists, indexOf, funcApp, 
+  namedArgError, selfFuncApp, extFuncApp, newObj, lambda, notNull, func, get, 
+  set, listSize, listAdd, listAppend, iterBegin, iterEnd, listAccess, listSet, 
+  getFunc, setFunc, listSizeFunc, listAddFunc, listAppendFunc, iterBeginError, 
+  iterEndError, listAccessFunc', printSt, state, loopState, emptyState, assign, 
+  assignToListIndex, multiAssignError, decrement, increment, decrement1, 
+  increment1, varDec, varDecDef, listDec, arrayDec, arrayDecDef, objDecNew, 
+  objDecNewNoParams, extObjDecNew, extObjDecNewNoParams, funcDecDef, 
+  discardInput, discardFileInput, openFileR, openFileW, openFileA, closeFile, 
+  discardFileLine, stringListVals, stringListLists, returnState, 
+  multiReturnError, valState, comment, freeError, throw, initState, 
+  changeState, initObserverList, addObserver, ifCond, ifNoElse, switch, 
+  switchAsIf, ifExists, for, forRange, forEach, while, tryCatch, checkState, 
+  notifyObservers, construct, param, method, getMethod, setMethod, privMethod, 
+  pubMethod, constructor, docMain, function, mainFunction, docFunc, intFunc, 
+  stateVar, stateVarDef, constVar, privMVar, pubMVar, pubGVar, buildClass, 
+  enum, extraClass, implementingClass, docClass, commentedClass, intClass, 
+  buildModule', modFromData, fileDoc, docMod, fileFromData)
 import GOOL.Drasil.LanguageRenderer.LanguagePolymorphic (unOpPrec, unExpr, 
-  unExpr', typeUnExpr, powerPrec, binExpr, binExpr', typeBinExpr)
+  unExpr', unExprNumDbl, typeUnExpr, powerPrec, binExpr, binExprNumDbl', 
+  typeBinExpr)
 import GOOL.Drasil.Data (Terminator(..), ScopeTag(..), FileType(..), 
   Exception(..), FileData(..), fileD, FuncData(..), fd, ModData(..), md, 
   updateModDoc, MethodData(..), mthd, updateMthdDoc, OpData(..), od, 
@@ -331,6 +331,7 @@ instance ValueSym JavaCode where
   litTrue = G.litTrue
   litFalse = G.litFalse
   litChar = G.litChar
+  litDouble = G.litDouble
   litFloat = G.litFloat
   litInt = G.litInt
   litString = G.litString
@@ -352,27 +353,27 @@ instance ValueSym JavaCode where
 
 instance NumericExpression JavaCode where
   (#~) = unExpr' negateOp
-  (#/^) = unExpr sqrtOp
+  (#/^) = unExprNumDbl sqrtOp
   (#|) = unExpr absOp
   (#+) = binExpr plusOp
   (#-) = binExpr minusOp
   (#*) = binExpr multOp
   (#/) = binExpr divideOp
   (#%) = binExpr moduloOp
-  (#^) = binExpr' powerOp
+  (#^) = binExprNumDbl' powerOp
 
-  log = unExpr logOp
-  ln = unExpr lnOp
-  exp = unExpr expOp
-  sin = unExpr sinOp
-  cos = unExpr cosOp
-  tan = unExpr tanOp
+  log = unExprNumDbl logOp
+  ln = unExprNumDbl lnOp
+  exp = unExprNumDbl expOp
+  sin = unExprNumDbl sinOp
+  cos = unExprNumDbl cosOp
+  tan = unExprNumDbl tanOp
   csc v = litFloat 1.0 #/ sin v
   sec v = litFloat 1.0 #/ cos v
   cot v = litFloat 1.0 #/ tan v
-  arcsin = unExpr asinOp
-  arccos = unExpr acosOp
-  arctan = unExpr atanOp
+  arcsin = unExprNumDbl asinOp
+  arccos = unExprNumDbl acosOp
+  arctan = unExprNumDbl atanOp
   floor = unExpr floorOp
   ceil = unExpr ceilOp
 

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer/JavaRenderer.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer/JavaRenderer.hs
@@ -33,11 +33,12 @@ import GOOL.Drasil.LanguageRenderer (packageDocD, classDocD, multiStateDocD,
   addCommentsDocD, commentedModD, docFuncRepr, variableList, parameterList, 
   appendToBody, surroundBody, intValue)
 import qualified GOOL.Drasil.LanguageRenderer.LanguagePolymorphic as G (
-  oneLiner, multiBody, block, multiBlock, bool, int, double, char, listType, 
-  arrayType, listInnerType, obj, enumType, funcType, void, runStrategy, 
-  listSlice, notOp, negateOp, equalOp, notEqualOp, greaterOp, greaterEqualOp, 
-  lessOp, lessEqualOp, plusOp, minusOp, multOp, divideOp, moduloOp, andOp, orOp,
-  var, staticVar, extVar, self, enumVar, classVar, objVar, objVarSelf, listVar, 
+  oneLiner, multiBody, block, multiBlock, bool, int, float, double, char, 
+  listType, arrayType, listInnerType, obj, enumType, funcType, void, 
+  runStrategy, listSlice, notOp, negateOp, equalOp, notEqualOp, greaterOp, 
+  greaterEqualOp, lessOp, lessEqualOp, plusOp, minusOp, multOp, divideOp, 
+  moduloOp, andOp, orOp, var, staticVar, extVar, self, enumVar, classVar, 
+  objVar, objVarSelf, listVar, 
   listOf, arrayElem, iterVar, litTrue, litFalse, litChar, litFloat, litInt, 
   litString, pi, valueOf, arg, enumElement, argsList, inlineIf, objAccess, 
   objMethodCall, objMethodCallNoParams, selfAccess, listIndexExists, indexOf, 
@@ -197,7 +198,8 @@ instance TypeSym JavaCode where
   type Type JavaCode = TypeData
   bool = G.bool
   int = G.int
-  float = G.double
+  float = G.float
+  double = G.double
   char = G.char
   string = jStringType
   infile = jInfileType

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer/LanguagePolymorphic.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer/LanguagePolymorphic.hs
@@ -6,36 +6,34 @@ module GOOL.Drasil.LanguageRenderer.LanguagePolymorphic (fileFromData, oneLiner,
   fileType, listType, arrayType, listInnerType, obj, enumType, funcType, void, 
   runStrategy, listSlice, unOpPrec, notOp, notOp', negateOp, sqrtOp, sqrtOp', 
   absOp, absOp', expOp, expOp', sinOp, sinOp', cosOp, cosOp', tanOp, tanOp', 
-  asinOp, asinOp', acosOp, acosOp', atanOp, atanOp', unExpr, unExpr', 
-  unExprNumDbl,
-  typeUnExpr, powerPrec, multPrec, andPrec, orPrec, equalOp, notEqualOp, 
-  greaterOp, greaterEqualOp, lessOp, lessEqualOp, plusOp, minusOp, multOp, 
-  divideOp, moduloOp, powerOp, andOp, orOp, binExpr, binExpr', binExprNumDbl', 
-  typeBinExpr, 
-  addmathImport, var, staticVar, extVar, self, enumVar, classVar, objVar, 
-  objVarSelf, listVar, listOf, arrayElem, iterVar, litTrue, litFalse, litChar, 
-  litDouble, litFloat, litInt, litString, pi, valueOf, arg, enumElement, 
-  argsList, inlineIf, funcApp, funcAppMixedArgs, namedArgError, selfFuncApp, 
-  extFuncApp, newObj, lambda, notNull, objAccess, objMethodCall, 
-  objMethodCallNoParams, selfAccess, listIndexExists, indexOf, func, get, set, 
-  listSize, listAdd, listAppend, iterBegin, iterEnd, listAccess, listSet, 
-  getFunc, setFunc, listSizeFunc, listAddFunc, listAppendFunc, iterBeginError, 
-  iterEndError, listAccessFunc, listAccessFunc', listSetFunc, printSt, state, 
-  loopState, emptyState, assign, assignToListIndex, multiAssignError, 
-  decrement, increment, increment', increment1, increment1', decrement1, 
-  varDec, varDecDef, listDec, listDecDef, listDecDef', arrayDec, arrayDecDef, 
-  objDecNew, objDecNewNoParams, extObjDecNew, extObjDecNewNoParams, constDecDef,
-  funcDecDef, discardInput, discardFileInput, openFileR, openFileW,
-  openFileA, closeFile, discardFileLine, stringListVals, stringListLists, 
-  returnState, multiReturnError, valState, comment, freeError, throw, initState,
-  changeState, initObserverList, addObserver, ifCond, ifNoElse, switch, 
-  switchAsIf, ifExists, for, forRange, forEach, while, tryCatch, checkState, 
-  notifyObservers, construct, param, method, getMethod, setMethod,privMethod, 
-  pubMethod, constructor, docMain, function, mainFunction, docFunc, 
-  docInOutFunc, intFunc, stateVar, stateVarDef, constVar, privMVar, pubMVar, 
-  pubGVar, buildClass, enum, extraClass, implementingClass, docClass, 
-  commentedClass, intClass, buildModule, buildModule', modFromData, fileDoc, 
-  docMod
+  asinOp, asinOp', acosOp, acosOp', atanOp, atanOp', csc, sec, cot, unExpr, 
+  unExpr', unExprNumDbl, typeUnExpr, powerPrec, multPrec, andPrec, orPrec, 
+  equalOp, notEqualOp, greaterOp, greaterEqualOp, lessOp, lessEqualOp, plusOp, 
+  minusOp, multOp, divideOp, moduloOp, powerOp, andOp, orOp, binExpr, binExpr', 
+  binExprNumDbl', typeBinExpr, addmathImport, var, staticVar, extVar, self, 
+  enumVar, classVar, objVar, objVarSelf, listVar, listOf, arrayElem, iterVar, 
+  litTrue, litFalse, litChar, litDouble, litFloat, litInt, litString, pi, 
+  valueOf, arg, enumElement, argsList, inlineIf, funcApp, funcAppMixedArgs, 
+  namedArgError, selfFuncApp, extFuncApp, newObj, lambda, notNull, objAccess, 
+  objMethodCall, objMethodCallNoParams, selfAccess, listIndexExists, indexOf, 
+  func, get, set, listSize, listAdd, listAppend, iterBegin, iterEnd, 
+  listAccess, listSet, getFunc, setFunc, listSizeFunc, listAddFunc, 
+  listAppendFunc, iterBeginError, iterEndError, listAccessFunc, 
+  listAccessFunc', listSetFunc, printSt, state, loopState, emptyState, assign, 
+  assignToListIndex, multiAssignError, decrement, increment, increment', 
+  increment1, increment1', decrement1, varDec, varDecDef, listDec, listDecDef, 
+  listDecDef', arrayDec, arrayDecDef, objDecNew, objDecNewNoParams, 
+  extObjDecNew, extObjDecNewNoParams, constDecDef, funcDecDef, discardInput, 
+  discardFileInput, openFileR, openFileW, openFileA, closeFile, discardFileLine,
+  stringListVals, stringListLists, returnState, multiReturnError, valState, 
+  comment, freeError, throw, initState, changeState, initObserverList, 
+  addObserver, ifCond, ifNoElse, switch, switchAsIf, ifExists, for, forRange, 
+  forEach, while, tryCatch, checkState, notifyObservers, construct, param, 
+  method, getMethod, setMethod, privMethod, pubMethod, constructor, docMain, 
+  function, mainFunction, docFunc, docInOutFunc, intFunc, stateVar, 
+  stateVarDef, constVar, privMVar, pubMVar, pubGVar, buildClass, enum, 
+  extraClass, implementingClass, docClass, commentedClass, intClass, 
+  buildModule, buildModule', modFromData, fileDoc, docMod
 ) where
 
 import Utils.Drasil (indent)
@@ -50,8 +48,9 @@ import GOOL.Drasil.Symantics (Label, Library, KeywordSym(..), RenderSym,
   InternalType(..), UnaryOpSym(UnaryOp), BinaryOpSym(BinaryOp), InternalOp(..),
   VariableSym(Variable, variableBind, variableName, variableType, variableDoc), 
   InternalVariable(varFromData), ValueSym(Value, valueDoc, valueType), 
-  NumericExpression(..), BooleanExpression(..), InternalValue(..), 
-  Selector(($.)), FunctionSym(Function), SelectorFunction(at), 
+  NumericExpression((#+), (#-), (#*), (#/), sin, cos, tan), 
+  BooleanExpression(..), InternalValue(..), Selector(($.)), 
+  FunctionSym(Function), SelectorFunction(at), 
   InternalFunction(iterBeginFunc, iterEndFunc, functionDoc, functionType, 
     funcFromData),
   InternalStatement(statementDoc, statementTerm, stateFromData), 
@@ -98,7 +97,7 @@ import GOOL.Drasil.State (FS, CS, MS, VS, lensFStoGS, lensFStoCS, lensFStoMS,
   getLibImports, getModuleImports, setModuleName, getModuleName, setClassName, 
   getClassName, addParameter)
 
-import Prelude hiding (break,print,last,mod,pi,(<>))
+import Prelude hiding (break,print,last,mod,pi,sin,cos,tan,(<>))
 import Data.Bifunctor (first)
 import Data.List (sort, intersperse)
 import Data.Map as Map (lookup, fromList)
@@ -287,6 +286,20 @@ atanOp = unOpPrec "atan"
 
 atanOp' :: (RenderSym repr) => VS (repr (UnaryOp repr))
 atanOp' = addmathImport $ unOpPrec "math.atan"
+
+csc :: (RenderSym repr) => VS (repr (Value repr)) -> VS (repr (Value repr))
+csc v = valOfOne (fmap valueType v) #/ sin v
+
+sec :: (RenderSym repr) => VS (repr (Value repr)) -> VS (repr (Value repr))
+sec v = valOfOne (fmap valueType v) #/ cos v
+
+cot :: (RenderSym repr) => VS (repr (Value repr)) -> VS (repr (Value repr))
+cot v = valOfOne (fmap valueType v) #/ tan v
+
+valOfOne :: (RenderSym repr) => VS (repr (Type repr)) -> VS (repr (Value repr))
+valOfOne t = t >>= (getVal . getType)
+  where getVal Float = litFloat 1.0
+        getVal _ = litDouble 1.0
 
 unOpDocD :: Doc -> Doc -> Doc
 unOpDocD op v = op <> parens v

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer/LanguagePolymorphic.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer/LanguagePolymorphic.hs
@@ -61,7 +61,8 @@ import GOOL.Drasil.Symantics (Label, Library, KeywordSym(..), RenderSym,
   ModuleSym(Module), InternalMod(moduleDoc, updateModuleDoc), BlockComment(..))
 import qualified GOOL.Drasil.Symantics as S (InternalFile(fileFromData), 
   BodySym(oneLiner), BlockSym(block), 
-  TypeSym(bool, int, float, char, string, listType, arrayType, listInnerType, void), 
+  TypeSym(bool, int, float, double, char, string, listType, arrayType, 
+    listInnerType, void), 
   VariableSym(var, self, objVar, objVarSelf, listVar, listOf),
   ValueSym(litTrue, litFalse, litInt, litString, valueOf),
   ValueExpression(funcApp, newObj, extNewObj, notNull, lambda), 
@@ -142,7 +143,7 @@ float :: (RenderSym repr) => VS (repr (Type repr))
 float = toState $ typeFromData Float "float" (text "float")
 
 double :: (RenderSym repr) => VS (repr (Type repr))
-double = toState $ typeFromData Float "double" (text "double")
+double = toState $ typeFromData Double "double" (text "double")
 
 char :: (RenderSym repr) => VS (repr (Type repr))
 char = toState $ typeFromData Char "char" (text "char")
@@ -472,7 +473,7 @@ litString :: (RenderSym repr) => String -> VS (repr (Value repr))
 litString s = mkStateVal S.string (doubleQuotedText s)
 
 pi :: (RenderSym repr) => VS (repr (Value repr))
-pi = mkStateVal S.float (text "Math.PI")
+pi = mkStateVal S.double (text "Math.PI")
 
 valueOf :: (RenderSym repr) => VS (repr (Variable repr)) -> 
   VS (repr (Value repr))
@@ -1193,6 +1194,8 @@ numType t1 t2 = numericType (getType t1) (getType t2)
   where numericType Integer Integer = t1
         numericType Float _ = t1
         numericType _ Float = t2
+        numericType Double _ = t1
+        numericType _ Double = t2
         numericType _ _ = error "Numeric types required for numeric expression"
 
 mkExpr :: (RenderSym repr) => Int -> repr (Type repr) -> Doc -> 

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer/PythonRenderer.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer/PythonRenderer.hs
@@ -184,7 +184,8 @@ instance TypeSym PythonCode where
   type Type PythonCode = TypeData
   bool = toState $ typeFromData Boolean "" empty
   int = G.int
-  float = G.float
+  float = double -- map floats to doubles for now so current examples dont break
+  double = G.float
   char = toState $ typeFromData Char "" empty
   string = pyStringType
   infile = toState $ typeFromData File "" empty

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer/PythonRenderer.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer/PythonRenderer.hs
@@ -36,7 +36,7 @@ import qualified GOOL.Drasil.LanguageRenderer.LanguagePolymorphic as G (
   sinOp', cosOp', tanOp', asinOp', acosOp', atanOp', equalOp, notEqualOp, 
   greaterOp, greaterEqualOp, lessOp, lessEqualOp, plusOp, minusOp, multOp, 
   divideOp, moduloOp, var, staticVar, extVar, enumVar, classVar, objVar, 
-  objVarSelf, listVar, listOf, arrayElem, iterVar, litChar, litFloat, litInt, 
+  objVarSelf, listVar, listOf, arrayElem, iterVar, litChar, litDouble, litInt, 
   litString, valueOf, arg, enumElement, argsList, objAccess, objMethodCall, 
   objMethodCallNoParams, selfAccess, listIndexExists, indexOf, funcApp, 
   funcAppMixedArgs, selfFuncApp, extFuncApp, newObj, lambda, func, get, set, 
@@ -321,7 +321,8 @@ instance ValueSym PythonCode where
   litTrue = mkStateVal bool (text "True")
   litFalse = mkStateVal bool (text "False")
   litChar = G.litChar
-  litFloat = G.litFloat
+  litDouble = G.litDouble
+  litFloat = litDouble . realToFrac -- map to litDouble for now so current examples don't break
   litInt = G.litInt
   litString = G.litString
 
@@ -357,9 +358,9 @@ instance NumericExpression PythonCode where
   sin = unExpr sinOp
   cos = unExpr cosOp
   tan = unExpr tanOp
-  csc v = litFloat 1.0 #/ sin v
-  sec v = litFloat 1.0 #/ cos v
-  cot v = litFloat 1.0 #/ tan v
+  csc v = litDouble 1.0 #/ sin v
+  sec v = litDouble 1.0 #/ cos v
+  cot v = litDouble 1.0 #/ tan v
   arcsin = unExpr asinOp
   arccos = unExpr acosOp
   arctan = unExpr atanOp

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer/PythonRenderer.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer/PythonRenderer.hs
@@ -33,15 +33,15 @@ import GOOL.Drasil.LanguageRenderer (enumElementsDocD', multiStateDocD,
 import qualified GOOL.Drasil.LanguageRenderer.LanguagePolymorphic as G (
   oneLiner, multiBody, block, multiBlock, int, float, listInnerType, obj, 
   enumType, funcType, runStrategy, notOp', negateOp, sqrtOp', absOp', expOp', 
-  sinOp', cosOp', tanOp', asinOp', acosOp', atanOp', equalOp, notEqualOp, 
-  greaterOp, greaterEqualOp, lessOp, lessEqualOp, plusOp, minusOp, multOp, 
-  divideOp, moduloOp, var, staticVar, extVar, enumVar, classVar, objVar, 
-  objVarSelf, listVar, listOf, arrayElem, iterVar, litChar, litDouble, litInt, 
-  litString, valueOf, arg, enumElement, argsList, objAccess, objMethodCall, 
-  objMethodCallNoParams, selfAccess, listIndexExists, indexOf, funcApp, 
-  funcAppMixedArgs, selfFuncApp, extFuncApp, newObj, lambda, func, get, set, 
-  listAdd, listAppend, iterBegin, iterEnd, listAccess, listSet, getFunc, 
-  setFunc, listAddFunc, listAppendFunc, iterBeginError, iterEndError, 
+  sinOp', cosOp', tanOp', asinOp', acosOp', atanOp', csc, sec, cot, equalOp, 
+  notEqualOp, greaterOp, greaterEqualOp, lessOp, lessEqualOp, plusOp, minusOp, 
+  multOp, divideOp, moduloOp, var, staticVar, extVar, enumVar, classVar, 
+  objVar, objVarSelf, listVar, listOf, arrayElem, iterVar, litChar, litDouble, 
+  litInt, litString, valueOf, arg, enumElement, argsList, objAccess, 
+  objMethodCall, objMethodCallNoParams, selfAccess, listIndexExists, indexOf, 
+  funcApp, funcAppMixedArgs, selfFuncApp, extFuncApp, newObj, lambda, func, 
+  get, set, listAdd, listAppend, iterBegin, iterEnd, listAccess, listSet, 
+  getFunc, setFunc, listAddFunc, listAppendFunc, iterBeginError, iterEndError, 
   listAccessFunc, listSetFunc, state, loopState, emptyState, assign, 
   assignToListIndex, decrement, increment', increment1', decrement1, objDecNew, 
   objDecNewNoParams, closeFile, discardFileLine, stringListVals, 
@@ -358,9 +358,9 @@ instance NumericExpression PythonCode where
   sin = unExpr sinOp
   cos = unExpr cosOp
   tan = unExpr tanOp
-  csc v = litDouble 1.0 #/ sin v
-  sec v = litDouble 1.0 #/ cos v
-  cot v = litDouble 1.0 #/ tan v
+  csc = G.csc
+  sec = G.sec
+  cot = G.cot
   arcsin = unExpr asinOp
   arccos = unExpr acosOp
   arctan = unExpr atanOp

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer/PythonRenderer.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer/PythonRenderer.hs
@@ -325,7 +325,7 @@ instance ValueSym PythonCode where
   litInt = G.litInt
   litString = G.litString
 
-  pi = addmathImport $ mkStateVal float (text "math.pi")
+  pi = addmathImport $ mkStateVal double (text "math.pi")
 
   ($:) = enumElement
 
@@ -784,7 +784,8 @@ pyInput :: VS (PythonCode (Value PythonCode)) ->
   MS (PythonCode (Statement PythonCode))
 pyInput inSrc v = v &= (v >>= pyInput' . getType . variableType)
   where pyInput' Integer = funcApp "int" int [inSrc]
-        pyInput' Float = funcApp "float" float [inSrc]
+        pyInput' Float = funcApp "float" double [inSrc]
+        pyInput' Double = funcApp "float" double [inSrc]
         pyInput' Boolean = inSrc ?!= litString "0"
         pyInput' String = objMethodCall string inSrc "rstrip" []
         pyInput' Char = inSrc

--- a/code/drasil-gool/GOOL/Drasil/Symantics.hs
+++ b/code/drasil-gool/GOOL/Drasil/Symantics.hs
@@ -132,6 +132,7 @@ class (PermanenceSym repr) => TypeSym repr where
   bool          :: VS (repr (Type repr))
   int           :: VS (repr (Type repr))
   float         :: VS (repr (Type repr))
+  double        :: VS (repr (Type repr))
   char          :: VS (repr (Type repr))
   string        :: VS (repr (Type repr))
   infile        :: VS (repr (Type repr))

--- a/code/drasil-gool/GOOL/Drasil/Symantics.hs
+++ b/code/drasil-gool/GOOL/Drasil/Symantics.hs
@@ -256,7 +256,8 @@ class (VariableSym repr) => ValueSym repr where
   litTrue   :: VS (repr (Value repr))
   litFalse  :: VS (repr (Value repr))
   litChar   :: Char -> VS (repr (Value repr))
-  litFloat  :: Double -> VS (repr (Value repr))
+  litDouble :: Double -> VS (repr (Value repr))
+  litFloat  :: Float -> VS (repr (Value repr))
   litInt    :: Integer -> VS (repr (Value repr))
   litString :: String -> VS (repr (Value repr))
 


### PR DESCRIPTION
This PR changes GOOL to distinguish between floats and doubles, so GOOL is now ready to handle the implementation of a floats vs. doubles choice (#1863). For now, we just render everything as doubles, which is what we were doing before, so there are no changes to stable.