### PR TITLE
3209: Makes neglectCurv Assumption more Generic

### DIFF
--- a/code/drasil-example/projectile/lib/Drasil/Projectile/Assumptions.hs
+++ b/code/drasil-example/projectile/lib/Drasil/Projectile/Assumptions.hs
@@ -84,7 +84,7 @@ freeFlightDesc = S "The flight" `S.is` S "free; there" `S.are` S "no" +:+ plural
 
 neglectCurvDesc :: Sentence
 neglectCurvDesc = atStartNP (the distance) `S.is` S "small enough that" +:+.
-                  (S "curvature" `S.the_ofThe` S "Earth can be neglected")
+                  (S "curvature" `S.the_ofThe` S "celestial body can be neglected")
 
 timeStartZeroDesc :: Sentence
 timeStartZeroDesc = atStart time +:+. S "starts at zero"

--- a/code/stable/projectile/SRS/HTML/Projectile_SRS.html
+++ b/code/stable/projectile/SRS/HTML/Projectile_SRS.html
@@ -558,7 +558,7 @@
                   </p>
                   <p>
                     <div id="neglectCurv">
-                      neglectCurv: The distance is small enough that the curvature of the Earth can be neglected. (RefBy: <a href=#targetXAxis>A:targetXAxis</a> and <a href=#cartSyst>A:cartSyst</a>.)
+                      neglectCurv: The distance is small enough that the curvature of the celestial body can be neglected. (RefBy: <a href=#targetXAxis>A:targetXAxis</a> and <a href=#cartSyst>A:cartSyst</a>.)
                     </div>
                   </p>
                   <p>

--- a/code/stable/projectile/SRS/JSON/Projectile_SRS.ipynb
+++ b/code/stable/projectile/SRS/JSON/Projectile_SRS.ipynb
@@ -251,7 +251,7 @@
     "\n",
     "</div>\n",
     "<div id=\\\"neglectCurv\\\">\n",
-    "neglectCurv: The distance is small enough that the curvature of the Earth can be neglected. (RefBy: [A:targetXAxis](#targetXAxis) and [A:cartSyst](#cartSyst).)\n",
+    "neglectCurv: The distance is small enough that the curvature of the celestial body can be neglected. (RefBy: [A:targetXAxis](#targetXAxis) and [A:cartSyst](#cartSyst).)\n",
     "\n",
     "</div>\n",
     "<div id=\\\"timeStartZero\\\">\n",

--- a/code/stable/projectile/SRS/PDF/Projectile_SRS.tex
+++ b/code/stable/projectile/SRS/PDF/Projectile_SRS.tex
@@ -248,7 +248,7 @@ This section simplifies the original problem and helps in developing the theoret
 \item[neglectDrag:\phantomsection\label{neglectDrag}]{Air drag is neglected. (RefBy: \hyperref[constAccel]{A:constAccel}.)}
 \item[pointMass:\phantomsection\label{pointMass}]{The size and shape of the projectile are negligible, so that it can be modelled as a point mass. (RefBy: \hyperref[GD:rectPos]{GD:rectPos} and \hyperref[GD:rectVel]{GD:rectVel}.)}
 \item[freeFlight:\phantomsection\label{freeFlight}]{The flight is free; there are no collisions during the trajectory of the projectile. (RefBy: \hyperref[constAccel]{A:constAccel}.)}
-\item[neglectCurv:\phantomsection\label{neglectCurv}]{The distance is small enough that the curvature of the Earth can be neglected. (RefBy: \hyperref[targetXAxis]{A:targetXAxis} and \hyperref[cartSyst]{A:cartSyst}.)}
+\item[neglectCurv:\phantomsection\label{neglectCurv}]{The distance is small enough that the curvature of the celestial body can be neglected. (RefBy: \hyperref[targetXAxis]{A:targetXAxis} and \hyperref[cartSyst]{A:cartSyst}.)}
 \item[timeStartZero:\phantomsection\label{timeStartZero}]{Time starts at zero. (RefBy: \hyperref[GD:velVec]{GD:velVec}, \hyperref[GD:rectPos]{GD:rectPos}, \hyperref[GD:rectVel]{GD:rectVel}, \hyperref[GD:posVec]{GD:posVec}, and \hyperref[IM:calOfLandingTime]{IM:calOfLandingTime}.)}
 \item[gravAccelValue:\phantomsection\label{gravAccelValue}]{The acceleration due to gravity is assumed to have the value provided in the section for \hyperref[Sec:AuxConstants]{Values of Auxiliary Constants}. (RefBy: \hyperref[IM:calOfLandingDist]{IM:calOfLandingDist} and \hyperref[IM:calOfLandingTime]{IM:calOfLandingTime}.)}
 \end{itemize}


### PR DESCRIPTION
fixes #3209 : Projectile: make neglectCurv assumption more generic. Changes have been made to stable code and Assumptions.hs of the Projectile example.