### PR TITLE
Remove unneeded import of elem (already in Prelude)

### DIFF
--- a/code/drasil-docLang/Drasil/DocumentLanguage/Definitions.hs
+++ b/code/drasil-docLang/Drasil/DocumentLanguage/Definitions.hs
@@ -5,7 +5,7 @@ module Drasil.DocumentLanguage.Definitions (Field(..), Fields, InclUnits(..),
   instanceModel, tmodel) where
 
 import Data.Map (keys)
-import Data.List (elem, nub)
+import Data.List (nub)
 import Data.Maybe (mapMaybe)
 import Control.Lens ((^.))
 


### PR DESCRIPTION
`elem` has been in Prelude as early as [`base-4.0.0.0`](https://hackage.haskell.org/package/base-4.0.0.0/docs/Prelude.html#v%3Aelem) so it seems that this won't break GHC compatibility with 8.* ([GHC 6.10.1](https://wiki.haskell.org/Base_package) is earliest to ship with `base-4.0.0.0`)