### PR TITLE
Move HLint script to a separate workflow file

### DIFF
--- a/.github/workflows/Build.yaml
+++ b/.github/workflows/Build.yaml
@@ -56,8 +56,6 @@ jobs:
         run: |
           echo "$HOME/.local/bin" >> $GITHUB_PATH
           echo "$HOME/.swift/usr/bin" >> $GITHUB_PATH
-      - name: "HLint"
-        run: make hot_hlint
       - name: "Install dependencies"
         run: make stackArgs="--no-terminal" deps
       - name: "Build"

--- a/.github/workflows/Lint.yaml
+++ b/.github/workflows/Lint.yaml
@@ -3,6 +3,9 @@ on:
     branches: master
     paths: 'code/drasil-*'
 name: Linter
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 defaults:
   run:
     shell: bash

--- a/.github/workflows/Lint.yaml
+++ b/.github/workflows/Lint.yaml
@@ -1,7 +1,7 @@
 on:
   pull_request:
     branches: master
-    paths: 'code/drasil-*'
+    paths: 'code/drasil-**'
 name: Linter
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/Lint.yaml
+++ b/.github/workflows/Lint.yaml
@@ -1,0 +1,17 @@
+on:
+  pull_request:
+    branches: master
+    paths: 'code/drasil-*'
+name: Linter
+defaults:
+  run:
+    shell: bash
+    working-directory: code
+jobs:
+  linter:
+    name: "HLint"
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v3
+      - name: "HLint"
+        run: make hot_hlint


### PR DESCRIPTION
Contributes to #2789 

Decreases build time by only running HLint when absolutely necessary (i.e., when a file in one of the `code/drasil-*` paths are edited) and concurrently alongside the "build & test" workflow.

Tested with #3553.