### PR TITLE
CommonPseudoOO

### DIFF
--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer/CSharpRenderer.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer/CSharpRenderer.hs
@@ -63,7 +63,7 @@ import qualified GOOL.Drasil.LanguageRenderer.LanguagePolymorphic as G (
   method, getMethod, setMethod, constructor, function, docFunc, buildClass, 
   implementingClass, docClass, commentedClass, modFromData, fileDoc, docMod, 
   fileFromData)
-import qualified GOOL.Drasil.LanguageRenderer.SemiPolymorphic as SP (
+import qualified GOOL.Drasil.LanguageRenderer.CommonPseudoOO as CP (
   bindingError, extVar, classVar, objVarSelf, iterVar, extFuncAppMixedArgs, 
   indexOf, listAddFunc, iterBeginError, iterEndError, listDecDef', 
   discardFileLine, checkState, destructorError, stateVarDef, constVar, 
@@ -155,7 +155,7 @@ instance PermanenceSym CSharpCode where
 
 instance PermElim CSharpCode where
   perm = unCSC
-  binding = error $ SP.bindingError csName
+  binding = error $ CP.bindingError csName
 
 instance BodySym CSharpCode where
   type Body CSharpCode = Doc
@@ -181,17 +181,17 @@ instance BlockElim CSharpCode where
 
 instance TypeSym CSharpCode where
   type Type CSharpCode = TypeData
-  bool = addSystemImport SP.bool
+  bool = addSystemImport CP.bool
   int = G.int
   float = C.float
   double = C.double
   char = C.char
-  string = SP.string
+  string = CP.string
   infile = csInfileType
   outfile = csOutfileType
   listType t = modify (addLangImportVS "System.Collections.Generic") >> 
     C.listType "List" t
-  arrayType = SP.arrayType
+  arrayType = CP.arrayType
   listInnerType = G.listInnerType
   obj = G.obj
   funcType = G.funcType
@@ -288,14 +288,14 @@ instance VariableSym CSharpCode where
   var = G.var
   staticVar = G.staticVar
   const = var
-  extVar = SP.extVar
+  extVar = CP.extVar
   self = C.self
-  classVar = SP.classVar R.classVar
+  classVar = CP.classVar R.classVar
   extClassVar = classVar
   objVar = on2StateValues csObjVar
-  objVarSelf = SP.objVarSelf
+  objVarSelf = CP.objVarSelf
   arrayElem i = G.arrayElem (litInt i)
-  iterVar = SP.iterVar
+  iterVar = CP.iterVar
 
 instance VariableElim CSharpCode where
   variableName = varName . unCSC
@@ -320,11 +320,11 @@ instance Literal CSharpCode where
   litFloat = C.litFloat
   litInt = G.litInt
   litString = G.litString
-  litArray = SP.litList arrayType
-  litList = SP.litList listType
+  litArray = CP.litList arrayType
+  litList = CP.litList listType
 
 instance MathConstant CSharpCode where
-  pi = SP.pi
+  pi = CP.pi
 
 instance VariableValue CSharpCode where
   valueOf v = join $ on2StateValues (\dvs vr -> maybe (G.valueOf v) (listAccess 
@@ -380,7 +380,7 @@ instance ValueExpression CSharpCode where
 
   funcAppMixedArgs = G.funcAppMixedArgs
   selfFuncAppMixedArgs = G.selfFuncAppMixedArgs dot self
-  extFuncAppMixedArgs = SP.extFuncAppMixedArgs
+  extFuncAppMixedArgs = CP.extFuncAppMixedArgs
   libFuncAppMixedArgs = C.libFuncAppMixedArgs
   newObjMixedArgs = G.newObjMixedArgs "new "
   extNewObjMixedArgs _ = newObjMixedArgs
@@ -388,7 +388,7 @@ instance ValueExpression CSharpCode where
 
   lambda = G.lambda csLambda
 
-  notNull = SP.notNull
+  notNull = CP.notNull
 
 instance RenderValue CSharpCode where
   inputFunc = addSystemImport $ mkStateVal string (text "Console.ReadLine()")
@@ -427,7 +427,7 @@ instance List CSharpCode where
   listAppend = G.listAppend
   listAccess = G.listAccess
   listSet = G.listSet
-  indexOf = SP.indexOf "IndexOf"
+  indexOf = CP.indexOf "IndexOf"
   
 instance InternalList CSharpCode where
   listSlice' = M.listSlice
@@ -442,14 +442,14 @@ instance InternalGetSet CSharpCode where
 
 instance InternalListFunc CSharpCode where
   listSizeFunc = funcFromData (R.func (text "Count")) int
-  listAddFunc _ = SP.listAddFunc "Insert"
+  listAddFunc _ = CP.listAddFunc "Insert"
   listAppendFunc = G.listAppendFunc "Add"
-  listAccessFunc = SP.listAccessFunc
-  listSetFunc = SP.listSetFunc R.listSetFunc
+  listAccessFunc = CP.listAccessFunc
+  listSetFunc = CP.listSetFunc R.listSetFunc
 
 instance InternalIterator CSharpCode where
-  iterBeginFunc _ = error $ SP.iterBeginError csName
-  iterEndFunc _ = error $ SP.iterEndError csName
+  iterBeginFunc _ = error $ CP.iterBeginError csName
+  iterEndFunc _ = error $ CP.iterEndError csName
     
 instance RenderFunction CSharpCode where
   funcFromData d = onStateValue (onCodeValue (`fd` d))
@@ -462,7 +462,7 @@ instance InternalAssignStmt CSharpCode where
   multiAssign _ _ = error $ C.multiAssignError csName
 
 instance InternalIOStmt CSharpCode where
-  printSt _ _ = SP.printSt
+  printSt _ _ = CP.printSt
   
 instance InternalControlStmt CSharpCode where
   multiReturn _ = error $ C.multiReturnError csName 
@@ -497,13 +497,13 @@ instance DeclStatement CSharpCode where
   varDecDef = C.varDecDef
   listDec n v = zoom lensMStoVS v >>= (\v' -> C.listDec (R.listDec v') 
     (litInt n) v)
-  listDecDef = SP.listDecDef'
-  arrayDec n = SP.arrayDec (litInt n)
-  arrayDecDef = SP.arrayDecDef
+  listDecDef = CP.listDecDef'
+  arrayDec n = CP.arrayDec (litInt n)
+  arrayDecDef = CP.arrayDecDef
   objDecDef = varDecDef
   objDecNew = G.objDecNew
   extObjDecNew = C.extObjDecNew
-  constDecDef = SP.constDecDef
+  constDecDef = CP.constDecDef
   funcDecDef = csFuncDecDef
 
 instance IOStatement CSharpCode where
@@ -522,13 +522,13 @@ instance IOStatement CSharpCode where
   getFileInput f v = v &= csInput (onStateValue variableType v) (csFileInput f)
   discardFileInput f = valStmt $ csFileInput f
 
-  openFileR = SP.openFileR csOpenFileR
-  openFileW = SP.openFileW csOpenFileWorA
-  openFileA = SP.openFileA csOpenFileWorA
+  openFileR = CP.openFileR csOpenFileR
+  openFileW = CP.openFileW csOpenFileWorA
+  openFileA = CP.openFileA csOpenFileWorA
   closeFile = G.closeFile "Close"
 
   getFileInputLine = getFileInput
-  discardFileLine = SP.discardFileLine "ReadLine"
+  discardFileLine = CP.discardFileLine "ReadLine"
   getFileInputAll f v = while ((f $. funcFromData (text ".EndOfStream") bool) 
     ?!) (oneLiner $ valStmt $ listAppend (valueOf v) (csFileInput f))
 
@@ -562,13 +562,13 @@ instance ControlStatement CSharpCode where
 
   for = C.for bodyStart bodyEnd
   forRange = C.forRange
-  forEach = SP.forEach bodyStart bodyEnd (text "foreach") inLabel 
+  forEach = CP.forEach bodyStart bodyEnd (text "foreach") inLabel 
   while = C.while bodyStart bodyEnd
 
   tryCatch = G.tryCatch csTryCatch
 
 instance StatePattern CSharpCode where 
-  checkState = SP.checkState
+  checkState = CP.checkState
 
 instance ObserverPattern CSharpCode where
   notifyObservers = C.notifyObservers
@@ -612,20 +612,20 @@ instance MethodSym CSharpCode where
   setMethod = G.setMethod
   constructor ps is b = getClassName >>= (\n -> G.constructor n ps is b)
 
-  docMain = SP.docMain
+  docMain = CP.docMain
  
   function = G.function
-  mainFunction = SP.mainFunction string "Main"
+  mainFunction = CP.mainFunction string "Main"
 
   docFunc = G.docFunc
 
   inOutMethod n = csInOut (method n)
 
-  docInOutMethod n = SP.docInOutFunc (inOutMethod n)
+  docInOutMethod n = CP.docInOutFunc (inOutMethod n)
 
   inOutFunc n = csInOut (function n)
 
-  docInOutFunc n = SP.docInOutFunc (inOutFunc n)
+  docInOutFunc n = CP.docInOutFunc (inOutFunc n)
 
 instance RenderMethod CSharpCode where
   intMethod m n s p t ps b = modify (if m then setCurrMain else id) >> 
@@ -635,16 +635,16 @@ instance RenderMethod CSharpCode where
   commentedFunc cmt m = on2StateValues (on2CodeValues updateMthd) m 
     (onStateValue (onCodeValue R.commentedItem) cmt)
     
-  destructor _ = error $ SP.destructorError csName
+  destructor _ = error $ CP.destructorError csName
   
 instance MethodElim CSharpCode where
   method = mthdDoc . unCSC
 
 instance StateVarSym CSharpCode where
   type StateVar CSharpCode = Doc
-  stateVar = SP.stateVar
-  stateVarDef _ = SP.stateVarDef
-  constVar _ = SP.constVar empty
+  stateVar = CP.stateVar
+  stateVarDef _ = CP.stateVarDef
+  constVar _ = CP.constVar empty
   
 instance StateVarElim CSharpCode where
   stateVar = unCSC
@@ -658,7 +658,7 @@ instance ClassSym CSharpCode where
   docClass = G.docClass
 
 instance RenderClass CSharpCode where
-  intClass = SP.intClass R.class'
+  intClass = CP.intClass R.class'
 
   inherit n = toCode $ maybe empty ((colon <+>) . text) n
   implements is = toCode $ colon <+> text (intercalate ", " is)
@@ -670,7 +670,7 @@ instance ClassElim CSharpCode where
 
 instance ModuleSym CSharpCode where
   type Module CSharpCode = ModData
-  buildModule n = SP.buildModule' n langImport
+  buildModule n = CP.buildModule' n langImport
   
 instance RenderMod CSharpCode where
   modFromData n = G.modFromData n (toCode . md n)

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer/CommonPseudoOO.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer/CommonPseudoOO.hs
@@ -1,16 +1,13 @@
 -- | Implementations defined here are valid in some, but not all, language renderers
 module GOOL.Drasil.LanguageRenderer.CommonPseudoOO (
   bindingError, extVar, classVar, objVarSelf, iterVar, extFuncAppMixedArgs, 
-  indexOf, listAddFunc, iterBeginError, iterEndError, listDecDef', 
+  indexOf, listAddFunc, iterBeginError, iterEndError, listDecDef, 
   discardFileLine, checkState, destructorError, stateVarDef, constVar, 
   intClass, objVar, listSetFunc, listAccessFunc, buildModule, bool, arrayType, 
   pi, notNull, printSt, arrayDec, arrayDecDef, openFileR, openFileW, openFileA, 
   forEach, docMain, mainFunction, stateVar, buildModule', litArray, call', 
   listSizeFunc, listAccessFunc', funcDecDef, discardFileInput, string, 
-  constDecDef, docInOutFunc, notOp, sqrtOp', absOp', expOp', sinOp', cosOp', 
-  tanOp', asinOp', acosOp', atanOp', addmathImport, extNewObjMixedArgs,
-  extraClass, litList, sqrtOp, absOp, expOp, sinOp, cosOp, tanOp, asinOp, 
-  acosOp, atanOp, powerOp, listDecDef
+  constDecDef, docInOutFunc
 ) where
 
 import Utils.Drasil (indent)
@@ -18,7 +15,7 @@ import Utils.Drasil (indent)
 import GOOL.Drasil.CodeType (CodeType(..))
 import GOOL.Drasil.ClassInterface (Label, Library, MSBody, VSType, SVariable, 
   SValue, VSFunction, MSStatement, SMethod, CSStateVar, SClass, FSModule, 
-  MixedCall, MixedCtorCall, PermanenceSym(..), 
+  MixedCall, PermanenceSym(..), 
   TypeSym(infile, outfile, listInnerType, iterator), 
   TypeElim(getType, getTypeString), VariableElim(variableName, variableType), 
   ValueSym(Value, valueType), Comparison(..), objMethodCallNoParams, (&=), 
@@ -32,29 +29,25 @@ import qualified GOOL.Drasil.ClassInterface as S (
   ClassSym(buildClass))
 import GOOL.Drasil.RendererClasses (RenderSym, ImportSym(..),  RenderType(..),
   RenderVariable(varFromData), InternalVarElim(variableBind), 
-  RenderFunction(funcFromData), RenderScope(..), MethodTypeSym(mType),
-  RenderMethod(commentedFunc), ParentSpec, RenderClass(inherit),
-  BlockCommentSym(..))
+  RenderFunction(funcFromData), MethodTypeSym(mType),
+  RenderMethod(commentedFunc), ParentSpec, BlockCommentSym(..))
 import qualified GOOL.Drasil.RendererClasses as S (RenderValue(call), 
-  RenderStatement(stmt), RenderMethod(intFunc), RenderClass(intClass), 
-  RenderMod(modFromData))
+  RenderStatement(stmt), RenderMethod(intFunc), RenderMod(modFromData))
 import qualified GOOL.Drasil.RendererClasses as RC (ImportElim(..), 
   PermElim(..), BodyElim(..), InternalTypeElim(..), InternalVarElim(variable), 
   ValueElim(value), StatementElim(statement), ScopeElim(..), MethodElim(..), 
   StateVarElim(..), ClassElim(..))
-import GOOL.Drasil.AST (ScopeTag(..))
 import GOOL.Drasil.Helpers (vibcat, toCode, toState, onCodeValue, onStateValue, 
-  on2StateValues, onStateList, on1StateValue1List)
+  on2StateValues, onStateList)
 import GOOL.Drasil.LanguageRenderer (new, functionDox, valueList, intValue)
 import qualified GOOL.Drasil.LanguageRenderer as R (module', print, stateVar, 
   stateVarList, constDecDef, extVar, objVar, listAccessFunc)
 import GOOL.Drasil.LanguageRenderer.Constructors (mkStmt, mkStmtNoEnd, 
-  mkStateVal, mkVal, mkStateVar, mkVar, VSOp, unOpPrec, powerPrec)
+  mkStateVal, mkStateVar, mkVar)
 import GOOL.Drasil.LanguageRenderer.LanguagePolymorphic (classVarCheckStatic,
   call, docFuncRepr)
-import GOOL.Drasil.State (FS, CS, VS, lensFStoCS, lensFStoMS, lensCStoMS, 
-  lensMStoVS, addLangImportVS, getLangImports, getLibImports, getModuleImports, 
-  setClassName)
+import GOOL.Drasil.State (FS, CS, lensFStoCS, lensFStoMS, lensCStoMS, 
+  lensMStoVS, getLangImports, getLibImports, getModuleImports, setClassName)
 
 import Prelude hiding (print,pi,(<>))
 import Data.List (sort)
@@ -102,8 +95,8 @@ iterEndError :: String -> String
 iterEndError l = "Attempt to use iterEndFunc in " ++ l ++ ", but " ++ l ++ 
   " has no iterators"
   
-listDecDef' :: (RenderSym r) => SVariable r -> [SValue r] -> MSStatement r
-listDecDef' v vals = zoom lensMStoVS v >>= (\vr -> S.varDecDef (return vr) 
+listDecDef :: (RenderSym r) => SVariable r -> [SValue r] -> MSStatement r
+listDecDef v vals = zoom lensMStoVS v >>= (\vr -> S.varDecDef (return vr) 
   (S.litList (listInnerType $ return $ variableType vr) vals))
   
 discardFileLine :: (RenderSym r) => Label -> SValue r -> MSStatement r
@@ -296,92 +289,3 @@ docInOutFunc f s p desc is [] [both] b = docFuncRepr desc (map fst $ both : is)
   [fst both] (f s p (map snd is) [] [snd both] b)
 docInOutFunc f s p desc is os bs b = docFuncRepr desc (map fst $ bs ++ is ++ os)
   [] (f s p (map snd is) (map snd os) (map snd bs) b)
-
--- Python --
-
-notOp :: (Monad r) => VSOp r
-notOp = unOpPrec "not"
-
-sqrtOp' :: (Monad r) => VSOp r
-sqrtOp' = addmathImport $ unOpPrec "math.sqrt"
-
-absOp' :: (Monad r) => VSOp r
-absOp' = addmathImport $ unOpPrec "math.fabs"
-
-expOp' :: (Monad r) => VSOp r
-expOp' = addmathImport $ unOpPrec "math.exp"
-
-sinOp' :: (Monad r) => VSOp r
-sinOp' = addmathImport $ unOpPrec "math.sin"
-
-cosOp' :: (Monad r) => VSOp r
-cosOp' = addmathImport $ unOpPrec "math.cos"
-
-tanOp' :: (Monad r) => VSOp r
-tanOp' = addmathImport $ unOpPrec "math.tan"
-
-asinOp' :: (Monad r) => VSOp r
-asinOp' = addmathImport $ unOpPrec "math.asin"
-
-acosOp' :: (Monad r) => VSOp r
-acosOp' = addmathImport $ unOpPrec "math.acos"
-
-atanOp' :: (Monad r) => VSOp r
-atanOp' = addmathImport $ unOpPrec "math.atan"
-
-addmathImport :: VS a -> VS a
-addmathImport = (>>) $ modify (addLangImportVS "math")
-
-extNewObjMixedArgs :: (RenderSym r) => Library -> MixedCtorCall r
-extNewObjMixedArgs l tp vs ns = tp >>= (\t -> S.call (Just l) Nothing 
-  (getTypeString t) (return t) vs ns)
-
--- Java -- 
-
-extraClass :: (RenderSym r) => Label -> Maybe Label -> [CSStateVar r] -> 
-  [SMethod r] -> SClass r
-extraClass n = S.intClass n (scopeFromData Priv empty) . inherit
-
--- C# --
-
-litList :: (RenderSym r) => (VSType r -> VSType r) -> VSType r -> [SValue r] -> 
-  SValue r
-litList f t = on1StateValue1List (\lt es -> mkVal lt (new <+> RC.type' lt <+> 
-  braces (valueList es))) (f t)
-
--- C++ -- 
-
-sqrtOp :: (Monad r) => VSOp r
-sqrtOp = unOpPrec "sqrt"
-
-absOp :: (Monad r) => VSOp r
-absOp = unOpPrec "fabs"
-
-expOp :: (Monad r) => VSOp r
-expOp = unOpPrec "exp"
-
-sinOp :: (Monad r) => VSOp r
-sinOp = unOpPrec "sin"
-
-cosOp :: (Monad r) => VSOp r
-cosOp = unOpPrec "cos"
-
-tanOp :: (Monad r) => VSOp r
-tanOp = unOpPrec "tan"
-
-asinOp :: (Monad r) => VSOp r
-asinOp = unOpPrec "asin"
-
-acosOp :: (Monad r) => VSOp r
-acosOp = unOpPrec "acos"
-
-atanOp :: (Monad r) => VSOp r
-atanOp = unOpPrec "atan"
-
-powerOp :: (Monad r) => VSOp r
-powerOp = powerPrec "pow"
-
-listDecDef :: (RenderSym r) => ([r (Value r)] -> Doc) -> SVariable r -> 
-  [SValue r] -> MSStatement r
-listDecDef f v vls = on1StateValue1List (\vd vs -> mkStmt (RC.statement vd <> 
-  f vs)) (S.varDec v) (map (zoom lensMStoVS) vls)

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer/CommonPseudoOO.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer/CommonPseudoOO.hs
@@ -1,5 +1,5 @@
 -- | Implementations defined here are valid in some, but not all, language renderers
-module GOOL.Drasil.LanguageRenderer.SemiPolymorphic (
+module GOOL.Drasil.LanguageRenderer.CommonPseudoOO (
   bindingError, extVar, classVar, objVarSelf, iterVar, extFuncAppMixedArgs, 
   indexOf, listAddFunc, iterBeginError, iterEndError, listDecDef', 
   discardFileLine, checkState, destructorError, stateVarDef, constVar, 

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer/CppRenderer.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer/CppRenderer.hs
@@ -66,7 +66,7 @@ import qualified GOOL.Drasil.LanguageRenderer.LanguagePolymorphic as G (
   implementingClass, docClass, commentedClass, modFromData, fileDoc, docMod, 
   fileFromData)
 import GOOL.Drasil.LanguageRenderer.LanguagePolymorphic (classVarCheckStatic)
-import qualified GOOL.Drasil.LanguageRenderer.SemiPolymorphic as SP (objVar, 
+import qualified GOOL.Drasil.LanguageRenderer.CommonPseudoOO as CP (objVar, 
   listSetFunc, buildModule, litArray, call', listSizeFunc, listAccessFunc', 
   funcDecDef, discardFileInput, string, constDecDef, docInOutFunc, sqrtOp, 
   absOp, expOp, sinOp, cosOp, tanOp, asinOp, acosOp, atanOp, powerOp, 
@@ -1138,7 +1138,7 @@ instance TypeSym CppSrcCode where
   float = C.float
   double = C.double
   char = C.char
-  string = modify (addUsing "string" . addLangImportVS "string") >> SP.string
+  string = modify (addUsing "string" . addLangImportVS "string") >> CP.string
   infile = modify (addUsing "ifstream") >> cppInfileType
   outfile = modify (addUsing "ofstream") >> cppOutfileType
   listType t = modify (addUsing vec . addLangImportVS vec) >> C.listType vec t
@@ -1186,17 +1186,17 @@ instance UnaryOpSym CppSrcCode where
   type UnaryOp CppSrcCode = OpData
   notOp = C.notOp
   negateOp = G.negateOp
-  sqrtOp = addMathHImport SP.sqrtOp
-  absOp = addMathHImport SP.absOp
+  sqrtOp = addMathHImport CP.sqrtOp
+  absOp = addMathHImport CP.absOp
   logOp = addMathHImport $ unOpPrec "log10"
   lnOp = addMathHImport $ unOpPrec "log"
-  expOp = addMathHImport SP.expOp
-  sinOp = addMathHImport SP.sinOp
-  cosOp = addMathHImport SP.cosOp
-  tanOp = addMathHImport SP.tanOp
-  asinOp = addMathHImport SP.asinOp
-  acosOp = addMathHImport SP.acosOp
-  atanOp = addMathHImport SP.atanOp
+  expOp = addMathHImport CP.expOp
+  sinOp = addMathHImport CP.sinOp
+  cosOp = addMathHImport CP.cosOp
+  tanOp = addMathHImport CP.tanOp
+  asinOp = addMathHImport CP.asinOp
+  acosOp = addMathHImport CP.acosOp
+  atanOp = addMathHImport CP.atanOp
   floorOp = addMathHImport $ unOpPrec "floor"
   ceilOp = addMathHImport $ unOpPrec "ceil"
 
@@ -1212,7 +1212,7 @@ instance BinaryOpSym CppSrcCode where
   minusOp = G.minusOp
   multOp = G.multOp
   divideOp = G.divideOp
-  powerOp = addMathHImport SP.powerOp
+  powerOp = addMathHImport CP.powerOp
   moduloOp = G.moduloOp
   andOp = C.andOp
   orOp = C.orOp
@@ -1237,7 +1237,7 @@ instance VariableSym CppSrcCode where
     addModuleImportVS) (Map.lookup (getTypeString t) cm) $ 
     classVar (toState t) v) c getClassMap
   objVar o v = join $ on3StateValues (\ovs ob vr -> if (variableName ob ++ "." 
-    ++ variableName vr) `elem` ovs then toState vr else SP.objVar (toState ob) 
+    ++ variableName vr) `elem` ovs then toState vr else CP.objVar (toState ob) 
     (toState vr)) getODEOthVars o v
   objVarSelf = onStateValue (\v -> mkVar ("this->"++variableName v) 
     (variableType v) (text "this->" <> RC.variable v))
@@ -1267,7 +1267,7 @@ instance Literal CppSrcCode where
   litFloat = C.litFloat
   litInt = G.litInt
   litString = G.litString
-  litArray = SP.litArray
+  litArray = CP.litArray
   litList _ _ = error $ "List literals not supported in " ++ cppName
 
 instance MathConstant CppSrcCode where
@@ -1347,7 +1347,7 @@ instance RenderValue CppSrcCode where
 
   cast = cppCast
 
-  call = SP.call' cppName
+  call = CP.call' cppName
 
   valFromData p t d = on2CodeValues (vd p) t (toCode d)
   
@@ -1388,12 +1388,12 @@ instance InternalGetSet CppSrcCode where
   setFunc = G.setFunc
 
 instance InternalListFunc CppSrcCode where
-  listSizeFunc = SP.listSizeFunc
+  listSizeFunc = CP.listSizeFunc
   listAddFunc l i v = func "insert" (listType $ onStateValue valueType v) 
     [iterBegin l #+ i, v]
   listAppendFunc = G.listAppendFunc "push_back"
-  listAccessFunc = SP.listAccessFunc' "at"
-  listSetFunc = SP.listSetFunc cppListSetDoc
+  listAccessFunc = CP.listAccessFunc' "at"
+  listSetFunc = CP.listSetFunc cppListSetDoc
 
 instance InternalIterator CppSrcCode where
   iterBeginFunc t = func "begin" (iterator t) []
@@ -1443,7 +1443,7 @@ instance DeclStatement CppSrcCode where
   varDec = C.varDec static dynamic
   varDecDef = C.varDecDef 
   listDec n = C.listDec cppListDecDoc (litInt n)
-  listDecDef = SP.listDecDef cppListDecDefDoc
+  listDecDef = CP.listDecDef cppListDecDefDoc
   arrayDec n vr = zoom lensMStoVS $ on2StateValues (\sz v -> mkStmt $ RC.type' 
     (variableType v) <+> RC.variable v <> brackets (RC.value sz)) 
     (litInt n :: SValue CppSrcCode) vr
@@ -1453,8 +1453,8 @@ instance DeclStatement CppSrcCode where
   objDecDef = varDecDef
   objDecNew = G.objDecNew
   extObjDecNew = C.extObjDecNew
-  constDecDef = SP.constDecDef
-  funcDecDef = SP.funcDecDef
+  constDecDef = CP.constDecDef
+  funcDecDef = CP.funcDecDef
 
 instance IOStatement CppSrcCode where
   print = G.print False Nothing printFunc
@@ -1472,7 +1472,7 @@ instance IOStatement CppSrcCode where
     (cppDiscardInput "\\n")
   getFileInput f v = cppInput v f
   discardFileInput f = addAlgorithmImport $ addLimitsImport $ 
-    SP.discardFileInput (cppDiscardInput " ") f
+    CP.discardFileInput (cppDiscardInput " ") f
 
   openFileR f' v' = zoom lensMStoVS $ on2StateValues (\f v -> mkStmt $ 
     cppOpenFile "std::fstream::in" f v) f' v'
@@ -1605,11 +1605,11 @@ instance MethodSym CppSrcCode where
 
   inOutMethod n = cppsInOut (method n)
 
-  docInOutMethod n = SP.docInOutFunc (inOutMethod n)
+  docInOutMethod n = CP.docInOutFunc (inOutMethod n)
 
   inOutFunc n = cppsInOut (function n)
 
-  docInOutFunc n = SP.docInOutFunc (inOutFunc n)
+  docInOutFunc n = CP.docInOutFunc (inOutFunc n)
 
 instance RenderMethod CppSrcCode where
   intMethod m n s _ t ps b = modify (setScope (snd $ unCPPSC s) . if m then 
@@ -1671,7 +1671,7 @@ instance ClassElim CppSrcCode where
 
 instance ModuleSym CppSrcCode where
   type Module CppSrcCode = ModData
-  buildModule n is ms cs = SP.buildModule n ((\ds lis libis mis us mn -> vibcat [
+  buildModule n is ms cs = CP.buildModule n ((\ds lis libis mis us mn -> vibcat [
     if mn && length ms + length cs == 1 then empty else RC.import' $ mi n,
     vcat (map ((text "#define" <+>) . text) ds),
     vcat (map (RC.import' . li) lis),
@@ -1782,7 +1782,7 @@ instance TypeSym CppHdrCode where
   double = C.double
   char = C.char
   string = modify (addHeaderUsing "string" . addHeaderLangImport "string") >> 
-    SP.string
+    CP.string
   infile = modify (addHeaderUsing "ifstream") >> cppInfileType
   outfile = modify (addHeaderUsing "ofstream") >> cppOutfileType
   listType t = modify (addHeaderUsing vec . addHeaderLangImport vec) >> 
@@ -1863,7 +1863,7 @@ instance VariableSym CppHdrCode where
   classVar _ _ = mkStateVar "" void empty
   extClassVar _ _ = mkStateVar "" void empty
   objVar o v = join $ on3StateValues (\ovs ob vr -> if (variableName ob ++ "." 
-    ++ variableName vr) `elem` ovs then toState vr else SP.objVar (toState ob) 
+    ++ variableName vr) `elem` ovs then toState vr else CP.objVar (toState ob) 
     (toState vr)) getODEOthVars o v
   objVarSelf _ = mkStateVar "" void empty
   arrayElem _ _ = mkStateVar "" void empty
@@ -1892,7 +1892,7 @@ instance Literal CppHdrCode where
   litFloat = C.litFloat
   litInt = G.litInt
   litString = G.litString
-  litArray = SP.litArray
+  litArray = CP.litArray
   litList _ _ = error $ "List literals not supported in " ++ cppName
 
 instance MathConstant CppHdrCode where
@@ -2070,7 +2070,7 @@ instance DeclStatement CppHdrCode where
   objDecDef _ _ = emptyStmt
   objDecNew _ _ = emptyStmt
   extObjDecNew _ _ _ = emptyStmt
-  constDecDef = SP.constDecDef
+  constDecDef = CP.constDecDef
   funcDecDef _ _ _ = emptyStmt
 
 instance IOStatement CppHdrCode where
@@ -2189,11 +2189,11 @@ instance MethodSym CppHdrCode where
 
   inOutMethod n = cpphInOut (method n)
 
-  docInOutMethod n = SP.docInOutFunc (inOutMethod n)
+  docInOutMethod n = CP.docInOutFunc (inOutMethod n)
 
   inOutFunc n = cpphInOut (function n)
 
-  docInOutFunc n = SP.docInOutFunc (inOutFunc n)
+  docInOutFunc n = CP.docInOutFunc (inOutFunc n)
 
 instance RenderMethod CppHdrCode where
   intMethod _ n s _ t ps _ = modify (setScope (snd $ unCPPHC s)) >> 
@@ -2249,7 +2249,7 @@ instance ClassElim CppHdrCode where
 
 instance ModuleSym CppHdrCode where
   type Module CppHdrCode = ModData
-  buildModule n is = SP.buildModule n ((\ds lis libis mis us -> vibcat [
+  buildModule n is = CP.buildModule n ((\ds lis libis mis us -> vibcat [
     vcat (map ((text "#define" <+>) . text) ds),
     vcat (map (RC.import' . li) lis),
     vcat (map (RC.import' . mi) (sort (is ++ libis) ++ mis)),

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer/JavaRenderer.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer/JavaRenderer.hs
@@ -66,7 +66,7 @@ import qualified GOOL.Drasil.LanguageRenderer.LanguagePolymorphic as G (
   implementingClass, docClass, commentedClass, modFromData, fileDoc, docMod, 
   fileFromData)
 import GOOL.Drasil.LanguageRenderer.LanguagePolymorphic (docFuncRepr)
-import qualified GOOL.Drasil.LanguageRenderer.SemiPolymorphic as SP (  
+import qualified GOOL.Drasil.LanguageRenderer.CommonPseudoOO as CP (  
   bindingError, extVar, classVar, objVarSelf, iterVar, extFuncAppMixedArgs, 
   indexOf, listAddFunc, iterBeginError, iterEndError, listDecDef', 
   discardFileLine, checkState, destructorError, stateVarDef, constVar, 
@@ -166,7 +166,7 @@ instance PermanenceSym JavaCode where
 
 instance PermElim JavaCode where
   perm = unJC
-  binding = error $ SP.bindingError jName
+  binding = error $ CP.bindingError jName
 
 instance BodySym JavaCode where
   type Body JavaCode = Doc
@@ -192,7 +192,7 @@ instance BlockElim JavaCode where
 
 instance TypeSym JavaCode where
   type Type JavaCode = TypeData
-  bool = SP.bool
+  bool = CP.bool
   int = G.int
   float = C.float
   double = C.double
@@ -201,7 +201,7 @@ instance TypeSym JavaCode where
   infile = jInfileType
   outfile = jOutfileType
   listType = jListType "ArrayList"
-  arrayType = SP.arrayType
+  arrayType = CP.arrayType
   listInnerType = G.listInnerType
   obj = G.obj
   funcType = G.funcType
@@ -293,16 +293,16 @@ instance VariableSym JavaCode where
   var = G.var
   staticVar = G.staticVar
   const = var
-  extVar = SP.extVar
+  extVar = CP.extVar
   self = C.self
-  classVar = SP.classVar R.classVar
+  classVar = CP.classVar R.classVar
   extClassVar = classVar
   objVar o v = join $ on3StateValues (\ovs ob vr -> if (variableName ob ++ "." 
-    ++ variableName vr) `elem` ovs then toState vr else SP.objVar (toState ob) 
+    ++ variableName vr) `elem` ovs then toState vr else CP.objVar (toState ob) 
     (toState vr)) getODEOthVars o v
-  objVarSelf = SP.objVarSelf
+  objVarSelf = CP.objVarSelf
   arrayElem i = G.arrayElem (litInt i)
-  iterVar = SP.iterVar
+  iterVar = CP.iterVar
 
 instance VariableElim JavaCode where
   variableName = varName . unJC
@@ -327,13 +327,13 @@ instance Literal JavaCode where
   litFloat = C.litFloat
   litInt = G.litInt
   litString = G.litString
-  litArray = SP.litArray
+  litArray = CP.litArray
   litList t es = zoom lensVStoMS (modify (if null es then id else addLangImport 
     "java.util.Arrays")) >> newObj (listType t) [funcApp "Arrays.asList" 
     (listType t) es | not (null es)]
 
 instance MathConstant JavaCode where
-  pi = SP.pi
+  pi = CP.pi
 
 instance VariableValue JavaCode where
   valueOf v = G.valueOf $ join $ on2StateValues (\dvs vr -> maybe v (\i -> 
@@ -398,7 +398,7 @@ instance ValueExpression JavaCode where
   extFuncAppMixedArgs l n t vs ns = do
     mem <- getMethodExcMap
     modify (maybe id addExceptions (Map.lookup (l ++ "." ++ n) mem))
-    SP.extFuncAppMixedArgs l n t vs ns
+    CP.extFuncAppMixedArgs l n t vs ns
   libFuncAppMixedArgs = C.libFuncAppMixedArgs
   newObjMixedArgs ot vs ns = addConstructorCallExcsCurrMod ot (\t -> 
     G.newObjMixedArgs "new " t vs ns)
@@ -412,7 +412,7 @@ instance ValueExpression JavaCode where
 
   lambda = G.lambda jLambda
 
-  notNull = SP.notNull
+  notNull = CP.notNull
 
 instance RenderValue JavaCode where
   inputFunc = modify (addLangImportVS "java.util.Scanner") >> mkStateVal 
@@ -426,7 +426,7 @@ instance RenderValue JavaCode where
   
   cast = jCast
 
-  call = SP.call' jName
+  call = CP.call' jName
   
   valFromData p t d = on2CodeValues (vd p) t (toCode d)
 
@@ -457,7 +457,7 @@ instance List JavaCode where
   listAppend = G.listAppend
   listAccess = G.listAccess
   listSet = G.listSet
-  indexOf = SP.indexOf "indexOf"
+  indexOf = CP.indexOf "indexOf"
 
 instance InternalList JavaCode where
   listSlice' = M.listSlice
@@ -471,16 +471,16 @@ instance InternalGetSet JavaCode where
   setFunc = G.setFunc
 
 instance InternalListFunc JavaCode where
-  listSizeFunc = SP.listSizeFunc
-  listAddFunc _ = SP.listAddFunc "add"
+  listSizeFunc = CP.listSizeFunc
+  listAddFunc _ = CP.listAddFunc "add"
   listAppendFunc = G.listAppendFunc "add"
-  listAccessFunc = SP.listAccessFunc' "get"
+  listAccessFunc = CP.listAccessFunc' "get"
   listSetFunc v i toVal = func "set" (onStateValue valueType v) [intValue i, 
     toVal]
 
 instance InternalIterator JavaCode where
-  iterBeginFunc _ = error $ SP.iterBeginError jName
-  iterEndFunc _ = error $ SP.iterEndError jName
+  iterBeginFunc _ = error $ CP.iterBeginError jName
+  iterEndFunc _ = error $ CP.iterEndError jName
 
 instance RenderFunction JavaCode where
   funcFromData d = onStateValue (onCodeValue (`fd` d))
@@ -493,7 +493,7 @@ instance InternalAssignStmt JavaCode where
   multiAssign _ _ = error $ C.multiAssignError jName
 
 instance InternalIOStmt JavaCode where
-  printSt _ _ = SP.printSt
+  printSt _ _ = CP.printSt
 
 instance InternalControlStmt JavaCode where
   multiReturn _ = error $ C.multiReturnError jName
@@ -528,15 +528,15 @@ instance DeclStatement JavaCode where
   varDecDef = C.varDecDef
   listDec n v = zoom lensMStoVS v >>= (\v' -> C.listDec (R.listDec v') 
     (litInt n) v)
-  listDecDef = SP.listDecDef'
-  arrayDec n = SP.arrayDec (litInt n)
-  arrayDecDef = SP.arrayDecDef
+  listDecDef = CP.listDecDef'
+  arrayDec n = CP.arrayDec (litInt n)
+  arrayDecDef = CP.arrayDecDef
   objDecDef = varDecDef
   objDecNew = G.objDecNew
   extObjDecNew = C.extObjDecNew
   constDecDef vr' vl' = zoom lensMStoVS $ on2StateValues (\vr vl -> mkStmt $ 
     jConstDecDef vr vl) vr' vl'
-  funcDecDef = SP.funcDecDef
+  funcDecDef = CP.funcDecDef
 
 instance IOStatement JavaCode where
   print = jOut False Nothing printFunc
@@ -552,15 +552,15 @@ instance IOStatement JavaCode where
   getInput v = v &= jInput (onStateValue variableType v) inputFunc
   discardInput = C.discardInput jDiscardInput
   getFileInput f v = v &= jInput (onStateValue variableType v) f
-  discardFileInput = SP.discardFileInput jDiscardInput
+  discardFileInput = CP.discardFileInput jDiscardInput
 
-  openFileR = SP.openFileR jOpenFileR
-  openFileW = SP.openFileW jOpenFileWorA
-  openFileA = SP.openFileA jOpenFileWorA
+  openFileR = CP.openFileR jOpenFileR
+  openFileW = CP.openFileW jOpenFileWorA
+  openFileA = CP.openFileA jOpenFileWorA
   closeFile = G.closeFile "close"
 
   getFileInputLine f v = v &= f $. func "nextLine" string []
-  discardFileLine = SP.discardFileLine "nextLine"
+  discardFileLine = CP.discardFileLine "nextLine"
   getFileInputAll f v = while (f $. func "hasNextLine" bool [])
     (oneLiner $ valStmt $ listAppend (valueOf v) (f $. func "nextLine" string []))
 
@@ -596,13 +596,13 @@ instance ControlStatement JavaCode where
 
   for = C.for bodyStart bodyEnd
   forRange = C.forRange 
-  forEach = SP.forEach bodyStart bodyEnd forLabel colon
+  forEach = CP.forEach bodyStart bodyEnd forLabel colon
   while = C.while bodyStart bodyEnd
 
   tryCatch = G.tryCatch jTryCatch
   
 instance StatePattern JavaCode where 
-  checkState = SP.checkState
+  checkState = CP.checkState
 
 instance ObserverPattern JavaCode where
   notifyObservers = C.notifyObservers
@@ -646,10 +646,10 @@ instance MethodSym JavaCode where
   setMethod = G.setMethod
   constructor ps is b = getClassName >>= (\n -> G.constructor n ps is b)
 
-  docMain = SP.docMain
+  docMain = CP.docMain
 
   function = G.function
-  mainFunction = SP.mainFunction string "main"
+  mainFunction = CP.mainFunction string "main"
 
   docFunc = G.docFunc
 
@@ -678,16 +678,16 @@ instance RenderMethod JavaCode where
   commentedFunc cmt m = on2StateValues (on2CodeValues updateMthd) m 
     (onStateValue (onCodeValue R.commentedItem) cmt)
     
-  destructor _ = error $ SP.destructorError jName
+  destructor _ = error $ CP.destructorError jName
   
 instance MethodElim JavaCode where
   method = mthdDoc . unJC
 
 instance StateVarSym JavaCode where
   type StateVar JavaCode = Doc
-  stateVar = SP.stateVar
-  stateVarDef _ = SP.stateVarDef
-  constVar _ = SP.constVar (RC.perm (static :: JavaCode (Permanence JavaCode)))
+  stateVar = CP.stateVar
+  stateVarDef _ = CP.stateVarDef
+  constVar _ = CP.constVar (RC.perm (static :: JavaCode (Permanence JavaCode)))
   
 instance StateVarElim JavaCode where
   stateVar = unJC
@@ -695,13 +695,13 @@ instance StateVarElim JavaCode where
 instance ClassSym JavaCode where
   type Class JavaCode = Doc
   buildClass = G.buildClass
-  extraClass = SP.extraClass
+  extraClass = CP.extraClass
   implementingClass = G.implementingClass
 
   docClass = G.docClass
 
 instance RenderClass JavaCode where
-  intClass = SP.intClass R.class'
+  intClass = CP.intClass R.class'
   
   inherit n = toCode $ maybe empty ((text "extends" <+>) . text) n
   implements is = toCode $ text "implements" <+> text (intercalate ", " is)
@@ -713,7 +713,7 @@ instance ClassElim JavaCode where
 
 instance ModuleSym JavaCode where
   type Module JavaCode = ModData
-  buildModule n = SP.buildModule' n langImport
+  buildModule n = CP.buildModule' n langImport
   
 instance RenderMod JavaCode where
   modFromData n = G.modFromData n (toCode . md n)

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer/PythonRenderer.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer/PythonRenderer.hs
@@ -62,7 +62,7 @@ import qualified GOOL.Drasil.LanguageRenderer.LanguagePolymorphic as G (
   implementingClass, docClass, commentedClass, modFromData, fileDoc, docMod, 
   fileFromData)
 import GOOL.Drasil.LanguageRenderer.LanguagePolymorphic (docFuncRepr)
-import qualified GOOL.Drasil.LanguageRenderer.SemiPolymorphic as SP (
+import qualified GOOL.Drasil.LanguageRenderer.CommonPseudoOO as CP (
   bindingError, extVar, classVar, objVarSelf, iterVar, extFuncAppMixedArgs, 
   indexOf, listAddFunc,  iterBeginError, iterEndError, listDecDef', 
   discardFileLine, checkState, destructorError, stateVarDef, constVar, 
@@ -150,7 +150,7 @@ instance PermanenceSym PythonCode where
 
 instance PermElim PythonCode where
   perm = unPC
-  binding = error $ SP.bindingError pyName
+  binding = error $ CP.bindingError pyName
 
 instance BodySym PythonCode where
   type Body PythonCode = Doc
@@ -235,21 +235,21 @@ instance ControlBlock PythonCode where
 
 instance UnaryOpSym PythonCode where
   type UnaryOp PythonCode = OpData
-  notOp = SP.notOp
+  notOp = CP.notOp
   negateOp = G.negateOp
-  sqrtOp = SP.sqrtOp'
-  absOp = SP.absOp'
+  sqrtOp = CP.sqrtOp'
+  absOp = CP.absOp'
   logOp = pyLogOp
   lnOp = pyLnOp
-  expOp = SP.expOp'
-  sinOp = SP.sinOp'
-  cosOp = SP.cosOp'
-  tanOp = SP.tanOp'
-  asinOp = SP.asinOp'
-  acosOp = SP.acosOp'
-  atanOp = SP.atanOp'
-  floorOp = SP.addmathImport $ unOpPrec "math.floor"
-  ceilOp = SP.addmathImport $ unOpPrec "math.ceil"
+  expOp = CP.expOp'
+  sinOp = CP.sinOp'
+  cosOp = CP.cosOp'
+  tanOp = CP.tanOp'
+  asinOp = CP.asinOp'
+  acosOp = CP.acosOp'
+  atanOp = CP.atanOp'
+  floorOp = CP.addmathImport $ unOpPrec "math.floor"
+  ceilOp = CP.addmathImport $ unOpPrec "math.ceil"
 
 instance BinaryOpSym PythonCode where
   type BinaryOp PythonCode = OpData
@@ -279,16 +279,16 @@ instance VariableSym PythonCode where
   var = G.var
   staticVar = G.staticVar
   const = var
-  extVar l n t = modify (addModuleImportVS l) >> SP.extVar l n t
+  extVar l n t = modify (addModuleImportVS l) >> CP.extVar l n t
   self = zoom lensVStoMS getClassName >>= (\l -> mkStateVar "self" (obj l) (text "self"))
-  classVar = SP.classVar R.classVar
+  classVar = CP.classVar R.classVar
   extClassVar c v = join $ on2StateValues (\t cm -> maybe id ((>>) . modify . 
     addModuleImportVS) (Map.lookup (getTypeString t) cm) $ 
-    SP.classVar pyClassVar (toState t) v) c getClassMap
-  objVar = SP.objVar
-  objVarSelf = SP.objVarSelf
+    CP.classVar pyClassVar (toState t) v) c getClassMap
+  objVar = CP.objVar
+  objVarSelf = CP.objVarSelf
   arrayElem i = G.arrayElem (litInt i)
-  iterVar = SP.iterVar
+  iterVar = CP.iterVar
 
 instance VariableElim PythonCode where
   variableName = varName . unPC
@@ -318,7 +318,7 @@ instance Literal PythonCode where
   litList = litArray
 
 instance MathConstant PythonCode where
-  pi = SP.addmathImport $ mkStateVal double (text "math.pi")
+  pi = CP.addmathImport $ mkStateVal double (text "math.pi")
 
 instance VariableValue PythonCode where
   valueOf = G.valueOf
@@ -376,14 +376,14 @@ instance ValueExpression PythonCode where
   funcAppMixedArgs = G.funcAppMixedArgs
   selfFuncAppMixedArgs = G.selfFuncAppMixedArgs dot self
   extFuncAppMixedArgs l n t ps ns = modify (addModuleImportVS l) >> 
-    SP.extFuncAppMixedArgs l n t ps ns
+    CP.extFuncAppMixedArgs l n t ps ns
   libFuncAppMixedArgs l n t ps ns = modify (addLibImportVS l) >> 
-    SP.extFuncAppMixedArgs l n t ps ns
+    CP.extFuncAppMixedArgs l n t ps ns
   newObjMixedArgs = G.newObjMixedArgs ""
   extNewObjMixedArgs l tp ps ns = modify (addModuleImportVS l) >> 
-    SP.extNewObjMixedArgs l tp ps ns
+    CP.extNewObjMixedArgs l tp ps ns
   libNewObjMixedArgs l tp ps ns = modify (addLibImportVS l) >> 
-    SP.extNewObjMixedArgs l tp ps ns
+    CP.extNewObjMixedArgs l tp ps ns
 
   lambda = G.lambda pyLambda
 
@@ -425,7 +425,7 @@ instance List PythonCode where
   listAppend = G.listAppend
   listAccess = G.listAccess
   listSet = G.listSet
-  indexOf = SP.indexOf "index"
+  indexOf = CP.indexOf "index"
 
 instance InternalList PythonCode where
   listSlice' b e s vnew vold = onStateValue toCode $ zoom lensMStoVS $ 
@@ -442,14 +442,14 @@ instance InternalGetSet PythonCode where
 
 instance InternalListFunc PythonCode where
   listSizeFunc = funcFromData (text "len") int
-  listAddFunc _ = SP.listAddFunc "insert"
+  listAddFunc _ = CP.listAddFunc "insert"
   listAppendFunc = G.listAppendFunc "append"
-  listAccessFunc = SP.listAccessFunc
-  listSetFunc = SP.listSetFunc R.listSetFunc
+  listAccessFunc = CP.listAccessFunc
+  listSetFunc = CP.listSetFunc R.listSetFunc
 
 instance InternalIterator PythonCode where
-  iterBeginFunc _ = error $ SP.iterBeginError pyName
-  iterEndFunc _ = error $ SP.iterEndError pyName
+  iterBeginFunc _ = error $ CP.iterBeginError pyName
+  iterEndFunc _ = error $ CP.iterEndError pyName
 
 instance RenderFunction PythonCode where
   funcFromData d = onStateValue (onCodeValue (`fd` d))
@@ -499,7 +499,7 @@ instance DeclStatement PythonCode where
   varDec _ = toState $ mkStmtNoEnd empty
   varDecDef = assign
   listDec _ v = zoom lensMStoVS $ onStateValue (mkStmtNoEnd . pyListDec) v
-  listDecDef = SP.listDecDef'
+  listDecDef = CP.listDecDef'
   arrayDec = listDec
   arrayDecDef = listDecDef
   objDecDef = varDecDef
@@ -533,7 +533,7 @@ instance IOStatement PythonCode where
   closeFile = G.closeFile "close"
 
   getFileInputLine = getFileInput
-  discardFileLine = SP.discardFileLine "readline"
+  discardFileLine = CP.discardFileLine "readline"
   getFileInputAll f v = v &= objMethodCall (listType string) f
     "readlines" []
   
@@ -577,7 +577,7 @@ instance ControlStatement PythonCode where
   tryCatch = G.tryCatch pyTryCatch
 
 instance StatePattern PythonCode where 
-  checkState = SP.checkState
+  checkState = CP.checkState
 
 instance ObserverPattern PythonCode where
   notifyObservers f t = forRange index initv (listSize obsList) 
@@ -654,7 +654,7 @@ instance RenderMethod PythonCode where
   commentedFunc cmt m = on2StateValues (on2CodeValues updateMthd) m 
     (onStateValue (onCodeValue R.commentedItem) cmt)
     
-  destructor _ = error $ SP.destructorError pyName
+  destructor _ = error $ CP.destructorError pyName
   
 instance MethodElim PythonCode where
   method = mthdDoc . unPC
@@ -662,8 +662,8 @@ instance MethodElim PythonCode where
 instance StateVarSym PythonCode where
   type StateVar PythonCode = Doc
   stateVar _ _ _ = toState (toCode empty)
-  stateVarDef _ = SP.stateVarDef
-  constVar _ = SP.constVar (RC.perm 
+  stateVarDef _ = CP.stateVarDef
+  constVar _ = CP.constVar (RC.perm 
     (static :: PythonCode (Permanence PythonCode)))
   
 instance StateVarElim PythonCode where
@@ -678,7 +678,7 @@ instance ClassSym PythonCode where
   docClass = G.docClass
 
 instance RenderClass PythonCode where
-  intClass = SP.intClass pyClass
+  intClass = CP.intClass pyClass
 
   inherit n = toCode $ maybe empty (parens . text) n
   implements is = toCode $ parens (text $ intercalate ", " is)
@@ -690,7 +690,7 @@ instance ClassElim PythonCode where
 
 instance ModuleSym PythonCode where
   type Module PythonCode = ModData
-  buildModule n is = SP.buildModule n (on3StateValues (\lis libis mis -> vibcat [
+  buildModule n is = CP.buildModule n (on3StateValues (\lis libis mis -> vibcat [
     vcat (map (RC.import' . 
       (langImport :: Label -> PythonCode (Import PythonCode))) lis),
     vcat (map (RC.import' . 
@@ -738,10 +738,10 @@ pyODEMethod Adams = [litString "vode",
   (mkStateVal string . (text "method=" <>) . RC.value)]
 
 pyLogOp :: (Monad r) => VSOp r
-pyLogOp = SP.addmathImport $ unOpPrec "math.log10"
+pyLogOp = CP.addmathImport $ unOpPrec "math.log10"
 
 pyLnOp :: (Monad r) => VSOp r
-pyLnOp = SP.addmathImport $ unOpPrec "math.log"
+pyLnOp = CP.addmathImport $ unOpPrec "math.log"
 
 pyClassVar :: Doc -> Doc -> Doc
 pyClassVar c v = c <> dot <> c <> dot <> v

--- a/code/drasil-gool/drasil-gool.cabal
+++ b/code/drasil-gool/drasil-gool.cabal
@@ -17,7 +17,7 @@ library
     , GOOL.Drasil.CodeInfo
     , GOOL.Drasil.LanguageRenderer.Constructors
     , GOOL.Drasil.LanguageRenderer.LanguagePolymorphic
-    , GOOL.Drasil.LanguageRenderer.SemiPolymorphic
+    , GOOL.Drasil.LanguageRenderer.CommonPseudoOO
     , GOOL.Drasil.LanguageRenderer.CLike
     , GOOL.Drasil.LanguageRenderer.Macros
     , GOOL.Drasil.LanguageRenderer
@@ -62,7 +62,7 @@ executable codegenTest
     , GOOL.Drasil.CodeInfo
     , GOOL.Drasil.LanguageRenderer.Constructors
     , GOOL.Drasil.LanguageRenderer.LanguagePolymorphic
-    , GOOL.Drasil.LanguageRenderer.SemiPolymorphic
+    , GOOL.Drasil.LanguageRenderer.CommonPseudoOO
     , GOOL.Drasil.LanguageRenderer.CLike
     , GOOL.Drasil.LanguageRenderer.Macros
     , GOOL.Drasil.LanguageRenderer


### PR DESCRIPTION
This PR addresses the comments on #2084, renaming `SemiPolymorphic` to `CommonPseudoOO` and moving any functions it contained that were only used in one language to the language renderer.