### PR TITLE
Splitting up Haddock documentation

### DIFF
--- a/.github/workflows/Build.yaml
+++ b/.github/workflows/Build.yaml
@@ -50,7 +50,7 @@ jobs:
       - name: "Doxygen"
         run: make doxygen
       - name: "Docs"
-        run: make docs haddockArgs="--no-haddock-deps --no-haddock-hyperlink-source"
+        run: make docs
       - name: "Graphs"
         run: make graphs
       - name: "Build website"

--- a/.github/workflows/Test.yaml
+++ b/.github/workflows/Test.yaml
@@ -66,6 +66,6 @@ jobs:
       - name: "Doxygen"
         run: make doxygen
       - name: "Docs"
-        run: make docs haddockArgs="--no-haddock-deps --no-haddock-hyperlink-source"
+        run: make docs
       - name: "Graphs"
         run: make graphs

--- a/code/Makefile
+++ b/code/Makefile
@@ -171,11 +171,8 @@ analysis: check_stack
 	@mkdir -p $(ANALYSIS_FOLDER)
 	cd $(SCRIPT_FOLDER) && stack exec -- runghc DataTableGen.hs
 
-# use stack to build the documentation too
-$(filter %$(DOC_P_SUFFIX), $(DOC_PACKAGES)): %$(DOC_P_SUFFIX): check_stack
-	stack haddock "drasil-$*" $(haddockArgs)
-
-docs: $(DOC_PACKAGES)
+docs: check_stack
+	sh scripts/make_docs.sh
 
 %$(TEX_E_SUFFIX): EXAMPLE=$(shell echo $* | tr a-z A-Z)
 %$(TEX_E_SUFFIX): EDIR=$($(EXAMPLE)_DIR)

--- a/code/drasil-build/drasil-build.cabal
+++ b/code/drasil-build/drasil-build.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 3d78b46c08af67680dcfaa9191fa7bb26b1bcbc5e4479ec9583ba68d8706756f
+-- hash: fcacf133f18f617ea0275c285750248bc7f1254a879c436db44684e83f01ee0c
 
 name:           drasil-build
 version:        0.1.1.0
@@ -29,7 +29,6 @@ library
       Build.Drasil.Make.Import
       Build.Drasil.Make.MakeString
       Build.Drasil.Make.Print
-      Paths_drasil_build
   hs-source-dirs:
       ./
   ghc-options: -Wall -Wredundant-constraints
@@ -37,4 +36,7 @@ library
       base >=4.7 && <5
     , drasil-lang
     , pretty
+  if false
+    other-modules:
+        Paths_drasil_build
   default-language: Haskell2010

--- a/code/drasil-build/package.yaml
+++ b/code/drasil-build/package.yaml
@@ -22,3 +22,6 @@ library:
   source-dirs: ./
   exposed-modules:
   - Build.Drasil
+  when:
+  - condition: false
+    other-modules: Paths_drasil_build

--- a/code/drasil-code/drasil-code.cabal
+++ b/code/drasil-code/drasil-code.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: a9a50a45f3a9e998f60776d2574553d0a145ad3e40e1f2062e6fec85b9bbc3ee
+-- hash: ef3d221e344d6b4913db63661032e6a726132b5f039fb4119c05d54692b53eb6
 
 name:           drasil-code
 version:        0.1.9.0
@@ -90,6 +90,9 @@ library
     , mtl
     , pretty
     , split
+  if false
+    other-modules:
+        Paths_drasil_code
   default-language: Haskell2010
 
 executable codegenTest

--- a/code/drasil-code/package.yaml
+++ b/code/drasil-code/package.yaml
@@ -82,6 +82,9 @@ library:
     - Language.Drasil.CodeExpr
     - Language.Drasil.CodeSpec
     - Language.Drasil.Mod
+  when:
+  - condition: false
+    other-modules: Paths_drasil_code
 
 executables:
   codegenTest:

--- a/code/drasil-data/drasil-data.cabal
+++ b/code/drasil-data/drasil-data.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: f743e282a93bbbc1ff53332bf4f55c16d7ed6e375660c5150fdc785005579abc
+-- hash: c102bde6a242335d0215ba9d105491b1031080f2b4c370c9e6e52af54e9b441e
 
 name:           drasil-data
 version:        0.1.13.0
@@ -47,8 +47,6 @@ library
       Data.Drasil.Units.Physics
       Data.Drasil.Units.SolidMechanics
       Data.Drasil.Theories.Physics
-  other-modules:
-      Paths_drasil_data
   hs-source-dirs:
       ./
   ghc-options: -Wall -Wredundant-constraints
@@ -59,4 +57,7 @@ library
     , drasil-theory
     , drasil-utils
     , lens
+  if false
+    other-modules:
+        Paths_drasil_data
   default-language: Haskell2010

--- a/code/drasil-data/package.yaml
+++ b/code/drasil-data/package.yaml
@@ -49,3 +49,6 @@ library:
   - Data.Drasil.Units.Physics
   - Data.Drasil.Units.SolidMechanics
   - Data.Drasil.Theories.Physics
+  when:
+  - condition: false
+    other-modules: Paths_drasil_data

--- a/code/drasil-database/drasil-database.cabal
+++ b/code/drasil-database/drasil-database.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: c7914c27958a58ca35e5337f1d6f282141991b1526cc81651588a14c0c87fb86
+-- hash: 3c00f96ea30e6543cf94717fbdfa3548a6a963dcb842e7cc07a140ec80afe866
 
 name:           drasil-database
 version:        0.1.1.0
@@ -27,7 +27,6 @@ library
       Database.Drasil.ChunkDB
       Database.Drasil.ChunkDB.GetChunk
       Database.Drasil.SystemInformation
-      Paths_drasil_database
   hs-source-dirs:
       ./
   ghc-options: -Wall -Wredundant-constraints
@@ -37,4 +36,7 @@ library
     , drasil-lang
     , drasil-theory
     , lens
+  if false
+    other-modules:
+        Paths_drasil_database
   default-language: Haskell2010

--- a/code/drasil-database/package.yaml
+++ b/code/drasil-database/package.yaml
@@ -24,3 +24,6 @@ library:
   source-dirs: ./
   exposed-modules:
   - Database.Drasil
+  when:
+  - condition: false
+    other-modules: Paths_drasil_database

--- a/code/drasil-docLang/drasil-docLang.cabal
+++ b/code/drasil-docLang/drasil-docLang.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 6f978264fbfc29f81be470962339098152c6c923043130ebd7d8a21ddf9e3ea2
+-- hash: 959b8d65d9d5c1afea29ace890f800b161e03a51410286826562a151c92d29ab
 
 name:           drasil-docLang
 version:        0.1.26.0
@@ -46,7 +46,6 @@ library
       Drasil.Sections.TableOfUnits
       Drasil.Sections.TraceabilityMandGs
       Drasil.TraceTable
-      Paths_drasil_docLang
   hs-source-dirs:
       ./
   ghc-options: -Wall -Wredundant-constraints
@@ -63,4 +62,7 @@ library
     , multiplate
     , pretty
     , transformers
+  if false
+    other-modules:
+        Paths_drasil_docLang
   default-language: Haskell2010

--- a/code/drasil-docLang/package.yaml
+++ b/code/drasil-docLang/package.yaml
@@ -33,3 +33,6 @@ library:
   - Drasil.DocLang
   - Drasil.DocLang.SRS
   - Drasil.DocumentLanguage.Units
+  when:
+  - condition: false
+    other-modules: Paths_drasil_docLang

--- a/code/drasil-gen/drasil-gen.cabal
+++ b/code/drasil-gen/drasil-gen.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 1a1bb141778cbdd79ef6f3b712d9e73bf6b0a527c10889de868f32565e70cfed
+-- hash: 505fea915d5f809dbbaa1a880d3850369e342069fdc3ac2b9293735435a973f0
 
 name:           drasil-gen
 version:        0.1.3.0
@@ -25,7 +25,6 @@ library
       Language.Drasil.Generate
   other-modules:
       Language.Drasil.Output.Formats
-      Paths_drasil_gen
   hs-source-dirs:
       ./
   ghc-options: -Wall -Wredundant-constraints
@@ -39,4 +38,7 @@ library
     , drasil-printers
     , pretty
     , time
+  if false
+    other-modules:
+        Paths_drasil_gen
   default-language: Haskell2010

--- a/code/drasil-gen/package.yaml
+++ b/code/drasil-gen/package.yaml
@@ -28,3 +28,6 @@ library:
   source-dirs: ./
   exposed-modules:
   - Language.Drasil.Generate
+  when:
+  - condition: false
+    other-modules: Paths_drasil_gen

--- a/code/drasil-gool/drasil-gool.cabal
+++ b/code/drasil-gool/drasil-gool.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: bc4d9c2026a30622f7d3d0cf67e8a1cce5cdf5b41910e6fe7f98db4278b9ba37
+-- hash: 5a0b328c117c3657697e6ee4a86bb584ebf63d0093089238a1af21efccbe1d7d
 
 name:           drasil-gool
 version:        0.1.1.0
@@ -44,7 +44,6 @@ library
       GOOL.Drasil.LanguageRenderer.SwiftRenderer
       GOOL.Drasil.RendererClasses
       GOOL.Drasil.State
-      Paths_drasil_gool
   hs-source-dirs:
       ./
   ghc-options: -Wall -Wredundant-constraints
@@ -57,4 +56,7 @@ library
     , lens
     , mtl
     , pretty
+  if false
+    other-modules:
+        Paths_drasil_gool
   default-language: Haskell2010

--- a/code/drasil-gool/package.yaml
+++ b/code/drasil-gool/package.yaml
@@ -27,3 +27,6 @@ library:
   source-dirs: ./
   exposed-modules:
   - GOOL.Drasil
+  when:
+  - condition: false
+    other-modules: Paths_drasil_gool

--- a/code/drasil-lang/drasil-lang.cabal
+++ b/code/drasil-lang/drasil-lang.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: a66fc1dd99658187a5fe62a5cda4c43ba29e84dce6f22f0b37b85288ae0858bf
+-- hash: f5b13da53fd5de44b65ca88e3e532fe2c7417b2289d1bc4f892f1f10bf13b781
 
 name:           drasil-lang
 version:        0.1.60.0
@@ -77,7 +77,6 @@ library
       Language.Drasil.Unicode
       Language.Drasil.UnitLang
       Language.Drasil.URI.AST
-      Paths_drasil_lang
   hs-source-dirs:
       ./
   ghc-options: -Wall -Wredundant-constraints
@@ -86,4 +85,7 @@ library
     , lens
     , split
     , unicode-names >=3.2.0.0
+  if false
+    other-modules:
+        Paths_drasil_lang
   default-language: Haskell2010

--- a/code/drasil-lang/package.yaml
+++ b/code/drasil-lang/package.yaml
@@ -25,3 +25,6 @@ library:
   - Language.Drasil
   - Language.Drasil.Development
   - Language.Drasil.ShortHands
+  when:
+  - condition: false
+    other-modules: Paths_drasil_lang

--- a/code/drasil-metadata/drasil-metadata.cabal
+++ b/code/drasil-metadata/drasil-metadata.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 1fab52f2d65668ebfd695562d5ff02ccf2e717c3058e5495376e724750ce2a68
+-- hash: f73a7f9ee123e2b82735ca8671f5ce4c96cd02b4779a5204c039e983a75f7b66
 
 name:           drasil-metadata
 version:        0.1.1.0
@@ -23,12 +23,13 @@ source-repository head
 library
   exposed-modules:
       Data.Drasil.Domains
-  other-modules:
-      Paths_drasil_metadata
   hs-source-dirs:
       ./
   ghc-options: -Wall -Wredundant-constraints
   build-depends:
       base >=4.7 && <5
     , drasil-lang
+  if false
+    other-modules:
+        Paths_drasil_metadata
   default-language: Haskell2010

--- a/code/drasil-metadata/package.yaml
+++ b/code/drasil-metadata/package.yaml
@@ -21,3 +21,6 @@ library:
   source-dirs: ./
   exposed-modules:
   - Data.Drasil.Domains
+  when:
+  - condition: false
+    other-modules: Paths_drasil_metadata

--- a/code/drasil-printers/drasil-printers.cabal
+++ b/code/drasil-printers/drasil-printers.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 4d682a5f8646dd4b02881b977f282c2a5596931fc71793550f81c10d32fe3b6a
+-- hash: d16a8ade5934f82bf4fb426cd06188cc156bc02fc55bab96b822df4c13c051df
 
 name:           drasil-printers
 version:        0.1.10.0
@@ -43,7 +43,6 @@ library
       Language.Drasil.TeX.Monad
       Language.Drasil.TeX.Preamble
       Language.Drasil.TeX.Print
-      Paths_drasil_printers
   hs-source-dirs:
       ./
   ghc-options: -Wall -Wredundant-constraints
@@ -54,4 +53,7 @@ library
     , drasil-utils
     , lens
     , pretty
+  if false
+    other-modules:
+        Paths_drasil_printers
   default-language: Haskell2010

--- a/code/drasil-printers/package.yaml
+++ b/code/drasil-printers/package.yaml
@@ -25,3 +25,6 @@ library:
   source-dirs: ./
   exposed-modules:
   - Language.Drasil.Printers
+  when:
+  - condition: false
+    other-modules: Paths_drasil_printers

--- a/code/drasil-theory/drasil-theory.cabal
+++ b/code/drasil-theory/drasil-theory.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 3cc05d5aac512ed3b6a641929f6bd7928cfed2a17c9f8d713503812e9764cabd
+-- hash: 7ac680e321d549078594c3d6ca4b19d095f5a7b72aae80dcefb44949eb511bed
 
 name:           drasil-theory
 version:        0.1.0.0
@@ -31,7 +31,6 @@ library
       Theory.Drasil.InstanceModel
       Theory.Drasil.ModelKinds
       Theory.Drasil.Theory
-      Paths_drasil_theory
   hs-source-dirs:
       ./
   ghc-options: -Wall -Wredundant-constraints
@@ -40,4 +39,7 @@ library
     , drasil-lang
     , drasil-metadata
     , lens
+  if false
+    other-modules:
+        Paths_drasil_theory
   default-language: Haskell2010

--- a/code/drasil-theory/package.yaml
+++ b/code/drasil-theory/package.yaml
@@ -24,3 +24,6 @@ library:
   exposed-modules:
   - Theory.Drasil
   - Data.Drasil.TheoryConcepts
+  when:
+  - condition: false
+    other-modules: Paths_drasil_theory

--- a/code/drasil-utils/drasil-utils.cabal
+++ b/code/drasil-utils/drasil-utils.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 628bab8f4dc8526daf25de7a6331190555e2134717f52bb05c67fe8a4eaacf03
+-- hash: 8b0e39912046760aba25837d38085f128504b13d975a213f1180095d21aa31b8
 
 name:           drasil-utils
 version:        0.1.1.0
@@ -32,7 +32,6 @@ library
       Utils.Drasil.English
       Utils.Drasil.Fold
       Utils.Drasil.Misc
-      Paths_drasil_utils
   hs-source-dirs:
       ./
   ghc-options: -Wall -Wredundant-constraints
@@ -42,4 +41,7 @@ library
     , drasil-lang
     , lens
     , pretty
+  if false
+    other-modules:
+        Paths_drasil_utils
   default-language: Haskell2010

--- a/code/drasil-utils/package.yaml
+++ b/code/drasil-utils/package.yaml
@@ -27,3 +27,6 @@ library:
   - Utils.Drasil.Sentence
   - Utils.Drasil.NounPhrase
   - Utils.Drasil.Concepts
+  when:
+  - condition: false
+    other-modules: Paths_drasil_utils

--- a/code/scripts/deploy_stage.sh
+++ b/code/scripts/deploy_stage.sh
@@ -44,29 +44,20 @@ DOX_DEST=doxygen/
 EXAMPLE_DEST=examples/
 CUR_DIR="$PWD/"
 
-
-copy_docs() {
-  # The doc directory can be in two locations (as of Stack 2.1.1) depending on which arguments are
-  # passed to `stack haddock`. The first directory is when no arguments are specified. The second
-  # is used when `--no-haddock-deps` is passed as an argument.
-  DOC_DIR=$(cd "$CUR_DIR" && stack path --local-doc-root)/
-  if [ ! -d "$DOC_DIR" ]; then
-    DOC_DIR=$(cd "$CUR_DIR" && stack path --local-install-root)/doc/
-  fi
-  rm -r "$DOC_DEST" >/dev/null 2>&1  # Printing an error message that a directory doesn't exist isn't the most useful.
-  mkdir -p "$DOC_DEST"
-  cp -r "$DOC_DIR". "$DOC_DEST"
-}
+if [ ! -d "$DOC_DIR"]; then
+  echo "Missing $DOC_DIR folder."
+  exit 1
+fi
 
 copy_datafiles() {
   echo "FIXME: Drasil should copy needed images and resources to the appropriate output directory to avoid needing the entirety of datafiles (for HTML)."
-  rm -r datafiles  >/dev/null 2>&1  # Printing an error message that a directory doesn't exist isn't the most useful.
+  rm -rf datafiles
   mkdir -p datafiles
   cp -r "$CUR_DIR"datafiles/. datafiles/
 }
 
 copy_graphs() {
-  rm -r "$GRAPH_FOLDER" >/dev/null 2>&1  # Printing an error message that a directory doesn't exist isn't the most useful.
+  rm -rf "$GRAPH_FOLDER"
   cp -r "$CUR_DIR$GRAPH_FOLDER". "$GRAPH_FOLDER"
 }
 
@@ -122,7 +113,7 @@ copy_examples() {
 
 copy_images() {
   if [ -d "$CUR_DIR"deploy/images ]; then
-    rm -r "$CUR_DIR"deploy/images
+    rm -rf "$CUR_DIR"deploy/images
   fi
   mkdir -p "$CUR_DIR"deploy/images
   cp -r "$CUR_DIR"website/images/* "$CUR_DIR"deploy/images
@@ -130,7 +121,7 @@ copy_images() {
 }
 
 copy_analysis() {
-  rm -r "$ANALYSIS_FOLDER" >/dev/null 2>&1  # Printing an error message that a directory doesn't exist isn't the most useful.
+  rm -rf "$ANALYSIS_FOLDER"
   cp -r "$CUR_DIR$ANALYSIS_FOLDER". "$ANALYSIS_FOLDER"
 }
 

--- a/code/scripts/deploy_stage.sh
+++ b/code/scripts/deploy_stage.sh
@@ -44,10 +44,15 @@ DOX_DEST=doxygen/
 EXAMPLE_DEST=examples/
 CUR_DIR="$PWD/"
 
-if [ ! -d "$DOC_DIR"]; then
-  echo "Missing $DOC_DIR folder."
+if [ ! -d "$DOC_DEST" ]; then
+  echo "Missing $DOC_DEST folder artifacts."
   exit 1
 fi
+
+copy_docs() {
+  rm -rf "$DOC_DEST"
+  cp -r "$CUR_DIR$DOC_DEST" "$DOC_DEST"
+}
 
 copy_datafiles() {
   echo "FIXME: Drasil should copy needed images and resources to the appropriate output directory to avoid needing the entirety of datafiles (for HTML)."

--- a/code/scripts/make_docs.sh
+++ b/code/scripts/make_docs.sh
@@ -1,0 +1,32 @@
+DOCS_FOLDER=docs/
+FULL_DOCS_FOLDER=docs/full/
+
+# Clean workspace
+rm -rf $DOCS_FOLDER
+mkdir -p $FULL_DOCS_FOLDER
+
+# Get location of buildable docs location
+
+# Build full variant
+stack haddock --no-haddock-deps --no-haddock-hyperlink-source --haddock-arguments "--show-all"
+
+# Get doc folder
+DOCS_LOC="$(stack path --local-install-root)/doc"
+
+# Copy over full docs
+cp -rf "$DOCS_LOC/." "$FULL_DOCS_FOLDER"
+
+# Clean up build artifacts
+# Unfortunately, this is needed because haddock requires a compilation
+stack clean
+
+# Build small variant
+stack haddock --no-haddock-deps --no-haddock-hyperlink-source
+
+# Find new docs folder
+DOCS_LOC="$(stack path --local-install-root)/doc"
+
+# Copy over small docs
+cp -rf "$DOCS_LOC/." "$DOCS_FOLDER"
+
+

--- a/code/website/Main.hs
+++ b/code/website/Main.hs
@@ -190,10 +190,12 @@ main = do
 
   let repoCommitRoot = "https://github.com/" ++ repoSlug ++ "/tree/" ++ commit ++ "/"
   let docsPath = docsRoot ++ "index.html"
+  let fullDocsPath = docsRoot ++ "full/index.html"
 
   let buildPath = "https://github.com/" ++ repoSlug ++ "/actions" ++ maybe "" ("/runs/" ++) buildId
 
   doesDocsExist <- doesFileExist $ deployLocation ++ docsPath
+  doesFullDocsExist <- doesFileExist $ deployLocation ++ fullDocsPath
   examples <- mkExamples repoCommitRoot (deployLocation ++ exampleRoot) srsDir
   graphs <- mkGraphs $ deployLocation ++ graphRoot
 
@@ -215,6 +217,7 @@ main = do
         let indexCtx = listField "examples" (mkExampleCtx exampleRoot srsDir doxDir) (mapM makeItem examples) <>
                        listField "graphs" (mkGraphCtx graphRoot) (mapM makeItem graphs) <>
                        (if doesDocsExist then field "docsUrl" (return . const docsPath) else mempty) <>
+                       (if doesFullDocsExist then field "fullDocsUrl" (return . const fullDocsPath) else mempty) <>
                        field "buildNumber" (return . const buildNumber) <>
                        field "buildUrl" (return . const buildPath) <>
                        field "commit" (return . const commit) <>

--- a/code/website/index.html
+++ b/code/website/index.html
@@ -215,7 +215,7 @@ $endfor$
 $if(docsUrl)-$
   <h3 id="haskDoc">Haddock Documentation</h3>
   <p>
-    The current <a href="$docsUrl$">Haddock documentation</a> for the Drasil framework. $if(fullDocsUrl)-$A variant with fully exposed modules is also available <a href="$fullDocsUrl$">here</a>.$-endif$
+    The current <a href="$docsUrl$">Haddock documentation</a> for the Drasil framework. $if(fullDocsUrl)-$A variant with <a href="$fullDocsUrl$">fully exposed modules</a> is also available.$-endif$
   </p>
 $-endif$
 

--- a/code/website/index.html
+++ b/code/website/index.html
@@ -215,7 +215,7 @@ $endfor$
 $if(docsUrl)-$
   <h3 id="haskDoc">Haddock Documentation</h3>
   <p>
-    The current <a href="$docsUrl$">Haddock documentation</a> for the Drasil framework.
+    The current <a href="$docsUrl$">Haddock documentation</a> for the Drasil framework. $if(fullDocsUrl)-$A variant with fully exposed modules is also available <a href="$fullDocsUrl$">here</a>.$-endif$
   </p>
 $-endif$
 


### PR DESCRIPTION
Closes #2294 

As discussed previously, we would have 2 variants of Haddock documents. One with all modules fully exposed, and one variant as it is right now.

These changes edit the scripts just slightly, but it adds a bit of overhead. Unfortunately, it seems that Haddock requires a whole recompilation (!) in order to change the settings of the haddock documents last built. So, this adds ~3-5 min of overhead to our build times. Luckily, I think we can remove a bit of time elsewhere by using pre-compiled binaries of graphmod/dotgen.

Demo: https://balacij.github.io/Drasil/

Change to textual links:
![image](https://user-images.githubusercontent.com/1627302/119572150-55548c80-bd80-11eb-8ad2-b7f0cf86656c.png)

Normal docs: https://balacij.github.io/Drasil/docs/index.html
Full docs (fully exposed modules): https://balacij.github.io/Drasil/docs/full/index.html
