### PR TITLE
Remove space before colon in Python files

### DIFF
--- a/code/drasil-gool/lib/GOOL/Drasil/LanguageRenderer/CSharpRenderer.hs
+++ b/code/drasil-gool/lib/GOOL/Drasil/LanguageRenderer/CSharpRenderer.hs
@@ -62,7 +62,7 @@ import qualified GOOL.Drasil.LanguageRenderer.LanguagePolymorphic as G (
   increment, objDecNew, print, closeFile, returnStmt, valStmt,
   comment, throw, ifCond, tryCatch, construct, param, method, getMethod,
   setMethod, function, buildClass, implementingClass, commentedClass,
-  modFromData, fileDoc, fileFromData)
+  modFromData, fileDoc, fileFromData, defaultOptSpace)
 import qualified GOOL.Drasil.LanguageRenderer.CommonPseudoOO as CP (int,
   constructor, doxFunc, doxClass, doxMod, extVar, classVar, objVarSelf,
   extFuncAppMixedArgs, indexOf, listAddFunc, discardFileLine, intClass, 
@@ -559,7 +559,7 @@ instance ControlStatement CSharpCode where
     modify (addLangImport csSystem)
     G.throw csThrowDoc Semi msg
 
-  ifCond = G.ifCond parens bodyStart elseIfLabel bodyEnd
+  ifCond = G.ifCond parens bodyStart G.defaultOptSpace elseIfLabel bodyEnd
   switch = C.switch parens break
 
   ifExists = M.ifExists

--- a/code/drasil-gool/lib/GOOL/Drasil/LanguageRenderer/CppRenderer.hs
+++ b/code/drasil-gool/lib/GOOL/Drasil/LanguageRenderer/CppRenderer.hs
@@ -66,7 +66,7 @@ import qualified GOOL.Drasil.LanguageRenderer.LanguagePolymorphic as G (
   increment, objDecNew, print, closeFile, returnStmt, valStmt, comment, throw,
   ifCond, tryCatch, construct, param, method, getMethod, setMethod, function,
   buildClass, implementingClass, commentedClass, modFromData, fileDoc,
-  fileFromData)
+  fileFromData, defaultOptSpace)
 import GOOL.Drasil.LanguageRenderer.LanguagePolymorphic (classVarCheckStatic)
 import qualified GOOL.Drasil.LanguageRenderer.CommonPseudoOO as CP (int,
   constructor, doxFunc, doxClass, doxMod, funcType, buildModule, litArray, 
@@ -1492,7 +1492,7 @@ instance ControlStatement CppSrcCode where
 
   throw = G.throw cppThrowDoc Semi
 
-  ifCond = G.ifCond parens bodyStart elseIfLabel bodyEnd
+  ifCond = G.ifCond parens bodyStart G.defaultOptSpace elseIfLabel bodyEnd
   switch = C.switch parens break
 
   ifExists _ ifBody _ = do 

--- a/code/drasil-gool/lib/GOOL/Drasil/LanguageRenderer/JavaRenderer.hs
+++ b/code/drasil-gool/lib/GOOL/Drasil/LanguageRenderer/JavaRenderer.hs
@@ -65,7 +65,7 @@ import qualified GOOL.Drasil.LanguageRenderer.LanguagePolymorphic as G (
   increment, objDecNew, print, closeFile, returnStmt, valStmt, comment, throw,
   ifCond, tryCatch, construct, param, method, getMethod, setMethod, function,
   buildClass, implementingClass, commentedClass, modFromData, fileDoc,
-  fileFromData)
+  fileFromData, defaultOptSpace)
 import GOOL.Drasil.LanguageRenderer.LanguagePolymorphic (docFuncRepr)
 import qualified GOOL.Drasil.LanguageRenderer.CommonPseudoOO as CP (int, 
   constructor, doxFunc, doxClass, doxMod, extVar, classVar, objVarSelf,
@@ -591,7 +591,7 @@ instance ControlStatement JavaCode where
   
   throw = G.throw jThrowDoc Semi
 
-  ifCond = G.ifCond parens bodyStart elseIfLabel bodyEnd
+  ifCond = G.ifCond parens bodyStart G.defaultOptSpace elseIfLabel bodyEnd
   switch  = C.switch parens break
 
   ifExists = M.ifExists

--- a/code/drasil-gool/lib/GOOL/Drasil/LanguageRenderer/LanguagePolymorphic.hs
+++ b/code/drasil-gool/lib/GOOL/Drasil/LanguageRenderer/LanguagePolymorphic.hs
@@ -13,7 +13,7 @@ module GOOL.Drasil.LanguageRenderer.LanguagePolymorphic (fileFromData,
   objDecNew, print, closeFile, returnStmt, valStmt, comment, throw, ifCond,
   tryCatch, construct, param, method, getMethod, setMethod, initStmts,
   function, docFuncRepr, docFunc, buildClass, implementingClass, docClass,
-  commentedClass, modFromData, fileDoc, docMod
+  commentedClass, modFromData, fileDoc, docMod, OptionalSpace(..), defaultOptSpace
 ) where
 
 import Utils.Drasil (indent)
@@ -75,7 +75,7 @@ import Control.Monad.State (modify)
 import Control.Lens ((^.), over)
 import Control.Lens.Zoom (zoom)
 import Text.PrettyPrint.HughesPJ (Doc, text, empty, render, (<>), (<+>), parens,
-  brackets, integer, vcat, comma, isEmpty)
+  brackets, integer, vcat, comma, isEmpty, space)
 import qualified Text.PrettyPrint.HughesPJ as D (char, double)
 
 -- Bodies --
@@ -386,18 +386,26 @@ throw f t l = do
   msg <- zoom lensMStoVS (S.litString l)
   stmtFromData (f msg) t
 
+newtype OptionalSpace = OSpace {oSpace :: Doc}
+
+defaultOptSpace :: OptionalSpace
+defaultOptSpace = OSpace {oSpace = space}
+
+optSpaceDoc :: OptionalSpace -> Doc
+optSpaceDoc OSpace {oSpace = sp} = sp
+
 -- ControlStatements --
 
 -- 1st parameter is a Doc function to use on the render of each condition (i.e. parens)
 -- 2nd parameter is the syntax for starting a block in an if-condition
 -- 3rd parameter is the keyword for an else-if statement
 -- 4th parameter is the syntax for ending a block in an if-condition
-ifCond :: (RenderSym r) => (Doc -> Doc) -> Doc -> Doc -> Doc -> 
+ifCond :: (RenderSym r) => (Doc -> Doc) -> Doc -> OptionalSpace -> Doc -> Doc ->
   [(SValue r, MSBody r)] -> MSBody r -> MSStatement r
-ifCond _ _ _ _ [] _ = error "if condition created with no cases"
-ifCond f ifStart elif bEnd (c:cs) eBody =
+ifCond _ _ _ _ _ [] _ = error "if condition created with no cases"
+ifCond f ifStart os elif bEnd (c:cs) eBody =
     let ifSect (v, b) = on2StateValues (\val bd -> vcat [
-          ifLabel <+> f (RC.value val) <+> ifStart,
+          ifLabel <+> f (RC.value val) <> optSpaceDoc os <> ifStart,
           indent $ RC.body bd,
           bEnd]) (zoom lensMStoVS v) b
         elseIfSect (v, b) = on2StateValues (\val bd -> vcat [

--- a/code/drasil-gool/lib/GOOL/Drasil/LanguageRenderer/PythonRenderer.hs
+++ b/code/drasil-gool/lib/GOOL/Drasil/LanguageRenderer/PythonRenderer.hs
@@ -95,6 +95,7 @@ import Data.List (intercalate, sort)
 import qualified Data.Map as Map (lookup)
 import Text.PrettyPrint.HughesPJ (Doc, text, (<>), (<+>), parens, empty, equals,
   vcat, colon, brackets, isEmpty, quotes)
+import GOOL.Drasil.LanguageRenderer.LanguagePolymorphic (OptionalSpace(..))
 
 pyExt :: String
 pyExt = "py"
@@ -571,7 +572,7 @@ instance ControlStatement PythonCode where
 
   throw = G.throw pyThrow Empty
 
-  ifCond = G.ifCond parens pyBodyStart pyElseIf pyBodyEnd
+  ifCond = G.ifCond parens pyBodyStart pySpace pyElseIf pyBodyEnd
   switch = switchAsIf
 
   ifExists = M.ifExists
@@ -809,6 +810,9 @@ pyBodyEnd = empty
 pyCommentStart = text "#"
 pyDocCommentStart = pyCommentStart <> pyCommentStart
 pyNamedArgSep = equals
+
+pySpace :: OptionalSpace
+pySpace = OSpace {oSpace = empty}
 
 pyNotOp :: (Monad r) => VSOp r
 pyNotOp = unOpPrec "not"

--- a/code/drasil-gool/lib/GOOL/Drasil/LanguageRenderer/SwiftRenderer.hs
+++ b/code/drasil-gool/lib/GOOL/Drasil/LanguageRenderer/SwiftRenderer.hs
@@ -65,7 +65,7 @@ import qualified GOOL.Drasil.LanguageRenderer.LanguagePolymorphic as G (
   increment, objDecNew, print, returnStmt, valStmt, comment, throw, ifCond,
   tryCatch, construct, param, method, getMethod, setMethod, initStmts,
   function, docFunc, buildClass, implementingClass, docClass, commentedClass,
-  modFromData, fileDoc, docMod, fileFromData)
+  modFromData, fileDoc, docMod, fileFromData, defaultOptSpace)
 import qualified GOOL.Drasil.LanguageRenderer.CommonPseudoOO as CP (classVar, 
   objVarSelf, intClass, buildModule, bindingError, extFuncAppMixedArgs, 
   notNull, listDecDef, destructorError, stateVarDef, constVar, litArray, 
@@ -598,7 +598,7 @@ instance ControlStatement SwiftCode where
     modify setThrowUsed
     G.throw swiftThrowDoc Empty msg
 
-  ifCond = G.ifCond id bodyStart elseIfLabel bodyEnd
+  ifCond = G.ifCond id bodyStart G.defaultOptSpace elseIfLabel bodyEnd
   switch = C.switch (space <>) emptyStmt
 
   ifExists = M.ifExists

--- a/code/stable/dblpend/src/python/InputParameters.py
+++ b/code/stable/dblpend/src/python/InputParameters.py
@@ -28,7 +28,7 @@ def get_input(filename):
 # \param m_1 mass of the first object (kg)
 # \param m_2 mass of the second object (kg)
 def input_constraints(L_1, L_2, m_1, m_2):
-    if (not(L_1 > 0.0)) :
+    if (not(L_1 > 0.0)):
         print("Warning: ", end="")
         print("L_1 has value ", end="")
         print(L_1, end="")
@@ -36,7 +36,7 @@ def input_constraints(L_1, L_2, m_1, m_2):
         print("above ", end="")
         print(0.0, end="")
         print(".")
-    if (not(L_2 > 0.0)) :
+    if (not(L_2 > 0.0)):
         print("Warning: ", end="")
         print("L_2 has value ", end="")
         print(L_2, end="")
@@ -44,7 +44,7 @@ def input_constraints(L_1, L_2, m_1, m_2):
         print("above ", end="")
         print(0.0, end="")
         print(".")
-    if (not(m_1 > 0.0)) :
+    if (not(m_1 > 0.0)):
         print("Warning: ", end="")
         print("m_1 has value ", end="")
         print(m_1, end="")
@@ -52,7 +52,7 @@ def input_constraints(L_1, L_2, m_1, m_2):
         print("above ", end="")
         print(0.0, end="")
         print(".")
-    if (not(m_2 > 0.0)) :
+    if (not(m_2 > 0.0)):
         print("Warning: ", end="")
         print("m_2 has value ", end="")
         print(m_2, end="")

--- a/code/stable/glassbr/src/python/DerivedValues.py
+++ b/code/stable/glassbr/src/python/DerivedValues.py
@@ -28,7 +28,7 @@ def derived_values(inParams):
     print(" in module DerivedValues", file=outfile)
     outfile.close()
     
-    if (inParams.g == "AN") :
+    if (inParams.g == "AN"):
         inParams.GTF = 1
         outfile = open("log.txt", "a")
         print("var 'inParams.GTF' assigned ", end="", file=outfile)

--- a/code/stable/glassbr/src/python/InputConstraints.py
+++ b/code/stable/glassbr/src/python/InputConstraints.py
@@ -12,7 +12,7 @@ def input_constraints(inParams):
     print("  }", file=outfile)
     outfile.close()
     
-    if (not(0.1 <= inParams.a and inParams.a <= 5.0)) :
+    if (not(0.1 <= inParams.a and inParams.a <= 5.0)):
         print("a has value ", end="")
         print(inParams.a, end="")
         print(", but is expected to be ", end="")
@@ -24,7 +24,7 @@ def input_constraints(inParams):
         print(" (d_max)", end="")
         print(".")
         raise Exception("InputError")
-    if (not(0.1 <= inParams.b and inParams.b <= 5.0)) :
+    if (not(0.1 <= inParams.b and inParams.b <= 5.0)):
         print("b has value ", end="")
         print(inParams.b, end="")
         print(", but is expected to be ", end="")
@@ -36,7 +36,7 @@ def input_constraints(inParams):
         print(" (d_max)", end="")
         print(".")
         raise Exception("InputError")
-    if (not(4.5 <= inParams.w and inParams.w <= 910.0)) :
+    if (not(4.5 <= inParams.w and inParams.w <= 910.0)):
         print("w has value ", end="")
         print(inParams.w, end="")
         print(", but is expected to be ", end="")
@@ -48,7 +48,7 @@ def input_constraints(inParams):
         print(" (w_max)", end="")
         print(".")
         raise Exception("InputError")
-    if (not(6.0 <= inParams.SD and inParams.SD <= 130.0)) :
+    if (not(6.0 <= inParams.SD and inParams.SD <= 130.0)):
         print("SD has value ", end="")
         print(inParams.SD, end="")
         print(", but is expected to be ", end="")
@@ -60,7 +60,7 @@ def input_constraints(inParams):
         print(" (SD_max)", end="")
         print(".")
         raise Exception("InputError")
-    if (not(inParams.AR <= 5.0)) :
+    if (not(inParams.AR <= 5.0)):
         print("AR has value ", end="")
         print(inParams.AR, end="")
         print(", but is expected to be ", end="")
@@ -70,7 +70,7 @@ def input_constraints(inParams):
         print(".")
         raise Exception("InputError")
     
-    if (not(inParams.a > 0.0)) :
+    if (not(inParams.a > 0.0)):
         print("a has value ", end="")
         print(inParams.a, end="")
         print(", but is expected to be ", end="")
@@ -78,7 +78,7 @@ def input_constraints(inParams):
         print(0.0, end="")
         print(".")
         raise Exception("InputError")
-    if (not(inParams.a >= inParams.b)) :
+    if (not(inParams.a >= inParams.b)):
         print("a has value ", end="")
         print(inParams.a, end="")
         print(", but is expected to be ", end="")
@@ -87,7 +87,7 @@ def input_constraints(inParams):
         print(" (b)", end="")
         print(".")
         raise Exception("InputError")
-    if (not(0.0 < inParams.b and inParams.b <= inParams.a)) :
+    if (not(0.0 < inParams.b and inParams.b <= inParams.a)):
         print("b has value ", end="")
         print(inParams.b, end="")
         print(", but is expected to be ", end="")
@@ -98,7 +98,7 @@ def input_constraints(inParams):
         print(" (a)", end="")
         print(".")
         raise Exception("InputError")
-    if (not(inParams.w > 0.0)) :
+    if (not(inParams.w > 0.0)):
         print("w has value ", end="")
         print(inParams.w, end="")
         print(", but is expected to be ", end="")
@@ -106,7 +106,7 @@ def input_constraints(inParams):
         print(0.0, end="")
         print(".")
         raise Exception("InputError")
-    if (not(0.0 <= inParams.P_btol and inParams.P_btol <= 1.0)) :
+    if (not(0.0 <= inParams.P_btol and inParams.P_btol <= 1.0)):
         print("P_btol has value ", end="")
         print(inParams.P_btol, end="")
         print(", but is expected to be ", end="")
@@ -116,7 +116,7 @@ def input_constraints(inParams):
         print(1.0, end="")
         print(".")
         raise Exception("InputError")
-    if (not(inParams.TNT > 0.0)) :
+    if (not(inParams.TNT > 0.0)):
         print("TNT has value ", end="")
         print(inParams.TNT, end="")
         print(", but is expected to be ", end="")
@@ -124,7 +124,7 @@ def input_constraints(inParams):
         print(0.0, end="")
         print(".")
         raise Exception("InputError")
-    if (not(inParams.SD > 0.0)) :
+    if (not(inParams.SD > 0.0)):
         print("SD has value ", end="")
         print(inParams.SD, end="")
         print(", but is expected to be ", end="")
@@ -132,7 +132,7 @@ def input_constraints(inParams):
         print(0.0, end="")
         print(".")
         raise Exception("InputError")
-    if (not(inParams.AR >= 1.0)) :
+    if (not(inParams.AR >= 1.0)):
         print("AR has value ", end="")
         print(inParams.AR, end="")
         print(", but is expected to be ", end="")

--- a/code/stable/glassbr/src/python/Interpolation.py
+++ b/code/stable/glassbr/src/python/Interpolation.py
@@ -49,7 +49,7 @@ def find(arr, v):
     outfile.close()
     
     for i in range(0, len(arr) - 1, 1):
-        if (arr[i] <= v and v <= arr[i + 1]) :
+        if (arr[i] <= v and v <= arr[i + 1]):
             return i
     raise Exception("Bound error")
 
@@ -230,6 +230,6 @@ def interpZ(filename, x, y):
         print(y_2, end="", file=outfile)
         print(" in module Interpolation", file=outfile)
         outfile.close()
-        if (y_1 <= y and y <= y_2) :
+        if (y_1 <= y and y <= y_2):
             return lin_interp(y_1, z_vector[i], y_2, z_vector[i + 1], y)
     raise Exception("Interpolation of z failed")

--- a/code/stable/pdcontroller/src/python/InputParameters.py
+++ b/code/stable/pdcontroller/src/python/InputParameters.py
@@ -32,7 +32,7 @@ def get_input(filename):
 # \param t_step Step Time: Simulation step time (s)
 # \param t_sim Simulation Time: Total execution time of the PD simulation (s)
 def input_constraints(r_t, K_d, K_p, t_step, t_sim):
-    if (not(r_t > 0.0)) :
+    if (not(r_t > 0.0)):
         print("r_t has value ", end="")
         print(r_t, end="")
         print(", but is expected to be ", end="")
@@ -40,7 +40,7 @@ def input_constraints(r_t, K_d, K_p, t_step, t_sim):
         print(0.0, end="")
         print(".")
         raise Exception("InputError")
-    if (not(K_d >= 0.0)) :
+    if (not(K_d >= 0.0)):
         print("K_d has value ", end="")
         print(K_d, end="")
         print(", but is expected to be ", end="")
@@ -48,7 +48,7 @@ def input_constraints(r_t, K_d, K_p, t_step, t_sim):
         print(0.0, end="")
         print(".")
         raise Exception("InputError")
-    if (not(K_p > 0.0)) :
+    if (not(K_p > 0.0)):
         print("K_p has value ", end="")
         print(K_p, end="")
         print(", but is expected to be ", end="")
@@ -56,7 +56,7 @@ def input_constraints(r_t, K_d, K_p, t_step, t_sim):
         print(0.0, end="")
         print(".")
         raise Exception("InputError")
-    if (not(1.0 / 1000.0 <= t_step and t_step < t_sim)) :
+    if (not(1.0 / 1000.0 <= t_step and t_step < t_sim)):
         print("t_step has value ", end="")
         print(t_step, end="")
         print(", but is expected to be ", end="")
@@ -68,7 +68,7 @@ def input_constraints(r_t, K_d, K_p, t_step, t_sim):
         print(" (t_sim)", end="")
         print(".")
         raise Exception("InputError")
-    if (not(1.0 <= t_sim and t_sim <= 60.0)) :
+    if (not(1.0 <= t_sim and t_sim <= 60.0)):
         print("t_sim has value ", end="")
         print(t_sim, end="")
         print(", but is expected to be ", end="")

--- a/code/stable/projectile/projectile_c_p_nol_b_u_v_d/src/python/Calculations.py
+++ b/code/stable/projectile/projectile_c_p_nol_b_u_v_d/src/python/Calculations.py
@@ -31,7 +31,7 @@ def func_d_offset(inParams, p_land):
 # \param d_offset distance between the target position and the landing position: the offset between the target position and the landing position (m)
 # \return output message as a string
 def func_s(inParams, epsilon, d_offset):
-    if (math.fabs(d_offset / inParams.p_target) < epsilon) :
+    if (math.fabs(d_offset / inParams.p_target) < epsilon):
         return "The target was hit."
     elif (d_offset < 0.0) :
         return "The projectile fell short."

--- a/code/stable/projectile/projectile_c_p_nol_b_u_v_d/src/python/InputParameters.py
+++ b/code/stable/projectile/projectile_c_p_nol_b_u_v_d/src/python/InputParameters.py
@@ -26,7 +26,7 @@ class InputParameters:
     
     ## \brief Verifies that input values satisfy the physical constraints
     def input_constraints(self):
-        if (not(self.v_launch > 0.0)) :
+        if (not(self.v_launch > 0.0)):
             print("Warning: ", end="")
             print("v_launch has value ", end="")
             print(self.v_launch, end="")
@@ -34,7 +34,7 @@ class InputParameters:
             print("above ", end="")
             print(0.0, end="")
             print(".")
-        if (not(0.0 < self.theta and self.theta < math.pi / 2.0)) :
+        if (not(0.0 < self.theta and self.theta < math.pi / 2.0)):
             print("Warning: ", end="")
             print("theta has value ", end="")
             print(self.theta, end="")
@@ -45,7 +45,7 @@ class InputParameters:
             print(math.pi / 2.0, end="")
             print(" ((pi)/(2))", end="")
             print(".")
-        if (not(self.p_target > 0.0)) :
+        if (not(self.p_target > 0.0)):
             print("Warning: ", end="")
             print("p_target has value ", end="")
             print(self.p_target, end="")

--- a/code/stable/projectile/projectile_s_l_nol_u_u_v_f/src/python/Calculations.py
+++ b/code/stable/projectile/projectile_s_l_nol_u_u_v_f/src/python/Calculations.py
@@ -33,7 +33,7 @@ def func_d_offset(p_target, p_land):
 # \param d_offset distance between the target position and the landing position: the offset between the target position and the landing position (m)
 # \return output message as a string
 def func_s(p_target, epsilon, d_offset):
-    if (math.fabs(d_offset / p_target) < epsilon) :
+    if (math.fabs(d_offset / p_target) < epsilon):
         return "The target was hit."
     elif (d_offset < 0.0) :
         return "The projectile fell short."

--- a/code/stable/projectile/projectile_s_l_nol_u_u_v_f/src/python/InputConstraints.py
+++ b/code/stable/projectile/projectile_s_l_nol_u_u_v_f/src/python/InputConstraints.py
@@ -9,7 +9,7 @@ import math
 # \param theta launch angle: the angle between the launcher and a straight line from the launcher to the target (rad)
 # \param p_target target position: the distance from the launcher to the target (m)
 def input_constraints(v_launch, theta, p_target):
-    if (not(v_launch > 0.0)) :
+    if (not(v_launch > 0.0)):
         print("Warning: ", end="")
         print("v_launch has value ", end="")
         print(v_launch, end="")
@@ -17,7 +17,7 @@ def input_constraints(v_launch, theta, p_target):
         print("above ", end="")
         print(0.0, end="")
         print(".")
-    if (not(0.0 < theta and theta < math.pi / 2.0)) :
+    if (not(0.0 < theta and theta < math.pi / 2.0)):
         print("Warning: ", end="")
         print("theta has value ", end="")
         print(theta, end="")
@@ -28,7 +28,7 @@ def input_constraints(v_launch, theta, p_target):
         print(math.pi / 2.0, end="")
         print(" ((pi)/(2))", end="")
         print(".")
-    if (not(p_target > 0.0)) :
+    if (not(p_target > 0.0)):
         print("Warning: ", end="")
         print("p_target has value ", end="")
         print(p_target, end="")

--- a/code/stable/projectile/projectile_u_p_l_b_b_c_d/src/python/Projectile.py
+++ b/code/stable/projectile/projectile_u_p_l_b_b_c_d/src/python/Projectile.py
@@ -61,7 +61,7 @@ class InputParameters:
         print("  }", file=outfile)
         outfile.close()
         
-        if (not(self.v_launch > 0.0)) :
+        if (not(self.v_launch > 0.0)):
             print("Warning: ", end="")
             print("v_launch has value ", end="")
             print(self.v_launch, end="")
@@ -69,7 +69,7 @@ class InputParameters:
             print("above ", end="")
             print(0.0, end="")
             print(".")
-        if (not(0.0 < self.theta and self.theta < math.pi / 2.0)) :
+        if (not(0.0 < self.theta and self.theta < math.pi / 2.0)):
             print("Warning: ", end="")
             print("theta has value ", end="")
             print(self.theta, end="")
@@ -80,7 +80,7 @@ class InputParameters:
             print(math.pi / 2.0, end="")
             print(" ((pi)/(2))", end="")
             print(".")
-        if (not(self.p_target > 0.0)) :
+        if (not(self.p_target > 0.0)):
             print("Warning: ", end="")
             print("p_target has value ", end="")
             print(self.p_target, end="")
@@ -152,7 +152,7 @@ def func_s(inParams, d_offset):
     print("  }", file=outfile)
     outfile.close()
     
-    if (math.fabs(d_offset / inParams.p_target) < Constants.epsilon) :
+    if (math.fabs(d_offset / inParams.p_target) < Constants.epsilon):
         return "The target was hit."
     elif (d_offset < 0.0) :
         return "The projectile fell short."

--- a/code/stable/projectile/projectile_u_p_l_b_wi_v_f/src/python/Projectile.py
+++ b/code/stable/projectile/projectile_u_p_l_b_wi_v_f/src/python/Projectile.py
@@ -64,7 +64,7 @@ class InputParameters:
         print("  }", file=outfile)
         outfile.close()
         
-        if (not(self.v_launch > 0.0)) :
+        if (not(self.v_launch > 0.0)):
             print("Warning: ", end="")
             print("v_launch has value ", end="")
             print(self.v_launch, end="")
@@ -72,7 +72,7 @@ class InputParameters:
             print("above ", end="")
             print(0.0, end="")
             print(".")
-        if (not(0.0 < self.theta and self.theta < math.pi / 2.0)) :
+        if (not(0.0 < self.theta and self.theta < math.pi / 2.0)):
             print("Warning: ", end="")
             print("theta has value ", end="")
             print(self.theta, end="")
@@ -83,7 +83,7 @@ class InputParameters:
             print(math.pi / 2.0, end="")
             print(" ((pi)/(2))", end="")
             print(".")
-        if (not(self.p_target > 0.0)) :
+        if (not(self.p_target > 0.0)):
             print("Warning: ", end="")
             print("p_target has value ", end="")
             print(self.p_target, end="")
@@ -150,7 +150,7 @@ def func_s(inParams, d_offset):
     print("  }", file=outfile)
     outfile.close()
     
-    if (math.fabs(d_offset / inParams.p_target) < inParams.epsilon) :
+    if (math.fabs(d_offset / inParams.p_target) < inParams.epsilon):
         return "The target was hit."
     elif (d_offset < 0.0) :
         return "The projectile fell short."

--- a/code/stable/projectile/projectile_u_p_nol_u_wi_v_d/src/python/Projectile.py
+++ b/code/stable/projectile/projectile_u_p_nol_u_wi_v_d/src/python/Projectile.py
@@ -34,7 +34,7 @@ def func_d_offset(p_target, p_land):
 # \param d_offset distance between the target position and the landing position: the offset between the target position and the landing position (m)
 # \return output message as a string
 def func_s(p_target, epsilon, d_offset):
-    if (math.fabs(d_offset / p_target) < epsilon) :
+    if (math.fabs(d_offset / p_target) < epsilon):
         return "The target was hit."
     elif (d_offset < 0.0) :
         return "The projectile fell short."
@@ -63,7 +63,7 @@ def get_input(filename):
 # \param theta launch angle: the angle between the launcher and a straight line from the launcher to the target (rad)
 # \param p_target target position: the distance from the launcher to the target (m)
 def input_constraints(v_launch, theta, p_target):
-    if (not(v_launch > 0.0)) :
+    if (not(v_launch > 0.0)):
         print("Warning: ", end="")
         print("v_launch has value ", end="")
         print(v_launch, end="")
@@ -71,7 +71,7 @@ def input_constraints(v_launch, theta, p_target):
         print("above ", end="")
         print(0.0, end="")
         print(".")
-    if (not(0.0 < theta and theta < math.pi / 2.0)) :
+    if (not(0.0 < theta and theta < math.pi / 2.0)):
         print("Warning: ", end="")
         print("theta has value ", end="")
         print(theta, end="")
@@ -82,7 +82,7 @@ def input_constraints(v_launch, theta, p_target):
         print(math.pi / 2.0, end="")
         print(" ((pi)/(2))", end="")
         print(".")
-    if (not(p_target > 0.0)) :
+    if (not(p_target > 0.0)):
         print("Warning: ", end="")
         print("p_target has value ", end="")
         print(p_target, end="")

--- a/code/stable/swhsnopcm/src/python/InputParameters.py
+++ b/code/stable/swhsnopcm/src/python/InputParameters.py
@@ -73,7 +73,7 @@ def derived_values(D, L):
 # \param D diameter of tank: the diameter of the tank (m)
 # \param E_W change in heat energy in the water: change in thermal energy within the water (J)
 def input_constraints(A_C, C_W, h_C, T_init, t_final, L, T_C, t_step, rho_W, D, E_W):
-    if (not(A_C <= Constants.Constants.A_C_max)) :
+    if (not(A_C <= Constants.Constants.A_C_max)):
         print("Warning: ", end="")
         print("A_C has value ", end="")
         print(A_C, end="")
@@ -82,7 +82,7 @@ def input_constraints(A_C, C_W, h_C, T_init, t_final, L, T_C, t_step, rho_W, D, 
         print(Constants.Constants.A_C_max, end="")
         print(" (A_C_max)", end="")
         print(".")
-    if (not(Constants.Constants.C_W_min < C_W and C_W < Constants.Constants.C_W_max)) :
+    if (not(Constants.Constants.C_W_min < C_W and C_W < Constants.Constants.C_W_max)):
         print("Warning: ", end="")
         print("C_W has value ", end="")
         print(C_W, end="")
@@ -94,7 +94,7 @@ def input_constraints(A_C, C_W, h_C, T_init, t_final, L, T_C, t_step, rho_W, D, 
         print(Constants.Constants.C_W_max, end="")
         print(" (C_W_max)", end="")
         print(".")
-    if (not(Constants.Constants.h_C_min <= h_C and h_C <= Constants.Constants.h_C_max)) :
+    if (not(Constants.Constants.h_C_min <= h_C and h_C <= Constants.Constants.h_C_max)):
         print("Warning: ", end="")
         print("h_C has value ", end="")
         print(h_C, end="")
@@ -106,7 +106,7 @@ def input_constraints(A_C, C_W, h_C, T_init, t_final, L, T_C, t_step, rho_W, D, 
         print(Constants.Constants.h_C_max, end="")
         print(" (h_C_max)", end="")
         print(".")
-    if (not(t_final < Constants.Constants.t_final_max)) :
+    if (not(t_final < Constants.Constants.t_final_max)):
         print("Warning: ", end="")
         print("t_final has value ", end="")
         print(t_final, end="")
@@ -115,7 +115,7 @@ def input_constraints(A_C, C_W, h_C, T_init, t_final, L, T_C, t_step, rho_W, D, 
         print(Constants.Constants.t_final_max, end="")
         print(" (t_final_max)", end="")
         print(".")
-    if (not(Constants.Constants.L_min <= L and L <= Constants.Constants.L_max)) :
+    if (not(Constants.Constants.L_min <= L and L <= Constants.Constants.L_max)):
         print("Warning: ", end="")
         print("L has value ", end="")
         print(L, end="")
@@ -127,7 +127,7 @@ def input_constraints(A_C, C_W, h_C, T_init, t_final, L, T_C, t_step, rho_W, D, 
         print(Constants.Constants.L_max, end="")
         print(" (L_max)", end="")
         print(".")
-    if (not(Constants.Constants.rho_W_min < rho_W and rho_W <= Constants.Constants.rho_W_max)) :
+    if (not(Constants.Constants.rho_W_min < rho_W and rho_W <= Constants.Constants.rho_W_max)):
         print("Warning: ", end="")
         print("rho_W has value ", end="")
         print(rho_W, end="")
@@ -139,7 +139,7 @@ def input_constraints(A_C, C_W, h_C, T_init, t_final, L, T_C, t_step, rho_W, D, 
         print(Constants.Constants.rho_W_max, end="")
         print(" (rho_W_max)", end="")
         print(".")
-    if (not(Constants.Constants.AR_min <= D and D <= Constants.Constants.AR_max)) :
+    if (not(Constants.Constants.AR_min <= D and D <= Constants.Constants.AR_max)):
         print("Warning: ", end="")
         print("D has value ", end="")
         print(D, end="")
@@ -152,7 +152,7 @@ def input_constraints(A_C, C_W, h_C, T_init, t_final, L, T_C, t_step, rho_W, D, 
         print(" (AR_max)", end="")
         print(".")
     
-    if (not(A_C > 0.0)) :
+    if (not(A_C > 0.0)):
         print("Warning: ", end="")
         print("A_C has value ", end="")
         print(A_C, end="")
@@ -160,7 +160,7 @@ def input_constraints(A_C, C_W, h_C, T_init, t_final, L, T_C, t_step, rho_W, D, 
         print("above ", end="")
         print(0.0, end="")
         print(".")
-    if (not(C_W > 0.0)) :
+    if (not(C_W > 0.0)):
         print("Warning: ", end="")
         print("C_W has value ", end="")
         print(C_W, end="")
@@ -168,7 +168,7 @@ def input_constraints(A_C, C_W, h_C, T_init, t_final, L, T_C, t_step, rho_W, D, 
         print("above ", end="")
         print(0.0, end="")
         print(".")
-    if (not(h_C > 0.0)) :
+    if (not(h_C > 0.0)):
         print("Warning: ", end="")
         print("h_C has value ", end="")
         print(h_C, end="")
@@ -176,7 +176,7 @@ def input_constraints(A_C, C_W, h_C, T_init, t_final, L, T_C, t_step, rho_W, D, 
         print("above ", end="")
         print(0.0, end="")
         print(".")
-    if (not(0.0 < T_init and T_init < 100.0)) :
+    if (not(0.0 < T_init and T_init < 100.0)):
         print("Warning: ", end="")
         print("T_init has value ", end="")
         print(T_init, end="")
@@ -186,7 +186,7 @@ def input_constraints(A_C, C_W, h_C, T_init, t_final, L, T_C, t_step, rho_W, D, 
         print(" and ", end="")
         print(100.0, end="")
         print(".")
-    if (not(t_final > 0.0)) :
+    if (not(t_final > 0.0)):
         print("Warning: ", end="")
         print("t_final has value ", end="")
         print(t_final, end="")
@@ -194,7 +194,7 @@ def input_constraints(A_C, C_W, h_C, T_init, t_final, L, T_C, t_step, rho_W, D, 
         print("above ", end="")
         print(0.0, end="")
         print(".")
-    if (not(L > 0.0)) :
+    if (not(L > 0.0)):
         print("Warning: ", end="")
         print("L has value ", end="")
         print(L, end="")
@@ -202,7 +202,7 @@ def input_constraints(A_C, C_W, h_C, T_init, t_final, L, T_C, t_step, rho_W, D, 
         print("above ", end="")
         print(0.0, end="")
         print(".")
-    if (not(0.0 < T_C and T_C < 100.0)) :
+    if (not(0.0 < T_C and T_C < 100.0)):
         print("Warning: ", end="")
         print("T_C has value ", end="")
         print(T_C, end="")
@@ -212,7 +212,7 @@ def input_constraints(A_C, C_W, h_C, T_init, t_final, L, T_C, t_step, rho_W, D, 
         print(" and ", end="")
         print(100.0, end="")
         print(".")
-    if (not(0.0 < t_step and t_step < t_final)) :
+    if (not(0.0 < t_step and t_step < t_final)):
         print("Warning: ", end="")
         print("t_step has value ", end="")
         print(t_step, end="")
@@ -223,7 +223,7 @@ def input_constraints(A_C, C_W, h_C, T_init, t_final, L, T_C, t_step, rho_W, D, 
         print(t_final, end="")
         print(" (t_final)", end="")
         print(".")
-    if (not(rho_W > 0.0)) :
+    if (not(rho_W > 0.0)):
         print("Warning: ", end="")
         print("rho_W has value ", end="")
         print(rho_W, end="")
@@ -231,7 +231,7 @@ def input_constraints(A_C, C_W, h_C, T_init, t_final, L, T_C, t_step, rho_W, D, 
         print("above ", end="")
         print(0.0, end="")
         print(".")
-    if (not(D > 0.0)) :
+    if (not(D > 0.0)):
         print("Warning: ", end="")
         print("D has value ", end="")
         print(D, end="")
@@ -239,7 +239,7 @@ def input_constraints(A_C, C_W, h_C, T_init, t_final, L, T_C, t_step, rho_W, D, 
         print("above ", end="")
         print(0.0, end="")
         print(".")
-    if (not(E_W >= 0.0)) :
+    if (not(E_W >= 0.0)):
         print("Warning: ", end="")
         print("E_W has value ", end="")
         print(E_W, end="")


### PR DESCRIPTION
Contributes to #3221. Removes spaces before the colon in Python files, making it more PEP8 compliant. Changes have been made to `drasil-gool` and stable.