### PR TITLE
Making CI use NamedChunk instead of direct fields

### DIFF
--- a/code/drasil-lang/Language/Drasil/Chunk/CommonIdea.hs
+++ b/code/drasil-lang/Language/Drasil/Chunk/CommonIdea.hs
@@ -2,7 +2,7 @@
 module Language.Drasil.Chunk.CommonIdea
   (CI, commonIdea, getAcc, getAccStr, commonIdeaWithDict, prependAbrv) where
 
-import Language.Drasil.Chunk.NamedIdea (IdeaDict)
+import Language.Drasil.Chunk.NamedIdea (IdeaDict, NamedChunk, nc)
 import Language.Drasil.Classes.Core (HasUID(uid))
 import Language.Drasil.Classes (NamedIdea(term), Idea(getA),
  CommonIdea(abrv), ConceptDomain(cdom))
@@ -15,13 +15,13 @@ import Control.Lens (makeLenses, (^.), view)
 
 -- | The common idea (with 'NounPhrase') data type. It must have a 'UID',
 -- 'NounPhrase' for its term, an abbreviation ('String'), and a domain (['UID']).
-data CI = CI { _cid :: UID, _ni :: NP, _ab :: String, cdom' :: [UID]}
+data CI = CI { _nc' :: NamedChunk, _ab :: String, cdom' :: [UID]}
 makeLenses ''CI
 
--- | Finds 'UID' of 'CI'.
-instance HasUID        CI where uid  = cid
--- | Finds term ('NP') of 'CI'.
-instance NamedIdea     CI where term = ni
+-- | Finds 'UID' of the 'NamedChunk' used to make the 'CI'.
+instance HasUID        CI where uid  = nc' . uid
+-- | Finds term ('NP') of the 'NamedChunk' used to make the 'CI'.
+instance NamedIdea     CI where term = nc' . term
 -- | Finds the idea of a 'CI' (abbreviation).
 instance Idea          CI where getA = Just . view ab
 -- | Finds the idea of a 'CI' (abbreviation).
@@ -31,12 +31,12 @@ instance ConceptDomain CI where cdom = cdom'
   
 -- | The commonIdea smart constructor requires a chunk id ('UID'), a
 -- term ('NP'), an abbreviation ('String'), and a domain (['UID']).
-commonIdea :: String -> NP -> String -> [UID] -> CI
-commonIdea = CI
+commonIdea :: UID -> NP -> String -> [UID] -> CI
+commonIdea s np = CI (nc s np)
 
 -- | Similar to 'commonIdea', but takes a list of 'IdeaDict' (often a domain).
-commonIdeaWithDict :: String -> NP -> String -> [IdeaDict] -> CI
-commonIdeaWithDict x y z = CI x y z . map (^.uid)
+commonIdeaWithDict :: UID -> NP -> String -> [IdeaDict] -> CI
+commonIdeaWithDict x y z = CI (nc x y) z . map (^.uid)
 
 -- | Get abbreviation in 'Sentence' form from a 'CI'.
 getAcc :: CI -> Sentence


### PR DESCRIPTION
Contributes #2679, #2677
This change shouldn't interfere with anything.

For reference, I generated the type analysis for drasil lang and its starting to look much more like a hierarchy now (specifically the types starting from NamedChunk rather than UID). I will attach the picture below with the unrelated types whited out:
![Drasil Chunk Types Aug 5 2021](https://user-images.githubusercontent.com/69334555/128382349-9ce54e9c-1694-4c82-b95f-4308a88acb08.png)
