### PR TITLE
Remove QDs from TMs added to GlassBR's SystemInformation

### DIFF
--- a/code/drasil-example/Drasil/GlassBR/Body.hs
+++ b/code/drasil-example/Drasil/GlassBR/Body.hs
@@ -80,9 +80,7 @@ si = SI {
   _purpose     = purpDoc glassBR Verbose,
   _quants      = symbolsForTable,
   _concepts    = [] :: [DefinedQuantityDict],
-  _definitions = getEqModQdsFromIm iMods ++ 
-                 concatMap (^. defined_quant) tMods ++
-                 concatMap (^. defined_fun) tMods,
+  _definitions = getEqModQdsFromIm iMods,
   _datadefs    = GB.dataDefs,
   _configFiles = configFp,
   _inputs      = inputs,

--- a/code/drasil-example/Drasil/GlassBR/Body.hs
+++ b/code/drasil-example/Drasil/GlassBR/Body.hs
@@ -8,7 +8,7 @@ import Database.Drasil (ChunkDB, ReferenceDB, SystemInformation(SI),
   cdb, rdb, refdb, _authors, _purpose, _concepts, _constants, _constraints, 
   _datadefs, _definitions, _configFiles, _defSequence, _inputs, _kind, 
   _outputs, _quants, _sys, _sysinfodb, _usedinfodb)
-import Theory.Drasil (Theory(defined_fun, defined_quant), getEqModQdsFromIm)
+import Theory.Drasil (getEqModQdsFromIm)
 import Utils.Drasil
 import Utils.Drasil.Concepts
 import qualified Utils.Drasil.Sentence as S


### PR DESCRIPTION
These particular QDefinitions for GlassBR are not needed since they're obtained from the IMs. However, from past discussion, I think that we're not supposed to be creating generable code using the TMs.

I came across this while checking the QDef-In-InstMod branch while trying to port over the last few changes back slowly. After this, I think we will need to get a well-placed "getEqModQdsFromIM/GDs" somewhere to get the definitions of the IMs and GDs into the realm of generable code.