### PR TITLE
Alternative style for printing vector magnitude?

### DIFF
--- a/code/drasil-example/Drasil/Projectile/DataDefs.hs
+++ b/code/drasil-example/Drasil/Projectile/DataDefs.hs
@@ -27,7 +27,7 @@ speedIXQD = mkQuantDef ixVel $ sy iSpeed * cos (sy launAngle)
 speedIYQD = mkQuantDef iyVel $ sy iSpeed * sin (sy launAngle)
 
 speedE :: Expr
-speedE = UnaryOp Abs $ sy velocity
+speedE = norm $ sy velocity
 ----------
 magNote :: Sentence
 magNote = foldlSent [S "For a given", phrase velocity, S "vector", ch velocity `sC`

--- a/code/drasil-printers/Language/Drasil/Plain/Print.hs
+++ b/code/drasil-printers/Language/Drasil/Plain/Print.hs
@@ -144,11 +144,11 @@ opsDoc Perc = text "%"
 fenceDocL :: Fence -> Doc
 fenceDocL Paren = text "("
 fenceDocL Curly = text "{"
-fenceDocL Norm = text "||"
+fenceDocL Norm = text "\\|"
 fenceDocL Abs = text "|"
 
 fenceDocR :: Fence -> Doc
 fenceDocR Paren = text ")"
 fenceDocR Curly = text "}"
-fenceDocR Norm = text "||"
+fenceDocR Norm = text "\\|"
 fenceDocR Abs = text "|"

--- a/code/drasil-printers/Language/Drasil/TeX/Print.hs
+++ b/code/drasil-printers/Language/Drasil/TeX/Print.hs
@@ -177,7 +177,7 @@ fence Close Paren = texSym "right)"
 fence Open Curly  = texSym "{"
 fence Close Curly = texSym "}"
 fence _ Abs       = pure $ text "|"
-fence _ Norm      = pure $ text "||"
+fence _ Norm      = pure $ text "\\|"
 
 -- | For printing Matrix
 pMatrix :: [[Expr]] -> D

--- a/code/stable/projectile/SRS/Projectile_SRS.tex
+++ b/code/stable/projectile/SRS/Projectile_SRS.tex
@@ -567,7 +567,7 @@ Units & $\frac{\text{m}}{\text{s}}$
         
 \\ \midrule \\
 Equation & \begin{displaymath}
-           v=|\mathbf{v}|
+           v=||\mathbf{v}||
            \end{displaymath}
 \\ \midrule \\
 Description & \begin{symbDescription}
@@ -575,7 +575,7 @@ Description & \begin{symbDescription}
               \item{$\mathbf{v}$ is the velocity ($\frac{\text{m}}{\text{s}}$)}
               \end{symbDescription}
 \\ \midrule \\
-Notes & For a given velocity vector $\mathbf{v}$, the magnitude of the vector ($|\mathbf{v}|$) is the scalar called speed.
+Notes & For a given velocity vector $\mathbf{v}$, the magnitude of the vector ($||\mathbf{v}||$) is the scalar called speed.
         
 \\ \midrule \\
 Source & --

--- a/code/stable/projectile/SRS/Projectile_SRS.tex
+++ b/code/stable/projectile/SRS/Projectile_SRS.tex
@@ -567,7 +567,7 @@ Units & $\frac{\text{m}}{\text{s}}$
         
 \\ \midrule \\
 Equation & \begin{displaymath}
-           v=||\mathbf{v}||
+           v=\|\mathbf{v}\|
            \end{displaymath}
 \\ \midrule \\
 Description & \begin{symbDescription}
@@ -575,7 +575,7 @@ Description & \begin{symbDescription}
               \item{$\mathbf{v}$ is the velocity ($\frac{\text{m}}{\text{s}}$)}
               \end{symbDescription}
 \\ \midrule \\
-Notes & For a given velocity vector $\mathbf{v}$, the magnitude of the vector ($||\mathbf{v}||$) is the scalar called speed.
+Notes & For a given velocity vector $\mathbf{v}$, the magnitude of the vector ($\|\mathbf{v}\|$) is the scalar called speed.
         
 \\ \midrule \\
 Source & --

--- a/code/stable/projectile/Website/Projectile_SRS.html
+++ b/code/stable/projectile/Website/Projectile_SRS.html
@@ -948,7 +948,7 @@
                     </tr>
                     <tr>
                       <th>Equation</th>
-                      <td>\[v=||\mathbf{v}||\]</td>
+                      <td>\[v=\|\mathbf{v}\|\]</td>
                     </tr>
                     <tr>
                       <th>Description</th>

--- a/code/stable/projectile/Website/Projectile_SRS.html
+++ b/code/stable/projectile/Website/Projectile_SRS.html
@@ -948,7 +948,7 @@
                     </tr>
                     <tr>
                       <th>Equation</th>
-                      <td>\[v=|\mathbf{v}|\]</td>
+                      <td>\[v=||\mathbf{v}||\]</td>
                     </tr>
                     <tr>
                       <th>Description</th>
@@ -967,7 +967,7 @@
                       <th>Notes</th>
                       <td>
                         <p class="paragraph">
-                          For a given velocity vector <em><b>v</b></em>, the magnitude of the vector (<em>|<b>v</b>|</em>) is the scalar called speed.
+                          For a given velocity vector <em><b>v</b></em>, the magnitude of the vector (<em>||<b>v</b>||</em>) is the scalar called speed.
                         </p>
                       </td>
                     </tr>


### PR DESCRIPTION
Builds on #2495 

Just a suggestion, I think the standard way to have vector norms in LaTeX is `\|` wrapped around a vector, so this changes ours from `||`:
![image](https://user-images.githubusercontent.com/1627302/119058535-932a6d00-b99c-11eb-9c11-d5777c16e673.png)

to:
![image](https://user-images.githubusercontent.com/1627302/119058316-24e5aa80-b99c-11eb-9c0c-4151dbd2a8af.png)