### PR TITLE
Only provide links to actual examples on website

### DIFF
--- a/code/Makefile
+++ b/code/Makefile
@@ -36,6 +36,9 @@ GOOLTEST_DIR = GOOLTest
 
 MULTI_SRC_DIRS = $(PROJECTILE_DIR) # Directories for examples with multiple src versions
 
+EXAMPLE_DIRS = $(MULTI_SRC_DIRS) $(HGHC_DIR) $(GLASSBR_DIR) $(NOPCM_DIR) \
+  $(SWHS_DIR) $(SSP_DIR) $(GAMEPHYSICS_DIR) # All example directories
+
 # and the name of their executables
 HGHC_EXE  = hghc
 GLASSBR_EXE = glassbr
@@ -196,7 +199,8 @@ deploy_code_path: $(DCP_EXAMPLES)
 deploy_lite:
 	@mkdir -p "$(DEPLOY_FOLDER)"
 	@BUILD_FOLDER="$(BUILD_FOLDER)" DEPLOY_FOLDER="$(DEPLOY_FOLDER)" GRAPH_FOLDER="$(GRAPH_FOLDER)" \
-	MULTI_SRC_DIRS="$(MULTI_SRC_DIRS)" DEPLOY_CODE_PATH_KV_SEP="$(DEPLOY_CODE_PATH_KV_SEP)" MAKE="$(MAKE)" "$(SHELL)" "$(SCRIPT_FOLDER)"deploy_stage.sh
+	EXAMPLE_DIRS="$(EXAMPLE_DIRS)" MULTI_SRC_DIRS="$(MULTI_SRC_DIRS)" \
+	DEPLOY_CODE_PATH_KV_SEP="$(DEPLOY_CODE_PATH_KV_SEP)" MAKE="$(MAKE)" "$(SHELL)" "$(SCRIPT_FOLDER)"deploy_stage.sh
 
 # This rule is for use with developing deployment layout locally. As part of it, it ensures all needed
 # dependencies exist. One of the downsides is we ensure all files are re-generated which means the TeX

--- a/code/scripts/deploy_stage.sh
+++ b/code/scripts/deploy_stage.sh
@@ -18,6 +18,11 @@ if [ -z "$MULTI_SRC_DIRS" ]; then
   exit 1
 fi
 
+if [ -z "$EXAMPLE_DIRS" ]; then
+  echo "Missing EXAMPLE_DIRS."
+  exit 1
+fi
+
 if [ -z "$DEPLOY_CODE_PATH_KV_SEP" ]; then
   echo "Missing DEPLOY_CODE_PATH_KV_SEP."
   exit 1
@@ -67,34 +72,37 @@ copy_examples() {
   fi
   for example in "$CUR_DIR$BUILD_FOLDER"*; do
     example_name=$(basename "$example")
-    mkdir -p "$EXAMPLE_DEST$example_name/$SRS_DEST"
-    if [ -d "$example/"SRS ]; then
-      cp "$example/"SRS/*.pdf "$EXAMPLE_DEST$example_name/$SRS_DEST"
-    fi
-    if [ -d "$example/"Website/ ]; then
-      cp -r "$example/"Website/. "$EXAMPLE_DEST$example_name/$SRS_DEST"
-    fi
-    if [ -d "$example/"src ]; then
-      mkdir -p "$EXAMPLE_DEST$example_name/$DOX_DEST"
-      for lang in "$example/"src/*; do
-        lang_name=$(basename "$lang")
-        mkdir -p "$EXAMPLE_DEST$example_name/$DOX_DEST$lang_name"
-        cp -r "$lang/"html/. "$EXAMPLE_DEST$example_name/$DOX_DEST$lang_name/"
-      done
-      src_stub
-    fi
-    # For examples with multiple versions, directory structure is different
-    if [[ "$MULTI_SRC_DIRS" == *"$example_name"* ]]; then
-      for v in "$example/$example_name"*/; do
-        v_name=$(basename "$v")
-        mkdir -p "$EXAMPLE_DEST$example_name/$DOX_DEST$v_name/"
-        for lang in "$v/"src/*; do
+    # Only copy actual examples
+    if [[ "$EXAMPLE_DIRS" == *"$example_name"* ]]; then
+      mkdir -p "$EXAMPLE_DEST$example_name/$SRS_DEST"
+      if [ -d "$example/"SRS ]; then
+        cp "$example/"SRS/*.pdf "$EXAMPLE_DEST$example_name/$SRS_DEST"
+      fi
+      if [ -d "$example/"Website/ ]; then
+        cp -r "$example/"Website/. "$EXAMPLE_DEST$example_name/$SRS_DEST"
+      fi
+      if [ -d "$example/"src ]; then
+        mkdir -p "$EXAMPLE_DEST$example_name/$DOX_DEST"
+        for lang in "$example/"src/*; do
           lang_name=$(basename "$lang")
-          mkdir -p "$EXAMPLE_DEST$example_name/$DOX_DEST$v_name/$lang_name"
-          cp -r "$lang/"html/. "$EXAMPLE_DEST$example_name/$DOX_DEST$v_name/$lang_name/"
+          mkdir -p "$EXAMPLE_DEST$example_name/$DOX_DEST$lang_name"
+          cp -r "$lang/"html/. "$EXAMPLE_DEST$example_name/$DOX_DEST$lang_name/"
         done
-      done
-      src_stub
+        src_stub
+      fi
+      # For examples with multiple versions, directory structure is different
+      if [[ "$MULTI_SRC_DIRS" == *"$example_name"* ]]; then
+        for v in "$example/$example_name"*/; do
+          v_name=$(basename "$v")
+          mkdir -p "$EXAMPLE_DEST$example_name/$DOX_DEST$v_name/"
+          for lang in "$v/"src/*; do
+            lang_name=$(basename "$lang")
+            mkdir -p "$EXAMPLE_DEST$example_name/$DOX_DEST$v_name/$lang_name"
+            cp -r "$lang/"html/. "$EXAMPLE_DEST$example_name/$DOX_DEST$v_name/$lang_name/"
+          done
+        done
+        src_stub
+      fi
     fi
     src_stub() {
       # We don't expose code in deploy. It's more conveneient to link to GitHub's directory


### PR DESCRIPTION
I noticed that the section of the website that provides links to the generated artifacts for each example had a "GOOLTest" heading with no links, which must have been added when I incorporated my GOOL tests into the build. This PR updates the Makefile and deploy script so that only actual examples are shown on the website.

Though the empty "Template" is currently showing on the website, I didn't include it as an example, so it will be removed from the website after this PR. I assume this is what we want, but correct me if I'm wrong, and I will change it.