### PR TITLE
Make ModelKind an ADT containing the original ModelKinds

### DIFF
--- a/code/drasil-data/Data/Drasil/Theories/Physics.hs
+++ b/code/drasil-data/Data/Drasil/Theories/Physics.hs
@@ -22,14 +22,14 @@ physicsTMs :: [TheoryModel]
 physicsTMs = [newtonSL]
 
 newtonSL :: TheoryModel
-newtonSL = tmNoRefs' "newtonSL" (EquationalModel newtonSLQD)
+newtonSL = tmNoRefs (equationalModelU "newtonSL" newtonSLQD)
   [qw QP.force, qw QPP.mass, qw QP.acceleration] ([] :: [ConceptChunk])
   [newtonSLQD] [] [] "NewtonSecLawMot" [newtonSLDesc]
 
 --
 
 weightGD :: GenDefn
-weightGD = gd (EquationalModel weightQD) (getUnit QP.weight) (Just weightDeriv) [weightSrc] 
+weightGD = gd (equationalModel' weightQD) (getUnit QP.weight) (Just weightDeriv) [weightSrc] 
   "weight" [{-Notes-}]
 
 weightQD :: QDefinition
@@ -73,7 +73,7 @@ weightDerivSpecWeightSentence = [S "Substituting", phrase QPP.specWeight,
 --
 
 hsPressureGD :: GenDefn
-hsPressureGD = gd (EquationalModel hsPressureQD) (getUnit QP.pressure) Nothing
+hsPressureGD = gd (equationalModel' hsPressureQD) (getUnit QP.pressure) Nothing
   [hsPressureSrc] "hsPressure" [hsPressureNotes]
 
 hsPressureQD :: QDefinition
@@ -119,7 +119,7 @@ vecMag = ddNoRefs vecMagQD Nothing "vecMag" [magNote]
 
 --
 newtonSLR :: TheoryModel
-newtonSLR = tmNoRefs' "newtonSLR" (EquationalModel newtonSLRQD)
+newtonSLR = tmNoRefs (equationalModelU "newtonSLR" newtonSLRQD)
   [qw QP.torque, qw QP.momentOfInertia, qw QP.angularAccel] 
   ([] :: [ConceptChunk]) [newtonSLRQD] [] [] "NewtonSecLawRotMot" newtonSLRNotes
 
@@ -138,13 +138,13 @@ newtonSLRNotes = map foldlSent [
 --
 
 accelerationTM :: TheoryModel
-accelerationTM = tm' "accelerationTM" (EquationalModel accelerationQD)
+accelerationTM = tm (equationalModelU "accelerationTM" accelerationQD)
   [qw QP.acceleration, qw QP.velocity, qw QP.time] ([] :: [ConceptChunk]) [accelerationQD] [] []
   [ref accelerationWiki] "acceleration" []
 
 ----------
 
 velocityTM :: TheoryModel
-velocityTM = tm' "velocityTM" (EquationalModel velocityQD)
+velocityTM = tm (equationalModelU "velocityTM" velocityQD)
   [qw QP.velocity, qw QP.position, qw QP.time] ([] :: [ConceptChunk]) [velocityQD] [] []
   [ref velocityWiki] "velocity" []

--- a/code/drasil-example/Drasil/DblPendulum/GenDefs.hs
+++ b/code/drasil-example/Drasil/DblPendulum/GenDefs.hs
@@ -7,8 +7,10 @@ import Prelude hiding (cos, sin, sqrt)
 import qualified Data.List.NonEmpty as NE
 
 import Language.Drasil
-import Theory.Drasil (GenDefn, gdNoRefs, gdNoRefs',
-    ModelKinds (EquationalModel, EquationalRealm),
+import Theory.Drasil (GenDefn, gdNoRefs,
+    ModelKind,
+    equationalModel', equationalModelU,
+    equationalRealm', equationalRealmU,
     MultiDefn, mkDefiningExpr, mkMultiDefnForQuant)
 import Utils.Drasil
 import Utils.Drasil.Concepts
@@ -38,7 +40,7 @@ genDefns = [velocityIXGD, velocityIYGD, accelerationIXGD, accelerationIYGD,
 
 ---------------------
 velocityIXGD :: GenDefn
-velocityIXGD = gdNoRefs (EquationalModel velocityIXQD) (getUnit velocity)
+velocityIXGD = gdNoRefs (equationalModel' velocityIXQD) (getUnit velocity)
            (Just velocityIXDeriv) "velocityIX" [{-Notes-}]
 
 velocityIXQD :: QDefinition
@@ -68,7 +70,7 @@ velocityIXDerivSent5 = S "Therefore, using the chain rule,"
 
 ---------------------
 velocityIYGD :: GenDefn
-velocityIYGD = gdNoRefs (EquationalModel velocityIYQD) (getUnit velocity)
+velocityIYGD = gdNoRefs (equationalModel' velocityIYQD) (getUnit velocity)
            (Just velocityIYDeriv) "velocityIY" [{-Notes-}]
 
 velocityIYQD :: QDefinition
@@ -94,7 +96,7 @@ velocityIYDerivSent5 = S "Therefore, using the chain rule,"
 
 -----------------------
 accelerationIXGD :: GenDefn
-accelerationIXGD = gdNoRefs (EquationalModel accelerationIXQD) (getUnit acceleration)
+accelerationIXGD = gdNoRefs (equationalModel' accelerationIXQD) (getUnit acceleration)
            (Just accelerationIXDeriv) "accelerationIX" [{-Notes-}]
 
 accelerationIXQD :: QDefinition
@@ -123,7 +125,7 @@ accelerationIXDerivSent5 = S "Simplifying,"
 
 -----------------------
 accelerationIYGD :: GenDefn
-accelerationIYGD = gdNoRefs (EquationalModel accelerationIYQD) (getUnit acceleration)
+accelerationIYGD = gdNoRefs (equationalModel' accelerationIYQD) (getUnit acceleration)
            (Just accelerationIYDeriv) "accelerationIY" [{-Notes-}]
 
 accelerationIYQD :: QDefinition
@@ -149,7 +151,7 @@ accelerationIYDerivSent5 = S "Simplifying,"
 
 -------------------------------------Horizontal force acting on the pendulum 
 hForceOnPendulumGD :: GenDefn
-hForceOnPendulumGD = gdNoRefs' "hForceOnPendulum" (EquationalRealm hForceOnPendulumMD)
+hForceOnPendulumGD = gdNoRefs (equationalRealmU "hForceOnPendulum" hForceOnPendulumMD)
         (getUnit force) (Just hForceOnPendulumDeriv) "hForceOnPendulum" [{-Notes-}]
 
 hForceOnPendulumMD :: MultiDefn
@@ -168,7 +170,7 @@ hForceOnPendulumDeriv = mkDerivName (phraseNP (force `onThe` pendulum)) [eS hFor
 
 ----------------------------------------Vertical force acting on the pendulum 
 vForceOnPendulumGD :: GenDefn
-vForceOnPendulumGD = gdNoRefs' "vForceOnPendulum" (EquationalRealm vForceOnPendulumMD)
+vForceOnPendulumGD = gdNoRefs (equationalRealmU "vForceOnPendulum" vForceOnPendulumMD)
         (getUnit force) (Just vForceOnPendulumDeriv) "vForceOnPendulum" [{-Notes-}]
 
 vForceOnPendulumMD :: MultiDefn
@@ -188,7 +190,7 @@ vForceOnPendulumDeriv = mkDerivName (phraseNP (force `onThe` pendulum)) [eS vFor
 --------------------------------------Angular Frequency Of Pendulum
 
 angFrequencyGD :: GenDefn
-angFrequencyGD = gdNoRefs' "angFrequencyGD" (EquationalModel angFrequencyQD) (getUnit angularFrequency)
+angFrequencyGD = gdNoRefs (equationalModelU "angFrequencyGD" angFrequencyQD) (getUnit angularFrequency)
            (Just angFrequencyDeriv) "angFrequencyGD" [angFrequencyGDNotes]
 
 angFrequencyQD :: QDefinition
@@ -224,7 +226,7 @@ angFrequencyGDNotes = S "The" +:+ phrase torque `S.is` definedIn'' newtonSLR  `S
  -------------------------------- Period of Pendulum Motion 
 
 periodPend :: GenDefn
-periodPend = gdNoRefs' "periodPendGD" (EquationalModel periodPendQD) (getUnit period)
+periodPend = gdNoRefs (equationalModelU "periodPendGD" periodPendQD) (getUnit period)
            (Just periodPendDeriv) "periodPend" [periodPendNotes]
 
 periodPendQD :: QDefinition

--- a/code/drasil-example/Drasil/DblPendulum/GenDefs.hs
+++ b/code/drasil-example/Drasil/DblPendulum/GenDefs.hs
@@ -8,9 +8,7 @@ import qualified Data.List.NonEmpty as NE
 
 import Language.Drasil
 import Theory.Drasil (GenDefn, gdNoRefs,
-    ModelKind,
-    equationalModel', equationalModelU,
-    equationalRealm', equationalRealmU,
+    equationalModel', equationalModelU, equationalRealmU,
     MultiDefn, mkDefiningExpr, mkMultiDefnForQuant)
 import Utils.Drasil
 import Utils.Drasil.Concepts

--- a/code/drasil-example/Drasil/DblPendulum/IMods.hs
+++ b/code/drasil-example/Drasil/DblPendulum/IMods.hs
@@ -4,7 +4,7 @@ module Drasil.DblPendulum.IMods (iMods, angularDisplacementIM, iModRefs) where
 import Prelude hiding (cos, sin)
 
 import Language.Drasil
-import Theory.Drasil (InstanceModel, imNoRefs, qwC, ModelKinds (OthModel))
+import Theory.Drasil (InstanceModel, imNoRefs, qwC, ModelKind, othModel')
   --imNoDerivNoRefs, )
 import Utils.Drasil
 import Utils.Drasil.Concepts
@@ -27,7 +27,7 @@ iMods = [angularDisplacementIM]
 
 ---
 angularDisplacementIM :: InstanceModel
-angularDisplacementIM = imNoRefs (OthModel angularDisplacementRC)
+angularDisplacementIM = imNoRefs (othModel' angularDisplacementRC)
   [qwC lenRod $ UpFrom (Exc, exactDbl 0)
   ,qwC initialPendAngle $ UpFrom (Exc, exactDbl 0)
   , qwC gravitationalAccel $ UpFrom (Exc, exactDbl 0)]

--- a/code/drasil-example/Drasil/DblPendulum/IMods.hs
+++ b/code/drasil-example/Drasil/DblPendulum/IMods.hs
@@ -4,8 +4,7 @@ module Drasil.DblPendulum.IMods (iMods, angularDisplacementIM, iModRefs) where
 import Prelude hiding (cos, sin)
 
 import Language.Drasil
-import Theory.Drasil (InstanceModel, imNoRefs, qwC, ModelKind, othModel')
-  --imNoDerivNoRefs, )
+import Theory.Drasil (InstanceModel, imNoRefs, qwC, othModel')
 import Utils.Drasil
 import Utils.Drasil.Concepts
 import qualified Utils.Drasil.Sentence as S

--- a/code/drasil-example/Drasil/GamePhysics/GenDefs.hs
+++ b/code/drasil-example/Drasil/GamePhysics/GenDefs.hs
@@ -4,7 +4,7 @@ module Drasil.GamePhysics.GenDefs (generalDefns, accelGravityGD, impulseGD, genD
 import Language.Drasil
 import Utils.Drasil
 import qualified Utils.Drasil.Sentence as S
-import Theory.Drasil (GenDefn, gd, ModelKinds (EquationalModel))
+import Theory.Drasil (GenDefn, gd, ModelKind, equationalModel')
 import qualified Data.Drasil.Quantities.Physics as QP (acceleration,
  gravitationalAccel, gravitationalConst, restitutionCoef, impulseS, force,
  fOfGravity)
@@ -62,7 +62,7 @@ conservationOfMomentDeriv = foldlSent [S "When bodies collide, they exert",
 
 --------------------------Acceleration due to gravity----------------------------
 accelGravityGD :: GenDefn
-accelGravityGD = gd (EquationalModel accelGravityQD) (getUnit QP.acceleration) (Just accelGravityDeriv)
+accelGravityGD = gd (equationalModel' accelGravityQD) (getUnit QP.acceleration) (Just accelGravityDeriv)
    [accelGravitySrc] "accelGravity" [accelGravityDesc]
 
 accelGravityQD :: QDefinition
@@ -146,7 +146,7 @@ accelGravityDerivEqns = [accelGravityDerivEqn1, accelGravityDerivEqn2, accelGrav
 ----------------------------Impulse for Collision--------------------------------------------
 
 impulseGD :: GenDefn
-impulseGD = gd (EquationalModel impulseQD) (getUnit QP.impulseS) Nothing
+impulseGD = gd (equationalModel' impulseQD) (getUnit QP.impulseS) Nothing
   [impulseSrc] "impulse" [rigidTwoDAssump, rightHandAssump, collisionAssump]
 
 impulseQD :: QDefinition

--- a/code/drasil-example/Drasil/GamePhysics/GenDefs.hs
+++ b/code/drasil-example/Drasil/GamePhysics/GenDefs.hs
@@ -4,7 +4,7 @@ module Drasil.GamePhysics.GenDefs (generalDefns, accelGravityGD, impulseGD, genD
 import Language.Drasil
 import Utils.Drasil
 import qualified Utils.Drasil.Sentence as S
-import Theory.Drasil (GenDefn, gd, ModelKind, equationalModel')
+import Theory.Drasil (GenDefn, gd, equationalModel')
 import qualified Data.Drasil.Quantities.Physics as QP (acceleration,
  gravitationalAccel, gravitationalConst, restitutionCoef, impulseS, force,
  fOfGravity)

--- a/code/drasil-example/Drasil/GamePhysics/IMods.hs
+++ b/code/drasil-example/Drasil/GamePhysics/IMods.hs
@@ -34,7 +34,7 @@ iMods = [transMot, rotMot, col2D]
 
 {-- Force on the translational motion  --}
 transMot :: InstanceModel
-transMot = imNoRefs (EquationalModel transMotQD) 
+transMot = imNoRefs (equationalModel' transMotQD) 
   [ qwC velj               $ UpFrom (Exc, exactDbl 0)
   , qwC time               $ UpFrom (Exc, exactDbl 0)
   , qwC gravitationalAccel $ UpFrom (Exc, exactDbl 0)
@@ -83,7 +83,7 @@ transMotDerivEqns = map eS [transMotExprDeriv1, toDispExpr transMotQD]
 {-- Rotational Motion --}
 
 rotMot :: InstanceModel
-rotMot = imNoRefs (EquationalModel rotMotQD) 
+rotMot = imNoRefs (equationalModel' rotMotQD) 
   [ qwC angularVelocity $ UpFrom (Exc, exactDbl 0)
   , qwC time            $ UpFrom (Exc, exactDbl 0)
   , qwC torquej         $ UpFrom (Exc, exactDbl 0)
@@ -123,7 +123,7 @@ rotMotDerivEqns = map eS [rotMotExprDeriv1, toDispExpr rotMotQD]
 {-- 2D Collision --}
 
 col2D :: InstanceModel
-col2D = imNoDerivNoRefs (OthModel col2DRC)
+col2D = imNoDerivNoRefs (othModel' col2DRC)
   [qwC time $ UpFrom (Exc, exactDbl 0)
   ,qwC impulseS $ UpFrom (Exc, exactDbl 0)
   ,qwC massA $ UpFrom (Exc, exactDbl 0)

--- a/code/drasil-example/Drasil/GamePhysics/TMods.hs
+++ b/code/drasil-example/Drasil/GamePhysics/TMods.hs
@@ -29,7 +29,7 @@ tMods = [newtonSL, newtonTL, newtonLUG, newtonSLR]
 -- T2 : Newton's third law of motion --
 
 newtonTL :: TheoryModel
-newtonTL = tmNoRefs (EquationalModel newtonTLQD) [qw force_1, qw force_2]
+newtonTL = tmNoRefs (equationalModel' newtonTLQD) [qw force_1, qw force_2]
   ([] :: [ConceptChunk]) [newtonTLQD] [] [] "NewtonThirdLawMot" [newtonTLNote]
 
 newtonTLQD :: QDefinition
@@ -47,8 +47,8 @@ newtonTLNote = foldlSent [(S "Every action has an equal and opposite reaction" !
 -- T3 : Newton's law of universal gravitation --
 
 -- FIXME: Missing ConceptDomain!
-newtonLUGModel :: ModelKinds
-newtonLUGModel = EquationalRealm $ mkMultiDefnForQuant newtonForceQuant EmptyS $ NE.fromList [
+newtonLUGModel :: ModelKind
+newtonLUGModel = equationalRealm' $ mkMultiDefnForQuant newtonForceQuant EmptyS $ NE.fromList [
     mkDefiningExpr "newtonLUGviaDeriv" [] EmptyS (sy gravitationalConst `mulRe` (sy mass_1 `mulRe` sy mass_2 $/ square (sy dispNorm)) `mulRe` sy dVect),
     mkDefiningExpr "newtonLUGviaForm" [] EmptyS (sy gravitationalConst `mulRe` (sy mass_1 `mulRe` sy mass_2 $/ square (sy dispNorm)) `mulRe` (sy distMass $/ sy dispNorm))
   ]
@@ -79,7 +79,7 @@ newtonLUGNotes = map foldlSent [
 -- T4 : Newton's second law for rotational motion --
 
 newtonSLR :: TheoryModel
-newtonSLR = tmNoRefs' "newtonSLR" (EquationalModel newtonSLRQD)
+newtonSLR = tmNoRefs (equationalModelU "newtonSLR" newtonSLRQD)
   [qw torque, qw momentOfInertia, qw angularAccel]
   ([] :: [ConceptChunk]) [newtonSLRQD] [] [] "NewtonSecLawRotMot" newtonSLRNotes
 

--- a/code/drasil-example/Drasil/GlassBR/IMods.hs
+++ b/code/drasil-example/Drasil/GlassBR/IMods.hs
@@ -2,7 +2,7 @@ module Drasil.GlassBR.IMods (symb, iMods, pbIsSafe, lrIsSafe, instModIntro, iMod
 
 import Prelude hiding (exp)
 import Language.Drasil
-import Theory.Drasil (InstanceModel, imNoDeriv', qwC, ModelKinds ( EquationalModel))
+import Theory.Drasil (InstanceModel, imNoDeriv, qwC, ModelKind, equationalModelN)
 import Utils.Drasil
 import Utils.Drasil.Concepts
 import qualified Utils.Drasil.Sentence as S
@@ -26,7 +26,7 @@ symb = map dqdWr [plateLen, plateWidth, charWeight, standOffDist] ++
 {--}
 
 pbIsSafe :: InstanceModel
-pbIsSafe = imNoDeriv' (EquationalModel pbIsSafeQD) (nounPhraseSP "Safety Req-Pb")
+pbIsSafe = imNoDeriv (equationalModelN (nounPhraseSP "Safety Req-Pb") pbIsSafeQD)
   [qwC probBr $ UpFrom (Exc, exactDbl 0), qwC pbTol $ UpFrom (Exc, exactDbl 0)]
   (qw isSafePb) []
   [ref astm2009] "isSafePb"
@@ -39,7 +39,7 @@ pbIsSafeQD = mkQuantDef isSafePb (sy probBr $< sy pbTol)
 {--}
 
 lrIsSafe :: InstanceModel
-lrIsSafe = imNoDeriv' (EquationalModel lrIsSafeQD) (nounPhraseSP "Safety Req-LR")
+lrIsSafe = imNoDeriv (equationalModelN (nounPhraseSP "Safety Req-LR") lrIsSafeQD)
   [qwC lRe $ UpFrom (Exc, exactDbl 0), qwC demand $ UpFrom (Exc, exactDbl 0)]
   (qw isSafeLR) []
   [ref astm2009] "isSafeLR"

--- a/code/drasil-example/Drasil/GlassBR/IMods.hs
+++ b/code/drasil-example/Drasil/GlassBR/IMods.hs
@@ -2,7 +2,7 @@ module Drasil.GlassBR.IMods (symb, iMods, pbIsSafe, lrIsSafe, instModIntro, iMod
 
 import Prelude hiding (exp)
 import Language.Drasil
-import Theory.Drasil (InstanceModel, imNoDeriv, qwC, ModelKind, equationalModelN)
+import Theory.Drasil (InstanceModel, imNoDeriv, qwC, equationalModelN)
 import Utils.Drasil
 import Utils.Drasil.Concepts
 import qualified Utils.Drasil.Sentence as S

--- a/code/drasil-example/Drasil/GlassBR/TMods.hs
+++ b/code/drasil-example/Drasil/GlassBR/TMods.hs
@@ -1,7 +1,7 @@
 module Drasil.GlassBR.TMods (tMods, pbIsSafe, lrIsSafe, tModRefs) where
 
 import Language.Drasil
-import Theory.Drasil (TheoryModel, tm, ModelKinds(EquationalModel))
+import Theory.Drasil (TheoryModel, tm, equationalModel')
 
 import Drasil.GlassBR.References (astm2009)
 import Drasil.GlassBR.Unitals (isSafeLoad, isSafeProb, pbTolfail, probFail,
@@ -21,7 +21,7 @@ tMods = [pbIsSafe, lrIsSafe]
 
 
 lrIsSafe :: TheoryModel
-lrIsSafe = tm (EquationalModel lrIsSafeQD)
+lrIsSafe = tm (equationalModel' lrIsSafeQD)
    [qw isSafeLoad, qw tmLRe, qw tmDemand] ([] :: [ConceptChunk])
    [lrIsSafeQD] [] [] [ref astm2009] 
    "isSafeLoad" [lrIsSafeDesc]
@@ -36,7 +36,7 @@ lrIsSafeDesc :: Sentence
 lrIsSafeDesc = tModDesc isSafeLoad
 
 pbIsSafe :: TheoryModel
-pbIsSafe = tm (EquationalModel pbIsSafeQD) 
+pbIsSafe = tm (equationalModel' pbIsSafeQD) 
   [qw isSafeProb, qw probFail, qw pbTolfail] ([] :: [ConceptChunk])
   [pbIsSafeQD] [] [] [ref astm2009]
   "isSafeProb" [pbIsSafeDesc]

--- a/code/drasil-example/Drasil/NoPCM/GenDefs.hs
+++ b/code/drasil-example/Drasil/NoPCM/GenDefs.hs
@@ -1,7 +1,7 @@
 module Drasil.NoPCM.GenDefs (rocTempSimp, genDefs, genDefRefs) where
 
 import Language.Drasil
-import Theory.Drasil (GenDefn, gdNoRefs, ModelKinds (OthModel))
+import Theory.Drasil (GenDefn, gdNoRefs, ModelKind, othModel')
 
 import Drasil.NoPCM.Assumptions (assumpDWCoW, assumpSHECoW)
 import Drasil.SWHS.Assumptions (assumpCWTAT)
@@ -11,7 +11,7 @@ genDefs :: [GenDefn]
 genDefs = [rocTempSimp, htFluxWaterFromCoil] 
 
 rocTempSimp :: GenDefn
-rocTempSimp = gdNoRefs (OthModel rocTempSimpRC) (Nothing :: Maybe UnitDefn)
+rocTempSimp = gdNoRefs (othModel' rocTempSimpRC) (Nothing :: Maybe UnitDefn)
   (Just $ rocTempSimpDeriv EmptyS [assumpCWTAT, assumpDWCoW, assumpSHECoW])
   "rocTempSimp" [{-Notes-}]
 

--- a/code/drasil-example/Drasil/NoPCM/GenDefs.hs
+++ b/code/drasil-example/Drasil/NoPCM/GenDefs.hs
@@ -1,7 +1,7 @@
 module Drasil.NoPCM.GenDefs (rocTempSimp, genDefs, genDefRefs) where
 
 import Language.Drasil
-import Theory.Drasil (GenDefn, gdNoRefs, ModelKind, othModel')
+import Theory.Drasil (GenDefn, gdNoRefs, othModel')
 
 import Drasil.NoPCM.Assumptions (assumpDWCoW, assumpSHECoW)
 import Drasil.SWHS.Assumptions (assumpCWTAT)

--- a/code/drasil-example/Drasil/NoPCM/IMods.hs
+++ b/code/drasil-example/Drasil/NoPCM/IMods.hs
@@ -1,7 +1,7 @@
 module Drasil.NoPCM.IMods (eBalanceOnWtr, iMods, instModIntro, iModRefs) where
 
 import Language.Drasil
-import Theory.Drasil (InstanceModel, im, qwC, qwUC, ModelKind, deModel')
+import Theory.Drasil (InstanceModel, im, qwC, qwUC, deModel')
 import Utils.Drasil
 import Utils.Drasil.Concepts
 import qualified Utils.Drasil.Sentence as S

--- a/code/drasil-example/Drasil/NoPCM/IMods.hs
+++ b/code/drasil-example/Drasil/NoPCM/IMods.hs
@@ -1,7 +1,7 @@
 module Drasil.NoPCM.IMods (eBalanceOnWtr, iMods, instModIntro, iModRefs) where
 
 import Language.Drasil
-import Theory.Drasil (InstanceModel, im, qwC, qwUC, ModelKinds (DEModel))
+import Theory.Drasil (InstanceModel, im, qwC, qwUC, ModelKind, deModel')
 import Utils.Drasil
 import Utils.Drasil.Concepts
 import qualified Utils.Drasil.Sentence as S
@@ -33,7 +33,7 @@ iMods = [eBalanceOnWtr, heatEInWtr]
 ---------
 -- FIXME: comment on reference?
 eBalanceOnWtr :: InstanceModel
-eBalanceOnWtr = im (DEModel eBalanceOnWtrRC)
+eBalanceOnWtr = im (deModel' eBalanceOnWtrRC)
   [qwC tempC $ UpFrom (Inc, sy tempInit)
   , qwUC tempInit, qwUC timeFinal, qwUC coilSA, qwUC coilHTC, qwUC htCapW, qwUC wMass]
   (qw tempW) []

--- a/code/drasil-example/Drasil/PDController/GenDefs.hs
+++ b/code/drasil-example/Drasil/PDController/GenDefs.hs
@@ -8,7 +8,7 @@ import Drasil.PDController.Concepts
 import Drasil.PDController.References
 import Drasil.PDController.TModel
 import Language.Drasil
-import Theory.Drasil (GenDefn, gd, ModelKinds (OthModel))
+import Theory.Drasil (GenDefn, gd, ModelKind, othModel')
 import Utils.Drasil
 import Utils.Drasil.Concepts
 import qualified Utils.Drasil.Sentence as S
@@ -22,7 +22,7 @@ genDefns = [gdPowerPlant]
 
 gdPowerPlant :: GenDefn
 gdPowerPlant
-  = gd (OthModel gdPowerPlantRC) (Nothing :: Maybe UnitDefn) Nothing
+  = gd (othModel' gdPowerPlantRC) (Nothing :: Maybe UnitDefn) Nothing
       [ref pidWiki, ref abbasi2015]
       "gdPowerPlant"
       [gdPowerPlantNote]

--- a/code/drasil-example/Drasil/PDController/GenDefs.hs
+++ b/code/drasil-example/Drasil/PDController/GenDefs.hs
@@ -8,7 +8,7 @@ import Drasil.PDController.Concepts
 import Drasil.PDController.References
 import Drasil.PDController.TModel
 import Language.Drasil
-import Theory.Drasil (GenDefn, gd, ModelKind, othModel')
+import Theory.Drasil (GenDefn, gd, othModel')
 import Utils.Drasil
 import Utils.Drasil.Concepts
 import qualified Utils.Drasil.Sentence as S

--- a/code/drasil-example/Drasil/PDController/IModel.hs
+++ b/code/drasil-example/Drasil/PDController/IModel.hs
@@ -9,7 +9,7 @@ import Drasil.PDController.GenDefs
 import Drasil.PDController.References
 import Drasil.PDController.TModel
 import Language.Drasil
-import Theory.Drasil (InstanceModel, im, qwC, ModelKinds (DEModel))
+import Theory.Drasil (InstanceModel, im, qwC, ModelKind, deModel')
 import Utils.Drasil
 import Utils.Drasil.Concepts
 import qualified Utils.Drasil.Sentence as S
@@ -22,7 +22,7 @@ instanceModels = [imPD]
 
 imPD :: InstanceModel
 imPD
-  = im (DEModel imPDRC)
+  = im (deModel' imPDRC)
       [qwC qdSetPointTD $ UpFrom (Exc, exactDbl 0), qwC qdPropGain $ UpFrom (Exc, exactDbl 0),
        qwC qdDerivGain $ UpFrom (Exc, exactDbl 0)]
       (qw qdProcessVariableTD)

--- a/code/drasil-example/Drasil/PDController/IModel.hs
+++ b/code/drasil-example/Drasil/PDController/IModel.hs
@@ -9,7 +9,7 @@ import Drasil.PDController.GenDefs
 import Drasil.PDController.References
 import Drasil.PDController.TModel
 import Language.Drasil
-import Theory.Drasil (InstanceModel, im, qwC, ModelKind, deModel')
+import Theory.Drasil (InstanceModel, im, qwC, deModel')
 import Utils.Drasil
 import Utils.Drasil.Concepts
 import qualified Utils.Drasil.Sentence as S

--- a/code/drasil-example/Drasil/PDController/TModel.hs
+++ b/code/drasil-example/Drasil/PDController/TModel.hs
@@ -8,7 +8,7 @@ import Drasil.PDController.Concepts
 import Drasil.PDController.References
 import Language.Drasil
 import qualified Language.Drasil as DrasilLang
-import Theory.Drasil (TheoryModel, tm, ModelKinds(OthModel))
+import Theory.Drasil (TheoryModel, tm, ModelKind, othModel')
 import Utils.Drasil
 import Utils.Drasil.Concepts
 import qualified Utils.Drasil.Sentence as S
@@ -20,7 +20,7 @@ theoreticalModels = [tmLaplace, tmInvLaplace, tmSOSystem]
 
 tmLaplace :: TheoryModel
 tmLaplace
-  = tm (OthModel laplaceRC)
+  = tm (othModel' laplaceRC)
       [qw qdLaplaceTransform, qw qdFreqDomain, qw time, qw qdPosInf,
        qw qdFxnTDomain]
       ([] :: [ConceptChunk])
@@ -52,7 +52,7 @@ laplaceDesc
 
 tmInvLaplace :: TheoryModel
 tmInvLaplace
-  = tm (OthModel invlaplaceRC)
+  = tm (othModel' invlaplaceRC)
       [qw qdLaplaceTransform, qw qdFreqDomain, qw time, qw qdPosInf,
        qw qdFxnTDomain]
       ([] :: [ConceptChunk])
@@ -82,7 +82,7 @@ invLaplaceDesc
 
 tmSOSystem :: TheoryModel
 tmSOSystem
-  = tm (OthModel tmSOSystemRC)
+  = tm (othModel' tmSOSystemRC)
       [qw mass, qw qdDampingCoeff, qw qdStiffnessCoeff, qw qdFreqDomain]
       ([] :: [ConceptChunk])
       []

--- a/code/drasil-example/Drasil/PDController/TModel.hs
+++ b/code/drasil-example/Drasil/PDController/TModel.hs
@@ -8,7 +8,7 @@ import Drasil.PDController.Concepts
 import Drasil.PDController.References
 import Language.Drasil
 import qualified Language.Drasil as DrasilLang
-import Theory.Drasil (TheoryModel, tm, ModelKind, othModel')
+import Theory.Drasil (TheoryModel, tm, othModel')
 import Utils.Drasil
 import Utils.Drasil.Concepts
 import qualified Utils.Drasil.Sentence as S

--- a/code/drasil-example/Drasil/Projectile/GenDefs.hs
+++ b/code/drasil-example/Drasil/Projectile/GenDefs.hs
@@ -3,7 +3,7 @@ module Drasil.Projectile.GenDefs (genDefns, posVecGD, genDefRefs) where
 
 import Prelude hiding (cos, sin)
 import Language.Drasil
-import Theory.Drasil (GenDefn, TheoryModel, gd, gdNoRefs, ModelKind, equationalModel')
+import Theory.Drasil (GenDefn, TheoryModel, gd, gdNoRefs, equationalModel')
 import Utils.Drasil
 import Utils.Drasil.Concepts
 import qualified Utils.Drasil.Sentence as S

--- a/code/drasil-example/Drasil/Projectile/GenDefs.hs
+++ b/code/drasil-example/Drasil/Projectile/GenDefs.hs
@@ -3,7 +3,7 @@ module Drasil.Projectile.GenDefs (genDefns, posVecGD, genDefRefs) where
 
 import Prelude hiding (cos, sin)
 import Language.Drasil
-import Theory.Drasil (GenDefn, TheoryModel, gd, gdNoRefs, ModelKinds(EquationalModel))
+import Theory.Drasil (GenDefn, TheoryModel, gd, gdNoRefs, ModelKind, equationalModel')
 import Utils.Drasil
 import Utils.Drasil.Concepts
 import qualified Utils.Drasil.Sentence as S
@@ -31,7 +31,7 @@ genDefns = [rectVelGD, rectPosGD, velVecGD, posVecGD]
 
 ----------
 rectVelGD :: GenDefn
-rectVelGD = gd (EquationalModel rectVelQD) (getUnit projSpeed) (Just rectVelDeriv)
+rectVelGD = gd (equationalModel' rectVelQD) (getUnit projSpeed) (Just rectVelDeriv)
   [refInfo hibbeler2004 $ Page [8]] "rectVel" [{-Notes-}]
 
 rectVelQD :: QDefinition 
@@ -56,7 +56,7 @@ rectVelDerivEqns = map eS [E.rectVelDerivEqn1, E.rectVelDerivEqn2]
 
 ----------
 rectPosGD :: GenDefn
-rectPosGD = gd (EquationalModel rectPosQD) (getUnit scalarPos) (Just rectPosDeriv)
+rectPosGD = gd (equationalModel' rectPosQD) (getUnit scalarPos) (Just rectPosDeriv)
   [refInfo hibbeler2004 $ Page [8]] "rectPos" [{-Notes-}]
 
 rectPosQD :: QDefinition
@@ -80,7 +80,7 @@ rectPosDerivEqns = [E.rectPosDerivEqn1, E.rectPosDerivEqn2, E.rectPosDerivEqn3, 
 
 ----------
 velVecGD :: GenDefn
-velVecGD = gdNoRefs (EquationalModel velVecQD) (getUnit velocity)
+velVecGD = gdNoRefs (equationalModel' velVecQD) (getUnit velocity)
            (Just velVecDeriv) "velVec" [{-Notes-}]
 
 velVecQD :: QDefinition 
@@ -97,7 +97,7 @@ velVecDerivSent = vecDeriv [(velocity, E.velocityXY), (acceleration, E.accelerat
 
 ----------
 posVecGD :: GenDefn
-posVecGD = gdNoRefs (EquationalModel posVecQD) (getUnit position) 
+posVecGD = gdNoRefs (equationalModel' posVecQD) (getUnit position) 
            (Just posVecDeriv) "posVec" [{-Notes-}]
 
 posVecQD :: QDefinition

--- a/code/drasil-example/Drasil/Projectile/IMods.hs
+++ b/code/drasil-example/Drasil/Projectile/IMods.hs
@@ -3,7 +3,7 @@ module Drasil.Projectile.IMods (iMods, landPosIM, messageIM, offsetIM, timeIM, i
 import Prelude hiding (cos, sin)
 
 import Language.Drasil
-import Theory.Drasil (InstanceModel, imNoDerivNoRefs',imNoRefs', qwC, ModelKinds ( EquationalModel))
+import Theory.Drasil (InstanceModel, imNoDerivNoRefs, imNoRefs, qwC, ModelKind, equationalModelN)
 import Utils.Drasil
 import Utils.Drasil.Concepts
 import qualified Utils.Drasil.Sentence as S
@@ -34,7 +34,7 @@ iMods :: [InstanceModel]
 iMods = [timeIM, landPosIM, offsetIM, messageIM]
 ---
 timeIM :: InstanceModel
-timeIM = imNoRefs' (EquationalModel timeQD)(nounPhraseSP "calculation of landing time")
+timeIM = imNoRefs (equationalModelN (nounPhraseSP "calculation of landing time") timeQD)
   [qwC launSpeed $ UpFrom (Exc, exactDbl 0)
   ,qwC launAngle $ Bounded (Exc, exactDbl 0) (Exc, half $ sy pi_)]
   (qw flightDur) [UpFrom (Exc, exactDbl 0)]
@@ -73,7 +73,7 @@ timeDerivEqns = [E.timeDerivEqn1, E.timeDerivEqn2, E.timeDerivEqn3, E.timeDerivE
 
 ---
 landPosIM :: InstanceModel
-landPosIM = imNoRefs' (EquationalModel landPosQD)(nounPhraseSP "calculation of landing position")
+landPosIM = imNoRefs (equationalModelN (nounPhraseSP "calculation of landing position") landPosQD)
   [qwC launSpeed $ UpFrom (Exc, exactDbl 0),
    qwC launAngle $ Bounded (Exc, exactDbl 0) (Exc, half $ sy pi_)]
   (qw landPos) [UpFrom (Exc, exactDbl 0)]
@@ -107,7 +107,7 @@ landPosDerivEqns = [E.landPosDerivEqn1, E.landPosDerivEqn2, E.landPosDerivEqn3, 
 
 ---
 offsetIM :: InstanceModel
-offsetIM = imNoDerivNoRefs' (EquationalModel offsetQD) (nounPhraseSP "offset")
+offsetIM = imNoDerivNoRefs (equationalModelN (nounPhraseSP "offset") offsetQD)
   [qwC landPos $ UpFrom (Exc, exactDbl 0)
   ,qwC targPos $ UpFrom (Exc, exactDbl 0)]
   (qw offset) [] "offsetIM" [landPosNote, landAndTargPosConsNote]
@@ -116,7 +116,7 @@ offsetQD :: QDefinition
 offsetQD = mkQuantDef offset E.offset'
 ---
 messageIM :: InstanceModel
-messageIM = imNoDerivNoRefs' (EquationalModel messageQD)(nounPhraseSP "output message")
+messageIM = imNoDerivNoRefs (equationalModelN (nounPhraseSP "output message") messageQD)
   [qwC offset $ UpFrom (Exc, neg (sy landPos))
   ,qwC targPos $ UpFrom (Exc, exactDbl 0)]
   (qw message)

--- a/code/drasil-example/Drasil/Projectile/IMods.hs
+++ b/code/drasil-example/Drasil/Projectile/IMods.hs
@@ -3,7 +3,7 @@ module Drasil.Projectile.IMods (iMods, landPosIM, messageIM, offsetIM, timeIM, i
 import Prelude hiding (cos, sin)
 
 import Language.Drasil
-import Theory.Drasil (InstanceModel, imNoDerivNoRefs, imNoRefs, qwC, ModelKind, equationalModelN)
+import Theory.Drasil (InstanceModel, imNoDerivNoRefs, imNoRefs, qwC, equationalModelN)
 import Utils.Drasil
 import Utils.Drasil.Concepts
 import qualified Utils.Drasil.Sentence as S

--- a/code/drasil-example/Drasil/SSP/GenDefs.hs
+++ b/code/drasil-example/Drasil/SSP/GenDefs.hs
@@ -8,7 +8,7 @@ import Control.Lens ((^.))
 import Prelude hiding (sin, cos, tan)
 import qualified Data.List.NonEmpty as NE
 import Language.Drasil
-import Theory.Drasil (GenDefn, gd, ModelKinds(EquationalConstraints, OthModel, EquationalModel), mkConstraintSet, )
+import Theory.Drasil
 import Utils.Drasil
 import Utils.Drasil.Concepts
 import qualified Utils.Drasil.NounPhrase as NP
@@ -56,29 +56,29 @@ generalDefinitions = [normForcEqGD, bsShrFEqGD, resShrGD, mobShrGD,
 normForcEqGD, bsShrFEqGD, resShrGD, mobShrGD, effNormFGD, resShearWOGD,
   mobShearWOGD, normShrRGD, momentEqlGD, sliceWghtGD, baseWtrFGD,
   srfWtrFGD :: GenDefn
-normForcEqGD = gd (OthModel normForcEq) (getUnit totNrmForce)   (Just nmFEqDeriv)
+normForcEqGD = gd (othModel' normForcEq) (getUnit totNrmForce)   (Just nmFEqDeriv)
   [ref chen2005]                      "normForcEq"  [nmFEqDesc]
-bsShrFEqGD   = gd (OthModel bsShrFEq)   (getUnit mobShrI)       (Just bShFEqDeriv)
+bsShrFEqGD   = gd (othModel' bsShrFEq)   (getUnit mobShrI)       (Just bShFEqDeriv)
   [ref chen2005]                      "bsShrFEq"    [bShFEqDesc]
-resShrGD     = gd (OthModel resShr)     (getUnit shrResI)       (Just resShrDeriv)
+resShrGD     = gd (othModel' resShr)     (getUnit shrResI)       (Just resShrDeriv)
   [ref chen2005]                      "resShr"      [resShrDesc]
-mobShrGD     = gd (OthModel mobShr)     (getUnit mobShrI)       (Just mobShrDeriv)
+mobShrGD     = gd (othModel' mobShr)     (getUnit mobShrI)       (Just mobShrDeriv)
   [ref chen2005]                      "mobShr"      [mobShrDesc]
-effNormFGD   = gd (OthModel effNormF)   (getUnit nrmFSubWat)    (Just effNormFDeriv)
+effNormFGD   = gd (othModel' effNormF)   (getUnit nrmFSubWat)    (Just effNormFDeriv)
   [ref chen2005]                      "effNormF"    [effNormFDesc]
-resShearWOGD = gd (OthModel resShearWO) (getUnit shearRNoIntsl) Nothing
+resShearWOGD = gd (othModel' resShearWO) (getUnit shearRNoIntsl) Nothing
   (map ref[chen2005, karchewski2012]) "resShearWO"  [resShearWODesc]
-mobShearWOGD = gd (OthModel mobShearWO) (getUnit shearFNoIntsl) Nothing
+mobShearWOGD = gd (othModel' mobShearWO) (getUnit shearFNoIntsl) Nothing
   (map ref[chen2005, karchewski2012]) "mobShearWO"  [mobShearWODesc]
-normShrRGD   = gd (EquationalModel normShrR)   (getUnit intShrForce)   Nothing
+normShrRGD   = gd (equationalModel' normShrR)   (getUnit intShrForce)   Nothing
   [ref chen2005]                      "normShrR"    [nmShrRDesc]
 momentEqlGD  = gd momentEqlModel        (Just newton)            (Just momEqlDeriv)
   [ref chen2005]                      "momentEql"   [momEqlDesc]
-sliceWghtGD  = gd (OthModel sliceWght)  (getUnit slcWght)       (Just sliceWghtDeriv)
+sliceWghtGD  = gd (othModel' sliceWght)  (getUnit slcWght)       (Just sliceWghtDeriv)
   [ref fredlund1977]                  "sliceWght"   [sliceWghtNotes]
-baseWtrFGD   = gd (OthModel baseWtrF)   (getUnit baseHydroForce) (Just bsWtrFDeriv)
+baseWtrFGD   = gd (othModel' baseWtrF)   (getUnit baseHydroForce) (Just bsWtrFDeriv)
   [ref fredlund1977]                  "baseWtrF"    [bsWtrFNotes]
-srfWtrFGD    = gd (OthModel srfWtrF)    (getUnit surfHydroForce) (Just srfWtrFDeriv)
+srfWtrFGD    = gd (othModel' srfWtrF)    (getUnit surfHydroForce) (Just srfWtrFDeriv)
   [ref fredlund1977]                  "srfWtrF"     [srfWtrFNotes]
 --
 normForcEq :: RelationConcept
@@ -245,8 +245,8 @@ mobShearWODesc = (foldlList Comma List [slcWght `definedIn'''` sliceWghtGD,
 
 --
 
-momentEqlModel :: ModelKinds
-momentEqlModel = EquationalConstraints $
+momentEqlModel :: ModelKind
+momentEqlModel = equationalConstraints' $
   mkConstraintSet (dccWDS "momentEql" (nounPhraseSP "moment equilibrium") momEqlDesc) $
   NE.fromList [momEqlRel]
 

--- a/code/drasil-example/Drasil/SSP/IMods.hs
+++ b/code/drasil-example/Drasil/SSP/IMods.hs
@@ -4,7 +4,7 @@ module Drasil.SSP.IMods where
 import Prelude hiding (tan, product, sin, cos)
 
 import Language.Drasil
-import Theory.Drasil (InstanceModel, im, imNoDeriv, qwUC, ModelKinds (OthModel, EquationalModel))
+import Theory.Drasil
 import Utils.Drasil
 import Utils.Drasil.Concepts
 import qualified Utils.Drasil.Sentence as S
@@ -51,7 +51,7 @@ iMods = [fctSfty, nrmShrFor, nrmShrForNum, nrmShrForDen, intsliceFs, crtSlpId]
 --
 
 fctSfty :: InstanceModel
-fctSfty = im (EquationalModel fctSftyQD)
+fctSfty = im (equationalModel' fctSftyQD)
  [qwUC slopeDist, qwUC slopeHght, qwUC waterHght, qwUC effCohesion, qwUC fricAngle,
   qwUC dryWeight, qwUC satWeight, qwUC waterWeight, qwUC slipDist, qwUC slipHght, qwUC constF]
   (qw fs) [] (map ref [chen2005, karchewski2012])
@@ -372,7 +372,7 @@ fctSftyDerivEqn18 = sy fs `mulRe` (idx (sy mobShrC) (sy numbSlices $- int 1) `mu
 ------------------------------------------------------------------------
 
 nrmShrFor :: InstanceModel
-nrmShrFor = im (OthModel nrmShrForRC) [qwUC slopeDist, qwUC slopeHght, qwUC waterHght,
+nrmShrFor = im (othModel' nrmShrForRC) [qwUC slopeDist, qwUC slopeHght, qwUC waterHght,
   qwUC waterWeight, qwUC slipDist, qwUC slipHght, qwUC constF]
   (qw normToShear) [] (map ref [chen2005, karchewski2012])
   (Just nrmShrDeriv) "nrmShrFor" [nrmShrFDesc]
@@ -457,7 +457,7 @@ nrmShrDerivEqn4 = sy normToShear $= sum1toN
 ---------------------------------------------------------------------
 
 nrmShrForNum :: InstanceModel
-nrmShrForNum = im (OthModel nrmShrForNumRC) [qwUC slopeDist, qwUC slopeHght, qwUC waterHght,
+nrmShrForNum = im (othModel' nrmShrForNumRC) [qwUC slopeDist, qwUC slopeHght, qwUC waterHght,
   qwUC waterWeight, qwUC slipDist, qwUC slipHght]
   (qw nrmShearNum) [] (map ref [chen2005, karchewski2012])
   (Just nrmShrFNumDeriv) "nrmShrForNum" [nrmShrFNumDesc]
@@ -495,7 +495,7 @@ nrmShrFNumDesc = (foldlList Comma List [baseWthX `definedIn'''` lengthB,
 ---------------------------------------------------------------------------
 
 nrmShrForDen :: InstanceModel
-nrmShrForDen = im (OthModel nrmShrForDenRC) [qwUC slipDist, qwUC constF]
+nrmShrForDen = im (othModel' nrmShrForDenRC) [qwUC slipDist, qwUC constF]
   (qw nrmShearDen) [] (map ref [chen2005, karchewski2012])
   (Just nrmShrFDenDeriv) "nrmShrForDen" [nrmShrFDenDesc]
 
@@ -525,7 +525,7 @@ nrmShrFDenDesc = baseWthX `definedIn'''`
 --------------------------------------------------------------------------
 
 intsliceFs :: InstanceModel
-intsliceFs = im (OthModel intsliceFsRC) [qwUC slopeDist, qwUC slopeHght, qwUC waterHght
+intsliceFs = im (othModel' intsliceFsRC) [qwUC slopeDist, qwUC slopeHght, qwUC waterHght
   , qwUC effCohesion, qwUC fricAngle, qwUC dryWeight, qwUC satWeight, qwUC waterWeight
   , qwUC slipDist, qwUC slipHght, qwUC constF]
   (qw intNormForce) [] [ref chen2005] (Just intrSlcDeriv) "intsliceFs" [sliceFsDesc]
@@ -585,7 +585,7 @@ intrSlcDerivEqn = inxi intNormForce $=
 
 --------------------------------------------------------------------------
 crtSlpId :: InstanceModel
-crtSlpId = imNoDeriv (OthModel crtSlpIdRC) [qwUC slopeDist, qwUC slopeHght, qwUC waterDist,
+crtSlpId = imNoDeriv (othModel' crtSlpIdRC) [qwUC slopeDist, qwUC slopeHght, qwUC waterDist,
   qwUC waterHght, qwUC effCohesion, qwUC fricAngle, qwUC dryWeight, qwUC satWeight,
   qwUC waterWeight, qwUC constF] (qw fsMin) [] [ref li2010] "crtSlpId"
   [crtSlpIdDesc]

--- a/code/drasil-example/Drasil/SSP/TMods.hs
+++ b/code/drasil-example/Drasil/SSP/TMods.hs
@@ -48,7 +48,7 @@ factOfSafetyExpr = sy resistiveShear $/ sy mobilizedShear
 --
 ------------- New Chunk -----------
 equilibrium :: TheoryModel
-equilibrium = tm (EquationalConstraints equilibriumCS)
+equilibrium = tm (equationalConstraints' equilibriumCS)
   [qw fx] ([] :: [ConceptChunk])
   [] (map toDispExpr equilibriumRels) [] [ref fredlund1977] "equilibrium" [eqDesc]
 

--- a/code/drasil-example/Drasil/SSP/TMods.hs
+++ b/code/drasil-example/Drasil/SSP/TMods.hs
@@ -34,7 +34,7 @@ tMods = [factOfSafety, equilibrium, mcShrStrgth, effStress, newtonSL]
 
 ------------- New Chunk -----------
 factOfSafety :: TheoryModel
-factOfSafety = tm' "factOfSafetyTM" (EquationalModel factOfSafetyQD)
+factOfSafety = tm (equationalModelU "factOfSafetyTM" factOfSafetyQD)
   [qw fs, qw resistiveShear, qw mobilizedShear] ([] :: [ConceptChunk])
   [factOfSafetyQD] [] [] [ref fredlund1977] "factOfSafety" []
 
@@ -75,7 +75,7 @@ eqDesc = foldlSent [S "For a body in static equilibrium, the net",
 --
 ------------- New Chunk -----------
 mcShrStrgth :: TheoryModel
-mcShrStrgth = tm' "mcShrSrgth" (EquationalModel mcShrStrgthQD)
+mcShrStrgth = tm (equationalModelU "mcShrSrgth" mcShrStrgthQD)
   [qw shrStress, qw effNormStress, qw fricAngle, qw effCohesion] 
   ([] :: [ConceptChunk])
   [mcShrStrgthQD] [] [] [ref fredlund1977] "mcShrStrgth" [mcShrStrgthDesc]
@@ -105,7 +105,7 @@ mcShrStrgthDesc = foldlSent [S "In this", phrase model, S "the",
 --
 ------------- New Chunk -----------
 effStress :: TheoryModel
-effStress = tm' "effectiveStressTM" (EquationalModel effStressQD)
+effStress = tm (equationalModelU "effectiveStressTM" effStressQD)
   [qw effectiveStress, qw totNormStress, qw porePressure] 
   ([] :: [ConceptChunk])
   [effStressQD] [] [] [ref fredlund1977] "effStress" [effStressDesc]

--- a/code/drasil-example/Drasil/SWHS/GenDefs.hs
+++ b/code/drasil-example/Drasil/SWHS/GenDefs.hs
@@ -2,7 +2,7 @@ module Drasil.SWHS.GenDefs (genDefs, htFluxWaterFromCoil, htFluxPCMFromWater,
   rocTempSimp, rocTempSimpDeriv, rocTempSimpRC, genDefRefs) where
 
 import Language.Drasil
-import Theory.Drasil (GenDefn, gd, gdNoRefs, ModelKind, deModel', equationalModel')
+import Theory.Drasil (GenDefn, gd, gdNoRefs, deModel', equationalModel')
 import Utils.Drasil
 import Utils.Drasil.Concepts
 import qualified Utils.Drasil.Sentence as S

--- a/code/drasil-example/Drasil/SWHS/GenDefs.hs
+++ b/code/drasil-example/Drasil/SWHS/GenDefs.hs
@@ -2,7 +2,7 @@ module Drasil.SWHS.GenDefs (genDefs, htFluxWaterFromCoil, htFluxPCMFromWater,
   rocTempSimp, rocTempSimpDeriv, rocTempSimpRC, genDefRefs) where
 
 import Language.Drasil
-import Theory.Drasil (GenDefn, gd, gdNoRefs, ModelKinds (DEModel, EquationalModel))
+import Theory.Drasil (GenDefn, gd, gdNoRefs, ModelKind, deModel', equationalModel')
 import Utils.Drasil
 import Utils.Drasil.Concepts
 import qualified Utils.Drasil.Sentence as S
@@ -35,7 +35,7 @@ genDefs :: [GenDefn]
 genDefs = [rocTempSimp, htFluxWaterFromCoil, htFluxPCMFromWater] 
 
 rocTempSimp :: GenDefn
-rocTempSimp = gdNoRefs (DEModel rocTempSimpRC) (Nothing :: Maybe UnitDefn)
+rocTempSimp = gdNoRefs (deModel' rocTempSimpRC) (Nothing :: Maybe UnitDefn)
   (Just $ rocTempSimpDeriv rocTempDerivConsFlxSWHS
    [assumpCWTAT, assumpTPCAV, assumpDWPCoV, assumpSHECoV])
   "rocTempSimp" [{-Notes-}]
@@ -52,7 +52,7 @@ rocTempSimpRel = sy QPP.mass `mulRe` sy QT.heatCapSpec `mulRe`
 ----
 
 htFluxWaterFromCoil :: GenDefn
-htFluxWaterFromCoil = gd (EquationalModel htFluxWaterFromCoilQD) (getUnit htFluxC) Nothing
+htFluxWaterFromCoil = gd (equationalModel' htFluxWaterFromCoilQD) (getUnit htFluxC) Nothing
   [ref koothoor2013] "htFluxWaterFromCoil"
   [newtonLawNote htFluxC assumpLCCCW coil, refS assumpTHCCoT]
 
@@ -66,7 +66,7 @@ htFluxWaterFromCoilExpr = sy coilHTC `mulRe` (sy tempC $- apply1 tempW time)
 ----
 
 htFluxPCMFromWater :: GenDefn
-htFluxPCMFromWater = gd (EquationalModel htFluxPCMFromWaterQD) (getUnit htFluxP) Nothing
+htFluxPCMFromWater = gd (equationalModel' htFluxPCMFromWaterQD) (getUnit htFluxP) Nothing
   [ref koothoor2013] "htFluxPCMFromWater"
   [newtonLawNote htFluxP assumpLCCWP phaseChangeMaterial]
 

--- a/code/drasil-example/Drasil/SWHS/IMods.hs
+++ b/code/drasil-example/Drasil/SWHS/IMods.hs
@@ -2,7 +2,7 @@ module Drasil.SWHS.IMods (iMods, eBalanceOnWtr, eBalanceOnWtrDerivDesc1,
   eBalanceOnWtrDerivDesc3, eBalanceOnPCM, heatEInWtr, heatEInPCM, instModIntro, iModRefs) where
 
 import Language.Drasil
-import Theory.Drasil (InstanceModel, im, imNoDeriv, qwUC, qwC, ModelKind, deModel', othModel')
+import Theory.Drasil (InstanceModel, im, imNoDeriv, qwUC, qwC, deModel', othModel')
 import Utils.Drasil
 import Utils.Drasil.Concepts
 import qualified Utils.Drasil.NounPhrase as NP

--- a/code/drasil-example/Drasil/SWHS/IMods.hs
+++ b/code/drasil-example/Drasil/SWHS/IMods.hs
@@ -2,7 +2,7 @@ module Drasil.SWHS.IMods (iMods, eBalanceOnWtr, eBalanceOnWtrDerivDesc1,
   eBalanceOnWtrDerivDesc3, eBalanceOnPCM, heatEInWtr, heatEInPCM, instModIntro, iModRefs) where
 
 import Language.Drasil
-import Theory.Drasil (InstanceModel, im, imNoDeriv, qwUC, qwC, ModelKinds (DEModel, OthModel))
+import Theory.Drasil (InstanceModel, im, imNoDeriv, qwUC, qwC, ModelKind, deModel', othModel')
 import Utils.Drasil
 import Utils.Drasil.Concepts
 import qualified Utils.Drasil.NounPhrase as NP
@@ -39,7 +39,7 @@ iMods = [eBalanceOnWtr, eBalanceOnPCM, heatEInWtr, heatEInPCM]
 -- IM1 --
 ---------
 eBalanceOnWtr :: InstanceModel
-eBalanceOnWtr = im (DEModel eBalanceOnWtrRC)
+eBalanceOnWtr = im (deModel' eBalanceOnWtrRC)
   [qwUC wMass ,qwUC htCapW, qwUC coilHTC, qwUC pcmSA, qwUC pcmHTC, qwUC coilSA
   ,qwUC tempPCM, qwUC timeFinal, qwC tempC $ UpFrom (Exc, sy tempInit)
   ,qwUC tempInit]
@@ -188,7 +188,7 @@ eBalanceOnWtrDerivEqnsIM1 = [eBalanceOnWtrDerivEqn1, eBalanceOnWtrDerivEqn2,
 -- IM2 --
 ---------
 eBalanceOnPCM :: InstanceModel
-eBalanceOnPCM = im (DEModel eBalanceOnPCMRC) [qwC tempMeltP $ UpFrom (Exc, sy tempInit)
+eBalanceOnPCM = im (deModel' eBalanceOnPCMRC) [qwC tempMeltP $ UpFrom (Exc, sy tempInit)
   , qwUC timeFinal, qwUC tempInit, qwUC pcmSA
   , qwUC pcmHTC, qwUC pcmMass, qwUC htCapSP, qwUC htCapLP]
   (qw tempPCM) []
@@ -316,7 +316,7 @@ eBalanceOnPCMDerivEqnsIM2 = [eBalanceOnPCMEqn1, eBalanceOnPCMEqn2,
 -- IM3 --
 ---------
 heatEInWtr :: InstanceModel
-heatEInWtr = imNoDeriv (OthModel heatEInWtrRC)
+heatEInWtr = imNoDeriv (othModel'  heatEInWtrRC)
   [qwUC tempInit, qwUC wMass, qwUC htCapW, qwUC wMass]
   (qw watE) [] [ref koothoor2013]
   "heatEInWtr" htWtrNotes
@@ -343,7 +343,7 @@ htWtrNotes = map foldlSent [
 -- IM4 --
 ---------
 heatEInPCM :: InstanceModel
-heatEInPCM = imNoDeriv (DEModel heatEInPCMRC) [qwC tempMeltP $ UpFrom (Exc, sy tempInit)
+heatEInPCM = imNoDeriv (deModel' heatEInPCMRC) [qwC tempMeltP $ UpFrom (Exc, sy tempInit)
   , qwUC timeFinal, qwUC tempInit, qwUC pcmSA, qwUC pcmHTC
   , qwUC pcmMass, qwUC htCapSP, qwUC htCapLP, qwUC tempPCM, qwUC htFusion, qwUC tInitMelt]
   (qw pcmE)

--- a/code/drasil-example/Drasil/SWHS/TMods.hs
+++ b/code/drasil-example/Drasil/SWHS/TMods.hs
@@ -7,7 +7,7 @@ import qualified Data.List.NonEmpty as NE
 import Language.Drasil
 import Control.Lens ((^.))
 import Theory.Drasil (TheoryModel, tm, 
-  ModelKinds(OthModel, EquationalModel, EquationalConstraints),
+  ModelKind, othModel', equationalModel', equationalConstraints',
   ConstraintSet, mkConstraintSet)
 import Utils.Drasil
 import Utils.Drasil.Concepts
@@ -39,7 +39,7 @@ tMods = [consThermE, sensHtE, latentHtE, nwtnCooling]
 -- Theoretical Model 1 --
 -------------------------
 consThermE :: TheoryModel
-consThermE = tm (EquationalConstraints consThermECS)
+consThermE = tm (equationalConstraints' consThermECS)
   [qw thFluxVect, qw gradient, qw volHtGen,
     qw density, qw heatCapSpec, qw temp, qw time] ([] :: [ConceptChunk])
   [] [toDispExpr consThermERel] [] [consThemESrc] "consThermE" consThermENotes
@@ -78,7 +78,7 @@ data PhaseChange = AllPhases
                  | Liquid
 
 sensHtETemplate :: PhaseChange -> Sentence -> TheoryModel
-sensHtETemplate pc desc = tm (EquationalModel qd)
+sensHtETemplate pc desc = tm (equationalModel' qd)
   [qw sensHeat, qw htCapS, qw mass,
     qw deltaT, qw meltPt, qw temp, qw htCapL, qw boilPt, qw htCapV] ([] :: [ConceptChunk])
   [qd] [] [] [sensHtESrc] "sensHtE" [desc]
@@ -130,7 +130,7 @@ sensHtEdesc = foldlSent [
 -- Theoretical Model 3 --
 -------------------------
 latentHtE :: TheoryModel
-latentHtE = tm (OthModel latentHtERC)
+latentHtE = tm (othModel' latentHtERC)
   [qw latentHeat, qw time, qw tau] ([] :: [ConceptChunk])
   [] [toDispExpr latHtEEqn] [] [latHtESrc] "latentHtE" latentHtENotes
 
@@ -164,7 +164,7 @@ latentHtENotes = map foldlSent [
 -- Theoretical Model 4 --
 -------------------------
 nwtnCooling :: TheoryModel
-nwtnCooling = tm (OthModel nwtnCoolingRC)
+nwtnCooling = tm (othModel' nwtnCoolingRC)
   [qw latentHeat, qw time, qw htTransCoeff, qw deltaT] ([] :: [ConceptChunk])
   [] [toDispExpr nwtnCoolingEqn] [] [refInfo incroperaEtAl2007 $ Page [8]]
   "nwtnCooling" nwtnCoolingNotes

--- a/code/drasil-example/Drasil/SWHS/TMods.hs
+++ b/code/drasil-example/Drasil/SWHS/TMods.hs
@@ -6,9 +6,8 @@ import qualified Data.List.NonEmpty as NE
 
 import Language.Drasil
 import Control.Lens ((^.))
-import Theory.Drasil (TheoryModel, tm, 
-  ModelKind, othModel', equationalModel', equationalConstraints',
-  ConstraintSet, mkConstraintSet)
+import Theory.Drasil (TheoryModel, tm, othModel', equationalModel',
+  equationalConstraints', ConstraintSet, mkConstraintSet)
 import Utils.Drasil
 import Utils.Drasil.Concepts
 import qualified Utils.Drasil.Sentence as S

--- a/code/drasil-theory/Theory/Drasil.hs
+++ b/code/drasil-theory/Theory/Drasil.hs
@@ -3,26 +3,30 @@ module Theory.Drasil (
   -- Classes
     HasInputs(..), HasOutput(..)
   -- ConstraintSet
-  , ConstraintSet, mkConstraintSet
+  , ConstraintSet
+  , mkConstraintSet
   -- DataDefinition
-  , DataDefinition, dd, ddNoRefs, qdFromDD
+  , DataDefinition
+  , dd, ddNoRefs, qdFromDD
   -- GenDefn
   , GenDefn
-  , gd, gdNoRefs, gd', gdNoRefs'
+  , gd, gdNoRefs
   , getEqModQdsFromGd
   -- MultiDefn
   , MultiDefn, DefiningExpr
   , mkMultiDefn, mkMultiDefnForQuant, mkDefiningExpr
   , multiDefnGenQD, multiDefnGenQDByUID
   -- ModelKinds
-  , ModelKinds(..), getEqModQds
+  , ModelKind(..)
+  , deModel, equationalConstraints, equationalModel, equationalRealm, othModel
+  , deModel', equationalConstraints', equationalModel', equationalRealm', othModel'
   -- InstanceModel
   , InstanceModel
   , im, imNoDeriv, imNoRefs, imNoDerivNoRefs
-  , im', imNoDeriv', imNoRefs', imNoDerivNoRefs'
   , qwUC, qwC, getEqModQdsFromIm
   -- Theory
-  , Theory(..), TheoryModel, tm, tmNoRefs, tm', tmNoRefs'
+  , Theory(..), TheoryModel
+  , tm, tmNoRefs
 ) where
 
 import Theory.Drasil.Classes (HasInputs(..), HasOutput(..))

--- a/code/drasil-theory/Theory/Drasil.hs
+++ b/code/drasil-theory/Theory/Drasil.hs
@@ -20,6 +20,7 @@ module Theory.Drasil (
   , ModelKind(..)
   , deModel, equationalConstraints, equationalModel, equationalRealm, othModel
   , deModel', equationalConstraints', equationalModel', equationalRealm', othModel'
+  , equationalModelU, equationalModelN, equationalRealmU, equationalRealmN
   -- InstanceModel
   , InstanceModel
   , im, imNoDeriv, imNoRefs, imNoDerivNoRefs

--- a/code/drasil-theory/Theory/Drasil/GenDefn.hs
+++ b/code/drasil-theory/Theory/Drasil/GenDefn.hs
@@ -1,17 +1,16 @@
 {-# LANGUAGE TemplateHaskell, Rank2Types, ScopedTypeVariables  #-}
 module Theory.Drasil.GenDefn (GenDefn,
-  gd, gdNoRefs, gd', gdNoRefs', getEqModQdsFromGd) where
+  gd, gdNoRefs, getEqModQdsFromGd) where
 
 import Language.Drasil
 import Data.Drasil.TheoryConcepts (genDefn)
-import Theory.Drasil.ModelKinds (ModelKinds(..), getEqModQds)
+import Theory.Drasil.ModelKinds (ModelKind, getEqModQds)
 
 import Control.Lens ((^.), view, makeLenses)
 
 -- | A general definition is a 'ModelKind' that may have units, a derivation,
 -- references, a shortname, a reference address, and notes.
-data GenDefn = GD { _gUid  :: UID
-                  , _mk    :: ModelKinds
+data GenDefn = GD { _mk    :: ModelKind
                   , gdUnit :: Maybe UnitDefn -- TODO: Should be derived from the ModelKinds
                   , _deri  :: Maybe Derivation
                   , _rf   :: [Reference]
@@ -22,7 +21,7 @@ data GenDefn = GD { _gUid  :: UID
 makeLenses ''GenDefn
 
 -- | Finds the 'UID' of a 'GenDefn'.
-instance HasUID             GenDefn where uid           = gUid
+instance HasUID             GenDefn where uid           = mk . uid
 -- | Finds the term ('NP') of the 'GenDefn'.
 instance NamedIdea          GenDefn where term          = mk . term
 -- | Finds the idea contained in the 'GenDefn'.
@@ -52,28 +51,18 @@ instance Referable          GenDefn where
   refAdd      = getRefAdd
   renderRef l = RP (prepend $ abrv l) (getRefAdd l)
 
--- | Smart constructor for general definitions derived from ModelKinds.
-gd :: IsUnit u => ModelKinds -> Maybe u ->
-  Maybe Derivation -> [Reference] -> String -> [Sentence] -> GenDefn
-gd mkind = gd' (mkind ^. uid) mkind
-
--- | Smart constructor for general definitions with no references, derived from ModelKinds.
-gdNoRefs :: (IsUnit u) => ModelKinds -> Maybe u ->
-  Maybe Derivation -> String -> [Sentence] -> GenDefn
-gdNoRefs mkind = gdNoRefs' (mkind ^. uid) mkind
-
 -- | Smart constructor for general definitions.
-gd' :: IsUnit u => UID -> ModelKinds -> Maybe u ->
+gd :: IsUnit u => ModelKind -> Maybe u ->
   Maybe Derivation -> [Reference] -> String -> [Sentence] -> GenDefn
-gd' gid _     _   _     []   _  = error $ "Source field of " ++ gid ++ " is empty"
-gd' gid mkind u derivs refs sn_ = 
-  GD gid mkind (fmap unitWrapper u) derivs refs (shortname' $ S sn_) (prependAbrv genDefn sn_)
+gd mkind _   _     []   _  = error $ "Source field of " ++ (mkind ^. uid) ++ " is empty"
+gd mkind u derivs refs sn_ = 
+  GD mkind (fmap unitWrapper u) derivs refs (shortname' $ S sn_) (prependAbrv genDefn sn_)
 
 -- | Smart constructor for general definitions with no references.
-gdNoRefs' :: IsUnit u => UID -> ModelKinds -> Maybe u ->
+gdNoRefs :: IsUnit u => ModelKind -> Maybe u ->
   Maybe Derivation -> String -> [Sentence] -> GenDefn
-gdNoRefs' gid mkind u derivs sn_ = 
-  GD gid mkind (fmap unitWrapper u) derivs [] (shortname' $ S sn_) (prependAbrv genDefn sn_)
+gdNoRefs mkind u derivs sn_ = 
+  GD mkind (fmap unitWrapper u) derivs [] (shortname' $ S sn_) (prependAbrv genDefn sn_)
 
 -- | Grab all related 'QDefinitions' from a list of general definitions.
 getEqModQdsFromGd :: [GenDefn] -> [QDefinition]

--- a/code/drasil-theory/Theory/Drasil/InstanceModel.hs
+++ b/code/drasil-theory/Theory/Drasil/InstanceModel.hs
@@ -2,7 +2,6 @@
 module Theory.Drasil.InstanceModel
   ( InstanceModel
   , im, imNoDeriv, imNoRefs, imNoDerivNoRefs
-  , im', imNoDeriv', imNoRefs', imNoDerivNoRefs'
   , getEqModQdsFromIm
   , qwUC, qwC
   ) where
@@ -12,7 +11,7 @@ import Theory.Drasil.Classes (HasInputs(inputs), HasOutput(..))
 import Data.Drasil.TheoryConcepts (inModel)
 
 import Control.Lens ((^.), view, makeLenses, _1, _2) 
-import Theory.Drasil.ModelKinds (ModelKinds(..), getEqModQds)
+import Theory.Drasil.ModelKinds (ModelKind, getEqModQds)
 
 type Input = (QuantityDict, Maybe (RealInterval Expr Expr))
 type Inputs = [Input]
@@ -21,8 +20,7 @@ type OutputConstraints = [RealInterval Expr Expr]
 
 -- | An instance model is a ModelKind that may have specific inputs, outputs, and output
 -- constraints. It also has attributes like references, derivation, labels ('ShortName'), reference address, and notes.
-data InstanceModel = IM { _mk       :: ModelKinds
-                        , _imTerm   :: NP
+data InstanceModel = IM { _mk       :: ModelKind
                         , _imInputs :: Inputs
                         , _imOutput :: (Output, OutputConstraints)
                         , _rf      :: [Reference]
@@ -36,7 +34,7 @@ makeLenses ''InstanceModel
 -- | Finds the 'UID' of an 'InstanceModel'.
 instance HasUID             InstanceModel where uid = mk . uid
 -- | Finds the term ('NP') of the 'InstanceModel'.
-instance NamedIdea          InstanceModel where term = imTerm
+instance NamedIdea          InstanceModel where term = mk . term
 -- | Finds the idea contained in the 'InstanceModel'.
 instance Idea               InstanceModel where getA = getA . (^. mk)
 -- | Finds the definition of the 'InstanceModel'.
@@ -78,50 +76,30 @@ instance HasSpace           InstanceModel where typ = output . typ
 instance MayHaveUnit        InstanceModel where getUnit = getUnit . view output
 
 -- | Smart constructor for instance models with everything defined.
-im :: ModelKinds -> Inputs -> Output -> 
+im :: ModelKind -> Inputs -> Output -> 
   OutputConstraints -> [Reference] -> Maybe Derivation -> String -> [Sentence] -> InstanceModel
-im mkind = im' mkind (mkind ^. term)
-
--- | Smart constructor for instance models with no derivation.
-imNoDeriv :: ModelKinds -> Inputs -> Output -> 
-  OutputConstraints -> [Reference] -> String -> [Sentence] -> InstanceModel
-imNoDeriv mkind = imNoDeriv' mkind (mkind ^. term)
-
--- | Smart constructor for instance models with no references.
-imNoRefs :: ModelKinds -> Inputs -> Output -> 
-  OutputConstraints -> Maybe Derivation -> String -> [Sentence] -> InstanceModel
-imNoRefs mkind = imNoRefs' mkind (mkind ^. term)
-
--- | Smart constructor for instance models with no derivations or references.
-imNoDerivNoRefs :: ModelKinds -> Inputs -> Output -> 
-  OutputConstraints -> String -> [Sentence] -> InstanceModel
-imNoDerivNoRefs mkind = imNoDerivNoRefs' mkind (mkind ^. term)
-
--- | Smart constructor for instance models with everything defined.
-im' :: ModelKinds -> NP -> Inputs -> Output -> 
-  OutputConstraints -> [Reference] -> Maybe Derivation -> String -> [Sentence] -> InstanceModel
-im' mkind _ _  _ _  [] _  _  = error $ "Source field of " ++ mkind ^. uid ++ " is empty"
-im' mkind n i o oc r der sn = 
-  IM mkind n i (o, oc) r der (shortname' $ S sn) (prependAbrv inModel sn)
+im mkind _  _ _  [] _  _  = error $ "Source field of " ++ mkind ^. uid ++ " is empty"
+im mkind i o oc r der sn = 
+  IM mkind i (o, oc) r der (shortname' $ S sn) (prependAbrv inModel sn)
 
 -- | Smart constructor for instance models with a custom term, and no derivation.
-imNoDeriv' :: ModelKinds -> NP -> Inputs -> Output -> 
+imNoDeriv :: ModelKind -> Inputs -> Output -> 
   OutputConstraints -> [Reference] -> String -> [Sentence] -> InstanceModel
-imNoDeriv' mkind _ _  _ _ [] _  = error $ "Source field of " ++ mkind ^. uid ++ " is empty"
-imNoDeriv' mkind n i o oc r sn =
-  IM mkind n i (o, oc) r Nothing (shortname' $ S sn) (prependAbrv inModel sn)
+imNoDeriv mkind _ _ _  [] _  = error $ "Source field of " ++ mkind ^. uid ++ " is empty"
+imNoDeriv mkind i o oc r  sn =
+  IM mkind i (o, oc) r Nothing (shortname' $ S sn) (prependAbrv inModel sn)
 
 -- | Smart constructor for instance models with a custom term, and no references.
-imNoRefs' :: ModelKinds -> NP -> Inputs -> Output -> 
+imNoRefs :: ModelKind -> Inputs -> Output -> 
   OutputConstraints -> Maybe Derivation -> String -> [Sentence] -> InstanceModel
-imNoRefs' mkind n i o oc der sn = 
-  IM mkind n i (o, oc) [] der (shortname' $ S sn) (prependAbrv inModel sn)
+imNoRefs mkind i o oc der sn = 
+  IM mkind i (o, oc) [] der (shortname' $ S sn) (prependAbrv inModel sn)
 
 -- | Smart constructor for instance models with a custom term, and no derivations or references.
-imNoDerivNoRefs' :: ModelKinds -> NP -> Inputs -> Output -> 
+imNoDerivNoRefs :: ModelKind -> Inputs -> Output -> 
   OutputConstraints -> String -> [Sentence] -> InstanceModel
-imNoDerivNoRefs' mkind n i o oc sn = 
-  IM mkind n i (o, oc) [] Nothing (shortname' $ S sn) (prependAbrv inModel sn)
+imNoDerivNoRefs mkind i o oc sn = 
+  IM mkind i (o, oc) [] Nothing (shortname' $ S sn) (prependAbrv inModel sn)
 
 -- | For building a quantity with no constraint.
 qwUC :: (Quantity q, MayHaveUnit q) => q -> Input 

--- a/code/drasil-theory/Theory/Drasil/InstanceModel.hs
+++ b/code/drasil-theory/Theory/Drasil/InstanceModel.hs
@@ -23,7 +23,7 @@ type OutputConstraints = [RealInterval Expr Expr]
 data InstanceModel = IM { _mk       :: ModelKind
                         , _imInputs :: Inputs
                         , _imOutput :: (Output, OutputConstraints)
-                        , _rf      :: [Reference]
+                        , _rf       :: [Reference]
                         , _deri     :: Maybe Derivation
                         ,  lb       :: ShortName
                         ,  ra       :: String

--- a/code/drasil-theory/Theory/Drasil/ModelKinds.hs
+++ b/code/drasil-theory/Theory/Drasil/ModelKinds.hs
@@ -3,6 +3,7 @@ module Theory.Drasil.ModelKinds (
     ModelKind(..), ModelKinds(..),
     deModel, equationalConstraints, equationalModel, equationalRealm, othModel,
     deModel', equationalConstraints', equationalModel', equationalRealm', othModel',
+    equationalModelU, equationalModelN, equationalRealmU, equationalRealmN,
     setMk, elimMk, lensMk, getEqModQds
   ) where
 
@@ -55,11 +56,23 @@ equationalModel u n qd = MK (EquationalModel qd) u n
 equationalModel' :: QDefinition -> ModelKind
 equationalModel' qd = MK (EquationalModel qd) (qd ^. uid) (qd ^. term)
 
+equationalModelU :: UID -> QDefinition -> ModelKind
+equationalModelU u qd = MK (EquationalModel qd) u (qd ^. term)
+
+equationalModelN :: NP -> QDefinition -> ModelKind
+equationalModelN n qd = MK (EquationalModel qd) (qd ^. uid) n
+
 equationalRealm :: UID -> NP -> MultiDefn -> ModelKind
 equationalRealm u n md = MK (EquationalRealm md) u n
 
 equationalRealm' :: MultiDefn -> ModelKind
 equationalRealm' md = MK (EquationalRealm md) (md ^. uid) (md ^. term)
+
+equationalRealmU :: UID -> MultiDefn -> ModelKind
+equationalRealmU u md = MK (EquationalRealm md) u (md ^. term)
+
+equationalRealmN :: NP -> MultiDefn -> ModelKind
+equationalRealmN n md = MK (EquationalRealm md) (md ^. uid) n
 
 othModel :: UID -> NP -> RelationConcept -> ModelKind
 othModel u n rc = MK (OthModel rc) u n

--- a/code/drasil-theory/Theory/Drasil/ModelKinds.hs
+++ b/code/drasil-theory/Theory/Drasil/ModelKinds.hs
@@ -30,6 +30,7 @@ data ModelKinds = DEModel RelationConcept
 
 makeLenses ''ModelKinds
 
+-- | 'ModelKinds' carrier, used to carry commonly overwritten information from the IMs/TMs/GDs.
 data ModelKind = MK {
   _mk     :: ModelKinds,
   _mkUid  :: UID,
@@ -38,50 +39,61 @@ data ModelKind = MK {
 
 makeLenses ''ModelKind
 
+-- | Smart constructor for 'DEModel's
 deModel :: UID -> NP -> RelationConcept -> ModelKind
 deModel u n rc = MK (DEModel rc) u n
 
+-- | Smart constructor for 'DEModel's, deriving UID+Term from the 'RelationConcept'
 deModel' :: RelationConcept -> ModelKind
 deModel' rc = MK (DEModel rc) (rc ^. uid) (rc ^. term)
 
+-- | Smart constructor for 'EquationalConstraints'
 equationalConstraints :: UID -> NP -> ConstraintSet-> ModelKind
 equationalConstraints u n qs = MK (EquationalConstraints qs) u n
 
+-- | Smart constructor for 'EquationalConstraints', deriving UID+Term from the 'ConstraintSet'
 equationalConstraints' :: ConstraintSet-> ModelKind
 equationalConstraints' qs = MK (EquationalConstraints qs) (qs ^. uid) (qs ^. term)
 
+-- | Smart constructor for 'EquationalModel's
 equationalModel :: UID -> NP -> QDefinition -> ModelKind
 equationalModel u n qd = MK (EquationalModel qd) u n
 
+-- | Smart constructor for 'EquationalModel's, deriving UID+Term from the 'QDefinition'
 equationalModel' :: QDefinition -> ModelKind
 equationalModel' qd = MK (EquationalModel qd) (qd ^. uid) (qd ^. term)
 
+-- | Smart constructor for 'EquationalModel's, deriving Term from the 'QDefinition'
 equationalModelU :: UID -> QDefinition -> ModelKind
 equationalModelU u qd = MK (EquationalModel qd) u (qd ^. term)
 
+-- | Smart constructor for 'EquationalModel's, deriving UID from the 'QDefinition'
 equationalModelN :: NP -> QDefinition -> ModelKind
 equationalModelN n qd = MK (EquationalModel qd) (qd ^. uid) n
 
+-- | Smart constructor for 'EquationalRealm's
 equationalRealm :: UID -> NP -> MultiDefn -> ModelKind
 equationalRealm u n md = MK (EquationalRealm md) u n
 
+-- | Smart constructor for 'EquationalRealm's
 equationalRealm' :: MultiDefn -> ModelKind
 equationalRealm' md = MK (EquationalRealm md) (md ^. uid) (md ^. term)
 
+-- | Smart constructor for 'EquationalRealm's
 equationalRealmU :: UID -> MultiDefn -> ModelKind
 equationalRealmU u md = MK (EquationalRealm md) u (md ^. term)
 
+-- | Smart constructor for 'EquationalRealm's, deriving UID from the 'MultiDefn'
 equationalRealmN :: NP -> MultiDefn -> ModelKind
 equationalRealmN n md = MK (EquationalRealm md) (md ^. uid) n
 
+-- | Smart constructor for 'OthModel's
 othModel :: UID -> NP -> RelationConcept -> ModelKind
 othModel u n rc = MK (OthModel rc) u n
 
+-- | Smart constructor for 'OthModel's, deriving UID+Term from the 'RelationConcept'
 othModel' :: RelationConcept -> ModelKind
 othModel' rc = MK (OthModel rc) (rc ^. uid) (rc ^. term)
-
-
--- FIXME: The repetition is starting to get bad.
 
 -- | Finds the 'UID' of the 'ModelKinds'.
 instance HasUID        ModelKinds where uid        = lensMk uid uid uid uid
@@ -93,17 +105,22 @@ instance Idea          ModelKinds where getA       = elimMk (to getA) (to getA) 
 instance Definition    ModelKinds where defn       = lensMk defn defn defn defn
 -- | Finds the domain of the 'ModelKinds'.
 instance ConceptDomain ModelKinds where cdom       = elimMk (to cdom) (to cdom) (to cdom) (to cdom)
--- | Displays 'ModelKind' in DisplayExpr
+-- | Rewrites the underlying model using DisplayExpr
 instance Display       ModelKinds where toDispExpr = elimMk (to toDispExpr) (to toDispExpr) (to toDispExpr) (to toDispExpr)
 
 -- TODO: implement MayHaveUnit for ModelKinds once we've sufficiently removed OthModels & RelationConcepts (else we'd be breaking too much of `stable`)
 
--- | Finds the 'UID' of the 'ModelKinds'.
+-- | Finds the 'UID' of the 'ModelKind'.
 instance HasUID        ModelKind where uid        = mkUid
+-- | Finds the term ('NP') of the 'ModelKind'.
 instance NamedIdea     ModelKind where term       = mkTerm
+-- | Finds the idea of the 'ModelKind'.
 instance Idea          ModelKind where getA       = getA . (^. mk)
+-- | Finds the definition of the 'ModelKind'.
 instance Definition    ModelKind where defn       = mk . defn
+-- | Finds the domain of the 'ModelKind'.
 instance ConceptDomain ModelKind where cdom       = cdom . (^. mk)
+-- | Rewrites the underlying model using DisplayExpr
 instance Display       ModelKind where toDispExpr = toDispExpr . (^. mk)
 
 

--- a/code/drasil-theory/Theory/Drasil/Theory.hs
+++ b/code/drasil-theory/Theory/Drasil/Theory.hs
@@ -1,12 +1,12 @@
 {-# Language TemplateHaskell #-}
-module Theory.Drasil.Theory (Theory(..), TheoryModel, tm, tmNoRefs, tm', tmNoRefs') where
+module Theory.Drasil.Theory (Theory(..), TheoryModel, tm, tmNoRefs) where
 
-import Theory.Drasil.ModelKinds (ModelKinds)
+import Control.Lens (Lens', view, makeLenses, (^.))
 
 import Language.Drasil
 import Data.Drasil.TheoryConcepts (thModel)
 
-import Control.Lens (Lens', view, makeLenses, (^.))
+import Theory.Drasil.ModelKinds
 
 -- | Theories are the basis for building models with context,
 -- spaces, quantities, operations, invariants, etc.
@@ -40,8 +40,7 @@ data SpaceDefn -- FIXME: This should be defined.
 -- Right now, neither the definition context (vctx) nor the
 -- spaces (spc) are ever defined.
 data TheoryModel = TM 
-  { _tUid  :: UID
-  , _con   :: ConceptChunk
+  { _mk    :: ModelKind
   , _vctx  :: [TheoryModel]
   , _spc   :: [SpaceDefn]
   , _quan  :: [QuantityDict]
@@ -49,7 +48,7 @@ data TheoryModel = TM
   , _defq  :: [QDefinition]
   , _invs  :: [DisplayExpr]
   , _dfun  :: [QDefinition]
-  , _rf   :: [Reference]
+  , _rf    :: [Reference]
   ,  lb    :: ShortName
   ,  ra    :: String
   , _notes :: [Sentence]
@@ -57,17 +56,17 @@ data TheoryModel = TM
 makeLenses ''TheoryModel
 
 -- | Finds the 'UID' of a 'TheoryModel'.
-instance HasUID             TheoryModel where uid = tUid
+instance HasUID             TheoryModel where uid = mk . uid
 -- | Finds the term ('NP') of the 'TheoryModel'.
-instance NamedIdea          TheoryModel where term = con . term
+instance NamedIdea          TheoryModel where term = mk . term
 -- | Finds the idea of the 'ConceptChunk' contained in the 'TheoryModel'.
-instance Idea               TheoryModel where getA = getA . view con
+instance Idea               TheoryModel where getA = getA . view mk
 -- | Finds the definition of the 'ConceptChunk' contained in a 'TheoryModel'.
-instance Definition         TheoryModel where defn = con . defn
+instance Definition         TheoryModel where defn = mk . defn
 -- | Finds 'Reference's contained in the 'TheoryModel'.
 instance HasReference       TheoryModel where getReferences = rf
 -- | Finds the domain of the 'ConceptChunk' contained in a 'TheoryModel'.
-instance ConceptDomain      TheoryModel where cdom = cdom . view con
+instance ConceptDomain      TheoryModel where cdom = cdom . view mk
 -- | Finds any additional notes for the 'TheoryModel'.
 instance HasAdditionalNotes TheoryModel where getNotes = notes
 
@@ -98,36 +97,24 @@ instance Referable TheoryModel where
 -- TODO: Theory Models should generally be using their own UID, instead of
 --       having their UIDs derived by the model kind.
 
+
 -- This "smart" constructor is really quite awful, it takes way too many arguments.
 -- This should likely be re-arranged somehow. Especially since since of the arguments
 -- have the same type!
--- | Constructor for theory models.
-tm :: (Quantity q, MayHaveUnit q, Concept c) => ModelKinds ->
-    [q] -> [c] -> [QDefinition] ->
-    [DisplayExpr] -> [QDefinition] -> [Reference] ->
-    String -> [Sentence] -> TheoryModel
-tm mk = tm' (mk ^. uid) mk
-
--- | Constructor for theory models with no references. 
-tmNoRefs :: (Quantity q, MayHaveUnit q, Concept c) => ModelKinds ->
-    [q] -> [c] -> [QDefinition] -> [DisplayExpr] -> [QDefinition] -> 
-    String -> [Sentence] -> TheoryModel
-tmNoRefs mk = tmNoRefs' (mk ^. uid) mk
-
 -- | Constructor for theory models. Must have a source. Uses the shortname of the reference address.
-tm' :: (Quantity q, MayHaveUnit q, Concept c) => UID -> ModelKinds ->
+tm :: (Quantity q, MayHaveUnit q, Concept c) => ModelKind ->
     [q] -> [c] -> [QDefinition] ->
     [DisplayExpr] -> [QDefinition] -> [Reference] ->
     String -> [Sentence] -> TheoryModel
-tm' u _  _ _ _  _   _   [] _   = error $ "Source field of " ++ u ++ " is empty"
-tm' u mk q c dq inv dfn r  lbe = 
-  TM u (cw mk) [] [] (map qw q) (map cw c) dq inv dfn r (shortname' $ S lbe)
+tm mkind _ _ _  _   _   [] _   = error $ "Source field of " ++ (mkind ^. uid) ++ " is empty"
+tm mkind q c dq inv dfn r  lbe = 
+  TM mkind [] [] (map qw q) (map cw c) dq inv dfn r (shortname' $ S lbe)
       (prependAbrv thModel lbe)
 
 -- | Constructor for theory models. Uses the shortname of the reference address.
-tmNoRefs' :: (Quantity q, MayHaveUnit q, Concept c) => UID -> ModelKinds ->
+tmNoRefs :: (Quantity q, MayHaveUnit q, Concept c) => ModelKind ->
     [q] -> [c] -> [QDefinition] -> [DisplayExpr] -> [QDefinition] -> 
     String -> [Sentence] -> TheoryModel
-tmNoRefs' u mk q c dq inv dfn lbe = 
-  TM u (cw mk) [] [] (map qw q) (map cw c) dq inv dfn [] (shortname' $ S lbe)
+tmNoRefs mkind q c dq inv dfn lbe = 
+  TM mkind [] [] (map qw q) (map cw c) dq inv dfn [] (shortname' $ S lbe)
       (prependAbrv thModel lbe)


### PR DESCRIPTION
Contributes to #2371

+ Create `ModelKind` as a 3-tuple, around `ModelKinds`
+ Create smart constructors for each model kind, remove exposure of `ModelKinds` completely
+ Clean up IM/GD/TM, pushing the overridable UID/NP to the new `ModelKind`
