### PR TITLE
Disallow Continuous Domain Descs from Expr, move into ModelExpr for now

### DIFF
--- a/code/drasil-code-base/lib/Language/Drasil/Code/Expr.hs
+++ b/code/drasil-code-base/lib/Language/Drasil/Code/Expr.hs
@@ -2,7 +2,7 @@
 
 module Language.Drasil.Code.Expr where
 
-import Language.Drasil (UID, DomainDesc, Completeness, RealInterval)
+import Language.Drasil (UID, DiscreteDomainDesc, Completeness, RealInterval)
 
 -- * Operators (mostly binary)
 
@@ -132,7 +132,7 @@ data CodeExpr where
   -- | Operators are generalized arithmetic operators over a 'DomainDesc'
   --   of an 'Expr'.  Could be called BigOp.
   --   ex: Summation is represented via 'Add' over a discrete domain.
-  Operator :: AssocArithOper -> DomainDesc CodeExpr CodeExpr -> CodeExpr -> CodeExpr
+  Operator :: AssocArithOper -> DiscreteDomainDesc CodeExpr CodeExpr -> CodeExpr -> CodeExpr
   -- | The expression is an element of a space.
   -- IsIn     :: Expr -> Space -> Expr
   -- | A different kind of 'IsIn'. A 'UID' is an element of an interval.

--- a/code/drasil-code-base/lib/Language/Drasil/Code/Expr/Convert.hs
+++ b/code/drasil-code-base/lib/Language/Drasil/Code/Expr/Convert.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE GADTs #-}
 module Language.Drasil.Code.Expr.Convert (
     expr, realInterval, constraint
 ) where
@@ -47,9 +48,8 @@ constraint :: L.ConstraintE -> L.Constraint CodeExpr
 constraint (L.Range r ri) = L.Range r (realInterval ri)
 
 -- | Convert 'DomainDesc Expr Expr' into 'DomainDesc CodeExpr CodeExpr's.
-renderDomainDesc :: L.DomainDesc L.Expr L.Expr -> L.DomainDesc CodeExpr CodeExpr
+renderDomainDesc :: L.DiscreteDomainDesc L.Expr L.Expr -> L.DiscreteDomainDesc CodeExpr CodeExpr
 renderDomainDesc (L.BoundedDD s t l r) = L.BoundedDD s t (expr l) (expr r)
-renderDomainDesc (L.AllDD s t) = L.AllDD s t
 
 arithBinOp :: LD.ArithBinOp -> ArithBinOp
 arithBinOp LD.Frac = Frac

--- a/code/drasil-example/gamephysics/lib/Drasil/GamePhysics/DataDefs.hs
+++ b/code/drasil-example/gamephysics/lib/Drasil/GamePhysics/DataDefs.hs
@@ -36,13 +36,13 @@ dataDefs = [ctrOfMassDD, linDispDD, linVelDD, linAccDD, angDispDD,
 -- DD1 : Centre of mass --
 
 ctrOfMassDD :: DataDefinition
-ctrOfMassDD = ddENoRefs ctrOfMass Nothing "ctrOfMass" [rigidBodyAssump]
+ctrOfMassDD = ddMENoRefs ctrOfMass Nothing "ctrOfMass" [rigidBodyAssump]
 
-ctrOfMass :: SimpleQDef
+ctrOfMass :: ModelQDef
 ctrOfMass = mkQuantDef posCM ctrOfMassEqn
 
 -- FIXME (variable "i") is a horrible hack
-ctrOfMassEqn :: Expr
+ctrOfMassEqn :: ModelExpr
 ctrOfMassEqn = sumAll (variable "j") (sy massj `mulRe` sy posj) $/ sy mTot
 
 -- DD2 : Linear displacement --
@@ -296,13 +296,13 @@ kEnergyDesc = foldlSent [atStart QP.kEnergy `S.is` (QP.kEnergy ^. defn)]
 -----------------------DD16 Moment Of Inertia--------------------------------------------------------
 
 momentOfInertiaDD :: DataDefinition
-momentOfInertiaDD = ddENoRefs momentOfInertia Nothing "momentOfInertia"
+momentOfInertiaDD = ddMENoRefs momentOfInertia Nothing "momentOfInertia"
  [momentOfInertiaDesc, rigidBodyAssump] 
 
-momentOfInertia :: SimpleQDef
+momentOfInertia :: ModelQDef
 momentOfInertia = mkQuantDef QP.momentOfInertia momentOfInertiaEqn
 
-momentOfInertiaEqn :: Expr
+momentOfInertiaEqn :: ModelExpr
 momentOfInertiaEqn = sumAll (variable "j") $ sy massj `mulRe` square (sy rRot)
 
 momentOfInertiaDesc :: Sentence

--- a/code/drasil-lang/lib/Language/Drasil.hs
+++ b/code/drasil-lang/lib/Language/Drasil.hs
@@ -214,8 +214,10 @@ module Language.Drasil (
   -- | Used for rendering mathematical symbols in Drasil.
 
   -- Language.Drasil.Space
-  , Space(..) , RealInterval(..), Inclusive(..), RTopology(..)
-  , DomainDesc(AllDD, BoundedDD), getActorName, getInnerSpace
+  , Space(..)
+  , RealInterval(..), Inclusive(..)
+  , DomainDesc(..), RTopology(..), ContinuousDomainDesc, DiscreteDomainDesc
+  , getActorName, getInnerSpace
   -- Language.Drasil.Symbol
   , Decoration, Symbol
   -- Language.Drasil.UnitLang
@@ -310,7 +312,8 @@ import Language.Drasil.Data.Citation(CiteField(..), HP(..), CitationKind(..) -- 
 import Language.Drasil.NounPhrase
 import Language.Drasil.ShortName (ShortName, shortname', getSentSN)
 import Language.Drasil.Space (Space(..), RealInterval(..), Inclusive(..), 
-  RTopology(..), DomainDesc(AllDD, BoundedDD), getActorName, getInnerSpace)
+  RTopology(..), DomainDesc(..), ContinuousDomainDesc, DiscreteDomainDesc,
+  getActorName, getInnerSpace)
 import Language.Drasil.Sentence (Sentence(..), SentenceStyle(..), TermCapitalization(..), RefInfo(..), (+:+),
   (+:+.), (+:), (!.), capSent, ch, eS, eS', sC, sDash, sParen)
 import Language.Drasil.Sentence.Extract (sdep, shortdep) -- exported for drasil-database FIXME: move to development package?

--- a/code/drasil-lang/lib/Language/Drasil/Expr/Class.hs
+++ b/code/drasil-lang/lib/Language/Drasil/Expr/Class.hs
@@ -165,8 +165,6 @@ class ExprC r where
   
   -- | Smart constructor for the summation, product, and integral functions over an interval.
   defint, defsum, defprod :: Symbol -> r -> r -> r -> r
-  -- | Smart constructor for the summation, product, and integral functions over all Real numbers.
-  intAll, sumAll, prodAll :: Symbol -> r -> r
   
   -- | Smart constructor for 'real interval' membership.
   realInterval :: HasUID c => c -> RealInterval r r -> r
@@ -367,19 +365,12 @@ instance ExprC Expr where
   
   -- | Integrate over some expression with bounds (∫).
   defint v low high = Operator AddRe (BoundedDD v Continuous low high)
-  -- | Integrate over some expression (∫).
-  intAll v = Operator AddRe (AllDD v Continuous)
   
   -- | Sum over some expression with bounds (∑).
   defsum v low high = Operator AddRe (BoundedDD v Discrete low high)
-  -- | Sum over some expression (∑).
-  sumAll v = Operator AddRe (AllDD v Discrete)
   
   -- | Product over some expression with bounds (∏).
   defprod v low high = Operator MulRe (BoundedDD v Discrete low high)
-  -- | Product over some expression (∏).
-  prodAll v = Operator MulRe (AllDD v Discrete)
-  -- TODO: Above only does for Reals
   
   -- | Smart constructor for 'real interval' membership.
   realInterval c = RealI (c ^. uid)
@@ -577,19 +568,12 @@ instance ExprC M.ModelExpr where
 
   -- | Integrate over some expression with bounds (∫).
   defint v low high = M.Operator M.AddRe (BoundedDD v Continuous low high)
-  -- | Integrate over some expression (∫).
-  intAll v = M.Operator M.AddRe (AllDD v Continuous)
 
   -- | Sum over some expression with bounds (∑).
   defsum v low high = M.Operator M.AddRe (BoundedDD v Discrete low high)
-  -- | Sum over some expression (∑).
-  sumAll v = M.Operator M.AddRe (AllDD v Discrete)
 
   -- | Product over some expression with bounds (∏).
   defprod v low high = M.Operator M.MulRe (BoundedDD v Discrete low high)
-  -- | Product over some expression (∏).
-  prodAll v = M.Operator M.MulRe (AllDD v Discrete)
-  -- TODO: Above only does for Reals
 
   -- | Smart constructor for 'real interval' membership.
   realInterval c = M.RealI (c ^. uid)

--- a/code/drasil-lang/lib/Language/Drasil/Expr/Lang.hs
+++ b/code/drasil-lang/lib/Language/Drasil/Expr/Lang.hs
@@ -3,7 +3,7 @@
 -- | The Drasil Expression language 
 module Language.Drasil.Expr.Lang where
 
-import Language.Drasil.Space (DomainDesc, RealInterval)
+import Language.Drasil.Space (DiscreteDomainDesc, RealInterval)
 import Language.Drasil.UID (UID)
 
 -- * Expression Types
@@ -134,7 +134,7 @@ data Expr where
   -- | Operators are generalized arithmetic operators over a 'DomainDesc'
   --   of an 'Expr'.  Could be called BigOp.
   --   ex: Summation is represented via 'Add' over a discrete domain.
-  Operator :: AssocArithOper -> DomainDesc Expr Expr -> Expr -> Expr
+  Operator :: AssocArithOper -> DiscreteDomainDesc Expr Expr -> Expr -> Expr
   -- | A different kind of 'IsIn'. A 'UID' is an element of an interval.
   RealI    :: UID -> RealInterval Expr Expr -> Expr
 

--- a/code/drasil-lang/lib/Language/Drasil/ModelExpr/Class.hs
+++ b/code/drasil-lang/lib/Language/Drasil/ModelExpr/Class.hs
@@ -5,10 +5,11 @@ import Prelude hiding (sqrt, log, sin, cos, tan, exp)
 
 import Control.Lens ((^.))
 
-import Language.Drasil.ModelExpr.Lang (ModelExpr(..), DerivType(..),
-  SpaceBinOp(..), StatBinOp(..), AssocBoolOper(..))
-import Language.Drasil.Space (Space)
 import Language.Drasil.Classes.Core (HasSymbol, HasUID(..))
+import Language.Drasil.ModelExpr.Lang (ModelExpr(..), DerivType(..),
+  SpaceBinOp(..), StatBinOp(..), AssocBoolOper(..), AssocArithOper(..))
+import Language.Drasil.Space (DomainDesc(..), RTopology(..), Space)
+import Language.Drasil.Symbol (Symbol)
 
   
 -- | Helper for creating new smart constructors for Associative Binary
@@ -42,6 +43,9 @@ class ModelExprC r where
   
   -- | Binary associative "Equivalence".
   equiv :: [r] -> r
+  
+  -- | Smart constructor for the summation, product, and integral functions over all Real numbers.
+  intAll, sumAll, prodAll :: Symbol -> r -> r
 
 instance ModelExprC ModelExpr where
   deriv e c  = Deriv Total e (c ^. uid)
@@ -57,3 +61,10 @@ instance ModelExprC ModelExpr where
     | length des >= 2 = assocCreate Equivalence des
     | otherwise       = error $ "Need at least 2 expressions to create " ++ show Equivalence
  
+  -- TODO: All of the below only allow for Reals! Will be easier to fix while we add typing.
+  -- | Integrate over some expression (∫).
+  intAll v = Operator AddRe (AllDD v Continuous)
+  -- | Sum over some expression (∑).
+  sumAll v = Operator AddRe (AllDD v Discrete)
+  -- | Product over some expression (∏).
+  prodAll v = Operator MulRe (AllDD v Discrete)

--- a/code/drasil-lang/lib/Language/Drasil/ModelExpr/Convert.hs
+++ b/code/drasil-lang/lib/Language/Drasil/ModelExpr/Convert.hs
@@ -1,9 +1,10 @@
+{-# LANGUAGE GADTs #-}
 -- | Defines functions to convert from the base expression language to 'ModelExpr's.
 module Language.Drasil.ModelExpr.Convert where
 
 import Data.Bifunctor (bimap, second)
 
-import Language.Drasil.Space (DomainDesc(..), RealInterval(..))
+import Language.Drasil.Space
 import qualified Language.Drasil.Expr.Lang as E
 import Language.Drasil.ModelExpr.Lang
 
@@ -103,6 +104,6 @@ realInterval (Bounded (li, l) (ri, r)) = Bounded (li, expr l) (ri, expr r)
 realInterval (UpTo (i, e)) = UpTo (i, expr e)
 realInterval (UpFrom (i, e)) = UpFrom (i, expr e)
 
-domainDesc :: DomainDesc E.Expr E.Expr -> DomainDesc ModelExpr ModelExpr
+domainDesc :: DiscreteDomainDesc E.Expr E.Expr -> DiscreteDomainDesc ModelExpr ModelExpr
 domainDesc (BoundedDD s rt l r) = BoundedDD s rt (expr l) (expr r)
-domainDesc (AllDD s rt) = AllDD s rt
+-- domainDesc (AllDD s rt) = AllDD s rt

--- a/code/drasil-lang/lib/Language/Drasil/ModelExpr/Lang.hs
+++ b/code/drasil-lang/lib/Language/Drasil/ModelExpr/Lang.hs
@@ -146,7 +146,7 @@ data ModelExpr where
   -- | Operators are generalized arithmetic operators over a 'DomainDesc'
   --   of an 'Expr'.  Could be called BigOp.
   --   ex: Summation is represented via 'Add' over a discrete domain.
-  Operator :: AssocArithOper -> DomainDesc ModelExpr ModelExpr -> ModelExpr -> ModelExpr
+  Operator :: AssocArithOper -> DomainDesc t ModelExpr ModelExpr -> ModelExpr -> ModelExpr
   -- | A different kind of 'IsIn'. A 'UID' is an element of an interval.
   RealI    :: UID -> RealInterval ModelExpr ModelExpr -> ModelExpr
   

--- a/code/drasil-lang/lib/Language/Drasil/Space.hs
+++ b/code/drasil-lang/lib/Language/Drasil/Space.hs
@@ -1,8 +1,12 @@
-{-# LANGUAGE GADTs #-}
+{-# LANGUAGE GADTs, DataKinds #-}
+{-# LANGUAGE KindSignatures #-}
+
 -- | Number space types and functions.
 module Language.Drasil.Space (
   -- * Types
-  Space(..), DomainDesc(..), RealInterval(..), RTopology(..), Inclusive(..),
+  Space(..), 
+  RealInterval(..), Inclusive(..),
+  DomainDesc(..), RTopology(..), DiscreteDomainDesc, ContinuousDomainDesc,
   -- * Functions
   getActorName, getInnerSpace, mkFunction) where
 
@@ -46,9 +50,12 @@ mkFunction ins = Function (NE.fromList ins)
 data RTopology = Continuous | Discrete
 
 -- | Describes the domain of a 'Symbol' given a topology. Can be bounded or encase all of the domain.
-data DomainDesc a b where
-  BoundedDD :: Symbol -> RTopology -> a -> b -> DomainDesc a b
-  AllDD     :: Symbol -> RTopology -> DomainDesc a b
+data DomainDesc (tplgy :: RTopology) a b where
+  BoundedDD :: Symbol -> RTopology -> a -> b -> DomainDesc 'Discrete a b
+  AllDD     :: Symbol -> RTopology -> DomainDesc 'Continuous a b
+
+type DiscreteDomainDesc a b = DomainDesc 'Discrete a b
+type ContinuousDomainDesc a b = DomainDesc 'Continuous a b
 
 -- | Inclusive or exclusive bounds.
 data Inclusive = Inc | Exc

--- a/code/drasil-printers/lib/Language/Drasil/Printing/Import/CodeExpr.hs
+++ b/code/drasil-printers/lib/Language/Drasil/Printing/Import/CodeExpr.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE GADTs #-}
+
 -- | Defines functions to render 'CodeExpr's as printable 'P.Expr's.
 module Language.Drasil.Printing.Import.CodeExpr (codeExpr) where
 
@@ -75,7 +77,7 @@ call sm f ps ns = P.Row [symbol $ lookupC (sm ^. stg) (sm ^. ckdb) f,
   P.MO P.Eq, codeExpr a sm]) (map fst ns) (map snd ns)]
 
 -- | Helper function for addition 'EOperator's.
-eopAdds :: PrintingInformation -> DomainDesc CodeExpr CodeExpr -> CodeExpr -> P.Expr
+eopAdds :: PrintingInformation -> DomainDesc t CodeExpr CodeExpr -> CodeExpr -> P.Expr
 eopAdds sm (BoundedDD v Continuous l h) e =
   P.Row [P.MO P.Inte, P.Sub (codeExpr l sm), P.Sup (codeExpr h sm),
          P.Row [codeExpr e sm], P.Spc P.Thin, P.Ident "d", symbol v]
@@ -88,7 +90,7 @@ eopAdds sm (BoundedDD v Discrete l h) e =
 eopAdds sm (AllDD _ Discrete) e = P.Row [P.MO P.Summ, P.Row [codeExpr e sm]]
 
 -- | Helper function for multiplicative 'EOperator's.
-eopMuls :: PrintingInformation -> DomainDesc CodeExpr CodeExpr -> CodeExpr -> P.Expr
+eopMuls :: PrintingInformation -> DomainDesc t CodeExpr CodeExpr -> CodeExpr -> P.Expr
 eopMuls sm (BoundedDD v Discrete l h) e =
   P.Row [P.MO P.Prod, P.Sub (P.Row [symbol v, P.MO P.Eq, codeExpr l sm]), P.Sup (codeExpr h sm),
          P.Row [codeExpr e sm]]
@@ -98,7 +100,7 @@ eopMuls _ (BoundedDD _ Continuous _ _) _ = error "Printing/Import.hs Product-Int
 
 
 -- | Helper function for translating 'EOperator's.
-eop :: PrintingInformation -> AssocArithOper -> DomainDesc CodeExpr CodeExpr -> CodeExpr -> P.Expr
+eop :: PrintingInformation -> AssocArithOper -> DomainDesc t CodeExpr CodeExpr -> CodeExpr -> P.Expr
 eop sm AddI = eopAdds sm
 eop sm AddRe = eopAdds sm
 eop sm MulI = eopMuls sm

--- a/code/drasil-printers/lib/Language/Drasil/Printing/Import/Expr.hs
+++ b/code/drasil-printers/lib/Language/Drasil/Printing/Import/Expr.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE GADTs #-}
+
 -- | Defines functions for printing expressions.
 module Language.Drasil.Printing.Import.Expr (expr) where
 
@@ -76,7 +78,7 @@ call sm f ps ns = P.Row [symbol $ lookupC (sm ^. stg) (sm ^. ckdb) f,
   P.MO P.Eq, expr a sm]) (map fst ns) (map snd ns)]
 
 -- | Helper function for addition 'EOperator's.
-eopAdds :: PrintingInformation -> DomainDesc Expr Expr -> Expr -> P.Expr
+eopAdds :: PrintingInformation -> DomainDesc t Expr Expr -> Expr -> P.Expr
 eopAdds sm (BoundedDD v Continuous l h) e =
   P.Row [P.MO P.Inte, P.Sub (expr l sm), P.Sup (expr h sm),
          P.Row [expr e sm], P.Spc P.Thin, P.Ident "d", symbol v]
@@ -89,7 +91,7 @@ eopAdds sm (BoundedDD v Discrete l h) e =
 eopAdds sm (AllDD _ Discrete) e = P.Row [P.MO P.Summ, P.Row [expr e sm]]
 
 -- | Helper function for multiplicative 'EOperator's.
-eopMuls :: PrintingInformation -> DomainDesc Expr Expr -> Expr -> P.Expr
+eopMuls :: PrintingInformation -> DomainDesc t Expr Expr -> Expr -> P.Expr
 eopMuls sm (BoundedDD v Discrete l h) e =
   P.Row [P.MO P.Prod, P.Sub (P.Row [symbol v, P.MO P.Eq, expr l sm]), P.Sup (expr h sm),
          P.Row [expr e sm]]
@@ -99,7 +101,7 @@ eopMuls _ (BoundedDD _ Continuous _ _) _ = error "Printing/Import.hs Product-Int
 
 
 -- | Helper function for translating 'EOperator's.
-eop :: PrintingInformation -> AssocArithOper -> DomainDesc Expr Expr -> Expr -> P.Expr
+eop :: PrintingInformation -> AssocArithOper -> DomainDesc t Expr Expr -> Expr -> P.Expr
 eop sm AddI = eopAdds sm
 eop sm AddRe = eopAdds sm
 eop sm MulI = eopMuls sm

--- a/code/drasil-printers/lib/Language/Drasil/Printing/Import/ModelExpr.hs
+++ b/code/drasil-printers/lib/Language/Drasil/Printing/Import/ModelExpr.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE GADTs #-}
+
 -- | Defines functions to render 'CodeExpr's as printable 'P.Expr's.
 module Language.Drasil.Printing.Import.ModelExpr where -- TODO: tighten exports
 
@@ -73,7 +75,7 @@ call sm f ps ns = P.Row [symbol $ lookupC (sm ^. stg) (sm ^. ckdb) f,
   P.MO P.Eq, modelExpr a sm]) (map fst ns) (map snd ns)]
 
 -- | Helper function for addition 'EOperator's.
-eopAdds :: PrintingInformation -> DomainDesc ModelExpr ModelExpr -> ModelExpr -> P.Expr
+eopAdds :: PrintingInformation -> DomainDesc t ModelExpr ModelExpr -> ModelExpr -> P.Expr
 eopAdds sm (BoundedDD v Continuous l h) e =
   P.Row [P.MO P.Inte, P.Sub (modelExpr l sm), P.Sup (modelExpr h sm),
          P.Row [modelExpr e sm], P.Spc P.Thin, P.Ident "d", symbol v]
@@ -86,7 +88,7 @@ eopAdds sm (BoundedDD v Discrete l h) e =
 eopAdds sm (AllDD _ Discrete) e = P.Row [P.MO P.Summ, P.Row [modelExpr e sm]]
 
 -- | Helper function for multiplicative 'EOperator's.
-eopMuls :: PrintingInformation -> DomainDesc ModelExpr ModelExpr -> ModelExpr -> P.Expr
+eopMuls :: PrintingInformation -> DomainDesc t ModelExpr ModelExpr -> ModelExpr -> P.Expr
 eopMuls sm (BoundedDD v Discrete l h) e =
   P.Row [P.MO P.Prod, P.Sub (P.Row [symbol v, P.MO P.Eq, modelExpr l sm]), P.Sup (modelExpr h sm),
          P.Row [modelExpr e sm]]
@@ -96,7 +98,7 @@ eopMuls _ (BoundedDD _ Continuous _ _) _ = error "Printing/Import.hs Product-Int
 
 
 -- | Helper function for translating 'EOperator's.
-eop :: PrintingInformation -> AssocArithOper -> DomainDesc ModelExpr ModelExpr -> ModelExpr -> P.Expr
+eop :: PrintingInformation -> AssocArithOper -> DomainDesc t ModelExpr ModelExpr -> ModelExpr -> P.Expr
 eop sm AddI = eopAdds sm
 eop sm AddRe = eopAdds sm
 eop sm MulI = eopMuls sm


### PR DESCRIPTION
Contributes to #2646 

Using DataKinds + GADTs, we add a type variable to DomainDesc (the related RTopology of it's constructors), and force Exprs to only allow for DiscreteDomainDescs, while ModelExprs may allow for either.