### PR TITLE
Custom text refs

### DIFF
--- a/code/drasil-docLang/Drasil/DocumentLanguage.hs
+++ b/code/drasil-docLang/Drasil/DocumentLanguage.hs
@@ -49,7 +49,8 @@ import qualified Drasil.DocumentLanguage.TraceabilityMatrix as TM (traceMGF,
   generateTraceTableView)
 
 import Data.Drasil.Concepts.Documentation (likelyChg, refmat, section_,
-  software, unlikelyChg)
+  software, unlikelyChg) 
+import qualified Data.Drasil.Concepts.Documentation as Doc (tOfSymb, tOfUnit)
 
 import Control.Lens ((^.), over, set)
 import Data.Function (on)
@@ -176,8 +177,8 @@ tsI :: TSIntro -> Sentence
 tsI (TypogConvention ts) = typogConvention ts
 tsI SymbOrder = S "The symbols are listed in alphabetical order."
 tsI (SymbConvention ls) = symbConvention ls
-tsI TSPurpose = S "The symbols used in this document are summarized in" +:+
-  refS symbTableRef +:+. S "along with their units"
+tsI TSPurpose = S "The symbols used in this document are summarized in the" +:+
+  namedRef symbTableRef (plural Doc.tOfSymb) +:+. S "along with their units"
 tsI VectorUnits = S "For vector quantities, the units shown are for each component of the vector."
 
 -- | Typographic convention writer. Translates a list of typographic conventions ('TConvention's)
@@ -210,7 +211,7 @@ tuI :: TUIntro -> Sentence
 tuI System  = 
   S "The unit system used throughout is SI (Système International d'Unités)."
 tuI TUPurpose = 
-  S "For each unit" `sC` refS unitTableRef +:+. S "lists the symbol, a description and the SI name"
+  S "For each unit" `sC` S "the" +:+ namedRef unitTableRef (plural Doc.tOfUnit) +:+. S "lists the symbol, a description and the SI name"
 tuI Derived = 
   S "In addition to the basic units, several derived units are also used."
 

--- a/code/drasil-docLang/Drasil/DocumentLanguage.hs
+++ b/code/drasil-docLang/Drasil/DocumentLanguage.hs
@@ -178,7 +178,7 @@ tsI (TypogConvention ts) = typogConvention ts
 tsI SymbOrder = S "The symbols are listed in alphabetical order."
 tsI (SymbConvention ls) = symbConvention ls
 tsI TSPurpose = S "The symbols used in this document are summarized in the" +:+
-  namedRef symbTableRef (plural Doc.tOfSymb) +:+. S "along with their units"
+  namedRef symbTableRef (titleize' Doc.tOfSymb) +:+. S "along with their units"
 tsI VectorUnits = S "For vector quantities, the units shown are for each component of the vector."
 
 -- | Typographic convention writer. Translates a list of typographic conventions ('TConvention's)
@@ -211,7 +211,7 @@ tuI :: TUIntro -> Sentence
 tuI System  = 
   S "The unit system used throughout is SI (Système International d'Unités)."
 tuI TUPurpose = 
-  S "For each unit" `sC` S "the" +:+ namedRef unitTableRef (plural Doc.tOfUnit) +:+. S "lists the symbol, a description and the SI name"
+  S "For each unit" `sC` S "the" +:+ namedRef unitTableRef (titleize' Doc.tOfUnit) +:+. S "lists the symbol, a description and the SI name"
 tuI Derived = 
   S "In addition to the basic units, several derived units are also used."
 

--- a/code/drasil-docLang/Drasil/DocumentLanguage/TraceabilityMatrix.hs
+++ b/code/drasil-docLang/Drasil/DocumentLanguage/TraceabilityMatrix.hs
@@ -4,6 +4,7 @@ import Language.Drasil
 import Database.Drasil(ChunkDB, SystemInformation, UMap, _sysinfodb, asOrderedList,
   conceptinsTable, defResolve, refbyTable, traceTable, traceLookup)
 import Utils.Drasil
+import Utils.Drasil.Concepts
 import qualified Utils.Drasil.Sentence as S
 
 import Data.Drasil.Concepts.Documentation (purpose, component, dependency,
@@ -43,7 +44,7 @@ traceGIntro refs trailings = map ulcc [Paragraph $ foldlSent
         S "is also to provide easy", plural reference, S "on what has to be",
         S "additionally modified if a certain", phrase component +:+. S "is changed", 
         S "The arrows in the", plural graph, S "represent" +:+. plural dependency,
-        S "The", phrase component, S "at the tail of an arrow is depended on by the",
+        atStartNP (the component), S "at the tail of an arrow is depended on by the",
         phrase component, S "at the head of that arrow. Therefore, if a", phrase component,
         S "is changed, the", plural component, S "that it points to should also be changed"] +:+
         foldlSent (zipWith tableShows refs trailings)]

--- a/code/drasil-docLang/Drasil/Sections/Introduction.hs
+++ b/code/drasil-docLang/Drasil/Sections/Introduction.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE PostfixOperators #-}
 module Drasil.Sections.Introduction (orgSec, introductionSection, purposeOfDoc, scopeOfRequirements, 
   charIntRdrF, purpDoc) where
 
@@ -6,6 +7,7 @@ import qualified Drasil.DocLang.SRS as SRS (intro, prpsOfDoc, scpOfReq,
   charOfIR, orgOfDoc, goalStmt, thModel, inModel, sysCon)
 import Drasil.DocumentLanguage.Definitions(Verbosity(..))
 import Utils.Drasil
+import Utils.Drasil.Concepts
 import qualified Utils.Drasil.Sentence as S
 
 import Data.Drasil.Concepts.Computation (algorithm)
@@ -26,13 +28,13 @@ import Data.Drasil.Citations (parnasClements1986)
 developmentProcessParagraph :: Sentence
 developmentProcessParagraph = foldlSent [S "This", phrase document, 
   S "will be used as a starting point for subsequent development", 
-  S "phases, including writing the", phrase desSpec, S "and the", 
-  phrase softwareVAV, S "plan. The", phrase designDoc, S "will show how the", 
+  S "phases, including writing the", phraseNP (desSpec `andThe` softwareVAV) +:+.
+  S "plan", atStartNP (the designDoc), S "will show how the", 
   plural requirement, S "are to be realized, including", plural decision, 
   S "on the numerical", plural algorithm, S "and programming" +:+. 
   phrase environment, S "The", phrase vavPlan, 
   S "will show the steps that will be used to increase confidence in the",
-  phrase softwareDoc, S "and the" +:+. phrase implementation, S "Although",
+  (phraseNP (softwareDoc `andThe` implementation) !.), S "Although",
   S "the", short srs, S "fits in a series of", plural document, 
   S "that follow the so-called waterfall", phrase model `sC` 
   S "the actual development process is not constrained", 
@@ -128,8 +130,8 @@ intReaderIntro :: (Idea a) => a -> [Sentence] -> [Sentence] -> [Sentence] ->
 intReaderIntro progName assumed topic asset sectionRef = 
   [foldlSP [S "Reviewers of this", phrase documentation,
   S "should have an understanding of" +:+.
-  foldlList Comma List (assumed ++ topic), assetSent, S "The",
-  plural user `S.of_` short progName, S "can have a lower level" `S.of_`
+  foldlList Comma List (assumed ++ topic), assetSent,
+  atStartNP' (the user) `S.of_` short progName, S "can have a lower level" `S.of_`
   S "expertise, as explained" `S.in_` refS sectionRef]]
   where
     assetSent = case asset of

--- a/code/drasil-docLang/Drasil/Sections/Requirements.hs
+++ b/code/drasil-docLang/Drasil/Sections/Requirements.hs
@@ -3,6 +3,7 @@ module Drasil.Sections.Requirements (fReqF, fullReqs, fullTables, inReq, inTable
 
 import Language.Drasil
 import Utils.Drasil
+import Utils.Drasil.Concepts
 import qualified Utils.Drasil.Sentence as S
 
 import Data.Drasil.Concepts.Documentation (description, funcReqDom,
@@ -62,12 +63,12 @@ reqIntroStart = foldlSent_ [S "This", phrase section_, S "provides"]
 
 -- | General 'Sentence' for use in the Functional Requirements subsection introduction.
 frReqIntroBody :: Sentence
-frReqIntroBody = foldlSent_ [S "the", plural functionalRequirement `sC`
+frReqIntroBody = foldlSent_ [pluralNP (the functionalRequirement) `sC`
   S "the tasks and behaviours that the", phrase software, S "is expected to complete"]
 
 -- | General 'Sentence' for use in the Non-Functional Requirements subsection introduction.
 nfrReqIntroBody :: Sentence
-nfrReqIntroBody = foldlSent_ [S "the", plural nonfunctionalRequirement `sC`
+nfrReqIntroBody = foldlSent_ [pluralNP (the nonfunctionalRequirement) `sC`
   S "the qualities that the", phrase software, S "is expected to exhibit"]
 
 -- | Generalized Requirements section introduction.

--- a/code/drasil-docLang/Drasil/Sections/SpecificSystemDescription.hs
+++ b/code/drasil-docLang/Drasil/Sections/SpecificSystemDescription.hs
@@ -157,7 +157,7 @@ inModelIntro r1 r2 r3 r4 = foldlSP [S "This", phrase section_,
   S "into one which is expressed in mathematical terms. It uses concrete", 
   plural symbol_, S "defined in the", namedRef r2 $ plural dataDefn, S "to replace the abstract",
   pluralNP $ symbol_ `inThePP` model, S "identified in", namedRef r3 (plural thModel) `S.and_`
-  (namedRef r4 $ plural genDefn)]
+  namedRef r4 (plural genDefn)]
 
 -- | Constructor for Data Constraints section. Takes a trailing 'Sentence' (use 'EmptyS' if none) and data constraints.
 datConF :: (HasUncertainty c, Quantity c, Constrained c, HasReasVal c, MayHaveUnit c) => 

--- a/code/drasil-docLang/Drasil/Sections/SpecificSystemDescription.hs
+++ b/code/drasil-docLang/Drasil/Sections/SpecificSystemDescription.hs
@@ -17,6 +17,8 @@ module Drasil.Sections.SpecificSystemDescription
 
 import Language.Drasil hiding (variable)
 import Utils.Drasil
+import Utils.Drasil.Concepts
+import qualified Utils.Drasil.NounPhrase as NP
 import qualified Utils.Drasil.Sentence as S
 
 import Data.Drasil.Concepts.Documentation (assumption, column, constraint, corSol,
@@ -24,10 +26,11 @@ import Data.Drasil.Concepts.Documentation (assumption, column, constraint, corSo
   input_, limitation, model, output_, physical, physicalConstraint, physicalSystem,
   physSyst, problem, problemDescription, property, purpose, quantity, requirement,
   scope, section_, softwareConstraint, solutionCharacteristic, specification,
-  symbol_, system, theory, typUnc, uncertainty, user, value, variable)
+  symbol_, system, theory, typUnc, uncertainty, user, value, variable, table_, problemDescription)
+import qualified Data.Drasil.Concepts.Documentation as DCD (sec)
 import Data.Drasil.Concepts.Math (equation, parameter)
 
-import Data.Drasil.TheoryConcepts (inModel, thModel)
+import Data.Drasil.TheoryConcepts (inModel, thModel, dataDefn, genDefn)
 
 import qualified Drasil.DocLang.SRS as SRS
 
@@ -51,7 +54,7 @@ intro_ = mkParagraph $ foldlSent [S "This", phrase section_, S "first presents t
 
 -- | Describes a problem the system is needed to accomplish.
 probDescF :: Sentence -> [Section] -> Section
-probDescF prob = SRS.probDesc [mkParagraph $ foldlSent [S "A", phrase system `S.is` S "needed to", prob]]
+probDescF prob = SRS.probDesc [mkParagraph $ foldlSent [atStartNP (a_ system) `S.is` S "needed to", prob]]
                   
 -- | Creates the Terms and Definitions section. Can take a ('Just' 'Sentence') if needed or 'Nothing' if not. Also takes 'Concept's that contain the definitions.
 termDefnF :: Concept c => Maybe Sentence -> [c] -> Section
@@ -75,21 +78,21 @@ termDefnF' end otherContents = SRS.termAndDefn (intro : otherContents) []
 -- | General introduction for the Physical System Description section.
 physSystDesc :: Idea a => a -> [Sentence] -> LabelledContent -> [Contents] -> Section
 physSystDesc progName parts fg other = SRS.physSyst (intro : bullets : LlC fg : other) []
-  where intro = mkParagraph $ foldlSentCol [S "The", phrase physicalSystem `S.of_` short progName `sC`
-                S "as shown in", refS fg `sC` S "includes the following", plural element]
+  where intro = mkParagraph $ foldlSentCol [atStartNP (the physicalSystem) `S.of_` short progName `sC`
+                S "as shown in the", namedRef fg (S "figure"), S "below" `sC` S "includes the following", plural element]
         bullets = enumSimpleU 1 (short physSyst) parts
 
 -- | General constructor for the Goal Statement section. Takes the given inputs ('Sentence's) and the descriptions ('Contents').
 goalStmtF :: [Sentence] -> [Contents] -> Section
 goalStmtF givenInputs otherContents = SRS.goalStmt (intro:otherContents) []
-  where intro = mkParagraph $ S "Given" +:+ foldlList Comma List givenInputs `sC` S "the" +:+ 
-                plural goalStmt +: S "are"
+  where intro = mkParagraph $ S "Given" +:+ foldlList Comma List givenInputs `sC` 
+                pluralNP (the goalStmt) +: S "are"
 
 -- | General introduction for the Solution Characteristics Specification section. Takes the program name and a section of instance models. 
 solutionCharSpecIntro :: (Idea a) => a -> Section -> Contents
-solutionCharSpecIntro progName instModelSection = foldlSP [S "The", plural inModel, 
-  S "that govern", short progName, S "are presented in" +:+. 
-  refS instModelSection, S "The", phrase information, S "to understand", 
+solutionCharSpecIntro progName instModelSection = foldlSP [atStartNP' (the inModel), 
+  S "that govern", short progName, S "are presented in the" +:+. 
+  namedRef instModelSection (phrase inModel +:+ phrase DCD.sec), atStartNP (the information), S "to understand", 
   S "meaning" `S.the_ofThe` plural inModel, 
   S "and their derivation is also presented, so that the", plural inModel, 
   S "can be verified"]
@@ -104,7 +107,7 @@ assumpF otherContents = SRS.assumpt (assumpIntro : otherContents) []
       [S "This", phrase section_, S "simplifies the original", phrase problem,
        S "and helps in developing the", plural thModel, S "by filling in the", 
        S "missing", phrase information, S "for the" +:+. phrase physicalSystem,
-       S "The", plural assumption, S "refine the", phrase scope,
+       atStartNP' (the assumption), S "refine the", phrase scope,
        S "by providing more detail"]
 
 -- | Wrapper for 'thModelIntro'. Takes the program name and other 'Contents'.
@@ -150,11 +153,11 @@ inModelF probDes datDef theMod genDef otherContents = SRS.inModel
 -- | Creates a general Instance Model introduction. Requires four references to function. Nothing can be input into the last reference if only three tables are present.
 inModelIntro :: Section -> Section -> Section -> Section -> Contents
 inModelIntro r1 r2 r3 r4 = foldlSP [S "This", phrase section_, 
-  S "transforms the", phrase problem, S "defined in", refS r1,
+  S "transforms the", phrase problem, S "defined in the", namedRef r1 $ phrase problemDescription,
   S "into one which is expressed in mathematical terms. It uses concrete", 
-  plural symbol_, S "defined in", refS r2, S "to replace the abstract",
-  plural symbol_, S "in the", plural model, S "identified in", refS r3 `S.and_`
-  refS r4]
+  plural symbol_, S "defined in the", namedRef r2 $ plural dataDefn, S "to replace the abstract",
+  pluralNP $ symbol_ `inThePP` model, S "identified in", namedRef r3 (plural thModel) `S.and_`
+  (namedRef r4 $ plural genDefn)]
 
 -- | Constructor for Data Constraints section. Takes a trailing 'Sentence' (use 'EmptyS' if none) and data constraints.
 datConF :: (HasUncertainty c, Quantity c, Constrained c, HasReasVal c, MayHaveUnit c) => 
@@ -170,18 +173,18 @@ dataConstraintParagraph trailingSent = foldlSP_ [inputTableSent, physConsSent,
 
 -- | General 'Sentence' that describes the data constraints on the input variables.
 inputTableSent :: Sentence
-inputTableSent = foldlSent [refS $ inDataConstTbl ([] :: [UncertQ]), S "shows the",
-  plural datumConstraint, S "on the", phrase input_, plural variable]
+inputTableSent = foldlSent [S "The", namedRef (inDataConstTbl ([] :: [UncertQ])) $ plural datumConstraint +:+ phrase table_, S "shows the",
+  pluralNP (datumConstraint `onThePS` input_), plural variable]
 
 -- | General 'Sentence' that describes the physical constraints/limitations on the variables.
 physConsSent :: Sentence
-physConsSent = foldlSent [S "The", phrase column, S "for", phrase physical,
+physConsSent = foldlSent [atStartNP $ NP.the $ column `for` physical,
   plural constraint, S "gives the",  phrase physical, plural limitation,
   S "on the range" `S.of_` plural value, S "that can be taken by the", phrase variable]
 
 -- | General 'Sentence' that describes the uncertainty on the input variables.
 uncertSent :: Sentence
-uncertSent = foldlSent [S "The", phrase uncertainty, phrase column,
+uncertSent = foldlSent [atStartNP (the uncertainty), phrase column,
   S "provides an estimate of the confidence with which the", phrase physical,
   plural quantity +:+. S "can be measured", S "This", phrase information,
   S "would be part of the", phrase input_, S "if one were performing an",
@@ -189,20 +192,20 @@ uncertSent = foldlSent [S "The", phrase uncertainty, phrase column,
 
 -- | General 'Sentence' that describes some conservative constraints on the model.
 conservConsSent :: Sentence
-conservConsSent = foldlSent [S "The", plural constraint `S.are` S "conservative" `sC`
+conservConsSent = foldlSent [atStartNP' (the constraint) `S.are` S "conservative" `sC`
   S "to give", phrase user `S.the_ofThe` phrase model,
   S "the flexibility to experiment with unusual situations"]
 
 -- | General 'Sentence' that describes the typical values.
 typValSent :: Sentence
-typValSent = foldlSent [S "The", phrase column `S.of_` S "typical",
+typValSent = foldlSent [atStartNP (the column) `S.of_` S "typical",
   plural value `S.is` S "intended to provide a feel for a common scenario"]
 
 -- | General 'Sentence' that describes some auxiliary specifications of the system.
 auxSpecSent :: Sentence
-auxSpecSent = foldlSent [refS $ SRS.valsOfAuxCons [] [], S "gives",
-  plural value `S.the_ofThe` phrase specification, plural parameter, S "used in",
-  refS $ inDataConstTbl ([] :: [UncertQ])]
+auxSpecSent = foldlSent [S "The", namedRef (SRS.valsOfAuxCons [] []) $ S "auxiliary constants section", S "gives",
+  plural value `S.the_ofThe` phrase specification, plural parameter, S "used in the",
+  namedRef (inDataConstTbl ([] :: [UncertQ])) $ plural datumConstraint +:+ phrase table_]
 
 -- | Creates a Data Constraints table. Takes in Columns, reference, and a label.
 mkDataConstraintTable :: [(Sentence, [Sentence])] -> String -> Sentence -> LabelledContent
@@ -250,7 +253,7 @@ propCorSolF c  con = SRS.propCorSol ([propsIntro, LlC $ outDataConstTbl c] ++ co
 
 -- | General 'Sentence' that states there are no properties of a correct solution. Used in 'propCorSolF'.
 noPropsSent :: Sentence
-noPropsSent = foldlSent [S "There are no", plural property, S "of a", phrase corSol]
+noPropsSent = foldlSent [S "There are no", pluralNP $ property `ofAPS` corSol]
 
 -- | Creates the Properties of a Correct Solution introduction.
 propsIntro :: Contents
@@ -258,5 +261,5 @@ propsIntro = foldlSP_ [outputTableSent, physConsSent]
 
 -- | Outputs a data constraint table as a 'Sentence'.
 outputTableSent :: Sentence
-outputTableSent = foldlSent [refS $ outDataConstTbl ([] :: [UncertQ]), S "shows the",
-  plural datumConstraint, S "on the", phrase output_, plural variable]
+outputTableSent = foldlSent [S "The", namedRef (outDataConstTbl ([] :: [UncertQ])) $ plural datumConstraint +:+ phrase table_, S "shows the",
+  pluralNP (datumConstraint `onThePS` output_), plural variable]

--- a/code/drasil-docLang/Drasil/Sections/SpecificSystemDescription.hs
+++ b/code/drasil-docLang/Drasil/Sections/SpecificSystemDescription.hs
@@ -92,7 +92,7 @@ goalStmtF givenInputs otherContents = SRS.goalStmt (intro:otherContents) []
 solutionCharSpecIntro :: (Idea a) => a -> Section -> Contents
 solutionCharSpecIntro progName instModelSection = foldlSP [atStartNP' (the inModel), 
   S "that govern", short progName, S "are presented in the" +:+. 
-  namedRef instModelSection (phrase inModel +:+ phrase DCD.sec), atStartNP (the information), S "to understand", 
+  namedRef instModelSection (titleize inModel +:+ titleize DCD.sec), atStartNP (the information), S "to understand", 
   S "meaning" `S.the_ofThe` plural inModel, 
   S "and their derivation is also presented, so that the", plural inModel, 
   S "can be verified"]
@@ -173,7 +173,7 @@ dataConstraintParagraph trailingSent = foldlSP_ [inputTableSent, physConsSent,
 
 -- | General 'Sentence' that describes the data constraints on the input variables.
 inputTableSent :: Sentence
-inputTableSent = foldlSent [S "The", namedRef (inDataConstTbl ([] :: [UncertQ])) $ plural datumConstraint +:+ phrase table_, S "shows the",
+inputTableSent = foldlSent [S "The", namedRef (inDataConstTbl ([] :: [UncertQ])) $ titleize' datumConstraint +:+ titleize table_, S "shows the",
   pluralNP (datumConstraint `onThePS` input_), plural variable]
 
 -- | General 'Sentence' that describes the physical constraints/limitations on the variables.
@@ -203,9 +203,9 @@ typValSent = foldlSent [atStartNP (the column) `S.of_` S "typical",
 
 -- | General 'Sentence' that describes some auxiliary specifications of the system.
 auxSpecSent :: Sentence
-auxSpecSent = foldlSent [S "The", namedRef (SRS.valsOfAuxCons [] []) $ S "auxiliary constants section", S "gives",
+auxSpecSent = foldlSent [S "The", namedRef (SRS.valsOfAuxCons [] []) $ S "auxiliary constants", S "give",
   plural value `S.the_ofThe` phrase specification, plural parameter, S "used in the",
-  namedRef (inDataConstTbl ([] :: [UncertQ])) $ plural datumConstraint +:+ phrase table_]
+  namedRef (inDataConstTbl ([] :: [UncertQ])) $ titleize' datumConstraint +:+ titleize table_]
 
 -- | Creates a Data Constraints table. Takes in Columns, reference, and a label.
 mkDataConstraintTable :: [(Sentence, [Sentence])] -> String -> Sentence -> LabelledContent
@@ -261,5 +261,5 @@ propsIntro = foldlSP_ [outputTableSent, physConsSent]
 
 -- | Outputs a data constraint table as a 'Sentence'.
 outputTableSent :: Sentence
-outputTableSent = foldlSent [S "The", namedRef (outDataConstTbl ([] :: [UncertQ])) $ plural datumConstraint +:+ phrase table_, S "shows the",
+outputTableSent = foldlSent [S "The", namedRef (outDataConstTbl ([] :: [UncertQ])) $ titleize' datumConstraint +:+ titleize table_, S "shows the",
   pluralNP (datumConstraint `onThePS` output_), plural variable]

--- a/code/drasil-docLang/Drasil/Sections/SpecificSystemDescription.hs
+++ b/code/drasil-docLang/Drasil/Sections/SpecificSystemDescription.hs
@@ -79,7 +79,7 @@ termDefnF' end otherContents = SRS.termAndDefn (intro : otherContents) []
 physSystDesc :: Idea a => a -> [Sentence] -> LabelledContent -> [Contents] -> Section
 physSystDesc progName parts fg other = SRS.physSyst (intro : bullets : LlC fg : other) []
   where intro = mkParagraph $ foldlSentCol [atStartNP (the physicalSystem) `S.of_` short progName `sC`
-                S "as shown in the", namedRef fg (S "figure"), S "below" `sC` S "includes the following", plural element]
+                S "as shown in the", refS fg, S "below" `sC` S "includes the following", plural element]
         bullets = enumSimpleU 1 (short physSyst) parts
 
 -- | General constructor for the Goal Statement section. Takes the given inputs ('Sentence's) and the descriptions ('Contents').

--- a/code/drasil-docLang/Drasil/Sections/TraceabilityMandGs.hs
+++ b/code/drasil-docLang/Drasil/Sections/TraceabilityMandGs.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE PostfixOperators #-}
 module Drasil.Sections.TraceabilityMandGs (generateTraceTable,tvAssumps,
   tvDataDefns, tvGenDefns, tvTheoryModels, tvInsModels, tvGoals, tvReqs,
   tvChanges, traceMatAssumpAssump, traceMatAssumpOther, traceMatRefinement, traceMatOtherReq,
@@ -14,6 +15,7 @@ import qualified Data.Drasil.TheoryConcepts as Doc (genDefn, dataDefn, inModel, 
 import Database.Drasil(SystemInformation, _sysinfodb, gendefTable, dataDefnTable,
   insmodelTable, theoryModelTable)
 import Language.Drasil
+import Utils.Drasil.Concepts
 
 -- | Makes a Traceability Table/Matrix that contains Items of Different Sections.
 generateTraceTable :: SystemInformation -> LabelledContent
@@ -50,15 +52,15 @@ tvChanges = traceViewCC chgProbDom
 
 -- | Assumptions on the assumptions of a traceabiliy matrix.
 traceMatAssumpAssump :: TraceConfig
-traceMatAssumpAssump = TraceConfig "TraceMatAvsA" [plural assumption +:+
-  S "on the" +:+. plural assumption] (titleize' assumption +:+.
+traceMatAssumpAssump = TraceConfig "TraceMatAvsA" [(pluralNP (assumption
+  `onThePP` assumption) !.)] (titleize' assumption +:+.
   S "dependence of each other") [tvAssumps] [tvAssumps]
 
 -- | Other assumptions of the traceability matrix
 traceMatAssumpOther :: TraceConfig
 traceMatAssumpOther = TraceConfig "TraceMatAvsAll" [plural Doc.dataDefn,
   plural Doc.thModel, plural Doc.genDefn, plural Doc.inModel, plural requirement,
-  plural likelyChg, plural unlikelyChg +:+ S "on the" +:+. plural assumption]
+  plural likelyChg, (pluralNP (unlikelyChg `onThePP` assumption) !.)]
   (titleize' assumption +:+ S "and Other" +:+ titleize' item) [tvAssumps]
   [tvDataDefns, tvTheoryModels, tvGenDefns, tvInsModels, tvReqs, tvChanges]
 

--- a/code/drasil-example/Drasil/DblPendulum/GenDefs.hs
+++ b/code/drasil-example/Drasil/DblPendulum/GenDefs.hs
@@ -237,13 +237,13 @@ periodPendDerivSents :: [Sentence]
 periodPendDerivSents = [periodPendDerivSent1, periodPendDerivSent2]
 
 periodPendDerivSent1, periodPendDerivSent2 :: Sentence
-periodPendDerivSent1 = atStartNP (period `the_ofThe` pendulum) +:+ S "can be defined from" +:+
-                refS angFrequencyGD +:+ phrase equation
-periodPendDerivSent2 =  S "Therefore from the" +:+ phrase equation +:+ refS angFrequencyDD `sC` S "we have"
+periodPendDerivSent1 = atStartNP (period `the_ofThe` pendulum) +:+ S "can be defined from the general definition for the" +:+ phrase equation `S.of_`
+                namedRef angFrequencyGD (phrase angFrequencyDD)
+periodPendDerivSent2 =  S "Therefore from the data definition of the" +:+ phrase equation `S.for` namedRef angFrequencyDD (phrase angFrequencyDD) `sC` S "we have"
 
 periodPendNotes :: Sentence
-periodPendNotes = atStartNP (NP.the (frequency `and_` period)) +:+ S "are defined in" +:+ refS frequencyDD +:+
-        refS periodSHMDD +:+ S "respectively"
+periodPendNotes = atStartNP (NP.the (frequency `and_` period)) +:+ S "are defined in the data definitions for" +:+ namedRef frequencyDD (phrase frequencyDD) `S.and_`
+        namedRef periodSHMDD (phrase periodSHMDD) +:+ S "respectively"
 
 -- References --
 genDefRefs :: [Reference]

--- a/code/drasil-example/Drasil/DblPendulum/IMods.hs
+++ b/code/drasil-example/Drasil/DblPendulum/IMods.hs
@@ -52,7 +52,7 @@ angularDisplacementDerivSent1, angularDisplacementDerivSent2, angularDisplacemen
 
 angularDisplacementDerivSent1 = foldlSentCol [S "When", phraseNP (the pendulum) `S.is` S "displaced to an", phrase iAngle `S.and_` S "released" `sC`
                                        phraseNP (the pendulum), S "swings back and forth with periodic" +:+. phrase motion,
-                                       S "By applying", phrase newtonSLR `S.in_` refS newtonSLR `sC`
+                                       S "By applying", namedRef newtonSLR (phrase newtonSLR) `sC`
                                        phraseNP (NP.the (equation `of_` motion) `NP.for` the pendulum), S "may be obtained"]
        
  

--- a/code/drasil-example/Drasil/DblPendulum/Requirements.hs
+++ b/code/drasil-example/Drasil/DblPendulum/Requirements.hs
@@ -9,7 +9,7 @@ import qualified Utils.Drasil.Sentence as S
 
 import Data.Drasil.Concepts.Computation (inValue)
 import Data.Drasil.Concepts.Documentation (datumConstraint, funcReqDom,
-        output_, value,  nonFuncReqDom, code, property, environment)
+        output_, value,  nonFuncReqDom, code, environment, propOfCorSol)
 --  likelyChg, mg, mis, module_, nonFuncReqDom,
 --   requirement, srs, traceyMatrix, unlikelyChg, value, vavPlan)
 import Data.Drasil.Concepts.Math (calculation)
@@ -32,8 +32,7 @@ outputValues = cic "outputValues" outputValuesDesc "Output-Values" funcReqDom
 verifyInptValsDesc, calcAngPosDesc, outputValuesDesc :: Sentence
 
 verifyInptValsDesc = foldlSent [S "Check the entered", plural inValue,
-  S "to ensure that they do not exceed the", plural datumConstraint,
-  S "mentioned in" +:+. refS (datCon ([]::[Contents]) ([]::[Section])), 
+  S "to ensure that they do not exceed the" +:+. namedRef (datCon ([]::[Contents]) ([]::[Section])) (plural datumConstraint),
   S "If any of the", plural inValue, S "are out of bounds" `sC`
   S "an", phrase errMsg, S "is displayed" `S.andThe` plural calculation, S "stop"]
 
@@ -56,7 +55,7 @@ nonFuncReqs = [correct, portable]
 correct :: ConceptInstance
 correct = cic "correct" (foldlSent [
  atStartNP' (output_ `the_ofThePS` code), S "have the",
- plural property, S "described in", refS (propCorSol [] [])
+ namedRef (propCorSol [] []) (plural propOfCorSol)
  ]) "Correct" nonFuncReqDom
 
 portable :: ConceptInstance

--- a/code/drasil-example/Drasil/GamePhysics/Body.hs
+++ b/code/drasil-example/Drasil/GamePhysics/Body.hs
@@ -26,7 +26,8 @@ import Data.Drasil.Concepts.Documentation as Doc (assumption, concept,
   input_, interface, object, organization, physical,
   physicalSim, physics, problem, product_, project, quantity, realtime,
   section_, simulation, software, softwareSys, srsDomains, system,
-  systemConstraint, sysCont, task, template, user, doccon, doccon', property)
+  systemConstraint, sysCont, task, template, user, doccon, doccon',
+  property, problemDescription)
 import qualified Data.Drasil.Concepts.Documentation as Doc (srs)
 import Data.Drasil.TheoryConcepts as Doc (dataDefn, inModel)
 import Data.Drasil.Concepts.Education (frstYr, highSchoolCalculus,
@@ -250,15 +251,15 @@ sysCtxUsrResp = [S "Provide initial" +:+ pluralNP (condition `ofThePS`
   S "applied to them",
   S "Ensure application programming" +:+ phrase interface +:+
   S "use complies with the" +:+ phrase user +:+. phrase guide,
-  S "Ensure required" +:+ phrase software +:+ plural assumption +:+
-  sParen (refS $ SRS.assumpt ([]::[Contents]) ([]::[Section])) +:+ 
+  S "Ensure required" +:+
+  namedRef (SRS.assumpt ([]::[Contents]) ([]::[Section])) (phrase software +:+ plural assumption) +:+
   S "are appropriate for any particular" +:+
   phrase problem +:+ phraseNP (the software) +:+. S "addresses"]
 
 sysCtxSysResp :: [Sentence]
 sysCtxSysResp = [S "Determine if the" +:+ pluralNP (input_ `and_PS`
-    simulation) +:+ S "state satisfy the required" +:+
-    (phrase physical `S.and_` plural systemConstraint) +:+. sParen(refS $ SRS.datCon ([]::[Contents]) ([]::[Section])),
+    simulation) +:+ S "state satisfy the required" +:+.
+    namedRef (SRS.datCon ([]::[Contents]) ([]::[Section])) (phrase physical `S.and_` plural systemConstraint),
   S "Calculate the new state of all" +:+ plural CP.rigidBody +:+
     S "within the" +:+ phrase simulation +:+ S "at each" +:+
     phrase simulation +:+. S "step",
@@ -312,8 +313,8 @@ probDescIntro = foldlSent_
   S "is very costly" `sC` S "presenting barriers of entry which make it difficult for",
   phrase game, S "developers to include", phrase Doc.physics, S "in their" +:+. 
   plural product_, S "There are a few free" `sC` phrase openSource `S.and_` S "high quality",
-  plural physLib, S "available to be used for", phrase consumer, plural product_,
-  sParen (refS $ SRS.offShelfSol ([] :: [Contents]) ([] :: [Section]))]
+  plural physLib, namedRef (SRS.offShelfSol ([] :: [Contents]) ([] :: [Section])) (S "available"),
+  S "to be used for", phrase consumer, plural product_]
   
 -----------------------------------------
 -- 4.1.1 : Terminology and Definitions --
@@ -413,7 +414,7 @@ offShelfSolsIntro, offShelfSols2DList,
   offShelfSolsMid, offShelfSols3DList :: Contents
 
 offShelfSolsIntro = mkParagraph $ foldlSentCol 
-  [S "As mentioned in", refS (SRS.probDesc [] []) `sC`
+  [S "As mentioned in the", namedRef (SRS.probDesc [] []) (phrase problemDescription) `sC`
   S "there already exist free", phrase openSource, phrase game +:+.
   plural physLib, S "Similar", getAcc twoD, plural physLib, S "are"]
 

--- a/code/drasil-example/Drasil/GamePhysics/Body.hs
+++ b/code/drasil-example/Drasil/GamePhysics/Body.hs
@@ -313,8 +313,8 @@ probDescIntro = foldlSent_
   S "is very costly" `sC` S "presenting barriers of entry which make it difficult for",
   phrase game, S "developers to include", phrase Doc.physics, S "in their" +:+. 
   plural product_, S "There are a few free" `sC` phrase openSource `S.and_` S "high quality",
-  plural physLib, namedRef (SRS.offShelfSol ([] :: [Contents]) ([] :: [Section])) (S "available"),
-  S "to be used for", phrase consumer, plural product_]
+  namedRef (SRS.offShelfSol ([] :: [Contents]) ([] :: [Section])) (plural physLib),
+  S "available to be used for", phrase consumer, plural product_]
   
 -----------------------------------------
 -- 4.1.1 : Terminology and Definitions --

--- a/code/drasil-example/Drasil/GamePhysics/GenDefs.hs
+++ b/code/drasil-example/Drasil/GamePhysics/GenDefs.hs
@@ -92,7 +92,7 @@ accelGravityDerivSentences = map foldlSentCol [accelGravityDerivSentence1,
  accelGravityDerivSentence5]
 
 accelGravityDerivSentence1 :: [Sentence]
-accelGravityDerivSentence1 = [S "From", namedRef newtonLUG (phrase newtonLUG), S "we have"]
+accelGravityDerivSentence1 = [S "From", namedRef newtonLUG (S "Newton's law of universal gravitation") `sC` S "we have"]
 
 
 accelGravityDerivSentence2 :: [Sentence]

--- a/code/drasil-example/Drasil/GamePhysics/GenDefs.hs
+++ b/code/drasil-example/Drasil/GamePhysics/GenDefs.hs
@@ -92,7 +92,7 @@ accelGravityDerivSentences = map foldlSentCol [accelGravityDerivSentence1,
  accelGravityDerivSentence5]
 
 accelGravityDerivSentence1 :: [Sentence]
-accelGravityDerivSentence1 = [S "From Newton's law of universal gravitation", sParen(refS newtonLUG), S "we have"]
+accelGravityDerivSentence1 = [S "From", namedRef newtonLUG (phrase newtonLUG), S "we have"]
 
 
 accelGravityDerivSentence2 :: [Sentence]

--- a/code/drasil-example/Drasil/GamePhysics/Requirements.hs
+++ b/code/drasil-example/Drasil/GamePhysics/Requirements.hs
@@ -9,7 +9,7 @@ import qualified Utils.Drasil.Sentence as S
 import Drasil.DocLang (inReq)
 import qualified Drasil.DocLang.SRS as SRS (solCharSpec)
 import Data.Drasil.Concepts.Documentation as Doc (body, funcReqDom, input_, 
-  nonFuncReqDom, output_, physicalConstraint, physicalSim, property)
+  nonFuncReqDom, output_, physicalConstraint, physicalSim, property, solutionCharSpec)
 
 import qualified Data.Drasil.Concepts.Physics as CP (collision, elasticity, 
   friction, rigidBody, space)
@@ -69,8 +69,8 @@ inputSurfacePropsDesc = foldlSent [S "Input", pluralNP (combineNINI CM.surface
   phrase CP.elasticity]
 
 verifyPhysConsDesc = foldlSent [S "Verify that the", plural input_,
-  S "satisfy the required", plural physicalConstraint, S "from", 
-  refS (SRS.solCharSpec [] [])]
+  S "satisfy the required", plural physicalConstraint, S "from the", 
+  namedRef (SRS.solCharSpec [] []) (phrase solutionCharSpec)]
 
 calcTransOverTimeDesc = requirementS QP.position QP.velocity 
   (S "acted upon by a" +:+ phrase QP.force)
@@ -78,7 +78,7 @@ calcTransOverTimeDesc = requirementS QP.position QP.velocity
 calcRotOverTimeDesc = requirementS' QM.orientation QP.angularVelocity
 
 deterCollsDesc = foldlSent [S "Determine if any of the", 
-  plural CP.rigidBody, S "in the", phrase CP.space, 
+  pluralNP (CP.rigidBody `inThePS` CP.space), 
   S "have collided"]
 
 deterCollRespOverTimeDesc = requirementS QP.position QP.velocity 

--- a/code/drasil-example/Drasil/GlassBR/Body.hs
+++ b/code/drasil-example/Drasil/GlassBR/Body.hs
@@ -276,8 +276,8 @@ sysCtxUsrResp = [S "Provide the" +:+ plural inDatum +:+ S "related to the" +:+
   phraseNP (glaSlab `and_` blastTy) `sC` S "ensuring no errors in the" +:+
   plural datum +:+. S "entry",
   S "Ensure that consistent units are used for" +:+. pluralNP (combineNINI input_ variable),
-  S "Ensure required" +:+ pluralNP (combineNINI software assumption) +:+
-    sParen (refS $ SRS.assumpt ([]::[Contents]) ([]::[Section]))
+  S "Ensure required" +:+ 
+  namedRef (SRS.assumpt [] []) (pluralNP (combineNINI software assumption))
     +:+ S "are appropriate for any particular" +:+
     phrase problem +:+ S "input to the" +:+. phrase software]
 

--- a/code/drasil-example/Drasil/GlassBR/Requirements.hs
+++ b/code/drasil-example/Drasil/GlassBR/Requirements.hs
@@ -55,7 +55,7 @@ inReqDesc = foldlList Comma List [pluralNP (NP.the (combineNINI glass dimension)
   phraseNP (type_ `of_` glass), phrase pbTolfail, pluralNP (characteristic `the_ofThePS` blast)]
 
 sysSetValsFollowingAssumpsDesc = foldlSent [atStartNP (the system), S "shall set the known",
-    plural value, S "as described in", refS sysSetValsFollowingAssumpsTable]
+    plural value, S "as described in the table for", namedRef sysSetValsFollowingAssumpsTable (S "Required Assignments")]
 
 sysSetValsFollowingAssumpsTable :: LabelledContent
 sysSetValsFollowingAssumpsTable = mkValsSourceTable (mkQRTupleRef r2AQs r2ARs ++ mkQRTuple r2DDs) "ReqAssignments"
@@ -69,8 +69,7 @@ sysSetValsFollowingAssumpsTable = mkValsSourceTable (mkQRTupleRef r2AQs r2ARs ++
 -- the assumption(s) that're being followed? (Issue #349)
 
 checkInputWithDataConsDesc = foldlSent [atStartNP (the system), S "shall check the entered",
-  plural inValue, S "to ensure that they do not exceed the", plural datumConstraint,
-  S "mentioned in" +:+. refS (datCon ([]::[Contents]) ([]::[Section])), 
+  plural inValue, S "to ensure that they do not exceed the" +:+. namedRef (datCon [] []) (plural datumConstraint), 
   S "If any" `S.ofThe` plural inValue, S "are out" `S.of_` S "bounds" `sC`
   S "an", phrase errMsg, S "is displayed" `S.andThe` plural calculation, S "stop"]
 
@@ -85,7 +84,7 @@ checkGlassSafetyDesc = foldlSent_ [S "If", eS (sy isSafePb $&& sy isSafeLR),
   phraseNP (the message), Quote (notSafe ^. defn)]
 
 outputValuesDesc :: Sentence
-outputValuesDesc = foldlSent [titleize output_, pluralNP (the value), S "from", refS outputValuesTable]
+outputValuesDesc = foldlSent [titleize output_, pluralNP (the value), S "from the table for", namedRef outputValuesTable (S "Required Outputs")]
 
 outputValuesTable :: LabelledContent
 outputValuesTable = mkValsSourceTable (mkQRTuple iMods ++ mkQRTuple r6DDs) "ReqOutputs"

--- a/code/drasil-example/Drasil/NoPCM/Requirements.hs
+++ b/code/drasil-example/Drasil/NoPCM/Requirements.hs
@@ -28,8 +28,8 @@ import Drasil.NoPCM.Unitals (inputs)
 --
 inputInitVals :: ConceptInstance
 inputInitVals = cic "inputInitVals" (foldlSent [
-  titleize input_, S "the following", plural value, S "described in",
-  refS inputInitValsTable `sC` S "which define", inReqDesc])
+  titleize input_, S "the following", plural value, S "described in the table for",
+  namedRef inputInitValsTable (S "Required Inputs")`sC` S "which define", inReqDesc])
   "Input-Initial-Values" funcReqDom
 
 --

--- a/code/drasil-example/Drasil/PDController/Requirements.hs
+++ b/code/drasil-example/Drasil/PDController/Requirements.hs
@@ -1,7 +1,7 @@
 {-#LANGUAGE PostfixOperators#-}
 module Drasil.PDController.Requirements where
 
-import Data.Drasil.Concepts.Documentation (funcReqDom, nonFuncReqDom)
+import Data.Drasil.Concepts.Documentation (funcReqDom, nonFuncReqDom, datumConstraint)
 
 import Drasil.DocLang (inReq)
 import Drasil.DocLang.SRS (datCon)
@@ -27,8 +27,8 @@ verifyInputsDesc, calculateValuesDesc, outputValuesDesc :: Sentence
 verifyInputsDesc
   = foldlSent_
       [S "Ensure that the input values are within the",
-         S "limits specified in"
-         +:+. refS (datCon ([] :: [Contents]) ([] :: [Section]))]
+         S "limits specified in the"
+         +:+. namedRef (datCon [] []) (plural datumConstraint)]
 
 calculateValuesDesc
   = foldlSent

--- a/code/drasil-example/Drasil/Projectile/Assumptions.hs
+++ b/code/drasil-example/Drasil/Projectile/Assumptions.hs
@@ -11,7 +11,7 @@ import qualified Utils.Drasil.Sentence as S
 
 import qualified Drasil.DocLang.SRS as SRS (valsOfAuxCons)
 
-import Data.Drasil.Concepts.Documentation (assumpDom, value)
+import Data.Drasil.Concepts.Documentation (assumpDom, value, consVals)
 import Data.Drasil.Concepts.Math (cartesian, xAxis, xDir, yAxis, yDir, direction, positive)
 import Data.Drasil.Concepts.PhysicalProperties (mass)
 import Data.Drasil.Concepts.Physics (acceleration, collision, distance, gravity, time, twoD)
@@ -93,7 +93,7 @@ timeStartZeroDesc = atStart time +:+. S "starts at zero"
 gravAccelValueDesc :: Sentence
 gravAccelValueDesc = atStartNP (the acceleration) +:+ S "due to" +:+
   phrase gravity +:+ S "is assumed to have the" +:+ phrase value +:+ 
-  S "provided in" +:+. refS (SRS.valsOfAuxCons ([]::[Contents]) ([]::[Section]))
+  S "provided in the section for" +:+. namedRef (SRS.valsOfAuxCons [] []) (titleize consVals)
 
 -- References --
 assumpRefs :: [Reference]

--- a/code/drasil-example/Drasil/Projectile/Requirements.hs
+++ b/code/drasil-example/Drasil/Projectile/Requirements.hs
@@ -10,7 +10,7 @@ import Drasil.DocLang (inReq)
 import Data.Drasil.Concepts.Computation (inValue)
 import Data.Drasil.Concepts.Documentation (assumption, code, datumConstraint,
   environment, funcReqDom, likelyChg, mg, mis, module_, nonFuncReqDom, output_,
-  property, requirement, srs, traceyMatrix, unlikelyChg, value, vavPlan)
+  property, requirement, srs, traceyMatrix, unlikelyChg, value, vavPlan, propOfCorSol)
 import Data.Drasil.Concepts.Math (calculation)
 import Data.Drasil.Concepts.Software (errMsg)
 import Data.Drasil.TheoryConcepts (dataDefn, genDefn, inModel, thModel)
@@ -31,8 +31,7 @@ outputValues = cic "outputValues" outputValuesDesc "Output-Values"       funcReq
 
 verifyParamsDesc, calcValuesDesc, outputValuesDesc :: Sentence
 verifyParamsDesc = foldlSent [S "Check the entered", plural inValue,
-  S "to ensure that they do not exceed the", plural datumConstraint,
-  S "mentioned in" +:+. refS (datCon ([]::[Contents]) ([]::[Section])), 
+  S "to ensure that they do not exceed the" +:+. namedRef (datCon [] []) (plural datumConstraint),
   S "If any of the", plural inValue, S "are out of bounds" `sC`
   S "an", phrase errMsg, S "is displayed" `S.andThe` plural calculation, S "stop"]
 calcValuesDesc = foldlSent [S "Calculate the following" +: plural value,
@@ -53,7 +52,7 @@ nonfuncReqs = [correct, verifiable, understandable, reusable, maintainable, port
 correct :: ConceptInstance
 correct = cic "correct" (foldlSent [
   atStartNP' (output_ `the_ofThePS` code), S "have the",
-  plural property, S "described in", refS (propCorSol [] [])
+  plural property, S "described in", namedRef (propCorSol [] []) (titleize' propOfCorSol)
   ]) "Correct" nonFuncReqDom
  
 verifiable :: ConceptInstance

--- a/code/drasil-example/Drasil/SSP/Body.hs
+++ b/code/drasil-example/Drasil/SSP/Body.hs
@@ -29,11 +29,11 @@ import qualified Drasil.DocLang.SRS as SRS (inModel, assumpt,
   genDefn, dataDefn, datCon)
 
 import Data.Drasil.Concepts.Documentation as Doc (analysis, assumption,
-  constant, constraint, document, effect, endUser, environment,
+  constant, document, effect, endUser, environment,
   input_, interest, loss, method_, organization,
   physical, physics, problem, software,
   softwareSys, srsDomains, symbol_, sysCont, system,
-  template, type_, user, value, variable, doccon, doccon')
+  template, type_, user, value, variable, doccon, doccon', datumConstraint)
 import qualified Data.Drasil.Concepts.Documentation as Doc (srs)
 import Data.Drasil.TheoryConcepts as Doc (inModel)
 import Data.Drasil.Concepts.Education (solidMechanics, undergraduate, educon)
@@ -274,9 +274,8 @@ sysCtxUsrResp = [S "Provide" +:+ phraseNP (the input_) +:+ S "data related to" +
   S "ensuring conformation to" +:+ phrase input_ +:+ S "data format" +:+
   S "required by" +:+ short ssp,
   S "Ensure that consistent units are used for" +:+ pluralNP (combineNINI input_ variable),
-  S "Ensure required" +:+ pluralNP (combineNINI software assumption) +:+ sParen ( 
-  refS $ SRS.assumpt ([]::[Contents]) ([]::[Section])) +:+ S "are" +:+ 
-  S "appropriate for the" +:+ phrase problem +:+ S "to which the" +:+ 
+  S "Ensure required" +:+ namedRef (SRS.assumpt [] []) (pluralNP (combineNINI software assumption)) 
+  +:+ S "are" +:+ S "appropriate for the" +:+ phrase problem +:+ S "to which the" +:+ 
   phrase user +:+ S "is applying the" +:+ phrase software]
   
 sysCtxSysResp :: [Sentence]
@@ -284,7 +283,7 @@ sysCtxSysResp = [S "Detect data" +:+ phrase type_ +:+ S "mismatch, such as" +:+
   S "a string of characters" +:+ phrase input_ +:+ S "instead of a floating" +:+
   S "point" +:+ phrase number,
   S "Verify that the" +:+ plural input_ +:+ S "satisfy the required" +:+
-  phrase physical `S.and_` S "other data" +:+ plural constraint +:+ sParen (refS $ SRS.datCon ([]::[Contents]) ([]::[Section])),
+  phrase physical `S.and_` S "other" +:+ namedRef (SRS.datCon [] []) (plural datumConstraint),
   S "Identify the" +:+ phrase crtSlpSrf +:+ S "within the possible" +:+
   phrase input_ +:+ S "range",
   S "Find the" +:+ phrase fsConcept +:+ S "for the" +:+ phrase slope,

--- a/code/drasil-example/Drasil/SSP/Requirements.hs
+++ b/code/drasil-example/Drasil/SSP/Requirements.hs
@@ -12,7 +12,7 @@ import Data.Drasil.Concepts.Computation (inDatum)
 import Data.Drasil.Concepts.Documentation (assumption, code,
   datum, funcReqDom, input_, likelyChg, mg, mis, module_, name_, nonFuncReqDom,
   output_, physicalConstraint, property, requirement, srs, symbol_,
-  traceyMatrix, unlikelyChg, user, value)
+  traceyMatrix, unlikelyChg, user, value, propOfCorSol)
 import Data.Drasil.Concepts.Physics (twoD)
 import Data.Drasil.TheoryConcepts (dataDefn, genDefn, inModel, thModel)
 
@@ -37,13 +37,13 @@ readAndStore, verifyInput, determineCritSlip, verifyOutput, displayInput,
   writeToFile :: ConceptInstance
 
 readAndStore = cic "readAndStore" ( foldlSent [
-  S "Read the", plural input_ `sC` S "shown in", 
-  refS inputDataTable `sC` S "and store the", plural datum]) 
+  S "Read the", plural input_ `sC` S "shown in the table", 
+  namedRef inputDataTable (S "Required Inputs") `sC` S "and store the", plural datum]) 
   "Read-and-Store" funcReqDom
 
 verifyInput = cic "verifyInput" ( foldlSent [
   S "Verify that the", plural inDatum, S "lie within the",
-  plural physicalConstraint, S "shown in", refS (datCon [] [])])
+  namedRef (datCon [] []) (plural physicalConstraint)])
   "Verify-Input" funcReqDom
 
 determineCritSlip = cic "determineCritSlip" ( foldlSent [
@@ -56,7 +56,7 @@ determineCritSlip = cic "determineCritSlip" ( foldlSent [
 
 verifyOutput = cic "verifyOutput" ( foldlSent [
   S "Verify that the", phrase fsMin `S.and_` phrase crtSlpSrf, S "satisfy the",
-  plural physicalConstraint, S "shown in", refS (propCorSol [] [])])
+  plural physicalConstraint, S "shown in", namedRef (propCorSol [] []) (titleize' propOfCorSol)])
   "Verify-Output" funcReqDom
 
 displayInput = cic "displayInput" ( foldlSent [

--- a/code/drasil-example/Drasil/SWHS/Requirements.hs
+++ b/code/drasil-example/Drasil/SWHS/Requirements.hs
@@ -13,7 +13,7 @@ import Data.Drasil.Concepts.Computation (inValue)
 import Data.Drasil.Concepts.Documentation (assumption, code, condition,
   funcReqDom, input_, likelyChg, mg, mis, module_, nonFuncReqDom, output_,
   physicalConstraint, property, requirement, simulation, srs, traceyMatrix,
-  unlikelyChg, value, vavPlan)
+  unlikelyChg, value, vavPlan, propOfCorSol)
 import Data.Drasil.Concepts.Math (parameter)
 import Data.Drasil.Concepts.PhysicalProperties (materialProprty)
 import Data.Drasil.Concepts.Thermodynamics as CT (lawConsEnergy, melting)
@@ -69,7 +69,7 @@ findMassConstruct fr m ims ddefs = cic "findMass" (foldlSent [
 --
 checkWithPhysConsts = cic "checkWithPhysConsts" (foldlSent [
   S "Verify that", pluralNP (the input_), S "satisfy the required",
-  plural physicalConstraint, S "shown in", refS (datCon ([]::[Contents]) ([]::[Section]))])
+  namedRef (datCon [] []) (plural physicalConstraint)])
   "Check-Input-with-Physical_Constraints" funcReqDom
 --
 outputInputDerivVals = oIDQConstruct oIDQVals
@@ -119,7 +119,7 @@ verifyEnergyOutput = cic "verifyEnergyOutput" (foldlSent [
   S "Verify that the", phrase energy, plural output_,
   sParen (ch watE :+: sParen (ch time) `S.and_` ch pcmE :+:
   sParen (ch time)), S "follow the", phrase CT.lawConsEnergy `sC`
-  S "as outlined in", refS (propCorSol [] []) `sC`
+  S "as outlined in", namedRef (propCorSol [] []) (titleize' propOfCorSol) `sC`
   S "with relative error no greater than", ch consTol])
   "Verify-Energy-Output-Follow-Conservation-of-Energy" funcReqDom
 --
@@ -150,7 +150,7 @@ nfRequirements = [correct, verifiable, understandable, reusable, maintainable]
 correct :: ConceptInstance
 correct = cic "correct" (foldlSent [atStartNP'
   (output_ `the_ofThePS` code), S "have the",
-  plural property, S "described in", refS (propCorSol [] [])
+  plural property, S "described in", namedRef (propCorSol [] []) (titleize' propOfCorSol)
   ]) "Correct" nonFuncReqDom
  
 verifiable :: ConceptInstance

--- a/code/drasil-utils/Utils/Drasil/Concepts.hs
+++ b/code/drasil-utils/Utils/Drasil/Concepts.hs
@@ -1,5 +1,5 @@
 module Utils.Drasil.Concepts (and_, and_PS, and_PP, and_TGen, and_Gen, andIts, andThe, with, of_, of_NINP, of_PSNPNI, of_PS, ofA,
-ofAPS, ofThe, ofThePS, the_ofThe, the_ofThePS, onThe, onThePS, inThe, inThePS, isThe, toThe, for, forTGen, in_, in_PS, inA, is, the, theGen, a_, a_Gen,
+ofAPS, ofThe, ofThePS, the_ofThe, the_ofThePS, onThe, onThePS, onThePP, inThe, inThePS, inThePP, isThe, toThe, for, forTGen, in_, in_PS, inA, is, the, theGen, a_, a_Gen,
 compoundNC, compoundNCPP, compoundNCGen, compoundNCPS, compoundNCPSPP, compoundNCGenP, combineNINP, combineNPNI, combineNINI) where
 
 import Language.Drasil
@@ -178,6 +178,14 @@ onThePS t1 t2 = nounPhrase''
   CapFirst
   CapWords
 
+-- | Same as 'onThe', except plural case is (plural t1) S.onThe (plural t2)
+onThePP :: (NamedIdea c, NamedIdea d) => c -> d -> NP
+onThePP t1 t2 = nounPhrase'' 
+  (phrase t1 `S.onThe` phrase t2)
+  (plural t1 `S.onThe` plural t2)
+  CapFirst
+  CapWords
+
 -- | Creates a 'NP' by combining two 'NamedIdea's with the words "in the" between
 -- their terms. Plural case is @(phrase t1) "in the" (plural t2)@.
 inThe :: (NamedIdea c, NamedIdea d) => c -> d -> NP
@@ -193,6 +201,15 @@ inThePS :: (NamedIdea c, NamedIdea d) => c -> d -> NP
 inThePS t1 t2 = nounPhrase'' 
   (phrase t1 `S.inThe` phrase t2) 
   (plural t1 `S.inThe` phrase t2)
+  CapFirst
+  CapWords
+
+-- | Creates a 'NP' by combining two 'NamedIdea's with the words "in the" between
+-- their terms. Plural case is @(plural t1) "in the" (plural t2)@.
+inThePP :: (NamedIdea c, NamedIdea d) => c -> d -> NP
+inThePP t1 t2 = nounPhrase'' 
+  (phrase t1 `S.inThe` phrase t2)
+  (plural t1 `S.inThe` plural t2)
   CapFirst
   CapWords
 

--- a/code/stable/dblpendulum/SRS/DblPendulum_SRS.tex
+++ b/code/stable/dblpendulum/SRS/DblPendulum_SRS.tex
@@ -35,7 +35,7 @@ This section records information for easy reference.
 
 \subsection{Table of Units}
 \label{Sec:ToU}
-The unit system used throughout is SI (Système International d'Unités). In addition to the basic units, several derived units are also used. For each unit, \hyperref[Table:ToU]{Tab:ToU} lists the symbol, a description and the SI name.
+The unit system used throughout is SI (Système International d'Unités). In addition to the basic units, several derived units are also used. For each unit, the \hyperref[Table:ToU]{table of units} lists the symbol, a description and the SI name.
 
 \begin{longtable}{l l l}
 \toprule
@@ -63,7 +63,7 @@ ${\text{s}}$ & time & second
 \end{longtable}
 \subsection{Table of Symbols}
 \label{Sec:ToS}
-The symbols used in this document are summarized in \hyperref[Table:ToS]{Tab:ToS} along with their units. Throughout the document, symbols in bold will represent vectors, and scalars otherwise. The symbols are listed in alphabetical order. For vector quantities, the units shown are for each component of the vector.
+The symbols used in this document are summarized in the \hyperref[Table:ToS]{table of symbols} along with their units. Throughout the document, symbols in bold will represent vectors, and scalars otherwise. The symbols are listed in alphabetical order. For vector quantities, the units shown are for each component of the vector.
 
 \begin{longtable}{l l l}
 \toprule
@@ -195,7 +195,7 @@ This subsection provides a list of terms that are used in the subsequent section
 \end{itemize}
 \subsubsection{Physical System Description}
 \label{Sec:PhysSyst}
-The physical system of Pendulum, as shown in \hyperref[Figure:pendulum]{Fig:pendulum}, includes the following elements:
+The physical system of Pendulum, as shown in the \hyperref[Figure:pendulum]{figure} below, includes the following elements:
 
 \begin{itemize}
 \item[PS1:]{The rod.}
@@ -217,7 +217,7 @@ Given the mass and length of the rod, initial angle of the mass and the gravitat
 \end{itemize}
 \subsection{Solution Characteristics Specification}
 \label{Sec:SolCharSpec}
-The instance models that govern Pendulum are presented in \hyperref[Sec:IMs]{Sec:Instance Models}. The information to understand the meaning of the instance models and their derivation is also presented, so that the instance models can be verified.
+The instance models that govern Pendulum are presented in the \hyperref[Sec:IMs]{instance model section}. The information to understand the meaning of the instance models and their derivation is also presented, so that the instance models can be verified.
 
 \subsubsection{Assumptions}
 \label{Sec:Assumps}
@@ -994,7 +994,7 @@ RefBy & \hyperref[GD:periodPend]{GD:periodPend} and \hyperref[DD:angFrequencyDD]
 
 \subsubsection{Instance Models}
 \label{Sec:IMs}
-This section transforms the problem defined in \hyperref[Sec:ProbDesc]{Sec:Problem Description} into one which is expressed in mathematical terms. It uses concrete symbols defined in \hyperref[Sec:DDs]{Sec:Data Definitions} to replace the abstract symbols in the models identified in \hyperref[Sec:TMs]{Sec:Theoretical Models} and \hyperref[Sec:GDs]{Sec:General Definitions}.
+This section transforms the problem defined in the \hyperref[Sec:ProbDesc]{problem description} into one which is expressed in mathematical terms. It uses concrete symbols defined in the \hyperref[Sec:DDs]{data definitions} to replace the abstract symbols in the models identified in \hyperref[Sec:TMs]{theoretical models} and \hyperref[Sec:GDs]{general definitions}.
 
 \vspace{\baselineskip}
 \noindent
@@ -1078,7 +1078,7 @@ Thus the simple harmonic motion is:
 \end{displaymath}
 \subsubsection{Data Constraints}
 \label{Sec:DataConstraints}
-\hyperref[Table:InDataConstraints]{Tab:InDataConstraints} shows the data constraints on the input variables. The column for physical constraints gives the physical limitations on the range of values that can be taken by the variable. The uncertainty column provides an estimate of the confidence with which the physical quantities can be measured. This information would be part of the input if one were performing an uncertainty quantification exercise. The constraints are conservative, to give the user of the model the flexibility to experiment with unusual situations. The column of typical values is intended to provide a feel for a common scenario.
+The \hyperref[Table:InDataConstraints]{data constraints table} shows the data constraints on the input variables. The column for physical constraints gives the physical limitations on the range of values that can be taken by the variable. The uncertainty column provides an estimate of the confidence with which the physical quantities can be measured. This information would be part of the input if one were performing an uncertainty quantification exercise. The constraints are conservative, to give the user of the model the flexibility to experiment with unusual situations. The column of typical values is intended to provide a feel for a common scenario.
 
 \begin{longtable}{l l l l}
 \toprule
@@ -1096,7 +1096,7 @@ ${θ_{i}}$ & ${θ_{i}}\gt{}0$ & $2.1$ ${\text{rad}}$ & 10$\%$
 \end{longtable}
 \subsubsection{Properties of a Correct Solution}
 \label{Sec:CorSolProps}
-\hyperref[Table:OutDataConstraints]{Tab:OutDataConstraints} shows the data constraints on the output variables. The column for physical constraints gives the physical limitations on the range of values that can be taken by the variable.
+The \hyperref[Table:OutDataConstraints]{data constraints table} shows the data constraints on the output variables. The column for physical constraints gives the physical limitations on the range of values that can be taken by the variable.
 
 \begin{longtable}{l l}
 \toprule

--- a/code/stable/dblpendulum/SRS/DblPendulum_SRS.tex
+++ b/code/stable/dblpendulum/SRS/DblPendulum_SRS.tex
@@ -35,7 +35,7 @@ This section records information for easy reference.
 
 \subsection{Table of Units}
 \label{Sec:ToU}
-The unit system used throughout is SI (Système International d'Unités). In addition to the basic units, several derived units are also used. For each unit, the \hyperref[Table:ToU]{table of units} lists the symbol, a description and the SI name.
+The unit system used throughout is SI (Système International d'Unités). In addition to the basic units, several derived units are also used. For each unit, the \hyperref[Table:ToU]{Table of Units} lists the symbol, a description and the SI name.
 
 \begin{longtable}{l l l}
 \toprule
@@ -63,7 +63,7 @@ ${\text{s}}$ & time & second
 \end{longtable}
 \subsection{Table of Symbols}
 \label{Sec:ToS}
-The symbols used in this document are summarized in the \hyperref[Table:ToS]{table of symbols} along with their units. Throughout the document, symbols in bold will represent vectors, and scalars otherwise. The symbols are listed in alphabetical order. For vector quantities, the units shown are for each component of the vector.
+The symbols used in this document are summarized in the \hyperref[Table:ToS]{Table of Symbols} along with their units. Throughout the document, symbols in bold will represent vectors, and scalars otherwise. The symbols are listed in alphabetical order. For vector quantities, the units shown are for each component of the vector.
 
 \begin{longtable}{l l l}
 \toprule
@@ -217,7 +217,7 @@ Given the mass and length of the rod, initial angle of the mass and the gravitat
 \end{itemize}
 \subsection{Solution Characteristics Specification}
 \label{Sec:SolCharSpec}
-The instance models that govern Pendulum are presented in the \hyperref[Sec:IMs]{instance model section}. The information to understand the meaning of the instance models and their derivation is also presented, so that the instance models can be verified.
+The instance models that govern Pendulum are presented in the \hyperref[Sec:IMs]{Instance Model Section}. The information to understand the meaning of the instance models and their derivation is also presented, so that the instance models can be verified.
 
 \subsubsection{Assumptions}
 \label{Sec:Assumps}
@@ -1078,7 +1078,7 @@ Thus the simple harmonic motion is:
 \end{displaymath}
 \subsubsection{Data Constraints}
 \label{Sec:DataConstraints}
-The \hyperref[Table:InDataConstraints]{data constraints table} shows the data constraints on the input variables. The column for physical constraints gives the physical limitations on the range of values that can be taken by the variable. The uncertainty column provides an estimate of the confidence with which the physical quantities can be measured. This information would be part of the input if one were performing an uncertainty quantification exercise. The constraints are conservative, to give the user of the model the flexibility to experiment with unusual situations. The column of typical values is intended to provide a feel for a common scenario.
+The \hyperref[Table:InDataConstraints]{Data Constraints Table} shows the data constraints on the input variables. The column for physical constraints gives the physical limitations on the range of values that can be taken by the variable. The uncertainty column provides an estimate of the confidence with which the physical quantities can be measured. This information would be part of the input if one were performing an uncertainty quantification exercise. The constraints are conservative, to give the user of the model the flexibility to experiment with unusual situations. The column of typical values is intended to provide a feel for a common scenario.
 
 \begin{longtable}{l l l l}
 \toprule
@@ -1096,7 +1096,7 @@ ${θ_{i}}$ & ${θ_{i}}\gt{}0$ & $2.1$ ${\text{rad}}$ & 10$\%$
 \end{longtable}
 \subsubsection{Properties of a Correct Solution}
 \label{Sec:CorSolProps}
-The \hyperref[Table:OutDataConstraints]{data constraints table} shows the data constraints on the output variables. The column for physical constraints gives the physical limitations on the range of values that can be taken by the variable.
+The \hyperref[Table:OutDataConstraints]{Data Constraints Table} shows the data constraints on the output variables. The column for physical constraints gives the physical limitations on the range of values that can be taken by the variable.
 
 \begin{longtable}{l l}
 \toprule

--- a/code/stable/dblpendulum/SRS/DblPendulum_SRS.tex
+++ b/code/stable/dblpendulum/SRS/DblPendulum_SRS.tex
@@ -195,7 +195,7 @@ This subsection provides a list of terms that are used in the subsequent section
 \end{itemize}
 \subsubsection{Physical System Description}
 \label{Sec:PhysSyst}
-The physical system of Pendulum, as shown in the \hyperref[Figure:pendulum]{figure} below, includes the following elements:
+The physical system of Pendulum, as shown in the \hyperref[Figure:pendulum]{Fig:pendulum} below, includes the following elements:
 
 \begin{itemize}
 \item[PS1:]{The rod.}
@@ -771,7 +771,7 @@ Description & \begin{symbDescription}
               \item{$\mathbf{g}$ is the gravitational acceleration ($\frac{\text{m}}{\text{s}^{2}}$)}
               \end{symbDescription}
 \\ \midrule \\
-Notes & The frequency and period are defined in \hyperref[DD:frequencyDD]{DD:frequencyDD} \hyperref[DD:periodSHMDD]{DD:periodSHMDD} respectively
+Notes & The frequency and period are defined in the data definitions for \hyperref[DD:frequencyDD]{frequency} and \hyperref[DD:periodSHMDD]{period} respectively
         
 \\ \midrule \\
 Source & --
@@ -783,12 +783,12 @@ RefBy &
 \end{minipage}
 \paragraph{Detailed derivation of the period of the pendulum:}
 \label{GD:periodPendDeriv}
-The period of the pendulum can be defined from \hyperref[GD:angFrequencyGD]{GD:angFrequencyGD} equation
+The period of the pendulum can be defined from the general definition for the equation of \hyperref[GD:angFrequencyGD]{angular frequency}
 
 \begin{displaymath}
 Ω=\sqrt{\frac{\mathbf{g}}{{L_{\text{rod}}}}}
 \end{displaymath}
-Therefore from the equation \hyperref[DD:angFrequencyDD]{DD:angFrequencyDD}, we have
+Therefore from the data definition of the equation for \hyperref[DD:angFrequencyDD]{angular frequency}, we have
 
 \begin{displaymath}
 T=2 π \sqrt{\frac{{L_{\text{rod}}}}{\mathbf{g}}}
@@ -1051,7 +1051,7 @@ RefBy & \hyperref[outputValues]{FR:Output-Values} and \hyperref[calcAngPos]{FR:C
 \end{minipage}
 \paragraph{Detailed derivation of angular displacement:}
 \label{IM:calOfAngularDisplacementDeriv}
-When the pendulum is displaced to an initial angle and released, the pendulum swings back and forth with periodic motion. By applying Newton's second law for rotational motion in \hyperref[TM:NewtonSecLawRotMot]{TM:NewtonSecLawRotMot}, the equation of motion for the pendulum may be obtained:
+When the pendulum is displaced to an initial angle and released, the pendulum swings back and forth with periodic motion. By applying \hyperref[TM:NewtonSecLawRotMot]{Newton's second law for rotational motion}, the equation of motion for the pendulum may be obtained:
 
 \begin{displaymath}
 \mathbf{τ}=\mathbf{I} α
@@ -1122,7 +1122,7 @@ This section provides the functional requirements, the tasks and behaviours that
 
 \begin{itemize}
 \item[Input-Values:\phantomsection\label{inputValues}]{Input the values from \hyperref[Table:ReqInputs]{Tab:ReqInputs}.}
-\item[Verify-Input-Values:\phantomsection\label{verifyInptVals}]{Check the entered input values to ensure that they do not exceed the data constraints mentioned in \hyperref[Sec:DataConstraints]{Sec:Data Constraints}. If any of the input values are out of bounds, an error message is displayed and the calculations stop.}
+\item[Verify-Input-Values:\phantomsection\label{verifyInptVals}]{Check the entered input values to ensure that they do not exceed the \hyperref[Sec:DataConstraints]{data constraints}. If any of the input values are out of bounds, an error message is displayed and the calculations stop.}
 \item[Calculate-Angular-Position-Of-Mass:\phantomsection\label{calcAngPos}]{Calculate the following values: $θ$ (from \hyperref[IM:calOfAngularDisplacement]{IM:calOfAngularDisplacement}) and ${θ_{p}}$ (from \hyperref[IM:calOfAngularDisplacement]{IM:calOfAngularDisplacement}).}
 \item[Output-Values:\phantomsection\label{outputValues}]{Output ${L_{\text{rod}}}$ (from \hyperref[IM:calOfAngularDisplacement]{IM:calOfAngularDisplacement}) and ${L_{\text{rod}}}$ (from \hyperref[IM:calOfAngularDisplacement]{IM:calOfAngularDisplacement}).}
 \end{itemize}
@@ -1151,7 +1151,7 @@ ${θ_{p}}$ & Displacement angle of the pendulum & ${{}^{\circ}}$
 This section provides the non-functional requirements, the qualities that the software is expected to exhibit.
 
 \begin{itemize}
-\item[Correct:\phantomsection\label{correct}]{The outputs of the code have the properties described in \hyperref[Sec:CorSolProps]{Sec:Properties of a Correct Solution}.}
+\item[Correct:\phantomsection\label{correct}]{The outputs of the code have the \hyperref[Sec:CorSolProps]{properties of a correct solution}.}
 \item[Portable:\phantomsection\label{portable}]{The code is able to be run in different environments.}
 \end{itemize}
 \section{Traceability Matrices and Graphs}

--- a/code/stable/dblpendulum/Website/DblPendulum_SRS.html
+++ b/code/stable/dblpendulum/Website/DblPendulum_SRS.html
@@ -21,7 +21,7 @@
           <div class="subsection">
             <h2>Table of Units</h2>
             <p class="paragraph">
-              The unit system used throughout is SI (Système International d'Unités). In addition to the basic units, several derived units are also used. For each unit, <a href=#Table:ToU>Tab:ToU</a> lists the symbol, a description and the SI name.
+              The unit system used throughout is SI (Système International d'Unités). In addition to the basic units, several derived units are also used. For each unit, the <a href=#Table:ToU>table of units</a> lists the symbol, a description and the SI name.
             </p>
             <div id="Table:ToU">
               <table class="table">
@@ -74,7 +74,7 @@
           <div class="subsection">
             <h2>Table of Symbols</h2>
             <p class="paragraph">
-              The symbols used in this document are summarized in <a href=#Table:ToS>Tab:ToS</a> along with their units. Throughout the document, symbols in bold will represent vectors, and scalars otherwise. The symbols are listed in alphabetical order. For vector quantities, the units shown are for each component of the vector.
+              The symbols used in this document are summarized in the <a href=#Table:ToS>table of symbols</a> along with their units. Throughout the document, symbols in bold will represent vectors, and scalars otherwise. The symbols are listed in alphabetical order. For vector quantities, the units shown are for each component of the vector.
             </p>
             <div id="Table:ToS">
               <table class="table">
@@ -344,7 +344,7 @@
               <div class="subsubsection">
                 <h3>Physical System Description</h3>
                 <p class="paragraph">
-                  The physical system of Pendulum, as shown in <a href=#Figure:pendulum>Fig:pendulum</a>, includes the following elements:
+                  The physical system of Pendulum, as shown in the <a href=#Figure:pendulum>figure</a> below, includes the following elements:
                 </p>
                 <div class="list">
                   <p>PS1: The rod.</p>
@@ -379,7 +379,7 @@
           <div class="subsection">
             <h2>Solution Characteristics Specification</h2>
             <p class="paragraph">
-              The instance models that govern Pendulum are presented in <a href=#Sec:IMs>Sec:Instance Models</a>. The information to understand the meaning of the instance models and their derivation is also presented, so that the instance models can be verified.
+              The instance models that govern Pendulum are presented in the <a href=#Sec:IMs>instance model section</a>. The information to understand the meaning of the instance models and their derivation is also presented, so that the instance models can be verified.
             </p>
             <div id="Sec:Assumps">
               <div class="subsubsection">
@@ -1484,7 +1484,7 @@
               <div class="subsubsection">
                 <h3>Instance Models</h3>
                 <p class="paragraph">
-                  This section transforms the problem defined in <a href=#Sec:ProbDesc>Sec:Problem Description</a> into one which is expressed in mathematical terms. It uses concrete symbols defined in <a href=#Sec:DDs>Sec:Data Definitions</a> to replace the abstract symbols in the models identified in <a href=#Sec:TMs>Sec:Theoretical Models</a> and <a href=#Sec:GDs>Sec:General Definitions</a>.
+                  This section transforms the problem defined in the <a href=#Sec:ProbDesc>problem description</a> into one which is expressed in mathematical terms. It uses concrete symbols defined in the <a href=#Sec:DDs>data definitions</a> to replace the abstract symbols in the models identified in <a href=#Sec:TMs>theoretical models</a> and <a href=#Sec:GDs>general definitions</a>.
                 </p>
                 <div id="IM:calOfAngularDisplacement">
                   <table class="idefn">
@@ -1590,7 +1590,7 @@
               <div class="subsubsection">
                 <h3>Data Constraints</h3>
                 <p class="paragraph">
-                  <a href=#Table:InDataConstraints>Tab:InDataConstraints</a> shows the data constraints on the input variables. The column for physical constraints gives the physical limitations on the range of values that can be taken by the variable. The uncertainty column provides an estimate of the confidence with which the physical quantities can be measured. This information would be part of the input if one were performing an uncertainty quantification exercise. The constraints are conservative, to give the user of the model the flexibility to experiment with unusual situations. The column of typical values is intended to provide a feel for a common scenario.
+                  The <a href=#Table:InDataConstraints>data constraints table</a> shows the data constraints on the input variables. The column for physical constraints gives the physical limitations on the range of values that can be taken by the variable. The uncertainty column provides an estimate of the confidence with which the physical quantities can be measured. This information would be part of the input if one were performing an uncertainty quantification exercise. The constraints are conservative, to give the user of the model the flexibility to experiment with unusual situations. The column of typical values is intended to provide a feel for a common scenario.
                 </p>
                 <div id="Table:InDataConstraints">
                   <table class="table">
@@ -1621,7 +1621,7 @@
               <div class="subsubsection">
                 <h3>Properties of a Correct Solution</h3>
                 <p class="paragraph">
-                  <a href=#Table:OutDataConstraints>Tab:OutDataConstraints</a> shows the data constraints on the output variables. The column for physical constraints gives the physical limitations on the range of values that can be taken by the variable.
+                  The <a href=#Table:OutDataConstraints>data constraints table</a> shows the data constraints on the output variables. The column for physical constraints gives the physical limitations on the range of values that can be taken by the variable.
                 </p>
                 <div id="Table:OutDataConstraints">
                   <table class="table">

--- a/code/stable/dblpendulum/Website/DblPendulum_SRS.html
+++ b/code/stable/dblpendulum/Website/DblPendulum_SRS.html
@@ -21,7 +21,7 @@
           <div class="subsection">
             <h2>Table of Units</h2>
             <p class="paragraph">
-              The unit system used throughout is SI (Système International d'Unités). In addition to the basic units, several derived units are also used. For each unit, the <a href=#Table:ToU>table of units</a> lists the symbol, a description and the SI name.
+              The unit system used throughout is SI (Système International d'Unités). In addition to the basic units, several derived units are also used. For each unit, the <a href=#Table:ToU>Table of Units</a> lists the symbol, a description and the SI name.
             </p>
             <div id="Table:ToU">
               <table class="table">
@@ -74,7 +74,7 @@
           <div class="subsection">
             <h2>Table of Symbols</h2>
             <p class="paragraph">
-              The symbols used in this document are summarized in the <a href=#Table:ToS>table of symbols</a> along with their units. Throughout the document, symbols in bold will represent vectors, and scalars otherwise. The symbols are listed in alphabetical order. For vector quantities, the units shown are for each component of the vector.
+              The symbols used in this document are summarized in the <a href=#Table:ToS>Table of Symbols</a> along with their units. Throughout the document, symbols in bold will represent vectors, and scalars otherwise. The symbols are listed in alphabetical order. For vector quantities, the units shown are for each component of the vector.
             </p>
             <div id="Table:ToS">
               <table class="table">
@@ -379,7 +379,7 @@
           <div class="subsection">
             <h2>Solution Characteristics Specification</h2>
             <p class="paragraph">
-              The instance models that govern Pendulum are presented in the <a href=#Sec:IMs>instance model section</a>. The information to understand the meaning of the instance models and their derivation is also presented, so that the instance models can be verified.
+              The instance models that govern Pendulum are presented in the <a href=#Sec:IMs>Instance Model Section</a>. The information to understand the meaning of the instance models and their derivation is also presented, so that the instance models can be verified.
             </p>
             <div id="Sec:Assumps">
               <div class="subsubsection">
@@ -1590,7 +1590,7 @@
               <div class="subsubsection">
                 <h3>Data Constraints</h3>
                 <p class="paragraph">
-                  The <a href=#Table:InDataConstraints>data constraints table</a> shows the data constraints on the input variables. The column for physical constraints gives the physical limitations on the range of values that can be taken by the variable. The uncertainty column provides an estimate of the confidence with which the physical quantities can be measured. This information would be part of the input if one were performing an uncertainty quantification exercise. The constraints are conservative, to give the user of the model the flexibility to experiment with unusual situations. The column of typical values is intended to provide a feel for a common scenario.
+                  The <a href=#Table:InDataConstraints>Data Constraints Table</a> shows the data constraints on the input variables. The column for physical constraints gives the physical limitations on the range of values that can be taken by the variable. The uncertainty column provides an estimate of the confidence with which the physical quantities can be measured. This information would be part of the input if one were performing an uncertainty quantification exercise. The constraints are conservative, to give the user of the model the flexibility to experiment with unusual situations. The column of typical values is intended to provide a feel for a common scenario.
                 </p>
                 <div id="Table:InDataConstraints">
                   <table class="table">
@@ -1621,7 +1621,7 @@
               <div class="subsubsection">
                 <h3>Properties of a Correct Solution</h3>
                 <p class="paragraph">
-                  The <a href=#Table:OutDataConstraints>data constraints table</a> shows the data constraints on the output variables. The column for physical constraints gives the physical limitations on the range of values that can be taken by the variable.
+                  The <a href=#Table:OutDataConstraints>Data Constraints Table</a> shows the data constraints on the output variables. The column for physical constraints gives the physical limitations on the range of values that can be taken by the variable.
                 </p>
                 <div id="Table:OutDataConstraints">
                   <table class="table">

--- a/code/stable/dblpendulum/Website/DblPendulum_SRS.html
+++ b/code/stable/dblpendulum/Website/DblPendulum_SRS.html
@@ -344,7 +344,7 @@
               <div class="subsubsection">
                 <h3>Physical System Description</h3>
                 <p class="paragraph">
-                  The physical system of Pendulum, as shown in the <a href=#Figure:pendulum>figure</a> below, includes the following elements:
+                  The physical system of Pendulum, as shown in the <a href=#Figure:pendulum>Fig:pendulum</a> below, includes the following elements:
                 </p>
                 <div class="list">
                   <p>PS1: The rod.</p>
@@ -1148,7 +1148,7 @@
                       <th>Notes</th>
                       <td>
                         <p class="paragraph">
-                          The frequency and period are defined in <a href=#DD:frequencyDD>DD:frequencyDD</a> <a href=#DD:periodSHMDD>DD:periodSHMDD</a> respectively
+                          The frequency and period are defined in the data definitions for <a href=#DD:frequencyDD>frequency</a> and <a href=#DD:periodSHMDD>period</a> respectively
                         </p>
                       </td>
                     </tr>
@@ -1166,11 +1166,11 @@
                   <div class="subsubsubsection">
                     <h4>Detailed derivation of the period of the pendulum:</h4>
                     <p class="paragraph">
-                      The period of the pendulum can be defined from <a href=#GD:angFrequencyGD>GD:angFrequencyGD</a> equation
+                      The period of the pendulum can be defined from the general definition for the equation of <a href=#GD:angFrequencyGD>angular frequency</a>
                     </p>
                     \[Ω=\sqrt{\frac{\mathbf{g}}{{L_{\text{rod}}}}}\]
                     <p class="paragraph">
-                      Therefore from the equation <a href=#DD:angFrequencyDD>DD:angFrequencyDD</a>, we have
+                      Therefore from the data definition of the equation for <a href=#DD:angFrequencyDD>angular frequency</a>, we have
                     </p>
                     \[T=2 π \sqrt{\frac{{L_{\text{rod}}}}{\mathbf{g}}}\]
                   </div>
@@ -1567,7 +1567,7 @@
                   <div class="subsubsubsection">
                     <h4>Detailed derivation of angular displacement:</h4>
                     <p class="paragraph">
-                      When the pendulum is displaced to an initial angle and released, the pendulum swings back and forth with periodic motion. By applying Newton's second law for rotational motion in <a href=#TM:NewtonSecLawRotMot>TM:NewtonSecLawRotMot</a>, the equation of motion for the pendulum may be obtained:
+                      When the pendulum is displaced to an initial angle and released, the pendulum swings back and forth with periodic motion. By applying <a href=#TM:NewtonSecLawRotMot>Newton's second law for rotational motion</a>, the equation of motion for the pendulum may be obtained:
                     </p>
                     \[\mathbf{τ}=\mathbf{I} α\]
                     <p class="paragraph">
@@ -1666,7 +1666,7 @@
               </p>
               <p>
                 <div id="verifyInptVals">
-                  Verify-Input-Values: Check the entered input values to ensure that they do not exceed the data constraints mentioned in <a href=#Sec:DataConstraints>Sec:Data Constraints</a>. If any of the input values are out of bounds, an error message is displayed and the calculations stop.
+                  Verify-Input-Values: Check the entered input values to ensure that they do not exceed the <a href=#Sec:DataConstraints>data constraints</a>. If any of the input values are out of bounds, an error message is displayed and the calculations stop.
                 </div>
               </p>
               <p>
@@ -1728,7 +1728,7 @@
             <div class="list">
               <p>
                 <div id="correct">
-                  Correct: The outputs of the code have the properties described in <a href=#Sec:CorSolProps>Sec:Properties of a Correct Solution</a>.
+                  Correct: The outputs of the code have the <a href=#Sec:CorSolProps>properties of a correct solution</a>.
                 </div>
               </p>
               <p>

--- a/code/stable/gamephysics/SRS/GamePhysics_SRS.tex
+++ b/code/stable/gamephysics/SRS/GamePhysics_SRS.tex
@@ -35,7 +35,7 @@ This section records information for easy reference.
 
 \subsection{Table of Units}
 \label{Sec:ToU}
-The unit system used throughout is SI (Système International d'Unités). In addition to the basic units, several derived units are also used. For each unit, \hyperref[Table:ToU]{Tab:ToU} lists the symbol, a description and the SI name.
+The unit system used throughout is SI (Système International d'Unités). In addition to the basic units, several derived units are also used. For each unit, the \hyperref[Table:ToU]{table of units} lists the symbol, a description and the SI name.
 
 \begin{longtable}{l l l}
 \toprule
@@ -61,7 +61,7 @@ ${\text{s}}$ & time & second
 \end{longtable}
 \subsection{Table of Symbols}
 \label{Sec:ToS}
-The symbols used in this document are summarized in \hyperref[Table:ToS]{Tab:ToS} along with their units. Throughout the document, symbols in bold will represent vectors, and scalars otherwise. The symbols are listed in alphabetical order. For vector quantities, the units shown are for each component of the vector.
+The symbols used in this document are summarized in the \hyperref[Table:ToS]{table of symbols} along with their units. Throughout the document, symbols in bold will represent vectors, and scalars otherwise. The symbols are listed in alphabetical order. For vector quantities, the units shown are for each component of the vector.
 
 \begin{longtabu}{l X[l] l}
 \toprule
@@ -344,7 +344,7 @@ Given the kinematic properties, and forces (including any collision forces) appl
 \end{itemize}
 \subsection{Solution Characteristics Specification}
 \label{Sec:SolCharSpec}
-The instance models that govern Game Physics are presented in \hyperref[Sec:IMs]{Sec:Instance Models}. The information to understand the meaning of the instance models and their derivation is also presented, so that the instance models can be verified.
+The instance models that govern Game Physics are presented in the \hyperref[Sec:IMs]{instance model section}. The information to understand the meaning of the instance models and their derivation is also presented, so that the instance models can be verified.
 
 \subsubsection{Assumptions}
 \label{Sec:Assumps}
@@ -1230,7 +1230,7 @@ RefBy &
 
 \subsubsection{Instance Models}
 \label{Sec:IMs}
-This section transforms the problem defined in \hyperref[Sec:ProbDesc]{Sec:Problem Description} into one which is expressed in mathematical terms. It uses concrete symbols defined in \hyperref[Sec:DDs]{Sec:Data Definitions} to replace the abstract symbols in the models identified in \hyperref[Sec:TMs]{Sec:Theoretical Models} and \hyperref[Sec:GDs]{Sec:General Definitions}.
+This section transforms the problem defined in the \hyperref[Sec:ProbDesc]{problem description} into one which is expressed in mathematical terms. It uses concrete symbols defined in the \hyperref[Sec:DDs]{data definitions} to replace the abstract symbols in the models identified in \hyperref[Sec:TMs]{theoretical models} and \hyperref[Sec:GDs]{general definitions}.
 
 The goal \hyperref[linearGS]{GS:Determine-Linear-Properties} is met by \hyperref[IM:transMot]{IM:transMot} and \hyperref[IM:col2D]{IM:col2D}. The goal \hyperref[angularGS]{GS:Determine-Angular-Properties} is met by \hyperref[IM:rotMot]{IM:rotMot} and \hyperref[IM:col2D]{IM:col2D}.
 
@@ -1440,7 +1440,7 @@ RefBy &
 
 \subsubsection{Data Constraints}
 \label{Sec:DataConstraints}
-\hyperref[Table:InDataConstraints]{Tab:InDataConstraints} shows the data constraints on the input variables. The column for physical constraints gives the physical limitations on the range of values that can be taken by the variable. The uncertainty column provides an estimate of the confidence with which the physical quantities can be measured. This information would be part of the input if one were performing an uncertainty quantification exercise. The constraints are conservative, to give the user of the model the flexibility to experiment with unusual situations. The column of typical values is intended to provide a feel for a common scenario.
+The \hyperref[Table:InDataConstraints]{data constraints table} shows the data constraints on the input variables. The column for physical constraints gives the physical limitations on the range of values that can be taken by the variable. The uncertainty column provides an estimate of the confidence with which the physical quantities can be measured. This information would be part of the input if one were performing an uncertainty quantification exercise. The constraints are conservative, to give the user of the model the flexibility to experiment with unusual situations. The column of typical values is intended to provide a feel for a common scenario.
 
 \begin{longtable}{l l l l l}
 \toprule
@@ -1476,7 +1476,7 @@ $ϕ$ & -- & $0\leq{}ϕ\leq{}2 π$ & $\frac{π}{2}$ ${\text{rad}}$ & 10$\%$
 \end{longtable}
 \subsubsection{Properties of a Correct Solution}
 \label{Sec:CorSolProps}
-\hyperref[Table:OutDataConstraints]{Tab:OutDataConstraints} shows the data constraints on the output variables. The column for physical constraints gives the physical limitations on the range of values that can be taken by the variable.
+The \hyperref[Table:OutDataConstraints]{data constraints table} shows the data constraints on the output variables. The column for physical constraints gives the physical limitations on the range of values that can be taken by the variable.
 
 \begin{longtable}{l}
 \toprule

--- a/code/stable/gamephysics/SRS/GamePhysics_SRS.tex
+++ b/code/stable/gamephysics/SRS/GamePhysics_SRS.tex
@@ -35,7 +35,7 @@ This section records information for easy reference.
 
 \subsection{Table of Units}
 \label{Sec:ToU}
-The unit system used throughout is SI (Système International d'Unités). In addition to the basic units, several derived units are also used. For each unit, the \hyperref[Table:ToU]{table of units} lists the symbol, a description and the SI name.
+The unit system used throughout is SI (Système International d'Unités). In addition to the basic units, several derived units are also used. For each unit, the \hyperref[Table:ToU]{Table of Units} lists the symbol, a description and the SI name.
 
 \begin{longtable}{l l l}
 \toprule
@@ -61,7 +61,7 @@ ${\text{s}}$ & time & second
 \end{longtable}
 \subsection{Table of Symbols}
 \label{Sec:ToS}
-The symbols used in this document are summarized in the \hyperref[Table:ToS]{table of symbols} along with their units. Throughout the document, symbols in bold will represent vectors, and scalars otherwise. The symbols are listed in alphabetical order. For vector quantities, the units shown are for each component of the vector.
+The symbols used in this document are summarized in the \hyperref[Table:ToS]{Table of Symbols} along with their units. Throughout the document, symbols in bold will represent vectors, and scalars otherwise. The symbols are listed in alphabetical order. For vector quantities, the units shown are for each component of the vector.
 
 \begin{longtabu}{l X[l] l}
 \toprule
@@ -295,11 +295,11 @@ The interaction between the product and the user is through an application progr
 \begin{itemize}
 \item{Provide initial conditions of the physical state of the simulation, rigid bodies present, and forces applied to them.}
 \item{Ensure application programming interface use complies with the user guide.}
-\item{Ensure required software assumptions (\hyperref[Sec:Assumps]{Sec:Assumptions}) are appropriate for any particular problem the software addresses.}
+\item{Ensure required \hyperref[Sec:Assumps]{software assumptions} are appropriate for any particular problem the software addresses.}
 \end{itemize}
 \item{Game Physics Responsibilities}
 \begin{itemize}
-\item{Determine if the inputs and simulation state satisfy the required physical and system constraints (\hyperref[Sec:DataConstraints]{Sec:Data Constraints}).}
+\item{Determine if the inputs and simulation state satisfy the required \hyperref[Sec:DataConstraints]{physical and system constraints}.}
 \item{Calculate the new state of all rigid bodies within the simulation at each simulation step.}
 \item{Provide updated physical state of all rigid bodies at the end of a simulation step.}
 \end{itemize}
@@ -318,7 +318,7 @@ This section first presents the problem description, which gives a high-level vi
 
 \subsection{Problem Description}
 \label{Sec:ProbDesc}
-A system is needed to create a simple, lightweight, fast, and portable 2D rigid body physics library, which will allow for more accessible game development and the production of higher quality products. Creating a gaming physics library is a difficult task. Games need physics libraries that simulate objects acting under various physical conditions, while simultaneously being fast and efficient enough to work in soft real-time during the game. Developing a physics library from scratch takes a long period of time and is very costly, presenting barriers of entry which make it difficult for game developers to include physics in their products. There are a few free, open source and high quality physics libraries available to be used for consumer products (\hyperref[Sec:offShelfSolns]{Sec:Off-The-Shelf Solutions}).
+A system is needed to create a simple, lightweight, fast, and portable 2D rigid body physics library, which will allow for more accessible game development and the production of higher quality products. Creating a gaming physics library is a difficult task. Games need physics libraries that simulate objects acting under various physical conditions, while simultaneously being fast and efficient enough to work in soft real-time during the game. Developing a physics library from scratch takes a long period of time and is very costly, presenting barriers of entry which make it difficult for game developers to include physics in their products. There are a few free, open source and high quality \hyperref[Sec:offShelfSolns]{physics libraries} available to be used for consumer products.
 
 \subsubsection{Terminology and Definitions}
 \label{Sec:TermDefs}
@@ -344,7 +344,7 @@ Given the kinematic properties, and forces (including any collision forces) appl
 \end{itemize}
 \subsection{Solution Characteristics Specification}
 \label{Sec:SolCharSpec}
-The instance models that govern Game Physics are presented in the \hyperref[Sec:IMs]{instance model section}. The information to understand the meaning of the instance models and their derivation is also presented, so that the instance models can be verified.
+The instance models that govern Game Physics are presented in the \hyperref[Sec:IMs]{Instance Model Section}. The information to understand the meaning of the instance models and their derivation is also presented, so that the instance models can be verified.
 
 \subsubsection{Assumptions}
 \label{Sec:Assumps}
@@ -538,7 +538,7 @@ RefBy & \hyperref[IM:transMot]{IM:transMot}
 \end{minipage}
 \paragraph{Detailed derivation of gravitational acceleration:}
 \label{GD:accelGravityDeriv}
-From Newton's law of universal gravitation (\hyperref[TM:UniversalGravLaw]{TM:UniversalGravLaw}) we have:
+From \hyperref[TM:UniversalGravLaw]{Newton's law of universal gravitation}, we have:
 
 \begin{displaymath}
 \mathbf{F}=\frac{G {m_{1}} {m_{2}}}{{\text{||}\mathbf{d}\text{||}^{2}}} \mathbf{\hat{d}}
@@ -1440,7 +1440,7 @@ RefBy &
 
 \subsubsection{Data Constraints}
 \label{Sec:DataConstraints}
-The \hyperref[Table:InDataConstraints]{data constraints table} shows the data constraints on the input variables. The column for physical constraints gives the physical limitations on the range of values that can be taken by the variable. The uncertainty column provides an estimate of the confidence with which the physical quantities can be measured. This information would be part of the input if one were performing an uncertainty quantification exercise. The constraints are conservative, to give the user of the model the flexibility to experiment with unusual situations. The column of typical values is intended to provide a feel for a common scenario.
+The \hyperref[Table:InDataConstraints]{Data Constraints Table} shows the data constraints on the input variables. The column for physical constraints gives the physical limitations on the range of values that can be taken by the variable. The uncertainty column provides an estimate of the confidence with which the physical quantities can be measured. This information would be part of the input if one were performing an uncertainty quantification exercise. The constraints are conservative, to give the user of the model the flexibility to experiment with unusual situations. The column of typical values is intended to provide a feel for a common scenario.
 
 \begin{longtable}{l l l l l}
 \toprule
@@ -1476,7 +1476,7 @@ $ϕ$ & -- & $0\leq{}ϕ\leq{}2 π$ & $\frac{π}{2}$ ${\text{rad}}$ & 10$\%$
 \end{longtable}
 \subsubsection{Properties of a Correct Solution}
 \label{Sec:CorSolProps}
-The \hyperref[Table:OutDataConstraints]{data constraints table} shows the data constraints on the output variables. The column for physical constraints gives the physical limitations on the range of values that can be taken by the variable.
+The \hyperref[Table:OutDataConstraints]{Data Constraints Table} shows the data constraints on the output variables. The column for physical constraints gives the physical limitations on the range of values that can be taken by the variable.
 
 \begin{longtable}{l}
 \toprule
@@ -1508,7 +1508,7 @@ This section provides the functional requirements, the tasks and behaviours that
 \item[Simulation-Space:\phantomsection\label{simSpace}]{Create a space for all of the rigid bodies in the physical simulation to interact in.}
 \item[Input-Initial-Conditions:\phantomsection\label{inputInitialConds}]{Input the initial masses, velocities, orientations, angular velocities of, and forces applied on rigid bodies.}
 \item[Input-Surface-Properties:\phantomsection\label{inputSurfaceProps}]{Input the surface properties of the bodies such as friction or elasticity.}
-\item[Verify-Physical\_Constraints:\phantomsection\label{verifyPhysCons}]{Verify that the inputs satisfy the required physical constraints from \hyperref[Sec:SolCharSpec]{Sec:Solution Characteristics Specification}.}
+\item[Verify-Physical\_Constraints:\phantomsection\label{verifyPhysCons}]{Verify that the inputs satisfy the required physical constraints from the \hyperref[Sec:SolCharSpec]{solution characteristics specification}.}
 \item[Calculate-Translation-Over-Time:\phantomsection\label{calcTransOverTime}]{Determine the positions and velocities over a period of time of the 2D rigid bodies acted upon by a force.}
 \item[Calculate-Rotation-Over-Time:\phantomsection\label{calcRotOverTime}]{Determine the orientations and angular velocities over a period of time of the 2D rigid bodies.}
 \item[Determine-Collisions:\phantomsection\label{deterColls}]{Determine if any of the rigid bodies in the space have collided.}
@@ -1547,7 +1547,7 @@ This section lists the unlikely changes to be made to the software.
 \end{itemize}
 \section{Off-The-Shelf Solutions}
 \label{Sec:offShelfSolns}
-As mentioned in \hyperref[Sec:ProbDesc]{Sec:Problem Description}, there already exist free open source game physics libraries. Similar 2D physics libraries are:
+As mentioned in the \hyperref[Sec:ProbDesc]{problem description}, there already exist free open source game physics libraries. Similar 2D physics libraries are:
 
 \begin{itemize}
 \item{Box2D: http://box2d.org/}

--- a/code/stable/gamephysics/Website/GamePhysics_SRS.html
+++ b/code/stable/gamephysics/Website/GamePhysics_SRS.html
@@ -23,7 +23,7 @@
           <div class="subsection">
             <h2>Table of Units</h2>
             <p class="paragraph">
-              The unit system used throughout is SI (Système International d'Unités). In addition to the basic units, several derived units are also used. For each unit, the <a href=#Table:ToU>table of units</a> lists the symbol, a description and the SI name.
+              The unit system used throughout is SI (Système International d'Unités). In addition to the basic units, several derived units are also used. For each unit, the <a href=#Table:ToU>Table of Units</a> lists the symbol, a description and the SI name.
             </p>
             <div id="Table:ToU">
               <table class="table">
@@ -71,7 +71,7 @@
           <div class="subsection">
             <h2>Table of Symbols</h2>
             <p class="paragraph">
-              The symbols used in this document are summarized in the <a href=#Table:ToS>table of symbols</a> along with their units. Throughout the document, symbols in bold will represent vectors, and scalars otherwise. The symbols are listed in alphabetical order. For vector quantities, the units shown are for each component of the vector.
+              The symbols used in this document are summarized in the <a href=#Table:ToS>Table of Symbols</a> along with their units. Throughout the document, symbols in bold will represent vectors, and scalars otherwise. The symbols are listed in alphabetical order. For vector quantities, the units shown are for each component of the vector.
             </p>
             <div id="Table:ToS">
               <table class="table">
@@ -581,7 +581,7 @@
                     Ensure application programming interface use complies with the user guide.
                   </li>
                   <li>
-                    Ensure required software assumptions (<a href=#Sec:Assumps>Sec:Assumptions</a>) are appropriate for any particular problem the software addresses.
+                    Ensure required <a href=#Sec:Assumps>software assumptions</a> are appropriate for any particular problem the software addresses.
                   </li>
                 </ul>
               </li>
@@ -589,7 +589,7 @@
                 Game Physics Responsibilities
                 <ul class="list">
                   <li>
-                    Determine if the inputs and simulation state satisfy the required physical and system constraints (<a href=#Sec:DataConstraints>Sec:Data Constraints</a>).
+                    Determine if the inputs and simulation state satisfy the required <a href=#Sec:DataConstraints>physical and system constraints</a>.
                   </li>
                   <li>
                     Calculate the new state of all rigid bodies within the simulation at each simulation step.
@@ -628,7 +628,7 @@
           <div class="subsection">
             <h2>Problem Description</h2>
             <p class="paragraph">
-              A system is needed to create a simple, lightweight, fast, and portable 2D rigid body physics library, which will allow for more accessible game development and the production of higher quality products. Creating a gaming physics library is a difficult task. Games need physics libraries that simulate objects acting under various physical conditions, while simultaneously being fast and efficient enough to work in soft real-time during the game. Developing a physics library from scratch takes a long period of time and is very costly, presenting barriers of entry which make it difficult for game developers to include physics in their products. There are a few free, open source and high quality physics libraries available to be used for consumer products (<a href=#Sec:offShelfSolns>Sec:Off-The-Shelf Solutions</a>).
+              A system is needed to create a simple, lightweight, fast, and portable 2D rigid body physics library, which will allow for more accessible game development and the production of higher quality products. Creating a gaming physics library is a difficult task. Games need physics libraries that simulate objects acting under various physical conditions, while simultaneously being fast and efficient enough to work in soft real-time during the game. Developing a physics library from scratch takes a long period of time and is very costly, presenting barriers of entry which make it difficult for game developers to include physics in their products. There are a few free, open source and high quality <a href=#Sec:offShelfSolns>physics libraries</a> available to be used for consumer products.
             </p>
             <div id="Sec:TermDefs">
               <div class="subsubsection">
@@ -690,7 +690,7 @@
           <div class="subsection">
             <h2>Solution Characteristics Specification</h2>
             <p class="paragraph">
-              The instance models that govern Game Physics are presented in the <a href=#Sec:IMs>instance model section</a>. The information to understand the meaning of the instance models and their derivation is also presented, so that the instance models can be verified.
+              The instance models that govern Game Physics are presented in the <a href=#Sec:IMs>Instance Model Section</a>. The information to understand the meaning of the instance models and their derivation is also presented, so that the instance models can be verified.
             </p>
             <div id="Sec:Assumps">
               <div class="subsubsection">
@@ -1031,7 +1031,7 @@
                   <div class="subsubsubsection">
                     <h4>Detailed derivation of gravitational acceleration:</h4>
                     <p class="paragraph">
-                      From Newton's law of universal gravitation (<a href=#TM:UniversalGravLaw>TM:UniversalGravLaw</a>) we have:
+                      From <a href=#TM:UniversalGravLaw>Newton's law of universal gravitation</a>, we have:
                     </p>
                     \[\mathbf{F}=\frac{G {m_{1}} {m_{2}}}{{\text{||}\mathbf{d}\text{||}^{2}}} \mathbf{\hat{d}}\]
                     <p class="paragraph">
@@ -2361,7 +2361,7 @@
               <div class="subsubsection">
                 <h3>Data Constraints</h3>
                 <p class="paragraph">
-                  The <a href=#Table:InDataConstraints>data constraints table</a> shows the data constraints on the input variables. The column for physical constraints gives the physical limitations on the range of values that can be taken by the variable. The uncertainty column provides an estimate of the confidence with which the physical quantities can be measured. This information would be part of the input if one were performing an uncertainty quantification exercise. The constraints are conservative, to give the user of the model the flexibility to experiment with unusual situations. The column of typical values is intended to provide a feel for a common scenario.
+                  The <a href=#Table:InDataConstraints>Data Constraints Table</a> shows the data constraints on the input variables. The column for physical constraints gives the physical limitations on the range of values that can be taken by the variable. The uncertainty column provides an estimate of the confidence with which the physical quantities can be measured. This information would be part of the input if one were performing an uncertainty quantification exercise. The constraints are conservative, to give the user of the model the flexibility to experiment with unusual situations. The column of typical values is intended to provide a feel for a common scenario.
                 </p>
                 <div id="Table:InDataConstraints">
                   <table class="table">
@@ -2464,7 +2464,7 @@
               <div class="subsubsection">
                 <h3>Properties of a Correct Solution</h3>
                 <p class="paragraph">
-                  The <a href=#Table:OutDataConstraints>data constraints table</a> shows the data constraints on the output variables. The column for physical constraints gives the physical limitations on the range of values that can be taken by the variable.
+                  The <a href=#Table:OutDataConstraints>Data Constraints Table</a> shows the data constraints on the output variables. The column for physical constraints gives the physical limitations on the range of values that can be taken by the variable.
                 </p>
                 <div id="Table:OutDataConstraints">
                   <table class="table">
@@ -2512,7 +2512,7 @@
               </p>
               <p>
                 <div id="verifyPhysCons">
-                  Verify-Physical_Constraints: Verify that the inputs satisfy the required physical constraints from <a href=#Sec:SolCharSpec>Sec:Solution Characteristics Specification</a>.
+                  Verify-Physical_Constraints: Verify that the inputs satisfy the required physical constraints from the <a href=#Sec:SolCharSpec>solution characteristics specification</a>.
                 </div>
               </p>
               <p>
@@ -2639,7 +2639,7 @@
       <div class="section">
         <h1>Off-The-Shelf Solutions</h1>
         <p class="paragraph">
-          As mentioned in <a href=#Sec:ProbDesc>Sec:Problem Description</a>, there already exist free open source game physics libraries. Similar 2D physics libraries are:
+          As mentioned in the <a href=#Sec:ProbDesc>problem description</a>, there already exist free open source game physics libraries. Similar 2D physics libraries are:
         </p>
         <ul class="list">
           <li>Box2D: http://box2d.org/</li>

--- a/code/stable/gamephysics/Website/GamePhysics_SRS.html
+++ b/code/stable/gamephysics/Website/GamePhysics_SRS.html
@@ -23,7 +23,7 @@
           <div class="subsection">
             <h2>Table of Units</h2>
             <p class="paragraph">
-              The unit system used throughout is SI (Système International d'Unités). In addition to the basic units, several derived units are also used. For each unit, <a href=#Table:ToU>Tab:ToU</a> lists the symbol, a description and the SI name.
+              The unit system used throughout is SI (Système International d'Unités). In addition to the basic units, several derived units are also used. For each unit, the <a href=#Table:ToU>table of units</a> lists the symbol, a description and the SI name.
             </p>
             <div id="Table:ToU">
               <table class="table">
@@ -71,7 +71,7 @@
           <div class="subsection">
             <h2>Table of Symbols</h2>
             <p class="paragraph">
-              The symbols used in this document are summarized in <a href=#Table:ToS>Tab:ToS</a> along with their units. Throughout the document, symbols in bold will represent vectors, and scalars otherwise. The symbols are listed in alphabetical order. For vector quantities, the units shown are for each component of the vector.
+              The symbols used in this document are summarized in the <a href=#Table:ToS>table of symbols</a> along with their units. Throughout the document, symbols in bold will represent vectors, and scalars otherwise. The symbols are listed in alphabetical order. For vector quantities, the units shown are for each component of the vector.
             </p>
             <div id="Table:ToS">
               <table class="table">
@@ -690,7 +690,7 @@
           <div class="subsection">
             <h2>Solution Characteristics Specification</h2>
             <p class="paragraph">
-              The instance models that govern Game Physics are presented in <a href=#Sec:IMs>Sec:Instance Models</a>. The information to understand the meaning of the instance models and their derivation is also presented, so that the instance models can be verified.
+              The instance models that govern Game Physics are presented in the <a href=#Sec:IMs>instance model section</a>. The information to understand the meaning of the instance models and their derivation is also presented, so that the instance models can be verified.
             </p>
             <div id="Sec:Assumps">
               <div class="subsubsection">
@@ -2058,7 +2058,7 @@
               <div class="subsubsection">
                 <h3>Instance Models</h3>
                 <p class="paragraph">
-                  This section transforms the problem defined in <a href=#Sec:ProbDesc>Sec:Problem Description</a> into one which is expressed in mathematical terms. It uses concrete symbols defined in <a href=#Sec:DDs>Sec:Data Definitions</a> to replace the abstract symbols in the models identified in <a href=#Sec:TMs>Sec:Theoretical Models</a> and <a href=#Sec:GDs>Sec:General Definitions</a>.
+                  This section transforms the problem defined in the <a href=#Sec:ProbDesc>problem description</a> into one which is expressed in mathematical terms. It uses concrete symbols defined in the <a href=#Sec:DDs>data definitions</a> to replace the abstract symbols in the models identified in <a href=#Sec:TMs>theoretical models</a> and <a href=#Sec:GDs>general definitions</a>.
                 </p>
                 <p class="paragraph">
                   The goal <a href=#linearGS>GS:Determine-Linear-Properties</a> is met by <a href=#IM:transMot>IM:transMot</a> and <a href=#IM:col2D>IM:col2D</a>. The goal <a href=#angularGS>GS:Determine-Angular-Properties</a> is met by <a href=#IM:rotMot>IM:rotMot</a> and <a href=#IM:col2D>IM:col2D</a>.
@@ -2361,7 +2361,7 @@
               <div class="subsubsection">
                 <h3>Data Constraints</h3>
                 <p class="paragraph">
-                  <a href=#Table:InDataConstraints>Tab:InDataConstraints</a> shows the data constraints on the input variables. The column for physical constraints gives the physical limitations on the range of values that can be taken by the variable. The uncertainty column provides an estimate of the confidence with which the physical quantities can be measured. This information would be part of the input if one were performing an uncertainty quantification exercise. The constraints are conservative, to give the user of the model the flexibility to experiment with unusual situations. The column of typical values is intended to provide a feel for a common scenario.
+                  The <a href=#Table:InDataConstraints>data constraints table</a> shows the data constraints on the input variables. The column for physical constraints gives the physical limitations on the range of values that can be taken by the variable. The uncertainty column provides an estimate of the confidence with which the physical quantities can be measured. This information would be part of the input if one were performing an uncertainty quantification exercise. The constraints are conservative, to give the user of the model the flexibility to experiment with unusual situations. The column of typical values is intended to provide a feel for a common scenario.
                 </p>
                 <div id="Table:InDataConstraints">
                   <table class="table">
@@ -2464,7 +2464,7 @@
               <div class="subsubsection">
                 <h3>Properties of a Correct Solution</h3>
                 <p class="paragraph">
-                  <a href=#Table:OutDataConstraints>Tab:OutDataConstraints</a> shows the data constraints on the output variables. The column for physical constraints gives the physical limitations on the range of values that can be taken by the variable.
+                  The <a href=#Table:OutDataConstraints>data constraints table</a> shows the data constraints on the output variables. The column for physical constraints gives the physical limitations on the range of values that can be taken by the variable.
                 </p>
                 <div id="Table:OutDataConstraints">
                   <table class="table">

--- a/code/stable/glassbr/SRS/GlassBR_SRS.tex
+++ b/code/stable/glassbr/SRS/GlassBR_SRS.tex
@@ -35,7 +35,7 @@ This section records information for easy reference.
 
 \subsection{Table of Units}
 \label{Sec:ToU}
-The unit system used throughout is SI (Système International d'Unités). In addition to the basic units, several derived units are also used. For each unit, the \hyperref[Table:ToU]{table of units} lists the symbol, a description and the SI name.
+The unit system used throughout is SI (Système International d'Unités). In addition to the basic units, several derived units are also used. For each unit, the \hyperref[Table:ToU]{Table of Units} lists the symbol, a description and the SI name.
 
 \begin{longtable}{l l l}
 \toprule
@@ -59,7 +59,7 @@ ${\text{s}}$ & time & second
 \end{longtable}
 \subsection{Table of Symbols}
 \label{Sec:ToS}
-The symbols used in this document are summarized in the \hyperref[Table:ToS]{table of symbols} along with their units. The symbols are listed in alphabetical order.
+The symbols used in this document are summarized in the \hyperref[Table:ToS]{Table of Symbols} along with their units. The symbols are listed in alphabetical order.
 
 \begin{longtabu}{l X[l] l}
 \toprule
@@ -371,7 +371,7 @@ Given the dimensions of the glass plane, the glass type, the characteristics of 
 \end{itemize}
 \subsection{Solution Characteristics Specification}
 \label{Sec:SolCharSpec}
-The instance models that govern GlassBR are presented in the \hyperref[Sec:IMs]{instance model section}. The information to understand the meaning of the instance models and their derivation is also presented, so that the instance models can be verified.
+The instance models that govern GlassBR are presented in the \hyperref[Sec:IMs]{Instance Model Section}. The information to understand the meaning of the instance models and their derivation is also presented, so that the instance models can be verified.
 
 \subsubsection{Assumptions}
 \label{Sec:Assumps}
@@ -1236,7 +1236,7 @@ RefBy & \hyperref[IM:isSafePb]{IM:isSafePb}
 \end{minipage}
 \subsubsection{Data Constraints}
 \label{Sec:DataConstraints}
-The \hyperref[Table:InDataConstraints]{data constraints table} shows the data constraints on the input variables. The column for physical constraints gives the physical limitations on the range of values that can be taken by the variable. The uncertainty column provides an estimate of the confidence with which the physical quantities can be measured. This information would be part of the input if one were performing an uncertainty quantification exercise. The constraints are conservative, to give the user of the model the flexibility to experiment with unusual situations. The column of typical values is intended to provide a feel for a common scenario. The \hyperref[Sec:AuxConstants]{auxiliary constants section} gives the values of the specification parameters used in the \hyperref[Table:InDataConstraints]{data constraints table}.
+The \hyperref[Table:InDataConstraints]{Data Constraints Table} shows the data constraints on the input variables. The column for physical constraints gives the physical limitations on the range of values that can be taken by the variable. The uncertainty column provides an estimate of the confidence with which the physical quantities can be measured. This information would be part of the input if one were performing an uncertainty quantification exercise. The constraints are conservative, to give the user of the model the flexibility to experiment with unusual situations. The column of typical values is intended to provide a feel for a common scenario. The \hyperref[Sec:AuxConstants]{auxiliary constants} give the values of the specification parameters used in the \hyperref[Table:InDataConstraints]{Data Constraints Table}.
 
 \begin{longtable}{l l l l l}
 \toprule
@@ -1264,7 +1264,7 @@ $w$ & $w\gt{}0$ & ${w_{\text{min}}}\leq{}w\leq{}{w_{\text{max}}}$ & $42$ ${\text
 \end{longtable}
 \subsubsection{Properties of a Correct Solution}
 \label{Sec:CorSolProps}
-The \hyperref[Table:OutDataConstraints]{data constraints table} shows the data constraints on the output variables. The column for physical constraints gives the physical limitations on the range of values that can be taken by the variable.
+The \hyperref[Table:OutDataConstraints]{Data Constraints Table} shows the data constraints on the output variables. The column for physical constraints gives the physical limitations on the range of values that can be taken by the variable.
 
 \begin{longtable}{l l}
 \toprule

--- a/code/stable/glassbr/SRS/GlassBR_SRS.tex
+++ b/code/stable/glassbr/SRS/GlassBR_SRS.tex
@@ -287,7 +287,7 @@ The interaction between the product and the user is through a user interface. Th
 \begin{itemize}
 \item{Provide the input data related to the glass slab and blast type, ensuring no errors in the data entry.}
 \item{Ensure that consistent units are used for input variables.}
-\item{Ensure required software assumptions (\hyperref[Sec:Assumps]{Sec:Assumptions}) are appropriate for any particular problem input to the software.}
+\item{Ensure required \hyperref[Sec:Assumps]{software assumptions} are appropriate for any particular problem input to the software.}
 \end{itemize}
 \item{GlassBR Responsibilities}
 \begin{itemize}
@@ -1290,11 +1290,11 @@ This section provides the functional requirements, the tasks and behaviours that
 
 \begin{itemize}
 \item[Input-Values:\phantomsection\label{inputValues}]{Input the values from \hyperref[Table:ReqInputs]{Tab:ReqInputs}, which define the glass dimensions, type of glass, tolerable probability of failure, and the characteristics of the blast.}
-\item[System-Set-Values-Following-Assumptions:\phantomsection\label{sysSetValsFollowingAssumps}]{The system shall set the known values as described in \hyperref[Table:ReqAssignments]{Tab:ReqAssignments}.}
-\item[Check-Input-with-Data\_Constraints:\phantomsection\label{checkInputWithDataCons}]{The system shall check the entered input values to ensure that they do not exceed the data constraints mentioned in \hyperref[Sec:DataConstraints]{Sec:Data Constraints}. If any of the input values are out of bounds, an error message is displayed and the calculations stop.}
+\item[System-Set-Values-Following-Assumptions:\phantomsection\label{sysSetValsFollowingAssumps}]{The system shall set the known values as described in the table for \hyperref[Table:ReqAssignments]{Required Assignments}.}
+\item[Check-Input-with-Data\_Constraints:\phantomsection\label{checkInputWithDataCons}]{The system shall check the entered input values to ensure that they do not exceed the \hyperref[Sec:DataConstraints]{data constraints}. If any of the input values are out of bounds, an error message is displayed and the calculations stop.}
 \item[Output-Values-and-Known-Values:\phantomsection\label{outputValsAndKnownValues}]{Output the input values from \hyperref[inputValues]{FR:Input-Values} and the known values from \hyperref[sysSetValsFollowingAssumps]{FR:System-Set-Values-Following-Assumptions}.}
 \item[Check-Glass-Safety:\phantomsection\label{checkGlassSafety}]{If $is-safePb\land{}is-safeLR$ (from \hyperref[TM:isSafeProb]{TM:isSafeProb} and \hyperref[TM:isSafeLoad]{TM:isSafeLoad}), output the message ``For the given input parameters, the glass is considered safe.'' If the condition is false, then output the message ``For the given input parameters, the glass is NOT considered safe.''}
-\item[Output-Values:\phantomsection\label{outputValues}]{Output the values from \hyperref[Table:ReqOutputs]{Tab:ReqOutputs}.}
+\item[Output-Values:\phantomsection\label{outputValues}]{Output the values from the table for \hyperref[Table:ReqOutputs]{Required Outputs}.}
 \end{itemize}
 \begin{longtabu}{l X[l] l}
 \toprule

--- a/code/stable/glassbr/SRS/GlassBR_SRS.tex
+++ b/code/stable/glassbr/SRS/GlassBR_SRS.tex
@@ -35,7 +35,7 @@ This section records information for easy reference.
 
 \subsection{Table of Units}
 \label{Sec:ToU}
-The unit system used throughout is SI (Système International d'Unités). In addition to the basic units, several derived units are also used. For each unit, \hyperref[Table:ToU]{Tab:ToU} lists the symbol, a description and the SI name.
+The unit system used throughout is SI (Système International d'Unités). In addition to the basic units, several derived units are also used. For each unit, the \hyperref[Table:ToU]{table of units} lists the symbol, a description and the SI name.
 
 \begin{longtable}{l l l}
 \toprule
@@ -59,7 +59,7 @@ ${\text{s}}$ & time & second
 \end{longtable}
 \subsection{Table of Symbols}
 \label{Sec:ToS}
-The symbols used in this document are summarized in \hyperref[Table:ToS]{Tab:ToS} along with their units. The symbols are listed in alphabetical order.
+The symbols used in this document are summarized in the \hyperref[Table:ToS]{table of symbols} along with their units. The symbols are listed in alphabetical order.
 
 \begin{longtabu}{l X[l] l}
 \toprule
@@ -349,7 +349,7 @@ This subsection provides a list of terms that are used in the subsequent section
 \end{enumerate}
 \subsubsection{Physical System Description}
 \label{Sec:PhysSyst}
-The physical system of GlassBR, as shown in \hyperref[Figure:physSystImage]{Fig:physSystImage}, includes the following elements:
+The physical system of GlassBR, as shown in the \hyperref[Figure:physSystImage]{figure} below, includes the following elements:
 
 \begin{itemize}
 \item[PS1:]{The glass slab.}
@@ -371,7 +371,7 @@ Given the dimensions of the glass plane, the glass type, the characteristics of 
 \end{itemize}
 \subsection{Solution Characteristics Specification}
 \label{Sec:SolCharSpec}
-The instance models that govern GlassBR are presented in \hyperref[Sec:IMs]{Sec:Instance Models}. The information to understand the meaning of the instance models and their derivation is also presented, so that the instance models can be verified.
+The instance models that govern GlassBR are presented in the \hyperref[Sec:IMs]{instance model section}. The information to understand the meaning of the instance models and their derivation is also presented, so that the instance models can be verified.
 
 \subsubsection{Assumptions}
 \label{Sec:Assumps}
@@ -1128,7 +1128,7 @@ RefBy & \hyperref[IM:isSafeLR]{IM:isSafeLR} and \hyperref[DD:dimlessLoad]{DD:dim
 
 \subsubsection{Instance Models}
 \label{Sec:IMs}
-This section transforms the problem defined in \hyperref[Sec:ProbDesc]{Sec:Problem Description} into one which is expressed in mathematical terms. It uses concrete symbols defined in \hyperref[Sec:DDs]{Sec:Data Definitions} to replace the abstract symbols in the models identified in \hyperref[Sec:TMs]{Sec:Theoretical Models} and \hyperref[Sec:GDs]{Sec:General Definitions}.
+This section transforms the problem defined in the \hyperref[Sec:ProbDesc]{problem description} into one which is expressed in mathematical terms. It uses concrete symbols defined in the \hyperref[Sec:DDs]{data definitions} to replace the abstract symbols in the models identified in \hyperref[Sec:TMs]{theoretical models} and \hyperref[Sec:GDs]{general definitions}.
 
 The goal \hyperref[willBreakGS]{GS:Predict-Glass-Withstands-Explosion} is met by \hyperref[IM:isSafePb]{IM:isSafePb}, \hyperref[IM:isSafeLR]{IM:isSafeLR}.
 
@@ -1236,7 +1236,7 @@ RefBy & \hyperref[IM:isSafePb]{IM:isSafePb}
 \end{minipage}
 \subsubsection{Data Constraints}
 \label{Sec:DataConstraints}
-\hyperref[Table:InDataConstraints]{Tab:InDataConstraints} shows the data constraints on the input variables. The column for physical constraints gives the physical limitations on the range of values that can be taken by the variable. The uncertainty column provides an estimate of the confidence with which the physical quantities can be measured. This information would be part of the input if one were performing an uncertainty quantification exercise. The constraints are conservative, to give the user of the model the flexibility to experiment with unusual situations. The column of typical values is intended to provide a feel for a common scenario. \hyperref[Sec:AuxConstants]{Sec:Values of Auxiliary Constants} gives the values of the specification parameters used in \hyperref[Table:InDataConstraints]{Tab:InDataConstraints}.
+The \hyperref[Table:InDataConstraints]{data constraints table} shows the data constraints on the input variables. The column for physical constraints gives the physical limitations on the range of values that can be taken by the variable. The uncertainty column provides an estimate of the confidence with which the physical quantities can be measured. This information would be part of the input if one were performing an uncertainty quantification exercise. The constraints are conservative, to give the user of the model the flexibility to experiment with unusual situations. The column of typical values is intended to provide a feel for a common scenario. The \hyperref[Sec:AuxConstants]{auxiliary constants section} gives the values of the specification parameters used in the \hyperref[Table:InDataConstraints]{data constraints table}.
 
 \begin{longtable}{l l l l l}
 \toprule
@@ -1264,7 +1264,7 @@ $w$ & $w\gt{}0$ & ${w_{\text{min}}}\leq{}w\leq{}{w_{\text{max}}}$ & $42$ ${\text
 \end{longtable}
 \subsubsection{Properties of a Correct Solution}
 \label{Sec:CorSolProps}
-\hyperref[Table:OutDataConstraints]{Tab:OutDataConstraints} shows the data constraints on the output variables. The column for physical constraints gives the physical limitations on the range of values that can be taken by the variable.
+The \hyperref[Table:OutDataConstraints]{data constraints table} shows the data constraints on the output variables. The column for physical constraints gives the physical limitations on the range of values that can be taken by the variable.
 
 \begin{longtable}{l l}
 \toprule

--- a/code/stable/glassbr/SRS/GlassBR_SRS.tex
+++ b/code/stable/glassbr/SRS/GlassBR_SRS.tex
@@ -349,7 +349,7 @@ This subsection provides a list of terms that are used in the subsequent section
 \end{enumerate}
 \subsubsection{Physical System Description}
 \label{Sec:PhysSyst}
-The physical system of GlassBR, as shown in the \hyperref[Figure:physSystImage]{figure} below, includes the following elements:
+The physical system of GlassBR, as shown in the \hyperref[Figure:physSystImage]{Fig:physSystImage} below, includes the following elements:
 
 \begin{itemize}
 \item[PS1:]{The glass slab.}

--- a/code/stable/glassbr/Website/GlassBR_SRS.html
+++ b/code/stable/glassbr/Website/GlassBR_SRS.html
@@ -536,7 +536,7 @@
                   </li>
                   <li>Ensure that consistent units are used for input variables.</li>
                   <li>
-                    Ensure required software assumptions (<a href=#Sec:Assumps>Sec:Assumptions</a>) are appropriate for any particular problem input to the software.
+                    Ensure required <a href=#Sec:Assumps>software assumptions</a> are appropriate for any particular problem input to the software.
                   </li>
                 </ul>
               </li>
@@ -2175,12 +2175,12 @@
               </p>
               <p>
                 <div id="sysSetValsFollowingAssumps">
-                  System-Set-Values-Following-Assumptions: The system shall set the known values as described in <a href=#Table:ReqAssignments>Tab:ReqAssignments</a>.
+                  System-Set-Values-Following-Assumptions: The system shall set the known values as described in the table for <a href=#Table:ReqAssignments>Required Assignments</a>.
                 </div>
               </p>
               <p>
                 <div id="checkInputWithDataCons">
-                  Check-Input-with-Data_Constraints: The system shall check the entered input values to ensure that they do not exceed the data constraints mentioned in <a href=#Sec:DataConstraints>Sec:Data Constraints</a>. If any of the input values are out of bounds, an error message is displayed and the calculations stop.
+                  Check-Input-with-Data_Constraints: The system shall check the entered input values to ensure that they do not exceed the <a href=#Sec:DataConstraints>data constraints</a>. If any of the input values are out of bounds, an error message is displayed and the calculations stop.
                 </div>
               </p>
               <p>
@@ -2195,7 +2195,7 @@
               </p>
               <p>
                 <div id="outputValues">
-                  Output-Values: Output the values from <a href=#Table:ReqOutputs>Tab:ReqOutputs</a>.
+                  Output-Values: Output the values from the table for <a href=#Table:ReqOutputs>Required Outputs</a>.
                 </div>
               </p>
             </div>

--- a/code/stable/glassbr/Website/GlassBR_SRS.html
+++ b/code/stable/glassbr/Website/GlassBR_SRS.html
@@ -23,7 +23,7 @@
           <div class="subsection">
             <h2>Table of Units</h2>
             <p class="paragraph">
-              The unit system used throughout is SI (Système International d'Unités). In addition to the basic units, several derived units are also used. For each unit, <a href=#Table:ToU>Tab:ToU</a> lists the symbol, a description and the SI name.
+              The unit system used throughout is SI (Système International d'Unités). In addition to the basic units, several derived units are also used. For each unit, the <a href=#Table:ToU>table of units</a> lists the symbol, a description and the SI name.
             </p>
             <div id="Table:ToU">
               <table class="table">
@@ -66,7 +66,7 @@
           <div class="subsection">
             <h2>Table of Symbols</h2>
             <p class="paragraph">
-              The symbols used in this document are summarized in <a href=#Table:ToS>Tab:ToS</a> along with their units. The symbols are listed in alphabetical order.
+              The symbols used in this document are summarized in the <a href=#Table:ToS>table of symbols</a> along with their units. The symbols are listed in alphabetical order.
             </p>
             <div id="Table:ToS">
               <table class="table">
@@ -671,7 +671,7 @@
               <div class="subsubsection">
                 <h3>Physical System Description</h3>
                 <p class="paragraph">
-                  The physical system of GlassBR, as shown in <a href=#Figure:physSystImage>Fig:physSystImage</a>, includes the following elements:
+                  The physical system of GlassBR, as shown in the <a href=#Figure:physSystImage>figure</a> below, includes the following elements:
                 </p>
                 <div class="list">
                   <p>PS1: The glass slab.</p>
@@ -708,7 +708,7 @@
           <div class="subsection">
             <h2>Solution Characteristics Specification</h2>
             <p class="paragraph">
-              The instance models that govern GlassBR are presented in <a href=#Sec:IMs>Sec:Instance Models</a>. The information to understand the meaning of the instance models and their derivation is also presented, so that the instance models can be verified.
+              The instance models that govern GlassBR are presented in the <a href=#Sec:IMs>instance model section</a>. The information to understand the meaning of the instance models and their derivation is also presented, so that the instance models can be verified.
             </p>
             <div id="Sec:Assumps">
               <div class="subsubsection">
@@ -1884,7 +1884,7 @@
               <div class="subsubsection">
                 <h3>Instance Models</h3>
                 <p class="paragraph">
-                  This section transforms the problem defined in <a href=#Sec:ProbDesc>Sec:Problem Description</a> into one which is expressed in mathematical terms. It uses concrete symbols defined in <a href=#Sec:DDs>Sec:Data Definitions</a> to replace the abstract symbols in the models identified in <a href=#Sec:TMs>Sec:Theoretical Models</a> and <a href=#Sec:GDs>Sec:General Definitions</a>.
+                  This section transforms the problem defined in the <a href=#Sec:ProbDesc>problem description</a> into one which is expressed in mathematical terms. It uses concrete symbols defined in the <a href=#Sec:DDs>data definitions</a> to replace the abstract symbols in the models identified in <a href=#Sec:TMs>theoretical models</a> and <a href=#Sec:GDs>general definitions</a>.
                 </p>
                 <p class="paragraph">
                   The goal <a href=#willBreakGS>GS:Predict-Glass-Withstands-Explosion</a> is met by <a href=#IM:isSafePb>IM:isSafePb</a>, <a href=#IM:isSafeLR>IM:isSafeLR</a>.
@@ -2045,7 +2045,7 @@
               <div class="subsubsection">
                 <h3>Data Constraints</h3>
                 <p class="paragraph">
-                  <a href=#Table:InDataConstraints>Tab:InDataConstraints</a> shows the data constraints on the input variables. The column for physical constraints gives the physical limitations on the range of values that can be taken by the variable. The uncertainty column provides an estimate of the confidence with which the physical quantities can be measured. This information would be part of the input if one were performing an uncertainty quantification exercise. The constraints are conservative, to give the user of the model the flexibility to experiment with unusual situations. The column of typical values is intended to provide a feel for a common scenario. <a href=#Sec:AuxConstants>Sec:Values of Auxiliary Constants</a> gives the values of the specification parameters used in <a href=#Table:InDataConstraints>Tab:InDataConstraints</a>.
+                  The <a href=#Table:InDataConstraints>data constraints table</a> shows the data constraints on the input variables. The column for physical constraints gives the physical limitations on the range of values that can be taken by the variable. The uncertainty column provides an estimate of the confidence with which the physical quantities can be measured. This information would be part of the input if one were performing an uncertainty quantification exercise. The constraints are conservative, to give the user of the model the flexibility to experiment with unusual situations. The column of typical values is intended to provide a feel for a common scenario. The <a href=#Sec:AuxConstants>auxiliary constants section</a> gives the values of the specification parameters used in the <a href=#Table:InDataConstraints>data constraints table</a>.
                 </p>
                 <div id="Table:InDataConstraints">
                   <table class="table">
@@ -2126,7 +2126,7 @@
               <div class="subsubsection">
                 <h3>Properties of a Correct Solution</h3>
                 <p class="paragraph">
-                  <a href=#Table:OutDataConstraints>Tab:OutDataConstraints</a> shows the data constraints on the output variables. The column for physical constraints gives the physical limitations on the range of values that can be taken by the variable.
+                  The <a href=#Table:OutDataConstraints>data constraints table</a> shows the data constraints on the output variables. The column for physical constraints gives the physical limitations on the range of values that can be taken by the variable.
                 </p>
                 <div id="Table:OutDataConstraints">
                   <table class="table">

--- a/code/stable/glassbr/Website/GlassBR_SRS.html
+++ b/code/stable/glassbr/Website/GlassBR_SRS.html
@@ -23,7 +23,7 @@
           <div class="subsection">
             <h2>Table of Units</h2>
             <p class="paragraph">
-              The unit system used throughout is SI (Système International d'Unités). In addition to the basic units, several derived units are also used. For each unit, the <a href=#Table:ToU>table of units</a> lists the symbol, a description and the SI name.
+              The unit system used throughout is SI (Système International d'Unités). In addition to the basic units, several derived units are also used. For each unit, the <a href=#Table:ToU>Table of Units</a> lists the symbol, a description and the SI name.
             </p>
             <div id="Table:ToU">
               <table class="table">
@@ -66,7 +66,7 @@
           <div class="subsection">
             <h2>Table of Symbols</h2>
             <p class="paragraph">
-              The symbols used in this document are summarized in the <a href=#Table:ToS>table of symbols</a> along with their units. The symbols are listed in alphabetical order.
+              The symbols used in this document are summarized in the <a href=#Table:ToS>Table of Symbols</a> along with their units. The symbols are listed in alphabetical order.
             </p>
             <div id="Table:ToS">
               <table class="table">
@@ -708,7 +708,7 @@
           <div class="subsection">
             <h2>Solution Characteristics Specification</h2>
             <p class="paragraph">
-              The instance models that govern GlassBR are presented in the <a href=#Sec:IMs>instance model section</a>. The information to understand the meaning of the instance models and their derivation is also presented, so that the instance models can be verified.
+              The instance models that govern GlassBR are presented in the <a href=#Sec:IMs>Instance Model Section</a>. The information to understand the meaning of the instance models and their derivation is also presented, so that the instance models can be verified.
             </p>
             <div id="Sec:Assumps">
               <div class="subsubsection">
@@ -2045,7 +2045,7 @@
               <div class="subsubsection">
                 <h3>Data Constraints</h3>
                 <p class="paragraph">
-                  The <a href=#Table:InDataConstraints>data constraints table</a> shows the data constraints on the input variables. The column for physical constraints gives the physical limitations on the range of values that can be taken by the variable. The uncertainty column provides an estimate of the confidence with which the physical quantities can be measured. This information would be part of the input if one were performing an uncertainty quantification exercise. The constraints are conservative, to give the user of the model the flexibility to experiment with unusual situations. The column of typical values is intended to provide a feel for a common scenario. The <a href=#Sec:AuxConstants>auxiliary constants section</a> gives the values of the specification parameters used in the <a href=#Table:InDataConstraints>data constraints table</a>.
+                  The <a href=#Table:InDataConstraints>Data Constraints Table</a> shows the data constraints on the input variables. The column for physical constraints gives the physical limitations on the range of values that can be taken by the variable. The uncertainty column provides an estimate of the confidence with which the physical quantities can be measured. This information would be part of the input if one were performing an uncertainty quantification exercise. The constraints are conservative, to give the user of the model the flexibility to experiment with unusual situations. The column of typical values is intended to provide a feel for a common scenario. The <a href=#Sec:AuxConstants>auxiliary constants</a> give the values of the specification parameters used in the <a href=#Table:InDataConstraints>Data Constraints Table</a>.
                 </p>
                 <div id="Table:InDataConstraints">
                   <table class="table">
@@ -2126,7 +2126,7 @@
               <div class="subsubsection">
                 <h3>Properties of a Correct Solution</h3>
                 <p class="paragraph">
-                  The <a href=#Table:OutDataConstraints>data constraints table</a> shows the data constraints on the output variables. The column for physical constraints gives the physical limitations on the range of values that can be taken by the variable.
+                  The <a href=#Table:OutDataConstraints>Data Constraints Table</a> shows the data constraints on the output variables. The column for physical constraints gives the physical limitations on the range of values that can be taken by the variable.
                 </p>
                 <div id="Table:OutDataConstraints">
                   <table class="table">

--- a/code/stable/glassbr/Website/GlassBR_SRS.html
+++ b/code/stable/glassbr/Website/GlassBR_SRS.html
@@ -671,7 +671,7 @@
               <div class="subsubsection">
                 <h3>Physical System Description</h3>
                 <p class="paragraph">
-                  The physical system of GlassBR, as shown in the <a href=#Figure:physSystImage>figure</a> below, includes the following elements:
+                  The physical system of GlassBR, as shown in the <a href=#Figure:physSystImage>Fig:physSystImage</a> below, includes the following elements:
                 </p>
                 <div class="list">
                   <p>PS1: The glass slab.</p>

--- a/code/stable/hghc/SRS/HGHC_SRS.tex
+++ b/code/stable/hghc/SRS/HGHC_SRS.tex
@@ -30,7 +30,7 @@ This section records information for easy reference.
 
 \subsection{Table of Units}
 \label{Sec:ToU}
-The unit system used throughout is SI (Système International d'Unités). In addition to the basic units, several derived units are also used. For each unit, \hyperref[Table:ToU]{Tab:ToU} lists the symbol, a description and the SI name.
+The unit system used throughout is SI (Système International d'Unités). In addition to the basic units, several derived units are also used. For each unit, the \hyperref[Table:ToU]{table of units} lists the symbol, a description and the SI name.
 
 \begin{longtable}{l l l}
 \toprule
@@ -50,7 +50,7 @@ ${\text{W}}$ & power & watt
 \end{longtable}
 \subsection{Table of Symbols}
 \label{Sec:ToS}
-The symbols used in this document are summarized in \hyperref[Table:ToS]{Tab:ToS} along with their units. The choice of symbols was made to be consistent with the nuclear physics literature and with that used in the FP manual.
+The symbols used in this document are summarized in the \hyperref[Table:ToS]{table of symbols} along with their units. The choice of symbols was made to be consistent with the nuclear physics literature and with that used in the FP manual.
 
 \begin{longtabu}{l X[l] l}
 \toprule
@@ -80,7 +80,7 @@ This section first presents the problem description, which gives a high-level vi
 
 \subsection{Solution Characteristics Specification}
 \label{Sec:SolCharSpec}
-The instance models that govern HGHC are presented in \hyperref[Sec:IMs]{Sec:Instance Models}. The information to understand the meaning of the instance models and their derivation is also presented, so that the instance models can be verified.
+The instance models that govern HGHC are presented in the \hyperref[Sec:IMs]{instance model section}. The information to understand the meaning of the instance models and their derivation is also presented, so that the instance models can be verified.
 
 \subsubsection{Data Definitions}
 \label{Sec:DDs}

--- a/code/stable/hghc/SRS/HGHC_SRS.tex
+++ b/code/stable/hghc/SRS/HGHC_SRS.tex
@@ -30,7 +30,7 @@ This section records information for easy reference.
 
 \subsection{Table of Units}
 \label{Sec:ToU}
-The unit system used throughout is SI (Système International d'Unités). In addition to the basic units, several derived units are also used. For each unit, the \hyperref[Table:ToU]{table of units} lists the symbol, a description and the SI name.
+The unit system used throughout is SI (Système International d'Unités). In addition to the basic units, several derived units are also used. For each unit, the \hyperref[Table:ToU]{Table of Units} lists the symbol, a description and the SI name.
 
 \begin{longtable}{l l l}
 \toprule
@@ -50,7 +50,7 @@ ${\text{W}}$ & power & watt
 \end{longtable}
 \subsection{Table of Symbols}
 \label{Sec:ToS}
-The symbols used in this document are summarized in the \hyperref[Table:ToS]{table of symbols} along with their units. The choice of symbols was made to be consistent with the nuclear physics literature and with that used in the FP manual.
+The symbols used in this document are summarized in the \hyperref[Table:ToS]{Table of Symbols} along with their units. The choice of symbols was made to be consistent with the nuclear physics literature and with that used in the FP manual.
 
 \begin{longtabu}{l X[l] l}
 \toprule
@@ -80,7 +80,7 @@ This section first presents the problem description, which gives a high-level vi
 
 \subsection{Solution Characteristics Specification}
 \label{Sec:SolCharSpec}
-The instance models that govern HGHC are presented in the \hyperref[Sec:IMs]{instance model section}. The information to understand the meaning of the instance models and their derivation is also presented, so that the instance models can be verified.
+The instance models that govern HGHC are presented in the \hyperref[Sec:IMs]{Instance Model Section}. The information to understand the meaning of the instance models and their derivation is also presented, so that the instance models can be verified.
 
 \subsubsection{Data Definitions}
 \label{Sec:DDs}

--- a/code/stable/hghc/Website/HGHC_SRS.html
+++ b/code/stable/hghc/Website/HGHC_SRS.html
@@ -21,7 +21,7 @@
           <div class="subsection">
             <h2>Table of Units</h2>
             <p class="paragraph">
-              The unit system used throughout is SI (Système International d'Unités). In addition to the basic units, several derived units are also used. For each unit, the <a href=#Table:ToU>table of units</a> lists the symbol, a description and the SI name.
+              The unit system used throughout is SI (Système International d'Unités). In addition to the basic units, several derived units are also used. For each unit, the <a href=#Table:ToU>Table of Units</a> lists the symbol, a description and the SI name.
             </p>
             <div id="Table:ToU">
               <table class="table">
@@ -54,7 +54,7 @@
           <div class="subsection">
             <h2>Table of Symbols</h2>
             <p class="paragraph">
-              The symbols used in this document are summarized in the <a href=#Table:ToS>table of symbols</a> along with their units. The choice of symbols was made to be consistent with the nuclear physics literature and with that used in the FP manual.
+              The symbols used in this document are summarized in the <a href=#Table:ToS>Table of Symbols</a> along with their units. The choice of symbols was made to be consistent with the nuclear physics literature and with that used in the FP manual.
             </p>
             <div id="Table:ToS">
               <table class="table">
@@ -118,7 +118,7 @@
           <div class="subsection">
             <h2>Solution Characteristics Specification</h2>
             <p class="paragraph">
-              The instance models that govern HGHC are presented in the <a href=#Sec:IMs>instance model section</a>. The information to understand the meaning of the instance models and their derivation is also presented, so that the instance models can be verified.
+              The instance models that govern HGHC are presented in the <a href=#Sec:IMs>Instance Model Section</a>. The information to understand the meaning of the instance models and their derivation is also presented, so that the instance models can be verified.
             </p>
             <div id="Sec:DDs">
               <div class="subsubsection">

--- a/code/stable/hghc/Website/HGHC_SRS.html
+++ b/code/stable/hghc/Website/HGHC_SRS.html
@@ -21,7 +21,7 @@
           <div class="subsection">
             <h2>Table of Units</h2>
             <p class="paragraph">
-              The unit system used throughout is SI (Système International d'Unités). In addition to the basic units, several derived units are also used. For each unit, <a href=#Table:ToU>Tab:ToU</a> lists the symbol, a description and the SI name.
+              The unit system used throughout is SI (Système International d'Unités). In addition to the basic units, several derived units are also used. For each unit, the <a href=#Table:ToU>table of units</a> lists the symbol, a description and the SI name.
             </p>
             <div id="Table:ToU">
               <table class="table">
@@ -54,7 +54,7 @@
           <div class="subsection">
             <h2>Table of Symbols</h2>
             <p class="paragraph">
-              The symbols used in this document are summarized in <a href=#Table:ToS>Tab:ToS</a> along with their units. The choice of symbols was made to be consistent with the nuclear physics literature and with that used in the FP manual.
+              The symbols used in this document are summarized in the <a href=#Table:ToS>table of symbols</a> along with their units. The choice of symbols was made to be consistent with the nuclear physics literature and with that used in the FP manual.
             </p>
             <div id="Table:ToS">
               <table class="table">
@@ -118,7 +118,7 @@
           <div class="subsection">
             <h2>Solution Characteristics Specification</h2>
             <p class="paragraph">
-              The instance models that govern HGHC are presented in <a href=#Sec:IMs>Sec:Instance Models</a>. The information to understand the meaning of the instance models and their derivation is also presented, so that the instance models can be verified.
+              The instance models that govern HGHC are presented in the <a href=#Sec:IMs>instance model section</a>. The information to understand the meaning of the instance models and their derivation is also presented, so that the instance models can be verified.
             </p>
             <div id="Sec:DDs">
               <div class="subsubsection">

--- a/code/stable/nopcm/SRS/NoPCM_SRS.tex
+++ b/code/stable/nopcm/SRS/NoPCM_SRS.tex
@@ -35,7 +35,7 @@ This section records information for easy reference.
 
 \subsection{Table of Units}
 \label{Sec:ToU}
-The unit system used throughout is SI (Système International d'Unités). In addition to the basic units, several derived units are also used. For each unit, the \hyperref[Table:ToU]{table of units} lists the symbol, a description and the SI name.
+The unit system used throughout is SI (Système International d'Unités). In addition to the basic units, several derived units are also used. For each unit, the \hyperref[Table:ToU]{Table of Units} lists the symbol, a description and the SI name.
 
 \begin{longtable}{l l l}
 \toprule
@@ -61,7 +61,7 @@ ${\text{W}}$ & power & watt
 \end{longtable}
 \subsection{Table of Symbols}
 \label{Sec:ToS}
-The symbols used in this document are summarized in the \hyperref[Table:ToS]{table of symbols} along with their units. The choice of symbols was made to be consistent with the heat transfer literature and with existing documentation for solar water heating systems. The symbols are listed in alphabetical order. For vector quantities, the units shown are for each component of the vector.
+The symbols used in this document are summarized in the \hyperref[Table:ToS]{Table of Symbols} along with their units. The choice of symbols was made to be consistent with the heat transfer literature and with existing documentation for solar water heating systems. The symbols are listed in alphabetical order. For vector quantities, the units shown are for each component of the vector.
 
 \begin{longtabu}{l X[l] l}
 \toprule
@@ -326,7 +326,7 @@ Given the temperature of the heating coil, the initial temperature of the water,
 \end{itemize}
 \subsection{Solution Characteristics Specification}
 \label{Sec:SolCharSpec}
-The instance models that govern SWHS are presented in the \hyperref[Sec:IMs]{instance model section}. The information to understand the meaning of the instance models and their derivation is also presented, so that the instance models can be verified.
+The instance models that govern SWHS are presented in the \hyperref[Sec:IMs]{Instance Model Section}. The information to understand the meaning of the instance models and their derivation is also presented, so that the instance models can be verified.
 
 \subsubsection{Assumptions}
 \label{Sec:Assumps}
@@ -847,7 +847,7 @@ RefBy & \hyperref[calcChgHeatEnergyWtrOverTime]{FR:Calculate-Change-Heat\_Energy
 
 \subsubsection{Data Constraints}
 \label{Sec:DataConstraints}
-The \hyperref[Table:InDataConstraints]{data constraints table} shows the data constraints on the input variables. The column for physical constraints gives the physical limitations on the range of values that can be taken by the variable. The uncertainty column provides an estimate of the confidence with which the physical quantities can be measured. This information would be part of the input if one were performing an uncertainty quantification exercise. The constraints are conservative, to give the user of the model the flexibility to experiment with unusual situations. The column of typical values is intended to provide a feel for a common scenario. The column for software constraints restricts the range of inputs to reasonable values.
+The \hyperref[Table:InDataConstraints]{Data Constraints Table} shows the data constraints on the input variables. The column for physical constraints gives the physical limitations on the range of values that can be taken by the variable. The uncertainty column provides an estimate of the confidence with which the physical quantities can be measured. This information would be part of the input if one were performing an uncertainty quantification exercise. The constraints are conservative, to give the user of the model the flexibility to experiment with unusual situations. The column of typical values is intended to provide a feel for a common scenario. The column for software constraints restricts the range of inputs to reasonable values.
 
 \begin{longtable}{l l l l l}
 \toprule
@@ -881,7 +881,7 @@ ${ρ_{\text{W}}}$ & ${ρ_{\text{W}}}\gt{}0$ & ${{ρ_{\text{W}}}^{\text{min}}}\lt
 \end{longtable}
 \subsubsection{Properties of a Correct Solution}
 \label{Sec:CorSolProps}
-The \hyperref[Table:OutDataConstraints]{data constraints table} shows the data constraints on the output variables. The column for physical constraints gives the physical limitations on the range of values that can be taken by the variable.
+The \hyperref[Table:OutDataConstraints]{Data Constraints Table} shows the data constraints on the output variables. The column for physical constraints gives the physical limitations on the range of values that can be taken by the variable.
 
 \begin{longtable}{l l}
 \toprule

--- a/code/stable/nopcm/SRS/NoPCM_SRS.tex
+++ b/code/stable/nopcm/SRS/NoPCM_SRS.tex
@@ -35,7 +35,7 @@ This section records information for easy reference.
 
 \subsection{Table of Units}
 \label{Sec:ToU}
-The unit system used throughout is SI (Système International d'Unités). In addition to the basic units, several derived units are also used. For each unit, \hyperref[Table:ToU]{Tab:ToU} lists the symbol, a description and the SI name.
+The unit system used throughout is SI (Système International d'Unités). In addition to the basic units, several derived units are also used. For each unit, the \hyperref[Table:ToU]{table of units} lists the symbol, a description and the SI name.
 
 \begin{longtable}{l l l}
 \toprule
@@ -61,7 +61,7 @@ ${\text{W}}$ & power & watt
 \end{longtable}
 \subsection{Table of Symbols}
 \label{Sec:ToS}
-The symbols used in this document are summarized in \hyperref[Table:ToS]{Tab:ToS} along with their units. The choice of symbols was made to be consistent with the heat transfer literature and with existing documentation for solar water heating systems. The symbols are listed in alphabetical order. For vector quantities, the units shown are for each component of the vector.
+The symbols used in this document are summarized in the \hyperref[Table:ToS]{table of symbols} along with their units. The choice of symbols was made to be consistent with the heat transfer literature and with existing documentation for solar water heating systems. The symbols are listed in alphabetical order. For vector quantities, the units shown are for each component of the vector.
 
 \begin{longtabu}{l X[l] l}
 \toprule
@@ -303,7 +303,7 @@ This subsection provides a list of terms that are used in the subsequent section
 \end{itemize}
 \subsubsection{Physical System Description}
 \label{Sec:PhysSyst}
-The physical system of SWHS, as shown in \hyperref[Figure:Tank]{Fig:Tank}, includes the following elements:
+The physical system of SWHS, as shown in the \hyperref[Figure:Tank]{figure} below, includes the following elements:
 
 \begin{itemize}
 \item[PS1:]{Tank containing water.}
@@ -326,7 +326,7 @@ Given the temperature of the heating coil, the initial temperature of the water,
 \end{itemize}
 \subsection{Solution Characteristics Specification}
 \label{Sec:SolCharSpec}
-The instance models that govern SWHS are presented in \hyperref[Sec:IMs]{Sec:Instance Models}. The information to understand the meaning of the instance models and their derivation is also presented, so that the instance models can be verified.
+The instance models that govern SWHS are presented in the \hyperref[Sec:IMs]{instance model section}. The information to understand the meaning of the instance models and their derivation is also presented, so that the instance models can be verified.
 
 \subsubsection{Assumptions}
 \label{Sec:Assumps}
@@ -722,7 +722,7 @@ RefBy & \hyperref[outputInputDerivVals]{FR:Output-Input-Derived-Values} and \hyp
 
 \subsubsection{Instance Models}
 \label{Sec:IMs}
-This section transforms the problem defined in \hyperref[Sec:ProbDesc]{Sec:Problem Description} into one which is expressed in mathematical terms. It uses concrete symbols defined in \hyperref[Sec:DDs]{Sec:Data Definitions} to replace the abstract symbols in the models identified in \hyperref[Sec:TMs]{Sec:Theoretical Models} and \hyperref[Sec:GDs]{Sec:General Definitions}.
+This section transforms the problem defined in the \hyperref[Sec:ProbDesc]{problem description} into one which is expressed in mathematical terms. It uses concrete symbols defined in the \hyperref[Sec:DDs]{data definitions} to replace the abstract symbols in the models identified in \hyperref[Sec:TMs]{theoretical models} and \hyperref[Sec:GDs]{general definitions}.
 
 The goal \hyperref[waterTempGS]{GS:Predict-Water-Temperature} is met by \hyperref[IM:eBalanceOnWtr]{IM:eBalanceOnWtr} and the goal \hyperref[waterEnergyGS]{GS:Predict-Water-Energy} is met by \hyperref[IM:heatEInWtr]{IM:heatEInWtr}.
 
@@ -847,7 +847,7 @@ RefBy & \hyperref[calcChgHeatEnergyWtrOverTime]{FR:Calculate-Change-Heat\_Energy
 
 \subsubsection{Data Constraints}
 \label{Sec:DataConstraints}
-\hyperref[Table:InDataConstraints]{Tab:InDataConstraints} shows the data constraints on the input variables. The column for physical constraints gives the physical limitations on the range of values that can be taken by the variable. The uncertainty column provides an estimate of the confidence with which the physical quantities can be measured. This information would be part of the input if one were performing an uncertainty quantification exercise. The constraints are conservative, to give the user of the model the flexibility to experiment with unusual situations. The column of typical values is intended to provide a feel for a common scenario. The column for software constraints restricts the range of inputs to reasonable values.
+The \hyperref[Table:InDataConstraints]{data constraints table} shows the data constraints on the input variables. The column for physical constraints gives the physical limitations on the range of values that can be taken by the variable. The uncertainty column provides an estimate of the confidence with which the physical quantities can be measured. This information would be part of the input if one were performing an uncertainty quantification exercise. The constraints are conservative, to give the user of the model the flexibility to experiment with unusual situations. The column of typical values is intended to provide a feel for a common scenario. The column for software constraints restricts the range of inputs to reasonable values.
 
 \begin{longtable}{l l l l l}
 \toprule
@@ -881,7 +881,7 @@ ${ρ_{\text{W}}}$ & ${ρ_{\text{W}}}\gt{}0$ & ${{ρ_{\text{W}}}^{\text{min}}}\lt
 \end{longtable}
 \subsubsection{Properties of a Correct Solution}
 \label{Sec:CorSolProps}
-\hyperref[Table:OutDataConstraints]{Tab:OutDataConstraints} shows the data constraints on the output variables. The column for physical constraints gives the physical limitations on the range of values that can be taken by the variable.
+The \hyperref[Table:OutDataConstraints]{data constraints table} shows the data constraints on the output variables. The column for physical constraints gives the physical limitations on the range of values that can be taken by the variable.
 
 \begin{longtable}{l l}
 \toprule

--- a/code/stable/nopcm/SRS/NoPCM_SRS.tex
+++ b/code/stable/nopcm/SRS/NoPCM_SRS.tex
@@ -906,9 +906,9 @@ This section provides the functional requirements, the tasks and behaviours that
 This section provides the functional requirements, the tasks and behaviours that the software is expected to complete.
 
 \begin{itemize}
-\item[Input-Initial-Values:\phantomsection\label{inputInitVals}]{Input the following values described in \hyperref[Table:ReqInputs]{Tab:ReqInputs}, which define the tank parameters, material properties, and initial conditions.}
+\item[Input-Initial-Values:\phantomsection\label{inputInitVals}]{Input the following values described in the table for \hyperref[Table:ReqInputs]{Required Inputs}, which define the tank parameters, material properties, and initial conditions.}
 \item[Find-Mass:\phantomsection\label{findMass}]{Use the inputs in \hyperref[inputInitVals]{FR:Input-Initial-Values} to find the mass needed for \hyperref[IM:eBalanceOnWtr]{IM:eBalanceOnWtr}, using \hyperref[DD:waterMass]{DD:waterMass}, \hyperref[DD:waterVolume.nopcm]{DD:waterVolume\_nopcm}, and \hyperref[DD:tankVolume]{DD:tankVolume}.}
-\item[Check-Input-with-Physical\_Constraints:\phantomsection\label{checkWithPhysConsts}]{Verify that the inputs satisfy the required physical constraints shown in \hyperref[Sec:DataConstraints]{Sec:Data Constraints}.}
+\item[Check-Input-with-Physical\_Constraints:\phantomsection\label{checkWithPhysConsts}]{Verify that the inputs satisfy the required \hyperref[Sec:DataConstraints]{physical constraints}.}
 \item[Output-Input-Derived-Values:\phantomsection\label{outputInputDerivVals}]{Output the input values and derived values in the following list: the values (from \hyperref[inputInitVals]{FR:Input-Initial-Values}), the mass (from \hyperref[findMass]{FR:Find-Mass}), and ${τ_{\text{W}}}$ (from \hyperref[DD:balanceDecayRate]{DD:balanceDecayRate}).}
 \item[Calculate-Temperature-Water-Over-Time:\phantomsection\label{calcTempWtrOverTime}]{Calculate and output the temperature of the water (${T_{\text{W}}}$($t$)) over the simulation time (from \hyperref[IM:eBalanceOnWtr]{IM:eBalanceOnWtr}).}
 \item[Calculate-Change-Heat\_Energy-Water-Over-Time:\phantomsection\label{calcChgHeatEnergyWtrOverTime}]{Calculate and output the change in heat energy in the water (${E_{\text{W}}}$($t$)) over the simulation time (from \hyperref[IM:heatEInWtr]{IM:heatEInWtr}).}
@@ -952,7 +952,7 @@ ${ρ_{\text{W}}}$ & Density of water & $\frac{\text{kg}}{\text{m}^{3}}$
 This section provides the non-functional requirements, the qualities that the software is expected to exhibit.
 
 \begin{itemize}
-\item[Correct:\phantomsection\label{correct}]{The outputs of the code have the properties described in \hyperref[Sec:CorSolProps]{Sec:Properties of a Correct Solution}.}
+\item[Correct:\phantomsection\label{correct}]{The outputs of the code have the properties described in \hyperref[Sec:CorSolProps]{Properties of a Correct Solution}.}
 \item[Verifiable:\phantomsection\label{verifiable}]{The code is tested with complete verification and validation plan.}
 \item[Understandable:\phantomsection\label{understandable}]{The code is modularized with complete module guide and module interface specification.}
 \item[Reusable:\phantomsection\label{reusable}]{The code is modularized.}

--- a/code/stable/nopcm/SRS/NoPCM_SRS.tex
+++ b/code/stable/nopcm/SRS/NoPCM_SRS.tex
@@ -303,7 +303,7 @@ This subsection provides a list of terms that are used in the subsequent section
 \end{itemize}
 \subsubsection{Physical System Description}
 \label{Sec:PhysSyst}
-The physical system of SWHS, as shown in the \hyperref[Figure:Tank]{figure} below, includes the following elements:
+The physical system of SWHS, as shown in the \hyperref[Figure:Tank]{Fig:Tank} below, includes the following elements:
 
 \begin{itemize}
 \item[PS1:]{Tank containing water.}

--- a/code/stable/nopcm/Website/NoPCM_SRS.html
+++ b/code/stable/nopcm/Website/NoPCM_SRS.html
@@ -589,7 +589,7 @@
               <div class="subsubsection">
                 <h3>Physical System Description</h3>
                 <p class="paragraph">
-                  The physical system of SWHS, as shown in the <a href=#Figure:Tank>figure</a> below, includes the following elements:
+                  The physical system of SWHS, as shown in the <a href=#Figure:Tank>Fig:Tank</a> below, includes the following elements:
                 </p>
                 <div class="list">
                   <p>PS1: Tank containing water.</p>

--- a/code/stable/nopcm/Website/NoPCM_SRS.html
+++ b/code/stable/nopcm/Website/NoPCM_SRS.html
@@ -1666,7 +1666,7 @@
             <div class="list">
               <p>
                 <div id="inputInitVals">
-                  Input-Initial-Values: Input the following values described in <a href=#Table:ReqInputs>Tab:ReqInputs</a>, which define the tank parameters, material properties, and initial conditions.
+                  Input-Initial-Values: Input the following values described in the table for <a href=#Table:ReqInputs>Required Inputs</a>, which define the tank parameters, material properties, and initial conditions.
                 </div>
               </p>
               <p>
@@ -1676,7 +1676,7 @@
               </p>
               <p>
                 <div id="checkWithPhysConsts">
-                  Check-Input-with-Physical_Constraints: Verify that the inputs satisfy the required physical constraints shown in <a href=#Sec:DataConstraints>Sec:Data Constraints</a>.
+                  Check-Input-with-Physical_Constraints: Verify that the inputs satisfy the required <a href=#Sec:DataConstraints>physical constraints</a>.
                 </div>
               </p>
               <p>
@@ -1782,7 +1782,7 @@
             <div class="list">
               <p>
                 <div id="correct">
-                  Correct: The outputs of the code have the properties described in <a href=#Sec:CorSolProps>Sec:Properties of a Correct Solution</a>.
+                  Correct: The outputs of the code have the properties described in <a href=#Sec:CorSolProps>Properties of a Correct Solution</a>.
                 </div>
               </p>
               <p>

--- a/code/stable/nopcm/Website/NoPCM_SRS.html
+++ b/code/stable/nopcm/Website/NoPCM_SRS.html
@@ -25,7 +25,7 @@
           <div class="subsection">
             <h2>Table of Units</h2>
             <p class="paragraph">
-              The unit system used throughout is SI (Système International d'Unités). In addition to the basic units, several derived units are also used. For each unit, the <a href=#Table:ToU>table of units</a> lists the symbol, a description and the SI name.
+              The unit system used throughout is SI (Système International d'Unités). In addition to the basic units, several derived units are also used. For each unit, the <a href=#Table:ToU>Table of Units</a> lists the symbol, a description and the SI name.
             </p>
             <div id="Table:ToU">
               <table class="table">
@@ -73,7 +73,7 @@
           <div class="subsection">
             <h2>Table of Symbols</h2>
             <p class="paragraph">
-              The symbols used in this document are summarized in the <a href=#Table:ToS>table of symbols</a> along with their units. The choice of symbols was made to be consistent with the heat transfer literature and with existing documentation for solar water heating systems. The symbols are listed in alphabetical order. For vector quantities, the units shown are for each component of the vector.
+              The symbols used in this document are summarized in the <a href=#Table:ToS>Table of Symbols</a> along with their units. The choice of symbols was made to be consistent with the heat transfer literature and with existing documentation for solar water heating systems. The symbols are listed in alphabetical order. For vector quantities, the units shown are for each component of the vector.
             </p>
             <div id="Table:ToS">
               <table class="table">
@@ -633,7 +633,7 @@
           <div class="subsection">
             <h2>Solution Characteristics Specification</h2>
             <p class="paragraph">
-              The instance models that govern SWHS are presented in the <a href=#Sec:IMs>instance model section</a>. The information to understand the meaning of the instance models and their derivation is also presented, so that the instance models can be verified.
+              The instance models that govern SWHS are presented in the <a href=#Sec:IMs>Instance Model Section</a>. The information to understand the meaning of the instance models and their derivation is also presented, so that the instance models can be verified.
             </p>
             <div id="Sec:Assumps">
               <div class="subsubsection">
@@ -1510,7 +1510,7 @@
               <div class="subsubsection">
                 <h3>Data Constraints</h3>
                 <p class="paragraph">
-                  The <a href=#Table:InDataConstraints>data constraints table</a> shows the data constraints on the input variables. The column for physical constraints gives the physical limitations on the range of values that can be taken by the variable. The uncertainty column provides an estimate of the confidence with which the physical quantities can be measured. This information would be part of the input if one were performing an uncertainty quantification exercise. The constraints are conservative, to give the user of the model the flexibility to experiment with unusual situations. The column of typical values is intended to provide a feel for a common scenario. The column for software constraints restricts the range of inputs to reasonable values.
+                  The <a href=#Table:InDataConstraints>Data Constraints Table</a> shows the data constraints on the input variables. The column for physical constraints gives the physical limitations on the range of values that can be taken by the variable. The uncertainty column provides an estimate of the confidence with which the physical quantities can be measured. This information would be part of the input if one were performing an uncertainty quantification exercise. The constraints are conservative, to give the user of the model the flexibility to experiment with unusual situations. The column of typical values is intended to provide a feel for a common scenario. The column for software constraints restricts the range of inputs to reasonable values.
                 </p>
                 <div id="Table:InDataConstraints">
                   <table class="table">
@@ -1624,7 +1624,7 @@
               <div class="subsubsection">
                 <h3>Properties of a Correct Solution</h3>
                 <p class="paragraph">
-                  The <a href=#Table:OutDataConstraints>data constraints table</a> shows the data constraints on the output variables. The column for physical constraints gives the physical limitations on the range of values that can be taken by the variable.
+                  The <a href=#Table:OutDataConstraints>Data Constraints Table</a> shows the data constraints on the output variables. The column for physical constraints gives the physical limitations on the range of values that can be taken by the variable.
                 </p>
                 <div id="Table:OutDataConstraints">
                   <table class="table">

--- a/code/stable/nopcm/Website/NoPCM_SRS.html
+++ b/code/stable/nopcm/Website/NoPCM_SRS.html
@@ -25,7 +25,7 @@
           <div class="subsection">
             <h2>Table of Units</h2>
             <p class="paragraph">
-              The unit system used throughout is SI (Système International d'Unités). In addition to the basic units, several derived units are also used. For each unit, <a href=#Table:ToU>Tab:ToU</a> lists the symbol, a description and the SI name.
+              The unit system used throughout is SI (Système International d'Unités). In addition to the basic units, several derived units are also used. For each unit, the <a href=#Table:ToU>table of units</a> lists the symbol, a description and the SI name.
             </p>
             <div id="Table:ToU">
               <table class="table">
@@ -73,7 +73,7 @@
           <div class="subsection">
             <h2>Table of Symbols</h2>
             <p class="paragraph">
-              The symbols used in this document are summarized in <a href=#Table:ToS>Tab:ToS</a> along with their units. The choice of symbols was made to be consistent with the heat transfer literature and with existing documentation for solar water heating systems. The symbols are listed in alphabetical order. For vector quantities, the units shown are for each component of the vector.
+              The symbols used in this document are summarized in the <a href=#Table:ToS>table of symbols</a> along with their units. The choice of symbols was made to be consistent with the heat transfer literature and with existing documentation for solar water heating systems. The symbols are listed in alphabetical order. For vector quantities, the units shown are for each component of the vector.
             </p>
             <div id="Table:ToS">
               <table class="table">
@@ -589,7 +589,7 @@
               <div class="subsubsection">
                 <h3>Physical System Description</h3>
                 <p class="paragraph">
-                  The physical system of SWHS, as shown in <a href=#Figure:Tank>Fig:Tank</a>, includes the following elements:
+                  The physical system of SWHS, as shown in the <a href=#Figure:Tank>figure</a> below, includes the following elements:
                 </p>
                 <div class="list">
                   <p>PS1: Tank containing water.</p>
@@ -633,7 +633,7 @@
           <div class="subsection">
             <h2>Solution Characteristics Specification</h2>
             <p class="paragraph">
-              The instance models that govern SWHS are presented in <a href=#Sec:IMs>Sec:Instance Models</a>. The information to understand the meaning of the instance models and their derivation is also presented, so that the instance models can be verified.
+              The instance models that govern SWHS are presented in the <a href=#Sec:IMs>instance model section</a>. The information to understand the meaning of the instance models and their derivation is also presented, so that the instance models can be verified.
             </p>
             <div id="Sec:Assumps">
               <div class="subsubsection">
@@ -1304,7 +1304,7 @@
               <div class="subsubsection">
                 <h3>Instance Models</h3>
                 <p class="paragraph">
-                  This section transforms the problem defined in <a href=#Sec:ProbDesc>Sec:Problem Description</a> into one which is expressed in mathematical terms. It uses concrete symbols defined in <a href=#Sec:DDs>Sec:Data Definitions</a> to replace the abstract symbols in the models identified in <a href=#Sec:TMs>Sec:Theoretical Models</a> and <a href=#Sec:GDs>Sec:General Definitions</a>.
+                  This section transforms the problem defined in the <a href=#Sec:ProbDesc>problem description</a> into one which is expressed in mathematical terms. It uses concrete symbols defined in the <a href=#Sec:DDs>data definitions</a> to replace the abstract symbols in the models identified in <a href=#Sec:TMs>theoretical models</a> and <a href=#Sec:GDs>general definitions</a>.
                 </p>
                 <p class="paragraph">
                   The goal <a href=#waterTempGS>GS:Predict-Water-Temperature</a> is met by <a href=#IM:eBalanceOnWtr>IM:eBalanceOnWtr</a> and the goal <a href=#waterEnergyGS>GS:Predict-Water-Energy</a> is met by <a href=#IM:heatEInWtr>IM:heatEInWtr</a>.
@@ -1510,7 +1510,7 @@
               <div class="subsubsection">
                 <h3>Data Constraints</h3>
                 <p class="paragraph">
-                  <a href=#Table:InDataConstraints>Tab:InDataConstraints</a> shows the data constraints on the input variables. The column for physical constraints gives the physical limitations on the range of values that can be taken by the variable. The uncertainty column provides an estimate of the confidence with which the physical quantities can be measured. This information would be part of the input if one were performing an uncertainty quantification exercise. The constraints are conservative, to give the user of the model the flexibility to experiment with unusual situations. The column of typical values is intended to provide a feel for a common scenario. The column for software constraints restricts the range of inputs to reasonable values.
+                  The <a href=#Table:InDataConstraints>data constraints table</a> shows the data constraints on the input variables. The column for physical constraints gives the physical limitations on the range of values that can be taken by the variable. The uncertainty column provides an estimate of the confidence with which the physical quantities can be measured. This information would be part of the input if one were performing an uncertainty quantification exercise. The constraints are conservative, to give the user of the model the flexibility to experiment with unusual situations. The column of typical values is intended to provide a feel for a common scenario. The column for software constraints restricts the range of inputs to reasonable values.
                 </p>
                 <div id="Table:InDataConstraints">
                   <table class="table">
@@ -1624,7 +1624,7 @@
               <div class="subsubsection">
                 <h3>Properties of a Correct Solution</h3>
                 <p class="paragraph">
-                  <a href=#Table:OutDataConstraints>Tab:OutDataConstraints</a> shows the data constraints on the output variables. The column for physical constraints gives the physical limitations on the range of values that can be taken by the variable.
+                  The <a href=#Table:OutDataConstraints>data constraints table</a> shows the data constraints on the output variables. The column for physical constraints gives the physical limitations on the range of values that can be taken by the variable.
                 </p>
                 <div id="Table:OutDataConstraints">
                   <table class="table">

--- a/code/stable/pdController/SRS/PDController_SRS.tex
+++ b/code/stable/pdController/SRS/PDController_SRS.tex
@@ -713,7 +713,7 @@ This section provides the functional requirements, the tasks and behaviours that
 
 \begin{itemize}
 \item[Input-Values:\phantomsection\label{inputValues}]{Input the values from \hyperref[Table:ReqInputs]{Tab:ReqInputs}.}
-\item[Verify-Input-Values:\phantomsection\label{verifyInputs}]{Ensure that the input values are within the limits specified in \hyperref[Sec:DataConstraints]{Sec:Data Constraints}.}
+\item[Verify-Input-Values:\phantomsection\label{verifyInputs}]{Ensure that the input values are within the limits specified in the \hyperref[Sec:DataConstraints]{data constraints}.}
 \item[Calculate-Values:\phantomsection\label{calculateValues}]{Calculate the Process Variable (from \hyperref[IM:pdEquationIM]{IM:pdEquationIM}) over the simulation time.}
 \item[Output-Values:\phantomsection\label{outputValues}]{Output the Process Variable (from \hyperref[IM:pdEquationIM]{IM:pdEquationIM}) over the simulation time.}
 \end{itemize}

--- a/code/stable/pdController/SRS/PDController_SRS.tex
+++ b/code/stable/pdController/SRS/PDController_SRS.tex
@@ -35,7 +35,7 @@ This section records information for easy reference.
 
 \subsection{Table of Units}
 \label{Sec:ToU}
-The unit system used throughout is SI (Système International d'Unités). In addition to the basic units, several derived units are also used. For each unit, the \hyperref[Table:ToU]{table of units} lists the symbol, a description and the SI name.
+The unit system used throughout is SI (Système International d'Unités). In addition to the basic units, several derived units are also used. For each unit, the \hyperref[Table:ToU]{Table of Units} lists the symbol, a description and the SI name.
 
 \begin{longtable}{l l l}
 \toprule
@@ -53,7 +53,7 @@ ${\text{s}}$ & time & second
 \end{longtable}
 \subsection{Table of Symbols}
 \label{Sec:ToS}
-The symbols used in this document are summarized in the \hyperref[Table:ToS]{table of symbols} along with their units. The symbols are listed in alphabetical order.
+The symbols used in this document are summarized in the \hyperref[Table:ToS]{Table of Symbols} along with their units. The symbols are listed in alphabetical order.
 
 \begin{longtable}{l l l}
 \toprule
@@ -285,7 +285,7 @@ Given Set-Point, Simulation Time, Proportional Gain, Derivative Gain, and Step T
 \end{itemize}
 \subsection{Solution Characteristics Specification}
 \label{Sec:SolCharSpec}
-The instance models that govern PD Controller are presented in the \hyperref[Sec:IMs]{instance model section}. The information to understand the meaning of the instance models and their derivation is also presented, so that the instance models can be verified.
+The instance models that govern PD Controller are presented in the \hyperref[Sec:IMs]{Instance Model Section}. The information to understand the meaning of the instance models and their derivation is also presented, so that the instance models can be verified.
 
 \subsubsection{Assumptions}
 \label{Sec:Assumps}
@@ -681,7 +681,7 @@ The Set-Point ${r_{\text{t}}}$ is a step function and a constant (from \hyperref
 \end{displaymath}
 \subsubsection{Data Constraints}
 \label{Sec:DataConstraints}
-The \hyperref[Table:InDataConstraints]{data constraints table} shows the data constraints on the input variables. The column for physical constraints gives the physical limitations on the range of values that can be taken by the variable. The uncertainty column provides an estimate of the confidence with which the physical quantities can be measured. This information would be part of the input if one were performing an uncertainty quantification exercise. The constraints are conservative, to give the user of the model the flexibility to experiment with unusual situations. The column of typical values is intended to provide a feel for a common scenario.
+The \hyperref[Table:InDataConstraints]{Data Constraints Table} shows the data constraints on the input variables. The column for physical constraints gives the physical limitations on the range of values that can be taken by the variable. The uncertainty column provides an estimate of the confidence with which the physical quantities can be measured. This information would be part of the input if one were performing an uncertainty quantification exercise. The constraints are conservative, to give the user of the model the flexibility to experiment with unusual situations. The column of typical values is intended to provide a feel for a common scenario.
 
 \begin{longtable}{l l l l}
 \toprule

--- a/code/stable/pdController/SRS/PDController_SRS.tex
+++ b/code/stable/pdController/SRS/PDController_SRS.tex
@@ -262,7 +262,7 @@ This subsection provides a list of terms that are used in the subsequent section
 \end{itemize}
 \subsubsection{Physical System Description}
 \label{Sec:PhysSyst}
-The physical system of PD Controller, as shown in the \hyperref[Figure:pidSysDiagram]{figure} below, includes the following elements:
+The physical system of PD Controller, as shown in the \hyperref[Figure:pidSysDiagram]{Fig:pidSysDiagram} below, includes the following elements:
 
 \begin{itemize}
 \item[PS1:]{The Summing Point.}

--- a/code/stable/pdController/SRS/PDController_SRS.tex
+++ b/code/stable/pdController/SRS/PDController_SRS.tex
@@ -35,7 +35,7 @@ This section records information for easy reference.
 
 \subsection{Table of Units}
 \label{Sec:ToU}
-The unit system used throughout is SI (Système International d'Unités). In addition to the basic units, several derived units are also used. For each unit, \hyperref[Table:ToU]{Tab:ToU} lists the symbol, a description and the SI name.
+The unit system used throughout is SI (Système International d'Unités). In addition to the basic units, several derived units are also used. For each unit, the \hyperref[Table:ToU]{table of units} lists the symbol, a description and the SI name.
 
 \begin{longtable}{l l l}
 \toprule
@@ -53,7 +53,7 @@ ${\text{s}}$ & time & second
 \end{longtable}
 \subsection{Table of Symbols}
 \label{Sec:ToS}
-The symbols used in this document are summarized in \hyperref[Table:ToS]{Tab:ToS} along with their units. The symbols are listed in alphabetical order.
+The symbols used in this document are summarized in the \hyperref[Table:ToS]{table of symbols} along with their units. The symbols are listed in alphabetical order.
 
 \begin{longtable}{l l l}
 \toprule
@@ -262,7 +262,7 @@ This subsection provides a list of terms that are used in the subsequent section
 \end{itemize}
 \subsubsection{Physical System Description}
 \label{Sec:PhysSyst}
-The physical system of PD Controller, as shown in \hyperref[Figure:pidSysDiagram]{Fig:pidSysDiagram}, includes the following elements:
+The physical system of PD Controller, as shown in the \hyperref[Figure:pidSysDiagram]{figure} below, includes the following elements:
 
 \begin{itemize}
 \item[PS1:]{The Summing Point.}
@@ -285,7 +285,7 @@ Given Set-Point, Simulation Time, Proportional Gain, Derivative Gain, and Step T
 \end{itemize}
 \subsection{Solution Characteristics Specification}
 \label{Sec:SolCharSpec}
-The instance models that govern PD Controller are presented in \hyperref[Sec:IMs]{Sec:Instance Models}. The information to understand the meaning of the instance models and their derivation is also presented, so that the instance models can be verified.
+The instance models that govern PD Controller are presented in the \hyperref[Sec:IMs]{instance model section}. The information to understand the meaning of the instance models and their derivation is also presented, so that the instance models can be verified.
 
 \subsubsection{Assumptions}
 \label{Sec:Assumps}
@@ -604,7 +604,7 @@ RefBy & \hyperref[IM:pdEquationIM]{IM:pdEquationIM}
 
 \subsubsection{Instance Models}
 \label{Sec:IMs}
-This section transforms the problem defined in \hyperref[Sec:ProbDesc]{Sec:Problem Description} into one which is expressed in mathematical terms. It uses concrete symbols defined in \hyperref[Sec:DDs]{Sec:Data Definitions} to replace the abstract symbols in the models identified in \hyperref[Sec:TMs]{Sec:Theoretical Models} and \hyperref[Sec:GDs]{Sec:General Definitions}.
+This section transforms the problem defined in the \hyperref[Sec:ProbDesc]{problem description} into one which is expressed in mathematical terms. It uses concrete symbols defined in the \hyperref[Sec:DDs]{data definitions} to replace the abstract symbols in the models identified in \hyperref[Sec:TMs]{theoretical models} and \hyperref[Sec:GDs]{general definitions}.
 
 \vspace{\baselineskip}
 \noindent
@@ -681,7 +681,7 @@ The Set-Point ${r_{\text{t}}}$ is a step function and a constant (from \hyperref
 \end{displaymath}
 \subsubsection{Data Constraints}
 \label{Sec:DataConstraints}
-\hyperref[Table:InDataConstraints]{Tab:InDataConstraints} shows the data constraints on the input variables. The column for physical constraints gives the physical limitations on the range of values that can be taken by the variable. The uncertainty column provides an estimate of the confidence with which the physical quantities can be measured. This information would be part of the input if one were performing an uncertainty quantification exercise. The constraints are conservative, to give the user of the model the flexibility to experiment with unusual situations. The column of typical values is intended to provide a feel for a common scenario.
+The \hyperref[Table:InDataConstraints]{data constraints table} shows the data constraints on the input variables. The column for physical constraints gives the physical limitations on the range of values that can be taken by the variable. The uncertainty column provides an estimate of the confidence with which the physical quantities can be measured. This information would be part of the input if one were performing an uncertainty quantification exercise. The constraints are conservative, to give the user of the model the flexibility to experiment with unusual situations. The column of typical values is intended to provide a feel for a common scenario.
 
 \begin{longtable}{l l l l}
 \toprule

--- a/code/stable/pdController/Website/PDController_SRS.html
+++ b/code/stable/pdController/Website/PDController_SRS.html
@@ -461,7 +461,7 @@
               <div class="subsubsection">
                 <h3>Physical System Description</h3>
                 <p class="paragraph">
-                  The physical system of PD Controller, as shown in the <a href=#Figure:pidSysDiagram>figure</a> below, includes the following elements:
+                  The physical system of PD Controller, as shown in the <a href=#Figure:pidSysDiagram>Fig:pidSysDiagram</a> below, includes the following elements:
                 </p>
                 <div class="list">
                   <p>PS1: The Summing Point.</p>

--- a/code/stable/pdController/Website/PDController_SRS.html
+++ b/code/stable/pdController/Website/PDController_SRS.html
@@ -1246,7 +1246,7 @@
               </p>
               <p>
                 <div id="verifyInputs">
-                  Verify-Input-Values: Ensure that the input values are within the limits specified in <a href=#Sec:DataConstraints>Sec:Data Constraints</a>.
+                  Verify-Input-Values: Ensure that the input values are within the limits specified in the <a href=#Sec:DataConstraints>data constraints</a>.
                 </div>
               </p>
               <p>

--- a/code/stable/pdController/Website/PDController_SRS.html
+++ b/code/stable/pdController/Website/PDController_SRS.html
@@ -23,7 +23,7 @@
           <div class="subsection">
             <h2>Table of Units</h2>
             <p class="paragraph">
-              The unit system used throughout is SI (Système International d'Unités). In addition to the basic units, several derived units are also used. For each unit, the <a href=#Table:ToU>table of units</a> lists the symbol, a description and the SI name.
+              The unit system used throughout is SI (Système International d'Unités). In addition to the basic units, several derived units are also used. For each unit, the <a href=#Table:ToU>Table of Units</a> lists the symbol, a description and the SI name.
             </p>
             <div id="Table:ToU">
               <table class="table">
@@ -51,7 +51,7 @@
           <div class="subsection">
             <h2>Table of Symbols</h2>
             <p class="paragraph">
-              The symbols used in this document are summarized in the <a href=#Table:ToS>table of symbols</a> along with their units. The symbols are listed in alphabetical order.
+              The symbols used in this document are summarized in the <a href=#Table:ToS>Table of Symbols</a> along with their units. The symbols are listed in alphabetical order.
             </p>
             <div id="Table:ToS">
               <table class="table">
@@ -497,7 +497,7 @@
           <div class="subsection">
             <h2>Solution Characteristics Specification</h2>
             <p class="paragraph">
-              The instance models that govern PD Controller are presented in the <a href=#Sec:IMs>instance model section</a>. The information to understand the meaning of the instance models and their derivation is also presented, so that the instance models can be verified.
+              The instance models that govern PD Controller are presented in the <a href=#Sec:IMs>Instance Model Section</a>. The information to understand the meaning of the instance models and their derivation is also presented, so that the instance models can be verified.
             </p>
             <div id="Sec:Assumps">
               <div class="subsubsection">
@@ -1173,7 +1173,7 @@
               <div class="subsubsection">
                 <h3>Data Constraints</h3>
                 <p class="paragraph">
-                  The <a href=#Table:InDataConstraints>data constraints table</a> shows the data constraints on the input variables. The column for physical constraints gives the physical limitations on the range of values that can be taken by the variable. The uncertainty column provides an estimate of the confidence with which the physical quantities can be measured. This information would be part of the input if one were performing an uncertainty quantification exercise. The constraints are conservative, to give the user of the model the flexibility to experiment with unusual situations. The column of typical values is intended to provide a feel for a common scenario.
+                  The <a href=#Table:InDataConstraints>Data Constraints Table</a> shows the data constraints on the input variables. The column for physical constraints gives the physical limitations on the range of values that can be taken by the variable. The uncertainty column provides an estimate of the confidence with which the physical quantities can be measured. This information would be part of the input if one were performing an uncertainty quantification exercise. The constraints are conservative, to give the user of the model the flexibility to experiment with unusual situations. The column of typical values is intended to provide a feel for a common scenario.
                 </p>
                 <div id="Table:InDataConstraints">
                   <table class="table">

--- a/code/stable/pdController/Website/PDController_SRS.html
+++ b/code/stable/pdController/Website/PDController_SRS.html
@@ -23,7 +23,7 @@
           <div class="subsection">
             <h2>Table of Units</h2>
             <p class="paragraph">
-              The unit system used throughout is SI (Système International d'Unités). In addition to the basic units, several derived units are also used. For each unit, <a href=#Table:ToU>Tab:ToU</a> lists the symbol, a description and the SI name.
+              The unit system used throughout is SI (Système International d'Unités). In addition to the basic units, several derived units are also used. For each unit, the <a href=#Table:ToU>table of units</a> lists the symbol, a description and the SI name.
             </p>
             <div id="Table:ToU">
               <table class="table">
@@ -51,7 +51,7 @@
           <div class="subsection">
             <h2>Table of Symbols</h2>
             <p class="paragraph">
-              The symbols used in this document are summarized in <a href=#Table:ToS>Tab:ToS</a> along with their units. The symbols are listed in alphabetical order.
+              The symbols used in this document are summarized in the <a href=#Table:ToS>table of symbols</a> along with their units. The symbols are listed in alphabetical order.
             </p>
             <div id="Table:ToS">
               <table class="table">
@@ -461,7 +461,7 @@
               <div class="subsubsection">
                 <h3>Physical System Description</h3>
                 <p class="paragraph">
-                  The physical system of PD Controller, as shown in <a href=#Figure:pidSysDiagram>Fig:pidSysDiagram</a>, includes the following elements:
+                  The physical system of PD Controller, as shown in the <a href=#Figure:pidSysDiagram>figure</a> below, includes the following elements:
                 </p>
                 <div class="list">
                   <p>PS1: The Summing Point.</p>
@@ -497,7 +497,7 @@
           <div class="subsection">
             <h2>Solution Characteristics Specification</h2>
             <p class="paragraph">
-              The instance models that govern PD Controller are presented in <a href=#Sec:IMs>Sec:Instance Models</a>. The information to understand the meaning of the instance models and their derivation is also presented, so that the instance models can be verified.
+              The instance models that govern PD Controller are presented in the <a href=#Sec:IMs>instance model section</a>. The information to understand the meaning of the instance models and their derivation is also presented, so that the instance models can be verified.
             </p>
             <div id="Sec:Assumps">
               <div class="subsubsection">
@@ -1070,7 +1070,7 @@
               <div class="subsubsection">
                 <h3>Instance Models</h3>
                 <p class="paragraph">
-                  This section transforms the problem defined in <a href=#Sec:ProbDesc>Sec:Problem Description</a> into one which is expressed in mathematical terms. It uses concrete symbols defined in <a href=#Sec:DDs>Sec:Data Definitions</a> to replace the abstract symbols in the models identified in <a href=#Sec:TMs>Sec:Theoretical Models</a> and <a href=#Sec:GDs>Sec:General Definitions</a>.
+                  This section transforms the problem defined in the <a href=#Sec:ProbDesc>problem description</a> into one which is expressed in mathematical terms. It uses concrete symbols defined in the <a href=#Sec:DDs>data definitions</a> to replace the abstract symbols in the models identified in <a href=#Sec:TMs>theoretical models</a> and <a href=#Sec:GDs>general definitions</a>.
                 </p>
                 <div id="IM:pdEquationIM">
                   <table class="idefn">
@@ -1173,7 +1173,7 @@
               <div class="subsubsection">
                 <h3>Data Constraints</h3>
                 <p class="paragraph">
-                  <a href=#Table:InDataConstraints>Tab:InDataConstraints</a> shows the data constraints on the input variables. The column for physical constraints gives the physical limitations on the range of values that can be taken by the variable. The uncertainty column provides an estimate of the confidence with which the physical quantities can be measured. This information would be part of the input if one were performing an uncertainty quantification exercise. The constraints are conservative, to give the user of the model the flexibility to experiment with unusual situations. The column of typical values is intended to provide a feel for a common scenario.
+                  The <a href=#Table:InDataConstraints>data constraints table</a> shows the data constraints on the input variables. The column for physical constraints gives the physical limitations on the range of values that can be taken by the variable. The uncertainty column provides an estimate of the confidence with which the physical quantities can be measured. This information would be part of the input if one were performing an uncertainty quantification exercise. The constraints are conservative, to give the user of the model the flexibility to experiment with unusual situations. The column of typical values is intended to provide a feel for a common scenario.
                 </p>
                 <div id="Table:InDataConstraints">
                   <table class="table">

--- a/code/stable/projectile/SRS/Projectile_SRS.tex
+++ b/code/stable/projectile/SRS/Projectile_SRS.tex
@@ -249,7 +249,7 @@ This section simplifies the original problem and helps in developing the theoret
 \item[freeFlight:\phantomsection\label{freeFlight}]{The flight is free; there are no collisions during the trajectory of the projectile. (RefBy: \hyperref[constAccel]{A:constAccel}.)}
 \item[neglectCurv:\phantomsection\label{neglectCurv}]{The distance is small enough that the curvature of the Earth can be neglected. (RefBy: \hyperref[targetXAxis]{A:targetXAxis} and \hyperref[cartSyst]{A:cartSyst}.)}
 \item[timeStartZero:\phantomsection\label{timeStartZero}]{Time starts at zero. (RefBy: \hyperref[GD:velVec]{GD:velVec}, \hyperref[GD:rectPos]{GD:rectPos}, \hyperref[GD:rectVel]{GD:rectVel}, \hyperref[GD:posVec]{GD:posVec}, and \hyperref[IM:calOfLandingTime]{IM:calOfLandingTime}.)}
-\item[gravAccelValue:\phantomsection\label{gravAccelValue}]{The acceleration due to gravity is assumed to have the value provided in \hyperref[Sec:AuxConstants]{Sec:Values of Auxiliary Constants}. (RefBy: \hyperref[IM:calOfLandingDist]{IM:calOfLandingDist} and \hyperref[IM:calOfLandingTime]{IM:calOfLandingTime}.)}
+\item[gravAccelValue:\phantomsection\label{gravAccelValue}]{The acceleration due to gravity is assumed to have the value provided in the section for \hyperref[Sec:AuxConstants]{Values of Auxiliary Constants}. (RefBy: \hyperref[IM:calOfLandingDist]{IM:calOfLandingDist} and \hyperref[IM:calOfLandingTime]{IM:calOfLandingTime}.)}
 \end{itemize}
 \subsubsection{Theoretical Models}
 \label{Sec:TMs}
@@ -989,7 +989,7 @@ This section provides the functional requirements, the tasks and behaviours that
 
 \begin{itemize}
 \item[Input-Values:\phantomsection\label{inputValues}]{Input the values from \hyperref[Table:ReqInputs]{Tab:ReqInputs}.}
-\item[Verify-Input-Values:\phantomsection\label{verifyInVals}]{Check the entered input values to ensure that they do not exceed the data constraints mentioned in \hyperref[Sec:DataConstraints]{Sec:Data Constraints}. If any of the input values are out of bounds, an error message is displayed and the calculations stop.}
+\item[Verify-Input-Values:\phantomsection\label{verifyInVals}]{Check the entered input values to ensure that they do not exceed the \hyperref[Sec:DataConstraints]{data constraints}. If any of the input values are out of bounds, an error message is displayed and the calculations stop.}
 \item[Calculate-Values:\phantomsection\label{calcValues}]{Calculate the following values: ${t_{\text{flight}}}$ (from \hyperref[IM:calOfLandingTime]{IM:calOfLandingTime}), ${p_{\text{land}}}$ (from \hyperref[IM:calOfLandingDist]{IM:calOfLandingDist}), ${d_{\text{offset}}}$ (from \hyperref[IM:offsetIM]{IM:offsetIM}), and $s$ (from \hyperref[IM:messageIM]{IM:messageIM}).}
 \item[Output-Values:\phantomsection\label{outputValues}]{Output $s$ (from \hyperref[IM:messageIM]{IM:messageIM}) and ${d_{\text{offset}}}$ (from \hyperref[IM:offsetIM]{IM:offsetIM}).}
 \end{itemize}
@@ -1014,7 +1014,7 @@ $θ$ & Launch angle & ${\text{rad}}$
 This section provides the non-functional requirements, the qualities that the software is expected to exhibit.
 
 \begin{itemize}
-\item[Correct:\phantomsection\label{correct}]{The outputs of the code have the properties described in \hyperref[Sec:CorSolProps]{Sec:Properties of a Correct Solution}.}
+\item[Correct:\phantomsection\label{correct}]{The outputs of the code have the properties described in \hyperref[Sec:CorSolProps]{Properties of a Correct Solution}.}
 \item[Verifiable:\phantomsection\label{verifiable}]{The code is tested with complete verification and validation plan.}
 \item[Understandable:\phantomsection\label{understandable}]{The code is modularized with complete module guide and module interface specification.}
 \item[Reusable:\phantomsection\label{reusable}]{The code is modularized.}

--- a/code/stable/projectile/SRS/Projectile_SRS.tex
+++ b/code/stable/projectile/SRS/Projectile_SRS.tex
@@ -35,7 +35,7 @@ This section records information for easy reference.
 
 \subsection{Table of Units}
 \label{Sec:ToU}
-The unit system used throughout is SI (Système International d'Unités). In addition to the basic units, several derived units are also used. For each unit, the \hyperref[Table:ToU]{table of units} lists the symbol, a description and the SI name.
+The unit system used throughout is SI (Système International d'Unités). In addition to the basic units, several derived units are also used. For each unit, the \hyperref[Table:ToU]{Table of Units} lists the symbol, a description and the SI name.
 
 \begin{longtable}{l l l}
 \toprule
@@ -55,7 +55,7 @@ ${\text{s}}$ & time & second
 \end{longtable}
 \subsection{Table of Symbols}
 \label{Sec:ToS}
-The symbols used in this document are summarized in the \hyperref[Table:ToS]{table of symbols} along with their units. Throughout the document, symbols in bold will represent vectors, and scalars otherwise. The symbols are listed in alphabetical order. For vector quantities, the units shown are for each component of the vector.
+The symbols used in this document are summarized in the \hyperref[Table:ToS]{Table of Symbols} along with their units. Throughout the document, symbols in bold will represent vectors, and scalars otherwise. The symbols are listed in alphabetical order. For vector quantities, the units shown are for each component of the vector.
 
 \begin{longtabu}{l X[l] l}
 \toprule
@@ -228,7 +228,7 @@ Given the initial velocity vector of the projectile, the goal statements are:
 \end{itemize}
 \subsection{Solution Characteristics Specification}
 \label{Sec:SolCharSpec}
-The instance models that govern Projectile are presented in the \hyperref[Sec:IMs]{instance model section}. The information to understand the meaning of the instance models and their derivation is also presented, so that the instance models can be verified.
+The instance models that govern Projectile are presented in the \hyperref[Sec:IMs]{Instance Model Section}. The information to understand the meaning of the instance models and their derivation is also presented, so that the instance models can be verified.
 
 \subsubsection{Assumptions}
 \label{Sec:Assumps}
@@ -943,7 +943,7 @@ RefBy & \hyperref[outputValues]{FR:Output-Values} and \hyperref[calcValues]{FR:C
 
 \subsubsection{Data Constraints}
 \label{Sec:DataConstraints}
-The \hyperref[Table:InDataConstraints]{data constraints table} shows the data constraints on the input variables. The column for physical constraints gives the physical limitations on the range of values that can be taken by the variable. The uncertainty column provides an estimate of the confidence with which the physical quantities can be measured. This information would be part of the input if one were performing an uncertainty quantification exercise. The constraints are conservative, to give the user of the model the flexibility to experiment with unusual situations. The column of typical values is intended to provide a feel for a common scenario.
+The \hyperref[Table:InDataConstraints]{Data Constraints Table} shows the data constraints on the input variables. The column for physical constraints gives the physical limitations on the range of values that can be taken by the variable. The uncertainty column provides an estimate of the confidence with which the physical quantities can be measured. This information would be part of the input if one were performing an uncertainty quantification exercise. The constraints are conservative, to give the user of the model the flexibility to experiment with unusual situations. The column of typical values is intended to provide a feel for a common scenario.
 
 \begin{longtable}{l l l l}
 \toprule
@@ -963,7 +963,7 @@ $θ$ & $0\lt{}θ\lt{}\frac{π}{2}$ & $\frac{π}{4}$ ${\text{rad}}$ & 10$\%$
 \end{longtable}
 \subsubsection{Properties of a Correct Solution}
 \label{Sec:CorSolProps}
-The \hyperref[Table:OutDataConstraints]{data constraints table} shows the data constraints on the output variables. The column for physical constraints gives the physical limitations on the range of values that can be taken by the variable.
+The \hyperref[Table:OutDataConstraints]{Data Constraints Table} shows the data constraints on the output variables. The column for physical constraints gives the physical limitations on the range of values that can be taken by the variable.
 
 \begin{longtable}{l l}
 \toprule

--- a/code/stable/projectile/SRS/Projectile_SRS.tex
+++ b/code/stable/projectile/SRS/Projectile_SRS.tex
@@ -35,7 +35,7 @@ This section records information for easy reference.
 
 \subsection{Table of Units}
 \label{Sec:ToU}
-The unit system used throughout is SI (Système International d'Unités). In addition to the basic units, several derived units are also used. For each unit, \hyperref[Table:ToU]{Tab:ToU} lists the symbol, a description and the SI name.
+The unit system used throughout is SI (Système International d'Unités). In addition to the basic units, several derived units are also used. For each unit, the \hyperref[Table:ToU]{table of units} lists the symbol, a description and the SI name.
 
 \begin{longtable}{l l l}
 \toprule
@@ -55,7 +55,7 @@ ${\text{s}}$ & time & second
 \end{longtable}
 \subsection{Table of Symbols}
 \label{Sec:ToS}
-The symbols used in this document are summarized in \hyperref[Table:ToS]{Tab:ToS} along with their units. Throughout the document, symbols in bold will represent vectors, and scalars otherwise. The symbols are listed in alphabetical order. For vector quantities, the units shown are for each component of the vector.
+The symbols used in this document are summarized in the \hyperref[Table:ToS]{table of symbols} along with their units. Throughout the document, symbols in bold will represent vectors, and scalars otherwise. The symbols are listed in alphabetical order. For vector quantities, the units shown are for each component of the vector.
 
 \begin{longtabu}{l X[l] l}
 \toprule
@@ -205,7 +205,7 @@ This subsection provides a list of terms that are used in the subsequent section
 \end{itemize}
 \subsubsection{Physical System Description}
 \label{Sec:PhysSyst}
-The physical system of Projectile, as shown in \hyperref[Figure:Launch]{Fig:Launch}, includes the following elements:
+The physical system of Projectile, as shown in the \hyperref[Figure:Launch]{figure} below, includes the following elements:
 
 \begin{itemize}
 \item[PS1:]{The launcher.}
@@ -228,7 +228,7 @@ Given the initial velocity vector of the projectile, the goal statements are:
 \end{itemize}
 \subsection{Solution Characteristics Specification}
 \label{Sec:SolCharSpec}
-The instance models that govern Projectile are presented in \hyperref[Sec:IMs]{Sec:Instance Models}. The information to understand the meaning of the instance models and their derivation is also presented, so that the instance models can be verified.
+The instance models that govern Projectile are presented in the \hyperref[Sec:IMs]{instance model section}. The information to understand the meaning of the instance models and their derivation is also presented, so that the instance models can be verified.
 
 \subsubsection{Assumptions}
 \label{Sec:Assumps}
@@ -673,7 +673,7 @@ RefBy & \hyperref[IM:calOfLandingTime]{IM:calOfLandingTime}
 
 \subsubsection{Instance Models}
 \label{Sec:IMs}
-This section transforms the problem defined in \hyperref[Sec:ProbDesc]{Sec:Problem Description} into one which is expressed in mathematical terms. It uses concrete symbols defined in \hyperref[Sec:DDs]{Sec:Data Definitions} to replace the abstract symbols in the models identified in \hyperref[Sec:TMs]{Sec:Theoretical Models} and \hyperref[Sec:GDs]{Sec:General Definitions}.
+This section transforms the problem defined in the \hyperref[Sec:ProbDesc]{problem description} into one which is expressed in mathematical terms. It uses concrete symbols defined in the \hyperref[Sec:DDs]{data definitions} to replace the abstract symbols in the models identified in \hyperref[Sec:TMs]{theoretical models} and \hyperref[Sec:GDs]{general definitions}.
 
 \vspace{\baselineskip}
 \noindent
@@ -943,7 +943,7 @@ RefBy & \hyperref[outputValues]{FR:Output-Values} and \hyperref[calcValues]{FR:C
 
 \subsubsection{Data Constraints}
 \label{Sec:DataConstraints}
-\hyperref[Table:InDataConstraints]{Tab:InDataConstraints} shows the data constraints on the input variables. The column for physical constraints gives the physical limitations on the range of values that can be taken by the variable. The uncertainty column provides an estimate of the confidence with which the physical quantities can be measured. This information would be part of the input if one were performing an uncertainty quantification exercise. The constraints are conservative, to give the user of the model the flexibility to experiment with unusual situations. The column of typical values is intended to provide a feel for a common scenario.
+The \hyperref[Table:InDataConstraints]{data constraints table} shows the data constraints on the input variables. The column for physical constraints gives the physical limitations on the range of values that can be taken by the variable. The uncertainty column provides an estimate of the confidence with which the physical quantities can be measured. This information would be part of the input if one were performing an uncertainty quantification exercise. The constraints are conservative, to give the user of the model the flexibility to experiment with unusual situations. The column of typical values is intended to provide a feel for a common scenario.
 
 \begin{longtable}{l l l l}
 \toprule
@@ -963,7 +963,7 @@ $θ$ & $0\lt{}θ\lt{}\frac{π}{2}$ & $\frac{π}{4}$ ${\text{rad}}$ & 10$\%$
 \end{longtable}
 \subsubsection{Properties of a Correct Solution}
 \label{Sec:CorSolProps}
-\hyperref[Table:OutDataConstraints]{Tab:OutDataConstraints} shows the data constraints on the output variables. The column for physical constraints gives the physical limitations on the range of values that can be taken by the variable.
+The \hyperref[Table:OutDataConstraints]{data constraints table} shows the data constraints on the output variables. The column for physical constraints gives the physical limitations on the range of values that can be taken by the variable.
 
 \begin{longtable}{l l}
 \toprule

--- a/code/stable/projectile/SRS/Projectile_SRS.tex
+++ b/code/stable/projectile/SRS/Projectile_SRS.tex
@@ -205,7 +205,7 @@ This subsection provides a list of terms that are used in the subsequent section
 \end{itemize}
 \subsubsection{Physical System Description}
 \label{Sec:PhysSyst}
-The physical system of Projectile, as shown in the \hyperref[Figure:Launch]{figure} below, includes the following elements:
+The physical system of Projectile, as shown in the \hyperref[Figure:Launch]{Fig:Launch} below, includes the following elements:
 
 \begin{itemize}
 \item[PS1:]{The launcher.}

--- a/code/stable/projectile/Website/Projectile_SRS.html
+++ b/code/stable/projectile/Website/Projectile_SRS.html
@@ -370,7 +370,7 @@
               <div class="subsubsection">
                 <h3>Physical System Description</h3>
                 <p class="paragraph">
-                  The physical system of Projectile, as shown in the <a href=#Figure:Launch>figure</a> below, includes the following elements:
+                  The physical system of Projectile, as shown in the <a href=#Figure:Launch>Fig:Launch</a> below, includes the following elements:
                 </p>
                 <div class="list">
                   <p>PS1: The launcher.</p>

--- a/code/stable/projectile/Website/Projectile_SRS.html
+++ b/code/stable/projectile/Website/Projectile_SRS.html
@@ -25,7 +25,7 @@
           <div class="subsection">
             <h2>Table of Units</h2>
             <p class="paragraph">
-              The unit system used throughout is SI (Système International d'Unités). In addition to the basic units, several derived units are also used. For each unit, the <a href=#Table:ToU>table of units</a> lists the symbol, a description and the SI name.
+              The unit system used throughout is SI (Système International d'Unités). In addition to the basic units, several derived units are also used. For each unit, the <a href=#Table:ToU>Table of Units</a> lists the symbol, a description and the SI name.
             </p>
             <div id="Table:ToU">
               <table class="table">
@@ -58,7 +58,7 @@
           <div class="subsection">
             <h2>Table of Symbols</h2>
             <p class="paragraph">
-              The symbols used in this document are summarized in the <a href=#Table:ToS>table of symbols</a> along with their units. Throughout the document, symbols in bold will represent vectors, and scalars otherwise. The symbols are listed in alphabetical order. For vector quantities, the units shown are for each component of the vector.
+              The symbols used in this document are summarized in the <a href=#Table:ToS>Table of Symbols</a> along with their units. Throughout the document, symbols in bold will represent vectors, and scalars otherwise. The symbols are listed in alphabetical order. For vector quantities, the units shown are for each component of the vector.
             </p>
             <div id="Table:ToS">
               <table class="table">
@@ -408,7 +408,7 @@
           <div class="subsection">
             <h2>Solution Characteristics Specification</h2>
             <p class="paragraph">
-              The instance models that govern Projectile are presented in the <a href=#Sec:IMs>instance model section</a>. The information to understand the meaning of the instance models and their derivation is also presented, so that the instance models can be verified.
+              The instance models that govern Projectile are presented in the <a href=#Sec:IMs>Instance Model Section</a>. The information to understand the meaning of the instance models and their derivation is also presented, so that the instance models can be verified.
             </p>
             <div id="Sec:Assumps">
               <div class="subsubsection">
@@ -1526,7 +1526,7 @@
               <div class="subsubsection">
                 <h3>Data Constraints</h3>
                 <p class="paragraph">
-                  The <a href=#Table:InDataConstraints>data constraints table</a> shows the data constraints on the input variables. The column for physical constraints gives the physical limitations on the range of values that can be taken by the variable. The uncertainty column provides an estimate of the confidence with which the physical quantities can be measured. This information would be part of the input if one were performing an uncertainty quantification exercise. The constraints are conservative, to give the user of the model the flexibility to experiment with unusual situations. The column of typical values is intended to provide a feel for a common scenario.
+                  The <a href=#Table:InDataConstraints>Data Constraints Table</a> shows the data constraints on the input variables. The column for physical constraints gives the physical limitations on the range of values that can be taken by the variable. The uncertainty column provides an estimate of the confidence with which the physical quantities can be measured. This information would be part of the input if one were performing an uncertainty quantification exercise. The constraints are conservative, to give the user of the model the flexibility to experiment with unusual situations. The column of typical values is intended to provide a feel for a common scenario.
                 </p>
                 <div id="Table:InDataConstraints">
                   <table class="table">
@@ -1565,7 +1565,7 @@
               <div class="subsubsection">
                 <h3>Properties of a Correct Solution</h3>
                 <p class="paragraph">
-                  The <a href=#Table:OutDataConstraints>data constraints table</a> shows the data constraints on the output variables. The column for physical constraints gives the physical limitations on the range of values that can be taken by the variable.
+                  The <a href=#Table:OutDataConstraints>Data Constraints Table</a> shows the data constraints on the output variables. The column for physical constraints gives the physical limitations on the range of values that can be taken by the variable.
                 </p>
                 <div id="Table:OutDataConstraints">
                   <table class="table">

--- a/code/stable/projectile/Website/Projectile_SRS.html
+++ b/code/stable/projectile/Website/Projectile_SRS.html
@@ -25,7 +25,7 @@
           <div class="subsection">
             <h2>Table of Units</h2>
             <p class="paragraph">
-              The unit system used throughout is SI (Système International d'Unités). In addition to the basic units, several derived units are also used. For each unit, <a href=#Table:ToU>Tab:ToU</a> lists the symbol, a description and the SI name.
+              The unit system used throughout is SI (Système International d'Unités). In addition to the basic units, several derived units are also used. For each unit, the <a href=#Table:ToU>table of units</a> lists the symbol, a description and the SI name.
             </p>
             <div id="Table:ToU">
               <table class="table">
@@ -58,7 +58,7 @@
           <div class="subsection">
             <h2>Table of Symbols</h2>
             <p class="paragraph">
-              The symbols used in this document are summarized in <a href=#Table:ToS>Tab:ToS</a> along with their units. Throughout the document, symbols in bold will represent vectors, and scalars otherwise. The symbols are listed in alphabetical order. For vector quantities, the units shown are for each component of the vector.
+              The symbols used in this document are summarized in the <a href=#Table:ToS>table of symbols</a> along with their units. Throughout the document, symbols in bold will represent vectors, and scalars otherwise. The symbols are listed in alphabetical order. For vector quantities, the units shown are for each component of the vector.
             </p>
             <div id="Table:ToS">
               <table class="table">
@@ -370,7 +370,7 @@
               <div class="subsubsection">
                 <h3>Physical System Description</h3>
                 <p class="paragraph">
-                  The physical system of Projectile, as shown in <a href=#Figure:Launch>Fig:Launch</a>, includes the following elements:
+                  The physical system of Projectile, as shown in the <a href=#Figure:Launch>figure</a> below, includes the following elements:
                 </p>
                 <div class="list">
                   <p>PS1: The launcher.</p>
@@ -408,7 +408,7 @@
           <div class="subsection">
             <h2>Solution Characteristics Specification</h2>
             <p class="paragraph">
-              The instance models that govern Projectile are presented in <a href=#Sec:IMs>Sec:Instance Models</a>. The information to understand the meaning of the instance models and their derivation is also presented, so that the instance models can be verified.
+              The instance models that govern Projectile are presented in the <a href=#Sec:IMs>instance model section</a>. The information to understand the meaning of the instance models and their derivation is also presented, so that the instance models can be verified.
             </p>
             <div id="Sec:Assumps">
               <div class="subsubsection">
@@ -1137,7 +1137,7 @@
               <div class="subsubsection">
                 <h3>Instance Models</h3>
                 <p class="paragraph">
-                  This section transforms the problem defined in <a href=#Sec:ProbDesc>Sec:Problem Description</a> into one which is expressed in mathematical terms. It uses concrete symbols defined in <a href=#Sec:DDs>Sec:Data Definitions</a> to replace the abstract symbols in the models identified in <a href=#Sec:TMs>Sec:Theoretical Models</a> and <a href=#Sec:GDs>Sec:General Definitions</a>.
+                  This section transforms the problem defined in the <a href=#Sec:ProbDesc>problem description</a> into one which is expressed in mathematical terms. It uses concrete symbols defined in the <a href=#Sec:DDs>data definitions</a> to replace the abstract symbols in the models identified in <a href=#Sec:TMs>theoretical models</a> and <a href=#Sec:GDs>general definitions</a>.
                 </p>
                 <div id="IM:calOfLandingTime">
                   <table class="idefn">
@@ -1526,7 +1526,7 @@
               <div class="subsubsection">
                 <h3>Data Constraints</h3>
                 <p class="paragraph">
-                  <a href=#Table:InDataConstraints>Tab:InDataConstraints</a> shows the data constraints on the input variables. The column for physical constraints gives the physical limitations on the range of values that can be taken by the variable. The uncertainty column provides an estimate of the confidence with which the physical quantities can be measured. This information would be part of the input if one were performing an uncertainty quantification exercise. The constraints are conservative, to give the user of the model the flexibility to experiment with unusual situations. The column of typical values is intended to provide a feel for a common scenario.
+                  The <a href=#Table:InDataConstraints>data constraints table</a> shows the data constraints on the input variables. The column for physical constraints gives the physical limitations on the range of values that can be taken by the variable. The uncertainty column provides an estimate of the confidence with which the physical quantities can be measured. This information would be part of the input if one were performing an uncertainty quantification exercise. The constraints are conservative, to give the user of the model the flexibility to experiment with unusual situations. The column of typical values is intended to provide a feel for a common scenario.
                 </p>
                 <div id="Table:InDataConstraints">
                   <table class="table">
@@ -1565,7 +1565,7 @@
               <div class="subsubsection">
                 <h3>Properties of a Correct Solution</h3>
                 <p class="paragraph">
-                  <a href=#Table:OutDataConstraints>Tab:OutDataConstraints</a> shows the data constraints on the output variables. The column for physical constraints gives the physical limitations on the range of values that can be taken by the variable.
+                  The <a href=#Table:OutDataConstraints>data constraints table</a> shows the data constraints on the output variables. The column for physical constraints gives the physical limitations on the range of values that can be taken by the variable.
                 </p>
                 <div id="Table:OutDataConstraints">
                   <table class="table">

--- a/code/stable/projectile/Website/Projectile_SRS.html
+++ b/code/stable/projectile/Website/Projectile_SRS.html
@@ -489,7 +489,7 @@
                   </p>
                   <p>
                     <div id="gravAccelValue">
-                      gravAccelValue: The acceleration due to gravity is assumed to have the value provided in <a href=#Sec:AuxConstants>Sec:Values of Auxiliary Constants</a>. (RefBy: <a href=#IM:calOfLandingDist>IM:calOfLandingDist</a> and <a href=#IM:calOfLandingTime>IM:calOfLandingTime</a>.)
+                      gravAccelValue: The acceleration due to gravity is assumed to have the value provided in the section for <a href=#Sec:AuxConstants>Values of Auxiliary Constants</a>. (RefBy: <a href=#IM:calOfLandingDist>IM:calOfLandingDist</a> and <a href=#IM:calOfLandingTime>IM:calOfLandingTime</a>.)
                     </div>
                   </p>
                 </div>
@@ -1612,7 +1612,7 @@
               </p>
               <p>
                 <div id="verifyInVals">
-                  Verify-Input-Values: Check the entered input values to ensure that they do not exceed the data constraints mentioned in <a href=#Sec:DataConstraints>Sec:Data Constraints</a>. If any of the input values are out of bounds, an error message is displayed and the calculations stop.
+                  Verify-Input-Values: Check the entered input values to ensure that they do not exceed the <a href=#Sec:DataConstraints>data constraints</a>. If any of the input values are out of bounds, an error message is displayed and the calculations stop.
                 </div>
               </p>
               <p>
@@ -1664,7 +1664,7 @@
             <div class="list">
               <p>
                 <div id="correct">
-                  Correct: The outputs of the code have the properties described in <a href=#Sec:CorSolProps>Sec:Properties of a Correct Solution</a>.
+                  Correct: The outputs of the code have the properties described in <a href=#Sec:CorSolProps>Properties of a Correct Solution</a>.
                 </div>
               </p>
               <p>

--- a/code/stable/ssp/SRS/SSP_SRS.tex
+++ b/code/stable/ssp/SRS/SSP_SRS.tex
@@ -35,7 +35,7 @@ This section records information for easy reference.
 
 \subsection{Table of Units}
 \label{Sec:ToU}
-The unit system used throughout is SI (Système International d'Unités). In addition to the basic units, several derived units are also used. For each unit, \hyperref[Table:ToU]{Tab:ToU} lists the symbol, a description and the SI name.
+The unit system used throughout is SI (Système International d'Unités). In addition to the basic units, several derived units are also used. For each unit, the \hyperref[Table:ToU]{table of units} lists the symbol, a description and the SI name.
 
 \begin{longtable}{l l l}
 \toprule
@@ -61,7 +61,7 @@ ${\text{s}}$ & time & second
 \end{longtable}
 \subsection{Table of Symbols}
 \label{Sec:ToS}
-The symbols used in this document are summarized in \hyperref[Table:ToS]{Tab:ToS} along with their units. Throughout the document, a subscript $i$ indicates that the value will be taken at, and analyzed at, a slice or slice interface composing the total slip mass. For vector quantities, the units shown are for each component of the vector.
+The symbols used in this document are summarized in the \hyperref[Table:ToS]{table of symbols} along with their units. Throughout the document, a subscript $i$ indicates that the value will be taken at, and analyzed at, a slice or slice interface composing the total slip mass. For vector quantities, the units shown are for each component of the vector.
 
 \begin{longtabu}{l X[l] l}
 \toprule
@@ -402,7 +402,7 @@ This subsection provides a list of terms that are used in the subsequent section
 \end{itemize}
 \subsubsection{Physical System Description}
 \label{Sec:PhysSyst}
-The physical system of SSP, as shown in \hyperref[Figure:PhysicalSystem]{Fig:PhysicalSystem}, includes the following elements:
+The physical system of SSP, as shown in the \hyperref[Figure:PhysicalSystem]{figure} below, includes the following elements:
 
 \begin{itemize}
 \item[PS1:]{A slope comprised of one soil layer.}
@@ -444,7 +444,7 @@ Given the shape of the soil mass, the location of the water table, and the mater
 \end{itemize}
 \subsection{Solution Characteristics Specification}
 \label{Sec:SolCharSpec}
-The instance models that govern SSP are presented in \hyperref[Sec:IMs]{Sec:Instance Models}. The information to understand the meaning of the instance models and their derivation is also presented, so that the instance models can be verified.
+The instance models that govern SSP are presented in the \hyperref[Sec:IMs]{instance model section}. The information to understand the meaning of the instance models and their derivation is also presented, so that the instance models can be verified.
 
 \subsubsection{Assumptions}
 \label{Sec:Assumps}
@@ -2064,7 +2064,7 @@ RefBy & \hyperref[DD:slcHeight]{DD:slcHeight}
 
 \subsubsection{Instance Models}
 \label{Sec:IMs}
-This section transforms the problem defined in \hyperref[Sec:ProbDesc]{Sec:Problem Description} into one which is expressed in mathematical terms. It uses concrete symbols defined in \hyperref[Sec:DDs]{Sec:Data Definitions} to replace the abstract symbols in the models identified in \hyperref[Sec:TMs]{Sec:Theoretical Models} and \hyperref[Sec:GDs]{Sec:General Definitions}.
+This section transforms the problem defined in the \hyperref[Sec:ProbDesc]{problem description} into one which is expressed in mathematical terms. It uses concrete symbols defined in the \hyperref[Sec:DDs]{data definitions} to replace the abstract symbols in the models identified in \hyperref[Sec:TMs]{theoretical models} and \hyperref[Sec:GDs]{general definitions}.
 
 The goals \hyperref[identifyCritAndFS]{GS:Identify-Crit-and-FS}, \hyperref[determineNormalF]{GS:Determine-Normal-Forces}, and \hyperref[determineShearF]{GS:Determine-Shear-Forces} are met by the simultaneous solution of \hyperref[IM:fctSfty]{IM:fctSfty}, \hyperref[IM:nrmShrFor]{IM:nrmShrFor}, and \hyperref[IM:intsliceFs]{IM:intsliceFs}. The goal \hyperref[identifyCritAndFS]{GS:Identify-Crit-and-FS} is also contributed to by \hyperref[IM:crtSlpId]{IM:crtSlpId}.
 
@@ -2530,7 +2530,7 @@ RefBy & \hyperref[displayGraph]{FR:Display-Graph} and \hyperref[determineCritSli
 
 \subsubsection{Data Constraints}
 \label{Sec:DataConstraints}
-\hyperref[Table:InDataConstraints]{Tab:InDataConstraints} shows the data constraints on the input variables. The column for physical constraints gives the physical limitations on the range of values that can be taken by the variable. The uncertainty column provides an estimate of the confidence with which the physical quantities can be measured. This information would be part of the input if one were performing an uncertainty quantification exercise. The constraints are conservative, to give the user of the model the flexibility to experiment with unusual situations. The column of typical values is intended to provide a feel for a common scenario.
+The \hyperref[Table:InDataConstraints]{data constraints table} shows the data constraints on the input variables. The column for physical constraints gives the physical limitations on the range of values that can be taken by the variable. The uncertainty column provides an estimate of the confidence with which the physical quantities can be measured. This information would be part of the input if one were performing an uncertainty quantification exercise. The constraints are conservative, to give the user of the model the flexibility to experiment with unusual situations. The column of typical values is intended to provide a feel for a common scenario.
 
 \begin{longtable}{l l l l}
 \toprule
@@ -2574,7 +2574,7 @@ $φ'$ & $0\lt{}φ'\lt{}90$ & $25$ ${{}^{\circ}}$ & 10$\%$
 \end{longtable}
 \subsubsection{Properties of a Correct Solution}
 \label{Sec:CorSolProps}
-\hyperref[Table:OutDataConstraints]{Tab:OutDataConstraints} shows the data constraints on the output variables. The column for physical constraints gives the physical limitations on the range of values that can be taken by the variable.
+The \hyperref[Table:OutDataConstraints]{data constraints table} shows the data constraints on the output variables. The column for physical constraints gives the physical limitations on the range of values that can be taken by the variable.
 
 \begin{longtable}{l l}
 \toprule

--- a/code/stable/ssp/SRS/SSP_SRS.tex
+++ b/code/stable/ssp/SRS/SSP_SRS.tex
@@ -402,7 +402,7 @@ This subsection provides a list of terms that are used in the subsequent section
 \end{itemize}
 \subsubsection{Physical System Description}
 \label{Sec:PhysSyst}
-The physical system of SSP, as shown in the \hyperref[Figure:PhysicalSystem]{figure} below, includes the following elements:
+The physical system of SSP, as shown in the \hyperref[Figure:PhysicalSystem]{Fig:PhysicalSystem} below, includes the following elements:
 
 \begin{itemize}
 \item[PS1:]{A slope comprised of one soil layer.}

--- a/code/stable/ssp/SRS/SSP_SRS.tex
+++ b/code/stable/ssp/SRS/SSP_SRS.tex
@@ -35,7 +35,7 @@ This section records information for easy reference.
 
 \subsection{Table of Units}
 \label{Sec:ToU}
-The unit system used throughout is SI (Système International d'Unités). In addition to the basic units, several derived units are also used. For each unit, the \hyperref[Table:ToU]{table of units} lists the symbol, a description and the SI name.
+The unit system used throughout is SI (Système International d'Unités). In addition to the basic units, several derived units are also used. For each unit, the \hyperref[Table:ToU]{Table of Units} lists the symbol, a description and the SI name.
 
 \begin{longtable}{l l l}
 \toprule
@@ -61,7 +61,7 @@ ${\text{s}}$ & time & second
 \end{longtable}
 \subsection{Table of Symbols}
 \label{Sec:ToS}
-The symbols used in this document are summarized in the \hyperref[Table:ToS]{table of symbols} along with their units. Throughout the document, a subscript $i$ indicates that the value will be taken at, and analyzed at, a slice or slice interface composing the total slip mass. For vector quantities, the units shown are for each component of the vector.
+The symbols used in this document are summarized in the \hyperref[Table:ToS]{Table of Symbols} along with their units. Throughout the document, a subscript $i$ indicates that the value will be taken at, and analyzed at, a slice or slice interface composing the total slip mass. For vector quantities, the units shown are for each component of the vector.
 
 \begin{longtabu}{l X[l] l}
 \toprule
@@ -444,7 +444,7 @@ Given the shape of the soil mass, the location of the water table, and the mater
 \end{itemize}
 \subsection{Solution Characteristics Specification}
 \label{Sec:SolCharSpec}
-The instance models that govern SSP are presented in the \hyperref[Sec:IMs]{instance model section}. The information to understand the meaning of the instance models and their derivation is also presented, so that the instance models can be verified.
+The instance models that govern SSP are presented in the \hyperref[Sec:IMs]{Instance Model Section}. The information to understand the meaning of the instance models and their derivation is also presented, so that the instance models can be verified.
 
 \subsubsection{Assumptions}
 \label{Sec:Assumps}
@@ -2530,7 +2530,7 @@ RefBy & \hyperref[displayGraph]{FR:Display-Graph} and \hyperref[determineCritSli
 
 \subsubsection{Data Constraints}
 \label{Sec:DataConstraints}
-The \hyperref[Table:InDataConstraints]{data constraints table} shows the data constraints on the input variables. The column for physical constraints gives the physical limitations on the range of values that can be taken by the variable. The uncertainty column provides an estimate of the confidence with which the physical quantities can be measured. This information would be part of the input if one were performing an uncertainty quantification exercise. The constraints are conservative, to give the user of the model the flexibility to experiment with unusual situations. The column of typical values is intended to provide a feel for a common scenario.
+The \hyperref[Table:InDataConstraints]{Data Constraints Table} shows the data constraints on the input variables. The column for physical constraints gives the physical limitations on the range of values that can be taken by the variable. The uncertainty column provides an estimate of the confidence with which the physical quantities can be measured. This information would be part of the input if one were performing an uncertainty quantification exercise. The constraints are conservative, to give the user of the model the flexibility to experiment with unusual situations. The column of typical values is intended to provide a feel for a common scenario.
 
 \begin{longtable}{l l l l}
 \toprule
@@ -2574,7 +2574,7 @@ $φ'$ & $0\lt{}φ'\lt{}90$ & $25$ ${{}^{\circ}}$ & 10$\%$
 \end{longtable}
 \subsubsection{Properties of a Correct Solution}
 \label{Sec:CorSolProps}
-The \hyperref[Table:OutDataConstraints]{data constraints table} shows the data constraints on the output variables. The column for physical constraints gives the physical limitations on the range of values that can be taken by the variable.
+The \hyperref[Table:OutDataConstraints]{Data Constraints Table} shows the data constraints on the output variables. The column for physical constraints gives the physical limitations on the range of values that can be taken by the variable.
 
 \begin{longtable}{l l}
 \toprule

--- a/code/stable/ssp/SRS/SSP_SRS.tex
+++ b/code/stable/ssp/SRS/SSP_SRS.tex
@@ -353,12 +353,12 @@ The responsibilities of the user and the system are as follows:
 \begin{itemize}
 \item{Provide the input data related to the soil layer(s) and water table (if applicable), ensuring conformation to input data format required by SSP}
 \item{Ensure that consistent units are used for input variables}
-\item{Ensure required software assumptions (\hyperref[Sec:Assumps]{Sec:Assumptions}) are appropriate for the problem to which the user is applying the software}
+\item{Ensure required \hyperref[Sec:Assumps]{software assumptions} are appropriate for the problem to which the user is applying the software}
 \end{itemize}
 \item{SSP Responsibilities}
 \begin{itemize}
 \item{Detect data type mismatch, such as a string of characters input instead of a floating point number}
-\item{Verify that the inputs satisfy the required physical and other data constraints (\hyperref[Sec:DataConstraints]{Sec:Data Constraints})}
+\item{Verify that the inputs satisfy the required physical and other \hyperref[Sec:DataConstraints]{data constraints}}
 \item{Identify the critical slip surface within the possible input range}
 \item{Find the factor of safety for the slope}
 \item{Find the interslice normal force and shear force along the critical slip surface}
@@ -2599,10 +2599,10 @@ This section provides the functional requirements, the tasks and behaviours that
 This section provides the functional requirements, the tasks and behaviours that the software is expected to complete.
 
 \begin{itemize}
-\item[Read-and-Store:\phantomsection\label{readAndStore}]{Read the inputs, shown in \hyperref[Table:ReqInputs]{Tab:ReqInputs}, and store the data.}
-\item[Verify-Input:\phantomsection\label{verifyInput}]{Verify that the input data lie within the physical constraints shown in \hyperref[Sec:DataConstraints]{Sec:Data Constraints}.}
+\item[Read-and-Store:\phantomsection\label{readAndStore}]{Read the inputs, shown in the table \hyperref[Table:ReqInputs]{Required Inputs}, and store the data.}
+\item[Verify-Input:\phantomsection\label{verifyInput}]{Verify that the input data lie within the \hyperref[Sec:DataConstraints]{physical constraints}.}
 \item[Determine-Critical-Slip-Surface:\phantomsection\label{determineCritSlip}]{Determine the critical slip surface for the input slope, corresponding to the minimum factor of safety, by using \hyperref[IM:fctSfty]{IM:fctSfty}, \hyperref[IM:nrmShrFor]{IM:nrmShrFor}, and \hyperref[IM:intsliceFs]{IM:intsliceFs} to calculate the factor of safety for a slip surface and using \hyperref[IM:crtSlpId]{IM:crtSlpId} to find the slip surface that minimizes it.}
-\item[Verify-Output:\phantomsection\label{verifyOutput}]{Verify that the minimum factor of safety and critical slip surface satisfy the physical constraints shown in \hyperref[Sec:CorSolProps]{Sec:Properties of a Correct Solution}.}
+\item[Verify-Output:\phantomsection\label{verifyOutput}]{Verify that the minimum factor of safety and critical slip surface satisfy the physical constraints shown in \hyperref[Sec:CorSolProps]{Properties of a Correct Solution}.}
 \item[Display-Input:\phantomsection\label{displayInput}]{Display as output the user-supplied inputs listed in \hyperref[Table:inputsToOutputTable]{Tab:inputsToOutputTable}.}
 \item[Display-Graph:\phantomsection\label{displayGraph}]{Display the critical slip surface of the 2D slope, as determined from \hyperref[IM:crtSlpId]{IM:crtSlpId}, graphically.}
 \item[Display-Factor-of-Safety:\phantomsection\label{displayFS}]{Display the value of the factor of safety for the critical slip surface, as determined from \hyperref[IM:fctSfty]{IM:fctSfty}, \hyperref[IM:nrmShrFor]{IM:nrmShrFor}, and \hyperref[IM:intsliceFs]{IM:intsliceFs}.}

--- a/code/stable/ssp/Website/SSP_SRS.html
+++ b/code/stable/ssp/Website/SSP_SRS.html
@@ -27,7 +27,7 @@
           <div class="subsection">
             <h2>Table of Units</h2>
             <p class="paragraph">
-              The unit system used throughout is SI (Système International d'Unités). In addition to the basic units, several derived units are also used. For each unit, <a href=#Table:ToU>Tab:ToU</a> lists the symbol, a description and the SI name.
+              The unit system used throughout is SI (Système International d'Unités). In addition to the basic units, several derived units are also used. For each unit, the <a href=#Table:ToU>table of units</a> lists the symbol, a description and the SI name.
             </p>
             <div id="Table:ToU">
               <table class="table">
@@ -75,7 +75,7 @@
           <div class="subsection">
             <h2>Table of Symbols</h2>
             <p class="paragraph">
-              The symbols used in this document are summarized in <a href=#Table:ToS>Tab:ToS</a> along with their units. Throughout the document, a subscript <em>i</em> indicates that the value will be taken at, and analyzed at, a slice or slice interface composing the total slip mass. For vector quantities, the units shown are for each component of the vector.
+              The symbols used in this document are summarized in the <a href=#Table:ToS>table of symbols</a> along with their units. Throughout the document, a subscript <em>i</em> indicates that the value will be taken at, and analyzed at, a slice or slice interface composing the total slip mass. For vector quantities, the units shown are for each component of the vector.
             </p>
             <div id="Table:ToS">
               <table class="table">
@@ -998,7 +998,7 @@
               <div class="subsubsection">
                 <h3>Physical System Description</h3>
                 <p class="paragraph">
-                  The physical system of SSP, as shown in <a href=#Figure:PhysicalSystem>Fig:PhysicalSystem</a>, includes the following elements:
+                  The physical system of SSP, as shown in the <a href=#Figure:PhysicalSystem>figure</a> below, includes the following elements:
                 </p>
                 <div class="list">
                   <p>PS1: A slope comprised of one soil layer.</p>
@@ -1067,7 +1067,7 @@
           <div class="subsection">
             <h2>Solution Characteristics Specification</h2>
             <p class="paragraph">
-              The instance models that govern SSP are presented in <a href=#Sec:IMs>Sec:Instance Models</a>. The information to understand the meaning of the instance models and their derivation is also presented, so that the instance models can be verified.
+              The instance models that govern SSP are presented in the <a href=#Sec:IMs>instance model section</a>. The information to understand the meaning of the instance models and their derivation is also presented, so that the instance models can be verified.
             </p>
             <div id="Sec:Assumps">
               <div class="subsubsection">
@@ -3627,7 +3627,7 @@
               <div class="subsubsection">
                 <h3>Instance Models</h3>
                 <p class="paragraph">
-                  This section transforms the problem defined in <a href=#Sec:ProbDesc>Sec:Problem Description</a> into one which is expressed in mathematical terms. It uses concrete symbols defined in <a href=#Sec:DDs>Sec:Data Definitions</a> to replace the abstract symbols in the models identified in <a href=#Sec:TMs>Sec:Theoretical Models</a> and <a href=#Sec:GDs>Sec:General Definitions</a>.
+                  This section transforms the problem defined in the <a href=#Sec:ProbDesc>problem description</a> into one which is expressed in mathematical terms. It uses concrete symbols defined in the <a href=#Sec:DDs>data definitions</a> to replace the abstract symbols in the models identified in <a href=#Sec:TMs>theoretical models</a> and <a href=#Sec:GDs>general definitions</a>.
                 </p>
                 <p class="paragraph">
                   The goals <a href=#identifyCritAndFS>GS:Identify-Crit-and-FS</a>, <a href=#determineNormalF>GS:Determine-Normal-Forces</a>, and <a href=#determineShearF>GS:Determine-Shear-Forces</a> are met by the simultaneous solution of <a href=#IM:fctSfty>IM:fctSfty</a>, <a href=#IM:nrmShrFor>IM:nrmShrFor</a>, and <a href=#IM:intsliceFs>IM:intsliceFs</a>. The goal <a href=#identifyCritAndFS>GS:Identify-Crit-and-FS</a> is also contributed to by <a href=#IM:crtSlpId>IM:crtSlpId</a>.
@@ -4323,7 +4323,7 @@
               <div class="subsubsection">
                 <h3>Data Constraints</h3>
                 <p class="paragraph">
-                  <a href=#Table:InDataConstraints>Tab:InDataConstraints</a> shows the data constraints on the input variables. The column for physical constraints gives the physical limitations on the range of values that can be taken by the variable. The uncertainty column provides an estimate of the confidence with which the physical quantities can be measured. This information would be part of the input if one were performing an uncertainty quantification exercise. The constraints are conservative, to give the user of the model the flexibility to experiment with unusual situations. The column of typical values is intended to provide a feel for a common scenario.
+                  The <a href=#Table:InDataConstraints>data constraints table</a> shows the data constraints on the input variables. The column for physical constraints gives the physical limitations on the range of values that can be taken by the variable. The uncertainty column provides an estimate of the confidence with which the physical quantities can be measured. This information would be part of the input if one were performing an uncertainty quantification exercise. The constraints are conservative, to give the user of the model the flexibility to experiment with unusual situations. The column of typical values is intended to provide a feel for a common scenario.
                 </p>
                 <div id="Table:InDataConstraints">
                   <table class="table">
@@ -4434,7 +4434,7 @@
               <div class="subsubsection">
                 <h3>Properties of a Correct Solution</h3>
                 <p class="paragraph">
-                  <a href=#Table:OutDataConstraints>Tab:OutDataConstraints</a> shows the data constraints on the output variables. The column for physical constraints gives the physical limitations on the range of values that can be taken by the variable.
+                  The <a href=#Table:OutDataConstraints>data constraints table</a> shows the data constraints on the output variables. The column for physical constraints gives the physical limitations on the range of values that can be taken by the variable.
                 </p>
                 <div id="Table:OutDataConstraints">
                   <table class="table">

--- a/code/stable/ssp/Website/SSP_SRS.html
+++ b/code/stable/ssp/Website/SSP_SRS.html
@@ -27,7 +27,7 @@
           <div class="subsection">
             <h2>Table of Units</h2>
             <p class="paragraph">
-              The unit system used throughout is SI (Système International d'Unités). In addition to the basic units, several derived units are also used. For each unit, the <a href=#Table:ToU>table of units</a> lists the symbol, a description and the SI name.
+              The unit system used throughout is SI (Système International d'Unités). In addition to the basic units, several derived units are also used. For each unit, the <a href=#Table:ToU>Table of Units</a> lists the symbol, a description and the SI name.
             </p>
             <div id="Table:ToU">
               <table class="table">
@@ -75,7 +75,7 @@
           <div class="subsection">
             <h2>Table of Symbols</h2>
             <p class="paragraph">
-              The symbols used in this document are summarized in the <a href=#Table:ToS>table of symbols</a> along with their units. Throughout the document, a subscript <em>i</em> indicates that the value will be taken at, and analyzed at, a slice or slice interface composing the total slip mass. For vector quantities, the units shown are for each component of the vector.
+              The symbols used in this document are summarized in the <a href=#Table:ToS>Table of Symbols</a> along with their units. Throughout the document, a subscript <em>i</em> indicates that the value will be taken at, and analyzed at, a slice or slice interface composing the total slip mass. For vector quantities, the units shown are for each component of the vector.
             </p>
             <div id="Table:ToS">
               <table class="table">
@@ -1067,7 +1067,7 @@
           <div class="subsection">
             <h2>Solution Characteristics Specification</h2>
             <p class="paragraph">
-              The instance models that govern SSP are presented in the <a href=#Sec:IMs>instance model section</a>. The information to understand the meaning of the instance models and their derivation is also presented, so that the instance models can be verified.
+              The instance models that govern SSP are presented in the <a href=#Sec:IMs>Instance Model Section</a>. The information to understand the meaning of the instance models and their derivation is also presented, so that the instance models can be verified.
             </p>
             <div id="Sec:Assumps">
               <div class="subsubsection">
@@ -4323,7 +4323,7 @@
               <div class="subsubsection">
                 <h3>Data Constraints</h3>
                 <p class="paragraph">
-                  The <a href=#Table:InDataConstraints>data constraints table</a> shows the data constraints on the input variables. The column for physical constraints gives the physical limitations on the range of values that can be taken by the variable. The uncertainty column provides an estimate of the confidence with which the physical quantities can be measured. This information would be part of the input if one were performing an uncertainty quantification exercise. The constraints are conservative, to give the user of the model the flexibility to experiment with unusual situations. The column of typical values is intended to provide a feel for a common scenario.
+                  The <a href=#Table:InDataConstraints>Data Constraints Table</a> shows the data constraints on the input variables. The column for physical constraints gives the physical limitations on the range of values that can be taken by the variable. The uncertainty column provides an estimate of the confidence with which the physical quantities can be measured. This information would be part of the input if one were performing an uncertainty quantification exercise. The constraints are conservative, to give the user of the model the flexibility to experiment with unusual situations. The column of typical values is intended to provide a feel for a common scenario.
                 </p>
                 <div id="Table:InDataConstraints">
                   <table class="table">
@@ -4434,7 +4434,7 @@
               <div class="subsubsection">
                 <h3>Properties of a Correct Solution</h3>
                 <p class="paragraph">
-                  The <a href=#Table:OutDataConstraints>data constraints table</a> shows the data constraints on the output variables. The column for physical constraints gives the physical limitations on the range of values that can be taken by the variable.
+                  The <a href=#Table:OutDataConstraints>Data Constraints Table</a> shows the data constraints on the output variables. The column for physical constraints gives the physical limitations on the range of values that can be taken by the variable.
                 </p>
                 <div id="Table:OutDataConstraints">
                   <table class="table">

--- a/code/stable/ssp/Website/SSP_SRS.html
+++ b/code/stable/ssp/Website/SSP_SRS.html
@@ -887,7 +887,7 @@
                   </li>
                   <li>Ensure that consistent units are used for input variables</li>
                   <li>
-                    Ensure required software assumptions (<a href=#Sec:Assumps>Sec:Assumptions</a>) are appropriate for the problem to which the user is applying the software
+                    Ensure required <a href=#Sec:Assumps>software assumptions</a> are appropriate for the problem to which the user is applying the software
                   </li>
                 </ul>
               </li>
@@ -898,7 +898,7 @@
                     Detect data type mismatch, such as a string of characters input instead of a floating point number
                   </li>
                   <li>
-                    Verify that the inputs satisfy the required physical and other data constraints (<a href=#Sec:DataConstraints>Sec:Data Constraints</a>)
+                    Verify that the inputs satisfy the required physical and other <a href=#Sec:DataConstraints>data constraints</a>
                   </li>
                   <li>
                     Identify the critical slip surface within the possible input range
@@ -4474,12 +4474,12 @@
             <div class="list">
               <p>
                 <div id="readAndStore">
-                  Read-and-Store: Read the inputs, shown in <a href=#Table:ReqInputs>Tab:ReqInputs</a>, and store the data.
+                  Read-and-Store: Read the inputs, shown in the table <a href=#Table:ReqInputs>Required Inputs</a>, and store the data.
                 </div>
               </p>
               <p>
                 <div id="verifyInput">
-                  Verify-Input: Verify that the input data lie within the physical constraints shown in <a href=#Sec:DataConstraints>Sec:Data Constraints</a>.
+                  Verify-Input: Verify that the input data lie within the <a href=#Sec:DataConstraints>physical constraints</a>.
                 </div>
               </p>
               <p>
@@ -4489,7 +4489,7 @@
               </p>
               <p>
                 <div id="verifyOutput">
-                  Verify-Output: Verify that the minimum factor of safety and critical slip surface satisfy the physical constraints shown in <a href=#Sec:CorSolProps>Sec:Properties of a Correct Solution</a>.
+                  Verify-Output: Verify that the minimum factor of safety and critical slip surface satisfy the physical constraints shown in <a href=#Sec:CorSolProps>Properties of a Correct Solution</a>.
                 </div>
               </p>
               <p>

--- a/code/stable/ssp/Website/SSP_SRS.html
+++ b/code/stable/ssp/Website/SSP_SRS.html
@@ -998,7 +998,7 @@
               <div class="subsubsection">
                 <h3>Physical System Description</h3>
                 <p class="paragraph">
-                  The physical system of SSP, as shown in the <a href=#Figure:PhysicalSystem>figure</a> below, includes the following elements:
+                  The physical system of SSP, as shown in the <a href=#Figure:PhysicalSystem>Fig:PhysicalSystem</a> below, includes the following elements:
                 </p>
                 <div class="list">
                   <p>PS1: A slope comprised of one soil layer.</p>

--- a/code/stable/swhs/SRS/SWHS_SRS.tex
+++ b/code/stable/swhs/SRS/SWHS_SRS.tex
@@ -384,7 +384,7 @@ This subsection provides a list of terms that are used in the subsequent section
 \end{itemize}
 \subsubsection{Physical System Description}
 \label{Sec:PhysSyst}
-The physical system of SWHS, as shown in the \hyperref[Figure:Tank]{figure} below, includes the following elements:
+The physical system of SWHS, as shown in the \hyperref[Figure:Tank]{Fig:Tank} below, includes the following elements:
 
 \begin{itemize}
 \item[PS1:]{Tank containing water.}

--- a/code/stable/swhs/SRS/SWHS_SRS.tex
+++ b/code/stable/swhs/SRS/SWHS_SRS.tex
@@ -1533,13 +1533,13 @@ This section provides the functional requirements, the tasks and behaviours that
 \begin{itemize}
 \item[Input-Values:\phantomsection\label{inputValues}]{Input the values from \hyperref[Table:ReqInputs]{Tab:ReqInputs}, which define the tank parameters, material properties, and initial conditions.}
 \item[Find-Mass:\phantomsection\label{findMass}]{Use the inputs in \hyperref[inputValues]{FR:Input-Values} to find the masses needed for \hyperref[IM:eBalanceOnWtr]{IM:eBalanceOnWtr}, \hyperref[IM:eBalanceOnPCM]{IM:eBalanceOnPCM}, \hyperref[IM:heatEInWtr]{IM:heatEInWtr}, and \hyperref[IM:heatEInPCM]{IM:heatEInPCM}, using \hyperref[DD:waterMass]{DD:waterMass}, \hyperref[DD:waterVolume.pcm]{DD:waterVolume\_pcm}, and \hyperref[DD:tankVolume]{DD:tankVolume}.}
-\item[Check-Input-with-Physical\_Constraints:\phantomsection\label{checkWithPhysConsts}]{Verify that the inputs satisfy the required physical constraints shown in \hyperref[Sec:DataConstraints]{Sec:Data Constraints}.}
+\item[Check-Input-with-Physical\_Constraints:\phantomsection\label{checkWithPhysConsts}]{Verify that the inputs satisfy the required \hyperref[Sec:DataConstraints]{physical constraints}.}
 \item[Output-Input-Derived-Values:\phantomsection\label{outputInputDerivVals}]{Output the input values and derived values in the following list: the values (from \hyperref[inputValues]{FR:Input-Values}), the masses (from \hyperref[findMass]{FR:Find-Mass}), ${τ_{\text{W}}}$ (from \hyperref[DD:balanceDecayRate]{DD:balanceDecayRate}), $η$ (from \hyperref[DD:balanceDecayTime]{DD:balanceDecayTime}), ${{τ_{\text{P}}}^{\text{S}}}$ (from \hyperref[DD:balanceSolidPCM]{DD:balanceSolidPCM}), and ${{τ_{\text{P}}}^{\text{L}}}$ (from \hyperref[DD:balanceLiquidPCM]{DD:balanceLiquidPCM}).}
 \item[Calculate-Temperature-Water-Over-Time:\phantomsection\label{calcTempWtrOverTime}]{Calculate and output the temperature of the water (${T_{\text{W}}}$($t$)) over the simulation time (from \hyperref[IM:eBalanceOnWtr]{IM:eBalanceOnWtr}).}
 \item[Calculate-Temperature-PCM-Over-Time:\phantomsection\label{calcTempPCMOverTime}]{Calculate and output the temperature of the phase change material (${T_{\text{P}}}$($t$)) over the simulation time (from \hyperref[IM:eBalanceOnPCM]{IM:eBalanceOnPCM}).}
 \item[Calculate-Change-Heat\_Energy-Water-Over-Time:\phantomsection\label{calcChgHeatEnergyWtrOverTime}]{Calculate and output the change in heat energy in the water (${E_{\text{W}}}$($t$)) over the simulation time (from \hyperref[IM:heatEInWtr]{IM:heatEInWtr}).}
 \item[Calculate-Change-Heat\_Energy-PCM-Over-Time:\phantomsection\label{calcChgHeatEnergyPCMOverTime}]{Calculate and output the change in heat energy in the PCM (${E_{\text{P}}}$($t$)) over the simulation time (from \hyperref[IM:heatEInPCM]{IM:heatEInPCM}).}
-\item[Verify-Energy-Output-Follow-Conservation-of-Energy:\phantomsection\label{verifyEnergyOutput}]{Verify that the energy outputs (${E_{\text{W}}}$($t$) and ${E_{\text{P}}}$($t$)) follow the law of conservation of energy, as outlined in \hyperref[Sec:CorSolProps]{Sec:Properties of a Correct Solution}, with relative error no greater than ${C_{\text{tol}}}$.}
+\item[Verify-Energy-Output-Follow-Conservation-of-Energy:\phantomsection\label{verifyEnergyOutput}]{Verify that the energy outputs (${E_{\text{W}}}$($t$) and ${E_{\text{P}}}$($t$)) follow the law of conservation of energy, as outlined in \hyperref[Sec:CorSolProps]{Properties of a Correct Solution}, with relative error no greater than ${C_{\text{tol}}}$.}
 \item[Calculate-PCM-Melt-Begin-Time:\phantomsection\label{calcPCMMeltBegin}]{Calculate and output the time at which the PCM begins to melt ${{t_{\text{melt}}}^{\text{init}}}$ (from \hyperref[IM:eBalanceOnPCM]{IM:eBalanceOnPCM}).}
 \item[Calculate-PCM-Melt-End-Time:\phantomsection\label{calcPCMMeltEnd}]{Calculate and output the time at which the PCM stops melting ${{t_{\text{melt}}}^{\text{final}}}$ (from \hyperref[IM:eBalanceOnPCM]{IM:eBalanceOnPCM}).}
 \end{itemize}
@@ -1598,7 +1598,7 @@ ${ρ_{\text{W}}}$ & Density of water & $\frac{\text{kg}}{\text{m}^{3}}$
 This section provides the non-functional requirements, the qualities that the software is expected to exhibit.
 
 \begin{itemize}
-\item[Correct:\phantomsection\label{correct}]{The outputs of the code have the properties described in \hyperref[Sec:CorSolProps]{Sec:Properties of a Correct Solution}.}
+\item[Correct:\phantomsection\label{correct}]{The outputs of the code have the properties described in \hyperref[Sec:CorSolProps]{Properties of a Correct Solution}.}
 \item[Verifiable:\phantomsection\label{verifiable}]{The code is tested with complete verification and validation plan.}
 \item[Understandable:\phantomsection\label{understandable}]{The code is modularized with complete module guide and module interface specification.}
 \item[Reusable:\phantomsection\label{reusable}]{The code is modularized.}

--- a/code/stable/swhs/SRS/SWHS_SRS.tex
+++ b/code/stable/swhs/SRS/SWHS_SRS.tex
@@ -35,7 +35,7 @@ This section records information for easy reference.
 
 \subsection{Table of Units}
 \label{Sec:ToU}
-The unit system used throughout is SI (Système International d'Unités). In addition to the basic units, several derived units are also used. For each unit, the \hyperref[Table:ToU]{table of units} lists the symbol, a description and the SI name.
+The unit system used throughout is SI (Système International d'Unités). In addition to the basic units, several derived units are also used. For each unit, the \hyperref[Table:ToU]{Table of Units} lists the symbol, a description and the SI name.
 
 \begin{longtable}{l l l}
 \toprule
@@ -61,7 +61,7 @@ ${\text{W}}$ & power & watt
 \end{longtable}
 \subsection{Table of Symbols}
 \label{Sec:ToS}
-The symbols used in this document are summarized in the \hyperref[Table:ToS]{table of symbols} along with their units. The choice of symbols was made to be consistent with the heat transfer literature and with existing documentation for solar water heating systems. The symbols are listed in alphabetical order. For vector quantities, the units shown are for each component of the vector.
+The symbols used in this document are summarized in the \hyperref[Table:ToS]{Table of Symbols} along with their units. The choice of symbols was made to be consistent with the heat transfer literature and with existing documentation for solar water heating systems. The symbols are listed in alphabetical order. For vector quantities, the units shown are for each component of the vector.
 
 \begin{longtabu}{l X[l] l}
 \toprule
@@ -410,7 +410,7 @@ Given the temperature of the heating coil, the initial conditions for the temper
 \end{itemize}
 \subsection{Solution Characteristics Specification}
 \label{Sec:SolCharSpec}
-The instance models that govern SWHS are presented in the \hyperref[Sec:IMs]{instance model section}. The information to understand the meaning of the instance models and their derivation is also presented, so that the instance models can be verified.
+The instance models that govern SWHS are presented in the \hyperref[Sec:IMs]{Instance Model Section}. The information to understand the meaning of the instance models and their derivation is also presented, so that the instance models can be verified.
 
 \subsubsection{Assumptions}
 \label{Sec:Assumps}
@@ -1440,7 +1440,7 @@ RefBy & \hyperref[unlikeChgNGS]{UC:No-Gaseous-State}, \hyperref[findMass]{FR:Fin
 
 \subsubsection{Data Constraints}
 \label{Sec:DataConstraints}
-The \hyperref[Table:InDataConstraints]{data constraints table} shows the data constraints on the input variables. The column for physical constraints gives the physical limitations on the range of values that can be taken by the variable. The uncertainty column provides an estimate of the confidence with which the physical quantities can be measured. This information would be part of the input if one were performing an uncertainty quantification exercise. The constraints are conservative, to give the user of the model the flexibility to experiment with unusual situations. The column of typical values is intended to provide a feel for a common scenario. The column for software constraints restricts the range of inputs to reasonable values. (*) These quantities cannot be equal to zero, or there will be a divide by zero in the model. (+) These quantities cannot be zero, or there would be freezing (\hyperref[assumpPIS]{A:PCM-Initially-Solid}). (++) The constraints on the surface area are calculated by considering the surface area to volume ratio. The assumption is that the lowest ratio is 1 and the highest possible is $\frac{2}{{h_{\text{min}}}}$, where ${h_{\text{min}}}$ is the thickness of a ``sheet'' of PCM. A thin sheet has the greatest surface area to volume ratio. (**) The constraint on the maximum time at the end of the simulation is the total number of seconds in one day.
+The \hyperref[Table:InDataConstraints]{Data Constraints Table} shows the data constraints on the input variables. The column for physical constraints gives the physical limitations on the range of values that can be taken by the variable. The uncertainty column provides an estimate of the confidence with which the physical quantities can be measured. This information would be part of the input if one were performing an uncertainty quantification exercise. The constraints are conservative, to give the user of the model the flexibility to experiment with unusual situations. The column of typical values is intended to provide a feel for a common scenario. The column for software constraints restricts the range of inputs to reasonable values. (*) These quantities cannot be equal to zero, or there will be a divide by zero in the model. (+) These quantities cannot be zero, or there would be freezing (\hyperref[assumpPIS]{A:PCM-Initially-Solid}). (++) The constraints on the surface area are calculated by considering the surface area to volume ratio. The assumption is that the lowest ratio is 1 and the highest possible is $\frac{2}{{h_{\text{min}}}}$, where ${h_{\text{min}}}$ is the thickness of a ``sheet'' of PCM. A thin sheet has the greatest surface area to volume ratio. (**) The constraint on the maximum time at the end of the simulation is the total number of seconds in one day.
 
 \begin{longtabu}{l l X[l] l l}
 \toprule
@@ -1490,7 +1490,7 @@ ${ρ_{\text{W}}}$ & ${ρ_{\text{W}}}\gt{}0$ & ${{ρ_{\text{W}}}^{\text{min}}}\lt
 \end{longtabu}
 \subsubsection{Properties of a Correct Solution}
 \label{Sec:CorSolProps}
-The \hyperref[Table:OutDataConstraints]{data constraints table} shows the data constraints on the output variables. The column for physical constraints gives the physical limitations on the range of values that can be taken by the variable.
+The \hyperref[Table:OutDataConstraints]{Data Constraints Table} shows the data constraints on the output variables. The column for physical constraints gives the physical limitations on the range of values that can be taken by the variable.
 
 \begin{longtable}{l l}
 \toprule

--- a/code/stable/swhs/SRS/SWHS_SRS.tex
+++ b/code/stable/swhs/SRS/SWHS_SRS.tex
@@ -35,7 +35,7 @@ This section records information for easy reference.
 
 \subsection{Table of Units}
 \label{Sec:ToU}
-The unit system used throughout is SI (Système International d'Unités). In addition to the basic units, several derived units are also used. For each unit, \hyperref[Table:ToU]{Tab:ToU} lists the symbol, a description and the SI name.
+The unit system used throughout is SI (Système International d'Unités). In addition to the basic units, several derived units are also used. For each unit, the \hyperref[Table:ToU]{table of units} lists the symbol, a description and the SI name.
 
 \begin{longtable}{l l l}
 \toprule
@@ -61,7 +61,7 @@ ${\text{W}}$ & power & watt
 \end{longtable}
 \subsection{Table of Symbols}
 \label{Sec:ToS}
-The symbols used in this document are summarized in \hyperref[Table:ToS]{Tab:ToS} along with their units. The choice of symbols was made to be consistent with the heat transfer literature and with existing documentation for solar water heating systems. The symbols are listed in alphabetical order. For vector quantities, the units shown are for each component of the vector.
+The symbols used in this document are summarized in the \hyperref[Table:ToS]{table of symbols} along with their units. The choice of symbols was made to be consistent with the heat transfer literature and with existing documentation for solar water heating systems. The symbols are listed in alphabetical order. For vector quantities, the units shown are for each component of the vector.
 
 \begin{longtabu}{l X[l] l}
 \toprule
@@ -384,7 +384,7 @@ This subsection provides a list of terms that are used in the subsequent section
 \end{itemize}
 \subsubsection{Physical System Description}
 \label{Sec:PhysSyst}
-The physical system of SWHS, as shown in \hyperref[Figure:Tank]{Fig:Tank}, includes the following elements:
+The physical system of SWHS, as shown in the \hyperref[Figure:Tank]{figure} below, includes the following elements:
 
 \begin{itemize}
 \item[PS1:]{Tank containing water.}
@@ -410,7 +410,7 @@ Given the temperature of the heating coil, the initial conditions for the temper
 \end{itemize}
 \subsection{Solution Characteristics Specification}
 \label{Sec:SolCharSpec}
-The instance models that govern SWHS are presented in \hyperref[Sec:IMs]{Sec:Instance Models}. The information to understand the meaning of the instance models and their derivation is also presented, so that the instance models can be verified.
+The instance models that govern SWHS are presented in the \hyperref[Sec:IMs]{instance model section}. The information to understand the meaning of the instance models and their derivation is also presented, so that the instance models can be verified.
 
 \subsubsection{Assumptions}
 \label{Sec:Assumps}
@@ -1130,7 +1130,7 @@ RefBy &
 
 \subsubsection{Instance Models}
 \label{Sec:IMs}
-This section transforms the problem defined in \hyperref[Sec:ProbDesc]{Sec:Problem Description} into one which is expressed in mathematical terms. It uses concrete symbols defined in \hyperref[Sec:DDs]{Sec:Data Definitions} to replace the abstract symbols in the models identified in \hyperref[Sec:TMs]{Sec:Theoretical Models} and \hyperref[Sec:GDs]{Sec:General Definitions}.
+This section transforms the problem defined in the \hyperref[Sec:ProbDesc]{problem description} into one which is expressed in mathematical terms. It uses concrete symbols defined in the \hyperref[Sec:DDs]{data definitions} to replace the abstract symbols in the models identified in \hyperref[Sec:TMs]{theoretical models} and \hyperref[Sec:GDs]{general definitions}.
 
 The goals \hyperref[waterTempGS]{GS:Predict-Water-Temperature}, \hyperref[pcmTempGS]{GS:Predict-PCM-Temperature}, \hyperref[waterEnergyGS]{GS:Predict-Water-Energy}, and \hyperref[pcmEnergyGS]{GS:Predict-PCM-Energy} are solved by \hyperref[IM:eBalanceOnWtr]{IM:eBalanceOnWtr}, \hyperref[IM:eBalanceOnPCM]{IM:eBalanceOnPCM}, \hyperref[IM:heatEInWtr]{IM:heatEInWtr}, and \hyperref[IM:heatEInPCM]{IM:heatEInPCM}. The solutions for \hyperref[IM:eBalanceOnWtr]{IM:eBalanceOnWtr} and \hyperref[IM:eBalanceOnPCM]{IM:eBalanceOnPCM} are coupled since the solutions for ${T_{\text{W}}}$ and ${T_{\text{P}}}$ depend on one another. \hyperref[IM:heatEInWtr]{IM:heatEInWtr} can be solved once \hyperref[IM:eBalanceOnWtr]{IM:eBalanceOnWtr} has been solved. The solutions of \hyperref[IM:eBalanceOnPCM]{IM:eBalanceOnPCM} and \hyperref[IM:heatEInPCM]{IM:heatEInPCM} are also coupled, since the temperature of the phase change material and the change in heat energy in the PCM depend on the phase change.
 
@@ -1440,7 +1440,7 @@ RefBy & \hyperref[unlikeChgNGS]{UC:No-Gaseous-State}, \hyperref[findMass]{FR:Fin
 
 \subsubsection{Data Constraints}
 \label{Sec:DataConstraints}
-\hyperref[Table:InDataConstraints]{Tab:InDataConstraints} shows the data constraints on the input variables. The column for physical constraints gives the physical limitations on the range of values that can be taken by the variable. The uncertainty column provides an estimate of the confidence with which the physical quantities can be measured. This information would be part of the input if one were performing an uncertainty quantification exercise. The constraints are conservative, to give the user of the model the flexibility to experiment with unusual situations. The column of typical values is intended to provide a feel for a common scenario. The column for software constraints restricts the range of inputs to reasonable values. (*) These quantities cannot be equal to zero, or there will be a divide by zero in the model. (+) These quantities cannot be zero, or there would be freezing (\hyperref[assumpPIS]{A:PCM-Initially-Solid}). (++) The constraints on the surface area are calculated by considering the surface area to volume ratio. The assumption is that the lowest ratio is 1 and the highest possible is $\frac{2}{{h_{\text{min}}}}$, where ${h_{\text{min}}}$ is the thickness of a ``sheet'' of PCM. A thin sheet has the greatest surface area to volume ratio. (**) The constraint on the maximum time at the end of the simulation is the total number of seconds in one day.
+The \hyperref[Table:InDataConstraints]{data constraints table} shows the data constraints on the input variables. The column for physical constraints gives the physical limitations on the range of values that can be taken by the variable. The uncertainty column provides an estimate of the confidence with which the physical quantities can be measured. This information would be part of the input if one were performing an uncertainty quantification exercise. The constraints are conservative, to give the user of the model the flexibility to experiment with unusual situations. The column of typical values is intended to provide a feel for a common scenario. The column for software constraints restricts the range of inputs to reasonable values. (*) These quantities cannot be equal to zero, or there will be a divide by zero in the model. (+) These quantities cannot be zero, or there would be freezing (\hyperref[assumpPIS]{A:PCM-Initially-Solid}). (++) The constraints on the surface area are calculated by considering the surface area to volume ratio. The assumption is that the lowest ratio is 1 and the highest possible is $\frac{2}{{h_{\text{min}}}}$, where ${h_{\text{min}}}$ is the thickness of a ``sheet'' of PCM. A thin sheet has the greatest surface area to volume ratio. (**) The constraint on the maximum time at the end of the simulation is the total number of seconds in one day.
 
 \begin{longtabu}{l l X[l] l l}
 \toprule
@@ -1490,7 +1490,7 @@ ${ρ_{\text{W}}}$ & ${ρ_{\text{W}}}\gt{}0$ & ${{ρ_{\text{W}}}^{\text{min}}}\lt
 \end{longtabu}
 \subsubsection{Properties of a Correct Solution}
 \label{Sec:CorSolProps}
-\hyperref[Table:OutDataConstraints]{Tab:OutDataConstraints} shows the data constraints on the output variables. The column for physical constraints gives the physical limitations on the range of values that can be taken by the variable.
+The \hyperref[Table:OutDataConstraints]{data constraints table} shows the data constraints on the output variables. The column for physical constraints gives the physical limitations on the range of values that can be taken by the variable.
 
 \begin{longtable}{l l}
 \toprule

--- a/code/stable/swhs/Website/SWHS_SRS.html
+++ b/code/stable/swhs/Website/SWHS_SRS.html
@@ -806,7 +806,7 @@
               <div class="subsubsection">
                 <h3>Physical System Description</h3>
                 <p class="paragraph">
-                  The physical system of SWHS, as shown in the <a href=#Figure:Tank>figure</a> below, includes the following elements:
+                  The physical system of SWHS, as shown in the <a href=#Figure:Tank>Fig:Tank</a> below, includes the following elements:
                 </p>
                 <div class="list">
                   <p>PS1: Tank containing water.</p>

--- a/code/stable/swhs/Website/SWHS_SRS.html
+++ b/code/stable/swhs/Website/SWHS_SRS.html
@@ -2845,7 +2845,7 @@
               </p>
               <p>
                 <div id="checkWithPhysConsts">
-                  Check-Input-with-Physical_Constraints: Verify that the inputs satisfy the required physical constraints shown in <a href=#Sec:DataConstraints>Sec:Data Constraints</a>.
+                  Check-Input-with-Physical_Constraints: Verify that the inputs satisfy the required <a href=#Sec:DataConstraints>physical constraints</a>.
                 </div>
               </p>
               <p>
@@ -2875,7 +2875,7 @@
               </p>
               <p>
                 <div id="verifyEnergyOutput">
-                  Verify-Energy-Output-Follow-Conservation-of-Energy: Verify that the energy outputs (<em>E<sub>W</sub></em>(<em>t</em>) and <em>E<sub>P</sub></em>(<em>t</em>)) follow the law of conservation of energy, as outlined in <a href=#Sec:CorSolProps>Sec:Properties of a Correct Solution</a>, with relative error no greater than <em>C<sub>tol</sub></em>.
+                  Verify-Energy-Output-Follow-Conservation-of-Energy: Verify that the energy outputs (<em>E<sub>W</sub></em>(<em>t</em>) and <em>E<sub>P</sub></em>(<em>t</em>)) follow the law of conservation of energy, as outlined in <a href=#Sec:CorSolProps>Properties of a Correct Solution</a>, with relative error no greater than <em>C<sub>tol</sub></em>.
                 </div>
               </p>
               <p>
@@ -3018,7 +3018,7 @@
             <div class="list">
               <p>
                 <div id="correct">
-                  Correct: The outputs of the code have the properties described in <a href=#Sec:CorSolProps>Sec:Properties of a Correct Solution</a>.
+                  Correct: The outputs of the code have the properties described in <a href=#Sec:CorSolProps>Properties of a Correct Solution</a>.
                 </div>
               </p>
               <p>

--- a/code/stable/swhs/Website/SWHS_SRS.html
+++ b/code/stable/swhs/Website/SWHS_SRS.html
@@ -29,7 +29,7 @@
           <div class="subsection">
             <h2>Table of Units</h2>
             <p class="paragraph">
-              The unit system used throughout is SI (Système International d'Unités). In addition to the basic units, several derived units are also used. For each unit, <a href=#Table:ToU>Tab:ToU</a> lists the symbol, a description and the SI name.
+              The unit system used throughout is SI (Système International d'Unités). In addition to the basic units, several derived units are also used. For each unit, the <a href=#Table:ToU>table of units</a> lists the symbol, a description and the SI name.
             </p>
             <div id="Table:ToU">
               <table class="table">
@@ -77,7 +77,7 @@
           <div class="subsection">
             <h2>Table of Symbols</h2>
             <p class="paragraph">
-              The symbols used in this document are summarized in <a href=#Table:ToS>Tab:ToS</a> along with their units. The choice of symbols was made to be consistent with the heat transfer literature and with existing documentation for solar water heating systems. The symbols are listed in alphabetical order. For vector quantities, the units shown are for each component of the vector.
+              The symbols used in this document are summarized in the <a href=#Table:ToS>table of symbols</a> along with their units. The choice of symbols was made to be consistent with the heat transfer literature and with existing documentation for solar water heating systems. The symbols are listed in alphabetical order. For vector quantities, the units shown are for each component of the vector.
             </p>
             <div id="Table:ToS">
               <table class="table">
@@ -806,7 +806,7 @@
               <div class="subsubsection">
                 <h3>Physical System Description</h3>
                 <p class="paragraph">
-                  The physical system of SWHS, as shown in <a href=#Figure:Tank>Fig:Tank</a>, includes the following elements:
+                  The physical system of SWHS, as shown in the <a href=#Figure:Tank>figure</a> below, includes the following elements:
                 </p>
                 <div class="list">
                   <p>PS1: Tank containing water.</p>
@@ -863,7 +863,7 @@
           <div class="subsection">
             <h2>Solution Characteristics Specification</h2>
             <p class="paragraph">
-              The instance models that govern SWHS are presented in <a href=#Sec:IMs>Sec:Instance Models</a>. The information to understand the meaning of the instance models and their derivation is also presented, so that the instance models can be verified.
+              The instance models that govern SWHS are presented in the <a href=#Sec:IMs>instance model section</a>. The information to understand the meaning of the instance models and their derivation is also presented, so that the instance models can be verified.
             </p>
             <div id="Sec:Assumps">
               <div class="subsubsection">
@@ -2085,7 +2085,7 @@
               <div class="subsubsection">
                 <h3>Instance Models</h3>
                 <p class="paragraph">
-                  This section transforms the problem defined in <a href=#Sec:ProbDesc>Sec:Problem Description</a> into one which is expressed in mathematical terms. It uses concrete symbols defined in <a href=#Sec:DDs>Sec:Data Definitions</a> to replace the abstract symbols in the models identified in <a href=#Sec:TMs>Sec:Theoretical Models</a> and <a href=#Sec:GDs>Sec:General Definitions</a>.
+                  This section transforms the problem defined in the <a href=#Sec:ProbDesc>problem description</a> into one which is expressed in mathematical terms. It uses concrete symbols defined in the <a href=#Sec:DDs>data definitions</a> to replace the abstract symbols in the models identified in <a href=#Sec:TMs>theoretical models</a> and <a href=#Sec:GDs>general definitions</a>.
                 </p>
                 <p class="paragraph">
                   The goals <a href=#waterTempGS>GS:Predict-Water-Temperature</a>, <a href=#pcmTempGS>GS:Predict-PCM-Temperature</a>, <a href=#waterEnergyGS>GS:Predict-Water-Energy</a>, and <a href=#pcmEnergyGS>GS:Predict-PCM-Energy</a> are solved by <a href=#IM:eBalanceOnWtr>IM:eBalanceOnWtr</a>, <a href=#IM:eBalanceOnPCM>IM:eBalanceOnPCM</a>, <a href=#IM:heatEInWtr>IM:heatEInWtr</a>, and <a href=#IM:heatEInPCM>IM:heatEInPCM</a>. The solutions for <a href=#IM:eBalanceOnWtr>IM:eBalanceOnWtr</a> and <a href=#IM:eBalanceOnPCM>IM:eBalanceOnPCM</a> are coupled since the solutions for <em>T<sub>W</sub></em> and <em>T<sub>P</sub></em> depend on one another. <a href=#IM:heatEInWtr>IM:heatEInWtr</a> can be solved once <a href=#IM:eBalanceOnWtr>IM:eBalanceOnWtr</a> has been solved. The solutions of <a href=#IM:eBalanceOnPCM>IM:eBalanceOnPCM</a> and <a href=#IM:heatEInPCM>IM:heatEInPCM</a> are also coupled, since the temperature of the phase change material and the change in heat energy in the PCM depend on the phase change.
@@ -2578,7 +2578,7 @@
               <div class="subsubsection">
                 <h3>Data Constraints</h3>
                 <p class="paragraph">
-                  <a href=#Table:InDataConstraints>Tab:InDataConstraints</a> shows the data constraints on the input variables. The column for physical constraints gives the physical limitations on the range of values that can be taken by the variable. The uncertainty column provides an estimate of the confidence with which the physical quantities can be measured. This information would be part of the input if one were performing an uncertainty quantification exercise. The constraints are conservative, to give the user of the model the flexibility to experiment with unusual situations. The column of typical values is intended to provide a feel for a common scenario. The column for software constraints restricts the range of inputs to reasonable values. (*) These quantities cannot be equal to zero, or there will be a divide by zero in the model. (+) These quantities cannot be zero, or there would be freezing (<a href=#assumpPIS>A:PCM-Initially-Solid</a>). (++) The constraints on the surface area are calculated by considering the surface area to volume ratio. The assumption is that the lowest ratio is 1 and the highest possible is <em>\(\frac{2}{{h_{\text{min}}}}\)</em>, where <em>h<sub>min</sub></em> is the thickness of a "sheet" of PCM. A thin sheet has the greatest surface area to volume ratio. (**) The constraint on the maximum time at the end of the simulation is the total number of seconds in one day.
+                  The <a href=#Table:InDataConstraints>data constraints table</a> shows the data constraints on the input variables. The column for physical constraints gives the physical limitations on the range of values that can be taken by the variable. The uncertainty column provides an estimate of the confidence with which the physical quantities can be measured. This information would be part of the input if one were performing an uncertainty quantification exercise. The constraints are conservative, to give the user of the model the flexibility to experiment with unusual situations. The column of typical values is intended to provide a feel for a common scenario. The column for software constraints restricts the range of inputs to reasonable values. (*) These quantities cannot be equal to zero, or there will be a divide by zero in the model. (+) These quantities cannot be zero, or there would be freezing (<a href=#assumpPIS>A:PCM-Initially-Solid</a>). (++) The constraints on the surface area are calculated by considering the surface area to volume ratio. The assumption is that the lowest ratio is 1 and the highest possible is <em>\(\frac{2}{{h_{\text{min}}}}\)</em>, where <em>h<sub>min</sub></em> is the thickness of a "sheet" of PCM. A thin sheet has the greatest surface area to volume ratio. (**) The constraint on the maximum time at the end of the simulation is the total number of seconds in one day.
                 </p>
                 <div id="Table:InDataConstraints">
                   <table class="table">
@@ -2772,7 +2772,7 @@
               <div class="subsubsection">
                 <h3>Properties of a Correct Solution</h3>
                 <p class="paragraph">
-                  <a href=#Table:OutDataConstraints>Tab:OutDataConstraints</a> shows the data constraints on the output variables. The column for physical constraints gives the physical limitations on the range of values that can be taken by the variable.
+                  The <a href=#Table:OutDataConstraints>data constraints table</a> shows the data constraints on the output variables. The column for physical constraints gives the physical limitations on the range of values that can be taken by the variable.
                 </p>
                 <div id="Table:OutDataConstraints">
                   <table class="table">

--- a/code/stable/swhs/Website/SWHS_SRS.html
+++ b/code/stable/swhs/Website/SWHS_SRS.html
@@ -29,7 +29,7 @@
           <div class="subsection">
             <h2>Table of Units</h2>
             <p class="paragraph">
-              The unit system used throughout is SI (Système International d'Unités). In addition to the basic units, several derived units are also used. For each unit, the <a href=#Table:ToU>table of units</a> lists the symbol, a description and the SI name.
+              The unit system used throughout is SI (Système International d'Unités). In addition to the basic units, several derived units are also used. For each unit, the <a href=#Table:ToU>Table of Units</a> lists the symbol, a description and the SI name.
             </p>
             <div id="Table:ToU">
               <table class="table">
@@ -77,7 +77,7 @@
           <div class="subsection">
             <h2>Table of Symbols</h2>
             <p class="paragraph">
-              The symbols used in this document are summarized in the <a href=#Table:ToS>table of symbols</a> along with their units. The choice of symbols was made to be consistent with the heat transfer literature and with existing documentation for solar water heating systems. The symbols are listed in alphabetical order. For vector quantities, the units shown are for each component of the vector.
+              The symbols used in this document are summarized in the <a href=#Table:ToS>Table of Symbols</a> along with their units. The choice of symbols was made to be consistent with the heat transfer literature and with existing documentation for solar water heating systems. The symbols are listed in alphabetical order. For vector quantities, the units shown are for each component of the vector.
             </p>
             <div id="Table:ToS">
               <table class="table">
@@ -863,7 +863,7 @@
           <div class="subsection">
             <h2>Solution Characteristics Specification</h2>
             <p class="paragraph">
-              The instance models that govern SWHS are presented in the <a href=#Sec:IMs>instance model section</a>. The information to understand the meaning of the instance models and their derivation is also presented, so that the instance models can be verified.
+              The instance models that govern SWHS are presented in the <a href=#Sec:IMs>Instance Model Section</a>. The information to understand the meaning of the instance models and their derivation is also presented, so that the instance models can be verified.
             </p>
             <div id="Sec:Assumps">
               <div class="subsubsection">
@@ -2578,7 +2578,7 @@
               <div class="subsubsection">
                 <h3>Data Constraints</h3>
                 <p class="paragraph">
-                  The <a href=#Table:InDataConstraints>data constraints table</a> shows the data constraints on the input variables. The column for physical constraints gives the physical limitations on the range of values that can be taken by the variable. The uncertainty column provides an estimate of the confidence with which the physical quantities can be measured. This information would be part of the input if one were performing an uncertainty quantification exercise. The constraints are conservative, to give the user of the model the flexibility to experiment with unusual situations. The column of typical values is intended to provide a feel for a common scenario. The column for software constraints restricts the range of inputs to reasonable values. (*) These quantities cannot be equal to zero, or there will be a divide by zero in the model. (+) These quantities cannot be zero, or there would be freezing (<a href=#assumpPIS>A:PCM-Initially-Solid</a>). (++) The constraints on the surface area are calculated by considering the surface area to volume ratio. The assumption is that the lowest ratio is 1 and the highest possible is <em>\(\frac{2}{{h_{\text{min}}}}\)</em>, where <em>h<sub>min</sub></em> is the thickness of a "sheet" of PCM. A thin sheet has the greatest surface area to volume ratio. (**) The constraint on the maximum time at the end of the simulation is the total number of seconds in one day.
+                  The <a href=#Table:InDataConstraints>Data Constraints Table</a> shows the data constraints on the input variables. The column for physical constraints gives the physical limitations on the range of values that can be taken by the variable. The uncertainty column provides an estimate of the confidence with which the physical quantities can be measured. This information would be part of the input if one were performing an uncertainty quantification exercise. The constraints are conservative, to give the user of the model the flexibility to experiment with unusual situations. The column of typical values is intended to provide a feel for a common scenario. The column for software constraints restricts the range of inputs to reasonable values. (*) These quantities cannot be equal to zero, or there will be a divide by zero in the model. (+) These quantities cannot be zero, or there would be freezing (<a href=#assumpPIS>A:PCM-Initially-Solid</a>). (++) The constraints on the surface area are calculated by considering the surface area to volume ratio. The assumption is that the lowest ratio is 1 and the highest possible is <em>\(\frac{2}{{h_{\text{min}}}}\)</em>, where <em>h<sub>min</sub></em> is the thickness of a "sheet" of PCM. A thin sheet has the greatest surface area to volume ratio. (**) The constraint on the maximum time at the end of the simulation is the total number of seconds in one day.
                 </p>
                 <div id="Table:InDataConstraints">
                   <table class="table">
@@ -2772,7 +2772,7 @@
               <div class="subsubsection">
                 <h3>Properties of a Correct Solution</h3>
                 <p class="paragraph">
-                  The <a href=#Table:OutDataConstraints>data constraints table</a> shows the data constraints on the output variables. The column for physical constraints gives the physical limitations on the range of values that can be taken by the variable.
+                  The <a href=#Table:OutDataConstraints>Data Constraints Table</a> shows the data constraints on the output variables. The column for physical constraints gives the physical limitations on the range of values that can be taken by the variable.
                 </p>
                 <div id="Table:OutDataConstraints">
                   <table class="table">


### PR DESCRIPTION
Contributes (maybe closes) #2653.

I added some in-text references where there was duplicate information provided by the text and reference name to help with readability. I'm not sure if we want to change any other references, but I mainly focused on `Sec:` references. If we don't want any more, then we could close #2653 