### PR TITLE
Removed method calls from `listAccess` and `listSet`

### DIFF
--- a/code/drasil-gool/lib/GOOL/Drasil/LanguageRenderer/CommonPseudoOO.hs
+++ b/code/drasil-gool/lib/GOOL/Drasil/LanguageRenderer/CommonPseudoOO.hs
@@ -333,22 +333,22 @@ litArray :: (RenderSym r) => (Doc -> Doc) -> VSType r -> [SValue r] -> SValue r
 litArray f t es = sequence es >>= (\elems -> mkStateVal (IC.arrayType t) 
   (f $ valueList elems))
 
--- Python, C#, C++, and Swift --
+-- Python, C#, C++, and Swift--
+
+extraClass :: (RenderSym r) =>  Label -> Maybe Label -> [CSStateVar r] ->
+  [SMethod r] -> [SMethod r] -> SClass r
+extraClass n = S.intClass n public . S.inherit
+
+-- Python, C#, Swift, and Julia --
+
+listAccessFunc :: (RenderSym r) => VSType r -> SValue r -> VSFunction r
+listAccessFunc t v = intValue v >>= ((`funcFromData` t) . R.listAccessFunc)
 
 listSetFunc :: (RenderSym r) => (Doc -> Doc -> Doc) -> SValue r -> SValue r -> 
   SValue r -> VSFunction r
 listSetFunc f v idx setVal = join $ on2StateValues (\i toVal -> funcFromData 
   (f (RC.value i) (RC.value toVal)) (onStateValue valueType v)) (intValue idx) 
   setVal
-
-extraClass :: (RenderSym r) =>  Label -> Maybe Label -> [CSStateVar r] -> 
-  [SMethod r] -> [SMethod r] -> SClass r
-extraClass n = S.intClass n public . S.inherit
-
--- Python, C#, and Swift --
-
-listAccessFunc :: (RenderSym r) => VSType r -> SValue r -> VSFunction r
-listAccessFunc t v = intValue v >>= ((`funcFromData` t) . R.listAccessFunc)
 
 -- Java, C#, and Swift --
 

--- a/code/stable/gooltest/cpp/PatternTest/PatternTest.cpp
+++ b/code/stable/gooltest/cpp/PatternTest/PatternTest.cpp
@@ -10,17 +10,6 @@ using std::vector;
 
 int main(int argc, const char *argv[]) {
     int n;
-    string myFSM = "Off";
-    myFSM = "On";
-    if (myFSM == "Off") {
-        std::cout << "Off" << std::endl;
-    }
-    else if (myFSM == "On") {
-        std::cout << "On" << std::endl;
-    }
-    else {
-        std::cout << "Neither" << std::endl;
-    }
     
     std::cout << "myStrat" << std::endl;
     n = 3;

--- a/code/stable/gooltest/csharp/PatternTest/PatternTest.cs
+++ b/code/stable/gooltest/csharp/PatternTest/PatternTest.cs
@@ -5,19 +5,6 @@ public class PatternTest {
     
     public static void Main(string[] args) {
         int n;
-        string myFSM = "Off";
-        myFSM = "On";
-        switch(myFSM) {
-            case "Off":
-                Console.WriteLine("Off");
-                break;
-            case "On":
-                Console.WriteLine("On");
-                break;
-            default:
-                Console.WriteLine("Neither");
-                break;
-        };
         
         Console.WriteLine("myStrat");
         n = 3;

--- a/code/stable/gooltest/java/PatternTest/PatternTest/PatternTest.java
+++ b/code/stable/gooltest/java/PatternTest/PatternTest/PatternTest.java
@@ -7,19 +7,6 @@ public class PatternTest {
     
     public static void main(String[] args) {
         int n;
-        String myFSM = "Off";
-        myFSM = "On";
-        switch(myFSM) {
-            case "Off":
-                System.out.println("Off");
-                break;
-            case "On":
-                System.out.println("On");
-                break;
-            default:
-                System.out.println("Neither");
-                break;
-        };
         
         System.out.println("myStrat");
         n = 3;

--- a/code/stable/gooltest/python/PatternTest/PatternTest.py
+++ b/code/stable/gooltest/python/PatternTest/PatternTest.py
@@ -1,14 +1,5 @@
 import Observer
 
-myFSM = "Off"
-myFSM = "On"
-if (myFSM == "Off"):
-    print("Off")
-elif (myFSM == "On"):
-    print("On")
-else:
-    print("Neither")
-
 print("myStrat")
 n = 3
 

--- a/code/stable/gooltest/swift/PatternTest/main.swift
+++ b/code/stable/gooltest/swift/PatternTest/main.swift
@@ -1,14 +1,4 @@
 var n: Int
-var myFSM: String = "Off"
-myFSM = "On"
-switch myFSM {
-    case "Off":
-        print("Off")
-    case "On":
-        print("On")
-    default:
-        print("Neither")
-};
 
 print("myStrat")
 n = 3


### PR DESCRIPTION
Both `listAccess` and `listSet` are implemented as a method call in the implementations used by all targets.  I thought this  was weird, as they are only actually method calls for Java and C++.  I changed the implementation to create a value without worrying what kind of call it is.

Another option would be to split these functions up into functions that use methods and functions that don't.  I opted to keep them together, as `listAccess` in particular is large enough that I'd rather not duplicate it, when this way does essentially the same thing.

P.S. I also updated `stable/gooltest`, as I must have forgotten to do so for the last commit.