### PR TITLE
Add `.direnv` to `.gitignore`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ desktop.ini
 # Editors
 .idea
 .vscode
+.direnv
 
 # Drasil/Haskell
 *.cabal


### PR DESCRIPTION
[`direnv`](https://direnv.net/) is a tool for automatically loading environment variables from a `.envrc` file. I use it to load up the nix shell script. I also use it in general now to load virtual environments for any programming project. Just adding the 'direnv build' folder to our `.gitignore`, so that I don't accidentally commit it.