### PR TITLE
Update gitattributes to ignore files from external libraries in our repo

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -4,3 +4,6 @@ FamilyOfGamePhysicsEngines/* linguist-documentation
 notes/* linguist-documentation
 Presentations/* linguist-documentation
 code/stable/* linguist-generated=true
+code/datafiles/NoPCM/cpp/* linguist-vendored
+code/datafiles/NoPCM/csharp/* linguist-vendored
+code/datafiles/NoPCM/java/* linguist-vendored


### PR DESCRIPTION
Related to #2183. If I understand correctly, marking files as linguist-vendored in the .gitattributes file will make them ignored for GitHub's language statistics, so this repo will go back to being a Haskell project.