### PR TITLE
Issue 2147

### DIFF
--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer.hs
@@ -13,7 +13,7 @@ module GOOL.Drasil.LanguageRenderer (
   -- * Default Functions available for use in renderers
   package, file, module', class', multiStmt, block, body, print, printFile, 
   param, method, stateVar, constVar, stateVarList, switch, assign, multiAssign, 
-  addAssign, increment, listDec, getTerm, return', comment, var, extVar,
+  addAssign, subAssign, increment, listDec, getTerm, return', comment, var, extVar,
   arg, classVar, objVar, unOpDocD, unOpDocD', binOpDocD, binOpDocD', 
   constDecDef, func, cast, listAccessFunc, listSetFunc, objAccess, castObj, 
   break, continue, static, dynamic, private, public, blockCmt, docCmt, 
@@ -227,6 +227,9 @@ multiAssign vrs vls = variableList vrs <+> equals <+> valueList vls
 
 addAssign :: (RenderSym r) => r (Variable r) -> r (Value r) -> Doc
 addAssign vr vl = RC.variable vr <+> text "+=" <+> RC.value vl
+
+subAssign :: (RenderSym r) => r (Variable r) -> r (Value r) -> Doc
+subAssign vr vl = RC.variable vr <+> text "-=" <+> RC.value vl
 
 increment :: (RenderSym r) => r (Variable r) -> Doc
 increment v = RC.variable v <> text "++"

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer/CSharpRenderer.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer/CSharpRenderer.hs
@@ -59,7 +59,7 @@ import qualified GOOL.Drasil.LanguageRenderer.LanguagePolymorphic as G (
   objAccess, objMethodCall, call, funcAppMixedArgs, selfFuncAppMixedArgs, 
   newObjMixedArgs, lambda, func, get, set, listAdd, listAppend, iterBegin, 
   iterEnd, listAccess, listSet, getFunc, setFunc, listAppendFunc, stmt, 
-  loopStmt, emptyStmt, assign, increment, objDecNew, print, closeFile,
+  loopStmt, emptyStmt, assign, subAssign, increment, objDecNew, print, closeFile,
   returnStmt, valStmt, comment, throw, ifCond, tryCatch, construct, param, 
   method, getMethod, setMethod, constructor, function, docFunc, buildClass, 
   extraClass, implementingClass, docClass, commentedClass, modFromData, fileDoc, 
@@ -76,7 +76,7 @@ import qualified GOOL.Drasil.LanguageRenderer.CLike as C (float, double, char,
   inlineIf, libFuncAppMixedArgs, libNewObjMixedArgs, listSize, increment1, 
   varDec, varDecDef, listDec, extObjDecNew, switch, for, while, intFunc, 
   multiAssignError, multiReturnError)
-import qualified GOOL.Drasil.LanguageRenderer.Macros as M (ifExists, decrement, 
+import qualified GOOL.Drasil.LanguageRenderer.Macros as M (ifExists, 
   decrement1, runStrategy, listSlice, stringListVals, stringListLists,
   forRange, notifyObservers, checkState)
 import GOOL.Drasil.AST (Terminator(..), FileType(..), FileData(..), fileD, 
@@ -456,7 +456,7 @@ instance StatementSym CSharpCode where
 
 instance AssignStatement CSharpCode where
   assign = G.assign Semi
-  (&-=) = M.decrement
+  (&-=) = G.subAssign Semi
   (&+=) = G.increment
   (&++) = C.increment1
   (&--) = M.decrement1

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer/CppRenderer.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer/CppRenderer.hs
@@ -60,7 +60,7 @@ import qualified GOOL.Drasil.LanguageRenderer.LanguagePolymorphic as G (
   objMethodCall, funcAppMixedArgs, selfFuncAppMixedArgs, newObjMixedArgs, 
   lambda, func, get, set, listAdd, listAppend, iterBegin, iterEnd, listAccess, 
   listSet, getFunc, setFunc, listAppendFunc, stmt, loopStmt, emptyStmt, assign, 
-  increment, objDecNew, print, closeFile, returnStmt, valStmt, comment, throw, 
+  subAssign, increment, objDecNew, print, closeFile, returnStmt, valStmt, comment, throw, 
   ifCond, tryCatch, construct, param, method, getMethod, setMethod, 
   constructor, function, docFunc, buildClass, extraClass, 
   implementingClass, docClass, commentedClass, modFromData, fileDoc, docMod, fileFromData)
@@ -73,7 +73,7 @@ import qualified GOOL.Drasil.LanguageRenderer.CLike as C (charRender, float,
   litFloat, inlineIf, libFuncAppMixedArgs, libNewObjMixedArgs, listSize, 
   increment1, varDec, varDecDef, listDec, extObjDecNew, switch, for, while, 
   intFunc, multiAssignError, multiReturnError)
-import qualified GOOL.Drasil.LanguageRenderer.Macros as M (decrement, 
+import qualified GOOL.Drasil.LanguageRenderer.Macros as M ( 
   decrement1, runStrategy, listSlice, stringListVals, stringListLists, forRange,
   notifyObservers)
 import GOOL.Drasil.AST (Terminator(..), ScopeTag(..), Binding(..), onBinding, 
@@ -1325,7 +1325,7 @@ instance StatementSym CppSrcCode where
 
 instance AssignStatement CppSrcCode where
   assign = G.assign Semi
-  (&-=) = M.decrement
+  (&-=) = G.subAssign Semi
   (&+=) = G.increment
   (&++) = C.increment1
   (&--) = M.decrement1

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer/JavaRenderer.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer/JavaRenderer.hs
@@ -58,7 +58,7 @@ import qualified GOOL.Drasil.LanguageRenderer.LanguagePolymorphic as G (
   objAccess, objMethodCall, funcAppMixedArgs, selfFuncAppMixedArgs, 
   newObjMixedArgs, lambda, func, get, set, listAdd, listAppend, iterBegin, 
   iterEnd, listAccess, listSet, getFunc, setFunc, listAppendFunc, stmt, 
-  loopStmt, emptyStmt, assign, increment, objDecNew, print, closeFile, 
+  loopStmt, emptyStmt, assign, subAssign, increment, objDecNew, print, closeFile, 
   returnStmt, valStmt, comment, throw, ifCond, tryCatch, construct, param, 
   method, getMethod, setMethod, constructor, function, docFunc, buildClass, 
   implementingClass, docClass, commentedClass, modFromData, fileDoc, 
@@ -76,7 +76,7 @@ import qualified GOOL.Drasil.LanguageRenderer.CLike as C (float, double, char,
   inlineIf, libFuncAppMixedArgs, libNewObjMixedArgs, listSize, increment1, 
   varDec, varDecDef, listDec, extObjDecNew, switch, for, while, intFunc, 
   multiAssignError, multiReturnError)
-import qualified GOOL.Drasil.LanguageRenderer.Macros as M (ifExists, decrement, 
+import qualified GOOL.Drasil.LanguageRenderer.Macros as M (ifExists, 
   decrement1, runStrategy, listSlice, stringListVals, stringListLists,
   forRange, notifyObservers, checkState)
 import GOOL.Drasil.AST (Terminator(..), ScopeTag(..), qualName, FileType(..), 
@@ -483,7 +483,7 @@ instance StatementSym JavaCode where
 
 instance AssignStatement JavaCode where
   assign = G.assign Semi
-  (&-=) = M.decrement
+  (&-=) = G.subAssign Semi
   (&+=) = G.increment
   (&++) = C.increment1
   (&--) = M.decrement1

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer/LanguagePolymorphic.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer/LanguagePolymorphic.hs
@@ -9,11 +9,11 @@ module GOOL.Drasil.LanguageRenderer.LanguagePolymorphic (fileFromData,
   valueOf, arg, argsList, call, funcAppMixedArgs, selfFuncAppMixedArgs, 
   newObjMixedArgs, lambda, objAccess, objMethodCall, func, get, set, listAdd, 
   listAppend, iterBegin, iterEnd, listAccess, listSet, getFunc, setFunc, 
-  listAppendFunc, stmt, loopStmt, emptyStmt, assign, increment, objDecNew, 
-  print, closeFile, returnStmt, valStmt, comment, throw, ifCond, tryCatch, 
-  construct, param, method, getMethod, setMethod, constructor, function, 
-  docFuncRepr, docFunc, buildClass, extraClass, implementingClass, docClass, 
-  commentedClass, modFromData, fileDoc, docMod
+  listAppendFunc, stmt, loopStmt, emptyStmt, assign, subAssign, increment, 
+  objDecNew, print, closeFile, returnStmt, valStmt, comment, throw, ifCond, 
+  tryCatch, construct, param, method, getMethod, setMethod, constructor, 
+  function, docFuncRepr, docFunc, buildClass, extraClass, implementingClass, 
+  docClass, commentedClass, modFromData, fileDoc, docMod
 ) where
 
 import Utils.Drasil (indent)
@@ -61,7 +61,7 @@ import GOOL.Drasil.LanguageRenderer (dot, ifLabel, elseLabel, access, addExt,
   functionDox, classDox, moduleDox, getterName, setterName, valueList, 
   namedArgList)
 import qualified GOOL.Drasil.LanguageRenderer as R (file, block, assign, 
-  addAssign, return', comment, getTerm, var, arg, func, objAccess, 
+  addAssign, subAssign, return', comment, getTerm, var, arg, func, objAccess, 
   commentedItem)
 import GOOL.Drasil.LanguageRenderer.Constructors (mkStmt, mkStmtNoEnd, 
   mkStateVal, mkVal, mkStateVar, mkStaticVar, VSOp, unOpPrec, compEqualPrec, 
@@ -314,6 +314,10 @@ emptyStmt = toState $ mkStmtNoEnd empty
 assign :: (RenderSym r) => Terminator -> SVariable r -> SValue r -> 
   MSStatement r
 assign t = zoom lensMStoVS .: on2StateValues (flip stmtFromData t .: R.assign)
+
+subAssign :: (RenderSym r) => Terminator -> SVariable r -> SValue r -> 
+  MSStatement r
+subAssign t = zoom lensMStoVS .: on2StateValues (flip stmtFromData t .: R.subAssign)
 
 increment :: (RenderSym r) => SVariable r -> SValue r -> MSStatement r
 increment = zoom lensMStoVS .: on2StateValues (mkStmt .: R.addAssign)

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer/Macros.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer/Macros.hs
@@ -2,7 +2,7 @@
 
 -- | Language-polymorphic functions that are defined by GOOL code
 module GOOL.Drasil.LanguageRenderer.Macros (
-  ifExists, decrement, decrement1, increment, increment1, runStrategy, 
+  ifExists, decrement1, increment, increment1, runStrategy, 
   listSlice, stringListVals, stringListLists, forRange, notifyObservers,
   observerIndex, checkState
 ) where
@@ -34,9 +34,6 @@ import Text.PrettyPrint.HughesPJ (Doc, vcat)
 
 ifExists :: (RenderSym r) => SValue r -> MSBody r -> MSBody r -> MSStatement r
 ifExists v ifBody = S.ifCond [(S.notNull v, ifBody)]
-
-decrement :: (RenderSym r) => SVariable r -> SValue r -> MSStatement r
-decrement vr vl = vr &= (S.valueOf vr #- vl)
 
 decrement1 :: (RenderSym r) => SVariable r -> MSStatement r
 decrement1 v = v &= (S.valueOf v #- S.litInt 1)

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer/PythonRenderer.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer/PythonRenderer.hs
@@ -55,7 +55,7 @@ import qualified GOOL.Drasil.LanguageRenderer.LanguagePolymorphic as G (
   objMethodCall, call, funcAppMixedArgs, selfFuncAppMixedArgs, newObjMixedArgs, 
   lambda, func, get, set, listAdd, listAppend, iterBegin, iterEnd, listAccess, 
   listSet, getFunc, setFunc, listAppendFunc, stmt, loopStmt, emptyStmt, assign, 
-  increment, objDecNew, print, closeFile, returnStmt, valStmt, comment, throw, 
+  subAssign, increment, objDecNew, print, closeFile, returnStmt, valStmt, comment, throw, 
   ifCond, tryCatch, construct, param, method, getMethod, setMethod, 
   constructor, function, docFunc, buildClass, extraClass, implementingClass, docClass, 
   commentedClass, modFromData, fileDoc, docMod, fileFromData)
@@ -65,7 +65,7 @@ import qualified GOOL.Drasil.LanguageRenderer.CommonPseudoOO as CP (
   indexOf, listAddFunc,  iterBeginError, iterEndError, listDecDef, 
   discardFileLine, destructorError, stateVarDef, constVar, intClass, objVar, 
   funcType, listSetFunc, listAccessFunc, buildModule)
-import qualified GOOL.Drasil.LanguageRenderer.Macros as M (ifExists, decrement, 
+import qualified GOOL.Drasil.LanguageRenderer.Macros as M (ifExists, 
   decrement1, increment1, runStrategy, stringListVals, stringListLists,
   observerIndex, checkState)
 import GOOL.Drasil.AST (Terminator(..), FileType(..), FileData(..), fileD, 
@@ -468,7 +468,7 @@ instance StatementSym PythonCode where
 
 instance AssignStatement PythonCode where
   assign = G.assign Empty
-  (&-=) = M.decrement
+  (&-=) = G.subAssign Empty
   (&+=) = G.increment
   (&++) = M.increment1
   (&--) = M.decrement1

--- a/code/stable/gooltest/cpp/HelloWorld/HelloWorld.cpp
+++ b/code/stable/gooltest/cpp/HelloWorld/HelloWorld.cpp
@@ -75,8 +75,8 @@ int main(int argc, const char *argv[]) {
         b = a + 2;
         c = b + 3;
         d = b;
-        d = d - a;
-        c = c - d;
+        d -= a;
+        c -= d;
         b += 17;
         c += 17;
         a++;

--- a/code/stable/gooltest/csharp/HelloWorld/HelloWorld.cs
+++ b/code/stable/gooltest/csharp/HelloWorld/HelloWorld.cs
@@ -60,8 +60,8 @@ public class HelloWorld {
             b = a + 2;
             c = b + 3;
             d = b;
-            d = d - a;
-            c = c - d;
+            d -= a;
+            c -= d;
             b += 17;
             c += 17;
             a++;

--- a/code/stable/gooltest/java/HelloWorld/HelloWorld/HelloWorld.java
+++ b/code/stable/gooltest/java/HelloWorld/HelloWorld/HelloWorld.java
@@ -47,8 +47,8 @@ public class HelloWorld {
             b = a + 2;
             c = b + 3;
             d = b;
-            d = d - a;
-            c = c - d;
+            d -= a;
+            c -= d;
             b += 17;
             c += 17;
             a++;

--- a/code/stable/gooltest/python/HelloWorld/HelloWorld.py
+++ b/code/stable/gooltest/python/HelloWorld/HelloWorld.py
@@ -33,8 +33,8 @@ elif (b == 5) :
     b = a + 2
     c = b + 3
     d = b
-    d = d - a
-    c = c - d
+    d -= a
+    c -= d
     b += 17;
     c += 17;
     a = a + 1


### PR DESCRIPTION
Closes #2147 

Quick synopsis of the modules if need be:
Language Renderer implements: subAssign which returns Doc
Language Polymorphic implements subAssign which uses previous subAssign, variable, value and terminator to return a MSStatement
Macros: was another subdivision of old solution (no longer needed)

Finally each language implements its own version of &-= by importing from Language Polymorphic. 


