### PR TITLE
Remove doc

### DIFF
--- a/code/drasil-gool/GOOL/Drasil/AST.hs
+++ b/code/drasil-gool/GOOL/Drasil/AST.hs
@@ -1,11 +1,11 @@
 module GOOL.Drasil.AST (Terminator(..), ScopeTag(..), FileType(..), isSource, 
   Binding(..), onBinding, BindData(bind, bindDoc), bd, 
   FileData(filePath, fileMod), fileD, updateFileMod, FuncData(fType, funcDoc), 
-  fd, ModData(name, modDoc), md, updateModDoc, MethodData(mthdDoc), mthd, 
-  updateMthdDoc, OpData(opPrec, opDoc), od, ParamData(paramVar, paramDoc), pd, 
-  paramName, updateParamDoc, ProgData(progName, progMods), progD, emptyProg, 
-  StateVarData(getStVarScp, stVarDoc, destructSts), svd, 
-  TypeData(cType, typeString, typeDoc), td, ValData(valPrec, valType, valDoc), 
+  fd, ModData(name, modDoc), md, updateMod, MethodData(mthdDoc), mthd, 
+  updateMthd, OpData(opPrec, opDoc), od, ParamData(paramVar, paramDoc), pd, 
+  paramName, updateParam, ProgData(progName, progMods), progD, emptyProg, 
+  StateVarData(getStVarScp, stVar, destructSts), svd, 
+  TypeData(cType, typeString, typeDoc), td, ValData(valPrec, valType, val), 
   vd, updateValDoc, VarData(varBind, varName, varType, varDoc), vard
 ) where
 
@@ -66,8 +66,8 @@ data ModData = MD {name :: String, modDoc :: Doc}
 md :: String -> Doc -> ModData
 md = MD
 
-updateModDoc :: (Doc -> Doc) -> ModData -> ModData
-updateModDoc f m = md (name m) (f $ modDoc m)
+updateMod :: (Doc -> Doc) -> ModData -> ModData
+updateMod f m = md (name m) (f $ modDoc m)
 
 -- Used as the underlying data type for Methods in all renderers except C++
 newtype MethodData = MthD {mthdDoc :: Doc}
@@ -75,8 +75,8 @@ newtype MethodData = MthD {mthdDoc :: Doc}
 mthd :: Doc -> MethodData
 mthd = MthD 
 
-updateMthdDoc :: MethodData -> (Doc -> Doc) -> MethodData
-updateMthdDoc m f = mthd ((f . mthdDoc) m)
+updateMthd :: MethodData -> (Doc -> Doc) -> MethodData
+updateMthd m f = mthd ((f . mthdDoc) m)
 
 -- Used as the underlying data type for UnaryOp and BinaryOp in all renderers
 data OpData = OD {opPrec :: Int, opDoc :: Doc}
@@ -93,8 +93,8 @@ pd = PD
 paramName :: ParamData -> String
 paramName = varName . paramVar
 
-updateParamDoc :: (Doc -> Doc) -> ParamData -> ParamData
-updateParamDoc f v = pd (paramVar v) ((f . paramDoc) v)
+updateParam :: (Doc -> Doc) -> ParamData -> ParamData
+updateParam f v = pd (paramVar v) ((f . paramDoc) v)
 
 -- Used as the underlying data type for Programs in all renderers
 data ProgData = ProgD {progName :: String, progMods :: [FileData]}
@@ -106,7 +106,7 @@ emptyProg :: ProgData
 emptyProg = progD "" []
 
 -- Used as the underlying data type for StateVars in the C++ renderer
-data StateVarData = SVD {getStVarScp :: ScopeTag, stVarDoc :: Doc, 
+data StateVarData = SVD {getStVarScp :: ScopeTag, stVar :: Doc, 
   destructSts :: (Doc, Terminator)}
 
 svd :: ScopeTag -> Doc -> (Doc, Terminator) -> StateVarData
@@ -119,13 +119,13 @@ td :: CodeType -> String -> Doc -> TypeData
 td = TD
 
 -- Used as the underlying data type for Values in all renderers
-data ValData = VD {valPrec :: Maybe Int, valType :: TypeData, valDoc :: Doc}
+data ValData = VD {valPrec :: Maybe Int, valType :: TypeData, val :: Doc}
 
 vd :: Maybe Int -> TypeData -> Doc -> ValData
 vd = VD
 
 updateValDoc :: (Doc -> Doc) -> ValData -> ValData
-updateValDoc f v = vd (valPrec v) (valType v) ((f . valDoc) v)
+updateValDoc f v = vd (valPrec v) (valType v) ((f . val) v)
 
 -- Used as the underlying data type for Variables in all renderers
 data VarData = VarD {varBind :: Binding, varName :: String, 

--- a/code/drasil-gool/GOOL/Drasil/CodeAnalysis.hs
+++ b/code/drasil-gool/GOOL/Drasil/CodeAnalysis.hs
@@ -15,7 +15,7 @@ printExc (Exc l e) = if null l then e else l ++ "." ++ e
 
 hasLoc :: Exception -> Bool
 hasLoc (Exc [] _) = False
-hasLoc _ = True
+hasLoc (Exc (_:_) _) = True
 
 exception :: String -> String -> Exception
 exception = Exc

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer.hs
@@ -37,7 +37,7 @@ import GOOL.Drasil.Symantics (Label, Library, RenderSym, BodySym(..),
   BlockCommentSym(..))
 import qualified GOOL.Drasil.Symantics as S (TypeSym(int))
 import GOOL.Drasil.AST (Terminator(..), FileData(..), fileD, updateFileMod, 
-  updateModDoc, TypeData(..), Binding(..), VarData(..))
+  updateMod, TypeData(..), Binding(..), VarData(..))
 import GOOL.Drasil.Helpers (hicat, vibcat, vmap, emptyIfEmpty, emptyIfNull,
   onStateValue, getNestDegree)
 import GOOL.Drasil.State (MS, VS, lensMStoVS, getParameters)
@@ -76,7 +76,7 @@ addExt ext nm = nm ++ "." ++ ext
 ----------------------------------
 
 packageDocD :: Label -> Doc -> FileData -> FileData
-packageDocD n end f = fileD (n ++ "/" ++ filePath f) (updateModDoc 
+packageDocD n end f = fileD (n ++ "/" ++ filePath f) (updateMod 
   (\d -> emptyIfEmpty d (vibcat [text "package" <+> text n <> end, d])) 
   (fileMod f))
 
@@ -447,7 +447,7 @@ moduleDox desc as date m = (doxFile ++ m) :
   [doxBrief ++ desc | not (null desc)]
 
 commentedModD :: FileData -> Doc -> FileData
-commentedModD m cmt = updateFileMod (updateModDoc (commentedItem cmt) (fileMod m)) m
+commentedModD m cmt = updateFileMod (updateMod (commentedItem cmt) (fileMod m)) m
 
 docFuncRepr :: (RenderSym repr) => String -> [String] -> [String] -> 
   MS (repr (Method repr)) -> MS (repr (Method repr))

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer/CSharpRenderer.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer/CSharpRenderer.hs
@@ -65,9 +65,9 @@ import GOOL.Drasil.LanguageRenderer.LanguagePolymorphic (unOpPrec, unExpr,
   unExpr', unExprNumDbl, typeUnExpr, powerPrec, binExpr, binExprNumDbl', 
   typeBinExpr)
 import GOOL.Drasil.AST (Terminator(..), ScopeTag(..), FileType(..), 
-  FileData(..), fileD, FuncData(..), fd, ModData(..), md, updateModDoc, 
-  MethodData(..), mthd, updateMthdDoc, OpData(..), od, ParamData(..), pd, 
-  updateParamDoc, ProgData(..), progD, TypeData(..), td, ValData(..), vd, 
+  FileData(..), fileD, FuncData(..), fd, ModData(..), md, updateMod, 
+  MethodData(..), mthd, updateMthd, OpData(..), od, ParamData(..), pd, 
+  updateParam, ProgData(..), progD, TypeData(..), td, ValData(..), vd, 
   updateValDoc, Binding(..), VarData(..), vard)
 import GOOL.Drasil.Helpers (toCode, toState, onCodeValue, onStateValue, 
   on2CodeValues, on2StateValues, on3CodeValues, on3StateValues, onCodeList, 
@@ -349,7 +349,7 @@ instance ValueSym CSharpCode where
   argsList = G.argsList "args"
 
   valueType = onCodeValue valType
-  valueDoc = valDoc . unCSC
+  valueDoc = val . unCSC
 
 instance NumericExpression CSharpCode where
   (#~) = unExpr' negateOp
@@ -650,7 +650,7 @@ instance InternalMethod CSharpCode where
     on3StateValues (\tp pms bd -> methodFromData Pub $ methodDocD n s p tp pms 
     bd) t (sequence ps) b
   intFunc = G.intFunc
-  commentedFunc cmt m = on2StateValues (on2CodeValues updateMthdDoc) m 
+  commentedFunc cmt m = on2StateValues (on2CodeValues updateMthd) m 
     (onStateValue (onCodeValue commentedItem) cmt)
   
   methodDoc = mthdDoc . unCSC
@@ -692,7 +692,7 @@ instance ModuleSym CSharpCode where
 instance InternalMod CSharpCode where
   moduleDoc = modDoc . unCSC
   modFromData n = G.modFromData n (toCode . md n)
-  updateModuleDoc f = onCodeValue (updateModDoc f)
+  updateModuleDoc f = onCodeValue (updateMod f)
 
 instance BlockCommentSym CSharpCode where
   type BlockComment CSharpCode = Doc
@@ -838,5 +838,5 @@ csInOut f s p ins [] [v] b = f s p (onStateValue variableType v)
   (map param $ v : ins) (on2StateValues (on2CodeValues appendToBody) b 
   (returnState $ valueOf v))
 csInOut f s p ins outs both b = f s p void (map (onStateValue (onCodeValue 
-  (updateParamDoc csRef)) . param) both ++ map param ins ++ map (onStateValue 
-  (onCodeValue (updateParamDoc csOut)) . param) outs) b
+  (updateParam csRef)) . param) both ++ map param ins ++ map (onStateValue 
+  (onCodeValue (updateParam csOut)) . param) outs) b

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer/JavaRenderer.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer/JavaRenderer.hs
@@ -66,8 +66,8 @@ import GOOL.Drasil.LanguageRenderer.LanguagePolymorphic (unOpPrec, unExpr,
   unExpr', unExprNumDbl, typeUnExpr, powerPrec, binExpr, binExprNumDbl', 
   typeBinExpr)
 import GOOL.Drasil.AST (Terminator(..), ScopeTag(..), FileType(..), 
-  FileData(..), fileD, FuncData(..), fd, ModData(..), md, updateModDoc, 
-  MethodData(..), mthd, updateMthdDoc, OpData(..), od, ParamData(..), pd, 
+  FileData(..), fileD, FuncData(..), fd, ModData(..), md, updateMod, 
+  MethodData(..), mthd, updateMthd, OpData(..), od, ParamData(..), pd, 
   ProgData(..), progD, TypeData(..), td, ValData(..), vd, VarData(..), vard)
 import GOOL.Drasil.CodeAnalysis (Exception(..))
 import GOOL.Drasil.Helpers (angles, emptyIfNull, toCode, toState, onCodeValue, 
@@ -357,7 +357,7 @@ instance ValueSym JavaCode where
   argsList = G.argsList "args"
 
   valueType = onCodeValue valType
-  valueDoc = valDoc . unJC
+  valueDoc = val . unJC
 
 instance NumericExpression JavaCode where
   (#~) = unExpr' negateOp
@@ -691,7 +691,7 @@ instance InternalMethod JavaCode where
     modify ((if m then setCurrMain else id) . addExceptionImports excs) 
     toState $ methodFromData Pub $ jMethod n (map exc excs) s p tp pms bd
   intFunc = G.intFunc
-  commentedFunc cmt m = on2StateValues (on2CodeValues updateMthdDoc) m 
+  commentedFunc cmt m = on2StateValues (on2CodeValues updateMthd) m 
     (onStateValue (onCodeValue commentedItem) cmt)
   
   methodDoc = mthdDoc . unJC
@@ -733,7 +733,7 @@ instance ModuleSym JavaCode where
 instance InternalMod JavaCode where
   moduleDoc = modDoc . unJC
   modFromData n = G.modFromData n (toCode . md n)
-  updateModuleDoc f = onCodeValue (updateModDoc f)
+  updateModuleDoc f = onCodeValue (updateMod f)
 
 instance BlockCommentSym JavaCode where
   type BlockComment JavaCode = Doc

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer/PythonRenderer.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer/PythonRenderer.hs
@@ -58,8 +58,8 @@ import GOOL.Drasil.LanguageRenderer.LanguagePolymorphic (unOpPrec, unExpr,
   unExpr', typeUnExpr, powerPrec, multPrec, andPrec, orPrec, binExpr, 
   typeBinExpr, addmathImport)
 import GOOL.Drasil.AST (Terminator(..), ScopeTag(..), FileType(..), 
-  FileData(..), fileD, FuncData(..), fd, ModData(..), md, updateModDoc, 
-  MethodData(..), mthd, updateMthdDoc, OpData(..), od, ParamData(..), pd, 
+  FileData(..), fileD, FuncData(..), fd, ModData(..), md, updateMod, 
+  MethodData(..), mthd, updateMthd, OpData(..), od, ParamData(..), pd, 
   ProgData(..), progD, TypeData(..), td, ValData(..), vd, VarData(..), vard)
 import GOOL.Drasil.Helpers (vibcat, emptyIfEmpty, toCode, toState, onCodeValue,
   onStateValue, on2CodeValues, on2StateValues, on3CodeValues, on3StateValues,
@@ -342,7 +342,7 @@ instance ValueSym PythonCode where
   argsList = modify (addLangImportVS "sys") >> G.argsList "sys.argv"
 
   valueType = onCodeValue valType
-  valueDoc = valDoc . unPC
+  valueDoc = val . unPC
 
 instance NumericExpression PythonCode where
   (#~) = unExpr' negateOp
@@ -673,7 +673,7 @@ instance InternalMethod PythonCode where
   intFunc m n _ _ _ ps b = modify (if m then setCurrMain else id) >>
     on1StateValue1List (\bd pms -> methodFromData Pub $ pyFunction n pms bd) 
     b ps
-  commentedFunc cmt m = on2StateValues (on2CodeValues updateMthdDoc) m 
+  commentedFunc cmt m = on2StateValues (on2CodeValues updateMthd) m 
     (onStateValue (onCodeValue commentedItem) cmt)
 
   methodDoc = mthdDoc . unPC
@@ -725,7 +725,7 @@ instance ModuleSym PythonCode where
 instance InternalMod PythonCode where
   moduleDoc = modDoc . unPC
   modFromData n = G.modFromData n (toCode . md n)
-  updateModuleDoc f = onCodeValue (updateModDoc f)
+  updateModuleDoc f = onCodeValue (updateMod f)
 
 instance BlockCommentSym PythonCode where
   type BlockComment PythonCode = Doc


### PR DESCRIPTION
Based on code review meeting on April 3rd, removing `Doc` from the end of some functions. (and also changing on catch-all clause to not be a catch-all).