### PR TITLE
GOOL List/Array updates

### DIFF
--- a/code/drasil-code/Language/Drasil/Code/Imperative/Import.hs
+++ b/code/drasil-code/Language/Drasil/Code/Imperative/Import.hs
@@ -423,7 +423,8 @@ convStmt (FAsg v (Matrix [es]))  = do
       listFunc (C.Array _) = litArray
       listFunc _ = error "Type mismatch between variable and value in assignment FuncStmt"
   l <- maybeLog v'
-  return $ multi $ assign v' (listFunc t (fmap variableType v') els) : l
+  return $ multi $ assign v' (listFunc t (listInnerType $ fmap variableType v') 
+    els) : l
 convStmt (FAsg v e) = do
   e' <- convExpr e
   v' <- mkVar v

--- a/code/drasil-code/Language/Drasil/Code/Imperative/Import.hs
+++ b/code/drasil-code/Language/Drasil/Code/Imperative/Import.hs
@@ -249,7 +249,7 @@ convExpr (Case c l)      = doit l -- FIXME this is sub-optimal
     doit [(e,_)] = convExpr e -- should always be the else clause
     doit ((e,cond):xs) = liftM3 inlineIf (convExpr cond) (convExpr e) 
       (convExpr (Case c xs))
-convExpr (Matrix [(e:es)]) = do
+convExpr (Matrix [e:es]) = do
   (el:els) <- mapM convExpr (e:es)
   return $ litArray (fmap valueType el) els
 convExpr Matrix{}    = error "convExpr: Matrix"

--- a/code/drasil-gool/GOOL/Drasil/CodeInfo.hs
+++ b/code/drasil-gool/GOOL/Drasil/CodeInfo.hs
@@ -140,6 +140,8 @@ instance ValueSym CodeInfo where
   litFloat _ = noInfo
   litInt _ = noInfo
   litString _ = noInfo
+  litArray _ = executeList
+  litList _ = executeList
 
   pi = noInfo
 

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer/CSharpRenderer.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer/CSharpRenderer.hs
@@ -39,8 +39,8 @@ import qualified GOOL.Drasil.LanguageRenderer.LanguagePolymorphic as G (
   greaterOp, greaterEqualOp, lessOp, lessEqualOp,plusOp, minusOp, multOp, 
   divideOp, moduloOp, andOp, orOp, var, staticVar, extVar, self, enumVar, 
   classVar, objVarSelf, listVar, listOf, arrayElem, iterVar, pi, litTrue, 
-  litFalse, litChar, litDouble, litFloat, litInt, litString, valueOf, arg, 
-  enumElement, argsList, inlineIf, objAccess, objMethodCall, 
+  litFalse, litChar, litDouble, litFloat, litInt, litString, litList, valueOf, 
+  arg, enumElement, argsList, inlineIf, objAccess, objMethodCall, 
   objMethodCallNoParams, selfAccess, listIndexExists, indexOf, call, funcApp, 
   selfFuncApp, extFuncApp, newObj, lambda, notNull, func, get, set, listSize, 
   listAdd, listAppend, iterBegin, iterEnd, listAccess, listSet, getFunc, 
@@ -330,6 +330,8 @@ instance ValueSym CSharpCode where
   litFloat = G.litFloat
   litInt = G.litInt
   litString = G.litString
+  litArray = G.litList arrayType
+  litList = G.litList listType
 
   pi = G.pi
 

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer/CppRenderer.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer/CppRenderer.hs
@@ -42,7 +42,7 @@ import qualified GOOL.Drasil.LanguageRenderer.LanguagePolymorphic as G (
   greaterEqualOp, lessOp, lessEqualOp, plusOp, minusOp, multOp, divideOp, 
   moduloOp, powerOp, andOp, orOp, var, staticVar, self, enumVar, objVar, 
   listVar, listOf, arrayElem, litTrue, litFalse, litChar, litDouble, litFloat, 
-  litInt, litString, valueOf, arg, argsList, inlineIf, objAccess, 
+  litInt, litString, litArray, valueOf, arg, argsList, inlineIf, objAccess, 
   objMethodCall, objMethodCallNoParams, selfAccess, listIndexExists, call', 
   funcApp, selfFuncApp, newObj, lambda, func, get, set, listSize, listAdd, 
   listAppend, iterBegin, iterEnd, listAccess, listSet, getFunc, setFunc, 
@@ -391,6 +391,8 @@ instance (Pair p) => ValueSym (p CppSrcCode CppHdrCode) where
   litFloat v = on2StateValues pair (litFloat v) (litFloat v)
   litInt v =on2StateValues  pair (litInt v) (litInt v)
   litString s = on2StateValues pair (litString s) (litString s)
+  litArray = pair1Val1List litArray litArray
+  litList = pair1Val1List litList litList
 
   pi = on2StateValues pair pi pi
 
@@ -1332,6 +1334,8 @@ instance ValueSym CppSrcCode where
   litFloat = G.litFloat
   litInt = G.litInt
   litString = G.litString
+  litArray = G.litArray
+  litList _ _ = error $ "List literals not supported in " ++ cppName
 
   pi = modify (addDefine "_USE_MATH_DEFINES") >> addMathHImport (mkStateVal 
     double (text "M_PI"))
@@ -1988,6 +1992,8 @@ instance ValueSym CppHdrCode where
   litFloat = G.litFloat
   litInt = G.litInt
   litString = G.litString
+  litArray = G.litArray
+  litList _ _ = error $ "List literals not supported in " ++ cppName
 
   pi = modify (addHeaderDefine "_USE_MATH_DEFINES" . addHeaderLangImport 
     "math.h") >> mkStateVal double (text "M_PI")

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer/JavaRenderer.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer/JavaRenderer.hs
@@ -39,16 +39,16 @@ import qualified GOOL.Drasil.LanguageRenderer.LanguagePolymorphic as G (
   greaterOp, greaterEqualOp, lessOp, lessEqualOp, plusOp, minusOp, multOp, 
   divideOp, moduloOp, andOp, orOp, var, staticVar, extVar, self, enumVar, 
   classVar, objVar, objVarSelf, listVar, listOf, arrayElem, iterVar, litTrue, 
-  litFalse, litChar, litDouble, litFloat, litInt, litString, pi, valueOf, arg, 
-  enumElement, argsList, inlineIf, objAccess, objMethodCall, 
+  litFalse, litChar, litDouble, litFloat, litInt, litString, litArray, pi, 
+  valueOf, arg, enumElement, argsList, inlineIf, objAccess, objMethodCall, 
   objMethodCallNoParams, selfAccess, listIndexExists, indexOf, call', funcApp, 
   selfFuncApp, extFuncApp, newObj, lambda, notNull, func, get, set, listSize, 
   listAdd, listAppend, iterBegin, iterEnd, listAccess, listSet, getFunc, 
   setFunc, listSizeFunc, listAddFunc, listAppendFunc, iterBeginError, 
   iterEndError, listAccessFunc', printSt, state, loopState, emptyState, assign, 
   assignToListIndex, multiAssignError, decrement, increment, decrement1, 
-  increment1, varDec, varDecDef, listDec, arrayDec, arrayDecDef, objDecNew, 
-  objDecNewNoParams, extObjDecNew, extObjDecNewNoParams, funcDecDef, 
+  increment1, varDec, varDecDef, listDec, listDecDef', arrayDec, arrayDecDef, 
+  objDecNew, objDecNewNoParams, extObjDecNew, extObjDecNewNoParams, funcDecDef, 
   discardInput, discardFileInput, openFileR, openFileW, openFileA, closeFile, 
   discardFileLine, stringListVals, stringListLists, returnState, 
   multiReturnError, valState, comment, freeError, throw, initState, 
@@ -71,7 +71,7 @@ import GOOL.Drasil.Helpers (angles, emptyIfNull, toCode, toState, onCodeValue,
   onStateValue, on2CodeValues, on2StateValues, on3CodeValues, on3StateValues, 
   onCodeList, onStateList, on1CodeValue1List, on1StateValue1List)
 import GOOL.Drasil.State (GOOLState, MS, VS, lensGStoFS, lensFStoVS, lensMStoFS,
-  lensMStoVS, lensVStoFS, initialState, initialFS, modifyReturn, 
+  lensMStoVS, lensVStoFS, lensVStoMS, initialState, initialFS, modifyReturn, 
   modifyReturnFunc, addODEFilePaths, addProgNameToPaths, addODEFiles, 
   getODEFiles, addLangImport, addLangImportVS, addExceptionImports, 
   addLibImport, getModuleName, setFileType, getClassName, setCurrMain, 
@@ -335,6 +335,10 @@ instance ValueSym JavaCode where
   litFloat = G.litFloat
   litInt = G.litInt
   litString = G.litString
+  litArray = G.litArray
+  litList t es = zoom lensVStoMS (modify (if null es then id else addLangImport 
+    "java.util.Arrays")) >> newObj (listType t) [funcApp "Arrays.asList" 
+    (listType t) es | not (null es)]
 
   pi = G.pi
 
@@ -525,9 +529,7 @@ instance StatementSym JavaCode where
   varDecDef = G.varDecDef
   listDec n v = zoom lensMStoVS v >>= (\v' -> G.listDec (listDecDocD v') 
     (litInt n) v)
-  listDecDef v vs = modify (if null vs then id else addLangImport 
-    "java.util.Arrays") >> objDecNew v [funcApp "Arrays.asList" 
-    (onStateValue variableType v) vs | not (null vs)]
+  listDecDef = G.listDecDef'
   arrayDec n = G.arrayDec (litInt n)
   arrayDecDef = G.arrayDecDef
   objDecDef = varDecDef

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer/LanguagePolymorphic.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer/LanguagePolymorphic.hs
@@ -678,8 +678,14 @@ iterEnd v = v $. iterEndFunc (S.listInnerType $ onStateValue valueType v)
 
 listAccess :: (RenderSym repr) => VS (repr (Value repr)) -> 
   VS (repr (Value repr)) -> VS (repr (Value repr))
-listAccess v i = v $. S.listAccessFunc (S.listInnerType $ onStateValue 
-  valueType v) i
+listAccess v i = do
+  v' <- v
+  let checkType (List _) = S.listAccessFunc (S.listInnerType $ return $ 
+        valueType v') i
+      checkType (Array _) = i >>= (\ix -> funcFromData (brackets (valueDoc ix)) 
+        (S.listInnerType $ return $ valueType v'))
+      checkType _ = error "listAccess called on non-list-type value"
+  v $. checkType (getType (valueType v'))
 
 listSet :: (RenderSym repr) => VS (repr (Value repr)) -> VS (repr (Value repr)) 
   -> VS (repr (Value repr)) -> VS (repr (Value repr))

--- a/code/drasil-gool/GOOL/Drasil/Symantics.hs
+++ b/code/drasil-gool/GOOL/Drasil/Symantics.hs
@@ -235,9 +235,9 @@ class (TypeSym repr) => VariableSym repr where
   enumVar      :: Label -> Label -> VS (repr (Variable repr))
   listVar      :: Label -> VS (repr (Type repr)) -> VS (repr (Variable repr))
   listOf       :: Label -> VS (repr (Type repr)) -> VS (repr (Variable repr))
-  -- Use for iterator variables, i.e. in a forEach loop.
   arrayElem    :: Integer -> VS (repr (Variable repr)) -> 
     VS (repr (Variable repr))
+  -- Use for iterator variables, i.e. in a forEach loop.
   iterVar      :: Label -> VS (repr (Type repr)) -> VS (repr (Variable repr))
 
   ($->) :: VS (repr (Variable repr)) -> VS (repr (Variable repr)) -> VS (repr (Variable repr))
@@ -261,6 +261,10 @@ class (VariableSym repr) => ValueSym repr where
   litFloat  :: Float -> VS (repr (Value repr))
   litInt    :: Integer -> VS (repr (Value repr))
   litString :: String -> VS (repr (Value repr))
+  litArray  :: VS (repr (Type repr)) -> [VS (repr (Value repr))] ->
+    VS (repr (Value repr))
+  litList   :: VS (repr (Type repr)) -> [VS (repr (Value repr))] -> 
+    VS (repr (Value repr))
 
   pi :: VS (repr (Value repr))
 


### PR DESCRIPTION
Some updates to GOOL needed for external libraries, like list- and array-typed literal values and making `listAccess` work on both lists and arrays. Also uses these new GOOL methods to implement the translator for `Matrix` `Expr`s in Drasil.