### PR TITLE
Remove drasil-theory from drasil-utils' stack.yaml

### DIFF
--- a/code/drasil-utils/stack.yaml
+++ b/code/drasil-utils/stack.yaml
@@ -32,7 +32,6 @@ resolver:
 packages:
 - .
 - ../drasil-lang
-- ../drasil-theory
 
 # Dependency packages to be pulled from upstream that are not in the resolver.
 # These entries can reference officially published versions as well as


### PR DESCRIPTION
Following suit in 333bbbf02fba4c925a603ca60e2ebfc2e64293c1