### PR TITLE
Moving fterms to Utils

### DIFF
--- a/code/drasil-data/Data/Drasil/Concepts/Documentation.hs
+++ b/code/drasil-data/Data/Drasil/Concepts/Documentation.hs
@@ -297,9 +297,3 @@ unlikeChgDom  = ccs (mkIdea "unlikeChgDom"  (unlikelyChg ^. term)              $
 srsDomains :: [ConceptChunk]
 srsDomains = [cw srsDom, goalStmtDom, reqDom, funcReqDom, nonFuncReqDom, assumpDom, chgProbDom, likeChgDom, unlikeChgDom]
 
--- FIXME: fterms is here instead of Utils because of cyclic import
--- | Apply a binary function to the terms of two named ideas, instead of to the named
--- ideas themselves. Ex. @fterms compoundPhrase t1 t2@ instead of
--- @compoundPhrase (t1 ^. term) (t2 ^. term)@
-fterms :: (NamedIdea c, NamedIdea d) => (NP -> NP -> t) -> c -> d -> t
-fterms f a b = f (a ^. term) (b ^. term)

--- a/code/drasil-data/Data/Drasil/Concepts/Math.hs
+++ b/code/drasil-data/Data/Drasil/Concepts/Math.hs
@@ -7,7 +7,6 @@ import Data.Drasil.Citations (cartesianWiki, lineSource, pointSource)
 import Utils.Drasil
 import Utils.Drasil.Sentence
 
---import Control.Lens ((^.))
 
 mathcon :: [ConceptChunk]
 

--- a/code/drasil-data/Data/Drasil/Concepts/Math.hs
+++ b/code/drasil-data/Data/Drasil/Concepts/Math.hs
@@ -7,7 +7,7 @@ import Data.Drasil.Citations (cartesianWiki, lineSource, pointSource)
 import Utils.Drasil
 import Utils.Drasil.Sentence
 
-import Control.Lens ((^.))
+--import Control.Lens ((^.))
 
 mathcon :: [ConceptChunk]
 
@@ -106,9 +106,9 @@ leftSide  = commonIdeaWithDict "leftSide"  (nounPhrase "left hand side"  "left h
 rightSide = commonIdeaWithDict "rightSide" (nounPhrase "right hand side" "right hand sides") "RHS" [mathematics]
 
 --FIXME: COMBINATION HACK (all below)
-euclidN = dcc "euclidNorm"    (compoundPhrase' (euclidSpace ^. term) (norm ^. term)) "euclidean norm"
-normalV = dcc "normal vector" (compoundPhrase' (normal ^. term) (vector ^. term)) "unit outward normal vector for a surface"
-perpV   = dcc "perp_vect"     (compoundPhrase' (perp ^. term) (vector ^. term)) "vector perpendicular or 90 degrees to another vector"
+euclidN = dcc "euclidNorm"    (fterms compoundPhrase' euclidSpace norm) "euclidean norm"
+normalV = dcc "normal vector" (fterms compoundPhrase' normal vector) "unit outward normal vector for a surface"
+perpV   = dcc "perp_vect"     (fterms compoundPhrase' perp vector) "vector perpendicular or 90 degrees to another vector"
 rOfChng = dcc "rOfChng"       (rate `of_` change) "ratio between a change in one variable relative to a corresponding change in another"
-surArea = dcc "surArea"       (compoundPhrase' (surface ^. term) (area ^. term)) "a measure of the total area that the surface of the object occupies"
-unitV   = dcc "unit_vect"     (compoundPhrase' (unit_ ^. term) (vector ^. term)) "a vector that has a magnitude of one"
+surArea = dcc "surArea"       (fterms compoundPhrase' surface area) "a measure of the total area that the surface of the object occupies"
+unitV   = dcc "unit_vect"     (fterms compoundPhrase' unit_ vector) "a vector that has a magnitude of one"

--- a/code/drasil-data/Data/Drasil/Concepts/Physics.hs
+++ b/code/drasil-data/Data/Drasil/Concepts/Physics.hs
@@ -3,6 +3,7 @@ module Data.Drasil.Concepts.Physics where
 --  up with a better one.
 import Language.Drasil
 import Utils.Drasil.Sentence
+import Utils.Drasil
 
 import Data.Drasil.Domains (mathematics, physics)
 import Data.Drasil.Concepts.Documentation (property, value)
@@ -196,19 +197,19 @@ yConstAccel = dccWDS "yConstAccel" (nounPhraseSent $ phrase yComp `sOf` phrase c
 
 
 --FIXME: COMBINATION HACK (for all below)
-angDisp = dcc "angularDisplacement" (compoundPhrase' (angular ^. term) (displacement ^. term))
+angDisp = dcc "angularDisplacement" (fterms compoundPhrase' angular displacement)
   "the angle through which an object moves on a circular path"
-angVelo = dcc "angularVelocity" (compoundPhrase' (angular ^. term) (velocity ^. term))
+angVelo = dcc "angularVelocity" (fterms compoundPhrase' angular velocity)
   "the rate of change of angular position of a rotating body"
-angAccel = dcc "angularAcceleration" (compoundPhrase' (angular ^. term) (acceleration ^. term))
+angAccel = dcc "angularAcceleration" (fterms compoundPhrase' angular acceleration)
   "the rate of change of angular velocity"
 constAccel = dcc "constantAcceleration" (cn "constant acceleration")
   "a one-dimensional acceleration that is constant"
-linDisp = dcc "linearDisplacement" (compoundPhrase' (linear ^. term) (displacement ^. term)) 
+linDisp = dcc "linearDisplacement" (fterms compoundPhrase' linear displacement) 
   "movement in one direction along a single axis"
-linVelo = dcc "linearVelocity" (compoundPhrase' (linear ^. term) (velocity ^. term)) 
+linVelo = dcc "linearVelocity" (fterms compoundPhrase' linear velocity) 
   "the speed of a moving object, dependent on the perspective taken"
-linAccel = dcc "linearAcceleration" (compoundPhrase' (linear ^. term) (acceleration ^. term)) 
+linAccel = dcc "linearAcceleration" (fterms compoundPhrase' linear acceleration) 
   "the rate of change of velocity without a change in direction"
 
 -- The following feel like they're missing something/need to be more

--- a/code/drasil-data/Data/Drasil/Concepts/Thermodynamics.hs
+++ b/code/drasil-data/Data/Drasil/Concepts/Thermodynamics.hs
@@ -6,7 +6,6 @@ import Utils.Drasil
 import Data.Drasil.Concepts.Documentation (source, theory)
 import Data.Drasil.Concepts.Physics (energy)
 
---import Control.Lens((^.))
 
 thermocon :: [ConceptChunk]
 thermocon = [boilPt, boiling, degree_', enerSrc, heat, heatCapSpec, heatTrans,

--- a/code/drasil-data/Data/Drasil/Concepts/Thermodynamics.hs
+++ b/code/drasil-data/Data/Drasil/Concepts/Thermodynamics.hs
@@ -1,11 +1,12 @@
 module Data.Drasil.Concepts.Thermodynamics where
 
 import Language.Drasil
+import Utils.Drasil
 
 import Data.Drasil.Concepts.Documentation (source, theory)
 import Data.Drasil.Concepts.Physics (energy)
 
-import Control.Lens((^.))
+--import Control.Lens((^.))
 
 thermocon :: [ConceptChunk]
 thermocon = [boilPt, boiling, degree_', enerSrc, heat, heatCapSpec, heatTrans,
@@ -67,8 +68,8 @@ thermalConductor  = dcc "thermalConductor"  (cn' "thermal conductor")
 thermalEnergy     = dcc "thermalEnergy"     (cnIES "thermal energy")
                       "the energy that comes from heat"
 
-enerSrc           = dcc "enerSrc"     (compoundPhrase' (energy ^. term)    (source ^. term))
+enerSrc           = dcc "enerSrc"     (fterms compoundPhrase' energy source)
                       "a source from which useful energy can be extracted"
-htTransTheo       = dcc "htTransTheo" (compoundPhrase' (heatTrans ^. term) (theory ^. term))
+htTransTheo       = dcc "htTransTheo" (fterms compoundPhrase' heatTrans theory)
                       ("the theory predicting the energy transfer that may take " ++
                       "place between material bodies as a result of temperature difference")

--- a/code/drasil-utils/Utils/Drasil.hs
+++ b/code/drasil-utils/Utils/Drasil.hs
@@ -16,7 +16,7 @@ module Utils.Drasil (
   itemRefToSent, makeListRef, makeTMatrix, maybeChanged, maybeExpanded,
   maybeWOVerb, mkEnumAbbrevList, mkTableFromColumns, noRefs, refineChain,
   showingCxnBw, sortBySymbol, sortBySymbolTuple, substitute, tAndDOnly,
-  tAndDWAcc, tAndDWSym, typUncr, underConsidertn, unwrap, weave, zipSentList,
+  tAndDWAcc, tAndDWSym, typUncr, underConsidertn, unwrap, weave, zipSentList, fterms,
   -- Phrase
   and_, and_', andRT, compoundNC, compoundNC', compoundNC'', compoundNC''',
   compoundNCP1, compoundNCPlPh, for, for', of_, of_',

--- a/code/drasil-utils/Utils/Drasil/Misc.hs
+++ b/code/drasil-utils/Utils/Drasil/Misc.hs
@@ -5,7 +5,7 @@ module Utils.Drasil.Misc (addPercent, bulletFlat, bulletNested, checkValidStr,
   itemRefToSent, makeListRef, makeTMatrix, maybeChanged, maybeExpanded,
   maybeWOVerb, mkEnumAbbrevList, mkTableFromColumns, noRefs, refineChain,
   showingCxnBw, sortBySymbol, sortBySymbolTuple, substitute, tAndDOnly,
-  tAndDWAcc, tAndDWSym, typUncr, underConsidertn, unwrap, weave, zipSentList) where
+  tAndDWAcc, tAndDWSym, typUncr, underConsidertn, unwrap, weave, zipSentList, fterms) where
 
 import Language.Drasil
 import Utils.Drasil.Fold (FoldType(List), SepType(Comma), foldlList, foldlSent)
@@ -227,3 +227,10 @@ checkValidStr s [] = Right s
 checkValidStr s (x:xs)
   | x `elem` s = Left $ "Invalid character: \'" ++ [x] ++ "\' in string \"" ++ s ++ ['\"']
   | otherwise  = checkValidStr s xs
+
+-- FIXME: fterms is here instead of Utils because of cyclic import
+-- | Apply a binary function to the terms of two named ideas, instead of to the named
+-- ideas themselves. Ex. @fterms compoundPhrase t1 t2@ instead of
+-- @compoundPhrase (t1 ^. term) (t2 ^. term)@
+fterms :: (NamedIdea c, NamedIdea d) => (NP -> NP -> t) -> c -> d -> t
+fterms f a b = f (a ^. term) (b ^. term)

--- a/code/drasil-utils/Utils/Drasil/Misc.hs
+++ b/code/drasil-utils/Utils/Drasil/Misc.hs
@@ -228,9 +228,8 @@ checkValidStr s (x:xs)
   | x `elem` s = Left $ "Invalid character: \'" ++ [x] ++ "\' in string \"" ++ s ++ ['\"']
   | otherwise  = checkValidStr s xs
 
--- FIXME: fterms is here instead of Utils because of cyclic import
 -- | Apply a binary function to the terms of two named ideas, instead of to the named
 -- ideas themselves. Ex. @fterms compoundPhrase t1 t2@ instead of
--- @compoundPhrase (t1 ^. term) (t2 ^. term)@
+-- @compoundPhrase (t1 ^. term) (t2 ^. term)@.
 fterms :: (NamedIdea c, NamedIdea d) => (NP -> NP -> t) -> c -> d -> t
 fterms f a b = f (a ^. term) (b ^. term)


### PR DESCRIPTION
Moved `fterms` to `Utils.Drasil.Misc`, used `fterms` more in `Data.Drasil.Concepts.Math`.
Closes #2483. 