### PR TITLE
Generate Design Log

### DIFF
--- a/code/drasil-code/Language/Drasil/Choices.hs
+++ b/code/drasil-code/Language/Drasil/Choices.hs
@@ -1,7 +1,7 @@
 module Language.Drasil.Choices (
   Choices(..), Modularity(..), InputModule(..), inputModule, Structure(..), 
   ConstantStructure(..), ConstantRepr(..), MatchedConceptMap, CodeConcept(..), 
-  matchConcepts, SpaceMatch, MatchedSpaces, matchSpaces, ImplementationType(..),
+  matchConcepts, SpaceMatch, matchSpaces, ImplementationType(..),
   ConstraintBehaviour(..), Comments(..), Verbosity(..), Visibility(..), 
   Logging(..), AuxFile(..), getSampleData, hasSampleInput, defaultChoices
 ) where
@@ -96,7 +96,6 @@ matchConcepts :: (HasUID c) => [(c, [CodeConcept])] -> ConceptMatchMap
 matchConcepts = fromList . map (\(cnc,cdc) -> (cnc ^. uid, cdc))
 
 type SpaceMatch = Space -> [CodeType]
-type MatchedSpaces = Space -> CodeType
 
 matchSpace :: Space -> [CodeType] -> SpaceMatch -> SpaceMatch
 matchSpace _ [] _ = error "Must match each Space to at least one CodeType"

--- a/code/drasil-code/Language/Drasil/Code/Imperative/Comments.hs
+++ b/code/drasil-code/Language/Drasil/Code/Imperative/Comments.hs
@@ -5,25 +5,25 @@ module Language.Drasil.Code.Imperative.Comments (
 import Language.Drasil
 import Database.Drasil (defTable)
 import Language.Drasil.Chunk.Code (CodeIdea(..))
-import Language.Drasil.Code.Imperative.DrasilState (DrasilState(..))
+import Language.Drasil.Code.Imperative.DrasilState (GenState, DrasilState(..))
 import Language.Drasil.CodeSpec (CodeSpec(..))
 import Language.Drasil.Printers (Linearity(Linear), sentenceDoc, unitDoc)
 
 import qualified Data.Map as Map (lookup)
 import Data.Maybe (maybe)
-import Control.Monad.Reader (Reader, ask)
+import Control.Monad.State (get)
 import Control.Lens ((^.))
 import Text.PrettyPrint.HughesPJ (Doc, (<+>), colon, empty, parens, render)
 
-getTermDoc :: (CodeIdea c) => c -> Reader DrasilState Doc
+getTermDoc :: (CodeIdea c) => c -> GenState Doc
 getTermDoc c = do
-  g <- ask
+  g <- get
   let db = sysinfodb $ codeSpec g
   return $ sentenceDoc db Implementation Linear $ phraseNP $ codeChunk c ^. term
 
-getDefnDoc :: (CodeIdea c) => c -> Reader DrasilState Doc
+getDefnDoc :: (CodeIdea c) => c -> GenState Doc
 getDefnDoc c = do
-  g <- ask
+  g <- get
   let db = sysinfodb $ codeSpec g
   return $ maybe empty ((<+>) colon . sentenceDoc db Implementation Linear . 
     (^. defn) . fst) (Map.lookup (codeChunk c ^. uid) $ defTable db)
@@ -32,7 +32,7 @@ getUnitsDoc :: (CodeIdea c) => c -> Doc
 getUnitsDoc c = maybe empty (parens . unitDoc Linear . usymb) 
   (getUnit $ codeChunk c)
 
-getComment :: (CodeIdea c) => c -> Reader DrasilState String
+getComment :: (CodeIdea c) => c -> GenState String
 getComment l = do
   t <- getTermDoc l
   d <- getDefnDoc l

--- a/code/drasil-code/Language/Drasil/Code/Imperative/ConceptMatch.hs
+++ b/code/drasil-code/Language/Drasil/Code/Imperative/ConceptMatch.hs
@@ -8,13 +8,15 @@ import GOOL.Drasil (SValue, OOProg, MathConstant(..))
 
 import Prelude hiding (pi)
 import qualified Data.Map as Map (map)
+import Control.Monad.State (State)
+import Text.PrettyPrint.HughesPJ (Doc)
 
 -- Currently we don't have any Choices that would prevent a CodeConcept from being mapped, so we just take the head of the list of CodeConcepts
-chooseConcept :: Choices -> MatchedConceptMap
-chooseConcept chs = Map.map (chooseConcept' chs) (conceptMatch chs)
+chooseConcept :: Choices -> State Doc MatchedConceptMap
+chooseConcept chs = sequence $ Map.map (chooseConcept' chs) (conceptMatch chs)
   where chooseConcept' _ [] = error $ "Empty list of CodeConcepts in the " ++ 
           "ConceptMatchMap"
-        chooseConcept' _ cs = head cs
+        chooseConcept' _ cs = return $ head cs
 
 conceptToGOOL :: (OOProg r) => CodeConcept -> SValue r
 conceptToGOOL Pi = pi

--- a/code/drasil-code/Language/Drasil/Code/Imperative/DrasilState.hs
+++ b/code/drasil-code/Language/Drasil/Code/Imperative/DrasilState.hs
@@ -35,20 +35,24 @@ type GenState = State DrasilState
 -- Private State, used to push these options around the generator
 data DrasilState = DrasilState {
   codeSpec :: CodeSpec,
-  date :: String,
+  -- Choices
   modular :: Modularity,
   implType :: ImplementationType,
   inStruct :: Structure,
   conStruct :: ConstantStructure,
   conRepr :: ConstantRepr,
-  logName :: String,
-  logKind :: [Logging],
-  commented :: [Comments],
-  doxOutput :: Verbosity,
   concMatches :: MatchedConceptMap,
   spaceMatches :: MatchedSpaces,
+  onSfwrC :: ConstraintBehaviour,
+  onPhysC :: ConstraintBehaviour,
+  commented :: [Comments],
+  doxOutput :: Verbosity,
+  date :: String,
+  logName :: String,
+  logKind :: [Logging],
   auxiliaries :: [AuxFile],
   sampleData :: [Expr],
+  -- Reference materials
   modules :: [Mod],
   extLibMap :: ExtLibMap,
   libPaths :: [FilePath],
@@ -56,11 +60,11 @@ data DrasilState = DrasilState {
   libEMap :: ModExportMap, 
   clsMap :: ClassDefinitionMap,
   defList :: [Name],
+  -- Stateful
   currentModule :: String,
   currentClass :: String,
-
-  onSfwrC :: ConstraintBehaviour,
-  onPhysC :: ConstraintBehaviour
+  designLog :: Doc,
+  loggedSpaces :: [Space]
 }
 
 inMod :: DrasilState -> InputModule

--- a/code/drasil-code/Language/Drasil/Code/Imperative/DrasilState.hs
+++ b/code/drasil-code/Language/Drasil/Code/Imperative/DrasilState.hs
@@ -1,6 +1,6 @@
 module Language.Drasil.Code.Imperative.DrasilState (
-  DrasilState(..), inMod, ModExportMap, ClassDefinitionMap, modExportMap, 
-  clsDefMap
+  GenState, DrasilState(..), inMod, ModExportMap, ClassDefinitionMap, 
+  modExportMap, clsDefMap
 ) where
 
 import Language.Drasil
@@ -16,6 +16,7 @@ import Language.Drasil.CodeSpec (Input, Const, Derived, Output, Def,
   CodeSpec(..),  getConstraints)
 import Language.Drasil.Mod (Mod(..), Name, Class(..), StateVariable(..), fname)
 
+import Control.Monad.State (State)
 import Data.List (nub)
 import Data.Map (Map, fromList)
 
@@ -27,6 +28,9 @@ type ModExportMap = Map String String
 
 -- name of variable/function maps to class name
 type ClassDefinitionMap = Map String String
+
+-- Abbreviation used throughout generator
+type GenState = State DrasilState
 
 -- Private State, used to push these options around the generator
 data DrasilState = DrasilState {

--- a/code/drasil-code/Language/Drasil/Code/Imperative/GOOL/Data.hs
+++ b/code/drasil-code/Language/Drasil/Code/Imperative/GOOL/Data.hs
@@ -8,7 +8,7 @@ import Text.PrettyPrint.HughesPJ (Doc)
 
 data AuxData = AD {auxFilePath :: FilePath, auxDoc :: Doc}
 
-ad :: String -> Doc -> AuxData
+ad :: FilePath -> Doc -> AuxData
 ad = AD
 
 data PackData = PackD {packProg :: ProgData, packAux :: [AuxData]}

--- a/code/drasil-code/Language/Drasil/Code/Imperative/Generator.hs
+++ b/code/drasil-code/Language/Drasil/Code/Imperative/Generator.hs
@@ -37,7 +37,7 @@ import Control.Monad.State (get, evalState, runState)
 import Data.List (nub)
 import Data.Map (fromList, member, keys, elems)
 import Data.Maybe (maybeToList)
-import Text.PrettyPrint.HughesPJ (($$), empty)
+import Text.PrettyPrint.HughesPJ (($$), empty, isEmpty)
 
 generator :: Lang -> String -> [Expr] -> Choices -> CodeSpec -> DrasilState
 generator l dt sd chs spec = DrasilState {
@@ -71,7 +71,7 @@ generator l dt sd chs spec = DrasilState {
   currentModule = "",
   currentClass = "",
   _designLog = concLog $$ libLog,
-  _loggedSpaces = []
+  _loggedSpaces = [] -- Used to prevent duplicate logs added to design log
 }
   where (mcm, concLog) = runState (chooseConcept chs) empty
         showDate Show = dt
@@ -93,7 +93,8 @@ generateCode l unReprProg unReprPack g = do
   setCurrentDirectory (getDir l)
   let (pckg, ds) = runState (genPackage unReprProg) g 
       code = makeCode (progMods $ packProg $ unReprPack pckg) 
-        (ad "designLog.txt" (ds ^. designLog) : packAux (unReprPack pckg))
+        ([ad "designLog.txt" (ds ^. designLog) | not $ isEmpty $ 
+          ds ^. designLog] ++ packAux (unReprPack pckg))
   createCodeFiles code
   setCurrentDirectory workingDir
 

--- a/code/drasil-code/Language/Drasil/Code/Imperative/Generator.hs
+++ b/code/drasil-code/Language/Drasil/Code/Imperative/Generator.hs
@@ -42,17 +42,20 @@ generator :: Lang -> String -> [Expr] -> Choices -> CodeSpec -> DrasilState
 generator l dt sd chs spec = DrasilState {
   -- constants
   codeSpec = spec,
-  date = showDate $ dates chs,
   modular = modularity chs,
-  implType = impType chs,
   inStruct = inputStructure chs,
   conStruct = constStructure chs,
   conRepr = constRepr chs,
-  logKind  = logging chs,
-  commented = comments chs,
-  doxOutput = doxVerbosity chs,
   concMatches = chooseConcept chs,
   spaceMatches = chooseSpace l chs,
+  implType = impType chs,
+  onSfwrC = onSfwrConstraint chs,
+  onPhysC = onPhysConstraint chs,
+  commented = comments chs,
+  doxOutput = doxVerbosity chs,
+  date = showDate $ dates chs,
+  logKind  = logging chs,
+  logName = logFile chs,
   auxiliaries = auxFiles chs,
   sampleData = sd,
   modules = modules',
@@ -63,14 +66,11 @@ generator l dt sd chs spec = DrasilState {
   clsMap = cdm,
   defList = nub $ keys mem ++ keys cdm,
   
-  -- state
+  -- stateful
   currentModule = "",
   currentClass = "",
-
-  -- next depend on chs
-  logName = logFile chs,
-  onSfwrC = onSfwrConstraint chs,
-  onPhysC = onPhysConstraint chs
+  designLog = empty,
+  loggedSpaces = []
 }
   where showDate Show = dt
         showDate Hide = ""

--- a/code/drasil-code/Language/Drasil/Code/Imperative/Helpers.hs
+++ b/code/drasil-code/Language/Drasil/Code/Imperative/Helpers.hs
@@ -7,9 +7,9 @@ import Database.Drasil (symbResolve)
 import Language.Drasil.Code.Imperative.DrasilState (DrasilState(..))
 import Language.Drasil.CodeSpec (CodeSpec(..))
 
-import Control.Monad.Reader (Reader)
+import Control.Monad.State (State)
 
-liftS :: Reader a b -> Reader a [b]
+liftS :: State a b -> State a [b]
 liftS = fmap (: [])
 
 getUpperBound :: Expr -> Expr

--- a/code/drasil-code/Language/Drasil/Code/Imperative/Import.hs
+++ b/code/drasil-code/Language/Drasil/Code/Imperative/Import.hs
@@ -15,7 +15,7 @@ import Language.Drasil.Code.Imperative.GenerateGOOL (auxClass, fApp, ctorCall,
   genModuleWithImports, primaryClass)
 import Language.Drasil.Code.Imperative.Helpers (getUpperBound, lookupC)
 import Language.Drasil.Code.Imperative.Logging (maybeLog, logBody)
-import Language.Drasil.Code.Imperative.DrasilState (DrasilState(..))
+import Language.Drasil.Code.Imperative.DrasilState (GenState, DrasilState(..))
 import Language.Drasil.Chunk.Code (CodeIdea(codeName), CodeVarChunk, obv, 
   quantvar, quantfunc, ccObjVar)
 import Language.Drasil.Chunk.CodeDefinition (codeEquat)
@@ -49,12 +49,12 @@ import qualified Data.Map as Map (lookup)
 import Data.Maybe (maybe)
 import Control.Applicative ((<$>))
 import Control.Monad (liftM2,liftM3)
-import Control.Monad.Reader (Reader, ask)
+import Control.Monad.State (get)
 import Control.Lens ((^.))
 
-codeType :: (HasSpace c) => c -> Reader DrasilState CodeType
+codeType :: (HasSpace c) => c -> GenState CodeType
 codeType c = do
-  g <- ask
+  g <- get
   return $ spaceMatches g (c ^. typ)
 
 -- | If UID for the variable is matched to a concept, call conceptToGOOL to get 
@@ -63,9 +63,9 @@ codeType c = do
 -- defining Expr to a value with convExpr.
 -- Otherwise, just a regular variable: construct it by calling variable, then 
 -- call valueOf to reference its value
-value :: (OOProg r) => UID -> Name -> VSType r -> Reader DrasilState (SValue r)
+value :: (OOProg r) => UID -> Name -> VSType r -> GenState (SValue r)
 value u s t = do
-  g <- ask
+  g <- get
   let cs = codeSpec g
       mm = constMap cs
       cm = concMatches g
@@ -81,9 +81,9 @@ value u s t = do
 -- If variable is a constant and Const constant representation is chosen,
 -- construct it with staticVar and pass to constVariable
 -- If variable is neither, just construct it with var and return it
-variable :: (OOProg r) => Name -> VSType r -> Reader DrasilState (SVariable r)
+variable :: (OOProg r) => Name -> VSType r -> GenState (SVariable r)
 variable s t = do
-  g <- ask
+  g <- get
   let cs = codeSpec g
       defFunc Var = var
       defFunc Const = staticVar
@@ -101,10 +101,10 @@ variable s t = do
 -- representation is Const. Variable should be accessed through class, so 
 -- classVariable is called.
 inputVariable :: (OOProg r) => Structure -> ConstantRepr -> SVariable r -> 
-  Reader DrasilState (SVariable r)
+  GenState (SVariable r)
 inputVariable Unbundled _ v = return v
 inputVariable Bundled Var v = do
-  g <- ask
+  g <- get
   let inClsName = "InputParameters"
   ip <- mkVar (quantvar inParams)
   return $ if currentClass g == inClsName then objVarSelf v else ip $-> v
@@ -121,7 +121,7 @@ inputVariable Bundled Const v = do
 -- If constants Inlined, the generator should not be attempting to make a 
 -- variable for one of the constants.
 constVariable :: (OOProg r) => ConstantStructure -> ConstantRepr -> 
-  SVariable r -> Reader DrasilState (SVariable r)
+  SVariable r -> GenState (SVariable r)
 constVariable (Store Unbundled) _ v = return v
 constVariable (Store Bundled) Var v = do
   cs <- mkVar (quantvar consts)
@@ -130,7 +130,7 @@ constVariable (Store Bundled) Const v = do
   cs <- mkVar (quantvar consts)
   classVariable cs v
 constVariable WithInputs cr v = do
-  g <- ask
+  g <- get
   inputVariable (inStruct g) cr v
 constVariable Inline _ _ = error $ "mkVar called on a constant, but user " ++
   "chose to Inline constants. Generator has bug."
@@ -141,9 +141,9 @@ constVariable Inline _ _ = error $ "mkVar called on a constant, but user " ++
 -- If the variable is exported by the current module, use classVar
 -- If the variable is exported by a different module, use extClassVar
 classVariable :: (OOProg r) => SVariable r -> SVariable r -> 
-  Reader DrasilState (SVariable r)
+  GenState (SVariable r)
 classVariable c v = do
-  g <- ask
+  g <- get
   let checkCurrent m = if currentModule g == m then classVar else extClassVar
   return $ do
     v' <- v
@@ -151,7 +151,7 @@ classVariable c v = do
     maybe (error $ "Variable " ++ nm ++ " missing from export map") 
       checkCurrent (Map.lookup nm (eMap g)) (onStateValue variableType c) v
 
-mkVal :: (OOProg r) => CodeVarChunk -> Reader DrasilState (SValue r)
+mkVal :: (OOProg r) => CodeVarChunk -> GenState (SValue r)
 mkVal v = do
   t <- codeType v
   let toGOOLVal Nothing = value (v ^. uid) (codeName v) (convType t)
@@ -161,7 +161,7 @@ mkVal v = do
           (var (codeName v) (convType t))
   toGOOLVal (v ^. obv)
 
-mkVar :: (OOProg r) => CodeVarChunk -> Reader DrasilState (SVariable r)
+mkVar :: (OOProg r) => CodeVarChunk -> GenState (SVariable r)
 mkVar v = do
   t <- codeType v
   let toGOOLVar Nothing = variable (codeName v) (convType t)
@@ -171,7 +171,7 @@ mkVar v = do
           (var (codeName v) (convType t))
   toGOOLVar (v ^. obv)
 
-mkParam :: (OOProg r) => ParameterChunk -> Reader DrasilState (MSParameter r)
+mkParam :: (OOProg r) => ParameterChunk -> GenState (MSParameter r)
 mkParam p = do
   v <- mkVar (quantvar p)
   return $ paramFunc (passBy p) v
@@ -180,42 +180,42 @@ mkParam p = do
 
 publicFunc :: (OOProg r) => Label -> VSType r -> Description -> 
   [ParameterChunk] -> Maybe Description -> [MSBlock r] -> 
-  Reader DrasilState (SMethod r)
+  GenState (SMethod r)
 publicFunc n t = genMethod (function n public static t) n
 
 publicMethod :: (OOProg r) => Label -> VSType r -> Description -> 
   [ParameterChunk] -> Maybe Description -> [MSBlock r] -> 
-  Reader DrasilState (SMethod r)
+  GenState (SMethod r)
 publicMethod n t = genMethod (method n public dynamic t) n
 
 privateMethod :: (OOProg r) => Label -> VSType r -> Description -> 
   [ParameterChunk] -> Maybe Description -> [MSBlock r] -> 
-  Reader DrasilState (SMethod r)
+  GenState (SMethod r)
 privateMethod n t = genMethod (method n private dynamic t) n
 
 publicInOutFunc :: (OOProg r) => Label -> Description -> [CodeVarChunk] -> 
-  [CodeVarChunk] -> [MSBlock r] -> Reader DrasilState (SMethod r)
+  [CodeVarChunk] -> [MSBlock r] -> GenState (SMethod r)
 publicInOutFunc n = genInOutFunc (inOutFunc n) (docInOutFunc n) public static n
 
 privateInOutMethod :: (OOProg r) => Label -> Description -> [CodeVarChunk] -> 
-  [CodeVarChunk] -> [MSBlock r] -> Reader DrasilState (SMethod r)
+  [CodeVarChunk] -> [MSBlock r] -> GenState (SMethod r)
 privateInOutMethod n = genInOutFunc (inOutMethod n) (docInOutMethod n) 
   private dynamic n
 
 genConstructor :: (OOProg r) => Label -> Description -> [ParameterChunk] -> 
-  [MSBlock r] -> Reader DrasilState (SMethod r)
+  [MSBlock r] -> GenState (SMethod r)
 genConstructor n desc p = genMethod nonInitConstructor n desc p Nothing
 
 genInitConstructor :: (OOProg r) => Label -> Description -> [ParameterChunk] 
-  -> Initializers r -> [MSBlock r] -> Reader DrasilState (SMethod r)
+  -> Initializers r -> [MSBlock r] -> GenState (SMethod r)
 genInitConstructor n desc p is = genMethod (`constructor` is) n desc p 
   Nothing
 
 genMethod :: (OOProg r) => ([MSParameter r] -> MSBody r -> SMethod r) -> 
   Label -> Description -> [ParameterChunk] -> Maybe Description -> [MSBlock r] 
-  -> Reader DrasilState (SMethod r)
+  -> GenState (SMethod r)
 genMethod f n desc p r b = do
-  g <- ask
+  g <- get
   vars <- mapM (mkVar . quantvar) p
   ps <- mapM mkParam p
   bod <- logBody n vars b
@@ -229,9 +229,9 @@ genInOutFunc :: (OOProg r) => (r (Scope r) -> r (Permanence r) ->
   -> (r (Scope r) -> r (Permanence r) -> String -> [(String, SVariable r)] -> 
     [(String, SVariable r)] -> [(String, SVariable r)] -> MSBody r -> SMethod r)
   -> r (Scope r) -> r (Permanence r) -> Label -> Description -> [CodeVarChunk] 
-  -> [CodeVarChunk] -> [MSBlock r] -> Reader DrasilState (SMethod r)
+  -> [CodeVarChunk] -> [MSBlock r] -> GenState (SMethod r)
 genInOutFunc f docf s pr n desc ins' outs' b = do
-  g <- ask
+  g <- get
   let ins = ins' \\ outs'
       outs = outs' \\ ins'
       both = ins' `intersect` outs'
@@ -246,9 +246,9 @@ genInOutFunc f docf s pr n desc ins' outs' b = do
     then docf s pr desc (zip pComms inVs) (zip oComms outVs) (zip 
     bComms bothVs) bod else f s pr inVs outVs bothVs bod
 
-convExpr :: (OOProg r) => Expr -> Reader DrasilState (SValue r)
+convExpr :: (OOProg r) => Expr -> GenState (SValue r)
 convExpr (Dbl d) = do
-  g <- ask
+  g <- get
   let sm = spaceMatches g
       getLiteral Double = litDouble d
       getLiteral Float = litFloat (realToFrac d)
@@ -257,7 +257,7 @@ convExpr (Dbl d) = do
 convExpr (Int i) = return $ litInt i
 convExpr (Str s) = return $ litString s
 convExpr (Perc a b) = do
-  g <- ask
+  g <- get
   let sm = spaceMatches g
       getLiteral Double = litDouble
       getLiteral Float = litFloat . realToFrac
@@ -269,14 +269,14 @@ convExpr (AssocB And l) = foldl1 (?&&) <$> mapM convExpr l
 convExpr (AssocB Or l)  = foldl1 (?||) <$> mapM convExpr l
 convExpr Deriv{} = return $ litString "**convExpr :: Deriv unimplemented**"
 convExpr (C c)   = do
-  g <- ask
+  g <- get
   let v = quantvar (lookupC g c)
   mkVal v
 convExpr (FCall c x ns) = convCall c x ns fApp libFuncAppMixedArgs
 convExpr (New c x ns) = convCall c x ns (\m _ -> ctorCall m) 
   (\m _ -> libNewObjMixedArgs m)
 convExpr (Message a m x ns) = do
-  g <- ask
+  g <- get
   let info = sysinfodb $ codeSpec g
       objCd = quantvar (symbResolve info a)
   o <- mkVal objCd
@@ -284,14 +284,14 @@ convExpr (Message a m x ns) = do
     (\_ n t ps nas -> return (objMethodCallMixedArgs t o n ps nas)) 
     (\_ n t -> objMethodCallMixedArgs t o n)
 convExpr (Field o f) = do
-  g <- ask
+  g <- get
   let ob = quantvar (lookupC g o)
       fld = quantvar (lookupC g f)
   v <- mkVar (ccObjVar ob fld)
   return $ valueOf v
 convExpr (UnaryOp o u) = fmap (unop o) (convExpr u)
 convExpr (BinaryOp Frac (Int a) (Int b)) = do -- hack to deal with integer division
-  g <- ask
+  g <- get
   let sm = spaceMatches g
       getLiteral Double = litDouble (fromIntegral a) #/ litDouble (fromIntegral b)
       getLiteral Float = litFloat (fromIntegral a) #/ litFloat (fromIntegral b)
@@ -312,15 +312,15 @@ convExpr Matrix{} = error "convExpr: Matrix"
 convExpr Operator{} = error "convExpr: Operator"
 convExpr IsIn{}    = error "convExpr: IsIn"
 convExpr (RealI c ri)  = do
-  g <- ask
+  g <- get
   convExpr $ renderRealInt (lookupC g c) ri
 
 convCall :: (OOProg r) => UID -> [Expr] -> [(UID, Expr)] -> 
   (Name -> Name -> VSType r -> [SValue r] -> NamedArgs r -> 
-  Reader DrasilState (SValue r)) -> (Name -> Name -> VSType r -> [SValue r] 
-  -> NamedArgs r -> SValue r) -> Reader DrasilState (SValue r)
+  GenState (SValue r)) -> (Name -> Name -> VSType r -> [SValue r] 
+  -> NamedArgs r -> SValue r) -> GenState (SValue r)
 convCall c x ns f libf = do
-  g <- ask
+  g <- get
   let info = sysinfodb $ codeSpec g
       mem = eMap g
       lem = libEMap g
@@ -388,22 +388,22 @@ bfunc Frac  = (#/)
 bfunc Index = listAccess
 
 -- medium hacks --
-genModDef :: (OOProg r) => Mod -> Reader DrasilState (SFile r)
+genModDef :: (OOProg r) => Mod -> GenState (SFile r)
 genModDef (Mod n desc is cs fs) = genModuleWithImports n desc is (map (fmap 
   Just . genFunc publicFunc []) fs) 
   (case cs of [] -> []
               (cl:cls) -> fmap Just (genClass primaryClass cl) : 
                 map (fmap Just . genClass auxClass) cls)
 
-genModFuncs :: (OOProg r) => Mod -> [Reader DrasilState (SMethod r)]
+genModFuncs :: (OOProg r) => Mod -> [GenState (SMethod r)]
 genModFuncs (Mod _ _ _ _ fs) = map (genFunc publicFunc []) fs
 
-genModClasses :: (OOProg r) => Mod -> [Reader DrasilState (SClass r)]
+genModClasses :: (OOProg r) => Mod -> [GenState (SClass r)]
 genModClasses (Mod _ _ _ cs _) = map (genClass auxClass) cs
 
 genClass :: (OOProg r) => (Name -> Maybe Name -> Description -> [CSStateVar r] 
-  -> Reader DrasilState [SMethod r] -> Reader DrasilState (SClass r)) -> 
-  M.Class -> Reader DrasilState (SClass r)
+  -> GenState [SMethod r] -> GenState (SClass r)) -> 
+  M.Class -> GenState (SClass r)
 genClass f (M.ClassDef n i desc svs ms) = let svar Pub = pubDVar
                                               svar Priv = privDVar 
   in do
@@ -412,17 +412,17 @@ genClass f (M.ClassDef n i desc svs ms) = let svar Pub = pubDVar
   f n i desc svrs (mapM (genFunc publicMethod svs) ms)
 
 genFunc :: (OOProg r) => (Name -> VSType r -> Description -> [ParameterChunk] 
-  -> Maybe Description -> [MSBlock r] -> Reader DrasilState (SMethod r)) -> 
-  [StateVariable] -> Func -> Reader DrasilState (SMethod r)
+  -> Maybe Description -> [MSBlock r] -> GenState (SMethod r)) -> 
+  [StateVariable] -> Func -> GenState (SMethod r)
 genFunc f svs (FDef (FuncDef n desc parms o rd s)) = do
-  g <- ask
+  g <- get
   stmts <- mapM convStmt s
   vars <- mapM mkVar (fstdecl (sysinfodb $ codeSpec g) s 
     \\ (map quantvar parms ++ map stVar svs))
   f n (convType $ spaceMatches g o) desc parms rd 
     [block $ map varDec vars, block stmts]
 genFunc _ svs (FDef (CtorDef n desc parms i s)) = do
-  g <- ask
+  g <- get
   inits <- mapM (convExpr . snd) i
   initvars <- mapM ((\iv -> fmap (var (codeName iv) . convType) (codeType iv))
     . fst) i
@@ -433,7 +433,7 @@ genFunc _ svs (FDef (CtorDef n desc parms i s)) = do
     [block $ map varDec vars, block stmts]
 genFunc _ _ (FData (FuncData n desc ddef)) = genDataFunc n desc ddef
 
-convStmt :: (OOProg r) => FuncStmt -> Reader DrasilState (MSStatement r)
+convStmt :: (OOProg r) => FuncStmt -> GenState (MSStatement r)
 convStmt (FAsg v (Matrix [es]))  = do
   els <- mapM convExpr es
   v' <- mkVar v
@@ -529,7 +529,7 @@ convStmt (FAppend a b) = do
   return $ valStmt $ listAppend a' b'
 
 genDataFunc :: (OOProg r) => Name -> Description -> DataDesc -> 
-  Reader DrasilState (SMethod r)
+  GenState (SMethod r)
 genDataFunc nameTitle desc ddef = do
   let parms = getInputs ddef
   bod <- readData ddef
@@ -537,7 +537,7 @@ genDataFunc nameTitle desc ddef = do
     Nothing bod
 
 -- this is really ugly!!
-readData :: (OOProg r) => DataDesc -> Reader DrasilState [MSBlock r]
+readData :: (OOProg r) => DataDesc -> GenState [MSBlock r]
 readData ddef = do
   inD <- mapM inData ddef
   v_filename <- mkVal $ quantvar inFileName
@@ -548,7 +548,7 @@ readData ddef = do
     openFileR var_infile v_filename :
     concat inD ++ [
     closeFile v_infile ]]
-  where inData :: (OOProg r) => Data -> Reader DrasilState [MSStatement r]
+  where inData :: (OOProg r) => Data -> GenState [MSStatement r]
         inData (Singleton v) = do
             vv <- mkVar v
             l <- maybeLog vv
@@ -575,7 +575,7 @@ readData ddef = do
           return $ readLines ls ++ logs
         ---------------
         lineData :: (OOProg r) => Maybe String -> LinePattern -> 
-          Reader DrasilState [MSStatement r]
+          GenState [MSStatement r]
         lineData s p@(Straight _) = do
           vs <- getEntryVars s p
           return [stringListVals vs v_linetokens]
@@ -585,22 +585,22 @@ readData ddef = do
             : appendTemps s ds
         ---------------
         clearTemps :: (OOProg r) => Maybe String -> [DataItem] -> 
-          [Reader DrasilState (MSStatement r)]
+          [GenState (MSStatement r)]
         clearTemps Nothing _ = []
         clearTemps (Just sfx) es = map (clearTemp sfx) es
         ---------------
         clearTemp :: (OOProg r) => String -> DataItem -> 
-          Reader DrasilState (MSStatement r)
+          GenState (MSStatement r)
         clearTemp sfx v = fmap (\t -> listDecDef (var (codeName v ++ sfx) 
           (listInnerType $ convType t)) []) (codeType v)
         ---------------
         appendTemps :: (OOProg r) => Maybe String -> [DataItem] -> 
-          [Reader DrasilState (MSStatement r)]
+          [GenState (MSStatement r)]
         appendTemps Nothing _ = []
         appendTemps (Just sfx) es = map (appendTemp sfx) es
         ---------------
         appendTemp :: (OOProg r) => String -> DataItem -> 
-          Reader DrasilState (MSStatement r)
+          GenState (MSStatement r)
         appendTemp sfx v = fmap (\t -> valStmt $ listAppend 
           (valueOf $ var (codeName v) (convType t)) 
           (valueOf $ var (codeName v ++ sfx) (convType t))) (codeType v)
@@ -627,12 +627,12 @@ readData ddef = do
         v_i = valueOf var_i
 
 getEntryVars :: (OOProg r) => Maybe String -> LinePattern -> 
-  Reader DrasilState [SVariable r]
+  GenState [SVariable r]
 getEntryVars s lp = mapM (maybe mkVar (\st v -> codeType v >>= (variable 
   (codeName v ++ st) . listInnerType . convType)) s) (getPatternInputs lp)
 
 getEntryVarLogs :: (OOProg r) => LinePattern -> 
-  Reader DrasilState [MSStatement r]
+  GenState [MSStatement r]
 getEntryVarLogs lp = do
   vs <- getEntryVars Nothing lp
   logs <- mapM maybeLog vs

--- a/code/drasil-code/Language/Drasil/Code/Imperative/Modules.hs
+++ b/code/drasil-code/Language/Drasil/Code/Imperative/Modules.hs
@@ -23,7 +23,7 @@ import Language.Drasil.Code.Imperative.Logging (maybeLog, varLogFile)
 import Language.Drasil.Code.Imperative.Parameters (getConstraintParams, 
   getDerivedIns, getDerivedOuts, getInConstructorParams, getInputFormatIns, 
   getInputFormatOuts, getCalcParams, getOutputParams)
-import Language.Drasil.Code.Imperative.DrasilState (DrasilState(..))
+import Language.Drasil.Code.Imperative.DrasilState (GenState, DrasilState(..))
 import Language.Drasil.Code.Imperative.GOOL.ClassInterface (AuxiliarySym(..))
 import Language.Drasil.Chunk.Code (CodeIdea(codeName), CodeVarChunk, quantvar, 
   physLookup, sfwrLookup)
@@ -54,19 +54,19 @@ import qualified Data.Map as Map (lookup, filter)
 import Data.Maybe (maybeToList, catMaybes)
 import Control.Applicative ((<$>))
 import Control.Monad (liftM2, zipWithM)
-import Control.Monad.Reader (Reader, ask, asks)
+import Control.Monad.State (get, gets)
 import Control.Lens ((^.))
 import Text.PrettyPrint.HughesPJ (render)
 
 ---- MAIN ---
 
-genMain :: (OOProg r) => Reader DrasilState (SFile r)
+genMain :: (OOProg r) => GenState (SFile r)
 genMain = genModule "Control" "Controls the flow of the program" 
   [genMainFunc] []
 
-genMainFunc :: (OOProg r) => Reader DrasilState (Maybe (SMethod r))
+genMainFunc :: (OOProg r) => GenState (Maybe (SMethod r))
 genMainFunc = do
-    g <- ask
+    g <- get
     let mainFunc Library = return Nothing
         mainFunc Program = do
           v_filename <- mkVar $ quantvar inFileName
@@ -94,9 +94,9 @@ genMainFunc = do
 -- the InputParameters class, so inParams should be declared and constructed,
 -- using objDecNew if the inputs are exported by the current module, and 
 -- extObjDecNew if they are exported by a different module.
-getInputDecl :: (OOProg r) => Reader DrasilState (Maybe (MSStatement r))
+getInputDecl :: (OOProg r) => GenState (Maybe (MSStatement r))
 getInputDecl = do
-  g <- ask
+  g <- get
   v_params <- mkVar (quantvar inParams)
   constrParams <- getInConstructorParams 
   cps <- mapM mkVal constrParams
@@ -128,14 +128,14 @@ getInputDecl = do
 -- If constants are Bundled WithInputs, do Nothing; declaration of the inParams 
 -- object is handled by getInputDecl.
 -- If constants are Inlined, nothing needs to be declared.
-initConsts :: (OOProg r) => Reader DrasilState (Maybe (MSStatement r))
+initConsts :: (OOProg r) => GenState (Maybe (MSStatement r))
 initConsts = do
-  g <- ask
+  g <- get
   v_consts <- mkVar (quantvar consts)
   let cname = "Constants"
       cs = constants $ codeSpec g 
       getDecl (Store Unbundled) _ = declVars
-      getDecl (Store Bundled) _ = asks (declObj cs . conRepr)
+      getDecl (Store Bundled) _ = gets (declObj cs . conRepr)
       getDecl WithInputs Unbundled = declVars
       getDecl WithInputs Bundled = return Nothing
       getDecl Inline _ = return Nothing
@@ -158,12 +158,12 @@ initLogFileVar l = [varDec varLogFile | LogVar `elem` l]
 
 ------- INPUT ----------
 
-chooseInModule :: (OOProg r) => InputModule -> Reader DrasilState 
+chooseInModule :: (OOProg r) => InputModule -> GenState 
   [SFile r]
 chooseInModule Combined = genInputModCombined
 chooseInModule Separated = genInputModSeparated
 
-genInputModSeparated :: (OOProg r) => Reader DrasilState [SFile r]
+genInputModSeparated :: (OOProg r) => GenState [SFile r]
 genInputModSeparated = do
   ipDesc <- modDesc inputParametersDesc
   ifDesc <- modDesc (liftS inputFormatDesc)
@@ -175,12 +175,12 @@ genInputModSeparated = do
     genModule "DerivedValues" dvDesc [genInputDerived Pub] [],
     genModule "InputConstraints" icDesc [genInputConstraints Pub] []]
 
-genInputModCombined :: (OOProg r) => Reader DrasilState [SFile r]
+genInputModCombined :: (OOProg r) => GenState [SFile r]
 genInputModCombined = do
   ipDesc <- modDesc inputParametersDesc
   let cname = "InputParameters"
       genMod :: (OOProg r) => Maybe (SClass r) ->
-        Reader DrasilState (SFile r)
+        GenState (SFile r)
       genMod Nothing = genModule cname ipDesc [genInputFormat Pub, 
         genInputDerived Pub, genInputConstraints Pub] []
       genMod _ = genModule cname ipDesc [] [genInputClass Primary]
@@ -199,20 +199,20 @@ constVarFunc Const = constVar public
 -- variables. If the InputParameters constructor is also exported, then the
 -- generated class also contains the input-related functions as private methods
 genInputClass :: (OOProg r) => ClassType -> 
-  Reader DrasilState (Maybe (SClass r))
+  GenState (Maybe (SClass r))
 genInputClass scp = do
-  g <- ask
+  g <- get
   let ins = inputs $ codeSpec g
       cs = constants $ codeSpec g
       filt :: (CodeIdea c) => [c] -> [c]
       filt = filter ((Just cname ==) . flip Map.lookup (clsMap g) . codeName)
-      methods :: (OOProg r) => Reader DrasilState [SMethod r]
+      methods :: (OOProg r) => GenState [SMethod r]
       methods = if cname `elem` defList g 
         then concat <$> mapM (fmap maybeToList) [genInputConstructor, 
         genInputFormat Priv, genInputDerived Priv, genInputConstraints Priv] 
         else return []
       genClass :: (OOProg r) => [CodeVarChunk] -> [CodeDefinition] -> 
-        Reader DrasilState (Maybe (SClass r))
+        GenState (Maybe (SClass r))
       genClass [] [] = return Nothing
       genClass inps csts = do
         vals <- mapM (convExpr . codeEquat) csts
@@ -230,9 +230,9 @@ genInputClass scp = do
   genClass (filt ins) (filt cs)
   where cname = "InputParameters"
 
-genInputConstructor :: (OOProg r) => Reader DrasilState (Maybe (SMethod r))
+genInputConstructor :: (OOProg r) => GenState (Maybe (SMethod r))
 genInputConstructor = do
-  g <- ask
+  g <- get
   let dl = defList g
       genCtor False = return Nothing
       genCtor True = do 
@@ -246,13 +246,13 @@ genInputConstructor = do
     "input_constraints"]
 
 genInputDerived :: (OOProg r) => ScopeTag ->
-  Reader DrasilState (Maybe (SMethod r))
+  GenState (Maybe (SMethod r))
 genInputDerived s = do
-  g <- ask
+  g <- get
   let dvals = derivedInputs $ codeSpec g
       getFunc Pub = publicInOutFunc
       getFunc Priv = privateInOutMethod
-      genDerived :: (OOProg r) => Bool -> Reader DrasilState 
+      genDerived :: (OOProg r) => Bool -> GenState 
         (Maybe (SMethod r))
       genDerived False = return Nothing
       genDerived _ = do
@@ -266,13 +266,13 @@ genInputDerived s = do
 
 -- Generates function that checks constraints on the input.
 genInputConstraints :: (OOProg r) => ScopeTag ->
-  Reader DrasilState (Maybe (SMethod r))
+  GenState (Maybe (SMethod r))
 genInputConstraints s = do
-  g <- ask
+  g <- get
   let cm = cMap $ codeSpec g
       getFunc Pub = publicFunc
       getFunc Priv = privateMethod
-      genConstraints :: (OOProg r) => Bool -> Reader DrasilState 
+      genConstraints :: (OOProg r) => Bool -> GenState 
         (Maybe (SMethod r))
       genConstraints False = return Nothing
       genConstraints _ = do
@@ -290,24 +290,24 @@ genInputConstraints s = do
 
 -- | Generates input constraints code block for checking software constraints
 sfwrCBody :: (OOProg r) => [(CodeVarChunk,[Constraint])] -> 
-  Reader DrasilState [MSStatement r]
+  GenState [MSStatement r]
 sfwrCBody cs = do
-  g <- ask
+  g <- get
   let cb = onSfwrC g
   chooseConstr cb cs
 
 -- | Generates input constraints code block for checking physical constraints
 physCBody :: (OOProg r) => [(CodeVarChunk,[Constraint])] -> 
-  Reader DrasilState [MSStatement r]
+  GenState [MSStatement r]
 physCBody cs = do
-  g <- ask
+  g <- get
   let cb = onPhysC g
   chooseConstr cb cs
 
 -- | Generates conditional statements for checking constraints, where the 
 -- bodies depend on user's choice of constraint violation behaviour
 chooseConstr :: (OOProg r) => ConstraintBehaviour -> 
-  [(CodeVarChunk,[Constraint])] -> Reader DrasilState [MSStatement r]
+  [(CodeVarChunk,[Constraint])] -> GenState [MSStatement r]
 chooseConstr cb cs = do
   conds <- mapM (\(q,cns) -> mapM (convExpr . renderC q) cns) cs
   bods <- mapM (chooseCB cb) cs
@@ -320,7 +320,7 @@ chooseConstr cb cs = do
 -- including printing a "Warning" message, followed by a message that says
 -- what value was "suggested".
 constrWarn :: (OOProg r) => (CodeVarChunk,[Constraint]) -> 
-  Reader DrasilState [MSBody r]
+  GenState [MSBody r]
 constrWarn c = do
   let q = fst c
       cs = snd c
@@ -331,7 +331,7 @@ constrWarn c = do
 -- including printing a message that says what value was "expected", 
 -- followed by throwing an exception.
 constrExc :: (OOProg r) => (CodeVarChunk,[Constraint]) -> 
-  Reader DrasilState [MSBody r]
+  GenState [MSBody r]
 constrExc c = do
   let q = fst c
       cs = snd c
@@ -342,7 +342,7 @@ constrExc c = do
 -- Message includes the name of the cosntraint quantity, its value, and a
 -- description of the constraint that is violated.
 constraintViolatedMsg :: (OOProg r) => CodeVarChunk -> String -> 
-  Constraint -> Reader DrasilState [MSStatement r]
+  Constraint -> GenState [MSStatement r]
 constraintViolatedMsg q s c = do
   pc <- printConstraint c 
   v <- mkVal (quantvar q)
@@ -354,11 +354,11 @@ constraintViolatedMsg q s c = do
 -- the constrained values. Constrained values are followed by printing the 
 -- expression they originated from, using printExpr. 
 printConstraint :: (OOProg r) => Constraint ->
-  Reader DrasilState [MSStatement r]
+  GenState [MSStatement r]
 printConstraint c = do
-  g <- ask
+  g <- get
   let db = sysinfodb $ codeSpec g
-      printConstraint' :: (OOProg r) => Constraint -> Reader DrasilState 
+      printConstraint' :: (OOProg r) => Constraint -> GenState 
         [MSStatement r]
       printConstraint' (Range _ (Bounded (_,e1) (_,e2))) = do
         lb <- convExpr e1
@@ -389,13 +389,13 @@ printExpr e db = [printStr $ " (" ++ render (exprDoc db Implementation Linear e)
   ++ ")"]
 
 genInputFormat :: (OOProg r) => ScopeTag -> 
-  Reader DrasilState (Maybe (SMethod r))
+  GenState (Maybe (SMethod r))
 genInputFormat s = do
-  g <- ask
+  g <- get
   dd <- genDataDesc
   let getFunc Pub = publicInOutFunc
       getFunc Priv = privateInOutMethod
-      genInFormat :: (OOProg r) => Bool -> Reader DrasilState 
+      genInFormat :: (OOProg r) => Bool -> GenState 
         (Maybe (SMethod r))
       genInFormat False = return Nothing
       genInFormat _ = do
@@ -407,32 +407,32 @@ genInputFormat s = do
         return $ Just mthd
   genInFormat $ "get_input" `elem` defList g
 
-genDataDesc :: Reader DrasilState DataDesc
+genDataDesc :: GenState DataDesc
 genDataDesc = do
-  g <- ask
+  g <- get
   return $ junkLine : 
     intersperse junkLine (map singleton (extInputs $ codeSpec g))
 
-genSampleInput :: (AuxiliarySym r) => Reader DrasilState [r (Auxiliary r)]
+genSampleInput :: (AuxiliarySym r) => GenState [r (Auxiliary r)]
 genSampleInput = do
-  g <- ask
+  g <- get
   dd <- genDataDesc
   return [sampleInput (sysinfodb $ codeSpec g) dd (sampleData g) | 
     hasSampleInput (auxiliaries g)]
 
 ----- CONSTANTS -----
 
-genConstMod :: (OOProg r) => Reader DrasilState [SFile r]
+genConstMod :: (OOProg r) => GenState [SFile r]
 genConstMod = do
   cDesc <- modDesc $ liftS constModDesc
   liftS $ genModule "Constants" cDesc [] [genConstClass Primary]
 
 genConstClass :: (OOProg r) => ClassType ->
-  Reader DrasilState (Maybe (SClass r))
+  GenState (Maybe (SClass r))
 genConstClass scp = do
-  g <- ask
+  g <- get
   let cs = constants $ codeSpec g
-      genClass :: (OOProg r) => [CodeDefinition] -> Reader DrasilState 
+      genClass :: (OOProg r) => [CodeDefinition] -> GenState 
         (Maybe (SClass r))
       genClass [] = return Nothing 
       genClass vs = do
@@ -451,17 +451,17 @@ genConstClass scp = do
 
 ------- CALC ----------
 
-genCalcMod :: (OOProg r) => Reader DrasilState (SFile r)
+genCalcMod :: (OOProg r) => GenState (SFile r)
 genCalcMod = do
-  g <- ask
+  g <- get
   let elmap = extLibMap g
   genModuleWithImports "Calculations" calcModDesc (concatMap (^. imports) $ 
     elems elmap) (map (fmap Just . genCalcFunc) (execOrder $ codeSpec g)) []
 
 genCalcFunc :: (OOProg r) => CodeDefinition -> 
-  Reader DrasilState (SMethod r)
+  GenState (SMethod r)
 genCalcFunc cdef = do
-  g <- ask
+  g <- get
   parms <- getCalcParams cdef
   let nm = codeName cdef
   tp <- codeType cdef
@@ -489,7 +489,7 @@ genCalcFunc cdef = do
 data CalcType = CalcAssign | CalcReturn deriving Eq
 
 genCalcBlock :: (OOProg r) => CalcType -> CodeDefinition -> Expr ->
-  Reader DrasilState (MSBlock r)
+  GenState (MSBlock r)
 genCalcBlock t v (Case c e) = genCaseBlock t v c e
 genCalcBlock CalcAssign v e = do
   vv <- mkVar (quantvar v)
@@ -499,7 +499,7 @@ genCalcBlock CalcAssign v e = do
 genCalcBlock CalcReturn _ e = block <$> liftS (returnStmt <$> convExpr e)
 
 genCaseBlock :: (OOProg r) => CalcType -> CodeDefinition -> Completeness 
-  -> [(Expr,Relation)] -> Reader DrasilState (MSBlock r)
+  -> [(Expr,Relation)] -> GenState (MSBlock r)
 genCaseBlock _ _ _ [] = error $ "Case expression with no cases encountered" ++
   " in code generator"
 genCaseBlock t v c cs = do
@@ -515,15 +515,15 @@ genCaseBlock t v c cs = do
 
 ----- OUTPUT -------
 
-genOutputMod :: (OOProg r) => Reader DrasilState [SFile r]
+genOutputMod :: (OOProg r) => GenState [SFile r]
 genOutputMod = do
   ofDesc <- modDesc $ liftS outputFormatDesc
   liftS $ genModule "OutputFormat" ofDesc [genOutputFormat] []
 
-genOutputFormat :: (OOProg r) => Reader DrasilState (Maybe (SMethod r))
+genOutputFormat :: (OOProg r) => GenState (Maybe (SMethod r))
 genOutputFormat = do
-  g <- ask
-  let genOutput :: (OOProg r) => Maybe String -> Reader DrasilState 
+  g <- get
+  let genOutput :: (OOProg r) => Maybe String -> GenState 
         (Maybe (SMethod r))
       genOutput Nothing = return Nothing
       genOutput (Just _) = do

--- a/code/drasil-code/Language/Drasil/Code/Imperative/SpaceMatch.hs
+++ b/code/drasil-code/Language/Drasil/Code/Imperative/SpaceMatch.hs
@@ -2,17 +2,32 @@ module Language.Drasil.Code.Imperative.SpaceMatch (
   chooseSpace
 ) where
 
-import Language.Drasil.Choices (Choices(..), MatchedSpaces)
+import Language.Drasil
+import Language.Drasil.Choices (Choices(..))
+import Language.Drasil.Code.Imperative.DrasilState (GenState, MatchedSpaces, 
+  addToDesignLog, addLoggedSpace)
 import Language.Drasil.Code.Lang (Lang(..))
 
 import GOOL.Drasil (CodeType(..))
+
+import Control.Monad.State (modify)
+import Text.PrettyPrint.HughesPJ (Doc, text)
 
 -- Concretizes the SpaceMatch in Choices to a MatchedSpace based on target language
 chooseSpace :: Lang -> Choices -> MatchedSpaces
 chooseSpace lng chs = \s -> selectType lng s (spaceMatch chs s)
         -- Floats unavailable in Python
-  where selectType Python s (Float:ts) = selectType Python s ts
+  where selectType :: Lang -> Space -> [CodeType] -> GenState CodeType
+        selectType Python s (Float:ts) = do
+          modify (addLoggedSpace s . 
+            addToDesignLog s (incompatibleType Python s Float))
+          selectType Python s ts
         -- In all other cases, just select first choice
-        selectType _ _ (t:_) = t
+        selectType _ _ (t:_) = return t
         selectType l s [] = error $ "Chosen CodeType matches for Space " ++ 
           show s ++ " are not compatible with target language " ++ show l
+
+incompatibleType :: Lang -> Space -> CodeType -> Doc
+incompatibleType l s t = text $ "Language " ++ show l ++ " does not support "
+  ++ "code type " ++ show t ++ ", chosen as the match for the " ++ show s ++ 
+  " space. Trying next choice." 

--- a/code/drasil-code/Language/Drasil/Data/ODELibPckg.hs
+++ b/code/drasil-code/Language/Drasil/Data/ODELibPckg.hs
@@ -6,8 +6,10 @@ import Language.Drasil.Code.ExternalLibrary (ExternalLibrary)
 import Language.Drasil.Code.ExternalLibraryCall (ExternalLibraryCall)
 import Language.Drasil.Code.Lang (Lang)
 import Language.Drasil.Data.ODEInfo (ODEInfo)
+import Language.Drasil.Mod (Name)
 
 data ODELibPckg = ODELib {
+  libName :: String,
   libSpec :: ExternalLibrary,
   libCall :: ODEInfo -> ExternalLibraryCall,
   libPath :: Maybe FilePath,
@@ -23,10 +25,10 @@ data ODELibPckg = ODELib {
   compatibleLangs :: [Lang]
 }
 
-mkODELib :: ExternalLibrary -> (ODEInfo -> ExternalLibraryCall) -> FilePath -> 
+mkODELib :: Name -> ExternalLibrary -> (ODEInfo -> ExternalLibraryCall) -> FilePath -> 
   [Lang] -> ODELibPckg
-mkODELib e c f = ODELib e c (Just f)
+mkODELib n e c f = ODELib n e c (Just f)
 
-mkODELibNoPath :: ExternalLibrary -> (ODEInfo -> ExternalLibraryCall) -> [Lang] 
+mkODELibNoPath :: Name -> ExternalLibrary -> (ODEInfo -> ExternalLibraryCall) -> [Lang] 
   -> ODELibPckg
-mkODELibNoPath e c = ODELib e c Nothing
+mkODELibNoPath n e c = ODELib n e c Nothing

--- a/code/drasil-data/Data/Drasil/ExternalLibraries/ODELibraries.hs
+++ b/code/drasil-data/Data/Drasil/ExternalLibraries/ODELibraries.hs
@@ -32,7 +32,7 @@ import Control.Lens ((^.), _1, _2, over)
 -- SciPy -- 
 
 scipyODEPckg :: ODELibPckg
-scipyODEPckg = mkODELibNoPath scipyODE scipyCall [Python]
+scipyODEPckg = mkODELibNoPath "SciPy" scipyODE scipyCall [Python]
 
 scipyODE :: ExternalLibrary
 scipyODE = externalLib [
@@ -131,7 +131,7 @@ integrateStep = quantfunc $ implVar "integrate_scipy" (nounPhrase
 -- Oslo (C#) --
 
 osloPckg :: ODELibPckg
-osloPckg = mkODELib oslo osloCall "Microsoft.Research.Oslo.dll" [CSharp]
+osloPckg = mkODELib "OSLO" oslo osloCall "Microsoft.Research.Oslo.dll" [CSharp]
 
 oslo :: ExternalLibrary
 oslo = externalLib [
@@ -239,8 +239,8 @@ arrayVecDepVar info = quantvar $ implVar (dv ^. uid ++ "vec") (dv ^. term)
 -- Apache (Java) --
 
 apacheODEPckg :: ODELibPckg
-apacheODEPckg = mkODELib apacheODE apacheODECall "lib/commons-math3-3.6.1.jar" 
-  [Java]
+apacheODEPckg = mkODELib "Apache" apacheODE apacheODECall 
+  "lib/commons-math3-3.6.1.jar" [Java]
 
 apacheODE :: ExternalLibrary
 apacheODE = externalLib [
@@ -388,7 +388,7 @@ computeDerivatives = quantfunc $ implVar "computeDerivatives_apache" (nounPhrase
 -- odeint (C++) --
 
 odeintPckg :: ODELibPckg
-odeintPckg = mkODELib odeint odeintCall "." [Cpp]
+odeintPckg = mkODELib "odeint" odeint odeintCall "." [Cpp]
 
 odeint :: ExternalLibrary
 odeint = externalLib [

--- a/code/drasil-gool/GOOL/Drasil/CodeType.hs
+++ b/code/drasil-gool/GOOL/Drasil/CodeType.hs
@@ -18,4 +18,4 @@ data CodeType = Boolean
               | Iterator CodeType
               | Object ClassName
               | Func [CodeType] CodeType
-              | Void deriving Eq
+              | Void deriving (Eq, Show)

--- a/code/stable/nopcm/src/cpp/designLog.txt
+++ b/code/stable/nopcm/src/cpp/designLog.txt
@@ -1,0 +1,3 @@
+Language Cpp is not compatible with chosen library SciPy, trying next choice.
+Language Cpp is not compatible with chosen library OSLO, trying next choice.
+Language Cpp is not compatible with chosen library Apache, trying next choice.

--- a/code/stable/nopcm/src/csharp/designLog.txt
+++ b/code/stable/nopcm/src/csharp/designLog.txt
@@ -1,0 +1,1 @@
+Language CSharp is not compatible with chosen library SciPy, trying next choice.

--- a/code/stable/nopcm/src/java/designLog.txt
+++ b/code/stable/nopcm/src/java/designLog.txt
@@ -1,0 +1,2 @@
+Language Java is not compatible with chosen library SciPy, trying next choice.
+Language Java is not compatible with chosen library OSLO, trying next choice.

--- a/code/stable/projectile/Projectile_S_L_NoL_U_U_V_F/src/python/designLog.txt
+++ b/code/stable/projectile/Projectile_S_L_NoL_U_U_V_F/src/python/designLog.txt
@@ -1,0 +1,2 @@
+Language Python does not support code type Float, chosen as the match for the Real space. Trying next choice.
+Language Python does not support code type Float, chosen as the match for the Rational space. Trying next choice.

--- a/code/stable/projectile/Projectile_U_P_L_B_WI_V_F/src/python/designLog.txt
+++ b/code/stable/projectile/Projectile_U_P_L_B_WI_V_F/src/python/designLog.txt
@@ -1,0 +1,2 @@
+Language Python does not support code type Float, chosen as the match for the Real space. Trying next choice.
+Language Python does not support code type Float, chosen as the match for the Rational space. Trying next choice.


### PR DESCRIPTION
This PR updates the generator to build a design log (which required switching from `Reader` to `State`). The design log logs when there is a conflict between the users' choices, leading to one of their back-up choices being used instead. If there are no conflicts, no design log is generated.

I've added the generated design logs to stable.

Closes #2088.