### PR TITLE
Fix website deploy script by copying files to expected areas

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@ dist
 .drasil-min-stack-ver
 stack.yaml.lock
 .hlint*
+.envrc
 
 # Drasil supported programming languages
 __pycache__

--- a/code/Makefile
+++ b/code/Makefile
@@ -489,7 +489,7 @@ deploy_lite: website ##@Deploy Deploy the Drasil website without regenerating ar
 # files appear newer and thus PDF's are regenerated. If you want to "just generate the structure,
 # everything exists," (or you've run `deploy` once already) then `deploy_lite` does just that and is
 # what `deploy.bash` calls. 
-deploy: analysis graphs packagedeps docs tex doxygen website ##@Deploy Generates all artifacts and the Drasil website locally.
+deploy: analysis graphs packagedeps docs tex doxygen ##@Deploy Generates all artifacts and the Drasil website locally.
 	"$(MAKE)" deploy_lite
 
 #-----------------------#

--- a/code/scripts/deploy_stage.sh
+++ b/code/scripts/deploy_stage.sh
@@ -90,7 +90,7 @@ copy_examples() {
     example_name=$(basename "$example")
     # Only copy actual examples
     if [[ "$EXAMPLE_DIRS" == *"$example_name"* ]]; then
-      target_srs_dir="./HTML/$EXAMPLE_DEST$example_name/$SRS_DEST"
+      target_srs_dir="./$EXAMPLE_DEST$example_name/$SRS_DEST"
       mkdir -p "$target_srs_dir"
       if [ -d "$example/SRS/PDF" ]; then
         cp "$example/SRS/PDF/"*.pdf "$target_srs_dir"

--- a/code/scripts/deploy_stage.sh
+++ b/code/scripts/deploy_stage.sh
@@ -74,12 +74,12 @@ copy_datafiles() {
   echo "FIXME: Drasil should copy needed images and resources to the appropriate output directory to avoid needing the entirety of datafiles (for HTML)."
   rm -rf datafiles
   mkdir -p datafiles
-  cp -r "$CUR_DIR/datafiles/" datafiles/
+  cp -r "$CUR_DIR/datafiles/." datafiles/
 }
 
 copy_graphs() {
   rm -rf "$GRAPH_FOLDER"
-  cp -r "$CUR_DIR$GRAPH_FOLDER" "$GRAPH_FOLDER"
+  cp -r "$CUR_DIR$GRAPH_FOLDER." "$GRAPH_FOLDER"
 }
 
 copy_examples() {
@@ -90,19 +90,22 @@ copy_examples() {
     example_name=$(basename "$example")
     # Only copy actual examples
     if [[ "$EXAMPLE_DIRS" == *"$example_name"* ]]; then
-      mkdir -p "$EXAMPLE_DEST$example_name/$SRS_DEST"
-      if [ -d "$example/"SRS/PDF ]; then
-        cp "$example/"SRS/PDF/*.pdf "$EXAMPLE_DEST$example_name/$SRS_DEST"
+      target_srs_dir="./HTML/$EXAMPLE_DEST$example_name/$SRS_DEST"
+      mkdir -p "$target_srs_dir"
+      if [ -d "$example/SRS/PDF" ]; then
+        cp "$example/SRS/PDF/"*.pdf "$target_srs_dir"
       fi
-      if [ -d "$example/"SRS/HTML ]; then
-        cp -r "$example/"SRS/HTML/ "$EXAMPLE_DEST$example_name/$SRS_DEST"
+      if [ -d "$example/SRS/HTML" ]; then
+        cp -r "$example/SRS/HTML/." "$target_srs_dir"
       fi
-      if [ -d "$example/"src ]; then
+      if [ -d "$example/src" ]; then
         mkdir -p "$EXAMPLE_DEST$example_name/$DOX_DEST"
-        for lang in "$example/"src/*; do
+        for lang in "$example/src/"*; do
           lang_name=$(basename "$lang")
-          mkdir -p "$EXAMPLE_DEST$example_name/$DOX_DEST$lang_name"
-          cp -r "$lang/" "$EXAMPLE_DEST$example_name/$DOX_DEST$lang_name/"
+          if [ "$lang_name" != "swift" ]; then
+            mkdir -p "$EXAMPLE_DEST$example_name/$DOX_DEST$lang_name"
+            cp -r "$lang/html/." "$EXAMPLE_DEST$example_name/$DOX_DEST$lang_name/"
+          fi
         done
         src_stub
       fi
@@ -113,8 +116,10 @@ copy_examples() {
           mkdir -p "$EXAMPLE_DEST$example_name/$DOX_DEST$v_name/"
           for lang in "$v/"src/*; do
             lang_name=$(basename "$lang")
-            mkdir -p "$EXAMPLE_DEST$example_name/$DOX_DEST$v_name/$lang_name"
-            cp -r "$lang/" "$EXAMPLE_DEST$example_name/$DOX_DEST$v_name/$lang_name/"
+            if [ "$lang_name" != "swift" ]; then
+              mkdir -p "$EXAMPLE_DEST$example_name/$DOX_DEST$v_name/$lang_name"
+              cp -r "$lang/html/." "$EXAMPLE_DEST$example_name/$DOX_DEST$v_name/$lang_name/"
+            fi
           done
         done
         src_stub
@@ -123,9 +128,8 @@ copy_examples() {
   done
 }
 
-
 src_stub() {
-  # We don't expose code in deploy. It's more conveneient to link to GitHub's directory
+  # We don't expose code in deploy. It's more convenient to link to GitHub's directory
   # We place a stub file which Hakyll will replace.
   REL_PATH=$(cd "$CUR_DIR" && "$MAKE" deploy_code_path | grep "$example_name" | cut -d"$DEPLOY_CODE_PATH_KV_SEP" -f 2-)
   # On a real deploy, `deploy` folder is itself a git repo, thus we need to ensure the path lookup is in the outer Drasil repo.
@@ -135,10 +139,8 @@ src_stub() {
 }
 
 copy_images() {
-  if [ -d "$CUR_DIR"deploy/images ]; then
-    rm -rf "$CUR_DIR"deploy/images
-  fi
-  mkdir -p "$CUR_DIR"deploy/images
+  rm -rf "$CUR_DIR/deploy/images"
+  mkdir -p "$CUR_DIR/deploy/images"
   cp -r "$CUR_DIR/drasil-website/WebInfo/images/" "$CUR_DIR/deploy"
 }
 
@@ -154,7 +156,7 @@ copy_traceygraphs() {
 
 copy_website() {
   cd "$CUR_DIR$DEPLOY_FOLDER"
-  cp -r "$CUR_DIR$WEBSITE_FOLDER" .
+  cp -r "$CUR_DIR$WEBSITE_FOLDER". .
 
   # src stubs were consumed by site generator; safe to delete those.
   rm "$EXAMPLE_DEST"*/src

--- a/code/shell.nix
+++ b/code/shell.nix
@@ -1,43 +1,34 @@
-# Drasil development requirements
-# Installs everything except `Latin Modern` and `Latin Modern Math` font families.
-
-{ pkgs ? import (builtins.fetchGit {
-    name = "pinned-pkgs";   # Pinned at around ~Stack v2.5.1                       
-    url = "https://github.com/NixOS/nixpkgs/";                       
-    ref = "refs/heads/nixos-unstable";                     
-    rev = "046f8835dcb9082beb75bb471c28c832e1b067b6";                           
-  }) {}
-}:
-
-let
-  # Examples require some dependencies, these should eventually move into their respective artifact files
-  py-deps = python38-packages: with python38-packages; [
-    pandas
-    numpy
-    scipy
-  ]; 
-  py-with-deps = pkgs.python38.withPackages py-deps;
-in
+# A (nearly) fully featured development environment for working with Drasil. One
+# missing requirement is an installation of the `Latin Modern` and `Latin Modern
+# Math` font families (nix-shell understandably does not support installing
+# fonts).
+{pkgs ? import <nixpkgs> {}}:
 pkgs.mkShell {
   buildInputs = with pkgs; [
     # Stack is our full Haskell toolchain manager
     stack
 
+    # Raw GHC + HLS
+    haskell.compiler.ghc927
+    haskell.packages.ghc927.haskell-language-server
+
     # Makefile processor
     gnumake
-    
-    # Printing-related requirements (TeX + Graphs/Analysis)
+
+    # Document-related compilers needed for examples
     graphviz
     inkscape
     imagemagick
     texlive.combined.scheme-medium
-    
-    # Compilers
-    gcc            #  C/C++
-    mono           #  C#
-    jdk8           #  Java
-    swift          #  Swift
-    py-with-deps   #  Python + dependencies for examples
+
+    # Extra compilers needed for examples
+    gcc # C/C++
+    mono # C#
+    jdk8 # Java
+    swift # Swift
+
+    # Python + dependencies
+    (python310.withPackages (ps: with ps; [pandas nump scipy]))
   ];
 
   # NOTE: If fonts are ever allowed here, we will want them.

--- a/code/shell.nix
+++ b/code/shell.nix
@@ -19,7 +19,7 @@ pkgs.mkShell {
     graphviz
     inkscape
     imagemagick
-    texlive.combined.scheme-medium
+    texlive.combined.scheme-full
 
     # Extra compilers needed for examples
     gcc # C/C++

--- a/code/shell.nix
+++ b/code/shell.nix
@@ -28,7 +28,7 @@ pkgs.mkShell {
     swift # Swift
 
     # Python + dependencies
-    (python310.withPackages (ps: with ps; [pandas nump scipy]))
+    (python310.withPackages (ps: with ps; [pandas numpy scipy]))
   ];
 
   # NOTE: If fonts are ever allowed here, we will want them.

--- a/code/stack.yaml
+++ b/code/stack.yaml
@@ -81,6 +81,9 @@ flags: {}
 # Extra package databases containing global packages
 extra-package-dbs: []
 
+nix:
+  pure: false
+
 # Control whether we use the GHC we find on the path
 # system-ghc: true
 #


### PR DESCRIPTION
Closes #3646 

Builds on #3657

I'm leaving this as a draft because I want to make sure folder links are plugged in properly. The structure of the `gh-pages` branch is very confusing, we might need to re-evaluate that at some point.

To test this branch:
1. `make clean`,
2. `make deploy`,
3. get a coffee while waiting for (2) to finish -- it takes a crazy amount of time building the PDFs (which it shouldn't even be needing to do!),
4. open `deploy/HTML/index.html` in your local web browser,
5. look at the "HTML" and "PDF" links related to each example, and make sure they don't lead to 404s