### PR TITLE
added Class to render Choices as String

### DIFF
--- a/code/drasil-code/lib/Language/Drasil/Choices.hs
+++ b/code/drasil-code/lib/Language/Drasil/Choices.hs
@@ -172,7 +172,7 @@ matchSpaces spMtchs = matchSpaces' spMtchs spaceToCodeType
         matchSpaces' [] sm = sm
 
 -- | Sets component names.
-data ComponentName = GetInput --deriving Eq -- ^ Sets input component name.
+data ComponentName = GetInput -- ^ Sets input component name.
 
 instance RenderChoicesStr ComponentName where
   showChsStr GetInput = "get_input"  

--- a/code/drasil-code/lib/Language/Drasil/Code/Imperative/Descriptions.hs
+++ b/code/drasil-code/lib/Language/Drasil/Code/Imperative/Descriptions.hs
@@ -74,7 +74,7 @@ inputConstructorDesc = do
       icDesc True = "checking " ++ pAndS ++ " on the input"
       dl = defList g
   return $ "Initializes input object by " ++ stringList [ 
-    ifDesc ((showChsStr GetInput) `elem` dl),
+    ifDesc (showChsStr GetInput `elem` dl),
     idDesc ("derived_values" `elem` dl),
     icDesc ("input_constraints" `elem` dl)]
 
@@ -85,7 +85,7 @@ inputFormatDesc = do
   g <- get
   let ifDesc False = ""
       ifDesc _ = "the function for reading inputs"
-  return $ ifDesc $ (showChsStr GetInput) `elem` defList g
+  return $ ifDesc $ showChsStr GetInput `elem` defList g
 
 -- | Returns a description of what is contained in the Derived Values module,
 -- if it exists.
@@ -169,7 +169,7 @@ inFmtFuncDesc = do
   g <- get
   let ifDesc False = ""
       ifDesc _ = "Reads input from a file with the given file name"
-  return $ ifDesc $ (showChsStr GetInput) `elem` defList g
+  return $ ifDesc $ showChsStr GetInput `elem` defList g
 
 -- | Returns a description for the generated function that checks input constraints,
 -- if it exists.

--- a/code/drasil-code/lib/Language/Drasil/Code/Imperative/Descriptions.hs
+++ b/code/drasil-code/lib/Language/Drasil/Code/Imperative/Descriptions.hs
@@ -14,7 +14,7 @@ import Language.Drasil.Code.Imperative.DrasilState (GenState, DrasilState(..),
   inMod)
 import Language.Drasil.Chunk.Code (CodeIdea(codeName), quantvar)
 import Language.Drasil.Choices (ImplementationType(..), InputModule(..), 
-  Structure(..))
+  Structure(..), ComponentName(..), showChsStr)
 import Language.Drasil.CodeSpec (CodeSpec(..))
 import Language.Drasil.Mod (Description)
 
@@ -74,7 +74,7 @@ inputConstructorDesc = do
       icDesc True = "checking " ++ pAndS ++ " on the input"
       dl = defList g
   return $ "Initializes input object by " ++ stringList [ 
-    ifDesc ("get_input" `elem` dl),
+    ifDesc ((showChsStr GetInput) `elem` dl),
     idDesc ("derived_values" `elem` dl),
     icDesc ("input_constraints" `elem` dl)]
 
@@ -85,7 +85,7 @@ inputFormatDesc = do
   g <- get
   let ifDesc False = ""
       ifDesc _ = "the function for reading inputs"
-  return $ ifDesc $ "get_input" `elem` defList g
+  return $ ifDesc $ (showChsStr GetInput) `elem` defList g
 
 -- | Returns a description of what is contained in the Derived Values module,
 -- if it exists.
@@ -169,7 +169,7 @@ inFmtFuncDesc = do
   g <- get
   let ifDesc False = ""
       ifDesc _ = "Reads input from a file with the given file name"
-  return $ ifDesc $ "get_input" `elem` defList g
+  return $ ifDesc $ (showChsStr GetInput) `elem` defList g
 
 -- | Returns a description for the generated function that checks input constraints,
 -- if it exists.

--- a/code/drasil-code/lib/Language/Drasil/Code/Imperative/DrasilState.hs
+++ b/code/drasil-code/lib/Language/Drasil/Code/Imperative/DrasilState.hs
@@ -13,7 +13,8 @@ import Language.Drasil.Code.ExtLibImport (ExtLibState)
 import Language.Drasil.Choices (Choices(..), AuxFile, Modularity(..), 
   ImplementationType(..), Comments, Verbosity, MatchedConceptMap, 
   ConstantRepr, ConstantStructure(..), ConstraintBehaviour, 
-  InputModule(..), Logging, Structure(..), inputModule)
+  InputModule(..), Logging, Structure(..), ComponentName(..), inputModule,
+  showChsStr)
 import Language.Drasil.CodeSpec (Input, Const, Derived, Output, Def, 
   CodeSpec(..),  getConstraints)
 import Language.Drasil.Mod (Mod(..), Name, Version, Class(..), 
@@ -260,14 +261,14 @@ getExpInputFormat n chs _ = fMod (modularity chs) (inputStructure chs)
         fMod _ Bundled = []
         fMod Unmodular _ = [(giNm, n)]
         fMod (Modular Combined) _ = [(giNm, "InputParameters")]
-        giNm = "get_input"
+        giNm = showChsStr GetInput
 
 -- | Get input format defined in a class (for @get_input@).
 -- See 'getDerivedCls' for full logic details.
 getInputFormatCls :: Choices -> [Input] -> [ClassDef]
 getInputFormatCls _ [] = []
 getInputFormatCls chs _ = ifCls (inputModule chs) (inputStructure chs)
-  where ifCls Combined Bundled = [("get_input", "InputParameters")]
+  where ifCls Combined Bundled = [((showChsStr GetInput), "InputParameters")]
         ifCls _ _ = []
 
 -- | Gets exported calculations.

--- a/code/drasil-code/lib/Language/Drasil/Code/Imperative/DrasilState.hs
+++ b/code/drasil-code/lib/Language/Drasil/Code/Imperative/DrasilState.hs
@@ -268,7 +268,7 @@ getExpInputFormat n chs _ = fMod (modularity chs) (inputStructure chs)
 getInputFormatCls :: Choices -> [Input] -> [ClassDef]
 getInputFormatCls _ [] = []
 getInputFormatCls chs _ = ifCls (inputModule chs) (inputStructure chs)
-  where ifCls Combined Bundled = [((showChsStr GetInput), "InputParameters")]
+  where ifCls Combined Bundled = [(showChsStr GetInput, "InputParameters")]
         ifCls _ _ = []
 
 -- | Gets exported calculations.

--- a/code/drasil-code/lib/Language/Drasil/Code/Imperative/FunctionCalls.hs
+++ b/code/drasil-code/lib/Language/Drasil/Code/Imperative/FunctionCalls.hs
@@ -10,6 +10,7 @@ import Language.Drasil.Code.Imperative.Parameters (getCalcParams,
   getConstraintParams, getDerivedIns, getDerivedOuts, getInputFormatIns, 
   getInputFormatOuts, getOutputParams)
 import Language.Drasil.Code.Imperative.DrasilState (GenState, DrasilState(..))
+import Language.Drasil.Choices (ComponentName(..), showChsStr)
 import Language.Drasil.Chunk.Code (CodeIdea(codeName), CodeVarChunk, quantvar)
 import Language.Drasil.Chunk.CodeDefinition (CodeDefinition)
 import Language.Drasil.Mod (Name)
@@ -35,7 +36,7 @@ getAllInputCalls = do
 
 -- | Generates a call to the function for reading inputs from a file.
 getInputCall :: (OOProg r) => GenState (Maybe (MSStatement r))
-getInputCall = getInOutCall "get_input" getInputFormatIns getInputFormatOuts
+getInputCall = getInOutCall (showChsStr GetInput) getInputFormatIns getInputFormatOuts
 
 -- | Generates a call to the function for calculating derived inputs.
 getDerivedCall :: (OOProg r) => GenState (Maybe (MSStatement r))

--- a/code/drasil-code/lib/Language/Drasil/Code/Imperative/Generator.hs
+++ b/code/drasil-code/lib/Language/Drasil/Code/Imperative/Generator.hs
@@ -26,7 +26,7 @@ import Language.Drasil.Code.CodeGeneration (createCodeFiles, makeCode)
 import Language.Drasil.Code.ExtLibImport (auxMods, imports, modExports)
 import Language.Drasil.Code.Lang (Lang(..))
 import Language.Drasil.Choices (Choices(..), Modularity(..), Visibility(..),
-  choicesSent)
+  ComponentName(..), choicesSent, showChsStr)
 import Language.Drasil.CodeSpec (CodeSpec(..))
 import Language.Drasil.Printers (Linearity(Linear), sentenceDoc)
 
@@ -166,7 +166,7 @@ genUnmodular = do
   umDesc <- unmodularDesc
   let n = pName $ codeSpec g
       cls = any (`member` clsMap g) 
-        ["get_input", "derived_values", "input_constraints"]
+        [(showChsStr GetInput), "derived_values", "input_constraints"]
   genModuleWithImports n umDesc (concatMap (^. imports) (elems $ extLibMap g))
     (genMainFunc 
       : map (fmap Just) (map genCalcFunc (execOrder $ codeSpec g) 

--- a/code/drasil-code/lib/Language/Drasil/Code/Imperative/Generator.hs
+++ b/code/drasil-code/lib/Language/Drasil/Code/Imperative/Generator.hs
@@ -166,7 +166,7 @@ genUnmodular = do
   umDesc <- unmodularDesc
   let n = pName $ codeSpec g
       cls = any (`member` clsMap g) 
-        [(showChsStr GetInput), "derived_values", "input_constraints"]
+        [showChsStr GetInput, "derived_values", "input_constraints"]
   genModuleWithImports n umDesc (concatMap (^. imports) (elems $ extLibMap g))
     (genMainFunc 
       : map (fmap Just) (map genCalcFunc (execOrder $ codeSpec g) 

--- a/code/drasil-code/lib/Language/Drasil/Code/Imperative/Modules.hs
+++ b/code/drasil-code/lib/Language/Drasil/Code/Imperative/Modules.hs
@@ -38,7 +38,8 @@ import Language.Drasil.Code.DataDesc (DataDesc, junkLine, singleton)
 import Language.Drasil.Code.ExtLibImport (defs, imports, steps)
 import Language.Drasil.Choices (Comments(..), ConstantStructure(..), 
   ConstantRepr(..), ConstraintBehaviour(..), ImplementationType(..), 
-  InputModule(..), Logging(..), Structure(..), hasSampleInput)
+  InputModule(..), Logging(..), Structure(..), ComponentName(..), hasSampleInput, 
+  showChsStr)
 import Language.Drasil.CodeSpec (CodeSpec(..))
 import Language.Drasil.Expr.Development (Completeness(..))
 import Language.Drasil.Printers (Linearity(Linear), codeExprDoc)
@@ -266,7 +267,7 @@ genInputConstructor = do
         ctor <- genConstructor "InputParameters" cdesc (map pcAuto cparams)
           [block ics]
         return $ Just ctor
-  genCtor $ any (`elem` dl) ["get_input", "derived_values", 
+  genCtor $ any (`elem` dl) [(showChsStr GetInput), "derived_values", 
     "input_constraints"]
 
 -- | Generates a function for calculating derived inputs.
@@ -422,9 +423,9 @@ genInputFormat s = do
         outs <- getInputFormatOuts
         bod <- readData dd
         desc <- inFmtFuncDesc
-        mthd <- getFunc s "get_input" desc ins outs bod
+        mthd <- getFunc s (showChsStr GetInput) desc ins outs bod
         return $ Just mthd
-  genInFormat $ "get_input" `elem` defList g
+  genInFormat $ (showChsStr GetInput) `elem` defList g
 
 -- | Defines the 'DataDesc' for the format we require for input files. When we make
 -- input format a design variability, this will read the user's design choices 

--- a/code/drasil-code/lib/Language/Drasil/Code/Imperative/Modules.hs
+++ b/code/drasil-code/lib/Language/Drasil/Code/Imperative/Modules.hs
@@ -267,7 +267,7 @@ genInputConstructor = do
         ctor <- genConstructor "InputParameters" cdesc (map pcAuto cparams)
           [block ics]
         return $ Just ctor
-  genCtor $ any (`elem` dl) [(showChsStr GetInput), "derived_values", 
+  genCtor $ any (`elem` dl) [showChsStr GetInput, "derived_values", 
     "input_constraints"]
 
 -- | Generates a function for calculating derived inputs.
@@ -425,7 +425,7 @@ genInputFormat s = do
         desc <- inFmtFuncDesc
         mthd <- getFunc s (showChsStr GetInput) desc ins outs bod
         return $ Just mthd
-  genInFormat $ (showChsStr GetInput) `elem` defList g
+  genInFormat $ showChsStr GetInput `elem` defList g
 
 -- | Defines the 'DataDesc' for the format we require for input files. When we make
 -- input format a design variability, this will read the user's design choices 

--- a/code/drasil-code/lib/Language/Drasil/Code/Imperative/Parameters.hs
+++ b/code/drasil-code/lib/Language/Drasil/Code/Imperative/Parameters.hs
@@ -8,7 +8,7 @@ import Language.Drasil.Chunk.Code (CodeVarChunk, CodeIdea(codeChunk, codeName),
   quantvar, codevars, codevars', DefiningCodeExpr(..))
 import Language.Drasil.Chunk.CodeDefinition (CodeDefinition, auxExprs)
 import Language.Drasil.Choices (Structure(..), InputModule(..), 
-  ConstantStructure(..), ConstantRepr(..))
+  ConstantStructure(..), ConstantRepr(..), ComponentName(..), showChsStr)
 import Language.Drasil.Code.CodeQuantityDicts (inFileName, inParams, consts)
 import Language.Drasil.Code.Imperative.DrasilState (GenState, DrasilState(..), 
   inMod)
@@ -56,13 +56,13 @@ getInputFormatIns = do
   let getIns :: Structure -> InputModule -> [CodeVarChunk]
       getIns Bundled Separated = [quantvar inParams]
       getIns _ _ = []
-  getParams "get_input" In $ quantvar inFileName : getIns (inStruct g) (inMod g)
+  getParams (showChsStr GetInput) In $ quantvar inFileName : getIns (inStruct g) (inMod g)
 
 -- | The outputs from the function for reading inputs are the inputs.
 getInputFormatOuts :: GenState [CodeVarChunk]
 getInputFormatOuts = do
   g <- get
-  getParams "get_input" Out $ extInputs $ codeSpec g
+  getParams (showChsStr GetInput) Out $ extInputs $ codeSpec g
 
 -- | The inputs to the function for calculating derived inputs are any variables 
 -- used in the equations for the derived inputs.


### PR DESCRIPTION
Renamed the `RenderChoices` class to `RenderChoicesS` (`Sentence`) and added `RenderChoicesStr`, as suggested in #2843, to render `ComponentName`. 