### PR TITLE
Update .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,11 +1,11 @@
 *.sh text eol=lf
 *.cls linguist-vendored
 *.bst linguist-vendored
+Papers/** linguist-documentation
 People/** linguist-documentation
 Presentations/** linguist-documentation
+WindowsFix/** linguist-vendored
 code/stable/** linguist-generated
-code/datafiles/nopcm/cpp/** linguist-vendored
-code/datafiles/nopcm/csharp/** linguist-vendored
-code/datafiles/nopcm/java/** linguist-vendored
+code/datafiles/** linguist-vendored
 doc/** linguist-documentation
 notes/** linguist-documentation


### PR DESCRIPTION
Closes #3000 

This marks everything in...:
- `datafiles/` as "vendored"/external
- `WindowsFix/` as vendored
- `Papers/` as documentation 

https://github.com/balacij/Drasil is a demo, and it shows now that Haskell is at 98.1%.