### PR TITLE
Fix #3161 (kEnergy in GamePhysics)

### DIFF
--- a/code/drasil-example/gamephysics/lib/Drasil/GamePhysics/DataDefs.hs
+++ b/code/drasil-example/gamephysics/lib/Drasil/GamePhysics/DataDefs.hs
@@ -289,7 +289,7 @@ kEnergy :: SimpleQDef
 kEnergy = mkQuantDef QP.kEnergy kEnergyEqn
 
 kEnergyEqn :: Expr
-kEnergyEqn = sy QPP.mass `mulRe` half (square (sy QP.velocity))
+kEnergyEqn = sy QPP.mass `mulRe` half (square (norm (sy QP.velocity)))
 
 kEnergyDesc :: Sentence
 kEnergyDesc = foldlSent [atStart QP.kEnergy `S.is` (QP.kEnergy ^. defn)]

--- a/code/stable/gamephysics/SRS/HTML/GamePhysics_SRS.html
+++ b/code/stable/gamephysics/SRS/HTML/GamePhysics_SRS.html
@@ -1794,7 +1794,7 @@
                     </tr>
                     <tr>
                       <th>Equation</th>
-                      <td>\[KE=m \frac{\symbf{v}^{2}}{2}\]</td>
+                      <td>\[KE=m \frac{\|\symbf{v}\|^{2}}{2}\]</td>
                     </tr>
                     <tr>
                       <th>Description</th>

--- a/code/stable/gamephysics/SRS/PDF/GamePhysics_SRS.tex
+++ b/code/stable/gamephysics/SRS/PDF/GamePhysics_SRS.tex
@@ -989,7 +989,7 @@ Units & ${\text{J}}$
         
 \\ \midrule \\
 Equation & \begin{displaymath}
-           KE=m \frac{\symbf{v}^{2}}{2}
+           KE=m \frac{\|\symbf{v}\|^{2}}{2}
            \end{displaymath}
 \\ \midrule \\
 Description & \begin{symbDescription}


### PR DESCRIPTION
Definition of kEnergy was missing a norm call. Was found through type checking. Fixes #3161.