### PR TITLE
Making Glassbr compatible with Strict Data

### DIFF
--- a/code/drasil-build/package.yaml
+++ b/code/drasil-build/package.yaml
@@ -20,6 +20,9 @@ ghc-options:
 - -Wall
 - -Wredundant-constraints
 
+default-extensions:
+- StrictData
+
 library:
   source-dirs: lib
   exposed-modules:

--- a/code/drasil-code/package.yaml
+++ b/code/drasil-code/package.yaml
@@ -32,6 +32,9 @@ ghc-options:
 - -Wall
 - -Wredundant-constraints
 
+default-extensions:
+- StrictData
+
 library:
   source-dirs: lib
   exposed-modules:

--- a/code/drasil-codeLang/package.yaml
+++ b/code/drasil-codeLang/package.yaml
@@ -16,6 +16,9 @@ ghc-options:
 - -Wall
 - -Wredundant-constraints
 
+default-extensions:
+- StrictData
+
 library:
   source-dirs: lib
   exposed-modules:

--- a/code/drasil-data/package.yaml
+++ b/code/drasil-data/package.yaml
@@ -21,6 +21,9 @@ ghc-options:
 - -Wall
 - -Wredundant-constraints
 
+default-extensions:
+- StrictData
+
 library:
   source-dirs: lib
   exposed-modules:

--- a/code/drasil-example/glassbr/lib/Drasil/GlassBR/Unitals.hs
+++ b/code/drasil-example/glassbr/lib/Drasil/GlassBR/Unitals.hs
@@ -104,15 +104,9 @@ standOffDist = uq (constrained' (uc sD (variable "SD") Real metre)
   [ gtZeroConstr,
     sfwrc $ Bounded (Inc, sy sdMin) (Inc, sy sdMax)] (exactDbl 45)) defaultUncrt
 
-nomThick' :: ConstrainedChunk
-nomThick' = cuc "nomThick" 
-  (nounPhraseSent $ S "nominal thickness")
-  lT millimetre Rational 
-  [] $ exactDbl 0
-
 nomThick = cuc "nomThick" 
   (nounPhraseSent $ S "nominal thickness" +:+ displayDblConstrntsAsSet 
-    nomThick' nominalThicknesses)
+    (mkQuant "nomThick" (nounPhraseSent $ S "nominal thickness") lT Rational Nothing Nothing) nominalThicknesses)
   lT millimetre {-Discrete nominalThicknesses, but not implemented-} Rational 
   [{- TODO: add back constraint: enumc nominalThicknesses -}] $ exactDbl 8
 

--- a/code/drasil-example/glassbr/lib/Drasil/GlassBR/Unitals.hs
+++ b/code/drasil-example/glassbr/lib/Drasil/GlassBR/Unitals.hs
@@ -104,9 +104,15 @@ standOffDist = uq (constrained' (uc sD (variable "SD") Real metre)
   [ gtZeroConstr,
     sfwrc $ Bounded (Inc, sy sdMin) (Inc, sy sdMax)] (exactDbl 45)) defaultUncrt
 
+nomThick' :: ConstrainedChunk
+nomThick' = cuc "nomThick" 
+  (nounPhraseSent $ S "nominal thickness")
+  lT millimetre Rational 
+  [] $ exactDbl 0
+
 nomThick = cuc "nomThick" 
   (nounPhraseSent $ S "nominal thickness" +:+ displayDblConstrntsAsSet 
-    nomThick nominalThicknesses)
+    nomThick' nominalThicknesses)
   lT millimetre {-Discrete nominalThicknesses, but not implemented-} Rational 
   [{- TODO: add back constraint: enumc nominalThicknesses -}] $ exactDbl 8
 

--- a/code/drasil-example/glassbr/package.yaml
+++ b/code/drasil-example/glassbr/package.yaml
@@ -26,6 +26,9 @@ dependencies:
 - drasil-theory
 - drasil-utils
 
+default-extensions:
+- StrictData
+
 library:
   source-dirs: lib
   when:


### PR DESCRIPTION
In `glassbr.unitals` the ConstrainedChunk `nomThick` is self-referential creating an infinite loop when used with strict data. To prevent this, I created a new function called `nomThick'` that gives the `displayDblConstrntsAsSet` function in `nomThick` the information it needs to properly display the nominal thickness constraints as a set.