### PR TITLE
Switch `compsy` usage to an instance of `Ord` for `Symbol`

### DIFF
--- a/code/drasil-docLang/lib/Drasil/DocumentLanguage.hs
+++ b/code/drasil-docLang/lib/Drasil/DocumentLanguage.hs
@@ -21,7 +21,6 @@ import Drasil.ExtractDocDesc (getDocDesc, egetDocDesc)
 import Drasil.TraceTable (generateTraceMap)
 
 import Language.Drasil hiding (kind)
-import Language.Drasil.Display (compsy)
 
 import Database.Drasil hiding (cdb)
 import SysInfo.Drasil
@@ -290,7 +289,7 @@ mkTSymb :: (Quantity e, Concept e, Eq e, MayHaveUnit e) =>
   [e] -> LFunc -> [TSIntro] -> Section
 mkTSymb v f c = SRS.tOfSymb [tsIntro c,
   LlC $ table Equational
-    (sortBy (compsy `on` eqSymb) $ filter (`hasStageSymbol` Equational) (nub v))
+    (sortBy (compare `on` eqSymb) $ filter (`hasStageSymbol` Equational) (nub v))
     (lf f)] 
     []
   where lf Term = atStart

--- a/code/drasil-lang/lib/Language/Drasil/Display.hs
+++ b/code/drasil-lang/lib/Language/Drasil/Display.hs
@@ -1,7 +1,9 @@
 -- | Re-export display-related functions and types to simplify external use.
-module Language.Drasil.Display (
-    -- * Symbol
-    Decoration(..), Symbol(..), compsy
-    ) where
+module Language.Drasil.Display
+  ( -- * Symbol
+    Decoration (..),
+    Symbol (..)
+  )
+where
 
-import Language.Drasil.Symbol (Decoration(..), Symbol(..), compsy)
+import Language.Drasil.Symbol (Decoration(..), Symbol(..))

--- a/code/drasil-lang/lib/Language/Drasil/Document/Combinators.hs
+++ b/code/drasil-lang/lib/Language/Drasil/Document/Combinators.hs
@@ -75,9 +75,9 @@ sortBySymbol = sortBy compareBySymbol
 sortBySymbolTuple :: HasSymbol a => [(a, b)] -> [(a, b)]
 sortBySymbolTuple = sortBy (compareBySymbol `on` fst)
 
--- | Compares two 'Symbol's and returns their order. See 'compsy' for more information.
+-- | Compare the equational 'Symbol' of two things.
 compareBySymbol :: HasSymbol a => a -> a -> Ordering
-compareBySymbol a b = compsy (eqSymb a) (eqSymb b)
+compareBySymbol a b = eqSymb a `compare` eqSymb b
 
 -- Ideally this would create a reference to the equation too.
 -- Doesn't use equation concept so utils doesn't depend on data

--- a/code/drasil-lang/lib/Language/Drasil/Symbol.hs
+++ b/code/drasil-lang/lib/Language/Drasil/Symbol.hs
@@ -3,9 +3,7 @@ module Language.Drasil.Symbol (
   -- * Types
   Decoration(..), Symbol(..),
   -- * Classes
-  HasSymbol(..),
-  -- * Ordering Function
-  compsy
+  HasSymbol(..)
 ) where
 
 import Language.Drasil.Stages (Stage)
@@ -77,30 +75,27 @@ instance Semigroup Symbol where
 instance Monoid Symbol where
   mempty = Empty
 
--- | Gives an 'Ordering' of two lists of 'Symbol's.
-complsy :: [Symbol] -> [Symbol] -> Ordering
-complsy [] [] = EQ
-complsy [] _  = LT
-complsy _  [] = GT
-complsy (x : xs) (y : ys) = compsy x y <> complsy xs ys
+instance Ord Symbol where
+  compare = compsy
 
--- | The default compare function that sorts all the lower case symbols after the upper case ones.
+-- | The default compare function that sorts all the lower case symbols after
+-- the upper case ones.
 --
--- Comparation is used twice for each `Atomic` case,
--- once for making sure they are the same letter, once for case sensitive.
--- As far as this comparison is considered, `Δ` is a "decoration" and ignored
--- unless the compared symbols are the exact same, in which case it is ordered
--- after the undecorated symbol.
+-- Comparation is used twice for each `Atomic` case, once for making sure they
+-- are the same letter, once for case sensitive. As far as this comparison is
+-- considered, `Δ` is a "decoration" and ignored unless the compared symbols are
+-- the exact same, in which case it is ordered after the undecorated symbol.
 --
--- Superscripts and subscripts are ordered after the base symbols (because they add additional context to a symbol). 
--- For example: `v_f^{AB}` (expressed in LaTeX
--- notation for clarity), where `v_f` is a final velocity, and the `^{AB}` adds context that it is the
--- final velocity between points `A` and `B`. In these cases, the sorting of `v_f^{AB}` should be
--- following `v_f` as it is logical to place it with its parent concept.
+-- Superscripts and subscripts are ordered after the base symbols (because they
+-- add additional context to a symbol). For example: `v_f^{AB}` (expressed in
+-- LaTeX notation for clarity), where `v_f` is a final velocity, and the `^{AB}`
+-- adds context that it is the final velocity between points `A` and `B`. In
+-- these cases, the sorting of `v_f^{AB}` should be following `v_f` as it is
+-- logical to place it with its parent concept.
 compsy :: Symbol -> Symbol -> Ordering
-compsy (Concat x) (Concat y) = complsy x y
-compsy (Concat a) b = complsy a [b]
-compsy b (Concat a) = complsy [b] a
+compsy (Concat x) (Concat y) = compare x y
+compsy (Concat a) b = compare a [b]
+compsy b (Concat a) = compare [b] a
 compsy (Atop d1 a) (Atop d2 a') = 
   case compsy a a' of
     EQ -> compare d1 d2
@@ -130,8 +125,8 @@ compsy (Corners [] [] ur [] (Corners [] [] [] lr b)) a = compsy (Corners [] [] u
 compsy a (Corners [] [] ur [] (Corners [] [] [] lr b)) = compsy a (Corners [] [] ur lr b)
 compsy (Corners _ _ u l b) (Corners _ _ u' l' b')  =
   case compsy b b' of
-    EQ -> case complsy l l' of
-      EQ -> complsy u u'
+    EQ -> case compare l l' of
+      EQ -> compare u u'
       other -> other
     other -> other
 compsy a (Corners _ _ _ _ b) =

--- a/code/drasil-lang/lib/Language/Drasil/UnitLang.hs
+++ b/code/drasil-lang/lib/Language/Drasil/UnitLang.hs
@@ -6,7 +6,7 @@ module Language.Drasil.UnitLang (
   , fromUDefn, compUSymb, getUSymb, getDefn
   ) where
 
-import Language.Drasil.Symbol (Symbol, compsy)
+import Language.Drasil.Symbol (Symbol)
 
 -- UName for the base cases, otherwise build up.
 -- Probably a 7-vector would be better (less error-prone!)
@@ -32,7 +32,7 @@ fromUDefn (UShift _ s) = s
 compUSymb :: USymb -> USymb -> Ordering
 compUSymb (US l)  (US m)  = foldl mappend EQ $ zipWith comp l m
   where
-    comp (s1, i1) (s2, i2) = compsy s1 s2 `mappend` compare i1 i2
+    comp (s1, i1) (s2, i2) = compare s1 s2 `mappend` compare i1 i2
 
 -- | When we define units, they come in three flavours:
 -- SI (base) units, derived SI units (aka synonyms), and defined units.


### PR DESCRIPTION
Removes an export, re-using `Ord` instead.