### PR TITLE
GOOL methods for calling library functions

### DIFF
--- a/code/drasil-code/Language/Drasil/Code/Imperative/Import.hs
+++ b/code/drasil-code/Language/Drasil/Code/Imperative/Import.hs
@@ -249,7 +249,7 @@ convExpr (Case c l)      = doit l -- FIXME this is sub-optimal
     doit [(e,_)] = convExpr e -- should always be the else clause
     doit ((e,cond):xs) = liftM3 inlineIf (convExpr cond) (convExpr e) 
       (convExpr (Case c xs))
-convExpr (Matrix [(e:es)]) = do
+convExpr (Matrix [e:es]) = do
   (el:els) <- mapM convExpr (e:es)
   return $ litArray (fmap valueType el) els
 convExpr Matrix{}    = error "convExpr: Matrix"

--- a/code/drasil-gool/GOOL/Drasil/CodeInfo.hs
+++ b/code/drasil-gool/GOOL/Drasil/CodeInfo.hs
@@ -140,6 +140,8 @@ instance ValueSym CodeInfo where
   litFloat _ = noInfo
   litInt _ = noInfo
   litString _ = noInfo
+  litArray _ = executeList
+  litList _ = executeList
 
   pi = noInfo
 

--- a/code/drasil-gool/GOOL/Drasil/CodeInfo.hs
+++ b/code/drasil-gool/GOOL/Drasil/CodeInfo.hs
@@ -211,7 +211,9 @@ instance ValueExpression CodeInfo where
   extFuncAppMixedArgs l n _ vs ns = do
     sequence_ vs
     executePairList ns
-    addExternalCall l n
+    addExternalCall l n  
+  libFuncApp = extFuncApp
+  libFuncAppMixedArgs = extFuncAppMixedArgs
   newObj ot vs = do
     sequence_ vs
     addCurrModConstructorCall ot
@@ -226,6 +228,8 @@ instance ValueExpression CodeInfo where
     sequence_ vs
     executePairList ns
     addExternalConstructorCall l ot
+  libNewObj = extNewObj
+  libNewObjMixedArgs = extNewObjMixedArgs
 
   lambda _ = execute1
 

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer/CSharpRenderer.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer/CSharpRenderer.hs
@@ -42,9 +42,11 @@ import qualified GOOL.Drasil.LanguageRenderer.LanguagePolymorphic as G (
   litFalse, litChar, litDouble, litFloat, litInt, litString, litList, valueOf, 
   arg, enumElement, argsList, inlineIf, objAccess, objMethodCall, 
   objMethodCallNoParams, selfAccess, listIndexExists, indexOf, call, funcApp, 
-  selfFuncApp, extFuncApp, newObj, lambda, notNull, func, get, set, listSize, 
-  listAdd, listAppend, iterBegin, iterEnd, listAccess, listSet, getFunc, 
-  setFunc, listAddFunc, listAppendFunc, iterBeginError, iterEndError, 
+  funcAppMixedArgs, selfFuncApp, selfFuncAppMixedArgs, extFuncApp, 
+  extFuncAppMixedArgs, libFuncApp, libFuncAppMixedArgs, newObj, 
+  newObjMixedArgs, libNewObj, libNewObjMixedArgs, lambda, notNull, func, get, 
+  set, listSize, listAdd, listAppend, iterBegin, iterEnd, listAccess, listSet, 
+  getFunc, setFunc, listAddFunc, listAppendFunc, iterBeginError, iterEndError, 
   listAccessFunc, listSetFunc, printSt, state, loopState, emptyState, assign, 
   assignToListIndex, multiAssignError, decrement, increment, decrement1, 
   increment1, varDec, varDecDef, listDec, listDecDef', arrayDec, arrayDecDef, 
@@ -388,17 +390,21 @@ instance BooleanExpression CSharpCode where
   
 instance ValueExpression CSharpCode where
   inlineIf = G.inlineIf
-  funcApp n t vs = G.funcApp n t vs []
-  funcAppNamedArgs n t = G.funcApp n t []
-  funcAppMixedArgs = G.funcApp
-  selfFuncApp n t vs = selfFuncAppMixedArgs n t vs []
-  selfFuncAppMixedArgs = G.selfFuncApp dot self
-  extFuncApp l n t vs = extFuncAppMixedArgs l n t vs []
-  extFuncAppMixedArgs = G.extFuncApp
-  newObj t vs = newObjMixedArgs t vs []
-  newObjMixedArgs = G.newObj "new "
+  funcApp = G.funcApp
+  funcAppNamedArgs n t = funcAppMixedArgs n t []
+  funcAppMixedArgs = G.funcAppMixedArgs
+  selfFuncApp = G.selfFuncApp
+  selfFuncAppMixedArgs = G.selfFuncAppMixedArgs dot self
+  extFuncApp = G.extFuncApp
+  extFuncAppMixedArgs = G.extFuncAppMixedArgs
+  libFuncApp = G.libFuncApp
+  libFuncAppMixedArgs = G.libFuncAppMixedArgs
+  newObj = G.newObj
+  newObjMixedArgs = G.newObjMixedArgs "new "
   extNewObj _ = newObj
   extNewObjMixedArgs _ = newObjMixedArgs
+  libNewObj = G.libNewObj
+  libNewObjMixedArgs = G.libNewObjMixedArgs
 
   lambda = G.lambda csLambda
 

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer/CSharpRenderer.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer/CSharpRenderer.hs
@@ -39,8 +39,8 @@ import qualified GOOL.Drasil.LanguageRenderer.LanguagePolymorphic as G (
   greaterOp, greaterEqualOp, lessOp, lessEqualOp,plusOp, minusOp, multOp, 
   divideOp, moduloOp, andOp, orOp, var, staticVar, extVar, self, enumVar, 
   classVar, objVarSelf, listVar, listOf, arrayElem, iterVar, pi, litTrue, 
-  litFalse, litChar, litDouble, litFloat, litInt, litString, valueOf, arg, 
-  enumElement, argsList, inlineIf, objAccess, objMethodCall, 
+  litFalse, litChar, litDouble, litFloat, litInt, litString, litList, valueOf, 
+  arg, enumElement, argsList, inlineIf, objAccess, objMethodCall, 
   objMethodCallNoParams, selfAccess, listIndexExists, indexOf, call, funcApp, 
   selfFuncApp, extFuncApp, newObj, lambda, notNull, func, get, set, listSize, 
   listAdd, listAppend, iterBegin, iterEnd, listAccess, listSet, getFunc, 
@@ -330,6 +330,8 @@ instance ValueSym CSharpCode where
   litFloat = G.litFloat
   litInt = G.litInt
   litString = G.litString
+  litArray = G.litList arrayType
+  litList = G.litList listType
 
   pi = G.pi
 

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer/CppRenderer.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer/CppRenderer.hs
@@ -42,7 +42,7 @@ import qualified GOOL.Drasil.LanguageRenderer.LanguagePolymorphic as G (
   greaterEqualOp, lessOp, lessEqualOp, plusOp, minusOp, multOp, divideOp, 
   moduloOp, powerOp, andOp, orOp, var, staticVar, self, enumVar, objVar, 
   listVar, listOf, arrayElem, litTrue, litFalse, litChar, litDouble, litFloat, 
-  litInt, litString, valueOf, arg, argsList, inlineIf, objAccess, 
+  litInt, litString, litArray, valueOf, arg, argsList, inlineIf, objAccess, 
   objMethodCall, objMethodCallNoParams, selfAccess, listIndexExists, call', 
   funcApp, selfFuncApp, newObj, lambda, func, get, set, listSize, listAdd, 
   listAppend, iterBegin, iterEnd, listAccess, listSet, getFunc, setFunc, 
@@ -391,6 +391,8 @@ instance (Pair p) => ValueSym (p CppSrcCode CppHdrCode) where
   litFloat v = on2StateValues pair (litFloat v) (litFloat v)
   litInt v =on2StateValues  pair (litInt v) (litInt v)
   litString s = on2StateValues pair (litString s) (litString s)
+  litArray = pair1Val1List litArray litArray
+  litList = pair1Val1List litList litList
 
   pi = on2StateValues pair pi pi
 
@@ -1332,6 +1334,8 @@ instance ValueSym CppSrcCode where
   litFloat = G.litFloat
   litInt = G.litInt
   litString = G.litString
+  litArray = G.litArray
+  litList _ _ = error $ "List literals not supported in " ++ cppName
 
   pi = modify (addDefine "_USE_MATH_DEFINES") >> addMathHImport (mkStateVal 
     double (text "M_PI"))
@@ -1988,6 +1992,8 @@ instance ValueSym CppHdrCode where
   litFloat = G.litFloat
   litInt = G.litInt
   litString = G.litString
+  litArray = G.litArray
+  litList _ _ = error $ "List literals not supported in " ++ cppName
 
   pi = modify (addHeaderDefine "_USE_MATH_DEFINES" . addHeaderLangImport 
     "math.h") >> mkStateVal double (text "M_PI")

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer/JavaRenderer.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer/JavaRenderer.hs
@@ -39,16 +39,16 @@ import qualified GOOL.Drasil.LanguageRenderer.LanguagePolymorphic as G (
   greaterOp, greaterEqualOp, lessOp, lessEqualOp, plusOp, minusOp, multOp, 
   divideOp, moduloOp, andOp, orOp, var, staticVar, extVar, self, enumVar, 
   classVar, objVar, objVarSelf, listVar, listOf, arrayElem, iterVar, litTrue, 
-  litFalse, litChar, litDouble, litFloat, litInt, litString, pi, valueOf, arg, 
-  enumElement, argsList, inlineIf, objAccess, objMethodCall, 
+  litFalse, litChar, litDouble, litFloat, litInt, litString, litArray, pi, 
+  valueOf, arg, enumElement, argsList, inlineIf, objAccess, objMethodCall, 
   objMethodCallNoParams, selfAccess, listIndexExists, indexOf, call', funcApp, 
   selfFuncApp, extFuncApp, newObj, lambda, notNull, func, get, set, listSize, 
   listAdd, listAppend, iterBegin, iterEnd, listAccess, listSet, getFunc, 
   setFunc, listSizeFunc, listAddFunc, listAppendFunc, iterBeginError, 
   iterEndError, listAccessFunc', printSt, state, loopState, emptyState, assign, 
   assignToListIndex, multiAssignError, decrement, increment, decrement1, 
-  increment1, varDec, varDecDef, listDec, arrayDec, arrayDecDef, objDecNew, 
-  objDecNewNoParams, extObjDecNew, extObjDecNewNoParams, funcDecDef, 
+  increment1, varDec, varDecDef, listDec, listDecDef', arrayDec, arrayDecDef, 
+  objDecNew, objDecNewNoParams, extObjDecNew, extObjDecNewNoParams, funcDecDef, 
   discardInput, discardFileInput, openFileR, openFileW, openFileA, closeFile, 
   discardFileLine, stringListVals, stringListLists, returnState, 
   multiReturnError, valState, comment, freeError, throw, initState, 
@@ -71,7 +71,7 @@ import GOOL.Drasil.Helpers (angles, emptyIfNull, toCode, toState, onCodeValue,
   onStateValue, on2CodeValues, on2StateValues, on3CodeValues, on3StateValues, 
   onCodeList, onStateList, on1CodeValue1List, on1StateValue1List)
 import GOOL.Drasil.State (GOOLState, MS, VS, lensGStoFS, lensFStoVS, lensMStoFS,
-  lensMStoVS, lensVStoFS, initialState, initialFS, modifyReturn, 
+  lensMStoVS, lensVStoFS, lensVStoMS, initialState, initialFS, modifyReturn, 
   modifyReturnFunc, addODEFilePaths, addProgNameToPaths, addODEFiles, 
   getODEFiles, addLangImport, addLangImportVS, addExceptionImports, 
   addLibImport, getModuleName, setFileType, getClassName, setCurrMain, 
@@ -335,6 +335,10 @@ instance ValueSym JavaCode where
   litFloat = G.litFloat
   litInt = G.litInt
   litString = G.litString
+  litArray = G.litArray
+  litList t es = zoom lensVStoMS (modify (if null es then id else addLangImport 
+    "java.util.Arrays")) >> newObj (listType t) [funcApp "Arrays.asList" 
+    (listType t) es | not (null es)]
 
   pi = G.pi
 
@@ -525,9 +529,7 @@ instance StatementSym JavaCode where
   varDecDef = G.varDecDef
   listDec n v = zoom lensMStoVS v >>= (\v' -> G.listDec (listDecDocD v') 
     (litInt n) v)
-  listDecDef v vs = modify (if null vs then id else addLangImport 
-    "java.util.Arrays") >> objDecNew v [funcApp "Arrays.asList" 
-    (onStateValue variableType v) vs | not (null vs)]
+  listDecDef = G.listDecDef'
   arrayDec n = G.arrayDec (litInt n)
   arrayDecDef = G.arrayDecDef
   objDecDef = varDecDef

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer/JavaRenderer.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer/JavaRenderer.hs
@@ -42,14 +42,17 @@ import qualified GOOL.Drasil.LanguageRenderer.LanguagePolymorphic as G (
   litFalse, litChar, litDouble, litFloat, litInt, litString, litArray, pi, 
   valueOf, arg, enumElement, argsList, inlineIf, objAccess, objMethodCall, 
   objMethodCallNoParams, selfAccess, listIndexExists, indexOf, call', funcApp, 
-  selfFuncApp, extFuncApp, newObj, lambda, notNull, func, get, set, listSize, 
-  listAdd, listAppend, iterBegin, iterEnd, listAccess, listSet, getFunc, 
-  setFunc, listSizeFunc, listAddFunc, listAppendFunc, iterBeginError, 
-  iterEndError, listAccessFunc', printSt, state, loopState, emptyState, assign, 
-  assignToListIndex, multiAssignError, decrement, increment, decrement1, 
-  increment1, varDec, varDecDef, listDec, listDecDef', arrayDec, arrayDecDef, 
-  objDecNew, objDecNewNoParams, extObjDecNew, extObjDecNewNoParams, funcDecDef, 
-  discardInput, discardFileInput, openFileR, openFileW, openFileA, closeFile, 
+  funcAppMixedArgs, selfFuncApp, selfFuncAppMixedArgs, extFuncApp, 
+  extFuncAppMixedArgs, libFuncApp, libFuncAppMixedArgs, newObj, 
+  newObjMixedArgs, extNewObj, libNewObj, libNewObjMixedArgs, lambda, notNull, 
+  func, get, set, listSize, listAdd, listAppend, iterBegin, iterEnd, 
+  listAccess, listSet, getFunc, setFunc, listSizeFunc, listAddFunc, 
+  listAppendFunc, iterBeginError, iterEndError, listAccessFunc', printSt, 
+  state, loopState, emptyState, assign, assignToListIndex, multiAssignError, 
+  decrement, increment, decrement1, increment1, varDec, varDecDef, listDec, 
+  listDecDef', arrayDec, arrayDecDef, objDecNew, objDecNewNoParams, 
+  extObjDecNew, extObjDecNewNoParams, funcDecDef, discardInput, 
+  discardFileInput, openFileR, openFileW, openFileA, closeFile, 
   discardFileLine, stringListVals, stringListLists, returnState, 
   multiReturnError, valState, comment, freeError, throw, initState, 
   changeState, initObserverList, addObserver, ifCond, ifNoElse, switch, 
@@ -399,26 +402,32 @@ instance ValueExpression JavaCode where
   -- map from the CodeInfo pass, but it's possible that one of the higher-level 
   -- functions implicitly calls these functions in the Java renderer, so we 
   -- also check here to add the exceptions from the called function to the map
-  funcApp n t vs = funcAppMixedArgs n t vs []
+  funcApp = G.funcApp
   funcAppNamedArgs n t = funcAppMixedArgs n t []
-  funcAppMixedArgs n t vs ns = addCallExcsCurrMod n >> G.funcApp n t vs ns
-  selfFuncApp n t vs = selfFuncAppMixedArgs n t vs []
-  selfFuncAppMixedArgs n t ps ns = addCallExcsCurrMod n >> G.selfFuncApp dot 
-    self n t ps ns
-  extFuncApp l n t vs = extFuncAppMixedArgs l n t vs []
+  funcAppMixedArgs n t vs ns = addCallExcsCurrMod n >> 
+    G.funcAppMixedArgs n t vs ns
+  selfFuncApp = G.selfFuncApp
+  selfFuncAppMixedArgs n t ps ns = addCallExcsCurrMod n >> 
+    G.selfFuncAppMixedArgs dot self n t ps ns
+  extFuncApp = G.extFuncApp
   extFuncAppMixedArgs l n t vs ns = do
     mem <- getMethodExcMap
     modify (maybe id addExceptions (Map.lookup (l ++ "." ++ n) mem))
-    G.extFuncApp l n t vs ns
-  newObj ot vs = newObjMixedArgs ot vs []
-  newObjMixedArgs ot vs ns = addConstructorCallExcsCurrMod ot (\t -> G.newObj "new " t vs ns)
-  extNewObj l ot vs = extNewObjMixedArgs l ot vs []
+    G.extFuncAppMixedArgs l n t vs ns
+  libFuncApp = G.libFuncApp
+  libFuncAppMixedArgs = G.libFuncAppMixedArgs
+  newObj = G.newObj
+  newObjMixedArgs ot vs ns = addConstructorCallExcsCurrMod ot (\t -> 
+    G.newObjMixedArgs "new " t vs ns)
+  extNewObj = G.extNewObj
   extNewObjMixedArgs l ot vs ns = do
     t <- ot
     mem <- getMethodExcMap
     let tp = getTypeString t
     modify (maybe id addExceptions (Map.lookup (l ++ "." ++ tp) mem))
     newObjMixedArgs (toState t) vs ns
+  libNewObj = G.libNewObj
+  libNewObjMixedArgs = G.libNewObjMixedArgs
 
   lambda = G.lambda jLambda
 

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer/LanguagePolymorphic.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer/LanguagePolymorphic.hs
@@ -678,8 +678,14 @@ iterEnd v = v $. iterEndFunc (S.listInnerType $ onStateValue valueType v)
 
 listAccess :: (RenderSym repr) => VS (repr (Value repr)) -> 
   VS (repr (Value repr)) -> VS (repr (Value repr))
-listAccess v i = v $. S.listAccessFunc (S.listInnerType $ onStateValue 
-  valueType v) i
+listAccess v i = do
+  v' <- v
+  let checkType (List _) = S.listAccessFunc (S.listInnerType $ return $ 
+        valueType v') i
+      checkType (Array _) = i >>= (\ix -> funcFromData (brackets (valueDoc ix)) 
+        (S.listInnerType $ return $ valueType v'))
+      checkType _ = error "listAccess called on non-list-type value"
+  v $. checkType (getType (valueType v'))
 
 listSet :: (RenderSym repr) => VS (repr (Value repr)) -> VS (repr (Value repr)) 
   -> VS (repr (Value repr)) -> VS (repr (Value repr))

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer/PythonRenderer.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer/PythonRenderer.hs
@@ -39,16 +39,18 @@ import qualified GOOL.Drasil.LanguageRenderer.LanguagePolymorphic as G (
   objVar, objVarSelf, listVar, listOf, arrayElem, iterVar, litChar, litDouble, 
   litInt, litString, valueOf, arg, enumElement, argsList, objAccess, 
   objMethodCall, objMethodCallNoParams, selfAccess, listIndexExists, indexOf, 
-  call, funcApp, selfFuncApp, extFuncApp, newObj, extNewObj, lambda, func, 
-  get, set, listAdd, listAppend, iterBegin, iterEnd, listAccess, listSet, 
-  getFunc, setFunc, listAddFunc, listAppendFunc, iterBeginError, iterEndError, 
-  listAccessFunc, listSetFunc, state, loopState, emptyState, assign, 
-  assignToListIndex, decrement, increment', increment1', decrement1, 
-  listDecDef', objDecNew, objDecNewNoParams, closeFile, discardFileLine, 
-  stringListVals, stringListLists, returnState, valState, comment, throw, 
-  initState, changeState, initObserverList, addObserver, ifCond, ifNoElse, 
-  switchAsIf, ifExists, tryCatch, checkState, construct, param, method, 
-  getMethod, setMethod, privMethod, pubMethod, constructor, function, docFunc, 
+  call, funcApp, funcAppMixedArgs, selfFuncApp, selfFuncAppMixedArgs, 
+  extFuncApp, extFuncAppMixedArgs, libFuncApp, newObj, newObjMixedArgs, 
+  extNewObj, extNewObjMixedArgs, libNewObj, lambda, func, get, set, listAdd, 
+  listAppend, iterBegin, iterEnd, listAccess, listSet, getFunc, setFunc, 
+  listAddFunc, listAppendFunc, iterBeginError, iterEndError, listAccessFunc, 
+  listSetFunc, state, loopState, emptyState, assign, assignToListIndex, 
+  decrement, increment', increment1', decrement1, listDecDef', objDecNew, 
+  objDecNewNoParams, closeFile, discardFileLine, stringListVals, 
+  stringListLists, returnState, valState, comment, throw, initState, 
+  changeState, initObserverList, addObserver, ifCond, ifNoElse, switchAsIf, 
+  ifExists, tryCatch, checkState, construct, param, method, getMethod, 
+  setMethod, privMethod, pubMethod, constructor, function, docFunc, 
   stateVarDef, constVar, privMVar, pubMVar, pubGVar, buildClass, 
   implementingClass, docClass, commentedClass, intClass, buildModule, 
   modFromData, fileDoc, docMod, fileFromData)
@@ -63,9 +65,9 @@ import GOOL.Drasil.Helpers (vibcat, emptyIfEmpty, toCode, toState, onCodeValue,
   onStateValue, on2CodeValues, on2StateValues, on3CodeValues, on3StateValues,
   onCodeList, onStateList, on2StateLists, on1CodeValue1List, on1StateValue1List)
 import GOOL.Drasil.State (MS, VS, lensGStoFS, lensMStoVS, lensVStoMS, 
-  addLangImportVS, getLangImports, addLibImport, getLibImports, addModuleImport,
-  addModuleImportVS, getModuleImports, setFileType, setClassName, getClassName, 
-  setCurrMain, getClassMap, setMainDoc, getMainDoc)
+  addLangImportVS, getLangImports, addLibImport, addLibImportVS, getLibImports, 
+  addModuleImport, addModuleImportVS, getModuleImports, setFileType, 
+  setClassName, getClassName, setCurrMain, getClassMap, setMainDoc, getMainDoc)
 
 import Prelude hiding (break,print,sin,cos,tan,floor,(<>))
 import Data.Maybe (fromMaybe)
@@ -384,19 +386,25 @@ instance BooleanExpression PythonCode where
 
 instance ValueExpression PythonCode where
   inlineIf = pyInlineIf
-  funcApp n t ps = funcAppMixedArgs n t ps []
+  funcApp = G.funcApp
   funcAppNamedArgs n t = funcAppMixedArgs n t []
-  funcAppMixedArgs = G.funcApp
-  selfFuncApp n t ps = selfFuncAppMixedArgs n t ps []
-  selfFuncAppMixedArgs = G.selfFuncApp dot self
-  extFuncApp l n t ps = extFuncAppMixedArgs l n t ps []
+  funcAppMixedArgs = G.funcAppMixedArgs
+  selfFuncApp = G.selfFuncApp
+  selfFuncAppMixedArgs = G.selfFuncAppMixedArgs dot self
+  extFuncApp = G.extFuncApp
   extFuncAppMixedArgs l n t ps ns = modify (addModuleImportVS l) >> 
-    G.extFuncApp l n t ps ns
-  newObj t ps = newObjMixedArgs t ps []
-  newObjMixedArgs = G.newObj ""
-  extNewObj l tp ps = extNewObjMixedArgs l tp ps []
-  extNewObjMixedArgs l tp ps ns = modify (addModuleImportVS l) >> G.extNewObj 
-    "" l tp ps ns
+    G.extFuncAppMixedArgs l n t ps ns
+  libFuncApp = G.libFuncApp
+  libFuncAppMixedArgs l n t ps ns = modify (addLibImportVS l) >> 
+    G.extFuncAppMixedArgs l n t ps ns
+  newObj = G.newObj
+  newObjMixedArgs = G.newObjMixedArgs ""
+  extNewObj = G.extNewObj
+  extNewObjMixedArgs l tp ps ns = modify (addModuleImportVS l) >> 
+    G.extNewObjMixedArgs l tp ps ns
+  libNewObj = G.libNewObj
+  libNewObjMixedArgs l tp ps ns = modify (addLibImportVS l) >> 
+    G.extNewObjMixedArgs l tp ps ns
 
   lambda = G.lambda pyLambda
 

--- a/code/drasil-gool/GOOL/Drasil/State.hs
+++ b/code/drasil-gool/GOOL/Drasil/State.hs
@@ -8,8 +8,8 @@ module GOOL.Drasil.State (
   modifyReturnFunc2, modifyReturnList, addODEFilePaths, addFile, 
   addCombinedHeaderSource, addHeader, addSource, addProgNameToPaths, setMainMod,
   addODEFiles, getODEFiles, addLangImport, addLangImportVS, addExceptionImports,
-  getLangImports, addLibImport, addLibImports, getLibImports, addModuleImport, 
-  addModuleImportVS, getModuleImports, addHeaderLangImport, 
+  getLangImports, addLibImport, addLibImportVS, addLibImports, getLibImports, 
+  addModuleImport, addModuleImportVS, getModuleImports, addHeaderLangImport, 
   getHeaderLangImports, addHeaderLibImport, getHeaderLibImports, 
   addHeaderModImport, getHeaderModImports, addDefine, getDefines, 
   addHeaderDefine, getHeaderDefines, addUsing, getUsing, addHeaderUsing, 
@@ -379,6 +379,12 @@ addLibImport :: String -> (((GOOLState, FileState), ClassState), MethodState)
   -> (((GOOLState, FileState), ClassState), MethodState)
 addLibImport i = over _1 $ over _1 $ over _2 $ over libImports (\is -> 
   if i `elem` is then is else sort $ i:is)
+
+addLibImportVS :: String -> 
+  ((((GOOLState, FileState), ClassState), MethodState), ValueState) -> 
+  ((((GOOLState, FileState), ClassState), MethodState), ValueState)
+addLibImportVS i = over _1 $ over _1 $ over _1 $ over _2 $ over libImports 
+  (\is -> if i `elem` is then is else sort $ i:is)
 
 addLibImports :: [String] -> (((GOOLState, FileState), ClassState), MethodState)
   -> (((GOOLState, FileState), ClassState), MethodState)

--- a/code/drasil-gool/GOOL/Drasil/Symantics.hs
+++ b/code/drasil-gool/GOOL/Drasil/Symantics.hs
@@ -383,6 +383,12 @@ class (ValueSym repr, BooleanExpression repr) =>
     [VS (repr (Value repr))] -> 
     [(VS (repr (Variable repr)), VS (repr (Value repr)))] -> 
     VS (repr (Value repr))
+  libFuncApp :: Library -> Label -> VS (repr (Type repr)) -> 
+    [VS (repr (Value repr))] -> VS (repr (Value repr))
+  libFuncAppMixedArgs :: Library -> Label -> VS (repr (Type repr)) -> 
+    [VS (repr (Value repr))] -> 
+    [(VS (repr (Variable repr)), VS (repr (Value repr)))] -> 
+    VS (repr (Value repr))
   newObj     :: VS (repr (Type repr)) -> [VS (repr (Value repr))] -> 
     VS (repr (Value repr))
   newObjMixedArgs ::  VS (repr (Type repr)) -> [VS (repr (Value repr))] -> 
@@ -391,6 +397,12 @@ class (ValueSym repr, BooleanExpression repr) =>
   extNewObj  :: Library -> VS (repr (Type repr)) -> [VS (repr (Value repr))] -> 
     VS (repr (Value repr))
   extNewObjMixedArgs :: Library -> VS (repr (Type repr)) -> 
+    [VS (repr (Value repr))] -> 
+    [(VS (repr (Variable repr)), VS (repr (Value repr)))] -> 
+    VS (repr (Value repr))
+  libNewObj :: Library -> VS (repr (Type repr)) -> [VS (repr (Value repr))] -> 
+    VS (repr (Value repr))
+  libNewObjMixedArgs :: Library -> VS (repr (Type repr)) -> 
     [VS (repr (Value repr))] -> 
     [(VS (repr (Variable repr)), VS (repr (Value repr)))] -> 
     VS (repr (Value repr))

--- a/code/drasil-gool/GOOL/Drasil/Symantics.hs
+++ b/code/drasil-gool/GOOL/Drasil/Symantics.hs
@@ -235,9 +235,9 @@ class (TypeSym repr) => VariableSym repr where
   enumVar      :: Label -> Label -> VS (repr (Variable repr))
   listVar      :: Label -> VS (repr (Type repr)) -> VS (repr (Variable repr))
   listOf       :: Label -> VS (repr (Type repr)) -> VS (repr (Variable repr))
-  -- Use for iterator variables, i.e. in a forEach loop.
   arrayElem    :: Integer -> VS (repr (Variable repr)) -> 
     VS (repr (Variable repr))
+  -- Use for iterator variables, i.e. in a forEach loop.
   iterVar      :: Label -> VS (repr (Type repr)) -> VS (repr (Variable repr))
 
   ($->) :: VS (repr (Variable repr)) -> VS (repr (Variable repr)) -> VS (repr (Variable repr))
@@ -261,6 +261,10 @@ class (VariableSym repr) => ValueSym repr where
   litFloat  :: Float -> VS (repr (Value repr))
   litInt    :: Integer -> VS (repr (Value repr))
   litString :: String -> VS (repr (Value repr))
+  litArray  :: VS (repr (Type repr)) -> [VS (repr (Value repr))] ->
+    VS (repr (Value repr))
+  litList   :: VS (repr (Type repr)) -> [VS (repr (Value repr))] -> 
+    VS (repr (Value repr))
 
   pi :: VS (repr (Value repr))
 


### PR DESCRIPTION
This small PR adds some GOOL methods for calling functions from external libraries (as opposed to the existing `extFuncApp` etc. which are for calling functions from external modules within the same program or package). These are needed for generating external library code.

#2038 should be merged first. The only new commit is 3e96d6c.