### PR TITLE
Update GOOL's &-- Operator Implementation + HelloWorld Stable Files

### DIFF
--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer.hs
@@ -13,8 +13,8 @@ module GOOL.Drasil.LanguageRenderer (
   -- * Default Functions available for use in renderers
   package, file, module', class', multiStmt, block, body, print, printFile, 
   param, method, stateVar, constVar, stateVarList, switch, assign, multiAssign, 
-  addAssign, subAssign, increment, listDec, getTerm, return', comment, var, extVar,
-  arg, classVar, objVar, unOpDocD, unOpDocD', binOpDocD, binOpDocD', 
+  addAssign, subAssign, increment, decrement, listDec, getTerm, return', comment, 
+  var, extVar, arg, classVar, objVar, unOpDocD, unOpDocD', binOpDocD, binOpDocD', 
   constDecDef, func, cast, listAccessFunc, listSetFunc, objAccess, castObj, 
   break, continue, static, dynamic, private, public, blockCmt, docCmt, 
   commentedItem, addComments, functionDox, classDox, moduleDox, commentedMod, 
@@ -233,6 +233,9 @@ subAssign vr vl = RC.variable vr <+> text "-=" <+> RC.value vl
 
 increment :: (RenderSym r) => r (Variable r) -> Doc
 increment v = RC.variable v <> text "++"
+
+decrement :: (RenderSym r) => r (Variable r) -> Doc
+decrement v = RC.variable v <> text "--"
 
 listDec :: (RenderSym r) => r (Variable r) -> r (Value r) -> Doc
 listDec v n = space <> equals <+> new' <+> RC.type' (variableType v) 

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer/CLike.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer/CLike.hs
@@ -4,8 +4,8 @@
 module GOOL.Drasil.LanguageRenderer.CLike (charRender, float, double, char, 
   listType, void, notOp, andOp, orOp, self, litTrue, litFalse, litFloat, 
   inlineIf, libFuncAppMixedArgs, libNewObjMixedArgs, listSize, increment1, 
-  varDec, varDecDef, listDec, extObjDecNew, switch, for, while, intFunc, 
-  multiAssignError, multiReturnError
+  decrement1, varDec, varDecDef, listDec, extObjDecNew, switch, for, while, 
+  intFunc, multiAssignError, multiReturnError
 ) where
 
 import Utils.Drasil (indent)
@@ -31,8 +31,8 @@ import GOOL.Drasil.AST (Binding(..))
 import GOOL.Drasil.Helpers (angles, toState, onStateValue, on2StateValues, 
   on3StateValues)
 import GOOL.Drasil.LanguageRenderer (forLabel, whileLabel, containing)
-import qualified GOOL.Drasil.LanguageRenderer as R (switch, increment, self', 
-  self)
+import qualified GOOL.Drasil.LanguageRenderer as R (switch, increment, decrement, 
+  self', self)
 import GOOL.Drasil.LanguageRenderer.Constructors (mkStmt, mkStmtNoEnd, 
   mkStateVal, mkStateVar, VSOp, unOpPrec, andPrec, orPrec)
 import GOOL.Drasil.State (lensMStoVS, lensVStoMS, addLibImportVS, getClassName)
@@ -121,6 +121,9 @@ listSize v = v $. S.listSizeFunc
 
 increment1 :: (RenderSym r) => SVariable r -> MSStatement r
 increment1 vr = zoom lensMStoVS $ onStateValue (mkStmt . R.increment) vr
+
+decrement1 :: (RenderSym r) => SVariable r -> MSStatement r
+decrement1 vr = zoom lensMStoVS $ onStateValue (mkStmt . R.decrement) vr
 
 varDec :: (RenderSym r) => r (Permanence r) -> r (Permanence r) -> Doc -> 
   SVariable r -> MSStatement r

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer/CSharpRenderer.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer/CSharpRenderer.hs
@@ -74,11 +74,11 @@ import qualified GOOL.Drasil.LanguageRenderer.CommonPseudoOO as CP (
 import qualified GOOL.Drasil.LanguageRenderer.CLike as C (float, double, char, 
   listType, void, notOp, andOp, orOp, self, litTrue, litFalse, litFloat, 
   inlineIf, libFuncAppMixedArgs, libNewObjMixedArgs, listSize, increment1, 
-  varDec, varDecDef, listDec, extObjDecNew, switch, for, while, intFunc, 
-  multiAssignError, multiReturnError)
+  decrement1, varDec, varDecDef, listDec, extObjDecNew, switch, for, while, 
+  intFunc, multiAssignError, multiReturnError)
 import qualified GOOL.Drasil.LanguageRenderer.Macros as M (ifExists, 
-  decrement1, runStrategy, listSlice, stringListVals, stringListLists,
-  forRange, notifyObservers, checkState)
+  runStrategy, listSlice, stringListVals, stringListLists, forRange, 
+  notifyObservers, checkState)
 import GOOL.Drasil.AST (Terminator(..), FileType(..), FileData(..), fileD, 
   FuncData(..), fd, ModData(..), md, updateMod, MethodData(..), mthd, 
   updateMthd, OpData(..), ParamData(..), pd, updateParam, ProgData(..), progD, 
@@ -459,7 +459,7 @@ instance AssignStatement CSharpCode where
   (&-=) = G.subAssign Semi
   (&+=) = G.increment
   (&++) = C.increment1
-  (&--) = M.decrement1
+  (&--) = C.decrement1
 
 instance DeclStatement CSharpCode where
   varDec v = zoom lensMStoVS v >>= (\v' -> csVarDec (variableBind v') $ 

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer/CppRenderer.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer/CppRenderer.hs
@@ -71,11 +71,10 @@ import qualified GOOL.Drasil.LanguageRenderer.CommonPseudoOO as CP (objVar,
 import qualified GOOL.Drasil.LanguageRenderer.CLike as C (charRender, float, 
   double, char, listType, void, notOp, andOp, orOp, self, litTrue, litFalse, 
   litFloat, inlineIf, libFuncAppMixedArgs, libNewObjMixedArgs, listSize, 
-  increment1, varDec, varDecDef, listDec, extObjDecNew, switch, for, while, 
-  intFunc, multiAssignError, multiReturnError)
-import qualified GOOL.Drasil.LanguageRenderer.Macros as M ( 
-  decrement1, runStrategy, listSlice, stringListVals, stringListLists, forRange,
-  notifyObservers)
+  increment1, decrement1, varDec, varDecDef, listDec, extObjDecNew, switch, for, 
+  while, intFunc, multiAssignError, multiReturnError)
+import qualified GOOL.Drasil.LanguageRenderer.Macros as M (runStrategy, 
+  listSlice, stringListVals, stringListLists, forRange, notifyObservers)
 import GOOL.Drasil.AST (Terminator(..), ScopeTag(..), Binding(..), onBinding, 
   BindData(..), bd, FileType(..), FileData(..), fileD, FuncData(..), fd, 
   ModData(..), md, updateMod, OpData(..), ParamData(..), pd, ProgData(..), 
@@ -1328,7 +1327,7 @@ instance AssignStatement CppSrcCode where
   (&-=) = G.subAssign Semi
   (&+=) = G.increment
   (&++) = C.increment1
-  (&--) = M.decrement1
+  (&--) = C.decrement1
 
 instance DeclStatement CppSrcCode where
   varDec = C.varDec static dynamic empty

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer/JavaRenderer.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer/JavaRenderer.hs
@@ -74,11 +74,11 @@ import qualified GOOL.Drasil.LanguageRenderer.CommonPseudoOO as CP (
 import qualified GOOL.Drasil.LanguageRenderer.CLike as C (float, double, char, 
   listType, void, notOp, andOp, orOp, self, litTrue, litFalse, litFloat, 
   inlineIf, libFuncAppMixedArgs, libNewObjMixedArgs, listSize, increment1, 
-  varDec, varDecDef, listDec, extObjDecNew, switch, for, while, intFunc, 
-  multiAssignError, multiReturnError)
+  decrement1, varDec, varDecDef, listDec, extObjDecNew, switch, for, while, 
+  intFunc, multiAssignError, multiReturnError)
 import qualified GOOL.Drasil.LanguageRenderer.Macros as M (ifExists, 
-  decrement1, runStrategy, listSlice, stringListVals, stringListLists,
-  forRange, notifyObservers, checkState)
+  runStrategy, listSlice, stringListVals, stringListLists, forRange, 
+  notifyObservers, checkState)
 import GOOL.Drasil.AST (Terminator(..), ScopeTag(..), qualName, FileType(..), 
   FileData(..), fileD, FuncData(..), fd, ModData(..), md, updateMod, 
   MethodData(..), mthd, updateMthd, OpData(..), ParamData(..), pd, ProgData(..),
@@ -486,7 +486,7 @@ instance AssignStatement JavaCode where
   (&-=) = G.subAssign Semi
   (&+=) = G.increment
   (&++) = C.increment1
-  (&--) = M.decrement1
+  (&--) = C.decrement1
 
 instance DeclStatement JavaCode where
   varDec = C.varDec static dynamic empty

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer/PythonRenderer.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer/PythonRenderer.hs
@@ -66,8 +66,8 @@ import qualified GOOL.Drasil.LanguageRenderer.CommonPseudoOO as CP (
   discardFileLine, destructorError, stateVarDef, constVar, intClass, objVar, 
   funcType, listSetFunc, listAccessFunc, buildModule)
 import qualified GOOL.Drasil.LanguageRenderer.Macros as M (ifExists, 
-  decrement1, increment1, runStrategy, stringListVals, stringListLists,
-  observerIndex, checkState)
+  increment1, runStrategy, stringListVals, stringListLists, observerIndex, 
+  checkState)
 import GOOL.Drasil.AST (Terminator(..), FileType(..), FileData(..), fileD, 
   FuncData(..), fd, ModData(..), md, updateMod, MethodData(..), mthd, 
   updateMthd, OpData(..), ParamData(..), pd, ProgData(..), progD, TypeData(..), 
@@ -471,7 +471,7 @@ instance AssignStatement PythonCode where
   (&-=) = G.subAssign Empty
   (&+=) = G.increment
   (&++) = M.increment1
-  (&--) = M.decrement1
+  (&--) vr = (&-=) vr (litInt 1)
 
 instance DeclStatement PythonCode where
   varDec _ = toState $ mkStmtNoEnd empty

--- a/code/stable/gooltest/cpp/HelloWorld/HelloWorld.cpp
+++ b/code/stable/gooltest/cpp/HelloWorld/HelloWorld.cpp
@@ -81,8 +81,8 @@ int main(int argc, const char *argv[]) {
         c += 17;
         a++;
         d++;
-        c = c - 1;
-        b = b - 1;
+        c--;
+        b--;
         vector<int> myList(5);
         char myObj = 'o';
         const string myConst = "Imconstant";

--- a/code/stable/gooltest/csharp/HelloWorld/HelloWorld.cs
+++ b/code/stable/gooltest/csharp/HelloWorld/HelloWorld.cs
@@ -66,8 +66,8 @@ public class HelloWorld {
             c += 17;
             a++;
             d++;
-            c = c - 1;
-            b = b - 1;
+            c--;
+            b--;
             List<int> myList = new List<int>(5);
             char myObj = 'o';
             const string myConst = "Imconstant";

--- a/code/stable/gooltest/java/HelloWorld/HelloWorld/HelloWorld.java
+++ b/code/stable/gooltest/java/HelloWorld/HelloWorld/HelloWorld.java
@@ -53,8 +53,8 @@ public class HelloWorld {
             c += 17;
             a++;
             d++;
-            c = c - 1;
-            b = b - 1;
+            c--;
+            b--;
             ArrayList<Integer> myList = new ArrayList<Integer>(5);
             char myObj = 'o';
             final String myConst = "Imconstant";

--- a/code/stable/gooltest/python/HelloWorld/HelloWorld.py
+++ b/code/stable/gooltest/python/HelloWorld/HelloWorld.py
@@ -39,8 +39,8 @@ elif (b == 5) :
     c += 17;
     a = a + 1
     d = d + 1
-    c = c - 1
-    b = b - 1
+    c -= 1
+    b -= 1
     myList = []
     myObj = 'o'
     myConst = "Imconstant"


### PR DESCRIPTION
- contains all changed files related to updating GOOL's `&--` operator to use the decrement operator (`--`) in generated code (and the `-=` operator in Python)

- implemented changes to updating GOOL's `&--` operator to use the decrement operator (`--`) in generated code (and `-=` operator in Python)

- to implement the above changes, two new functions, `decrement` (in LanguageRenderer.hs) and `decrement1` (in CLike.hs) were created
- references to the function `decrement1` (from Macros.hs) were removed and replaced with:
   - the function `decrement1` (from CLike.hs) in the C++, C# and Java Language Renderers
   - a partial application of the `&-=` GOOL operator implementation in the Python Language Renderer

- changed files (ten):
   - drasil-gool: LanguageRenderer.hs, CLike.hs, CSharpRenderer.hs, CppRenderer.hs, JavaRenderer.hs, PythonRenderer.hs
   - stable folder files: HelloWorld.cpp, HelloWorld.cs, HelloWorld.java, HelloWorld.py

- see [this commit](https://github.com/JacquesCarette/Drasil/commit/d5a902741787c1dbaf2cd3a0283a78ca812f2ed8) for more details on changes made

- closes #2148 (addresses all items/changes requested in this Issue)