### PR TITLE
Moving forTT functions

### DIFF
--- a/code/drasil-docLang/Drasil/DocLang/SRS.hs
+++ b/code/drasil-docLang/Drasil/DocLang/SRS.hs
@@ -25,12 +25,6 @@ import qualified Data.Drasil.Concepts.Documentation as Doc (appendix, assumption
   tOfSymb, tOfUnit, userCharacteristic)
 import qualified Data.Drasil.TheoryConcepts as Doc (dataDefn, genDefn, inModel, thModel)
 
--- Local function to keep things looking clean, not exported.
-forTT :: (NamedIdea c, NamedIdea d) => c -> d -> Sentence
-forTT = sFor'' titleize' titleize
-
-forTT' :: (NamedIdea c, NamedIdea d) => c -> d -> Sentence
-forTT' = sFor'' titleize' titleize'
 
 -- | SRS document constructor. 
 -- Create the SRS from given system name, authors, and sections

--- a/code/drasil-utils/Utils/Drasil.hs
+++ b/code/drasil-utils/Utils/Drasil.hs
@@ -23,7 +23,7 @@ module Utils.Drasil (
   of_'', of__, ofA, ofN_, the, the', the'', with, ofThe',
   -- Sentence
   andIts, andThe, fromThe, inThe, isExpctdToHv, isThe, ofGiv, ofGiv', ofThe, the_ofThe, the_ofThe',
-  sOf, sOfA, sOr, sVersus, sAnd, sAre, sIn, sIs, toThe, sFor, sFor', sFor''
+  sOf, sOfA, sOr, sVersus, sAnd, sAre, sIn, sIs, toThe, sFor, sFor', sFor'', forTT, forTT'
 ) where
 
 import Utils.Drasil.Contents

--- a/code/drasil-utils/Utils/Drasil/Sentence.hs
+++ b/code/drasil-utils/Utils/Drasil/Sentence.hs
@@ -1,4 +1,4 @@
-module Utils.Drasil.Sentence (andIts, andThe, fromThe, inThe, isExpctdToHv, isThe, ofGiv,
+module Utils.Drasil.Sentence (andIts, andThe, fromThe, inThe, isExpctdToHv, isThe, ofGiv, forTT, forTT',
   ofGiv', ofThe, the_ofThe, the_ofThe', sOf, sOfA, sOr, sVersus, sAnd, sAre, sIn, sIs, toThe, sFor, sFor', sFor'') where
 
 import Language.Drasil
@@ -53,6 +53,13 @@ sFor' t1 t2 = titleize t1 +:+ S "for" +:+ titleize t2
 -- | Similar to 'sFor'', but takes two arguments (for capitalization or pluralization) to apply to the two terms respectively
 sFor'' :: (c -> Sentence) -> (d -> Sentence) -> c -> d -> Sentence
 sFor'' f1 f2 t1 t2 = f1 t1 +:+ S "for" +:+ f2 t2   
+
+-- | Similar to 'sFor', but used for titles and first 'NamedIdea' is pluralized
+forTT :: (NamedIdea c, NamedIdea d) => c -> d -> Sentence
+forTT = sFor'' titleize' titleize
+-- | Similar to 'forTT', but both 'NamedIdea's are pluralized
+forTT' :: (NamedIdea c, NamedIdea d) => c -> d -> Sentence
+forTT' = sFor'' titleize' titleize'
 
 -- | Prepends "The" and inserts "is expected to have" between two Sentences
 isExpctdToHv a b = S "The" +:+ sentHelper "is expected to have" a b


### PR DESCRIPTION
Moved forTT function to Utils.Drasil.Sentence.
Closes #2457 
PR #2464 will likely not be able to merge automatically with this, but I think this one should still be merged to master first as the other one is much bigger.