### PR TITLE
Abbreviations throughout GOOL

### DIFF
--- a/code/drasil-code/Language/Drasil/Code/Imperative/ConceptMatch.hs
+++ b/code/drasil-code/Language/Drasil/Code/Imperative/ConceptMatch.hs
@@ -17,6 +17,6 @@ chooseConcept chs = Map.map (chooseConcept' chs) (conceptMatch chs)
           "ConceptMatchMap"
         chooseConcept' _ cs = head cs
 
-conceptToGOOL :: (ProgramSym repr) => CodeConcept -> SValue repr
+conceptToGOOL :: (ProgramSym r) => CodeConcept -> SValue r
 conceptToGOOL Pi = pi
 

--- a/code/drasil-code/Language/Drasil/Code/Imperative/FunctionCalls.hs
+++ b/code/drasil-code/Language/Drasil/Code/Imperative/FunctionCalls.hs
@@ -24,29 +24,29 @@ import Data.Maybe (catMaybes)
 import Control.Applicative ((<|>))
 import Control.Monad.Reader (Reader, ask)
 
-getAllInputCalls :: (ProgramSym repr) => Reader DrasilState [MSStatement repr]
+getAllInputCalls :: (ProgramSym r) => Reader DrasilState [MSStatement r]
 getAllInputCalls = do
   gi <- getInputCall
   dv <- getDerivedCall
   ic <- getConstraintCall
   return $ catMaybes [gi, dv, ic]
 
-getInputCall :: (ProgramSym repr) => Reader DrasilState 
-  (Maybe (MSStatement repr))
+getInputCall :: (ProgramSym r) => Reader DrasilState 
+  (Maybe (MSStatement r))
 getInputCall = getInOutCall "get_input" getInputFormatIns getInputFormatOuts
 
-getDerivedCall :: (ProgramSym repr) => Reader DrasilState 
-  (Maybe (MSStatement repr))
+getDerivedCall :: (ProgramSym r) => Reader DrasilState 
+  (Maybe (MSStatement r))
 getDerivedCall = getInOutCall "derived_values" getDerivedIns getDerivedOuts
 
-getConstraintCall :: (ProgramSym repr) => Reader DrasilState 
-  (Maybe (MSStatement repr))
+getConstraintCall :: (ProgramSym r) => Reader DrasilState 
+  (Maybe (MSStatement r))
 getConstraintCall = do
   val <- getFuncCall "input_constraints" void getConstraintParams
   return $ fmap valState val
 
-getCalcCall :: (ProgramSym repr) => CodeDefinition -> Reader DrasilState 
-  (Maybe (MSStatement repr))
+getCalcCall :: (ProgramSym r) => CodeDefinition -> Reader DrasilState 
+  (Maybe (MSStatement r))
 getCalcCall c = do
   t <- codeType c
   val <- getFuncCall (codeName c) (convType t) (getCalcParams c)
@@ -54,15 +54,15 @@ getCalcCall c = do
   l <- maybeLog v
   return $ fmap (multi . (: l) . varDecDef v) val
 
-getOutputCall :: (ProgramSym repr) => Reader DrasilState 
-  (Maybe (MSStatement repr))
+getOutputCall :: (ProgramSym r) => Reader DrasilState 
+  (Maybe (MSStatement r))
 getOutputCall = do
   val <- getFuncCall "write_output" void getOutputParams
   return $ fmap valState val
 
-getFuncCall :: (ProgramSym repr, HasUID c, HasSpace c, CodeIdea c) => String 
-  -> VSType repr -> Reader DrasilState [c] -> 
-  Reader DrasilState (Maybe (SValue repr))
+getFuncCall :: (ProgramSym r, HasUID c, HasSpace c, CodeIdea c) => String 
+  -> VSType r -> Reader DrasilState [c] -> 
+  Reader DrasilState (Maybe (SValue r))
 getFuncCall n t funcPs = do
   mm <- getCall n
   let getFuncCall' Nothing = return Nothing
@@ -73,9 +73,9 @@ getFuncCall n t funcPs = do
         return $ Just val
   getFuncCall' mm
 
-getInOutCall :: (ProgramSym repr, HasSpace c, CodeIdea c, Eq c) => String -> 
+getInOutCall :: (ProgramSym r, HasSpace c, CodeIdea c, Eq c) => String -> 
   Reader DrasilState [c] -> Reader DrasilState [c] ->
-  Reader DrasilState (Maybe (MSStatement repr))
+  Reader DrasilState (Maybe (MSStatement r))
 getInOutCall n inFunc outFunc = do
   mm <- getCall n
   let getInOutCall' Nothing = return Nothing

--- a/code/drasil-code/Language/Drasil/Code/Imperative/GOOL/ClassInterface.hs
+++ b/code/drasil-code/Language/Drasil/Code/Imperative/GOOL/ClassInterface.hs
@@ -14,21 +14,21 @@ import GOOL.Drasil (ProgData, GOOLState)
 
 import Text.PrettyPrint.HughesPJ (Doc)
 
-class (AuxiliarySym repr) => PackageSym repr where
-  type Package repr 
-  package :: ProgData -> [repr (Auxiliary repr)] -> 
-    repr (Package repr)
+class (AuxiliarySym r) => PackageSym r where
+  type Package r 
+  package :: ProgData -> [r (Auxiliary r)] -> 
+    r (Package r)
 
-class AuxiliarySym repr where
-  type Auxiliary repr
-  type AuxHelper repr
-  doxConfig :: String -> GOOLState -> Verbosity -> repr (Auxiliary repr)
-  sampleInput :: ChunkDB -> DataDesc -> [Expr] -> repr (Auxiliary repr)
+class AuxiliarySym r where
+  type Auxiliary r
+  type AuxHelper r
+  doxConfig :: String -> GOOLState -> Verbosity -> r (Auxiliary r)
+  sampleInput :: ChunkDB -> DataDesc -> [Expr] -> r (Auxiliary r)
 
-  optimizeDox :: repr (AuxHelper repr)
+  optimizeDox :: r (AuxHelper r)
 
   makefile :: ImplementationType -> [Comments] -> GOOLState -> ProgData -> 
-    repr (Auxiliary repr)
+    r (Auxiliary r)
 
-  auxHelperDoc :: repr (AuxHelper repr) -> Doc
-  auxFromData :: FilePath -> Doc -> repr (Auxiliary repr)
+  auxHelperDoc :: r (AuxHelper r) -> Doc
+  auxFromData :: FilePath -> Doc -> r (Auxiliary r)

--- a/code/drasil-code/Language/Drasil/Code/Imperative/GOOL/LanguageRenderer/LanguagePolymorphic.hs
+++ b/code/drasil-code/Language/Drasil/Code/Imperative/GOOL/LanguageRenderer/LanguagePolymorphic.hs
@@ -20,17 +20,17 @@ import Language.Drasil.Code.Imperative.GOOL.LanguageRenderer (doxConfigName,
 import Language.Drasil.Code.Imperative.GOOL.ClassInterface (
   AuxiliarySym(Auxiliary, AuxHelper, auxHelperDoc, auxFromData))
 
-doxConfig :: (AuxiliarySym repr) => repr (AuxHelper repr) -> String -> 
-  GOOLState -> Verbosity -> repr (Auxiliary repr)
+doxConfig :: (AuxiliarySym r) => r (AuxHelper r) -> String -> 
+  GOOLState -> Verbosity -> r (Auxiliary r)
 doxConfig opt pName s v = auxFromData doxConfigName (makeDoxConfig pName s 
   (auxHelperDoc opt) v)
 
-sampleInput :: (AuxiliarySym repr) => ChunkDB -> DataDesc -> [Expr] -> 
-  repr (Auxiliary repr)
+sampleInput :: (AuxiliarySym r) => ChunkDB -> DataDesc -> [Expr] -> 
+  r (Auxiliary r)
 sampleInput db d sd = auxFromData sampleInputName (makeInputFile db d sd)
 
-makefile :: (AuxiliarySym repr) => Maybe BuildConfig -> Maybe Runnable -> 
-  [Comments] -> GOOLState -> ProgData -> repr (Auxiliary repr)
+makefile :: (AuxiliarySym r) => Maybe BuildConfig -> Maybe Runnable -> 
+  [Comments] -> GOOLState -> ProgData -> r (Auxiliary r)
 makefile bc r cms s p = auxFromData makefileName (makeBuild cms bc r s p)
 
 noRunIfLib :: ImplementationType -> Maybe Runnable -> Maybe Runnable

--- a/code/drasil-code/Language/Drasil/Code/Imperative/GenerateGOOL.hs
+++ b/code/drasil-code/Language/Drasil/Code/Imperative/GenerateGOOL.hs
@@ -10,7 +10,7 @@ import Language.Drasil.CodeSpec (CodeSpec(..), CodeSystInfo(..), Comments(..))
 import Language.Drasil.Mod (Name)
   
 import GOOL.Drasil (Label, SFile, VSType, SVariable, SValue, MSStatement, 
-  MSParameter, SMethod, CSStateVar, SClass, ProgramSym, FileSym(..), 
+  MSParameter, SMethod, CSStateVar, SClass, NamedArg, ProgramSym, FileSym(..), 
   TypeSym(..), VariableSym(..), ValueExpression(..), FuncAppStatement(..), 
   ParameterSym(..), ClassSym(..), ModuleSym(..), CodeType(..), GOOLState, 
   lensMStoVS)
@@ -84,7 +84,7 @@ auxClass = mkClass Auxiliary
 --   calling a method on self. This assumes all private methods are dynamic, 
 --   which is true for this generator.
 fApp :: (ProgramSym repr) => String -> String -> VSType repr -> [SValue repr] 
-  -> [(SVariable repr, SValue repr)] -> Reader DrasilState (SValue repr)
+  -> [NamedArg repr] -> Reader DrasilState (SValue repr)
 fApp m s t vl ns = do
   g <- ask
   let cm = currentModule g
@@ -95,7 +95,7 @@ fApp m s t vl ns = do
 -- Logic similar to fApp above, but self case not required here 
 -- (because constructor will never be private)
 ctorCall :: (ProgramSym repr) => String -> VSType repr -> [SValue repr] -> 
-  [(SVariable repr, SValue repr)] -> Reader DrasilState (SValue repr)
+  [NamedArg repr] -> Reader DrasilState (SValue repr)
 ctorCall m t vl ns = do
   g <- ask
   let cm = currentModule g

--- a/code/drasil-code/Language/Drasil/Code/Imperative/GenerateGOOL.hs
+++ b/code/drasil-code/Language/Drasil/Code/Imperative/GenerateGOOL.hs
@@ -20,9 +20,9 @@ import qualified Data.Map as Map (lookup)
 import Data.Maybe (catMaybes)
 import Control.Monad.Reader (Reader, ask, withReader)
 
-genModuleWithImports :: (ProgramSym repr) => Name -> String -> [String] -> 
-  [Reader DrasilState (Maybe (SMethod repr))] -> 
-  [Reader DrasilState (Maybe (SClass repr))] -> Reader DrasilState (SFile repr)
+genModuleWithImports :: (ProgramSym r) => Name -> String -> [String] -> 
+  [Reader DrasilState (Maybe (SMethod r))] -> 
+  [Reader DrasilState (Maybe (SClass r))] -> Reader DrasilState (SFile r)
 genModuleWithImports n desc is maybeMs maybeCs = do
   g <- ask
   let updateState = withReader (\s -> s { currentModule = n })
@@ -37,13 +37,13 @@ genModuleWithImports n desc is maybeMs maybeCs = do
               | otherwise                                       = id
   return $ commMod $ fileDoc $ buildModule n is (catMaybes ms) (catMaybes cs)
 
-genModule :: (ProgramSym repr) => Name -> String -> 
-  [Reader DrasilState (Maybe (SMethod repr))] -> 
-  [Reader DrasilState (Maybe (SClass repr))] -> Reader DrasilState (SFile repr)
+genModule :: (ProgramSym r) => Name -> String -> 
+  [Reader DrasilState (Maybe (SMethod r))] -> 
+  [Reader DrasilState (Maybe (SClass r))] -> Reader DrasilState (SFile r)
 genModule n desc = genModuleWithImports n desc []
 
-genDoxConfig :: (AuxiliarySym repr) => String -> GOOLState ->
-  Reader DrasilState [repr (Auxiliary repr)]
+genDoxConfig :: (AuxiliarySym r) => String -> GOOLState ->
+  Reader DrasilState [r (Auxiliary r)]
 genDoxConfig n s = do
   g <- ask
   let cms = commented g
@@ -52,9 +52,9 @@ genDoxConfig n s = do
 
 data ClassType = Primary | Auxiliary
 
-mkClass :: (ProgramSym repr) => ClassType -> String -> Label -> Maybe Label -> 
-  [CSStateVar repr] -> Reader DrasilState [SMethod repr] -> 
-  Reader DrasilState (SClass repr)
+mkClass :: (ProgramSym r) => ClassType -> String -> Label -> Maybe Label -> 
+  [CSStateVar r] -> Reader DrasilState [SMethod r] -> 
+  Reader DrasilState (SClass r)
 mkClass s desc n l vs mths = do
   g <- ask
   ms <- mths
@@ -65,14 +65,14 @@ mkClass s desc n l vs mths = do
     then docClass desc (f n l vs ms) 
     else f n l vs ms
 
-primaryClass :: (ProgramSym repr) => String -> Label -> Maybe Label -> 
-  [CSStateVar repr] -> Reader DrasilState [SMethod repr] -> 
-  Reader DrasilState (SClass repr)
+primaryClass :: (ProgramSym r) => String -> Label -> Maybe Label -> 
+  [CSStateVar r] -> Reader DrasilState [SMethod r] -> 
+  Reader DrasilState (SClass r)
 primaryClass = mkClass Primary
 
-auxClass :: (ProgramSym repr) => String -> Label -> Maybe Label -> 
-  [CSStateVar repr] -> Reader DrasilState [SMethod repr] -> 
-  Reader DrasilState (SClass repr)
+auxClass :: (ProgramSym r) => String -> Label -> Maybe Label -> 
+  [CSStateVar r] -> Reader DrasilState [SMethod r] -> 
+  Reader DrasilState (SClass r)
 auxClass = mkClass Auxiliary
 
 -- m parameter is the module where the function is defined
@@ -83,8 +83,8 @@ auxClass = mkClass Auxiliary
 -- if m is current module and function is not exported, use GOOL's function for 
 --   calling a method on self. This assumes all private methods are dynamic, 
 --   which is true for this generator.
-fApp :: (ProgramSym repr) => String -> String -> VSType repr -> [SValue repr] 
-  -> [NamedArg repr] -> Reader DrasilState (SValue repr)
+fApp :: (ProgramSym r) => String -> String -> VSType r -> [SValue r] 
+  -> [NamedArg r] -> Reader DrasilState (SValue r)
 fApp m s t vl ns = do
   g <- ask
   let cm = currentModule g
@@ -94,8 +94,8 @@ fApp m s t vl ns = do
 
 -- Logic similar to fApp above, but self case not required here 
 -- (because constructor will never be private)
-ctorCall :: (ProgramSym repr) => String -> VSType repr -> [SValue repr] -> 
-  [NamedArg repr] -> Reader DrasilState (SValue repr)
+ctorCall :: (ProgramSym r) => String -> VSType r -> [SValue r] -> 
+  [NamedArg r] -> Reader DrasilState (SValue r)
 ctorCall m t vl ns = do
   g <- ask
   let cm = currentModule g
@@ -103,8 +103,8 @@ ctorCall m t vl ns = do
     newObjMixedArgs t vl ns
 
 -- Logic similar to fApp above
-fAppInOut :: (ProgramSym repr) => String -> String -> [SValue repr] -> 
-  [SVariable repr] -> [SVariable repr] -> Reader DrasilState (MSStatement repr)
+fAppInOut :: (ProgramSym r) => String -> String -> [SValue r] -> 
+  [SVariable r] -> [SVariable r] -> Reader DrasilState (MSStatement r)
 fAppInOut m n ins outs both = do
   g <- ask
   let cm = currentModule g
@@ -112,7 +112,7 @@ fAppInOut m n ins outs both = do
     (eMap $ codeSpec g) == Just cm then inOutCall n ins outs both else 
     selfInOutCall n ins outs both
 
-mkParam :: (ProgramSym repr) => SVariable repr -> MSParameter repr
+mkParam :: (ProgramSym r) => SVariable r -> MSParameter r
 mkParam v = zoom lensMStoVS v >>= (\v' -> paramFunc (getType $ variableType v') 
   v)
   where paramFunc (List _) = pointerParam

--- a/code/drasil-code/Language/Drasil/Code/Imperative/GenerateGOOL.hs
+++ b/code/drasil-code/Language/Drasil/Code/Imperative/GenerateGOOL.hs
@@ -10,7 +10,7 @@ import Language.Drasil.CodeSpec (CodeSpec(..), CodeSystInfo(..), Comments(..))
 import Language.Drasil.Mod (Name)
   
 import GOOL.Drasil (Label, SFile, VSType, SVariable, SValue, MSStatement, 
-  MSParameter, SMethod, CSStateVar, SClass, NamedArg, ProgramSym, FileSym(..), 
+  MSParameter, SMethod, CSStateVar, SClass, NamedArgs, ProgramSym, FileSym(..), 
   TypeSym(..), VariableSym(..), ValueExpression(..), FuncAppStatement(..), 
   ParameterSym(..), ClassSym(..), ModuleSym(..), CodeType(..), GOOLState, 
   lensMStoVS)
@@ -84,7 +84,7 @@ auxClass = mkClass Auxiliary
 --   calling a method on self. This assumes all private methods are dynamic, 
 --   which is true for this generator.
 fApp :: (ProgramSym r) => String -> String -> VSType r -> [SValue r] 
-  -> [NamedArg r] -> Reader DrasilState (SValue r)
+  -> NamedArgs r -> Reader DrasilState (SValue r)
 fApp m s t vl ns = do
   g <- ask
   let cm = currentModule g
@@ -95,7 +95,7 @@ fApp m s t vl ns = do
 -- Logic similar to fApp above, but self case not required here 
 -- (because constructor will never be private)
 ctorCall :: (ProgramSym r) => String -> VSType r -> [SValue r] -> 
-  [NamedArg r] -> Reader DrasilState (SValue r)
+  NamedArgs r -> Reader DrasilState (SValue r)
 ctorCall m t vl ns = do
   g <- ask
   let cm = currentModule g

--- a/code/drasil-code/Language/Drasil/Code/Imperative/Generator.hs
+++ b/code/drasil-code/Language/Drasil/Code/Imperative/Generator.hs
@@ -89,19 +89,19 @@ genPackage unRepr = do
   d <- genDoxConfig n s
   return $ package pd (m:i++d)
 
-genProgram :: (ProgramSym repr) => Reader DrasilState (GSProgram repr)
+genProgram :: (ProgramSym r) => Reader DrasilState (GSProgram r)
 genProgram = do
   g <- ask
   ms <- chooseModules $ modular g
   let n = pName $ csi $ codeSpec g
   return $ prog n ms
 
-chooseModules :: (ProgramSym repr) => Modularity -> 
-  Reader DrasilState [SFile repr]
+chooseModules :: (ProgramSym r) => Modularity -> 
+  Reader DrasilState [SFile r]
 chooseModules Unmodular = liftS genUnmodular
 chooseModules (Modular _) = genModules
 
-genUnmodular :: (ProgramSym repr) => Reader DrasilState (SFile repr)
+genUnmodular :: (ProgramSym r) => Reader DrasilState (SFile r)
 genUnmodular = do
   g <- ask
   let s = csi $ codeSpec g
@@ -120,7 +120,7 @@ genUnmodular = do
     ([genInputClass Auxiliary, genConstClass Auxiliary] 
     ++ map (fmap Just) (concatMap genModClasses $ mods s))
           
-genModules :: (ProgramSym repr) => Reader DrasilState [SFile repr]
+genModules :: (ProgramSym r) => Reader DrasilState [SFile r]
 genModules = do
   g <- ask
   let s = csi $ codeSpec g

--- a/code/drasil-code/Language/Drasil/Code/Imperative/Import.hs
+++ b/code/drasil-code/Language/Drasil/Code/Imperative/Import.hs
@@ -28,7 +28,7 @@ import Language.Drasil.Mod (Func(..), FuncData(..), FuncDef(..), FuncStmt(..),
 import qualified Language.Drasil.Mod as M (Class(..))
 
 import GOOL.Drasil (Label, SFile, MSBody, MSBlock, VSType, SVariable, SValue, 
-  MSStatement, MSParameter, SMethod, CSStateVar, SClass, ProgramSym, 
+  MSStatement, MSParameter, SMethod, CSStateVar, SClass, NamedArg, Initializer, ProgramSym, 
   PermanenceSym(..), bodyStatements, BlockSym(..), TypeSym(..), VariableSym(..),
   ($->), ValueSym(..), Literal(..), VariableValue(..), NumericExpression(..), BooleanExpression(..), Comparison(..), 
   ValueExpression(..), objMethodCallMixedArgs, List(..), StatementSym(..),
@@ -148,7 +148,7 @@ genConstructor :: (ProgramSym repr, HasSpace c, CodeIdea c) => Label -> String
 genConstructor n desc p = genMethod nonInitConstructor n desc p Nothing
 
 genInitConstructor :: (ProgramSym repr, HasSpace c, CodeIdea c) => Label -> 
-  String -> [c] -> [(SVariable repr, SValue repr)] -> [MSBlock repr] -> 
+  String -> [c] -> [Initializer repr] -> [MSBlock repr] -> 
   Reader DrasilState (SMethod repr)
 genInitConstructor n desc p is = genMethod (`constructor` is) n desc p 
   Nothing
@@ -250,7 +250,7 @@ convExpr (RealI c ri)  = do
   convExpr $ renderRealInt (lookupC g c) ri
 
 convCall :: (ProgramSym repr) => UID -> [Expr] -> [(UID, Expr)] -> (String -> 
-  String -> VSType repr -> [SValue repr] -> [(SVariable repr, SValue repr)] -> 
+  String -> VSType repr -> [SValue repr] -> [NamedArg repr] -> 
   Reader DrasilState (SValue repr)) -> Reader DrasilState (SValue repr)
 convCall c x ns f = do
   g <- ask

--- a/code/drasil-code/Language/Drasil/Code/Imperative/Import.hs
+++ b/code/drasil-code/Language/Drasil/Code/Imperative/Import.hs
@@ -28,7 +28,7 @@ import Language.Drasil.Mod (Func(..), FuncData(..), FuncDef(..), FuncStmt(..),
 import qualified Language.Drasil.Mod as M (Class(..))
 
 import GOOL.Drasil (Label, SFile, MSBody, MSBlock, VSType, SVariable, SValue, 
-  MSStatement, MSParameter, SMethod, CSStateVar, SClass, NamedArgs, Initializer, ProgramSym, 
+  MSStatement, MSParameter, SMethod, CSStateVar, SClass, NamedArgs, Initializers, ProgramSym, 
   PermanenceSym(..), bodyStatements, BlockSym(..), TypeSym(..), VariableSym(..),
   ($->), ValueSym(..), Literal(..), VariableValue(..), NumericExpression(..), BooleanExpression(..), Comparison(..), 
   ValueExpression(..), objMethodCallMixedArgs, List(..), StatementSym(..),
@@ -148,7 +148,7 @@ genConstructor :: (ProgramSym r, HasSpace c, CodeIdea c) => Label -> String
 genConstructor n desc p = genMethod nonInitConstructor n desc p Nothing
 
 genInitConstructor :: (ProgramSym r, HasSpace c, CodeIdea c) => Label -> 
-  String -> [c] -> [Initializer r] -> [MSBlock r] -> 
+  String -> [c] -> Initializers r -> [MSBlock r] -> 
   Reader DrasilState (SMethod r)
 genInitConstructor n desc p is = genMethod (`constructor` is) n desc p 
   Nothing

--- a/code/drasil-code/Language/Drasil/Code/Imperative/Import.hs
+++ b/code/drasil-code/Language/Drasil/Code/Imperative/Import.hs
@@ -52,8 +52,8 @@ codeType c = do
   g <- ask
   return $ spaceMatches g (c ^. typ)
 
-value :: (ProgramSym repr) => UID -> String -> VSType repr -> 
-  Reader DrasilState (SValue repr)
+value :: (ProgramSym r) => UID -> String -> VSType r -> 
+  Reader DrasilState (SValue r)
 value u s t = do
   g <- ask
   let cs = codeSpec g
@@ -65,8 +65,8 @@ value u s t = do
     (convExpr . codeEquat) (Map.lookup u mm >>= maybeInline (conStruct g))) 
     (return . conceptToGOOL) (Map.lookup u cm)
 
-variable :: (ProgramSym repr) => String -> VSType repr -> 
-  Reader DrasilState (SVariable repr)
+variable :: (ProgramSym r) => String -> VSType r -> 
+  Reader DrasilState (SVariable r)
 variable s t = do
   g <- ask
   let cs = csi $ codeSpec g
@@ -78,8 +78,8 @@ variable s t = do
       then constVariable (conStruct g) (conRepr g) ((defFunc $ conRepr g) s t)
       else return $ var s t
   
-inputVariable :: (ProgramSym repr) => Structure -> ConstantRepr -> 
-  SVariable repr -> Reader DrasilState (SVariable repr)
+inputVariable :: (ProgramSym r) => Structure -> ConstantRepr -> 
+  SVariable r -> Reader DrasilState (SVariable r)
 inputVariable Unbundled _ v = return v
 inputVariable Bundled Var v = do
   g <- ask
@@ -90,8 +90,8 @@ inputVariable Bundled Const v = do
   ip <- mkVar (quantvar inParams)
   classVariable ip v
 
-constVariable :: (ProgramSym repr) => ConstantStructure -> ConstantRepr -> 
-  SVariable repr -> Reader DrasilState (SVariable repr)
+constVariable :: (ProgramSym r) => ConstantStructure -> ConstantRepr -> 
+  SVariable r -> Reader DrasilState (SVariable r)
 constVariable (Store Bundled) Var v = do
   cs <- mkVar (quantvar consts)
   return $ cs $-> v
@@ -103,8 +103,8 @@ constVariable WithInputs cr v = do
   inputVariable (inStruct g) cr v
 constVariable _ _ v = return v
 
-classVariable :: (ProgramSym repr) => SVariable repr -> SVariable repr -> 
-  Reader DrasilState (SVariable repr)
+classVariable :: (ProgramSym r) => SVariable r -> SVariable r -> 
+  Reader DrasilState (SVariable r)
 classVariable c v = do
   g <- ask
   let checkCurrent m = if currentModule g == m then classVar else extClassVar
@@ -112,50 +112,50 @@ classVariable c v = do
     " missing from export map") checkCurrent (Map.lookup (variableName v') 
     (eMap $ codeSpec g)) (onStateValue variableType c) v)
 
-mkVal :: (ProgramSym repr, HasUID c, HasSpace c, CodeIdea c) => c -> 
-  Reader DrasilState (SValue repr)
+mkVal :: (ProgramSym r, HasUID c, HasSpace c, CodeIdea c) => c -> 
+  Reader DrasilState (SValue r)
 mkVal v = do
   t <- codeType v
   value (v ^. uid) (codeName v) (convType t)
 
-mkVar :: (ProgramSym repr, HasSpace c, CodeIdea c) => c -> 
-  Reader DrasilState (SVariable repr)
+mkVar :: (ProgramSym r, HasSpace c, CodeIdea c) => c -> 
+  Reader DrasilState (SVariable r)
 mkVar v = do
   t <- codeType v
   variable (codeName v) (convType t)
 
-publicFunc :: (ProgramSym repr, HasSpace c, CodeIdea c) => Label -> VSType repr 
-  -> String -> [c] -> Maybe String -> [MSBlock repr] -> 
-  Reader DrasilState (SMethod repr)
+publicFunc :: (ProgramSym r, HasSpace c, CodeIdea c) => Label -> VSType r 
+  -> String -> [c] -> Maybe String -> [MSBlock r] -> 
+  Reader DrasilState (SMethod r)
 publicFunc n t = genMethod (function n public static t) n
 
-privateMethod :: (ProgramSym repr, HasSpace c, CodeIdea c) => Label -> 
-  VSType repr -> String -> [c] -> Maybe String -> [MSBlock repr] -> 
-  Reader DrasilState (SMethod repr)
+privateMethod :: (ProgramSym r, HasSpace c, CodeIdea c) => Label -> 
+  VSType r -> String -> [c] -> Maybe String -> [MSBlock r] -> 
+  Reader DrasilState (SMethod r)
 privateMethod n t = genMethod (method n private dynamic t) n
 
-publicInOutFunc :: (ProgramSym repr, HasSpace c, CodeIdea c, Eq c) => Label -> 
-  String -> [c] -> [c] -> [MSBlock repr] -> Reader DrasilState (SMethod repr)
+publicInOutFunc :: (ProgramSym r, HasSpace c, CodeIdea c, Eq c) => Label -> 
+  String -> [c] -> [c] -> [MSBlock r] -> Reader DrasilState (SMethod r)
 publicInOutFunc n = genInOutFunc (inOutFunc n) (docInOutFunc n) public static n
 
-privateInOutMethod :: (ProgramSym repr, HasSpace c, CodeIdea c, Eq c) => Label 
-  -> String -> [c] -> [c] -> [MSBlock repr] -> Reader DrasilState (SMethod repr)
+privateInOutMethod :: (ProgramSym r, HasSpace c, CodeIdea c, Eq c) => Label 
+  -> String -> [c] -> [c] -> [MSBlock r] -> Reader DrasilState (SMethod r)
 privateInOutMethod n = genInOutFunc (inOutMethod n) (docInOutMethod n) 
   private dynamic n
 
-genConstructor :: (ProgramSym repr, HasSpace c, CodeIdea c) => Label -> String 
-  -> [c] -> [MSBlock repr] -> Reader DrasilState (SMethod repr)
+genConstructor :: (ProgramSym r, HasSpace c, CodeIdea c) => Label -> String 
+  -> [c] -> [MSBlock r] -> Reader DrasilState (SMethod r)
 genConstructor n desc p = genMethod nonInitConstructor n desc p Nothing
 
-genInitConstructor :: (ProgramSym repr, HasSpace c, CodeIdea c) => Label -> 
-  String -> [c] -> [Initializer repr] -> [MSBlock repr] -> 
-  Reader DrasilState (SMethod repr)
+genInitConstructor :: (ProgramSym r, HasSpace c, CodeIdea c) => Label -> 
+  String -> [c] -> [Initializer r] -> [MSBlock r] -> 
+  Reader DrasilState (SMethod r)
 genInitConstructor n desc p is = genMethod (`constructor` is) n desc p 
   Nothing
 
-genMethod :: (ProgramSym repr, HasSpace c, CodeIdea c) => ([MSParameter repr] 
-  -> MSBody repr -> SMethod repr) -> Label -> String -> [c] -> Maybe String -> 
-  [MSBlock repr] -> Reader DrasilState (SMethod repr)
+genMethod :: (ProgramSym r, HasSpace c, CodeIdea c) => ([MSParameter r] 
+  -> MSBody r -> SMethod r) -> Label -> String -> [c] -> Maybe String -> 
+  [MSBlock r] -> Reader DrasilState (SMethod r)
 genMethod f n desc p r b = do
   g <- ask
   vars <- mapM mkVar p
@@ -166,14 +166,14 @@ genMethod f n desc p r b = do
   return $ if CommentFunc `elem` commented g
     then docFunc desc pComms r fn else fn
 
-genInOutFunc :: (ProgramSym repr, HasSpace c, CodeIdea c, Eq c) => 
-  (repr (Scope repr) -> repr (Permanence repr) -> [SVariable repr] 
-    -> [SVariable repr] -> [SVariable repr] -> MSBody repr -> SMethod repr) -> 
-  (repr (Scope repr) -> repr (Permanence repr) -> String -> 
-    [(String, SVariable repr)] -> [(String, SVariable repr)] -> 
-    [(String, SVariable repr)] -> MSBody repr -> SMethod repr) -> 
-  repr (Scope repr) -> repr (Permanence repr) -> Label -> String -> [c] -> 
-  [c] -> [MSBlock repr] -> Reader DrasilState (SMethod repr)
+genInOutFunc :: (ProgramSym r, HasSpace c, CodeIdea c, Eq c) => 
+  (r (Scope r) -> r (Permanence r) -> [SVariable r] 
+    -> [SVariable r] -> [SVariable r] -> MSBody r -> SMethod r) -> 
+  (r (Scope r) -> r (Permanence r) -> String -> 
+    [(String, SVariable r)] -> [(String, SVariable r)] -> 
+    [(String, SVariable r)] -> MSBody r -> SMethod r) -> 
+  r (Scope r) -> r (Permanence r) -> Label -> String -> [c] -> 
+  [c] -> [MSBlock r] -> Reader DrasilState (SMethod r)
 genInOutFunc f docf s pr n desc ins' outs' b = do
   g <- ask
   let ins = ins' \\ outs'
@@ -190,7 +190,7 @@ genInOutFunc f docf s pr n desc ins' outs' b = do
     then docf s pr desc (zip pComms inVs) (zip oComms outVs) (zip 
     bComms bothVs) bod else f s pr inVs outVs bothVs bod
 
-convExpr :: (ProgramSym repr) => Expr -> Reader DrasilState (SValue repr)
+convExpr :: (ProgramSym r) => Expr -> Reader DrasilState (SValue r)
 convExpr (Dbl d) = do
   g <- ask
   let sm = spaceMatches g
@@ -249,9 +249,9 @@ convExpr (RealI c ri)  = do
   g <- ask
   convExpr $ renderRealInt (lookupC g c) ri
 
-convCall :: (ProgramSym repr) => UID -> [Expr] -> [(UID, Expr)] -> (String -> 
-  String -> VSType repr -> [SValue repr] -> [NamedArg repr] -> 
-  Reader DrasilState (SValue repr)) -> Reader DrasilState (SValue repr)
+convCall :: (ProgramSym r) => UID -> [Expr] -> [(UID, Expr)] -> (String -> 
+  String -> VSType r -> [SValue r] -> [NamedArg r] -> 
+  Reader DrasilState (SValue r)) -> Reader DrasilState (SValue r)
 convCall c x ns f = do
   g <- ask
   let info = sysinfodb $ csi $ codeSpec g
@@ -280,7 +280,7 @@ renderRealInt s (UpTo (Exc,a))    = sy s $< a
 renderRealInt s (UpFrom (Inc,a))  = sy s $>= a
 renderRealInt s (UpFrom (Exc,a))  = sy s $>  a
 
-unop :: (ProgramSym repr) => UFunc -> (SValue repr -> SValue repr)
+unop :: (ProgramSym r) => UFunc -> (SValue r -> SValue r)
 unop Sqrt = (#/^)
 unop Log  = log
 unop Ln   = ln
@@ -300,8 +300,8 @@ unop Norm = error "unop: Norm not implemented"
 unop Not  = (?!)
 unop Neg  = (#~)
 
-bfunc :: (ProgramSym repr) => BinOp -> (SValue repr -> SValue repr -> 
-  SValue repr)
+bfunc :: (ProgramSym r) => BinOp -> (SValue r -> SValue r -> 
+  SValue r)
 bfunc Eq    = (?==)
 bfunc NEq   = (?!=)
 bfunc Gt    = (?>)
@@ -318,29 +318,29 @@ bfunc Frac  = (#/)
 bfunc Index = listAccess
 
 -- medium hacks --
-genModDef :: (ProgramSym repr) => Mod -> Reader DrasilState (SFile repr)
+genModDef :: (ProgramSym r) => Mod -> Reader DrasilState (SFile r)
 genModDef (Mod n desc is cs fs) = genModuleWithImports n desc is (map (fmap 
   Just . genFunc) fs) 
   (case cs of [] -> []
               (cl:cls) -> fmap Just (genClass primaryClass cl) : 
                 map (fmap Just . genClass auxClass) cls)
 
-genModFuncs :: (ProgramSym repr) => Mod -> [Reader DrasilState (SMethod repr)]
+genModFuncs :: (ProgramSym r) => Mod -> [Reader DrasilState (SMethod r)]
 genModFuncs (Mod _ _ _ _ fs) = map genFunc fs
 
-genModClasses :: (ProgramSym repr) => Mod -> [Reader DrasilState (SClass repr)]
+genModClasses :: (ProgramSym r) => Mod -> [Reader DrasilState (SClass r)]
 genModClasses (Mod _ _ _ cs _) = map (genClass auxClass) cs
 
-genClass :: (ProgramSym repr) => (String -> Label -> Maybe Label -> 
-  [CSStateVar repr] -> Reader DrasilState [SMethod repr] -> 
-  Reader DrasilState (SClass repr)) -> M.Class -> 
-  Reader DrasilState (SClass repr)
+genClass :: (ProgramSym r) => (String -> Label -> Maybe Label -> 
+  [CSStateVar r] -> Reader DrasilState [SMethod r] -> 
+  Reader DrasilState (SClass r)) -> M.Class -> 
+  Reader DrasilState (SClass r)
 genClass f (M.ClassDef n i desc svs ms) = do
   svrs <- mapM (\v -> fmap (pubDVar . var (codeName v) . convType) (codeType v))
     svs
   f n desc i svrs (mapM genFunc ms) 
 
-genFunc :: (ProgramSym repr) => Func -> Reader DrasilState (SMethod repr)
+genFunc :: (ProgramSym r) => Func -> Reader DrasilState (SMethod r)
 genFunc (FDef (FuncDef n desc parms o rd s)) = do
   g <- ask
   stmts <- mapM convStmt s
@@ -358,7 +358,7 @@ genFunc (FDef (CtorDef n desc parms i s)) = do
     [block $ map varDec vars ++ stmts]
 genFunc (FData (FuncData n desc ddef)) = genDataFunc n desc ddef
 
-convStmt :: (ProgramSym repr) => FuncStmt -> Reader DrasilState (MSStatement repr)
+convStmt :: (ProgramSym r) => FuncStmt -> Reader DrasilState (MSStatement r)
 convStmt (FAsg v (Matrix [es]))  = do
   els <- mapM convExpr es
   v' <- mkVar v
@@ -452,15 +452,15 @@ convStmt (FAppend a b) = do
   b' <- convExpr b
   return $ valState $ listAppend a' b'
 
-genDataFunc :: (ProgramSym repr) => Name -> String -> DataDesc -> 
-  Reader DrasilState (SMethod repr)
+genDataFunc :: (ProgramSym r) => Name -> String -> DataDesc -> 
+  Reader DrasilState (SMethod r)
 genDataFunc nameTitle desc ddef = do
   let parms = getInputs ddef
   bod <- readData ddef
   publicFunc nameTitle void desc (quantvar inFileName : parms) Nothing bod
 
 -- this is really ugly!!
-readData :: (ProgramSym repr) => DataDesc -> Reader DrasilState [MSBlock repr]
+readData :: (ProgramSym r) => DataDesc -> Reader DrasilState [MSBlock r]
 readData ddef = do
   inD <- mapM inData ddef
   v_filename <- mkVal $ quantvar inFileName
@@ -471,7 +471,7 @@ readData ddef = do
     openFileR var_infile v_filename :
     concat inD ++ [
     closeFile v_infile ]]
-  where inData :: (ProgramSym repr) => Data -> Reader DrasilState [MSStatement repr]
+  where inData :: (ProgramSym r) => Data -> Reader DrasilState [MSStatement r]
         inData (Singleton v) = do
             vv <- mkVar v
             l <- maybeLog vv
@@ -497,8 +497,8 @@ readData ddef = do
                   ] ++ lnV)]
           return $ readLines ls ++ logs
         ---------------
-        lineData :: (ProgramSym repr) => Maybe String -> LinePattern -> 
-          Reader DrasilState [MSStatement repr]
+        lineData :: (ProgramSym r) => Maybe String -> LinePattern -> 
+          Reader DrasilState [MSStatement r]
         lineData s p@(Straight _) = do
           vs <- getEntryVars s p
           return [stringListVals vs v_linetokens]
@@ -507,32 +507,32 @@ readData ddef = do
           sequence $ clearTemps s ds ++ return (stringListLists vs v_linetokens)
             : appendTemps s ds
         ---------------
-        clearTemps :: (ProgramSym repr) => Maybe String -> [DataItem] -> 
-          [Reader DrasilState (MSStatement repr)]
+        clearTemps :: (ProgramSym r) => Maybe String -> [DataItem] -> 
+          [Reader DrasilState (MSStatement r)]
         clearTemps Nothing _ = []
         clearTemps (Just sfx) es = map (clearTemp sfx) es
         ---------------
-        clearTemp :: (ProgramSym repr) => String -> DataItem -> 
-          Reader DrasilState (MSStatement repr)
+        clearTemp :: (ProgramSym r) => String -> DataItem -> 
+          Reader DrasilState (MSStatement r)
         clearTemp sfx v = fmap (\t -> listDecDef (var (codeName v ++ sfx) 
           (listInnerType $ convType t)) []) (codeType v)
         ---------------
-        appendTemps :: (ProgramSym repr) => Maybe String -> [DataItem] -> 
-          [Reader DrasilState (MSStatement repr)]
+        appendTemps :: (ProgramSym r) => Maybe String -> [DataItem] -> 
+          [Reader DrasilState (MSStatement r)]
         appendTemps Nothing _ = []
         appendTemps (Just sfx) es = map (appendTemp sfx) es
         ---------------
-        appendTemp :: (ProgramSym repr) => String -> DataItem -> 
-          Reader DrasilState (MSStatement repr)
+        appendTemp :: (ProgramSym r) => String -> DataItem -> 
+          Reader DrasilState (MSStatement r)
         appendTemp sfx v = fmap (\t -> valState $ listAppend 
           (valueOf $ var (codeName v) (convType t)) 
           (valueOf $ var (codeName v ++ sfx) (convType t))) (codeType v)
         ---------------
         l_line, l_lines, l_linetokens, l_infile, l_i :: Label
         var_line, var_lines, var_linetokens, var_infile, var_i :: 
-          (ProgramSym repr) => SVariable repr
+          (ProgramSym r) => SVariable r
         v_line, v_lines, v_linetokens, v_infile, v_i ::
-          (ProgramSym repr) => SValue repr
+          (ProgramSym r) => SValue r
         l_line = "line"
         var_line = var l_line string
         v_line = valueOf var_line
@@ -549,13 +549,13 @@ readData ddef = do
         var_i = var l_i int
         v_i = valueOf var_i
 
-getEntryVars :: (ProgramSym repr) => Maybe String -> LinePattern -> 
-  Reader DrasilState [SVariable repr]
+getEntryVars :: (ProgramSym r) => Maybe String -> LinePattern -> 
+  Reader DrasilState [SVariable r]
 getEntryVars s lp = mapM (maybe mkVar (\st v -> codeType v >>= (variable 
   (codeName v ++ st) . listInnerType . convType)) s) (getPatternInputs lp)
 
-getEntryVarLogs :: (ProgramSym repr) => LinePattern -> 
-  Reader DrasilState [MSStatement repr]
+getEntryVarLogs :: (ProgramSym r) => LinePattern -> 
+  Reader DrasilState [MSStatement r]
 getEntryVarLogs lp = do
   vs <- getEntryVars Nothing lp
   logs <- mapM maybeLog vs

--- a/code/drasil-code/Language/Drasil/Code/Imperative/Import.hs
+++ b/code/drasil-code/Language/Drasil/Code/Imperative/Import.hs
@@ -28,7 +28,7 @@ import Language.Drasil.Mod (Func(..), FuncData(..), FuncDef(..), FuncStmt(..),
 import qualified Language.Drasil.Mod as M (Class(..))
 
 import GOOL.Drasil (Label, SFile, MSBody, MSBlock, VSType, SVariable, SValue, 
-  MSStatement, MSParameter, SMethod, CSStateVar, SClass, NamedArg, Initializer, ProgramSym, 
+  MSStatement, MSParameter, SMethod, CSStateVar, SClass, NamedArgs, Initializer, ProgramSym, 
   PermanenceSym(..), bodyStatements, BlockSym(..), TypeSym(..), VariableSym(..),
   ($->), ValueSym(..), Literal(..), VariableValue(..), NumericExpression(..), BooleanExpression(..), Comparison(..), 
   ValueExpression(..), objMethodCallMixedArgs, List(..), StatementSym(..),
@@ -250,7 +250,7 @@ convExpr (RealI c ri)  = do
   convExpr $ renderRealInt (lookupC g c) ri
 
 convCall :: (ProgramSym r) => UID -> [Expr] -> [(UID, Expr)] -> (String -> 
-  String -> VSType r -> [SValue r] -> [NamedArg r] -> 
+  String -> VSType r -> [SValue r] -> NamedArgs r -> 
   Reader DrasilState (SValue r)) -> Reader DrasilState (SValue r)
 convCall c x ns f = do
   g <- ask

--- a/code/drasil-code/Language/Drasil/Code/Imperative/Logging.hs
+++ b/code/drasil-code/Language/Drasil/Code/Imperative/Logging.hs
@@ -15,21 +15,21 @@ import Data.Maybe (maybeToList)
 import Control.Applicative ((<$>))
 import Control.Monad.Reader (Reader, ask)
 
-maybeLog :: (ProgramSym repr) => SVariable repr ->
-  Reader DrasilState [MSStatement repr]
+maybeLog :: (ProgramSym r) => SVariable r ->
+  Reader DrasilState [MSStatement r]
 maybeLog v = do
   g <- ask
   l <- chooseLogging (logKind g) v
   return $ maybeToList l
 
-chooseLogging :: (ProgramSym repr) => Logging -> (SVariable repr -> 
-  Reader DrasilState (Maybe (MSStatement repr)))
+chooseLogging :: (ProgramSym r) => Logging -> (SVariable r -> 
+  Reader DrasilState (Maybe (MSStatement r)))
 chooseLogging LogVar v = Just <$> loggedVar v
 chooseLogging LogAll v = Just <$> loggedVar v
 chooseLogging _      _ = return Nothing
 
-loggedVar :: (ProgramSym repr) => SVariable repr -> 
-  Reader DrasilState (MSStatement repr)
+loggedVar :: (ProgramSym r) => SVariable r -> 
+  Reader DrasilState (MSStatement r)
 loggedVar v = do
     g <- ask
     return $ multi [
@@ -40,8 +40,8 @@ loggedVar v = do
       printFileStrLn valLogFile (" in module " ++ currentModule g),
       closeFile valLogFile ]
 
-logBody :: (ProgramSym repr) => Label -> [SVariable repr] -> [MSBlock repr] -> 
-  Reader DrasilState (MSBody repr)
+logBody :: (ProgramSym r) => Label -> [SVariable r] -> [MSBlock r] -> 
+  Reader DrasilState (MSBody r)
 logBody n vars b = do
   g <- ask
   let loggedBody LogFunc = loggedMethod (logName g) n vars b
@@ -49,8 +49,8 @@ logBody n vars b = do
       loggedBody _       = b
   return $ body $ loggedBody $ logKind g
 
-loggedMethod :: (ProgramSym repr) => Label -> Label -> [SVariable repr] -> 
-  [MSBlock repr] -> [MSBlock repr]
+loggedMethod :: (ProgramSym r) => Label -> Label -> [SVariable r] -> 
+  [MSBlock r] -> [MSBlock r]
 loggedMethod lName n vars b = block [
       varDec varLogFile,
       openFileA varLogFile (litString lName),
@@ -71,8 +71,8 @@ loggedMethod lName n vars b = block [
       printFile valLogFile (valueOf v), 
       printFileStrLn valLogFile ", "] ++ printInputs vs
 
-varLogFile :: (ProgramSym repr) => SVariable repr
+varLogFile :: (ProgramSym r) => SVariable r
 varLogFile = var "outfile" outfile
 
-valLogFile :: (ProgramSym repr) => SValue repr
+valLogFile :: (ProgramSym r) => SValue r
 valLogFile = valueOf varLogFile

--- a/code/drasil-code/Language/Drasil/Code/Imperative/Modules.hs
+++ b/code/drasil-code/Language/Drasil/Code/Imperative/Modules.hs
@@ -55,11 +55,11 @@ import Text.PrettyPrint.HughesPJ (render)
 
 ---- MAIN ---
 
-genMain :: (ProgramSym repr) => Reader DrasilState (SFile repr)
+genMain :: (ProgramSym r) => Reader DrasilState (SFile r)
 genMain = genModule "Control" "Controls the flow of the program" 
   [fmap Just genMainFunc] []
 
-genMainFunc :: (ProgramSym repr) => Reader DrasilState (SMethod repr)
+genMainFunc :: (ProgramSym r) => Reader DrasilState (SMethod r)
 genMainFunc = do
     g <- ask
     v_filename <- mkVar $ quantvar inFileName
@@ -75,8 +75,8 @@ genMainFunc = do
       varDecDef v_filename (arg 0) : logInFile ++
       catMaybes [ip, co] ++ ics ++ catMaybes (varDef ++ [wo])
 
-getInputDecl :: (ProgramSym repr) => Reader DrasilState 
-  (Maybe (MSStatement repr))
+getInputDecl :: (ProgramSym r) => Reader DrasilState 
+  (Maybe (MSStatement r))
 getInputDecl = do
   g <- ask
   v_params <- mkVar (quantvar inParams)
@@ -101,7 +101,7 @@ getInputDecl = do
   getDecl (partition (flip member (eMap $ codeSpec g) . codeName) 
     (inputs $ csi $ codeSpec g))
 
-initConsts :: (ProgramSym repr) => Reader DrasilState (Maybe (MSStatement repr))
+initConsts :: (ProgramSym r) => Reader DrasilState (Maybe (MSStatement r))
 initConsts = do
   g <- ask
   v_consts <- mkVar (quantvar consts)
@@ -126,19 +126,19 @@ initConsts = do
   getDecl (partition (flip member (eMap $ codeSpec g) . codeName) 
     (constants $ csi $ codeSpec g)) (conStruct g)
 
-initLogFileVar :: (ProgramSym repr) => Logging -> [MSStatement repr]
+initLogFileVar :: (ProgramSym r) => Logging -> [MSStatement r]
 initLogFileVar LogVar = [varDec varLogFile]
 initLogFileVar LogAll = [varDec varLogFile]
 initLogFileVar _ = []
 
 ------- INPUT ----------
 
-chooseInModule :: (ProgramSym repr) => InputModule -> Reader DrasilState 
-  [SFile repr]
+chooseInModule :: (ProgramSym r) => InputModule -> Reader DrasilState 
+  [SFile r]
 chooseInModule Combined = genInputModCombined
 chooseInModule Separated = genInputModSeparated
 
-genInputModSeparated :: (ProgramSym repr) => Reader DrasilState [SFile repr]
+genInputModSeparated :: (ProgramSym r) => Reader DrasilState [SFile r]
 genInputModSeparated = do
   ipDesc <- modDesc inputParametersDesc
   ifDesc <- modDesc (liftS inputFormatDesc)
@@ -150,25 +150,25 @@ genInputModSeparated = do
     genModule "DerivedValues" dvDesc [genInputDerived Primary] [],
     genModule "InputConstraints" icDesc [genInputConstraints Primary] []]
 
-genInputModCombined :: (ProgramSym repr) => Reader DrasilState [SFile repr]
+genInputModCombined :: (ProgramSym r) => Reader DrasilState [SFile r]
 genInputModCombined = do
   ipDesc <- modDesc inputParametersDesc
   let cname = "InputParameters"
-      genMod :: (ProgramSym repr) => Maybe (SClass repr) ->
-        Reader DrasilState (SFile repr)
+      genMod :: (ProgramSym r) => Maybe (SClass r) ->
+        Reader DrasilState (SFile r)
       genMod Nothing = genModule cname ipDesc [genInputFormat Primary, 
         genInputDerived Primary, genInputConstraints Primary] []
       genMod _ = genModule cname ipDesc [] [genInputClass Primary]
   ic <- genInputClass Primary
   liftS $ genMod ic
 
-constVarFunc :: (ProgramSym repr) => ConstantRepr -> String ->
-  (SVariable repr -> SValue repr -> CSStateVar repr)
+constVarFunc :: (ProgramSym r) => ConstantRepr -> String ->
+  (SVariable r -> SValue r -> CSStateVar r)
 constVarFunc Var n = stateVarDef n public dynamic
 constVarFunc Const n = constVar n public
 
-genInputClass :: (ProgramSym repr) => ClassType -> 
-  Reader DrasilState (Maybe (SClass repr))
+genInputClass :: (ProgramSym r) => ClassType -> 
+  Reader DrasilState (Maybe (SClass r))
 genInputClass scp = withReader (\s -> s {currentClass = cname}) $ do
   g <- ask
   let ins = inputs $ csi $ codeSpec g
@@ -178,14 +178,14 @@ genInputClass scp = withReader (\s -> s {currentClass = cname}) $ do
       includedConstants :: (CodeIdea c) => ConstantStructure -> [c] -> [c]
       includedConstants WithInputs cs' = filt cs'
       includedConstants _ _ = []
-      methods :: (ProgramSym repr) => InputModule -> 
-        Reader DrasilState [SMethod repr]
+      methods :: (ProgramSym r) => InputModule -> 
+        Reader DrasilState [SMethod r]
       methods Separated = return []
       methods Combined = concat <$> mapM (fmap maybeToList) 
         [genInputConstructor, genInputFormat Auxiliary, 
         genInputDerived Auxiliary, genInputConstraints Auxiliary]
-      genClass :: (ProgramSym repr) => [CodeVarChunk] -> [CodeDefinition] -> 
-        Reader DrasilState (Maybe (SClass repr))
+      genClass :: (ProgramSym r) => [CodeVarChunk] -> [CodeDefinition] -> 
+        Reader DrasilState (Maybe (SClass r))
       genClass [] [] = return Nothing
       genClass inps csts = do
         vals <- mapM (convExpr . codeEquat) csts
@@ -203,8 +203,8 @@ genInputClass scp = withReader (\s -> s {currentClass = cname}) $ do
   genClass (filt ins) (includedConstants (conStruct g) cs)
   where cname = "InputParameters"
 
-genInputConstructor :: (ProgramSym repr) => Reader DrasilState 
-  (Maybe (SMethod repr))
+genInputConstructor :: (ProgramSym r) => Reader DrasilState 
+  (Maybe (SMethod r))
 genInputConstructor = do
   g <- ask
   let dl = defList $ codeSpec g
@@ -218,15 +218,15 @@ genInputConstructor = do
   genCtor $ any (`elem` dl) ["get_input", "derived_values", 
     "input_constraints"]
 
-genInputDerived :: (ProgramSym repr) => ClassType -> 
-  Reader DrasilState (Maybe (SMethod repr))
+genInputDerived :: (ProgramSym r) => ClassType -> 
+  Reader DrasilState (Maybe (SMethod r))
 genInputDerived s = do
   g <- ask
   let dvals = derivedInputs $ csi $ codeSpec g
       getFunc Primary = publicInOutFunc
       getFunc Auxiliary = privateInOutMethod
-      genDerived :: (ProgramSym repr) => Bool -> Reader DrasilState 
-        (Maybe (SMethod repr))
+      genDerived :: (ProgramSym r) => Bool -> Reader DrasilState 
+        (Maybe (SMethod r))
       genDerived False = return Nothing
       genDerived _ = do
         ins <- getDerivedIns
@@ -237,15 +237,15 @@ genInputDerived s = do
         return $ Just mthd
   genDerived $ "derived_values" `elem` defList (codeSpec g)
 
-genInputConstraints :: (ProgramSym repr) => ClassType ->
-  Reader DrasilState (Maybe (SMethod repr))
+genInputConstraints :: (ProgramSym r) => ClassType ->
+  Reader DrasilState (Maybe (SMethod r))
 genInputConstraints s = do
   g <- ask
   let cm = cMap $ csi $ codeSpec g
       getFunc Primary = publicFunc
       getFunc Auxiliary = privateMethod
-      genConstraints :: (ProgramSym repr) => Bool -> Reader DrasilState 
-        (Maybe (SMethod repr))
+      genConstraints :: (ProgramSym r) => Bool -> Reader DrasilState 
+        (Maybe (SMethod r))
       genConstraints False = return Nothing
       genConstraints _ = do
         h <- ask
@@ -262,23 +262,23 @@ genInputConstraints s = do
         return $ Just mthd
   genConstraints $ "input_constraints" `elem` defList (codeSpec g)
 
-sfwrCBody :: (HasUID q, HasSymbol q, CodeIdea q, HasSpace q, ProgramSym repr) 
-  => [(q,[Constraint])] -> Reader DrasilState [MSStatement repr]
+sfwrCBody :: (HasUID q, HasSymbol q, CodeIdea q, HasSpace q, ProgramSym r) 
+  => [(q,[Constraint])] -> Reader DrasilState [MSStatement r]
 sfwrCBody cs = do
   g <- ask
   let cb = onSfwrC g
   chooseConstr cb cs
 
-physCBody :: (HasUID q, HasSymbol q, CodeIdea q, HasSpace q, ProgramSym repr) 
-  => [(q,[Constraint])] -> Reader DrasilState [MSStatement repr]
+physCBody :: (HasUID q, HasSymbol q, CodeIdea q, HasSpace q, ProgramSym r) 
+  => [(q,[Constraint])] -> Reader DrasilState [MSStatement r]
 physCBody cs = do
   g <- ask
   let cb = onPhysC g
   chooseConstr cb cs
 
 chooseConstr :: (HasUID q, HasSymbol q, CodeIdea q, HasSpace q, 
-  ProgramSym repr) => ConstraintBehaviour -> [(q,[Constraint])] -> 
-  Reader DrasilState [MSStatement repr]
+  ProgramSym r) => ConstraintBehaviour -> [(q,[Constraint])] -> 
+  Reader DrasilState [MSStatement r]
 chooseConstr cb cs = do
   conds <- mapM (\(q,cns) -> mapM (convExpr . renderC q) cns) cs
   bods <- mapM (chooseCB cb) cs
@@ -287,25 +287,25 @@ chooseConstr cb cs = do
   where chooseCB Warning = constrWarn
         chooseCB Exception = constrExc 
 
-constrWarn :: (HasUID q, CodeIdea q, HasSpace q, ProgramSym repr)
-  => (q,[Constraint]) -> Reader DrasilState [MSBody repr]
+constrWarn :: (HasUID q, CodeIdea q, HasSpace q, ProgramSym r)
+  => (q,[Constraint]) -> Reader DrasilState [MSBody r]
 constrWarn c = do
   let q = fst c
       cs = snd c
   msgs <- mapM (constraintViolatedMsg q "suggested") cs
   return $ map (bodyStatements . (printStr "Warning: " :)) msgs
 
-constrExc :: (HasUID q, CodeIdea q, HasSpace q, ProgramSym repr) 
-  => (q,[Constraint]) -> Reader DrasilState [MSBody repr]
+constrExc :: (HasUID q, CodeIdea q, HasSpace q, ProgramSym r) 
+  => (q,[Constraint]) -> Reader DrasilState [MSBody r]
 constrExc c = do
   let q = fst c
       cs = snd c
   msgs <- mapM (constraintViolatedMsg q "expected") cs
   return $ map (bodyStatements . (++ [throw "InputError"])) msgs
 
-constraintViolatedMsg :: (CodeIdea q, HasUID q, HasSpace q, ProgramSym repr) 
+constraintViolatedMsg :: (CodeIdea q, HasUID q, HasSpace q, ProgramSym r) 
   => q -> String -> Constraint -> Reader DrasilState 
-  [MSStatement repr]
+  [MSStatement r]
 constraintViolatedMsg q s c = do
   pc <- printConstraint c 
   v <- mkVal q
@@ -313,13 +313,13 @@ constraintViolatedMsg q s c = do
     print v,
     printStr $ " but " ++ s ++ " to be "] ++ pc
 
-printConstraint :: (ProgramSym repr) => Constraint -> 
-  Reader DrasilState [MSStatement repr]
+printConstraint :: (ProgramSym r) => Constraint -> 
+  Reader DrasilState [MSStatement r]
 printConstraint c = do
   g <- ask
   let db = sysinfodb $ csi $ codeSpec g
-      printConstraint' :: (ProgramSym repr) => Constraint -> Reader DrasilState 
-        [MSStatement repr]
+      printConstraint' :: (ProgramSym r) => Constraint -> Reader DrasilState 
+        [MSStatement r]
       printConstraint' (Range _ (Bounded (_,e1) (_,e2))) = do
         lb <- convExpr e1
         ub <- convExpr e2
@@ -340,21 +340,21 @@ printConstraint c = do
         printStrLn $ "one of: " ++ intercalate ", " ss]
   printConstraint' c
 
-printExpr :: (ProgramSym repr) => Expr -> ChunkDB -> [MSStatement repr]
+printExpr :: (ProgramSym r) => Expr -> ChunkDB -> [MSStatement r]
 printExpr (Dbl _) _ = []
 printExpr (Int _) _ = []
 printExpr e db = [printStr $ " (" ++ render (exprDoc db Implementation Linear e)
   ++ ")"]
 
-genInputFormat :: (ProgramSym repr) => ClassType -> 
-  Reader DrasilState (Maybe (SMethod repr))
+genInputFormat :: (ProgramSym r) => ClassType -> 
+  Reader DrasilState (Maybe (SMethod r))
 genInputFormat s = do
   g <- ask
   dd <- genDataDesc
   let getFunc Primary = publicInOutFunc
       getFunc Auxiliary = privateInOutMethod
-      genInFormat :: (ProgramSym repr) => Bool -> Reader DrasilState 
-        (Maybe (SMethod repr))
+      genInFormat :: (ProgramSym r) => Bool -> Reader DrasilState 
+        (Maybe (SMethod r))
       genInFormat False = return Nothing
       genInFormat _ = do
         ins <- getInputFormatIns
@@ -371,7 +371,7 @@ genDataDesc = do
   return $ junkLine : 
     intersperse junkLine (map singleton (extInputs $ csi $ codeSpec g))
 
-genSampleInput :: (AuxiliarySym repr) => Reader DrasilState [repr (Auxiliary repr)]
+genSampleInput :: (AuxiliarySym r) => Reader DrasilState [r (Auxiliary r)]
 genSampleInput = do
   g <- ask
   dd <- genDataDesc
@@ -380,18 +380,18 @@ genSampleInput = do
 
 ----- CONSTANTS -----
 
-genConstMod :: (ProgramSym repr) => Reader DrasilState [SFile repr]
+genConstMod :: (ProgramSym r) => Reader DrasilState [SFile r]
 genConstMod = do
   cDesc <- modDesc $ liftS constModDesc
   liftS $ genModule "Constants" cDesc [] [genConstClass Primary]
 
-genConstClass :: (ProgramSym repr) => ClassType ->
-  Reader DrasilState (Maybe (SClass repr))
+genConstClass :: (ProgramSym r) => ClassType ->
+  Reader DrasilState (Maybe (SClass r))
 genConstClass scp = withReader (\s -> s {currentClass = cname}) $ do
   g <- ask
   let cs = constants $ csi $ codeSpec g
-      genClass :: (ProgramSym repr) => [CodeDefinition] -> Reader DrasilState (Maybe 
-        (SClass repr))
+      genClass :: (ProgramSym r) => [CodeDefinition] -> Reader DrasilState (Maybe 
+        (SClass r))
       genClass [] = return Nothing 
       genClass vs = do
         vals <- mapM (convExpr . codeEquat) vs 
@@ -409,14 +409,14 @@ genConstClass scp = withReader (\s -> s {currentClass = cname}) $ do
 
 ------- CALC ----------
 
-genCalcMod :: (ProgramSym repr) => Reader DrasilState (SFile repr)
+genCalcMod :: (ProgramSym r) => Reader DrasilState (SFile r)
 genCalcMod = do
   g <- ask
   genModule "Calculations" calcModDesc (map (fmap Just . genCalcFunc) 
     (execOrder $ csi $ codeSpec g)) []
 
-genCalcFunc :: (ProgramSym repr) => CodeDefinition -> 
-  Reader DrasilState (SMethod repr)
+genCalcFunc :: (ProgramSym r) => CodeDefinition -> 
+  Reader DrasilState (SMethod r)
 genCalcFunc cdef = do
   parms <- getCalcParams cdef
   let nm = codeName cdef
@@ -433,8 +433,8 @@ genCalcFunc cdef = do
 
 data CalcType = CalcAssign | CalcReturn deriving Eq
 
-genCalcBlock :: (ProgramSym repr) => CalcType -> CodeDefinition -> Expr ->
-  Reader DrasilState (MSBlock repr)
+genCalcBlock :: (ProgramSym r) => CalcType -> CodeDefinition -> Expr ->
+  Reader DrasilState (MSBlock r)
 genCalcBlock t v (Case c e) = genCaseBlock t v c e
 genCalcBlock CalcAssign v e = do
   vv <- mkVar v
@@ -443,8 +443,8 @@ genCalcBlock CalcAssign v e = do
   return $ block $ assign vv ee : l
 genCalcBlock CalcReturn _ e = block <$> liftS (returnState <$> convExpr e)
 
-genCaseBlock :: (ProgramSym repr) => CalcType -> CodeDefinition -> Completeness 
-  -> [(Expr,Relation)] -> Reader DrasilState (MSBlock repr)
+genCaseBlock :: (ProgramSym r) => CalcType -> CodeDefinition -> Completeness 
+  -> [(Expr,Relation)] -> Reader DrasilState (MSBlock r)
 genCaseBlock _ _ _ [] = error $ "Case expression with no cases encountered" ++
   " in code generator"
 genCaseBlock t v c cs = do
@@ -460,16 +460,16 @@ genCaseBlock t v c cs = do
 
 ----- OUTPUT -------
 
-genOutputMod :: (ProgramSym repr) => Reader DrasilState [SFile repr]
+genOutputMod :: (ProgramSym r) => Reader DrasilState [SFile r]
 genOutputMod = do
   ofDesc <- modDesc $ liftS outputFormatDesc
   liftS $ genModule "OutputFormat" ofDesc [genOutputFormat] []
 
-genOutputFormat :: (ProgramSym repr) => Reader DrasilState (Maybe (SMethod repr))
+genOutputFormat :: (ProgramSym r) => Reader DrasilState (Maybe (SMethod r))
 genOutputFormat = do
   g <- ask
-  let genOutput :: (ProgramSym repr) => Maybe String -> Reader DrasilState 
-        (Maybe (SMethod repr))
+  let genOutput :: (ProgramSym r) => Maybe String -> Reader DrasilState 
+        (Maybe (SMethod r))
       genOutput Nothing = return Nothing
       genOutput (Just _) = do
         let l_outfile = "outputfile"

--- a/code/drasil-gool/GOOL/Drasil.hs
+++ b/code/drasil-gool/GOOL/Drasil.hs
@@ -1,7 +1,7 @@
 -- | re-export smart constructors for external code writing
 module GOOL.Drasil (Label, GSProgram, SFile, MSBody, MSBlock, VSType, 
   SVariable, SValue, VSFunction, MSStatement, MSParameter, SMethod, CSStateVar, 
-  SClass, FSModule, ProgramSym(..), FileSym(..), PermanenceSym(..), BodySym(..),
+  SClass, FSModule, NamedArg, Initializer, ProgramSym(..), FileSym(..), PermanenceSym(..), BodySym(..),
   bodyStatements, oneLiner, BlockSym(..), ControlBlock(..), listSlice, 
   TypeSym(..), StatementSym(..), AssignStatement(..), (&=), assignToListIndex, 
   DeclStatement(..), IOStatement(..), StringStatement(..), FuncAppStatement(..), CommentStatement(..), 
@@ -28,7 +28,7 @@ module GOOL.Drasil (Label, GSProgram, SFile, MSBody, MSBlock, VSType,
 
 import GOOL.Drasil.ClassInterface (Label, GSProgram, SFile, MSBody, MSBlock, 
   VSType, SVariable, SValue, VSFunction, MSStatement, MSParameter, SMethod, 
-  CSStateVar, SClass, FSModule, ProgramSym(..), FileSym(..), PermanenceSym(..), 
+  CSStateVar, SClass, FSModule, NamedArg, Initializer, ProgramSym(..), FileSym(..), PermanenceSym(..), 
   BodySym(..), bodyStatements, oneLiner, BlockSym(..), ControlBlock(..), 
   listSlice, TypeSym(..), StatementSym(..), AssignStatement(..), (&=), 
   assignToListIndex, DeclStatement(..), IOStatement(..), StringStatement(..), FuncAppStatement(..),

--- a/code/drasil-gool/GOOL/Drasil.hs
+++ b/code/drasil-gool/GOOL/Drasil.hs
@@ -1,7 +1,7 @@
 -- | re-export smart constructors for external code writing
 module GOOL.Drasil (Label, GSProgram, SFile, MSBody, MSBlock, VSType, 
   SVariable, SValue, VSFunction, MSStatement, MSParameter, SMethod, CSStateVar, 
-  SClass, FSModule, NamedArg, Initializer, ProgramSym(..), FileSym(..), PermanenceSym(..), BodySym(..),
+  SClass, FSModule, NamedArgs, Initializer, ProgramSym(..), FileSym(..), PermanenceSym(..), BodySym(..),
   bodyStatements, oneLiner, BlockSym(..), ControlBlock(..), listSlice, 
   TypeSym(..), StatementSym(..), AssignStatement(..), (&=), assignToListIndex, 
   DeclStatement(..), IOStatement(..), StringStatement(..), FuncAppStatement(..), CommentStatement(..), 
@@ -28,7 +28,7 @@ module GOOL.Drasil (Label, GSProgram, SFile, MSBody, MSBlock, VSType,
 
 import GOOL.Drasil.ClassInterface (Label, GSProgram, SFile, MSBody, MSBlock, 
   VSType, SVariable, SValue, VSFunction, MSStatement, MSParameter, SMethod, 
-  CSStateVar, SClass, FSModule, NamedArg, Initializer, ProgramSym(..), FileSym(..), PermanenceSym(..), 
+  CSStateVar, SClass, FSModule, NamedArgs, Initializer, ProgramSym(..), FileSym(..), PermanenceSym(..), 
   BodySym(..), bodyStatements, oneLiner, BlockSym(..), ControlBlock(..), 
   listSlice, TypeSym(..), StatementSym(..), AssignStatement(..), (&=), 
   assignToListIndex, DeclStatement(..), IOStatement(..), StringStatement(..), FuncAppStatement(..),

--- a/code/drasil-gool/GOOL/Drasil.hs
+++ b/code/drasil-gool/GOOL/Drasil.hs
@@ -1,7 +1,7 @@
 -- | re-export smart constructors for external code writing
 module GOOL.Drasil (Label, GSProgram, SFile, MSBody, MSBlock, VSType, 
   SVariable, SValue, VSFunction, MSStatement, MSParameter, SMethod, CSStateVar, 
-  SClass, FSModule, NamedArgs, Initializer, ProgramSym(..), FileSym(..), PermanenceSym(..), BodySym(..),
+  SClass, FSModule, NamedArgs, Initializers, ProgramSym(..), FileSym(..), PermanenceSym(..), BodySym(..),
   bodyStatements, oneLiner, BlockSym(..), ControlBlock(..), listSlice, 
   TypeSym(..), StatementSym(..), AssignStatement(..), (&=), assignToListIndex, 
   DeclStatement(..), IOStatement(..), StringStatement(..), FuncAppStatement(..), CommentStatement(..), 
@@ -28,7 +28,7 @@ module GOOL.Drasil (Label, GSProgram, SFile, MSBody, MSBlock, VSType,
 
 import GOOL.Drasil.ClassInterface (Label, GSProgram, SFile, MSBody, MSBlock, 
   VSType, SVariable, SValue, VSFunction, MSStatement, MSParameter, SMethod, 
-  CSStateVar, SClass, FSModule, NamedArgs, Initializer, ProgramSym(..), FileSym(..), PermanenceSym(..), 
+  CSStateVar, SClass, FSModule, NamedArgs, Initializers, ProgramSym(..), FileSym(..), PermanenceSym(..), 
   BodySym(..), bodyStatements, oneLiner, BlockSym(..), ControlBlock(..), 
   listSlice, TypeSym(..), StatementSym(..), AssignStatement(..), (&=), 
   assignToListIndex, DeclStatement(..), IOStatement(..), StringStatement(..), FuncAppStatement(..),

--- a/code/drasil-gool/GOOL/Drasil/ClassInterface.hs
+++ b/code/drasil-gool/GOOL/Drasil/ClassInterface.hs
@@ -413,14 +413,14 @@ class (VariableSym repr, StatementSym repr) => StringStatement repr where
   stringListVals  :: [SVariable repr] -> SValue repr -> MSStatement repr
   stringListLists :: [SVariable repr] -> SValue repr -> MSStatement repr
 
+type InOutCall r = Label -> [SValue r] -> [SVariable r] -> [SVariable r] -> 
+  MSStatement r
+
 class (VariableSym repr, StatementSym repr) => FuncAppStatement repr where
   -- The three lists are inputs, outputs, and both, respectively
-  inOutCall :: Label -> [SValue repr] -> [SVariable repr] -> [SVariable repr] 
-    -> MSStatement repr
-  selfInOutCall :: Label -> [SValue repr] -> [SVariable repr] -> 
-    [SVariable repr] -> MSStatement repr
-  extInOutCall :: Library -> Label -> [SValue repr] -> [SVariable repr] -> 
-    [SVariable repr] -> MSStatement repr
+  inOutCall     ::            InOutCall repr
+  selfInOutCall ::            InOutCall repr
+  extInOutCall  :: Library -> InOutCall repr
 
 type Comment = String  
 
@@ -507,6 +507,17 @@ class ParameterSym repr where
 type SMethod a = MS (a (Method a))
 type Initializer r = (SVariable r, SValue r)
 
+-- The three lists are inputs, outputs, and both, respectively
+type InOutFunc r = Label -> r (Scope r) -> r (Permanence r) -> [SVariable r] -> 
+  [SVariable r] -> [SVariable r] -> MSBody r -> SMethod r
+-- Parameters are: function name, scope, permanence, brief description, 
+-- input descriptions and variables, output descriptions and variables, 
+-- descriptions and variables for parameters that are both input and output, 
+-- function body
+type DocInOutFunc r = Label -> r (Scope r) -> r (Permanence r) -> String -> 
+  [(String, SVariable r)] -> [(String, SVariable r)] -> [(String, SVariable r)] 
+  -> MSBody r -> SMethod r
+
 class (BodySym repr, ParameterSym repr, ScopeSym repr, PermanenceSym repr) => MethodSym repr where
   type Method repr
   method      :: Label -> repr (Scope repr) -> repr (Permanence repr) -> 
@@ -525,21 +536,10 @@ class (BodySym repr, ParameterSym repr, ScopeSym repr, PermanenceSym repr) => Me
   --   return value description if applicable, function
   docFunc :: String -> [String] -> Maybe String -> SMethod repr -> SMethod repr
 
-  inOutMethod :: Label -> repr (Scope repr) -> repr (Permanence repr) -> 
-    [SVariable repr] -> [SVariable repr] -> [SVariable repr] -> MSBody repr -> 
-    SMethod repr
-  docInOutMethod :: Label -> repr (Scope repr) -> repr (Permanence repr) -> 
-    String -> [(String, SVariable repr)] -> [(String, SVariable repr)] -> 
-    [(String, SVariable repr)] -> MSBody repr -> SMethod repr
-
-  -- The three lists are inputs, outputs, and both, respectively
-  inOutFunc :: Label -> repr (Scope repr) -> repr (Permanence repr) -> 
-    [SVariable repr] -> [SVariable repr] -> [SVariable repr] -> MSBody repr -> 
-    SMethod repr
-  -- Parameters are: function name, scope, permanence, brief description, input descriptions and variables, output descriptions and variables, descriptions and variables for parameters that are both input and output, function body
-  docInOutFunc :: Label -> repr (Scope repr) -> repr (Permanence repr) -> 
-    String -> [(String, SVariable repr)] -> [(String, SVariable repr)] -> 
-    [(String, SVariable repr)] -> MSBody repr -> SMethod repr
+  inOutMethod :: InOutFunc repr
+  docInOutMethod :: DocInOutFunc repr
+  inOutFunc :: InOutFunc repr
+  docInOutFunc :: DocInOutFunc repr
 
 privMethod :: (MethodSym repr) => Label -> VSType repr -> [MSParameter repr] -> 
   MSBody repr -> SMethod repr

--- a/code/drasil-gool/GOOL/Drasil/ClassInterface.hs
+++ b/code/drasil-gool/GOOL/Drasil/ClassInterface.hs
@@ -4,7 +4,7 @@ module GOOL.Drasil.ClassInterface (
   -- Types
   Label, Library, GSProgram, SFile, MSBody, MSBlock, VSType, SVariable, SValue, 
   VSFunction, MSStatement, MSParameter, SMethod, CSStateVar, SClass, FSModule,
-  NamedArgs, Initializer, MixedCall, MixedCtorCall, PosCall, PosCtorCall,
+  NamedArgs, Initializers, MixedCall, MixedCtorCall, PosCall, PosCtorCall,
   -- Typeclasses
   ProgramSym(..), FileSym(..), PermanenceSym(..), BodySym(..), bodyStatements, 
   oneLiner, BlockSym(..), TypeSym(..), ControlBlock(..), VariableSym(..), ($->), listOf, 
@@ -507,7 +507,7 @@ class ParameterSym r where
   pointerParam :: SVariable r -> MSParameter r
 
 type SMethod a = MS (a (Method a))
-type Initializer r = (SVariable r, SValue r)
+type Initializers r = [(SVariable r, SValue r)]
 
 -- The three lists are inputs, outputs, and both, respectively
 type InOutFunc r = Label -> r (Scope r) -> r (Permanence r) -> [SVariable r] -> 
@@ -526,7 +526,7 @@ class (BodySym r, ParameterSym r, ScopeSym r, PermanenceSym r) => MethodSym r wh
     VSType r -> [MSParameter r] -> MSBody r -> SMethod r
   getMethod   :: SVariable r -> SMethod r
   setMethod   :: SVariable r -> SMethod r 
-  constructor :: [MSParameter r] -> [Initializer r] -> MSBody r -> 
+  constructor :: [MSParameter r] -> Initializers r -> MSBody r -> 
     SMethod r
 
   docMain :: MSBody r -> SMethod r
@@ -551,7 +551,7 @@ pubMethod :: (MethodSym r) => Label -> VSType r -> [MSParameter r] ->
   MSBody r -> SMethod r
 pubMethod n = method n public dynamic
 
-initializer :: (MethodSym r) => [MSParameter r] -> [Initializer r] -> 
+initializer :: (MethodSym r) => [MSParameter r] -> Initializers r -> 
   SMethod r
 initializer ps is = constructor ps is (body [])
 

--- a/code/drasil-gool/GOOL/Drasil/ClassInterface.hs
+++ b/code/drasil-gool/GOOL/Drasil/ClassInterface.hs
@@ -34,188 +34,190 @@ type Library = String
 
 type GSProgram a = GS (a (Program a))
 
-class (FileSym repr) => ProgramSym repr where
-  type Program repr
-  prog :: Label -> [SFile repr] -> GSProgram repr
+-- In relation to GOOL, the type variable r can be considered as short for "representation"
+
+class (FileSym r) => ProgramSym r where
+  type Program r
+  prog :: Label -> [SFile r] -> GSProgram r
 
 type SFile a = FS (a (RenderFile a))
 
-class (ModuleSym repr, ControlBlock repr, AssignStatement repr, 
-  DeclStatement repr, IOStatement repr, StringStatement repr, FuncAppStatement repr,
-  CommentStatement repr, ControlStatement repr, InternalList repr, Literal repr, MathConstant repr, VariableValue repr, CommandLineArgs repr, NumericExpression repr, BooleanExpression repr, Comparison repr, 
-  ValueExpression repr, InternalValueExp repr, GetSet repr, List repr, 
-  Iterator repr, StatePattern repr, ObserverPattern repr, StrategyPattern repr) => 
-  FileSym repr where 
-  type RenderFile repr
-  fileDoc :: FSModule repr -> SFile repr
+class (ModuleSym r, ControlBlock r, AssignStatement r, 
+  DeclStatement r, IOStatement r, StringStatement r, FuncAppStatement r,
+  CommentStatement r, ControlStatement r, InternalList r, Literal r, MathConstant r, VariableValue r, CommandLineArgs r, NumericExpression r, BooleanExpression r, Comparison r, 
+  ValueExpression r, InternalValueExp r, GetSet r, List r, 
+  Iterator r, StatePattern r, ObserverPattern r, StrategyPattern r) => 
+  FileSym r where 
+  type RenderFile r
+  fileDoc :: FSModule r -> SFile r
 
   -- Module description, list of author names, date as a String, file to comment
-  docMod :: String -> [String] -> String -> SFile repr -> SFile repr
+  docMod :: String -> [String] -> String -> SFile r -> SFile r
 
-class PermanenceSym repr where
-  type Permanence repr
-  static  :: repr (Permanence repr)
-  dynamic :: repr (Permanence repr)
+class PermanenceSym r where
+  type Permanence r
+  static  :: r (Permanence r)
+  dynamic :: r (Permanence r)
 
 type MSBody a = MS (a (Body a))
 
-class (BlockSym repr) => BodySym repr where
-  type Body repr
-  body           :: [MSBlock repr] -> MSBody repr
+class (BlockSym r) => BodySym r where
+  type Body r
+  body           :: [MSBlock r] -> MSBody r
 
-  addComments :: Label -> MSBody repr -> MSBody repr
+  addComments :: Label -> MSBody r -> MSBody r
 
-bodyStatements :: (BodySym repr) => [MSStatement repr] -> MSBody repr
+bodyStatements :: (BodySym r) => [MSStatement r] -> MSBody r
 bodyStatements sts = body [block sts]
 
-oneLiner :: (BodySym repr) => MSStatement repr -> MSBody repr
+oneLiner :: (BodySym r) => MSStatement r -> MSBody r
 oneLiner s = bodyStatements [s]
 
 type MSBlock a = MS (a (Block a))
 
-class (StatementSym repr) => BlockSym repr where
-  type Block repr
-  block   :: [MSStatement repr] -> MSBlock repr
+class (StatementSym r) => BlockSym r where
+  type Block r
+  block   :: [MSStatement r] -> MSBlock r
 
 type VSType a = VS (a (Type a))
 
-class TypeSym repr where
-  type Type repr
-  bool          :: VSType repr
-  int           :: VSType repr -- This is 32-bit signed ints except in Python, 
+class TypeSym r where
+  type Type r
+  bool          :: VSType r
+  int           :: VSType r -- This is 32-bit signed ints except in Python, 
                                -- which has unlimited precision ints
-  float         :: VSType repr
-  double        :: VSType repr
-  char          :: VSType repr
-  string        :: VSType repr
-  infile        :: VSType repr
-  outfile       :: VSType repr
-  listType      :: VSType repr -> VSType repr
-  arrayType     :: VSType repr -> VSType repr
-  listInnerType :: VSType repr -> VSType repr
-  obj           :: ClassName -> VSType repr
-  funcType      :: [VSType repr] -> VSType repr -> VSType repr
-  iterator      :: VSType repr -> VSType repr
-  void          :: VSType repr
+  float         :: VSType r
+  double        :: VSType r
+  char          :: VSType r
+  string        :: VSType r
+  infile        :: VSType r
+  outfile       :: VSType r
+  listType      :: VSType r -> VSType r
+  arrayType     :: VSType r -> VSType r
+  listInnerType :: VSType r -> VSType r
+  obj           :: ClassName -> VSType r
+  funcType      :: [VSType r] -> VSType r -> VSType r
+  iterator      :: VSType r -> VSType r
+  void          :: VSType r
 
-  getType :: repr (Type repr) -> CodeType
-  getTypeString :: repr (Type repr) -> String
+  getType :: r (Type r) -> CodeType
+  getTypeString :: r (Type r) -> String
 
-class (BodySym repr) => ControlBlock repr where
-  solveODE :: ODEInfo repr -> ODEOptions repr -> MSBlock repr
+class (BodySym r) => ControlBlock r where
+  solveODE :: ODEInfo r -> ODEOptions r -> MSBlock r
 
 type SVariable a = VS (a (Variable a))
 
-class (TypeSym repr) => VariableSym repr where
-  type Variable repr
-  var          :: Label -> VSType repr -> SVariable repr
-  staticVar    :: Label -> VSType repr -> SVariable repr
-  const        :: Label -> VSType repr -> SVariable repr
-  extVar       :: Library -> Label -> VSType repr -> SVariable repr
-  self         :: SVariable repr
-  classVar     :: VSType repr -> SVariable repr -> SVariable repr
-  extClassVar  :: VSType repr -> SVariable repr -> SVariable repr
-  objVar       :: SVariable repr -> SVariable repr -> SVariable repr
-  objVarSelf   :: SVariable repr -> SVariable repr
-  listVar      :: Label -> VSType repr -> SVariable repr
-  arrayElem    :: Integer -> SVariable repr -> SVariable repr
+class (TypeSym r) => VariableSym r where
+  type Variable r
+  var          :: Label -> VSType r -> SVariable r
+  staticVar    :: Label -> VSType r -> SVariable r
+  const        :: Label -> VSType r -> SVariable r
+  extVar       :: Library -> Label -> VSType r -> SVariable r
+  self         :: SVariable r
+  classVar     :: VSType r -> SVariable r -> SVariable r
+  extClassVar  :: VSType r -> SVariable r -> SVariable r
+  objVar       :: SVariable r -> SVariable r -> SVariable r
+  objVarSelf   :: SVariable r -> SVariable r
+  listVar      :: Label -> VSType r -> SVariable r
+  arrayElem    :: Integer -> SVariable r -> SVariable r
   -- Use for iterator variables, i.e. in a forEach loop.
-  iterVar      :: Label -> VSType repr -> SVariable repr
+  iterVar      :: Label -> VSType r -> SVariable r
   
-  variableName :: repr (Variable repr) -> String
-  variableType :: repr (Variable repr) -> repr (Type repr)
+  variableName :: r (Variable r) -> String
+  variableType :: r (Variable r) -> r (Type r)
 
-($->) :: (VariableSym repr) => SVariable repr -> SVariable repr -> 
-  SVariable repr
+($->) :: (VariableSym r) => SVariable r -> SVariable r -> 
+  SVariable r
 infixl 9 $->
 ($->) = objVar
 
-listOf :: (VariableSym repr) => Label -> VSType repr -> SVariable repr
+listOf :: (VariableSym r) => Label -> VSType r -> SVariable r
 listOf = listVar
 
 type SValue a = VS (a (Value a))
 
-class (TypeSym repr) => ValueSym repr where
-  type Value repr
-  valueType :: repr (Value repr) -> repr (Type repr)
+class (TypeSym r) => ValueSym r where
+  type Value r
+  valueType :: r (Value r) -> r (Type r)
 
-class (ValueSym repr) => Literal repr where
-  litTrue   :: SValue repr
-  litFalse  :: SValue repr
-  litChar   :: Char -> SValue repr
-  litDouble :: Double -> SValue repr
-  litFloat  :: Float -> SValue repr
-  litInt    :: Integer -> SValue repr
-  litString :: String -> SValue repr
-  litArray  :: VSType repr -> [SValue repr] -> SValue repr
-  litList   :: VSType repr -> [SValue repr] -> SValue repr
+class (ValueSym r) => Literal r where
+  litTrue   :: SValue r
+  litFalse  :: SValue r
+  litChar   :: Char -> SValue r
+  litDouble :: Double -> SValue r
+  litFloat  :: Float -> SValue r
+  litInt    :: Integer -> SValue r
+  litString :: String -> SValue r
+  litArray  :: VSType r -> [SValue r] -> SValue r
+  litList   :: VSType r -> [SValue r] -> SValue r
 
-class (ValueSym repr) => MathConstant repr where
-  pi :: SValue repr
+class (ValueSym r) => MathConstant r where
+  pi :: SValue r
 
-class (VariableSym repr, ValueSym repr) => VariableValue repr where
-  valueOf       :: SVariable repr -> SValue repr
+class (VariableSym r, ValueSym r) => VariableValue r where
+  valueOf       :: SVariable r -> SValue r
 
-class (ValueSym repr) => CommandLineArgs repr where
-  arg          :: Integer -> SValue repr
-  argsList     :: SValue repr
-  argExists    :: Integer -> SValue repr
+class (ValueSym r) => CommandLineArgs r where
+  arg          :: Integer -> SValue r
+  argsList     :: SValue r
+  argExists    :: Integer -> SValue r
 
-class (ValueSym repr) => NumericExpression repr where
-  (#~)  :: SValue repr -> SValue repr
+class (ValueSym r) => NumericExpression r where
+  (#~)  :: SValue r -> SValue r
   infixl 8 #~
-  (#/^) :: SValue repr -> SValue repr
+  (#/^) :: SValue r -> SValue r
   infixl 7 #/^
-  (#|)  :: SValue repr -> SValue repr
+  (#|)  :: SValue r -> SValue r
   infixl 7 #|
-  (#+)  :: SValue repr -> SValue repr -> SValue repr
+  (#+)  :: SValue r -> SValue r -> SValue r
   infixl 5 #+
-  (#-)  :: SValue repr -> SValue repr -> SValue repr
+  (#-)  :: SValue r -> SValue r -> SValue r
   infixl 5 #-
-  (#*)  :: SValue repr -> SValue repr -> SValue repr
+  (#*)  :: SValue r -> SValue r -> SValue r
   infixl 6 #*
-  (#/)  :: SValue repr -> SValue repr -> SValue repr
+  (#/)  :: SValue r -> SValue r -> SValue r
   infixl 6 #/
-  (#%)  :: SValue repr -> SValue repr -> SValue repr
+  (#%)  :: SValue r -> SValue r -> SValue r
   infixl 6 #%
-  (#^)  :: SValue repr -> SValue repr -> SValue repr
+  (#^)  :: SValue r -> SValue r -> SValue r
   infixl 7 #^
 
-  log    :: SValue repr -> SValue repr
-  ln     :: SValue repr -> SValue repr
-  exp    :: SValue repr -> SValue repr
-  sin    :: SValue repr -> SValue repr
-  cos    :: SValue repr -> SValue repr
-  tan    :: SValue repr -> SValue repr
-  csc    :: SValue repr -> SValue repr
-  sec    :: SValue repr -> SValue repr
-  cot    :: SValue repr -> SValue repr
-  arcsin :: SValue repr -> SValue repr
-  arccos :: SValue repr -> SValue repr
-  arctan :: SValue repr -> SValue repr
-  floor  :: SValue repr -> SValue repr
-  ceil   :: SValue repr -> SValue repr
+  log    :: SValue r -> SValue r
+  ln     :: SValue r -> SValue r
+  exp    :: SValue r -> SValue r
+  sin    :: SValue r -> SValue r
+  cos    :: SValue r -> SValue r
+  tan    :: SValue r -> SValue r
+  csc    :: SValue r -> SValue r
+  sec    :: SValue r -> SValue r
+  cot    :: SValue r -> SValue r
+  arcsin :: SValue r -> SValue r
+  arccos :: SValue r -> SValue r
+  arctan :: SValue r -> SValue r
+  floor  :: SValue r -> SValue r
+  ceil   :: SValue r -> SValue r
 
-class (ValueSym repr) => BooleanExpression repr where
-  (?!)  :: SValue repr -> SValue repr
+class (ValueSym r) => BooleanExpression r where
+  (?!)  :: SValue r -> SValue r
   infixr 6 ?!
-  (?&&) :: SValue repr -> SValue repr -> SValue repr
+  (?&&) :: SValue r -> SValue r -> SValue r
   infixl 2 ?&&
-  (?||) :: SValue repr -> SValue repr -> SValue repr
+  (?||) :: SValue r -> SValue r -> SValue r
   infixl 1 ?||
 
-class (ValueSym repr) => Comparison repr where
-  (?<)  :: SValue repr -> SValue repr -> SValue repr
+class (ValueSym r) => Comparison r where
+  (?<)  :: SValue r -> SValue r -> SValue r
   infixl 4 ?<
-  (?<=) :: SValue repr -> SValue repr -> SValue repr
+  (?<=) :: SValue r -> SValue r -> SValue r
   infixl 4 ?<=
-  (?>)  :: SValue repr -> SValue repr -> SValue repr
+  (?>)  :: SValue r -> SValue r -> SValue r
   infixl 4 ?>
-  (?>=) :: SValue repr -> SValue repr -> SValue repr
+  (?>=) :: SValue r -> SValue r -> SValue r
   infixl 4 ?>=
-  (?==) :: SValue repr -> SValue repr -> SValue repr
+  (?==) :: SValue r -> SValue r -> SValue r
   infixl 3 ?==
-  (?!=) :: SValue repr -> SValue repr -> SValue repr
+  (?!=) :: SValue r -> SValue r -> SValue r
   infixl 3 ?!=
 
 type NamedArg r = (SVariable r, SValue r)
@@ -229,280 +231,280 @@ type PosCall r = Label -> VSType r -> [SValue r] -> SValue r
 type PosCtorCall r = VSType r -> [SValue r] -> SValue r
 
 -- for values that can include expressions
-class ValueExpression repr where
-  inlineIf     :: SValue repr -> SValue repr -> SValue repr -> SValue repr
+class ValueExpression r where
+  inlineIf     :: SValue r -> SValue r -> SValue r -> SValue r
   
-  funcAppMixedArgs     ::            MixedCall repr
-  selfFuncAppMixedArgs ::            MixedCall repr
-  extFuncAppMixedArgs  :: Library -> MixedCall repr
-  libFuncAppMixedArgs  :: Library -> MixedCall repr
-  newObjMixedArgs      ::            MixedCtorCall repr
-  extNewObjMixedArgs   :: Library -> MixedCtorCall repr
-  libNewObjMixedArgs   :: Library -> MixedCtorCall repr
+  funcAppMixedArgs     ::            MixedCall r
+  selfFuncAppMixedArgs ::            MixedCall r
+  extFuncAppMixedArgs  :: Library -> MixedCall r
+  libFuncAppMixedArgs  :: Library -> MixedCall r
+  newObjMixedArgs      ::            MixedCtorCall r
+  extNewObjMixedArgs   :: Library -> MixedCtorCall r
+  libNewObjMixedArgs   :: Library -> MixedCtorCall r
 
-  lambda :: [SVariable repr] -> SValue repr -> SValue repr
+  lambda :: [SVariable r] -> SValue r -> SValue r
 
-  notNull :: SValue repr -> SValue repr
+  notNull :: SValue r -> SValue r
 
-funcApp          :: (ValueExpression repr) =>            PosCall repr
+funcApp          :: (ValueExpression r) =>            PosCall r
 funcApp n t vs = funcAppMixedArgs n t vs []
 
-funcAppNamedArgs :: (ValueExpression repr) =>            Label -> VSType repr ->
-  [NamedArg repr] -> SValue repr
+funcAppNamedArgs :: (ValueExpression r) =>            Label -> VSType r ->
+  [NamedArg r] -> SValue r
 funcAppNamedArgs n t = funcAppMixedArgs n t []
 
-selfFuncApp      :: (ValueExpression repr) =>            PosCall repr
+selfFuncApp      :: (ValueExpression r) =>            PosCall r
 selfFuncApp n t vs = selfFuncAppMixedArgs n t vs []
 
-extFuncApp       :: (ValueExpression repr) => Library -> PosCall repr
+extFuncApp       :: (ValueExpression r) => Library -> PosCall r
 extFuncApp l n t vs = extFuncAppMixedArgs l n t vs []
 
-libFuncApp       :: (ValueExpression repr) => Library -> PosCall repr
+libFuncApp       :: (ValueExpression r) => Library -> PosCall r
 libFuncApp l n t vs = libFuncAppMixedArgs l n t vs []
 
-newObj           :: (ValueExpression repr) =>            PosCtorCall repr
+newObj           :: (ValueExpression r) =>            PosCtorCall r
 newObj t vs = newObjMixedArgs t vs []
 
-extNewObj        :: (ValueExpression repr) => Library -> PosCtorCall repr
+extNewObj        :: (ValueExpression r) => Library -> PosCtorCall r
 extNewObj l t vs = extNewObjMixedArgs l t vs []
 
-libNewObj        :: (ValueExpression repr) => Library -> PosCtorCall repr
+libNewObj        :: (ValueExpression r) => Library -> PosCtorCall r
 libNewObj l t vs = libNewObjMixedArgs l t vs []
 
-exists :: (ValueExpression repr) => SValue repr -> SValue repr
+exists :: (ValueExpression r) => SValue r -> SValue r
 exists = notNull
 
-class (FunctionSym repr) => InternalValueExp repr where
-  objMethodCallMixedArgs' :: Label -> VSType repr -> SValue repr -> 
-    [SValue repr] -> [NamedArg repr] -> SValue repr
-  objMethodCallNoParams' :: Label -> VSType repr -> SValue repr -> SValue repr
+class (FunctionSym r) => InternalValueExp r where
+  objMethodCallMixedArgs' :: Label -> VSType r -> SValue r -> 
+    [SValue r] -> [NamedArg r] -> SValue r
+  objMethodCallNoParams' :: Label -> VSType r -> SValue r -> SValue r
 
-objMethodCall :: (InternalValueExp repr) => VSType repr -> SValue repr -> Label 
-  -> [SValue repr] -> SValue repr
+objMethodCall :: (InternalValueExp r) => VSType r -> SValue r -> Label 
+  -> [SValue r] -> SValue r
 objMethodCall t o f ps = objMethodCallMixedArgs' f t o ps []
 
-objMethodCallMixedArgs :: (InternalValueExp repr) => VSType repr -> SValue repr 
-  -> Label -> [SValue repr] -> [NamedArg repr] -> SValue repr
+objMethodCallMixedArgs :: (InternalValueExp r) => VSType r -> SValue r 
+  -> Label -> [SValue r] -> [NamedArg r] -> SValue r
 objMethodCallMixedArgs t o f = objMethodCallMixedArgs' f t o
 
-objMethodCallNoParams :: (InternalValueExp repr) => VSType repr -> SValue repr 
-  -> Label -> SValue repr
+objMethodCallNoParams :: (InternalValueExp r) => VSType r -> SValue r 
+  -> Label -> SValue r
 objMethodCallNoParams t o f = objMethodCallNoParams' f t o
 
 type VSFunction a = VS (a (Function a))
 
-class (ValueSym repr) => FunctionSym repr where
-  type Function repr
-  func :: Label -> VSType repr -> [SValue repr] -> VSFunction repr
-  objAccess :: SValue repr -> VSFunction repr -> SValue repr
+class (ValueSym r) => FunctionSym r where
+  type Function r
+  func :: Label -> VSType r -> [SValue r] -> VSFunction r
+  objAccess :: SValue r -> VSFunction r -> SValue r
 
-($.) :: (FunctionSym repr) => SValue repr -> VSFunction repr -> SValue repr
+($.) :: (FunctionSym r) => SValue r -> VSFunction r -> SValue r
 infixl 9 $.
 ($.) = objAccess
 
-selfAccess :: (VariableValue repr, FunctionSym repr) => VSFunction repr -> 
-  SValue repr
+selfAccess :: (VariableValue r, FunctionSym r) => VSFunction r -> 
+  SValue r
 selfAccess = objAccess (valueOf self)
 
-class (ValueSym repr, VariableSym repr) => GetSet repr where
-  get :: SValue repr -> SVariable repr -> SValue repr
-  set :: SValue repr -> SVariable repr -> SValue repr -> SValue repr
+class (ValueSym r, VariableSym r) => GetSet r where
+  get :: SValue r -> SVariable r -> SValue r
+  set :: SValue r -> SVariable r -> SValue r -> SValue r
 
-class (ValueSym repr) => List repr where
-  listSize   :: SValue repr -> SValue repr
-  listAdd    :: SValue repr -> SValue repr -> SValue repr -> SValue repr
-  listAppend :: SValue repr -> SValue repr -> SValue repr
-  listAccess :: SValue repr -> SValue repr -> SValue repr
-  listSet    :: SValue repr -> SValue repr -> SValue repr -> SValue repr
+class (ValueSym r) => List r where
+  listSize   :: SValue r -> SValue r
+  listAdd    :: SValue r -> SValue r -> SValue r -> SValue r
+  listAppend :: SValue r -> SValue r -> SValue r
+  listAccess :: SValue r -> SValue r -> SValue r
+  listSet    :: SValue r -> SValue r -> SValue r -> SValue r
   
-  indexOf :: SValue repr -> SValue repr -> SValue repr
+  indexOf :: SValue r -> SValue r -> SValue r
 
-class (ValueSym repr) => InternalList repr where
-  listSlice'      :: Maybe (SValue repr) -> Maybe (SValue repr) -> 
-    Maybe (SValue repr) -> SVariable repr -> SValue repr -> MSBlock repr
+class (ValueSym r) => InternalList r where
+  listSlice'      :: Maybe (SValue r) -> Maybe (SValue r) -> 
+    Maybe (SValue r) -> SVariable r -> SValue r -> MSBlock r
   
-listSlice :: (InternalList repr) => SVariable repr -> SValue repr -> 
-  Maybe (SValue repr) -> Maybe (SValue repr) -> Maybe (SValue repr) -> 
-  MSBlock repr
+listSlice :: (InternalList r) => SVariable r -> SValue r -> 
+  Maybe (SValue r) -> Maybe (SValue r) -> Maybe (SValue r) -> 
+  MSBlock r
 listSlice vnew vold b e s = listSlice' b e s vnew vold
 
-listIndexExists :: (List repr, Comparison repr) => SValue repr -> SValue repr 
-  -> SValue repr
+listIndexExists :: (List r, Comparison r) => SValue r -> SValue r 
+  -> SValue r
 listIndexExists lst index = listSize lst ?> index
 
-at :: (List repr) => SValue repr -> SValue repr -> SValue repr
+at :: (List r) => SValue r -> SValue r -> SValue r
 at = listAccess
 
-class (ValueSym repr) => Iterator repr where
-  iterBegin :: SValue repr -> SValue repr
-  iterEnd   :: SValue repr -> SValue repr
+class (ValueSym r) => Iterator r where
+  iterBegin :: SValue r -> SValue r
+  iterEnd   :: SValue r -> SValue r
 
 type MSStatement a = MS (a (Statement a))
 
-class (ValueSym repr) => StatementSym repr where
-  type Statement repr
-  valState :: SValue repr -> MSStatement repr -- converts value to statement
-  multi     :: [MSStatement repr] -> MSStatement repr
+class (ValueSym r) => StatementSym r where
+  type Statement r
+  valState :: SValue r -> MSStatement r -- converts value to statement
+  multi     :: [MSStatement r] -> MSStatement r
 
-class (VariableSym repr, StatementSym repr) => AssignStatement repr where
-  (&-=)  :: SVariable repr -> SValue repr -> MSStatement repr
+class (VariableSym r, StatementSym r) => AssignStatement r where
+  (&-=)  :: SVariable r -> SValue r -> MSStatement r
   infixl 1 &-=
-  (&+=)  :: SVariable repr -> SValue repr -> MSStatement repr
+  (&+=)  :: SVariable r -> SValue r -> MSStatement r
   infixl 1 &+=
-  (&++)  :: SVariable repr -> MSStatement repr
+  (&++)  :: SVariable r -> MSStatement r
   infixl 8 &++
-  (&--)  :: SVariable repr -> MSStatement repr
+  (&--)  :: SVariable r -> MSStatement r
   infixl 8 &--
 
-  assign :: SVariable repr -> SValue repr -> MSStatement repr
+  assign :: SVariable r -> SValue r -> MSStatement r
 
-(&=) :: (AssignStatement repr) => SVariable repr -> SValue repr -> 
-  MSStatement repr
+(&=) :: (AssignStatement r) => SVariable r -> SValue r -> 
+  MSStatement r
 infixr 1 &=
 (&=) = assign
 
-assignToListIndex :: (StatementSym repr, VariableValue repr, List repr) => 
-  SVariable repr -> SValue repr -> SValue repr -> MSStatement repr
+assignToListIndex :: (StatementSym r, VariableValue r, List r) => 
+  SVariable r -> SValue r -> SValue r -> MSStatement r
 assignToListIndex lst index v = valState $ listSet (valueOf lst) index v
 
-class (VariableSym repr, StatementSym repr) => DeclStatement repr where
-  varDec           :: SVariable repr -> MSStatement repr
-  varDecDef        :: SVariable repr -> SValue repr -> MSStatement repr
-  listDec          :: Integer -> SVariable repr -> MSStatement repr
-  listDecDef       :: SVariable repr -> [SValue repr] -> MSStatement repr
-  arrayDec         :: Integer -> SVariable repr -> MSStatement repr
-  arrayDecDef      :: SVariable repr -> [SValue repr] -> MSStatement repr
-  objDecDef        :: SVariable repr -> SValue repr -> MSStatement repr
-  objDecNew        :: SVariable repr -> [SValue repr] -> MSStatement repr
-  extObjDecNew     :: Library -> SVariable repr -> [SValue repr] -> 
-    MSStatement repr
-  objDecNewNoParams    :: SVariable repr -> MSStatement repr
-  extObjDecNewNoParams :: Library -> SVariable repr -> MSStatement repr
-  constDecDef      :: SVariable repr -> SValue repr -> MSStatement repr
-  funcDecDef       :: SVariable repr -> [SVariable repr] -> SValue repr -> 
-    MSStatement repr
+class (VariableSym r, StatementSym r) => DeclStatement r where
+  varDec           :: SVariable r -> MSStatement r
+  varDecDef        :: SVariable r -> SValue r -> MSStatement r
+  listDec          :: Integer -> SVariable r -> MSStatement r
+  listDecDef       :: SVariable r -> [SValue r] -> MSStatement r
+  arrayDec         :: Integer -> SVariable r -> MSStatement r
+  arrayDecDef      :: SVariable r -> [SValue r] -> MSStatement r
+  objDecDef        :: SVariable r -> SValue r -> MSStatement r
+  objDecNew        :: SVariable r -> [SValue r] -> MSStatement r
+  extObjDecNew     :: Library -> SVariable r -> [SValue r] -> 
+    MSStatement r
+  objDecNewNoParams    :: SVariable r -> MSStatement r
+  extObjDecNewNoParams :: Library -> SVariable r -> MSStatement r
+  constDecDef      :: SVariable r -> SValue r -> MSStatement r
+  funcDecDef       :: SVariable r -> [SVariable r] -> SValue r -> 
+    MSStatement r
 
-class (VariableSym repr, StatementSym repr) => IOStatement repr where
-  print      :: SValue repr -> MSStatement repr
-  printLn    :: SValue repr -> MSStatement repr
-  printStr   :: String -> MSStatement repr
-  printStrLn :: String -> MSStatement repr
+class (VariableSym r, StatementSym r) => IOStatement r where
+  print      :: SValue r -> MSStatement r
+  printLn    :: SValue r -> MSStatement r
+  printStr   :: String -> MSStatement r
+  printStrLn :: String -> MSStatement r
 
-  printFile      :: SValue repr -> SValue repr -> MSStatement repr
-  printFileLn    :: SValue repr -> SValue repr -> MSStatement repr
-  printFileStr   :: SValue repr -> String -> MSStatement repr
-  printFileStrLn :: SValue repr -> String -> MSStatement repr
+  printFile      :: SValue r -> SValue r -> MSStatement r
+  printFileLn    :: SValue r -> SValue r -> MSStatement r
+  printFileStr   :: SValue r -> String -> MSStatement r
+  printFileStrLn :: SValue r -> String -> MSStatement r
 
-  getInput         :: SVariable repr -> MSStatement repr
-  discardInput     :: MSStatement repr
-  getFileInput     :: SValue repr -> SVariable repr -> MSStatement repr
-  discardFileInput :: SValue repr -> MSStatement repr
+  getInput         :: SVariable r -> MSStatement r
+  discardInput     :: MSStatement r
+  getFileInput     :: SValue r -> SVariable r -> MSStatement r
+  discardFileInput :: SValue r -> MSStatement r
 
-  openFileR :: SVariable repr -> SValue repr -> MSStatement repr
-  openFileW :: SVariable repr -> SValue repr -> MSStatement repr
-  openFileA :: SVariable repr -> SValue repr -> MSStatement repr
-  closeFile :: SValue repr -> MSStatement repr
+  openFileR :: SVariable r -> SValue r -> MSStatement r
+  openFileW :: SVariable r -> SValue r -> MSStatement r
+  openFileA :: SVariable r -> SValue r -> MSStatement r
+  closeFile :: SValue r -> MSStatement r
 
-  getFileInputLine :: SValue repr -> SVariable repr -> MSStatement repr
-  discardFileLine  :: SValue repr -> MSStatement repr
-  getFileInputAll  :: SValue repr -> SVariable repr -> MSStatement repr
+  getFileInputLine :: SValue r -> SVariable r -> MSStatement r
+  discardFileLine  :: SValue r -> MSStatement r
+  getFileInputAll  :: SValue r -> SVariable r -> MSStatement r
 
-class (VariableSym repr, StatementSym repr) => StringStatement repr where
-  stringSplit :: Char -> SVariable repr -> SValue repr -> MSStatement repr
+class (VariableSym r, StatementSym r) => StringStatement r where
+  stringSplit :: Char -> SVariable r -> SValue r -> MSStatement r
 
-  stringListVals  :: [SVariable repr] -> SValue repr -> MSStatement repr
-  stringListLists :: [SVariable repr] -> SValue repr -> MSStatement repr
+  stringListVals  :: [SVariable r] -> SValue r -> MSStatement r
+  stringListLists :: [SVariable r] -> SValue r -> MSStatement r
 
 type InOutCall r = Label -> [SValue r] -> [SVariable r] -> [SVariable r] -> 
   MSStatement r
 
-class (VariableSym repr, StatementSym repr) => FuncAppStatement repr where
+class (VariableSym r, StatementSym r) => FuncAppStatement r where
   -- The three lists are inputs, outputs, and both, respectively
-  inOutCall     ::            InOutCall repr
-  selfInOutCall ::            InOutCall repr
-  extInOutCall  :: Library -> InOutCall repr
+  inOutCall     ::            InOutCall r
+  selfInOutCall ::            InOutCall r
+  extInOutCall  :: Library -> InOutCall r
 
 type Comment = String  
 
-class (StatementSym repr) => CommentStatement repr where
-  comment :: Comment -> MSStatement repr
+class (StatementSym r) => CommentStatement r where
+  comment :: Comment -> MSStatement r
 
-class (BodySym repr) => ControlStatement repr where
-  break :: MSStatement repr
-  continue :: MSStatement repr
+class (BodySym r) => ControlStatement r where
+  break :: MSStatement r
+  continue :: MSStatement r
 
-  returnState :: SValue repr -> MSStatement repr
+  returnState :: SValue r -> MSStatement r
 
-  throw :: Label -> MSStatement repr
+  throw :: Label -> MSStatement r
 
-  ifCond     :: [(SValue repr, MSBody repr)] -> MSBody repr -> MSStatement repr
-  switch     :: SValue repr -> [(SValue repr, MSBody repr)] -> MSBody repr -> 
-    MSStatement repr -- is there value in separating Literals into their own type?
+  ifCond     :: [(SValue r, MSBody r)] -> MSBody r -> MSStatement r
+  switch     :: SValue r -> [(SValue r, MSBody r)] -> MSBody r -> 
+    MSStatement r -- is there value in separating Literals into their own type?
 
-  ifExists :: SValue repr -> MSBody repr -> MSBody repr -> MSStatement repr
+  ifExists :: SValue r -> MSBody r -> MSBody r -> MSStatement r
 
-  for      :: MSStatement repr -> SValue repr -> MSStatement repr -> 
-    MSBody repr -> MSStatement repr
-  forRange :: SVariable repr -> SValue repr -> SValue repr -> SValue repr ->
-    MSBody repr -> MSStatement repr
-  forEach  :: SVariable repr -> SValue repr -> MSBody repr -> MSStatement repr
-  while    :: SValue repr -> MSBody repr -> MSStatement repr 
+  for      :: MSStatement r -> SValue r -> MSStatement r -> 
+    MSBody r -> MSStatement r
+  forRange :: SVariable r -> SValue r -> SValue r -> SValue r ->
+    MSBody r -> MSStatement r
+  forEach  :: SVariable r -> SValue r -> MSBody r -> MSStatement r
+  while    :: SValue r -> MSBody r -> MSStatement r 
 
-  tryCatch :: MSBody repr -> MSBody repr -> MSStatement repr
+  tryCatch :: MSBody r -> MSBody r -> MSStatement r
 
-ifNoElse :: (ControlStatement repr) => [(SValue repr, MSBody repr)] 
-  -> MSStatement repr
+ifNoElse :: (ControlStatement r) => [(SValue r, MSBody r)] 
+  -> MSStatement r
 ifNoElse bs = ifCond bs $ body []
 
-switchAsIf :: (ControlStatement repr, Comparison repr) => SValue repr -> 
-  [(SValue repr, MSBody repr)] -> MSBody repr -> MSStatement repr
+switchAsIf :: (ControlStatement r, Comparison r) => SValue r -> 
+  [(SValue r, MSBody r)] -> MSBody r -> MSStatement r
 switchAsIf v = ifCond . map (first (v ?==))
 
-class (BodySym repr) => StatePattern repr where
-  checkState      :: Label -> [(SValue repr, MSBody repr)] -> MSBody repr -> 
-    MSStatement repr
+class (BodySym r) => StatePattern r where
+  checkState      :: Label -> [(SValue r, MSBody r)] -> MSBody r -> 
+    MSStatement r
 
-initState :: (DeclStatement repr, Literal repr) => Label -> Label -> 
-  MSStatement repr
+initState :: (DeclStatement r, Literal r) => Label -> Label -> 
+  MSStatement r
 initState fsmName initialState = varDecDef (var fsmName string) 
   (litString initialState)
 
-changeState :: (AssignStatement repr, Literal repr) => Label -> Label -> 
-  MSStatement repr
+changeState :: (AssignStatement r, Literal r) => Label -> Label -> 
+  MSStatement r
 changeState fsmName toState = var fsmName string &= litString toState
 
-class (StatementSym repr, FunctionSym repr) => ObserverPattern repr where
-  notifyObservers :: VSFunction repr -> VSType repr -> MSStatement repr
+class (StatementSym r, FunctionSym r) => ObserverPattern r where
+  notifyObservers :: VSFunction r -> VSType r -> MSStatement r
 
 observerListName :: Label
 observerListName = "observerList"
 
-initObserverList :: (DeclStatement repr) => VSType repr -> [SValue repr] -> 
-  MSStatement repr
+initObserverList :: (DeclStatement r) => VSType r -> [SValue r] -> 
+  MSStatement r
 initObserverList t = listDecDef (var observerListName (listType t))
 
-addObserver :: (StatementSym repr, VariableValue repr, List repr) => 
-  SValue repr -> MSStatement repr
+addObserver :: (StatementSym r, VariableValue r, List r) => 
+  SValue r -> MSStatement r
 addObserver o = valState $ listAdd obsList lastelem o
   where obsList = valueOf $ observerListName `listOf` onStateValue valueType o
         lastelem = listSize obsList
 
-class (BodySym repr, VariableSym repr) => StrategyPattern repr where
-  runStrategy     :: Label -> [(Label, MSBody repr)] -> Maybe (SValue repr) -> 
-    Maybe (SVariable repr) -> MSBlock repr
+class (BodySym r, VariableSym r) => StrategyPattern r where
+  runStrategy     :: Label -> [(Label, MSBody r)] -> Maybe (SValue r) -> 
+    Maybe (SVariable r) -> MSBlock r
 
-class ScopeSym repr where
-  type Scope repr
-  private :: repr (Scope repr)
-  public  :: repr (Scope repr)
+class ScopeSym r where
+  type Scope r
+  private :: r (Scope r)
+  public  :: r (Scope r)
 
 type MSParameter a = MS (a (Parameter a))
 
-class ParameterSym repr where
-  type Parameter repr
-  param :: SVariable repr -> MSParameter repr
-  -- funcParam  :: Label -> repr (MethodType repr) -> [repr (Parameter repr)] -> repr (Parameter repr) -- not implemented in GOOL
-  pointerParam :: SVariable repr -> MSParameter repr
+class ParameterSym r where
+  type Parameter r
+  param :: SVariable r -> MSParameter r
+  -- funcParam  :: Label -> r (MethodType r) -> [r (Parameter r)] -> r (Parameter r) -- not implemented in GOOL
+  pointerParam :: SVariable r -> MSParameter r
 
 type SMethod a = MS (a (Method a))
 type Initializer r = (SVariable r, SValue r)
@@ -518,120 +520,120 @@ type DocInOutFunc r = Label -> r (Scope r) -> r (Permanence r) -> String ->
   [(String, SVariable r)] -> [(String, SVariable r)] -> [(String, SVariable r)] 
   -> MSBody r -> SMethod r
 
-class (BodySym repr, ParameterSym repr, ScopeSym repr, PermanenceSym repr) => MethodSym repr where
-  type Method repr
-  method      :: Label -> repr (Scope repr) -> repr (Permanence repr) -> 
-    VSType repr -> [MSParameter repr] -> MSBody repr -> SMethod repr
-  getMethod   :: SVariable repr -> SMethod repr
-  setMethod   :: SVariable repr -> SMethod repr 
-  constructor :: [MSParameter repr] -> [Initializer repr] -> MSBody repr -> 
-    SMethod repr
+class (BodySym r, ParameterSym r, ScopeSym r, PermanenceSym r) => MethodSym r where
+  type Method r
+  method      :: Label -> r (Scope r) -> r (Permanence r) -> 
+    VSType r -> [MSParameter r] -> MSBody r -> SMethod r
+  getMethod   :: SVariable r -> SMethod r
+  setMethod   :: SVariable r -> SMethod r 
+  constructor :: [MSParameter r] -> [Initializer r] -> MSBody r -> 
+    SMethod r
 
-  docMain :: MSBody repr -> SMethod repr
+  docMain :: MSBody r -> SMethod r
 
-  function :: Label -> repr (Scope repr) -> repr (Permanence repr) -> 
-    VSType repr -> [MSParameter repr] -> MSBody repr -> SMethod repr
-  mainFunction  :: MSBody repr -> SMethod repr
+  function :: Label -> r (Scope r) -> r (Permanence r) -> 
+    VSType r -> [MSParameter r] -> MSBody r -> SMethod r
+  mainFunction  :: MSBody r -> SMethod r
   -- Parameters are: function description, parameter descriptions, 
   --   return value description if applicable, function
-  docFunc :: String -> [String] -> Maybe String -> SMethod repr -> SMethod repr
+  docFunc :: String -> [String] -> Maybe String -> SMethod r -> SMethod r
 
-  inOutMethod :: InOutFunc repr
-  docInOutMethod :: DocInOutFunc repr
-  inOutFunc :: InOutFunc repr
-  docInOutFunc :: DocInOutFunc repr
+  inOutMethod :: InOutFunc r
+  docInOutMethod :: DocInOutFunc r
+  inOutFunc :: InOutFunc r
+  docInOutFunc :: DocInOutFunc r
 
-privMethod :: (MethodSym repr) => Label -> VSType repr -> [MSParameter repr] -> 
-  MSBody repr -> SMethod repr
+privMethod :: (MethodSym r) => Label -> VSType r -> [MSParameter r] -> 
+  MSBody r -> SMethod r
 privMethod n = method n private dynamic
 
-pubMethod :: (MethodSym repr) => Label -> VSType repr -> [MSParameter repr] -> 
-  MSBody repr -> SMethod repr
+pubMethod :: (MethodSym r) => Label -> VSType r -> [MSParameter r] -> 
+  MSBody r -> SMethod r
 pubMethod n = method n public dynamic
 
-initializer :: (MethodSym repr) => [MSParameter repr] -> [Initializer repr] -> 
-  SMethod repr
+initializer :: (MethodSym r) => [MSParameter r] -> [Initializer r] -> 
+  SMethod r
 initializer ps is = constructor ps is (body [])
 
-nonInitConstructor :: (MethodSym repr) => [MSParameter repr] -> MSBody repr -> 
-  SMethod repr
+nonInitConstructor :: (MethodSym r) => [MSParameter r] -> MSBody r -> 
+  SMethod r
 nonInitConstructor ps = constructor ps []
 
 type CSStateVar a = CS (a (StateVar a))
 
-class (ScopeSym repr, PermanenceSym repr) => StateVarSym repr where
-  type StateVar repr
-  stateVar :: repr (Scope repr) -> repr (Permanence repr) -> SVariable repr -> 
-    CSStateVar repr
-  stateVarDef :: Label -> repr (Scope repr) -> repr (Permanence repr) ->
-    SVariable repr -> SValue repr -> CSStateVar repr
-  constVar :: Label -> repr (Scope repr) ->  SVariable repr -> SValue repr -> 
-    CSStateVar repr
+class (ScopeSym r, PermanenceSym r) => StateVarSym r where
+  type StateVar r
+  stateVar :: r (Scope r) -> r (Permanence r) -> SVariable r -> 
+    CSStateVar r
+  stateVarDef :: Label -> r (Scope r) -> r (Permanence r) ->
+    SVariable r -> SValue r -> CSStateVar r
+  constVar :: Label -> r (Scope r) ->  SVariable r -> SValue r -> 
+    CSStateVar r
 
-privDVar :: (StateVarSym repr) => SVariable repr -> CSStateVar repr
+privDVar :: (StateVarSym r) => SVariable r -> CSStateVar r
 privDVar = stateVar private dynamic
 
-pubDVar :: (StateVarSym repr) => SVariable repr -> CSStateVar repr
+pubDVar :: (StateVarSym r) => SVariable r -> CSStateVar r
 pubDVar = stateVar public dynamic
 
-pubSVar :: (StateVarSym repr) => SVariable repr -> CSStateVar repr
+pubSVar :: (StateVarSym r) => SVariable r -> CSStateVar r
 pubSVar = stateVar public static
 
 type SClass a = CS (a (Class a))
 
-class (MethodSym repr, StateVarSym repr) => ClassSym repr where
-  type Class repr
-  buildClass :: Label -> Maybe Label -> [CSStateVar repr] -> [SMethod repr] -> 
-    SClass repr
-  -- enum :: Label -> [Label] -> repr (Scope repr) -> SClass repr
-  extraClass :: Label -> Maybe Label -> [CSStateVar repr] -> [SMethod repr] -> 
-    SClass repr
-  implementingClass :: Label -> [Label] -> [CSStateVar repr] -> [SMethod repr] 
-    -> SClass repr
+class (MethodSym r, StateVarSym r) => ClassSym r where
+  type Class r
+  buildClass :: Label -> Maybe Label -> [CSStateVar r] -> [SMethod r] -> 
+    SClass r
+  -- enum :: Label -> [Label] -> r (Scope r) -> SClass r
+  extraClass :: Label -> Maybe Label -> [CSStateVar r] -> [SMethod r] -> 
+    SClass r
+  implementingClass :: Label -> [Label] -> [CSStateVar r] -> [SMethod r] 
+    -> SClass r
 
-  docClass :: String -> SClass repr -> SClass repr
+  docClass :: String -> SClass r -> SClass r
 
 type FSModule a = FS (a (Module a))
 
-class (ClassSym repr) => ModuleSym repr where
-  type Module repr
-  buildModule :: Label -> [Label] -> [SMethod repr] -> [SClass repr] -> 
-    FSModule repr
+class (ClassSym r) => ModuleSym r where
+  type Module r
+  buildModule :: Label -> [Label] -> [SMethod r] -> [SClass r] -> 
+    FSModule r
 
 -- Data
 
-data ODEInfo repr = ODEInfo {
-  indepVar :: SVariable repr,
-  depVar :: SVariable repr,
-  otherVars :: [SVariable repr],
-  tInit :: SValue repr,
-  tFinal :: SValue repr,
-  initVal :: SValue repr,
-  ode :: SValue repr
+data ODEInfo r = ODEInfo {
+  indepVar :: SVariable r,
+  depVar :: SVariable r,
+  otherVars :: [SVariable r],
+  tInit :: SValue r,
+  tFinal :: SValue r,
+  initVal :: SValue r,
+  ode :: SValue r
 }
 
-odeInfo :: SVariable repr -> SVariable repr -> 
-  [SVariable repr] -> SValue repr -> 
-  SValue repr -> SValue repr -> SValue repr -> 
-  ODEInfo repr
+odeInfo :: SVariable r -> SVariable r -> 
+  [SVariable r] -> SValue r -> 
+  SValue r -> SValue r -> SValue r -> 
+  ODEInfo r
 odeInfo = ODEInfo
 
-data ODEOptions repr = ODEOptions {
+data ODEOptions r = ODEOptions {
   solveMethod :: ODEMethod,
-  absTol :: SValue repr,
-  relTol :: SValue repr,
-  stepSize :: SValue repr
+  absTol :: SValue r,
+  relTol :: SValue r,
+  stepSize :: SValue r
 }
 
-odeOptions :: ODEMethod -> SValue repr -> SValue repr -> 
-  SValue repr -> ODEOptions repr
+odeOptions :: ODEMethod -> SValue r -> SValue r -> 
+  SValue r -> ODEOptions r
 odeOptions = ODEOptions
 
 data ODEMethod = RK45 | BDF | Adams
 
 -- Utility
 
-convType :: (TypeSym repr) => CodeType -> VSType repr
+convType :: (TypeSym r) => CodeType -> VSType r
 convType Boolean = bool
 convType Integer = int
 convType Float = float

--- a/code/drasil-gool/GOOL/Drasil/ClassInterface.hs
+++ b/code/drasil-gool/GOOL/Drasil/ClassInterface.hs
@@ -4,7 +4,7 @@ module GOOL.Drasil.ClassInterface (
   -- Types
   Label, Library, GSProgram, SFile, MSBody, MSBlock, VSType, SVariable, SValue, 
   VSFunction, MSStatement, MSParameter, SMethod, CSStateVar, SClass, FSModule,
-  NamedArg, Initializer, MixedCall, MixedCtorCall, PosCall, PosCtorCall,
+  NamedArgs, Initializer, MixedCall, MixedCtorCall, PosCall, PosCtorCall,
   -- Typeclasses
   ProgramSym(..), FileSym(..), PermanenceSym(..), BodySym(..), bodyStatements, 
   oneLiner, BlockSym(..), TypeSym(..), ControlBlock(..), VariableSym(..), ($->), listOf, 
@@ -220,11 +220,11 @@ class (ValueSym r) => Comparison r where
   (?!=) :: SValue r -> SValue r -> SValue r
   infixl 3 ?!=
 
-type NamedArg r = (SVariable r, SValue r)
+type NamedArgs r = [(SVariable r, SValue r)]
 -- Function call with both positional and named arguments
-type MixedCall r = Label -> VSType r -> [SValue r] -> [NamedArg r] -> SValue r
+type MixedCall r = Label -> VSType r -> [SValue r] -> NamedArgs r -> SValue r
 -- Constructor call with both positional and named arguments
-type MixedCtorCall r = VSType r -> [SValue r] -> [NamedArg r] -> SValue r
+type MixedCtorCall r = VSType r -> [SValue r] -> NamedArgs r -> SValue r
 -- Function call with only positional arguments
 type PosCall r = Label -> VSType r -> [SValue r] -> SValue r
 -- Constructor call with only positional arguments
@@ -250,7 +250,7 @@ funcApp          :: (ValueExpression r) =>            PosCall r
 funcApp n t vs = funcAppMixedArgs n t vs []
 
 funcAppNamedArgs :: (ValueExpression r) =>            Label -> VSType r ->
-  [NamedArg r] -> SValue r
+  NamedArgs r -> SValue r
 funcAppNamedArgs n t = funcAppMixedArgs n t []
 
 selfFuncApp      :: (ValueExpression r) =>            PosCall r
@@ -276,7 +276,7 @@ exists = notNull
 
 class (FunctionSym r) => InternalValueExp r where
   objMethodCallMixedArgs' :: Label -> VSType r -> SValue r -> 
-    [SValue r] -> [NamedArg r] -> SValue r
+    [SValue r] -> NamedArgs r -> SValue r
   objMethodCallNoParams' :: Label -> VSType r -> SValue r -> SValue r
 
 objMethodCall :: (InternalValueExp r) => VSType r -> SValue r -> Label 
@@ -284,7 +284,7 @@ objMethodCall :: (InternalValueExp r) => VSType r -> SValue r -> Label
 objMethodCall t o f ps = objMethodCallMixedArgs' f t o ps []
 
 objMethodCallMixedArgs :: (InternalValueExp r) => VSType r -> SValue r 
-  -> Label -> [SValue r] -> [NamedArg r] -> SValue r
+  -> Label -> [SValue r] -> NamedArgs r -> SValue r
 objMethodCallMixedArgs t o f = objMethodCallMixedArgs' f t o
 
 objMethodCallNoParams :: (InternalValueExp r) => VSType r -> SValue r 

--- a/code/drasil-gool/GOOL/Drasil/CodeInfo.hs
+++ b/code/drasil-gool/GOOL/Drasil/CodeInfo.hs
@@ -29,6 +29,9 @@ import Data.Maybe (fromMaybe)
 
 newtype CodeInfo a = CI {unCI :: a} deriving Eq
 
+-- FIXME: Use DerivingVia language extension (and maybe DeriveFunctor) to 
+-- derive the Functor, Applicative, Monad instances for this 
+-- (and for JavaCode, PythonCode, etc.)
 instance Functor CodeInfo where
   fmap f (CI x) = CI (f x)
 
@@ -56,7 +59,7 @@ instance FileSym CodeInfo where
 
 instance PermanenceSym CodeInfo where
   type Permanence CodeInfo = ()
-  static = toCode ()
+  static  = toCode ()
   dynamic = toCode ()
 
 instance BodySym CodeInfo where
@@ -71,24 +74,23 @@ instance BlockSym CodeInfo where
 
 instance TypeSym CodeInfo where
   type Type CodeInfo = String
-  bool = noInfoType
-  int = noInfoType
-  float = noInfoType
-  double = noInfoType
-  char = noInfoType
-  string = noInfoType
-  infile = noInfoType
-  outfile = noInfoType
-  listType _ = noInfoType
-  arrayType _ = noInfoType
-  listInnerType _ = noInfoType
-  obj = toState . toCode
-  -- enumType _ = noInfoType
-  funcType _ _ = noInfoType
-  iterator _ = noInfoType
-  void = noInfoType
+  bool              = noInfoType
+  int               = noInfoType
+  float             = noInfoType
+  double            = noInfoType
+  char              = noInfoType
+  string            = noInfoType
+  infile            = noInfoType
+  outfile           = noInfoType
+  listType      _   = noInfoType
+  arrayType     _   = noInfoType
+  listInnerType _   = noInfoType
+  obj               = toState . toCode
+  funcType      _ _ = noInfoType
+  iterator      _   = noInfoType
+  void              = noInfoType
 
-  getType _ = Void
+  getType _     = Void
   getTypeString = unCI
 
 instance ControlBlock CodeInfo where
@@ -96,18 +98,18 @@ instance ControlBlock CodeInfo where
 
 instance VariableSym CodeInfo where
   type Variable CodeInfo = ()
-  var _ _ = noInfo
-  staticVar _ _ = noInfo
-  const _ _ = noInfo
-  extVar _ _ _ = noInfo
-  self = noInfo
-  classVar _ _ = noInfo
-  extClassVar _ _ = noInfo
-  objVar _ _ = noInfo
-  objVarSelf _ = noInfo
-  listVar _ _ = noInfo
-  arrayElem _ _ = noInfo
-  iterVar _ _ = noInfo
+  var         _ _   = noInfo
+  staticVar   _ _   = noInfo
+  const       _ _   = noInfo
+  extVar      _ _ _ = noInfo
+  self              = noInfo
+  classVar    _ _   = noInfo
+  extClassVar _ _   = noInfo
+  objVar      _ _   = noInfo
+  objVarSelf  _     = noInfo
+  listVar     _ _   = noInfo
+  arrayElem   _ _   = noInfo
+  iterVar     _ _   = noInfo
   
   variableName _ = ""
   variableType _ = toCode ""
@@ -117,15 +119,15 @@ instance ValueSym CodeInfo where
   valueType _ = toCode ""
 
 instance Literal CodeInfo where
-  litTrue = noInfo
-  litFalse = noInfo
-  litChar _ = noInfo
+  litTrue     = noInfo
+  litFalse    = noInfo
+  litChar   _ = noInfo
   litDouble _ = noInfo
-  litFloat _ = noInfo
-  litInt _ = noInfo
+  litFloat  _ = noInfo
+  litInt    _ = noInfo
   litString _ = noInfo
-  litArray _ = executeList
-  litList _ = executeList
+  litArray  _ = executeList
+  litList   _ = executeList
 
 instance MathConstant CodeInfo where
   pi = noInfo
@@ -134,45 +136,45 @@ instance VariableValue CodeInfo where
   valueOf _ = noInfo
 
 instance CommandLineArgs CodeInfo where
-  arg _ = noInfo
-  argsList = noInfo
+  arg       _ = noInfo
+  argsList    = noInfo
   argExists _ = noInfo
 
 instance NumericExpression CodeInfo where
-  (#~) = execute1
+  (#~)  = execute1
   (#/^) = execute1
-  (#|) = execute1
-  (#+) = execute2
-  (#-) = execute2
-  (#*) = execute2
-  (#/) = execute2
-  (#%) = execute2
-  (#^) = execute2
+  (#|)  = execute1
+  (#+)  = execute2
+  (#-)  = execute2
+  (#*)  = execute2
+  (#/)  = execute2
+  (#%)  = execute2
+  (#^)  = execute2
 
-  log = execute1
-  ln = execute1
-  exp = execute1
-  sin = execute1
-  cos = execute1
-  tan = execute1
-  csc = execute1
-  sec = execute1
-  cot = execute1
+  log    = execute1
+  ln     = execute1
+  exp    = execute1
+  sin    = execute1
+  cos    = execute1
+  tan    = execute1
+  csc    = execute1
+  sec    = execute1
+  cot    = execute1
   arcsin = execute1
   arccos = execute1
   arctan = execute1
-  floor = execute1
-  ceil = execute1
+  floor  = execute1
+  ceil   = execute1
 
 instance BooleanExpression CodeInfo where
-  (?!) = execute1
+  (?!)  = execute1
   (?&&) = execute2
   (?||) = execute2
 
 instance Comparison CodeInfo where
-  (?<) = execute2
+  (?<)  = execute2
   (?<=) = execute2
-  (?>) = execute2
+  (?>)  = execute2
   (?>=) = execute2
   (?==) = execute2
   (?!=) = execute2
@@ -201,16 +203,12 @@ instance ValueExpression CodeInfo where
   notNull = execute1
   
 instance InternalValueExp CodeInfo where
-  objMethodCallMixedArgs' n _ v vs ns = do
-    _ <- v
-    currModCall n vs ns
-  objMethodCallNoParams' n _ v = do
-    _ <- v
-    addCurrModCall n
+  objMethodCallMixedArgs' n _ v vs ns = v >> currModCall n vs ns
+  objMethodCallNoParams' n _ v = v >> addCurrModCall n
 
 instance FunctionSym CodeInfo where
   type Function CodeInfo = ()
-  func _ _ = executeList
+  func  _ _ = executeList
   objAccess = execute2
   
 instance GetSet CodeInfo where
@@ -218,12 +216,12 @@ instance GetSet CodeInfo where
   set v _ = execute2 v
 
 instance List CodeInfo where
-  listSize = execute1
-  listAdd = execute3
+  listSize   = execute1
+  listAdd    = execute3
   listAppend = execute2
   listAccess = execute2
-  listSet = execute3
-  indexOf = execute2
+  listSet    = execute3
+  indexOf    = execute2
   
 instance InternalList CodeInfo where
   listSlice' b e s _ vl = zoom lensMStoVS $ do
@@ -233,64 +231,64 @@ instance InternalList CodeInfo where
 
 instance Iterator CodeInfo where
   iterBegin = execute1
-  iterEnd = execute1
+  iterEnd   = execute1
 
 instance StatementSym CodeInfo where
   type Statement CodeInfo = ()
   valState = zoom lensMStoVS . execute1
-  multi = executeList
+  multi    = executeList
   
 instance AssignStatement CodeInfo where
   assign _ = zoom lensMStoVS . execute1
-  (&-=) _ = zoom lensMStoVS . execute1
-  (&+=) _ = zoom lensMStoVS . execute1
-  (&++) _ = noInfo
-  (&--) _ = noInfo
+  (&-=)  _ = zoom lensMStoVS . execute1
+  (&+=)  _ = zoom lensMStoVS . execute1
+  (&++)  _ = noInfo
+  (&--)  _ = noInfo
 
 instance DeclStatement CodeInfo where
-  varDec _ = noInfo
-  varDecDef _ = zoom lensMStoVS . execute1
-  listDec _ _ = noInfo
-  listDecDef _ = zoom lensMStoVS . executeList
-  arrayDec _ _ = noInfo
-  arrayDecDef _ = zoom lensMStoVS . executeList
-  objDecDef _ = zoom lensMStoVS . execute1
-  objDecNew _ = zoom lensMStoVS . executeList
-  extObjDecNew _ _ = zoom lensMStoVS . executeList
-  objDecNewNoParams _ = noInfo
+  varDec                 _ = noInfo
+  varDecDef              _ = zoom lensMStoVS . execute1
+  listDec              _ _ = noInfo
+  listDecDef             _ = zoom lensMStoVS . executeList
+  arrayDec             _ _ = noInfo
+  arrayDecDef            _ = zoom lensMStoVS . executeList
+  objDecDef              _ = zoom lensMStoVS . execute1
+  objDecNew              _ = zoom lensMStoVS . executeList
+  extObjDecNew         _ _ = zoom lensMStoVS . executeList
+  objDecNewNoParams      _ = noInfo
   extObjDecNewNoParams _ _ = noInfo
-  constDecDef _ = zoom lensMStoVS . execute1
-  funcDecDef _ _ = zoom lensMStoVS . execute1
+  constDecDef            _ = zoom lensMStoVS . execute1
+  funcDecDef           _ _ = zoom lensMStoVS . execute1
 
 instance IOStatement CodeInfo where
-  print = zoom lensMStoVS . execute1
-  printLn = zoom lensMStoVS . execute1
-  printStr _ = noInfo
+  print        = zoom lensMStoVS . execute1
+  printLn      = zoom lensMStoVS . execute1
+  printStr   _ = noInfo
   printStrLn _ = noInfo
 
-  printFile v = zoom lensMStoVS . execute2 v
-  printFileLn v = zoom lensMStoVS . execute2 v
-  printFileStr v _ = zoom lensMStoVS $ execute1 v
+  printFile      v   = zoom lensMStoVS . execute2 v
+  printFileLn    v   = zoom lensMStoVS . execute2 v
+  printFileStr   v _ = zoom lensMStoVS $ execute1 v
   printFileStrLn v _ = zoom lensMStoVS $ execute1 v
 
-  getInput _ = noInfo
-  discardInput = noInfo
+  getInput       _ = noInfo
+  discardInput     = noInfo
   getFileInput v _ = zoom lensMStoVS $ execute1 v
   discardFileInput = zoom lensMStoVS . execute1
 
   openFileR _ v = modify (addException fnfExc) >> execute1 (zoom lensMStoVS v)
   openFileW _ v = modify (addException ioExc) >> execute1 (zoom lensMStoVS v)
   openFileA _ v = modify (addException ioExc) >> execute1 (zoom lensMStoVS v)
-  closeFile = zoom lensMStoVS . execute1
+  closeFile     = zoom lensMStoVS . execute1
 
   getFileInputLine v _ = zoom lensMStoVS $ execute1 v
-  discardFileLine = zoom lensMStoVS . execute1
-  getFileInputAll v _ = execute1 (zoom lensMStoVS v)
+  discardFileLine      = zoom lensMStoVS . execute1
+  getFileInputAll  v _ = execute1 (zoom lensMStoVS v)
 
 instance StringStatement CodeInfo where
   stringSplit _ _ = zoom lensMStoVS . execute1
 
-  stringListVals _ = zoom lensMStoVS . execute1
+  stringListVals  _ = zoom lensMStoVS . execute1
   stringListLists _ = zoom lensMStoVS . execute1
 
 instance FuncAppStatement CodeInfo where
@@ -308,7 +306,7 @@ instance CommentStatement CodeInfo where
   comment _ = noInfo
 
 instance ControlStatement CodeInfo where
-  break = noInfo
+  break    = noInfo
   continue = noInfo
 
   returnState = zoom lensMStoVS . execute1
@@ -347,11 +345,11 @@ instance StrategyPattern CodeInfo where
 instance ScopeSym CodeInfo where
   type Scope CodeInfo = ScopeTag
   private = toCode Priv
-  public = toCode Pub
+  public  = toCode Pub
 
 instance ParameterSym CodeInfo where
   type Parameter CodeInfo = ()
-  param _ = noInfo
+  param        _ = noInfo
   pointerParam _ = noInfo
 
 instance MethodSym CodeInfo where
@@ -375,19 +373,19 @@ instance MethodSym CodeInfo where
     _ <- f
     noInfo
 
-  inOutMethod n _ _ _ _ _ = updateMEMandCM n
+  inOutMethod    n _ _ _ _ _   = updateMEMandCM n
 
   docInOutMethod n _ _ _ _ _ _ = updateMEMandCM n
 
-  inOutFunc n _ _ _ _ _ = updateMEMandCM n
+  inOutFunc      n _ _ _ _ _   = updateMEMandCM n
 
-  docInOutFunc n _ _ _ _ _ _ = updateMEMandCM n
+  docInOutFunc   n _ _ _ _ _ _ = updateMEMandCM n
 
 instance StateVarSym CodeInfo where
   type StateVar CodeInfo = ()
-  stateVar _ _ _ = noInfo
+  stateVar    _ _ _     = noInfo
   stateVarDef _ _ _ _ _ = noInfo
-  constVar _ _ _ _ = noInfo
+  constVar    _ _ _ _   = noInfo
 
 instance ClassSym CodeInfo where
   type Class CodeInfo = ()

--- a/code/drasil-gool/GOOL/Drasil/Helpers.hs
+++ b/code/drasil-gool/GOOL/Drasil/Helpers.hs
@@ -44,27 +44,27 @@ emptyIfEmpty ifDoc elseDoc = if isEmpty ifDoc then empty else elseDoc
 emptyIfNull :: [a] -> Doc -> Doc
 emptyIfNull lst elseDoc = if null lst then empty else elseDoc
 
-toCode :: (Monad repr) => a -> repr a
+toCode :: (Monad r) => a -> r a
 toCode = return
 
 toState :: a -> State s a
 toState = return
 
-onCodeValue :: (Functor repr) => (a -> b) -> repr a -> repr b
+onCodeValue :: (Functor r) => (a -> b) -> r a -> r b
 onCodeValue = fmap
 
 onStateValue :: (a -> b) -> State s a -> State s b
 onStateValue = fmap
 
-on2CodeValues :: (Applicative repr) => (a -> b -> c) -> repr a -> repr b -> 
-  repr c
+on2CodeValues :: (Applicative r) => (a -> b -> c) -> r a -> r b -> 
+  r c
 on2CodeValues = liftA2
 
 on2StateValues :: (a -> b -> c) -> State s a -> State s b -> State s c
 on2StateValues = liftM2
 
-on3CodeValues :: (Applicative repr) => (a -> b -> c -> d) -> repr a -> repr b 
-  -> repr c -> repr d
+on3CodeValues :: (Applicative r) => (a -> b -> c -> d) -> r a -> r b 
+  -> r c -> r d
 on3CodeValues = liftA3
 
 on3StateValues :: (a -> b -> c -> d) -> State s a -> State s b -> State s c ->

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer/CSharpRenderer.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer/CSharpRenderer.hs
@@ -678,15 +678,15 @@ csODEMethod _ = error "Chosen ODE method unavailable in C#"
 csImport :: Label -> Doc
 csImport n = text ("using " ++ n) <> endStatement
 
-csInfileType :: (RenderSym repr) => VSType repr
+csInfileType :: (RenderSym r) => VSType r
 csInfileType = modifyReturn (addLangImportVS "System.IO") $ 
   typeFromData File "StreamReader" (text "StreamReader")
 
-csOutfileType :: (RenderSym repr) => VSType repr
+csOutfileType :: (RenderSym r) => VSType r
 csOutfileType = modifyReturn (addLangImportVS "System.IO") $ 
   typeFromData File "StreamWriter" (text "StreamWriter")
 
-csLambda :: (RenderSym repr) => [repr (Variable repr)] -> repr (Value repr) -> 
+csLambda :: (RenderSym r) => [r (Variable r)] -> r (Value r) -> 
   Doc
 csLambda ps ex = parens (variableList ps) <+> text "=>" <+> valueDoc ex
 
@@ -698,18 +698,18 @@ csCast t v = join $ on2StateValues (\tp vl -> csCast' (getType tp) (getType $
         csCast' _ _ tp vl = mkStateVal t (castObjDocD (castDocD (getTypeDoc 
           tp)) (valueDoc vl))
 
-csFuncDecDef :: (RenderSym repr) => SVariable repr -> 
-  [SVariable repr] -> SValue repr -> MSStatement repr
+csFuncDecDef :: (RenderSym r) => SVariable r -> 
+  [SVariable r] -> SValue r -> MSStatement r
 csFuncDecDef v ps r = on3StateValues (\vr pms b -> mkStNoEnd $ 
   getTypeDoc (variableType vr) <+> text (variableName vr) <> parens 
   (variableList pms) <+> bodyStart $$ indent (bodyDoc b) $$ bodyEnd) 
   (zoom lensMStoVS v) (mapM (zoom lensMStoVS) ps) (oneLiner $ returnState r)
 
-csThrowDoc :: (RenderSym repr) => repr (Value repr) -> Doc
+csThrowDoc :: (RenderSym r) => r (Value r) -> Doc
 csThrowDoc errMsg = text "throw new" <+> text "Exception" <> 
   parens (valueDoc errMsg)
 
-csTryCatch :: (RenderSym repr) => repr (Body repr) -> repr (Body repr) -> Doc
+csTryCatch :: (RenderSym r) => r (Body r) -> r (Body r) -> Doc
 csTryCatch tb cb = vcat [
   text "try" <+> lbrace,
   indent $ bodyDoc tb,
@@ -718,14 +718,14 @@ csTryCatch tb cb = vcat [
   indent $ bodyDoc cb,
   rbrace]
 
-csDiscardInput :: (RenderSym repr) => repr (Value repr) -> Doc
+csDiscardInput :: (RenderSym r) => r (Value r) -> Doc
 csDiscardInput = valueDoc
 
-csFileInput :: (RenderSym repr) => SValue repr -> SValue repr
+csFileInput :: (RenderSym r) => SValue r -> SValue r
 csFileInput = onStateValue (\f -> mkVal (valueType f) (valueDoc f <> dot <> 
   text "ReadLine()"))
 
-csInput :: (RenderSym repr) => VSType repr -> SValue repr -> SValue repr
+csInput :: (RenderSym r) => VSType r -> SValue r -> SValue r
 csInput tp inF = tp >>= (\t -> csInputImport (getType t) $ onStateValue (\inFn 
   -> mkVal t $ text (csInput' (getType t)) <> parens (valueDoc inFn)) inF)
   where csInput' Integer = "Int32.Parse"
@@ -738,11 +738,11 @@ csInput tp inF = tp >>= (\t -> csInputImport (getType t) $ onStateValue (\inFn
         csInputImport t = if t `elem` [Integer, Float, Double, Boolean, Char] 
           then addSystemImport else id
 
-csOpenFileR :: (RenderSym repr) => SValue repr -> VSType repr -> SValue repr
+csOpenFileR :: (RenderSym r) => SValue r -> VSType r -> SValue r
 csOpenFileR n r = newObj r [n]
 
-csOpenFileWorA :: (RenderSym repr) => SValue repr -> VSType repr -> SValue repr 
-  -> SValue repr
+csOpenFileWorA :: (RenderSym r) => SValue r -> VSType r -> SValue r 
+  -> SValue r
 csOpenFileWorA n w a = newObj w [n, a] 
 
 csRef :: Doc -> Doc
@@ -766,8 +766,8 @@ csVarDec :: Binding -> MSStatement CSharpCode -> MSStatement CSharpCode
 csVarDec Static _ = error "Static variables can't be declared locally to a function in C#. Use stateVar to make a static state variable instead."
 csVarDec Dynamic d = d
 
-csObjVar :: (RenderSym repr) => repr (Variable repr) -> repr (Variable repr) -> 
-  repr (Variable repr)
+csObjVar :: (RenderSym r) => r (Variable r) -> r (Variable r) -> 
+  r (Variable r)
 csObjVar o v = csObjVar' (variableBind v)
   where csObjVar' Static = error 
           "Cannot use objVar to access static variables through an object in C#"

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer/CppRenderer.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer/CppRenderer.hs
@@ -12,7 +12,7 @@ import Utils.Drasil (blank, indent, indentList)
 
 import GOOL.Drasil.CodeType (CodeType(..))
 import GOOL.Drasil.ClassInterface (Label, MSBody, MSBlock, VSType, SVariable, 
-  SValue, MSStatement, MSParameter, SMethod, ProgramSym(..), FileSym(..), 
+  SValue, MSStatement, MSParameter, SMethod, NamedArg, ProgramSym(..), FileSym(..), 
   PermanenceSym(..), BodySym(..), bodyStatements, oneLiner, BlockSym(..), 
   TypeSym(..), ControlBlock(..), VariableSym(..), 
   ValueSym(..), Literal(..), MathConstant(..), VariableValue(..), CommandLineArgs(..), NumericExpression(..), BooleanExpression(..), Comparison(..), ValueExpression(..), funcApp, selfFuncApp, extFuncApp, newObj, InternalValueExp(..), objMethodCall, FunctionSym(..), ($.), GetSet(..), List(..), InternalList(..), Iterator(..), StatementSym(..), AssignStatement(..), (&=), DeclStatement(..), IOStatement(..), StringStatement(..), FuncAppStatement(..), CommentStatement(..),
@@ -2451,8 +2451,8 @@ cppsMethod is n c t ps b = emptyIfEmpty (bodyDoc b <> initList) $
               | otherwise = getTypeDoc t
         initList = hicat (text ", ") is
 
-cppConstructor :: [MSParameter CppSrcCode] -> [(SVariable CppSrcCode, 
-  SValue CppSrcCode)] -> MSBody CppSrcCode -> SMethod CppSrcCode
+cppConstructor :: [MSParameter CppSrcCode] -> [NamedArg CppSrcCode] -> 
+  MSBody CppSrcCode -> SMethod CppSrcCode
 cppConstructor ps is b = getClassName >>= (\n -> join $ (\tp pms ivars ivals 
   bod -> if null is then G.constructor n ps is b else modify (setScope Pub) >> 
   toState (methodFromData Pub (cppsMethod (zipWith (\ivar ival -> variableDoc 

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer/CppRenderer.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer/CppRenderer.hs
@@ -12,7 +12,7 @@ import Utils.Drasil (blank, indent, indentList)
 
 import GOOL.Drasil.CodeType (CodeType(..))
 import GOOL.Drasil.ClassInterface (Label, MSBody, MSBlock, VSType, SVariable, 
-  SValue, MSStatement, MSParameter, SMethod, NamedArg, ProgramSym(..), FileSym(..), 
+  SValue, MSStatement, MSParameter, SMethod, NamedArgs, ProgramSym(..), FileSym(..), 
   PermanenceSym(..), BodySym(..), bodyStatements, oneLiner, BlockSym(..), 
   TypeSym(..), ControlBlock(..), VariableSym(..), 
   ValueSym(..), Literal(..), MathConstant(..), VariableValue(..), CommandLineArgs(..), NumericExpression(..), BooleanExpression(..), Comparison(..), ValueExpression(..), funcApp, selfFuncApp, extFuncApp, newObj, InternalValueExp(..), objMethodCall, FunctionSym(..), ($.), GetSet(..), List(..), InternalList(..), Iterator(..), StatementSym(..), AssignStatement(..), (&=), DeclStatement(..), IOStatement(..), StringStatement(..), FuncAppStatement(..), CommentStatement(..),
@@ -2451,7 +2451,7 @@ cppsMethod is n c t ps b = emptyIfEmpty (bodyDoc b <> initList) $
               | otherwise = getTypeDoc t
         initList = hicat (text ", ") is
 
-cppConstructor :: [MSParameter CppSrcCode] -> [NamedArg CppSrcCode] -> 
+cppConstructor :: [MSParameter CppSrcCode] -> NamedArgs CppSrcCode -> 
   MSBody CppSrcCode -> SMethod CppSrcCode
 cppConstructor ps is b = getClassName >>= (\n -> join $ (\tp pms ivars ivals 
   bod -> if null is then G.constructor n ps is b else modify (setScope Pub) >> 

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer/JavaRenderer.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer/JavaRenderer.hs
@@ -776,18 +776,18 @@ jName = "Java"
 jImport :: Label -> Doc
 jImport n = text ("import " ++ n) <> endStatement
 
-jStringType :: (RenderSym repr) => VSType repr
+jStringType :: (RenderSym r) => VSType r
 jStringType = toState $ typeFromData String "String" (text "String")
 
-jInfileType :: (RenderSym repr) => VSType repr
+jInfileType :: (RenderSym r) => VSType r
 jInfileType = modifyReturn (addLangImportVS "java.util.Scanner") $ 
   typeFromData File "Scanner" (text "Scanner")
 
-jOutfileType :: (RenderSym repr) => VSType repr
+jOutfileType :: (RenderSym r) => VSType r
 jOutfileType = modifyReturn (addLangImportVS "java.io.PrintWriter") $ 
   typeFromData File "PrintWriter" (text "PrintWriter")
 
-jListType :: (RenderSym repr) => String -> VSType repr -> VSType repr
+jListType :: (RenderSym r) => String -> VSType r -> VSType r
 jListType l t = modify (addLangImportVS $ "java.util." ++ l) >> 
   (t >>= (jListType' . getType))
   where jListType' Integer = toState $ typeFromData (List Integer) 
@@ -802,11 +802,11 @@ jListType l t = modify (addLangImportVS $ "java.util." ++ l) >>
 jArrayType :: VSType JavaCode
 jArrayType = arrayType (obj "Object")
 
-jFileType :: (RenderSym repr) => VSType repr
+jFileType :: (RenderSym r) => VSType r
 jFileType = modifyReturn (addLangImportVS "java.io.File") $ typeFromData File 
   "File" (text "File")
 
-jFileWriterType :: (RenderSym repr) => VSType repr
+jFileWriterType :: (RenderSym r) => VSType r
 jFileWriterType = modifyReturn (addLangImportVS "java.io.FileWriter") $ 
   typeFromData File "FileWriter" (text "FileWriter")
 
@@ -815,7 +815,7 @@ jEquality v1 v2 = v2 >>= jEquality' . getType . valueType
   where jEquality' String = objAccess v1 (func "equals" bool [v2])
         jEquality' _ = typeBinExpr equalOp bool v1 v2
 
-jLambda :: (RenderSym repr) => [repr (Variable repr)] -> repr (Value repr) -> 
+jLambda :: (RenderSym r) => [r (Variable r)] -> r (Value r) -> 
   Doc
 jLambda ps ex = parens (variableList ps) <+> text "->" <+> valueDoc ex
 
@@ -828,16 +828,16 @@ jCast t v = join $ on2StateValues (\tp vl -> jCast' (getType tp) (getType $
         jCast' _ _ tp vl = mkStateVal t (castObjDocD (castDocD (getTypeDoc 
           tp)) (valueDoc vl))
 
-jConstDecDef :: (RenderSym repr) => repr (Variable repr) -> repr (Value repr) 
+jConstDecDef :: (RenderSym r) => r (Variable r) -> r (Value r) 
   -> Doc
 jConstDecDef v def = text "final" <+> getTypeDoc (variableType v) <+> 
   variableDoc v <+> equals <+> valueDoc def
 
-jThrowDoc :: (RenderSym repr) => repr (Value repr) -> Doc
+jThrowDoc :: (RenderSym r) => r (Value r) -> Doc
 jThrowDoc errMsg = text "throw new" <+> text "Exception" <> parens (valueDoc 
   errMsg)
 
-jTryCatch :: (RenderSym repr) => repr (Body repr) -> repr (Body repr) -> Doc
+jTryCatch :: (RenderSym r) => r (Body r) -> r (Body r) -> Doc
 jTryCatch tb cb = vcat [
   text "try" <+> lbrace,
   indent $ bodyDoc tb,
@@ -846,17 +846,17 @@ jTryCatch tb cb = vcat [
   indent $ bodyDoc cb,
   rbrace]
 
-jOut :: (RenderSym repr) => Bool -> Maybe (SValue repr) -> SValue repr -> 
-  SValue repr -> MSStatement repr
+jOut :: (RenderSym r) => Bool -> Maybe (SValue r) -> SValue r -> 
+  SValue r -> MSStatement r
 jOut newLn f printFn v = zoom lensMStoVS v >>= jOut' . getType . valueType
   where jOut' (List (Object _)) = outDoc newLn f printFn v
         jOut' (List _) = printSt newLn f printFn v
         jOut' _ = outDoc newLn f printFn v
 
-jDiscardInput :: (RenderSym repr) => repr (Value repr) -> Doc
+jDiscardInput :: (RenderSym r) => r (Value r) -> Doc
 jDiscardInput inFn = valueDoc inFn <> dot <> text "next()"
 
-jInput :: (RenderSym repr) => VSType repr -> SValue repr -> SValue repr
+jInput :: (RenderSym r) => VSType r -> SValue r -> SValue r
 jInput = on2StateValues (\t -> mkVal t . jInput' (getType t))
   where jInput' Integer inFn = text "Integer.parseInt" <> parens (valueDoc inFn 
           <> dot <> text "nextLine()")
@@ -869,21 +869,21 @@ jInput = on2StateValues (\t -> mkVal t . jInput' (getType t))
         jInput' Char inFn = valueDoc inFn <> dot <> text "next().charAt(0)"
         jInput' _ _ = error "Attempt to read value of unreadable type"
 
-jOpenFileR :: (RenderSym repr) => SValue repr -> VSType repr -> SValue repr
+jOpenFileR :: (RenderSym r) => SValue r -> VSType r -> SValue r
 jOpenFileR n t = newObj t [newObj jFileType [n]]
 
-jOpenFileWorA :: (RenderSym repr) => SValue repr -> VSType repr -> SValue repr 
-  -> SValue repr
+jOpenFileWorA :: (RenderSym r) => SValue r -> VSType r -> SValue r 
+  -> SValue r
 jOpenFileWorA n t wa = newObj t [newObj jFileWriterType [newObj jFileType [n], 
   wa]]
 
-jStringSplit :: (RenderSym repr) => SVariable repr -> SValue repr -> VS Doc
+jStringSplit :: (RenderSym r) => SVariable r -> SValue r -> VS Doc
 jStringSplit = on2StateValues (\vnew s -> variableDoc vnew <+> equals <+> new 
   <+> getTypeDoc (variableType vnew) <> parens (valueDoc s))
 
-jMethod :: (RenderSym repr) => Label -> [String] -> repr (Scope repr) -> 
-  repr (Permanence repr) -> repr (Type repr) -> [repr (Parameter repr)] -> 
-  repr (Body repr) -> Doc
+jMethod :: (RenderSym r) => Label -> [String] -> r (Scope r) -> 
+  r (Permanence r) -> r (Type r) -> [r (Parameter r)] -> 
+  r (Body r) -> Doc
 jMethod n es s p t ps b = vcat [
   scopeDoc s <+> permDoc p <+> getTypeDoc t <+> text n <> 
     parens (parameterList ps) <+> emptyIfNull es (text "throws" <+> 
@@ -944,12 +944,12 @@ jInOut f s p ins outs both b = f s p (returnTp rets)
         rets = both ++ outs
         outputs = var "outputs" jArrayType
 
-jDocInOut :: (RenderSym repr) => (repr (Scope repr) -> repr (Permanence repr) 
-    -> [SVariable repr] -> [SVariable repr] -> [SVariable repr] -> MSBody repr 
-    -> SMethod repr)
-  -> repr (Scope repr) -> repr (Permanence repr) -> String -> 
-  [(String, SVariable repr)] -> [(String, SVariable repr)]
-  -> [(String, SVariable repr)] -> MSBody repr -> SMethod repr
+jDocInOut :: (RenderSym r) => (r (Scope r) -> r (Permanence r) 
+    -> [SVariable r] -> [SVariable r] -> [SVariable r] -> MSBody r 
+    -> SMethod r)
+  -> r (Scope r) -> r (Permanence r) -> String -> 
+  [(String, SVariable r)] -> [(String, SVariable r)]
+  -> [(String, SVariable r)] -> MSBody r -> SMethod r
 jDocInOut f s p desc is [] [] b = docFuncRepr desc (map fst is) [] 
   (f s p (map snd is) [] [] b)
 jDocInOut f s p desc is [o] [] b = docFuncRepr desc (map fst is) [fst o] 
@@ -967,8 +967,8 @@ addCallExcsCurrMod n = do
   mem <- getMethodExcMap
   modify (maybe id addExceptions (Map.lookup (cm ++ "." ++ n) mem))
 
-addConstructorCallExcsCurrMod :: (RenderSym repr) => VSType repr -> 
-  (VSType repr -> SValue repr) -> SValue repr
+addConstructorCallExcsCurrMod :: (RenderSym r) => VSType r -> 
+  (VSType r -> SValue r) -> SValue r
 addConstructorCallExcsCurrMod ot f = do
   t <- ot
   cm <- zoom lensVStoFS getModuleName

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer/LanguagePolymorphic.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer/LanguagePolymorphic.hs
@@ -65,7 +65,7 @@ import qualified GOOL.Drasil.ClassInterface as S (BlockSym(block),
     constDecDef),
   ControlStatement(returnState, ifCond, for, forRange, switch), 
   ParameterSym(param), MethodSym(method, mainFunction), ClassSym(buildClass))
-import GOOL.Drasil.RendererClasses (InternalFile(commentedMod),
+import GOOL.Drasil.RendererClasses (VSUnOp, VSBinOp, InternalFile(commentedMod),
   RenderSym, InternalBody(bodyDoc, docBody), InternalBlock(docBlock, blockDoc), 
   ImportSym(..), InternalPerm(..), InternalType(..), UnaryOpSym(UnaryOp), 
   BinaryOpSym(BinaryOp), InternalOp(..), 
@@ -213,70 +213,70 @@ listSlice b e s vnew vold =
 
 -- Unary Operators --
 
-unOpPrec :: (RenderSym repr) => String -> VS (repr (UnaryOp repr))
+unOpPrec :: (RenderSym repr) => String -> VSUnOp repr
 unOpPrec = uOpFromData 9 . text
 
-notOp :: (RenderSym repr) => VS (repr (UnaryOp repr))
+notOp :: (RenderSym repr) => VSUnOp repr
 notOp = unOpPrec "!"
 
-notOp' :: (RenderSym repr) => VS (repr (UnaryOp repr))
+notOp' :: (RenderSym repr) => VSUnOp repr
 notOp' = unOpPrec "not"
 
-negateOp :: (RenderSym repr) => VS (repr (UnaryOp repr))
+negateOp :: (RenderSym repr) => VSUnOp repr
 negateOp = unOpPrec "-"
 
-sqrtOp :: (RenderSym repr) => VS (repr (UnaryOp repr))
+sqrtOp :: (RenderSym repr) => VSUnOp repr
 sqrtOp = unOpPrec "sqrt"
 
-sqrtOp' :: (RenderSym repr) => VS (repr (UnaryOp repr))
+sqrtOp' :: (RenderSym repr) => VSUnOp repr
 sqrtOp' = addmathImport $ unOpPrec "math.sqrt"
 
-absOp :: (RenderSym repr) => VS (repr (UnaryOp repr))
+absOp :: (RenderSym repr) => VSUnOp repr
 absOp = unOpPrec "fabs"
 
-absOp' :: (RenderSym repr) => VS (repr (UnaryOp repr))
+absOp' :: (RenderSym repr) => VSUnOp repr
 absOp' = addmathImport $ unOpPrec "math.fabs"
 
-expOp :: (RenderSym repr) => VS (repr (UnaryOp repr))
+expOp :: (RenderSym repr) => VSUnOp repr
 expOp = unOpPrec "exp"
 
-expOp' :: (RenderSym repr) => VS (repr (UnaryOp repr))
+expOp' :: (RenderSym repr) => VSUnOp repr
 expOp' = addmathImport $ unOpPrec "math.exp"
 
-sinOp :: (RenderSym repr) => VS (repr (UnaryOp repr))
+sinOp :: (RenderSym repr) => VSUnOp repr
 sinOp = unOpPrec "sin"
 
-sinOp' :: (RenderSym repr) => VS (repr (UnaryOp repr))
+sinOp' :: (RenderSym repr) => VSUnOp repr
 sinOp' = addmathImport $ unOpPrec "math.sin"
 
-cosOp :: (RenderSym repr) => VS (repr (UnaryOp repr))
+cosOp :: (RenderSym repr) => VSUnOp repr
 cosOp = unOpPrec "cos"
 
-cosOp' :: (RenderSym repr) => VS (repr (UnaryOp repr))
+cosOp' :: (RenderSym repr) => VSUnOp repr
 cosOp' = addmathImport $ unOpPrec "math.cos"
 
-tanOp :: (RenderSym repr) => VS (repr (UnaryOp repr))
+tanOp :: (RenderSym repr) => VSUnOp repr
 tanOp = unOpPrec "tan"
 
-tanOp' :: (RenderSym repr) => VS (repr (UnaryOp repr))
+tanOp' :: (RenderSym repr) => VSUnOp repr
 tanOp' = addmathImport $ unOpPrec "math.tan"
 
-asinOp :: (RenderSym repr) => VS (repr (UnaryOp repr))
+asinOp :: (RenderSym repr) => VSUnOp repr
 asinOp = unOpPrec "asin"
 
-asinOp' :: (RenderSym repr) => VS (repr (UnaryOp repr))
+asinOp' :: (RenderSym repr) => VSUnOp repr
 asinOp' = addmathImport $ unOpPrec "math.asin"
 
-acosOp :: (RenderSym repr) => VS (repr (UnaryOp repr))
+acosOp :: (RenderSym repr) => VSUnOp repr
 acosOp = unOpPrec "acos"
 
-acosOp' :: (RenderSym repr) => VS (repr (UnaryOp repr))
+acosOp' :: (RenderSym repr) => VSUnOp repr
 acosOp' = addmathImport $ unOpPrec "math.acos"
 
-atanOp :: (RenderSym repr) => VS (repr (UnaryOp repr))
+atanOp :: (RenderSym repr) => VSUnOp repr
 atanOp = unOpPrec "atan"
 
-atanOp' :: (RenderSym repr) => VS (repr (UnaryOp repr))
+atanOp' :: (RenderSym repr) => VSUnOp repr
 atanOp' = addmathImport $ unOpPrec "math.atan"
 
 csc :: (RenderSym repr) => SValue repr -> SValue repr
@@ -299,11 +299,11 @@ unOpDocD op v = op <> parens v
 unOpDocD' :: Doc -> Doc -> Doc
 unOpDocD' op v = op <> v
 
-unExpr :: (RenderSym repr) => VS (repr (UnaryOp repr)) -> SValue repr
+unExpr :: (RenderSym repr) => VSUnOp repr -> SValue repr
   -> SValue repr
 unExpr = on2StateValues (mkUnExpr unOpDocD)
 
-unExpr' :: (RenderSym repr) => VS (repr (UnaryOp repr)) -> SValue repr -> 
+unExpr' :: (RenderSym repr) => VSUnOp repr -> SValue repr -> 
   SValue repr
 unExpr' = on2StateValues (mkUnExpr unOpDocD')
 
@@ -311,7 +311,7 @@ mkUnExpr :: (RenderSym repr) => (Doc -> Doc -> Doc) -> repr (UnaryOp repr) ->
   repr (Value repr) -> repr (Value repr)
 mkUnExpr d u v = mkExpr (uOpPrec u) (valueType v) (d (uOpDoc u) (valueDoc v))
 
-unExprNumDbl :: (RenderSym repr) => VS (repr (UnaryOp repr)) -> SValue repr -> 
+unExprNumDbl :: (RenderSym repr) => VSUnOp repr -> SValue repr -> 
   SValue repr
 unExprNumDbl u' v' = u' >>= (\u -> v' >>= (\v -> 
   unExprCastFloat (valueType v) $ return $ mkUnExpr unOpDocD u v))
@@ -322,74 +322,74 @@ unExprCastFloat t = castType $ getType t
   where castType Float = cast float
         castType _ = id
   
-typeUnExpr :: (RenderSym repr) => VS (repr (UnaryOp repr)) -> VSType repr -> 
+typeUnExpr :: (RenderSym repr) => VSUnOp repr -> VSType repr -> 
   SValue repr -> SValue repr
 typeUnExpr = on3StateValues (\u t -> mkExpr (uOpPrec u) t . unOpDocD (uOpDoc u) 
   . valueDoc)
 
 -- Binary Operators --
 
-compEqualPrec :: (RenderSym repr) => String -> VS (repr (BinaryOp repr))
+compEqualPrec :: (RenderSym repr) => String -> VSBinOp repr
 compEqualPrec = bOpFromData 4 . text
 
-compPrec :: (RenderSym repr) => String -> VS (repr (BinaryOp repr))
+compPrec :: (RenderSym repr) => String -> VSBinOp repr
 compPrec = bOpFromData 5 . text
 
-addPrec :: (RenderSym repr) => String -> VS (repr (BinaryOp repr))
+addPrec :: (RenderSym repr) => String -> VSBinOp repr
 addPrec = bOpFromData 6 . text
 
-multPrec :: (RenderSym repr) => String -> VS (repr (BinaryOp repr))
+multPrec :: (RenderSym repr) => String -> VSBinOp repr
 multPrec = bOpFromData 7 . text
 
-powerPrec :: (RenderSym repr) => String -> VS (repr (BinaryOp repr))
+powerPrec :: (RenderSym repr) => String -> VSBinOp repr
 powerPrec = bOpFromData 8 . text
 
-andPrec :: (RenderSym repr) => String -> VS (repr (BinaryOp repr)) 
+andPrec :: (RenderSym repr) => String -> VSBinOp repr 
 andPrec = bOpFromData 3 . text
 
-orPrec :: (RenderSym repr) => String -> VS (repr (BinaryOp repr))
+orPrec :: (RenderSym repr) => String -> VSBinOp repr
 orPrec = bOpFromData 2 . text
 
-equalOp :: (RenderSym repr) => VS (repr (BinaryOp repr))
+equalOp :: (RenderSym repr) => VSBinOp repr
 equalOp = compEqualPrec "=="
 
-notEqualOp :: (RenderSym repr) => VS (repr (BinaryOp repr))
+notEqualOp :: (RenderSym repr) => VSBinOp repr
 notEqualOp = compEqualPrec "!="
 
-greaterOp :: (RenderSym repr) => VS (repr (BinaryOp repr))
+greaterOp :: (RenderSym repr) => VSBinOp repr
 greaterOp = compPrec ">"
 
-greaterEqualOp :: (RenderSym repr) => VS (repr (BinaryOp repr))
+greaterEqualOp :: (RenderSym repr) => VSBinOp repr
 greaterEqualOp = compPrec ">="
 
-lessOp :: (RenderSym repr) => VS (repr (BinaryOp repr))
+lessOp :: (RenderSym repr) => VSBinOp repr
 lessOp = compPrec "<"
 
-lessEqualOp :: (RenderSym repr) => VS (repr (BinaryOp repr))
+lessEqualOp :: (RenderSym repr) => VSBinOp repr
 lessEqualOp = compPrec "<="
 
-plusOp :: (RenderSym repr) => VS (repr (BinaryOp repr))
+plusOp :: (RenderSym repr) => VSBinOp repr
 plusOp = addPrec "+"
 
-minusOp :: (RenderSym repr) => VS (repr (BinaryOp repr))
+minusOp :: (RenderSym repr) => VSBinOp repr
 minusOp = addPrec "-"
 
-multOp :: (RenderSym repr) => VS (repr (BinaryOp repr))
+multOp :: (RenderSym repr) => VSBinOp repr
 multOp = multPrec "*"
 
-divideOp :: (RenderSym repr) => VS (repr (BinaryOp repr))
+divideOp :: (RenderSym repr) => VSBinOp repr
 divideOp = multPrec "/"
 
-moduloOp :: (RenderSym repr) => VS (repr (BinaryOp repr))
+moduloOp :: (RenderSym repr) => VSBinOp repr
 moduloOp = multPrec "%"
 
-powerOp :: (RenderSym repr) => VS (repr (BinaryOp repr))
+powerOp :: (RenderSym repr) => VSBinOp repr
 powerOp = powerPrec "pow"
 
-andOp :: (RenderSym repr) => VS (repr (BinaryOp repr))
+andOp :: (RenderSym repr) => VSBinOp repr
 andOp = andPrec "&&"
 
-orOp :: (RenderSym repr) => VS (repr (BinaryOp repr))
+orOp :: (RenderSym repr) => VSBinOp repr
 orOp = orPrec "||"
 
 binOpDocD :: Doc -> Doc -> Doc -> Doc
@@ -398,18 +398,18 @@ binOpDocD op v1 v2 = v1 <+> op <+> v2
 binOpDocD' :: Doc -> Doc -> Doc -> Doc
 binOpDocD' op v1 v2 = op <> parens (v1 <> comma <+> v2)
 
-binExpr :: (RenderSym repr) => VS (repr (BinaryOp repr)) -> SValue repr -> 
+binExpr :: (RenderSym repr) => VSBinOp repr -> SValue repr -> 
   SValue repr -> SValue repr
 binExpr = on3StateValues (\b v1 v2 -> mkExpr (bOpPrec b) (numType (valueType v1)
   (valueType v2)) (binOpDocD (bOpDoc b) (exprParensL b v1 $ valueDoc v1) 
   (exprParensR b v2 $ valueDoc v2)))
 
-binExpr' :: (RenderSym repr) => VS (repr (BinaryOp repr)) -> SValue repr -> 
+binExpr' :: (RenderSym repr) => VSBinOp repr -> SValue repr -> 
   SValue repr -> SValue repr
 binExpr' = on3StateValues (\b v1 v2 -> mkExpr 9 (numType (valueType v1) 
   (valueType v2)) (binOpDocD' (bOpDoc b) (valueDoc v1) (valueDoc v2)))
 
-binExprNumDbl' :: (RenderSym repr) => VS (repr (BinaryOp repr)) -> SValue repr 
+binExprNumDbl' :: (RenderSym repr) => VSBinOp repr -> SValue repr 
   -> SValue repr -> SValue repr
 binExprNumDbl' b' v1' v2' = b' >>= (\b -> v1' >>= (\v1 -> v2' >>= (\v2 -> 
   let t1 = valueType v1
@@ -424,7 +424,7 @@ binExprCastFloat t1 t2 = castType (getType t1) (getType t2)
         castType _ Float = cast float
         castType _ _ = id
 
-typeBinExpr :: (RenderSym repr) => VS (repr (BinaryOp repr)) -> VSType repr -> 
+typeBinExpr :: (RenderSym repr) => VSBinOp repr -> VSType repr -> 
   SValue repr -> SValue repr -> SValue repr
 typeBinExpr bod tp vl1 vl2 = (\b t v1 v2 -> mkExpr (bOpPrec b) t (binOpDocD 
   (bOpDoc b) (exprParensL b v1 $ valueDoc v1) (exprParensR b v2 $ valueDoc v2)))

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer/LanguagePolymorphic.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer/LanguagePolymorphic.hs
@@ -119,73 +119,73 @@ import qualified Text.PrettyPrint.HughesPJ as D (char, double, float)
 
 -- Bodies --
 
-multiBody :: (RenderSym repr) => [MSBody repr] -> MSBody repr
+multiBody :: (RenderSym r) => [MSBody r] -> MSBody r
 multiBody bs = docBody $ onStateList vibcat $ map (onStateValue bodyDoc) bs
 
 -- Blocks --
 
-block :: (RenderSym repr) => [MSStatement repr] -> MSBlock repr
+block :: (RenderSym r) => [MSStatement r] -> MSBlock r
 block sts = docBlock $ onStateList (blockDocD . map statementDoc) 
   (map S.state sts)
 
-multiBlock :: (RenderSym repr) => [MSBlock repr] -> MSBlock repr
+multiBlock :: (RenderSym r) => [MSBlock r] -> MSBlock r
 multiBlock bs = docBlock $ onStateList vibcat $ map (onStateValue blockDoc) bs
 
 -- Types --
 
-bool :: (RenderSym repr) => VSType repr
+bool :: (RenderSym r) => VSType r
 bool = toState $ typeFromData Boolean "Boolean" (text "Boolean")
 
-int :: (RenderSym repr) => VSType repr
+int :: (RenderSym r) => VSType r
 int = toState $ typeFromData Integer "int" (text "int")
 
-float :: (RenderSym repr) => VSType repr
+float :: (RenderSym r) => VSType r
 float = toState $ typeFromData Float "float" (text "float")
 
-double :: (RenderSym repr) => VSType repr
+double :: (RenderSym r) => VSType r
 double = toState $ typeFromData Double "double" (text "double")
 
-char :: (RenderSym repr) => VSType repr
+char :: (RenderSym r) => VSType r
 char = toState $ typeFromData Char "char" (text "char")
 
-string :: (RenderSym repr) => VSType repr
+string :: (RenderSym r) => VSType r
 string = toState $ typeFromData String "string" (text "string")
 
-fileType :: (RenderSym repr) => VSType repr
+fileType :: (RenderSym r) => VSType r
 fileType = toState $ typeFromData File "File" (text "File")
 
-listType :: (RenderSym repr) => String -> VSType repr -> VSType repr
+listType :: (RenderSym r) => String -> VSType r -> VSType r
 listType lst = onStateValue (\t -> typeFromData (List (getType t)) (lst ++ "<" 
   ++ getTypeString t ++ ">") (text lst <> angles (getTypeDoc t)))
 
-arrayType :: (RenderSym repr) => VSType repr -> VSType repr
+arrayType :: (RenderSym r) => VSType r -> VSType r
 arrayType = onStateValue (\t -> typeFromData (Array (getType t)) 
   (getTypeString t ++ "[]") (getTypeDoc t <> brackets empty)) 
 
-listInnerType :: (RenderSym repr) => VSType repr -> VSType repr
+listInnerType :: (RenderSym r) => VSType r -> VSType r
 listInnerType t = t >>= (convType . getInnerType . getType)
 
-obj :: (RenderSym repr) => ClassName -> VSType repr
+obj :: (RenderSym r) => ClassName -> VSType r
 obj n = toState $ typeFromData (Object n) n (text n)
 
--- enumType :: (RenderSym repr) => Label -> VSType repr
+-- enumType :: (RenderSym r) => Label -> VSType r
 -- enumType e = toState $ typeFromData (Enum e) e (text e)
 
-funcType :: (RenderSym repr) => [VSType repr] -> VSType repr -> VSType repr
+funcType :: (RenderSym r) => [VSType r] -> VSType r -> VSType r
 funcType ps' = on2StateValues (\ps r -> typeFromData (Func (map getType ps) 
   (getType r)) "" empty) (sequence ps')
 
-void :: (RenderSym repr) => VSType repr
+void :: (RenderSym r) => VSType r
 void = toState $ typeFromData Void "void" (text "void")
 
 -- ControlBlock --
 
-strat :: (RenderSym repr) => MSStatement repr -> MSBody repr -> MSBlock repr
+strat :: (RenderSym r) => MSStatement r -> MSBody r -> MSBlock r
 strat r bd = docBlock $ on2StateValues (\result b -> vcat [bodyDoc b, 
   statementDoc result]) r bd
 
-runStrategy :: (RenderSym repr) => String -> [(Label, MSBody repr)] 
-  -> Maybe (SValue repr) -> Maybe (SVariable repr) -> MSBlock repr
+runStrategy :: (RenderSym r) => String -> [(Label, MSBody r)] 
+  -> Maybe (SValue r) -> Maybe (SVariable r) -> MSBlock r
 runStrategy l strats rv av = maybe
   (strError l "RunStrategy called on non-existent strategy") 
   (strat (S.state resultState)) (Map.lookup l (Map.fromList strats))
@@ -194,8 +194,8 @@ runStrategy l strats rv av = maybe
           "Attempt to assign null return to a Value") (v &=) rv
         strError n s = error $ "Strategy '" ++ n ++ "': " ++ s ++ "."
 
-listSlice :: (RenderSym repr) => Maybe (SValue repr) -> Maybe (SValue repr) -> 
-  Maybe (SValue repr) -> SVariable repr -> SValue repr -> MSBlock repr
+listSlice :: (RenderSym r) => Maybe (SValue r) -> Maybe (SValue r) -> 
+  Maybe (SValue r) -> SVariable r -> SValue r -> MSBlock r
 listSlice b e s vnew vold = 
   let l_temp = "temp"
       var_temp = S.var l_temp (onStateValue variableType vnew)
@@ -213,82 +213,82 @@ listSlice b e s vnew vold =
 
 -- Unary Operators --
 
-unOpPrec :: (RenderSym repr) => String -> VSUnOp repr
+unOpPrec :: (RenderSym r) => String -> VSUnOp r
 unOpPrec = uOpFromData 9 . text
 
-notOp :: (RenderSym repr) => VSUnOp repr
+notOp :: (RenderSym r) => VSUnOp r
 notOp = unOpPrec "!"
 
-notOp' :: (RenderSym repr) => VSUnOp repr
+notOp' :: (RenderSym r) => VSUnOp r
 notOp' = unOpPrec "not"
 
-negateOp :: (RenderSym repr) => VSUnOp repr
+negateOp :: (RenderSym r) => VSUnOp r
 negateOp = unOpPrec "-"
 
-sqrtOp :: (RenderSym repr) => VSUnOp repr
+sqrtOp :: (RenderSym r) => VSUnOp r
 sqrtOp = unOpPrec "sqrt"
 
-sqrtOp' :: (RenderSym repr) => VSUnOp repr
+sqrtOp' :: (RenderSym r) => VSUnOp r
 sqrtOp' = addmathImport $ unOpPrec "math.sqrt"
 
-absOp :: (RenderSym repr) => VSUnOp repr
+absOp :: (RenderSym r) => VSUnOp r
 absOp = unOpPrec "fabs"
 
-absOp' :: (RenderSym repr) => VSUnOp repr
+absOp' :: (RenderSym r) => VSUnOp r
 absOp' = addmathImport $ unOpPrec "math.fabs"
 
-expOp :: (RenderSym repr) => VSUnOp repr
+expOp :: (RenderSym r) => VSUnOp r
 expOp = unOpPrec "exp"
 
-expOp' :: (RenderSym repr) => VSUnOp repr
+expOp' :: (RenderSym r) => VSUnOp r
 expOp' = addmathImport $ unOpPrec "math.exp"
 
-sinOp :: (RenderSym repr) => VSUnOp repr
+sinOp :: (RenderSym r) => VSUnOp r
 sinOp = unOpPrec "sin"
 
-sinOp' :: (RenderSym repr) => VSUnOp repr
+sinOp' :: (RenderSym r) => VSUnOp r
 sinOp' = addmathImport $ unOpPrec "math.sin"
 
-cosOp :: (RenderSym repr) => VSUnOp repr
+cosOp :: (RenderSym r) => VSUnOp r
 cosOp = unOpPrec "cos"
 
-cosOp' :: (RenderSym repr) => VSUnOp repr
+cosOp' :: (RenderSym r) => VSUnOp r
 cosOp' = addmathImport $ unOpPrec "math.cos"
 
-tanOp :: (RenderSym repr) => VSUnOp repr
+tanOp :: (RenderSym r) => VSUnOp r
 tanOp = unOpPrec "tan"
 
-tanOp' :: (RenderSym repr) => VSUnOp repr
+tanOp' :: (RenderSym r) => VSUnOp r
 tanOp' = addmathImport $ unOpPrec "math.tan"
 
-asinOp :: (RenderSym repr) => VSUnOp repr
+asinOp :: (RenderSym r) => VSUnOp r
 asinOp = unOpPrec "asin"
 
-asinOp' :: (RenderSym repr) => VSUnOp repr
+asinOp' :: (RenderSym r) => VSUnOp r
 asinOp' = addmathImport $ unOpPrec "math.asin"
 
-acosOp :: (RenderSym repr) => VSUnOp repr
+acosOp :: (RenderSym r) => VSUnOp r
 acosOp = unOpPrec "acos"
 
-acosOp' :: (RenderSym repr) => VSUnOp repr
+acosOp' :: (RenderSym r) => VSUnOp r
 acosOp' = addmathImport $ unOpPrec "math.acos"
 
-atanOp :: (RenderSym repr) => VSUnOp repr
+atanOp :: (RenderSym r) => VSUnOp r
 atanOp = unOpPrec "atan"
 
-atanOp' :: (RenderSym repr) => VSUnOp repr
+atanOp' :: (RenderSym r) => VSUnOp r
 atanOp' = addmathImport $ unOpPrec "math.atan"
 
-csc :: (RenderSym repr) => SValue repr -> SValue repr
+csc :: (RenderSym r) => SValue r -> SValue r
 csc v = valOfOne (fmap valueType v) #/ sin v
 
-sec :: (RenderSym repr) => SValue repr -> SValue repr
+sec :: (RenderSym r) => SValue r -> SValue r
 sec v = valOfOne (fmap valueType v) #/ cos v
 
-cot :: (RenderSym repr) => SValue repr -> SValue repr
+cot :: (RenderSym r) => SValue r -> SValue r
 cot v = valOfOne (fmap valueType v) #/ tan v
 
-valOfOne :: (RenderSym repr) => VSType repr -> SValue repr
+valOfOne :: (RenderSym r) => VSType r -> SValue r
 valOfOne t = t >>= (getVal . getType)
   where getVal Float = litFloat 1.0
         getVal _ = litDouble 1.0
@@ -299,97 +299,97 @@ unOpDocD op v = op <> parens v
 unOpDocD' :: Doc -> Doc -> Doc
 unOpDocD' op v = op <> v
 
-unExpr :: (RenderSym repr) => VSUnOp repr -> SValue repr
-  -> SValue repr
+unExpr :: (RenderSym r) => VSUnOp r -> SValue r
+  -> SValue r
 unExpr = on2StateValues (mkUnExpr unOpDocD)
 
-unExpr' :: (RenderSym repr) => VSUnOp repr -> SValue repr -> 
-  SValue repr
+unExpr' :: (RenderSym r) => VSUnOp r -> SValue r -> 
+  SValue r
 unExpr' = on2StateValues (mkUnExpr unOpDocD')
 
-mkUnExpr :: (RenderSym repr) => (Doc -> Doc -> Doc) -> repr (UnaryOp repr) -> 
-  repr (Value repr) -> repr (Value repr)
+mkUnExpr :: (RenderSym r) => (Doc -> Doc -> Doc) -> r (UnaryOp r) -> 
+  r (Value r) -> r (Value r)
 mkUnExpr d u v = mkExpr (uOpPrec u) (valueType v) (d (uOpDoc u) (valueDoc v))
 
-unExprNumDbl :: (RenderSym repr) => VSUnOp repr -> SValue repr -> 
-  SValue repr
+unExprNumDbl :: (RenderSym r) => VSUnOp r -> SValue r -> 
+  SValue r
 unExprNumDbl u' v' = u' >>= (\u -> v' >>= (\v -> 
   unExprCastFloat (valueType v) $ return $ mkUnExpr unOpDocD u v))
 
-unExprCastFloat :: (RenderSym repr) => repr (Type repr) -> (SValue repr -> 
-  SValue repr)
+unExprCastFloat :: (RenderSym r) => r (Type r) -> (SValue r -> 
+  SValue r)
 unExprCastFloat t = castType $ getType t
   where castType Float = cast float
         castType _ = id
   
-typeUnExpr :: (RenderSym repr) => VSUnOp repr -> VSType repr -> 
-  SValue repr -> SValue repr
+typeUnExpr :: (RenderSym r) => VSUnOp r -> VSType r -> 
+  SValue r -> SValue r
 typeUnExpr = on3StateValues (\u t -> mkExpr (uOpPrec u) t . unOpDocD (uOpDoc u) 
   . valueDoc)
 
 -- Binary Operators --
 
-compEqualPrec :: (RenderSym repr) => String -> VSBinOp repr
+compEqualPrec :: (RenderSym r) => String -> VSBinOp r
 compEqualPrec = bOpFromData 4 . text
 
-compPrec :: (RenderSym repr) => String -> VSBinOp repr
+compPrec :: (RenderSym r) => String -> VSBinOp r
 compPrec = bOpFromData 5 . text
 
-addPrec :: (RenderSym repr) => String -> VSBinOp repr
+addPrec :: (RenderSym r) => String -> VSBinOp r
 addPrec = bOpFromData 6 . text
 
-multPrec :: (RenderSym repr) => String -> VSBinOp repr
+multPrec :: (RenderSym r) => String -> VSBinOp r
 multPrec = bOpFromData 7 . text
 
-powerPrec :: (RenderSym repr) => String -> VSBinOp repr
+powerPrec :: (RenderSym r) => String -> VSBinOp r
 powerPrec = bOpFromData 8 . text
 
-andPrec :: (RenderSym repr) => String -> VSBinOp repr 
+andPrec :: (RenderSym r) => String -> VSBinOp r 
 andPrec = bOpFromData 3 . text
 
-orPrec :: (RenderSym repr) => String -> VSBinOp repr
+orPrec :: (RenderSym r) => String -> VSBinOp r
 orPrec = bOpFromData 2 . text
 
-equalOp :: (RenderSym repr) => VSBinOp repr
+equalOp :: (RenderSym r) => VSBinOp r
 equalOp = compEqualPrec "=="
 
-notEqualOp :: (RenderSym repr) => VSBinOp repr
+notEqualOp :: (RenderSym r) => VSBinOp r
 notEqualOp = compEqualPrec "!="
 
-greaterOp :: (RenderSym repr) => VSBinOp repr
+greaterOp :: (RenderSym r) => VSBinOp r
 greaterOp = compPrec ">"
 
-greaterEqualOp :: (RenderSym repr) => VSBinOp repr
+greaterEqualOp :: (RenderSym r) => VSBinOp r
 greaterEqualOp = compPrec ">="
 
-lessOp :: (RenderSym repr) => VSBinOp repr
+lessOp :: (RenderSym r) => VSBinOp r
 lessOp = compPrec "<"
 
-lessEqualOp :: (RenderSym repr) => VSBinOp repr
+lessEqualOp :: (RenderSym r) => VSBinOp r
 lessEqualOp = compPrec "<="
 
-plusOp :: (RenderSym repr) => VSBinOp repr
+plusOp :: (RenderSym r) => VSBinOp r
 plusOp = addPrec "+"
 
-minusOp :: (RenderSym repr) => VSBinOp repr
+minusOp :: (RenderSym r) => VSBinOp r
 minusOp = addPrec "-"
 
-multOp :: (RenderSym repr) => VSBinOp repr
+multOp :: (RenderSym r) => VSBinOp r
 multOp = multPrec "*"
 
-divideOp :: (RenderSym repr) => VSBinOp repr
+divideOp :: (RenderSym r) => VSBinOp r
 divideOp = multPrec "/"
 
-moduloOp :: (RenderSym repr) => VSBinOp repr
+moduloOp :: (RenderSym r) => VSBinOp r
 moduloOp = multPrec "%"
 
-powerOp :: (RenderSym repr) => VSBinOp repr
+powerOp :: (RenderSym r) => VSBinOp r
 powerOp = powerPrec "pow"
 
-andOp :: (RenderSym repr) => VSBinOp repr
+andOp :: (RenderSym r) => VSBinOp r
 andOp = andPrec "&&"
 
-orOp :: (RenderSym repr) => VSBinOp repr
+orOp :: (RenderSym r) => VSBinOp r
 orOp = orPrec "||"
 
 binOpDocD :: Doc -> Doc -> Doc -> Doc
@@ -398,34 +398,34 @@ binOpDocD op v1 v2 = v1 <+> op <+> v2
 binOpDocD' :: Doc -> Doc -> Doc -> Doc
 binOpDocD' op v1 v2 = op <> parens (v1 <> comma <+> v2)
 
-binExpr :: (RenderSym repr) => VSBinOp repr -> SValue repr -> 
-  SValue repr -> SValue repr
+binExpr :: (RenderSym r) => VSBinOp r -> SValue r -> 
+  SValue r -> SValue r
 binExpr = on3StateValues (\b v1 v2 -> mkExpr (bOpPrec b) (numType (valueType v1)
   (valueType v2)) (binOpDocD (bOpDoc b) (exprParensL b v1 $ valueDoc v1) 
   (exprParensR b v2 $ valueDoc v2)))
 
-binExpr' :: (RenderSym repr) => VSBinOp repr -> SValue repr -> 
-  SValue repr -> SValue repr
+binExpr' :: (RenderSym r) => VSBinOp r -> SValue r -> 
+  SValue r -> SValue r
 binExpr' = on3StateValues (\b v1 v2 -> mkExpr 9 (numType (valueType v1) 
   (valueType v2)) (binOpDocD' (bOpDoc b) (valueDoc v1) (valueDoc v2)))
 
-binExprNumDbl' :: (RenderSym repr) => VSBinOp repr -> SValue repr 
-  -> SValue repr -> SValue repr
+binExprNumDbl' :: (RenderSym r) => VSBinOp r -> SValue r 
+  -> SValue r -> SValue r
 binExprNumDbl' b' v1' v2' = b' >>= (\b -> v1' >>= (\v1 -> v2' >>= (\v2 -> 
   let t1 = valueType v1
       t2 = valueType v2
   in binExprCastFloat t1 t2 $ return $ mkExpr 9 (numType t1 t2) 
   (binOpDocD' (bOpDoc b) (valueDoc v1) (valueDoc v2)))))
 
-binExprCastFloat :: (RenderSym repr) => repr (Type repr) -> repr (Type repr) ->
-  (SValue repr -> SValue repr)
+binExprCastFloat :: (RenderSym r) => r (Type r) -> r (Type r) ->
+  (SValue r -> SValue r)
 binExprCastFloat t1 t2 = castType (getType t1) (getType t2)
   where castType Float _ = cast float
         castType _ Float = cast float
         castType _ _ = id
 
-typeBinExpr :: (RenderSym repr) => VSBinOp repr -> VSType repr -> 
-  SValue repr -> SValue repr -> SValue repr
+typeBinExpr :: (RenderSym r) => VSBinOp r -> VSType r -> 
+  SValue r -> SValue r -> SValue r
 typeBinExpr bod tp vl1 vl2 = (\b t v1 v2 -> mkExpr (bOpPrec b) t (binOpDocD 
   (bOpDoc b) (exprParensL b v1 $ valueDoc v1) (exprParensR b v2 $ valueDoc v2)))
   <$> bod <*> tp <*> vl1 <*> vl2 
@@ -435,105 +435,105 @@ addmathImport = (>>) $ modify (addLangImportVS "math")
 
 -- Variables --
 
-var :: (RenderSym repr) => Label -> VSType repr -> SVariable repr
+var :: (RenderSym r) => Label -> VSType r -> SVariable r
 var n t = mkStateVar n t (varDocD n)
 
-staticVar :: (RenderSym repr) => Label -> VSType repr -> SVariable repr
+staticVar :: (RenderSym r) => Label -> VSType r -> SVariable r
 staticVar n t = mkStaticVar n t (varDocD n)
 
-extVar :: (RenderSym repr) => Label -> Label -> VSType repr -> SVariable repr
+extVar :: (RenderSym r) => Label -> Label -> VSType r -> SVariable r
 extVar l n t = mkStateVar (l ++ "." ++ n) t (extVarDocD l n)
 
-self :: (RenderSym repr) => SVariable repr
+self :: (RenderSym r) => SVariable r
 self = zoom lensVStoMS getClassName >>= (\l -> mkStateVar "this" (obj l) selfDocD)
 
--- enumVar :: (RenderSym repr) => Label -> Label -> SVariable repr
+-- enumVar :: (RenderSym r) => Label -> Label -> SVariable r
 -- enumVar e en = S.var e (enumType en)
 
-classVar :: (RenderSym repr) => (Doc -> Doc -> Doc) -> VSType repr -> 
-  SVariable repr -> SVariable repr
+classVar :: (RenderSym r) => (Doc -> Doc -> Doc) -> VSType r -> 
+  SVariable r -> SVariable r
 classVar f = on2StateValues (\c v -> classVarCheckStatic $ varFromData 
   (variableBind v) (getTypeString c ++ "." ++ variableName v) 
   (variableType v) (f (getTypeDoc c) (variableDoc v)))
 
-objVar :: (RenderSym repr) => SVariable repr -> SVariable repr -> SVariable repr
+objVar :: (RenderSym r) => SVariable r -> SVariable r -> SVariable r
 objVar = on2StateValues (\o v -> mkVar (variableName o ++ "." ++ variableName 
   v) (variableType v) (objVarDocD (variableDoc o) (variableDoc v)))
 
-objVarSelf :: (RenderSym repr) => SVariable repr -> SVariable repr
+objVarSelf :: (RenderSym r) => SVariable r -> SVariable r
 objVarSelf = S.objVar S.self
 
-listVar :: (RenderSym repr) => Label -> VSType repr -> SVariable repr
+listVar :: (RenderSym r) => Label -> VSType r -> SVariable r
 listVar n t = S.var n (S.listType t)
 
-arrayElem :: (RenderSym repr) => SValue repr -> SVariable repr -> SVariable repr
+arrayElem :: (RenderSym r) => SValue r -> SVariable r -> SVariable r
 arrayElem i' v' = join $ on2StateValues (\i v -> mkStateVar (variableName v ++ 
   "[" ++ render (valueDoc i) ++ "]") (listInnerType $ toState $ variableType v) 
   (variableDoc v <> brackets (valueDoc i))) i' v'
 
-iterVar :: (RenderSym repr) => Label -> VSType repr -> SVariable repr
+iterVar :: (RenderSym r) => Label -> VSType r -> SVariable r
 iterVar n t = S.var n (iterator t)
 
 -- Values --
 
-litTrue :: (RenderSym repr) => SValue repr
+litTrue :: (RenderSym r) => SValue r
 litTrue = mkStateVal S.bool (text "true")
 
-litFalse :: (RenderSym repr) => SValue repr
+litFalse :: (RenderSym r) => SValue r
 litFalse = mkStateVal S.bool (text "false")
 
-litChar :: (RenderSym repr) => Char -> SValue repr
+litChar :: (RenderSym r) => Char -> SValue r
 litChar c = mkStateVal S.char (quotes $ D.char c)
 
-litDouble :: (RenderSym repr) => Double -> SValue repr
+litDouble :: (RenderSym r) => Double -> SValue r
 litDouble d = mkStateVal S.double (D.double d)
 
-litFloat :: (RenderSym repr) => Float -> SValue repr
+litFloat :: (RenderSym r) => Float -> SValue r
 litFloat f = mkStateVal S.float (D.float f <> text "f")
 
-litInt :: (RenderSym repr) => Integer -> SValue repr
+litInt :: (RenderSym r) => Integer -> SValue r
 litInt i = mkStateVal S.int (integer i)
 
-litString :: (RenderSym repr) => String -> SValue repr
+litString :: (RenderSym r) => String -> SValue r
 litString s = mkStateVal S.string (doubleQuotedText s)
 
-litArray :: (RenderSym repr) => VSType repr -> [SValue repr] -> SValue repr
+litArray :: (RenderSym r) => VSType r -> [SValue r] -> SValue r
 litArray t es = sequence es >>= (\elems -> mkStateVal (S.arrayType t) 
   (braces $ valueList elems))
 
-litList :: (RenderSym repr) => (VSType repr -> VSType repr) -> VSType repr -> 
-  [SValue repr] -> SValue repr
+litList :: (RenderSym r) => (VSType r -> VSType r) -> VSType r -> 
+  [SValue r] -> SValue r
 litList f t = on1StateValue1List (\lt es -> mkVal lt (new <+> getTypeDoc lt <+> 
   braces (valueList es))) (f t)
 
-pi :: (RenderSym repr) => SValue repr
+pi :: (RenderSym r) => SValue r
 pi = mkStateVal S.double (text "Math.PI")
 
-valueOf :: (RenderSym repr) => SVariable repr -> SValue repr
+valueOf :: (RenderSym r) => SVariable r -> SValue r
 valueOf = onStateValue (\v -> mkVal (variableType v) (variableDoc v))
 
-arg :: (RenderSym repr) => SValue repr -> SValue repr -> SValue repr
+arg :: (RenderSym r) => SValue r -> SValue r -> SValue r
 arg = on3StateValues (\s n args -> mkVal s (argDocD n args)) S.string
 
--- enumElement :: (RenderSym repr) => Label -> Label -> SValue repr
+-- enumElement :: (RenderSym r) => Label -> Label -> SValue r
 -- enumElement en (e = mkStateVal (enumType en) (enumElemDocD en e)
 
-argsList :: (RenderSym repr) => String -> SValue repr
+argsList :: (RenderSym r) => String -> SValue r
 argsList l = mkStateVal (S.arrayType S.string) (text l)
 
-inlineIf :: (RenderSym repr) => SValue repr -> SValue repr -> SValue repr -> 
-  SValue repr
+inlineIf :: (RenderSym r) => SValue r -> SValue r -> SValue r -> 
+  SValue r
 inlineIf = on3StateValues (\c v1 v2 -> valFromData (prec c) (valueType v1) 
   (valueDoc c <+> text "?" <+> valueDoc v1 <+> text ":" <+> valueDoc v2)) 
   where prec cd = valuePrec cd <|> Just 0
 
-call' :: (RenderSym repr) => String -> Maybe Library -> Label -> VSType repr -> 
-  Maybe Doc -> [SValue repr] -> [NamedArg repr] -> SValue repr
+call' :: (RenderSym r) => String -> Maybe Library -> Label -> VSType r -> 
+  Maybe Doc -> [SValue r] -> [NamedArg r] -> SValue r
 call' l _ _ _ _ _ (_:_) = error $ namedArgError l
 call' _ l n t o ps ns = call empty l n t o ps ns
 
-call :: (RenderSym repr) => Doc -> Maybe Library -> Label -> VSType repr -> 
-  Maybe Doc -> [SValue repr] -> [NamedArg repr] -> SValue repr
+call :: (RenderSym r) => Doc -> Maybe Library -> Label -> VSType r -> 
+  Maybe Doc -> [SValue r] -> [NamedArg r] -> SValue r
 call sep lib n t o pas nas = (\tp pargs nms nargs -> mkVal tp $ obDoc <> libDoc 
   <> text n <> parens (valueList pargs <+> (if null pas || null nas then empty 
   else comma) <+> hcat (intersperse (text ", ") (zipWith (\nm a -> 
@@ -542,91 +542,91 @@ call sep lib n t o pas nas = (\tp pargs nms nargs -> mkVal tp $ obDoc <> libDoc
   where libDoc = maybe empty (text . (++ ".")) lib
         obDoc = fromMaybe empty o
 
-funcAppMixedArgs :: (RenderSym repr) => MixedCall repr
+funcAppMixedArgs :: (RenderSym r) => MixedCall r
 funcAppMixedArgs n t = S.call Nothing n t Nothing
 
 namedArgError :: String -> String
 namedArgError l = "Named arguments not supported in " ++ l 
 
-selfFuncAppMixedArgs :: (RenderSym repr) => Doc -> SVariable repr -> MixedCall repr
+selfFuncAppMixedArgs :: (RenderSym r) => Doc -> SVariable r -> MixedCall r
 selfFuncAppMixedArgs d slf n t vs ns = slf >>= (\s -> S.call Nothing n t 
   (Just $ variableDoc s <> d) vs ns)
 
-extFuncAppMixedArgs :: (RenderSym repr) => Library -> MixedCall repr
+extFuncAppMixedArgs :: (RenderSym r) => Library -> MixedCall r
 extFuncAppMixedArgs l n t = S.call (Just l) n t Nothing
 
-libFuncAppMixedArgs :: (RenderSym repr) => Library -> MixedCall repr
+libFuncAppMixedArgs :: (RenderSym r) => Library -> MixedCall r
 libFuncAppMixedArgs l n t vs ns = modify (addLibImportVS l) >> 
   S.funcAppMixedArgs n t vs ns
 
-newObjMixedArgs :: (RenderSym repr) => String -> MixedCtorCall repr
+newObjMixedArgs :: (RenderSym r) => String -> MixedCtorCall r
 newObjMixedArgs s tp vs ns = tp >>= 
   (\t -> S.call Nothing (s ++ getTypeString t) (return t) Nothing vs ns)
 
-extNewObjMixedArgs :: (RenderSym repr) => Library -> MixedCtorCall repr
+extNewObjMixedArgs :: (RenderSym r) => Library -> MixedCtorCall r
 extNewObjMixedArgs l tp vs ns = tp >>= (\t -> S.call (Just l) (getTypeString t) 
   (return t) Nothing vs ns)
 
-libNewObjMixedArgs :: (RenderSym repr) => Library -> MixedCtorCall repr
+libNewObjMixedArgs :: (RenderSym r) => Library -> MixedCtorCall r
 libNewObjMixedArgs l tp vs ns = modify (addLibImportVS l) >> 
   S.newObjMixedArgs tp vs ns
 
-notNull :: (RenderSym repr) => SValue repr -> SValue repr
+notNull :: (RenderSym r) => SValue r -> SValue r
 notNull v = v ?!= S.valueOf (S.var "null" $ onStateValue valueType v)
 
-lambda :: (RenderSym repr) => ([repr (Variable repr)] -> repr (Value repr) -> 
-  Doc) -> [SVariable repr] -> SValue repr -> SValue repr
+lambda :: (RenderSym r) => ([r (Variable r)] -> r (Value r) -> 
+  Doc) -> [SVariable r] -> SValue r -> SValue r
 lambda f ps' ex' = sequence ps' >>= (\ps -> ex' >>= (\ex -> funcType (map 
   (toState . variableType) ps) (toState $ valueType ex) >>= (\ft -> 
   toState $ valFromData (Just 0) ft (f ps ex))))
 
-objAccess :: (RenderSym repr) => SValue repr -> VSFunction repr -> SValue repr
+objAccess :: (RenderSym r) => SValue r -> VSFunction r -> SValue r
 objAccess = on2StateValues (\v f -> mkVal (functionType f) (objAccessDocD 
   (valueDoc v) (functionDoc f)))
 
-objMethodCall :: (RenderSym repr) => Label -> VSType repr -> SValue repr -> 
-  [SValue repr] -> [NamedArg repr] -> SValue repr
+objMethodCall :: (RenderSym r) => Label -> VSType r -> SValue r -> 
+  [SValue r] -> [NamedArg r] -> SValue r
 objMethodCall f t ob vs ns = ob >>= (\o -> S.call Nothing f t 
   (Just $ valueDoc o <> dot) vs ns)
 
-objMethodCallNoParams :: (RenderSym repr) => Label -> VSType repr -> 
-  SValue repr -> SValue repr
+objMethodCallNoParams :: (RenderSym r) => Label -> VSType r -> 
+  SValue r -> SValue r
 objMethodCallNoParams f t o = S.objMethodCall t o f []
 
-indexOf :: (RenderSym repr) => Label -> SValue repr -> SValue repr -> 
-  SValue repr
+indexOf :: (RenderSym r) => Label -> SValue r -> SValue r -> 
+  SValue r
 indexOf f l v = S.objAccess l (S.func f S.int [v])
 
 -- Functions --
 
-func :: (RenderSym repr) => Label -> VSType repr -> [SValue repr] -> 
-  VSFunction repr
+func :: (RenderSym r) => Label -> VSType r -> [SValue r] -> 
+  VSFunction r
 func l t vs = funcApp l t vs >>= ((`funcFromData` t) . funcDocD . valueDoc)
 
-get :: (RenderSym repr) => SValue repr -> SVariable repr -> SValue repr
+get :: (RenderSym r) => SValue r -> SVariable r -> SValue r
 get v vToGet = v $. S.getFunc vToGet
 
-set :: (RenderSym repr) => SValue repr -> SVariable repr -> SValue repr -> 
-  SValue repr
+set :: (RenderSym r) => SValue r -> SVariable r -> SValue r -> 
+  SValue r
 set v vToSet toVal = v $. S.setFunc (onStateValue valueType v) vToSet toVal
 
-listSize :: (RenderSym repr) => SValue repr -> SValue repr
+listSize :: (RenderSym r) => SValue r -> SValue r
 listSize v = v $. S.listSizeFunc
 
-listAdd :: (RenderSym repr) => SValue repr -> SValue repr -> SValue repr -> 
-  SValue repr
+listAdd :: (RenderSym r) => SValue r -> SValue r -> SValue r -> 
+  SValue r
 listAdd v i vToAdd = v $. S.listAddFunc v i vToAdd
 
-listAppend :: (RenderSym repr) => SValue repr -> SValue repr -> SValue repr
+listAppend :: (RenderSym r) => SValue r -> SValue r -> SValue r
 listAppend v vToApp = v $. S.listAppendFunc vToApp
 
-iterBegin :: (RenderSym repr) => SValue repr -> SValue repr
+iterBegin :: (RenderSym r) => SValue r -> SValue r
 iterBegin v = v $. iterBeginFunc (S.listInnerType $ onStateValue valueType v)
 
-iterEnd :: (RenderSym repr) => SValue repr -> SValue repr
+iterEnd :: (RenderSym r) => SValue r -> SValue r
 iterEnd v = v $. iterEndFunc (S.listInnerType $ onStateValue valueType v)
 
-listAccess :: (RenderSym repr) => SValue repr -> SValue repr -> SValue repr
+listAccess :: (RenderSym r) => SValue r -> SValue r -> SValue r
 listAccess v i = do
   v' <- v
   let checkType (List _) = S.listAccessFunc (S.listInnerType $ return $ 
@@ -636,28 +636,28 @@ listAccess v i = do
       checkType _ = error "listAccess called on non-list-type value"
   v $. checkType (getType (valueType v'))
 
-listSet :: (RenderSym repr) => SValue repr -> SValue repr -> SValue repr -> 
-  SValue repr
+listSet :: (RenderSym r) => SValue r -> SValue r -> SValue r -> 
+  SValue r
 listSet v i toVal = v $. S.listSetFunc v i toVal
 
-getFunc :: (RenderSym repr) => SVariable repr -> VSFunction repr
+getFunc :: (RenderSym r) => SVariable r -> VSFunction r
 getFunc v = v >>= (\vr -> S.func (getterName $ variableName vr) 
   (toState $ variableType vr) [])
 
-setFunc :: (RenderSym repr) => VSType repr -> SVariable repr -> SValue repr -> 
-  VSFunction repr
+setFunc :: (RenderSym r) => VSType r -> SVariable r -> SValue r -> 
+  VSFunction r
 setFunc t v toVal = v >>= (\vr -> S.func (setterName $ variableName vr) t 
   [toVal])
 
-listSizeFunc :: (RenderSym repr) => VSFunction repr
+listSizeFunc :: (RenderSym r) => VSFunction r
 listSizeFunc = S.func "size" S.int []
 
-listAddFunc :: (RenderSym repr) => Label -> SValue repr -> SValue repr -> 
-  VSFunction repr
+listAddFunc :: (RenderSym r) => Label -> SValue r -> SValue r -> 
+  VSFunction r
 listAddFunc f i v = S.func f (S.listType $ onStateValue valueType v) 
   [i, v]
 
-listAppendFunc :: (RenderSym repr) => Label -> SValue repr -> VSFunction repr
+listAppendFunc :: (RenderSym r) => Label -> SValue r -> VSFunction r
 listAppendFunc f v = S.func f (S.listType $ onStateValue valueType v) [v]
 
 iterBeginError :: String -> String
@@ -668,157 +668,157 @@ iterEndError :: String -> String
 iterEndError l = "Attempt to use iterEndFunc in " ++ l ++ ", but " ++ l ++ 
   " has no iterators"
 
-listAccessFunc :: (RenderSym repr) => VSType repr -> SValue repr -> 
-  VSFunction repr
+listAccessFunc :: (RenderSym r) => VSType r -> SValue r -> 
+  VSFunction r
 listAccessFunc t v = intValue v >>= ((`funcFromData` t) . listAccessFuncDocD)
 
-listAccessFunc' :: (RenderSym repr) => Label -> VSType repr -> SValue repr -> 
-  VSFunction repr
+listAccessFunc' :: (RenderSym r) => Label -> VSType r -> SValue r -> 
+  VSFunction r
 listAccessFunc' f t i = S.func f t [intValue i]
 
-listSetFunc :: (RenderSym repr) => (Doc -> Doc -> Doc) -> SValue repr -> 
-  SValue repr -> SValue repr -> VSFunction repr
+listSetFunc :: (RenderSym r) => (Doc -> Doc -> Doc) -> SValue r -> 
+  SValue r -> SValue r -> VSFunction r
 listSetFunc f v idx setVal = join $ on2StateValues (\i toVal -> funcFromData 
   (f (valueDoc i) (valueDoc toVal)) (onStateValue valueType v)) (intValue idx) 
   setVal
 
 -- Statements --
 
-printSt :: (RenderSym repr) => SValue repr -> SValue repr -> MSStatement repr
+printSt :: (RenderSym r) => SValue r -> SValue r -> MSStatement r
 printSt p v = zoom lensMStoVS $ on2StateValues (\p' -> mkSt . printDoc p') p v
 
-state :: (RenderSym repr) => MSStatement repr -> MSStatement repr
+state :: (RenderSym r) => MSStatement r -> MSStatement r
 state = onStateValue (\s -> mkStNoEnd (statementDoc s <> getTermDoc 
   (statementTerm s)))
   
-loopState :: (RenderSym repr) => MSStatement repr -> MSStatement repr
+loopState :: (RenderSym r) => MSStatement r -> MSStatement r
 loopState = S.state . setEmpty
 
-emptyState :: (RenderSym repr) => MSStatement repr
+emptyState :: (RenderSym r) => MSStatement r
 emptyState = toState $ mkStNoEnd empty
 
-assign :: (RenderSym repr) => Terminator -> SVariable repr -> SValue repr -> 
-  MSStatement repr
+assign :: (RenderSym r) => Terminator -> SVariable r -> SValue r -> 
+  MSStatement r
 assign t vr vl = zoom lensMStoVS $ on2StateValues (\vr' vl' -> stateFromData 
   (assignDocD vr' vl') t) vr vl
 
 multiAssignError :: String -> String
 multiAssignError l = "No multiple assignment statements in " ++ l
 
-decrement :: (RenderSym repr) => SVariable repr -> SValue repr -> 
-  MSStatement repr
+decrement :: (RenderSym r) => SVariable r -> SValue r -> 
+  MSStatement r
 decrement vr vl = vr &= (S.valueOf vr #- vl)
 
-increment :: (RenderSym repr) => SVariable repr -> SValue repr -> 
-  MSStatement repr
+increment :: (RenderSym r) => SVariable r -> SValue r -> 
+  MSStatement r
 increment vr vl = zoom lensMStoVS $ on2StateValues (\vr' -> mkSt . 
   plusEqualsDocD vr') vr vl
 
-increment1 :: (RenderSym repr) => SVariable repr -> MSStatement repr
+increment1 :: (RenderSym r) => SVariable r -> MSStatement r
 increment1 vr = zoom lensMStoVS $ onStateValue (mkSt . plusPlusDocD) vr
 
-increment' :: (RenderSym repr) => SVariable repr -> SValue repr -> 
-  MSStatement repr
+increment' :: (RenderSym r) => SVariable r -> SValue r -> 
+  MSStatement r
 increment' vr vl = vr &= S.valueOf vr #+ vl
 
-increment1' :: (RenderSym repr) => SVariable repr -> MSStatement repr
+increment1' :: (RenderSym r) => SVariable r -> MSStatement r
 increment1' vr = vr &= S.valueOf vr #+ S.litInt 1
 
-decrement1 :: (RenderSym repr) => SVariable repr -> 
-  MSStatement repr
+decrement1 :: (RenderSym r) => SVariable r -> 
+  MSStatement r
 decrement1 v = v &= (S.valueOf v #- S.litInt 1)
 
-varDec :: (RenderSym repr) => repr (Permanence repr) -> repr (Permanence repr) 
-  -> SVariable repr -> MSStatement repr
+varDec :: (RenderSym r) => r (Permanence r) -> r (Permanence r) 
+  -> SVariable r -> MSStatement r
 varDec s d v' = onStateValue (\v -> mkSt (permDoc (bind $ variableBind v) 
   <+> getTypeDoc (variableType v) <+> variableDoc v)) (zoom lensMStoVS v')
   where bind Static = s
         bind Dynamic = d
 
-varDecDef :: (RenderSym repr) => SVariable repr -> SValue repr -> 
-  MSStatement repr
+varDecDef :: (RenderSym r) => SVariable r -> SValue r -> 
+  MSStatement r
 varDecDef vr vl' = on2StateValues (\vd vl -> mkSt (statementDoc vd <+> equals 
   <+> valueDoc vl)) (S.varDec vr) (zoom lensMStoVS vl')
 
-listDec :: (RenderSym repr) => (repr (Value repr) -> Doc) -> SValue repr -> 
-  SVariable repr -> MSStatement repr
+listDec :: (RenderSym r) => (r (Value r) -> Doc) -> SValue r -> 
+  SVariable r -> MSStatement r
 listDec f vl v = on2StateValues (\sz vd -> mkSt (statementDoc vd <> f 
   sz)) (zoom lensMStoVS vl) (S.varDec v)
 
-listDecDef :: (RenderSym repr) => ([repr (Value repr)] -> Doc) -> 
-  SVariable repr -> [SValue repr] -> MSStatement repr
+listDecDef :: (RenderSym r) => ([r (Value r)] -> Doc) -> 
+  SVariable r -> [SValue r] -> MSStatement r
 listDecDef f v vls = on1StateValue1List (\vd vs -> mkSt (statementDoc vd <> 
   f vs)) (S.varDec v) (map (zoom lensMStoVS) vls)
 
-listDecDef' :: (RenderSym repr) => SVariable repr -> [SValue repr] -> 
-  MSStatement repr
+listDecDef' :: (RenderSym r) => SVariable r -> [SValue r] -> 
+  MSStatement r
 listDecDef' v vals = zoom lensMStoVS v >>= (\vr -> S.varDecDef (return vr) 
   (S.litList (listInnerType $ return $ variableType vr) vals))
 
-arrayDec :: (RenderSym repr) => SValue repr -> SVariable repr -> 
-  MSStatement repr
+arrayDec :: (RenderSym r) => SValue r -> SVariable r -> 
+  MSStatement r
 arrayDec n vr = zoom lensMStoVS $ on3StateValues (\sz v it -> mkSt (getTypeDoc 
   (variableType v) <+> variableDoc v <+> equals <+> new <+> getTypeDoc it <> 
   brackets (valueDoc sz))) n vr (listInnerType $ onStateValue variableType vr)
 
-arrayDecDef :: (RenderSym repr) => SVariable repr -> [SValue repr] -> 
-  MSStatement repr
+arrayDecDef :: (RenderSym r) => SVariable r -> [SValue r] -> 
+  MSStatement r
 arrayDecDef v vals = on2StateValues (\vd vs -> mkSt (statementDoc vd <+> 
   equals <+> braces (valueList vs))) (S.varDec v) (mapM (zoom lensMStoVS) vals)
 
-objDecNew :: (RenderSym repr) => SVariable repr -> [SValue repr] -> 
-  MSStatement repr
+objDecNew :: (RenderSym r) => SVariable r -> [SValue r] -> 
+  MSStatement r
 objDecNew v vs = S.varDecDef v (newObj (onStateValue variableType v) vs)
 
-objDecNewNoParams :: (RenderSym repr) => SVariable repr -> MSStatement repr
+objDecNewNoParams :: (RenderSym r) => SVariable r -> MSStatement r
 objDecNewNoParams v = S.objDecNew v []
 
-extObjDecNew :: (RenderSym repr) => Library -> SVariable repr -> [SValue repr] 
-  -> MSStatement repr
+extObjDecNew :: (RenderSym r) => Library -> SVariable r -> [SValue r] 
+  -> MSStatement r
 extObjDecNew l v vs = S.varDecDef v (extNewObj l (onStateValue variableType v)
   vs)
 
-extObjDecNewNoParams :: (RenderSym repr) => Library -> SVariable repr
-  -> MSStatement repr
+extObjDecNewNoParams :: (RenderSym r) => Library -> SVariable r
+  -> MSStatement r
 extObjDecNewNoParams l v = S.extObjDecNew l v []
 
-constDecDef :: (RenderSym repr) => SVariable repr -> SValue repr -> 
-  MSStatement repr
+constDecDef :: (RenderSym r) => SVariable r -> SValue r -> 
+  MSStatement r
 constDecDef vr vl = zoom lensMStoVS $ on2StateValues (\v -> mkSt . 
   constDecDefDocD v) vr vl
 
-funcDecDef :: (RenderSym repr) => SVariable repr -> [SVariable repr] -> 
-  SValue repr -> MSStatement repr
+funcDecDef :: (RenderSym r) => SVariable r -> [SVariable r] -> 
+  SValue r -> MSStatement r
 funcDecDef v ps r = S.varDecDef v (S.lambda ps r)
 
-discardInput :: (RenderSym repr) => (repr (Value repr) -> Doc) ->
-  MSStatement repr
+discardInput :: (RenderSym r) => (r (Value r) -> Doc) ->
+  MSStatement r
 discardInput f = zoom lensMStoVS $ onStateValue (mkSt . f) inputFunc
 
-discardFileInput :: (RenderSym repr) => (repr (Value repr) -> Doc) -> 
-  SValue repr -> MSStatement repr
+discardFileInput :: (RenderSym r) => (r (Value r) -> Doc) -> 
+  SValue r -> MSStatement r
 discardFileInput f v = zoom lensMStoVS $ onStateValue (mkSt . f) v
 
-openFileR :: (RenderSym repr) => (SValue repr -> VSType repr -> SValue repr) -> 
-  SVariable repr -> SValue repr -> MSStatement repr
+openFileR :: (RenderSym r) => (SValue r -> VSType r -> SValue r) -> 
+  SVariable r -> SValue r -> MSStatement r
 openFileR f vr vl = vr &= f vl infile
 
-openFileW :: (RenderSym repr) => (SValue repr -> VSType repr -> SValue repr -> 
-  SValue repr) -> SVariable repr -> SValue repr -> MSStatement repr
+openFileW :: (RenderSym r) => (SValue r -> VSType r -> SValue r -> 
+  SValue r) -> SVariable r -> SValue r -> MSStatement r
 openFileW f vr vl = vr &= f vl outfile S.litFalse
 
-openFileA :: (RenderSym repr) => (SValue repr -> VSType repr -> SValue repr -> 
-  SValue repr) -> SVariable repr -> SValue repr -> MSStatement repr
+openFileA :: (RenderSym r) => (SValue r -> VSType r -> SValue r -> 
+  SValue r) -> SVariable r -> SValue r -> MSStatement r
 openFileA f vr vl = vr &= f vl outfile S.litTrue
 
-closeFile :: (RenderSym repr) => Label -> SValue repr -> MSStatement repr
+closeFile :: (RenderSym r) => Label -> SValue r -> MSStatement r
 closeFile n f = S.valState $ S.objMethodCallNoParams S.void f n
 
-discardFileLine :: (RenderSym repr) => Label -> SValue repr -> MSStatement repr
+discardFileLine :: (RenderSym r) => Label -> SValue r -> MSStatement r
 discardFileLine n f = S.valState $ S.objMethodCallNoParams S.string f n 
 
-stringListVals :: (RenderSym repr) => [SVariable repr] -> SValue repr -> 
-  MSStatement repr
+stringListVals :: (RenderSym r) => [SVariable r] -> SValue r -> 
+  MSStatement r
 stringListVals vars sl = zoom lensMStoVS sl >>= (\slst -> multi $ checkList 
   (getType $ valueType slst))
   where checkList (List String) = assignVals vars 0
@@ -828,8 +828,8 @@ stringListVals vars sl = zoom lensMStoVS sl >>= (\slst -> multi $ checkList
         assignVals (v:vs) n = S.assign v (cast (onStateValue variableType v) 
           (S.listAccess sl (S.litInt n))) : assignVals vs (n+1)
 
-stringListLists :: (RenderSym repr) => [SVariable repr] -> SValue repr -> 
-  MSStatement repr
+stringListLists :: (RenderSym r) => [SVariable r] -> SValue r -> 
+  MSStatement r
 stringListLists lsts sl = zoom lensMStoVS sl >>= (\slst -> checkList (getType $ 
   valueType slst))
   where checkList (List String) = mapM (zoom lensMStoVS) lsts >>= listVals . 
@@ -851,29 +851,29 @@ stringListLists lsts sl = zoom lensMStoVS sl >>= (\slst -> checkList (getType $
         var_i = S.var "stringlist_i" S.int
         v_i = S.valueOf var_i
 
-returnState :: (RenderSym repr) => Terminator -> SValue repr -> MSStatement repr
+returnState :: (RenderSym r) => Terminator -> SValue r -> MSStatement r
 returnState t v' = zoom lensMStoVS $ onStateValue (\v -> stateFromData 
   (returnDocD [v]) t) v'
 
 multiReturnError :: String -> String
 multiReturnError l = "Cannot return multiple values in " ++ l
 
-valState :: (RenderSym repr) => Terminator -> SValue repr -> MSStatement repr
+valState :: (RenderSym r) => Terminator -> SValue r -> MSStatement r
 valState t v' = zoom lensMStoVS $ onStateValue (\v -> stateFromData (valueDoc v)
   t) v'
 
-comment :: (RenderSym repr) => Doc -> Label -> MSStatement repr
+comment :: (RenderSym r) => Doc -> Label -> MSStatement r
 comment cs c = toState $ mkStNoEnd (commentDocD c cs)
 
-throw :: (RenderSym repr) => (repr (Value repr) -> Doc) -> Terminator -> 
-  Label -> MSStatement repr
+throw :: (RenderSym r) => (r (Value r) -> Doc) -> Terminator -> 
+  Label -> MSStatement r
 throw f t = onStateValue (\msg -> stateFromData (f msg) t) . zoom lensMStoVS . 
   S.litString
 
 -- ControlStatements --
 
-ifCond :: (RenderSym repr) => Doc -> Doc -> Doc
-  -> [(SValue repr, MSBody repr)] -> MSBody repr -> MSStatement repr
+ifCond :: (RenderSym r) => Doc -> Doc -> Doc
+  -> [(SValue r, MSBody r)] -> MSBody r -> MSStatement r
 ifCond _ _ _ [] _ = error "if condition created with no cases"
 ifCond ifStart elif bEnd (c:cs) eBody =
     let ifSect (v, b) = on2StateValues (\val bd -> vcat [
@@ -891,18 +891,18 @@ ifCond ifStart elif bEnd (c:cs) eBody =
     in onStateList (mkStNoEnd . vcat)
       (ifSect c : map elseIfSect cs ++ [elseSect])
 
-switch :: (RenderSym repr) => SValue repr -> [(SValue repr, MSBody repr)] -> 
-  MSBody repr -> MSStatement repr
+switch :: (RenderSym r) => SValue r -> [(SValue r, MSBody r)] -> 
+  MSBody r -> MSStatement r
 switch v cs bod = (\b val css de -> mkSt (switchDocD b val de css)) <$>
   S.state break <*> zoom lensMStoVS v <*> on2StateLists zip (map (zoom 
   lensMStoVS . fst) cs) (map snd cs) <*> bod
 
-ifExists :: (RenderSym repr) => SValue repr -> MSBody repr -> MSBody repr -> 
-  MSStatement repr
+ifExists :: (RenderSym r) => SValue r -> MSBody r -> MSBody r -> 
+  MSStatement r
 ifExists v ifBody = S.ifCond [(S.notNull v, ifBody)]
 
-for :: (RenderSym repr) => Doc -> Doc -> MSStatement repr -> SValue repr -> 
-  MSStatement repr -> MSBody repr -> MSStatement repr
+for :: (RenderSym r) => Doc -> Doc -> MSStatement r -> SValue r -> 
+  MSStatement r -> MSBody r -> MSStatement r
 for bStart bEnd sInit vGuard sUpdate b = (\initl guard upd bod -> mkStNoEnd 
   (vcat [forLabel <+> parens (statementDoc initl <> semi <+> valueDoc guard <> 
     semi <+> statementDoc upd) <+> bStart,
@@ -910,36 +910,36 @@ for bStart bEnd sInit vGuard sUpdate b = (\initl guard upd bod -> mkStNoEnd
   bEnd])) <$> S.loopState sInit <*> zoom lensMStoVS vGuard <*> 
   S.loopState sUpdate <*> b
 
-forRange :: (RenderSym repr) => SVariable repr -> SValue repr -> SValue repr -> 
-  SValue repr -> MSBody repr -> MSStatement repr
+forRange :: (RenderSym r) => SVariable r -> SValue r -> SValue r -> 
+  SValue r -> MSBody r -> MSStatement r
 forRange i initv finalv stepv = S.for (S.varDecDef i initv) (S.valueOf i ?< 
   finalv) (i &+= stepv)
 
-forEach :: (RenderSym repr) => Doc -> Doc -> Doc -> Doc -> SVariable repr -> 
-  SValue repr -> MSBody repr -> MSStatement repr
+forEach :: (RenderSym r) => Doc -> Doc -> Doc -> Doc -> SVariable r -> 
+  SValue r -> MSBody r -> MSStatement r
 forEach bStart bEnd forEachLabel inLbl e' v' = on3StateValues (\e v b -> 
   mkStNoEnd (vcat [forEachLabel <+> parens (getTypeDoc (variableType e) 
     <+> variableDoc e <+> inLbl <+> valueDoc v) <+> bStart,
   indent $ bodyDoc b,
   bEnd])) (zoom lensMStoVS e') (zoom lensMStoVS v') 
 
-while :: (RenderSym repr) => Doc -> Doc -> SValue repr -> MSBody repr -> 
-  MSStatement repr
+while :: (RenderSym r) => Doc -> Doc -> SValue r -> MSBody r -> 
+  MSStatement r
 while bStart bEnd v' = on2StateValues (\v b -> mkStNoEnd (vcat [
   text "while" <+> parens (valueDoc v) <+> bStart,
   indent $ bodyDoc b,
   bEnd])) (zoom lensMStoVS v')
 
-tryCatch :: (RenderSym repr) => (repr (Body repr) -> repr (Body repr) -> Doc) ->
-  MSBody repr -> MSBody repr -> MSStatement repr
+tryCatch :: (RenderSym r) => (r (Body r) -> r (Body r) -> Doc) ->
+  MSBody r -> MSBody r -> MSStatement r
 tryCatch f = on2StateValues (\tb -> mkStNoEnd . f tb)
 
-checkState :: (RenderSym repr) => Label -> [(SValue repr, MSBody repr)] -> 
-  MSBody repr -> MSStatement repr
+checkState :: (RenderSym r) => Label -> [(SValue r, MSBody r)] -> 
+  MSBody r -> MSStatement r
 checkState l = S.switch (S.valueOf $ S.var l S.string)
 
-notifyObservers :: (RenderSym repr) => VSFunction repr -> VSType repr -> 
-  MSStatement repr
+notifyObservers :: (RenderSym r) => VSFunction r -> VSType r -> 
+  MSStatement r
 notifyObservers f t = S.for initv (v_index ?< S.listSize obsList) 
   (var_index &++) notify
   where obsList = S.valueOf $ observerListName `listOf` t 
@@ -950,62 +950,62 @@ notifyObservers f t = S.for initv (v_index ?< S.listSize obsList)
 
 -- Methods --
 
-construct :: (RenderSym repr) => Label -> MS (repr (Type repr))
+construct :: (RenderSym r) => Label -> MS (r (Type r))
 construct n = toState $ typeFromData (Object n) n empty
 
-param :: (RenderSym repr) => (repr (Variable repr) -> Doc) -> SVariable repr -> 
-  MSParameter repr
+param :: (RenderSym r) => (r (Variable r) -> Doc) -> SVariable r -> 
+  MSParameter r
 param f v' = modifyReturnFunc (\v s -> addParameter (variableName v) s) 
   (\v -> paramFromData v (f v)) (zoom lensMStoVS v')
 
-method :: (RenderSym repr) => Label -> repr (Scope repr) -> 
-  repr (Permanence repr) -> VSType repr -> [MSParameter repr] -> MSBody repr -> 
-  SMethod repr
+method :: (RenderSym r) => Label -> r (Scope r) -> 
+  r (Permanence r) -> VSType r -> [MSParameter r] -> MSBody r -> 
+  SMethod r
 method n s p t = intMethod False n s p (mType t)
 
-getMethod :: (RenderSym repr) => SVariable repr -> SMethod repr
+getMethod :: (RenderSym r) => SVariable r -> SMethod r
 getMethod v = zoom lensMStoVS v >>= (\vr -> S.method (getterName $ variableName 
   vr) public dynamic (toState $ variableType vr) [] getBody)
   where getBody = oneLiner $ S.returnState (S.valueOf $ S.objVarSelf v)
 
-setMethod :: (RenderSym repr) => SVariable repr -> SMethod repr
+setMethod :: (RenderSym r) => SVariable r -> SMethod r
 setMethod v = zoom lensMStoVS v >>= (\vr -> S.method (setterName $ variableName 
   vr) public dynamic S.void [S.param v] setBody)
   where setBody = oneLiner $ S.objVarSelf v &= S.valueOf v
 
-constructor :: (RenderSym repr) => Label -> [MSParameter repr] -> 
-  [Initializer repr] -> MSBody repr -> SMethod repr
+constructor :: (RenderSym r) => Label -> [MSParameter r] -> 
+  [Initializer r] -> MSBody r -> SMethod r
 constructor fName ps is b = getClassName >>= (\c -> intMethod False fName 
   public dynamic (S.construct c) ps (multiBody [ib, b]))
   where ib = bodyStatements (zipWith (\vr vl -> objVarSelf vr &= vl) 
           (map fst is) (map snd is))
 
-docMain :: (RenderSym repr) => MSBody repr -> SMethod repr
+docMain :: (RenderSym r) => MSBody r -> SMethod r
 docMain b = commentedFunc (docComment $ toState $ functionDox 
   "Controls the flow of the program" 
   [("args", "List of command-line arguments")] []) (S.mainFunction b)
 
-function :: (RenderSym repr) => Label -> repr (Scope repr) -> 
-  repr (Permanence repr) -> VSType repr -> [MSParameter repr] -> MSBody repr -> 
-  SMethod repr
+function :: (RenderSym r) => Label -> r (Scope r) -> 
+  r (Permanence r) -> VSType r -> [MSParameter r] -> MSBody r -> 
+  SMethod r
 function n s p t = S.intFunc False n s p (mType t)
 
-mainFunction :: (RenderSym repr) => VSType repr -> Label -> MSBody repr -> 
-  SMethod repr
+mainFunction :: (RenderSym r) => VSType r -> Label -> MSBody r -> 
+  SMethod r
 mainFunction s n = S.intFunc True n public static (mType S.void)
   [S.param (S.var "args" (onStateValue (\argT -> typeFromData (List String) 
   (render (getTypeDoc argT) ++ "[]") (getTypeDoc argT <> text "[]")) s))]
 
-docFunc :: (RenderSym repr) => String -> [String] -> Maybe String -> 
-  SMethod repr -> SMethod repr
+docFunc :: (RenderSym r) => String -> [String] -> Maybe String -> 
+  SMethod r -> SMethod r
 docFunc desc pComms rComm = docFuncRepr desc pComms (maybeToList rComm)
 
-docInOutFunc :: (RenderSym repr) => (repr (Scope repr) -> repr (Permanence repr)
-    -> [SVariable repr] -> [SVariable repr] -> [SVariable repr] -> 
-    MSBody repr -> SMethod repr)
-  -> repr (Scope repr) -> repr (Permanence repr) -> String -> 
-  [(String, SVariable repr)] -> [(String, SVariable repr)]
-  -> [(String, SVariable repr)] -> MSBody repr -> SMethod repr
+docInOutFunc :: (RenderSym r) => (r (Scope r) -> r (Permanence r)
+    -> [SVariable r] -> [SVariable r] -> [SVariable r] -> 
+    MSBody r -> SMethod r)
+  -> r (Scope r) -> r (Permanence r) -> String -> 
+  [(String, SVariable r)] -> [(String, SVariable r)]
+  -> [(String, SVariable r)] -> MSBody r -> SMethod r
 docInOutFunc f s p desc is [o] [] b = docFuncRepr desc (map fst is) [fst o] 
   (f s p (map snd is) [snd o] [] b)
 docInOutFunc f s p desc is [] [both] b = docFuncRepr desc (map fst $ both : is) 
@@ -1013,59 +1013,59 @@ docInOutFunc f s p desc is [] [both] b = docFuncRepr desc (map fst $ both : is)
 docInOutFunc f s p desc is os bs b = docFuncRepr desc (map fst $ bs ++ is ++ os)
   [] (f s p (map snd is) (map snd os) (map snd bs) b)
 
-intFunc :: (RenderSym repr) => Bool -> Label -> repr (Scope repr) -> 
-  repr (Permanence repr) -> MS (repr (MethodType repr)) -> [MSParameter repr] 
-  -> MSBody repr -> SMethod repr
+intFunc :: (RenderSym r) => Bool -> Label -> r (Scope r) -> 
+  r (Permanence r) -> MS (r (MethodType r)) -> [MSParameter r] 
+  -> MSBody r -> SMethod r
 intFunc = intMethod
 
 -- State Variables --
 
-stateVar :: (RenderSym repr) => repr (Scope repr) -> repr (Permanence repr) ->
-  SVariable repr -> CSStateVar repr
+stateVar :: (RenderSym r) => r (Scope r) -> r (Permanence r) ->
+  SVariable r -> CSStateVar r
 stateVar s p v = stateVarFromData (zoom lensCStoMS $ onStateValue (stateVarDocD 
   (scopeDoc s) (permDoc p) . statementDoc) (S.state $ S.varDec v))
 
-stateVarDef :: (RenderSym repr) => repr (Scope repr) -> repr (Permanence repr) 
-  -> SVariable repr -> SValue repr -> CSStateVar repr
+stateVarDef :: (RenderSym r) => r (Scope r) -> r (Permanence r) 
+  -> SVariable r -> SValue r -> CSStateVar r
 stateVarDef s p vr vl = stateVarFromData (zoom lensCStoMS $ onStateValue 
   (stateVarDocD (scopeDoc s) (permDoc p) . statementDoc) (S.state $ S.varDecDef 
   vr vl))
 
-constVar :: (RenderSym repr) => Doc -> repr (Scope repr) -> SVariable repr -> 
-  SValue repr -> CSStateVar repr
+constVar :: (RenderSym r) => Doc -> r (Scope r) -> SVariable r -> 
+  SValue r -> CSStateVar r
 constVar p s vr vl = stateVarFromData (zoom lensCStoMS $ onStateValue 
   (stateVarDocD (scopeDoc s) p . statementDoc) (S.state $ S.constDecDef vr vl))
 
 -- Classes --
 
-buildClass :: (RenderSym repr) => Label -> Maybe Label -> [CSStateVar repr] -> 
-  [SMethod repr] -> SClass repr
+buildClass :: (RenderSym r) => Label -> Maybe Label -> [CSStateVar r] -> 
+  [SMethod r] -> SClass r
 buildClass n = S.intClass n public . inherit
 
--- enum :: (RenderSym repr) => Label -> [Label] -> repr (Scope repr) -> 
---   SClass repr
+-- enum :: (RenderSym r) => Label -> [Label] -> r (Scope r) -> 
+--   SClass r
 -- enum n es s = modify (setClassName n) >> classFromData (toState $ enumDocD n 
 --   (enumElementsDocD es False) (scopeDoc s))
 
-extraClass :: (RenderSym repr) => Label -> Maybe Label -> [CSStateVar repr] -> 
-  [SMethod repr] -> SClass repr
+extraClass :: (RenderSym r) => Label -> Maybe Label -> [CSStateVar r] -> 
+  [SMethod r] -> SClass r
 extraClass n = S.intClass n (scopeFromData Priv empty) . inherit
 
-implementingClass :: (RenderSym repr) => Label -> [Label] -> [CSStateVar repr] 
-  -> [SMethod repr] -> SClass repr
+implementingClass :: (RenderSym r) => Label -> [Label] -> [CSStateVar r] 
+  -> [SMethod r] -> SClass r
 implementingClass n is = S.intClass n public (implements is)
 
-docClass :: (RenderSym repr) => String -> SClass repr -> SClass repr
+docClass :: (RenderSym r) => String -> SClass r -> SClass r
 docClass d = S.commentedClass (docComment $ toState $ classDox d)
 
-commentedClass :: (RenderSym repr, Monad repr) => CS (repr (BlockComment repr)) 
-  -> SClass repr -> SClass repr
+commentedClass :: (RenderSym r, Monad r) => CS (r (BlockComment r)) 
+  -> SClass r -> SClass r
 commentedClass cmt cs = classFromData (on2StateValues (\cmt' cs' -> toCode $
   commentedItem (blockCommentDoc cmt') (classDoc cs')) cmt cs)
 
-intClass :: (RenderSym repr, Monad repr) => (Label -> Doc -> Doc -> Doc -> Doc 
-  -> Doc) -> Label -> repr (Scope repr) -> repr ParentSpec -> [CSStateVar repr] 
-  -> [SMethod repr] -> SClass repr
+intClass :: (RenderSym r, Monad r) => (Label -> Doc -> Doc -> Doc -> Doc 
+  -> Doc) -> Label -> r (Scope r) -> r ParentSpec -> [CSStateVar r] 
+  -> [SMethod r] -> SClass r
 intClass f n s i svrs mths = modify (setClassName n) >> classFromData 
   (on2StateValues (\svs ms -> onCodeValue (\p -> f n p (scopeDoc s) svs ms) i) 
   (onStateList (stateVarListDocD . map stateVarDoc) svrs) 
@@ -1073,49 +1073,49 @@ intClass f n s i svrs mths = modify (setClassName n) >> classFromData
 
 -- Modules --
 
-buildModule :: (RenderSym repr) => Label -> FS Doc -> FS Doc -> [SMethod repr] 
-  -> [SClass repr] -> FSModule repr
+buildModule :: (RenderSym r) => Label -> FS Doc -> FS Doc -> [SMethod r] 
+  -> [SClass r] -> FSModule r
 buildModule n imps bot ms cs = S.modFromData n ((\cls fs is bt -> 
   moduleDocD is (vibcat (map classDoc cls)) (vibcat (map methodDoc fs ++ [bt])))
   <$> mapM (zoom lensFStoCS) cs <*> mapM (zoom lensFStoMS) ms <*> imps <*> bot)
 
-buildModule' :: (RenderSym repr) => Label -> (String -> repr (Import repr)) -> 
-  [Label] -> [SMethod repr] -> [SClass repr] -> FSModule repr
+buildModule' :: (RenderSym r) => Label -> (String -> r (Import r)) -> 
+  [Label] -> [SMethod r] -> [SClass r] -> FSModule r
 buildModule' n inc is ms cs = S.modFromData n ((\cls lis libis mis -> vibcat [
     vcat (map (importDoc . inc) (lis ++ sort (is ++ libis) ++ mis)),
     vibcat (map classDoc cls)]) <$>
   mapM (zoom lensFStoCS) (if null ms then cs else S.buildClass n Nothing [] ms 
     : cs) <*> getLangImports <*> getLibImports <*> getModuleImports)
 
-modFromData :: Label -> (Doc -> repr (Module repr)) -> FS Doc -> FSModule repr
+modFromData :: Label -> (Doc -> r (Module r)) -> FS Doc -> FSModule r
 modFromData n f d = modify (setModuleName n) >> onStateValue f d
 
 -- Files --
 
-fileDoc :: (RenderSym repr) => String -> (repr (Module repr) -> 
-  repr (Block repr)) -> repr (Block repr) -> FSModule repr -> SFile repr
+fileDoc :: (RenderSym r) => String -> (r (Module r) -> 
+  r (Block r)) -> r (Block r) -> FSModule r -> SFile r
 fileDoc ext topb botb = S.fileFromData (onStateValue (addExt ext) 
   getModuleName) . onStateValue (\m -> updateModuleDoc (\d -> emptyIfEmpty d 
   (fileDoc' (blockDoc $ topb m) d (blockDoc botb))) m)
 
-docMod :: (RenderSym repr) => String -> String -> [String] -> String -> 
-  SFile repr -> SFile repr
+docMod :: (RenderSym r) => String -> String -> [String] -> String -> 
+  SFile r -> SFile r
 docMod e d a dt = commentedMod (docComment $ moduleDox d a dt . addExt e <$> 
   getModuleName)
 
-fileFromData :: (RenderSym repr) => (repr (Module repr) -> FilePath -> 
-  repr (RenderFile repr)) -> FS FilePath -> FSModule repr -> SFile repr
+fileFromData :: (RenderSym r) => (r (Module r) -> FilePath -> 
+  r (RenderFile r)) -> FS FilePath -> FSModule r -> SFile r
 fileFromData f fp m = modifyReturnFunc2 (\mdl fpath s -> (if isEmpty 
   (moduleDoc mdl) then id else (if s ^. currMain && isSource (s ^. currFileType) then over lensFStoGS 
   (setMainMod fpath) else id) . over lensFStoGS (addFile (s ^. currFileType) fpath)) s) f m fp 
 
 -- Helper functions
 
-setEmpty :: (RenderSym repr) => MSStatement repr -> MSStatement repr
+setEmpty :: (RenderSym r) => MSStatement r -> MSStatement r
 setEmpty = onStateValue (mkStNoEnd . statementDoc)
 
-numType :: (RenderSym repr) => repr (Type repr) -> repr (Type repr) -> 
-  repr (Type repr)
+numType :: (RenderSym r) => r (Type r) -> r (Type r) -> 
+  r (Type r)
 numType t1 t2 = numericType (getType t1) (getType t2)
   where numericType Integer Integer = t1
         numericType Float _ = t1
@@ -1124,15 +1124,15 @@ numType t1 t2 = numericType (getType t1) (getType t2)
         numericType _ Double = t2
         numericType _ _ = error "Numeric types required for numeric expression"
 
-mkExpr :: (RenderSym repr) => Int -> repr (Type repr) -> Doc -> 
-  repr (Value repr)
+mkExpr :: (RenderSym r) => Int -> r (Type r) -> Doc -> 
+  r (Value r)
 mkExpr p = valFromData (Just p)
 
-exprParensL :: (RenderSym repr) => repr (BinaryOp repr) -> repr (Value repr) -> 
+exprParensL :: (RenderSym r) => r (BinaryOp r) -> r (Value r) -> 
   (Doc -> Doc)
 exprParensL o v = if maybe False (< bOpPrec o) (valuePrec v) then parens else id
 
-exprParensR :: (RenderSym repr) => repr (BinaryOp repr) -> repr (Value repr) -> 
+exprParensR :: (RenderSym r) => r (BinaryOp r) -> r (Value r) -> 
   (Doc -> Doc)
 exprParensR o v = if maybe False (<= bOpPrec o) (valuePrec v) then parens else 
   id

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer/LanguagePolymorphic.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer/LanguagePolymorphic.hs
@@ -41,7 +41,7 @@ import Utils.Drasil (indent)
 import GOOL.Drasil.CodeType (CodeType(..), ClassName)
 import GOOL.Drasil.ClassInterface (Label, Library, SFile, MSBody, MSBlock, 
   VSType, SVariable, SValue, VSFunction, MSStatement, MSParameter, SMethod, 
-  CSStateVar, SClass, FSModule, NamedArgs, Initializer, MixedCall, MixedCtorCall, FileSym(RenderFile), BodySym(Body), 
+  CSStateVar, SClass, FSModule, NamedArgs, Initializers, MixedCall, MixedCtorCall, FileSym(RenderFile), BodySym(Body), 
   bodyStatements, oneLiner, BlockSym(Block), PermanenceSym(..), 
   TypeSym(Type, infile, outfile, iterator, getType, getTypeString), 
   VariableSym(Variable, variableName, variableType), listOf,
@@ -974,7 +974,7 @@ setMethod v = zoom lensMStoVS v >>= (\vr -> S.method (setterName $ variableName
   where setBody = oneLiner $ S.objVarSelf v &= S.valueOf v
 
 constructor :: (RenderSym r) => Label -> [MSParameter r] -> 
-  [Initializer r] -> MSBody r -> SMethod r
+  Initializers r -> MSBody r -> SMethod r
 constructor fName ps is b = getClassName >>= (\c -> intMethod False fName 
   public dynamic (S.construct c) ps (multiBody [ib, b]))
   where ib = bodyStatements (zipWith (\vr vl -> objVarSelf vr &= vl) 

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer/LanguagePolymorphic.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer/LanguagePolymorphic.hs
@@ -41,7 +41,7 @@ import Utils.Drasil (indent)
 import GOOL.Drasil.CodeType (CodeType(..), ClassName)
 import GOOL.Drasil.ClassInterface (Label, Library, SFile, MSBody, MSBlock, 
   VSType, SVariable, SValue, VSFunction, MSStatement, MSParameter, SMethod, 
-  CSStateVar, SClass, FSModule, NamedArg, Initializer, MixedCall, MixedCtorCall, FileSym(RenderFile), BodySym(Body), 
+  CSStateVar, SClass, FSModule, NamedArgs, Initializer, MixedCall, MixedCtorCall, FileSym(RenderFile), BodySym(Body), 
   bodyStatements, oneLiner, BlockSym(Block), PermanenceSym(..), 
   TypeSym(Type, infile, outfile, iterator, getType, getTypeString), 
   VariableSym(Variable, variableName, variableType), listOf,
@@ -528,12 +528,12 @@ inlineIf = on3StateValues (\c v1 v2 -> valFromData (prec c) (valueType v1)
   where prec cd = valuePrec cd <|> Just 0
 
 call' :: (RenderSym r) => String -> Maybe Library -> Label -> VSType r -> 
-  Maybe Doc -> [SValue r] -> [NamedArg r] -> SValue r
+  Maybe Doc -> [SValue r] -> NamedArgs r -> SValue r
 call' l _ _ _ _ _ (_:_) = error $ namedArgError l
 call' _ l n t o ps ns = call empty l n t o ps ns
 
 call :: (RenderSym r) => Doc -> Maybe Library -> Label -> VSType r -> 
-  Maybe Doc -> [SValue r] -> [NamedArg r] -> SValue r
+  Maybe Doc -> [SValue r] -> NamedArgs r -> SValue r
 call sep lib n t o pas nas = (\tp pargs nms nargs -> mkVal tp $ obDoc <> libDoc 
   <> text n <> parens (valueList pargs <+> (if null pas || null nas then empty 
   else comma) <+> hcat (intersperse (text ", ") (zipWith (\nm a -> 
@@ -585,7 +585,7 @@ objAccess = on2StateValues (\v f -> mkVal (functionType f) (objAccessDocD
   (valueDoc v) (functionDoc f)))
 
 objMethodCall :: (RenderSym r) => Label -> VSType r -> SValue r -> 
-  [SValue r] -> [NamedArg r] -> SValue r
+  [SValue r] -> NamedArgs r -> SValue r
 objMethodCall f t ob vs ns = ob >>= (\o -> S.call Nothing f t 
   (Just $ valueDoc o <> dot) vs ns)
 

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer/PythonRenderer.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer/PythonRenderer.hs
@@ -714,42 +714,42 @@ pyODEMethod Adams = [litString "vode",
   (litString "adams" :: SValue PythonCode) >>= 
   (mkStateVal string . (text "method=" <>) . valueDoc)]
 
-pyLogOp :: (RenderSym repr) => VSUnOp repr
+pyLogOp :: (RenderSym r) => VSUnOp r
 pyLogOp = addmathImport $ unOpPrec "math.log10"
 
-pyLnOp :: (RenderSym repr) => VSUnOp repr
+pyLnOp :: (RenderSym r) => VSUnOp r
 pyLnOp = addmathImport $ unOpPrec "math.log"
 
 pyClassVar :: Doc -> Doc -> Doc
 pyClassVar c v = c <> dot <> c <> dot <> v
 
-pyInlineIf :: (RenderSym repr) => SValue repr -> SValue repr -> SValue repr -> 
-  SValue repr
+pyInlineIf :: (RenderSym r) => SValue r -> SValue r -> SValue r -> 
+  SValue r
 pyInlineIf = on3StateValues (\c v1 v2 -> valFromData (valuePrec c) 
   (valueType v1) (valueDoc v1 <+> text "if" <+> valueDoc c <+> text "else" <+> 
   valueDoc v2))
 
-pyLambda :: (RenderSym repr) => [repr (Variable repr)] -> repr (Value repr) -> 
+pyLambda :: (RenderSym r) => [r (Variable r)] -> r (Value r) -> 
   Doc
 pyLambda ps ex = text "lambda" <+> variableList ps <> colon <+> valueDoc ex
 
 pyListSize :: Doc -> Doc -> Doc
 pyListSize v f = f <> parens v
 
-pyStringType :: (RenderSym repr) => VSType repr
+pyStringType :: (RenderSym r) => VSType r
 pyStringType = toState $ typeFromData String "str" (text "str")
 
-pyListDec :: (RenderSym repr) => repr (Variable repr) -> Doc
+pyListDec :: (RenderSym r) => r (Variable r) -> Doc
 pyListDec v = variableDoc v <+> equals <+> getTypeDoc (variableType v)
 
-pyPrint :: (RenderSym repr) => Bool -> repr (Value repr) -> repr (Value repr) 
-  -> repr (Value repr) -> Doc
+pyPrint :: (RenderSym r) => Bool -> r (Value r) -> r (Value r) 
+  -> r (Value r) -> Doc
 pyPrint newLn prf v f = valueDoc prf <> parens (valueDoc v <> nl <> fl)
   where nl = if newLn then empty else text ", end=''"
         fl = emptyIfEmpty (valueDoc f) $ text ", file=" <> valueDoc f
 
-pyOut :: (RenderSym repr) => Bool -> Maybe (SValue repr) -> SValue repr -> 
-  SValue repr -> MSStatement repr
+pyOut :: (RenderSym r) => Bool -> Maybe (SValue r) -> SValue r -> 
+  SValue r -> MSStatement r
 pyOut newLn f printFn v = zoom lensMStoVS v >>= pyOut' . getType . valueType
   where pyOut' (List _) = printSt newLn f printFn v
         pyOut' _ = outDoc newLn f printFn v
@@ -764,35 +764,35 @@ pyInput inSrc v = v &= (v >>= pyInput' . getType . variableType)
         pyInput' Char = inSrc
         pyInput' _ = error "Attempt to read a value of unreadable type"
 
-pyThrow :: (RenderSym repr) => repr (Value repr) -> Doc
+pyThrow :: (RenderSym r) => r (Value r) -> Doc
 pyThrow errMsg = text "raise" <+> text "Exception" <> parens (valueDoc errMsg)
 
-pyForEach :: (RenderSym repr) => repr (Variable repr) -> repr (Value repr) -> 
-  repr (Body repr) -> Doc
+pyForEach :: (RenderSym r) => r (Variable r) -> r (Value r) -> 
+  r (Body r) -> Doc
 pyForEach i lstVar b = vcat [
   forLabel <+> variableDoc i <+> inLabel <+> valueDoc lstVar <> colon,
   indent $ bodyDoc b]
 
-pyWhile :: (RenderSym repr) => repr (Value repr) -> repr (Body repr) -> Doc
+pyWhile :: (RenderSym r) => r (Value r) -> r (Body r) -> Doc
 pyWhile v b = vcat [
   text "while" <+> valueDoc v <> colon,
   indent $ bodyDoc b]
 
-pyTryCatch :: (RenderSym repr) => repr (Body repr) -> repr (Body repr) -> Doc
+pyTryCatch :: (RenderSym r) => r (Body r) -> r (Body r) -> Doc
 pyTryCatch tryB catchB = vcat [
   text "try" <+> colon,
   indent $ bodyDoc tryB,
   text "except" <+> text "Exception" <+> colon,
   indent $ bodyDoc catchB]
 
-pyListSlice :: (RenderSym repr) => SVariable repr -> SValue repr -> SValue repr 
-  -> SValue repr -> SValue repr -> VS Doc
+pyListSlice :: (RenderSym r) => SVariable r -> SValue r -> SValue r 
+  -> SValue r -> SValue r -> VS Doc
 pyListSlice vn vo beg end step = (\vnew vold b e s -> variableDoc vnew <+> 
   equals <+> valueDoc vold <> brackets (valueDoc b <> colon <> valueDoc e <> 
   colon <> valueDoc s)) <$> vn <*> vo <*> beg <*> end <*> step
 
-pyMethod :: (RenderSym repr) => Label -> repr (Variable repr) -> 
-  [repr (Parameter repr)] -> repr (Body repr) -> Doc
+pyMethod :: (RenderSym r) => Label -> r (Variable r) -> 
+  [r (Parameter r)] -> r (Body r) -> Doc
 pyMethod n slf ps b = vcat [
   text "def" <+> text n <> parens (variableDoc slf <> oneParam <> pms) <> colon,
   indent bodyD]
@@ -801,8 +801,8 @@ pyMethod n slf ps b = vcat [
             bodyD | isEmpty (bodyDoc b) = text "None"
                   | otherwise = bodyDoc b
 
-pyFunction :: (RenderSym repr) => Label -> [repr (Parameter repr)] -> 
-  repr (Body repr) -> Doc
+pyFunction :: (RenderSym r) => Label -> [r (Parameter r)] -> 
+  r (Body r) -> Doc
 pyFunction n ps b = vcat [
   text "def" <+> text n <> parens (parameterList ps) <> colon,
   indent bodyD]
@@ -846,11 +846,11 @@ pyInOut f s p ins outs both b = f s p void (map param $ both ++ ins)
   (multiReturn $ map valueOf rets))
   where rets = both ++ outs
 
-pyDocInOut :: (RenderSym repr) => (repr (Scope repr) -> repr (Permanence repr) 
-    -> [SVariable repr] -> [SVariable repr] -> [SVariable repr] -> MSBody repr 
-    -> SMethod repr)
-  -> repr (Scope repr) -> repr (Permanence repr) -> String -> 
-  [(String, SVariable repr)] -> [(String, SVariable repr)]
-  -> [(String, SVariable repr)] -> MSBody repr -> SMethod repr
+pyDocInOut :: (RenderSym r) => (r (Scope r) -> r (Permanence r) 
+    -> [SVariable r] -> [SVariable r] -> [SVariable r] -> MSBody r 
+    -> SMethod r)
+  -> r (Scope r) -> r (Permanence r) -> String -> 
+  [(String, SVariable r)] -> [(String, SVariable r)]
+  -> [(String, SVariable r)] -> MSBody r -> SMethod r
 pyDocInOut f s p desc is os bs b = docFuncRepr desc (map fst $ bs ++ is)
   (map fst $ bs ++ os) (f s p (map snd is) (map snd os) (map snd bs) b)

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer/PythonRenderer.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer/PythonRenderer.hs
@@ -22,7 +22,7 @@ import GOOL.Drasil.ClassInterface (Label, MSBody, VSType, SVariable, SValue,
   ControlStatement(..), switchAsIf, StatePattern(..), ObserverPattern(..), StrategyPattern(..), ScopeSym(..), ParameterSym(..), 
   MethodSym(..), StateVarSym(..), ClassSym(..), ModuleSym(..), ODEInfo(..), 
   ODEOptions(..), ODEMethod(..))
-import GOOL.Drasil.RendererClasses (RenderSym, InternalFile(..),
+import GOOL.Drasil.RendererClasses (VSUnOp, RenderSym, InternalFile(..),
   ImportSym(..), InternalPerm(..), InternalBody(..), InternalBlock(..), 
   InternalType(..), UnaryOpSym(..), BinaryOpSym(..), InternalOp(..), 
   InternalVariable(..), InternalValue(..), InternalGetSet(..), InternalListFunc(..), InternalIterator(..), InternalFunction(..), InternalAssignStmt(..), InternalIOStmt(..), InternalControlStmt(..),
@@ -714,10 +714,10 @@ pyODEMethod Adams = [litString "vode",
   (litString "adams" :: SValue PythonCode) >>= 
   (mkStateVal string . (text "method=" <>) . valueDoc)]
 
-pyLogOp :: (RenderSym repr) => VS (repr (UnaryOp repr))
+pyLogOp :: (RenderSym repr) => VSUnOp repr
 pyLogOp = addmathImport $ unOpPrec "math.log10"
 
-pyLnOp :: (RenderSym repr) => VS (repr (UnaryOp repr))
+pyLnOp :: (RenderSym repr) => VSUnOp repr
 pyLnOp = addmathImport $ unOpPrec "math.log"
 
 pyClassVar :: Doc -> Doc -> Doc

--- a/code/drasil-gool/GOOL/Drasil/RendererClasses.hs
+++ b/code/drasil-gool/GOOL/Drasil/RendererClasses.hs
@@ -23,216 +23,216 @@ import GOOL.Drasil.State (FS, CS, MS, VS)
 import Control.Monad.State (State)
 import Text.PrettyPrint.HughesPJ (Doc)
 
-class (FileSym repr, InternalBlock repr, InternalBody repr, InternalClass repr, 
-  InternalFile repr, InternalGetSet repr, InternalListFunc repr, InternalIterator repr, InternalFunction repr, InternalMethod repr, 
-  InternalMod repr, InternalOp repr, InternalParam repr, InternalPerm repr, 
-  InternalScope repr, InternalAssignStmt repr, InternalIOStmt repr, InternalControlStmt repr, InternalStatement repr, InternalStateVar repr, 
-  InternalType repr, InternalValue repr, InternalVariable repr,
-  ImportSym repr, UnaryOpSym repr, BinaryOpSym repr) => RenderSym repr
+class (FileSym r, InternalBlock r, InternalBody r, InternalClass r, 
+  InternalFile r, InternalGetSet r, InternalListFunc r, InternalIterator r, InternalFunction r, InternalMethod r, 
+  InternalMod r, InternalOp r, InternalParam r, InternalPerm r, 
+  InternalScope r, InternalAssignStmt r, InternalIOStmt r, InternalControlStmt r, InternalStatement r, InternalStateVar r, 
+  InternalType r, InternalValue r, InternalVariable r,
+  ImportSym r, UnaryOpSym r, BinaryOpSym r) => RenderSym r
 
-class (BlockCommentSym repr) => InternalFile repr where
-  top :: repr (Module repr) -> repr (Block repr)
-  bottom :: repr (Block repr)
+class (BlockCommentSym r) => InternalFile r where
+  top :: r (Module r) -> r (Block r)
+  bottom :: r (Block r)
 
-  commentedMod :: FS (repr (BlockComment repr)) -> SFile repr -> SFile repr
+  commentedMod :: FS (r (BlockComment r)) -> SFile r -> SFile r
 
-  fileFromData :: FS FilePath -> FSModule repr -> SFile repr
+  fileFromData :: FS FilePath -> FSModule r -> SFile r
 
-class ImportSym repr where
-  type Import repr
-  langImport :: Label -> repr (Import repr)
-  modImport :: Label -> repr (Import repr)
+class ImportSym r where
+  type Import r
+  langImport :: Label -> r (Import r)
+  modImport :: Label -> r (Import r)
 
-  importDoc :: repr (Import repr) -> Doc
+  importDoc :: r (Import r) -> Doc
 
-class InternalPerm repr where
-  permDoc :: repr (Permanence repr) -> Doc
-  binding :: repr (Permanence repr) -> Binding
+class InternalPerm r where
+  permDoc :: r (Permanence r) -> Doc
+  binding :: r (Permanence r) -> Binding
 
-class InternalBody repr where
-  bodyDoc :: repr (Body repr) -> Doc
-  docBody :: MS Doc -> MSBody repr
-  multiBody :: [MSBody repr] -> MSBody repr
+class InternalBody r where
+  bodyDoc :: r (Body r) -> Doc
+  docBody :: MS Doc -> MSBody r
+  multiBody :: [MSBody r] -> MSBody r
 
-class InternalBlock repr where
-  blockDoc :: repr (Block repr) -> Doc
-  docBlock :: MS Doc -> MSBlock repr
-  multiBlock :: [MSBlock repr] -> MSBlock repr
+class InternalBlock r where
+  blockDoc :: r (Block r) -> Doc
+  docBlock :: MS Doc -> MSBlock r
+  multiBlock :: [MSBlock r] -> MSBlock r
 
-class InternalType repr where
-  getTypeDoc :: repr (Type repr) -> Doc
-  typeFromData :: CodeType -> String -> Doc -> repr (Type repr)
+class InternalType r where
+  getTypeDoc :: r (Type r) -> Doc
+  typeFromData :: CodeType -> String -> Doc -> r (Type r)
 
 type VSUnOp a = VS (a (UnaryOp a))
 
-class UnaryOpSym repr where
-  type UnaryOp repr
-  notOp    :: VSUnOp repr
-  negateOp :: VSUnOp repr
-  sqrtOp   :: VSUnOp repr
-  absOp    :: VSUnOp repr
-  logOp    :: VSUnOp repr
-  lnOp     :: VSUnOp repr
-  expOp    :: VSUnOp repr
-  sinOp    :: VSUnOp repr
-  cosOp    :: VSUnOp repr
-  tanOp    :: VSUnOp repr
-  asinOp   :: VSUnOp repr
-  acosOp   :: VSUnOp repr
-  atanOp   :: VSUnOp repr
-  floorOp  :: VSUnOp repr
-  ceilOp   :: VSUnOp repr
+class UnaryOpSym r where
+  type UnaryOp r
+  notOp    :: VSUnOp r
+  negateOp :: VSUnOp r
+  sqrtOp   :: VSUnOp r
+  absOp    :: VSUnOp r
+  logOp    :: VSUnOp r
+  lnOp     :: VSUnOp r
+  expOp    :: VSUnOp r
+  sinOp    :: VSUnOp r
+  cosOp    :: VSUnOp r
+  tanOp    :: VSUnOp r
+  asinOp   :: VSUnOp r
+  acosOp   :: VSUnOp r
+  atanOp   :: VSUnOp r
+  floorOp  :: VSUnOp r
+  ceilOp   :: VSUnOp r
 
 type VSBinOp a = VS (a (BinaryOp a))
 
-class BinaryOpSym repr where
-  type BinaryOp repr
-  equalOp        :: VSBinOp repr
-  notEqualOp     :: VSBinOp repr
-  greaterOp      :: VSBinOp repr
-  greaterEqualOp :: VSBinOp repr
-  lessOp         :: VSBinOp repr
-  lessEqualOp    :: VSBinOp repr
-  plusOp         :: VSBinOp repr
-  minusOp        :: VSBinOp repr
-  multOp         :: VSBinOp repr
-  divideOp       :: VSBinOp repr
-  powerOp        :: VSBinOp repr
-  moduloOp       :: VSBinOp repr
-  andOp          :: VSBinOp repr
-  orOp           :: VSBinOp repr
+class BinaryOpSym r where
+  type BinaryOp r
+  equalOp        :: VSBinOp r
+  notEqualOp     :: VSBinOp r
+  greaterOp      :: VSBinOp r
+  greaterEqualOp :: VSBinOp r
+  lessOp         :: VSBinOp r
+  lessEqualOp    :: VSBinOp r
+  plusOp         :: VSBinOp r
+  minusOp        :: VSBinOp r
+  multOp         :: VSBinOp r
+  divideOp       :: VSBinOp r
+  powerOp        :: VSBinOp r
+  moduloOp       :: VSBinOp r
+  andOp          :: VSBinOp r
+  orOp           :: VSBinOp r
 
-class InternalOp repr where
-  uOpDoc :: repr (UnaryOp repr) -> Doc
-  bOpDoc :: repr (BinaryOp repr) -> Doc
-  uOpPrec :: repr (UnaryOp repr) -> Int
-  bOpPrec :: repr (BinaryOp repr) -> Int
+class InternalOp r where
+  uOpDoc :: r (UnaryOp r) -> Doc
+  bOpDoc :: r (BinaryOp r) -> Doc
+  uOpPrec :: r (UnaryOp r) -> Int
+  bOpPrec :: r (BinaryOp r) -> Int
 
-  uOpFromData :: Int -> Doc -> VSUnOp repr
-  bOpFromData :: Int -> Doc -> VSBinOp repr
+  uOpFromData :: Int -> Doc -> VSUnOp r
+  bOpFromData :: Int -> Doc -> VSBinOp r
 
-class InternalVariable repr where
-  variableBind :: repr (Variable repr) -> Binding
-  variableDoc  :: repr (Variable repr) -> Doc
-  varFromData :: Binding -> String -> repr (Type repr) -> Doc -> 
-    repr (Variable repr)
+class InternalVariable r where
+  variableBind :: r (Variable r) -> Binding
+  variableDoc  :: r (Variable r) -> Doc
+  varFromData :: Binding -> String -> r (Type r) -> Doc -> 
+    r (Variable r)
 
-class InternalValue repr where
-  inputFunc       :: SValue repr
-  printFunc       :: SValue repr
-  printLnFunc     :: SValue repr
-  printFileFunc   :: SValue repr -> SValue repr
-  printFileLnFunc :: SValue repr -> SValue repr
+class InternalValue r where
+  inputFunc       :: SValue r
+  printFunc       :: SValue r
+  printLnFunc     :: SValue r
+  printFileFunc   :: SValue r -> SValue r
+  printFileLnFunc :: SValue r -> SValue r
 
-  cast :: VSType repr -> SValue repr -> SValue repr
+  cast :: VSType r -> SValue r -> SValue r
 
   -- Very generic internal function for generating calls, to reduce repeated code throughout generators
   -- Maybe library, function name, return type, maybe object doc, regular arguments, named arguments
-  call :: Maybe Library -> Label -> VSType repr -> Maybe Doc -> [SValue repr] 
-    -> [NamedArg repr] -> SValue repr
+  call :: Maybe Library -> Label -> VSType r -> Maybe Doc -> [SValue r] 
+    -> [NamedArg r] -> SValue r
 
-  valuePrec :: repr (Value repr) -> Maybe Int
-  valueDoc :: repr (Value repr) -> Doc
-  valFromData :: Maybe Int -> repr (Type repr) -> Doc -> repr (Value repr)
+  valuePrec :: r (Value r) -> Maybe Int
+  valueDoc :: r (Value r) -> Doc
+  valFromData :: Maybe Int -> r (Type r) -> Doc -> r (Value r)
 
-class InternalGetSet repr where
-  getFunc :: SVariable repr -> VSFunction repr
-  setFunc :: VSType repr -> SVariable repr -> SValue repr -> VSFunction repr
+class InternalGetSet r where
+  getFunc :: SVariable r -> VSFunction r
+  setFunc :: VSType r -> SVariable r -> SValue r -> VSFunction r
 
-class InternalListFunc repr where
-  listSizeFunc   :: VSFunction repr
-  listAddFunc    :: SValue repr -> SValue repr -> SValue repr -> VSFunction repr
-  listAppendFunc :: SValue repr -> VSFunction repr
-  listAccessFunc :: VSType repr -> SValue repr -> VSFunction repr
-  listSetFunc    :: SValue repr -> SValue repr -> SValue repr -> VSFunction repr
+class InternalListFunc r where
+  listSizeFunc   :: VSFunction r
+  listAddFunc    :: SValue r -> SValue r -> SValue r -> VSFunction r
+  listAppendFunc :: SValue r -> VSFunction r
+  listAccessFunc :: VSType r -> SValue r -> VSFunction r
+  listSetFunc    :: SValue r -> SValue r -> SValue r -> VSFunction r
 
-class InternalIterator repr where
-  iterBeginFunc :: VSType repr -> VSFunction repr
-  iterEndFunc   :: VSType repr -> VSFunction repr
+class InternalIterator r where
+  iterBeginFunc :: VSType r -> VSFunction r
+  iterEndFunc   :: VSType r -> VSFunction r
 
-class InternalFunction repr where
-  functionType :: repr (Function repr) -> repr (Type repr)
-  functionDoc :: repr (Function repr) -> Doc
+class InternalFunction r where
+  functionType :: r (Function r) -> r (Type r)
+  functionDoc :: r (Function r) -> Doc
 
-  funcFromData :: Doc -> VSType repr -> VSFunction repr
+  funcFromData :: Doc -> VSType r -> VSFunction r
 
-class InternalAssignStmt repr where
-  multiAssign       :: [SVariable repr] -> [SValue repr] -> MSStatement repr 
+class InternalAssignStmt r where
+  multiAssign       :: [SVariable r] -> [SValue r] -> MSStatement r 
 
-class InternalIOStmt repr where
+class InternalIOStmt r where
   -- newLn, maybe a file to print to, printFunc, value to print
-  printSt :: Bool -> Maybe (SValue repr) -> SValue repr -> SValue repr -> 
-    MSStatement repr
+  printSt :: Bool -> Maybe (SValue r) -> SValue r -> SValue r -> 
+    MSStatement r
     
-class InternalControlStmt repr where
-  multiReturn :: [SValue repr] -> MSStatement repr
+class InternalControlStmt r where
+  multiReturn :: [SValue r] -> MSStatement r
 
-class InternalStatement repr where
-  state     :: MSStatement repr -> MSStatement repr
-  loopState :: MSStatement repr -> MSStatement repr
+class InternalStatement r where
+  state     :: MSStatement r -> MSStatement r
+  loopState :: MSStatement r -> MSStatement r
 
-  emptyState   :: MSStatement repr
-  statementDoc :: repr (Statement repr) -> Doc
-  statementTerm :: repr (Statement repr) -> Terminator
+  emptyState   :: MSStatement r
+  statementDoc :: r (Statement r) -> Doc
+  statementTerm :: r (Statement r) -> Terminator
 
-  stateFromData :: Doc -> Terminator -> repr (Statement repr)
+  stateFromData :: Doc -> Terminator -> r (Statement r)
 
-class InternalScope repr where
-  scopeDoc :: repr (Scope repr) -> Doc
-  scopeFromData :: ScopeTag -> Doc -> repr (Scope repr)
+class InternalScope r where
+  scopeDoc :: r (Scope r) -> Doc
+  scopeFromData :: ScopeTag -> Doc -> r (Scope r)
 
-class (TypeSym repr) => MethodTypeSym repr where
-  type MethodType repr
-  mType    :: VSType repr -> MS (repr (MethodType repr))
-  construct :: Label -> MS (repr (MethodType repr))
+class (TypeSym r) => MethodTypeSym r where
+  type MethodType r
+  mType    :: VSType r -> MS (r (MethodType r))
+  construct :: Label -> MS (r (MethodType r))
 
-class InternalParam repr where
-  parameterName :: repr (Parameter repr) -> Label
-  parameterType :: repr (Parameter repr) -> repr (Type repr)
-  parameterDoc  :: repr (Parameter repr) -> Doc
-  paramFromData :: repr (Variable repr) -> Doc -> repr (Parameter repr)
+class InternalParam r where
+  parameterName :: r (Parameter r) -> Label
+  parameterType :: r (Parameter r) -> r (Type r)
+  parameterDoc  :: r (Parameter r) -> Doc
+  paramFromData :: r (Variable r) -> Doc -> r (Parameter r)
 
-class (MethodTypeSym repr, BlockCommentSym repr, StateVarSym repr) => 
-  InternalMethod repr where
-  intMethod     :: Bool -> Label -> repr (Scope repr) -> repr (Permanence repr) 
-    -> MS (repr (MethodType repr)) -> [MSParameter repr] -> MSBody repr -> 
-    SMethod repr
-  intFunc       :: Bool -> Label -> repr (Scope repr) -> repr (Permanence repr) 
-    -> MS (repr (MethodType repr)) -> [MSParameter repr] -> MSBody repr -> 
-    SMethod repr
-  commentedFunc :: MS (repr (BlockComment repr)) -> SMethod repr -> SMethod repr
+class (MethodTypeSym r, BlockCommentSym r, StateVarSym r) => 
+  InternalMethod r where
+  intMethod     :: Bool -> Label -> r (Scope r) -> r (Permanence r) 
+    -> MS (r (MethodType r)) -> [MSParameter r] -> MSBody r -> 
+    SMethod r
+  intFunc       :: Bool -> Label -> r (Scope r) -> r (Permanence r) 
+    -> MS (r (MethodType r)) -> [MSParameter r] -> MSBody r -> 
+    SMethod r
+  commentedFunc :: MS (r (BlockComment r)) -> SMethod r -> SMethod r
     
-  destructor :: [CSStateVar repr] -> SMethod repr
+  destructor :: [CSStateVar r] -> SMethod r
 
-  methodDoc :: repr (Method repr) -> Doc
-  methodFromData :: ScopeTag -> Doc -> repr (Method repr)
+  methodDoc :: r (Method r) -> Doc
+  methodFromData :: ScopeTag -> Doc -> r (Method r)
 
-class InternalStateVar repr where
-  stateVarDoc :: repr (StateVar repr) -> Doc
-  stateVarFromData :: CS Doc -> CSStateVar repr
+class InternalStateVar r where
+  stateVarDoc :: r (StateVar r) -> Doc
+  stateVarFromData :: CS Doc -> CSStateVar r
 
 type ParentSpec = Doc
 
-class (BlockCommentSym repr) => InternalClass repr where
-  intClass :: Label -> repr (Scope repr) -> repr ParentSpec -> [CSStateVar repr]
-    -> [SMethod repr] -> SClass repr
+class (BlockCommentSym r) => InternalClass r where
+  intClass :: Label -> r (Scope r) -> r ParentSpec -> [CSStateVar r]
+    -> [SMethod r] -> SClass r
     
-  inherit :: Maybe Label -> repr ParentSpec
-  implements :: [Label] -> repr ParentSpec
+  inherit :: Maybe Label -> r ParentSpec
+  implements :: [Label] -> r ParentSpec
 
-  commentedClass :: CS (repr (BlockComment repr)) -> SClass repr -> SClass repr
+  commentedClass :: CS (r (BlockComment r)) -> SClass r -> SClass r
 
-  classDoc :: repr (Class repr) -> Doc
-  classFromData :: CS (repr Doc) -> SClass repr
+  classDoc :: r (Class r) -> Doc
+  classFromData :: CS (r Doc) -> SClass r
 
-class InternalMod repr where
-  moduleDoc :: repr (Module repr) -> Doc
-  modFromData :: String -> FS Doc -> FSModule repr
-  updateModuleDoc :: (Doc -> Doc) -> repr (Module repr) -> repr (Module repr)
+class InternalMod r where
+  moduleDoc :: r (Module r) -> Doc
+  modFromData :: String -> FS Doc -> FSModule r
+  updateModuleDoc :: (Doc -> Doc) -> r (Module r) -> r (Module r)
 
-class BlockCommentSym repr where
-  type BlockComment repr
-  blockComment :: [String] -> repr (BlockComment repr)
-  docComment :: State a [String] -> State a (repr (BlockComment repr))
+class BlockCommentSym r where
+  type BlockComment r
+  blockComment :: [String] -> r (BlockComment r)
+  docComment :: State a [String] -> State a (r (BlockComment r))
 
-  blockCommentDoc :: repr (BlockComment repr) -> Doc
+  blockCommentDoc :: r (BlockComment r) -> Doc

--- a/code/drasil-gool/GOOL/Drasil/RendererClasses.hs
+++ b/code/drasil-gool/GOOL/Drasil/RendererClasses.hs
@@ -12,7 +12,7 @@ module GOOL.Drasil.RendererClasses (
 
 import GOOL.Drasil.ClassInterface (Label, Library, SFile, MSBody, MSBlock, 
   VSType, SVariable, SValue, VSFunction, MSStatement, MSParameter, SMethod, 
-  CSStateVar, SClass, FSModule, FileSym(..), PermanenceSym(..), BodySym(..), 
+  CSStateVar, SClass, FSModule, NamedArg, FileSym(..), PermanenceSym(..), BodySym(..), 
   BlockSym(..), TypeSym(..), VariableSym(..), ValueSym(..), FunctionSym(..), 
   StatementSym(..), ScopeSym(..), ParameterSym(..), MethodSym(..), 
   StateVarSym(..), ClassSym(..), ModuleSym(..))
@@ -129,7 +129,7 @@ class InternalValue repr where
   -- Very generic internal function for generating calls, to reduce repeated code throughout generators
   -- Maybe library, function name, return type, maybe object doc, regular arguments, named arguments
   call :: Maybe Library -> Label -> VSType repr -> Maybe Doc -> [SValue repr] 
-    -> [(SVariable repr, SValue repr)] -> SValue repr
+    -> [NamedArg repr] -> SValue repr
 
   valuePrec :: repr (Value repr) -> Maybe Int
   valueDoc :: repr (Value repr) -> Doc

--- a/code/drasil-gool/GOOL/Drasil/RendererClasses.hs
+++ b/code/drasil-gool/GOOL/Drasil/RendererClasses.hs
@@ -2,8 +2,8 @@
 
 module GOOL.Drasil.RendererClasses (
   RenderSym, InternalFile(..), ImportSym(..), InternalPerm(..), 
-  InternalBody(..), InternalBlock(..), InternalType(..), UnaryOpSym(..), 
-  BinaryOpSym(..), InternalOp(..), InternalVariable(..), InternalValue(..),
+  InternalBody(..), InternalBlock(..), InternalType(..), VSUnOp, UnaryOpSym(..),
+  VSBinOp, BinaryOpSym(..), InternalOp(..), InternalVariable(..), InternalValue(..),
   InternalGetSet(..), InternalListFunc(..), InternalIterator(..), InternalFunction(..), InternalAssignStmt(..), InternalIOStmt(..), InternalControlStmt(..), InternalStatement(..), InternalScope(..), 
   MethodTypeSym(..), InternalParam(..), InternalMethod(..), 
   InternalStateVar(..), ParentSpec, InternalClass(..), InternalMod(..), 
@@ -63,40 +63,44 @@ class InternalType repr where
   getTypeDoc :: repr (Type repr) -> Doc
   typeFromData :: CodeType -> String -> Doc -> repr (Type repr)
 
+type VSUnOp a = VS (a (UnaryOp a))
+
 class UnaryOpSym repr where
   type UnaryOp repr
-  notOp    :: VS (repr (UnaryOp repr))
-  negateOp :: VS (repr (UnaryOp repr))
-  sqrtOp   :: VS (repr (UnaryOp repr))
-  absOp    :: VS (repr (UnaryOp repr))
-  logOp    :: VS (repr (UnaryOp repr))
-  lnOp     :: VS (repr (UnaryOp repr))
-  expOp    :: VS (repr (UnaryOp repr))
-  sinOp    :: VS (repr (UnaryOp repr))
-  cosOp    :: VS (repr (UnaryOp repr))
-  tanOp    :: VS (repr (UnaryOp repr))
-  asinOp   :: VS (repr (UnaryOp repr))
-  acosOp   :: VS (repr (UnaryOp repr))
-  atanOp   :: VS (repr (UnaryOp repr))
-  floorOp  :: VS (repr (UnaryOp repr))
-  ceilOp   :: VS (repr (UnaryOp repr))
+  notOp    :: VSUnOp repr
+  negateOp :: VSUnOp repr
+  sqrtOp   :: VSUnOp repr
+  absOp    :: VSUnOp repr
+  logOp    :: VSUnOp repr
+  lnOp     :: VSUnOp repr
+  expOp    :: VSUnOp repr
+  sinOp    :: VSUnOp repr
+  cosOp    :: VSUnOp repr
+  tanOp    :: VSUnOp repr
+  asinOp   :: VSUnOp repr
+  acosOp   :: VSUnOp repr
+  atanOp   :: VSUnOp repr
+  floorOp  :: VSUnOp repr
+  ceilOp   :: VSUnOp repr
+
+type VSBinOp a = VS (a (BinaryOp a))
 
 class BinaryOpSym repr where
   type BinaryOp repr
-  equalOp        :: VS (repr (BinaryOp repr))
-  notEqualOp     :: VS (repr (BinaryOp repr))
-  greaterOp      :: VS (repr (BinaryOp repr))
-  greaterEqualOp :: VS (repr (BinaryOp repr))
-  lessOp         :: VS (repr (BinaryOp repr))
-  lessEqualOp    :: VS (repr (BinaryOp repr))
-  plusOp         :: VS (repr (BinaryOp repr))
-  minusOp        :: VS (repr (BinaryOp repr))
-  multOp         :: VS (repr (BinaryOp repr))
-  divideOp       :: VS (repr (BinaryOp repr))
-  powerOp        :: VS (repr (BinaryOp repr))
-  moduloOp       :: VS (repr (BinaryOp repr))
-  andOp          :: VS (repr (BinaryOp repr))
-  orOp           :: VS (repr (BinaryOp repr))
+  equalOp        :: VSBinOp repr
+  notEqualOp     :: VSBinOp repr
+  greaterOp      :: VSBinOp repr
+  greaterEqualOp :: VSBinOp repr
+  lessOp         :: VSBinOp repr
+  lessEqualOp    :: VSBinOp repr
+  plusOp         :: VSBinOp repr
+  minusOp        :: VSBinOp repr
+  multOp         :: VSBinOp repr
+  divideOp       :: VSBinOp repr
+  powerOp        :: VSBinOp repr
+  moduloOp       :: VSBinOp repr
+  andOp          :: VSBinOp repr
+  orOp           :: VSBinOp repr
 
 class InternalOp repr where
   uOpDoc :: repr (UnaryOp repr) -> Doc
@@ -104,8 +108,8 @@ class InternalOp repr where
   uOpPrec :: repr (UnaryOp repr) -> Int
   bOpPrec :: repr (BinaryOp repr) -> Int
 
-  uOpFromData :: Int -> Doc -> VS (repr (UnaryOp repr))
-  bOpFromData :: Int -> Doc -> VS (repr (BinaryOp repr))
+  uOpFromData :: Int -> Doc -> VSUnOp repr
+  bOpFromData :: Int -> Doc -> VSBinOp repr
 
 class InternalVariable repr where
   variableBind :: repr (Variable repr) -> Binding

--- a/code/drasil-gool/GOOL/Drasil/RendererClasses.hs
+++ b/code/drasil-gool/GOOL/Drasil/RendererClasses.hs
@@ -12,7 +12,7 @@ module GOOL.Drasil.RendererClasses (
 
 import GOOL.Drasil.ClassInterface (Label, Library, SFile, MSBody, MSBlock, 
   VSType, SVariable, SValue, VSFunction, MSStatement, MSParameter, SMethod, 
-  CSStateVar, SClass, FSModule, NamedArg, FileSym(..), PermanenceSym(..), BodySym(..), 
+  CSStateVar, SClass, FSModule, NamedArgs, FileSym(..), PermanenceSym(..), BodySym(..), 
   BlockSym(..), TypeSym(..), VariableSym(..), ValueSym(..), FunctionSym(..), 
   StatementSym(..), ScopeSym(..), ParameterSym(..), MethodSym(..), 
   StateVarSym(..), ClassSym(..), ModuleSym(..))
@@ -129,7 +129,7 @@ class InternalValue r where
   -- Very generic internal function for generating calls, to reduce repeated code throughout generators
   -- Maybe library, function name, return type, maybe object doc, regular arguments, named arguments
   call :: Maybe Library -> Label -> VSType r -> Maybe Doc -> [SValue r] 
-    -> [NamedArg r] -> SValue r
+    -> NamedArgs r -> SValue r
 
   valuePrec :: r (Value r) -> Maybe Int
   valueDoc :: r (Value r) -> Doc

--- a/code/drasil-gool/Test/FileTests.hs
+++ b/code/drasil-gool/Test/FileTests.hs
@@ -6,14 +6,14 @@ import GOOL.Drasil (GSProgram, MSBlock, MSStatement, SMethod, ProgramSym(..),
   MethodSym(..), ModuleSym(..))
 import Prelude hiding (return,print,log,exp,sin,cos,tan)
 
-fileTests :: (ProgramSym repr) => GSProgram repr
+fileTests :: (ProgramSym r) => GSProgram r
 fileTests = prog "FileTests" [fileDoc (buildModule "FileTests" [] 
   [fileTestMethod] [])]
 
-fileTestMethod :: (ProgramSym repr) => SMethod repr
+fileTestMethod :: (ProgramSym r) => SMethod r
 fileTestMethod = mainFunction (body [writeStory, block [readStory], goodBye])
 
-writeStory :: (ProgramSym repr) => MSBlock repr
+writeStory :: (ProgramSym r) => MSBlock r
 writeStory = block [
   varDec $ var "fileToWrite" outfile,
 
@@ -32,11 +32,11 @@ writeStory = block [
   discardFileLine (valueOf $ var "fileToRead" infile),
   listDec 0 (var "fileContents" (listType string))]
 
-readStory :: (ProgramSym repr) => MSStatement repr
+readStory :: (ProgramSym r) => MSStatement r
 readStory = getFileInputAll (valueOf $ var "fileToRead" infile) 
   (var "fileContents" (listType string))
 
-goodBye :: (ProgramSym repr) => MSBlock repr
+goodBye :: (ProgramSym r) => MSBlock r
 goodBye = block [
   printLn (valueOf $ var "fileContents" (listType string)), 
   closeFile (valueOf $ var "fileToRead" infile)]

--- a/code/drasil-gool/Test/HelloWorld.hs
+++ b/code/drasil-gool/Test/HelloWorld.hs
@@ -12,7 +12,7 @@ import GOOL.Drasil (GSProgram, MSBody, MSBlock, MSStatement, SMethod,
 import Prelude hiding (return,print,log,exp,sin,cos,tan,const)
 import Test.Helper (helper)
 
-helloWorld :: (ProgramSym repr) => GSProgram repr
+helloWorld :: (ProgramSym r) => GSProgram r
 helloWorld = prog "HelloWorld" [docMod description 
   ["Brooks MacLachlan"] "" $ fileDoc (buildModule "HelloWorld" [] 
   [helloWorldMain] []), helper]
@@ -20,14 +20,14 @@ helloWorld = prog "HelloWorld" [docMod description
 description :: String
 description = "Tests various GOOL functions. It should run without errors."
 
-helloWorldMain :: (ProgramSym repr) => SMethod repr
+helloWorldMain :: (ProgramSym r) => SMethod r
 helloWorldMain = mainFunction (body [ helloInitVariables, 
     helloListSlice,
     block [ifCond [(valueOf (var "b" int) ?>= litInt 6, bodyStatements [varDecDef (var "dummy" string) (litString "dummy")]),
       (valueOf (var "b" int) ?== litInt 5, helloIfBody)] helloElseBody, helloIfExists,
     helloSwitch, helloForLoop, helloWhileLoop, helloForEachLoop, helloTryCatch]])
 
-helloInitVariables :: (ProgramSym repr) => MSBlock repr
+helloInitVariables :: (ProgramSym r) => MSBlock r
 helloInitVariables = block [comment "Initializing variables",
   varDec $ var "a" int, 
   varDecDef (var "b" int) (litInt 5),
@@ -54,12 +54,12 @@ helloInitVariables = block [comment "Initializing variables",
   printLn (valueOf $ var "boringList" (listType bool)),
   listDec 2 $ var "mySlicedList" (listType double)]
 
-helloListSlice :: (ProgramSym repr) => MSBlock repr
+helloListSlice :: (ProgramSym r) => MSBlock r
 helloListSlice = listSlice (var "mySlicedList" (listType double)) 
   (valueOf $ var "myOtherList" (listType double)) (Just (litInt 1)) 
   (Just (litInt 3)) Nothing
 
-helloIfBody :: (ProgramSym repr) => MSBody repr
+helloIfBody :: (ProgramSym r) => MSBody r
 helloIfBody = addComments "If body" (body [
   block [
     varDec $ var "c" int,
@@ -127,33 +127,33 @@ helloIfBody = addComments "If body" (body [
     printLn (inlineIf litTrue (litInt 5) (litInt 0)),
     printLn (cot (litDouble 1.0))]])
 
-helloElseBody :: (ProgramSym repr) => MSBody repr
+helloElseBody :: (ProgramSym r) => MSBody r
 helloElseBody = bodyStatements [printLn (arg 5)]
 
-helloIfExists :: (ProgramSym repr) => MSStatement repr
+helloIfExists :: (ProgramSym r) => MSStatement r
 helloIfExists = ifExists (valueOf $ var "boringList" (listType bool)) 
   (oneLiner (printStrLn "Ew, boring list!")) (oneLiner (printStrLn "Great, no bores!"))
 
-helloSwitch :: (ProgramSym repr) => MSStatement repr
+helloSwitch :: (ProgramSym r) => MSStatement r
 helloSwitch = switch (valueOf $ var "a" int) [(litInt 5, oneLiner (var "b" int &= litInt 10)), 
   (litInt 0, oneLiner (var "b" int &= litInt 5))]
   (oneLiner (var "b" int &= litInt 0))
 
-helloForLoop :: (ProgramSym repr) => MSStatement repr
+helloForLoop :: (ProgramSym r) => MSStatement r
 helloForLoop = forRange i (litInt 0) (litInt 9) (litInt 1) (oneLiner (printLn 
   (valueOf i)))
   where i = var "i" int
 
-helloWhileLoop :: (ProgramSym repr) => MSStatement repr
+helloWhileLoop :: (ProgramSym r) => MSStatement r
 helloWhileLoop = while (valueOf (var "a" int) ?< litInt 13) (bodyStatements 
   [printStrLn "Hello", (&++) (var "a" int)]) 
 
-helloForEachLoop :: (ProgramSym repr) => MSStatement repr
+helloForEachLoop :: (ProgramSym r) => MSStatement r
 helloForEachLoop = forEach i (valueOf $ listVar "myOtherList" double) 
   (oneLiner (printLn (extFuncApp "Helper" "doubleAndAdd" double [valueOf i, 
   litDouble 1.0])))
   where i = iterVar "num" double
 
-helloTryCatch :: (ProgramSym repr) => MSStatement repr
+helloTryCatch :: (ProgramSym r) => MSStatement r
 helloTryCatch = tryCatch (oneLiner (throw "Good-bye!"))
   (oneLiner (printStrLn "Caught intentional error"))

--- a/code/drasil-gool/Test/Helper.hs
+++ b/code/drasil-gool/Test/Helper.hs
@@ -7,10 +7,10 @@ import GOOL.Drasil (SFile, SMethod,
   ModuleSym(..))
 import Prelude hiding (return,print,log,exp,sin,cos,tan)
 
-helper :: (ProgramSym repr) => SFile repr
+helper :: (ProgramSym r) => SFile r
 helper = fileDoc (buildModule "Helper" [] [doubleAndAdd] [])
 
-doubleAndAdd :: (ProgramSym repr) => SMethod repr
+doubleAndAdd :: (ProgramSym r) => SMethod r
 doubleAndAdd = docFunc "This function adds two numbers" 
   ["First number to add", "Second number to add"] (Just "Sum") $ 
   function "doubleAndAdd"  public static double

--- a/code/drasil-gool/Test/Main.hs
+++ b/code/drasil-gool/Test/Main.hs
@@ -38,7 +38,7 @@ genCode :: [ProgData] -> IO()
 genCode files = createCodeFiles (concatMap (\p -> replicate (length $ progMods 
   p) (progName p)) files) $ makeCode (concatMap progMods files)
 
-classes :: (ProgramSym repr) => (repr (Program repr) -> ProgData) -> [ProgData]
+classes :: (ProgramSym r) => (r (Program r) -> ProgData) -> [ProgData]
 classes unRepr = zipWith (\p gs -> unRepr (evalState p gs)) [helloWorld, patternTest, fileTests, simpleODE] 
   (map (unCI . (`evalState` initialState)) [helloWorld, patternTest, fileTests, simpleODE])
 

--- a/code/drasil-gool/Test/Observer.hs
+++ b/code/drasil-gool/Test/Observer.hs
@@ -11,24 +11,24 @@ observerName = "Observer"
 observerDesc = "This is an arbitrary class acting as an Observer"
 printNum = "printNum"
 
-observer :: (ProgramSym repr) => SFile repr
+observer :: (ProgramSym r) => SFile r
 observer = fileDoc (buildModule observerName [] [] [docClass observerDesc
   helperClass])
 
-x :: (VariableSym repr) => SVariable repr
+x :: (VariableSym r) => SVariable r
 x = var "x" int
 
-selfX :: (VariableSym repr) => SVariable repr
+selfX :: (VariableSym r) => SVariable r
 selfX = objVarSelf x
 
-helperClass :: (ClassSym repr, IOStatement repr, Literal repr, VariableValue repr) => SClass repr
+helperClass :: (ClassSym r, IOStatement r, Literal r, VariableValue r) => SClass r
 helperClass = buildClass observerName Nothing [stateVar public dynamic x]
   [observerConstructor, printNumMethod, getMethod x, setMethod x]
 
-observerConstructor :: (MethodSym repr, VariableSym repr, Literal repr) => 
-  SMethod repr
+observerConstructor :: (MethodSym r, VariableSym r, Literal r) => 
+  SMethod r
 observerConstructor = initializer [] [(x, litInt 5)]
 
-printNumMethod :: (MethodSym repr, IOStatement repr, VariableValue repr) => SMethod repr
+printNumMethod :: (MethodSym r, IOStatement r, VariableValue r) => SMethod r
 printNumMethod = method printNum public dynamic void [] $
   oneLiner $ printLn $ valueOf selfX

--- a/code/drasil-gool/Test/PatternTest.hs
+++ b/code/drasil-gool/Test/PatternTest.hs
@@ -22,25 +22,25 @@ obs1Name = "obs1"
 obs2Name = "obs2"
 nName = "n"
 
-observerType :: (TypeSym repr) => VSType repr
+observerType :: (TypeSym r) => VSType r
 observerType = obj observerName
 
-n, obs1, obs2 :: (VariableSym repr) => SVariable repr
+n, obs1, obs2 :: (VariableSym r) => SVariable r
 n = var nName int
 obs1 = var obs1Name observerType
 obs2 = var obs2Name observerType
 
-newObserver :: (ValueExpression repr, TypeSym repr) => SValue repr
+newObserver :: (ValueExpression r, TypeSym r) => SValue r
 newObserver = extNewObj observerName observerType []
 
-patternTest :: (ProgramSym repr) => GSProgram repr
+patternTest :: (ProgramSym r) => GSProgram r
 patternTest = prog progName [fileDoc (buildModule progName []
   [patternTestMainMethod] []), observer]
 
-patternTestMainMethod :: (MethodSym repr, AssignStatement repr, 
-  DeclStatement repr, IOStatement repr, Literal repr, VariableValue repr, ValueExpression repr, GetSet repr, List repr, 
-  StatePattern repr, ObserverPattern repr, StrategyPattern repr) => 
-  SMethod repr
+patternTestMainMethod :: (MethodSym r, AssignStatement r, 
+  DeclStatement r, IOStatement r, Literal r, VariableValue r, ValueExpression r, GetSet r, List r, 
+  StatePattern r, ObserverPattern r, StrategyPattern r) => 
+  SMethod r
 patternTestMainMethod = mainFunction (body [block [
   varDec n,
   initState fsmName offState, 

--- a/code/drasil-gool/Test/SimpleODE.hs
+++ b/code/drasil-gool/Test/SimpleODE.hs
@@ -6,23 +6,23 @@ import GOOL.Drasil (GSProgram, SVariable, SMethod, ProgramSym(..), FileSym(..), 
   odeInfo, ODEOptions, odeOptions, ODEMethod(RK45))
 import Prelude hiding (return,print,log,exp,sin,cos,tan)
 
-simpleODE :: (ProgramSym repr) => GSProgram repr
+simpleODE :: (ProgramSym r) => GSProgram r
 simpleODE = prog "SimpleODE" [fileDoc (buildModule "SimpleODE" []
   [simpleODEMain] [])]
 
-simpleODEMain :: (ProgramSym repr) => SMethod repr
+simpleODEMain :: (ProgramSym r) => SMethod r
 simpleODEMain = mainFunction (body [block [varDecDef odeConst (litDouble 3.5)],
   solveODE info opts,
   block [print $ valueOf odeDepVar]])
 
-odeConst, odeDepVar, odeIndepVar :: (ProgramSym repr) => SVariable repr
+odeConst, odeDepVar, odeIndepVar :: (ProgramSym r) => SVariable r
 odeConst = var "c" double
 odeDepVar = var "T" (listType double)
 odeIndepVar = var "t" (listType double)
 
-info :: (ProgramSym repr) => ODEInfo repr
+info :: (ProgramSym r) => ODEInfo r
 info = odeInfo odeIndepVar odeDepVar [odeConst] (litDouble 0.0) (litDouble 10.0) 
   (litDouble 1.0) (valueOf odeDepVar #+ valueOf odeConst)
 
-opts :: (ProgramSym repr) => ODEOptions repr
+opts :: (ProgramSym r) => ODEOptions r
 opts = odeOptions RK45 (litDouble 0.001) (litDouble 0.001) (litDouble 1.0)


### PR DESCRIPTION
This PR abbreviates GOOL in various ways:
- Introducing type synonyms for repeated type patterns
- Shortening `repr` type variable to `r`
- Using `>>` instead of `_ <-`

Based on discussion from the April 14th GOOL code review meeting.