### PR TITLE
Add citation to original (manual) works from each case study #3562 (Attempt 1)

### DIFF
--- a/code/drasil-example/README.md
+++ b/code/drasil-example/README.md
@@ -7,50 +7,50 @@ This folder contains our working examples (implementations in Drasil of the prev
 
 **dblpend**
   - Contains the current state of the Double Pendulum case study implemented in Drasil
-  - This is a recreation of the original, manually-created version 
+  - This is a re-creation of the original, manually-created version 
     in the [dblpend](https://github.com/Zhang-Zhi-ZZ/CAS741Project) Double Pendulum example.
 
 **gamephysics**
   - Contains the current state of the Game Physics case study implemented in Drasil
-  - This is a recreation of the original, manually-created version 
+  - This is a re-creation of the original, manually-created version 
     in the [gamephysics](https://github.com/smiths/caseStudies/tree/master/CaseStudies/gamephys) 2D Rigid Body Physics Library.
 
 **glassbr**
   - Contains the current state of the GlassBR case study implemented in Drasil
-  - This is a recreation of the original, manually-created version 
+  - This is a re-creation of the original, manually-created version 
     in the [Glass-BR](https://github.com/smiths/caseStudies/tree/master/CaseStudies/glass) example.
   
 **hghc**
   - Contains the current state of the HGHC (fuel pin) example implemented in Drasil
-  - This is a recreation of the original, manually-created version 
+  - This is a re-creation of the original, manually-created version 
     in the [hghc](https://github.com/smiths/caseStudies/tree/master/CaseStudies/hghc) toy example.
   
 **swhsnopcm**
   - Contains the current state of the solar water heating system case study implemented in Drasil
-  - This is a recreation of the original, manually-created version 
+  - This is a re-creation of the original, manually-created version 
     in the [Nopcm](https://github.com/smiths/caseStudies/tree/master/CaseStudies/noPCM) SWHS without PCM example.
 
 **pdcontroller**
   - Contains the current state of the PD Controller example implemented in Drasil
-  - This is a recreation of the original, manually-created version 
+  - This is a re-creation of the original, manually-created version 
     in the [Proportional Derivative Controller](https://github.com/muralidn/CAS741-Fall20) example.
 
 **projectile**
   - Contains the current work on implementing the projectile example in Drasil
-  - This is a recreation of the original, manually-created version 
-    in the [Projectile](https://github.com/smiths/caseStudies/tree/master/CaseStudies/projectile) motion analysis example.  
+  - This is a re-creation of the original, manually-created version 
+    in the [Projectile](https://github.com/smiths/caseStudies/tree/master/CaseStudies/projectile/projectileSRS) motion analysis example.  
 
 **sglpend**
   - Contains the current state of the Single Pendulum case study implemented in Drasil
 
 **ssp**
   - Contains the current state of the slope stability analysis case study implemented in Drasil
-  - This is a recreation of the original, manually-created version 
+  - This is a re-creation of the original, manually-created version 
     in the [SSP](https://github.com/smiths/caseStudies/tree/master/CaseStudies/ssp) Slope Stability Analysis example. 
   
 **swhs**
   - Contains the current state of the solar water heating system incorporating phase change material case study implemented in Drasil
-  - This is a recreation of the original, manually-created version 
+  - This is a re-creation of the original, manually-created version 
     in the [swhs](https://github.com/smiths/swhs) Solar Water Heating System example. 
 
 **template**

--- a/code/drasil-example/README.md
+++ b/code/drasil-example/README.md
@@ -13,7 +13,7 @@ This folder contains our working examples (implementations in Drasil of the prev
 **gamephysics**
   - Contains the current state of the Game Physics case study implemented in Drasil
   - This is a recreation of the original, manually-created version 
-    in the https://github.com/smiths/caseStudies/tree/master/CaseStudies/gamephys repo.
+    in the [gamephysics](https://github.com/smiths/caseStudies/tree/master/CaseStudies/gamephys) 2D Rigid Body Physics Library.
 
 **glassbr**
   - Contains the current state of the GlassBR case study implemented in Drasil

--- a/code/drasil-example/README.md
+++ b/code/drasil-example/README.md
@@ -42,8 +42,6 @@ This folder contains our working examples (implementations in Drasil of the prev
 
 **sglpend**
   - Contains the current state of the Single Pendulum case study implemented in Drasil
-  - This is a recreation of the original, manually-created version 
-    in the https://github.com/smiths/caseStudies/tree/master/CaseStudies repo. 
 
 **ssp**
   - Contains the current state of the slope stability analysis case study implemented in Drasil

--- a/code/drasil-example/README.md
+++ b/code/drasil-example/README.md
@@ -56,7 +56,7 @@ This folder contains our working examples (implementations in Drasil of the prev
     in the https://github.com/smiths/caseStudies/tree/master/CaseStudies repo. 
 
 **template**
-  - An empty example for implementing future examples in Drasil 
+  - An empty example for implementing future examples in Drasil
 
 README.md
   - This file

--- a/code/drasil-example/README.md
+++ b/code/drasil-example/README.md
@@ -18,27 +18,27 @@ This folder contains our working examples (implementations in Drasil of the prev
 **glassbr**
   - Contains the current state of the GlassBR case study implemented in Drasil
   - This is a recreation of the original, manually-created version 
-    in the https://github.com/smiths/caseStudies/tree/master/CaseStudies/glass repo.
+    in the [Glass-BR](https://github.com/smiths/caseStudies/tree/master/CaseStudies/glass) example.
   
 **hghc**
   - Contains the current state of the HGHC (fuel pin) example implemented in Drasil
   - This is a recreation of the original, manually-created version 
-    in the https://github.com/smiths/caseStudies/tree/master/CaseStudies/hghc repo.
+    in the [hghc](https://github.com/smiths/caseStudies/tree/master/CaseStudies/hghc) toy example.
   
 **swhsnopcm**
   - Contains the current state of the solar water heating system case study implemented in Drasil
   - This is a recreation of the original, manually-created version 
-    in the https://github.com/smiths/caseStudies/tree/master/CaseStudies/noPCM repo.
+    in the [Nopcm](https://github.com/smiths/caseStudies/tree/master/CaseStudies/noPCM) SWHS without PCM example.
 
 **pdcontroller**
   - Contains the current state of the PD Controller example implemented in Drasil
   - This is a recreation of the original, manually-created version 
-    in the https://github.com/topics/pd-controller repo.
+    in the [Proportional Derivative Controller](https://github.com/muralidn/CAS741-Fall20) example.
 
 **projectile**
   - Contains the current work on implementing the projectile example in Drasil
   - This is a recreation of the original, manually-created version 
-    in the https://github.com/smiths/caseStudies/tree/master/CaseStudies/projectile repo.  
+    in the [Projectile](https://github.com/smiths/caseStudies/tree/master/CaseStudies/projectile) motion analysis example.  
 
 **sglpend**
   - Contains the current state of the Single Pendulum case study implemented in Drasil
@@ -48,7 +48,7 @@ This folder contains our working examples (implementations in Drasil of the prev
 **ssp**
   - Contains the current state of the slope stability analysis case study implemented in Drasil
   - This is a recreation of the original, manually-created version 
-    in the https://github.com/smiths/caseStudies/tree/master/CaseStudies/projectile repo. 
+    in the [SSP](https://github.com/smiths/caseStudies/tree/master/CaseStudies/ssp) Slope Stability Analysis example. 
   
 **swhs**
   - Contains the current state of the solar water heating system incorporating phase change material case study implemented in Drasil

--- a/code/drasil-example/README.md
+++ b/code/drasil-example/README.md
@@ -56,9 +56,7 @@ This folder contains our working examples (implementations in Drasil of the prev
     in the https://github.com/smiths/caseStudies/tree/master/CaseStudies repo. 
 
 **template**
-  - An empty example for implementing future examples in Drasil
-  - This is a recreation of the original, manually-created version 
-    in the https://github.com/smiths/caseStudies/tree/master/CaseStudies repo. 
+  - An empty example for implementing future examples in Drasil 
 
 README.md
   - This file

--- a/code/drasil-example/README.md
+++ b/code/drasil-example/README.md
@@ -8,7 +8,7 @@ This folder contains our working examples (implementations in Drasil of the prev
 **dblpend**
   - Contains the current state of the Double Pendulum case study implemented in Drasil
   - This is a recreation of the original, manually-created version 
-    in the https://github.com/smiths/caseStudies/tree/master/CaseStudies repo.
+    in the [dblpend](https://github.com/Zhang-Zhi-ZZ/CAS741Project) Double Pendulum example.
 
 **gamephysics**
   - Contains the current state of the Game Physics case study implemented in Drasil
@@ -53,7 +53,7 @@ This folder contains our working examples (implementations in Drasil of the prev
 **swhs**
   - Contains the current state of the solar water heating system incorporating phase change material case study implemented in Drasil
   - This is a recreation of the original, manually-created version 
-    in the https://github.com/smiths/caseStudies/tree/master/CaseStudies repo. 
+    in the [swhs](https://github.com/smiths/swhs) Solar Water Heating System example. 
 
 **template**
   - An empty example for implementing future examples in Drasil

--- a/code/drasil-example/README.md
+++ b/code/drasil-example/README.md
@@ -7,36 +7,58 @@ This folder contains our working examples (implementations in Drasil of the prev
 
 **dblpend**
   - Contains the current state of the Double Pendulum case study implemented in Drasil
+  - This is a recreation of the original, manually-created version 
+    in the https://github.com/smiths/caseStudies/tree/master/CaseStudies repo.
 
 **gamephysics**
   - Contains the current state of the Game Physics case study implemented in Drasil
+  - This is a recreation of the original, manually-created version 
+    in the https://github.com/smiths/caseStudies/tree/master/CaseStudies/gamephys repo.
 
 **glassbr**
   - Contains the current state of the GlassBR case study implemented in Drasil
+  - This is a recreation of the original, manually-created version 
+    in the https://github.com/smiths/caseStudies/tree/master/CaseStudies/glass repo.
   
 **hghc**
   - Contains the current state of the HGHC (fuel pin) example implemented in Drasil
+  - This is a recreation of the original, manually-created version 
+    in the https://github.com/smiths/caseStudies/tree/master/CaseStudies/hghc repo.
   
 **swhsnopcm**
   - Contains the current state of the solar water heating system case study implemented in Drasil
+  - This is a recreation of the original, manually-created version 
+    in the https://github.com/smiths/caseStudies/tree/master/CaseStudies/noPCM repo.
 
 **pdcontroller**
   - Contains the current state of the PD Controller example implemented in Drasil
+  - This is a recreation of the original, manually-created version 
+    in the https://github.com/topics/pd-controller repo.
 
 **projectile**
   - Contains the current work on implementing the projectile example in Drasil
+  - This is a recreation of the original, manually-created version 
+    in the https://github.com/smiths/caseStudies/tree/master/CaseStudies/projectile repo.  
 
 **sglpend**
   - Contains the current state of the Single Pendulum case study implemented in Drasil
+  - This is a recreation of the original, manually-created version 
+    in the https://github.com/smiths/caseStudies/tree/master/CaseStudies repo. 
 
 **ssp**
   - Contains the current state of the slope stability analysis case study implemented in Drasil
+  - This is a recreation of the original, manually-created version 
+    in the https://github.com/smiths/caseStudies/tree/master/CaseStudies/projectile repo. 
   
 **swhs**
   - Contains the current state of the solar water heating system incorporating phase change material case study implemented in Drasil
+  - This is a recreation of the original, manually-created version 
+    in the https://github.com/smiths/caseStudies/tree/master/CaseStudies repo. 
 
 **template**
   - An empty example for implementing future examples in Drasil
+  - This is a recreation of the original, manually-created version 
+    in the https://github.com/smiths/caseStudies/tree/master/CaseStudies repo. 
 
 README.md
   - This file


### PR DESCRIPTION
@balacij @smiths Hi Jason and Dr.Smith,
Because the `drasil-example` folder stores all regenerated examples, I think this is the right position to add the mentioned "back" citation. After checking inside folders, I did not find any README files. So the only correct place is in this README file.

Jason, There is one thing I did not find: Where is the Naveen's PD controller github address? I tried to search it before, but I did not find what I expected.
#3562 