### PR TITLE
Remove SpaceMatch parameter from matchSpaces

### DIFF
--- a/code/drasil-code/Language/Drasil/CodeSpec.hs
+++ b/code/drasil-code/Language/Drasil/CodeSpec.hs
@@ -175,9 +175,10 @@ matchSpace :: Space -> [CodeType] -> SpaceMatch -> SpaceMatch
 matchSpace _ [] _ = error "Must match each Space to at least one CodeType"
 matchSpace s ts sm = \sp -> if sp == s then ts else sm sp
 
-matchSpaces :: [(Space, [CodeType])] -> SpaceMatch -> SpaceMatch
-matchSpaces ((s,ct):sms) sm = matchSpaces sms $ matchSpace s ct sm
-matchSpaces [] sm = sm
+matchSpaces :: [(Space, [CodeType])] -> SpaceMatch
+matchSpaces spMtchs = matchSpaces' spMtchs spaceToCodeType 
+  where matchSpaces' ((s,ct):sms) sm = matchSpaces' sms $ matchSpace s ct sm
+        matchSpaces' [] sm = sm
 
 data AuxFile = SampleInput deriving Eq
              

--- a/code/drasil-example/Drasil/Projectile/Main.hs
+++ b/code/drasil-example/Drasil/Projectile/Main.hs
@@ -7,8 +7,7 @@ import Language.Drasil.Code (Choices(..), Comments(..),
   Verbosity(..), ConstraintBehaviour(..), ImplementationType(..), Lang(..), 
   Logging(..), Modularity(..), Structure(..), ConstantStructure(..), 
   ConstantRepr(..), InputModule(..), CodeConcept(..), matchConcepts, SpaceMatch,
-  matchSpaces, AuxFile(..), Visibility(..), defaultChoices, codeSpec, 
-  spaceToCodeType)
+  matchSpaces, AuxFile(..), Visibility(..), defaultChoices, codeSpec)
 import Language.Drasil.Generate (gen, genCode)
 import Language.Drasil.Printers (DocSpec(DocSpec), DocType(SRS, Website))
 
@@ -107,8 +106,7 @@ choiceCombos = [baseChoices,
     spaceMatch = matchToFloats}]
 
 matchToFloats :: SpaceMatch
-matchToFloats = matchSpaces (map (,[Float, Double]) [Real, Radians, Rational]) 
-  spaceToCodeType
+matchToFloats = matchSpaces (map (,[Float, Double]) [Real, Radians, Rational])
 
 baseChoices :: Choices
 baseChoices = defaultChoices {


### PR DESCRIPTION
Small PR that simplifies the user interface for the space match choice so they don't need to explicitly pass `spaceToCodeType`. 