### PR TITLE
Generator improvements

### DIFF
--- a/code/drasil-code/Language/Drasil/Code/Imperative/Descriptions.hs
+++ b/code/drasil-code/Language/Drasil/Code/Imperative/Descriptions.hs
@@ -2,7 +2,7 @@ module Language.Drasil.Code.Imperative.Descriptions (
   modDesc, inputParametersDesc, inputConstructorDesc, inputFormatDesc, 
   derivedValuesDesc, inputConstraintsDesc, constModDesc, outputFormatDesc, 
   inputClassDesc, constClassDesc, inFmtFuncDesc, inConsFuncDesc, dvFuncDesc, 
-  woFuncDesc
+  calcModDesc, woFuncDesc
 ) where
 
 import Utils.Drasil (stringList)
@@ -136,6 +136,9 @@ dvFuncDesc = do
       dvDesc _ = "Calculates values that can be immediately derived from the" ++
         " inputs"
   return $ dvDesc $ "derived_values" `elem` defList (codeSpec g)
+
+calcModDesc :: String
+calcModDesc = "Provides functions for calculating the outputs"
 
 woFuncDesc :: Reader DrasilState String
 woFuncDesc = do

--- a/code/drasil-code/Language/Drasil/Code/Imperative/Generator.hs
+++ b/code/drasil-code/Language/Drasil/Code/Imperative/Generator.hs
@@ -8,7 +8,8 @@ import Language.Drasil.Code.Imperative.SpaceMatch (chooseSpace)
 import Language.Drasil.Code.Imperative.GenerateGOOL (ClassType(..), 
   genDoxConfig, genModule)
 import Language.Drasil.Code.Imperative.Helpers (liftS)
-import Language.Drasil.Code.Imperative.Import (genModDef, genModFuncs)
+import Language.Drasil.Code.Imperative.Import (genModDef, genModFuncs,
+  genModClasses)
 import Language.Drasil.Code.Imperative.Modules (chooseInModule, genConstClass, 
   genConstMod, genInputClass, genInputConstraints, genInputDerived, 
   genInputFormat, genMain, genMainFunc, genCalcMod, genCalcFunc, 
@@ -117,7 +118,8 @@ genUnmodular = do
     csi $ codeSpec g) ++ concatMap genModFuncs (mods s)) ++ ((if cls then [] 
       else [genInputFormat Primary, genInputDerived Primary, 
         genInputConstraints Primary]) ++ [genOutputFormat])) 
-    [genInputClass Auxiliary, genConstClass Auxiliary]
+    ([genInputClass Auxiliary, genConstClass Auxiliary] 
+    ++ map (fmap Just) (concatMap genModClasses $ mods s))
           
 genModules :: (ProgramSym repr) => 
   Reader DrasilState [FS (repr (RenderFile repr))]

--- a/code/drasil-code/Language/Drasil/Code/Imperative/Generator.hs
+++ b/code/drasil-code/Language/Drasil/Code/Imperative/Generator.hs
@@ -11,8 +11,8 @@ import Language.Drasil.Code.Imperative.Helpers (liftS)
 import Language.Drasil.Code.Imperative.Import (genModDef, genModFuncs)
 import Language.Drasil.Code.Imperative.Modules (chooseInModule, genConstClass, 
   genConstMod, genInputClass, genInputConstraints, genInputDerived, 
-  genInputFormat, genMain, genMainFunc, genOutputFormat, genOutputMod, 
-  genSampleInput)
+  genInputFormat, genMain, genMainFunc, genCalcMod, genCalcFunc, 
+  genOutputFormat, genOutputMod, genSampleInput)
 import Language.Drasil.Code.Imperative.DrasilState (DrasilState(..), inMod)
 import Language.Drasil.Code.Imperative.GOOL.Symantics (PackageSym(..), 
   AuxiliarySym(..))
@@ -113,9 +113,10 @@ genUnmodular = do
       mainIfExe Library = []
       mainIfExe Program = [genMainFunc]
   genModule n ("Contains the entire " ++ n ++ " " ++ getDesc (implType g))
-    (map (fmap Just) (mainIfExe (implType g) ++ concatMap genModFuncs (mods s)) 
-    ++ ((if cls then [] else [genInputFormat Primary, genInputDerived Primary, 
-      genInputConstraints Primary]) ++ [genOutputFormat])) 
+    (map (fmap Just) (mainIfExe (implType g) ++ map genCalcFunc (execOrder $ 
+    csi $ codeSpec g) ++ concatMap genModFuncs (mods s)) ++ ((if cls then [] 
+      else [genInputFormat Primary, genInputDerived Primary, 
+        genInputConstraints Primary]) ++ [genOutputFormat])) 
     [genInputClass Auxiliary, genConstClass Auxiliary]
           
 genModules :: (ProgramSym repr) => 
@@ -128,9 +129,10 @@ genModules = do
   mn     <- mainIfExe $ implType g
   inp    <- chooseInModule $ inMod g
   con    <- genConstMod 
+  cal    <- genCalcMod
   out    <- genOutputMod
   moddef <- traverse genModDef (mods s) -- hack ?
-  return $ mn ++ inp ++ con ++ out ++ moddef
+  return $ mn ++ inp ++ con ++ cal : out ++ moddef
 
 -- private utilities used in generateCode
 getDir :: Lang -> String

--- a/code/drasil-code/Language/Drasil/Code/Imperative/Import.hs
+++ b/code/drasil-code/Language/Drasil/Code/Imperative/Import.hs
@@ -2,7 +2,7 @@
 {-# LANGUAGE Rank2Types #-}
 module Language.Drasil.Code.Imperative.Import (codeType, publicFunc, 
   privateMethod, publicInOutFunc, privateInOutMethod, genConstructor, mkVar, 
-  mkVal, convExpr, genModDef, genModFuncs, readData, renderC
+  mkVal, convExpr, genModDef, genModFuncs, genModClasses, readData, renderC
 ) where
 
 import Language.Drasil hiding (int, log, ln, exp,
@@ -338,6 +338,10 @@ genModDef (Mod n desc is cs fs) = genModuleWithImports n desc is (map (fmap
 genModFuncs :: (ProgramSym repr) => Mod -> 
   [Reader DrasilState (MS (repr (Method repr)))]
 genModFuncs (Mod _ _ _ _ fs) = map genFunc fs
+
+genModClasses :: (ProgramSym repr) => Mod -> 
+  [Reader DrasilState (CS (repr (Class repr)))]
+genModClasses (Mod _ _ _ cs _) = map (genClass auxClass) cs
 
 genClass :: (ProgramSym repr) => (String -> Label -> Maybe Label -> 
   [CS (repr (StateVar repr))] -> Reader DrasilState [MS (repr (Method repr))] 

--- a/code/drasil-code/Language/Drasil/Code/Imperative/Import.hs
+++ b/code/drasil-code/Language/Drasil/Code/Imperative/Import.hs
@@ -1,9 +1,8 @@
 {-# LANGUAGE PostfixOperators #-}
 {-# LANGUAGE Rank2Types #-}
-module Language.Drasil.Code.Imperative.Import (codeType,
-  publicFunc, privateMethod, publicInOutFunc, privateInOutMethod, 
-  genConstructor, mkVar, mkVal, convExpr, genCalcBlock, CalcType(..), genModDef,
-  genModFuncs, readData, renderC
+module Language.Drasil.Code.Imperative.Import (codeType, publicFunc, 
+  privateMethod, publicInOutFunc, privateInOutMethod, genConstructor, mkVar, 
+  mkVal, convExpr, genModDef, genModFuncs, readData, renderC
 ) where
 
 import Language.Drasil hiding (int, log, ln, exp,
@@ -13,12 +12,11 @@ import Language.Drasil.Code.Imperative.Comments (getComment)
 import Language.Drasil.Code.Imperative.ConceptMatch (conceptToGOOL)
 import Language.Drasil.Code.Imperative.GenerateGOOL (auxClass, fApp, ctorCall,
   genModuleWithImports, mkParam, primaryClass)
-import Language.Drasil.Code.Imperative.Helpers (getUpperBound, liftS, lookupC)
+import Language.Drasil.Code.Imperative.Helpers (getUpperBound, lookupC)
 import Language.Drasil.Code.Imperative.Logging (maybeLog, logBody)
-import Language.Drasil.Code.Imperative.Parameters (getCalcParams)
 import Language.Drasil.Code.Imperative.DrasilState (DrasilState(..))
 import Language.Drasil.Chunk.Code (CodeIdea(codeName), quantvar, quantfunc)
-import Language.Drasil.Chunk.CodeDefinition (CodeDefinition, codeEquat)
+import Language.Drasil.Chunk.CodeDefinition (codeEquat)
 import Language.Drasil.Code.CodeQuantityDicts (inFileName, inParams, consts)
 import Language.Drasil.CodeSpec (CodeSpec(..), CodeSystInfo(..), Comments(..),
   ConstantRepr(..), ConstantStructure(..), Structure(..))
@@ -328,49 +326,6 @@ bfunc Dot   = error "convExpr DotProduct"
 bfunc Frac  = (#/)
 bfunc Index = listAccess
 
-------- CALC ----------
-
-genCalcFunc :: (ProgramSym repr) => CodeDefinition -> 
-  Reader DrasilState (MS (repr (Method repr)))
-genCalcFunc cdef = do
-  parms <- getCalcParams cdef
-  let nm = codeName cdef
-  tp <- codeType cdef
-  blck <- genCalcBlock CalcReturn cdef (codeEquat cdef)
-  desc <- getComment cdef
-  publicFunc
-    nm
-    (convType tp)
-    ("Calculates " ++ desc)
-    parms
-    (Just desc)
-    [blck]
-
-data CalcType = CalcAssign | CalcReturn deriving Eq
-
-genCalcBlock :: (ProgramSym repr) => CalcType -> CodeDefinition -> Expr ->
-  Reader DrasilState (MS (repr (Block repr)))
-genCalcBlock t v (Case c e) = genCaseBlock t v c e
-genCalcBlock t v e
-    | t == CalcAssign  = fmap block $ liftS $ do { vv <- mkVar v; ee <-
-      convExpr e; l <- maybeLog vv; return $ multi $ assign vv ee : l}
-    | otherwise        = block <$> liftS (returnState <$> convExpr e)
-
-genCaseBlock :: (ProgramSym repr) => CalcType -> CodeDefinition -> Completeness 
-  -> [(Expr,Relation)] -> Reader DrasilState (MS (repr (Block repr)))
-genCaseBlock _ _ _ [] = error $ "Case expression with no cases encountered" ++
-  " in code generator"
-genCaseBlock t v c cs = do
-  ifs <- mapM (\(e,r) -> liftM2 (,) (convExpr r) (calcBody e)) (ifEs c)
-  els <- elseE c
-  return $ block [ifCond ifs els]
-  where calcBody e = fmap body $ liftS $ genCalcBlock t v e
-        ifEs Complete = init cs
-        ifEs Incomplete = cs
-        elseE Complete = calcBody $ fst $ last cs
-        elseE Incomplete = return $ oneLiner $ throw $  
-          "Undefined case encountered in function " ++ codeName v
-
 -- medium hacks --
 genModDef :: (ProgramSym repr) => Mod -> 
   Reader DrasilState (FS (repr (RenderFile repr)))
@@ -410,7 +365,6 @@ genFunc (FDef (CtorDef n desc parms i s)) = do
   genInitConstructor n desc parms (zip initvars inits) 
     [block $ map varDec vars ++ stmts]
 genFunc (FData (FuncData n desc ddef)) = genDataFunc n desc ddef
-genFunc (FCD cd) = genCalcFunc cd
 
 convStmt :: (ProgramSym repr) => FuncStmt -> Reader DrasilState (MS (repr (Statement repr)))
 convStmt (FAsg v (Matrix [es]))  = do

--- a/code/drasil-code/Language/Drasil/CodeSpec.hs
+++ b/code/drasil-code/Language/Drasil/CodeSpec.hs
@@ -272,13 +272,23 @@ clsDefMap cs@CSI {
   inputs = ins,
   extInputs = extIns,
   derivedInputs = ds,
-  constants = cns
-  } chs = Map.fromList $ getInputCls chs ins
+  constants = cns,
+  mods = ms
+  } chs = Map.fromList $ concatMap mclasses ms
+    ++ getInputCls chs ins
     ++ getConstantsCls chs cns
     ++ getDerivedCls chs ds
     ++ getConstraintsCls chs (getConstraints (cMap cs) ins)
     ++ getInputFormatCls chs extIns
+  where mclasses (Mod _ _ _ cls _) = concatMap (\c -> let cln = className c in
+          map (svclass cln) (stateVars c) ++ map (mthclass cln) (methods c)) cls
+        svclass cln sv = (codeName sv, cln)
+        mthclass cln m = (fname m, cln)
+        
 
+-- Determines the derived inputs, which can be immediately calculated from the 
+-- knowns (inputs and constants). If there are DDs, the derived inputs will 
+-- come from those. If there are none, then the QDefinitions are used instead.
 getDerivedInputs :: [DataDefinition] -> [QDefinition] -> [Input] -> [Const] ->
   ChunkDB -> [QDefinition]
 getDerivedInputs ddefs defs' ins cnsts sm =

--- a/code/drasil-code/Language/Drasil/CodeSpec.hs
+++ b/code/drasil-code/Language/Drasil/CodeSpec.hs
@@ -262,8 +262,8 @@ modExportMap cs@CSI {
     ++ getExpInputFormat prn chs extIns
     ++ getExpCalcs prn chs (execOrder cs)
     ++ getExpOutput prn chs (outputs cs)
-  where mpair (Mod n _ _ cls fs) = (map className cls ++ map fname (fs ++ 
-          concatMap methods cls)) `zip` repeat (defModName m n)
+  where mpair (Mod n _ _ cls fs) = (concatMap (map codeName . stateVars) cls ++ 
+          map fname (fs ++ concatMap methods cls)) `zip` repeat (defModName m n)
         defModName Unmodular _ = prn
         defModName _ nm = nm
 

--- a/code/drasil-code/Language/Drasil/Mod.hs
+++ b/code/drasil-code/Language/Drasil/Mod.hs
@@ -1,16 +1,15 @@
 {-# LANGUAGE GADTs #-}
 module Language.Drasil.Mod (Class(..), Func(..), FuncData(..), FuncDef(..), 
   FuncStmt(..), Initializer, Mod(..), Name, ($:=), classDef, classImplements, 
-  ctorDef, ffor, fdec, fname, fstdecl, funcData, funcDef, funcQD, 
-  packmod, packmodRequires, prefixFunctions
+  ctorDef, ffor, fdec, fname, fstdecl, funcData, funcDef, packmod, 
+  packmodRequires, prefixFunctions
 ) where
 
 import Language.Drasil
 import Database.Drasil (ChunkDB)
 
-import Language.Drasil.Chunk.Code (CodeIdea(..), CodeVarChunk, codeName, 
-  codevars, codevars', funcPrefix, quantvar)
-import Language.Drasil.Chunk.CodeDefinition (CodeDefinition, qtoc)
+import Language.Drasil.Chunk.Code (CodeVarChunk, codevars, codevars', 
+  funcPrefix, quantvar)
 import Language.Drasil.Code.DataDesc (DataDesc)
 import Language.Drasil.Printers (toPlainName)
 
@@ -40,12 +39,8 @@ classDef n = ClassDef n Nothing
 classImplements :: Name -> Name -> String -> [CodeVarChunk] -> [Func] -> Class
 classImplements n i = ClassDef n (Just i)
      
-data Func = FCD CodeDefinition
-          | FDef FuncDef
+data Func = FDef FuncDef
           | FData FuncData
-
-funcQD :: QDefinition -> Func
-funcQD qd = FCD $ qtoc qd 
 
 funcData :: Name -> String -> DataDesc -> Func
 funcData n desc d = FData $ FuncData (toPlainName n) desc d
@@ -138,8 +133,7 @@ fstdecl ctx fsts = nub (concatMap (fstvars ctx) fsts) \\ nub (concatMap (declare
     declared sm (FMulti ss) = concatMap (declared sm) ss
     declared _  (FAppend _ _) = []
        
-fname :: Func -> Name       
-fname (FCD cd) = codeName cd
+fname :: Func -> Name
 fname (FDef (FuncDef n _ _ _ _ _)) = n
 fname (FDef (CtorDef n _ _ _ _)) = n
 fname (FData (FuncData n _ _)) = n 

--- a/code/stable/glassbr/src/cpp/Makefile
+++ b/code/stable/glassbr/src/cpp/Makefile
@@ -12,13 +12,13 @@ endif
 
 build: GlassBR$(TARGET_EXTENSION)
 
-GlassBR$(TARGET_EXTENSION): InputParameters.hpp InputFormat.hpp DerivedValues.hpp InputConstraints.hpp OutputFormat.hpp Calculations.hpp ReadTable.hpp Interpolation.hpp Control.cpp InputFormat.cpp DerivedValues.cpp InputConstraints.cpp OutputFormat.cpp Calculations.cpp ReadTable.cpp Interpolation.cpp
-	"$(CXX)" Control.cpp InputFormat.cpp DerivedValues.cpp InputConstraints.cpp OutputFormat.cpp Calculations.cpp ReadTable.cpp Interpolation.cpp --std=c++11 -o GlassBR$(TARGET_EXTENSION)
+GlassBR$(TARGET_EXTENSION): InputParameters.hpp InputFormat.hpp DerivedValues.hpp InputConstraints.hpp Calculations.hpp OutputFormat.hpp ReadTable.hpp Interpolation.hpp Control.cpp InputFormat.cpp DerivedValues.cpp InputConstraints.cpp Calculations.cpp OutputFormat.cpp ReadTable.cpp Interpolation.cpp
+	"$(CXX)" Control.cpp InputFormat.cpp DerivedValues.cpp InputConstraints.cpp Calculations.cpp OutputFormat.cpp ReadTable.cpp Interpolation.cpp --std=c++11 -o GlassBR$(TARGET_EXTENSION)
 
 run: build
 	./GlassBR$(TARGET_EXTENSION) $(RUNARGS)
 
-doc: doxConfig InputParameters.hpp InputFormat.hpp DerivedValues.hpp InputConstraints.hpp OutputFormat.hpp Calculations.hpp ReadTable.hpp Interpolation.hpp Control.cpp
+doc: doxConfig InputParameters.hpp InputFormat.hpp DerivedValues.hpp InputConstraints.hpp Calculations.hpp OutputFormat.hpp ReadTable.hpp Interpolation.hpp Control.cpp
 	doxygen doxConfig
 
 .PHONY: build run doc

--- a/code/stable/glassbr/src/cpp/doxConfig
+++ b/code/stable/glassbr/src/cpp/doxConfig
@@ -813,7 +813,7 @@ WARN_LOGFILE           =
 # spaces. See also FILE_PATTERNS and EXTENSION_MAPPING
 # Note: If this tag is empty the current directory is searched.
 
-INPUT                  = InputParameters.hpp InputFormat.hpp DerivedValues.hpp InputConstraints.hpp OutputFormat.hpp Calculations.hpp ReadTable.hpp Interpolation.hpp Control.cpp
+INPUT                  = InputParameters.hpp InputFormat.hpp DerivedValues.hpp InputConstraints.hpp Calculations.hpp OutputFormat.hpp ReadTable.hpp Interpolation.hpp Control.cpp
 
 # This tag can be used to specify the character encoding of the source files
 # that doxygen parses. Internally doxygen uses the UTF-8 encoding. Doxygen uses

--- a/code/stable/glassbr/src/csharp/Makefile
+++ b/code/stable/glassbr/src/csharp/Makefile
@@ -15,13 +15,13 @@ endif
 
 build: GlassBR$(TARGET_EXTENSION)
 
-GlassBR$(TARGET_EXTENSION): Control.cs InputParameters.cs InputFormat.cs DerivedValues.cs InputConstraints.cs OutputFormat.cs Calculations.cs ReadTable.cs Interpolation.cs
-	$(CSC) -out:GlassBR$(TARGET_EXTENSION) Control.cs InputParameters.cs InputFormat.cs DerivedValues.cs InputConstraints.cs OutputFormat.cs Calculations.cs ReadTable.cs Interpolation.cs
+GlassBR$(TARGET_EXTENSION): Control.cs InputParameters.cs InputFormat.cs DerivedValues.cs InputConstraints.cs Calculations.cs OutputFormat.cs ReadTable.cs Interpolation.cs
+	$(CSC) -out:GlassBR$(TARGET_EXTENSION) Control.cs InputParameters.cs InputFormat.cs DerivedValues.cs InputConstraints.cs Calculations.cs OutputFormat.cs ReadTable.cs Interpolation.cs
 
 run: build
 	./GlassBR$(TARGET_EXTENSION) $(RUNARGS)
 
-doc: doxConfig Control.cs InputParameters.cs InputFormat.cs DerivedValues.cs InputConstraints.cs OutputFormat.cs Calculations.cs ReadTable.cs Interpolation.cs
+doc: doxConfig Control.cs InputParameters.cs InputFormat.cs DerivedValues.cs InputConstraints.cs Calculations.cs OutputFormat.cs ReadTable.cs Interpolation.cs
 	doxygen doxConfig
 
 .PHONY: build run doc

--- a/code/stable/glassbr/src/csharp/doxConfig
+++ b/code/stable/glassbr/src/csharp/doxConfig
@@ -813,7 +813,7 @@ WARN_LOGFILE           =
 # spaces. See also FILE_PATTERNS and EXTENSION_MAPPING
 # Note: If this tag is empty the current directory is searched.
 
-INPUT                  = Control.cs InputParameters.cs InputFormat.cs DerivedValues.cs InputConstraints.cs OutputFormat.cs Calculations.cs ReadTable.cs Interpolation.cs
+INPUT                  = Control.cs InputParameters.cs InputFormat.cs DerivedValues.cs InputConstraints.cs Calculations.cs OutputFormat.cs ReadTable.cs Interpolation.cs
 
 # This tag can be used to specify the character encoding of the source files
 # that doxygen parses. Internally doxygen uses the UTF-8 encoding. Doxygen uses

--- a/code/stable/glassbr/src/java/Makefile
+++ b/code/stable/glassbr/src/java/Makefile
@@ -1,12 +1,12 @@
 build: GlassBR/Control.class
 
-GlassBR/Control.class: GlassBR/Control.java GlassBR/InputParameters.java GlassBR/InputFormat.java GlassBR/DerivedValues.java GlassBR/InputConstraints.java GlassBR/OutputFormat.java GlassBR/Calculations.java GlassBR/ReadTable.java GlassBR/Interpolation.java
+GlassBR/Control.class: GlassBR/Control.java GlassBR/InputParameters.java GlassBR/InputFormat.java GlassBR/DerivedValues.java GlassBR/InputConstraints.java GlassBR/Calculations.java GlassBR/OutputFormat.java GlassBR/ReadTable.java GlassBR/Interpolation.java
 	javac GlassBR/Control.java
 
 run: build
 	java GlassBR.Control $(RUNARGS)
 
-doc: doxConfig GlassBR/Control.java GlassBR/InputParameters.java GlassBR/InputFormat.java GlassBR/DerivedValues.java GlassBR/InputConstraints.java GlassBR/OutputFormat.java GlassBR/Calculations.java GlassBR/ReadTable.java GlassBR/Interpolation.java
+doc: doxConfig GlassBR/Control.java GlassBR/InputParameters.java GlassBR/InputFormat.java GlassBR/DerivedValues.java GlassBR/InputConstraints.java GlassBR/Calculations.java GlassBR/OutputFormat.java GlassBR/ReadTable.java GlassBR/Interpolation.java
 	doxygen doxConfig
 
 .PHONY: build run doc

--- a/code/stable/glassbr/src/java/doxConfig
+++ b/code/stable/glassbr/src/java/doxConfig
@@ -813,7 +813,7 @@ WARN_LOGFILE           =
 # spaces. See also FILE_PATTERNS and EXTENSION_MAPPING
 # Note: If this tag is empty the current directory is searched.
 
-INPUT                  = GlassBR/Control.java GlassBR/InputParameters.java GlassBR/InputFormat.java GlassBR/DerivedValues.java GlassBR/InputConstraints.java GlassBR/OutputFormat.java GlassBR/Calculations.java GlassBR/ReadTable.java GlassBR/Interpolation.java
+INPUT                  = GlassBR/Control.java GlassBR/InputParameters.java GlassBR/InputFormat.java GlassBR/DerivedValues.java GlassBR/InputConstraints.java GlassBR/Calculations.java GlassBR/OutputFormat.java GlassBR/ReadTable.java GlassBR/Interpolation.java
 
 # This tag can be used to specify the character encoding of the source files
 # that doxygen parses. Internally doxygen uses the UTF-8 encoding. Doxygen uses

--- a/code/stable/glassbr/src/python/Makefile
+++ b/code/stable/glassbr/src/python/Makefile
@@ -3,7 +3,7 @@ build:
 run: build
 	python Control.py $(RUNARGS)
 
-doc: doxConfig Control.py InputParameters.py InputFormat.py DerivedValues.py InputConstraints.py OutputFormat.py Calculations.py ReadTable.py Interpolation.py
+doc: doxConfig Control.py InputParameters.py InputFormat.py DerivedValues.py InputConstraints.py Calculations.py OutputFormat.py ReadTable.py Interpolation.py
 	doxygen doxConfig
 
 .PHONY: build run doc

--- a/code/stable/glassbr/src/python/doxConfig
+++ b/code/stable/glassbr/src/python/doxConfig
@@ -813,7 +813,7 @@ WARN_LOGFILE           =
 # spaces. See also FILE_PATTERNS and EXTENSION_MAPPING
 # Note: If this tag is empty the current directory is searched.
 
-INPUT                  = Control.py InputParameters.py InputFormat.py DerivedValues.py InputConstraints.py OutputFormat.py Calculations.py ReadTable.py Interpolation.py
+INPUT                  = Control.py InputParameters.py InputFormat.py DerivedValues.py InputConstraints.py Calculations.py OutputFormat.py ReadTable.py Interpolation.py
 
 # This tag can be used to specify the character encoding of the source files
 # that doxygen parses. Internally doxygen uses the UTF-8 encoding. Doxygen uses

--- a/code/stable/projectile/Projectile_C_P_NoL_B_U_V_D/src/cpp/Makefile
+++ b/code/stable/projectile/Projectile_C_P_NoL_B_U_V_D/src/cpp/Makefile
@@ -12,13 +12,13 @@ endif
 
 build: Projectile$(TARGET_EXTENSION)
 
-Projectile$(TARGET_EXTENSION): InputParameters.hpp OutputFormat.hpp Calculations.hpp Control.cpp InputParameters.cpp OutputFormat.cpp Calculations.cpp
-	"$(CXX)" Control.cpp InputParameters.cpp OutputFormat.cpp Calculations.cpp --std=c++11 -o Projectile$(TARGET_EXTENSION)
+Projectile$(TARGET_EXTENSION): InputParameters.hpp Calculations.hpp OutputFormat.hpp Control.cpp InputParameters.cpp Calculations.cpp OutputFormat.cpp
+	"$(CXX)" Control.cpp InputParameters.cpp Calculations.cpp OutputFormat.cpp --std=c++11 -o Projectile$(TARGET_EXTENSION)
 
 run: build
 	./Projectile$(TARGET_EXTENSION) $(RUNARGS)
 
-doc: doxConfig InputParameters.hpp OutputFormat.hpp Calculations.hpp Control.cpp
+doc: doxConfig InputParameters.hpp Calculations.hpp OutputFormat.hpp Control.cpp
 	doxygen doxConfig
 
 .PHONY: build run doc

--- a/code/stable/projectile/Projectile_C_P_NoL_B_U_V_D/src/cpp/doxConfig
+++ b/code/stable/projectile/Projectile_C_P_NoL_B_U_V_D/src/cpp/doxConfig
@@ -813,7 +813,7 @@ WARN_LOGFILE           =
 # spaces. See also FILE_PATTERNS and EXTENSION_MAPPING
 # Note: If this tag is empty the current directory is searched.
 
-INPUT                  = InputParameters.hpp OutputFormat.hpp Calculations.hpp Control.cpp
+INPUT                  = InputParameters.hpp Calculations.hpp OutputFormat.hpp Control.cpp
 
 # This tag can be used to specify the character encoding of the source files
 # that doxygen parses. Internally doxygen uses the UTF-8 encoding. Doxygen uses

--- a/code/stable/projectile/Projectile_C_P_NoL_B_U_V_D/src/csharp/Makefile
+++ b/code/stable/projectile/Projectile_C_P_NoL_B_U_V_D/src/csharp/Makefile
@@ -15,13 +15,13 @@ endif
 
 build: Projectile$(TARGET_EXTENSION)
 
-Projectile$(TARGET_EXTENSION): Control.cs InputParameters.cs OutputFormat.cs Calculations.cs
-	$(CSC) -out:Projectile$(TARGET_EXTENSION) Control.cs InputParameters.cs OutputFormat.cs Calculations.cs
+Projectile$(TARGET_EXTENSION): Control.cs InputParameters.cs Calculations.cs OutputFormat.cs
+	$(CSC) -out:Projectile$(TARGET_EXTENSION) Control.cs InputParameters.cs Calculations.cs OutputFormat.cs
 
 run: build
 	./Projectile$(TARGET_EXTENSION) $(RUNARGS)
 
-doc: doxConfig Control.cs InputParameters.cs OutputFormat.cs Calculations.cs
+doc: doxConfig Control.cs InputParameters.cs Calculations.cs OutputFormat.cs
 	doxygen doxConfig
 
 .PHONY: build run doc

--- a/code/stable/projectile/Projectile_C_P_NoL_B_U_V_D/src/csharp/doxConfig
+++ b/code/stable/projectile/Projectile_C_P_NoL_B_U_V_D/src/csharp/doxConfig
@@ -813,7 +813,7 @@ WARN_LOGFILE           =
 # spaces. See also FILE_PATTERNS and EXTENSION_MAPPING
 # Note: If this tag is empty the current directory is searched.
 
-INPUT                  = Control.cs InputParameters.cs OutputFormat.cs Calculations.cs
+INPUT                  = Control.cs InputParameters.cs Calculations.cs OutputFormat.cs
 
 # This tag can be used to specify the character encoding of the source files
 # that doxygen parses. Internally doxygen uses the UTF-8 encoding. Doxygen uses

--- a/code/stable/projectile/Projectile_C_P_NoL_B_U_V_D/src/java/Makefile
+++ b/code/stable/projectile/Projectile_C_P_NoL_B_U_V_D/src/java/Makefile
@@ -1,12 +1,12 @@
 build: Projectile/Control.class
 
-Projectile/Control.class: Projectile/Control.java Projectile/InputParameters.java Projectile/OutputFormat.java Projectile/Calculations.java
+Projectile/Control.class: Projectile/Control.java Projectile/InputParameters.java Projectile/Calculations.java Projectile/OutputFormat.java
 	javac Projectile/Control.java
 
 run: build
 	java Projectile.Control $(RUNARGS)
 
-doc: doxConfig Projectile/Control.java Projectile/InputParameters.java Projectile/OutputFormat.java Projectile/Calculations.java
+doc: doxConfig Projectile/Control.java Projectile/InputParameters.java Projectile/Calculations.java Projectile/OutputFormat.java
 	doxygen doxConfig
 
 .PHONY: build run doc

--- a/code/stable/projectile/Projectile_C_P_NoL_B_U_V_D/src/java/doxConfig
+++ b/code/stable/projectile/Projectile_C_P_NoL_B_U_V_D/src/java/doxConfig
@@ -813,7 +813,7 @@ WARN_LOGFILE           =
 # spaces. See also FILE_PATTERNS and EXTENSION_MAPPING
 # Note: If this tag is empty the current directory is searched.
 
-INPUT                  = Projectile/Control.java Projectile/InputParameters.java Projectile/OutputFormat.java Projectile/Calculations.java
+INPUT                  = Projectile/Control.java Projectile/InputParameters.java Projectile/Calculations.java Projectile/OutputFormat.java
 
 # This tag can be used to specify the character encoding of the source files
 # that doxygen parses. Internally doxygen uses the UTF-8 encoding. Doxygen uses

--- a/code/stable/projectile/Projectile_C_P_NoL_B_U_V_D/src/python/Makefile
+++ b/code/stable/projectile/Projectile_C_P_NoL_B_U_V_D/src/python/Makefile
@@ -3,7 +3,7 @@ build:
 run: build
 	python Control.py $(RUNARGS)
 
-doc: doxConfig Control.py InputParameters.py OutputFormat.py Calculations.py
+doc: doxConfig Control.py InputParameters.py Calculations.py OutputFormat.py
 	doxygen doxConfig
 
 .PHONY: build run doc

--- a/code/stable/projectile/Projectile_C_P_NoL_B_U_V_D/src/python/doxConfig
+++ b/code/stable/projectile/Projectile_C_P_NoL_B_U_V_D/src/python/doxConfig
@@ -813,7 +813,7 @@ WARN_LOGFILE           =
 # spaces. See also FILE_PATTERNS and EXTENSION_MAPPING
 # Note: If this tag is empty the current directory is searched.
 
-INPUT                  = Control.py InputParameters.py OutputFormat.py Calculations.py
+INPUT                  = Control.py InputParameters.py Calculations.py OutputFormat.py
 
 # This tag can be used to specify the character encoding of the source files
 # that doxygen parses. Internally doxygen uses the UTF-8 encoding. Doxygen uses

--- a/code/stable/projectile/Projectile_S_L_NoL_U_U_V_F/src/cpp/Makefile
+++ b/code/stable/projectile/Projectile_S_L_NoL_U_U_V_F/src/cpp/Makefile
@@ -12,10 +12,10 @@ endif
 
 build: Projectile$(LIB_EXTENSION)
 
-Projectile$(LIB_EXTENSION): InputFormat.hpp InputConstraints.hpp OutputFormat.hpp Calculations.hpp InputFormat.cpp InputConstraints.cpp OutputFormat.cpp Calculations.cpp
-	"$(CXX)" InputFormat.cpp InputConstraints.cpp OutputFormat.cpp Calculations.cpp --std=c++11 -shared -fPIC -o Projectile$(LIB_EXTENSION)
+Projectile$(LIB_EXTENSION): InputFormat.hpp InputConstraints.hpp Calculations.hpp OutputFormat.hpp InputFormat.cpp InputConstraints.cpp Calculations.cpp OutputFormat.cpp
+	"$(CXX)" InputFormat.cpp InputConstraints.cpp Calculations.cpp OutputFormat.cpp --std=c++11 -shared -fPIC -o Projectile$(LIB_EXTENSION)
 
-doc: doxConfig InputFormat.hpp InputConstraints.hpp OutputFormat.hpp Calculations.hpp
+doc: doxConfig InputFormat.hpp InputConstraints.hpp Calculations.hpp OutputFormat.hpp
 	doxygen doxConfig
 
 .PHONY: build doc

--- a/code/stable/projectile/Projectile_S_L_NoL_U_U_V_F/src/cpp/doxConfig
+++ b/code/stable/projectile/Projectile_S_L_NoL_U_U_V_F/src/cpp/doxConfig
@@ -813,7 +813,7 @@ WARN_LOGFILE           =
 # spaces. See also FILE_PATTERNS and EXTENSION_MAPPING
 # Note: If this tag is empty the current directory is searched.
 
-INPUT                  = InputFormat.hpp InputConstraints.hpp OutputFormat.hpp Calculations.hpp
+INPUT                  = InputFormat.hpp InputConstraints.hpp Calculations.hpp OutputFormat.hpp
 
 # This tag can be used to specify the character encoding of the source files
 # that doxygen parses. Internally doxygen uses the UTF-8 encoding. Doxygen uses

--- a/code/stable/projectile/Projectile_S_L_NoL_U_U_V_F/src/csharp/Makefile
+++ b/code/stable/projectile/Projectile_S_L_NoL_U_U_V_F/src/csharp/Makefile
@@ -15,10 +15,10 @@ endif
 
 build: Projectile$(LIB_EXTENSION)
 
-Projectile$(LIB_EXTENSION): InputFormat.cs InputConstraints.cs OutputFormat.cs Calculations.cs
-	$(CSC) -t:library -out:Projectile$(LIB_EXTENSION) InputFormat.cs InputConstraints.cs OutputFormat.cs Calculations.cs
+Projectile$(LIB_EXTENSION): InputFormat.cs InputConstraints.cs Calculations.cs OutputFormat.cs
+	$(CSC) -t:library -out:Projectile$(LIB_EXTENSION) InputFormat.cs InputConstraints.cs Calculations.cs OutputFormat.cs
 
-doc: doxConfig InputFormat.cs InputConstraints.cs OutputFormat.cs Calculations.cs
+doc: doxConfig InputFormat.cs InputConstraints.cs Calculations.cs OutputFormat.cs
 	doxygen doxConfig
 
 .PHONY: build doc

--- a/code/stable/projectile/Projectile_S_L_NoL_U_U_V_F/src/csharp/doxConfig
+++ b/code/stable/projectile/Projectile_S_L_NoL_U_U_V_F/src/csharp/doxConfig
@@ -813,7 +813,7 @@ WARN_LOGFILE           =
 # spaces. See also FILE_PATTERNS and EXTENSION_MAPPING
 # Note: If this tag is empty the current directory is searched.
 
-INPUT                  = InputFormat.cs InputConstraints.cs OutputFormat.cs Calculations.cs
+INPUT                  = InputFormat.cs InputConstraints.cs Calculations.cs OutputFormat.cs
 
 # This tag can be used to specify the character encoding of the source files
 # that doxygen parses. Internally doxygen uses the UTF-8 encoding. Doxygen uses

--- a/code/stable/projectile/Projectile_S_L_NoL_U_U_V_F/src/java/Makefile
+++ b/code/stable/projectile/Projectile_S_L_NoL_U_U_V_F/src/java/Makefile
@@ -1,10 +1,10 @@
 build: Projectile.jar
 
-Projectile.jar: Projectile/InputFormat.java Projectile/InputConstraints.java Projectile/OutputFormat.java Projectile/Calculations.java
-	javac Projectile/InputFormat.java Projectile/InputConstraints.java Projectile/OutputFormat.java Projectile/Calculations.java
+Projectile.jar: Projectile/InputFormat.java Projectile/InputConstraints.java Projectile/Calculations.java Projectile/OutputFormat.java
+	javac Projectile/InputFormat.java Projectile/InputConstraints.java Projectile/Calculations.java Projectile/OutputFormat.java
 	jar -cvf Projectile.jar Projectile
 
-doc: doxConfig Projectile/InputFormat.java Projectile/InputConstraints.java Projectile/OutputFormat.java Projectile/Calculations.java
+doc: doxConfig Projectile/InputFormat.java Projectile/InputConstraints.java Projectile/Calculations.java Projectile/OutputFormat.java
 	doxygen doxConfig
 
 .PHONY: build doc

--- a/code/stable/projectile/Projectile_S_L_NoL_U_U_V_F/src/java/doxConfig
+++ b/code/stable/projectile/Projectile_S_L_NoL_U_U_V_F/src/java/doxConfig
@@ -813,7 +813,7 @@ WARN_LOGFILE           =
 # spaces. See also FILE_PATTERNS and EXTENSION_MAPPING
 # Note: If this tag is empty the current directory is searched.
 
-INPUT                  = Projectile/InputFormat.java Projectile/InputConstraints.java Projectile/OutputFormat.java Projectile/Calculations.java
+INPUT                  = Projectile/InputFormat.java Projectile/InputConstraints.java Projectile/Calculations.java Projectile/OutputFormat.java
 
 # This tag can be used to specify the character encoding of the source files
 # that doxygen parses. Internally doxygen uses the UTF-8 encoding. Doxygen uses

--- a/code/stable/projectile/Projectile_S_L_NoL_U_U_V_F/src/python/Makefile
+++ b/code/stable/projectile/Projectile_S_L_NoL_U_U_V_F/src/python/Makefile
@@ -1,6 +1,6 @@
 build:
 
-doc: doxConfig InputFormat.py InputConstraints.py OutputFormat.py Calculations.py
+doc: doxConfig InputFormat.py InputConstraints.py Calculations.py OutputFormat.py
 	doxygen doxConfig
 
 .PHONY: build doc

--- a/code/stable/projectile/Projectile_S_L_NoL_U_U_V_F/src/python/doxConfig
+++ b/code/stable/projectile/Projectile_S_L_NoL_U_U_V_F/src/python/doxConfig
@@ -813,7 +813,7 @@ WARN_LOGFILE           =
 # spaces. See also FILE_PATTERNS and EXTENSION_MAPPING
 # Note: If this tag is empty the current directory is searched.
 
-INPUT                  = InputFormat.py InputConstraints.py OutputFormat.py Calculations.py
+INPUT                  = InputFormat.py InputConstraints.py Calculations.py OutputFormat.py
 
 # This tag can be used to specify the character encoding of the source files
 # that doxygen parses. Internally doxygen uses the UTF-8 encoding. Doxygen uses


### PR DESCRIPTION
For some reason the Calculations module was generated by first defining a `Mod` containing various calculation functions, whereas most of our other modules do not have this intermediate `Mod` representation. I couldn't find a good reason why the Calculations module was treated differently, and in fact treating it this way makes things less flexible (it forces each calculation to be in its own function, so it wouldn't be possible to later have a fully unmodular choice where everything is all in one function). So I fixed this so that Calculations is treated like the other modules we generated, then removed the `FCD` node from `Func` altogether, because it is no longer used or needed.

I also fixed a minor bug where the class definition map and module export map weren't being completely defined and some classes were not getting generated when Unmodular is chosen.