### PR TITLE
Add basic CITATION.cff file

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -3,7 +3,7 @@ title: "Drasil"
 abstract: "Generate All The Things! Drasil is a framework for generating all of the software artifacts for (well understood) research software, from the natural knowledge base of the domain."
 type: software
 message: "If you use this software, please cite it using these metadata."
-authors:
+contact:
   - family-names: Carette
     given-names: Jacques
     orcid: "https://orcid.org/0000-0001-8993-9804"
@@ -39,3 +39,16 @@ repository: "https://github.com/JacquesCarette/Drasil"
 repository-code: "https://github.com/JacquesCarette/Drasil/tree/v0.1-alpha"
 version: "v0.1-alpha"
 date-released: "2021-02-09"
+authors:
+  - family-names: Carette
+    given-names: Jacques
+    orcid: "https://orcid.org/0000-0001-8993-9804"
+    website: "https://www.cas.mcmaster.ca/~carette/"
+    affiliation: "McMaster University, Computing and Software Department"
+    email: "carette@mcmaster.ca"
+  - family-names: Smith
+    given-names: Spencer
+    orcid: "https://orcid.org/0000-0002-0760-0987"
+    website: "https://www.cas.mcmaster.ca/~smiths/"
+    affiliation: "McMaster University, Computing and Software Department"
+    email: "smiths@mcmaster.ca"

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,39 @@
+cff-version: 1.2.0
+title: "Drasil"
+abstract: "Generate All The Things! Drasil is a framework for generating all of the software artifacts for (well understood) research software, from the natural knowledge base of the domain."
+type: software
+message: "If you use this software, please cite it using these metadata."
+authors:
+  - family-names: Carette
+    given-names: Jacques
+    orcid: "https://orcid.org/0000-0001-8993-9804"
+    website: "https://www.cas.mcmaster.ca/~carette/"
+    affiliation: "McMaster University, Computing and Software Department"
+  - family-names: Smith
+    given-names: Spencer
+    orcid: "https://orcid.org/0000-0002-0760-0987"
+    website: "https://www.cas.mcmaster.ca/~smiths/"
+    affiliation: "McMaster University, Computing and Software Department"
+identifiers:
+  - description: "All archived snapshots of Drasil."
+    type: doi
+    value: 10.5281/zenodo.4526444
+  - description: "Snapshot v0.1-alpha."
+    type: doi
+    value: 10.5281/zenodo.4526445
+keywords:
+  - research
+  - haskell
+  - knowledge
+  - dsl
+  - scientific
+  - "code generation"
+  - "documentation generator"
+  - "software generator"
+  - "drasil framework"
+license: "BSD-2-Clause"
+url: "https://jacquescarette.github.io/Drasil/"
+repository: "https://github.com/JacquesCarette/Drasil"
+repository-code: "https://github.com/JacquesCarette/Drasil/tree/v0.1-alpha"
+version: "v0.1-alpha"
+date-released: "2021-02-09"

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -9,11 +9,13 @@ authors:
     orcid: "https://orcid.org/0000-0001-8993-9804"
     website: "https://www.cas.mcmaster.ca/~carette/"
     affiliation: "McMaster University, Computing and Software Department"
+    email: "carette@mcmaster.ca"
   - family-names: Smith
     given-names: Spencer
     orcid: "https://orcid.org/0000-0002-0760-0987"
     website: "https://www.cas.mcmaster.ca/~smiths/"
     affiliation: "McMaster University, Computing and Software Department"
+    email: "smiths@mcmaster.ca"
 identifiers:
   - description: "All archived snapshots of Drasil."
     type: doi


### PR DESCRIPTION
Closes #2794 

Regarding the authors list, @JacquesCarette & @smiths, on the Zenodo page, the following are listed as authors:
* Dan Szymczak
* bmaclach
* Jacques Carette
* Maryyam
* Sam Crawford
* Daniel Scime
* AKM11
* palmerst
* Spencer Smith
* oluowoj
* elwazana
* Mornix
* muhammadaliog3
* Devi Prasad Reddy Guttapati
* Nathaniel Hu
* Jingwei
* Luthfi Mawarid
* Joseph Seger
* Aida
* Naveen Ganesh Muralidharan
* Azer-X
* Daniel Genkin
* Rohan Jain

By any chance, do we have any named organization we all belong to (e.g., ~ "Drasil Research Group") that we would prefer to put as the preferred citation author?

Also, should we ask individually what everyone wants to put for their personal information? There's [a lot of information](https://github.com/citation-file-format/citation-file-format/blob/main/schema-guide.md#definitionsperson) we can write for each person.

Regarding emails, despite them being publicly available, I feel the need to ask if you want your emails listed in the file (I see many professors often hide their emails using images [I guess to avoid web scrapers?]).