### PR TITLE
Resolve conflicting instances for Semigroup & Monoid for `PrintLaTeX Doc`

### DIFF
--- a/code/drasil-printers/lib/Language/Drasil/TeX/Monad.hs
+++ b/code/drasil-printers/lib/Language/Drasil/TeX/Monad.hs
@@ -80,11 +80,9 @@ getCtx = PL id
 instance Semigroup (PrintLaTeX TP.Doc) where
   (PL s1) <> (PL s2) = PL $ \ctx -> s1 ctx TP.<> s2 ctx
 
--- very convenient lifting of $$
--- | D is a monad.
+-- | D is a monoid.
 instance Monoid (PrintLaTeX TP.Doc) where
   mempty = pure TP.empty
-  -- (PL s1) `mappend` (PL s2) = PL $ \ctx -> s1 ctx $$ s2 ctx
 
 -- may revisit later
 -- | Since Text.PrettyPrint steals <>, use %% instead for mappend.

--- a/code/drasil-printers/lib/Language/Drasil/TeX/Monad.hs
+++ b/code/drasil-printers/lib/Language/Drasil/TeX/Monad.hs
@@ -84,12 +84,12 @@ instance Semigroup (PrintLaTeX TP.Doc) where
 -- | D is a monad.
 instance Monoid (PrintLaTeX TP.Doc) where
   mempty = pure TP.empty
-  (PL s1) `mappend` (PL s2) = PL $ \ctx -> s1 ctx $$ s2 ctx
+  -- (PL s1) `mappend` (PL s2) = PL $ \ctx -> s1 ctx $$ s2 ctx
 
 -- may revisit later
 -- | Since Text.PrettyPrint steals <>, use %% instead for mappend.
 (%%) :: D -> D -> D
-(%%) = mappend
+(%%) = liftA2 ($$)
 
 -- | Lifts Text.PrettyPrint's $+$. Above, with no overlapping. Associative.
 ($+$) :: D -> D -> D

--- a/code/drasil-printers/lib/Language/Drasil/TeX/Print.hs
+++ b/code/drasil-printers/lib/Language/Drasil/TeX/Print.hs
@@ -247,7 +247,7 @@ makeHeaders ls = hpunctuate (text " & ") (map (bold . spec) ls) %% pure dbs
 
 -- | Creates the rows for a table.
 makeRows :: [[Spec]] -> D
-makeRows = mconcat . map (\c -> makeColumns c %% pure dbs)
+makeRows = foldr (%%) mempty . map (\c -> makeColumns c %% pure dbs)
 
 -- | Creates the columns for a table.
 makeColumns :: [Spec] -> D
@@ -460,7 +460,7 @@ makeBib sm bib = mkEnvArgBr "filecontents*" (bibFname ++ ".bib") (mkBibRef sm bi
 
 -- | Renders a bibliographical reference.
 mkBibRef :: PrintingInformation -> BibRef -> D
-mkBibRef sm = mconcat . map (renderF sm)
+mkBibRef sm = foldr (%%) mempty . map (renderF sm)
 
 -- | Helper that renders a citation.
 renderF :: PrintingInformation -> Citation -> D

--- a/code/drasil-printers/lib/Language/Drasil/TeX/Print.hs
+++ b/code/drasil-printers/lib/Language/Drasil/TeX/Print.hs
@@ -247,7 +247,7 @@ makeHeaders ls = hpunctuate (text " & ") (map (bold . spec) ls) %% pure dbs
 
 -- | Creates the rows for a table.
 makeRows :: [[Spec]] -> D
-makeRows = foldr (%%) mempty . map (\c -> makeColumns c %% pure dbs)
+makeRows = foldr ((%%) . (\c -> makeColumns c %% pure dbs)) mempty
 
 -- | Creates the columns for a table.
 makeColumns :: [Spec] -> D
@@ -460,7 +460,7 @@ makeBib sm bib = mkEnvArgBr "filecontents*" (bibFname ++ ".bib") (mkBibRef sm bi
 
 -- | Renders a bibliographical reference.
 mkBibRef :: PrintingInformation -> BibRef -> D
-mkBibRef sm = foldr (%%) mempty . map (renderF sm)
+mkBibRef sm = foldr ((%%) . renderF sm) mempty
 
 -- | Helper that renders a citation.
 renderF :: PrintingInformation -> Citation -> D

--- a/code/drasil-printers/lib/Language/Drasil/TeX/Print.hs
+++ b/code/drasil-printers/lib/Language/Drasil/TeX/Print.hs
@@ -245,7 +245,7 @@ dontCount = "\\/[]{}()_^$:"
 makeHeaders :: [Spec] -> D
 makeHeaders ls = hpunctuate (text " & ") (map (bold . spec) ls) %% pure dbs
 
--- | Creates the rows for a table.
+-- | Create rows for a table with a single line break between them.
 makeRows :: [[Spec]] -> D
 makeRows = foldr ((%%) . (\c -> makeColumns c %% pure dbs)) mempty
 
@@ -458,7 +458,8 @@ makeBib sm bib = mkEnvArgBr "filecontents*" (bibFname ++ ".bib") (mkBibRef sm bi
   command "nocite" "*" %% command "bibstyle" bibStyleT %%
   command0 "printbibliography" <> sq (pure $ text "heading=none")
 
--- | Renders a bibliographical reference.
+-- | Renders a bibliographical reference with a single line break between
+-- entries.
 mkBibRef :: PrintingInformation -> BibRef -> D
 mkBibRef sm = foldr ((%%) . renderF sm) mempty
 


### PR DESCRIPTION
Closes #3230 

I'm not quite sure I'm happy with this resolution yet. The 'code' part of the solution isn't difficult now that it's understood. The only questionable component is: what should `<>` (and hence `mappend`) be doing?

For now, I've defaulted to `mappend` to `<>` as per current recommendations by the Haskell community, as `mappend` will eventually be removed. Then, I replaced usage of `mconcat` (which relied on the old `mappend` definition) with a copy of the old definition.

So, now the question goes to: was this the right solution?
