### PR TITLE
Clean unnecessary fields of CodeSpec

### DIFF
--- a/code/drasil-code/Language/Drasil/Code/Imperative/Comments.hs
+++ b/code/drasil-code/Language/Drasil/Code/Imperative/Comments.hs
@@ -1,55 +1,40 @@
 module Language.Drasil.Code.Imperative.Comments (
-  paramComment, returnComment
+  getComment
 ) where
 
 import Language.Drasil
 import Database.Drasil (defTable)
+import Language.Drasil.Chunk.Code (CodeIdea(..))
 import Language.Drasil.Code.Imperative.DrasilState (DrasilState(..))
 import Language.Drasil.CodeSpec (CodeSpec(..), CodeSystInfo(..))
 import Language.Drasil.Printers (Linearity(Linear), sentenceDoc, unitDoc)
 
-import Data.Map (Map)
 import qualified Data.Map as Map (lookup)
 import Data.Maybe (maybe)
 import Control.Monad.Reader (Reader, ask)
-import Control.Lens (view)
-import Text.PrettyPrint.HughesPJ (Doc, (<+>), colon, empty, parens, render, 
-  text)
+import Control.Lens ((^.))
+import Text.PrettyPrint.HughesPJ (Doc, (<+>), colon, empty, parens, render)
 
-getTermDoc :: (NamedIdea c) => UID -> Map UID c -> Reader DrasilState Doc
-getTermDoc cname m = do
+getTermDoc :: (CodeIdea c) => c -> Reader DrasilState Doc
+getTermDoc c = do
   g <- ask
   let db = sysinfodb $ csi $ codeSpec g
-  return $ (maybe (text "No description given") (sentenceDoc db 
-    Implementation Linear . phraseNP . view term) . Map.lookup cname) m
+  return $ sentenceDoc db Implementation Linear $ phraseNP $ codeChunk c ^. term
 
-getDefnDoc :: UID -> Reader DrasilState Doc
-getDefnDoc cname = do
+getDefnDoc :: (CodeIdea c) => c -> Reader DrasilState Doc
+getDefnDoc c = do
   g <- ask
   let db = sysinfodb $ csi $ codeSpec g
   return $ maybe empty ((<+>) colon . sentenceDoc db Implementation Linear . 
-    view defn . fst) (Map.lookup cname $ defTable db)
+    (^. defn) . fst) (Map.lookup (codeChunk c ^. uid) $ defTable db)
 
-getUnitsDoc :: (MayHaveUnit c) => UID -> Map UID c -> Doc
-getUnitsDoc cname m = maybe empty (parens . unitDoc Linear . usymb) 
-  (Map.lookup cname m >>= getUnit)
+getUnitsDoc :: (CodeIdea c) => c -> Doc
+getUnitsDoc c = maybe empty (parens . unitDoc Linear . usymb) 
+  (getUnit $ codeChunk c)
 
-getComment :: (NamedIdea c, MayHaveUnit c) => UID -> Map UID c -> 
-  Reader DrasilState String
-getComment l m = do
-  t <- getTermDoc l m
+getComment :: (CodeIdea c) => c -> Reader DrasilState String
+getComment l = do
+  t <- getTermDoc l
   d <- getDefnDoc l
-  let u = getUnitsDoc l m
+  let u = getUnitsDoc l
   return $ render $ (t <> d) <+> u
-
-paramComment :: UID -> Reader DrasilState String
-paramComment l = do
-  g <- ask
-  let m = vMap $ codeSpec g
-  getComment l m
-
-returnComment :: UID -> Reader DrasilState String
-returnComment l = do
-  g <- ask
-  let m = fMap $ codeSpec g
-  getComment l m

--- a/code/drasil-code/Language/Drasil/Code/Imperative/FunctionCalls.hs
+++ b/code/drasil-code/Language/Drasil/Code/Imperative/FunctionCalls.hs
@@ -11,7 +11,7 @@ import Language.Drasil.Code.Imperative.Parameters (getCalcParams,
   getConstraintParams, getDerivedIns, getDerivedOuts, getInputFormatIns, 
   getInputFormatOuts, getOutputParams)
 import Language.Drasil.Code.Imperative.DrasilState (DrasilState(..))
-import Language.Drasil.Chunk.Code (CodeIdea(codeName))
+import Language.Drasil.Chunk.Code (CodeIdea(codeName), quantvar)
 import Language.Drasil.Chunk.CodeDefinition (CodeDefinition)
 import Language.Drasil.CodeSpec (CodeSpec(..))
 
@@ -20,10 +20,9 @@ import GOOL.Drasil (ProgramSym, TypeSym(..), ValueSym(..), StatementSym(..),
 
 import Data.List ((\\), intersect)
 import qualified Data.Map as Map (lookup)
-import Data.Maybe (maybe, catMaybes)
+import Data.Maybe (catMaybes)
 import Control.Applicative ((<|>))
 import Control.Monad.Reader (Reader, ask)
-import Control.Lens ((^.))
 
 getAllInputCalls :: (ProgramSym repr) => Reader DrasilState 
   [MS (repr (Statement repr))]
@@ -50,11 +49,9 @@ getConstraintCall = do
 getCalcCall :: (ProgramSym repr) => CodeDefinition -> Reader DrasilState 
   (Maybe (MS (repr (Statement repr))))
 getCalcCall c = do
-  g <- ask
   t <- codeType c
   val <- getFuncCall (codeName c) (convType t) (getCalcParams c)
-  v <- maybe (error $ (c ^. uid) ++ " missing from VarMap") mkVar 
-    (Map.lookup (c ^. uid) (vMap $ codeSpec g))
+  v <- mkVar $ quantvar c
   l <- maybeLog v
   return $ fmap (multi . (: l) . varDecDef v) val
 

--- a/code/drasil-code/Language/Drasil/CodeSpec.hs
+++ b/code/drasil-code/Language/Drasil/CodeSpec.hs
@@ -57,7 +57,6 @@ data CodeSystInfo where
 
 data CodeSpec where
   CodeSpec :: {
-  relations :: [Def],
   fMap :: FunctionMap,
   vMap :: VarMap,
   eMap :: ModExportMap,
@@ -113,7 +112,6 @@ codeSpec SI {_sys = sys
         smplData = sd
       }
   in  CodeSpec {
-        relations = rels,
         fMap = assocToMap rels,
         vMap = assocToMap (map quantvar q ++ getAdditionalVars chs (mods csi')),
         eMap = mem,

--- a/code/drasil-code/Language/Drasil/CodeSpec.hs
+++ b/code/drasil-code/Language/Drasil/CodeSpec.hs
@@ -4,7 +4,7 @@ module Language.Drasil.CodeSpec where
 import Language.Drasil
 import Database.Drasil (ChunkDB, SystemInformation(SI), symbResolve,
   _authors, _constants, _constraints, _datadefs, _definitions, _inputs,
-  _outputs, _quants, _sys, _sysinfodb, sampleData)
+  _outputs, _sys, _sysinfodb, sampleData)
 import Language.Drasil.Development (dep, namesRI)
 import Theory.Drasil (DataDefinition, qdFromDD)
 
@@ -14,9 +14,8 @@ import Language.Drasil.Chunk.Code (CodeChunk, CodeVarChunk, CodeIdea(codeChunk),
 import Language.Drasil.Chunk.CodeDefinition (CodeDefinition, qtov, qtoc, 
   codeEquat)
 import Language.Drasil.Code.Code (spaceToCodeType)
-import Language.Drasil.Code.CodeQuantityDicts (inFileName, inParams, consts)
 import Language.Drasil.Mod (Class(..), Func(..), FuncData(..), FuncDef(..), 
-  Mod(..), Name, fname, getFuncParams, packmod, prefixFunctions)
+  Mod(..), Name, fname, packmod, prefixFunctions)
 
 import GOOL.Drasil (CodeType)
 
@@ -57,17 +56,14 @@ data CodeSystInfo where
 
 data CodeSpec where
   CodeSpec :: {
-  fMap :: FunctionMap,
-  vMap :: VarMap,
   eMap :: ModExportMap,
   clsMap :: ClassDefinitionMap,
   defList :: [Name],
-  constMap :: FunctionMap,
+  constMap :: ConstantMap,
   csi :: CodeSystInfo
   } -> CodeSpec
 
-type FunctionMap = Map.Map String CodeDefinition
-type VarMap      = Map.Map String CodeVarChunk
+type ConstantMap = Map.Map String CodeDefinition
 
 assocToMap :: HasUID a => [a] -> Map.Map UID a
 assocToMap = Map.fromList . map (\x -> (x ^. uid, x))
@@ -75,7 +71,6 @@ assocToMap = Map.fromList . map (\x -> (x ^. uid, x))
 codeSpec :: SystemInformation -> Choices -> [Mod] -> CodeSpec
 codeSpec SI {_sys = sys
               , _authors = as
-              , _quants = q
               , _definitions = defs'
               , _datadefs = ddefs
               , _inputs = ins
@@ -112,8 +107,6 @@ codeSpec SI {_sys = sys
         smplData = sd
       }
   in  CodeSpec {
-        fMap = assocToMap rels,
-        vMap = assocToMap (map quantvar q ++ getAdditionalVars chs (mods csi')),
         eMap = mem,
         clsMap = cdm,
         defList = nub $ Map.keys mem ++ Map.keys cdm,
@@ -249,18 +242,6 @@ asVC' (FDef (FuncDef n _ _ _ _ _)) = vc n (nounPhraseSP n) (Variable n) Real
 asVC' (FDef (CtorDef n _ _ _ _)) = vc n (nounPhraseSP n) (Variable n) Real
 asVC' (FData (FuncData n _ _)) = vc n (nounPhraseSP n) (Variable n) Real
 asVC' (FCD _) = error "Can't make QuantityDict from FCD function" -- vc'' cd (codeSymb cd) (cd ^. typ)
-
-getAdditionalVars :: Choices -> [Mod] -> [CodeVarChunk]
-getAdditionalVars chs ms = map quantvar (inFileName 
-  : inParamsVar (inputStructure chs) 
-  ++ constsVar (constStructure chs))
-  ++ concatMap funcParams ms
-  where inParamsVar Bundled = [inParams]
-        inParamsVar Unbundled = []
-        constsVar (Store Bundled) = [consts]
-        constsVar _ = []
-        funcParams (Mod _ _ _ cs fs) = concatMap getFuncParams (fs ++ 
-          concatMap methods cs)
 
 -- name of variable/function maps to module name
 type ModExportMap = Map.Map String String

--- a/code/drasil-code/Language/Drasil/Mod.hs
+++ b/code/drasil-code/Language/Drasil/Mod.hs
@@ -2,7 +2,7 @@
 module Language.Drasil.Mod (Class(..), Func(..), FuncData(..), FuncDef(..), 
   FuncStmt(..), Initializer, Mod(..), Name, ($:=), classDef, classImplements, 
   ctorDef, ffor, fdec, fname, fstdecl, funcData, funcDef, funcQD, 
-  getFuncParams, packmod, packmodRequires, prefixFunctions
+  packmod, packmodRequires, prefixFunctions
 ) where
 
 import Language.Drasil
@@ -11,7 +11,7 @@ import Database.Drasil (ChunkDB)
 import Language.Drasil.Chunk.Code (CodeIdea(..), CodeVarChunk, codeName, 
   codevars, codevars', funcPrefix, quantvar)
 import Language.Drasil.Chunk.CodeDefinition (CodeDefinition, qtoc)
-import Language.Drasil.Code.DataDesc (DataDesc, getInputs)
+import Language.Drasil.Code.DataDesc (DataDesc)
 import Language.Drasil.Printers (toPlainName)
 
 import Data.List ((\\), nub)
@@ -98,12 +98,6 @@ ffor v = FFor (quantvar  v)
 
 fdec :: (Quantity c, MayHaveUnit c) => c -> FuncStmt
 fdec v  = FDec (quantvar v)
-
-getFuncParams :: Func -> [CodeVarChunk]
-getFuncParams (FDef (FuncDef _ _ ps _ _ _)) = ps
-getFuncParams (FDef (CtorDef _ _ ps _ _)) = ps
-getFuncParams (FData (FuncData _ _ d)) = getInputs d
-getFuncParams (FCD _) = []
 
 fstdecl :: ChunkDB -> [FuncStmt] -> [CodeVarChunk]
 fstdecl ctx fsts = nub (concatMap (fstvars ctx) fsts) \\ nub (concatMap (declared ctx) fsts) 

--- a/code/drasil-example/Drasil/GamePhysics/Body.hs
+++ b/code/drasil-example/Drasil/GamePhysics/Body.hs
@@ -107,8 +107,7 @@ si = SI {
   -- FIXME: The _quants field should be filled in with all the symbols, however
   -- #1658 is why this is empty, otherwise we end up with unused (and probably
   -- should be removed) symbols. But that's for another time. This is "fine"
-  -- because _quants are only used relative to #1658 and in code gen. And
-  -- Gamephysics is not in a place to be able to do codegen.
+  -- because _quants are only used relative to #1658.
   _quants =  [] :: [QuantityDict], -- map qw iMods ++ map qw symbolsAll,
   _concepts = [] :: [DefinedQuantityDict],
   _definitions = qDefs,


### PR DESCRIPTION
This PR cleans up `CodeSpec` by:

- removing the `rels` field, which was simply not used.
- removing the variable map and function map (`vMap` and `fMap`), which were used only once or twice and only seemed to over-complicate the code, without really having a benefit that I could see. I think they probably made sense when I started, but I've made so many changes to the generator since then that they no longer seem useful.