### PR TITLE
Stack Updates

### DIFF
--- a/code/Makefile
+++ b/code/Makefile
@@ -76,7 +76,7 @@ ALL_EXPANDED_TARGETS = $(foreach P, $(PACKAGE_GEN_TARGET), $($(P)_PACKAGES)) $(f
 # make variables/configuration
 DIFF = diff --strip-trailing-cr -r -X ../.gitignore -x '*.txt'
 LOG_SUFFIX = _log.log
-MIN_STACK_VER = 1.9.1  # Version which adds --interleaved-output flag
+MIN_STACK_VER = 2.3.1  # Match stack.yaml see PR #2142 for more info.
 CACHED_MSV_FILE = .drasil-min-stack-ver
 DF_DIR = datafiles/
 BUILD_FOLDER_NAME = build

--- a/code/website/stack.yaml
+++ b/code/website/stack.yaml
@@ -39,7 +39,8 @@ packages:
 - .
 # Dependency packages to be pulled from upstream that are not in the resolver
 # (e.g., acme-missiles-0.3)
-# extra-deps: []
+extra-deps:
+- hakyll-4.13.3.0@sha256:7d8903f03974691aec049a6188ace8d93457563bad9f078c6faf4c9156e27a33,8867  # Hakyll not in 14.27 LTS resolver
 
 # Override default flag values for local packages and extra-deps
 flags: 

--- a/code/website/stack.yaml
+++ b/code/website/stack.yaml
@@ -15,7 +15,7 @@
 # resolver:
 #  name: custom-snapshot
 #  location: "./custom-snapshot.yaml"
-resolver: lts-12.25
+resolver: lts-14.27
 
 # User packages to be built.
 # Various formats can be used as shown in the example below.

--- a/code/website/website.cabal
+++ b/code/website/website.cabal
@@ -6,7 +6,7 @@ cabal-version:      >= 1.10
 executable site
   main-is:          site.hs
   build-depends:    base == 4.*
-                  , hakyll == 4.12.*
+                  , hakyll == 4.13.*
                   , directory >= 1.3.0.2
                   , MissingH >= 1.4.0
                   , filepath >= 1.4.1


### PR DESCRIPTION
This PR is two small stack related changes related to 340638bad523d7c7c5e2335fd66569a9f1985c25. 

1. Match the resolver used for the deploy site, uses its own YAML as its auxiliary and not regularly compiled with the rest of the project, with that of the project. The benefit of this is the dependencies will be the same version throughout and we're not using two different versions of GHC.

2. Update the minimum Stack version required in the Makefile. This change is for consistency. I though I may be able to remove the `check_stack.sh` script with the `required-stack-version` YAML flag, but if someone is on <1.9.1 then our `stack` command will fail with an "unknown argument" error. Of course this is bad and why the `check_stack.sh` script was added in the first place and is truly our minimum required Stack version. However, using `required-stack-version` in `stack.yaml` will cause stack invocations to fail if we're between 1.9.1 and 2.1.3. As such, I've updated our minimum version to 2.3.1 to prevent that case where someone with a pre-1.9.1 Stack tries to build, gets an error, updates to 1.9.1-2.1.3 (for some reason -- possibly dependency manager/OS related?) and gets another error message then requiring 2.3.1.