### PR TITLE
Update Stress to NormStress + Implement TangStress + Update Dependencies

### DIFF
--- a/code/drasil-example/Drasil/SSP/DataDefs.hs
+++ b/code/drasil-example/Drasil/SSP/DataDefs.hs
@@ -30,7 +30,7 @@ dataDefs = [intersliceWtrF, angleA, angleB, lengthB, lengthLb, lengthLs,
   slcHeight, normStressDD, tangStressDD, torqueDD, ratioVariation, convertFunc1, 
   convertFunc2, nrmForceSumDD, watForceSumDD, sliceHghtRightDD, sliceHghtLeftDD]
 
---DD4
+--DD intersliceWtrF: interslice normal water forces
 
 intersliceWtrF :: DataDefinition
 intersliceWtrF = dd intersliceWtrFQD [makeCite fredlund1977] Nothing "intersliceWtrF"
@@ -51,7 +51,7 @@ intersliceWtrFEqn = completeCase [case1,case2,case3]
 
         case3 = (0, inxi waterHght $<= inxi slipHght)
 
---DD5
+--DD angleA: base angles
 
 angleA :: DataDefinition
 angleA = dd angleAQD [makeCite fredlund1977] Nothing "angleA" 
@@ -70,7 +70,7 @@ angleANotes = foldlSent [S "This", phrase equation, S "is based on the",
   phrase assumption, S "that the base of a", phrase slice,
   S "is a straight line", sParen (makeRef2S assumpSBSBISL)]
 
---DD6
+--DD angleB: surface angles
 
 angleB :: DataDefinition
 angleB = dd angleBQD [makeCite fredlund1977] Nothing "angleB"
@@ -89,7 +89,7 @@ angleBNotes = foldlSent [S "This", phrase equation, S "is based on the",
   phrase assumption, S "that the surface of a", phrase slice,
   S "is a straight line", sParen (makeRef2S assumpSBSBISL)]
 
---DD7
+--DD lengthB: base width of slices
 
 lengthB :: DataDefinition
 lengthB = dd lengthBQD [makeCite fredlund1977] Nothing "lengthB" []--Notes
@@ -101,7 +101,7 @@ lengthBQD = mkQuantDef baseWthX lengthBEqn
 lengthBEqn :: Expr
 lengthBEqn = inxi slipDist - inx slipDist (-1)
 
---DD8
+--DD lengthLb: total base lengths of slices
 
 lengthLb :: DataDefinition
 lengthLb = dd lengthLbQD [makeCite fredlund1977] Nothing "lengthLb"
@@ -118,7 +118,7 @@ lengthLbNotes :: Sentence
 lengthLbNotes = foldlSent [ch baseWthX, S "is defined in", 
   makeRef2S lengthB `sAnd` ch baseAngle, S "is defined in", makeRef2S angleA]
 
---
+--DD lengthLs: surface lengths of slices
 
 lengthLs :: DataDefinition
 lengthLs = dd lengthLsQD [makeCite fredlund1977] Nothing "lengthLs"
@@ -136,7 +136,7 @@ lengthLsNotes = foldlSent [ch baseWthX, S "is defined in",
   makeRef2S lengthB `sAnd` ch surfAngle, S "is defined in", makeRef2S angleB]
   
 
---DD9
+--DD slcHeight: y-direction heights of slices
 
 slcHeight :: DataDefinition
 slcHeight = dd slcHeightQD [makeCite fredlund1977] Nothing "slcHeight"
@@ -156,7 +156,7 @@ slcHeightNotes = [S "This" +:+ phrase equation +:+ S "is based on the" +:+
   makeRef2S sliceHghtRightDD `sAnd` makeRef2S sliceHghtLeftDD `sC` 
   S "respectively."]
 
---DD10
+--DD normStress: total normal stress
 
 normStressDD :: DataDefinition
 normStressDD = dd normStressQD [makeCite huston2008] Nothing "normStress" []
@@ -167,7 +167,7 @@ normStressQD = mkQuantDef totNormStress normStressEqn
 normStressEqn :: Expr
 normStressEqn = sy fn / sy genericA
 
---DD11
+--DD tangStress: tangential stress
 
 tangStressDD :: DataDefinition
 tangStressDD = dd tangStressQD [makeCite huston2008] Nothing "tangStress" []
@@ -178,7 +178,7 @@ tangStressQD = mkQuantDef tangStress tangStressEqn
 tangStressEqn :: Expr
 tangStressEqn = sy ft / sy genericA
 
---DD12
+--DD ratioVariation: interslice normal to shear force ratio variation function
 
 ratioVariation :: DataDefinition
 ratioVariation = dd ratioVarQD [makeCite fredlund1977] Nothing 
@@ -194,7 +194,7 @@ ratioVarEqn = completeCase [case1, case2]
         case2 = (sin (sy QM.pi_ * ((inxi slipDist - idx (sy slipDist) 0) /
                 (indxn slipDist - idx (sy slipDist) 0))), UnaryOp Not (sy constF))
 
---DD13
+--DD convertFunc1: first function for incorporating interslice forces into shear force
 
 convertFunc1 :: DataDefinition
 convertFunc1 = dd convertFunc1QD (map makeCite [chen2005, karchewski2012]) Nothing
@@ -212,7 +212,7 @@ convertFunc1Eqn = (sy normToShear * inxi scalFunc *
 convertFunc1Notes :: Sentence
 convertFunc1Notes = foldlSent [ch scalFunc, S "is defined in", makeRef2S ratioVariation `sAnd` ch baseAngle, S "is defined in", makeRef2S angleA]
 
---DD14
+--DD convertFunc2: second function for incorporating interslice forces into shear force
 
 convertFunc2 :: DataDefinition
 convertFunc2 = dd convertFunc2QD (map makeCite [chen2005, karchewski2012]) Nothing

--- a/code/drasil-example/Drasil/SSP/DataDefs.hs
+++ b/code/drasil-example/Drasil/SSP/DataDefs.hs
@@ -1,6 +1,6 @@
 module Drasil.SSP.DataDefs (dataDefs, intersliceWtrF, angleA, angleB, lengthB,
-  lengthLb, lengthLs, slcHeight, normStressDD, ratioVariation, convertFunc1, 
-  convertFunc2, nrmForceSumDD, watForceSumDD) where 
+  lengthLb, lengthLs, slcHeight, normStressDD, tangStressDD, ratioVariation, 
+  convertFunc1, convertFunc2, nrmForceSumDD, watForceSumDD) where 
 
 import Prelude hiding (cos, sin, tan)
 import Language.Drasil
@@ -17,9 +17,9 @@ import Drasil.SSP.Defs (slice)
 import Drasil.SSP.References (chen2005, fredlund1977, karchewski2012, huston2008)
 import Drasil.SSP.Unitals (baseAngle, baseLngth, baseWthX, constF, fricAngle, 
   fs, genericA, intNormForce, indxn, inx, inxi, inxiM1, midpntHght, 
-  fn, mobShrC, normToShear, scalFunc, shrResC, slipDist, slipHght, slopeDist, 
-  slopeHght, surfAngle, surfLngth, totStress, nrmForceSum, watForceSum, 
-  sliceHghtRight, sliceHghtLeft, waterHght, waterWeight, watrForce)
+  fn, ft, mobShrC, normToShear, scalFunc, shrResC, slipDist, slipHght, slopeDist, 
+  slopeHght, surfAngle, surfLngth, totNormStress, tangStress, nrmForceSum, 
+  watForceSum, sliceHghtRight, sliceHghtLeft, waterHght, waterWeight, watrForce)
 
 ------------------------
 --  Data Definitions  --
@@ -27,7 +27,7 @@ import Drasil.SSP.Unitals (baseAngle, baseLngth, baseWthX, constF, fricAngle,
 
 dataDefs :: [DataDefinition]
 dataDefs = [intersliceWtrF, angleA, angleB, lengthB, lengthLb, lengthLs,
-  slcHeight, normStressDD, torqueDD, ratioVariation, convertFunc1, 
+  slcHeight, normStressDD, tangStressDD, torqueDD, ratioVariation, convertFunc1, 
   convertFunc2, nrmForceSumDD, watForceSumDD, sliceHghtRightDD, sliceHghtLeftDD]
 
 --DD4
@@ -162,12 +162,23 @@ normStressDD :: DataDefinition
 normStressDD = dd normStressQD [makeCite huston2008] Nothing "normStress" []
 
 normStressQD :: QDefinition
-normStressQD = mkQuantDef totStress normStressEqn
+normStressQD = mkQuantDef totNormStress normStressEqn
 
 normStressEqn :: Expr
 normStressEqn = sy fn / sy genericA
 
 --DD11
+
+tangStressDD :: DataDefinition
+tangStressDD = dd tangStressQD [makeCite huston2008] Nothing "tangStress" []
+
+tangStressQD :: QDefinition
+tangStressQD = mkQuantDef tangStress tangStressEqn
+
+tangStressEqn :: Expr
+tangStressEqn = sy ft / sy genericA
+
+--DD12
 
 ratioVariation :: DataDefinition
 ratioVariation = dd ratioVarQD [makeCite fredlund1977] Nothing 
@@ -183,7 +194,7 @@ ratioVarEqn = completeCase [case1, case2]
         case2 = (sin (sy QM.pi_ * ((inxi slipDist - idx (sy slipDist) 0) /
                 (indxn slipDist - idx (sy slipDist) 0))), UnaryOp Not (sy constF))
 
---DD12
+--DD13
 
 convertFunc1 :: DataDefinition
 convertFunc1 = dd convertFunc1QD (map makeCite [chen2005, karchewski2012]) Nothing
@@ -201,7 +212,7 @@ convertFunc1Eqn = (sy normToShear * inxi scalFunc *
 convertFunc1Notes :: Sentence
 convertFunc1Notes = foldlSent [ch scalFunc, S "is defined in", makeRef2S ratioVariation `sAnd` ch baseAngle, S "is defined in", makeRef2S angleA]
 
---DD13
+--DD14
 
 convertFunc2 :: DataDefinition
 convertFunc2 = dd convertFunc2QD (map makeCite [chen2005, karchewski2012]) Nothing

--- a/code/drasil-example/Drasil/SSP/DataDefs.hs
+++ b/code/drasil-example/Drasil/SSP/DataDefs.hs
@@ -1,5 +1,5 @@
 module Drasil.SSP.DataDefs (dataDefs, intersliceWtrF, angleA, angleB, lengthB,
-  lengthLb, lengthLs, slcHeight, stressDD, ratioVariation, convertFunc1, 
+  lengthLb, lengthLs, slcHeight, normStressDD, ratioVariation, convertFunc1, 
   convertFunc2, nrmForceSumDD, watForceSumDD) where 
 
 import Prelude hiding (cos, sin, tan)
@@ -27,7 +27,7 @@ import Drasil.SSP.Unitals (baseAngle, baseLngth, baseWthX, constF, fricAngle,
 
 dataDefs :: [DataDefinition]
 dataDefs = [intersliceWtrF, angleA, angleB, lengthB, lengthLb, lengthLs,
-  slcHeight, stressDD, torqueDD, ratioVariation, convertFunc1, 
+  slcHeight, normStressDD, torqueDD, ratioVariation, convertFunc1, 
   convertFunc2, nrmForceSumDD, watForceSumDD, sliceHghtRightDD, sliceHghtLeftDD]
 
 --DD4
@@ -158,14 +158,14 @@ slcHeightNotes = [S "This" +:+ phrase equation +:+ S "is based on the" +:+
 
 --DD10
 
-stressDD :: DataDefinition
-stressDD = dd stressQD [makeCite huston2008] Nothing "normStress" []
+normStressDD :: DataDefinition
+normStressDD = dd normStressQD [makeCite huston2008] Nothing "normStress" []
 
-stressQD :: QDefinition
-stressQD = mkQuantDef totStress stressEqn
+normStressQD :: QDefinition
+normStressQD = mkQuantDef totStress normStressEqn
 
-stressEqn :: Expr
-stressEqn = sy fn / sy genericA
+normStressEqn :: Expr
+normStressEqn = sy fn / sy genericA
 
 --DD11
 

--- a/code/drasil-example/Drasil/SSP/GenDefs.hs
+++ b/code/drasil-example/Drasil/SSP/GenDefs.hs
@@ -28,7 +28,7 @@ import Drasil.SSP.Assumptions (assumpFOSL, assumpSLH, assumpSP, assumpSLI,
   assumpHFSM)
 import Drasil.SSP.BasicExprs (eqlExpr, eqlExprN, momExpr)
 import Drasil.SSP.DataDefs (intersliceWtrF, angleA, angleB, lengthB, lengthLb, 
-  lengthLs, slcHeight, stressDD, ratioVariation)
+  lengthLs, slcHeight, normStressDD, ratioVariation)
 import Drasil.SSP.Defs (intrslce, slice, slope, slopeSrf, slpSrf, soil, 
   soilPrpty, waterTable)
 import Drasil.SSP.Figures (figForceActing)
@@ -139,7 +139,7 @@ resShrDesc = foldlSent [ch baseLngth, S "is defined in", makeRef2S lengthLb]
 
 resShrDeriv :: Derivation
 resShrDeriv = mkDerivNoHeader [foldlSent [S "Derived by substituting",
-  makeRef2S stressDD, S "into the Mohr-Coulomb", phrase shrStress `sC`
+  makeRef2S normStressDD, S "into the Mohr-Coulomb", phrase shrStress `sC`
   makeRef2S mcShrStrgth `sC` S "and multiplying both sides of the",
   phrase equation, S "by",  phrase genericA `ofThe` phrase slice `sIn`
   S "the shear-" :+: ch zcoord +:+. S "plane", S "Since the", phrase slope,
@@ -184,7 +184,7 @@ effNormFDesc = ch baseHydroForce +:+ S "is defined in" +:+. makeRef2S baseWtrFGD
 
 effNormFDeriv :: Derivation
 effNormFDeriv = mkDerivNoHeader [foldlSent [
-  S "Derived by substituting", makeRef2S stressDD, S "into", 
+  S "Derived by substituting", makeRef2S normStressDD, S "into", 
   makeRef2S effStress `sAnd` S "multiplying both sides of the", phrase equation,
   S "by the", phrase genericA `ofThe` phrase slice, S "in the shear-" :+: 
   ch zcoord +:+. S "plane", S "Since the", phrase slope, 

--- a/code/drasil-example/Drasil/SSP/TMods.hs
+++ b/code/drasil-example/Drasil/SSP/TMods.hs
@@ -17,7 +17,7 @@ import Drasil.SSP.Defs (factorOfSafety)
 import Drasil.SSP.References (fredlund1977)
 import Drasil.SSP.Unitals (effCohesion, effNormStress, effectiveStress, 
   fricAngle, fs, fx, fy, genericM, mobilizedShear, nrmFSubWat, porePressure, 
-  resistiveShear, shrStress, totStress)
+  resistiveShear, shrStress, totNormStress)
 import Drasil.SSP.DataDefs (normStressDD)
 
 --------------------------
@@ -96,7 +96,7 @@ mcShrStrgthDesc = foldlSent [S "In this", phrase model, S "the",
 ------------- New Chunk -----------
 effStress :: TheoryModel
 effStress = tm (cw effStressRC)
-  [qw effectiveStress, qw totStress, qw porePressure] 
+  [qw effectiveStress, qw totNormStress, qw porePressure] 
   ([] :: [ConceptChunk])
   [] [effStressRel] [] [makeCite fredlund1977] "effStress" [effStressDesc]
 
@@ -106,7 +106,7 @@ effStressRC = makeRC "effStressRC"
   (nounPhraseSP "effective stress") effStressDesc effStressRel -- l4
 
 effStressRel :: Relation
-effStressRel = sy effectiveStress $= sy totStress - sy porePressure
+effStressRel = sy effectiveStress $= sy totNormStress - sy porePressure
 
 effStressDesc :: Sentence
-effStressDesc = foldlSent [ch totStress, S "is defined in", makeRef2S normStressDD]
+effStressDesc = foldlSent [ch totNormStress, S "is defined in", makeRef2S normStressDD]

--- a/code/drasil-example/Drasil/SSP/TMods.hs
+++ b/code/drasil-example/Drasil/SSP/TMods.hs
@@ -18,7 +18,7 @@ import Drasil.SSP.References (fredlund1977)
 import Drasil.SSP.Unitals (effCohesion, effNormStress, effectiveStress, 
   fricAngle, fs, fx, fy, genericM, mobilizedShear, nrmFSubWat, porePressure, 
   resistiveShear, shrStress, totStress)
-import Drasil.SSP.DataDefs (stressDD)
+import Drasil.SSP.DataDefs (normStressDD)
 
 --------------------------
 --  Theoretical Models  --
@@ -109,4 +109,4 @@ effStressRel :: Relation
 effStressRel = sy effectiveStress $= sy totStress - sy porePressure
 
 effStressDesc :: Sentence
-effStressDesc = foldlSent [ch totStress, S "is defined in", makeRef2S stressDD]
+effStressDesc = foldlSent [ch totStress, S "is defined in", makeRef2S normStressDD]

--- a/code/drasil-example/Drasil/SSP/Unitals.hs
+++ b/code/drasil-example/Drasil/SSP/Unitals.hs
@@ -201,8 +201,8 @@ units = map ucw [accel, genericMass, genericF, genericA, genericM, genericV,
   shearRNoIntsl, slcWght, watrForce, intShrForce, baseHydroForce, 
   surfHydroForce, totNrmForce, nrmFSubWat, surfLoad, baseAngle, surfAngle, 
   impLoadAngle, baseWthX, baseLngth, surfLngth, midpntHght, 
-  porePressure, sliceHght, sliceHghtW, fx, fy, fn, nrmForceSum, watForceSum, 
-  sliceHghtRight, sliceHghtLeft, intNormForce, shrStress, totStress, 
+  porePressure, sliceHght, sliceHghtW, fx, fy, fn, ft, nrmForceSum, watForceSum, 
+  sliceHghtRight, sliceHghtLeft, intNormForce, shrStress, totNormStress, tangStress,
   effectiveStress, effNormStress, dryVol, satVol, rotForce, momntArm, posVec]
 
 accel, genericMass, genericF, genericA, genericM, genericV, genericW, 
@@ -211,10 +211,10 @@ accel, genericMass, genericF, genericA, genericM, genericV, genericW,
   mobilizedShear, mobShrI, sliceHght, sliceHghtW, shearFNoIntsl, shearRNoIntsl,
   slcWght, watrForce, resistiveShear, shrResI, intShrForce, baseHydroForce, 
   surfHydroForce, totNrmForce, nrmFSubWat, surfLoad, baseAngle, surfAngle, 
-  impLoadAngle, baseWthX, baseLngth, surfLngth, midpntHght, fx, fy, fn, 
+  impLoadAngle, baseWthX, baseLngth, surfLngth, midpntHght, fx, fy, fn, ft, 
   nrmForceSum, watForceSum, sliceHghtRight, sliceHghtLeft, porePressure, 
-  intNormForce, shrStress, totStress, effectiveStress, effNormStress, dryVol, 
-  satVol, rotForce, momntArm, posVec :: UnitalChunk
+  intNormForce, shrStress, totNormStress, tangStress, effectiveStress, 
+  effNormStress, dryVol, satVol, rotForce, momntArm, posVec :: UnitalChunk
   
 {-FIXME: Many of these need to be split into term, defn pairs as
          their defns are mixed into the terms.-}
@@ -383,6 +383,9 @@ fy = makeUCWDS "fy" (nounPhraseSent $ phrase yCoord +:+ S "of the force")
 fn = uc' "F_n" (cn "total normal force") "component of a force in the normal direction"
   (sub cF (Label "n")) newton
 
+ft = uc' "F_t" (cn "tangential force") "component of a force in the tangential direction"
+  (sub cF (Label "t")) newton
+
 nrmForceSum = uc' "F_x^G" (cn "sums of the interslice normal forces") 
   "the sums of the normal forces acting on each pair of adjacent interslice boundaries"
   (sup (subX (vec cF)) lNorm) newton
@@ -399,8 +402,11 @@ sliceHghtLeft = uc' "h^L" (cn "heights of the left side of slices")
   "the heights of the left side of each slice, assuming slice surfaces have negative slope"
   (sup (vec lH) lLeft) metre
 
-totStress = uc' "sigma" (cn' "total normal stress")
+totNormStress = uc' "sigma" (cn' "total normal stress")
   "the total force per area acting on the soil mass" lSigma pascal
+
+tangStress = uc' "tau" (cn' "tangential stress")
+  "the total force per area acting on the soil mass" lTau pascal
 
 effectiveStress = uc' "sigma'" (cn' "effective stress")
   ("the stress in a soil mass that is effective in causing volume changes " ++

--- a/code/drasil-example/Drasil/SSP/Unitals.hs
+++ b/code/drasil-example/Drasil/SSP/Unitals.hs
@@ -406,7 +406,7 @@ totNormStress = uc' "sigma" (cn' "total normal stress")
   "the total force per area acting on the soil mass" lSigma pascal
 
 tangStress = uc' "tau" (cn' "tangential stress")
-  "the total force per area acting on the soil mass" lTau pascal
+  "the shear force per unit area" lTau pascal
 
 effectiveStress = uc' "sigma'" (cn' "effective stress")
   ("the stress in a soil mass that is effective in causing volume changes " ++

--- a/code/stable/ssp/SRS/SSP_SRS.tex
+++ b/code/stable/ssp/SRS/SSP_SRS.tex
@@ -239,7 +239,7 @@ $σ'$ & Effective Stress: The stress in a soil mass that is effective in causing
 \\
 ${σ_{N}}'$ & Effective Normal Stress: The normal stress in a soil mass that is effective in causing volume changes; represents the average normal stress carried by the soil skeleton. & ${\text{Pa}}$
 \\
-$τ$ & Tangential Stress: The total force per area acting on the soil mass. & ${\text{Pa}}$
+$τ$ & Tangential Stress: The shear force per unit area. & ${\text{Pa}}$
 \\
 ${τ^{\text{f}}}$ & Shear Strength: The strength of a material against shear failure. & ${\text{Pa}}$
 \\

--- a/code/stable/ssp/SRS/SSP_SRS.tex
+++ b/code/stable/ssp/SRS/SSP_SRS.tex
@@ -93,6 +93,8 @@ ${F_{\text{S}}}$ & Factor of Safety: The global stability metric of a slip surfa
 \\
 ${{F_{\text{S}}}^{\text{min}}}$ & Minimum Factor of Safety: The minimum factor of safety associated with the critical slip surface. & --
 \\
+${F_{\text{t}}}$ & Tangential Force: Component of a force in the tangential direction. & ${\text{N}}$
+\\
 ${F_{\text{x}}}$ & $x$-coordinate of the Force: The force acting in the $x$-direction. & ${\text{N}}$
 \\
 ${F_{\text{y}}}$ & $y$-coordinate of the Force: The force acting in the $y$-direction. & ${\text{N}}$
@@ -236,6 +238,8 @@ $σ$ & Total Normal Stress: The total force per area acting on the soil mass. & 
 $σ'$ & Effective Stress: The stress in a soil mass that is effective in causing volume changes and mobilizes the shear strength arising from friction; represents the average stress carried by the soil skeleton. & ${\text{Pa}}$
 \\
 ${σ_{N}}'$ & Effective Normal Stress: The normal stress in a soil mass that is effective in causing volume changes; represents the average normal stress carried by the soil skeleton. & ${\text{Pa}}$
+\\
+$τ$ & Tangential Stress: The total force per area acting on the soil mass. & ${\text{Pa}}$
 \\
 ${τ^{\text{f}}}$ & Shear Strength: The strength of a material against shear failure. & ${\text{Pa}}$
 \\
@@ -1704,6 +1708,41 @@ RefBy & \hyperref[GD:resShr]{GD: resShr}, \hyperref[TM:effStress]{TM: effStress}
 \noindent
 \begin{minipage}{\textwidth}
 \begin{tabular}{>{\raggedright}p{0.13\textwidth}>{\raggedright\arraybackslash}p{0.82\textwidth}}
+\toprule \textbf{Refname} & \textbf{DD:tangStress}
+\phantomsection 
+\label{DD:tangStress}
+\\ \midrule \\
+Label & Tangential stress
+        
+\\ \midrule \\
+Symbol & $τ$
+         
+\\ \midrule \\
+Units & ${\text{Pa}}$
+        
+\\ \midrule \\
+Equation & \begin{displaymath}
+           τ=\frac{{F_{\text{t}}}}{A}
+           \end{displaymath}
+\\ \midrule \\
+Description & \begin{symbDescription}
+              \item{$τ$ is the tangential stress (${\text{Pa}}$)}
+              \item{${F_{\text{t}}}$ is the tangential force (${\text{N}}$)}
+              \item{$A$ is the area (${\text{m}^{2}}$)}
+              \end{symbDescription}
+\\ \midrule \\
+Source & \cite{huston2008}
+         
+\\ \midrule \\
+RefBy & 
+\\ \bottomrule
+\end{tabular}
+\end{minipage}
+
+\vspace{\baselineskip}
+\noindent
+\begin{minipage}{\textwidth}
+\begin{tabular}{>{\raggedright}p{0.13\textwidth}>{\raggedright\arraybackslash}p{0.82\textwidth}}
 \toprule \textbf{Refname} & \textbf{DD:torque}
 \phantomsection 
 \label{DD:torque}
@@ -2681,6 +2720,8 @@ The purpose of the traceability matrices is to provide easy references on what h
 \\
 \hyperref[DD:normStress]{DD: normStress} &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  & 
 \\
+\hyperref[DD:tangStress]{DD: tangStress} &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  & 
+\\
 \hyperref[DD:torque]{DD: torque} &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  & 
 \\
 \hyperref[DD:ratioVariation]{DD: ratioVariation} &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  & 
@@ -2789,137 +2830,139 @@ The purpose of the traceability matrices is to provide easy references on what h
 \caption{Traceability Matrix Showing the Connections Between Assumptions and Other Items}
 \label{Table:TraceMatAvsAll}
 \end{longtable}
-\begin{longtable}{l l l l l l l l l l l l l l l l l l l l l l l l l l l l l l l l l l l l l l l l l l}
+\begin{longtable}{l l l l l l l l l l l l l l l l l l l l l l l l l l l l l l l l l l l l l l l l l l l}
 \toprule
-\textbf{} & \textbf{\hyperref[DD:intersliceWtrF]{DD: intersliceWtrF}} & \textbf{\hyperref[DD:angleA]{DD: angleA}} & \textbf{\hyperref[DD:angleB]{DD: angleB}} & \textbf{\hyperref[DD:lengthB]{DD: lengthB}} & \textbf{\hyperref[DD:lengthLb]{DD: lengthLb}} & \textbf{\hyperref[DD:lengthLs]{DD: lengthLs}} & \textbf{\hyperref[DD:slcHeight]{DD: slcHeight}} & \textbf{\hyperref[DD:normStress]{DD: normStress}} & \textbf{\hyperref[DD:torque]{DD: torque}} & \textbf{\hyperref[DD:ratioVariation]{DD: ratioVariation}} & \textbf{\hyperref[DD:convertFunc1]{DD: convertFunc1}} & \textbf{\hyperref[DD:convertFunc2]{DD: convertFunc2}} & \textbf{\hyperref[DD:nrmForceSumDD]{DD: nrmForceSumDD}} & \textbf{\hyperref[DD:watForceSumDD]{DD: watForceSumDD}} & \textbf{\hyperref[DD:sliceHghtRightDD]{DD: sliceHghtRightDD}} & \textbf{\hyperref[DD:sliceHghtLeftDD]{DD: sliceHghtLeftDD}} & \textbf{\hyperref[TM:factOfSafety]{TM: factOfSafety}} & \textbf{\hyperref[TM:equilibrium]{TM: equilibrium}} & \textbf{\hyperref[TM:mcShrStrgth]{TM: mcShrStrgth}} & \textbf{\hyperref[TM:effStress]{TM: effStress}} & \textbf{\hyperref[TM:NewtonSecLawMot]{TM: NewtonSecLawMot}} & \textbf{\hyperref[GD:normForcEq]{GD: normForcEq}} & \textbf{\hyperref[GD:bsShrFEq]{GD: bsShrFEq}} & \textbf{\hyperref[GD:resShr]{GD: resShr}} & \textbf{\hyperref[GD:mobShr]{GD: mobShr}} & \textbf{\hyperref[GD:effNormF]{GD: effNormF}} & \textbf{\hyperref[GD:resShearWO]{GD: resShearWO}} & \textbf{\hyperref[GD:mobShearWO]{GD: mobShearWO}} & \textbf{\hyperref[GD:normShrR]{GD: normShrR}} & \textbf{\hyperref[GD:momentEql]{GD: momentEql}} & \textbf{\hyperref[GD:weight]{GD: weight}} & \textbf{\hyperref[GD:sliceWght]{GD: sliceWght}} & \textbf{\hyperref[GD:hsPressure]{GD: hsPressure}} & \textbf{\hyperref[GD:baseWtrF]{GD: baseWtrF}} & \textbf{\hyperref[GD:srfWtrF]{GD: srfWtrF}} & \textbf{\hyperref[IM:fctSfty]{IM: fctSfty}} & \textbf{\hyperref[IM:nrmShrFor]{IM: nrmShrFor}} & \textbf{\hyperref[IM:nrmShrForNum]{IM: nrmShrForNum}} & \textbf{\hyperref[IM:nrmShrForDen]{IM: nrmShrForDen}} & \textbf{\hyperref[IM:intsliceFs]{IM: intsliceFs}} & \textbf{\hyperref[IM:crtSlpId]{IM: crtSlpId}}
+\textbf{} & \textbf{\hyperref[DD:intersliceWtrF]{DD: intersliceWtrF}} & \textbf{\hyperref[DD:angleA]{DD: angleA}} & \textbf{\hyperref[DD:angleB]{DD: angleB}} & \textbf{\hyperref[DD:lengthB]{DD: lengthB}} & \textbf{\hyperref[DD:lengthLb]{DD: lengthLb}} & \textbf{\hyperref[DD:lengthLs]{DD: lengthLs}} & \textbf{\hyperref[DD:slcHeight]{DD: slcHeight}} & \textbf{\hyperref[DD:normStress]{DD: normStress}} & \textbf{\hyperref[DD:tangStress]{DD: tangStress}} & \textbf{\hyperref[DD:torque]{DD: torque}} & \textbf{\hyperref[DD:ratioVariation]{DD: ratioVariation}} & \textbf{\hyperref[DD:convertFunc1]{DD: convertFunc1}} & \textbf{\hyperref[DD:convertFunc2]{DD: convertFunc2}} & \textbf{\hyperref[DD:nrmForceSumDD]{DD: nrmForceSumDD}} & \textbf{\hyperref[DD:watForceSumDD]{DD: watForceSumDD}} & \textbf{\hyperref[DD:sliceHghtRightDD]{DD: sliceHghtRightDD}} & \textbf{\hyperref[DD:sliceHghtLeftDD]{DD: sliceHghtLeftDD}} & \textbf{\hyperref[TM:factOfSafety]{TM: factOfSafety}} & \textbf{\hyperref[TM:equilibrium]{TM: equilibrium}} & \textbf{\hyperref[TM:mcShrStrgth]{TM: mcShrStrgth}} & \textbf{\hyperref[TM:effStress]{TM: effStress}} & \textbf{\hyperref[TM:NewtonSecLawMot]{TM: NewtonSecLawMot}} & \textbf{\hyperref[GD:normForcEq]{GD: normForcEq}} & \textbf{\hyperref[GD:bsShrFEq]{GD: bsShrFEq}} & \textbf{\hyperref[GD:resShr]{GD: resShr}} & \textbf{\hyperref[GD:mobShr]{GD: mobShr}} & \textbf{\hyperref[GD:effNormF]{GD: effNormF}} & \textbf{\hyperref[GD:resShearWO]{GD: resShearWO}} & \textbf{\hyperref[GD:mobShearWO]{GD: mobShearWO}} & \textbf{\hyperref[GD:normShrR]{GD: normShrR}} & \textbf{\hyperref[GD:momentEql]{GD: momentEql}} & \textbf{\hyperref[GD:weight]{GD: weight}} & \textbf{\hyperref[GD:sliceWght]{GD: sliceWght}} & \textbf{\hyperref[GD:hsPressure]{GD: hsPressure}} & \textbf{\hyperref[GD:baseWtrF]{GD: baseWtrF}} & \textbf{\hyperref[GD:srfWtrF]{GD: srfWtrF}} & \textbf{\hyperref[IM:fctSfty]{IM: fctSfty}} & \textbf{\hyperref[IM:nrmShrFor]{IM: nrmShrFor}} & \textbf{\hyperref[IM:nrmShrForNum]{IM: nrmShrForNum}} & \textbf{\hyperref[IM:nrmShrForDen]{IM: nrmShrForDen}} & \textbf{\hyperref[IM:intsliceFs]{IM: intsliceFs}} & \textbf{\hyperref[IM:crtSlpId]{IM: crtSlpId}}
 \\
 \midrule
 \endhead
-\hyperref[DD:intersliceWtrF]{DD: intersliceWtrF} &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  & 
+\hyperref[DD:intersliceWtrF]{DD: intersliceWtrF} &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  & 
 \\
-\hyperref[DD:angleA]{DD: angleA} &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  & 
+\hyperref[DD:angleA]{DD: angleA} &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  & 
 \\
-\hyperref[DD:angleB]{DD: angleB} &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  & 
+\hyperref[DD:angleB]{DD: angleB} &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  & 
 \\
-\hyperref[DD:lengthB]{DD: lengthB} &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  & 
+\hyperref[DD:lengthB]{DD: lengthB} &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  & 
 \\
-\hyperref[DD:lengthLb]{DD: lengthLb} &  & X &  & X &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  & 
+\hyperref[DD:lengthLb]{DD: lengthLb} &  & X &  & X &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  & 
 \\
-\hyperref[DD:lengthLs]{DD: lengthLs} &  &  & X & X &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  & 
+\hyperref[DD:lengthLs]{DD: lengthLs} &  &  & X & X &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  & 
 \\
-\hyperref[DD:slcHeight]{DD: slcHeight} &  &  &  &  &  &  &  &  &  &  &  &  &  &  & X & X &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  & 
+\hyperref[DD:slcHeight]{DD: slcHeight} &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  & X & X &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  & 
 \\
-\hyperref[DD:normStress]{DD: normStress} &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  & 
+\hyperref[DD:normStress]{DD: normStress} &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  & 
 \\
-\hyperref[DD:torque]{DD: torque} &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  & 
+\hyperref[DD:tangStress]{DD: tangStress} &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  & 
 \\
-\hyperref[DD:ratioVariation]{DD: ratioVariation} &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  & 
+\hyperref[DD:torque]{DD: torque} &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  & 
 \\
-\hyperref[DD:convertFunc1]{DD: convertFunc1} &  & X &  &  &  &  &  &  &  & X &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  & 
+\hyperref[DD:ratioVariation]{DD: ratioVariation} &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  & 
 \\
-\hyperref[DD:convertFunc2]{DD: convertFunc2} &  & X &  &  &  &  &  &  &  & X & X &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  & 
+\hyperref[DD:convertFunc1]{DD: convertFunc1} &  & X &  &  &  &  &  &  &  &  & X &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  & 
 \\
-\hyperref[DD:nrmForceSumDD]{DD: nrmForceSumDD} &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  & 
+\hyperref[DD:convertFunc2]{DD: convertFunc2} &  & X &  &  &  &  &  &  &  &  & X & X &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  & 
 \\
-\hyperref[DD:watForceSumDD]{DD: watForceSumDD} &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  & 
+\hyperref[DD:nrmForceSumDD]{DD: nrmForceSumDD} &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  & 
 \\
-\hyperref[DD:sliceHghtRightDD]{DD: sliceHghtRightDD} &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  & 
+\hyperref[DD:watForceSumDD]{DD: watForceSumDD} &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  & 
 \\
-\hyperref[DD:sliceHghtLeftDD]{DD: sliceHghtLeftDD} &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  & 
+\hyperref[DD:sliceHghtRightDD]{DD: sliceHghtRightDD} &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  & 
 \\
-\hyperref[TM:factOfSafety]{TM: factOfSafety} &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  & 
+\hyperref[DD:sliceHghtLeftDD]{DD: sliceHghtLeftDD} &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  & 
 \\
-\hyperref[TM:equilibrium]{TM: equilibrium} &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  & 
+\hyperref[TM:factOfSafety]{TM: factOfSafety} &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  & 
 \\
-\hyperref[TM:mcShrStrgth]{TM: mcShrStrgth} &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  & 
+\hyperref[TM:equilibrium]{TM: equilibrium} &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  & 
 \\
-\hyperref[TM:effStress]{TM: effStress} &  &  &  &  &  &  &  & X &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  & 
+\hyperref[TM:mcShrStrgth]{TM: mcShrStrgth} &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  & 
 \\
-\hyperref[TM:NewtonSecLawMot]{TM: NewtonSecLawMot} &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  & 
+\hyperref[TM:effStress]{TM: effStress} &  &  &  &  &  &  &  & X &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  & 
 \\
-\hyperref[GD:normForcEq]{GD: normForcEq} &  & X & X &  &  &  &  &  &  &  &  &  &  &  &  &  &  & X &  &  &  &  &  &  &  &  &  &  &  &  &  & X &  &  & X &  &  &  &  &  & 
+\hyperref[TM:NewtonSecLawMot]{TM: NewtonSecLawMot} &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  & 
 \\
-\hyperref[GD:bsShrFEq]{GD: bsShrFEq} &  & X & X &  &  &  &  &  &  &  &  &  &  &  &  &  &  & X &  &  &  &  &  &  &  &  &  &  &  &  &  & X &  &  & X &  &  &  &  &  & 
+\hyperref[GD:normForcEq]{GD: normForcEq} &  & X & X &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  & X &  &  &  &  &  &  &  &  &  &  &  &  &  & X &  &  & X &  &  &  &  &  & 
 \\
-\hyperref[GD:resShr]{GD: resShr} &  &  &  &  & X &  &  & X &  &  &  &  &  &  &  &  &  &  & X &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  & 
+\hyperref[GD:bsShrFEq]{GD: bsShrFEq} &  & X & X &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  & X &  &  &  &  &  &  &  &  &  &  &  &  &  & X &  &  & X &  &  &  &  &  & 
 \\
-\hyperref[GD:mobShr]{GD: mobShr} &  &  &  &  & X &  &  &  &  &  &  &  &  &  &  &  & X &  &  &  &  &  &  & X &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  & 
+\hyperref[GD:resShr]{GD: resShr} &  &  &  &  & X &  &  & X &  &  &  &  &  &  &  &  &  &  &  & X &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  & 
 \\
-\hyperref[GD:effNormF]{GD: effNormF} &  &  &  &  &  &  &  & X &  &  &  &  &  &  &  &  &  &  &  & X &  &  &  &  &  &  &  &  &  &  &  &  &  & X &  &  &  &  &  &  & 
+\hyperref[GD:mobShr]{GD: mobShr} &  &  &  &  & X &  &  &  &  &  &  &  &  &  &  &  &  & X &  &  &  &  &  &  & X &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  & 
 \\
-\hyperref[GD:resShearWO]{GD: resShearWO} & X & X & X &  & X &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  & X &  & X & X &  &  &  &  &  & 
+\hyperref[GD:effNormF]{GD: effNormF} &  &  &  &  &  &  &  & X &  &  &  &  &  &  &  &  &  &  &  &  & X &  &  &  &  &  &  &  &  &  &  &  &  &  & X &  &  &  &  &  &  & 
 \\
-\hyperref[GD:mobShearWO]{GD: mobShearWO} & X & X & X &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  & X &  &  & X &  &  &  &  &  & 
+\hyperref[GD:resShearWO]{GD: resShearWO} & X & X & X &  & X &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  & X &  & X & X &  &  &  &  &  & 
 \\
-\hyperref[GD:normShrR]{GD: normShrR} &  &  &  &  &  &  &  &  &  & X &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  & 
+\hyperref[GD:mobShearWO]{GD: mobShearWO} & X & X & X &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  & X &  &  & X &  &  &  &  &  & 
 \\
-\hyperref[GD:momentEql]{GD: momentEql} &  & X & X & X &  &  & X &  & X &  &  &  &  &  &  &  &  & X &  &  &  &  &  &  &  &  &  &  &  &  & X & X &  &  & X &  &  &  &  &  & 
+\hyperref[GD:normShrR]{GD: normShrR} &  &  &  &  &  &  &  &  &  &  & X &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  & 
 \\
-\hyperref[GD:weight]{GD: weight} &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  & X &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  & 
+\hyperref[GD:momentEql]{GD: momentEql} &  & X & X & X &  &  & X &  &  & X &  &  &  &  &  &  &  &  & X &  &  &  &  &  &  &  &  &  &  &  &  & X & X &  &  & X &  &  &  &  &  & 
 \\
-\hyperref[GD:sliceWght]{GD: sliceWght} &  &  &  & X &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  & X &  &  &  &  &  &  &  &  &  & 
+\hyperref[GD:weight]{GD: weight} &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  & X &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  & 
 \\
-\hyperref[GD:hsPressure]{GD: hsPressure} &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  & 
+\hyperref[GD:sliceWght]{GD: sliceWght} &  &  &  & X &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  & X &  &  &  &  &  &  &  &  &  & 
 \\
-\hyperref[GD:baseWtrF]{GD: baseWtrF} &  &  &  &  & X &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  & X & X &  &  &  &  &  &  & 
+\hyperref[GD:hsPressure]{GD: hsPressure} &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  & 
 \\
-\hyperref[GD:srfWtrF]{GD: srfWtrF} &  &  &  &  &  & X &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  & X &  & X &  &  &  &  &  & 
+\hyperref[GD:baseWtrF]{GD: baseWtrF} &  &  &  &  & X &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  & X & X &  &  &  &  &  &  & 
 \\
-\hyperref[IM:fctSfty]{IM: fctSfty} &  &  &  &  &  &  &  &  &  &  & X & X &  &  &  &  &  &  &  &  &  & X & X &  & X &  & X & X & X &  &  &  &  &  &  & X & X &  &  & X & 
+\hyperref[GD:srfWtrF]{GD: srfWtrF} &  &  &  &  &  & X &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  & X &  & X &  &  &  &  &  & 
 \\
-\hyperref[IM:nrmShrFor]{IM: nrmShrFor} &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  & X & X &  &  &  &  &  & X & X & X & X & X & 
+\hyperref[IM:fctSfty]{IM: fctSfty} &  &  &  &  &  &  &  &  &  &  &  & X & X &  &  &  &  &  &  &  &  &  & X & X &  & X &  & X & X & X &  &  &  &  &  &  & X & X &  &  & X & 
 \\
-\hyperref[IM:nrmShrForNum]{IM: nrmShrForNum} & X & X & X & X &  &  & X &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  & X &  & X &  &  &  & 
+\hyperref[IM:nrmShrFor]{IM: nrmShrFor} &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  & X & X &  &  &  &  &  & X & X & X & X & X & 
 \\
-\hyperref[IM:nrmShrForDen]{IM: nrmShrForDen} &  &  &  & X &  &  &  &  &  & X &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  & X &  &  &  & 
+\hyperref[IM:nrmShrForNum]{IM: nrmShrForNum} & X & X & X & X &  &  & X &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  & X &  & X &  &  &  & 
 \\
-\hyperref[IM:intsliceFs]{IM: intsliceFs} &  &  &  &  &  &  &  &  &  &  & X & X &  &  &  &  &  &  &  &  &  &  &  &  &  &  & X & X &  &  &  &  &  &  &  & X & X &  &  & X & 
+\hyperref[IM:nrmShrForDen]{IM: nrmShrForDen} &  &  &  & X &  &  &  &  &  &  & X &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  & X &  &  &  & 
 \\
-\hyperref[IM:crtSlpId]{IM: crtSlpId} &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  & 
+\hyperref[IM:intsliceFs]{IM: intsliceFs} &  &  &  &  &  &  &  &  &  &  &  & X & X &  &  &  &  &  &  &  &  &  &  &  &  &  &  & X & X &  &  &  &  &  &  &  & X & X &  &  & X & 
+\\
+\hyperref[IM:crtSlpId]{IM: crtSlpId} &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  & 
 \\
 \bottomrule
 \caption{Traceability Matrix Showing the Connections Between Items and Other Sections}
 \label{Table:TraceMatRefvsRef}
 \end{longtable}
-\begin{longtable}{l l l l l l l l l l l l l l l l l l l l l l l l l l l l l l l l l l l l l l l l l l l l l l l l l l l l l l l l}
+\begin{longtable}{l l l l l l l l l l l l l l l l l l l l l l l l l l l l l l l l l l l l l l l l l l l l l l l l l l l l l l l l l}
 \toprule
-\textbf{} & \textbf{\hyperref[DD:intersliceWtrF]{DD: intersliceWtrF}} & \textbf{\hyperref[DD:angleA]{DD: angleA}} & \textbf{\hyperref[DD:angleB]{DD: angleB}} & \textbf{\hyperref[DD:lengthB]{DD: lengthB}} & \textbf{\hyperref[DD:lengthLb]{DD: lengthLb}} & \textbf{\hyperref[DD:lengthLs]{DD: lengthLs}} & \textbf{\hyperref[DD:slcHeight]{DD: slcHeight}} & \textbf{\hyperref[DD:normStress]{DD: normStress}} & \textbf{\hyperref[DD:torque]{DD: torque}} & \textbf{\hyperref[DD:ratioVariation]{DD: ratioVariation}} & \textbf{\hyperref[DD:convertFunc1]{DD: convertFunc1}} & \textbf{\hyperref[DD:convertFunc2]{DD: convertFunc2}} & \textbf{\hyperref[DD:nrmForceSumDD]{DD: nrmForceSumDD}} & \textbf{\hyperref[DD:watForceSumDD]{DD: watForceSumDD}} & \textbf{\hyperref[DD:sliceHghtRightDD]{DD: sliceHghtRightDD}} & \textbf{\hyperref[DD:sliceHghtLeftDD]{DD: sliceHghtLeftDD}} & \textbf{\hyperref[TM:factOfSafety]{TM: factOfSafety}} & \textbf{\hyperref[TM:equilibrium]{TM: equilibrium}} & \textbf{\hyperref[TM:mcShrStrgth]{TM: mcShrStrgth}} & \textbf{\hyperref[TM:effStress]{TM: effStress}} & \textbf{\hyperref[TM:NewtonSecLawMot]{TM: NewtonSecLawMot}} & \textbf{\hyperref[GD:normForcEq]{GD: normForcEq}} & \textbf{\hyperref[GD:bsShrFEq]{GD: bsShrFEq}} & \textbf{\hyperref[GD:resShr]{GD: resShr}} & \textbf{\hyperref[GD:mobShr]{GD: mobShr}} & \textbf{\hyperref[GD:effNormF]{GD: effNormF}} & \textbf{\hyperref[GD:resShearWO]{GD: resShearWO}} & \textbf{\hyperref[GD:mobShearWO]{GD: mobShearWO}} & \textbf{\hyperref[GD:normShrR]{GD: normShrR}} & \textbf{\hyperref[GD:momentEql]{GD: momentEql}} & \textbf{\hyperref[GD:weight]{GD: weight}} & \textbf{\hyperref[GD:sliceWght]{GD: sliceWght}} & \textbf{\hyperref[GD:hsPressure]{GD: hsPressure}} & \textbf{\hyperref[GD:baseWtrF]{GD: baseWtrF}} & \textbf{\hyperref[GD:srfWtrF]{GD: srfWtrF}} & \textbf{\hyperref[IM:fctSfty]{IM: fctSfty}} & \textbf{\hyperref[IM:nrmShrFor]{IM: nrmShrFor}} & \textbf{\hyperref[IM:nrmShrForNum]{IM: nrmShrForNum}} & \textbf{\hyperref[IM:nrmShrForDen]{IM: nrmShrForDen}} & \textbf{\hyperref[IM:intsliceFs]{IM: intsliceFs}} & \textbf{\hyperref[IM:crtSlpId]{IM: crtSlpId}} & \textbf{\hyperref[readAndStore]{FR: Read-and-Store}} & \textbf{\hyperref[verifyInput]{FR: Verify-Input}} & \textbf{\hyperref[determineCritSlip]{FR: Determine-Critical-Slip-Surface}} & \textbf{\hyperref[verifyOutput]{FR: Verify-Output}} & \textbf{\hyperref[displayInput]{FR: Display-Input}} & \textbf{\hyperref[displayGraph]{FR: Display-Graph}} & \textbf{\hyperref[displayFS]{FR: Display-Factor-of-Safety}} & \textbf{\hyperref[displayNormal]{FR: Display-Interslice-Normal-Forces}} & \textbf{\hyperref[displayShear]{FR: Display-Interslice-Shear-Forces}} & \textbf{\hyperref[writeToFile]{FR: Write-Results-To-File}} & \textbf{\hyperref[correct]{NFR: Correct}} & \textbf{\hyperref[understandable]{NFR: Understandable}} & \textbf{\hyperref[reusable]{NFR: Reusable}} & \textbf{\hyperref[maintainable]{NFR: Maintainable}}
+\textbf{} & \textbf{\hyperref[DD:intersliceWtrF]{DD: intersliceWtrF}} & \textbf{\hyperref[DD:angleA]{DD: angleA}} & \textbf{\hyperref[DD:angleB]{DD: angleB}} & \textbf{\hyperref[DD:lengthB]{DD: lengthB}} & \textbf{\hyperref[DD:lengthLb]{DD: lengthLb}} & \textbf{\hyperref[DD:lengthLs]{DD: lengthLs}} & \textbf{\hyperref[DD:slcHeight]{DD: slcHeight}} & \textbf{\hyperref[DD:normStress]{DD: normStress}} & \textbf{\hyperref[DD:tangStress]{DD: tangStress}} & \textbf{\hyperref[DD:torque]{DD: torque}} & \textbf{\hyperref[DD:ratioVariation]{DD: ratioVariation}} & \textbf{\hyperref[DD:convertFunc1]{DD: convertFunc1}} & \textbf{\hyperref[DD:convertFunc2]{DD: convertFunc2}} & \textbf{\hyperref[DD:nrmForceSumDD]{DD: nrmForceSumDD}} & \textbf{\hyperref[DD:watForceSumDD]{DD: watForceSumDD}} & \textbf{\hyperref[DD:sliceHghtRightDD]{DD: sliceHghtRightDD}} & \textbf{\hyperref[DD:sliceHghtLeftDD]{DD: sliceHghtLeftDD}} & \textbf{\hyperref[TM:factOfSafety]{TM: factOfSafety}} & \textbf{\hyperref[TM:equilibrium]{TM: equilibrium}} & \textbf{\hyperref[TM:mcShrStrgth]{TM: mcShrStrgth}} & \textbf{\hyperref[TM:effStress]{TM: effStress}} & \textbf{\hyperref[TM:NewtonSecLawMot]{TM: NewtonSecLawMot}} & \textbf{\hyperref[GD:normForcEq]{GD: normForcEq}} & \textbf{\hyperref[GD:bsShrFEq]{GD: bsShrFEq}} & \textbf{\hyperref[GD:resShr]{GD: resShr}} & \textbf{\hyperref[GD:mobShr]{GD: mobShr}} & \textbf{\hyperref[GD:effNormF]{GD: effNormF}} & \textbf{\hyperref[GD:resShearWO]{GD: resShearWO}} & \textbf{\hyperref[GD:mobShearWO]{GD: mobShearWO}} & \textbf{\hyperref[GD:normShrR]{GD: normShrR}} & \textbf{\hyperref[GD:momentEql]{GD: momentEql}} & \textbf{\hyperref[GD:weight]{GD: weight}} & \textbf{\hyperref[GD:sliceWght]{GD: sliceWght}} & \textbf{\hyperref[GD:hsPressure]{GD: hsPressure}} & \textbf{\hyperref[GD:baseWtrF]{GD: baseWtrF}} & \textbf{\hyperref[GD:srfWtrF]{GD: srfWtrF}} & \textbf{\hyperref[IM:fctSfty]{IM: fctSfty}} & \textbf{\hyperref[IM:nrmShrFor]{IM: nrmShrFor}} & \textbf{\hyperref[IM:nrmShrForNum]{IM: nrmShrForNum}} & \textbf{\hyperref[IM:nrmShrForDen]{IM: nrmShrForDen}} & \textbf{\hyperref[IM:intsliceFs]{IM: intsliceFs}} & \textbf{\hyperref[IM:crtSlpId]{IM: crtSlpId}} & \textbf{\hyperref[readAndStore]{FR: Read-and-Store}} & \textbf{\hyperref[verifyInput]{FR: Verify-Input}} & \textbf{\hyperref[determineCritSlip]{FR: Determine-Critical-Slip-Surface}} & \textbf{\hyperref[verifyOutput]{FR: Verify-Output}} & \textbf{\hyperref[displayInput]{FR: Display-Input}} & \textbf{\hyperref[displayGraph]{FR: Display-Graph}} & \textbf{\hyperref[displayFS]{FR: Display-Factor-of-Safety}} & \textbf{\hyperref[displayNormal]{FR: Display-Interslice-Normal-Forces}} & \textbf{\hyperref[displayShear]{FR: Display-Interslice-Shear-Forces}} & \textbf{\hyperref[writeToFile]{FR: Write-Results-To-File}} & \textbf{\hyperref[correct]{NFR: Correct}} & \textbf{\hyperref[understandable]{NFR: Understandable}} & \textbf{\hyperref[reusable]{NFR: Reusable}} & \textbf{\hyperref[maintainable]{NFR: Maintainable}}
 \\
 \midrule
 \endhead
-\hyperref[identifyCritAndFS]{GS: Identify-Crit-and-FS} &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  & 
+\hyperref[identifyCritAndFS]{GS: Identify-Crit-and-FS} &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  & 
 \\
-\hyperref[determineNormalF]{GS: Determine-Normal-Forces} &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  & 
+\hyperref[determineNormalF]{GS: Determine-Normal-Forces} &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  & 
 \\
-\hyperref[determineShearF]{GS: Determine-Shear-Forces} &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  & 
+\hyperref[determineShearF]{GS: Determine-Shear-Forces} &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  & 
 \\
-\hyperref[readAndStore]{FR: Read-and-Store} &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  & 
+\hyperref[readAndStore]{FR: Read-and-Store} &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  & 
 \\
-\hyperref[verifyInput]{FR: Verify-Input} &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  & 
+\hyperref[verifyInput]{FR: Verify-Input} &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  & 
 \\
-\hyperref[determineCritSlip]{FR: Determine-Critical-Slip-Surface} &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  & X & X &  &  & X & X &  &  &  &  &  &  &  &  &  &  &  &  &  & 
+\hyperref[determineCritSlip]{FR: Determine-Critical-Slip-Surface} &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  & X & X &  &  & X & X &  &  &  &  &  &  &  &  &  &  &  &  &  & 
 \\
-\hyperref[verifyOutput]{FR: Verify-Output} &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  & 
+\hyperref[verifyOutput]{FR: Verify-Output} &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  & 
 \\
-\hyperref[displayInput]{FR: Display-Input} &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  & 
+\hyperref[displayInput]{FR: Display-Input} &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  & 
 \\
-\hyperref[displayGraph]{FR: Display-Graph} &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  & X &  &  &  &  &  &  &  &  &  &  &  &  &  & 
+\hyperref[displayGraph]{FR: Display-Graph} &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  & X &  &  &  &  &  &  &  &  &  &  &  &  &  & 
 \\
-\hyperref[displayFS]{FR: Display-Factor-of-Safety} &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  & X & X &  &  & X &  &  &  &  &  &  &  &  &  &  &  &  &  &  & 
+\hyperref[displayFS]{FR: Display-Factor-of-Safety} &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  & X & X &  &  & X &  &  &  &  &  &  &  &  &  &  &  &  &  &  & 
 \\
-\hyperref[displayNormal]{FR: Display-Interslice-Normal-Forces} &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  & X & X &  &  & X &  &  &  &  &  &  &  &  &  &  &  &  &  &  & 
+\hyperref[displayNormal]{FR: Display-Interslice-Normal-Forces} &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  & X & X &  &  & X &  &  &  &  &  &  &  &  &  &  &  &  &  &  & 
 \\
-\hyperref[displayShear]{FR: Display-Interslice-Shear-Forces} &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  & X & X &  &  & X &  &  &  &  &  &  &  &  &  &  &  &  &  &  & 
+\hyperref[displayShear]{FR: Display-Interslice-Shear-Forces} &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  & X & X &  &  & X &  &  &  &  &  &  &  &  &  &  &  &  &  &  & 
 \\
-\hyperref[writeToFile]{FR: Write-Results-To-File} &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  & X & X & X & X & X &  &  &  &  & 
+\hyperref[writeToFile]{FR: Write-Results-To-File} &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  & X & X & X & X & X &  &  &  &  & 
 \\
-\hyperref[correct]{NFR: Correct} &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  & 
+\hyperref[correct]{NFR: Correct} &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  & 
 \\
-\hyperref[understandable]{NFR: Understandable} &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  & 
+\hyperref[understandable]{NFR: Understandable} &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  & 
 \\
-\hyperref[reusable]{NFR: Reusable} &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  & 
+\hyperref[reusable]{NFR: Reusable} &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  & 
 \\
-\hyperref[maintainable]{NFR: Maintainable} &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  & 
+\hyperref[maintainable]{NFR: Maintainable} &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  & 
 \\
 \bottomrule
 \caption{Traceability Matrix Showing the Connections Between Requirements, Goal Statements and Other Items}

--- a/code/stable/ssp/Website/SSP_SRS.html
+++ b/code/stable/ssp/Website/SSP_SRS.html
@@ -663,9 +663,7 @@
                 </tr>
                 <tr>
                   <td><em>τ</em></td>
-                  <td>
-                    Tangential Stress: The total force per area acting on the soil mass.
-                  </td>
+                  <td>Tangential Stress: The shear force per unit area.</td>
                   <td><em>Pa</em></td>
                 </tr>
                 <tr>

--- a/code/stable/ssp/Website/SSP_SRS.html
+++ b/code/stable/ssp/Website/SSP_SRS.html
@@ -165,6 +165,13 @@
                   <td>--</td>
                 </tr>
                 <tr>
+                  <td><em>F<sub>t</sub></em></td>
+                  <td>
+                    Tangential Force: Component of a force in the tangential direction.
+                  </td>
+                  <td><em>N</em></td>
+                </tr>
+                <tr>
                   <td><em>F<sub>x</sub></em></td>
                   <td>
                     <em>x</em>-coordinate of the Force: The force acting in the <em>x</em>-direction.
@@ -651,6 +658,13 @@
                   <td><em>σ<sub>N</sub>&prime;</em></td>
                   <td>
                     Effective Normal Stress: The normal stress in a soil mass that is effective in causing volume changes; represents the average normal stress carried by the soil skeleton.
+                  </td>
+                  <td><em>Pa</em></td>
+                </tr>
+                <tr>
+                  <td><em>τ</em></td>
+                  <td>
+                    Tangential Stress: The total force per area acting on the soil mass.
                   </td>
                   <td><em>Pa</em></td>
                 </tr>
@@ -3061,6 +3075,53 @@
                   </table>
                 </div>
                 <p class="paragraph"></p>
+                <div id="DD:tangStress">
+                  <table class="ddefn">
+                    <tr>
+                      <th>Refname</th>
+                      <td><b>DD:tangStress</b></td>
+                    </tr>
+                    <tr>
+                      <th>Label</th>
+                      <td><p class="paragraph">Tangential stress</p></td>
+                    </tr>
+                    <tr>
+                      <th>Symbol</th>
+                      <td><p class="paragraph"><em>τ</em></p></td>
+                    </tr>
+                    <tr>
+                      <th>Units</th>
+                      <td><p class="paragraph"><em>Pa</em></p></td>
+                    </tr>
+                    <tr>
+                      <th>Equation</th>
+                      <td>\[τ=\frac{{F_{\text{t}}}}{A}\]</td>
+                    </tr>
+                    <tr>
+                      <th>Description</th>
+                      <td>
+                        <ul class="hide-list-style-no-indent">
+                          <li><em>τ</em> is the tangential stress (<em>Pa</em>)</li>
+                          <li>
+                            <em>F<sub>t</sub></em> is the tangential force (<em>N</em>)
+                          </li>
+                          <li><em>A</em> is the area (<em>m<sup>2</sup></em>)</li>
+                        </ul>
+                      </td>
+                    </tr>
+                    <tr>
+                      <th>Source</th>
+                      <td>
+                        <p class="paragraph"><a href=#huston2008>huston2008</a></p>
+                      </td>
+                    </tr>
+                    <tr>
+                      <th>RefBy</th>
+                      <td><p class="paragraph"></p></td>
+                    </tr>
+                  </table>
+                </div>
+                <p class="paragraph"></p>
                 <div id="DD:torque">
                   <table class="ddefn">
                     <tr>
@@ -4865,6 +4926,25 @@
               <td></td>
             </tr>
             <tr>
+              <td><a href=#DD:tangStress>DD: tangStress</a></td>
+              <td></td>
+              <td></td>
+              <td></td>
+              <td></td>
+              <td></td>
+              <td></td>
+              <td></td>
+              <td></td>
+              <td></td>
+              <td></td>
+              <td></td>
+              <td></td>
+              <td></td>
+              <td></td>
+              <td></td>
+              <td></td>
+            </tr>
+            <tr>
               <td><a href=#DD:torque>DD: torque</a></td>
               <td></td>
               <td></td>
@@ -5879,6 +5959,7 @@
               <th><a href=#DD:lengthLs>DD: lengthLs</a></th>
               <th><a href=#DD:slcHeight>DD: slcHeight</a></th>
               <th><a href=#DD:normStress>DD: normStress</a></th>
+              <th><a href=#DD:tangStress>DD: tangStress</a></th>
               <th><a href=#DD:torque>DD: torque</a></th>
               <th><a href=#DD:ratioVariation>DD: ratioVariation</a></th>
               <th><a href=#DD:convertFunc1>DD: convertFunc1</a></th>
@@ -5915,6 +5996,7 @@
             </tr>
             <tr>
               <td><a href=#DD:intersliceWtrF>DD: intersliceWtrF</a></td>
+              <td></td>
               <td></td>
               <td></td>
               <td></td>
@@ -6000,9 +6082,11 @@
               <td></td>
               <td></td>
               <td></td>
+              <td></td>
             </tr>
             <tr>
               <td><a href=#DD:angleB>DD: angleB</a></td>
+              <td></td>
               <td></td>
               <td></td>
               <td></td>
@@ -6088,6 +6172,7 @@
               <td></td>
               <td></td>
               <td></td>
+              <td></td>
             </tr>
             <tr>
               <td><a href=#DD:lengthLb>DD: lengthLb</a></td>
@@ -6095,6 +6180,7 @@
               <td>X</td>
               <td></td>
               <td>X</td>
+              <td></td>
               <td></td>
               <td></td>
               <td></td>
@@ -6176,9 +6262,11 @@
               <td></td>
               <td></td>
               <td></td>
+              <td></td>
             </tr>
             <tr>
               <td><a href=#DD:slcHeight>DD: slcHeight</a></td>
+              <td></td>
               <td></td>
               <td></td>
               <td></td>
@@ -6264,9 +6352,56 @@
               <td></td>
               <td></td>
               <td></td>
+              <td></td>
+            </tr>
+            <tr>
+              <td><a href=#DD:tangStress>DD: tangStress</a></td>
+              <td></td>
+              <td></td>
+              <td></td>
+              <td></td>
+              <td></td>
+              <td></td>
+              <td></td>
+              <td></td>
+              <td></td>
+              <td></td>
+              <td></td>
+              <td></td>
+              <td></td>
+              <td></td>
+              <td></td>
+              <td></td>
+              <td></td>
+              <td></td>
+              <td></td>
+              <td></td>
+              <td></td>
+              <td></td>
+              <td></td>
+              <td></td>
+              <td></td>
+              <td></td>
+              <td></td>
+              <td></td>
+              <td></td>
+              <td></td>
+              <td></td>
+              <td></td>
+              <td></td>
+              <td></td>
+              <td></td>
+              <td></td>
+              <td></td>
+              <td></td>
+              <td></td>
+              <td></td>
+              <td></td>
+              <td></td>
             </tr>
             <tr>
               <td><a href=#DD:torque>DD: torque</a></td>
+              <td></td>
               <td></td>
               <td></td>
               <td></td>
@@ -6352,11 +6487,13 @@
               <td></td>
               <td></td>
               <td></td>
+              <td></td>
             </tr>
             <tr>
               <td><a href=#DD:convertFunc1>DD: convertFunc1</a></td>
               <td></td>
               <td>X</td>
+              <td></td>
               <td></td>
               <td></td>
               <td></td>
@@ -6408,6 +6545,7 @@
               <td></td>
               <td></td>
               <td></td>
+              <td></td>
               <td>X</td>
               <td>X</td>
               <td></td>
@@ -6443,6 +6581,7 @@
             </tr>
             <tr>
               <td><a href=#DD:nrmForceSumDD>DD: nrmForceSumDD</a></td>
+              <td></td>
               <td></td>
               <td></td>
               <td></td>
@@ -6528,9 +6667,11 @@
               <td></td>
               <td></td>
               <td></td>
+              <td></td>
             </tr>
             <tr>
               <td><a href=#DD:sliceHghtRightDD>DD: sliceHghtRightDD</a></td>
+              <td></td>
               <td></td>
               <td></td>
               <td></td>
@@ -6616,9 +6757,11 @@
               <td></td>
               <td></td>
               <td></td>
+              <td></td>
             </tr>
             <tr>
               <td><a href=#TM:factOfSafety>TM: factOfSafety</a></td>
+              <td></td>
               <td></td>
               <td></td>
               <td></td>
@@ -6704,9 +6847,11 @@
               <td></td>
               <td></td>
               <td></td>
+              <td></td>
             </tr>
             <tr>
               <td><a href=#TM:mcShrStrgth>TM: mcShrStrgth</a></td>
+              <td></td>
               <td></td>
               <td></td>
               <td></td>
@@ -6792,9 +6937,11 @@
               <td></td>
               <td></td>
               <td></td>
+              <td></td>
             </tr>
             <tr>
               <td><a href=#TM:NewtonSecLawMot>TM: NewtonSecLawMot</a></td>
+              <td></td>
               <td></td>
               <td></td>
               <td></td>
@@ -6856,6 +7003,7 @@
               <td></td>
               <td></td>
               <td></td>
+              <td></td>
               <td>X</td>
               <td></td>
               <td></td>
@@ -6886,6 +7034,7 @@
               <td></td>
               <td>X</td>
               <td>X</td>
+              <td></td>
               <td></td>
               <td></td>
               <td></td>
@@ -6945,6 +7094,7 @@
               <td></td>
               <td></td>
               <td></td>
+              <td></td>
               <td>X</td>
               <td></td>
               <td></td>
@@ -6976,6 +7126,7 @@
               <td></td>
               <td></td>
               <td>X</td>
+              <td></td>
               <td></td>
               <td></td>
               <td></td>
@@ -7034,6 +7185,7 @@
               <td></td>
               <td></td>
               <td></td>
+              <td></td>
               <td>X</td>
               <td></td>
               <td></td>
@@ -7064,6 +7216,7 @@
               <td>X</td>
               <td></td>
               <td>X</td>
+              <td></td>
               <td></td>
               <td></td>
               <td></td>
@@ -7134,6 +7287,7 @@
               <td></td>
               <td></td>
               <td></td>
+              <td></td>
               <td>X</td>
               <td></td>
               <td></td>
@@ -7147,6 +7301,7 @@
             </tr>
             <tr>
               <td><a href=#GD:normShrR>GD: normShrR</a></td>
+              <td></td>
               <td></td>
               <td></td>
               <td></td>
@@ -7198,6 +7353,7 @@
               <td></td>
               <td></td>
               <td>X</td>
+              <td></td>
               <td></td>
               <td>X</td>
               <td></td>
@@ -7255,6 +7411,7 @@
               <td></td>
               <td></td>
               <td></td>
+              <td></td>
               <td>X</td>
               <td></td>
               <td></td>
@@ -7283,6 +7440,7 @@
               <td></td>
               <td></td>
               <td>X</td>
+              <td></td>
               <td></td>
               <td></td>
               <td></td>
@@ -7364,6 +7522,7 @@
               <td></td>
               <td></td>
               <td></td>
+              <td></td>
             </tr>
             <tr>
               <td><a href=#GD:baseWtrF>GD: baseWtrF</a></td>
@@ -7372,6 +7531,7 @@
               <td></td>
               <td></td>
               <td>X</td>
+              <td></td>
               <td></td>
               <td></td>
               <td></td>
@@ -7443,6 +7603,7 @@
               <td></td>
               <td></td>
               <td></td>
+              <td></td>
               <td>X</td>
               <td></td>
               <td>X</td>
@@ -7455,6 +7616,7 @@
             </tr>
             <tr>
               <td><a href=#IM:fctSfty>IM: fctSfty</a></td>
+              <td></td>
               <td></td>
               <td></td>
               <td></td>
@@ -7499,6 +7661,7 @@
             </tr>
             <tr>
               <td><a href=#IM:nrmShrFor>IM: nrmShrFor</a></td>
+              <td></td>
               <td></td>
               <td></td>
               <td></td>
@@ -7577,6 +7740,7 @@
               <td></td>
               <td></td>
               <td></td>
+              <td></td>
               <td>X</td>
               <td></td>
               <td>X</td>
@@ -7591,6 +7755,7 @@
               <td></td>
               <td></td>
               <td>X</td>
+              <td></td>
               <td></td>
               <td></td>
               <td></td>
@@ -7631,6 +7796,7 @@
             </tr>
             <tr>
               <td><a href=#IM:intsliceFs>IM: intsliceFs</a></td>
+              <td></td>
               <td></td>
               <td></td>
               <td></td>
@@ -7716,6 +7882,7 @@
               <td></td>
               <td></td>
               <td></td>
+              <td></td>
             </tr>
           </table>
           <p class="caption">
@@ -7734,6 +7901,7 @@
               <th><a href=#DD:lengthLs>DD: lengthLs</a></th>
               <th><a href=#DD:slcHeight>DD: slcHeight</a></th>
               <th><a href=#DD:normStress>DD: normStress</a></th>
+              <th><a href=#DD:tangStress>DD: tangStress</a></th>
               <th><a href=#DD:torque>DD: torque</a></th>
               <th><a href=#DD:ratioVariation>DD: ratioVariation</a></th>
               <th><a href=#DD:convertFunc1>DD: convertFunc1</a></th>
@@ -7790,6 +7958,7 @@
             </tr>
             <tr>
               <td><a href=#identifyCritAndFS>GS: Identify-Crit-and-FS</a></td>
+              <td></td>
               <td></td>
               <td></td>
               <td></td>
@@ -7903,9 +8072,11 @@
               <td></td>
               <td></td>
               <td></td>
+              <td></td>
             </tr>
             <tr>
               <td><a href=#determineShearF>GS: Determine-Shear-Forces</a></td>
+              <td></td>
               <td></td>
               <td></td>
               <td></td>
@@ -8019,9 +8190,11 @@
               <td></td>
               <td></td>
               <td></td>
+              <td></td>
             </tr>
             <tr>
               <td><a href=#verifyInput>FR: Verify-Input</a></td>
+              <td></td>
               <td></td>
               <td></td>
               <td></td>
@@ -8082,6 +8255,7 @@
               <td>
                 <a href=#determineCritSlip>FR: Determine-Critical-Slip-Surface</a>
               </td>
+              <td></td>
               <td></td>
               <td></td>
               <td></td>
@@ -8195,9 +8369,11 @@
               <td></td>
               <td></td>
               <td></td>
+              <td></td>
             </tr>
             <tr>
               <td><a href=#displayInput>FR: Display-Input</a></td>
+              <td></td>
               <td></td>
               <td></td>
               <td></td>
@@ -8296,6 +8472,7 @@
               <td></td>
               <td></td>
               <td></td>
+              <td></td>
               <td>X</td>
               <td></td>
               <td></td>
@@ -8314,6 +8491,7 @@
             </tr>
             <tr>
               <td><a href=#displayFS>FR: Display-Factor-of-Safety</a></td>
+              <td></td>
               <td></td>
               <td></td>
               <td></td>
@@ -8409,6 +8587,7 @@
               <td></td>
               <td></td>
               <td></td>
+              <td></td>
               <td>X</td>
               <td>X</td>
               <td></td>
@@ -8469,6 +8648,7 @@
               <td></td>
               <td></td>
               <td></td>
+              <td></td>
               <td>X</td>
               <td>X</td>
               <td></td>
@@ -8492,6 +8672,7 @@
             </tr>
             <tr>
               <td><a href=#writeToFile>FR: Write-Results-To-File</a></td>
+              <td></td>
               <td></td>
               <td></td>
               <td></td>
@@ -8605,9 +8786,11 @@
               <td></td>
               <td></td>
               <td></td>
+              <td></td>
             </tr>
             <tr>
               <td><a href=#understandable>NFR: Understandable</a></td>
+              <td></td>
               <td></td>
               <td></td>
               <td></td>
@@ -8721,9 +8904,11 @@
               <td></td>
               <td></td>
               <td></td>
+              <td></td>
             </tr>
             <tr>
               <td><a href=#maintainable>NFR: Maintainable</a></td>
+              <td></td>
               <td></td>
               <td></td>
               <td></td>


### PR DESCRIPTION
- contains all changed files related to updating the Stress Data Definition to NormStress + Implementing the new TangStress Data Definition
- implementation of new TangStress Data Definition also necessitated creation of:
  - new symbol F_t for SSP
  - QDefinition TangStressQD
  - Expr TangStressEqn
  - Unital Chunk TangStress

- updated all references of totStress to totNormStress (changes related to Item 2)
- changed files: DataDefs.hs, TMods.hs, Unitals.hs, SSP_SRS.tex, SSP_SRS.html
- contributes to #2156 (addresses Issue Item 3, includes changes related to Item 2)