### PR TITLE
Caching in deployment build + force `make clean` before rebuilding suite

### DIFF
--- a/.github/workflows/Build.yaml
+++ b/.github/workflows/Build.yaml
@@ -31,6 +31,16 @@ jobs:
           enable-stack: true
           stack-no-global: true
           stack-version: 'latest'
+      - name: "Cache dependencies"
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.stack
+            ~/.cabal/packages
+            ~/.cabal/store
+            code/.stack-work/
+            ~/.local/bin/graphmod
+          key: ${{ runner.os }}-store-${{ hashFiles('code/stack.yaml') }}
       - name: "Update PATH"
         run: |
           echo "$HOME/.local/bin" >> $GITHUB_PATH

--- a/.github/workflows/Build.yaml
+++ b/.github/workflows/Build.yaml
@@ -41,6 +41,8 @@ jobs:
             code/.stack-work/
             ~/.local/bin/graphmod
           key: ${{ runner.os }}-store-${{ hashFiles('code/stack.yaml') }}
+      - name: "Clean previous run"
+        run: make clean
       - name: "Update PATH"
         run: |
           echo "$HOME/.local/bin" >> $GITHUB_PATH

--- a/.github/workflows/Build.yaml
+++ b/.github/workflows/Build.yaml
@@ -39,6 +39,7 @@ jobs:
             ~/.cabal/packages
             ~/.cabal/store
             code/.stack-work/
+            code/website/.stack-work/
             ~/.local/bin/graphmod
           key: ${{ runner.os }}-store-${{ hashFiles('code/stack.yaml') }}
       - name: "Clean previous run"

--- a/.github/workflows/Test.yaml
+++ b/.github/workflows/Test.yaml
@@ -47,6 +47,8 @@ jobs:
             code/.stack-work/
             ~/.local/bin/graphmod
           key: ${{ runner.os }}-store-${{ hashFiles('code/stack.yaml') }}
+      - name: "Clean previous run"
+        run: make clean
       - name: "Update PATH"
         run: |
           echo "$HOME/.local/bin" >> $GITHUB_PATH


### PR DESCRIPTION
Contributes to #2326 

Adding in caching to the build deployment will speed it up quite a bit (see https://github.com/balacij/Drasil/actions/runs/879639653 vs subsequent run https://github.com/balacij/Drasil/actions/runs/879785183). Unfortunately, this speed up will only work when there's a cache hit, meaning only when the previous run was successful.

These changes also force a `make clean` before building the software suite to make sure that we never inherit issues from previous builds.