### PR TITLE
Correct references in "Organization of Document" section.

### DIFF
--- a/code/drasil-example/Drasil/GamePhysics/Body.hs
+++ b/code/drasil-example/Drasil/GamePhysics/Body.hs
@@ -45,7 +45,7 @@ import Drasil.GamePhysics.Concepts (gamePhysics, acronyms, threeD, twoD)
 import Drasil.GamePhysics.DataDefs (dataDefs)
 import Drasil.GamePhysics.Goals (goals)
 import Drasil.GamePhysics.IMods (iMods, instModIntro)
-import Drasil.GamePhysics.References (citations, parnas1972, parnasClements1984)
+import Drasil.GamePhysics.References (citations, koothoor2013, smithLai2005)
 import Drasil.GamePhysics.Requirements (funcReqs, nonfuncReqs)
 import Drasil.GamePhysics.TMods (tMods)
 import Drasil.GamePhysics.Unitals (symbolsAll, outputConstraints,
@@ -228,8 +228,8 @@ organizationOfDocumentsIntro :: Sentence
 organizationOfDocumentsIntro = foldlSent 
   [S "The", phrase organization, S "of this", phrase document, 
   S "follows the", phrase template, S "for an", getAcc Doc.srs, S "for", 
-  phrase sciCompS, S "proposed by", makeCiteS parnas1972 `sAnd` 
-  makeCiteS parnasClements1984]
+  phrase sciCompS, S "proposed by", makeCiteS koothoor2013 `sAnd`
+  makeCiteS smithLai2005]
 
 --------------------------------------------
 -- Section 3: GENERAL SYSTEM DESCRIPTION --

--- a/code/drasil-example/Drasil/GamePhysics/References.hs
+++ b/code/drasil-example/Drasil/GamePhysics/References.hs
@@ -1,18 +1,19 @@
-module Drasil.GamePhysics.References (chaslesWiki, citations, parnas1972,
-  parnasClements1984) where
+module Drasil.GamePhysics.References (chaslesWiki, citations, koothoor2013,
+  smithLai2005) where
 
 import Language.Drasil
 
 import Data.Drasil.Citations (cartesianWiki, koothoor2013, parnasClements1986,
-  parnas1972, parnasClements1984, smithLai2005, lineSource, pointSource, dampingSource)
+  smithLai2005, lineSource, pointSource, dampingSource)
 import Data.Drasil.People (bWaugh, cTitus, dParnas, daAruliah, epWhite, gWilson,
   imMitchell, jBueche, kdHuff, mDavis, mdPlumblet, nChueHong, pWilson, rGuy, shdHaddock)
 
 chaslesWiki, jfBeucheIntro, parnas1978, sciComp2013 :: Citation
 
 citations :: BibRef
-citations = [parnas1978, sciComp2013, parnas1972, parnasClements1984, chaslesWiki,
-  parnasClements1986, koothoor2013, smithLai2005, jfBeucheIntro, cartesianWiki, lineSource, pointSource, dampingSource]
+citations = [parnas1978, sciComp2013, chaslesWiki, parnasClements1986,
+  koothoor2013, smithLai2005, jfBeucheIntro, cartesianWiki, lineSource,
+  pointSource, dampingSource]
 
 --FIXME: check for references made within document
 

--- a/code/drasil-example/Drasil/SWHS/Body.hs
+++ b/code/drasil-example/Drasil/SWHS/Body.hs
@@ -58,7 +58,7 @@ import Drasil.SWHS.GenDefs (genDefs, htFluxWaterFromCoil, htFluxPCMFromWater)
 import Drasil.SWHS.Goals (goals)
 import Drasil.SWHS.IMods (eBalanceOnWtr, eBalanceOnPCM, heatEInWtr, heatEInPCM,
   iMods, instModIntro)
-import Drasil.SWHS.References (parnas1972, parnasClements1984, citations)
+import Drasil.SWHS.References (citations, koothoor2013, smithLai2005)
 import Drasil.SWHS.Requirements (funcReqs, inReqDesc, nfRequirements, verifyEnergyOutput)
 import Drasil.SWHS.TMods (tMods)
 import Drasil.SWHS.Unitals (absTol, coilHTC, coilSA, consTol, constrained,
@@ -275,8 +275,8 @@ charReaderDE = plural de +:+ S "from level 1 and 2" +:+ phrase calculus
 orgDocIntro :: Sentence
 orgDocIntro = foldlSent [S "The", phrase organization, S "of this",
   phrase document, S "follows the template for an", short Doc.srs,
-  S "for", phrase sciCompS, S "proposed by", makeCiteS parnas1972 `sAnd` 
-  makeCiteS parnasClements1984]
+  S "for", phrase sciCompS, S "proposed by", makeCiteS koothoor2013 `sAnd`
+  makeCiteS smithLai2005]
 
 orgDocEnd :: Sentence
 orgDocEnd = foldlSent_ [S "The", plural inModel, 

--- a/code/drasil-example/Drasil/SWHS/References.hs
+++ b/code/drasil-example/Drasil/SWHS/References.hs
@@ -1,19 +1,19 @@
 module Drasil.SWHS.References (citations, bueche1986, incroperaEtAl2007, koothoor2013, lightstone2012, 
-  parnasClements1986, parnas1972, parnasClements1984, smithLai2005) where
+  parnasClements1986, smithLai2005) where
 
 import Language.Drasil
 
 import Data.Drasil.People (jBueche, fIncropera, dDewitt, tBergman, aLavine,
   mLightstone)
 
-import Data.Drasil.Citations (koothoor2013, parnasClements1986, smithLai2005, parnas1972, parnasClements1984)
+import Data.Drasil.Citations (koothoor2013, parnasClements1986, smithLai2005)
 
 ----------------------------
 -- Section 9 : References --
 ----------------------------
 citations :: BibRef
 citations = [bueche1986, incroperaEtAl2007, koothoor2013, lightstone2012, parnasClements1986, 
-  smithLai2005, parnas1972, parnasClements1984]
+  smithLai2005]
 
 bueche1986, incroperaEtAl2007, lightstone2012 :: Citation
 

--- a/code/stable/gamephysics/SRS/GamePhysics_SRS.tex
+++ b/code/stable/gamephysics/SRS/GamePhysics_SRS.tex
@@ -269,7 +269,7 @@ Reviewers of this documentation should have an understanding of rigid body dynam
 
 \subsection{Organization of Document}
 \label{Sec:DocOrg}
-The organization of this document follows the template for an SRS for scientific computing software proposed by \cite{dParnas1972} and \cite{parnasClements1984}. The presentation follows the standard pattern of presenting goals, theories, definitions, and assumptions. For readers that would like a more bottom up approach, they can start reading the instance models in \hyperref[Sec:IMs]{Section: Instance Models} and trace back to find any additional information they require.
+The organization of this document follows the template for an SRS for scientific computing software proposed by \cite{koothoor2013} and \cite{smithLai2005}. The presentation follows the standard pattern of presenting goals, theories, definitions, and assumptions. For readers that would like a more bottom up approach, they can start reading the instance models in \hyperref[Sec:IMs]{Section: Instance Models} and trace back to find any additional information they require.
 
 The goal statements (\hyperref[Sec:GoalStmt]{Section: Goal Statements}) are refined to the theoretical models and the theoretical models (\hyperref[Sec:TMs]{Section: Theoretical Models}) to the instance models (\hyperref[Sec:IMs]{Section: Instance Models}).
 
@@ -1783,12 +1783,6 @@ title={A document drive approach to certifying scientific computing software},
 school={McMaster University},
 year={2013},
 address={Hamilton, ON, Canada}}
-@article{dParnas1972,
-author={Parnas, David L.},
-title={On the Criteria To Be Used in Decomposing Systems into Modules},
-journal={Communications of the ACM},
-year={1972},
-pages={1053--1058}}
 @inproceedings{parnas1978,
 author={Parnas, David L.},
 title={Designing Software for Ease of Extension and Contraction},
@@ -1805,12 +1799,6 @@ volume={12},
 number={2},
 pages={251--257},
 address={Washington, USA}}
-@inproceedings{parnasClements1984,
-author={Parnas, David L. and Clements, P. C. and Wiess},
-title={The Modular Structure of Complex Systems},
-booktitle={ICSE '84: Proceedings of the 7th international conference on Software engineering},
-year={1984},
-pages={408--417}}
 @misc{pointSource,
 author={Pierce, Rod},
 title={Point},

--- a/code/stable/gamephysics/Website/GamePhysics_SRS.html
+++ b/code/stable/gamephysics/Website/GamePhysics_SRS.html
@@ -540,7 +540,7 @@
           <div class="subsection">
             <h2>Organization of Document</h2>
             <p class="paragraph">
-              The organization of this document follows the template for an SRS for scientific computing software proposed by <a href=#dParnas1972>dParnas1972</a> and <a href=#parnasClements1984>parnasClements1984</a>. The presentation follows the standard pattern of presenting goals, theories, definitions, and assumptions. For readers that would like a more bottom up approach, they can start reading the instance models in <a href=#Sec:IMs>Section: Instance Models</a> and trace back to find any additional information they require.
+              The organization of this document follows the template for an SRS for scientific computing software proposed by <a href=#koothoor2013>koothoor2013</a> and <a href=#smithLai2005>smithLai2005</a>. The presentation follows the standard pattern of presenting goals, theories, definitions, and assumptions. For readers that would like a more bottom up approach, they can start reading the instance models in <a href=#Sec:IMs>Section: Instance Models</a> and trace back to find any additional information they require.
             </p>
             <p class="paragraph">
               The goal statements (<a href=#Sec:GoalStmt>Section: Goal Statements</a>) are refined to the theoretical models and the theoretical models (<a href=#Sec:TMs>Section: Theoretical Models</a>) to the instance models (<a href=#Sec:IMs>Section: Instance Models</a>).
@@ -4595,58 +4595,48 @@
             </div>
           </li>
           <li>
-            <div id="dParnas1972">
-              [3]: Parnas, David L. "On the Criteria To Be Used in Decomposing Systems into Modules." <em>Communications of the ACM</em>, 1972. pp. 1053&ndash;1058. Print.
-            </div>
-          </li>
-          <li>
             <div id="parnas1978">
-              [4]: Parnas, David L. "Designing Software for Ease of Extension and Contraction." <em>ICSE '78: Proceedings of the 3rd international conference on Software engineering</em>. 1978. pp. 264&ndash;277.
+              [3]: Parnas, David L. "Designing Software for Ease of Extension and Contraction." <em>ICSE '78: Proceedings of the 3rd international conference on Software engineering</em>. 1978. pp. 264&ndash;277.
             </div>
           </li>
           <li>
             <div id="parnasClements1986">
-              [5]: Parnas, David L. and Clements, P. C. "A rational design process: How and why to fake it." <em>IEEE Transactions on Software Engineering</em>, vol. 12, no. 2, Washington, USA: February, 1986. pp. 251&ndash;257. Print.
-            </div>
-          </li>
-          <li>
-            <div id="parnasClements1984">
-              [6]: Parnas, David L., Clements, P. C., and Wiess. "The Modular Structure of Complex Systems." <em>ICSE '84: Proceedings of the 7th international conference on Software engineering</em>. 1984. pp. 408&ndash;417.
+              [4]: Parnas, David L. and Clements, P. C. "A rational design process: How and why to fake it." <em>IEEE Transactions on Software Engineering</em>, vol. 12, no. 2, Washington, USA: February, 1986. pp. 251&ndash;257. Print.
             </div>
           </li>
           <li>
             <div id="pointSource">
-              [7]: Pierce, Rod. <em>Point</em>. May, 2017. <a href="https://www.mathsisfun.com/geometry/point.html">https://www.mathsisfun.com/geometry/point.html</a>.
+              [5]: Pierce, Rod. <em>Point</em>. May, 2017. <a href="https://www.mathsisfun.com/geometry/point.html">https://www.mathsisfun.com/geometry/point.html</a>.
             </div>
           </li>
           <li>
             <div id="smithLai2005">
-              [8]: Smith, W. Spencer and Lai, Lei. "A new requirements template for scientific computing." <em>Proceedings of the First International Workshop on Situational Requirements Engineering Processes - Methods, Techniques and Tools to Support Situation-Specific Requirements Engineering Processes, SREP'05</em>. Edited by PJ Agerfalk, N. Kraiem, and J. Ralyte, Paris, France: 2005. pp. 107&ndash;121. In conjunction with 13th IEEE International Requirements Engineering Conference,
+              [6]: Smith, W. Spencer and Lai, Lei. "A new requirements template for scientific computing." <em>Proceedings of the First International Workshop on Situational Requirements Engineering Processes - Methods, Techniques and Tools to Support Situation-Specific Requirements Engineering Processes, SREP'05</em>. Edited by PJ Agerfalk, N. Kraiem, and J. Ralyte, Paris, France: 2005. pp. 107&ndash;121. In conjunction with 13th IEEE International Requirements Engineering Conference,
             </div>
           </li>
           <li>
             <div id="lineSource">
-              [9]: The Editors of Encyclopaedia Britannica. <em>Line</em>. June, 2019. <a href="https://www.britannica.com/science/line-mathematics">https://www.britannica.com/science/line-mathematics</a>.
+              [7]: The Editors of Encyclopaedia Britannica. <em>Line</em>. June, 2019. <a href="https://www.britannica.com/science/line-mathematics">https://www.britannica.com/science/line-mathematics</a>.
             </div>
           </li>
           <li>
             <div id="chaslesWiki">
-              [10]: Wikipedia Contributors. <em>Chasles' theorem (kinematics)</em>. November, 2018. <a href="https://en.wikipedia.org/wiki/Chasles'_theorem_(kinematics)">https://en.wikipedia.org/wiki/Chasles'_theorem_(kinematics)</a>.
+              [8]: Wikipedia Contributors. <em>Chasles' theorem (kinematics)</em>. November, 2018. <a href="https://en.wikipedia.org/wiki/Chasles'_theorem_(kinematics)">https://en.wikipedia.org/wiki/Chasles'_theorem_(kinematics)</a>.
             </div>
           </li>
           <li>
             <div id="cartesianWiki">
-              [11]: Wikipedia Contributors. <em>Cartesian coordinate system</em>. June, 2019. <a href="https://en.wikipedia.org/wiki/Cartesian_coordinate_system">https://en.wikipedia.org/wiki/Cartesian_coordinate_system</a>.
+              [9]: Wikipedia Contributors. <em>Cartesian coordinate system</em>. June, 2019. <a href="https://en.wikipedia.org/wiki/Cartesian_coordinate_system">https://en.wikipedia.org/wiki/Cartesian_coordinate_system</a>.
             </div>
           </li>
           <li>
             <div id="dampingSource">
-              [12]: Wikipedia Contributors. <em>Damping</em>. July, 2019. <a href="https://en.wikipedia.org/wiki/Damping_ratio">https://en.wikipedia.org/wiki/Damping_ratio</a>.
+              [10]: Wikipedia Contributors. <em>Damping</em>. July, 2019. <a href="https://en.wikipedia.org/wiki/Damping_ratio">https://en.wikipedia.org/wiki/Damping_ratio</a>.
             </div>
           </li>
           <li>
             <div id="sciComp2013">
-              [13]: Wilson, Greg, Aruliah, D. A., Titus, C., Chue Hong, Neil P., Davis, Matt, Guy, Richard T., Haddock, Steven H. D., Huff, Kathryn D., Mitchell, Ian M., Plumblet, Mark D., Waugh, Ben, White, Ethan P., and Wilson, Paul. "Best Practices for Scientific Computing, 2013." <em>PLoS Biol</em>, vol. 12, no. 1, 2013. Print.
+              [11]: Wilson, Greg, Aruliah, D. A., Titus, C., Chue Hong, Neil P., Davis, Matt, Guy, Richard T., Haddock, Steven H. D., Huff, Kathryn D., Mitchell, Ian M., Plumblet, Mark D., Waugh, Ben, White, Ethan P., and Wilson, Paul. "Best Practices for Scientific Computing, 2013." <em>PLoS Biol</em>, vol. 12, no. 1, 2013. Print.
             </div>
           </li>
         </ul>

--- a/code/stable/nopcm/SRS/NoPCM_SRS.tex
+++ b/code/stable/nopcm/SRS/NoPCM_SRS.tex
@@ -241,7 +241,7 @@ Reviewers of this documentation should have an understanding of heat transfer th
 
 \subsection{Organization of Document}
 \label{Sec:DocOrg}
-The organization of this document follows the template for an SRS for scientific computing software proposed by \cite{dParnas1972} and \cite{parnasClements1984}. The presentation follows the standard pattern of presenting goals, theories, definitions, and assumptions. For readers that would like a more bottom up approach, they can start reading the instance models in \hyperref[Sec:IMs]{Section: Instance Models} and trace back to find any additional information they require.
+The organization of this document follows the template for an SRS for scientific computing software proposed by \cite{koothoor2013} and \cite{smithLai2005}. The presentation follows the standard pattern of presenting goals, theories, definitions, and assumptions. For readers that would like a more bottom up approach, they can start reading the instance models in \hyperref[Sec:IMs]{Section: Instance Models} and trace back to find any additional information they require.
 
 The goal statements (\hyperref[Sec:GoalStmt]{Section: Goal Statements}) are refined to the theoretical models and the theoretical models (\hyperref[Sec:TMs]{Section: Theoretical Models}) to the instance models (\hyperref[Sec:IMs]{Section: Instance Models}). The instance model to be solved is referred to as \hyperref[IM:eBalanceOnWtr]{IM: eBalanceOnWtr}. The instance model provides the Ordinary Differential Equation (ODE) that models the solar water heating system. SWHS solves this ODE.
 

--- a/code/stable/nopcm/Website/NoPCM_SRS.html
+++ b/code/stable/nopcm/Website/NoPCM_SRS.html
@@ -470,7 +470,7 @@
           <div class="subsection">
             <h2>Organization of Document</h2>
             <p class="paragraph">
-              The organization of this document follows the template for an SRS for scientific computing software proposed by <a href=#dParnas1972>dParnas1972</a> and <a href=#parnasClements1984>parnasClements1984</a>. The presentation follows the standard pattern of presenting goals, theories, definitions, and assumptions. For readers that would like a more bottom up approach, they can start reading the instance models in <a href=#Sec:IMs>Section: Instance Models</a> and trace back to find any additional information they require.
+              The organization of this document follows the template for an SRS for scientific computing software proposed by <a href=#koothoor2013>koothoor2013</a> and <a href=#smithLai2005>smithLai2005</a>. The presentation follows the standard pattern of presenting goals, theories, definitions, and assumptions. For readers that would like a more bottom up approach, they can start reading the instance models in <a href=#Sec:IMs>Section: Instance Models</a> and trace back to find any additional information they require.
             </p>
             <p class="paragraph">
               The goal statements (<a href=#Sec:GoalStmt>Section: Goal Statements</a>) are refined to the theoretical models and the theoretical models (<a href=#Sec:TMs>Section: Theoretical Models</a>) to the instance models (<a href=#Sec:IMs>Section: Instance Models</a>). The instance model to be solved is referred to as <a href=#IM:eBalanceOnWtr>IM: eBalanceOnWtr</a>. The instance model provides the Ordinary Differential Equation (ODE) that models the solar water heating system. SWHS solves this ODE.

--- a/code/stable/swhs/SRS/SWHS_SRS.tex
+++ b/code/stable/swhs/SRS/SWHS_SRS.tex
@@ -275,7 +275,7 @@ Reviewers of this documentation should have an understanding of heat transfer th
 
 \subsection{Organization of Document}
 \label{Sec:DocOrg}
-The organization of this document follows the template for an SRS for scientific computing software proposed by \cite{dParnas1972} and \cite{parnasClements1984}. The presentation follows the standard pattern of presenting goals, theories, definitions, and assumptions. For readers that would like a more bottom up approach, they can start reading the instance models in \hyperref[Sec:IMs]{Section: Instance Models} and trace back to find any additional information they require.
+The organization of this document follows the template for an SRS for scientific computing software proposed by \cite{koothoor2013} and \cite{smithLai2005}. The presentation follows the standard pattern of presenting goals, theories, definitions, and assumptions. For readers that would like a more bottom up approach, they can start reading the instance models in \hyperref[Sec:IMs]{Section: Instance Models} and trace back to find any additional information they require.
 
 The goal statements (\hyperref[Sec:GoalStmt]{Section: Goal Statements}) are refined to the theoretical models and the theoretical models (\hyperref[Sec:TMs]{Section: Theoretical Models}) to the instance models (\hyperref[Sec:IMs]{Section: Instance Models}). The instance models to be solved are referred to as \hyperref[IM:eBalanceOnWtr]{IM: eBalanceOnWtr}, \hyperref[IM:eBalanceOnPCM]{IM: eBalanceOnPCM}, \hyperref[IM:heatEInWtr]{IM: heatEInWtr}, and \hyperref[IM:heatEInPCM]{IM: heatEInPCM}. The instance models provide the ordinary differential equations (ODEs) and algebraic equations that model the solar water heating systems incorporating PCM. SWHS solves these ODEs.
 
@@ -1885,12 +1885,6 @@ author={Lightstone, Marilyn},
 title={Derivation of tank/pcm model},
 year={2012},
 note={From Marilyn Lightstone's Personal Notes}}
-@article{dParnas1972,
-author={Parnas, David L.},
-title={On the Criteria To Be Used in Decomposing Systems into Modules},
-journal={Communications of the ACM},
-year={1972},
-pages={1053--1058}}
 @article{parnasClements1986,
 author={Parnas, David L. and Clements, P. C.},
 title={A rational design process: How and why to fake it},
@@ -1901,12 +1895,6 @@ volume={12},
 number={2},
 pages={251--257},
 address={Washington, USA}}
-@inproceedings{parnasClements1984,
-author={Parnas, David L. and Clements, P. C. and Wiess},
-title={The Modular Structure of Complex Systems},
-booktitle={ICSE '84: Proceedings of the 7th international conference on Software engineering},
-year={1984},
-pages={408--417}}
 @inproceedings{smithLai2005,
 author={Smith, W. Spencer and Lai, Lei},
 title={A new requirements template for scientific computing},

--- a/code/stable/swhs/Website/SWHS_SRS.html
+++ b/code/stable/swhs/Website/SWHS_SRS.html
@@ -555,7 +555,7 @@
           <div class="subsection">
             <h2>Organization of Document</h2>
             <p class="paragraph">
-              The organization of this document follows the template for an SRS for scientific computing software proposed by <a href=#dParnas1972>dParnas1972</a> and <a href=#parnasClements1984>parnasClements1984</a>. The presentation follows the standard pattern of presenting goals, theories, definitions, and assumptions. For readers that would like a more bottom up approach, they can start reading the instance models in <a href=#Sec:IMs>Section: Instance Models</a> and trace back to find any additional information they require.
+              The organization of this document follows the template for an SRS for scientific computing software proposed by <a href=#koothoor2013>koothoor2013</a> and <a href=#smithLai2005>smithLai2005</a>. The presentation follows the standard pattern of presenting goals, theories, definitions, and assumptions. For readers that would like a more bottom up approach, they can start reading the instance models in <a href=#Sec:IMs>Section: Instance Models</a> and trace back to find any additional information they require.
             </p>
             <p class="paragraph">
               The goal statements (<a href=#Sec:GoalStmt>Section: Goal Statements</a>) are refined to the theoretical models and the theoretical models (<a href=#Sec:TMs>Section: Theoretical Models</a>) to the instance models (<a href=#Sec:IMs>Section: Instance Models</a>). The instance models to be solved are referred to as <a href=#IM:eBalanceOnWtr>IM: eBalanceOnWtr</a>, <a href=#IM:eBalanceOnPCM>IM: eBalanceOnPCM</a>, <a href=#IM:heatEInWtr>IM: heatEInWtr</a>, and <a href=#IM:heatEInPCM>IM: heatEInPCM</a>. The instance models provide the ordinary differential equations (ODEs) and algebraic equations that model the solar water heating systems incorporating PCM. SWHS solves these ODEs.
@@ -5716,23 +5716,13 @@
             </div>
           </li>
           <li>
-            <div id="dParnas1972">
-              [5]: Parnas, David L. "On the Criteria To Be Used in Decomposing Systems into Modules." <em>Communications of the ACM</em>, 1972. pp. 1053&ndash;1058. Print.
-            </div>
-          </li>
-          <li>
             <div id="parnasClements1986">
-              [6]: Parnas, David L. and Clements, P. C. "A rational design process: How and why to fake it." <em>IEEE Transactions on Software Engineering</em>, vol. 12, no. 2, Washington, USA: February, 1986. pp. 251&ndash;257. Print.
-            </div>
-          </li>
-          <li>
-            <div id="parnasClements1984">
-              [7]: Parnas, David L., Clements, P. C., and Wiess. "The Modular Structure of Complex Systems." <em>ICSE '84: Proceedings of the 7th international conference on Software engineering</em>. 1984. pp. 408&ndash;417.
+              [5]: Parnas, David L. and Clements, P. C. "A rational design process: How and why to fake it." <em>IEEE Transactions on Software Engineering</em>, vol. 12, no. 2, Washington, USA: February, 1986. pp. 251&ndash;257. Print.
             </div>
           </li>
           <li>
             <div id="smithLai2005">
-              [8]: Smith, W. Spencer and Lai, Lei. "A new requirements template for scientific computing." <em>Proceedings of the First International Workshop on Situational Requirements Engineering Processes - Methods, Techniques and Tools to Support Situation-Specific Requirements Engineering Processes, SREP'05</em>. Edited by PJ Agerfalk, N. Kraiem, and J. Ralyte, Paris, France: 2005. pp. 107&ndash;121. In conjunction with 13th IEEE International Requirements Engineering Conference,
+              [6]: Smith, W. Spencer and Lai, Lei. "A new requirements template for scientific computing." <em>Proceedings of the First International Workshop on Situational Requirements Engineering Processes - Methods, Techniques and Tools to Support Situation-Specific Requirements Engineering Processes, SREP'05</em>. Edited by PJ Agerfalk, N. Kraiem, and J. Ralyte, Paris, France: 2005. pp. 107&ndash;121. In conjunction with 13th IEEE International Requirements Engineering Conference,
             </div>
           </li>
         </ul>


### PR DESCRIPTION
A little while ago I noticed a few of the examples (GamePhysics, SWHS, and, by extension, NoPCM) had the wrong references in the "Organization of Document" section. 

It looks like this has been the case for at least two years. It was a quick fix. I've included @smiths on this PR as stable has changed.

The "Organization of Document" section looks pretty standard (with some holes) between all the examples. Perhaps this is a good candidate for being moved into `drasil-docLang` (possibly with help from a multiple pass to extract the relevant sections), similar to #2116? 