### PR TITLE
Add Stack-based shebangs to some of the `scripts/**.hs` files

### DIFF
--- a/code/Makefile
+++ b/code/Makefile
@@ -342,8 +342,8 @@ $(filter %$(GRAPH_P_SUFFIX), $(GRAPH_PACKAGES)): %$(GRAPH_P_SUFFIX): graphmod ch
 analysis: graphmod ##@Analysis Generate a table and some graphs to analyze Drasil's class, datatype, and instance structures.
 	- rm -rf "$(ANALYSIS_FOLDER)"
 	@mkdir -p "$(ANALYSIS_FOLDER)"
-	cd $(SCRIPT_FOLDER) && stack exec -- runghc ClassInstDepGen.hs
-	cd $(SCRIPT_FOLDER) && stack exec -- runghc TypeDepGen.hs
+	cd $(SCRIPT_FOLDER) && stack ClassInstDepGen.hs
+	cd $(SCRIPT_FOLDER) && stack TypeDepGen.hs
 	@echo "Analysis complete. Please see '$(ANALYSIS_FOLDER)' folder."
 
 convertAnalyzed: ##@Analysis Convert analyzed dot graphs into SVGs.

--- a/code/scripts/ClassInstDepGen.hs
+++ b/code/scripts/ClassInstDepGen.hs
@@ -1,3 +1,12 @@
+#!/usr/bin/env stack
+{- stack script
+   --resolver lts-20.20
+   --package split
+   --package directory,filepath
+   --package text
+   --package containers
+-}
+
 -- FIXME: use real parser (Low Priority; see line 267)
 -- | Data table generator. Uses information from SourceCodeReader.hs 
 -- to organize all types, classes, and instances in Drasil.

--- a/code/scripts/TypeDepGen.hs
+++ b/code/scripts/TypeDepGen.hs
@@ -1,3 +1,12 @@
+#!/usr/bin/env stack
+{- stack script
+   --resolver lts-20.20
+   --package split
+   --package directory,filepath
+   --package text
+   --package containers
+-}
+
 -- FIXME: use real parser (Low Priority; see line 189)
 -- | Creates graphs showing the dependency of one type upon another.
 module TypeDepGen (main) where


### PR DESCRIPTION
Closes #3369 by adding direct traceability to the requirements of the scripts. I'm only adding it to the ones that are actual "scripts" and intended to be runnable. Adding the shebang to the local shared modules `SourceCodeReader...hs` wouldn't make sense since it is not intended to be run.