### PR TITLE
Clean drasil utils

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@ dist
 .drasil-min-stack-ver
 stack.yaml.lock
 .hlint*
+.envrc
 
 # Drasil supported programming languages
 __pycache__

--- a/code/drasil-code/lib/Language/Drasil/Code/Imperative/Doxygen/Import.hs
+++ b/code/drasil-code/lib/Language/Drasil/Code/Imperative/Doxygen/Import.hs
@@ -12,7 +12,6 @@ import Data.List (intersperse, nub)
 import Data.Maybe (maybeToList)
 import Control.Lens ((^.))
 import Text.PrettyPrint.HughesPJ (Doc, (<+>), text, hcat, vcat)
-import Utils.Drasil.Document ((+:+.))
 
 -- | A 'Doc' that holds optimized choices for configuring doxygen files.
 type OptimizeChoice = Doc
@@ -31,11 +30,14 @@ verbosityToDoc :: Verbosity -> Doc
 verbosityToDoc Verbose = no
 verbosityToDoc Quiet = yes
 
--- | Renderings of comments regarding the default tag values for various Doxygen settings.
+-- | Renderings of comments regarding the default tag values for various Doxygen
+-- settings.
+-- 
+-- TODO: `makeDoxConfig` needs access to a `ChunkDB` so that we can re-write
+-- these `Doc`s as `Sentence`s and render them back into `Doc`s appropriately.
 defNo, defYes :: Doc
-defNo = defaultValSentence +:+. no
-defYes = defaultValSentence +:+. yes
-
+defNo  = defaultValSentence <> no  <> text "."
+defYes = defaultValSentence <> yes <> text "."
 
 -- | Renders a Doxygen configuration file.
 --

--- a/code/drasil-printers/lib/Language/Drasil/Markdown/CreateMd.hs
+++ b/code/drasil-printers/lib/Language/Drasil/Markdown/CreateMd.hs
@@ -8,16 +8,13 @@ module Language.Drasil.Markdown.CreateMd (
 
 import Prelude hiding ((<>))
 import Text.PrettyPrint.HughesPJ (Doc, empty, isEmpty, vcat, text, (<+>),
-    (<>), comma, punctuate, hsep)
-import Utils.Drasil.Document (drasilImage, contSep)
+    (<>), punctuate, hsep)
 import Language.Drasil.Printing.Helpers (upcase)
-
--- | Separates document sections.
-type Separator = Doc
+import Utils.Drasil
 
 -- | Combines a list of sentences into a final Doc, also appends end note.
 makeMd :: [Doc] -> Doc
-makeMd = vcat . punctuate secSep . filtEmp
+makeMd = vcat . punctuate secSep . filterEmpty
 
 -- | Example title, authors, and maybe purpose section.
 introInfo :: String -> [String] -> Maybe String -> Doc
@@ -86,7 +83,7 @@ unsupOS = maybe empty (\uns-> regularSec (text "Unsupported Operating Systems")
 extLibSec:: [(String, String)] -> [String]-> Doc
 extLibSec libns libfps = 
     let libs = addListToTuple libns libfps
-        formattedLibs = (hsep . punctuate contSep . filtEmp . 
+        formattedLibs = (hsep . punctuate contSep . filterEmpty . 
             map libStatment) libs
     in if isEmpty formattedLibs then empty else 
             regularSec (text "External Libraries") formattedLibs
@@ -140,10 +137,16 @@ introSec hd ms1 l descr = text "#" <+> hd <+> contSep <> (if l == 1 then text ">
 regularSec :: Doc -> Doc -> Doc
 regularSec hd ms = text "##" <+> hd <+> contSep <+> ms
 
--- | Helper for 'makeMd' and 'extLibSec'.
-filtEmp :: [Doc] -> [Doc]
-filtEmp = filter (not . isEmpty) 
+-- Function to create the prefix for the path of the Drasil Logo
+buildPath :: Int -> String
+buildPath num = filter (/= ' ') $ unwords $ replicate num "../"
 
--- | Helper for authors and configuration files.
-listToDoc :: [String] -> Doc
-listToDoc = hsep . punctuate comma . map text
+-- | Drasil Tree icon. Uses HTML directly to format image since normal markdown doesn't support it.
+drasilImage :: Int -> Doc
+drasilImage num = alignImage (buildPath num ++
+  "drasil-website/WebInfo/images/Icon.png")
+
+-- | Aligns an image to the center using HTML, since markdown doesn't support it.
+alignImage :: FilePath -> Doc
+alignImage img = text "<p align=\"center\">" <> contSep <> text ("<img src=\"" 
+  ++ img ++ "\" alt=\"Drasil Tree\" width=\"200\" />") <> contSep <> text "</p>"

--- a/code/drasil-utils/lib/Utils/Drasil.hs
+++ b/code/drasil-utils/lib/Utils/Drasil.hs
@@ -1,9 +1,9 @@
 -- | Gather Drasil's utility functions and re-export for easy use.
--- For now, does not include combinators (Sentence.hs, NounPhrase.hs, Concepts.hs)
 module Utils.Drasil (
   -- * Documents
   -- | From "Utils.Drasil.Document".
-  blank, indent, indentList,
+  blank, indent, indentList, filterEmpty, listToDoc,
+  Separator, contSep,
 
   -- * Language
   -- | From "Utils.Drasil.English".

--- a/code/drasil-utils/lib/Utils/Drasil/Document.hs
+++ b/code/drasil-utils/lib/Utils/Drasil/Document.hs
@@ -22,10 +22,12 @@ indent = nest 4
 indentList :: [Doc] -> Doc
 indentList = indent . vcat
 
--- | Helper for 'makeMd' and 'extLibSec'.
+-- | Filter blank `Doc`s from a list.
 filterEmpty :: [Doc] -> [Doc]
 filterEmpty = filter (not . isEmpty) 
 
--- | Helper for authors and configuration files.
+-- | Merge a list of `String`s into a `Doc` format:
+--
+-- e.g., `listToDoc [a,b,c,...] ~= a, b, c, ...`
 listToDoc :: [String] -> Doc
 listToDoc = hsep . punctuate comma . map text

--- a/code/drasil-utils/lib/Utils/Drasil/Document.hs
+++ b/code/drasil-utils/lib/Utils/Drasil/Document.hs
@@ -1,8 +1,14 @@
 -- | Common 'Doc'-related functions for writting printers with a little more clarity.
-module Utils.Drasil.Document (blank, indent, (+:+.), indentList, drasilImage, 
-  contSep) where
+module Utils.Drasil.Document (blank, indent, indentList, contSep, filterEmpty,
+  listToDoc, Separator) where
 
-import Text.PrettyPrint.HughesPJ (Doc, nest, text, vcat)
+import Text.PrettyPrint.HughesPJ
+
+-- | Separates document sections.
+type Separator = Doc
+
+contSep :: Separator
+contSep = text "\n"
 
 -- | Creates a blank document with no text.
 blank :: Doc
@@ -12,30 +18,14 @@ blank = text ""
 indent :: Doc -> Doc
 indent = nest 4
 
--- | Helper which concatenates two Docs and appends a period.
-(+:+.) :: Doc -> Doc -> Doc
-a +:+. b = a <> b <> text "."
-
 -- | Indents a list of Docs and combines into one Doc.
 indentList :: [Doc] -> Doc
-indentList = vcat . map indent  -- TODO: Isn't this just `indent . vcat`? This would be a bit more efficient too
+indentList = indent . vcat
 
--- Function to create the prefix for the path of the Drasil Logo
-buildPath :: Int -> String
-buildPath num = filter (/= ' ') $ unwords $ replicate num "../"
+-- | Helper for 'makeMd' and 'extLibSec'.
+filterEmpty :: [Doc] -> [Doc]
+filterEmpty = filter (not . isEmpty) 
 
--- | Drasil Tree icon. Uses HTML directly to format image since normal markdown doesn't support it.
-drasilImage :: Int -> Doc
-drasilImage num = alignImage (buildPath num ++
-  "drasil-website/WebInfo/images/Icon.png")
-
--- | Aligns an image to the center using HTML, since markdown doesn't support it.
-alignImage :: FilePath -> Doc
-alignImage img = text "<p align=\"center\">" <> contSep <> text ("<img src=\"" 
-  ++ img ++ "\" alt=\"Drasil Tree\" width=\"200\" />") <> contSep <> text "</p>"
-
--- | Separates document sections.
-type Separator = Doc
-
-contSep :: Separator
-contSep = text "\n"
+-- | Helper for authors and configuration files.
+listToDoc :: [String] -> Doc
+listToDoc = hsep . punctuate comma . map text

--- a/code/drasil-utils/package.yaml
+++ b/code/drasil-utils/package.yaml
@@ -22,7 +22,6 @@ library:
   source-dirs: lib
   exposed-modules:
   - Utils.Drasil
-  - Utils.Drasil.Document
   when:
   - condition: false
     other-modules: Paths_drasil_utils

--- a/code/shell.nix
+++ b/code/shell.nix
@@ -1,43 +1,34 @@
-# Drasil development requirements
-# Installs everything except `Latin Modern` and `Latin Modern Math` font families.
-
-{ pkgs ? import (builtins.fetchGit {
-    name = "pinned-pkgs";   # Pinned at around ~Stack v2.5.1                       
-    url = "https://github.com/NixOS/nixpkgs/";                       
-    ref = "refs/heads/nixos-unstable";                     
-    rev = "046f8835dcb9082beb75bb471c28c832e1b067b6";                           
-  }) {}
-}:
-
-let
-  # Examples require some dependencies, these should eventually move into their respective artifact files
-  py-deps = python38-packages: with python38-packages; [
-    pandas
-    numpy
-    scipy
-  ]; 
-  py-with-deps = pkgs.python38.withPackages py-deps;
-in
+# A (nearly) fully featured development environment for working with Drasil. One
+# missing requirement is an installation of the `Latin Modern` and `Latin Modern
+# Math` font families (nix-shell understandably does not support installing
+# fonts).
+{pkgs ? import <nixpkgs> {}}:
 pkgs.mkShell {
   buildInputs = with pkgs; [
     # Stack is our full Haskell toolchain manager
     stack
 
+    # Raw GHC + HLS
+    haskell.compiler.ghc927
+    haskell.packages.ghc927.haskell-language-server
+
     # Makefile processor
     gnumake
-    
-    # Printing-related requirements (TeX + Graphs/Analysis)
+
+    # Document-related compilers needed for examples
     graphviz
     inkscape
     imagemagick
     texlive.combined.scheme-medium
-    
-    # Compilers
-    gcc            #  C/C++
-    mono           #  C#
-    jdk8           #  Java
-    swift          #  Swift
-    py-with-deps   #  Python + dependencies for examples
+
+    # Extra compilers needed for examples
+    gcc # C/C++
+    mono # C#
+    jdk8 # Java
+    swift # Swift
+
+    # Python + dependencies
+    (python310.withPackages (ps: with ps; [pandas nump scipy]))
   ];
 
   # NOTE: If fonts are ever allowed here, we will want them.

--- a/code/shell.nix
+++ b/code/shell.nix
@@ -19,7 +19,7 @@ pkgs.mkShell {
     graphviz
     inkscape
     imagemagick
-    texlive.combined.scheme-medium
+    texlive.combined.scheme-full
 
     # Extra compilers needed for examples
     gcc # C/C++

--- a/code/shell.nix
+++ b/code/shell.nix
@@ -28,7 +28,7 @@ pkgs.mkShell {
     swift # Swift
 
     # Python + dependencies
-    (python310.withPackages (ps: with ps; [pandas nump scipy]))
+    (python310.withPackages (ps: with ps; [pandas numpy scipy]))
   ];
 
   # NOTE: If fonts are ever allowed here, we will want them.

--- a/code/stack.yaml
+++ b/code/stack.yaml
@@ -81,6 +81,9 @@ flags: {}
 # Extra package databases containing global packages
 extra-package-dbs: []
 
+nix:
+  pure: false
+
 # Control whether we use the GHC we find on the path
 # system-ghc: true
 #


### PR DESCRIPTION
Builds on #3657 

1. Move very specific things out of `drasil-utils`, such as external
   resources.
2. Move generic things related to `Doc`s into `drasil-utils`.
3. Remove `Utils.Drasil.Document` from the list of exposed modules.