### PR TITLE
Remove sampleData file path from SystemInformation, put it in Choices

### DIFF
--- a/code/drasil-code/Language/Drasil/Code.hs
+++ b/code/drasil-code/Language/Drasil/Code.hs
@@ -8,8 +8,9 @@ module Language.Drasil.Code (
   ConstraintBehaviour(..), ImplementationType(..), Lang(..), 
   Logging(..), Modularity(..), Structure(..), ConstantStructure(..), 
   ConstantRepr(..), InputModule(..), CodeConcept(..), matchConcepts, 
-  SpaceMatch, matchSpaces, AuxFile(..), Visibility(..), ODEMethod(..), 
-  defaultChoices, funcUID, funcUID', asVC, asVC', codeSpec, relToQD,
+  SpaceMatch, matchSpaces, AuxFile(..), getSampleData, Visibility(..), 
+  ODEMethod(..), defaultChoices, funcUID, funcUID', asVC, asVC', codeSpec, 
+  relToQD,
   ($:=), Mod(Mod), Func, FuncStmt(..), fDecDef, ffor, funcData, funcDef, 
   packmod,
   junkLine, multiLine, repeated, singleLine, singleton,
@@ -77,8 +78,8 @@ import Language.Drasil.CodeSpec (Choices(..), CodeSpec(..), CodeSystInfo(..),
   Comments(..), Verbosity(..), ConstraintBehaviour(..), ImplementationType(..), 
   Lang(..), Logging(..), Modularity(..), Structure(..), ConstantStructure(..), 
   ConstantRepr(..), InputModule(..), CodeConcept(..), matchConcepts, SpaceMatch,
-  matchSpaces, AuxFile(..), Visibility(..), ODEMethod(..), defaultChoices, 
-  funcUID, funcUID', asVC, asVC', codeSpec, relToQD)
+  matchSpaces, AuxFile(..), getSampleData, Visibility(..), ODEMethod(..), 
+  defaultChoices, funcUID, funcUID', asVC, asVC', codeSpec, relToQD)
 import Language.Drasil.Mod (($:=), Mod(Mod), Func, FuncStmt(..), fDecDef, ffor, 
   funcData, funcDef, packmod)
 

--- a/code/drasil-code/Language/Drasil/Code/Imperative/Modules.hs
+++ b/code/drasil-code/Language/Drasil/Code/Imperative/Modules.hs
@@ -30,10 +30,10 @@ import Language.Drasil.Chunk.Code (CodeIdea(codeName), CodeVarChunk, quantvar,
 import Language.Drasil.Chunk.CodeDefinition (CodeDefinition, codeEquat)
 import Language.Drasil.Code.CodeQuantityDicts (inFileName, inParams, consts)
 import Language.Drasil.Code.DataDesc (DataDesc, junkLine, singleton)
-import Language.Drasil.CodeSpec (AuxFile(..), CodeSpec(..), CodeSystInfo(..),
+import Language.Drasil.CodeSpec (CodeSpec(..), CodeSystInfo(..),
   Comments(CommentFunc), ConstantStructure(..), ConstantRepr(..), 
   ConstraintBehaviour(..), ImplementationType(..), InputModule(..), Logging(..),
-  Structure(..))
+  Structure(..), hasSampleInput)
 import Language.Drasil.Printers (Linearity(Linear), exprDoc)
 
 import GOOL.Drasil (SFile, MSBody, MSBlock, SVariable, SValue, MSStatement, 
@@ -398,8 +398,8 @@ genSampleInput :: (AuxiliarySym r) => Reader DrasilState [r (Auxiliary r)]
 genSampleInput = do
   g <- ask
   dd <- genDataDesc
-  return [sampleInput (sysinfodb $ csi $ codeSpec g) dd (sampleData g) | SampleInput `elem` 
-    auxiliaries g]
+  return [sampleInput (sysinfodb $ csi $ codeSpec g) dd (sampleData g) | 
+    hasSampleInput (auxiliaries g)]
 
 ----- CONSTANTS -----
 

--- a/code/drasil-database/Database/Drasil/SystemInformation.hs
+++ b/code/drasil-database/Database/Drasil/SystemInformation.hs
@@ -39,7 +39,6 @@ data SystemInformation where
   , _sysinfodb :: ChunkDB
   , _usedinfodb :: ChunkDB
   , refdb :: ReferenceDB
-  , sampleData :: FilePath
   } -> SystemInformation
   
 -- | for listing QDefs in SystemInformation

--- a/code/drasil-example/Drasil/GamePhysics/Body.hs
+++ b/code/drasil-example/Drasil/GamePhysics/Body.hs
@@ -5,7 +5,7 @@ import Language.Drasil.Printers (PrintingInformation(..), defaultConfiguration)
 import Database.Drasil (Block(Parallel), ChunkDB, ReferenceDB, SystemInformation(SI),
   cdb, rdb, refdb, _authors, _concepts, _constants, _constraints, _datadefs,
   _definitions, _defSequence, _inputs, _kind, _outputs, _quants, _sys, _sysinfodb,
-  _usedinfodb, sampleData)
+  _usedinfodb)
 import Theory.Drasil (qdFromDD)
 import Utils.Drasil
 import Drasil.DocLang (DerivationDisplay(..), DocSection(..), Emphasis(..),
@@ -119,8 +119,7 @@ si = SI {
   _constants = [],
   _sysinfodb = symbMap,
   _usedinfodb = usedDB,
-   refdb = refDB,
-   sampleData = "../../datafiles/GamePhysics/sampleInput.txt"
+   refdb = refDB
 }
   where qDefs = map qdFromDD dataDefs
 

--- a/code/drasil-example/Drasil/GamePhysics/Main.hs
+++ b/code/drasil-example/Drasil/GamePhysics/Main.hs
@@ -30,7 +30,7 @@ import Drasil.GamePhysics.Body (srs, printSetting) -- sysInfo
 --   constStructure   = Inline,
 --   constRepr        = Const,
 --   conceptMatch     = matchConcepts ([] :: [QDefinition]) [],
---   auxFiles         = [SampleInput]
+--   auxFiles         = [SampleInput "../../datafiles/GamePhysics/sampleInput.txt"]
 -- }       
        
 main :: IO ()

--- a/code/drasil-example/Drasil/GlassBR/Body.hs
+++ b/code/drasil-example/Drasil/GlassBR/Body.hs
@@ -7,7 +7,7 @@ import Language.Drasil.Printers (PrintingInformation(..), defaultConfiguration)
 import Database.Drasil (ChunkDB, ReferenceDB, SystemInformation(SI),
   cdb, rdb, refdb, _authors, _concepts, _constants, _constraints, _datadefs,
   _definitions, _defSequence, _inputs, _kind, _outputs, _quants, _sys,
-  _sysinfodb, _usedinfodb, sampleData)
+  _sysinfodb, _usedinfodb)
 import Theory.Drasil (Theory(defined_fun, defined_quant))
 import Utils.Drasil
 
@@ -89,8 +89,7 @@ si = SI {
   _constants   = constants,
   _sysinfodb   = symbMap,
   _usedinfodb = usedDB,
-   refdb       = refDB,
-   sampleData  = "../../datafiles/GlassBR/sampleInput.txt"
+   refdb       = refDB
 }
   --FIXME: All named ideas, not just acronyms.
 

--- a/code/drasil-example/Drasil/GlassBR/Main.hs
+++ b/code/drasil-example/Drasil/GlassBR/Main.hs
@@ -29,7 +29,7 @@ choices = defaultChoices {
   inputStructure = Bundled,
   constStructure = Inline,
   constRepr = Const,
-  auxFiles = [SampleInput] 
+  auxFiles = [SampleInput "../../datafiles/GlassBR/sampleInput.txt"] 
 }
   
 main :: IO()

--- a/code/drasil-example/Drasil/HGHC/Body.hs
+++ b/code/drasil-example/Drasil/HGHC/Body.hs
@@ -11,7 +11,7 @@ import Language.Drasil.Printers (PrintingInformation(..), defaultConfiguration)
 import Database.Drasil (Block, ChunkDB, SystemInformation(SI), cdb,
   rdb, refdb, _authors, _concepts, _constants, _constraints,
   _datadefs, _definitions, _defSequence, _inputs, _kind, _outputs, _quants, 
-  _sys, _sysinfodb, _usedinfodb, sampleData)
+  _sys, _sysinfodb, _usedinfodb)
 import Utils.Drasil
 
 import Drasil.HGHC.HeatTransfer (fp, hghc, dataDefs, htInputs, htOutputs, 
@@ -44,8 +44,7 @@ si = SI {
   _constants = [],
   _sysinfodb = symbMap,
   _usedinfodb = usedDB,
-   refdb = rdb [] [], -- FIXME?
-   sampleData = "../../datafiles/HGHC/sampleInput.txt"
+   refdb = rdb [] [] -- FIXME?
 }
   
 mkSRS :: SRSDecl

--- a/code/drasil-example/Drasil/HGHC/Main.hs
+++ b/code/drasil-example/Drasil/HGHC/Main.hs
@@ -31,7 +31,7 @@ thisChoices = defaultChoices {
   constStructure   = Inline,
   constRepr        = Const,
   conceptMatch     = matchConcepts ([] :: [QDefinition]) [],
-  auxFiles         = [SampleInput] 
+  auxFiles         = [SampleInput "../../datafiles/HGHC/sampleInput.txt"] 
 } -}
   
 main :: IO ()            

--- a/code/drasil-example/Drasil/NoPCM/Body.hs
+++ b/code/drasil-example/Drasil/NoPCM/Body.hs
@@ -5,7 +5,7 @@ import Language.Drasil.Printers (PrintingInformation(..), defaultConfiguration)
 import Database.Drasil (Block(Parallel), ChunkDB, ReferenceDB,
   SystemInformation(SI), cdb, rdb, refdb, _authors, _concepts, _constants,
   _constraints, _datadefs, _definitions, _defSequence, _inputs, _kind, _outputs,
-  _quants, _sys, _sysinfodb, _usedinfodb, sampleData)
+  _quants, _sys, _sysinfodb, _usedinfodb)
 import Theory.Drasil (TheoryModel)
 import Utils.Drasil
 
@@ -188,8 +188,7 @@ si = SI {
   _constants = specParamValList,
   _sysinfodb = symbMap,
   _usedinfodb = usedDB,
-   refdb = refDB,
-   sampleData = "../../datafiles/NoPCM/sampleInput.txt"
+   refdb = refDB
 }
 
 refDB :: ReferenceDB

--- a/code/drasil-example/Drasil/NoPCM/Main.hs
+++ b/code/drasil-example/Drasil/NoPCM/Main.hs
@@ -28,7 +28,7 @@ choices = defaultChoices {
   inputStructure = Unbundled,
   constStructure = Store Bundled,
   constRepr = Const,
-  auxFiles = [SampleInput]
+  auxFiles = [SampleInput "../../datafiles/NoPCM/sampleInput.txt"]
 }       
        
 main :: IO ()            

--- a/code/drasil-example/Drasil/Projectile/Body.hs
+++ b/code/drasil-example/Drasil/Projectile/Body.hs
@@ -6,7 +6,7 @@ import Language.Drasil.Printers (PrintingInformation(..), defaultConfiguration)
 import Database.Drasil (Block, ChunkDB, ReferenceDB, SystemInformation(SI),
   cdb, rdb, refdb, _authors, _concepts, _constants, _constraints, _datadefs,
   _definitions, _defSequence, _inputs, _kind, _outputs, _quants, _sys,
-  _sysinfodb, _usedinfodb, sampleData)
+  _sysinfodb, _usedinfodb)
 import Utils.Drasil
 
 import Drasil.DocLang (AuxConstntSec(AuxConsProg),
@@ -119,8 +119,7 @@ si = SI {
   _constants   = constants,
   _sysinfodb   = symbMap,
   _usedinfodb  = usedDB,
-   refdb       = refDB,
-   sampleData  = "../../../datafiles/Projectile/sampleInput.txt"
+   refdb       = refDB
 }
 
 symbMap :: ChunkDB

--- a/code/drasil-example/Drasil/Projectile/Main.hs
+++ b/code/drasil-example/Drasil/Projectile/Main.hs
@@ -124,5 +124,5 @@ baseChoices = defaultChoices {
   constStructure = WithInputs,
   constRepr = Var,
   conceptMatch = matchConcepts [(piConst, [Pi])],
-  auxFiles = [SampleInput]
+  auxFiles = [SampleInput "../../../datafiles/Projectile/sampleInput.txt"]
 }

--- a/code/drasil-example/Drasil/SSP/Body.hs
+++ b/code/drasil-example/Drasil/SSP/Body.hs
@@ -5,7 +5,7 @@ import Language.Drasil.Printers (PrintingInformation(..), defaultConfiguration)
 import Database.Drasil (Block(Parallel), ChunkDB, ReferenceDB,
   SystemInformation(SI), cdb, rdb, refdb, _authors, _concepts, _constants,
   _constraints, _datadefs, _definitions, _defSequence, _inputs, _kind, _outputs,
-  _quants, _sys, _sysinfodb, _usedinfodb, sampleData)
+  _quants, _sys, _sysinfodb, _usedinfodb)
 import Theory.Drasil (qdFromDD)
 
 import Prelude hiding (sin, cos, tan)
@@ -90,8 +90,7 @@ si = SI {
   _constants = [],
   _sysinfodb = symbMap,
   _usedinfodb = usedDB,
-   refdb = refDB,
-   sampleData = "../../datafiles/SSP/sampleInput.txt"
+   refdb = refDB
 }
   
 mkSRS :: SRSDecl

--- a/code/drasil-example/Drasil/SSP/Main.hs
+++ b/code/drasil-example/Drasil/SSP/Main.hs
@@ -30,7 +30,7 @@ import Drasil.SSP.Body (srs, printSetting) -- si
 --   constStructure = Inline,   -- Inline, WithInputs, Store Structure
 --   constRepr = Const,    -- Var, Const
 --   conceptMatch = matchConcepts ([] :: [QDefinition]) [],
---   auxFiles = [SampleInput]
+--   auxFiles = [SampleInput "../../datafiles/SSP/sampleInput.txt"]
 -- }
        
 main :: IO ()            

--- a/code/drasil-example/Drasil/SWHS/Body.hs
+++ b/code/drasil-example/Drasil/SWHS/Body.hs
@@ -5,7 +5,7 @@ import Language.Drasil.Printers (PrintingInformation(..), defaultConfiguration)
 import Database.Drasil (Block, ChunkDB, ReferenceDB,
   SystemInformation(SI), cdb, rdb, refdb, _authors, _concepts, _constants,
   _constraints, _datadefs, _definitions, _defSequence, _inputs, _kind, _outputs,
-  _quants, _sys, _sysinfodb, _usedinfodb, sampleData)
+  _quants, _sys, _sysinfodb, _usedinfodb)
 import Theory.Drasil (GenDefn, InstanceModel)
 import Utils.Drasil
 
@@ -98,8 +98,7 @@ si = SI {
   _constants = specParamValList,
   _sysinfodb = symbMap,
   _usedinfodb = usedDB,
-   refdb = refDB,
-   sampleData = "../../datafiles/SWHS/sampleInput.txt"
+   refdb = refDB
 }
 
 symbMap :: ChunkDB

--- a/code/drasil-example/Drasil/SWHS/Generate.hs
+++ b/code/drasil-example/Drasil/SWHS/Generate.hs
@@ -29,7 +29,7 @@ import Drasil.SWHS.Body (srs, printSetting) -- si
 --   constStructure = Inline,   -- Inline, WithInputs, Store Structure
 --   constRepr = Const,      -- Var, Const
 --   conceptMatch = matchConcepts ([] :: [QDefinition]) [],
---   auxFiles = [SampleInput]
+--   auxFiles = [SampleInput "../../datafiles/SWHS/sampleInput.txt"]
 -- }
 
 generate :: IO ()

--- a/code/drasil-example/Drasil/Template/Body.hs
+++ b/code/drasil-example/Drasil/Template/Body.hs
@@ -5,7 +5,7 @@ import Language.Drasil.Printers (PrintingInformation(..), defaultConfiguration)
 import Database.Drasil (Block, ChunkDB, ReferenceDB, SystemInformation(SI),
   cdb, rdb, refdb, _authors, _concepts, _constants, _constraints, _datadefs,
   _definitions, _defSequence, _inputs, _kind, _outputs, _quants, _sys,
-  _sysinfodb, _usedinfodb, sampleData)
+  _sysinfodb, _usedinfodb)
 import Theory.Drasil (DataDefinition, GenDefn, InstanceModel, TheoryModel)
 import Utils.Drasil
 
@@ -38,8 +38,7 @@ si = SI {
   _constants   = [] :: [QDefinition],
   _sysinfodb   = symbMap,
   _usedinfodb  = usedDB,
-   refdb       = refDB,
-   sampleData  = "../../datafiles/Template/sampleInput.txt"
+   refdb       = refDB
 }
 
 symbMap :: ChunkDB

--- a/code/drasil-gen/Language/Drasil/Generate.hs
+++ b/code/drasil-gen/Language/Drasil/Generate.hs
@@ -14,8 +14,8 @@ import Language.Drasil.Printers (Format(TeX, HTML), DocSpec(DocSpec),
   DocType(SRS, MG, MIS, Website), Filename, makeCSS, genHTML,
   genTeX, PrintingInformation)
 import Language.Drasil.Code (generator, generateCode, Choices(..), CodeSpec(..),
-  CodeSystInfo(..), Lang(..), readWithDataDesc, sampleInputDD, unPP, unJP, 
-  unCSP, unCPPP)
+  CodeSystInfo(..), Lang(..), getSampleData, readWithDataDesc, sampleInputDD, 
+  unPP, unJP, unCSP, unCPPP)
 
 import GOOL.Drasil (unJC, unPC, unCSC, unCPPC)
 
@@ -70,7 +70,8 @@ genCode :: Choices -> CodeSpec -> IO ()
 genCode chs spec = do 
   workingDir <- getCurrentDirectory
   time <- getCurrentTime
-  sampData <- readWithDataDesc (smplData $ csi spec) $ sampleInputDD (extInputs $ csi spec)
+  sampData <- maybe (return []) (\sd -> readWithDataDesc sd $ sampleInputDD 
+    (extInputs $ csi spec)) (getSampleData chs)
   createDirectoryIfMissing False "src"
   setCurrentDirectory "src"
   let genLangCode Java = genCall Java unJC unJP


### PR DESCRIPTION
Previously every Drasil example was forced to provide a sample data file path even if they did not want to generate a sample input file, because it was a field in `SystemInformation`. This PR updates it so the file path is instead passed through `Choices`, and only needs to be specified if the user chooses to generate a sample input file.