### PR TITLE
Stop `make clean` from returning an error code when it doesn't delete everything

### DIFF
--- a/code/Makefile
+++ b/code/Makefile
@@ -227,10 +227,10 @@ deploy: analysis graphs docs tex doxygen
 
 # follow two are for cleaning things out
 $(filter $(CLEAN_GF_PREFIX)%, $(CLEAN_FOLDERS)): $(CLEAN_GF_PREFIX)%:
-	- rm -r "./$*"
+	- rm -rf "./$*"
 
 clean: $(CLEAN_FOLDERS)
 	- stack clean
-	- rm "$(CACHED_MSV_FILE)"
+	- rm -f "$(CACHED_MSV_FILE)"
 
 .PHONY: clean code analysis tex doc debug prog test graphs graphmod check_stack graphs deploy_code_path deploy deploy_lite all $(GOOLTEST) $(ALL_EXPANDED_TARGETS)


### PR DESCRIPTION
From the [manual page](https://man7.org/linux/man-pages/man1/rm.1.html) of `rm`,

>       -f, --force
>             ignore nonexistent files and arguments, never prompt

Adding `-f` will just make it ignore errors, always seeing the command through. For what we're doing here, I think it's appropriate, causes less errors in the logs (that I don't think we care about).