### PR TITLE
Disable single HLint false-positive: 'Evaluation' on `const`

### DIFF
--- a/code/drasil-code/test/HelloWorld.hs
+++ b/code/drasil-code/test/HelloWorld.hs
@@ -66,6 +66,7 @@ helloListSlice = listSlice (var "mySlicedList" (listType double))
   (Just (litInt 3)) Nothing
 
 -- | Create an If statement.
+{-# ANN module "HLint: ignore Evaluate" #-}
 helloIfBody :: (OOProg r) => MSBody r
 helloIfBody = addComments "If body" (body [
   block [


### PR DESCRIPTION
Fixes #2968 