### PR TITLE
deleting outdated constructor: `ciGetDocDesc`

### DIFF
--- a/code/drasil-docLang/Drasil/DocLang.hs
+++ b/code/drasil-docLang/Drasil/DocLang.hs
@@ -33,7 +33,7 @@ module Drasil.DocLang (
   -- Sections.TraceabilityMandGs
   traceMatStandard,
   -- ExtractDocDesc
-  getDocDesc, egetDocDesc, ciGetDocDesc,
+  getDocDesc, egetDocDesc,
   -- Tracetable
   generateTraceMap,
  -- Labels
@@ -66,7 +66,7 @@ import Drasil.Sections.SpecificSystemDescription (auxSpecSent, termDefnF')
 --import Drasil.Sections.TableOfSymbols
 --import Drasil.Sections.TableOfUnits
 import Drasil.Sections.TraceabilityMandGs (traceMatStandard)
-import Drasil.ExtractDocDesc (getDocDesc, egetDocDesc, ciGetDocDesc)
+import Drasil.ExtractDocDesc (getDocDesc, egetDocDesc)
 import Drasil.TraceTable (generateTraceMap)
 -- Commented out modules aren't used - uncomment if this changes
 import Drasil.DocumentLanguage.Labels (solutionLabel, characteristicsLabel)

--- a/code/drasil-docLang/Drasil/ExtractDocDesc.hs
+++ b/code/drasil-docLang/Drasil/ExtractDocDesc.hs
@@ -1,5 +1,5 @@
 {-# LANGUAGE LambdaCase, Rank2Types #-}
-module Drasil.ExtractDocDesc (getDocDesc, egetDocDesc, ciGetDocDesc, sentencePlate) where
+module Drasil.ExtractDocDesc (getDocDesc, egetDocDesc, sentencePlate) where
 
 import Control.Lens((^.))
 import Drasil.DocumentLanguage.Core
@@ -209,16 +209,15 @@ getIL :: ItemType -> [Sentence]
 getIL (Flat s) = [s]
 getIL (Nested h lt) = h : getLT lt
 
-ciPlate :: DLPlate (Constant [CI])
-ciPlate = preorderFold $ purePlate {
-  introSub = Constant <$> \case
-    (IOrgSec _ ci _ _) -> [ci]
-    _ -> [],
-  stkSub = Constant <$> \case
-   (Client ci _) -> [ci]
-   (Cstmr ci) -> [ci],
-   auxConsSec = Constant <$> \(AuxConsProg ci _) -> [ci]
-}
+-- ciPlate is not currently used.
+-- ciPlate :: DLPlate (Constant [CI])
+-- ciPlate = preorderFold $ purePlate {
+  -- introSub = Constant <$> \case
+    -- (IOrgSec _ ci _ _) -> [ci]
+    -- _ -> [],
+  -- stkSub = Constant <$> \case
+   -- (Client ci _) -> [ci]
+   -- (Cstmr ci) -> [ci],
+   -- auxConsSec = Constant <$> \(AuxConsProg ci _) -> [ci]
+-- }
 
-ciGetDocDesc :: DocDesc -> [CI]
-ciGetDocDesc = fmGetDocDesc ciPlate


### PR DESCRIPTION
closes Issue #2541 
contributes to Issue #1602