### PR TITLE
Remove Label Parameter from GOOL's State Variable Constructors

### DIFF
--- a/code/drasil-code/Language/Drasil/Code/Imperative/Modules.hs
+++ b/code/drasil-code/Language/Drasil/Code/Imperative/Modules.hs
@@ -187,10 +187,10 @@ genInputModCombined = do
   ic <- genInputClass Primary
   liftS $ genMod ic
 
-constVarFunc :: (OOProg r) => ConstantRepr -> String ->
+constVarFunc :: (OOProg r) => ConstantRepr ->
   (SVariable r -> SValue r -> CSStateVar r)
-constVarFunc Var n = stateVarDef n public dynamic
-constVarFunc Const n = constVar n public
+constVarFunc Var = stateVarDef public dynamic
+constVarFunc Const = constVar public
 
 -- | Returns Nothing if no inputs or constants are mapped to InputParameters in 
 -- the class definition map.
@@ -219,7 +219,7 @@ genInputClass scp = do
         inputVars <- mapM (\x -> fmap (pubDVar . var (codeName x) . convType) 
           (codeType x)) inps
         constVars <- zipWithM (\c vl -> fmap (\t -> constVarFunc (conRepr g) 
-          cname (var (codeName c) (convType t)) vl) (codeType c)) 
+          (var (codeName c) (convType t)) vl) (codeType c)) 
           csts vals
         let getFunc Primary = primaryClass
             getFunc Auxiliary = auxClass
@@ -438,7 +438,7 @@ genConstClass scp = do
       genClass vs = do
         vals <- mapM (convExpr . codeEquat) vs 
         vars <- mapM (\x -> fmap (var (codeName x) . convType) (codeType x)) vs
-        let constVars = zipWith (constVarFunc (conRepr g) cname) vars vals
+        let constVars = zipWith (constVarFunc (conRepr g)) vars vals
             getFunc Primary = primaryClass
             getFunc Auxiliary = auxClass
             f = getFunc scp

--- a/code/drasil-gool/GOOL/Drasil/ClassInterface.hs
+++ b/code/drasil-gool/GOOL/Drasil/ClassInterface.hs
@@ -559,9 +559,9 @@ type CSStateVar a = CS (a (StateVar a))
 class (ScopeSym r, PermanenceSym r, VariableSym r) => StateVarSym r where
   type StateVar r
   stateVar :: r (Scope r) -> r (Permanence r) -> SVariable r -> CSStateVar r
-  stateVarDef :: Label -> r (Scope r) -> r (Permanence r) -> SVariable r -> 
+  stateVarDef :: r (Scope r) -> r (Permanence r) -> SVariable r -> 
     SValue r -> CSStateVar r
-  constVar :: Label -> r (Scope r) ->  SVariable r -> SValue r -> CSStateVar r
+  constVar :: r (Scope r) ->  SVariable r -> SValue r -> CSStateVar r
 
 privDVar :: (StateVarSym r) => SVariable r -> CSStateVar r
 privDVar = stateVar private dynamic

--- a/code/drasil-gool/GOOL/Drasil/CodeInfo.hs
+++ b/code/drasil-gool/GOOL/Drasil/CodeInfo.hs
@@ -383,9 +383,9 @@ instance MethodSym CodeInfo where
 
 instance StateVarSym CodeInfo where
   type StateVar CodeInfo = ()
-  stateVar    _ _ _     = noInfo
-  stateVarDef _ _ _ _ _ = noInfo
-  constVar    _ _ _ _   = noInfo
+  stateVar    _ _ _   = noInfo
+  stateVarDef _ _ _ _ = noInfo
+  constVar    _ _ _   = noInfo
 
 instance ClassSym CodeInfo where
   type Class CodeInfo = ()

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer/CSharpRenderer.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer/CSharpRenderer.hs
@@ -617,8 +617,8 @@ instance MethodElim CSharpCode where
 instance StateVarSym CSharpCode where
   type StateVar CSharpCode = Doc
   stateVar = CP.stateVar
-  stateVarDef _ = CP.stateVarDef
-  constVar _ = CP.constVar empty
+  stateVarDef = CP.stateVarDef
+  constVar = CP.constVar empty
   
 instance StateVarElim CSharpCode where
   stateVar = unCSC

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer/JavaRenderer.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer/JavaRenderer.hs
@@ -650,8 +650,8 @@ instance MethodElim JavaCode where
 instance StateVarSym JavaCode where
   type StateVar JavaCode = Doc
   stateVar = CP.stateVar
-  stateVarDef _ = CP.stateVarDef
-  constVar _ = CP.constVar (RC.perm (static :: JavaCode (Permanence JavaCode)))
+  stateVarDef = CP.stateVarDef
+  constVar = CP.constVar (RC.perm (static :: JavaCode (Permanence JavaCode)))
   
 instance StateVarElim JavaCode where
   stateVar = unJC

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer/PythonRenderer.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer/PythonRenderer.hs
@@ -648,8 +648,8 @@ instance MethodElim PythonCode where
 instance StateVarSym PythonCode where
   type StateVar PythonCode = Doc
   stateVar _ _ _ = toState (toCode empty)
-  stateVarDef _ = CP.stateVarDef
-  constVar _ = CP.constVar (RC.perm 
+  stateVarDef = CP.stateVarDef
+  constVar = CP.constVar (RC.perm 
     (static :: PythonCode (Permanence PythonCode)))
   
 instance StateVarElim PythonCode where


### PR DESCRIPTION
- contains all changed files related to removing the `Label` parameter from GOOL's state variable constructors

- implemented changes to remove `Label` parameter from GOOL's state variable constructors `stateVarDef` and `constVar`

- changed files (seven):
   - drasil-code: Modules.hs
   - drasil-gool: ClassInterface.hs, CodeInfo.hs, CSharpRenderer.hs, CppRenderer.hs, JavaRenderer.hs, PythonRenderer.hs

- closes #2144 (addresses all items/changes requested in this Issue)