### PR TITLE
Remove the extra period on the scope - Double Pendulum 

### DIFF
--- a/code/drasil-example/Drasil/DblPendulum/Body.hs
+++ b/code/drasil-example/Drasil/DblPendulum/Body.hs
@@ -107,7 +107,7 @@ justification = foldlSent [ atStartNP (a_ pendulum), S "consists" `S.of_` phrase
                             `the_ofThe` pendulum), (S "to exhibit its chaotic characteristics" !.),
                             atStartNP (the program), S "documented here is called", phrase pendulumTitle]
 scope :: Sentence
-scope = foldlSent [phraseNP (NP.the (analysis `ofA` twoD)), 
+scope = foldlSent_ [phraseNP (NP.the (analysis `ofA` twoD)), 
   sParen (getAcc twoD), phrase pendMotion, phrase problem,
                    S "with various initial conditions"]
 

--- a/code/stable/dblpendulum/SRS/DblPendulum_SRS.tex
+++ b/code/stable/dblpendulum/SRS/DblPendulum_SRS.tex
@@ -175,7 +175,7 @@ The following section provides an overview of the Software Requirements Specific
 
 \subsection{Scope of Requirements}
 \label{Sec:ReqsScope}
-The scope of the requirements includes the analysis of a two-dimensional (2D) pendulum motion problem with various initial conditions..
+The scope of the requirements includes the analysis of a two-dimensional (2D) pendulum motion problem with various initial conditions.
 
 \section{Specific System Description}
 \label{Sec:SpecSystDesc}

--- a/code/stable/dblpendulum/Website/DblPendulum_SRS.html
+++ b/code/stable/dblpendulum/Website/DblPendulum_SRS.html
@@ -306,7 +306,7 @@
           <div class="subsection">
             <h2>Scope of Requirements</h2>
             <p class="paragraph">
-              The scope of the requirements includes the analysis of a two-dimensional (2D) pendulum motion problem with various initial conditions..
+              The scope of the requirements includes the analysis of a two-dimensional (2D) pendulum motion problem with various initial conditions.
             </p>
           </div>
         </div>


### PR DESCRIPTION
In the scope, there are two periods at the end of the sentence. Removed one extra period.

close #2616