### PR TITLE
Remove KeywordSym

### DIFF
--- a/code/drasil-gool/GOOL/Drasil/Helpers.hs
+++ b/code/drasil-gool/GOOL/Drasil/Helpers.hs
@@ -1,8 +1,8 @@
 module GOOL.Drasil.Helpers (angles, doubleQuotedText, hicat, vicat, vibcat, 
   vmap, vimap, emptyIfEmpty, emptyIfNull, toCode, toState, onCodeValue, 
   onStateValue, on2CodeValues, on2StateValues, on3CodeValues, on3StateValues, 
-  onCodeList, onStateList, on2StateLists, on1CodeValue1List, 
-  on1StateValue1List, getInnerType, getNestDegree
+  onCodeList, onStateList, on2StateLists, on1StateValue1List, getInnerType, 
+  getNestDegree
 ) where
 
 import Utils.Drasil (blank)
@@ -79,9 +79,6 @@ onStateList f as = f <$> sequence as
 
 on2StateLists :: ([a] -> [b] -> c) -> [State s a] -> [State s b] -> State s c
 on2StateLists f as bs = liftM2 f (sequence as) (sequence bs)
-
-on1CodeValue1List :: Monad m => (a -> [b] -> c) -> m a -> [m b] -> m c
-on1CodeValue1List f a as = liftA2 f a (sequence as)
 
 on1StateValue1List :: (a -> [b] -> c) -> State s a -> [State s b] -> State s c
 on1StateValue1List f a as = liftM2 f a (sequence as)

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer.hs
@@ -4,7 +4,7 @@
 module GOOL.Drasil.LanguageRenderer (
   -- * Common Syntax
   classDec, dot, doubleSlash, elseIfLabel, forLabel, inLabel, new, 
-  blockCmtStart, blockCmtEnd, docCmtStart, addExt,
+  blockCmtStart, blockCmtEnd, docCmtStart, bodyStart, bodyEnd, addExt,
   
   -- * Default Functions available for use in renderers
   packageDocD, fileDoc', moduleDocD, classDocD, 
@@ -55,7 +55,7 @@ import Text.PrettyPrint.HughesPJ (Doc, text, empty, render, (<>), (<+>), ($+$),
 ----------------------------------------
 
 classDec, dot, doubleSlash, elseIfLabel, forLabel, inLabel, new, blockCmtStart, 
-  blockCmtEnd, docCmtStart :: Doc
+  blockCmtEnd, docCmtStart, bodyStart, bodyEnd :: Doc
 classDec = text "class"
 dot = text "."
 doubleSlash = text "//"
@@ -66,6 +66,8 @@ new = text "new"
 blockCmtStart = text "/*"
 blockCmtEnd = text "*/"
 docCmtStart = text "/**"
+bodyStart = lbrace
+bodyEnd = rbrace
 
 addExt :: String -> String -> String
 addExt ext nm = nm ++ "." ++ ext

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer.hs
@@ -3,7 +3,7 @@
 -- | The structure for a class of renderers is defined here.
 module GOOL.Drasil.LanguageRenderer (
   -- * Common Syntax
-  classDec, dot, doubleSlash, elseIfLabel, forLabel, inLabel, new, 
+  classDec, dot, commentStart, elseIfLabel, forLabel, inLabel, new,
   blockCmtStart, blockCmtEnd, docCmtStart, bodyStart, bodyEnd, addExt,
   
   -- * Default Functions available for use in renderers
@@ -54,11 +54,11 @@ import Text.PrettyPrint.HughesPJ (Doc, text, empty, render, (<>), (<+>), ($+$),
 -- Syntax common to several renderers --
 ----------------------------------------
 
-classDec, dot, doubleSlash, elseIfLabel, forLabel, inLabel, new, blockCmtStart, 
+classDec, dot, commentStart, elseIfLabel, forLabel, inLabel, new, blockCmtStart,
   blockCmtEnd, docCmtStart, bodyStart, bodyEnd :: Doc
 classDec = text "class"
 dot = text "."
-doubleSlash = text "//"
+commentStart = text "//"
 elseIfLabel = text "else if"
 forLabel = text "for"
 inLabel = text "in"

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer/CSharpRenderer.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer/CSharpRenderer.hs
@@ -132,8 +132,6 @@ instance KeywordSym CSharpCode where
   inherit n = toCode $ colon <+> text n
   implements is = toCode $ colon <+> text (intercalate ", " is)
 
-  list = toCode $ text "List"
-
   blockStart = toCode lbrace
   blockEnd = toCode rbrace
 
@@ -199,7 +197,7 @@ instance TypeSym CSharpCode where
   infile = csInfileType
   outfile = csOutfileType
   listType t = modify (addLangImportVS "System.Collections.Generic") >> 
-    G.listType list t
+    G.listType "List" t
   arrayType = G.arrayType
   listInnerType = G.listInnerType
   obj = G.obj

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer/CSharpRenderer.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer/CSharpRenderer.hs
@@ -128,15 +128,11 @@ instance KeywordSym CSharpCode where
   type Keyword CSharpCode = Doc
   endStatement = toCode semi
 
-  inherit n = toCode $ colon <+> text n
-  implements is = toCode $ colon <+> text (intercalate ", " is)
-
   blockStart = toCode lbrace
   blockEnd = toCode rbrace
 
   commentStart = toCode doubleSlash
 
-  keyFromDoc = toCode
   keyDoc = unCSC
 
 instance ImportSym CSharpCode where
@@ -639,9 +635,14 @@ instance ClassSym CSharpCode where
 
 instance InternalClass CSharpCode where
   intClass = G.intClass classDocD
+
+  inherit n = toCode $ maybe empty ((colon <+>) . text) n
+  implements is = toCode $ colon <+> text (intercalate ", " is)
+
   commentedClass = G.commentedClass
+
   classDoc = unCSC
-  classFromData = onStateValue toCode
+  classFromData d = d
 
 instance ModuleSym CSharpCode where
   type Module CSharpCode = ModData

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer/CSharpRenderer.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer/CSharpRenderer.hs
@@ -127,7 +127,6 @@ instance InternalFile CSharpCode where
 instance KeywordSym CSharpCode where
   type Keyword CSharpCode = Doc
   endStatement = toCode semi
-  endStatementLoop = toCode empty
 
   inherit n = toCode $ colon <+> text n
   implements is = toCode $ colon <+> text (intercalate ", " is)
@@ -135,17 +134,7 @@ instance KeywordSym CSharpCode where
   blockStart = toCode lbrace
   blockEnd = toCode rbrace
 
-  ifBodyStart = blockStart
-  elseIf = toCode elseIfLabel
-  
-  iterForEachLabel = toCode $ text "foreach"
-  iterInLabel = toCode inLabel
-
   commentStart = toCode doubleSlash
-  blockCommentStart = toCode blockCmtStart
-  blockCommentEnd = toCode blockCmtEnd
-  docCommentStart = toCode docCmtStart
-  docCommentEnd = blockCommentEnd
 
   keyFromDoc = toCode
   keyDoc = unCSC
@@ -551,14 +540,14 @@ instance StatementSym CSharpCode where
   multi = onStateList (on1CodeValue1List multiStateDocD endStatement)
 
 instance ControlStatement CSharpCode where
-  ifCond = G.ifCond ifBodyStart elseIf blockEnd
+  ifCond = G.ifCond blockStart elseIfLabel blockEnd
   switch = G.switch
 
   ifExists = G.ifExists
 
   for = G.for blockStart blockEnd
   forRange = G.forRange
-  forEach = G.forEach blockStart blockEnd iterForEachLabel iterInLabel 
+  forEach = G.forEach blockStart blockEnd (text "foreach") inLabel 
   while = G.while blockStart blockEnd
 
   tryCatch = G.tryCatch csTryCatch
@@ -665,10 +654,9 @@ instance InternalMod CSharpCode where
 
 instance BlockCommentSym CSharpCode where
   type BlockComment CSharpCode = Doc
-  blockComment lns = on2CodeValues (blockCmtDoc lns) blockCommentStart 
-    blockCommentEnd
-  docComment = onStateValue (\lns -> on2CodeValues (docCmtDoc lns) 
-    docCommentStart docCommentEnd)
+  blockComment lns = toCode $ blockCmtDoc lns blockCmtStart blockCmtEnd
+  docComment = onStateValue (\lns -> toCode $ docCmtDoc lns docCmtStart 
+    blockCmtEnd)
 
   blockCommentDoc = unCSC
 

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer/CSharpRenderer.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer/CSharpRenderer.hs
@@ -32,7 +32,7 @@ import GOOL.Drasil.LanguageRenderer (classDocD, multiStateDocD, bodyDocD,
   mkSt, mkStNoEnd, breakDocD, continueDocD, mkStateVal, mkVal, mkVar, 
   classVarDocD, objVarDocD, funcDocD, castDocD, listSetFuncDocD, castObjDocD, 
   staticDocD, dynamicDocD, bindingError, privateDocD, publicDocD, dot, 
-  blockCmtStart, blockCmtEnd, docCmtStart, bodyStart, bodyEnd, doubleSlash, 
+  blockCmtStart, blockCmtEnd, docCmtStart, bodyStart, bodyEnd, commentStart, 
   elseIfLabel, inLabel, blockCmtDoc, docCmtDoc, commentedItem, addCommentsDocD, 
   commentedModD, variableList, appendToBody, surroundBody)
 import qualified GOOL.Drasil.LanguageRenderer.LanguagePolymorphic as G (
@@ -128,8 +128,6 @@ instance KeywordSym CSharpCode where
   type Keyword CSharpCode = Doc
   endStatement = toCode semi
 
-  commentStart = toCode doubleSlash
-
   keyDoc = unCSC
 
 instance ImportSym CSharpCode where
@@ -152,7 +150,7 @@ instance BodySym CSharpCode where
   type Body CSharpCode = Doc
   body = onStateList (onCodeList bodyDocD)
 
-  addComments s = onStateValue (on2CodeValues (addCommentsDocD s) commentStart)
+  addComments s = onStateValue (onCodeValue (addCommentsDocD s commentStart))
 
 instance InternalBody CSharpCode where
   bodyDoc = unCSC

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer/CppRenderer.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer/CppRenderer.hs
@@ -93,7 +93,7 @@ import Data.List (sort)
 import qualified Data.Map as Map (lookup)
 import Text.PrettyPrint.HughesPJ (Doc, text, (<>), (<+>), hcat, brackets, 
   braces, parens, comma, empty, equals, semi, vcat, lbrace, rbrace, quotes, 
-  render, colon, isEmpty)
+  colon, isEmpty)
 
 cppHdrExt, cppSrcExt :: String
 cppHdrExt = "hpp"
@@ -145,8 +145,6 @@ instance (Pair p) => KeywordSym (p CppSrcCode CppHdrCode) where
 
   inherit n = pair (inherit n) (inherit n)
   implements is = pair (implements is) (implements is)
-
-  list = pair list list
 
   blockStart = pair blockStart blockStart
   blockEnd = pair blockEnd blockEnd
@@ -1090,8 +1088,6 @@ instance KeywordSym CppSrcCode where
   implements is = onCodeValue ((\p -> colon <+> hcat (map ((p <+>) . text) is)) 
     . fst) public
 
-  list = toCode $ text "vector"
-
   blockStart = toCode lbrace
   blockEnd = toCode rbrace
 
@@ -1157,8 +1153,8 @@ instance TypeSym CppSrcCode where
   string = modify (addUsing "string" . addLangImportVS "string") >> G.string
   infile = modify (addUsing "ifstream") >> cppInfileType
   outfile = modify (addUsing "ofstream") >> cppOutfileType
-  listType t = modify (addUsing lst . addLangImportVS lst) >> G.listType list t
-    where lst = render $ keyDoc (list :: CppSrcCode (Keyword CppSrcCode))
+  listType t = modify (addUsing vec . addLangImportVS vec) >> G.listType vec t
+    where vec = "vector"
   arrayType = cppArrayType
   listInnerType = G.listInnerType
   obj n = zoom lensVStoMS getClassName >>= (\cn -> if cn == n then G.obj n else 
@@ -1739,9 +1735,6 @@ instance KeywordSym CppHdrCode where
   implements is = onCodeValue ((\p -> colon <+> hcat (map ((p <+>) . text) is)) 
     . fst) public
 
-
-  list = toCode $ text "vector"
-
   blockStart = toCode lbrace
   blockEnd = toCode rbrace
 
@@ -1808,9 +1801,9 @@ instance TypeSym CppHdrCode where
     G.string
   infile = modify (addHeaderUsing "ifstream") >> cppInfileType
   outfile = modify (addHeaderUsing "ofstream") >> cppOutfileType
-  listType t = modify (addHeaderUsing lst . addHeaderLangImport lst) >> 
-    G.listType list t
-    where lst = render $ keyDoc (list :: CppHdrCode (Keyword CppHdrCode))
+  listType t = modify (addHeaderUsing vec . addHeaderLangImport vec) >> 
+    G.listType vec t
+    where vec = "vector"
   arrayType = cppArrayType
   listInnerType = G.listInnerType
   obj n = getClassMap >>= (\cm -> maybe id ((>>) . modify . addHeaderModImport) 

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer/CppRenderer.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer/CppRenderer.hs
@@ -34,7 +34,7 @@ import GOOL.Drasil.LanguageRenderer (addExt, multiStateDocD,
   mkStNoEnd, breakDocD, continueDocD, mkStateVal, mkVal, mkStateVar, mkVar, 
   classVarCheckStatic, castDocD, castObjDocD, staticDocD, dynamicDocD, 
   privateDocD, publicDocD, classDec, dot, blockCmtStart, blockCmtEnd, 
-  docCmtStart, bodyStart, bodyEnd, doubleSlash, elseIfLabel, blockCmtDoc, 
+  docCmtStart, bodyStart, bodyEnd, commentStart, elseIfLabel, blockCmtDoc, 
   docCmtDoc, commentedItem, addCommentsDocD, functionDox, commentedModD, 
   valueList, parameterList, appendToBody, surroundBody, getterName, setterName)
 import qualified GOOL.Drasil.LanguageRenderer.LanguagePolymorphic as G (
@@ -141,8 +141,6 @@ instance (Pair p) => InternalFile (p CppSrcCode CppHdrCode) where
 instance (Pair p) => KeywordSym (p CppSrcCode CppHdrCode) where
   type Keyword (p CppSrcCode CppHdrCode) = Doc
   endStatement = pair endStatement endStatement
-
-  commentStart = pair commentStart commentStart
 
   keyDoc k = keyDoc $ pfst k
 
@@ -1070,8 +1068,6 @@ instance KeywordSym CppSrcCode where
   type Keyword CppSrcCode = Doc
   endStatement = toCode semi
 
-  commentStart = toCode doubleSlash
-
   keyDoc = unCPPSC
 
 instance ImportSym CppSrcCode where
@@ -1095,7 +1091,7 @@ instance BodySym CppSrcCode where
   type Body CppSrcCode = Doc
   body = onStateList (onCodeList bodyDocD)
 
-  addComments s = onStateValue (on2CodeValues (addCommentsDocD s) commentStart)
+  addComments s = onStateValue (onCodeValue (addCommentsDocD s commentStart))
 
 instance InternalBody CppSrcCode where
   bodyDoc = unCPPSC
@@ -1702,8 +1698,6 @@ instance InternalFile CppHdrCode where
 instance KeywordSym CppHdrCode where
   type Keyword CppHdrCode = Doc
   endStatement = toCode semi
-
-  commentStart = toCode empty
 
   keyDoc = unCPPHC
 

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer/JavaRenderer.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer/JavaRenderer.hs
@@ -91,7 +91,7 @@ import Control.Monad.State (modify, runState)
 import qualified Data.Map as Map (lookup)
 import Data.List (elemIndex, nub, intercalate, sort)
 import Text.PrettyPrint.HughesPJ (Doc, text, (<>), (<+>), parens, empty, 
-  equals, semi, vcat, lbrace, rbrace, render, colon)
+  equals, semi, vcat, lbrace, rbrace, colon)
 
 jExt :: String
 jExt = "java"
@@ -138,9 +138,7 @@ instance KeywordSym JavaCode where
   endStatementLoop = toCode empty
 
   inherit n = toCode $ text "extends" <+> text n
-  implements is = toCode $ text "implements" <+> text (intercalate ", " is) 
-
-  list = toCode $ text "ArrayList"
+  implements is = toCode $ text "implements" <+> text (intercalate ", " is)
 
   blockStart = toCode lbrace
   blockEnd = toCode rbrace
@@ -206,7 +204,7 @@ instance TypeSym JavaCode where
   string = jStringType
   infile = jInfileType
   outfile = jOutfileType
-  listType = jListType list
+  listType = jListType "ArrayList"
   arrayType = G.arrayType
   listInnerType = G.listInnerType
   obj = G.obj
@@ -798,17 +796,17 @@ jOutfileType :: (RenderSym repr) => VSType repr
 jOutfileType = modifyReturn (addLangImportVS "java.io.PrintWriter") $ 
   typeFromData File "PrintWriter" (text "PrintWriter")
 
-jListType :: (RenderSym repr) => repr (Keyword repr) -> VSType repr -> VSType repr
-jListType l t = modify (addLangImportVS $ "java.util." ++ render lst) >> 
+jListType :: (RenderSym repr) => String -> VSType repr -> VSType repr
+jListType l t = modify (addLangImportVS $ "java.util." ++ l) >> 
   (t >>= (jListType' . getType))
-  where jListType' Integer = toState $ typeFromData (List Integer) (render lst 
-          ++ "<Integer>") (lst <> angles (text "Integer"))
+  where jListType' Integer = toState $ typeFromData (List Integer) 
+          (l ++ "<Integer>") (lst <> angles (text "Integer"))
         jListType' Float = toState $ typeFromData (List Float) 
-          (render lst ++ "<Float>") (lst <> angles (text "Float"))
+          (l ++ "<Float>") (lst <> angles (text "Float"))
         jListType' Double = toState $ typeFromData (List Double) 
-          (render lst ++ "<Double>") (lst <> angles (text "Double"))
+          (l ++ "<Double>") (lst <> angles (text "Double"))
         jListType' _ = G.listType l t
-        lst = keyDoc l
+        lst = text l
 
 jArrayType :: VSType JavaCode
 jArrayType = arrayType (obj "Object")

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer/JavaRenderer.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer/JavaRenderer.hs
@@ -33,7 +33,7 @@ import GOOL.Drasil.LanguageRenderer (packageDocD, classDocD, multiStateDocD,
   mkSt, breakDocD, continueDocD, mkStateVal, mkVal, classVarDocD, castDocD, 
   castObjDocD, staticDocD, dynamicDocD, bindingError, privateDocD, publicDocD, 
   dot, new, elseIfLabel, forLabel, blockCmtStart, blockCmtEnd, docCmtStart, 
-  bodyStart, bodyEnd, doubleSlash, blockCmtDoc, docCmtDoc, commentedItem, 
+  bodyStart, bodyEnd, commentStart, blockCmtDoc, docCmtDoc, commentedItem, 
   addCommentsDocD, commentedModD, docFuncRepr, variableList, parameterList, 
   appendToBody, surroundBody, intValue)
 import qualified GOOL.Drasil.LanguageRenderer.LanguagePolymorphic as G (
@@ -136,8 +136,6 @@ instance KeywordSym JavaCode where
   type Keyword JavaCode = Doc
   endStatement = toCode semi
 
-  commentStart = toCode doubleSlash
-
   keyDoc = unJC
 
 instance ImportSym JavaCode where
@@ -160,7 +158,7 @@ instance BodySym JavaCode where
   type Body JavaCode = Doc
   body = onStateList (onCodeList bodyDocD)
 
-  addComments s = onStateValue (on2CodeValues (addCommentsDocD s) commentStart)
+  addComments s = onStateValue (onCodeValue (addCommentsDocD s commentStart))
 
 instance InternalBody JavaCode where
   bodyDoc = unJC

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer/JavaRenderer.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer/JavaRenderer.hs
@@ -135,7 +135,6 @@ instance InternalFile JavaCode where
 instance KeywordSym JavaCode where
   type Keyword JavaCode = Doc
   endStatement = toCode semi
-  endStatementLoop = toCode empty
 
   inherit n = toCode $ text "extends" <+> text n
   implements is = toCode $ text "implements" <+> text (intercalate ", " is)
@@ -143,17 +142,7 @@ instance KeywordSym JavaCode where
   blockStart = toCode lbrace
   blockEnd = toCode rbrace
 
-  ifBodyStart = blockStart
-  elseIf = toCode elseIfLabel
-  
-  iterForEachLabel = toCode forLabel
-  iterInLabel = toCode colon
-
   commentStart = toCode doubleSlash
-  blockCommentStart = toCode blockCmtStart
-  blockCommentEnd = toCode blockCmtEnd
-  docCommentStart = toCode docCmtStart
-  docCommentEnd = blockCommentEnd
 
   keyFromDoc = toCode
   keyDoc = unJC
@@ -582,14 +571,14 @@ instance StatementSym JavaCode where
   multi = onStateList (on1CodeValue1List multiStateDocD endStatement)
 
 instance ControlStatement JavaCode where
-  ifCond = G.ifCond ifBodyStart elseIf blockEnd
+  ifCond = G.ifCond blockStart elseIfLabel blockEnd
   switch  = G.switch
 
   ifExists = G.ifExists
 
   for = G.for blockStart blockEnd
   forRange = G.forRange 
-  forEach = G.forEach blockStart blockEnd iterForEachLabel iterInLabel
+  forEach = G.forEach blockStart blockEnd forLabel colon
   while = G.while blockStart blockEnd
 
   tryCatch = G.tryCatch jTryCatch
@@ -704,10 +693,9 @@ instance InternalMod JavaCode where
 
 instance BlockCommentSym JavaCode where
   type BlockComment JavaCode = Doc
-  blockComment lns = on2CodeValues (blockCmtDoc lns) blockCommentStart 
-    blockCommentEnd
-  docComment = onStateValue (\lns -> on2CodeValues (docCmtDoc lns) 
-    docCommentStart docCommentEnd)
+  blockComment lns = toCode $ blockCmtDoc lns blockCmtStart blockCmtEnd
+  docComment = onStateValue (\lns -> toCode $ docCmtDoc lns docCmtStart 
+    blockCmtEnd)
 
   blockCommentDoc = unJC
 

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer/JavaRenderer.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer/JavaRenderer.hs
@@ -33,9 +33,9 @@ import GOOL.Drasil.LanguageRenderer (packageDocD, classDocD, multiStateDocD,
   mkSt, breakDocD, continueDocD, mkStateVal, mkVal, classVarDocD, castDocD, 
   castObjDocD, staticDocD, dynamicDocD, bindingError, privateDocD, publicDocD, 
   dot, new, elseIfLabel, forLabel, blockCmtStart, blockCmtEnd, docCmtStart, 
-  doubleSlash, blockCmtDoc, docCmtDoc, commentedItem, addCommentsDocD, 
-  commentedModD, docFuncRepr, variableList, parameterList, appendToBody, 
-  surroundBody, intValue)
+  bodyStart, bodyEnd, doubleSlash, blockCmtDoc, docCmtDoc, commentedItem, 
+  addCommentsDocD, commentedModD, docFuncRepr, variableList, parameterList, 
+  appendToBody, surroundBody, intValue)
 import qualified GOOL.Drasil.LanguageRenderer.LanguagePolymorphic as G (
   multiBody, block, multiBlock, bool, int, float, double, char, listType, 
   arrayType, listInnerType, obj, funcType, void, runStrategy, listSlice, notOp, 
@@ -135,9 +135,6 @@ instance InternalFile JavaCode where
 instance KeywordSym JavaCode where
   type Keyword JavaCode = Doc
   endStatement = toCode semi
-
-  blockStart = toCode lbrace
-  blockEnd = toCode rbrace
 
   commentStart = toCode doubleSlash
 
@@ -567,15 +564,15 @@ instance StatementSym JavaCode where
   multi = onStateList (on1CodeValue1List multiStateDocD endStatement)
 
 instance ControlStatement JavaCode where
-  ifCond = G.ifCond blockStart elseIfLabel blockEnd
+  ifCond = G.ifCond bodyStart elseIfLabel bodyEnd
   switch  = G.switch
 
   ifExists = G.ifExists
 
-  for = G.for blockStart blockEnd
+  for = G.for bodyStart bodyEnd
   forRange = G.forRange 
-  forEach = G.forEach blockStart blockEnd forLabel colon
-  while = G.while blockStart blockEnd
+  forEach = G.forEach bodyStart bodyEnd forLabel colon
+  while = G.while bodyStart bodyEnd
 
   tryCatch = G.tryCatch jTryCatch
   

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer/JavaRenderer.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer/JavaRenderer.hs
@@ -136,15 +136,11 @@ instance KeywordSym JavaCode where
   type Keyword JavaCode = Doc
   endStatement = toCode semi
 
-  inherit n = toCode $ text "extends" <+> text n
-  implements is = toCode $ text "implements" <+> text (intercalate ", " is)
-
   blockStart = toCode lbrace
   blockEnd = toCode rbrace
 
   commentStart = toCode doubleSlash
 
-  keyFromDoc = toCode
   keyDoc = unJC
 
 instance ImportSym JavaCode where
@@ -678,9 +674,14 @@ instance ClassSym JavaCode where
 
 instance InternalClass JavaCode where
   intClass = G.intClass classDocD
+  
+  inherit n = toCode $ maybe empty ((text "extends" <+>) . text) n
+  implements is = toCode $ text "implements" <+> text (intercalate ", " is)
+
   commentedClass = G.commentedClass
+
   classDoc = unJC
-  classFromData = onStateValue toCode
+  classFromData d = d
 
 instance ModuleSym JavaCode where
   type Module JavaCode = ModData

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer/LanguagePolymorphic.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer/LanguagePolymorphic.hs
@@ -64,7 +64,7 @@ import qualified GOOL.Drasil.ClassInterface as S (BlockSym(block),
     constDecDef, valState, returnState),
   ControlStatement(ifCond, for, forRange, switch), ParameterSym(param), 
   MethodSym(method, mainFunction), ClassSym(buildClass))
-import GOOL.Drasil.RendererClasses (InternalFile(commentedMod), KeywordSym(..), 
+import GOOL.Drasil.RendererClasses (InternalFile(commentedMod),
   RenderSym, InternalBody(bodyDoc, docBody), InternalBlock(docBlock, blockDoc), 
   ImportSym(..), InternalPerm(..), InternalType(..), UnaryOpSym(UnaryOp), 
   BinaryOpSym(BinaryOp), InternalOp(..), 
@@ -122,10 +122,9 @@ multiBody bs = docBody $ onStateList vibcat $ map (onStateValue bodyDoc) bs
 
 -- Blocks --
 
-block :: (RenderSym repr) => repr (Keyword repr) -> [MSStatement repr] -> 
-  MSBlock repr
-block end sts = docBlock $ onStateList (blockDocD (keyDoc end) . map 
-  statementDoc) (map S.state sts)
+block :: (RenderSym repr) => [MSStatement repr] -> MSBlock repr
+block sts = docBlock $ onStateList (blockDocD . map statementDoc) 
+  (map S.state sts)
 
 multiBlock :: (RenderSym repr) => [MSBlock repr] -> MSBlock repr
 multiBlock bs = docBlock $ onStateList vibcat $ map (onStateValue blockDoc) bs

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer/LanguagePolymorphic.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer/LanguagePolymorphic.hs
@@ -153,11 +153,9 @@ string = toState $ typeFromData String "string" (text "string")
 fileType :: (RenderSym repr) => VSType repr
 fileType = toState $ typeFromData File "File" (text "File")
 
-listType :: (RenderSym repr) => repr (Keyword repr) -> VSType repr -> 
-  VSType repr
-listType lst = onStateValue (\t -> typeFromData (List (getType t)) (render 
-  (keyDoc lst) ++ "<" ++ getTypeString t ++ ">") (keyDoc lst <> 
-  angles (getTypeDoc t)))
+listType :: (RenderSym repr) => String -> VSType repr -> VSType repr
+listType lst = onStateValue (\t -> typeFromData (List (getType t)) (lst ++ "<" 
+  ++ getTypeString t ++ ">") (text lst <> angles (getTypeDoc t)))
 
 arrayType :: (RenderSym repr) => VSType repr -> VSType repr
 arrayType = onStateValue (\t -> typeFromData (Array (getType t)) 

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer/LanguagePolymorphic.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer/LanguagePolymorphic.hs
@@ -881,13 +881,11 @@ throw f t = onStateValue (\msg -> stateFromData (f msg) t) . zoom lensMStoVS .
 
 -- ControlStatements --
 
-ifCond :: (RenderSym repr) => repr (Keyword repr) -> repr (Keyword repr) -> 
-  repr (Keyword repr) -> [(SValue repr, MSBody repr)] -> MSBody repr -> 
-  MSStatement repr
+ifCond :: (RenderSym repr) => repr (Keyword repr) -> Doc -> repr (Keyword repr) 
+  -> [(SValue repr, MSBody repr)] -> MSBody repr -> MSStatement repr
 ifCond _ _ _ [] _ = error "if condition created with no cases"
-ifCond ifst elseif blEnd (c:cs) eBody = 
+ifCond ifst elif blEnd (c:cs) eBody = 
     let ifStart = keyDoc ifst
-        elif = keyDoc elseif
         bEnd = keyDoc blEnd
         ifSect (v, b) = on2StateValues (\val bd -> vcat [
           text "if" <+> parens (valueDoc val) <+> ifStart,
@@ -930,11 +928,10 @@ forRange i initv finalv stepv = S.for (S.varDecDef i initv) (S.valueOf i ?<
   finalv) (i &+= stepv)
 
 forEach :: (RenderSym repr) => repr (Keyword repr) -> repr (Keyword repr) -> 
-  repr (Keyword repr) -> repr (Keyword repr) -> SVariable repr -> SValue repr 
-  -> MSBody repr -> MSStatement repr
+  Doc -> Doc -> SVariable repr -> SValue repr -> MSBody repr -> MSStatement repr
 forEach bStart bEnd forEachLabel inLbl e' v' = on3StateValues (\e v b -> 
-  mkStNoEnd (vcat [keyDoc forEachLabel <+> parens (getTypeDoc (variableType e) 
-    <+> variableDoc e <+> keyDoc inLbl <+> valueDoc v) <+> keyDoc bStart,
+  mkStNoEnd (vcat [forEachLabel <+> parens (getTypeDoc (variableType e) 
+    <+> variableDoc e <+> inLbl <+> valueDoc v) <+> keyDoc bStart,
   indent $ bodyDoc b,
   keyDoc bEnd])) (zoom lensMStoVS e') (zoom lensMStoVS v') 
 

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer/LanguagePolymorphic.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer/LanguagePolymorphic.hs
@@ -868,8 +868,8 @@ valState :: (RenderSym repr) => Terminator -> SValue repr -> MSStatement repr
 valState t v' = zoom lensMStoVS $ onStateValue (\v -> stateFromData (valueDoc v)
   t) v'
 
-comment :: (RenderSym repr) => repr (Keyword repr) -> Label -> MSStatement repr
-comment cs c = toState $ mkStNoEnd (commentDocD c (keyDoc cs))
+comment :: (RenderSym repr) => Doc -> Label -> MSStatement repr
+comment cs c = toState $ mkStNoEnd (commentDocD c cs)
 
 freeError :: String -> String
 freeError l = "Cannot free variables in " ++ l

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer/PythonRenderer.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer/PythonRenderer.hs
@@ -20,7 +20,7 @@ import GOOL.Drasil.ClassInterface (Label, MSBody, VSType, SVariable, SValue,
   StatementSym(..), (&=), observerListName, ControlStatement(..), 
   switchAsIf, ScopeSym(..), ParameterSym(..), MethodSym(..), StateVarSym(..), 
   ClassSym(..), ModuleSym(..), ODEInfo(..), ODEOptions(..), ODEMethod(..))
-import GOOL.Drasil.RendererClasses (RenderSym, InternalFile(..), KeywordSym(..),
+import GOOL.Drasil.RendererClasses (RenderSym, InternalFile(..),
   ImportSym(..), InternalPerm(..), InternalBody(..), InternalBlock(..), 
   InternalType(..), UnaryOpSym(..), BinaryOpSym(..), InternalOp(..), 
   InternalVariable(..), InternalValue(..), InternalFunction(..), 
@@ -61,7 +61,7 @@ import GOOL.Drasil.AST (Terminator(..), ScopeTag(..), FileType(..),
   ProgData(..), progD, TypeData(..), td, ValData(..), vd, VarData(..), vard)
 import GOOL.Drasil.Helpers (vibcat, emptyIfEmpty, toCode, toState, onCodeValue,
   onStateValue, on2CodeValues, on2StateValues, on3CodeValues, on3StateValues,
-  onCodeList, onStateList, on2StateLists, on1CodeValue1List, on1StateValue1List)
+  onCodeList, onStateList, on2StateLists, on1StateValue1List)
 import GOOL.Drasil.State (VS, lensGStoFS, lensMStoVS, lensVStoMS, revFiles,
   addLangImportVS, getLangImports, addLibImport, addLibImportVS, getLibImports, 
   addModuleImport, addModuleImportVS, getModuleImports, setFileType, 
@@ -117,12 +117,6 @@ instance InternalFile PythonCode where
 
   fileFromData = G.fileFromData (\m fp -> onCodeValue (fileD fp) m)
 
-instance KeywordSym PythonCode where
-  type Keyword PythonCode = Doc
-  endStatement = toCode empty
-
-  keyDoc = unPC
-
 instance ImportSym PythonCode where
   type Import PythonCode = Doc
   langImport n = toCode $ text $ "import " ++ n
@@ -152,7 +146,7 @@ instance InternalBody PythonCode where
 
 instance BlockSym PythonCode where
   type Block PythonCode = Doc
-  block = G.block endStatement
+  block = G.block
 
 instance InternalBlock PythonCode where
   blockDoc = unPC
@@ -531,7 +525,7 @@ instance StatementSym PythonCode where
   selfInOutCall = pyInOutCall selfFuncApp
   extInOutCall m = pyInOutCall (extFuncApp m)
 
-  multi = onStateList (on1CodeValue1List multiStateDocD endStatement)
+  multi = onStateList (onCodeList multiStateDocD)
 
 instance ControlStatement PythonCode where
   ifCond = G.ifCond pyBodyStart (text "elif") pyBodyEnd

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer/PythonRenderer.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer/PythonRenderer.hs
@@ -121,8 +121,6 @@ instance KeywordSym PythonCode where
   type Keyword PythonCode = Doc
   endStatement = toCode empty
 
-  commentStart = toCode $ text "#"
-
   keyDoc = unPC
 
 instance ImportSym PythonCode where
@@ -145,7 +143,7 @@ instance BodySym PythonCode where
   type Body PythonCode = Doc
   body = onStateList (onCodeList bodyDocD)
 
-  addComments s = onStateValue (on2CodeValues (addCommentsDocD s) commentStart)
+  addComments s = onStateValue (onCodeValue (addCommentsDocD s pyCommentStart))
 
 instance InternalBody PythonCode where
   bodyDoc = unPC
@@ -523,7 +521,7 @@ instance StatementSym PythonCode where
 
   valState = G.valState Empty
 
-  comment = G.comment commentStart
+  comment = G.comment pyCommentStart
 
   free v = v &= valueOf (var "None" void)
 
@@ -680,9 +678,9 @@ instance InternalMod PythonCode where
 
 instance BlockCommentSym PythonCode where
   type BlockComment PythonCode = Doc
-  blockComment lns = onCodeValue (pyBlockComment lns) commentStart
-  docComment = onStateValue (\lns -> onCodeValue (pyDocComment lns (text "##")) 
-    commentStart)
+  blockComment lns = toCode $ pyBlockComment lns pyCommentStart
+  docComment = onStateValue (\lns -> toCode $ pyDocComment lns (text "##") 
+    pyCommentStart)
 
   blockCommentDoc = unPC
 
@@ -693,9 +691,10 @@ initName = "__init__"
 pyName :: String
 pyName = "Python"
 
-pyBodyStart, pyBodyEnd :: Doc
+pyBodyStart, pyBodyEnd, pyCommentStart :: Doc
 pyBodyStart = colon
 pyBodyEnd = empty
+pyCommentStart = text "#"
 
 pyODEMethod :: ODEMethod -> [SValue PythonCode]
 pyODEMethod RK45 = [litString "dopri5"]

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer/PythonRenderer.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer/PythonRenderer.hs
@@ -121,15 +121,11 @@ instance KeywordSym PythonCode where
   type Keyword PythonCode = Doc
   endStatement = toCode empty
 
-  inherit n = toCode $ parens (text n)
-  implements is = toCode $ parens (text $ intercalate ", " is)
-
   blockStart = toCode colon
   blockEnd = toCode empty
 
   commentStart = toCode $ text "#"
 
-  keyFromDoc = toCode
   keyDoc = unPC
 
 instance ImportSym PythonCode where
@@ -659,9 +655,14 @@ instance ClassSym PythonCode where
 
 instance InternalClass PythonCode where
   intClass = G.intClass pyClass
+
+  inherit n = toCode $ maybe empty (parens . text) n
+  implements is = toCode $ parens (text $ intercalate ", " is)
+
   commentedClass = G.commentedClass
+
   classDoc = unPC
-  classFromData = onStateValue toCode
+  classFromData d = d
 
 instance ModuleSym PythonCode where
   type Module PythonCode = ModData

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer/PythonRenderer.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer/PythonRenderer.hs
@@ -121,9 +121,6 @@ instance KeywordSym PythonCode where
   type Keyword PythonCode = Doc
   endStatement = toCode empty
 
-  blockStart = toCode colon
-  blockEnd = toCode empty
-
   commentStart = toCode $ text "#"
 
   keyDoc = unPC
@@ -539,7 +536,7 @@ instance StatementSym PythonCode where
   multi = onStateList (on1CodeValue1List multiStateDocD endStatement)
 
 instance ControlStatement PythonCode where
-  ifCond = G.ifCond blockStart (text "elif") blockEnd
+  ifCond = G.ifCond pyBodyStart (text "elif") pyBodyEnd
   switch = switchAsIf
 
   ifExists = G.ifExists
@@ -695,6 +692,10 @@ initName = "__init__"
 
 pyName :: String
 pyName = "Python"
+
+pyBodyStart, pyBodyEnd :: Doc
+pyBodyStart = colon
+pyBodyEnd = empty
 
 pyODEMethod :: ODEMethod -> [SValue PythonCode]
 pyODEMethod RK45 = [litString "dopri5"]

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer/PythonRenderer.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer/PythonRenderer.hs
@@ -125,8 +125,6 @@ instance KeywordSym PythonCode where
   inherit n = toCode $ parens (text n)
   implements is = toCode $ parens (text $ intercalate ", " is)
 
-  list = toCode empty
-
   blockStart = toCode colon
   blockEnd = toCode empty
 

--- a/code/drasil-gool/GOOL/Drasil/RendererClasses.hs
+++ b/code/drasil-gool/GOOL/Drasil/RendererClasses.hs
@@ -6,7 +6,8 @@ module GOOL.Drasil.RendererClasses (
   BinaryOpSym(..), InternalOp(..), InternalVariable(..), InternalValue(..),
   InternalFunction(..), InternalStatement(..), InternalScope(..), 
   MethodTypeSym(..), InternalParam(..), InternalMethod(..), 
-  InternalStateVar(..), InternalClass(..), InternalMod(..), BlockCommentSym(..)
+  InternalStateVar(..), ParentSpec, InternalClass(..), InternalMod(..), 
+  BlockCommentSym(..)
 ) where
 
 import GOOL.Drasil.ClassInterface (Label, Library, SFile, MSBody, MSBlock, 
@@ -41,15 +42,11 @@ class KeywordSym repr where
   type Keyword repr
   endStatement     :: repr (Keyword repr)
 
-  inherit :: Label -> repr (Keyword repr)
-  implements :: [Label] -> repr (Keyword repr)
-
   blockStart :: repr (Keyword repr)
   blockEnd   :: repr (Keyword repr)
 
   commentStart :: repr (Keyword repr)
 
-  keyFromDoc :: Doc -> repr (Keyword repr)
   keyDoc :: repr (Keyword repr) -> Doc
 
 class ImportSym repr where
@@ -215,14 +212,19 @@ class InternalStateVar repr where
   stateVarDoc :: repr (StateVar repr) -> Doc
   stateVarFromData :: CS Doc -> CSStateVar repr
 
+type ParentSpec = Doc
+
 class (BlockCommentSym repr) => InternalClass repr where
-  intClass :: Label -> repr (Scope repr) -> repr (Keyword repr) ->
-    [CSStateVar repr] -> [SMethod repr] -> SClass repr
+  intClass :: Label -> repr (Scope repr) -> repr ParentSpec -> [CSStateVar repr]
+    -> [SMethod repr] -> SClass repr
+    
+  inherit :: Maybe Label -> repr ParentSpec
+  implements :: [Label] -> repr ParentSpec
 
   commentedClass :: CS (repr (BlockComment repr)) -> SClass repr -> SClass repr
 
   classDoc :: repr (Class repr) -> Doc
-  classFromData :: CS Doc -> SClass repr
+  classFromData :: CS (repr Doc) -> SClass repr
 
 class InternalMod repr where
   moduleDoc :: repr (Module repr) -> Doc

--- a/code/drasil-gool/GOOL/Drasil/RendererClasses.hs
+++ b/code/drasil-gool/GOOL/Drasil/RendererClasses.hs
@@ -45,8 +45,6 @@ class KeywordSym repr where
   inherit :: Label -> repr (Keyword repr)
   implements :: [Label] -> repr (Keyword repr)
 
-  list     :: repr (Keyword repr)
-
   blockStart :: repr (Keyword repr)
   blockEnd   :: repr (Keyword repr)
 

--- a/code/drasil-gool/GOOL/Drasil/RendererClasses.hs
+++ b/code/drasil-gool/GOOL/Drasil/RendererClasses.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE TypeFamilies #-}
 
 module GOOL.Drasil.RendererClasses (
-  RenderSym, InternalFile(..), KeywordSym(..), ImportSym(..), InternalPerm(..),
+  RenderSym, InternalFile(..), ImportSym(..), InternalPerm(..), 
   InternalBody(..), InternalBlock(..), InternalType(..), UnaryOpSym(..), 
   BinaryOpSym(..), InternalOp(..), InternalVariable(..), InternalValue(..),
   InternalFunction(..), InternalStatement(..), InternalScope(..), 
@@ -27,7 +27,7 @@ class (FileSym repr, InternalBlock repr, InternalBody repr, InternalClass repr,
   InternalFile repr, InternalFunction repr, InternalMethod repr, 
   InternalMod repr, InternalOp repr, InternalParam repr, InternalPerm repr, 
   InternalScope repr, InternalStatement repr, InternalStateVar repr, 
-  InternalType repr, InternalValue repr, InternalVariable repr, KeywordSym repr,
+  InternalType repr, InternalValue repr, InternalVariable repr,
   ImportSym repr, UnaryOpSym repr, BinaryOpSym repr) => RenderSym repr
 
 class (BlockCommentSym repr) => InternalFile repr where
@@ -37,12 +37,6 @@ class (BlockCommentSym repr) => InternalFile repr where
   commentedMod :: FS (repr (BlockComment repr)) -> SFile repr -> SFile repr
 
   fileFromData :: FS FilePath -> FSModule repr -> SFile repr
-
-class KeywordSym repr where
-  type Keyword repr
-  endStatement     :: repr (Keyword repr)
-
-  keyDoc :: repr (Keyword repr) -> Doc
 
 class ImportSym repr where
   type Import repr

--- a/code/drasil-gool/GOOL/Drasil/RendererClasses.hs
+++ b/code/drasil-gool/GOOL/Drasil/RendererClasses.hs
@@ -42,9 +42,6 @@ class KeywordSym repr where
   type Keyword repr
   endStatement     :: repr (Keyword repr)
 
-  blockStart :: repr (Keyword repr)
-  blockEnd   :: repr (Keyword repr)
-
   commentStart :: repr (Keyword repr)
 
   keyDoc :: repr (Keyword repr) -> Doc

--- a/code/drasil-gool/GOOL/Drasil/RendererClasses.hs
+++ b/code/drasil-gool/GOOL/Drasil/RendererClasses.hs
@@ -42,8 +42,6 @@ class KeywordSym repr where
   type Keyword repr
   endStatement     :: repr (Keyword repr)
 
-  commentStart :: repr (Keyword repr)
-
   keyDoc :: repr (Keyword repr) -> Doc
 
 class ImportSym repr where

--- a/code/drasil-gool/GOOL/Drasil/RendererClasses.hs
+++ b/code/drasil-gool/GOOL/Drasil/RendererClasses.hs
@@ -40,7 +40,6 @@ class (BlockCommentSym repr) => InternalFile repr where
 class KeywordSym repr where
   type Keyword repr
   endStatement     :: repr (Keyword repr)
-  endStatementLoop :: repr (Keyword repr)
 
   inherit :: Label -> repr (Keyword repr)
   implements :: [Label] -> repr (Keyword repr)
@@ -48,17 +47,7 @@ class KeywordSym repr where
   blockStart :: repr (Keyword repr)
   blockEnd   :: repr (Keyword repr)
 
-  ifBodyStart :: repr (Keyword repr)
-  elseIf      :: repr (Keyword repr)
-
-  iterForEachLabel :: repr (Keyword repr)
-  iterInLabel      :: repr (Keyword repr)
-
-  commentStart      :: repr (Keyword repr)
-  blockCommentStart :: repr (Keyword repr)
-  blockCommentEnd   :: repr (Keyword repr)
-  docCommentStart   :: repr (Keyword repr)
-  docCommentEnd     :: repr (Keyword repr)
+  commentStart :: repr (Keyword repr)
 
   keyFromDoc :: Doc -> repr (Keyword repr)
   keyDoc :: repr (Keyword repr) -> Doc


### PR DESCRIPTION
Closes #1942.

This PR removes the `KeywordSym` type class mostly by removing the methods it contained. A lot of the methods were only used once or not at all, so they made sense to remove. Others (like `endStatement`, for instance) were used many times but were so simple (just a concrete `Doc`) that putting them in a type class and having to wrap them in a `repr` made the code far more complicated than it needed to be, so I removed those too, and instead defined them as regular functions in `LanguageRenderer.hs`. Only the `implements` and `inherit` methods still made sense to keep, so I moved those to the `InternalClass` type class.
