### PR TITLE
Remove codevarC and codefuncC 

### DIFF
--- a/code/drasil-code/Language/Drasil/Chunk/Code.hs
+++ b/code/drasil-code/Language/Drasil/Chunk/Code.hs
@@ -1,9 +1,9 @@
 {-# LANGUAGE TemplateHaskell #-}
 module Language.Drasil.Chunk.Code (
     CodeIdea(..), CodeChunk(..), CodeVarChunk(..), CodeFuncChunk(..), 
-    VarOrFunc(..), codevarC, codefuncC, quantvar, quantfunc, ccObjVar, codevars,
-    codevars', funcResolve, varResolve, ConstraintMap, constraintMap, 
-    physLookup, sfwrLookup, programName, funcPrefix
+    VarOrFunc(..), quantvar, quantfunc, ccObjVar, codevars, codevars', 
+    funcResolve, varResolve, ConstraintMap, constraintMap, physLookup, 
+    sfwrLookup, programName, funcPrefix
   ) where
 
 import Control.Lens ((^.),makeLenses,view)
@@ -78,12 +78,6 @@ instance CodeIdea    CodeFuncChunk where
   codeChunk = codeChunk . view ccf
 instance Eq          CodeFuncChunk where c1 == c2 = (c1 ^. uid) == (c2 ^. uid)
 instance MayHaveUnit CodeFuncChunk where getUnit = getUnit . view ccf
-
-codevarC :: (CodeIdea c) => c -> CodeVarChunk
-codevarC = CodeVC . codeChunk
-
-codefuncC :: (CodeIdea c) => c -> CodeFuncChunk
-codefuncC = CodeFC . codeChunk
 
 quantvar :: (Quantity c, MayHaveUnit c) => c -> CodeVarChunk
 quantvar c = CodeVC $ CodeC (qw c) Var

--- a/code/drasil-code/Language/Drasil/Chunk/CodeDefinition.hs
+++ b/code/drasil-code/Language/Drasil/Chunk/CodeDefinition.hs
@@ -19,6 +19,7 @@ instance NamedIdea    CodeDefinition where term = cchunk . term
 instance Idea         CodeDefinition where getA = getA . view cchunk
 instance HasSpace     CodeDefinition where typ = cchunk . typ
 instance HasSymbol    CodeDefinition where symbol c = symbol (c ^. cchunk)
+instance Quantity     CodeDefinition
 instance CodeIdea     CodeDefinition where 
   codeName = codeName . view cchunk
   codeChunk = view cchunk

--- a/code/drasil-code/Language/Drasil/Code/Imperative/Modules.hs
+++ b/code/drasil-code/Language/Drasil/Code/Imperative/Modules.hs
@@ -25,7 +25,7 @@ import Language.Drasil.Code.Imperative.Parameters (getConstraintParams,
 import Language.Drasil.Code.Imperative.DrasilState (DrasilState(..), inMod)
 import Language.Drasil.Code.Imperative.GOOL.Symantics (AuxiliarySym(..))
 import Language.Drasil.Chunk.Code (CodeIdea(codeName), CodeVarChunk,
-  codevarC, quantvar, physLookup, sfwrLookup)
+  quantvar, physLookup, sfwrLookup)
 import Language.Drasil.Chunk.CodeDefinition (CodeDefinition, codeEquat)
 import Language.Drasil.Code.CodeQuantityDicts (inFileName, inParams, consts)
 import Language.Drasil.Code.DataDesc (DataDesc, junkLine, singleton)
@@ -82,7 +82,7 @@ getInputDecl = do
   cps <- mapM mkVal constrParams
   let cname = "InputParameters"
       getDecl ([],[]) = constIns (partition (flip member (eMap $ codeSpec g) . 
-        codeName) (map codevarC $ constants $ csi $ codeSpec g)) (conRepr g) 
+        codeName) (map quantvar $ constants $ csi $ codeSpec g)) (conRepr g) 
         (conStruct g)
       getDecl ([],ins) = do
         vars <- mapM mkVar ins

--- a/code/drasil-code/Language/Drasil/Code/Imperative/Parameters.hs
+++ b/code/drasil-code/Language/Drasil/Code/Imperative/Parameters.hs
@@ -5,7 +5,7 @@ module Language.Drasil.Code.Imperative.Parameters(getInConstructorParams,
 
 import Language.Drasil 
 import Language.Drasil.Code.Imperative.DrasilState (DrasilState(..), inMod)
-import Language.Drasil.Chunk.Code (CodeVarChunk, CodeIdea(codeChunk), codevarC, 
+import Language.Drasil.Chunk.Code (CodeVarChunk, CodeIdea(codeChunk), 
   quantvar, codevars, codevars')
 import Language.Drasil.Chunk.CodeDefinition (CodeDefinition, codeEquat)
 import Language.Drasil.Code.CodeQuantityDicts (inFileName, inParams, consts)
@@ -64,7 +64,7 @@ getConstraintParams = do
       mem = eMap $ codeSpec g
       db = sysinfodb $ csi $ codeSpec g
       varsList = filter (\i -> member (i ^. uid) cm) (inputs $ csi $ codeSpec g)
-      reqdVals = nub $ varsList ++ map codevarC (concatMap (\v -> 
+      reqdVals = nub $ varsList ++ map quantvar (concatMap (\v -> 
         constraintvarsandfuncs v db mem) (getConstraints cm varsList))
   getParams In reqdVals
 
@@ -78,12 +78,13 @@ getOutputParams = do
   g <- ask
   getParams In $ outputs $ csi $ codeSpec g
 
-getParams :: (CodeIdea c) => ParamType -> [c] -> Reader DrasilState [CodeVarChunk]
+getParams :: (Quantity c, MayHaveUnit c) => ParamType -> [c] -> 
+  Reader DrasilState [CodeVarChunk]
 getParams pt cs' = do
   g <- ask
-  let cs = map codevarC cs'
+  let cs = map quantvar cs'
       ins = inputs $ csi $ codeSpec g
-      cnsnts = map codevarC $ constants $ csi $ codeSpec g
+      cnsnts = map quantvar $ constants $ csi $ codeSpec g
       inpVars = filter (`elem` ins) cs
       conVars = filter (`elem` cnsnts) cs
       csSubIns = filter ((`notMember` concMatches g) . (^. uid)) 

--- a/code/drasil-code/Language/Drasil/CodeSpec.hs
+++ b/code/drasil-code/Language/Drasil/CodeSpec.hs
@@ -9,7 +9,7 @@ import Language.Drasil.Development (dep, namesRI)
 import Theory.Drasil (DataDefinition, qdFromDD)
 
 import Language.Drasil.Chunk.Code (CodeChunk, CodeVarChunk, CodeIdea(codeChunk),
-  ConstraintMap, programName, codevarC, quantvar, funcPrefix, codeName,
+  ConstraintMap, programName, quantvar, funcPrefix, codeName,
   codevars, codevars', funcResolve, varResolve, constraintMap)
 import Language.Drasil.Chunk.CodeDefinition (CodeDefinition, qtov, qtoc, 
   codeEquat)
@@ -306,7 +306,7 @@ clsDefMap cs@CSI {
 getDerivedInputs :: [DataDefinition] -> [QDefinition] -> [Input] -> [Const] ->
   ChunkDB -> [QDefinition]
 getDerivedInputs ddefs defs' ins cnsts sm =
-  let refSet = ins ++ map codevarC cnsts
+  let refSet = ins ++ map quantvar cnsts
   in  if null ddefs then filter ((`subsetOf` refSet) . flip codevars sm . (^.equat)) defs'
       else filter ((`subsetOf` refSet) . flip codevars sm . (^.defnExpr)) (map qdFromDD ddefs)
 
@@ -319,7 +319,7 @@ getExecOrder d k' n' sm  = getExecOrder' [] d k' (n' \\ k')
         getExecOrder' ord defs' k n = 
           let new  = filter ((`subsetOf` k) . flip codevars' sm . codeEquat) 
                 defs'
-              cnew = map codevarC new
+              cnew = map quantvar new
               kNew = k ++ cnew
               nNew = n \\ cnew
           in  if null new 


### PR DESCRIPTION
Another small PR, removing constructors that are no longer needed now that `QuantityDict` is the underlying type for `CodeChunk`s.