### PR TITLE
Rename `drasil-lang`s ...CodeBase to ...CodeVar

### DIFF
--- a/code/drasil-lang/lib/Language/Drasil.hs
+++ b/code/drasil-lang/lib/Language/Drasil.hs
@@ -87,7 +87,6 @@ module Language.Drasil (
   , (+++), (+++.), (+++!)
   , nc, ncUID, IdeaDict , mkIdea
   , nw -- bad name (historical)
-  -- Language.Drasil.Chunk.CodeBase
   , CodeIdea(..), CodeChunk(..), CodeVarChunk(..), CodeFuncChunk(..), VarOrFunc(..)
   , obv, qc, ccf, ccv, listToArray, programName, funcPrefix, DefiningCodeExpr(..)
   -- Language.Drasil.Chunk.CommonIdea
@@ -345,8 +344,9 @@ import Language.Drasil.Chunk.Citation (
   , cInBookACP, cInBookECP, cInBookAC, cInBookEC, cInBookAP, cInBookEP
   , cInCollection, cInProceedings, cManual, cMThesis, cMisc, cPhDThesis
   , cProceedings, cTechReport, cUnpublished)
-import Language.Drasil.Chunk.CodeBase (CodeIdea(..), CodeChunk(..), CodeVarChunk(..), CodeFuncChunk(..), 
-  VarOrFunc(..), obv, qc, ccf, ccv, listToArray, programName, funcPrefix, DefiningCodeExpr(..))
+import Language.Drasil.Chunk.CodeVar (CodeIdea(..), CodeChunk(..), 
+  CodeVarChunk(..), CodeFuncChunk(..), VarOrFunc(..), obv, qc, ccf, ccv, 
+  listToArray, programName, funcPrefix, DefiningCodeExpr(..))
 import Language.Drasil.Chunk.CommonIdea
 import Language.Drasil.Chunk.Concept
 import Language.Drasil.Chunk.Concept.Core (sDom) -- exported for drasil-database FIXME: move to development package?

--- a/code/drasil-lang/lib/Language/Drasil/Chunk/CodeVar.hs
+++ b/code/drasil-lang/lib/Language/Drasil/Chunk/CodeVar.hs
@@ -1,6 +1,6 @@
 {-# LANGUAGE TemplateHaskell #-}
 -- | Defines chunk types for use in code generation.
-module Language.Drasil.Chunk.CodeBase where
+module Language.Drasil.Chunk.CodeVar where
 
 import Control.Lens ((^.), view, makeLenses, Lens')
 

--- a/code/drasil-lang/lib/Language/Drasil/CodeExpr/Class.hs
+++ b/code/drasil-lang/lib/Language/Drasil/CodeExpr/Class.hs
@@ -4,7 +4,7 @@ import Language.Drasil.Classes(IsArgumentName, Callable)
 import Language.Drasil.UID (HasUID(..))
 import Language.Drasil.Symbol (HasSymbol)
 import Language.Drasil.Space (Space(Actor), HasSpace(..))
-import Language.Drasil.Chunk.CodeBase (CodeIdea, CodeVarChunk)
+import Language.Drasil.Chunk.CodeVar (CodeIdea, CodeVarChunk)
 import Language.Drasil.Expr.Class (ExprC(..))
 import Language.Drasil.CodeExpr.Lang (CodeExpr(FCall, New, Message, Field))
 


### PR DESCRIPTION
Closes #3470 and allows us to load Drasil into `ghci` again.

@hrzhuang if you could confirm it runs on your machine as well, I'd appreciate it!