### PR TITLE
3357 Issues with display of references - Suffix

### DIFF
--- a/code/drasil-printers/lib/Language/Drasil/Printing/Helpers.hs
+++ b/code/drasil-printers/lib/Language/Drasil/Printing/Helpers.hs
@@ -92,7 +92,7 @@ sufx _ = "th"
 -- | Similar to 'sufx' but used on any sized 'Int'.
 sufxer :: Int -> String
 sufxer x
-    | x `elem` [11, 12, 13] = period(sufx 0)
-    | otherwise = period(sufx (mod x 10))
+    | x `elem` [11, 12, 13] = period (sufx 0)
+    | otherwise = period (sufx (mod x 10))
     where
         period = (++ ".")

--- a/code/drasil-printers/lib/Language/Drasil/Printing/Helpers.hs
+++ b/code/drasil-printers/lib/Language/Drasil/Printing/Helpers.hs
@@ -87,8 +87,12 @@ sufx :: Int -> String
 sufx 1 = "st"
 sufx 2 = "nd"
 sufx 3 = "rd"
+sufx 11 = "th"
 sufx _ = "th"
 
 -- | Similar to 'sufx' but used on any sized 'Int'.
+-- Since 11, 12, and 13 use the same suffix, the suffix for 11 can be applied in
+-- the case of either number
 sufxer :: Int -> String
-sufxer x = (++ ".") (sufx (mod x 10))
+sufxer x = if x `elem` [11, 12, 13] then (++ ".") (sufx 11) else 
+    (++ ".") (sufx (mod x 10))

--- a/code/drasil-printers/lib/Language/Drasil/Printing/Helpers.hs
+++ b/code/drasil-printers/lib/Language/Drasil/Printing/Helpers.hs
@@ -91,4 +91,4 @@ sufx _ = "th"
 
 -- | Similar to 'sufx' but used on any sized 'Int'.
 sufxer :: Int -> String
-sufxer = (++ ".") . sufx . mod 10
+sufxer x = (++ ".") (sufx (mod x 10))

--- a/code/drasil-printers/lib/Language/Drasil/Printing/Helpers.hs
+++ b/code/drasil-printers/lib/Language/Drasil/Printing/Helpers.hs
@@ -91,5 +91,8 @@ sufx _ = "th"
 
 -- | Similar to 'sufx' but used on any sized 'Int'.
 sufxer :: Int -> String
-sufxer x = (++ ".") (if x `elem` [11, 12, 13] then sufx 0 else
-    sufx (mod x 10))
+sufxer x
+    | x `elem` [11, 12, 13] = period(sufx 0)
+    | otherwise = period(sufx (mod x 10))
+    where
+        period = (++ ".")

--- a/code/drasil-printers/lib/Language/Drasil/Printing/Helpers.hs
+++ b/code/drasil-printers/lib/Language/Drasil/Printing/Helpers.hs
@@ -91,8 +91,6 @@ sufx _ = "th"
 
 -- | Similar to 'sufx' but used on any sized 'Int'.
 sufxer :: Int -> String
-sufxer x
-    | x `elem` [11, 12, 13] = period (sufx 0)
-    | otherwise = period (sufx (mod x 10))
+sufxer x = sufx r ++ "."
     where
-        period = (++ ".")
+        r = if x `elem` [11, 12, 13] then 0 else mod x 10

--- a/code/drasil-printers/lib/Language/Drasil/Printing/Helpers.hs
+++ b/code/drasil-printers/lib/Language/Drasil/Printing/Helpers.hs
@@ -87,12 +87,9 @@ sufx :: Int -> String
 sufx 1 = "st"
 sufx 2 = "nd"
 sufx 3 = "rd"
-sufx 11 = "th"
 sufx _ = "th"
 
 -- | Similar to 'sufx' but used on any sized 'Int'.
--- Since 11, 12, and 13 use the same suffix, the suffix for 11 can be applied in
--- the case of either number
 sufxer :: Int -> String
-sufxer x = if x `elem` [11, 12, 13] then (++ ".") (sufx 11) else 
-    (++ ".") (sufx (mod x 10))
+sufxer x = (++ ".") (if x `elem` [11, 12, 13] then sufx 0 else
+    sufx (mod x 10))

--- a/code/stable/ssp/SRS/HTML/SSP_SRS.html
+++ b/code/stable/ssp/SRS/HTML/SSP_SRS.html
@@ -9439,7 +9439,7 @@
           </li>
           <li>
             <div id="huston2008">
-              [2]: Huston, Ronald and Josephs, Harold. <em>Practical stress analysis in engineering design</em>. 3st. ed., CRC Press, 2008. Print.
+              [2]: Huston, Ronald and Josephs, Harold. <em>Practical stress analysis in engineering design</em>. 3rd. ed., CRC Press, 2008. Print.
             </div>
           </li>
           <li>

--- a/code/stable/ssp/SRS/JSON/SSP_SRS.ipynb
+++ b/code/stable/ssp/SRS/JSON/SSP_SRS.ipynb
@@ -3860,7 +3860,7 @@
     "<a id=\"fredlund1977\"></a>\n",
     "[1]: Fredlund, D. G. and Krahn, J. \"Comparison of slope stability methods of analysis.\" <em>Canadian Geotechnical Journal</em>, vol. 14, no. 3, April, 1977. pp. 429&ndash;439. Print.\n",
     "<a id=\"huston2008\"></a>\n",
-    "[2]: Huston, Ronald and Josephs, Harold. <em>Practical stress analysis in engineering design</em>. 3st. ed., CRC Press, 2008. Print.\n",
+    "[2]: Huston, Ronald and Josephs, Harold. <em>Practical stress analysis in engineering design</em>. 3rd. ed., CRC Press, 2008. Print.\n",
     "<a id=\"karchewski2012\"></a>\n",
     "[3]: Canadian Geotechnical Society, Karchewski, Brandon, Guo, Peijun, and Stolle, Dieter. \"Influence of inherent anisotropy of soil strength on limit equilibrium slope stability analysis.\" <em>Proceedings of the 65th annual Canadian GeoTechnical Conference</em>. Winnipeg, MB, Canada: 2012.\n",
     "<a id=\"koothoor2013\"></a>\n",

--- a/code/stable/swhs/SRS/HTML/SWHS_SRS.html
+++ b/code/stable/swhs/SRS/HTML/SWHS_SRS.html
@@ -6517,7 +6517,7 @@
         <ul class="hide-list-style">
           <li>
             <div id="bueche1986">
-              [1]: Bueche, J. Frederick. <em>Introduction to Physics for Scientists</em>. 4nd. ed., New York City, New York: McGraw Hill, 1986. Print.
+              [1]: Bueche, J. Frederick. <em>Introduction to Physics for Scientists</em>. 4th. ed., New York City, New York: McGraw Hill, 1986. Print.
             </div>
           </li>
           <li>

--- a/code/stable/swhs/SRS/JSON/SWHS_SRS.ipynb
+++ b/code/stable/swhs/SRS/JSON/SWHS_SRS.ipynb
@@ -2360,7 +2360,7 @@
     "# References\n",
     "<a id=\"Sec:References\"></a>\n",
     "<a id=\"bueche1986\"></a>\n",
-    "[1]: Bueche, J. Frederick. <em>Introduction to Physics for Scientists</em>. 4nd. ed., New York City, New York: McGraw Hill, 1986. Print.\n",
+    "[1]: Bueche, J. Frederick. <em>Introduction to Physics for Scientists</em>. 4th. ed., New York City, New York: McGraw Hill, 1986. Print.\n",
     "<a id=\"incroperaEtAl2007\"></a>\n",
     "[2]: Incropera, F. P., Dewitt, D. P., Bergman, T. L., and Lavine, A. S. <em>Fundamentals of Heat and Mass Transfer</em>. 6th. ed., Hoboken, New Jersey: John Wiley and Sons, 2007. Print.\n",
     "<a id=\"koothoor2013\"></a>\n",


### PR DESCRIPTION
Contributes to #3357 for part 2 of the issue. Changes made to Helpers.hs in `drasil-printers` and stable to fix the suffixes of edition numbers.