### PR TITLE
capitalized pendulum in the introduction

### DIFF
--- a/code/drasil-example/Drasil/DblPendulum/Body.hs
+++ b/code/drasil-example/Drasil/DblPendulum/Body.hs
@@ -102,7 +102,7 @@ justification = foldlSent [ atStartNP (a_ pendulum), S "consists" `S.of_` phrase
                             (S "highly sensitive to initial conditions" !.), S "Therefore" `sC`
                             S "it is useful to have a", phrase program, S "to simulate", phraseNP (motion
                             `the_ofThe` pendulum), (S "to exhibit its chaotic characteristics" !.),
-                            atStartNP (the program), S "documented here is called", phrase pendulum]
+                            atStartNP (the program), S "documented here is called", phrase pendulumTitle]
 scope :: Sentence
 scope = foldlSent [phraseNP (NP.the (analysis `ofA` twoD)), 
   sParen (getAcc twoD), phrase pendMotion, phrase problem,

--- a/code/stable/dblpendulum/SRS/DblPendulum_SRS.tex
+++ b/code/stable/dblpendulum/SRS/DblPendulum_SRS.tex
@@ -169,7 +169,7 @@ Uncert. & Typical Uncertainty
 \end{longtable}
 \section{Introduction}
 \label{Sec:Intro}
-A pendulum consists of mass attached to the end of a rod and its moving curve is highly sensitive to initial conditions. Therefore, it is useful to have a program to simulate the motion of the pendulum to exhibit its chaotic characteristics. The program documented here is called pendulum.
+A pendulum consists of mass attached to the end of a rod and its moving curve is highly sensitive to initial conditions. Therefore, it is useful to have a program to simulate the motion of the pendulum to exhibit its chaotic characteristics. The program documented here is called Pendulum.
 
 The following section provides an overview of the Software Requirements Specification (SRS) for Pendulum. This section explains the purpose of this document, the scope of the requirements, the characteristics of the intended reader, and the organization of the document.
 

--- a/code/stable/dblpendulum/Website/DblPendulum_SRS.html
+++ b/code/stable/dblpendulum/Website/DblPendulum_SRS.html
@@ -297,7 +297,7 @@
       <div class="section">
         <h1>Introduction</h1>
         <p class="paragraph">
-          A pendulum consists of mass attached to the end of a rod and its moving curve is highly sensitive to initial conditions. Therefore, it is useful to have a program to simulate the motion of the pendulum to exhibit its chaotic characteristics. The program documented here is called pendulum.
+          A pendulum consists of mass attached to the end of a rod and its moving curve is highly sensitive to initial conditions. Therefore, it is useful to have a program to simulate the motion of the pendulum to exhibit its chaotic characteristics. The program documented here is called Pendulum.
         </p>
         <p class="paragraph">
           The following section provides an overview of the Software Requirements Specification (SRS) for Pendulum. This section explains the purpose of this document, the scope of the requirements, the characteristics of the intended reader, and the organization of the document.


### PR DESCRIPTION
- The Pendulum is capitalized in the last word of the first paragraph.

- I created additional three tickets to add three new sections.

close #2615