### PR TITLE
Remove some constraints from GOOL class hierarchy

### DIFF
--- a/code/drasil-gool/Test/Observer.hs
+++ b/code/drasil-gool/Test/Observer.hs
@@ -21,13 +21,13 @@ x = var "x" int
 selfX :: (VariableSym repr) => SVariable repr
 selfX = objVarSelf x
 
-helperClass :: (ClassSym repr) => SClass repr
+helperClass :: (ClassSym repr, IOStatement repr) => SClass repr
 helperClass = buildClass observerName Nothing [stateVar public dynamic x]
   [observerConstructor, printNumMethod, getMethod x, setMethod x]
 
 observerConstructor :: (MethodSym repr) => SMethod repr
 observerConstructor = initializer [] [(x, litInt 5)]
 
-printNumMethod :: (MethodSym repr) => SMethod repr
+printNumMethod :: (MethodSym repr, IOStatement repr) => SMethod repr
 printNumMethod = method printNum public dynamic void [] $
   oneLiner $ printLn $ valueOf selfX

--- a/code/drasil-gool/Test/PatternTest.hs
+++ b/code/drasil-gool/Test/PatternTest.hs
@@ -2,10 +2,10 @@ module Test.PatternTest (patternTest) where
 
 import GOOL.Drasil (GSProgram, VSType, SVariable, SValue, SMethod, 
   ProgramSym(..), FileSym(..), BodySym(..), oneLiner, BlockSym(..), 
-  ControlBlock(..), TypeSym(..), DeclStatement(..), IOStatement(..), 
-  MiscStatement(..), initState, changeState, initObserverList, addObserver, 
-  ControlStatement(..), VariableSym(..), ValueSym(..), ValueExpression(..), 
-  extNewObj, FunctionSym(..), MethodSym(..), ModuleSym(..))
+  ControlBlock(..), TypeSym(..), AssignStatement, DeclStatement(..), 
+  IOStatement(..), MiscStatement(..), initState, changeState, initObserverList, 
+  addObserver, ControlStatement(..), VariableSym(..), ValueSym(..), 
+  ValueExpression(..), extNewObj, FunctionSym(..), MethodSym(..), ModuleSym(..))
 import Prelude hiding (return,print,log,exp,sin,cos,tan)
 import Test.Observer (observer, observerName, printNum, x)
 
@@ -37,7 +37,9 @@ patternTest :: (ProgramSym repr) => GSProgram repr
 patternTest = prog progName [fileDoc (buildModule progName []
   [patternTestMainMethod] []), observer]
 
-patternTestMainMethod :: (MethodSym repr) => SMethod repr
+patternTestMainMethod :: (MethodSym repr, AssignStatement repr, 
+  DeclStatement repr, ControlStatement repr, IOStatement repr, 
+  MiscStatement repr, ControlBlock repr) => SMethod repr
 patternTestMainMethod = mainFunction (body [block [
   varDec n,
   initState fsmName offState, 

--- a/code/drasil-gool/Test/SimpleODE.hs
+++ b/code/drasil-gool/Test/SimpleODE.hs
@@ -1,7 +1,7 @@
 module Test.SimpleODE (simpleODE) where
 
 import GOOL.Drasil (GSProgram, SVariable, SMethod, ProgramSym(..), FileSym(..), BodySym(..), BlockSym(..), 
-  TypeSym(..), ControlBlock(..), DeclStatement(..), StatementSym(..), IOStatement(..), VariableSym(..), 
+  TypeSym(..), ControlBlock(..), DeclStatement(..), IOStatement(..), VariableSym(..), 
   ValueSym(..), NumericExpression(..), MethodSym(..), ModuleSym(..), ODEInfo, 
   odeInfo, ODEOptions, odeOptions, ODEMethod(RK45))
 import Prelude hiding (return,print,log,exp,sin,cos,tan)
@@ -10,19 +10,19 @@ simpleODE :: (ProgramSym repr) => GSProgram repr
 simpleODE = prog "SimpleODE" [fileDoc (buildModule "SimpleODE" []
   [simpleODEMain] [])]
 
-simpleODEMain :: (MethodSym repr) => SMethod repr
+simpleODEMain :: (ProgramSym repr) => SMethod repr
 simpleODEMain = mainFunction (body [block [varDecDef odeConst (litDouble 3.5)],
   solveODE info opts,
   block [print $ valueOf odeDepVar]])
 
-odeConst, odeDepVar, odeIndepVar :: (VariableSym repr) => SVariable repr
+odeConst, odeDepVar, odeIndepVar :: (ProgramSym repr) => SVariable repr
 odeConst = var "c" double
 odeDepVar = var "T" (listType double)
 odeIndepVar = var "t" (listType double)
 
-info :: (StatementSym repr) => ODEInfo repr
+info :: (ProgramSym repr) => ODEInfo repr
 info = odeInfo odeIndepVar odeDepVar [odeConst] (litDouble 0.0) (litDouble 10.0) 
   (litDouble 1.0) (valueOf odeDepVar #+ valueOf odeConst)
 
-opts :: (StatementSym repr) => ODEOptions repr
+opts :: (ProgramSym repr) => ODEOptions repr
 opts = odeOptions RK45 (litDouble 0.001) (litDouble 0.001) (litDouble 1.0)


### PR DESCRIPTION
@JacquesCarette I've taken a  half-measure here because I have questions.

Removing constraints from the GOOL class hierarchy like we talked about in today's code review meeting will have the consequence of needing to specify more constraints where the methods are used. For example, if `AssignStatement` is no longer a constraint in the GOOL class hierarchy, it would mean that throughout Drasil's generator, we would have to add the `AssignStatement repr` constraint to any function that does an assignment. Currently the only constraint we need is `ProgramSym repr`, which is essentially a catch-all constraint, but with this change the generator would become cluttered with constraints.

So the half-measure I've taken is to remove unnecessary constraints in the hierarchy, but then add them all as constraints on the `FileSym` class, so `ProgramSym repr` and `RenderSym repr` can still act as catch-all constraints.

I doubt that is what we actually want. A perhaps better option would be to define, in Drasil rather than in GOOL, a new type class, say `DrasilProg`, which will be constrained by all of the GOOL type classes (and have no methods of its own), and then `DrasilProg` can be used in the generator as a catch-all constraint. Does that sound okay? Or do you disagree with the idea of a catch-all constraint altogether?