### PR TITLE
Adding concept-level combinators to GlassBR example

### DIFF
--- a/code/drasil-example/Drasil/DblPendulum/Requirements.hs
+++ b/code/drasil-example/Drasil/DblPendulum/Requirements.hs
@@ -54,7 +54,7 @@ nonFuncReqs = [correct, portable]
 
 correct :: ConceptInstance
 correct = cic "correct" (foldlSent [
- atStartNP' (output_ `the_ofThe` code), S "have the",
+ atStartNP' (output_ `the_ofThePS` code), S "have the",
  plural property, S "described in", makeRef2S (propCorSol [] [])
  ]) "Correct" nonFuncReqDom
 

--- a/code/drasil-example/Drasil/GlassBR/Assumptions.hs
+++ b/code/drasil-example/Drasil/GlassBR/Assumptions.hs
@@ -5,6 +5,8 @@ module Drasil.GlassBR.Assumptions (assumpGT, assumpGC, assumpES, assumpSV,
 import Language.Drasil hiding (organization)
 import qualified Drasil.DocLang.SRS as SRS (valsOfAuxCons)
 import Utils.Drasil
+import Utils.Drasil.Concepts
+import qualified Utils.Drasil.NounPhrase as NP
 import qualified Utils.Drasil.Sentence as S
 
 import Data.Drasil.Concepts.Documentation as Doc (assumpDom, condition,
@@ -59,10 +61,10 @@ glassConditionDesc = foldlSent [S "Following", makeCiteInfoS astm2009 (Page [1])
 
 explainScenarioDesc :: Sentence
 explainScenarioDesc = foldlSent [S "This", phrase system, S "only considers the external", 
-  phrase explosion, phrase scenario, S "for its", plural calculation]
+  phraseNP (combineNINI explosion scenario), S "for its", plural calculation]
 
 standardValuesDesc :: UnitaryChunk -> Sentence
-standardValuesDesc mainIdea = foldlSent [S "The", plural value, S "provided in",
+standardValuesDesc mainIdea = foldlSent [atStartNP' (the value), S "provided in",
   makeRef2S $ SRS.valsOfAuxCons ([]::[Contents]) ([]::[Section]), S "are assumed for the", phrase mainIdea, 
   sParen (ch mainIdea) `sC` S "and the", plural materialProprty `S.of_` 
   foldlList Comma List (map ch (take 3 assumptionConstants))]
@@ -78,11 +80,11 @@ boundaryConditionsDesc = foldlSent [S "Boundary", plural condition, S "for the",
   plural calculation]
 
 responseTypeDesc :: Sentence
-responseTypeDesc = foldlSent [S "The", phrase responseTy, S "considered in",
+responseTypeDesc = foldlSent [atStartNP (the responseTy), S "considered in",
   short glassBR, S "is flexural"]
 
 ldfConstantDesc :: QuantityDict -> Sentence
 ldfConstantDesc mainConcept = foldlSent [S "With", phrase reference, S "to",
-  makeRef2S assumpSV `sC` S "the", phrase value `S.of_`
-  phrase mainConcept, sParen (ch mainConcept), S "is a", phrase constant,
-  S "in", short glassBR]
+  makeRef2S assumpSV `sC` phraseNP (NP.the (value `of_`
+  mainConcept)), sParen (ch mainConcept) `S.is` phraseNP (a_ constant)
+  `S.in_` short glassBR]

--- a/code/drasil-example/Drasil/GlassBR/Body.hs
+++ b/code/drasil-example/Drasil/GlassBR/Body.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE PostfixOperators #-}
 module Drasil.GlassBR.Body where
 
 import Control.Lens ((^.))
@@ -51,7 +52,7 @@ import Data.Drasil.SI_Units (kilogram, metre, newton, pascal, second, fundamenta
 import Drasil.GlassBR.Assumptions (assumptionConstants, assumptions)
 import Drasil.GlassBR.Changes (likelyChgs, unlikelyChgs)
 import Drasil.GlassBR.Concepts (acronyms, blastRisk, glaPlane, glaSlab, glassBR, 
-  ptOfExplsn, con, con')
+  ptOfExplsn, con, con', glass)
 import Drasil.GlassBR.DataDefs (qDefns, configFp)
 import qualified Drasil.GlassBR.DataDefs as GB (dataDefs)
 import Drasil.GlassBR.Figures
@@ -107,7 +108,7 @@ mkSRS = [RefSec $ RefProg intro [TUnits, tsymb [TSPurpose, SymbOrder], TAandA],
      IOrgSec orgOfDocIntro Doc.dataDefn (SRS.inModel [] []) orgOfDocIntroEnd],
   StkhldrSec $
     StkhldrProg
-      [Client glassBR $ S "a" +:+ phrase company
+      [Client glassBR $ phraseNP (a_ company)
         +:+. S "named Entuitive" +:+ S "It is developed by Dr." +:+ S (name mCampidelli),
       Cstmr glassBR],
   GSDSec $ GSDProg [SysCntxt [sysCtxIntro, LlC sysCtxFig, sysCtxDesc, sysCtxList],
@@ -188,7 +189,7 @@ termsAndDescBulletsGlTySubSec, termsAndDescBulletsLoadSubSec :: [ItemType]
 termsAndDescBulletsGlTySubSec = [Nested (EmptyS +: titleize glassTy) $
   Bullet $ noRefs $ map tAndDWAcc glassTypes]
 
-termsAndDescBulletsLoadSubSec = [Nested (atStart load `sDash` EmptyS +:+. capSent (load ^. defn)) $
+termsAndDescBulletsLoadSubSec = [Nested (atStart load `sDash` capSent (load ^. defn) !.) $
   Bullet $ noRefs $ map tAndDWAcc (take 2 loadTypes)
   ++
   map tAndDOnly (drop 2 loadTypes)]
@@ -213,13 +214,13 @@ startIntro :: NamedChunk -> Sentence -> CI -> Sentence
 startIntro prgm sfwrPredicts progName = foldlSent [
   atStart prgm, S "is helpful to efficiently" `S.and_` S "correctly predict the"
   +:+. sfwrPredicts, underConsidertn blast,
-  S "The", phrase prgm `sC` S "herein called", short progName `sC`
+  atStartNP (the prgm) `sC` S "herein called", short progName `sC`
   S "aims to predict the", sfwrPredicts, S "using an intuitive",
   phrase interface]
 
 undIR, appStanddIR :: [Sentence]
 undIR = [phrase scndYrCalculus, phrase structuralMechanics, phrase glBreakage,
-  phrase blastRisk, plural computerApp `S.in_` phrase Edu.civilEng]
+  phrase blastRisk, pluralNP (computerApp `in_PS` Edu.civilEng)]
 appStanddIR = [S "applicable" +:+ plural standard +:+
   S "for constructions using glass from" +:+ foldlList Comma List
   (map makeCiteS [astm2009, astm2012, astm2016]) `S.in_`
@@ -239,9 +240,9 @@ scope = foldlSent_ [S "determining the safety of a", phrase glaSlab,
 {--Organization of Document--}
 
 orgOfDocIntro, orgOfDocIntroEnd :: Sentence
-orgOfDocIntro = foldlSent [S "The", phrase organization, S "of this",
-  phrase document, S "follows the", phrase template, S "for an", short Doc.srs,
-  S "for", phrase sciCompS, S "proposed by" +:+ makeCiteS koothoor2013
+orgOfDocIntro = foldlSent [atStartNP (the organization), S "of this",
+  phrase document, S "follows the", phrase template, S "for an", short Doc.srs
+  `S.for` phrase sciCompS, S "proposed by" +:+ makeCiteS koothoor2013
   `S.and_` makeCiteS smithLai2005 `sC` S "with some", 
   plural aspect, S "taken from Volere", phrase template,
   S "16", makeCiteS rbrtsn2012]
@@ -262,24 +263,24 @@ sysCtxIntro :: Contents
 sysCtxIntro = foldlSP
   [makeRef2S sysCtxFig +:+ S "shows the" +:+. phrase sysCont,
    S "A circle represents an external entity outside the" +:+ phrase software
-   `sC` S "the", phrase user, S "in this case. A rectangle represents the",
-   phrase softwareSys, S "itself", sParen (short glassBR) +:+. EmptyS,
-   S "Arrows are used to show the data flow between the" +:+ phrase system,
-   S "and its" +:+ phrase environment]
+   `sC` phraseNP (the user), S "in this case. A rectangle represents the",
+   phrase softwareSys, S "itself", (sParen (short glassBR) !.),
+   S "Arrows are used to show the data flow between the" +:+ phraseNP (system
+   `andIts` environment)]
 
 sysCtxDesc :: Contents
 sysCtxDesc = foldlSPCol
-  [S "The interaction between the", phrase product_, S "and the", phrase user,
+  [S "The interaction between the", phraseNP (product_ `andThe` user),
    S "is through a user" +:+. phrase interface,
-   S "The responsibilities of the", phrase user, S "and the", phrase system,
+   S "The responsibilities of the", phraseNP (user `andThe` system),
    S "are as follows"]
    
 sysCtxUsrResp :: [Sentence]
 sysCtxUsrResp = [S "Provide the" +:+ plural inDatum +:+ S "related to the" +:+
-  phrase glaSlab `S.and_` phrase blastTy `sC` S "ensuring no errors in the" +:+
+  phraseNP (glaSlab `and_` blastTy) `sC` S "ensuring no errors in the" +:+
   plural datum +:+. S "entry",
-  S "Ensure that consistent units are used for" +:+ phrase input_ +:+. plural variable,
-  S "Ensure required" +:+ phrase software +:+ plural assumption +:+
+  S "Ensure that consistent units are used for" +:+. pluralNP (combineNINI input_  variable),
+  S "Ensure required" +:+ pluralNP (combineNINI software assumption) +:+
     sParen (makeRef2S $ SRS.assumpt ([]::[Contents]) ([]::[Section]))
     +:+ S "are appropriate for any particular" +:+
     phrase problem +:+ S "input to the" +:+. phrase software]
@@ -288,7 +289,7 @@ sysCtxSysResp :: [Sentence]
 sysCtxSysResp = [S "Detect data type mismatch, such as a string of characters" +:+
   phrase input_ +:+. S "instead of a floating point number",
   S "Determine if the" +:+ plural input_ +:+ S "satisfy the required" +:+.
-  (phrase physical `S.and_` plural softwareConstraint),
+  pluralNP (physical `and_` softwareConstraint),
   S "Predict whether the" +:+ phrase glaSlab +:+. S "is safe or not"]
   
 sysCtxResp :: [Sentence]
@@ -331,16 +332,16 @@ termsAndDesc = termDefnF' (Just (S "All of the" +:+ plural term_ +:+
 {--Physical System Description--}
 
 physSystParts :: [Sentence]
-physSystParts = [S "The" +:+. phrase glaSlab,
-  foldlSent [S "The" +:+. phrase ptOfExplsn, S "Where the", phrase bomb `sC`
-  S "or", (blast ^. defn) `sC` S "is located. The", phrase sD `S.isThe`
-  phrase distance, S "between the", phrase ptOfExplsn `S.and_` S "the glass"]]
+physSystParts = [(atStartNP (the glaSlab)!.),
+  foldlSent [(atStartNP (the ptOfExplsn) !.), S "Where the", phrase bomb `sC`
+  S "or", (blast ^. defn) `sC` (S "is located" !.), atStartNP (the sD) `S.isThe`
+  phrase distance, S "between the", phrase ptOfExplsn `S.and_` phraseNP (the glass)]]
 
 {--Goal Statements--}
 
 goalInputs :: [Sentence]
-goalInputs = [plural dimension `S.the_ofThe` phrase glaPlane, S "the" +:+ phrase glassTy,
-  plural characteristic `S.the_ofThe` phrase explosion, S "the" +:+ phrase pbTol]
+goalInputs = [pluralNP (dimension `the_ofThePS` glaPlane), phraseNP (the glassTy),
+  pluralNP (characteristic `the_ofThePS` explosion), phraseNP (the pbTol)]
 
 {--SOLUTION CHARACTERISTICS SPECIFICATION--}
 

--- a/code/drasil-example/Drasil/GlassBR/Changes.hs
+++ b/code/drasil-example/Drasil/GlassBR/Changes.hs
@@ -4,7 +4,7 @@ module Drasil.GlassBR.Changes (likelyChgs, unlikelyChgs) where
 
 import Language.Drasil
 import Utils.Drasil
-import qualified Utils.Drasil.Sentence as S
+import Utils.Drasil.Concepts
 
 import Data.Drasil.Concepts.Documentation (condition, goal, input_, likeChgDom,
   software, system, unlikeChgDom, value, variable)
@@ -43,7 +43,7 @@ varValsOfmkEDesc = foldlSent [makeRef2S assumpSV `sC` chgsStart assumpLDFC (S "C
   plural value, S "for", foldlList Comma List (map ch (take 3 assumptionConstants)),
   S "are assumed to be the same for all" +:+. phrase glass,
   S "In the future, these", plural value, S "can be changed to",
-  phrase variable, plural input_]
+  pluralNP (combineNINI variable input_)]
 
 accMoreThanSingleLiteDesc = foldlSent [chgsStart assumpGL (S "The"), phrase software,
   S "may be changed to accommodate more than a single", phrase lite]
@@ -68,7 +68,7 @@ accAlteredGlass           = cic "accAlteredGlass"           accAlteredGlassDesc 
 
 predictWithstandOfCertDegDesc, accAlteredGlassDesc :: Sentence
 
-predictWithstandOfCertDegDesc = foldlSent [phrase goal `S.the_ofTheC` phrase system,
+predictWithstandOfCertDegDesc = foldlSent [atStartNP (goal `the_ofThe` system),
   S "is to predict whether the", phrase glaSlab, S "under consideration can",
   S "withstand an", phrase explosion, S "of a certain degree"]
 

--- a/code/drasil-example/Drasil/GlassBR/IMods.hs
+++ b/code/drasil-example/Drasil/GlassBR/IMods.hs
@@ -4,6 +4,7 @@ import Prelude hiding (exp)
 import Language.Drasil
 import Theory.Drasil (InstanceModel, imNoDeriv, qwC, ModelKinds (OthModel))
 import Utils.Drasil
+import Utils.Drasil.Concepts
 import qualified Utils.Drasil.Sentence as S
 
 import Drasil.GlassBR.DataDefs (probOfBreak, calofCapacity, calofDemand,
@@ -56,7 +57,7 @@ iModDesc main s = foldlSent [S "If", ch main `sC` S "the glass is" +:+.
 -- Intro --
 
 instModIntro :: Sentence
-instModIntro = foldlSent [S "The", phrase goal, makeRef2S willBreakGS, 
+instModIntro = foldlSent [atStartNP (the goal), makeRef2S willBreakGS, 
   S "is met by", makeRef2S pbIsSafe `sC` makeRef2S lrIsSafe]
 
 -- Notes --

--- a/code/drasil-example/Drasil/GlassBR/Requirements.hs
+++ b/code/drasil-example/Drasil/GlassBR/Requirements.hs
@@ -7,6 +7,8 @@ import Drasil.DocLang (inReq, mkQRTuple, mkQRTupleRef, mkValsSourceTable)
 import Drasil.DocLang.SRS (datCon, propCorSol)
 import Theory.Drasil (DataDefinition)
 import Utils.Drasil
+import Utils.Drasil.Concepts
+import qualified Utils.Drasil.NounPhrase as NP
 import qualified Utils.Drasil.Sentence as S
 
 import Data.Drasil.Concepts.Computation (inValue)
@@ -49,10 +51,10 @@ outputValues               = cic "outputValues"               outputValuesDesc  
 
 inReqDesc, sysSetValsFollowingAssumpsDesc, checkInputWithDataConsDesc, outputValsAndKnownValuesDesc, checkGlassSafetyDesc :: Sentence
 
-inReqDesc = foldlList Comma List [S "the" +:+ phrase glass +:+ plural dimension,
-  phrase type_ `S.of_` phrase glass, phrase pbTolfail, plural characteristic `S.the_ofThe` phrase blast]
+inReqDesc = foldlList Comma List [pluralNP (NP.the (combineNINI glass dimension)),
+  phraseNP (type_ `of_` glass), phrase pbTolfail, pluralNP (characteristic `the_ofThePS` blast)]
 
-sysSetValsFollowingAssumpsDesc = foldlSent [S "The", phrase system, S "shall set the known",
+sysSetValsFollowingAssumpsDesc = foldlSent [atStartNP (the system), S "shall set the known",
     plural value, S "as described in", makeRef2S sysSetValsFollowingAssumpsTable]
 
 sysSetValsFollowingAssumpsTable :: LabelledContent
@@ -66,24 +68,24 @@ sysSetValsFollowingAssumpsTable = mkValsSourceTable (mkQRTupleRef r2AQs r2ARs ++
 --FIXME:should constants, LDF, and LSF have some sort of field that holds
 -- the assumption(s) that're being followed? (Issue #349)
 
-checkInputWithDataConsDesc = foldlSent [S "The", phrase system, S "shall check the entered",
+checkInputWithDataConsDesc = foldlSent [atStartNP (the system), S "shall check the entered",
   plural inValue, S "to ensure that they do not exceed the", plural datumConstraint,
   S "mentioned in" +:+. makeRef2S (datCon ([]::[Contents]) ([]::[Section])), 
   S "If any" `S.ofThe` plural inValue, S "are out" `S.of_` S "bounds" `sC`
   S "an", phrase errMsg, S "is displayed" `S.andThe` plural calculation, S "stop"]
 
-outputValsAndKnownValuesDesc = foldlSent [titleize output_, S "the", plural inValue,
+outputValsAndKnownValuesDesc = foldlSent [titleize output_, pluralNP (the inValue),
   S "from", makeRef2S (inReq EmptyS) `S.andThe` S "known", plural value,
   S "from", makeRef2S sysSetValsFollowingAssumps]
 
 checkGlassSafetyDesc = foldlSent_ [S "If", E (sy isSafePb $&& sy isSafeLR),
   sParen (S "from" +:+ makeRef2S pbIsSafe `S.and_` makeRef2S lrIsSafe) `sC`
-  phrase output_, S "the", phrase message, Quote (safeMessage ^. defn),
+  phrase output_, phraseNP (the message), Quote (safeMessage ^. defn),
   S "If the", phrase condition, S "is false, then", phrase output_,
-  S "the", phrase message, Quote (notSafe ^. defn)]
+  phraseNP (the message), Quote (notSafe ^. defn)]
 
 outputValuesDesc :: Sentence
-outputValuesDesc = foldlSent [titleize output_, S "the", plural value, S "from", makeRef2S outputValuesTable]
+outputValuesDesc = foldlSent [titleize output_, pluralNP (the value), S "from", makeRef2S outputValuesTable]
 
 outputValuesTable :: LabelledContent
 outputValuesTable = mkValsSourceTable (mkQRTuple iMods ++ mkQRTuple r6DDs) "ReqOutputs"
@@ -99,23 +101,23 @@ nonfuncReqs = [correct, verifiable, understandable, reusable, maintainable, port
 
 correct :: ConceptInstance
 correct = cic "correct" (foldlSent [
-  plural output_ `S.the_ofTheC` phrase code, S "have the",
+  atStartNP' (output_ `the_ofThePS` code), S "have the",
   plural property, S "described in", makeRef2S (propCorSol [] [])
   ]) "Correct" nonFuncReqDom
  
 verifiable :: ConceptInstance
 verifiable = cic "verifiable" (foldlSent [
-  S "The", phrase code, S "is tested with complete",
+  atStartNP (the code), S "is tested with complete",
   phrase vavPlan]) "Verifiable" nonFuncReqDom
 
 understandable :: ConceptInstance
 understandable = cic "understandable" (foldlSent [
-  S "The", phrase code, S "is modularized with complete",
+  atStartNP (the code), S "is modularized with complete",
   phrase mg `S.and_` phrase mis]) "Understandable" nonFuncReqDom
 
 reusable :: ConceptInstance
 reusable = cic "reusable" (foldlSent [
-  S "The", phrase code, S "is modularized"]) "Reusable" nonFuncReqDom
+  atStartNP (the code), S "is modularized"]) "Reusable" nonFuncReqDom
 
 maintainable :: ConceptInstance
 maintainable = cic "maintainable" (foldlSent [
@@ -126,5 +128,5 @@ maintainable = cic "maintainable" (foldlSent [
 
 portable :: ConceptInstance
 portable = cic "portable" (foldlSent [
-  S "The", phrase code, S "is able to be run in different", plural environment])
+  atStartNP (the code), S "is able to be run in different", plural environment])
   "Portable" nonFuncReqDom

--- a/code/drasil-example/Drasil/GlassBR/Unitals.hs
+++ b/code/drasil-example/Drasil/GlassBR/Unitals.hs
@@ -194,21 +194,21 @@ demand, tmDemand, lRe, tmLRe, nonFactorL, eqTNTWeight :: UnitalChunk
 
 demand      = ucs' demandq lQ Rational pascal --correct Space used?
 
-tmDemand      = ucs' load (Variable "Load") Rational pascal --correct Space used?
+tmDemand    = ucs' load (Variable "Load") Rational pascal --correct Space used?
   
-lRe      = ucs' loadResis (Variable "LR") Rational pascal --correct Space used?
+lRe         = ucs' loadResis (Variable "LR") Rational pascal --correct Space used?
 
-tmLRe      = ucs' capacity (Variable "capacity") Rational pascal --correct Space used?
+tmLRe       = ucs' capacity (Variable "capacity") Rational pascal --correct Space used?
 
-nonFactorL      = ucs' nonFactoredL (Variable "NFL") Rational pascal --correct Space used?
+nonFactorL  = ucs' nonFactoredL (Variable "NFL") Rational pascal --correct Space used?
 
 eqTNTWeight = ucs' eqTNTChar (sub (eqSymb charWeight) (eqSymb tNT)) Real 
   kilogram
 
-loadDur    = unitary "loadDur"    (nounPhraseSP "duration of load")
+loadDur     = unitary "loadDur"    (nounPhraseSP "duration of load")
   (sub lT lDur) second Real
 
-minThick   = unitary "minThick"   (nounPhraseSP "minimum thickness")
+minThick    = unitary "minThick"   (nounPhraseSP "minimum thickness")
   lH metre Rational
 
 sdx         = unitary "sdx" (nounPhraseSent $ phrase standOffDist +:+ sParen (phrase xComp))

--- a/code/drasil-utils/Utils/Drasil/Concepts.hs
+++ b/code/drasil-utils/Utils/Drasil/Concepts.hs
@@ -1,12 +1,12 @@
-module Utils.Drasil.Concepts (and_, and_TSP, andTGen, with, of_, of_NINP, of_TSP, of_PS, of_TPS, ofA,
-ofATPS, ofThe, the_ofThe, onThe, for, forTGen, the, theT, theGen, a_, a_Gen, inThe, compoundNC, compoundNCPP,
-compoundNCGen, compoundNCPS, compoundNCPSPP, compoundNCGenP, combineNINP, combineNPNI) where
+module Utils.Drasil.Concepts (and_, and_TSP, andTGen, andIts, andThe, with, of_, of_NINP, of_TSP, of_PS, of_TPS, ofA,
+ofATPS, ofThe, the_ofThe, the_ofThePS, onThe, for, forTGen, in_, in_PS, the, theT, theGen, a_, a_Gen, inThe, compoundNC, compoundNCPP,
+compoundNCGen, compoundNCPS, compoundNCPSPP, compoundNCGenP, combineNINP, combineNPNI, combineNINI) where
 
 import Language.Drasil
 import qualified Language.Drasil.Development as D
 import Control.Lens ((^.))
 
-import qualified Utils.Drasil.Sentence as S (and_, of_, ofThe, the_ofThe, onThe, for, inThe) 
+import qualified Utils.Drasil.Sentence as S (and_, andIts, andThe, of_, ofThe, the_ofThe, onThe, for, inThe, in_) 
 
 -----------
 --FIXME: Find out why CapFirst and CapWords can't just be used instead of Replace constructor.
@@ -37,6 +37,24 @@ andTGen f1 f2 t1 t2 = nounPhrase''
   (phrase t1 `S.and_` plural t2)
   (Replace (atStart t1 `S.and_` phrase t2))
   (Replace (f1 t1 `S.and_` f2 t2))
+
+-- | Creates a 'NP' by combining two 'NamedIdea's with the words "and its" between
+-- their terms. Plural case is @(phrase t1) "and its" (plural t2)@.
+andIts :: (NamedIdea c, NamedIdea d) => c -> d -> NP
+andIts t1 t2 = nounPhrase''
+  (phrase t1 `S.andIts` phrase t2)
+  (phrase t1 `S.andIts` plural t2)
+  CapFirst
+  CapWords
+
+-- | Creates a 'NP' by combining two 'NamedIdea's with the words "and the" between
+-- their terms. Plural case is @(phrase t1) "and the" (plural t2)@.
+andThe :: (NamedIdea c, NamedIdea d) => c -> d -> NP
+andThe t1 t2 = nounPhrase''
+  (phrase t1 `S.andThe` phrase t2)
+  (phrase t1 `S.andThe` plural t2)
+  CapFirst
+  CapWords
 
 -- | Case with "T1s with T2", as opposed to "T1 with T2", i.e.
 -- singular case is @(plural t1) "with" (phrase t2)@ while the plural case pluralizes both.
@@ -113,9 +131,17 @@ ofThe t1 t2 = nounPhrase''
   (Replace (atStart t1 `S.ofThe` phrase t2))
   (Replace (titleize t1 `S.ofThe` titleize t2))
 
--- | Same as 'S.ofThe'', except prepends "the".
+-- | Same as 'ofThe', except prepends "the".
 the_ofThe :: (NamedIdea c, NamedIdea d) => c -> d -> NP
 the_ofThe t1 t2 = nounPhrase'' 
+  (phrase t1 `S.the_ofThe` phrase t2)
+  (phrase t1 `S.the_ofThe` plural t2)
+  CapFirst
+  CapWords
+
+-- | Same as 'the_ofThe', except plural case is @(plural t1) `S.the_ofThe` (phrase t2)@
+the_ofThePS :: (NamedIdea c, NamedIdea d) => c -> d -> NP
+the_ofThePS t1 t2 = nounPhrase'' 
   (phrase t1 `S.the_ofThe` phrase t2)
   (plural t1 `S.the_ofThe` phrase t2)
   CapFirst
@@ -155,6 +181,23 @@ forTGen f1 f2 t1 t2 = nounPhrase''
   (plural t1 +:+ S "for" +:+ phrase t2)
   (Replace (atStart t1 +:+ S "for" +:+ phrase t2))
   (Replace (f1 t1 +:+ S "for" +:+ f2 t2))
+
+-- | Creates a 'NP' by combining two 'NamedIdea's with the word "in" between
+-- their terms. Plural case is @(phrase t1) "in" (plural t2)@.
+in_ :: (NamedIdea c, NamedIdea d) => c -> d -> NP
+in_ t1 t2 = nounPhrase'' 
+  (phrase t1 `S.in_` phrase t2)
+  (phrase t1 `S.in_` plural t2)
+  CapFirst
+  CapWords
+
+-- | Same as 'in_', except plural case is @(plural t1) "in" (phrase t2)@.
+in_PS :: (NamedIdea c, NamedIdea d) => c -> d -> NP
+in_PS t1 t2 = nounPhrase'' 
+  (phrase t1 `S.in_` phrase t2)
+  (plural t1 `S.in_` phrase t2)
+  CapFirst
+  CapWords
 
 -- | Prepends "the" to a 'NamedIdea'. Similar to 'the'', but not titleized.
 the :: (NamedIdea t) => t -> NP
@@ -227,3 +270,6 @@ combineNINP t1 t2 = nounPhrase'' (phrase t1 +:+ phraseNP t2) (phrase t1 +:+ plur
 -- | Similar to 'combineNINP' but takes in a 'NP' first and a 'NamedIdea' second.
 combineNPNI :: (NamedIdea c) => NP -> c -> NP
 combineNPNI t1 t2 = nounPhrase'' (phraseNP t1 +:+ phrase t2) (phraseNP t1 +:+ plural t2) CapFirst CapWords
+-- | Similar to 'combineNINP' but takes two 'NamedIdea's.
+combineNINI :: (NamedIdea c, NamedIdea d) => c -> d -> NP
+combineNINI t1 t2 = nounPhrase'' (phrase t1 +:+ phrase t2) (phrase t1 +:+ plural t2) CapFirst CapWords

--- a/code/drasil-utils/Utils/Drasil/Concepts.hs
+++ b/code/drasil-utils/Utils/Drasil/Concepts.hs
@@ -1,5 +1,5 @@
 module Utils.Drasil.Concepts (and_, and_TSP, and_PS, and_PP, andTGen, andIts, andThe, with, of_, of_NINP, of_TSP, of_PS, of_TPS, ofA,
-ofATPS, ofThe, ofThePS, the_ofThe, the_ofThePS, onThe, inThe, inThePS, for, forTGen, in_, in_PS, the, theT, theGen, a_, a_Gen, inThe,
+ofATPS, ofThe, ofThePS, the_ofThe, the_ofThePS, onThe, inThe, inThePS, for, forTGen, in_, in_PS, the, theT, theGen, a_, a_Gen,
 compoundNC, compoundNCPP, compoundNCGen, compoundNCPS, compoundNCPSPP, compoundNCGenP, combineNINP, combineNPNI, combineNINI) where
 
 import Language.Drasil


### PR DESCRIPTION
Adding concept-level combinators to GlassBR example, introduced some new combinators to Utils.Drasil.Concepts used in the GlassBR example (this will likely have some merge conflicts with the GamePhys PR, but it should quick to fix when it's ready).
Contributes #2499 