### PR TITLE
Add basic nix shell script

### DIFF
--- a/.github/workflows/Build.yaml
+++ b/.github/workflows/Build.yaml
@@ -55,7 +55,7 @@ jobs:
       - name: "Build"
         run: make code stackArgs="--no-terminal" GHCFLAGS="-Werror"
       - name: "Stable"
-        run: make stackArgs="--no-terminal" NOISY=yes GHCFLAGS="-Werror"
+        run: make stackArgs="--no-terminal" GHCFLAGS="-Werror" NOISY=yes
       - name: "TeX"
         run: make tex SUMMARIZE_TEX=yes
       - name: "Code"

--- a/.github/workflows/Test.yaml
+++ b/.github/workflows/Test.yaml
@@ -60,7 +60,7 @@ jobs:
       - name: "Build"
         run: make code stackArgs="--no-terminal" GHCFLAGS="-Werror"
       - name: "Stable"
-        run: make stackArgs="--no-terminal" NOISY=yes GHCFLAGS="-Werror"
+        run: make stackArgs="--no-terminal" GHCFLAGS="-Werror" NOISY=yes
       - name: "TeX"
         run: make tex SUMMARIZE_TEX=yes
       - name: "Code"

--- a/code/shell.nix
+++ b/code/shell.nix
@@ -1,3 +1,6 @@
+# Drasil development requirements
+# Installs everything except `Latin Modern` and `Latin Modern Math` font families.
+
 { pkgs ? import (builtins.fetchGit {
     name = "pinned-pkgs";   # Pinned at around ~Stack v2.5.1                       
     url = "https://github.com/NixOS/nixpkgs/";                       
@@ -20,11 +23,10 @@ pkgs.mkShell {
     # Stack is our full Haskell toolchain manager
     stack
 
-    # Misc. tools that will help
-    ripgrep
+    # Makefile processor
     gnumake
     
-    # Printing-related required (TeX + Graphs/Analysis)
+    # Printing-related requirements (TeX + Graphs/Analysis)
     graphviz
     inkscape
     imagemagick
@@ -38,8 +40,9 @@ pkgs.mkShell {
     py-with-deps   #  Python + dependencies for examples
   ];
 
+  # NOTE: If fonts are ever allowed here, we will want them.
   # # Font requirements for TeX compilation
-  # fonts.fonts = with pkgs; [
+  # fonts = with pkgs; [
   #   lmodern # Latin Modern Font
   #   lmmath  # Latin Modern Math Font
   # ];

--- a/code/shell.nix
+++ b/code/shell.nix
@@ -1,0 +1,46 @@
+{ pkgs ? import (builtins.fetchGit {
+    name = "pinned-pkgs";   # Pinned at around ~Stack v2.5.1                       
+    url = "https://github.com/NixOS/nixpkgs/";                       
+    ref = "refs/heads/nixos-unstable";                     
+    rev = "046f8835dcb9082beb75bb471c28c832e1b067b6";                           
+  }) {}
+}:
+
+let
+  # Examples require some dependencies, these should eventually move into their respective artifact files
+  py-deps = python38-packages: with python38-packages; [
+    pandas
+    numpy
+    scipy
+  ]; 
+  py-with-deps = pkgs.python38.withPackages py-deps;
+in
+pkgs.mkShell {
+  buildInputs = with pkgs; [
+    # Stack is our full Haskell toolchain manager
+    stack
+
+    # Misc. tools that will help
+    ripgrep
+    gnumake
+    
+    # Printing-related required (TeX + Graphs/Analysis)
+    graphviz
+    inkscape
+    imagemagick
+    texlive.combined.scheme-medium
+    
+    # Compilers
+    gcc            #  C/C++
+    mono           #  C#
+    jdk8           #  Java
+    swift          #  Swift
+    py-with-deps   #  Python + dependencies for examples
+  ];
+
+  # # Font requirements for TeX compilation
+  # fonts.fonts = with pkgs; [
+  #   lmodern # Latin Modern Font
+  #   lmmath  # Latin Modern Math Font
+  # ];
+}


### PR DESCRIPTION
Closes #2702 

Unfortunately, installing fonts is considered a side-effect on systems, and, as such, is only allowed in the NixOS `configuration.nix` (or if users use `home-manager`, it's allowed through that too). So, this script will install the base requirements for a CLI user to develop Drasil and work with the generated artifacts.

(I also have a small change where I reorder a NOISY=yes parameter in both of the CI files.)