### PR TITLE
Update GD ResShr Referencing

### DIFF
--- a/code/drasil-example/Drasil/SSP/GenDefs.hs
+++ b/code/drasil-example/Drasil/SSP/GenDefs.hs
@@ -28,7 +28,7 @@ import Drasil.SSP.Assumptions (assumpFOSL, assumpSLH, assumpSP, assumpSLI,
   assumpHFSM)
 import Drasil.SSP.BasicExprs (eqlExpr, eqlExprN, momExpr)
 import Drasil.SSP.DataDefs (intersliceWtrF, angleA, angleB, lengthB, lengthLb, 
-  lengthLs, slcHeight, normStressDD, ratioVariation)
+  lengthLs, slcHeight, normStressDD, tangStressDD, ratioVariation)
 import Drasil.SSP.Defs (intrslce, slice, slope, slopeSrf, slpSrf, soil, 
   soilPrpty, waterTable)
 import Drasil.SSP.Figures (figForceActing)
@@ -139,7 +139,7 @@ resShrDesc = foldlSent [ch baseLngth, S "is defined in", makeRef2S lengthLb]
 
 resShrDeriv :: Derivation
 resShrDeriv = mkDerivNoHeader [foldlSent [S "Derived by substituting",
-  makeRef2S normStressDD, S "into the Mohr-Coulomb", phrase shrStress `sC`
+  makeRef2S normStressDD, S "and", makeRef2S tangStressDD, S "into the Mohr-Coulomb", phrase shrStress `sC`
   makeRef2S mcShrStrgth `sC` S "and multiplying both sides of the",
   phrase equation, S "by",  phrase genericA `ofThe` phrase slice `sIn`
   S "the shear-" :+: ch zcoord +:+. S "plane", S "Since the", phrase slope,

--- a/code/stable/ssp/SRS/SSP_SRS.tex
+++ b/code/stable/ssp/SRS/SSP_SRS.tex
@@ -770,7 +770,7 @@ RefBy & \hyperref[GD:mobShr]{GD: mobShr}
 \end{minipage}
 \paragraph{}
 \label{GD:resShrDeriv}
-Derived by substituting \hyperref[DD:normStress]{DD: normStress} into the Mohr-Coulomb shear strength, \hyperref[TM:mcShrStrgth]{TM: mcShrStrgth}, and multiplying both sides of the equation by the area of the slice in the shear-$z$ plane. Since the slope is assumed to extend infinitely in the $z$-direction (\hyperref[assumpPSC]{A: Plane-Strain-Conditions}), the resulting forces are expressed per metre in the $z$-direction. The effective angle of friction $φ'$ and the effective cohesion $c'$ are not indexed by $i$ because they are assumed to be isotropic (\hyperref[assumpSLI]{A: Soil-Layers-Isotropic}) and the soil is assumed to be homogeneous, with constant soil properties throughout (\hyperref[assumpSLH]{A: Soil-Layer-Homogeneous}, \hyperref[assumpSP]{A: Soil-Properties}).
+Derived by substituting \hyperref[DD:normStress]{DD: normStress} and \hyperref[DD:tangStress]{DD: tangStress} into the Mohr-Coulomb shear strength, \hyperref[TM:mcShrStrgth]{TM: mcShrStrgth}, and multiplying both sides of the equation by the area of the slice in the shear-$z$ plane. Since the slope is assumed to extend infinitely in the $z$-direction (\hyperref[assumpPSC]{A: Plane-Strain-Conditions}), the resulting forces are expressed per metre in the $z$-direction. The effective angle of friction $φ'$ and the effective cohesion $c'$ are not indexed by $i$ because they are assumed to be isotropic (\hyperref[assumpSLI]{A: Soil-Layers-Isotropic}) and the soil is assumed to be homogeneous, with constant soil properties throughout (\hyperref[assumpSLH]{A: Soil-Layer-Homogeneous}, \hyperref[assumpSP]{A: Soil-Properties}).
 
 \vspace{\baselineskip}
 \noindent
@@ -1734,7 +1734,8 @@ Description & \begin{symbDescription}
 Source & \cite{huston2008}
          
 \\ \midrule \\
-RefBy & 
+RefBy & \hyperref[GD:resShr]{GD: resShr}
+        
 \\ \bottomrule
 \end{tabular}
 \end{minipage}
@@ -2884,7 +2885,7 @@ The purpose of the traceability matrices is to provide easy references on what h
 \\
 \hyperref[GD:bsShrFEq]{GD: bsShrFEq} &  & X & X &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  & X &  &  &  &  &  &  &  &  &  &  &  &  &  & X &  &  & X &  &  &  &  &  & 
 \\
-\hyperref[GD:resShr]{GD: resShr} &  &  &  &  & X &  &  & X &  &  &  &  &  &  &  &  &  &  &  & X &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  & 
+\hyperref[GD:resShr]{GD: resShr} &  &  &  &  & X &  &  & X & X &  &  &  &  &  &  &  &  &  &  & X &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  & 
 \\
 \hyperref[GD:mobShr]{GD: mobShr} &  &  &  &  & X &  &  &  &  &  &  &  &  &  &  &  &  & X &  &  &  &  &  &  & X &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  & 
 \\

--- a/code/stable/ssp/Website/SSP_SRS.html
+++ b/code/stable/ssp/Website/SSP_SRS.html
@@ -1641,7 +1641,7 @@
                   <div class="subsubsubsection">
                     <h4></h4>
                     <p class="paragraph">
-                      Derived by substituting <a href=#DD:normStress>DD: normStress</a> into the Mohr-Coulomb shear strength, <a href=#TM:mcShrStrgth>TM: mcShrStrgth</a>, and multiplying both sides of the equation by the area of the slice in the shear-<em>z</em> plane. Since the slope is assumed to extend infinitely in the <em>z</em>-direction (<a href=#assumpPSC>A: Plane-Strain-Conditions</a>), the resulting forces are expressed per metre in the <em>z</em>-direction. The effective angle of friction <em>φ&prime;</em> and the effective cohesion <em>c&prime;</em> are not indexed by <em>i</em> because they are assumed to be isotropic (<a href=#assumpSLI>A: Soil-Layers-Isotropic</a>) and the soil is assumed to be homogeneous, with constant soil properties throughout (<a href=#assumpSLH>A: Soil-Layer-Homogeneous</a>, <a href=#assumpSP>A: Soil-Properties</a>).
+                      Derived by substituting <a href=#DD:normStress>DD: normStress</a> and <a href=#DD:tangStress>DD: tangStress</a> into the Mohr-Coulomb shear strength, <a href=#TM:mcShrStrgth>TM: mcShrStrgth</a>, and multiplying both sides of the equation by the area of the slice in the shear-<em>z</em> plane. Since the slope is assumed to extend infinitely in the <em>z</em>-direction (<a href=#assumpPSC>A: Plane-Strain-Conditions</a>), the resulting forces are expressed per metre in the <em>z</em>-direction. The effective angle of friction <em>φ&prime;</em> and the effective cohesion <em>c&prime;</em> are not indexed by <em>i</em> because they are assumed to be isotropic (<a href=#assumpSLI>A: Soil-Layers-Isotropic</a>) and the soil is assumed to be homogeneous, with constant soil properties throughout (<a href=#assumpSLH>A: Soil-Layer-Homogeneous</a>, <a href=#assumpSP>A: Soil-Properties</a>).
                     </p>
                   </div>
                 </div>
@@ -3115,7 +3115,7 @@
                     </tr>
                     <tr>
                       <th>RefBy</th>
-                      <td><p class="paragraph"></p></td>
+                      <td><p class="paragraph"><a href=#GD:resShr>GD: resShr</a></p></td>
                     </tr>
                   </table>
                 </div>
@@ -7082,7 +7082,7 @@
               <td></td>
               <td></td>
               <td>X</td>
-              <td></td>
+              <td>X</td>
               <td></td>
               <td></td>
               <td></td>


### PR DESCRIPTION
- contains all changed files related to updating referencing for the general definition ResShr

- updated referencing for GD ResShr to include DD TangStress

- changed files: GenDefs.hs, SSP_SRS.tex, SSP_SRS.html

- closes #2156 (addresses Issue Item 4, the last Item of this Issue)