### PR TITLE
Lang Documentation

### DIFF
--- a/code/drasil-lang/Language/Drasil/Chunk/Citation.hs
+++ b/code/drasil-lang/Language/Drasil/Chunk/Citation.hs
@@ -25,12 +25,12 @@ import Language.Drasil.UID (UID)
 
 import Control.Lens (makeLenses, (^.))
 
-type BibRef = [Citation] -- ^ A list of 'Citation's
-type EntryID = String -- ^ Should contain no spaces
+type BibRef = [Citation] -- ^ A list of 'Citation's.
+type EntryID = String -- ^ A 'String' that should contain no spaces.
 
 -- | All citations require a unique identifier used by the Drasil chunk.
--- We will re-use the UID part as an EntryID (String) used for creating reference links.
--- Finally we will have the reference information (type and fields).
+-- We will re-use the 'UID' part as an EntryID ('String') used for creating reference links.
+-- Finally we will have the reference information ('CitationKind', 'CiteField's, and a 'ShortName').
 data Citation = Cite
   { _citeKind :: CitationKind
   , _fields :: [CiteField]
@@ -40,43 +40,48 @@ data Citation = Cite
 makeLenses ''Citation
 
 instance HasUID       Citation where uid       = citeID
+-- ^ Finds 'UID' of the 'Citation'.
 instance HasShortName Citation where shortname = sn
+-- ^ Finds 'ShortName' of the 'Citation'.
 instance HasFields    Citation where getFields = fields
+-- ^ Finds 'Fields' of the 'Citation'.
 instance Referable    Citation where
-  refAdd    c = c ^. citeID -- citeID should be unique.
+  refAdd    c = c ^. citeID 
+  -- ^ 'Citation' 'UID' should be unique as a reference address.
   renderRef c = Citation $ refAdd c
+  -- ^ Get the alternate form of reference address.
 
--- | Smart constructor which implicitly uses EntryID as chunk i.
+-- | Smart constructor which implicitly uses EntryID as chunk id.
 cite :: CitationKind -> [CiteField] -> String -> Citation
 cite x y z = let s = noSpaces z in Cite x y s (shortname' s)
 
 -- | Article citation requires author(s), title, journal, year.
 -- Optional fields can be: volume, number, pages, month, and note.
--- Implicitly uses the EntryID as the chunk i.
+-- Implicitly uses the EntryID as the chunk id.
 cArticle :: People -> String -> String -> Int -> [CiteField] -> String -> Citation
 cArticle aut t journ yr opt = cite Article 
   (author aut : title t : journal journ : year yr : opt)
 
 -- | Book citation requires author or editor, title, publisher, year.
 -- Optional fields can be volume or number, series, address, edition, month, and note.
--- Implicitly uses the EntryID as the chunk i.
+-- Implicitly uses the EntryID as the chunk id.
 cBookA, cBookE :: People -> String -> String -> Int ->
   [CiteField] -> String -> Citation
--- | Book citation by author
+-- | Book citation by author.
 cBookA aut t pub yr opt = cite Book (author aut : stdFields t pub yr opt)
--- | Book citation by editor
+-- | Book citation by editor.
 cBookE ed t pub yr opt = cite Book (editor ed : stdFields t pub yr opt)
 
 -- | Booklet citation requires title.
 -- Optional fields can be author, how published, address, month, year, note.
--- Implicitly uses the EntryID as the chunk i.
+-- Implicitly uses the EntryID as the chunk id.
 cBooklet :: String -> [CiteField] -> String -> Citation
 cBooklet t opt = cite Booklet (title t : opt)
 
 -- | InBook citation requires author or editor, title, chapter and/or pages,
 -- publisher, year. Optional fields can be volume or number, series, type,
 -- address, edition, month, and note.
--- Implicitly uses the EntryID as the chunk i.
+-- Implicitly uses the EntryID as the chunk id.
 -- This smart constructor includes both chapter and page numbers.
 cInBookACP, cInBookECP :: People -> String -> Int -> [Int] ->
   String -> Int -> [CiteField] -> String -> Citation
@@ -91,10 +96,10 @@ cInBookECP ed t chap pgs pub yr opt = cite InBook
 cInBookAC, cInBookEC :: People -> String -> Int ->
   String -> Int -> [CiteField] -> String -> Citation
 
--- | Otherwise identical to 'cInBookACP'
+-- | Otherwise identical to 'cInBookACP'.
 cInBookAC auth t chap pub yr opt = cite InBook 
   (author auth : chapter chap : stdFields t pub yr opt)
--- | Otherwise identical to 'cInBookECP'
+-- | Otherwise identical to 'cInBookECP'.
 cInBookEC ed t chap pub yr opt = cite InBook 
   (editor ed : chapter chap : stdFields t pub yr opt)
 
@@ -102,17 +107,17 @@ cInBookEC ed t chap pub yr opt = cite InBook
 cInBookAP, cInBookEP :: People -> String -> [Int] ->
   String -> Int -> [CiteField] -> String -> Citation
 
--- | Otherwise identical to 'cInBookACP'
+-- | Otherwise identical to 'cInBookACP'.
 cInBookAP auth t pgs pub yr opt = cite InBook 
   (author auth : pages pgs : stdFields t pub yr opt)
--- | Otherwise identical to 'cInBookECP'
+-- | Otherwise identical to 'cInBookECP'.
 cInBookEP ed t pgs pub yr opt = cite InBook 
   (editor ed : pages pgs : stdFields t pub yr opt)
 
 -- | InCollection citation requires author, title, bookTitle, publisher, year.
 -- Optional fields can be editor, volume or number, series, type, chapter,
 -- pages, address, edition, month, and note.
--- Implicitly uses the EntryID as the chunk i.
+-- Implicitly uses the EntryID as the chunk id.
 cInCollection :: People -> String -> String -> String -> Int ->
   [CiteField] -> String -> Citation
 cInCollection auth t bt pub yr opt = cite InCollection 
@@ -121,7 +126,7 @@ cInCollection auth t bt pub yr opt = cite InCollection
 -- | InProceedings citation requires author, title, bookTitle, year.
 -- Optional fields can be editor, volume or number, series, pages,
 -- address, month, organization, publisher, and note.
--- Implicitly uses the EntryID as the chunk i.
+-- Implicitly uses the EntryID as the chunk id.
 cInProceedings :: People -> String -> String -> Int ->
   [CiteField] -> String -> Citation
 cInProceedings auth t bt yr opt = cite InProceedings 
@@ -129,54 +134,54 @@ cInProceedings auth t bt yr opt = cite InProceedings
 
 -- | Manual (technical documentation) citation requires title.
 -- Optional fields can be author, organization, address, edition, month, year, and note.
--- Implicitly uses the EntryID as the chunk i.
+-- Implicitly uses the EntryID as the chunk id.
 cManual :: String -> [CiteField] -> String -> Citation
 cManual t opt = cite Manual (title t : opt)
 
 -- | Master's Thesis citation requires author, title, school, and year.
 -- Optional fields can be type, address, month, and note.
--- Implicitly uses the EntryID as the chunk i.
+-- Implicitly uses the EntryID as the chunk id.
 cMThesis :: People -> String -> String -> Int -> [CiteField] -> String -> Citation
 cMThesis auth t sch yr opt = cite MThesis (thesis auth t sch yr opt)
 
 -- | Misc citation requires nothing.
 -- Optional fields can be author, title, howpublished, month, year, and note.
--- Implicitly uses the EntryID as the chunk i.
+-- Implicitly uses the EntryID as the chunk id.
 cMisc :: [CiteField] -> String -> Citation
 cMisc = cite Misc
 
 -- | PhD Thesis citation requires author, title, school, and year.
 -- Optional fields can be type, address, month, and note.
--- Implicitly uses the EntryID as the chunk i.
+-- Implicitly uses the EntryID as the chunk id.
 cPhDThesis :: People -> String -> String -> Int -> [CiteField] -> String -> Citation
 cPhDThesis auth t sch yr opt = cite PhDThesis (thesis auth t sch yr opt)
 
 -- | Proceedings citation requires title and year.
 -- Optional fields can be editor, volume or number, series, address,
 -- publisher, note, month, and organization.
--- Implicitly uses the EntryID as the chunk i.
+-- Implicitly uses the EntryID as the chunk id.
 cProceedings :: String -> Int -> [CiteField] -> String -> Citation
 cProceedings t yr opt = cite Proceedings (title t : year yr : opt)
 
 -- | Technical Report citation requires author, title, institution, and year.
 -- Optional fields can be type, number, address, month, and note.
--- Implicitly uses the EntryID as the chunk i.
+-- Implicitly uses the EntryID as the chunk id.
 cTechReport :: People -> String -> String -> Int -> [CiteField] -> String -> Citation
 cTechReport auth t inst yr opt = cite TechReport 
   (author auth : title t : institution inst : year yr : opt)
 
 -- | Unpublished citation requires author, title, and note.
 -- Optional fields can be month and year.
--- Implicitly uses the EntryID as the chunk i.
+-- Implicitly uses the EntryID as the chunk id.
 cUnpublished :: People -> String -> String -> [CiteField] -> String -> Citation
 cUnpublished auth t n opt = cite Unpublished 
   (author auth : title t : note n : opt)
 
--- Helper function (do not export) for creating book reference.
+-- | Helper function (do not export) for creating book reference.
 stdFields :: String -> String -> Int -> [CiteField] -> [CiteField]
 stdFields t pub yr opt = title t : publisher pub : year yr : opt
 
--- Helper function (do not export) for creating thesis reference.
+-- | Helper function (do not export) for creating thesis reference.
 thesis :: People -> String -> String -> Int -> [CiteField] -> [CiteField]
 thesis auth t sch yr opt = author auth : title t : school sch : year yr : opt
 

--- a/code/drasil-lang/Language/Drasil/Chunk/CommonIdea.hs
+++ b/code/drasil-lang/Language/Drasil/Chunk/CommonIdea.hs
@@ -13,34 +13,39 @@ import Language.Drasil.UID (UID)
 
 import Control.Lens (makeLenses, (^.), view)
 
--- | The common idea (with nounPhrase) data type. It must have a 
--- 'NounPhrase' for its 'term', and must have an abbreviation.
+-- | The common idea (with 'NounPhrase') data type. It must have a 'UID',
+-- 'NounPhrase' for its term, an abbreviation ('String'), and a domain (['UID']).
 data CI = CI { _cid :: UID, _ni :: NP, _ab :: String, cdom' :: [UID]}
 makeLenses ''CI
 
 instance HasUID        CI where uid  = cid
+-- ^ Finds 'UID' of 'CI'.
 instance NamedIdea     CI where term = ni
+-- ^ Finds term ('NP') of 'CI'.
 instance Idea          CI where getA = Just . view ab
+-- ^ Finds idea of 'CI' (abbreviation).
 instance CommonIdea    CI where abrv = view ab
+-- ^ Finds idea of 'CI' (abbreviation).
 instance ConceptDomain CI where cdom = cdom'
+-- ^ Finds domain of 'CI'.
   
--- | The commonIdea smart constructor requires a chunk id, 
--- term (of type 'NP'), abbreviation (as a string), and a list of related 'UID's
+-- | The commonIdea smart constructor requires a chunk id ('UID'), a
+-- term ('NP'), an abbreviation ('String'), and a domain (['UID']).
 commonIdea :: String -> NP -> String -> [UID] -> CI
 commonIdea = CI
 
--- | Similar to 'commonIdea', but takes a list of 'IdeaDict' (often a domain)
+-- | Similar to 'commonIdea', but takes a list of 'IdeaDict' (often a domain).
 commonIdeaWithDict :: String -> NP -> String -> [IdeaDict] -> CI
 commonIdeaWithDict x y z = CI x y z . map (^.uid)
 
--- | Get abbreviation in 'Sentence' form from a 'CI'
+-- | Get abbreviation in 'Sentence' form from a 'CI'.
 getAcc :: CI -> Sentence
 getAcc = S . abrv
 
--- | Get abbreviation in 'String' form from a 'CI'
+-- | Get abbreviation in 'String' form from a 'CI'.
 getAccStr :: CI -> String
 getAccStr = abrv
 
--- | Prepends the abbreviation from a 'CommonIdea' to a 'String'
+-- | Prepends the abbreviation from a 'CommonIdea' to a 'String'.
 prependAbrv :: CommonIdea c => c -> String -> String
 prependAbrv c s = abrv c ++ (':' : repUnd s)

--- a/code/drasil-lang/Language/Drasil/Chunk/CommonIdea.hs
+++ b/code/drasil-lang/Language/Drasil/Chunk/CommonIdea.hs
@@ -23,11 +23,11 @@ instance HasUID        CI where uid  = cid
 instance NamedIdea     CI where term = ni
 -- ^ Finds term ('NP') of 'CI'.
 instance Idea          CI where getA = Just . view ab
--- ^ Finds idea of 'CI' (abbreviation).
+-- ^ Finds the idea of a 'CI' (abbreviation).
 instance CommonIdea    CI where abrv = view ab
--- ^ Finds idea of 'CI' (abbreviation).
+-- ^ Finds the idea of a 'CI' (abbreviation).
 instance ConceptDomain CI where cdom = cdom'
--- ^ Finds domain of 'CI'.
+-- ^ Finds the domain of a 'CI'.
   
 -- | The commonIdea smart constructor requires a chunk id ('UID'), a
 -- term ('NP'), an abbreviation ('String'), and a domain (['UID']).

--- a/code/drasil-lang/Language/Drasil/Chunk/Concept.hs
+++ b/code/drasil-lang/Language/Drasil/Chunk/Concept.hs
@@ -24,25 +24,25 @@ dcc :: String -> NP -> String -> ConceptChunk
 dcc i ter des = ConDict (mkIdea i ter Nothing) (S des) []
 -- ^ Concept domain tagging is not yet implemented in this constructor.
 
--- | Identical to 'dcc', but adds an abbreviation ('String')
+-- | Identical to 'dcc', but takes an abbreviation ('String').
 dcc' :: String -> NP -> String -> String -> CommonConcept
 dcc' i t d a = ComConDict (commonIdea i t a []) (S d)
 
--- | Similar to 'dcc', except the definition takes a 'Sentence'
+-- | Similar to 'dcc', except the definition takes a 'Sentence'.
 dccWDS :: String -> NP -> Sentence -> ConceptChunk
 dccWDS i t d = ConDict (mkIdea i t Nothing) d []
 
--- | Similar to 'dcc', except the definition is a 'Sentence' and adds
--- an abbreviation ('String')
+-- | Similar to 'dcc', except the definition is a 'Sentence' and takes
+-- an abbreviation ('String').
 dccWDS' :: String -> NP -> Sentence -> String -> CommonConcept
 dccWDS' i t d a = ComConDict (commonIdea i t a []) d
 
 -- | Constructor for 'ConceptChunk'. Takes the definition of the 
--- 'ConceptChunk' as a String. Does not allow concept domain tagging.
+-- 'ConceptChunk' as a 'String'. Does not allow concept domain tagging.
 cc :: Idea c => c -> String -> ConceptChunk
 cc n d = ConDict (nw n) (S d) []
 
--- | Same as cc, except definition is a 'Sentence'
+-- | Same as cc, except definition is a 'Sentence'.
 cc' :: Idea c => c -> Sentence -> ConceptChunk
 cc' n d = ConDict (nw n) d []
 
@@ -50,12 +50,12 @@ cc' n d = ConDict (nw n) d []
 ccs :: (Idea c, Concept d) => c -> Sentence -> [d] -> ConceptChunk --Explicit tagging
 ccs n d l = ConDict (nw n) d $ map (^. uid) l
 
--- | For projecting out to the ConceptChunk data-type
+-- | For projecting out to the 'ConceptChunk' data-type.
 cw :: Concept c => c -> ConceptChunk
 cw c = ConDict (nw c) (c ^. defn) (cdom c)
 
 -- | Constructor for a 'ConceptInstance'. Takes in the 
 -- Reference Address ('String'), a definition ('Sentence'), 
--- a Shortname ('String'), and a domain (or explicit tagging)
+-- a short name ('String'), and a domain (or explicit tagging).
 cic :: Concept c => String -> Sentence -> String -> c -> ConceptInstance
 cic u d sn dom = ConInst (ccs (nc u $ pn sn) d [dom]) u $ shortname' sn

--- a/code/drasil-lang/Language/Drasil/Chunk/Concept/Core.hs
+++ b/code/drasil-lang/Language/Drasil/Chunk/Concept/Core.hs
@@ -39,9 +39,9 @@ instance NamedIdea     ConceptChunk where term = idea . term
 instance Idea          ConceptChunk where getA = getA . view idea 
 -- ^ Finds the idea contained in the 'IdeaDict' used to make the 'ConceptChunk'.
 instance Definition    ConceptChunk where defn = defn' 
--- ^ Finds definition from record of the datatype.
+-- ^ Finds definition of a 'ConceptChunk'.
 instance ConceptDomain ConceptChunk where cdom = cdom' 
--- ^ Finds domain of 'UID's from record of the datatype.
+-- ^ Finds the domain of 'UID's of a 'ConceptChunk'.
 
 -- | Contains a common idea ('CI') with a definition ('Sentence').
 data CommonConcept = ComConDict { _comm :: CI, _def :: Sentence}
@@ -56,7 +56,7 @@ instance NamedIdea     CommonConcept where term = comm . term
 instance Idea          CommonConcept where getA = getA . view comm 
 -- ^ Finds the idea contained in the 'CI' used to make the 'CommonConcept'.
 instance Definition    CommonConcept where defn = def 
--- ^ Finds definition from record of the datatype.
+-- ^ Finds definition of a 'CommonConcept'.
 instance CommonIdea    CommonConcept where abrv = abrv . view comm 
 -- ^ Finds the abbreviation contained in the 'CI' used to make the 'CommonConcept'.
 instance ConceptDomain CommonConcept where cdom = cdom . view comm 
@@ -79,12 +79,12 @@ instance Definition    ConceptInstance where defn = cc . defn'
 instance ConceptDomain ConceptInstance where cdom = cdom' . view cc 
 -- ^ Finds the domain contained in the 'ConceptChunk' used to make the 'ConceptInstance'.
 instance HasShortName  ConceptInstance where shortname = shnm 
--- ^ Finds the 'ShortName' contained in the record of the datatype.
+-- ^ Finds the 'ShortName' contained in a 'ConceptInstance'.
 instance HasRefAddress ConceptInstance where getRefAdd = ra 
--- ^ Finds the reference address contained in the record of the datatype.
+-- ^ Finds the reference address contained in a 'ConceptInstance'.
 instance Referable     ConceptInstance where
   refAdd      = ra 
-  -- ^ Finds the reference address contained in the record of the datatype.
+  -- ^ Finds the reference address contained in a 'ConceptInstance'.
   renderRef l = RP (defer (sDom $ cdom l) +::+ raw ": " +::+ name) (ra l) 
   -- ^ Finds the reference address but in a diferent form.
 

--- a/code/drasil-lang/Language/Drasil/Chunk/Concept/Core.hs
+++ b/code/drasil-lang/Language/Drasil/Chunk/Concept/Core.hs
@@ -17,48 +17,74 @@ import Language.Drasil.UID (UID)
 
 import Control.Lens (makeLenses, (^.), view)
 
+-- | Check if something has one domain. Throws an error if there is more than one.
 sDom :: [UID] -> UID
 sDom [d] = d
 sDom d = error $ "Expected ConceptDomain to have a single domain, found " ++
   show (length d) ++ " instead."
 
--- | The ConceptChunk datatype is a Concept
-data ConceptChunk = ConDict { _idea :: IdeaDict -- ^ Contains the idea of the concept
-                            , _defn' :: Sentence -- ^ The definition of the concept
-                            , cdom' :: [UID] -- ^ List of 'UID's in the concept
+-- | The ConceptChunk datatype is a Concept that contains an idea ('IdeaDict'), a definition ('Sentence'), and a domain (['UID']).
+data ConceptChunk = ConDict { _idea :: IdeaDict -- ^ Contains the idea of the concept.
+                            , _defn' :: Sentence -- ^ The definition of the concept.
+                            , cdom' :: [UID] -- ^ List of 'UID's in the concept.
                             }
 makeLenses ''ConceptChunk
 
-instance Eq            ConceptChunk where c1 == c2 = (c1 ^. uid) == (c2 ^. uid)
-instance HasUID        ConceptChunk where uid = idea . uid
-instance NamedIdea     ConceptChunk where term = idea . term
-instance Idea          ConceptChunk where getA = getA . view idea
-instance Definition    ConceptChunk where defn = defn'
-instance ConceptDomain ConceptChunk where cdom = cdom'
+instance Eq            ConceptChunk where c1 == c2 = (c1 ^. uid) == (c2 ^. uid) 
+-- ^ Equal if 'UID's are equal.
+instance HasUID        ConceptChunk where uid = idea . uid 
+-- ^ Finds 'UID' of the 'IdeaDict' used to make the 'ConceptChunk'.
+instance NamedIdea     ConceptChunk where term = idea . term 
+-- ^ Finds term ('NP') of the 'IdeaDict' used to make the 'ConceptChunk'.
+instance Idea          ConceptChunk where getA = getA . view idea 
+-- ^ Finds the idea contained in the 'IdeaDict' used to make the 'ConceptChunk'.
+instance Definition    ConceptChunk where defn = defn' 
+-- ^ Finds definition from record of the datatype.
+instance ConceptDomain ConceptChunk where cdom = cdom' 
+-- ^ Finds domain of 'UID's from record of the datatype.
 
+-- | Contains a common idea ('CI') with a definition ('Sentence').
 data CommonConcept = ComConDict { _comm :: CI, _def :: Sentence}
 makeLenses ''CommonConcept
 
-instance Eq            CommonConcept where c1 == c2 = (c1 ^. uid) == (c2 ^. uid)
-instance HasUID        CommonConcept where uid = comm . uid
-instance NamedIdea     CommonConcept where term = comm . term
-instance Idea          CommonConcept where getA = getA . view comm
-instance Definition    CommonConcept where defn = def
-instance CommonIdea    CommonConcept where abrv = abrv . view comm
-instance ConceptDomain CommonConcept where cdom = cdom . view comm
+instance Eq            CommonConcept where c1 == c2 = (c1 ^. uid) == (c2 ^. uid) 
+-- ^ Equal if 'UID's are equal.
+instance HasUID        CommonConcept where uid = comm . uid 
+-- ^ Finds 'UID' of the 'CI' used to make the 'CommonConcept'.
+instance NamedIdea     CommonConcept where term = comm . term 
+-- ^ Finds term ('NP') of the 'CI' used to make the 'CommonConcept'.
+instance Idea          CommonConcept where getA = getA . view comm 
+-- ^ Finds the idea contained in the 'CI' used to make the 'CommonConcept'.
+instance Definition    CommonConcept where defn = def 
+-- ^ Finds definition from record of the datatype.
+instance CommonIdea    CommonConcept where abrv = abrv . view comm 
+-- ^ Finds the abbreviation contained in the 'CI' used to make the 'CommonConcept'.
+instance ConceptDomain CommonConcept where cdom = cdom . view comm 
+-- ^ Finds the domain contained in the 'CI' used to make the 'CommonConcept'.
 
+-- | Contains a 'ConceptChunk', reference address, and a 'ShortName'.
 data ConceptInstance = ConInst { _cc :: ConceptChunk , ra :: String, shnm :: ShortName}
 makeLenses ''ConceptInstance
 
-instance Eq            ConceptInstance where c1 == c2 = (c1 ^. uid) == (c2 ^. uid)
-instance HasUID        ConceptInstance where uid = cc . idea . uid
-instance NamedIdea     ConceptInstance where term = cc . idea . term
-instance Idea          ConceptInstance where getA = getA . view (cc . idea)
-instance Definition    ConceptInstance where defn = cc . defn'
-instance ConceptDomain ConceptInstance where cdom = cdom' . view cc
-instance HasShortName  ConceptInstance where shortname = shnm
-instance HasRefAddress ConceptInstance where getRefAdd = ra
+instance Eq            ConceptInstance where c1 == c2 = (c1 ^. uid) == (c2 ^. uid) 
+-- ^ Equal if 'UID's are equal.
+instance HasUID        ConceptInstance where uid = cc . idea . uid 
+-- ^ Finds 'UID' of the 'ConceptChunk' used to make the 'ConceptInstance'.
+instance NamedIdea     ConceptInstance where term = cc . idea . term 
+-- ^ Finds term ('NP') of the 'ConceptChunk' used to make the 'ConceptInstance'.
+instance Idea          ConceptInstance where getA = getA . view (cc . idea) 
+-- ^ Finds the idea contained in the 'ConceptChunk' used to make the 'ConceptInstance'.
+instance Definition    ConceptInstance where defn = cc . defn' 
+-- ^ Finds the definition contained in the 'ConceptChunk' used to make the 'ConceptInstance'.
+instance ConceptDomain ConceptInstance where cdom = cdom' . view cc 
+-- ^ Finds the domain contained in the 'ConceptChunk' used to make the 'ConceptInstance'.
+instance HasShortName  ConceptInstance where shortname = shnm 
+-- ^ Finds the 'ShortName' contained in the record of the datatype.
+instance HasRefAddress ConceptInstance where getRefAdd = ra 
+-- ^ Finds the reference address contained in the record of the datatype.
 instance Referable     ConceptInstance where
-  refAdd      = ra
-  renderRef l = RP (defer (sDom $ cdom l) +::+ raw ": " +::+ name) (ra l)
+  refAdd      = ra 
+  -- ^ Finds the reference address contained in the record of the datatype.
+  renderRef l = RP (defer (sDom $ cdom l) +::+ raw ": " +::+ name) (ra l) 
+  -- ^ Finds the reference address but in a diferent form.
 

--- a/code/drasil-lang/Language/Drasil/Chunk/Constrained.hs
+++ b/code/drasil-lang/Language/Drasil/Chunk/Constrained.hs
@@ -21,8 +21,8 @@ import Language.Drasil.Space (Space)
 import Language.Drasil.Stages (Stage)
 import Language.Drasil.Symbol (Symbol)
 
--- | ConstrainedChunks are 'Symbolic Quantities'
--- with 'Constraints' and maybe a typical value
+-- | ConstrainedChunks are symbolic quantities ('QuantityDict')
+-- with 'Constraint's and maybe a typical value ('Maybe' 'Expr').
 data ConstrainedChunk = ConstrainedChunk { _qd :: QuantityDict
                                          , _constr :: [Constraint]
                                          , _reasV :: Maybe Expr
@@ -30,31 +30,40 @@ data ConstrainedChunk = ConstrainedChunk { _qd :: QuantityDict
 makeLenses ''ConstrainedChunk
 
 instance HasUID        ConstrainedChunk where uid = qd . uid
+-- ^ Finds 'UID' of the 'QuantityDict' used to make the 'ConstrainedChunk'.
 instance NamedIdea     ConstrainedChunk where term = qd . term
+-- ^ Finds term ('NP') of the 'QuantityDict' used to make the 'ConstrainedChunk'.
 instance Idea          ConstrainedChunk where getA = getA . view qd
+-- ^ Finds the idea contained in the 'QuantityDict' used to make the 'ConstrainedChunk'.
 instance HasSpace      ConstrainedChunk where typ = qd . typ
+-- ^ Finds the 'Space' of the 'QuantityDict' used to make the 'ConstrainedChunk'.
 instance HasSymbol     ConstrainedChunk where symbol c = symbol (c^.qd)
+-- ^ Finds the 'Symbol' of the 'QuantityDict' used to make the 'ConstrainedChunk'.
 instance Quantity      ConstrainedChunk where 
 instance Constrained   ConstrainedChunk where constraints = constr
+-- ^ Finds the 'Constraint's of a 'ConstrainedChunk'.
 instance HasReasVal    ConstrainedChunk where reasVal     = reasV
+-- ^ Finds a reasonable value for the 'ConstrainedChunk'.
 instance Eq            ConstrainedChunk where c1 == c2 = (c1 ^. qd . uid) == (c2 ^. qd . uid)
+-- ^ Equal if 'UID's are equal.
 instance MayHaveUnit   ConstrainedChunk where getUnit = getUnit . view qd
+-- ^ Finds units contained in the 'QuantityDict' used to make the 'ConstrainedChunk'.
 
--- | Creates a constrained unitary chunk from a 'UID', term ('NP'), 'Symbol', unit, 'Space', 'Constraint's, and an 'Expr'
+-- | Creates a constrained unitary chunk from a 'UID', term ('NP'), 'Symbol', unit, 'Space', 'Constraint's, and an 'Expr'.
 cuc :: (IsUnit u) => String -> NP -> Symbol -> u
   -> Space -> [Constraint] -> Expr -> ConstrainedChunk
 cuc i t s u space cs rv = ConstrainedChunk (qw (unitary i t s u space)) cs (Just rv)
 
--- | Creates a constrained unitary chunk from a 'UID', term ('NP'), 'Symbol', 'Space', 'Constraint's, and a 'Maybe' 'Expr' (no units)
+-- | Creates a constrained unitary chunk from a 'UID', term ('NP'), 'Symbol', 'Space', 'Constraint's, and a 'Maybe' 'Expr' (Similar to 'cuc' but no units).
 cvc :: String -> NP -> Symbol -> Space -> [Constraint] -> Maybe Expr -> ConstrainedChunk
 cvc i des sym space = ConstrainedChunk (qw (vc i des sym space))
 
--- | Creates a new ConstrainedChunk from either a 'ConstrainedChunk', 'ConstrConcept', 'UncertainChunk', or an 'UncertQ'
+-- | Creates a new ConstrainedChunk from either a 'ConstrainedChunk', 'ConstrConcept', 'UncertainChunk', or an 'UncertQ'.
 cnstrw :: (Quantity c, Constrained c, HasReasVal c, MayHaveUnit c) => c -> ConstrainedChunk
 cnstrw c = ConstrainedChunk (qw c) (c ^. constraints) (c ^. reasVal)
 
--- | ConstrConcepts are 'Conceptual Symbolic Quantities'
--- with 'Constraints' and maybe a reasonable value (and no unit!)
+-- | ConstrConcepts are Conceptual Symbolic Quantities ('DefinedQuantityDict')
+-- with 'Constraint's and maybe a reasonable value (no units!).
 data ConstrConcept = ConstrConcept { _defq :: DefinedQuantityDict
                                    , _constr' :: [Constraint]
                                    , _reasV' :: Maybe Expr
@@ -62,40 +71,53 @@ data ConstrConcept = ConstrConcept { _defq :: DefinedQuantityDict
 makeLenses ''ConstrConcept
 
 instance HasUID        ConstrConcept where uid = defq . uid
+-- ^ Finds 'UID' of the 'DefinedQuantityDict' used to make the 'ConstrConcept'.
 instance NamedIdea     ConstrConcept where term = defq . term
+-- ^ Finds term ('NP') of the 'DefinedQuantityDict' used to make the 'ConstrConcept'.
 instance Idea          ConstrConcept where getA = getA . view defq
+-- ^ Finds the idea contained in the 'DefinedQuantityDict' used to make the 'ConstrConcept'.
 instance HasSpace      ConstrConcept where typ = defq . typ
+-- ^ Finds the 'Space' of the 'DefinedQuantityDict' used to make the 'ConstrConcept'.
 instance HasSymbol     ConstrConcept where symbol c = symbol (c^.defq)
+-- ^ Finds the 'Symbol' of the 'DefinedQuantityDict' used to make the 'ConstrConcept'.
 instance Quantity      ConstrConcept where 
 instance Definition    ConstrConcept where defn = defq . defn
+-- ^ Finds definition of the 'DefinedQuantityDict' used to make the 'ConstrConcept'.
 instance ConceptDomain ConstrConcept where cdom = cdom . view defq
+-- ^ Finds domain contained in the 'DefinedQuantityDict' used to make the 'ConstrConcept'.
 instance Constrained   ConstrConcept where constraints  = constr'
+-- ^ Finds the 'Constraint's of a 'ConstrConcept'.
 instance HasReasVal    ConstrConcept where reasVal      = reasV'
+-- ^ Finds a reasonable value for the 'ConstrConcept'.
 instance Eq            ConstrConcept where c1 == c2 = (c1 ^.defq.uid) == (c2 ^.defq.uid)
+-- ^ Equal if 'UID's are equal.
 instance MayHaveUnit   ConstrConcept where getUnit = getUnit . view defq
+-- ^ Finds the units of the 'DefinedQuantityDict' used to make the 'ConstrConcept'.
 
--- | Creates a 'ConstrConcept' with a quantitative concept, a list of 'Constraint's and an 'Expr'
+-- | Creates a 'ConstrConcept' with a quantitative concept, a list of 'Constraint's and an 'Expr'.
 constrained' :: (Concept c, MayHaveUnit c, Quantity c) =>
   c -> [Constraint] -> Expr -> ConstrConcept
 constrained' q cs rv = ConstrConcept (dqdWr q) cs (Just rv)
 
--- | Similar to 'constrained'', but defaults 'Maybe' 'Expr' to 'Nothing'
+-- | Similar to 'constrained'', but defaults 'Maybe' 'Expr' to 'Nothing'.
 constrainedNRV' :: (Concept c, MayHaveUnit c, Quantity c) =>
   c -> [Constraint] -> ConstrConcept
 constrainedNRV' q cs = ConstrConcept (dqdWr q) cs Nothing
 
---TODO: Document these functions
+-- | Creates a constrained unitary chunk from a 'UID', term ('NP'), description ('String'), 'Symbol', unit, 'Space', 'Constraint's, and an 'Expr'.
 cuc' :: (IsUnit u) => String -> NP -> String -> Symbol -> u
             -> Space -> [Constraint] -> Expr -> ConstrConcept
 cuc' nam trm desc sym un space cs rv =
   ConstrConcept (dqd (cw (ucs nam trm desc sym space un)) sym space uu) cs (Just rv)
   where uu = unitWrapper un
 
+-- | Similar to 'cuc'', but 'Symbol' is dependent on 'Stage'.
 cuc'' :: (IsUnit u) => String -> NP -> String -> (Stage -> Symbol) -> u
             -> Space -> [Constraint] -> Expr -> ConstrConcept
 cuc'' nam trm desc sym un space cs rv =
   ConstrConcept (dqd' (dcc nam trm desc) sym space (Just uu)) cs (Just rv)
   where uu = unitWrapper un
 
+-- | Similar to 'cnstrw', but types must also have a 'Concept'.
 cnstrw' :: (Quantity c, Concept c, Constrained c, HasReasVal c, MayHaveUnit c) => c -> ConstrConcept
 cnstrw' c = ConstrConcept (dqdWr c) (c ^. constraints) (c ^. reasVal)

--- a/code/drasil-lang/Language/Drasil/Chunk/Constrained.hs
+++ b/code/drasil-lang/Language/Drasil/Chunk/Constrained.hs
@@ -62,7 +62,7 @@ cvc i des sym space = ConstrainedChunk (qw (vc i des sym space))
 cnstrw :: (Quantity c, Constrained c, HasReasVal c, MayHaveUnit c) => c -> ConstrainedChunk
 cnstrw c = ConstrainedChunk (qw c) (c ^. constraints) (c ^. reasVal)
 
--- | ConstrConcepts are Conceptual Symbolic Quantities ('DefinedQuantityDict')
+-- | ConstrConcepts are conceptual symbolic quantities ('DefinedQuantityDict')
 -- with 'Constraint's and maybe a reasonable value (no units!).
 data ConstrConcept = ConstrConcept { _defq :: DefinedQuantityDict
                                    , _constr' :: [Constraint]
@@ -84,7 +84,7 @@ instance Quantity      ConstrConcept where
 instance Definition    ConstrConcept where defn = defq . defn
 -- ^ Finds definition of the 'DefinedQuantityDict' used to make the 'ConstrConcept'.
 instance ConceptDomain ConstrConcept where cdom = cdom . view defq
--- ^ Finds domain contained in the 'DefinedQuantityDict' used to make the 'ConstrConcept'.
+-- ^ Finds the domain contained in the 'DefinedQuantityDict' used to make the 'ConstrConcept'.
 instance Constrained   ConstrConcept where constraints  = constr'
 -- ^ Finds the 'Constraint's of a 'ConstrConcept'.
 instance HasReasVal    ConstrConcept where reasVal      = reasV'

--- a/code/drasil-lang/Language/Drasil/Chunk/DefinedQuantity.hs
+++ b/code/drasil-lang/Language/Drasil/Chunk/DefinedQuantity.hs
@@ -15,7 +15,7 @@ import Language.Drasil.Symbol (Symbol)
 
 import Control.Lens ((^.), makeLenses, view)
 
--- | DefinedQuantity is the combinatino of a Concept and Quantity
+-- | DefinedQuantityDict is the combination of a 'Concept' and a 'Quantity'. Contains a 'ConceptChunk', a 'Symbol' dependent on 'Stage', a 'Space', and maybe a 'UnitDefn'.
 data DefinedQuantityDict = DQD { _con :: ConceptChunk
                                , _symb :: Stage -> Symbol
                                , _spa :: Space
@@ -25,29 +25,38 @@ data DefinedQuantityDict = DQD { _con :: ConceptChunk
 makeLenses ''DefinedQuantityDict
 
 instance HasUID        DefinedQuantityDict where uid = con . uid
+-- ^ Finds the 'UID' of the 'ConceptChunk' used to make the 'DefinedQuantityDIct'.
 instance Eq            DefinedQuantityDict where a == b = (a ^. uid) == (b ^. uid)
+-- Equal if 'UID's are equal.
 instance NamedIdea     DefinedQuantityDict where term = con . term
+-- ^ Finds the term ('NP') of the 'ConceptChunk' used to make the 'DefinedQuantityDIct'.
 instance Idea          DefinedQuantityDict where getA = getA . view con
+-- ^ Finds the idea contained in the 'ConceptChunk' used to make the 'DefinedQuantityDIct'.
 instance Definition    DefinedQuantityDict where defn = con . defn
+-- ^ Finds the definition contained in the 'ConceptChunk' used to make the 'DefinedQuantityDIct'.
 instance ConceptDomain DefinedQuantityDict where cdom = cdom . view con
+-- ^ Finds the domain of the 'ConceptChunk' used to make the 'DefinedQuantityDIct'.
 instance HasSpace      DefinedQuantityDict where typ = spa
+-- ^ Finds the 'Space' of the 'DefinedQuantityDict'.
 instance HasSymbol     DefinedQuantityDict where symbol = view symb
+-- ^ Finds the 'Stage' -> 'Symbol' of the 'DefinedQuantityDict'.
 instance Quantity      DefinedQuantityDict where 
 instance MayHaveUnit   DefinedQuantityDict where getUnit = view unit'
+-- ^ Finds the units of the 'DefinedQuantityDict'.
 
--- | For when the symbol is constant through stages
+-- | Smart constructor that creates a DefinedQuantityDict with a 'ConceptChunk', a 'Symbol' independent of 'Stage', a 'Space', and a unit.
 dqd :: (IsUnit u) => ConceptChunk -> Symbol -> Space -> u -> DefinedQuantityDict
 dqd c s sp = DQD c (const s) sp . Just . unitWrapper
 
--- | Similar to 'dqd', but without any units
+-- | Similar to 'dqd', but without any units.
 dqdNoUnit :: ConceptChunk -> Symbol -> Space -> DefinedQuantityDict
 dqdNoUnit c s sp = DQD c (const s) sp Nothing
 
--- | For when the symbol changes depending on the stage
+-- | Similar to 'dqd', but the 'Symbol' is now dependent on the 'Stage'.
 dqd' :: ConceptChunk -> (Stage -> Symbol) -> Space -> Maybe UnitDefn -> DefinedQuantityDict
 dqd' = DQD
 
--- | When the input already has all the necessary information. A 'projection' operator
+-- | When the input already has all the necessary information. A 'projection' operator from some a type with instances of listed classes to a 'DefinedQuantityDict'.
 dqdWr :: (Quantity c, Concept c, MayHaveUnit c) => c -> DefinedQuantityDict
 dqdWr c = DQD (cw c) (symbol c) (c ^. typ) (getUnit c)
 

--- a/code/drasil-lang/Language/Drasil/Chunk/DefinedQuantity.hs
+++ b/code/drasil-lang/Language/Drasil/Chunk/DefinedQuantity.hs
@@ -25,17 +25,17 @@ data DefinedQuantityDict = DQD { _con :: ConceptChunk
 makeLenses ''DefinedQuantityDict
 
 instance HasUID        DefinedQuantityDict where uid = con . uid
--- ^ Finds the 'UID' of the 'ConceptChunk' used to make the 'DefinedQuantityDIct'.
+-- ^ Finds the 'UID' of the 'ConceptChunk' used to make the 'DefinedQuantityDict'.
 instance Eq            DefinedQuantityDict where a == b = (a ^. uid) == (b ^. uid)
--- Equal if 'UID's are equal.
+-- ^ Equal if 'UID's are equal.
 instance NamedIdea     DefinedQuantityDict where term = con . term
--- ^ Finds the term ('NP') of the 'ConceptChunk' used to make the 'DefinedQuantityDIct'.
+-- ^ Finds the term ('NP') of the 'ConceptChunk' used to make the 'DefinedQuantityDict'.
 instance Idea          DefinedQuantityDict where getA = getA . view con
--- ^ Finds the idea contained in the 'ConceptChunk' used to make the 'DefinedQuantityDIct'.
+-- ^ Finds the idea contained in the 'ConceptChunk' used to make the 'DefinedQuantityDict'.
 instance Definition    DefinedQuantityDict where defn = con . defn
--- ^ Finds the definition contained in the 'ConceptChunk' used to make the 'DefinedQuantityDIct'.
+-- ^ Finds the definition contained in the 'ConceptChunk' used to make the 'DefinedQuantityDict'.
 instance ConceptDomain DefinedQuantityDict where cdom = cdom . view con
--- ^ Finds the domain of the 'ConceptChunk' used to make the 'DefinedQuantityDIct'.
+-- ^ Finds the domain of the 'ConceptChunk' used to make the 'DefinedQuantityDict'.
 instance HasSpace      DefinedQuantityDict where typ = spa
 -- ^ Finds the 'Space' of the 'DefinedQuantityDict'.
 instance HasSymbol     DefinedQuantityDict where symbol = view symb

--- a/code/drasil-lang/Language/Drasil/Chunk/Eq.hs
+++ b/code/drasil-lang/Language/Drasil/Chunk/Eq.hs
@@ -19,7 +19,7 @@ import Language.Drasil.Stages (Stage)
 import Language.Drasil.Symbol (Symbol)
 import Language.Drasil.UID (UID)
 
--- | A QDefinition is a 'Quantity' with a defining expression, and a definition
+-- | A QDefinition is a 'QuantityDict' with a defining expression ('Expr'), a definition ('Sentence'), and a domain (['UID']).
 data QDefinition = EC
   { _qua :: QuantityDict
   , _defn' :: Sentence
@@ -30,20 +30,31 @@ makeLenses ''QDefinition
 
 -- this works because UnitalChunk is a Chunk
 instance HasUID        QDefinition where uid = qua . uid
+-- ^ Finds the 'UID' of the 'QuantityDict' used to make the 'QDefinition'.
 instance NamedIdea     QDefinition where term = qua . term
+-- ^ Finds the term ('NP') of the 'QuantityDict' used to make the 'QDefinition'.
 instance Idea          QDefinition where getA c = getA $ c ^. qua
+-- ^ Finds the idea contained in the 'QuantityDict' used to make the 'QDefinition'.
 instance HasSpace      QDefinition where typ = qua . typ
+-- ^ Finds the 'Space' of the 'QuantityDict' used to make the 'QDefinition'.
 instance HasSymbol     QDefinition where symbol e = symbol (e^.qua)
+-- ^ Finds the 'Symbol' of the 'QuantityDict' used to make the 'QDefinition'.
 instance Definition    QDefinition where defn = defn'
+-- ^ Finds the definition of 'QDefinition'.
 instance Quantity      QDefinition where
 instance DefiningExpr  QDefinition where defnExpr = equat
+-- ^ Finds the defining expression of 'QDefinition'.
 instance Eq            QDefinition where a == b = (a ^. uid) == (b ^. uid)
+-- ^ Equal if 'UID's are equal.
 instance MayHaveUnit   QDefinition where getUnit = getUnit . view qua
+-- ^ Finds the units of the 'QuantityDict' used to make the 'QDefinition'.
 instance ExprRelat     QDefinition where relat z = sy z $= z ^. equat
+-- ^ Finds the relation given by the expression in 'QDefinition'.
 instance ConceptDomain QDefinition where cdom = cd
+-- ^ Finds the domain of 'QDefinition'
 
 -- | Create a 'QDefinition' with a 'UID', term ('NP'), definition ('Sentence'), 'Symbol',
--- 'Space', unit, and defining equation.
+-- 'Space', unit, and defining expression.
 fromEqn :: (IsUnit u) => String -> NP -> Sentence -> Symbol -> Space -> u -> Expr -> QDefinition
 fromEqn nm desc def symb sp un expr =
   EC (mkQuant nm desc symb sp (Just $ unitWrapper un) Nothing) def expr []
@@ -53,31 +64,32 @@ fromEqn' :: String -> NP -> Sentence -> Symbol -> Space -> Expr -> QDefinition
 fromEqn' nm desc def symb sp expr =
   EC (mkQuant nm desc symb sp Nothing Nothing) def expr []
 
--- | Same as 'fromEqn', but symbol depends on stage
+-- | Same as 'fromEqn', but symbol depends on stage.
 fromEqnSt :: (IsUnit u) => String -> NP -> Sentence -> (Stage -> Symbol) ->
   Space -> u -> Expr -> QDefinition
 fromEqnSt nm desc def symb sp un expr =
   EC (mkQuant' nm desc Nothing sp symb (Just $ unitWrapper un)) def expr []
 
--- | Same as 'fromEqn'', but symbol depends on stage
+-- | Same as 'fromEqn', but symbol depends on stage and has no units.
 fromEqnSt' :: String -> NP -> Sentence -> (Stage -> Symbol) -> Space -> Expr ->
   QDefinition
 fromEqnSt' nm desc def symb sp expr =
   EC (mkQuant' nm desc Nothing sp symb Nothing) def expr []
 
--- | Used to help make 'Qdefinition's when 'UID', term, and 'Symbol' come from the same source
+-- | Used to help make 'Qdefinition's when 'UID', term, and 'Symbol' come from the same source.
 mkQuantDef :: (Quantity c, MayHaveUnit c) => c -> Expr -> QDefinition
 mkQuantDef c e = datadef $ getUnit c
   where datadef (Just a) = fromEqnSt  (c ^. uid) (c ^. term) EmptyS (symbol c) (c ^. typ) a e
         datadef Nothing  = fromEqnSt' (c ^. uid) (c ^. term) EmptyS (symbol c) (c ^. typ) e
 
--- | Used to help make 'Qdefinition's when 'UID' and 'Symbol' come from the same source, with the term separate
+-- | Used to help make 'Qdefinition's when 'UID' and 'Symbol' come from the same source, with the term separate.
 mkQuantDef' :: (Quantity c, MayHaveUnit c) => c -> NP -> Expr -> QDefinition
 mkQuantDef' c t e = datadef $ getUnit c
   where datadef (Just a) = fromEqnSt  (c ^. uid) t EmptyS (symbol c) (c ^. typ) a e
         datadef Nothing  = fromEqnSt' (c ^. uid) t EmptyS (symbol c) (c ^. typ) e
-
+        
+-- HACK - makes the definition EmptyS !!! FIXME
 -- | Smart constructor for QDefinitions. Requires a quantity and its defining 
--- equation. HACK - makes the definition EmptyS !!! FIXME
+-- equation. 
 ec :: (Quantity c, MayHaveUnit c) => c -> Expr -> QDefinition
 ec c eqn = EC (qw c) EmptyS eqn []

--- a/code/drasil-lang/Language/Drasil/Chunk/Eq.hs
+++ b/code/drasil-lang/Language/Drasil/Chunk/Eq.hs
@@ -51,7 +51,7 @@ instance MayHaveUnit   QDefinition where getUnit = getUnit . view qua
 instance ExprRelat     QDefinition where relat z = sy z $= z ^. equat
 -- ^ Finds the relation given by the expression in 'QDefinition'.
 instance ConceptDomain QDefinition where cdom = cd
--- ^ Finds the domain of 'QDefinition'
+-- ^ Finds the domain of 'QDefinition'.
 
 -- | Create a 'QDefinition' with a 'UID', term ('NP'), definition ('Sentence'), 'Symbol',
 -- 'Space', unit, and defining expression.
@@ -87,7 +87,7 @@ mkQuantDef' :: (Quantity c, MayHaveUnit c) => c -> NP -> Expr -> QDefinition
 mkQuantDef' c t e = datadef $ getUnit c
   where datadef (Just a) = fromEqnSt  (c ^. uid) t EmptyS (symbol c) (c ^. typ) a e
         datadef Nothing  = fromEqnSt' (c ^. uid) t EmptyS (symbol c) (c ^. typ) e
-        
+
 -- HACK - makes the definition EmptyS !!! FIXME
 -- | Smart constructor for QDefinitions. Requires a quantity and its defining 
 -- equation. 

--- a/code/drasil-lang/Language/Drasil/Chunk/NamedArgument.hs
+++ b/code/drasil-lang/Language/Drasil/Chunk/NamedArgument.hs
@@ -9,7 +9,7 @@ import Language.Drasil.Chunk.UnitDefn(MayHaveUnit(getUnit))
 
 import Control.Lens ((^.), makeLenses, view)
 
--- | Any quantity can be a named argument
+-- | Any quantity can be a named argument (wrapper for 'QuantityDict')
 newtype NamedArgument = NA {_qtd :: QuantityDict}
 makeLenses ''NamedArgument
 
@@ -23,6 +23,6 @@ instance IsArgumentName NamedArgument where
 instance Eq             NamedArgument where a == b = (a ^. uid) == (b ^. uid)
 instance MayHaveUnit    NamedArgument where getUnit = getUnit . view qtd
   
--- | 'NamedArgument' constructor
+-- | Smart constructor for 'NamedArgument' 
 narg :: (Quantity q, MayHaveUnit q) => q -> NamedArgument
 narg = NA . qw

--- a/code/drasil-lang/Language/Drasil/Chunk/NamedArgument.hs
+++ b/code/drasil-lang/Language/Drasil/Chunk/NamedArgument.hs
@@ -14,14 +14,21 @@ newtype NamedArgument = NA {_qtd :: QuantityDict}
 makeLenses ''NamedArgument
 
 instance HasUID         NamedArgument where uid = qtd . uid
+-- ^ Finds the 'UID' of the 'QuantityDict' used to make the 'NamedArgument'.
 instance NamedIdea      NamedArgument where term = qtd . term
+-- ^ Finds the term ('NP') of the 'QuantityDict' used to make the 'NamedArgument'.
 instance Idea           NamedArgument where getA = getA . view qtd
+-- ^ Finds the idea contained in the 'QuantityDict' used to make the 'NamedArgument'.
 instance HasSpace       NamedArgument where typ = qtd . typ
+-- ^ Finds the 'Space' of the 'QuantityDict' used to make the 'NamedArgument'.
 instance HasSymbol      NamedArgument where symbol = symbol . view qtd
+-- ^ Finds the 'Symbol' of the 'QuantityDict' used to make the 'NamedArgument'.
 instance Quantity       NamedArgument where 
 instance IsArgumentName NamedArgument where
 instance Eq             NamedArgument where a == b = (a ^. uid) == (b ^. uid)
+-- ^ Equal if 'UID's are equal.
 instance MayHaveUnit    NamedArgument where getUnit = getUnit . view qtd
+-- ^ Finds the units of the 'QuantityDict' used to make the 'NamedArgument'.
   
 -- | Smart constructor for 'NamedArgument' 
 narg :: (Quantity q, MayHaveUnit q) => q -> NamedArgument

--- a/code/drasil-lang/Language/Drasil/Chunk/NamedIdea.hs
+++ b/code/drasil-lang/Language/Drasil/Chunk/NamedIdea.hs
@@ -10,28 +10,38 @@ import Language.Drasil.NounPhrase (NP)
 
 -- === DATA TYPES/INSTANCES === --
 -- | Note that a 'NamedChunk' does not have an acronym/abbreviation
--- as that's a 'CommonIdea', which has its own representation
+-- as that's a 'CommonIdea', which has its own representation. Contains
+-- a 'UID' and a term ('NP').
 data NamedChunk = NC {_uu :: UID, _np :: NP}
 makeLenses ''NamedChunk
 
 instance Eq        NamedChunk where c1 == c2 = (c1 ^. uid) == (c2 ^. uid)
+-- ^ Equal if 'UID's are equal.
 instance HasUID    NamedChunk where uid = uu
+-- ^ Finds the 'UID' of the 'NamedChunk'.
 instance NamedIdea NamedChunk where term = np
+-- ^ Finds the term ('NP') of the 'NamedChunk'.
 instance Idea      NamedChunk where getA _ = Nothing
+-- ^ Finds the idea of a 'NamedChunk' (always 'Nothing').
   
 -- | 'NamedChunk' constructor, takes a 'UID' and a term.
 nc :: String -> NP -> NamedChunk
 nc = NC
 
--- | 'IdeaDict' is the canonical dictionary associated to 'Idea',
--- don't export the record accessors
+-- | 'IdeaDict' is the canonical dictionary associated to 'Idea'.
+-- Contains a 'NamedChunk' and maybe an abbreviation ('String').
+-- Don't export the record accessors.
 data IdeaDict = IdeaDict { _nc' :: NamedChunk, mabbr :: Maybe String }
 makeLenses ''IdeaDict
 
 instance Eq        IdeaDict where a == b = a ^. uid == b ^. uid
+-- ^ Equal if 'UID's are equal.
 instance HasUID    IdeaDict where uid = nc' . uid
+-- ^ Finds the 'UID' of the 'NamedChunk' used to make the 'IdeaDict'.
 instance NamedIdea IdeaDict where term = nc' . term
+-- ^ Finds the term ('NP') of the 'NamedChunk' used to make the 'IdeaDict'.
 instance Idea      IdeaDict where getA = mabbr
+-- ^ Finds the abbreviation of the 'IdeaDict'.
   
 -- | 'IdeaDict' constructor, takes a 'UID', 'NP', and 
 -- an abbreviation in the form of 'Maybe' 'String'

--- a/code/drasil-lang/Language/Drasil/Chunk/NamedIdea.hs
+++ b/code/drasil-lang/Language/Drasil/Chunk/NamedIdea.hs
@@ -19,7 +19,7 @@ instance HasUID    NamedChunk where uid = uu
 instance NamedIdea NamedChunk where term = np
 instance Idea      NamedChunk where getA _ = Nothing
   
--- | 'NamedChunk' constructor, takes an uid and a term.
+-- | 'NamedChunk' constructor, takes a 'UID' and a term.
 nc :: String -> NP -> NamedChunk
 nc = NC
 

--- a/code/drasil-lang/Language/Drasil/Chunk/Quantity.hs
+++ b/code/drasil-lang/Language/Drasil/Chunk/Quantity.hs
@@ -13,8 +13,9 @@ import Language.Drasil.Space (Space)
 import Language.Drasil.Stages (Stage(..))
 import Language.Drasil.Symbol (Symbol(Empty))
 
--- | A datatype that contains an 'IdeaDict', 'Space', a function from 
--- 'Stage' -> 'Symbol', and 'Maybe' a 'UnitDefn'
+-- | QuantityDict is a combination of an 'IdeaDict' with a quantity.
+-- Contains an 'IdeaDict', 'Space', a function from 
+-- 'Stage' -> 'Symbol', and 'Maybe' a 'UnitDefn'.
 data QuantityDict = QD { _id' :: IdeaDict
                        , _typ' :: Space
                        , _symb' :: Stage -> Symbol
@@ -23,31 +24,38 @@ data QuantityDict = QD { _id' :: IdeaDict
 makeLenses ''QuantityDict
 
 instance HasUID        QuantityDict where uid = id' . uid
+-- ^ Finds the 'UID' of the 'IdeaDict' used to make the 'QuantityDict'.
 instance NamedIdea     QuantityDict where term = id' . term
+-- ^ Finds the term ('NP') of the 'IdeaDict' used to make the 'QuantityDict'.
 instance Idea          QuantityDict where getA  qd = getA (qd ^. id')
+-- ^ Finds the idea contained in the 'IdeaDict' used to make the 'QuantityDict'.
 instance HasSpace      QuantityDict where typ = typ'
+-- ^ Finds the 'Space' of the 'QuantityDict'.
 instance HasSymbol     QuantityDict where symbol = view symb'
+-- ^ Finds the 'Stage' dependent 'Symbol' of the 'QuantityDict'.
 instance Quantity      QuantityDict where 
 instance Eq            QuantityDict where a == b = (a ^. uid) == (b ^. uid)
+-- ^ Equal if 'UID's are equal.
 instance MayHaveUnit   QuantityDict where getUnit = view unit'
+-- ^ Finds the units of the 'QuantityDict'.
 
--- | A constructor for a 'QuantityDict' from another 'Quantity' with units
+-- | Smart constructor for a 'QuantityDict' from another 'Quantity' with units.
 qw :: (Quantity q, MayHaveUnit q) => q -> QuantityDict
 qw q = QD (nw q) (q^.typ) (symbol q) (getUnit q)
 
--- | Make a QuantityDict from a 'UID', 'NP', 'Symbol', 'Space', 
--- 'Maybe' 'UnitDefn', and an abbreviation ('Maybe' 'String')
+-- | Make a 'QuantityDict' from a 'UID', 'NP', 'Symbol', 'Space', 
+-- 'Maybe' 'UnitDefn', and an abbreviation ('Maybe' 'String').
 mkQuant :: String -> NP -> Symbol -> Space -> Maybe UnitDefn -> Maybe String -> 
   QuantityDict
 mkQuant i t s sp u ab = QD (mkIdea i t ab) sp (const s) u
 
 -- | Similar to 'mkQuant', but the abbreviation is moved to 
--- the third argument ('Maybe' 'String'), and the 'Symbol' is no longer 'const'
+-- the third argument ('Maybe' 'String'), and the 'Symbol' is now dependent on 'Stage'.
 mkQuant' :: String -> NP -> Maybe String -> Space -> (Stage -> Symbol) -> 
   Maybe UnitDefn -> QuantityDict
 mkQuant' i t ab = QD (mkIdea i t ab)
 
--- | implVar makes a variable that is implementation-only
+-- | Makes a variable that is implementation-only.
 implVar :: String -> NP -> Space -> Symbol -> QuantityDict
 implVar i des sp sym = vcSt i des f sp
   where
@@ -55,7 +63,7 @@ implVar i des sp sym = vcSt i des f sp
     f Implementation = sym
     f Equational = Empty
 
--- | Similar to 'implVar' but allows specification of abbreviation and unit 
+-- | Similar to 'implVar' but allows specification of abbreviation and unit.
 implVar' :: String -> NP -> Maybe String -> Space -> Symbol -> 
   Maybe UnitDefn -> QuantityDict
 implVar' s np a t sym = mkQuant' s np a t f
@@ -63,19 +71,19 @@ implVar' s np a t sym = mkQuant' s np a t f
         f Implementation = sym
         f Equational = Empty
 
--- | Creates a 'Quantity' from a 'UID', term ('NP'), 'Symbol', and 'Space'
+-- | Creates a 'QuantityDict' from a 'UID', term ('NP'), 'Symbol', and 'Space'.
 vc :: String -> NP -> Symbol -> Space -> QuantityDict
 vc i des sym space = QD (nw $ nc i des) space (const sym) Nothing
 
--- | Creates a 'Quantity' from a 'UID', term ('NP'), 'Symbol', 'Space', and unit ('UnitDefn')
+-- | Creates a 'QuantityDict' from a 'UID', term ('NP'), 'Symbol', 'Space', and unit ('UnitDefn').
 vcUnit :: String -> NP -> Symbol -> Space -> UnitDefn -> QuantityDict
 vcUnit i des sym space u = QD (nw $ nc i des) space (const sym) (Just u)
 
--- | Similar to 'vc', but creates a 'QuantityDict' from something that knows about stages
+-- | Similar to 'vc', but creates a 'QuantityDict' from something that knows about 'Stage's.
 vcSt :: String -> NP -> (Stage -> Symbol) -> Space -> QuantityDict
 vcSt i des sym space = QD (nw $ nc i des) space sym Nothing
 
--- | Makes a 'QuantityDict' from an 'Idea', 'Symbol', and 'Space'. 'Symbol' is implementation-only
+-- | Makes a 'QuantityDict' from an 'Idea', 'Symbol', and 'Space'. 'Symbol' is implementation-only.
 codeVC :: Idea c => c -> Symbol -> Space -> QuantityDict
 codeVC n s t = QD (nw n) t f Nothing
   where
@@ -83,6 +91,6 @@ codeVC n s t = QD (nw n) t f Nothing
     f Implementation = s
     f Equational = Empty
 
--- | Creates a 'QuantityDict' from an 'Idea', 'Symbol', and 'Space'
+-- | Creates a 'QuantityDict' from an 'Idea', 'Symbol', and 'Space'.
 vc'' :: Idea c => c -> Symbol -> Space -> QuantityDict
 vc'' n = vc (n ^. uid) (n ^. term)

--- a/code/drasil-lang/Language/Drasil/Chunk/Relation.hs
+++ b/code/drasil-lang/Language/Drasil/Chunk/Relation.hs
@@ -12,21 +12,28 @@ import Language.Drasil.NounPhrase (NP)
 import Language.Drasil.Sentence (Sentence)
 import Language.Drasil.UID (UID)
 
--- | For a 'ConceptChunk' that also has a 'Relation' attached
+-- | For a 'ConceptChunk' that also has a 'Relation' attached.
 data RelationConcept = RC { _conc :: ConceptChunk
                           , rel :: Relation
                           }
 makeLenses ''RelationConcept
 
 instance HasUID        RelationConcept where uid = conc . uid
+-- ^ Finds the 'UID' of the 'ConceptChunk' used to make the 'RelationConcept'.
 instance NamedIdea     RelationConcept where term = conc . term
+-- ^ Finds the term ('NP') of the 'ConceptChunk' used to make the 'RelationConcept'.
 instance Idea          RelationConcept where getA = getA . view conc
+-- ^ Finds the idea contained in the 'ConceptChunk' used to make the 'RelationConcept'.
 instance Definition    RelationConcept where defn = conc . defn
+-- ^ Finds the definition contained in the 'ConceptChunk' used to make the 'RelationConcept'.
 instance ConceptDomain RelationConcept where cdom = cdom . view conc
+-- ^ Finds the domain of the 'ConceptChunk' used to make the 'RelationConcept'.
 instance ExprRelat     RelationConcept where relat = rel
+-- ^ Finds the relation expression for a 'RelationConcept'.
 instance Eq            RelationConcept where a == b = (a ^. uid) == (b ^. uid)
+-- ^ Equal if 'UID's are equal.
 
--- | Create a 'RelationConcept' from a given 'UID', term, defn, and relation.
+-- | Create a 'RelationConcept' from a given 'UID', term ('NP'), definition ('Sentence'), and 'Relation'.
 makeRC :: UID -> NP -> Sentence -> Relation -> RelationConcept
 makeRC rID rTerm rDefn = RC (dccWDS rID rTerm rDefn)
 

--- a/code/drasil-lang/Language/Drasil/Chunk/UncertainQuantity.hs
+++ b/code/drasil-lang/Language/Drasil/Chunk/UncertainQuantity.hs
@@ -21,66 +21,92 @@ import Control.Lens ((^.), makeLenses, view)
 
 {- The order of the following two implementations is the same as in Constrained -}
 
--- | UncertainChunk is a chunk that contains a 'ConstrainedChunk' and an 'Uncertainty'.
+-- | UncertainChunk is a symbolic quantity with constraints, a typical value, and an uncertainty. 
+-- Contains a 'ConstrainedChunk' and an 'Uncertainty'.
 data UncertainChunk  = UCh { _conc :: ConstrainedChunk , _unc' :: Uncertainty }
 makeLenses ''UncertainChunk
 
 instance HasUID            UncertainChunk where uid = conc . uid
+-- ^ Finds 'UID' of the 'ConstrainedChunk' used to make the 'UncertainChunk'.
 instance Eq                UncertainChunk where c1 == c2 = (c1 ^. uid) == (c2 ^. uid)
+-- ^ Equal if 'UID's are equal.
 instance NamedIdea         UncertainChunk where term = conc . term
+-- ^ Finds term ('NP') of the 'ConstrainedChunk' used to make the 'UncertainChunk'.
 instance Idea              UncertainChunk where getA (UCh n _) = getA n
+-- ^ Finds the idea contained in the 'ConstrainedChunk' used to make the 'UncertainChunk'.
 instance HasSpace          UncertainChunk where typ = conc . typ
+-- ^ Finds the 'Space' of the 'ConstrainedChunk' used to make the 'UncertainChunk'.
 instance HasSymbol         UncertainChunk where symbol c = symbol (c^.conc)
+-- ^ Finds the 'Symbol' of the 'ConstrainedChunk' used to make the 'UncertainChunk'.
 instance Quantity          UncertainChunk where 
 instance Constrained       UncertainChunk where constraints = conc . constraints
+-- ^ Finds the 'Constraint's of the 'ConstrainedChunk' used to make the 'UncertainChunk'.
 instance HasReasVal        UncertainChunk where reasVal = conc . reasVal
+-- ^ Finds a reasonable value for the 'ConstrainedChunk' used to make the 'UncertainChunk'.
 instance HasUncertainty    UncertainChunk where unc = unc'
+-- ^ Finds the uncertainty of an 'UncertainChunk'.
 instance MayHaveUnit       UncertainChunk where getUnit = getUnit . view conc
+-- ^ Finds units contained in the 'ConstrainedChunk' used to make the 'UncertainChunk'.
 
 {-- Constructors --}
+-- | Smart constructor that can project to an 'UncertainChunk' (also given an 'Uncertainty').
 uncrtnChunk :: (Quantity c, Constrained c, HasReasVal c, MayHaveUnit c) => 
   c -> Uncertainty -> UncertainChunk
 uncrtnChunk q = UCh (cnstrw q)
 
--- | Creates an uncertain variable chunk. Takes 'UID', term ('NP'), 'Symbol', 'Space', 'Constrains', 'Expr', and 'Uncertainty'
+-- | Creates an uncertain variable chunk. Takes 'UID', term ('NP'),
+-- 'Symbol', 'Space', 'Constrains', 'Expr', and 'Uncertainty'.
 uvc :: String -> NP -> Symbol -> Space -> [Constraint] -> Expr -> Uncertainty -> UncertainChunk
 uvc nam trm sym space cs val = uncrtnChunk (cvc nam trm sym space cs (Just val))
 
--- | Projection function into an 'UncertainChunk' from 'UncertQ' or an 'UncertainChunk'
+-- | Projection function into an 'UncertainChunk' from 'UncertQ' or an 'UncertainChunk'.
 uncrtnw :: (HasUncertainty c, Quantity c, Constrained c, HasReasVal c, MayHaveUnit c) => c -> UncertainChunk
 uncrtnw c = UCh (cnstrw c) (c ^. unc)
 
--- | UncertQ is a chunk that contains a 'ConstrConcept' and an 'Uncertainty'.
+-- | UncertQs are conceptual symbolic quantities with constraints and an 'Uncertainty'.
+-- Contains a 'ConstrConcept' and an 'Uncertainty'.
 data UncertQ = UQ { _coco :: ConstrConcept , _unc'' :: Uncertainty }
 makeLenses ''UncertQ
   
 instance Eq             UncertQ where a == b = (a ^. uid) == (b ^. uid)
+-- ^ Equal if 'UID's are equal.
 instance HasUID         UncertQ where uid = coco . uid
+-- ^ Finds 'UID' of the 'ConstrConcept' used to make the 'UncertQ'.
 instance NamedIdea      UncertQ where term = coco . term
+-- ^ Finds term ('NP') of the 'ConstrConcept' used to make the 'UncertQ'.
 instance Idea           UncertQ where getA (UQ q _) = getA q
+-- ^ Finds the idea contained in the 'ConstrConcept' used to make the 'UncertQ'.
 instance HasSpace       UncertQ where typ = coco . typ
+-- ^ Finds the 'Space' of the 'ConstrConcept' used to make the 'UncertQ'.
 instance HasSymbol      UncertQ where symbol c = symbol (c^.coco)
+-- ^ Finds the 'Symbol' of the 'ConstrConcept' used to make the 'UncertQ'.
 instance Quantity       UncertQ where 
 instance HasUncertainty UncertQ where unc = unc''
+-- ^ Finds the uncertainty of an 'UncertQ'.
 instance Constrained    UncertQ where constraints = coco . constraints
+-- ^ Finds the 'Constraint's of a 'ConstrConcept' used to make the 'UncertQ'.
 instance HasReasVal     UncertQ where reasVal = coco . reasVal
+-- ^ Finds a reasonable value for the 'ConstrConcept' used to make the 'UncertQ'.
 instance Definition     UncertQ where defn = coco . defn
+-- ^ Finds definition of the 'ConstrConcept' used to make the 'UncertQ'.
 instance ConceptDomain  UncertQ where cdom = cdom . view coco
+-- ^ Finds the domain contained in the 'ConstrConcept' used to make the 'UncertQ'.
 instance MayHaveUnit    UncertQ where getUnit = getUnit . view coco
+-- ^ Finds the units of the 'ConstrConcept' used to make the 'UncertQ'.
 
 {-- Constructors --}
--- | The UncertainQuantity constructor. Requires a Quantity, a percentage, and a typical value
+-- | Smart constructor that requires a 'Quantity', a percentage, and a typical value with an 'Uncertainty'.
 uq :: (Quantity c, Constrained c, Concept c, HasReasVal c, MayHaveUnit c) =>
   c -> Uncertainty -> UncertQ
 uq q = UQ (ConstrConcept (dqdWr q) (q ^. constraints) (q ^. reasVal))
 
 --FIXME: this is kind of crazy and probably shouldn't be used!
--- | Uncertainty quantity ('uq') but with a constraint
+-- | Uncertainty quantity ('uq') but with a constraint.
 uqc :: (IsUnit u) => String -> NP -> String -> Symbol -> u -> Space
                 -> [Constraint] -> Expr -> Uncertainty -> UncertQ
 uqc nam trm desc sym un space cs val = uq (cuc' nam trm desc sym un space cs val)
 
--- | Uncertainty quantity constraint ('uqc') with no description 
+-- | Uncertainty quantity constraint ('uqc') without a description.
 uqcND :: (IsUnit u) => String -> NP -> Symbol -> u -> Space -> [Constraint]
                   -> Expr -> Uncertainty -> UncertQ
 uqcND nam trm sym un space cs val = uq (cuc' nam trm "" sym un space cs val)

--- a/code/drasil-lang/Language/Drasil/Chunk/UnitDefn.hs
+++ b/code/drasil-lang/Language/Drasil/Chunk/UnitDefn.hs
@@ -25,7 +25,7 @@ import Language.Drasil.UID
 
 -- | For defining units.
 -- It has a 'ConceptChunk' (that defines what kind of unit it is),
--- has a unit symbol, maybe another (when it is a synonym),
+-- a unit symbol, maybe another (when it is a synonym),
 -- perhaps a definition, and a list of 'UID' of the units that make up
 -- the definition.
 data UnitDefn = UD { _vc :: ConceptChunk 
@@ -34,60 +34,77 @@ data UnitDefn = UD { _vc :: ConceptChunk
 makeLenses ''UnitDefn
 
 instance HasUID        UnitDefn where uid = vc . uid
+-- ^ Finds 'UID' of the 'ConceptChunk' used to make the 'UnitDefn'.
 instance NamedIdea     UnitDefn where term   = vc . term
+-- ^ Finds term ('NP') of the 'ConceptChunk' used to make the 'UnitDefn'.
 instance Idea          UnitDefn where getA c = getA (c ^. vc)
+-- ^ Finds the idea contained in the 'ConceptChunk' used to make the 'UnitDefn'.
 instance Definition    UnitDefn where defn = vc . defn
+-- ^ Finds definition of the 'ConceptChunk' used to make the 'UnitDefn'.
 instance Eq            UnitDefn where a == b = usymb a == usymb b
+-- ^ Equal if 'Symbol's are equal.
 instance ConceptDomain UnitDefn where cdom = cdom . view vc
+-- ^ Finds the domain contained in the 'ConceptChunk' used to make the 'UnitDefn'.
 instance HasUnitSymbol UnitDefn where usymb = getUSymb . view cas
-instance IsUnit        UnitDefn where udefn = getDefn . view cas
-                                      getUnits = view cu
+-- ^ Finds unit symbol of the 'ConceptChunk' used to make the 'UnitDefn'.
+instance IsUnit        UnitDefn where 
+  udefn = getDefn . view cas
+  -- ^ Finds unit definition of 'UnitDefn'.
+  getUnits = view cu
+  -- ^ Finds list of 'UID' from 'UnitDefn'.
+
+-- | Types may contain a unit ('UnitDefn').
 class MayHaveUnit u where
    getUnit :: u -> Maybe UnitDefn
 
+-- | Takes a contributing unit (['UID']) and a symbol ('USymb').
 data UnitEquation = UE {_contributingUnit :: [UID]
                        , _us :: USymb}
 makeLenses ''UnitEquation
 instance HasUnitSymbol UnitEquation where usymb u = u ^. us
+-- ^ Finds the unit symbol ('USymb') for a 'UnitEquation'.
 
--- | Get a list of 'UID' of the units that make up the 'UnitEquation'
+-- | Get a list of 'UID' of the units that make up the 'UnitEquation'.
 getCu :: UnitEquation -> [UID]
 getCu = view contributingUnit
 
--- | Create a derived unit chunk from a concept and a unit equation
+-- | Create a derived unit chunk from a concept and a unit equation.
 makeDerU :: ConceptChunk -> UnitEquation -> UnitDefn
 makeDerU concept eqn = UD concept (Defined (usymb eqn) (USynonym $ usymb eqn)) (getCu eqn)
 
 derCUC, derCUC' :: String -> String -> String -> Symbol -> UnitEquation -> UnitDefn
--- | Create a 'SI_Unit' with two 'Symbol' representations. The created 'NP' is self-plural
+-- | Create a 'SI_Unit' with two 'Symbol' representations. The created 'NP' is self-plural.
 derCUC a b c s ue = UD (dcc a (cn b) c) (DerivedSI (US [(s,1)]) (usymb ue) (USynonym $ usymb ue)) [a]
 -- | Similar to 'derCUC', but the created 'NP' has the 'AddS' plural rule.
 derCUC' a b c s ue = UD (dcc a (cn' b) c) (DerivedSI (US [(s,1)]) (usymb ue) (USynonym $ usymb ue)) [a]
  
--- | Create a derived unit chunk from an id, term (as 'String'), definition,
--- symbol, and unit equation
+-- | Create a derived unit chunk from a 'UID', term ('String'), definition,
+-- 'Symbol', and unit equation.
 derUC, derUC' :: String -> String -> String -> Symbol -> UDefn -> UnitDefn
--- | Uses self-plural term
+-- | Uses self-plural term.
 derUC  a b c s u = UD (dcc a (cn b) c) (DerivedSI (US [(s,1)]) (fromUDefn u) u) []
--- | Uses term that pluralizes by adding *s* to the end
+-- | Uses term that pluralizes by adding "s" to the end.
 derUC' a b c s u = UD (dcc a (cn' b) c) (DerivedSI (US [(s,1)]) (fromUDefn u) u) []
 
+-- | Create a derived unit chunk from a 'UID', term ('NP'), definition, 
+-- 'Symbol', and unit equation.
 derCUC'' :: String -> NP -> String -> Symbol -> UnitEquation -> UnitDefn
 derCUC'' a b c s ue = UD (dcc a b c) (DerivedSI (US [(s,1)]) (usymb ue) (USynonym $ usymb ue)) (getCu ue)
--- | Create a derived unit chunk from an id, term (as noun phrase), definition, 
--- symbol, and unit equation
+-- | Create a derived unit chunk from a 'UID', term ('NP'), definition, 
+-- 'Symbol', and unit equation.
 derUC'' :: String -> NP -> String -> Symbol -> UDefn -> UnitDefn
 derUC'' a b c s u = UD (dcc a b c) (DerivedSI (US [(s,1)]) (fromUDefn u) u) []
 
 --FIXME: Make this use a meaningful identifier.
--- | Helper for fundamental unit concept chunk creation. Uses the same string
+-- | Helper for fundamental unit concept chunk creation. Uses the same 'String'
 -- for the identifier, term, and definition.
 unitCon :: String -> ConceptChunk
 unitCon s = dcc s (cn' s) s
 ---------------------------------------------------------
 
+-- TODO: Could use a clearer definition here
 -- | For allowing lists to mix the two, thus forgetting
--- the definition part
+-- the definition part.
 unitWrapper :: (IsUnit u)  => u -> UnitDefn
 unitWrapper u = UD (cc' u (u ^. defn)) (Defined (usymb u) (USynonym $ usymb u)) (getUnits u)
 
@@ -106,48 +123,48 @@ helperUnit a = case getSecondSymb a of
   Nothing -> getUnits a
 
 --- These conveniences go here, because we need the class
--- | Combinator for raising a unit to a power
+-- | Combinator for raising a unit to a power.
 (^:) :: UnitDefn -> Integer -> UnitEquation
 u ^: i = UE (helperUnit u) (upow (usymb u))
 --u ^: i = UE ((helperUnit u) ^. uid) (upow (u ^. usymb))
   where
     upow (US l) = US $ map (second (* i)) l
 
--- | Combinator for dividing one unit by another
+-- | Combinator for dividing one unit by another.
 (/:) :: UnitDefn -> UnitDefn -> UnitEquation
 u1 /: u2 = let US l1 = usymb u1
                US l2 = usymb u2 in
   UE (helperUnit u1 ++ helperUnit u2) (US $ l1 ++ map (second negate) l2)
 
--- | Combinator for multiplying two units together
+-- | Combinator for multiplying two units together.
 (*:) :: UnitDefn -> UnitDefn -> UnitEquation
 u1 *: u2 = let US l1 = usymb u1
                US l2 = usymb u2 in
   UE (helperUnit u1 ++ helperUnit u2) (US $ l1 ++ l2)
 
--- | Combinator for multiplying a unit and a symbol
+-- | Combinator for multiplying a unit and a symbol.
 (*$) :: UnitDefn -> UnitEquation -> UnitEquation
 u1 *$ u2 = let US l1 = usymb u1
                US l2 = usymb u2 in
   UE (helperUnit u1 ++ getCu u2) (US $ l1 ++ l2)
 
--- | Combinator for dividing a unit and a symbol
+-- | Combinator for dividing a unit and a symbol.
 (/$) :: UnitDefn -> UnitEquation -> UnitEquation
 u1 /$ u2 = let US l1 = usymb u1
                US l2 = usymb u2 in
   UE (helperUnit u1 ++ getCu u2) (US $ l1 ++ map (second negate) l2)
 
--- | Combinator for mulitiplying two unit equations
+-- | Combinator for mulitiplying two unit equations.
 (^$) :: UnitEquation -> UnitEquation -> UnitEquation
 u1 ^$ u2 = let US l1 = usymb u1
                US l2 = usymb u2 in
   UE (getCu u1 ++ getCu u2) (US $ l1 ++ l2)
  
--- | Combinator for scaling one unit by some number
+-- | Combinator for scaling one unit by some number.
 scale :: IsUnit s => Double -> s -> UDefn
 scale a b = UScale a (usymb b)
 
--- | Combinator for shifting one unit by some number
+-- | Combinator for shifting one unit by some number.
 shift :: IsUnit s => Double -> s -> UDefn
 shift a b = UShift a (usymb b)
 
@@ -155,14 +172,14 @@ shift a b = UShift a (usymb b)
 newUnit :: String -> UnitEquation -> UnitDefn
 newUnit s = makeDerU (unitCon s)
 
--- | Smart constructor for a "fundamental" unit
+-- | Smart constructor for a "fundamental" unit.
 fund :: String -> String -> String -> UnitDefn
 fund nam desc sym = UD (dcc nam (cn' nam) desc) (BaseSI $ US [(Label sym, 1)]) [nam]
 
--- | Variant of the above, useful for degree
+-- | Variant of the 'fund', useful for degree.
 fund' :: String -> String -> Symbol -> UnitDefn
 fund' nam desc sym = UD (dcc nam (cn' nam) desc) (BaseSI $ US [(sym, 1)]) [nam]
 
--- | We don't want an Ord on units, but this still allows us to compare them
+-- | We don't want an Ord on units, but this still allows us to compare them.
 compUnitDefn :: UnitDefn -> UnitDefn -> Ordering
 compUnitDefn a b = compUSymb (usymb a) (usymb b)

--- a/code/drasil-lang/Language/Drasil/Chunk/Unital.hs
+++ b/code/drasil-lang/Language/Drasil/Chunk/Unital.hs
@@ -17,32 +17,43 @@ import Language.Drasil.Space (Space(..))
 import Language.Drasil.Sentence (Sentence)
 import Language.Drasil.Stages (Stage)
 
--- | UnitalChunks are 'DefinedQuantityDict's with a 'UnitDefn'
+-- | UnitalChunks are concepts with quantities and a unit definition.
+-- Contains 'DefinedQuantityDict's and a 'UnitDefn'.
 data UnitalChunk = UC { _defq' :: DefinedQuantityDict
                       , _uni :: UnitDefn
                       }
 makeLenses ''UnitalChunk
 
 instance HasUID        UnitalChunk where uid = defq' . uid
+-- ^ Finds 'UID' of the 'DefinedQuantityDict' used to make the 'UnitalChunk'.
 instance NamedIdea     UnitalChunk where term = defq' . term
+-- ^ Finds term ('NP') of the 'DefinedQuantityDict' used to make the 'UnitalChunk'.
 instance Idea          UnitalChunk where getA (UC qc _) = getA qc
+-- ^ Finds the idea contained in the 'DefinedQuantityDict' used to make the 'UnitalChunk'.
 instance Definition    UnitalChunk where defn = defq' . defn
+-- ^ Finds definition of the 'DefinedQuantityDict' used to make the 'UnitalChunk'.
 instance ConceptDomain UnitalChunk where cdom = cdom . view defq'
+-- ^ Finds the domain contained in the 'DefinedQuantityDict' used to make the 'UnitalChunk'.
 instance HasSpace      UnitalChunk where typ = defq' . typ
+-- ^ Finds the 'Space' of the 'DefinedQuantityDict' used to make the 'UnitalChunk'.
 instance HasSymbol     UnitalChunk where symbol c = symbol (c^.defq')
+-- ^ Finds the 'Symbol' of the 'DefinedQuantityDict' used to make the 'UnitalChunk'.
 instance Quantity      UnitalChunk where 
 instance Unitary       UnitalChunk where unit = view uni
+-- ^ Finds the unit definition of a 'UnitalChunk'.
 instance MayHaveUnit   UnitalChunk where getUnit = Just . view uni
+-- ^ Finds the units of the 'DefinedQuantityDict' used to make the 'UnitalChunk'.
 instance Eq            UnitalChunk where c1 == c2 = (c1 ^. uid) == (c2 ^. uid) 
+-- ^ Equal if 'UID's are equal.
 
 --{BEGIN HELPER FUNCTIONS}--
 
--- | Used to create a UnitalChunk from a 'Concept', 'Symbol', and 'Unit'.
--- Assumes the 'Space' is Real
+-- | Used to create a 'UnitalChunk' from a 'Concept', 'Symbol', and 'Unit'.
+-- Assumes the 'Space' is Real.
 uc :: (Concept c, IsUnit u) => c -> Symbol -> u -> UnitalChunk
 uc a b = ucs' a b Real
 
--- | Similar to 'uc' but does not assume the 'Space'
+-- | Similar to 'uc' but does not assume the 'Space'.
 ucs' :: (Concept c, IsUnit u) => c -> Symbol -> Space -> u -> UnitalChunk
 ucs' a sym space c = UC (dqd (cw a) sym space un) un
  where un = unitWrapper c
@@ -53,19 +64,19 @@ uc' :: (IsUnit u) => String -> NP -> String -> Symbol -> u -> UnitalChunk
 uc' i t d s u = UC (dqd (dcc i t d) s Real un) un
  where un = unitWrapper u
 
--- | Similar to 'uc'', but 'Symbol' is dependent on the 'Stage'
+-- | Similar to 'uc'', but 'Symbol' is dependent on the 'Stage'.
 ucStaged :: (IsUnit u) => String -> NP -> String -> (Stage -> Symbol) -> u -> 
   UnitalChunk
 ucStaged i t d s u = UC (dqd' (dcc i t d) s Real (Just un)) un
  where un = unitWrapper u
 
--- | Similar to 'uc'', but does not assume the 'Space'
+-- | Similar to 'uc'', but does not assume the 'Space'.
 ucs :: (IsUnit u) => String -> NP ->
   String -> Symbol -> Space -> u -> UnitalChunk
 ucs nam trm desc sym space un = UC (dqd (dcc nam trm desc) sym space uu) uu
   where uu = unitWrapper un
 
--- | Similar to 'ucs', but uses a 'Sentence' for description
+-- | Similar to 'ucs', but uses a 'Sentence' for description.
 ucsWS :: (IsUnit u) => String -> NP ->
   Sentence -> Symbol -> Space -> u -> UnitalChunk
 ucsWS nam trm desc sym space un = UC (dqd (dccWDS nam trm desc) sym space uu) uu
@@ -73,7 +84,7 @@ ucsWS nam trm desc sym space un = UC (dqd (dccWDS nam trm desc) sym space uu) uu
 
 --Better names will come later.
 -- | Creates a 'UnitalChunk' in the same way as 'uc'', but with a 'Sentence' for
--- the definition instead of a String
+-- the definition instead of a 'String'.
 makeUCWDS :: (IsUnit u) => String -> NP -> Sentence -> Symbol ->
   u -> UnitalChunk
 makeUCWDS nam trm desc sym un = UC (dqd (dccWDS nam trm desc) sym Real uu) uu

--- a/code/drasil-lang/Language/Drasil/Chunk/Unitary.hs
+++ b/code/drasil-lang/Language/Drasil/Chunk/Unitary.hs
@@ -15,41 +15,48 @@ import Language.Drasil.NounPhrase (NP)
 
 import Control.Lens ((^.), makeLenses)
 
--- | A Unitary is a 'Quantity' that __must__ have a unit
+-- | A Unitary is a 'Quantity' that __must__ have a unit.
 class (Quantity c) => Unitary c where
   unit :: c -> UnitDefn
 
--- | UnitaryChunks are 'Unitary's with 'Symbols'
+-- | UnitaryChunks are 'Unitary's with 'Symbols'. Contains a 'QuantityDict' and a 'UnitDefn'.
 data UnitaryChunk = UC { _quant :: QuantityDict
                        , _un :: UnitDefn
                        }
 makeLenses ''UnitaryChunk
 
 instance HasUID        UnitaryChunk where uid = quant . uid
+-- ^ Finds 'UID' of the 'QuantityDict' used to make the 'UnitaryChunk'.
 instance NamedIdea     UnitaryChunk where term = quant . term
+-- ^ Finds term ('NP') of the 'QuantityDict' used to make the 'UnitaryChunk'.
 instance Idea          UnitaryChunk where getA uc = getA $ uc ^. quant
+-- ^ Finds the idea contained in the 'QuantityDict' used to make the 'UnitaryChunk'.
 instance HasSpace      UnitaryChunk where typ = quant . typ
+-- ^ Finds the 'Space' of the 'QuantityDict' used to make the 'UnitaryChunk'.
 instance HasSymbol     UnitaryChunk where symbol u = symbol (u^.quant)
+-- ^ Finds the 'Symbol' of the 'QuantityDict' used to make the 'UnitaryChunk'.
 instance Quantity      UnitaryChunk where 
 instance Unitary       UnitaryChunk where unit x = x ^. un
+-- ^ Finds the unit definition of a 'UnitaryChunk'.
 instance MayHaveUnit   UnitaryChunk where getUnit u = Just $ u ^. un
+-- ^ Finds the units of the 'QuantityDict' used to make the 'UnitaryChunk'.
 
--- | Builds the 'Quantity' part from the 'UID', term ('NP'), 'Symbol' and 'Space'.
+-- | Builds the 'QuantityDict' part from the 'UID', term ('NP'), 'Symbol', and 'Space'.
 -- Assumes there's no abbreviation.
 unitary :: (IsUnit u) => String -> NP -> Symbol -> u -> Space -> UnitaryChunk
 unitary i t s u space = UC (mkQuant i t s space (Just uu) Nothing) uu -- Unit doesn't have a unitDefn, so [] is passed in
   where uu = unitWrapper u
 
--- | Same as 'unitary' but with a 'Symbol' that changes based on the 'Stage'
+-- | Same as 'unitary' but with a 'Symbol' that changes based on the 'Stage'.
 unitary' :: (IsUnit u) => String -> NP -> (Stage -> Symbol) -> u -> Space -> UnitaryChunk
 unitary' i t s u space = UC (mkQuant' i t Nothing space s (Just uu)) uu -- Unit doesn't have a unitDefn, so [] is passed in
   where uu = unitWrapper u
 
--- | Makes a 'UnitaryChunk' from a unit with a quantity
+-- | Makes a 'UnitaryChunk' from a quantity with a unit.
 mkUnitary :: (Unitary u, MayHaveUnit u) => u -> UnitaryChunk
 mkUnitary u = UC (qw u) (unit u)
 
--- | Helper for getting the unit's symbol from a chunk, 
+-- | Helper for getting the unit's 'Symbol' from a chunk, 
 -- as opposed to the symbols of the chunk itself.
 unit_symb :: (Unitary c) => c -> USymb
 unit_symb c = usymb $ unit c

--- a/code/drasil-lang/Language/Drasil/Chunk/UnitaryConcept.hs
+++ b/code/drasil-lang/Language/Drasil/Chunk/UnitaryConcept.hs
@@ -11,7 +11,7 @@ import Language.Drasil.Chunk.UnitDefn (MayHaveUnit(getUnit))
 import Language.Drasil.Sentence (Sentence)
 import Language.Drasil.UID (UID)
 
--- | Contains a 'UnitaryChunk', a definition, and a list of related 'UID's
+-- | Contains a 'UnitaryChunk', a definition, and a list of related 'UID's.
 data UnitaryConceptDict = UCC { _unitary :: UnitaryChunk
                               , _defn' :: Sentence
                               , cdom' :: [UID]
@@ -19,17 +19,28 @@ data UnitaryConceptDict = UCC { _unitary :: UnitaryChunk
 makeLenses ''UnitaryConceptDict
 
 instance HasUID        UnitaryConceptDict where uid = unitary . uid
+-- ^ Finds 'UID' of the 'UnitaryChunk' used to make the 'UnitaryConceptDict'.
 instance NamedIdea     UnitaryConceptDict where term = unitary . term
+-- ^ Finds term ('NP') of the 'UnitaryChunk' used to make the 'UnitaryConceptDict'.
 instance Idea          UnitaryConceptDict where getA u = getA (u ^. unitary)
+-- ^ Finds the idea contained in the 'UnitaryChunk' used to make the 'UnitaryConceptDict'.
 instance Definition    UnitaryConceptDict where defn = defn'
+-- ^ Finds definition of the 'UnitaryConceptDict'.
 instance ConceptDomain UnitaryConceptDict where cdom = cdom'
+-- ^ Finds the domain of the 'UnitaryConceptDict'.
 instance HasSpace      UnitaryConceptDict where typ = unitary . typ
+-- ^ Finds the 'Space' of the 'UnitaryChunk' used to make the 'UnitaryConceptDict'.
 instance HasSymbol     UnitaryConceptDict where symbol c = symbol (c^.unitary)
+-- ^ Finds the 'Symbol' of the 'UnitaryChunk' used to make the 'UnitaryConceptDict'.
 instance Quantity      UnitaryConceptDict where 
 instance Eq            UnitaryConceptDict where a == b = (a ^. uid) == (b ^. uid)
+-- ^ Equal if 'UID's are equal.
 instance MayHaveUnit   UnitaryConceptDict where getUnit u = getUnit $ u ^. unitary
+-- ^ Finds the units of the 'UnitaryChunk' used to make the 'UnitaryConceptDict'.
 instance Unitary       UnitaryConceptDict where unit x = unit (x ^. unitary)
+-- ^ Finds the quantity of the 'UnitaryChunk' used to make the 'UnitaryConceptDict'.
 
--- | Constructs a UnitaryConceptDict from a 'Concept' with 'Units'
+
+-- | Constructs a UnitaryConceptDict from a 'Concept' with 'Units'.
 ucw :: (Unitary c, Concept c, MayHaveUnit c) => c -> UnitaryConceptDict
 ucw c = UCC (mkUnitary c) (c ^. defn) (cdom c)

--- a/code/drasil-lang/Language/Drasil/Classes/Core.hs
+++ b/code/drasil-lang/Language/Drasil/Classes/Core.hs
@@ -19,7 +19,7 @@ class HasUID c where
   -- | Provides a /unique/ id for internal Drasil use
   uid :: Lens' c UID
 
--- A ShortName is the text to be displayed for a link.
+-- | A ShortName is the text to be displayed for a link.
 -- Used for referencing within a document that can include symbols and whatnot if required.
 -- Visible in the typeset documents (pdf)
 class HasShortName  s where

--- a/code/drasil-lang/Language/Drasil/NounPhrase.hs
+++ b/code/drasil-lang/Language/Drasil/NounPhrase.hs
@@ -17,17 +17,17 @@ import Language.Drasil.Sentence (Sentence((:+:), S), (+:+))
 
 class NounPhrase n where
   phraseNP :: n -> Sentence -- ^ ex. "the quick brown fox"
-  pluralNP :: n -> PluralForm -- ^ ex. "the quick brown foxes" 
+  pluralNP :: n -> PluralForm -- ^ ex. "the quick brown foxes"
     --Could replace plural string with a function.
   sentenceCase :: n -> (NP -> Sentence) -> Capitalization 
     --Should this be replaced with a data type instead?
     --Data types should use functions to determine capitalization based
     -- on rules.
-    -- ^ example: "The quick brown fox" 
+    -- ^ example: "The quick brown fox"
   titleCase :: n -> (NP -> Sentence) -> Capitalization -- ^ ex. "The Quick Brown Fox"
 
-type Capitalization = Sentence  --Using type synonyms for clarity.
-type PluralString   = String
+type Capitalization = Sentence  -- ^ Using type synonyms for clarity.
+type PluralString   = String -- ^ Type synonym for 'String'.
 
 instance NounPhrase NP where
   phraseNP (ProperNoun n _)           = S n

--- a/code/drasil-lang/Language/Drasil/NounPhrase.hs
+++ b/code/drasil-lang/Language/Drasil/NounPhrase.hs
@@ -21,9 +21,9 @@ class NounPhrase n where
     --Could replace plural string with a function.
   sentenceCase :: n -> (NP -> Sentence) -> Capitalization 
     --Should this be replaced with a data type instead?
-    -- ^ example: "The quick brown fox" 
     --Data types should use functions to determine capitalization based
     -- on rules.
+    -- ^ example: "The quick brown fox" 
   titleCase :: n -> (NP -> Sentence) -> Capitalization -- ^ ex. "The Quick Brown Fox"
 
 type Capitalization = Sentence  --Using type synonyms for clarity.


### PR DESCRIPTION
Documented all files in `Chunk` folder under `drasil-lang`. Mostly focused on instances and datatypes, but mainly a second go at the documentation for all of `Chunk` now that I understand more of the functions. Also some style changes.
Contributes #2477. 