### PR TITLE
Change `hghc`, `srsSWHS`, and `swhsPCM` to `CI`s

### DIFF
--- a/code/drasil-example/hghc/lib/Drasil/HGHC/HeatTransfer.hs
+++ b/code/drasil-example/hghc/lib/Drasil/HGHC/HeatTransfer.hs
@@ -65,8 +65,8 @@ htTransCladFuelEq = (exactDbl 2 `mulRe` sy cladCond `mulRe` sy gapFilmCond) $/ (
 
 ---
 
-hghc :: CommonConcept
-hghc = dcc' "hghc" (cn "HGHC") "HGHC program" "HGHC"
+hghc :: CI
+hghc = commonIdea "hghc" (cn "HGHC") "HGHC" []
 
 nuclearPhys, fp :: IdeaDict
 nuclearPhys = nc "nuclearPhys" (nounPhraseSP "nuclear physics")

--- a/code/drasil-example/nopcm/lib/Drasil/NoPCM/Definitions.hs
+++ b/code/drasil-example/nopcm/lib/Drasil/NoPCM/Definitions.hs
@@ -7,6 +7,5 @@ htTrans :: IdeaDict
 htTrans = nc "heat transfer" (cn "heat transfer") --Not really a nounphase,
                                                    --just a hack to get RefSec to work
 
-srsSWHS :: CommonConcept -- Used to make the title of the paper
-srsSWHS = dcc' "srsSWHS" (nounPhraseSP "Solar Water Heating Systems")
-  "SWHS" "NoPCM"
+srsSWHS :: CI -- Used to make the title of the paper
+srsSWHS = commonIdea "srsSWHS" (nounPhraseSP "Solar Water Heating Systems") "NoPCM" []

--- a/code/drasil-example/swhs/lib/Drasil/SWHS/Body.hs
+++ b/code/drasil-example/swhs/lib/Drasil/SWHS/Body.hs
@@ -1,6 +1,8 @@
 {-# LANGUAGE PostfixOperators #-}
 module Drasil.SWHS.Body where
 
+import Control.Lens ((^.))
+
 import Language.Drasil hiding (organization, section, variable)
 import Drasil.SRSDocument
 import qualified Drasil.DocLang.SRS as SRS (inModel)
@@ -8,8 +10,6 @@ import Theory.Drasil (GenDefn, InstanceModel)
 import Language.Drasil.Chunk.Concept.NamedCombinators
 import qualified Language.Drasil.NounPhrase.Combinators as NP
 import qualified Language.Drasil.Sentence.Combinators as S
-
-import Control.Lens ((^.))
 
 import qualified Data.Drasil.Concepts.Documentation as Doc (srs)
 import Data.Drasil.TheoryConcepts as Doc (inModel)
@@ -199,9 +199,10 @@ introStart = foldlSent [S "Due to", foldlList Comma List (map S
   energy), S "storage technology"]
 
 introStartSWHS :: Sentence
-introStartSWHS = foldlSent [capSent (swhsPCM ^. defn), sParen (short phsChgMtrl),
-  S "use a renewable", phrase enerSrc `S.and_` S "provide a novel way of storing" +:+.
-  phrase energy, atStart swhsPCM, S "improve over the traditional", plural progName,
+introStartSWHS = foldlSent [capSent $ pluralNP $ progName ^. term, S "incorporating",
+  phrase phsChgMtrl, sParen (short phsChgMtrl), S "use a renewable",
+  phrase enerSrc `S.and_` S "provide a novel way of storing" +:+.  phrase energy,
+  atStart swhsPCM, S "improve over the traditional", plural progName,
   S "because of their smaller size. The smaller size is possible because of the ability" `S.of_`
   short phsChgMtrl, S "to store", phrase thermalEnergy, S "as", phrase latentHeat `sC`
   S "which allows higher", phrase thermalEnergy, S "storage capacity per",

--- a/code/drasil-example/swhs/lib/Drasil/SWHS/Concepts.hs
+++ b/code/drasil-example/swhs/lib/Drasil/SWHS/Concepts.hs
@@ -80,13 +80,13 @@ tankPCM = dcc "tankPCM" (nounPhrase''
   CapFirst CapWords)
   "solar water heating tank incorporating phase change material"
 
-swhsPCM :: CommonConcept
+swhsPCM :: CI
 -- Nounphrase'' hack to get nounPhraseSP words to accept
 -- nounPhrases instead of strings
 -- Another capitalization hack.
-swhsPCM = dcc' "swhsPCM" (nounPhrase''
+swhsPCM = commonIdea "swhsPCM" (nounPhrase''
   (S "solar water heating systems" +:+ S "incorporating" +:+ short phsChgMtrl)
   (S "solar water heating systems" +:+ S "incorporating" +:+ short phsChgMtrl)
   CapFirst CapWords)
-  "solar water heating systems incorporating phase change material"
   "SWHS"
+  []


### PR DESCRIPTION
Closes #3542.

A possibly controversial change is the change from `capSent (swhsPCM ^. defn)` to `capSent $ pluralNP $ progName ^. term, S "incorporating", phrase phsChgMtrl` (this is inside the list of `Setence`s passed to `foldlSent`) in `introStartSWHS`.

In the original code, `swhsPCM` is a `CommonConcept` whose term is "solar water heating systems incorporating PCM" and whose definition is "solar water heating systems incorporating phase change material" (the definition expands "PCM" to "phase change material"). This is not really a definition but rather a hack to get multiple levels of abbreviation, and since this "definition" is only used in one place, I don't think we are worse off if we just construct it in the spot where it is used, especially with respect to our goal of removing `CommonConcept` (#3536).