### PR TITLE
Pass GHC options to make_docs.sh, move flags to stack.yaml, and outpu…

### DIFF
--- a/code/Makefile
+++ b/code/Makefile
@@ -108,7 +108,7 @@ override GHCTHREADS = 2
 endif
 
 override GHCFLAGS += -Wall -j$(GHCTHREADS)
-override stackArgs += --ghc-options="$(GHCFLAGS)" --dump-logs --interleaved-output
+override stackArgs += --ghc-options="$(GHCFLAGS)"
 
 #  Output amount control
 NOISY=no
@@ -172,7 +172,7 @@ analysis: check_stack
 	cd $(SCRIPT_FOLDER) && stack exec -- runghc DataTableGen.hs
 
 docs: check_stack
-	sh scripts/make_docs.sh
+	GHC_FLAGS="$(GHCFLAGS)" sh scripts/make_docs.sh
 
 %$(TEX_E_SUFFIX): EXAMPLE=$(shell echo $* | tr a-z A-Z)
 %$(TEX_E_SUFFIX): EDIR=$($(EXAMPLE)_DIR)

--- a/code/README.md
+++ b/code/README.md
@@ -71,30 +71,22 @@ of which classes.
 -------------------------------------------------
 
 To build the documentation for Drasil, simply type `make docs`.
+It will build 2 variants of the Haddock documentation; a normal external 
+documentation set, and an internal documentation set with all modules fully exposed.
 
-Upon completion you should receive several messages stating the haddock for certain
-packages has been updated. You will also get the path to the index file(s).
+Upon completion, you should receive several messages stating the Haddock for certain
+packages has been updated, as well as directory locations for the related generated Haddock docs.
 
-The drasil documentation will be on the path for **local packages** (normally in
-the *.stack-work* folder), for example:
-
-```
-Updating Haddock index for local packages in
-C:\Users\Dan\...\literate-scientific-software\code\website\index.html
-```
-
-or
-
-```
-Updating Haddock index for local packages in
-/.../literate-scientific-software/code/website/index.html
-```
+The generated Haddock documentation will be placed inside of a newly created `code/docs/` folder.
+You should open up the `code/docs/index.html` file with your web browser if you'd like to view 
+the external documentation set. Alternatively, if you would like to view the internal documentation set,
+you should instead open the `code/docs/full/index.html` file.
 
 --------------------------------------------------
 ### Summary of Folder Structure and File Contents
 --------------------------------------------------
 
-**data-files**
+**datafiles**
   - Contains additional "helper" files for each of the examples
 
 **drasil-build**

--- a/code/scripts/make_docs.sh
+++ b/code/scripts/make_docs.sh
@@ -8,7 +8,7 @@ mkdir -p $FULL_DOCS_FOLDER
 # Get location of buildable docs location
 
 # Build full variant
-stack haddock --no-haddock-deps --no-haddock-hyperlink-source --haddock-arguments "--show-all"
+stack haddock --haddock-arguments "--show-all" --ghc-options="$GHC_FLAGS"
 
 # Get doc folder
 DOCS_LOC="$(stack path --local-install-root)/doc"
@@ -21,7 +21,7 @@ cp -rf "$DOCS_LOC/." "$FULL_DOCS_FOLDER"
 stack clean
 
 # Build small variant
-stack haddock --no-haddock-deps --no-haddock-hyperlink-source
+stack haddock --ghc-options="$GHC_FLAGS" 
 
 # Find new docs folder
 DOCS_LOC="$(stack path --local-install-root)/doc"
@@ -29,4 +29,7 @@ DOCS_LOC="$(stack path --local-install-root)/doc"
 # Copy over small docs
 cp -rf "$DOCS_LOC/." "$DOCS_FOLDER"
 
-
+echo "-------------------------------------------"
+echo "- Docs: ./$DOCS_FOLDER"
+echo "- Full docs: ./$FULL_DOCS_FOLDER"
+echo "-------------------------------------------"

--- a/code/stack.yaml
+++ b/code/stack.yaml
@@ -58,6 +58,11 @@ extra-deps:
 - unicode-names-3.2.0.0@sha256:fef7241d93170e26265e84553090253a5e8ee207645d47cf271816f5834d07d2
 - unicode-properties-3.2.0.0@sha256:239766a6ac4322329353f6b9cd546024fd8c5f0235c8e32b3cba2d6bd245a699
 
+# Used only for a basic set of flags for haddock
+build:
+  haddock-deps: false
+  haddock-hyperlink-source: false
+
 # Override default flag values for local packages and extra-deps
 flags: {}
 
@@ -81,3 +86,5 @@ require-stack-version: ">=2.3.1"
 #
 # Allow a newer minor version of GHC than the snapshot specifies
 # compiler-check: newer-minor
+
+dump-logs: all


### PR DESCRIPTION
…t location of generated docs

Note: `--interleaved-output` can be omitted since it's enabled by default since Stack 1.8

Contributes to: #2525 