### PR TITLE
Remove Permanence Parameter from GOOL's Function Constructor (Warning: Large Commit)

### DIFF
--- a/code/drasil-code/Test/Helper.hs
+++ b/code/drasil-code/Test/Helper.hs
@@ -1,7 +1,7 @@
 module Test.Helper (helper) where
 
 import GOOL.Drasil (SFile, SMethod,
-  OOProg, FileSym(..), PermanenceSym(..), bodyStatements, TypeSym(..), 
+  OOProg, FileSym(..), bodyStatements, TypeSym(..), 
   DeclStatement(..), ControlStatement(..), (&=), VariableSym(..),
   Literal(..), VariableValue(..), NumericExpression(..), ScopeSym(..), ParameterSym(..), MethodSym(..), 
   ModuleSym(..))
@@ -13,7 +13,7 @@ helper = fileDoc (buildModule "Helper" [] [doubleAndAdd] [])
 doubleAndAdd :: (OOProg r) => SMethod r
 doubleAndAdd = docFunc "This function adds two numbers" 
   ["First number to add", "Second number to add"] (Just "Sum") $ 
-  function "doubleAndAdd"  public static double
+  function "doubleAndAdd"  public double
   [param $ var "num1" double, param $ var "num2" double]
   (bodyStatements [
     varDec $ var "doubledSum" double, 

--- a/code/drasil-gool/GOOL/Drasil/ClassInterface.hs
+++ b/code/drasil-gool/GOOL/Drasil/ClassInterface.hs
@@ -507,15 +507,13 @@ type SMethod a = MS (a (Method a))
 type Initializers r = [(SVariable r, SValue r)]
 
 -- The three lists are inputs, outputs, and both, respectively
-type InOutFunc r = Label -> r (Scope r) -> r (Permanence r) -> [SVariable r] -> 
-  [SVariable r] -> [SVariable r] -> MSBody r -> SMethod r
--- Parameters are: function name, scope, permanence, brief description, 
--- input descriptions and variables, output descriptions and variables, 
--- descriptions and variables for parameters that are both input and output, 
--- function body
-type DocInOutFunc r = Label -> r (Scope r) -> r (Permanence r) -> String -> 
-  [(String, SVariable r)] -> [(String, SVariable r)] -> [(String, SVariable r)] 
-  -> MSBody r -> SMethod r
+type InOutFunc r = [SVariable r] -> [SVariable r] -> [SVariable r] -> 
+  MSBody r -> SMethod r
+-- Parameters are: brief description of function, input descriptions and 
+-- variables, output descriptions and variables, descriptions and variables 
+-- for parameters that are both input and output, function body
+type DocInOutFunc r = String -> [(String, SVariable r)] -> 
+  [(String, SVariable r)] -> [(String, SVariable r)] -> MSBody r -> SMethod r
 
 class (BodySym r, ParameterSym r, ScopeSym r, PermanenceSym r) => MethodSym r 
   where
@@ -528,17 +526,19 @@ class (BodySym r, ParameterSym r, ScopeSym r, PermanenceSym r) => MethodSym r
 
   docMain :: MSBody r -> SMethod r
 
-  function :: Label -> r (Scope r) -> r (Permanence r) -> 
-    VSType r -> [MSParameter r] -> MSBody r -> SMethod r
+  function :: Label -> r (Scope r) -> VSType r -> [MSParameter r] -> 
+    MSBody r -> SMethod r
   mainFunction  :: MSBody r -> SMethod r
   -- Parameters are: function description, parameter descriptions, 
   --   return value description if applicable, function
   docFunc :: String -> [String] -> Maybe String -> SMethod r -> SMethod r
 
-  inOutMethod :: InOutFunc r
-  docInOutMethod :: DocInOutFunc r
-  inOutFunc :: InOutFunc r
-  docInOutFunc :: DocInOutFunc r
+  -- inOutMethod and docInOutMethod both need the Permanence parameter
+  inOutMethod :: Label -> r (Scope r) -> r (Permanence r) -> InOutFunc r
+  docInOutMethod :: Label -> r (Scope r) -> r (Permanence r) -> DocInOutFunc r
+  -- inOutFunc and docInOutFunc both do not need the Permanence parameter
+  inOutFunc :: Label -> r (Scope r) -> InOutFunc r
+  docInOutFunc :: Label -> r (Scope r) -> DocInOutFunc r
 
 privMethod :: (MethodSym r) => Label -> VSType r -> [MSParameter r] -> MSBody r 
   -> SMethod r

--- a/code/drasil-gool/GOOL/Drasil/CodeInfo.hs
+++ b/code/drasil-gool/GOOL/Drasil/CodeInfo.hs
@@ -366,7 +366,7 @@ instance MethodSym CodeInfo where
 
   docMain = updateMEMandCM "main"
 
-  function n _ _ _ _ = updateMEMandCM n
+  function n _ _ _ = updateMEMandCM n
   mainFunction = updateMEMandCM "main"
 
   docFunc _ _ _ f = do
@@ -377,9 +377,9 @@ instance MethodSym CodeInfo where
 
   docInOutMethod n _ _ _ _ _ _ = updateMEMandCM n
 
-  inOutFunc      n _ _ _ _ _   = updateMEMandCM n
+  inOutFunc      n _ _ _ _     = updateMEMandCM n
 
-  docInOutFunc   n _ _ _ _ _ _ = updateMEMandCM n
+  docInOutFunc   n _ _ _ _ _   = updateMEMandCM n
 
 instance StateVarSym CodeInfo where
   type StateVar CodeInfo = ()

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer/CSharpRenderer.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer/CSharpRenderer.hs
@@ -591,13 +591,13 @@ instance MethodSym CSharpCode where
 
   docFunc = G.docFunc
 
-  inOutMethod n = csInOut (method n)
+  inOutMethod n s p = csInOut (method n s p)
 
-  docInOutMethod n = CP.docInOutFunc (inOutMethod n)
+  docInOutMethod n s p = CP.docInOutFunc (inOutMethod n s p)
 
-  inOutFunc n = csInOut (function n)
+  inOutFunc n s = csInOut (function n s)
 
-  docInOutFunc n = CP.docInOutFunc (inOutFunc n)
+  docInOutFunc n s = CP.docInOutFunc (inOutFunc n s)
 
 instance RenderMethod CSharpCode where
   intMethod m n s p t ps b = do
@@ -854,18 +854,16 @@ csObjVar o v = csObjVar' (variableBind v)
         csObjVar' Dynamic = mkVar (variableName o ++ "." ++ variableName v) 
           (variableType v) (R.objVar (RC.variable o) (RC.variable v))
 
-csInOut :: (CSharpCode (Scope CSharpCode) -> CSharpCode (Permanence CSharpCode) 
-    -> VSType CSharpCode -> [MSParameter CSharpCode] -> MSBody CSharpCode -> 
-    SMethod CSharpCode)
-  -> CSharpCode (Scope CSharpCode) -> CSharpCode (Permanence CSharpCode) -> 
+csInOut :: (VSType CSharpCode -> [MSParameter CSharpCode] -> MSBody CSharpCode -> 
+    SMethod CSharpCode) -> 
   [SVariable CSharpCode] -> [SVariable CSharpCode] -> [SVariable CSharpCode] -> 
   MSBody CSharpCode -> SMethod CSharpCode
-csInOut f s p ins [v] [] b = f s p (onStateValue variableType v) (map param ins)
+csInOut f ins [v] [] b = f (onStateValue variableType v) (map param ins)
   (on3StateValues (on3CodeValues surroundBody) (varDec v) b (returnStmt $ 
   valueOf v))
-csInOut f s p ins [] [v] b = f s p (onStateValue variableType v) 
+csInOut f ins [] [v] b = f (onStateValue variableType v) 
   (map param $ v : ins) (on2StateValues (on2CodeValues appendToBody) b 
   (returnStmt $ valueOf v))
-csInOut f s p ins outs both b = f s p void (map (onStateValue (onCodeValue 
+csInOut f ins outs both b = f void (map (onStateValue (onCodeValue 
   (updateParam csRef)) . param) both ++ map param ins ++ map (onStateValue 
   (onCodeValue (updateParam csOut)) . param) outs) b

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer/CommonPseudoOO.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer/CommonPseudoOO.hs
@@ -275,13 +275,13 @@ string = toState $ typeFromData String stringRender (text stringRender)
 constDecDef :: (RenderSym r) => SVariable r -> SValue r -> MSStatement r
 constDecDef = zoom lensMStoVS .: on2StateValues (mkStmt .: R.constDecDef)
   
-docInOutFunc :: (RenderSym r) => (r (Scope r) -> r (Permanence r) -> 
-    [SVariable r] -> [SVariable r] -> [SVariable r] -> MSBody r -> SMethod r)
-  -> r (Scope r) -> r (Permanence r) -> String -> [(String, SVariable r)] -> 
-  [(String, SVariable r)] -> [(String, SVariable r)] -> MSBody r -> SMethod r
-docInOutFunc f s p desc is [o] [] b = docFuncRepr desc (map fst is) [fst o] 
-  (f s p (map snd is) [snd o] [] b)
-docInOutFunc f s p desc is [] [both] b = docFuncRepr desc (map fst $ both : is) 
-  [fst both] (f s p (map snd is) [] [snd both] b)
-docInOutFunc f s p desc is os bs b = docFuncRepr desc (map fst $ bs ++ is ++ os)
-  [] (f s p (map snd is) (map snd os) (map snd bs) b)
+docInOutFunc :: (RenderSym r) => ([SVariable r] -> [SVariable r] -> 
+    [SVariable r] -> MSBody r -> SMethod r) -> 
+  String -> [(String, SVariable r)] -> [(String, SVariable r)] -> 
+  [(String, SVariable r)] -> MSBody r -> SMethod r
+docInOutFunc f desc is [o] [] b = docFuncRepr desc (map fst is) [fst o] 
+  (f (map snd is) [snd o] [] b)
+docInOutFunc f desc is [] [both] b = docFuncRepr desc (map fst $ both : is) 
+  [fst both] (f (map snd is) [] [snd both] b)
+docInOutFunc f desc is os bs b = docFuncRepr desc (map fst $ bs ++ is ++ os)
+  [] (f (map snd is) (map snd os) (map snd bs) b)

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer/CppRenderer.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer/CppRenderer.hs
@@ -664,8 +664,8 @@ instance (Pair p) => MethodSym (p CppSrcCode CppHdrCode) where
 
   docMain = pair1 docMain docMain
 
-  function n s p t = pairValListVal 
-    (function n (pfst s) (pfst p)) (function n (psnd s) (psnd p)) 
+  function n s t = pairValListVal 
+    (function n (pfst s)) (function n (psnd s)) 
     (zoom lensMStoVS t)
   mainFunction = pair1 mainFunction mainFunction
 
@@ -685,15 +685,15 @@ instance (Pair p) => MethodSym (p CppSrcCode CppHdrCode) where
     (map (zoom lensMStoVS . snd) is) (map (zoom lensMStoVS . snd) os) 
     (map (zoom lensMStoVS . snd) bs)
 
-  inOutFunc n s p is os bs = pair3Lists1Val
-    (inOutFunc n (pfst s) (pfst p)) (inOutFunc n (psnd s) (psnd p))
+  inOutFunc n s is os bs = pair3Lists1Val
+    (inOutFunc n (pfst s)) (inOutFunc n (psnd s))
     (map (zoom lensMStoVS) is) (map (zoom lensMStoVS) os) 
     (map (zoom lensMStoVS) bs)
 
-  docInOutFunc n s p desc is os bs = pair3Lists1Val 
-    (\ins outs both -> docInOutFunc n (pfst s) (pfst p) desc (zip (map fst 
+  docInOutFunc n s desc is os bs = pair3Lists1Val 
+    (\ins outs both -> docInOutFunc n (pfst s) desc (zip (map fst 
       is) ins) (zip (map fst os) outs) (zip (map fst bs) both))
-    (\ins outs both -> docInOutFunc n (psnd s) (psnd p) desc (zip (map fst 
+    (\ins outs both -> docInOutFunc n (psnd s) desc (zip (map fst 
       is) ins) (zip (map fst os) outs) (zip (map fst bs) both))
     (map (zoom lensMStoVS . snd) is) (map (zoom lensMStoVS . snd) os) 
     (map (zoom lensMStoVS . snd) bs)
@@ -1492,13 +1492,13 @@ instance MethodSym CppSrcCode where
 
   docFunc = G.docFunc
 
-  inOutMethod n = cppsInOut (method n)
+  inOutMethod n s p = cppsInOut (method n s p)
 
-  docInOutMethod n = CP.docInOutFunc (inOutMethod n)
+  docInOutMethod n s p = CP.docInOutFunc (inOutMethod n s p)
 
-  inOutFunc n = cppsInOut (function n)
+  inOutFunc n s = cppsInOut (function n s)
 
-  docInOutFunc n = CP.docInOutFunc (inOutFunc n)
+  docInOutFunc n s = CP.docInOutFunc (inOutFunc n s)
 
 instance RenderMethod CppSrcCode where
   intMethod m n s _ t ps b = do
@@ -2079,13 +2079,13 @@ instance MethodSym CppHdrCode where
 
   docFunc = G.docFunc
 
-  inOutMethod n = cpphInOut (method n)
+  inOutMethod n s p = cpphInOut (method n s p)
 
-  docInOutMethod n = CP.docInOutFunc (inOutMethod n)
+  docInOutMethod n s p = CP.docInOutFunc (inOutMethod n s p)
 
-  inOutFunc n = cpphInOut (function n)
+  inOutFunc n s = cpphInOut (function n s)
 
-  docInOutFunc n = CP.docInOutFunc (inOutFunc n)
+  docInOutFunc n s = CP.docInOutFunc (inOutFunc n s)
 
 instance RenderMethod CppHdrCode where
   intMethod _ n s _ t ps _ = do
@@ -2629,31 +2629,27 @@ cppInOutCall f n ins [] [out] = assign out $ f n (onStateValue variableType out)
 cppInOutCall f n ins outs both = valStmt $ f n void (map valueOf both ++ ins 
   ++ map valueOf outs)
 
-cppsInOut :: (CppSrcCode (Scope CppSrcCode) -> 
-    CppSrcCode (Permanence CppSrcCode) -> VSType CppSrcCode -> 
-    [MSParameter CppSrcCode] -> MSBody CppSrcCode -> SMethod CppSrcCode)
-  -> CppSrcCode (Scope CppSrcCode) -> CppSrcCode (Permanence CppSrcCode) -> 
+cppsInOut :: (VSType CppSrcCode -> [MSParameter CppSrcCode] -> MSBody CppSrcCode -> 
+    SMethod CppSrcCode) -> 
   [SVariable CppSrcCode] -> [SVariable CppSrcCode] -> [SVariable CppSrcCode] -> 
   MSBody CppSrcCode -> SMethod CppSrcCode
-cppsInOut f s p ins [v] [] b = f s p (onStateValue variableType v) 
+cppsInOut f ins [v] [] b = f (onStateValue variableType v) 
   (cppInOutParams ins [v] []) (on3StateValues (on3CodeValues surroundBody) 
   (varDec v) b (returnStmt $ valueOf v))
-cppsInOut f s p ins [] [v] b = f s p (onStateValue variableType v) 
+cppsInOut f ins [] [v] b = f (onStateValue variableType v) 
   (cppInOutParams ins [] [v]) (on2StateValues (on2CodeValues appendToBody) b 
   (returnStmt $ valueOf v))
-cppsInOut f s p ins outs both b = f s p void (cppInOutParams ins outs both) b
+cppsInOut f ins outs both b = f void (cppInOutParams ins outs both) b
 
-cpphInOut :: (CppHdrCode (Scope CppHdrCode) -> 
-    CppHdrCode (Permanence CppHdrCode) -> VSType CppHdrCode -> 
-    [MSParameter CppHdrCode] -> MSBody CppHdrCode -> SMethod CppHdrCode) 
-  -> CppHdrCode (Scope CppHdrCode) -> CppHdrCode (Permanence CppHdrCode) -> 
+cpphInOut :: (VSType CppHdrCode -> [MSParameter CppHdrCode] -> MSBody CppHdrCode -> 
+    SMethod CppHdrCode) -> 
   [SVariable CppHdrCode] -> [SVariable CppHdrCode] -> [SVariable CppHdrCode] -> 
   MSBody CppHdrCode -> SMethod CppHdrCode
-cpphInOut f s p ins [v] [] b = f s p (onStateValue variableType v) 
+cpphInOut f ins [v] [] b = f (onStateValue variableType v) 
   (cppInOutParams ins [v] []) b
-cpphInOut f s p ins [] [v] b = f s p (onStateValue variableType v) 
+cpphInOut f ins [] [v] b = f (onStateValue variableType v) 
   (cppInOutParams ins [] [v]) b
-cpphInOut f s p ins outs both b = f s p void (cppInOutParams ins outs both) b
+cpphInOut f ins outs both b = f void (cppInOutParams ins outs both) b
 
 cppInOutParams :: (RenderSym r) => [SVariable r] -> [SVariable r] -> 
   [SVariable r] -> [MSParameter r]

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer/LanguagePolymorphic.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer/LanguagePolymorphic.hs
@@ -426,9 +426,9 @@ constructor fName ps is b = getClassName >>= (\c -> intMethod False fName
   public dynamic (S.construct c) ps (S.multiBody [ib, b]))
   where ib = bodyStatements (map (\(vr, vl) -> S.objVarSelf vr &= vl) is)
 
-function :: (RenderSym r) => Label -> r (Scope r) -> r (Permanence r) -> 
-  VSType r -> [MSParameter r] -> MSBody r -> SMethod r
-function n s p t = S.intFunc False n s p (mType t)
+function :: (RenderSym r) => Label -> r (Scope r) -> VSType r -> 
+  [MSParameter r] -> MSBody r -> SMethod r
+function n s t = S.intFunc False n s static (mType t)
   
 docFuncRepr :: (RenderSym r) => String -> [String] -> [String] -> SMethod r -> 
   SMethod r


### PR DESCRIPTION
- contains all changed files related to removing the Permanence parameter from GOOL's function constructor

- implemented changes to remove Permanence parameter from GOOL's function constructors `function`
- to implement the above changes, modifications were also made to functions `inOutFunc`, `docInOutFunc`, `inOutMethod`, `docInOutMethod` and `genInOutFunc`,  as well as types `InOutFunc` and `DocInOutFunc` (and maybe others as well)
    - changes were also made to each individual target languages' `_InOut` and `_DocInOut` functions (e.g. `pyInOut` and `pyDocInOut`)

- changed files (ten):

   - drasil-code: Import.hs, Helper.hs
   - drasil-gool: ClassInterface.hs, CodeInfo.hs, CSharpRenderer.hs, CommonPseudoOO.hs, CppRenderer.hs, JavaRenderer.hs, LanguagePolymorphic.hs, PythonRenderer.hs

- see [this commit](https://github.com/JacquesCarette/Drasil/commit/44ffb2f5a2115e2d5701d697e0faf09fd4ca33f2) for more details on changes made
- closes #2146 (addresses all items/changes requested in this Issue)