### PR TITLE
Update Haskell installation script in GH Workflow

### DIFF
--- a/.github/workflows/Build.yaml
+++ b/.github/workflows/Build.yaml
@@ -45,7 +45,7 @@ jobs:
         run: sudo apt-get install -y --fix-missing libgmp-dev python3 graphviz doxygen fonts-lmodern texlive-bibtex-extra texlive-latex-extra texlive-science texlive-xetex texlive-luatex g++ default-jdk mono-devel inkscape
 
       - name: "Install Stack"
-        uses: haskell/actions/setup@v2
+        uses: haskell-actions/setup@v2
         with:
           enable-stack: true
           stack-no-global: true


### PR DESCRIPTION
`haskell/actions/setup` is deprecated, but there is a maintained fork: `haskell-actions/setup`