### PR TITLE
Trigger doxygen to generate documentation for dblpendulum

### DIFF
--- a/code/Makefile
+++ b/code/Makefile
@@ -27,8 +27,8 @@ PACKAGE_GEN_TARGET = BUILD DOC GRAPH
 #--------------------------------------------#
 
 # Current list of examples
-SRC_EXAMPLES = glassbr nopcm projectile pdcontroller
-EXAMPLES = $(SRC_EXAMPLES) hghc swhs ssp gamephysics template dblpendulum sglpendulum 
+SRC_EXAMPLES = glassbr nopcm projectile pdcontroller dblpendulum
+EXAMPLES = $(SRC_EXAMPLES) hghc swhs ssp gamephysics template sglpendulum 
 GOOLTEST = codegenTest
 
 # where they live

--- a/code/datafiles/dblpendulum/cpp
+++ b/code/datafiles/dblpendulum/cpp
@@ -1,0 +1,1 @@
+../odelib/cpp

--- a/code/datafiles/dblpendulum/csharp
+++ b/code/datafiles/dblpendulum/csharp
@@ -1,0 +1,1 @@
+../odelib/csharp

--- a/code/datafiles/dblpendulum/java
+++ b/code/datafiles/dblpendulum/java
@@ -1,0 +1,1 @@
+../odelib/java


### PR DESCRIPTION
This will fix the broken documentation links of the double pendulum on the website. The way we fixed it seems odd to me because we have to make the change in the makefile. Is it possible to move it to the Haskell level?

related #3011