### PR TITLE
Update Quick Start Guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,44 +5,47 @@ Generate all the Things!
 
 [Current Generated Artifacts](https://jacquescarette.github.io/Drasil/)
 
+## Table of Contents
+
+1. [What is Drasil?](https://github.com/JacquesCarette/Drasil/tree/Issue%232136#what-is-drasil)
+   - description of the Drasil framework
+2. [Quick Start](https://github.com/JacquesCarette/Drasil/tree/Issue%232136#quick-start)
+   - instructions for quick-starting the Drasil framework
+3. [Building Specific Examples](https://github.com/JacquesCarette/Drasil/tree/Issue%232136#building-specific-examples)
+   - instructions for how to build specific examples using Drasil
+4. [Running the Example(s)](https://github.com/JacquesCarette/Drasil/tree/Issue%232136#running-the-examples)
+   - instructions for running specific examples
+5. [Finding / Building the Haddock Documentation](https://github.com/JacquesCarette/Drasil/tree/Issue%232136#finding--building-the-haddock-documentation)
+   - Haddock documentation instructions
+6. [Summary of Folder Structure and File Contents](https://github.com/JacquesCarette/Drasil/tree/Issue%232136#summary-of-folder-structure-and-file-contents)
+
 ## What is Drasil?
 
-Drasil is a framework for generating all of the software artifacts from
-a stable knowledge base, focusing currently on scientific software. The main goals
-are to reduce knowledge duplication and improve traceability. We also are
-extreme in our drive to reuse everything.  We hope that
-maintainability, verifiability, traceability, and other software qualities will 
-also be improved as a side-effect of our methods.
+Drasil is a framework for generating all of the software artifacts from a stable knowledge base, focusing currently on scientific software. The main goals are to reduce knowledge duplication and improve traceability. We also are extreme in our drive to reuse everything.  We hope that maintainability, verifiability, traceability, and other software qualities will also be improved as a side-effect of our methods.
 
-Drasil is used to generate *all* requisite software artifacts from a common 
-*knowledge-base* using *recipes* written in a Domain-Specific Language (DSL).
-These recipes allow us to specify which pieces of knowledge should be used in
-which artifacts, how to transform them, and more.
+Drasil is used to generate *all* requisite software artifacts from a common *knowledge-base* using *recipes* written in a Domain-Specific Language (DSL). These recipes allow us to specify which pieces of knowledge should be used in which artifacts, how to transform them, and more.
 
-Drasil is being designed and implemented using a grounded theory approach.  To
-determine what is needed and make the design general, we are concurrently
-implementing six examples (case studies) in Drasil.  (The specific examples are
-listed below under "Building specific examples.")  These examples were first
-written using a typical "manual" approach.  The full files for the case studies
-are available in [a separate case studies repo](https://github.com/smiths/caseStudies).
+Drasil is being designed and implemented using a grounded theory approach.  To determine what is needed and make the design general, we are concurrently implementing six examples (case studies) in Drasil.  (The specific examples are listed below under "Building specific examples.")  These examples were first
+written using a typical "manual" approach.  The full files for the case studies are available in [a separate case studies repo](https://github.com/smiths/caseStudies).
 
-For more information on Drasil, please read 
-[our position paper](https://github.com/JacquesCarette/Drasil/blob/master/People/Dan/ICSE%20Workshop%20-%20SE4Science/ICSE_LiterateFrameworkForSCSoftware_LSS.pdf)
-or take a look at 
-[our poster](https://github.com/JacquesCarette/Drasil/blob/master/People/Dan/CAS%20Poster%20Competition/Poster/DrasilPoster.pdf).
+For more information on Drasil, please read [our position paper](https://github.com/JacquesCarette/Drasil/blob/master/People/Dan/ICSE%20Workshop%20-%20SE4Science/ICSE_LiterateFrameworkForSCSoftware_LSS.pdf) or take a look at [our poster](https://github.com/JacquesCarette/Drasil/blob/master/People/Dan/CAS%20Poster%20Competition/Poster/DrasilPoster.pdf).
 
 ## Quick Start
 
-If you are on Windows, we recommend you use cygwin (MinGW probably works too,
-but we have not tested it).  `make` is required as well; on MacOS, you may
-need to install XCode to get that. Most linux installs have it by default.
+If you are on Windows, we recommend you use cygwin (MinGW probably works too, but we have not tested it).  `make` is required as well; on MacOS, you may need to install XCode to get that. Most linux installs have it by default.
 
 1. Ensure you have [Stack](https://www.haskell.org/downloads#stack) installed (if you have the Haskell Platform, you should already have Stack).
+	- Also ensure that your stack version is at least 2.3.1 (latest version); for help, see [Stack Install & Upgrade](docs.haskellstack.org/en/stable/install_and_upgrade/)
 2. Run `stack setup` while in **./code/**
-3. Use the `make` command to build the current version of Drasil. This will build and run all of the examples as well.
-4. You can find the generated output in the build folder that appears. Each example will have its own subdirectory.
+	- Remember to  change your working directory to **./code/** first
+	- Use `cd` to change working directory, `pwd` to print your current working directory
+	- Refer to [File Directory](swcarpentry.github.io/shell-novice/02-filedir/index.html) for further help regarding file directory commands
+	- e.g. **./Users/.../GitHub/Drasil/code** (on MacOS)
+3. Use the `make` command to build the current version of Drasil. Note that this will build and run **all** of the examples as well.
+	- **Warning**: this entire process takes around 10-15 minutes to complete (MacOS estimate)
+4. You can find the generated output in the build folder that appears in the **./code/** folder. Each example will have its own subdirectory.
 
-## Building specific examples
+## Building Specific Examples
 
 Simply run: `make argument` to build the corresponding example, where argument is detailed below:
 
@@ -56,7 +59,7 @@ ssp_diff | Slope Stability Analysis
 nopcm_diff | minimal SWHS example, with PCM removed
 projectile_diff | Projectile motion analysis
 
-## Running the example(s)
+## Running the Example(s)
 
 Please note that if `make` has been used, docs are already generated automatically and can be found in build.
 Automated testing can be done on these examples.
@@ -77,31 +80,24 @@ This runs the examples manually from the .stack-work folder after building, and 
 appear in this folder (i.e. in the SRS and Website folders). Due to this placement, these generated
 versions will not be subject to automated tests.
 
-## Finding / Building the Haddock documentation
+## Finding / Building the Haddock Documentation
 
-You can run `make docs` from the ./code folder to build the documentation.
+You can run `make docs` from the ./code/ folder to build the documentation. **Note**: this process can take about 10-12 minutes (MacOS estimate).
 
-See the [README](https://github.com/JacquesCarette/Drasil/tree/master/code#building-up-to-date-documentation) 
-in ./code/ for more information.
+See the [README](https://github.com/JacquesCarette/Drasil/tree/master/code#building-up-to-date-documentation) in ./code/ for more information.
 
 --------------------------------------------------
 ### Summary of Folder Structure and File Contents
 --------------------------------------------------
 
-**Dan**
-  - Subdirectory for Dan Szymczak's work. Mostly papers and presentations
+**Papers**
+  - Subdirectory for papers related to Drasil framework, GOOL
   
-**GOOLCodeGen**
-  - An isolated compilation space for creating GOOL code for the examples.
+**People**
+  - contains contributions specific to some contributors (not necessarily to be implemented in Drasil)
   
 **Presentations**
   - Presentations on LSS/Drasil
-  
-**RelatedCode**
-  - Contains the *Generic Object Oriented Language* (GOOL) code.
-
-**Steve**
-  - Steven Palmer's work
   
 **WindowsFix**
   - Contains registry files for adding and removing the autorun of the command 
@@ -127,4 +123,4 @@ LICENSE
   
 README.md
   - This file
-  
+ 


### PR DESCRIPTION
Implemented the following proposed changes (contributes somewhat to #2136):
- add linked and descriptive Table of Contents section
- update Quick Start section with pointers for Stack Install/Upgrade and File Directory commands
- add warning for time taken to complete entire Drasil examples build process/Haddock documentation Finding/Building
- update Summary of Folder Structure and File Contents section