### PR TITLE
Update `sufxer` to deal with mod 100

### DIFF
--- a/code/drasil-printers/lib/Language/Drasil/Printing/Helpers.hs
+++ b/code/drasil-printers/lib/Language/Drasil/Printing/Helpers.hs
@@ -94,7 +94,7 @@ sufx _ = "th"
 sufxer :: Int -> String
 sufxer x = sufx r ++ "."
     where
-        r = if x `elem` [11, 12, 13] then 0 else mod x 10
+        r = if mod x 100 `elem` [11, 12, 13] then 0 else mod x 10
 
 sufxPrint :: [CiteField] -> String
 sufxPrint fields = if any isUrl fields then "" else " Print."


### PR DESCRIPTION
While making #3459, I came across [this Stack Exchange post](https://codegolf.stackexchange.com/questions/4707/outputting-ordinal-numbers-1st-2nd-3rd) that pointed out that the pattern 11, 12, and 13 using "th" repeats every 100 (e.g., 11th, 112th, 498713th).

This PR implements this based on the work done in #3421