### PR TITLE
Adding velocity and acceleration derivations in pendulum

### DIFF
--- a/code/drasil-data/Data/Drasil/Quantities/Physics.hs
+++ b/code/drasil-data/Data/Drasil/Quantities/Physics.hs
@@ -9,7 +9,7 @@ import qualified Data.Drasil.Concepts.Physics as CP (acceleration, angAccel,
   kEnergy, linAccel, linDisp, linVelo, momentOfInertia, position, potEnergy,
   pressure, restitutionCoef, scalarAccel, scalarPos, speed, time, torque,
   velocity, weight, xAccel, xConstAccel, xDist, xPos, xVel, yAccel, yConstAccel,
-  yDist,  yPos, yVel, momentum, moment, fOfGravity, positionVec, tension, angFreq, period, frequency)
+  yDist, yPos, yVel, momentum, moment, fOfGravity, positionVec, tension, angFreq, period, frequency)
 
 import Data.Drasil.SI_Units (joule, metre, newton, pascal, radian, second, hertz)
 import Data.Drasil.Units.Physics (accelU, angAccelU, angVelU, gravConstU, 

--- a/code/drasil-example/Drasil/DblPendulum/DataDefs.hs
+++ b/code/drasil-example/Drasil/DblPendulum/DataDefs.hs
@@ -42,7 +42,7 @@ positionIYQD :: QDefinition
 positionIYQD = mkQuantDef QP.iyPos positionIYEqn
 
 positionIYEqn :: Expr
-positionIYEqn = sy lenRod * cos (sy initialPendAngle)
+positionIYEqn = negate (sy lenRod * cos (sy initialPendAngle))
 
 figReff :: Sentence
 figReff = ch QP.iyPos `sIs` S "shown in" +:+. makeRef2S figMotion

--- a/code/drasil-example/Drasil/DblPendulum/GenDefs.hs
+++ b/code/drasil-example/Drasil/DblPendulum/GenDefs.hs
@@ -9,7 +9,7 @@ import Utils.Drasil
 
 -- import Data.Drasil.Concepts.Documentation (coordinate, symbol_)
 import Data.Drasil.Concepts.Math (xComp, yComp, equation)
-import Data.Drasil.Quantities.Physics(ixPos, iyPos, velocity, angularVelocity, xVel, yVel,
+import Data.Drasil.Quantities.Physics(xPos, yPos, velocity, angularVelocity, xVel, yVel,
     angularAccel, xAccel, yAccel, acceleration, force, tension, gravitationalAccel,
     angularFrequency, torque, momentOfInertia, angularDisplacement, time,
     momentOfInertia, period, frequency, position)
@@ -57,7 +57,7 @@ velocityIDerivEqn1,velocityIXDerivEqn2,velocityIXDerivEqn3,velocityIXDerivEqn4 :
 velocityIDerivSent1 = S "At a given point in time" `sC` phrase velocity +:+ S "may be defined as"
 velocityIDerivEqn1 = sy velocity $= deriv (sy position) time
 velocityIXDerivSent2 = S "We also know the horizontal" +:+ phrase position
-velocityIXDerivEqn2 = sy ixPos $= sy lenRod * sin (sy pendDisplacementAngle) --FIXME xPos
+velocityIXDerivEqn2 = sy xPos $= sy lenRod * sin (sy pendDisplacementAngle) --FIXME xPos
 velocityIXDerivSent3 = S "Applying this,"
 velocityIXDerivEqn3 = sy xVel $= deriv (sy lenRod * sin (sy pendDisplacementAngle)) time
 velocityIXDerivSent4 = E (sy lenRod) `sIs` S "constant with respect to time, so"
@@ -91,7 +91,7 @@ velocityIYDerivSent2,velocityIYDerivSent3,velocityIYDerivSent4,velocityIYDerivSe
 velocityIYDerivEqn2,velocityIYDerivEqn3,velocityIYDerivEqn4 :: Expr
 
 velocityIYDerivSent2 = S "We also know the vertical" +:+ phrase position
-velocityIYDerivEqn2 = sy iyPos $= negate (sy lenRod * cos (sy pendDisplacementAngle)) --FIXME yPos
+velocityIYDerivEqn2 = sy yPos $= negate (sy lenRod * cos (sy pendDisplacementAngle)) --FIXME yPos
 velocityIYDerivSent3 = S "Applying this again,"
 velocityIYDerivEqn3 = sy yVel $= negate (deriv (sy lenRod * cos (sy pendDisplacementAngle)) time)
 velocityIYDerivSent4 = E (sy lenRod) `sIs` S "constant with respect to time, so"

--- a/code/drasil-example/Drasil/DblPendulum/GenDefs.hs
+++ b/code/drasil-example/Drasil/DblPendulum/GenDefs.hs
@@ -62,7 +62,7 @@ velocityIXDerivSent3 = S "Applying this,"
 velocityIXDerivEqn3 = sy xVel $= deriv (sy lenRod * sin (sy pendDisplacementAngle)) time
 velocityIXDerivSent4 = E (sy lenRod) `sIs` S "constant with respect to time, so"
 velocityIXDerivEqn4 = sy xVel $= sy lenRod * deriv (sin (sy pendDisplacementAngle)) time
-velocityIXDerivSent5 = S "Therefore,"
+velocityIXDerivSent5 = S "Therefore, using the chain rule,"
 
 ---------------------
 velocityIYGD :: GenDefn
@@ -74,7 +74,7 @@ velocityIYRC = makeRC "velocityIYRC" (nounPhraseSent $ foldlSent_
             [ phrase yComp `sOf` phrase velocity `the_ofThe` phrase pendulum]) EmptyS velocityIYRel
  
 velocityIYRel :: Relation             
-velocityIYRel = sy yVel $= negate (sy angularVelocity * sy lenRod * sin (sy pendDisplacementAngle))
+velocityIYRel = sy yVel $= sy angularVelocity * sy lenRod * sin (sy pendDisplacementAngle)
 
 velocityIYDeriv :: Derivation
 velocityIYDeriv = mkDerivName (phrase yComp +:+ phrase velocity) (weave [velocityIYDerivSents, map E velocityIYDerivEqns])
@@ -91,12 +91,12 @@ velocityIYDerivSent2,velocityIYDerivSent3,velocityIYDerivSent4,velocityIYDerivSe
 velocityIYDerivEqn2,velocityIYDerivEqn3,velocityIYDerivEqn4 :: Expr
 
 velocityIYDerivSent2 = S "We also know the vertical" +:+ phrase position
-velocityIYDerivEqn2 = sy iyPos $= sy lenRod * cos (sy pendDisplacementAngle) --FIXME yPos
+velocityIYDerivEqn2 = sy iyPos $= negate (sy lenRod * cos (sy pendDisplacementAngle)) --FIXME yPos
 velocityIYDerivSent3 = S "Applying this again,"
-velocityIYDerivEqn3 = sy yVel $= deriv (sy lenRod * cos (sy pendDisplacementAngle)) time
+velocityIYDerivEqn3 = sy yVel $= negate (deriv (sy lenRod * cos (sy pendDisplacementAngle)) time)
 velocityIYDerivSent4 = E (sy lenRod) `sIs` S "constant with respect to time, so"
-velocityIYDerivEqn4 = sy yVel $= sy lenRod * deriv (cos (sy pendDisplacementAngle)) time
-velocityIYDerivSent5 = S "Therefore,"
+velocityIYDerivEqn4 = sy yVel $= negate (sy lenRod * deriv (cos (sy pendDisplacementAngle)) time)
+velocityIYDerivSent5 = S "Therefore, using the chain rule,"
 
 -----------------------
 accelerationIXGD :: GenDefn
@@ -108,11 +108,33 @@ accelerationIXRC = makeRC "accelerationIXRC" (nounPhraseSent $ foldlSent_
             [ phrase xComp `sOf` phrase acceleration `the_ofThe` phrase pendulum]) EmptyS accelerationIXRel
  
 accelerationIXRel :: Relation             
-accelerationIXRel = sy xAccel $= negate (sy angularVelocity * sy lenRod * sin (sy pendDisplacementAngle))
+accelerationIXRel = sy xAccel $= negate (square (sy angularVelocity) * sy lenRod * sin (sy pendDisplacementAngle))
                     + sy angularAccel * sy lenRod * cos (sy pendDisplacementAngle)
 
 accelerationIXDeriv :: Derivation
-accelerationIXDeriv = mkDerivName (phrase xComp +:+ phrase acceleration) [ E accelerationIXRel]
+accelerationIXDeriv = mkDerivName (phrase xComp +:+ phrase acceleration) (weave [accelerationIXDerivSents, map E accelerationIXDerivEqns])
+
+accelerationIXDerivSents :: [Sentence]
+accelerationIXDerivSents = [accelerationIDerivSent1, accelerationIXDerivSent2, accelerationIXDerivSent3,
+    accelerationIXDerivSent4, accelerationIXDerivSent5]
+
+accelerationIXDerivEqns :: [Expr]
+accelerationIXDerivEqns = [accelerationIDerivEqn1, accelerationIXDerivEqn2, accelerationIXDerivEqn3, accelerationIXDerivEqn4, accelerationIXRel]
+
+accelerationIDerivSent1, accelerationIXDerivSent2, accelerationIXDerivSent3,
+     accelerationIXDerivSent4, accelerationIXDerivSent5 :: Sentence
+accelerationIDerivEqn1, accelerationIXDerivEqn2, accelerationIXDerivEqn3, accelerationIXDerivEqn4 :: Expr
+
+accelerationIDerivSent1 = S "Our" +:+ phrase acceleration +: S "is"
+accelerationIDerivEqn1 = sy acceleration $= deriv (sy velocity) time 
+accelerationIXDerivSent2 = S "Earlier" `sC` S "we found the horizontal" +:+ phrase velocity +:+ S "to be"
+accelerationIXDerivEqn2 = velocityIXRel
+accelerationIXDerivSent3 = S "Applying this to our equation for" +:+ phrase acceleration
+accelerationIXDerivEqn3 = sy xAccel $= deriv (sy angularVelocity * sy lenRod * cos (sy pendDisplacementAngle)) time
+accelerationIXDerivSent4 = S "By the product and chain rules, we find"
+accelerationIXDerivEqn4 = sy xAccel $= (deriv (sy angularVelocity) time) * sy lenRod * cos (sy pendDisplacementAngle)
+                        + negate (sy angularVelocity * sy lenRod * sin (sy pendDisplacementAngle) * deriv (sy pendDisplacementAngle) time)
+accelerationIXDerivSent5 = S "Simplifying,"
 
 -----------------------
 accelerationIYGD :: GenDefn
@@ -124,11 +146,31 @@ accelerationIYRC = makeRC "accelerationIYRC" (nounPhraseSent $ foldlSent_
             [ phrase yComp `sOf` phrase acceleration `the_ofThe` phrase pendulum]) EmptyS accelerationIYRel
  
 accelerationIYRel :: Relation             
-accelerationIYRel = sy yAccel $= (sy angularVelocity * sy lenRod * cos (sy pendDisplacementAngle))
+accelerationIYRel = sy yAccel $= (square (sy angularVelocity) * sy lenRod * cos (sy pendDisplacementAngle))
                     + sy angularAccel * sy lenRod * sin (sy pendDisplacementAngle)
 
 accelerationIYDeriv :: Derivation
-accelerationIYDeriv = mkDerivName (phrase yComp +:+ phrase acceleration) [ E accelerationIYRel]
+accelerationIYDeriv = mkDerivName (phrase yComp +:+ phrase acceleration) (weave [accelerationIYDerivSents, map E accelerationIYDerivEqns])
+
+accelerationIYDerivSents :: [Sentence]
+accelerationIYDerivSents = [accelerationIDerivSent1, accelerationIYDerivSent2, accelerationIYDerivSent3,
+    accelerationIYDerivSent4, accelerationIYDerivSent5]
+
+accelerationIYDerivEqns :: [Expr]
+accelerationIYDerivEqns = [accelerationIDerivEqn1, accelerationIYDerivEqn2, accelerationIYDerivEqn3, accelerationIYDerivEqn4, accelerationIYRel]
+
+accelerationIYDerivSent2, accelerationIYDerivSent3, accelerationIYDerivSent4, 
+    accelerationIYDerivSent5 :: Sentence
+accelerationIYDerivEqn2, accelerationIYDerivEqn3, accelerationIYDerivEqn4 :: Expr
+
+accelerationIYDerivSent2 = S "Earlier" `sC` S "we found the vertical" +:+ phrase velocity +:+ S "to be"
+accelerationIYDerivEqn2 = velocityIYRel
+accelerationIYDerivSent3 = S "Applying this to our equation for" +:+ phrase acceleration
+accelerationIYDerivEqn3 = sy yAccel $= deriv (sy angularVelocity * sy lenRod * sin (sy pendDisplacementAngle)) time
+accelerationIYDerivSent4 = S "By the product and chain rules, we find"
+accelerationIYDerivEqn4 = sy yAccel $= (deriv (sy angularVelocity) time) * sy lenRod * sin (sy pendDisplacementAngle)
+                        + sy angularVelocity * sy lenRod * cos (sy pendDisplacementAngle) * deriv (sy pendDisplacementAngle) time
+accelerationIYDerivSent5 = S "Simplifying,"
 
 -------------------------------------Horizontal force acting on the pendulum 
 hForceOnPendulumGD :: GenDefn

--- a/code/drasil-example/Drasil/DblPendulum/GenDefs.hs
+++ b/code/drasil-example/Drasil/DblPendulum/GenDefs.hs
@@ -54,31 +54,15 @@ velocityIXDerivEqns = [velocityIDerivEqn1,velocityIXDerivEqn2,velocityIXDerivEqn
 velocityIDerivSent1,velocityIXDerivSent2,velocityIXDerivSent3,velocityIXDerivSent4,velocityIXDerivSent5 :: Sentence
 velocityIDerivEqn1,velocityIXDerivEqn2,velocityIXDerivEqn3,velocityIXDerivEqn4 :: Expr
 
-{-velocityIDerivSent1 = S "Using the formula for arc length" `sC` (phrase position `the_ofThe` phrase pendulum) +: S "may be defined as"
-velocityIDerivEqn1 = sy position $= sy pendDisplacementAngle * sy lenRod
-velocityIDerivSent2 = S "Then" `sC` S "the" +:+ phrase velocity `ofThe` phrase pendulum +:+ S "at a given time will be"
-velocityIDerivEqn2 = sy velocity $= deriv (sy position) time 
-velocityIDerivSent3 = S "Applying this, we find"
-velocityIDerivEqn3 = sy velocity $= deriv (sy pendDisplacementAngle * sy lenRod) time
-velocityIDerivSent4 = E (sy lenRod) `sIs` S "constant with respect to time, so"
-velocityIDerivEqn4 = sy velocity $= sy lenRod * deriv (sy pendDisplacementAngle) time
-velocityIDerivSent5 = S "We also know that"
-velocityIDerivEqn5 = sy angularVelocity $= deriv (sy pendDisplacementAngle) time
-velocityIDerivSent6 = S "So,"
-velocityIDerivEqn6 = sy velocity $= sy angularVelocity * sy lenRod
-velocityIXDerivSent7 = S "For the x-component of" +: phrase velocity 
-velocityIYDerivSent7 = S "For the y-component of" +: phrase velocity-}
-
-velocityIDerivSent1 = S "At a given point in time, velocity may be defined as"
+velocityIDerivSent1 = S "At a given point in time" `sC` phrase velocity +:+ S "may be defined as"
 velocityIDerivEqn1 = sy velocity $= deriv (sy position) time
-velocityIXDerivSent2 = S "We also know that at a given horizontal position,"
-velocityIXDerivEqn2 = sy ixPos $= sy lenRod * sin (sy pendDisplacementAngle)
+velocityIXDerivSent2 = S "We also know the horizontal" +:+ phrase position
+velocityIXDerivEqn2 = sy ixPos $= sy lenRod * sin (sy pendDisplacementAngle) --FIXME xPos
 velocityIXDerivSent3 = S "Applying this,"
 velocityIXDerivEqn3 = sy xVel $= deriv (sy lenRod * sin (sy pendDisplacementAngle)) time
 velocityIXDerivSent4 = E (sy lenRod) `sIs` S "constant with respect to time, so"
 velocityIXDerivEqn4 = sy xVel $= sy lenRod * deriv (sin (sy pendDisplacementAngle)) time
 velocityIXDerivSent5 = S "Therefore,"
---velocityIXDerivEqn5 = sy xVel $= sy lenRod * cos (sy pendDisplacementAngle)
 
 ---------------------
 velocityIYGD :: GenDefn
@@ -106,14 +90,13 @@ velocityIYDerivEqns = [velocityIDerivEqn1,velocityIYDerivEqn2,velocityIYDerivEqn
 velocityIYDerivSent2,velocityIYDerivSent3,velocityIYDerivSent4,velocityIYDerivSent5 :: Sentence
 velocityIYDerivEqn2,velocityIYDerivEqn3,velocityIYDerivEqn4 :: Expr
 
-velocityIYDerivSent2 = S "We also know that at a given horizontal position,"
-velocityIYDerivEqn2 = sy iyPos $= sy lenRod * cos (sy pendDisplacementAngle)
+velocityIYDerivSent2 = S "We also know the vertical" +:+ phrase position
+velocityIYDerivEqn2 = sy iyPos $= sy lenRod * cos (sy pendDisplacementAngle) --FIXME yPos
 velocityIYDerivSent3 = S "Applying this again,"
 velocityIYDerivEqn3 = sy yVel $= deriv (sy lenRod * cos (sy pendDisplacementAngle)) time
 velocityIYDerivSent4 = E (sy lenRod) `sIs` S "constant with respect to time, so"
 velocityIYDerivEqn4 = sy yVel $= sy lenRod * deriv (cos (sy pendDisplacementAngle)) time
 velocityIYDerivSent5 = S "Therefore,"
---velocityIYDerivEqn5 = sy yVel $= sy angularVelocity * sy lenRod * sin (sy pendDisplacementAngle)
 
 -----------------------
 accelerationIXGD :: GenDefn

--- a/code/drasil-example/Drasil/DblPendulum/GenDefs.hs
+++ b/code/drasil-example/Drasil/DblPendulum/GenDefs.hs
@@ -132,7 +132,7 @@ accelerationIXDerivEqn2 = velocityIXRel
 accelerationIXDerivSent3 = S "Applying this to our equation for" +:+ phrase acceleration
 accelerationIXDerivEqn3 = sy xAccel $= deriv (sy angularVelocity * sy lenRod * cos (sy pendDisplacementAngle)) time
 accelerationIXDerivSent4 = S "By the product and chain rules, we find"
-accelerationIXDerivEqn4 = sy xAccel $= (deriv (sy angularVelocity) time) * sy lenRod * cos (sy pendDisplacementAngle)
+accelerationIXDerivEqn4 = sy xAccel $= deriv (sy angularVelocity) time * sy lenRod * cos (sy pendDisplacementAngle)
                         - (sy angularVelocity * sy lenRod * sin (sy pendDisplacementAngle) * deriv (sy pendDisplacementAngle) time)
 accelerationIXDerivSent5 = S "Simplifying,"
 
@@ -168,7 +168,7 @@ accelerationIYDerivEqn2 = velocityIYRel
 accelerationIYDerivSent3 = S "Applying this to our equation for" +:+ phrase acceleration
 accelerationIYDerivEqn3 = sy yAccel $= deriv (sy angularVelocity * sy lenRod * sin (sy pendDisplacementAngle)) time
 accelerationIYDerivSent4 = S "By the product and chain rules, we find"
-accelerationIYDerivEqn4 = sy yAccel $= (deriv (sy angularVelocity) time) * sy lenRod * sin (sy pendDisplacementAngle)
+accelerationIYDerivEqn4 = sy yAccel $= deriv (sy angularVelocity) time * sy lenRod * sin (sy pendDisplacementAngle)
                         + sy angularVelocity * sy lenRod * cos (sy pendDisplacementAngle) * deriv (sy pendDisplacementAngle) time
 accelerationIYDerivSent5 = S "Simplifying,"
 

--- a/code/drasil-example/Drasil/DblPendulum/GenDefs.hs
+++ b/code/drasil-example/Drasil/DblPendulum/GenDefs.hs
@@ -9,7 +9,7 @@ import Utils.Drasil
 
 -- import Data.Drasil.Concepts.Documentation (coordinate, symbol_)
 import Data.Drasil.Concepts.Math (xComp, yComp, equation)
-import Data.Drasil.Quantities.Physics(velocity, angularVelocity, xVel, yVel,
+import Data.Drasil.Quantities.Physics(ixPos, iyPos, velocity, angularVelocity, xVel, yVel,
     angularAccel, xAccel, yAccel, acceleration, force, tension, gravitationalAccel,
     angularFrequency, torque, momentOfInertia, angularDisplacement, time,
     momentOfInertia, period, frequency, position)
@@ -44,18 +44,17 @@ velocityIXDeriv :: Derivation
 velocityIXDeriv = mkDerivName (phrase xComp +:+ phrase velocity) (weave [velocityIXDerivSents, map E velocityIXDerivEqns])
 
 velocityIXDerivSents :: [Sentence]
-velocityIXDerivSents = [velocityIDerivSent1,velocityIDerivSent2,velocityIDerivSent3,velocityIDerivSent4,
-                            velocityIDerivSent5,velocityIDerivSent6,velocityIXDerivSent7]
+velocityIXDerivSents = [velocityIDerivSent1,velocityIXDerivSent2,velocityIXDerivSent3,velocityIXDerivSent4,
+                            velocityIXDerivSent5]
 
 velocityIXDerivEqns :: [Expr]
-velocityIXDerivEqns = [velocityIDerivEqn1,velocityIDerivEqn2,velocityIDerivEqn3,
-                            velocityIDerivEqn4,velocityIDerivEqn5,velocityIDerivEqn6,velocityIXRel]
+velocityIXDerivEqns = [velocityIDerivEqn1,velocityIXDerivEqn2,velocityIXDerivEqn3,
+                            velocityIXDerivEqn4,velocityIXRel]
 
-velocityIDerivSent1,velocityIDerivSent2,velocityIDerivSent3,velocityIDerivSent4,
-            velocityIDerivSent5,velocityIDerivSent6,velocityIXDerivSent7,velocityIYDerivSent7 :: Sentence
-velocityIDerivEqn1,velocityIDerivEqn2,velocityIDerivEqn3,velocityIDerivEqn4,velocityIDerivEqn5,velocityIDerivEqn6 :: Expr
+velocityIDerivSent1,velocityIXDerivSent2,velocityIXDerivSent3,velocityIXDerivSent4,velocityIXDerivSent5 :: Sentence
+velocityIDerivEqn1,velocityIXDerivEqn2,velocityIXDerivEqn3,velocityIXDerivEqn4 :: Expr
 
-velocityIDerivSent1 = S "Using the formula for arc length" `sC` (phrase position `the_ofThe` phrase pendulum) +: S "may be defined as"
+{-velocityIDerivSent1 = S "Using the formula for arc length" `sC` (phrase position `the_ofThe` phrase pendulum) +: S "may be defined as"
 velocityIDerivEqn1 = sy position $= sy pendDisplacementAngle * sy lenRod
 velocityIDerivSent2 = S "Then" `sC` S "the" +:+ phrase velocity `ofThe` phrase pendulum +:+ S "at a given time will be"
 velocityIDerivEqn2 = sy velocity $= deriv (sy position) time 
@@ -68,8 +67,18 @@ velocityIDerivEqn5 = sy angularVelocity $= deriv (sy pendDisplacementAngle) time
 velocityIDerivSent6 = S "So,"
 velocityIDerivEqn6 = sy velocity $= sy angularVelocity * sy lenRod
 velocityIXDerivSent7 = S "For the x-component of" +: phrase velocity 
-velocityIYDerivSent7 = S "For the y-componet of" +: phrase velocity
+velocityIYDerivSent7 = S "For the y-component of" +: phrase velocity-}
 
+velocityIDerivSent1 = S "At a given point in time, velocity may be defined as"
+velocityIDerivEqn1 = sy velocity $= deriv (sy position) time
+velocityIXDerivSent2 = S "We also know that at a given horizontal position,"
+velocityIXDerivEqn2 = sy ixPos $= sy lenRod * sin (sy pendDisplacementAngle)
+velocityIXDerivSent3 = S "Applying this,"
+velocityIXDerivEqn3 = sy xVel $= deriv (sy lenRod * sin (sy pendDisplacementAngle)) time
+velocityIXDerivSent4 = E (sy lenRod) `sIs` S "constant with respect to time, so"
+velocityIXDerivEqn4 = sy xVel $= sy lenRod * deriv (sin (sy pendDisplacementAngle)) time
+velocityIXDerivSent5 = S "Therefore,"
+--velocityIXDerivEqn5 = sy xVel $= sy lenRod * cos (sy pendDisplacementAngle)
 
 ---------------------
 velocityIYGD :: GenDefn
@@ -81,18 +90,30 @@ velocityIYRC = makeRC "velocityIYRC" (nounPhraseSent $ foldlSent_
             [ phrase yComp `sOf` phrase velocity `the_ofThe` phrase pendulum]) EmptyS velocityIYRel
  
 velocityIYRel :: Relation             
-velocityIYRel = sy yVel $= sy angularVelocity * sy lenRod * sin (sy pendDisplacementAngle)
+velocityIYRel = sy yVel $= negate (sy angularVelocity * sy lenRod * sin (sy pendDisplacementAngle))
 
 velocityIYDeriv :: Derivation
 velocityIYDeriv = mkDerivName (phrase yComp +:+ phrase velocity) (weave [velocityIYDerivSents, map E velocityIYDerivEqns])
 
 velocityIYDerivSents :: [Sentence]
-velocityIYDerivSents = [velocityIDerivSent1,velocityIDerivSent2,velocityIDerivSent3,velocityIDerivSent4,
-                            velocityIDerivSent5,velocityIDerivSent5,velocityIYDerivSent7]
+velocityIYDerivSents = [velocityIDerivSent1,velocityIYDerivSent2,velocityIYDerivSent3,velocityIYDerivSent4,
+                            velocityIYDerivSent5,velocityIYDerivSent5]
 
 velocityIYDerivEqns :: [Expr]
-velocityIYDerivEqns = [velocityIDerivEqn1,velocityIDerivEqn2,velocityIDerivEqn3,
-                            velocityIDerivEqn4,velocityIDerivEqn5,velocityIDerivEqn6,velocityIYRel]
+velocityIYDerivEqns = [velocityIDerivEqn1,velocityIYDerivEqn2,velocityIYDerivEqn3,
+                            velocityIYDerivEqn4,velocityIYRel]
+
+velocityIYDerivSent2,velocityIYDerivSent3,velocityIYDerivSent4,velocityIYDerivSent5 :: Sentence
+velocityIYDerivEqn2,velocityIYDerivEqn3,velocityIYDerivEqn4 :: Expr
+
+velocityIYDerivSent2 = S "We also know that at a given horizontal position,"
+velocityIYDerivEqn2 = sy iyPos $= sy lenRod * cos (sy pendDisplacementAngle)
+velocityIYDerivSent3 = S "Applying this again,"
+velocityIYDerivEqn3 = sy yVel $= deriv (sy lenRod * cos (sy pendDisplacementAngle)) time
+velocityIYDerivSent4 = E (sy lenRod) `sIs` S "constant with respect to time, so"
+velocityIYDerivEqn4 = sy yVel $= sy lenRod * deriv (cos (sy pendDisplacementAngle)) time
+velocityIYDerivSent5 = S "Therefore,"
+--velocityIYDerivEqn5 = sy yVel $= sy angularVelocity * sy lenRod * sin (sy pendDisplacementAngle)
 
 -----------------------
 accelerationIXGD :: GenDefn

--- a/code/drasil-example/Drasil/DblPendulum/GenDefs.hs
+++ b/code/drasil-example/Drasil/DblPendulum/GenDefs.hs
@@ -133,7 +133,7 @@ accelerationIXDerivSent3 = S "Applying this to our equation for" +:+ phrase acce
 accelerationIXDerivEqn3 = sy xAccel $= deriv (sy angularVelocity * sy lenRod * cos (sy pendDisplacementAngle)) time
 accelerationIXDerivSent4 = S "By the product and chain rules, we find"
 accelerationIXDerivEqn4 = sy xAccel $= (deriv (sy angularVelocity) time) * sy lenRod * cos (sy pendDisplacementAngle)
-                        + negate (sy angularVelocity * sy lenRod * sin (sy pendDisplacementAngle) * deriv (sy pendDisplacementAngle) time)
+                        - (sy angularVelocity * sy lenRod * sin (sy pendDisplacementAngle) * deriv (sy pendDisplacementAngle) time)
 accelerationIXDerivSent5 = S "Simplifying,"
 
 -----------------------

--- a/code/drasil-example/Drasil/DblPendulum/GenDefs.hs
+++ b/code/drasil-example/Drasil/DblPendulum/GenDefs.hs
@@ -45,28 +45,30 @@ velocityIXDeriv = mkDerivName (phrase xComp +:+ phrase velocity) (weave [velocit
 
 velocityIXDerivSents :: [Sentence]
 velocityIXDerivSents = [velocityIDerivSent1,velocityIDerivSent2,velocityIDerivSent3,velocityIDerivSent4,
-                            velocityIDerivSent5,velocityIXDerivSent6]
+                            velocityIDerivSent5,velocityIDerivSent6,velocityIXDerivSent7]
 
 velocityIXDerivEqns :: [Expr]
 velocityIXDerivEqns = [velocityIDerivEqn1,velocityIDerivEqn2,velocityIDerivEqn3,
-                            velocityIDerivEqn4,velocityIDerivEqn5,velocityIXRel]
+                            velocityIDerivEqn4,velocityIDerivEqn5,velocityIDerivEqn6,velocityIXRel]
 
 velocityIDerivSent1,velocityIDerivSent2,velocityIDerivSent3,velocityIDerivSent4,
-            velocityIDerivSent5,velocityIXDerivSent6,velocityIYDerivSent6 :: Sentence
-velocityIDerivEqn1,velocityIDerivEqn2,velocityIDerivEqn3,velocityIDerivEqn4,velocityIDerivEqn5 :: Expr
+            velocityIDerivSent5,velocityIDerivSent6,velocityIXDerivSent7,velocityIYDerivSent7 :: Sentence
+velocityIDerivEqn1,velocityIDerivEqn2,velocityIDerivEqn3,velocityIDerivEqn4,velocityIDerivEqn5,velocityIDerivEqn6 :: Expr
 
-velocityIDerivSent1 = foldlSentCol [S "Using the formula for arc length" `sC` S "the", phrase position `ofThe` phrase pendulum +: S "may be defined as"]
+velocityIDerivSent1 = S "Using the formula for arc length" `sC` (phrase position `the_ofThe` phrase pendulum) +: S "may be defined as"
 velocityIDerivEqn1 = sy position $= sy pendDisplacementAngle * sy lenRod
 velocityIDerivSent2 = S "Then" `sC` S "the" +:+ phrase velocity `ofThe` phrase pendulum +:+ S "at a given time will be"
-velocityIDerivEqn2 = sy velocity $= deriv (sy position) time $= deriv (sy pendDisplacementAngle * sy lenRod) time
-velocityIDerivSent3 = E (sy lenRod) `sIs` S "constant with respect to time, so"
-velocityIDerivEqn3 = sy velocity $= sy lenRod * deriv (sy pendDisplacementAngle) time
-velocityIDerivSent4 = S "We also know that"
-velocityIDerivEqn4 = sy angularVelocity $= deriv (sy pendDisplacementAngle) time
-velocityIDerivSent5 = S "So,"
-velocityIDerivEqn5 = sy velocity $= sy angularVelocity * sy lenRod
-velocityIXDerivSent6 = S "For the x-component of" +: phrase velocity 
-velocityIYDerivSent6 = S "For the y-componenet of" +: phrase velocity
+velocityIDerivEqn2 = sy velocity $= deriv (sy position) time 
+velocityIDerivSent3 = S "Applying this, we find"
+velocityIDerivEqn3 = sy velocity $= deriv (sy pendDisplacementAngle * sy lenRod) time
+velocityIDerivSent4 = E (sy lenRod) `sIs` S "constant with respect to time, so"
+velocityIDerivEqn4 = sy velocity $= sy lenRod * deriv (sy pendDisplacementAngle) time
+velocityIDerivSent5 = S "We also know that"
+velocityIDerivEqn5 = sy angularVelocity $= deriv (sy pendDisplacementAngle) time
+velocityIDerivSent6 = S "So,"
+velocityIDerivEqn6 = sy velocity $= sy angularVelocity * sy lenRod
+velocityIXDerivSent7 = S "For the x-component of" +: phrase velocity 
+velocityIYDerivSent7 = S "For the y-componet of" +: phrase velocity
 
 
 ---------------------
@@ -79,18 +81,18 @@ velocityIYRC = makeRC "velocityIYRC" (nounPhraseSent $ foldlSent_
             [ phrase yComp `sOf` phrase velocity `the_ofThe` phrase pendulum]) EmptyS velocityIYRel
  
 velocityIYRel :: Relation             
-velocityIYRel = sy yVel $= sy angularVelocity * sy lenRod * cos (sy pendDisplacementAngle)
+velocityIYRel = sy yVel $= sy angularVelocity * sy lenRod * sin (sy pendDisplacementAngle)
 
 velocityIYDeriv :: Derivation
 velocityIYDeriv = mkDerivName (phrase yComp +:+ phrase velocity) (weave [velocityIYDerivSents, map E velocityIYDerivEqns])
 
 velocityIYDerivSents :: [Sentence]
 velocityIYDerivSents = [velocityIDerivSent1,velocityIDerivSent2,velocityIDerivSent3,velocityIDerivSent4,
-                            velocityIDerivSent5,velocityIYDerivSent6]
+                            velocityIDerivSent5,velocityIDerivSent5,velocityIYDerivSent7]
 
 velocityIYDerivEqns :: [Expr]
 velocityIYDerivEqns = [velocityIDerivEqn1,velocityIDerivEqn2,velocityIDerivEqn3,
-                            velocityIDerivEqn4,velocityIDerivEqn5,velocityIYRel]
+                            velocityIDerivEqn4,velocityIDerivEqn5,velocityIDerivEqn6,velocityIYRel]
 
 -----------------------
 accelerationIXGD :: GenDefn

--- a/code/drasil-example/Drasil/DblPendulum/GenDefs.hs
+++ b/code/drasil-example/Drasil/DblPendulum/GenDefs.hs
@@ -57,7 +57,7 @@ velocityIDerivEqn1,velocityIXDerivEqn2,velocityIXDerivEqn3,velocityIXDerivEqn4 :
 velocityIDerivSent1 = S "At a given point in time" `sC` phrase velocity +:+ S "may be defined as"
 velocityIDerivEqn1 = sy velocity $= deriv (sy position) time
 velocityIXDerivSent2 = S "We also know the horizontal" +:+ phrase position
-velocityIXDerivEqn2 = sy xPos $= sy lenRod * sin (sy pendDisplacementAngle) --FIXME xPos
+velocityIXDerivEqn2 = sy xPos $= sy lenRod * sin (sy pendDisplacementAngle) 
 velocityIXDerivSent3 = S "Applying this,"
 velocityIXDerivEqn3 = sy xVel $= deriv (sy lenRod * sin (sy pendDisplacementAngle)) time
 velocityIXDerivSent4 = E (sy lenRod) `sIs` S "constant with respect to time, so"
@@ -91,7 +91,7 @@ velocityIYDerivSent2,velocityIYDerivSent3,velocityIYDerivSent4,velocityIYDerivSe
 velocityIYDerivEqn2,velocityIYDerivEqn3,velocityIYDerivEqn4 :: Expr
 
 velocityIYDerivSent2 = S "We also know the vertical" +:+ phrase position
-velocityIYDerivEqn2 = sy yPos $= negate (sy lenRod * cos (sy pendDisplacementAngle)) --FIXME yPos
+velocityIYDerivEqn2 = sy yPos $= negate (sy lenRod * cos (sy pendDisplacementAngle)) 
 velocityIYDerivSent3 = S "Applying this again,"
 velocityIYDerivEqn3 = sy yVel $= negate (deriv (sy lenRod * cos (sy pendDisplacementAngle)) time)
 velocityIYDerivSent4 = E (sy lenRod) `sIs` S "constant with respect to time, so"

--- a/code/drasil-example/Drasil/DblPendulum/GenDefs.hs
+++ b/code/drasil-example/Drasil/DblPendulum/GenDefs.hs
@@ -12,7 +12,7 @@ import Data.Drasil.Concepts.Math (xComp, yComp, equation)
 import Data.Drasil.Quantities.Physics(velocity, angularVelocity, xVel, yVel,
     angularAccel, xAccel, yAccel, acceleration, force, tension, gravitationalAccel,
     angularFrequency, torque, momentOfInertia, angularDisplacement, time,
-    momentOfInertia, period, frequency)
+    momentOfInertia, period, frequency, position)
 import Data.Drasil.Concepts.Physics(pendulum, weight)
 import Data.Drasil.Quantities.PhysicalProperties(mass)
 import Data.Drasil.Theories.Physics(newtonSLR)
@@ -41,8 +41,32 @@ velocityIXRel :: Relation
 velocityIXRel = sy xVel $= sy angularVelocity * sy lenRod * cos (sy pendDisplacementAngle)
 
 velocityIXDeriv :: Derivation
-velocityIXDeriv = mkDerivName (phrase xComp +:+ phrase velocity) [ E velocityIXRel]
+velocityIXDeriv = mkDerivName (phrase xComp +:+ phrase velocity) (weave [velocityIXDerivSents, map E velocityIXDerivEqns])
 
+velocityIXDerivSents :: [Sentence]
+velocityIXDerivSents = [velocityIDerivSent1,velocityIDerivSent2,velocityIDerivSent3,velocityIDerivSent4,
+                            velocityIDerivSent5,velocityIXDerivSent6]
+
+velocityIXDerivEqns :: [Expr]
+velocityIXDerivEqns = [velocityIDerivEqn1,velocityIDerivEqn2,velocityIDerivEqn3,
+                            velocityIDerivEqn4,velocityIDerivEqn5,velocityIXRel]
+
+velocityIDerivSent1,velocityIDerivSent2,velocityIDerivSent3,velocityIDerivSent4,
+            velocityIDerivSent5,velocityIXDerivSent6,velocityIYDerivSent6 :: Sentence
+velocityIDerivEqn1,velocityIDerivEqn2,velocityIDerivEqn3,velocityIDerivEqn4,velocityIDerivEqn5 :: Expr
+
+velocityIDerivSent1 = foldlSentCol [S "Using the formula for arc length" `sC` S "the", phrase position `ofThe` phrase pendulum +: S "may be defined as"]
+velocityIDerivEqn1 = sy position $= sy pendDisplacementAngle * sy lenRod
+velocityIDerivSent2 = S "Then" `sC` S "the" +:+ phrase velocity `ofThe` phrase pendulum +:+ S "at a given time will be"
+velocityIDerivEqn2 = sy velocity $= deriv (sy position) time $= deriv (sy pendDisplacementAngle * sy lenRod) time
+velocityIDerivSent3 = E (sy lenRod) `sIs` S "constant with respect to time, so"
+velocityIDerivEqn3 = sy velocity $= sy lenRod * deriv (sy pendDisplacementAngle) time
+velocityIDerivSent4 = S "We also know that"
+velocityIDerivEqn4 = sy angularVelocity $= deriv (sy pendDisplacementAngle) time
+velocityIDerivSent5 = S "So,"
+velocityIDerivEqn5 = sy velocity $= sy angularVelocity * sy lenRod
+velocityIXDerivSent6 = S "For the x-component of" +: phrase velocity 
+velocityIYDerivSent6 = S "For the y-componenet of" +: phrase velocity
 
 
 ---------------------
@@ -58,7 +82,15 @@ velocityIYRel :: Relation
 velocityIYRel = sy yVel $= sy angularVelocity * sy lenRod * cos (sy pendDisplacementAngle)
 
 velocityIYDeriv :: Derivation
-velocityIYDeriv = mkDerivName (phrase yComp +:+ phrase velocity) [ E velocityIYRel]
+velocityIYDeriv = mkDerivName (phrase yComp +:+ phrase velocity) (weave [velocityIYDerivSents, map E velocityIYDerivEqns])
+
+velocityIYDerivSents :: [Sentence]
+velocityIYDerivSents = [velocityIDerivSent1,velocityIDerivSent2,velocityIDerivSent3,velocityIDerivSent4,
+                            velocityIDerivSent5,velocityIYDerivSent6]
+
+velocityIYDerivEqns :: [Expr]
+velocityIYDerivEqns = [velocityIDerivEqn1,velocityIDerivEqn2,velocityIDerivEqn3,
+                            velocityIDerivEqn4,velocityIDerivEqn5,velocityIYRel]
 
 -----------------------
 accelerationIXGD :: GenDefn

--- a/code/drasil-example/Drasil/DblPendulum/Unitals.hs
+++ b/code/drasil-example/Drasil/DblPendulum/Unitals.hs
@@ -12,7 +12,7 @@ import Data.Drasil.Quantities.PhysicalProperties as QPP (len, mass)
 import Data.Drasil.SI_Units (metre, degree, radian)
 import qualified Data.Drasil.Quantities.Physics as QP (position, ixPos, force, velocity,
   angularVelocity, angularAccel, gravitationalAccel, tension, acceleration, yAccel,
-  xAccel, yVel, xVel, iyPos, time, position, torque, momentOfInertia, angularDisplacement,
+  xAccel, yVel, xVel, iyPos, time, torque, momentOfInertia, angularDisplacement,
   angularFrequency, frequency, period)
 import Data.Drasil.Concepts.Physics (pendulum, twoD)
 import Data.Drasil.Concepts.Math as CM (angle)

--- a/code/drasil-example/Drasil/DblPendulum/Unitals.hs
+++ b/code/drasil-example/Drasil/DblPendulum/Unitals.hs
@@ -10,9 +10,9 @@ import Data.Drasil.Concepts.Documentation (assumption, goalStmt, physSyst,
         requirement, srs, typUnc)
 import Data.Drasil.Quantities.PhysicalProperties as QPP (len, mass)
 import Data.Drasil.SI_Units (metre, degree, radian)
-import qualified Data.Drasil.Quantities.Physics as QP (position, ixPos, force, velocity,
+import qualified Data.Drasil.Quantities.Physics as QP (position, ixPos, xPos, force, velocity,
   angularVelocity, angularAccel, gravitationalAccel, tension, acceleration, yAccel,
-  xAccel, yVel, xVel, iyPos, time, torque, momentOfInertia, angularDisplacement,
+  xAccel, yVel, xVel, iyPos, yPos, time, torque, momentOfInertia, angularDisplacement,
   angularFrequency, frequency, period)
 import Data.Drasil.Concepts.Physics (pendulum, twoD)
 import Data.Drasil.Concepts.Math as CM (angle)
@@ -36,7 +36,7 @@ units :: [UnitaryConceptDict]
 units = map ucw unitalChunks ++ map ucw [lenRod, pendDisplacementAngle, initialPendAngle]
 
 unitalChunks :: [UnitalChunk]
-unitalChunks = [lenRod, QPP.mass, QP.force, QP.ixPos,
+unitalChunks = [lenRod, QPP.mass, QP.force, QP.ixPos, QP.xPos, QP.yPos,
    QP.angularVelocity, QP.angularAccel, QP.gravitationalAccel, QP.tension, QP.acceleration,
    QP.yAccel, QP.xAccel, QP.yVel, QP.xVel, QP.iyPos, QP.time, QP.velocity, QP.position, QP.torque,
    QP.momentOfInertia, QP.angularDisplacement, QP.angularVelocity, initialPendAngle,

--- a/code/stable/dblpendulum/SRS/DblPendulum_SRS.tex
+++ b/code/stable/dblpendulum/SRS/DblPendulum_SRS.tex
@@ -530,7 +530,7 @@ Applying this to our equation for acceleration
 By the product and chain rules, we find
 
 \begin{displaymath}
-{a_{\text{x}}}=\frac{\,dω}{\,dt} {L_{\text{rod}}} \cos\left({θ_{p}}\right)+-ω {L_{\text{rod}}} \sin\left({θ_{p}}\right) \frac{\,d{θ_{p}}}{\,dt}
+{a_{\text{x}}}=\frac{\,dω}{\,dt} {L_{\text{rod}}} \cos\left({θ_{p}}\right)-ω {L_{\text{rod}}} \sin\left({θ_{p}}\right) \frac{\,d{θ_{p}}}{\,dt}
 \end{displaymath}
 Simplifying,
 

--- a/code/stable/dblpendulum/SRS/DblPendulum_SRS.tex
+++ b/code/stable/dblpendulum/SRS/DblPendulum_SRS.tex
@@ -407,7 +407,7 @@ ${L_{\text{rod}}}$ is constant with respect to time, so
 \begin{displaymath}
 {v_{\text{x}}}={L_{\text{rod}}} \frac{\,d\sin\left({θ_{p}}\right)}{\,dt}
 \end{displaymath}
-Therefore,
+Therefore, using the chain rule,
 
 \begin{displaymath}
 {v_{\text{x}}}=ω {L_{\text{rod}}} \cos\left({θ_{p}}\right)
@@ -427,7 +427,7 @@ Units & $\frac{\text{m}}{\text{s}}$
         
 \\ \midrule \\
 Equation & \begin{displaymath}
-           {v_{\text{y}}}=-ω {L_{\text{rod}}} \sin\left({θ_{p}}\right)
+           {v_{\text{y}}}=ω {L_{\text{rod}}} \sin\left({θ_{p}}\right)
            \end{displaymath}
 \\ \midrule \\
 Description & \begin{symbDescription}
@@ -454,24 +454,24 @@ At a given point in time, velocity may be defined as
 We also know the vertical position
 
 \begin{displaymath}
-{{p_{\text{y}}}^{\text{i}}}={L_{\text{rod}}} \cos\left({θ_{p}}\right)
+{{p_{\text{y}}}^{\text{i}}}=-{L_{\text{rod}}} \cos\left({θ_{p}}\right)
 \end{displaymath}
 Applying this again,
 
 \begin{displaymath}
-{v_{\text{y}}}=\frac{\,d{L_{\text{rod}}} \cos\left({θ_{p}}\right)}{\,dt}
+{v_{\text{y}}}=-\left(\frac{\,d{L_{\text{rod}}} \cos\left({θ_{p}}\right)}{\,dt}\right)
 \end{displaymath}
 ${L_{\text{rod}}}$ is constant with respect to time, so
 
 \begin{displaymath}
-{v_{\text{y}}}={L_{\text{rod}}} \frac{\,d\cos\left({θ_{p}}\right)}{\,dt}
+{v_{\text{y}}}=-{L_{\text{rod}}} \frac{\,d\cos\left({θ_{p}}\right)}{\,dt}
 \end{displaymath}
-Therefore,
+Therefore, using the chain rule,
 
 \begin{displaymath}
-{v_{\text{y}}}=-ω {L_{\text{rod}}} \sin\left({θ_{p}}\right)
+{v_{\text{y}}}=ω {L_{\text{rod}}} \sin\left({θ_{p}}\right)
 \end{displaymath}
-Therefore,
+Therefore, using the chain rule,
 
 \vspace{\baselineskip}
 \noindent
@@ -488,7 +488,7 @@ Units & $\frac{\text{m}}{\text{s}^{2}}$
         
 \\ \midrule \\
 Equation & \begin{displaymath}
-           {a_{\text{x}}}=-ω {L_{\text{rod}}} \sin\left({θ_{p}}\right)+α {L_{\text{rod}}} \cos\left({θ_{p}}\right)
+           {a_{\text{x}}}=-ω^{2} {L_{\text{rod}}} \sin\left({θ_{p}}\right)+α {L_{\text{rod}}} \cos\left({θ_{p}}\right)
            \end{displaymath}
 \\ \midrule \\
 Description & \begin{symbDescription}
@@ -508,8 +508,30 @@ RefBy &
 \end{minipage}
 \paragraph{Detailed derivation of $x$-component acceleration:}
 \label{GD:accelerationIXDeriv}
+Our acceleration is:
+
 \begin{displaymath}
-{a_{\text{x}}}=-ω {L_{\text{rod}}} \sin\left({θ_{p}}\right)+α {L_{\text{rod}}} \cos\left({θ_{p}}\right)
+\mathbf{a}=\frac{\,d\mathbf{v}}{\,dt}
+\end{displaymath}
+Earlier, we found the horizontal velocity to be
+
+\begin{displaymath}
+{v_{\text{x}}}=ω {L_{\text{rod}}} \cos\left({θ_{p}}\right)
+\end{displaymath}
+Applying this to our equation for acceleration
+
+\begin{displaymath}
+{a_{\text{x}}}=\frac{\,dω {L_{\text{rod}}} \cos\left({θ_{p}}\right)}{\,dt}
+\end{displaymath}
+By the product and chain rules, we find
+
+\begin{displaymath}
+{a_{\text{x}}}=\frac{\,dω}{\,dt} {L_{\text{rod}}} \cos\left({θ_{p}}\right)+-ω {L_{\text{rod}}} \sin\left({θ_{p}}\right) \frac{\,d{θ_{p}}}{\,dt}
+\end{displaymath}
+Simplifying,
+
+\begin{displaymath}
+{a_{\text{x}}}=-ω^{2} {L_{\text{rod}}} \sin\left({θ_{p}}\right)+α {L_{\text{rod}}} \cos\left({θ_{p}}\right)
 \end{displaymath}
 \vspace{\baselineskip}
 \noindent
@@ -526,7 +548,7 @@ Units & $\frac{\text{m}}{\text{s}^{2}}$
         
 \\ \midrule \\
 Equation & \begin{displaymath}
-           {a_{\text{y}}}=ω {L_{\text{rod}}} \cos\left({θ_{p}}\right)+α {L_{\text{rod}}} \sin\left({θ_{p}}\right)
+           {a_{\text{y}}}=ω^{2} {L_{\text{rod}}} \cos\left({θ_{p}}\right)+α {L_{\text{rod}}} \sin\left({θ_{p}}\right)
            \end{displaymath}
 \\ \midrule \\
 Description & \begin{symbDescription}
@@ -546,8 +568,30 @@ RefBy &
 \end{minipage}
 \paragraph{Detailed derivation of $y$-component acceleration:}
 \label{GD:accelerationIYDeriv}
+Our acceleration is:
+
 \begin{displaymath}
-{a_{\text{y}}}=ω {L_{\text{rod}}} \cos\left({θ_{p}}\right)+α {L_{\text{rod}}} \sin\left({θ_{p}}\right)
+\mathbf{a}=\frac{\,d\mathbf{v}}{\,dt}
+\end{displaymath}
+Earlier, we found the vertical velocity to be
+
+\begin{displaymath}
+{v_{\text{y}}}=ω {L_{\text{rod}}} \sin\left({θ_{p}}\right)
+\end{displaymath}
+Applying this to our equation for acceleration
+
+\begin{displaymath}
+{a_{\text{y}}}=\frac{\,dω {L_{\text{rod}}} \sin\left({θ_{p}}\right)}{\,dt}
+\end{displaymath}
+By the product and chain rules, we find
+
+\begin{displaymath}
+{a_{\text{y}}}=\frac{\,dω}{\,dt} {L_{\text{rod}}} \sin\left({θ_{p}}\right)+ω {L_{\text{rod}}} \cos\left({θ_{p}}\right) \frac{\,d{θ_{p}}}{\,dt}
+\end{displaymath}
+Simplifying,
+
+\begin{displaymath}
+{a_{\text{y}}}=ω^{2} {L_{\text{rod}}} \cos\left({θ_{p}}\right)+α {L_{\text{rod}}} \sin\left({θ_{p}}\right)
 \end{displaymath}
 \vspace{\baselineskip}
 \noindent
@@ -807,7 +851,7 @@ Units & ${\text{m}}$
         
 \\ \midrule \\
 Equation & \begin{displaymath}
-           {{p_{\text{y}}}^{\text{i}}}={L_{\text{rod}}} \cos\left({θ_{i}}\right)
+           {{p_{\text{y}}}^{\text{i}}}=-{L_{\text{rod}}} \cos\left({θ_{i}}\right)
            \end{displaymath}
 \\ \midrule \\
 Description & \begin{symbDescription}

--- a/code/stable/dblpendulum/SRS/DblPendulum_SRS.tex
+++ b/code/stable/dblpendulum/SRS/DblPendulum_SRS.tex
@@ -387,7 +387,7 @@ RefBy &
 \end{minipage}
 \paragraph{Detailed derivation of $x$-component velocity:}
 \label{GD:velocityIXDeriv}
-Using the formula for arc length, the position of the pendulum may be defined as::
+Using the formula for arc length, the position of the pendulum may be defined as:
 
 \begin{displaymath}
 \mathbf{p}={θ_{p}} {L_{\text{rod}}}
@@ -395,7 +395,12 @@ Using the formula for arc length, the position of the pendulum may be defined as
 Then, the velocity of the pendulum at a given time will be
 
 \begin{displaymath}
-\mathbf{v}=\frac{\,d\mathbf{p}}{\,dt}=\frac{\,d{θ_{p}} {L_{\text{rod}}}}{\,dt}
+\mathbf{v}=\frac{\,d\mathbf{p}}{\,dt}
+\end{displaymath}
+Applying this, we find
+
+\begin{displaymath}
+\mathbf{v}=\frac{\,d{θ_{p}} {L_{\text{rod}}}}{\,dt}
 \end{displaymath}
 ${L_{\text{rod}}}$ is constant with respect to time, so
 
@@ -432,7 +437,7 @@ Units & $\frac{\text{m}}{\text{s}}$
         
 \\ \midrule \\
 Equation & \begin{displaymath}
-           {v_{\text{y}}}=ω {L_{\text{rod}}} \cos\left({θ_{p}}\right)
+           {v_{\text{y}}}=ω {L_{\text{rod}}} \sin\left({θ_{p}}\right)
            \end{displaymath}
 \\ \midrule \\
 Description & \begin{symbDescription}
@@ -451,7 +456,7 @@ RefBy &
 \end{minipage}
 \paragraph{Detailed derivation of $y$-component velocity:}
 \label{GD:velocityIYDeriv}
-Using the formula for arc length, the position of the pendulum may be defined as::
+Using the formula for arc length, the position of the pendulum may be defined as:
 
 \begin{displaymath}
 \mathbf{p}={θ_{p}} {L_{\text{rod}}}
@@ -459,7 +464,12 @@ Using the formula for arc length, the position of the pendulum may be defined as
 Then, the velocity of the pendulum at a given time will be
 
 \begin{displaymath}
-\mathbf{v}=\frac{\,d\mathbf{p}}{\,dt}=\frac{\,d{θ_{p}} {L_{\text{rod}}}}{\,dt}
+\mathbf{v}=\frac{\,d\mathbf{p}}{\,dt}
+\end{displaymath}
+Applying this, we find
+
+\begin{displaymath}
+\mathbf{v}=\frac{\,d{θ_{p}} {L_{\text{rod}}}}{\,dt}
 \end{displaymath}
 ${L_{\text{rod}}}$ is constant with respect to time, so
 
@@ -471,15 +481,15 @@ We also know that
 \begin{displaymath}
 ω=\frac{\,d{θ_{p}}}{\,dt}
 \end{displaymath}
-So,
+We also know that
 
 \begin{displaymath}
 \mathbf{v}=ω {L_{\text{rod}}}
 \end{displaymath}
-For the y-componenet of velocity:
+For the y-componet of velocity:
 
 \begin{displaymath}
-{v_{\text{y}}}=ω {L_{\text{rod}}} \cos\left({θ_{p}}\right)
+{v_{\text{y}}}=ω {L_{\text{rod}}} \sin\left({θ_{p}}\right)
 \end{displaymath}
 \vspace{\baselineskip}
 \noindent

--- a/code/stable/dblpendulum/SRS/DblPendulum_SRS.tex
+++ b/code/stable/dblpendulum/SRS/DblPendulum_SRS.tex
@@ -91,7 +91,11 @@ ${L_{\text{rod}}}$ & Length of rod & ${\text{m}}$
 \\
 $m$ & Mass & ${\text{kg}}$
 \\
+${p_{\text{x}}}$ & $x$-component of position & ${\text{m}}$
+\\
 ${{p_{\text{x}}}^{\text{i}}}$ & $x$-component of initial position & ${\text{m}}$
+\\
+${p_{\text{y}}}$ & $y$-component of position & ${\text{m}}$
 \\
 ${{p_{\text{y}}}^{\text{i}}}$ & $y$-component of initial position & ${\text{m}}$
 \\
@@ -395,7 +399,7 @@ At a given point in time, velocity may be defined as
 We also know the horizontal position
 
 \begin{displaymath}
-{{p_{\text{x}}}^{\text{i}}}={L_{\text{rod}}} \sin\left({θ_{p}}\right)
+{p_{\text{x}}}={L_{\text{rod}}} \sin\left({θ_{p}}\right)
 \end{displaymath}
 Applying this,
 
@@ -454,7 +458,7 @@ At a given point in time, velocity may be defined as
 We also know the vertical position
 
 \begin{displaymath}
-{{p_{\text{y}}}^{\text{i}}}=-{L_{\text{rod}}} \cos\left({θ_{p}}\right)
+{p_{\text{y}}}=-{L_{\text{rod}}} \cos\left({θ_{p}}\right)
 \end{displaymath}
 Applying this again,
 

--- a/code/stable/dblpendulum/SRS/DblPendulum_SRS.tex
+++ b/code/stable/dblpendulum/SRS/DblPendulum_SRS.tex
@@ -387,6 +387,33 @@ RefBy &
 \end{minipage}
 \paragraph{Detailed derivation of $x$-component velocity:}
 \label{GD:velocityIXDeriv}
+Using the formula for arc length, the position of the pendulum may be defined as::
+
+\begin{displaymath}
+\mathbf{p}={θ_{p}} {L_{\text{rod}}}
+\end{displaymath}
+Then, the velocity of the pendulum at a given time will be
+
+\begin{displaymath}
+\mathbf{v}=\frac{\,d\mathbf{p}}{\,dt}=\frac{\,d{θ_{p}} {L_{\text{rod}}}}{\,dt}
+\end{displaymath}
+${L_{\text{rod}}}$ is constant with respect to time, so
+
+\begin{displaymath}
+\mathbf{v}={L_{\text{rod}}} \frac{\,d{θ_{p}}}{\,dt}
+\end{displaymath}
+We also know that
+
+\begin{displaymath}
+ω=\frac{\,d{θ_{p}}}{\,dt}
+\end{displaymath}
+So,
+
+\begin{displaymath}
+\mathbf{v}=ω {L_{\text{rod}}}
+\end{displaymath}
+For the x-component of velocity:
+
 \begin{displaymath}
 {v_{\text{x}}}=ω {L_{\text{rod}}} \cos\left({θ_{p}}\right)
 \end{displaymath}
@@ -424,6 +451,33 @@ RefBy &
 \end{minipage}
 \paragraph{Detailed derivation of $y$-component velocity:}
 \label{GD:velocityIYDeriv}
+Using the formula for arc length, the position of the pendulum may be defined as::
+
+\begin{displaymath}
+\mathbf{p}={θ_{p}} {L_{\text{rod}}}
+\end{displaymath}
+Then, the velocity of the pendulum at a given time will be
+
+\begin{displaymath}
+\mathbf{v}=\frac{\,d\mathbf{p}}{\,dt}=\frac{\,d{θ_{p}} {L_{\text{rod}}}}{\,dt}
+\end{displaymath}
+${L_{\text{rod}}}$ is constant with respect to time, so
+
+\begin{displaymath}
+\mathbf{v}={L_{\text{rod}}} \frac{\,d{θ_{p}}}{\,dt}
+\end{displaymath}
+We also know that
+
+\begin{displaymath}
+ω=\frac{\,d{θ_{p}}}{\,dt}
+\end{displaymath}
+So,
+
+\begin{displaymath}
+\mathbf{v}=ω {L_{\text{rod}}}
+\end{displaymath}
+For the y-componenet of velocity:
+
 \begin{displaymath}
 {v_{\text{y}}}=ω {L_{\text{rod}}} \cos\left({θ_{p}}\right)
 \end{displaymath}

--- a/code/stable/dblpendulum/SRS/DblPendulum_SRS.tex
+++ b/code/stable/dblpendulum/SRS/DblPendulum_SRS.tex
@@ -387,37 +387,27 @@ RefBy &
 \end{minipage}
 \paragraph{Detailed derivation of $x$-component velocity:}
 \label{GD:velocityIXDeriv}
-Using the formula for arc length, the position of the pendulum may be defined as:
-
-\begin{displaymath}
-\mathbf{p}={θ_{p}} {L_{\text{rod}}}
-\end{displaymath}
-Then, the velocity of the pendulum at a given time will be
+At a given point in time, velocity may be defined as
 
 \begin{displaymath}
 \mathbf{v}=\frac{\,d\mathbf{p}}{\,dt}
 \end{displaymath}
-Applying this, we find
+We also know the horizontal position
 
 \begin{displaymath}
-\mathbf{v}=\frac{\,d{θ_{p}} {L_{\text{rod}}}}{\,dt}
+{{p_{\text{x}}}^{\text{i}}}={L_{\text{rod}}} \sin\left({θ_{p}}\right)
+\end{displaymath}
+Applying this,
+
+\begin{displaymath}
+{v_{\text{x}}}=\frac{\,d{L_{\text{rod}}} \sin\left({θ_{p}}\right)}{\,dt}
 \end{displaymath}
 ${L_{\text{rod}}}$ is constant with respect to time, so
 
 \begin{displaymath}
-\mathbf{v}={L_{\text{rod}}} \frac{\,d{θ_{p}}}{\,dt}
+{v_{\text{x}}}={L_{\text{rod}}} \frac{\,d\sin\left({θ_{p}}\right)}{\,dt}
 \end{displaymath}
-We also know that
-
-\begin{displaymath}
-ω=\frac{\,d{θ_{p}}}{\,dt}
-\end{displaymath}
-So,
-
-\begin{displaymath}
-\mathbf{v}=ω {L_{\text{rod}}}
-\end{displaymath}
-For the x-component of velocity:
+Therefore,
 
 \begin{displaymath}
 {v_{\text{x}}}=ω {L_{\text{rod}}} \cos\left({θ_{p}}\right)
@@ -437,7 +427,7 @@ Units & $\frac{\text{m}}{\text{s}}$
         
 \\ \midrule \\
 Equation & \begin{displaymath}
-           {v_{\text{y}}}=ω {L_{\text{rod}}} \sin\left({θ_{p}}\right)
+           {v_{\text{y}}}=-ω {L_{\text{rod}}} \sin\left({θ_{p}}\right)
            \end{displaymath}
 \\ \midrule \\
 Description & \begin{symbDescription}
@@ -456,41 +446,33 @@ RefBy &
 \end{minipage}
 \paragraph{Detailed derivation of $y$-component velocity:}
 \label{GD:velocityIYDeriv}
-Using the formula for arc length, the position of the pendulum may be defined as:
-
-\begin{displaymath}
-\mathbf{p}={θ_{p}} {L_{\text{rod}}}
-\end{displaymath}
-Then, the velocity of the pendulum at a given time will be
+At a given point in time, velocity may be defined as
 
 \begin{displaymath}
 \mathbf{v}=\frac{\,d\mathbf{p}}{\,dt}
 \end{displaymath}
-Applying this, we find
+We also know the vertical position
 
 \begin{displaymath}
-\mathbf{v}=\frac{\,d{θ_{p}} {L_{\text{rod}}}}{\,dt}
+{{p_{\text{y}}}^{\text{i}}}={L_{\text{rod}}} \cos\left({θ_{p}}\right)
+\end{displaymath}
+Applying this again,
+
+\begin{displaymath}
+{v_{\text{y}}}=\frac{\,d{L_{\text{rod}}} \cos\left({θ_{p}}\right)}{\,dt}
 \end{displaymath}
 ${L_{\text{rod}}}$ is constant with respect to time, so
 
 \begin{displaymath}
-\mathbf{v}={L_{\text{rod}}} \frac{\,d{θ_{p}}}{\,dt}
+{v_{\text{y}}}={L_{\text{rod}}} \frac{\,d\cos\left({θ_{p}}\right)}{\,dt}
 \end{displaymath}
-We also know that
+Therefore,
 
 \begin{displaymath}
-ω=\frac{\,d{θ_{p}}}{\,dt}
+{v_{\text{y}}}=-ω {L_{\text{rod}}} \sin\left({θ_{p}}\right)
 \end{displaymath}
-We also know that
+Therefore,
 
-\begin{displaymath}
-\mathbf{v}=ω {L_{\text{rod}}}
-\end{displaymath}
-For the y-componet of velocity:
-
-\begin{displaymath}
-{v_{\text{y}}}=ω {L_{\text{rod}}} \sin\left({θ_{p}}\right)
-\end{displaymath}
 \vspace{\baselineskip}
 \noindent
 \begin{minipage}{\textwidth}

--- a/code/stable/dblpendulum/Website/DblPendulum_SRS.html
+++ b/code/stable/dblpendulum/Website/DblPendulum_SRS.html
@@ -653,24 +653,18 @@
                   <div class="subsubsubsection">
                     <h4>Detailed derivation of <em>x</em>-component velocity:</h4>
                     <p class="paragraph">
-                      Using the formula for arc length, the position of the pendulum may be defined as:
-                    </p>
-                    \[\mathbf{p}={θ_{p}} {L_{\text{rod}}}\]
-                    <p class="paragraph">
-                      Then, the velocity of the pendulum at a given time will be
+                      At a given point in time, velocity may be defined as
                     </p>
                     \[\mathbf{v}=\frac{\,d\mathbf{p}}{\,dt}\]
-                    <p class="paragraph">Applying this, we find</p>
-                    \[\mathbf{v}=\frac{\,d{θ_{p}} {L_{\text{rod}}}}{\,dt}\]
+                    <p class="paragraph">We also know the horizontal position</p>
+                    \[{{p_{\text{x}}}^{\text{i}}}={L_{\text{rod}}} \sin\left({θ_{p}}\right)\]
+                    <p class="paragraph">Applying this,</p>
+                    \[{v_{\text{x}}}=\frac{\,d{L_{\text{rod}}} \sin\left({θ_{p}}\right)}{\,dt}\]
                     <p class="paragraph">
                       <em>L<sub>rod</sub></em> is constant with respect to time, so
                     </p>
-                    \[\mathbf{v}={L_{\text{rod}}} \frac{\,d{θ_{p}}}{\,dt}\]
-                    <p class="paragraph">We also know that</p>
-                    \[ω=\frac{\,d{θ_{p}}}{\,dt}\]
-                    <p class="paragraph">So,</p>
-                    \[\mathbf{v}=ω {L_{\text{rod}}}\]
-                    <p class="paragraph">For the x-component of velocity:</p>
+                    \[{v_{\text{x}}}={L_{\text{rod}}} \frac{\,d\sin\left({θ_{p}}\right)}{\,dt}\]
+                    <p class="paragraph">Therefore,</p>
                     \[{v_{\text{x}}}=ω {L_{\text{rod}}} \cos\left({θ_{p}}\right)\]
                   </div>
                 </div>
@@ -697,7 +691,7 @@
                     <tr>
                       <th>Equation</th>
                       <td>
-                        \[{v_{\text{y}}}=ω {L_{\text{rod}}} \sin\left({θ_{p}}\right)\]
+                        \[{v_{\text{y}}}=-ω {L_{\text{rod}}} \sin\left({θ_{p}}\right)\]
                       </td>
                     </tr>
                     <tr>
@@ -731,25 +725,20 @@
                   <div class="subsubsubsection">
                     <h4>Detailed derivation of <em>y</em>-component velocity:</h4>
                     <p class="paragraph">
-                      Using the formula for arc length, the position of the pendulum may be defined as:
-                    </p>
-                    \[\mathbf{p}={θ_{p}} {L_{\text{rod}}}\]
-                    <p class="paragraph">
-                      Then, the velocity of the pendulum at a given time will be
+                      At a given point in time, velocity may be defined as
                     </p>
                     \[\mathbf{v}=\frac{\,d\mathbf{p}}{\,dt}\]
-                    <p class="paragraph">Applying this, we find</p>
-                    \[\mathbf{v}=\frac{\,d{θ_{p}} {L_{\text{rod}}}}{\,dt}\]
+                    <p class="paragraph">We also know the vertical position</p>
+                    \[{{p_{\text{y}}}^{\text{i}}}={L_{\text{rod}}} \cos\left({θ_{p}}\right)\]
+                    <p class="paragraph">Applying this again,</p>
+                    \[{v_{\text{y}}}=\frac{\,d{L_{\text{rod}}} \cos\left({θ_{p}}\right)}{\,dt}\]
                     <p class="paragraph">
                       <em>L<sub>rod</sub></em> is constant with respect to time, so
                     </p>
-                    \[\mathbf{v}={L_{\text{rod}}} \frac{\,d{θ_{p}}}{\,dt}\]
-                    <p class="paragraph">We also know that</p>
-                    \[ω=\frac{\,d{θ_{p}}}{\,dt}\]
-                    <p class="paragraph">We also know that</p>
-                    \[\mathbf{v}=ω {L_{\text{rod}}}\]
-                    <p class="paragraph">For the y-componet of velocity:</p>
-                    \[{v_{\text{y}}}=ω {L_{\text{rod}}} \sin\left({θ_{p}}\right)\]
+                    \[{v_{\text{y}}}={L_{\text{rod}}} \frac{\,d\cos\left({θ_{p}}\right)}{\,dt}\]
+                    <p class="paragraph">Therefore,</p>
+                    \[{v_{\text{y}}}=-ω {L_{\text{rod}}} \sin\left({θ_{p}}\right)\]
+                    <p class="paragraph">Therefore,</p>
                   </div>
                 </div>
                 <div id="GD:accelerationIX">

--- a/code/stable/dblpendulum/Website/DblPendulum_SRS.html
+++ b/code/stable/dblpendulum/Website/DblPendulum_SRS.html
@@ -664,7 +664,7 @@
                       <em>L<sub>rod</sub></em> is constant with respect to time, so
                     </p>
                     \[{v_{\text{x}}}={L_{\text{rod}}} \frac{\,d\sin\left({θ_{p}}\right)}{\,dt}\]
-                    <p class="paragraph">Therefore,</p>
+                    <p class="paragraph">Therefore, using the chain rule,</p>
                     \[{v_{\text{x}}}=ω {L_{\text{rod}}} \cos\left({θ_{p}}\right)\]
                   </div>
                 </div>
@@ -691,7 +691,7 @@
                     <tr>
                       <th>Equation</th>
                       <td>
-                        \[{v_{\text{y}}}=-ω {L_{\text{rod}}} \sin\left({θ_{p}}\right)\]
+                        \[{v_{\text{y}}}=ω {L_{\text{rod}}} \sin\left({θ_{p}}\right)\]
                       </td>
                     </tr>
                     <tr>
@@ -729,16 +729,16 @@
                     </p>
                     \[\mathbf{v}=\frac{\,d\mathbf{p}}{\,dt}\]
                     <p class="paragraph">We also know the vertical position</p>
-                    \[{{p_{\text{y}}}^{\text{i}}}={L_{\text{rod}}} \cos\left({θ_{p}}\right)\]
+                    \[{{p_{\text{y}}}^{\text{i}}}=-{L_{\text{rod}}} \cos\left({θ_{p}}\right)\]
                     <p class="paragraph">Applying this again,</p>
-                    \[{v_{\text{y}}}=\frac{\,d{L_{\text{rod}}} \cos\left({θ_{p}}\right)}{\,dt}\]
+                    \[{v_{\text{y}}}=-\left(\frac{\,d{L_{\text{rod}}} \cos\left({θ_{p}}\right)}{\,dt}\right)\]
                     <p class="paragraph">
                       <em>L<sub>rod</sub></em> is constant with respect to time, so
                     </p>
-                    \[{v_{\text{y}}}={L_{\text{rod}}} \frac{\,d\cos\left({θ_{p}}\right)}{\,dt}\]
-                    <p class="paragraph">Therefore,</p>
-                    \[{v_{\text{y}}}=-ω {L_{\text{rod}}} \sin\left({θ_{p}}\right)\]
-                    <p class="paragraph">Therefore,</p>
+                    \[{v_{\text{y}}}=-{L_{\text{rod}}} \frac{\,d\cos\left({θ_{p}}\right)}{\,dt}\]
+                    <p class="paragraph">Therefore, using the chain rule,</p>
+                    \[{v_{\text{y}}}=ω {L_{\text{rod}}} \sin\left({θ_{p}}\right)\]
+                    <p class="paragraph">Therefore, using the chain rule,</p>
                   </div>
                 </div>
                 <div id="GD:accelerationIX">
@@ -764,7 +764,7 @@
                     <tr>
                       <th>Equation</th>
                       <td>
-                        \[{a_{\text{x}}}=-ω {L_{\text{rod}}} \sin\left({θ_{p}}\right)+α {L_{\text{rod}}} \cos\left({θ_{p}}\right)\]
+                        \[{a_{\text{x}}}=-ω^{2} {L_{\text{rod}}} \sin\left({θ_{p}}\right)+α {L_{\text{rod}}} \cos\left({θ_{p}}\right)\]
                       </td>
                     </tr>
                     <tr>
@@ -800,7 +800,20 @@
                 <div id="GD:accelerationIXDeriv">
                   <div class="subsubsubsection">
                     <h4>Detailed derivation of <em>x</em>-component acceleration:</h4>
-                    \[{a_{\text{x}}}=-ω {L_{\text{rod}}} \sin\left({θ_{p}}\right)+α {L_{\text{rod}}} \cos\left({θ_{p}}\right)\]
+                    <p class="paragraph">Our acceleration is:</p>
+                    \[\mathbf{a}=\frac{\,d\mathbf{v}}{\,dt}\]
+                    <p class="paragraph">
+                      Earlier, we found the horizontal velocity to be
+                    </p>
+                    \[{v_{\text{x}}}=ω {L_{\text{rod}}} \cos\left({θ_{p}}\right)\]
+                    <p class="paragraph">
+                      Applying this to our equation for acceleration
+                    </p>
+                    \[{a_{\text{x}}}=\frac{\,dω {L_{\text{rod}}} \cos\left({θ_{p}}\right)}{\,dt}\]
+                    <p class="paragraph">By the product and chain rules, we find</p>
+                    \[{a_{\text{x}}}=\frac{\,dω}{\,dt} {L_{\text{rod}}} \cos\left({θ_{p}}\right)+-ω {L_{\text{rod}}} \sin\left({θ_{p}}\right) \frac{\,d{θ_{p}}}{\,dt}\]
+                    <p class="paragraph">Simplifying,</p>
+                    \[{a_{\text{x}}}=-ω^{2} {L_{\text{rod}}} \sin\left({θ_{p}}\right)+α {L_{\text{rod}}} \cos\left({θ_{p}}\right)\]
                   </div>
                 </div>
                 <div id="GD:accelerationIY">
@@ -826,7 +839,7 @@
                     <tr>
                       <th>Equation</th>
                       <td>
-                        \[{a_{\text{y}}}=ω {L_{\text{rod}}} \cos\left({θ_{p}}\right)+α {L_{\text{rod}}} \sin\left({θ_{p}}\right)\]
+                        \[{a_{\text{y}}}=ω^{2} {L_{\text{rod}}} \cos\left({θ_{p}}\right)+α {L_{\text{rod}}} \sin\left({θ_{p}}\right)\]
                       </td>
                     </tr>
                     <tr>
@@ -862,7 +875,20 @@
                 <div id="GD:accelerationIYDeriv">
                   <div class="subsubsubsection">
                     <h4>Detailed derivation of <em>y</em>-component acceleration:</h4>
-                    \[{a_{\text{y}}}=ω {L_{\text{rod}}} \cos\left({θ_{p}}\right)+α {L_{\text{rod}}} \sin\left({θ_{p}}\right)\]
+                    <p class="paragraph">Our acceleration is:</p>
+                    \[\mathbf{a}=\frac{\,d\mathbf{v}}{\,dt}\]
+                    <p class="paragraph">
+                      Earlier, we found the vertical velocity to be
+                    </p>
+                    \[{v_{\text{y}}}=ω {L_{\text{rod}}} \sin\left({θ_{p}}\right)\]
+                    <p class="paragraph">
+                      Applying this to our equation for acceleration
+                    </p>
+                    \[{a_{\text{y}}}=\frac{\,dω {L_{\text{rod}}} \sin\left({θ_{p}}\right)}{\,dt}\]
+                    <p class="paragraph">By the product and chain rules, we find</p>
+                    \[{a_{\text{y}}}=\frac{\,dω}{\,dt} {L_{\text{rod}}} \sin\left({θ_{p}}\right)+ω {L_{\text{rod}}} \cos\left({θ_{p}}\right) \frac{\,d{θ_{p}}}{\,dt}\]
+                    <p class="paragraph">Simplifying,</p>
+                    \[{a_{\text{y}}}=ω^{2} {L_{\text{rod}}} \cos\left({θ_{p}}\right)+α {L_{\text{rod}}} \sin\left({θ_{p}}\right)\]
                   </div>
                 </div>
                 <div id="GD:hForceOnPendulum">
@@ -1214,7 +1240,7 @@
                     <tr>
                       <th>Equation</th>
                       <td>
-                        \[{{p_{\text{y}}}^{\text{i}}}={L_{\text{rod}}} \cos\left({θ_{i}}\right)\]
+                        \[{{p_{\text{y}}}^{\text{i}}}=-{L_{\text{rod}}} \cos\left({θ_{i}}\right)\]
                       </td>
                     </tr>
                     <tr>

--- a/code/stable/dblpendulum/Website/DblPendulum_SRS.html
+++ b/code/stable/dblpendulum/Website/DblPendulum_SRS.html
@@ -652,6 +652,23 @@
                 <div id="GD:velocityIXDeriv">
                   <div class="subsubsubsection">
                     <h4>Detailed derivation of <em>x</em>-component velocity:</h4>
+                    <p class="paragraph">
+                      Using the formula for arc length, the position of the pendulum may be defined as::
+                    </p>
+                    \[\mathbf{p}={θ_{p}} {L_{\text{rod}}}\]
+                    <p class="paragraph">
+                      Then, the velocity of the pendulum at a given time will be
+                    </p>
+                    \[\mathbf{v}=\frac{\,d\mathbf{p}}{\,dt}=\frac{\,d{θ_{p}} {L_{\text{rod}}}}{\,dt}\]
+                    <p class="paragraph">
+                      <em>L<sub>rod</sub></em> is constant with respect to time, so
+                    </p>
+                    \[\mathbf{v}={L_{\text{rod}}} \frac{\,d{θ_{p}}}{\,dt}\]
+                    <p class="paragraph">We also know that</p>
+                    \[ω=\frac{\,d{θ_{p}}}{\,dt}\]
+                    <p class="paragraph">So,</p>
+                    \[\mathbf{v}=ω {L_{\text{rod}}}\]
+                    <p class="paragraph">For the x-component of velocity:</p>
                     \[{v_{\text{x}}}=ω {L_{\text{rod}}} \cos\left({θ_{p}}\right)\]
                   </div>
                 </div>
@@ -711,6 +728,23 @@
                 <div id="GD:velocityIYDeriv">
                   <div class="subsubsubsection">
                     <h4>Detailed derivation of <em>y</em>-component velocity:</h4>
+                    <p class="paragraph">
+                      Using the formula for arc length, the position of the pendulum may be defined as::
+                    </p>
+                    \[\mathbf{p}={θ_{p}} {L_{\text{rod}}}\]
+                    <p class="paragraph">
+                      Then, the velocity of the pendulum at a given time will be
+                    </p>
+                    \[\mathbf{v}=\frac{\,d\mathbf{p}}{\,dt}=\frac{\,d{θ_{p}} {L_{\text{rod}}}}{\,dt}\]
+                    <p class="paragraph">
+                      <em>L<sub>rod</sub></em> is constant with respect to time, so
+                    </p>
+                    \[\mathbf{v}={L_{\text{rod}}} \frac{\,d{θ_{p}}}{\,dt}\]
+                    <p class="paragraph">We also know that</p>
+                    \[ω=\frac{\,d{θ_{p}}}{\,dt}\]
+                    <p class="paragraph">So,</p>
+                    \[\mathbf{v}=ω {L_{\text{rod}}}\]
+                    <p class="paragraph">For the y-componenet of velocity:</p>
                     \[{v_{\text{y}}}=ω {L_{\text{rod}}} \cos\left({θ_{p}}\right)\]
                   </div>
                 </div>

--- a/code/stable/dblpendulum/Website/DblPendulum_SRS.html
+++ b/code/stable/dblpendulum/Website/DblPendulum_SRS.html
@@ -134,8 +134,18 @@
                   <td><em>kg</em></td>
                 </tr>
                 <tr>
+                  <td><em>p<sub>x</sub></em></td>
+                  <td><em>x</em>-component of position</td>
+                  <td><em>m</em></td>
+                </tr>
+                <tr>
                   <td><em>p<sub>x</sub><sup>i</sup></em></td>
                   <td><em>x</em>-component of initial position</td>
+                  <td><em>m</em></td>
+                </tr>
+                <tr>
+                  <td><em>p<sub>y</sub></em></td>
+                  <td><em>y</em>-component of position</td>
                   <td><em>m</em></td>
                 </tr>
                 <tr>
@@ -657,7 +667,7 @@
                     </p>
                     \[\mathbf{v}=\frac{\,d\mathbf{p}}{\,dt}\]
                     <p class="paragraph">We also know the horizontal position</p>
-                    \[{{p_{\text{x}}}^{\text{i}}}={L_{\text{rod}}} \sin\left({θ_{p}}\right)\]
+                    \[{p_{\text{x}}}={L_{\text{rod}}} \sin\left({θ_{p}}\right)\]
                     <p class="paragraph">Applying this,</p>
                     \[{v_{\text{x}}}=\frac{\,d{L_{\text{rod}}} \sin\left({θ_{p}}\right)}{\,dt}\]
                     <p class="paragraph">
@@ -729,7 +739,7 @@
                     </p>
                     \[\mathbf{v}=\frac{\,d\mathbf{p}}{\,dt}\]
                     <p class="paragraph">We also know the vertical position</p>
-                    \[{{p_{\text{y}}}^{\text{i}}}=-{L_{\text{rod}}} \cos\left({θ_{p}}\right)\]
+                    \[{p_{\text{y}}}=-{L_{\text{rod}}} \cos\left({θ_{p}}\right)\]
                     <p class="paragraph">Applying this again,</p>
                     \[{v_{\text{y}}}=-\left(\frac{\,d{L_{\text{rod}}} \cos\left({θ_{p}}\right)}{\,dt}\right)\]
                     <p class="paragraph">

--- a/code/stable/dblpendulum/Website/DblPendulum_SRS.html
+++ b/code/stable/dblpendulum/Website/DblPendulum_SRS.html
@@ -821,7 +821,7 @@
                     </p>
                     \[{a_{\text{x}}}=\frac{\,dω {L_{\text{rod}}} \cos\left({θ_{p}}\right)}{\,dt}\]
                     <p class="paragraph">By the product and chain rules, we find</p>
-                    \[{a_{\text{x}}}=\frac{\,dω}{\,dt} {L_{\text{rod}}} \cos\left({θ_{p}}\right)+-ω {L_{\text{rod}}} \sin\left({θ_{p}}\right) \frac{\,d{θ_{p}}}{\,dt}\]
+                    \[{a_{\text{x}}}=\frac{\,dω}{\,dt} {L_{\text{rod}}} \cos\left({θ_{p}}\right)-ω {L_{\text{rod}}} \sin\left({θ_{p}}\right) \frac{\,d{θ_{p}}}{\,dt}\]
                     <p class="paragraph">Simplifying,</p>
                     \[{a_{\text{x}}}=-ω^{2} {L_{\text{rod}}} \sin\left({θ_{p}}\right)+α {L_{\text{rod}}} \cos\left({θ_{p}}\right)\]
                   </div>

--- a/code/stable/dblpendulum/Website/DblPendulum_SRS.html
+++ b/code/stable/dblpendulum/Website/DblPendulum_SRS.html
@@ -653,13 +653,15 @@
                   <div class="subsubsubsection">
                     <h4>Detailed derivation of <em>x</em>-component velocity:</h4>
                     <p class="paragraph">
-                      Using the formula for arc length, the position of the pendulum may be defined as::
+                      Using the formula for arc length, the position of the pendulum may be defined as:
                     </p>
                     \[\mathbf{p}={θ_{p}} {L_{\text{rod}}}\]
                     <p class="paragraph">
                       Then, the velocity of the pendulum at a given time will be
                     </p>
-                    \[\mathbf{v}=\frac{\,d\mathbf{p}}{\,dt}=\frac{\,d{θ_{p}} {L_{\text{rod}}}}{\,dt}\]
+                    \[\mathbf{v}=\frac{\,d\mathbf{p}}{\,dt}\]
+                    <p class="paragraph">Applying this, we find</p>
+                    \[\mathbf{v}=\frac{\,d{θ_{p}} {L_{\text{rod}}}}{\,dt}\]
                     <p class="paragraph">
                       <em>L<sub>rod</sub></em> is constant with respect to time, so
                     </p>
@@ -695,7 +697,7 @@
                     <tr>
                       <th>Equation</th>
                       <td>
-                        \[{v_{\text{y}}}=ω {L_{\text{rod}}} \cos\left({θ_{p}}\right)\]
+                        \[{v_{\text{y}}}=ω {L_{\text{rod}}} \sin\left({θ_{p}}\right)\]
                       </td>
                     </tr>
                     <tr>
@@ -729,23 +731,25 @@
                   <div class="subsubsubsection">
                     <h4>Detailed derivation of <em>y</em>-component velocity:</h4>
                     <p class="paragraph">
-                      Using the formula for arc length, the position of the pendulum may be defined as::
+                      Using the formula for arc length, the position of the pendulum may be defined as:
                     </p>
                     \[\mathbf{p}={θ_{p}} {L_{\text{rod}}}\]
                     <p class="paragraph">
                       Then, the velocity of the pendulum at a given time will be
                     </p>
-                    \[\mathbf{v}=\frac{\,d\mathbf{p}}{\,dt}=\frac{\,d{θ_{p}} {L_{\text{rod}}}}{\,dt}\]
+                    \[\mathbf{v}=\frac{\,d\mathbf{p}}{\,dt}\]
+                    <p class="paragraph">Applying this, we find</p>
+                    \[\mathbf{v}=\frac{\,d{θ_{p}} {L_{\text{rod}}}}{\,dt}\]
                     <p class="paragraph">
                       <em>L<sub>rod</sub></em> is constant with respect to time, so
                     </p>
                     \[\mathbf{v}={L_{\text{rod}}} \frac{\,d{θ_{p}}}{\,dt}\]
                     <p class="paragraph">We also know that</p>
                     \[ω=\frac{\,d{θ_{p}}}{\,dt}\]
-                    <p class="paragraph">So,</p>
+                    <p class="paragraph">We also know that</p>
                     \[\mathbf{v}=ω {L_{\text{rod}}}\]
-                    <p class="paragraph">For the y-componenet of velocity:</p>
-                    \[{v_{\text{y}}}=ω {L_{\text{rod}}} \cos\left({θ_{p}}\right)\]
+                    <p class="paragraph">For the y-componet of velocity:</p>
+                    \[{v_{\text{y}}}=ω {L_{\text{rod}}} \sin\left({θ_{p}}\right)\]
                   </div>
                 </div>
                 <div id="GD:accelerationIX">


### PR DESCRIPTION
I apologize in advance for the large PR. After discussing issue #2391 some more, Dr. Smith gave me the link to the derivations of the velocity and acceleration equations, so most of the changes are just implementing those. `xPos` and `yPos` were also added to the list of symbols (which closes issue #2411) 