### PR TITLE
Issue #3731: Fixed typo in the SRS of the Projectile example

### DIFF
--- a/code/drasil-data/lib/Data/Drasil/Concepts/Physics.hs
+++ b/code/drasil-data/lib/Data/Drasil/Concepts/Physics.hs
@@ -144,7 +144,7 @@ potEnergy = dccWDS "potEnergy" (cn "potential energy")
 pressure = dccWDS "pressure" (cn' "pressure")
   (S "a" +:+ phrase force +:+ S "exerted over an area")
 rectilinear = dcc "rectilinear" (cn "rectilinear")
-  "occuring in one dimension"
+  "occurring in one dimension"
 rigidBody = dcc "rigidBody" (cnIES "rigid body")
   "a solid body in which deformation is neglected"
 space = dcc "space" (cn' "space")

--- a/code/stable/projectile/SRS/HTML/Projectile_SRS.html
+++ b/code/stable/projectile/SRS/HTML/Projectile_SRS.html
@@ -562,7 +562,7 @@
                   <li>
                     Cartesian coordinate system: A coordinate system that specifies each point uniquely in a plane by a set of numerical coordinates, which are the signed distances to the point from two fixed perpendicular oriented lines, measured in the same unit of length (from <a href=#cartesianWiki>cartesianWiki</a>).
                   </li>
-                  <li>Rectilinear: Occuring in one dimension.</li>
+                  <li>Rectilinear: Occurring in one dimension.</li>
                 </ul>
               </div>
             </div>

--- a/code/stable/projectile/SRS/JSON/Projectile_SRS.ipynb
+++ b/code/stable/projectile/SRS/JSON/Projectile_SRS.ipynb
@@ -230,7 +230,7 @@
     "- Target: Where the projectile should be launched to.\n",
     "- Gravity: The force that attracts one physical body with mass to another.\n",
     "- Cartesian coordinate system: A coordinate system that specifies each point uniquely in a plane by a set of numerical coordinates, which are the signed distances to the point from two fixed perpendicular oriented lines, measured in the same unit of length (from <a href=#cartesianWiki>cartesianWiki</a> ).\n",
-    "- Rectilinear: Occuring in one dimension.\n",
+    "- Rectilinear: Occurring in one dimension.\n",
     "\n",
     "### Physical System Description\n",
     "<a id=\"Sec:PhysSyst\"></a>\n",

--- a/code/stable/projectile/SRS/PDF/Projectile_SRS.tex
+++ b/code/stable/projectile/SRS/PDF/Projectile_SRS.tex
@@ -250,7 +250,7 @@ This subsection provides a list of terms that are used in the subsequent section
 \item{Target: Where the projectile should be launched to.}
 \item{Gravity: The force that attracts one physical body with mass to another.}
 \item{Cartesian coordinate system: A coordinate system that specifies each point uniquely in a plane by a set of numerical coordinates, which are the signed distances to the point from two fixed perpendicular oriented lines, measured in the same unit of length (from \cite{cartesianWiki}).}
-\item{Rectilinear: Occuring in one dimension.}
+\item{Rectilinear: Occurring in one dimension.}
 \end{itemize}
 \subsubsection{Physical System Description}
 \label{Sec:PhysSyst}


### PR DESCRIPTION
Fixed the typo "occuring" to "occurring" in the definition of rectilinear in the SRS of the projectile example. Also updated stable with the typo fix.

Closes #3731  