### PR TITLE
Remove FDec node of FuncStmt

### DIFF
--- a/code/drasil-code/Language/Drasil/Code.hs
+++ b/code/drasil-code/Language/Drasil/Code.hs
@@ -11,7 +11,7 @@ module Language.Drasil.Code (
   matchConcepts, SpaceMatch, matchSpaces, AuxFile(..), Visibility(..), 
   ODEMethod(..), defaultChoices, funcUID, funcUID', asVC, asVC', codeSpec, 
   relToQD,
-  ($:=), Mod(Mod), Func, FuncStmt(..), fdec, ffor, funcData, funcDef, 
+  ($:=), Mod(Mod), Func, FuncStmt(..), fDecDef, ffor, funcData, funcDef, 
   packmod,
   junkLine, multiLine, repeated, singleLine, singleton,
   ExternalLibrary, Step, FunctionInterface, Argument, externalLib, choiceSteps, 
@@ -79,7 +79,7 @@ import Language.Drasil.CodeSpec (Choices(..), CodeSpec(..), CodeSystInfo(..),
   ConstantRepr(..), InputModule(..), CodeConcept(..), matchConcepts, SpaceMatch,
   matchSpaces, AuxFile(..), Visibility(..), ODEMethod(..), defaultChoices, 
   funcUID, funcUID', asVC, asVC', codeSpec, relToQD)
-import Language.Drasil.Mod (($:=), Mod(Mod), Func, FuncStmt(..), fdec, ffor, 
+import Language.Drasil.Mod (($:=), Mod(Mod), Func, FuncStmt(..), fDecDef, ffor, 
   funcData, funcDef, packmod)
 
 import Language.Drasil.Code.Imperative.GOOL.ClassInterface (PackageSym(..))

--- a/code/drasil-code/Language/Drasil/Code/Imperative/Import.hs
+++ b/code/drasil-code/Language/Drasil/Code/Imperative/Import.hs
@@ -341,7 +341,7 @@ genFunc (FDef (FuncDef n desc parms o rd s)) = do
   stmts <- mapM convStmt s
   vars <- mapM mkVar (fstdecl (sysinfodb $ csi $ codeSpec g) s \\ parms)
   publicFunc n (convType $ spaceMatches g o) desc parms rd 
-    [block $ map varDec vars ++ stmts]
+    [block $ map varDec vars, block stmts]
 genFunc (FDef (CtorDef n desc parms i s)) = do
   g <- ask
   inits <- mapM (convExpr . snd) i
@@ -350,7 +350,7 @@ genFunc (FDef (CtorDef n desc parms i s)) = do
   stmts <- mapM convStmt s
   vars <- mapM mkVar (fstdecl (sysinfodb $ csi $ codeSpec g) s \\ parms)
   genInitConstructor n desc parms (zip initvars inits) 
-    [block $ map varDec vars ++ stmts]
+    [block $ map varDec vars, block stmts]
 genFunc (FData (FuncData n desc ddef)) = genDataFunc n desc ddef
 
 convStmt :: (ProgramSym r) => FuncStmt -> Reader DrasilState (MSStatement r)

--- a/code/drasil-code/Language/Drasil/Code/Imperative/Import.hs
+++ b/code/drasil-code/Language/Drasil/Code/Imperative/Import.hs
@@ -414,13 +414,12 @@ convStmt (FTry t c) = do
   stmt2 <- mapM convStmt c
   return $ tryCatch (bodyStatements stmt1) (bodyStatements stmt2)
 convStmt FContinue = return continue
-convStmt (FDec v) = do
+convStmt (FDecDef v (Matrix [[]])) = do
   vari <- mkVar v
   let convDec (C.List _) = listDec 0 vari
       convDec (C.Array _) = arrayDec 0 vari
       convDec _ = varDec vari
   fmap convDec (codeType v) 
-convStmt (FDecDef v (Matrix [[]])) = convStmt (FDec v)
 convStmt (FDecDef v e) = do
   v' <- mkVar v
   l <- maybeLog v'

--- a/code/drasil-code/Language/Drasil/Mod.hs
+++ b/code/drasil-code/Language/Drasil/Mod.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE GADTs #-}
 module Language.Drasil.Mod (Class(..), Func(..), FuncData(..), FuncDef(..), 
   FuncStmt(..), Initializer, Mod(..), Name, ($:=), classDef, classImplements, 
-  ctorDef, ffor, fdec, fname, fstdecl, funcData, funcDef, packmod, 
+  ctorDef, ffor, fDecDef, fname, fstdecl, funcData, funcDef, packmod, 
   packmodRequires, prefixFunctions
 ) where
 
@@ -91,8 +91,8 @@ v $:= e = FAsg (quantvar v) e
 ffor :: (Quantity c, MayHaveUnit c) => c -> Expr -> [FuncStmt] -> FuncStmt
 ffor v = FFor (quantvar  v)
 
-fdec :: (Quantity c, MayHaveUnit c) => c -> FuncStmt
-fdec v  = FDec (quantvar v)
+fDecDef :: (Quantity c, MayHaveUnit c) => c -> Expr -> FuncStmt
+fDecDef v  = FDecDef (quantvar v)
 
 fstdecl :: ChunkDB -> [FuncStmt] -> [CodeVarChunk]
 fstdecl ctx fsts = nub (concatMap (fstvars ctx) fsts) \\ nub (concatMap (declared ctx) fsts) 

--- a/code/drasil-code/Language/Drasil/Mod.hs
+++ b/code/drasil-code/Language/Drasil/Mod.hs
@@ -78,7 +78,6 @@ data FuncStmt where
   FThrow :: String -> FuncStmt
   FTry :: [FuncStmt] -> [FuncStmt] -> FuncStmt
   FContinue :: FuncStmt
-  FDec :: CodeVarChunk -> FuncStmt
   FDecDef :: CodeVarChunk -> Expr -> FuncStmt
   FVal :: Expr -> FuncStmt
   FMulti :: [FuncStmt] -> FuncStmt
@@ -98,7 +97,6 @@ fstdecl :: ChunkDB -> [FuncStmt] -> [CodeVarChunk]
 fstdecl ctx fsts = nub (concatMap (fstvars ctx) fsts) \\ nub (concatMap (declared ctx) fsts) 
   where
     fstvars :: ChunkDB -> FuncStmt -> [CodeVarChunk]
-    fstvars _  (FDec cch) = [cch]
     fstvars sm (FDecDef cch e) = cch:codevars' e sm
     fstvars sm (FAsg cch e) = cch:codevars' e sm
     fstvars sm (FAsgIndex cch _ e) = cch:codevars' e sm
@@ -116,7 +114,6 @@ fstdecl ctx fsts = nub (concatMap (fstvars ctx) fsts) \\ nub (concatMap (declare
     fstvars sm (FAppend a b) = nub (codevars a sm ++ codevars b sm)
 
     declared :: ChunkDB -> FuncStmt -> [CodeVarChunk]
-    declared _  (FDec cch) = [cch]
     declared _  (FDecDef cch _) = [cch]
     declared _  (FAsg _ _) = []
     declared _  FAsgIndex {} = []

--- a/code/drasil-example/Drasil/GlassBR/ModuleDefs.hs
+++ b/code/drasil-example/Drasil/GlassBR/ModuleDefs.hs
@@ -7,7 +7,7 @@ module Drasil.GlassBR.ModuleDefs (allMods, implVars, interpY, interpZ) where
 import Language.Drasil
 import Language.Drasil.ShortHands
 import Language.Drasil.Code (($:=), Func, FuncStmt(..), Mod, 
-  asVC, funcDef, fdec, ffor, funcData, quantvar, 
+  asVC, funcDef, fDecDef, ffor, funcData, quantvar, 
   multiLine, packmod, repeated, singleLine)
 
 allMods :: [Mod]
@@ -149,7 +149,7 @@ extractColumnCT :: Func
 extractColumnCT = funcDef "extractColumn" "Extracts a column from a 2D matrix" 
   [mat, j] (Vect Real) (Just "column of the given matrix at the given index")
   [
-    fdec col,
+    fDecDef col (Matrix [[]]),
     --
     ffor i (sy i $< dim (sy mat))
       [ FAppend (sy col) (aLook mat i j) ],
@@ -162,9 +162,9 @@ interpY = funcDef "interpY"
   [filename, x, z] Real (Just "y value interpolated at given x and z values")
   [
   -- hack
-  fdec xMatrix,
-  fdec yMatrix,
-  fdec zVector,
+  fDecDef xMatrix (Matrix [[]]),
+  fDecDef yMatrix (Matrix [[]]),
+  fDecDef zVector (Matrix [[]]),
   --
   call readTable [filename, zVector, xMatrix, yMatrix],
   -- endhack
@@ -188,9 +188,9 @@ interpZ = funcDef "interpZ"
   [filename, x, y] Real (Just "z value interpolated at given x and y values")
   [
     -- hack
-  fdec xMatrix,
-  fdec yMatrix,
-  fdec zVector,
+  fDecDef xMatrix (Matrix [[]]),
+  fDecDef yMatrix (Matrix [[]]),
+  fDecDef zVector (Matrix [[]]),
   --
   call readTable [filename, zVector, xMatrix, yMatrix],
   -- endhack

--- a/code/stable/glassbr/src/cpp/Interpolation.cpp
+++ b/code/stable/glassbr/src/cpp/Interpolation.cpp
@@ -130,6 +130,7 @@ double func_interpY(string filename, double x, double z) {
     int k_2;
     double y_1;
     double y_2;
+    
     vector<vector<double>> x_matrix(0);
     vector<vector<double>> y_matrix(0);
     vector<double> z_vector(0);
@@ -250,6 +251,7 @@ double func_interpZ(string filename, double x, double y) {
     int k_2;
     double y_1;
     double y_2;
+    
     vector<vector<double>> x_matrix(0);
     vector<vector<double>> y_matrix(0);
     vector<double> z_vector(0);

--- a/code/stable/glassbr/src/csharp/Interpolation.cs
+++ b/code/stable/glassbr/src/csharp/Interpolation.cs
@@ -151,6 +151,7 @@ public class Interpolation {
         int k_2;
         double y_1;
         double y_2;
+        
         List<List<double>> x_matrix = new List<List<double>>(0);
         List<List<double>> y_matrix = new List<List<double>>(0);
         List<double> z_vector = new List<double>(0);
@@ -277,6 +278,7 @@ public class Interpolation {
         int k_2;
         double y_1;
         double y_2;
+        
         List<List<double>> x_matrix = new List<List<double>>(0);
         List<List<double>> y_matrix = new List<List<double>>(0);
         List<double> z_vector = new List<double>(0);

--- a/code/stable/glassbr/src/java/GlassBR/Interpolation.java
+++ b/code/stable/glassbr/src/java/GlassBR/Interpolation.java
@@ -124,6 +124,7 @@ public class Interpolation {
         int k_2;
         double y_1;
         double y_2;
+        
         ArrayList<ArrayList<Double>> x_matrix = new ArrayList<ArrayList<Double>>(0);
         ArrayList<ArrayList<Double>> y_matrix = new ArrayList<ArrayList<Double>>(0);
         ArrayList<Double> z_vector = new ArrayList<Double>(0);
@@ -218,6 +219,7 @@ public class Interpolation {
         int k_2;
         double y_1;
         double y_2;
+        
         ArrayList<ArrayList<Double>> x_matrix = new ArrayList<ArrayList<Double>>(0);
         ArrayList<ArrayList<Double>> y_matrix = new ArrayList<ArrayList<Double>>(0);
         ArrayList<Double> z_vector = new ArrayList<Double>(0);


### PR DESCRIPTION
The generator automatically generates any needed function declarations for modules defined with `FuncStmt`s, so it did not make sense to have a node in `FuncStmt` for declaration statements. This node was only being used in places where what was really intended was not just declaring a variable, but also assigning an empty list to it, so the `FDecDef` node is more appropriate to use in those cases. So I switched those to use `FDecDef`, and then removed `FDec`. 

While I was at it, I updated the generator to put the automatically-generated declaration statements for each function into their own block, resulting in some (expected) new-lines added to stable.