### PR TITLE
redundant import: fst, snd

### DIFF
--- a/code/drasil-printers/Language/Drasil/Printing/Import.hs
+++ b/code/drasil-printers/Language/Drasil/Printing/Import.hs
@@ -18,7 +18,6 @@ import Control.Lens ((^.))
 import Data.Bifunctor (bimap, second)
 import Data.List (intersperse, partition)
 import Data.Maybe (fromMaybe)
-import Data.Tuple (fst, snd)
 import Numeric (floatToDigits)
 
 -- | Render a Space


### PR DESCRIPTION
As early as [base 4.6.0.0](https://hackage.haskell.org/package/base-4.6.0.0/docs/Prelude.html#v:fst) (GHC 7.6.1) contained `fst` and `snd`, so we can remove the import causing the warning without worrying about causing compatibility issues for GHC 8.*.