### PR TITLE
Add support for 1-indexed languages

### DIFF
--- a/code/drasil-code/lib/Language/Drasil/Code/Imperative/DrasilState.hs
+++ b/code/drasil-code/lib/Language/Drasil/Code/Imperative/DrasilState.hs
@@ -199,7 +199,7 @@ getConstantsCls chs cs = cnCls (constStructure $ dataInfo chs) (inputStructure $
   where cnCls (Store Bundled) _ = zipCs Constants
         cnCls WithInputs Bundled = zipCs InputParameters
         cnCls _ _ = []
-        zipCs ic = zip (map codeName cs) $ repeat (icNames chs ic)
+        zipCs ic = map ((, icNames chs ic) . codeName) cs
 
 -- | Get derived input functions (for @derived_values@).
 -- If there are no derived inputs, a derived inputs function is not generated.

--- a/code/drasil-gool/lib/GOOL/Drasil/ClassInterface.hs
+++ b/code/drasil-gool/lib/GOOL/Drasil/ClassInterface.hs
@@ -346,12 +346,23 @@ class (ValueSym r, VariableSym r) => GetSet r where
   set :: SValue r -> SVariable r -> SValue r -> SValue r
 
 class (ValueSym r) => List r where
+  -- | Finds the size of a list.
+  --   Arguments are: List
   listSize   :: SValue r -> SValue r
+  -- | Inserts a value into a list.
+  --   Arguments are: List, Index, Value
   listAdd    :: SValue r -> SValue r -> SValue r -> SValue r
+  -- | Appens a value to a list.
+  --   Arguments are: List, Value
   listAppend :: SValue r -> SValue r -> SValue r
+  -- | Gets the value of an index of a list.
+  --   Arguments are: List, Index
   listAccess :: SValue r -> SValue r -> SValue r
+  -- | Sets the value of an index of a list.
+  --   Arguments are: List, Index, Value
   listSet    :: SValue r -> SValue r -> SValue r -> SValue r
-  
+  -- | Finds the index of the first occurrence of a value in a list.
+  --   Arguments are: List, Value
   indexOf :: SValue r -> SValue r -> SValue r
 
 class (ValueSym r) => InternalList r where

--- a/code/drasil-gool/lib/GOOL/Drasil/ClassInterface.hs
+++ b/code/drasil-gool/lib/GOOL/Drasil/ClassInterface.hs
@@ -16,7 +16,7 @@ module GOOL.Drasil.ClassInterface (
   extFuncApp, libFuncApp, newObj, extNewObj, libNewObj, exists,
   InternalValueExp(..), objMethodCall, objMethodCallNamedArgs,
   objMethodCallMixedArgs, objMethodCallNoParams, FunctionSym(..), ($.),
-  selfAccess, GetSet(..), List(..), InternalList(..), listSlice,
+  selfAccess, GetSet(..), List(..), IndexingScheme(..), InternalList(..), listSlice,
   listIndexExists, at, ThunkSym(..), VectorType(..), VectorDecl(..),
   VectorThunk(..), VectorExpression(..), ThunkAssign(..), StatementSym(..),
   AssignStatement(..), (&=), assignToListIndex, DeclStatement(..),
@@ -345,7 +345,12 @@ class (ValueSym r, VariableSym r) => GetSet r where
   get :: SValue r -> SVariable r -> SValue r
   set :: SValue r -> SVariable r -> SValue r -> SValue r
 
+data IndexingScheme = ZeroIndexed -- Stores whether the language's list API
+                    | OneIndexed  -- is 0- or 1-indexed.
+
 class (ValueSym r) => List r where
+  type IScheme r
+  indexingScheme :: r (IScheme r)
   -- | Finds the size of a list.
   --   Arguments are: List
   listSize   :: SValue r -> SValue r
@@ -364,6 +369,16 @@ class (ValueSym r) => List r where
   -- | Finds the index of the first occurrence of a value in a list.
   --   Arguments are: List, Value
   indexOf :: SValue r -> SValue r -> SValue r
+
+intToIndex :: (Literal r, NumericExpression r) => 
+  SValue r -> IndexingScheme -> SValue r
+intToIndex i ZeroIndexed = i
+intToIndex i OneIndexed = i #+ (litInt 1)
+
+indexToInt :: (Literal r, NumericExpression r) =>
+  SValue r -> IndexingScheme -> SValue r
+indexToInt i ZeroIndexed = i
+indexToInt i OneIndexed = i #- (litInt 1)
 
 class (ValueSym r) => InternalList r where
   listSlice'      :: Maybe (SValue r) -> Maybe (SValue r) -> Maybe (SValue r) 

--- a/code/drasil-gool/lib/GOOL/Drasil/CodeInfo.hs
+++ b/code/drasil-gool/lib/GOOL/Drasil/CodeInfo.hs
@@ -219,8 +219,8 @@ instance GetSet CodeInfo where
   set v _ = execute2 v
 
 instance List CodeInfo where
-  type IScheme CodeInfo = ()
-  indexingScheme = toCode ()
+  intToIndex = execute1
+  indexToInt = execute1
   listSize   = execute1
   listAdd    = execute3
   listAppend = execute2

--- a/code/drasil-gool/lib/GOOL/Drasil/CodeInfo.hs
+++ b/code/drasil-gool/lib/GOOL/Drasil/CodeInfo.hs
@@ -219,6 +219,8 @@ instance GetSet CodeInfo where
   set v _ = execute2 v
 
 instance List CodeInfo where
+  type IScheme CodeInfo = ()
+  indexingScheme = toCode ()
   listSize   = execute1
   listAdd    = execute3
   listAppend = execute2

--- a/code/drasil-gool/lib/GOOL/Drasil/LanguageRenderer.hs
+++ b/code/drasil-gool/lib/GOOL/Drasil/LanguageRenderer.hs
@@ -17,12 +17,12 @@ module GOOL.Drasil.LanguageRenderer (
   param, method, stateVar, constVar, stateVarList, switch, assign, 
   addAssign, subAssign, increment, decrement, listDec, getTerm, return', 
   comment, var, extVar, arg, classVar, objVar, unOpDocD, unOpDocD', binOpDocD, 
-  binOpDocD', constDecDef, func, cast, listAccessFunc, listSetFunc, objAccess, 
-  castObj, break, continue, static, dynamic, private, public, blockCmt, docCmt, 
-  commentedItem, addComments, FuncDocRenderer, functionDox, ClassDocRenderer,
-  classDox, ModuleDocRenderer, moduleDox, commentedMod, valueList, 
-  variableList, parameterList, namedArgList, prependToBody, appendToBody, 
-  surroundBody, getterName, setterName, intValue
+  binOpDocD', constDecDef, func, cast, listAccessFunc, listSetFunc, 
+  objAccess, castObj, break, continue, static, dynamic, private, public, 
+  blockCmt, docCmt, commentedItem, addComments, FuncDocRenderer, functionDox,
+  ClassDocRenderer, classDox, ModuleDocRenderer, moduleDox, commentedMod, 
+  valueList, variableList, parameterList, namedArgList, prependToBody, 
+  appendToBody, surroundBody, getterName, setterName, intValue
 ) where
 
 import Utils.Drasil (blank, capitalize, indent, indentList, stringList)

--- a/code/drasil-gool/lib/GOOL/Drasil/LanguageRenderer/CLike.hs
+++ b/code/drasil-gool/lib/GOOL/Drasil/LanguageRenderer/CLike.hs
@@ -121,7 +121,7 @@ libNewObjMixedArgs l tp vs ns = modify (addLibImportVS l) >>
 -- Functions --
 
 listSize :: (RenderSym r) => SValue r -> SValue r
-listSize v = v $. S.listSizeFunc
+listSize v = v $. S.listSizeFunc v
 
 -- Statements --
 

--- a/code/drasil-gool/lib/GOOL/Drasil/LanguageRenderer/CSharpRenderer.hs
+++ b/code/drasil-gool/lib/GOOL/Drasil/LanguageRenderer/CSharpRenderer.hs
@@ -414,9 +414,9 @@ instance InternalGetSet CSharpCode where
   setFunc = G.setFunc
 
 instance InternalListFunc CSharpCode where
-  listSizeFunc = funcFromData (R.func csListSize) int
+  listSizeFunc _ = funcFromData (R.func csListSize) int
   listAddFunc _ = CP.listAddFunc csListAdd
-  listAppendFunc = G.listAppendFunc csListAppend
+  listAppendFunc _ = G.listAppendFunc csListAppend
   listAccessFunc = CP.listAccessFunc
   listSetFunc = CP.listSetFunc R.listSetFunc
 

--- a/code/drasil-gool/lib/GOOL/Drasil/LanguageRenderer/CSharpRenderer.hs
+++ b/code/drasil-gool/lib/GOOL/Drasil/LanguageRenderer/CSharpRenderer.hs
@@ -18,9 +18,9 @@ import GOOL.Drasil.ClassInterface (Label, MSBody, VSType, SVariable, SValue,
   CommandLineArgs(..), NumericExpression(..), BooleanExpression(..),
   Comparison(..), ValueExpression(..), funcApp, selfFuncApp, extFuncApp,
   newObj, InternalValueExp(..), objMethodCallNoParams, FunctionSym(..), ($.),
-  GetSet(..), List(..), IndexingScheme(..), InternalList(..), ThunkSym(..), 
-  VectorType(..), VectorDecl(..), VectorThunk(..), VectorExpression(..), 
-  ThunkAssign(..), StatementSym(..), AssignStatement(..), (&=), DeclStatement(..),
+  GetSet(..), List(..), InternalList(..), ThunkSym(..), VectorType(..),
+  VectorDecl(..), VectorThunk(..), VectorExpression(..), ThunkAssign(..),
+  StatementSym(..), AssignStatement(..), (&=), DeclStatement(..), 
   IOStatement(..), StringStatement(..), FuncAppStatement(..),
   CommentStatement(..), ControlStatement(..), StatePattern(..),
   ObserverPattern(..), StrategyPattern(..), ScopeSym(..), ParameterSym(..),
@@ -70,7 +70,7 @@ import qualified GOOL.Drasil.LanguageRenderer.CommonPseudoOO as CP (int,
   mainFunction, buildModule', string, constDecDef, docInOutFunc, bindingError, 
   notNull, listDecDef, destructorError, stateVarDef, constVar, listSetFunc, 
   extraClass, listAccessFunc, doubleRender, openFileR, openFileW, stateVar, 
-  inherit, implements)
+  inherit, implements, intToIndex, indexToInt)
 import qualified GOOL.Drasil.LanguageRenderer.CLike as C (float, double, char, 
   listType, void, notOp, andOp, orOp, self, litTrue, litFalse, litFloat, 
   inlineIf, libFuncAppMixedArgs, libNewObjMixedArgs, listSize, increment1, 
@@ -399,8 +399,8 @@ instance GetSet CSharpCode where
   set = G.set
 
 instance List CSharpCode where
-  type IScheme CSharpCode = IndexingScheme
-  indexingScheme = toCode ZeroIndexed
+  intToIndex = CP.intToIndex
+  indexToInt = CP.indexToInt
   listSize = C.listSize
   listAdd = G.listAdd
   listAppend = G.listAppend

--- a/code/drasil-gool/lib/GOOL/Drasil/LanguageRenderer/CSharpRenderer.hs
+++ b/code/drasil-gool/lib/GOOL/Drasil/LanguageRenderer/CSharpRenderer.hs
@@ -18,9 +18,9 @@ import GOOL.Drasil.ClassInterface (Label, MSBody, VSType, SVariable, SValue,
   CommandLineArgs(..), NumericExpression(..), BooleanExpression(..),
   Comparison(..), ValueExpression(..), funcApp, selfFuncApp, extFuncApp,
   newObj, InternalValueExp(..), objMethodCallNoParams, FunctionSym(..), ($.),
-  GetSet(..), List(..), InternalList(..), ThunkSym(..), VectorType(..),
-  VectorDecl(..), VectorThunk(..), VectorExpression(..), ThunkAssign(..),
-  StatementSym(..), AssignStatement(..), (&=), DeclStatement(..),
+  GetSet(..), List(..), IndexingScheme(..), InternalList(..), ThunkSym(..), 
+  VectorType(..), VectorDecl(..), VectorThunk(..), VectorExpression(..), 
+  ThunkAssign(..), StatementSym(..), AssignStatement(..), (&=), DeclStatement(..),
   IOStatement(..), StringStatement(..), FuncAppStatement(..),
   CommentStatement(..), ControlStatement(..), StatePattern(..),
   ObserverPattern(..), StrategyPattern(..), ScopeSym(..), ParameterSym(..),
@@ -399,6 +399,8 @@ instance GetSet CSharpCode where
   set = G.set
 
 instance List CSharpCode where
+  type IScheme CSharpCode = IndexingScheme
+  indexingScheme = toCode ZeroIndexed
   listSize = C.listSize
   listAdd = G.listAdd
   listAppend = G.listAppend

--- a/code/drasil-gool/lib/GOOL/Drasil/LanguageRenderer/CommonPseudoOO.hs
+++ b/code/drasil-gool/lib/GOOL/Drasil/LanguageRenderer/CommonPseudoOO.hs
@@ -1,15 +1,15 @@
 -- | Implementations defined here are valid in some, but not all, language renderers
-module GOOL.Drasil.LanguageRenderer.CommonPseudoOO (int, constructor, doxFunc, 
-  doxClass, doxMod, docMod', extVar, classVar, objVarSelf, indexOf, listAddFunc, 
-  discardFileLine, intClass, funcType, buildModule, arrayType, pi, printSt, 
-  arrayDec, arrayDecDef, openFileA, forEach, docMain, mainFunction, 
-  buildModule', call', listSizeFunc, listAccessFunc', string, constDecDef, 
-  docInOutFunc, bindingError, extFuncAppMixedArgs, notNull, listDecDef, 
-  destructorError, stateVarDef, constVar, litArray, listSetFunc, extraClass, 
-  listAccessFunc, doubleRender, double, openFileR, openFileW, stateVar, self, 
-  multiAssign, multiReturn, listDec, funcDecDef, inOutCall, forLoopError, 
-  mainBody, inOutFunc, docInOutFunc', boolRender, bool, floatRender, float, stringRender', 
-  string', inherit, implements
+module GOOL.Drasil.LanguageRenderer.CommonPseudoOO (int, constructor, doxFunc,
+  doxClass, doxMod, docMod', functionDoc, extVar, classVar, objVarSelf, indexOf, listAddFunc,
+  discardFileLine, intClass, funcType, buildModule, arrayType, pi, printSt,
+  arrayDec, arrayDecDef, openFileA, forEach, docMain, mainFunction,
+  buildModule', call', listSizeFunc, listAccessFunc', string, constDecDef,
+  docInOutFunc, bindingError, extFuncAppMixedArgs, notNull, listDecDef,
+  destructorError, stateVarDef, constVar, litArray, listSetFunc, extraClass,
+  listAccessFunc, doubleRender, double, openFileR, openFileW, stateVar, self,
+  multiAssign, multiReturn, listDec, funcDecDef, inOutCall, forLoopError,
+  mainBody, inOutFunc, docInOutFunc', boolRender, bool, floatRender, float, stringRender',
+  string', inherit, implements, listSize, listAdd, listAppend
 ) where
 
 import Utils.Drasil (indent, stringList)
@@ -34,27 +34,29 @@ import GOOL.Drasil.RendererClasses (RenderSym, ImportSym(..), RenderBody(..),
   RenderFunction(funcFromData), MethodTypeSym(mType),
   RenderMethod(intMethod, commentedFunc, mthdFromData), ParentSpec, 
   BlockCommentSym(..))
-import qualified GOOL.Drasil.RendererClasses as S (RenderBody(multiBody), 
-  RenderValue(call), RenderStatement(stmt), InternalAssignStmt(multiAssign), 
-  InternalControlStmt(multiReturn), MethodTypeSym(construct), 
-  RenderMethod(intFunc), RenderClass(intClass, inherit), RenderMod(modFromData))
-import qualified GOOL.Drasil.RendererClasses as RC (ImportElim(..), 
-  PermElim(..), BodyElim(..), InternalTypeElim(..), InternalVarElim(variable), 
-  ValueElim(value), StatementElim(statement), ScopeElim(..), MethodElim(..), 
-  StateVarElim(..), ClassElim(..))
-import GOOL.Drasil.Helpers (vibcat, toCode, toState, onCodeValue, onStateValue, 
+import qualified GOOL.Drasil.RendererClasses as S (RenderBody(multiBody),
+  RenderValue(call), RenderStatement(stmt), InternalAssignStmt(multiAssign),
+  InternalControlStmt(multiReturn), MethodTypeSym(construct),
+  RenderMethod(intFunc), RenderClass(intClass, inherit), RenderMod(modFromData),
+  InternalListFunc(listSizeFunc, listAddFunc, listAppendFunc))
+import qualified GOOL.Drasil.RendererClasses as RC (ImportElim(..),
+  PermElim(..), BodyElim(..), InternalTypeElim(..), InternalVarElim(variable),
+  ValueElim(..), StatementElim(statement), ScopeElim(..), MethodElim(..),
+  StateVarElim(..), ClassElim(..), FunctionElim(..))
+import GOOL.Drasil.Helpers (vibcat, toCode, toState, onCodeValue, onStateValue,
   on2StateValues, onStateList)
 import GOOL.Drasil.LanguageRenderer (array', new', args, array, listSep, access,
-  mathFunc, ModuleDocRenderer, FuncDocRenderer, functionDox, classDox, moduleDox, variableList, valueList, intValue)
-import qualified GOOL.Drasil.LanguageRenderer as R (self, self', module', 
+  mathFunc, ModuleDocRenderer, FuncDocRenderer, functionDox, classDox,
+  moduleDox, variableList, valueList, intValue)
+import qualified GOOL.Drasil.LanguageRenderer as R (self, self', module',
   print, stateVar, stateVarList, constDecDef, extVar, listAccessFunc)
 import GOOL.Drasil.LanguageRenderer.Constructors (mkStmt, mkStmtNoEnd, 
   mkStateVal, mkStateVar)
 import GOOL.Drasil.LanguageRenderer.LanguagePolymorphic (classVarCheckStatic,
   call, initStmts, docFunc, docFuncRepr, docClass, docMod)
 import GOOL.Drasil.AST (ScopeTag(..))
-import GOOL.Drasil.State (FS, CS, lensFStoCS, lensFStoMS, lensCStoMS, 
-  lensMStoVS, lensVStoMS, currParameters, getClassName, getLangImports, 
+import GOOL.Drasil.State (FS, CS, lensFStoCS, lensFStoMS, lensCStoMS,
+  lensMStoVS, lensVStoMS, currParameters, getClassName, getLangImports,
   getLibImports, getModuleImports, setClassName, setCurrMain, setMainDoc,
   useVarName)
 
@@ -475,3 +477,22 @@ docCommandSep = ": "
 authorDoc = "Authors"
 dateDoc = "Date"
 noteDoc = "Note"
+paramDoc = "Parameter"
+returnDoc = "Returns"
+
+-- Python, Julia, and MATLAB --
+listSize :: (RenderSym r) => SValue r -> SValue r
+listSize l = do
+  f <- S.listSizeFunc l
+  mkVal (RC.functionType f) (RC.function f)
+
+-- Julia and MATLAB --
+listAdd :: (RenderSym r) => SValue r -> SValue r -> SValue r -> SValue r
+listAdd l i v = do
+  f <- S.listAddFunc l i v
+  mkVal (RC.functionType f) (RC.function f)
+
+listAppend :: (RenderSym r) => SValue r -> SValue r -> SValue r
+listAppend l v = do
+  f <- S.listAppendFunc l v
+  mkVal (RC.functionType f) (RC.function f)

--- a/code/drasil-gool/lib/GOOL/Drasil/LanguageRenderer/CommonPseudoOO.hs
+++ b/code/drasil-gool/lib/GOOL/Drasil/LanguageRenderer/CommonPseudoOO.hs
@@ -74,9 +74,13 @@ import Text.PrettyPrint.HughesPJ (Doc, text, empty, render, (<>), (<+>), parens,
 import Metadata.Drasil.DrasilMetaCall (watermark)
 
 -- Python, Java, C#, C++, and Swift --
+-- | Convert an integer to an index in a 0-indexed language
+--   Since GOOL is 0-indexed, no adjustments need be made
 intToIndex :: SValue r -> SValue r
 intToIndex = id
 
+-- | Convert an index to an integer in a 0-indexed language
+--   Since GOOL is 0-indexed, no adjustments need be made
 indexToInt :: SValue r -> SValue r
 indexToInt = id
 
@@ -488,24 +492,31 @@ dateDoc = "Date"
 noteDoc = "Note"
 
 -- Python, Julia, and MATLAB --
+-- | Call to get the size of a list in a language where this is not a method.
 listSize :: (RenderSym r) => SValue r -> SValue r
 listSize l = do
   f <- S.listSizeFunc l
   mkVal (RC.functionType f) (RC.function f)
 
 -- Julia and MATLAB --
+-- | Call to insert a value into a list in a language where this is not a method.
 listAdd :: (RenderSym r) => SValue r -> SValue r -> SValue r -> SValue r
 listAdd l i v = do
   f <- S.listAddFunc l (S.intToIndex i) v
   mkVal (RC.functionType f) (RC.function f)
 
+-- | Call to append a value to a list in a language where this is not a method.
 listAppend :: (RenderSym r) => SValue r -> SValue r -> SValue r
 listAppend l v = do
   f <- S.listAppendFunc l v
   mkVal (RC.functionType f) (RC.function f)
 
+-- | Convert an integer to an index in a 1-indexed language
+--   Since GOOL is 0-indexed, we need to add 1
 intToIndex' :: (RenderSym r) => SValue r -> SValue r
 intToIndex' = (#+ S.litInt 1)
 
+-- | Convert an index to an integer in a 1-indexed language
+--   Since GOOL is 0-indexed, we need to subtract 1
 indexToInt' :: (RenderSym r) => SValue r -> SValue r
 indexToInt' = (#- S.litInt 1)

--- a/code/drasil-gool/lib/GOOL/Drasil/LanguageRenderer/CommonPseudoOO.hs
+++ b/code/drasil-gool/lib/GOOL/Drasil/LanguageRenderer/CommonPseudoOO.hs
@@ -507,7 +507,7 @@ listAppend l v = do
   mkVal (RC.functionType f) (RC.function f)
 
 intToIndex' :: (RenderSym r) => SValue r -> SValue r
-intToIndex' = (#+ (S.litInt 1))
+intToIndex' = (#+ S.litInt 1)
 
 indexToInt' :: (RenderSym r) => SValue r -> SValue r
-indexToInt' = (#- (S.litInt 1))
+indexToInt' = (#- S.litInt 1)

--- a/code/drasil-gool/lib/GOOL/Drasil/LanguageRenderer/CommonPseudoOO.hs
+++ b/code/drasil-gool/lib/GOOL/Drasil/LanguageRenderer/CommonPseudoOO.hs
@@ -9,25 +9,27 @@ module GOOL.Drasil.LanguageRenderer.CommonPseudoOO (int, constructor, doxFunc,
   listAccessFunc, doubleRender, double, openFileR, openFileW, stateVar, self,
   multiAssign, multiReturn, listDec, funcDecDef, inOutCall, forLoopError,
   mainBody, inOutFunc, docInOutFunc', boolRender, bool, floatRender, float, stringRender',
-  string', inherit, implements, listSize, listAdd, listAppend
+  string', inherit, implements, listSize, listAdd, listAppend, intToIndex,
+  indexToInt, intToIndex', indexToInt'
 ) where
 
 import Utils.Drasil (indent, stringList)
 
 import GOOL.Drasil.CodeType (CodeType(..))
-import GOOL.Drasil.ClassInterface (Label, Library, SFile, MSBody, VSType, 
-  SVariable, SValue, VSFunction, MSStatement, MSParameter, SMethod, CSStateVar, 
-  SClass, FSModule, Initializers, MixedCall, PermanenceSym(..), bodyStatements, 
-  oneLiner, TypeSym(infile, outfile, listInnerType, obj), 
-  TypeElim(getType, getTypeString), VariableElim(variableName, variableType), 
-  ValueSym(valueType), Comparison(..), objMethodCallNoParams, (&=), 
-  ControlStatement(returnStmt), ScopeSym(..), MethodSym(function))
+import GOOL.Drasil.ClassInterface (Label, Library, SFile, MSBody, VSType,
+  SVariable, SValue, VSFunction, MSStatement, MSParameter, SMethod, CSStateVar,
+  SClass, FSModule, Initializers, MixedCall, PermanenceSym(..), bodyStatements,
+  oneLiner, TypeSym(infile, outfile, listInnerType, obj),
+  TypeElim(getType, getTypeString), VariableElim(variableName, variableType),
+  ValueSym(valueType), Comparison(..), objMethodCallNoParams, (&=),
+  ControlStatement(returnStmt), ScopeSym(..), MethodSym(function),
+  NumericExpression((#+), (#-)))
 import qualified GOOL.Drasil.ClassInterface as S (
   TypeSym(int, double, string, listType, arrayType, void),
-  VariableSym(var, self, objVar), Literal(litTrue, litFalse, litList), 
-  VariableValue(valueOf), FunctionSym(func, objAccess), StatementSym(valStmt), 
-  DeclStatement(varDec, varDecDef, constDecDef), 
-  ParameterSym(param, pointerParam), MethodSym(mainFunction), 
+  VariableSym(var, self, objVar), Literal(litTrue, litFalse, litList, litInt),
+  VariableValue(valueOf), FunctionSym(func, objAccess), StatementSym(valStmt),
+  DeclStatement(varDec, varDecDef, constDecDef), List(intToIndex, indexToInt),
+  ParameterSym(param, pointerParam), MethodSym(mainFunction),
   ClassSym(buildClass))
 import GOOL.Drasil.RendererClasses (RenderSym, ImportSym(..), RenderBody(..), 
   RenderType(..), RenderVariable(varFromData), InternalVarElim(variableBind), 
@@ -70,6 +72,13 @@ import Control.Lens.Zoom (zoom)
 import Text.PrettyPrint.HughesPJ (Doc, text, empty, render, (<>), (<+>), parens,
   brackets, braces, colon, vcat, equals)
 import Metadata.Drasil.DrasilMetaCall (watermark)
+
+-- Python, Java, C#, C++, and Swift --
+intToIndex :: SValue r -> SValue r
+intToIndex = id
+
+indexToInt :: SValue r -> SValue r
+indexToInt = id
 
 -- Python, Java, C#, and C++ --
 
@@ -114,7 +123,7 @@ objVarSelf :: (RenderSym r) => SVariable r -> SVariable r
 objVarSelf = S.objVar S.self
 
 indexOf :: (RenderSym r) => Label -> SValue r -> SValue r -> SValue r
-indexOf f l v = S.objAccess l (S.func f S.int [v])
+indexOf f l v = S.indexToInt $ S.objAccess l (S.func f S.int [v])
 
 listAddFunc :: (RenderSym r) => Label -> SValue r -> SValue r -> VSFunction r
 listAddFunc f i v = S.func f (S.listType $ onStateValue valueType v) 
@@ -489,10 +498,16 @@ listSize l = do
 -- Julia and MATLAB --
 listAdd :: (RenderSym r) => SValue r -> SValue r -> SValue r -> SValue r
 listAdd l i v = do
-  f <- S.listAddFunc l i v
+  f <- S.listAddFunc l (S.intToIndex i) v
   mkVal (RC.functionType f) (RC.function f)
 
 listAppend :: (RenderSym r) => SValue r -> SValue r -> SValue r
 listAppend l v = do
   f <- S.listAppendFunc l v
   mkVal (RC.functionType f) (RC.function f)
+
+intToIndex' :: (RenderSym r) => SValue r -> SValue r
+intToIndex' = (#+ (S.litInt 1))
+
+indexToInt' :: (RenderSym r) => SValue r -> SValue r
+indexToInt' = (#- (S.litInt 1))

--- a/code/drasil-gool/lib/GOOL/Drasil/LanguageRenderer/CommonPseudoOO.hs
+++ b/code/drasil-gool/lib/GOOL/Drasil/LanguageRenderer/CommonPseudoOO.hs
@@ -486,8 +486,6 @@ docCommandSep = ": "
 authorDoc = "Authors"
 dateDoc = "Date"
 noteDoc = "Note"
-paramDoc = "Parameter"
-returnDoc = "Returns"
 
 -- Python, Julia, and MATLAB --
 listSize :: (RenderSym r) => SValue r -> SValue r

--- a/code/drasil-gool/lib/GOOL/Drasil/LanguageRenderer/CommonPseudoOO.hs
+++ b/code/drasil-gool/lib/GOOL/Drasil/LanguageRenderer/CommonPseudoOO.hs
@@ -1,6 +1,6 @@
 -- | Implementations defined here are valid in some, but not all, language renderers
 module GOOL.Drasil.LanguageRenderer.CommonPseudoOO (int, constructor, doxFunc,
-  doxClass, doxMod, docMod', functionDoc, extVar, classVar, objVarSelf, indexOf, listAddFunc,
+  doxClass, doxMod, docMod', extVar, classVar, objVarSelf, indexOf, listAddFunc,
   discardFileLine, intClass, funcType, buildModule, arrayType, pi, printSt,
   arrayDec, arrayDecDef, openFileA, forEach, docMain, mainFunction,
   buildModule', call', listSizeFunc, listAccessFunc', string, constDecDef,
@@ -51,7 +51,7 @@ import GOOL.Drasil.LanguageRenderer (array', new', args, array, listSep, access,
 import qualified GOOL.Drasil.LanguageRenderer as R (self, self', module',
   print, stateVar, stateVarList, constDecDef, extVar, listAccessFunc)
 import GOOL.Drasil.LanguageRenderer.Constructors (mkStmt, mkStmtNoEnd, 
-  mkStateVal, mkStateVar)
+  mkStateVal, mkStateVar, mkVal)
 import GOOL.Drasil.LanguageRenderer.LanguagePolymorphic (classVarCheckStatic,
   call, initStmts, docFunc, docFuncRepr, docClass, docMod)
 import GOOL.Drasil.AST (ScopeTag(..))

--- a/code/drasil-gool/lib/GOOL/Drasil/LanguageRenderer/CppRenderer.hs
+++ b/code/drasil-gool/lib/GOOL/Drasil/LanguageRenderer/CppRenderer.hs
@@ -19,14 +19,14 @@ import GOOL.Drasil.ClassInterface (Label, MSBody, VSType, SVariable, SValue,
   MathConstant(..), VariableValue(..), CommandLineArgs(..),
   NumericExpression(..), BooleanExpression(..), Comparison(..),
   ValueExpression(..), funcApp, selfFuncApp, extFuncApp, InternalValueExp(..),
-  objMethodCall, FunctionSym(..), ($.), GetSet(..), List(..), InternalList(..),
-  ThunkSym(..), VectorType(..), VectorDecl(..), VectorThunk(..),
-  VectorExpression(..), ThunkAssign(..), StatementSym(..), AssignStatement(..),
-  DeclStatement(..), IOStatement(..), StringStatement(..),
-  FuncAppStatement(..), CommentStatement(..), ControlStatement(..), switchAsIf,
-  StatePattern(..), ObserverPattern(..), StrategyPattern(..), ScopeSym(..),
-  ParameterSym(..), MethodSym(..), pubMethod, StateVarSym(..), ClassSym(..),
-  ModuleSym(..))
+  objMethodCall, FunctionSym(..), ($.), GetSet(..), List(..), 
+  IndexingScheme(..), InternalList(..), ThunkSym(..), VectorType(..), 
+  VectorDecl(..), VectorThunk(..), VectorExpression(..), ThunkAssign(..), 
+  StatementSym(..), AssignStatement(..), DeclStatement(..), IOStatement(..), 
+  StringStatement(..), FuncAppStatement(..), CommentStatement(..), 
+  ControlStatement(..), switchAsIf, StatePattern(..), ObserverPattern(..), 
+  StrategyPattern(..), ScopeSym(..), ParameterSym(..), MethodSym(..), pubMethod, 
+  StateVarSym(..), ClassSym(..), ModuleSym(..))
 import GOOL.Drasil.RendererClasses (RenderSym, RenderFile(..), ImportSym(..), 
   ImportElim, PermElim(binding), RenderBody(..), BodyElim, RenderBlock(..), 
   BlockElim, RenderType(..), InternalTypeElim, UnaryOpSym(..), BinaryOpSym(..), 
@@ -416,6 +416,8 @@ instance (Pair p) => GetSet (p CppSrcCode CppHdrCode) where
   set = pair3 set set
 
 instance (Pair p) => List (p CppSrcCode CppHdrCode) where
+  type IScheme (p CppSrcCode CppHdrCode) = IndexingScheme
+  indexingScheme = pair indexingScheme indexingScheme
   listSize = pair1 listSize listSize
   listAdd = pair3 listAdd listAdd
   listAppend = pair2 listAppend listAppend
@@ -1307,6 +1309,8 @@ instance GetSet CppSrcCode where
   set = G.set
 
 instance List CppSrcCode where
+  type IScheme CppSrcCode = IndexingScheme
+  indexingScheme = toCode ZeroIndexed
   listSize v = cast int (C.listSize v)
   listAdd = G.listAdd
   listAppend = G.listAppend 
@@ -1971,6 +1975,8 @@ instance GetSet CppHdrCode where
   set _ _ _ = mkStateVal void empty
 
 instance List CppHdrCode where
+  type IScheme CppHdrCode = IndexingScheme
+  indexingScheme = toCode ZeroIndexed
   listSize _ = mkStateVal void empty
   listAdd _ _ _ = mkStateVal void empty
   listAppend _ _ = mkStateVal void empty

--- a/code/drasil-gool/lib/GOOL/Drasil/LanguageRenderer/CppRenderer.hs
+++ b/code/drasil-gool/lib/GOOL/Drasil/LanguageRenderer/CppRenderer.hs
@@ -436,9 +436,9 @@ instance (Pair p) => InternalGetSet (p CppSrcCode CppHdrCode) where
   setFunc = pair3 setFunc setFunc
 
 instance (Pair p) => InternalListFunc (p CppSrcCode CppHdrCode) where  
-  listSizeFunc = on2StateValues pair listSizeFunc listSizeFunc
+  listSizeFunc = pair1 listSizeFunc listSizeFunc
   listAddFunc = pair3 listAddFunc listAddFunc
-  listAppendFunc = pair1 listAppendFunc listAppendFunc
+  listAppendFunc = pair2 listAppendFunc listAppendFunc
   listAccessFunc = pair2 listAccessFunc listAccessFunc
   listSetFunc = pair3 listSetFunc listSetFunc
 
@@ -1322,9 +1322,9 @@ instance InternalGetSet CppSrcCode where
   setFunc = G.setFunc
 
 instance InternalListFunc CppSrcCode where
-  listSizeFunc = CP.listSizeFunc
+  listSizeFunc _ = CP.listSizeFunc
   listAddFunc = cppListAddFunc
-  listAppendFunc = G.listAppendFunc cppListAppend
+  listAppendFunc _ = G.listAppendFunc cppListAppend
   listAccessFunc = CP.listAccessFunc' cppListAccess
   listSetFunc = CP.listSetFunc cppListSetDoc
 
@@ -1986,9 +1986,9 @@ instance InternalGetSet CppHdrCode where
   setFunc _ _ _ = funcFromData empty void
 
 instance InternalListFunc CppHdrCode where
-  listSizeFunc = funcFromData empty void
+  listSizeFunc _ = funcFromData empty void
   listAddFunc _ _ _ = funcFromData empty void
-  listAppendFunc _ = funcFromData empty void
+  listAppendFunc _ _ = funcFromData empty void
   listAccessFunc _ _ = funcFromData empty void
   listSetFunc _ _ _ = funcFromData empty void
 

--- a/code/drasil-gool/lib/GOOL/Drasil/LanguageRenderer/CppRenderer.hs
+++ b/code/drasil-gool/lib/GOOL/Drasil/LanguageRenderer/CppRenderer.hs
@@ -20,13 +20,13 @@ import GOOL.Drasil.ClassInterface (Label, MSBody, VSType, SVariable, SValue,
   NumericExpression(..), BooleanExpression(..), Comparison(..),
   ValueExpression(..), funcApp, selfFuncApp, extFuncApp, InternalValueExp(..),
   objMethodCall, FunctionSym(..), ($.), GetSet(..), List(..), 
-  IndexingScheme(..), InternalList(..), ThunkSym(..), VectorType(..), 
-  VectorDecl(..), VectorThunk(..), VectorExpression(..), ThunkAssign(..), 
-  StatementSym(..), AssignStatement(..), DeclStatement(..), IOStatement(..), 
-  StringStatement(..), FuncAppStatement(..), CommentStatement(..), 
-  ControlStatement(..), switchAsIf, StatePattern(..), ObserverPattern(..), 
-  StrategyPattern(..), ScopeSym(..), ParameterSym(..), MethodSym(..), pubMethod, 
-  StateVarSym(..), ClassSym(..), ModuleSym(..))
+  InternalList(..), ThunkSym(..), VectorType(..), VectorDecl(..),
+  VectorThunk(..), VectorExpression(..), ThunkAssign(..), StatementSym(..),
+  AssignStatement(..), DeclStatement(..), IOStatement(..), StringStatement(..),
+  FuncAppStatement(..), CommentStatement(..), ControlStatement(..), switchAsIf,
+  StatePattern(..), ObserverPattern(..), StrategyPattern(..), ScopeSym(..),
+  ParameterSym(..), MethodSym(..), pubMethod, StateVarSym(..), ClassSym(..),
+  ModuleSym(..))
 import GOOL.Drasil.RendererClasses (RenderSym, RenderFile(..), ImportSym(..), 
   ImportElim, PermElim(binding), RenderBody(..), BodyElim, RenderBlock(..), 
   BlockElim, RenderType(..), InternalTypeElim, UnaryOpSym(..), BinaryOpSym(..), 
@@ -71,7 +71,7 @@ import GOOL.Drasil.LanguageRenderer.LanguagePolymorphic (classVarCheckStatic)
 import qualified GOOL.Drasil.LanguageRenderer.CommonPseudoOO as CP (int,
   constructor, doxFunc, doxClass, doxMod, funcType, buildModule, litArray, 
   call', listSizeFunc, listAccessFunc', string, constDecDef, docInOutFunc, 
-  listSetFunc, extraClass)
+  listSetFunc, extraClass, intToIndex, indexToInt)
 import qualified GOOL.Drasil.LanguageRenderer.CLike as C (charRender, float, 
   double, char, listType, void, notOp, andOp, orOp, self, litTrue, litFalse, 
   litFloat, inlineIf, libFuncAppMixedArgs, libNewObjMixedArgs, listSize, 
@@ -416,8 +416,8 @@ instance (Pair p) => GetSet (p CppSrcCode CppHdrCode) where
   set = pair3 set set
 
 instance (Pair p) => List (p CppSrcCode CppHdrCode) where
-  type IScheme (p CppSrcCode CppHdrCode) = IndexingScheme
-  indexingScheme = pair indexingScheme indexingScheme
+  intToIndex = pair1 intToIndex intToIndex
+  indexToInt = pair1 indexToInt indexToInt
   listSize = pair1 listSize listSize
   listAdd = pair3 listAdd listAdd
   listAppend = pair2 listAppend listAppend
@@ -1309,8 +1309,8 @@ instance GetSet CppSrcCode where
   set = G.set
 
 instance List CppSrcCode where
-  type IScheme CppSrcCode = IndexingScheme
-  indexingScheme = toCode ZeroIndexed
+  intToIndex = CP.intToIndex
+  indexToInt = CP.indexToInt
   listSize v = cast int (C.listSize v)
   listAdd = G.listAdd
   listAppend = G.listAppend 
@@ -1975,8 +1975,8 @@ instance GetSet CppHdrCode where
   set _ _ _ = mkStateVal void empty
 
 instance List CppHdrCode where
-  type IScheme CppHdrCode = IndexingScheme
-  indexingScheme = toCode ZeroIndexed
+  intToIndex _ = mkStateVal void empty
+  indexToInt _ = mkStateVal void empty
   listSize _ = mkStateVal void empty
   listAdd _ _ _ = mkStateVal void empty
   listAppend _ _ = mkStateVal void empty

--- a/code/drasil-gool/lib/GOOL/Drasil/LanguageRenderer/JavaRenderer.hs
+++ b/code/drasil-gool/lib/GOOL/Drasil/LanguageRenderer/JavaRenderer.hs
@@ -445,9 +445,9 @@ instance InternalGetSet JavaCode where
   setFunc = G.setFunc
 
 instance InternalListFunc JavaCode where
-  listSizeFunc = CP.listSizeFunc
+  listSizeFunc _ = CP.listSizeFunc
   listAddFunc _ = CP.listAddFunc jListAdd
-  listAppendFunc = G.listAppendFunc jListAdd
+  listAppendFunc _ = G.listAppendFunc jListAdd
   listAccessFunc = CP.listAccessFunc' jListAccess
   listSetFunc = jListSetFunc
 

--- a/code/drasil-gool/lib/GOOL/Drasil/LanguageRenderer/JavaRenderer.hs
+++ b/code/drasil-gool/lib/GOOL/Drasil/LanguageRenderer/JavaRenderer.hs
@@ -18,9 +18,9 @@ import GOOL.Drasil.ClassInterface (Label, MSBody, VSType, SVariable, SValue,
   VariableValue(..), CommandLineArgs(..), NumericExpression(..),
   BooleanExpression(..), Comparison(..), ValueExpression(..), funcApp,
   selfFuncApp, extFuncApp, newObj, InternalValueExp(..), FunctionSym(..), ($.),
-  GetSet(..), List(..), InternalList(..), ThunkSym(..), VectorType(..),
-  VectorDecl(..), VectorThunk(..), VectorExpression(..), ThunkAssign(..),
-  StatementSym(..), AssignStatement(..), (&=), DeclStatement(..),
+  GetSet(..), List(..), IndexingScheme(..), InternalList(..), ThunkSym(..), 
+  VectorType(..), VectorDecl(..), VectorThunk(..), VectorExpression(..), 
+  ThunkAssign(..), StatementSym(..), AssignStatement(..), (&=), DeclStatement(..),
   IOStatement(..), StringStatement(..), FuncAppStatement(..),
   CommentStatement(..), ControlStatement(..), StatePattern(..),
   ObserverPattern(..), StrategyPattern(..), ScopeSym(..), ParameterSym(..),
@@ -430,6 +430,8 @@ instance GetSet JavaCode where
   set = G.set
 
 instance List JavaCode where
+  type IScheme JavaCode = IndexingScheme
+  indexingScheme = toCode ZeroIndexed
   listSize = C.listSize
   listAdd = G.listAdd
   listAppend = G.listAppend

--- a/code/drasil-gool/lib/GOOL/Drasil/LanguageRenderer/JavaRenderer.hs
+++ b/code/drasil-gool/lib/GOOL/Drasil/LanguageRenderer/JavaRenderer.hs
@@ -18,9 +18,9 @@ import GOOL.Drasil.ClassInterface (Label, MSBody, VSType, SVariable, SValue,
   VariableValue(..), CommandLineArgs(..), NumericExpression(..),
   BooleanExpression(..), Comparison(..), ValueExpression(..), funcApp,
   selfFuncApp, extFuncApp, newObj, InternalValueExp(..), FunctionSym(..), ($.),
-  GetSet(..), List(..), IndexingScheme(..), InternalList(..), ThunkSym(..), 
-  VectorType(..), VectorDecl(..), VectorThunk(..), VectorExpression(..), 
-  ThunkAssign(..), StatementSym(..), AssignStatement(..), (&=), DeclStatement(..),
+  GetSet(..), List(..), InternalList(..), ThunkSym(..), VectorType(..),
+  VectorDecl(..), VectorThunk(..), VectorExpression(..), ThunkAssign(..),
+  StatementSym(..), AssignStatement(..), (&=), DeclStatement(..), 
   IOStatement(..), StringStatement(..), FuncAppStatement(..),
   CommentStatement(..), ControlStatement(..), StatePattern(..),
   ObserverPattern(..), StrategyPattern(..), ScopeSym(..), ParameterSym(..),
@@ -74,7 +74,7 @@ import qualified GOOL.Drasil.LanguageRenderer.CommonPseudoOO as CP (int,
   docMain, mainFunction, buildModule', bindingError, listDecDef, 
   destructorError, stateVarDef, constVar, litArray, call', listSizeFunc, 
   listAccessFunc', notNull, doubleRender, double, openFileR, openFileW, 
-  stateVar, floatRender, float, string')
+  stateVar, floatRender, float, string', intToIndex, indexToInt)
 import qualified GOOL.Drasil.LanguageRenderer.CLike as C (float, double, char, 
   listType, void, notOp, andOp, orOp, self, litTrue, litFalse, litFloat, 
   inlineIf, libFuncAppMixedArgs, libNewObjMixedArgs, listSize, increment1, 
@@ -430,8 +430,8 @@ instance GetSet JavaCode where
   set = G.set
 
 instance List JavaCode where
-  type IScheme JavaCode = IndexingScheme
-  indexingScheme = toCode ZeroIndexed
+  intToIndex = CP.intToIndex
+  indexToInt = CP.indexToInt
   listSize = C.listSize
   listAdd = G.listAdd
   listAppend = G.listAppend

--- a/code/drasil-gool/lib/GOOL/Drasil/LanguageRenderer/LanguagePolymorphic.hs
+++ b/code/drasil-gool/lib/GOOL/Drasil/LanguageRenderer/LanguagePolymorphic.hs
@@ -275,7 +275,7 @@ listAdd :: (RenderSym r) => SValue r -> SValue r -> SValue r -> SValue r
 listAdd v i vToAdd = v $. S.listAddFunc v i vToAdd
 
 listAppend :: (RenderSym r) => SValue r -> SValue r -> SValue r
-listAppend v vToApp = v $. S.listAppendFunc vToApp
+listAppend v vToApp = v $. S.listAppendFunc v vToApp
 
 listAccess :: (RenderSym r) => SValue r -> SValue r -> SValue r
 listAccess v i = do

--- a/code/drasil-gool/lib/GOOL/Drasil/LanguageRenderer/LanguagePolymorphic.hs
+++ b/code/drasil-gool/lib/GOOL/Drasil/LanguageRenderer/LanguagePolymorphic.hs
@@ -36,7 +36,7 @@ import qualified GOOL.Drasil.ClassInterface as S (
   litDouble, litString), VariableValue(valueOf), FunctionSym(func),
   List(listSize, listAccess), StatementSym(valStmt), DeclStatement(varDecDef),
   IOStatement(print), ControlStatement(returnStmt, for), ParameterSym(param),
-  MethodSym(method))
+  MethodSym(method), List(intToIndex))
 import GOOL.Drasil.RendererClasses (RenderSym, RenderFile(commentedMod),  
   RenderType(..), InternalVarElim(variableBind), RenderValue(valFromData),
   RenderFunction(funcFromData), FunctionElim(functionType), 
@@ -272,7 +272,7 @@ set :: (RenderSym r) => SValue r -> SVariable r -> SValue r -> SValue r
 set v vToSet toVal = v $. S.setFunc (onStateValue valueType v) vToSet toVal
 
 listAdd :: (RenderSym r) => SValue r -> SValue r -> SValue r -> SValue r
-listAdd v i vToAdd = v $. S.listAddFunc v i vToAdd
+listAdd v i vToAdd = v $. S.listAddFunc v (S.intToIndex i) vToAdd
 
 listAppend :: (RenderSym r) => SValue r -> SValue r -> SValue r
 listAppend v vToApp = v $. S.listAppendFunc v vToApp
@@ -280,15 +280,16 @@ listAppend v vToApp = v $. S.listAppendFunc v vToApp
 listAccess :: (RenderSym r) => SValue r -> SValue r -> SValue r
 listAccess v i = do
   v' <- v
-  let checkType (List _) = S.listAccessFunc (S.listInnerType $ return $ 
-        valueType v') i
-      checkType (Array _) = i >>= (\ix -> funcFromData (brackets (RC.value ix)) 
+  let i' = S.intToIndex i
+      checkType (List _) = S.listAccessFunc (S.listInnerType $ return $ 
+        valueType v') i'
+      checkType (Array _) = i' >>= (\ix -> funcFromData (brackets (RC.value ix)) 
         (S.listInnerType $ return $ valueType v'))
       checkType _ = error "listAccess called on non-list-type value"
   v $. checkType (getType (valueType v'))
 
 listSet :: (RenderSym r) => SValue r -> SValue r -> SValue r -> SValue r
-listSet v i toVal = v $. S.listSetFunc v i toVal
+listSet v i toVal = v $. S.listSetFunc v (S.intToIndex i) toVal
 
 getFunc :: (RenderSym r) => SVariable r -> VSFunction r
 getFunc v = v >>= (\vr -> S.func (getterName $ variableName vr) 

--- a/code/drasil-gool/lib/GOOL/Drasil/LanguageRenderer/Macros.hs
+++ b/code/drasil-gool/lib/GOOL/Drasil/LanguageRenderer/Macros.hs
@@ -17,7 +17,7 @@ import GOOL.Drasil.ClassInterface (Label, MSBody, MSBlock, VSType, SVariable,
 import qualified GOOL.Drasil.ClassInterface as S (BlockSym(block), 
   TypeSym(int, string, listInnerType), VariableSym(var), Literal(litInt), 
   VariableValue(valueOf), ValueExpression(notNull), 
-  List(listSize, listAppend, listAccess), StatementSym(valStmt), 
+  List(listSize, listAppend, listAccess, intToIndex), StatementSym(valStmt), 
   AssignStatement(assign), DeclStatement(varDecDef, listDec), 
   ControlStatement(ifCond, switch, for, forRange))
 import GOOL.Drasil.RendererClasses (RenderSym, RenderValue(cast))
@@ -68,10 +68,12 @@ listSlice b e s vnew vold = do
     v_temp = S.valueOf var_temp
     var_i = S.var l_i S.int
     v_i = S.valueOf var_i
+    begin = S.intToIndex $ (fromMaybe (S.litInt 0) b)
+    end = S.intToIndex $ (fromMaybe (S.listSize vold) e)
   S.block [
     S.listDec 0 var_temp,
-    S.for (S.varDecDef var_i (fromMaybe (S.litInt 0) b))
-      (v_i ?< fromMaybe (S.listSize vold) e) (maybe (var_i &++) (var_i &+=) s)
+    S.for (S.varDecDef var_i begin)
+      (v_i ?< end) (maybe (var_i &++) (var_i &+=) s)
       (oneLiner $ S.valStmt $ S.listAppend v_temp (S.listAccess vold v_i)),
     vnew &= v_temp]
       

--- a/code/drasil-gool/lib/GOOL/Drasil/LanguageRenderer/Macros.hs
+++ b/code/drasil-gool/lib/GOOL/Drasil/LanguageRenderer/Macros.hs
@@ -68,8 +68,8 @@ listSlice b e s vnew vold = do
     v_temp = S.valueOf var_temp
     var_i = S.var l_i S.int
     v_i = S.valueOf var_i
-    begin = S.intToIndex $ (fromMaybe (S.litInt 0) b)
-    end = S.intToIndex $ (fromMaybe (S.listSize vold) e)
+    begin = S.intToIndex $ fromMaybe (S.litInt 0) b
+    end = S.intToIndex $ fromMaybe (S.listSize vold) e
   S.block [
     S.listDec 0 var_temp,
     S.for (S.varDecDef var_i begin)

--- a/code/drasil-gool/lib/GOOL/Drasil/LanguageRenderer/PythonRenderer.hs
+++ b/code/drasil-gool/lib/GOOL/Drasil/LanguageRenderer/PythonRenderer.hs
@@ -17,13 +17,13 @@ import GOOL.Drasil.ClassInterface (Label, Library, VSType, SVariable, SValue,
   NumericExpression(..), BooleanExpression(..), Comparison(..),
   ValueExpression(..), funcApp, selfFuncApp, extFuncApp, extNewObj,
   InternalValueExp(..), objMethodCall, FunctionSym(..), GetSet(..), List(..),
-  IndexingScheme(..), InternalList(..), ThunkSym(..), VectorType(..), 
-  VectorDecl(..), VectorThunk(..), VectorExpression(..), ThunkAssign(..), 
-  StatementSym(..), AssignStatement(..), (&=), DeclStatement(..), 
-  IOStatement(..), StringStatement(..), FuncAppStatement(..), 
-  CommentStatement(..), ControlStatement(..), switchAsIf, StatePattern(..), 
-  ObserverPattern(..), StrategyPattern(..), ScopeSym(..), ParameterSym(..), 
-  MethodSym(..), StateVarSym(..), ClassSym(..), ModuleSym(..))
+  InternalList(..), ThunkSym(..), VectorType(..), VectorDecl(..), 
+  VectorThunk(..), VectorExpression(..), ThunkAssign(..), StatementSym(..), 
+  AssignStatement(..), (&=), DeclStatement(..), IOStatement(..),
+  StringStatement(..), FuncAppStatement(..), CommentStatement(..),
+  ControlStatement(..), switchAsIf, StatePattern(..), ObserverPattern(..),
+  StrategyPattern(..), ScopeSym(..), ParameterSym(..), MethodSym(..),
+  StateVarSym(..), ClassSym(..), ModuleSym(..))
 import GOOL.Drasil.RendererClasses (RenderSym, RenderFile(..), ImportSym(..), 
   ImportElim, PermElim(binding), RenderBody(..), BodyElim, RenderBlock(..), 
   BlockElim, RenderType(..), InternalTypeElim, UnaryOpSym(..), BinaryOpSym(..), 
@@ -68,7 +68,7 @@ import qualified GOOL.Drasil.LanguageRenderer.CommonPseudoOO as CP (int,
   funcType, buildModule, bindingError, notNull, listDecDef, destructorError, 
   stateVarDef, constVar, litArray, listSetFunc, extraClass, listAccessFunc, 
   multiAssign, multiReturn, listDec, funcDecDef, inOutCall, forLoopError, 
-  mainBody, inOutFunc, docInOutFunc', listSize)
+  mainBody, inOutFunc, docInOutFunc', listSize, intToIndex, indexToInt)
 import qualified GOOL.Drasil.LanguageRenderer.Macros as M (ifExists, 
   decrement1, increment1, runStrategy, stringListVals, stringListLists, 
   notifyObservers', checkState)
@@ -407,8 +407,8 @@ instance GetSet PythonCode where
   set = G.set
 
 instance List PythonCode where
-  type IScheme PythonCode = IndexingScheme
-  indexingScheme = toCode ZeroIndexed
+  intToIndex = CP.intToIndex
+  indexToInt = CP.indexToInt
   listSize = CP.listSize
   listAdd = G.listAdd
   listAppend = G.listAppend

--- a/code/drasil-gool/lib/GOOL/Drasil/LanguageRenderer/PythonRenderer.hs
+++ b/code/drasil-gool/lib/GOOL/Drasil/LanguageRenderer/PythonRenderer.hs
@@ -68,7 +68,7 @@ import qualified GOOL.Drasil.LanguageRenderer.CommonPseudoOO as CP (int,
   funcType, buildModule, bindingError, notNull, listDecDef, destructorError, 
   stateVarDef, constVar, litArray, listSetFunc, extraClass, listAccessFunc, 
   multiAssign, multiReturn, listDec, funcDecDef, inOutCall, forLoopError, 
-  mainBody, inOutFunc, docInOutFunc')
+  mainBody, inOutFunc, docInOutFunc', listSize)
 import qualified GOOL.Drasil.LanguageRenderer.Macros as M (ifExists, 
   decrement1, increment1, runStrategy, stringListVals, stringListLists, 
   notifyObservers', checkState)

--- a/code/drasil-gool/lib/GOOL/Drasil/LanguageRenderer/PythonRenderer.hs
+++ b/code/drasil-gool/lib/GOOL/Drasil/LanguageRenderer/PythonRenderer.hs
@@ -407,8 +407,8 @@ instance GetSet PythonCode where
   set = G.set
 
 instance List PythonCode where
-  listSize = on2StateWrapped(\f v-> mkVal (functionType f) 
-    (pyListSize (RC.value v) (RC.function f))) listSizeFunc
+  listSize l = on2StateWrapped(\f v -> mkVal (functionType f) 
+    (pyListSize (RC.value v) (RC.function f))) (listSizeFunc l) l
   listAdd = G.listAdd
   listAppend = G.listAppend
   listAccess = G.listAccess
@@ -424,9 +424,9 @@ instance InternalGetSet PythonCode where
   setFunc = G.setFunc
 
 instance InternalListFunc PythonCode where
-  listSizeFunc = funcFromData pyListSizeFunc int
+  listSizeFunc _ = funcFromData pyListSizeFunc int --TODO: update this
   listAddFunc _ = CP.listAddFunc pyInsert
-  listAppendFunc = G.listAppendFunc pyAppendFunc
+  listAppendFunc _ = G.listAppendFunc pyAppendFunc
   listAccessFunc = CP.listAccessFunc
   listSetFunc = CP.listSetFunc R.listSetFunc
 

--- a/code/drasil-gool/lib/GOOL/Drasil/LanguageRenderer/PythonRenderer.hs
+++ b/code/drasil-gool/lib/GOOL/Drasil/LanguageRenderer/PythonRenderer.hs
@@ -407,8 +407,9 @@ instance GetSet PythonCode where
   set = G.set
 
 instance List PythonCode where
-  listSize l = on2StateWrapped(\f v -> mkVal (functionType f) 
-    (pyListSize (RC.value v) (RC.function f))) (listSizeFunc l) l
+  listSize l = do
+    f <- listSizeFunc l
+    mkVal (functionType f) (RC.function f)
   listAdd = G.listAdd
   listAppend = G.listAppend
   listAccess = G.listAccess
@@ -424,7 +425,9 @@ instance InternalGetSet PythonCode where
   setFunc = G.setFunc
 
 instance InternalListFunc PythonCode where
-  listSizeFunc _ = funcFromData pyListSizeFunc int --TODO: update this
+  listSizeFunc l = do
+    f <- funcApp pyListSize int [l]
+    funcFromData (RC.value f) int
   listAddFunc _ = CP.listAddFunc pyInsert
   listAppendFunc _ = G.listAppendFunc pyAppendFunc
   listAccessFunc = CP.listAccessFunc
@@ -775,13 +778,13 @@ pyPi = text $ pyMath `access` piLabel
 pySys :: String
 pySys = "sys"
 
-pyInputFunc, pyPrintFunc, pyListSizeFunc :: Doc
+pyInputFunc, pyPrintFunc :: Doc
 pyInputFunc = text "input()" -- raw_input() for < Python 3.0
 pyPrintFunc = text printLabel
-pyListSizeFunc = text "len"
 
-pyIndex, pyInsert, pyAppendFunc, pyReadline, pyReadlines, pyOpen, pyClose, 
+pyListSize, pyIndex, pyInsert, pyAppendFunc, pyReadline, pyReadlines, pyOpen, pyClose, 
   pyRead, pyWrite, pyAppend, pySplit, pyRange, pyRstrip, pyMath :: String
+pyListSize = "len"
 pyIndex = "index"
 pyInsert = "insert"
 pyAppendFunc = "append"
@@ -895,9 +898,6 @@ pyInlineIf c' v1' v2' = do
 
 pyLambda :: (RenderSym r) => [r (Variable r)] -> r (Value r) -> Doc
 pyLambda ps ex = pyLambdaDec <+> variableList ps <> colon <+> RC.value ex
-
-pyListSize :: Doc -> Doc -> Doc
-pyListSize v f = f <> parens v
 
 pyStringType :: (RenderSym r) => VSType r
 pyStringType = typeFromData String pyString (text pyString)

--- a/code/drasil-gool/lib/GOOL/Drasil/LanguageRenderer/PythonRenderer.hs
+++ b/code/drasil-gool/lib/GOOL/Drasil/LanguageRenderer/PythonRenderer.hs
@@ -17,13 +17,13 @@ import GOOL.Drasil.ClassInterface (Label, Library, VSType, SVariable, SValue,
   NumericExpression(..), BooleanExpression(..), Comparison(..),
   ValueExpression(..), funcApp, selfFuncApp, extFuncApp, extNewObj,
   InternalValueExp(..), objMethodCall, FunctionSym(..), GetSet(..), List(..),
-  InternalList(..), ThunkSym(..), VectorType(..), VectorDecl(..),
-  VectorThunk(..), VectorExpression(..), ThunkAssign(..), StatementSym(..),
-  AssignStatement(..), (&=), DeclStatement(..), IOStatement(..),
-  StringStatement(..), FuncAppStatement(..), CommentStatement(..),
-  ControlStatement(..), switchAsIf, StatePattern(..), ObserverPattern(..),
-  StrategyPattern(..), ScopeSym(..), ParameterSym(..), MethodSym(..),
-  StateVarSym(..), ClassSym(..), ModuleSym(..))
+  IndexingScheme(..), InternalList(..), ThunkSym(..), VectorType(..), 
+  VectorDecl(..), VectorThunk(..), VectorExpression(..), ThunkAssign(..), 
+  StatementSym(..), AssignStatement(..), (&=), DeclStatement(..), 
+  IOStatement(..), StringStatement(..), FuncAppStatement(..), 
+  CommentStatement(..), ControlStatement(..), switchAsIf, StatePattern(..), 
+  ObserverPattern(..), StrategyPattern(..), ScopeSym(..), ParameterSym(..), 
+  MethodSym(..), StateVarSym(..), ClassSym(..), ModuleSym(..))
 import GOOL.Drasil.RendererClasses (RenderSym, RenderFile(..), ImportSym(..), 
   ImportElim, PermElim(binding), RenderBody(..), BodyElim, RenderBlock(..), 
   BlockElim, RenderType(..), InternalTypeElim, UnaryOpSym(..), BinaryOpSym(..), 
@@ -407,6 +407,8 @@ instance GetSet PythonCode where
   set = G.set
 
 instance List PythonCode where
+  type IScheme PythonCode = IndexingScheme
+  indexingScheme = toCode ZeroIndexed
   listSize = CP.listSize
   listAdd = G.listAdd
   listAppend = G.listAppend

--- a/code/drasil-gool/lib/GOOL/Drasil/LanguageRenderer/PythonRenderer.hs
+++ b/code/drasil-gool/lib/GOOL/Drasil/LanguageRenderer/PythonRenderer.hs
@@ -407,9 +407,7 @@ instance GetSet PythonCode where
   set = G.set
 
 instance List PythonCode where
-  listSize l = do
-    f <- listSizeFunc l
-    mkVal (functionType f) (RC.function f)
+  listSize = CP.listSize
   listAdd = G.listAdd
   listAppend = G.listAppend
   listAccess = G.listAccess

--- a/code/drasil-gool/lib/GOOL/Drasil/LanguageRenderer/SwiftRenderer.hs
+++ b/code/drasil-gool/lib/GOOL/Drasil/LanguageRenderer/SwiftRenderer.hs
@@ -19,14 +19,14 @@ import GOOL.Drasil.ClassInterface (Label, MSBody, MSBlock, VSType, SVariable,
   NumericExpression(..), BooleanExpression(..), Comparison(..),
   ValueExpression(..), funcApp, funcAppNamedArgs, selfFuncApp, extFuncApp,
   newObj, InternalValueExp(..), objMethodCall, objMethodCallNamedArgs,
-  objMethodCallNoParams, FunctionSym(..), ($.), GetSet(..), List(..),
-  listSlice, InternalList(..), ThunkSym(..), VectorType(..), VectorDecl(..),
-  VectorThunk(..), VectorExpression(..), ThunkAssign(..), StatementSym(..),
-  AssignStatement(..), (&=), DeclStatement(..), IOStatement(..),
-  StringStatement(..), FuncAppStatement(..), CommentStatement(..),
-  ControlStatement(..), StatePattern(..), ObserverPattern(..),
-  StrategyPattern(..), ScopeSym(..), ParameterSym(..), MethodSym(..),
-  StateVarSym(..), ClassSym(..), ModuleSym(..), convType)
+  objMethodCallNoParams, FunctionSym(..), ($.), GetSet(..), List(..), 
+  IndexingScheme(..), listSlice, InternalList(..), ThunkSym(..), VectorType(..), 
+  VectorDecl(..), VectorThunk(..), VectorExpression(..), ThunkAssign(..), 
+  StatementSym(..), AssignStatement(..), (&=), DeclStatement(..), 
+  IOStatement(..), StringStatement(..), FuncAppStatement(..), 
+  CommentStatement(..), ControlStatement(..), StatePattern(..), 
+  ObserverPattern(..), StrategyPattern(..), ScopeSym(..), ParameterSym(..), 
+  MethodSym(..), StateVarSym(..), ClassSym(..), ModuleSym(..), convType)
 import GOOL.Drasil.RendererClasses (MSMthdType, RenderSym, 
   RenderFile(..), ImportSym(..), ImportElim, PermElim(binding), RenderBody(..), 
   BodyElim, RenderBlock(..), BlockElim, RenderType(..), InternalTypeElim, 
@@ -415,6 +415,8 @@ instance GetSet SwiftCode where
   set = G.set
 
 instance List SwiftCode where
+  type IScheme SwiftCode = IndexingScheme
+  indexingScheme = toCode ZeroIndexed
   listSize = C.listSize
   listAdd = G.listAdd
   listAppend = G.listAppend

--- a/code/drasil-gool/lib/GOOL/Drasil/LanguageRenderer/SwiftRenderer.hs
+++ b/code/drasil-gool/lib/GOOL/Drasil/LanguageRenderer/SwiftRenderer.hs
@@ -72,7 +72,7 @@ import qualified GOOL.Drasil.LanguageRenderer.CommonPseudoOO as CP (classVar,
   listSetFunc, extraClass, listAccessFunc, doubleRender, double, openFileR, 
   openFileW, self, multiAssign, multiReturn, listDec, funcDecDef, 
   inOutCall, forLoopError, mainBody, inOutFunc, docInOutFunc', bool, float, 
-  stringRender', string', inherit, implements, functionDoc, intToIndex,
+  stringRender', string', inherit, implements, intToIndex,
   indexToInt)
 import qualified GOOL.Drasil.LanguageRenderer.CLike as C (notOp, andOp, orOp, 
   litTrue, litFalse, inlineIf, libFuncAppMixedArgs, libNewObjMixedArgs, 

--- a/code/drasil-gool/lib/GOOL/Drasil/LanguageRenderer/SwiftRenderer.hs
+++ b/code/drasil-gool/lib/GOOL/Drasil/LanguageRenderer/SwiftRenderer.hs
@@ -20,13 +20,13 @@ import GOOL.Drasil.ClassInterface (Label, MSBody, MSBlock, VSType, SVariable,
   ValueExpression(..), funcApp, funcAppNamedArgs, selfFuncApp, extFuncApp,
   newObj, InternalValueExp(..), objMethodCall, objMethodCallNamedArgs,
   objMethodCallNoParams, FunctionSym(..), ($.), GetSet(..), List(..), 
-  IndexingScheme(..), listSlice, InternalList(..), ThunkSym(..), VectorType(..), 
-  VectorDecl(..), VectorThunk(..), VectorExpression(..), ThunkAssign(..), 
-  StatementSym(..), AssignStatement(..), (&=), DeclStatement(..), 
-  IOStatement(..), StringStatement(..), FuncAppStatement(..), 
-  CommentStatement(..), ControlStatement(..), StatePattern(..), 
-  ObserverPattern(..), StrategyPattern(..), ScopeSym(..), ParameterSym(..), 
-  MethodSym(..), StateVarSym(..), ClassSym(..), ModuleSym(..), convType)
+  listSlice, InternalList(..), ThunkSym(..), VectorType(..), VectorDecl(..),
+  VectorThunk(..), VectorExpression(..), ThunkAssign(..), StatementSym(..),
+  AssignStatement(..), (&=), DeclStatement(..), IOStatement(..),
+  StringStatement(..), FuncAppStatement(..), CommentStatement(..),
+  ControlStatement(..), StatePattern(..), ObserverPattern(..), 
+  StrategyPattern(..), ScopeSym(..), ParameterSym(..), MethodSym(..),
+  StateVarSym(..), ClassSym(..), ModuleSym(..), convType)
 import GOOL.Drasil.RendererClasses (MSMthdType, RenderSym, 
   RenderFile(..), ImportSym(..), ImportElim, PermElim(binding), RenderBody(..), 
   BodyElim, RenderBlock(..), BlockElim, RenderType(..), InternalTypeElim, 
@@ -72,7 +72,8 @@ import qualified GOOL.Drasil.LanguageRenderer.CommonPseudoOO as CP (classVar,
   listSetFunc, extraClass, listAccessFunc, doubleRender, double, openFileR, 
   openFileW, self, multiAssign, multiReturn, listDec, funcDecDef, 
   inOutCall, forLoopError, mainBody, inOutFunc, docInOutFunc', bool, float, 
-  stringRender', string', inherit, implements)
+  stringRender', string', inherit, implements, functionDoc, intToIndex,
+  indexToInt)
 import qualified GOOL.Drasil.LanguageRenderer.CLike as C (notOp, andOp, orOp, 
   litTrue, litFalse, inlineIf, libFuncAppMixedArgs, libNewObjMixedArgs, 
   listSize, varDecDef, extObjDecNew, switch, while)
@@ -415,8 +416,8 @@ instance GetSet SwiftCode where
   set = G.set
 
 instance List SwiftCode where
-  type IScheme SwiftCode = IndexingScheme
-  indexingScheme = toCode ZeroIndexed
+  intToIndex = CP.intToIndex
+  indexToInt = CP.indexToInt
   listSize = C.listSize
   listAdd = G.listAdd
   listAppend = G.listAppend

--- a/code/drasil-gool/lib/GOOL/Drasil/LanguageRenderer/SwiftRenderer.hs
+++ b/code/drasil-gool/lib/GOOL/Drasil/LanguageRenderer/SwiftRenderer.hs
@@ -431,11 +431,11 @@ instance InternalGetSet SwiftCode where
   setFunc = G.setFunc
 
 instance InternalListFunc SwiftCode where
-  listSizeFunc = funcFromData (R.func swiftListSize) int
+  listSizeFunc _ = funcFromData (R.func swiftListSize) int
   listAddFunc _ i v = do
     f <- swiftListAddFunc i v 
     funcFromData (R.func (RC.value f)) (pure $ valueType f)
-  listAppendFunc = G.listAppendFunc swiftListAppend
+  listAppendFunc _ = G.listAppendFunc swiftListAppend
   listAccessFunc = CP.listAccessFunc
   listSetFunc = CP.listSetFunc R.listSetFunc
 

--- a/code/drasil-gool/lib/GOOL/Drasil/RendererClasses.hs
+++ b/code/drasil-gool/lib/GOOL/Drasil/RendererClasses.hs
@@ -172,9 +172,9 @@ class InternalGetSet r where
   setFunc :: VSType r -> SVariable r -> SValue r -> VSFunction r
 
 class InternalListFunc r where
-  listSizeFunc   :: VSFunction r
+  listSizeFunc   :: SValue r -> VSFunction r
   listAddFunc    :: SValue r -> SValue r -> SValue r -> VSFunction r
-  listAppendFunc :: SValue r -> VSFunction r
+  listAppendFunc :: SValue r -> SValue r -> VSFunction r
   listAccessFunc :: VSType r -> SValue r -> VSFunction r
   listSetFunc    :: SValue r -> SValue r -> SValue r -> VSFunction r
 


### PR DESCRIPTION
I added functions to the `List` type class for converting between integers and indices, the idea being that integers are always 0-indexed, but indices match the language's semantics.  I then integrated these functions into the default functions supplied by `LanguagePolymorphic.hs`, `CommonPseudoOO.hs`, and `Macros.hs`.  This makes it very easy for most if not all of list indexing to automatically switch for a language just by changing which function it uses for `intToIndex` and `indexToInt`.  Most languages have one or two functions that they implement on their own, which I did not update to use these new functions, but anything that is shared between languages supports them.

I know in the [issue](https://github.com/JacquesCarette/Drasil/issues/3746#issuecomment-2127853787) @JacquesCarette had said it might be better to have the functions outside the type classes, and give the type classes an `IndexingScheme` to give this function.  To be honest I tried that, and had a lot of trouble with Haskell's types 😅 .  I'm not sure if this is a big deal, but if it is I can definitely give it another shot, asking for help this time.

The one major benefit of @JacquesCarette's implementation, is that it allows us to shift the index in other ways.  The concrete example is list slicing.  Currently with some languages a list slice involves something like:
```java
for (int i = start; i < end; i++) {
```
Which, if converted to 1-indexed lists, would look like:
```java
for (int i = start + 1; i < end + 1; i++) {
```
When this would be more idiomatic:
```java
for (int i = start + 1; i <= end; i++) {
```
It's not a big deal, and there are likely not many similar cases, but it does show one way that we  could benefit from the other implementation.

Builds on #3808
Closes #3746

P.S. I know we had talked about constant-folding in the list API, so I'm not sure if I should say 'Closes' or 'Contributes to'.  I'd rather move on to other things for now, and reopen the issue if when we get the Julia renderer working, we see that constant-folding would be beneficial for the examples we're generating.