### PR TITLE
Updated Citations.hs to properly reflect the title of Koothoor2013 thesis

### DIFF
--- a/code/drasil-data/lib/Data/Drasil/Citations.hs
+++ b/code/drasil-data/lib/Data/Drasil/Citations.hs
@@ -20,7 +20,7 @@ campidelli = cBooklet
 
 koothoor2013 = 
   cMThesis [nKoothoor] 
-  "A document drive approach to certifying scientific computing software"
+  "A Document Driven Approach to Certifying Scientific Computing Software"
   "McMaster University" 2013 [address "Hamilton, ON, Canada"]
   "koothoor2013"
 

--- a/code/stable/dblpendulum/SRS/HTML/DblPendulum_SRS.html
+++ b/code/stable/dblpendulum/SRS/HTML/DblPendulum_SRS.html
@@ -3959,7 +3959,7 @@
           </li>
           <li>
             <div id="koothoor2013">
-              [2]: Koothoor, Nirmitha. <em>A document drive approach to certifying scientific computing software</em>. McMaster University, Hamilton, ON, Canada: 2013. Print.
+              [2]: Koothoor, Nirmitha. <em>A Document Driven Approach to Certifying Scientific Computing Software</em>. McMaster University, Hamilton, ON, Canada: 2013. Print.
             </div>
           </li>
           <li>

--- a/code/stable/dblpendulum/SRS/JSON/DblPendulum_SRS.ipynb
+++ b/code/stable/dblpendulum/SRS/JSON/DblPendulum_SRS.ipynb
@@ -10,7 +10,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [

--- a/code/stable/dblpendulum/SRS/JSON/DblPendulum_SRS.ipynb
+++ b/code/stable/dblpendulum/SRS/JSON/DblPendulum_SRS.ipynb
@@ -10,6 +10,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -2156,7 +2157,7 @@
     "<a id=\"hibbeler2004\"></a>\n",
     "[1]: Hibbeler, R. C. <em>Engineering Mechanics: Dynamics</em>. Pearson Prentice Hall, 2004. Print.\n",
     "<a id=\"koothoor2013\"></a>\n",
-    "[2]: Koothoor, Nirmitha. <em>A document drive approach to certifying scientific computing software</em>. McMaster University, Hamilton, ON, Canada: 2013. Print.\n",
+    "[2]: Koothoor, Nirmitha. <em>A Document Driven Approach to Certifying Scientific Computing Software</em>. McMaster University, Hamilton, ON, Canada: 2013. Print.\n",
     "<a id=\"parnasClements1986\"></a>\n",
     "[3]: Parnas, David L. and Clements, P. C. \"A rational design process: How and why to fake it.\" <em>IEEE Transactions on Software Engineering</em>, vol. 12, no. 2, Washington, USA: February, 1986. pp. 251&ndash;257. Print.\n",
     "<a id=\"smithLai2005\"></a>\n",

--- a/code/stable/dblpendulum/SRS/PDF/DblPendulum_SRS.tex
+++ b/code/stable/dblpendulum/SRS/PDF/DblPendulum_SRS.tex
@@ -1782,7 +1782,7 @@ publisher={Pearson Prentice Hall},
 year={2004}}
 @mastersthesis{koothoor2013,
 author={Koothoor, Nirmitha},
-title={A document drive approach to certifying scientific computing software},
+title={A Document Driven Approach to Certifying Scientific Computing Software},
 school={McMaster University},
 year={2013},
 address={Hamilton, ON, Canada}}

--- a/code/stable/gamephysics/SRS/HTML/GamePhysics_SRS.html
+++ b/code/stable/gamephysics/SRS/HTML/GamePhysics_SRS.html
@@ -4730,7 +4730,7 @@
           </li>
           <li>
             <div id="koothoor2013">
-              [2]: Koothoor, Nirmitha. <em>A document drive approach to certifying scientific computing software</em>. McMaster University, Hamilton, ON, Canada: 2013. Print.
+              [2]: Koothoor, Nirmitha. <em>A Document Driven Approach to Certifying Scientific Computing Software</em>. McMaster University, Hamilton, ON, Canada: 2013. Print.
             </div>
           </li>
           <li>

--- a/code/stable/gamephysics/SRS/JSON/GamePhysics_SRS.ipynb
+++ b/code/stable/gamephysics/SRS/JSON/GamePhysics_SRS.ipynb
@@ -10,7 +10,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [

--- a/code/stable/gamephysics/SRS/JSON/GamePhysics_SRS.ipynb
+++ b/code/stable/gamephysics/SRS/JSON/GamePhysics_SRS.ipynb
@@ -10,6 +10,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -2396,7 +2397,7 @@
     "<a id=\"jfBeucheIntro\"></a>\n",
     "[1]: Bueche, J. Frederick. <em>Introduction to Physics for Scientists, Fourth Edition</em>. Mcgraw-Hill College, 1986.\n",
     "<a id=\"koothoor2013\"></a>\n",
-    "[2]: Koothoor, Nirmitha. <em>A document drive approach to certifying scientific computing software</em>. McMaster University, Hamilton, ON, Canada: 2013. Print.\n",
+    "[2]: Koothoor, Nirmitha. <em>A Document Driven Approach to Certifying Scientific Computing Software</em>. McMaster University, Hamilton, ON, Canada: 2013. Print.\n",
     "<a id=\"parnas1978\"></a>\n",
     "[3]: Parnas, David L. \"Designing Software for Ease of Extension and Contraction.\" <em>ICSE '78: Proceedings of the 3rd international conference on Software engineering</em>. 1978. pp. 264&ndash;277.\n",
     "<a id=\"parnasClements1986\"></a>\n",

--- a/code/stable/gamephysics/SRS/PDF/GamePhysics_SRS.tex
+++ b/code/stable/gamephysics/SRS/PDF/GamePhysics_SRS.tex
@@ -1859,7 +1859,7 @@ publisher={Mcgraw-Hill College},
 year={1986}}
 @mastersthesis{koothoor2013,
 author={Koothoor, Nirmitha},
-title={A document drive approach to certifying scientific computing software},
+title={A Document Driven Approach to Certifying Scientific Computing Software},
 school={McMaster University},
 year={2013},
 address={Hamilton, ON, Canada}}

--- a/code/stable/glassbr/SRS/HTML/GlassBR_SRS.html
+++ b/code/stable/glassbr/SRS/HTML/GlassBR_SRS.html
@@ -4322,7 +4322,7 @@
           </li>
           <li>
             <div id="koothoor2013">
-              [6]: Koothoor, Nirmitha. <em>A document drive approach to certifying scientific computing software</em>. McMaster University, Hamilton, ON, Canada: 2013. Print.
+              [6]: Koothoor, Nirmitha. <em>A Document Driven Approach to Certifying Scientific Computing Software</em>. McMaster University, Hamilton, ON, Canada: 2013. Print.
             </div>
           </li>
           <li>

--- a/code/stable/glassbr/SRS/JSON/GlassBR_SRS.ipynb
+++ b/code/stable/glassbr/SRS/JSON/GlassBR_SRS.ipynb
@@ -10,7 +10,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [

--- a/code/stable/glassbr/SRS/JSON/GlassBR_SRS.ipynb
+++ b/code/stable/glassbr/SRS/JSON/GlassBR_SRS.ipynb
@@ -10,6 +10,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -2102,7 +2103,7 @@
     "<a id=\"campidelli\"></a>\n",
     "[5]: Campidelli, Manuel. \"Glass-BR Software for the design and risk assessment of glass facades subjected to blast loading.\"\n",
     "<a id=\"koothoor2013\"></a>\n",
-    "[6]: Koothoor, Nirmitha. <em>A document drive approach to certifying scientific computing software</em>. McMaster University, Hamilton, ON, Canada: 2013. Print.\n",
+    "[6]: Koothoor, Nirmitha. <em>A Document Driven Approach to Certifying Scientific Computing Software</em>. McMaster University, Hamilton, ON, Canada: 2013. Print.\n",
     "<a id=\"parnasClements1986\"></a>\n",
     "[7]: Parnas, David L. and Clements, P. C. \"A rational design process: How and why to fake it.\" <em>IEEE Transactions on Software Engineering</em>, vol. 12, no. 2, Washington, USA: February, 1986. pp. 251&ndash;257. Print.\n",
     "<a id=\"rbrtsn2012\"></a>\n",

--- a/code/stable/glassbr/SRS/PDF/GlassBR_SRS.tex
+++ b/code/stable/glassbr/SRS/PDF/GlassBR_SRS.tex
@@ -1746,7 +1746,7 @@ title={Glass-BR Software for the design and risk assessment of glass facades sub
 author={Campidelli, Manuel}}
 @mastersthesis{koothoor2013,
 author={Koothoor, Nirmitha},
-title={A document drive approach to certifying scientific computing software},
+title={A Document Driven Approach to Certifying Scientific Computing Software},
 school={McMaster University},
 year={2013},
 address={Hamilton, ON, Canada}}

--- a/code/stable/nopcm/SRS/HTML/NoPCM_SRS.html
+++ b/code/stable/nopcm/SRS/HTML/NoPCM_SRS.html
@@ -3479,7 +3479,7 @@
           </li>
           <li>
             <div id="koothoor2013">
-              [2]: Koothoor, Nirmitha. <em>A document drive approach to certifying scientific computing software</em>. McMaster University, Hamilton, ON, Canada: 2013. Print.
+              [2]: Koothoor, Nirmitha. <em>A Document Driven Approach to Certifying Scientific Computing Software</em>. McMaster University, Hamilton, ON, Canada: 2013. Print.
             </div>
           </li>
           <li>

--- a/code/stable/nopcm/SRS/JSON/NoPCM_SRS.ipynb
+++ b/code/stable/nopcm/SRS/JSON/NoPCM_SRS.ipynb
@@ -10,7 +10,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [

--- a/code/stable/nopcm/SRS/JSON/NoPCM_SRS.ipynb
+++ b/code/stable/nopcm/SRS/JSON/NoPCM_SRS.ipynb
@@ -10,6 +10,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -1415,7 +1416,7 @@
     "<a id=\"incroperaEtAl2007\"></a>\n",
     "[1]: Incropera, F. P., Dewitt, D. P., Bergman, T. L., and Lavine, A. S. <em>Fundamentals of Heat and Mass Transfer</em>. 6th. ed., Hoboken, New Jersey: John Wiley and Sons, 2007. Print.\n",
     "<a id=\"koothoor2013\"></a>\n",
-    "[2]: Koothoor, Nirmitha. <em>A document drive approach to certifying scientific computing software</em>. McMaster University, Hamilton, ON, Canada: 2013. Print.\n",
+    "[2]: Koothoor, Nirmitha. <em>A Document Driven Approach to Certifying Scientific Computing Software</em>. McMaster University, Hamilton, ON, Canada: 2013. Print.\n",
     "<a id=\"lightstone2012\"></a>\n",
     "[3]: Lightstone, Marilyn. <em>Derivation of tank/pcm model</em>. 2012. From Marilyn Lightstone's Personal Notes\n",
     "<a id=\"parnasClements1986\"></a>\n",

--- a/code/stable/nopcm/SRS/PDF/NoPCM_SRS.tex
+++ b/code/stable/nopcm/SRS/PDF/NoPCM_SRS.tex
@@ -1249,7 +1249,7 @@ edition={6},
 address={Hoboken, New Jersey}}
 @mastersthesis{koothoor2013,
 author={Koothoor, Nirmitha},
-title={A document drive approach to certifying scientific computing software},
+title={A Document Driven Approach to Certifying Scientific Computing Software},
 school={McMaster University},
 year={2013},
 address={Hamilton, ON, Canada}}

--- a/code/stable/sglpendulum/SRS/HTML/SglPendulum_SRS.html
+++ b/code/stable/sglpendulum/SRS/HTML/SglPendulum_SRS.html
@@ -2906,7 +2906,7 @@
           </li>
           <li>
             <div id="koothoor2013">
-              [2]: Koothoor, Nirmitha. <em>A document drive approach to certifying scientific computing software</em>. McMaster University, Hamilton, ON, Canada: 2013. Print.
+              [2]: Koothoor, Nirmitha. <em>A Document Driven Approach to Certifying Scientific Computing Software</em>. McMaster University, Hamilton, ON, Canada: 2013. Print.
             </div>
           </li>
           <li>

--- a/code/stable/sglpendulum/SRS/JSON/SglPendulum_SRS.ipynb
+++ b/code/stable/sglpendulum/SRS/JSON/SglPendulum_SRS.ipynb
@@ -10,7 +10,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [

--- a/code/stable/sglpendulum/SRS/JSON/SglPendulum_SRS.ipynb
+++ b/code/stable/sglpendulum/SRS/JSON/SglPendulum_SRS.ipynb
@@ -10,6 +10,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -1704,7 +1705,7 @@
     "<a id=\"hibbeler2004\"></a>\n",
     "[1]: Hibbeler, R. C. <em>Engineering Mechanics: Dynamics</em>. Pearson Prentice Hall, 2004. Print.\n",
     "<a id=\"koothoor2013\"></a>\n",
-    "[2]: Koothoor, Nirmitha. <em>A document drive approach to certifying scientific computing software</em>. McMaster University, Hamilton, ON, Canada: 2013. Print.\n",
+    "[2]: Koothoor, Nirmitha. <em>A Document Driven Approach to Certifying Scientific Computing Software</em>. McMaster University, Hamilton, ON, Canada: 2013. Print.\n",
     "<a id=\"parnasClements1986\"></a>\n",
     "[3]: Parnas, David L. and Clements, P. C. \"A rational design process: How and why to fake it.\" <em>IEEE Transactions on Software Engineering</em>, vol. 12, no. 2, Washington, USA: February, 1986. pp. 251&ndash;257. Print.\n",
     "<a id=\"smithLai2005\"></a>\n",

--- a/code/stable/sglpendulum/SRS/PDF/SglPendulum_SRS.tex
+++ b/code/stable/sglpendulum/SRS/PDF/SglPendulum_SRS.tex
@@ -1419,7 +1419,7 @@ publisher={Pearson Prentice Hall},
 year={2004}}
 @mastersthesis{koothoor2013,
 author={Koothoor, Nirmitha},
-title={A document drive approach to certifying scientific computing software},
+title={A Document Driven Approach to Certifying Scientific Computing Software},
 school={McMaster University},
 year={2013},
 address={Hamilton, ON, Canada}}

--- a/code/stable/ssp/SRS/HTML/SSP_SRS.html
+++ b/code/stable/ssp/SRS/HTML/SSP_SRS.html
@@ -9441,7 +9441,7 @@
           </li>
           <li>
             <div id="koothoor2013">
-              [4]: Koothoor, Nirmitha. <em>A document drive approach to certifying scientific computing software</em>. McMaster University, Hamilton, ON, Canada: 2013. Print.
+              [4]: Koothoor, Nirmitha. <em>A Document Driven Approach to Certifying Scientific Computing Software</em>. McMaster University, Hamilton, ON, Canada: 2013. Print.
             </div>
           </li>
           <li>

--- a/code/stable/ssp/SRS/JSON/SSP_SRS.ipynb
+++ b/code/stable/ssp/SRS/JSON/SSP_SRS.ipynb
@@ -10,7 +10,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [

--- a/code/stable/ssp/SRS/JSON/SSP_SRS.ipynb
+++ b/code/stable/ssp/SRS/JSON/SSP_SRS.ipynb
@@ -10,6 +10,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -3862,7 +3863,7 @@
     "<a id=\"karchewski2012\"></a>\n",
     "[3]: Canadian Geotechnical Society, Karchewski, Brandon, Guo, Peijun, and Stolle, Dieter. \"Influence of inherent anisotropy of soil strength on limit equilibrium slope stability analysis.\" <em>Proceedings of the 65th annual Canadian GeoTechnical Conference</em>. Winnipeg, MB, Canada: 2012.\n",
     "<a id=\"koothoor2013\"></a>\n",
-    "[4]: Koothoor, Nirmitha. <em>A document drive approach to certifying scientific computing software</em>. McMaster University, Hamilton, ON, Canada: 2013. Print.\n",
+    "[4]: Koothoor, Nirmitha. <em>A Document Driven Approach to Certifying Scientific Computing Software</em>. McMaster University, Hamilton, ON, Canada: 2013. Print.\n",
     "<a id=\"morgenstern1965\"></a>\n",
     "[5]: Morgenstern, N. R. and Price, P. E. \"The analysis of the stability of general slip surfaces.\" <em>Géotechnique</em>, no. 15, January, 1965. pp. 79&ndash;93. Print.\n",
     "<a id=\"parnasClements1986\"></a>\n",

--- a/code/stable/ssp/SRS/PDF/SSP_SRS.tex
+++ b/code/stable/ssp/SRS/PDF/SSP_SRS.tex
@@ -3086,7 +3086,7 @@ address={Winnipeg, MB, Canada},
 organization={Canadian Geotechnical Society}}
 @mastersthesis{koothoor2013,
 author={Koothoor, Nirmitha},
-title={A document drive approach to certifying scientific computing software},
+title={A Document Driven Approach to Certifying Scientific Computing Software},
 school={McMaster University},
 year={2013},
 address={Hamilton, ON, Canada}}

--- a/code/stable/swhs/SRS/HTML/SWHS_SRS.html
+++ b/code/stable/swhs/SRS/HTML/SWHS_SRS.html
@@ -6519,7 +6519,7 @@
           </li>
           <li>
             <div id="koothoor2013">
-              [3]: Koothoor, Nirmitha. <em>A document drive approach to certifying scientific computing software</em>. McMaster University, Hamilton, ON, Canada: 2013. Print.
+              [3]: Koothoor, Nirmitha. <em>A Document Driven Approach to Certifying Scientific Computing Software</em>. McMaster University, Hamilton, ON, Canada: 2013. Print.
             </div>
           </li>
           <li>

--- a/code/stable/swhs/SRS/JSON/SWHS_SRS.ipynb
+++ b/code/stable/swhs/SRS/JSON/SWHS_SRS.ipynb
@@ -10,7 +10,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [

--- a/code/stable/swhs/SRS/JSON/SWHS_SRS.ipynb
+++ b/code/stable/swhs/SRS/JSON/SWHS_SRS.ipynb
@@ -10,6 +10,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -2362,7 +2363,7 @@
     "<a id=\"incroperaEtAl2007\"></a>\n",
     "[2]: Incropera, F. P., Dewitt, D. P., Bergman, T. L., and Lavine, A. S. <em>Fundamentals of Heat and Mass Transfer</em>. 6th. ed., Hoboken, New Jersey: John Wiley and Sons, 2007. Print.\n",
     "<a id=\"koothoor2013\"></a>\n",
-    "[3]: Koothoor, Nirmitha. <em>A document drive approach to certifying scientific computing software</em>. McMaster University, Hamilton, ON, Canada: 2013. Print.\n",
+    "[3]: Koothoor, Nirmitha. <em>A Document Driven Approach to Certifying Scientific Computing Software</em>. McMaster University, Hamilton, ON, Canada: 2013. Print.\n",
     "<a id=\"lightstone2012\"></a>\n",
     "[4]: Lightstone, Marilyn. <em>Derivation of tank/pcm model</em>. 2012. From Marilyn Lightstone's Personal Notes\n",
     "<a id=\"parnasClements1986\"></a>\n",

--- a/code/stable/swhs/SRS/PDF/SWHS_SRS.tex
+++ b/code/stable/swhs/SRS/PDF/SWHS_SRS.tex
@@ -2011,7 +2011,7 @@ edition={6},
 address={Hoboken, New Jersey}}
 @mastersthesis{koothoor2013,
 author={Koothoor, Nirmitha},
-title={A document drive approach to certifying scientific computing software},
+title={A Document Driven Approach to Certifying Scientific Computing Software},
 school={McMaster University},
 year={2013},
 address={Hamilton, ON, Canada}}


### PR DESCRIPTION
Fixed Koothoor2013 reference in Citations.hs which had incorrectly stated the title of the thesis as "A document drive approach to certifying scientific computing software." This has now been fixed to include the correct title for the reference.