### PR TITLE
Issue 1342

### DIFF
--- a/code/drasil-lang/Language/Drasil.hs
+++ b/code/drasil-lang/Language/Drasil.hs
@@ -151,7 +151,7 @@ module Language.Drasil (
   -- Uncertainty.Core
   , Uncertainty, uncty
   -- Uncertainty
-  , defaultUncrt, uncVal, uncPrec
+  , defaultUncrt, uncVal, uncPrec, ignoreUncrt
   -- UnitLang
   , USymb(US)
   -- Data.Date
@@ -278,7 +278,7 @@ import Language.Drasil.Label.Type (getAdd, LblType(RP, Citation, URI), IRefProg(
 
 import Language.Drasil.UnitLang (USymb(US))
 import Language.Drasil.Uncertainty.Core(Uncertainty, uncty)
-import Language.Drasil.Uncertainty(defaultUncrt, uncVal, uncPrec)
+import Language.Drasil.Uncertainty(defaultUncrt, uncVal, uncPrec, ignoreUncrt)
 
 import Language.Drasil.Development.Sentence -- are these really development?
 import Language.Drasil.Chunk.UnitDefn (UnitDefn(..)

--- a/code/drasil-lang/Language/Drasil/Uncertainty.hs
+++ b/code/drasil-lang/Language/Drasil/Uncertainty.hs
@@ -10,7 +10,7 @@ defaultUncrt :: Uncertainty
 defaultUncrt = uncty 0.1 (Just 0)
 
 ignoreUncrt :: Uncertainty
-ignoreUncrt = uncty 0 (Nothing)
+ignoreUncrt = uncty 0 Nothing
 
 -- accessor for uncertainty value
 uncVal :: HasUncertainty x => x -> Double

--- a/code/drasil-lang/Language/Drasil/Uncertainty.hs
+++ b/code/drasil-lang/Language/Drasil/Uncertainty.hs
@@ -1,5 +1,5 @@
 module Language.Drasil.Uncertainty (defaultUncrt, uncty,
-    uncVal, uncPrec) where
+    uncVal, uncPrec, ignoreUncrt) where
 
 import Control.Lens ((^.))
 
@@ -8,6 +8,9 @@ import Language.Drasil.Uncertainty.Core (Uncertainty, uncert, prec, uncty)
 
 defaultUncrt :: Uncertainty
 defaultUncrt = uncty 0.1 (Just 0)
+
+ignoreUncrt :: Uncertainty
+ignoreUncrt = uncty 0 (Nothing)
 
 -- accessor for uncertainty value
 uncVal :: HasUncertainty x => x -> Double

--- a/code/drasil-lang/Language/Drasil/Uncertainty/Core.hs
+++ b/code/drasil-lang/Language/Drasil/Uncertainty/Core.hs
@@ -11,5 +11,6 @@ uncty u = Uncert (isDecimal u)
 
 --make sure that it is between 0 and 1, and throw an error otherwise
 isDecimal :: (Num a, Ord a) => a -> a
-isDecimal u  =  if (0 <= u) && (u < 1) then u
-                else error "Uncertainty must be between 0 and 1."
+isDecimal 0  =  error "To ignore uncertainty please use ' ignoreUncertainty '' "
+isDecimal u  =  if (0 < u) && (u < 1) then u
+                else error "Uncertainty must be between 0 and 1"

--- a/code/drasil-lang/Language/Drasil/Uncertainty/Core.hs
+++ b/code/drasil-lang/Language/Drasil/Uncertainty/Core.hs
@@ -11,6 +11,6 @@ uncty u = Uncert (isDecimal u)
 
 --make sure that it is between 0 and 1, and throw an error otherwise
 isDecimal :: (Num a, Ord a) => a -> a
-isDecimal 0  =  error "To ignore uncertainty please use ' ignoreUncertainty '' "
+isDecimal 0  =  error "To ignore uncertainty please use the ignoreUncertainty contructor."
 isDecimal u  =  if (0 < u) && (u < 1) then u
                 else error "Uncertainty must be between 0 and 1"

--- a/code/drasil-lang/Language/Drasil/Uncertainty/Core.hs
+++ b/code/drasil-lang/Language/Drasil/Uncertainty/Core.hs
@@ -11,6 +11,6 @@ uncty u = Uncert (isDecimal u)
 
 --make sure that it is between 0 and 1, and throw an error otherwise
 isDecimal :: (Num a, Ord a) => a -> a
-isDecimal 0  =  error "To ignore uncertainty please use the ignoreUncertainty contructor."
+isDecimal 0  =  error "To ignore uncertainty please use the ignoreUncrt contructor."
 isDecimal u  =  if (0 < u) && (u < 1) then u
                 else error "Uncertainty must be between 0 and 1"


### PR DESCRIPTION
Closes #1342 
Description of this approach:
This first potential solution is simpler, and easier. Rather then changing the Uncertainty data type to a Maybe value which could potentially influence more modules and later development to include a feature for “ignoring uncertainty” that rarely happens. What it does is simply output an error is the user tries to set the uncertainty to zero. In order to create an uncertainty of zero the user must use the “ignoreUncert”constructor. This way the uncertainty remains a double while including the ignore uncertainty feature is available. 