### PR TITLE
Add a `hlint` + `hot_hlint` Makefile target

### DIFF
--- a/.github/workflows/Build.yaml
+++ b/.github/workflows/Build.yaml
@@ -49,7 +49,7 @@ jobs:
           echo "$HOME/.local/bin" >> $GITHUB_PATH
           echo "$HOME/.swift/usr/bin" >> $GITHUB_PATH
       - name: "HLint"
-        run: curl --max-time 60 -sSL https://raw.github.com/ndmitchell/hlint/master/misc/run.sh | sh -s .
+        run: make hot_hlint
       - name: "Install dependencies"
         run: stack --no-terminal test --bench --only-dependencies
       - name: "Build"

--- a/.github/workflows/Test.yaml
+++ b/.github/workflows/Test.yaml
@@ -54,7 +54,7 @@ jobs:
           echo "$HOME/.local/bin" >> $GITHUB_PATH
           echo "$HOME/.swift/usr/bin" >> $GITHUB_PATH
       - name: "HLint"
-        run: curl --max-time 60 -sSL https://raw.github.com/ndmitchell/hlint/master/misc/run.sh | sh -s .
+        run: make hot_hlint
       - name: "Install dependencies"
         run: stack --no-terminal test --bench --only-dependencies
       - name: "Build"

--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@ dist
 *.chs.h
 .drasil-min-stack-ver
 stack.yaml.lock
+.hlint*
 
 # Drasil supported programming languages
 __pycache__

--- a/code/Makefile
+++ b/code/Makefile
@@ -186,17 +186,16 @@ stabilize: $(STABILIZE_EXAMPLES)
 graphmod: check_stack
 	stack install dotgen graphmod
 
-$(filter %$(GRAPH_P_SUFFIX), $(GRAPH_PACKAGES)): %$(GRAPH_P_SUFFIX): check_stack check_dot graphmod
-	@mkdir -p $(GRAPH_FOLDER)
+$(filter %$(GRAPH_P_SUFFIX), $(GRAPH_PACKAGES)): %$(GRAPH_P_SUFFIX): graphmod check_dot
+	@mkdir -p "$(GRAPH_FOLDER)"
 	find "drasil-$*" -name '*.hs' -print | grep -v stack | xargs stack exec -- graphmod -q -p --no-cluster | dot -Tpdf > "$(GRAPH_FOLDER)drasil-$*".pdf
 
 graphs: $(GRAPH_PACKAGES)
 ###
 
-analysis: check_stack
-	stack install dotgen graphmod
-	- rm -rf $(ANALYSIS_FOLDER)
-	@mkdir -p $(ANALYSIS_FOLDER)
+analysis: graphmod
+	- rm -rf "$(ANALYSIS_FOLDER)"
+	@mkdir -p "$(ANALYSIS_FOLDER)"
 	cd $(SCRIPT_FOLDER) && stack exec -- runghc DataTableGen.hs
 	cd $(SCRIPT_FOLDER) && stack exec -- runghc TypeGraphGen.hs
 	@echo Making dependency graphs
@@ -204,6 +203,15 @@ analysis: check_stack
 		dot -Tpdf $$pack.dot > "./$$pack.pdf" ; \
 	done
 	@echo Done dependency graphs
+
+# Use a 'local' HLint installation, using HLint from the current stack repo
+hlint: check_stack
+	- stack install hlint
+	- hlint .
+
+# Use the latest HLint version, downloading the binary each time
+hot_hlint:
+	- curl --max-time 60 -sSL https://raw.github.com/ndmitchell/hlint/master/misc/run.sh | sh -s .
 
 docs: check_stack
 	DOCS_FOLDER="$(DOCS_FOLDER)" GHC_FLAGS="$(GHCFLAGS)" sh scripts/make_docs.sh

--- a/code/Makefile
+++ b/code/Makefile
@@ -274,4 +274,4 @@ clean_artifacts cleanArtifacts: $(CLEAN_FOLDERS)
 clean: clean_artifacts
 	- stack clean
 
-.PHONY: clean clean_artifacts cleanArtifacts code analysis tex doc debug prog test graphs graphmod check_stack graphs deploy_code_path deploy deploy_lite all $(GOOLTEST) $(ALL_EXPANDED_TARGETS)
+.PHONY: clean clean_artifacts cleanArtifacts code hlint hot_hlint analysis tex doc debug prog test graphs graphmod check_stack graphs deploy_code_path deploy deploy_lite all $(GOOLTEST) $(ALL_EXPANDED_TARGETS)


### PR DESCRIPTION
* Added `.hlint*` to the .gitignore
* Wrapped string fields in double quotes in the makefile
* Add 2 new make targets -- `hlint` and `hot_hlint` for using hlint, respectively, via a local installation or via hot download