### PR TITLE
`make docs` should fail when the haddock docs fail to build

### DIFF
--- a/code/scripts/make_docs.sh
+++ b/code/scripts/make_docs.sh
@@ -23,6 +23,13 @@ mkdir -p "$FULL_DOCS_FOLDER"
 # Build full variant
 stack haddock --haddock-arguments "--show-all" --ghc-options="$GHC_FLAGS"
 
+if [ "$?" -eq "0" ]; then
+  echo "Successfully created fully exposed variant of Haddock docs!"
+else
+  echo "Fully exposed Haddock build failed!"
+  exit 1
+fi
+
 # Get doc folder
 DOCS_LOC="$(stack path --local-install-root)/doc"
 
@@ -34,7 +41,14 @@ cp -rf "$DOCS_LOC/." "$FULL_DOCS_FOLDER"
 stack clean
 
 # Build small variant
-stack haddock --ghc-options="$GHC_FLAGS" 
+stack haddock --ghc-options="$GHC_FLAGS"
+
+if [ "$?" -eq "0" ]; then
+  echo "Successfully created normal Haddock docs!"
+else
+  echo "Normal Haddock build failed!"
+  exit 1
+fi
 
 # Find new docs folder
 DOCS_LOC="$(stack path --local-install-root)/doc"


### PR DESCRIPTION
CI _should_ fail due to actual Haddock errors.

Contributes to #2762 