### PR TITLE
Fix CITATION.cff file formatting

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -71,6 +71,7 @@ authors:
     email: "sam.crawford82@gmail.com"
     website: "https://github.com/samm82"
   - family-names: Chen
-     given-names: Dong
-     email: chend79@mcmaster.ca
-     website: "https://github.com/cd155"
+    given-names: Dong
+    email: chend79@mcmaster.ca
+    website: "https://github.com/cd155"
+


### PR DESCRIPTION
Closes #2817

It looks like a few spaces just needed aligning for the GitHub CFF reader to understand the file.