### PR TITLE
Adding manually triggered builds + cancelling previous runs

### DIFF
--- a/.github/workflows/Drasil.yaml
+++ b/.github/workflows/Drasil.yaml
@@ -1,4 +1,4 @@
-on:
+on: 
   push:
     branches-ignore: master
   pull_request:

--- a/.github/workflows/Drasil.yaml
+++ b/.github/workflows/Drasil.yaml
@@ -1,4 +1,4 @@
-on: 
+on:
   push:
     branches-ignore: master
   pull_request:

--- a/.github/workflows/Drasil.yaml
+++ b/.github/workflows/Drasil.yaml
@@ -1,4 +1,6 @@
-on: 
+on:
+  push:
+    branches-ignore: master
   pull_request:
     branches: master
   workflow_dispatch:
@@ -10,6 +12,10 @@ defaults:
 jobs:
   build:
     name: "Build"
+    if: |
+      github.event_name == 'pull_request'
+      || github.event_name == 'workflow_dispatch'
+      || (github.event_name == 'push' && contains(github.event.head_commit.message, '[workflow-trigger]'))
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/Drasil.yaml
+++ b/.github/workflows/Drasil.yaml
@@ -16,6 +16,11 @@ jobs:
       || github.event_name == 'workflow_dispatch'
       || (github.event_name == 'push' && contains(github.event.head_commit.message, '[workflow-trigger]'))
     runs-on: ubuntu-latest
+    steps:
+      - name: Cancel Previous Runs
+        uses: styfle/cancel-workflow-action@0.9.0
+        with:
+          access_token: ${{ github.token }}
   build:
     needs: auto-cancel
     name: "Build"

--- a/.github/workflows/Drasil.yaml
+++ b/.github/workflows/Drasil.yaml
@@ -10,12 +10,15 @@ defaults:
     shell: bash
     working-directory: code
 jobs:
-  build:
-    name: "Build"
+  auto-cancel:
     if: |
       github.event_name == 'pull_request'
       || github.event_name == 'workflow_dispatch'
       || (github.event_name == 'push' && contains(github.event.head_commit.message, '[workflow-trigger]'))
+    runs-on: ubuntu-latest
+  build:
+    needs: auto-cancel
+    name: "Build"
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
Closes #2366 

+ Adds a button in the "Actions" menu for manually running workflows.
+ When `[workflow-trigger]` is in a pushed commit message, the build workflow will run on it.
+ Cancels workflows that are running on the same branch with a different SHA.

When commits don't have the trigger text, they will still be considered to have passed checks. We can probably figure out a way to make this look like it's failed instead. Do you have any preference for this @JacquesCarette ?