### PR TITLE
Remove excess line breaks from LaTeX tables

### DIFF
--- a/code/drasil-printers/lib/Language/Drasil/TeX/Print.hs
+++ b/code/drasil-printers/lib/Language/Drasil/TeX/Print.hs
@@ -349,7 +349,7 @@ makeDefTable sm ps l = mkEnvArgBr "tabular" (col rr colAwidth ++ col (rr ++ "\\a
 makeDRows :: PrintingInformation -> [(String,[LayoutObj])] -> D
 makeDRows _  []         = error "No fields to create Defn table"
 makeDRows sm ls    = foldl1 (%%) $ map (\(f, d) -> dBoilerplate %%  pure (text (f ++ " & ")) <> print sm d) ls
-  where dBoilerplate = pure $ dbs <+> text "\\midrule" <+> dbs
+  where dBoilerplate = pure $ dbs <+> text "\\midrule"
 
 -----------------------------------------------------------------
 ------------------ EQUATION PRINTING------------------------

--- a/code/stable/dblpendulum/SRS/PDF/DblPendulum_SRS.tex
+++ b/code/stable/dblpendulum/SRS/PDF/DblPendulum_SRS.tex
@@ -316,23 +316,23 @@ This section focuses on the general equations and laws that DblPendulum is based
 \toprule \textbf{Refname} & \textbf{TM:acceleration}
 \phantomsection 
 \label{TM:acceleration}
-\\ \midrule \\
+\\ \midrule
 Label & Acceleration
         
-\\ \midrule \\
+\\ \midrule
 Equation & \begin{displaymath}
            \symbf{a}\text{(}t\text{)}=\frac{\,d\symbf{v}\text{(}t\text{)}}{\,dt}
            \end{displaymath}
-\\ \midrule \\
+\\ \midrule
 Description & \begin{symbDescription}
               \item{$\symbf{a}\text{(}t\text{)}$ is the acceleration ($\frac{\text{m}}{\text{s}^{2}}$)}
               \item{$t$ is the time (${\text{s}}$)}
               \item{$\symbf{v}\text{(}t\text{)}$ is the velocity ($\frac{\text{m}}{\text{s}}$)}
               \end{symbDescription}
-\\ \midrule \\
+\\ \midrule
 Source & \cite{accelerationWiki}
          
-\\ \midrule \\
+\\ \midrule
 RefBy & 
 \\ \bottomrule
 \end{tabular}
@@ -344,23 +344,23 @@ RefBy &
 \toprule \textbf{Refname} & \textbf{TM:velocity}
 \phantomsection 
 \label{TM:velocity}
-\\ \midrule \\
+\\ \midrule
 Label & Velocity
         
-\\ \midrule \\
+\\ \midrule
 Equation & \begin{displaymath}
            \symbf{v}\text{(}t\text{)}=\frac{\,d\symbf{p}\text{(}t\text{)}}{\,dt}
            \end{displaymath}
-\\ \midrule \\
+\\ \midrule
 Description & \begin{symbDescription}
               \item{$\symbf{v}\text{(}t\text{)}$ is the velocity ($\frac{\text{m}}{\text{s}}$)}
               \item{$t$ is the time (${\text{s}}$)}
               \item{$\symbf{p}\text{(}t\text{)}$ is the position (${\text{m}}$)}
               \end{symbDescription}
-\\ \midrule \\
+\\ \midrule
 Source & \cite{velocityWiki}
          
-\\ \midrule \\
+\\ \midrule
 RefBy & 
 \\ \bottomrule
 \end{tabular}
@@ -372,26 +372,26 @@ RefBy &
 \toprule \textbf{Refname} & \textbf{TM:NewtonSecLawMot}
 \phantomsection 
 \label{TM:NewtonSecLawMot}
-\\ \midrule \\
+\\ \midrule
 Label & Newton's second law of motion
         
-\\ \midrule \\
+\\ \midrule
 Equation & \begin{displaymath}
            \symbf{F}=m \symbf{a}\text{(}t\text{)}
            \end{displaymath}
-\\ \midrule \\
+\\ \midrule
 Description & \begin{symbDescription}
               \item{$\symbf{F}$ is the force (${\text{N}}$)}
               \item{$m$ is the mass (${\text{kg}}$)}
               \item{$\symbf{a}\text{(}t\text{)}$ is the acceleration ($\frac{\text{m}}{\text{s}^{2}}$)}
               \end{symbDescription}
-\\ \midrule \\
+\\ \midrule
 Notes & The net force $\symbf{F}$ on a body is proportional to the acceleration $\symbf{a}\text{(}t\text{)}$ of the body, where $m$ denotes the mass of the body as the constant of proportionality.
         
-\\ \midrule \\
+\\ \midrule
 Source & --
          
-\\ \midrule \\
+\\ \midrule
 RefBy & 
 \\ \bottomrule
 \end{tabular}
@@ -407,27 +407,27 @@ This section collects the laws and equations that will be used to build the inst
 \toprule \textbf{Refname} & \textbf{GD:velocityX1}
 \phantomsection 
 \label{GD:velocityX1}
-\\ \midrule \\
+\\ \midrule
 Label & The $x$-component of velocity of the first object
         
-\\ \midrule \\
+\\ \midrule
 Units & $\frac{\text{m}}{\text{s}}$
         
-\\ \midrule \\
+\\ \midrule
 Equation & \begin{displaymath}
            {v_{\text{x}1}}={w_{1}} {L_{1}} \cos\left({θ_{1}}\right)
            \end{displaymath}
-\\ \midrule \\
+\\ \midrule
 Description & \begin{symbDescription}
               \item{${v_{\text{x}1}}$ is the the horizontal velocity of the first object ($\frac{\text{m}}{\text{s}}$)}
               \item{${w_{1}}$ is the the angular velocity of the first object ($\frac{\text{rad}}{\text{s}}$)}
               \item{${L_{1}}$ is the the length of the first rod (${\text{m}}$)}
               \item{${θ_{1}}$ is the the angle of the first rod (${\text{rad}}$)}
               \end{symbDescription}
-\\ \midrule \\
+\\ \midrule
 Source & --
          
-\\ \midrule \\
+\\ \midrule
 RefBy & 
 \\ \bottomrule
 \end{tabular}
@@ -466,27 +466,27 @@ Therefore, using the chain rule,
 \toprule \textbf{Refname} & \textbf{GD:velocityY1}
 \phantomsection 
 \label{GD:velocityY1}
-\\ \midrule \\
+\\ \midrule
 Label & The $y$-component of velocity of the first object
         
-\\ \midrule \\
+\\ \midrule
 Units & $\frac{\text{m}}{\text{s}}$
         
-\\ \midrule \\
+\\ \midrule
 Equation & \begin{displaymath}
            {v_{\text{y}1}}={w_{1}} {L_{1}} \sin\left({θ_{1}}\right)
            \end{displaymath}
-\\ \midrule \\
+\\ \midrule
 Description & \begin{symbDescription}
               \item{${v_{\text{y}1}}$ is the the vertical velocity of the first object ($\frac{\text{m}}{\text{s}}$)}
               \item{${w_{1}}$ is the the angular velocity of the first object ($\frac{\text{rad}}{\text{s}}$)}
               \item{${L_{1}}$ is the the length of the first rod (${\text{m}}$)}
               \item{${θ_{1}}$ is the the angle of the first rod (${\text{rad}}$)}
               \end{symbDescription}
-\\ \midrule \\
+\\ \midrule
 Source & --
          
-\\ \midrule \\
+\\ \midrule
 RefBy & 
 \\ \bottomrule
 \end{tabular}
@@ -525,17 +525,17 @@ Therefore, using the chain rule,
 \toprule \textbf{Refname} & \textbf{GD:velocityX2}
 \phantomsection 
 \label{GD:velocityX2}
-\\ \midrule \\
+\\ \midrule
 Label & The $x$-component of velocity of the second object
         
-\\ \midrule \\
+\\ \midrule
 Units & $\frac{\text{m}}{\text{s}}$
         
-\\ \midrule \\
+\\ \midrule
 Equation & \begin{displaymath}
            {v_{\text{x}2}}={v_{\text{x}1}}+{w_{2}} {L_{2}} \cos\left({θ_{2}}\right)
            \end{displaymath}
-\\ \midrule \\
+\\ \midrule
 Description & \begin{symbDescription}
               \item{${v_{\text{x}2}}$ is the the horizontal velocity of the second object ($\frac{\text{m}}{\text{s}}$)}
               \item{${v_{\text{x}1}}$ is the the horizontal velocity of the first object ($\frac{\text{m}}{\text{s}}$)}
@@ -543,10 +543,10 @@ Description & \begin{symbDescription}
               \item{${L_{2}}$ is the the length of the second rod (${\text{m}}$)}
               \item{${θ_{2}}$ is the the angle of the second rod (${\text{rad}}$)}
               \end{symbDescription}
-\\ \midrule \\
+\\ \midrule
 Source & --
          
-\\ \midrule \\
+\\ \midrule
 RefBy & 
 \\ \bottomrule
 \end{tabular}
@@ -580,17 +580,17 @@ ${L_{1}}$ is constant with respect to time, so
 \toprule \textbf{Refname} & \textbf{GD:velocityY2}
 \phantomsection 
 \label{GD:velocityY2}
-\\ \midrule \\
+\\ \midrule
 Label & The $y$-component of velocity of the second object
         
-\\ \midrule \\
+\\ \midrule
 Units & $\frac{\text{m}}{\text{s}}$
         
-\\ \midrule \\
+\\ \midrule
 Equation & \begin{displaymath}
            {v_{\text{y}2}}={v_{\text{y}1}}+{w_{2}} {L_{2}} \sin\left({θ_{2}}\right)
            \end{displaymath}
-\\ \midrule \\
+\\ \midrule
 Description & \begin{symbDescription}
               \item{${v_{\text{y}2}}$ is the the vertical velocity of the second object ($\frac{\text{m}}{\text{s}}$)}
               \item{${v_{\text{y}1}}$ is the the vertical velocity of the first object ($\frac{\text{m}}{\text{s}}$)}
@@ -598,10 +598,10 @@ Description & \begin{symbDescription}
               \item{${L_{2}}$ is the the length of the second rod (${\text{m}}$)}
               \item{${θ_{2}}$ is the the angle of the second rod (${\text{rad}}$)}
               \end{symbDescription}
-\\ \midrule \\
+\\ \midrule
 Source & --
          
-\\ \midrule \\
+\\ \midrule
 RefBy & 
 \\ \bottomrule
 \end{tabular}
@@ -635,17 +635,17 @@ Therefore, using the chain rule,
 \toprule \textbf{Refname} & \textbf{GD:accelerationX1}
 \phantomsection 
 \label{GD:accelerationX1}
-\\ \midrule \\
+\\ \midrule
 Label & The $x$-component of acceleration of the first object
         
-\\ \midrule \\
+\\ \midrule
 Units & $\frac{\text{m}}{\text{s}^{2}}$
         
-\\ \midrule \\
+\\ \midrule
 Equation & \begin{displaymath}
            {a_{\text{x}1}}=-{w_{1}}^{2} {L_{1}} \sin\left({θ_{1}}\right)+{α_{1}} {L_{1}} \cos\left({θ_{1}}\right)
            \end{displaymath}
-\\ \midrule \\
+\\ \midrule
 Description & \begin{symbDescription}
               \item{${a_{\text{x}1}}$ is the the horizontal acceleration of the first object ($\frac{\text{m}}{\text{s}^{2}}$)}
               \item{${w_{1}}$ is the the angular velocity of the first object ($\frac{\text{rad}}{\text{s}}$)}
@@ -653,10 +653,10 @@ Description & \begin{symbDescription}
               \item{${θ_{1}}$ is the the angle of the first rod (${\text{rad}}$)}
               \item{${α_{1}}$ is the the angular acceleration of the first object ($\frac{\text{rad}}{\text{s}^{2}}$)}
               \end{symbDescription}
-\\ \midrule \\
+\\ \midrule
 Source & --
          
-\\ \midrule \\
+\\ \midrule
 RefBy & \hyperref[IM:calOfAngularAcceleration2]{IM:calOfAngularAcceleration2}
         
 \\ \bottomrule
@@ -696,17 +696,17 @@ Simplifying,
 \toprule \textbf{Refname} & \textbf{GD:accelerationY1}
 \phantomsection 
 \label{GD:accelerationY1}
-\\ \midrule \\
+\\ \midrule
 Label & The $y$-component of acceleration of the first object
         
-\\ \midrule \\
+\\ \midrule
 Units & $\frac{\text{m}}{\text{s}^{2}}$
         
-\\ \midrule \\
+\\ \midrule
 Equation & \begin{displaymath}
            {a_{\text{y}1}}={w_{1}}^{2} {L_{1}} \cos\left({θ_{1}}\right)+{α_{1}} {L_{1}} \sin\left({θ_{1}}\right)
            \end{displaymath}
-\\ \midrule \\
+\\ \midrule
 Description & \begin{symbDescription}
               \item{${a_{\text{y}1}}$ is the the vertical acceleration of the first object ($\frac{\text{m}}{\text{s}^{2}}$)}
               \item{${w_{1}}$ is the the angular velocity of the first object ($\frac{\text{rad}}{\text{s}}$)}
@@ -714,10 +714,10 @@ Description & \begin{symbDescription}
               \item{${θ_{1}}$ is the the angle of the first rod (${\text{rad}}$)}
               \item{${α_{1}}$ is the the angular acceleration of the first object ($\frac{\text{rad}}{\text{s}^{2}}$)}
               \end{symbDescription}
-\\ \midrule \\
+\\ \midrule
 Source & --
          
-\\ \midrule \\
+\\ \midrule
 RefBy & \hyperref[IM:calOfAngularAcceleration2]{IM:calOfAngularAcceleration2}
         
 \\ \bottomrule
@@ -757,17 +757,17 @@ Simplifying,
 \toprule \textbf{Refname} & \textbf{GD:accelerationX2}
 \phantomsection 
 \label{GD:accelerationX2}
-\\ \midrule \\
+\\ \midrule
 Label & The $x$-component of acceleration of the second object
         
-\\ \midrule \\
+\\ \midrule
 Units & $\frac{\text{m}}{\text{s}^{2}}$
         
-\\ \midrule \\
+\\ \midrule
 Equation & \begin{displaymath}
            {a_{\text{x}2}}={a_{\text{x}1}}-{w_{2}}^{2} {L_{2}} \sin\left({θ_{2}}\right)+{α_{2}} {L_{2}} \cos\left({θ_{2}}\right)
            \end{displaymath}
-\\ \midrule \\
+\\ \midrule
 Description & \begin{symbDescription}
               \item{${a_{\text{x}2}}$ is the the horizontal acceleration of the second object ($\frac{\text{m}}{\text{s}^{2}}$)}
               \item{${a_{\text{x}1}}$ is the the horizontal acceleration of the first object ($\frac{\text{m}}{\text{s}^{2}}$)}
@@ -776,10 +776,10 @@ Description & \begin{symbDescription}
               \item{${θ_{2}}$ is the the angle of the second rod (${\text{rad}}$)}
               \item{${α_{2}}$ is the the angular acceleration of the second object ($\frac{\text{rad}}{\text{s}^{2}}$)}
               \end{symbDescription}
-\\ \midrule \\
+\\ \midrule
 Source & --
          
-\\ \midrule \\
+\\ \midrule
 RefBy & \hyperref[IM:calOfAngularAcceleration2]{IM:calOfAngularAcceleration2}
         
 \\ \bottomrule
@@ -814,17 +814,17 @@ By the product and chain rules, we find
 \toprule \textbf{Refname} & \textbf{GD:accelerationY2}
 \phantomsection 
 \label{GD:accelerationY2}
-\\ \midrule \\
+\\ \midrule
 Label & The $y$-component of acceleration of the second object
         
-\\ \midrule \\
+\\ \midrule
 Units & $\frac{\text{m}}{\text{s}^{2}}$
         
-\\ \midrule \\
+\\ \midrule
 Equation & \begin{displaymath}
            {a_{\text{y}2}}={a_{\text{y}1}}+{w_{2}}^{2} {L_{2}} \cos\left({θ_{2}}\right)+{α_{2}} {L_{2}} \sin\left({θ_{2}}\right)
            \end{displaymath}
-\\ \midrule \\
+\\ \midrule
 Description & \begin{symbDescription}
               \item{${a_{\text{y}2}}$ is the the vertical acceleration of the second object ($\frac{\text{m}}{\text{s}^{2}}$)}
               \item{${a_{\text{y}1}}$ is the the vertical acceleration of the first object ($\frac{\text{m}}{\text{s}^{2}}$)}
@@ -833,10 +833,10 @@ Description & \begin{symbDescription}
               \item{${θ_{2}}$ is the the angle of the second rod (${\text{rad}}$)}
               \item{${α_{2}}$ is the the angular acceleration of the second object ($\frac{\text{rad}}{\text{s}^{2}}$)}
               \end{symbDescription}
-\\ \midrule \\
+\\ \midrule
 Source & --
          
-\\ \midrule \\
+\\ \midrule
 RefBy & \hyperref[IM:calOfAngularAcceleration2]{IM:calOfAngularAcceleration2}
         
 \\ \bottomrule
@@ -871,17 +871,17 @@ By the product and chain rules, we find
 \toprule \textbf{Refname} & \textbf{GD:xForce1}
 \phantomsection 
 \label{GD:xForce1}
-\\ \midrule \\
+\\ \midrule
 Label & Horizontal force on the first object
         
-\\ \midrule \\
+\\ \midrule
 Units & ${\text{N}}$
         
-\\ \midrule \\
+\\ \midrule
 Equation & \begin{displaymath}
            \symbf{F}=m \symbf{a}\text{(}t\text{)}=-{\symbf{T}_{1}} \sin\left({θ_{1}}\right)+{\symbf{T}_{2}} \sin\left({θ_{2}}\right)
            \end{displaymath}
-\\ \midrule \\
+\\ \midrule
 Description & \begin{symbDescription}
               \item{$\symbf{F}$ is the force (${\text{N}}$)}
               \item{$m$ is the mass (${\text{kg}}$)}
@@ -891,10 +891,10 @@ Description & \begin{symbDescription}
               \item{${\symbf{T}_{2}}$ is the the tension of the second object (${\text{N}}$)}
               \item{${θ_{2}}$ is the the angle of the second rod (${\text{rad}}$)}
               \end{symbDescription}
-\\ \midrule \\
+\\ \midrule
 Source & --
          
-\\ \midrule \\
+\\ \midrule
 RefBy & \hyperref[IM:calOfAngularAcceleration2]{IM:calOfAngularAcceleration2}
         
 \\ \bottomrule
@@ -912,17 +912,17 @@ RefBy & \hyperref[IM:calOfAngularAcceleration2]{IM:calOfAngularAcceleration2}
 \toprule \textbf{Refname} & \textbf{GD:yForce1}
 \phantomsection 
 \label{GD:yForce1}
-\\ \midrule \\
+\\ \midrule
 Label & Vertical force on the first object
         
-\\ \midrule \\
+\\ \midrule
 Units & ${\text{N}}$
         
-\\ \midrule \\
+\\ \midrule
 Equation & \begin{displaymath}
            \symbf{F}=m \symbf{a}\text{(}t\text{)}={\symbf{T}_{1}} \cos\left({θ_{1}}\right)-{\symbf{T}_{2}} \cos\left({θ_{2}}\right)-{m_{1}} \symbf{g}
            \end{displaymath}
-\\ \midrule \\
+\\ \midrule
 Description & \begin{symbDescription}
               \item{$\symbf{F}$ is the force (${\text{N}}$)}
               \item{$m$ is the mass (${\text{kg}}$)}
@@ -934,10 +934,10 @@ Description & \begin{symbDescription}
               \item{${m_{1}}$ is the the mass of the first object (${\text{kg}}$)}
               \item{$\symbf{g}$ is the gravitational acceleration ($\frac{\text{m}}{\text{s}^{2}}$)}
               \end{symbDescription}
-\\ \midrule \\
+\\ \midrule
 Source & --
          
-\\ \midrule \\
+\\ \midrule
 RefBy & \hyperref[IM:calOfAngularAcceleration2]{IM:calOfAngularAcceleration2}
         
 \\ \bottomrule
@@ -955,17 +955,17 @@ RefBy & \hyperref[IM:calOfAngularAcceleration2]{IM:calOfAngularAcceleration2}
 \toprule \textbf{Refname} & \textbf{GD:xForce2}
 \phantomsection 
 \label{GD:xForce2}
-\\ \midrule \\
+\\ \midrule
 Label & Horizontal force on the second object
         
-\\ \midrule \\
+\\ \midrule
 Units & ${\text{N}}$
         
-\\ \midrule \\
+\\ \midrule
 Equation & \begin{displaymath}
            \symbf{F}=m \symbf{a}\text{(}t\text{)}=-{\symbf{T}_{2}} \sin\left({θ_{2}}\right)
            \end{displaymath}
-\\ \midrule \\
+\\ \midrule
 Description & \begin{symbDescription}
               \item{$\symbf{F}$ is the force (${\text{N}}$)}
               \item{$m$ is the mass (${\text{kg}}$)}
@@ -973,10 +973,10 @@ Description & \begin{symbDescription}
               \item{${\symbf{T}_{2}}$ is the the tension of the second object (${\text{N}}$)}
               \item{${θ_{2}}$ is the the angle of the second rod (${\text{rad}}$)}
               \end{symbDescription}
-\\ \midrule \\
+\\ \midrule
 Source & --
          
-\\ \midrule \\
+\\ \midrule
 RefBy & \hyperref[IM:calOfAngularAcceleration2]{IM:calOfAngularAcceleration2}
         
 \\ \bottomrule
@@ -994,17 +994,17 @@ RefBy & \hyperref[IM:calOfAngularAcceleration2]{IM:calOfAngularAcceleration2}
 \toprule \textbf{Refname} & \textbf{GD:yForce2}
 \phantomsection 
 \label{GD:yForce2}
-\\ \midrule \\
+\\ \midrule
 Label & Vertical force on the second object
         
-\\ \midrule \\
+\\ \midrule
 Units & ${\text{N}}$
         
-\\ \midrule \\
+\\ \midrule
 Equation & \begin{displaymath}
            \symbf{F}=m \symbf{a}\text{(}t\text{)}={\symbf{T}_{2}} \cos\left({θ_{2}}\right)-{m_{2}} \symbf{g}
            \end{displaymath}
-\\ \midrule \\
+\\ \midrule
 Description & \begin{symbDescription}
               \item{$\symbf{F}$ is the force (${\text{N}}$)}
               \item{$m$ is the mass (${\text{kg}}$)}
@@ -1014,10 +1014,10 @@ Description & \begin{symbDescription}
               \item{${m_{2}}$ is the the mass of the second object (${\text{kg}}$)}
               \item{$\symbf{g}$ is the gravitational acceleration ($\frac{\text{m}}{\text{s}^{2}}$)}
               \end{symbDescription}
-\\ \midrule \\
+\\ \midrule
 Source & --
          
-\\ \midrule \\
+\\ \midrule
 RefBy & \hyperref[IM:calOfAngularAcceleration2]{IM:calOfAngularAcceleration2}
         
 \\ \bottomrule
@@ -1039,29 +1039,29 @@ This section collects and defines all the data needed to build the instance mode
 \toprule \textbf{Refname} & \textbf{DD:positionGDD}
 \phantomsection 
 \label{DD:positionGDD}
-\\ \midrule \\
+\\ \midrule
 Label & Velocity
         
-\\ \midrule \\
+\\ \midrule
 Symbol & $\symbf{v}\text{(}t\text{)}$
          
-\\ \midrule \\
+\\ \midrule
 Units & $\frac{\text{m}}{\text{s}}$
         
-\\ \midrule \\
+\\ \midrule
 Equation & \begin{displaymath}
            \symbf{v}\text{(}t\text{)}=\frac{\,d\symbf{p}\text{(}t\text{)}}{\,dt}
            \end{displaymath}
-\\ \midrule \\
+\\ \midrule
 Description & \begin{symbDescription}
               \item{$\symbf{v}\text{(}t\text{)}$ is the velocity ($\frac{\text{m}}{\text{s}}$)}
               \item{$t$ is the time (${\text{s}}$)}
               \item{$\symbf{p}\text{(}t\text{)}$ is the position (${\text{m}}$)}
               \end{symbDescription}
-\\ \midrule \\
+\\ \midrule
 Source & --
          
-\\ \midrule \\
+\\ \midrule
 RefBy & \hyperref[GD:velocityY2]{GD:velocityY2}, \hyperref[GD:velocityY1]{GD:velocityY1}, \hyperref[GD:velocityX2]{GD:velocityX2}, and \hyperref[GD:velocityX1]{GD:velocityX1}
         
 \\ \bottomrule
@@ -1075,34 +1075,34 @@ RefBy & \hyperref[GD:velocityY2]{GD:velocityY2}, \hyperref[GD:velocityY1]{GD:vel
 \toprule \textbf{Refname} & \textbf{DD:positionXDD1}
 \phantomsection 
 \label{DD:positionXDD1}
-\\ \midrule \\
+\\ \midrule
 Label & The horizontal position of the first object
         
-\\ \midrule \\
+\\ \midrule
 Symbol & ${p_{\text{x}1}}$
          
-\\ \midrule \\
+\\ \midrule
 Units & ${\text{m}}$
         
-\\ \midrule \\
+\\ \midrule
 Equation & \begin{displaymath}
            {p_{\text{x}1}}={L_{1}} \sin\left({θ_{1}}\right)
            \end{displaymath}
-\\ \midrule \\
+\\ \midrule
 Description & \begin{symbDescription}
               \item{${p_{\text{x}1}}$ is the the horizontal position of the first object (${\text{m}}$)}
               \item{${L_{1}}$ is the the length of the first rod (${\text{m}}$)}
               \item{${θ_{1}}$ is the the angle of the first rod (${\text{rad}}$)}
               \end{symbDescription}
-\\ \midrule \\
+\\ \midrule
 Notes & ${p_{\text{x}1}}$ is the horizontal position
         
         ${p_{\text{x}1}}$ is shown in \hyperref[Figure:dblpendulum]{Fig:dblpendulum}.
         
-\\ \midrule \\
+\\ \midrule
 Source & --
          
-\\ \midrule \\
+\\ \midrule
 RefBy & \hyperref[GD:velocityX1]{GD:velocityX1}
         
 \\ \bottomrule
@@ -1116,34 +1116,34 @@ RefBy & \hyperref[GD:velocityX1]{GD:velocityX1}
 \toprule \textbf{Refname} & \textbf{DD:positionYDD1}
 \phantomsection 
 \label{DD:positionYDD1}
-\\ \midrule \\
+\\ \midrule
 Label & The vertical position of the first object
         
-\\ \midrule \\
+\\ \midrule
 Symbol & ${p_{\text{y}1}}$
          
-\\ \midrule \\
+\\ \midrule
 Units & ${\text{m}}$
         
-\\ \midrule \\
+\\ \midrule
 Equation & \begin{displaymath}
            {p_{\text{y}1}}=-{L_{1}} \cos\left({θ_{1}}\right)
            \end{displaymath}
-\\ \midrule \\
+\\ \midrule
 Description & \begin{symbDescription}
               \item{${p_{\text{y}1}}$ is the the vertical position of the first object (${\text{m}}$)}
               \item{${L_{1}}$ is the the length of the first rod (${\text{m}}$)}
               \item{${θ_{1}}$ is the the angle of the first rod (${\text{rad}}$)}
               \end{symbDescription}
-\\ \midrule \\
+\\ \midrule
 Notes & ${p_{\text{y}1}}$ is the vertical position
         
         ${p_{\text{y}1}}$ is shown in \hyperref[Figure:dblpendulum]{Fig:dblpendulum}.
         
-\\ \midrule \\
+\\ \midrule
 Source & --
          
-\\ \midrule \\
+\\ \midrule
 RefBy & \hyperref[GD:velocityY1]{GD:velocityY1}
         
 \\ \bottomrule
@@ -1157,35 +1157,35 @@ RefBy & \hyperref[GD:velocityY1]{GD:velocityY1}
 \toprule \textbf{Refname} & \textbf{DD:positionXDD2}
 \phantomsection 
 \label{DD:positionXDD2}
-\\ \midrule \\
+\\ \midrule
 Label & The horizontal position of the second object
         
-\\ \midrule \\
+\\ \midrule
 Symbol & ${p_{\text{x}2}}$
          
-\\ \midrule \\
+\\ \midrule
 Units & ${\text{m}}$
         
-\\ \midrule \\
+\\ \midrule
 Equation & \begin{displaymath}
            {p_{\text{x}2}}={p_{\text{x}1}}+{L_{2}} \sin\left({θ_{2}}\right)
            \end{displaymath}
-\\ \midrule \\
+\\ \midrule
 Description & \begin{symbDescription}
               \item{${p_{\text{x}2}}$ is the the horizontal position of the second object (${\text{m}}$)}
               \item{${p_{\text{x}1}}$ is the the horizontal position of the first object (${\text{m}}$)}
               \item{${L_{2}}$ is the the length of the second rod (${\text{m}}$)}
               \item{${θ_{2}}$ is the the angle of the second rod (${\text{rad}}$)}
               \end{symbDescription}
-\\ \midrule \\
+\\ \midrule
 Notes & ${p_{\text{x}2}}$ is the horizontal position
         
         ${p_{\text{x}2}}$ is shown in \hyperref[Figure:dblpendulum]{Fig:dblpendulum}.
         
-\\ \midrule \\
+\\ \midrule
 Source & --
          
-\\ \midrule \\
+\\ \midrule
 RefBy & \hyperref[GD:velocityX2]{GD:velocityX2}
         
 \\ \bottomrule
@@ -1199,35 +1199,35 @@ RefBy & \hyperref[GD:velocityX2]{GD:velocityX2}
 \toprule \textbf{Refname} & \textbf{DD:positionYDD2}
 \phantomsection 
 \label{DD:positionYDD2}
-\\ \midrule \\
+\\ \midrule
 Label & The vertical position of the second object
         
-\\ \midrule \\
+\\ \midrule
 Symbol & ${p_{\text{y}2}}$
          
-\\ \midrule \\
+\\ \midrule
 Units & ${\text{m}}$
         
-\\ \midrule \\
+\\ \midrule
 Equation & \begin{displaymath}
            {p_{\text{y}2}}={p_{\text{y}1}}-{L_{2}} \cos\left({θ_{2}}\right)
            \end{displaymath}
-\\ \midrule \\
+\\ \midrule
 Description & \begin{symbDescription}
               \item{${p_{\text{y}2}}$ is the the vertical position of the second object (${\text{m}}$)}
               \item{${p_{\text{y}1}}$ is the the vertical position of the first object (${\text{m}}$)}
               \item{${L_{2}}$ is the the length of the second rod (${\text{m}}$)}
               \item{${θ_{2}}$ is the the angle of the second rod (${\text{rad}}$)}
               \end{symbDescription}
-\\ \midrule \\
+\\ \midrule
 Notes & ${p_{\text{y}2}}$ is the vertical position
         
         ${p_{\text{y}2}}$ is shown in \hyperref[Figure:dblpendulum]{Fig:dblpendulum}.
         
-\\ \midrule \\
+\\ \midrule
 Source & --
          
-\\ \midrule \\
+\\ \midrule
 RefBy & \hyperref[GD:velocityY2]{GD:velocityY2}
         
 \\ \bottomrule
@@ -1241,29 +1241,29 @@ RefBy & \hyperref[GD:velocityY2]{GD:velocityY2}
 \toprule \textbf{Refname} & \textbf{DD:accelerationGDD}
 \phantomsection 
 \label{DD:accelerationGDD}
-\\ \midrule \\
+\\ \midrule
 Label & Acceleration
         
-\\ \midrule \\
+\\ \midrule
 Symbol & $\symbf{a}\text{(}t\text{)}$
          
-\\ \midrule \\
+\\ \midrule
 Units & $\frac{\text{m}}{\text{s}^{2}}$
         
-\\ \midrule \\
+\\ \midrule
 Equation & \begin{displaymath}
            \symbf{a}\text{(}t\text{)}=\frac{\,d\symbf{v}\text{(}t\text{)}}{\,dt}
            \end{displaymath}
-\\ \midrule \\
+\\ \midrule
 Description & \begin{symbDescription}
               \item{$\symbf{a}\text{(}t\text{)}$ is the acceleration ($\frac{\text{m}}{\text{s}^{2}}$)}
               \item{$t$ is the time (${\text{s}}$)}
               \item{$\symbf{v}\text{(}t\text{)}$ is the velocity ($\frac{\text{m}}{\text{s}}$)}
               \end{symbDescription}
-\\ \midrule \\
+\\ \midrule
 Source & --
          
-\\ \midrule \\
+\\ \midrule
 RefBy & 
 \\ \bottomrule
 \end{tabular}
@@ -1276,29 +1276,29 @@ RefBy &
 \toprule \textbf{Refname} & \textbf{DD:forceGDD}
 \phantomsection 
 \label{DD:forceGDD}
-\\ \midrule \\
+\\ \midrule
 Label & Force
         
-\\ \midrule \\
+\\ \midrule
 Symbol & $\symbf{F}$
          
-\\ \midrule \\
+\\ \midrule
 Units & ${\text{N}}$
         
-\\ \midrule \\
+\\ \midrule
 Equation & \begin{displaymath}
            \symbf{F}=m \symbf{a}\text{(}t\text{)}
            \end{displaymath}
-\\ \midrule \\
+\\ \midrule
 Description & \begin{symbDescription}
               \item{$\symbf{F}$ is the force (${\text{N}}$)}
               \item{$m$ is the mass (${\text{kg}}$)}
               \item{$\symbf{a}\text{(}t\text{)}$ is the acceleration ($\frac{\text{m}}{\text{s}^{2}}$)}
               \end{symbDescription}
-\\ \midrule \\
+\\ \midrule
 Source & --
          
-\\ \midrule \\
+\\ \midrule
 RefBy & 
 \\ \bottomrule
 \end{tabular}
@@ -1315,16 +1315,16 @@ This section transforms the problem defined in the \hyperref[Sec:ProbDesc]{probl
 \toprule \textbf{Refname} & \textbf{IM:calOfAngularAcceleration1}
 \phantomsection 
 \label{IM:calOfAngularAcceleration1}
-\\ \midrule \\
+\\ \midrule
 Label & Calculation of angular acceleration
         
-\\ \midrule \\
+\\ \midrule
 Input & ${L_{1}}$, ${L_{2}}$, ${m_{1}}$, ${m_{2}}$, ${θ_{1}}$, ${θ_{2}}$
         
-\\ \midrule \\
+\\ \midrule
 Output & ${α_{1}}$
          
-\\ \midrule \\
+\\ \midrule
 Input Constraints & \begin{displaymath}
                     {L_{1}}\gt{}0
                     \end{displaymath}
@@ -1337,15 +1337,15 @@ Input Constraints & \begin{displaymath}
                     \begin{displaymath}
                     {m_{2}}\gt{}0
                     \end{displaymath}
-\\ \midrule \\
+\\ \midrule
 Output Constraints & \begin{displaymath}
                      {α_{1}}\gt{}0
                      \end{displaymath}
-\\ \midrule \\
+\\ \midrule
 Equation & \begin{displaymath}
            {α_{1}}\left({θ_{1}},{θ_{2}},{w_{1}},{w_{2}}\right)=\frac{-g \left(2 {m_{1}}+{m_{2}}\right) \sin\left({θ_{1}}\right)-{m_{2}} g \sin\left({θ_{1}}-2 {θ_{2}}\right)-2 \sin\left({θ_{1}}-{θ_{2}}\right) {m_{2}} \left({w_{2}}^{2} {L_{2}}+{w_{1}}^{2} {L_{1}} \cos\left({θ_{1}}-{θ_{2}}\right)\right)}{{L_{1}} \left(2 {m_{1}}+{m_{2}}-{m_{2}} \cos\left(2 {θ_{1}}-2 {θ_{2}}\right)\right)}
            \end{displaymath}
-\\ \midrule \\
+\\ \midrule
 Description & \begin{symbDescription}
               \item{${α_{1}}$ is the the angular acceleration of the first object ($\frac{\text{rad}}{\text{s}^{2}}$)}
               \item{${θ_{1}}$ is the the angle of the first rod (${\text{rad}}$)}
@@ -1358,10 +1358,10 @@ Description & \begin{symbDescription}
               \item{${L_{2}}$ is the the length of the second rod (${\text{m}}$)}
               \item{${L_{1}}$ is the the length of the first rod (${\text{m}}$)}
               \end{symbDescription}
-\\ \midrule \\
+\\ \midrule
 Source & --
          
-\\ \midrule \\
+\\ \midrule
 RefBy & \hyperref[outputValues]{FR:Output-Values}, \hyperref[calcAngPos]{FR:Calculate-Angular-Position-Of-Mass}, and \hyperref[IM:calOfAngularAcceleration2]{IM:calOfAngularAcceleration2}
         
 \\ \bottomrule
@@ -1375,16 +1375,16 @@ RefBy & \hyperref[outputValues]{FR:Output-Values}, \hyperref[calcAngPos]{FR:Calc
 \toprule \textbf{Refname} & \textbf{IM:calOfAngularAcceleration2}
 \phantomsection 
 \label{IM:calOfAngularAcceleration2}
-\\ \midrule \\
+\\ \midrule
 Label & Calculation of angular acceleration
         
-\\ \midrule \\
+\\ \midrule
 Input & ${L_{1}}$, ${L_{2}}$, ${m_{1}}$, ${m_{2}}$, ${θ_{1}}$, ${θ_{2}}$
         
-\\ \midrule \\
+\\ \midrule
 Output & ${α_{2}}$
          
-\\ \midrule \\
+\\ \midrule
 Input Constraints & \begin{displaymath}
                     {L_{1}}\gt{}0
                     \end{displaymath}
@@ -1397,15 +1397,15 @@ Input Constraints & \begin{displaymath}
                     \begin{displaymath}
                     {m_{2}}\gt{}0
                     \end{displaymath}
-\\ \midrule \\
+\\ \midrule
 Output Constraints & \begin{displaymath}
                      {α_{2}}\gt{}0
                      \end{displaymath}
-\\ \midrule \\
+\\ \midrule
 Equation & \begin{displaymath}
            {α_{2}}\left({θ_{1}},{θ_{2}},{w_{1}},{w_{2}}\right)=\frac{2 \sin\left({θ_{1}}-{θ_{2}}\right) \left({w_{1}}^{2} {L_{1}} \left({m_{1}}+{m_{2}}\right)+g \left({m_{1}}+{m_{2}}\right) \cos\left({θ_{1}}\right)+{w_{2}}^{2} {L_{2}} {m_{2}} \cos\left({θ_{1}}-{θ_{2}}\right)\right)}{{L_{2}} \left(2 {m_{1}}+{m_{2}}-{m_{2}} \cos\left(2 {θ_{1}}-2 {θ_{2}}\right)\right)}
            \end{displaymath}
-\\ \midrule \\
+\\ \midrule
 Description & \begin{symbDescription}
               \item{${α_{2}}$ is the the angular acceleration of the second object ($\frac{\text{rad}}{\text{s}^{2}}$)}
               \item{${θ_{1}}$ is the the angle of the first rod (${\text{rad}}$)}
@@ -1418,10 +1418,10 @@ Description & \begin{symbDescription}
               \item{$g$ is the magnitude of gravitational acceleration ($\frac{\text{m}}{\text{s}^{2}}$)}
               \item{${L_{2}}$ is the the length of the second rod (${\text{m}}$)}
               \end{symbDescription}
-\\ \midrule \\
+\\ \midrule
 Source & --
          
-\\ \midrule \\
+\\ \midrule
 RefBy & \hyperref[outputValues]{FR:Output-Values}, \hyperref[calcAngPos]{FR:Calculate-Angular-Position-Of-Mass}, and \hyperref[IM:calOfAngularAcceleration2]{IM:calOfAngularAcceleration2}
         
 \\ \bottomrule

--- a/code/stable/gamephysics/SRS/PDF/GamePhysics_SRS.tex
+++ b/code/stable/gamephysics/SRS/PDF/GamePhysics_SRS.tex
@@ -377,26 +377,26 @@ This section focuses on the general equations and laws that Game Physics is base
 \toprule \textbf{Refname} & \textbf{TM:NewtonSecLawMot}
 \phantomsection 
 \label{TM:NewtonSecLawMot}
-\\ \midrule \\
+\\ \midrule
 Label & Newton's second law of motion
         
-\\ \midrule \\
+\\ \midrule
 Equation & \begin{displaymath}
            \symbf{F}=m \symbf{a}\text{(}t\text{)}
            \end{displaymath}
-\\ \midrule \\
+\\ \midrule
 Description & \begin{symbDescription}
               \item{$\symbf{F}$ is the force (${\text{N}}$)}
               \item{$m$ is the mass (${\text{kg}}$)}
               \item{$\symbf{a}\text{(}t\text{)}$ is the acceleration ($\frac{\text{m}}{\text{s}^{2}}$)}
               \end{symbDescription}
-\\ \midrule \\
+\\ \midrule
 Notes & The net force $\symbf{F}$ on a body is proportional to the acceleration $\symbf{a}\text{(}t\text{)}$ of the body, where $m$ denotes the mass of the body as the constant of proportionality.
         
-\\ \midrule \\
+\\ \midrule
 Source & --
          
-\\ \midrule \\
+\\ \midrule
 RefBy & \hyperref[IM:transMot]{IM:transMot}
         
 \\ \bottomrule
@@ -409,25 +409,25 @@ RefBy & \hyperref[IM:transMot]{IM:transMot}
 \toprule \textbf{Refname} & \textbf{TM:NewtonThirdLawMot}
 \phantomsection 
 \label{TM:NewtonThirdLawMot}
-\\ \midrule \\
+\\ \midrule
 Label & Newton's third law of motion
         
-\\ \midrule \\
+\\ \midrule
 Equation & \begin{displaymath}
            {\symbf{F}_{1}}=-{\symbf{F}_{2}}
            \end{displaymath}
-\\ \midrule \\
+\\ \midrule
 Description & \begin{symbDescription}
               \item{${\symbf{F}_{1}}$ is the force exerted by the first body (on another body) (${\text{N}}$)}
               \item{${\symbf{F}_{2}}$ is the force exerted by the second body (on another body) (${\text{N}}$)}
               \end{symbDescription}
-\\ \midrule \\
+\\ \midrule
 Notes & Every action has an equal and opposite reaction. In other words, the force ${\symbf{F}_{1}}$ exerted on the second rigid body by the first is equal in magnitude and in the opposite direction to the force ${\symbf{F}_{2}}$ exerted on the first rigid body by the second.
         
-\\ \midrule \\
+\\ \midrule
 Source & --
          
-\\ \midrule \\
+\\ \midrule
 RefBy & 
 \\ \bottomrule
 \end{tabular}
@@ -439,14 +439,14 @@ RefBy &
 \toprule \textbf{Refname} & \textbf{TM:UniversalGravLaw}
 \phantomsection 
 \label{TM:UniversalGravLaw}
-\\ \midrule \\
+\\ \midrule
 Label & Newton's law of universal gravitation
         
-\\ \midrule \\
+\\ \midrule
 Equation & \begin{displaymath}
            \symbf{F}=G \frac{{m_{1}} {m_{2}}}{\|\symbf{d}\|^{2}} \symbf{\hat{d}}=G \frac{{m_{1}} {m_{2}}}{\|\symbf{d}\|^{2}} \frac{\symbf{d}}{\|\symbf{d}\|}
            \end{displaymath}
-\\ \midrule \\
+\\ \midrule
 Description & \begin{symbDescription}
               \item{$\symbf{F}$ is the force (${\text{N}}$)}
               \item{$G$ is the gravitational constant ($\frac{\text{m}^{3}}{\text{kg}\text{s}^{2}}$)}
@@ -456,13 +456,13 @@ Description & \begin{symbDescription}
               \item{$\symbf{\hat{d}}$ is the unit vector directed from the center of the large mass to the center of the smaller mass (${\text{m}}$)}
               \item{$\symbf{d}$ is the distance between the center of mass of the rigid bodies (${\text{m}}$)}
               \end{symbDescription}
-\\ \midrule \\
+\\ \midrule
 Notes & Two rigid bodies in the universe attract each other with a force $\symbf{F}$ that is directly proportional to the product of their masses, ${m_{1}}$ and ${m_{2}}$, and inversely proportional to the squared distance ${\|\symbf{d}\|^{2}}$ between them.
         
-\\ \midrule \\
+\\ \midrule
 Source & --
          
-\\ \midrule \\
+\\ \midrule
 RefBy & \hyperref[GD:accelGravity]{GD:accelGravity}
         
 \\ \bottomrule
@@ -475,28 +475,28 @@ RefBy & \hyperref[GD:accelGravity]{GD:accelGravity}
 \toprule \textbf{Refname} & \textbf{TM:NewtonSecLawRotMot}
 \phantomsection 
 \label{TM:NewtonSecLawRotMot}
-\\ \midrule \\
+\\ \midrule
 Label & Newton's second law for rotational motion
         
-\\ \midrule \\
+\\ \midrule
 Equation & \begin{displaymath}
            \symbf{τ}=\symbf{I} α
            \end{displaymath}
-\\ \midrule \\
+\\ \midrule
 Description & \begin{symbDescription}
               \item{$\symbf{τ}$ is the torque ($\text{N}\text{m}$)}
               \item{$\symbf{I}$ is the moment of inertia ($\text{kg}\text{m}^{2}$)}
               \item{$α$ is the angular acceleration ($\frac{\text{rad}}{\text{s}^{2}}$)}
               \end{symbDescription}
-\\ \midrule \\
+\\ \midrule
 Notes & The net torque $\symbf{τ}$ on a rigid body is proportional to its angular acceleration $α$, where $\symbf{I}$ denotes the moment of inertia of the rigid body as the constant of proportionality.
         
         We also assume that all rigid bodies involved are two-dimensional (from \hyperref[assumpOD]{A:objectDimension}).
         
-\\ \midrule \\
+\\ \midrule
 Source & --
          
-\\ \midrule \\
+\\ \midrule
 RefBy & \hyperref[IM:rotMot]{IM:rotMot}
         
 \\ \bottomrule
@@ -513,17 +513,17 @@ This section collects the laws and equations that will be used to build the inst
 \toprule \textbf{Refname} & \textbf{GD:accelGravity}
 \phantomsection 
 \label{GD:accelGravity}
-\\ \midrule \\
+\\ \midrule
 Label & Acceleration due to gravity
         
-\\ \midrule \\
+\\ \midrule
 Units & $\frac{\text{m}}{\text{s}^{2}}$
         
-\\ \midrule \\
+\\ \midrule
 Equation & \begin{displaymath}
            \symbf{g}=-\frac{G M}{\|\symbf{d}\|^{2}} \symbf{\hat{d}}
            \end{displaymath}
-\\ \midrule \\
+\\ \midrule
 Description & \begin{symbDescription}
               \item{$\symbf{g}$ is the gravitational acceleration ($\frac{\text{m}}{\text{s}^{2}}$)}
               \item{$G$ is the gravitational constant ($\frac{\text{m}^{3}}{\text{kg}\text{s}^{2}}$)}
@@ -531,13 +531,13 @@ Description & \begin{symbDescription}
               \item{$\|\symbf{d}\|$ is the Euclidean norm of the distance between the center of mass of two bodies (${\text{m}}$)}
               \item{$\symbf{\hat{d}}$ is the unit vector directed from the center of the large mass to the center of the smaller mass (${\text{m}}$)}
               \end{symbDescription}
-\\ \midrule \\
+\\ \midrule
 Notes & If one of the masses is much larger than the other, it is convenient to define a gravitational field around the larger mass as shown above. The negative sign in the equation indicates that the force is an attractive force.
         
-\\ \midrule \\
+\\ \midrule
 Source & \hyperref{https://en.wikipedia.org/wiki/Gravitational_acceleration}{}{}{Definition of Gravitational Acceleration}
          
-\\ \midrule \\
+\\ \midrule
 RefBy & \hyperref[IM:transMot]{IM:transMot}
         
 \\ \bottomrule
@@ -577,17 +577,17 @@ and thus the negative sign indicates that the force is an attractive force:
 \toprule \textbf{Refname} & \textbf{GD:impulse}
 \phantomsection 
 \label{GD:impulse}
-\\ \midrule \\
+\\ \midrule
 Label & Impulse for Collision
         
-\\ \midrule \\
+\\ \midrule
 Units & $\text{N}\text{s}$
         
-\\ \midrule \\
+\\ \midrule
 Equation & \begin{displaymath}
            j=\frac{-\left(1+{C_{\text{R}}}\right) {{\symbf{v}\text{(}t\text{)}_{\text{i}}}^{\text{A}\text{B}}}\cdot{}\symbf{n}}{\left(\frac{1}{{m_{\text{A}}}}+\frac{1}{{m_{\text{B}}}}\right) \|\symbf{n}\|^{2}+\frac{\|{\symbf{u}_{\text{A}\text{P}}}\text{*}\symbf{n}\|^{2}}{{\symbf{I}_{\text{A}}}}+\frac{\|{\symbf{u}_{\text{B}\text{P}}}\text{*}\symbf{n}\|^{2}}{{\symbf{I}_{\text{B}}}}}
            \end{displaymath}
-\\ \midrule \\
+\\ \midrule
 Description & \begin{symbDescription}
               \item{$j$ is the impulse (scalar) ($\text{N}\text{s}$)}
               \item{${C_{\text{R}}}$ is the coefficient of restitution (Unitless)}
@@ -601,17 +601,17 @@ Description & \begin{symbDescription}
               \item{$\|{\symbf{u}_{\text{B}\text{P}}}\text{*}\symbf{n}\|$ is the length of the perpendicular vector to the contact displacement vector of rigid body B (${\text{m}}$)}
               \item{${\symbf{I}_{\text{B}}}$ is the moment of inertia of rigid body B ($\text{kg}\text{m}^{2}$)}
               \end{symbDescription}
-\\ \midrule \\
+\\ \midrule
 Notes & All bodies are assumed to be rigid (from \hyperref[assumpOT]{A:objectTy}) and two-dimensional (from \hyperref[assumpOD]{A:objectDimension}).
         
         A right-handed coordinate system is used (from \hyperref[assumpAD]{A:axesDefined}).
         
         All collisions are vertex-to-edge (from \hyperref[assumpCT]{A:collisionType}).
         
-\\ \midrule \\
+\\ \midrule
 Source & \hyperref{http://www.chrishecker.com/images/e/e7/Gdmphys3.pdf}{}{}{Impulse for Collision Ref}
          
-\\ \midrule \\
+\\ \midrule
 RefBy & \hyperref[IM:col2D]{IM:col2D}
         
 \\ \bottomrule
@@ -629,33 +629,33 @@ This section collects and defines all the data needed to build the instance mode
 \toprule \textbf{Refname} & \textbf{DD:ctrOfMass}
 \phantomsection 
 \label{DD:ctrOfMass}
-\\ \midrule \\
+\\ \midrule
 Label & Center of Mass
         
-\\ \midrule \\
+\\ \midrule
 Symbol & ${\symbf{p}\text{(}t\text{)}_{\text{CM}}}$
          
-\\ \midrule \\
+\\ \midrule
 Units & ${\text{m}}$
         
-\\ \midrule \\
+\\ \midrule
 Equation & \begin{displaymath}
            {\symbf{p}\text{(}t\text{)}_{\text{CM}}}=\frac{\displaystyle\sum{{m_{j}} {\symbf{p}\text{(}t\text{)}_{j}}}}{{m_{T}}}
            \end{displaymath}
-\\ \midrule \\
+\\ \midrule
 Description & \begin{symbDescription}
               \item{${\symbf{p}\text{(}t\text{)}_{\text{CM}}}$ is the Center of Mass (${\text{m}}$)}
               \item{${m_{j}}$ is the mass of the j-th particle (${\text{kg}}$)}
               \item{${\symbf{p}\text{(}t\text{)}_{j}}$ is the position vector of the j-th particle (${\text{m}}$)}
               \item{${m_{T}}$ is the total mass of the rigid body (${\text{kg}}$)}
               \end{symbDescription}
-\\ \midrule \\
+\\ \midrule
 Notes & All bodies are assumed to be rigid (from \hyperref[assumpOT]{A:objectTy}).
         
-\\ \midrule \\
+\\ \midrule
 Source & --
          
-\\ \midrule \\
+\\ \midrule
 RefBy & \hyperref[IM:col2D]{IM:col2D} and \hyperref[IM:transMot]{IM:transMot}
         
 \\ \bottomrule
@@ -669,32 +669,32 @@ RefBy & \hyperref[IM:col2D]{IM:col2D} and \hyperref[IM:transMot]{IM:transMot}
 \toprule \textbf{Refname} & \textbf{DD:linDisp}
 \phantomsection 
 \label{DD:linDisp}
-\\ \midrule \\
+\\ \midrule
 Label & Linear displacement
         
-\\ \midrule \\
+\\ \midrule
 Symbol & $u\text{(}t\text{)}$
          
-\\ \midrule \\
+\\ \midrule
 Units & ${\text{m}}$
         
-\\ \midrule \\
+\\ \midrule
 Equation & \begin{displaymath}
            u\text{(}t\text{)}=\frac{\,d\symbf{p}\text{(}t\text{)}\left(t\right)}{\,dt}
            \end{displaymath}
-\\ \midrule \\
+\\ \midrule
 Description & \begin{symbDescription}
               \item{$u\text{(}t\text{)}$ is the linear displacement (${\text{m}}$)}
               \item{$t$ is the time (${\text{s}}$)}
               \item{$\symbf{p}\text{(}t\text{)}$ is the position (${\text{m}}$)}
               \end{symbDescription}
-\\ \midrule \\
+\\ \midrule
 Notes & All bodies are assumed to be rigid (from \hyperref[assumpOT]{A:objectTy}).
         
-\\ \midrule \\
+\\ \midrule
 Source & --
          
-\\ \midrule \\
+\\ \midrule
 RefBy & \hyperref[IM:transMot]{IM:transMot}
         
 \\ \bottomrule
@@ -708,32 +708,32 @@ RefBy & \hyperref[IM:transMot]{IM:transMot}
 \toprule \textbf{Refname} & \textbf{DD:linVel}
 \phantomsection 
 \label{DD:linVel}
-\\ \midrule \\
+\\ \midrule
 Label & Linear velocity
         
-\\ \midrule \\
+\\ \midrule
 Symbol & $v\text{(}t\text{)}$
          
-\\ \midrule \\
+\\ \midrule
 Units & $\frac{\text{m}}{\text{s}}$
         
-\\ \midrule \\
+\\ \midrule
 Equation & \begin{displaymath}
            v\text{(}t\text{)}=\frac{\,d\symbf{u}\left(t\right)}{\,dt}
            \end{displaymath}
-\\ \midrule \\
+\\ \midrule
 Description & \begin{symbDescription}
               \item{$v\text{(}t\text{)}$ is the linear velocity ($\frac{\text{m}}{\text{s}}$)}
               \item{$t$ is the time (${\text{s}}$)}
               \item{$\symbf{u}$ is the displacement (${\text{m}}$)}
               \end{symbDescription}
-\\ \midrule \\
+\\ \midrule
 Notes & All bodies are assumed to be rigid (from \hyperref[assumpOT]{A:objectTy}).
         
-\\ \midrule \\
+\\ \midrule
 Source & --
          
-\\ \midrule \\
+\\ \midrule
 RefBy & \hyperref[IM:transMot]{IM:transMot}
         
 \\ \bottomrule
@@ -747,32 +747,32 @@ RefBy & \hyperref[IM:transMot]{IM:transMot}
 \toprule \textbf{Refname} & \textbf{DD:linAcc}
 \phantomsection 
 \label{DD:linAcc}
-\\ \midrule \\
+\\ \midrule
 Label & Linear acceleration
         
-\\ \midrule \\
+\\ \midrule
 Symbol & $a\text{(}t\text{)}$
          
-\\ \midrule \\
+\\ \midrule
 Units & $\frac{\text{m}}{\text{s}^{2}}$
         
-\\ \midrule \\
+\\ \midrule
 Equation & \begin{displaymath}
            a\text{(}t\text{)}=\frac{\,d\symbf{v}\text{(}t\text{)}\left(t\right)}{\,dt}
            \end{displaymath}
-\\ \midrule \\
+\\ \midrule
 Description & \begin{symbDescription}
               \item{$a\text{(}t\text{)}$ is the linear acceleration ($\frac{\text{m}}{\text{s}^{2}}$)}
               \item{$t$ is the time (${\text{s}}$)}
               \item{$\symbf{v}\text{(}t\text{)}$ is the velocity ($\frac{\text{m}}{\text{s}}$)}
               \end{symbDescription}
-\\ \midrule \\
+\\ \midrule
 Notes & All bodies are assumed to be rigid (from \hyperref[assumpOT]{A:objectTy}).
         
-\\ \midrule \\
+\\ \midrule
 Source & --
          
-\\ \midrule \\
+\\ \midrule
 RefBy & \hyperref[IM:transMot]{IM:transMot}
         
 \\ \bottomrule
@@ -786,32 +786,32 @@ RefBy & \hyperref[IM:transMot]{IM:transMot}
 \toprule \textbf{Refname} & \textbf{DD:angDisp}
 \phantomsection 
 \label{DD:angDisp}
-\\ \midrule \\
+\\ \midrule
 Label & Angular displacement
         
-\\ \midrule \\
+\\ \midrule
 Symbol & $θ$
          
-\\ \midrule \\
+\\ \midrule
 Units & ${\text{rad}}$
         
-\\ \midrule \\
+\\ \midrule
 Equation & \begin{displaymath}
            θ=\frac{\,dϕ\left(t\right)}{\,dt}
            \end{displaymath}
-\\ \midrule \\
+\\ \midrule
 Description & \begin{symbDescription}
               \item{$θ$ is the angular displacement (${\text{rad}}$)}
               \item{$t$ is the time (${\text{s}}$)}
               \item{$ϕ$ is the orientation (${\text{rad}}$)}
               \end{symbDescription}
-\\ \midrule \\
+\\ \midrule
 Notes & All bodies are assumed to be rigid (from \hyperref[assumpOT]{A:objectTy}) and two-dimensional (from \hyperref[assumpOD]{A:objectDimension}).
         
-\\ \midrule \\
+\\ \midrule
 Source & --
          
-\\ \midrule \\
+\\ \midrule
 RefBy & \hyperref[IM:rotMot]{IM:rotMot}
         
 \\ \bottomrule
@@ -825,32 +825,32 @@ RefBy & \hyperref[IM:rotMot]{IM:rotMot}
 \toprule \textbf{Refname} & \textbf{DD:angVel}
 \phantomsection 
 \label{DD:angVel}
-\\ \midrule \\
+\\ \midrule
 Label & Angular velocity
         
-\\ \midrule \\
+\\ \midrule
 Symbol & $ω$
          
-\\ \midrule \\
+\\ \midrule
 Units & $\frac{\text{rad}}{\text{s}}$
         
-\\ \midrule \\
+\\ \midrule
 Equation & \begin{displaymath}
            ω=\frac{\,dθ\left(t\right)}{\,dt}
            \end{displaymath}
-\\ \midrule \\
+\\ \midrule
 Description & \begin{symbDescription}
               \item{$ω$ is the angular velocity ($\frac{\text{rad}}{\text{s}}$)}
               \item{$t$ is the time (${\text{s}}$)}
               \item{$θ$ is the angular displacement (${\text{rad}}$)}
               \end{symbDescription}
-\\ \midrule \\
+\\ \midrule
 Notes & All bodies are assumed to be rigid (from \hyperref[assumpOT]{A:objectTy}) and two-dimensional (from \hyperref[assumpOD]{A:objectDimension}).
         
-\\ \midrule \\
+\\ \midrule
 Source & --
          
-\\ \midrule \\
+\\ \midrule
 RefBy & \hyperref[IM:rotMot]{IM:rotMot}
         
 \\ \bottomrule
@@ -864,32 +864,32 @@ RefBy & \hyperref[IM:rotMot]{IM:rotMot}
 \toprule \textbf{Refname} & \textbf{DD:angAccel}
 \phantomsection 
 \label{DD:angAccel}
-\\ \midrule \\
+\\ \midrule
 Label & Angular acceleration
         
-\\ \midrule \\
+\\ \midrule
 Symbol & $α$
          
-\\ \midrule \\
+\\ \midrule
 Units & $\frac{\text{rad}}{\text{s}^{2}}$
         
-\\ \midrule \\
+\\ \midrule
 Equation & \begin{displaymath}
            α=\frac{\,dω\left(t\right)}{\,dt}
            \end{displaymath}
-\\ \midrule \\
+\\ \midrule
 Description & \begin{symbDescription}
               \item{$α$ is the angular acceleration ($\frac{\text{rad}}{\text{s}^{2}}$)}
               \item{$t$ is the time (${\text{s}}$)}
               \item{$ω$ is the angular velocity ($\frac{\text{rad}}{\text{s}}$)}
               \end{symbDescription}
-\\ \midrule \\
+\\ \midrule
 Notes & All bodies are assumed to be rigid (from \hyperref[assumpOT]{A:objectTy}) and two-dimensional (from \hyperref[assumpOD]{A:objectDimension}).
         
-\\ \midrule \\
+\\ \midrule
 Source & --
          
-\\ \midrule \\
+\\ \midrule
 RefBy & \hyperref[IM:rotMot]{IM:rotMot}
         
 \\ \bottomrule
@@ -903,35 +903,35 @@ RefBy & \hyperref[IM:rotMot]{IM:rotMot}
 \toprule \textbf{Refname} & \textbf{DD:chaslesThm}
 \phantomsection 
 \label{DD:chaslesThm}
-\\ \midrule \\
+\\ \midrule
 Label & Chasles' theorem
         
-\\ \midrule \\
+\\ \midrule
 Symbol & ${\symbf{v}\text{(}t\text{)}_{\text{B}}}$
          
-\\ \midrule \\
+\\ \midrule
 Units & $\frac{\text{m}}{\text{s}}$
         
-\\ \midrule \\
+\\ \midrule
 Equation & \begin{displaymath}
            {\symbf{v}\text{(}t\text{)}_{\text{B}}}={\symbf{v}\text{(}t\text{)}_{\text{O}}}+ω\times{\symbf{u}_{\text{O}\text{B}}}
            \end{displaymath}
-\\ \midrule \\
+\\ \midrule
 Description & \begin{symbDescription}
               \item{${\symbf{v}\text{(}t\text{)}_{\text{B}}}$ is the velocity at point B ($\frac{\text{m}}{\text{s}}$)}
               \item{${\symbf{v}\text{(}t\text{)}_{\text{O}}}$ is the velocity at point origin ($\frac{\text{m}}{\text{s}}$)}
               \item{$ω$ is the angular velocity ($\frac{\text{rad}}{\text{s}}$)}
               \item{${\symbf{u}_{\text{O}\text{B}}}$ is the displacement vector between the origin and point B (${\text{m}}$)}
               \end{symbDescription}
-\\ \midrule \\
+\\ \midrule
 Notes & The linear velocity ${\symbf{v}\text{(}t\text{)}_{\text{B}}}$ of any point B in a rigid body is the sum of the linear velocity ${\symbf{v}\text{(}t\text{)}_{\text{O}}}$ of the rigid body at the origin (axis of rotation) and the resultant vector from the cross product of the rigid body's angular velocity $ω$ and the displacement vector between the origin and point B ${\symbf{u}_{\text{O}\text{B}}}$.
         
         All bodies are assumed to be rigid (from \hyperref[assumpOT]{A:objectTy}).
         
-\\ \midrule \\
+\\ \midrule
 Source & \cite{chaslesWiki}
          
-\\ \midrule \\
+\\ \midrule
 RefBy & 
 \\ \bottomrule
 \end{tabular}
@@ -944,32 +944,32 @@ RefBy &
 \toprule \textbf{Refname} & \textbf{DD:torque}
 \phantomsection 
 \label{DD:torque}
-\\ \midrule \\
+\\ \midrule
 Label & Torque
         
-\\ \midrule \\
+\\ \midrule
 Symbol & $\symbf{τ}$
          
-\\ \midrule \\
+\\ \midrule
 Units & $\text{N}\text{m}$
         
-\\ \midrule \\
+\\ \midrule
 Equation & \begin{displaymath}
            \symbf{τ}=\symbf{r}\times\symbf{F}
            \end{displaymath}
-\\ \midrule \\
+\\ \midrule
 Description & \begin{symbDescription}
               \item{$\symbf{τ}$ is the torque ($\text{N}\text{m}$)}
               \item{$\symbf{r}$ is the position vector (${\text{m}}$)}
               \item{$\symbf{F}$ is the force (${\text{N}}$)}
               \end{symbDescription}
-\\ \midrule \\
+\\ \midrule
 Notes & The torque on a body measures the tendency of a force to rotate the body around an axis or pivot.
         
-\\ \midrule \\
+\\ \midrule
 Source & --
          
-\\ \midrule \\
+\\ \midrule
 RefBy & 
 \\ \bottomrule
 \end{tabular}
@@ -982,36 +982,36 @@ RefBy &
 \toprule \textbf{Refname} & \textbf{DD:kEnergy}
 \phantomsection 
 \label{DD:kEnergy}
-\\ \midrule \\
+\\ \midrule
 Label & Kinetic energy
         
-\\ \midrule \\
+\\ \midrule
 Symbol & $KE$
          
-\\ \midrule \\
+\\ \midrule
 Units & ${\text{J}}$
         
-\\ \midrule \\
+\\ \midrule
 Equation & \begin{displaymath}
            KE=m \frac{\|\symbf{v}\text{(}t\text{)}\|^{2}}{2}
            \end{displaymath}
-\\ \midrule \\
+\\ \midrule
 Description & \begin{symbDescription}
               \item{$KE$ is the kinetic energy (${\text{J}}$)}
               \item{$m$ is the mass (${\text{kg}}$)}
               \item{$\symbf{v}\text{(}t\text{)}$ is the velocity ($\frac{\text{m}}{\text{s}}$)}
               \end{symbDescription}
-\\ \midrule \\
+\\ \midrule
 Notes & Kinetic energy is the measure of the energy a body possesses due to its motion.
         
         All bodies are assumed to be rigid (from \hyperref[assumpOT]{A:objectTy}) and two-dimensional (from \hyperref[assumpOD]{A:objectDimension}).
         
         No damping occurs during the simulation (from \hyperref[assumpDI]{A:dampingInvolvement}).
         
-\\ \midrule \\
+\\ \midrule
 Source & --
          
-\\ \midrule \\
+\\ \midrule
 RefBy & 
 \\ \bottomrule
 \end{tabular}
@@ -1024,33 +1024,33 @@ RefBy &
 \toprule \textbf{Refname} & \textbf{DD:coeffRestitution}
 \phantomsection 
 \label{DD:coeffRestitution}
-\\ \midrule \\
+\\ \midrule
 Label & Coefficient of restitution
         
-\\ \midrule \\
+\\ \midrule
 Symbol & ${C_{\text{R}}}$
          
-\\ \midrule \\
+\\ \midrule
 Units & Unitless
         
-\\ \midrule \\
+\\ \midrule
 Equation & \begin{displaymath}
            {C_{\text{R}}}=-\left(\frac{{{\symbf{v}\text{(}t\text{)}_{\text{f}}}^{\text{A}\text{B}}}\cdot{}\symbf{n}}{{{\symbf{v}\text{(}t\text{)}_{\text{i}}}^{\text{A}\text{B}}}\cdot{}\symbf{n}}\right)
            \end{displaymath}
-\\ \midrule \\
+\\ \midrule
 Description & \begin{symbDescription}
               \item{${C_{\text{R}}}$ is the coefficient of restitution (Unitless)}
               \item{${{\symbf{v}\text{(}t\text{)}_{\text{f}}}^{\text{A}\text{B}}}$ is the final relative velocity between rigid bodies of A and B ($\frac{\text{m}}{\text{s}}$)}
               \item{$\symbf{n}$ is the collision normal vector (${\text{m}}$)}
               \item{${{\symbf{v}\text{(}t\text{)}_{\text{i}}}^{\text{A}\text{B}}}$ is the initial relative velocity between rigid bodies of A and B ($\frac{\text{m}}{\text{s}}$)}
               \end{symbDescription}
-\\ \midrule \\
+\\ \midrule
 Notes & The coefficient of restitution ${C_{\text{R}}}$ determines the elasticity of a collision between two rigid bodies. ${C_{\text{R}}}=1$ results in an elastic collision, ${C_{\text{R}}}\lt{}1$ results in an inelastic collision, and ${C_{\text{R}}}=0$ results in a totally inelastic collision.
         
-\\ \midrule \\
+\\ \midrule
 Source & --
          
-\\ \midrule \\
+\\ \midrule
 RefBy & 
 \\ \bottomrule
 \end{tabular}
@@ -1063,34 +1063,34 @@ RefBy &
 \toprule \textbf{Refname} & \textbf{DD:reVeInColl}
 \phantomsection 
 \label{DD:reVeInColl}
-\\ \midrule \\
+\\ \midrule
 Label & Initial Relative Velocity Between Rigid Bodies of A and B
         
-\\ \midrule \\
+\\ \midrule
 Symbol & ${{\symbf{v}\text{(}t\text{)}_{\text{i}}}^{\text{A}\text{B}}}$
          
-\\ \midrule \\
+\\ \midrule
 Units & $\frac{\text{m}}{\text{s}}$
         
-\\ \midrule \\
+\\ \midrule
 Equation & \begin{displaymath}
            {{\symbf{v}\text{(}t\text{)}_{\text{i}}}^{\text{A}\text{B}}}={\symbf{v}\text{(}t\text{)}^{\text{A}\text{P}}}-{\symbf{v}\text{(}t\text{)}^{\text{B}\text{P}}}
            \end{displaymath}
-\\ \midrule \\
+\\ \midrule
 Description & \begin{symbDescription}
               \item{${{\symbf{v}\text{(}t\text{)}_{\text{i}}}^{\text{A}\text{B}}}$ is the initial relative velocity between rigid bodies of A and B ($\frac{\text{m}}{\text{s}}$)}
               \item{${\symbf{v}\text{(}t\text{)}^{\text{A}\text{P}}}$ is the velocity of the point of collision P in body A ($\frac{\text{m}}{\text{s}}$)}
               \item{${\symbf{v}\text{(}t\text{)}^{\text{B}\text{P}}}$ is the velocity of the point of collision P in body B ($\frac{\text{m}}{\text{s}}$)}
               \end{symbDescription}
-\\ \midrule \\
+\\ \midrule
 Notes & In a collision, the velocity of a rigid body A colliding with another rigid body B relative to that body ${{\symbf{v}\text{(}t\text{)}_{\text{i}}}^{\text{A}\text{B}}}$ is the difference between the velocities of A and B at point P.
         
         All bodies are assumed to be rigid (from \hyperref[assumpOT]{A:objectTy}).
         
-\\ \midrule \\
+\\ \midrule
 Source & --
          
-\\ \midrule \\
+\\ \midrule
 RefBy & 
 \\ \bottomrule
 \end{tabular}
@@ -1103,34 +1103,34 @@ RefBy &
 \toprule \textbf{Refname} & \textbf{DD:impulseV}
 \phantomsection 
 \label{DD:impulseV}
-\\ \midrule \\
+\\ \midrule
 Label & Impulse (vector)
         
-\\ \midrule \\
+\\ \midrule
 Symbol & $\symbf{J}$
          
-\\ \midrule \\
+\\ \midrule
 Units & $\text{N}\text{s}$
         
-\\ \midrule \\
+\\ \midrule
 Equation & \begin{displaymath}
            \symbf{J}=m Δ\symbf{v}
            \end{displaymath}
-\\ \midrule \\
+\\ \midrule
 Description & \begin{symbDescription}
               \item{$\symbf{J}$ is the impulse (vector) ($\text{N}\text{s}$)}
               \item{$m$ is the mass (${\text{kg}}$)}
               \item{$Δ\symbf{v}$ is the change in velocity ($\frac{\text{m}}{\text{s}}$)}
               \end{symbDescription}
-\\ \midrule \\
+\\ \midrule
 Notes & An impulse (vector) $\symbf{J}$ occurs when a force $\symbf{F}$ acts over a body over an interval of time.
         
         All bodies are assumed to be rigid (from \hyperref[assumpOT]{A:objectTy}).
         
-\\ \midrule \\
+\\ \midrule
 Source & --
          
-\\ \midrule \\
+\\ \midrule
 RefBy & 
 \\ \bottomrule
 \end{tabular}
@@ -1159,37 +1159,37 @@ Integrating the right hand side:
 \toprule \textbf{Refname} & \textbf{DD:potEnergy}
 \phantomsection 
 \label{DD:potEnergy}
-\\ \midrule \\
+\\ \midrule
 Label & Potential energy
         
-\\ \midrule \\
+\\ \midrule
 Symbol & $PE$
          
-\\ \midrule \\
+\\ \midrule
 Units & ${\text{J}}$
         
-\\ \midrule \\
+\\ \midrule
 Equation & \begin{displaymath}
            PE=m \symbf{g} h
            \end{displaymath}
-\\ \midrule \\
+\\ \midrule
 Description & \begin{symbDescription}
               \item{$PE$ is the potential energy (${\text{J}}$)}
               \item{$m$ is the mass (${\text{kg}}$)}
               \item{$\symbf{g}$ is the gravitational acceleration ($\frac{\text{m}}{\text{s}^{2}}$)}
               \item{$h$ is the height (${\text{m}}$)}
               \end{symbDescription}
-\\ \midrule \\
+\\ \midrule
 Notes & The potential energy of an object is the energy held by an object because of its position to other objects.
         
         All bodies are assumed to be rigid (from \hyperref[assumpOT]{A:objectTy}) and two-dimensional (from \hyperref[assumpOD]{A:objectDimension}).
         
         No damping occurs during the simulation (from \hyperref[assumpDI]{A:dampingInvolvement}).
         
-\\ \midrule \\
+\\ \midrule
 Source & --
          
-\\ \midrule \\
+\\ \midrule
 RefBy & 
 \\ \bottomrule
 \end{tabular}
@@ -1202,34 +1202,34 @@ RefBy &
 \toprule \textbf{Refname} & \textbf{DD:momentOfInertia}
 \phantomsection 
 \label{DD:momentOfInertia}
-\\ \midrule \\
+\\ \midrule
 Label & Moment of inertia
         
-\\ \midrule \\
+\\ \midrule
 Symbol & $\symbf{I}$
          
-\\ \midrule \\
+\\ \midrule
 Units & $\text{kg}\text{m}^{2}$
         
-\\ \midrule \\
+\\ \midrule
 Equation & \begin{displaymath}
            \symbf{I}=\displaystyle\sum{{m_{j}} {d_{j}}^{2}}
            \end{displaymath}
-\\ \midrule \\
+\\ \midrule
 Description & \begin{symbDescription}
               \item{$\symbf{I}$ is the moment of inertia ($\text{kg}\text{m}^{2}$)}
               \item{${m_{j}}$ is the mass of the j-th particle (${\text{kg}}$)}
               \item{${d_{j}}$ is the distance between the j-th particle and the axis of rotation (${\text{m}}$)}
               \end{symbDescription}
-\\ \midrule \\
+\\ \midrule
 Notes & The moment of inertia $\symbf{I}$ of a body measures how much torque is needed for the body to achieve angular acceleration about the axis of rotation.
         
         All bodies are assumed to be rigid (from \hyperref[assumpOT]{A:objectTy}).
         
-\\ \midrule \\
+\\ \midrule
 Source & --
          
-\\ \midrule \\
+\\ \midrule
 RefBy & 
 \\ \bottomrule
 \end{tabular}
@@ -1248,16 +1248,16 @@ The goal \hyperref[linearGS]{GS:Determine-Linear-Properties} is met by \hyperref
 \toprule \textbf{Refname} & \textbf{IM:transMot}
 \phantomsection 
 \label{IM:transMot}
-\\ \midrule \\
+\\ \midrule
 Label & J-Th Body's Acceleration
         
-\\ \midrule \\
+\\ \midrule
 Input & ${\symbf{v}\text{(}t\text{)}_{j}}$, $t$, $\symbf{g}$, ${\symbf{F}_{j}}$, ${m_{j}}$
         
-\\ \midrule \\
+\\ \midrule
 Output & ${\symbf{a}\text{(}t\text{)}_{j}}$
          
-\\ \midrule \\
+\\ \midrule
 Input Constraints & \begin{displaymath}
                     {\symbf{v}\text{(}t\text{)}_{j}}\gt{}0
                     \end{displaymath}
@@ -1273,13 +1273,13 @@ Input Constraints & \begin{displaymath}
                     \begin{displaymath}
                     {m_{j}}\gt{}0
                     \end{displaymath}
-\\ \midrule \\
+\\ \midrule
 Output Constraints & 
-\\ \midrule \\
+\\ \midrule
 Equation & \begin{displaymath}
            {\symbf{a}\text{(}t\text{)}_{j}}=\symbf{g}+\frac{{\symbf{F}_{j}}\left(t\right)}{{m_{j}}}
            \end{displaymath}
-\\ \midrule \\
+\\ \midrule
 Description & \begin{symbDescription}
               \item{${\symbf{a}\text{(}t\text{)}_{j}}$ is the j-th body's acceleration ($\frac{\text{m}}{\text{s}^{2}}$)}
               \item{$\symbf{g}$ is the gravitational acceleration ($\frac{\text{m}}{\text{s}^{2}}$)}
@@ -1287,7 +1287,7 @@ Description & \begin{symbDescription}
               \item{$t$ is the time (${\text{s}}$)}
               \item{${m_{j}}$ is the mass of the j-th particle (${\text{kg}}$)}
               \end{symbDescription}
-\\ \midrule \\
+\\ \midrule
 Notes & The above equation expresses the total acceleration of the rigid body $j$ as the sum of gravitational acceleration (from \hyperref[GD:accelGravity]{GD:accelGravity}) and acceleration due to applied force ${\symbf{F}_{j}}\left(t\right)$ (from \hyperref[TM:NewtonSecLawMot]{TM:NewtonSecLawMot}). The resultant outputs are then obtained from this equation using \hyperref[DD:linDisp]{DD:linDisp}, \hyperref[DD:linVel]{DD:linVel}, and \hyperref[DD:linAcc]{DD:linAcc}.
         
         The output of the instance model will be the functions of position and velocity over time that satisfy the ODE for the acceleration, with the given initial conditions for position and velocity. The motion is translational, so the position and velocity functions are for the centre of mass (from \hyperref[DD:ctrOfMass]{DD:ctrOfMass}).
@@ -1296,10 +1296,10 @@ Notes & The above equation expresses the total acceleration of the rigid body $j
         
         It is currently assumed that no damping occurs during the simulation (from \hyperref[assumpDI]{A:dampingInvolvement}) and that no constraints are involved (from \hyperref[assumpCAJI]{A:constraintsAndJointsInvolvement}).
         
-\\ \midrule \\
+\\ \midrule
 Source & --
          
-\\ \midrule \\
+\\ \midrule
 RefBy & 
 \\ \bottomrule
 \end{tabular}
@@ -1323,16 +1323,16 @@ Performing the derivative, we obtain:
 \toprule \textbf{Refname} & \textbf{IM:rotMot}
 \phantomsection 
 \label{IM:rotMot}
-\\ \midrule \\
+\\ \midrule
 Label & J-Th Body's Angular Acceleration
         
-\\ \midrule \\
+\\ \midrule
 Input & $ω$, $t$, ${\symbf{τ}_{j}}$, $\symbf{I}$
         
-\\ \midrule \\
+\\ \midrule
 Output & ${α_{j}}$
          
-\\ \midrule \\
+\\ \midrule
 Input Constraints & \begin{displaymath}
                     ω\gt{}0
                     \end{displaymath}
@@ -1345,32 +1345,32 @@ Input Constraints & \begin{displaymath}
                     \begin{displaymath}
                     \symbf{I}\gt{}0
                     \end{displaymath}
-\\ \midrule \\
+\\ \midrule
 Output Constraints & \begin{displaymath}
                      {α_{j}}\gt{}0
                      \end{displaymath}
-\\ \midrule \\
+\\ \midrule
 Equation & \begin{displaymath}
            {α_{j}}=\frac{{\symbf{τ}_{j}}\left(t\right)}{\symbf{I}}
            \end{displaymath}
-\\ \midrule \\
+\\ \midrule
 Description & \begin{symbDescription}
               \item{${α_{j}}$ is the j-th body's angular acceleration ($\frac{\text{rad}}{\text{s}^{2}}$)}
               \item{${\symbf{τ}_{j}}$ is the torque applied to the j-th body ($\text{N}\text{m}$)}
               \item{$t$ is the time (${\text{s}}$)}
               \item{$\symbf{I}$ is the moment of inertia ($\text{kg}\text{m}^{2}$)}
               \end{symbDescription}
-\\ \midrule \\
+\\ \midrule
 Notes & The above equation for the total angular acceleration of the rigid body $j$ is derived from \hyperref[TM:NewtonSecLawRotMot]{TM:NewtonSecLawRotMot}, and the resultant outputs are then obtained from this equation using \hyperref[DD:angDisp]{DD:angDisp}, \hyperref[DD:angVel]{DD:angVel}, and \hyperref[DD:angAccel]{DD:angAccel}.
         
         All bodies are assumed to be rigid (from \hyperref[assumpOT]{A:objectTy}) and two-dimensional (from \hyperref[assumpOD]{A:objectDimension}).
         
         A right-handed coordinate system is used (from \hyperref[assumpAD]{A:axesDefined}).
         
-\\ \midrule \\
+\\ \midrule
 Source & --
          
-\\ \midrule \\
+\\ \midrule
 RefBy & 
 \\ \bottomrule
 \end{tabular}
@@ -1394,16 +1394,16 @@ Performing the derivative, we obtain:
 \toprule \textbf{Refname} & \textbf{IM:col2D}
 \phantomsection 
 \label{IM:col2D}
-\\ \midrule \\
+\\ \midrule
 Label & Collisions on 2D rigid bodies
         
-\\ \midrule \\
+\\ \midrule
 Input & $t$, $j$, ${m_{\text{A}}}$, $\symbf{n}$
         
-\\ \midrule \\
+\\ \midrule
 Output & ${t_{\text{c}}}$
          
-\\ \midrule \\
+\\ \midrule
 Input Constraints & \begin{displaymath}
                     t\gt{}0
                     \end{displaymath}
@@ -1416,15 +1416,15 @@ Input Constraints & \begin{displaymath}
                     \begin{displaymath}
                     \symbf{n}\gt{}0
                     \end{displaymath}
-\\ \midrule \\
+\\ \midrule
 Output Constraints & \begin{displaymath}
                      {t_{\text{c}}}\gt{}0
                      \end{displaymath}
-\\ \midrule \\
+\\ \midrule
 Equation & \begin{displaymath}
            {\symbf{v}\text{(}t\text{)}_{\text{A}}}\left({t_{\text{c}}}\right)={\symbf{v}\text{(}t\text{)}_{\text{A}}}\left(t\right)+\frac{j}{{m_{\text{A}}}} \symbf{n}
            \end{displaymath}
-\\ \midrule \\
+\\ \midrule
 Description & \begin{symbDescription}
               \item{${\symbf{v}\text{(}t\text{)}_{\text{A}}}$ is the velocity at point A ($\frac{\text{m}}{\text{s}}$)}
               \item{${t_{\text{c}}}$ is the denotes the time at collision (${\text{s}}$)}
@@ -1433,7 +1433,7 @@ Description & \begin{symbDescription}
               \item{${m_{\text{A}}}$ is the mass of rigid body A (${\text{kg}}$)}
               \item{$\symbf{n}$ is the collision normal vector (${\text{m}}$)}
               \end{symbDescription}
-\\ \midrule \\
+\\ \midrule
 Notes & The output of the instance model will be the functions of position, velocity, orientation, and angular acceleration over time that satisfy the equations for the velocity and angular acceleration, with the given initial conditions for position, velocity, orientation, and angular acceleration. The motion is translational, so the position, velocity, orientation, and angular acceleration functions are for the centre of mass (from \hyperref[DD:ctrOfMass]{DD:ctrOfMass}).
         
         All bodies are assumed to be rigid (from \hyperref[assumpOT]{A:objectTy}) and two-dimensional (from \hyperref[assumpOD]{A:objectDimension}).
@@ -1446,10 +1446,10 @@ Notes & The output of the instance model will be the functions of position, velo
         
         $j$ is defined in \hyperref[GD:impulse]{GD:impulse}
         
-\\ \midrule \\
+\\ \midrule
 Source & --
          
-\\ \midrule \\
+\\ \midrule
 RefBy & 
 \\ \bottomrule
 \end{tabular}

--- a/code/stable/glassbr/SRS/PDF/GlassBR_SRS.tex
+++ b/code/stable/glassbr/SRS/PDF/GlassBR_SRS.tex
@@ -405,26 +405,26 @@ This section focuses on the general equations and laws that GlassBR is based on.
 \toprule \textbf{Refname} & \textbf{TM:isSafeProb}
 \phantomsection 
 \label{TM:isSafeProb}
-\\ \midrule \\
+\\ \midrule
 Label & Safety Probability
         
-\\ \midrule \\
+\\ \midrule
 Equation & \begin{displaymath}
            \mathit{isSafeProb}={P_{\text{f}}}\lt{}{P_{\text{f}\text{tol}}}
            \end{displaymath}
-\\ \midrule \\
+\\ \midrule
 Description & \begin{symbDescription}
               \item{$\mathit{isSafeProb}$ is the probability of failure safety requirement (Unitless)}
               \item{${P_{\text{f}}}$ is the probability of failure (Unitless)}
               \item{${P_{\text{f}\text{tol}}}$ is the tolerable probability of failure (Unitless)}
               \end{symbDescription}
-\\ \midrule \\
+\\ \midrule
 Notes & If $\mathit{isSafeProb}$, the structure is considered safe.
         
-\\ \midrule \\
+\\ \midrule
 Source & \cite{astm2009}
          
-\\ \midrule \\
+\\ \midrule
 RefBy & \hyperref[checkGlassSafety]{FR:Check-Glass-Safety}
         
 \\ \bottomrule
@@ -437,26 +437,26 @@ RefBy & \hyperref[checkGlassSafety]{FR:Check-Glass-Safety}
 \toprule \textbf{Refname} & \textbf{TM:isSafeLoad}
 \phantomsection 
 \label{TM:isSafeLoad}
-\\ \midrule \\
+\\ \midrule
 Label & Safety Load
         
-\\ \midrule \\
+\\ \midrule
 Equation & \begin{displaymath}
            \mathit{isSafeLoad}=\mathit{capacity}\gt{}\mathit{Load}
            \end{displaymath}
-\\ \midrule \\
+\\ \midrule
 Description & \begin{symbDescription}
               \item{$\mathit{isSafeLoad}$ is the load resistance safety requirement (Unitless)}
               \item{$\mathit{capacity}$ is the capacity or load resistance (${\text{Pa}}$)}
               \item{$\mathit{Load}$ is the applied load (demand) or pressure (${\text{Pa}}$)}
               \end{symbDescription}
-\\ \midrule \\
+\\ \midrule
 Notes & If $\mathit{isSafeLoad}$, the structure is considered safe.
         
-\\ \midrule \\
+\\ \midrule
 Source & \cite{astm2009}
          
-\\ \midrule \\
+\\ \midrule
 RefBy & \hyperref[checkGlassSafety]{FR:Check-Glass-Safety}
         
 \\ \bottomrule
@@ -477,20 +477,20 @@ This section collects and defines all the data needed to build the instance mode
 \toprule \textbf{Refname} & \textbf{DD:riskFun}
 \phantomsection 
 \label{DD:riskFun}
-\\ \midrule \\
+\\ \midrule
 Label & Risk of failure
         
-\\ \midrule \\
+\\ \midrule
 Symbol & $B$
          
-\\ \midrule \\
+\\ \midrule
 Units & Unitless
         
-\\ \midrule \\
+\\ \midrule
 Equation & \begin{displaymath}
            B=\frac{k}{\left(a b\right)^{m-1}} \left(E h^{2}\right)^{m} \mathit{LDF} e^{J}
            \end{displaymath}
-\\ \midrule \\
+\\ \midrule
 Description & \begin{symbDescription}
               \item{$B$ is the risk of failure (Unitless)}
               \item{$k$ is the surface flaw parameter ($\frac{\text{m}^{12}}{\text{N}^{7}}$)}
@@ -502,7 +502,7 @@ Description & \begin{symbDescription}
               \item{$\mathit{LDF}$ is the load duration factor (Unitless)}
               \item{$J$ is the stress distribution factor (Function) (Unitless)}
               \end{symbDescription}
-\\ \midrule \\
+\\ \midrule
 Notes & $a$ and $b$ are the dimensions of the plate, where ($a\geq{}b$).
         
         $h$ is defined in \hyperref[DD:minThick]{DD:minThick} and is based on the nominal thicknesses.
@@ -511,10 +511,10 @@ Notes & $a$ and $b$ are the dimensions of the plate, where ($a\geq{}b$).
         
         $J$ is defined in \hyperref[DD:stressDistFac]{DD:stressDistFac}.
         
-\\ \midrule \\
+\\ \midrule
 Source & \cite{astm2009}, \cite[(Eqs. 4-5)]{beasonEtAl1998}, and \cite[(Eq. 14)]{campidelli}
          
-\\ \midrule \\
+\\ \midrule
 RefBy & \hyperref[DD:probOfBreak]{DD:probOfBreak}
         
 \\ \bottomrule
@@ -528,16 +528,16 @@ RefBy & \hyperref[DD:probOfBreak]{DD:probOfBreak}
 \toprule \textbf{Refname} & \textbf{DD:minThick}
 \phantomsection 
 \label{DD:minThick}
-\\ \midrule \\
+\\ \midrule
 Label & Minimum thickness
         
-\\ \midrule \\
+\\ \midrule
 Symbol & $h$
          
-\\ \midrule \\
+\\ \midrule
 Units & ${\text{m}}$
         
-\\ \midrule \\
+\\ \midrule
 Equation & \begin{displaymath}
            h=\frac{1}{1000} \begin{cases}
                             2.16, & t=2.5\\
@@ -554,18 +554,18 @@ Equation & \begin{displaymath}
                             21.44, & t=22.0
                             \end{cases}
            \end{displaymath}
-\\ \midrule \\
+\\ \midrule
 Description & \begin{symbDescription}
               \item{$h$ is the minimum thickness (${\text{m}}$)}
               \item{$t$ is the nominal thickness $t\in{}\{2.5,2.7,3.0,4.0,5.0,6.0,8.0,10.0,12.0,16.0,19.0,22.0\}$ (${\text{mm}}$)}
               \end{symbDescription}
-\\ \midrule \\
+\\ \midrule
 Notes & $t$ is a function that maps from the nominal thickness ($h$) to the minimum thickness.
         
-\\ \midrule \\
+\\ \midrule
 Source & \cite{astm2009}
          
-\\ \midrule \\
+\\ \midrule
 RefBy & \hyperref[DD:sdfTol]{DD:sdfTol}, \hyperref[DD:riskFun]{DD:riskFun}, \hyperref[DD:nFL]{DD:nFL}, and \hyperref[DD:dimlessLoad]{DD:dimlessLoad}
         
 \\ \bottomrule
@@ -579,34 +579,34 @@ RefBy & \hyperref[DD:sdfTol]{DD:sdfTol}, \hyperref[DD:riskFun]{DD:riskFun}, \hyp
 \toprule \textbf{Refname} & \textbf{DD:loadDurFactor}
 \phantomsection 
 \label{DD:loadDurFactor}
-\\ \midrule \\
+\\ \midrule
 Label & Load duration factor
         
-\\ \midrule \\
+\\ \midrule
 Symbol & $\mathit{LDF}$
          
-\\ \midrule \\
+\\ \midrule
 Units & Unitless
         
-\\ \midrule \\
+\\ \midrule
 Equation & \begin{displaymath}
            \mathit{LDF}=\left(\frac{{t_{\text{d}}}}{60}\right)^{\frac{m}{16}}
            \end{displaymath}
-\\ \midrule \\
+\\ \midrule
 Description & \begin{symbDescription}
               \item{$\mathit{LDF}$ is the load duration factor (Unitless)}
               \item{${t_{\text{d}}}$ is the duration of load (${\text{s}}$)}
               \item{$m$ is the surface flaw parameter ($\frac{\text{m}^{12}}{\text{N}^{7}}$)}
               \end{symbDescription}
-\\ \midrule \\
+\\ \midrule
 Notes & ${t_{\text{d}}}$ and $m$ come from \hyperref[assumpSV]{A:standardValues}.
         
         $\mathit{LDF}$ is assumed to be constant (from \hyperref[assumpLDFC]{A:ldfConstant}).
         
-\\ \midrule \\
+\\ \midrule
 Source & \cite{astm2009}
          
-\\ \midrule \\
+\\ \midrule
 RefBy & \hyperref[DD:sdfTol]{DD:sdfTol} and \hyperref[DD:riskFun]{DD:riskFun}
         
 \\ \bottomrule
@@ -620,37 +620,37 @@ RefBy & \hyperref[DD:sdfTol]{DD:sdfTol} and \hyperref[DD:riskFun]{DD:riskFun}
 \toprule \textbf{Refname} & \textbf{DD:stressDistFac}
 \phantomsection 
 \label{DD:stressDistFac}
-\\ \midrule \\
+\\ \midrule
 Label & Stress distribution factor (Function)
         
-\\ \midrule \\
+\\ \midrule
 Symbol & $J$
          
-\\ \midrule \\
+\\ \midrule
 Units & Unitless
         
-\\ \midrule \\
+\\ \midrule
 Equation & \begin{displaymath}
            J=\mathit{interpZ}\left(\text{``SDF.txt''},\mathit{AR},\hat{q}\right)
            \end{displaymath}
-\\ \midrule \\
+\\ \midrule
 Description & \begin{symbDescription}
               \item{$J$ is the stress distribution factor (Function) (Unitless)}
               \item{$\mathit{interpZ}$ is the interpZ (Unitless)}
               \item{$\mathit{AR}$ is the aspect ratio (Unitless)}
               \item{$\hat{q}$ is the dimensionless load (Unitless)}
               \end{symbDescription}
-\\ \midrule \\
+\\ \midrule
 Notes & $J$ is obtained by interpolating from data shown in \hyperref[Figure:dimlessloadVSaspect]{Fig:dimlessloadVSaspect}.
         
         $\mathit{AR}$ is defined in \hyperref[DD:aspectRatio]{DD:aspectRatio}.
         
         $\hat{q}$ is defined in \hyperref[DD:dimlessLoad]{DD:dimlessLoad}.
         
-\\ \midrule \\
+\\ \midrule
 Source & \cite{astm2009}
          
-\\ \midrule \\
+\\ \midrule
 RefBy & \hyperref[DD:riskFun]{DD:riskFun}
         
 \\ \bottomrule
@@ -664,20 +664,20 @@ RefBy & \hyperref[DD:riskFun]{DD:riskFun}
 \toprule \textbf{Refname} & \textbf{DD:nFL}
 \phantomsection 
 \label{DD:nFL}
-\\ \midrule \\
+\\ \midrule
 Label & Non-factored load
         
-\\ \midrule \\
+\\ \midrule
 Symbol & $\mathit{NFL}$
          
-\\ \midrule \\
+\\ \midrule
 Units & ${\text{Pa}}$
         
-\\ \midrule \\
+\\ \midrule
 Equation & \begin{displaymath}
            \mathit{NFL}=\frac{{\hat{q}_{\text{tol}}} E h^{4}}{\left(a b\right)^{2}}
            \end{displaymath}
-\\ \midrule \\
+\\ \midrule
 Description & \begin{symbDescription}
               \item{$\mathit{NFL}$ is the non-factored load (${\text{Pa}}$)}
               \item{${\hat{q}_{\text{tol}}}$ is the tolerable load (Unitless)}
@@ -686,7 +686,7 @@ Description & \begin{symbDescription}
               \item{$a$ is the plate length (long dimension) (${\text{m}}$)}
               \item{$b$ is the plate width (short dimension) (${\text{m}}$)}
               \end{symbDescription}
-\\ \midrule \\
+\\ \midrule
 Notes & ${\hat{q}_{\text{tol}}}$ is defined in \hyperref[DD:tolLoad]{DD:tolLoad}.
         
         $E$ comes from \hyperref[assumpSV]{A:standardValues}.
@@ -695,10 +695,10 @@ Notes & ${\hat{q}_{\text{tol}}}$ is defined in \hyperref[DD:tolLoad]{DD:tolLoad}
         
         $a$ and $b$ are the dimensions of the plate, where ($a\geq{}b$).
         
-\\ \midrule \\
+\\ \midrule
 Source & \cite{astm2009}
          
-\\ \midrule \\
+\\ \midrule
 RefBy & \hyperref[DD:calofCapacity]{DD:calofCapacity}
         
 \\ \bottomrule
@@ -712,16 +712,16 @@ RefBy & \hyperref[DD:calofCapacity]{DD:calofCapacity}
 \toprule \textbf{Refname} & \textbf{DD:gTF}
 \phantomsection 
 \label{DD:gTF}
-\\ \midrule \\
+\\ \midrule
 Label & Glass type factor
         
-\\ \midrule \\
+\\ \midrule
 Symbol & $\mathit{GTF}$
          
-\\ \midrule \\
+\\ \midrule
 Units & Unitless
         
-\\ \midrule \\
+\\ \midrule
 Equation & \begin{displaymath}
            \mathit{GTF}=\begin{cases}
                         1, & g=\text{``AN''}\\
@@ -729,22 +729,22 @@ Equation & \begin{displaymath}
                         2, & g=\text{``HS''}
                         \end{cases}
            \end{displaymath}
-\\ \midrule \\
+\\ \midrule
 Description & \begin{symbDescription}
               \item{$\mathit{GTF}$ is the glass type factor (Unitless)}
               \item{$g$ is the glass type (Unitless)}
               \end{symbDescription}
-\\ \midrule \\
+\\ \midrule
 Notes & AN is annealed glass.
         
         FT is fully tempered glass.
         
         HS is heat strengthened glass.
         
-\\ \midrule \\
+\\ \midrule
 Source & \cite{astm2009}
          
-\\ \midrule \\
+\\ \midrule
 RefBy & \hyperref[DD:calofCapacity]{DD:calofCapacity} and \hyperref[DD:dimlessLoad]{DD:dimlessLoad}
         
 \\ \bottomrule
@@ -758,20 +758,20 @@ RefBy & \hyperref[DD:calofCapacity]{DD:calofCapacity} and \hyperref[DD:dimlessLo
 \toprule \textbf{Refname} & \textbf{DD:dimlessLoad}
 \phantomsection 
 \label{DD:dimlessLoad}
-\\ \midrule \\
+\\ \midrule
 Label & Dimensionless load
         
-\\ \midrule \\
+\\ \midrule
 Symbol & $\hat{q}$
          
-\\ \midrule \\
+\\ \midrule
 Units & Unitless
         
-\\ \midrule \\
+\\ \midrule
 Equation & \begin{displaymath}
            \hat{q}=\frac{q \left(a b\right)^{2}}{E h^{4} \mathit{GTF}}
            \end{displaymath}
-\\ \midrule \\
+\\ \midrule
 Description & \begin{symbDescription}
               \item{$\hat{q}$ is the dimensionless load (Unitless)}
               \item{$q$ is the applied load (demand) (${\text{Pa}}$)}
@@ -781,7 +781,7 @@ Description & \begin{symbDescription}
               \item{$h$ is the minimum thickness (${\text{m}}$)}
               \item{$\mathit{GTF}$ is the glass type factor (Unitless)}
               \end{symbDescription}
-\\ \midrule \\
+\\ \midrule
 Notes & $q$ is the 3 second duration equivalent pressure, as given in \hyperref[DD:calofDemand]{DD:calofDemand}.
         
         $a$ and $b$ are the dimensions of the plate, where ($a\geq{}b$).
@@ -792,10 +792,10 @@ Notes & $q$ is the 3 second duration equivalent pressure, as given in \hyperref[
         
         $\mathit{GTF}$ is defined in \hyperref[DD:gTF]{DD:gTF}.
         
-\\ \midrule \\
+\\ \midrule
 Source & \cite{astm2009} and \cite[(Eq. 7)]{campidelli}
          
-\\ \midrule \\
+\\ \midrule
 RefBy & \hyperref[DD:stressDistFac]{DD:stressDistFac}
         
 \\ \bottomrule
@@ -809,37 +809,37 @@ RefBy & \hyperref[DD:stressDistFac]{DD:stressDistFac}
 \toprule \textbf{Refname} & \textbf{DD:tolLoad}
 \phantomsection 
 \label{DD:tolLoad}
-\\ \midrule \\
+\\ \midrule
 Label & Tolerable load
         
-\\ \midrule \\
+\\ \midrule
 Symbol & ${\hat{q}_{\text{tol}}}$
          
-\\ \midrule \\
+\\ \midrule
 Units & Unitless
         
-\\ \midrule \\
+\\ \midrule
 Equation & \begin{displaymath}
            {\hat{q}_{\text{tol}}}=\mathit{interpY}\left(\text{``SDF.txt''},\mathit{AR},{J_{\text{tol}}}\right)
            \end{displaymath}
-\\ \midrule \\
+\\ \midrule
 Description & \begin{symbDescription}
               \item{${\hat{q}_{\text{tol}}}$ is the tolerable load (Unitless)}
               \item{$\mathit{interpY}$ is the interpY (Unitless)}
               \item{$\mathit{AR}$ is the aspect ratio (Unitless)}
               \item{${J_{\text{tol}}}$ is the stress distribution factor (Function) based on Pbtol (Unitless)}
               \end{symbDescription}
-\\ \midrule \\
+\\ \midrule
 Notes & ${\hat{q}_{\text{tol}}}$ is obtained by interpolating from data shown in \hyperref[Figure:dimlessloadVSaspect]{Fig:dimlessloadVSaspect}.
         
         $\mathit{AR}$ is defined in \hyperref[DD:aspectRatio]{DD:aspectRatio}.
         
         ${J_{\text{tol}}}$ is defined in \hyperref[DD:sdfTol]{DD:sdfTol}.
         
-\\ \midrule \\
+\\ \midrule
 Source & \cite{astm2009}
          
-\\ \midrule \\
+\\ \midrule
 RefBy & \hyperref[DD:nFL]{DD:nFL}
         
 \\ \bottomrule
@@ -853,20 +853,20 @@ RefBy & \hyperref[DD:nFL]{DD:nFL}
 \toprule \textbf{Refname} & \textbf{DD:sdfTol}
 \phantomsection 
 \label{DD:sdfTol}
-\\ \midrule \\
+\\ \midrule
 Label & Stress distribution factor (Function) based on Pbtol
         
-\\ \midrule \\
+\\ \midrule
 Symbol & ${J_{\text{tol}}}$
          
-\\ \midrule \\
+\\ \midrule
 Units & Unitless
         
-\\ \midrule \\
+\\ \midrule
 Equation & \begin{displaymath}
            {J_{\text{tol}}}=\ln\left(\ln\left(\frac{1}{1-{P_{\text{b}\text{tol}}}}\right) \frac{\left(a b\right)^{m-1}}{k \left(E h^{2}\right)^{m} \mathit{LDF}}\right)
            \end{displaymath}
-\\ \midrule \\
+\\ \midrule
 Description & \begin{symbDescription}
               \item{${J_{\text{tol}}}$ is the stress distribution factor (Function) based on Pbtol (Unitless)}
               \item{${P_{\text{b}\text{tol}}}$ is the tolerable probability of breakage (Unitless)}
@@ -878,7 +878,7 @@ Description & \begin{symbDescription}
               \item{$h$ is the minimum thickness (${\text{m}}$)}
               \item{$\mathit{LDF}$ is the load duration factor (Unitless)}
               \end{symbDescription}
-\\ \midrule \\
+\\ \midrule
 Notes & ${P_{\text{b}\text{tol}}}$ is entered by the user.
         
         $a$ and $b$ are the dimensions of the plate, where ($a\geq{}b$).
@@ -889,10 +889,10 @@ Notes & ${P_{\text{b}\text{tol}}}$ is entered by the user.
         
         $\mathit{LDF}$ is defined in \hyperref[DD:loadDurFactor]{DD:loadDurFactor}.
         
-\\ \midrule \\
+\\ \midrule
 Source & \cite{astm2009}
          
-\\ \midrule \\
+\\ \midrule
 RefBy & \hyperref[DD:tolLoad]{DD:tolLoad}
         
 \\ \bottomrule
@@ -906,30 +906,30 @@ RefBy & \hyperref[DD:tolLoad]{DD:tolLoad}
 \toprule \textbf{Refname} & \textbf{DD:standOffDist}
 \phantomsection 
 \label{DD:standOffDist}
-\\ \midrule \\
+\\ \midrule
 Label & Stand off distance
         
-\\ \midrule \\
+\\ \midrule
 Symbol & $\mathit{SD}$
          
-\\ \midrule \\
+\\ \midrule
 Units & ${\text{m}}$
         
-\\ \midrule \\
+\\ \midrule
 Equation & \begin{displaymath}
            \mathit{SD}=\sqrt{{\mathit{SD}_{\text{x}}}^{2}+{\mathit{SD}_{\text{y}}}^{2}+{\mathit{SD}_{\text{z}}}^{2}}
            \end{displaymath}
-\\ \midrule \\
+\\ \midrule
 Description & \begin{symbDescription}
               \item{$\mathit{SD}$ is the stand off distance (${\text{m}}$)}
               \item{${\mathit{SD}_{\text{x}}}$ is the stand off distance ($x$-component) (${\text{m}}$)}
               \item{${\mathit{SD}_{\text{y}}}$ is the stand off distance ($y$-component) (${\text{m}}$)}
               \item{${\mathit{SD}_{\text{z}}}$ is the stand off distance ($z$-component) (${\text{m}}$)}
               \end{symbDescription}
-\\ \midrule \\
+\\ \midrule
 Source & \cite{astm2009}
          
-\\ \midrule \\
+\\ \midrule
 RefBy & \hyperref[DD:calofDemand]{DD:calofDemand}
         
 \\ \bottomrule
@@ -943,32 +943,32 @@ RefBy & \hyperref[DD:calofDemand]{DD:calofDemand}
 \toprule \textbf{Refname} & \textbf{DD:aspectRatio}
 \phantomsection 
 \label{DD:aspectRatio}
-\\ \midrule \\
+\\ \midrule
 Label & Aspect ratio
         
-\\ \midrule \\
+\\ \midrule
 Symbol & $\mathit{AR}$
          
-\\ \midrule \\
+\\ \midrule
 Units & Unitless
         
-\\ \midrule \\
+\\ \midrule
 Equation & \begin{displaymath}
            \mathit{AR}=\frac{a}{b}
            \end{displaymath}
-\\ \midrule \\
+\\ \midrule
 Description & \begin{symbDescription}
               \item{$\mathit{AR}$ is the aspect ratio (Unitless)}
               \item{$a$ is the plate length (long dimension) (${\text{m}}$)}
               \item{$b$ is the plate width (short dimension) (${\text{m}}$)}
               \end{symbDescription}
-\\ \midrule \\
+\\ \midrule
 Notes & $a$ and $b$ are the dimensions of the plate, where ($a\geq{}b$).
         
-\\ \midrule \\
+\\ \midrule
 Source & \cite{astm2009}
          
-\\ \midrule \\
+\\ \midrule
 RefBy & \hyperref[DD:tolLoad]{DD:tolLoad} and \hyperref[DD:stressDistFac]{DD:stressDistFac}
         
 \\ \bottomrule
@@ -982,29 +982,29 @@ RefBy & \hyperref[DD:tolLoad]{DD:tolLoad} and \hyperref[DD:stressDistFac]{DD:str
 \toprule \textbf{Refname} & \textbf{DD:eqTNTW}
 \phantomsection 
 \label{DD:eqTNTW}
-\\ \midrule \\
+\\ \midrule
 Label & Equivalent TNT charge mass
         
-\\ \midrule \\
+\\ \midrule
 Symbol & ${w_{\mathit{TNT}}}$
          
-\\ \midrule \\
+\\ \midrule
 Units & ${\text{kg}}$
         
-\\ \midrule \\
+\\ \midrule
 Equation & \begin{displaymath}
            {w_{\mathit{TNT}}}=w \mathit{TNT}
            \end{displaymath}
-\\ \midrule \\
+\\ \midrule
 Description & \begin{symbDescription}
               \item{${w_{\mathit{TNT}}}$ is the equivalent TNT charge mass (${\text{kg}}$)}
               \item{$w$ is the charge weight (${\text{kg}}$)}
               \item{$\mathit{TNT}$ is the TNT equivalent factor (Unitless)}
               \end{symbDescription}
-\\ \midrule \\
+\\ \midrule
 Source & \cite{astm2009}
          
-\\ \midrule \\
+\\ \midrule
 RefBy & \hyperref[DD:calofDemand]{DD:calofDemand}
         
 \\ \bottomrule
@@ -1018,31 +1018,31 @@ RefBy & \hyperref[DD:calofDemand]{DD:calofDemand}
 \toprule \textbf{Refname} & \textbf{DD:probOfBreak}
 \phantomsection 
 \label{DD:probOfBreak}
-\\ \midrule \\
+\\ \midrule
 Label & Probability of breakage
         
-\\ \midrule \\
+\\ \midrule
 Symbol & ${P_{\text{b}}}$
          
-\\ \midrule \\
+\\ \midrule
 Units & Unitless
         
-\\ \midrule \\
+\\ \midrule
 Equation & \begin{displaymath}
            {P_{\text{b}}}=1-e^{-B}
            \end{displaymath}
-\\ \midrule \\
+\\ \midrule
 Description & \begin{symbDescription}
               \item{${P_{\text{b}}}$ is the probability of breakage (Unitless)}
               \item{$B$ is the risk of failure (Unitless)}
               \end{symbDescription}
-\\ \midrule \\
+\\ \midrule
 Notes & $B$ is defined in \hyperref[DD:riskFun]{DD:riskFun}.
         
-\\ \midrule \\
+\\ \midrule
 Source & \cite{astm2009} and \cite{beasonEtAl1998}
          
-\\ \midrule \\
+\\ \midrule
 RefBy & \hyperref[IM:isSafePb]{IM:isSafePb}
         
 \\ \bottomrule
@@ -1056,37 +1056,37 @@ RefBy & \hyperref[IM:isSafePb]{IM:isSafePb}
 \toprule \textbf{Refname} & \textbf{DD:calofCapacity}
 \phantomsection 
 \label{DD:calofCapacity}
-\\ \midrule \\
+\\ \midrule
 Label & Load resistance
         
-\\ \midrule \\
+\\ \midrule
 Symbol & $\mathit{LR}$
          
-\\ \midrule \\
+\\ \midrule
 Units & ${\text{Pa}}$
         
-\\ \midrule \\
+\\ \midrule
 Equation & \begin{displaymath}
            \mathit{LR}=\mathit{NFL} \mathit{GTF} \mathit{LSF}
            \end{displaymath}
-\\ \midrule \\
+\\ \midrule
 Description & \begin{symbDescription}
               \item{$\mathit{LR}$ is the load resistance (${\text{Pa}}$)}
               \item{$\mathit{NFL}$ is the non-factored load (${\text{Pa}}$)}
               \item{$\mathit{GTF}$ is the glass type factor (Unitless)}
               \item{$\mathit{LSF}$ is the load share factor (Unitless)}
               \end{symbDescription}
-\\ \midrule \\
+\\ \midrule
 Notes & $\mathit{LR}$ is also called capacity.
         
         $\mathit{NFL}$ is defined in \hyperref[DD:nFL]{DD:nFL}.
         
         $\mathit{GTF}$ is defined in \hyperref[DD:gTF]{DD:gTF}.
         
-\\ \midrule \\
+\\ \midrule
 Source & \cite{astm2009}
          
-\\ \midrule \\
+\\ \midrule
 RefBy & \hyperref[IM:isSafeLR]{IM:isSafeLR}
         
 \\ \bottomrule
@@ -1100,33 +1100,33 @@ RefBy & \hyperref[IM:isSafeLR]{IM:isSafeLR}
 \toprule \textbf{Refname} & \textbf{DD:calofDemand}
 \phantomsection 
 \label{DD:calofDemand}
-\\ \midrule \\
+\\ \midrule
 Label & Applied load (demand)
         
-\\ \midrule \\
+\\ \midrule
 Symbol & $q$
          
-\\ \midrule \\
+\\ \midrule
 Units & ${\text{Pa}}$
         
-\\ \midrule \\
+\\ \midrule
 Equation & \begin{displaymath}
            q=\mathit{interpY}\left(\text{``TSD.txt''},\mathit{SD},{w_{\mathit{TNT}}}\right)
            \end{displaymath}
-\\ \midrule \\
+\\ \midrule
 Description & \begin{symbDescription}
               \item{$q$ is the applied load (demand) (${\text{Pa}}$)}
               \item{$\mathit{interpY}$ is the interpY (Unitless)}
               \item{$\mathit{SD}$ is the stand off distance (${\text{m}}$)}
               \item{${w_{\mathit{TNT}}}$ is the equivalent TNT charge mass (${\text{kg}}$)}
               \end{symbDescription}
-\\ \midrule \\
+\\ \midrule
 Notes & $q$, or applied load (demand), is the 3 second duration equivalent pressure obtained from \hyperref[Figure:demandVSsod]{Fig:demandVSsod} by interpolation using stand off distance ($\mathit{SD}$) and ${w_{\mathit{TNT}}}$ as parameters. ${w_{\mathit{TNT}}}$ is defined in \hyperref[DD:eqTNTW]{DD:eqTNTW}. $\mathit{SD}$ is the stand off distance as defined in \hyperref[DD:standOffDist]{DD:standOffDist}.
         
-\\ \midrule \\
+\\ \midrule
 Source & \cite{astm2009}
          
-\\ \midrule \\
+\\ \midrule
 RefBy & \hyperref[IM:isSafeLR]{IM:isSafeLR} and \hyperref[DD:dimlessLoad]{DD:dimlessLoad}
         
 \\ \bottomrule
@@ -1146,45 +1146,45 @@ The goal \hyperref[willBreakGS]{GS:Predict-Glass-Withstands-Explosion} is met by
 \toprule \textbf{Refname} & \textbf{IM:isSafePb}
 \phantomsection 
 \label{IM:isSafePb}
-\\ \midrule \\
+\\ \midrule
 Label & Safety Req-Pb
         
-\\ \midrule \\
+\\ \midrule
 Input & ${P_{\text{b}}}$, ${P_{\text{b}\text{tol}}}$
         
-\\ \midrule \\
+\\ \midrule
 Output & $\mathit{isSafePb}$
          
-\\ \midrule \\
+\\ \midrule
 Input Constraints & \begin{displaymath}
                     {P_{\text{b}}}\gt{}0
                     \end{displaymath}
                     \begin{displaymath}
                     {P_{\text{b}\text{tol}}}\gt{}0
                     \end{displaymath}
-\\ \midrule \\
+\\ \midrule
 Output Constraints & 
-\\ \midrule \\
+\\ \midrule
 Equation & \begin{displaymath}
            \mathit{isSafePb}={P_{\text{b}}}\lt{}{P_{\text{b}\text{tol}}}
            \end{displaymath}
-\\ \midrule \\
+\\ \midrule
 Description & \begin{symbDescription}
               \item{$\mathit{isSafePb}$ is the probability of glass breakage safety requirement (Unitless)}
               \item{${P_{\text{b}}}$ is the probability of breakage (Unitless)}
               \item{${P_{\text{b}\text{tol}}}$ is the tolerable probability of breakage (Unitless)}
               \end{symbDescription}
-\\ \midrule \\
+\\ \midrule
 Notes & If $\mathit{isSafePb}$, the glass is considered safe. $\mathit{isSafePb}$ and $\mathit{isSafePb}$ (from \hyperref[IM:isSafeLR]{IM:isSafeLR}) are either both True or both False.
         
         ${P_{\text{b}}}$ is defined in \hyperref[DD:probOfBreak]{DD:probOfBreak}.
         
         ${P_{\text{b}\text{tol}}}$ is entered by the user.
         
-\\ \midrule \\
+\\ \midrule
 Source & \cite{astm2009}
          
-\\ \midrule \\
+\\ \midrule
 RefBy & \hyperref[IM:isSafeLR]{IM:isSafeLR}
         
 \\ \bottomrule
@@ -1197,45 +1197,45 @@ RefBy & \hyperref[IM:isSafeLR]{IM:isSafeLR}
 \toprule \textbf{Refname} & \textbf{IM:isSafeLR}
 \phantomsection 
 \label{IM:isSafeLR}
-\\ \midrule \\
+\\ \midrule
 Label & Safety Req-LR
         
-\\ \midrule \\
+\\ \midrule
 Input & $\mathit{LR}$, $q$
         
-\\ \midrule \\
+\\ \midrule
 Output & $\mathit{isSafeLR}$
          
-\\ \midrule \\
+\\ \midrule
 Input Constraints & \begin{displaymath}
                     \mathit{LR}\gt{}0
                     \end{displaymath}
                     \begin{displaymath}
                     q\gt{}0
                     \end{displaymath}
-\\ \midrule \\
+\\ \midrule
 Output Constraints & 
-\\ \midrule \\
+\\ \midrule
 Equation & \begin{displaymath}
            \mathit{isSafeLR}=\mathit{LR}\gt{}q
            \end{displaymath}
-\\ \midrule \\
+\\ \midrule
 Description & \begin{symbDescription}
               \item{$\mathit{isSafeLR}$ is the 3 second load equivalent resistance safety requirement (Unitless)}
               \item{$\mathit{LR}$ is the load resistance (${\text{Pa}}$)}
               \item{$q$ is the applied load (demand) (${\text{Pa}}$)}
               \end{symbDescription}
-\\ \midrule \\
+\\ \midrule
 Notes & If $\mathit{isSafeLR}$, the glass is considered safe. $\mathit{isSafePb}$ (from \hyperref[IM:isSafePb]{IM:isSafePb}) and $\mathit{isSafeLR}$ are either both True or both False.
         
         $\mathit{LR}$ is defined in \hyperref[DD:calofCapacity]{DD:calofCapacity} and is also called capacity.
         
         $q$ is the 3 second duration equivalent pressure, as given in \hyperref[DD:calofDemand]{DD:calofDemand}.
         
-\\ \midrule \\
+\\ \midrule
 Source & \cite{astm2009}
          
-\\ \midrule \\
+\\ \midrule
 RefBy & \hyperref[IM:isSafePb]{IM:isSafePb}
         
 \\ \bottomrule

--- a/code/stable/hghc/SRS/PDF/HGHC_SRS.tex
+++ b/code/stable/hghc/SRS/PDF/HGHC_SRS.tex
@@ -101,20 +101,20 @@ This section collects and defines all the data needed to build the instance mode
 \toprule \textbf{Refname} & \textbf{DD:htTransCladFuel}
 \phantomsection 
 \label{DD:htTransCladFuel}
-\\ \midrule \\
+\\ \midrule
 Label & Effective heat transfer coefficient between clad and fuel surface
         
-\\ \midrule \\
+\\ \midrule
 Symbol & ${h_{\text{g}}}$
          
-\\ \midrule \\
+\\ \midrule
 Units & $\frac{\text{W}}{\text{m}^{2}{}^{\circ}\text{C}}$
         
-\\ \midrule \\
+\\ \midrule
 Equation & \begin{displaymath}
            {h_{\text{g}}}=\frac{2 {k_{\text{c}}} {h_{\text{p}}}}{2 {k_{\text{c}}}+{τ_{\text{c}}} {h_{\text{p}}}}
            \end{displaymath}
-\\ \midrule \\
+\\ \midrule
 Description & \begin{symbDescription}
               \item{${h_{\text{g}}}$ is the effective heat transfer coefficient between clad and fuel surface ($\frac{\text{W}}{\text{m}^{2}{}^{\circ}\text{C}}$)}
               \item{${k_{\text{c}}}$ is the clad conductivity (Unitless)}
@@ -131,20 +131,20 @@ Description & \begin{symbDescription}
 \toprule \textbf{Refname} & \textbf{DD:htTransCladCool}
 \phantomsection 
 \label{DD:htTransCladCool}
-\\ \midrule \\
+\\ \midrule
 Label & Convective heat transfer coefficient between clad and coolant
         
-\\ \midrule \\
+\\ \midrule
 Symbol & ${h_{\text{c}}}$
          
-\\ \midrule \\
+\\ \midrule
 Units & $\frac{\text{W}}{\text{m}^{2}{}^{\circ}\text{C}}$
         
-\\ \midrule \\
+\\ \midrule
 Equation & \begin{displaymath}
            {h_{\text{c}}}=\frac{2 {k_{\text{c}}} {h_{\text{b}}}}{2 {k_{\text{c}}}+{τ_{\text{c}}} {h_{\text{b}}}}
            \end{displaymath}
-\\ \midrule \\
+\\ \midrule
 Description & \begin{symbDescription}
               \item{${h_{\text{c}}}$ is the convective heat transfer coefficient between clad and coolant ($\frac{\text{W}}{\text{m}^{2}{}^{\circ}\text{C}}$)}
               \item{${k_{\text{c}}}$ is the clad conductivity (Unitless)}

--- a/code/stable/nopcm/SRS/PDF/NoPCM_SRS.tex
+++ b/code/stable/nopcm/SRS/PDF/NoPCM_SRS.tex
@@ -364,14 +364,14 @@ This section focuses on the general equations and laws that NoPCM is based on.
 \toprule \textbf{Refname} & \textbf{TM:consThermE}
 \phantomsection 
 \label{TM:consThermE}
-\\ \midrule \\
+\\ \midrule
 Label & Conservation of thermal energy
         
-\\ \midrule \\
+\\ \midrule
 Equation & \begin{displaymath}
            -∇\cdot{}\symbf{q}+g=ρ C \frac{\,\partial{}T}{\,\partial{}t}
            \end{displaymath}
-\\ \midrule \\
+\\ \midrule
 Description & \begin{symbDescription}
               \item{$∇$ is the gradient (Unitless)}
               \item{$\symbf{q}$ is the thermal flux vector ($\frac{\text{W}}{\text{m}^{2}}$)}
@@ -381,15 +381,15 @@ Description & \begin{symbDescription}
               \item{$t$ is the time (${\text{s}}$)}
               \item{$T$ is the temperature (${{}^{\circ}\text{C}}$)}
               \end{symbDescription}
-\\ \midrule \\
+\\ \midrule
 Notes & The above equation gives the law of conservation of energy for transient heat transfer in a given material.
         
         For this equation to apply, other forms of energy, such as mechanical energy, are assumed to be negligible in the system (\hyperref[assumpTEO]{A:Thermal-Energy-Only}).
         
-\\ \midrule \\
+\\ \midrule
 Source & \hyperref{http://www.efunda.com/formulae/heat_transfer/conduction/overview_cond.cfm}{}{}{Fourier Law of Heat Conduction and Heat Equation}
          
-\\ \midrule \\
+\\ \midrule
 RefBy & \hyperref[GD:rocTempSimp]{GD:rocTempSimp}
         
 \\ \bottomrule
@@ -402,27 +402,27 @@ RefBy & \hyperref[GD:rocTempSimp]{GD:rocTempSimp}
 \toprule \textbf{Refname} & \textbf{TM:sensHtE}
 \phantomsection 
 \label{TM:sensHtE}
-\\ \midrule \\
+\\ \midrule
 Label & Sensible heat energy (no state change)
         
-\\ \midrule \\
+\\ \midrule
 Equation & \begin{displaymath}
            E={C^{\text{L}}} m ΔT
            \end{displaymath}
-\\ \midrule \\
+\\ \midrule
 Description & \begin{symbDescription}
               \item{$E$ is the sensible heat (${\text{J}}$)}
               \item{${C^{\text{L}}}$ is the specific heat capacity of a liquid ($\frac{\text{J}}{\text{kg}{}^{\circ}\text{C}}$)}
               \item{$m$ is the mass (${\text{kg}}$)}
               \item{$ΔT$ is the change in temperature (${{}^{\circ}\text{C}}$)}
               \end{symbDescription}
-\\ \midrule \\
+\\ \midrule
 Notes & $E$ occurs as long as the material does not reach a temperature where a phase change occurs, as assumed in \hyperref[assumpWAL]{A:Water-Always-Liquid}.
         
-\\ \midrule \\
+\\ \midrule
 Source & \hyperref{http://en.wikipedia.org/wiki/Sensible_heat}{}{}{Definition of Sensible Heat}
          
-\\ \midrule \\
+\\ \midrule
 RefBy & \hyperref[IM:heatEInWtr]{IM:heatEInWtr}
         
 \\ \bottomrule
@@ -435,31 +435,31 @@ RefBy & \hyperref[IM:heatEInWtr]{IM:heatEInWtr}
 \toprule \textbf{Refname} & \textbf{TM:nwtnCooling}
 \phantomsection 
 \label{TM:nwtnCooling}
-\\ \midrule \\
+\\ \midrule
 Label & Newton's law of cooling
         
-\\ \midrule \\
+\\ \midrule
 Equation & \begin{displaymath}
            q\left(t\right)=h ΔT\left(t\right)
            \end{displaymath}
-\\ \midrule \\
+\\ \midrule
 Description & \begin{symbDescription}
               \item{$q$ is the heat flux ($\frac{\text{W}}{\text{m}^{2}}$)}
               \item{$t$ is the time (${\text{s}}$)}
               \item{$h$ is the convective heat transfer coefficient ($\frac{\text{W}}{\text{m}^{2}{}^{\circ}\text{C}}$)}
               \item{$ΔT$ is the change in temperature (${{}^{\circ}\text{C}}$)}
               \end{symbDescription}
-\\ \midrule \\
+\\ \midrule
 Notes & Newton's law of cooling describes convective cooling from a surface. The law is stated as: the rate of heat loss from a body is proportional to the difference in temperatures between the body and its surroundings.
         
         $h$ is assumed to be independent of $T$ (from \hyperref[assumpHTCC]{A:Heat-Transfer-Coeffs-Constant}).
         
         $ΔT\left(t\right)=T\left(t\right)-{T_{\text{env}}}\left(t\right)$ is the time-dependant thermal gradient between the environment and the object.
         
-\\ \midrule \\
+\\ \midrule
 Source & \cite[(pg. 8)]{incroperaEtAl2007}
          
-\\ \midrule \\
+\\ \midrule
 RefBy & \hyperref[GD:htFluxWaterFromCoil]{GD:htFluxWaterFromCoil}
         
 \\ \bottomrule
@@ -476,14 +476,14 @@ This section collects the laws and equations that will be used to build the inst
 \toprule \textbf{Refname} & \textbf{GD:rocTempSimp}
 \phantomsection 
 \label{GD:rocTempSimp}
-\\ \midrule \\
+\\ \midrule
 Label & Simplified rate of change of temperature
         
-\\ \midrule \\
+\\ \midrule
 Equation & \begin{displaymath}
            m C \frac{\,dT}{\,dt}={q_{\text{in}}} {A_{\text{in}}}-{q_{\text{out}}} {A_{\text{out}}}+g V
            \end{displaymath}
-\\ \midrule \\
+\\ \midrule
 Description & \begin{symbDescription}
               \item{$m$ is the mass (${\text{kg}}$)}
               \item{$C$ is the specific heat capacity ($\frac{\text{J}}{\text{kg}{}^{\circ}\text{C}}$)}
@@ -496,10 +496,10 @@ Description & \begin{symbDescription}
               \item{$g$ is the volumetric heat generation per unit volume ($\frac{\text{W}}{\text{m}^{3}}$)}
               \item{$V$ is the volume (${\text{m}^{3}}$)}
               \end{symbDescription}
-\\ \midrule \\
+\\ \midrule
 Source & --
          
-\\ \midrule \\
+\\ \midrule
 RefBy & \hyperref[GD:rocTempSimp]{GD:rocTempSimp} and \hyperref[IM:eBalanceOnWtr]{IM:eBalanceOnWtr}
         
 \\ \bottomrule
@@ -539,17 +539,17 @@ m C \frac{\,dT}{\,dt}={q_{\text{in}}} {A_{\text{in}}}-{q_{\text{out}}} {A_{\text
 \toprule \textbf{Refname} & \textbf{GD:htFluxWaterFromCoil}
 \phantomsection 
 \label{GD:htFluxWaterFromCoil}
-\\ \midrule \\
+\\ \midrule
 Label & Heat flux into the water from the coil
         
-\\ \midrule \\
+\\ \midrule
 Units & $\frac{\text{W}}{\text{m}^{2}}$
         
-\\ \midrule \\
+\\ \midrule
 Equation & \begin{displaymath}
            {q_{\text{C}}}={h_{\text{C}}} \left({T_{\text{C}}}-{T_{\text{W}}}\left(t\right)\right)
            \end{displaymath}
-\\ \midrule \\
+\\ \midrule
 Description & \begin{symbDescription}
               \item{${q_{\text{C}}}$ is the heat flux into the water from the coil ($\frac{\text{W}}{\text{m}^{2}}$)}
               \item{${h_{\text{C}}}$ is the convective heat transfer coefficient between coil and water ($\frac{\text{W}}{\text{m}^{2}{}^{\circ}\text{C}}$)}
@@ -557,15 +557,15 @@ Description & \begin{symbDescription}
               \item{${T_{\text{W}}}$ is the temperature of the water (${{}^{\circ}\text{C}}$)}
               \item{$t$ is the time (${\text{s}}$)}
               \end{symbDescription}
-\\ \midrule \\
+\\ \midrule
 Notes & ${q_{\text{C}}}$ is found by assuming that Newton's law of cooling applies (\hyperref[assumpLCCCW]{A:Newton-Law-Convective-Cooling-Coil-Water}). This law (defined in \hyperref[TM:nwtnCooling]{TM:nwtnCooling}) is used on the surface of the heating coil.
         
         \hyperref[assumpTHCCoT]{A:Temp-Heating-Coil-Constant-over-Time}
         
-\\ \midrule \\
+\\ \midrule
 Source & \cite{koothoor2013}
          
-\\ \midrule \\
+\\ \midrule
 RefBy & \hyperref[IM:eBalanceOnWtr]{IM:eBalanceOnWtr}
         
 \\ \bottomrule
@@ -583,29 +583,29 @@ This section collects and defines all the data needed to build the instance mode
 \toprule \textbf{Refname} & \textbf{DD:waterMass}
 \phantomsection 
 \label{DD:waterMass}
-\\ \midrule \\
+\\ \midrule
 Label & Mass of water
         
-\\ \midrule \\
+\\ \midrule
 Symbol & ${m_{\text{W}}}$
          
-\\ \midrule \\
+\\ \midrule
 Units & ${\text{kg}}$
         
-\\ \midrule \\
+\\ \midrule
 Equation & \begin{displaymath}
            {m_{\text{W}}}={V_{\text{W}}} {ρ_{\text{W}}}
            \end{displaymath}
-\\ \midrule \\
+\\ \midrule
 Description & \begin{symbDescription}
               \item{${m_{\text{W}}}$ is the mass of water (${\text{kg}}$)}
               \item{${V_{\text{W}}}$ is the volume of water (${\text{m}^{3}}$)}
               \item{${ρ_{\text{W}}}$ is the density of water ($\frac{\text{kg}}{\text{m}^{3}}$)}
               \end{symbDescription}
-\\ \midrule \\
+\\ \midrule
 Source & --
          
-\\ \midrule \\
+\\ \midrule
 RefBy & \hyperref[findMass]{FR:Find-Mass}
         
 \\ \bottomrule
@@ -619,31 +619,31 @@ RefBy & \hyperref[findMass]{FR:Find-Mass}
 \toprule \textbf{Refname} & \textbf{DD:waterVolume.nopcm}
 \phantomsection 
 \label{DD:waterVolume.nopcm}
-\\ \midrule \\
+\\ \midrule
 Label & Volume of water
         
-\\ \midrule \\
+\\ \midrule
 Symbol & ${V_{\text{W}}}$
          
-\\ \midrule \\
+\\ \midrule
 Units & ${\text{m}^{3}}$
         
-\\ \midrule \\
+\\ \midrule
 Equation & \begin{displaymath}
            {V_{\text{W}}}={V_{\text{tank}}}
            \end{displaymath}
-\\ \midrule \\
+\\ \midrule
 Description & \begin{symbDescription}
               \item{${V_{\text{W}}}$ is the volume of water (${\text{m}^{3}}$)}
               \item{${V_{\text{tank}}}$ is the volume of the cylindrical tank (${\text{m}^{3}}$)}
               \end{symbDescription}
-\\ \midrule \\
+\\ \midrule
 Notes & Based on \hyperref[assumpVCN]{A:Volume-Coil-Negligible}. ${V_{\text{tank}}}$ is defined in \hyperref[DD:tankVolume]{DD:tankVolume}.
         
-\\ \midrule \\
+\\ \midrule
 Source & --
          
-\\ \midrule \\
+\\ \midrule
 RefBy & \hyperref[findMass]{FR:Find-Mass}
         
 \\ \bottomrule
@@ -657,30 +657,30 @@ RefBy & \hyperref[findMass]{FR:Find-Mass}
 \toprule \textbf{Refname} & \textbf{DD:tankVolume}
 \phantomsection 
 \label{DD:tankVolume}
-\\ \midrule \\
+\\ \midrule
 Label & Volume of the cylindrical tank
         
-\\ \midrule \\
+\\ \midrule
 Symbol & ${V_{\text{tank}}}$
          
-\\ \midrule \\
+\\ \midrule
 Units & ${\text{m}^{3}}$
         
-\\ \midrule \\
+\\ \midrule
 Equation & \begin{displaymath}
            {V_{\text{tank}}}=π \left(\frac{D}{2}\right)^{2} L
            \end{displaymath}
-\\ \midrule \\
+\\ \midrule
 Description & \begin{symbDescription}
               \item{${V_{\text{tank}}}$ is the volume of the cylindrical tank (${\text{m}^{3}}$)}
               \item{$π$ is the ratio of circumference to diameter for any circle (Unitless)}
               \item{$D$ is the diameter of tank (${\text{m}}$)}
               \item{$L$ is the length of tank (${\text{m}}$)}
               \end{symbDescription}
-\\ \midrule \\
+\\ \midrule
 Source & --
          
-\\ \midrule \\
+\\ \midrule
 RefBy & \hyperref[DD:waterVolume.nopcm]{DD:waterVolume\_nopcm} and \hyperref[findMass]{FR:Find-Mass}
         
 \\ \bottomrule
@@ -694,20 +694,20 @@ RefBy & \hyperref[DD:waterVolume.nopcm]{DD:waterVolume\_nopcm} and \hyperref[fin
 \toprule \textbf{Refname} & \textbf{DD:balanceDecayRate}
 \phantomsection 
 \label{DD:balanceDecayRate}
-\\ \midrule \\
+\\ \midrule
 Label & ODE parameter for water related to decay time
         
-\\ \midrule \\
+\\ \midrule
 Symbol & ${τ_{\text{W}}}$
          
-\\ \midrule \\
+\\ \midrule
 Units & ${\text{s}}$
         
-\\ \midrule \\
+\\ \midrule
 Equation & \begin{displaymath}
            {τ_{\text{W}}}=\frac{{m_{\text{W}}} {C_{\text{W}}}}{{h_{\text{C}}} {A_{\text{C}}}}
            \end{displaymath}
-\\ \midrule \\
+\\ \midrule
 Description & \begin{symbDescription}
               \item{${τ_{\text{W}}}$ is the ODE parameter for water related to decay time (${\text{s}}$)}
               \item{${m_{\text{W}}}$ is the mass of water (${\text{kg}}$)}
@@ -715,10 +715,10 @@ Description & \begin{symbDescription}
               \item{${h_{\text{C}}}$ is the convective heat transfer coefficient between coil and water ($\frac{\text{W}}{\text{m}^{2}{}^{\circ}\text{C}}$)}
               \item{${A_{\text{C}}}$ is the heating coil surface area (${\text{m}^{2}}$)}
               \end{symbDescription}
-\\ \midrule \\
+\\ \midrule
 Source & \cite{koothoor2013}
          
-\\ \midrule \\
+\\ \midrule
 RefBy & \hyperref[outputInputDerivVals]{FR:Output-Input-Derived-Values} and \hyperref[IM:eBalanceOnWtr]{IM:eBalanceOnWtr}
         
 \\ \bottomrule
@@ -738,41 +738,41 @@ The goal \hyperref[waterTempGS]{GS:Predict-Water-Temperature} is met by \hyperre
 \toprule \textbf{Refname} & \textbf{IM:eBalanceOnWtr}
 \phantomsection 
 \label{IM:eBalanceOnWtr}
-\\ \midrule \\
+\\ \midrule
 Label & Energy balance on water to find the temperature of the water
         
-\\ \midrule \\
+\\ \midrule
 Input & ${T_{\text{C}}}$, ${T_{\text{init}}}$, ${t_{\text{final}}}$, ${A_{\text{C}}}$, ${h_{\text{C}}}$, ${C_{\text{W}}}$, ${m_{\text{W}}}$
         
-\\ \midrule \\
+\\ \midrule
 Output & ${T_{\text{W}}}$
          
-\\ \midrule \\
+\\ \midrule
 Input Constraints & \begin{displaymath}
                     {T_{\text{C}}}\geq{}{T_{\text{init}}}
                     \end{displaymath}
-\\ \midrule \\
+\\ \midrule
 Output Constraints & 
-\\ \midrule \\
+\\ \midrule
 Equation & \begin{displaymath}
            \frac{\,d{T_{\text{W}}}}{\,dt}+\frac{1}{{τ_{\text{W}}}} {{T_{\text{W}}}}=\frac{1}{{τ_{\text{W}}}} {T_{\text{C}}}
            \end{displaymath}
-\\ \midrule \\
+\\ \midrule
 Description & \begin{symbDescription}
               \item{$t$ is the time (${\text{s}}$)}
               \item{${T_{\text{W}}}$ is the temperature of the water (${{}^{\circ}\text{C}}$)}
               \item{${τ_{\text{W}}}$ is the ODE parameter for water related to decay time (${\text{s}}$)}
               \item{${T_{\text{C}}}$ is the temperature of the heating coil (${{}^{\circ}\text{C}}$)}
               \end{symbDescription}
-\\ \midrule \\
+\\ \midrule
 Notes & ${τ_{\text{W}}}$ is calculated from \hyperref[DD:balanceDecayRate]{DD:balanceDecayRate}.
         
         The above equation applies as long as the water is in liquid form, $0\lt{}{T_{\text{W}}}\lt{}100$ (${{}^{\circ}\text{C}}$) where $0$ (${{}^{\circ}\text{C}}$) and $100$ (${{}^{\circ}\text{C}}$) are the melting and boiling point temperatures of water, respectively (\hyperref[assumpWAL]{A:Water-Always-Liquid}).
         
-\\ \midrule \\
+\\ \midrule
 Source & \cite[(with PCM removed)]{koothoor2013}
          
-\\ \midrule \\
+\\ \midrule
 RefBy & \hyperref[unlikeChgNIHG]{UC:No-Internal-Heat-Generation}, \hyperref[findMass]{FR:Find-Mass}, and \hyperref[calcTempWtrOverTime]{FR:Calculate-Temperature-Water-Over-Time}
         
 \\ \bottomrule
@@ -807,24 +807,24 @@ By substituting ${τ_{\text{W}}}$ (from \hyperref[DD:balanceDecayRate]{DD:balanc
 \toprule \textbf{Refname} & \textbf{IM:heatEInWtr}
 \phantomsection 
 \label{IM:heatEInWtr}
-\\ \midrule \\
+\\ \midrule
 Label & Heat energy in the water
         
-\\ \midrule \\
+\\ \midrule
 Input & ${T_{\text{init}}}$, ${m_{\text{W}}}$, ${C_{\text{W}}}$, ${m_{\text{W}}}$
         
-\\ \midrule \\
+\\ \midrule
 Output & ${E_{\text{W}}}$
          
-\\ \midrule \\
+\\ \midrule
 Input Constraints & 
-\\ \midrule \\
+\\ \midrule
 Output Constraints & 
-\\ \midrule \\
+\\ \midrule
 Equation & \begin{displaymath}
            {E_{\text{W}}}\left(t\right)={C_{\text{W}}} {m_{\text{W}}} \left({T_{\text{W}}}\left(t\right)-{T_{\text{init}}}\right)
            \end{displaymath}
-\\ \midrule \\
+\\ \midrule
 Description & \begin{symbDescription}
               \item{${E_{\text{W}}}$ is the change in heat energy in the water (${\text{J}}$)}
               \item{$t$ is the time (${\text{s}}$)}
@@ -833,17 +833,17 @@ Description & \begin{symbDescription}
               \item{${T_{\text{W}}}$ is the temperature of the water (${{}^{\circ}\text{C}}$)}
               \item{${T_{\text{init}}}$ is the initial temperature (${{}^{\circ}\text{C}}$)}
               \end{symbDescription}
-\\ \midrule \\
+\\ \midrule
 Notes & The above equation is derived using \hyperref[TM:sensHtE]{TM:sensHtE}.
         
         The change in temperature is the difference between the temperature at time $t$ (${\text{s}}$), ${T_{\text{W}}}$ and the initial temperature, ${T_{\text{init}}}$ (${{}^{\circ}\text{C}}$).
         
         This equation applies as long as $0\lt{}{T_{\text{W}}}\lt{}100$${{}^{\circ}\text{C}}$ (\hyperref[assumpWAL]{A:Water-Always-Liquid}, \hyperref[assumpAPT]{A:Atmospheric-Pressure-Tank}).
         
-\\ \midrule \\
+\\ \midrule
 Source & \cite{koothoor2013}
          
-\\ \midrule \\
+\\ \midrule
 RefBy & \hyperref[calcChgHeatEnergyWtrOverTime]{FR:Calculate-Change-Heat\_Energy-Water-Over-Time}
         
 \\ \bottomrule

--- a/code/stable/pdcontroller/SRS/PDF/PDController_SRS.tex
+++ b/code/stable/pdcontroller/SRS/PDF/PDController_SRS.tex
@@ -316,27 +316,27 @@ This section focuses on the general equations and laws that PD Controller is bas
 \toprule \textbf{Refname} & \textbf{TM:laplaceTransform}
 \phantomsection 
 \label{TM:laplaceTransform}
-\\ \midrule \\
+\\ \midrule
 Label & Laplace Transform
         
-\\ \midrule \\
+\\ \midrule
 Equation & \begin{displaymath}
            {F_{\text{s}}}=\int_{\mathit{-∞}}^{∞}{{f_{\text{t}}} e^{-s t}}\,dt
            \end{displaymath}
-\\ \midrule \\
+\\ \midrule
 Description & \begin{symbDescription}
               \item{${F_{\text{s}}}$ is the Laplace Transform of a function (Unitless)}
               \item{${f_{\text{t}}}$ is the Function in the time domain (Unitless)}
               \item{$s$ is the Complex frequency-domain parameter (Unitless)}
               \item{$t$ is the time (${\text{s}}$)}
               \end{symbDescription}
-\\ \midrule \\
+\\ \midrule
 Notes & Bilateral Laplace Transform. The Laplace transforms are typically inferred from a pre-computed table of Laplace Transforms (\cite{laplaceWiki}).
         
-\\ \midrule \\
+\\ \midrule
 Source & \cite{laplaceWiki}
          
-\\ \midrule \\
+\\ \midrule
 RefBy & \hyperref[DD:ddPropCtrl]{DD:ddPropCtrl}, \hyperref[DD:ddProcessError]{DD:ddProcessError}, \hyperref[DD:ddDerivCtrl]{DD:ddDerivCtrl}, and \hyperref[GD:gdPowerPlant]{GD:gdPowerPlant}
         
 \\ \bottomrule
@@ -349,25 +349,25 @@ RefBy & \hyperref[DD:ddPropCtrl]{DD:ddPropCtrl}, \hyperref[DD:ddProcessError]{DD
 \toprule \textbf{Refname} & \textbf{TM:invLaplaceTransform}
 \phantomsection 
 \label{TM:invLaplaceTransform}
-\\ \midrule \\
+\\ \midrule
 Label & Inverse Laplace Transform
         
-\\ \midrule \\
+\\ \midrule
 Equation & \begin{displaymath}
            {f_{\text{t}}}=\mathit{L⁻¹[F(s)]}
            \end{displaymath}
-\\ \midrule \\
+\\ \midrule
 Description & \begin{symbDescription}
               \item{${f_{\text{t}}}$ is the Function in the time domain (Unitless)}
               \item{$\mathit{L⁻¹[F(s)]}$ is the Inverse Laplace Transform of a function (Unitless)}
               \end{symbDescription}
-\\ \midrule \\
+\\ \midrule
 Notes & Inverse Laplace Transform of F(S). The Inverse Laplace transforms are typically inferred from a pre-computed table of Laplace Transforms (\cite{laplaceWiki}).
         
-\\ \midrule \\
+\\ \midrule
 Source & \cite{laplaceWiki}
          
-\\ \midrule \\
+\\ \midrule
 RefBy & \hyperref[IM:pdEquationIM]{IM:pdEquationIM}
         
 \\ \bottomrule
@@ -380,27 +380,27 @@ RefBy & \hyperref[IM:pdEquationIM]{IM:pdEquationIM}
 \toprule \textbf{Refname} & \textbf{TM:tmSOSystem}
 \phantomsection 
 \label{TM:tmSOSystem}
-\\ \midrule \\
+\\ \midrule
 Label & Second Order Mass-Spring-Damper System
         
-\\ \midrule \\
+\\ \midrule
 Equation & \begin{displaymath}
            \frac{1}{m s^{2}+c s+k}
            \end{displaymath}
-\\ \midrule \\
+\\ \midrule
 Description & \begin{symbDescription}
               \item{$m$ is the mass (${\text{kg}}$)}
               \item{$s$ is the Complex frequency-domain parameter (Unitless)}
               \item{$c$ is the Damping coefficient of the spring (Unitless)}
               \item{$k$ is the Stiffness coefficient of the spring (${\text{s}}$)}
               \end{symbDescription}
-\\ \midrule \\
+\\ \midrule
 Notes & The Transfer Function (from \hyperref[pwrPlantTxFnx]{A:Transfer Function}) of a Second Order System (mass-spring-damper) is characterized by this equation.
         
-\\ \midrule \\
+\\ \midrule
 Source & \cite{abbasi2015}
          
-\\ \midrule \\
+\\ \midrule
 RefBy & \hyperref[GD:gdPowerPlant]{GD:gdPowerPlant}
         
 \\ \bottomrule
@@ -417,24 +417,24 @@ This section collects the laws and equations that will be used to build the inst
 \toprule \textbf{Refname} & \textbf{GD:gdPowerPlant}
 \phantomsection 
 \label{GD:gdPowerPlant}
-\\ \midrule \\
+\\ \midrule
 Label & The Transfer Function of the Power Plant
         
-\\ \midrule \\
+\\ \midrule
 Equation & \begin{displaymath}
            \frac{1}{s^{2}+s+20}
            \end{displaymath}
-\\ \midrule \\
+\\ \midrule
 Description & \begin{symbDescription}
               \item{$s$ is the Complex frequency-domain parameter (Unitless)}
               \end{symbDescription}
-\\ \midrule \\
+\\ \midrule
 Notes & The Transfer Function of the Second Order System (from \hyperref[TM:tmSOSystem]{TM:tmSOSystem}) is reduced to this equation by substituting the mass (m) to 1 Kg (from \hyperref[massSpring]{A:Spring Mass}), the Damping Coefficient ($c$) to 1 (from \hyperref[dampingCoeffSpring]{A:Spring Damping Coefficient}), and the Stiffness Coefficient ($k$) to 20 (from \hyperref[stiffnessCoeffSpring]{A:Spring Stiffness Coefficient}). The equation is converted to the frequency domain by applying the Laplace transform (from \hyperref[TM:laplaceTransform]{TM:laplaceTransform}). Additionally, there are no external disturbances to the power plant (from \hyperref[externalDisturb]{A:External disturbance}).
         
-\\ \midrule \\
+\\ \midrule
 Source & \cite{pidWiki} and \cite{abbasi2015}
          
-\\ \midrule \\
+\\ \midrule
 RefBy & \hyperref[IM:pdEquationIM]{IM:pdEquationIM}
         
 \\ \bottomrule
@@ -451,32 +451,32 @@ This section collects and defines all the data needed to build the instance mode
 \toprule \textbf{Refname} & \textbf{DD:ddProcessError}
 \phantomsection 
 \label{DD:ddProcessError}
-\\ \midrule \\
+\\ \midrule
 Label & Process Error in the frequency domain
         
-\\ \midrule \\
+\\ \midrule
 Symbol & ${E_{\text{s}}}$
          
-\\ \midrule \\
+\\ \midrule
 Units & Unitless
         
-\\ \midrule \\
+\\ \midrule
 Equation & \begin{displaymath}
            {E_{\text{s}}}={R_{\text{s}}}-{Y_{\text{s}}}
            \end{displaymath}
-\\ \midrule \\
+\\ \midrule
 Description & \begin{symbDescription}
               \item{${E_{\text{s}}}$ is the Process Error in the frequency domain (Unitless)}
               \item{${R_{\text{s}}}$ is the Set-Point in the frequency domain (Unitless)}
               \item{${Y_{\text{s}}}$ is the Process Variable in the frequency domain (Unitless)}
               \end{symbDescription}
-\\ \midrule \\
+\\ \midrule
 Notes & The Process Error is the difference between the Set-Point and Process Variable. The equation is converted to the frequency domain by applying the Laplace transform (from \hyperref[TM:laplaceTransform]{TM:laplaceTransform}). The Set-Point is assumed to be constant throughout the simulation (from \hyperref[setPoint]{A:Set-Point}). The initial value of the Process Variable is assumed to be zero (from \hyperref[initialValue]{A:Initial Value}).
         
-\\ \midrule \\
+\\ \midrule
 Source & \cite{johnson2008}
          
-\\ \midrule \\
+\\ \midrule
 RefBy & \hyperref[DD:ddPropCtrl]{DD:ddPropCtrl}, \hyperref[DD:ddDerivCtrl]{DD:ddDerivCtrl}, and \hyperref[IM:pdEquationIM]{IM:pdEquationIM}
         
 \\ \bottomrule
@@ -490,32 +490,32 @@ RefBy & \hyperref[DD:ddPropCtrl]{DD:ddPropCtrl}, \hyperref[DD:ddDerivCtrl]{DD:dd
 \toprule \textbf{Refname} & \textbf{DD:ddPropCtrl}
 \phantomsection 
 \label{DD:ddPropCtrl}
-\\ \midrule \\
+\\ \midrule
 Label & Proportional control in the frequency domain
         
-\\ \midrule \\
+\\ \midrule
 Symbol & ${P_{\text{s}}}$
          
-\\ \midrule \\
+\\ \midrule
 Units & Unitless
         
-\\ \midrule \\
+\\ \midrule
 Equation & \begin{displaymath}
            {P_{\text{s}}}={K_{\text{p}}} {E_{\text{s}}}
            \end{displaymath}
-\\ \midrule \\
+\\ \midrule
 Description & \begin{symbDescription}
               \item{${P_{\text{s}}}$ is the Proportional control in the frequency domain (Unitless)}
               \item{${K_{\text{p}}}$ is the Proportional Gain (Unitless)}
               \item{${E_{\text{s}}}$ is the Process Error in the frequency domain (Unitless)}
               \end{symbDescription}
-\\ \midrule \\
+\\ \midrule
 Notes & The Proportional Controller is the product of the Proportional Gain and the Process Error (from \hyperref[DD:ddProcessError]{DD:ddProcessError}). The equation is converted to the frequency domain by applying the Laplace transform (from \hyperref[TM:laplaceTransform]{TM:laplaceTransform}).
         
-\\ \midrule \\
+\\ \midrule
 Source & \cite{johnson2008}
          
-\\ \midrule \\
+\\ \midrule
 RefBy & \hyperref[DD:ddCtrlVar]{DD:ddCtrlVar}
         
 \\ \bottomrule
@@ -529,33 +529,33 @@ RefBy & \hyperref[DD:ddCtrlVar]{DD:ddCtrlVar}
 \toprule \textbf{Refname} & \textbf{DD:ddDerivCtrl}
 \phantomsection 
 \label{DD:ddDerivCtrl}
-\\ \midrule \\
+\\ \midrule
 Label & Derivative control in the frequency domain
         
-\\ \midrule \\
+\\ \midrule
 Symbol & ${D_{\text{s}}}$
          
-\\ \midrule \\
+\\ \midrule
 Units & Unitless
         
-\\ \midrule \\
+\\ \midrule
 Equation & \begin{displaymath}
            {D_{\text{s}}}={K_{\text{d}}} {E_{\text{s}}} s
            \end{displaymath}
-\\ \midrule \\
+\\ \midrule
 Description & \begin{symbDescription}
               \item{${D_{\text{s}}}$ is the Derivative control in the frequency domain (Unitless)}
               \item{${K_{\text{d}}}$ is the Derivative Gain (Unitless)}
               \item{${E_{\text{s}}}$ is the Process Error in the frequency domain (Unitless)}
               \item{$s$ is the Complex frequency-domain parameter (Unitless)}
               \end{symbDescription}
-\\ \midrule \\
+\\ \midrule
 Notes & The Derivative Controller is the product of the Derivative Gain and the differential of the Process Error (from \hyperref[DD:ddProcessError]{DD:ddProcessError}). The equation is converted to the frequency domain by applying the Laplace transform (from \hyperref[TM:laplaceTransform]{TM:laplaceTransform}). A pure form of the Derivative controller is used in this application (from \hyperref[unfilteredDerivative]{A:Unfiltered Derivative}).
         
-\\ \midrule \\
+\\ \midrule
 Source & \cite{johnson2008}
          
-\\ \midrule \\
+\\ \midrule
 RefBy & \hyperref[DD:ddCtrlVar]{DD:ddCtrlVar}
         
 \\ \bottomrule
@@ -569,20 +569,20 @@ RefBy & \hyperref[DD:ddCtrlVar]{DD:ddCtrlVar}
 \toprule \textbf{Refname} & \textbf{DD:ddCtrlVar}
 \phantomsection 
 \label{DD:ddCtrlVar}
-\\ \midrule \\
+\\ \midrule
 Label & Control Variable in the frequency domain
         
-\\ \midrule \\
+\\ \midrule
 Symbol & ${C_{\text{s}}}$
          
-\\ \midrule \\
+\\ \midrule
 Units & Unitless
         
-\\ \midrule \\
+\\ \midrule
 Equation & \begin{displaymath}
            {C_{\text{s}}}={E_{\text{s}}} \left({K_{\text{p}}}+{K_{\text{d}}} s\right)
            \end{displaymath}
-\\ \midrule \\
+\\ \midrule
 Description & \begin{symbDescription}
               \item{${C_{\text{s}}}$ is the Control Variable in the frequency domain (Unitless)}
               \item{${E_{\text{s}}}$ is the Process Error in the frequency domain (Unitless)}
@@ -590,13 +590,13 @@ Description & \begin{symbDescription}
               \item{${K_{\text{d}}}$ is the Derivative Gain (Unitless)}
               \item{$s$ is the Complex frequency-domain parameter (Unitless)}
               \end{symbDescription}
-\\ \midrule \\
+\\ \midrule
 Notes & The Control Variable is the output of the controller. In this case, it is the sum of the Proportional (from \hyperref[DD:ddPropCtrl]{DD:ddPropCtrl}) and Derivative (from \hyperref[DD:ddDerivCtrl]{DD:ddDerivCtrl}) controllers. The parallel (from \hyperref[parallelEq]{A:Parallel Equation}) and de-coupled (from \hyperref[decoupled]{A:Decoupled equation}) form of the PD equation is used in this document.
         
-\\ \midrule \\
+\\ \midrule
 Source & \cite{johnson2008}
          
-\\ \midrule \\
+\\ \midrule
 RefBy & \hyperref[IM:pdEquationIM]{IM:pdEquationIM}
         
 \\ \bottomrule
@@ -614,16 +614,16 @@ This section transforms the problem defined in the \hyperref[Sec:ProbDesc]{probl
 \toprule \textbf{Refname} & \textbf{IM:pdEquationIM}
 \phantomsection 
 \label{IM:pdEquationIM}
-\\ \midrule \\
+\\ \midrule
 Label & Computation of the Process Variable as a function of time
         
-\\ \midrule \\
+\\ \midrule
 Input & ${r_{\text{t}}}$, ${K_{\text{p}}}$, ${K_{\text{d}}}$
         
-\\ \midrule \\
+\\ \midrule
 Output & ${y_{\text{t}}}$
          
-\\ \midrule \\
+\\ \midrule
 Input Constraints & \begin{displaymath}
                     {r_{\text{t}}}\gt{}0
                     \end{displaymath}
@@ -633,15 +633,15 @@ Input Constraints & \begin{displaymath}
                     \begin{displaymath}
                     {K_{\text{d}}}\gt{}0
                     \end{displaymath}
-\\ \midrule \\
+\\ \midrule
 Output Constraints & \begin{displaymath}
                      {y_{\text{t}}}\gt{}0
                      \end{displaymath}
-\\ \midrule \\
+\\ \midrule
 Equation & \begin{displaymath}
            \frac{\,d^{2}{y_{\text{t}}}}{\,dt^{2}}+\left(1+{K_{\text{d}}}\right) \frac{\,d{y_{\text{t}}}}{\,dt}+\left(20+{K_{\text{p}}}\right) {{y_{\text{t}}}}={r_{\text{t}}} {K_{\text{p}}}
            \end{displaymath}
-\\ \midrule \\
+\\ \midrule
 Description & \begin{symbDescription}
               \item{$t$ is the time (${\text{s}}$)}
               \item{${y_{\text{t}}}$ is the Process Variable (Unitless)}
@@ -649,10 +649,10 @@ Description & \begin{symbDescription}
               \item{${K_{\text{p}}}$ is the Proportional Gain (Unitless)}
               \item{${r_{\text{t}}}$ is the Set-Point (Unitless)}
               \end{symbDescription}
-\\ \midrule \\
+\\ \midrule
 Source & \cite{abbasi2015} and \cite{johnson2008}
          
-\\ \midrule \\
+\\ \midrule
 RefBy & \hyperref[outputValues]{FR:Output-Values} and \hyperref[calculateValues]{FR:Calculate-Values}
         
 \\ \bottomrule

--- a/code/stable/projectile/SRS/PDF/Projectile_SRS.tex
+++ b/code/stable/projectile/SRS/PDF/Projectile_SRS.tex
@@ -269,23 +269,23 @@ This section focuses on the general equations and laws that Projectile is based 
 \toprule \textbf{Refname} & \textbf{TM:acceleration}
 \phantomsection 
 \label{TM:acceleration}
-\\ \midrule \\
+\\ \midrule
 Label & Acceleration
         
-\\ \midrule \\
+\\ \midrule
 Equation & \begin{displaymath}
            \symbf{a}\text{(}t\text{)}=\frac{\,d\symbf{v}\text{(}t\text{)}}{\,dt}
            \end{displaymath}
-\\ \midrule \\
+\\ \midrule
 Description & \begin{symbDescription}
               \item{$\symbf{a}\text{(}t\text{)}$ is the acceleration ($\frac{\text{m}}{\text{s}^{2}}$)}
               \item{$t$ is the time (${\text{s}}$)}
               \item{$\symbf{v}\text{(}t\text{)}$ is the velocity ($\frac{\text{m}}{\text{s}}$)}
               \end{symbDescription}
-\\ \midrule \\
+\\ \midrule
 Source & \cite{accelerationWiki}
          
-\\ \midrule \\
+\\ \midrule
 RefBy & \hyperref[GD:rectVel]{GD:rectVel}
         
 \\ \bottomrule
@@ -298,23 +298,23 @@ RefBy & \hyperref[GD:rectVel]{GD:rectVel}
 \toprule \textbf{Refname} & \textbf{TM:velocity}
 \phantomsection 
 \label{TM:velocity}
-\\ \midrule \\
+\\ \midrule
 Label & Velocity
         
-\\ \midrule \\
+\\ \midrule
 Equation & \begin{displaymath}
            \symbf{v}\text{(}t\text{)}=\frac{\,d\symbf{p}\text{(}t\text{)}}{\,dt}
            \end{displaymath}
-\\ \midrule \\
+\\ \midrule
 Description & \begin{symbDescription}
               \item{$\symbf{v}\text{(}t\text{)}$ is the velocity ($\frac{\text{m}}{\text{s}}$)}
               \item{$t$ is the time (${\text{s}}$)}
               \item{$\symbf{p}\text{(}t\text{)}$ is the position (${\text{m}}$)}
               \end{symbDescription}
-\\ \midrule \\
+\\ \midrule
 Source & \cite{velocityWiki}
          
-\\ \midrule \\
+\\ \midrule
 RefBy & \hyperref[GD:rectPos]{GD:rectPos}
         
 \\ \bottomrule
@@ -331,27 +331,27 @@ This section collects the laws and equations that will be used to build the inst
 \toprule \textbf{Refname} & \textbf{GD:rectVel}
 \phantomsection 
 \label{GD:rectVel}
-\\ \midrule \\
+\\ \midrule
 Label & Rectilinear (1D) velocity as a function of time for constant acceleration
         
-\\ \midrule \\
+\\ \midrule
 Units & $\frac{\text{m}}{\text{s}}$
         
-\\ \midrule \\
+\\ \midrule
 Equation & \begin{displaymath}
            v\text{(}t\text{)}={v^{\text{i}}}+{a^{c}} t
            \end{displaymath}
-\\ \midrule \\
+\\ \midrule
 Description & \begin{symbDescription}
               \item{$v\text{(}t\text{)}$ is the 1D speed ($\frac{\text{m}}{\text{s}}$)}
               \item{${v^{\text{i}}}$ is the initial speed ($\frac{\text{m}}{\text{s}}$)}
               \item{${a^{c}}$ is the constant acceleration ($\frac{\text{m}}{\text{s}^{2}}$)}
               \item{$t$ is the time (${\text{s}}$)}
               \end{symbDescription}
-\\ \midrule \\
+\\ \midrule
 Source & \cite[(pg. 8)]{hibbeler2004}
          
-\\ \midrule \\
+\\ \midrule
 RefBy & \hyperref[GD:velVec]{GD:velVec} and \hyperref[GD:rectPos]{GD:rectPos}
         
 \\ \bottomrule
@@ -381,17 +381,17 @@ v\text{(}t\text{)}={v^{\text{i}}}+{a^{c}} t
 \toprule \textbf{Refname} & \textbf{GD:rectPos}
 \phantomsection 
 \label{GD:rectPos}
-\\ \midrule \\
+\\ \midrule
 Label & Rectilinear (1D) position as a function of time for constant acceleration
         
-\\ \midrule \\
+\\ \midrule
 Units & ${\text{m}}$
         
-\\ \midrule \\
+\\ \midrule
 Equation & \begin{displaymath}
            p\text{(}t\text{)}={p^{\text{i}}}+{v^{\text{i}}} t+\frac{{a^{c}} t^{2}}{2}
            \end{displaymath}
-\\ \midrule \\
+\\ \midrule
 Description & \begin{symbDescription}
               \item{$p\text{(}t\text{)}$ is the 1D position (${\text{m}}$)}
               \item{${p^{\text{i}}}$ is the initial position (${\text{m}}$)}
@@ -399,10 +399,10 @@ Description & \begin{symbDescription}
               \item{$t$ is the time (${\text{s}}$)}
               \item{${a^{c}}$ is the constant acceleration ($\frac{\text{m}}{\text{s}^{2}}$)}
               \end{symbDescription}
-\\ \midrule \\
+\\ \midrule
 Source & \cite[(pg. 8)]{hibbeler2004}
          
-\\ \midrule \\
+\\ \midrule
 RefBy & \hyperref[GD:posVec]{GD:posVec}
         
 \\ \bottomrule
@@ -437,20 +437,20 @@ p\text{(}t\text{)}={p^{\text{i}}}+{v^{\text{i}}} t+\frac{{a^{c}} t^{2}}{2}
 \toprule \textbf{Refname} & \textbf{GD:velVec}
 \phantomsection 
 \label{GD:velVec}
-\\ \midrule \\
+\\ \midrule
 Label & Velocity vector as a function of time for 2D motion under constant acceleration
         
-\\ \midrule \\
+\\ \midrule
 Units & $\frac{\text{m}}{\text{s}}$
         
-\\ \midrule \\
+\\ \midrule
 Equation & \begin{displaymath}
            \symbf{v}\text{(}t\text{)}=\begin{bmatrix}
                                       {{v_{\text{x}}}^{\text{i}}}+{{a_{\text{x}}}^{\text{c}}} t\\
                                       {{v_{\text{y}}}^{\text{i}}}+{{a_{\text{y}}}^{\text{c}}} t
                                       \end{bmatrix}
            \end{displaymath}
-\\ \midrule \\
+\\ \midrule
 Description & \begin{symbDescription}
               \item{$\symbf{v}\text{(}t\text{)}$ is the velocity ($\frac{\text{m}}{\text{s}}$)}
               \item{${{v_{\text{x}}}^{\text{i}}}$ is the $x$-component of initial velocity ($\frac{\text{m}}{\text{s}}$)}
@@ -459,10 +459,10 @@ Description & \begin{symbDescription}
               \item{${{v_{\text{y}}}^{\text{i}}}$ is the $y$-component of initial velocity ($\frac{\text{m}}{\text{s}}$)}
               \item{${{a_{\text{y}}}^{\text{c}}}$ is the $y$-component of constant acceleration ($\frac{\text{m}}{\text{s}^{2}}$)}
               \end{symbDescription}
-\\ \midrule \\
+\\ \midrule
 Source & --
          
-\\ \midrule \\
+\\ \midrule
 RefBy & 
 \\ \bottomrule
 \end{tabular}
@@ -496,20 +496,20 @@ For a two-dimensional Cartesian coordinate system (\hyperref[twoDMotion]{A:twoDM
 \toprule \textbf{Refname} & \textbf{GD:posVec}
 \phantomsection 
 \label{GD:posVec}
-\\ \midrule \\
+\\ \midrule
 Label & Position vector as a function of time for 2D motion under constant acceleration
         
-\\ \midrule \\
+\\ \midrule
 Units & ${\text{m}}$
         
-\\ \midrule \\
+\\ \midrule
 Equation & \begin{displaymath}
            \symbf{p}\text{(}t\text{)}=\begin{bmatrix}
                                       {{p_{\text{x}}}^{\text{i}}}+{{v_{\text{x}}}^{\text{i}}} t+\frac{{{a_{\text{x}}}^{\text{c}}} t^{2}}{2}\\
                                       {{p_{\text{y}}}^{\text{i}}}+{{v_{\text{y}}}^{\text{i}}} t+\frac{{{a_{\text{y}}}^{\text{c}}} t^{2}}{2}
                                       \end{bmatrix}
            \end{displaymath}
-\\ \midrule \\
+\\ \midrule
 Description & \begin{symbDescription}
               \item{$\symbf{p}\text{(}t\text{)}$ is the position (${\text{m}}$)}
               \item{${{p_{\text{x}}}^{\text{i}}}$ is the $x$-component of initial position (${\text{m}}$)}
@@ -520,10 +520,10 @@ Description & \begin{symbDescription}
               \item{${{v_{\text{y}}}^{\text{i}}}$ is the $y$-component of initial velocity ($\frac{\text{m}}{\text{s}}$)}
               \item{${{a_{\text{y}}}^{\text{c}}}$ is the $y$-component of constant acceleration ($\frac{\text{m}}{\text{s}^{2}}$)}
               \end{symbDescription}
-\\ \midrule \\
+\\ \midrule
 Source & --
          
-\\ \midrule \\
+\\ \midrule
 RefBy & \hyperref[IM:calOfLandingDist]{IM:calOfLandingDist} and \hyperref[IM:calOfLandingTime]{IM:calOfLandingTime}
         
 \\ \bottomrule
@@ -565,31 +565,31 @@ This section collects and defines all the data needed to build the instance mode
 \toprule \textbf{Refname} & \textbf{DD:vecMag}
 \phantomsection 
 \label{DD:vecMag}
-\\ \midrule \\
+\\ \midrule
 Label & Speed
         
-\\ \midrule \\
+\\ \midrule
 Symbol & $v$
          
-\\ \midrule \\
+\\ \midrule
 Units & $\frac{\text{m}}{\text{s}}$
         
-\\ \midrule \\
+\\ \midrule
 Equation & \begin{displaymath}
            v=\|\symbf{v}\text{(}t\text{)}\|
            \end{displaymath}
-\\ \midrule \\
+\\ \midrule
 Description & \begin{symbDescription}
               \item{$v$ is the speed ($\frac{\text{m}}{\text{s}}$)}
               \item{$\symbf{v}\text{(}t\text{)}$ is the velocity ($\frac{\text{m}}{\text{s}}$)}
               \end{symbDescription}
-\\ \midrule \\
+\\ \midrule
 Notes & For a given velocity vector $\symbf{v}\text{(}t\text{)}$, the magnitude of the vector ($\|\symbf{v}\text{(}t\text{)}\|$) is the scalar called speed.
         
-\\ \midrule \\
+\\ \midrule
 Source & --
          
-\\ \midrule \\
+\\ \midrule
 RefBy & \hyperref[DD:speedIY]{DD:speedIY} and \hyperref[DD:speedIX]{DD:speedIX}
         
 \\ \bottomrule
@@ -603,34 +603,34 @@ RefBy & \hyperref[DD:speedIY]{DD:speedIY} and \hyperref[DD:speedIX]{DD:speedIX}
 \toprule \textbf{Refname} & \textbf{DD:speedIX}
 \phantomsection 
 \label{DD:speedIX}
-\\ \midrule \\
+\\ \midrule
 Label & $x$-component of initial velocity
         
-\\ \midrule \\
+\\ \midrule
 Symbol & ${{v_{\text{x}}}^{\text{i}}}$
          
-\\ \midrule \\
+\\ \midrule
 Units & $\frac{\text{m}}{\text{s}}$
         
-\\ \midrule \\
+\\ \midrule
 Equation & \begin{displaymath}
            {{v_{\text{x}}}^{\text{i}}}={v^{\text{i}}} \cos\left(θ\right)
            \end{displaymath}
-\\ \midrule \\
+\\ \midrule
 Description & \begin{symbDescription}
               \item{${{v_{\text{x}}}^{\text{i}}}$ is the $x$-component of initial velocity ($\frac{\text{m}}{\text{s}}$)}
               \item{${v^{\text{i}}}$ is the initial speed ($\frac{\text{m}}{\text{s}}$)}
               \item{$θ$ is the launch angle (${\text{rad}}$)}
               \end{symbDescription}
-\\ \midrule \\
+\\ \midrule
 Notes & ${v^{\text{i}}}$ is from \hyperref[DD:vecMag]{DD:vecMag}.
         
         $θ$ is shown in \hyperref[Figure:Launch]{Fig:Launch}.
         
-\\ \midrule \\
+\\ \midrule
 Source & --
          
-\\ \midrule \\
+\\ \midrule
 RefBy & \hyperref[IM:calOfLandingDist]{IM:calOfLandingDist}
         
 \\ \bottomrule
@@ -644,34 +644,34 @@ RefBy & \hyperref[IM:calOfLandingDist]{IM:calOfLandingDist}
 \toprule \textbf{Refname} & \textbf{DD:speedIY}
 \phantomsection 
 \label{DD:speedIY}
-\\ \midrule \\
+\\ \midrule
 Label & $y$-component of initial velocity
         
-\\ \midrule \\
+\\ \midrule
 Symbol & ${{v_{\text{y}}}^{\text{i}}}$
          
-\\ \midrule \\
+\\ \midrule
 Units & $\frac{\text{m}}{\text{s}}$
         
-\\ \midrule \\
+\\ \midrule
 Equation & \begin{displaymath}
            {{v_{\text{y}}}^{\text{i}}}={v^{\text{i}}} \sin\left(θ\right)
            \end{displaymath}
-\\ \midrule \\
+\\ \midrule
 Description & \begin{symbDescription}
               \item{${{v_{\text{y}}}^{\text{i}}}$ is the $y$-component of initial velocity ($\frac{\text{m}}{\text{s}}$)}
               \item{${v^{\text{i}}}$ is the initial speed ($\frac{\text{m}}{\text{s}}$)}
               \item{$θ$ is the launch angle (${\text{rad}}$)}
               \end{symbDescription}
-\\ \midrule \\
+\\ \midrule
 Notes & ${v^{\text{i}}}$ is from \hyperref[DD:vecMag]{DD:vecMag}.
         
         $θ$ is shown in \hyperref[Figure:Launch]{Fig:Launch}.
         
-\\ \midrule \\
+\\ \midrule
 Source & --
          
-\\ \midrule \\
+\\ \midrule
 RefBy & \hyperref[IM:calOfLandingTime]{IM:calOfLandingTime}
         
 \\ \bottomrule
@@ -689,48 +689,48 @@ This section transforms the problem defined in the \hyperref[Sec:ProbDesc]{probl
 \toprule \textbf{Refname} & \textbf{IM:calOfLandingTime}
 \phantomsection 
 \label{IM:calOfLandingTime}
-\\ \midrule \\
+\\ \midrule
 Label & Calculation of landing time
         
-\\ \midrule \\
+\\ \midrule
 Input & ${v_{\text{launch}}}$, $θ$
         
-\\ \midrule \\
+\\ \midrule
 Output & ${t_{\text{flight}}}$
          
-\\ \midrule \\
+\\ \midrule
 Input Constraints & \begin{displaymath}
                     {v_{\text{launch}}}\gt{}0
                     \end{displaymath}
                     \begin{displaymath}
                     0\lt{}θ\lt{}\frac{π}{2}
                     \end{displaymath}
-\\ \midrule \\
+\\ \midrule
 Output Constraints & \begin{displaymath}
                      {t_{\text{flight}}}\gt{}0
                      \end{displaymath}
-\\ \midrule \\
+\\ \midrule
 Equation & \begin{displaymath}
            {t_{\text{flight}}}=\frac{2 {v_{\text{launch}}} \sin\left(θ\right)}{g}
            \end{displaymath}
-\\ \midrule \\
+\\ \midrule
 Description & \begin{symbDescription}
               \item{${t_{\text{flight}}}$ is the flight duration (${\text{s}}$)}
               \item{${v_{\text{launch}}}$ is the launch speed ($\frac{\text{m}}{\text{s}}$)}
               \item{$θ$ is the launch angle (${\text{rad}}$)}
               \item{$g$ is the magnitude of gravitational acceleration ($\frac{\text{m}}{\text{s}^{2}}$)}
               \end{symbDescription}
-\\ \midrule \\
+\\ \midrule
 Notes & The constraint $0\lt{}θ\lt{}\frac{π}{2}$ is from \hyperref[posXDirection]{A:posXDirection} and \hyperref[yAxisGravity]{A:yAxisGravity}, and is shown in \hyperref[Figure:Launch]{Fig:Launch}.
         
         $g$ is defined in \hyperref[gravAccelValue]{A:gravAccelValue}.
         
         The constraint ${t_{\text{flight}}}\gt{}0$ is from \hyperref[timeStartZero]{A:timeStartZero}.
         
-\\ \midrule \\
+\\ \midrule
 Source & --
          
-\\ \midrule \\
+\\ \midrule
 RefBy & \hyperref[outputValues]{FR:Output-Values}, \hyperref[IM:calOfLandingDist]{IM:calOfLandingDist}, and \hyperref[calcValues]{FR:Calculate-Values}
         
 \\ \bottomrule
@@ -770,48 +770,48 @@ From \hyperref[DD:speedIY]{DD:speedIY} (with ${v^{\text{i}}}={v_{\text{launch}}}
 \toprule \textbf{Refname} & \textbf{IM:calOfLandingDist}
 \phantomsection 
 \label{IM:calOfLandingDist}
-\\ \midrule \\
+\\ \midrule
 Label & Calculation of landing position
         
-\\ \midrule \\
+\\ \midrule
 Input & ${v_{\text{launch}}}$, $θ$
         
-\\ \midrule \\
+\\ \midrule
 Output & ${p_{\text{land}}}$
          
-\\ \midrule \\
+\\ \midrule
 Input Constraints & \begin{displaymath}
                     {v_{\text{launch}}}\gt{}0
                     \end{displaymath}
                     \begin{displaymath}
                     0\lt{}θ\lt{}\frac{π}{2}
                     \end{displaymath}
-\\ \midrule \\
+\\ \midrule
 Output Constraints & \begin{displaymath}
                      {p_{\text{land}}}\gt{}0
                      \end{displaymath}
-\\ \midrule \\
+\\ \midrule
 Equation & \begin{displaymath}
            {p_{\text{land}}}=\frac{2 {v_{\text{launch}}}^{2} \sin\left(θ\right) \cos\left(θ\right)}{g}
            \end{displaymath}
-\\ \midrule \\
+\\ \midrule
 Description & \begin{symbDescription}
               \item{${p_{\text{land}}}$ is the landing position (${\text{m}}$)}
               \item{${v_{\text{launch}}}$ is the launch speed ($\frac{\text{m}}{\text{s}}$)}
               \item{$θ$ is the launch angle (${\text{rad}}$)}
               \item{$g$ is the magnitude of gravitational acceleration ($\frac{\text{m}}{\text{s}^{2}}$)}
               \end{symbDescription}
-\\ \midrule \\
+\\ \midrule
 Notes & The constraint $0\lt{}θ\lt{}\frac{π}{2}$ is from \hyperref[posXDirection]{A:posXDirection} and \hyperref[yAxisGravity]{A:yAxisGravity}, and is shown in \hyperref[Figure:Launch]{Fig:Launch}.
         
         $g$ is defined in \hyperref[gravAccelValue]{A:gravAccelValue}.
         
         The constraint ${p_{\text{land}}}\gt{}0$ is from \hyperref[posXDirection]{A:posXDirection}.
         
-\\ \midrule \\
+\\ \midrule
 Source & --
          
-\\ \midrule \\
+\\ \midrule
 RefBy & \hyperref[IM:offsetIM]{IM:offsetIM} and \hyperref[calcValues]{FR:Calculate-Values}
         
 \\ \bottomrule
@@ -846,43 +846,43 @@ Rearranging this gives us the required equation:
 \toprule \textbf{Refname} & \textbf{IM:offsetIM}
 \phantomsection 
 \label{IM:offsetIM}
-\\ \midrule \\
+\\ \midrule
 Label & Offset
         
-\\ \midrule \\
+\\ \midrule
 Input & ${p_{\text{land}}}$, ${p_{\text{target}}}$
         
-\\ \midrule \\
+\\ \midrule
 Output & ${d_{\text{offset}}}$
          
-\\ \midrule \\
+\\ \midrule
 Input Constraints & \begin{displaymath}
                     {p_{\text{land}}}\gt{}0
                     \end{displaymath}
                     \begin{displaymath}
                     {p_{\text{target}}}\gt{}0
                     \end{displaymath}
-\\ \midrule \\
+\\ \midrule
 Output Constraints & 
-\\ \midrule \\
+\\ \midrule
 Equation & \begin{displaymath}
            {d_{\text{offset}}}={p_{\text{land}}}-{p_{\text{target}}}
            \end{displaymath}
-\\ \midrule \\
+\\ \midrule
 Description & \begin{symbDescription}
               \item{${d_{\text{offset}}}$ is the distance between the target position and the landing position (${\text{m}}$)}
               \item{${p_{\text{land}}}$ is the landing position (${\text{m}}$)}
               \item{${p_{\text{target}}}$ is the target position (${\text{m}}$)}
               \end{symbDescription}
-\\ \midrule \\
+\\ \midrule
 Notes & ${p_{\text{land}}}$ is from \hyperref[IM:calOfLandingDist]{IM:calOfLandingDist}.
         
         The constraints ${p_{\text{land}}}\gt{}0$ and ${p_{\text{target}}}\gt{}0$ are from \hyperref[posXDirection]{A:posXDirection}.
         
-\\ \midrule \\
+\\ \midrule
 Source & --
          
-\\ \midrule \\
+\\ \midrule
 RefBy & \hyperref[outputValues]{FR:Output-Values}, \hyperref[IM:messageIM]{IM:messageIM}, and \hyperref[calcValues]{FR:Calculate-Values}
         
 \\ \bottomrule
@@ -896,25 +896,25 @@ RefBy & \hyperref[outputValues]{FR:Output-Values}, \hyperref[IM:messageIM]{IM:me
 \toprule \textbf{Refname} & \textbf{IM:messageIM}
 \phantomsection 
 \label{IM:messageIM}
-\\ \midrule \\
+\\ \midrule
 Label & Output message
         
-\\ \midrule \\
+\\ \midrule
 Input & ${d_{\text{offset}}}$, ${p_{\text{target}}}$
         
-\\ \midrule \\
+\\ \midrule
 Output & $s$
          
-\\ \midrule \\
+\\ \midrule
 Input Constraints & \begin{displaymath}
                     {d_{\text{offset}}}\gt{}-{p_{\text{target}}}
                     \end{displaymath}
                     \begin{displaymath}
                     {p_{\text{target}}}\gt{}0
                     \end{displaymath}
-\\ \midrule \\
+\\ \midrule
 Output Constraints & 
-\\ \midrule \\
+\\ \midrule
 Equation & \begin{displaymath}
            s=\begin{cases}
              \text{``The target was hit.''}, & |\frac{{d_{\text{offset}}}}{{p_{\text{target}}}}|\lt{}ε\\
@@ -922,14 +922,14 @@ Equation & \begin{displaymath}
              \text{``The projectile went long.''}, & {d_{\text{offset}}}\gt{}0
              \end{cases}
            \end{displaymath}
-\\ \midrule \\
+\\ \midrule
 Description & \begin{symbDescription}
               \item{$s$ is the output message as a string (Unitless)}
               \item{${d_{\text{offset}}}$ is the distance between the target position and the landing position (${\text{m}}$)}
               \item{${p_{\text{target}}}$ is the target position (${\text{m}}$)}
               \item{$ε$ is the hit tolerance (Unitless)}
               \end{symbDescription}
-\\ \midrule \\
+\\ \midrule
 Notes & ${d_{\text{offset}}}$ is from \hyperref[IM:offsetIM]{IM:offsetIM}.
         
         The constraint ${p_{\text{target}}}\gt{}0$ is from \hyperref[posXDirection]{A:posXDirection}.
@@ -938,10 +938,10 @@ Notes & ${d_{\text{offset}}}$ is from \hyperref[IM:offsetIM]{IM:offsetIM}.
         
         $ε$ is defined in \hyperref[Sec:AuxConstants]{Sec:Values of Auxiliary Constants}.
         
-\\ \midrule \\
+\\ \midrule
 Source & --
          
-\\ \midrule \\
+\\ \midrule
 RefBy & \hyperref[outputValues]{FR:Output-Values} and \hyperref[calcValues]{FR:Calculate-Values}
         
 \\ \bottomrule

--- a/code/stable/sglpendulum/SRS/PDF/SglPendulum_SRS.tex
+++ b/code/stable/sglpendulum/SRS/PDF/SglPendulum_SRS.tex
@@ -300,23 +300,23 @@ This section focuses on the general equations and laws that SglPendulum is based
 \toprule \textbf{Refname} & \textbf{TM:acceleration}
 \phantomsection 
 \label{TM:acceleration}
-\\ \midrule \\
+\\ \midrule
 Label & Acceleration
         
-\\ \midrule \\
+\\ \midrule
 Equation & \begin{displaymath}
            \symbf{a}\text{(}t\text{)}=\frac{\,d\symbf{v}\text{(}t\text{)}}{\,dt}
            \end{displaymath}
-\\ \midrule \\
+\\ \midrule
 Description & \begin{symbDescription}
               \item{$\symbf{a}\text{(}t\text{)}$ is the acceleration ($\frac{\text{m}}{\text{s}^{2}}$)}
               \item{$t$ is the time (${\text{s}}$)}
               \item{$\symbf{v}\text{(}t\text{)}$ is the velocity ($\frac{\text{m}}{\text{s}}$)}
               \end{symbDescription}
-\\ \midrule \\
+\\ \midrule
 Source & \cite{accelerationWiki}
          
-\\ \midrule \\
+\\ \midrule
 RefBy & 
 \\ \bottomrule
 \end{tabular}
@@ -328,23 +328,23 @@ RefBy &
 \toprule \textbf{Refname} & \textbf{TM:velocity}
 \phantomsection 
 \label{TM:velocity}
-\\ \midrule \\
+\\ \midrule
 Label & Velocity
         
-\\ \midrule \\
+\\ \midrule
 Equation & \begin{displaymath}
            \symbf{v}\text{(}t\text{)}=\frac{\,d\symbf{p}\text{(}t\text{)}}{\,dt}
            \end{displaymath}
-\\ \midrule \\
+\\ \midrule
 Description & \begin{symbDescription}
               \item{$\symbf{v}\text{(}t\text{)}$ is the velocity ($\frac{\text{m}}{\text{s}}$)}
               \item{$t$ is the time (${\text{s}}$)}
               \item{$\symbf{p}\text{(}t\text{)}$ is the position (${\text{m}}$)}
               \end{symbDescription}
-\\ \midrule \\
+\\ \midrule
 Source & \cite{velocityWiki}
          
-\\ \midrule \\
+\\ \midrule
 RefBy & 
 \\ \bottomrule
 \end{tabular}
@@ -356,26 +356,26 @@ RefBy &
 \toprule \textbf{Refname} & \textbf{TM:NewtonSecLawMot}
 \phantomsection 
 \label{TM:NewtonSecLawMot}
-\\ \midrule \\
+\\ \midrule
 Label & Newton's second law of motion
         
-\\ \midrule \\
+\\ \midrule
 Equation & \begin{displaymath}
            \symbf{F}=m \symbf{a}\text{(}t\text{)}
            \end{displaymath}
-\\ \midrule \\
+\\ \midrule
 Description & \begin{symbDescription}
               \item{$\symbf{F}$ is the force (${\text{N}}$)}
               \item{$m$ is the mass (${\text{kg}}$)}
               \item{$\symbf{a}\text{(}t\text{)}$ is the acceleration ($\frac{\text{m}}{\text{s}^{2}}$)}
               \end{symbDescription}
-\\ \midrule \\
+\\ \midrule
 Notes & The net force $\symbf{F}$ on a body is proportional to the acceleration $\symbf{a}\text{(}t\text{)}$ of the body, where $m$ denotes the mass of the body as the constant of proportionality.
         
-\\ \midrule \\
+\\ \midrule
 Source & --
          
-\\ \midrule \\
+\\ \midrule
 RefBy & 
 \\ \bottomrule
 \end{tabular}
@@ -387,26 +387,26 @@ RefBy &
 \toprule \textbf{Refname} & \textbf{TM:NewtonSecLawRotMot}
 \phantomsection 
 \label{TM:NewtonSecLawRotMot}
-\\ \midrule \\
+\\ \midrule
 Label & Newton's second law for rotational motion
         
-\\ \midrule \\
+\\ \midrule
 Equation & \begin{displaymath}
            \symbf{τ}=\symbf{I} α
            \end{displaymath}
-\\ \midrule \\
+\\ \midrule
 Description & \begin{symbDescription}
               \item{$\symbf{τ}$ is the torque ($\text{N}\text{m}$)}
               \item{$\symbf{I}$ is the moment of inertia ($\text{kg}\text{m}^{2}$)}
               \item{$α$ is the angular acceleration ($\frac{\text{rad}}{\text{s}^{2}}$)}
               \end{symbDescription}
-\\ \midrule \\
+\\ \midrule
 Notes & The net torque $\symbf{τ}$ on a rigid body is proportional to its angular acceleration $α$, where $\symbf{I}$ denotes the moment of inertia of the rigid body as the constant of proportionality.
         
-\\ \midrule \\
+\\ \midrule
 Source & --
          
-\\ \midrule \\
+\\ \midrule
 RefBy & \hyperref[IM:calOfAngularDisplacement]{IM:calOfAngularDisplacement} and \hyperref[GD:angFrequencyGD]{GD:angFrequencyGD}
         
 \\ \bottomrule
@@ -423,27 +423,27 @@ This section collects the laws and equations that will be used to build the inst
 \toprule \textbf{Refname} & \textbf{GD:velocityIX}
 \phantomsection 
 \label{GD:velocityIX}
-\\ \midrule \\
+\\ \midrule
 Label & The $x$-component of velocity of the pendulum
         
-\\ \midrule \\
+\\ \midrule
 Units & $\frac{\text{m}}{\text{s}}$
         
-\\ \midrule \\
+\\ \midrule
 Equation & \begin{displaymath}
            {v_{\text{x}}}=ω {L_{\text{rod}}} \cos\left({θ_{p}}\right)
            \end{displaymath}
-\\ \midrule \\
+\\ \midrule
 Description & \begin{symbDescription}
               \item{${v_{\text{x}}}$ is the $x$-component of velocity ($\frac{\text{m}}{\text{s}}$)}
               \item{$ω$ is the angular velocity ($\frac{\text{rad}}{\text{s}}$)}
               \item{${L_{\text{rod}}}$ is the length of the rod (${\text{m}}$)}
               \item{${θ_{p}}$ is the displacement angle of the pendulum (${\text{rad}}$)}
               \end{symbDescription}
-\\ \midrule \\
+\\ \midrule
 Source & --
          
-\\ \midrule \\
+\\ \midrule
 RefBy & 
 \\ \bottomrule
 \end{tabular}
@@ -482,27 +482,27 @@ Therefore, using the chain rule,
 \toprule \textbf{Refname} & \textbf{GD:velocityIY}
 \phantomsection 
 \label{GD:velocityIY}
-\\ \midrule \\
+\\ \midrule
 Label & The $y$-component of velocity of the pendulum
         
-\\ \midrule \\
+\\ \midrule
 Units & $\frac{\text{m}}{\text{s}}$
         
-\\ \midrule \\
+\\ \midrule
 Equation & \begin{displaymath}
            {v_{\text{y}}}=ω {L_{\text{rod}}} \sin\left({θ_{p}}\right)
            \end{displaymath}
-\\ \midrule \\
+\\ \midrule
 Description & \begin{symbDescription}
               \item{${v_{\text{y}}}$ is the $y$-component of velocity ($\frac{\text{m}}{\text{s}}$)}
               \item{$ω$ is the angular velocity ($\frac{\text{rad}}{\text{s}}$)}
               \item{${L_{\text{rod}}}$ is the length of the rod (${\text{m}}$)}
               \item{${θ_{p}}$ is the displacement angle of the pendulum (${\text{rad}}$)}
               \end{symbDescription}
-\\ \midrule \\
+\\ \midrule
 Source & --
          
-\\ \midrule \\
+\\ \midrule
 RefBy & 
 \\ \bottomrule
 \end{tabular}
@@ -541,17 +541,17 @@ Therefore, using the chain rule,
 \toprule \textbf{Refname} & \textbf{GD:accelerationIX}
 \phantomsection 
 \label{GD:accelerationIX}
-\\ \midrule \\
+\\ \midrule
 Label & The $x$-component of acceleration of the pendulum
         
-\\ \midrule \\
+\\ \midrule
 Units & $\frac{\text{m}}{\text{s}^{2}}$
         
-\\ \midrule \\
+\\ \midrule
 Equation & \begin{displaymath}
            {a_{\text{x}}}=-ω^{2} {L_{\text{rod}}} \sin\left({θ_{p}}\right)+α {L_{\text{rod}}} \cos\left({θ_{p}}\right)
            \end{displaymath}
-\\ \midrule \\
+\\ \midrule
 Description & \begin{symbDescription}
               \item{${a_{\text{x}}}$ is the $x$-component of acceleration ($\frac{\text{m}}{\text{s}^{2}}$)}
               \item{$ω$ is the angular velocity ($\frac{\text{rad}}{\text{s}}$)}
@@ -559,10 +559,10 @@ Description & \begin{symbDescription}
               \item{${θ_{p}}$ is the displacement angle of the pendulum (${\text{rad}}$)}
               \item{$α$ is the angular acceleration ($\frac{\text{rad}}{\text{s}^{2}}$)}
               \end{symbDescription}
-\\ \midrule \\
+\\ \midrule
 Source & --
          
-\\ \midrule \\
+\\ \midrule
 RefBy & 
 \\ \bottomrule
 \end{tabular}
@@ -601,17 +601,17 @@ Simplifying,
 \toprule \textbf{Refname} & \textbf{GD:accelerationIY}
 \phantomsection 
 \label{GD:accelerationIY}
-\\ \midrule \\
+\\ \midrule
 Label & The $y$-component of acceleration of the pendulum
         
-\\ \midrule \\
+\\ \midrule
 Units & $\frac{\text{m}}{\text{s}^{2}}$
         
-\\ \midrule \\
+\\ \midrule
 Equation & \begin{displaymath}
            {a_{\text{y}}}=ω^{2} {L_{\text{rod}}} \cos\left({θ_{p}}\right)+α {L_{\text{rod}}} \sin\left({θ_{p}}\right)
            \end{displaymath}
-\\ \midrule \\
+\\ \midrule
 Description & \begin{symbDescription}
               \item{${a_{\text{y}}}$ is the $y$-component of acceleration ($\frac{\text{m}}{\text{s}^{2}}$)}
               \item{$ω$ is the angular velocity ($\frac{\text{rad}}{\text{s}}$)}
@@ -619,10 +619,10 @@ Description & \begin{symbDescription}
               \item{${θ_{p}}$ is the displacement angle of the pendulum (${\text{rad}}$)}
               \item{$α$ is the angular acceleration ($\frac{\text{rad}}{\text{s}^{2}}$)}
               \end{symbDescription}
-\\ \midrule \\
+\\ \midrule
 Source & --
          
-\\ \midrule \\
+\\ \midrule
 RefBy & 
 \\ \bottomrule
 \end{tabular}
@@ -661,17 +661,17 @@ Simplifying,
 \toprule \textbf{Refname} & \textbf{GD:hForceOnPendulum}
 \phantomsection 
 \label{GD:hForceOnPendulum}
-\\ \midrule \\
+\\ \midrule
 Label & Horizontal force on the pendulum
         
-\\ \midrule \\
+\\ \midrule
 Units & ${\text{N}}$
         
-\\ \midrule \\
+\\ \midrule
 Equation & \begin{displaymath}
            \symbf{F}=m {a_{\text{x}}}=-\symbf{T} \sin\left({θ_{p}}\right)
            \end{displaymath}
-\\ \midrule \\
+\\ \midrule
 Description & \begin{symbDescription}
               \item{$\symbf{F}$ is the force (${\text{N}}$)}
               \item{$m$ is the mass (${\text{kg}}$)}
@@ -679,10 +679,10 @@ Description & \begin{symbDescription}
               \item{$\symbf{T}$ is the tension (${\text{N}}$)}
               \item{${θ_{p}}$ is the displacement angle of the pendulum (${\text{rad}}$)}
               \end{symbDescription}
-\\ \midrule \\
+\\ \midrule
 Source & --
          
-\\ \midrule \\
+\\ \midrule
 RefBy & 
 \\ \bottomrule
 \end{tabular}
@@ -699,17 +699,17 @@ RefBy &
 \toprule \textbf{Refname} & \textbf{GD:vForceOnPendulum}
 \phantomsection 
 \label{GD:vForceOnPendulum}
-\\ \midrule \\
+\\ \midrule
 Label & Vertical force on the pendulum
         
-\\ \midrule \\
+\\ \midrule
 Units & ${\text{N}}$
         
-\\ \midrule \\
+\\ \midrule
 Equation & \begin{displaymath}
            \symbf{F}=m {a_{\text{y}}}=\symbf{T} \cos\left({θ_{p}}\right)-m \symbf{g}
            \end{displaymath}
-\\ \midrule \\
+\\ \midrule
 Description & \begin{symbDescription}
               \item{$\symbf{F}$ is the force (${\text{N}}$)}
               \item{$m$ is the mass (${\text{kg}}$)}
@@ -718,10 +718,10 @@ Description & \begin{symbDescription}
               \item{${θ_{p}}$ is the displacement angle of the pendulum (${\text{rad}}$)}
               \item{$\symbf{g}$ is the gravitational acceleration ($\frac{\text{m}}{\text{s}^{2}}$)}
               \end{symbDescription}
-\\ \midrule \\
+\\ \midrule
 Source & --
          
-\\ \midrule \\
+\\ \midrule
 RefBy & 
 \\ \bottomrule
 \end{tabular}
@@ -738,29 +738,29 @@ RefBy &
 \toprule \textbf{Refname} & \textbf{GD:angFrequencyGD}
 \phantomsection 
 \label{GD:angFrequencyGD}
-\\ \midrule \\
+\\ \midrule
 Label & The angular frequency of the pendulum
         
-\\ \midrule \\
+\\ \midrule
 Units & ${\text{s}}$
         
-\\ \midrule \\
+\\ \midrule
 Equation & \begin{displaymath}
            Ω=\sqrt{\frac{\symbf{g}}{{L_{\text{rod}}}}}
            \end{displaymath}
-\\ \midrule \\
+\\ \midrule
 Description & \begin{symbDescription}
               \item{$Ω$ is the angular frequency (${\text{s}}$)}
               \item{$\symbf{g}$ is the gravitational acceleration ($\frac{\text{m}}{\text{s}^{2}}$)}
               \item{${L_{\text{rod}}}$ is the length of the rod (${\text{m}}$)}
               \end{symbDescription}
-\\ \midrule \\
+\\ \midrule
 Notes & The torque is defined in \hyperref[TM:NewtonSecLawRotMot]{TM:NewtonSecLawRotMot} and frequency is $f$ is defined in \hyperref[DD:frequencyDD]{DD:frequencyDD}.
         
-\\ \midrule \\
+\\ \midrule
 Source & --
          
-\\ \midrule \\
+\\ \midrule
 RefBy & \hyperref[GD:periodPend]{GD:periodPend} and \hyperref[IM:calOfAngularDisplacement]{IM:calOfAngularDisplacement}
         
 \\ \bottomrule
@@ -810,30 +810,30 @@ Because this equation, has the same form as the equation for simple harmonic mot
 \toprule \textbf{Refname} & \textbf{GD:periodPend}
 \phantomsection 
 \label{GD:periodPend}
-\\ \midrule \\
+\\ \midrule
 Label & The period of the pendulum
         
-\\ \midrule \\
+\\ \midrule
 Units & ${\text{s}}$
         
-\\ \midrule \\
+\\ \midrule
 Equation & \begin{displaymath}
            T=2 π \sqrt{\frac{{L_{\text{rod}}}}{\symbf{g}}}
            \end{displaymath}
-\\ \midrule \\
+\\ \midrule
 Description & \begin{symbDescription}
               \item{$T$ is the period (${\text{s}}$)}
               \item{$π$ is the ratio of circumference to diameter for any circle (Unitless)}
               \item{${L_{\text{rod}}}$ is the length of the rod (${\text{m}}$)}
               \item{$\symbf{g}$ is the gravitational acceleration ($\frac{\text{m}}{\text{s}^{2}}$)}
               \end{symbDescription}
-\\ \midrule \\
+\\ \midrule
 Notes & The frequency and period are defined in the data definitions for \hyperref[DD:frequencyDD]{frequency} and \hyperref[DD:periodSHMDD]{period} respectively
         
-\\ \midrule \\
+\\ \midrule
 Source & --
          
-\\ \midrule \\
+\\ \midrule
 RefBy & 
 \\ \bottomrule
 \end{tabular}
@@ -861,34 +861,34 @@ This section collects and defines all the data needed to build the instance mode
 \toprule \textbf{Refname} & \textbf{DD:positionIX}
 \phantomsection 
 \label{DD:positionIX}
-\\ \midrule \\
+\\ \midrule
 Label & $x$-component of initial position
         
-\\ \midrule \\
+\\ \midrule
 Symbol & ${{p_{\text{x}}}^{\text{i}}}$
          
-\\ \midrule \\
+\\ \midrule
 Units & ${\text{m}}$
         
-\\ \midrule \\
+\\ \midrule
 Equation & \begin{displaymath}
            {{p_{\text{x}}}^{\text{i}}}={L_{\text{rod}}} \sin\left({θ_{i}}\right)
            \end{displaymath}
-\\ \midrule \\
+\\ \midrule
 Description & \begin{symbDescription}
               \item{${{p_{\text{x}}}^{\text{i}}}$ is the $x$-component of initial position (${\text{m}}$)}
               \item{${L_{\text{rod}}}$ is the length of the rod (${\text{m}}$)}
               \item{${θ_{i}}$ is the initial pendulum angle (${\text{rad}}$)}
               \end{symbDescription}
-\\ \midrule \\
+\\ \midrule
 Notes & ${{p_{\text{x}}}^{\text{i}}}$ is the horizontal position
         
         ${{p_{\text{x}}}^{\text{i}}}$ is shown in \hyperref[Figure:sglpendulum]{Fig:sglpendulum}.
         
-\\ \midrule \\
+\\ \midrule
 Source & --
          
-\\ \midrule \\
+\\ \midrule
 RefBy & 
 \\ \bottomrule
 \end{tabular}
@@ -901,34 +901,34 @@ RefBy &
 \toprule \textbf{Refname} & \textbf{DD:positionIY}
 \phantomsection 
 \label{DD:positionIY}
-\\ \midrule \\
+\\ \midrule
 Label & $y$-component of initial position
         
-\\ \midrule \\
+\\ \midrule
 Symbol & ${{p_{\text{y}}}^{\text{i}}}$
          
-\\ \midrule \\
+\\ \midrule
 Units & ${\text{m}}$
         
-\\ \midrule \\
+\\ \midrule
 Equation & \begin{displaymath}
            {{p_{\text{y}}}^{\text{i}}}=-{L_{\text{rod}}} \cos\left({θ_{i}}\right)
            \end{displaymath}
-\\ \midrule \\
+\\ \midrule
 Description & \begin{symbDescription}
               \item{${{p_{\text{y}}}^{\text{i}}}$ is the $y$-component of initial position (${\text{m}}$)}
               \item{${L_{\text{rod}}}$ is the length of the rod (${\text{m}}$)}
               \item{${θ_{i}}$ is the initial pendulum angle (${\text{rad}}$)}
               \end{symbDescription}
-\\ \midrule \\
+\\ \midrule
 Notes & ${{p_{\text{y}}}^{\text{i}}}$ is the vertical position
         
         ${{p_{\text{y}}}^{\text{i}}}$ is shown in \hyperref[Figure:sglpendulum]{Fig:sglpendulum}.
         
-\\ \midrule \\
+\\ \midrule
 Source & --
          
-\\ \midrule \\
+\\ \midrule
 RefBy & 
 \\ \bottomrule
 \end{tabular}
@@ -941,31 +941,31 @@ RefBy &
 \toprule \textbf{Refname} & \textbf{DD:frequencyDD}
 \phantomsection 
 \label{DD:frequencyDD}
-\\ \midrule \\
+\\ \midrule
 Label & Frequency
         
-\\ \midrule \\
+\\ \midrule
 Symbol & $f$
          
-\\ \midrule \\
+\\ \midrule
 Units & ${\text{Hz}}$
         
-\\ \midrule \\
+\\ \midrule
 Equation & \begin{displaymath}
            f=\frac{1}{T}
            \end{displaymath}
-\\ \midrule \\
+\\ \midrule
 Description & \begin{symbDescription}
               \item{$f$ is the frequency (${\text{Hz}}$)}
               \item{$T$ is the period (${\text{s}}$)}
               \end{symbDescription}
-\\ \midrule \\
+\\ \midrule
 Notes & $f$ is the number of back and forth swings in one second
         
-\\ \midrule \\
+\\ \midrule
 Source & --
          
-\\ \midrule \\
+\\ \midrule
 RefBy & \hyperref[GD:periodPend]{GD:periodPend}, \hyperref[DD:periodSHMDD]{DD:periodSHMDD}, and \hyperref[GD:angFrequencyGD]{GD:angFrequencyGD}
         
 \\ \bottomrule
@@ -979,32 +979,32 @@ RefBy & \hyperref[GD:periodPend]{GD:periodPend}, \hyperref[DD:periodSHMDD]{DD:pe
 \toprule \textbf{Refname} & \textbf{DD:angFrequencyDD}
 \phantomsection 
 \label{DD:angFrequencyDD}
-\\ \midrule \\
+\\ \midrule
 Label & Angular frequency
         
-\\ \midrule \\
+\\ \midrule
 Symbol & $Ω$
          
-\\ \midrule \\
+\\ \midrule
 Units & ${\text{s}}$
         
-\\ \midrule \\
+\\ \midrule
 Equation & \begin{displaymath}
            Ω=\frac{2 π}{T}
            \end{displaymath}
-\\ \midrule \\
+\\ \midrule
 Description & \begin{symbDescription}
               \item{$Ω$ is the angular frequency (${\text{s}}$)}
               \item{$π$ is the ratio of circumference to diameter for any circle (Unitless)}
               \item{$T$ is the period (${\text{s}}$)}
               \end{symbDescription}
-\\ \midrule \\
+\\ \midrule
 Notes & $T$ is from \hyperref[DD:periodSHMDD]{DD:periodSHMDD}
         
-\\ \midrule \\
+\\ \midrule
 Source & --
          
-\\ \midrule \\
+\\ \midrule
 RefBy & \hyperref[GD:periodPend]{GD:periodPend}
         
 \\ \bottomrule
@@ -1018,31 +1018,31 @@ RefBy & \hyperref[GD:periodPend]{GD:periodPend}
 \toprule \textbf{Refname} & \textbf{DD:periodSHMDD}
 \phantomsection 
 \label{DD:periodSHMDD}
-\\ \midrule \\
+\\ \midrule
 Label & Period
         
-\\ \midrule \\
+\\ \midrule
 Symbol & $T$
          
-\\ \midrule \\
+\\ \midrule
 Units & ${\text{s}}$
         
-\\ \midrule \\
+\\ \midrule
 Equation & \begin{displaymath}
            T=\frac{1}{f}
            \end{displaymath}
-\\ \midrule \\
+\\ \midrule
 Description & \begin{symbDescription}
               \item{$T$ is the period (${\text{s}}$)}
               \item{$f$ is the frequency (${\text{Hz}}$)}
               \end{symbDescription}
-\\ \midrule \\
+\\ \midrule
 Notes & $T$ is from \hyperref[DD:frequencyDD]{DD:frequencyDD}
         
-\\ \midrule \\
+\\ \midrule
 Source & --
          
-\\ \midrule \\
+\\ \midrule
 RefBy & \hyperref[GD:periodPend]{GD:periodPend} and \hyperref[DD:angFrequencyDD]{DD:angFrequencyDD}
         
 \\ \bottomrule
@@ -1060,16 +1060,16 @@ This section transforms the problem defined in the \hyperref[Sec:ProbDesc]{probl
 \toprule \textbf{Refname} & \textbf{IM:calOfAngularDisplacement}
 \phantomsection 
 \label{IM:calOfAngularDisplacement}
-\\ \midrule \\
+\\ \midrule
 Label & Calculation of angular displacement
         
-\\ \midrule \\
+\\ \midrule
 Input & ${L_{\text{rod}}}$, ${θ_{i}}$, $\symbf{g}$
         
-\\ \midrule \\
+\\ \midrule
 Output & ${θ_{p}}$
          
-\\ \midrule \\
+\\ \midrule
 Input Constraints & \begin{displaymath}
                     {L_{\text{rod}}}\gt{}0
                     \end{displaymath}
@@ -1079,28 +1079,28 @@ Input Constraints & \begin{displaymath}
                     \begin{displaymath}
                     \symbf{g}\gt{}0
                     \end{displaymath}
-\\ \midrule \\
+\\ \midrule
 Output Constraints & \begin{displaymath}
                      {θ_{p}}\gt{}0
                      \end{displaymath}
-\\ \midrule \\
+\\ \midrule
 Equation & \begin{displaymath}
            {θ_{p}}\left(t\right)={θ_{i}} \cos\left(Ω t\right)
            \end{displaymath}
-\\ \midrule \\
+\\ \midrule
 Description & \begin{symbDescription}
               \item{${θ_{p}}$ is the displacement angle of the pendulum (${\text{rad}}$)}
               \item{$t$ is the time (${\text{s}}$)}
               \item{${θ_{i}}$ is the initial pendulum angle (${\text{rad}}$)}
               \item{$Ω$ is the angular frequency (${\text{s}}$)}
               \end{symbDescription}
-\\ \midrule \\
+\\ \midrule
 Notes & The constraint ${θ_{i}}\gt{}0$ is required. The angular frequency is defined in \hyperref[GD:angFrequencyGD]{GD:angFrequencyGD}.
         
-\\ \midrule \\
+\\ \midrule
 Source & --
          
-\\ \midrule \\
+\\ \midrule
 RefBy & \hyperref[outputValues]{FR:Output-Values} and \hyperref[calcAngPos]{FR:Calculate-Angular-Position-Of-Mass}
         
 \\ \bottomrule

--- a/code/stable/ssp/SRS/PDF/SSP_SRS.tex
+++ b/code/stable/ssp/SRS/PDF/SSP_SRS.tex
@@ -480,23 +480,23 @@ This section focuses on the general equations and laws that SSP is based on.
 \toprule \textbf{Refname} & \textbf{TM:factOfSafety}
 \phantomsection 
 \label{TM:factOfSafety}
-\\ \midrule \\
+\\ \midrule
 Label & Factor of safety
         
-\\ \midrule \\
+\\ \midrule
 Equation & \begin{displaymath}
            {F_{\text{S}}}=\frac{P}{S}
            \end{displaymath}
-\\ \midrule \\
+\\ \midrule
 Description & \begin{symbDescription}
               \item{${F_{\text{S}}}$ is the factor of safety (Unitless)}
               \item{$P$ is the resistive shear force (${\text{N}}$)}
               \item{$S$ is the mobilized shear force (${\text{N}}$)}
               \end{symbDescription}
-\\ \midrule \\
+\\ \midrule
 Source & \cite{fredlund1977}
          
-\\ \midrule \\
+\\ \midrule
 RefBy & \hyperref[GD:mobShr]{GD:mobShr}
         
 \\ \bottomrule
@@ -509,10 +509,10 @@ RefBy & \hyperref[GD:mobShr]{GD:mobShr}
 \toprule \textbf{Refname} & \textbf{TM:equilibrium}
 \phantomsection 
 \label{TM:equilibrium}
-\\ \midrule \\
+\\ \midrule
 Label & Equilibrium
         
-\\ \midrule \\
+\\ \midrule
 Equation & \begin{displaymath}
            \displaystyle\sum{{F_{\text{x}}}}=0
            \end{displaymath}
@@ -522,7 +522,7 @@ Equation & \begin{displaymath}
            \begin{displaymath}
            \displaystyle\sum{M}=0
            \end{displaymath}
-\\ \midrule \\
+\\ \midrule
 Description & \begin{symbDescription}
               \item{${F_{\text{x}}}$ is the $x$-coordinate of the force (${\text{N}}$)}
               \end{symbDescription}
@@ -532,13 +532,13 @@ Description & \begin{symbDescription}
               \begin{symbDescription}
               \item{$M$ is the moment ($\text{N}\text{m}$)}
               \end{symbDescription}
-\\ \midrule \\
+\\ \midrule
 Notes & For a body in static equilibrium, the net forces and moments acting on the body will cancel out. Assuming a 2D problem (\hyperref[assumpENSL]{A:Effective-Norm-Stress-Large}), the $x$-coordinate of the force ${F_{\text{x}}}$ and $y$-coordinate of the force ${F_{\text{y}}}$ will be equal to $0$. All forces and their distance from the chosen point of rotation will create a net moment equal to $0$.
         
-\\ \midrule \\
+\\ \midrule
 Source & \cite{fredlund1977}
          
-\\ \midrule \\
+\\ \midrule
 RefBy & \hyperref[GD:normForcEq]{GD:normForcEq}, \hyperref[GD:momentEql]{GD:momentEql}, and \hyperref[GD:bsShrFEq]{GD:bsShrFEq}
         
 \\ \bottomrule
@@ -551,27 +551,27 @@ RefBy & \hyperref[GD:normForcEq]{GD:normForcEq}, \hyperref[GD:momentEql]{GD:mome
 \toprule \textbf{Refname} & \textbf{TM:mcShrStrgth}
 \phantomsection 
 \label{TM:mcShrStrgth}
-\\ \midrule \\
+\\ \midrule
 Label & Mohr-Coulumb shear strength
         
-\\ \midrule \\
+\\ \midrule
 Equation & \begin{displaymath}
            {τ^{\text{f}}}={σ_{N}}' \tan\left(φ'\right)+c'
            \end{displaymath}
-\\ \midrule \\
+\\ \midrule
 Description & \begin{symbDescription}
               \item{${τ^{\text{f}}}$ is the shear strength (${\text{Pa}}$)}
               \item{${σ_{N}}'$ is the effective normal stress (${\text{Pa}}$)}
               \item{$φ'$ is the effective angle of friction (${{}^{\circ}}$)}
               \item{$c'$ is the effective cohesion (${\text{Pa}}$)}
               \end{symbDescription}
-\\ \midrule \\
+\\ \midrule
 Notes & In this model the shear strength ${τ^{\text{f}}}$ is proportional to the product of the effective normal stress ${σ_{N}}'$ on the plane with its static friction in the angular form $\tan\left(φ'\right)$. The ${τ^{\text{f}}}$ versus ${σ_{N}}'$ relationship is not truly linear, but assuming the effective normal forces is strong enough, it can be approximated with a linear fit (\hyperref[assumpSBSBISL]{A:Surface-Base-Slice-between-Interslice-Straight-Lines}) where the effective cohesion $c'$ represents the ${τ^{\text{f}}}$ intercept of the fitted line.
         
-\\ \midrule \\
+\\ \midrule
 Source & \cite{fredlund1977}
          
-\\ \midrule \\
+\\ \midrule
 RefBy & \hyperref[GD:resShr]{GD:resShr}
         
 \\ \bottomrule
@@ -584,26 +584,26 @@ RefBy & \hyperref[GD:resShr]{GD:resShr}
 \toprule \textbf{Refname} & \textbf{TM:effStress}
 \phantomsection 
 \label{TM:effStress}
-\\ \midrule \\
+\\ \midrule
 Label & Effective stress
         
-\\ \midrule \\
+\\ \midrule
 Equation & \begin{displaymath}
            σ'=σ-u
            \end{displaymath}
-\\ \midrule \\
+\\ \midrule
 Description & \begin{symbDescription}
               \item{$σ'$ is the effective stress (${\text{Pa}}$)}
               \item{$σ$ is the total normal stress (${\text{Pa}}$)}
               \item{$u$ is the pore pressure (${\text{Pa}}$)}
               \end{symbDescription}
-\\ \midrule \\
+\\ \midrule
 Notes & $σ$ is defined in \hyperref[DD:normStress]{DD:normStress}.
         
-\\ \midrule \\
+\\ \midrule
 Source & \cite{fredlund1977}
          
-\\ \midrule \\
+\\ \midrule
 RefBy & \hyperref[GD:effNormF]{GD:effNormF}
         
 \\ \bottomrule
@@ -616,26 +616,26 @@ RefBy & \hyperref[GD:effNormF]{GD:effNormF}
 \toprule \textbf{Refname} & \textbf{TM:NewtonSecLawMot}
 \phantomsection 
 \label{TM:NewtonSecLawMot}
-\\ \midrule \\
+\\ \midrule
 Label & Newton's second law of motion
         
-\\ \midrule \\
+\\ \midrule
 Equation & \begin{displaymath}
            \symbf{F}=m \symbf{a}\text{(}t\text{)}
            \end{displaymath}
-\\ \midrule \\
+\\ \midrule
 Description & \begin{symbDescription}
               \item{$\symbf{F}$ is the force (${\text{N}}$)}
               \item{$m$ is the mass (${\text{kg}}$)}
               \item{$\symbf{a}\text{(}t\text{)}$ is the acceleration ($\frac{\text{m}}{\text{s}^{2}}$)}
               \end{symbDescription}
-\\ \midrule \\
+\\ \midrule
 Notes & The net force $\symbf{F}$ on a body is proportional to the acceleration $\symbf{a}\text{(}t\text{)}$ of the body, where $m$ denotes the mass of the body as the constant of proportionality.
         
-\\ \midrule \\
+\\ \midrule
 Source & --
          
-\\ \midrule \\
+\\ \midrule
 RefBy & \hyperref[GD:weight]{GD:weight}
         
 \\ \bottomrule
@@ -652,17 +652,17 @@ This section collects the laws and equations that will be used to build the inst
 \toprule \textbf{Refname} & \textbf{GD:normForcEq}
 \phantomsection 
 \label{GD:normForcEq}
-\\ \midrule \\
+\\ \midrule
 Label & Normal force equilibrium
         
-\\ \midrule \\
+\\ \midrule
 Units & $\frac{\text{N}}{\text{m}}$
         
-\\ \midrule \\
+\\ \midrule
 Equation & \begin{displaymath}
            {\symbf{N}}_{i}=\left({\symbf{W}}_{i}-{\symbf{X}}_{i-1}+{\symbf{X}}_{i}+{\symbf{U}_{\text{g},i}} \cos\left({\symbf{β}}_{i}\right)+{\symbf{Q}}_{i} \cos\left({\symbf{ω}}_{i}\right)\right) \cos\left({\symbf{α}}_{i}\right)+\left(-{K_{\text{c}}} {\symbf{W}}_{i}-{\symbf{G}}_{i}+{\symbf{G}}_{i-1}-{\symbf{H}}_{i}+{\symbf{H}}_{i-1}+{\symbf{U}_{\text{g},i}} \sin\left({\symbf{β}}_{i}\right)+{\symbf{Q}}_{i} \sin\left({\symbf{ω}}_{i}\right)\right) \sin\left({\symbf{α}}_{i}\right)
            \end{displaymath}
-\\ \midrule \\
+\\ \midrule
 Description & \begin{symbDescription}
               \item{$\symbf{N}$ is the normal forces ($\frac{\text{N}}{\text{m}}$)}
               \item{$i$ is the index (Unitless)}
@@ -677,13 +677,13 @@ Description & \begin{symbDescription}
               \item{$\symbf{G}$ is the interslice normal forces ($\frac{\text{N}}{\text{m}}$)}
               \item{$\symbf{H}$ is the interslice normal water forces ($\frac{\text{N}}{\text{m}}$)}
               \end{symbDescription}
-\\ \midrule \\
+\\ \midrule
 Notes & This equation satisfies \hyperref[TM:equilibrium]{TM:equilibrium} in the normal direction. $\symbf{W}$ is defined in \hyperref[GD:sliceWght]{GD:sliceWght}, ${\symbf{U}_{\text{g}}}$ is defined in \hyperref[GD:srfWtrF]{GD:srfWtrF}, $\symbf{β}$ is defined in \hyperref[DD:angleB]{DD:angleB}, and $\symbf{α}$ is defined in \hyperref[DD:angleA]{DD:angleA}.
         
-\\ \midrule \\
+\\ \midrule
 Source & \cite{chen2005}
          
-\\ \midrule \\
+\\ \midrule
 RefBy & \hyperref[IM:fctSfty]{IM:fctSfty}
         
 \\ \bottomrule
@@ -700,17 +700,17 @@ Normal force equilibrium is derived from the free body diagram of \hyperref[Figu
 \toprule \textbf{Refname} & \textbf{GD:bsShrFEq}
 \phantomsection 
 \label{GD:bsShrFEq}
-\\ \midrule \\
+\\ \midrule
 Label & Base shear force equilibrium
         
-\\ \midrule \\
+\\ \midrule
 Units & $\frac{\text{N}}{\text{m}}$
         
-\\ \midrule \\
+\\ \midrule
 Equation & \begin{displaymath}
            {\symbf{S}}_{i}=\left({\symbf{W}}_{i}-{\symbf{X}}_{i-1}+{\symbf{X}}_{i}+{\symbf{U}_{\text{g},i}} \cos\left({\symbf{β}}_{i}\right)+{\symbf{Q}}_{i} \cos\left({\symbf{ω}}_{i}\right)\right) \sin\left({\symbf{α}}_{i}\right)-\left(-{K_{\text{c}}} {\symbf{W}}_{i}-{\symbf{G}}_{i}+{\symbf{G}}_{i-1}-{\symbf{H}}_{i}+{\symbf{H}}_{i-1}+{\symbf{U}_{\text{g},i}} \sin\left({\symbf{β}}_{i}\right)+{\symbf{Q}}_{i} \sin\left({\symbf{ω}}_{i}\right)\right) \cos\left({\symbf{α}}_{i}\right)
            \end{displaymath}
-\\ \midrule \\
+\\ \midrule
 Description & \begin{symbDescription}
               \item{$\symbf{S}$ is the mobilized shear force ($\frac{\text{N}}{\text{m}}$)}
               \item{$i$ is the index (Unitless)}
@@ -725,13 +725,13 @@ Description & \begin{symbDescription}
               \item{$\symbf{G}$ is the interslice normal forces ($\frac{\text{N}}{\text{m}}$)}
               \item{$\symbf{H}$ is the interslice normal water forces ($\frac{\text{N}}{\text{m}}$)}
               \end{symbDescription}
-\\ \midrule \\
+\\ \midrule
 Notes & This equation satisfies \hyperref[TM:equilibrium]{TM:equilibrium} in the shear direction. $\symbf{W}$ is defined in \hyperref[GD:sliceWght]{GD:sliceWght}, ${\symbf{U}_{\text{g}}}$ is defined in \hyperref[GD:srfWtrF]{GD:srfWtrF}, $\symbf{β}$ is defined in \hyperref[DD:angleB]{DD:angleB}, and $\symbf{α}$ is defined in \hyperref[DD:angleA]{DD:angleA}.
         
-\\ \midrule \\
+\\ \midrule
 Source & \cite{chen2005}
          
-\\ \midrule \\
+\\ \midrule
 RefBy & \hyperref[IM:fctSfty]{IM:fctSfty}
         
 \\ \bottomrule
@@ -748,17 +748,17 @@ Base shear force equilibrium is derived from the free body diagram of \hyperref[
 \toprule \textbf{Refname} & \textbf{GD:resShr}
 \phantomsection 
 \label{GD:resShr}
-\\ \midrule \\
+\\ \midrule
 Label & Resistive shear force
         
-\\ \midrule \\
+\\ \midrule
 Units & $\frac{\text{N}}{\text{m}}$
         
-\\ \midrule \\
+\\ \midrule
 Equation & \begin{displaymath}
            {\symbf{P}}_{i}={\symbf{N'}}_{i} \tan\left({φ'}_{i}\right)+{c'}_{i} {\symbf{L}_{b,i}}
            \end{displaymath}
-\\ \midrule \\
+\\ \midrule
 Description & \begin{symbDescription}
               \item{$\symbf{P}$ is the resistive shear forces ($\frac{\text{N}}{\text{m}}$)}
               \item{$i$ is the index (Unitless)}
@@ -767,13 +767,13 @@ Description & \begin{symbDescription}
               \item{$c'$ is the effective cohesion (${\text{Pa}}$)}
               \item{${\symbf{L}_{b}}$ is the total base lengths of slices (${\text{m}}$)}
               \end{symbDescription}
-\\ \midrule \\
+\\ \midrule
 Notes & ${\symbf{L}_{b}}$ is defined in \hyperref[DD:lengthLb]{DD:lengthLb}.
         
-\\ \midrule \\
+\\ \midrule
 Source & \cite{chen2005}
          
-\\ \midrule \\
+\\ \midrule
 RefBy & \hyperref[GD:mobShr]{GD:mobShr}
         
 \\ \bottomrule
@@ -790,17 +790,17 @@ Derived by substituting \hyperref[DD:normStress]{DD:normStress} and \hyperref[DD
 \toprule \textbf{Refname} & \textbf{GD:mobShr}
 \phantomsection 
 \label{GD:mobShr}
-\\ \midrule \\
+\\ \midrule
 Label & Mobilized shear force
         
-\\ \midrule \\
+\\ \midrule
 Units & $\frac{\text{N}}{\text{m}}$
         
-\\ \midrule \\
+\\ \midrule
 Equation & \begin{displaymath}
            {\symbf{S}}_{i}=\frac{{\symbf{P}}_{i}}{{F_{\text{S}}}}=\frac{{\symbf{N'}}_{i} \tan\left({φ'}_{i}\right)+{c'}_{i} {\symbf{L}_{b,i}}}{{F_{\text{S}}}}
            \end{displaymath}
-\\ \midrule \\
+\\ \midrule
 Description & \begin{symbDescription}
               \item{$\symbf{S}$ is the mobilized shear force ($\frac{\text{N}}{\text{m}}$)}
               \item{$i$ is the index (Unitless)}
@@ -811,13 +811,13 @@ Description & \begin{symbDescription}
               \item{$c'$ is the effective cohesion (${\text{Pa}}$)}
               \item{${\symbf{L}_{b}}$ is the total base lengths of slices (${\text{m}}$)}
               \end{symbDescription}
-\\ \midrule \\
+\\ \midrule
 Notes & ${\symbf{L}_{b}}$ is defined in \hyperref[DD:lengthLb]{DD:lengthLb}.
         
-\\ \midrule \\
+\\ \midrule
 Source & \cite{chen2005}
          
-\\ \midrule \\
+\\ \midrule
 RefBy & \hyperref[IM:fctSfty]{IM:fctSfty}
         
 \\ \bottomrule
@@ -834,30 +834,30 @@ Mobilized shear forces is derived by dividing the definition of the $\symbf{P}$ 
 \toprule \textbf{Refname} & \textbf{GD:effNormF}
 \phantomsection 
 \label{GD:effNormF}
-\\ \midrule \\
+\\ \midrule
 Label & Effective normal force
         
-\\ \midrule \\
+\\ \midrule
 Units & $\frac{\text{N}}{\text{m}}$
         
-\\ \midrule \\
+\\ \midrule
 Equation & \begin{displaymath}
            {\symbf{N'}}_{i}={\symbf{N}}_{i}-{\symbf{U}_{\text{b},i}}
            \end{displaymath}
-\\ \midrule \\
+\\ \midrule
 Description & \begin{symbDescription}
               \item{$\symbf{N'}$ is the effective normal forces ($\frac{\text{N}}{\text{m}}$)}
               \item{$i$ is the index (Unitless)}
               \item{$\symbf{N}$ is the normal forces ($\frac{\text{N}}{\text{m}}$)}
               \item{${\symbf{U}_{\text{b}}}$ is the base hydrostatic forces ($\frac{\text{N}}{\text{m}}$)}
               \end{symbDescription}
-\\ \midrule \\
+\\ \midrule
 Notes & ${\symbf{U}_{\text{b}}}$ is defined in \hyperref[GD:baseWtrF]{GD:baseWtrF}.
         
-\\ \midrule \\
+\\ \midrule
 Source & \cite{chen2005}
          
-\\ \midrule \\
+\\ \midrule
 RefBy & 
 \\ \bottomrule
 \end{tabular}
@@ -873,17 +873,17 @@ Derived by substituting \hyperref[DD:normStress]{DD:normStress} into \hyperref[T
 \toprule \textbf{Refname} & \textbf{GD:resShearWO}
 \phantomsection 
 \label{GD:resShearWO}
-\\ \midrule \\
+\\ \midrule
 Label & Resistive shear force, without interslice normal and shear forces
         
-\\ \midrule \\
+\\ \midrule
 Units & $\frac{\text{N}}{\text{m}}$
         
-\\ \midrule \\
+\\ \midrule
 Equation & \begin{displaymath}
            {\symbf{R}}_{i}=\left(\left({\symbf{W}}_{i}+{\symbf{U}_{\text{g},i}} \cos\left({\symbf{β}}_{i}\right)\right) \cos\left({\symbf{α}}_{i}\right)+\left(-{\symbf{H}}_{i}+{\symbf{H}}_{i-1}+{\symbf{U}_{\text{g},i}} \sin\left({\symbf{β}}_{i}\right)\right) \sin\left({\symbf{α}}_{i}\right)-{\symbf{U}_{\text{b},i}}\right) \tan\left({φ'}_{i}\right)+{c'}_{i} {\symbf{L}_{b,i}}
            \end{displaymath}
-\\ \midrule \\
+\\ \midrule
 Description & \begin{symbDescription}
               \item{$\symbf{R}$ is the resistive shear forces without the influence of interslice forces ($\frac{\text{N}}{\text{m}}$)}
               \item{$i$ is the index (Unitless)}
@@ -897,13 +897,13 @@ Description & \begin{symbDescription}
               \item{$c'$ is the effective cohesion (${\text{Pa}}$)}
               \item{${\symbf{L}_{b}}$ is the total base lengths of slices (${\text{m}}$)}
               \end{symbDescription}
-\\ \midrule \\
+\\ \midrule
 Notes & $\symbf{W}$ is defined in \hyperref[GD:sliceWght]{GD:sliceWght}, ${\symbf{U}_{\text{g}}}$ is defined in \hyperref[GD:srfWtrF]{GD:srfWtrF}, $\symbf{β}$ is defined in \hyperref[DD:angleB]{DD:angleB}, $\symbf{α}$ is defined in \hyperref[DD:angleA]{DD:angleA}, $\symbf{H}$ is defined in \hyperref[DD:intersliceWtrF]{DD:intersliceWtrF}, ${\symbf{U}_{\text{b}}}$ is defined in \hyperref[GD:baseWtrF]{GD:baseWtrF}, and ${\symbf{L}_{b}}$ is defined in \hyperref[DD:lengthLb]{DD:lengthLb}.
         
-\\ \midrule \\
+\\ \midrule
 Source & \cite{chen2005} and \cite{karchewski2012}
          
-\\ \midrule \\
+\\ \midrule
 RefBy & \hyperref[IM:intsliceFs]{IM:intsliceFs} and \hyperref[IM:fctSfty]{IM:fctSfty}
         
 \\ \bottomrule
@@ -917,17 +917,17 @@ RefBy & \hyperref[IM:intsliceFs]{IM:intsliceFs} and \hyperref[IM:fctSfty]{IM:fct
 \toprule \textbf{Refname} & \textbf{GD:mobShearWO}
 \phantomsection 
 \label{GD:mobShearWO}
-\\ \midrule \\
+\\ \midrule
 Label & Mobilized shear force, without interslice normal and shear forces
         
-\\ \midrule \\
+\\ \midrule
 Units & $\frac{\text{N}}{\text{m}}$
         
-\\ \midrule \\
+\\ \midrule
 Equation & \begin{displaymath}
            {\symbf{T}}_{i}=\left({\symbf{W}}_{i}+{\symbf{U}_{\text{g},i}} \cos\left({\symbf{β}}_{i}\right)\right) \sin\left({\symbf{α}}_{i}\right)-\left(-{\symbf{H}}_{i}+{\symbf{H}}_{i-1}+{\symbf{U}_{\text{g},i}} \sin\left({\symbf{β}}_{i}\right)\right) \cos\left({\symbf{α}}_{i}\right)
            \end{displaymath}
-\\ \midrule \\
+\\ \midrule
 Description & \begin{symbDescription}
               \item{$\symbf{T}$ is the mobilized shear forces without the influence of interslice forces ($\frac{\text{N}}{\text{m}}$)}
               \item{$i$ is the index (Unitless)}
@@ -937,13 +937,13 @@ Description & \begin{symbDescription}
               \item{$\symbf{α}$ is the base angles (${{}^{\circ}}$)}
               \item{$\symbf{H}$ is the interslice normal water forces ($\frac{\text{N}}{\text{m}}$)}
               \end{symbDescription}
-\\ \midrule \\
+\\ \midrule
 Notes & $\symbf{W}$ is defined in \hyperref[GD:sliceWght]{GD:sliceWght}, ${\symbf{U}_{\text{g}}}$ is defined in \hyperref[GD:srfWtrF]{GD:srfWtrF}, $\symbf{β}$ is defined in \hyperref[DD:angleB]{DD:angleB}, $\symbf{α}$ is defined in \hyperref[DD:angleA]{DD:angleA}, and $\symbf{H}$ is defined in \hyperref[DD:intersliceWtrF]{DD:intersliceWtrF}.
         
-\\ \midrule \\
+\\ \midrule
 Source & \cite{chen2005} and \cite{karchewski2012}
          
-\\ \midrule \\
+\\ \midrule
 RefBy & \hyperref[IM:intsliceFs]{IM:intsliceFs} and \hyperref[IM:fctSfty]{IM:fctSfty}
         
 \\ \bottomrule
@@ -957,30 +957,30 @@ RefBy & \hyperref[IM:intsliceFs]{IM:intsliceFs} and \hyperref[IM:fctSfty]{IM:fct
 \toprule \textbf{Refname} & \textbf{GD:normShrR}
 \phantomsection 
 \label{GD:normShrR}
-\\ \midrule \\
+\\ \midrule
 Label & Interslice shear forces
         
-\\ \midrule \\
+\\ \midrule
 Units & $\frac{\text{N}}{\text{m}}$
         
-\\ \midrule \\
+\\ \midrule
 Equation & \begin{displaymath}
            \symbf{X}=λ \symbf{f} \symbf{G}
            \end{displaymath}
-\\ \midrule \\
+\\ \midrule
 Description & \begin{symbDescription}
               \item{$\symbf{X}$ is the interslice shear forces ($\frac{\text{N}}{\text{m}}$)}
               \item{$λ$ is the proportionality constant (Unitless)}
               \item{$\symbf{f}$ is the interslice normal to shear force ratio variation function (Unitless)}
               \item{$\symbf{G}$ is the interslice normal forces ($\frac{\text{N}}{\text{m}}$)}
               \end{symbDescription}
-\\ \midrule \\
+\\ \midrule
 Notes & Mathematical representation of the primary assumption for the Morgenstern-Price method (\hyperref[assumpINSFL]{A:Interslice-Norm-Shear-Forces-Linear}). $\symbf{f}$ is defined in \hyperref[DD:ratioVariation]{DD:ratioVariation}.
         
-\\ \midrule \\
+\\ \midrule
 Source & \cite{chen2005}
          
-\\ \midrule \\
+\\ \midrule
 RefBy & \hyperref[IM:nrmShrFor]{IM:nrmShrFor} and \hyperref[IM:fctSfty]{IM:fctSfty}
         
 \\ \bottomrule
@@ -994,17 +994,17 @@ RefBy & \hyperref[IM:nrmShrFor]{IM:nrmShrFor} and \hyperref[IM:fctSfty]{IM:fctSf
 \toprule \textbf{Refname} & \textbf{GD:momentEql}
 \phantomsection 
 \label{GD:momentEql}
-\\ \midrule \\
+\\ \midrule
 Label & Moment equilibrium
         
-\\ \midrule \\
+\\ \midrule
 Units & ${\text{N}}$
         
-\\ \midrule \\
+\\ \midrule
 Equation & \begin{displaymath}
            0=-{\symbf{G}}_{i} \left({\symbf{h}_{\text{z},i}}+\frac{{\symbf{b}}_{i}}{2} \tan\left({\symbf{α}}_{i}\right)\right)+{\symbf{G}}_{i-1} \left({\symbf{h}_{\text{z},i-1}}-\frac{{\symbf{b}}_{i}}{2} \tan\left({\symbf{α}}_{i}\right)\right)-{\symbf{H}}_{i} \left(\frac{1}{3} {\symbf{h}_{\text{z,w},i}}+\frac{{\symbf{b}}_{i}}{2} \tan\left({\symbf{α}}_{i}\right)\right)+{\symbf{H}}_{i-1} \left(\frac{1}{3} {\symbf{h}_{\text{z,w},i-1}}-\frac{{\symbf{b}}_{i}}{2} \tan\left({\symbf{α}}_{i}\right)\right)+\frac{{\symbf{b}}_{i}}{2} \left({\symbf{X}}_{i}+{\symbf{X}}_{i-1}\right)+\frac{-{K_{\text{c}}} {\symbf{W}}_{i} {\symbf{h}}_{i}}{2}+{\symbf{U}_{\text{g},i}} \sin\left({\symbf{β}}_{i}\right) {\symbf{h}}_{i}+{\symbf{Q}}_{i} \sin\left({\symbf{ω}}_{i}\right) {\symbf{h}}_{i}
            \end{displaymath}
-\\ \midrule \\
+\\ \midrule
 Description & \begin{symbDescription}
               \item{$\symbf{G}$ is the interslice normal forces ($\frac{\text{N}}{\text{m}}$)}
               \item{$i$ is the index (Unitless)}
@@ -1022,13 +1022,13 @@ Description & \begin{symbDescription}
               \item{$\symbf{Q}$ is the external forces ($\frac{\text{N}}{\text{m}}$)}
               \item{$\symbf{ω}$ is the imposed load angles (${{}^{\circ}}$)}
               \end{symbDescription}
-\\ \midrule \\
+\\ \midrule
 Notes & This equation satisfies \hyperref[TM:equilibrium]{TM:equilibrium} for the net moment. $\symbf{b}$ is defined in \hyperref[DD:lengthB]{DD:lengthB}, $\symbf{α}$ is defined in \hyperref[DD:angleA]{DD:angleA}, $\symbf{W}$ is defined in \hyperref[GD:sliceWght]{GD:sliceWght}, $\symbf{h}$ is defined in \hyperref[DD:slcHeight]{DD:slcHeight}, ${\symbf{U}_{\text{g}}}$ is defined in \hyperref[GD:srfWtrF]{GD:srfWtrF}, and $\symbf{β}$ is defined in \hyperref[DD:angleB]{DD:angleB}.
         
-\\ \midrule \\
+\\ \midrule
 Source & \cite{chen2005}
          
-\\ \midrule \\
+\\ \midrule
 RefBy & \hyperref[IM:nrmShrFor]{IM:nrmShrFor}
         
 \\ \bottomrule
@@ -1113,26 +1113,26 @@ The base hydrostatic force and slice weight both act in the direction of the poi
 \toprule \textbf{Refname} & \textbf{GD:weight}
 \phantomsection 
 \label{GD:weight}
-\\ \midrule \\
+\\ \midrule
 Label & Weight
         
-\\ \midrule \\
+\\ \midrule
 Units & ${\text{N}}$
         
-\\ \midrule \\
+\\ \midrule
 Equation & \begin{displaymath}
            W=V γ
            \end{displaymath}
-\\ \midrule \\
+\\ \midrule
 Description & \begin{symbDescription}
               \item{$W$ is the weight (${\text{N}}$)}
               \item{$V$ is the volume (${\text{m}^{3}}$)}
               \item{$γ$ is the specific weight ($\frac{\text{N}}{\text{m}^{3}}$)}
               \end{symbDescription}
-\\ \midrule \\
+\\ \midrule
 Source & \hyperref{https://en.wikipedia.org/wiki/Weight}{}{}{Definition of Weight}
          
-\\ \midrule \\
+\\ \midrule
 RefBy & \hyperref[GD:sliceWght]{GD:sliceWght} and \hyperref[GD:momentEql]{GD:momentEql}
         
 \\ \bottomrule
@@ -1170,13 +1170,13 @@ W=V γ
 \toprule \textbf{Refname} & \textbf{GD:sliceWght}
 \phantomsection 
 \label{GD:sliceWght}
-\\ \midrule \\
+\\ \midrule
 Label & Slice weight
         
-\\ \midrule \\
+\\ \midrule
 Units & $\frac{\text{N}}{\text{m}}$
         
-\\ \midrule \\
+\\ \midrule
 Equation & \begin{displaymath}
            {\symbf{W}}_{i}={\symbf{b}}_{i} \frac{1}{2} \begin{cases}
                                                        \left({\symbf{y}_{\text{slope},i}}-{\symbf{y}_{\text{slip},i}}+{\symbf{y}_{\text{slope},i-1}}-{\symbf{y}_{\text{slip},i-1}}\right) {γ_{\text{sat}}}, & {\symbf{y}_{\text{wt},i}}\gt{}{\symbf{y}_{\text{slope},i}}\lor{}{\symbf{y}_{\text{wt},i-1}}\gt{}{\symbf{y}_{\text{slope},i-1}}\\
@@ -1184,7 +1184,7 @@ Equation & \begin{displaymath}
                                                        \left({\symbf{y}_{\text{slope},i}}-{\symbf{y}_{\text{slip},i}}+{\symbf{y}_{\text{slope},i-1}}-{\symbf{y}_{\text{slip},i-1}}\right) {γ_{\text{dry}}}, & {\symbf{y}_{\text{wt},i}}\lt{}{\symbf{y}_{\text{slip},i}}\lor{}{\symbf{y}_{\text{wt},i-1}}\lt{}{\symbf{y}_{\text{slip},i-1}}
                                                        \end{cases}
            \end{displaymath}
-\\ \midrule \\
+\\ \midrule
 Description & \begin{symbDescription}
               \item{$\symbf{W}$ is the weights ($\frac{\text{N}}{\text{m}}$)}
               \item{$i$ is the index (Unitless)}
@@ -1195,13 +1195,13 @@ Description & \begin{symbDescription}
               \item{${\symbf{y}_{\text{wt}}}$ is the $y$-coordinates of the water table (${\text{m}}$)}
               \item{${γ_{\text{dry}}}$ is the soil dry unit weight ($\frac{\text{N}}{\text{m}^{3}}$)}
               \end{symbDescription}
-\\ \midrule \\
+\\ \midrule
 Notes & This equation is based on the assumption that the surface and the base of a slice are straight lines (\hyperref[assumpSBSBISL]{A:Surface-Base-Slice-between-Interslice-Straight-Lines}). The soil dry unit weight ${γ_{\text{dry}}}$ and the soil saturated unit weight ${γ_{\text{sat}}}$ are not indexed by $i$ because the soil is assumed to be homogeneous, with constant soil properties throughout (\hyperref[assumpSLH]{A:Soil-Layer-Homogeneous}). $\symbf{b}$ is defined in \hyperref[DD:lengthB]{DD:lengthB}.
         
-\\ \midrule \\
+\\ \midrule
 Source & \cite{fredlund1977}
          
-\\ \midrule \\
+\\ \midrule
 RefBy & \hyperref[GD:resShearWO]{GD:resShearWO}, \hyperref[GD:normForcEq]{GD:normForcEq}, \hyperref[GD:momentEql]{GD:momentEql}, \hyperref[GD:mobShearWO]{GD:mobShearWO}, and \hyperref[GD:bsShrFEq]{GD:bsShrFEq}
         
 \\ \bottomrule
@@ -1246,29 +1246,29 @@ For the case where the water table is between the slope surface and slip surface
 \toprule \textbf{Refname} & \textbf{GD:hsPressure}
 \phantomsection 
 \label{GD:hsPressure}
-\\ \midrule \\
+\\ \midrule
 Label & Hydrostatic pressure
         
-\\ \midrule \\
+\\ \midrule
 Units & ${\text{Pa}}$
         
-\\ \midrule \\
+\\ \midrule
 Equation & \begin{displaymath}
            p=γ h
            \end{displaymath}
-\\ \midrule \\
+\\ \midrule
 Description & \begin{symbDescription}
               \item{$p$ is the pressure (${\text{Pa}}$)}
               \item{$γ$ is the specific weight ($\frac{\text{N}}{\text{m}^{3}}$)}
               \item{$h$ is the height (${\text{m}}$)}
               \end{symbDescription}
-\\ \midrule \\
+\\ \midrule
 Notes & This equation is derived from Bernoulli's equation for a slow moving fluid through a porous material.
         
-\\ \midrule \\
+\\ \midrule
 Source & \hyperref{https://en.wikipedia.org/wiki/Pressure}{}{}{Definition of Pressure}
          
-\\ \midrule \\
+\\ \midrule
 RefBy & \hyperref[GD:srfWtrF]{GD:srfWtrF} and \hyperref[GD:baseWtrF]{GD:baseWtrF}
         
 \\ \bottomrule
@@ -1282,20 +1282,20 @@ RefBy & \hyperref[GD:srfWtrF]{GD:srfWtrF} and \hyperref[GD:baseWtrF]{GD:baseWtrF
 \toprule \textbf{Refname} & \textbf{GD:baseWtrF}
 \phantomsection 
 \label{GD:baseWtrF}
-\\ \midrule \\
+\\ \midrule
 Label & Base hydrostatic force
         
-\\ \midrule \\
+\\ \midrule
 Units & $\frac{\text{N}}{\text{m}}$
         
-\\ \midrule \\
+\\ \midrule
 Equation & \begin{displaymath}
            {\symbf{U}_{\text{b},i}}={\symbf{L}_{b,i}} {γ_{w}} \frac{1}{2} \begin{cases}
                                                                           {\symbf{y}_{\text{wt},i}}-{\symbf{y}_{\text{slip},i}}+{\symbf{y}_{\text{wt},i-1}}-{\symbf{y}_{\text{slip},i-1}}, & {\symbf{y}_{\text{wt},i}}\gt{}{\symbf{y}_{\text{slip},i}}\lor{}{\symbf{y}_{\text{wt},i-1}}\gt{}{\symbf{y}_{\text{slip},i-1}}\\
                                                                           0, & {\symbf{y}_{\text{wt},i}}\leq{}{\symbf{y}_{\text{slip},i}}\land{}{\symbf{y}_{\text{wt},i-1}}\leq{}{\symbf{y}_{\text{slip},i-1}}
                                                                           \end{cases}
            \end{displaymath}
-\\ \midrule \\
+\\ \midrule
 Description & \begin{symbDescription}
               \item{${\symbf{U}_{\text{b}}}$ is the base hydrostatic forces ($\frac{\text{N}}{\text{m}}$)}
               \item{$i$ is the index (Unitless)}
@@ -1304,13 +1304,13 @@ Description & \begin{symbDescription}
               \item{${\symbf{y}_{\text{wt}}}$ is the $y$-coordinates of the water table (${\text{m}}$)}
               \item{${\symbf{y}_{\text{slip}}}$ is the $y$-coordinates of the slip surface (${\text{m}}$)}
               \end{symbDescription}
-\\ \midrule \\
+\\ \midrule
 Notes & This equation is based on the assumption that the base of a slice is a straight line (\hyperref[assumpSBSBISL]{A:Surface-Base-Slice-between-Interslice-Straight-Lines}). ${\symbf{L}_{b}}$ is defined in \hyperref[DD:lengthLb]{DD:lengthLb}.
         
-\\ \midrule \\
+\\ \midrule
 Source & \cite{fredlund1977}
          
-\\ \midrule \\
+\\ \midrule
 RefBy & \hyperref[GD:resShearWO]{GD:resShearWO}, \hyperref[GD:effNormF]{GD:effNormF}, and \hyperref[GD:baseWtrF]{GD:baseWtrF}
         
 \\ \bottomrule
@@ -1342,20 +1342,20 @@ This equation is the non-zero case of \hyperref[GD:baseWtrF]{GD:baseWtrF}. The z
 \toprule \textbf{Refname} & \textbf{GD:srfWtrF}
 \phantomsection 
 \label{GD:srfWtrF}
-\\ \midrule \\
+\\ \midrule
 Label & Surface hydrostatic force
         
-\\ \midrule \\
+\\ \midrule
 Units & $\frac{\text{N}}{\text{m}}$
         
-\\ \midrule \\
+\\ \midrule
 Equation & \begin{displaymath}
            {\symbf{U}_{\text{g},i}}={\symbf{L}_{s,i}} {γ_{w}} \frac{1}{2} \begin{cases}
                                                                           {\symbf{y}_{\text{wt},i}}-{\symbf{y}_{\text{slope},i}}+{\symbf{y}_{\text{wt},i-1}}-{\symbf{y}_{\text{slope},i-1}}, & {\symbf{y}_{\text{wt},i}}\gt{}{\symbf{y}_{\text{slope},i}}\lor{}{\symbf{y}_{\text{wt},i-1}}\gt{}{\symbf{y}_{\text{slope},i-1}}\\
                                                                           0, & {\symbf{y}_{\text{wt},i}}\leq{}{\symbf{y}_{\text{slope},i}}\land{}{\symbf{y}_{\text{wt},i-1}}\leq{}{\symbf{y}_{\text{slope},i-1}}
                                                                           \end{cases}
            \end{displaymath}
-\\ \midrule \\
+\\ \midrule
 Description & \begin{symbDescription}
               \item{${\symbf{U}_{\text{g}}}$ is the surface hydrostatic forces ($\frac{\text{N}}{\text{m}}$)}
               \item{$i$ is the index (Unitless)}
@@ -1364,13 +1364,13 @@ Description & \begin{symbDescription}
               \item{${\symbf{y}_{\text{wt}}}$ is the $y$-coordinates of the water table (${\text{m}}$)}
               \item{${\symbf{y}_{\text{slope}}}$ is the $y$-coordinates of the slope (${\text{m}}$)}
               \end{symbDescription}
-\\ \midrule \\
+\\ \midrule
 Notes & This equation is based on the assumption that the surface of a slice is a straight line (\hyperref[assumpSBSBISL]{A:Surface-Base-Slice-between-Interslice-Straight-Lines}). ${\symbf{L}_{s}}$ is defined in \hyperref[DD:lengthLs]{DD:lengthLs}.
         
-\\ \midrule \\
+\\ \midrule
 Source & \cite{fredlund1977}
          
-\\ \midrule \\
+\\ \midrule
 RefBy & \hyperref[GD:srfWtrF]{GD:srfWtrF}, \hyperref[GD:resShearWO]{GD:resShearWO}, \hyperref[IM:nrmShrForNum]{IM:nrmShrForNum}, \hyperref[GD:normForcEq]{GD:normForcEq}, \hyperref[GD:momentEql]{GD:momentEql}, \hyperref[GD:mobShearWO]{GD:mobShearWO}, and \hyperref[GD:bsShrFEq]{GD:bsShrFEq}
         
 \\ \bottomrule
@@ -1406,16 +1406,16 @@ This section collects and defines all the data needed to build the instance mode
 \toprule \textbf{Refname} & \textbf{DD:intersliceWtrF}
 \phantomsection 
 \label{DD:intersliceWtrF}
-\\ \midrule \\
+\\ \midrule
 Label & Interslice normal water forces
         
-\\ \midrule \\
+\\ \midrule
 Symbol & $\symbf{H}$
          
-\\ \midrule \\
+\\ \midrule
 Units & $\frac{\text{N}}{\text{m}}$
         
-\\ \midrule \\
+\\ \midrule
 Equation & \begin{displaymath}
            \symbf{H}=\begin{cases}
                      \frac{\left({\symbf{y}_{\text{slope},i}}-{\symbf{y}_{\text{slip},i}}\right)^{2}}{2} {γ_{w}}+\left({\symbf{y}_{\text{wt},i}}-{\symbf{y}_{\text{slope},i}}\right)^{2} {γ_{w}}, & {\symbf{y}_{\text{wt},i}}\geq{}{\symbf{y}_{\text{slope},i}}\\
@@ -1423,7 +1423,7 @@ Equation & \begin{displaymath}
                      0, & {\symbf{y}_{\text{wt},i}}\leq{}{\symbf{y}_{\text{slip},i}}
                      \end{cases}
            \end{displaymath}
-\\ \midrule \\
+\\ \midrule
 Description & \begin{symbDescription}
               \item{$\symbf{H}$ is the interslice normal water forces ($\frac{\text{N}}{\text{m}}$)}
               \item{${\symbf{y}_{\text{slope}}}$ is the $y$-coordinates of the slope (${\text{m}}$)}
@@ -1432,10 +1432,10 @@ Description & \begin{symbDescription}
               \item{${γ_{w}}$ is the unit weight of water ($\frac{\text{N}}{\text{m}^{3}}$)}
               \item{${\symbf{y}_{\text{wt}}}$ is the $y$-coordinates of the water table (${\text{m}}$)}
               \end{symbDescription}
-\\ \midrule \\
+\\ \midrule
 Source & \cite{fredlund1977}
          
-\\ \midrule \\
+\\ \midrule
 RefBy & \hyperref[GD:resShearWO]{GD:resShearWO}, \hyperref[IM:nrmShrForNum]{IM:nrmShrForNum}, and \hyperref[GD:mobShearWO]{GD:mobShearWO}
         
 \\ \bottomrule
@@ -1449,33 +1449,33 @@ RefBy & \hyperref[GD:resShearWO]{GD:resShearWO}, \hyperref[IM:nrmShrForNum]{IM:n
 \toprule \textbf{Refname} & \textbf{DD:angleA}
 \phantomsection 
 \label{DD:angleA}
-\\ \midrule \\
+\\ \midrule
 Label & Base angles
         
-\\ \midrule \\
+\\ \midrule
 Symbol & $\symbf{α}$
          
-\\ \midrule \\
+\\ \midrule
 Units & ${{}^{\circ}}$
         
-\\ \midrule \\
+\\ \midrule
 Equation & \begin{displaymath}
            \symbf{α}=\arctan\left(\frac{{\symbf{y}_{\text{slip},i}}-{\symbf{y}_{\text{slip},i-1}}}{{\symbf{x}_{\text{slip},i}}-{\symbf{x}_{\text{slip},i-1}}}\right)
            \end{displaymath}
-\\ \midrule \\
+\\ \midrule
 Description & \begin{symbDescription}
               \item{$\symbf{α}$ is the base angles (${{}^{\circ}}$)}
               \item{${\symbf{y}_{\text{slip}}}$ is the $y$-coordinates of the slip surface (${\text{m}}$)}
               \item{$i$ is the index (Unitless)}
               \item{${\symbf{x}_{\text{slip}}}$ is the $x$-coordinates of the slip surface (${\text{m}}$)}
               \end{symbDescription}
-\\ \midrule \\
+\\ \midrule
 Notes & This equation is based on the assumption that the base of a slice is a straight line (\hyperref[assumpSBSBISL]{A:Surface-Base-Slice-between-Interslice-Straight-Lines}).
         
-\\ \midrule \\
+\\ \midrule
 Source & \cite{fredlund1977}
          
-\\ \midrule \\
+\\ \midrule
 RefBy & \hyperref[GD:resShearWO]{GD:resShearWO}, \hyperref[IM:nrmShrForNum]{IM:nrmShrForNum}, \hyperref[GD:normForcEq]{GD:normForcEq}, \hyperref[GD:momentEql]{GD:momentEql}, \hyperref[GD:mobShearWO]{GD:mobShearWO}, \hyperref[DD:lengthLb]{DD:lengthLb}, \hyperref[GD:bsShrFEq]{GD:bsShrFEq}, \hyperref[DD:convertFunc2]{DD:convertFunc2}, and \hyperref[DD:convertFunc1]{DD:convertFunc1}
         
 \\ \bottomrule
@@ -1489,33 +1489,33 @@ RefBy & \hyperref[GD:resShearWO]{GD:resShearWO}, \hyperref[IM:nrmShrForNum]{IM:n
 \toprule \textbf{Refname} & \textbf{DD:angleB}
 \phantomsection 
 \label{DD:angleB}
-\\ \midrule \\
+\\ \midrule
 Label & Surface angles
         
-\\ \midrule \\
+\\ \midrule
 Symbol & $\symbf{β}$
          
-\\ \midrule \\
+\\ \midrule
 Units & ${{}^{\circ}}$
         
-\\ \midrule \\
+\\ \midrule
 Equation & \begin{displaymath}
            \symbf{β}=\arctan\left(\frac{{\symbf{y}_{\text{slope},i}}-{\symbf{y}_{\text{slope},i-1}}}{{\symbf{x}_{\text{slope},i}}-{\symbf{x}_{\text{slope},i-1}}}\right)
            \end{displaymath}
-\\ \midrule \\
+\\ \midrule
 Description & \begin{symbDescription}
               \item{$\symbf{β}$ is the surface angles (${{}^{\circ}}$)}
               \item{${\symbf{y}_{\text{slope}}}$ is the $y$-coordinates of the slope (${\text{m}}$)}
               \item{$i$ is the index (Unitless)}
               \item{${\symbf{x}_{\text{slope}}}$ is the $x$-coordinates of the slope (${\text{m}}$)}
               \end{symbDescription}
-\\ \midrule \\
+\\ \midrule
 Notes & This equation is based on the assumption that the surface of a slice is a straight line (\hyperref[assumpSBSBISL]{A:Surface-Base-Slice-between-Interslice-Straight-Lines}).
         
-\\ \midrule \\
+\\ \midrule
 Source & \cite{fredlund1977}
          
-\\ \midrule \\
+\\ \midrule
 RefBy & \hyperref[GD:resShearWO]{GD:resShearWO}, \hyperref[IM:nrmShrForNum]{IM:nrmShrForNum}, \hyperref[GD:normForcEq]{GD:normForcEq}, \hyperref[GD:momentEql]{GD:momentEql}, \hyperref[GD:mobShearWO]{GD:mobShearWO}, \hyperref[DD:lengthLs]{DD:lengthLs}, and \hyperref[GD:bsShrFEq]{GD:bsShrFEq}
         
 \\ \bottomrule
@@ -1529,29 +1529,29 @@ RefBy & \hyperref[GD:resShearWO]{GD:resShearWO}, \hyperref[IM:nrmShrForNum]{IM:n
 \toprule \textbf{Refname} & \textbf{DD:lengthB}
 \phantomsection 
 \label{DD:lengthB}
-\\ \midrule \\
+\\ \midrule
 Label & Base width of slices
         
-\\ \midrule \\
+\\ \midrule
 Symbol & $\symbf{b}$
          
-\\ \midrule \\
+\\ \midrule
 Units & ${\text{m}}$
         
-\\ \midrule \\
+\\ \midrule
 Equation & \begin{displaymath}
            \symbf{b}={\symbf{x}_{\text{slip},i}}-{\symbf{x}_{\text{slip},i-1}}
            \end{displaymath}
-\\ \midrule \\
+\\ \midrule
 Description & \begin{symbDescription}
               \item{$\symbf{b}$ is the base width of slices (${\text{m}}$)}
               \item{${\symbf{x}_{\text{slip}}}$ is the $x$-coordinates of the slip surface (${\text{m}}$)}
               \item{$i$ is the index (Unitless)}
               \end{symbDescription}
-\\ \midrule \\
+\\ \midrule
 Source & \cite{fredlund1977}
          
-\\ \midrule \\
+\\ \midrule
 RefBy & \hyperref[GD:sliceWght]{GD:sliceWght}, \hyperref[IM:nrmShrForNum]{IM:nrmShrForNum}, \hyperref[IM:nrmShrForDen]{IM:nrmShrForDen}, \hyperref[GD:momentEql]{GD:momentEql}, \hyperref[DD:lengthLs]{DD:lengthLs}, and \hyperref[DD:lengthLb]{DD:lengthLb}
         
 \\ \bottomrule
@@ -1565,33 +1565,33 @@ RefBy & \hyperref[GD:sliceWght]{GD:sliceWght}, \hyperref[IM:nrmShrForNum]{IM:nrm
 \toprule \textbf{Refname} & \textbf{DD:lengthLb}
 \phantomsection 
 \label{DD:lengthLb}
-\\ \midrule \\
+\\ \midrule
 Label & Total base lengths of slices
         
-\\ \midrule \\
+\\ \midrule
 Symbol & ${\symbf{L}_{b}}$
          
-\\ \midrule \\
+\\ \midrule
 Units & ${\text{m}}$
         
-\\ \midrule \\
+\\ \midrule
 Equation & \begin{displaymath}
            {\symbf{L}_{b}}={\symbf{b}}_{i} \sec\left({\symbf{α}}_{i}\right)
            \end{displaymath}
-\\ \midrule \\
+\\ \midrule
 Description & \begin{symbDescription}
               \item{${\symbf{L}_{b}}$ is the total base lengths of slices (${\text{m}}$)}
               \item{$\symbf{b}$ is the base width of slices (${\text{m}}$)}
               \item{$i$ is the index (Unitless)}
               \item{$\symbf{α}$ is the base angles (${{}^{\circ}}$)}
               \end{symbDescription}
-\\ \midrule \\
+\\ \midrule
 Notes & $\symbf{b}$ is defined in \hyperref[DD:lengthB]{DD:lengthB} and $\symbf{α}$ is defined in \hyperref[DD:angleA]{DD:angleA}.
         
-\\ \midrule \\
+\\ \midrule
 Source & \cite{fredlund1977}
          
-\\ \midrule \\
+\\ \midrule
 RefBy & \hyperref[GD:resShr]{GD:resShr}, \hyperref[GD:resShearWO]{GD:resShearWO}, \hyperref[GD:mobShr]{GD:mobShr}, and \hyperref[GD:baseWtrF]{GD:baseWtrF}
         
 \\ \bottomrule
@@ -1605,33 +1605,33 @@ RefBy & \hyperref[GD:resShr]{GD:resShr}, \hyperref[GD:resShearWO]{GD:resShearWO}
 \toprule \textbf{Refname} & \textbf{DD:lengthLs}
 \phantomsection 
 \label{DD:lengthLs}
-\\ \midrule \\
+\\ \midrule
 Label & Surface lengths of slices
         
-\\ \midrule \\
+\\ \midrule
 Symbol & ${\symbf{L}_{s}}$
          
-\\ \midrule \\
+\\ \midrule
 Units & ${\text{m}}$
         
-\\ \midrule \\
+\\ \midrule
 Equation & \begin{displaymath}
            {\symbf{L}_{s}}={\symbf{b}}_{i} \sec\left({\symbf{β}}_{i}\right)
            \end{displaymath}
-\\ \midrule \\
+\\ \midrule
 Description & \begin{symbDescription}
               \item{${\symbf{L}_{s}}$ is the surface lengths of slices (${\text{m}}$)}
               \item{$\symbf{b}$ is the base width of slices (${\text{m}}$)}
               \item{$i$ is the index (Unitless)}
               \item{$\symbf{β}$ is the surface angles (${{}^{\circ}}$)}
               \end{symbDescription}
-\\ \midrule \\
+\\ \midrule
 Notes & $\symbf{b}$ is defined in \hyperref[DD:lengthB]{DD:lengthB} and $\symbf{β}$ is defined in \hyperref[DD:angleB]{DD:angleB}.
         
-\\ \midrule \\
+\\ \midrule
 Source & \cite{fredlund1977}
          
-\\ \midrule \\
+\\ \midrule
 RefBy & \hyperref[GD:srfWtrF]{GD:srfWtrF}
         
 \\ \bottomrule
@@ -1645,35 +1645,35 @@ RefBy & \hyperref[GD:srfWtrF]{GD:srfWtrF}
 \toprule \textbf{Refname} & \textbf{DD:slcHeight}
 \phantomsection 
 \label{DD:slcHeight}
-\\ \midrule \\
+\\ \midrule
 Label & $y$-direction heights of slices
         
-\\ \midrule \\
+\\ \midrule
 Symbol & $\symbf{h}$
          
-\\ \midrule \\
+\\ \midrule
 Units & ${\text{m}}$
         
-\\ \midrule \\
+\\ \midrule
 Equation & \begin{displaymath}
            \symbf{h}=\frac{1}{2} \left({{\symbf{h}^{\text{R}}}}_{i}+{{\symbf{h}^{\text{L}}}}_{i}\right)
            \end{displaymath}
-\\ \midrule \\
+\\ \midrule
 Description & \begin{symbDescription}
               \item{$\symbf{h}$ is the $y$-direction heights of slices (${\text{m}}$)}
               \item{${\symbf{h}^{\text{R}}}$ is the heights of the right side of slices (${\text{m}}$)}
               \item{$i$ is the index (Unitless)}
               \item{${\symbf{h}^{\text{L}}}$ is the heights of the left side of slices (${\text{m}}$)}
               \end{symbDescription}
-\\ \midrule \\
+\\ \midrule
 Notes & This equation is based on the assumption that the surface and base of a slice are straight lines (\hyperref[assumpSBSBISL]{A:Surface-Base-Slice-between-Interslice-Straight-Lines}).
         
         ${\symbf{h}^{\text{R}}}$ and ${\symbf{h}^{\text{L}}}$ are defined in \hyperref[DD:sliceHghtRightDD]{DD:sliceHghtRightDD} and \hyperref[DD:sliceHghtLeftDD]{DD:sliceHghtLeftDD}, respectively.
         
-\\ \midrule \\
+\\ \midrule
 Source & \cite{fredlund1977}
          
-\\ \midrule \\
+\\ \midrule
 RefBy & \hyperref[IM:nrmShrForNum]{IM:nrmShrForNum} and \hyperref[GD:momentEql]{GD:momentEql}
         
 \\ \bottomrule
@@ -1687,29 +1687,29 @@ RefBy & \hyperref[IM:nrmShrForNum]{IM:nrmShrForNum} and \hyperref[GD:momentEql]{
 \toprule \textbf{Refname} & \textbf{DD:normStress}
 \phantomsection 
 \label{DD:normStress}
-\\ \midrule \\
+\\ \midrule
 Label & Total normal stress
         
-\\ \midrule \\
+\\ \midrule
 Symbol & $σ$
          
-\\ \midrule \\
+\\ \midrule
 Units & ${\text{Pa}}$
         
-\\ \midrule \\
+\\ \midrule
 Equation & \begin{displaymath}
            σ=\frac{{F_{\text{n}}}}{A}
            \end{displaymath}
-\\ \midrule \\
+\\ \midrule
 Description & \begin{symbDescription}
               \item{$σ$ is the total normal stress (${\text{Pa}}$)}
               \item{${F_{\text{n}}}$ is the total normal force (${\text{N}}$)}
               \item{$A$ is the area (${\text{m}^{2}}$)}
               \end{symbDescription}
-\\ \midrule \\
+\\ \midrule
 Source & \cite{huston2008}
          
-\\ \midrule \\
+\\ \midrule
 RefBy & \hyperref[GD:resShr]{GD:resShr}, \hyperref[TM:effStress]{TM:effStress}, and \hyperref[GD:effNormF]{GD:effNormF}
         
 \\ \bottomrule
@@ -1723,29 +1723,29 @@ RefBy & \hyperref[GD:resShr]{GD:resShr}, \hyperref[TM:effStress]{TM:effStress}, 
 \toprule \textbf{Refname} & \textbf{DD:tangStress}
 \phantomsection 
 \label{DD:tangStress}
-\\ \midrule \\
+\\ \midrule
 Label & Tangential stress
         
-\\ \midrule \\
+\\ \midrule
 Symbol & $τ$
          
-\\ \midrule \\
+\\ \midrule
 Units & ${\text{Pa}}$
         
-\\ \midrule \\
+\\ \midrule
 Equation & \begin{displaymath}
            τ=\frac{{F_{\text{t}}}}{A}
            \end{displaymath}
-\\ \midrule \\
+\\ \midrule
 Description & \begin{symbDescription}
               \item{$τ$ is the tangential stress (${\text{Pa}}$)}
               \item{${F_{\text{t}}}$ is the tangential force (${\text{N}}$)}
               \item{$A$ is the area (${\text{m}^{2}}$)}
               \end{symbDescription}
-\\ \midrule \\
+\\ \midrule
 Source & \cite{huston2008}
          
-\\ \midrule \\
+\\ \midrule
 RefBy & \hyperref[GD:resShr]{GD:resShr}
         
 \\ \bottomrule
@@ -1759,32 +1759,32 @@ RefBy & \hyperref[GD:resShr]{GD:resShr}
 \toprule \textbf{Refname} & \textbf{DD:torque}
 \phantomsection 
 \label{DD:torque}
-\\ \midrule \\
+\\ \midrule
 Label & Torque
         
-\\ \midrule \\
+\\ \midrule
 Symbol & $\symbf{τ}$
          
-\\ \midrule \\
+\\ \midrule
 Units & $\text{N}\text{m}$
         
-\\ \midrule \\
+\\ \midrule
 Equation & \begin{displaymath}
            \symbf{τ}=\symbf{r}\times\symbf{F}
            \end{displaymath}
-\\ \midrule \\
+\\ \midrule
 Description & \begin{symbDescription}
               \item{$\symbf{τ}$ is the torque ($\text{N}\text{m}$)}
               \item{$\symbf{r}$ is the position vector (${\text{m}}$)}
               \item{$\symbf{F}$ is the force (${\text{N}}$)}
               \end{symbDescription}
-\\ \midrule \\
+\\ \midrule
 Notes & The torque on a body measures the tendency of a force to rotate the body around an axis or pivot.
         
-\\ \midrule \\
+\\ \midrule
 Source & --
          
-\\ \midrule \\
+\\ \midrule
 RefBy & \hyperref[GD:momentEql]{GD:momentEql}
         
 \\ \bottomrule
@@ -1798,23 +1798,23 @@ RefBy & \hyperref[GD:momentEql]{GD:momentEql}
 \toprule \textbf{Refname} & \textbf{DD:ratioVariation}
 \phantomsection 
 \label{DD:ratioVariation}
-\\ \midrule \\
+\\ \midrule
 Label & Interslice normal to shear force ratio variation function
         
-\\ \midrule \\
+\\ \midrule
 Symbol & $\symbf{f}$
          
-\\ \midrule \\
+\\ \midrule
 Units & Unitless
         
-\\ \midrule \\
+\\ \midrule
 Equation & \begin{displaymath}
            \symbf{f}=\begin{cases}
                      1, & \mathit{const\_f}\\
                      \sin\left(π \frac{{\symbf{x}_{\text{slip},i}}-{\symbf{x}_{\text{slip},0}}}{{\symbf{x}_{\text{slip},n}}-{\symbf{x}_{\text{slip},0}}}\right), & \neg{}\mathit{const\_f}
                      \end{cases}
            \end{displaymath}
-\\ \midrule \\
+\\ \midrule
 Description & \begin{symbDescription}
               \item{$\symbf{f}$ is the interslice normal to shear force ratio variation function (Unitless)}
               \item{$π$ is the ratio of circumference to diameter for any circle (Unitless)}
@@ -1823,10 +1823,10 @@ Description & \begin{symbDescription}
               \item{$n$ is the number of slices (Unitless)}
               \item{$\mathit{const\_f}$ is the decision on f (Unitless)}
               \end{symbDescription}
-\\ \midrule \\
+\\ \midrule
 Source & \cite{fredlund1977}
          
-\\ \midrule \\
+\\ \midrule
 RefBy & \hyperref[IM:nrmShrForDen]{IM:nrmShrForDen}, \hyperref[GD:normShrR]{GD:normShrR}, \hyperref[DD:convertFunc2]{DD:convertFunc2}, and \hyperref[DD:convertFunc1]{DD:convertFunc1}
         
 \\ \bottomrule
@@ -1840,20 +1840,20 @@ RefBy & \hyperref[IM:nrmShrForDen]{IM:nrmShrForDen}, \hyperref[GD:normShrR]{GD:n
 \toprule \textbf{Refname} & \textbf{DD:convertFunc1}
 \phantomsection 
 \label{DD:convertFunc1}
-\\ \midrule \\
+\\ \midrule
 Label & First function for incorporating interslice forces into shear force
         
-\\ \midrule \\
+\\ \midrule
 Symbol & $\symbf{Φ}$
          
-\\ \midrule \\
+\\ \midrule
 Units & Unitless
         
-\\ \midrule \\
+\\ \midrule
 Equation & \begin{displaymath}
            \symbf{Φ}=\left(λ {\symbf{f}}_{i} \cos\left({\symbf{α}}_{i}\right)-\sin\left({\symbf{α}}_{i}\right)\right) \tan\left(φ'\right)-\left(λ {\symbf{f}}_{i} \sin\left({\symbf{α}}_{i}\right)+\cos\left({\symbf{α}}_{i}\right)\right) {F_{\text{S}}}
            \end{displaymath}
-\\ \midrule \\
+\\ \midrule
 Description & \begin{symbDescription}
               \item{$\symbf{Φ}$ is the first function for incorporating interslice forces into shear force (Unitless)}
               \item{$λ$ is the proportionality constant (Unitless)}
@@ -1863,13 +1863,13 @@ Description & \begin{symbDescription}
               \item{$φ'$ is the effective angle of friction (${{}^{\circ}}$)}
               \item{${F_{\text{S}}}$ is the factor of safety (Unitless)}
               \end{symbDescription}
-\\ \midrule \\
+\\ \midrule
 Notes & $\symbf{f}$ is defined in \hyperref[DD:ratioVariation]{DD:ratioVariation} and $\symbf{α}$ is defined in \hyperref[DD:angleA]{DD:angleA}.
         
-\\ \midrule \\
+\\ \midrule
 Source & \cite{chen2005} and \cite{karchewski2012}
          
-\\ \midrule \\
+\\ \midrule
 RefBy & \hyperref[IM:intsliceFs]{IM:intsliceFs}, \hyperref[DD:convertFunc2]{DD:convertFunc2}, and \hyperref[IM:fctSfty]{IM:fctSfty}
         
 \\ \bottomrule
@@ -1883,20 +1883,20 @@ RefBy & \hyperref[IM:intsliceFs]{IM:intsliceFs}, \hyperref[DD:convertFunc2]{DD:c
 \toprule \textbf{Refname} & \textbf{DD:convertFunc2}
 \phantomsection 
 \label{DD:convertFunc2}
-\\ \midrule \\
+\\ \midrule
 Label & Second function for incorporating interslice forces into shear force
         
-\\ \midrule \\
+\\ \midrule
 Symbol & $\symbf{Ψ}$
          
-\\ \midrule \\
+\\ \midrule
 Units & Unitless
         
-\\ \midrule \\
+\\ \midrule
 Equation & \begin{displaymath}
            \symbf{Ψ}=\frac{\left(λ {\symbf{f}}_{i} \cos\left({\symbf{α}}_{i}\right)-\sin\left({\symbf{α}}_{i}\right)\right) \tan\left(φ'\right)-\left(λ {\symbf{f}}_{i} \sin\left({\symbf{α}}_{i}\right)+\cos\left({\symbf{α}}_{i}\right)\right) {F_{\text{S}}}}{{\symbf{Φ}}_{i-1}}
            \end{displaymath}
-\\ \midrule \\
+\\ \midrule
 Description & \begin{symbDescription}
               \item{$\symbf{Ψ}$ is the second function for incorporating interslice forces into shear force (Unitless)}
               \item{$λ$ is the proportionality constant (Unitless)}
@@ -1907,13 +1907,13 @@ Description & \begin{symbDescription}
               \item{${F_{\text{S}}}$ is the factor of safety (Unitless)}
               \item{$\symbf{Φ}$ is the first function for incorporating interslice forces into shear force (Unitless)}
               \end{symbDescription}
-\\ \midrule \\
+\\ \midrule
 Notes & $\symbf{f}$ is defined in \hyperref[DD:ratioVariation]{DD:ratioVariation}, $\symbf{α}$ is defined in \hyperref[DD:angleA]{DD:angleA}, and $\symbf{Φ}$ is defined in \hyperref[DD:convertFunc1]{DD:convertFunc1}.
         
-\\ \midrule \\
+\\ \midrule
 Source & \cite{chen2005} and \cite{karchewski2012}
          
-\\ \midrule \\
+\\ \midrule
 RefBy & \hyperref[IM:intsliceFs]{IM:intsliceFs} and \hyperref[IM:fctSfty]{IM:fctSfty}
         
 \\ \bottomrule
@@ -1927,29 +1927,29 @@ RefBy & \hyperref[IM:intsliceFs]{IM:intsliceFs} and \hyperref[IM:fctSfty]{IM:fct
 \toprule \textbf{Refname} & \textbf{DD:nrmForceSumDD}
 \phantomsection 
 \label{DD:nrmForceSumDD}
-\\ \midrule \\
+\\ \midrule
 Label & Sums of the interslice normal forces
         
-\\ \midrule \\
+\\ \midrule
 Symbol & ${{\symbf{F}_{\text{x}}}^{\text{G}}}$
          
-\\ \midrule \\
+\\ \midrule
 Units & ${\text{N}}$
         
-\\ \midrule \\
+\\ \midrule
 Equation & \begin{displaymath}
            {{\symbf{F}_{\text{x}}}^{\text{G}}}={\symbf{G}}_{i}+{\symbf{G}}_{i-1}
            \end{displaymath}
-\\ \midrule \\
+\\ \midrule
 Description & \begin{symbDescription}
               \item{${{\symbf{F}_{\text{x}}}^{\text{G}}}$ is the sums of the interslice normal forces (${\text{N}}$)}
               \item{$\symbf{G}$ is the interslice normal forces ($\frac{\text{N}}{\text{m}}$)}
               \item{$i$ is the index (Unitless)}
               \end{symbDescription}
-\\ \midrule \\
+\\ \midrule
 Source & \cite{fredlund1977}
          
-\\ \midrule \\
+\\ \midrule
 RefBy & 
 \\ \bottomrule
 \end{tabular}
@@ -1962,29 +1962,29 @@ RefBy &
 \toprule \textbf{Refname} & \textbf{DD:watForceSumDD}
 \phantomsection 
 \label{DD:watForceSumDD}
-\\ \midrule \\
+\\ \midrule
 Label & Sums of the interslice normal water forces
         
-\\ \midrule \\
+\\ \midrule
 Symbol & ${{\symbf{F}_{\text{x}}}^{\text{H}}}$
          
-\\ \midrule \\
+\\ \midrule
 Units & ${\text{N}}$
         
-\\ \midrule \\
+\\ \midrule
 Equation & \begin{displaymath}
            {{\symbf{F}_{\text{x}}}^{\text{H}}}={\symbf{H}}_{i}+{\symbf{H}}_{i-1}
            \end{displaymath}
-\\ \midrule \\
+\\ \midrule
 Description & \begin{symbDescription}
               \item{${{\symbf{F}_{\text{x}}}^{\text{H}}}$ is the sums of the interslice normal water forces (${\text{N}}$)}
               \item{$\symbf{H}$ is the interslice normal water forces ($\frac{\text{N}}{\text{m}}$)}
               \item{$i$ is the index (Unitless)}
               \end{symbDescription}
-\\ \midrule \\
+\\ \midrule
 Source & \cite{fredlund1977}
          
-\\ \midrule \\
+\\ \midrule
 RefBy & 
 \\ \bottomrule
 \end{tabular}
@@ -1997,30 +1997,30 @@ RefBy &
 \toprule \textbf{Refname} & \textbf{DD:sliceHghtRightDD}
 \phantomsection 
 \label{DD:sliceHghtRightDD}
-\\ \midrule \\
+\\ \midrule
 Label & Heights of the right side of slices
         
-\\ \midrule \\
+\\ \midrule
 Symbol & ${\symbf{h}^{\text{R}}}$
          
-\\ \midrule \\
+\\ \midrule
 Units & ${\text{m}}$
         
-\\ \midrule \\
+\\ \midrule
 Equation & \begin{displaymath}
            {\symbf{h}^{\text{R}}}={\symbf{y}_{\text{slope},i}}-{\symbf{y}_{\text{slip},i}}
            \end{displaymath}
-\\ \midrule \\
+\\ \midrule
 Description & \begin{symbDescription}
               \item{${\symbf{h}^{\text{R}}}$ is the heights of the right side of slices (${\text{m}}$)}
               \item{${\symbf{y}_{\text{slope}}}$ is the $y$-coordinates of the slope (${\text{m}}$)}
               \item{$i$ is the index (Unitless)}
               \item{${\symbf{y}_{\text{slip}}}$ is the $y$-coordinates of the slip surface (${\text{m}}$)}
               \end{symbDescription}
-\\ \midrule \\
+\\ \midrule
 Source & \cite{fredlund1977}
          
-\\ \midrule \\
+\\ \midrule
 RefBy & \hyperref[DD:slcHeight]{DD:slcHeight}
         
 \\ \bottomrule
@@ -2034,30 +2034,30 @@ RefBy & \hyperref[DD:slcHeight]{DD:slcHeight}
 \toprule \textbf{Refname} & \textbf{DD:sliceHghtLeftDD}
 \phantomsection 
 \label{DD:sliceHghtLeftDD}
-\\ \midrule \\
+\\ \midrule
 Label & Heights of the left side of slices
         
-\\ \midrule \\
+\\ \midrule
 Symbol & ${\symbf{h}^{\text{L}}}$
          
-\\ \midrule \\
+\\ \midrule
 Units & ${\text{m}}$
         
-\\ \midrule \\
+\\ \midrule
 Equation & \begin{displaymath}
            {\symbf{h}^{\text{L}}}={\symbf{y}_{\text{slope},i-1}}-{\symbf{y}_{\text{slip},i-1}}
            \end{displaymath}
-\\ \midrule \\
+\\ \midrule
 Description & \begin{symbDescription}
               \item{${\symbf{h}^{\text{L}}}$ is the heights of the left side of slices (${\text{m}}$)}
               \item{${\symbf{y}_{\text{slope}}}$ is the $y$-coordinates of the slope (${\text{m}}$)}
               \item{$i$ is the index (Unitless)}
               \item{${\symbf{y}_{\text{slip}}}$ is the $y$-coordinates of the slip surface (${\text{m}}$)}
               \end{symbDescription}
-\\ \midrule \\
+\\ \midrule
 Source & \cite{fredlund1977}
          
-\\ \midrule \\
+\\ \midrule
 RefBy & \hyperref[DD:slcHeight]{DD:slcHeight}
         
 \\ \bottomrule
@@ -2079,24 +2079,24 @@ The Morgenstern-Price method is a vertical slice, limit equilibrium slope stabil
 \toprule \textbf{Refname} & \textbf{IM:fctSfty}
 \phantomsection 
 \label{IM:fctSfty}
-\\ \midrule \\
+\\ \midrule
 Label & Factor of safety
         
-\\ \midrule \\
+\\ \midrule
 Input & ${\symbf{x}_{\text{slope}}}$, ${\symbf{y}_{\text{slope}}}$, ${\symbf{y}_{\text{wt}}}$, $c'$, $φ'$, ${γ_{\text{dry}}}$, ${γ_{\text{sat}}}$, ${γ_{w}}$, ${\symbf{x}_{\text{slip}}}$, ${\symbf{y}_{\text{slip}}}$, $\mathit{const\_f}$
         
-\\ \midrule \\
+\\ \midrule
 Output & ${F_{\text{S}}}$
          
-\\ \midrule \\
+\\ \midrule
 Input Constraints & 
-\\ \midrule \\
+\\ \midrule
 Output Constraints & 
-\\ \midrule \\
+\\ \midrule
 Equation & \begin{displaymath}
            {F_{\text{S}}}=\frac{\displaystyle\sum_{i=1}^{n-1}{{\symbf{R}}_{i} \displaystyle\prod_{v=i}^{n-1}{{\symbf{Ψ}}_{v}}}+{\symbf{R}}_{n}}{\displaystyle\sum_{i=1}^{n-1}{{\symbf{T}}_{i} \displaystyle\prod_{v=i}^{n-1}{{\symbf{Ψ}}_{v}}}+{\symbf{T}}_{n}}
            \end{displaymath}
-\\ \midrule \\
+\\ \midrule
 Description & \begin{symbDescription}
               \item{${F_{\text{S}}}$ is the factor of safety (Unitless)}
               \item{$\symbf{R}$ is the resistive shear forces without the influence of interslice forces ($\frac{\text{N}}{\text{m}}$)}
@@ -2106,13 +2106,13 @@ Description & \begin{symbDescription}
               \item{$n$ is the number of slices (Unitless)}
               \item{$\symbf{T}$ is the mobilized shear forces without the influence of interslice forces ($\frac{\text{N}}{\text{m}}$)}
               \end{symbDescription}
-\\ \midrule \\
+\\ \midrule
 Notes & $\symbf{R}$ is defined in \hyperref[GD:resShearWO]{GD:resShearWO}, $\symbf{Ψ}$ is defined in \hyperref[DD:convertFunc2]{DD:convertFunc2}, and $\symbf{T}$ is defined in \hyperref[GD:mobShearWO]{GD:mobShearWO}
         
-\\ \midrule \\
+\\ \midrule
 Source & \cite{chen2005} and \cite{karchewski2012}
          
-\\ \midrule \\
+\\ \midrule
 RefBy & \hyperref[IM:nrmShrFor]{IM:nrmShrFor}, \hyperref[IM:intsliceFs]{IM:intsliceFs}, \hyperref[displayShear]{FR:Display-Interslice-Shear-Forces}, \hyperref[displayNormal]{FR:Display-Interslice-Normal-Forces}, \hyperref[displayFS]{FR:Display-Factor-of-Safety}, \hyperref[determineCritSlip]{FR:Determine-Critical-Slip-Surface}, and \hyperref[IM:fctSfty]{IM:fctSfty}
         
 \\ \bottomrule
@@ -2241,37 +2241,37 @@ ${F_{\text{S}}}$ depends on the unknowns $λ$ (\hyperref[IM:nrmShrFor]{IM:nrmShr
 \toprule \textbf{Refname} & \textbf{IM:nrmShrFor}
 \phantomsection 
 \label{IM:nrmShrFor}
-\\ \midrule \\
+\\ \midrule
 Label & Normal and shear force proportionality constant
         
-\\ \midrule \\
+\\ \midrule
 Input & ${\symbf{x}_{\text{slope}}}$, ${\symbf{y}_{\text{slope}}}$, ${\symbf{y}_{\text{wt}}}$, ${γ_{w}}$, ${\symbf{x}_{\text{slip}}}$, ${\symbf{y}_{\text{slip}}}$, $\mathit{const\_f}$
         
-\\ \midrule \\
+\\ \midrule
 Output & $λ$
          
-\\ \midrule \\
+\\ \midrule
 Input Constraints & 
-\\ \midrule \\
+\\ \midrule
 Output Constraints & 
-\\ \midrule \\
+\\ \midrule
 Equation & \begin{displaymath}
            λ=\frac{\displaystyle\sum_{i=1}^{n}{{\symbf{C}_{\text{num},i}}}}{\displaystyle\sum_{i=1}^{n}{{\symbf{C}_{\text{den},i}}}}
            \end{displaymath}
-\\ \midrule \\
+\\ \midrule
 Description & \begin{symbDescription}
               \item{$λ$ is the proportionality constant (Unitless)}
               \item{${\symbf{C}_{\text{num}}}$ is the proportionality constant numerator (${\text{N}}$)}
               \item{$i$ is the index (Unitless)}
               \item{${\symbf{C}_{\text{den}}}$ is the proportionality constant denominator (${\text{N}}$)}
               \end{symbDescription}
-\\ \midrule \\
+\\ \midrule
 Notes & ${\symbf{C}_{\text{num}}}$ is defined in \hyperref[IM:nrmShrForNum]{IM:nrmShrForNum} and ${\symbf{C}_{\text{den}}}$ is defined in \hyperref[IM:nrmShrForDen]{IM:nrmShrForDen}.
         
-\\ \midrule \\
+\\ \midrule
 Source & \cite{chen2005} and \cite{karchewski2012}
          
-\\ \midrule \\
+\\ \midrule
 RefBy & \hyperref[IM:nrmShrForNum]{IM:nrmShrForNum}, \hyperref[IM:nrmShrFor]{IM:nrmShrFor}, \hyperref[IM:nrmShrForDen]{IM:nrmShrForDen}, \hyperref[IM:intsliceFs]{IM:intsliceFs}, \hyperref[displayShear]{FR:Display-Interslice-Shear-Forces}, \hyperref[displayNormal]{FR:Display-Interslice-Normal-Forces}, \hyperref[displayFS]{FR:Display-Factor-of-Safety}, \hyperref[determineCritSlip]{FR:Determine-Critical-Slip-Surface}, and \hyperref[IM:fctSfty]{IM:fctSfty}
         
 \\ \bottomrule
@@ -2308,20 +2308,20 @@ Equation (16) for $λ$ is a function of the unknown interslice normal forces $\s
 \toprule \textbf{Refname} & \textbf{IM:nrmShrForNum}
 \phantomsection 
 \label{IM:nrmShrForNum}
-\\ \midrule \\
+\\ \midrule
 Label & Normal and shear force proportionality constant numerator
         
-\\ \midrule \\
+\\ \midrule
 Input & ${\symbf{x}_{\text{slope}}}$, ${\symbf{y}_{\text{slope}}}$, ${\symbf{y}_{\text{wt}}}$, ${γ_{w}}$, ${\symbf{x}_{\text{slip}}}$, ${\symbf{y}_{\text{slip}}}$
         
-\\ \midrule \\
+\\ \midrule
 Output & ${\symbf{C}_{\text{num}}}$
          
-\\ \midrule \\
+\\ \midrule
 Input Constraints & 
-\\ \midrule \\
+\\ \midrule
 Output Constraints & 
-\\ \midrule \\
+\\ \midrule
 Equation & \begin{displaymath}
            {\symbf{C}_{\text{num},i}}=\begin{cases}
                                       {\symbf{b}}_{1} \left({\symbf{G}}_{1}+{\symbf{H}}_{1}\right) \tan\left({\symbf{α}}_{1}\right), & i=1\\
@@ -2329,7 +2329,7 @@ Equation & \begin{displaymath}
                                       {\symbf{b}}_{n} \left({\symbf{G}}_{n-1}+{\symbf{H}}_{n-1}\right) \tan\left({\symbf{α}}_{n-1}\right), & i=n
                                       \end{cases}
            \end{displaymath}
-\\ \midrule \\
+\\ \midrule
 Description & \begin{symbDescription}
               \item{${\symbf{C}_{\text{num}}}$ is the proportionality constant numerator (${\text{N}}$)}
               \item{$i$ is the index (Unitless)}
@@ -2344,13 +2344,13 @@ Description & \begin{symbDescription}
               \item{$\symbf{β}$ is the surface angles (${{}^{\circ}}$)}
               \item{$n$ is the number of slices (Unitless)}
               \end{symbDescription}
-\\ \midrule \\
+\\ \midrule
 Notes & $\symbf{b}$ is defined in \hyperref[DD:lengthB]{DD:lengthB}, $\symbf{H}$ is defined in \hyperref[DD:intersliceWtrF]{DD:intersliceWtrF}, $\symbf{α}$ is defined in \hyperref[DD:angleA]{DD:angleA}, $\symbf{h}$ is defined in \hyperref[DD:slcHeight]{DD:slcHeight}, ${\symbf{U}_{\text{g}}}$ is defined in \hyperref[GD:srfWtrF]{GD:srfWtrF}, and $\symbf{β}$ is defined in \hyperref[DD:angleB]{DD:angleB}.
         
-\\ \midrule \\
+\\ \midrule
 Source & \cite{chen2005} and \cite{karchewski2012}
          
-\\ \midrule \\
+\\ \midrule
 RefBy & \hyperref[IM:nrmShrFor]{IM:nrmShrFor}
         
 \\ \bottomrule
@@ -2367,20 +2367,20 @@ See \hyperref[IM:nrmShrFor]{IM:nrmShrFor} for the derivation of ${\symbf{C}_{\te
 \toprule \textbf{Refname} & \textbf{IM:nrmShrForDen}
 \phantomsection 
 \label{IM:nrmShrForDen}
-\\ \midrule \\
+\\ \midrule
 Label & Normal and shear force proportionality constant denominator
         
-\\ \midrule \\
+\\ \midrule
 Input & ${\symbf{x}_{\text{slip}}}$, $\mathit{const\_f}$
         
-\\ \midrule \\
+\\ \midrule
 Output & ${\symbf{C}_{\text{den}}}$
          
-\\ \midrule \\
+\\ \midrule
 Input Constraints & 
-\\ \midrule \\
+\\ \midrule
 Output Constraints & 
-\\ \midrule \\
+\\ \midrule
 Equation & \begin{displaymath}
            {\symbf{C}_{\text{den},i}}=\begin{cases}
                                       {\symbf{b}}_{1} {\symbf{f}}_{1} {\symbf{G}}_{1}, & i=1\\
@@ -2388,7 +2388,7 @@ Equation & \begin{displaymath}
                                       {\symbf{b}}_{n} {\symbf{G}}_{n-1} {\symbf{f}}_{n-1}, & i=n
                                       \end{cases}
            \end{displaymath}
-\\ \midrule \\
+\\ \midrule
 Description & \begin{symbDescription}
               \item{${\symbf{C}_{\text{den}}}$ is the proportionality constant denominator (${\text{N}}$)}
               \item{$i$ is the index (Unitless)}
@@ -2397,13 +2397,13 @@ Description & \begin{symbDescription}
               \item{$\symbf{G}$ is the interslice normal forces ($\frac{\text{N}}{\text{m}}$)}
               \item{$n$ is the number of slices (Unitless)}
               \end{symbDescription}
-\\ \midrule \\
+\\ \midrule
 Notes & $\symbf{b}$ is defined in \hyperref[DD:lengthB]{DD:lengthB} and $\symbf{f}$ is defined in \hyperref[DD:ratioVariation]{DD:ratioVariation}.
         
-\\ \midrule \\
+\\ \midrule
 Source & \cite{chen2005} and \cite{karchewski2012}
          
-\\ \midrule \\
+\\ \midrule
 RefBy & \hyperref[IM:nrmShrFor]{IM:nrmShrFor}
         
 \\ \bottomrule
@@ -2420,20 +2420,20 @@ See \hyperref[IM:nrmShrFor]{IM:nrmShrFor} for the derivation of ${\symbf{C}_{\te
 \toprule \textbf{Refname} & \textbf{IM:intsliceFs}
 \phantomsection 
 \label{IM:intsliceFs}
-\\ \midrule \\
+\\ \midrule
 Label & Interslice normal forces
         
-\\ \midrule \\
+\\ \midrule
 Input & ${\symbf{x}_{\text{slope}}}$, ${\symbf{y}_{\text{slope}}}$, ${\symbf{y}_{\text{wt}}}$, $c'$, $φ'$, ${γ_{\text{dry}}}$, ${γ_{\text{sat}}}$, ${γ_{w}}$, ${\symbf{x}_{\text{slip}}}$, ${\symbf{y}_{\text{slip}}}$, $\mathit{const\_f}$
         
-\\ \midrule \\
+\\ \midrule
 Output & $\symbf{G}$
          
-\\ \midrule \\
+\\ \midrule
 Input Constraints & 
-\\ \midrule \\
+\\ \midrule
 Output Constraints & 
-\\ \midrule \\
+\\ \midrule
 Equation & \begin{displaymath}
            {\symbf{G}}_{i}=\begin{cases}
                            \frac{{F_{\text{S}}} {\symbf{T}}_{1}-{\symbf{R}}_{1}}{{\symbf{Φ}}_{1}}, & i=1\\
@@ -2441,7 +2441,7 @@ Equation & \begin{displaymath}
                            0, & i=0\lor{}i=n
                            \end{cases}
            \end{displaymath}
-\\ \midrule \\
+\\ \midrule
 Description & \begin{symbDescription}
               \item{$\symbf{G}$ is the interslice normal forces ($\frac{\text{N}}{\text{m}}$)}
               \item{$i$ is the index (Unitless)}
@@ -2452,13 +2452,13 @@ Description & \begin{symbDescription}
               \item{$\symbf{Ψ}$ is the second function for incorporating interslice forces into shear force (Unitless)}
               \item{$n$ is the number of slices (Unitless)}
               \end{symbDescription}
-\\ \midrule \\
+\\ \midrule
 Notes & $\symbf{T}$ is defined in \hyperref[GD:mobShearWO]{GD:mobShearWO}, $\symbf{R}$ is defined in \hyperref[GD:resShearWO]{GD:resShearWO}, $\symbf{Φ}$ is defined in \hyperref[DD:convertFunc1]{DD:convertFunc1}, and $\symbf{Ψ}$ is defined in \hyperref[DD:convertFunc2]{DD:convertFunc2}.
         
-\\ \midrule \\
+\\ \midrule
 Source & \cite{chen2005}
          
-\\ \midrule \\
+\\ \midrule
 RefBy & \hyperref[IM:nrmShrFor]{IM:nrmShrFor}, \hyperref[IM:intsliceFs]{IM:intsliceFs}, \hyperref[displayShear]{FR:Display-Interslice-Shear-Forces}, \hyperref[displayNormal]{FR:Display-Interslice-Normal-Forces}, \hyperref[displayFS]{FR:Display-Factor-of-Safety}, \hyperref[determineCritSlip]{FR:Determine-Critical-Slip-Surface}, and \hyperref[IM:fctSfty]{IM:fctSfty}
         
 \\ \bottomrule
@@ -2485,35 +2485,35 @@ The cases shown in \hyperref[IM:intsliceFs]{IM:intsliceFs} for when $i=0$, $i=1$
 \toprule \textbf{Refname} & \textbf{IM:crtSlpId}
 \phantomsection 
 \label{IM:crtSlpId}
-\\ \midrule \\
+\\ \midrule
 Label & Critical slip surface identification
         
-\\ \midrule \\
+\\ \midrule
 Input & ${\symbf{x}_{\text{slope}}}$, ${\symbf{y}_{\text{slope}}}$, ${\symbf{x}_{\text{wt}}}$, ${\symbf{y}_{\text{wt}}}$, $c'$, $φ'$, ${γ_{\text{dry}}}$, ${γ_{\text{sat}}}$, ${γ_{w}}$, $\mathit{const\_f}$
         
-\\ \midrule \\
+\\ \midrule
 Output & ${{F_{\text{S}}}^{\text{min}}}$
          
-\\ \midrule \\
+\\ \midrule
 Input Constraints & 
-\\ \midrule \\
+\\ \midrule
 Output Constraints & 
-\\ \midrule \\
+\\ \midrule
 Equation & \begin{displaymath}
            {\symbf{x}_{\text{slope}}}={\symbf{y}_{\text{slope}}}
            \end{displaymath}
-\\ \midrule \\
+\\ \midrule
 Description & \begin{symbDescription}
               \item{${\symbf{x}_{\text{slope}}}$ is the $x$-coordinates of the slope (${\text{m}}$)}
               \item{${\symbf{y}_{\text{slope}}}$ is the $y$-coordinates of the slope (${\text{m}}$)}
               \end{symbDescription}
-\\ \midrule \\
+\\ \midrule
 Notes & The minimization function must enforce the constraints on the critical slip surface expressed in \hyperref[assumpSSC]{A:Slip-Surface-Concave} and \hyperref[Sec:CorSolProps]{Sec:Properties of a Correct Solution}. The sizes of ${\symbf{x}_{\text{wt}}}$ and ${\symbf{y}_{\text{wt}}}$ must be equal and not 1. The sizes of ${\symbf{x}_{\text{slope}}}$ and ${\symbf{y}_{\text{slope}}}$ must be equal and at least 2. The first and last ${\symbf{x}_{\text{wt}}}$ values must be equal to the first and last ${\symbf{x}_{\text{slope}}}$ values. ${\symbf{x}_{\text{wt}}}$ and ${\symbf{x}_{\text{slope}}}$ values must be monotonically increasing. ${{x_{\text{slip}}}^{\text{maxExt}}}$, ${{x_{\text{slip}}}^{\text{maxEtr}}}$, ${{x_{\text{slip}}}^{\text{minExt}}}$, and ${{x_{\text{slip}}}^{\text{minEtr}}}$ must be between or equal to the minimum and maximum ${\symbf{x}_{\text{slope}}}$ values. ${{y_{\text{slip}}}^{\text{max}}}$ cannot be below the minimum ${\symbf{y}_{\text{slope}}}$ value. ${{y_{\text{slip}}}^{\text{min}}}$ cannot be above the maximum ${\symbf{y}_{\text{slope}}}$ value. All $x$ values of ${\symbf{x}_{\text{cs}}}\text{,}{\symbf{y}_{\text{cs}}}$ must be between ${{x_{\text{slip}}}^{\text{minEtr}}}$ and ${{x_{\text{slip}}}^{\text{maxExt}}}$. All $y$ values of ${\symbf{x}_{\text{cs}}}\text{,}{\symbf{y}_{\text{cs}}}$ must not be below ${{y_{\text{slip}}}^{\text{min}}}$. For any given vertex in ${\symbf{x}_{\text{cs}}}\text{,}{\symbf{y}_{\text{cs}}}$ the $y$ value must not exceed the ${\symbf{y}_{\text{slope}}}$ value corresponding to the same $x$ value. The first and last vertices in ${\symbf{x}_{\text{cs}}}\text{,}{\symbf{y}_{\text{cs}}}$ must each be equal to one of the vertices formed by ${\symbf{x}_{\text{slope}}}$ and ${\symbf{y}_{\text{slope}}}$. The slope between consecutive vertices must be always increasing as $x$ increases. The internal angle between consecutive vertices in ${\symbf{x}_{\text{cs}}}\text{,}{\symbf{y}_{\text{cs}}}$ must not be below 110 degrees.
         
-\\ \midrule \\
+\\ \midrule
 Source & \cite{li2010}
          
-\\ \midrule \\
+\\ \midrule
 RefBy & \hyperref[displayGraph]{FR:Display-Graph} and \hyperref[determineCritSlip]{FR:Determine-Critical-Slip-Surface}
         
 \\ \bottomrule

--- a/code/stable/swhs/SRS/PDF/SWHS_SRS.tex
+++ b/code/stable/swhs/SRS/PDF/SWHS_SRS.tex
@@ -454,14 +454,14 @@ This section focuses on the general equations and laws that SWHS is based on.
 \toprule \textbf{Refname} & \textbf{TM:consThermE}
 \phantomsection 
 \label{TM:consThermE}
-\\ \midrule \\
+\\ \midrule
 Label & Conservation of thermal energy
         
-\\ \midrule \\
+\\ \midrule
 Equation & \begin{displaymath}
            -∇\cdot{}\symbf{q}+g=ρ C \frac{\,\partial{}T}{\,\partial{}t}
            \end{displaymath}
-\\ \midrule \\
+\\ \midrule
 Description & \begin{symbDescription}
               \item{$∇$ is the gradient (Unitless)}
               \item{$\symbf{q}$ is the thermal flux vector ($\frac{\text{W}}{\text{m}^{2}}$)}
@@ -471,15 +471,15 @@ Description & \begin{symbDescription}
               \item{$t$ is the time (${\text{s}}$)}
               \item{$T$ is the temperature (${{}^{\circ}\text{C}}$)}
               \end{symbDescription}
-\\ \midrule \\
+\\ \midrule
 Notes & The above equation gives the law of conservation of energy for transient heat transfer in a given material.
         
         For this equation to apply, other forms of energy, such as mechanical energy, are assumed to be negligible in the system (\hyperref[assumpTEO]{A:Thermal-Energy-Only}).
         
-\\ \midrule \\
+\\ \midrule
 Source & \hyperref{http://www.efunda.com/formulae/heat_transfer/conduction/overview_cond.cfm}{}{}{Fourier Law of Heat Conduction and Heat Equation}
          
-\\ \midrule \\
+\\ \midrule
 RefBy & \hyperref[GD:rocTempSimp]{GD:rocTempSimp}
         
 \\ \bottomrule
@@ -492,10 +492,10 @@ RefBy & \hyperref[GD:rocTempSimp]{GD:rocTempSimp}
 \toprule \textbf{Refname} & \textbf{TM:sensHtE}
 \phantomsection 
 \label{TM:sensHtE}
-\\ \midrule \\
+\\ \midrule
 Label & Sensible heat energy
         
-\\ \midrule \\
+\\ \midrule
 Equation & \begin{displaymath}
            E=\begin{cases}
              {C^{\text{S}}} m ΔT, & T\lt{}{T_{\text{melt}}}\\
@@ -503,7 +503,7 @@ Equation & \begin{displaymath}
              {C^{\text{V}}} m ΔT, & {T_{\text{boil}}}\lt{}T
              \end{cases}
            \end{displaymath}
-\\ \midrule \\
+\\ \midrule
 Description & \begin{symbDescription}
               \item{$E$ is the sensible heat (${\text{J}}$)}
               \item{${C^{\text{S}}}$ is the specific heat capacity of a solid ($\frac{\text{J}}{\text{kg}{}^{\circ}\text{C}}$)}
@@ -515,13 +515,13 @@ Description & \begin{symbDescription}
               \item{${T_{\text{melt}}}$ is the melting point temperature (${{}^{\circ}\text{C}}$)}
               \item{${T_{\text{boil}}}$ is the boiling point temperature (${{}^{\circ}\text{C}}$)}
               \end{symbDescription}
-\\ \midrule \\
+\\ \midrule
 Notes & Sensible heating occurs as long as the material does not reach a temperature where a phase change occurs. A phase change occurs if $T={T_{\text{boil}}}$ or $T={T_{\text{melt}}}$. If this is the case, refer to \hyperref[TM:latentHtE]{TM:latentHtE}.
         
-\\ \midrule \\
+\\ \midrule
 Source & \hyperref{http://en.wikipedia.org/wiki/Sensible_heat}{}{}{Definition of Sensible Heat}
          
-\\ \midrule \\
+\\ \midrule
 RefBy & \hyperref[IM:heatEInWtr]{IM:heatEInWtr} and \hyperref[IM:heatEInPCM]{IM:heatEInPCM}
         
 \\ \bottomrule
@@ -534,20 +534,20 @@ RefBy & \hyperref[IM:heatEInWtr]{IM:heatEInWtr} and \hyperref[IM:heatEInPCM]{IM:
 \toprule \textbf{Refname} & \textbf{TM:latentHtE}
 \phantomsection 
 \label{TM:latentHtE}
-\\ \midrule \\
+\\ \midrule
 Label & Latent heat energy
         
-\\ \midrule \\
+\\ \midrule
 Equation & \begin{displaymath}
            Q\left(t\right)=\int_{0}^{t}{\frac{\,dQ\left(τ\right)}{\,dτ}}\,dτ
            \end{displaymath}
-\\ \midrule \\
+\\ \midrule
 Description & \begin{symbDescription}
               \item{$Q$ is the latent heat (${\text{J}}$)}
               \item{$t$ is the time (${\text{s}}$)}
               \item{$τ$ is the dummy variable for integration over time (${\text{s}}$)}
               \end{symbDescription}
-\\ \midrule \\
+\\ \midrule
 Notes & $Q$ is the change in thermal energy (latent heat energy).
         
         $Q\left(t\right)=\int_{0}^{t}{\frac{\,dQ\left(τ\right)}{\,dτ}}\,dτ$ is the rate of change of $Q$ with respect to time $τ$.
@@ -558,10 +558,10 @@ Notes & $Q$ is the change in thermal energy (latent heat energy).
         
         Latent heating stops when all material has changed to the new phase.
         
-\\ \midrule \\
+\\ \midrule
 Source & \hyperref{http://en.wikipedia.org/wiki/Latent_heat}{}{}{Definition of Latent Heat}
          
-\\ \midrule \\
+\\ \midrule
 RefBy & \hyperref[TM:sensHtE]{TM:sensHtE} and \hyperref[IM:heatEInPCM]{IM:heatEInPCM}
         
 \\ \bottomrule
@@ -574,31 +574,31 @@ RefBy & \hyperref[TM:sensHtE]{TM:sensHtE} and \hyperref[IM:heatEInPCM]{IM:heatEI
 \toprule \textbf{Refname} & \textbf{TM:nwtnCooling}
 \phantomsection 
 \label{TM:nwtnCooling}
-\\ \midrule \\
+\\ \midrule
 Label & Newton's law of cooling
         
-\\ \midrule \\
+\\ \midrule
 Equation & \begin{displaymath}
            q\left(t\right)=h ΔT\left(t\right)
            \end{displaymath}
-\\ \midrule \\
+\\ \midrule
 Description & \begin{symbDescription}
               \item{$q$ is the heat flux ($\frac{\text{W}}{\text{m}^{2}}$)}
               \item{$t$ is the time (${\text{s}}$)}
               \item{$h$ is the convective heat transfer coefficient ($\frac{\text{W}}{\text{m}^{2}{}^{\circ}\text{C}}$)}
               \item{$ΔT$ is the change in temperature (${{}^{\circ}\text{C}}$)}
               \end{symbDescription}
-\\ \midrule \\
+\\ \midrule
 Notes & Newton's law of cooling describes convective cooling from a surface. The law is stated as: the rate of heat loss from a body is proportional to the difference in temperatures between the body and its surroundings.
         
         $h$ is assumed to be independent of $T$ (from \hyperref[assumpHTCC]{A:Heat-Transfer-Coeffs-Constant}).
         
         $ΔT\left(t\right)=T\left(t\right)-{T_{\text{env}}}\left(t\right)$ is the time-dependant thermal gradient between the environment and the object.
         
-\\ \midrule \\
+\\ \midrule
 Source & \cite[(pg. 8)]{incroperaEtAl2007}
          
-\\ \midrule \\
+\\ \midrule
 RefBy & \hyperref[GD:htFluxPCMFromWater]{GD:htFluxPCMFromWater} and \hyperref[GD:htFluxWaterFromCoil]{GD:htFluxWaterFromCoil}
         
 \\ \bottomrule
@@ -615,14 +615,14 @@ This section collects the laws and equations that will be used to build the inst
 \toprule \textbf{Refname} & \textbf{GD:rocTempSimp}
 \phantomsection 
 \label{GD:rocTempSimp}
-\\ \midrule \\
+\\ \midrule
 Label & Simplified rate of change of temperature
         
-\\ \midrule \\
+\\ \midrule
 Equation & \begin{displaymath}
            m C \frac{\,dT}{\,dt}={q_{\text{in}}} {A_{\text{in}}}-{q_{\text{out}}} {A_{\text{out}}}+g V
            \end{displaymath}
-\\ \midrule \\
+\\ \midrule
 Description & \begin{symbDescription}
               \item{$m$ is the mass (${\text{kg}}$)}
               \item{$C$ is the specific heat capacity ($\frac{\text{J}}{\text{kg}{}^{\circ}\text{C}}$)}
@@ -635,10 +635,10 @@ Description & \begin{symbDescription}
               \item{$g$ is the volumetric heat generation per unit volume ($\frac{\text{W}}{\text{m}^{3}}$)}
               \item{$V$ is the volume (${\text{m}^{3}}$)}
               \end{symbDescription}
-\\ \midrule \\
+\\ \midrule
 Source & --
          
-\\ \midrule \\
+\\ \midrule
 RefBy & \hyperref[GD:rocTempSimp]{GD:rocTempSimp}, \hyperref[IM:eBalanceOnWtr]{IM:eBalanceOnWtr}, and \hyperref[IM:eBalanceOnPCM]{IM:eBalanceOnPCM}
         
 \\ \bottomrule
@@ -678,17 +678,17 @@ m C \frac{\,dT}{\,dt}={q_{\text{in}}} {A_{\text{in}}}-{q_{\text{out}}} {A_{\text
 \toprule \textbf{Refname} & \textbf{GD:htFluxWaterFromCoil}
 \phantomsection 
 \label{GD:htFluxWaterFromCoil}
-\\ \midrule \\
+\\ \midrule
 Label & Heat flux into the water from the coil
         
-\\ \midrule \\
+\\ \midrule
 Units & $\frac{\text{W}}{\text{m}^{2}}$
         
-\\ \midrule \\
+\\ \midrule
 Equation & \begin{displaymath}
            {q_{\text{C}}}={h_{\text{C}}} \left({T_{\text{C}}}-{T_{\text{W}}}\left(t\right)\right)
            \end{displaymath}
-\\ \midrule \\
+\\ \midrule
 Description & \begin{symbDescription}
               \item{${q_{\text{C}}}$ is the heat flux into the water from the coil ($\frac{\text{W}}{\text{m}^{2}}$)}
               \item{${h_{\text{C}}}$ is the convective heat transfer coefficient between coil and water ($\frac{\text{W}}{\text{m}^{2}{}^{\circ}\text{C}}$)}
@@ -696,15 +696,15 @@ Description & \begin{symbDescription}
               \item{${T_{\text{W}}}$ is the temperature of the water (${{}^{\circ}\text{C}}$)}
               \item{$t$ is the time (${\text{s}}$)}
               \end{symbDescription}
-\\ \midrule \\
+\\ \midrule
 Notes & ${q_{\text{C}}}$ is found by assuming that Newton's law of cooling applies (\hyperref[assumpLCCCW]{A:Newton-Law-Convective-Cooling-Coil-Water}). This law (defined in \hyperref[TM:nwtnCooling]{TM:nwtnCooling}) is used on the surface of the heating coil.
         
         \hyperref[assumpTHCCoT]{A:Temp-Heating-Coil-Constant-over-Time}
         
-\\ \midrule \\
+\\ \midrule
 Source & \cite{koothoor2013}
          
-\\ \midrule \\
+\\ \midrule
 RefBy & \hyperref[IM:eBalanceOnWtr]{IM:eBalanceOnWtr}
         
 \\ \bottomrule
@@ -718,17 +718,17 @@ RefBy & \hyperref[IM:eBalanceOnWtr]{IM:eBalanceOnWtr}
 \toprule \textbf{Refname} & \textbf{GD:htFluxPCMFromWater}
 \phantomsection 
 \label{GD:htFluxPCMFromWater}
-\\ \midrule \\
+\\ \midrule
 Label & Heat flux into the PCM from water
         
-\\ \midrule \\
+\\ \midrule
 Units & $\frac{\text{W}}{\text{m}^{2}}$
         
-\\ \midrule \\
+\\ \midrule
 Equation & \begin{displaymath}
            {q_{\text{P}}}={h_{\text{P}}} \left({T_{\text{W}}}\left(t\right)-{T_{\text{P}}}\left(t\right)\right)
            \end{displaymath}
-\\ \midrule \\
+\\ \midrule
 Description & \begin{symbDescription}
               \item{${q_{\text{P}}}$ is the heat flux into the PCM from water ($\frac{\text{W}}{\text{m}^{2}}$)}
               \item{${h_{\text{P}}}$ is the convective heat transfer coefficient between PCM and water ($\frac{\text{W}}{\text{m}^{2}{}^{\circ}\text{C}}$)}
@@ -736,13 +736,13 @@ Description & \begin{symbDescription}
               \item{$t$ is the time (${\text{s}}$)}
               \item{${T_{\text{P}}}$ is the temperature of the phase change material (${{}^{\circ}\text{C}}$)}
               \end{symbDescription}
-\\ \midrule \\
+\\ \midrule
 Notes & ${q_{\text{P}}}$ is found by assuming that Newton's law of cooling applies (\hyperref[assumpLCCWP]{A:Law-Convective-Cooling-Water-PCM}). This law (defined in \hyperref[TM:nwtnCooling]{TM:nwtnCooling}) is used on the surface of the phase change material.
         
-\\ \midrule \\
+\\ \midrule
 Source & \cite{koothoor2013}
          
-\\ \midrule \\
+\\ \midrule
 RefBy & \hyperref[IM:eBalanceOnWtr]{IM:eBalanceOnWtr} and \hyperref[IM:eBalanceOnPCM]{IM:eBalanceOnPCM}
         
 \\ \bottomrule
@@ -760,29 +760,29 @@ This section collects and defines all the data needed to build the instance mode
 \toprule \textbf{Refname} & \textbf{DD:waterMass}
 \phantomsection 
 \label{DD:waterMass}
-\\ \midrule \\
+\\ \midrule
 Label & Mass of water
         
-\\ \midrule \\
+\\ \midrule
 Symbol & ${m_{\text{W}}}$
          
-\\ \midrule \\
+\\ \midrule
 Units & ${\text{kg}}$
         
-\\ \midrule \\
+\\ \midrule
 Equation & \begin{displaymath}
            {m_{\text{W}}}={V_{\text{W}}} {ρ_{\text{W}}}
            \end{displaymath}
-\\ \midrule \\
+\\ \midrule
 Description & \begin{symbDescription}
               \item{${m_{\text{W}}}$ is the mass of water (${\text{kg}}$)}
               \item{${V_{\text{W}}}$ is the volume of water (${\text{m}^{3}}$)}
               \item{${ρ_{\text{W}}}$ is the density of water ($\frac{\text{kg}}{\text{m}^{3}}$)}
               \end{symbDescription}
-\\ \midrule \\
+\\ \midrule
 Source & --
          
-\\ \midrule \\
+\\ \midrule
 RefBy & \hyperref[findMass]{FR:Find-Mass}
         
 \\ \bottomrule
@@ -796,32 +796,32 @@ RefBy & \hyperref[findMass]{FR:Find-Mass}
 \toprule \textbf{Refname} & \textbf{DD:waterVolume.pcm}
 \phantomsection 
 \label{DD:waterVolume.pcm}
-\\ \midrule \\
+\\ \midrule
 Label & Volume of water
         
-\\ \midrule \\
+\\ \midrule
 Symbol & ${V_{\text{W}}}$
          
-\\ \midrule \\
+\\ \midrule
 Units & ${\text{m}^{3}}$
         
-\\ \midrule \\
+\\ \midrule
 Equation & \begin{displaymath}
            {V_{\text{W}}}={V_{\text{tank}}}-{V_{\text{P}}}
            \end{displaymath}
-\\ \midrule \\
+\\ \midrule
 Description & \begin{symbDescription}
               \item{${V_{\text{W}}}$ is the volume of water (${\text{m}^{3}}$)}
               \item{${V_{\text{tank}}}$ is the volume of the cylindrical tank (${\text{m}^{3}}$)}
               \item{${V_{\text{P}}}$ is the volume of PCM (${\text{m}^{3}}$)}
               \end{symbDescription}
-\\ \midrule \\
+\\ \midrule
 Notes & Based on \hyperref[assumpVCN]{A:Volume-Coil-Negligible}. ${V_{\text{tank}}}$ is defined in \hyperref[DD:tankVolume]{DD:tankVolume}.
         
-\\ \midrule \\
+\\ \midrule
 Source & --
          
-\\ \midrule \\
+\\ \midrule
 RefBy & \hyperref[findMass]{FR:Find-Mass}
         
 \\ \bottomrule
@@ -835,30 +835,30 @@ RefBy & \hyperref[findMass]{FR:Find-Mass}
 \toprule \textbf{Refname} & \textbf{DD:tankVolume}
 \phantomsection 
 \label{DD:tankVolume}
-\\ \midrule \\
+\\ \midrule
 Label & Volume of the cylindrical tank
         
-\\ \midrule \\
+\\ \midrule
 Symbol & ${V_{\text{tank}}}$
          
-\\ \midrule \\
+\\ \midrule
 Units & ${\text{m}^{3}}$
         
-\\ \midrule \\
+\\ \midrule
 Equation & \begin{displaymath}
            {V_{\text{tank}}}=π \left(\frac{D}{2}\right)^{2} L
            \end{displaymath}
-\\ \midrule \\
+\\ \midrule
 Description & \begin{symbDescription}
               \item{${V_{\text{tank}}}$ is the volume of the cylindrical tank (${\text{m}^{3}}$)}
               \item{$π$ is the ratio of circumference to diameter for any circle (Unitless)}
               \item{$D$ is the diameter of tank (${\text{m}}$)}
               \item{$L$ is the length of tank (${\text{m}}$)}
               \end{symbDescription}
-\\ \midrule \\
+\\ \midrule
 Source & --
          
-\\ \midrule \\
+\\ \midrule
 RefBy & \hyperref[DD:waterVolume.pcm]{DD:waterVolume\_pcm} and \hyperref[findMass]{FR:Find-Mass}
         
 \\ \bottomrule
@@ -872,20 +872,20 @@ RefBy & \hyperref[DD:waterVolume.pcm]{DD:waterVolume\_pcm} and \hyperref[findMas
 \toprule \textbf{Refname} & \textbf{DD:balanceDecayRate}
 \phantomsection 
 \label{DD:balanceDecayRate}
-\\ \midrule \\
+\\ \midrule
 Label & ODE parameter for water related to decay time
         
-\\ \midrule \\
+\\ \midrule
 Symbol & ${τ_{\text{W}}}$
          
-\\ \midrule \\
+\\ \midrule
 Units & ${\text{s}}$
         
-\\ \midrule \\
+\\ \midrule
 Equation & \begin{displaymath}
            {τ_{\text{W}}}=\frac{{m_{\text{W}}} {C_{\text{W}}}}{{h_{\text{C}}} {A_{\text{C}}}}
            \end{displaymath}
-\\ \midrule \\
+\\ \midrule
 Description & \begin{symbDescription}
               \item{${τ_{\text{W}}}$ is the ODE parameter for water related to decay time (${\text{s}}$)}
               \item{${m_{\text{W}}}$ is the mass of water (${\text{kg}}$)}
@@ -893,10 +893,10 @@ Description & \begin{symbDescription}
               \item{${h_{\text{C}}}$ is the convective heat transfer coefficient between coil and water ($\frac{\text{W}}{\text{m}^{2}{}^{\circ}\text{C}}$)}
               \item{${A_{\text{C}}}$ is the heating coil surface area (${\text{m}^{2}}$)}
               \end{symbDescription}
-\\ \midrule \\
+\\ \midrule
 Source & \cite{koothoor2013}
          
-\\ \midrule \\
+\\ \midrule
 RefBy & \hyperref[outputInputDerivVals]{FR:Output-Input-Derived-Values} and \hyperref[IM:eBalanceOnWtr]{IM:eBalanceOnWtr}
         
 \\ \bottomrule
@@ -910,20 +910,20 @@ RefBy & \hyperref[outputInputDerivVals]{FR:Output-Input-Derived-Values} and \hyp
 \toprule \textbf{Refname} & \textbf{DD:balanceDecayTime}
 \phantomsection 
 \label{DD:balanceDecayTime}
-\\ \midrule \\
+\\ \midrule
 Label & ODE parameter related to decay rate
         
-\\ \midrule \\
+\\ \midrule
 Symbol & $η$
          
-\\ \midrule \\
+\\ \midrule
 Units & Unitless
         
-\\ \midrule \\
+\\ \midrule
 Equation & \begin{displaymath}
            η=\frac{{h_{\text{P}}} {A_{\text{P}}}}{{h_{\text{C}}} {A_{\text{C}}}}
            \end{displaymath}
-\\ \midrule \\
+\\ \midrule
 Description & \begin{symbDescription}
               \item{$η$ is the ODE parameter related to decay rate (Unitless)}
               \item{${h_{\text{P}}}$ is the convective heat transfer coefficient between PCM and water ($\frac{\text{W}}{\text{m}^{2}{}^{\circ}\text{C}}$)}
@@ -931,10 +931,10 @@ Description & \begin{symbDescription}
               \item{${h_{\text{C}}}$ is the convective heat transfer coefficient between coil and water ($\frac{\text{W}}{\text{m}^{2}{}^{\circ}\text{C}}$)}
               \item{${A_{\text{C}}}$ is the heating coil surface area (${\text{m}^{2}}$)}
               \end{symbDescription}
-\\ \midrule \\
+\\ \midrule
 Source & \cite{koothoor2013}
          
-\\ \midrule \\
+\\ \midrule
 RefBy & \hyperref[outputInputDerivVals]{FR:Output-Input-Derived-Values} and \hyperref[IM:eBalanceOnWtr]{IM:eBalanceOnWtr}
         
 \\ \bottomrule
@@ -948,20 +948,20 @@ RefBy & \hyperref[outputInputDerivVals]{FR:Output-Input-Derived-Values} and \hyp
 \toprule \textbf{Refname} & \textbf{DD:balanceSolidPCM}
 \phantomsection 
 \label{DD:balanceSolidPCM}
-\\ \midrule \\
+\\ \midrule
 Label & ODE parameter for solid PCM
         
-\\ \midrule \\
+\\ \midrule
 Symbol & ${{τ_{\text{P}}}^{\text{S}}}$
          
-\\ \midrule \\
+\\ \midrule
 Units & ${\text{s}}$
         
-\\ \midrule \\
+\\ \midrule
 Equation & \begin{displaymath}
            {{τ_{\text{P}}}^{\text{S}}}=\frac{{m_{\text{P}}} {{C_{\text{P}}}^{\text{S}}}}{{h_{\text{P}}} {A_{\text{P}}}}
            \end{displaymath}
-\\ \midrule \\
+\\ \midrule
 Description & \begin{symbDescription}
               \item{${{τ_{\text{P}}}^{\text{S}}}$ is the ODE parameter for solid PCM (${\text{s}}$)}
               \item{${m_{\text{P}}}$ is the mass of phase change material (${\text{kg}}$)}
@@ -969,10 +969,10 @@ Description & \begin{symbDescription}
               \item{${h_{\text{P}}}$ is the convective heat transfer coefficient between PCM and water ($\frac{\text{W}}{\text{m}^{2}{}^{\circ}\text{C}}$)}
               \item{${A_{\text{P}}}$ is the phase change material surface area (${\text{m}^{2}}$)}
               \end{symbDescription}
-\\ \midrule \\
+\\ \midrule
 Source & \cite{lightstone2012}
          
-\\ \midrule \\
+\\ \midrule
 RefBy & \hyperref[outputInputDerivVals]{FR:Output-Input-Derived-Values} and \hyperref[IM:eBalanceOnPCM]{IM:eBalanceOnPCM}
         
 \\ \bottomrule
@@ -986,20 +986,20 @@ RefBy & \hyperref[outputInputDerivVals]{FR:Output-Input-Derived-Values} and \hyp
 \toprule \textbf{Refname} & \textbf{DD:balanceLiquidPCM}
 \phantomsection 
 \label{DD:balanceLiquidPCM}
-\\ \midrule \\
+\\ \midrule
 Label & ODE parameter for liquid PCM
         
-\\ \midrule \\
+\\ \midrule
 Symbol & ${{τ_{\text{P}}}^{\text{L}}}$
          
-\\ \midrule \\
+\\ \midrule
 Units & ${\text{s}}$
         
-\\ \midrule \\
+\\ \midrule
 Equation & \begin{displaymath}
            {{τ_{\text{P}}}^{\text{L}}}=\frac{{m_{\text{P}}} {{C_{\text{P}}}^{\text{L}}}}{{h_{\text{P}}} {A_{\text{P}}}}
            \end{displaymath}
-\\ \midrule \\
+\\ \midrule
 Description & \begin{symbDescription}
               \item{${{τ_{\text{P}}}^{\text{L}}}$ is the ODE parameter for liquid PCM (${\text{s}}$)}
               \item{${m_{\text{P}}}$ is the mass of phase change material (${\text{kg}}$)}
@@ -1007,10 +1007,10 @@ Description & \begin{symbDescription}
               \item{${h_{\text{P}}}$ is the convective heat transfer coefficient between PCM and water ($\frac{\text{W}}{\text{m}^{2}{}^{\circ}\text{C}}$)}
               \item{${A_{\text{P}}}$ is the phase change material surface area (${\text{m}^{2}}$)}
               \end{symbDescription}
-\\ \midrule \\
+\\ \midrule
 Source & \cite{lightstone2012}
          
-\\ \midrule \\
+\\ \midrule
 RefBy & \hyperref[outputInputDerivVals]{FR:Output-Input-Derived-Values} and \hyperref[IM:eBalanceOnPCM]{IM:eBalanceOnPCM}
         
 \\ \bottomrule
@@ -1024,32 +1024,32 @@ RefBy & \hyperref[outputInputDerivVals]{FR:Output-Input-Derived-Values} and \hyp
 \toprule \textbf{Refname} & \textbf{DD:htFusion}
 \phantomsection 
 \label{DD:htFusion}
-\\ \midrule \\
+\\ \midrule
 Label & Specific latent heat of fusion
         
-\\ \midrule \\
+\\ \midrule
 Symbol & ${H_{\text{f}}}$
          
-\\ \midrule \\
+\\ \midrule
 Units & $\frac{\text{J}}{\text{kg}}$
         
-\\ \midrule \\
+\\ \midrule
 Equation & \begin{displaymath}
            {H_{\text{f}}}=\frac{Q}{m}
            \end{displaymath}
-\\ \midrule \\
+\\ \midrule
 Description & \begin{symbDescription}
               \item{${H_{\text{f}}}$ is the specific latent heat of fusion ($\frac{\text{J}}{\text{kg}}$)}
               \item{$Q$ is the latent heat (${\text{J}}$)}
               \item{$m$ is the mass (${\text{kg}}$)}
               \end{symbDescription}
-\\ \midrule \\
+\\ \midrule
 Notes & The specific latent heat of fusion (also known as the enthalpy of fusion) of a substance is the heat energy required ($Q$) to change the state of a unit of the mass ($m$) of the substance from solid to liquid, at constant pressure.
         
-\\ \midrule \\
+\\ \midrule
 Source & \cite[(pg. 282)]{bueche1986}
          
-\\ \midrule \\
+\\ \midrule
 RefBy & \hyperref[DD:meltFrac]{DD:meltFrac} and \hyperref[IM:heatEInPCM]{IM:heatEInPCM}
         
 \\ \bottomrule
@@ -1063,35 +1063,35 @@ RefBy & \hyperref[DD:meltFrac]{DD:meltFrac} and \hyperref[IM:heatEInPCM]{IM:heat
 \toprule \textbf{Refname} & \textbf{DD:meltFrac}
 \phantomsection 
 \label{DD:meltFrac}
-\\ \midrule \\
+\\ \midrule
 Label & Melt fraction
         
-\\ \midrule \\
+\\ \midrule
 Symbol & $ϕ$
          
-\\ \midrule \\
+\\ \midrule
 Units & Unitless
         
-\\ \midrule \\
+\\ \midrule
 Equation & \begin{displaymath}
            ϕ=\frac{{Q_{\text{P}}}}{{H_{\text{f}}} {m_{\text{P}}}}
            \end{displaymath}
-\\ \midrule \\
+\\ \midrule
 Description & \begin{symbDescription}
               \item{$ϕ$ is the melt fraction (Unitless)}
               \item{${Q_{\text{P}}}$ is the latent heat energy added to PCM (${\text{J}}$)}
               \item{${H_{\text{f}}}$ is the specific latent heat of fusion ($\frac{\text{J}}{\text{kg}}$)}
               \item{${m_{\text{P}}}$ is the mass of phase change material (${\text{kg}}$)}
               \end{symbDescription}
-\\ \midrule \\
+\\ \midrule
 Notes & The value of $ϕ$ is constrained to $0\leq{}ϕ\leq{}1$.
         
         \hyperref[DD:htFusion]{DD:htFusion}
         
-\\ \midrule \\
+\\ \midrule
 Source & \cite{koothoor2013}
          
-\\ \midrule \\
+\\ \midrule
 RefBy & \hyperref[TM:latentHtE]{TM:latentHtE} and \hyperref[IM:eBalanceOnPCM]{IM:eBalanceOnPCM}
         
 \\ \bottomrule
@@ -1105,29 +1105,29 @@ RefBy & \hyperref[TM:latentHtE]{TM:latentHtE} and \hyperref[IM:eBalanceOnPCM]{IM
 \toprule \textbf{Refname} & \textbf{DD:aspectRatio}
 \phantomsection 
 \label{DD:aspectRatio}
-\\ \midrule \\
+\\ \midrule
 Label & Aspect ratio
         
-\\ \midrule \\
+\\ \midrule
 Symbol & $\mathit{AR}$
          
-\\ \midrule \\
+\\ \midrule
 Units & Unitless
         
-\\ \midrule \\
+\\ \midrule
 Equation & \begin{displaymath}
            \mathit{AR}=\frac{D}{L}
            \end{displaymath}
-\\ \midrule \\
+\\ \midrule
 Description & \begin{symbDescription}
               \item{$\mathit{AR}$ is the aspect ratio (Unitless)}
               \item{$D$ is the diameter of tank (${\text{m}}$)}
               \item{$L$ is the length of tank (${\text{m}}$)}
               \end{symbDescription}
-\\ \midrule \\
+\\ \midrule
 Source & --
          
-\\ \midrule \\
+\\ \midrule
 RefBy & 
 \\ \bottomrule
 \end{tabular}
@@ -1146,26 +1146,26 @@ The goals \hyperref[waterTempGS]{GS:Predict-Water-Temperature}, \hyperref[pcmTem
 \toprule \textbf{Refname} & \textbf{IM:eBalanceOnWtr}
 \phantomsection 
 \label{IM:eBalanceOnWtr}
-\\ \midrule \\
+\\ \midrule
 Label & Energy balance on water to find the temperature of the water
         
-\\ \midrule \\
+\\ \midrule
 Input & ${m_{\text{W}}}$, ${C_{\text{W}}}$, ${h_{\text{C}}}$, ${A_{\text{P}}}$, ${h_{\text{P}}}$, ${A_{\text{C}}}$, ${T_{\text{P}}}$, ${t_{\text{final}}}$, ${T_{\text{C}}}$, ${T_{\text{init}}}$
         
-\\ \midrule \\
+\\ \midrule
 Output & ${T_{\text{W}}}$
          
-\\ \midrule \\
+\\ \midrule
 Input Constraints & \begin{displaymath}
                     {T_{\text{C}}}\gt{}{T_{\text{init}}}
                     \end{displaymath}
-\\ \midrule \\
+\\ \midrule
 Output Constraints & 
-\\ \midrule \\
+\\ \midrule
 Equation & \begin{displaymath}
            \frac{\,d{T_{\text{W}}}}{\,dt}=\frac{1}{{τ_{\text{W}}}} \left({T_{\text{C}}}-{T_{\text{W}}}\left(t\right)+η \left({T_{\text{P}}}\left(t\right)-{T_{\text{W}}}\left(t\right)\right)\right)
            \end{displaymath}
-\\ \midrule \\
+\\ \midrule
 Description & \begin{symbDescription}
               \item{$t$ is the time (${\text{s}}$)}
               \item{${T_{\text{W}}}$ is the temperature of the water (${{}^{\circ}\text{C}}$)}
@@ -1174,7 +1174,7 @@ Description & \begin{symbDescription}
               \item{$η$ is the ODE parameter related to decay rate (Unitless)}
               \item{${T_{\text{P}}}$ is the temperature of the phase change material (${{}^{\circ}\text{C}}$)}
               \end{symbDescription}
-\\ \midrule \\
+\\ \midrule
 Notes & ${T_{\text{P}}}$ is defined by \hyperref[IM:eBalanceOnPCM]{IM:eBalanceOnPCM}.
         
         The input constraint ${T_{\text{init}}}\leq{}{T_{\text{C}}}$ comes from \hyperref[assumpCTNOD]{A:Charging-Tank-No-Temp-Discharge}.
@@ -1187,10 +1187,10 @@ Notes & ${T_{\text{P}}}$ is defined by \hyperref[IM:eBalanceOnPCM]{IM:eBalanceOn
         
         The ODE applies as long as the water is in liquid form, $0\lt{}{T_{\text{W}}}\lt{}100$ (${{}^{\circ}\text{C}}$) where $0$ (${{}^{\circ}\text{C}}$) and $100$ (${{}^{\circ}\text{C}}$) are the melting and boiling point temperatures of water, respectively (from \hyperref[assumpWAL]{A:Water-Always-Liquid} and \hyperref[assumpAPT]{A:Atmospheric-Pressure-Tank}).
         
-\\ \midrule \\
+\\ \midrule
 Source & \cite{koothoor2013}
          
-\\ \midrule \\
+\\ \midrule
 RefBy & \hyperref[unlikeChgNIHG]{UC:No-Internal-Heat-Generation}, \hyperref[findMass]{FR:Find-Mass}, \hyperref[IM:eBalanceOnWtr]{IM:eBalanceOnWtr}, \hyperref[IM:eBalanceOnPCM]{IM:eBalanceOnPCM}, and \hyperref[calcTempWtrOverTime]{FR:Calculate-Temperature-Water-Over-Time}
         
 \\ \bottomrule
@@ -1240,22 +1240,22 @@ Finally, factoring out $\frac{1}{{τ_{\text{W}}}}$, we are left with the governi
 \toprule \textbf{Refname} & \textbf{IM:eBalanceOnPCM}
 \phantomsection 
 \label{IM:eBalanceOnPCM}
-\\ \midrule \\
+\\ \midrule
 Label & Energy Balance on PCM to find temperature of PCM
         
-\\ \midrule \\
+\\ \midrule
 Input & ${{T_{\text{melt}}}^{\text{P}}}$, ${t_{\text{final}}}$, ${T_{\text{init}}}$, ${A_{\text{P}}}$, ${h_{\text{P}}}$, ${m_{\text{P}}}$, ${{C_{\text{P}}}^{\text{S}}}$, ${{C_{\text{P}}}^{\text{L}}}$
         
-\\ \midrule \\
+\\ \midrule
 Output & ${T_{\text{P}}}$
          
-\\ \midrule \\
+\\ \midrule
 Input Constraints & \begin{displaymath}
                     {{T_{\text{melt}}}^{\text{P}}}\gt{}{T_{\text{init}}}
                     \end{displaymath}
-\\ \midrule \\
+\\ \midrule
 Output Constraints & 
-\\ \midrule \\
+\\ \midrule
 Equation & \begin{displaymath}
            \frac{\,d{T_{\text{P}}}}{\,dt}=\begin{cases}
                                           \frac{1}{{{τ_{\text{P}}}^{\text{S}}}} \left({T_{\text{W}}}\left(t\right)-{T_{\text{P}}}\left(t\right)\right), & {T_{\text{P}}}\lt{}{{T_{\text{melt}}}^{\text{P}}}\\
@@ -1263,7 +1263,7 @@ Equation & \begin{displaymath}
                                           0, & {T_{\text{P}}}={{T_{\text{melt}}}^{\text{P}}}\land{}0\lt{}ϕ\lt{}1
                                           \end{cases}
            \end{displaymath}
-\\ \midrule \\
+\\ \midrule
 Description & \begin{symbDescription}
               \item{$t$ is the time (${\text{s}}$)}
               \item{${T_{\text{P}}}$ is the temperature of the phase change material (${{}^{\circ}\text{C}}$)}
@@ -1273,7 +1273,7 @@ Description & \begin{symbDescription}
               \item{${{T_{\text{melt}}}^{\text{P}}}$ is the melting point temperature for PCM (${{}^{\circ}\text{C}}$)}
               \item{$ϕ$ is the melt fraction (Unitless)}
               \end{symbDescription}
-\\ \midrule \\
+\\ \midrule
 Notes & ${T_{\text{W}}}$ is defined by \hyperref[IM:eBalanceOnWtr]{IM:eBalanceOnWtr}.
         
         The input constraint ${T_{\text{init}}}\leq{}{{T_{\text{melt}}}^{\text{P}}}$ comes from \hyperref[assumpPIS]{A:PCM-Initially-Solid}.
@@ -1286,10 +1286,10 @@ Notes & ${T_{\text{W}}}$ is defined by \hyperref[IM:eBalanceOnWtr]{IM:eBalanceOn
         
         The initial conditions for the ODE are ${T_{\text{W}}}\left(0\right)={T_{\text{P}}}\left(0\right)={T_{\text{init}}}$ following \hyperref[assumpSITWP]{A:Same-Initial-Temp-Water-PCM}.
         
-\\ \midrule \\
+\\ \midrule
 Source & \cite{koothoor2013}
          
-\\ \midrule \\
+\\ \midrule
 RefBy & \hyperref[unlikeChgNIHG]{UC:No-Internal-Heat-Generation}, \hyperref[unlikeChgNGS]{UC:No-Gaseous-State}, \hyperref[findMass]{FR:Find-Mass}, \hyperref[IM:eBalanceOnWtr]{IM:eBalanceOnWtr}, \hyperref[calcTempPCMOverTime]{FR:Calculate-Temperature-PCM-Over-Time}, \hyperref[calcPCMMeltEnd]{FR:Calculate-PCM-Melt-End-Time}, and \hyperref[calcPCMMeltBegin]{FR:Calculate-PCM-Melt-Begin-Time}
         
 \\ \bottomrule
@@ -1330,24 +1330,24 @@ This derivation does not consider the boiling of the PCM, as the PCM is assumed 
 \toprule \textbf{Refname} & \textbf{IM:heatEInWtr}
 \phantomsection 
 \label{IM:heatEInWtr}
-\\ \midrule \\
+\\ \midrule
 Label & Heat energy in the water
         
-\\ \midrule \\
+\\ \midrule
 Input & ${T_{\text{init}}}$, ${m_{\text{W}}}$, ${C_{\text{W}}}$, ${m_{\text{W}}}$
         
-\\ \midrule \\
+\\ \midrule
 Output & ${E_{\text{W}}}$
          
-\\ \midrule \\
+\\ \midrule
 Input Constraints & 
-\\ \midrule \\
+\\ \midrule
 Output Constraints & 
-\\ \midrule \\
+\\ \midrule
 Equation & \begin{displaymath}
            {E_{\text{W}}}\left(t\right)={C_{\text{W}}} {m_{\text{W}}} \left({T_{\text{W}}}\left(t\right)-{T_{\text{init}}}\right)
            \end{displaymath}
-\\ \midrule \\
+\\ \midrule
 Description & \begin{symbDescription}
               \item{${E_{\text{W}}}$ is the change in heat energy in the water (${\text{J}}$)}
               \item{$t$ is the time (${\text{s}}$)}
@@ -1356,17 +1356,17 @@ Description & \begin{symbDescription}
               \item{${T_{\text{W}}}$ is the temperature of the water (${{}^{\circ}\text{C}}$)}
               \item{${T_{\text{init}}}$ is the initial temperature (${{}^{\circ}\text{C}}$)}
               \end{symbDescription}
-\\ \midrule \\
+\\ \midrule
 Notes & The above equation is derived using \hyperref[TM:sensHtE]{TM:sensHtE}.
         
         The change in temperature is the difference between the temperature at time $t$ (${\text{s}}$), ${T_{\text{W}}}$ and the initial temperature, ${T_{\text{init}}}$ (${{}^{\circ}\text{C}}$).
         
         This equation applies as long as $0\lt{}{T_{\text{W}}}\lt{}100$${{}^{\circ}\text{C}}$ (\hyperref[assumpWAL]{A:Water-Always-Liquid}, \hyperref[assumpAPT]{A:Atmospheric-Pressure-Tank}).
         
-\\ \midrule \\
+\\ \midrule
 Source & \cite{koothoor2013}
          
-\\ \midrule \\
+\\ \midrule
 RefBy & \hyperref[findMass]{FR:Find-Mass} and \hyperref[calcChgHeatEnergyWtrOverTime]{FR:Calculate-Change-Heat\_Energy-Water-Over-Time}
         
 \\ \bottomrule
@@ -1380,22 +1380,22 @@ RefBy & \hyperref[findMass]{FR:Find-Mass} and \hyperref[calcChgHeatEnergyWtrOver
 \toprule \textbf{Refname} & \textbf{IM:heatEInPCM}
 \phantomsection 
 \label{IM:heatEInPCM}
-\\ \midrule \\
+\\ \midrule
 Label & Heat energy in the PCM
         
-\\ \midrule \\
+\\ \midrule
 Input & ${{T_{\text{melt}}}^{\text{P}}}$, ${t_{\text{final}}}$, ${T_{\text{init}}}$, ${A_{\text{P}}}$, ${h_{\text{P}}}$, ${m_{\text{P}}}$, ${{C_{\text{P}}}^{\text{S}}}$, ${{C_{\text{P}}}^{\text{L}}}$, ${T_{\text{P}}}$, ${H_{\text{f}}}$, ${{t_{\text{melt}}}^{\text{init}}}$
         
-\\ \midrule \\
+\\ \midrule
 Output & ${E_{\text{P}}}$
          
-\\ \midrule \\
+\\ \midrule
 Input Constraints & \begin{displaymath}
                     {{T_{\text{melt}}}^{\text{P}}}\gt{}{T_{\text{init}}}
                     \end{displaymath}
-\\ \midrule \\
+\\ \midrule
 Output Constraints & 
-\\ \midrule \\
+\\ \midrule
 Equation & \begin{displaymath}
            {E_{\text{P}}}=\begin{cases}
                           {{C_{\text{P}}}^{\text{S}}} {m_{\text{P}}} \left({T_{\text{P}}}\left(t\right)-{T_{\text{init}}}\right), & {T_{\text{P}}}\lt{}{{T_{\text{melt}}}^{\text{P}}}\\
@@ -1403,7 +1403,7 @@ Equation & \begin{displaymath}
                           {{{E_{\text{P}}}_{\text{melt}}}^{\text{init}}}+{Q_{\text{P}}}\left(t\right), & {T_{\text{P}}}={{T_{\text{melt}}}^{\text{P}}}\land{}0\lt{}ϕ\lt{}1
                           \end{cases}
            \end{displaymath}
-\\ \midrule \\
+\\ \midrule
 Description & \begin{symbDescription}
               \item{${E_{\text{P}}}$ is the change in heat energy in the PCM (${\text{J}}$)}
               \item{${{C_{\text{P}}}^{\text{S}}}$ is the specific heat capacity of PCM as a solid ($\frac{\text{J}}{\text{kg}{}^{\circ}\text{C}}$)}
@@ -1418,7 +1418,7 @@ Description & \begin{symbDescription}
               \item{${Q_{\text{P}}}$ is the latent heat energy added to PCM (${\text{J}}$)}
               \item{$ϕ$ is the melt fraction (Unitless)}
               \end{symbDescription}
-\\ \midrule \\
+\\ \midrule
 Notes & The above equation is derived using \hyperref[TM:sensHtE]{TM:sensHtE} and \hyperref[TM:latentHtE]{TM:latentHtE}.
         
         ${E_{\text{P}}}$ for the solid PCM is found using \hyperref[TM:sensHtE]{TM:sensHtE} for sensible heating, with the specific heat capacity of the solid PCM, ${{C_{\text{P}}}^{\text{S}}}$ ($\frac{\text{J}}{\text{kg}{}^{\circ}\text{C}}$) and the change in the PCM temperature from the initial temperature (${{}^{\circ}\text{C}}$).
@@ -1433,10 +1433,10 @@ Notes & The above equation is derived using \hyperref[TM:sensHtE]{TM:sensHtE} an
         
         The heat energy for boiling of the PCM is not detailed, since the PCM is assumed to either be in a solid or liquid state (\hyperref[assumpNGSP]{A:No-Gaseous-State-PCM}) (\hyperref[assumpPIS]{A:PCM-Initially-Solid}).
         
-\\ \midrule \\
+\\ \midrule
 Source & \cite{koothoor2013}
          
-\\ \midrule \\
+\\ \midrule
 RefBy & \hyperref[unlikeChgNGS]{UC:No-Gaseous-State}, \hyperref[findMass]{FR:Find-Mass}, \hyperref[IM:eBalanceOnPCM]{IM:eBalanceOnPCM}, and \hyperref[calcChgHeatEnergyPCMOverTime]{FR:Calculate-Change-Heat\_Energy-PCM-Over-Time}
         
 \\ \bottomrule


### PR DESCRIPTION
Closes #3458.

I have checked locally that this can be merged independently of #3460 (I ran `git merge --no-commit fix-tabu` followed by `make pr_ready`).