### PR TITLE
Change decrement operator to use -- instead of ~-

### DIFF
--- a/code/drasil-gool/GOOL/Drasil/CodeInfo.hs
+++ b/code/drasil-gool/GOOL/Drasil/CodeInfo.hs
@@ -283,7 +283,7 @@ instance StatementSym CodeInfo where
   (&-=) _ = zoom lensMStoVS . execute1
   (&+=) _ = zoom lensMStoVS . execute1
   (&++) _ = noInfo
-  (&~-) _ = noInfo
+  (&--) _ = noInfo
 
   varDec _ = noInfo
   varDecDef _ = zoom lensMStoVS . execute1

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer/CSharpRenderer.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer/CSharpRenderer.hs
@@ -502,7 +502,7 @@ instance StatementSym CSharpCode where
   (&-=) = G.decrement
   (&+=) = G.increment
   (&++) = G.increment1
-  (&~-) = G.decrement1
+  (&--) = G.decrement1
 
   varDec v = zoom lensMStoVS v >>= (\v' -> csVarDec (variableBind v') $ 
     G.varDec static dynamic v)

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer/CppRenderer.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer/CppRenderer.hs
@@ -598,7 +598,7 @@ instance (Pair p) => StatementSym (p CppSrcCode CppHdrCode) where
   (&-=) vr vl = pair2 (&-=) (&-=) (zoom lensMStoVS vr) (zoom lensMStoVS vl)
   (&+=) vr vl = pair2 (&+=) (&+=) (zoom lensMStoVS vr) (zoom lensMStoVS vl)
   (&++) vl = pair1 (&++) (&++) (zoom lensMStoVS vl)
-  (&~-) vl = pair1 (&~-) (&~-) (zoom lensMStoVS vl)
+  (&--) vl = pair1 (&--) (&--) (zoom lensMStoVS vl)
 
   varDec vr = pair1 varDec varDec (zoom lensMStoVS vr)
   varDecDef vr vl = pair2 varDecDef varDecDef (zoom lensMStoVS vr) 
@@ -1518,7 +1518,7 @@ instance StatementSym CppSrcCode where
   (&-=) = G.decrement
   (&+=) = G.increment
   (&++) = G.increment1
-  (&~-) = G.decrement1
+  (&--) = G.decrement1
 
   varDec = G.varDec static dynamic
   varDecDef = G.varDecDef 
@@ -2178,7 +2178,7 @@ instance StatementSym CppHdrCode where
   (&-=) _ _ = emptyState
   (&+=) _ _ = emptyState
   (&++) _ = emptyState
-  (&~-) _ = emptyState
+  (&--) _ = emptyState
 
   varDec = G.varDec static dynamic
   varDecDef = G.varDecDef

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer/JavaRenderer.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer/JavaRenderer.hs
@@ -533,7 +533,7 @@ instance StatementSym JavaCode where
   (&-=) = G.decrement
   (&+=) = G.increment
   (&++) = G.increment1
-  (&~-) = G.decrement1
+  (&--) = G.decrement1
 
   varDec = G.varDec static dynamic
   varDecDef = G.varDecDef

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer/PythonRenderer.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer/PythonRenderer.hs
@@ -504,7 +504,7 @@ instance StatementSym PythonCode where
   (&-=) = G.decrement
   (&+=) = G.increment'
   (&++) = G.increment1'
-  (&~-) = G.decrement1
+  (&--) = G.decrement1
 
   varDec _ = toState $ mkStNoEnd empty
   varDecDef = assign

--- a/code/drasil-gool/GOOL/Drasil/Symantics.hs
+++ b/code/drasil-gool/GOOL/Drasil/Symantics.hs
@@ -557,8 +557,8 @@ class (SelectorFunction repr) => StatementSym repr where
   infixl 1 &+=
   (&++)  :: VS (repr (Variable repr)) -> MS (repr (Statement repr))
   infixl 8 &++
-  (&~-)  :: VS (repr (Variable repr)) -> MS (repr (Statement repr))
-  infixl 8 &~-
+  (&--)  :: VS (repr (Variable repr)) -> MS (repr (Statement repr))
+  infixl 8 &--
 
   assign            :: VS (repr (Variable repr)) -> VS (repr (Value repr)) -> 
     MS (repr (Statement repr))

--- a/code/drasil-gool/Test/HelloWorld.hs
+++ b/code/drasil-gool/Test/HelloWorld.hs
@@ -72,8 +72,8 @@ helloIfBody = addComments "If body" (body [
     var "c" int &+= litInt 17,
     (&++) (var "a" int),
     (&++) (var "d" int),
-    (&~-) (var "c" int),
-    (&~-) (var "b" int),
+    (&--) (var "c" int),
+    (&--) (var "b" int),
 
     listDec 5 (var "myList" (listType int)),
     objDecDef (var "myObj" char) (litChar 'o'),


### PR DESCRIPTION
We used `&~-` for GOOL's decrement operator because the more intuitive `&--` could not be used because `--` starts a comment in Haskell. However I've recently discovered this is not true. Haskell allows using `--` in an operator, so I changed the operator to use this better symbol.