### PR TITLE
Improve error message for when output cannot be computed 

### DIFF
--- a/code/drasil-code/Language/Drasil/CodeSpec.hs
+++ b/code/drasil-code/Language/Drasil/CodeSpec.hs
@@ -22,7 +22,7 @@ import Language.Drasil.Mod (Func(..), FuncData(..), FuncDef(..), Mod(..), Name)
 import GOOL.Drasil (CodeType)
 
 import Control.Lens ((^.))
-import Data.List (nub, (\\))
+import Data.List (intercalate, nub, (\\))
 import qualified Data.Map as Map
 import Data.Maybe (mapMaybe)
 
@@ -253,10 +253,12 @@ getExecOrder d k' n' sm  = getExecOrder' [] d k' (n' \\ k')
               kNew = k ++ cnew
               nNew = n \\ cnew
           in  if null new 
-              then error ("Cannot find path from inputs to outputs: " ++
-                        show (map (^. uid) n)
-                        ++ " given Defs as " ++ show (map (^. uid) defs')
-                        ++ " and Knowns as " ++ show (map (^. uid) k))
+              then error ("The following outputs cannot be computed: " ++
+                       intercalate ", " (map (^. uid) n) ++ "\n"
+                     ++ "Unused definitions are: " 
+                       ++ intercalate ", " (map (^. uid) defs') ++ "\n"
+                     ++ "Known values are: " 
+                       ++ intercalate ", " (map (^. uid) k))
               else getExecOrder' (ord ++ new) (defs' \\ new) kNew nNew
 
 subsetOf :: (Eq a) => [a] -> [a] -> Bool


### PR DESCRIPTION
Small PR, just improves an error message in the code generator for when a path from inputs to outputs cannot be found. The new error message has line breaks so it is easier to read and is (in my opinion) more clear.