### PR TITLE
Add language name on site for Swift

### DIFF
--- a/code/website/site.hs
+++ b/code/website/site.hs
@@ -50,6 +50,7 @@ getSrc names repoRoot source = CS (repoRoot ++ source)
     lang "csharp" = "C#"
     lang "python" = "Python"
     lang "java"   = "Java"
+    lang "swift"  = "Swift"
     lang x        = error ("No given display name for language: " ++ x)
     eDir = takeBaseName $ takeDirectory $ takeDirectory source
     verName = if any (`isInfixOf` eDir) names then eDir else ""


### PR DESCRIPTION
This should fix #2201. The function that determines the text for the links on the site to each language needed a case for Swift.