### PR TITLE
Move `NamedArgument` to `drasil-code`

### DIFF
--- a/code/drasil-code/lib/Data/Drasil/ExternalLibraries/ODELibraries.hs
+++ b/code/drasil-code/lib/Data/Drasil/ExternalLibraries/ODELibraries.hs
@@ -11,8 +11,8 @@ module Data.Drasil.ExternalLibraries.ODELibraries (
 ) where
 
 import Language.Drasil (HasSymbol(symbol), HasUID(uid), MayHaveUnit(getUnit),
-  QuantityDict, HasSpace(typ), Space(..), narg, implVar, implVarUID, implVarUID', qw,
-  compoundPhrase, nounPhrase, nounPhraseSP, label, sub, NamedArgument,
+  QuantityDict, HasSpace(typ), Space(..), implVar, implVarUID, implVarUID', qw,
+  compoundPhrase, nounPhrase, nounPhraseSP, label, sub,
   Idea(getA), NamedIdea(term), Stage(..), (+++))
 import Language.Drasil.Display (Symbol(Label, Concat))
 
@@ -36,7 +36,8 @@ import Language.Drasil.Code (Lang(..), ExternalLibrary, Step, Argument,
   solveAndPopulateWhileFill, returnExprListFill, fixedStatementFill,
   CodeVarChunk, CodeFuncChunk, quantvar, quantfunc, listToArray,
   ODEInfo(..), ODEOptions(..), ODEMethod(..), ODELibPckg, mkODELib,
-  mkODELibNoPath, pubStateVar, privStateVar, initSolWithValFill)
+  mkODELibNoPath, pubStateVar, privStateVar, initSolWithValFill,
+  NamedArgument, narg)
 import Language.Drasil.CodeExpr
 import Language.Drasil.Code.Expr.Development
 

--- a/code/drasil-code/lib/Language/Drasil/Chunk/NamedArgument.hs
+++ b/code/drasil-code/lib/Language/Drasil/Chunk/NamedArgument.hs
@@ -9,14 +9,6 @@ module Language.Drasil.Chunk.NamedArgument (
 import Language.Drasil (QuantityDict, HasSpace(..), HasSymbol(..), HasUID(..),
   Idea(..), MayHaveUnit(..), NamedIdea(..), Quantity, qw, IsArgumentName)
 
--- import Language.Drasil.Space (HasSpace(..))
--- import Language.Drasil.Symbol (HasSymbol(symbol))
--- import Language.Drasil.Classes (NamedIdea(term), Idea(getA),
---   Quantity, IsArgumentName)
--- import Language.Drasil.Chunk.Quantity (QuantityDict, qw)
--- import Language.Drasil.Chunk.UnitDefn(MayHaveUnit(getUnit))
--- import Language.Drasil.UID (HasUID(..))
-
 import Control.Lens ((^.), makeLenses, view)
 
 -- | Any quantity can be a named argument (wrapper for 'QuantityDict'),

--- a/code/drasil-code/lib/Language/Drasil/Chunk/NamedArgument.hs
+++ b/code/drasil-code/lib/Language/Drasil/Chunk/NamedArgument.hs
@@ -6,13 +6,16 @@ module Language.Drasil.Chunk.NamedArgument (
   -- * Constructor
   narg) where
 
-import Language.Drasil.Space (HasSpace(..))
-import Language.Drasil.Symbol (HasSymbol(symbol))
-import Language.Drasil.Classes (NamedIdea(term), Idea(getA),
-  Quantity, IsArgumentName)
-import Language.Drasil.Chunk.Quantity (QuantityDict, qw)
-import Language.Drasil.Chunk.UnitDefn(MayHaveUnit(getUnit))
-import Language.Drasil.UID (HasUID(..))
+import Language.Drasil (QuantityDict, HasSpace(..), HasSymbol(..), HasUID(..),
+  Idea(..), MayHaveUnit(..), NamedIdea(..), Quantity, qw, IsArgumentName)
+
+-- import Language.Drasil.Space (HasSpace(..))
+-- import Language.Drasil.Symbol (HasSymbol(symbol))
+-- import Language.Drasil.Classes (NamedIdea(term), Idea(getA),
+--   Quantity, IsArgumentName)
+-- import Language.Drasil.Chunk.Quantity (QuantityDict, qw)
+-- import Language.Drasil.Chunk.UnitDefn(MayHaveUnit(getUnit))
+-- import Language.Drasil.UID (HasUID(..))
 
 import Control.Lens ((^.), makeLenses, view)
 

--- a/code/drasil-code/lib/Language/Drasil/Chunk/README.md
+++ b/code/drasil-code/lib/Language/Drasil/Chunk/README.md
@@ -6,5 +6,8 @@ Last updated: July 25, 2018
 Code.hs
   - Contains helpers for code generation
 
+NamedArgument.hs
+  - Code-oriented version of `DefinedQuantityDict`
+
 README.md
   - This file

--- a/code/drasil-code/lib/Language/Drasil/Code.hs
+++ b/code/drasil-code/lib/Language/Drasil/Code.hs
@@ -41,6 +41,8 @@ module Language.Drasil.Code (
   ODEInfo(..), odeInfo, ODEOptions(..), odeOptions, ODEMethod(..), 
   ODELibPckg(..), mkODELib, mkODELibNoPath,
   unPP, unJP, unCSP, unCPPP, unSP
+  -- Language.Drasil.Chunk.NamedArgument
+  , NamedArgument, narg
 ) where
 
 import Prelude hiding (break, print, return, log, exp)
@@ -97,6 +99,8 @@ import Language.Drasil.Code.Imperative.GOOL.Data (AuxData(..), PackData(..))
 
 import Language.Drasil.Chunk.Code (CodeChunk, CodeVarChunk, CodeFuncChunk, 
   quantvar, quantfunc, ccObjVar, listToArray)
+
+import Language.Drasil.Chunk.NamedArgument (NamedArgument, narg)
 
 import Language.Drasil.CodeExpr (field)
 

--- a/code/drasil-code/lib/Language/Drasil/Code/ExtLibImport.hs
+++ b/code/drasil-code/lib/Language/Drasil/Code/ExtLibImport.hs
@@ -4,11 +4,12 @@
 module Language.Drasil.Code.ExtLibImport (ExtLibState(..), auxMods, defs, 
   imports, modExports, steps, genExternalLibraryCall) where
 
-import Language.Drasil (HasSpace(typ), getActorName, NamedArgument)
+import Language.Drasil (HasSpace(typ), getActorName)
 
 import Language.Drasil.Chunk.Code (CodeVarChunk, CodeFuncChunk, codeName, 
   ccObjVar)
 import Language.Drasil.Chunk.Parameter (ParameterChunk)
+import Language.Drasil.Chunk.NamedArgument (NamedArgument)
 import Language.Drasil.CodeExpr (CodeExpr, ($&&), applyWithNamedArgs,
   msgWithNamedArgs, new, newWithNamedArgs, sy)
 import Language.Drasil.Mod (Class, StateVariable, Func(..), Mod, Name, 

--- a/code/drasil-code/lib/Language/Drasil/Code/ExternalLibrary.hs
+++ b/code/drasil-code/lib/Language/Drasil/Code/ExternalLibrary.hs
@@ -14,9 +14,10 @@ module Language.Drasil.Code.ExternalLibrary (ExternalLibrary, Step(..),
   returnExprList, fixedReturn, initSolWithVal
 ) where
 
-import Language.Drasil (Space, HasSpace(typ), NamedArgument)
+import Language.Drasil (Space, HasSpace(typ))
 import Language.Drasil.Chunk.Code (CodeVarChunk, CodeFuncChunk, codeName)
 import Language.Drasil.Chunk.Parameter (ParameterChunk, pcAuto)
+import Language.Drasil.Chunk.NamedArgument (NamedArgument)
 import Language.Drasil.Code.Expr.Development
 import Language.Drasil.CodeExpr
 import Language.Drasil.Mod (FuncStmt(..), Description)

--- a/code/drasil-code/lib/Language/Drasil/Code/ExternalLibraryCall.hs
+++ b/code/drasil-code/lib/Language/Drasil/Code/ExternalLibraryCall.hs
@@ -12,11 +12,10 @@ module Language.Drasil.Code.ExternalLibraryCall (ExternalLibraryCall,
   fixedStatementFill, initSolWithValFill
 ) where
 
-import Language.Drasil
-
 import Language.Drasil.Chunk.Code (CodeVarChunk)
 import Language.Drasil.Chunk.Parameter (ParameterChunk, pcAuto, pcVal)
-import Language.Drasil.CodeExpr
+import Language.Drasil.Chunk.NamedArgument (NamedArgument)
+import Language.Drasil.CodeExpr (CodeExpr)
 import Language.Drasil.Mod (Initializer, StateVariable)
 
 import Data.List.NonEmpty (NonEmpty(..), fromList)

--- a/code/drasil-code/package.yaml
+++ b/code/drasil-code/package.yaml
@@ -41,6 +41,7 @@ library:
     - Language.Drasil.Chunk.Code
     - Language.Drasil.Chunk.CodeDefinition
     - Language.Drasil.Chunk.ConstraintMap
+    - Language.Drasil.Chunk.NamedArgument
     - Language.Drasil.Chunk.Parameter
     - Language.Drasil.Code.Code
     - Language.Drasil.Code.CodeQuantityDicts

--- a/code/drasil-lang/lib/Language/Drasil.hs
+++ b/code/drasil-lang/lib/Language/Drasil.hs
@@ -98,8 +98,6 @@ module Language.Drasil (
   -- Language.Drasil.Chunk.Quantity
   , QuantityDict, qw, mkQuant, mkQuant', codeVC, implVar, implVar', implVarUID, implVarUID'
   , vc, vc'', vcSt, vcUnit
-  -- Language.Drasil.Chunk.NamedArgument
-  , NamedArgument, narg
   -- Language.Drasil.Chunk.Eq
   , QDefinition, fromEqn, fromEqn', fromEqnSt, fromEqnSt', fromEqnSt''
   , mkQDefSt, mkQuantDef, mkQuantDef', ec
@@ -333,7 +331,6 @@ import Language.Drasil.Chunk.DefinedQuantity
 import Language.Drasil.Chunk.Eq (QDefinition, fromEqn, fromEqn', fromEqnSt,
   fromEqnSt', fromEqnSt'', mkQDefSt, mkQuantDef, mkQuantDef', ec,
   mkFuncDef, mkFuncDef', mkFuncDefByQ)
-import Language.Drasil.Chunk.NamedArgument (NamedArgument, narg)
 import Language.Drasil.Chunk.NamedIdea
 import Language.Drasil.Chunk.Quantity
 import Language.Drasil.Chunk.Relation(RelationConcept, makeRC, addRelToCC)

--- a/code/drasil-lang/lib/Language/Drasil/Chunk/README.md
+++ b/code/drasil-lang/lib/Language/Drasil/Chunk/README.md
@@ -25,9 +25,6 @@ DefinedQuantity.hs
 Eq.hs
   - Defines `QDefinition` data type (quantity with units and defining equations)
 
-NamedArgument.hs
-  - Code-oriented version of `DefinedQuantityDict`
-
 NamedIdea.hs
   - `NamedChunk` and `IdeaDict` data types
   - Various `NamedChunk` combinators


### PR DESCRIPTION
Contributes to #2885 

NamedArgument is only used in `drasil-code` at the moment, and is described as a tool for "generating code".