### PR TITLE
Website: add links to the source code for each generated example #3668

### DIFF
--- a/code/drasil-website/lib/Drasil/Website/Example.hs
+++ b/code/drasil-website/lib/Drasil/Website/Example.hs
@@ -185,16 +185,16 @@ getCodeRef ex@E{sysInfoE=SI{_sys = sys}, choicesE = chcs} l verName =
     -- Program language converted for use in file folder navigation.
     programLang = convertLang l
 
--- | Similar to 'getCodeRef', but builds the source code references 
--- and uses 'getExampleSrcCodePath' instead.
+-- | Similar to 'getCodeRef', but builds the source code references
 buildDrasilExSrcRef :: Example -> Reference
 buildDrasilExSrcRef ex@E{sysInfoE=SI{_sys = sys}} = 
   makeURI refUID refURI refShortNm
   where
     refUID = "srcCodeRef" ++ sysName
-    refURI = getExampleSrcCodePath (codePath ex) sysName
+    refURI = path ++ "code/drasil-example/" ++ sysName
     refShortNm = shortname' $ S refUID
     sysName = map toLower $ programName sys
+    path = codePath ex
 
 -- | Similar to 'getCodeRef', but gets the doxygen references and uses 'getDoxRef' instead.
 getDoxRef :: Example -> Lang -> String -> Reference
@@ -233,11 +233,6 @@ getCodePath, getDoxPath :: FilePath -> String -> String -> FilePath
 getCodePath path ex programLang = path ++ "code/stable/" ++ map toLower ex ++ "/src/" ++ programLang -- need repoCommit path
 -- | Uses 'exRt' path (srsDoxPath in this module).
 getDoxPath path ex programLang = path ++ map toLower ex ++ "/doxygen/" ++ programLang ++ "/index.html" -- need example path
-
--- | Get the paths for the source code located in the code/drasil-example directory.
-getExampleSrcCodePath :: FilePath -> String -> FilePath
--- | Uses 'repoRt' path (codePath in this module).
-getExampleSrcCodePath path ex = path ++ "code/drasil-example/" ++ map toLower ex
 
 -- | Gather all references used in making the Examples section.
 exampleRefs :: FilePath -> FilePath -> [Reference]

--- a/code/drasil-website/lib/Drasil/Website/Example.hs
+++ b/code/drasil-website/lib/Drasil/Website/Example.hs
@@ -85,11 +85,11 @@ allExampleList = map (\x -> Nested (nameAndDesc x) $ Bullet $ map (, Nothing) (i
 individualExList :: Example -> [ItemType]
 -- No choices mean no generated code, so we do not need to display generated code and thus do not call versionList.
 individualExList ex@E{sysInfoE = SI{_sys = sys}, choicesE = [], codePath = srsP} = 
-  [Flat $ namedRef (getSourceCodeRef ex) (S "Source Code"),
+  [Flat $ namedRef (getSourceCodeRef ex) (S "Drasil Source Code"),
   Flat $ S "SRS:" +:+ namedRef (getSRSRef srsP "html" $ programName sys) (S "[HTML]") +:+ namedRef (getSRSRef srsP "pdf" $ programName sys) (S "[PDF]")]
 -- Anything else means we need to display program information, so use versionList.
 individualExList ex@E{sysInfoE = SI{_sys = sys}, codePath = srsP} = 
-  [Flat $ namedRef (getSourceCodeRef ex) (S "Source Code"),
+  [Flat $ namedRef (getSourceCodeRef ex) (S "Drasil Source Code"),
   Flat $ S "SRS:" +:+ namedRef (getSRSRef srsP "html" $ programName sys) (S "[HTML]") +:+ namedRef (getSRSRef srsP "pdf" $ programName sys) (S "[PDF]"),
   Nested (S generatedCodeTitle) $ Bullet $ map (, Nothing) (versionList getCodeRef ex),
   Nested (S generatedCodeDocsTitle) $ Bullet $ map (, Nothing) (versionList getDoxRef noSwiftEx)]

--- a/code/drasil-website/lib/Drasil/Website/Example.hs
+++ b/code/drasil-website/lib/Drasil/Website/Example.hs
@@ -245,7 +245,7 @@ exampleRefs codePth srsDoxPth =
   concatMap getDoxRefDB (examples codePth srsDoxPth) ++ 
   map (getSRSRef srsDoxPth "html" . getAbrv) (examples codePth srsDoxPth) ++ 
   map (getSRSRef srsDoxPth "pdf" . getAbrv) (examples codePth srsDoxPth) ++ 
-  map (getSourceCodeRef) (examples codePth srsDoxPth)
+  map getSourceCodeRef (examples codePth srsDoxPth)
 
 -- | Helpers to pull code and doxygen references from an example.
 -- Creates a reference for every possible choice in every possible language.

--- a/code/drasil-website/lib/Drasil/Website/Example.hs
+++ b/code/drasil-website/lib/Drasil/Website/Example.hs
@@ -192,7 +192,7 @@ getSourceCodeRef ex@E{sysInfoE=SI{_sys = sys}} =
   makeURI refUID refURI refShortNm
   where
     refUID = "srcCodeRef" ++ sysName
-    refURI = getSourceCodePath (codePath ex) sysName
+    refURI = getExampleSrcCodePath (codePath ex) sysName
     refShortNm = shortname' $ S refUID
     sysName = map toLower $ programName sys
 
@@ -234,9 +234,10 @@ getCodePath path ex programLang = path ++ "code/stable/" ++ map toLower ex ++ "/
 -- | Uses 'exRt' path (srsDoxPath in this module).
 getDoxPath path ex programLang = path ++ map toLower ex ++ "/doxygen/" ++ programLang ++ "/index.html" -- need example path
 
--- | Get the paths for the source code locations
-getSourceCodePath :: FilePath -> String -> FilePath
-getSourceCodePath path ex = path ++ "code/drasil-example/" ++ map toLower ex
+-- | Get the paths for the source code located in the code/drasil-example directory.
+getExampleSrcCodePath :: FilePath -> String -> FilePath
+-- | Uses 'repoRt' path (codePath in this module).
+getExampleSrcCodePath path ex = path ++ "code/drasil-example/" ++ map toLower ex
 
 -- | Gather all references used in making the Examples section.
 exampleRefs :: FilePath -> FilePath -> [Reference]

--- a/code/drasil-website/lib/Drasil/Website/Example.hs
+++ b/code/drasil-website/lib/Drasil/Website/Example.hs
@@ -85,11 +85,11 @@ allExampleList = map (\x -> Nested (nameAndDesc x) $ Bullet $ map (, Nothing) (i
 individualExList :: Example -> [ItemType]
 -- No choices mean no generated code, so we do not need to display generated code and thus do not call versionList.
 individualExList ex@E{sysInfoE = SI{_sys = sys}, choicesE = [], codePath = srsP} = 
-  [Flat $ namedRef (getSourceCodeRef ex) (S "Drasil Source Code"),
+  [Flat $ namedRef (buildDrasilExSrcRef ex) (S "Drasil Source Code"),
   Flat $ S "SRS:" +:+ namedRef (getSRSRef srsP "html" $ programName sys) (S "[HTML]") +:+ namedRef (getSRSRef srsP "pdf" $ programName sys) (S "[PDF]")]
 -- Anything else means we need to display program information, so use versionList.
 individualExList ex@E{sysInfoE = SI{_sys = sys}, codePath = srsP} = 
-  [Flat $ namedRef (getSourceCodeRef ex) (S "Drasil Source Code"),
+  [Flat $ namedRef (buildDrasilExSrcRef ex) (S "Drasil Source Code"),
   Flat $ S "SRS:" +:+ namedRef (getSRSRef srsP "html" $ programName sys) (S "[HTML]") +:+ namedRef (getSRSRef srsP "pdf" $ programName sys) (S "[PDF]"),
   Nested (S generatedCodeTitle) $ Bullet $ map (, Nothing) (versionList getCodeRef ex),
   Nested (S generatedCodeDocsTitle) $ Bullet $ map (, Nothing) (versionList getDoxRef noSwiftEx)]
@@ -185,10 +185,10 @@ getCodeRef ex@E{sysInfoE=SI{_sys = sys}, choicesE = chcs} l verName =
     -- Program language converted for use in file folder navigation.
     programLang = convertLang l
 
--- | Similar to 'getCodeRef', but gets the source code references 
--- and uses 'getSourceCodePath' instead.
-getSourceCodeRef :: Example -> Reference
-getSourceCodeRef ex@E{sysInfoE=SI{_sys = sys}} = 
+-- | Similar to 'getCodeRef', but builds the source code references 
+-- and uses 'getExampleSrcCodePath' instead.
+buildDrasilExSrcRef :: Example -> Reference
+buildDrasilExSrcRef ex@E{sysInfoE=SI{_sys = sys}} = 
   makeURI refUID refURI refShortNm
   where
     refUID = "srcCodeRef" ++ sysName
@@ -246,7 +246,7 @@ exampleRefs codePth srsDoxPth =
   concatMap getDoxRefDB (examples codePth srsDoxPth) ++ 
   map (getSRSRef srsDoxPth "html" . getAbrv) (examples codePth srsDoxPth) ++ 
   map (getSRSRef srsDoxPth "pdf" . getAbrv) (examples codePth srsDoxPth) ++ 
-  map getSourceCodeRef (examples codePth srsDoxPth)
+  map buildDrasilExSrcRef (examples codePth srsDoxPth)
 
 -- | Helpers to pull code and doxygen references from an example.
 -- Creates a reference for every possible choice in every possible language.

--- a/code/stable-website/index.html
+++ b/code/stable-website/index.html
@@ -151,6 +151,9 @@
             DblPend  - To predict the motion of a double pendulum.
             <ul class="list">
               <li>
+                <a href="https://github.com/JacquesCarette/Drasil/tree/master/code/drasil-example/dblpend">Source Code</a>
+              </li>
+              <li>
                 SRS: <a href="examples/dblpend/SRS/srs/DblPend_SRS.html">[HTML]</a> <a href="examples/dblpend/SRS/srs/DblPend_SRS.pdf">[PDF]</a>
               </li>
               <li>
@@ -175,6 +178,9 @@
             GamePhysics  - To simulate 2D rigid body physics for use in game development.
             <ul class="list">
               <li>
+                <a href="https://github.com/JacquesCarette/Drasil/tree/master/code/drasil-example/gamephysics">Source Code</a>
+              </li>
+              <li>
                 SRS: <a href="examples/gamephysics/SRS/srs/GamePhysics_SRS.html">[HTML]</a> <a href="examples/gamephysics/SRS/srs/GamePhysics_SRS.pdf">[PDF]</a>
               </li>
             </ul>
@@ -182,6 +188,9 @@
           <li>
             GlassBR  - To predict whether a glass slab can withstand a blast under given conditions.
             <ul class="list">
+              <li>
+                <a href="https://github.com/JacquesCarette/Drasil/tree/master/code/drasil-example/glassbr">Source Code</a>
+              </li>
               <li>
                 SRS: <a href="examples/glassbr/SRS/srs/GlassBR_SRS.html">[HTML]</a> <a href="examples/glassbr/SRS/srs/GlassBR_SRS.pdf">[PDF]</a>
               </li>
@@ -207,6 +216,9 @@
             HGHC  - To describes heat transfer coefficients related to clad..
             <ul class="list">
               <li>
+                <a href="https://github.com/JacquesCarette/Drasil/tree/master/code/drasil-example/hghc">Source Code</a>
+              </li>
+              <li>
                 SRS: <a href="examples/hghc/SRS/srs/HGHC_SRS.html">[HTML]</a> <a href="examples/hghc/SRS/srs/HGHC_SRS.pdf">[PDF]</a>
               </li>
             </ul>
@@ -214,6 +226,9 @@
           <li>
             SWHSNoPCM  - To investigate the heating of water in a solar water heating tank.
             <ul class="list">
+              <li>
+                <a href="https://github.com/JacquesCarette/Drasil/tree/master/code/drasil-example/swhsnopcm">Source Code</a>
+              </li>
               <li>
                 SRS: <a href="examples/swhsnopcm/SRS/srs/SWHSNoPCM_SRS.html">[HTML]</a> <a href="examples/swhsnopcm/SRS/srs/SWHSNoPCM_SRS.pdf">[PDF]</a>
               </li>
@@ -239,6 +254,9 @@
             PD Controller  - To provide a model of a PD Controller that can be used for the tuning of the gain constants before the deployment of the controller.
             <ul class="list">
               <li>
+                <a href="https://github.com/JacquesCarette/Drasil/tree/master/code/drasil-example/pdcontroller">Source Code</a>
+              </li>
+              <li>
                 SRS: <a href="examples/pdcontroller/SRS/srs/PDController_SRS.html">[HTML]</a> <a href="examples/pdcontroller/SRS/srs/PDController_SRS.pdf">[PDF]</a>
               </li>
               <li>
@@ -262,6 +280,9 @@
           <li>
             Projectile  - To predict whether a launched projectile hits its target.
             <ul class="list">
+              <li>
+                <a href="https://github.com/JacquesCarette/Drasil/tree/master/code/drasil-example/projectile">Source Code</a>
+              </li>
               <li>
                 SRS: <a href="examples/projectile/SRS/srs/Projectile_SRS.html">[HTML]</a> <a href="examples/projectile/SRS/srs/Projectile_SRS.pdf">[PDF]</a>
               </li>
@@ -311,6 +332,9 @@
             SglPend  - To predict the motion of a single pendulum.
             <ul class="list">
               <li>
+                <a href="https://github.com/JacquesCarette/Drasil/tree/master/code/drasil-example/sglpend">Source Code</a>
+              </li>
+              <li>
                 SRS: <a href="examples/sglpend/SRS/srs/SglPend_SRS.html">[HTML]</a> <a href="examples/sglpend/SRS/srs/SglPend_SRS.pdf">[PDF]</a>
               </li>
             </ul>
@@ -319,6 +343,9 @@
             SSP  - To evaluate the factor of safety of a slope's slip surface and identify the critical slip surface of the slope, as well as the interslice normal force and shear force along the critical slip surface.
             <ul class="list">
               <li>
+                <a href="https://github.com/JacquesCarette/Drasil/tree/master/code/drasil-example/ssp">Source Code</a>
+              </li>
+              <li>
                 SRS: <a href="examples/ssp/SRS/srs/SSP_SRS.html">[HTML]</a> <a href="examples/ssp/SRS/srs/SSP_SRS.pdf">[PDF]</a>
               </li>
             </ul>
@@ -326,6 +353,9 @@
           <li>
             SWHS  - To investigate the effect of employing PCM within a solar water heating tank.
             <ul class="list">
+              <li>
+                <a href="https://github.com/JacquesCarette/Drasil/tree/master/code/drasil-example/swhs">Source Code</a>
+              </li>
               <li>
                 SRS: <a href="examples/swhs/SRS/srs/SWHS_SRS.html">[HTML]</a> <a href="examples/swhs/SRS/srs/SWHS_SRS.pdf">[PDF]</a>
               </li>

--- a/code/stable-website/index.html
+++ b/code/stable-website/index.html
@@ -151,7 +151,7 @@
             DblPend  - To predict the motion of a double pendulum.
             <ul class="list">
               <li>
-                <a href="https://github.com/JacquesCarette/Drasil/tree/master/code/drasil-example/dblpend">Source Code</a>
+                <a href="https://github.com/JacquesCarette/Drasil/tree/master/code/drasil-example/dblpend">Drasil Source Code</a>
               </li>
               <li>
                 SRS: <a href="examples/dblpend/SRS/srs/DblPend_SRS.html">[HTML]</a> <a href="examples/dblpend/SRS/srs/DblPend_SRS.pdf">[PDF]</a>
@@ -178,7 +178,7 @@
             GamePhysics  - To simulate 2D rigid body physics for use in game development.
             <ul class="list">
               <li>
-                <a href="https://github.com/JacquesCarette/Drasil/tree/master/code/drasil-example/gamephysics">Source Code</a>
+                <a href="https://github.com/JacquesCarette/Drasil/tree/master/code/drasil-example/gamephysics">Drasil Source Code</a>
               </li>
               <li>
                 SRS: <a href="examples/gamephysics/SRS/srs/GamePhysics_SRS.html">[HTML]</a> <a href="examples/gamephysics/SRS/srs/GamePhysics_SRS.pdf">[PDF]</a>
@@ -189,7 +189,7 @@
             GlassBR  - To predict whether a glass slab can withstand a blast under given conditions.
             <ul class="list">
               <li>
-                <a href="https://github.com/JacquesCarette/Drasil/tree/master/code/drasil-example/glassbr">Source Code</a>
+                <a href="https://github.com/JacquesCarette/Drasil/tree/master/code/drasil-example/glassbr">Drasil Source Code</a>
               </li>
               <li>
                 SRS: <a href="examples/glassbr/SRS/srs/GlassBR_SRS.html">[HTML]</a> <a href="examples/glassbr/SRS/srs/GlassBR_SRS.pdf">[PDF]</a>
@@ -216,7 +216,7 @@
             HGHC  - To describes heat transfer coefficients related to clad..
             <ul class="list">
               <li>
-                <a href="https://github.com/JacquesCarette/Drasil/tree/master/code/drasil-example/hghc">Source Code</a>
+                <a href="https://github.com/JacquesCarette/Drasil/tree/master/code/drasil-example/hghc">Drasil Source Code</a>
               </li>
               <li>
                 SRS: <a href="examples/hghc/SRS/srs/HGHC_SRS.html">[HTML]</a> <a href="examples/hghc/SRS/srs/HGHC_SRS.pdf">[PDF]</a>
@@ -227,7 +227,7 @@
             SWHSNoPCM  - To investigate the heating of water in a solar water heating tank.
             <ul class="list">
               <li>
-                <a href="https://github.com/JacquesCarette/Drasil/tree/master/code/drasil-example/swhsnopcm">Source Code</a>
+                <a href="https://github.com/JacquesCarette/Drasil/tree/master/code/drasil-example/swhsnopcm">Drasil Source Code</a>
               </li>
               <li>
                 SRS: <a href="examples/swhsnopcm/SRS/srs/SWHSNoPCM_SRS.html">[HTML]</a> <a href="examples/swhsnopcm/SRS/srs/SWHSNoPCM_SRS.pdf">[PDF]</a>
@@ -254,7 +254,7 @@
             PD Controller  - To provide a model of a PD Controller that can be used for the tuning of the gain constants before the deployment of the controller.
             <ul class="list">
               <li>
-                <a href="https://github.com/JacquesCarette/Drasil/tree/master/code/drasil-example/pdcontroller">Source Code</a>
+                <a href="https://github.com/JacquesCarette/Drasil/tree/master/code/drasil-example/pdcontroller">Drasil Source Code</a>
               </li>
               <li>
                 SRS: <a href="examples/pdcontroller/SRS/srs/PDController_SRS.html">[HTML]</a> <a href="examples/pdcontroller/SRS/srs/PDController_SRS.pdf">[PDF]</a>
@@ -281,7 +281,7 @@
             Projectile  - To predict whether a launched projectile hits its target.
             <ul class="list">
               <li>
-                <a href="https://github.com/JacquesCarette/Drasil/tree/master/code/drasil-example/projectile">Source Code</a>
+                <a href="https://github.com/JacquesCarette/Drasil/tree/master/code/drasil-example/projectile">Drasil Source Code</a>
               </li>
               <li>
                 SRS: <a href="examples/projectile/SRS/srs/Projectile_SRS.html">[HTML]</a> <a href="examples/projectile/SRS/srs/Projectile_SRS.pdf">[PDF]</a>
@@ -332,7 +332,7 @@
             SglPend  - To predict the motion of a single pendulum.
             <ul class="list">
               <li>
-                <a href="https://github.com/JacquesCarette/Drasil/tree/master/code/drasil-example/sglpend">Source Code</a>
+                <a href="https://github.com/JacquesCarette/Drasil/tree/master/code/drasil-example/sglpend">Drasil Source Code</a>
               </li>
               <li>
                 SRS: <a href="examples/sglpend/SRS/srs/SglPend_SRS.html">[HTML]</a> <a href="examples/sglpend/SRS/srs/SglPend_SRS.pdf">[PDF]</a>
@@ -343,7 +343,7 @@
             SSP  - To evaluate the factor of safety of a slope's slip surface and identify the critical slip surface of the slope, as well as the interslice normal force and shear force along the critical slip surface.
             <ul class="list">
               <li>
-                <a href="https://github.com/JacquesCarette/Drasil/tree/master/code/drasil-example/ssp">Source Code</a>
+                <a href="https://github.com/JacquesCarette/Drasil/tree/master/code/drasil-example/ssp">Drasil Source Code</a>
               </li>
               <li>
                 SRS: <a href="examples/ssp/SRS/srs/SSP_SRS.html">[HTML]</a> <a href="examples/ssp/SRS/srs/SSP_SRS.pdf">[PDF]</a>
@@ -354,7 +354,7 @@
             SWHS  - To investigate the effect of employing PCM within a solar water heating tank.
             <ul class="list">
               <li>
-                <a href="https://github.com/JacquesCarette/Drasil/tree/master/code/drasil-example/swhs">Source Code</a>
+                <a href="https://github.com/JacquesCarette/Drasil/tree/master/code/drasil-example/swhs">Drasil Source Code</a>
               </li>
               <li>
                 SRS: <a href="examples/swhs/SRS/srs/SWHS_SRS.html">[HTML]</a> <a href="examples/swhs/SRS/srs/SWHS_SRS.pdf">[PDF]</a>


### PR DESCRIPTION
Added links to the source code for each generated example on the website. Also updated the stable website to reflect those changes.

NOTE: I followed the existing code to add the new references. However, a problem, which @balacij pointed out, is that each chunk is being created twice. This may require a redesign of the code.

![image](https://github.com/JacquesCarette/Drasil/assets/77511892/bf990aab-37d2-4b75-b187-460528bd5c52)

Closes #3668 
