### PR TITLE
Re-enable errors on warnings in GitHub Actions Workflows/Builds

### DIFF
--- a/.github/workflows/Drasil.yaml
+++ b/.github/workflows/Drasil.yaml
@@ -56,8 +56,7 @@ jobs:
       - name: "Install dependencies"
         run: stack --no-terminal test --bench --only-dependencies
       - name: "Build"
-        # TODO: Add back -Werror flag to stackArgs
-        run: make prog stackArgs="--no-terminal"
+        run: make prog stackArgs="--no-terminal" GHCFLAGS="-Werror"
       - name: "Stable"
         run: make stackArgs="--no-terminal" NOISY=yes
       - name: "TeX"

--- a/code/drasil-gool/GOOL/Drasil/LanguageRenderer/PythonRenderer.hs
+++ b/code/drasil-gool/GOOL/Drasil/LanguageRenderer/PythonRenderer.hs
@@ -36,7 +36,7 @@ import GOOL.Drasil.RendererClasses (RenderSym, RenderFile(..), ImportSym(..),
   BlockCommentSym(..), BlockCommentElim)
 import qualified GOOL.Drasil.RendererClasses as RC (import', perm, body, block, 
   type', uOp, bOp, variable, value, function, statement, scope, parameter,
-  method, stateVar, class', module', blockComment', intClass)
+  method, stateVar, class', module', blockComment')
 import GOOL.Drasil.LanguageRenderer (classDec, dot, ifLabel, elseLabel, 
   forLabel, inLabel, whileLabel, tryLabel, importLabel, exceptionObj', listSep',
   argv, printLabel, listSep, piLabel, access, functionDox, variableList, 


### PR DESCRIPTION
Relies on #2430 (so as not to fail the build)