### PR TITLE
STAN-0202 foldl' #3710

### DIFF
--- a/code/drasil-docLang/lib/Drasil/Sections/TraceabilityMandGs.hs
+++ b/code/drasil-docLang/lib/Drasil/Sections/TraceabilityMandGs.hs
@@ -22,7 +22,7 @@ import SysInfo.Drasil
 import Language.Drasil
 import Language.Drasil.Chunk.Concept.NamedCombinators as NC
 import Language.Drasil.Sentence.Combinators as S
-import Data.Foldable(foldl')
+import Data.Foldable (foldl')
 
 -- | Makes a Traceability Table/Matrix that contains Items of Different Sections.
 generateTraceTable :: SystemInformation -> LabelledContent

--- a/code/drasil-docLang/lib/Drasil/Sections/TraceabilityMandGs.hs
+++ b/code/drasil-docLang/lib/Drasil/Sections/TraceabilityMandGs.hs
@@ -22,6 +22,7 @@ import SysInfo.Drasil
 import Language.Drasil
 import Language.Drasil.Chunk.Concept.NamedCombinators as NC
 import Language.Drasil.Sentence.Combinators as S
+import Data.Foldable(foldl')
 
 -- | Makes a Traceability Table/Matrix that contains Items of Different Sections.
 generateTraceTable :: SystemInformation -> LabelledContent
@@ -93,7 +94,7 @@ traceMatOtherReq si = TraceConfig (mkUid "TraceMatAllvsR") [plural requirement
   plural Doc.genDefn, plural Doc.inModel] (x titleize' +:+ S "and Other" +:+ 
   titleize' item) [tvDataDefns, tvTheoryModels, tvGenDefns, tvInsModels, tvReqs] 
   [tvGoals, tvReqs] where
-    x g = foldl (\a (f,t) -> a `sC'` case traceMReferrers (flip f $ _sysinfodb si) $
+    x g = foldl' (\a (f,t) -> a `sC'` case traceMReferrers (flip f $ _sysinfodb si) $
       _sysinfodb si of
       [] -> mempty
       _ -> g t) mempty [(tvReqs, requirement), (tvGoals, goalStmt)]

--- a/code/drasil-gool/lib/GOOL/Drasil/State.hs
+++ b/code/drasil-gool/lib/GOOL/Drasil/State.hs
@@ -41,6 +41,7 @@ import Control.Lens (Lens', (^.), lens, makeLenses, over, set, _1, _2, both, at)
 import Control.Monad.State (State, modify, gets)
 import Data.Char (isDigit)
 import Data.List (nub, delete)
+import Data.Foldable(foldl')
 import Data.Maybe (isNothing, fromMaybe)
 import Data.Map (Map)
 import qualified Data.Map as Map
@@ -348,7 +349,7 @@ addLibImportVS :: String -> ValueState -> ValueState
 addLibImportVS i = over (lensVStoFS . libImports) (\is -> nubSort $ i:is)
 
 addLibImports :: [String] -> MethodState -> MethodState
-addLibImports is s = foldl (flip addLibImport) s is
+addLibImports is s = foldl' (flip addLibImport) s is
 
 getLibImports :: FS [String]
 getLibImports = gets (^. libImports)

--- a/code/drasil-gool/lib/GOOL/Drasil/State.hs
+++ b/code/drasil-gool/lib/GOOL/Drasil/State.hs
@@ -41,7 +41,7 @@ import Control.Lens (Lens', (^.), lens, makeLenses, over, set, _1, _2, both, at)
 import Control.Monad.State (State, modify, gets)
 import Data.Char (isDigit)
 import Data.List (nub, delete)
-import Data.Foldable(foldl')
+import Data.Foldable (foldl')
 import Data.Maybe (isNothing, fromMaybe)
 import Data.Map (Map)
 import qualified Data.Map as Map

--- a/code/drasil-lang/lib/Language/Drasil/Sentence/Fold.hs
+++ b/code/drasil-lang/lib/Language/Drasil/Sentence/Fold.hs
@@ -22,7 +22,7 @@ import Language.Drasil.Sentence
     ( Sentence(S, E, EmptyS, (:+:)), sParen, (+:+), sC, (+:+.), (+:) )
 import qualified Language.Drasil.Sentence.Combinators as S (and_, or_)
 import Utils.Drasil
-import Data.Foldable(foldl')
+import Data.Foldable (foldl')
 -- TODO: This looks like it should be moved to wherever uses it, it's too specific.
 -- | Helper for formatting a list of constraints.
 foldConstraints :: Quantity c => c -> [ConstraintE] -> Sentence

--- a/code/drasil-lang/lib/Language/Drasil/Sentence/Fold.hs
+++ b/code/drasil-lang/lib/Language/Drasil/Sentence/Fold.hs
@@ -22,7 +22,7 @@ import Language.Drasil.Sentence
     ( Sentence(S, E, EmptyS, (:+:)), sParen, (+:+), sC, (+:+.), (+:) )
 import qualified Language.Drasil.Sentence.Combinators as S (and_, or_)
 import Utils.Drasil
-
+import Data.Foldable(foldl')
 -- TODO: This looks like it should be moved to wherever uses it, it's too specific.
 -- | Helper for formatting a list of constraints.
 foldConstraints :: Quantity c => c -> [ConstraintE] -> Sentence
@@ -38,7 +38,7 @@ foldlSent = foldle (+:+) (+:+.) EmptyS
 
 -- | 'foldlSent' but does not add a period.
 foldlSent_ :: [Sentence] -> Sentence
-foldlSent_ = foldl (+:+) EmptyS
+foldlSent_ = foldl' (+:+) EmptyS
 
 -- | 'foldlSent' but ends with colon.
 foldlSentCol :: [Sentence] -> Sentence

--- a/code/drasil-lang/lib/Language/Drasil/UnitLang.hs
+++ b/code/drasil-lang/lib/Language/Drasil/UnitLang.hs
@@ -7,6 +7,7 @@ module Language.Drasil.UnitLang (
   ) where
 
 import Language.Drasil.Symbol (Symbol, compsy)
+import Data.Foldable(foldl')
 
 -- UName for the base cases, otherwise build up.
 -- Probably a 7-vector would be better (less error-prone!)
@@ -30,7 +31,7 @@ fromUDefn (UShift _ s) = s
 -- | Hand-rolled version of compare. Should assume 'USymb' is normalized, so
 -- that some redundant EQ cases can be removed.
 compUSymb :: USymb -> USymb -> Ordering
-compUSymb (US l)  (US m)  = foldl mappend EQ $ zipWith comp l m
+compUSymb (US l)  (US m)  = foldl' mappend EQ $ zipWith comp l m
   where
     comp (s1, i1) (s2, i2) = compsy s1 s2 `mappend` compare i1 i2
 

--- a/code/drasil-lang/lib/Language/Drasil/UnitLang.hs
+++ b/code/drasil-lang/lib/Language/Drasil/UnitLang.hs
@@ -7,7 +7,7 @@ module Language.Drasil.UnitLang (
   ) where
 
 import Language.Drasil.Symbol (Symbol, compsy)
-import Data.Foldable(foldl')
+import Data.Foldable (foldl')
 
 -- UName for the base cases, otherwise build up.
 -- Probably a 7-vector would be better (less error-prone!)

--- a/code/drasil-printers/lib/Language/Drasil/Debug/Print.hs
+++ b/code/drasil-printers/lib/Language/Drasil/Debug/Print.hs
@@ -9,6 +9,7 @@ import           Utils.Drasil (stringList)
 import qualified Data.Map as Map
 import           Control.Lens ((^.), view)
 import           Data.List (nub, sort, sortBy)
+import           Data.Foldable(foldl')
 import           Data.Maybe (fromMaybe)
 import           Data.Bifunctor (second)
 import           Data.Function (on)
@@ -71,8 +72,8 @@ mkTableFromLenses pin@PI { _ckdb = db } tableLens ttle hsNEs =
     ins :: [Int]
     ins = [1..]
 
-    hdr   = foldl (\r l -> r $$ nest (nestNum * snd l) (text $ fst l)) (text "UID")       (zip (map fst namedLenses) ins)
-    col a = foldl (\r l -> r $$ nest (nestNum * snd l) (fst l a)     ) (text $ showUID a) (zip (map snd namedLenses) ins)
+    hdr   = foldl' (\r l -> r $$ nest (nestNum * snd l) (text $ fst l)) (text "UID")       (zip (map fst namedLenses) ins)
+    col a = foldl' (\r l -> r $$ nest (nestNum * snd l) (fst l a)     ) (text $ showUID a) (zip (map snd namedLenses) ins)
 
     chunks = map (fst . snd) (Map.assocs $ tableLens db)
 

--- a/code/drasil-printers/lib/Language/Drasil/Debug/Print.hs
+++ b/code/drasil-printers/lib/Language/Drasil/Debug/Print.hs
@@ -9,7 +9,7 @@ import           Utils.Drasil (stringList)
 import qualified Data.Map as Map
 import           Control.Lens ((^.), view)
 import           Data.List (nub, sort, sortBy)
-import           Data.Foldable(foldl')
+import           Data.Foldable (foldl')
 import           Data.Maybe (fromMaybe)
 import           Data.Bifunctor (second)
 import           Data.Function (on)

--- a/code/drasil-printers/lib/Language/Drasil/TeX/Print.hs
+++ b/code/drasil-printers/lib/Language/Drasil/TeX/Print.hs
@@ -37,7 +37,7 @@ import Language.Drasil.TeX.Monad (D, MathContext(Curr, Math, Text), (%%), ($+$),
   hpunctuate, lub, runPrint, switch, toMath, toText, unPL, vcat, vpunctuate)
 import Language.Drasil.TeX.Preamble (genPreamble)
 import Language.Drasil.Printing.PrintingInformation (PrintingInformation)
-import Data.Foldable(foldl')
+import Data.Foldable (foldl')
 
 -- | Generates a LaTeX document.
 genTeX :: L.Document -> PrintingInformation -> TP.Doc

--- a/code/drasil-printers/lib/Language/Drasil/TeX/Print.hs
+++ b/code/drasil-printers/lib/Language/Drasil/TeX/Print.hs
@@ -37,6 +37,7 @@ import Language.Drasil.TeX.Monad (D, MathContext(Curr, Math, Text), (%%), ($+$),
   hpunctuate, lub, runPrint, switch, toMath, toText, unPL, vcat, vpunctuate)
 import Language.Drasil.TeX.Preamble (genPreamble)
 import Language.Drasil.Printing.PrintingInformation (PrintingInformation)
+import Data.Foldable(foldl')
 
 -- | Generates a LaTeX document.
 genTeX :: L.Document -> PrintingInformation -> TP.Doc
@@ -315,7 +316,7 @@ pUnit (L.US ls) = formatu t b
     pow (n,1) = p_symb n
     pow (n,p) = toMath $ superscript (p_symb n) (pure $ text $ show p)
     -- printing of unit symbols is done weirdly... FIXME?
-    p_symb (LD.Concat s) = foldl (<>) empty $ map p_symb s
+    p_symb (LD.Concat s) = foldl' (<>) empty $ map p_symb s
     p_symb n = let cn = symbolNeeds n in switch (const cn) $ pExpr $ I.symbol n
 
 -----------------------------------------------------------------


### PR DESCRIPTION
In large Haskell projects, using `foldl'` can help improve performance and reduce memory usage, making your code more efficient.  In large data structures, using `foldl` can lead to space leaks and stack overflows because it builds up thunks that represent the unevaluated computations of each step. `foldl'` avoids this problem by immediately evaluating the accumulator at each step, which can significantly reduce memory usage for large data structures.