### PR TITLE
Only build dot & circo graphs for deployments, when required

### DIFF
--- a/.github/workflows/Build.yaml
+++ b/.github/workflows/Build.yaml
@@ -79,6 +79,9 @@ jobs:
         run: make graphs
       - name: "Analyze Drasil code"
         run: make analysis
+      - name: "Convert analysis graphs into dot and circo SVGs" # only needed in deployments, not required for tests
+        run: make convertAnalyzed
+        if: ${{ fromJSON(env.is_deployment) }}
       - name: "Build website generator"
         run: make website
       - name: "Build website"

--- a/code/Makefile
+++ b/code/Makefile
@@ -140,7 +140,7 @@ WEBSITE_FOLDER = $(WEBSITE_FOLDER_NAME)/HTML/
 #--- `make` command line options ---#
 #####################################
 
-# Indicating whether an operation will be used for deployment (1), or for generaal testing purposes (0).
+# Indicating whether an operation will be used for deployment (1), or for general testing purposes (0).
 FULL ?= 0
 
 # GHC debug options
@@ -323,7 +323,7 @@ convertAnalyzed: ##@Analysis Convert analyzed dot graphs into dot and circo SVGs
 		dot -Tsvg $$pack.dot > "./$$pack.svg" ; \
 		circo -Tsvg $$pack.dot > "./circo_$$pack.svg" ; \
 	done
-	@echo "Built dependency graphs."
+	@echo "Dependency graphs built."
 
 #---------------------------------------#
 #--- HLint and Haddock Documentation ---#

--- a/code/Makefile
+++ b/code/Makefile
@@ -140,6 +140,9 @@ WEBSITE_FOLDER = $(WEBSITE_FOLDER_NAME)/HTML/
 #--- `make` command line options ---#
 #####################################
 
+# Indicating whether an operation will be used for deployment (1), or for generaal testing purposes (0).
+FULL ?= 0
+
 # GHC debug options
 PROFALL = --executable-profiling --library-profiling
 PROFEXEC = +RTS -xc -P
@@ -306,7 +309,10 @@ analysis: graphmod ##@Analysis Generate a table and some graphs to analyze Drasi
 	@mkdir -p "$(ANALYSIS_FOLDER)"
 	cd $(SCRIPT_FOLDER) && stack exec -- runghc ClassInstDepGen.hs
 	cd $(SCRIPT_FOLDER) && stack exec -- runghc TypeDepGen.hs
-	@echo Making dependency graphs. This may take a few minutes.
+	@echo "Analysis complete. Please see 'analysis/' folder."
+
+convertAnalyzed: ##@Analysis Convert analyzed dot graphs into dot and circo SVGs.
+	@echo "Building dependency graphs in Dot and Circo formats. This may take a few minutes."
 	@cd $(TYPEGRAPH_FOLDER) && for pack in $(ANALYSIS_PACKAGES); do \
 		echo "Converting type dot graph for '$$pack' into an svg, and creating a circo svg graph based on it" ; \
 		dot -Tsvg $$pack.dot > "./$$pack.svg" ; \
@@ -317,7 +323,7 @@ analysis: graphmod ##@Analysis Generate a table and some graphs to analyze Drasi
 		dot -Tsvg $$pack.dot > "./$$pack.svg" ; \
 		circo -Tsvg $$pack.dot > "./circo_$$pack.svg" ; \
 	done
-	@echo Done dependency graphs.
+	@echo "Built dependency graphs."
 
 #---------------------------------------#
 #--- HLint and Haddock Documentation ---#
@@ -330,7 +336,6 @@ hlint: check_stack ##@HLint Run HLint through the drasil packages. Uses a local 
 hot_hlint: ##@HLint Run HLint through the drasil packages. Uses the latest HLint version, downloading the binary each time.
 	curl --max-time 60 -sSL https://raw.github.com/ndmitchell/hlint/master/misc/run.sh | sh -s .
 
-FULL ?= 0
 docs: check_stack ##@Documentation Create Haddock documentation of all Drasil modules. Set FULL=1 if you want to additionally test Haddock generation for website deployment.
 	FULL="$(FULL)" DOCS_FOLDER="$(DOCS_FOLDER)" GHC_FLAGS="$(GHCFLAGS)" sh scripts/make_docs.sh
 


### PR DESCRIPTION
Contributes to #2789 

Removes dot and circo SVG conversions from tests, leaving them only performed for full deployments.