### PR TITLE
Switching QDefinition to use DefinedQuantityDict

### DIFF
--- a/code/drasil-lang/Language/Drasil/Chunk/Eq.hs
+++ b/code/drasil-lang/Language/Drasil/Chunk/Eq.hs
@@ -11,7 +11,6 @@ import Language.Drasil.Classes.Core (HasUID(uid), HasSymbol(symbol))
 import Language.Drasil.Classes (NamedIdea(term), Idea(getA),
   IsUnit, DefiningExpr(defnExpr), Definition(defn), Quantity, HasSpace(typ),
   ConceptDomain(cdom), Display(toDispExpr))
-import Language.Drasil.Chunk.Quantity (QuantityDict, mkQuant, mkQuant', qw)
 import Language.Drasil.Chunk.DefinedQuantity (DefinedQuantityDict, dqd, dqd')
 import Language.Drasil.Chunk.Concept (cc')
 import Language.Drasil.Chunk.NamedIdea (mkIdea, nw)


### PR DESCRIPTION
Contributes #2679, #2677 
Might interfere with #2735, #2705 

I know #2677 wants to move away from the `Maybe UnitDefn` in `DefinedQuantityDict` but I think this reliance on the `dqd` constructors is okay:
- While there are a lot of `QDefinition` function constructors, most of them set the unit definition to `Nothing` anyway
- The ones that do have a `UnitDefn` have very few calls in the examples.

However, both `mkQuantDef` and `mkQuantDef'` are used a lot. They are both projector functions and they still hold units. Would we then want `QDefinition` to use a `UnitalChunk` instead of a `DefinedQuantityDict`?