### PR TITLE
Fixed type signatures in `InternalListFunc` typeclass

### DIFF
--- a/code/drasil-code/lib/Language/Drasil/Code/Imperative/DrasilState.hs
+++ b/code/drasil-code/lib/Language/Drasil/Code/Imperative/DrasilState.hs
@@ -199,7 +199,7 @@ getConstantsCls chs cs = cnCls (constStructure $ dataInfo chs) (inputStructure $
   where cnCls (Store Bundled) _ = zipCs Constants
         cnCls WithInputs Bundled = zipCs InputParameters
         cnCls _ _ = []
-        zipCs ic = zip (map codeName cs) $ repeat (icNames chs ic)
+        zipCs ic = map ((, icNames chs ic) . codeName) cs
 
 -- | Get derived input functions (for @derived_values@).
 -- If there are no derived inputs, a derived inputs function is not generated.

--- a/code/drasil-gool/lib/GOOL/Drasil/ClassInterface.hs
+++ b/code/drasil-gool/lib/GOOL/Drasil/ClassInterface.hs
@@ -346,12 +346,23 @@ class (ValueSym r, VariableSym r) => GetSet r where
   set :: SValue r -> SVariable r -> SValue r -> SValue r
 
 class (ValueSym r) => List r where
+  -- | Finds the size of a list.
+  --   Arguments are: List
   listSize   :: SValue r -> SValue r
+  -- | Inserts a value into a list.
+  --   Arguments are: List, Index, Value
   listAdd    :: SValue r -> SValue r -> SValue r -> SValue r
+  -- | Appens a value to a list.
+  --   Arguments are: List, Value
   listAppend :: SValue r -> SValue r -> SValue r
+  -- | Gets the value of an index of a list.
+  --   Arguments are: List, Index
   listAccess :: SValue r -> SValue r -> SValue r
+  -- | Sets the value of an index of a list.
+  --   Arguments are: List, Index, Value
   listSet    :: SValue r -> SValue r -> SValue r -> SValue r
-  
+  -- | Finds the index of the first occurrence of a value in a list.
+  --   Arguments are: List, Value
   indexOf :: SValue r -> SValue r -> SValue r
 
 class (ValueSym r) => InternalList r where

--- a/code/drasil-gool/lib/GOOL/Drasil/LanguageRenderer/CLike.hs
+++ b/code/drasil-gool/lib/GOOL/Drasil/LanguageRenderer/CLike.hs
@@ -121,7 +121,7 @@ libNewObjMixedArgs l tp vs ns = modify (addLibImportVS l) >>
 -- Functions --
 
 listSize :: (RenderSym r) => SValue r -> SValue r
-listSize v = v $. S.listSizeFunc
+listSize v = v $. S.listSizeFunc v
 
 -- Statements --
 

--- a/code/drasil-gool/lib/GOOL/Drasil/LanguageRenderer/CSharpRenderer.hs
+++ b/code/drasil-gool/lib/GOOL/Drasil/LanguageRenderer/CSharpRenderer.hs
@@ -414,9 +414,9 @@ instance InternalGetSet CSharpCode where
   setFunc = G.setFunc
 
 instance InternalListFunc CSharpCode where
-  listSizeFunc = funcFromData (R.func csListSize) int
+  listSizeFunc _ = funcFromData (R.func csListSize) int
   listAddFunc _ = CP.listAddFunc csListAdd
-  listAppendFunc = G.listAppendFunc csListAppend
+  listAppendFunc _ = G.listAppendFunc csListAppend
   listAccessFunc = CP.listAccessFunc
   listSetFunc = CP.listSetFunc R.listSetFunc
 

--- a/code/drasil-gool/lib/GOOL/Drasil/LanguageRenderer/CppRenderer.hs
+++ b/code/drasil-gool/lib/GOOL/Drasil/LanguageRenderer/CppRenderer.hs
@@ -436,9 +436,9 @@ instance (Pair p) => InternalGetSet (p CppSrcCode CppHdrCode) where
   setFunc = pair3 setFunc setFunc
 
 instance (Pair p) => InternalListFunc (p CppSrcCode CppHdrCode) where  
-  listSizeFunc = on2StateValues pair listSizeFunc listSizeFunc
+  listSizeFunc = pair1 listSizeFunc listSizeFunc
   listAddFunc = pair3 listAddFunc listAddFunc
-  listAppendFunc = pair1 listAppendFunc listAppendFunc
+  listAppendFunc = pair2 listAppendFunc listAppendFunc
   listAccessFunc = pair2 listAccessFunc listAccessFunc
   listSetFunc = pair3 listSetFunc listSetFunc
 
@@ -1322,9 +1322,9 @@ instance InternalGetSet CppSrcCode where
   setFunc = G.setFunc
 
 instance InternalListFunc CppSrcCode where
-  listSizeFunc = CP.listSizeFunc
+  listSizeFunc _ = CP.listSizeFunc
   listAddFunc = cppListAddFunc
-  listAppendFunc = G.listAppendFunc cppListAppend
+  listAppendFunc _ = G.listAppendFunc cppListAppend
   listAccessFunc = CP.listAccessFunc' cppListAccess
   listSetFunc = CP.listSetFunc cppListSetDoc
 
@@ -1986,9 +1986,9 @@ instance InternalGetSet CppHdrCode where
   setFunc _ _ _ = funcFromData empty void
 
 instance InternalListFunc CppHdrCode where
-  listSizeFunc = funcFromData empty void
+  listSizeFunc _ = funcFromData empty void
   listAddFunc _ _ _ = funcFromData empty void
-  listAppendFunc _ = funcFromData empty void
+  listAppendFunc _ _ = funcFromData empty void
   listAccessFunc _ _ = funcFromData empty void
   listSetFunc _ _ _ = funcFromData empty void
 

--- a/code/drasil-gool/lib/GOOL/Drasil/LanguageRenderer/JavaRenderer.hs
+++ b/code/drasil-gool/lib/GOOL/Drasil/LanguageRenderer/JavaRenderer.hs
@@ -445,9 +445,9 @@ instance InternalGetSet JavaCode where
   setFunc = G.setFunc
 
 instance InternalListFunc JavaCode where
-  listSizeFunc = CP.listSizeFunc
+  listSizeFunc _ = CP.listSizeFunc
   listAddFunc _ = CP.listAddFunc jListAdd
-  listAppendFunc = G.listAppendFunc jListAdd
+  listAppendFunc _ = G.listAppendFunc jListAdd
   listAccessFunc = CP.listAccessFunc' jListAccess
   listSetFunc = jListSetFunc
 

--- a/code/drasil-gool/lib/GOOL/Drasil/LanguageRenderer/LanguagePolymorphic.hs
+++ b/code/drasil-gool/lib/GOOL/Drasil/LanguageRenderer/LanguagePolymorphic.hs
@@ -275,7 +275,7 @@ listAdd :: (RenderSym r) => SValue r -> SValue r -> SValue r -> SValue r
 listAdd v i vToAdd = v $. S.listAddFunc v i vToAdd
 
 listAppend :: (RenderSym r) => SValue r -> SValue r -> SValue r
-listAppend v vToApp = v $. S.listAppendFunc vToApp
+listAppend v vToApp = v $. S.listAppendFunc v vToApp
 
 listAccess :: (RenderSym r) => SValue r -> SValue r -> SValue r
 listAccess v i = do

--- a/code/drasil-gool/lib/GOOL/Drasil/LanguageRenderer/PythonRenderer.hs
+++ b/code/drasil-gool/lib/GOOL/Drasil/LanguageRenderer/PythonRenderer.hs
@@ -407,8 +407,8 @@ instance GetSet PythonCode where
   set = G.set
 
 instance List PythonCode where
-  listSize = on2StateWrapped(\f v-> mkVal (functionType f) 
-    (pyListSize (RC.value v) (RC.function f))) listSizeFunc
+  listSize l = on2StateWrapped(\f v -> mkVal (functionType f) 
+    (pyListSize (RC.value v) (RC.function f))) (listSizeFunc l) l
   listAdd = G.listAdd
   listAppend = G.listAppend
   listAccess = G.listAccess
@@ -424,9 +424,9 @@ instance InternalGetSet PythonCode where
   setFunc = G.setFunc
 
 instance InternalListFunc PythonCode where
-  listSizeFunc = funcFromData pyListSizeFunc int
+  listSizeFunc _ = funcFromData pyListSizeFunc int --TODO: update this
   listAddFunc _ = CP.listAddFunc pyInsert
-  listAppendFunc = G.listAppendFunc pyAppendFunc
+  listAppendFunc _ = G.listAppendFunc pyAppendFunc
   listAccessFunc = CP.listAccessFunc
   listSetFunc = CP.listSetFunc R.listSetFunc
 

--- a/code/drasil-gool/lib/GOOL/Drasil/LanguageRenderer/PythonRenderer.hs
+++ b/code/drasil-gool/lib/GOOL/Drasil/LanguageRenderer/PythonRenderer.hs
@@ -407,8 +407,9 @@ instance GetSet PythonCode where
   set = G.set
 
 instance List PythonCode where
-  listSize l = on2StateWrapped(\f v -> mkVal (functionType f) 
-    (pyListSize (RC.value v) (RC.function f))) (listSizeFunc l) l
+  listSize l = do
+    f <- listSizeFunc l
+    mkVal (functionType f) (RC.function f)
   listAdd = G.listAdd
   listAppend = G.listAppend
   listAccess = G.listAccess
@@ -424,7 +425,9 @@ instance InternalGetSet PythonCode where
   setFunc = G.setFunc
 
 instance InternalListFunc PythonCode where
-  listSizeFunc _ = funcFromData pyListSizeFunc int --TODO: update this
+  listSizeFunc l = do
+    f <- funcApp pyListSize int [l]
+    funcFromData (RC.value f) int
   listAddFunc _ = CP.listAddFunc pyInsert
   listAppendFunc _ = G.listAppendFunc pyAppendFunc
   listAccessFunc = CP.listAccessFunc
@@ -775,13 +778,13 @@ pyPi = text $ pyMath `access` piLabel
 pySys :: String
 pySys = "sys"
 
-pyInputFunc, pyPrintFunc, pyListSizeFunc :: Doc
+pyInputFunc, pyPrintFunc :: Doc
 pyInputFunc = text "input()" -- raw_input() for < Python 3.0
 pyPrintFunc = text printLabel
-pyListSizeFunc = text "len"
 
-pyIndex, pyInsert, pyAppendFunc, pyReadline, pyReadlines, pyOpen, pyClose, 
+pyListSize, pyIndex, pyInsert, pyAppendFunc, pyReadline, pyReadlines, pyOpen, pyClose, 
   pyRead, pyWrite, pyAppend, pySplit, pyRange, pyRstrip, pyMath :: String
+pyListSize = "len"
 pyIndex = "index"
 pyInsert = "insert"
 pyAppendFunc = "append"
@@ -895,9 +898,6 @@ pyInlineIf c' v1' v2' = do
 
 pyLambda :: (RenderSym r) => [r (Variable r)] -> r (Value r) -> Doc
 pyLambda ps ex = pyLambdaDec <+> variableList ps <> colon <+> RC.value ex
-
-pyListSize :: Doc -> Doc -> Doc
-pyListSize v f = f <> parens v
 
 pyStringType :: (RenderSym r) => VSType r
 pyStringType = typeFromData String pyString (text pyString)

--- a/code/drasil-gool/lib/GOOL/Drasil/LanguageRenderer/SwiftRenderer.hs
+++ b/code/drasil-gool/lib/GOOL/Drasil/LanguageRenderer/SwiftRenderer.hs
@@ -431,11 +431,11 @@ instance InternalGetSet SwiftCode where
   setFunc = G.setFunc
 
 instance InternalListFunc SwiftCode where
-  listSizeFunc = funcFromData (R.func swiftListSize) int
+  listSizeFunc _ = funcFromData (R.func swiftListSize) int
   listAddFunc _ i v = do
     f <- swiftListAddFunc i v 
     funcFromData (R.func (RC.value f)) (pure $ valueType f)
-  listAppendFunc = G.listAppendFunc swiftListAppend
+  listAppendFunc _ = G.listAppendFunc swiftListAppend
   listAccessFunc = CP.listAccessFunc
   listSetFunc = CP.listSetFunc R.listSetFunc
 

--- a/code/drasil-gool/lib/GOOL/Drasil/RendererClasses.hs
+++ b/code/drasil-gool/lib/GOOL/Drasil/RendererClasses.hs
@@ -172,9 +172,9 @@ class InternalGetSet r where
   setFunc :: VSType r -> SVariable r -> SValue r -> VSFunction r
 
 class InternalListFunc r where
-  listSizeFunc   :: VSFunction r
+  listSizeFunc   :: SValue r -> VSFunction r
   listAddFunc    :: SValue r -> SValue r -> SValue r -> VSFunction r
-  listAppendFunc :: SValue r -> VSFunction r
+  listAppendFunc :: SValue r -> SValue r -> VSFunction r
   listAccessFunc :: VSType r -> SValue r -> VSFunction r
   listSetFunc    :: SValue r -> SValue r -> SValue r -> VSFunction r
 


### PR DESCRIPTION
I noticed that the `listSizeFunc` and `listAppendFunc` methods of the `InternalListFunc` typeclass don't take the list as their parameter.  This is likely because in the OO renderers, these functions are used for everything after the dot (e.g. `l.size()`).  For the Python renderer this already requires a bit of a hack for `listSizeFunc`, as `len` is a function rather than a method in Python.  As we are adding procedural languages this will come up much more often, so I would like to avoid that hack.

These changes will make things much simpler and cleaner as we implement lists in procedural renderers.  This will also help with #3746.