### PR TITLE
Website: Prefer showing the public Drasil image over the local

### DIFF
--- a/code/drasil-website/lib/Drasil/Website/Body.hs
+++ b/code/drasil-website/lib/Drasil/Website/Body.hs
@@ -178,7 +178,7 @@ websiteTitle :: String
 gitHubInfoURL, imagePath :: FilePath
 websiteTitle = "Drasil - Generate All the Things!"
 gitHubInfoURL = "https://github.com/JacquesCarette/Drasil"
-imagePath = "../images/Icon.png"
+imagePath = "./images/Icon.png"
 
 -- * Footer Section
 

--- a/code/stable-website/index.html
+++ b/code/stable-website/index.html
@@ -31,7 +31,7 @@
         <h1></h1>
         <div id="Figure:Drasil">
           <figure>
-            <img src="../images/Icon.png" alt="" width="50.0%" >
+            <img src="./images/Icon.png" alt="" width="50.0%" >
             <figcaption></figcaption>
           </figure>
         </div>


### PR DESCRIPTION
Bug: Our image was removed from the website with #3662 getting merged in (but I don't think #3662 is the culprit).

![image](https://github.com/JacquesCarette/Drasil/assets/1627302/9d495dbd-360e-49ca-a3c6-5b56a38437ab)


It _looks_ like 26aab9ddff29d4b1aa8bd6001e7404effe78a85e introduced a small bug that only surfaced now (I have no idea why) with #3662 getting merged in. Since the locally constructed website doesn't have the same file structure as the one we have up on GitHub (specifically, the local one has `*.html` files nested in an `HTML` folder), it looks like the commit fixed the image displaying on the website locally but broke it on the remote/public website.