### PR TITLE
reuse of phrases with "in the frequency domain"

### DIFF
--- a/code/drasil-example/Drasil/PDController/Concepts.hs
+++ b/code/drasil-example/Drasil/PDController/Concepts.hs
@@ -131,9 +131,9 @@ concepts = map nw defs
 defs :: [ConceptChunk]
 defs
   = [pidCL, pidC, summingPt, powerPlant, secondOrderSystem, processError,
-     simulationTime, processVariable, setPoint, propGain, derGain,
-     ccFrequencyDomain, ccLaplaceTransform, controlVariable, stepTime,
-     ccAbsTolerance, ccRelTolerance, ccTransferFxn, ccDampingCoeff,
-     ccStiffCoeff]
+     simulationTime, processVariable, setPoint, propGain, derGain, propControl, 
+     derControl, ccFrequencyDomain, ccLaplaceTransform, controlVariable, 
+     stepTime, ccAbsTolerance, ccRelTolerance, ccTransferFxn, 
+     ccDampingCoeff, ccStiffCoeff]
 
 

--- a/code/drasil-example/Drasil/PDController/Unitals.hs
+++ b/code/drasil-example/Drasil/PDController/Unitals.hs
@@ -4,7 +4,7 @@ import Drasil.PDController.Concepts
 import Data.Drasil.Constraints (gtZeroConstr)
 import Data.Drasil.SI_Units (second)
 import Language.Drasil
-
+import Utils.Drasil(inThe')
 
 syms, symFS, symFt, symnegInf, symposInf, syminvLaplace, symKd, symKp,
        symYT, symYS, symYrT, symYrS, symET, symES, symPS, symDS, symHS,
@@ -125,15 +125,9 @@ opProcessVariable
 qdProcessVariableTD = qw opProcessVariable
 
 qdSetPointFD
-  = vc "qdSetPointFD" (nounPhraseSent (S "Set-Point in the frequency domain"))
-      symYrS
-      Real
+  = vc "qdSetPointFD" (setPoint `inThe'` ccFrequencyDomain) symYrS Real
 
-qdProcessVariableFD
-  = vc "qdProcessVariableFD"
-      (nounPhraseSent (S "Process Variable in the frequency domain"))
-      symYS
-      Real
+qdProcessVariableFD = vc "qdProcessVariableFD" (processVariable `inThe'` ccFrequencyDomain) symYS Real
 
 qdProcessErrorTD
   = vc "qdProcessErrorTD"
@@ -141,50 +135,32 @@ qdProcessErrorTD
       symET
       Real
 
-qdProcessErrorFD
-  = vc "qdProcessErrorFD"
-      (nounPhraseSent (S "Process Error in the frequency domain"))
-      symES
-      Real
+qdProcessErrorFD = vc "qdProcessErrorFD" (processError `inThe'` ccFrequencyDomain) symES Real
 
-qdPropControlFD
-  = vc "qdPropControlFD"
-      (nounPhraseSent (S "Proportional control in the frequency domain"))
-      symPS
-      Real
+qdPropControlFD  = vc "qdPropControlFD" (propControl `inThe'` ccFrequencyDomain) symPS Real
 
-qdDerivativeControlFD
-  = vc "qdDerivativeControlFD"
-      (nounPhraseSent (S "Derivative control in the frequency domain"))
-      symDS
-      Real
+qdDerivativeControlFD = vc "qdDerivativeControlFD" (derControl  `inThe'` ccFrequencyDomain) symDS Real
 
-qdTransferFunctionFD
-  = vc "qdTransferFunctionFD"
-      (nounPhraseSent (S "Transfer Function in the frequency domain"))
-      symHS
-      Real
+qdTransferFunctionFD = vc "qdTransferFunctionFD" (ccTransferFxn  `inThe'` ccFrequencyDomain) symHS Real
 
 qdCtrlVarTD
   = vc "qdCtrlVarTD" (nounPhraseSent (S "Control Variable in the time domain"))
       symCT
       Real
 
-qdCtrlVarFD
-  = vc "qdCtrlVarFD"
-      (nounPhraseSent (S "Control Variable in the frequency domain"))
-      symCS
-      Real
+qdCtrlVarFD = vc "qdCtrlVarFD" (controlVariable `inThe'` ccFrequencyDomain) symCS Real
 
 qdLaplaceTransform
   = vc "qLaplaceTransform"
       (nounPhraseSent (S "Laplace Transform of a function"))
       symFS
       Real
+
 qdFreqDomain
   = vc "qFreqDomain" (nounPhraseSent (S "Complex frequency-domain parameter"))
       syms
       Real
+      
 qdFxnTDomain
   = vc "qdFxnTDomain" (nounPhraseSent (S "Function in the time domain")) symFt
       Real

--- a/code/stable/pdController/SRS/PDController_SRS.tex
+++ b/code/stable/pdController/SRS/PDController_SRS.tex
@@ -65,15 +65,15 @@ $-∞$ & Negative Infinity & --
 \\
 $AbsTol$ & Absolute Tolerance & --
 \\
-${C_{\text{s}}}$ & Control Variable in the frequency domain & --
+${C_{\text{s}}}$ & Control Variable in the Frequency Domain & --
 \\
 $c$ & Damping coefficient of the spring & --
 \\
 ${c_{\text{t}}}$ & Control Variable in the time domain & --
 \\
-${D_{\text{s}}}$ & Derivative control in the frequency domain & --
+${D_{\text{s}}}$ & Derivative Control in the Frequency Domain & --
 \\
-${E_{\text{s}}}$ & Process Error in the frequency domain & --
+${E_{\text{s}}}$ & Process Error in the Frequency Domain & --
 \\
 ${e_{\text{t}}}$ & Process Error in the time domain & --
 \\
@@ -81,7 +81,7 @@ ${F_{\text{s}}}$ & Laplace Transform of a function & --
 \\
 ${f_{\text{t}}}$ & Function in the time domain & --
 \\
-${H_{\text{s}}}$ & Transfer Function in the frequency domain & --
+${H_{\text{s}}}$ & Transfer Function in the Frequency Domain & --
 \\
 ${K_{\text{d}}}$ & Derivative Gain & --
 \\
@@ -93,9 +93,9 @@ $L⁻¹[F(s)]$ & Inverse Laplace Transform of a function & --
 \\
 $m$ & Mass & ${\text{kg}}$
 \\
-${P_{\text{s}}}$ & Proportional control in the frequency domain & --
+${P_{\text{s}}}$ & Proportional Control in the Frequency Domain & --
 \\
-${R_{\text{s}}}$ & Set-Point in the frequency domain & --
+${R_{\text{s}}}$ & Set-Point in the Frequency Domain & --
 \\
 ${r_{\text{t}}}$ & Set-Point & --
 \\
@@ -109,7 +109,7 @@ ${t_{\text{sim}}}$ & Simulation Time & ${\text{s}}$
 \\
 ${t_{\text{step}}}$ & Step Time & ${\text{s}}$
 \\
-${Y_{\text{s}}}$ & Process Variable in the frequency domain & --
+${Y_{\text{s}}}$ & Process Variable in the Frequency Domain & --
 \\
 ${y_{\text{t}}}$ & Process Variable & --
 \\
@@ -247,6 +247,8 @@ This subsection provides a list of terms that are used in the subsequent section
 \item{Set-Point: The desired value that the control system must reach. This also knows as the reference variable.}
 \item{Proportional Gain: Gain constant of the proportional controller.}
 \item{Derivative Gain: Gain constant of the derivative controller.}
+\item{Proportional Control: A linear feedback control system were correction is applied to the controlledvariable which is proportional to the difference between desired and measured values.}
+\item{Derivative Control: Monitors the rate of change of the error signal and contributes a componentof the output signal (proportional to a derivative of the error signal).}
 \item{Frequency Domain: The analysis of mathematical functions in terms of frequency, instead of time.}
 \item{Laplace transform: An integral transform that converts a function of a real variable t (often time) to a function of a complex variable s (complex frequency).}
 \item{Control Variable: The Control Variable is the output of the PD controller.}
@@ -448,7 +450,7 @@ This section collects and defines all the data needed to build the instance mode
 \phantomsection 
 \label{DD:ddProcessError}
 \\ \midrule \\
-Label & Process Error in the frequency domain
+Label & Process Error in the Frequency Domain
         
 \\ \midrule \\
 Symbol & ${E_{\text{s}}}$
@@ -462,9 +464,9 @@ Equation & \begin{displaymath}
            \end{displaymath}
 \\ \midrule \\
 Description & \begin{symbDescription}
-              \item{${E_{\text{s}}}$ is the Process Error in the frequency domain (Unitless)}
-              \item{${R_{\text{s}}}$ is the Set-Point in the frequency domain (Unitless)}
-              \item{${Y_{\text{s}}}$ is the Process Variable in the frequency domain (Unitless)}
+              \item{${E_{\text{s}}}$ is the Process Error in the Frequency Domain (Unitless)}
+              \item{${R_{\text{s}}}$ is the Set-Point in the Frequency Domain (Unitless)}
+              \item{${Y_{\text{s}}}$ is the Process Variable in the Frequency Domain (Unitless)}
               \end{symbDescription}
 \\ \midrule \\
 Notes & The Process Error is the difference between the Set-Point and Process Variable. The equation is converted to the frequency domain by applying the Laplace transform (from \hyperref[TM:laplaceTransform]{TM: laplaceTransform}). The Set-Point is assumed to be constant throughout the simulation (from \hyperref[setPoint]{A: Set-Point}). The initial value of the Process Variable is assumed to be zero (from \hyperref[initialValue]{A: Initial Value}).
@@ -487,7 +489,7 @@ RefBy & \hyperref[DD:ddPropCtrl]{DD: ddPropCtrl}, \hyperref[DD:ddDerivCtrl]{DD: 
 \phantomsection 
 \label{DD:ddPropCtrl}
 \\ \midrule \\
-Label & Proportional control in the frequency domain
+Label & Proportional Control in the Frequency Domain
         
 \\ \midrule \\
 Symbol & ${P_{\text{s}}}$
@@ -501,9 +503,9 @@ Equation & \begin{displaymath}
            \end{displaymath}
 \\ \midrule \\
 Description & \begin{symbDescription}
-              \item{${P_{\text{s}}}$ is the Proportional control in the frequency domain (Unitless)}
+              \item{${P_{\text{s}}}$ is the Proportional Control in the Frequency Domain (Unitless)}
               \item{${K_{\text{p}}}$ is the Proportional Gain (Unitless)}
-              \item{${E_{\text{s}}}$ is the Process Error in the frequency domain (Unitless)}
+              \item{${E_{\text{s}}}$ is the Process Error in the Frequency Domain (Unitless)}
               \end{symbDescription}
 \\ \midrule \\
 Notes & The Proportional Controller is the product of the Proportional Gain and the Process Error (from \hyperref[DD:ddProcessError]{DD: ddProcessError}). The equation is converted to the frequency domain by applying the Laplace transform (from \hyperref[TM:laplaceTransform]{TM: laplaceTransform}).
@@ -526,7 +528,7 @@ RefBy & \hyperref[DD:ddCtrlVar]{DD: ddCtrlVar}
 \phantomsection 
 \label{DD:ddDerivCtrl}
 \\ \midrule \\
-Label & Derivative control in the frequency domain
+Label & Derivative Control in the Frequency Domain
         
 \\ \midrule \\
 Symbol & ${D_{\text{s}}}$
@@ -540,9 +542,9 @@ Equation & \begin{displaymath}
            \end{displaymath}
 \\ \midrule \\
 Description & \begin{symbDescription}
-              \item{${D_{\text{s}}}$ is the Derivative control in the frequency domain (Unitless)}
+              \item{${D_{\text{s}}}$ is the Derivative Control in the Frequency Domain (Unitless)}
               \item{${K_{\text{d}}}$ is the Derivative Gain (Unitless)}
-              \item{${E_{\text{s}}}$ is the Process Error in the frequency domain (Unitless)}
+              \item{${E_{\text{s}}}$ is the Process Error in the Frequency Domain (Unitless)}
               \item{$s$ is the Complex frequency-domain parameter (Unitless)}
               \end{symbDescription}
 \\ \midrule \\
@@ -566,7 +568,7 @@ RefBy & \hyperref[DD:ddCtrlVar]{DD: ddCtrlVar}
 \phantomsection 
 \label{DD:ddCtrlVar}
 \\ \midrule \\
-Label & Control Variable in the frequency domain
+Label & Control Variable in the Frequency Domain
         
 \\ \midrule \\
 Symbol & ${C_{\text{s}}}$
@@ -580,8 +582,8 @@ Equation & \begin{displaymath}
            \end{displaymath}
 \\ \midrule \\
 Description & \begin{symbDescription}
-              \item{${C_{\text{s}}}$ is the Control Variable in the frequency domain (Unitless)}
-              \item{${E_{\text{s}}}$ is the Process Error in the frequency domain (Unitless)}
+              \item{${C_{\text{s}}}$ is the Control Variable in the Frequency Domain (Unitless)}
+              \item{${E_{\text{s}}}$ is the Process Error in the Frequency Domain (Unitless)}
               \item{${K_{\text{p}}}$ is the Proportional Gain (Unitless)}
               \item{${K_{\text{d}}}$ is the Derivative Gain (Unitless)}
               \item{$s$ is the Complex frequency-domain parameter (Unitless)}

--- a/code/stable/pdController/Website/PDController_SRS.html
+++ b/code/stable/pdController/Website/PDController_SRS.html
@@ -72,7 +72,7 @@
                 </tr>
                 <tr>
                   <td><em>C<sub>s</sub></em></td>
-                  <td>Control Variable in the frequency domain</td>
+                  <td>Control Variable in the Frequency Domain</td>
                   <td>--</td>
                 </tr>
                 <tr>
@@ -87,12 +87,12 @@
                 </tr>
                 <tr>
                   <td><em>D<sub>s</sub></em></td>
-                  <td>Derivative control in the frequency domain</td>
+                  <td>Derivative Control in the Frequency Domain</td>
                   <td>--</td>
                 </tr>
                 <tr>
                   <td><em>E<sub>s</sub></em></td>
-                  <td>Process Error in the frequency domain</td>
+                  <td>Process Error in the Frequency Domain</td>
                   <td>--</td>
                 </tr>
                 <tr>
@@ -112,7 +112,7 @@
                 </tr>
                 <tr>
                   <td><em>H<sub>s</sub></em></td>
-                  <td>Transfer Function in the frequency domain</td>
+                  <td>Transfer Function in the Frequency Domain</td>
                   <td>--</td>
                 </tr>
                 <tr>
@@ -142,12 +142,12 @@
                 </tr>
                 <tr>
                   <td><em>P<sub>s</sub></em></td>
-                  <td>Proportional control in the frequency domain</td>
+                  <td>Proportional Control in the Frequency Domain</td>
                   <td>--</td>
                 </tr>
                 <tr>
                   <td><em>R<sub>s</sub></em></td>
-                  <td>Set-Point in the frequency domain</td>
+                  <td>Set-Point in the Frequency Domain</td>
                   <td>--</td>
                 </tr>
                 <tr>
@@ -182,7 +182,7 @@
                 </tr>
                 <tr>
                   <td><em>Y<sub>s</sub></em></td>
-                  <td>Process Variable in the frequency domain</td>
+                  <td>Process Variable in the Frequency Domain</td>
                   <td>--</td>
                 </tr>
                 <tr>
@@ -423,6 +423,12 @@
                   </li>
                   <li>
                     Derivative Gain: Gain constant of the derivative controller.
+                  </li>
+                  <li>
+                    Proportional Control: A linear feedback control system were correction is applied to the controlledvariable which is proportional to the difference between desired and measured values.
+                  </li>
+                  <li>
+                    Derivative Control: Monitors the rate of change of the error signal and contributes a componentof the output signal (proportional to a derivative of the error signal).
                   </li>
                   <li>
                     Frequency Domain: The analysis of mathematical functions in terms of frequency, instead of time.
@@ -803,7 +809,7 @@
                     <tr>
                       <th>Label</th>
                       <td>
-                        <p class="paragraph">Process Error in the frequency domain</p>
+                        <p class="paragraph">Process Error in the Frequency Domain</p>
                       </td>
                     </tr>
                     <tr>
@@ -823,13 +829,13 @@
                       <td>
                         <ul class="hide-list-style-no-indent">
                           <li>
-                            <em>E<sub>s</sub></em> is the Process Error in the frequency domain (Unitless)
+                            <em>E<sub>s</sub></em> is the Process Error in the Frequency Domain (Unitless)
                           </li>
                           <li>
-                            <em>R<sub>s</sub></em> is the Set-Point in the frequency domain (Unitless)
+                            <em>R<sub>s</sub></em> is the Set-Point in the Frequency Domain (Unitless)
                           </li>
                           <li>
-                            <em>Y<sub>s</sub></em> is the Process Variable in the frequency domain (Unitless)
+                            <em>Y<sub>s</sub></em> is the Process Variable in the Frequency Domain (Unitless)
                           </li>
                         </ul>
                       </td>
@@ -869,7 +875,7 @@
                       <th>Label</th>
                       <td>
                         <p class="paragraph">
-                          Proportional control in the frequency domain
+                          Proportional Control in the Frequency Domain
                         </p>
                       </td>
                     </tr>
@@ -890,11 +896,11 @@
                       <td>
                         <ul class="hide-list-style-no-indent">
                           <li>
-                            <em>P<sub>s</sub></em> is the Proportional control in the frequency domain (Unitless)
+                            <em>P<sub>s</sub></em> is the Proportional Control in the Frequency Domain (Unitless)
                           </li>
                           <li><em>K<sub>p</sub></em> is the Proportional Gain (Unitless)</li>
                           <li>
-                            <em>E<sub>s</sub></em> is the Process Error in the frequency domain (Unitless)
+                            <em>E<sub>s</sub></em> is the Process Error in the Frequency Domain (Unitless)
                           </li>
                         </ul>
                       </td>
@@ -931,7 +937,7 @@
                     <tr>
                       <th>Label</th>
                       <td>
-                        <p class="paragraph">Derivative control in the frequency domain</p>
+                        <p class="paragraph">Derivative Control in the Frequency Domain</p>
                       </td>
                     </tr>
                     <tr>
@@ -951,11 +957,11 @@
                       <td>
                         <ul class="hide-list-style-no-indent">
                           <li>
-                            <em>D<sub>s</sub></em> is the Derivative control in the frequency domain (Unitless)
+                            <em>D<sub>s</sub></em> is the Derivative Control in the Frequency Domain (Unitless)
                           </li>
                           <li><em>K<sub>d</sub></em> is the Derivative Gain (Unitless)</li>
                           <li>
-                            <em>E<sub>s</sub></em> is the Process Error in the frequency domain (Unitless)
+                            <em>E<sub>s</sub></em> is the Process Error in the Frequency Domain (Unitless)
                           </li>
                           <li>
                             <em>s</em> is the Complex frequency-domain parameter (Unitless)
@@ -995,7 +1001,7 @@
                     <tr>
                       <th>Label</th>
                       <td>
-                        <p class="paragraph">Control Variable in the frequency domain</p>
+                        <p class="paragraph">Control Variable in the Frequency Domain</p>
                       </td>
                     </tr>
                     <tr>
@@ -1017,10 +1023,10 @@
                       <td>
                         <ul class="hide-list-style-no-indent">
                           <li>
-                            <em>C<sub>s</sub></em> is the Control Variable in the frequency domain (Unitless)
+                            <em>C<sub>s</sub></em> is the Control Variable in the Frequency Domain (Unitless)
                           </li>
                           <li>
-                            <em>E<sub>s</sub></em> is the Process Error in the frequency domain (Unitless)
+                            <em>E<sub>s</sub></em> is the Process Error in the Frequency Domain (Unitless)
                           </li>
                           <li><em>K<sub>p</sub></em> is the Proportional Gain (Unitless)</li>
                           <li><em>K<sub>d</sub></em> is the Derivative Gain (Unitless)</li>


### PR DESCRIPTION
for the phrases with "in the time domain" it seems like what should be the equivalent of "ccFrequencyDomain" doesn't exist yet. I can create a "ccTimeDomain". and then get started on those.
I can also investigate and work on phrases with "of the" and "of a". I could also look at phrases in the other examples afterwards as well?
is that okay?
@JacquesCarette 

contributes to Issue #2397.