### PR TITLE
Removed Whitespaces in PDController

### DIFF
--- a/code/drasil-example/Drasil/PDController/Assumptions.hs
+++ b/code/drasil-example/Drasil/PDController/Assumptions.hs
@@ -54,45 +54,41 @@ pwrPlantDesc, aDecoupledDesc, aSPDesc, aExtDisturbDesc, aManualTuningDesc,
               aStiffnessCoeffDesc :: Sentence
 pwrPlantDesc
   = foldlSent
-      [S "The" +:+ phrase powerPlant +:+ S "and the Sensor are coupled" +:+
-         S "as a single unit"]
+      [S "The", phrase powerPlant, S "and the Sensor are coupled as a single unit"]
 
 apwrPlantTxFnxDesc
   = foldlSent
-      [S "The combined" +:+ phrase powerPlant +:+ S "and Sensor " +:+
-         sParen (makeRef2S aPwrPlant)         
-         +:+ S " are characterized by a Second Order mass-spring-damper"
-         +:+ S " System"]
+      [S "The combined", phrase powerPlant, S "and Sensor",
+         sParen (makeRef2S aPwrPlant),        
+         S "are characterized by a Second Order mass-spring-damper System"]
 
 aDecoupledDesc
   = foldlSent
-      [S "The decoupled form of the" +:+ phrase pidC +:+
-         S "equation used in this"
-         +:+ phrase simulation]
+      [S "The decoupled form of the", phrase pidC,
+         S "equation used in this", phrase simulation]
 
 aSPDesc
   = foldlSent
-      [S "The" +:+ phrase setPoint +:+ S "is constant throughout the" +:+
+      [S "The", phrase setPoint, S "is constant throughout the",
          phrase simulation]
 
 aExtDisturbDesc
   = foldlSent
-      [S "There are no external disturbances to the" +:+ phrase powerPlant +:+
-         S "during the"
-         +:+ phrase simulation]
+      [S "There are no external disturbances to the", phrase powerPlant,
+         S "during the", phrase simulation]
 
 aManualTuningDesc
   = foldlSent
-      [S "This model will be used for  manual tuning of the" +:+ phrase pidC]
+      [S "This model will be used for manual tuning of the", phrase pidC]
 
 aInitialValueDesc
   = foldlSent
-      [S "The initial value of the" +:+ phrase processVariable +:+
+      [S "The initial value of the", phrase processVariable,
          S "is assumed to be zero"]
 
 aParallelEqDesc
   = foldlSent
-      [S "The Parallel form of the equation is used for the" +:+ phrase pidC]
+      [S "The Parallel form of the equation is used for the", phrase pidC]
 
 aUnfilteredDerivativeDesc
   = foldlSent
@@ -102,21 +98,21 @@ aUnfilteredDerivativeDesc
 aMassDesc
   = foldlSent
       [S "The", phrase mass,
-       S "of the spring in the mass-spring-damper system ",
+       S "of the spring in the mass-spring-damper system",
        sParen (makeRef2S aPwrPlant),
-       S " is assumed to be 1", 
+       S "is assumed to be 1", 
        phrase kilogram]
 
 aDampingCoeffDesc
   = foldlSent
       [S "The", phrase ccDampingCoeff,
-       S "of the spring in the mass-spring-damper system ",
+       S "of the spring in the mass-spring-damper system",
        sParen (makeRef2S aPwrPlant), 
-       S " is assumed to be 1"]
+       S "is assumed to be 1"]
 
 aStiffnessCoeffDesc
   = foldlSent
       [S "The", phrase ccStiffCoeff,
-       S " of the spring in the mass-spring-damper system ",
+       S "of the spring in the mass-spring-damper system",
        sParen (makeRef2S aPwrPlant), 
-       S ") is assumed to be 20"]
+       S "is assumed to be 20"]

--- a/code/drasil-example/Drasil/PDController/Body.hs
+++ b/code/drasil-example/Drasil/PDController/Body.hs
@@ -71,9 +71,9 @@ mkSRS
           IChar introUserChar1 introUserChar2 [],
           IOrgSec introDocOrg IDict.dataDefn (SRS.inModel [] [])
             (S "The instance model referred as" +:+ makeRef2S imPD +:+
-               S " provides an"
-               +:+ S "Ordinary Differential Equation (ODE) that "
-               +:+ S " models the"
+               S "provides an"
+               +:+ S "Ordinary Differential Equation (ODE) that"
+               +:+ S "models the"
                +:+ phrase pidC)],
      GSDSec $
        GSDProg

--- a/code/drasil-example/Drasil/PDController/Changes.hs
+++ b/code/drasil-example/Drasil/PDController/Changes.hs
@@ -17,8 +17,8 @@ likeChgPP = cic "likeChgPP" likeChgPPDesc "DC Gain and Time Constant" likeChgDom
 likeChgPPDesc :: Sentence
 likeChgPPDesc
   = foldlSent
-      [S "The", phrase mass, S ", ", phrase ccDampingCoeff, S " and the",
+      [S "The", phrase mass `sC` phrase ccDampingCoeff, S "and the",
        phrase ccStiffCoeff,
-       S "may be changed to be supplied by the user (from ",
+       S "may be changed to be supplied by the user", sParen (S "from" +:+
        foldlList Comma List [makeRef2S aMass, makeRef2S aDampingCoeff,
-       makeRef2S aStiffnessCoeff] <> S ")"]
+       makeRef2S aStiffnessCoeff])]

--- a/code/drasil-example/Drasil/PDController/DataDefs.hs
+++ b/code/drasil-example/Drasil/PDController/DataDefs.hs
@@ -31,17 +31,14 @@ ddErrSigNote
       [S "The Process Error is the difference between the Set-Point and " +:+.
          S "Process Variable",
        S "The equation is converted to the frequency" +:+
-         S "domain by applying the Laplace transform (from "
-         <> makeRef2S tmLaplace
-         <> (S ")" !.),
+         S "domain by applying the Laplace transform" +:+. sParen (S "from" +:+
+         makeRef2S tmLaplace),
        S "The Set-Point is assumed to be constant throughout the" +:+
-         S "simulation (from "
-         <> makeRef2S aSP
-         <> (S ")" !.),
+         S "simulation" +:+. sParen (S "from" +:+
+         makeRef2S aSP),
        S "The initial value of the Process Variable is assumed" +:+
-         S "to be zero (from "
-         <> makeRef2S aInitialValue
-         <> S ")"]
+         S "to be zero", sParen (S "from" +:+
+         makeRef2S aInitialValue)]
 
 ----------------------------------------------
 
@@ -59,14 +56,12 @@ ddPropCtrlEqn = sy qdPropGain * sy qdProcessErrorFD
 ddPropCtrlNote :: Sentence
 ddPropCtrlNote
   = foldlSent
-      [S "The Proportional Controller is the product of the Proportional Gain"
-         +:+ S "and the Process Error (from "
-         <> makeRef2S ddErrSig
-         <> (S ")" !.),
-       S "The equation is converted to the frequency" +:+
-         S "domain by applying the Laplace transform (from "
-         <> makeRef2S tmLaplace
-         <> S ")"]
+      [S "The Proportional Controller is the product of the Proportional Gain",
+         S "and the Process Error" +:+. sParen (S "from" +:+
+         makeRef2S ddErrSig),
+       S "The equation is converted to the frequency",
+         S "domain by applying the Laplace transform", sParen (S "from" +:+
+         makeRef2S tmLaplace)]
 
 ----------------------------------------------
 
@@ -85,19 +80,16 @@ ddDerivCtrlEqn
 ddDerivCtrlNote :: Sentence
 ddDerivCtrlNote
   = foldlSent
-      [S "The Derivative Controller is the product of the Derivative Gain" +:+
-         S "and the differential of the Process Error (from "
-         <> makeRef2S ddErrSig
-         <> (S ")" !.),
-       S "The equation is" +:+ S "converted to the frequency" +:+
-         S "domain by applying the Laplace"
-         +:+ S "transform (from "
-         <> makeRef2S tmLaplace
-         <> (S ")" !.),
-       S "A pure form of the Derivative controller is used in this" +:+
-         S "application (from "
-         <> makeRef2S aUnfilteredDerivative
-         <> S ")"]
+      [S "The Derivative Controller is the product of the Derivative Gain",
+         S "and the differential of the Process Error" +:+. sParen (S "from" +:+
+         makeRef2S ddErrSig),
+       S "The equation is converted to the frequency",
+         S "domain by applying the Laplace",
+         S "transform" +:+. sParen (S "from" +:+
+         makeRef2S tmLaplace),
+       S "A pure form of the Derivative controller is used in this",
+         S "application", sParen (S "from" +:+
+         makeRef2S aUnfilteredDerivative)]
 
 ----------------------------------------------
 
@@ -117,14 +109,14 @@ ddCtrlNote :: Sentence
 ddCtrlNote
   = foldlSent
       [(S "The Control Variable is the output of the controller" !.),
-       S "In this case," +:+ S "it is the sum of the Proportional (from " <>
-         makeRef2S ddPropCtrl
-         <> S ") and Derivative (from "
-         <> makeRef2S ddDerivCtrl
-         <> (S ") controllers" !.),
-       S "The parallel (from " <> makeRef2S aParallelEq <>
-         S ") and de-coupled (from "
-         <> makeRef2S aDecoupled
-         <> S ") form of the PD equation is"
-         +:+ S "used in this document"]
+       S "In this case" `sC` S "it is the sum of the Proportional", sParen (S "from" +:+
+         makeRef2S ddPropCtrl),
+         S "and Derivative", sParen (S "from" +:+
+         makeRef2S ddDerivCtrl) +:+.
+         S "controllers",
+       S "The parallel", sParen (S "from" +:+ makeRef2S aParallelEq),
+         S "and de-coupled", sParen (S "from" +:+
+         makeRef2S aDecoupled),
+         S "form of the PD equation is",
+         S "used in this document"]
 

--- a/code/drasil-example/Drasil/PDController/GenDefs.hs
+++ b/code/drasil-example/Drasil/PDController/GenDefs.hs
@@ -38,33 +38,29 @@ gdPowerPlantEqn
 gdPowerPlantNote :: Sentence
 gdPowerPlantNote
   = foldlSent
-      [S "The " +:+ phrase ccTransferFxn +:+ S "of the" +:+
-         phrase secondOrderSystem
-         +:+ S "(from "
-         <> makeRef2S tmSOSystem
-         <> S ") is reduced to this equation by substituting the"
-         +:+ phrase mass
-         +:+ S "(m)"
-         +:+ S "to 1 Kg (from "
-         <> makeRef2S aMass
-         <> S "), the"
-         +:+ phrase ccDampingCoeff
-         +:+ S "("
-         <> P symDampingCoeff
-         <> S ") to 1 (from "
-         <> makeRef2S aDampingCoeff
-         <> S "), and the"
-         +:+ phrase ccStiffCoeff
-         +:+ S "("
-         <> P symStifnessCoeff
-         <> S ") to 20 (from "
-         <> makeRef2S aStiffnessCoeff
-         <> S "). The equation is" +:+ S "converted to the frequency" +:+
-         S "domain by applying the Laplace"
-         +:+ S "transform (from "
-         <> makeRef2S tmLaplace
-         <> (S ")" !.),
-       S "Additionally, there are no external disturbances to the power plant"
-         +:+ S "(from "
-         <> makeRef2S aExtDisturb
-         <> S ")"]
+      [S "The ", phrase ccTransferFxn `ofThe`
+         phrase secondOrderSystem,
+         sParen (S "from" +:+
+         makeRef2S tmSOSystem),
+         S "is reduced to this equation by substituting the",
+         phrase mass,
+         S "(m)",
+         S "to 1 Kg", sParen (S "from" +:+
+         makeRef2S aMass) `sC`
+         S "the",
+         phrase ccDampingCoeff,
+         sParen (P symDampingCoeff),
+         S "to 1", sParen (S "from" +:+
+         makeRef2S aDampingCoeff) `sC`
+         S "and the",
+         phrase ccStiffCoeff,
+         sParen (P symStifnessCoeff),
+         S "to 20" +:+. sParen (S "from" +:+
+         makeRef2S aStiffnessCoeff),
+         S "The equation is converted to the frequency",
+         S "domain by applying the Laplace",
+         S "transform" +:+. sParen (S "from" +:+
+         makeRef2S tmLaplace),
+       S "Additionally, there are no external disturbances to the power plant",
+         sParen (S "from" +:+
+         makeRef2S aExtDisturb)]

--- a/code/drasil-example/Drasil/PDController/GenSysDesc.hs
+++ b/code/drasil-example/Drasil/PDController/GenSysDesc.hs
@@ -16,22 +16,22 @@ gsdSysContextFig
 gsdSysContextP1, gsdSysContextP2 :: Contents
 gsdSysContextP1
   = foldlSP
-      [makeRef2S gsdSysContextFig +:+ S "shows the" +:+. phrase sysCont,
-       S "The circle represents an external entity outside the" +:+
+      [makeRef2S gsdSysContextFig, S "shows the" +:+. phrase sysCont,
+       S "The circle represents an external entity outside the",
          phrase software
          `sC` S "the",
-       phrase user, S "in this case. The rectangle represents the",
-       phrase softwareSys, S "itself,", phrase pidC +:+. S "in this case",
-       S "Arrows are used to show the data flow between the" +:+ phrase system,
-       S "and its" +:+ phrase environment]
+       phrase user +:+. S "in this case", S "The rectangle represents the",
+       phrase softwareSys, S "itself" `sC` phrase pidC +:+. S "in this case",
+       S "Arrows are used to show the data flow between the", phrase system,
+       S "and its", phrase environment]
 
 gsdSysContextP2
   = foldlSPCol
-      [phrase pidC +:+ S " is self-contained. The only external interaction is "
-         +:+. S " with the user",
-       S "The responsibilities of the " +:+ phrase user +:+ S " and the " +:+
-         phrase system
-         +:+ S " are as follows"]
+      [phrase pidC, S "is self-contained. The only external interaction is"
+         +:+. S "with the user",
+       S "The responsibilities of the", phrase user,S "and the",
+         phrase system,
+         S "are as follows"]
 
 gsdTitle :: [Sentence]
 gsdTitle
@@ -41,13 +41,13 @@ gsdTitle
 gsdUsrResp :: [Sentence]
 gsdUsrResp
   = [S "Feed inputs to the model",
-     S "Review the response of the " +:+ phrase powerPlant,
+     S "Review the response of the" +:+ phrase powerPlant,
      S "Tune the controller gains"]
 
 gsdSysResp :: [Sentence]
 gsdSysResp
   = [S "Check the validity of the inputs",
-     S "Calculate the outputs of the " +:+ phrase pidC +:+ S " and " +:+
+     S "Calculate the outputs of the" +:+ phrase pidC +:+ S "and" +:+
        phrase powerPlant]
 
 gsdSysContextList :: Contents
@@ -60,6 +60,6 @@ gsdSysContextList
 gsduserCharacteristics :: Contents
 gsduserCharacteristics
   = foldlSP
-      [S "The end-user of " +:+ phrase pidC +:+
-         S " is expected to have taken a course on Control Systems at an "
-         +:+ S "undergraduate level"]
+      [S "The end-user of", phrase pidC,
+         S "is expected to have taken a course on Control Systems at an",
+         S "undergraduate level"]

--- a/code/drasil-example/Drasil/PDController/IModel.hs
+++ b/code/drasil-example/Drasil/PDController/IModel.hs
@@ -60,13 +60,12 @@ derivStmt1 :: Sentence
 derivStmt1
   = foldlSent
       [S "The Process Variable (Y(S)) in a" +:+ phrase pidCL +:+
-         S "is the product of the Process Error (from "
-         <> makeRef2S ddErrSig
-         <> S "), Control Variable (from "
-         <> makeRef2S ddCtrlVar
-         <> S "), and the Power-Plant (from "
-         <> makeRef2S gdPowerPlant
-         <> S ")"]
+         S "is the product of the Process Error", sParen (S "from" +:+
+         makeRef2S ddErrSig) `sC`
+         S "Control Variable", sParen (S "from" +:+
+         makeRef2S ddCtrlVar) `sC`
+         S "and the Power-Plant", sParen (S "from" +:+
+          makeRef2S gdPowerPlant)]
 
 derivEqn1 :: Expr
 derivEqn1
@@ -76,7 +75,7 @@ derivEqn1
       * (1 / (square (sy qdFreqDomain) + sy qdFreqDomain + 20))
 
 derivStmt2 :: Sentence
-derivStmt2 = foldlSent [S "Substituting the values and rearranging the equation"]
+derivStmt2 = (S "Substituting the values and rearranging the equation" !.)
 
 derivEqn2 :: Expr
 derivEqn2
@@ -88,9 +87,9 @@ derivEqn2
 
 derivStmt3 :: Sentence
 derivStmt3
-  = S "Computing the" +:+ phrase qdInvLaplaceTransform +:+ S "(from " <>
-      makeRef2S tmInvLaplace
-      <> (S ") of the equation" !.)
+  = S "Computing the" +:+ phrase qdInvLaplaceTransform +:+ sParen (S "from" +:+
+      makeRef2S tmInvLaplace) +:+
+      (S "of the equation" !.)
 
 derivEqn3 :: Expr
 derivEqn3
@@ -103,13 +102,11 @@ derivEqn3
 derivStmt4 :: Sentence
 derivStmt4
   = foldlSent_
-      [S "The Set point (r(t)) is a step function, and a constant " +:+
-         S "(from "
-         <> makeRef2S aSP
-         <> (S ")" !.),
-       S "Therefore the" +:+
-         S " differential of the set point is zero. Hence the equation "
-         +:+ S "reduces to,"]
+      [S "The Set point (r(t)) is a step function, and a constant" +:+.
+         sParen (S "from" +:+ makeRef2S aSP),
+       S "Therefore the",
+         S "differential of the set point is zero. Hence the equation",
+         S "reduces to,"]
 
 derivEqn4 :: Expr
 derivEqn4

--- a/code/drasil-example/Drasil/PDController/IntroSection.hs
+++ b/code/drasil-example/Drasil/PDController/IntroSection.hs
@@ -9,37 +9,35 @@ import Utils.Drasil
 introPara, introPurposeOfDoc, introscopeOfReq :: Sentence
 introPara
   = foldlSent
-      [S "Automatic process control with a controller (P/PI/PD/PID) is used "
-         +:+ S "in a variety of applications such as thermostats, automobile "
-         +:+
-         S "cruise-control, etc. The gains of a controller in an application "
-         +:+. S "must be tuned before the controller is ready for production",
-       S "Therefore a simulation of the " +:+ phrase pidC +:+ S " with a " +:+
-         phrase secondOrderSystem
-         +:+ S "is created in this project that can be "
-         +:+ S "used to tune the gain constants"]
+      [S "Automatic process control with a controller (P/PI/PD/PID) is used",
+         S "in a variety of applications such as thermostats, automobile",
+         S "cruise-control, etc. The gains of a controller in an application" +:+. 
+         S "must be tuned before the controller is ready for production",
+       S "Therefore a simulation of the", phrase pidC, S "with a",
+         phrase secondOrderSystem,
+         S "is created in this project that can be",
+         S "used to tune the gain constants"]
 
 introscopeOfReq
   = foldlSent_
       [S "a", phrase pidCL,
-       S " with three subsystems namely a " +:+.
+       S "with three subsystems namely a" +:+.
          foldlList Comma List
            [phrase pidC, S "a" +:+ phrase summingPt,
             S "a" +:+ phrase powerPlant],
-       S "Only " +:+
+       S "Only",
          S "the Proportional and Derivative controllers are used in this software;"
-         +:+. S " the Integral controller is beyond the scope of this project"
-         +:+ S "Additionally, this software is intended to aid with the manual "
-         +:+ S "tuning of the",
+         +:+. S "the Integral controller is beyond the scope of this project",
+         S "Additionally, this software is intended to aid with the manual",
+         S "tuning of the",
        phrase pidC]
 
 introPurposeOfDoc
   = foldlSent
-      [S "The purpose of this document is to capture all the necessary " +:+
-         S "information including assumptions, data definitions, constraints, "
-         +:+
-         S "models, and requirements to facilitate an unambiguous development "
-         +:+ S "of the PD controller software and test procedures"]
+      [S "The purpose of this document is to capture all the necessary",
+         S "information including assumptions, data definitions, constraints,",
+         S "models, and requirements to facilitate an unambiguous development",
+         S "of the PD controller software and test procedures"]
 
 introUserChar1, introUserChar2 :: [Sentence]
 introUserChar1
@@ -50,5 +48,5 @@ introUserChar2
 introDocOrg :: Sentence
 introDocOrg
   = foldlSent
-      [S "The sections in this document are based on " +:+
+      [S "The sections in this document are based on",
          makeCiteS smithLai2005]

--- a/code/drasil-example/Drasil/PDController/Requirements.hs
+++ b/code/drasil-example/Drasil/PDController/Requirements.hs
@@ -1,3 +1,4 @@
+{-#LANGUAGE PostfixOperators#-}
 module Drasil.PDController.Requirements where
 
 import Data.Drasil.Concepts.Documentation (funcReqDom, nonFuncReqDom)
@@ -24,23 +25,21 @@ verifyInputsDesc, calculateValuesDesc, outputValuesDesc :: Sentence
 
 verifyInputsDesc
   = foldlSent_
-      [S "Ensure that the input values are within the" +:+
+      [S "Ensure that the input values are within the",
          S "limits specified in"
          +:+. makeRef2S (datCon ([] :: [Contents]) ([] :: [Section]))]
 
 calculateValuesDesc
   = foldlSent
-      [S "Calculate the" +:+ phrase processVariable +:+ S "(from " <>
-         makeRef2S imPD
-         <> S ") over "
-         +:+ S "the simulation time"]
+      [S "Calculate the", phrase processVariable, sParen (S "from" +:+
+         makeRef2S imPD),
+         S "over the simulation time"]
 
 outputValuesDesc
   = foldlSent
-      [S "Output the" +:+ phrase processVariable +:+ S "(from " <>
-         makeRef2S imPD
-         <> S ") over "
-         +:+ S "the simulation time"]
+      [S "Output the", phrase processVariable, sParen (S "from" +:+
+         makeRef2S imPD),
+         S "over the simulation time"]
 
 -----------------------------------------------------------------------------
 
@@ -50,7 +49,7 @@ nonfuncReqs = [portability, security, maintainability, verifiability]
 portability :: ConceptInstance
 portability
   = cic "portability"
-      (foldlSent [S "The code shall be portable to multiple Operating Systems"])
+      (S "The code shall be portable to multiple Operating Systems" !.)
       "Portable"
       nonFuncReqDom
 
@@ -58,8 +57,7 @@ security :: ConceptInstance
 security
   = cic "security"
       (foldlSent
-         [S "The code shall be immune to common security problems such as memory"
-            +:+
+         [S "The code shall be immune to common security problems such as memory",
             S "leaks, divide by zero errors, and the square root of negative numbers"])
       "Secure"
       nonFuncReqDom
@@ -68,9 +66,8 @@ maintainability :: ConceptInstance
 maintainability
   = cic "maintainability"
       (foldlSent
-         [S "The dependencies among the instance models, requirements," +:+
-            S "likely changes, assumptions and all other relevant sections of"
-            +:+
+         [S "The dependencies among the instance models, requirements,",
+            S "likely changes, assumptions and all other relevant sections of",
             S "this document shall be traceable to each other in the trace matrix"])
       "Maintainable"
       nonFuncReqDom
@@ -78,8 +75,7 @@ maintainability
 verifiability :: ConceptInstance
 verifiability
   = cic "verifiability"
-      (foldlSent
-         [S "The code shall be verifiable against a Verification and Validation plan"])
+      (S "The code shall be verifiable against a Verification and Validation plan" !.)
       "Verifiable"
       nonFuncReqDom
 

--- a/code/drasil-example/Drasil/PDController/SpSysDesc.hs
+++ b/code/drasil-example/Drasil/PDController/SpSysDesc.hs
@@ -9,9 +9,9 @@ import Utils.Drasil
 sysProblemDesc :: Sentence
 sysProblemDesc
   = foldlSent_
-      [S "provide a model of a" +:+ phrase pidC +:+
-         S " that can be used for the tuning of the gain constants before"
-         +:+ S " the deployment of the controller"]
+      [S "provide a model of a", phrase pidC,
+         S "that can be used for the tuning of the gain constants before",
+         S "the deployment of the controller"]
 
 sysParts :: [Sentence]
 sysParts
@@ -38,9 +38,9 @@ sysProcessVariable :: ConceptInstance
 sysProcessVariable
   = cic "processVariable"
       (foldlSent
-         [S "Calculate the" +:+ S "output of the" +:+ phrase powerPlant +:+
-            sParen (phrase processVariable)
-            +:+ S " over time"])
+         [S "Calculate the", S "output of the", phrase powerPlant,
+            sParen (phrase processVariable),
+            S "over time"])
       "Process-Variable"
       goalStmtDom
 

--- a/code/drasil-example/Drasil/PDController/TModel.hs
+++ b/code/drasil-example/Drasil/PDController/TModel.hs
@@ -42,11 +42,9 @@ laplaceDesc :: Sentence
 laplaceDesc
   = foldlSent
       [(S "Bilateral Laplace Transform" !.),
-       S "The Laplace transforms are " +:+
-         S "typically inferred from a pre-computed table of Laplace Transforms"
-         +:+ S " ("
-         <> makeCiteS laplaceWiki
-         <> S ")"]
+       S "The Laplace transforms are",
+         S "typically inferred from a pre-computed table of Laplace Transforms",
+         sParen (makeCiteS laplaceWiki)]
 
 --------
 
@@ -74,11 +72,9 @@ invLaplaceDesc :: Sentence
 invLaplaceDesc
   = foldlSent
       [(S "Inverse Laplace Transform of F(S)" !.),
-       S "The Inverse Laplace transforms are " +:+
-         S "typically inferred from a pre-computed table of Laplace Transforms"
-         +:+ S " ("
-         <> makeCiteS laplaceWiki
-         <> S ")"]
+       S "The Inverse Laplace transforms are",
+         S "typically inferred from a pre-computed table of Laplace Transforms",
+         sParen (makeCiteS laplaceWiki)]
 
 --------
 
@@ -109,10 +105,10 @@ soSystemRel
 soSystemDesc :: Sentence
 soSystemDesc
   = foldlSent
-      [S "The ", phrase ccTransferFxn, 
-        S "(from " <> makeRef2S apwrPlantTxFnx <> S ")",
+      [S "The", phrase ccTransferFxn, 
+        sParen (S "from" +:+ makeRef2S apwrPlantTxFnx),
         S "of a", phrase secondOrderSystem,
-        S "(mass-spring-damper)", 
+        sParen (S "mass-spring-damper"), 
         S "is characterized by this equation"]
 
        --------

--- a/code/stable/pdController/SRS/PDController_SRS.tex
+++ b/code/stable/pdController/SRS/PDController_SRS.tex
@@ -163,17 +163,17 @@ Uncert. & Typical Uncertainty
 \end{longtable}
 \section{Introduction}
 \label{Sec:Intro}
-Automatic process control with a controller (P/PI/PD/PID) is used  in a variety of applications such as thermostats, automobile  cruise-control, etc. The gains of a controller in an application  must be tuned before the controller is ready for production. Therefore a simulation of the  PD Controller  with a  Second Order System is created in this project that can be  used to tune the gain constants.
+Automatic process control with a controller (P/PI/PD/PID) is used in a variety of applications such as thermostats, automobile cruise-control, etc. The gains of a controller in an application must be tuned before the controller is ready for production. Therefore a simulation of the PD Controller with a Second Order System is created in this project that can be used to tune the gain constants.
 
 The following section provides an overview of the Software Requirements Specification (SRS) for PD Controller. This section explains the purpose of this document, the scope of the requirements, the characteristics of the intended reader, and the organization of the document.
 
 \subsection{Purpose of Document}
 \label{Sec:DocPurpose}
-The purpose of this document is to capture all the necessary  information including assumptions, data definitions, constraints,  models, and requirements to facilitate an unambiguous development  of the PD controller software and test procedures.
+The purpose of this document is to capture all the necessary information including assumptions, data definitions, constraints, models, and requirements to facilitate an unambiguous development of the PD controller software and test procedures.
 
 \subsection{Scope of Requirements}
 \label{Sec:ReqsScope}
-The scope of the requirements includes a PD Control Loop  with three subsystems namely a  PD Controller, a Summing Point, and a Power Plant. Only  the Proportional and Derivative controllers are used in this software;  the Integral controller is beyond the scope of this project. Additionally, this software is intended to aid with the manual  tuning of the PD Controller.
+The scope of the requirements includes a PD Control Loop with three subsystems namely a PD Controller, a Summing Point, and a Power Plant. Only the Proportional and Derivative controllers are used in this software; the Integral controller is beyond the scope of this project. Additionally, this software is intended to aid with the manual tuning of the PD Controller.
 
 \subsection{Characteristics of Intended Reader}
 \label{Sec:ReaderChars}
@@ -181,9 +181,9 @@ Reviewers of this documentation should have an understanding of control systems 
 
 \subsection{Organization of Document}
 \label{Sec:DocOrg}
-The sections in this document are based on  \cite{smithLai2005}. The presentation follows the standard pattern of presenting goals, theories, definitions, and assumptions. For readers that would like a more bottom up approach, they can start reading the data definitions in \hyperref[Sec:IMs]{Section: Instance Models} and trace back to find any additional information they require.
+The sections in this document are based on \cite{smithLai2005}. The presentation follows the standard pattern of presenting goals, theories, definitions, and assumptions. For readers that would like a more bottom up approach, they can start reading the data definitions in \hyperref[Sec:IMs]{Section: Instance Models} and trace back to find any additional information they require.
 
-The goal statements (\hyperref[Sec:GoalStmt]{Section: Goal Statements}) are refined to the theoretical models and the theoretical models (\hyperref[Sec:TMs]{Section: Theoretical Models}) to the instance models (\hyperref[Sec:IMs]{Section: Instance Models}). The instance model referred as \hyperref[IM:pdEquationIM]{IM: pdEquationIM}  provides an Ordinary Differential Equation (ODE) that   models the PD Controller.
+The goal statements (\hyperref[Sec:GoalStmt]{Section: Goal Statements}) are refined to the theoretical models and the theoretical models (\hyperref[Sec:TMs]{Section: Theoretical Models}) to the instance models (\hyperref[Sec:IMs]{Section: Instance Models}). The instance model referred as \hyperref[IM:pdEquationIM]{IM: pdEquationIM} provides an Ordinary Differential Equation (ODE) that models the PD Controller.
 
 \section{General System Description}
 \label{Sec:GenSysDesc}
@@ -200,24 +200,24 @@ This section provides general information about the system. It identifies the in
 \label{Figure:systemContextDiag}
 \end{center}
 \end{figure}
-PD Controller  is self-contained. The only external interaction is   with the user. The responsibilities of the  user  and the  system  are as follows:
+PD Controller is self-contained. The only external interaction is with the user. The responsibilities of the user and the system are as follows:
 
 \begin{itemize}
 \item{User Responsibilities}
 \begin{itemize}
 \item{Feed inputs to the model}
-\item{Review the response of the  Power Plant}
+\item{Review the response of the Power Plant}
 \item{Tune the controller gains}
 \end{itemize}
 \item{PD Controller Responsibilities}
 \begin{itemize}
 \item{Check the validity of the inputs}
-\item{Calculate the outputs of the  PD Controller  and  Power Plant}
+\item{Calculate the outputs of the PD Controller and Power Plant}
 \end{itemize}
 \end{itemize}
 \subsection{User Characteristics}
 \label{Sec:UserChars}
-The end-user of  PD Controller  is expected to have taken a course on Control Systems at an  undergraduate level.
+The end-user of PD Controller is expected to have taken a course on Control Systems at an undergraduate level.
 
 \subsection{System Constraints}
 \label{Sec:SysConstraints}
@@ -229,7 +229,7 @@ This section first presents the problem description, which gives a high-level vi
 
 \subsection{Problem Description}
 \label{Sec:ProbDesc}
-A system is needed to provide a model of a PD Controller  that can be used for the tuning of the gain constants before  the deployment of the controller.
+A system is needed to provide a model of a PD Controller that can be used for the tuning of the gain constants before the deployment of the controller.
 
 \subsubsection{Terminology and Definitions}
 \label{Sec:TermDefs}
@@ -278,7 +278,7 @@ The physical system of PD Controller, as shown in \hyperref[Figure:pidSysDiagram
 Given Set-Point, Simulation Time, Proportional Gain, Derivative Gain, and Step Time, the goal statements are:
 
 \begin{itemize}
-\item[Process-Variable:\phantomsection\label{processVariable}]{Calculate the output of the Power Plant (Process Variable)  over time.}
+\item[Process-Variable:\phantomsection\label{processVariable}]{Calculate the output of the Power Plant (Process Variable) over time.}
 \end{itemize}
 \subsection{Solution Characteristics Specification}
 \label{Sec:SolCharSpec}
@@ -296,10 +296,10 @@ This section simplifies the original problem and helps in developing the theoret
 \item[Initial Value:\phantomsection\label{initialValue}]{The initial value of the Process Variable is assumed to be zero. (RefBy: \hyperref[DD:ddProcessError]{DD: ddProcessError}.)}
 \item[Parallel Equation:\phantomsection\label{parallelEq}]{The Parallel form of the equation is used for the PD Controller. (RefBy: \hyperref[DD:ddCtrlVar]{DD: ddCtrlVar}.)}
 \item[Unfiltered Derivative:\phantomsection\label{unfilteredDerivative}]{A pure derivative function is used for this simulation; there are no filters applied. (RefBy: \hyperref[DD:ddDerivCtrl]{DD: ddDerivCtrl}.)}
-\item[Transfer Function:\phantomsection\label{pwrPlantTxFnx}]{The combined Power Plant and Sensor  (\hyperref[pwrPlant]{A: Power plant})  are characterized by a Second Order mass-spring-damper  System. (RefBy: \hyperref[TM:tmSOSystem]{TM: tmSOSystem}.)}
-\item[Spring Mass:\phantomsection\label{massSpring}]{The mass of the spring in the mass-spring-damper system  (\hyperref[pwrPlant]{A: Power plant})  is assumed to be 1 kilogram. (RefBy: \hyperref[likeChgPP]{LC: DC Gain and Time Constant} and \hyperref[GD:gdPowerPlant]{GD: gdPowerPlant}.)}
-\item[Spring Damping Coefficient:\phantomsection\label{dampingCoeffSpring}]{The Damping Coefficient of the spring in the mass-spring-damper system  (\hyperref[pwrPlant]{A: Power plant})  is assumed to be 1. (RefBy: \hyperref[likeChgPP]{LC: DC Gain and Time Constant} and \hyperref[GD:gdPowerPlant]{GD: gdPowerPlant}.)}
-\item[Spring Stiffness Coefficient:\phantomsection\label{stiffnessCoeffSpring}]{The Stiffness Coefficient  of the spring in the mass-spring-damper system  (\hyperref[pwrPlant]{A: Power plant}) ) is assumed to be 20. (RefBy: \hyperref[likeChgPP]{LC: DC Gain and Time Constant} and \hyperref[GD:gdPowerPlant]{GD: gdPowerPlant}.)}
+\item[Transfer Function:\phantomsection\label{pwrPlantTxFnx}]{The combined Power Plant and Sensor (\hyperref[pwrPlant]{A: Power plant}) are characterized by a Second Order mass-spring-damper System. (RefBy: \hyperref[TM:tmSOSystem]{TM: tmSOSystem}.)}
+\item[Spring Mass:\phantomsection\label{massSpring}]{The mass of the spring in the mass-spring-damper system (\hyperref[pwrPlant]{A: Power plant}) is assumed to be 1 kilogram. (RefBy: \hyperref[likeChgPP]{LC: DC Gain and Time Constant} and \hyperref[GD:gdPowerPlant]{GD: gdPowerPlant}.)}
+\item[Spring Damping Coefficient:\phantomsection\label{dampingCoeffSpring}]{The Damping Coefficient of the spring in the mass-spring-damper system (\hyperref[pwrPlant]{A: Power plant}) is assumed to be 1. (RefBy: \hyperref[likeChgPP]{LC: DC Gain and Time Constant} and \hyperref[GD:gdPowerPlant]{GD: gdPowerPlant}.)}
+\item[Spring Stiffness Coefficient:\phantomsection\label{stiffnessCoeffSpring}]{The Stiffness Coefficient of the spring in the mass-spring-damper system (\hyperref[pwrPlant]{A: Power plant}) is assumed to be 20. (RefBy: \hyperref[likeChgPP]{LC: DC Gain and Time Constant} and \hyperref[GD:gdPowerPlant]{GD: gdPowerPlant}.)}
 \end{itemize}
 \subsubsection{Theoretical Models}
 \label{Sec:TMs}
@@ -327,7 +327,7 @@ Description & \begin{symbDescription}
               \item{$t$ is the time (${\text{s}}$)}
               \end{symbDescription}
 \\ \midrule \\
-Notes & Bilateral Laplace Transform. The Laplace transforms are  typically inferred from a pre-computed table of Laplace Transforms  (\cite{laplaceWiki}).
+Notes & Bilateral Laplace Transform. The Laplace transforms are typically inferred from a pre-computed table of Laplace Transforms (\cite{laplaceWiki}).
         
 \\ \midrule \\
 Source & \cite{laplaceWiki}
@@ -358,7 +358,7 @@ Description & \begin{symbDescription}
               \item{$L⁻¹[F(s)]$ is the Inverse Laplace Transform of a function (Unitless)}
               \end{symbDescription}
 \\ \midrule \\
-Notes & Inverse Laplace Transform of F(S). The Inverse Laplace transforms are  typically inferred from a pre-computed table of Laplace Transforms  (\cite{laplaceWiki}).
+Notes & Inverse Laplace Transform of F(S). The Inverse Laplace transforms are typically inferred from a pre-computed table of Laplace Transforms (\cite{laplaceWiki}).
         
 \\ \midrule \\
 Source & \cite{laplaceWiki}
@@ -391,7 +391,7 @@ Description & \begin{symbDescription}
               \item{$k$ is the Stiffness coefficient of the spring (${\text{s}}$)}
               \end{symbDescription}
 \\ \midrule \\
-Notes & The  Transfer Function (from \hyperref[pwrPlantTxFnx]{A: Transfer Function}) of a Second Order System (mass-spring-damper) is characterized by this equation.
+Notes & The Transfer Function (from \hyperref[pwrPlantTxFnx]{A: Transfer Function}) of a Second Order System (mass-spring-damper) is characterized by this equation.
         
 \\ \midrule \\
 Source & \cite{abbasi2015}
@@ -671,7 +671,7 @@ Computing the Inverse Laplace Transform of a function (from \hyperref[TM:invLapl
 \begin{displaymath}
 \frac{\,d\frac{\,d{y_{\text{t}}}}{\,dt}}{\,dt}+\left(1+{K_{\text{d}}}\right) \frac{\,d{y_{\text{t}}}}{\,dt}+\left(20+{K_{\text{p}}}\right) {y_{\text{t}}}-{K_{\text{d}}} \frac{\,d{r_{\text{t}}}}{\,dt}-{r_{\text{t}}} {K_{\text{p}}}=0
 \end{displaymath}
-The Set point (r(t)) is a step function, and a constant  (from \hyperref[setPoint]{A: Set-Point}). Therefore the  differential of the set point is zero. Hence the equation  reduces to,
+The Set point (r(t)) is a step function, and a constant (from \hyperref[setPoint]{A: Set-Point}). Therefore the differential of the set point is zero. Hence the equation reduces to,
 
 \begin{displaymath}
 \frac{\,d\frac{\,d{y_{\text{t}}}}{\,dt}}{\,dt}+\left(1+{K_{\text{d}}}\right) \frac{\,d{y_{\text{t}}}}{\,dt}+\left(20+{K_{\text{p}}}\right) {y_{\text{t}}}-{r_{\text{t}}} {K_{\text{p}}}=0
@@ -711,8 +711,8 @@ This section provides the functional requirements, the tasks and behaviours that
 \begin{itemize}
 \item[Input-Values:\phantomsection\label{inputValues}]{Input the values from \hyperref[Table:ReqInputs]{Table:ReqInputs}.}
 \item[Verify-Input-Values:\phantomsection\label{verifyInputs}]{Ensure that the input values are within the limits specified in \hyperref[Sec:DataConstraints]{Section: Data Constraints}.}
-\item[Calculate-Values:\phantomsection\label{calculateValues}]{Calculate the Process Variable (from \hyperref[IM:pdEquationIM]{IM: pdEquationIM}) over  the simulation time.}
-\item[Output-Values:\phantomsection\label{outputValues}]{Output the Process Variable (from \hyperref[IM:pdEquationIM]{IM: pdEquationIM}) over  the simulation time.}
+\item[Calculate-Values:\phantomsection\label{calculateValues}]{Calculate the Process Variable (from \hyperref[IM:pdEquationIM]{IM: pdEquationIM}) over the simulation time.}
+\item[Output-Values:\phantomsection\label{outputValues}]{Output the Process Variable (from \hyperref[IM:pdEquationIM]{IM: pdEquationIM}) over the simulation time.}
 \end{itemize}
 \begin{longtable}{l l l}
 \toprule
@@ -749,7 +749,7 @@ This section provides the non-functional requirements, the qualities that the so
 This section lists the likely changes to be made to the software.
 
 \begin{itemize}
-\item[DC Gain and Time Constant:\phantomsection\label{likeChgPP}]{The mass ,  Damping Coefficient  and the Stiffness Coefficient may be changed to be supplied by the user (from  \hyperref[massSpring]{A: Spring Mass}, \hyperref[dampingCoeffSpring]{A: Spring Damping Coefficient}, and \hyperref[stiffnessCoeffSpring]{A: Spring Stiffness Coefficient}).}
+\item[DC Gain and Time Constant:\phantomsection\label{likeChgPP}]{The mass, Damping Coefficient and the Stiffness Coefficient may be changed to be supplied by the user (from \hyperref[massSpring]{A: Spring Mass}, \hyperref[dampingCoeffSpring]{A: Spring Damping Coefficient}, and \hyperref[stiffnessCoeffSpring]{A: Spring Stiffness Coefficient}).}
 \end{itemize}
 \section{Traceability Matrices and Graphs}
 \label{Sec:TraceMatrices}

--- a/code/stable/pdController/Website/PDController_SRS.html
+++ b/code/stable/pdController/Website/PDController_SRS.html
@@ -280,7 +280,7 @@
       <div class="section">
         <h1>Introduction</h1>
         <p class="paragraph">
-          Automatic process control with a controller (P/PI/PD/PID) is used  in a variety of applications such as thermostats, automobile  cruise-control, etc. The gains of a controller in an application  must be tuned before the controller is ready for production. Therefore a simulation of the  PD Controller  with a  Second Order System is created in this project that can be  used to tune the gain constants.
+          Automatic process control with a controller (P/PI/PD/PID) is used in a variety of applications such as thermostats, automobile cruise-control, etc. The gains of a controller in an application must be tuned before the controller is ready for production. Therefore a simulation of the PD Controller with a Second Order System is created in this project that can be used to tune the gain constants.
         </p>
         <p class="paragraph">
           The following section provides an overview of the Software Requirements Specification (SRS) for PD Controller. This section explains the purpose of this document, the scope of the requirements, the characteristics of the intended reader, and the organization of the document.
@@ -289,7 +289,7 @@
           <div class="subsection">
             <h2>Purpose of Document</h2>
             <p class="paragraph">
-              The purpose of this document is to capture all the necessary  information including assumptions, data definitions, constraints,  models, and requirements to facilitate an unambiguous development  of the PD controller software and test procedures.
+              The purpose of this document is to capture all the necessary information including assumptions, data definitions, constraints, models, and requirements to facilitate an unambiguous development of the PD controller software and test procedures.
             </p>
           </div>
         </div>
@@ -297,7 +297,7 @@
           <div class="subsection">
             <h2>Scope of Requirements</h2>
             <p class="paragraph">
-              The scope of the requirements includes a PD Control Loop  with three subsystems namely a  PD Controller, a Summing Point, and a Power Plant. Only  the Proportional and Derivative controllers are used in this software;  the Integral controller is beyond the scope of this project. Additionally, this software is intended to aid with the manual  tuning of the PD Controller.
+              The scope of the requirements includes a PD Control Loop with three subsystems namely a PD Controller, a Summing Point, and a Power Plant. Only the Proportional and Derivative controllers are used in this software; the Integral controller is beyond the scope of this project. Additionally, this software is intended to aid with the manual tuning of the PD Controller.
             </p>
           </div>
         </div>
@@ -313,10 +313,10 @@
           <div class="subsection">
             <h2>Organization of Document</h2>
             <p class="paragraph">
-              The sections in this document are based on  <a href=#smithLai2005>smithLai2005</a>. The presentation follows the standard pattern of presenting goals, theories, definitions, and assumptions. For readers that would like a more bottom up approach, they can start reading the data definitions in <a href=#Sec:IMs>Section: Instance Models</a> and trace back to find any additional information they require.
+              The sections in this document are based on <a href=#smithLai2005>smithLai2005</a>. The presentation follows the standard pattern of presenting goals, theories, definitions, and assumptions. For readers that would like a more bottom up approach, they can start reading the data definitions in <a href=#Sec:IMs>Section: Instance Models</a> and trace back to find any additional information they require.
             </p>
             <p class="paragraph">
-              The goal statements (<a href=#Sec:GoalStmt>Section: Goal Statements</a>) are refined to the theoretical models and the theoretical models (<a href=#Sec:TMs>Section: Theoretical Models</a>) to the instance models (<a href=#Sec:IMs>Section: Instance Models</a>). The instance model referred as <a href=#IM:pdEquationIM>IM: pdEquationIM</a>  provides an Ordinary Differential Equation (ODE) that   models the PD Controller.
+              The goal statements (<a href=#Sec:GoalStmt>Section: Goal Statements</a>) are refined to the theoretical models and the theoretical models (<a href=#Sec:TMs>Section: Theoretical Models</a>) to the instance models (<a href=#Sec:IMs>Section: Instance Models</a>). The instance model referred as <a href=#IM:pdEquationIM>IM: pdEquationIM</a> provides an Ordinary Differential Equation (ODE) that models the PD Controller.
             </p>
           </div>
         </div>
@@ -341,14 +341,14 @@
               </figure>
             </div>
             <p class="paragraph">
-              PD Controller  is self-contained. The only external interaction is   with the user. The responsibilities of the  user  and the  system  are as follows:
+              PD Controller is self-contained. The only external interaction is with the user. The responsibilities of the user and the system are as follows:
             </p>
             <ul class="list">
               <li>
                 User Responsibilities
                 <ul class="list">
                   <li>Feed inputs to the model</li>
-                  <li>Review the response of the  Power Plant</li>
+                  <li>Review the response of the Power Plant</li>
                   <li>Tune the controller gains</li>
                 </ul>
               </li>
@@ -356,9 +356,7 @@
                 PD Controller Responsibilities
                 <ul class="list">
                   <li>Check the validity of the inputs</li>
-                  <li>
-                    Calculate the outputs of the  PD Controller  and  Power Plant
-                  </li>
+                  <li>Calculate the outputs of the PD Controller and Power Plant</li>
                 </ul>
               </li>
             </ul>
@@ -368,7 +366,7 @@
           <div class="subsection">
             <h2>User Characteristics</h2>
             <p class="paragraph">
-              The end-user of  PD Controller  is expected to have taken a course on Control Systems at an  undergraduate level.
+              The end-user of PD Controller is expected to have taken a course on Control Systems at an undergraduate level.
             </p>
           </div>
         </div>
@@ -390,7 +388,7 @@
           <div class="subsection">
             <h2>Problem Description</h2>
             <p class="paragraph">
-              A system is needed to provide a model of a PD Controller  that can be used for the tuning of the gain constants before  the deployment of the controller.
+              A system is needed to provide a model of a PD Controller that can be used for the tuning of the gain constants before the deployment of the controller.
             </p>
             <div id="Sec:TermDefs">
               <div class="subsubsection">
@@ -478,7 +476,7 @@
                 <div class="list">
                   <p>
                     <div id="processVariable">
-                      Process-Variable: Calculate the output of the Power Plant (Process Variable)  over time.
+                      Process-Variable: Calculate the output of the Power Plant (Process Variable) over time.
                     </div>
                   </p>
                 </div>
@@ -536,22 +534,22 @@
                   </p>
                   <p>
                     <div id="pwrPlantTxFnx">
-                      Transfer Function: The combined Power Plant and Sensor  (<a href=#pwrPlant>A: Power plant</a>)  are characterized by a Second Order mass-spring-damper  System. (RefBy: <a href=#TM:tmSOSystem>TM: tmSOSystem</a>.)
+                      Transfer Function: The combined Power Plant and Sensor (<a href=#pwrPlant>A: Power plant</a>) are characterized by a Second Order mass-spring-damper System. (RefBy: <a href=#TM:tmSOSystem>TM: tmSOSystem</a>.)
                     </div>
                   </p>
                   <p>
                     <div id="massSpring">
-                      Spring Mass: The mass of the spring in the mass-spring-damper system  (<a href=#pwrPlant>A: Power plant</a>)  is assumed to be 1 kilogram. (RefBy: <a href=#likeChgPP>LC: DC Gain and Time Constant</a> and <a href=#GD:gdPowerPlant>GD: gdPowerPlant</a>.)
+                      Spring Mass: The mass of the spring in the mass-spring-damper system (<a href=#pwrPlant>A: Power plant</a>) is assumed to be 1 kilogram. (RefBy: <a href=#likeChgPP>LC: DC Gain and Time Constant</a> and <a href=#GD:gdPowerPlant>GD: gdPowerPlant</a>.)
                     </div>
                   </p>
                   <p>
                     <div id="dampingCoeffSpring">
-                      Spring Damping Coefficient: The Damping Coefficient of the spring in the mass-spring-damper system  (<a href=#pwrPlant>A: Power plant</a>)  is assumed to be 1. (RefBy: <a href=#likeChgPP>LC: DC Gain and Time Constant</a> and <a href=#GD:gdPowerPlant>GD: gdPowerPlant</a>.)
+                      Spring Damping Coefficient: The Damping Coefficient of the spring in the mass-spring-damper system (<a href=#pwrPlant>A: Power plant</a>) is assumed to be 1. (RefBy: <a href=#likeChgPP>LC: DC Gain and Time Constant</a> and <a href=#GD:gdPowerPlant>GD: gdPowerPlant</a>.)
                     </div>
                   </p>
                   <p>
                     <div id="stiffnessCoeffSpring">
-                      Spring Stiffness Coefficient: The Stiffness Coefficient  of the spring in the mass-spring-damper system  (<a href=#pwrPlant>A: Power plant</a>) ) is assumed to be 20. (RefBy: <a href=#likeChgPP>LC: DC Gain and Time Constant</a> and <a href=#GD:gdPowerPlant>GD: gdPowerPlant</a>.)
+                      Spring Stiffness Coefficient: The Stiffness Coefficient of the spring in the mass-spring-damper system (<a href=#pwrPlant>A: Power plant</a>) is assumed to be 20. (RefBy: <a href=#likeChgPP>LC: DC Gain and Time Constant</a> and <a href=#GD:gdPowerPlant>GD: gdPowerPlant</a>.)
                     </div>
                   </p>
                 </div>
@@ -600,7 +598,7 @@
                       <th>Notes</th>
                       <td>
                         <p class="paragraph">
-                          Bilateral Laplace Transform. The Laplace transforms are  typically inferred from a pre-computed table of Laplace Transforms  (<a href=#laplaceWiki>laplaceWiki</a>).
+                          Bilateral Laplace Transform. The Laplace transforms are typically inferred from a pre-computed table of Laplace Transforms (<a href=#laplaceWiki>laplaceWiki</a>).
                         </p>
                       </td>
                     </tr>
@@ -651,7 +649,7 @@
                       <th>Notes</th>
                       <td>
                         <p class="paragraph">
-                          Inverse Laplace Transform of F(S). The Inverse Laplace transforms are  typically inferred from a pre-computed table of Laplace Transforms  (<a href=#laplaceWiki>laplaceWiki</a>).
+                          Inverse Laplace Transform of F(S). The Inverse Laplace transforms are typically inferred from a pre-computed table of Laplace Transforms (<a href=#laplaceWiki>laplaceWiki</a>).
                         </p>
                       </td>
                     </tr>
@@ -708,7 +706,7 @@
                       <th>Notes</th>
                       <td>
                         <p class="paragraph">
-                          The  Transfer Function (from <a href=#pwrPlantTxFnx>A: Transfer Function</a>) of a Second Order System (mass-spring-damper) is characterized by this equation.
+                          The Transfer Function (from <a href=#pwrPlantTxFnx>A: Transfer Function</a>) of a Second Order System (mass-spring-damper) is characterized by this equation.
                         </p>
                       </td>
                     </tr>
@@ -1155,7 +1153,7 @@
                     </p>
                     \[\frac{\,d\frac{\,d{y_{\text{t}}}}{\,dt}}{\,dt}+\left(1+{K_{\text{d}}}\right) \frac{\,d{y_{\text{t}}}}{\,dt}+\left(20+{K_{\text{p}}}\right) {y_{\text{t}}}-{K_{\text{d}}} \frac{\,d{r_{\text{t}}}}{\,dt}-{r_{\text{t}}} {K_{\text{p}}}=0\]
                     <p class="paragraph">
-                      The Set point (r(t)) is a step function, and a constant  (from <a href=#setPoint>A: Set-Point</a>). Therefore the  differential of the set point is zero. Hence the equation  reduces to,
+                      The Set point (r(t)) is a step function, and a constant (from <a href=#setPoint>A: Set-Point</a>). Therefore the differential of the set point is zero. Hence the equation reduces to,
                     </p>
                     \[\frac{\,d\frac{\,d{y_{\text{t}}}}{\,dt}}{\,dt}+\left(1+{K_{\text{d}}}\right) \frac{\,d{y_{\text{t}}}}{\,dt}+\left(20+{K_{\text{p}}}\right) {y_{\text{t}}}-{r_{\text{t}}} {K_{\text{p}}}=0\]
                   </div>
@@ -1244,12 +1242,12 @@
               </p>
               <p>
                 <div id="calculateValues">
-                  Calculate-Values: Calculate the Process Variable (from <a href=#IM:pdEquationIM>IM: pdEquationIM</a>) over  the simulation time.
+                  Calculate-Values: Calculate the Process Variable (from <a href=#IM:pdEquationIM>IM: pdEquationIM</a>) over the simulation time.
                 </div>
               </p>
               <p>
                 <div id="outputValues">
-                  Output-Values: Output the Process Variable (from <a href=#IM:pdEquationIM>IM: pdEquationIM</a>) over  the simulation time.
+                  Output-Values: Output the Process Variable (from <a href=#IM:pdEquationIM>IM: pdEquationIM</a>) over the simulation time.
                 </div>
               </p>
             </div>
@@ -1333,7 +1331,7 @@
         <div class="list">
           <p>
             <div id="likeChgPP">
-              DC Gain and Time Constant: The mass ,  Damping Coefficient  and the Stiffness Coefficient may be changed to be supplied by the user (from  <a href=#massSpring>A: Spring Mass</a>, <a href=#dampingCoeffSpring>A: Spring Damping Coefficient</a>, and <a href=#stiffnessCoeffSpring>A: Spring Stiffness Coefficient</a>).
+              DC Gain and Time Constant: The mass, Damping Coefficient and the Stiffness Coefficient may be changed to be supplied by the user (from <a href=#massSpring>A: Spring Mass</a>, <a href=#dampingCoeffSpring>A: Spring Damping Coefficient</a>, and <a href=#stiffnessCoeffSpring>A: Spring Stiffness Coefficient</a>).
             </div>
           </p>
         </div>


### PR DESCRIPTION
Removed unneeded whitespaces and used commas over `+:+` and `<>` operators.
Closes issue #2450 