### PR TITLE
Added constant-folding to list indexing for 1-indexed languages

### DIFF
--- a/code/drasil-gool/lib/GOOL/Drasil/LanguageRenderer/CommonPseudoOO.hs
+++ b/code/drasil-gool/lib/GOOL/Drasil/LanguageRenderer/CommonPseudoOO.hs
@@ -514,9 +514,17 @@ listAppend l v = do
 -- | Convert an integer to an index in a 1-indexed language
 --   Since GOOL is 0-indexed, we need to add 1
 intToIndex' :: (RenderSym r) => SValue r -> SValue r
-intToIndex' = (#+ S.litInt 1)
+intToIndex' v = do 
+  v' <- v
+  case RC.valueInt v' of
+    (Just i) -> S.litInt (i + 1)
+    Nothing -> v #+ S.litInt 1
 
 -- | Convert an index to an integer in a 1-indexed language
 --   Since GOOL is 0-indexed, we need to subtract 1
 indexToInt' :: (RenderSym r) => SValue r -> SValue r
-indexToInt' = (#- S.litInt 1)
+indexToInt' v = do
+  v' <- v
+  case RC.valueInt v' of
+    (Just i) -> S.litInt (i - 1)
+    Nothing -> v #- S.litInt 1


### PR DESCRIPTION
Using the new features we added in #3820, I enabled GOOL to add or subtract the `1` 'internally' when adjusting list indices for 1-indexed languages, if the index to be adjusted is a `litInt`.

I didn't have a chance to test it with Julia, but I did a test where I made the Java renderer 1-indexed, and the results looked correct.