### PR TITLE
Move Choices to own module, add documentation

### DIFF
--- a/code/drasil-code/Language/Drasil/Choices.hs
+++ b/code/drasil-code/Language/Drasil/Choices.hs
@@ -1,0 +1,166 @@
+module Language.Drasil.Choices (
+  Choices(..), Modularity(..), InputModule(..), inputModule, Structure(..), 
+  ConstantStructure(..), ConstantRepr(..), MatchedConceptMap, CodeConcept(..), 
+  matchConcepts, SpaceMatch, MatchedSpaces, matchSpaces, ImplementationType(..),
+  ConstraintBehaviour(..), Comments(..), Verbosity(..), Visibility(..), 
+  Logging(..), AuxFile(..), getSampleData, hasSampleInput, defaultChoices
+) where
+
+import Language.Drasil
+
+import Language.Drasil.Code.Code (spaceToCodeType)
+import Language.Drasil.Code.Lang (Lang(..))
+import Language.Drasil.Data.ODEInfo (ODEInfo)
+import Language.Drasil.Data.ODELibPckg (ODELibPckg)
+
+import GOOL.Drasil (CodeType)
+
+import Control.Lens ((^.))
+import Data.Map (Map, fromList)
+
+data Choices = Choices {
+-- Global design choices (affect entire program)
+  -- Target languages
+  -- Choosing multiple means program will be generated in multiple languages
+  lang :: [Lang],
+  -- How the program should be modularized
+  modularity :: Modularity,
+  -- Structure of inputs (bundled or not)
+  inputStructure :: Structure,
+  -- Structure of constants (inlined or bundled or not, or stored with inputs)
+  constStructure :: ConstantStructure,
+  -- Representation of constants (as variables or as constants)
+  constRepr :: ConstantRepr,
+  -- Map of UIDs for Drasil concepts to code concepts
+  -- Matching a UID to a code concept means the code concept should be used
+  -- instead of the chunk associated with the UID
+  conceptMatch :: ConceptMatchMap,
+  -- Map of Spaces to CodeTypes
+  -- Matching a Space to a CodeType means values of the Space should have that
+  -- CodeType in the generated code.
+  spaceMatch :: SpaceMatch,
+-- Local design choices (affect one part of program)
+  -- Implementation type, program or library
+  impType :: ImplementationType,
+  -- Preferentially-ordered list ODE libraries to try
+  odeLib :: [ODELibPckg],
+  -- FIXME: ODEInfos should be automatically built from Instance models when 
+  -- needed, but we can't do that yet so I'm passing it through Choices instead.
+  -- This choice should really just be for an ODEMethod
+  odes :: [ODEInfo],
+  -- Constraint violation behaviour. Exception or Warning.
+  onSfwrConstraint :: ConstraintBehaviour,
+  onPhysConstraint :: ConstraintBehaviour,
+-- Features that can be toggled on on off
+  -- Turns Doxygen comments for different code structures on or off
+  comments :: [Comments],
+  -- Standard output from running Doxygen: verbose or quiet?
+  doxVerbosity :: Verbosity,
+  -- Turns date field on or off in the generated module-level Doxygen comments
+  dates :: Visibility,
+  -- Turns different forms of logging on or off
+  logging :: [Logging],
+  -- Name of log file
+  logFile :: FilePath,
+  -- Turns generation of different auxiliary (non-source-code) files on or off
+  auxFiles :: [AuxFile]
+}
+
+data Modularity = Modular InputModule | Unmodular
+
+data InputModule = Combined -- Input-related functions combined in one module
+                 | Separated -- Input-related functions each in own module  
+
+inputModule :: Choices -> InputModule
+inputModule c = inputModule' $ modularity c
+  where inputModule' Unmodular = Combined
+        inputModule' (Modular im) = im
+                 
+data Structure = Unbundled -- Individual variables
+               | Bundled -- Variables bundled in a class
+
+data ConstantStructure = Inline -- Inline values for constants
+                       | WithInputs -- Store constants with inputs
+                       | Store Structure -- Store constants separately from 
+                                         -- inputs, whether bundled or unbundled
+
+data ConstantRepr = Var | Const
+
+type ConceptMatchMap = Map UID [CodeConcept]
+type MatchedConceptMap = Map UID CodeConcept
+
+-- Currently we only support one code concept, more will be added later
+data CodeConcept = Pi
+
+matchConcepts :: (HasUID c) => [(c, [CodeConcept])] -> ConceptMatchMap
+matchConcepts = fromList . map (\(cnc,cdc) -> (cnc ^. uid, cdc))
+
+type SpaceMatch = Space -> [CodeType]
+type MatchedSpaces = Space -> CodeType
+
+matchSpace :: Space -> [CodeType] -> SpaceMatch -> SpaceMatch
+matchSpace _ [] _ = error "Must match each Space to at least one CodeType"
+matchSpace s ts sm = \sp -> if sp == s then ts else sm sp
+
+matchSpaces :: [(Space, [CodeType])] -> SpaceMatch
+matchSpaces spMtchs = matchSpaces' spMtchs spaceToCodeType 
+  where matchSpaces' ((s,ct):sms) sm = matchSpaces' sms $ matchSpace s ct sm
+        matchSpaces' [] sm = sm
+
+data ImplementationType = Library
+                        | Program
+                        
+data ConstraintBehaviour = Warning -- Print warning when constraint violated
+                         | Exception -- Throw exception when constraint violated
+        
+data Comments = CommentFunc -- Function/method-level comments
+              | CommentClass -- class-level comments
+              | CommentMod -- File/Module-level comments
+              deriving Eq
+
+data Verbosity = Verbose | Quiet
+
+data Visibility = Show
+                | Hide
+
+-- Eq instances required for Logging and Comments because generator needs to 
+-- check membership of these elements in lists
+data Logging = LogFunc -- Log messages generated for function calls
+             | LogVar -- Log messages generated for variable assignments
+             deriving Eq
+
+-- Currently we only support one kind of auxiliary file: sample input file
+-- To generate a sample input file compatible with the generated program
+-- FilePath is the path to the user-provided file containing a sample set of input data
+newtype AuxFile = SampleInput FilePath deriving Eq
+
+getSampleData :: Choices -> Maybe FilePath
+getSampleData chs = getSampleData' (auxFiles chs)
+  where getSampleData' [] = Nothing
+        getSampleData' (SampleInput fp:_) = Just fp
+
+hasSampleInput :: [AuxFile] -> Bool
+hasSampleInput [] = False
+hasSampleInput (SampleInput _:_) = True
+
+defaultChoices :: Choices
+defaultChoices = Choices {
+  lang = [Python],
+  modularity = Modular Combined,
+  impType = Program,
+  logFile = "log.txt",
+  logging = [],
+  comments = [],
+  doxVerbosity = Verbose,
+  dates = Hide,
+  onSfwrConstraint = Exception,
+  onPhysConstraint = Warning,
+  inputStructure = Bundled,
+  constStructure = Inline,
+  constRepr = Const,
+  conceptMatch = matchConcepts ([] :: [(QDefinition, [CodeConcept])]),
+  spaceMatch = spaceToCodeType, 
+  auxFiles = [],
+  odeLib = [],
+  odes = []
+}

--- a/code/drasil-code/Language/Drasil/Code.hs
+++ b/code/drasil-code/Language/Drasil/Code.hs
@@ -4,12 +4,12 @@ module Language.Drasil.Code (
   makeCode, createCodeFiles, 
   generator, generateCode,
   readWithDataDesc, sampleInputDD,
-  Choices(..), CodeSpec(..), Comments(..), Verbosity(..), 
-  ConstraintBehaviour(..), ImplementationType(..), Logging(..), 
-  Modularity(..), Structure(..), ConstantStructure(..), ConstantRepr(..), 
-  InputModule(..), CodeConcept(..), matchConcepts, SpaceMatch, matchSpaces, 
-  AuxFile(..), getSampleData, Visibility(..), defaultChoices, funcUID, 
-  funcUID', asVC, asVC', codeSpec, relToQD,
+  Choices(..), Comments(..), Verbosity(..), ConstraintBehaviour(..), 
+  ImplementationType(..), Logging(..), Modularity(..), Structure(..), 
+  ConstantStructure(..), ConstantRepr(..), InputModule(..), CodeConcept(..), 
+  matchConcepts, SpaceMatch, matchSpaces, AuxFile(..), getSampleData, 
+  Visibility(..), defaultChoices, 
+  CodeSpec(..), funcUID, funcUID', asVC, asVC', codeSpec, relToQD,
   ($:=), Mod(Mod), StateVariable, Func, FuncStmt(..), pubStateVar, 
   privStateVar, fDecDef, ffor, funcData, funcDef, packmod,
   junkLine, multiLine, repeated, singleLine, singleton,
@@ -83,12 +83,13 @@ import Language.Drasil.Code.ExternalLibraryCall (ExternalLibraryCall,
 
 import Language.Drasil.Code.Lang (Lang(..))
 
-import Language.Drasil.CodeSpec (Choices(..), CodeSpec(..), Comments(..), 
-  Verbosity(..), ConstraintBehaviour(..), ImplementationType(..), Logging(..), 
-  Modularity(..), Structure(..), ConstantStructure(..), ConstantRepr(..), 
-  InputModule(..), CodeConcept(..), matchConcepts, SpaceMatch, matchSpaces, 
-  AuxFile(..), getSampleData, Visibility(..), defaultChoices, funcUID, 
-  funcUID', asVC, asVC', codeSpec, relToQD)
+import Language.Drasil.Choices (Choices(..), Comments(..), Verbosity(..), 
+  ConstraintBehaviour(..), ImplementationType(..), Logging(..), Modularity(..), 
+  Structure(..), ConstantStructure(..), ConstantRepr(..), InputModule(..), 
+  CodeConcept(..), matchConcepts, SpaceMatch, matchSpaces, AuxFile(..), 
+  getSampleData, Visibility(..), defaultChoices,)
+import Language.Drasil.CodeSpec (CodeSpec(..), funcUID, funcUID', asVC, asVC', 
+  codeSpec, relToQD)
 import Language.Drasil.Mod (($:=), Mod(Mod), StateVariable, Func, FuncStmt(..), 
   pubStateVar, privStateVar, fDecDef, ffor, funcData, funcDef, packmod)
 

--- a/code/drasil-code/Language/Drasil/Code/Imperative/Build/Import.hs
+++ b/code/drasil-code/Language/Drasil/Code/Imperative/Build/Import.hs
@@ -2,7 +2,7 @@ module Language.Drasil.Code.Imperative.Build.Import (
   makeBuild
 ) where
 
-import Language.Drasil.CodeSpec (Comments)
+import Language.Drasil.Choices (Comments)
 import Language.Drasil.Code.Imperative.Build.AST (asFragment, 
   BuildConfig(BuildConfig), BuildDependencies(..), Ext(..), includeExt, 
   NameOpts, nameOpts, packSep, Runnable(Runnable), BuildName(..), RunType(..))

--- a/code/drasil-code/Language/Drasil/Code/Imperative/ConceptMatch.hs
+++ b/code/drasil-code/Language/Drasil/Code/Imperative/ConceptMatch.hs
@@ -2,8 +2,7 @@ module Language.Drasil.Code.Imperative.ConceptMatch (
   chooseConcept, conceptToGOOL
 ) where
 
-import Language.Drasil.CodeSpec (Choices(..), CodeConcept(..), 
-  MatchedConceptMap)
+import Language.Drasil.Choices (Choices(..), CodeConcept(..), MatchedConceptMap)
 
 import GOOL.Drasil (SValue, OOProg, MathConstant(..))
 

--- a/code/drasil-code/Language/Drasil/Code/Imperative/Descriptions.hs
+++ b/code/drasil-code/Language/Drasil/Code/Imperative/Descriptions.hs
@@ -12,8 +12,9 @@ import Utils.Drasil (stringList)
 import Language.Drasil
 import Language.Drasil.Code.Imperative.DrasilState (DrasilState(..), inMod)
 import Language.Drasil.Chunk.Code (CodeIdea(codeName), quantvar)
-import Language.Drasil.CodeSpec (CodeSpec(..), ImplementationType(..), 
-  InputModule(..), Structure(..))
+import Language.Drasil.Choices (ImplementationType(..), InputModule(..), 
+  Structure(..))
+import Language.Drasil.CodeSpec (CodeSpec(..))
 import Language.Drasil.Mod (Description)
 
 import Data.Map (member)

--- a/code/drasil-code/Language/Drasil/Code/Imperative/Doxygen/Import.hs
+++ b/code/drasil-code/Language/Drasil/Code/Imperative/Doxygen/Import.hs
@@ -6,7 +6,7 @@ import Utils.Drasil (blank)
 
 import GOOL.Drasil (GOOLState, headers, mainMod)
 
-import Language.Drasil.CodeSpec (Verbosity(..))
+import Language.Drasil.Choices (Verbosity(..))
 
 import Data.List (intersperse, nub)
 import Data.Maybe (maybeToList)

--- a/code/drasil-code/Language/Drasil/Code/Imperative/DrasilState.hs
+++ b/code/drasil-code/Language/Drasil/Code/Imperative/DrasilState.hs
@@ -8,11 +8,12 @@ import GOOL.Drasil (ScopeTag(..))
 
 import Language.Drasil.Chunk.Code (codeName)
 import Language.Drasil.Code.ExtLibImport (ExtLibState)
+import Language.Drasil.Choices (Choices(..), AuxFile, Modularity(..), 
+  ImplementationType(..), Comments, Verbosity, MatchedConceptMap, 
+  MatchedSpaces, ConstantRepr, ConstantStructure(..), ConstraintBehaviour, 
+  InputModule(..), Logging, Structure(..), inputModule)
 import Language.Drasil.CodeSpec (Input, Const, Derived, Output, Def, 
-  Choices(..), AuxFile, CodeSpec(..), Modularity(..), ImplementationType(..), 
-  Comments, Verbosity, MatchedConceptMap, MatchedSpaces, ConstantRepr, 
-  ConstantStructure(..), ConstraintBehaviour, InputModule(..), Logging, 
-  Structure(..), getConstraints, inputModule)
+  CodeSpec(..),  getConstraints)
 import Language.Drasil.Mod (Mod(..), Name, Class(..), StateVariable(..), fname)
 
 import Data.List (nub)

--- a/code/drasil-code/Language/Drasil/Code/Imperative/GOOL/ClassInterface.hs
+++ b/code/drasil-code/Language/Drasil/Code/Imperative/GOOL/ClassInterface.hs
@@ -8,7 +8,7 @@ module Language.Drasil.Code.Imperative.GOOL.ClassInterface (
 import Language.Drasil (Expr)
 import Database.Drasil (ChunkDB)
 import Language.Drasil.Code.DataDesc (DataDesc)
-import Language.Drasil.CodeSpec (Comments, ImplementationType, Verbosity)
+import Language.Drasil.Choices (Comments, ImplementationType, Verbosity)
 
 import GOOL.Drasil (ProgData, GOOLState)
 

--- a/code/drasil-code/Language/Drasil/Code/Imperative/GOOL/LanguageRenderer/CSharpRenderer.hs
+++ b/code/drasil-code/Language/Drasil/Code/Imperative/GOOL/LanguageRenderer/CSharpRenderer.hs
@@ -6,7 +6,7 @@ module Language.Drasil.Code.Imperative.GOOL.LanguageRenderer.CSharpRenderer (
   CSharpProject(..)
 ) where
 
-import Language.Drasil.CodeSpec (ImplementationType(..))
+import Language.Drasil.Choices (ImplementationType(..))
 import Language.Drasil.Code.Imperative.GOOL.ClassInterface (PackageSym(..), 
   AuxiliarySym(..))
 import qualified 

--- a/code/drasil-code/Language/Drasil/Code/Imperative/GOOL/LanguageRenderer/CppRenderer.hs
+++ b/code/drasil-code/Language/Drasil/Code/Imperative/GOOL/LanguageRenderer/CppRenderer.hs
@@ -7,7 +7,7 @@ module Language.Drasil.Code.Imperative.GOOL.LanguageRenderer.CppRenderer (
   CppProject(..)
 ) where
 
-import Language.Drasil.CodeSpec (ImplementationType(..))
+import Language.Drasil.Choices (ImplementationType(..))
 import Language.Drasil.Code.Imperative.GOOL.ClassInterface (PackageSym(..),
   AuxiliarySym(..))
 import qualified 

--- a/code/drasil-code/Language/Drasil/Code/Imperative/GOOL/LanguageRenderer/JavaRenderer.hs
+++ b/code/drasil-code/Language/Drasil/Code/Imperative/GOOL/LanguageRenderer/JavaRenderer.hs
@@ -6,7 +6,7 @@ module Language.Drasil.Code.Imperative.GOOL.LanguageRenderer.JavaRenderer (
   JavaProject(..)
 ) where
 
-import Language.Drasil.CodeSpec (ImplementationType(..))
+import Language.Drasil.Choices (ImplementationType(..))
 import Language.Drasil.Code.Imperative.GOOL.ClassInterface (PackageSym(..), 
   AuxiliarySym(..))
 import qualified 

--- a/code/drasil-code/Language/Drasil/Code/Imperative/GOOL/LanguageRenderer/LanguagePolymorphic.hs
+++ b/code/drasil-code/Language/Drasil/Code/Imperative/GOOL/LanguageRenderer/LanguagePolymorphic.hs
@@ -9,7 +9,7 @@ import Database.Drasil (ChunkDB)
 
 import GOOL.Drasil (ProgData, GOOLState)
 
-import Language.Drasil.CodeSpec (Comments, ImplementationType(..), Verbosity)
+import Language.Drasil.Choices (Comments, ImplementationType(..), Verbosity)
 import Language.Drasil.Code.DataDesc (DataDesc)
 import Language.Drasil.Code.Imperative.Doxygen.Import (makeDoxConfig)
 import Language.Drasil.Code.Imperative.Build.AST (BuildConfig, Runnable)

--- a/code/drasil-code/Language/Drasil/Code/Imperative/GenerateGOOL.hs
+++ b/code/drasil-code/Language/Drasil/Code/Imperative/GenerateGOOL.hs
@@ -6,7 +6,8 @@ module Language.Drasil.Code.Imperative.GenerateGOOL (ClassType(..),
 import Language.Drasil
 import Language.Drasil.Code.Imperative.DrasilState (DrasilState(..))
 import Language.Drasil.Code.Imperative.GOOL.ClassInterface (AuxiliarySym(..))
-import Language.Drasil.CodeSpec (CodeSpec(..), Comments(..))
+import Language.Drasil.Choices (Comments(..))
+import Language.Drasil.CodeSpec (CodeSpec(..))
 import Language.Drasil.Mod (Name, Description, Import)
   
 import GOOL.Drasil (SFile, VSType, SVariable, SValue, MSStatement, SMethod, 

--- a/code/drasil-code/Language/Drasil/Code/Imperative/Generator.hs
+++ b/code/drasil-code/Language/Drasil/Code/Imperative/Generator.hs
@@ -24,8 +24,8 @@ import Language.Drasil.Code.Imperative.GOOL.Data (PackData(..))
 import Language.Drasil.Code.CodeGeneration (createCodeFiles, makeCode)
 import Language.Drasil.Code.ExtLibImport (auxMods, imports, modExports)
 import Language.Drasil.Code.Lang (Lang(..))
-import Language.Drasil.CodeSpec (CodeSpec(..), Choices(..), Modularity(..), 
-  Visibility(..))
+import Language.Drasil.Choices (Choices(..), Modularity(..), Visibility(..))
+import Language.Drasil.CodeSpec (CodeSpec(..))
 
 import GOOL.Drasil (GSProgram, SFile, OOProg, ProgramSym(..), ScopeTag(..), 
   ProgData(..), initialState, unCI)

--- a/code/drasil-code/Language/Drasil/Code/Imperative/Import.hs
+++ b/code/drasil-code/Language/Drasil/Code/Imperative/Import.hs
@@ -21,8 +21,9 @@ import Language.Drasil.Chunk.Code (CodeIdea(codeName), CodeVarChunk, obv,
 import Language.Drasil.Chunk.CodeDefinition (codeEquat)
 import Language.Drasil.Chunk.Parameter (ParameterChunk(..), PassBy(..), pcAuto)
 import Language.Drasil.Code.CodeQuantityDicts (inFileName, inParams, consts)
-import Language.Drasil.CodeSpec (CodeSpec(..), Comments(..),
-  ConstantRepr(..), ConstantStructure(..), Structure(..))
+import Language.Drasil.Choices (Comments(..), ConstantRepr(..),
+  ConstantStructure(..), Structure(..))
+import Language.Drasil.CodeSpec (CodeSpec(..))
 import Language.Drasil.Code.DataDesc (DataItem, LinePattern(Repeat, Straight), 
   Data(Line, Lines, JunkData, Singleton), DataDesc, isLine, isLines, getInputs,
   getPatternInputs)

--- a/code/drasil-code/Language/Drasil/Code/Imperative/Logging.hs
+++ b/code/drasil-code/Language/Drasil/Code/Imperative/Logging.hs
@@ -3,7 +3,7 @@ module Language.Drasil.Code.Imperative.Logging (
 ) where
 
 import Language.Drasil.Code.Imperative.DrasilState (DrasilState(..))
-import Language.Drasil.CodeSpec hiding (codeSpec)
+import Language.Drasil.Choices (Logging(..))
 
 import GOOL.Drasil (Label, MSBody, MSBlock, SVariable, SValue, MSStatement, 
   OOProg, BodySym(..), BlockSym(..), TypeSym(..), VariableSym(..), 

--- a/code/drasil-code/Language/Drasil/Code/Imperative/Modules.hs
+++ b/code/drasil-code/Language/Drasil/Code/Imperative/Modules.hs
@@ -33,10 +33,10 @@ import Language.Drasil.Chunk.Parameter (pcAuto)
 import Language.Drasil.Code.CodeQuantityDicts (inFileName, inParams, consts)
 import Language.Drasil.Code.DataDesc (DataDesc, junkLine, singleton)
 import Language.Drasil.Code.ExtLibImport (defs, imports, steps)
-import Language.Drasil.CodeSpec (CodeSpec(..), Comments(CommentFunc), 
-  ConstantStructure(..), ConstantRepr(..), ConstraintBehaviour(..), 
-  ImplementationType(..), InputModule(..), Logging(..), Structure(..), 
-  hasSampleInput)
+import Language.Drasil.Choices (Comments(..), ConstantStructure(..), 
+  ConstantRepr(..), ConstraintBehaviour(..), ImplementationType(..), 
+  InputModule(..), Logging(..), Structure(..), hasSampleInput)
+import Language.Drasil.CodeSpec (CodeSpec(..))
 import Language.Drasil.Printers (Linearity(Linear), exprDoc)
 
 import GOOL.Drasil (SFile, MSBody, MSBlock, SVariable, SValue, MSStatement, 

--- a/code/drasil-code/Language/Drasil/Code/Imperative/Parameters.hs
+++ b/code/drasil-code/Language/Drasil/Code/Imperative/Parameters.hs
@@ -10,8 +10,9 @@ import Language.Drasil.Chunk.Code (CodeVarChunk, CodeIdea(codeChunk, codeName),
 import Language.Drasil.Chunk.CodeDefinition (CodeDefinition, auxExprs, 
   codeEquat)
 import Language.Drasil.Code.CodeQuantityDicts (inFileName, inParams, consts)
-import Language.Drasil.CodeSpec (CodeSpec(..), Structure(..), InputModule(..), 
-  ConstantStructure(..), ConstantRepr(..), constraintvars, getConstraints)
+import Language.Drasil.Choices (Structure(..), InputModule(..), 
+  ConstantStructure(..), ConstantRepr(..))
+import Language.Drasil.CodeSpec (CodeSpec(..), constraintvars, getConstraints)
 import Language.Drasil.Mod (Name)
 
 import Data.List (nub, (\\), delete)

--- a/code/drasil-code/Language/Drasil/Code/Imperative/SpaceMatch.hs
+++ b/code/drasil-code/Language/Drasil/Code/Imperative/SpaceMatch.hs
@@ -2,7 +2,7 @@ module Language.Drasil.Code.Imperative.SpaceMatch (
   chooseSpace
 ) where
 
-import Language.Drasil.CodeSpec (Choices(..), MatchedSpaces)
+import Language.Drasil.Choices (Choices(..), MatchedSpaces)
 import Language.Drasil.Code.Lang (Lang(..))
 
 import GOOL.Drasil (CodeType(..))

--- a/code/drasil-code/drasil-code.cabal
+++ b/code/drasil-code/drasil-code.cabal
@@ -49,6 +49,7 @@ library
     , Language.Drasil.Code.CodeGeneration
     , Language.Drasil.Data.ODEInfo
     , Language.Drasil.Data.ODELibPckg
+    , Language.Drasil.Choices
     , Language.Drasil.CodeExpr
     , Language.Drasil.CodeSpec
     , Language.Drasil.Mod
@@ -124,6 +125,7 @@ executable codegenTest
     , Language.Drasil.Code.CodeGeneration
     , Language.Drasil.Data.ODEInfo
     , Language.Drasil.Data.ODELibPckg
+    , Language.Drasil.Choices
     , Language.Drasil.CodeExpr
     , Language.Drasil.CodeSpec
     , Language.Drasil.Mod


### PR DESCRIPTION
`Choices` and `CodeSpec` were defined in the same module. This PR moves `Choices` to its own module and documents it. 