### PR TITLE
Fixes #2241 (2d is corrected to 2D)

### DIFF
--- a/code/drasil-example/Drasil/GamePhysics/IMods.hs
+++ b/code/drasil-example/Drasil/GamePhysics/IMods.hs
@@ -43,7 +43,7 @@ transMotRC :: RelationConcept
 transMotRC = makeRC "transMotRC" transMotNP EmptyS transMotRel
 
 transMotNP :: NP
-transMotNP = nounPhraseSP "Force on the translational motion of a set of 2d rigid bodies"
+transMotNP = nounPhraseSP "Force on the translational motion of a set of 2D rigid bodies"
 
 transMotRel :: Relation -- FIXME: add proper equation
 transMotRel = sy accI $= deriv (apply1 velI time) time

--- a/code/stable/gamephysics/SRS/GamePhysics_SRS.tex
+++ b/code/stable/gamephysics/SRS/GamePhysics_SRS.tex
@@ -1242,7 +1242,7 @@ The goal \hyperref[linearGS]{GS: Determine-Linear-Properties} is met by \hyperre
 \phantomsection 
 \label{IM:transMot}
 \\ \midrule \\
-Label & Force on the translational motion of a set of 2d rigid bodies
+Label & Force on the translational motion of a set of 2D rigid bodies
         
 \\ \midrule \\
 Input & ${\mathbf{v}_{i}}$, $t$, $\mathbf{g}$, ${\mathbf{F}_{i}}$, ${m_{j}}$

--- a/code/stable/gamephysics/Website/GamePhysics_SRS.html
+++ b/code/stable/gamephysics/Website/GamePhysics_SRS.html
@@ -2073,7 +2073,7 @@
                       <th>Label</th>
                       <td>
                         <p class="paragraph">
-                          Force on the translational motion of a set of 2d rigid bodies
+                          Force on the translational motion of a set of 2D rigid bodies
                         </p>
                       </td>
                     </tr>


### PR DESCRIPTION
Closes #2241.  There is a typo in the original text that uses 2d instead of 2D.  At some point we should probably introduce a symbolic constant for 2D, so that 2D is always used, instead of relying on the person coding in the example to use the proper case.  (I suppose if someone wanted to, they could always make an "error" like this by using a string, instead of using the symbolic constant.