### PR TITLE
Fixed PDF deployment

### DIFF
--- a/.github/workflows/Build.yaml
+++ b/.github/workflows/Build.yaml
@@ -86,8 +86,8 @@ jobs:
         run: make codegenTest
 
       - name: "Compile generated TeX artifacts"
-        run: make tex SUMMARIZE_TEX=yes
-        if: steps.changes.tex.src == 'true'
+        run: make -j tex SUMMARIZE_TEX=yes
+        if: ${{ steps.changes.outputs.tex == 'true' || fromJSON(env.is_deployment) }}
 
       - name: "Compile generated software artifacts"
         run: make gool

--- a/code/drasil-website/lib/Drasil/Website/Example.hs
+++ b/code/drasil-website/lib/Drasil/Website/Example.hs
@@ -6,7 +6,7 @@ module Drasil.Website.Example where
 import Language.Drasil hiding (E)
 import SysInfo.Drasil (SystemInformation(..))
 import Language.Drasil.Code (Choices(..), Lang(..))
-import Data.Char (toLower)
+import Data.Char (toLower, toUpper)
 
 import qualified Drasil.DblPend.Body as DblPend (fullSI)
 import qualified Drasil.GamePhysics.Body as GamePhysics (fullSI)
@@ -224,7 +224,7 @@ getSRSPath :: FilePath -> String -> String -> FilePath
 getSRSPath path sufx ex = 
   path
   ++ map toLower ex -- FIXME: The majority of these `map toLower`s are implicit knowledge!!! 
-  ++ "/SRS/srs/"
+  ++ "/SRS/" ++ map toUpper sufx ++ "/"
   ++ ex ++ "_SRS." ++ map toLower sufx
 
 -- | Get the file paths for generated code and doxygen locations.

--- a/code/scripts/prepare_deployment.sh
+++ b/code/scripts/prepare_deployment.sh
@@ -54,7 +54,7 @@ if [ -z "$MAKE" ]; then
 fi
 
 DOC_DEST=docs/
-SRS_DEST=SRS/
+SRS_DEST=SRS
 DOX_DEST=doxygen/
 EXAMPLE_DEST=examples/
 CUR_DIR="$PWD/"
@@ -90,13 +90,13 @@ copy_examples() {
     # Only copy actual examples
     if [[ "$EXAMPLE_DIRS" == *"$example_name"* ]]; then
       target_srs_dir="./$EXAMPLE_DEST$example_name/$SRS_DEST"
-      mkdir -p "$target_srs_dir"PDF
-      mkdir -p "$target_srs_dir"HTML
+      mkdir -p "$target_srs_dir/PDF"
+      mkdir -p "$target_srs_dir/HTML"
       if [ -d "$example/SRS/PDF" ]; then
-        cp "$example/SRS/PDF/"*.pdf "$target_srs_dir"PDF
+        cp "$example/SRS/PDF/"*.pdf "$target_srs_dir/PDF"
       fi
       if [ -d "$example/SRS/HTML" ]; then
-        cp -r "$example/SRS/HTML/." "$target_srs_dir"HTML
+        cp -r "$example/SRS/HTML/." "$target_srs_dir/HTML"
       fi
       if [ -d "$example/src" ]; then
         mkdir -p "$EXAMPLE_DEST$example_name/$DOX_DEST"

--- a/code/scripts/prepare_deployment.sh
+++ b/code/scripts/prepare_deployment.sh
@@ -54,8 +54,7 @@ if [ -z "$MAKE" ]; then
 fi
 
 DOC_DEST=docs/
-# SRS_DEST needs to be two levels deep for image filepaths to match those of the build folder
-SRS_DEST=SRS/srs
+SRS_DEST=SRS/
 DOX_DEST=doxygen/
 EXAMPLE_DEST=examples/
 CUR_DIR="$PWD/"
@@ -91,12 +90,13 @@ copy_examples() {
     # Only copy actual examples
     if [[ "$EXAMPLE_DIRS" == *"$example_name"* ]]; then
       target_srs_dir="./$EXAMPLE_DEST$example_name/$SRS_DEST"
-      mkdir -p "$target_srs_dir"
+      mkdir -p "$target_srs_dir"PDF
+      mkdir -p "$target_srs_dir"HTML
       if [ -d "$example/SRS/PDF" ]; then
-        cp "$example/SRS/PDF/"*.pdf "$target_srs_dir"
+        cp "$example/SRS/PDF/"*.pdf "$target_srs_dir"PDF
       fi
       if [ -d "$example/SRS/HTML" ]; then
-        cp -r "$example/SRS/HTML/." "$target_srs_dir"
+        cp -r "$example/SRS/HTML/." "$target_srs_dir"HTML
       fi
       if [ -d "$example/src" ]; then
         mkdir -p "$EXAMPLE_DEST$example_name/$DOX_DEST"

--- a/code/stable-website/index.html
+++ b/code/stable-website/index.html
@@ -154,7 +154,7 @@
                 <a href="https://github.com/JacquesCarette/Drasil/tree/main/code/drasil-example/dblpend">Drasil Source Code</a>
               </li>
               <li>
-                SRS: <a href="examples/dblpend/SRS/srs/DblPend_SRS.html">[HTML]</a> <a href="examples/dblpend/SRS/srs/DblPend_SRS.pdf">[PDF]</a>
+                SRS: <a href="examples/dblpend/SRS/HTML/DblPend_SRS.html">[HTML]</a> <a href="examples/dblpend/SRS/PDF/DblPend_SRS.pdf">[PDF]</a>
               </li>
               <li>
                 Generated Code:
@@ -181,7 +181,7 @@
                 <a href="https://github.com/JacquesCarette/Drasil/tree/main/code/drasil-example/gamephysics">Drasil Source Code</a>
               </li>
               <li>
-                SRS: <a href="examples/gamephysics/SRS/srs/GamePhysics_SRS.html">[HTML]</a> <a href="examples/gamephysics/SRS/srs/GamePhysics_SRS.pdf">[PDF]</a>
+                SRS: <a href="examples/gamephysics/SRS/HTML/GamePhysics_SRS.html">[HTML]</a> <a href="examples/gamephysics/SRS/PDF/GamePhysics_SRS.pdf">[PDF]</a>
               </li>
             </ul>
           </li>
@@ -192,7 +192,7 @@
                 <a href="https://github.com/JacquesCarette/Drasil/tree/main/code/drasil-example/glassbr">Drasil Source Code</a>
               </li>
               <li>
-                SRS: <a href="examples/glassbr/SRS/srs/GlassBR_SRS.html">[HTML]</a> <a href="examples/glassbr/SRS/srs/GlassBR_SRS.pdf">[PDF]</a>
+                SRS: <a href="examples/glassbr/SRS/HTML/GlassBR_SRS.html">[HTML]</a> <a href="examples/glassbr/SRS/PDF/GlassBR_SRS.pdf">[PDF]</a>
               </li>
               <li>
                 Generated Code:
@@ -219,7 +219,7 @@
                 <a href="https://github.com/JacquesCarette/Drasil/tree/main/code/drasil-example/hghc">Drasil Source Code</a>
               </li>
               <li>
-                SRS: <a href="examples/hghc/SRS/srs/HGHC_SRS.html">[HTML]</a> <a href="examples/hghc/SRS/srs/HGHC_SRS.pdf">[PDF]</a>
+                SRS: <a href="examples/hghc/SRS/HTML/HGHC_SRS.html">[HTML]</a> <a href="examples/hghc/SRS/PDF/HGHC_SRS.pdf">[PDF]</a>
               </li>
             </ul>
           </li>
@@ -230,7 +230,7 @@
                 <a href="https://github.com/JacquesCarette/Drasil/tree/main/code/drasil-example/swhsnopcm">Drasil Source Code</a>
               </li>
               <li>
-                SRS: <a href="examples/swhsnopcm/SRS/srs/SWHSNoPCM_SRS.html">[HTML]</a> <a href="examples/swhsnopcm/SRS/srs/SWHSNoPCM_SRS.pdf">[PDF]</a>
+                SRS: <a href="examples/swhsnopcm/SRS/HTML/SWHSNoPCM_SRS.html">[HTML]</a> <a href="examples/swhsnopcm/SRS/PDF/SWHSNoPCM_SRS.pdf">[PDF]</a>
               </li>
               <li>
                 Generated Code:
@@ -257,7 +257,7 @@
                 <a href="https://github.com/JacquesCarette/Drasil/tree/main/code/drasil-example/pdcontroller">Drasil Source Code</a>
               </li>
               <li>
-                SRS: <a href="examples/pdcontroller/SRS/srs/PDController_SRS.html">[HTML]</a> <a href="examples/pdcontroller/SRS/srs/PDController_SRS.pdf">[PDF]</a>
+                SRS: <a href="examples/pdcontroller/SRS/HTML/PDController_SRS.html">[HTML]</a> <a href="examples/pdcontroller/SRS/PDF/PDController_SRS.pdf">[PDF]</a>
               </li>
               <li>
                 Generated Code:
@@ -284,7 +284,7 @@
                 <a href="https://github.com/JacquesCarette/Drasil/tree/main/code/drasil-example/projectile">Drasil Source Code</a>
               </li>
               <li>
-                SRS: <a href="examples/projectile/SRS/srs/Projectile_SRS.html">[HTML]</a> <a href="examples/projectile/SRS/srs/Projectile_SRS.pdf">[PDF]</a>
+                SRS: <a href="examples/projectile/SRS/HTML/Projectile_SRS.html">[HTML]</a> <a href="examples/projectile/SRS/PDF/Projectile_SRS.pdf">[PDF]</a>
               </li>
               <li>
                 Generated Code:
@@ -335,7 +335,7 @@
                 <a href="https://github.com/JacquesCarette/Drasil/tree/main/code/drasil-example/sglpend">Drasil Source Code</a>
               </li>
               <li>
-                SRS: <a href="examples/sglpend/SRS/srs/SglPend_SRS.html">[HTML]</a> <a href="examples/sglpend/SRS/srs/SglPend_SRS.pdf">[PDF]</a>
+                SRS: <a href="examples/sglpend/SRS/HTML/SglPend_SRS.html">[HTML]</a> <a href="examples/sglpend/SRS/PDF/SglPend_SRS.pdf">[PDF]</a>
               </li>
             </ul>
           </li>
@@ -346,7 +346,7 @@
                 <a href="https://github.com/JacquesCarette/Drasil/tree/main/code/drasil-example/ssp">Drasil Source Code</a>
               </li>
               <li>
-                SRS: <a href="examples/ssp/SRS/srs/SSP_SRS.html">[HTML]</a> <a href="examples/ssp/SRS/srs/SSP_SRS.pdf">[PDF]</a>
+                SRS: <a href="examples/ssp/SRS/HTML/SSP_SRS.html">[HTML]</a> <a href="examples/ssp/SRS/PDF/SSP_SRS.pdf">[PDF]</a>
               </li>
             </ul>
           </li>
@@ -357,7 +357,7 @@
                 <a href="https://github.com/JacquesCarette/Drasil/tree/main/code/drasil-example/swhs">Drasil Source Code</a>
               </li>
               <li>
-                SRS: <a href="examples/swhs/SRS/srs/SWHS_SRS.html">[HTML]</a> <a href="examples/swhs/SRS/srs/SWHS_SRS.pdf">[PDF]</a>
+                SRS: <a href="examples/swhs/SRS/HTML/SWHS_SRS.html">[HTML]</a> <a href="examples/swhs/SRS/PDF/SWHS_SRS.pdf">[PDF]</a>
               </li>
             </ul>
           </li>


### PR DESCRIPTION
Closes #3704 

- Changed the conditions for when the TeX examples are compiled.
  1. On a pull request if there is a change in a TeX file within Stable.
  2. On a push to `main` (deployment environment).
- Separated the different SRS formats into their respective directories. Previously, all SRS artifacts were copied to `SRS/srs` directory within the `gh-pages` branch. Instead I separated it into `SRS/HTML` and `SRS/PDF`.
  - Updated the website with these link changes.
- Added `-j` flag when calling the `make` target to compile the TeX files.
  - The `-j` flag allows the parallel execution of jobs. This allows several TeX files to compile concurrently leading to faster times for the overall workfow.
  - [**No `-j` Flag**](https://github.com/BilalM04/Drasil/actions/runs/10048556021/job/27772779560): TeX takes ~13 min for a total workflow time of ~24 min
  - [**With `-j` Flag**](https://github.com/BilalM04/Drasil/actions/runs/10048133543/job/27771431028): TeX takes ~6min for a total workflow time of ~18 min