### PR TITLE
Assign ownership of yaml files to @JacquesCarette and @balacij

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -26,6 +26,10 @@ code/stable/template/ @JacquesCarette @smiths @samm82
 
 code/drasil-gool/ @JacquesCarette @bmaclach
 
+# YAML files
+
+**.yaml @JacquesCarette @balacij
+
 # `ModelKind`s
 
 **/DifferentialModel.hs @JacquesCarette @cd155


### PR DESCRIPTION
As per comments on #3394, yaml files will only be "owned" by @JacquesCarette and @balacij. 😅 @balacij, you only mentioned package.yaml and stack.yaml files in #3394; I also noticed .hlint.yaml files in our repo. Do you want to be assigned ownership of those too? (That is currently what I have here, but this can easily be changed.)

This is a follow-up to #3312 and #3348