### PR TITLE
New ODE package for Python, ScipyODELsoda, that can solve second order ODEs

### DIFF
--- a/code/drasil-code/Language/Drasil/Chunk/CodeDefinition.hs
+++ b/code/drasil-code/Language/Drasil/Chunk/CodeDefinition.hs
@@ -49,7 +49,7 @@ qtov q = CD (codeChunk $ quantvar q) (q ^. defnExpr) [] Definition
 odeDef :: ODEInfo -> CodeDefinition
 odeDef info = CD (codeChunk $ quantfunc $ depVar info) (Matrix [odeSyst info]) 
   (map ($ info) [tInit, tFinal, initVal, absTol . odeOpts, relTol . odeOpts, 
-  stepSize . odeOpts]) ODE
+  stepSize . odeOpts, initValFstOrd . odeOpts]) ODE
 
 -- Returns the defining Expr of a CodeDefinition
 codeEquat :: CodeDefinition -> Expr

--- a/code/drasil-code/Language/Drasil/Code.hs
+++ b/code/drasil-code/Language/Drasil/Code.hs
@@ -21,7 +21,7 @@ module Language.Drasil.Code (
   implementation, constructorInfo, methodInfo, methodInfoNoReturn, 
   appendCurrSol, populateSolList, assignArrayIndex, assignSolFromObj, 
   initSolListFromArray, initSolListWithVal, solveAndPopulateWhile, 
-  returnExprList, fixedReturn,
+  returnExprList, fixedReturn, initSolWithVal,
   ExternalLibraryCall, StepGroupFill(..), StepFill(..), FunctionIntFill(..), 
   ArgumentFill(..), ParameterFill(..), ClassInfoFill(..), MethodInfoFill(..),
   externalLibCall, choiceStepsFill, choiceStepFill, mandatoryStepFill, 
@@ -31,7 +31,7 @@ module Language.Drasil.Code (
   implementationFill, constructorInfoFill, methodInfoFill, appendCurrSolFill, 
   populateSolListFill, assignArrayIndexFill, assignSolFromObjFill, 
   initSolListFromArrayFill, initSolListWithValFill, solveAndPopulateWhileFill, 
-  returnExprListFill, fixedStatementFill,
+  returnExprListFill, fixedStatementFill, initSolWithValFill,
   Lang(..),
   PackageSym(..), AuxiliarySym(..),
   AuxData(..), PackData(..),
@@ -65,7 +65,7 @@ import Language.Drasil.Code.ExternalLibrary (ExternalLibrary, Step,
   implementation, constructorInfo, methodInfo, methodInfoNoReturn, 
   appendCurrSol, populateSolList, assignArrayIndex, assignSolFromObj, 
   initSolListFromArray, initSolListWithVal, solveAndPopulateWhile, 
-  returnExprList, fixedReturn)
+  returnExprList, fixedReturn, initSolWithVal)
 import Language.Drasil.Code.ExternalLibraryCall (ExternalLibraryCall,
   StepGroupFill(..), StepFill(..), FunctionIntFill(..), ArgumentFill(..),
   ParameterFill(..), ClassInfoFill(..), MethodInfoFill(..), externalLibCall, 
@@ -76,7 +76,7 @@ import Language.Drasil.Code.ExternalLibraryCall (ExternalLibraryCall,
   constructorInfoFill, methodInfoFill, appendCurrSolFill, populateSolListFill, 
   assignArrayIndexFill, assignSolFromObjFill, initSolListFromArrayFill, 
   initSolListWithValFill, solveAndPopulateWhileFill, returnExprListFill, 
-  fixedStatementFill)
+  fixedStatementFill, initSolWithValFill)
 
 import Language.Drasil.Code.Lang (Lang(..))
 

--- a/code/drasil-code/Language/Drasil/Code/ExternalLibrary.hs
+++ b/code/drasil-code/Language/Drasil/Code/ExternalLibrary.hs
@@ -11,7 +11,7 @@ module Language.Drasil.Code.ExternalLibrary (ExternalLibrary, Step(..),
   implementation, constructorInfo, methodInfo, methodInfoNoReturn, 
   appendCurrSol, populateSolList, assignArrayIndex, assignSolFromObj, 
   initSolListFromArray, initSolListWithVal, solveAndPopulateWhile, 
-  returnExprList, fixedReturn
+  returnExprList, fixedReturn, initSolWithVal
 ) where
 
 import Language.Drasil
@@ -304,3 +304,9 @@ statementStep = Statement
 -- Specifies a statement that is not use-case-dependent
 lockedStatement :: FuncStmt -> Step
 lockedStatement s = Statement (\_ _ -> s)
+
+-- Specifies a statement where a single solution is initialized with a value.
+initSolWithVal :: Step
+initSolWithVal = statementStep (\cdchs es -> case (cdchs, es) of
+  ([s],[v]) -> FDecDef s v
+  (_,_) -> error "Fill for initSolWithVal should provide one CodeChunk and one Expr")

--- a/code/drasil-code/Language/Drasil/Code/ExternalLibraryCall.hs
+++ b/code/drasil-code/Language/Drasil/Code/ExternalLibraryCall.hs
@@ -8,7 +8,8 @@ module Language.Drasil.Code.ExternalLibraryCall (ExternalLibraryCall,
   userDefinedParamFill, customClassFill, implementationFill, 
   constructorInfoFill, methodInfoFill, appendCurrSolFill, populateSolListFill, 
   assignArrayIndexFill, assignSolFromObjFill, initSolListFromArrayFill, 
-  initSolListWithValFill, solveAndPopulateWhileFill, returnExprListFill, fixedStatementFill
+  initSolListWithValFill, solveAndPopulateWhileFill, returnExprListFill, 
+  fixedStatementFill, initSolWithValFill
 ) where
 
 import Language.Drasil
@@ -195,3 +196,9 @@ statementStepFill = StatementF
 -- No parameters because the statement is not use-case-dependent.
 fixedStatementFill :: StepFill
 fixedStatementFill = StatementF [] []
+
+-- Corresponds to ExternalLibrary's initSolWithVal. Provides the 
+-- CodeVarChunk for one solution and one Expr for the initial element of 
+-- the solution list
+initSolWithValFill :: CodeVarChunk -> Expr -> StepFill
+initSolWithValFill s v = statementStepFill [s] [v]

--- a/code/drasil-code/Language/Drasil/Data/ODEInfo.hs
+++ b/code/drasil-code/Language/Drasil/Data/ODEInfo.hs
@@ -31,11 +31,12 @@ data ODEOptions = ODEOpts {
   solveMethod :: ODEMethod,
   absTol :: Expr,
   relTol :: Expr,
-  stepSize :: Expr
+  stepSize :: Expr,
+  initValFstOrd :: Expr -- Holds the initial value of a second order ODE.
 }
 
 -- Basic odeOptions constructor
-odeOptions :: ODEMethod -> Expr -> Expr -> Expr -> ODEOptions
+odeOptions :: ODEMethod -> Expr -> Expr -> Expr -> Expr -> ODEOptions
 odeOptions = ODEOpts
 
 -- Runge-Kutta 4-5, Backwards Differentiation Formula, or Adams' method.

--- a/code/drasil-data/Data/Drasil/ExternalLibraries/ODELibraries.hs
+++ b/code/drasil-data/Data/Drasil/ExternalLibraries/ODELibraries.hs
@@ -81,7 +81,7 @@ scipyLSodaODE = externalLib [
     odeintFunc [
       functionArg f (map unnamedParam [Array Real, Real]) 
       returnExprList, inlineArg (Array Real), inlineArg (Array Real)] ut,
-  mandatoryStep $ initSolWithVal
+  mandatoryStep initSolWithVal
     ]
 
 scipyLSodaCall :: ODEInfo -> ExternalLibraryCall
@@ -143,7 +143,7 @@ xAxis = quantvar $ implVar "x_numpy" (nounPhrase "Numpy value" "Numpy value")
   (Array Real) (Label "x_axis")
 ut = quantvar $ implVar "ut_scipy" 
   (nounPhrase "Scipy integrated value" "Scipy integrated value") 
-  (numpyArrayT) (Label "u_t")
+  numpyArrayT (Label "u_t")
 transpose = quantvar $ implVar "transpose_numpy" 
   (nounPhrase "Numpy Array Transpose" "Numpy Array Transpose") 
   (Array Real) (Label "u_t.T") -- (ccObjVar ut transpose) does not seem to work. 

--- a/code/drasil-data/Data/Drasil/ExternalLibraries/ODELibraries.hs
+++ b/code/drasil-data/Data/Drasil/ExternalLibraries/ODELibraries.hs
@@ -1,6 +1,6 @@
 module Data.Drasil.ExternalLibraries.ODELibraries (
   scipyODEPckg, scipyODESymbols, osloPckg, osloSymbols, arrayVecDepVar, 
-  apacheODEPckg, apacheODESymbols, odeintPckg, odeintSymbols
+  apacheODEPckg, apacheODESymbols, odeintPckg, odeintSymbols, scipyODELSodaPkg
 ) where
 
 import Language.Drasil
@@ -14,7 +14,7 @@ import Language.Drasil.Code (Lang(..), ExternalLibrary, Step, Argument,
   implementation, constructorInfo, methodInfo, methodInfoNoReturn, 
   appendCurrSol, populateSolList, assignArrayIndex, assignSolFromObj, 
   initSolListFromArray, initSolListWithVal, solveAndPopulateWhile, 
-  returnExprList, fixedReturn,
+  returnExprList, fixedReturn, initSolWithVal,
   ExternalLibraryCall, externalLibCall, choiceStepsFill, choiceStepFill, 
   mandatoryStepFill, mandatoryStepsFill, callStepFill, libCallFill, 
   userDefinedArgFill, basicArgFill, functionArgFill, customObjArgFill, 
@@ -25,7 +25,7 @@ import Language.Drasil.Code (Lang(..), ExternalLibrary, Step, Argument,
   solveAndPopulateWhileFill, returnExprListFill, fixedStatementFill, 
   CodeVarChunk, CodeFuncChunk, quantvar, quantfunc, listToArray, 
   ODEInfo(..), ODEOptions(..), ODEMethod(..), ODELibPckg, mkODELib, 
-  mkODELibNoPath, pubStateVar, privStateVar, field)
+  mkODELibNoPath, pubStateVar, privStateVar, field, initSolWithValFill)
 
 import Control.Lens ((^.), _1, _2, over)
 
@@ -68,8 +68,40 @@ scipyCall info = externalLibCall [
         solveMethodFill = callStepFill $ libCallFill $ map basicArgFill 
           [absTol $ odeOpts info, relTol $ odeOpts info]
 
+-- This package solves a system of ODE using the scipy odeint method.
+-- The odeint method solves the ode using the LSoda solver.
+scipyODELSodaPkg :: ODELibPckg
+scipyODELSodaPkg = mkODELibNoPath "SciPy" "1.4.1" scipyLSodaODE scipyLSodaCall [Python]
+
+scipyLSodaODE :: ExternalLibrary
+scipyLSodaODE = externalLib [
+  mandatoryStep $ callStep $ libFunctionWithResult numpyImport
+    arange [inlineArg Real, inlineArg Real, inlineArg Real] xAxis,
+  mandatoryStep $ callStep $ libFunctionWithResult scipyImport
+    odeintFunc [
+      functionArg f (map unnamedParam [Array Real, Real]) 
+      returnExprList, inlineArg (Array Real), inlineArg (Array Real)] ut,
+  mandatoryStep $ initSolWithVal
+    ]
+
+scipyLSodaCall :: ODEInfo -> ExternalLibraryCall
+scipyLSodaCall info = externalLibCall [
+  mandatoryStepsFill [callStepFill $ libCallFill $ map basicArgFill 
+      [tInit info, tFinal info, stepSize $ odeOpts info]],
+  mandatoryStepFill $ callStepFill $ libCallFill [functionArgFill 
+      (map unnamedParamFill [depVar info, indepVar info]) 
+      (returnExprListFill $ odeSyst info), 
+      basicArgFill (Matrix [[initVal info, initValFstOrd $ odeOpts info]]),
+      basicArgFill (sy xAxis)],
+  mandatoryStepFill $ initSolWithValFill (depVar info) 
+      (idx (sy transpose) (Int 0))
+    ]
+
 scipyImport :: String
 scipyImport = "scipy.integrate"
+
+numpyImport :: String
+numpyImport = "numpy"
 
 atol, rtol, vode :: Argument
 vode = lockedArg (str "vode")
@@ -82,12 +114,15 @@ methodArg = lockedNamedArg mthdArg . str
 setIntegratorMethod :: [Argument] -> Step
 setIntegratorMethod = callStep . libMethod scipyImport r setIntegrator
 
-odeT :: Space
+odeT, numpyArrayT :: Space
 odeT = Actor "ode"
+numpyArrayT = Actor "numpyArray"
 
 scipyODESymbols :: [QuantityDict]
-scipyODESymbols = map qw [mthdArg, atolArg, rtolArg] ++ map qw [r, t, y]
-  ++ map qw [f, odefunc, setIntegrator, setInitVal, successful, integrateStep]
+scipyODESymbols = map qw [mthdArg, atolArg, rtolArg] 
+  ++ map qw [r, t, y, xAxis, ut, transpose]
+  ++ map qw [f, odefunc, setIntegrator, setInitVal, successful, integrateStep,
+  arange, odeintFunc]
 
 mthdArg, atolArg, rtolArg :: NamedArgument
 mthdArg = narg $ implVar "method_scipy" (nounPhrase 
@@ -100,12 +135,22 @@ rtolArg = narg $ implVar "rtol_scipy" (nounPhrase
   "relative tolerance for ODE solution" "relative tolerances for ODE solution") 
   Real (Label "rtol")
 
-r :: CodeVarChunk
+
+r, xAxis, ut, transpose :: CodeVarChunk
 r = quantvar $ implVar "r_scipy" (nounPhrase "ODE object" "ODE objects") 
   odeT (Label "r")
+xAxis = quantvar $ implVar "x_numpy" (nounPhrase "Numpy value" "Numpy value") 
+  (Array Real) (Label "x_axis")
+ut = quantvar $ implVar "ut_scipy" 
+  (nounPhrase "Scipy integrated value" "Scipy integrated value") 
+  (numpyArrayT) (Label "u_t")
+transpose = quantvar $ implVar "transpose_numpy" 
+  (nounPhrase "Numpy Array Transpose" "Numpy Array Transpose") 
+  (Array Real) (Label "u_t.T") -- (ccObjVar ut transpose) does not seem to work. 
+
 
 f, odefunc, setIntegrator, setInitVal, successful, 
-  integrateStep :: CodeFuncChunk
+  integrateStep, arange, odeintFunc :: CodeFuncChunk
 f = quantfunc $ implVar "f_scipy" (nounPhrase "function representing ODE system" 
   "functions representing ODE system") (Array Real) (Label "f")
 odefunc = quantfunc $ implVar "ode_scipy" (nounPhrase 
@@ -126,7 +171,14 @@ integrateStep = quantfunc $ implVar "integrate_scipy" (nounPhrase
   "method that performs one integration step on an ODE"
   "methods that perform one integration step on an ODE") 
   Void (Label "integrate")
-
+arange = quantfunc $ implVar "arrange_numpy" (nounPhrase
+  "method that returns evenly spaced numbers over a specified interval."
+  "method that returns evenly spaced numbers over a specified interval.")
+  (Array Real) (Label "arange")
+odeintFunc = quantfunc $ implVar "odeint_scipy" (nounPhrase
+  "method that solves a system of ODE using lsoda from the FORTRAN library odepack."
+  "method that solves a system of ODE using lsoda from the FORTRAN library odepack.")
+  (Array Real) (Label "odeint")
 
 -- Oslo (C#) --
 

--- a/code/drasil-example/Drasil/NoPCM/Body.hs
+++ b/code/drasil-example/Drasil/NoPCM/Body.hs
@@ -204,7 +204,7 @@ si = SI {
 }
 
 noPCMODEOpts :: ODEOptions
-noPCMODEOpts = odeOptions RK45 (sy absTol) (sy relTol) (sy timeStep)
+noPCMODEOpts = odeOptions RK45 (sy absTol) (sy relTol) (sy timeStep) (dbl 0)
 
 noPCMODEInfo :: ODEInfo
 noPCMODEInfo = odeInfo (quantvar time) (quantvar tempW)


### PR DESCRIPTION
Added a new ODE package for Python called `scipyODELSodaPkg` that calls the [`odeint` ](https://docs.scipy.org/doc/scipy/reference/generated/scipy.integrate.odeint.html) method of Scipy. The [odeint ](https://docs.scipy.org/doc/scipy/reference/generated/scipy.integrate.odeint.html) method solves a system of ODE using the Lsoda solver.

Following is a summary of the changes. 

- ./drasil-data/Data/Drasil/ExternalLibraries/ODELibraries.hs - Contains the definition of the new ODE package.
- ./drasil-code/Language/Drasil/Data/ODEInfo.hs - Modified the `ODEInfo `and `ODEOptions `types, and added a new constructor `initValFstOrd` to hold `y'(0)`.
- . /drasil-code/Language/Drasil/Chunk/CodeDefinition.hs - Updated the `odeDef` function to include `initValFstOrd`.
- ./drasil-code/Language/Drasil/Code/ExternalLibrary.hs - Added a new function `initSolWithVal` that assigns a single value to a CodeChunk. 
- ./drasil-code/Language/Drasil/Code/ExternalLibraryCall.hs - Added the equivalent call for `initSolWithVal`.
- ./drasil-code/Language/Drasil/Code.hs - Import and export `initSolWithVal` and `initSolWithVal`
- ./drasil-example/Drasil/NoPCM/Body.hs - Though not used, assigned a value to `initValFstOrd`. 


