### PR TITLE
More do notation throughout GOOL

### DIFF
--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer/CLike.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer/CLike.hs
@@ -149,7 +149,7 @@ switch v cs bod = do
   vals <- mapM (zoom lensMStoVS . fst) cs
   bods <- mapM snd cs
   dflt <- bod
-  toState $ mkStmt $ R.switch brk val dflt (zip vals bods)
+  return $ mkStmt $ R.switch brk val dflt (zip vals bods)
 
 for :: (RenderSym r) => Doc -> Doc -> MSStatement r -> SValue r -> 
   MSStatement r -> MSBody r -> MSStatement r
@@ -158,7 +158,7 @@ for bStart bEnd sInit vGuard sUpdate b = do
   guard <- zoom lensMStoVS vGuard
   upd <- S.loopStmt sUpdate
   bod <- b
-  toState $ mkStmtNoEnd $ vcat [
+  return $ mkStmtNoEnd $ vcat [
     forLabel <+> parens (RC.statement initl <> semi <+> RC.value guard <> 
       semi <+> RC.statement upd) <+> bStart,
     indent $ RC.body bod,

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer/CSharpRenderer.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer/CSharpRenderer.hs
@@ -127,7 +127,9 @@ instance RenderSym CSharpCode
 
 instance FileSym CSharpCode where
   type File CSharpCode = FileData
-  fileDoc m = modify (setFileType Combined) >> G.fileDoc csExt top bottom m
+  fileDoc m = do
+    modify (setFileType Combined)
+    G.fileDoc csExt top bottom m
 
   docMod = G.docMod csExt
 
@@ -141,7 +143,7 @@ instance RenderFile CSharpCode where
 
 instance ImportSym CSharpCode where
   type Import CSharpCode = Doc
-  langImport n = toCode $ csImport n
+  langImport = toCode . csImport
   modImport = langImport
 
 instance ImportElim CSharpCode where
@@ -188,7 +190,8 @@ instance TypeSym CSharpCode where
   string = CP.string
   infile = csInfileType
   outfile = csOutfileType
-  listType t = modify (addLangImportVS "System.Collections.Generic") >> 
+  listType t = do
+    modify (addLangImportVS "System.Collections.Generic") 
     C.listType "List" t
   arrayType = CP.arrayType
   listInnerType = G.listInnerType
@@ -506,15 +509,15 @@ instance DeclStatement CSharpCode where
   funcDecDef = csFuncDecDef
 
 instance IOStatement CSharpCode where
-  print = G.print False Nothing printFunc
-  printLn = G.print True Nothing printLnFunc
-  printStr = G.print False Nothing printFunc . litString
-  printStrLn = G.print True Nothing printLnFunc . litString
+  print      = G.print False Nothing printFunc
+  printLn    = G.print True  Nothing printLnFunc
+  printStr   = G.print False Nothing printFunc   . litString
+  printStrLn = G.print True  Nothing printLnFunc . litString
 
-  printFile f = G.print False (Just f) (printFileFunc f)
-  printFileLn f = G.print True (Just f) (printFileLnFunc f)
-  printFileStr f = G.print False (Just f) (printFileFunc f) . litString
-  printFileStrLn f = G.print True (Just f) (printFileLnFunc f) . litString
+  printFile f      = G.print False (Just f) (printFileFunc f)
+  printFileLn f    = G.print True  (Just f) (printFileLnFunc f)
+  printFileStr f   = G.print False (Just f) (printFileFunc f)   . litString
+  printFileStrLn f = G.print True  (Just f) (printFileLnFunc f) . litString
 
   getInput v = v &= csInput (onStateValue variableType v) inputFunc
   discardInput = C.discardInput csDiscardInput
@@ -552,7 +555,9 @@ instance ControlStatement CSharpCode where
 
   returnStmt = G.returnStmt Semi
   
-  throw msg = modify (addLangImport "System") >> G.throw csThrowDoc Semi msg
+  throw msg = do
+    modify (addLangImport "System")
+    G.throw csThrowDoc Semi msg
 
   ifCond = G.ifCond bodyStart elseIfLabel bodyEnd
   switch = C.switch
@@ -627,9 +632,12 @@ instance MethodSym CSharpCode where
   docInOutFunc n = CP.docInOutFunc (inOutFunc n)
 
 instance RenderMethod CSharpCode where
-  intMethod m n s p t ps b = modify (if m then setCurrMain else id) >> 
-    on3StateValues (\tp pms bd -> toCode $ mthd $ R.method n s p tp pms bd) t 
-    (sequence ps) b
+  intMethod m n s p t ps b = do
+    modify (if m then setCurrMain else id)
+    tp <- t
+    pms <- sequence ps
+    bd <- b
+    toState $ toCode $ mthd $ R.method n s p tp pms bd
   intFunc = C.intFunc
   commentedFunc cmt m = on2StateValues (on2CodeValues updateMthd) m 
     (onStateValue (onCodeValue R.commentedItem) cmt)
@@ -727,10 +735,12 @@ csCast t v = join $ on2StateValues (\tp vl -> csCast' (getType tp) (getType $
 
 csFuncDecDef :: (RenderSym r) => SVariable r -> [SVariable r] -> SValue r -> 
   MSStatement r
-csFuncDecDef v ps r = on3StateValues (\vr pms b -> mkStmtNoEnd $ 
-  RC.type' (variableType vr) <+> text (variableName vr) <> parens 
-  (variableList pms) <+> bodyStart $$ indent (RC.body b) $$ bodyEnd) 
-  (zoom lensMStoVS v) (mapM (zoom lensMStoVS) ps) (oneLiner $ returnStmt r)
+csFuncDecDef v ps r = do
+  vr <- zoom lensMStoVS v
+  pms <- mapM (zoom lensMStoVS) ps
+  b <- oneLiner $ returnStmt r
+  toState $ mkStmtNoEnd $ RC.type' (variableType vr) <+> text (variableName vr) 
+    <> parens (variableList pms) <+> bodyStart $$ indent (RC.body b) $$ bodyEnd 
 
 csThrowDoc :: (RenderSym r) => r (Value r) -> Doc
 csThrowDoc errMsg = text "throw new" <+> text "Exception" <> 
@@ -753,8 +763,11 @@ csFileInput = onStateValue (\f -> mkVal (valueType f) (RC.value f <> dot <>
   text "ReadLine()"))
 
 csInput :: (RenderSym r) => VSType r -> SValue r -> SValue r
-csInput tp inF = tp >>= (\t -> csInputImport (getType t) $ onStateValue (\inFn 
-  -> mkVal t $ text (csInput' (getType t)) <> parens (RC.value inFn)) inF)
+csInput tp inF = do
+  t <- tp
+  inFn <- inF
+  let v = mkVal t $ text (csInput' (getType t)) <> parens (RC.value inFn)
+  csInputImport (getType t) (toState v)
   where csInput' Integer = "Int32.Parse"
         csInput' Float = "Single.Parse"
         csInput' Double = "Double.Parse"

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer/CSharpRenderer.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer/CSharpRenderer.hs
@@ -636,8 +636,7 @@ instance RenderMethod CSharpCode where
     modify (if m then setCurrMain else id)
     tp <- t
     pms <- sequence ps
-    bd <- b
-    return $ toCode $ mthd $ R.method n s p tp pms bd
+    toCode . mthd . R.method n s p tp pms <$> b
   intFunc = C.intFunc
   commentedFunc cmt m = on2StateValues (on2CodeValues updateMthd) m 
     (onStateValue (onCodeValue R.commentedItem) cmt)

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer/CSharpRenderer.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer/CSharpRenderer.hs
@@ -637,7 +637,7 @@ instance RenderMethod CSharpCode where
     tp <- t
     pms <- sequence ps
     bd <- b
-    toState $ toCode $ mthd $ R.method n s p tp pms bd
+    return $ toCode $ mthd $ R.method n s p tp pms bd
   intFunc = C.intFunc
   commentedFunc cmt m = on2StateValues (on2CodeValues updateMthd) m 
     (onStateValue (onCodeValue R.commentedItem) cmt)
@@ -739,7 +739,7 @@ csFuncDecDef v ps r = do
   vr <- zoom lensMStoVS v
   pms <- mapM (zoom lensMStoVS) ps
   b <- oneLiner $ returnStmt r
-  toState $ mkStmtNoEnd $ RC.type' (variableType vr) <+> text (variableName vr) 
+  return $ mkStmtNoEnd $ RC.type' (variableType vr) <+> text (variableName vr) 
     <> parens (variableList pms) <+> bodyStart $$ indent (RC.body b) $$ bodyEnd 
 
 csThrowDoc :: (RenderSym r) => r (Value r) -> Doc
@@ -767,7 +767,7 @@ csInput tp inF = do
   t <- tp
   inFn <- inF
   let v = mkVal t $ text (csInput' (getType t)) <> parens (RC.value inFn)
-  csInputImport (getType t) (toState v)
+  csInputImport (getType t) (return v)
   where csInput' Integer = "Int32.Parse"
         csInput' Float = "Single.Parse"
         csInput' Double = "Double.Parse"

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer/CommonPseudoOO.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer/CommonPseudoOO.hs
@@ -96,8 +96,10 @@ iterEndError l = "Attempt to use iterEndFunc in " ++ l ++ ", but " ++ l ++
   " has no iterators"
   
 listDecDef :: (RenderSym r) => SVariable r -> [SValue r] -> MSStatement r
-listDecDef v vals = zoom lensMStoVS v >>= (\vr -> S.varDecDef (return vr) 
-  (S.litList (listInnerType $ return $ variableType vr) vals))
+listDecDef v vals = do
+  vr <- zoom lensMStoVS v 
+  let lst = S.litList (listInnerType $ toState $ variableType vr) vals
+  S.varDecDef (toState vr) lst
   
 discardFileLine :: (RenderSym r) => Label -> SValue r -> MSStatement r
 discardFileLine n f = S.valStmt $ objMethodCallNoParams S.string f n 

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer/CppRenderer.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer/CppRenderer.hs
@@ -136,9 +136,9 @@ instance (Pair p) => ProgramSym (p CppSrcCode CppHdrCode) where
     m <-  mapM (zoom lensGStoFS) mods
     let fm = map pfst m
         sm = map (hdrToSrc . psnd) m
-    p1 <- prog n $ map toState sm ++ map toState fm
+    p1 <- prog n $ map return sm ++ map return fm
     modify revFiles
-    toState $ pair p1 (toCode emptyProg)
+    return $ pair p1 (toCode emptyProg)
 
 instance (Pair p) => RenderSym (p CppSrcCode CppHdrCode)
 
@@ -860,11 +860,11 @@ pair1 :: (Pair p) => (State r (CppSrcCode a) -> State s (CppSrcCode b)) ->
   State s (p CppSrcCode CppHdrCode a) -> State s (p CppSrcCode CppHdrCode b)
 pair1 srcf hdrf stv = do
   v <- stv
-  let fp = toState $ pfst v
-      sp = toState $ psnd v
+  let fp = return $ pfst v
+      sp = return $ psnd v
   p1 <- srcf fp
   p2 <- hdrf sp
-  toState $ pair p1 p2
+  return $ pair p1 p2
 
 pair2 :: (Pair p) => (State r (CppSrcCode a) -> State s (CppSrcCode b) -> 
   State t (CppSrcCode c)) -> (State r (CppHdrCode a) -> State s (CppHdrCode b) 
@@ -872,8 +872,8 @@ pair2 :: (Pair p) => (State r (CppSrcCode a) -> State s (CppSrcCode b) ->
   State t (p CppSrcCode CppHdrCode b) -> State t (p CppSrcCode CppHdrCode c)
 pair2 srcf hdrf stv1 stv2 = do
   v1 <- stv1
-  let fv1 = toState $ pfst v1
-      sv1 = toState $ psnd v1
+  let fv1 = return $ pfst v1
+      sv1 = return $ psnd v1
   pair1 (srcf fv1) (hdrf sv1) stv2
 
 pair3 :: (Pair p) => (State r (CppSrcCode a) -> State s (CppSrcCode b) -> 
@@ -883,8 +883,8 @@ pair3 :: (Pair p) => (State r (CppSrcCode a) -> State s (CppSrcCode b) ->
   -> State u (p CppSrcCode CppHdrCode c) -> State u (p CppSrcCode CppHdrCode d)
 pair3 srcf hdrf stv1 stv2 stv3 = do
   v1 <- stv1
-  let fv1 = toState $ pfst v1
-      sv1 = toState $ psnd v1
+  let fv1 = return $ pfst v1
+      sv1 = return $ psnd v1
   pair2 (srcf fv1) (hdrf sv1) stv2 stv3
 
 pair4 :: (Pair p) => (State r (CppSrcCode a) -> State s (CppSrcCode b) -> 
@@ -896,8 +896,8 @@ pair4 :: (Pair p) => (State r (CppSrcCode a) -> State s (CppSrcCode b) ->
   State v (p CppSrcCode CppHdrCode e)
 pair4 srcf hdrf stv1 stv2 stv3 stv4 = do
   v1 <- stv1
-  let fv1 = toState $ pfst v1
-      sv1 = toState $ psnd v1
+  let fv1 = return $ pfst v1
+      sv1 = return $ psnd v1
   pair3 (srcf fv1) (hdrf sv1) stv2 stv3 stv4
 
 pair5 :: (Pair p) => (State r (CppSrcCode a) -> State s (CppSrcCode b) -> 
@@ -910,8 +910,8 @@ pair5 :: (Pair p) => (State r (CppSrcCode a) -> State s (CppSrcCode b) ->
   State w (p CppSrcCode CppHdrCode f)
 pair5 srcf hdrf stv1 stv2 stv3 stv4 stv5 = do
   v1 <- stv1
-  let fv1 = toState $ pfst v1
-      sv1 = toState $ psnd v1
+  let fv1 = return $ pfst v1
+      sv1 = return $ psnd v1
   pair4 (srcf fv1) (hdrf sv1) stv2 stv3 stv4 stv5
   
 pair1List :: (Pair p) => ([State r (CppSrcCode a)] -> State s (CppSrcCode b)) 
@@ -919,11 +919,11 @@ pair1List :: (Pair p) => ([State r (CppSrcCode a)] -> State s (CppSrcCode b))
   [State s (p CppSrcCode CppHdrCode a)] -> State s (p CppSrcCode CppHdrCode b)
 pair1List srcf hdrf stv = do
   v <- sequence stv
-  let fl = map (toState . pfst) v
-      sl = map (toState . psnd) v
+  let fl = map (return . pfst) v
+      sl = map (return . psnd) v
   p1 <- srcf fl
   p2 <- hdrf sl
-  toState $ pair p1 p2
+  return $ pair p1 p2
 
 pair2Lists :: (Pair p) => ([State r (CppSrcCode a)] -> [State s (CppSrcCode b)] 
   -> State t (CppSrcCode c)) -> ([State r (CppHdrCode a)] -> 
@@ -932,8 +932,8 @@ pair2Lists :: (Pair p) => ([State r (CppSrcCode a)] -> [State s (CppSrcCode b)]
   -> State t (p CppSrcCode CppHdrCode c)
 pair2Lists srcf hdrf stv1 stv2 = do
   v1 <- sequence stv1
-  let fl1 = map (toState . pfst) v1
-      sl1 = map (toState . psnd) v1
+  let fl1 = map (return . pfst) v1
+      sl1 = map (return . psnd) v1
   pair1List (srcf fl1) (hdrf sl1) stv2
 
 pair3Lists :: (Pair p) => ([State r (CppSrcCode a)] -> [State s (CppSrcCode b)] 
@@ -945,8 +945,8 @@ pair3Lists :: (Pair p) => ([State r (CppSrcCode a)] -> [State s (CppSrcCode b)]
   State u (p CppSrcCode CppHdrCode d)
 pair3Lists srcf hdrf stv1 stv2 stv3 = do
   v1 <- sequence stv1
-  let fl1 = map (toState . pfst) v1
-      sl1 = map (toState . psnd) v1
+  let fl1 = map (return . pfst) v1
+      sl1 = map (return . psnd) v1
   pair2Lists (srcf fl1) (hdrf sl1) stv2 stv3 
 
 pair1List1Val :: (Pair p) => ([State r (CppSrcCode a)] -> State s (CppSrcCode b)
@@ -956,8 +956,8 @@ pair1List1Val :: (Pair p) => ([State r (CppSrcCode a)] -> State s (CppSrcCode b)
   -> State t (p CppSrcCode CppHdrCode c)
 pair1List1Val srcf hdrf stv1 stv2 = do
   v1 <- sequence stv1
-  let fl1 = map (toState . pfst) v1
-      sl1 = map (toState . psnd) v1
+  let fl1 = map (return . pfst) v1
+      sl1 = map (return . psnd) v1
   pair1 (srcf fl1) (hdrf sl1) stv2
 
 pair1Val1List :: (Pair p) => (State r (CppSrcCode a) -> [State s (CppSrcCode b)]
@@ -967,8 +967,8 @@ pair1Val1List :: (Pair p) => (State r (CppSrcCode a) -> [State s (CppSrcCode b)]
   -> State t (p CppSrcCode CppHdrCode c)
 pair1Val1List srcf hdrf stv1 stv2 = do
   v1 <- stv1
-  let fv1 = toState $ pfst v1
-      sv1 = toState $ psnd v1
+  let fv1 = return $ pfst v1
+      sv1 = return $ psnd v1
   pair1List (srcf fv1) (hdrf sv1) stv2
 
 pair2Lists1Val :: (Pair p) => ([State r (CppSrcCode a)] -> 
@@ -979,8 +979,8 @@ pair2Lists1Val :: (Pair p) => ([State r (CppSrcCode a)] ->
   -> State u (p CppSrcCode CppHdrCode c) -> State u (p CppSrcCode CppHdrCode d)
 pair2Lists1Val srcf hdrf stv1 stv2 stv3 = do
   v1 <- sequence stv1
-  let fl1 = map (toState . pfst) v1
-      sl1 = map (toState . psnd) v1
+  let fl1 = map (return . pfst) v1
+      sl1 = map (return . psnd) v1
   pair1List1Val (srcf fl1) (hdrf sl1) stv2 stv3 
 
 pairValListVal :: (Pair p) => (State r (CppSrcCode a) -> 
@@ -991,8 +991,8 @@ pairValListVal :: (Pair p) => (State r (CppSrcCode a) ->
   -> State u (p CppSrcCode CppHdrCode c) -> State u (p CppSrcCode CppHdrCode d)
 pairValListVal srcf hdrf stv1 stv2 stv3 = do
   v1 <- stv1
-  let fv1 = toState $ pfst v1
-      sv1 = toState $ psnd v1
+  let fv1 = return $ pfst v1
+      sv1 = return $ psnd v1
   pair1List1Val (srcf fv1) (hdrf sv1) stv2 stv3 
 
 pair3Lists1Val :: (Pair p) => ([State r (CppSrcCode a)] -> 
@@ -1005,8 +1005,8 @@ pair3Lists1Val :: (Pair p) => ([State r (CppSrcCode a)] ->
   State v (p CppSrcCode CppHdrCode d) -> State v (p CppSrcCode CppHdrCode e)
 pair3Lists1Val srcf hdrf stv1 stv2 stv3 stv4 = do
   v1 <- sequence stv1
-  let fl1 = map (toState . pfst) v1
-      sl1 = map (toState . psnd) v1
+  let fl1 = map (return . pfst) v1
+      sl1 = map (return . psnd) v1
   pair2Lists1Val (srcf fl1) (hdrf sl1) stv2 stv3 stv4 
 
 pair1Val3Lists :: (Pair p) => (State r (CppSrcCode a) -> 
@@ -1019,8 +1019,8 @@ pair1Val3Lists :: (Pair p) => (State r (CppSrcCode a) ->
   [State v (p CppSrcCode CppHdrCode d)] -> State v (p CppSrcCode CppHdrCode e)
 pair1Val3Lists srcf hdrf stv1 stv2 stv3 stv4 = do
   v1 <- stv1
-  let fv1 = toState $ pfst v1
-      sv1 = toState $ psnd v1
+  let fv1 = return $ pfst v1
+      sv1 = return $ psnd v1
   pair3Lists (srcf fv1) (hdrf sv1) stv2 stv3 stv4
 
 pair2Vals3Lists :: (Pair p) => (State r (CppSrcCode a) -> 
@@ -1035,8 +1035,8 @@ pair2Vals3Lists :: (Pair p) => (State r (CppSrcCode a) ->
   State w (p CppSrcCode CppHdrCode f)
 pair2Vals3Lists srcf hdrf stv1 stv2 stv3 stv4 stv5 = do
   v1 <- stv1
-  let fv1 = toState $ pfst v1
-      sv1 = toState $ psnd v1
+  let fv1 = return $ pfst v1
+      sv1 = return $ psnd v1
   pair1Val3Lists (srcf fv1) (hdrf sv1) stv2 stv3 stv4 stv5
 
 pairVal2ListsVal :: (Pair p) => (State r (CppSrcCode a) -> 
@@ -1049,8 +1049,8 @@ pairVal2ListsVal :: (Pair p) => (State r (CppSrcCode a) ->
   State v (p CppSrcCode CppHdrCode d) -> State v (p CppSrcCode CppHdrCode e)
 pairVal2ListsVal srcf hdrf stv1 stv2 stv3 stv4 = do
   v1 <- stv1
-  let fv1 = toState $ pfst v1
-      sv1 = toState $ psnd v1
+  let fv1 = return $ pfst v1
+      sv1 = return $ psnd v1
   pair2Lists1Val (srcf fv1) (hdrf sv1) stv2 stv3 stv4
 
 -----------------
@@ -1250,7 +1250,7 @@ instance VariableSym CppSrcCode where
     t <- c
     cm <- getClassMap
     maybe id ((>>) . modify . addModuleImportVS) 
-      (Map.lookup (getTypeString t) cm) $ classVar (toState t) v
+      (Map.lookup (getTypeString t) cm) $ classVar (return t) v
   objVar o v = join $ on3StateValues (\ovs ob vr -> if (variableName ob ++ "." 
     ++ variableName vr) `elem` ovs then toState vr else CP.objVar (toState ob) 
     (toState vr)) getODEOthVars o v
@@ -1465,12 +1465,12 @@ instance DeclStatement CppSrcCode where
   arrayDec n vr = zoom lensMStoVS $ do
     sz <- litInt n :: SValue CppSrcCode
     v <- vr 
-    toState $ mkStmt $ RC.type' (variableType v) <+> RC.variable v <> 
+    return $ mkStmt $ RC.type' (variableType v) <+> RC.variable v <> 
       brackets (RC.value sz)
   arrayDecDef vr vals = do
     vdc <- arrayDec (toInteger $ length vals) vr
     vs <- mapM (zoom lensMStoVS) vals
-    toState $ mkStmt $ RC.statement vdc <+> equals <+> braces (valueList vs)
+    return $ mkStmt $ RC.statement vdc <+> equals <+> braces (valueList vs)
   objDecDef = varDecDef
   objDecNew = G.objDecNew
   extObjDecNew = C.extObjDecNew
@@ -1696,13 +1696,13 @@ instance ModuleSym CppSrcCode where
     mis <- getModuleImports
     us <- getUsing
     mn <- getCurrMain
-    toState $ vibcat [
+    return $ vibcat [
       if mn && length ms + length cs == 1 then empty else RC.import' $ mi n,
       vcat (map ((text "#define" <+>) . text) ds),
       vcat (map (RC.import' . li) lis),
       vcat (map (RC.import' . mi) (sort (is ++ libis) ++ mis)),
       vcat (map (usingNameSpace "std" . Just) us)]) 
-    (toState empty) ms cs
+    (return empty) ms cs
     where mi, li :: Label -> CppSrcCode (Import CppSrcCode)
           mi = modImport
           li = langImport
@@ -2232,15 +2232,15 @@ instance RenderMethod CppHdrCode where
     modify (setScope (snd $ unCPPHC s)) 
     tp <- t
     pms <- sequence ps
-    toState $ toCode $ mthd (snd $ unCPPHC s) $ cpphMethod n tp pms
+    return $ toCode $ mthd (snd $ unCPPHC s) $ cpphMethod n tp pms
   intFunc = C.intFunc
   commentedFunc = cppCommentedFunc Header
 
   destructor vars = do
     n <- getClassName
-    m <- pubMethod ('~':n) void [] (toState (toCode empty)) :: SMethod CppHdrCode
+    m <- pubMethod ('~':n) void [] (return (toCode empty)) :: SMethod CppHdrCode
     vs <- mapM (zoom lensMStoCS) vars
-    toState $ toCode $ mthd Pub (emptyIfEmpty 
+    return $ toCode $ mthd Pub (emptyIfEmpty 
       (vcat (map (RC.statement . onCodeValue destructSts) vs)) (RC.method m))
   
 instance MethodElim CppHdrCode where
@@ -2251,7 +2251,7 @@ instance StateVarSym CppHdrCode where
   stateVar s p v = do
     dec <- zoom lensCStoMS $ stmt $ varDec v
     emptS <- zoom lensCStoMS emptyStmt
-    toState $ on3CodeValues svd (onCodeValue snd s)
+    return $ on3CodeValues svd (onCodeValue snd s)
       (toCode $ R.stateVar empty (RC.perm p) (RC.statement dec)) emptS
   stateVarDef _ s p vr vl = on2StateValues (onCodeValue . svd (snd $ unCPPHC s))
     (cpphStateVarDef empty p vr vl) (zoom lensCStoMS emptyStmt)
@@ -2275,7 +2275,7 @@ instance RenderClass CppHdrCode where
     modify (setClassName n)
     vars <- sequence vs
     funcs <- sequence fs
-    toState $ cpphClass n i vars funcs public private
+    return $ cpphClass n i vars funcs public private
     where fs = map (zoom lensCStoMS) $ mths ++ [destructor vs]
 
   inherit n = onCodeValue (cppInherit n . fst) public
@@ -2295,12 +2295,12 @@ instance ModuleSym CppHdrCode where
     libis <- getHeaderLibImports
     mis <- getHeaderModImports
     us <- getHeaderUsing
-    toState $ vibcat [
+    return $ vibcat [
       vcat (map ((text "#define" <+>) . text) ds),
       vcat (map (RC.import' . li) lis),
       vcat (map (RC.import' . mi) (sort (is ++ libis) ++ mis)),
       vcat (map (usingNameSpace "std" . Just) us)]) 
-    (toState empty)
+    (return empty)
     where mi, li :: Label -> CppHdrCode (Import CppHdrCode)
           mi = modImport
           li = langImport
@@ -2530,10 +2530,10 @@ cppPrint newLn pf vl = zoom lensMStoVS $ do
   e <- end
   printFn <- pf
   v <- vl
-  toState $ mkStmt $ RC.value printFn <+> text "<<" <+> pars v (RC.value v) <+> e
+  return $ mkStmt $ RC.value printFn <+> text "<<" <+> pars v (RC.value v) <+> e
   where pars v = if maybe False (< 9) (valuePrec v) then parens else id
-        end = if newLn then addIOStreamImport (toState $ text "<<" <+> 
-          text "std::endl") else toState empty
+        end = if newLn then addIOStreamImport (return $ text "<<" <+> 
+          text "std::endl") else return empty
 
 cppThrowDoc :: (RenderSym r) => r (Value r) -> Doc
 cppThrowDoc errMsg = text "throw" <> parens (RC.value errMsg)
@@ -2612,10 +2612,10 @@ cppCommentedFunc ft cmt fn = do
   mn <- getCurrMainFunc
   scp <- getScope
   cmnt <- cmt
-  let cf = toState (onCodeValue (mthd scp . R.commentedItem 
+  let cf = return (onCodeValue (mthd scp . R.commentedItem 
         (RC.blockComment' cmnt) . mthdDoc) f)
-      ret Source = if mn then cf else toState f
-      ret Header = if mn then toState f else cf
+      ret Source = if mn then cf else return f
+      ret Header = if mn then return f else cf
       ret Combined = error "Combined passed to cppCommentedFunc"
   ret ft
 
@@ -2626,7 +2626,7 @@ cppsStateVarDef cns n s p vr' vl' = do
   vr <- zoom lensCStoVS vr'
   vl <- zoom lensCStoVS vl'
   emptS <- zoom lensCStoMS emptyStmt
-  toState $ on3CodeValues svd (onCodeValue snd s) 
+  return $ on3CodeValues svd (onCodeValue snd s) 
     (toCode $ onBinding (binding p) (cns <+> RC.type' (variableType vr) <+> 
       text (n ++ "::") <> RC.variable vr <+> equals <+> RC.value vl <> 
       endStatement) empty) 

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer/CppRenderer.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer/CppRenderer.hs
@@ -154,7 +154,10 @@ instance (Pair p) => RenderFile (p CppSrcCode CppHdrCode) where
   
   commentedMod = pair2 commentedMod commentedMod
 
-  fileFromData fp = pair1 (fileFromData fp) (fileFromData fp)
+  fileFromData fp m = do
+    p1 <- fileFromData fp (pfst m)
+    p2 <- fileFromData fp (psnd m)
+    return $ pair p1 p2
 
 instance (Pair p) => ImportSym (p CppSrcCode CppHdrCode) where
   type Import (p CppSrcCode CppHdrCode) = Doc

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer/JavaRenderer.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer/JavaRenderer.hs
@@ -575,7 +575,7 @@ instance StringStatement JavaCode where
     ss <- zoom lensMStoVS $ 
       jStringSplit vnew (funcApp "Arrays.asList" (listType string) 
       [s $. func "split" (listType string) [litString [d]]])
-    toState $ mkStmt ss 
+    return $ mkStmt ss 
 
   stringListVals = M.stringListVals
   stringListLists = M.stringListLists
@@ -680,7 +680,7 @@ instance RenderMethod JavaCode where
           (Map.lookup (key mn n) mem) 
         key mnm nm = mnm ++ "." ++ nm
     modify ((if m then setCurrMain else id) . addExceptionImports excs) 
-    toState $ toCode $ mthd $ jMethod n (map exc excs) s p tp pms bd
+    return $ toCode $ mthd $ jMethod n (map exc excs) s p tp pms bd
   intFunc = C.intFunc
   commentedFunc cmt m = on2StateValues (on2CodeValues updateMthd) m 
     (onStateValue (onCodeValue R.commentedItem) cmt)
@@ -1014,4 +1014,4 @@ addConstructorCallExcsCurrMod ot f = do
   mem <- getMethodExcMap
   let tp = getTypeString t
   modify (maybe id addExceptions (Map.lookup (cm ++ "." ++ tp) mem))
-  f (toState t)
+  f (return t)

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer/LanguagePolymorphic.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer/LanguagePolymorphic.hs
@@ -467,8 +467,8 @@ fileDoc :: (RenderSym r) => String -> (r (Module r) -> r (Block r)) ->
 fileDoc ext topb botb mdl = do
   m <- mdl
   nm <- getModuleName
-  let fp = toState $ addExt ext nm
-      updm = toState $ updateModuleDoc (\d -> emptyIfEmpty d 
+  let fp = addExt ext nm
+      updm = updateModuleDoc (\d -> emptyIfEmpty d 
         (R.file (RC.block $ topb m) d (RC.block botb))) m
   S.fileFromData fp updm
 
@@ -478,10 +478,8 @@ docMod e d a dt = commentedMod (docComment $ moduleDox d a dt . addExt e <$>
   getModuleName)
 
 fileFromData :: (RenderSym r) => (FilePath -> r (Module r) -> r (File r)) 
-  -> FS FilePath -> FSModule r -> SFile r
-fileFromData f fp m = do
-  mdl <- m
-  fpath <- fp
+  -> FilePath -> r (Module r) -> SFile r
+fileFromData f fpath mdl = do
   modify (\s -> if isEmpty (RC.module' mdl) 
     then s
     else over lensFStoGS (addFile (s ^. currFileType) fpath) $ 

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer/LanguagePolymorphic.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer/LanguagePolymorphic.hs
@@ -181,7 +181,7 @@ arrayElem i' v' = do
   i <- i'
   v <- v'
   let vName = variableName v ++ "[" ++ render (RC.value i) ++ "]"
-      vType = listInnerType $ toState $ variableType v
+      vType = listInnerType $ return $ variableType v
       vRender = RC.variable v <> brackets (RC.value i)
   mkStateVar vName vType vRender
 
@@ -232,15 +232,15 @@ selfFuncAppMixedArgs d slf n t vs ns = do
 newObjMixedArgs :: (RenderSym r) => String -> MixedCtorCall r
 newObjMixedArgs s tp vs ns = do
   t <- tp 
-  S.call Nothing Nothing (s ++ getTypeString t) (toState t) vs ns
+  S.call Nothing Nothing (s ++ getTypeString t) (return t) vs ns
 
 lambda :: (RenderSym r) => ([r (Variable r)] -> r (Value r) -> Doc) -> 
   [SVariable r] -> SValue r -> SValue r
 lambda f ps' ex' = do
   ps <- sequence ps'
   ex <- ex'
-  ft <- funcType (map (toState . variableType) ps) (toState $ valueType ex)
-  toState $ valFromData (Just 0) ft (f ps ex)
+  ft <- funcType (map (return . variableType) ps) (return $ valueType ex)
+  return $ valFromData (Just 0) ft (f ps ex)
 
 objAccess :: (RenderSym r) => SValue r -> VSFunction r -> SValue r
 objAccess = on2StateValues (\v f -> mkVal (functionType f) (R.objAccess 
@@ -486,7 +486,7 @@ fileFromData f fpath mdl = do
       if s ^. currMain && isSource (s ^. currFileType) 
         then over lensFStoGS (setMainMod fpath) s
         else s)
-  toState $ f fpath mdl
+  return $ f fpath mdl
 
 -- Helper functions
 

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer/LanguagePolymorphic.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer/LanguagePolymorphic.hs
@@ -225,18 +225,22 @@ funcAppMixedArgs :: (RenderSym r) => MixedCall r
 funcAppMixedArgs = S.call Nothing Nothing
 
 selfFuncAppMixedArgs :: (RenderSym r) => Doc -> SVariable r -> MixedCall r
-selfFuncAppMixedArgs d slf n t vs ns = slf >>= (\s -> S.call Nothing 
-  (Just $ RC.variable s <> d) n t vs ns)
+selfFuncAppMixedArgs d slf n t vs ns = do
+  s <- slf 
+  S.call Nothing (Just $ RC.variable s <> d) n t vs ns
 
 newObjMixedArgs :: (RenderSym r) => String -> MixedCtorCall r
-newObjMixedArgs s tp vs ns = tp >>= 
-  (\t -> S.call Nothing Nothing (s ++ getTypeString t) (return t) vs ns)
+newObjMixedArgs s tp vs ns = do
+  t <- tp 
+  S.call Nothing Nothing (s ++ getTypeString t) (toState t) vs ns
 
 lambda :: (RenderSym r) => ([r (Variable r)] -> r (Value r) -> Doc) -> 
   [SVariable r] -> SValue r -> SValue r
-lambda f ps' ex' = sequence ps' >>= (\ps -> ex' >>= (\ex -> funcType (map 
-  (toState . variableType) ps) (toState $ valueType ex) >>= (\ft -> 
-  toState $ valFromData (Just 0) ft (f ps ex))))
+lambda f ps' ex' = do
+  ps <- sequence ps'
+  ex <- ex'
+  ft <- funcType (map (toState . variableType) ps) (toState $ valueType ex)
+  toState $ valFromData (Just 0) ft (f ps ex)
 
 objAccess :: (RenderSym r) => SValue r -> VSFunction r -> SValue r
 objAccess = on2StateValues (\v f -> mkVal (functionType f) (R.objAccess 
@@ -460,9 +464,13 @@ modFromData n f d = modify (setModuleName n) >> onStateValue f d
 
 fileDoc :: (RenderSym r) => String -> (r (Module r) -> r (Block r)) -> 
   r (Block r) -> FSModule r -> SFile r
-fileDoc ext topb botb = S.fileFromData (onStateValue (addExt ext) 
-  getModuleName) . onStateValue (\m -> updateModuleDoc (\d -> emptyIfEmpty d 
-  (R.file (RC.block $ topb m) d (RC.block botb))) m)
+fileDoc ext topb botb mdl = do
+  m <- mdl
+  nm <- getModuleName
+  let fp = toState $ addExt ext nm
+      updm = toState $ updateModuleDoc (\d -> emptyIfEmpty d 
+        (R.file (RC.block $ topb m) d (RC.block botb))) m
+  S.fileFromData fp updm
 
 docMod :: (RenderSym r) => String -> String -> [String] -> String -> SFile r -> 
   SFile r

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer/PythonRenderer.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer/PythonRenderer.hs
@@ -585,8 +585,7 @@ instance ControlStatement PythonCode where
   forEach i' v' b' = do
     i <- zoom lensMStoVS i'
     v <- zoom lensMStoVS v'
-    b <- b'
-    return $ mkStmtNoEnd $ pyForEach i v b
+    mkStmtNoEnd . pyForEach i v <$> b'
   while v' = on2StateValues (\v b -> mkStmtNoEnd (pyWhile v b)) 
     (zoom lensMStoVS v')
 
@@ -666,8 +665,7 @@ instance RenderMethod PythonCode where
     modify (if m then setCurrMain else id)
     sl <- zoom lensMStoVS self
     pms <- sequence ps
-    bd <- b
-    return $ toCode $ mthd $ pyMethod n sl pms bd
+    toCode . mthd . pyMethod n sl pms <$> b
   intFunc m n _ _ _ ps b = do
     modify (if m then setCurrMain else id)
     bd <- b

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer/PythonRenderer.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer/PythonRenderer.hs
@@ -75,8 +75,8 @@ import GOOL.Drasil.AST (Terminator(..), FileType(..), FileData(..), fileD,
   td, ValData(..), vd, VarData(..), vard)
 import GOOL.Drasil.Helpers (vibcat, emptyIfEmpty, toCode, toState, onCodeValue,
   onStateValue, on2CodeValues, on2StateValues, on3CodeValues, on3StateValues,
-  onCodeList, onStateList, on2StateLists, on1StateValue1List)
-import GOOL.Drasil.State (VS, lensGStoFS, lensMStoVS, lensVStoMS, revFiles,
+  onCodeList, onStateList, on2StateLists)
+import GOOL.Drasil.State (MS, VS, lensGStoFS, lensMStoVS, lensVStoMS, revFiles,
   addLangImportVS, getLangImports, addLibImport, addLibImportVS, getLibImports, 
   addModuleImport, addModuleImportVS, getModuleImports, setFileType, 
   getClassName, setCurrMain, getClassMap, setMainDoc, getMainDoc)
@@ -121,7 +121,9 @@ instance RenderSym PythonCode
 
 instance FileSym PythonCode where
   type File PythonCode = FileData
-  fileDoc m = modify (setFileType Combined) >> G.fileDoc pyExt top bottom m
+  fileDoc m = do
+    modify (setFileType Combined)
+    G.fileDoc pyExt top bottom m
 
   docMod = G.docMod pyExt
 
@@ -323,7 +325,9 @@ instance VariableValue PythonCode where
 
 instance CommandLineArgs PythonCode where
   arg n = G.arg (litInt $ n+1) argsList
-  argsList = modify (addLangImportVS "sys") >> G.argsList "sys.argv"
+  argsList = do
+    modify (addLangImportVS "sys")
+    G.argsList "sys.argv"
   argExists i = listSize argsList ?> litInt (fromIntegral $ i+1)
 
 instance NumericExpression PythonCode where
@@ -333,10 +337,13 @@ instance NumericExpression PythonCode where
   (#+) = binExpr plusOp
   (#-) = binExpr minusOp
   (#*) = binExpr multOp
-  (#/) v1' v2' = join $ on2StateValues (\v1 v2 -> pyDivision (getType $ 
-    valueType v1) (getType $ valueType v2) v1' v2') v1' v2'
-    where pyDivision Integer Integer = binExpr (multPrec "//")
-          pyDivision _ _ = binExpr divideOp
+  (#/) v1' v2' = do
+    v1 <- v1'
+    v2 <- v2'
+    let pyDivision Integer Integer = binExpr (multPrec "//")
+        pyDivision _ _ = binExpr divideOp
+    pyDivision (getType $ valueType v1) (getType $ valueType v2) (toState v1) 
+      (toState v2)
   (#%) = binExpr moduloOp
   (#^) = binExpr powerOp
 
@@ -373,14 +380,18 @@ instance ValueExpression PythonCode where
 
   funcAppMixedArgs = G.funcAppMixedArgs
   selfFuncAppMixedArgs = G.selfFuncAppMixedArgs dot self
-  extFuncAppMixedArgs l n t ps ns = modify (addModuleImportVS l) >> 
+  extFuncAppMixedArgs l n t ps ns = do
+    modify (addModuleImportVS l)
     CP.extFuncAppMixedArgs l n t ps ns
-  libFuncAppMixedArgs l n t ps ns = modify (addLibImportVS l) >> 
+  libFuncAppMixedArgs l n t ps ns = do
+    modify (addLibImportVS l)
     CP.extFuncAppMixedArgs l n t ps ns
   newObjMixedArgs = G.newObjMixedArgs ""
-  extNewObjMixedArgs l tp ps ns = modify (addModuleImportVS l) >> 
+  extNewObjMixedArgs l tp ps ns = do
+    modify (addModuleImportVS l)
     pyExtNewObjMixedArgs l tp ps ns
-  libNewObjMixedArgs l tp ps ns = modify (addLibImportVS l) >> 
+  libNewObjMixedArgs l tp ps ns = do
+    modify (addLibImportVS l)
     pyExtNewObjMixedArgs l tp ps ns
 
   lambda = G.lambda pyLambda
@@ -426,8 +437,7 @@ instance List PythonCode where
   indexOf = CP.indexOf "index"
 
 instance InternalList PythonCode where
-  listSlice' b e s vnew vold = onStateValue toCode $ zoom lensMStoVS $ 
-    pyListSlice vnew vold (getVal b) (getVal e) (getVal s)
+  listSlice' b e s vn vo = pyListSlice vn vo (getVal b) (getVal e) (getVal s)
     where getVal = fromMaybe (mkStateVal void empty)
 
 instance Iterator PythonCode where
@@ -461,9 +471,12 @@ instance InternalAssignStmt PythonCode where
     mkStmtNoEnd (R.multiAssign vrs vls)) vars vals
 
 instance InternalIOStmt PythonCode where
-  printSt nl f p v = zoom lensMStoVS $ on3StateValues (\f' p' v' -> mkStmtNoEnd $ 
-    pyPrint nl p' v' f') (fromMaybe (mkStateVal void empty) f) p v
-  
+  printSt nl f p v = zoom lensMStoVS $ do
+    f' <- fromMaybe (mkStateVal void empty) f
+    p' <- p
+    v' <- v
+    toState $ mkStmtNoEnd $ pyPrint nl p' v' f'
+
 instance InternalControlStmt PythonCode where
   multiReturn [] = error "Attempt to write return statement with no return variables"
   multiReturn vs = zoom lensMStoVS $ onStateList (mkStmtNoEnd . R.return') vs
@@ -502,22 +515,25 @@ instance DeclStatement PythonCode where
   arrayDecDef = listDecDef
   objDecDef = varDecDef
   objDecNew = G.objDecNew
-  extObjDecNew lib v vs = modify (addModuleImport lib) >> varDecDef v 
-    (extNewObj lib (onStateValue variableType v) vs)
+  extObjDecNew lib v vs = do
+    modify (addModuleImport lib)
+    varDecDef v (extNewObj lib (onStateValue variableType v) vs)
   constDecDef = varDecDef
-  funcDecDef v ps r = onStateValue (mkStmtNoEnd . RC.method) (zoom lensMStoVS v 
-    >>= (\vr -> function (variableName vr) private dynamic 
-    (toState $ variableType vr) (map param ps) (oneLiner $ returnStmt r)))
+  funcDecDef v ps r = do
+    vr <- zoom lensMStoVS v
+    f <- function (variableName vr) private dynamic (toState $ variableType vr) 
+      (map param ps) (oneLiner $ returnStmt r)
+    toState $ mkStmtNoEnd $ RC.method f
 
 instance IOStatement PythonCode where
-  print = pyOut False Nothing printFunc
-  printLn = pyOut True Nothing printFunc
-  printStr = print . litString
+  print      = pyOut False Nothing printFunc
+  printLn    = pyOut True  Nothing printFunc
+  printStr   = print   . litString
   printStrLn = printLn . litString
 
-  printFile f = pyOut False (Just f) printFunc
-  printFileLn f = pyOut True (Just f) printFunc
-  printFileStr f = printFile f . litString
+  printFile f      = pyOut False (Just f) printFunc
+  printFileLn f    = pyOut True  (Just f) printFunc
+  printFileStr f   = printFile f   . litString
   printFileStrLn f = printFileLn f . litString
 
   getInput = pyInput inputFunc
@@ -525,15 +541,14 @@ instance IOStatement PythonCode where
   getFileInput f = pyInput (objMethodCall string f "readline" [])
   discardFileInput f = valStmt (objMethodCall string f "readline" [])
 
-  openFileR f n = f &= funcApp "open" infile [n, litString "r"]
+  openFileR f n = f &= funcApp "open" infile  [n, litString "r"]
   openFileW f n = f &= funcApp "open" outfile [n, litString "w"]
   openFileA f n = f &= funcApp "open" outfile [n, litString "a"]
   closeFile = G.closeFile "close"
 
   getFileInputLine = getFileInput
   discardFileLine = CP.discardFileLine "readline"
-  getFileInputAll f v = v &= objMethodCall (listType string) f
-    "readlines" []
+  getFileInputAll f v = v &= objMethodCall (listType string) f "readlines" []
   
 instance StringStatement PythonCode where
   stringSplit d vnew s = assign vnew (objAccess s (func "split" 
@@ -567,8 +582,11 @@ instance ControlStatement PythonCode where
     "use forRange, forEach, or while instead"
   forRange i initv finalv stepv = forEach i
     (funcApp "range" (listType int) [initv, finalv, stepv])
-  forEach i' v' = on3StateValues (\i v b -> mkStmtNoEnd (pyForEach i v b)) 
-    (zoom lensMStoVS i') (zoom lensMStoVS v')
+  forEach i' v' b' = do
+    i <- zoom lensMStoVS i'
+    v <- zoom lensMStoVS v'
+    b <- b'
+    toState $ mkStmtNoEnd $ pyForEach i v b
   while v' = on2StateValues (\v b -> mkStmtNoEnd (pyWhile v b)) 
     (zoom lensMStoVS v')
 
@@ -644,11 +662,17 @@ instance MethodSym PythonCode where
   docInOutFunc n = pyDocInOut (inOutFunc n)
 
 instance RenderMethod PythonCode where
-  intMethod m n _ _ _ ps b = modify (if m then setCurrMain else id) >> 
-    on3StateValues (\sl pms bd -> toCode $ mthd $ pyMethod n sl pms bd) 
-    (zoom lensMStoVS self) (sequence ps) b 
-  intFunc m n _ _ _ ps b = modify (if m then setCurrMain else id) >>
-    on1StateValue1List (\bd pms -> toCode $ mthd $ pyFunction n pms bd) b ps
+  intMethod m n _ _ _ ps b = do
+    modify (if m then setCurrMain else id)
+    sl <- zoom lensMStoVS self
+    pms <- sequence ps
+    bd <- b
+    toState $ toCode $ mthd $ pyMethod n sl pms bd
+  intFunc m n _ _ _ ps b = do
+    modify (if m then setCurrMain else id)
+    bd <- b
+    pms <- sequence ps
+    toState $ toCode $ mthd $ pyFunction n pms bd
   commentedFunc cmt m = on2StateValues (on2CodeValues updateMthd) m 
     (onStateValue (onCodeValue R.commentedItem) cmt)
     
@@ -688,15 +712,19 @@ instance ClassElim PythonCode where
 
 instance ModuleSym PythonCode where
   type Module PythonCode = ModData
-  buildModule n is = CP.buildModule n (on3StateValues (\lis libis mis -> vibcat [
-    vcat (map (RC.import' . 
-      (langImport :: Label -> PythonCode (Import PythonCode))) lis),
-    vcat (map (RC.import' . 
-      (langImport :: Label -> PythonCode (Import PythonCode))) (sort $ is ++ 
-      libis)),
-    vcat (map (RC.import' . 
-      (modImport :: Label -> PythonCode (Import PythonCode))) mis)]) 
-    getLangImports getLibImports getModuleImports) getMainDoc
+  buildModule n is = CP.buildModule n (do
+    lis <- getLangImports
+    libis <- getLibImports
+    mis <- getModuleImports
+    toState $ vibcat [
+      vcat (map (RC.import' . 
+        (langImport :: Label -> PythonCode (Import PythonCode))) lis),
+      vcat (map (RC.import' . 
+        (langImport :: Label -> PythonCode (Import PythonCode))) (sort $ is ++ 
+        libis)),
+      vcat (map (RC.import' . 
+        (modImport :: Label -> PythonCode (Import PythonCode))) mis)]) 
+    getMainDoc
 
 instance RenderMod PythonCode where
   modFromData n = G.modFromData n (toCode . md n)
@@ -840,11 +868,16 @@ pyTryCatch tryB catchB = vcat [
   text "except" <+> text "Exception" <+> colon,
   indent $ RC.body catchB]
 
-pyListSlice :: (RenderSym r) => SVariable r -> SValue r -> SValue r -> SValue r 
-  -> SValue r -> VS Doc
-pyListSlice vn vo beg end step = (\vnew vold b e s -> RC.variable vnew <+> 
-  equals <+> RC.value vold <> brackets (RC.value b <> colon <> RC.value e <> 
-  colon <> RC.value s)) <$> vn <*> vo <*> beg <*> end <*> step
+pyListSlice :: (RenderSym r, Monad r) => SVariable r -> SValue r -> SValue r -> 
+  SValue r -> SValue r -> MS (r Doc)
+pyListSlice vn vo beg end step = zoom lensMStoVS $ do
+  vnew <- vn
+  vold <- vo
+  b <- beg
+  e <- end
+  s <- step
+  toState $ toCode $ RC.variable vnew <+> equals <+> RC.value vold <> 
+    brackets (RC.value b <> colon <> RC.value e <> colon <> RC.value s)
 
 pyMethod :: (RenderSym r) => Label -> r (Variable r) -> [r (Parameter r)] ->
   r (Body r) -> Doc

--- a/code/drasil-gool/GOOL/Drasil/RendererClasses.hs
+++ b/code/drasil-gool/GOOL/Drasil/RendererClasses.hs
@@ -62,7 +62,7 @@ class (BlockCommentSym r) => RenderFile r where
 
   commentedMod :: FS (r (BlockComment r)) -> SFile r -> SFile r
 
-  fileFromData :: FS FilePath -> FSModule r -> SFile r
+  fileFromData :: FilePath -> r (Module r) -> SFile r
 
 class ImportSym r where
   type Import r


### PR DESCRIPTION
As discussed at the April 29th GOOL code review meeting, this PR passes over GOOL and uses do-notation instead of long, unreadable lines.