### PR TITLE
Improvements to generation of main function

### DIFF
--- a/code/drasil-code/Language/Drasil/Code/Imperative/Descriptions.hs
+++ b/code/drasil-code/Language/Drasil/Code/Imperative/Descriptions.hs
@@ -1,8 +1,8 @@
 module Language.Drasil.Code.Imperative.Descriptions (
-  modDesc, inputParametersDesc, inputConstructorDesc, inputFormatDesc, 
-  derivedValuesDesc, inputConstraintsDesc, constModDesc, outputFormatDesc, 
-  inputClassDesc, constClassDesc, inFmtFuncDesc, inConsFuncDesc, dvFuncDesc, 
-  calcModDesc, woFuncDesc
+  modDesc, unmodularDesc, inputParametersDesc, inputConstructorDesc, 
+  inputFormatDesc, derivedValuesDesc, inputConstraintsDesc, constModDesc, 
+  outputFormatDesc, inputClassDesc, constClassDesc, inFmtFuncDesc, 
+  inConsFuncDesc, dvFuncDesc, calcModDesc, woFuncDesc
 ) where
 
 import Utils.Drasil (stringList)
@@ -11,7 +11,7 @@ import Language.Drasil
 import Language.Drasil.Code.Imperative.DrasilState (DrasilState(..), inMod)
 import Language.Drasil.Chunk.Code (CodeIdea(codeName))
 import Language.Drasil.CodeSpec (CodeSpec(..), CodeSystInfo(..), 
-  InputModule(..), Structure(..))
+  ImplementationType(..), InputModule(..), Structure(..))
 import Language.Drasil.Mod (Description)
 
 import Data.Map (member)
@@ -20,6 +20,14 @@ import Control.Monad.Reader (Reader, ask)
 
 modDesc :: Reader DrasilState [Description] -> Reader DrasilState Description
 modDesc = fmap ((++) "Provides " . stringList)
+
+unmodularDesc :: Reader DrasilState Description
+unmodularDesc = do
+  g <- ask
+  let n = pName $ csi $ codeSpec g
+      getDesc Library = "library"
+      getDesc Program = "program"
+  return $ "Contains the entire " ++ n ++ " " ++ getDesc (implType g)
 
 inputParametersDesc :: Reader DrasilState [Description]
 inputParametersDesc = do

--- a/code/drasil-code/Language/Drasil/Code/Imperative/Generator.hs
+++ b/code/drasil-code/Language/Drasil/Code/Imperative/Generator.hs
@@ -4,6 +4,7 @@ module Language.Drasil.Code.Imperative.Generator (
 
 import Language.Drasil
 import Language.Drasil.Code.Imperative.ConceptMatch (chooseConcept)
+import Language.Drasil.Code.Imperative.Descriptions (unmodularDesc)
 import Language.Drasil.Code.Imperative.SpaceMatch (chooseSpace)
 import Language.Drasil.Code.Imperative.GenerateGOOL (ClassType(..), 
   genDoxConfig, genModule)
@@ -20,7 +21,7 @@ import Language.Drasil.Code.Imperative.GOOL.ClassInterface (PackageSym(..),
 import Language.Drasil.Code.Imperative.GOOL.Data (PackData(..))
 import Language.Drasil.Code.CodeGeneration (createCodeFiles, makeCode)
 import Language.Drasil.CodeSpec (CodeSpec(..), CodeSystInfo(..), Choices(..), 
-  Lang(..), Modularity(..), ImplementationType(..), Visibility(..))
+  Lang(..), Modularity(..), Visibility(..))
 
 import GOOL.Drasil (GSProgram, SFile, OOProg, ProgramSym(..), ScopeTag(..), 
   ProgData(..), initialState, unCI)
@@ -103,13 +104,12 @@ chooseModules (Modular _) = genModules
 genUnmodular :: (OOProg r) => Reader DrasilState (SFile r)
 genUnmodular = do
   g <- ask
+  umDesc <- unmodularDesc
   let s = csi $ codeSpec g
       n = pName $ csi $ codeSpec g
       cls = any (`member` clsMap (codeSpec g)) 
         ["get_input", "derived_values", "input_constraints"]
-      getDesc Library = "library"
-      getDesc Program = "program"
-  genModule n ("Contains the entire " ++ n ++ " " ++ getDesc (implType g))
+  genModule n umDesc
     (genMainFunc 
       : map (fmap Just) (map genCalcFunc (execOrder $ csi $ codeSpec g) 
         ++ concatMap genModFuncs (mods s)) 

--- a/code/drasil-code/Language/Drasil/Code/Imperative/Generator.hs
+++ b/code/drasil-code/Language/Drasil/Code/Imperative/Generator.hs
@@ -109,11 +109,9 @@ genUnmodular = do
         ["get_input", "derived_values", "input_constraints"]
       getDesc Library = "library"
       getDesc Program = "program"
-      mainIfExe Library = []
-      mainIfExe Program = [genMainFunc]
   genModule n ("Contains the entire " ++ n ++ " " ++ getDesc (implType g))
-    (map (fmap Just) (mainIfExe (implType g) 
-        ++ map genCalcFunc (execOrder $ csi $ codeSpec g) 
+    (genMainFunc 
+      : map (fmap Just) (map genCalcFunc (execOrder $ csi $ codeSpec g) 
         ++ concatMap genModFuncs (mods s)) 
       ++ ((if cls then [] else [genInputFormat Pub, genInputDerived Pub, 
         genInputConstraints Pub]) ++ [genOutputFormat])) 
@@ -124,15 +122,13 @@ genModules :: (OOProg r) => Reader DrasilState [SFile r]
 genModules = do
   g <- ask
   let s = csi $ codeSpec g
-      mainIfExe Library = return []
-      mainIfExe Program = sequence [genMain]
-  mn     <- mainIfExe $ implType g
+  mn     <- genMain
   inp    <- chooseInModule $ inMod g
   con    <- genConstMod 
   cal    <- genCalcMod
   out    <- genOutputMod
   moddef <- traverse genModDef (mods s) -- hack ?
-  return $ mn ++ inp ++ con ++ cal : out ++ moddef
+  return $ mn : inp ++ con ++ cal : out ++ moddef
 
 -- private utilities used in generateCode
 getDir :: Lang -> String

--- a/code/drasil-code/Language/Drasil/Code/Imperative/Modules.hs
+++ b/code/drasil-code/Language/Drasil/Code/Imperative/Modules.hs
@@ -32,7 +32,8 @@ import Language.Drasil.Code.CodeQuantityDicts (inFileName, inParams, consts)
 import Language.Drasil.Code.DataDesc (DataDesc, junkLine, singleton)
 import Language.Drasil.CodeSpec (AuxFile(..), CodeSpec(..), CodeSystInfo(..),
   Comments(CommentFunc), ConstantStructure(..), ConstantRepr(..), 
-  ConstraintBehaviour(..), InputModule(..), Logging(..), Structure(..))
+  ConstraintBehaviour(..), ImplementationType(..), InputModule(..), Logging(..),
+  Structure(..))
 import Language.Drasil.Printers (Linearity(Linear), exprDoc)
 
 import GOOL.Drasil (SFile, MSBody, MSBlock, SVariable, SValue, MSStatement, 
@@ -58,25 +59,28 @@ import Text.PrettyPrint.HughesPJ (render)
 
 genMain :: (OOProg r) => Reader DrasilState (SFile r)
 genMain = genModule "Control" "Controls the flow of the program" 
-  [fmap Just genMainFunc] []
+  [genMainFunc] []
 
-genMainFunc :: (OOProg r) => Reader DrasilState (SMethod r)
+genMainFunc :: (OOProg r) => Reader DrasilState (Maybe (SMethod r))
 genMainFunc = do
     g <- ask
-    v_filename <- mkVar $ quantvar inFileName
-    logInFile <- maybeLog v_filename
-    co <- initConsts
-    ip <- getInputDecl
-    ics <- getAllInputCalls
-    varDef <- mapM getCalcCall (execOrder $ csi $ codeSpec g)
-    wo <- getOutputCall
-    return $ (if CommentFunc `elem` commented g then docMain else mainFunction)
-      $ bodyStatements $
-      initLogFileVar (logKind g) ++
-      varDecDef v_filename (arg 0) : logInFile ++
-      -- Constants must be declared before inputs because some derived input 
-      -- definitions or input constraints may use the constants
-      catMaybes [co, ip] ++ ics ++ catMaybes (varDef ++ [wo])
+    let mainFunc Library = return Nothing
+        mainFunc Program = do
+          v_filename <- mkVar $ quantvar inFileName
+          logInFile <- maybeLog v_filename
+          co <- initConsts
+          ip <- getInputDecl
+          ics <- getAllInputCalls
+          varDef <- mapM getCalcCall (execOrder $ csi $ codeSpec g)
+          wo <- getOutputCall
+          return $ Just $ (if CommentFunc `elem` commented g then docMain else 
+            mainFunction) $ bodyStatements $ initLogFileVar (logKind g) 
+            ++ varDecDef v_filename (arg 0) 
+            : logInFile 
+            -- Constants must be declared before inputs because some derived 
+            -- input definitions or input constraints may use the constants
+            ++ catMaybes [co, ip] ++ ics ++ catMaybes (varDef ++ [wo])
+    mainFunc $ implType g
 
 -- | If there are no inputs, the inParams object still needs to be declared 
 -- if inputs are Bundled, constants are stored WithInputs, and constant 


### PR DESCRIPTION
This PR:
- Moves the logic for whether or not a main function should be generated to `genMainFunc`, instead of repeating the logic in multiple places where `genMainFunc` is called
- Moves the description of the unmodular module to Descriptions.hs, where it belongs.