### PR TITLE
Adding more concept combinators to projectile

### DIFF
--- a/code/drasil-example/Drasil/Projectile/Assumptions.hs
+++ b/code/drasil-example/Drasil/Projectile/Assumptions.hs
@@ -59,7 +59,7 @@ targetXAxisDesc :: Sentence
 targetXAxisDesc = atStartNP (the target) +:+ S "lies on the" +:+ phrase xAxis +:+. fromSource neglectCurv
 
 posXDirectionDesc :: Sentence
-posXDirectionDesc = atStartNP (NP.the (combineNINI positive xDir)) `S.is` S "from the" +:+. (phrase launcher `S.toThe` phrase target)
+posXDirectionDesc = atStartNP (NP.the (combineNINI positive xDir)) `S.is` S "from the" +:+. phraseNP (launcher `toThe` target)
 
 constAccelDesc :: Sentence
 constAccelDesc = atStartNP (the acceleration) `S.is` S "constant" +:+.

--- a/code/drasil-example/Drasil/Projectile/Assumptions.hs
+++ b/code/drasil-example/Drasil/Projectile/Assumptions.hs
@@ -6,12 +6,13 @@ module Drasil.Projectile.Assumptions (accelYGravity, accelXZero, cartSyst,
 import Language.Drasil
 import Utils.Drasil
 import Utils.Drasil.Concepts
+import qualified Utils.Drasil.NounPhrase as NP
 import qualified Utils.Drasil.Sentence as S
 
 import qualified Drasil.DocLang.SRS as SRS (valsOfAuxCons)
 
 import Data.Drasil.Concepts.Documentation (assumpDom, value)
-import Data.Drasil.Concepts.Math (cartesian, xAxis, xDir, yAxis, yDir)
+import Data.Drasil.Concepts.Math (cartesian, xAxis, xDir, yAxis, yDir, direction, positive)
 import Data.Drasil.Concepts.PhysicalProperties (mass)
 import Data.Drasil.Concepts.Physics (acceleration, collision, distance, gravity, time, twoD)
 
@@ -43,13 +44,13 @@ timeStartZero   = cic "timeStartZero"   timeStartZeroDesc   "timeStartZero"   as
 gravAccelValue  = cic "gravAccelValue"  gravAccelValueDesc  "gravAccelValue"  assumpDom
 
 twoDMotionDesc :: Sentence
-twoDMotionDesc = atStartNP (the projMotion) `S.is` phrase twoD +:+. sParen (getAcc twoD)
+twoDMotionDesc = atStartNP (NP.the (projMotion `is` twoD)) +:+. sParen (getAcc twoD)
 
 cartSystDesc :: Sentence
-cartSystDesc = S "A" +:+ (phrase cartesian `S.is` S "used") +:+. fromSource neglectCurv
+cartSystDesc = atStartNP (a_ cartesian) `S.is` S "used" +:+. fromSource neglectCurv
 
 yAxisGravityDesc :: Sentence
-yAxisGravityDesc = S "direction" `S.the_ofTheC` phrase yAxis `S.is` S "directed opposite to" +:+. phrase gravity
+yAxisGravityDesc = atStartNP (direction `the_ofThe` yAxis) `S.is` S "directed opposite to" +:+. phrase gravity
 
 launchOriginDesc :: Sentence
 launchOriginDesc = (atStartNP (the launcher) `S.is` S "coincident with the origin" !.)
@@ -58,17 +59,17 @@ targetXAxisDesc :: Sentence
 targetXAxisDesc = atStartNP (the target) +:+ S "lies on the" +:+ phrase xAxis +:+. fromSource neglectCurv
 
 posXDirectionDesc :: Sentence
-posXDirectionDesc = S "The positive" +:+ phrase xDir `S.is` S "from the" +:+. (phrase launcher `S.toThe` phrase target)
+posXDirectionDesc = atStartNP (NP.the (combineNINI positive xDir)) `S.is` S "from the" +:+. (phrase launcher `S.toThe` phrase target)
 
 constAccelDesc :: Sentence
-constAccelDesc = S "The" +:+ (phrase acceleration `S.is` S "constant") +:+.
+constAccelDesc = atStartNP (the acceleration) `S.is` S "constant" +:+.
                  fromSources [accelXZero, accelYGravity, neglectDrag, freeFlight]
 
 accelXZeroDesc :: Sentence
-accelXZeroDesc = S "The" +:+ phrase acceleration +:+. (S "in the" +:+ phrase xDir `S.is` S "zero")
+accelXZeroDesc = atStartNP (NP.the (acceleration `inThe` xDir)) `S.is` (S "zero" !.)
 
 accelYGravityDesc :: Sentence
-accelYGravityDesc = S "The" +:+ phrase acceleration +:+ S "in the" +:+ phrase yDir `S.isThe` phrase acceleration +:+
+accelYGravityDesc = atStartNP (NP.the (acceleration `inThe` yDir)) `S.isThe` phrase acceleration +:+
                     S "due to" +:+ phrase gravity +:+. fromSource yAxisGravity
 
 neglectDragDesc :: Sentence
@@ -83,13 +84,13 @@ freeFlightDesc = S "The flight" `S.is` S "free; there" `S.are` S "no" +:+ plural
                  S "during" +:+. (S "trajectory" `S.the_ofThe` phrase projectile)
 
 neglectCurvDesc :: Sentence
-neglectCurvDesc = S "The" +:+ phrase distance `S.is` S "small enough that" +:+.
+neglectCurvDesc = atStartNP (the distance) `S.is` S "small enough that" +:+.
                   (S "curvature" `S.the_ofThe` S "Earth can be neglected")
 
 timeStartZeroDesc :: Sentence
 timeStartZeroDesc = atStart time +:+. S "starts at zero"
 
 gravAccelValueDesc :: Sentence
-gravAccelValueDesc = S "The" +:+ phrase acceleration +:+ S "due to" +:+
+gravAccelValueDesc = atStartNP (the acceleration) +:+ S "due to" +:+
   phrase gravity +:+ S "is assumed to have the" +:+ phrase value +:+ 
   S "provided in" +:+. makeRef2S (SRS.valsOfAuxCons ([]::[Contents]) ([]::[Section]))

--- a/code/drasil-example/Drasil/Projectile/Body.hs
+++ b/code/drasil-example/Drasil/Projectile/Body.hs
@@ -8,6 +8,8 @@ import Database.Drasil (Block, ChunkDB, ReferenceDB, SystemInformation(SI),
   _datadefs, _configFiles, _definitions, _defSequence, _inputs, _kind, 
   _outputs, _quants, _sys, _sysinfodb, _usedinfodb)
 import Utils.Drasil
+import Utils.Drasil.Concepts
+import qualified Utils.Drasil.NounPhrase as NP
 import qualified Utils.Drasil.Sentence as S
 
 import Drasil.DocLang (AuxConstntSec(AuxConsProg),
@@ -28,7 +30,7 @@ import qualified Data.Drasil.Concepts.Documentation as Doc (srs)
 import Data.Drasil.Concepts.Math (cartesian, mathcon)
 import Data.Drasil.Concepts.PhysicalProperties (mass)
 import Data.Drasil.Concepts.Physics (gravity, physicCon, physicCon',
-  rectilinear, oneD, twoD)
+  rectilinear, oneD, twoD, motion)
 import Data.Drasil.Concepts.Software (errMsg, program)
 
 import Data.Drasil.Quantities.Math (pi_, piConst)
@@ -103,12 +105,12 @@ mkSRS = [
   ]
 
 justification, scope :: Sentence
-justification = foldlSent [atStart projectile, S "motion is a common" +:+.
-  (phrase problem `S.in_` phrase physics), S "Therefore, it is useful to have a",
+justification = foldlSent [atStart projectile, phrase motion, S "is a common" +:+.
+  phraseNP (problem `in_` physics), S "Therefore, it is useful to have a",
   phrase program, S "to solve and model these types of" +:+. plural problem,
-  S "The", phrase program, S "documented here is called", phrase projectileTitle]
-scope = foldlSent_ [S "the", phrase analysis `S.of_` S "a", phrase twoD,
-  sParen (getAcc twoD), phrase projectile, S "motion", phrase problem, S "with",
+  atStartNP (the program), S "documented here is called", phrase projectileTitle]
+scope = foldlSent_ [phraseNP (NP.the (analysis `ofA` twoD)),
+  sParen (getAcc twoD), phraseNP (combineNINI projectile motion), phrase problem, S "with",
   phrase constAccel]
 
 projectileTitle :: CI
@@ -167,7 +169,7 @@ concIns = assumptions ++ funcReqs ++ goals ++ nonfuncReqs
 
 prob :: Sentence
 prob = foldlSent_ [S "efficiently" `S.and_` S "correctly predict the",
-  phrase landingPosNC, S "of a", phrase projectile]
+  phraseNP (landingPosNC `ofA` projectile)]
 
 ---------------------------------
 -- Terminology and Definitions --
@@ -181,10 +183,10 @@ terms = [launcher, projectile, target, gravity, cartesian, rectilinear]
 ---------------------------------
 
 physSystParts :: [Sentence]
-physSystParts = map foldlSent [
-  [S "The", phrase launcher],
-  [S "The", phrase projectile, sParen (S "with" +:+ getTandS iVel `S.and_` getTandS launAngle)],
-  [S "The", phrase target]]
+physSystParts = map (!.)
+  [atStartNP (the launcher),
+  atStartNP (the projectile) +:+ sParen (S "with" +:+ getTandS iVel `S.and_` getTandS launAngle),
+  atStartNP (the target)]
 
 ----------------------------------------------------
 -- Various gathered data that should be automated --

--- a/code/drasil-example/Drasil/Projectile/Concepts.hs
+++ b/code/drasil-example/Drasil/Projectile/Concepts.hs
@@ -42,14 +42,14 @@ target     = dcc "target"     (nounPhraseSP "target")     "where the projectile 
 landPos, launAngle, launSpeed, offset, targPos, flightDur :: ConceptChunk
 landPos = cc' landingPosNC
   (foldlSent_ [phraseNP (the distance) `S.fromThe` phrase launcher `S.toThe`
-            (S "final" +:+ phrase position) `S.ofThe` phrase projectile])
+            S "final", phraseNP (position `ofThe` projectile)])
 
 launAngle = cc' launchAngleNC
   (foldlSent_ [phraseNP (the angle), S "between the", phrase launcher `S.and_` S "a straight line"
-             `S.fromThe` phrase launcher `S.toThe` phrase target])
+             `S.fromThe` phraseNP (launcher `toThe` target)])
 
 launSpeed = cc' launchSpeedNC (phraseNP (iSpeed `the_ofThe` projectile) +:+ S "when launched")
 offset = cc' offsetNC (S "the offset between the" +:+ phraseNP (targetPosNC `andThe` landingPosNC))
-targPos = cc' targetPosNC (phraseNP (the distance) `S.fromThe` phrase launcher `S.toThe` phrase target)
+targPos = cc' targetPosNC (phraseNP (the distance) `S.fromThe` phraseNP (launcher `toThe` target))
 flightDur = cc' flightDurNC (foldlSent_ [phraseNP (the time), S "when the", phrase projectile, S "lands"])
 

--- a/code/drasil-example/Drasil/Projectile/Concepts.hs
+++ b/code/drasil-example/Drasil/Projectile/Concepts.hs
@@ -17,7 +17,7 @@ durationNC, flightDurNC, landingPosNC, launchNC, launchAngleNC, launchSpeedNC, o
   rectVel :: NamedChunk
 durationNC   = nc "duration" (nounPhraseSP "duration")
 launchNC     = nc "launch"   (nounPhraseSP "launch")
-offsetNC     = nc "offset"   (nounPhraseSent $ S "distance between the" +:+ phrase targetPosNC `S.andThe` phrase landingPosNC)
+offsetNC     = nc "offset"   (nounPhraseSent $ S "distance between the" +:+ phraseNP (targetPosNC `andThe` landingPosNC))
 
 flightDurNC   = compoundNC (nc "flight"  (nounPhraseSP "flight" )) durationNC
 landingPosNC  = compoundNC (nc "landing" (nounPhraseSP "landing")) position
@@ -41,15 +41,15 @@ target     = dcc "target"     (nounPhraseSP "target")     "where the projectile 
 
 landPos, launAngle, launSpeed, offset, targPos, flightDur :: ConceptChunk
 landPos = cc' landingPosNC
-  (foldlSent_ [phraseNP (the distance) `S.fromThe` phrase launcher, S "to",
-            (S "final" +:+ phrase position) `S.the_ofThe` phrase projectile])
+  (foldlSent_ [phraseNP (the distance) `S.fromThe` phrase launcher `S.toThe`
+            (S "final" +:+ phrase position) `S.ofThe` phrase projectile])
 
 launAngle = cc' launchAngleNC
   (foldlSent_ [phraseNP (the angle), S "between the", phrase launcher `S.and_` S "a straight line"
              `S.fromThe` phrase launcher `S.toThe` phrase target])
 
-launSpeed = cc' launchSpeedNC (phrase iSpeed `S.the_ofThe` phrase projectile +:+ S "when launched")
-offset = cc' offsetNC (S "the offset between the" +:+ phrase targetPosNC `S.andThe` phrase landingPosNC)
+launSpeed = cc' launchSpeedNC (phraseNP (iSpeed `the_ofThe` projectile) +:+ S "when launched")
+offset = cc' offsetNC (S "the offset between the" +:+ phraseNP (targetPosNC `andThe` landingPosNC))
 targPos = cc' targetPosNC (phraseNP (the distance) `S.fromThe` phrase launcher `S.toThe` phrase target)
 flightDur = cc' flightDurNC (foldlSent_ [phraseNP (the time), S "when the", phrase projectile, S "lands"])
 

--- a/code/drasil-example/Drasil/Projectile/GenDefs.hs
+++ b/code/drasil-example/Drasil/Projectile/GenDefs.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE PostfixOperators #-}
 module Drasil.Projectile.GenDefs (genDefns, genDefns0, posVecGD) where
 
 import Prelude hiding (cos, sin)
@@ -9,7 +10,7 @@ import qualified Utils.Drasil.Sentence as S
 
 import Data.Drasil.Concepts.Documentation (coordinate, symbol_)
 import Data.Drasil.Concepts.Math (cartesian, equation, vector)
-import Data.Drasil.Concepts.Physics (oneD, rectilinear, twoD)
+import Data.Drasil.Concepts.Physics (oneD, rectilinear, twoD, motion)
 
 import Data.Drasil.Quantities.Physics (acceleration, constAccelV, iPos, iSpeed,
   iVel, ixVel, iyVel, position, scalarAccel, scalarPos, speed,
@@ -48,7 +49,7 @@ rectVelQD = mkQuantDef' speed (nounPhraseSent $ foldlSent_
 rectVelRC :: RelationConcept
 rectVelRC = makeRC "rectVelRC" (nounPhraseSent $ foldlSent_ 
             [atStart rectilinear, sParen $ getAcc oneD, phrase velocity,
-             S "as a function" `S.of_` phrase time, S "for", phrase QP.constAccel])
+             S "as a function" `S.of_` phraseNP (time `for` QP.constAccel)])
             EmptyS $ sy speed $= E.speed'
 
 rectVelDeriv :: Derivation
@@ -58,7 +59,7 @@ rectVelDeriv = mkDerivName (phrase rectVel)
 rectVelDerivSents :: [Sentence]
 rectVelDerivSents = [rectDeriv velocity acceleration motSent iVel accelerationTM, rearrAndIntSent, performIntSent]
   where
-    motSent = foldlSent [S "The motion" `S.in_` makeRef2S accelerationTM `S.is` S "now", phrase oneD,
+    motSent = foldlSent [atStartNP (the motion) `S.in_` makeRef2S accelerationTM `S.is` S "now", phrase oneD,
                          S "with a", phrase QP.constAccel `sC` S "represented by", E (sy QP.constAccel)]
 
 rectVelDerivEqns :: [Expr]
@@ -72,7 +73,7 @@ rectPosGD = gd (EquationalModel rectPosQD) (getUnit scalarPos) (Just rectPosDeri
 rectPosQD :: QDefinition
 rectPosQD = mkQuantDef' scalarPos (nounPhraseSent $ foldlSent_ 
             [atStart rectilinear, sParen $ getAcc oneD, phrase position,
-             S "as a function" `S.of_` phrase time, S "for", phrase QP.constAccel])
+             S "as a function" `S.of_` phraseNP (time `for` QP.constAccel)])
             E.scalarPos'
 
 rectPosDeriv :: Derivation
@@ -83,7 +84,7 @@ rectPosDerivSents :: [Sentence]
 rectPosDerivSents = [rectDeriv position velocity motSent iPos velocityTM,
   rearrAndIntSent, fromReplace rectVelGD speed, performIntSent]
     where
-      motSent = S "The motion" `S.in_` makeRef2S velocityTM `S.is` S "now" +:+. phrase oneD
+      motSent = atStartNP (the motion) `S.in_` makeRef2S velocityTM `S.is` S "now" +:+. phrase oneD
 
 rectPosDerivEqns :: [Expr]
 rectPosDerivEqns = [E.rectPosDerivEqn1, E.rectPosDerivEqn2, E.rectPosDerivEqn3, sy scalarPos $= E.scalarPos']
@@ -95,7 +96,7 @@ velVecGD = gdNoRefs (EquationalModel velVecQD) (getUnit velocity)
 
 velVecQD :: QDefinition 
 velVecQD = mkQuantDef' velocity (nounPhraseSent $ foldlSent_ 
-           [atStart velocity, S "vector as a function" `S.of_` phrase time, S "for",
+           [atStart velocity, S "vector as a function" `S.of_` phrase time `S.for`
             getAcc twoD, S "motion under", phrase QP.constAccel]) E.velVecExpr
 
 velVecDeriv :: Derivation
@@ -112,7 +113,7 @@ posVecGD = gdNoRefs (EquationalModel posVecQD) (getUnit position)
 
 posVecQD :: QDefinition
 posVecQD = mkQuantDef' position (nounPhraseSent $ foldlSent_ 
-           [atStart position, S "vector as a function" `S.of_` phrase time, S "for",
+           [atStart position, S "vector as a function" `S.of_` phrase time `S.for`
             getAcc twoD, S "motion under", phrase QP.constAccel]) E.posVecExpr
 
 posVecDeriv :: Derivation
@@ -125,11 +126,11 @@ posVecDerivSent =
 -- Helper for making rectilinear derivations
 rectDeriv :: UnitalChunk -> UnitalChunk -> Sentence -> UnitalChunk -> TheoryModel -> Sentence
 rectDeriv c1 c2 motSent initc ctm = foldlSent_ [
-  S "Assume we have", phrase rectilinear, S "motion" `S.of_` S "a particle",
+  S "Assume we have", phraseNP (combineNINI rectilinear motion) `S.ofA` S "particle",
   sParen (S "of negligible size" `S.and_` S "shape" `sC` S "from" +:+ makeRef2S pointMass) :+:
-  S ";" +:+. (S "that is" `sC` S "motion" `S.in_` S "a straight line"), S "The" +:+.
-  (phrase c1 `S.is` getScalar c1 `S.andThe` phrase c2 `S.is` getScalar c2), motSent,
-  S "The", phrase initc, sParen (S "at" +:+ E (sy time $= exactDbl 0) `sC` S "from" +:+
+  S ";" +:+. (S "that is" `sC` S "motion" `S.in_` S "a straight line"),
+  (atStartNP (the c1) `S.is` getScalar c1 `S.andThe` phrase c2 `S.is` getScalar c2 !.), motSent,
+  atStartNP (the initc), sParen (S "at" +:+ E (sy time $= exactDbl 0) `sC` S "from" +:+
   makeRef2S timeStartZero) `S.is` S "represented by" +:+. getScalar initc,
   S "From", makeRef2S ctm `sC` S "using the above", plural symbol_ +: S "we have"]
   where
@@ -148,7 +149,7 @@ performIntSent    = S "Performing the integration" `sC` S "we have the required"
 -- Helper for making vector derivations
 vecDeriv :: [(UnitalChunk, Expr)] -> GenDefn -> Sentence
 vecDeriv vecs gdef = foldlSentCol [
-  S "For a", phrase twoD, phrase cartesian, sParen (makeRef2S twoDMotion `S.and_` makeRef2S cartSyst) `sC`
+  S "For a", phraseNP (combineNINI twoD cartesian), sParen (makeRef2S twoDMotion `S.and_` makeRef2S cartSyst) `sC`
   S "we can represent" +:+. foldlList Comma List 
   (map (\(c, e) -> foldlSent_ [phraseNP (the c), phrase vector, S "as", E e]) vecs),
   atStartNP (the acceleration) `S.is` S "assumed to be constant", sParen (makeRef2S constAccel) `S.andThe`
@@ -156,6 +157,6 @@ vecDeriv vecs gdef = foldlSentCol [
   atStartNP (the iVel) +:+ sParen (S "at" +:+ E (sy time $= exactDbl 0) `sC` S "from" +:+ makeRef2S timeStartZero) `S.is`
   S "represented by" +:+. E (sy iVel $= vec2D (sy ixVel) (sy iyVel)), 
   S "Since we have a",
-  phrase cartesian `sC` makeRef2S gdef, S "can be applied to each", phrase coordinate `S.of_`
-  S "the", phrase ((fst . head) vecs), phrase vector, S "to yield the required", phrase equation]
+  phrase cartesian `sC` makeRef2S gdef, S "can be applied to each", phraseNP (coordinate `ofThe`
+  ((fst . head) vecs)), phrase vector, S "to yield the required", phrase equation]
 

--- a/code/drasil-example/Drasil/Projectile/GenDefs.hs
+++ b/code/drasil-example/Drasil/Projectile/GenDefs.hs
@@ -158,5 +158,5 @@ vecDeriv vecs gdef = foldlSentCol [
   S "represented by" +:+. E (sy iVel $= vec2D (sy ixVel) (sy iyVel)), 
   S "Since we have a",
   phrase cartesian `sC` makeRef2S gdef, S "can be applied to each", phraseNP (coordinate `ofThe`
-  ((fst . head) vecs)), phrase vector, S "to yield the required", phrase equation]
+  (fst . head) vecs), phrase vector, S "to yield the required", phrase equation]
 

--- a/code/drasil-example/Drasil/Projectile/IMods.hs
+++ b/code/drasil-example/Drasil/Projectile/IMods.hs
@@ -5,6 +5,7 @@ import Prelude hiding (cos, sin)
 import Language.Drasil
 import Theory.Drasil (InstanceModel, imNoDerivNoRefs, imNoRefs, qwC, ModelKinds (OthModel))
 import Utils.Drasil
+import Utils.Drasil.Concepts
 import qualified Utils.Drasil.Sentence as S
 
 import qualified Drasil.DocLang.SRS as SRS (valsOfAuxCons)
@@ -61,7 +62,7 @@ timeDerivSent2 = foldlSentCol [S "To find the", phrase time, S "that the",
   phrase projectile, S "lands" `sC` S "we want to find the", ch time, phrase value,
   sParen (ch flightDur), S "where", E (sy yPos $= exactDbl 0) +:+. sParen (S "since the" +:+
   phrase target `S.is` S "on the" +:+ phrase xAxis +:+ S "from" +:+ makeRef2S targetXAxis),
-  S "From the", phrase equation, S "above",S "we get"]
+  S "From the", phrase equation, S "above we get"]
 timeDerivSent3 = foldlSentCol [S "Dividing by", ch flightDur,
   sParen (S "with the" +:+ phrase constraint +:+ E (sy flightDur $> exactDbl 0)),
   S "gives us"]
@@ -99,7 +100,7 @@ landPosDerivSent1 = foldlSentCol [S "We know that" +:+.
   makeRef2S posVecGD, S "gives us"]
 landPosDerivSent2 = foldlSentCol [S "To find the", phrase landPos `sC`
   S "we want to find the", ch xPos, phrase value, sParen (ch landPos),
-  S "at", phrase flightDur, sParen (S "from" +:+ makeRef2S timeIM)]
+  S "at", phrase flightDur, fromSource timeIM]
 landPosDerivSent3 = foldlSentCol [S "From", makeRef2S speedIX,
   sParen (S "with" +:+ E (sy iSpeed $= sy launSpeed)), S "we can replace", ch ixVel]
 landPosDerivSent4 = S "Rearranging this gives us the required" +: phrase equation
@@ -135,7 +136,7 @@ angleConstraintNote, gravitationalAccelConstNote, landAndTargPosConsNote, landPo
   landPosConsNote, offsetNote, offsetConsNote, targPosConsNote,
   timeConsNote, tolNote :: Sentence
 
-angleConstraintNote = foldlSent [S "The", phrase constraint,
+angleConstraintNote = foldlSent [atStartNP (the constraint),
   E (exactDbl 0 $< sy launAngle $< half (sy pi_)) `S.is` S "from",
   makeRef2S posXDirection `S.and_` makeRef2S yAxisGravity `sC`
   S "and is shown" `S.in_` makeRef2S figLaunch]
@@ -143,23 +144,23 @@ angleConstraintNote = foldlSent [S "The", phrase constraint,
 gravitationalAccelConstNote = ch gravitationalAccelConst `S.is`
   S "defined in" +:+. makeRef2S gravAccelValue
 
-landAndTargPosConsNote = S "The" +:+ plural constraint +:+
+landAndTargPosConsNote = atStartNP' (the constraint) +:+
   E (sy landPos $> exactDbl 0) `S.and_` E (sy targPos $> exactDbl 0) `S.are` S "from" +:+. makeRef2S posXDirection
 
 landPosNote = ch landPos `S.is` S "from" +:+. makeRef2S landPosIM
 
-landPosConsNote = S "The" +:+ phrase constraint +:+
+landPosConsNote = atStartNP (the constraint) +:+
   E (sy landPos $> exactDbl 0) `S.is` S "from" +:+. makeRef2S posXDirection
 
 offsetNote = ch offset `S.is` S "from" +:+. makeRef2S offsetIM
 
-offsetConsNote = foldlSent [S "The", phrase constraint, E (sy offset $> neg (sy landPos)) `S.is`
+offsetConsNote = foldlSent [atStartNP (the constraint), E (sy offset $> neg (sy landPos)) `S.is`
   S "from the fact that", E (sy landPos $> exactDbl 0) `sC` S "from", makeRef2S posXDirection]
 
-targPosConsNote = S "The" +:+ phrase constraint +:+
+targPosConsNote = atStartNP (the constraint) +:+
   E (sy targPos $> exactDbl 0) `S.is` S "from" +:+. makeRef2S posXDirection
 
-timeConsNote = S "The" +:+ phrase constraint +:+
+timeConsNote = atStartNP (the constraint) +:+
   E (sy flightDur $> exactDbl 0) `S.is` S "from" +:+. makeRef2S timeStartZero
 
 tolNote = ch tol `S.is` S "defined in" +:+. makeRef2S (SRS.valsOfAuxCons ([]::[Contents]) ([]::[Section]))

--- a/code/drasil-example/Drasil/Projectile/Requirements.hs
+++ b/code/drasil-example/Drasil/Projectile/Requirements.hs
@@ -51,7 +51,7 @@ nonfuncReqs = [correct, verifiable, understandable, reusable, maintainable, port
 
 correct :: ConceptInstance
 correct = cic "correct" (foldlSent [
-  plural output_ `S.the_ofTheC` phrase code, S "have the",
+  atStartNP' (output_ `the_ofThePS` code), S "have the",
   plural property, S "described in", makeRef2S (propCorSol [] [])
   ]) "Correct" nonFuncReqDom
  
@@ -63,7 +63,7 @@ verifiable = cic "verifiable" (foldlSent [
 understandable :: ConceptInstance
 understandable = cic "understandable" (foldlSent [
   atStartNP (the code), S "is modularized with complete",
-  phrase mg `S.and_` phrase mis]) "Understandable" nonFuncReqDom
+  phraseNP (mg `and_` mis)]) "Understandable" nonFuncReqDom
 
 reusable :: ConceptInstance
 reusable = cic "reusable" (foldlSent [atStartNP (the code), S "is modularized"]) "Reusable" nonFuncReqDom

--- a/code/drasil-utils/Utils/Drasil/Concepts.hs
+++ b/code/drasil-utils/Utils/Drasil/Concepts.hs
@@ -1,12 +1,12 @@
 module Utils.Drasil.Concepts (and_, and_TSP, and_PS, and_PP, and_TGen, and_Gen, andIts, andThe, with, of_, of_NINP, of_PSNPNI, of_TSP, of_PS, of_TPS, ofA,
-ofATPS, ofThe, ofThePS, the_ofThe, the_ofThePS, onThe, onThePS, inThe, inThePS, for, forTGen, in_, in_PS, inA, is, the, theT, theGen, a_, a_Gen,
+ofATPS, ofThe, ofThePS, the_ofThe, the_ofThePS, onThe, onThePS, inThe, inThePS, toThe, for, forTGen, in_, in_PS, inA, is, the, theT, theGen, a_, a_Gen,
 compoundNC, compoundNCPP, compoundNCGen, compoundNCPS, compoundNCPSPP, compoundNCGenP, combineNINP, combineNPNI, combineNINI) where
 
 import Language.Drasil
 import qualified Language.Drasil.Development as D
 import Control.Lens ((^.))
 
-import qualified Utils.Drasil.Sentence as S (and_, andIts, andThe, of_, ofA, ofThe, the_ofThe, onThe, for, inThe, in_, is) 
+import qualified Utils.Drasil.Sentence as S (and_, andIts, andThe, of_, ofA, ofThe, the_ofThe, onThe, for, inThe, in_, is, toThe) 
 
 -----------
 --FIXME: Find out why CapFirst and CapWords can't just be used instead of Replace constructor.
@@ -221,6 +221,15 @@ inThePS :: (NamedIdea c, NamedIdea d) => c -> d -> NP
 inThePS t1 t2 = nounPhrase'' 
   (phrase t1 `S.inThe` phrase t2) 
   (plural t1 `S.inThe` phrase t2)
+  CapFirst
+  CapWords
+
+-- | Creates a 'NP' by combining two 'NamedIdea's with the words "to the" between
+-- their terms. Plural case is @(phrase t1) "to the" (plural t2)@.
+toThe :: (NamedIdea c, NamedIdea d) => c -> d -> NP
+toThe t1 t2 = nounPhrase'' 
+  (phrase t1 `S.toThe` phrase t2) 
+  (phrase t1 `S.toThe` plural t2)
   CapFirst
   CapWords
 


### PR DESCRIPTION
For some reason, in line 108 of `code/drasil-example/Drasil/Projectile/Body.hs`, using the `combineNINI` combinator breaks the capitalization (where `atStartNP` and `titleizeNP` both don't work). But I think I should investigate that later.
Also, I know that you mentioned that fixing up examples and adding combinators to the existing infrastructure should have different PRs, but this was only a small change (adding a `toThe` combinator) and stable remained the same. Either way, they were incorporated in separate commits.
Contributes #2499 