### PR TITLE
Added concept-level combinators to SSP

### DIFF
--- a/code/drasil-example/Drasil/SSP/Assumptions.hs
+++ b/code/drasil-example/Drasil/SSP/Assumptions.hs
@@ -1,7 +1,10 @@
+{-# LANGUAGE PostfixOperators #-}
 module Drasil.SSP.Assumptions where
 
 import Language.Drasil
 import Utils.Drasil
+import Utils.Drasil.Concepts
+import qualified Utils.Drasil.NounPhrase as NP
 import qualified Utils.Drasil.Sentence as S
 
 import Drasil.SSP.Defs (plnStrn, slpSrf, slopeSrf, slope,
@@ -51,44 +54,44 @@ monotonicF, slopeS, homogeneousL, isotropicP, linearS, planeS, largeN,
   straightS, propertiesS, edgeS, seismicF, surfaceL, waterBIntersect, 
   waterSIntersect, negligibleSlopeEffect, hydrostaticFMidpoint :: Sentence
 
-monotonicF = foldlSent [S "The", phrase slpSrf,
-  S "is concave" `S.wrt` S "the" +:+. phrase slopeSrf, S "The",
-  sParen (ch slipDist `sC` ch slipHght) +:+ S "coordinates", S "of a", 
+monotonicF = foldlSent [atStartNP (the slpSrf),
+  S "is concave" `S.wrt` (phraseNP (the slopeSrf) !.), S "The",
+  sParen (ch slipDist `sC` ch slipHght), S "coordinates" `S.ofA` 
   phrase slpSrf, S "follow a concave up function"]
 
 slopeS = foldlSent [S "The factor of safety is assumed to be", phrase constant,
   S "across the entire", phrase slpSrf]
 
-homogeneousL = foldlSent [S "The", phrase soil, S "mass is homogeneous" `sC`
-  S "with consistent", plural soilPrpty +:+ S "throughout"]
+homogeneousL = foldlSent [atStartNP (the soil), S "mass is homogeneous" `sC`
+  S "with consistent", plural soilPrpty, S "throughout"]
 
-propertiesS = foldlSent [S "The", plural soilPrpty, S "are independent of dry or saturated",
+propertiesS = foldlSent [atStartNP' (the soilPrpty), S "are independent of dry or saturated",
   plural condition `sC` S "with the exception of", phrase unit_, S "weight"]
 
-isotropicP = foldlSent [S "The", phrase soil, S "mass is treated as if the", 
-  phrase effCohesion `S.and_` phrase fricAngle, S "are isotropic properties"]
+isotropicP = foldlSent [atStartNP (the soil), S "mass is treated as if the", 
+  phraseNP (effCohesion `and_` fricAngle), S "are isotropic properties"]
 
 linearS = foldlSent [S "Following the", phrase assumption, S "of Morgenstern",
   S "and Price", sParen (makeRef2S morgenstern1965) `sC` 
-  phrase intNormForce `S.and_` phrase intShrForce,
+  phraseNP (intNormForce `and_` intShrForce),
   S "have a proportional relationship, depending on a proportionality",
   phrase constant, sParen (ch normToShear), S "and a function", 
   sParen (ch scalFunc), S "describing variation depending on", ch xi, 
   phrase position]
 
-planeS = foldlSent [S "The", phrase slope, S "and", phrase slpSrf +:+
+planeS = foldlSent [atStartNP (NP.the (slope `and_` slpSrf)),
   S "extends far into and out of the geometry" +:+. sParen (ch zcoord +:+ 
-  S "coordinate"), S "This implies", phrase plnStrn, plural condition `sC`
+  S "coordinate"), S "This implies", pluralNP (combineNINI plnStrn condition) `sC`
   S "making", short twoD, phrase analysis, S "appropriate"]
 
 largeN = foldlSent [S "The effective normal", phrase stress,
   S "is large enough that the", phrase shrStress, S "to effective normal",
   phrase stress, S "relationship can be approximated as a linear relationship"]
 
-straightS = foldlSent [S "The", phrase surface, S "and base of a",
+straightS = foldlSent [atStartNP (the surface), S "and base of a",
   phrase slice, S "are approximated as straight lines"]
 
-edgeS = foldlSent [S "The", phrase intrslce, plural force, 
+edgeS = foldlSent [atStartNP (the intrslce), plural force, 
   S "at the 0th" `S.and_` ch numbSlices :+: S "th", phrase intrslce,
   plural interface, S "are zero"]
 
@@ -97,14 +100,14 @@ seismicF = foldlSent [S "There is no seismic", phrase force, S "acting on the", 
 surfaceL = foldlSent [S "There is no imposed", phrase surface, S "load" `sC`
   S "and therefore no", phrase surfLoad `sC` S "acting on the", phrase slope]
 
-waterBIntersect = foldlSent [S "The", phrase waterTable, S "only intersects", 
-  S "the base of a", phrase slice, S "at an edge of the", phrase slice]
+waterBIntersect = foldlSent [atStartNP (the waterTable), S "only intersects", 
+  S "the base" `S.ofA` phrase slice, S "at an edge" `S.ofThe` phrase slice]
 
-waterSIntersect = foldlSent [S "The", phrase waterTable, S "only intersects", 
-  S "the", phrase slopeSrf, S "at the edge of a", phrase slice]
+waterSIntersect = foldlSent [atStartNP (the waterTable), S "only intersects", 
+  phraseNP (the slopeSrf), S "at the edge of a", phrase slice]
 
-negligibleSlopeEffect = foldlSent [S "The", phrase effect, 
-  S "of the slope of the surface of the", phrase soil, S "on the seismic",
+negligibleSlopeEffect = foldlSent [atStartNP (the effect)
+  `S.ofThe` S "slope" `S.ofThe` phraseNP (surface `ofThe` soil) `S.onThe` S "seismic",
   phrase force, S "is assumed to be negligible"]
 
 hydrostaticFMidpoint = foldlSent [S "The resultant", phrase surfHydroForce,

--- a/code/drasil-example/Drasil/SSP/Body.hs
+++ b/code/drasil-example/Drasil/SSP/Body.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE PostfixOperators #-}
 module Drasil.SSP.Body (srs, si, symbMap, printSetting) where
 
 import Language.Drasil hiding (Symbol(..), Verb, number, organization, section)
@@ -10,6 +11,8 @@ import Theory.Drasil (qdFromDD)
 
 import Prelude hiding (sin, cos, tan)
 import Utils.Drasil
+import Utils.Drasil.Concepts
+import qualified Utils.Drasil.NounPhrase as NP
 import qualified Utils.Drasil.Sentence as S
 
 import Drasil.DocLang (DocSection(..), IntroSec(..), IntroSub(..),
@@ -192,17 +195,17 @@ tableOfSymbIntro = [TSPurpose, TypogConvention [Verb $ foldlSent_
 
 -- SECTION 2 --
 startIntro, kSent :: Sentence
-startIntro = foldlSent [S "A", phrase slope, S "of geological",
+startIntro = foldlSent [atStartNP (a_ slope), S "of geological",
   phrase mass `sC` S "composed of", phrase soil, S "and rock and sometimes",
-  S "water, is subject to the influence" `S.of_` phrase gravity +:+ S "on the" +:+.
-  phrase mass, S "This can cause instability in the form" `S.of_` phrase soil +:+.
-  S "or rock movement", S "The", plural effect `S.of_` phrase soil +:+
+  S "water, is subject to the influence" `S.of_` (phraseNP (gravity `onThe` mass) !.),
+  S "This can cause instability in the form" `S.of_` phrase soil +:+.
+  S "or rock movement", atStartNP' (NP.the (effect `of_PS` soil)),
   S "or rock movement can range from inconvenient to",
   S "seriously hazardous, resulting in significant life and economic" +:+.
   plural loss, atStart slope, S "stability is of", phrase interest,
   S "both when analysing natural", plural slope `sC`
-  S "and when designing an excavated" +:+.  phrase slope, atStart ssa `S.is`
-  (S "assessment" `S.the_ofThe` S "safety of a" +:+ phrase slope) `sC`
+  S "and when designing an excavated" +:+. phrase slope, atStart ssa `S.isThe`
+  S "assessment" `S.ofThe` S "safety of a" +:+ phrase slope `sC`
   S "identifying the", phrase surface,
   S "most likely to experience", phrase slip `S.and_`
   S "an index of its relative stability known as the", phrase fs]
@@ -210,7 +213,7 @@ startIntro = foldlSent [S "A", phrase slope, S "of geological",
 kSent = keySent ssa ssp
 
 keySent :: (Idea a, Idea b) => a -> b -> Sentence
-keySent probType pname = foldlSent_ [S "a", phrase probType +:+. phrase problem,
+keySent probType pname = foldlSent_ [(phraseNP (NP.a_ (combineNINI probType problem)) !.),
   S "The developed", phrase program, S "will be referred to as the",
   introduceAbb pname]
   
@@ -221,11 +224,11 @@ keySent probType pname = foldlSent_ [S "a", phrase probType +:+. phrase problem,
 -- SECTION 2.2 --
 -- Scope of Requirements automatically generated in IScope
 scope :: Sentence
-scope = foldlSent_ [phrase stabAnalysis, S "of a", phrase twoD, sParen (getAcc twoD),
-  phrase soil, phrase mass `sC` S "composed of a single homogeneous", phrase layer,
-  S "with", phrase constant +:+. plural mtrlPrpty, S "The", phrase soil,
-  phrase mass `S.is` S "assumed to extend infinitely in the third" +:+.
-  phrase dimension, S "The", phrase analysis, S "will be at an instant" `S.in_`
+scope = foldlSent_ [phraseNP (stabAnalysis `ofA` twoD), sParen (getAcc twoD),
+  phraseNP (combineNINI soil mass) `sC` S "composed of a single homogeneous", phrase layer,
+  S "with" +:+. pluralNP (combineNINI constant mtrlPrpty), atStartNP (NP.the (combineNINI soil mass))
+  `S.is` S "assumed to extend infinitely in the third" +:+.
+  phrase dimension, atStartNP (the analysis), S "will be at an instant" `S.in_`
   phrase time :+: S ";", plural factor, S "that may change the", plural soilPrpty,
   S "over", phrase time, S "will not be considered"]
 
@@ -235,12 +238,12 @@ scope = foldlSent_ [phrase stabAnalysis, S "of a", phrase twoD, sParen (getAcc t
 -- SECTION 2.4 --
 -- Organization automatically generated in IOrgSec
 orgSecStart, orgSecEnd :: Sentence
-orgSecStart = foldlSent [S "The", phrase organization, S "of this",
+orgSecStart = foldlSent [atStartNP (the organization), S "of this",
   phrase document, S "follows the", phrase template, S "for an",
-  short Doc.srs, S "for", phrase sciCompS,
+  short Doc.srs `S.for` phrase sciCompS,
   S "proposed by Koothoor", makeRef2S koothoor2013, S "as well as Smith" `S.and_`
   S "Lai", makeRef2S smithLai2005]
-orgSecEnd   = foldlSent_ [S "The", plural inModel, S "provide the set of",
+orgSecEnd   = foldlSent_ [atStartNP' (the inModel), S "provide the set of",
   S "algebraic", plural equation, S "that must be solved"]
 
 -- SECTION 3 --
@@ -251,25 +254,24 @@ sysCtxIntro = foldlSP
   [makeRef2S sysCtxFig1 +:+ S "shows the" +:+. phrase sysCont,
    S "A circle represents an external entity outside the" +:+. phrase software, S "A rectangle represents the",
    phrase softwareSys, S "itself" +:+. sParen (short ssp),
-   S "Arrows are used to show the data flow between the" +:+ phrase system,
-   S "and its" +:+ phrase environment]
+   S "Arrows are used to show the data flow between the" +:+ phraseNP (system
+   `andIts` environment)]
    
 sysCtxFig1 :: LabelledContent
 sysCtxFig1 = llcc (makeFigRef "sysCtxDiag") $ fig (titleize sysCont) (resourcePath ++ "SystemContextFigure.png")
 
 sysCtxDesc :: Contents
 sysCtxDesc = foldlSPCol
-  [S "The responsibilities of the", phrase user, S "and the", phrase system,
+  [S "The responsibilities of the", phraseNP (user `andThe` system),
    S "are as follows"]
    
 sysCtxUsrResp :: [Sentence]
-sysCtxUsrResp = [S "Provide the" +:+ phrase input_ +:+ S "data related to" +:+
-  S "the" +:+ phrase soilLyr :+: S "(s) and water table (if applicable)" `sC`
+sysCtxUsrResp = [S "Provide" +:+ phraseNP (the input_) +:+ S "data related to" +:+
+  phraseNP (the soilLyr) :+: S "(s) and water table (if applicable)" `sC`
   S "ensuring conformation to" +:+ phrase input_ +:+ S "data format" +:+
   S "required by" +:+ short ssp,
-  S "Ensure that consistent units are used for" +:+ phrase input_ +:+ 
-  plural variable,
-  S "Ensure required" +:+ phrase software +:+ plural assumption +:+ sParen ( 
+  S "Ensure that consistent units are used for" +:+ pluralNP (combineNINI input_ variable),
+  S "Ensure required" +:+ pluralNP (combineNINI software assumption) +:+ sParen ( 
   makeRef2S $ SRS.assumpt ([]::[Contents]) ([]::[Section])) +:+ S "are" +:+ 
   S "appropriate for the" +:+ phrase problem +:+ S "to which the" +:+ 
   phrase user +:+ S "is applying the" +:+ phrase software]
@@ -283,7 +285,7 @@ sysCtxSysResp = [S "Detect data" +:+ phrase type_ +:+ S "mismatch, such as" +:+
   S "Identify the" +:+ phrase crtSlpSrf +:+ S "within the possible" +:+
   phrase input_ +:+ S "range",
   S "Find the" +:+ phrase fsConcept +:+ S "for the" +:+ phrase slope,
-  S "Find the" +:+ phrase intrslce +:+ phrase normForce `S.and_` phrase shearForce +:+ S "along the" +:+ phrase crtSlpSrf]
+  S "Find the" +:+ phrase intrslce +:+ phraseNP (normForce `and_` shearForce) +:+ S "along the" +:+ phrase crtSlpSrf]
   
 sysCtxResp :: [Sentence]
 sysCtxResp = [titleize user +:+ S "Responsibilities",
@@ -304,7 +306,7 @@ userCharIntro = userChar ssp [S "Calculus", titleize Doc.physics]
 
 userChar :: (Idea a) => a -> [Sentence] -> [Sentence] -> [Sentence] -> Contents
 userChar pname understandings familiarities specifics = foldlSP [
-  S "The", phrase endUser `S.of_` short pname,
+  atStartNP (the endUser) `S.of_` short pname,
   S "should have an understanding of undergraduate Level 1",
   foldlList Comma List understandings `sC`
   S "and be familiar with", foldlList Comma List familiarities `sC` 
@@ -312,7 +314,7 @@ userChar pname understandings familiarities specifics = foldlSP [
 
 -- SECTION 3.2 --
 sysConstraints :: Contents
-sysConstraints = foldlSP [S "The", phrase morPrice, phrase method_, 
+sysConstraints = foldlSP [atStartNP (NP.the (combineNINI morPrice method_)), 
   makeRef2S morgenstern1965 `sC` S "which involves dividing the", phrase slope,
   S "into vertical", plural slice `sC` S "will be used to derive the",
   plural equation, S "for analysing the", phrase slope]
@@ -321,9 +323,9 @@ sysConstraints = foldlSP [S "The", phrase morPrice, phrase method_,
 
 -- SECTION 4.1 --
 prob :: Sentence
-prob = foldlSent_ [S "evaluate the", phrase fs `S.of_` S "a", phrasePoss slope,
-  phrase slpSrf `S.and_` S "identify", phrase crtSlpSrf `S.the_ofThe` phrase slope `sC`
-  S "as well as the", phrase intrslce, phrase normForce `S.and_` phrase shearForce,
+prob = foldlSent_ [S "evaluate the", phrase fs `S.ofA` phrasePoss slope,
+  phrase slpSrf `S.and_` S "identify", phraseNP (crtSlpSrf `the_ofThe` slope) `sC`
+  S "as well as the", phrase intrslce, phraseNP (normForce `and_` shearForce),
   S "along the", phrase crtSlpSrf]
 
 {-
@@ -343,12 +345,12 @@ terms = [fsConcept, slpSrf, crtSlpSrf, waterTable, stress, strain, normForce,
 -- SECTION 4.1.2 --
 physSystParts :: [Sentence]
 physSystParts = map foldlSent [
-  [S "A", phrase slope, S "comprised of one", phrase soilLyr],
-  [S "A", phrase waterTable `sC` S "which may or may not exist"]]
+  [atStartNP (a_ slope), S "comprised of one", phrase soilLyr],
+  [atStartNP (a_ waterTable) `sC` S "which may or may not exist"]]
 
 figPhysSyst :: LabelledContent
 figPhysSyst = llcc (makeFigRef "PhysicalSystem") $
-  fig (foldlSent_ [S "An example", phrase slope, S "for", phrase analysis,
+  fig (foldlSent_ [S "An example", phraseNP (slope `for` analysis),
   S "by", short ssp `sC` S "where the dashed line represents the",
   phrase waterTable]) (resourcePath ++ "PhysSyst.png")
 
@@ -356,10 +358,10 @@ physSystContents :: [Contents]
 physSystContents = [physSysConv, LlC figIndexConv, physSysFbd, LlC figForceActing]
 
 physSysConv :: Contents
-physSysConv = foldlSP [atStart morPrice, phrase analysis, makeRef2S morgenstern1965,
-  S "of the", phrase slope,  S "involves representing the", phrase slope,
+physSysConv = foldlSP [atStart morPrice, phrase analysis, makeRef2S morgenstern1965
+  `S.ofThe` phrase slope,  S "involves representing the", phrase slope,
   S "as a series of vertical" +:+. plural slice, S "As shown in",
-  makeRef2S figIndexConv `sC` S "the", phrase index, ch index, S "is used to denote a",
+  makeRef2S figIndexConv `sC` phraseNP (the index), ch index, S "is used to denote a",
   phrase value, S "for a single", phrase slice `sC` S "and an", phrase intrslce, 
   phrase value, S "at a given", phrase index, ch index, S "refers to the",
   phrase value, S "between", phrase slice, ch index `S.and_` S "adjacent", phrase slice,
@@ -367,24 +369,24 @@ physSysConv = foldlSP [atStart morPrice, phrase analysis, makeRef2S morgenstern1
 
 figIndexConv :: LabelledContent
 figIndexConv = llcc (makeFigRef "IndexConvention") $ 
-  fig (foldlSent_ [S "Index convention for", phrase slice `S.and_` 
-  phrase intrslce, plural value]) (resourcePath ++ "IndexConvention.png")
+  fig (foldlSent_ [S "Index convention for", phraseNP (slice `and_` 
+  intrslce), plural value]) (resourcePath ++ "IndexConvention.png")
 
 physSysFbd :: Contents
-physSysFbd = foldlSP [S "A", phrase fbd, S "of the", plural force, S "acting on a",
+physSysFbd = foldlSP [atStartNP' (NP.a_ (fbd `ofThe` force)), S "acting on a",
   phrase slice `S.is` S "displayed in" +:+. makeRef2S figForceActing, S "The specific",
-  plural force `S.and_` plural symbol_, S "will be discussed in detail in",
+  pluralNP (force `and_PP` symbol_), S "will be discussed in detail in",
   makeRef2S (SRS.genDefn [] []) `S.and_` makeRef2S (SRS.dataDefn [] [])]
 
 figForceActing :: LabelledContent
 figForceActing = llcc (makeFigRef "ForceDiagram") $
-  fig (atStart fbd `S.of_` plural force +:+ S "acting on a" +:+
+  fig (atStartNP' (fbd `of_TSP` force) +:+ S "acting on a" +:+
   phrase slice) (resourcePath ++ "ForceDiagram.png")
 
 -- SECTION 4.1.3 --
 goalsInputs :: [Sentence]
-goalsInputs = [phrase shape `S.the_ofThe` phrase soil +:+ S "mass",
-  S "location" `S.the_ofThe` phrase waterTable, plural mtrlPrpty `S.the_ofThe` phrase soil]
+goalsInputs = [phraseNP (the shape `NP.ofThe` combineNINI soil mass),
+  S "location" `S.the_ofThe` phrase waterTable, pluralNP (mtrlPrpty `the_ofThePS` soil)]
 
 -- SECTION 4.2 --
 

--- a/code/drasil-example/Drasil/SSP/Changes.hs
+++ b/code/drasil-example/Drasil/SSP/Changes.hs
@@ -4,6 +4,7 @@ module Drasil.SSP.Changes (likelyChgs, unlikelyChgs) where
 
 import Language.Drasil
 import Utils.Drasil
+import Utils.Drasil.Concepts
 import qualified Utils.Drasil.Sentence as S
 
 import Data.Drasil.Concepts.Documentation (analysis, likeChgDom, model, system, unlikeChgDom)
@@ -55,13 +56,13 @@ unlikelyChg2AO   = cic "UC_2donly"          uc2AODesc   "2D-Analysis-Only"      
 ucNASLODesc, uc2AODesc :: Sentence
 
 ucNASLODesc = foldlSent [S "Changes related to",
-  makeRef2S assumpINSFL, S "are not possible due to the dependency",
-  S "of the", plural calculation, S "on the linear relationship between",
-  phrase intNormForce `S.and_` phrase intShrForce]
+  makeRef2S assumpINSFL, S "are not possible due to the dependency"
+  `S.ofThe` plural calculation, S "on the linear relationship between",
+  phraseNP (intNormForce `and_` intShrForce)]
 
 uc2AODesc = foldlSent [makeRef2S assumpENSL, S "allows for", short twoD, 
   phrase analysis, S "with these", plural model, S "only because", 
   phrase stress, S "along the" +:+. (phrase zDir `S.is` S "zero"), 
-  S "These", plural model, S "do not take into account", phrase stress, 
-  S "in the", phrase zDir `sC` S "and therefore cannot be used",
-  S "without manipulation to attempt", phrase threeD, phrase analysis]
+  S "These", plural model, S "do not take into account", phraseNP (stress 
+  `inThe` zDir) `sC` S "and therefore cannot be used",
+  S "without manipulation to attempt", phraseNP (combineNINI threeD analysis)]

--- a/code/drasil-example/Drasil/SSP/DataDefs.hs
+++ b/code/drasil-example/Drasil/SSP/DataDefs.hs
@@ -68,8 +68,8 @@ angleAEqn = arctan ((inxi slipHght $- inx slipHght (-1)) $/
   (inxi slipDist $- inx slipDist (-1)))
 
 angleANotes :: Sentence
-angleANotes = foldlSent [S "This", phrase equation, S "is based on the",
-  phrase assumption, S "that the base of a", phrase slice,
+angleANotes = foldlSent [S "This", phrase equation, S "is based" `S.onThe`
+  phrase assumption, S "that the base" `S.ofA` phrase slice,
   S "is a straight line", sParen (makeRef2S assumpSBSBISL)]
 
 --DD angleB: surface angles
@@ -87,8 +87,8 @@ angleBEqn = arctan ((inxi slopeHght $- inx slopeHght (-1)) $/
   (inxi slopeDist $- inx slopeDist (-1)))
 
 angleBNotes :: Sentence
-angleBNotes = foldlSent [S "This", phrase equation, S "is based on the",
-  phrase assumption, S "that the surface of a", phrase slice,
+angleBNotes = foldlSent [S "This", phrase equation, S "is based" `S.onThe`
+  phrase assumption, S "that the surface" `S.ofA` phrase slice,
   S "is a straight line", sParen (makeRef2S assumpSBSBISL)]
 
 --DD lengthB: base width of slices
@@ -117,8 +117,8 @@ lengthLbEqn :: Expr
 lengthLbEqn = inxi baseWthX `mulRe` sec (inxi baseAngle)
 
 lengthLbNotes :: Sentence
-lengthLbNotes = foldlSent [ch baseWthX, S "is defined in",
-  makeRef2S lengthB `S.and_` ch baseAngle, S "is defined in", makeRef2S angleA]
+lengthLbNotes = foldlSent [baseWthX `definedIn'''`
+  lengthB `S.and_` (baseAngle `definedIn'''` angleA)]
 
 --DD lengthLs: surface lengths of slices
 
@@ -134,8 +134,8 @@ lengthLsEqn :: Expr
 lengthLsEqn = inxi baseWthX `mulRe` sec (inxi surfAngle)
 
 lengthLsNotes :: Sentence
-lengthLsNotes = foldlSent [ch baseWthX, S "is defined in",
-  makeRef2S lengthB `S.and_` ch surfAngle, S "is defined in", makeRef2S angleB]
+lengthLsNotes = foldlSent [baseWthX `definedIn'''`
+  lengthB `S.and_` (surfAngle `definedIn'''` angleB)]
 
 
 --DD slcHeight: y-direction heights of slices
@@ -212,7 +212,7 @@ convertFunc1Eqn = (sy normToShear `mulRe` inxi scalFunc `mulRe`
   cos (inxi baseAngle)) `mulRe` sy fs)
 
 convertFunc1Notes :: Sentence
-convertFunc1Notes = foldlSent [ch scalFunc, S "is defined in", makeRef2S ratioVariation `S.and_` ch baseAngle, S "is defined in", makeRef2S angleA]
+convertFunc1Notes = foldlSent [scalFunc `definedIn'''` ratioVariation `S.and_` (baseAngle `definedIn'''` angleA)]
 
 --DD convertFunc2: second function for incorporating interslice forces into shear force
 
@@ -231,10 +231,9 @@ convertFunc2Eqn = ((sy normToShear `mulRe` inxi scalFunc `mulRe`
   inxiM1 shrResC
 
 convertFunc2Notes :: Sentence
-convertFunc2Notes = foldlSent [ch scalFunc, S "is defined in",
-  makeRef2S ratioVariation `sC` ch baseAngle, S "is defined in",
-  makeRef2S angleA `sC` S "and", ch shrResC, S "is defined in",
-  makeRef2S convertFunc1]
+convertFunc2Notes = (foldlList Comma List
+  [scalFunc `definedIn'''` ratioVariation, baseAngle `definedIn'''` angleA,
+  shrResC `definedIn'''` convertFunc1] !.)
 
 {--DD10
 

--- a/code/drasil-example/Drasil/SSP/Defs.hs
+++ b/code/drasil-example/Drasil/SSP/Defs.hs
@@ -61,13 +61,13 @@ ssa = compoundNC slope stabAnalysis
 effFandS, slpSrf, crtSlpSrf, plnStrn, fsConcept, waterTable :: ConceptChunk
 effFandS = dccWDS "effective forces and stresses" 
   (cn "effective forces and stresses") 
-  (S "The" +:+ phrase normForce `S.or_` phrase nrmStrss +:+
+  (atStartNP (the normForce) `S.or_` phrase nrmStrss +:+
   S "carried by the" +:+ phrase soil +:+ S "skeleton" `sC`
   S "composed of the effective" +:+ phrase force `S.or_` phrase stress `S.andThe`
   phrase force `S.or_` phrase stress +:+ S "exerted by water")
 
-slpSrf = dccWDS "slip surface" (cn' "slip surface") (S "A" +:+
-  phrase surface +:+ S "within a" +:+ phrase slope +:+ S "that has the" +:+
+slpSrf = dccWDS "slip surface" (cn' "slip surface")
+  (atStartNP (a_ surface) +:+ S "within a" +:+ phrase slope +:+ S "that has the" +:+
   S "potential to fail or displace due to load or other" +:+ plural force)
 
 --FIXME: move to Concepts/soldMechanics.hs? They are too specific though
@@ -82,13 +82,13 @@ plnStrn = dccWDS "plane strain" (cn' "plane strain")
   S "dominant" +:+ phrase dimension +:+ S "can be approximated as zero")
 
 crtSlpSrf = dccWDS "critical slip surface" (cn' "critical slip surface") 
-  (atStart slpSrf +:+ S "of the" +:+ phrase slope +:+
+  (atStartNP (slpSrf `ofThe` slope) +:+
   S "that has the lowest" +:+ phrase fsConcept `sC`
   S "and is therefore most likely to experience failure")
 
 fsConcept = dccWDS "FS" factorOfSafety
-  (S "The global stability metric of a" +:+ phrase slpSrf +:+ S "of a" +:+
-  phrase slope `sC` S "defined as the ratio of" +:+ phrase shearRes +:+ 
+  (S "The global stability metric" `S.ofA` phraseNP (slpSrf `ofA` slope) `sC` 
+  S "defined as the ratio of" +:+ phrase shearRes +:+ 
   S "to" +:+ phrase mobShear)
 -- OLD DEFN: Stability metric. How likely a slip surface is to
 -- experience failure through slipping.

--- a/code/drasil-example/Drasil/SSP/GenDefs.hs
+++ b/code/drasil-example/Drasil/SSP/GenDefs.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE PostfixOperators #-}
 module Drasil.SSP.GenDefs (normForcEq, bsShrFEq, resShr, mobShr,
   normShrR, momentEql, generalDefinitions,
   normForcEqGD, bsShrFEqGD, resShrGD, mobShrGD, normShrRGD, momentEqlGD,
@@ -7,6 +8,8 @@ import Prelude hiding (sin, cos, tan)
 import Language.Drasil
 import Theory.Drasil (GenDefn, gd, ModelKinds (OthModel))
 import Utils.Drasil
+import Utils.Drasil.Concepts
+import qualified Utils.Drasil.NounPhrase as NP
 import qualified Utils.Drasil.Sentence as S
 
 import Drasil.DocLang.SRS as SRS (physSyst)
@@ -91,11 +94,9 @@ nmFEqRel = inxi totNrmForce $= eqlExprN cos sin
 
 nmFEqDesc :: Sentence
 nmFEqDesc = foldlSent [S "This equation satisfies", makeRef2S equilibrium +:+.
-  S "in the normal direction", ch slcWght, S "is defined in",
-  makeRef2S sliceWghtGD `sC` ch surfHydroForce,  S "is defined in",
-  makeRef2S srfWtrFGD `sC` ch surfAngle, S "is defined in",
-  makeRef2S angleB `sC` S "and", ch baseAngle, S "is defined in",
-  makeRef2S angleA]
+  S "in the normal direction", foldlList Comma List
+  [slcWght `definedIn'''` sliceWghtGD, surfHydroForce `definedIn'''` srfWtrFGD,
+  surfAngle `definedIn'''` angleB, baseAngle `definedIn'''` angleA]]
 
 nmFEqDeriv :: Derivation
 nmFEqDeriv = mkDerivNoHeader [foldlSent [atStart normForcEq `S.is`
@@ -113,11 +114,9 @@ bShFEqRel = inxi mobShrI $= eqlExpr sin cos
 
 bShFEqDesc :: Sentence
 bShFEqDesc = foldlSent [S "This equation satisfies", makeRef2S equilibrium +:+.
-  S "in the shear direction", ch slcWght, S "is defined in",
-  makeRef2S sliceWghtGD `sC` ch surfHydroForce, S "is defined in",
-  makeRef2S srfWtrFGD `sC` ch surfAngle, S "is defined in",
-  makeRef2S angleB `sC` S "and", ch baseAngle, S "is defined in",
-  makeRef2S angleA]
+  S "in the shear direction", foldlList Comma List [slcWght `definedIn'''` sliceWghtGD,
+  surfHydroForce `definedIn'''` srfWtrFGD, surfAngle `definedIn'''` angleB, 
+  baseAngle `definedIn'''` angleA]]
 
 bShFEqDeriv :: Derivation
 bShFEqDeriv = mkDerivNoHeader [foldlSent [atStart bsShrFEq `S.is`
@@ -136,15 +135,15 @@ resShrRel :: Relation
 resShrRel = inxi shrResI $= shrResEqn
 
 resShrDesc :: Sentence
-resShrDesc = foldlSent [ch baseLngth, S "is defined in", makeRef2S lengthLb]
+resShrDesc = foldlSent [baseLngth `definedIn'''` lengthLb]
 
 resShrDeriv :: Derivation
 resShrDeriv = mkDerivNoHeader [foldlSent [S "Derived by substituting",
-  makeRef2S normStressDD, S "and", makeRef2S tangStressDD, S "into the Mohr-Coulomb", phrase shrStress `sC`
+  makeRef2S normStressDD `S.and_` makeRef2S tangStressDD, S "into the Mohr-Coulomb", phrase shrStress `sC`
   makeRef2S mcShrStrgth `sC` S "and multiplying both sides of the",
-  phrase equation, S "by",  phrase genericA `S.the_ofThe` phrase slice `S.in_`
-  S "the shear-" :+: ch zcoord +:+. S "plane", S "Since the", phrase slope,
-  S "is assumed to extend infinitely in the", phrase zDir,
+  phrase equation, S "by",  phraseNP (genericA `the_ofThe` slice) `S.in_`
+  S "the shear-" :+: ch zcoord +:+. S "plane", S "Since", phraseNP (the slope),
+  S "is assumed to extend infinitely in", phraseNP (the zDir),
   sParen (makeRef2S assumpPSC) `sC` S "the resulting", plural force,
   S "are expressed per", phrase metre, S "in the" +:+. phrase zDir, S "The",
   getTandS fricAngle `S.andThe` getTandS effCohesion, S "are not indexed by",
@@ -162,13 +161,13 @@ mobShrRel :: Relation
 mobShrRel = inxi mobShrI $= inxi shrResI $/ sy fs $= shrResEqn $/ sy fs
 
 mobShrDesc :: Sentence
-mobShrDesc = foldlSent [ch baseLngth, S "is defined in", makeRef2S lengthLb]
+mobShrDesc = (baseLngth `definedIn'''` lengthLb !.)
 
 mobShrDeriv :: Derivation
 mobShrDeriv = mkDerivNoHeader [foldlSent_ [atStart mobShrI `S.is` S "derived by dividing",
-  phrase definition `S.the_ofThe` ch shrResI, S "from" +:+. makeRef2S resShrGD,
-  S "by", phrase definition `S.the_ofThe` phrase fs, S "from" +:+.
-  makeRef2S factOfSafety, S "The", getTandS fs, S "is not indexed by", ch index,
+  phrase definition `S.the_ofThe` ch shrResI, S "from", makeRef2S resShrGD,
+  S "by", phraseNP (definition `the_ofThe` fs), S "from" +:+. makeRef2S factOfSafety,
+  S "The", getTandS fs, S "is not indexed by", ch index,
   S "because it is assumed to be", phrase constant, S "for the entire",
   phrase slpSrf +:+. sParen (makeRef2S assumpFOSL)]]
 
@@ -181,17 +180,17 @@ effNormFRel :: Relation
 effNormFRel = inxi nrmFSubWat $= inxi totNrmForce $- inxi baseHydroForce
 
 effNormFDesc :: Sentence
-effNormFDesc = ch baseHydroForce +:+ S "is defined in" +:+. makeRef2S baseWtrFGD
+effNormFDesc = (baseHydroForce `definedIn'''` baseWtrFGD !.)
 
 effNormFDeriv :: Derivation
 effNormFDeriv = mkDerivNoHeader [foldlSent [
   S "Derived by substituting", makeRef2S normStressDD, S "into",
-  makeRef2S effStress `S.and_` S "multiplying both sides of the", phrase equation,
-  S "by", phrase genericA `S.the_ofThe` phrase slice, S "in the shear-" :+:
-  ch zcoord +:+. S "plane", S "Since the", phrase slope,
-  S "is assumed to extend infinitely in the", phrase zDir,
+  makeRef2S effStress `S.and_` S "multiplying both sides of", phraseNP (the equation),
+  S "by", phraseNP (genericA `the_ofThe` slice), S "in the shear-" :+:
+  ch zcoord +:+. S "plane", S "Since", phraseNP (the slope),
+  S "is assumed to extend infinitely in", phraseNP (the zDir),
   sParen (makeRef2S assumpPSC) `sC` S "the resulting", plural force,
-  S "are expressed per", phrase metre, S "in the", phrase zDir]]
+  S "are expressed per", phrase metre, S "in", phraseNP (the zDir)]]
 
 --
 normShrR :: RelationConcept
@@ -205,8 +204,7 @@ nmShrRRel = sy intShrForce $= sy normToShear `mulRe` sy scalFunc `mulRe` sy intN
 nmShrRDesc :: Sentence
 nmShrRDesc = foldlSent [S "Mathematical representation of the primary",
   phrase assumption, S "for the Morgenstern-Price", phrase method_ +:+.
-  sParen (makeRef2S assumpINSFL), ch scalFunc, S "is defined in",
-  makeRef2S ratioVariation]
+  sParen (makeRef2S assumpINSFL), scalFunc `definedIn'''` ratioVariation]
 
 --
 resShearWO :: RelationConcept
@@ -222,14 +220,13 @@ resShearWORel = inxi shearRNoIntsl $=
   inxi baseLngth))
 
 resShearWODesc :: Sentence
-resShearWODesc = foldlSent_ [ch slcWght, S "is defined in",
-  makeRef2S sliceWghtGD `sC` ch surfHydroForce, S "is defined in",
-  makeRef2S srfWtrFGD `sC` ch surfAngle, S "is defined in",
-  makeRef2S angleB `sC` ch baseAngle, S "is defined in",
-  makeRef2S angleA `sC` ch watrForce, S "is defined in",
-  makeRef2S intersliceWtrF `sC` ch baseHydroForce, S "is defined in",
-  makeRef2S baseWtrFGD `sC` S "and", ch baseLngth, S "is defined in" +:+.
-  makeRef2S lengthLb]
+resShearWODesc = (foldlList Comma List [slcWght `definedIn'''` sliceWghtGD,
+  surfHydroForce `definedIn'''` srfWtrFGD,
+  surfAngle `definedIn'''` angleB,
+  baseAngle `definedIn'''` angleA,
+  watrForce `definedIn'''` intersliceWtrF,
+  baseHydroForce `definedIn'''` baseWtrFGD,
+  baseLngth `definedIn'''` lengthLb] !.)
 
 --
 --
@@ -243,12 +240,11 @@ mobShearWORel = inxi shearFNoIntsl $= ((inxi slcWght `addRe` (inxi surfHydroForc
   inxiM1 watrForce `addRe` (inxi surfHydroForce `mulRe` sin (inxi surfAngle))) `mulRe` cos (inxi baseAngle)))
 
 mobShearWODesc :: Sentence
-mobShearWODesc = foldlSent_ [ch slcWght, S "is defined in",
-  makeRef2S sliceWghtGD `sC` ch surfHydroForce, S "is defined in",
-  makeRef2S srfWtrFGD `sC` ch surfAngle, S "is defined in",
-  makeRef2S angleB `sC` ch baseAngle, S "is defined in",
-  makeRef2S angleA `sC` S "and", ch watrForce, S "is defined in" +:+.
-  makeRef2S intersliceWtrF]
+mobShearWODesc = (foldlList Comma List [slcWght `definedIn'''` sliceWghtGD,
+  surfHydroForce `definedIn'''` srfWtrFGD,
+  surfAngle `definedIn'''` angleB,
+  baseAngle `definedIn'''` angleA,
+  watrForce `definedIn'''` intersliceWtrF] !.)
 
 --
 
@@ -262,13 +258,13 @@ momEqlRel = exactDbl 0 $= momExpr (\ x y -> x `addRe`
 
 momEqlDesc :: Sentence
 momEqlDesc = foldlSent [S "This", phrase equation, S "satisfies",
-  makeRef2S equilibrium, S "for the net" +:+. phrase genericM, ch baseWthX,
-  S "is defined in", makeRef2S lengthB `sC` ch baseAngle, S "is defined in",
-  makeRef2S angleA `sC` ch slcWght, S "is defined in",
-  makeRef2S sliceWghtGD `sC` ch midpntHght, S "is defined in",
-  makeRef2S slcHeight `sC` ch surfHydroForce, S "is defined in",
-  makeRef2S srfWtrFGD `sC` S "and", ch surfAngle, S "is defined in",
-  makeRef2S angleB]
+  makeRef2S equilibrium, S "for the net" +:+. phrase genericM,
+  foldlList Comma List [baseWthX `definedIn'''` lengthB,
+  baseAngle `definedIn'''` angleA,
+  slcWght `definedIn'''` sliceWghtGD,
+  midpntHght `definedIn'''` slcHeight,
+  surfHydroForce `definedIn'''` srfWtrFGD,
+  surfAngle `definedIn'''` angleB]]
 
 momEqlDeriv :: Derivation
 momEqlDeriv = mkDerivNoHeader (weave [momEqlDerivSentences, momEqlDerivEqns])
@@ -308,111 +304,111 @@ momEqlDerivTorqueEqn, momEqlDerivMomentEqn,
   momEqlDerivFinalEqn :: Expr
 
 momEqlDerivTorqueSentence = [atStart genericM, S "is equal to",
-  phrase torque `sC` S "so the", phrase equation, S "from", makeRef2S torqueDD,
+  phrase torque `sC` S "so", phraseNP (the equation), S "from", makeRef2S torqueDD,
   S "will be used to calculate", plural genericM]
 
 momEqlDerivMomentSentence = [S "Considering one dimension, with",
   plural genericM, S "in the clockwise direction as positive and",
   plural genericM, S "in the counterclockwise direction as negative" `sC`
-  S "and replacing the", phrase torque, S "symbol with the", phrase genericM,
-  S "symbol, the", phrase equation, S "simplifies to"]
+  S "and replacing", phraseNP (the torque), S "symbol with", phraseNP (the genericM),
+  S "symbol,", phraseNP (the equation), S "simplifies to"]
 
 momEqlDerivNormaliSentence = [S "where", ch rotForce `S.isThe`
   phrase rotForce `S.and_` ch momntArm `S.isThe` phrase momntArm `sC`
-  S "or the distance between the", phrase force `S.andThe` S "axis about" +:+.
+  S "or the distance between", phraseNP (the force) `S.andThe` S "axis about" +:+.
   S "which the rotation acts",
-  S "To represent the", phrase momentEqlGD `sC` S "the", plural genericM,
+  S "To represent", phraseNP (the momentEqlGD) `sC` pluralNP (the genericM),
   S "from each", phrase force, S "acting on a", phrase slice +:+.
-  S "must be considered and added together", S "The", plural force,
+  S "must be considered and added together", atStartNP' (the force),
   S "acting on a", phrase slice, S "are all shown in" +:+.
   makeRef2S figForceActing,
   S "The midpoint of the base of a", phrase slice, S "is considered as the",
-  S "axis of rotation, from which the", phrase momntArm +:+. S "is measured",
-  S "Considering first the", phrase intrslce, phrase normForce,
-  S "acting on", phrase slice, S "interface", ch index `sC` S "the",
-  phrase genericM, S "is negative because the", phrase force,
-  S "tends to rotate the", phrase slice, S "in a counterclockwise",
-  S "direction" `sC` S "and the", phrase momntArm `S.is` (S "height" `S.the_ofThe`
-  phrase force), S "plus the difference in height between the base at",
+  S "axis of rotation, from which", phraseNP (the momntArm) +:+. S "is measured",
+  S "Considering first", phraseNP (NP.the (combineNINI intrslce normForce)),
+  S "acting on", phrase slice, S "interface", ch index `sC`
+  phraseNP (the genericM), S "is negative because", phraseNP (the force),
+  S "tends to rotate", phraseNP (the slice), S "in a counterclockwise",
+  S "direction" `sC` S "and", phraseNP (the momntArm) `S.is` phraseNP (height `the_ofThe`
+  force), S "plus the difference in height between the base at",
   phrase slice, S "interface", ch index `S.andThe` S "base at the midpoint of",
   phrase slice +:+. ch index,
-  S "Thus, the", phrase genericM, S "is expressed as"]
+  S "Thus,", phraseNP (the genericM), S "is expressed as"]
 
 momEqlDerivNormaliM1Sentence = [S "For the", E (sy index $- int 1) :+: S "th",
-  phrase slice, S "interface" `sC` S "the", phrase genericM `S.is`
+  phrase slice, S "interface" `sC` phraseNP (the genericM) `S.is`
   S "similar but in the opposite direction"]
 
-momEqlDerivWateriSentence = [S "Next, the", phrase intrslce, S "normal water",
+momEqlDerivWateriSentence = [S "Next,", phraseNP (the intrslce), S "normal water",
   phrase force +:+. S "is considered", S "This", phrase force, S "is zero at",
-  S "height" `S.the_ofThe` phrase waterTable `sC` S "then increases linearly towards",
+  phraseNP (height `the_ofThe` waterTable) `sC` S "then increases linearly towards",
   S "base" `S.the_ofThe` phrase slice, S "due to the increasing water" +:+.
   phrase pressure, S "For such a triangular distribution, the resultant",
   phrase force +:+. S "acts at one-third of the height", S "Thus, for the",
   phrase intrslce, S "normal water", phrase force, S "acting on", phrase slice,
-  S "interface", ch index `sC` S "the", phrase genericM, S "is"]
+  S "interface", ch index `sC` phraseNP (the genericM), S "is"]
 
-momEqlDerivWateriM1Sentence = [S "The", phrase genericM, S "for the",
+momEqlDerivWateriM1Sentence = [atStartNP (the genericM), S "for the",
   phrase intrslce, S "normal water", phrase force, S "acting on", phrase slice,
   S "interface", E (sy index $- int 1), S "is"]
 
-momEqlDerivSheariSentence = [S "The", phrase intrslce, phrase shearForce,
+momEqlDerivSheariSentence = [atStartNP (the intrslce), phrase shearForce,
   S "at", phrase slice, S "interface", ch index, S "tends to rotate in the",
-  S "clockwise direction, and the", phrase momntArm, S "is the", phrase len,
-  S "from the", phrase slice, S "edge to the", phrase slice, S "midpoint" `sC`
+  S "clockwise direction, and", phraseNP (NP.the (momntArm `isThe` len)),
+  S "from", phraseNP (the slice), S "edge to", phraseNP (the slice), S "midpoint" `sC`
   S "equivalent to half of", S "width" `S.the_ofThe` phrase slice `sC` S "so the",
   phrase genericM, S "is"]
 
-momEqlDerivSheariM1Sentence = [S "The", phrase intrslce, phrase shearForce,
+momEqlDerivSheariM1Sentence = [atStartNP (NP.the (combineNINI intrslce shearForce)),
   S "at", phrase slice, S "interface", E (sy index $- int 1), S "also tends to",
   S "rotate in the clockwise direction, and has the same", phrase momntArm `sC`
-  S "so the", phrase genericM, S "is"]
+  S "so", phraseNP (the genericM), S "is"]
 
 -- FIXME: Once differentials are expressible in Expr (issue #1407), change "sy yi" to the differential dy. "ch yi" actually means y and should stay as-is.
 momEqlDerivSeismicIntSentence = [S "Seismic", plural force, S "act over the",
-  S "entire height of the" +:+. phrase slice, S "For each horizontal segment",
-  S "of the", phrase slice `sC` S "the seismic", phrase force, S "is",
+  S "entire height of the" +:+. phrase slice, S "For each horizontal segment"
+  `S.ofThe` phrase slice `sC` S "the seismic", phrase force `S.is`
   E (sy earthqkLoadFctr `mulRe` inxi slcWght), S "where", E (inxi slcWght),
   S "can be expressed as", E (sy genericSpWght `mulRe` inxi baseWthX `mulRe` sy yi),
   S "using", makeRef2S weightGD, S "where", E (sy yi), S "is the height of" +:+.
   S "the segment under consideration", S "The corresponding", phrase momntArm `S.is`
-  ch yi `sC` S "the height from the base of the", phrase slice +:+.
-  S "to the segment under consideration", S "In reality, the", plural force,
-  S "near the surface of the", phrase soil, S "mass are slightly different",
+  ch yi `sC` S "the height from the base of", phraseNP (the slice) +:+.
+  S "to the segment under consideration", S "In reality,", pluralNP (the force),
+  S "near the surface of", phraseNP (the soil), S "mass are slightly different",
   S "due to the slope of the surface, but this difference is assumed to be",
   S "negligible" +:+. sParen (makeRef2S assumpNESSS), S "The resultant",
-  phrase genericM, S "from the", plural force, S "on all of the segments",
+  phrase genericM, S "from", pluralNP (the force), S "on all of the segments",
   S "with an equivalent resultant", phrase momntArm, S "is determined by",
-  S "taking the integral over the", phrase slice +:+. S "height", S "The",
-  plural force, S "tend to rotate in the counterclockwise direction, so the",
+  S "taking the integral over" +:+. phraseNP (NP.the (combineNINI slice height)), atStartNP' (the force), 
+  S "tend to rotate in the counterclockwise direction, so the",
   phrase genericM, S "is negative"]
 
 momEqlDerivSeismicSentence = [S "Solving the definite integral yields"]
 
 momEqlDerivSeismicWSentence = [S "Using", makeRef2S weightGD,
   S "again to express", E (sy genericSpWght `mulRe` inxi baseWthX `mulRe` inxi midpntHght),
-  S "as", E (inxi slcWght) `sC` S "the", phrase genericM, S "is"]
+  S "as", E (inxi slcWght) `sC` phraseNP (the genericM), S "is"]
 
 momEqlDerivHydroSentence = [S "The surface hydrostatic", phrase force,
-  S "acts into the midpoint of the surface of the", phrase slice +:+.
+  S "acts into the midpoint of the surface of", phraseNP (the slice) +:+.
   sParen (makeRef2S assumpHFSM),
-  S "Thus, the vertical", phrase component, S "of the", phrase force,
+  S "Thus, the vertical", phraseNP (component `ofThe` force),
   S "acts directly towards the point of rotation, and has a",
-  phrase genericM +:+. S "of zero", S "The horizontal", phrase component,
-  S "of the", phrase force, S "tends to rotate in a clockwise direction" `S.and_`
-  S "the", phrase momntArm, S "is the entire height of the" +:+. phrase slice,
-  S "Thus, the", phrase genericM, S "is"]
+  phrase genericM +:+. S "of zero", S "The horizontal", phraseNP (component
+  `ofThe` force), S "tends to rotate in a clockwise direction" `S.and_`
+  phraseNP (the momntArm), S "is the entire height of the" +:+. phrase slice,
+  S "Thus,", phraseNP (the genericM), S "is"]
 
 momEqlDerivExtSentence = [S "The external", phrase force, S "again acts into",
   S "midpoint" `S.the_ofThe` phrase slice, S "surface, so the vertical",
-  phrase component, S "does not contribute to the", phrase genericM `sC`
-  S "and the", phrase momntArm, S "is again the entire height of the" +:+.
-  phrase slice, S "The", phrase genericM, S "is"]
+  phrase component, S "does not contribute to", phraseNP (the genericM) `sC`
+  S "and", phraseNP (the momntArm), S "is again the entire height of the" +:+.
+  phrase slice, atStartNP (the genericM), S "is"]
 
-momEqlDerivFinalSentence = [S "The base hydrostatic", phrase force `S.and_`
-  phrase slice, phrase weight, S "both act in the direction of the point of",
+momEqlDerivFinalSentence = [S "The base hydrostatic", phraseNP (force `and_`
+  slice), phrase weight, S "both act in the direction of the point of",
   S "rotation", sParen (makeRef2S assumpHFSM) `sC` S "therefore both have",
-  plural genericM +:+. S "of zero", S "Thus, all of the", plural genericM +:+.
-  S "have been determined", S "The", phrase momentEqlGD `S.is`
+  plural genericM +:+. S "of zero", S "Thus, all of", pluralNP (the genericM) +:+.
+  S "have been determined", atStartNP (the momentEqlGD) `S.is`
   S "then represented by the sum of all", plural genericM]
 
 momEqlDerivTorqueEqn = sy torque $= cross (sy displacement) (sy force)
@@ -480,10 +476,9 @@ sliceWghtNotes = foldlSent [S "This", phrase equation, S "is based on the",
   phrase assumption, S "that the surface and the base of a", phrase slice,
   S "are straight lines" +:+. sParen (makeRef2S assumpSBSBISL), S "The",
   getTandS dryWeight `S.andThe` getTandS satWeight, S "are not indexed by",
-  ch index, S "because the", phrase soil, S "is assumed to be homogeneous" `sC`
-  S "with", phrase constant, plural soilPrpty, S "throughout" +:+.
-  sParen (makeRef2S assumpSLH), ch baseWthX +:+ S "is defined in",
-  makeRef2S lengthB]
+  ch index, S "because", phraseNP (the soil), S "is assumed to be homogeneous" `sC`
+  S "with", pluralNP (combineNINI constant soilPrpty), S "throughout" +:+.
+  sParen (makeRef2S assumpSLH), baseWthX `definedIn'''` lengthB]
 
 sliceWghtDeriv :: Derivation
 sliceWghtDeriv = mkDerivNoHeader (weave [sliceWghtDerivSentences, sliceWghtDerivEqns])
@@ -510,23 +505,23 @@ sliceWghtDerivSatCaseWeightEqn, sliceWghtDerivSatCaseSliceEqn,
   sliceWghtDerivMixCaseWeightEqn, sliceWghtDerivMixCaseSliceEqn :: Expr
 
 sliceWghtDerivSatCaseIntroSentence = [S "For the case where the",
-  phrase waterTable, S "is above the", phrase slopeSrf `sC` S "the",
-  phrase slcWght, S "come from", phrase weight `S.the_ofThe` S "saturated" +:+.
+  phrase waterTable, S "is above", phraseNP (the slopeSrf) `sC`
+  phraseNP (the slcWght), S "come from", phrase weight `S.the_ofThe` S "saturated" +:+.
   phrase soil,
   S "Substituting", plural value, S "for saturated", phrase soil, S "into the",
-  phrase equation, S "for", phrase weight, S "from", makeRef2S weightGD,
+  phraseNP (equation `for` weight), S "from", makeRef2S weightGD,
   S "yields"]
 
 sliceWghtDerivSatCase2DSentence = [S "Due to", makeRef2S assumpPSC `sC`
-  S "only two dimensions are considered, so the", plural area `S.of_`
+  S "only two dimensions are considered, so", pluralNP (the area) `S.of_`
   S "saturated", phrase soil, S "are considered instead of the" +:+.
   phrase satVol,
-  S "Any given", phrase slice +:+. S "has a trapezoidal shape", S "The",
-  phrase area, S "of a trapezoid is the average of",
-  plural len `S.the_ofThe` S "parallel sides multiplied by the", phrase len +:+.
+  S "Any given", phrase slice +:+. S "has a trapezoidal shape",
+  atStartNP (the area), S "of a trapezoid is the average of",
+  plural len `S.the_ofThe` S "parallel sides multiplied by", phraseNP (the len) +:+.
   S "between the parallel sides", S "The parallel sides in this case are the",
-  phrase intrslce, S "edges and the", phrase len, S "between them" `S.isThe`
-  S "width of the" +:+. phrase slice, S "Thus" `sC` S "the", phrase slcWght,
+  phrase intrslce, S "edges and", phraseNP (the len), S "between them" `S.isThe`
+  S "width of the" +:+. phrase slice, S "Thus" `sC` phraseNP (the slcWght),
   S "are defined as"]
 
 sliceWghtDerivSatCaseWeightEqn = inxi slcWght $= inxi satVol `mulRe` sy satWeight
@@ -535,17 +530,17 @@ sliceWghtDerivSatCaseSliceEqn = inxi slcWght $= inxi baseWthX `mulRe` oneHalf `m
   ((inxi slopeHght $- inxi slipHght) `addRe` (inxiM1 slopeHght $- inxiM1 slipHght)) `mulRe` sy satWeight
 
 sliceWghtDerivDryCaseIntroSentence = [S "For the case where the",
-  phrase waterTable, S "is below the", phrase slpSrf `sC` S "the",
-  phrase slcWght, S "come from", phrase weight `S.the_ofThe` S "dry" +:+. phrase soil,
+  phrase waterTable, S "is below", phraseNP (the slpSrf) `sC`
+  phraseNP (the slcWght), S "come from", phrase weight `S.the_ofThe` S "dry" +:+. phrase soil,
   S "Substituting", plural value, S "for dry", phrase soil, S "into the",
-  phrase equation, S "for", phrase weight, S "from", makeRef2S weightGD,
+  phraseNP (equation `for` weight), S "from", makeRef2S weightGD,
   S "yields"]
 
 sliceWghtDerivDryCase2DSentence = [makeRef2S assumpPSC, S "again allows for",
-  phrase twoD, phrase analysis, S "so the", plural area `S.of_` S "dry",
+  phraseNP (combineNINI twoD analysis), S "so", pluralNP (the area) `S.of_` S "dry",
   phrase soil, S "are considered instead of the" +:+. phrase dryVol,
   S "The trapezoidal", phrase slice,
-  S "shape is the same as in the previous case" `sC` S "so the", phrase slcWght,
+  S "shape is the same as in the previous case" `sC` S "so", phraseNP (the slcWght),
   S "are defined as"]
 
 sliceWghtDerivDryCaseWeightEqn = inxi slcWght $= inxi dryVol `mulRe` sy dryWeight
@@ -554,28 +549,28 @@ sliceWghtDerivDryCaseSliceEqn = inxi slcWght $= inxi baseWthX `mulRe` oneHalf `m
   ((inxi slopeHght $- inxi slipHght) `addRe` (inxiM1 slopeHght $- inxiM1 slipHght)) `mulRe` sy dryWeight
 
 sliceWghtDerivMixCaseIntroSentence = [S "For the case where the",
-  phrase waterTable, S "is between the", phrase slopeSrf `S.and_`
-  phrase slpSrf `sC` S "the", phrase slcWght, S "are the sums of",
+  phrase waterTable, S "is between", phraseNP (NP.the (slopeSrf `and_`
+  slpSrf)) `sC` phraseNP (the slcWght), S "are the sums of",
   plural weight `S.the_ofThe` S "dry portions"  `S.and_` plural weight `S.ofThe`
   S "saturated portions of the" +:+. phrase soil,
   S "Substituting", plural value, S "for dry and saturated", phrase soil,
-  S "into the", phrase equation, S "for", phrase weight, S "from",
-  makeRef2S weightGD, S "and adding them together yields"]
+  S "into", phraseNP (NP.the (equation `for` weight)),
+  S "from", makeRef2S weightGD, S "and adding them together yields"]
 
 sliceWghtDerivMixCase2DSentence = [makeRef2S assumpPSC, S "again allows for",
-  phrase twoD, phrase analysis, S "so the", plural area `S.of_` S "dry",
+  phraseNP (combineNINI twoD analysis), S "so", pluralNP (the area) `S.of_` S "dry",
   phrase soil `S.and_` plural area `S.of_` S "saturated", phrase soil,
-  S "are considered instead of the" +:+. (phrase dryVol `S.and_` phrase satVol),
-  S "The", phrase waterTable, S "is assumed to only intersect a", phrase slice,
+  S "are considered instead of the" +:+. phraseNP (dryVol `and_` satVol),
+  atStartNP (the waterTable), S "is assumed to only intersect a", phrase slice,
   S "surface or base at a", phrase slice, S "edge",
   sParen (makeRef2S assumpWISE `sC` makeRef2S assumpWIBE) `sC` S "so the" +:+.
   S "dry and saturated portions each have trapezoidal shape", S "For the dry",
-  S "portion, the parallel sides of the trapezoid are the", plural len,
-  S "between the", phrase slopeSrf `S.and_` phrase waterTable, S "at the",
+  S "portion, the parallel sides of the trapezoid are", pluralNP (the len),
+  S "between", phraseNP (NP.the (slopeSrf `and_` waterTable)), S "at the",
   phrase slice +:+. S "edges", S "For the saturated portion, the parallel",
-  S "sides of the trapezoid are the", plural len, S "between the",
-  phrase waterTable `S.and_` phrase slpSrf, S "at the", phrase slice +:+.
-  S "edges", S "Thus" `sC` S "the", phrase slcWght,  S "are defined as"]
+  S "sides of the trapezoid are", pluralNP (the len), S "between the",
+  phraseNP (waterTable `and_` slpSrf), S "at", phraseNP (the slice) +:+.
+  S "edges", S "Thus" `sC` phraseNP (the slcWght),  S "are defined as"]
 
 sliceWghtDerivMixCaseWeightEqn = inxi slcWght $= inxi dryVol `mulRe` sy dryWeight `addRe`
   (inxi satVol `mulRe` sy satWeight)
@@ -605,8 +600,8 @@ bsWtrFEqn = inxi baseHydroForce $= inxi baseLngth `mulRe` sy waterWeight `mulRe`
 bsWtrFNotes :: Sentence
 bsWtrFNotes = foldlSent [S "This", phrase equation, S "is based on the",
   phrase assumption, S "that the base of a", phrase slice,
-  S "is a straight line" +:+. sParen (makeRef2S assumpSBSBISL), ch baseLngth,
-  S "is defined in", makeRef2S lengthLb]
+  S "is a straight line" +:+. sParen (makeRef2S assumpSBSBISL),
+  baseLngth `definedIn'''` lengthLb]
 
 bsWtrFDeriv :: Derivation
 bsWtrFDeriv = mkDerivNoHeader (weave [bsWtrFDerivSentences, bsWtrFDerivEqns] ++
@@ -625,41 +620,41 @@ bsWtrFDerivIntroSentence, bsWtrFDerivHeightSentence, bsWtrFDeriv2DSentence,
 
 bsWtrFDerivWeightEqn, bsWtrFDerivHeightEqn, bsWtrFDerivSliceEqn :: Expr
 
-bsWtrFDerivIntroSentence = [S "The", phrase baseHydroForce, S "come from the",
+bsWtrFDerivIntroSentence = [atStartNP (the baseHydroForce), S "come from the",
   S "hydrostatic", phrase pressure, S "exerted by the water above the base of",
   S "each" +:+. phrase slice,
-  S "The", phrase equation, S "for hydrostatic", phrase pressure, S "from",
-  makeRef2S hsPressureGD, S "is"]
+  atStartNP (the equation), S "for hydrostatic", phrase pressure,
+  S "from", makeRef2S hsPressureGD, S "is"]
 
-bsWtrFDerivHeightSentence = [S "The", phrase specWeight, S "in this case is",
+bsWtrFDerivHeightSentence = [atStartNP (the specWeight), S "in this case is",
   S "the" +:+. getTandS waterWeight,
-  S "The", phrase height, S "in this case is the height from the", phrase slice,
+  atStartNP (the height), S "in this case is the height from", phraseNP (the slice),
   S "base to the" +:+. phrase waterTable,
   S "This", phrase height, S "is measured from", S "midpoint" `S.the_ofThe`
   phrase slice, S "because the resultant hydrostatic", phrase force,
-  S "is assumed to act at the", phrase slice, S "midpoint" +:+.
+  S "is assumed to act at", phraseNP (the slice), S "midpoint" +:+.
   sParen (makeRef2S assumpHFSM),
-  S "The", phrase height, S "at the midpoint is the average of the",
+  atStartNP (the height), S "at the midpoint is the average of the",
   phrase height, S "at", phrase slice, S "interface", ch index `S.andThe`
   phrase height, S "at", phrase slice, S "interface", E (sy index $- int 1)]
 
 bsWtrFDeriv2DSentence = [S "Due to", makeRef2S assumpPSC `sC`
-  S "only two dimensions are considered, so the", phrase baseHydroForce,
-  S "are expressed as", plural force +:+. S "per meter", S "The",
-  plural pressure, S "acting on the", plural slice, S "can thus be converted",
+  S "only two dimensions are considered, so", phraseNP (the baseHydroForce),
+  S "are expressed as", plural force +:+. S "per meter",
+  atStartNP' (the pressure), S "acting on", pluralNP (the slice), S "can thus be converted",
   S "to", phrase baseHydroForce, S "by multiplying by the corresponding",
-  phrase len, S "of the", phrase slice, S "base", E (inxi baseLngth) `sC`
-  S "assuming the", phrase waterTable, S "does not intersect a", phrase slice,
+  phraseNP (len `ofThe` slice), S "base", E (inxi baseLngth) `sC`
+  S "assuming", phraseNP (the waterTable), S "does not intersect a", phrase slice,
   S "base except at a", phrase slice, S "edge" +:+.
   sParen (makeRef2S assumpWIBE),
-  S "Thus, in the case where", S "height" `S.the_ofThe` phrase waterTable,
-  S "is above", S "height" `S.the_ofThe` phrase slpSrf `sC` S "the",
-  phrase baseHydroForce, S "are defined as"]
+  S "Thus, in the case where", phraseNP (height `the_ofThe` waterTable),
+  S "is above", phraseNP (height `the_ofThe` slpSrf) `sC`
+  phraseNP (the baseHydroForce), S "are defined as"]
 
 bsWtrFDerivEndSentence = [foldlSent [S "This", phrase equation `S.is`
   S "the non-zero case of" +:+. makeRef2S baseWtrFGD,
-  S "The zero case is when", S "height" `S.the_ofThe` phrase waterTable,
-  S "is below", S "height" `S.the_ofThe` phrase slpSrf `sC` S "so there is no",
+  S "The zero case is when", phraseNP (height `the_ofThe` waterTable),
+  S "is below", phraseNP (height `the_ofThe` slpSrf) `sC` S "so there is no",
   S "hydrostatic", phrase force]]
 
 bsWtrFDerivWeightEqn = sy pressure $= sy specWeight `mulRe` sy height
@@ -688,8 +683,8 @@ srfWtrFEqn = inxi surfHydroForce $= inxi surfLngth `mulRe` sy waterWeight `mulRe
 srfWtrFNotes :: Sentence
 srfWtrFNotes = foldlSent [S "This", phrase equation, S "is based on the",
   phrase assumption, S "that the surface of a", phrase slice,
-  S "is a straight line" +:+. sParen (makeRef2S assumpSBSBISL), ch surfLngth,
-  S "is defined in", makeRef2S lengthLs]
+  S "is a straight line" +:+. sParen (makeRef2S assumpSBSBISL), 
+  surfLngth `definedIn'''` lengthLs]
 
 srfWtrFDeriv :: Derivation
 srfWtrFDeriv = mkDerivNoHeader (weave [srfWtrFDerivSentences, srfWtrFDerivEqns] ++
@@ -708,41 +703,41 @@ srfWtrFDerivIntroSentence, srfWtrFDerivHeightSentence, srfWtrFDeriv2DSentence,
 
 srfWtrFDerivWeightEqn, srfWtrFDerivHeightEqn, srfWtrFDerivSliceEqn :: Expr
 
-srfWtrFDerivIntroSentence = [S "The", phrase surfHydroForce, S "come from the",
+srfWtrFDerivIntroSentence = [atStartNP (the surfHydroForce), S "come from the",
   S "hydrostatic", phrase pressure, S "exerted by the water above the surface",
   S "of each" +:+. phrase slice,
-  S "The", phrase equation, S "for hydrostatic", phrase pressure, S "from",
+  atStartNP (the equation), S "for hydrostatic", phrase pressure, S "from",
   makeRef2S hsPressureGD, S "is"]
 
-srfWtrFDerivHeightSentence = [S "The", phrase specWeight, S "in this case is",
+srfWtrFDerivHeightSentence = [atStartNP (the specWeight), S "in this case is",
   S "the" +:+. getTandS waterWeight,
-  S "The", phrase height, S "in this case is the height from the", phrase slice,
+  atStartNP (the height), S "in this case is the height from", phraseNP (the slice),
   S "surface to the" +:+. phrase waterTable,
   S "This", phrase height, S "is measured from", S "midpoint" `S.the_ofThe`
   phrase slice, S "because the resultant hydrostatic", phrase force,
-  S "is assumed to act at the", phrase slice, S "midpoint" +:+.
+  S "is assumed to act at", phraseNP (the slice), S "midpoint" +:+.
   sParen (makeRef2S assumpHFSM),
-  S "The", phrase height, S "at the midpoint is the average of the",
+  atStartNP (the height), S "at the midpoint is the average of the",
   phrase height, S "at", phrase slice, S "interface", ch index `S.andThe`
   phrase height, S "at", phrase slice, S "interface", E (sy index $- int 1)]
 
 srfWtrFDeriv2DSentence = [S "Due to", makeRef2S assumpPSC `sC`
-  S "only two dimensions are considered, so the", phrase surfHydroForce,
+  S "only two dimensions are considered, so", phraseNP (the surfHydroForce),
   S "are expressed as", plural force +:+. S "per meter", S "The",
-  plural pressure, S "acting on the", plural slice, S "can thus be converted",
+  plural pressure, S "acting on", pluralNP (the slice), S "can thus be converted",
   S "to", phrase surfHydroForce, S "by multiplying by the corresponding",
-  phrase len, S "of the", phrase slice, S "surface", E (inxi surfLngth) `sC`
-  S "assuming the", phrase waterTable, S "does not intersect a", phrase slice,
+  phrase len, S "of", phraseNP (the slice), S "surface", E (inxi surfLngth) `sC`
+  S "assuming", phraseNP (the waterTable), S "does not intersect a", phrase slice,
   S "surface except at a", phrase slice, S "edge" +:+.
   sParen (makeRef2S assumpWISE),
-  S "Thus, in the case where", S "height" `S.the_ofThe` phrase waterTable,
-  S "is above", S "height" `S.the_ofThe` phrase slopeSrf `sC` S "the",
-  phrase surfHydroForce, S "are defined as"]
+  S "Thus, in the case where", phraseNP (height `the_ofThe` waterTable),
+  S "is above", phraseNP (height `the_ofThe` slopeSrf) `sC`
+  phraseNP (the surfHydroForce), S "are defined as"]
 
 srfWtrFDerivEndSentence = [foldlSent [S "This" +:+ phrase equation `S.is`
   S "the non-zero case of" +:+. makeRef2S srfWtrFGD,
-  S "The zero case is when", S "height" `S.the_ofThe` phrase waterTable,
-  S "is below", S "height" `S.the_ofThe` phrase slopeSrf `sC` S "so there is no",
+  S "The zero case is when", phraseNP (height `the_ofThe` waterTable),
+  S "is below", phraseNP (height `the_ofThe` slopeSrf) `sC` S "so there is no",
   S "hydrostatic", phrase force]]
 
 srfWtrFDerivWeightEqn = sy pressure $= sy specWeight `mulRe` sy height

--- a/code/drasil-example/Drasil/SSP/Goals.hs
+++ b/code/drasil-example/Drasil/SSP/Goals.hs
@@ -2,6 +2,7 @@ module Drasil.SSP.Goals (goals, identifyCritAndFSGS, determineNormalFGS,
   determineShearFGS) where
 
 import Language.Drasil
+import Utils.Drasil.Concepts
 import qualified Utils.Drasil.Sentence as S
 
 import Data.Drasil.Concepts.Documentation (goalStmtDom)
@@ -34,5 +35,5 @@ identifyCritAndFS = S "Identify the" +:+ phrase crtSlpSrf `S.andThe`
   
 determineF :: (NamedIdea a) => a -> Sentence
 determineF what = S "Determine the" +:+ phrase what +:+
-  S "between each pair of vertical" +:+. (plural slice `S.ofThe`
-  phrase slope)
+  S "between each pair of vertical" +:+. pluralNP (slice `ofThePS`
+  slope)

--- a/code/drasil-example/Drasil/SSP/IMods.hs
+++ b/code/drasil-example/Drasil/SSP/IMods.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE PostfixOperators #-}
 module Drasil.SSP.IMods where
 
 import Prelude hiding (tan, product, sin, cos)
@@ -5,6 +6,7 @@ import Prelude hiding (tan, product, sin, cos)
 import Language.Drasil
 import Theory.Drasil (InstanceModel, im, imNoDeriv, qwUC, ModelKinds (OthModel))
 import Utils.Drasil
+import Utils.Drasil.Concepts
 import qualified Utils.Drasil.Sentence as S
 import Drasil.DocLang.SRS (propCorSol)
 
@@ -66,9 +68,9 @@ fctSftyRel = sy fs $= sumOp shearRNoIntsl $/ sumOp shearFNoIntsl
           (idx (sy sym) (sy index) `mulRe` prodOp) `addRe` idx (sy sym) (sy numbSlices)
 
 fctSftyDesc :: Sentence
-fctSftyDesc = foldlSent_ [ch shearRNoIntsl, S "is defined in", makeRef2S
-  resShearWOGD `sC` ch mobShrC, S "is defined in", makeRef2S convertFunc2 `sC`
-  S "and", ch shearFNoIntsl, S "is defined in", makeRef2S mobShearWOGD]
+fctSftyDesc = foldlList Comma List [shearRNoIntsl `definedIn'''` resShearWOGD,
+  mobShrC `definedIn'''` convertFunc2,
+  shearFNoIntsl `definedIn'''` mobShearWOGD]
 
 fctSftyDeriv :: Derivation
 fctSftyDeriv = mkDerivNoHeader (weave [fctSftyDerivSentences1, map E fctSftyDerivEqns1] ++
@@ -100,42 +102,41 @@ fctSftyDerivEqns2 = [fctSftyDerivEqn11, fctSftyDerivEqn12, fctSftyDerivEqn13,
   fctSftyDerivEqn18, fctSftyRel]
 
 fctSftyDerivSentence1 :: [Sentence]
-fctSftyDerivSentence1 = [S "The" +:+ phrase mobShrI +:+ S "defined in",
-  makeRef2S bsShrFEqGD, S "can be substituted into the definition of" +:+
-  phrase mobShrI +:+ S "based on the" +:+ phrase fs `sC` S "from",
+fctSftyDerivSentence1 = [atStartNP (the mobShrI), definedIn'' bsShrFEqGD, 
+  S "can be substituted into the definition of",
+  phrase mobShrI, S "based on the", phrase fs `sC` S "from",
   makeRef2S mobShrGD, S "yielding", eqN 1, S "below"]
 
 fctSftyDerivSentence2 :: [Sentence]
-fctSftyDerivSentence2 = [S "An expression for the" +:+ phrase nrmFSubWat `sC`
-  ch nrmFSubWat `sC` S "can be derived by substituting the" +:+
-  phrase totNrmForce +:+ S "equilibrium from", makeRef2S normForcEqGD,
-  S "into the definition for" +:+ phrase nrmFSubWat +:+ S "from" +:+.
-  makeRef2S resShearWOGD, S "This results in", eqN 2]
+fctSftyDerivSentence2 = [S "An expression for the", phrase nrmFSubWat `sC`
+  ch nrmFSubWat `sC` S "can be derived by substituting the",
+  phrase totNrmForce, S "equilibrium from", makeRef2S normForcEqGD,
+  S "into the definition for", phrase nrmFSubWat, S "from" +:+. makeRef2S resShearWOGD, S "This results in", eqN 2]
 
 fctSftyDerivSentence3 :: [Sentence]
 fctSftyDerivSentence3 = [S "Substituting", eqN 2, S "into", eqN 1, S "gives"]
 
 fctSftyDerivSentence4 :: [Sentence]
-fctSftyDerivSentence4 = [S "Since the" +:+ phrase intShrForce +:+
-  ch intShrForce +:+ S "and" +:+ phrase intNormForce +:+ ch intNormForce +:+
+fctSftyDerivSentence4 = [S "Since the", phrase intShrForce,
+  ch intShrForce `S.and_` phrase intNormForce, ch intNormForce,
   S "are unknown, they are separated from the other terms as follows"]
 
 fctSftyDerivSentence5 :: [Sentence]
-fctSftyDerivSentence5 = [S "Applying assumptions" +:+ makeRef2S assumpSF `S.and_`
-  makeRef2S assumpSL `sC` S "which state that the" +:+
-  phrase earthqkLoadFctr `S.andThe` phrase surfLoad `sC`
+fctSftyDerivSentence5 = [S "Applying assumptions", makeRef2S assumpSF `S.and_`
+  makeRef2S assumpSL `sC` S "which state that the",
+  phraseNP (earthqkLoadFctr `andThe` surfLoad) `sC`
   S "respectively, are zero, allows for further simplification as shown below"]
 
 fctSftyDerivSentence6 :: [Sentence]
-fctSftyDerivSentence6 = [S "The definitions of" +:+ makeRef2S resShearWOGD
-  `S.and_` makeRef2S mobShearWOGD +:+ S "are present in this equation, and" +:+
-  S "thus can be replaced by" +:+ E (inxi shearRNoIntsl) `S.and_`
+fctSftyDerivSentence6 = [S "The definitions of", makeRef2S resShearWOGD
+  `S.and_` makeRef2S mobShearWOGD, S "are present in this equation, and",
+  S "thus can be replaced by", E (inxi shearRNoIntsl) `S.and_`
   E (inxi shearFNoIntsl) `sC` S "respectively"]
 
 fctSftyDerivSentence7 :: [Sentence]
-fctSftyDerivSentence7 = [S "The" +:+ phrase intShrForce +:+ ch intShrForce +:+
-  S "can be expressed in terms of the" +:+ phrase intNormForce +:+
-  ch intNormForce +:+ S "using" +:+ makeRef2S assumpINSFL `S.and_`
+fctSftyDerivSentence7 = [atStartNP (the intShrForce), ch intShrForce,
+  S "can be expressed in terms of the", phrase intNormForce,
+  ch intNormForce, S "using", makeRef2S assumpINSFL `S.and_`
   makeRef2S normShrRGD `sC` S "resulting in"]
 
 fctSftyDerivSentence8 :: [Sentence]
@@ -163,14 +164,13 @@ fctSftyDerivSentence12 = [S "and", eqN 9, S "for the", ch numbSlices :+:
   S "th slice"]
 
 fctSftyDerivSentence13 :: [Sentence]
-fctSftyDerivSentence13 = [S "Substituting", eqN 8, S "into", eqN 4, S "yields",
-  eqN 10]
+fctSftyDerivSentence13 = [S "Substituting", eqN 8, S "into", eqN 4, S "yields", eqN 10]
 
 fctSftyDerivSentence14 :: [Sentence]
-fctSftyDerivSentence14 = [S "which can be substituted into", eqN 5, S "to get",   eqN 11]
+fctSftyDerivSentence14 = [S "which can be substituted into", eqN 5, S "to get", eqN 11]
 
 fctSftyDerivSentence15 :: [Sentence]
-fctSftyDerivSentence15 = [S "and so on until", eqN 12, S "is obtained from",   eqN 7]
+fctSftyDerivSentence15 = [S "and so on until", eqN 12, S "is obtained from", eqN 7]
 
 fctSftyDerivSentence16 :: [Sentence]
 fctSftyDerivSentence16 = [eqN 9, S "can then be substituted into the",
@@ -385,9 +385,9 @@ nrmShrFRel :: Relation
 nrmShrFRel = sy normToShear $= sum1toN (inxi nrmShearNum) $/ sum1toN (inxi nrmShearDen)
 
 nrmShrFDesc :: Sentence
-nrmShrFDesc = foldlSent [ch nrmShearNum, S "is defined in",
-  makeRef2S nrmShrForNum `S.and_` ch nrmShearDen, S "is defined in",
-  makeRef2S nrmShrForDen]
+nrmShrFDesc = nrmShearNum `definedIn'''`
+  nrmShrForNum `S.and_` (nrmShearDen `definedIn'''`
+  nrmShrForDen !.)
 
 nrmShrDeriv :: Derivation
 nrmShrDeriv = mkDerivNoHeader (weave [nrmShrDerivationSentences, map E nrmShrDerivEqns] ++
@@ -420,7 +420,7 @@ nrmShrDerivSentence4 = [S "Taking the summation of all", plural slice `sC`
   makeRef2S nrmShrForDen]
 
 nrmShrDerivSentence5 :: [Sentence]
-nrmShrDerivSentence5 = [eqN 16 +:+ S "for" +:+ ch normToShear +:+
+nrmShrDerivSentence5 = [eqN 16 `S.for` ch normToShear +:+
   S "is a function of the unknown" +:+ getTandS intNormForce +:+
   sParen (makeRef2S intsliceFs) +:+ S "which itself depends on the unknown" +:+
   getTandS fs +:+. sParen (makeRef2S fctSfty)]
@@ -485,13 +485,12 @@ nrmShrFNumDeriv = mkDerivNoHeader [foldlSent [S "See", makeRef2S nrmShrFor,
   S "for the derivation" `S.of_` ch nrmShearNum]]
 
 nrmShrFNumDesc :: Sentence
-nrmShrFNumDesc = foldlSent [ch baseWthX, S "is defined in",
-  makeRef2S lengthB `sC` ch watrForce, S "is defined in",
-  makeRef2S intersliceWtrF `sC` ch baseAngle, S "is defined in",
-  makeRef2S angleA `sC` ch midpntHght, S "is defined in",
-  makeRef2S slcHeight `sC` ch surfHydroForce, S "is defined in",
-  makeRef2S srfWtrFGD `sC` S "and", ch surfAngle, S "is defined in",
-  makeRef2S angleB]
+nrmShrFNumDesc = (foldlList Comma List [baseWthX `definedIn'''` lengthB,
+  watrForce `definedIn'''` intersliceWtrF,
+  baseAngle `definedIn'''` angleA,
+  midpntHght `definedIn'''` slcHeight,
+  surfHydroForce `definedIn'''` srfWtrFGD,
+  surfAngle `definedIn'''` angleB] !.)
 
 ---------------------------------------------------------------------------
 
@@ -519,9 +518,9 @@ nrmShrFDenDeriv = mkDerivNoHeader [foldlSent [S "See", makeRef2S nrmShrFor,
   S "for the derivation" `S.of_` ch nrmShearDen]]
 
 nrmShrFDenDesc :: Sentence
-nrmShrFDenDesc = foldlSent [ch baseWthX, S "is defined in",
-  makeRef2S lengthB `S.and_` ch scalFunc, S "is defined in",
-  makeRef2S ratioVariation]
+nrmShrFDenDesc = baseWthX `definedIn'''`
+  lengthB `S.and_` (scalFunc `definedIn'''`
+  ratioVariation !.)
 
 --------------------------------------------------------------------------
 
@@ -546,11 +545,10 @@ sliceFsRel = inxi intNormForce $= incompleteCase [
   -- FIXME: Use index i as part of condition
 
 sliceFsDesc :: Sentence
-sliceFsDesc = foldlSent [ch shearFNoIntsl, S "is defined in",
-  makeRef2S mobShearWOGD `sC` ch shearRNoIntsl, S "is defined in",
-  makeRef2S resShearWOGD `sC` ch shrResC, S "is defined in",
-  makeRef2S convertFunc1 `sC` S "and", ch mobShrC, S "is defined in",
-  makeRef2S convertFunc2]
+sliceFsDesc = (foldlList Comma List [shearFNoIntsl `definedIn'''` mobShearWOGD,
+  shearRNoIntsl `definedIn'''` resShearWOGD,
+  shrResC `definedIn'''` convertFunc1,
+  mobShrC `definedIn'''` convertFunc2] !.)
 
 intrSlcDeriv :: Derivation
 intrSlcDeriv = mkDerivNoHeader (weave [intrSlcDerivationSentences, map E intrSlcDerivEqns] ++ intrSlcDerivSentence3)
@@ -605,13 +603,13 @@ crtSlpIdRel = sy fsMin $= apply minFunction [sy slopeDist,
 
 -- FIXME: The constraints described here should be replaced with formal constraints on the input variables once that is possible
 crtSlpIdDesc :: Sentence
-crtSlpIdDesc = foldlSent [S "The", phrase minFunction, S "must enforce the",
-  plural constraint, S "on the", phrase crtSlpSrf, S "expressed in" +:+.
+crtSlpIdDesc = foldlSent [atStartNP (the minFunction), S "must enforce the",
+  pluralNP (constraint `onThePS` crtSlpSrf), S "expressed in" +:+.
   (makeRef2S assumpSSC `S.and_` makeRef2S (propCorSol [] [])),
   S "The sizes of", ch waterDist `S.and_` ch waterHght +:+.
   S "must be equal and not 1", S "The", S "sizes of", ch slopeDist `S.and_`
   ch slopeHght +:+. (S "must be equal" `S.and_` S "at least 2"),
-  S "The", phrase first `S.and_` S "last", ch waterDist,
+  atStartNP (the first) `S.and_` S "last", ch waterDist,
   plural value, S "must be equal to the", phrase first `S.and_` S "last",
   ch slopeDist +:+. plural value, ch waterDist `S.and_` ch slopeDist,
   plural value +:+. S "must be monotonically increasing", ch xMaxExtSlip `sC`
@@ -624,7 +622,7 @@ crtSlpIdDesc = foldlSent [S "The", phrase minFunction, S "must enforce the",
   plural value `S.of_` ch critCoords, S "must not be below" +:+. ch yMinSlip,
   S "For any given vertex in", ch critCoords, S "the", ch yi, phrase value,
   S "must not exceed the", ch slopeHght, phrase value, S "corresponding to the",
-  S "same", ch xi +:+. phrase value, S "The", phrase first `S.and_` S "last",
+  S "same", ch xi +:+. phrase value, atStartNP (the first) `S.and_` S "last",
   S "vertices in", ch critCoords, S "must each be equal to one of the vertices",
   S "formed by" +:+. (ch slopeDist `S.and_` ch slopeHght), S "The slope between",
   S "consecutive vertices must be always increasing as", ch xi +:+.
@@ -640,25 +638,25 @@ instModIntro = [instModIntro1, instModIntro2]
 
 instModIntro1, instModIntro2 :: Sentence
 
-instModIntro1 = foldlSent [S "The", plural goal, foldlList Comma List
+instModIntro1 = foldlSent [atStartNP' (the goal), foldlList Comma List
   (map makeRef2S goals) `S.are` S "met by the simultaneous" +:+. (phrase solution `S.of_`
-  foldlList Comma List (map makeRef2S [fctSfty, nrmShrFor, intsliceFs])), S "The",
-  phrase goal, makeRef2S identifyCritAndFSGS `S.is` S "also contributed to by",
+  foldlList Comma List (map makeRef2S [fctSfty, nrmShrFor, intsliceFs])), atStartNP (the goal),
+  makeRef2S identifyCritAndFSGS `S.is` S "also contributed to by",
   makeRef2S crtSlpId]
 
-instModIntro2 = foldlSent [S "The", titleize morPrice,
+instModIntro2 = foldlSent [titleizeNP (the morPrice),
   phrase method_, S "is a vertical", phrase slice `sC` S "limit equilibrium",
   phrase ssa +:+. phrase method_, atStart analysis, S "is performed by",
   S "breaking the assumed", phrase slpSrf,
   S "into a series of vertical", plural slice, S "of" +:+. phrase mass,
   S "Static equilibrium analysis is performed, using two", phrase force,
   plural equation `S.and_` S "one moment", phrase equation, S "as in" +:+. makeRef2S equilibrium,
-  S "The", phrase problem, S "is statically indeterminate with only these 3",
+  atStartNP (the problem), S "is statically indeterminate with only these 3",
   plural equation, S "and one constitutive", phrase equation,
   sParen $ S "the Mohr Coulomb shear strength of" +:+
   makeRef2S mcShrStrgth, S "so the", phrase assumption,
   makeRef2S normShrRGD `S.and_` S "corresponding equation",
   makeRef2S normShrRGD +:+. S "are used",
-  S "The", phrase force, S "equilibrium", plural equation, S "can be modified",
+  atStartNP (the force), S "equilibrium", plural equation, S "can be modified",
   S "to be expressed only in terms of known", phrase physical, plural value `sC`
   S "as done in", makeRef2S resShearWOGD `S.and_` makeRef2S mobShearWOGD]

--- a/code/drasil-example/Drasil/SSP/Requirements.hs
+++ b/code/drasil-example/Drasil/SSP/Requirements.hs
@@ -2,6 +2,7 @@ module Drasil.SSP.Requirements (funcReqs, funcReqTables, nonFuncReqs) where
 
 import Language.Drasil
 import Utils.Drasil
+import Utils.Drasil.Concepts
 import qualified Utils.Drasil.Sentence as S
 
 import Drasil.DocLang (mkInputPropsTable)
@@ -59,7 +60,7 @@ verifyOutput = cic "verifyOutput" ( foldlSent [
   "Verify-Output" funcReqDom
 
 displayInput = cic "displayInput" ( foldlSent [
-  S "Display as", phrase output_, S "the", phrase user :+: S "-supplied",
+  S "Display as", phrase output_, phraseNP (the user) :+: S "-supplied",
   plural input_, S "listed in", makeRef2S inputsToOutputTable])
   "Display-Input" funcReqDom
 
@@ -110,22 +111,22 @@ nonFuncReqs = [correct, understandable, reusable, maintainable]
 
 correct :: ConceptInstance
 correct = cic "correct" (foldlSent [
-  plural output_ `S.the_ofTheC` phrase code, S "have the",
+  atStartNP' (output_ `the_ofThePS` code), S "have the",
   plural property, S "described in", makeRef2S (propCorSol [] [])
   ]) "Correct" nonFuncReqDom
 
 understandable :: ConceptInstance
 understandable = cic "understandable" (foldlSent [
-  S "The", phrase code, S "is modularized with complete",
+  atStartNP (the code), S "is modularized with complete",
   phrase mg `S.and_` phrase mis]) "Understandable" nonFuncReqDom
 
 reusable :: ConceptInstance
 reusable = cic "reusable" (foldlSent [
-  S "The", phrase code, S "is modularized"]) "Reusable" nonFuncReqDom
+  atStartNP (the code), S "is modularized"]) "Reusable" nonFuncReqDom
 
 maintainable :: ConceptInstance
 maintainable = cic "maintainable" (foldlSent [
   S "The traceability between", foldlList Comma List [plural requirement,
   plural assumption, plural thModel, plural genDefn, plural dataDefn, plural inModel,
   plural likelyChg, plural unlikelyChg, plural module_], S "is completely recorded in",
-  plural traceyMatrix, S "in the", getAcc srs `S.and_` phrase mg]) "Maintainable" nonFuncReqDom
+  plural traceyMatrix `S.inThe` getAcc srs `S.and_` phrase mg]) "Maintainable" nonFuncReqDom

--- a/code/drasil-example/Drasil/SSP/TMods.hs
+++ b/code/drasil-example/Drasil/SSP/TMods.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE PostfixOperators #-}
 module Drasil.SSP.TMods (tMods, factOfSafety, equilibrium, mcShrStrgth, effStress) 
   where
 
@@ -5,6 +6,7 @@ import Prelude hiding (tan)
 import Language.Drasil
 import Theory.Drasil (TheoryModel, tm, ModelKinds(EquationalModel, OthModel))
 import Utils.Drasil
+import Utils.Drasil.Concepts
 import qualified Utils.Drasil.Sentence as S
 
 import Data.Drasil.Quantities.Physics (distance, force)
@@ -57,7 +59,7 @@ eqRel = foldr (($=) . sumAll (Variable "i") . sy) (int 0) [fx, fy, genericM]
 
 eqDesc :: Sentence
 eqDesc = foldlSent [S "For a body in static equilibrium, the net",
-  plural force, S "and", plural genericM +:+. S "acting on the body will cancel out",
+  pluralNP (force `and_PP` genericM) +:+. S "acting on the body will cancel out",
   S "Assuming a 2D problem", sParen (makeRef2S assumpENSL) `sC` S "the", getTandS fx `S.and_`
   getTandS fy, S "will be equal to" +:+. E (exactDbl 0), S "All", plural force,
   S "and their", phrase distance, S "from the chosen point of rotation",
@@ -110,4 +112,4 @@ effStressRel :: Relation
 effStressRel = sy effectiveStress $= sy totNormStress $- sy porePressure
 
 effStressDesc :: Sentence
-effStressDesc = foldlSent [ch totNormStress, S "is defined in", makeRef2S normStressDD]
+effStressDesc = (totNormStress `definedIn'''` normStressDD !.)

--- a/code/drasil-example/Drasil/SSP/Unitals.hs
+++ b/code/drasil-example/Drasil/SSP/Unitals.hs
@@ -2,6 +2,8 @@ module Drasil.SSP.Unitals where --export all of it
 
 import Language.Drasil
 import Language.Drasil.ShortHands
+import Utils.Drasil.Concepts
+import qualified Utils.Drasil.NounPhrase as NP
 import qualified Utils.Drasil.Sentence as S
 
 import Drasil.SSP.Defs (fsConcept)
@@ -233,18 +235,18 @@ slipDist = makeUCWDS "x_slip,i" (nounPhraseSent $ plural xCoord +:+ S "of the sl
   (sub (vec lX) lSlip) metre
 
 xi     = makeUCWDS "x_i" (nounPhraseSent $ phrase xCoord)
-  (S "the" +:+ phrase xCoord `S.inThe` phrase cartesian) lX metre
+  (phraseNP (NP.the (xCoord `inThe` cartesian))) lX metre
 
 yi     = makeUCWDS "y_i" (nounPhraseSent $ phrase yCoord)
-  (S "the" +:+ phrase yCoord `S.inThe` phrase cartesian) lY metre
+  (phraseNP (NP.the (yCoord `inThe` cartesian))) lY metre
 
 zcoord = makeUCWDS "z"   (nounPhraseSent $ phrase zCoord)
-  (S "the" +:+ phrase zCoord `S.inThe` phrase cartesian) lZ metre
+  (phraseNP (NP.the (zCoord `inThe` cartesian))) lZ metre
 
 -- FIXME: the 'symbol' for this should not have { and } embedded in it.
 -- They have been removed now, but we need a reasonable notation.
 critCoords = makeUCWDS "(xcs,ycs)" (cn "critical slip surface coordinates")
-  (S "the set" `S.of_` plural xCoord `S.and_` plural yCoord +:+
+  (S "the set" `S.of_` pluralNP (xCoord `and_PP` yCoord) +:+
    S "that describe the vertices of the critical slip surface")
   (Concat [sub (vec lX) lCSlip, Label ",", sub (vec lY) lCSlip]) metre
 
@@ -257,7 +259,7 @@ resistiveShear = makeUCWDS "resistiveShear" (cn' "resistive shear force")
   cP newton
 
 mobShrI = makeUCWDS "mobShr" (cn "mobilized shear forces")
-  (S "the" +:+ plural mobilizedShear +:+ S "per meter" `S.inThe` phrase zDir +:+
+  (pluralNP (the mobilizedShear) +:+ S "per meter" `S.inThe` phrase zDir +:+
    S "for each slice")
   (vec cS) forcePerMeterU --FIXME: DUE TO ID THIS WILL SHARE THE SAME SYMBOL AS CSM.mobShear
               -- This is fine for now, as they are the same concept, but when this
@@ -274,12 +276,12 @@ shrResI = makeUCWDS "shrRes" (cn "resistive shear forces")
               -- Expr.
 
 shearFNoIntsl = makeUCWDS "T_i" (cn ("mobilized shear forces " ++ wiif)) 
-  (S "the" +:+ plural mobilizedShear +:+ S "per meter" +:+ S wiif `S.inThe`
+  (pluralNP (the mobilizedShear) +:+ S "per meter" +:+ S wiif `S.inThe`
    phrase zDir +:+  S "for each slice")
   (vec cT) forcePerMeterU
 
 shearRNoIntsl = makeUCWDS "R_i" (cn ("resistive shear forces " ++ wiif))
-  (S "the" +:+ plural resistiveShear +:+ S "per meter" +:+ S wiif `S.inThe`
+  (pluralNP (the resistiveShear) +:+ S "per meter" +:+ S wiif `S.inThe`
    phrase zDir +:+ S "for each slice")
   (vec cR) forcePerMeterU
 
@@ -357,7 +359,7 @@ shrStress = uc' "tau_i" (cn "shear strength")
   "the strength of a material against shear failure" (sup lTau (Label"f")) pascal
 
 sliceHght = makeUCWDS "h_z,i" (cn "heights of interslice normal forces")
-  ((plural height `S.inThe` phrase yDir) `S.the_ofThe` S "interslice normal forces on each slice")
+  (pluralNP (height `inThePS` yDir) `S.the_ofThe` S "interslice normal forces on each slice")
   (subZ (vec lH)) metre
 
 sliceHghtW = makeUCWDS "h_z,w,i" (cn "heights of the water table")
@@ -456,7 +458,7 @@ normToShear = dqd' (dcc "lambda" (nounPhraseSP "proportionality constant")
 
 scalFunc = dqd' (dccWDS "f_i" 
   (nounPhraseSP "interslice normal to shear force ratio variation function")
-  (S "a function" `S.of_` phrase distance `S.inThe` phrase xDir +:+
+  (S "a function" `S.of_` phraseNP (distance `inThe` xDir) +:+
    S "that describes the variation of the interslice normal to shear ratio"))
   (const (vec lF)) Real Nothing 
 

--- a/code/drasil-utils/Utils/Drasil.hs
+++ b/code/drasil-utils/Utils/Drasil.hs
@@ -11,7 +11,7 @@ module Utils.Drasil (
   foldlSent_,foldlSentCol, foldlsC, foldNums, numList,
   -- Misc
   addPercent, bulletFlat, bulletNested, checkValidStr, chgsStart, definedIn,
-  definedIn', definedIn'',  displayStrConstrntsAsSet, displayDblConstrntsAsSet, eqN,
+  definedIn', definedIn'', definedIn''', displayStrConstrntsAsSet, displayDblConstrntsAsSet, eqN,
   eqnWSource, fromReplace, fromSource, fromSources, fmtU, follows, getTandS,
   itemRefToSent, makeListRef, makeTMatrix, maybeChanged, maybeExpanded,
   maybeWOVerb, mkEnumAbbrevList, mkTableFromColumns, noRefs, refineChain,

--- a/code/drasil-utils/Utils/Drasil/Concepts.hs
+++ b/code/drasil-utils/Utils/Drasil/Concepts.hs
@@ -1,12 +1,12 @@
 module Utils.Drasil.Concepts (and_, and_TSP, and_PS, and_PP, and_TGen, and_Gen, andIts, andThe, with, of_, of_NINP, of_PSNPNI, of_TSP, of_PS, of_TPS, ofA,
-ofATPS, ofThe, ofThePS, the_ofThe, the_ofThePS, onThe, onThePS, inThe, inThePS, toThe, for, forTGen, in_, in_PS, inA, is, the, theT, theGen, a_, a_Gen,
+ofATPS, ofThe, ofThePS, the_ofThe, the_ofThePS, onThe, onThePS, inThe, inThePS, isThe, toThe, for, forTGen, in_, in_PS, inA, is, the, theT, theGen, a_, a_Gen,
 compoundNC, compoundNCPP, compoundNCGen, compoundNCPS, compoundNCPSPP, compoundNCGenP, combineNINP, combineNPNI, combineNINI) where
 
 import Language.Drasil
 import qualified Language.Drasil.Development as D
 import Control.Lens ((^.))
 
-import qualified Utils.Drasil.Sentence as S (and_, andIts, andThe, of_, ofA, ofThe, the_ofThe, onThe, for, inThe, in_, is, toThe) 
+import qualified Utils.Drasil.Sentence as S (and_, andIts, andThe, of_, ofA, ofThe, the_ofThe, onThe, for, inThe, in_, is, toThe, isThe) 
 
 -----------
 --FIXME: Find out why CapFirst and CapWords can't just be used instead of Replace constructor.
@@ -221,6 +221,15 @@ inThePS :: (NamedIdea c, NamedIdea d) => c -> d -> NP
 inThePS t1 t2 = nounPhrase'' 
   (phrase t1 `S.inThe` phrase t2) 
   (plural t1 `S.inThe` phrase t2)
+  CapFirst
+  CapWords
+
+-- | Creates a 'NP' by combining two 'NamedIdea's with the words "is the" between
+-- their terms. Plural case is @(phrase t1) "is the" (plural t2)@.
+isThe :: (NamedIdea c, NamedIdea d) => c -> d -> NP
+isThe t1 t2 = nounPhrase'' 
+  (phrase t1 `S.isThe` phrase t2) 
+  (phrase t1 `S.isThe` plural t2)
   CapFirst
   CapWords
 

--- a/code/drasil-utils/Utils/Drasil/Misc.hs
+++ b/code/drasil-utils/Utils/Drasil/Misc.hs
@@ -1,6 +1,6 @@
 {-# Language TypeFamilies #-}
 module Utils.Drasil.Misc (addPercent, bulletFlat, bulletNested, checkValidStr,
-  chgsStart, definedIn, definedIn', definedIn'',  displayStrConstrntsAsSet, displayDblConstrntsAsSet,
+  chgsStart, definedIn, definedIn', definedIn'', definedIn''', displayStrConstrntsAsSet, displayDblConstrntsAsSet,
   eqN, eqnWSource, fromReplace, fromSource, fromSources, fmtU, follows, getTandS,
   itemRefToSent, makeListRef, makeTMatrix, maybeChanged, maybeExpanded,
   maybeWOVerb, mkEnumAbbrevList, mkTableFromColumns, noRefs, refineChain,
@@ -59,6 +59,10 @@ definedIn' q info = ch q `S.is` S "defined" `S.in_` makeRef2S q +:+. info
 -- | Takes a 'Referable' and outputs as a 'Sentence' "defined in @reference@" (no 'HasSymbol').
 definedIn'' :: (Referable r, HasShortName r) => r -> Sentence
 definedIn'' q =  S "defined" `S.in_` makeRef2S q
+
+-- | Takes a 'Symbol' and its 'Reference' (does not append a period at the end!). Outputs as "@symbol@ is defined in @source@".
+definedIn''' :: (HasSymbol q, HasUID q, Referable r, HasShortName r) => q -> r -> Sentence
+definedIn''' q src = ch q `S.is` S "defined in" +:+ makeRef2S src
 
 -- | Zip helper function enumerates abbreviations and zips it with list of 'ItemType':
 --

--- a/code/stable/ssp/SRS/SSP_SRS.tex
+++ b/code/stable/ssp/SRS/SSP_SRS.tex
@@ -814,7 +814,7 @@ RefBy & \hyperref[IM:fctSfty]{IM: fctSfty}
 \end{minipage}
 \paragraph{}
 \label{GD:mobShrDeriv}
-Mobilized shear forces is derived by dividing the definition of the $\mathbf{P}$ from \hyperref[GD:resShr]{GD: resShr}. by the definition of the factor of safety from \hyperref[TM:factOfSafety]{TM: factOfSafety}. The factor of safety ${F_{\text{S}}}$ is not indexed by $i$ because it is assumed to be constant for the entire slip surface (\hyperref[assumpFOS]{A: Factor-of-Safety}).
+Mobilized shear forces is derived by dividing the definition of the $\mathbf{P}$ from \hyperref[GD:resShr]{GD: resShr} by the definition of the factor of safety from \hyperref[TM:factOfSafety]{TM: factOfSafety}. The factor of safety ${F_{\text{S}}}$ is not indexed by $i$ because it is assumed to be constant for the entire slip surface (\hyperref[assumpFOS]{A: Factor-of-Safety}).
 
 \vspace{\baselineskip}
 \noindent

--- a/code/stable/ssp/Website/SSP_SRS.html
+++ b/code/stable/ssp/Website/SSP_SRS.html
@@ -1716,7 +1716,7 @@
                   <div class="subsubsubsection">
                     <h4></h4>
                     <p class="paragraph">
-                      Mobilized shear forces is derived by dividing the definition of the <em><b>P</b></em> from <a href=#GD:resShr>GD: resShr</a>. by the definition of the factor of safety from <a href=#TM:factOfSafety>TM: factOfSafety</a>. The factor of safety <em>F<sub>S</sub></em> is not indexed by <em>i</em> because it is assumed to be constant for the entire slip surface (<a href=#assumpFOS>A: Factor-of-Safety</a>).
+                      Mobilized shear forces is derived by dividing the definition of the <em><b>P</b></em> from <a href=#GD:resShr>GD: resShr</a> by the definition of the factor of safety from <a href=#TM:factOfSafety>TM: factOfSafety</a>. The factor of safety <em>F<sub>S</sub></em> is not indexed by <em>i</em> because it is assumed to be constant for the entire slip surface (<a href=#assumpFOS>A: Factor-of-Safety</a>).
                     </p>
                   </div>
                 </div>


### PR DESCRIPTION
Also added a `definedIn'''` reference combinator as the same form was used quite a bit. Changed a misplaced period in stable as well. This should be the last of the examples that need to use the new combinators.
Contributes #2499