### PR TITLE
Update Stack minor version

### DIFF
--- a/code/drasil-build/stack.yaml
+++ b/code/drasil-build/stack.yaml
@@ -18,7 +18,7 @@
 # resolver: ./custom-snapshot.yaml
 # resolver: https://example.com/snapshots/2018-01-01.yaml
 resolver:
-  url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/20/5.yaml
+  url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/20/20.yaml
 
 # User packages to be built.
 # Various formats can be used as shown in the example below.

--- a/code/drasil-code/stack.yaml
+++ b/code/drasil-code/stack.yaml
@@ -18,7 +18,7 @@
 # resolver: ./custom-snapshot.yaml
 # resolver: https://example.com/snapshots/2018-01-01.yaml
 resolver:
-  url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/20/5.yaml
+  url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/20/20.yaml
 
 # User packages to be built.
 # Various formats can be used as shown in the example below.

--- a/code/drasil-data/stack.yaml
+++ b/code/drasil-data/stack.yaml
@@ -18,7 +18,7 @@
 # resolver: ./custom-snapshot.yaml
 # resolver: https://example.com/snapshots/2018-01-01.yaml
 resolver:
-  url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/20/5.yaml
+  url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/20/20.yaml
 
 # User packages to be built.
 # Various formats can be used as shown in the example below.

--- a/code/drasil-database/stack.yaml
+++ b/code/drasil-database/stack.yaml
@@ -18,7 +18,7 @@
 # resolver: ./custom-snapshot.yaml
 # resolver: https://example.com/snapshots/2018-01-01.yaml
 resolver:
-  url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/20/5.yaml
+  url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/20/20.yaml
 
 # User packages to be built.
 # Various formats can be used as shown in the example below.

--- a/code/drasil-docLang/stack.yaml
+++ b/code/drasil-docLang/stack.yaml
@@ -18,7 +18,7 @@
 # resolver: ./custom-snapshot.yaml
 # resolver: https://example.com/snapshots/2018-01-01.yaml
 resolver:
-  url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/20/5.yaml
+  url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/20/20.yaml
 
 # User packages to be built.
 # Various formats can be used as shown in the example below.

--- a/code/drasil-example/dblpendulum/stack.yaml
+++ b/code/drasil-example/dblpendulum/stack.yaml
@@ -1,5 +1,5 @@
 resolver:
-  url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/20/5.yaml
+  url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/20/20.yaml
 
 packages:
 - .

--- a/code/drasil-example/gamephysics/stack.yaml
+++ b/code/drasil-example/gamephysics/stack.yaml
@@ -1,5 +1,5 @@
 resolver:
-  url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/20/5.yaml
+  url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/20/20.yaml
 
 packages:
 - .

--- a/code/drasil-example/glassbr/stack.yaml
+++ b/code/drasil-example/glassbr/stack.yaml
@@ -1,5 +1,5 @@
 resolver:
-  url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/20/5.yaml
+  url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/20/20.yaml
 
 packages:
 - .

--- a/code/drasil-example/hghc/stack.yaml
+++ b/code/drasil-example/hghc/stack.yaml
@@ -1,5 +1,5 @@
 resolver:
-  url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/20/5.yaml
+  url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/20/20.yaml
 
 packages:
 - .

--- a/code/drasil-example/nopcm/stack.yaml
+++ b/code/drasil-example/nopcm/stack.yaml
@@ -1,5 +1,5 @@
 resolver:
-  url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/20/5.yaml
+  url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/20/20.yaml
 
 packages:
 - .

--- a/code/drasil-example/pdcontroller/stack.yaml
+++ b/code/drasil-example/pdcontroller/stack.yaml
@@ -1,5 +1,5 @@
 resolver:
-  url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/20/5.yaml
+  url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/20/20.yaml
 
 packages:
 - .

--- a/code/drasil-example/projectile/stack.yaml
+++ b/code/drasil-example/projectile/stack.yaml
@@ -1,5 +1,5 @@
 resolver:
-  url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/20/5.yaml
+  url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/20/20.yaml
 
 packages:
 - .

--- a/code/drasil-example/sglpendulum/stack.yaml
+++ b/code/drasil-example/sglpendulum/stack.yaml
@@ -1,5 +1,5 @@
 resolver:
-  url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/20/5.yaml
+  url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/20/20.yaml
 
 packages:
 - .

--- a/code/drasil-example/ssp/stack.yaml
+++ b/code/drasil-example/ssp/stack.yaml
@@ -1,5 +1,5 @@
 resolver:
-  url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/20/5.yaml
+  url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/20/20.yaml
 
 packages:
 - .

--- a/code/drasil-example/swhs/stack.yaml
+++ b/code/drasil-example/swhs/stack.yaml
@@ -1,5 +1,5 @@
 resolver:
-  url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/20/5.yaml
+  url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/20/20.yaml
 
 packages:
 - .

--- a/code/drasil-example/template/stack.yaml
+++ b/code/drasil-example/template/stack.yaml
@@ -1,5 +1,5 @@
 resolver:
-  url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/20/5.yaml
+  url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/20/20.yaml
 
 packages:
 - .

--- a/code/drasil-gen/stack.yaml
+++ b/code/drasil-gen/stack.yaml
@@ -18,7 +18,7 @@
 # resolver: ./custom-snapshot.yaml
 # resolver: https://example.com/snapshots/2018-01-01.yaml
 resolver:
-  url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/20/5.yaml
+  url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/20/20.yaml
 
 # User packages to be built.
 # Various formats can be used as shown in the example below.

--- a/code/drasil-gool/stack.yaml
+++ b/code/drasil-gool/stack.yaml
@@ -18,7 +18,7 @@
 # resolver: ./custom-snapshot.yaml
 # resolver: https://example.com/snapshots/2018-01-01.yaml
 resolver:
-  url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/20/5.yaml
+  url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/20/20.yaml
 
 # User packages to be built.
 # Various formats can be used as shown in the example below.

--- a/code/drasil-lang/stack.yaml
+++ b/code/drasil-lang/stack.yaml
@@ -18,7 +18,7 @@
 # resolver: ./custom-snapshot.yaml
 # resolver: https://example.com/snapshots/2018-01-01.yaml
 resolver:
-  url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/20/5.yaml
+  url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/20/20.yaml
 
 # User packages to be built.
 # Various formats can be used as shown in the example below.

--- a/code/drasil-metadata/stack.yaml
+++ b/code/drasil-metadata/stack.yaml
@@ -16,7 +16,7 @@
 # resolver: ./custom-snapshot.yaml
 # resolver: https://example.com/snapshots/2018-01-01.yaml
 resolver:
-  url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/20/5.yaml
+  url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/20/20.yaml
 
 # User packages to be built.
 # Various formats can be used as shown in the example below.

--- a/code/drasil-printers/stack.yaml
+++ b/code/drasil-printers/stack.yaml
@@ -18,7 +18,7 @@
 # resolver: ./custom-snapshot.yaml
 # resolver: https://example.com/snapshots/2018-01-01.yaml
 resolver:
-  url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/20/5.yaml
+  url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/20/20.yaml
 
 # User packages to be built.
 # Various formats can be used as shown in the example below.

--- a/code/drasil-sysinfo/stack.yaml
+++ b/code/drasil-sysinfo/stack.yaml
@@ -18,7 +18,7 @@
 # resolver: ./custom-snapshot.yaml
 # resolver: https://example.com/snapshots/2018-01-01.yaml
 resolver:
-  url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/20/5.yaml
+  url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/20/20.yaml
 
 # User packages to be built.
 # Various formats can be used as shown in the example below.

--- a/code/drasil-theory/stack.yaml
+++ b/code/drasil-theory/stack.yaml
@@ -18,7 +18,7 @@
 # resolver: ./custom-snapshot.yaml
 # resolver: https://example.com/snapshots/2018-01-01.yaml
 resolver:
-  url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/20/5.yaml
+  url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/20/20.yaml
 
 # User packages to be built.
 # Various formats can be used as shown in the example below.

--- a/code/drasil-utils/stack.yaml
+++ b/code/drasil-utils/stack.yaml
@@ -18,7 +18,7 @@
 # resolver: ./custom-snapshot.yaml
 # resolver: https://example.com/snapshots/2018-01-01.yaml
 resolver:
-  url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/20/5.yaml
+  url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/20/20.yaml
 
 # User packages to be built.
 # Various formats can be used as shown in the example below.

--- a/code/drasil-website/stack.yaml
+++ b/code/drasil-website/stack.yaml
@@ -1,5 +1,5 @@
 resolver:
-  url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/20/5.yaml
+  url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/20/20.yaml
 
 packages:
 - .

--- a/code/stack.yaml
+++ b/code/stack.yaml
@@ -16,7 +16,7 @@
 #  name: custom-snapshot
 #  location: "./custom-snapshot.yaml"
 resolver:
-  url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/20/5.yaml
+  url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/20/20.yaml
 
 # User packages to be built.
 # Various formats can be used as shown in the example below.


### PR DESCRIPTION
Bumping from GHC 9.2.5 to 9.2.7 with the updated Stackage lists.