### PR TITLE
3510 Fixes New Tests Failing on CI

### DIFF
--- a/code/drasil-code/test/NameGenTest.hs
+++ b/code/drasil-code/test/NameGenTest.hs
@@ -3,7 +3,7 @@ module NameGenTest (nameGenTest) where
 import GOOL.Drasil
 
 nameGenTest :: OOProg r => GSProgram r
-nameGenTest = prog "NameGenTest" [fileDoc $ buildModule "NameGenTest" [] [main, helper] []]
+nameGenTest = prog "NameGenTest" "" [fileDoc $ buildModule "NameGenTest" [] [main, helper] []]
 
 helper :: OOProg r => SMethod r
 helper = function "helper" private void [param temp] $ body

--- a/code/drasil-code/test/VectorTest.hs
+++ b/code/drasil-code/test/VectorTest.hs
@@ -7,7 +7,7 @@ import GOOL.Drasil (GSProgram, SVariable, SMethod, OOProg, ProgramSym(..),
   ModuleSym(..))
 
 vectorTest :: OOProg r => GSProgram r
-vectorTest = prog "VectorTest" [fileDoc $ buildModule "VectorTest" []
+vectorTest = prog "VectorTest" "" [fileDoc $ buildModule "VectorTest" []
   [main] []]
 
 v1 :: OOProg r => SVariable r


### PR DESCRIPTION
Closes #3510. Changes made to `VectorTest.hs` and `NameGenTest.hs`