### PR TITLE
Aggressively remove `drasil-lang` import from `drasil-utils`

### DIFF
--- a/code/drasil-code-base/lib/Language/Drasil/Chunk/CodeBase.hs
+++ b/code/drasil-code-base/lib/Language/Drasil/Chunk/CodeBase.hs
@@ -10,7 +10,7 @@ import Database.Drasil (ChunkDB, symbResolve)
 import Language.Drasil.Code.Expr (CodeExpr)
 import Language.Drasil.Code.Expr.Extract (eDep, eDep')
 
-import Utils.Drasil.Strings (toPlainName)
+import Utils.Drasil (toPlainName)
 
 import Data.List (nub)
 

--- a/code/drasil-code/lib/Language/Drasil/Choices.hs
+++ b/code/drasil-code/lib/Language/Drasil/Choices.hs
@@ -8,7 +8,6 @@ module Language.Drasil.Choices (
   choicesSent, showChs) where
 
 import Language.Drasil
-import Utils.Drasil (foldlSent_)
 
 import Language.Drasil.Code.Code (spaceToCodeType)
 import Language.Drasil.Code.Lang (Lang(..))

--- a/code/drasil-code/lib/Language/Drasil/Code/Imperative/GenerateGOOL.hs
+++ b/code/drasil-code/lib/Language/Drasil/Code/Imperative/GenerateGOOL.hs
@@ -3,7 +3,7 @@ module Language.Drasil.Code.Imperative.GenerateGOOL (ClassType(..),
   primaryClass, auxClass, fApp, ctorCall, fAppInOut
 ) where
 
-import Language.Drasil
+import Language.Drasil hiding (List)
 import Language.Drasil.Code.Imperative.DrasilState (GenState, DrasilState(..))
 import Language.Drasil.Code.Imperative.GOOL.ClassInterface (ReadMeInfo(..),
   AuxiliarySym(..))

--- a/code/drasil-code/lib/Language/Drasil/Mod.hs
+++ b/code/drasil-code/lib/Language/Drasil/Mod.hs
@@ -18,7 +18,7 @@ import Language.Drasil.Code.DataDesc (DataDesc)
 import Language.Drasil.CodeExpr (CodeExpr)
 import qualified Language.Drasil.CodeExpr as CE
 
-import Utils.Drasil.Strings (toPlainName)
+import Utils.Drasil (toPlainName)
 
 import Data.List ((\\), nub)
 

--- a/code/drasil-data/lib/Data/Drasil/Concepts/Documentation.hs
+++ b/code/drasil-data/lib/Data/Drasil/Concepts/Documentation.hs
@@ -2,7 +2,6 @@
 module Data.Drasil.Concepts.Documentation where
 
 import Language.Drasil hiding (organization, year, label, variable)
-import Utils.Drasil
 import Utils.Drasil.Concepts
 
 import Data.Drasil.Concepts.Math (graph, unit_)

--- a/code/drasil-data/lib/Data/Drasil/Concepts/Math.hs
+++ b/code/drasil-data/lib/Data/Drasil/Concepts/Math.hs
@@ -5,7 +5,7 @@ import Language.Drasil hiding (number, norm)
 import Language.Drasil.ShortHands (lX, lY, lZ)
 import Data.Drasil.Domains (mathematics)
 import Data.Drasil.Citations (cartesianWiki, lineSource, pointSource)
-import qualified Utils.Drasil.Sentence as S
+import qualified Language.Drasil.Sentence.Combinators as S
 import Utils.Drasil.Concepts
 
 -- | Collects all math-related concepts.

--- a/code/drasil-data/lib/Data/Drasil/Concepts/Math.hs
+++ b/code/drasil-data/lib/Data/Drasil/Concepts/Math.hs
@@ -5,7 +5,6 @@ import Language.Drasil hiding (number, norm)
 import Language.Drasil.ShortHands (lX, lY, lZ)
 import Data.Drasil.Domains (mathematics)
 import Data.Drasil.Citations (cartesianWiki, lineSource, pointSource)
-import Utils.Drasil
 import qualified Utils.Drasil.Sentence as S
 import Utils.Drasil.Concepts
 

--- a/code/drasil-data/lib/Data/Drasil/Concepts/Physics.hs
+++ b/code/drasil-data/lib/Data/Drasil/Concepts/Physics.hs
@@ -5,7 +5,6 @@ module Data.Drasil.Concepts.Physics where
 import Language.Drasil hiding (space)
 import qualified Utils.Drasil.Sentence as S
 import qualified Utils.Drasil.NounPhrase as NP
-import Utils.Drasil
 import Utils.Drasil.Concepts
 
 import Data.Drasil.Domains (mathematics, physics)

--- a/code/drasil-data/lib/Data/Drasil/Concepts/Physics.hs
+++ b/code/drasil-data/lib/Data/Drasil/Concepts/Physics.hs
@@ -3,7 +3,7 @@ module Data.Drasil.Concepts.Physics where
 --This is obviously a bad name, but for now it will do until we come
 --  up with a better one.
 import Language.Drasil hiding (space)
-import qualified Utils.Drasil.Sentence as S
+import qualified Language.Drasil.Sentence.Combinators as S
 import qualified Utils.Drasil.NounPhrase as NP
 import Utils.Drasil.Concepts
 

--- a/code/drasil-data/lib/Data/Drasil/Concepts/Software.hs
+++ b/code/drasil-data/lib/Data/Drasil/Concepts/Software.hs
@@ -2,7 +2,6 @@
 module Data.Drasil.Concepts.Software where
 
 import Language.Drasil
-import Utils.Drasil
 import qualified Utils.Drasil.Sentence as S
 
 import Data.Drasil.Concepts.Computation (algorithm, dataStruct, inParam)

--- a/code/drasil-data/lib/Data/Drasil/Concepts/Software.hs
+++ b/code/drasil-data/lib/Data/Drasil/Concepts/Software.hs
@@ -2,7 +2,7 @@
 module Data.Drasil.Concepts.Software where
 
 import Language.Drasil
-import qualified Utils.Drasil.Sentence as S
+import qualified Language.Drasil.Sentence.Combinators as S
 
 import Data.Drasil.Concepts.Computation (algorithm, dataStruct, inParam)
 import Data.Drasil.Concepts.Documentation (input_, physical, physicalConstraint,

--- a/code/drasil-data/lib/Data/Drasil/Equations/Defining/Physics.hs
+++ b/code/drasil-data/lib/Data/Drasil/Equations/Defining/Physics.hs
@@ -2,7 +2,6 @@
 module Data.Drasil.Equations.Defining.Physics where
 
 import Language.Drasil
-import Utils.Drasil (foldlSent, getTandS)
 import qualified Utils.Drasil.Sentence as S (is, of_, the_ofThe)
 
 import qualified Data.Drasil.Quantities.Physics as QP (acceleration, time,

--- a/code/drasil-data/lib/Data/Drasil/Equations/Defining/Physics.hs
+++ b/code/drasil-data/lib/Data/Drasil/Equations/Defining/Physics.hs
@@ -2,7 +2,7 @@
 module Data.Drasil.Equations.Defining.Physics where
 
 import Language.Drasil
-import qualified Utils.Drasil.Sentence as S (is, of_, the_ofThe)
+import qualified Language.Drasil.Sentence.Combinators as S (is, of_, the_ofThe)
 
 import qualified Data.Drasil.Quantities.Physics as QP (acceleration, time,
   force, height, velocity, position)

--- a/code/drasil-data/lib/Data/Drasil/Theories/Physics.hs
+++ b/code/drasil-data/lib/Data/Drasil/Theories/Physics.hs
@@ -3,7 +3,6 @@ module Data.Drasil.Theories.Physics where
 
 import Language.Drasil
 import Theory.Drasil
-import Utils.Drasil
 import qualified Utils.Drasil.Sentence as S
 
 import Data.Drasil.Citations (velocityWiki, accelerationWiki)

--- a/code/drasil-data/lib/Data/Drasil/Theories/Physics.hs
+++ b/code/drasil-data/lib/Data/Drasil/Theories/Physics.hs
@@ -2,6 +2,7 @@
 module Data.Drasil.Theories.Physics where
 
 import Language.Drasil
+import Utils.Drasil (weave)
 import Theory.Drasil
 import qualified Language.Drasil.Sentence.Combinators as S
 

--- a/code/drasil-data/lib/Data/Drasil/Theories/Physics.hs
+++ b/code/drasil-data/lib/Data/Drasil/Theories/Physics.hs
@@ -3,7 +3,7 @@ module Data.Drasil.Theories.Physics where
 
 import Language.Drasil
 import Theory.Drasil
-import qualified Utils.Drasil.Sentence as S
+import qualified Language.Drasil.Sentence.Combinators as S
 
 import Data.Drasil.Citations (velocityWiki, accelerationWiki)
 import Data.Drasil.Concepts.Documentation (component, material_, value, constant)

--- a/code/drasil-docLang/lib/Drasil/DocumentLanguage.hs
+++ b/code/drasil-docLang/lib/Drasil/DocumentLanguage.hs
@@ -22,7 +22,6 @@ import Drasil.TraceTable (generateTraceMap)
 
 import Language.Drasil
 import Language.Drasil.Display (compsy)
-import Utils.Drasil
 
 import Database.Drasil(ChunkDB, SystemInformation(SI), _authors, _kind,
   _quants, _sys, _sysinfodb, _usedinfodb, ccss, ccss', citeDB, collectUnits,

--- a/code/drasil-docLang/lib/Drasil/DocumentLanguage/Definitions.hs
+++ b/code/drasil-docLang/lib/Drasil/DocumentLanguage/Definitions.hs
@@ -23,7 +23,6 @@ import Database.Drasil (SystemInformation, _sysinfodb, citeDB, conceptinsLookup,
   theoryModelTable, vars)
 import Theory.Drasil (DataDefinition, GenDefn, InstanceModel, Theory(..),
   TheoryModel, HasInputs(inputs), HasOutput(output, out_constraints), qdFromDD)
-import Utils.Drasil
 
 import Drasil.DocumentLanguage.Units (toSentenceUnitless)
 

--- a/code/drasil-docLang/lib/Drasil/DocumentLanguage/Notebook/DocumentLanguage.hs
+++ b/code/drasil-docLang/lib/Drasil/DocumentLanguage/Notebook/DocumentLanguage.hs
@@ -7,8 +7,6 @@ import Drasil.DocumentLanguage.Notebook.Core (ApndxSec(..), NBDesc, DocSection(.
 
 import Language.Drasil
 
-import Utils.Drasil
-
 import Database.Drasil(SystemInformation(SI), _authors, _kind, _sys, citeDB)
 
 import qualified Drasil.DocLang.Notebook as NB (appendix, body, reference, summary)

--- a/code/drasil-docLang/lib/Drasil/DocumentLanguage/TraceabilityGraph.hs
+++ b/code/drasil-docLang/lib/Drasil/DocumentLanguage/TraceabilityGraph.hs
@@ -17,7 +17,6 @@ import Language.Drasil.Printers (GraphInfo(..), NodeFamily(..))
 import Data.Maybe (fromMaybe)
 import Data.Drasil.Concepts.Math (graph)
 import Data.Drasil.Concepts.Documentation (traceyGraph, component, dependency, reference, purpose)
-import Utils.Drasil
 import qualified Utils.Drasil.Sentence as S
 import Data.Char (isSpace, toLower)
 

--- a/code/drasil-docLang/lib/Drasil/DocumentLanguage/TraceabilityGraph.hs
+++ b/code/drasil-docLang/lib/Drasil/DocumentLanguage/TraceabilityGraph.hs
@@ -17,7 +17,7 @@ import Language.Drasil.Printers (GraphInfo(..), NodeFamily(..))
 import Data.Maybe (fromMaybe)
 import Data.Drasil.Concepts.Math (graph)
 import Data.Drasil.Concepts.Documentation (traceyGraph, component, dependency, reference, purpose)
-import qualified Utils.Drasil.Sentence as S
+import qualified Language.Drasil.Sentence.Combinators as S
 import Data.Char (isSpace, toLower)
 
 -- * Main Functions

--- a/code/drasil-docLang/lib/Drasil/DocumentLanguage/TraceabilityMatrix.hs
+++ b/code/drasil-docLang/lib/Drasil/DocumentLanguage/TraceabilityMatrix.hs
@@ -5,7 +5,7 @@ module Drasil.DocumentLanguage.TraceabilityMatrix where
 import Language.Drasil
 import Database.Drasil(ChunkDB, SystemInformation, UMap, _sysinfodb, asOrderedList,
   conceptinsTable, defResolve, refbyTable, traceTable, traceLookup)
-import qualified Utils.Drasil.Sentence as S
+import qualified Language.Drasil.Sentence.Combinators as S
 
 import Data.Drasil.Concepts.Documentation (purpose, component, dependency,
   item, reference, traceyMatrix)

--- a/code/drasil-docLang/lib/Drasil/DocumentLanguage/TraceabilityMatrix.hs
+++ b/code/drasil-docLang/lib/Drasil/DocumentLanguage/TraceabilityMatrix.hs
@@ -5,7 +5,6 @@ module Drasil.DocumentLanguage.TraceabilityMatrix where
 import Language.Drasil
 import Database.Drasil(ChunkDB, SystemInformation, UMap, _sysinfodb, asOrderedList,
   conceptinsTable, defResolve, refbyTable, traceTable, traceLookup)
-import Utils.Drasil
 import qualified Utils.Drasil.Sentence as S
 
 import Data.Drasil.Concepts.Documentation (purpose, component, dependency,

--- a/code/drasil-docLang/lib/Drasil/Sections/AuxiliaryConstants.hs
+++ b/code/drasil-docLang/lib/Drasil/Sections/AuxiliaryConstants.hs
@@ -3,7 +3,6 @@ module Drasil.Sections.AuxiliaryConstants
   (valsOfAuxConstantsF, tableOfConstants, tableOfConstantsRef) where
 
 import Language.Drasil
-import Utils.Drasil
 import qualified Drasil.DocLang.SRS as SRS (valsOfAuxCons)
 import Drasil.DocumentLanguage.Units (toSentence)
 import Data.Drasil.Concepts.Documentation (value, description, symbol_, tAuxConsts)

--- a/code/drasil-docLang/lib/Drasil/Sections/GeneralSystDesc.hs
+++ b/code/drasil-docLang/lib/Drasil/Sections/GeneralSystDesc.hs
@@ -2,7 +2,7 @@
 module Drasil.Sections.GeneralSystDesc where
 
 import Language.Drasil
-import Utils.Drasil.Sentence
+import Language.Drasil.Sentence.Combinators
 
 import Data.Drasil.Concepts.Documentation (interface, system, environment,
   userCharacteristic, systemConstraint, information, section_)

--- a/code/drasil-docLang/lib/Drasil/Sections/GeneralSystDesc.hs
+++ b/code/drasil-docLang/lib/Drasil/Sections/GeneralSystDesc.hs
@@ -2,7 +2,6 @@
 module Drasil.Sections.GeneralSystDesc where
 
 import Language.Drasil
-import Utils.Drasil
 import Utils.Drasil.Sentence
 
 import Data.Drasil.Concepts.Documentation (interface, system, environment,

--- a/code/drasil-docLang/lib/Drasil/Sections/Introduction.hs
+++ b/code/drasil-docLang/lib/Drasil/Sections/Introduction.hs
@@ -8,7 +8,7 @@ import qualified Drasil.DocLang.SRS as SRS (intro, prpsOfDoc, scpOfReq,
   charOfIR, orgOfDoc, goalStmt, thModel, inModel, sysCon)
 import Drasil.DocumentLanguage.Definitions(Verbosity(..))
 import Utils.Drasil.Concepts
-import qualified Utils.Drasil.Sentence as S
+import qualified Language.Drasil.Sentence.Combinators as S
 
 import Data.Drasil.Concepts.Computation (algorithm)
 import Data.Drasil.Concepts.Documentation as Doc (assumption, characteristic,

--- a/code/drasil-docLang/lib/Drasil/Sections/Introduction.hs
+++ b/code/drasil-docLang/lib/Drasil/Sections/Introduction.hs
@@ -7,7 +7,6 @@ import Language.Drasil
 import qualified Drasil.DocLang.SRS as SRS (intro, prpsOfDoc, scpOfReq,
   charOfIR, orgOfDoc, goalStmt, thModel, inModel, sysCon)
 import Drasil.DocumentLanguage.Definitions(Verbosity(..))
-import Utils.Drasil
 import Utils.Drasil.Concepts
 import qualified Utils.Drasil.Sentence as S
 

--- a/code/drasil-docLang/lib/Drasil/Sections/Requirements.hs
+++ b/code/drasil-docLang/lib/Drasil/Sections/Requirements.hs
@@ -12,7 +12,6 @@ module Drasil.Sections.Requirements (
   ) where
 
 import Language.Drasil
-import Utils.Drasil
 import Utils.Drasil.Concepts
 import qualified Utils.Drasil.Sentence as S
 

--- a/code/drasil-docLang/lib/Drasil/Sections/Requirements.hs
+++ b/code/drasil-docLang/lib/Drasil/Sections/Requirements.hs
@@ -13,7 +13,7 @@ module Drasil.Sections.Requirements (
 
 import Language.Drasil
 import Utils.Drasil.Concepts
-import qualified Utils.Drasil.Sentence as S
+import qualified Language.Drasil.Sentence.Combinators as S
 
 import Data.Drasil.Concepts.Documentation (description, funcReqDom,
   functionalRequirement, input_, nonfunctionalRequirement, {-output_,-} section_,

--- a/code/drasil-docLang/lib/Drasil/Sections/SpecificSystemDescription.hs
+++ b/code/drasil-docLang/lib/Drasil/Sections/SpecificSystemDescription.hs
@@ -24,7 +24,6 @@ module Drasil.Sections.SpecificSystemDescription (
 
 import Language.Drasil hiding (variable)
 import Language.Drasil.Development (showUID)
-import Utils.Drasil
 import Utils.Drasil.Concepts
 import qualified Utils.Drasil.NounPhrase as NP
 import qualified Utils.Drasil.Sentence as S

--- a/code/drasil-docLang/lib/Drasil/Sections/SpecificSystemDescription.hs
+++ b/code/drasil-docLang/lib/Drasil/Sections/SpecificSystemDescription.hs
@@ -26,7 +26,7 @@ import Language.Drasil hiding (variable)
 import Language.Drasil.Development (showUID)
 import Utils.Drasil.Concepts
 import qualified Utils.Drasil.NounPhrase as NP
-import qualified Utils.Drasil.Sentence as S
+import qualified Language.Drasil.Sentence.Combinators as S
 
 import Data.Drasil.Concepts.Documentation (assumption, column, constraint, corSol,
   datum, datumConstraint, inDatumConstraint, outDatumConstraint, definition, element, general, goalStmt, information,

--- a/code/drasil-docLang/lib/Drasil/Sections/Stakeholders.hs
+++ b/code/drasil-docLang/lib/Drasil/Sections/Stakeholders.hs
@@ -2,7 +2,6 @@
 module Drasil.Sections.Stakeholders (stakeholderIntro, tClientF, tCustomerF) where
 
 import Language.Drasil
-import Utils.Drasil
 import Utils.Drasil.Concepts
 import qualified Utils.Drasil.Sentence as S
 

--- a/code/drasil-docLang/lib/Drasil/Sections/Stakeholders.hs
+++ b/code/drasil-docLang/lib/Drasil/Sections/Stakeholders.hs
@@ -3,7 +3,7 @@ module Drasil.Sections.Stakeholders (stakeholderIntro, tClientF, tCustomerF) whe
 
 import Language.Drasil
 import Utils.Drasil.Concepts
-import qualified Utils.Drasil.Sentence as S
+import qualified Language.Drasil.Sentence.Combinators as S
 
 import qualified Drasil.DocLang.SRS as SRS
 import Data.Drasil.Concepts.Documentation (client, customer, endUser, interest,

--- a/code/drasil-docLang/lib/Drasil/Sections/TableOfSymbols.hs
+++ b/code/drasil-docLang/lib/Drasil/Sections/TableOfSymbols.hs
@@ -3,7 +3,6 @@ module Drasil.Sections.TableOfSymbols (table, symbTableRef, tsymb, tsymb', tsymb
 
 import Language.Drasil hiding (Manual, Verb) -- Manual - Citation name conflict. FIXME: Move to different namespace
                                                -- Vector - Name conflict (defined in file)
-import Utils.Drasil
 
 import Data.List (nub, (\\))
 import Control.Lens (view)

--- a/code/drasil-example/dblpendulum/lib/Drasil/DblPendulum/Assumptions.hs
+++ b/code/drasil-example/dblpendulum/lib/Drasil/DblPendulum/Assumptions.hs
@@ -4,7 +4,7 @@ module Drasil.DblPendulum.Assumptions (twoDMotion, cartSys, cartSysR,
     
 import Language.Drasil
 import Utils.Drasil.Concepts
-import qualified Utils.Drasil.Sentence as S
+import qualified Language.Drasil.Sentence.Combinators as S
 
 import Data.Drasil.Concepts.Documentation (assumpDom) 
 import Data.Drasil.Concepts.Math (cartesian, xAxis, yAxis, direction, origin, positive)

--- a/code/drasil-example/dblpendulum/lib/Drasil/DblPendulum/Assumptions.hs
+++ b/code/drasil-example/dblpendulum/lib/Drasil/DblPendulum/Assumptions.hs
@@ -3,7 +3,6 @@ module Drasil.DblPendulum.Assumptions (twoDMotion, cartSys, cartSysR,
   yAxisDir, startOriginSingle, startOriginDouble, firstPend, secondPend, assumpSingle, assumpDouble) where
     
 import Language.Drasil
-import Utils.Drasil (foldlSent)
 import Utils.Drasil.Concepts
 import qualified Utils.Drasil.Sentence as S
 

--- a/code/drasil-example/dblpendulum/lib/Drasil/DblPendulum/Body.hs
+++ b/code/drasil-example/dblpendulum/lib/Drasil/DblPendulum/Body.hs
@@ -6,7 +6,6 @@ import Theory.Drasil (TheoryModel)
 import Drasil.SRSDocument
 import qualified Drasil.DocLang.SRS as SRS
 
-import Utils.Drasil
 import Utils.Drasil.Concepts
 import qualified Utils.Drasil.NounPhrase as NP
 import qualified Utils.Drasil.Sentence as S

--- a/code/drasil-example/dblpendulum/lib/Drasil/DblPendulum/Body.hs
+++ b/code/drasil-example/dblpendulum/lib/Drasil/DblPendulum/Body.hs
@@ -8,7 +8,7 @@ import qualified Drasil.DocLang.SRS as SRS
 
 import Utils.Drasil.Concepts
 import qualified Utils.Drasil.NounPhrase as NP
-import qualified Utils.Drasil.Sentence as S
+import qualified Language.Drasil.Sentence.Combinators as S
 
 import Data.Drasil.People (dong)
 import Data.Drasil.SI_Units (metre, second, newton, kilogram, degree, radian, hertz)

--- a/code/drasil-example/dblpendulum/lib/Drasil/DblPendulum/DataDefs.hs
+++ b/code/drasil-example/dblpendulum/lib/Drasil/DblPendulum/DataDefs.hs
@@ -2,7 +2,7 @@ module Drasil.DblPendulum.DataDefs where
 
 import Prelude hiding (sin, cos, sqrt)
 import Language.Drasil
-import qualified Utils.Drasil.Sentence as S
+import qualified Language.Drasil.Sentence.Combinators as S
 import Theory.Drasil (DataDefinition, ddENoRefs, ddMENoRefs)
 import Drasil.DblPendulum.Figures (figMotion)
 import Drasil.DblPendulum.Unitals (pendDisAngle_1, pendDisAngle_2, lenRod_1, lenRod_2, xPos_1, yPos_1, xPos_2, yPos_2)

--- a/code/drasil-example/dblpendulum/lib/Drasil/DblPendulum/GenDefs.hs
+++ b/code/drasil-example/dblpendulum/lib/Drasil/DblPendulum/GenDefs.hs
@@ -7,6 +7,7 @@ import Prelude hiding (cos, sin, sqrt)
 import qualified Data.List.NonEmpty as NE
 
 import Language.Drasil
+import Utils.Drasil (weave)
 import Theory.Drasil
 import Utils.Drasil.Concepts
 import qualified Language.Drasil.Sentence.Combinators as S

--- a/code/drasil-example/dblpendulum/lib/Drasil/DblPendulum/GenDefs.hs
+++ b/code/drasil-example/dblpendulum/lib/Drasil/DblPendulum/GenDefs.hs
@@ -8,7 +8,6 @@ import qualified Data.List.NonEmpty as NE
 
 import Language.Drasil
 import Theory.Drasil
-import Utils.Drasil
 import Utils.Drasil.Concepts
 import qualified Utils.Drasil.Sentence as S
 import qualified Utils.Drasil.NounPhrase as NP

--- a/code/drasil-example/dblpendulum/lib/Drasil/DblPendulum/GenDefs.hs
+++ b/code/drasil-example/dblpendulum/lib/Drasil/DblPendulum/GenDefs.hs
@@ -9,7 +9,7 @@ import qualified Data.List.NonEmpty as NE
 import Language.Drasil
 import Theory.Drasil
 import Utils.Drasil.Concepts
-import qualified Utils.Drasil.Sentence as S
+import qualified Language.Drasil.Sentence.Combinators as S
 import qualified Utils.Drasil.NounPhrase as NP
 import Data.Drasil.Concepts.Math (xComp, yComp)
 import Data.Drasil.Quantities.Physics (velocity, acceleration, force)

--- a/code/drasil-example/dblpendulum/lib/Drasil/DblPendulum/Goals.hs
+++ b/code/drasil-example/dblpendulum/lib/Drasil/DblPendulum/Goals.hs
@@ -3,7 +3,7 @@ module Drasil.DblPendulum.Goals (goals, goalsInputs) where
 
 import Language.Drasil
 import Utils.Drasil.Concepts
-import qualified Utils.Drasil.Sentence as S
+import qualified Language.Drasil.Sentence.Combinators as S
 import Data.Drasil.Concepts.Documentation (goalStmtDom)
 import qualified Data.Drasil.Concepts.PhysicalProperties as CPP (mass, len)
 import Data.Drasil.Concepts.Physics (gravitationalConst, motion)

--- a/code/drasil-example/dblpendulum/lib/Drasil/DblPendulum/IMods.hs
+++ b/code/drasil-example/dblpendulum/lib/Drasil/DblPendulum/IMods.hs
@@ -5,7 +5,7 @@ import Prelude hiding (cos, sin)
 
 import Language.Drasil
 import Theory.Drasil
-import qualified Utils.Drasil.Sentence as S
+import qualified Language.Drasil.Sentence.Combinators as S
 import Drasil.DblPendulum.Expressions (angularAccelExpr_1, angularAccelExpr_2,
   forceDerivExpr1, forceDerivExpr2,
   cosAngleExpr1, sinAngleExpr1, cosAngleExpr2, sinAngleExpr2)

--- a/code/drasil-example/dblpendulum/lib/Drasil/DblPendulum/IMods.hs
+++ b/code/drasil-example/dblpendulum/lib/Drasil/DblPendulum/IMods.hs
@@ -5,7 +5,6 @@ import Prelude hiding (cos, sin)
 
 import Language.Drasil
 import Theory.Drasil
-import Utils.Drasil (foldlSentCol, weave)
 import qualified Utils.Drasil.Sentence as S
 import Drasil.DblPendulum.Expressions (angularAccelExpr_1, angularAccelExpr_2,
   forceDerivExpr1, forceDerivExpr2,

--- a/code/drasil-example/dblpendulum/lib/Drasil/DblPendulum/IMods.hs
+++ b/code/drasil-example/dblpendulum/lib/Drasil/DblPendulum/IMods.hs
@@ -5,6 +5,7 @@ import Prelude hiding (cos, sin)
 
 import Language.Drasil
 import Theory.Drasil
+import Utils.Drasil (weave)
 import qualified Language.Drasil.Sentence.Combinators as S
 import Drasil.DblPendulum.Expressions (angularAccelExpr_1, angularAccelExpr_2,
   forceDerivExpr1, forceDerivExpr2,

--- a/code/drasil-example/dblpendulum/lib/Drasil/DblPendulum/Requirements.hs
+++ b/code/drasil-example/dblpendulum/lib/Drasil/DblPendulum/Requirements.hs
@@ -2,7 +2,6 @@ module Drasil.DblPendulum.Requirements where
 
 import Language.Drasil
 import Drasil.DocLang.SRS (datCon, propCorSol)
-import Utils.Drasil
 import Utils.Drasil.Concepts
 import qualified Utils.Drasil.Sentence as S
 import Data.Drasil.Concepts.Computation (inValue)

--- a/code/drasil-example/dblpendulum/lib/Drasil/DblPendulum/Requirements.hs
+++ b/code/drasil-example/dblpendulum/lib/Drasil/DblPendulum/Requirements.hs
@@ -3,7 +3,7 @@ module Drasil.DblPendulum.Requirements where
 import Language.Drasil
 import Drasil.DocLang.SRS (datCon, propCorSol)
 import Utils.Drasil.Concepts
-import qualified Utils.Drasil.Sentence as S
+import qualified Language.Drasil.Sentence.Combinators as S
 import Data.Drasil.Concepts.Computation (inValue)
 import Data.Drasil.Concepts.Documentation (datumConstraint, funcReqDom,
         output_, value,  nonFuncReqDom, code, environment, propOfCorSol)

--- a/code/drasil-example/dblpendulum/lib/Drasil/DblPendulum/Unitals.hs
+++ b/code/drasil-example/dblpendulum/lib/Drasil/DblPendulum/Unitals.hs
@@ -4,7 +4,7 @@ import Language.Drasil
 import Language.Drasil.Display (Symbol(..))
 import Language.Drasil.ShortHands
 import Utils.Drasil.Concepts
-import qualified Utils.Drasil.Sentence as S
+import qualified Language.Drasil.Sentence.Combinators as S
 import Data.Drasil.Constraints (gtZeroConstr)
 import Data.Drasil.TheoryConcepts (dataDefn, genDefn, inModel, thModel)
 import Data.Drasil.Concepts.Documentation (assumption, goalStmt, physSyst, requirement, srs, typUnc)

--- a/code/drasil-example/gamephysics/lib/Drasil/GamePhysics/Assumptions.hs
+++ b/code/drasil-example/gamephysics/lib/Drasil/GamePhysics/Assumptions.hs
@@ -1,7 +1,6 @@
 module Drasil.GamePhysics.Assumptions where
 
 import Language.Drasil hiding (organization)
-import Utils.Drasil
 
 import Data.Drasil.Concepts.Documentation as Doc (simulation, assumpDom)
 import qualified Data.Drasil.Concepts.Physics as CP (collision, damping, force,

--- a/code/drasil-example/gamephysics/lib/Drasil/GamePhysics/Body.hs
+++ b/code/drasil-example/gamephysics/lib/Drasil/GamePhysics/Body.hs
@@ -7,7 +7,7 @@ import Drasil.SRSDocument
 import qualified Drasil.DocLang.SRS as SRS
 import Theory.Drasil (qdEFromDD)
 import Utils.Drasil.Concepts
-import qualified Utils.Drasil.Sentence as S
+import qualified Language.Drasil.Sentence.Combinators as S
 
 import Data.Drasil.Concepts.Computation (algorithm)
 import Data.Drasil.Concepts.Documentation as Doc (assumption, concept,

--- a/code/drasil-example/gamephysics/lib/Drasil/GamePhysics/Body.hs
+++ b/code/drasil-example/gamephysics/lib/Drasil/GamePhysics/Body.hs
@@ -6,7 +6,6 @@ import Language.Drasil hiding (organization, section)
 import Drasil.SRSDocument
 import qualified Drasil.DocLang.SRS as SRS
 import Theory.Drasil (qdEFromDD)
-import Utils.Drasil
 import Utils.Drasil.Concepts
 import qualified Utils.Drasil.Sentence as S
 

--- a/code/drasil-example/gamephysics/lib/Drasil/GamePhysics/Changes.hs
+++ b/code/drasil-example/gamephysics/lib/Drasil/GamePhysics/Changes.hs
@@ -4,7 +4,6 @@ module Drasil.GamePhysics.Changes (likelyChgs, unlikelyChgs) where
 --A list of likely and unlikely changes for GamePhysics
 
 import Language.Drasil
-import Utils.Drasil
 import qualified Utils.Drasil.Sentence as S
 
 import Data.Drasil.Concepts.Documentation as Doc (library, likeChgDom, unlikeChgDom)

--- a/code/drasil-example/gamephysics/lib/Drasil/GamePhysics/Changes.hs
+++ b/code/drasil-example/gamephysics/lib/Drasil/GamePhysics/Changes.hs
@@ -4,7 +4,7 @@ module Drasil.GamePhysics.Changes (likelyChgs, unlikelyChgs) where
 --A list of likely and unlikely changes for GamePhysics
 
 import Language.Drasil
-import qualified Utils.Drasil.Sentence as S
+import qualified Language.Drasil.Sentence.Combinators as S
 
 import Data.Drasil.Concepts.Documentation as Doc (library, likeChgDom, unlikeChgDom)
 import qualified Data.Drasil.Concepts.Math as CM (ode, constraint)

--- a/code/drasil-example/gamephysics/lib/Drasil/GamePhysics/DataDefs.hs
+++ b/code/drasil-example/gamephysics/lib/Drasil/GamePhysics/DataDefs.hs
@@ -7,7 +7,7 @@ import Language.Drasil
 
 import Theory.Drasil
 import Utils.Drasil.Concepts
-import qualified Utils.Drasil.Sentence as S
+import qualified Language.Drasil.Sentence.Combinators as S
 import Control.Lens ((^.))
 
 import Drasil.GamePhysics.Assumptions (assumpOT, assumpOD, assumpAD, assumpCT, assumpDI)

--- a/code/drasil-example/gamephysics/lib/Drasil/GamePhysics/DataDefs.hs
+++ b/code/drasil-example/gamephysics/lib/Drasil/GamePhysics/DataDefs.hs
@@ -6,6 +6,7 @@ module Drasil.GamePhysics.DataDefs (dataDefs, ctrOfMassDD,
 import Language.Drasil
 
 import Theory.Drasil
+import Utils.Drasil (weave)
 import Utils.Drasil.Concepts
 import qualified Language.Drasil.Sentence.Combinators as S
 import Control.Lens ((^.))

--- a/code/drasil-example/gamephysics/lib/Drasil/GamePhysics/DataDefs.hs
+++ b/code/drasil-example/gamephysics/lib/Drasil/GamePhysics/DataDefs.hs
@@ -6,7 +6,6 @@ module Drasil.GamePhysics.DataDefs (dataDefs, ctrOfMassDD,
 import Language.Drasil
 
 import Theory.Drasil
-import Utils.Drasil
 import Utils.Drasil.Concepts
 import qualified Utils.Drasil.Sentence as S
 import Control.Lens ((^.))

--- a/code/drasil-example/gamephysics/lib/Drasil/GamePhysics/GDefs.hs
+++ b/code/drasil-example/gamephysics/lib/Drasil/GamePhysics/GDefs.hs
@@ -8,7 +8,7 @@ module Drasil.GamePhysics.GDefs (genDefs) where
 
 import Language.Drasil
 import Utils.Drasil
-import qualified Utils.Drasil.Sentence as S
+import qualified Language.Drasil.Sentence.Combinators as S
 
 import Data.Drasil.Concepts.Physics (rigidBody)
 import Data.Drasil.Quantities.PhysicalProperties (mass)

--- a/code/drasil-example/gamephysics/lib/Drasil/GamePhysics/GenDefs.hs
+++ b/code/drasil-example/gamephysics/lib/Drasil/GamePhysics/GenDefs.hs
@@ -2,7 +2,6 @@
 module Drasil.GamePhysics.GenDefs (generalDefns, accelGravityGD, impulseGD) where
 
 import Language.Drasil
-import Utils.Drasil
 import qualified Utils.Drasil.Sentence as S
 import Theory.Drasil (GenDefn, gd, equationalModel')
 import qualified Data.Drasil.Quantities.Physics as QP (acceleration,

--- a/code/drasil-example/gamephysics/lib/Drasil/GamePhysics/GenDefs.hs
+++ b/code/drasil-example/gamephysics/lib/Drasil/GamePhysics/GenDefs.hs
@@ -2,7 +2,7 @@
 module Drasil.GamePhysics.GenDefs (generalDefns, accelGravityGD, impulseGD) where
 
 import Language.Drasil
-import qualified Utils.Drasil.Sentence as S
+import qualified Language.Drasil.Sentence.Combinators as S
 import Theory.Drasil (GenDefn, gd, equationalModel')
 import qualified Data.Drasil.Quantities.Physics as QP (acceleration,
  gravitationalAccel, gravitationalConst, restitutionCoef, impulseS, force,

--- a/code/drasil-example/gamephysics/lib/Drasil/GamePhysics/GenDefs.hs
+++ b/code/drasil-example/gamephysics/lib/Drasil/GamePhysics/GenDefs.hs
@@ -4,6 +4,7 @@ module Drasil.GamePhysics.GenDefs (generalDefns, accelGravityGD, impulseGD) wher
 import Language.Drasil
 import qualified Language.Drasil.Sentence.Combinators as S
 import Theory.Drasil (GenDefn, gd, equationalModel')
+import Utils.Drasil (weave)
 import qualified Data.Drasil.Quantities.Physics as QP (acceleration,
  gravitationalAccel, gravitationalConst, restitutionCoef, impulseS, force,
  fOfGravity)

--- a/code/drasil-example/gamephysics/lib/Drasil/GamePhysics/Goals.hs
+++ b/code/drasil-example/gamephysics/lib/Drasil/GamePhysics/Goals.hs
@@ -1,7 +1,6 @@
 module Drasil.GamePhysics.Goals (goals, linearGS, angularGS) where
 
 import Language.Drasil
-import Utils.Drasil
 
 import Data.Drasil.Concepts.Documentation (goalStmtDom)
 import Data.Drasil.Concepts.Physics (time)

--- a/code/drasil-example/gamephysics/lib/Drasil/GamePhysics/IMods.hs
+++ b/code/drasil-example/gamephysics/lib/Drasil/GamePhysics/IMods.hs
@@ -5,7 +5,7 @@ import Language.Drasil
 import Language.Drasil.ShortHands (lJ)
 import Theory.Drasil
 import Utils.Drasil.Concepts
-import qualified Utils.Drasil.Sentence as S
+import qualified Language.Drasil.Sentence.Combinators as S
 
 import Drasil.GamePhysics.Assumptions (assumpDI, assumpCAJI)
 import Drasil.GamePhysics.Concepts (centreMass)

--- a/code/drasil-example/gamephysics/lib/Drasil/GamePhysics/IMods.hs
+++ b/code/drasil-example/gamephysics/lib/Drasil/GamePhysics/IMods.hs
@@ -4,6 +4,7 @@ module Drasil.GamePhysics.IMods (iMods, instModIntro) where
 import Language.Drasil
 import Language.Drasil.ShortHands (lJ)
 import Theory.Drasil
+import Utils.Drasil (weave)
 import Utils.Drasil.Concepts
 import qualified Language.Drasil.Sentence.Combinators as S
 

--- a/code/drasil-example/gamephysics/lib/Drasil/GamePhysics/IMods.hs
+++ b/code/drasil-example/gamephysics/lib/Drasil/GamePhysics/IMods.hs
@@ -4,7 +4,6 @@ module Drasil.GamePhysics.IMods (iMods, instModIntro) where
 import Language.Drasil
 import Language.Drasil.ShortHands (lJ)
 import Theory.Drasil
-import Utils.Drasil
 import Utils.Drasil.Concepts
 import qualified Utils.Drasil.Sentence as S
 

--- a/code/drasil-example/gamephysics/lib/Drasil/GamePhysics/Requirements.hs
+++ b/code/drasil-example/gamephysics/lib/Drasil/GamePhysics/Requirements.hs
@@ -3,7 +3,7 @@ module Drasil.GamePhysics.Requirements (funcReqs, nonfuncReqs) where
 
 import Language.Drasil hiding (organization)
 import Utils.Drasil.Concepts
-import qualified Utils.Drasil.Sentence as S
+import qualified Language.Drasil.Sentence.Combinators as S
 
 import qualified Drasil.DocLang.SRS as SRS (solCharSpec)
 import Data.Drasil.Concepts.Documentation as Doc (body, funcReqDom, input_, 

--- a/code/drasil-example/gamephysics/lib/Drasil/GamePhysics/Requirements.hs
+++ b/code/drasil-example/gamephysics/lib/Drasil/GamePhysics/Requirements.hs
@@ -2,7 +2,6 @@
 module Drasil.GamePhysics.Requirements (funcReqs, nonfuncReqs) where
 
 import Language.Drasil hiding (organization)
-import Utils.Drasil
 import Utils.Drasil.Concepts
 import qualified Utils.Drasil.Sentence as S
 

--- a/code/drasil-example/gamephysics/lib/Drasil/GamePhysics/TMods.hs
+++ b/code/drasil-example/gamephysics/lib/Drasil/GamePhysics/TMods.hs
@@ -5,7 +5,6 @@ import qualified Data.List.NonEmpty as NE
 
 import Language.Drasil
 import Theory.Drasil
-import Utils.Drasil
 import qualified Utils.Drasil.Sentence as S
 
 import Drasil.GamePhysics.Assumptions (assumpOD)

--- a/code/drasil-example/gamephysics/lib/Drasil/GamePhysics/TMods.hs
+++ b/code/drasil-example/gamephysics/lib/Drasil/GamePhysics/TMods.hs
@@ -5,7 +5,7 @@ import qualified Data.List.NonEmpty as NE
 
 import Language.Drasil
 import Theory.Drasil
-import qualified Utils.Drasil.Sentence as S
+import qualified Language.Drasil.Sentence.Combinators as S
 
 import Drasil.GamePhysics.Assumptions (assumpOD)
 import Drasil.GamePhysics.Unitals (dispNorm, dVect, force_1, force_2,

--- a/code/drasil-example/glassbr/lib/Drasil/GlassBR/Assumptions.hs
+++ b/code/drasil-example/glassbr/lib/Drasil/GlassBR/Assumptions.hs
@@ -4,7 +4,6 @@ module Drasil.GlassBR.Assumptions (assumpGT, assumpGC, assumpES, assumpSV,
 
 import Language.Drasil hiding (organization)
 import qualified Drasil.DocLang.SRS as SRS (valsOfAuxCons)
-import Utils.Drasil
 import Utils.Drasil.Concepts
 import qualified Utils.Drasil.NounPhrase as NP
 import qualified Utils.Drasil.Sentence as S

--- a/code/drasil-example/glassbr/lib/Drasil/GlassBR/Assumptions.hs
+++ b/code/drasil-example/glassbr/lib/Drasil/GlassBR/Assumptions.hs
@@ -6,7 +6,7 @@ import Language.Drasil hiding (organization)
 import qualified Drasil.DocLang.SRS as SRS (valsOfAuxCons)
 import Utils.Drasil.Concepts
 import qualified Utils.Drasil.NounPhrase as NP
-import qualified Utils.Drasil.Sentence as S
+import qualified Language.Drasil.Sentence.Combinators as S
 
 import Data.Drasil.Concepts.Documentation as Doc (assumpDom, condition,
   constant, practice, reference, scenario, system, value)

--- a/code/drasil-example/glassbr/lib/Drasil/GlassBR/Body.hs
+++ b/code/drasil-example/glassbr/lib/Drasil/GlassBR/Body.hs
@@ -6,7 +6,6 @@ import Language.Drasil hiding (organization, section, variable)
 import Drasil.SRSDocument
 import Drasil.DocLang (auxSpecSent, termDefnF')
 import qualified Drasil.DocLang.SRS as SRS (reference, assumpt, inModel)
-import Utils.Drasil
 import Utils.Drasil.Concepts
 import qualified Utils.Drasil.Sentence as S
 

--- a/code/drasil-example/glassbr/lib/Drasil/GlassBR/Body.hs
+++ b/code/drasil-example/glassbr/lib/Drasil/GlassBR/Body.hs
@@ -7,7 +7,7 @@ import Drasil.SRSDocument
 import Drasil.DocLang (auxSpecSent, termDefnF')
 import qualified Drasil.DocLang.SRS as SRS (reference, assumpt, inModel)
 import Utils.Drasil.Concepts
-import qualified Utils.Drasil.Sentence as S
+import qualified Language.Drasil.Sentence.Combinators as S
 
 import Data.Drasil.Concepts.Computation (computerApp, inDatum, compcon, algorithm)
 import Data.Drasil.Concepts.Documentation as Doc (appendix, aspect,

--- a/code/drasil-example/glassbr/lib/Drasil/GlassBR/Changes.hs
+++ b/code/drasil-example/glassbr/lib/Drasil/GlassBR/Changes.hs
@@ -3,7 +3,6 @@ module Drasil.GlassBR.Changes (likelyChgs, unlikelyChgs) where
 --A list of likely and unlikely changes for GlassBR
 
 import Language.Drasil hiding (variable)
-import Utils.Drasil
 import Utils.Drasil.Concepts
 
 import Data.Drasil.Concepts.Documentation (condition, goal, input_, likeChgDom,

--- a/code/drasil-example/glassbr/lib/Drasil/GlassBR/DataDefs.hs
+++ b/code/drasil-example/glassbr/lib/Drasil/GlassBR/DataDefs.hs
@@ -9,7 +9,7 @@ import Language.Drasil.Code (asVC')
 import Prelude hiding (log, exp, sqrt)
 import Theory.Drasil (DataDefinition, ddE)
 import Database.Drasil (Block(Parallel))
-import qualified Utils.Drasil.Sentence as S
+import qualified Language.Drasil.Sentence.Combinators as S
 
 import Data.Drasil.Concepts.Documentation (datum, user)
 import Data.Drasil.Concepts.Math (parameter)

--- a/code/drasil-example/glassbr/lib/Drasil/GlassBR/DataDefs.hs
+++ b/code/drasil-example/glassbr/lib/Drasil/GlassBR/DataDefs.hs
@@ -9,7 +9,6 @@ import Language.Drasil.Code (asVC')
 import Prelude hiding (log, exp, sqrt)
 import Theory.Drasil (DataDefinition, ddE)
 import Database.Drasil (Block(Parallel))
-import Utils.Drasil
 import qualified Utils.Drasil.Sentence as S
 
 import Data.Drasil.Concepts.Documentation (datum, user)

--- a/code/drasil-example/glassbr/lib/Drasil/GlassBR/Figures.hs
+++ b/code/drasil-example/glassbr/lib/Drasil/GlassBR/Figures.hs
@@ -3,7 +3,6 @@ module Drasil.GlassBR.Figures where
 import Control.Lens((^.))
 
 import Language.Drasil
-import Utils.Drasil
 import Utils.Drasil.Concepts
 import qualified Utils.Drasil.Sentence as S
 

--- a/code/drasil-example/glassbr/lib/Drasil/GlassBR/Figures.hs
+++ b/code/drasil-example/glassbr/lib/Drasil/GlassBR/Figures.hs
@@ -4,7 +4,7 @@ import Control.Lens((^.))
 
 import Language.Drasil
 import Utils.Drasil.Concepts
-import qualified Utils.Drasil.Sentence as S
+import qualified Language.Drasil.Sentence.Combinators as S
 
 import Data.Drasil.Concepts.Documentation (assumption, item, physicalSystem,
   requirement, section_, sysCont, traceyMatrix)

--- a/code/drasil-example/glassbr/lib/Drasil/GlassBR/Goals.hs
+++ b/code/drasil-example/glassbr/lib/Drasil/GlassBR/Goals.hs
@@ -1,7 +1,6 @@
 module Drasil.GlassBR.Goals (goals, willBreakGS) where
 
 import Language.Drasil
-import Utils.Drasil
 import qualified Utils.Drasil.Sentence as S
 
 import Data.Drasil.Concepts.Documentation (goalStmtDom, userInput)

--- a/code/drasil-example/glassbr/lib/Drasil/GlassBR/Goals.hs
+++ b/code/drasil-example/glassbr/lib/Drasil/GlassBR/Goals.hs
@@ -1,7 +1,7 @@
 module Drasil.GlassBR.Goals (goals, willBreakGS) where
 
 import Language.Drasil
-import qualified Utils.Drasil.Sentence as S
+import qualified Language.Drasil.Sentence.Combinators as S
 
 import Data.Drasil.Concepts.Documentation (goalStmtDom, userInput)
 import Data.Drasil.Concepts.Thermodynamics (degree_')

--- a/code/drasil-example/glassbr/lib/Drasil/GlassBR/IMods.hs
+++ b/code/drasil-example/glassbr/lib/Drasil/GlassBR/IMods.hs
@@ -3,7 +3,6 @@ module Drasil.GlassBR.IMods (symb, iMods, pbIsSafe, lrIsSafe, instModIntro) wher
 import Prelude hiding (exp)
 import Language.Drasil
 import Theory.Drasil (InstanceModel, imNoDeriv, qwC, equationalModelN)
-import Utils.Drasil
 import Utils.Drasil.Concepts
 import qualified Utils.Drasil.Sentence as S
 import Data.Drasil.SI_Units

--- a/code/drasil-example/glassbr/lib/Drasil/GlassBR/IMods.hs
+++ b/code/drasil-example/glassbr/lib/Drasil/GlassBR/IMods.hs
@@ -4,7 +4,7 @@ import Prelude hiding (exp)
 import Language.Drasil
 import Theory.Drasil (InstanceModel, imNoDeriv, qwC, equationalModelN)
 import Utils.Drasil.Concepts
-import qualified Utils.Drasil.Sentence as S
+import qualified Language.Drasil.Sentence.Combinators as S
 import Data.Drasil.SI_Units
 import Drasil.GlassBR.DataDefs (probOfBreak, calofCapacity,
   pbTolUsr, qRef)

--- a/code/drasil-example/glassbr/lib/Drasil/GlassBR/Requirements.hs
+++ b/code/drasil-example/glassbr/lib/Drasil/GlassBR/Requirements.hs
@@ -6,7 +6,6 @@ import Language.Drasil
 import Drasil.DocLang (inReq, mkQRTuple, mkQRTupleRef, mkValsSourceTable)
 import Drasil.DocLang.SRS (datCon, propCorSol)
 import Theory.Drasil (DataDefinition)
-import Utils.Drasil
 import Utils.Drasil.Concepts
 import qualified Utils.Drasil.NounPhrase as NP
 import qualified Utils.Drasil.Sentence as S

--- a/code/drasil-example/glassbr/lib/Drasil/GlassBR/Requirements.hs
+++ b/code/drasil-example/glassbr/lib/Drasil/GlassBR/Requirements.hs
@@ -8,7 +8,7 @@ import Drasil.DocLang.SRS (datCon, propCorSol)
 import Theory.Drasil (DataDefinition)
 import Utils.Drasil.Concepts
 import qualified Utils.Drasil.NounPhrase as NP
-import qualified Utils.Drasil.Sentence as S
+import qualified Language.Drasil.Sentence.Combinators as S
 
 import Data.Drasil.Concepts.Computation (inValue)
 import Data.Drasil.Concepts.Documentation (assumption, characteristic, code,

--- a/code/drasil-example/glassbr/lib/Drasil/GlassBR/Unitals.hs
+++ b/code/drasil-example/glassbr/lib/Drasil/GlassBR/Unitals.hs
@@ -3,7 +3,6 @@ module Drasil.GlassBR.Unitals where --whole file is used
 import Language.Drasil
 import Language.Drasil.Display (Symbol(..))
 import Language.Drasil.ShortHands
-import Utils.Drasil
 import Utils.Drasil.Concepts
 
 import Prelude hiding (log)

--- a/code/drasil-example/hghc/lib/Drasil/HGHC/Body.hs
+++ b/code/drasil-example/hghc/lib/Drasil/HGHC/Body.hs
@@ -2,7 +2,7 @@ module Drasil.HGHC.Body (srs, si, symbMap, printSetting, fullSI) where
 
 import Language.Drasil hiding (Manual) -- Citation name conflict. FIXME: Move to different namespace
 import Drasil.SRSDocument
-import qualified Utils.Drasil.Sentence as S
+import qualified Language.Drasil.Sentence.Combinators as S
 
 import Drasil.HGHC.HeatTransfer (fp, hghc, dataDefs, htInputs, htOutputs, 
     nuclearPhys, symbols)

--- a/code/drasil-example/nopcm/lib/Drasil/NoPCM/Assumptions.hs
+++ b/code/drasil-example/nopcm/lib/Drasil/NoPCM/Assumptions.hs
@@ -2,7 +2,6 @@
 module Drasil.NoPCM.Assumptions where --all of this file is exported
 
 import Language.Drasil
-import Utils.Drasil
 import Utils.Drasil.Concepts
 import qualified Utils.Drasil.NounPhrase as NP
 import qualified Utils.Drasil.Sentence as S

--- a/code/drasil-example/nopcm/lib/Drasil/NoPCM/Assumptions.hs
+++ b/code/drasil-example/nopcm/lib/Drasil/NoPCM/Assumptions.hs
@@ -4,7 +4,7 @@ module Drasil.NoPCM.Assumptions where --all of this file is exported
 import Language.Drasil
 import Utils.Drasil.Concepts
 import qualified Utils.Drasil.NounPhrase as NP
-import qualified Utils.Drasil.Sentence as S
+import qualified Language.Drasil.Sentence.Combinators as S
 
 import Data.Drasil.Concepts.Documentation (model, assumpDom, material_)
 

--- a/code/drasil-example/nopcm/lib/Drasil/NoPCM/Body.hs
+++ b/code/drasil-example/nopcm/lib/Drasil/NoPCM/Body.hs
@@ -5,7 +5,7 @@ import Drasil.SRSDocument
 import qualified Drasil.DocLang.SRS as SRS (inModel)
 import Theory.Drasil (TheoryModel)
 import Utils.Drasil.Concepts
-import qualified Utils.Drasil.Sentence as S
+import qualified Language.Drasil.Sentence.Combinators as S
 
 import Language.Drasil.Code (quantvar, listToArray)
 

--- a/code/drasil-example/nopcm/lib/Drasil/NoPCM/Body.hs
+++ b/code/drasil-example/nopcm/lib/Drasil/NoPCM/Body.hs
@@ -4,7 +4,6 @@ import Language.Drasil hiding (section)
 import Drasil.SRSDocument
 import qualified Drasil.DocLang.SRS as SRS (inModel)
 import Theory.Drasil (TheoryModel)
-import Utils.Drasil
 import Utils.Drasil.Concepts
 import qualified Utils.Drasil.Sentence as S
 

--- a/code/drasil-example/nopcm/lib/Drasil/NoPCM/Changes.hs
+++ b/code/drasil-example/nopcm/lib/Drasil/NoPCM/Changes.hs
@@ -3,7 +3,7 @@ module Drasil.NoPCM.Changes (likelyChgs, unlikelyChgs) where
 
 import Language.Drasil
 import Utils.Drasil.Concepts
-import qualified Utils.Drasil.Sentence as S
+import qualified Language.Drasil.Sentence.Combinators as S
 
 import Data.Drasil.Concepts.Documentation (model, likeChgDom, unlikeChgDom)
 import Data.Drasil.Concepts.Thermodynamics (temp)

--- a/code/drasil-example/nopcm/lib/Drasil/NoPCM/Changes.hs
+++ b/code/drasil-example/nopcm/lib/Drasil/NoPCM/Changes.hs
@@ -2,7 +2,6 @@
 module Drasil.NoPCM.Changes (likelyChgs, unlikelyChgs) where
 
 import Language.Drasil
-import Utils.Drasil
 import Utils.Drasil.Concepts
 import qualified Utils.Drasil.Sentence as S
 

--- a/code/drasil-example/nopcm/lib/Drasil/NoPCM/DataDefs.hs
+++ b/code/drasil-example/nopcm/lib/Drasil/NoPCM/DataDefs.hs
@@ -2,7 +2,6 @@ module Drasil.NoPCM.DataDefs where --exports all of it
 
 import Language.Drasil
 import Theory.Drasil (DataDefinition, ddENoRefs)
-import Utils.Drasil
 
 import Drasil.SWHS.Assumptions (assumpVCN)
 import Drasil.SWHS.DataDefs (balanceDecayRate, balanceDecayRateQD, tankVolume, 

--- a/code/drasil-example/nopcm/lib/Drasil/NoPCM/IMods.hs
+++ b/code/drasil-example/nopcm/lib/Drasil/NoPCM/IMods.hs
@@ -1,12 +1,7 @@
 module Drasil.NoPCM.IMods (eBalanceOnWtr, iMods, instModIntro) where
 
-import Language.Drasil (dRefInfo, (+:+), ch, eS, atStartNP, refS, sParen,
-  sC, phrase, nounPhraseSP, qw, RefInfo(RefNote), NounPhrase(..),
-  ModelExprC(..), ExprC(..), PExpr, Definition(..), MayHaveUnit(..),
-  Sentence(..), ModelExpr, Inclusive(..), RealInterval(..), Derivation,
-  makeRC, mkDerivName, RelationConcept, recip_, apply1, LiteralC(..))
+import Language.Drasil
 import Theory.Drasil (InstanceModel, im, qwC, qwUC, deModel')
-import Utils.Drasil
 import Utils.Drasil.Concepts
 import qualified Utils.Drasil.Sentence as S
 import Control.Lens ((^.))

--- a/code/drasil-example/nopcm/lib/Drasil/NoPCM/IMods.hs
+++ b/code/drasil-example/nopcm/lib/Drasil/NoPCM/IMods.hs
@@ -2,6 +2,7 @@ module Drasil.NoPCM.IMods (eBalanceOnWtr, iMods, instModIntro) where
 
 import Language.Drasil
 import Theory.Drasil (InstanceModel, im, qwC, qwUC, deModel')
+import Utils.Drasil (weave)
 import Utils.Drasil.Concepts
 import qualified Language.Drasil.Sentence.Combinators as S
 import Control.Lens ((^.))

--- a/code/drasil-example/nopcm/lib/Drasil/NoPCM/IMods.hs
+++ b/code/drasil-example/nopcm/lib/Drasil/NoPCM/IMods.hs
@@ -3,7 +3,7 @@ module Drasil.NoPCM.IMods (eBalanceOnWtr, iMods, instModIntro) where
 import Language.Drasil
 import Theory.Drasil (InstanceModel, im, qwC, qwUC, deModel')
 import Utils.Drasil.Concepts
-import qualified Utils.Drasil.Sentence as S
+import qualified Language.Drasil.Sentence.Combinators as S
 import Control.Lens ((^.))
 
 import Data.Drasil.Concepts.Documentation (goal)

--- a/code/drasil-example/nopcm/lib/Drasil/NoPCM/Requirements.hs
+++ b/code/drasil-example/nopcm/lib/Drasil/NoPCM/Requirements.hs
@@ -2,7 +2,6 @@ module Drasil.NoPCM.Requirements (funcReqs, inputInitValsTable) where
 
 import Language.Drasil
 import Drasil.DocLang (mkInputPropsTable)
-import Utils.Drasil
 import Utils.Drasil.Concepts
 
 import Data.Drasil.Concepts.Documentation (funcReqDom, input_, value)

--- a/code/drasil-example/pdcontroller/lib/Drasil/PDController/Assumptions.hs
+++ b/code/drasil-example/pdcontroller/lib/Drasil/PDController/Assumptions.hs
@@ -6,7 +6,6 @@ import Data.Drasil.Concepts.PhysicalProperties (mass)
 import Data.Drasil.SI_Units (kilogram)
 import Drasil.PDController.Concepts
 import Language.Drasil
-import Utils.Drasil
 import Utils.Drasil.Concepts
 import qualified Utils.Drasil.Sentence as S
 

--- a/code/drasil-example/pdcontroller/lib/Drasil/PDController/Assumptions.hs
+++ b/code/drasil-example/pdcontroller/lib/Drasil/PDController/Assumptions.hs
@@ -7,7 +7,7 @@ import Data.Drasil.SI_Units (kilogram)
 import Drasil.PDController.Concepts
 import Language.Drasil
 import Utils.Drasil.Concepts
-import qualified Utils.Drasil.Sentence as S
+import qualified Language.Drasil.Sentence.Combinators as S
 
 assumptions :: [ConceptInstance]
 assumptions

--- a/code/drasil-example/pdcontroller/lib/Drasil/PDController/Body.hs
+++ b/code/drasil-example/pdcontroller/lib/Drasil/PDController/Body.hs
@@ -4,7 +4,7 @@ import Language.Drasil
 import Drasil.SRSDocument
 import qualified Drasil.DocLang.SRS as SRS (inModel)
 import Theory.Drasil (DataDefinition, GenDefn, InstanceModel, TheoryModel)
-import qualified Utils.Drasil.Sentence as S
+import qualified Language.Drasil.Sentence.Combinators as S
 
 import Data.Drasil.Concepts.Documentation (doccon, doccon', srsDomains)
 import qualified Data.Drasil.Concepts.Documentation as Doc (srs)

--- a/code/drasil-example/pdcontroller/lib/Drasil/PDController/Changes.hs
+++ b/code/drasil-example/pdcontroller/lib/Drasil/PDController/Changes.hs
@@ -6,7 +6,6 @@ import Data.Drasil.Concepts.PhysicalProperties (mass)
 import Drasil.PDController.Assumptions
 import Drasil.PDController.Concepts
 import Language.Drasil
-import Utils.Drasil
 import Utils.Drasil.Concepts
 
 likelyChgs :: [ConceptInstance]

--- a/code/drasil-example/pdcontroller/lib/Drasil/PDController/DataDefs.hs
+++ b/code/drasil-example/pdcontroller/lib/Drasil/PDController/DataDefs.hs
@@ -9,7 +9,6 @@ import Drasil.PDController.TModel
 import Data.Drasil.Concepts.Math (equation)
 import Language.Drasil
 import Theory.Drasil (DataDefinition, ddE)
-import Utils.Drasil
 import Utils.Drasil.Concepts
 import qualified Utils.Drasil.Sentence as S
 

--- a/code/drasil-example/pdcontroller/lib/Drasil/PDController/DataDefs.hs
+++ b/code/drasil-example/pdcontroller/lib/Drasil/PDController/DataDefs.hs
@@ -10,7 +10,7 @@ import Data.Drasil.Concepts.Math (equation)
 import Language.Drasil
 import Theory.Drasil (DataDefinition, ddE)
 import Utils.Drasil.Concepts
-import qualified Utils.Drasil.Sentence as S
+import qualified Language.Drasil.Sentence.Combinators as S
 
 dataDefinitions :: [DataDefinition]
 dataDefinitions = [ddErrSig, ddPropCtrl, ddDerivCtrl, ddCtrlVar]

--- a/code/drasil-example/pdcontroller/lib/Drasil/PDController/GenDefs.hs
+++ b/code/drasil-example/pdcontroller/lib/Drasil/PDController/GenDefs.hs
@@ -9,7 +9,6 @@ import Drasil.PDController.References
 import Drasil.PDController.TModel
 import Language.Drasil
 import Theory.Drasil (GenDefn, gd, othModel')
-import Utils.Drasil
 import Utils.Drasil.Concepts
 import qualified Utils.Drasil.Sentence as S
 import Data.Drasil.Citations ( pidWiki )

--- a/code/drasil-example/pdcontroller/lib/Drasil/PDController/GenDefs.hs
+++ b/code/drasil-example/pdcontroller/lib/Drasil/PDController/GenDefs.hs
@@ -10,7 +10,7 @@ import Drasil.PDController.TModel
 import Language.Drasil
 import Theory.Drasil (GenDefn, gd, othModel')
 import Utils.Drasil.Concepts
-import qualified Utils.Drasil.Sentence as S
+import qualified Language.Drasil.Sentence.Combinators as S
 import Data.Drasil.Citations ( pidWiki )
 import Drasil.PDController.Unitals
 

--- a/code/drasil-example/pdcontroller/lib/Drasil/PDController/GenSysDesc.hs
+++ b/code/drasil-example/pdcontroller/lib/Drasil/PDController/GenSysDesc.hs
@@ -5,7 +5,6 @@ import Data.Drasil.Concepts.Documentation
 
 import Drasil.PDController.Concepts
 import Language.Drasil
-import Utils.Drasil
 import Utils.Drasil.Concepts
 
 gsdSysContextFig :: LabelledContent

--- a/code/drasil-example/pdcontroller/lib/Drasil/PDController/IModel.hs
+++ b/code/drasil-example/pdcontroller/lib/Drasil/PDController/IModel.hs
@@ -11,7 +11,7 @@ import Drasil.PDController.TModel
 import Language.Drasil
 import Theory.Drasil (InstanceModel, im, qwC, deModel')
 import Utils.Drasil.Concepts
-import qualified Utils.Drasil.Sentence as S
+import qualified Language.Drasil.Sentence.Combinators as S
 import Drasil.PDController.Unitals
 
 instanceModels :: [InstanceModel]

--- a/code/drasil-example/pdcontroller/lib/Drasil/PDController/IModel.hs
+++ b/code/drasil-example/pdcontroller/lib/Drasil/PDController/IModel.hs
@@ -10,7 +10,6 @@ import Drasil.PDController.References
 import Drasil.PDController.TModel
 import Language.Drasil
 import Theory.Drasil (InstanceModel, im, qwC, deModel')
-import Utils.Drasil
 import Utils.Drasil.Concepts
 import qualified Utils.Drasil.Sentence as S
 import Drasil.PDController.Unitals

--- a/code/drasil-example/pdcontroller/lib/Drasil/PDController/IModel.hs
+++ b/code/drasil-example/pdcontroller/lib/Drasil/PDController/IModel.hs
@@ -10,6 +10,7 @@ import Drasil.PDController.References
 import Drasil.PDController.TModel
 import Language.Drasil
 import Theory.Drasil (InstanceModel, im, qwC, deModel')
+import Utils.Drasil (weave)
 import Utils.Drasil.Concepts
 import qualified Language.Drasil.Sentence.Combinators as S
 import Drasil.PDController.Unitals

--- a/code/drasil-example/pdcontroller/lib/Drasil/PDController/IntroSection.hs
+++ b/code/drasil-example/pdcontroller/lib/Drasil/PDController/IntroSection.hs
@@ -4,7 +4,6 @@ import Data.Drasil.Citations (smithLai2005)
 
 import Drasil.PDController.Concepts
 import Language.Drasil
-import Utils.Drasil
 import Utils.Drasil.Concepts
 import qualified Utils.Drasil.Sentence as S
 

--- a/code/drasil-example/pdcontroller/lib/Drasil/PDController/IntroSection.hs
+++ b/code/drasil-example/pdcontroller/lib/Drasil/PDController/IntroSection.hs
@@ -5,7 +5,7 @@ import Data.Drasil.Citations (smithLai2005)
 import Drasil.PDController.Concepts
 import Language.Drasil
 import Utils.Drasil.Concepts
-import qualified Utils.Drasil.Sentence as S
+import qualified Language.Drasil.Sentence.Combinators as S
 
 introPara, introPurposeOfDoc, introscopeOfReq :: Sentence
 introPara

--- a/code/drasil-example/pdcontroller/lib/Drasil/PDController/Requirements.hs
+++ b/code/drasil-example/pdcontroller/lib/Drasil/PDController/Requirements.hs
@@ -9,7 +9,6 @@ import Drasil.PDController.Concepts
 import Drasil.PDController.IModel
 
 import Language.Drasil
-import Utils.Drasil
 
 funcReqs :: [ConceptInstance]
 funcReqs = [verifyInputs, calculateValues, outputValues]

--- a/code/drasil-example/pdcontroller/lib/Drasil/PDController/SpSysDesc.hs
+++ b/code/drasil-example/pdcontroller/lib/Drasil/PDController/SpSysDesc.hs
@@ -4,7 +4,6 @@ import Data.Drasil.Concepts.Documentation (goalStmtDom, physicalSystem)
 
 import Drasil.PDController.Concepts
 import Language.Drasil
-import Utils.Drasil
 import Utils.Drasil.Concepts
 
 sysProblemDesc :: Sentence

--- a/code/drasil-example/pdcontroller/lib/Drasil/PDController/TModel.hs
+++ b/code/drasil-example/pdcontroller/lib/Drasil/PDController/TModel.hs
@@ -9,7 +9,6 @@ import Drasil.PDController.References
 import Language.Drasil
 import qualified Language.Drasil as DrasilLang
 import Theory.Drasil (TheoryModel, tm, othModel')
-import Utils.Drasil
 import Utils.Drasil.Concepts
 import qualified Utils.Drasil.Sentence as S
 import Data.Drasil.Citations(laplaceWiki)

--- a/code/drasil-example/pdcontroller/lib/Drasil/PDController/TModel.hs
+++ b/code/drasil-example/pdcontroller/lib/Drasil/PDController/TModel.hs
@@ -10,7 +10,7 @@ import Language.Drasil
 import qualified Language.Drasil as DrasilLang
 import Theory.Drasil (TheoryModel, tm, othModel')
 import Utils.Drasil.Concepts
-import qualified Utils.Drasil.Sentence as S
+import qualified Language.Drasil.Sentence.Combinators as S
 import Data.Drasil.Citations(laplaceWiki)
 import Drasil.PDController.Unitals
 

--- a/code/drasil-example/projectile/lib/Drasil/Projectile/Assumptions.hs
+++ b/code/drasil-example/projectile/lib/Drasil/Projectile/Assumptions.hs
@@ -6,7 +6,7 @@ module Drasil.Projectile.Assumptions (accelYGravity, accelXZero, cartSyst,
 import Language.Drasil
 import Utils.Drasil.Concepts
 import qualified Utils.Drasil.NounPhrase as NP
-import qualified Utils.Drasil.Sentence as S
+import qualified Language.Drasil.Sentence.Combinators as S
 
 import qualified Drasil.DocLang.SRS as SRS (valsOfAuxCons)
 

--- a/code/drasil-example/projectile/lib/Drasil/Projectile/Assumptions.hs
+++ b/code/drasil-example/projectile/lib/Drasil/Projectile/Assumptions.hs
@@ -4,7 +4,6 @@ module Drasil.Projectile.Assumptions (accelYGravity, accelXZero, cartSyst,
   posXDirection, targetXAxis, timeStartZero, twoDMotion, yAxisGravity) where
 
 import Language.Drasil
-import Utils.Drasil
 import Utils.Drasil.Concepts
 import qualified Utils.Drasil.NounPhrase as NP
 import qualified Utils.Drasil.Sentence as S

--- a/code/drasil-example/projectile/lib/Drasil/Projectile/Body.hs
+++ b/code/drasil-example/projectile/lib/Drasil/Projectile/Body.hs
@@ -4,7 +4,7 @@ import Language.Drasil
 import Drasil.SRSDocument
 import Utils.Drasil.Concepts
 import qualified Utils.Drasil.NounPhrase as NP
-import qualified Utils.Drasil.Sentence as S
+import qualified Language.Drasil.Sentence.Combinators as S
 
 import Data.Drasil.Concepts.Computation (inValue)
 import Data.Drasil.Concepts.Documentation (analysis, doccon, doccon', physics,

--- a/code/drasil-example/projectile/lib/Drasil/Projectile/Body.hs
+++ b/code/drasil-example/projectile/lib/Drasil/Projectile/Body.hs
@@ -2,7 +2,6 @@ module Drasil.Projectile.Body (printSetting, si, srs, projectileTitle, fullSI) w
 
 import Language.Drasil
 import Drasil.SRSDocument
-import Utils.Drasil
 import Utils.Drasil.Concepts
 import qualified Utils.Drasil.NounPhrase as NP
 import qualified Utils.Drasil.Sentence as S

--- a/code/drasil-example/projectile/lib/Drasil/Projectile/Concepts.hs
+++ b/code/drasil-example/projectile/lib/Drasil/Projectile/Concepts.hs
@@ -1,7 +1,6 @@
 module Drasil.Projectile.Concepts where
 
 import Language.Drasil
-import Utils.Drasil
 import Utils.Drasil.Concepts
 import qualified Utils.Drasil.Sentence as S
 

--- a/code/drasil-example/projectile/lib/Drasil/Projectile/Concepts.hs
+++ b/code/drasil-example/projectile/lib/Drasil/Projectile/Concepts.hs
@@ -2,7 +2,7 @@ module Drasil.Projectile.Concepts where
 
 import Language.Drasil
 import Utils.Drasil.Concepts
-import qualified Utils.Drasil.Sentence as S
+import qualified Language.Drasil.Sentence.Combinators as S
 
 import Data.Drasil.Concepts.Documentation (constant)
 import Data.Drasil.Concepts.Math (angle)

--- a/code/drasil-example/projectile/lib/Drasil/Projectile/DataDefs.hs
+++ b/code/drasil-example/projectile/lib/Drasil/Projectile/DataDefs.hs
@@ -2,7 +2,7 @@ module Drasil.Projectile.DataDefs (dataDefs, speedIX, speedIY) where
 
 import Prelude hiding (sin, cos)
 import Language.Drasil
-import qualified Utils.Drasil.Sentence as S
+import qualified Language.Drasil.Sentence.Combinators as S
 
 import Theory.Drasil (DataDefinition, ddENoRefs)
 

--- a/code/drasil-example/projectile/lib/Drasil/Projectile/Expressions.hs
+++ b/code/drasil-example/projectile/lib/Drasil/Projectile/Expressions.hs
@@ -7,7 +7,6 @@ module Drasil.Projectile.Expressions where
 import Prelude hiding (cos, sin)
 
 import Language.Drasil
-import Utils.Drasil
 import qualified Data.Drasil.Quantities.Physics as QP (iSpeed,
   constAccel, xConstAccel, yConstAccel, ixPos, iyPos)
 import Data.Drasil.Quantities.Physics (gravitationalAccelConst, 

--- a/code/drasil-example/projectile/lib/Drasil/Projectile/GenDefs.hs
+++ b/code/drasil-example/projectile/lib/Drasil/Projectile/GenDefs.hs
@@ -5,7 +5,7 @@ import Prelude hiding (cos, sin)
 import Language.Drasil
 import Theory.Drasil (GenDefn, TheoryModel, gd, gdNoRefs, equationalModel')
 import Utils.Drasil.Concepts
-import qualified Utils.Drasil.Sentence as S
+import qualified Language.Drasil.Sentence.Combinators as S
 
 import Data.Drasil.Concepts.Documentation (coordinate, symbol_)
 import Data.Drasil.Concepts.Math (cartesian, equation, vector)

--- a/code/drasil-example/projectile/lib/Drasil/Projectile/GenDefs.hs
+++ b/code/drasil-example/projectile/lib/Drasil/Projectile/GenDefs.hs
@@ -4,7 +4,6 @@ module Drasil.Projectile.GenDefs (genDefns, posVecGD) where
 import Prelude hiding (cos, sin)
 import Language.Drasil
 import Theory.Drasil (GenDefn, TheoryModel, gd, gdNoRefs, equationalModel')
-import Utils.Drasil
 import Utils.Drasil.Concepts
 import qualified Utils.Drasil.Sentence as S
 

--- a/code/drasil-example/projectile/lib/Drasil/Projectile/GenDefs.hs
+++ b/code/drasil-example/projectile/lib/Drasil/Projectile/GenDefs.hs
@@ -4,6 +4,7 @@ module Drasil.Projectile.GenDefs (genDefns, posVecGD) where
 import Prelude hiding (cos, sin)
 import Language.Drasil
 import Theory.Drasil (GenDefn, TheoryModel, gd, gdNoRefs, equationalModel')
+import Utils.Drasil (weave)
 import Utils.Drasil.Concepts
 import qualified Language.Drasil.Sentence.Combinators as S
 

--- a/code/drasil-example/projectile/lib/Drasil/Projectile/IMods.hs
+++ b/code/drasil-example/projectile/lib/Drasil/Projectile/IMods.hs
@@ -4,6 +4,7 @@ import Prelude hiding (cos, sin)
 
 import Language.Drasil
 import Theory.Drasil (InstanceModel, imNoDerivNoRefs, imNoRefs, qwC, equationalModelN)
+import Utils.Drasil (weave)
 import Utils.Drasil.Concepts
 import qualified Language.Drasil.Sentence.Combinators as S
 

--- a/code/drasil-example/projectile/lib/Drasil/Projectile/IMods.hs
+++ b/code/drasil-example/projectile/lib/Drasil/Projectile/IMods.hs
@@ -5,7 +5,7 @@ import Prelude hiding (cos, sin)
 import Language.Drasil
 import Theory.Drasil (InstanceModel, imNoDerivNoRefs, imNoRefs, qwC, equationalModelN)
 import Utils.Drasil.Concepts
-import qualified Utils.Drasil.Sentence as S
+import qualified Language.Drasil.Sentence.Combinators as S
 
 import qualified Drasil.DocLang.SRS as SRS (valsOfAuxCons)
 

--- a/code/drasil-example/projectile/lib/Drasil/Projectile/IMods.hs
+++ b/code/drasil-example/projectile/lib/Drasil/Projectile/IMods.hs
@@ -4,7 +4,6 @@ import Prelude hiding (cos, sin)
 
 import Language.Drasil
 import Theory.Drasil (InstanceModel, imNoDerivNoRefs, imNoRefs, qwC, equationalModelN)
-import Utils.Drasil
 import Utils.Drasil.Concepts
 import qualified Utils.Drasil.Sentence as S
 

--- a/code/drasil-example/projectile/lib/Drasil/Projectile/Lesson/Analysis.hs
+++ b/code/drasil-example/projectile/lib/Drasil/Projectile/Lesson/Analysis.hs
@@ -12,7 +12,7 @@ import Drasil.Projectile.Concepts (projectile)
 import Language.Drasil
 import Language.Drasil.ShortHands
 
-import qualified Utils.Drasil.Sentence as S
+import qualified Language.Drasil.Sentence.Combinators as S
 
 import Drasil.Projectile.Derivations (horMotionEqn1, horMotionEqn2)
 

--- a/code/drasil-example/projectile/lib/Drasil/Projectile/Lesson/Analysis.hs
+++ b/code/drasil-example/projectile/lib/Drasil/Projectile/Lesson/Analysis.hs
@@ -11,7 +11,6 @@ import qualified Data.Drasil.Quantities.Physics as QP (yVel)
 import Drasil.Projectile.Concepts (projectile)
 import Language.Drasil
 import Language.Drasil.ShortHands
-import Utils.Drasil
 
 import qualified Utils.Drasil.Sentence as S
 

--- a/code/drasil-example/projectile/lib/Drasil/Projectile/Lesson/Body.hs
+++ b/code/drasil-example/projectile/lib/Drasil/Projectile/Lesson/Body.hs
@@ -7,7 +7,7 @@ import Database.Drasil (Block, ChunkDB, ReferenceDB, SystemInformation(SI),
   cdb, rdb, refdb, _authors, _purpose, _concepts, _constants, _constraints, 
   _datadefs, _instModels, _configFiles, _defSequence, _inputs, _kind, 
   _outputs, _quants, _sys, _sysinfodb, _usedinfodb)
-import qualified Utils.Drasil.Sentence as S
+import qualified Language.Drasil.Sentence.Combinators as S
 
 -- TODO: Add export parameters in a module
 import Drasil.DocLang (mkNb, NBDecl, NbSection(BibSec, IntrodSec, BodySec), 

--- a/code/drasil-example/projectile/lib/Drasil/Projectile/Lesson/Body.hs
+++ b/code/drasil-example/projectile/lib/Drasil/Projectile/Lesson/Body.hs
@@ -7,7 +7,6 @@ import Database.Drasil (Block, ChunkDB, ReferenceDB, SystemInformation(SI),
   cdb, rdb, refdb, _authors, _purpose, _concepts, _constants, _constraints, 
   _datadefs, _instModels, _configFiles, _defSequence, _inputs, _kind, 
   _outputs, _quants, _sys, _sysinfodb, _usedinfodb)
-import Utils.Drasil
 import qualified Utils.Drasil.Sentence as S
 
 -- TODO: Add export parameters in a module

--- a/code/drasil-example/projectile/lib/Drasil/Projectile/Lesson/IntroSection.hs
+++ b/code/drasil-example/projectile/lib/Drasil/Projectile/Lesson/IntroSection.hs
@@ -3,7 +3,7 @@ module Drasil.Projectile.Lesson.IntroSection where
 import Data.Drasil.Concepts.Physics (force, motion)
 import Drasil.Projectile.Concepts (projectile, projMotion)
 
-import qualified Utils.Drasil.Sentence as S
+import qualified Language.Drasil.Sentence.Combinators as S
 import Language.Drasil
 
 introContext :: Contents

--- a/code/drasil-example/projectile/lib/Drasil/Projectile/Lesson/IntroSection.hs
+++ b/code/drasil-example/projectile/lib/Drasil/Projectile/Lesson/IntroSection.hs
@@ -3,7 +3,6 @@ module Drasil.Projectile.Lesson.IntroSection where
 import Data.Drasil.Concepts.Physics (force, motion)
 import Drasil.Projectile.Concepts (projectile, projMotion)
 
-import Utils.Drasil (foldlSP, foldlSP_, foldlSent, enumBulletU)
 import qualified Utils.Drasil.Sentence as S
 import Language.Drasil
 

--- a/code/drasil-example/projectile/lib/Drasil/Projectile/Lesson/Motion.hs
+++ b/code/drasil-example/projectile/lib/Drasil/Projectile/Lesson/Motion.hs
@@ -1,6 +1,7 @@
 module Drasil.Projectile.Lesson.Motion where
 
 import Data.List
+import Utils.Drasil (weave)
 
 import qualified Drasil.DocLang.Notebook as NB (summary, hormotion, vermotion)
 

--- a/code/drasil-example/projectile/lib/Drasil/Projectile/Lesson/Motion.hs
+++ b/code/drasil-example/projectile/lib/Drasil/Projectile/Lesson/Motion.hs
@@ -16,7 +16,6 @@ import qualified Data.Drasil.Quantities.Physics as QP (ixDist, iyDist, iSpeed, i
 import Data.Drasil.Concepts.Documentation (coordinateSystem)
 import Language.Drasil
 import Language.Drasil.ShortHands
-import Utils.Drasil
 import Utils.Drasil.Concepts
 import qualified Utils.Drasil.Sentence as S
 import Data.Drasil.SI_Units (s_2)

--- a/code/drasil-example/projectile/lib/Drasil/Projectile/Lesson/Motion.hs
+++ b/code/drasil-example/projectile/lib/Drasil/Projectile/Lesson/Motion.hs
@@ -17,7 +17,7 @@ import Data.Drasil.Concepts.Documentation (coordinateSystem)
 import Language.Drasil
 import Language.Drasil.ShortHands
 import Utils.Drasil.Concepts
-import qualified Utils.Drasil.Sentence as S
+import qualified Language.Drasil.Sentence.Combinators as S
 import Data.Drasil.SI_Units (s_2)
 
 motionContextP1, motionContextP2 :: Contents

--- a/code/drasil-example/projectile/lib/Drasil/Projectile/Lesson/Review.hs
+++ b/code/drasil-example/projectile/lib/Drasil/Projectile/Lesson/Review.hs
@@ -5,7 +5,6 @@ import qualified Drasil.Projectile.Expressions as E (lcrectVel, lcrectPos, lcrec
 import Drasil.Projectile.Concepts (projectile)
 import qualified Data.Drasil.Quantities.Physics as QP (speed, time, scalarPos, iPos, iSpeed, constAccel)
 import Language.Drasil
-import Utils.Drasil
 import qualified Utils.Drasil.Sentence as S
 
 reviewContent :: [Contents]

--- a/code/drasil-example/projectile/lib/Drasil/Projectile/Lesson/Review.hs
+++ b/code/drasil-example/projectile/lib/Drasil/Projectile/Lesson/Review.hs
@@ -5,7 +5,7 @@ import qualified Drasil.Projectile.Expressions as E (lcrectVel, lcrectPos, lcrec
 import Drasil.Projectile.Concepts (projectile)
 import qualified Data.Drasil.Quantities.Physics as QP (speed, time, scalarPos, iPos, iSpeed, constAccel)
 import Language.Drasil
-import qualified Utils.Drasil.Sentence as S
+import qualified Language.Drasil.Sentence.Combinators as S
 
 reviewContent :: [Contents]
 reviewContent = [reviewContextP1, LlC E.lcrectVel, LlC E.lcrectPos, LlC E.lcrectNoTime, reviewEqns, reviewContextP2]

--- a/code/drasil-example/projectile/lib/Drasil/Projectile/Requirements.hs
+++ b/code/drasil-example/projectile/lib/Drasil/Projectile/Requirements.hs
@@ -2,7 +2,6 @@ module Drasil.Projectile.Requirements (funcReqs, nonfuncReqs) where
 
 import Language.Drasil
 import Drasil.DocLang.SRS (datCon, propCorSol)
-import Utils.Drasil
 import Utils.Drasil.Concepts
 import qualified Utils.Drasil.Sentence as S
 

--- a/code/drasil-example/projectile/lib/Drasil/Projectile/Requirements.hs
+++ b/code/drasil-example/projectile/lib/Drasil/Projectile/Requirements.hs
@@ -3,7 +3,7 @@ module Drasil.Projectile.Requirements (funcReqs, nonfuncReqs) where
 import Language.Drasil
 import Drasil.DocLang.SRS (datCon, propCorSol)
 import Utils.Drasil.Concepts
-import qualified Utils.Drasil.Sentence as S
+import qualified Language.Drasil.Sentence.Combinators as S
 
 import Data.Drasil.Concepts.Computation (inValue)
 import Data.Drasil.Concepts.Documentation (assumption, code, datumConstraint,

--- a/code/drasil-example/sglpendulum/lib/Drasil/SglPendulum/Body.hs
+++ b/code/drasil-example/sglpendulum/lib/Drasil/SglPendulum/Body.hs
@@ -6,7 +6,7 @@ import Theory.Drasil (TheoryModel)
 import Drasil.SRSDocument
 import qualified Drasil.DocLang.SRS as SRS
 import Utils.Drasil.Concepts (the)
-import qualified Utils.Drasil.Sentence as S
+import qualified Language.Drasil.Sentence.Combinators as S
 
 import Data.Drasil.People (olu)
 import Data.Drasil.SI_Units (metre, second, newton, kilogram, degree, radian, hertz)

--- a/code/drasil-example/sglpendulum/lib/Drasil/SglPendulum/DataDefs.hs
+++ b/code/drasil-example/sglpendulum/lib/Drasil/SglPendulum/DataDefs.hs
@@ -3,7 +3,7 @@ module Drasil.SglPendulum.DataDefs (dataDefs, positionIY, positionIX, angFrequen
 
 import Prelude hiding (sin, cos, sqrt)
 import Language.Drasil
-import qualified Utils.Drasil.Sentence as S
+import qualified Language.Drasil.Sentence.Combinators as S
 import Data.Drasil.SI_Units (second)
 import Theory.Drasil (DataDefinition, ddENoRefs)
 import Drasil.SglPendulum.Figures (figMotion)

--- a/code/drasil-example/sglpendulum/lib/Drasil/SglPendulum/GenDefs.hs
+++ b/code/drasil-example/sglpendulum/lib/Drasil/SglPendulum/GenDefs.hs
@@ -10,6 +10,7 @@ import Language.Drasil
 import Theory.Drasil (GenDefn, gdNoRefs,
     equationalModel', equationalModelU, equationalRealmU,
     MultiDefn, mkDefiningExpr, mkMultiDefnForQuant)
+import Utils.Drasil (weave)
 import Utils.Drasil.Concepts
 import qualified Language.Drasil.Sentence.Combinators as S
 import qualified Utils.Drasil.NounPhrase as NP

--- a/code/drasil-example/sglpendulum/lib/Drasil/SglPendulum/GenDefs.hs
+++ b/code/drasil-example/sglpendulum/lib/Drasil/SglPendulum/GenDefs.hs
@@ -10,7 +10,6 @@ import Language.Drasil
 import Theory.Drasil (GenDefn, gdNoRefs,
     equationalModel', equationalModelU, equationalRealmU,
     MultiDefn, mkDefiningExpr, mkMultiDefnForQuant)
-import Utils.Drasil
 import Utils.Drasil.Concepts
 import qualified Utils.Drasil.Sentence as S
 import qualified Utils.Drasil.NounPhrase as NP

--- a/code/drasil-example/sglpendulum/lib/Drasil/SglPendulum/GenDefs.hs
+++ b/code/drasil-example/sglpendulum/lib/Drasil/SglPendulum/GenDefs.hs
@@ -11,7 +11,7 @@ import Theory.Drasil (GenDefn, gdNoRefs,
     equationalModel', equationalModelU, equationalRealmU,
     MultiDefn, mkDefiningExpr, mkMultiDefnForQuant)
 import Utils.Drasil.Concepts
-import qualified Utils.Drasil.Sentence as S
+import qualified Language.Drasil.Sentence.Combinators as S
 import qualified Utils.Drasil.NounPhrase as NP
 
 -- import Data.Drasil.Concepts.Documentation (coordinate, symbol_)

--- a/code/drasil-example/sglpendulum/lib/Drasil/SglPendulum/Goals.hs
+++ b/code/drasil-example/sglpendulum/lib/Drasil/SglPendulum/Goals.hs
@@ -3,7 +3,7 @@
 
  import Language.Drasil
  import Utils.Drasil.Concepts
- import qualified Utils.Drasil.Sentence as S
+ import qualified Language.Drasil.Sentence.Combinators as S
  import qualified Utils.Drasil.NounPhrase as NP
 
  import Data.Drasil.Concepts.Documentation (goalStmtDom)

--- a/code/drasil-example/sglpendulum/lib/Drasil/SglPendulum/IMods.hs
+++ b/code/drasil-example/sglpendulum/lib/Drasil/SglPendulum/IMods.hs
@@ -5,7 +5,6 @@ import Prelude hiding (cos, sin)
 
 import Language.Drasil
 import Theory.Drasil
-import Utils.Drasil
 import Utils.Drasil.Concepts
 import qualified Utils.Drasil.Sentence as S
 import qualified Utils.Drasil.NounPhrase as NP

--- a/code/drasil-example/sglpendulum/lib/Drasil/SglPendulum/IMods.hs
+++ b/code/drasil-example/sglpendulum/lib/Drasil/SglPendulum/IMods.hs
@@ -6,7 +6,7 @@ import Prelude hiding (cos, sin)
 import Language.Drasil
 import Theory.Drasil
 import Utils.Drasil.Concepts
-import qualified Utils.Drasil.Sentence as S
+import qualified Language.Drasil.Sentence.Combinators as S
 import qualified Utils.Drasil.NounPhrase as NP
 import Data.Drasil.Quantities.Physics (gravitationalAccel,
          angularAccel, momentOfInertia,

--- a/code/drasil-example/sglpendulum/lib/Drasil/SglPendulum/IMods.hs
+++ b/code/drasil-example/sglpendulum/lib/Drasil/SglPendulum/IMods.hs
@@ -5,6 +5,7 @@ import Prelude hiding (cos, sin)
 
 import Language.Drasil
 import Theory.Drasil
+import Utils.Drasil (weave)
 import Utils.Drasil.Concepts
 import qualified Language.Drasil.Sentence.Combinators as S
 import qualified Utils.Drasil.NounPhrase as NP

--- a/code/drasil-example/sglpendulum/lib/Drasil/SglPendulum/Requirements.hs
+++ b/code/drasil-example/sglpendulum/lib/Drasil/SglPendulum/Requirements.hs
@@ -1,7 +1,6 @@
 module Drasil.SglPendulum.Requirements where
 
 import Language.Drasil
-import Utils.Drasil
 import qualified Utils.Drasil.Sentence as S
 import Data.Drasil.Concepts.Documentation (funcReqDom, output_, value)
 import Drasil.SglPendulum.IMods (angularDisplacementIM)

--- a/code/drasil-example/sglpendulum/lib/Drasil/SglPendulum/Requirements.hs
+++ b/code/drasil-example/sglpendulum/lib/Drasil/SglPendulum/Requirements.hs
@@ -1,7 +1,7 @@
 module Drasil.SglPendulum.Requirements where
 
 import Language.Drasil
-import qualified Utils.Drasil.Sentence as S
+import qualified Language.Drasil.Sentence.Combinators as S
 import Data.Drasil.Concepts.Documentation (funcReqDom, output_, value)
 import Drasil.SglPendulum.IMods (angularDisplacementIM)
 import Drasil.SglPendulum.Unitals (lenRod, pendDisplacementAngle)

--- a/code/drasil-example/ssp/lib/Drasil/SSP/Assumptions.hs
+++ b/code/drasil-example/ssp/lib/Drasil/SSP/Assumptions.hs
@@ -4,7 +4,7 @@ module Drasil.SSP.Assumptions where
 import Language.Drasil
 import Utils.Drasil.Concepts
 import qualified Utils.Drasil.NounPhrase as NP
-import qualified Utils.Drasil.Sentence as S
+import qualified Language.Drasil.Sentence.Combinators as S
 
 import Drasil.SSP.Defs (plnStrn, slpSrf, slopeSrf, slope,
   soil, soilPrpty, intrslce, slice, waterTable)

--- a/code/drasil-example/ssp/lib/Drasil/SSP/Assumptions.hs
+++ b/code/drasil-example/ssp/lib/Drasil/SSP/Assumptions.hs
@@ -2,7 +2,6 @@
 module Drasil.SSP.Assumptions where
 
 import Language.Drasil
-import Utils.Drasil
 import Utils.Drasil.Concepts
 import qualified Utils.Drasil.NounPhrase as NP
 import qualified Utils.Drasil.Sentence as S

--- a/code/drasil-example/ssp/lib/Drasil/SSP/Body.hs
+++ b/code/drasil-example/ssp/lib/Drasil/SSP/Body.hs
@@ -11,7 +11,7 @@ import Prelude hiding (sin, cos, tan)
 import Data.Maybe (mapMaybe)
 import Utils.Drasil.Concepts
 import qualified Utils.Drasil.NounPhrase as NP
-import qualified Utils.Drasil.Sentence as S
+import qualified Language.Drasil.Sentence.Combinators as S
 
 import Data.Drasil.Concepts.Documentation as Doc (analysis, assumption,
   constant, document, effect, endUser, environment,

--- a/code/drasil-example/ssp/lib/Drasil/SSP/Body.hs
+++ b/code/drasil-example/ssp/lib/Drasil/SSP/Body.hs
@@ -9,7 +9,6 @@ import Theory.Drasil (qdEFromDD)
 
 import Prelude hiding (sin, cos, tan)
 import Data.Maybe (mapMaybe)
-import Utils.Drasil
 import Utils.Drasil.Concepts
 import qualified Utils.Drasil.NounPhrase as NP
 import qualified Utils.Drasil.Sentence as S

--- a/code/drasil-example/ssp/lib/Drasil/SSP/Changes.hs
+++ b/code/drasil-example/ssp/lib/Drasil/SSP/Changes.hs
@@ -3,7 +3,6 @@ module Drasil.SSP.Changes (likelyChgs, unlikelyChgs) where
 -- A list of likely and unlikely changes for the SSP example
 
 import Language.Drasil
-import Utils.Drasil
 import Utils.Drasil.Concepts
 import qualified Utils.Drasil.Sentence as S
 

--- a/code/drasil-example/ssp/lib/Drasil/SSP/Changes.hs
+++ b/code/drasil-example/ssp/lib/Drasil/SSP/Changes.hs
@@ -4,7 +4,7 @@ module Drasil.SSP.Changes (likelyChgs, unlikelyChgs) where
 
 import Language.Drasil
 import Utils.Drasil.Concepts
-import qualified Utils.Drasil.Sentence as S
+import qualified Language.Drasil.Sentence.Combinators as S
 
 import Data.Drasil.Concepts.Documentation (analysis, likeChgDom, model, system, unlikeChgDom)
 import Data.Drasil.Concepts.Math (calculation, zDir)

--- a/code/drasil-example/ssp/lib/Drasil/SSP/DataDefs.hs
+++ b/code/drasil-example/ssp/lib/Drasil/SSP/DataDefs.hs
@@ -6,7 +6,6 @@ module Drasil.SSP.DataDefs (dataDefs, intersliceWtrF, angleA, angleB, lengthB,
 import Prelude hiding (cos, sin, tan)
 import Language.Drasil
 import Theory.Drasil (DataDefinition, ddE)
-import Utils.Drasil
 import qualified Utils.Drasil.Sentence as S
 
 import Data.Drasil.Concepts.Documentation (assumption)

--- a/code/drasil-example/ssp/lib/Drasil/SSP/DataDefs.hs
+++ b/code/drasil-example/ssp/lib/Drasil/SSP/DataDefs.hs
@@ -6,7 +6,7 @@ module Drasil.SSP.DataDefs (dataDefs, intersliceWtrF, angleA, angleB, lengthB,
 import Prelude hiding (cos, sin, tan)
 import Language.Drasil
 import Theory.Drasil (DataDefinition, ddE)
-import qualified Utils.Drasil.Sentence as S
+import qualified Language.Drasil.Sentence.Combinators as S
 
 import Data.Drasil.Concepts.Documentation (assumption)
 import Data.Drasil.Concepts.Math (equation)

--- a/code/drasil-example/ssp/lib/Drasil/SSP/Defs.hs
+++ b/code/drasil-example/ssp/lib/Drasil/SSP/Defs.hs
@@ -3,7 +3,7 @@ module Drasil.SSP.Defs where --export all of this file
 import Language.Drasil
 import Data.Drasil.Domains (civilEng)
 import Utils.Drasil.Concepts
-import qualified Utils.Drasil.Sentence as S
+import qualified Language.Drasil.Sentence.Combinators as S
 
 import Data.Drasil.Concepts.Documentation (analysis, assumption, goalStmt,
   likelyChg, physSyst, property, requirement, safety, srs, typUnc, unlikelyChg)

--- a/code/drasil-example/ssp/lib/Drasil/SSP/GenDefs.hs
+++ b/code/drasil-example/ssp/lib/Drasil/SSP/GenDefs.hs
@@ -8,7 +8,6 @@ import Prelude hiding (sin, cos, tan)
 import qualified Data.List.NonEmpty as NE
 import Language.Drasil
 import Theory.Drasil
-import Utils.Drasil
 import Utils.Drasil.Concepts
 import qualified Utils.Drasil.NounPhrase as NP
 import qualified Utils.Drasil.Sentence as S

--- a/code/drasil-example/ssp/lib/Drasil/SSP/GenDefs.hs
+++ b/code/drasil-example/ssp/lib/Drasil/SSP/GenDefs.hs
@@ -8,6 +8,7 @@ import Prelude hiding (sin, cos, tan)
 import qualified Data.List.NonEmpty as NE
 import Language.Drasil
 import Theory.Drasil
+import Utils.Drasil (weave)
 import Utils.Drasil.Concepts
 import qualified Utils.Drasil.NounPhrase as NP
 import qualified Language.Drasil.Sentence.Combinators as S

--- a/code/drasil-example/ssp/lib/Drasil/SSP/GenDefs.hs
+++ b/code/drasil-example/ssp/lib/Drasil/SSP/GenDefs.hs
@@ -10,7 +10,7 @@ import Language.Drasil
 import Theory.Drasil
 import Utils.Drasil.Concepts
 import qualified Utils.Drasil.NounPhrase as NP
-import qualified Utils.Drasil.Sentence as S
+import qualified Language.Drasil.Sentence.Combinators as S
 import Drasil.DocLang.SRS as SRS (physSyst)
 import Data.Drasil.SI_Units (metre, newton)
 import Data.Drasil.Concepts.Documentation (analysis, assumption, component,

--- a/code/drasil-example/ssp/lib/Drasil/SSP/Goals.hs
+++ b/code/drasil-example/ssp/lib/Drasil/SSP/Goals.hs
@@ -3,7 +3,7 @@ module Drasil.SSP.Goals (goals, identifyCritAndFSGS, determineNormalFGS,
 
 import Language.Drasil
 import Utils.Drasil.Concepts
-import qualified Utils.Drasil.Sentence as S
+import qualified Language.Drasil.Sentence.Combinators as S
 
 import Data.Drasil.Concepts.Documentation (goalStmtDom)
 

--- a/code/drasil-example/ssp/lib/Drasil/SSP/IMods.hs
+++ b/code/drasil-example/ssp/lib/Drasil/SSP/IMods.hs
@@ -5,6 +5,7 @@ import Prelude hiding (tan, product, sin, cos)
 
 import Language.Drasil
 import Theory.Drasil
+import Utils.Drasil (weave)
 import Utils.Drasil.Concepts
 import qualified Language.Drasil.Sentence.Combinators as S
 import Drasil.DocLang.SRS (propCorSol)

--- a/code/drasil-example/ssp/lib/Drasil/SSP/IMods.hs
+++ b/code/drasil-example/ssp/lib/Drasil/SSP/IMods.hs
@@ -5,7 +5,6 @@ import Prelude hiding (tan, product, sin, cos)
 
 import Language.Drasil
 import Theory.Drasil
-import Utils.Drasil
 import Utils.Drasil.Concepts
 import qualified Utils.Drasil.Sentence as S
 import Drasil.DocLang.SRS (propCorSol)

--- a/code/drasil-example/ssp/lib/Drasil/SSP/IMods.hs
+++ b/code/drasil-example/ssp/lib/Drasil/SSP/IMods.hs
@@ -6,7 +6,7 @@ import Prelude hiding (tan, product, sin, cos)
 import Language.Drasil
 import Theory.Drasil
 import Utils.Drasil.Concepts
-import qualified Utils.Drasil.Sentence as S
+import qualified Language.Drasil.Sentence.Combinators as S
 import Drasil.DocLang.SRS (propCorSol)
 
 -- Needed for derivations

--- a/code/drasil-example/ssp/lib/Drasil/SSP/Requirements.hs
+++ b/code/drasil-example/ssp/lib/Drasil/SSP/Requirements.hs
@@ -2,7 +2,7 @@ module Drasil.SSP.Requirements (funcReqs, funcReqTables, nonFuncReqs) where
 
 import Language.Drasil
 import Utils.Drasil.Concepts
-import qualified Utils.Drasil.Sentence as S
+import qualified Language.Drasil.Sentence.Combinators as S
 
 import Drasil.DocLang (mkInputPropsTable)
 import Drasil.DocLang.SRS (datCon, propCorSol) 

--- a/code/drasil-example/ssp/lib/Drasil/SSP/Requirements.hs
+++ b/code/drasil-example/ssp/lib/Drasil/SSP/Requirements.hs
@@ -1,7 +1,6 @@
 module Drasil.SSP.Requirements (funcReqs, funcReqTables, nonFuncReqs) where
 
 import Language.Drasil
-import Utils.Drasil
 import Utils.Drasil.Concepts
 import qualified Utils.Drasil.Sentence as S
 

--- a/code/drasil-example/ssp/lib/Drasil/SSP/TMods.hs
+++ b/code/drasil-example/ssp/lib/Drasil/SSP/TMods.hs
@@ -9,7 +9,7 @@ import qualified Data.List.NonEmpty as NE
 import Language.Drasil
 import Theory.Drasil
 import Utils.Drasil.Concepts
-import qualified Utils.Drasil.Sentence as S
+import qualified Language.Drasil.Sentence.Combinators as S
 
 import Data.Drasil.Quantities.Physics (distance, force)
 

--- a/code/drasil-example/ssp/lib/Drasil/SSP/TMods.hs
+++ b/code/drasil-example/ssp/lib/Drasil/SSP/TMods.hs
@@ -8,7 +8,6 @@ import qualified Data.List.NonEmpty as NE
 
 import Language.Drasil
 import Theory.Drasil
-import Utils.Drasil
 import Utils.Drasil.Concepts
 import qualified Utils.Drasil.Sentence as S
 

--- a/code/drasil-example/ssp/lib/Drasil/SSP/Unitals.hs
+++ b/code/drasil-example/ssp/lib/Drasil/SSP/Unitals.hs
@@ -5,7 +5,7 @@ import Language.Drasil.Display (Symbol(..))
 import Language.Drasil.ShortHands
 import Utils.Drasil.Concepts
 import qualified Utils.Drasil.NounPhrase as NP
-import qualified Utils.Drasil.Sentence as S
+import qualified Language.Drasil.Sentence.Combinators as S
 
 import Drasil.SSP.Defs (fsConcept)
 

--- a/code/drasil-example/swhs/lib/Drasil/SWHS/Assumptions.hs
+++ b/code/drasil-example/swhs/lib/Drasil/SWHS/Assumptions.hs
@@ -4,7 +4,7 @@ import Language.Drasil
 import Control.Lens ((^.))
 import Utils.Drasil.Concepts
 import qualified Utils.Drasil.NounPhrase as NP
-import qualified Utils.Drasil.Sentence as S
+import qualified Language.Drasil.Sentence.Combinators as S
 
 import Data.Drasil.Concepts.Documentation (system, simulation, model, 
   problem, assumpDom)

--- a/code/drasil-example/swhs/lib/Drasil/SWHS/Assumptions.hs
+++ b/code/drasil-example/swhs/lib/Drasil/SWHS/Assumptions.hs
@@ -2,7 +2,6 @@ module Drasil.SWHS.Assumptions where --all of this file is exported
 
 import Language.Drasil
 import Control.Lens ((^.))
-import Utils.Drasil
 import Utils.Drasil.Concepts
 import qualified Utils.Drasil.NounPhrase as NP
 import qualified Utils.Drasil.Sentence as S

--- a/code/drasil-example/swhs/lib/Drasil/SWHS/Body.hs
+++ b/code/drasil-example/swhs/lib/Drasil/SWHS/Body.hs
@@ -5,7 +5,6 @@ import Language.Drasil hiding (organization, section, variable)
 import Drasil.SRSDocument
 import qualified Drasil.DocLang.SRS as SRS (inModel)
 import Theory.Drasil (GenDefn, InstanceModel)
-import Utils.Drasil
 import Utils.Drasil.Concepts
 import qualified Utils.Drasil.NounPhrase as NP
 import qualified Utils.Drasil.Sentence as S

--- a/code/drasil-example/swhs/lib/Drasil/SWHS/Body.hs
+++ b/code/drasil-example/swhs/lib/Drasil/SWHS/Body.hs
@@ -7,7 +7,7 @@ import qualified Drasil.DocLang.SRS as SRS (inModel)
 import Theory.Drasil (GenDefn, InstanceModel)
 import Utils.Drasil.Concepts
 import qualified Utils.Drasil.NounPhrase as NP
-import qualified Utils.Drasil.Sentence as S
+import qualified Language.Drasil.Sentence.Combinators as S
 
 import Control.Lens ((^.))
 

--- a/code/drasil-example/swhs/lib/Drasil/SWHS/Changes.hs
+++ b/code/drasil-example/swhs/lib/Drasil/SWHS/Changes.hs
@@ -2,7 +2,6 @@ module Drasil.SWHS.Changes (likelyChgs, likeChgTCVOD, likeChgTCVOL,
   likeChgTLH, unlikelyChgs) where
 
 import Language.Drasil
-import Utils.Drasil
 import Utils.Drasil.Concepts
 import qualified Utils.Drasil.Sentence as S
 

--- a/code/drasil-example/swhs/lib/Drasil/SWHS/Changes.hs
+++ b/code/drasil-example/swhs/lib/Drasil/SWHS/Changes.hs
@@ -3,7 +3,7 @@ module Drasil.SWHS.Changes (likelyChgs, likeChgTCVOD, likeChgTCVOL,
 
 import Language.Drasil
 import Utils.Drasil.Concepts
-import qualified Utils.Drasil.Sentence as S
+import qualified Language.Drasil.Sentence.Combinators as S
 
 import Data.Drasil.Concepts.Documentation (assumption, value, simulation,
   model, likeChgDom, unlikeChgDom)

--- a/code/drasil-example/swhs/lib/Drasil/SWHS/DataDefs.hs
+++ b/code/drasil-example/swhs/lib/Drasil/SWHS/DataDefs.hs
@@ -3,7 +3,7 @@ module Drasil.SWHS.DataDefs where --exports all of it
 import Language.Drasil
 import Theory.Drasil (DataDefinition, ddE, ddENoRefs)
 import Utils.Drasil.Concepts
-import qualified Utils.Drasil.Sentence as S
+import qualified Language.Drasil.Sentence.Combinators as S
 
 import Data.Drasil.Concepts.Documentation (value)
 import Data.Drasil.Concepts.Thermodynamics (heat)

--- a/code/drasil-example/swhs/lib/Drasil/SWHS/DataDefs.hs
+++ b/code/drasil-example/swhs/lib/Drasil/SWHS/DataDefs.hs
@@ -2,7 +2,6 @@ module Drasil.SWHS.DataDefs where --exports all of it
 
 import Language.Drasil
 import Theory.Drasil (DataDefinition, ddE, ddENoRefs)
-import Utils.Drasil
 import Utils.Drasil.Concepts
 import qualified Utils.Drasil.Sentence as S
 

--- a/code/drasil-example/swhs/lib/Drasil/SWHS/GenDefs.hs
+++ b/code/drasil-example/swhs/lib/Drasil/SWHS/GenDefs.hs
@@ -2,6 +2,7 @@ module Drasil.SWHS.GenDefs (genDefs, htFluxWaterFromCoil, htFluxPCMFromWater,
   rocTempSimp, rocTempSimpDeriv, rocTempSimpRC) where
 
 import Language.Drasil
+import Utils.Drasil (weave)
 import Theory.Drasil (GenDefn, gd, gdNoRefs, deModel', equationalModel')
 import Utils.Drasil.Concepts
 import qualified Language.Drasil.Sentence.Combinators as S

--- a/code/drasil-example/swhs/lib/Drasil/SWHS/GenDefs.hs
+++ b/code/drasil-example/swhs/lib/Drasil/SWHS/GenDefs.hs
@@ -3,7 +3,6 @@ module Drasil.SWHS.GenDefs (genDefs, htFluxWaterFromCoil, htFluxPCMFromWater,
 
 import Language.Drasil
 import Theory.Drasil (GenDefn, gd, gdNoRefs, deModel', equationalModel')
-import Utils.Drasil
 import Utils.Drasil.Concepts
 import qualified Utils.Drasil.Sentence as S
 

--- a/code/drasil-example/swhs/lib/Drasil/SWHS/GenDefs.hs
+++ b/code/drasil-example/swhs/lib/Drasil/SWHS/GenDefs.hs
@@ -4,7 +4,7 @@ module Drasil.SWHS.GenDefs (genDefs, htFluxWaterFromCoil, htFluxPCMFromWater,
 import Language.Drasil
 import Theory.Drasil (GenDefn, gd, gdNoRefs, deModel', equationalModel')
 import Utils.Drasil.Concepts
-import qualified Utils.Drasil.Sentence as S
+import qualified Language.Drasil.Sentence.Combinators as S
 
 import Data.Drasil.Concepts.Math (rOfChng, unit_)
 import Data.Drasil.Concepts.Thermodynamics (lawConvCooling)

--- a/code/drasil-example/swhs/lib/Drasil/SWHS/Goals.hs
+++ b/code/drasil-example/swhs/lib/Drasil/SWHS/Goals.hs
@@ -2,7 +2,6 @@ module Drasil.SWHS.Goals (goals, waterTempGS, pcmTempGS, waterEnergyGS,
   pcmEnergyGS) where
 
 import Language.Drasil
-import Utils.Drasil
 
 import Data.Drasil.Concepts.Documentation (goalStmtDom)
 import Data.Drasil.Concepts.Physics (time)

--- a/code/drasil-example/swhs/lib/Drasil/SWHS/IMods.hs
+++ b/code/drasil-example/swhs/lib/Drasil/SWHS/IMods.hs
@@ -2,6 +2,7 @@ module Drasil.SWHS.IMods (iMods, eBalanceOnWtr, eBalanceOnWtrDerivDesc1,
   eBalanceOnWtrDerivDesc3, eBalanceOnPCM, heatEInWtr, heatEInPCM, instModIntro) where
 
 import Language.Drasil
+import Utils.Drasil (weave)
 import Theory.Drasil (InstanceModel, im, imNoDeriv, qwC, qwUC, deModel',
   equationalModel, ModelKind)
 import Utils.Drasil.Concepts

--- a/code/drasil-example/swhs/lib/Drasil/SWHS/IMods.hs
+++ b/code/drasil-example/swhs/lib/Drasil/SWHS/IMods.hs
@@ -4,7 +4,6 @@ module Drasil.SWHS.IMods (iMods, eBalanceOnWtr, eBalanceOnWtrDerivDesc1,
 import Language.Drasil
 import Theory.Drasil (InstanceModel, im, imNoDeriv, qwC, qwUC, deModel',
   equationalModel, ModelKind)
-import Utils.Drasil
 import Utils.Drasil.Concepts
 import qualified Utils.Drasil.NounPhrase as NP
 import qualified Utils.Drasil.Sentence as S

--- a/code/drasil-example/swhs/lib/Drasil/SWHS/IMods.hs
+++ b/code/drasil-example/swhs/lib/Drasil/SWHS/IMods.hs
@@ -6,7 +6,7 @@ import Theory.Drasil (InstanceModel, im, imNoDeriv, qwC, qwUC, deModel',
   equationalModel, ModelKind)
 import Utils.Drasil.Concepts
 import qualified Utils.Drasil.NounPhrase as NP
-import qualified Utils.Drasil.Sentence as S
+import qualified Language.Drasil.Sentence.Combinators as S
 import Control.Lens((^.))
 
 import Data.Drasil.Concepts.Documentation (assumption, condition, constraint,

--- a/code/drasil-example/swhs/lib/Drasil/SWHS/Requirements.hs
+++ b/code/drasil-example/swhs/lib/Drasil/SWHS/Requirements.hs
@@ -1,7 +1,6 @@
 module Drasil.SWHS.Requirements where --all of this file is exported
 
 import Language.Drasil
-import Utils.Drasil
 import Utils.Drasil.Concepts
 import qualified Utils.Drasil.NounPhrase as NP
 import qualified Utils.Drasil.Sentence as S

--- a/code/drasil-example/swhs/lib/Drasil/SWHS/Requirements.hs
+++ b/code/drasil-example/swhs/lib/Drasil/SWHS/Requirements.hs
@@ -3,7 +3,7 @@ module Drasil.SWHS.Requirements where --all of this file is exported
 import Language.Drasil
 import Utils.Drasil.Concepts
 import qualified Utils.Drasil.NounPhrase as NP
-import qualified Utils.Drasil.Sentence as S
+import qualified Language.Drasil.Sentence.Combinators as S
 
 import Drasil.DocLang (inReq)
 import Drasil.DocLang.SRS (datCon, propCorSol) 

--- a/code/drasil-example/swhs/lib/Drasil/SWHS/TMods.hs
+++ b/code/drasil-example/swhs/lib/Drasil/SWHS/TMods.hs
@@ -4,17 +4,11 @@ module Drasil.SWHS.TMods (PhaseChange(Liquid), consThermE, latentHtE,
 
 import qualified Data.List.NonEmpty as NE
 
-import Language.Drasil (plural, (+:), dRefInfo, eS', (+:+), ch, eqSymb,
-  mkFuncDefByQ, eS, (+:+.), atStartNP, (!.), atStart, fromEqnSt'', refS,
-  sParen, sC, phrase, shortname', makeURI, nounPhraseSP, dccWDS, dRef,
-  qw, RefInfo(Page), HasSpace(typ), ModelExprC(..), HasSymbol(..), ExprC(..),
-  Definition(..), Reference, Express(..), Sentence(S, (:+:), E), ModelQDef,
-  ConceptChunk, ModelExpr, apply1, LiteralC(..))
+import Language.Drasil
 import Control.Lens ((^.))
 import Theory.Drasil (ConstraintSet, mkConstraintSet,
   TheoryModel, tm, equationalModel', equationalConstraints',
   ModelKind, equationalModel)
-import Utils.Drasil
 import Utils.Drasil.Concepts
 import qualified Utils.Drasil.Sentence as S
 

--- a/code/drasil-example/swhs/lib/Drasil/SWHS/TMods.hs
+++ b/code/drasil-example/swhs/lib/Drasil/SWHS/TMods.hs
@@ -10,7 +10,7 @@ import Theory.Drasil (ConstraintSet, mkConstraintSet,
   TheoryModel, tm, equationalModel', equationalConstraints',
   ModelKind, equationalModel)
 import Utils.Drasil.Concepts
-import qualified Utils.Drasil.Sentence as S
+import qualified Language.Drasil.Sentence.Combinators as S
 
 import Data.Drasil.Concepts.Documentation (system)
 import Data.Drasil.Concepts.Math (equation, rate, rOfChng)

--- a/code/drasil-example/template/lib/Drasil/Template/Body.hs
+++ b/code/drasil-example/template/lib/Drasil/Template/Body.hs
@@ -3,7 +3,7 @@ module Drasil.Template.Body where
 import Language.Drasil
 import Drasil.SRSDocument
 import Theory.Drasil (DataDefinition, GenDefn, InstanceModel, TheoryModel)
-import qualified Utils.Drasil.Sentence as S
+import qualified Language.Drasil.Sentence.Combinators as S
 
 import qualified Data.Drasil.Concepts.Documentation as Doc (srs)
 

--- a/code/drasil-gool/stack.yaml
+++ b/code/drasil-gool/stack.yaml
@@ -31,9 +31,6 @@ resolver:
 #   - wai
 packages:
 - .
-- ../drasil-lang
-- ../drasil-metadata
-- ../drasil-theory
 - ../drasil-utils
 
 # Dependency packages to be pulled from upstream that are not in the resolver.

--- a/code/drasil-lang/lib/Language/Drasil.hs
+++ b/code/drasil-lang/lib/Language/Drasil.hs
@@ -283,7 +283,7 @@ module Language.Drasil (
   bulletFlat, bulletNested, itemRefToSent, makeTMatrix, mkEnumAbbrevList,
   mkTableFromColumns, noRefs, refineChain, sortBySymbol, sortBySymbolTuple,
   tAndDOnly, tAndDWAcc, tAndDWSym,
-  weave, zipSentList,
+  zipSentList,
 ) where
 
 import Utils.Drasil.Contents

--- a/code/drasil-lang/lib/Language/Drasil.hs
+++ b/code/drasil-lang/lib/Language/Drasil.hs
@@ -237,8 +237,58 @@ module Language.Drasil (
 
   -- * Type Synonyms
   , ConstQDef, SimpleQDef, ModelQDef
-  , PExpr
+  , PExpr,
+
+
+  -- TODO: REMOVE ALL OF THE BELOW
+
+  -- * Content
+  -- | From "Utils.Drasil.Contents".
+  enumBullet, enumBulletU, enumSimple, enumSimpleU, mkEnumSimpleD,
+  lbldExpr, unlbldExpr,
+
+  -- * Fold-type utilities.
+  -- | From "Utils.Drasil.Fold". Defines many general fold functions
+  -- for use with Drasil-related types.
+
+  -- ** Folding Options as Types
+  EnumType(..), WrapType(..), SepType(..), FoldType(..),
+
+  -- ** Folding functions
+  -- *** Expression-related
+  foldConstraints,
+
+  -- *** Sentence-related
+  foldlEnumList, foldlList, foldlSP, foldlSP_, foldlSPCol, foldlSent,
+  foldlSent_,foldlSentCol, foldlsC, foldNums, numList,
+  
+  -- * Misc. utilities
+  -- | From "Utils.Drasil.Misc". General sorting functions, useful combinators,
+  -- and various functions to work with Drasil [Chunk](https://github.com/JacquesCarette/Drasil/wiki/Chunks) types.
+  
+  -- ** Reference-related functions
+  -- | Attach a 'Reference' and a 'Sentence' in different ways.
+  chgsStart, definedIn, definedIn', definedIn'', definedIn''',
+  eqnWSource, fromReplace, fromSource, fromSources, fmtU, follows,
+  makeListRef,
+
+  -- ** Sentence-related functions
+  -- | See Reference-related functions as well.
+  addPercent, displayStrConstrntsAsSet, displayDblConstrntsAsSet,
+  eqN, checkValidStr, getTandS, maybeChanged, maybeExpanded,
+  maybeWOVerb, showingCxnBw, substitute, typUncr, underConsidertn,
+  unwrap, fterms,
+
+  -- ** List-related functions
+  bulletFlat, bulletNested, itemRefToSent, makeTMatrix, mkEnumAbbrevList,
+  mkTableFromColumns, noRefs, refineChain, sortBySymbol, sortBySymbolTuple,
+  tAndDOnly, tAndDWAcc, tAndDWSym,
+  weave, zipSentList,
 ) where
+
+import Utils.Drasil.Contents
+import Utils.Drasil.Fold
+import Utils.Drasil.Misc
 
 import Prelude hiding (log, sin, cos, tan, sqrt, id, return, print, break, exp, product)
 import Language.Drasil.Expr.Class (ExprC(..),

--- a/code/drasil-lang/lib/Language/Drasil/Chunk/Citation.hs
+++ b/code/drasil-lang/lib/Language/Drasil/Chunk/Citation.hs
@@ -21,7 +21,6 @@ import Language.Drasil.Data.Citation (author, chapter, pages, editor, bookTitle,
   year, school, journal, institution, note, publisher, CitationKind(..), CiteField)
 import Language.Drasil.Sentence (Sentence(S))
 import Language.Drasil.Label.Type (LblType(Citation))
-import Language.Drasil.Misc (noSpaces)
 import Language.Drasil.ShortName (ShortName, shortname')
 import Language.Drasil.UID (UID)
 import qualified Language.Drasil.UID.Core as UID (uid, showUID)
@@ -62,7 +61,9 @@ instance HasRefAddress Citation where getRefAdd = Citation . UID.showUID
 
 -- | Smart constructor which implicitly uses EntryID as chunk id.
 cite :: CitationKind -> [CiteField] -> String -> Citation
-cite x y z = let s = noSpaces z in Cite x y (UID.uid s) (shortname' (S s))
+cite ck cfs n
+  | ' ' `elem` n = error "Citation names may not contain spaces." -- TODO: Why not?
+  | otherwise    = Cite ck cfs (UID.uid n) (shortname' (S n))
 
 -- | Article citation requires author(s), title, journal, year.
 -- Optional fields can be: volume, number, pages, month, and note.

--- a/code/drasil-lang/lib/Language/Drasil/Misc.hs
+++ b/code/drasil-lang/lib/Language/Drasil/Misc.hs
@@ -1,5 +1,5 @@
 -- | A collection of 'String'-handling routines as well as one for making tables.
-module Language.Drasil.Misc(mkTable, noSpaces, repUnd) where
+module Language.Drasil.Misc(mkTable, repUnd) where
 
 {- |
   Create a table body (not including header row) by applying the given
@@ -19,12 +19,6 @@ mkTable :: [a -> b] -> [a] -> [[b]]
 mkTable _     []  = []
 mkTable []     _  = error "Attempting to make table without data"
 mkTable fl (c:cl) = map ($ c) fl : mkTable fl cl
-
--- | Returns the given string if it doesn't contain spaces and throws an error if it does.
-noSpaces :: String -> String
-noSpaces s
-  | ' ' `notElem` s = s
-  | otherwise          = error "String has at least one space in it."
 
 -- | Replace underscores in a string with periods (@.@).
 repUnd :: String -> String

--- a/code/drasil-lang/lib/Language/Drasil/Misc.hs
+++ b/code/drasil-lang/lib/Language/Drasil/Misc.hs
@@ -1,5 +1,5 @@
 -- | A collection of 'String'-handling routines as well as one for making tables.
-module Language.Drasil.Misc(mkTable, repUnd) where
+module Language.Drasil.Misc (mkTable, repUnd) where
 
 {- |
   Create a table body (not including header row) by applying the given

--- a/code/drasil-lang/lib/Language/Drasil/Misc.hs
+++ b/code/drasil-lang/lib/Language/Drasil/Misc.hs
@@ -16,9 +16,7 @@ module Language.Drasil.Misc(mkTable, repUnd) where
   
 -}
 mkTable :: [a -> b] -> [a] -> [[b]]
-mkTable _     []  = []
-mkTable []     _  = error "Attempting to make table without data"
-mkTable fl (c:cl) = map ($ c) fl : mkTable fl cl
+mkTable fs = map (\x -> map ($ x) fs)
 
 -- | Replace underscores in a string with periods (@.@).
 repUnd :: String -> String

--- a/code/drasil-lang/lib/Language/Drasil/Sentence/Combinators.hs
+++ b/code/drasil-lang/lib/Language/Drasil/Sentence/Combinators.hs
@@ -4,7 +4,7 @@
 -- denote those meant for use at the start of a sentence (capitalizes the first word).
 -- This module should be used as a qualified import (usually as @S@),
 -- as many function names clash with those in Concepts.hs and NounPhrase.hs.
-module Utils.Drasil.Sentence (
+module Language.Drasil.Sentence.Combinators (
   -- * \"And\" Combinators
   and_, andIts, andThe,
   -- * \"The\" Combinators

--- a/code/drasil-lang/lib/Utils/Drasil/Concepts.hs
+++ b/code/drasil-lang/lib/Utils/Drasil/Concepts.hs
@@ -35,8 +35,21 @@ module Utils.Drasil.Concepts (
   compoundNCPS, compoundNCPSPP, compoundNCGenP,
   combineNINP, combineNPNI, combineNINI) where
 
-import Language.Drasil
-import qualified Language.Drasil.Development as D
+import Language.Drasil.Chunk.NamedIdea ( NamedChunk, ncUID )
+import Language.Drasil.Classes ( Idea, NamedIdea(..) )
+import Language.Drasil.Development.Sentence ( phrase, plural )
+import Language.Drasil.NounPhrase
+    ( NP,
+      CapitalizationRule(CapWords, Replace, CapFirst),
+      NounPhrase(phraseNP, pluralNP),
+      nounPhrase'',
+      compoundPhrase,
+      compoundPhrase'',
+      compoundPhrase''' )
+import Language.Drasil.Sentence ( Sentence(S), (+:+) )
+import Language.Drasil.UID.Core ( (+++!) )
+import qualified Language.Drasil.NounPhrase as D
+    ( NounPhrase(pluralNP, phraseNP) )
 import Control.Lens ((^.))
 
 import qualified Utils.Drasil.Sentence as S (and_, andIts, andThe, of_, ofA,

--- a/code/drasil-lang/lib/Utils/Drasil/Concepts.hs
+++ b/code/drasil-lang/lib/Utils/Drasil/Concepts.hs
@@ -52,7 +52,7 @@ import qualified Language.Drasil.NounPhrase as D
     ( NounPhrase(pluralNP, phraseNP) )
 import Control.Lens ((^.))
 
-import qualified Utils.Drasil.Sentence as S (and_, andIts, andThe, of_, ofA,
+import qualified Language.Drasil.Sentence.Combinators as S (and_, andIts, andThe, of_, ofA,
   ofThe, the_ofThe, onThe, for, inThe, in_, is, toThe, isThe)
 
 

--- a/code/drasil-lang/lib/Utils/Drasil/Contents.hs
+++ b/code/drasil-lang/lib/Utils/Drasil/Contents.hs
@@ -8,7 +8,21 @@ module Utils.Drasil.Contents (
   lbldExpr, unlbldExpr
   ) where
 
-import Language.Drasil
+import Language.Drasil.Classes ( Definition(..) )
+import Language.Drasil.Classes.Core ( Referable(refAdd) )
+import Language.Drasil.Classes.Core2 ( HasShortName(..) )
+import Language.Drasil.Document ( llcc, ulcc )
+import Language.Drasil.Document.Core
+    ( LabelledContent,
+      RawContent(Enumeration, EqnBlock),
+      Contents(UlC),
+      ListTuple,
+      ItemType(Flat),
+      ListType(Simple) )
+import Language.Drasil.ModelExpr.Lang ( ModelExpr )
+import Language.Drasil.Reference ( Reference )
+import Language.Drasil.Sentence ( Sentence )
+import Language.Drasil.ShortName ( getSentSN )
 import Utils.Drasil.Misc (bulletFlat, mkEnumAbbrevList)
 
 import Control.Lens ((^.))

--- a/code/drasil-lang/lib/Utils/Drasil/Fold.hs
+++ b/code/drasil-lang/lib/Utils/Drasil/Fold.hs
@@ -21,7 +21,7 @@ import Language.Drasil.Document.Core ( Contents )
 import Language.Drasil.Expr.Class ( ExprC(($&&), realInterval) )
 import Language.Drasil.Sentence
     ( Sentence(S, E, EmptyS, (:+:)), sParen, (+:+), sC, (+:+.), (+:) )
-import qualified Utils.Drasil.Sentence as S (and_, or_)
+import qualified Language.Drasil.Sentence.Combinators as S (and_, or_)
 
 -- | Fold helper function that applies f to all but the last element, applies g to
 -- last element and the accumulator.

--- a/code/drasil-lang/lib/Utils/Drasil/Fold.hs
+++ b/code/drasil-lang/lib/Utils/Drasil/Fold.hs
@@ -13,7 +13,14 @@ module Utils.Drasil.Fold (
   foldlSent, foldlSent_, foldlSentCol, foldlsC, foldNums, numList
   ) where
 
-import Language.Drasil
+import Language.Drasil.Classes ( Express(express), Quantity )
+import Language.Drasil.Constraint
+    ( Constraint(Range), ConstraintE )
+import Language.Drasil.Document ( mkParagraph )
+import Language.Drasil.Document.Core ( Contents )
+import Language.Drasil.Expr.Class ( ExprC(($&&), realInterval) )
+import Language.Drasil.Sentence
+    ( Sentence(S, E, EmptyS, (:+:)), sParen, (+:+), sC, (+:+.), (+:) )
 import qualified Utils.Drasil.Sentence as S (and_, or_)
 
 -- | Fold helper function that applies f to all but the last element, applies g to

--- a/code/drasil-lang/lib/Utils/Drasil/Misc.hs
+++ b/code/drasil-lang/lib/Utils/Drasil/Misc.hs
@@ -59,7 +59,7 @@ import Language.Drasil.Symbol.Helpers ( eqSymb )
 import Language.Drasil.Uncertainty ( uncVal, uncPrec )
 import Language.Drasil.Symbol ( compsy )
 import Utils.Drasil.Fold (FoldType(List), SepType(Comma), foldlList, foldlSent)
-import qualified Utils.Drasil.Sentence as S (are, in_, is, toThe)
+import qualified Language.Drasil.Sentence.Combinators as S (are, in_, is, toThe)
 
 import Control.Lens ((^.))
 

--- a/code/drasil-lang/lib/Utils/Drasil/Misc.hs
+++ b/code/drasil-lang/lib/Utils/Drasil/Misc.hs
@@ -16,10 +16,10 @@ module Utils.Drasil.Misc (
   bulletFlat, bulletNested, itemRefToSent, makeTMatrix, mkEnumAbbrevList,
   mkTableFromColumns, noRefs, refineChain, sortBySymbol, sortBySymbolTuple,
   tAndDOnly, tAndDWAcc, tAndDWSym,
-  weave, zipSentList
+  zipSentList
   ) where
 
-import Language.Drasil.Chunk.Concept ( ConceptChunk )
+import Language.Drasil.Chunk.Concept.Core ( ConceptChunk )
 import Language.Drasil.Chunk.UnitDefn ( UnitDefn, MayHaveUnit(..) )
 import Language.Drasil.Chunk.Unital ( UnitalChunk )
 import Language.Drasil.Classes
@@ -40,7 +40,7 @@ import Language.Drasil.Document.Core
 import Language.Drasil.Expr.Class ( ExprC(sy) )
 import Language.Drasil.ModelExpr.Class ( ModelExprC(isIn) )
 import Language.Drasil.ModelExpr.Lang ( ModelExpr )
-import Language.Drasil.NounPhrase ( NP )
+import Language.Drasil.NounPhrase.Core ( NP )
 import Language.Drasil.Reference ( refS, namedRef )
 import Language.Drasil.Sentence
     ( Sentence(S, Percent, (:+:), Sy, EmptyS),
@@ -185,10 +185,6 @@ bulletFlat = Bullet . noRefs . map Flat
 -- The first argument is the headers of the 'Nested' lists.
 bulletNested :: [Sentence] -> [ListType] -> ListType
 bulletNested t l = Bullet (zipWith (\h c -> (Nested h c, Nothing)) t l)
-
--- | Interweaves two lists together @[[a,b,c],[d,e,f]] -> [a,d,b,e,c,f]@.
-weave :: [[a]] -> [a]
-weave = concat . transpose
 
 -- | Get a unit symbol if there is one.
 unwrap :: Maybe UnitDefn -> Sentence

--- a/code/drasil-lang/lib/Utils/Drasil/Misc.hs
+++ b/code/drasil-lang/lib/Utils/Drasil/Misc.hs
@@ -19,8 +19,45 @@ module Utils.Drasil.Misc (
   weave, zipSentList
   ) where
 
-import Language.Drasil
-import Language.Drasil.Display
+import Language.Drasil.Chunk.Concept ( ConceptChunk )
+import Language.Drasil.Chunk.UnitDefn ( UnitDefn, MayHaveUnit(..) )
+import Language.Drasil.Chunk.Unital ( UnitalChunk )
+import Language.Drasil.Classes
+    ( HasUnitSymbol(usymb),
+      HasUncertainty,
+      Quantity,
+      Concept,
+      Definition(defn),
+      NamedIdea(..) )
+import Language.Drasil.Classes.Core
+    ( Referable, HasSymbol, HasUID )
+import Language.Drasil.Classes.Core2 ( HasShortName )
+import Language.Drasil.Development.Sentence
+    ( short, atStart, titleize, phrase, plural )
+import Language.Drasil.Document ( Section )
+import Language.Drasil.Document.Core
+    ( ItemType(..), ListType(Bullet) )
+import Language.Drasil.Expr.Class ( ExprC(sy) )
+import Language.Drasil.ModelExpr.Class ( ModelExprC(isIn) )
+import Language.Drasil.ModelExpr.Lang ( ModelExpr )
+import Language.Drasil.NounPhrase ( NP )
+import Language.Drasil.Reference ( refS, namedRef )
+import Language.Drasil.Sentence
+    ( Sentence(S, Percent, (:+:), Sy, EmptyS),
+      eS,
+      ch,
+      sParen,
+      sDash,
+      (+:+),
+      sC,
+      (+:+.),
+      (!.),
+      (+:),
+      capSent )
+import Language.Drasil.Space ( Space(DiscreteD, DiscreteS) )
+import Language.Drasil.Symbol.Helpers ( eqSymb )
+import Language.Drasil.Uncertainty ( uncVal, uncPrec )
+import Language.Drasil.Symbol ( compsy )
 import Utils.Drasil.Fold (FoldType(List), SepType(Comma), foldlList, foldlSent)
 import qualified Utils.Drasil.Sentence as S (are, in_, is, toThe)
 

--- a/code/drasil-lang/lib/Utils/Drasil/NounPhrase.hs
+++ b/code/drasil-lang/lib/Utils/Drasil/NounPhrase.hs
@@ -32,7 +32,12 @@ module Utils.Drasil.NounPhrase (
   -- ** Other Combinators
   with) where
 
-import Language.Drasil
+import Language.Drasil.NounPhrase
+    ( NP,
+      CapitalizationRule(CapWords, CapFirst),
+      NounPhrase(phraseNP, pluralNP),
+      nounPhrase'' )
+import Language.Drasil.Sentence ( Sentence(S), (+:+) )
 import qualified Utils.Drasil.Sentence as S
 
 

--- a/code/drasil-lang/lib/Utils/Drasil/NounPhrase.hs
+++ b/code/drasil-lang/lib/Utils/Drasil/NounPhrase.hs
@@ -38,7 +38,7 @@ import Language.Drasil.NounPhrase
       NounPhrase(phraseNP, pluralNP),
       nounPhrase'' )
 import Language.Drasil.Sentence ( Sentence(S), (+:+) )
-import qualified Utils.Drasil.Sentence as S
+import qualified Language.Drasil.Sentence.Combinators as S
 
 
 --Maybe move these to a separate Drasil.NounPhrase section

--- a/code/drasil-lang/lib/Utils/Drasil/Sentence.hs
+++ b/code/drasil-lang/lib/Utils/Drasil/Sentence.hs
@@ -15,7 +15,9 @@ module Utils.Drasil.Sentence (
   -- * Other Combinators
   of_, ofA, or_, are, in_, is, defnAs, denotes, versus, wrt) where
 
-import Language.Drasil
+import Language.Drasil.Classes ( NamedIdea )
+import Language.Drasil.Development.Sentence ( titleize, titleize' )
+import Language.Drasil.Sentence ( Sentence(S), (+:+) )
 
 
 sentHelper :: String -> Sentence -> Sentence -> Sentence

--- a/code/drasil-lang/package.yaml
+++ b/code/drasil-lang/package.yaml
@@ -29,13 +29,13 @@ library:
   - Language.Drasil.Expr.Development
   - Language.Drasil.Literal.Development
   - Language.Drasil.ModelExpr.Development
+  - Language.Drasil.Sentence.Combinators
   - Language.Drasil.ShortHands
   - Utils.Drasil.Concepts
   - Utils.Drasil.Contents
   - Utils.Drasil.Fold
   - Utils.Drasil.Misc
   - Utils.Drasil.NounPhrase
-  - Utils.Drasil.Sentence
   when:
   - condition: false
     other-modules: Paths_drasil_lang

--- a/code/drasil-lang/package.yaml
+++ b/code/drasil-lang/package.yaml
@@ -13,6 +13,7 @@ dependencies:
 - base >= 4.7 && < 5
 - lens
 - split
+- Decimal
 - unicode-names >= 3.2.0.0
 
 ghc-options:
@@ -29,6 +30,12 @@ library:
   - Language.Drasil.Literal.Development
   - Language.Drasil.ModelExpr.Development
   - Language.Drasil.ShortHands
+  - Utils.Drasil.Concepts
+  - Utils.Drasil.Contents
+  - Utils.Drasil.Fold
+  - Utils.Drasil.Misc
+  - Utils.Drasil.NounPhrase
+  - Utils.Drasil.Sentence
   when:
   - condition: false
     other-modules: Paths_drasil_lang

--- a/code/drasil-printers/lib/Language/Drasil/HTML/Print.hs
+++ b/code/drasil-printers/lib/Language/Drasil/HTML/Print.hs
@@ -12,12 +12,8 @@ import Prelude hiding (print, (<>))
 import Data.List (sortBy)
 import Text.PrettyPrint hiding (Str)
 import Numeric (showEFloat)
-import Utils.Drasil (checkValidStr, numList)
 
-import qualified Language.Drasil as L (People, Person, 
-  CitationKind(Misc, Book, MThesis, PhDThesis, Article), 
-  DType(Data, Theory, Instance, General),MaxWidthPercent,
-  Document, nameStr, rendPersLFM, rendPersLFM', rendPersLFM'', special)
+import qualified Language.Drasil as L
 
 import Language.Drasil.HTML.Monad (unPH)
 import Language.Drasil.HTML.Helpers (articleTitle, author, ba, body, bold,
@@ -136,7 +132,7 @@ pSpec (E e)  = em $ pExpr e
 -- pSpec (E e)     = printMath $ toMath $ TeX.pExpr e
 -- pSpec (Sy s)    = printMath $ TeX.pUnit s
 pSpec (a :+: b) = pSpec a <> pSpec b
-pSpec (S s)     = either error (text . concatMap escapeChars) $ checkValidStr s invalid
+pSpec (S s)     = either error (text . concatMap escapeChars) $ L.checkValidStr s invalid
   where
     invalid = ['<', '>']
     escapeChars '&' = "\\&"
@@ -505,7 +501,7 @@ rendPeople' people = S . foldlList $ map rendPers (init people) ++  [rendPersL (
 
 -- | Organize a list of pages.
 foldPages :: [Int] -> Doc
-foldPages = text . foldlList . numList "&ndash;"
+foldPages = text . foldlList . L.numList "&ndash;"
 
 -- | Organize a list of people.
 foldPeople :: L.People -> Doc

--- a/code/drasil-printers/lib/Language/Drasil/JSON/Print.hs
+++ b/code/drasil-printers/lib/Language/Drasil/JSON/Print.hs
@@ -4,10 +4,8 @@ module Language.Drasil.JSON.Print(genJSON) where
 import Prelude hiding (print, (<>))
 import Text.PrettyPrint hiding (Str)
 import Numeric (showEFloat)
-import Utils.Drasil (checkValidStr)
 
-import qualified Language.Drasil as L (DType(Data, Theory, Instance, General), 
-  MaxWidthPercent, Document, special)
+import qualified Language.Drasil as L
 
 import Language.Drasil.Printing.Import (makeDocument)
 import Language.Drasil.Printing.AST (Spec, ItemType(Flat, Nested),  
@@ -88,7 +86,7 @@ print = foldr (($$) . printLO) empty
 pSpec :: Spec -> Doc
 pSpec (E e)  = text "$" <> pExpr e <> text "$" -- symbols used
 pSpec (a :+: b) = pSpec a <> pSpec b
-pSpec (S s)     = either error (text . concatMap escapeChars) $ checkValidStr s invalid
+pSpec (S s)     = either error (text . concatMap escapeChars) $ L.checkValidStr s invalid
   where
     invalid = ['<', '>']
     escapeChars '&' = "\\&"

--- a/code/drasil-printers/lib/Language/Drasil/Plain/Print.hs
+++ b/code/drasil-printers/lib/Language/Drasil/Plain/Print.hs
@@ -16,7 +16,7 @@ import Language.Drasil.Printing.Import (expr, codeExpr, spec, symbol)
 import Language.Drasil.Printing.PrintingInformation (PrintingConfiguration(..), 
   PrintingInformation(..), Notation(Scientific))
 
-import Utils.Drasil.Strings (toPlainName)
+import Utils.Drasil (toPlainName)
 
 import Prelude hiding ((<>))
 import Data.List (partition)

--- a/code/drasil-printers/lib/Language/Drasil/Printing/Import/Sentence.hs
+++ b/code/drasil-printers/lib/Language/Drasil/Printing/Import/Sentence.hs
@@ -3,7 +3,6 @@ module Language.Drasil.Printing.Import.Sentence where
 
 import Language.Drasil hiding (neg, sec, symbol, isIn)
 import Database.Drasil (ChunkDB, defResolve, refResolve, refTable)
-import Utils.Drasil (foldNums, checkValidStr)
 
 import qualified Language.Drasil.Printing.AST as P
 import Language.Drasil.Printing.PrintingInformation

--- a/code/drasil-printers/lib/Language/Drasil/TeX/Print.hs
+++ b/code/drasil-printers/lib/Language/Drasil/TeX/Print.hs
@@ -12,7 +12,6 @@ import Control.Arrow (second)
 import qualified Language.Drasil as L
 import qualified Language.Drasil.ShortHands as LD (cDelta)
 import qualified Language.Drasil.Display as LD
-import Utils.Drasil (checkValidStr, foldNums)
 
 import Language.Drasil.Config (colAwidth, colBwidth, bibStyleT, bibFname)
 import Language.Drasil.Printing.AST (Spec, ItemType(Nested, Flat), 
@@ -287,7 +286,7 @@ spec a@(s :+: t) = s' <> t'
     s' = switch ctx $ spec s
     t' = switch ctx $ spec t
 spec (E ex) = toMath $ pExpr ex
-spec (S s)  = either error (pure . text . concatMap escapeChars) $ checkValidStr s invalid
+spec (S s)  = either error (pure . text . concatMap escapeChars) $ L.checkValidStr s invalid
   where
     invalid = ['&', '#', '$', '%', '&', '~', '^', '\\', '{', '}']
     escapeChars '_' = "\\_"
@@ -510,7 +509,7 @@ showBibTeX  _ (Month        m) = showFieldRaw "month" (bibTeXMonth m)
 showBibTeX  _ (Note         n) = showField "note" n
 showBibTeX  _ (Number       n) = showField "number" (wrapS n)
 showBibTeX  _ (Organization o) = showField "organization" o
-showBibTeX sm (Pages        p) = showField "pages" (I.spec sm $ foldNums "--" p)
+showBibTeX sm (Pages        p) = showField "pages" (I.spec sm $ L.foldNums "--" p)
 showBibTeX  _ (Publisher    p) = showField "publisher" p
 showBibTeX  _ (School       s) = showField "school" s
 showBibTeX  _ (Series       s) = showField "series" s

--- a/code/drasil-utils/lib/Utils/Drasil.hs
+++ b/code/drasil-utils/lib/Utils/Drasil.hs
@@ -11,7 +11,7 @@ module Utils.Drasil (
   
   -- * Lists
   -- | From "Utils.Drasil.Lists". General functions involving lists.
-  replaceAll, subsetOf, nubSort,
+  replaceAll, subsetOf, nubSort, weave,
 
   -- ** Strings
   toPlainName

--- a/code/drasil-utils/lib/Utils/Drasil.hs
+++ b/code/drasil-utils/lib/Utils/Drasil.hs
@@ -1,60 +1,70 @@
 -- | Gather Drasil's utility functions and re-export for easy use.
 -- For now, does not include combinators (Sentence.hs, NounPhrase.hs, Concepts.hs)
 module Utils.Drasil (
-  -- * Content-Related Utilities
+  -- * Documents
+  -- | From "Utils.Drasil.Document".
+  blank, indent, indentList,
+
+  -- * Language
+  -- | From "Utils.Drasil.English".
+  capitalize, stringList,
+  
+  -- * Lists
+  -- | From "Utils.Drasil.Lists". General functions involving lists.
+  replaceAll, subsetOf, nubSort,
+
+  -- ** Strings
+  toPlainName
+) where
+
+import Utils.Drasil.Document
+import Utils.Drasil.English
+import Utils.Drasil.Lists
+import Utils.Drasil.Strings
+
+{-
+
+
+  -- * Content
   -- | From "Utils.Drasil.Contents".
   enumBullet, enumBulletU, enumSimple, enumSimpleU, mkEnumSimpleD,
   lbldExpr, unlbldExpr,
-  -- * Document-Related Utilities
-  -- | From "Utils.Drasil.Document".
-  blank, indent, indentList,
-  -- * Language-Related Utilities
-  -- | From "Utils.Drasil.English".
-  capitalize, stringList,
-  -- * Fold-type Utilities.
+
+  -- * Fold-type utilities.
   -- | From "Utils.Drasil.Fold". Defines many general fold functions
   -- for use with Drasil-related types.
 
   -- ** Folding Options as Types
   EnumType(..), WrapType(..), SepType(..), FoldType(..),
-  -- ** Folding Functions
+
+  -- ** Folding functions
   -- *** Expression-related
   foldConstraints,
+
   -- *** Sentence-related
   foldlEnumList, foldlList, foldlSP, foldlSP_, foldlSPCol, foldlSent,
   foldlSent_,foldlSentCol, foldlsC, foldNums, numList,
-  -- * List-type Utilities.
-  -- | From "Utils.Drasil.Lists". General functions involving lists.
-  replaceAll, subsetOf, nubSort,
-  -- * Misc. Uitlities
+  
+  -- * Misc. utilities
   -- | From "Utils.Drasil.Misc". General sorting functions, useful combinators,
   -- and various functions to work with Drasil [Chunk](https://github.com/JacquesCarette/Drasil/wiki/Chunks) types.
   
-  -- ** Reference-related Functions
+  -- ** Reference-related functions
   -- | Attach a 'Reference' and a 'Sentence' in different ways.
   chgsStart, definedIn, definedIn', definedIn'', definedIn''',
   eqnWSource, fromReplace, fromSource, fromSources, fmtU, follows,
   makeListRef,
-  -- ** Sentence-related Functions
-  -- | See Reference-related Functions as well.
+
+  -- ** Sentence-related functions
+  -- | See Reference-related functions as well.
   addPercent, displayStrConstrntsAsSet, displayDblConstrntsAsSet,
   eqN, checkValidStr, getTandS, maybeChanged, maybeExpanded,
   maybeWOVerb, showingCxnBw, substitute, typUncr, underConsidertn,
   unwrap, fterms,
-  -- ** List-related Functions
+
+  -- ** List-related functions
   bulletFlat, bulletNested, itemRefToSent, makeTMatrix, mkEnumAbbrevList,
   mkTableFromColumns, noRefs, refineChain, sortBySymbol, sortBySymbolTuple,
   tAndDOnly, tAndDWAcc, tAndDWSym,
-  weave, zipSentList
-  -- Concepts
-    -- may want to add concept-level combinators back into Drasil.Utils,
-    -- but for now leave as a separate and exposed module.
-) where
-
-import Utils.Drasil.Contents
-import Utils.Drasil.Document
-import Utils.Drasil.English
-import Utils.Drasil.Fold
-import Utils.Drasil.Lists
-import Utils.Drasil.Misc
---import Utils.Drasil.Concepts
+  weave, zipSentList,
+-}

--- a/code/drasil-utils/lib/Utils/Drasil/Document.hs
+++ b/code/drasil-utils/lib/Utils/Drasil/Document.hs
@@ -13,4 +13,4 @@ indent = nest 4
 
 -- | Indents a list of Docs and combines into one Doc.
 indentList :: [Doc] -> Doc
-indentList = vcat . map indent
+indentList = vcat . map indent  -- TODO: Isn't this just `indent . vcat`? This would be a bit more efficient too

--- a/code/drasil-utils/lib/Utils/Drasil/English.hs
+++ b/code/drasil-utils/lib/Utils/Drasil/English.hs
@@ -11,10 +11,14 @@ capitalize (c:cs) = toUpper c:map toLower cs
 -- | Comma separated list with "and" before final item.
 stringList :: [String] -> String
 stringList s = mkStr (filter (not . null) s)
-  where mkStr [] = ""
-        mkStr [d] = d
-        mkStr [d1, d2] = d1 ++ " and " ++ d2
-        mkStr (d:ds) = d ++ manyStrs ds
-        manyStrs [] = error "impossible case in manyStrs"
-        manyStrs [d] = ", and " ++ d
-        manyStrs (d:ds) = ", " ++ d ++ manyStrs ds
+  where
+    mkStr :: [String] -> String
+    mkStr []       = ""
+    mkStr [d]      = d
+    mkStr [d1, d2] = d1 ++ " and " ++ d2 -- TODO: When you have a list of >=3 items, your last 2 should still have a comma between them.
+    mkStr (d:ds)   = d ++ manyStrs ds
+    
+    manyStrs :: [String] -> String
+    manyStrs []     = error "impossible case in manyStrs" -- TODO: Make explicit why this is an impossible case
+    manyStrs [d]    = ", and " ++ d
+    manyStrs (d:ds) = ", " ++ d ++ manyStrs ds

--- a/code/drasil-utils/lib/Utils/Drasil/Lists.hs
+++ b/code/drasil-utils/lib/Utils/Drasil/Lists.hs
@@ -1,7 +1,7 @@
 -- | Functions for working with lists.
 module Utils.Drasil.Lists where
 
-import Data.List (nub, sort)
+import Data.List
 
 -- | Replaces all elements of a target list that belong to a provided "bad"
 --   input list.
@@ -17,3 +17,7 @@ xs `subsetOf` ys = all (`elem` ys) xs
 -- | Sort a list, removing all duplicates
 nubSort :: Ord a => [a] -> [a]
 nubSort = nub . sort
+
+-- | Interweaves two lists together @[[a,b,c],[d,e,f]] -> [a,d,b,e,c,f]@.
+weave :: [[a]] -> [a]
+weave = concat . transpose

--- a/code/drasil-utils/lib/Utils/Drasil/Strings.hs
+++ b/code/drasil-utils/lib/Utils/Drasil/Strings.hs
@@ -1,11 +1,13 @@
 -- Contains a function that removes special characters from a string.
-module Utils.Drasil.Strings where
+module Utils.Drasil.Strings (
+    toPlainName
+) where
 
 import Utils.Drasil.Lists (replaceAll)
 
--- TODO: This can probably become a bit more comprehensive,
--- anything other than a-z, A-Z, or 0-9 could probably be replaced.
-
 -- | Replace occurences of special characters (@",~`-=!@#$%^&*+[]\\;'/|\"<>? "@) with underscores (@"_"@).
+-- 
+--   TODO: This can probably become a bit more comprehensive,
+--   anything other than a-z, A-Z, or 0-9 could probably be replaced.
 toPlainName :: String -> String
 toPlainName = replaceAll ",~`-=!@#$%^&*+[]\\;'/|\"<>? " '_'

--- a/code/drasil-utils/package.yaml
+++ b/code/drasil-utils/package.yaml
@@ -11,10 +11,8 @@ extra-source-files: []
 
 dependencies:
 - base >= 4.7 && < 5
-- lens
 - pretty
 - Decimal
-- drasil-lang
 
 ghc-options:
 - -Wall
@@ -24,10 +22,6 @@ library:
   source-dirs: lib
   exposed-modules:
   - Utils.Drasil
-  - Utils.Drasil.Concepts
-  - Utils.Drasil.NounPhrase
-  - Utils.Drasil.Sentence
-  - Utils.Drasil.Strings
   when:
   - condition: false
     other-modules: Paths_drasil_utils

--- a/code/drasil-utils/package.yaml
+++ b/code/drasil-utils/package.yaml
@@ -12,7 +12,6 @@ extra-source-files: []
 dependencies:
 - base >= 4.7 && < 5
 - pretty
-- Decimal
 
 ghc-options:
 - -Wall

--- a/code/drasil-utils/stack.yaml
+++ b/code/drasil-utils/stack.yaml
@@ -31,7 +31,6 @@ resolver:
 #   - wai
 packages:
 - .
-- ../drasil-lang
 
 # Dependency packages to be pulled from upstream that are not in the resolver.
 # These entries can reference officially published versions as well as
@@ -42,9 +41,7 @@ packages:
 # - git: https://github.com/commercialhaskell/stack.git
 #   commit: e7b331f14bcffb8367cd58fbfc8b40ec7642100a
 #
-extra-deps:
-- unicode-names-3.2.0.0@sha256:fef7241d93170e26265e84553090253a5e8ee207645d47cf271816f5834d07d2,470
-- unicode-properties-3.2.0.0@sha256:239766a6ac4322329353f6b9cd546024fd8c5f0235c8e32b3cba2d6bd245a699,1000
+# extra-deps:
 
 # Override default flag values for local packages and extra-deps
 # flags: {}

--- a/code/drasil-website/lib/Drasil/Website/Example.hs
+++ b/code/drasil-website/lib/Drasil/Website/Example.hs
@@ -4,7 +4,6 @@ module Drasil.Website.Example where
 import Language.Drasil hiding (E)
 import Database.Drasil (SystemInformation(..))
 import Language.Drasil.Code (Choices(..), Lang(..))
-import Utils.Drasil
 import Data.Char (toLower, isSpace)
 
 import qualified Drasil.DblPendulum.Body as DblPendulum (fullSI)

--- a/code/drasil-website/lib/Drasil/Website/Introduction.hs
+++ b/code/drasil-website/lib/Drasil/Website/Introduction.hs
@@ -3,7 +3,6 @@
 module Drasil.Website.Introduction where
 
 import Language.Drasil
-import Utils.Drasil
 
 
 -- * Introduction Section


### PR DESCRIPTION
Builds on #2881 
Contributes to #2885 
Contributes to #2886 

This is a first-pass in moving around files. Some modules are still left named as "Utils.Drasil.X", but that's not an issue, we can figure out what they should be named later, while figuring out how to split up `drasil-lang`. With this, we should at least have a better idea of what's needed.