### PR TITLE
Create EquationalConstraints Model + convert SSP's TM `equilibrium` into EquationalConstraints model

### DIFF
--- a/code/drasil-example/Drasil/SSP/TMods.hs
+++ b/code/drasil-example/Drasil/SSP/TMods.hs
@@ -4,9 +4,10 @@ module Drasil.SSP.TMods (tMods, factOfSafety, equilibrium, mcShrStrgth, effStres
 
 import Control.Lens ((^.))
 import Prelude hiding (tan)
+import qualified Data.List.NonEmpty as NE
 
 import Language.Drasil
-import Theory.Drasil (TheoryModel, tm, tm', ModelKinds(EquationalModel, OthModel))
+import Theory.Drasil
 import Utils.Drasil
 import Utils.Drasil.Concepts
 import qualified Utils.Drasil.Sentence as S
@@ -47,17 +48,18 @@ factOfSafetyExpr = sy resistiveShear $/ sy mobilizedShear
 --
 ------------- New Chunk -----------
 equilibrium :: TheoryModel
-equilibrium = tm (OthModel equilibriumRC)
+equilibrium = tm (EquationalConstraints equilibriumCS)
   [qw fx] ([] :: [ConceptChunk])
-  [] [eqRel] [] [makeCite fredlund1977] "equilibrium" [eqDesc]
+  [] [relat equilibriumCS] [] [makeCite fredlund1977] "equilibrium" [eqDesc]
 
 ------------------------------------  
-equilibriumRC :: RelationConcept
-equilibriumRC = makeRC "equilibriumRC" (nounPhraseSP "equilibrium") eqDesc eqRel
 
 -- FIXME: Variable "i" is a hack.  But we need to sum over something!
-eqRel :: Relation
-eqRel = foldr (($=) . sumAll (Variable "i") . sy) (int 0) [fx, fy, genericM]
+equilibriumCS :: ConstraintSet
+equilibriumCS = mkConstraintSet
+  (dccWDS "equilibriumCS" (nounPhraseSP "equilibrium") eqDesc) $
+  NE.fromList $ map (($= int 0) . sumAll (Variable "i") . sy) [fx, fy, genericM]
+-- makeRC "equilibriumRC" (nounPhraseSP "equilibrium") eqDesc eqRel
 
 eqDesc :: Sentence
 eqDesc = foldlSent [S "For a body in static equilibrium, the net",

--- a/code/drasil-theory/Theory/Drasil.hs
+++ b/code/drasil-theory/Theory/Drasil.hs
@@ -2,6 +2,8 @@
 module Theory.Drasil (
   -- Classes
     HasInputs(..), HasOutput(..)
+  -- ConstraintSet
+  , ConstraintSet, mkConstraintSet
   -- DataDefinition
   , DataDefinition, dd, ddNoRefs, qdFromDD
   -- GenDefn
@@ -24,6 +26,7 @@ module Theory.Drasil (
 ) where
 
 import Theory.Drasil.Classes (HasInputs(..), HasOutput(..))
+import Theory.Drasil.ConstraintSet
 import Theory.Drasil.DataDefinition (DataDefinition, dd, ddNoRefs, qdFromDD)
 import Theory.Drasil.GenDefn
 import Theory.Drasil.ModelKinds

--- a/code/drasil-theory/Theory/Drasil/ConstraintSet.hs
+++ b/code/drasil-theory/Theory/Drasil/ConstraintSet.hs
@@ -1,0 +1,31 @@
+{-# LANGUAGE TemplateHaskell, Rank2Types, ScopedTypeVariables, PostfixOperators  #-}
+
+module Theory.Drasil.ConstraintSet (ConstraintSet, mkConstraintSet) where
+
+import Control.Lens ((^.), makeLenses)
+
+import Language.Drasil
+import qualified Data.List.NonEmpty as NE
+
+data ConstraintSet = CL {
+    _con  :: ConceptChunk,
+    _invs   :: NE.NonEmpty Relation
+}
+makeLenses ''ConstraintSet
+
+-- | Finds the 'UID' of the 'ConstraintSet'.
+instance HasUID        ConstraintSet where uid   = con . uid
+-- | Finds the term ('NP') of the 'ConstraintSet'.
+instance NamedIdea     ConstraintSet where term  = con . term
+-- | Finds the idea of the 'ConstraintSet'.
+instance Idea          ConstraintSet where getA  = getA . (^. con)
+-- | Finds the definition of the 'ConstraintSet'.
+instance Definition    ConstraintSet where defn  = con . defn
+-- | Finds the domain of the 'ConstraintSet'.
+instance ConceptDomain ConstraintSet where cdom  = cdom .  (^. con)
+-- | Finds the relation expression of the 'ConstraintSet'.
+instance ExprRelat     ConstraintSet where relat = foldr1 ($&&) . (^. invs)
+
+-- | Smart constructor for building ConstraintSets
+mkConstraintSet :: ConceptChunk -> NE.NonEmpty Relation -> ConstraintSet
+mkConstraintSet = CL

--- a/code/drasil-theory/Theory/Drasil/ConstraintSet.hs
+++ b/code/drasil-theory/Theory/Drasil/ConstraintSet.hs
@@ -7,9 +7,10 @@ import Control.Lens ((^.), makeLenses)
 import Language.Drasil
 import qualified Data.List.NonEmpty as NE
 
+-- | 'ConstraintSet's are sets of invariants that always hold for underlying domains.
 data ConstraintSet = CL {
     _con  :: ConceptChunk,
-    _invs   :: NE.NonEmpty Relation
+    _invs :: NE.NonEmpty Relation
 }
 makeLenses ''ConstraintSet
 
@@ -22,8 +23,9 @@ instance Idea          ConstraintSet where getA  = getA . (^. con)
 -- | Finds the definition of the 'ConstraintSet'.
 instance Definition    ConstraintSet where defn  = con . defn
 -- | Finds the domain of the 'ConstraintSet'.
-instance ConceptDomain ConstraintSet where cdom  = cdom .  (^. con)
--- | Finds the relation expression of the 'ConstraintSet'.
+instance ConceptDomain ConstraintSet where cdom  = cdom . (^. con)
+-- | The complete Relation of a ConstraintSet is the logical conjunction of all
+--   the underlying relations (e.g., `a $&& b $&& ... $&& z`).
 instance ExprRelat     ConstraintSet where relat = foldr1 ($&&) . (^. invs)
 
 -- | Smart constructor for building ConstraintSets

--- a/code/drasil-theory/Theory/Drasil/GenDefn.hs
+++ b/code/drasil-theory/Theory/Drasil/GenDefn.hs
@@ -4,10 +4,9 @@ module Theory.Drasil.GenDefn (GenDefn,
 
 import Language.Drasil
 import Data.Drasil.TheoryConcepts (genDefn)
-import Theory.Drasil.ModelKinds (ModelKinds(..), elimMk, setMk, getEqModQds)
-import Theory.Drasil.MultiDefn (MultiDefn)
+import Theory.Drasil.ModelKinds (ModelKinds(..), getEqModQds)
 
-import Control.Lens (makeLenses, view, lens, (^.), set, Lens')
+import Control.Lens ((^.), view, makeLenses)
 
 -- | A general definition is a 'ModelKind' that may have units, a derivation,
 -- references, a shortname, a reference address, and notes.
@@ -22,22 +21,14 @@ data GenDefn = GD { _gUid  :: UID
                   }
 makeLenses ''GenDefn
 
--- | Make 'Lens' for a 'GenDefn' based on its 'ModelKinds'.
-lensMk :: forall a. Lens' QDefinition a -> Lens' MultiDefn a -> Lens' RelationConcept a -> Lens' GenDefn a
-lensMk lq lqd lr = lens g s
-    where g :: GenDefn -> a
-          g gd_ = elimMk lq lqd lr (gd_ ^. mk)
-          s :: GenDefn -> a -> GenDefn
-          s gd_ x = set mk (setMk (gd_ ^. mk) lq lqd lr x) gd_
-
 -- | Finds the 'UID' of a 'GenDefn'.
 instance HasUID             GenDefn where uid           = gUid
 -- | Finds the term ('NP') of the 'GenDefn'.
-instance NamedIdea          GenDefn where term          = lensMk term term term
+instance NamedIdea          GenDefn where term          = mk . term
 -- | Finds the idea contained in the 'GenDefn'.
 instance Idea               GenDefn where getA          = getA . (^. mk)
 -- | Finds the definition of the 'GenDefn'.
-instance Definition         GenDefn where defn          = lensMk defn defn defn
+instance Definition         GenDefn where defn          = mk . defn
 -- | Finds the domain of the 'GenDefn'.
 instance ConceptDomain      GenDefn where cdom          = cdom . (^. mk)
 -- | Finds the relation expression for a 'GenDefn'.

--- a/code/drasil-theory/Theory/Drasil/InstanceModel.hs
+++ b/code/drasil-theory/Theory/Drasil/InstanceModel.hs
@@ -11,9 +11,8 @@ import Language.Drasil
 import Theory.Drasil.Classes (HasInputs(inputs), HasOutput(..))
 import Data.Drasil.TheoryConcepts (inModel)
 
-import Control.Lens (set, (^.), lens, view, makeLenses, Lens', _1, _2) 
-import Theory.Drasil.ModelKinds (ModelKinds(..), elimMk, setMk, getEqModQds)
-import Theory.Drasil.MultiDefn (MultiDefn)
+import Control.Lens ((^.), view, makeLenses, _1, _2) 
+import Theory.Drasil.ModelKinds (ModelKinds(..), getEqModQds)
 
 type Input = (QuantityDict, Maybe (RealInterval Expr Expr))
 type Inputs = [Input]
@@ -34,22 +33,14 @@ data InstanceModel = IM { _mk       :: ModelKinds
                         }
 makeLenses ''InstanceModel
 
--- | Make 'Lens' for an 'InstanceModel' based on its 'ModelKinds'.
-lensMk :: forall a. Lens' QDefinition a -> Lens' MultiDefn a -> Lens' RelationConcept a -> Lens' InstanceModel a
-lensMk lq lqd lr = lens g s
-    where g :: InstanceModel -> a
-          g im_ = elimMk lq lqd lr (im_ ^. mk)
-          s :: InstanceModel -> a -> InstanceModel
-          s im_ x = set mk (setMk (im_ ^. mk) lq lqd lr x) im_
-
 -- | Finds the 'UID' of an 'InstanceModel'.
-instance HasUID             InstanceModel where uid = lensMk uid uid uid
+instance HasUID             InstanceModel where uid = mk . uid
 -- | Finds the term ('NP') of the 'InstanceModel'.
 instance NamedIdea          InstanceModel where term = imTerm
 -- | Finds the idea contained in the 'InstanceModel'.
 instance Idea               InstanceModel where getA = getA . (^. mk)
 -- | Finds the definition of the 'InstanceModel'.
-instance Definition         InstanceModel where defn = lensMk defn defn defn
+instance Definition         InstanceModel where defn = mk . defn
 -- | Finds the domain of the 'InstanceModel'.
 instance ConceptDomain      InstanceModel where cdom = cdom . (^. mk)
 -- | Finds the relation expression for an 'InstanceModel'.

--- a/code/drasil-theory/Theory/Drasil/ModelKinds.hs
+++ b/code/drasil-theory/Theory/Drasil/ModelKinds.hs
@@ -7,57 +7,64 @@ import Data.Maybe (mapMaybe)
 
 import Language.Drasil (ExprRelat(..), ConceptDomain(..), Definition(..),
   Idea(..), NamedIdea(..), RelationConcept, QDefinition, HasUID(..))
+import Theory.Drasil.ConstraintSet (ConstraintSet)
 import Theory.Drasil.MultiDefn (MultiDefn)
 
 -- | Models can be of different kinds: 
 --
+--     * 'DEModel's represent differential equations as 'RelationConcept's
+--     * 'EquationalConstraint's represent invariants that will hold in a system of equations.
 --     * 'EquationalModel's represent quantities that are calculated via a single definition/'QDefinition'.
 --     * 'EquationalRealm's represent MultiDefns; quantities that may be calculated using any one of many 'DefiningExpr's (e.g., 'x = A = ... = Z')
---     * 'DEModel's represent differential equations as 'RelationConcept's
 --     * 'OthModel's are placeholders for models. No new 'OthModel's should be created, they should be using one of the other kinds.
-data ModelKinds = EquationalModel QDefinition
+data ModelKinds = DEModel RelationConcept
+                | EquationalConstraints ConstraintSet
+                | EquationalModel QDefinition
                 | EquationalRealm MultiDefn
-                | DEModel RelationConcept
                 | OthModel RelationConcept
 
 makeLenses ''ModelKinds
 
+-- FIXME: The repetition is starting to get bad.
+
 -- | Finds the 'UID' of the 'ModelKinds'.
-instance HasUID        ModelKinds where uid      = lensMk uid uid uid
+instance HasUID        ModelKinds where uid      = lensMk uid uid uid uid
 -- | Finds the term ('NP') of the 'ModelKinds'.
-instance NamedIdea     ModelKinds where term     = lensMk term term term
+instance NamedIdea     ModelKinds where term     = lensMk term term term term
 -- | Finds the idea of the 'ModelKinds'.
-instance Idea          ModelKinds where getA     = elimMk (to getA) (to getA) (to getA)
+instance Idea          ModelKinds where getA     = elimMk (to getA) (to getA) (to getA) (to getA)
 -- | Finds the definition of the 'ModelKinds'.
-instance Definition    ModelKinds where defn     = lensMk defn defn defn
+instance Definition    ModelKinds where defn     = lensMk defn defn defn defn
 -- | Finds the domain of the 'ModelKinds'.
-instance ConceptDomain ModelKinds where cdom     = elimMk (to cdom) (to cdom) (to cdom)
+instance ConceptDomain ModelKinds where cdom     = elimMk (to cdom) (to cdom) (to cdom) (to cdom)
 -- | Finds the relation expression of the 'ModelKinds'.
-instance ExprRelat     ModelKinds where relat    = elimMk (to relat) (to relat) (to relat)
+instance ExprRelat     ModelKinds where relat    = elimMk (to relat) (to relat) (to relat) (to relat)
 
 -- TODO: implement MayHaveUnit for ModelKinds once we've sufficiently removed OthModels & RelationConcepts (else we'd be breaking too much of `stable`)
 
 -- | Retrieve internal data from ModelKinds
-elimMk :: Getter QDefinition a -> Getter MultiDefn a -> Getter RelationConcept a -> ModelKinds -> a
-elimMk l _ _ (EquationalModel q) = q ^. l
-elimMk _ l _ (EquationalRealm q) = q ^. l
-elimMk _ _ l (DEModel q)         = q ^. l
-elimMk _ _ l (OthModel q)        = q ^. l
+elimMk :: Getter RelationConcept a -> Getter ConstraintSet a -> Getter QDefinition a -> Getter MultiDefn a -> ModelKinds -> a
+elimMk f _ _ _ (DEModel q)               = q ^. f
+elimMk _ f _ _ (EquationalConstraints q) = q ^. f
+elimMk _ _ f _ (EquationalModel q)       = q ^. f
+elimMk _ _ _ f (EquationalRealm q)       = q ^. f
+elimMk f _ _ _ (OthModel q)              = q ^. f
 
 -- | Map into internal representations of ModelKinds
-setMk :: ModelKinds -> Setter' QDefinition a -> Setter' MultiDefn a -> Setter' RelationConcept a -> a -> ModelKinds
-setMk (EquationalModel q) f _ _ x = EquationalModel $ set f x q
-setMk (EquationalRealm q) _ f _ x = EquationalRealm $ set f x q
-setMk (DEModel q)         _ _ g x = DEModel $ set g x q
-setMk (OthModel q)        _ _ g x = OthModel $ set g x q
+setMk :: ModelKinds -> Setter' RelationConcept a -> Setter' ConstraintSet a -> Setter' QDefinition a -> Setter' MultiDefn a -> a -> ModelKinds
+setMk (DEModel q)               f _ _ _ x = DEModel               $ set f x q
+setMk (EquationalConstraints q) _ f _ _ x = EquationalConstraints $ set f x q
+setMk (EquationalModel q)       _ _ f _ x = EquationalModel       $ set f x q
+setMk (EquationalRealm q)       _ _ _ f x = EquationalRealm       $ set f x q
+setMk (OthModel q)              f _ _ _ x = OthModel              $ set f x q
 
 -- | Make a 'Lens' for 'ModelKinds'.
-lensMk :: forall a. Lens' QDefinition a -> Lens' MultiDefn a -> Lens' RelationConcept a -> Lens' ModelKinds a
-lensMk lq lqd lr = lens g s
+lensMk :: forall a. Lens' RelationConcept a -> Lens' ConstraintSet a -> Lens' QDefinition a -> Lens' MultiDefn a -> Lens' ModelKinds a
+lensMk lr lcs lq lqd = lens g s
     where g :: ModelKinds -> a
-          g mk = elimMk lq lqd lr mk
+          g mk = elimMk lr lcs lq lqd mk
           s :: ModelKinds -> a -> ModelKinds
-          s mk_ x = setMk mk_ lq lqd lr x
+          s mk_ x = setMk mk_ lr lcs lq lqd x
 
 -- | Extract a list of 'QDefinition's from a list of 'ModelKinds'.
 getEqModQds :: [ModelKinds] -> [QDefinition]

--- a/code/drasil-theory/Theory/Drasil/MultiDefn.hs
+++ b/code/drasil-theory/Theory/Drasil/MultiDefn.hs
@@ -47,7 +47,7 @@ instance MayHaveUnit   MultiDefn where getUnit  = getUnit . view qd
 -- | The concept domain of a MultiDefn is the union of the concept domains of the underlying variants.
 instance ConceptDomain MultiDefn where cdom     = foldr1 union . NE.toList . NE.map (^. cd) . (^. rvs)
 instance Definition    MultiDefn where defn     = rDesc
--- | The related Relation of a MultiDefn is defined as the quantity and the related expressions being equal
+-- | The complete Relation of a MultiDefn is defined as the quantity and the related expressions being equal
 --   e.g., `q $= a $= b $= ... $= z`
 instance ExprRelat     MultiDefn where relat q  = sy q $= foldr1 ($=) (NE.map (^. expr) (q ^. rvs))
 

--- a/code/drasil-theory/drasil-theory.cabal
+++ b/code/drasil-theory/drasil-theory.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: c1a2177af7458984fb872c413f09c8617c7aa150685a4e9eefc9ef4fcfae485a
+-- hash: ffb523fa20d59d5c77268207f4ec612bae16f742508bdd9bce4bb2b88a669652
 
 name:           drasil-theory
 version:        0.1.0.0
@@ -26,6 +26,7 @@ library
       Data.Drasil.TheoryConcepts
   other-modules:
       Theory.Drasil.Classes
+      Theory.Drasil.ConstraintSet
       Theory.Drasil.DataDefinition
       Theory.Drasil.GenDefn
       Theory.Drasil.InstanceModel

--- a/code/stable/ssp/SRS/SSP_SRS.tex
+++ b/code/stable/ssp/SRS/SSP_SRS.tex
@@ -513,7 +513,7 @@ Label & Equilibrium
         
 \\ \midrule \\
 Equation & \begin{displaymath}
-           \displaystyle\sum{{F_{\text{x}}}}=\displaystyle\sum{{F_{\text{y}}}}=\displaystyle\sum{M}=0
+           \displaystyle\sum{{F_{\text{x}}}}=0\land{}\displaystyle\sum{{F_{\text{y}}}}=0\land{}\displaystyle\sum{M}=0
            \end{displaymath}
 \\ \midrule \\
 Description & \begin{symbDescription}

--- a/code/stable/ssp/Website/SSP_SRS.html
+++ b/code/stable/ssp/Website/SSP_SRS.html
@@ -1214,7 +1214,7 @@
                     <tr>
                       <th>Equation</th>
                       <td>
-                        \[\displaystyle\sum{{F_{\text{x}}}}=\displaystyle\sum{{F_{\text{y}}}}=\displaystyle\sum{M}=0\]
+                        \[\displaystyle\sum{{F_{\text{x}}}}=0\land{}\displaystyle\sum{{F_{\text{y}}}}=0\land{}\displaystyle\sum{M}=0\]
                       </td>
                     </tr>
                     <tr>


### PR DESCRIPTION
Closes #2581 

One notable thing is that it divides the constraints for the `equilibrium` TM into 3 separate equations:
So, from ->
![image](https://user-images.githubusercontent.com/1627302/121397262-2b739c00-c922-11eb-8c7c-94fe54c5a08f.png)

we get ->
![image](https://user-images.githubusercontent.com/1627302/121397187-1f87da00-c922-11eb-9a1e-e18a0ccd264e.png)
