### PR TITLE
Update stackage release: 20.20 (GHC 9.2.7) -> 20.26 (GHC 9.2.8)

### DIFF
--- a/code/drasil-build/stack.yaml
+++ b/code/drasil-build/stack.yaml
@@ -17,8 +17,7 @@
 #
 # resolver: ./custom-snapshot.yaml
 # resolver: https://example.com/snapshots/2018-01-01.yaml
-resolver:
-  url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/20/20.yaml
+resolver: lts-20.26
 
 # User packages to be built.
 # Various formats can be used as shown in the example below.

--- a/code/drasil-code/stack.yaml
+++ b/code/drasil-code/stack.yaml
@@ -17,8 +17,7 @@
 #
 # resolver: ./custom-snapshot.yaml
 # resolver: https://example.com/snapshots/2018-01-01.yaml
-resolver:
-  url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/20/20.yaml
+resolver: lts-20.26
 
 # User packages to be built.
 # Various formats can be used as shown in the example below.

--- a/code/drasil-codeLang/stack.yaml
+++ b/code/drasil-codeLang/stack.yaml
@@ -17,8 +17,7 @@
 #
 # resolver: ./custom-snapshot.yaml
 # resolver: https://example.com/snapshots/2018-01-01.yaml
-resolver:
-  url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/20/20.yaml
+resolver: lts-20.26
 
 # User packages to be built.
 # Various formats can be used as shown in the example below.

--- a/code/drasil-data/stack.yaml
+++ b/code/drasil-data/stack.yaml
@@ -17,8 +17,7 @@
 #
 # resolver: ./custom-snapshot.yaml
 # resolver: https://example.com/snapshots/2018-01-01.yaml
-resolver:
-  url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/20/20.yaml
+resolver: lts-20.26
 
 # User packages to be built.
 # Various formats can be used as shown in the example below.

--- a/code/drasil-database/stack.yaml
+++ b/code/drasil-database/stack.yaml
@@ -17,8 +17,7 @@
 #
 # resolver: ./custom-snapshot.yaml
 # resolver: https://example.com/snapshots/2018-01-01.yaml
-resolver:
-  url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/20/20.yaml
+resolver: lts-20.26
 
 # User packages to be built.
 # Various formats can be used as shown in the example below.

--- a/code/drasil-docLang/stack.yaml
+++ b/code/drasil-docLang/stack.yaml
@@ -17,8 +17,7 @@
 #
 # resolver: ./custom-snapshot.yaml
 # resolver: https://example.com/snapshots/2018-01-01.yaml
-resolver:
-  url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/20/20.yaml
+resolver: lts-20.26
 
 # User packages to be built.
 # Various formats can be used as shown in the example below.

--- a/code/drasil-example/dblpend/stack.yaml
+++ b/code/drasil-example/dblpend/stack.yaml
@@ -1,5 +1,4 @@
-resolver:
-  url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/20/20.yaml
+resolver: lts-20.26
 
 packages:
 - .

--- a/code/drasil-example/gamephysics/stack.yaml
+++ b/code/drasil-example/gamephysics/stack.yaml
@@ -1,5 +1,4 @@
-resolver:
-  url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/20/20.yaml
+resolver: lts-20.26
 
 packages:
 - .

--- a/code/drasil-example/glassbr/stack.yaml
+++ b/code/drasil-example/glassbr/stack.yaml
@@ -1,5 +1,4 @@
-resolver:
-  url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/20/20.yaml
+resolver: lts-20.26
 
 packages:
 - .

--- a/code/drasil-example/hghc/stack.yaml
+++ b/code/drasil-example/hghc/stack.yaml
@@ -1,5 +1,4 @@
-resolver:
-  url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/20/20.yaml
+resolver: lts-20.26
 
 packages:
 - .

--- a/code/drasil-example/pdcontroller/stack.yaml
+++ b/code/drasil-example/pdcontroller/stack.yaml
@@ -1,5 +1,4 @@
-resolver:
-  url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/20/20.yaml
+resolver: lts-20.26
 
 packages:
 - .

--- a/code/drasil-example/projectile/stack.yaml
+++ b/code/drasil-example/projectile/stack.yaml
@@ -1,5 +1,4 @@
-resolver:
-  url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/20/20.yaml
+resolver: lts-20.26
 
 packages:
 - .

--- a/code/drasil-example/sglpend/stack.yaml
+++ b/code/drasil-example/sglpend/stack.yaml
@@ -1,5 +1,4 @@
-resolver:
-  url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/20/20.yaml
+resolver: lts-20.26
 
 packages:
 - .

--- a/code/drasil-example/ssp/stack.yaml
+++ b/code/drasil-example/ssp/stack.yaml
@@ -1,5 +1,4 @@
-resolver:
-  url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/20/20.yaml
+resolver: lts-20.26
 
 packages:
 - .

--- a/code/drasil-example/swhs/stack.yaml
+++ b/code/drasil-example/swhs/stack.yaml
@@ -1,5 +1,4 @@
-resolver:
-  url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/20/20.yaml
+resolver: lts-20.26
 
 packages:
 - .

--- a/code/drasil-example/swhsnopcm/stack.yaml
+++ b/code/drasil-example/swhsnopcm/stack.yaml
@@ -1,5 +1,4 @@
-resolver:
-  url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/20/20.yaml
+resolver: lts-20.26
 
 packages:
 - .

--- a/code/drasil-example/template/stack.yaml
+++ b/code/drasil-example/template/stack.yaml
@@ -1,5 +1,4 @@
-resolver:
-  url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/20/20.yaml
+resolver: lts-20.26
 
 packages:
 - .

--- a/code/drasil-gen/stack.yaml
+++ b/code/drasil-gen/stack.yaml
@@ -17,8 +17,7 @@
 #
 # resolver: ./custom-snapshot.yaml
 # resolver: https://example.com/snapshots/2018-01-01.yaml
-resolver:
-  url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/20/20.yaml
+resolver: lts-20.26
 
 # User packages to be built.
 # Various formats can be used as shown in the example below.

--- a/code/drasil-gool/stack.yaml
+++ b/code/drasil-gool/stack.yaml
@@ -17,8 +17,7 @@
 #
 # resolver: ./custom-snapshot.yaml
 # resolver: https://example.com/snapshots/2018-01-01.yaml
-resolver:
-  url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/20/20.yaml
+resolver: lts-20.26
 
 # User packages to be built.
 # Various formats can be used as shown in the example below.

--- a/code/drasil-lang/stack.yaml
+++ b/code/drasil-lang/stack.yaml
@@ -17,8 +17,7 @@
 #
 # resolver: ./custom-snapshot.yaml
 # resolver: https://example.com/snapshots/2018-01-01.yaml
-resolver:
-  url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/20/20.yaml
+resolver: lts-20.26
 
 # User packages to be built.
 # Various formats can be used as shown in the example below.

--- a/code/drasil-metadata/stack.yaml
+++ b/code/drasil-metadata/stack.yaml
@@ -15,8 +15,7 @@
 #
 # resolver: ./custom-snapshot.yaml
 # resolver: https://example.com/snapshots/2018-01-01.yaml
-resolver:
-  url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/20/20.yaml
+resolver: lts-20.26
 
 # User packages to be built.
 # Various formats can be used as shown in the example below.

--- a/code/drasil-printers/stack.yaml
+++ b/code/drasil-printers/stack.yaml
@@ -17,8 +17,7 @@
 #
 # resolver: ./custom-snapshot.yaml
 # resolver: https://example.com/snapshots/2018-01-01.yaml
-resolver:
-  url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/20/20.yaml
+resolver: lts-20.26
 
 # User packages to be built.
 # Various formats can be used as shown in the example below.

--- a/code/drasil-sysinfo/stack.yaml
+++ b/code/drasil-sysinfo/stack.yaml
@@ -17,8 +17,7 @@
 #
 # resolver: ./custom-snapshot.yaml
 # resolver: https://example.com/snapshots/2018-01-01.yaml
-resolver:
-  url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/20/20.yaml
+resolver: lts-20.26
 
 # User packages to be built.
 # Various formats can be used as shown in the example below.

--- a/code/drasil-theory/stack.yaml
+++ b/code/drasil-theory/stack.yaml
@@ -17,8 +17,7 @@
 #
 # resolver: ./custom-snapshot.yaml
 # resolver: https://example.com/snapshots/2018-01-01.yaml
-resolver:
-  url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/20/20.yaml
+resolver: lts-20.26
 
 # User packages to be built.
 # Various formats can be used as shown in the example below.

--- a/code/drasil-utils/stack.yaml
+++ b/code/drasil-utils/stack.yaml
@@ -17,8 +17,7 @@
 #
 # resolver: ./custom-snapshot.yaml
 # resolver: https://example.com/snapshots/2018-01-01.yaml
-resolver:
-  url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/20/20.yaml
+resolver: lts-20.26
 
 # User packages to be built.
 # Various formats can be used as shown in the example below.

--- a/code/drasil-website/stack.yaml
+++ b/code/drasil-website/stack.yaml
@@ -1,5 +1,4 @@
-resolver:
-  url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/20/20.yaml
+resolver: lts-20.26
 
 packages:
 - .

--- a/code/scripts/update_default_stackage.sh
+++ b/code/scripts/update_default_stackage.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+
+if [ -z "$1" ]; then
+    echo "Usage: $0 <lts-X>"
+    echo "Example: $0 20.26"
+    exit 1
+fi
+
+search="^resolver: lts-[0-9]+\.[0-9]+$"
+replace="resolver: lts-$1"
+
+find "." -type f -name "stack.yaml" | while read file; do
+    sed -i -E "s|${search}|${replace}|g" "$file"
+    echo "Updated: $file"
+done

--- a/code/stack.yaml
+++ b/code/stack.yaml
@@ -15,8 +15,7 @@
 # resolver:
 #  name: custom-snapshot
 #  location: "./custom-snapshot.yaml"
-resolver:
-  url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/20/20.yaml
+resolver: lts-20.26
 
 # User packages to be built.
 # Various formats can be used as shown in the example below.


### PR DESCRIPTION
And create a script for automating future updates.