### PR TITLE
Apply CSS to GD and IM tables

### DIFF
--- a/code/drasil-printers/lib/Language/Drasil/HTML/CSS.hs
+++ b/code/drasil-printers/lib/Language/Drasil/HTML/CSS.hs
@@ -66,9 +66,8 @@ makeCSS _ = vcat [
     text "  margin-left: auto;",
     text "  margin-right: auto;}"],
   text "th, td {border: 1px solid black; padding: 0.5em;}",
-  text ".tdefn, .ddefn {width: 75%; margin-top: 1%; margin-bottom: 1%;}",
-  text ".tdefn th {width: 15%;}",
-  text ".ddefn th {width: 15%;}",
+  text ".tdefn, .ddefn, .gdefn, .idefn {width: 75%; margin-top: 1%; margin-bottom: 1%;}",
+  text ".tdefn th, .ddefn th, .gdefn th, .idefn th {width: 15%;}",
   text ".section {width: 80%; margin: 0 auto; text-align: left;}",
   vcat [
     text ".code {",

--- a/code/stable/dblpend/SRS/HTML/DblPend_SRS.css
+++ b/code/stable/dblpend/SRS/HTML/DblPend_SRS.css
@@ -43,9 +43,8 @@ table, th, td {
   margin-left: auto;
   margin-right: auto;}
 th, td {border: 1px solid black; padding: 0.5em;}
-.tdefn, .ddefn {width: 75%; margin-top: 1%; margin-bottom: 1%;}
-.tdefn th {width: 15%;}
-.ddefn th {width: 15%;}
+.tdefn, .ddefn, .gdefn, .idefn {width: 75%; margin-top: 1%; margin-bottom: 1%;}
+.tdefn th, .ddefn th, .gdefn th, .idefn th {width: 15%;}
 .section {width: 80%; margin: 0 auto; text-align: left;}
 .code {
   display: inline-block;

--- a/code/stable/gamephysics/SRS/HTML/GamePhysics_SRS.css
+++ b/code/stable/gamephysics/SRS/HTML/GamePhysics_SRS.css
@@ -43,9 +43,8 @@ table, th, td {
   margin-left: auto;
   margin-right: auto;}
 th, td {border: 1px solid black; padding: 0.5em;}
-.tdefn, .ddefn {width: 75%; margin-top: 1%; margin-bottom: 1%;}
-.tdefn th {width: 15%;}
-.ddefn th {width: 15%;}
+.tdefn, .ddefn, .gdefn, .idefn {width: 75%; margin-top: 1%; margin-bottom: 1%;}
+.tdefn th, .ddefn th, .gdefn th, .idefn th {width: 15%;}
 .section {width: 80%; margin: 0 auto; text-align: left;}
 .code {
   display: inline-block;

--- a/code/stable/glassbr/SRS/HTML/GlassBR_SRS.css
+++ b/code/stable/glassbr/SRS/HTML/GlassBR_SRS.css
@@ -43,9 +43,8 @@ table, th, td {
   margin-left: auto;
   margin-right: auto;}
 th, td {border: 1px solid black; padding: 0.5em;}
-.tdefn, .ddefn {width: 75%; margin-top: 1%; margin-bottom: 1%;}
-.tdefn th {width: 15%;}
-.ddefn th {width: 15%;}
+.tdefn, .ddefn, .gdefn, .idefn {width: 75%; margin-top: 1%; margin-bottom: 1%;}
+.tdefn th, .ddefn th, .gdefn th, .idefn th {width: 15%;}
 .section {width: 80%; margin: 0 auto; text-align: left;}
 .code {
   display: inline-block;

--- a/code/stable/hghc/SRS/HTML/HGHC_SRS.css
+++ b/code/stable/hghc/SRS/HTML/HGHC_SRS.css
@@ -43,9 +43,8 @@ table, th, td {
   margin-left: auto;
   margin-right: auto;}
 th, td {border: 1px solid black; padding: 0.5em;}
-.tdefn, .ddefn {width: 75%; margin-top: 1%; margin-bottom: 1%;}
-.tdefn th {width: 15%;}
-.ddefn th {width: 15%;}
+.tdefn, .ddefn, .gdefn, .idefn {width: 75%; margin-top: 1%; margin-bottom: 1%;}
+.tdefn th, .ddefn th, .gdefn th, .idefn th {width: 15%;}
 .section {width: 80%; margin: 0 auto; text-align: left;}
 .code {
   display: inline-block;

--- a/code/stable/pdcontroller/SRS/HTML/PDController_SRS.css
+++ b/code/stable/pdcontroller/SRS/HTML/PDController_SRS.css
@@ -43,9 +43,8 @@ table, th, td {
   margin-left: auto;
   margin-right: auto;}
 th, td {border: 1px solid black; padding: 0.5em;}
-.tdefn, .ddefn {width: 75%; margin-top: 1%; margin-bottom: 1%;}
-.tdefn th {width: 15%;}
-.ddefn th {width: 15%;}
+.tdefn, .ddefn, .gdefn, .idefn {width: 75%; margin-top: 1%; margin-bottom: 1%;}
+.tdefn th, .ddefn th, .gdefn th, .idefn th {width: 15%;}
 .section {width: 80%; margin: 0 auto; text-align: left;}
 .code {
   display: inline-block;

--- a/code/stable/projectile/SRS/HTML/Projectile_SRS.css
+++ b/code/stable/projectile/SRS/HTML/Projectile_SRS.css
@@ -43,9 +43,8 @@ table, th, td {
   margin-left: auto;
   margin-right: auto;}
 th, td {border: 1px solid black; padding: 0.5em;}
-.tdefn, .ddefn {width: 75%; margin-top: 1%; margin-bottom: 1%;}
-.tdefn th {width: 15%;}
-.ddefn th {width: 15%;}
+.tdefn, .ddefn, .gdefn, .idefn {width: 75%; margin-top: 1%; margin-bottom: 1%;}
+.tdefn th, .ddefn th, .gdefn th, .idefn th {width: 15%;}
 .section {width: 80%; margin: 0 auto; text-align: left;}
 .code {
   display: inline-block;

--- a/code/stable/sglpend/SRS/HTML/SglPend_SRS.css
+++ b/code/stable/sglpend/SRS/HTML/SglPend_SRS.css
@@ -43,9 +43,8 @@ table, th, td {
   margin-left: auto;
   margin-right: auto;}
 th, td {border: 1px solid black; padding: 0.5em;}
-.tdefn, .ddefn {width: 75%; margin-top: 1%; margin-bottom: 1%;}
-.tdefn th {width: 15%;}
-.ddefn th {width: 15%;}
+.tdefn, .ddefn, .gdefn, .idefn {width: 75%; margin-top: 1%; margin-bottom: 1%;}
+.tdefn th, .ddefn th, .gdefn th, .idefn th {width: 15%;}
 .section {width: 80%; margin: 0 auto; text-align: left;}
 .code {
   display: inline-block;

--- a/code/stable/ssp/SRS/HTML/SSP_SRS.css
+++ b/code/stable/ssp/SRS/HTML/SSP_SRS.css
@@ -43,9 +43,8 @@ table, th, td {
   margin-left: auto;
   margin-right: auto;}
 th, td {border: 1px solid black; padding: 0.5em;}
-.tdefn, .ddefn {width: 75%; margin-top: 1%; margin-bottom: 1%;}
-.tdefn th {width: 15%;}
-.ddefn th {width: 15%;}
+.tdefn, .ddefn, .gdefn, .idefn {width: 75%; margin-top: 1%; margin-bottom: 1%;}
+.tdefn th, .ddefn th, .gdefn th, .idefn th {width: 15%;}
 .section {width: 80%; margin: 0 auto; text-align: left;}
 .code {
   display: inline-block;

--- a/code/stable/swhs/SRS/HTML/SWHS_SRS.css
+++ b/code/stable/swhs/SRS/HTML/SWHS_SRS.css
@@ -43,9 +43,8 @@ table, th, td {
   margin-left: auto;
   margin-right: auto;}
 th, td {border: 1px solid black; padding: 0.5em;}
-.tdefn, .ddefn {width: 75%; margin-top: 1%; margin-bottom: 1%;}
-.tdefn th {width: 15%;}
-.ddefn th {width: 15%;}
+.tdefn, .ddefn, .gdefn, .idefn {width: 75%; margin-top: 1%; margin-bottom: 1%;}
+.tdefn th, .ddefn th, .gdefn th, .idefn th {width: 15%;}
 .section {width: 80%; margin: 0 auto; text-align: left;}
 .code {
   display: inline-block;

--- a/code/stable/swhsnopcm/SRS/HTML/SWHSNoPCM_SRS.css
+++ b/code/stable/swhsnopcm/SRS/HTML/SWHSNoPCM_SRS.css
@@ -43,9 +43,8 @@ table, th, td {
   margin-left: auto;
   margin-right: auto;}
 th, td {border: 1px solid black; padding: 0.5em;}
-.tdefn, .ddefn {width: 75%; margin-top: 1%; margin-bottom: 1%;}
-.tdefn th {width: 15%;}
-.ddefn th {width: 15%;}
+.tdefn, .ddefn, .gdefn, .idefn {width: 75%; margin-top: 1%; margin-bottom: 1%;}
+.tdefn th, .ddefn th, .gdefn th, .idefn th {width: 15%;}
 .section {width: 80%; margin: 0 auto; text-align: left;}
 .code {
   display: inline-block;

--- a/code/stable/template/SRS/HTML/Template_SRS.css
+++ b/code/stable/template/SRS/HTML/Template_SRS.css
@@ -43,9 +43,8 @@ table, th, td {
   margin-left: auto;
   margin-right: auto;}
 th, td {border: 1px solid black; padding: 0.5em;}
-.tdefn, .ddefn {width: 75%; margin-top: 1%; margin-bottom: 1%;}
-.tdefn th {width: 15%;}
-.ddefn th {width: 15%;}
+.tdefn, .ddefn, .gdefn, .idefn {width: 75%; margin-top: 1%; margin-bottom: 1%;}
+.tdefn th, .ddefn th, .gdefn th, .idefn th {width: 15%;}
 .section {width: 80%; margin: 0 auto; text-align: left;}
 .code {
   display: inline-block;


### PR DESCRIPTION
Closes #3576. It turns out we have CSS rules for spacing between the tables, but it's only applied to DD and TM tables. This PR extends it to GD and IM tables.