### PR TITLE
Added good precedence to Monad.hs

### DIFF
--- a/code/drasil-printers/lib/Language/Drasil/TeX/Monad.hs
+++ b/code/drasil-printers/lib/Language/Drasil/TeX/Monad.hs
@@ -85,10 +85,12 @@ instance Monoid (PrintLaTeX TP.Doc) where
 
 -- may revisit later
 -- | Since Text.PrettyPrint steals <>, use %% instead for $$.
+infixl 5 %%
 (%%) :: D -> D -> D
 (%%) = liftA2 (TP.$$)
 
 -- | Lifts Text.PrettyPrint's $+$. Above, with no overlapping. Associative.
+infixr 6 $+$
 ($+$) :: D -> D -> D
 ($+$) = liftA2 (TP.$+$)
 


### PR DESCRIPTION
Fixes #3759. In some files like Monad.hs we should add 'infix[l|r]' declaration to the operator with explicit precedence rather than giving the operator the default of 9. 
![image](https://github.com/JacquesCarette/Drasil/assets/106560551/660bffcc-1f00-4d41-8f82-5301f61f6ba2)
![image](https://github.com/JacquesCarette/Drasil/assets/106560551/f746e1f5-7a63-4e3f-98a0-4e9a0e70968e)
