### PR TITLE
Deleting makeLst functions

### DIFF
--- a/code/drasil-docLang/Drasil/DocLang.hs
+++ b/code/drasil-docLang/Drasil/DocLang.hs
@@ -44,7 +44,7 @@ module Drasil.DocLang (
   -- Tracetable
   generateTraceMap,
   -- Labels
-  solutionLabel, characteristicsLabel,
+ -- solutionLabel, characteristicsLabel,
   -- References
   secRefs
 ) where 
@@ -79,5 +79,5 @@ import Drasil.Sections.TraceabilityMandGs (traceMatStandard, traceMatOtherReq)
 import Drasil.ExtractDocDesc (getDocDesc, egetDocDesc)
 import Drasil.TraceTable (generateTraceMap)
 -- Commented out modules aren't used - uncomment if this changes
-import Drasil.DocumentLanguage.Labels (solutionLabel, characteristicsLabel)
+-- import Drasil.DocumentLanguage.Labels (solutionLabel, characteristicsLabel)
 import Drasil.DocLang.References (secRefs)

--- a/code/drasil-docLang/Drasil/DocLang.hs
+++ b/code/drasil-docLang/Drasil/DocLang.hs
@@ -43,8 +43,6 @@ module Drasil.DocLang (
   getDocDesc, egetDocDesc,
   -- Tracetable
   generateTraceMap,
-  -- Labels
- -- solutionLabel, characteristicsLabel,
   -- References
   secRefs
 ) where 
@@ -79,5 +77,4 @@ import Drasil.Sections.TraceabilityMandGs (traceMatStandard, traceMatOtherReq)
 import Drasil.ExtractDocDesc (getDocDesc, egetDocDesc)
 import Drasil.TraceTable (generateTraceMap)
 -- Commented out modules aren't used - uncomment if this changes
--- import Drasil.DocumentLanguage.Labels (solutionLabel, characteristicsLabel)
 import Drasil.DocLang.References (secRefs)

--- a/code/drasil-docLang/Drasil/DocumentLanguage/Labels.hs
+++ b/code/drasil-docLang/Drasil/DocumentLanguage/Labels.hs
@@ -1,1 +1,0 @@
-{-# Language Rank2Types #-}

--- a/code/drasil-docLang/Drasil/DocumentLanguage/Labels.hs
+++ b/code/drasil-docLang/Drasil/DocumentLanguage/Labels.hs
@@ -1,15 +1,1 @@
 {-# Language Rank2Types #-}
-module Drasil.DocumentLanguage.Labels where
-
-import Language.Drasil (Reference, makeLstRef, phrase, plural)
-import Data.Drasil.Concepts.Documentation (goalStmt, solution, characteristic)
-
--- | Makes a reference label for a goal statement.
-goalStmtLabel :: Reference
-goalStmtLabel = makeLstRef "goalStmt" $ phrase goalStmt
--- | Makes a reference label for a soultion statement.
-solutionLabel :: Reference
-solutionLabel = makeLstRef "solution" $ phrase solution
--- | Makes a reference label for a characteristics statement.
-characteristicsLabel :: Reference
-characteristicsLabel = makeLstRef "characteristics" $ plural characteristic

--- a/code/drasil-docLang/drasil-docLang.cabal
+++ b/code/drasil-docLang/drasil-docLang.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: f5e045ef0f5a9973225b960bb74066b7c94a2a185f577c532b3b06a2376372df
+-- hash: 10710c807c861228b35d216852da7bd363585f190fe43b08055f7d666baf9bef
 
 name:           drasil-docLang
 version:        0.1.26.0
@@ -32,7 +32,6 @@ library
       Drasil.DocumentLanguage
       Drasil.DocumentLanguage.Core
       Drasil.DocumentLanguage.Definitions
-      Drasil.DocumentLanguage.Labels
       Drasil.DocumentLanguage.RefHelpers
       Drasil.DocumentLanguage.TraceabilityMatrix
       Drasil.ExtractDocDesc

--- a/code/drasil-example/Drasil/GamePhysics/Body.hs
+++ b/code/drasil-example/Drasil/GamePhysics/Body.hs
@@ -17,7 +17,7 @@ import Drasil.DocLang (DerivationDisplay(..), DocSection(..), Emphasis(..),
   SolChSpec(SCSProg), TConvention(..), TSIntro(..), Verbosity(Verbose),
   OffShelfSolnsSec(..), GSDSec(..), GSDSub(..), TraceabilitySec(TraceabilityProg),
   ReqrmntSec(..), ReqsSub(..), AuxConstntSec(..), ProblemDescription(PDProg),
-  PDSub(..), intro, mkDoc, tsymb, traceMatStandard, solutionLabel, purpDoc, getTraceConfigUID,
+  PDSub(..), intro, mkDoc, tsymb, traceMatStandard, purpDoc, getTraceConfigUID,
   secRefs, fillTraceSI)
 import qualified Drasil.DocLang.SRS as SRS
 import Data.Drasil.Concepts.Computation (algorithm)
@@ -420,13 +420,13 @@ offShelfSolsIntro = mkParagraph $ foldlSentCol
   S "there already exist free", phrase openSource, phrase game +:+.
   plural physLib, S "Similar", getAcc twoD, plural physLib, S "are"]
 
-offShelfSols2DList = LlC $ enumBullet solutionLabel [S "Box2D: http://box2d.org/",
+offShelfSols2DList = enumBulletU [S "Box2D: http://box2d.org/",
   S "Nape Physics Engine: http://napephys.com/"]
 
 offShelfSolsMid = mkParagraph $ foldl (+:+) EmptyS [S "Free", phrase openSource,
   getAcc threeD, phrase game, plural physLib, S "include:"]
 
-offShelfSols3DList = LlC $ enumBullet solutionLabel [
+offShelfSols3DList = enumBulletU [
   S "Bullet: http://bulletphysics.org/",
   S "Open Dynamics Engine: http://www.ode.org/",
   S "Newton Game Dynamics: http://newtondynamics.com/"]

--- a/code/drasil-example/Drasil/GlassBR/Body.hs
+++ b/code/drasil-example/Drasil/GlassBR/Body.hs
@@ -20,7 +20,7 @@ import Drasil.DocLang (AppndxSec(..), AuxConstntSec(..), DerivationDisplay(..),
   ReqrmntSec(..), ReqsSub(..), SCSSub(..), SRSDecl, SSDSec(..), SSDSub(..),
   SolChSpec(..), StkhldrSec(..), StkhldrSub(Client, Cstmr),
   TraceabilitySec(TraceabilityProg), TSIntro(SymbOrder, TSPurpose),
-  Verbosity(Verbose), auxSpecSent, characteristicsLabel, intro, mkDoc,
+  Verbosity(Verbose), auxSpecSent, intro, mkDoc,
   termDefnF', tsymb, traceMatStandard, purpDoc, getTraceConfigUID,
   secRefs, fillTraceSI)
 
@@ -302,7 +302,7 @@ sysCtxList = UlC $ ulcc $ Enumeration $ bulletNested sysCtxResp $
 {--User Characteristics--}
 
 userCharacteristicsIntro :: Contents
-userCharacteristicsIntro = LlC $ enumBullet characteristicsLabel $ map foldlSent
+userCharacteristicsIntro = enumBulletU $ map foldlSent
   [[S "The end user of GlassBR is expected to have completed at least the",
     S "equivalent of the second year of an undergraduate degree in civil engineering or structural engineering"],
   [S "The end user is expected to have an understanding of theory behind glass",

--- a/code/drasil-lang/Language/Drasil.hs
+++ b/code/drasil-lang/Language/Drasil.hs
@@ -131,7 +131,7 @@ module Language.Drasil (
   , HasContents(accessContents)
   , RawContent(..)
   , mkFig
-  , makeTabRef, makeFigRef, makeSecRef, makeLstRef, makeURI
+  , makeTabRef, makeFigRef, makeSecRef, makeURI
   -- Space
   , Space(..) , RealInterval(..), Inclusive(..), RTopology(..)
   , DomainDesc(AllDD, BoundedDD), getActorName, getInnerSpace
@@ -213,7 +213,7 @@ import Language.Drasil.Expr.Display
 import Language.Drasil.Document (section, fig, figWithWidth
   , Section(..), SecCons(..) , llcc, ulcc, Document(..)
   , mkParagraph, mkFig, mkRawLC, extractSection
-  , makeTabRef, makeFigRef, makeSecRef, makeLstRef, makeURI)
+  , makeTabRef, makeFigRef, makeSecRef, makeURI)
 import Language.Drasil.Document.Core (Contents(..), ListType(..), ItemType(..), DType(..)
   , RawContent(..), ListTuple, MaxWidthPercent
   , HasContents(accessContents)

--- a/code/drasil-lang/Language/Drasil/Document.hs
+++ b/code/drasil-lang/Language/Drasil/Document.hs
@@ -117,11 +117,6 @@ makeSecRef :: String -> Sentence -> Reference
 makeSecRef r s = Reference (r ++ "Label") (RP (prepend "Sec") ("Sec:" ++ repUnd r))
   (shortname' s) None
 
--- | Create a reference for a list. Takes in the name of the list and a shortname for the list.
-makeLstRef :: String -> Sentence -> Reference
-makeLstRef r s = Reference (r ++ "Label") (RP (prepend "Lst") ("Lst:" ++ repUnd r))
-  (shortname' s) None
-
 -- | Create a reference for a 'URI'.
 makeURI :: UID -> String -> ShortName -> Reference
 makeURI u r s = Reference u (URI r) s None

--- a/code/drasil-lang/Language/Drasil/Reference.hs
+++ b/code/drasil-lang/Language/Drasil/Reference.hs
@@ -1,6 +1,6 @@
 {-# Language TemplateHaskell #-}
 module Language.Drasil.Reference (Reference(Reference, rInfo), ref, refS,
-  namedRef, complexRef, namedComplexRef, refInfo) where
+  namedRef, complexRef, namedComplexRef, refInfo, RefInfo(..)) where
 
 import Language.Drasil.Classes.Core (HasUID(uid), HasRefAddress(getRefAdd),
   Referable(refAdd, renderRef))

--- a/code/drasil-lang/Language/Drasil/Reference.hs
+++ b/code/drasil-lang/Language/Drasil/Reference.hs
@@ -1,6 +1,6 @@
 {-# Language TemplateHaskell #-}
 module Language.Drasil.Reference (Reference(Reference, rInfo), ref, refS,
-  namedRef, complexRef, namedComplexRef, refInfo, RefInfo(..)) where
+  namedRef, complexRef, namedComplexRef, refInfo) where
 
 import Language.Drasil.Classes.Core (HasUID(uid), HasRefAddress(getRefAdd),
   Referable(refAdd, renderRef))


### PR DESCRIPTION
Contributes to #1216

This is going to break stable, but i'm pushing the changes so you can also see why.
I deleted the makeLstRef function but it's used in defining other functions which are used in the Examples. These functions were defined in a Label.hs file under doc-lang. I tried to delete the file just to see what things it would affect in turn.

I'm thinking now that i don't touch these functions? or do you think there might be something else to do here?
