### PR TITLE
Add hie.yaml to fix "multi-cradle" issues for Haskell Language Server

### DIFF
--- a/code/hie.yaml
+++ b/code/hie.yaml
@@ -1,0 +1,118 @@
+cradle:
+  stack:
+    - path: "drasil-build/lib"
+      component: "drasil-build:lib"
+
+    - path: "drasil-code/lib"
+      component: "drasil-code:lib"
+
+    - path: "drasil-code/test"
+      component: "drasil-code:test:codegenTest"
+
+    - path: "drasil-code-base/lib"
+      component: "drasil-code-base:lib"
+
+    - path: "drasil-data/lib"
+      component: "drasil-data:lib"
+
+    - path: "drasil-database/lib"
+      component: "drasil-database:lib"
+
+    - path: "drasil-docLang/lib"
+      component: "drasil-docLang:lib"
+
+    - path: "drasil-example/dblpendulum/lib"
+      component: "dblpendulum:lib"
+
+    - path: "drasil-example/dblpendulum/app/Main.hs"
+      component: "dblpendulum:exe:dblpendulum"
+
+    - path: "drasil-example/gamephysics/lib"
+      component: "gamephysics:lib"
+
+    - path: "drasil-example/gamephysics/app/Main.hs"
+      component: "gamephysics:exe:gamephysics"
+
+    - path: "drasil-example/glassbr/lib"
+      component: "glassbr:lib"
+
+    - path: "drasil-example/glassbr/app/Main.hs"
+      component: "glassbr:exe:glassbr"
+
+    - path: "drasil-example/hghc/lib"
+      component: "hghc:lib"
+
+    - path: "drasil-example/hghc/app/Main.hs"
+      component: "hghc:exe:hghc"
+
+    - path: "drasil-example/nopcm/lib"
+      component: "nopcm:lib"
+
+    - path: "drasil-example/nopcm/app/Main.hs"
+      component: "nopcm:exe:nopcm"
+
+    - path: "drasil-example/pdcontroller/lib"
+      component: "pdcontroller:lib"
+
+    - path: "drasil-example/pdcontroller/app/Main.hs"
+      component: "pdcontroller:exe:pdcontroller"
+
+    - path: "drasil-example/projectile/lib"
+      component: "projectile:lib"
+
+    - path: "drasil-example/projectile/app/Main.hs"
+      component: "projectile:exe:projectile"
+
+    - path: "drasil-example/sglpendulum/lib"
+      component: "sglpendulum:lib"
+
+    - path: "drasil-example/sglpendulum/app/Main.hs"
+      component: "sglpendulum:exe:sglpendulum"
+
+    - path: "drasil-example/ssp/lib"
+      component: "ssp:lib"
+
+    - path: "drasil-example/ssp/app/Main.hs"
+      component: "ssp:exe:ssp"
+
+    - path: "drasil-example/swhs/lib"
+      component: "swhs:lib"
+
+    - path: "drasil-example/swhs/app/Main.hs"
+      component: "swhs:exe:swhs"
+
+    - path: "drasil-example/template/lib"
+      component: "template:lib"
+
+    - path: "drasil-example/template/app/Main.hs"
+      component: "template:exe:template"
+
+    - path: "drasil-gen/lib"
+      component: "drasil-gen:lib"
+
+    - path: "drasil-gool/lib"
+      component: "drasil-gool:lib"
+
+    - path: "drasil-lang/lib"
+      component: "drasil-lang:lib"
+
+    - path: "drasil-metadata/lib"
+      component: "drasil-metadata:lib"
+
+    - path: "drasil-printers/lib"
+      component: "drasil-printers:lib"
+
+    - path: "drasil-sysinfo/lib"
+      component: "drasil-sysinfo:lib"
+
+    - path: "drasil-theory/lib"
+      component: "drasil-theory:lib"
+
+    - path: "drasil-utils/lib"
+      component: "drasil-utils:lib"
+
+    - path: "drasil-website/lib"
+      component: "drasil-website:lib"
+
+    - path: "drasil-website/app/Main.hs"
+      component: "drasil-website:exe:website"


### PR DESCRIPTION
HLS broke for me with their latest update, but I was able to fix it by adding this "hie.yaml" file. It is generated by [`implicit-hie`](https://hackage.haskell.org/package/implicit-hie).

@peter-michalski I remember you mentioning that you always had problems with HLS. Do you want to check if this branch makes it work for you? You will need to do a `make code` first, and then open VSCode. If VSCode fails to load, running `haskell-language-server` manually in the `code/` directory might help us understand what's broken with yours.