### PR TITLE
Minor generator improvements

### DIFF
--- a/code/drasil-code/Language/Drasil/Code/ExternalLibrary.hs
+++ b/code/drasil-code/Language/Drasil/Code/ExternalLibrary.hs
@@ -16,12 +16,11 @@ module Language.Drasil.Code.ExternalLibrary (ExternalLibrary, Step(..),
 import Language.Drasil
 import Language.Drasil.Chunk.Code (CodeVarChunk, CodeFuncChunk, codeName, 
   ccObjVar)
-import Language.Drasil.Mod (FuncStmt(..))
+import Language.Drasil.Mod (FuncStmt(..), Description)
 
 import Control.Lens ((^.))
 import Data.List.NonEmpty (NonEmpty(..), fromList)
 
-type Description = String
 type Condition = Expr
 type Requires = String
 

--- a/code/drasil-code/Language/Drasil/Code/Imperative/Descriptions.hs
+++ b/code/drasil-code/Language/Drasil/Code/Imperative/Descriptions.hs
@@ -12,15 +12,16 @@ import Language.Drasil.Code.Imperative.DrasilState (DrasilState(..), inMod)
 import Language.Drasil.Chunk.Code (CodeIdea(codeName))
 import Language.Drasil.CodeSpec (CodeSpec(..), CodeSystInfo(..), 
   InputModule(..), Structure(..))
+import Language.Drasil.Mod (Description)
 
 import Data.Map (member)
 import qualified Data.Map as Map (filter, lookup, elems)
 import Control.Monad.Reader (Reader, ask)
 
-modDesc :: Reader DrasilState [String] -> Reader DrasilState String
+modDesc :: Reader DrasilState [Description] -> Reader DrasilState Description
 modDesc = fmap ((++) "Provides " . stringList)
 
-inputParametersDesc :: Reader DrasilState [String]
+inputParametersDesc :: Reader DrasilState [Description]
 inputParametersDesc = do
   g <- ask
   ifDesc <- inputFormatDesc
@@ -34,7 +35,7 @@ inputParametersDesc = do
       inDesc Unbundled = [""]
   return $ ipDesc im
 
-inputConstructorDesc :: Reader DrasilState String
+inputConstructorDesc :: Reader DrasilState Description
 inputConstructorDesc = do
   g <- ask
   pAndS <- physAndSfwrCons
@@ -50,21 +51,21 @@ inputConstructorDesc = do
     idDesc ("derived_values" `elem` dl),
     icDesc ("input_constraints" `elem` dl)]
 
-inputFormatDesc :: Reader DrasilState String
+inputFormatDesc :: Reader DrasilState Description
 inputFormatDesc = do
   g <- ask
   let ifDesc Nothing = ""
       ifDesc _ = "the function for reading inputs"
   return $ ifDesc $ Map.lookup "get_input" (eMap $ codeSpec g)
 
-derivedValuesDesc :: Reader DrasilState String
+derivedValuesDesc :: Reader DrasilState Description
 derivedValuesDesc = do
   g <- ask
   let dvDesc Nothing = ""
       dvDesc _ = "the function for calculating derived values"
   return $ dvDesc $ Map.lookup "derived_values" (eMap $ codeSpec g)
 
-inputConstraintsDesc :: Reader DrasilState String
+inputConstraintsDesc :: Reader DrasilState Description
 inputConstraintsDesc = do
   g <- ask
   pAndS <- physAndSfwrCons
@@ -73,7 +74,7 @@ inputConstraintsDesc = do
         " on the input"
   return $ icDesc $ Map.lookup "input_constraints" (eMap $ codeSpec g)
 
-constModDesc :: Reader DrasilState String
+constModDesc :: Reader DrasilState Description
 constModDesc = do
   g <- ask
   let cDesc [] = ""
@@ -81,14 +82,14 @@ constModDesc = do
   return $ cDesc $ filter (flip member (eMap $ codeSpec g) . codeName) 
     (constants $ csi $ codeSpec g)
 
-outputFormatDesc :: Reader DrasilState String
+outputFormatDesc :: Reader DrasilState Description
 outputFormatDesc = do
   g <- ask
   let ofDesc Nothing = ""
       ofDesc _ = "the function for writing outputs"
   return $ ofDesc $ Map.lookup "write_output" (eMap $ codeSpec g)
 
-inputClassDesc :: Reader DrasilState String
+inputClassDesc :: Reader DrasilState Description
 inputClassDesc = do
   g <- ask
   let cname = "InputParameters"
@@ -106,7 +107,7 @@ inputClassDesc = do
       cVs _ = "constant values"
   return $ inClassD $ inputs $ csi $ codeSpec g
 
-constClassDesc :: Reader DrasilState String
+constClassDesc :: Reader DrasilState Description
 constClassDesc = do
   g <- ask
   let ccDesc [] = ""
@@ -114,14 +115,14 @@ constClassDesc = do
   return $ ccDesc $ filter (flip member (eMap $ codeSpec g) . codeName) 
     (constants $ csi $ codeSpec g)
 
-inFmtFuncDesc :: Reader DrasilState String
+inFmtFuncDesc :: Reader DrasilState Description
 inFmtFuncDesc = do
   g <- ask
   let ifDesc False = ""
       ifDesc _ = "Reads input from a file with the given file name"
   return $ ifDesc $ "get_input" `elem` defList (codeSpec g)
 
-inConsFuncDesc :: Reader DrasilState String
+inConsFuncDesc :: Reader DrasilState Description
 inConsFuncDesc = do
   g <- ask
   pAndS <- physAndSfwrCons
@@ -129,7 +130,7 @@ inConsFuncDesc = do
       icDesc _ = "Verifies that input values satisfy the " ++ pAndS
   return $ icDesc $ "input_constraints" `elem` defList (codeSpec g)
 
-dvFuncDesc :: Reader DrasilState String
+dvFuncDesc :: Reader DrasilState Description
 dvFuncDesc = do
   g <- ask
   let dvDesc False = ""
@@ -137,17 +138,17 @@ dvFuncDesc = do
         " inputs"
   return $ dvDesc $ "derived_values" `elem` defList (codeSpec g)
 
-calcModDesc :: String
+calcModDesc :: Description
 calcModDesc = "Provides functions for calculating the outputs"
 
-woFuncDesc :: Reader DrasilState String
+woFuncDesc :: Reader DrasilState Description
 woFuncDesc = do
   g <- ask
   let woDesc False = ""
       woDesc _ = "Writes the output values to output.txt"
   return $ woDesc $ "write_output" `elem` defList (codeSpec g)
 
-physAndSfwrCons :: Reader DrasilState String
+physAndSfwrCons :: Reader DrasilState Description
 physAndSfwrCons = do
   g <- ask
   let cns = concat $ Map.elems (cMap $ csi $ codeSpec g)

--- a/code/drasil-code/Language/Drasil/Code/Imperative/FunctionCalls.hs
+++ b/code/drasil-code/Language/Drasil/Code/Imperative/FunctionCalls.hs
@@ -14,6 +14,7 @@ import Language.Drasil.Code.Imperative.DrasilState (DrasilState(..))
 import Language.Drasil.Chunk.Code (CodeIdea(codeName), quantvar)
 import Language.Drasil.Chunk.CodeDefinition (CodeDefinition)
 import Language.Drasil.CodeSpec (CodeSpec(..))
+import Language.Drasil.Mod (Name)
 
 import GOOL.Drasil (VSType, SValue, MSStatement, OOProg, TypeSym(..), 
   VariableValue(..), StatementSym(..), DeclStatement(..), convType)
@@ -57,7 +58,7 @@ getOutputCall = do
   val <- getFuncCall "write_output" void getOutputParams
   return $ fmap valStmt val
 
-getFuncCall :: (OOProg r, HasUID c, HasSpace c, CodeIdea c) => String -> 
+getFuncCall :: (OOProg r, HasUID c, HasSpace c, CodeIdea c) => Name -> 
   VSType r -> Reader DrasilState [c] -> Reader DrasilState (Maybe (SValue r))
 getFuncCall n t funcPs = do
   mm <- getCall n
@@ -69,7 +70,7 @@ getFuncCall n t funcPs = do
         return $ Just val
   getFuncCall' mm
 
-getInOutCall :: (OOProg r, HasSpace c, CodeIdea c, Eq c) => String -> 
+getInOutCall :: (OOProg r, HasSpace c, CodeIdea c, Eq c) => Name -> 
   Reader DrasilState [c] -> Reader DrasilState [c] ->
   Reader DrasilState (Maybe (MSStatement r))
 getInOutCall n inFunc outFunc = do
@@ -91,7 +92,7 @@ getInOutCall n inFunc outFunc = do
 -- If the function is not in module export map but is in class definition map, 
 -- that means it is a private function, so return Nothing unless it is in the 
 -- current class
-getCall :: String -> Reader DrasilState (Maybe String)
+getCall :: Name -> Reader DrasilState (Maybe Name)
 getCall n = do
   g <- ask
   let currc = currentClass g

--- a/code/drasil-code/Language/Drasil/Code/Imperative/GenerateGOOL.hs
+++ b/code/drasil-code/Language/Drasil/Code/Imperative/GenerateGOOL.hs
@@ -57,7 +57,7 @@ mkClass :: (OOProg r) => ClassType -> Label -> Maybe Label -> String ->
   Reader DrasilState (SClass r)
 mkClass s n l desc vs mths = do
   g <- ask
-  ms <- mths
+  ms <- withReader (\ds -> ds {currentClass = n}) mths
   let getFunc Primary = buildClass
       getFunc Auxiliary = extraClass
       f = getFunc s

--- a/code/drasil-code/Language/Drasil/Code/Imperative/GenerateGOOL.hs
+++ b/code/drasil-code/Language/Drasil/Code/Imperative/GenerateGOOL.hs
@@ -52,10 +52,10 @@ genDoxConfig n s = do
 
 data ClassType = Primary | Auxiliary
 
-mkClass :: (OOProg r) => ClassType -> String -> Label -> Maybe Label -> 
+mkClass :: (OOProg r) => ClassType -> Label -> Maybe Label -> String -> 
   [CSStateVar r] -> Reader DrasilState [SMethod r] ->
   Reader DrasilState (SClass r)
-mkClass s desc n l vs mths = do
+mkClass s n l desc vs mths = do
   g <- ask
   ms <- mths
   let getFunc Primary = buildClass
@@ -65,12 +65,12 @@ mkClass s desc n l vs mths = do
     then docClass desc (f n l vs ms) 
     else f n l vs ms
 
-primaryClass :: (OOProg r) => String -> Label -> Maybe Label -> 
+primaryClass :: (OOProg r) => Label -> Maybe Label -> String -> 
   [CSStateVar r] -> Reader DrasilState [SMethod r] -> 
   Reader DrasilState (SClass r)
 primaryClass = mkClass Primary
 
-auxClass :: (OOProg r) => String -> Label -> Maybe Label -> 
+auxClass :: (OOProg r) => Label -> Maybe Label -> String -> 
   [CSStateVar r] -> Reader DrasilState [SMethod r] -> 
   Reader DrasilState (SClass r)
 auxClass = mkClass Auxiliary

--- a/code/drasil-code/Language/Drasil/Code/Imperative/Import.hs
+++ b/code/drasil-code/Language/Drasil/Code/Imperative/Import.hs
@@ -327,13 +327,13 @@ genModFuncs (Mod _ _ _ _ fs) = map genFunc fs
 genModClasses :: (OOProg r) => Mod -> [Reader DrasilState (SClass r)]
 genModClasses (Mod _ _ _ cs _) = map (genClass auxClass) cs
 
-genClass :: (OOProg r) => (String -> Label -> Maybe Label -> [CSStateVar r] 
+genClass :: (OOProg r) => (Label -> Maybe Label -> String -> [CSStateVar r] 
   -> Reader DrasilState [SMethod r] -> Reader DrasilState (SClass r)) -> 
   M.Class -> Reader DrasilState (SClass r)
 genClass f (M.ClassDef n i desc svs ms) = do
   svrs <- mapM (\v -> fmap (pubDVar . var (codeName v) . convType) (codeType v))
     svs
-  f n desc i svrs (mapM genFunc ms) 
+  f n i desc svrs (mapM genFunc ms) 
 
 genFunc :: (OOProg r) => Func -> Reader DrasilState (SMethod r)
 genFunc (FDef (FuncDef n desc parms o rd s)) = do

--- a/code/drasil-code/Language/Drasil/Code/Imperative/Import.hs
+++ b/code/drasil-code/Language/Drasil/Code/Imperative/Import.hs
@@ -24,7 +24,7 @@ import Language.Drasil.Code.DataDesc (DataItem, LinePattern(Repeat, Straight),
   Data(Line, Lines, JunkData, Singleton), DataDesc, isLine, isLines, getInputs,
   getPatternInputs)
 import Language.Drasil.Mod (Func(..), FuncData(..), FuncDef(..), FuncStmt(..), 
-  Mod(..), Name, fstdecl)
+  Mod(..), Name, Description, fstdecl)
 import qualified Language.Drasil.Mod as M (Class(..))
 
 import GOOL.Drasil (Label, SFile, MSBody, MSBlock, VSType, SVariable, SValue, 
@@ -53,8 +53,7 @@ codeType c = do
   g <- ask
   return $ spaceMatches g (c ^. typ)
 
-value :: (OOProg r) => UID -> String -> VSType r -> 
-  Reader DrasilState (SValue r)
+value :: (OOProg r) => UID -> Name -> VSType r -> Reader DrasilState (SValue r)
 value u s t = do
   g <- ask
   let cs = codeSpec g
@@ -66,8 +65,7 @@ value u s t = do
     (convExpr . codeEquat) (Map.lookup u mm >>= maybeInline (conStruct g))) 
     (return . conceptToGOOL) (Map.lookup u cm)
 
-variable :: (OOProg r) => String -> VSType r -> 
-  Reader DrasilState (SVariable r)
+variable :: (OOProg r) => Name -> VSType r -> Reader DrasilState (SVariable r)
 variable s t = do
   g <- ask
   let cs = csi $ codeSpec g
@@ -126,33 +124,36 @@ mkVar v = do
   variable (codeName v) (convType t)
 
 publicFunc :: (OOProg r, HasSpace c, CodeIdea c) => Label -> VSType r -> 
-  String -> [c] -> Maybe String -> [MSBlock r] -> Reader DrasilState (SMethod r)
+  Description -> [c] -> Maybe Description -> [MSBlock r] ->
+  Reader DrasilState (SMethod r)
 publicFunc n t = genMethod (function n public static t) n
 
 privateMethod :: (OOProg r, HasSpace c, CodeIdea c) => Label -> VSType r -> 
-  String -> [c] -> Maybe String -> [MSBlock r] -> Reader DrasilState (SMethod r)
+  Description -> [c] -> Maybe Description -> [MSBlock r] -> 
+  Reader DrasilState (SMethod r)
 privateMethod n t = genMethod (method n private dynamic t) n
 
 publicInOutFunc :: (OOProg r, HasSpace c, CodeIdea c, Eq c) => Label -> 
-  String -> [c] -> [c] -> [MSBlock r] -> Reader DrasilState (SMethod r)
+  Description -> [c] -> [c] -> [MSBlock r] -> Reader DrasilState (SMethod r)
 publicInOutFunc n = genInOutFunc (inOutFunc n) (docInOutFunc n) public static n
 
 privateInOutMethod :: (OOProg r, HasSpace c, CodeIdea c, Eq c) => Label -> 
-  String -> [c] -> [c] -> [MSBlock r] -> Reader DrasilState (SMethod r)
+  Description -> [c] -> [c] -> [MSBlock r] -> Reader DrasilState (SMethod r)
 privateInOutMethod n = genInOutFunc (inOutMethod n) (docInOutMethod n) 
   private dynamic n
 
-genConstructor :: (OOProg r, HasSpace c, CodeIdea c) => Label -> String -> 
+genConstructor :: (OOProg r, HasSpace c, CodeIdea c) => Label -> Description -> 
   [c] -> [MSBlock r] -> Reader DrasilState (SMethod r)
 genConstructor n desc p = genMethod nonInitConstructor n desc p Nothing
 
-genInitConstructor :: (OOProg r, HasSpace c, CodeIdea c) => Label -> String 
-  -> [c] -> Initializers r -> [MSBlock r] -> Reader DrasilState (SMethod r)
+genInitConstructor :: (OOProg r, HasSpace c, CodeIdea c) => Label -> 
+  Description -> [c] -> Initializers r -> [MSBlock r] -> 
+  Reader DrasilState (SMethod r)
 genInitConstructor n desc p is = genMethod (`constructor` is) n desc p 
   Nothing
 
 genMethod :: (OOProg r, HasSpace c, CodeIdea c) => ([MSParameter r] -> 
-  MSBody r -> SMethod r) -> Label -> String -> [c] -> Maybe String -> 
+  MSBody r -> SMethod r) -> Label -> Description -> [c] -> Maybe Description -> 
   [MSBlock r] -> Reader DrasilState (SMethod r)
 genMethod f n desc p r b = do
   g <- ask
@@ -169,7 +170,7 @@ genInOutFunc :: (OOProg r, HasSpace c, CodeIdea c, Eq c) => (r (Scope r) ->
     MSBody r -> SMethod r) -> 
   (r (Scope r) -> r (Permanence r) -> String -> [(String, SVariable r)] -> 
     [(String, SVariable r)] -> [(String, SVariable r)] -> MSBody r -> SMethod r)
-  -> r (Scope r) -> r (Permanence r) -> Label -> String -> [c] -> [c] -> 
+  -> r (Scope r) -> r (Permanence r) -> Label -> Description -> [c] -> [c] -> 
   [MSBlock r] -> Reader DrasilState (SMethod r)
 genInOutFunc f docf s pr n desc ins' outs' b = do
   g <- ask
@@ -246,9 +247,9 @@ convExpr (RealI c ri)  = do
   g <- ask
   convExpr $ renderRealInt (lookupC g c) ri
 
-convCall :: (OOProg r) => UID -> [Expr] -> [(UID, Expr)] -> (String -> 
-  String -> VSType r -> [SValue r] -> NamedArgs r -> 
-  Reader DrasilState (SValue r)) -> Reader DrasilState (SValue r)
+convCall :: (OOProg r) => UID -> [Expr] -> [(UID, Expr)] -> (Name -> Name -> 
+  VSType r -> [SValue r] -> NamedArgs r -> Reader DrasilState (SValue r)) -> 
+  Reader DrasilState (SValue r)
 convCall c x ns f = do
   g <- ask
   let info = sysinfodb $ csi $ codeSpec g
@@ -327,7 +328,7 @@ genModFuncs (Mod _ _ _ _ fs) = map genFunc fs
 genModClasses :: (OOProg r) => Mod -> [Reader DrasilState (SClass r)]
 genModClasses (Mod _ _ _ cs _) = map (genClass auxClass) cs
 
-genClass :: (OOProg r) => (Label -> Maybe Label -> String -> [CSStateVar r] 
+genClass :: (OOProg r) => (Name -> Maybe Name -> Description -> [CSStateVar r] 
   -> Reader DrasilState [SMethod r] -> Reader DrasilState (SClass r)) -> 
   M.Class -> Reader DrasilState (SClass r)
 genClass f (M.ClassDef n i desc svs ms) = do
@@ -447,7 +448,7 @@ convStmt (FAppend a b) = do
   b' <- convExpr b
   return $ valStmt $ listAppend a' b'
 
-genDataFunc :: (OOProg r) => Name -> String -> DataDesc -> 
+genDataFunc :: (OOProg r) => Name -> Description -> DataDesc -> 
   Reader DrasilState (SMethod r)
 genDataFunc nameTitle desc ddef = do
   let parms = getInputs ddef

--- a/code/drasil-code/Language/Drasil/Code/Imperative/Modules.hs
+++ b/code/drasil-code/Language/Drasil/Code/Imperative/Modules.hs
@@ -197,7 +197,7 @@ genInputClass scp = withReader (\s -> s {currentClass = cname}) $ do
             getFunc Auxiliary = auxClass
             f = getFunc scp
         icDesc <- inputClassDesc
-        c <- f icDesc cname Nothing (inputVars ++ constVars) (methods $ inMod g)
+        c <- f cname Nothing icDesc (inputVars ++ constVars) (methods $ inMod g)
         return $ Just c
   genClass (filt ins) (includedConstants (conStruct g) cs)
   where cname = "InputParameters"
@@ -398,7 +398,7 @@ genConstClass scp = withReader (\s -> s {currentClass = cname}) $ do
             getFunc Auxiliary = auxClass
             f = getFunc scp
         cDesc <- constClassDesc
-        cls <- f cDesc cname Nothing constVars (return [])
+        cls <- f cname Nothing cDesc constVars (return [])
         return $ Just cls
   genClass $ filter (flip member (Map.filter (cname ==) (clsMap $ codeSpec g)) 
     . codeName) cs

--- a/code/drasil-code/Language/Drasil/Code/Imperative/Modules.hs
+++ b/code/drasil-code/Language/Drasil/Code/Imperative/Modules.hs
@@ -50,7 +50,7 @@ import qualified Data.Map as Map (lookup, filter)
 import Data.Maybe (maybeToList, catMaybes)
 import Control.Applicative ((<$>))
 import Control.Monad (liftM2, zipWithM)
-import Control.Monad.Reader (Reader, ask, asks, withReader)
+import Control.Monad.Reader (Reader, ask, asks)
 import Control.Lens ((^.))
 import Text.PrettyPrint.HughesPJ (render)
 
@@ -169,7 +169,7 @@ constVarFunc Const n = constVar n public
 
 genInputClass :: (OOProg r) => ClassType -> 
   Reader DrasilState (Maybe (SClass r))
-genInputClass scp = withReader (\s -> s {currentClass = cname}) $ do
+genInputClass scp = do
   g <- ask
   let ins = inputs $ csi $ codeSpec g
       cs = constants $ csi $ codeSpec g
@@ -384,7 +384,7 @@ genConstMod = do
 
 genConstClass :: (OOProg r) => ClassType ->
   Reader DrasilState (Maybe (SClass r))
-genConstClass scp = withReader (\s -> s {currentClass = cname}) $ do
+genConstClass scp = do
   g <- ask
   let cs = constants $ csi $ codeSpec g
       genClass :: (OOProg r) => [CodeDefinition] -> Reader DrasilState 


### PR DESCRIPTION
This PR improves the generator in 3 minor ways:
- Re-orders parameters to some functions to be more consistent with other functions
- Set the `currentClass` field of the `DrasilState` in the generic `mkClass` function, instead of having to set it in each generator for a specific class
- Use `Name`, `Description`, and `Import` type synonyms for `String` more consistently.

#2072 should be merged first. cc266cb is the first new commit.
