### PR TITLE
Add GOOL examples to CI

### DIFF
--- a/.github/workflows/Build.yaml
+++ b/.github/workflows/Build.yaml
@@ -64,6 +64,8 @@ jobs:
         run: make code stackArgs="--no-terminal" GHCFLAGS="-Werror"
       - name: "Test built artifacts against stable"
         run: make stackArgs="--no-terminal" GHCFLAGS="-Werror" NOISY=yes
+      - name: "Compile GOOL examples"
+        run: make codegenTest
       - name: "Compile generated TeX artifacts"
         run: make tex SUMMARIZE_TEX=yes
       - name: "Compile generated software artifacts"


### PR DESCRIPTION
This PR adds a step in the GitHub workflow to generate C++, Java, etc. from the GOOL examples under `drasil-code/test` and compile them to check for compile errors.