### PR TITLE
Updated NFR for maintainability to refer to code, not SRS: #3288

### DIFF
--- a/code/drasil-docLang/lib/Drasil/DocLang.hs
+++ b/code/drasil-docLang/lib/Drasil/DocLang.hs
@@ -55,7 +55,8 @@ module Drasil.DocLang (
   unitTableRef, tunit, tunit', tunitNone,
   -- ** Requirements
   -- Drasil.Sections.Requirements
-  inReq, inTable, mkInputPropsTable, mkQRTuple, mkQRTupleRef, mkValsSourceTable, reqInputsRef,
+  inReq, inTable, mkInputPropsTable, mkQRTuple, mkQRTupleRef, 
+  mkValsSourceTable, reqInputsRef, mkMaintainableNFR,
   -- ** Specific System Description
   -- Drasil.Sections.SpecificSystemDescription
   auxSpecSent, termDefnF', inDataConstTbl, outDataConstTbl,
@@ -91,7 +92,7 @@ import Drasil.Sections.AuxiliaryConstants (tableOfConstants)
 import Drasil.Sections.Introduction (purpDoc)
 import Drasil.Sections.ReferenceMaterial (intro, emptySectSentPlu, emptySectSentSing)
 import Drasil.Sections.Requirements (inReq, inTable, mkInputPropsTable,
-  mkQRTuple, mkQRTupleRef, mkValsSourceTable, reqInputsRef)
+  mkQRTuple, mkQRTupleRef, mkValsSourceTable, reqInputsRef, mkMaintainableNFR)
 import Drasil.Sections.SpecificSystemDescription (auxSpecSent, termDefnF', inDataConstTbl, outDataConstTbl)
 --import Drasil.Sections.Stakeholders
 --import Drasil.Sections.TableOfAbbAndAcronyms

--- a/code/drasil-docLang/lib/Drasil/Sections/Requirements.hs
+++ b/code/drasil-docLang/lib/Drasil/Sections/Requirements.hs
@@ -106,7 +106,7 @@ nfReqIntro _  = mkParagraph $ reqIntroStart +:+. nfrReqIntroBody
 mkMaintainableNFR :: String -> Integer -> String -> ConceptInstance
 mkMaintainableNFR refAddress percent lbl = cic refAddress (foldlSent [
   S "If a likely change is made" `S.toThe` 
-  S "finished software, it will take", addPercent percent, EmptyS `S.ofThe`
+  S "finished software, it will take", addPercent percent `S.ofThe`
   S "original development time,",
   S "assuming the same development resources are available"
   ]) lbl nonFuncReqDom

--- a/code/drasil-docLang/lib/Drasil/Sections/Requirements.hs
+++ b/code/drasil-docLang/lib/Drasil/Sections/Requirements.hs
@@ -8,7 +8,7 @@ module Drasil.Sections.Requirements (
   fullReqs, fullTables, inReq, inTable,
   mkInputPropsTable, mkQRTuple, mkQRTupleRef, mkValsSourceTable,
   -- * Non-functional Requirements
-  nfReqF
+  nfReqF, mkMaintainableNFR
   ) where
 
 import Language.Drasil
@@ -17,7 +17,7 @@ import qualified Language.Drasil.Sentence.Combinators as S
 import Drasil.Sections.ReferenceMaterial(emptySectSentPlu)
 import Theory.Drasil (HasOutput(output))
 
-import Data.Drasil.Concepts.Documentation (description, funcReqDom,
+import Data.Drasil.Concepts.Documentation (description, funcReqDom, nonFuncReqDom,
   functionalRequirement, input_, nonfunctionalRequirement, {-output_,-} section_,
   software, symbol_, value, reqInput)
 import Data.Drasil.Concepts.Math (unit_)
@@ -99,6 +99,17 @@ fReqIntro _  = mkParagraph $ reqIntroStart +:+. frReqIntroBody
 nfReqIntro :: [Contents] -> Contents
 nfReqIntro [] = mkParagraph $ emptySectSentPlu [nonfunctionalRequirement]
 nfReqIntro _  = mkParagraph $ reqIntroStart +:+. nfrReqIntroBody
+
+-- | Common Non-Functional Requirement for Maintainability.
+-- Takes in a Reference Address ('String'), a percent value ('Integer'), 
+-- and a label ('String').
+mkMaintainableNFR :: String -> Integer -> String -> ConceptInstance
+mkMaintainableNFR refAddress percent lbl = cic refAddress (foldlSent [
+  S "If a likely change is made" `S.toThe` 
+  S "finished software, it will take", addPercent percent, EmptyS `S.ofThe`
+  S "original development time,",
+  S "assuming the same development resources are available"
+  ]) lbl nonFuncReqDom
 
 -- | Creates an Input Data Table for use in the Functional Requirments section. Takes a list of wrapped variables and something that is 'Referable'.
 mkInputPropsTable :: (Quantity i, MayHaveUnit i, HasShortName r, Referable r) => 

--- a/code/drasil-docLang/lib/Drasil/Sections/Requirements.hs
+++ b/code/drasil-docLang/lib/Drasil/Sections/Requirements.hs
@@ -106,7 +106,7 @@ nfReqIntro _  = mkParagraph $ reqIntroStart +:+. nfrReqIntroBody
 mkMaintainableNFR :: String -> Integer -> String -> ConceptInstance
 mkMaintainableNFR refAddress percent lbl = cic refAddress (foldlSent [
   S "If a likely change is made" `S.toThe` 
-  S "finished software, it will take", addPercent percent `S.ofThe`
+  S "finished software, it will take at most", addPercent percent `S.ofThe`
   S "original development time,",
   S "assuming the same development resources are available"
   ]) lbl nonFuncReqDom

--- a/code/drasil-docLang/package.yaml
+++ b/code/drasil-docLang/package.yaml
@@ -37,7 +37,6 @@ library:
   - Drasil.DocumentLanguage.Units
   - Drasil.DocumentLanguage.TraceabilityGraph
   - Drasil.SRSDocument
-  - Drasil.Sections.Requirements
   when:
   - condition: false
     other-modules: Paths_drasil_docLang

--- a/code/drasil-docLang/package.yaml
+++ b/code/drasil-docLang/package.yaml
@@ -37,6 +37,7 @@ library:
   - Drasil.DocumentLanguage.Units
   - Drasil.DocumentLanguage.TraceabilityGraph
   - Drasil.SRSDocument
+  - Drasil.Sections.Requirements
   when:
   - condition: false
     other-modules: Paths_drasil_docLang

--- a/code/drasil-example/gamephysics/lib/Drasil/GamePhysics/Requirements.hs
+++ b/code/drasil-example/gamephysics/lib/Drasil/GamePhysics/Requirements.hs
@@ -132,7 +132,8 @@ understandability = cic "understandability" (foldlSent [
 
 maintainability :: ConceptInstance
 maintainability = cic "maintainability" (foldlSent [
-  S "development time for any" `S.the_ofTheC` S "likely changes should not exceed", 
-  addPercent (10 :: Integer), S "percent of the original development time"
+  S "If a likely change is made" `S.toThe` S "finished software, it will take", 
+  addPercent (10 :: Integer), S "percent" `S.ofThe` S "original development time,",
+  S "assuming the same development resources are available"
   ]) "Maintainability" nonFuncReqDom
 

--- a/code/drasil-example/gamephysics/lib/Drasil/GamePhysics/Requirements.hs
+++ b/code/drasil-example/gamephysics/lib/Drasil/GamePhysics/Requirements.hs
@@ -6,6 +6,7 @@ import Language.Drasil.Chunk.Concept.NamedCombinators
 import qualified Language.Drasil.Sentence.Combinators as S
 
 import qualified Drasil.DocLang.SRS as SRS (solCharSpec)
+import Drasil.Sections.Requirements (mkMaintainableNFR)
 import Data.Drasil.Concepts.Documentation as Doc (body, funcReqDom, input_, 
   nonFuncReqDom, output_, physicalConstraint, physicalSim, property, solutionCharSpec)
 
@@ -131,9 +132,4 @@ understandability = cic "understandability" (foldlSent [
   ]) "Understandability" nonFuncReqDom
 
 maintainability :: ConceptInstance
-maintainability = cic "maintainability" (foldlSent [
-  S "If a likely change is made" `S.toThe` S "finished software, it will take", 
-  addPercent (10 :: Integer), S "percent" `S.ofThe` S "original development time,",
-  S "assuming the same development resources are available"
-  ]) "Maintainability" nonFuncReqDom
-
+maintainability = mkMaintainableNFR "maintainability" (10 :: Integer) "Maintainability"

--- a/code/drasil-example/gamephysics/lib/Drasil/GamePhysics/Requirements.hs
+++ b/code/drasil-example/gamephysics/lib/Drasil/GamePhysics/Requirements.hs
@@ -6,7 +6,7 @@ import Language.Drasil.Chunk.Concept.NamedCombinators
 import qualified Language.Drasil.Sentence.Combinators as S
 
 import qualified Drasil.DocLang.SRS as SRS (solCharSpec)
-import Drasil.Sections.Requirements (mkMaintainableNFR)
+import Drasil.DocLang (mkMaintainableNFR)
 import Data.Drasil.Concepts.Documentation as Doc (body, funcReqDom, input_, 
   nonFuncReqDom, output_, physicalConstraint, physicalSim, property, solutionCharSpec)
 

--- a/code/drasil-example/gamephysics/lib/Drasil/GamePhysics/Requirements.hs
+++ b/code/drasil-example/gamephysics/lib/Drasil/GamePhysics/Requirements.hs
@@ -132,4 +132,4 @@ understandability = cic "understandability" (foldlSent [
   ]) "Understandability" nonFuncReqDom
 
 maintainability :: ConceptInstance
-maintainability = mkMaintainableNFR "maintainability" (10 :: Integer) "Maintainability"
+maintainability = mkMaintainableNFR "maintainability" 10 "Maintainability"

--- a/code/drasil-example/glassbr/lib/Drasil/GlassBR/Requirements.hs
+++ b/code/drasil-example/glassbr/lib/Drasil/GlassBR/Requirements.hs
@@ -9,6 +9,7 @@ import Language.Drasil.Chunk.Concept.NamedCombinators
 import qualified Language.Drasil.NounPhrase.Combinators as NP
 import qualified Language.Drasil.Sentence.Combinators as S
 import Theory.Drasil (DataDefinition)
+import Drasil.Sections.Requirements (mkMaintainableNFR)
 
 import Data.Drasil.Concepts.Computation (inValue)
 import Data.Drasil.Concepts.Documentation (characteristic, code,
@@ -113,11 +114,7 @@ reusable = cic "reusable" (foldlSent [
   atStartNP (the code), S "is modularized"]) "Reusable" nonFuncReqDom
 
 maintainable :: ConceptInstance
-maintainable = cic "maintainable" (foldlSent [
-  S "If a likely change is made" `S.toThe` S "finished software, it will take", 
-  addPercent (10 :: Integer), S "percent" `S.ofThe` S "original development time,",
-  S "assuming the same development resources are available"
-  ]) "Maintainable" nonFuncReqDom
+maintainable = mkMaintainableNFR "maintainable" (10 :: Integer) "Maintainable"
 
 portable :: ConceptInstance
 portable = cic "portable" (foldlSent [

--- a/code/drasil-example/glassbr/lib/Drasil/GlassBR/Requirements.hs
+++ b/code/drasil-example/glassbr/lib/Drasil/GlassBR/Requirements.hs
@@ -114,7 +114,7 @@ reusable = cic "reusable" (foldlSent [
   atStartNP (the code), S "is modularized"]) "Reusable" nonFuncReqDom
 
 maintainable :: ConceptInstance
-maintainable = mkMaintainableNFR "maintainable" (10 :: Integer) "Maintainable"
+maintainable = mkMaintainableNFR "maintainable" 10 "Maintainable"
 
 portable :: ConceptInstance
 portable = cic "portable" (foldlSent [

--- a/code/drasil-example/glassbr/lib/Drasil/GlassBR/Requirements.hs
+++ b/code/drasil-example/glassbr/lib/Drasil/GlassBR/Requirements.hs
@@ -11,15 +11,12 @@ import qualified Language.Drasil.Sentence.Combinators as S
 import Theory.Drasil (DataDefinition)
 
 import Data.Drasil.Concepts.Computation (inValue)
-import Data.Drasil.Concepts.Documentation (assumption, characteristic, code,
-  condition, datumConstraint, environment, funcReqDom, likelyChg, message, mg,
-  mis, module_, nonFuncReqDom, output_, property, requirement, srs, system,
-  traceyMatrix, type_, unlikelyChg, value, vavPlan)
+import Data.Drasil.Concepts.Documentation (characteristic, code,
+  condition, datumConstraint, environment, funcReqDom, message, mg,
+  mis, nonFuncReqDom, output_, property, system, type_, value, vavPlan)
 import Data.Drasil.Concepts.Math (calculation)
 import Data.Drasil.Concepts.PhysicalProperties (dimension)
 import Data.Drasil.Concepts.Software (errMsg)
-
-import Data.Drasil.TheoryConcepts (dataDefn, genDefn, inModel, thModel)
 
 import Drasil.GlassBR.Assumptions (assumpSV, assumpGL, assumptionConstants)
 import Drasil.GlassBR.Concepts (glass)
@@ -116,11 +113,11 @@ reusable = cic "reusable" (foldlSent [
   atStartNP (the code), S "is modularized"]) "Reusable" nonFuncReqDom
 
 maintainable :: ConceptInstance
-maintainable = cic "maintainable" (foldlSent [
-  S "The traceability between", foldlList Comma List [plural requirement,
-  plural assumption, plural thModel, plural genDefn, plural dataDefn, plural inModel,
-  plural likelyChg, plural unlikelyChg, plural module_], S "is completely recorded in",
-  plural traceyMatrix `S.inThe` getAcc srs `S.and_` phrase mg]) "Maintainable" nonFuncReqDom
+maintainable = cic "maintainability" (foldlSent [
+  S "If a likely change is made" `S.toThe` S "finished software, it will take", 
+  addPercent (10 :: Integer), S "percent" `S.ofThe` S "original development time,",
+  S "assuming the same development resources are available"
+  ]) "Maintainability" nonFuncReqDom
 
 portable :: ConceptInstance
 portable = cic "portable" (foldlSent [

--- a/code/drasil-example/glassbr/lib/Drasil/GlassBR/Requirements.hs
+++ b/code/drasil-example/glassbr/lib/Drasil/GlassBR/Requirements.hs
@@ -113,11 +113,11 @@ reusable = cic "reusable" (foldlSent [
   atStartNP (the code), S "is modularized"]) "Reusable" nonFuncReqDom
 
 maintainable :: ConceptInstance
-maintainable = cic "maintainability" (foldlSent [
+maintainable = cic "maintainable" (foldlSent [
   S "If a likely change is made" `S.toThe` S "finished software, it will take", 
   addPercent (10 :: Integer), S "percent" `S.ofThe` S "original development time,",
   S "assuming the same development resources are available"
-  ]) "Maintainability" nonFuncReqDom
+  ]) "Maintainable" nonFuncReqDom
 
 portable :: ConceptInstance
 portable = cic "portable" (foldlSent [

--- a/code/drasil-example/glassbr/lib/Drasil/GlassBR/Requirements.hs
+++ b/code/drasil-example/glassbr/lib/Drasil/GlassBR/Requirements.hs
@@ -3,13 +3,12 @@ module Drasil.GlassBR.Requirements (funcReqs, funcReqsTables, inReqDesc, nonfunc
 import Control.Lens ((^.))
 
 import Language.Drasil
-import Drasil.DocLang (inReq, mkQRTuple, mkQRTupleRef, mkValsSourceTable)
+import Drasil.DocLang (inReq, mkQRTuple, mkQRTupleRef, mkValsSourceTable, mkMaintainableNFR)
 import Drasil.DocLang.SRS (datCon, propCorSol)
 import Language.Drasil.Chunk.Concept.NamedCombinators
 import qualified Language.Drasil.NounPhrase.Combinators as NP
 import qualified Language.Drasil.Sentence.Combinators as S
 import Theory.Drasil (DataDefinition)
-import Drasil.Sections.Requirements (mkMaintainableNFR)
 
 import Data.Drasil.Concepts.Computation (inValue)
 import Data.Drasil.Concepts.Documentation (characteristic, code,

--- a/code/drasil-example/pdcontroller/lib/Drasil/PDController/Requirements.hs
+++ b/code/drasil-example/pdcontroller/lib/Drasil/PDController/Requirements.hs
@@ -2,8 +2,8 @@
 module Drasil.PDController.Requirements where
 
 import Data.Drasil.Concepts.Documentation (funcReqDom, nonFuncReqDom, datumConstraint)
-
 import Drasil.DocLang.SRS (datCon)
+import qualified Language.Drasil.Sentence.Combinators as S
 
 import Drasil.PDController.Concepts
 import Drasil.PDController.IModel
@@ -60,14 +60,11 @@ security
       nonFuncReqDom
 
 maintainability :: ConceptInstance
-maintainability
-  = cic "maintainability"
-      (foldlSent
-         [S "The dependencies among the instance models, requirements,",
-            S "likely changes, assumptions and all other relevant sections of",
-            S "this document shall be traceable to each other in the trace matrix"])
-      "Maintainable"
-      nonFuncReqDom
+maintainability = cic "maintainability" (foldlSent [
+  S "If a likely change is made" `S.toThe` S "finished software, it will take", 
+  addPercent (10 :: Integer), S "percent" `S.ofThe` S "original development time,",
+  S "assuming the same development resources are available"
+  ]) "Maintainability" nonFuncReqDom
 
 verifiability :: ConceptInstance
 verifiability

--- a/code/drasil-example/pdcontroller/lib/Drasil/PDController/Requirements.hs
+++ b/code/drasil-example/pdcontroller/lib/Drasil/PDController/Requirements.hs
@@ -3,7 +3,6 @@ module Drasil.PDController.Requirements where
 
 import Data.Drasil.Concepts.Documentation (funcReqDom, nonFuncReqDom, datumConstraint)
 import Drasil.DocLang.SRS (datCon)
-import qualified Language.Drasil.Sentence.Combinators as S
 import Drasil.Sections.Requirements (mkMaintainableNFR)
 
 import Drasil.PDController.Concepts

--- a/code/drasil-example/pdcontroller/lib/Drasil/PDController/Requirements.hs
+++ b/code/drasil-example/pdcontroller/lib/Drasil/PDController/Requirements.hs
@@ -4,6 +4,7 @@ module Drasil.PDController.Requirements where
 import Data.Drasil.Concepts.Documentation (funcReqDom, nonFuncReqDom, datumConstraint)
 import Drasil.DocLang.SRS (datCon)
 import qualified Language.Drasil.Sentence.Combinators as S
+import Drasil.Sections.Requirements (mkMaintainableNFR)
 
 import Drasil.PDController.Concepts
 import Drasil.PDController.IModel
@@ -60,11 +61,7 @@ security
       nonFuncReqDom
 
 maintainability :: ConceptInstance
-maintainability = cic "maintainability" (foldlSent [
-  S "If a likely change is made" `S.toThe` S "finished software, it will take", 
-  addPercent (10 :: Integer), S "percent" `S.ofThe` S "original development time,",
-  S "assuming the same development resources are available"
-  ]) "Maintainable" nonFuncReqDom
+maintainability = mkMaintainableNFR "maintainability" (10 :: Integer) "Maintainable"
 
 verifiability :: ConceptInstance
 verifiability

--- a/code/drasil-example/pdcontroller/lib/Drasil/PDController/Requirements.hs
+++ b/code/drasil-example/pdcontroller/lib/Drasil/PDController/Requirements.hs
@@ -64,7 +64,7 @@ maintainability = cic "maintainability" (foldlSent [
   S "If a likely change is made" `S.toThe` S "finished software, it will take", 
   addPercent (10 :: Integer), S "percent" `S.ofThe` S "original development time,",
   S "assuming the same development resources are available"
-  ]) "Maintainability" nonFuncReqDom
+  ]) "Maintainable" nonFuncReqDom
 
 verifiability :: ConceptInstance
 verifiability

--- a/code/drasil-example/pdcontroller/lib/Drasil/PDController/Requirements.hs
+++ b/code/drasil-example/pdcontroller/lib/Drasil/PDController/Requirements.hs
@@ -3,7 +3,7 @@ module Drasil.PDController.Requirements where
 
 import Data.Drasil.Concepts.Documentation (funcReqDom, nonFuncReqDom, datumConstraint)
 import Drasil.DocLang.SRS (datCon)
-import Drasil.Sections.Requirements (mkMaintainableNFR)
+import Drasil.DocLang (mkMaintainableNFR)
 
 import Drasil.PDController.Concepts
 import Drasil.PDController.IModel

--- a/code/drasil-example/pdcontroller/lib/Drasil/PDController/Requirements.hs
+++ b/code/drasil-example/pdcontroller/lib/Drasil/PDController/Requirements.hs
@@ -60,7 +60,7 @@ security
       nonFuncReqDom
 
 maintainability :: ConceptInstance
-maintainability = mkMaintainableNFR "maintainability" (10 :: Integer) "Maintainable"
+maintainability = mkMaintainableNFR "maintainability" 10 "Maintainable"
 
 verifiability :: ConceptInstance
 verifiability

--- a/code/drasil-example/projectile/lib/Drasil/Projectile/Requirements.hs
+++ b/code/drasil-example/projectile/lib/Drasil/Projectile/Requirements.hs
@@ -6,12 +6,11 @@ import Language.Drasil.Chunk.Concept.NamedCombinators
 import qualified Language.Drasil.Sentence.Combinators as S
 
 import Data.Drasil.Concepts.Computation (inValue)
-import Data.Drasil.Concepts.Documentation (assumption, code, datumConstraint,
-  environment, funcReqDom, likelyChg, mg, mis, module_, nonFuncReqDom, output_,
-  property, requirement, srs, traceyMatrix, unlikelyChg, value, vavPlan, propOfCorSol)
+import Data.Drasil.Concepts.Documentation (code, datumConstraint,
+  environment, funcReqDom, mg, mis, nonFuncReqDom, output_,
+  property, value, vavPlan, propOfCorSol)
 import Data.Drasil.Concepts.Math (calculation)
 import Data.Drasil.Concepts.Software (errMsg)
-import Data.Drasil.TheoryConcepts (dataDefn, genDefn, inModel, thModel)
 
 import Drasil.Projectile.IMods (landPosIM, messageIM, offsetIM, timeIM)
 import Drasil.Projectile.Unitals (flightDur, landPos, message, offset)
@@ -72,13 +71,14 @@ reusable :: ConceptInstance
 reusable = cic "reusable" (foldlSent [atStartNP (the code), S "is modularized"]) "Reusable" nonFuncReqDom
 
 maintainable :: ConceptInstance
-maintainable = cic "maintainable" (foldlSent [
-  S "The traceability between", foldlList Comma List [plural requirement,
-  plural assumption, plural thModel, plural genDefn, plural dataDefn, plural inModel,
-  plural likelyChg, plural unlikelyChg, plural module_], S "is completely recorded in",
-  plural traceyMatrix, S "in the", getAcc srs `S.and_` phrase mg]) "Maintainable" nonFuncReqDom
+maintainable = cic "maintainability" (foldlSent [
+  S "If a likely change is made" `S.toThe` S "finished software, it will take", 
+  addPercent (10 :: Integer), S "percent" `S.ofThe` S "original development time,",
+  S "assuming the same development resources are available"
+  ]) "Maintainability" nonFuncReqDom
 
 portable :: ConceptInstance
 portable = cic "portable" (foldlSent [
   atStartNP (the code), S "is able to be run in different", plural environment])
   "Portable" nonFuncReqDom
+  

--- a/code/drasil-example/projectile/lib/Drasil/Projectile/Requirements.hs
+++ b/code/drasil-example/projectile/lib/Drasil/Projectile/Requirements.hs
@@ -71,11 +71,11 @@ reusable :: ConceptInstance
 reusable = cic "reusable" (foldlSent [atStartNP (the code), S "is modularized"]) "Reusable" nonFuncReqDom
 
 maintainable :: ConceptInstance
-maintainable = cic "maintainability" (foldlSent [
+maintainable = cic "maintainable" (foldlSent [
   S "If a likely change is made" `S.toThe` S "finished software, it will take", 
   addPercent (10 :: Integer), S "percent" `S.ofThe` S "original development time,",
   S "assuming the same development resources are available"
-  ]) "Maintainability" nonFuncReqDom
+  ]) "Maintainable" nonFuncReqDom
 
 portable :: ConceptInstance
 portable = cic "portable" (foldlSent [

--- a/code/drasil-example/projectile/lib/Drasil/Projectile/Requirements.hs
+++ b/code/drasil-example/projectile/lib/Drasil/Projectile/Requirements.hs
@@ -72,7 +72,7 @@ reusable :: ConceptInstance
 reusable = cic "reusable" (foldlSent [atStartNP (the code), S "is modularized"]) "Reusable" nonFuncReqDom
 
 maintainable :: ConceptInstance
-maintainable = mkMaintainableNFR "maintainable" (10 :: Integer) "Maintainable"
+maintainable = mkMaintainableNFR "maintainable" 10 "Maintainable"
 
 portable :: ConceptInstance
 portable = cic "portable" (foldlSent [

--- a/code/drasil-example/projectile/lib/Drasil/Projectile/Requirements.hs
+++ b/code/drasil-example/projectile/lib/Drasil/Projectile/Requirements.hs
@@ -4,7 +4,7 @@ import Language.Drasil
 import Drasil.DocLang.SRS (datCon, propCorSol)
 import Language.Drasil.Chunk.Concept.NamedCombinators
 import qualified Language.Drasil.Sentence.Combinators as S
-import Drasil.Sections.Requirements (mkMaintainableNFR)
+import Drasil.DocLang (mkMaintainableNFR)
 
 import Data.Drasil.Concepts.Computation (inValue)
 import Data.Drasil.Concepts.Documentation (code, datumConstraint,

--- a/code/drasil-example/projectile/lib/Drasil/Projectile/Requirements.hs
+++ b/code/drasil-example/projectile/lib/Drasil/Projectile/Requirements.hs
@@ -4,6 +4,7 @@ import Language.Drasil
 import Drasil.DocLang.SRS (datCon, propCorSol)
 import Language.Drasil.Chunk.Concept.NamedCombinators
 import qualified Language.Drasil.Sentence.Combinators as S
+import Drasil.Sections.Requirements (mkMaintainableNFR)
 
 import Data.Drasil.Concepts.Computation (inValue)
 import Data.Drasil.Concepts.Documentation (code, datumConstraint,
@@ -71,11 +72,7 @@ reusable :: ConceptInstance
 reusable = cic "reusable" (foldlSent [atStartNP (the code), S "is modularized"]) "Reusable" nonFuncReqDom
 
 maintainable :: ConceptInstance
-maintainable = cic "maintainable" (foldlSent [
-  S "If a likely change is made" `S.toThe` S "finished software, it will take", 
-  addPercent (10 :: Integer), S "percent" `S.ofThe` S "original development time,",
-  S "assuming the same development resources are available"
-  ]) "Maintainable" nonFuncReqDom
+maintainable = mkMaintainableNFR "maintainable" (10 :: Integer) "Maintainable"
 
 portable :: ConceptInstance
 portable = cic "portable" (foldlSent [

--- a/code/drasil-example/ssp/lib/Drasil/SSP/Requirements.hs
+++ b/code/drasil-example/ssp/lib/Drasil/SSP/Requirements.hs
@@ -124,4 +124,4 @@ reusable = cic "reusable" (foldlSent [
   atStartNP (the code), S "is modularized"]) "Reusable" nonFuncReqDom
 
 maintainable :: ConceptInstance
-maintainable = mkMaintainableNFR "maintainable" (10 :: Integer) "Maintainable"
+maintainable = mkMaintainableNFR "maintainable" 10 "Maintainable"

--- a/code/drasil-example/ssp/lib/Drasil/SSP/Requirements.hs
+++ b/code/drasil-example/ssp/lib/Drasil/SSP/Requirements.hs
@@ -6,6 +6,7 @@ import qualified Language.Drasil.Sentence.Combinators as S
 
 import Drasil.DocLang (mkInputPropsTable)
 import Drasil.DocLang.SRS (datCon, propCorSol) 
+import Drasil.Sections.Requirements (mkMaintainableNFR)
 
 import Data.Drasil.Concepts.Computation (inDatum)
 import Data.Drasil.Concepts.Documentation (code,
@@ -123,8 +124,4 @@ reusable = cic "reusable" (foldlSent [
   atStartNP (the code), S "is modularized"]) "Reusable" nonFuncReqDom
 
 maintainable :: ConceptInstance
-maintainable = cic "maintainable" (foldlSent [
-  S "If a likely change is made" `S.toThe` S "finished software, it will take", 
-  addPercent (10 :: Integer), S "percent" `S.ofThe` S "original development time,",
-  S "assuming the same development resources are available"
-  ]) "Maintainable" nonFuncReqDom
+maintainable = mkMaintainableNFR "maintainable" (10 :: Integer) "Maintainable"

--- a/code/drasil-example/ssp/lib/Drasil/SSP/Requirements.hs
+++ b/code/drasil-example/ssp/lib/Drasil/SSP/Requirements.hs
@@ -8,12 +8,10 @@ import Drasil.DocLang (mkInputPropsTable)
 import Drasil.DocLang.SRS (datCon, propCorSol) 
 
 import Data.Drasil.Concepts.Computation (inDatum)
-import Data.Drasil.Concepts.Documentation (assumption, code,
-  datum, funcReqDom, input_, likelyChg, mg, mis, module_, name_, nonFuncReqDom,
-  output_, physicalConstraint, property, requirement, srs, symbol_,
-  traceyMatrix, unlikelyChg, user, value, propOfCorSol)
+import Data.Drasil.Concepts.Documentation (code,
+  datum, funcReqDom, input_, mg, mis, name_, nonFuncReqDom,
+  output_, physicalConstraint, property, symbol_, user, value, propOfCorSol)
 import Data.Drasil.Concepts.Physics (twoD)
-import Data.Drasil.TheoryConcepts (dataDefn, genDefn, inModel, thModel)
 
 import Drasil.SSP.Defs (crtSlpSrf, slope, slpSrf)
 import Drasil.SSP.IMods (fctSfty, nrmShrFor, intsliceFs, crtSlpId)
@@ -125,8 +123,8 @@ reusable = cic "reusable" (foldlSent [
   atStartNP (the code), S "is modularized"]) "Reusable" nonFuncReqDom
 
 maintainable :: ConceptInstance
-maintainable = cic "maintainable" (foldlSent [
-  S "The traceability between", foldlList Comma List [plural requirement,
-  plural assumption, plural thModel, plural genDefn, plural dataDefn, plural inModel,
-  plural likelyChg, plural unlikelyChg, plural module_], S "is completely recorded in",
-  plural traceyMatrix `S.inThe` getAcc srs `S.and_` phrase mg]) "Maintainable" nonFuncReqDom
+maintainable = cic "maintainability" (foldlSent [
+  S "If a likely change is made" `S.toThe` S "finished software, it will take", 
+  addPercent (10 :: Integer), S "percent" `S.ofThe` S "original development time,",
+  S "assuming the same development resources are available"
+  ]) "Maintainability" nonFuncReqDom

--- a/code/drasil-example/ssp/lib/Drasil/SSP/Requirements.hs
+++ b/code/drasil-example/ssp/lib/Drasil/SSP/Requirements.hs
@@ -123,8 +123,8 @@ reusable = cic "reusable" (foldlSent [
   atStartNP (the code), S "is modularized"]) "Reusable" nonFuncReqDom
 
 maintainable :: ConceptInstance
-maintainable = cic "maintainability" (foldlSent [
+maintainable = cic "maintainable" (foldlSent [
   S "If a likely change is made" `S.toThe` S "finished software, it will take", 
   addPercent (10 :: Integer), S "percent" `S.ofThe` S "original development time,",
   S "assuming the same development resources are available"
-  ]) "Maintainability" nonFuncReqDom
+  ]) "Maintainable" nonFuncReqDom

--- a/code/drasil-example/ssp/lib/Drasil/SSP/Requirements.hs
+++ b/code/drasil-example/ssp/lib/Drasil/SSP/Requirements.hs
@@ -4,9 +4,8 @@ import Language.Drasil
 import Language.Drasil.Chunk.Concept.NamedCombinators
 import qualified Language.Drasil.Sentence.Combinators as S
 
-import Drasil.DocLang (mkInputPropsTable)
+import Drasil.DocLang (mkInputPropsTable, mkMaintainableNFR)
 import Drasil.DocLang.SRS (datCon, propCorSol) 
-import Drasil.Sections.Requirements (mkMaintainableNFR)
 
 import Data.Drasil.Concepts.Computation (inDatum)
 import Data.Drasil.Concepts.Documentation (code,

--- a/code/drasil-example/swhs/lib/Drasil/SWHS/Requirements.hs
+++ b/code/drasil-example/swhs/lib/Drasil/SWHS/Requirements.hs
@@ -157,4 +157,4 @@ reusable = cic "reusable" (foldlSent [
   atStartNP (the code), S "is modularized"]) "Reusable" nonFuncReqDom
 
 maintainable :: ConceptInstance
-maintainable = mkMaintainableNFR "maintainable" (10 :: Integer) "Maintainable"
+maintainable = mkMaintainableNFR "maintainable" 10 "Maintainable"

--- a/code/drasil-example/swhs/lib/Drasil/SWHS/Requirements.hs
+++ b/code/drasil-example/swhs/lib/Drasil/SWHS/Requirements.hs
@@ -6,9 +6,8 @@ import qualified Language.Drasil.NounPhrase.Combinators as NP
 import qualified Language.Drasil.Sentence.Combinators as S
 import Theory.Drasil (InstanceModel, HasOutput(output))
 
-import Drasil.DocLang (inReq)
+import Drasil.DocLang (inReq, mkMaintainableNFR)
 import Drasil.DocLang.SRS (datCon, propCorSol) 
-import Drasil.Sections.Requirements (mkMaintainableNFR)
 
 import Data.Drasil.Concepts.Computation (inValue)
 import Data.Drasil.Concepts.Documentation (code, condition,

--- a/code/drasil-example/swhs/lib/Drasil/SWHS/Requirements.hs
+++ b/code/drasil-example/swhs/lib/Drasil/SWHS/Requirements.hs
@@ -10,18 +10,15 @@ import Drasil.DocLang (inReq)
 import Drasil.DocLang.SRS (datCon, propCorSol) 
 
 import Data.Drasil.Concepts.Computation (inValue)
-import Data.Drasil.Concepts.Documentation (assumption, code, condition,
-  funcReqDom, input_, likelyChg, mg, mis, module_, nonFuncReqDom, output_,
-  physicalConstraint, property, propOfCorSol, requirement, srs, traceyMatrix,
-  unlikelyChg, value, vavPlan)
+import Data.Drasil.Concepts.Documentation (code, condition,
+  funcReqDom, input_, mg, mis, nonFuncReqDom, output_,
+  physicalConstraint, property, propOfCorSol, value, vavPlan)
 import Data.Drasil.Concepts.Math (parameter)
 import Data.Drasil.Concepts.PhysicalProperties (materialProprty)
 import Data.Drasil.Concepts.Thermodynamics as CT (lawConsEnergy, melting)
 
 import Data.Drasil.Quantities.PhysicalProperties (mass)
 import Data.Drasil.Quantities.Physics (energy, time)
-
-import Data.Drasil.TheoryConcepts (dataDefn, genDefn, inModel, thModel)
 
 import Drasil.SWHS.DataDefs (waterMass, waterVolume, tankVolume, 
   balanceDecayRate, balanceDecayTime, balanceSolidPCM, balanceLiquidPCM)
@@ -159,11 +156,11 @@ reusable = cic "reusable" (foldlSent [
   atStartNP (the code), S "is modularized"]) "Reusable" nonFuncReqDom
 
 maintainable :: ConceptInstance
-maintainable = cic "maintainable" (foldlSent [
-  S "The traceability between", foldlList Comma List [plural requirement,
-  plural assumption, plural thModel, plural genDefn, plural dataDefn, plural inModel,
-  plural likelyChg, plural unlikelyChg, plural module_], S "is completely recorded in",
-  plural traceyMatrix, S "in the", getAcc srs `S.and_` phrase mg]) "Maintainable" nonFuncReqDom
+maintainable = cic "maintainability" (foldlSent [
+  S "If a likely change is made" `S.toThe` S "finished software, it will take", 
+  addPercent (10 :: Integer), S "percent" `S.ofThe` S "original development time,",
+  S "assuming the same development resources are available"
+  ]) "Maintainability" nonFuncReqDom
 
 -- The second sentence of the above paragraph is repeated in all examples (not
 -- exactly, but the general idea is). The first sentence is not always

--- a/code/drasil-example/swhs/lib/Drasil/SWHS/Requirements.hs
+++ b/code/drasil-example/swhs/lib/Drasil/SWHS/Requirements.hs
@@ -8,6 +8,7 @@ import Theory.Drasil (InstanceModel, HasOutput(output))
 
 import Drasil.DocLang (inReq)
 import Drasil.DocLang.SRS (datCon, propCorSol) 
+import Drasil.Sections.Requirements (mkMaintainableNFR)
 
 import Data.Drasil.Concepts.Computation (inValue)
 import Data.Drasil.Concepts.Documentation (code, condition,
@@ -156,14 +157,4 @@ reusable = cic "reusable" (foldlSent [
   atStartNP (the code), S "is modularized"]) "Reusable" nonFuncReqDom
 
 maintainable :: ConceptInstance
-maintainable = cic "maintainable" (foldlSent [
-  S "If a likely change is made" `S.toThe` S "finished software, it will take", 
-  addPercent (10 :: Integer), S "percent" `S.ofThe` S "original development time,",
-  S "assuming the same development resources are available"
-  ]) "Maintainable" nonFuncReqDom
-
--- The second sentence of the above paragraph is repeated in all examples (not
--- exactly, but the general idea is). The first sentence is not always
--- repeated, but it is always either stating that performance is a priority or
--- performance is not a priority. This is probably something that can be
--- abstracted out.
+maintainable = mkMaintainableNFR "maintainable" (10 :: Integer) "Maintainable"

--- a/code/drasil-example/swhs/lib/Drasil/SWHS/Requirements.hs
+++ b/code/drasil-example/swhs/lib/Drasil/SWHS/Requirements.hs
@@ -156,11 +156,11 @@ reusable = cic "reusable" (foldlSent [
   atStartNP (the code), S "is modularized"]) "Reusable" nonFuncReqDom
 
 maintainable :: ConceptInstance
-maintainable = cic "maintainability" (foldlSent [
+maintainable = cic "maintainable" (foldlSent [
   S "If a likely change is made" `S.toThe` S "finished software, it will take", 
   addPercent (10 :: Integer), S "percent" `S.ofThe` S "original development time,",
   S "assuming the same development resources are available"
-  ]) "Maintainability" nonFuncReqDom
+  ]) "Maintainable" nonFuncReqDom
 
 -- The second sentence of the above paragraph is repeated in all examples (not
 -- exactly, but the general idea is). The first sentence is not always

--- a/code/stable/gamephysics/SRS/HTML/GamePhysics_SRS.html
+++ b/code/stable/gamephysics/SRS/HTML/GamePhysics_SRS.html
@@ -2651,7 +2651,7 @@
               </p>
               <p>
                 <div id="maintainability">
-                  Maintainability: The development time for any of the likely changes should not exceed 10<em>%</em> percent of the original development time.
+                  Maintainability: If a likely change is made to the finished software, it will take 10<em>%</em> percent of the original development time, assuming the same development resources are available.
                 </div>
               </p>
             </div>

--- a/code/stable/gamephysics/SRS/HTML/GamePhysics_SRS.html
+++ b/code/stable/gamephysics/SRS/HTML/GamePhysics_SRS.html
@@ -2651,7 +2651,7 @@
               </p>
               <p>
                 <div id="maintainability">
-                  Maintainability: If a likely change is made to the finished software, it will take 10<em>%</em> percent of the original development time, assuming the same development resources are available.
+                  Maintainability: If a likely change is made to the finished software, it will take 10<em>%</em> of the original development time, assuming the same development resources are available.
                 </div>
               </p>
             </div>

--- a/code/stable/gamephysics/SRS/HTML/GamePhysics_SRS.html
+++ b/code/stable/gamephysics/SRS/HTML/GamePhysics_SRS.html
@@ -2651,7 +2651,7 @@
               </p>
               <p>
                 <div id="maintainability">
-                  Maintainability: If a likely change is made to the finished software, it will take 10<em>%</em> of the original development time, assuming the same development resources are available.
+                  Maintainability: If a likely change is made to the finished software, it will take at most 10<em>%</em> of the original development time, assuming the same development resources are available.
                 </div>
               </p>
             </div>

--- a/code/stable/gamephysics/SRS/JSON/GamePhysics_SRS.ipynb
+++ b/code/stable/gamephysics/SRS/JSON/GamePhysics_SRS.ipynb
@@ -2145,7 +2145,7 @@
     "\n",
     "</div>\n",
     "<div id=\\\"maintainability\\\">\n",
-    "Maintainability: The development time for any of the likely changes should not exceed 10$%$ percent of the original development time.\n",
+    "Maintainability: If a likely change is made to the finished software, it will take 10$%$ percent of the original development time, assuming the same development resources are available.\n",
     "\n",
     "</div>\n",
     "\n",

--- a/code/stable/gamephysics/SRS/JSON/GamePhysics_SRS.ipynb
+++ b/code/stable/gamephysics/SRS/JSON/GamePhysics_SRS.ipynb
@@ -2145,7 +2145,7 @@
     "\n",
     "</div>\n",
     "<div id=\\\"maintainability\\\">\n",
-    "Maintainability: If a likely change is made to the finished software, it will take 10$%$ of the original development time, assuming the same development resources are available.\n",
+    "Maintainability: If a likely change is made to the finished software, it will take at most 10$%$ of the original development time, assuming the same development resources are available.\n",
     "\n",
     "</div>\n",
     "\n",

--- a/code/stable/gamephysics/SRS/JSON/GamePhysics_SRS.ipynb
+++ b/code/stable/gamephysics/SRS/JSON/GamePhysics_SRS.ipynb
@@ -2145,7 +2145,7 @@
     "\n",
     "</div>\n",
     "<div id=\\\"maintainability\\\">\n",
-    "Maintainability: If a likely change is made to the finished software, it will take 10$%$ percent of the original development time, assuming the same development resources are available.\n",
+    "Maintainability: If a likely change is made to the finished software, it will take 10$%$ of the original development time, assuming the same development resources are available.\n",
     "\n",
     "</div>\n",
     "\n",

--- a/code/stable/gamephysics/SRS/PDF/GamePhysics_SRS.tex
+++ b/code/stable/gamephysics/SRS/PDF/GamePhysics_SRS.tex
@@ -1525,7 +1525,7 @@ This section provides the non-functional requirements, the qualities that the so
 \item[Correctness:\phantomsection\label{correctness}]{The output of simulation results shall be compared to an existing implementation like Pymunk (please refer to: http://www.pymunk.org/en/latest/).}
 \item[Usability:\phantomsection\label{usability}]{Software shall be easy to learn and use. Usability shall be measured by how long it takes a user to learn how to use the library to create a small program to simulate the movement of 2 bodies over time in space. Creating a program should take no less than 30 to 60 minutes for an intermediate to experienced programmer.}
 \item[Understandability:\phantomsection\label{understandability}]{Users of Tamias2D shall be able to learn the software with ease. Users shall be able to easily create a small program using the library. Creating a small program to simulate the movement of 2 bodies in space should take no less that 60 minutes.}
-\item[Maintainability:\phantomsection\label{maintainability}]{If a likely change is made to the finished software, it will take 10$\%$ of the original development time, assuming the same development resources are available.}
+\item[Maintainability:\phantomsection\label{maintainability}]{If a likely change is made to the finished software, it will take at most 10$\%$ of the original development time, assuming the same development resources are available.}
 \end{itemize}
 \section{Likely Changes}
 \label{Sec:LCs}

--- a/code/stable/gamephysics/SRS/PDF/GamePhysics_SRS.tex
+++ b/code/stable/gamephysics/SRS/PDF/GamePhysics_SRS.tex
@@ -1525,7 +1525,7 @@ This section provides the non-functional requirements, the qualities that the so
 \item[Correctness:\phantomsection\label{correctness}]{The output of simulation results shall be compared to an existing implementation like Pymunk (please refer to: http://www.pymunk.org/en/latest/).}
 \item[Usability:\phantomsection\label{usability}]{Software shall be easy to learn and use. Usability shall be measured by how long it takes a user to learn how to use the library to create a small program to simulate the movement of 2 bodies over time in space. Creating a program should take no less than 30 to 60 minutes for an intermediate to experienced programmer.}
 \item[Understandability:\phantomsection\label{understandability}]{Users of Tamias2D shall be able to learn the software with ease. Users shall be able to easily create a small program using the library. Creating a small program to simulate the movement of 2 bodies in space should take no less that 60 minutes.}
-\item[Maintainability:\phantomsection\label{maintainability}]{If a likely change is made to the finished software, it will take 10$\%$ percent of the original development time, assuming the same development resources are available.}
+\item[Maintainability:\phantomsection\label{maintainability}]{If a likely change is made to the finished software, it will take 10$\%$ of the original development time, assuming the same development resources are available.}
 \end{itemize}
 \section{Likely Changes}
 \label{Sec:LCs}

--- a/code/stable/gamephysics/SRS/PDF/GamePhysics_SRS.tex
+++ b/code/stable/gamephysics/SRS/PDF/GamePhysics_SRS.tex
@@ -1525,7 +1525,7 @@ This section provides the non-functional requirements, the qualities that the so
 \item[Correctness:\phantomsection\label{correctness}]{The output of simulation results shall be compared to an existing implementation like Pymunk (please refer to: http://www.pymunk.org/en/latest/).}
 \item[Usability:\phantomsection\label{usability}]{Software shall be easy to learn and use. Usability shall be measured by how long it takes a user to learn how to use the library to create a small program to simulate the movement of 2 bodies over time in space. Creating a program should take no less than 30 to 60 minutes for an intermediate to experienced programmer.}
 \item[Understandability:\phantomsection\label{understandability}]{Users of Tamias2D shall be able to learn the software with ease. Users shall be able to easily create a small program using the library. Creating a small program to simulate the movement of 2 bodies in space should take no less that 60 minutes.}
-\item[Maintainability:\phantomsection\label{maintainability}]{The development time for any of the likely changes should not exceed 10$\%$ percent of the original development time.}
+\item[Maintainability:\phantomsection\label{maintainability}]{If a likely change is made to the finished software, it will take 10$\%$ percent of the original development time, assuming the same development resources are available.}
 \end{itemize}
 \section{Likely Changes}
 \label{Sec:LCs}

--- a/code/stable/glassbr/SRS/HTML/GlassBR_SRS.html
+++ b/code/stable/glassbr/SRS/HTML/GlassBR_SRS.html
@@ -2653,7 +2653,7 @@
               <p><div id="reusable">Reusable: The code is modularized.</div></p>
               <p>
                 <div id="maintainable">
-                  Maintainable: If a likely change is made to the finished software, it will take 10<em>%</em> percent of the original development time, assuming the same development resources are available.
+                  Maintainable: If a likely change is made to the finished software, it will take 10<em>%</em> of the original development time, assuming the same development resources are available.
                 </div>
               </p>
               <p>

--- a/code/stable/glassbr/SRS/HTML/GlassBR_SRS.html
+++ b/code/stable/glassbr/SRS/HTML/GlassBR_SRS.html
@@ -2653,7 +2653,7 @@
               <p><div id="reusable">Reusable: The code is modularized.</div></p>
               <p>
                 <div id="maintainable">
-                  Maintainable: If a likely change is made to the finished software, it will take 10<em>%</em> of the original development time, assuming the same development resources are available.
+                  Maintainable: If a likely change is made to the finished software, it will take at most 10<em>%</em> of the original development time, assuming the same development resources are available.
                 </div>
               </p>
               <p>

--- a/code/stable/glassbr/SRS/HTML/GlassBR_SRS.html
+++ b/code/stable/glassbr/SRS/HTML/GlassBR_SRS.html
@@ -2653,7 +2653,7 @@
               <p><div id="reusable">Reusable: The code is modularized.</div></p>
               <p>
                 <div id="maintainable">
-                  Maintainable: The traceability between requirements, assumptions, theoretical models, general definitions, data definitions, instance models, likely changes, unlikely changes, and modules is completely recorded in traceability matrices in the SRS and module guide.
+                  Maintainable: If a likely change is made to the finished software, it will take 10<em>%</em> percent of the original development time, assuming the same development resources are available.
                 </div>
               </p>
               <p>

--- a/code/stable/glassbr/SRS/JSON/GlassBR_SRS.ipynb
+++ b/code/stable/glassbr/SRS/JSON/GlassBR_SRS.ipynb
@@ -1948,7 +1948,7 @@
     "\n",
     "</div>\n",
     "<div id=\\\"maintainable\\\">\n",
-    "Maintainable: If a likely change is made to the finished software, it will take 10$%$ percent of the original development time, assuming the same development resources are available.\n",
+    "Maintainable: If a likely change is made to the finished software, it will take 10$%$ of the original development time, assuming the same development resources are available.\n",
     "\n",
     "</div>\n",
     "<div id=\\\"portable\\\">\n",

--- a/code/stable/glassbr/SRS/JSON/GlassBR_SRS.ipynb
+++ b/code/stable/glassbr/SRS/JSON/GlassBR_SRS.ipynb
@@ -1948,7 +1948,7 @@
     "\n",
     "</div>\n",
     "<div id=\\\"maintainable\\\">\n",
-    "Maintainable: If a likely change is made to the finished software, it will take 10$%$ of the original development time, assuming the same development resources are available.\n",
+    "Maintainable: If a likely change is made to the finished software, it will take at most 10$%$ of the original development time, assuming the same development resources are available.\n",
     "\n",
     "</div>\n",
     "<div id=\\\"portable\\\">\n",

--- a/code/stable/glassbr/SRS/JSON/GlassBR_SRS.ipynb
+++ b/code/stable/glassbr/SRS/JSON/GlassBR_SRS.ipynb
@@ -1948,7 +1948,7 @@
     "\n",
     "</div>\n",
     "<div id=\\\"maintainable\\\">\n",
-    "Maintainable: The traceability between requirements, assumptions, theoretical models, general definitions, data definitions, instance models, likely changes, unlikely changes, and modules is completely recorded in traceability matrices in the SRS and module guide.\n",
+    "Maintainable: If a likely change is made to the finished software, it will take 10$%$ percent of the original development time, assuming the same development resources are available.\n",
     "\n",
     "</div>\n",
     "<div id=\\\"portable\\\">\n",

--- a/code/stable/glassbr/SRS/PDF/GlassBR_SRS.tex
+++ b/code/stable/glassbr/SRS/PDF/GlassBR_SRS.tex
@@ -1440,7 +1440,7 @@ This section provides the non-functional requirements, the qualities that the so
 \item[Verifiable:\phantomsection\label{verifiable}]{The code is tested with complete verification and validation plan.}
 \item[Understandable:\phantomsection\label{understandable}]{The code is modularized with complete module guide and module interface specification.}
 \item[Reusable:\phantomsection\label{reusable}]{The code is modularized.}
-\item[Maintainable:\phantomsection\label{maintainable}]{The traceability between requirements, assumptions, theoretical models, general definitions, data definitions, instance models, likely changes, unlikely changes, and modules is completely recorded in traceability matrices in the SRS and module guide.}
+\item[Maintainable:\phantomsection\label{maintainable}]{If a likely change is made to the finished software, it will take 10$\%$ percent of the original development time, assuming the same development resources are available.}
 \item[Portable:\phantomsection\label{portable}]{The code is able to be run in different environments.}
 \end{itemize}
 \section{Likely Changes}

--- a/code/stable/glassbr/SRS/PDF/GlassBR_SRS.tex
+++ b/code/stable/glassbr/SRS/PDF/GlassBR_SRS.tex
@@ -1440,7 +1440,7 @@ This section provides the non-functional requirements, the qualities that the so
 \item[Verifiable:\phantomsection\label{verifiable}]{The code is tested with complete verification and validation plan.}
 \item[Understandable:\phantomsection\label{understandable}]{The code is modularized with complete module guide and module interface specification.}
 \item[Reusable:\phantomsection\label{reusable}]{The code is modularized.}
-\item[Maintainable:\phantomsection\label{maintainable}]{If a likely change is made to the finished software, it will take 10$\%$ of the original development time, assuming the same development resources are available.}
+\item[Maintainable:\phantomsection\label{maintainable}]{If a likely change is made to the finished software, it will take at most 10$\%$ of the original development time, assuming the same development resources are available.}
 \item[Portable:\phantomsection\label{portable}]{The code is able to be run in different environments.}
 \end{itemize}
 \section{Likely Changes}

--- a/code/stable/glassbr/SRS/PDF/GlassBR_SRS.tex
+++ b/code/stable/glassbr/SRS/PDF/GlassBR_SRS.tex
@@ -1440,7 +1440,7 @@ This section provides the non-functional requirements, the qualities that the so
 \item[Verifiable:\phantomsection\label{verifiable}]{The code is tested with complete verification and validation plan.}
 \item[Understandable:\phantomsection\label{understandable}]{The code is modularized with complete module guide and module interface specification.}
 \item[Reusable:\phantomsection\label{reusable}]{The code is modularized.}
-\item[Maintainable:\phantomsection\label{maintainable}]{If a likely change is made to the finished software, it will take 10$\%$ percent of the original development time, assuming the same development resources are available.}
+\item[Maintainable:\phantomsection\label{maintainable}]{If a likely change is made to the finished software, it will take 10$\%$ of the original development time, assuming the same development resources are available.}
 \item[Portable:\phantomsection\label{portable}]{The code is able to be run in different environments.}
 \end{itemize}
 \section{Likely Changes}

--- a/code/stable/pdcontroller/SRS/HTML/PDController_SRS.html
+++ b/code/stable/pdcontroller/SRS/HTML/PDController_SRS.html
@@ -1399,7 +1399,7 @@
               </p>
               <p>
                 <div id="maintainability">
-                  Maintainable: If a likely change is made to the finished software, it will take 10<em>%</em> percent of the original development time, assuming the same development resources are available.
+                  Maintainable: If a likely change is made to the finished software, it will take 10<em>%</em> of the original development time, assuming the same development resources are available.
                 </div>
               </p>
               <p>

--- a/code/stable/pdcontroller/SRS/HTML/PDController_SRS.html
+++ b/code/stable/pdcontroller/SRS/HTML/PDController_SRS.html
@@ -1399,7 +1399,7 @@
               </p>
               <p>
                 <div id="maintainability">
-                  Maintainable: The dependencies among the instance models, requirements, likely changes, assumptions and all other relevant sections of this document shall be traceable to each other in the trace matrix.
+                  Maintainable: If a likely change is made to the finished software, it will take 10<em>%</em> percent of the original development time, assuming the same development resources are available.
                 </div>
               </p>
               <p>

--- a/code/stable/pdcontroller/SRS/HTML/PDController_SRS.html
+++ b/code/stable/pdcontroller/SRS/HTML/PDController_SRS.html
@@ -1399,7 +1399,7 @@
               </p>
               <p>
                 <div id="maintainability">
-                  Maintainable: If a likely change is made to the finished software, it will take 10<em>%</em> of the original development time, assuming the same development resources are available.
+                  Maintainable: If a likely change is made to the finished software, it will take at most 10<em>%</em> of the original development time, assuming the same development resources are available.
                 </div>
               </p>
               <p>

--- a/code/stable/pdcontroller/SRS/JSON/PDController_SRS.ipynb
+++ b/code/stable/pdcontroller/SRS/JSON/PDController_SRS.ipynb
@@ -978,7 +978,7 @@
     "\n",
     "</div>\n",
     "<div id=\\\"maintainability\\\">\n",
-    "Maintainable: If a likely change is made to the finished software, it will take 10$%$ of the original development time, assuming the same development resources are available.\n",
+    "Maintainable: If a likely change is made to the finished software, it will take at most 10$%$ of the original development time, assuming the same development resources are available.\n",
     "\n",
     "</div>\n",
     "<div id=\\\"verifiability\\\">\n",

--- a/code/stable/pdcontroller/SRS/JSON/PDController_SRS.ipynb
+++ b/code/stable/pdcontroller/SRS/JSON/PDController_SRS.ipynb
@@ -978,7 +978,7 @@
     "\n",
     "</div>\n",
     "<div id=\\\"maintainability\\\">\n",
-    "Maintainable: The dependencies among the instance models, requirements, likely changes, assumptions and all other relevant sections of this document shall be traceable to each other in the trace matrix.\n",
+    "Maintainable: If a likely change is made to the finished software, it will take 10$%$ percent of the original development time, assuming the same development resources are available.\n",
     "\n",
     "</div>\n",
     "<div id=\\\"verifiability\\\">\n",

--- a/code/stable/pdcontroller/SRS/JSON/PDController_SRS.ipynb
+++ b/code/stable/pdcontroller/SRS/JSON/PDController_SRS.ipynb
@@ -978,7 +978,7 @@
     "\n",
     "</div>\n",
     "<div id=\\\"maintainability\\\">\n",
-    "Maintainable: If a likely change is made to the finished software, it will take 10$%$ percent of the original development time, assuming the same development resources are available.\n",
+    "Maintainable: If a likely change is made to the finished software, it will take 10$%$ of the original development time, assuming the same development resources are available.\n",
     "\n",
     "</div>\n",
     "<div id=\\\"verifiability\\\">\n",

--- a/code/stable/pdcontroller/SRS/PDF/PDController_SRS.tex
+++ b/code/stable/pdcontroller/SRS/PDF/PDController_SRS.tex
@@ -729,7 +729,7 @@ This section provides the non-functional requirements, the qualities that the so
 \begin{itemize}
 \item[Portable:\phantomsection\label{portability}]{The code shall be portable to multiple Operating Systems.}
 \item[Secure:\phantomsection\label{security}]{The code shall be immune to common security problems such as memory leaks, divide by zero errors, and the square root of negative numbers.}
-\item[Maintainable:\phantomsection\label{maintainability}]{If a likely change is made to the finished software, it will take 10$\%$ percent of the original development time, assuming the same development resources are available.}
+\item[Maintainable:\phantomsection\label{maintainability}]{If a likely change is made to the finished software, it will take 10$\%$ of the original development time, assuming the same development resources are available.}
 \item[Verifiable:\phantomsection\label{verifiability}]{The code shall be verifiable against a Verification and Validation plan.}
 \end{itemize}
 \section{Likely Changes}

--- a/code/stable/pdcontroller/SRS/PDF/PDController_SRS.tex
+++ b/code/stable/pdcontroller/SRS/PDF/PDController_SRS.tex
@@ -729,7 +729,7 @@ This section provides the non-functional requirements, the qualities that the so
 \begin{itemize}
 \item[Portable:\phantomsection\label{portability}]{The code shall be portable to multiple Operating Systems.}
 \item[Secure:\phantomsection\label{security}]{The code shall be immune to common security problems such as memory leaks, divide by zero errors, and the square root of negative numbers.}
-\item[Maintainable:\phantomsection\label{maintainability}]{If a likely change is made to the finished software, it will take 10$\%$ of the original development time, assuming the same development resources are available.}
+\item[Maintainable:\phantomsection\label{maintainability}]{If a likely change is made to the finished software, it will take at most 10$\%$ of the original development time, assuming the same development resources are available.}
 \item[Verifiable:\phantomsection\label{verifiability}]{The code shall be verifiable against a Verification and Validation plan.}
 \end{itemize}
 \section{Likely Changes}

--- a/code/stable/pdcontroller/SRS/PDF/PDController_SRS.tex
+++ b/code/stable/pdcontroller/SRS/PDF/PDController_SRS.tex
@@ -729,7 +729,7 @@ This section provides the non-functional requirements, the qualities that the so
 \begin{itemize}
 \item[Portable:\phantomsection\label{portability}]{The code shall be portable to multiple Operating Systems.}
 \item[Secure:\phantomsection\label{security}]{The code shall be immune to common security problems such as memory leaks, divide by zero errors, and the square root of negative numbers.}
-\item[Maintainable:\phantomsection\label{maintainability}]{The dependencies among the instance models, requirements, likely changes, assumptions and all other relevant sections of this document shall be traceable to each other in the trace matrix.}
+\item[Maintainable:\phantomsection\label{maintainability}]{If a likely change is made to the finished software, it will take 10$\%$ percent of the original development time, assuming the same development resources are available.}
 \item[Verifiable:\phantomsection\label{verifiability}]{The code shall be verifiable against a Verification and Validation plan.}
 \end{itemize}
 \section{Likely Changes}

--- a/code/stable/projectile/SRS/HTML/Projectile_SRS.html
+++ b/code/stable/projectile/SRS/HTML/Projectile_SRS.html
@@ -1883,7 +1883,7 @@
               <p><div id="reusable">Reusable: The code is modularized.</div></p>
               <p>
                 <div id="maintainable">
-                  Maintainable: The traceability between requirements, assumptions, theoretical models, general definitions, data definitions, instance models, likely changes, unlikely changes, and modules is completely recorded in traceability matrices in the SRS and module guide.
+                  Maintainable: If a likely change is made to the finished software, it will take 10<em>%</em> percent of the original development time, assuming the same development resources are available.
                 </div>
               </p>
               <p>

--- a/code/stable/projectile/SRS/HTML/Projectile_SRS.html
+++ b/code/stable/projectile/SRS/HTML/Projectile_SRS.html
@@ -1883,7 +1883,7 @@
               <p><div id="reusable">Reusable: The code is modularized.</div></p>
               <p>
                 <div id="maintainable">
-                  Maintainable: If a likely change is made to the finished software, it will take 10<em>%</em> of the original development time, assuming the same development resources are available.
+                  Maintainable: If a likely change is made to the finished software, it will take at most 10<em>%</em> of the original development time, assuming the same development resources are available.
                 </div>
               </p>
               <p>

--- a/code/stable/projectile/SRS/HTML/Projectile_SRS.html
+++ b/code/stable/projectile/SRS/HTML/Projectile_SRS.html
@@ -1883,7 +1883,7 @@
               <p><div id="reusable">Reusable: The code is modularized.</div></p>
               <p>
                 <div id="maintainable">
-                  Maintainable: If a likely change is made to the finished software, it will take 10<em>%</em> percent of the original development time, assuming the same development resources are available.
+                  Maintainable: If a likely change is made to the finished software, it will take 10<em>%</em> of the original development time, assuming the same development resources are available.
                 </div>
               </p>
               <p>

--- a/code/stable/projectile/SRS/JSON/Projectile_SRS.ipynb
+++ b/code/stable/projectile/SRS/JSON/Projectile_SRS.ipynb
@@ -1363,7 +1363,7 @@
     "\n",
     "</div>\n",
     "<div id=\\\"maintainable\\\">\n",
-    "Maintainable: If a likely change is made to the finished software, it will take 10$%$ percent of the original development time, assuming the same development resources are available.\n",
+    "Maintainable: If a likely change is made to the finished software, it will take 10$%$ of the original development time, assuming the same development resources are available.\n",
     "\n",
     "</div>\n",
     "<div id=\\\"portable\\\">\n",

--- a/code/stable/projectile/SRS/JSON/Projectile_SRS.ipynb
+++ b/code/stable/projectile/SRS/JSON/Projectile_SRS.ipynb
@@ -1363,7 +1363,7 @@
     "\n",
     "</div>\n",
     "<div id=\\\"maintainable\\\">\n",
-    "Maintainable: The traceability between requirements, assumptions, theoretical models, general definitions, data definitions, instance models, likely changes, unlikely changes, and modules is completely recorded in traceability matrices in the SRS and module guide.\n",
+    "Maintainable: If a likely change is made to the finished software, it will take 10$%$ percent of the original development time, assuming the same development resources are available.\n",
     "\n",
     "</div>\n",
     "<div id=\\\"portable\\\">\n",

--- a/code/stable/projectile/SRS/JSON/Projectile_SRS.ipynb
+++ b/code/stable/projectile/SRS/JSON/Projectile_SRS.ipynb
@@ -1363,7 +1363,7 @@
     "\n",
     "</div>\n",
     "<div id=\\\"maintainable\\\">\n",
-    "Maintainable: If a likely change is made to the finished software, it will take 10$%$ of the original development time, assuming the same development resources are available.\n",
+    "Maintainable: If a likely change is made to the finished software, it will take at most 10$%$ of the original development time, assuming the same development resources are available.\n",
     "\n",
     "</div>\n",
     "<div id=\\\"portable\\\">\n",

--- a/code/stable/projectile/SRS/PDF/Projectile_SRS.tex
+++ b/code/stable/projectile/SRS/PDF/Projectile_SRS.tex
@@ -1065,7 +1065,7 @@ This section provides the non-functional requirements, the qualities that the so
 \item[Verifiable:\phantomsection\label{verifiable}]{The code is tested with complete verification and validation plan.}
 \item[Understandable:\phantomsection\label{understandable}]{The code is modularized with complete module guide and module interface specification.}
 \item[Reusable:\phantomsection\label{reusable}]{The code is modularized.}
-\item[Maintainable:\phantomsection\label{maintainable}]{If a likely change is made to the finished software, it will take 10$\%$ of the original development time, assuming the same development resources are available.}
+\item[Maintainable:\phantomsection\label{maintainable}]{If a likely change is made to the finished software, it will take at most 10$\%$ of the original development time, assuming the same development resources are available.}
 \item[Portable:\phantomsection\label{portable}]{The code is able to be run in different environments.}
 \end{itemize}
 \section{Traceability Matrices and Graphs}

--- a/code/stable/projectile/SRS/PDF/Projectile_SRS.tex
+++ b/code/stable/projectile/SRS/PDF/Projectile_SRS.tex
@@ -1065,7 +1065,7 @@ This section provides the non-functional requirements, the qualities that the so
 \item[Verifiable:\phantomsection\label{verifiable}]{The code is tested with complete verification and validation plan.}
 \item[Understandable:\phantomsection\label{understandable}]{The code is modularized with complete module guide and module interface specification.}
 \item[Reusable:\phantomsection\label{reusable}]{The code is modularized.}
-\item[Maintainable:\phantomsection\label{maintainable}]{If a likely change is made to the finished software, it will take 10$\%$ percent of the original development time, assuming the same development resources are available.}
+\item[Maintainable:\phantomsection\label{maintainable}]{If a likely change is made to the finished software, it will take 10$\%$ of the original development time, assuming the same development resources are available.}
 \item[Portable:\phantomsection\label{portable}]{The code is able to be run in different environments.}
 \end{itemize}
 \section{Traceability Matrices and Graphs}

--- a/code/stable/projectile/SRS/PDF/Projectile_SRS.tex
+++ b/code/stable/projectile/SRS/PDF/Projectile_SRS.tex
@@ -1065,7 +1065,7 @@ This section provides the non-functional requirements, the qualities that the so
 \item[Verifiable:\phantomsection\label{verifiable}]{The code is tested with complete verification and validation plan.}
 \item[Understandable:\phantomsection\label{understandable}]{The code is modularized with complete module guide and module interface specification.}
 \item[Reusable:\phantomsection\label{reusable}]{The code is modularized.}
-\item[Maintainable:\phantomsection\label{maintainable}]{The traceability between requirements, assumptions, theoretical models, general definitions, data definitions, instance models, likely changes, unlikely changes, and modules is completely recorded in traceability matrices in the SRS and module guide.}
+\item[Maintainable:\phantomsection\label{maintainable}]{If a likely change is made to the finished software, it will take 10$\%$ percent of the original development time, assuming the same development resources are available.}
 \item[Portable:\phantomsection\label{portable}]{The code is able to be run in different environments.}
 \end{itemize}
 \section{Traceability Matrices and Graphs}

--- a/code/stable/ssp/SRS/HTML/SSP_SRS.html
+++ b/code/stable/ssp/SRS/HTML/SSP_SRS.html
@@ -4711,7 +4711,7 @@
               <p><div id="reusable">Reusable: The code is modularized.</div></p>
               <p>
                 <div id="maintainable">
-                  Maintainable: The traceability between requirements, assumptions, theoretical models, general definitions, data definitions, instance models, likely changes, unlikely changes, and modules is completely recorded in traceability matrices in the SRS and module guide.
+                  Maintainable: If a likely change is made to the finished software, it will take 10<em>%</em> percent of the original development time, assuming the same development resources are available.
                 </div>
               </p>
             </div>

--- a/code/stable/ssp/SRS/HTML/SSP_SRS.html
+++ b/code/stable/ssp/SRS/HTML/SSP_SRS.html
@@ -4711,7 +4711,7 @@
               <p><div id="reusable">Reusable: The code is modularized.</div></p>
               <p>
                 <div id="maintainable">
-                  Maintainable: If a likely change is made to the finished software, it will take 10<em>%</em> of the original development time, assuming the same development resources are available.
+                  Maintainable: If a likely change is made to the finished software, it will take at most 10<em>%</em> of the original development time, assuming the same development resources are available.
                 </div>
               </p>
             </div>

--- a/code/stable/ssp/SRS/HTML/SSP_SRS.html
+++ b/code/stable/ssp/SRS/HTML/SSP_SRS.html
@@ -4711,7 +4711,7 @@
               <p><div id="reusable">Reusable: The code is modularized.</div></p>
               <p>
                 <div id="maintainable">
-                  Maintainable: If a likely change is made to the finished software, it will take 10<em>%</em> percent of the original development time, assuming the same development resources are available.
+                  Maintainable: If a likely change is made to the finished software, it will take 10<em>%</em> of the original development time, assuming the same development resources are available.
                 </div>
               </p>
             </div>

--- a/code/stable/ssp/SRS/JSON/SSP_SRS.ipynb
+++ b/code/stable/ssp/SRS/JSON/SSP_SRS.ipynb
@@ -3575,7 +3575,7 @@
     "\n",
     "</div>\n",
     "<div id=\\\"maintainable\\\">\n",
-    "Maintainable: The traceability between requirements, assumptions, theoretical models, general definitions, data definitions, instance models, likely changes, unlikely changes, and modules is completely recorded in traceability matrices in the SRS and module guide.\n",
+    "Maintainable: If a likely change is made to the finished software, it will take 10$%$ percent of the original development time, assuming the same development resources are available.\n",
     "\n",
     "</div>\n",
     "\n",

--- a/code/stable/ssp/SRS/JSON/SSP_SRS.ipynb
+++ b/code/stable/ssp/SRS/JSON/SSP_SRS.ipynb
@@ -3575,7 +3575,7 @@
     "\n",
     "</div>\n",
     "<div id=\\\"maintainable\\\">\n",
-    "Maintainable: If a likely change is made to the finished software, it will take 10$%$ percent of the original development time, assuming the same development resources are available.\n",
+    "Maintainable: If a likely change is made to the finished software, it will take 10$%$ of the original development time, assuming the same development resources are available.\n",
     "\n",
     "</div>\n",
     "\n",

--- a/code/stable/ssp/SRS/JSON/SSP_SRS.ipynb
+++ b/code/stable/ssp/SRS/JSON/SSP_SRS.ipynb
@@ -3575,7 +3575,7 @@
     "\n",
     "</div>\n",
     "<div id=\\\"maintainable\\\">\n",
-    "Maintainable: If a likely change is made to the finished software, it will take 10$%$ of the original development time, assuming the same development resources are available.\n",
+    "Maintainable: If a likely change is made to the finished software, it will take at most 10$%$ of the original development time, assuming the same development resources are available.\n",
     "\n",
     "</div>\n",
     "\n",

--- a/code/stable/ssp/SRS/PDF/SSP_SRS.tex
+++ b/code/stable/ssp/SRS/PDF/SSP_SRS.tex
@@ -2665,7 +2665,7 @@ This section provides the non-functional requirements, the qualities that the so
 \item[Correct:\phantomsection\label{correct}]{The outputs of the code have the properties described in \hyperref[Sec:CorSolProps]{Sec:Properties of a Correct Solution}.}
 \item[Understandable:\phantomsection\label{understandable}]{The code is modularized with complete module guide and module interface specification.}
 \item[Reusable:\phantomsection\label{reusable}]{The code is modularized.}
-\item[Maintainable:\phantomsection\label{maintainable}]{If a likely change is made to the finished software, it will take 10$\%$ of the original development time, assuming the same development resources are available.}
+\item[Maintainable:\phantomsection\label{maintainable}]{If a likely change is made to the finished software, it will take at most 10$\%$ of the original development time, assuming the same development resources are available.}
 \end{itemize}
 \section{Likely Changes}
 \label{Sec:LCs}

--- a/code/stable/ssp/SRS/PDF/SSP_SRS.tex
+++ b/code/stable/ssp/SRS/PDF/SSP_SRS.tex
@@ -2665,7 +2665,7 @@ This section provides the non-functional requirements, the qualities that the so
 \item[Correct:\phantomsection\label{correct}]{The outputs of the code have the properties described in \hyperref[Sec:CorSolProps]{Sec:Properties of a Correct Solution}.}
 \item[Understandable:\phantomsection\label{understandable}]{The code is modularized with complete module guide and module interface specification.}
 \item[Reusable:\phantomsection\label{reusable}]{The code is modularized.}
-\item[Maintainable:\phantomsection\label{maintainable}]{The traceability between requirements, assumptions, theoretical models, general definitions, data definitions, instance models, likely changes, unlikely changes, and modules is completely recorded in traceability matrices in the SRS and module guide.}
+\item[Maintainable:\phantomsection\label{maintainable}]{If a likely change is made to the finished software, it will take 10$\%$ percent of the original development time, assuming the same development resources are available.}
 \end{itemize}
 \section{Likely Changes}
 \label{Sec:LCs}

--- a/code/stable/ssp/SRS/PDF/SSP_SRS.tex
+++ b/code/stable/ssp/SRS/PDF/SSP_SRS.tex
@@ -2665,7 +2665,7 @@ This section provides the non-functional requirements, the qualities that the so
 \item[Correct:\phantomsection\label{correct}]{The outputs of the code have the properties described in \hyperref[Sec:CorSolProps]{Sec:Properties of a Correct Solution}.}
 \item[Understandable:\phantomsection\label{understandable}]{The code is modularized with complete module guide and module interface specification.}
 \item[Reusable:\phantomsection\label{reusable}]{The code is modularized.}
-\item[Maintainable:\phantomsection\label{maintainable}]{If a likely change is made to the finished software, it will take 10$\%$ percent of the original development time, assuming the same development resources are available.}
+\item[Maintainable:\phantomsection\label{maintainable}]{If a likely change is made to the finished software, it will take 10$\%$ of the original development time, assuming the same development resources are available.}
 \end{itemize}
 \section{Likely Changes}
 \label{Sec:LCs}

--- a/code/stable/swhs/SRS/HTML/SWHS_SRS.html
+++ b/code/stable/swhs/SRS/HTML/SWHS_SRS.html
@@ -3112,7 +3112,7 @@
               <p><div id="reusable">Reusable: The code is modularized.</div></p>
               <p>
                 <div id="maintainable">
-                  Maintainable: The traceability between requirements, assumptions, theoretical models, general definitions, data definitions, instance models, likely changes, unlikely changes, and modules is completely recorded in traceability matrices in the SRS and module guide.
+                  Maintainable: If a likely change is made to the finished software, it will take 10<em>%</em> percent of the original development time, assuming the same development resources are available.
                 </div>
               </p>
             </div>

--- a/code/stable/swhs/SRS/HTML/SWHS_SRS.html
+++ b/code/stable/swhs/SRS/HTML/SWHS_SRS.html
@@ -3112,7 +3112,7 @@
               <p><div id="reusable">Reusable: The code is modularized.</div></p>
               <p>
                 <div id="maintainable">
-                  Maintainable: If a likely change is made to the finished software, it will take 10<em>%</em> percent of the original development time, assuming the same development resources are available.
+                  Maintainable: If a likely change is made to the finished software, it will take 10<em>%</em> of the original development time, assuming the same development resources are available.
                 </div>
               </p>
             </div>

--- a/code/stable/swhs/SRS/HTML/SWHS_SRS.html
+++ b/code/stable/swhs/SRS/HTML/SWHS_SRS.html
@@ -3112,7 +3112,7 @@
               <p><div id="reusable">Reusable: The code is modularized.</div></p>
               <p>
                 <div id="maintainable">
-                  Maintainable: If a likely change is made to the finished software, it will take 10<em>%</em> of the original development time, assuming the same development resources are available.
+                  Maintainable: If a likely change is made to the finished software, it will take at most 10<em>%</em> of the original development time, assuming the same development resources are available.
                 </div>
               </p>
             </div>

--- a/code/stable/swhs/SRS/JSON/SWHS_SRS.ipynb
+++ b/code/stable/swhs/SRS/JSON/SWHS_SRS.ipynb
@@ -2070,7 +2070,7 @@
     "\n",
     "</div>\n",
     "<div id=\\\"maintainable\\\">\n",
-    "Maintainable: If a likely change is made to the finished software, it will take 10$%$ of the original development time, assuming the same development resources are available.\n",
+    "Maintainable: If a likely change is made to the finished software, it will take at most 10$%$ of the original development time, assuming the same development resources are available.\n",
     "\n",
     "</div>\n",
     "\n",

--- a/code/stable/swhs/SRS/JSON/SWHS_SRS.ipynb
+++ b/code/stable/swhs/SRS/JSON/SWHS_SRS.ipynb
@@ -2070,7 +2070,7 @@
     "\n",
     "</div>\n",
     "<div id=\\\"maintainable\\\">\n",
-    "Maintainable: If a likely change is made to the finished software, it will take 10$%$ percent of the original development time, assuming the same development resources are available.\n",
+    "Maintainable: If a likely change is made to the finished software, it will take 10$%$ of the original development time, assuming the same development resources are available.\n",
     "\n",
     "</div>\n",
     "\n",

--- a/code/stable/swhs/SRS/JSON/SWHS_SRS.ipynb
+++ b/code/stable/swhs/SRS/JSON/SWHS_SRS.ipynb
@@ -2070,7 +2070,7 @@
     "\n",
     "</div>\n",
     "<div id=\\\"maintainable\\\">\n",
-    "Maintainable: The traceability between requirements, assumptions, theoretical models, general definitions, data definitions, instance models, likely changes, unlikely changes, and modules is completely recorded in traceability matrices in the SRS and module guide.\n",
+    "Maintainable: If a likely change is made to the finished software, it will take 10$%$ percent of the original development time, assuming the same development resources are available.\n",
     "\n",
     "</div>\n",
     "\n",

--- a/code/stable/swhs/SRS/PDF/SWHS_SRS.tex
+++ b/code/stable/swhs/SRS/PDF/SWHS_SRS.tex
@@ -1587,7 +1587,7 @@ This section provides the non-functional requirements, the qualities that the so
 \item[Verifiable:\phantomsection\label{verifiable}]{The code is tested with complete verification and validation plan.}
 \item[Understandable:\phantomsection\label{understandable}]{The code is modularized with complete module guide and module interface specification.}
 \item[Reusable:\phantomsection\label{reusable}]{The code is modularized.}
-\item[Maintainable:\phantomsection\label{maintainable}]{The traceability between requirements, assumptions, theoretical models, general definitions, data definitions, instance models, likely changes, unlikely changes, and modules is completely recorded in traceability matrices in the SRS and module guide.}
+\item[Maintainable:\phantomsection\label{maintainable}]{If a likely change is made to the finished software, it will take 10$\%$ percent of the original development time, assuming the same development resources are available.}
 \end{itemize}
 \section{Likely Changes}
 \label{Sec:LCs}

--- a/code/stable/swhs/SRS/PDF/SWHS_SRS.tex
+++ b/code/stable/swhs/SRS/PDF/SWHS_SRS.tex
@@ -1587,7 +1587,7 @@ This section provides the non-functional requirements, the qualities that the so
 \item[Verifiable:\phantomsection\label{verifiable}]{The code is tested with complete verification and validation plan.}
 \item[Understandable:\phantomsection\label{understandable}]{The code is modularized with complete module guide and module interface specification.}
 \item[Reusable:\phantomsection\label{reusable}]{The code is modularized.}
-\item[Maintainable:\phantomsection\label{maintainable}]{If a likely change is made to the finished software, it will take 10$\%$ of the original development time, assuming the same development resources are available.}
+\item[Maintainable:\phantomsection\label{maintainable}]{If a likely change is made to the finished software, it will take at most 10$\%$ of the original development time, assuming the same development resources are available.}
 \end{itemize}
 \section{Likely Changes}
 \label{Sec:LCs}

--- a/code/stable/swhs/SRS/PDF/SWHS_SRS.tex
+++ b/code/stable/swhs/SRS/PDF/SWHS_SRS.tex
@@ -1587,7 +1587,7 @@ This section provides the non-functional requirements, the qualities that the so
 \item[Verifiable:\phantomsection\label{verifiable}]{The code is tested with complete verification and validation plan.}
 \item[Understandable:\phantomsection\label{understandable}]{The code is modularized with complete module guide and module interface specification.}
 \item[Reusable:\phantomsection\label{reusable}]{The code is modularized.}
-\item[Maintainable:\phantomsection\label{maintainable}]{If a likely change is made to the finished software, it will take 10$\%$ percent of the original development time, assuming the same development resources are available.}
+\item[Maintainable:\phantomsection\label{maintainable}]{If a likely change is made to the finished software, it will take 10$\%$ of the original development time, assuming the same development resources are available.}
 \end{itemize}
 \section{Likely Changes}
 \label{Sec:LCs}

--- a/code/stable/swhsnopcm/SRS/HTML/SWHSNoPCM_SRS.html
+++ b/code/stable/swhsnopcm/SRS/HTML/SWHSNoPCM_SRS.html
@@ -1894,7 +1894,7 @@
               <p><div id="reusable">Reusable: The code is modularized.</div></p>
               <p>
                 <div id="maintainable">
-                  Maintainable: The traceability between requirements, assumptions, theoretical models, general definitions, data definitions, instance models, likely changes, unlikely changes, and modules is completely recorded in traceability matrices in the SRS and module guide.
+                  Maintainable: If a likely change is made to the finished software, it will take 10<em>%</em> percent of the original development time, assuming the same development resources are available.
                 </div>
               </p>
             </div>

--- a/code/stable/swhsnopcm/SRS/HTML/SWHSNoPCM_SRS.html
+++ b/code/stable/swhsnopcm/SRS/HTML/SWHSNoPCM_SRS.html
@@ -1894,7 +1894,7 @@
               <p><div id="reusable">Reusable: The code is modularized.</div></p>
               <p>
                 <div id="maintainable">
-                  Maintainable: If a likely change is made to the finished software, it will take 10<em>%</em> of the original development time, assuming the same development resources are available.
+                  Maintainable: If a likely change is made to the finished software, it will take at most 10<em>%</em> of the original development time, assuming the same development resources are available.
                 </div>
               </p>
             </div>

--- a/code/stable/swhsnopcm/SRS/HTML/SWHSNoPCM_SRS.html
+++ b/code/stable/swhsnopcm/SRS/HTML/SWHSNoPCM_SRS.html
@@ -1894,7 +1894,7 @@
               <p><div id="reusable">Reusable: The code is modularized.</div></p>
               <p>
                 <div id="maintainable">
-                  Maintainable: If a likely change is made to the finished software, it will take 10<em>%</em> percent of the original development time, assuming the same development resources are available.
+                  Maintainable: If a likely change is made to the finished software, it will take 10<em>%</em> of the original development time, assuming the same development resources are available.
                 </div>
               </p>
             </div>

--- a/code/stable/swhsnopcm/SRS/JSON/SWHSNoPCM_SRS.ipynb
+++ b/code/stable/swhsnopcm/SRS/JSON/SWHSNoPCM_SRS.ipynb
@@ -1214,7 +1214,7 @@
     "\n",
     "</div>\n",
     "<div id=\\\"maintainable\\\">\n",
-    "Maintainable: If a likely change is made to the finished software, it will take 10$%$ of the original development time, assuming the same development resources are available.\n",
+    "Maintainable: If a likely change is made to the finished software, it will take at most 10$%$ of the original development time, assuming the same development resources are available.\n",
     "\n",
     "</div>\n",
     "\n",

--- a/code/stable/swhsnopcm/SRS/JSON/SWHSNoPCM_SRS.ipynb
+++ b/code/stable/swhsnopcm/SRS/JSON/SWHSNoPCM_SRS.ipynb
@@ -1214,7 +1214,7 @@
     "\n",
     "</div>\n",
     "<div id=\\\"maintainable\\\">\n",
-    "Maintainable: The traceability between requirements, assumptions, theoretical models, general definitions, data definitions, instance models, likely changes, unlikely changes, and modules is completely recorded in traceability matrices in the SRS and module guide.\n",
+    "Maintainable: If a likely change is made to the finished software, it will take 10$%$ percent of the original development time, assuming the same development resources are available.\n",
     "\n",
     "</div>\n",
     "\n",

--- a/code/stable/swhsnopcm/SRS/JSON/SWHSNoPCM_SRS.ipynb
+++ b/code/stable/swhsnopcm/SRS/JSON/SWHSNoPCM_SRS.ipynb
@@ -1214,7 +1214,7 @@
     "\n",
     "</div>\n",
     "<div id=\\\"maintainable\\\">\n",
-    "Maintainable: If a likely change is made to the finished software, it will take 10$%$ percent of the original development time, assuming the same development resources are available.\n",
+    "Maintainable: If a likely change is made to the finished software, it will take 10$%$ of the original development time, assuming the same development resources are available.\n",
     "\n",
     "</div>\n",
     "\n",

--- a/code/stable/swhsnopcm/SRS/PDF/SWHSNoPCM_SRS.tex
+++ b/code/stable/swhsnopcm/SRS/PDF/SWHSNoPCM_SRS.tex
@@ -941,7 +941,7 @@ This section provides the non-functional requirements, the qualities that the so
 \item[Verifiable:\phantomsection\label{verifiable}]{The code is tested with complete verification and validation plan.}
 \item[Understandable:\phantomsection\label{understandable}]{The code is modularized with complete module guide and module interface specification.}
 \item[Reusable:\phantomsection\label{reusable}]{The code is modularized.}
-\item[Maintainable:\phantomsection\label{maintainable}]{If a likely change is made to the finished software, it will take 10$\%$ of the original development time, assuming the same development resources are available.}
+\item[Maintainable:\phantomsection\label{maintainable}]{If a likely change is made to the finished software, it will take at most 10$\%$ of the original development time, assuming the same development resources are available.}
 \end{itemize}
 \section{Likely Changes}
 \label{Sec:LCs}

--- a/code/stable/swhsnopcm/SRS/PDF/SWHSNoPCM_SRS.tex
+++ b/code/stable/swhsnopcm/SRS/PDF/SWHSNoPCM_SRS.tex
@@ -941,7 +941,7 @@ This section provides the non-functional requirements, the qualities that the so
 \item[Verifiable:\phantomsection\label{verifiable}]{The code is tested with complete verification and validation plan.}
 \item[Understandable:\phantomsection\label{understandable}]{The code is modularized with complete module guide and module interface specification.}
 \item[Reusable:\phantomsection\label{reusable}]{The code is modularized.}
-\item[Maintainable:\phantomsection\label{maintainable}]{The traceability between requirements, assumptions, theoretical models, general definitions, data definitions, instance models, likely changes, unlikely changes, and modules is completely recorded in traceability matrices in the SRS and module guide.}
+\item[Maintainable:\phantomsection\label{maintainable}]{If a likely change is made to the finished software, it will take 10$\%$ percent of the original development time, assuming the same development resources are available.}
 \end{itemize}
 \section{Likely Changes}
 \label{Sec:LCs}

--- a/code/stable/swhsnopcm/SRS/PDF/SWHSNoPCM_SRS.tex
+++ b/code/stable/swhsnopcm/SRS/PDF/SWHSNoPCM_SRS.tex
@@ -941,7 +941,7 @@ This section provides the non-functional requirements, the qualities that the so
 \item[Verifiable:\phantomsection\label{verifiable}]{The code is tested with complete verification and validation plan.}
 \item[Understandable:\phantomsection\label{understandable}]{The code is modularized with complete module guide and module interface specification.}
 \item[Reusable:\phantomsection\label{reusable}]{The code is modularized.}
-\item[Maintainable:\phantomsection\label{maintainable}]{If a likely change is made to the finished software, it will take 10$\%$ percent of the original development time, assuming the same development resources are available.}
+\item[Maintainable:\phantomsection\label{maintainable}]{If a likely change is made to the finished software, it will take 10$\%$ of the original development time, assuming the same development resources are available.}
 \end{itemize}
 \section{Likely Changes}
 \label{Sec:LCs}


### PR DESCRIPTION
Updated the NFR for maintainability to the following description:

> If a likely change is made to the finished software, it will take 10% of the original development time, assuming the same development resources are available.

Change applied to the following examples:

- [GamePhysics](https://jacquescarette.github.io/Drasil/examples/gamephysics/SRS/srs/GamePhysics_SRS.html#Sec:NFRs)
- [GlassBR](https://jacquescarette.github.io/Drasil/examples/glassbr/SRS/srs/GlassBR_SRS.html#Sec:NFRs)
- [NoPCM](https://jacquescarette.github.io/Drasil/examples/nopcm/SRS/srs/NoPCM_SRS.html#Sec:NFRs)
- [PDController](https://jacquescarette.github.io/Drasil/examples/pdcontroller/SRS/srs/PDController_SRS.html#Sec:NFRs)
- [Projectile](https://jacquescarette.github.io/Drasil/examples/projectile/SRS/srs/Projectile_SRS.html#Sec:NFRs)
- [SSP](https://jacquescarette.github.io/Drasil/examples/ssp/SRS/srs/SSP_SRS.html#Sec:NFRs)
- [SWHS](https://jacquescarette.github.io/Drasil/examples/swhs/SRS/srs/SWHS_SRS.html#Sec:NFRs)

TO DO: Instead of hard-coding the "10%", it should be a parameter than can vary at the time of SRS generation.

Contributes to #3288