### PR TITLE
Make CodeInfo fully generic

### DIFF
--- a/code/drasil-gool/GOOL/Drasil/CodeAnalysis.hs
+++ b/code/drasil-gool/GOOL/Drasil/CodeAnalysis.hs
@@ -1,14 +1,17 @@
 module GOOL.Drasil.CodeAnalysis (
-  Exception(loc, exc), printExc, hasLoc, exception, stdExc
+  ExceptionType(..), Exception(loc, exc), printExc, hasLoc, exception, stdExc,
+  HasException(..)
 ) where
 
--- Stores exception information
 -- Eq is needed so that the same exception doesn't get added multiple times 
 -- to the list of exceptions for a given method.
+data ExceptionType = Standard | FileNotFound | IO deriving Eq
+
+-- Stores exception information
 data Exception = Exc {
   loc :: String, -- import string where the exception is defined
   exc :: String -- name of the exception
-} deriving Eq
+}
 
 printExc :: Exception -> String
 printExc (Exc l e) = if null l then e else l ++ "." ++ e
@@ -22,3 +25,6 @@ exception = Exc
 
 stdExc :: String -> Exception
 stdExc = Exc ""
+
+class HasException r where
+  toConcreteExc :: ExceptionType -> r Exception

--- a/code/drasil-gool/GOOL/Drasil/CodeInfo.hs
+++ b/code/drasil-gool/GOOL/Drasil/CodeInfo.hs
@@ -14,7 +14,7 @@ import GOOL.Drasil.ClassInterface (MSBody, VSType, SValue, MSStatement,
   StateVarSym(..), ClassSym(..), ModuleSym(..))
 import GOOL.Drasil.CodeType (CodeType(Void))
 import GOOL.Drasil.AST (ScopeTag(..))
-import GOOL.Drasil.CodeAnalysis (Exception(..), exception, stdExc)
+import GOOL.Drasil.CodeAnalysis (ExceptionType(..))
 import GOOL.Drasil.Helpers (toCode, toState)
 import GOOL.Drasil.State (GOOLState, VS, lensGStoFS, lensFStoCS, lensFStoMS,
   lensCStoMS, lensMStoFS, lensMStoVS, lensVStoFS, modifyReturn, setClassName, 
@@ -276,9 +276,10 @@ instance IOStatement CodeInfo where
   getFileInput v _ = zoom lensMStoVS $ execute1 v
   discardFileInput = zoom lensMStoVS . execute1
 
-  openFileR _ v = modify (addException fnfExc) >> execute1 (zoom lensMStoVS v)
-  openFileW _ v = modify (addException ioExc) >> execute1 (zoom lensMStoVS v)
-  openFileA _ v = modify (addException ioExc) >> execute1 (zoom lensMStoVS v)
+  openFileR _ v = modify (addException FileNotFound) >> 
+    execute1 (zoom lensMStoVS v)
+  openFileW _ v = modify (addException IO) >> execute1 (zoom lensMStoVS v)
+  openFileA _ v = modify (addException IO) >> execute1 (zoom lensMStoVS v)
   closeFile     = zoom lensMStoVS . execute1
 
   getFileInputLine v _ = zoom lensMStoVS $ execute1 v
@@ -311,7 +312,7 @@ instance ControlStatement CodeInfo where
 
   returnState = zoom lensMStoVS . execute1
 
-  throw _ = modifyReturn (addException genericExc) (toCode ())
+  throw _ = modifyReturn (addException Standard) (toCode ())
 
   ifCond = evalConds
   switch v cs b = do
@@ -420,11 +421,6 @@ noInfo = toState $ toCode ()
 
 noInfoType :: State s (CodeInfo String)
 noInfoType = toState $ toCode ""
-
-fnfExc, ioExc, genericExc :: Exception
-fnfExc = exception "java.io" "FileNotFoundException"
-ioExc = exception "java.io" "IOException"
-genericExc = stdExc "Exception"
 
 updateMEMandCM :: String -> MSBody CodeInfo -> SMethod CodeInfo
 updateMEMandCM n b = do

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer/JavaRenderer.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer/JavaRenderer.hs
@@ -70,7 +70,8 @@ import GOOL.Drasil.AST (Terminator(..), ScopeTag(..), FileType(..),
   FileData(..), fileD, FuncData(..), fd, ModData(..), md, updateMod, 
   MethodData(..), mthd, updateMthd, OpData(..), od, ParamData(..), pd, 
   ProgData(..), progD, TypeData(..), td, ValData(..), vd, VarData(..), vard)
-import GOOL.Drasil.CodeAnalysis (Exception(..))
+import GOOL.Drasil.CodeAnalysis (Exception(..), ExceptionType(..), exception, 
+  stdExc, HasException(..))
 import GOOL.Drasil.Helpers (angles, emptyIfNull, toCode, toState, onCodeValue, 
   onStateValue, on2CodeValues, on2StateValues, on3CodeValues, on3StateValues, 
   onCodeList, onStateList, on1StateValue1List)
@@ -642,7 +643,8 @@ instance InternalMethod JavaCode where
     mem <- zoom lensMStoVS getMethodExcMap
     es <- getExceptions
     mn <- zoom lensMStoFS getModuleName
-    let excs = maybe es (nub . (++ es)) (Map.lookup (key mn n) mem) 
+    let excs = map (unJC . toConcreteExc) $ maybe es (nub . (++ es)) 
+          (Map.lookup (key mn n) mem) 
         key mnm nm = mnm ++ "." ++ nm
     modify ((if m then setCurrMain else id) . addExceptionImports excs) 
     toState $ methodFromData Pub $ jMethod n (map exc excs) s p tp pms bd
@@ -701,6 +703,12 @@ instance BlockCommentSym JavaCode where
     blockCmtEnd)
 
   blockCommentDoc = unJC
+
+instance HasException JavaCode where
+  toConcreteExc Standard = toCode $ stdExc "Exception"
+  toConcreteExc FileNotFound = toCode $ exception "java.io" 
+    "FileNotFoundException"
+  toConcreteExc IO = toCode $ exception "java.io" "IOException"
 
 odeImport :: String
 odeImport = "org.apache.commons.math3.ode."


### PR DESCRIPTION
CodeInfo had some Java-specific exception definitions. This PR adds an `ExceptionType` type to represent exceptions in a language-independent way, and a class for mapping an `ExceptionType` to the language specific `Exception`. The `CodeInfo` pass then uses `Exception` type so it is fully language-generic, and the Java renderer has an instance of the new class to translate that to concrete exception declarations in Java.