### PR TITLE
Add `make pr_ready` target to quickly check if a branch is ready for PR creation

### DIFF
--- a/code/Makefile
+++ b/code/Makefile
@@ -174,6 +174,10 @@ debug: stackArgs += $(PROFALL)
 debug: EXECARGS += $(PROFEXEC)
 debug: test ##@Examples Run test target with better debugging tools.
 
+pr_ready: all hot_hlint ##@General Check if your current work is ready to for a PR via `all` and `hot_hlint`.
+	- echo "Your build/ and stable/ match, and your code currently passes HLint tests."
+	- echo "Feel free to create a PR for your code if you feel it's ready."
+
 #--- Initial checks ---#
 #----------------------#
 


### PR DESCRIPTION
Contributes to #2152 

I added a small message regarding it on https://github.com/JacquesCarette/Drasil/wiki/Makefile and https://github.com/JacquesCarette/Drasil/wiki/Workflow . Unfortunately, I can't hyperlink to them directly, so please use CTRL+F and search for `pr_ready`.