### PR TITLE
Make `make hlint` and `make hot_hlint` return the error codes (no suppression with -)

### DIFF
--- a/code/Makefile
+++ b/code/Makefile
@@ -208,10 +208,12 @@ analysis: graphmod
 hlint: check_stack
 	- stack install hlint
 	- hlint .
+	@exit $(.SHELLSTATUS)
 
 # Use the latest HLint version, downloading the binary each time
 hot_hlint:
 	- curl --max-time 60 -sSL https://raw.github.com/ndmitchell/hlint/master/misc/run.sh | sh -s .
+	@exit $(.SHELLSTATUS)
 
 docs: check_stack
 	DOCS_FOLDER="$(DOCS_FOLDER)" GHC_FLAGS="$(GHCFLAGS)" sh scripts/make_docs.sh

--- a/code/Makefile
+++ b/code/Makefile
@@ -204,16 +204,17 @@ analysis: graphmod
 	done
 	@echo Done dependency graphs
 
+quick_fail:
+	exit 1
+
 # Use a 'local' HLint installation, using HLint from the current stack repo
 hlint: check_stack
-	- stack install hlint
-	- hlint .
-	@exit $(.SHELLSTATUS)
+	stack install hlint
+	hlint .
 
 # Use the latest HLint version, downloading the binary each time
 hot_hlint:
-	- curl --max-time 60 -sSL https://raw.github.com/ndmitchell/hlint/master/misc/run.sh | sh -s .
-	@exit $(.SHELLSTATUS)
+	curl --max-time 60 -sSL https://raw.github.com/ndmitchell/hlint/master/misc/run.sh | sh -s .
 
 docs: check_stack
 	DOCS_FOLDER="$(DOCS_FOLDER)" GHC_FLAGS="$(GHCFLAGS)" sh scripts/make_docs.sh

--- a/code/Makefile
+++ b/code/Makefile
@@ -204,9 +204,6 @@ analysis: graphmod
 	done
 	@echo Done dependency graphs
 
-quick_fail:
-	exit 1
-
 # Use a 'local' HLint installation, using HLint from the current stack repo
 hlint: check_stack
 	stack install hlint

--- a/code/drasil-lang/Language/Drasil/Sentence/Extract.hs
+++ b/code/drasil-lang/Language/Drasil/Sentence/Extract.hs
@@ -12,10 +12,10 @@ getUIDs (Ch ShortStyle _ _) = []
 getUIDs (Ch TermStyle _ _)  = []
 getUIDs (Ch PluralTerm _ _) = []
 getUIDs (SyCh a)            = [a]
-getUIDs (Sy _)              = []
-getUIDs (S _)               = []
-getUIDs (P _)               = []
-getUIDs (Ref {})            = []
+getUIDs Sy {}               = []
+getUIDs S {}                = []
+getUIDs P {}                = []
+getUIDs Ref {}              = []
 getUIDs Percent             = []
 getUIDs ((:+:) a b)         = getUIDs a ++ getUIDs b
 getUIDs (Quote a)           = getUIDs a
@@ -28,15 +28,15 @@ getUIDshort :: Sentence -> [UID]
 getUIDshort (Ch ShortStyle _ a) = [a]
 getUIDshort (Ch TermStyle _ _)  = []
 getUIDshort (Ch PluralTerm _ _) = []
-getUIDshort (SyCh _)            = []
-getUIDshort (Sy _)              = []
-getUIDshort (S _)               = []
+getUIDshort SyCh {}             = []
+getUIDshort Sy {}               = []
+getUIDshort S {}                = []
 getUIDshort Percent             = []
-getUIDshort (P _)               = []
-getUIDshort (Ref {})            = []
+getUIDshort P {}                = []
+getUIDshort Ref {}              = []
 getUIDshort ((:+:) a b)         = getUIDshort a ++ getUIDshort b
 getUIDshort (Quote a)           = getUIDshort a
-getUIDshort (E _)               = []
+getUIDshort E {}                = []
 getUIDshort EmptyS              = []
 
 -----------------------------------------------------------------------------
@@ -51,18 +51,18 @@ shortdep = nub . getUIDshort
 
 -- | Generic traverse of all positions that could lead to /reference/ 'UID's from 'Sentence's.
 lnames :: Sentence -> [UID]
-lnames (Ch _ _ _)     = []
-lnames (SyCh _)       = []
-lnames (Sy _)         = []
-lnames (S _)          = []
-lnames Percent        = []
-lnames (P _)          = []
-lnames (Ref a _ _)    = [a]
-lnames ((:+:) a b)    = lnames a ++ lnames b
-lnames (Quote _)      = []
-lnames (E _)          = []
-lnames EmptyS         = []
+lnames Ch {}       = []
+lnames SyCh {}     = []
+lnames Sy {}       = []
+lnames S {}        = []
+lnames Percent     = []
+lnames P {}        = []
+lnames (Ref a _ _) = [a]
+lnames ((:+:) a b) = lnames a ++ lnames b
+lnames Quote {}    = []
+lnames E {}        = []
+lnames EmptyS      = []
 
 -- | Get /reference/ 'UID's from 'Sentence's.
 lnames'  :: [Sentence] -> [UID]
-lnames' = concatMap lnames 
+lnames' = concatMap lnames

--- a/code/drasil-printers/Language/Drasil/Printing/Import/Helpers.hs
+++ b/code/drasil-printers/Language/Drasil/Printing/Import/Helpers.hs
@@ -59,7 +59,7 @@ lookupT sm c tCap = resolveCapT tCap $ termResolve sm c ^. term
 
 -- | Look up the acronym/abbreviation of a term. Otherwise returns the singular form of a term. Takes a chunk database and a 'UID' associated with the term.
 lookupS :: ChunkDB -> UID -> TermCapitalization -> Sentence
-lookupS sm c sCap = maybe (resolveCapT sCap $ l ^. term) S $ getA l >>= (capHelper sCap)
+lookupS sm c sCap = maybe (resolveCapT sCap $ l ^. term) S $ getA l >>= capHelper sCap
   where l = termResolve sm c
 
 -- | Look up the plural form of a term given a chunk database and a 'UID' associated with the term.
@@ -80,6 +80,6 @@ resolveCapP CapW = titleizeNP'
 
 -- | Helper to get the capital case of an abbreviation based on 'TermCapitalization'. For sentence and title cases.
 capHelper :: TermCapitalization -> String -> Maybe String
-capHelper NoCap s = return s
-capHelper _ [] = Nothing
-capHelper _ (x:xs) = Just ((toUpper x): xs)
+capHelper NoCap s      = return s
+capHelper _     []     = Nothing
+capHelper _     (x:xs) = Just (toUpper x: xs)

--- a/code/drasil-website/Drasil/Website/CaseStudy.hs
+++ b/code/drasil-website/Drasil/Website/CaseStudy.hs
@@ -31,14 +31,14 @@ headerRow :: [Sentence]
 headerRow = map S ["Case Study", modularityTitle, implementTypeTitle, loggingTitle, inStructTitle, conStructTitle, conRepTitle, realNumRepTitle]
 
 tableBody :: [[Sentence]]
-tableBody = mkTable [(\(CS x _ _ _ _ _ _ _) -> S x),
-                     (\(CS _ x _ _ _ _ _ _) -> S $ show x),
-                     (\(CS _ _ x _ _ _ _ _) -> S $ show x),
-                     (\(CS _ _ _ x _ _ _ _) -> S $ show x),
-                     (\(CS _ _ _ _ x _ _ _) -> S $ show x),
-                     (\(CS _ _ _ _ _ x _ _) -> S $ show x),
-                     (\(CS _ _ _ _ _ _ x _) -> S $ show x),
-                     (\(CS _ _ _ _ _ _ _ x) -> S $ show x)]
+tableBody = mkTable [\(CS x _ _ _ _ _ _ _) -> S x,
+                     \(CS _ x _ _ _ _ _ _) -> S $ show x,
+                     \(CS _ _ x _ _ _ _ _) -> S $ show x,
+                     \(CS _ _ _ x _ _ _ _) -> S $ show x,
+                     \(CS _ _ _ _ x _ _ _) -> S $ show x,
+                     \(CS _ _ _ _ _ x _ _) -> S $ show x,
+                     \(CS _ _ _ _ _ _ x _) -> S $ show x,
+                     \(CS _ _ _ _ _ _ _ x) -> S $ show x]
                      [glassBRCase, noPCMCase, pdControllerCase, projectileCase1, projectileCase2, projectileCase3, projectileCase4, projectileCase5]
 
 caseStudyTabRef :: Reference
@@ -88,13 +88,13 @@ projectileCase4  = CS "Projectile_U_P_NoL_U_WI_V_D" UMod PIm NoL UIn WI V D
 projectileCase5  = CS "Projectile_U_P_L_B_WI_V_F"   UMod PIm L   BIn WI V F
 
 -- case studies symbol legend
-modularityTitle, implementTypeTitle, loggingTitle, inStructTitle, conStructTitle, 
+modularityTitle, implementTypeTitle, loggingTitle, inStructTitle, conStructTitle,
   conRepTitle, realNumRepTitle :: String
-modPt1, modPt2, modPt3, implementPt1, implementPt2, 
-  logPt1, logPt2, inStructPt1, inStructPt2, conStructPt1, conStructPt2, conStructPt3, 
+modPt1, modPt2, modPt3, implementPt1, implementPt2,
+  logPt1, logPt2, inStructPt1, inStructPt2, conStructPt1, conStructPt2, conStructPt3,
   conStructPt4, conRepPt1, conRepPt2, realNumRepPt1, realNumRepPt2 :: String
-modSymbPt1, modSymbPt2, modSymbPt3, implementSymbPt1, implementSymbPt2, 
-  logSymbPt1, logSymbPt2, inStructSymbPt1, inStructSymbPt2, conStructSymbPt1, conStructSymbPt2, conStructSymbPt3, 
+modSymbPt1, modSymbPt2, modSymbPt3, implementSymbPt1, implementSymbPt2,
+  logSymbPt1, logSymbPt2, inStructSymbPt1, inStructSymbPt2, conStructSymbPt1, conStructSymbPt2, conStructSymbPt3,
   conStructSymbPt4, conRepSymbPt1, conRepSymbPt2, realNumRepSymbPt1, realNumRepSymbPt2 :: String
 
 caseStudyLegend :: RawContent

--- a/code/scripts/SourceCodeReaderTypes.hs
+++ b/code/scripts/SourceCodeReaderTypes.hs
@@ -81,7 +81,7 @@ filterEmptyS = filter (/= "")
 
 -- for those few cases of data declarations that start the actual data declaration on a new line after the "=" sign.
 removeNewlineEqual :: [String] -> [String]
-removeNewlineEqual = filterNewline prefixCheck (\_ -> True)
+removeNewlineEqual = filterNewline prefixCheck (const True)
   where
     prefixCheck l = ("data " `isPrefixOf` l || "type " `isPrefixOf` l || "newtype " `isPrefixOf` l) && "=" `isSuffixOf` l
 
@@ -93,7 +93,7 @@ removeNewlineBrace = filterNewline prefixCheck (isInfixOf "{")
 
 -- for those few cases of data declarations that use constructors with guards on a newline.
 removeNewlineGuard :: [String] -> [String]
-removeNewlineGuard = filterNewline (\_ -> True) (isPrefixOf "|") 
+removeNewlineGuard = filterNewline (const True) (isPrefixOf "|") 
 
 -- Gets rid of automatically derived instances since we only care about type dependencies.
 removeDeriving :: [String] -> [String]
@@ -198,12 +198,12 @@ useConstructFormRec _ ls = ls
 -- Instead of separating records by newline (which are not guarenteed),
 -- use commas (which will always be there for a record with more than one field).
 removeNewlineComma :: [String] -> [String]
-removeNewlineComma = filterNewline (\_ -> True) (isPrefixOf ",")
+removeNewlineComma = filterNewline (const True) (isPrefixOf ",")
 
 -- filter through records of the form rec :: Type1 -> f Type2. Only accepts the first type though, so this will eventually need to be changed
 filterFuncForm :: String -> String
 filterFuncForm l 
-  | "->" `isInfixOf` l = unwords $ filter (\x -> isUpper $ head x) $ nub $ words l
+  | "->" `isInfixOf` l = unwords $ filter (isUpper . head) $ nub $ words l
   | otherwise = l
 
 -- Take a list of data declarations for records and get the name of the datatype itself and all dependencies of that datatype.
@@ -211,7 +211,7 @@ sortDataRec :: [String] -> [(String, [String])]
 sortDataRec = map (\l -> (head $ typeContents l, typeDependencies l))
   where
     typeContents l = map stripWS $ L.splitOn "=" $ l \\ "data "
-    typeDependencies l = map filterFuncForm $ map stripWS $ concatMap (tail . L.splitOn "::") $ L.splitOn "," $ concat $ tail $ typeContents l
+    typeDependencies l = map (filterFuncForm . stripWS) $ concatMap (tail . L.splitOn "::") $ L.splitOn "," $ concat $ tail $ typeContents l
 
 -- Record a datatype and its dependencies. For record types using the @data@ declaration syntax.
 getDataContainedRec :: [(String, [String])] -> [DataDeclRecord]
@@ -253,11 +253,11 @@ getDataContainedConst = map (\l -> DDC {ddcName = filterName $ fst l, ddcContent
 
 -- Newtypes can be defined similar to records. Only includes those record-style declarations.
 isNewtypeRec :: [String] -> [String]
-isNewtypeRec = filter (\x -> isInfixOf "{" x && isPrefixOf "newtype " x)
+isNewtypeRec = filter (\x -> "{" `isInfixOf` x && "newtype " `isPrefixOf` x)
 
 -- Newtypes are often defined using constructors (they don't use @{@).
 isNewtypeConst :: [String] -> [String]
-isNewtypeConst = filter (\x -> not (isInfixOf "{" x) && isPrefixOf "newtype " x)
+isNewtypeConst = filter (\x -> not ("{" `isInfixOf` x) && "newtype " `isPrefixOf` x)
 
 -- Sorts a datatype and its dependencies. For record-style @newtype@ declaration syntax.
 sortNewtypesR :: [String] -> [(String, [String])]
@@ -306,7 +306,7 @@ filterName = filterPrimeTypes . filterQualifiedTypes . filterInvalidChars
 
 -- These characters should either not appear in a .dot file (eg. gets rid of list types), or does some extra cleanup that the general sort functions did not catch.
 filterInvalidChars :: String -> String
-filterInvalidChars = filter (\l -> not (l `elem` invalidChars))
+filterInvalidChars = filter (`notElem` invalidChars)
   where
     invalidChars = "[]!} (){->,$" --the space being here is kind of a hack (as a result of uncommon type syntax not caught by the above sorters), but it allows the .dot files to compile for now
 


### PR DESCRIPTION
Closes #2660 

The prefixed `-` of the hlint runs suppressed the errors.

The actions run _should_ fail. We can fix them in this ticket as well, but I want to see it fail first to make sure.