### PR TITLE
Add dependabot weekly GH Actions update script

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
Closes #3227 

Creates a Dependabot script that GitHub reads to automatically search for updates to our GitHub Actions script. It uses the [Example](https://docs.github.com/en/code-security/dependabot/working-with-dependabot/keeping-your-actions-up-to-date-with-dependabot#example-dependabotyml-file-for-github-actions) script GitHub provides to submit PRs on a weekly basis.

While I don't imagine there being an issue with the PR, it's probably best to wait for a PR (or some sort of feedback that it works) from dependabot on my fork before merging into the main repo. So, creating a PR so that we don't forget, but leaving it as a "draft" so that we know it's not yet tested.

We just need to manually enable the Dependabot > Dependabot Version updates under the repo settings. This is what it looks like from my fork. Note that I cannot edit the settings of this repository, so it will most likely need to be done by @JacquesCarette.

![image](https://user-images.githubusercontent.com/1627302/214143043-ca5a5df7-b40a-4087-8cb3-5b51025ad945.png)
