### PR TITLE
Shorten `make code` to just `stack build`.

### DIFF
--- a/code/Makefile
+++ b/code/Makefile
@@ -205,7 +205,7 @@ deps: check_stack ##@Dependencies Build only dependencies.
 
 # Build all the Drasil packages.
 code: ##@Examples Build all Drasil packages.
-	stack build
+	stack build $(stackArgs)
 
 # First build all the Drasil packages, then run all examples (no traceability graphs).
 examples: $(GEN_EXAMPLES) ##@Examples Run all examples (no traceability graphs).


### PR DESCRIPTION
This should make compilations slightly faster for `make code` usage.