### PR TITLE
Enable hyperlinking source in Haddock

### DIFF
--- a/code/stack.yaml
+++ b/code/stack.yaml
@@ -61,7 +61,6 @@ extra-deps:
 # Used only for a basic set of flags for haddock
 build:
   haddock-deps: false
-  haddock-hyperlink-source: false
 
 # Override default flag values for local packages and extra-deps
 flags: {}


### PR DESCRIPTION
Closes #2530 

Removes the flag that disabled Haddock "hyperlinked source code" creation.

Demo: https://balacij.github.io/Drasil/docs/full/drasil-build-0.1.1.0/Build-Drasil.html

It just creates a lot of extra LOC that drasil-bot will be committing. It will likely also increase the size of our project. If space becomes a concern, we can erase the `gh-pages` branch from here and host it in another repository. Alternatively, we can host the docs with something else.