### PR TITLE
Fill `purpose` for examples other than Template, Game Physics, and HGHC

### DIFF
--- a/code/drasil-example/dblpendulum/lib/Drasil/DblPendulum/Body.hs
+++ b/code/drasil-example/dblpendulum/lib/Drasil/DblPendulum/Body.hs
@@ -123,7 +123,7 @@ si = SI {
 }
 
 purp :: Sentence
-purp = foldlSent_ [S "efficiently and correctly to predict the", phraseNP (motion `ofA` pendulum)]
+purp = foldlSent_ [S "efficiently and correctly predict the", phraseNP (motion `ofA` pendulum)]
 
 symbolsAll :: [QuantityDict]
 symbolsAll = symbols ++ scipyODESymbols ++ osloSymbols ++ apacheODESymbols ++ odeintSymbols 

--- a/code/drasil-example/dblpendulum/lib/Drasil/DblPendulum/Body.hs
+++ b/code/drasil-example/dblpendulum/lib/Drasil/DblPendulum/Body.hs
@@ -269,6 +269,7 @@ userCharacteristicsIntro = foldlSP
 -------------------------------
 -- 4.1 : System Constraints  --
 -------------------------------
+-- Introduction of the Problem Description section derived from purp
 
 ---------------------------------
 -- 4.1.1 Terminology and Definitions --

--- a/code/drasil-example/dblpendulum/lib/Drasil/DblPendulum/Body.hs
+++ b/code/drasil-example/dblpendulum/lib/Drasil/DblPendulum/Body.hs
@@ -75,7 +75,7 @@ mkSRS = [TableOfContents, -- This creates the Table of Contents
       SystCons [] []],                            
   SSDSec $ 
     SSDProg
-      [ SSDProblem $ PDProg prob []                --  This adds a is used to define the problem your system will solve
+      [ SSDProblem $ PDProg purp []                --  This adds a is used to define the problem your system will solve
         [ TermsAndDefs Nothing terms               -- This is used to define the terms to be defined in terminology sub section
       , PhySysDesc progName physSystParts figMotion [] -- This defines the Physicalsystem sub-section, define the parts
                                                           -- of the system using physSysParts, figMotion is a function in figures for the image
@@ -105,7 +105,7 @@ si = SI {
   _sys         = progName, 
   _kind        = Doc.srs,
   _authors     = [dong],
-  _purpose     = [],
+  _purpose     = [purp],
   _background  = [], 
   _quants      = symbolsAll,
   _concepts    = [] :: [DefinedQuantityDict],
@@ -121,6 +121,9 @@ si = SI {
   _usedinfodb  = usedDB,
    refdb       = refDB
 }
+
+purp :: Sentence
+purp = foldlSent_ [S "efficiently and correctly to predict the", phraseNP (motion `ofA` pendulum)]
 
 symbolsAll :: [QuantityDict]
 symbolsAll = symbols ++ scipyODESymbols ++ osloSymbols ++ apacheODESymbols ++ odeintSymbols 
@@ -266,8 +269,6 @@ userCharacteristicsIntro = foldlSP
 -------------------------------
 -- 4.1 : System Constraints  --
 -------------------------------
-prob :: Sentence
-prob = foldlSent_ [S "efficiently and correctly to predict the", phraseNP (motion `ofA` pendulum)]
 
 ---------------------------------
 -- 4.1.1 Terminology and Definitions --

--- a/code/drasil-example/glassbr/lib/Drasil/GlassBR/Body.hs
+++ b/code/drasil-example/glassbr/lib/Drasil/GlassBR/Body.hs
@@ -65,7 +65,7 @@ si = SI {
   _sys         = glassBR,
   _kind        = Doc.srs,
   _authors     = [nikitha, spencerSmith],
-  _purpose     = [],
+  _purpose     = [purp],
   _background  = [],
   _quants      = symbolsForTable,
   _concepts    = [] :: [DefinedQuantityDict],
@@ -102,7 +102,7 @@ mkSRS = [TableOfContents,
     UsrChars [userCharacteristicsIntro], SystCons [] [] ],
   SSDSec $
     SSDProg
-      [SSDProblem $ PDProg prob [termsAndDesc]
+      [SSDProblem $ PDProg purp [termsAndDesc]
         [ PhySysDesc glassBR physSystParts physSystFig []
         , Goals goalInputs],
        SSDSolChSpec $ SCSProg
@@ -125,6 +125,11 @@ mkSRS = [TableOfContents,
   AuxConstntSec $ AuxConsProg glassBR auxiliaryConstants,
   Bibliography,
   AppndxSec $ AppndxProg [appdxIntro, LlC demandVsSDFig, LlC dimlessloadVsARFig]]
+
+purp :: Sentence
+purp = foldlSent_ [S "efficiently" `S.and_` S "correctly predict whether a",
+  phrase glaSlab, S "can withstand a", phrase blast, S "under given",
+  plural condition]
 
 symbMap :: ChunkDB
 symbMap = cdb thisSymbols (map nw acronyms ++ map nw thisSymbols ++ map nw con
@@ -302,10 +307,7 @@ userCharacteristicsIntro = enumBulletU $ map foldlSent
 
 {--PROBLEM DESCRIPTION--}
 
-prob :: Sentence
-prob = foldlSent_ [S "efficiently" `S.and_` S "correctly predict whether a",
-  phrase glaSlab, S "can withstand a", phrase blast, S "under given",
-  plural condition]
+--Introduction of Problem Description section derived from purp
 
 {--Terminology and Definitions--}
 

--- a/code/drasil-example/nopcm/lib/Drasil/NoPCM/Body.hs
+++ b/code/drasil-example/nopcm/lib/Drasil/NoPCM/Body.hs
@@ -132,7 +132,7 @@ mkSRS = [TableOfContents,
       ],
   SSDSec $
     SSDProg
-    [ SSDProblem $ PDProg probDescIntro []
+    [ SSDProblem $ PDProg purp []
       [ TermsAndDefs Nothing terms
       , PhySysDesc progName physSystParts figTank []
       , Goals goalInputs]
@@ -174,7 +174,7 @@ si = SI {
   _sys         = srsSWHS,
   _kind        = Doc.srs,
   _authors     = [thulasi],
-  _purpose     = [],
+  _purpose     = [purp],
   _background  = [],
   -- FIXME: Everything after (and including) \\ should be removed when
   -- #1658 is resolved. Basically, _quants is used here, but 
@@ -193,6 +193,9 @@ si = SI {
   _usedinfodb  = usedDB,
    refdb       = refDB
 }
+
+purp :: Sentence
+purp = foldlSent_ [S "investigate the heating" `S.of_` phraseNP (water `inA` sWHT)]
 
 refDB :: ReferenceDB
 refDB = rdb citations concIns
@@ -279,8 +282,7 @@ orgDocEnd = foldlSent_ [atStartNP (the inModel),
 --Section 4.1 : PROBLEM DESCRIPTION
 -----------------------------------
 
-probDescIntro :: Sentence
-probDescIntro = foldlSent_ [S "investigate the heating" `S.of_` phraseNP (water `inA` sWHT)]
+--Introduction of Problem Description section derived from purp
 
 terms :: [ConceptChunk]
 terms = [htFlux, heatCapSpec, thermalConduction, transient]

--- a/code/drasil-example/pdcontroller/lib/Drasil/PDController/Body.hs
+++ b/code/drasil-example/pdcontroller/lib/Drasil/PDController/Body.hs
@@ -36,8 +36,7 @@ import Drasil.PDController.IntroSection
         introUserChar2, introscopeOfReq)
 import Drasil.PDController.References (citations)
 import Drasil.PDController.Requirements (funcReqs, nonfuncReqs)
-import Drasil.PDController.SpSysDesc
-       (goals, sysFigure, sysGoalInput, sysParts, sysProblemDesc)
+import Drasil.PDController.SpSysDesc (goals, sysFigure, sysGoalInput, sysParts)
 import Drasil.PDController.TModel (theoreticalModels)
 import Drasil.PDController.Unitals (symbols, inputs, outputs, inputsUC,
   inpConstrained, pidConstants, pidDqdConstants, opProcessVariable)
@@ -79,7 +78,7 @@ mkSRS
      SSDSec $
        SSDProg
          [SSDProblem $
-            PDProg sysProblemDesc []
+            PDProg purp []
               [TermsAndDefs Nothing defs,
                PhySysDesc pdControllerApp sysParts sysFigure [],
                Goals sysGoalInput],
@@ -102,7 +101,7 @@ si = SI {
   _sys = pdControllerApp,
   _kind = Doc.srs,
   _authors = [naveen],
-  _purpose = [],
+  _purpose = [purp],
   _background  = [],
   _quants = symbolsAll,
   _concepts = [] :: [DefinedQuantityDict],
@@ -117,6 +116,11 @@ si = SI {
   _sysinfodb = symbMap,
   _usedinfodb = usedDB,
    refdb = refDB}
+
+purp :: Sentence
+purp = foldlSent_ [S "provide a model of a", phrase pidC,
+         S "that can be used for the tuning of the gain constants before",
+         S "the deployment of the controller"]
 
 symbolsAll :: [QuantityDict]
 symbolsAll = symbols ++ map qw pidDqdConstants ++ map qw pidConstants

--- a/code/drasil-example/pdcontroller/lib/Drasil/PDController/SpSysDesc.hs
+++ b/code/drasil-example/pdcontroller/lib/Drasil/PDController/SpSysDesc.hs
@@ -6,12 +6,8 @@ import Drasil.PDController.Concepts
 import Language.Drasil
 import Language.Drasil.Chunk.Concept.NamedCombinators
 
-sysProblemDesc :: Sentence
-sysProblemDesc
-  = foldlSent_
-      [S "provide a model of a", phrase pidC,
-         S "that can be used for the tuning of the gain constants before",
-         S "the deployment of the controller"]
+-- Introduction of the Problem Description section derives from purpose in
+-- SystemInformation (purp in Body.hs)
 
 sysParts :: [Sentence]
 sysParts

--- a/code/drasil-example/projectile/lib/Drasil/Projectile/Body.hs
+++ b/code/drasil-example/projectile/lib/Drasil/Projectile/Body.hs
@@ -63,7 +63,7 @@ mkSRS = [TableOfContents,
       [ IScope scope ],
   SSDSec $
     SSDProg
-      [ SSDProblem $ PDProg prob []
+      [ SSDProblem $ PDProg purp []
         [ TermsAndDefs Nothing terms
         , PhySysDesc projectileTitle physSystParts figLaunch []
         , Goals [(phrase iVel +:+ S "vector") `S.the_ofThe` phrase projectile]]
@@ -105,7 +105,7 @@ si = SI {
   _sys         = projectileTitle,
   _kind        = Doc.srs,
   _authors     = [samCrawford, brooks, spencerSmith],
-  _purpose     = [],
+  _purpose     = [purp],
   _background  = [],
   _quants      = symbols,
   _concepts    = [] :: [DefinedQuantityDict],
@@ -121,6 +121,10 @@ si = SI {
   _usedinfodb  = usedDB,
    refdb       = refDB
 }
+
+purp :: Sentence
+purp = foldlSent_ [S "efficiently" `S.and_` S "correctly predict whether a launched",
+  phrase projectile, S"hits its", phrase target]
 
 tMods :: [TheoryModel]
 tMods = [accelerationTM, velocityTM]
@@ -150,9 +154,7 @@ concIns = assumptions ++ funcReqs ++ goals ++ nonfuncReqs
 -- Problem Description --
 -------------------------
 
-prob :: Sentence
-prob = foldlSent_ [S "efficiently" `S.and_` S "correctly predict whether a launched",
-  phrase projectile, S"hits its", phrase target]
+-- Introduction of the Problem Description section derives from purp
 
 ---------------------------------
 -- Terminology and Definitions --

--- a/code/drasil-example/projectile/lib/Drasil/Projectile/Body.hs
+++ b/code/drasil-example/projectile/lib/Drasil/Projectile/Body.hs
@@ -124,7 +124,7 @@ si = SI {
 
 purp :: Sentence
 purp = foldlSent_ [S "efficiently" `S.and_` S "correctly predict whether a launched",
-  phrase projectile, S"hits its", phrase target]
+  phrase projectile, S "hits its", phrase target]
 
 tMods :: [TheoryModel]
 tMods = [accelerationTM, velocityTM]

--- a/code/drasil-example/sglpendulum/lib/Drasil/SglPendulum/Body.hs
+++ b/code/drasil-example/sglpendulum/lib/Drasil/SglPendulum/Body.hs
@@ -26,7 +26,7 @@ import Data.Drasil.Quantities.Math (unitVect, unitVectj)
 import Data.Drasil.Quantities.Physics (physicscon)
 
 import Drasil.DblPendulum.Assumptions (assumpSingle)
-import Drasil.DblPendulum.Body (justification, charsOfReader, prob, organizationOfDocumentsIntro,
+import Drasil.DblPendulum.Body (justification, charsOfReader, purp, organizationOfDocumentsIntro,
   sysCtxIntro, sysCtxDesc, sysCtxList, stdFields, scope, terms, userCharacteristicsIntro)
 import qualified Drasil.DblPendulum.Body as DPD (tMods)
 import Drasil.DblPendulum.Concepts (concepts, rod)
@@ -73,7 +73,7 @@ mkSRS = [TableOfContents, -- This creates the Table of Contents
       SystCons [] []],                            
   SSDSec $ 
     SSDProg
-      [ SSDProblem $ PDProg prob []                --  This adds a is used to define the problem your system will solve
+      [ SSDProblem $ PDProg purp []                --  This adds a is used to define the problem your system will solve
         [ TermsAndDefs Nothing terms               -- This is used to define the terms to be defined in terminology sub section
       , PhySysDesc progName physSystParts figMotion [] -- This defines the Physicalsystem sub-section, define the parts
                                                           -- of the system using physSysParts, figMotion is a function in figures for the image
@@ -107,7 +107,7 @@ si = SI {
   _kind        = Doc.srs,
   _authors     = [olu],
   _purpose     = [],
-  _background  = [],
+  _background  = [purp],
   _quants      = symbols,
   _concepts    = [] :: [DefinedQuantityDict],
   _instModels  = iMods,

--- a/code/drasil-example/ssp/lib/Drasil/SSP/Body.hs
+++ b/code/drasil-example/ssp/lib/Drasil/SSP/Body.hs
@@ -73,7 +73,7 @@ si = SI {
   _sys         = ssp, 
   _kind        = Doc.srs, 
   _authors     = [henryFrankis, brooks],
-  _purpose     = [],
+  _purpose     = [purp],
   _background  = [],
   _quants      = symbols,
   _concepts    = [] :: [DefinedQuantityDict],
@@ -110,7 +110,7 @@ mkSRS = [TableOfContents,
     ],
   SSDSec $
     SSDProg
-      [ SSDProblem $ PDProg prob []
+      [ SSDProblem $ PDProg purp []
         [ TermsAndDefs Nothing terms
         , PhySysDesc ssp physSystParts figPhysSyst physSystContents 
         , Goals goalsInputs]
@@ -133,6 +133,12 @@ mkSRS = [TableOfContents,
   TraceabilitySec $ TraceabilityProg $ traceMatStandard si,
   AuxConstntSec $ AuxConsProg ssp [],
   Bibliography]
+
+purp :: Sentence
+purp = foldlSent_ [S "evaluate the", phrase fs `S.ofA` phrasePoss slope,
+  phrase slpSrf `S.and_` S "identify", phraseNP (crtSlpSrf `the_ofThe` slope) `sC`
+  S "as well as the", phrase intrslce, phraseNP (normForce `and_` shearForce),
+  S "along the", phrase crtSlpSrf]
 
 units :: [UnitDefn]
 units = map unitWrapper [metre, degree, kilogram, second] ++ map unitWrapper [newton, pascal]
@@ -313,11 +319,8 @@ sysConstraints = foldlSP [atStartNP (NP.the (combineNINI morPrice method_)),
 -- SECTION 4 --
 
 -- SECTION 4.1 --
-prob :: Sentence
-prob = foldlSent_ [S "evaluate the", phrase fs `S.ofA` phrasePoss slope,
-  phrase slpSrf `S.and_` S "identify", phraseNP (crtSlpSrf `the_ofThe` slope) `sC`
-  S "as well as the", phrase intrslce, phraseNP (normForce `and_` shearForce),
-  S "along the", phrase crtSlpSrf]
+
+-- Introduction of the Problem Description section derives from purp
 
 {-
 From when solution was used in Problem Description:

--- a/code/drasil-example/swhs/lib/Drasil/SWHS/Body.hs
+++ b/code/drasil-example/swhs/lib/Drasil/SWHS/Body.hs
@@ -78,7 +78,7 @@ si = SI {
   _sys         = swhsPCM,
   _kind        = Doc.srs, 
   _authors     = [thulasi, brooks, spencerSmith],
-  _purpose     = [],
+  _purpose     = [purp],
   _background  = [],
   _quants      = symbols,
   _concepts    = [] :: [DefinedQuantityDict],
@@ -94,6 +94,10 @@ si = SI {
   _usedinfodb  = usedDB,
    refdb       = refDB
 }
+
+purp :: Sentence
+purp = foldlSent_ [S "investigate the effect" `S.of_` S "employing",
+  short phsChgMtrl, S "within a", phrase sWHT]
 
 symbMap :: ChunkDB
 symbMap = cdb (qw heatEInPCM : symbolsAll) -- heatEInPCM ?
@@ -133,7 +137,7 @@ mkSRS = [TableOfContents,
     ],
   SSDSec $
     SSDProg 
-      [ SSDProblem $ PDProg probDescIntro []
+      [ SSDProblem $ PDProg purp []
         [ TermsAndDefs Nothing terms
         , PhySysDesc progName physSystParts figTank []
         , Goals goalInputs]
@@ -353,9 +357,8 @@ userChars pro = foldlSP [S "The end", phrase user `S.of_` short pro,
 -------------------------------
 -- 4.1 : Problem Description --
 -------------------------------
-probDescIntro :: Sentence
-probDescIntro = foldlSent_ [S "investigate the effect" `S.of_` S "employing",
-  short phsChgMtrl, S "within a", phrase sWHT]
+
+-- Introduction of Problem Description section derived from purp
 
 -----------------------------------------
 -- 4.1.1 : Terminology and Definitions --

--- a/code/stable/dblpendulum/SRS/HTML/DblPendulum_SRS.html
+++ b/code/stable/dblpendulum/SRS/HTML/DblPendulum_SRS.html
@@ -530,7 +530,7 @@
           <div class="subsection">
             <h2>Problem Description</h2>
             <p class="paragraph">
-              A system is needed to efficiently and correctly to predict the motion of a pendulum.
+              A system is needed to efficiently and correctly predict the motion of a pendulum.
             </p>
             <div id="Sec:TermDefs">
               <div class="subsubsection">

--- a/code/stable/dblpendulum/SRS/JSON/DblPendulum_SRS.ipynb
+++ b/code/stable/dblpendulum/SRS/JSON/DblPendulum_SRS.ipynb
@@ -215,7 +215,7 @@
     "## Problem Description\n",
     "<a id=\"Sec:ProbDesc\"></a>\n",
     "\n",
-    "A system is needed to efficiently and correctly to predict the motion of a pendulum.\n",
+    "A system is needed to efficiently and correctly predict the motion of a pendulum.\n",
     "\n",
     "### Terminology and Definitions\n",
     "<a id=\"Sec:TermDefs\"></a>\n",

--- a/code/stable/dblpendulum/SRS/PDF/DblPendulum_SRS.tex
+++ b/code/stable/dblpendulum/SRS/PDF/DblPendulum_SRS.tex
@@ -248,7 +248,7 @@ This section first presents the problem description, which gives a high-level vi
 
 \subsection{Problem Description}
 \label{Sec:ProbDesc}
-A system is needed to efficiently and correctly to predict the motion of a pendulum.
+A system is needed to efficiently and correctly predict the motion of a pendulum.
 
 \subsubsection{Terminology and Definitions}
 \label{Sec:TermDefs}

--- a/code/stable/dblpendulum/src/cpp/README.md
+++ b/code/stable/dblpendulum/src/cpp/README.md
@@ -1,6 +1,8 @@
 # DblPendulum 
 > Author: Dong Chen
 
+> Purpose: efficiently and correctly to predict the motion of a pendulum.
+
 ------------------------------------------------------------
 ## Making Examples 
  How to Run the Program:

--- a/code/stable/dblpendulum/src/cpp/README.md
+++ b/code/stable/dblpendulum/src/cpp/README.md
@@ -1,7 +1,7 @@
 # DblPendulum 
 > Author: Dong Chen
 
-> Purpose: efficiently and correctly to predict the motion of a pendulum.
+> Purpose: efficiently and correctly predict the motion of a pendulum.
 
 ------------------------------------------------------------
 ## Making Examples 

--- a/code/stable/dblpendulum/src/csharp/README.md
+++ b/code/stable/dblpendulum/src/csharp/README.md
@@ -1,6 +1,8 @@
 # DblPendulum 
 > Author: Dong Chen
 
+> Purpose: efficiently and correctly to predict the motion of a pendulum.
+
 ------------------------------------------------------------
 ## Making Examples 
  How to Run the Program:

--- a/code/stable/dblpendulum/src/csharp/README.md
+++ b/code/stable/dblpendulum/src/csharp/README.md
@@ -1,7 +1,7 @@
 # DblPendulum 
 > Author: Dong Chen
 
-> Purpose: efficiently and correctly to predict the motion of a pendulum.
+> Purpose: efficiently and correctly predict the motion of a pendulum.
 
 ------------------------------------------------------------
 ## Making Examples 

--- a/code/stable/dblpendulum/src/java/README.md
+++ b/code/stable/dblpendulum/src/java/README.md
@@ -1,6 +1,8 @@
 # DblPendulum 
 > Author: Dong Chen
 
+> Purpose: efficiently and correctly to predict the motion of a pendulum.
+
 ------------------------------------------------------------
 ## Making Examples 
  How to Run the Program:

--- a/code/stable/dblpendulum/src/java/README.md
+++ b/code/stable/dblpendulum/src/java/README.md
@@ -1,7 +1,7 @@
 # DblPendulum 
 > Author: Dong Chen
 
-> Purpose: efficiently and correctly to predict the motion of a pendulum.
+> Purpose: efficiently and correctly predict the motion of a pendulum.
 
 ------------------------------------------------------------
 ## Making Examples 

--- a/code/stable/dblpendulum/src/python/README.md
+++ b/code/stable/dblpendulum/src/python/README.md
@@ -1,6 +1,8 @@
 # DblPendulum 
 > Author: Dong Chen
 
+> Purpose: efficiently and correctly to predict the motion of a pendulum.
+
 ------------------------------------------------------------
 ## Making Examples 
  How to Run the Program:

--- a/code/stable/dblpendulum/src/python/README.md
+++ b/code/stable/dblpendulum/src/python/README.md
@@ -1,7 +1,7 @@
 # DblPendulum 
 > Author: Dong Chen
 
-> Purpose: efficiently and correctly to predict the motion of a pendulum.
+> Purpose: efficiently and correctly predict the motion of a pendulum.
 
 ------------------------------------------------------------
 ## Making Examples 

--- a/code/stable/glassbr/src/cpp/README.md
+++ b/code/stable/glassbr/src/cpp/README.md
@@ -1,6 +1,8 @@
 # GlassBR 
 > Authors:  Nikitha Krithnan, W. Spencer Smith
 
+> Purpose: efficiently and correctly predict whether a glass slab can withstand a blast under given conditions.
+
 ------------------------------------------------------------
 ## Making Examples 
  How to Run the Program:

--- a/code/stable/glassbr/src/csharp/README.md
+++ b/code/stable/glassbr/src/csharp/README.md
@@ -1,6 +1,8 @@
 # GlassBR 
 > Authors:  Nikitha Krithnan, W. Spencer Smith
 
+> Purpose: efficiently and correctly predict whether a glass slab can withstand a blast under given conditions.
+
 ------------------------------------------------------------
 ## Making Examples 
  How to Run the Program:

--- a/code/stable/glassbr/src/java/README.md
+++ b/code/stable/glassbr/src/java/README.md
@@ -1,6 +1,8 @@
 # GlassBR 
 > Authors:  Nikitha Krithnan, W. Spencer Smith
 
+> Purpose: efficiently and correctly predict whether a glass slab can withstand a blast under given conditions.
+
 ------------------------------------------------------------
 ## Making Examples 
  How to Run the Program:

--- a/code/stable/glassbr/src/python/README.md
+++ b/code/stable/glassbr/src/python/README.md
@@ -1,6 +1,8 @@
 # GlassBR 
 > Authors:  Nikitha Krithnan, W. Spencer Smith
 
+> Purpose: efficiently and correctly predict whether a glass slab can withstand a blast under given conditions.
+
 ------------------------------------------------------------
 ## Making Examples 
  How to Run the Program:

--- a/code/stable/glassbr/src/swift/README.md
+++ b/code/stable/glassbr/src/swift/README.md
@@ -1,6 +1,8 @@
 # GlassBR 
 > Authors:  Nikitha Krithnan, W. Spencer Smith
 
+> Purpose: efficiently and correctly predict whether a glass slab can withstand a blast under given conditions.
+
 ------------------------------------------------------------
 ## Making Examples 
  How to Run the Program:

--- a/code/stable/nopcm/src/cpp/README.md
+++ b/code/stable/nopcm/src/cpp/README.md
@@ -1,6 +1,8 @@
 # NoPCM 
 > Author: Thulasi Jegatheesan
 
+> Purpose: investigate the heating of water in a solar water heating tank.
+
 ------------------------------------------------------------
 ## Making Examples 
  How to Run the Program:

--- a/code/stable/nopcm/src/csharp/README.md
+++ b/code/stable/nopcm/src/csharp/README.md
@@ -1,6 +1,8 @@
 # NoPCM 
 > Author: Thulasi Jegatheesan
 
+> Purpose: investigate the heating of water in a solar water heating tank.
+
 ------------------------------------------------------------
 ## Making Examples 
  How to Run the Program:

--- a/code/stable/nopcm/src/java/README.md
+++ b/code/stable/nopcm/src/java/README.md
@@ -1,6 +1,8 @@
 # NoPCM 
 > Author: Thulasi Jegatheesan
 
+> Purpose: investigate the heating of water in a solar water heating tank.
+
 ------------------------------------------------------------
 ## Making Examples 
  How to Run the Program:

--- a/code/stable/nopcm/src/python/README.md
+++ b/code/stable/nopcm/src/python/README.md
@@ -1,6 +1,8 @@
 # NoPCM 
 > Author: Thulasi Jegatheesan
 
+> Purpose: investigate the heating of water in a solar water heating tank.
+
 ------------------------------------------------------------
 ## Making Examples 
  How to Run the Program:

--- a/code/stable/pdcontroller/src/cpp/README.md
+++ b/code/stable/pdcontroller/src/cpp/README.md
@@ -1,6 +1,8 @@
 # PD_Controller 
 > Author: Naveen Ganesh Muralidharan
 
+> Purpose: provide a model of a PD Controller that can be used for the tuning of the gain constants before the deployment of the controller.
+
 ------------------------------------------------------------
 ## Making Examples 
  How to Run the Program:

--- a/code/stable/pdcontroller/src/csharp/README.md
+++ b/code/stable/pdcontroller/src/csharp/README.md
@@ -1,6 +1,8 @@
 # PD_Controller 
 > Author: Naveen Ganesh Muralidharan
 
+> Purpose: provide a model of a PD Controller that can be used for the tuning of the gain constants before the deployment of the controller.
+
 ------------------------------------------------------------
 ## Making Examples 
  How to Run the Program:

--- a/code/stable/pdcontroller/src/java/README.md
+++ b/code/stable/pdcontroller/src/java/README.md
@@ -1,6 +1,8 @@
 # PD_Controller 
 > Author: Naveen Ganesh Muralidharan
 
+> Purpose: provide a model of a PD Controller that can be used for the tuning of the gain constants before the deployment of the controller.
+
 ------------------------------------------------------------
 ## Making Examples 
  How to Run the Program:

--- a/code/stable/pdcontroller/src/python/README.md
+++ b/code/stable/pdcontroller/src/python/README.md
@@ -1,6 +1,8 @@
 # PD_Controller 
 > Author: Naveen Ganesh Muralidharan
 
+> Purpose: provide a model of a PD Controller that can be used for the tuning of the gain constants before the deployment of the controller.
+
 ------------------------------------------------------------
 ## Making Examples 
  How to Run the Program:

--- a/code/stable/projectile/projectile_c_p_nol_b_u_v_d/src/cpp/README.md
+++ b/code/stable/projectile/projectile_c_p_nol_b_u_v_d/src/cpp/README.md
@@ -1,6 +1,8 @@
 # Projectile 
 > Authors:  Samuel J. Crawford, Brooks MacLachlan, W. Spencer Smith
 
+> Purpose: efficiently and correctly predict whether a launched projectile hits its target.
+
 ------------------------------------------------------------
 ## Making Examples 
  How to Run the Program:

--- a/code/stable/projectile/projectile_c_p_nol_b_u_v_d/src/csharp/README.md
+++ b/code/stable/projectile/projectile_c_p_nol_b_u_v_d/src/csharp/README.md
@@ -1,6 +1,8 @@
 # Projectile 
 > Authors:  Samuel J. Crawford, Brooks MacLachlan, W. Spencer Smith
 
+> Purpose: efficiently and correctly predict whether a launched projectile hits its target.
+
 ------------------------------------------------------------
 ## Making Examples 
  How to Run the Program:

--- a/code/stable/projectile/projectile_c_p_nol_b_u_v_d/src/java/README.md
+++ b/code/stable/projectile/projectile_c_p_nol_b_u_v_d/src/java/README.md
@@ -1,6 +1,8 @@
 # Projectile 
 > Authors:  Samuel J. Crawford, Brooks MacLachlan, W. Spencer Smith
 
+> Purpose: efficiently and correctly predict whether a launched projectile hits its target.
+
 ------------------------------------------------------------
 ## Making Examples 
  How to Run the Program:

--- a/code/stable/projectile/projectile_c_p_nol_b_u_v_d/src/python/README.md
+++ b/code/stable/projectile/projectile_c_p_nol_b_u_v_d/src/python/README.md
@@ -1,6 +1,8 @@
 # Projectile 
 > Authors:  Samuel J. Crawford, Brooks MacLachlan, W. Spencer Smith
 
+> Purpose: efficiently and correctly predict whether a launched projectile hits its target.
+
 ------------------------------------------------------------
 ## Making Examples 
  How to Run the Program:

--- a/code/stable/projectile/projectile_c_p_nol_b_u_v_d/src/swift/README.md
+++ b/code/stable/projectile/projectile_c_p_nol_b_u_v_d/src/swift/README.md
@@ -1,6 +1,8 @@
 # Projectile 
 > Authors:  Samuel J. Crawford, Brooks MacLachlan, W. Spencer Smith
 
+> Purpose: efficiently and correctly predict whether a launched projectile hits its target.
+
 ------------------------------------------------------------
 ## Making Examples 
  How to Run the Program:

--- a/code/stable/projectile/projectile_s_l_nol_u_u_v_f/src/cpp/README.md
+++ b/code/stable/projectile/projectile_s_l_nol_u_u_v_f/src/cpp/README.md
@@ -1,6 +1,8 @@
 # Projectile 
 > Authors:  Samuel J. Crawford, Brooks MacLachlan, W. Spencer Smith
 
+> Purpose: efficiently and correctly predict whether a launched projectile hits its target.
+
 ------------------------------------------------------------
 ## Version 
  `C++ gcc 10.1`

--- a/code/stable/projectile/projectile_s_l_nol_u_u_v_f/src/csharp/README.md
+++ b/code/stable/projectile/projectile_s_l_nol_u_u_v_f/src/csharp/README.md
@@ -1,6 +1,8 @@
 # Projectile 
 > Authors:  Samuel J. Crawford, Brooks MacLachlan, W. Spencer Smith
 
+> Purpose: efficiently and correctly predict whether a launched projectile hits its target.
+
 ------------------------------------------------------------
 ## Version 
  `C# 6.0`

--- a/code/stable/projectile/projectile_s_l_nol_u_u_v_f/src/java/README.md
+++ b/code/stable/projectile/projectile_s_l_nol_u_u_v_f/src/java/README.md
@@ -1,6 +1,8 @@
 # Projectile 
 > Authors:  Samuel J. Crawford, Brooks MacLachlan, W. Spencer Smith
 
+> Purpose: efficiently and correctly predict whether a launched projectile hits its target.
+
 ------------------------------------------------------------
 ## Version 
  `Java 14`

--- a/code/stable/projectile/projectile_s_l_nol_u_u_v_f/src/python/README.md
+++ b/code/stable/projectile/projectile_s_l_nol_u_u_v_f/src/python/README.md
@@ -1,6 +1,8 @@
 # Projectile 
 > Authors:  Samuel J. Crawford, Brooks MacLachlan, W. Spencer Smith
 
+> Purpose: efficiently and correctly predict whether a launched projectile hits its target.
+
 ------------------------------------------------------------
 ## Version 
  `Python 3.5.1`

--- a/code/stable/projectile/projectile_s_l_nol_u_u_v_f/src/swift/README.md
+++ b/code/stable/projectile/projectile_s_l_nol_u_u_v_f/src/swift/README.md
@@ -1,6 +1,8 @@
 # Projectile 
 > Authors:  Samuel J. Crawford, Brooks MacLachlan, W. Spencer Smith
 
+> Purpose: efficiently and correctly predict whether a launched projectile hits its target.
+
 ------------------------------------------------------------
 ## Version 
  `Swift 5.2.4`

--- a/code/stable/projectile/projectile_u_p_l_b_b_c_d/src/cpp/README.md
+++ b/code/stable/projectile/projectile_u_p_l_b_b_c_d/src/cpp/README.md
@@ -1,6 +1,8 @@
 # Projectile 
 > Authors:  Samuel J. Crawford, Brooks MacLachlan, W. Spencer Smith
 
+> Purpose: efficiently and correctly predict whether a launched projectile hits its target.
+
 ------------------------------------------------------------
 ## Making Examples 
  How to Run the Program:

--- a/code/stable/projectile/projectile_u_p_l_b_b_c_d/src/csharp/README.md
+++ b/code/stable/projectile/projectile_u_p_l_b_b_c_d/src/csharp/README.md
@@ -1,6 +1,8 @@
 # Projectile 
 > Authors:  Samuel J. Crawford, Brooks MacLachlan, W. Spencer Smith
 
+> Purpose: efficiently and correctly predict whether a launched projectile hits its target.
+
 ------------------------------------------------------------
 ## Making Examples 
  How to Run the Program:

--- a/code/stable/projectile/projectile_u_p_l_b_b_c_d/src/java/README.md
+++ b/code/stable/projectile/projectile_u_p_l_b_b_c_d/src/java/README.md
@@ -1,6 +1,8 @@
 # Projectile 
 > Authors:  Samuel J. Crawford, Brooks MacLachlan, W. Spencer Smith
 
+> Purpose: efficiently and correctly predict whether a launched projectile hits its target.
+
 ------------------------------------------------------------
 ## Making Examples 
  How to Run the Program:

--- a/code/stable/projectile/projectile_u_p_l_b_b_c_d/src/python/README.md
+++ b/code/stable/projectile/projectile_u_p_l_b_b_c_d/src/python/README.md
@@ -1,6 +1,8 @@
 # Projectile 
 > Authors:  Samuel J. Crawford, Brooks MacLachlan, W. Spencer Smith
 
+> Purpose: efficiently and correctly predict whether a launched projectile hits its target.
+
 ------------------------------------------------------------
 ## Making Examples 
  How to Run the Program:

--- a/code/stable/projectile/projectile_u_p_l_b_b_c_d/src/swift/README.md
+++ b/code/stable/projectile/projectile_u_p_l_b_b_c_d/src/swift/README.md
@@ -1,6 +1,8 @@
 # Projectile 
 > Authors:  Samuel J. Crawford, Brooks MacLachlan, W. Spencer Smith
 
+> Purpose: efficiently and correctly predict whether a launched projectile hits its target.
+
 ------------------------------------------------------------
 ## Making Examples 
  How to Run the Program:

--- a/code/stable/projectile/projectile_u_p_l_b_wi_v_f/src/cpp/README.md
+++ b/code/stable/projectile/projectile_u_p_l_b_wi_v_f/src/cpp/README.md
@@ -1,6 +1,8 @@
 # Projectile 
 > Authors:  Samuel J. Crawford, Brooks MacLachlan, W. Spencer Smith
 
+> Purpose: efficiently and correctly predict whether a launched projectile hits its target.
+
 ------------------------------------------------------------
 ## Making Examples 
  How to Run the Program:

--- a/code/stable/projectile/projectile_u_p_l_b_wi_v_f/src/csharp/README.md
+++ b/code/stable/projectile/projectile_u_p_l_b_wi_v_f/src/csharp/README.md
@@ -1,6 +1,8 @@
 # Projectile 
 > Authors:  Samuel J. Crawford, Brooks MacLachlan, W. Spencer Smith
 
+> Purpose: efficiently and correctly predict whether a launched projectile hits its target.
+
 ------------------------------------------------------------
 ## Making Examples 
  How to Run the Program:

--- a/code/stable/projectile/projectile_u_p_l_b_wi_v_f/src/java/README.md
+++ b/code/stable/projectile/projectile_u_p_l_b_wi_v_f/src/java/README.md
@@ -1,6 +1,8 @@
 # Projectile 
 > Authors:  Samuel J. Crawford, Brooks MacLachlan, W. Spencer Smith
 
+> Purpose: efficiently and correctly predict whether a launched projectile hits its target.
+
 ------------------------------------------------------------
 ## Making Examples 
  How to Run the Program:

--- a/code/stable/projectile/projectile_u_p_l_b_wi_v_f/src/python/README.md
+++ b/code/stable/projectile/projectile_u_p_l_b_wi_v_f/src/python/README.md
@@ -1,6 +1,8 @@
 # Projectile 
 > Authors:  Samuel J. Crawford, Brooks MacLachlan, W. Spencer Smith
 
+> Purpose: efficiently and correctly predict whether a launched projectile hits its target.
+
 ------------------------------------------------------------
 ## Making Examples 
  How to Run the Program:

--- a/code/stable/projectile/projectile_u_p_l_b_wi_v_f/src/swift/README.md
+++ b/code/stable/projectile/projectile_u_p_l_b_wi_v_f/src/swift/README.md
@@ -1,6 +1,8 @@
 # Projectile 
 > Authors:  Samuel J. Crawford, Brooks MacLachlan, W. Spencer Smith
 
+> Purpose: efficiently and correctly predict whether a launched projectile hits its target.
+
 ------------------------------------------------------------
 ## Making Examples 
  How to Run the Program:

--- a/code/stable/projectile/projectile_u_p_nol_u_wi_v_d/src/cpp/README.md
+++ b/code/stable/projectile/projectile_u_p_nol_u_wi_v_d/src/cpp/README.md
@@ -1,6 +1,8 @@
 # Projectile 
 > Authors:  Samuel J. Crawford, Brooks MacLachlan, W. Spencer Smith
 
+> Purpose: efficiently and correctly predict whether a launched projectile hits its target.
+
 ------------------------------------------------------------
 ## Making Examples 
  How to Run the Program:

--- a/code/stable/projectile/projectile_u_p_nol_u_wi_v_d/src/csharp/README.md
+++ b/code/stable/projectile/projectile_u_p_nol_u_wi_v_d/src/csharp/README.md
@@ -1,6 +1,8 @@
 # Projectile 
 > Authors:  Samuel J. Crawford, Brooks MacLachlan, W. Spencer Smith
 
+> Purpose: efficiently and correctly predict whether a launched projectile hits its target.
+
 ------------------------------------------------------------
 ## Making Examples 
  How to Run the Program:

--- a/code/stable/projectile/projectile_u_p_nol_u_wi_v_d/src/java/README.md
+++ b/code/stable/projectile/projectile_u_p_nol_u_wi_v_d/src/java/README.md
@@ -1,6 +1,8 @@
 # Projectile 
 > Authors:  Samuel J. Crawford, Brooks MacLachlan, W. Spencer Smith
 
+> Purpose: efficiently and correctly predict whether a launched projectile hits its target.
+
 ------------------------------------------------------------
 ## Making Examples 
  How to Run the Program:

--- a/code/stable/projectile/projectile_u_p_nol_u_wi_v_d/src/python/README.md
+++ b/code/stable/projectile/projectile_u_p_nol_u_wi_v_d/src/python/README.md
@@ -1,6 +1,8 @@
 # Projectile 
 > Authors:  Samuel J. Crawford, Brooks MacLachlan, W. Spencer Smith
 
+> Purpose: efficiently and correctly predict whether a launched projectile hits its target.
+
 ------------------------------------------------------------
 ## Making Examples 
  How to Run the Program:

--- a/code/stable/projectile/projectile_u_p_nol_u_wi_v_d/src/swift/README.md
+++ b/code/stable/projectile/projectile_u_p_nol_u_wi_v_d/src/swift/README.md
@@ -1,6 +1,8 @@
 # Projectile 
 > Authors:  Samuel J. Crawford, Brooks MacLachlan, W. Spencer Smith
 
+> Purpose: efficiently and correctly predict whether a launched projectile hits its target.
+
 ------------------------------------------------------------
 ## Making Examples 
  How to Run the Program:

--- a/code/stable/sglpendulum/SRS/HTML/SglPendulum_SRS.html
+++ b/code/stable/sglpendulum/SRS/HTML/SglPendulum_SRS.html
@@ -505,7 +505,7 @@
           <div class="subsection">
             <h2>Problem Description</h2>
             <p class="paragraph">
-              A system is needed to efficiently and correctly to predict the motion of a pendulum.
+              A system is needed to efficiently and correctly predict the motion of a pendulum.
             </p>
             <div id="Sec:TermDefs">
               <div class="subsubsection">

--- a/code/stable/sglpendulum/SRS/JSON/SglPendulum_SRS.ipynb
+++ b/code/stable/sglpendulum/SRS/JSON/SglPendulum_SRS.ipynb
@@ -210,7 +210,7 @@
     "## Problem Description\n",
     "<a id=\"Sec:ProbDesc\"></a>\n",
     "\n",
-    "A system is needed to efficiently and correctly to predict the motion of a pendulum.\n",
+    "A system is needed to efficiently and correctly predict the motion of a pendulum.\n",
     "\n",
     "### Terminology and Definitions\n",
     "<a id=\"Sec:TermDefs\"></a>\n",

--- a/code/stable/sglpendulum/SRS/PDF/SglPendulum_SRS.tex
+++ b/code/stable/sglpendulum/SRS/PDF/SglPendulum_SRS.tex
@@ -238,7 +238,7 @@ This section first presents the problem description, which gives a high-level vi
 
 \subsection{Problem Description}
 \label{Sec:ProbDesc}
-A system is needed to efficiently and correctly to predict the motion of a pendulum.
+A system is needed to efficiently and correctly predict the motion of a pendulum.
 
 \subsubsection{Terminology and Definitions}
 \label{Sec:TermDefs}


### PR DESCRIPTION
Contributes to #3391. `purpose` is lifted from the existing introductions of the Problem Description sections. Template and HGHC are excluded since they do not have such an introduction. Game Physics is excluded since its introduction is too long.