### PR TITLE
Hosting mdBook examples on website

### DIFF
--- a/.github/workflows/Build.yaml
+++ b/.github/workflows/Build.yaml
@@ -44,7 +44,10 @@ jobs:
               - 'code/stable/**/*.tex'
 
       - name: "Install system requirements"
-        run: sudo apt-get install -y --fix-missing libgmp-dev python3 graphviz doxygen fonts-lmodern texlive-bibtex-extra texlive-latex-extra texlive-science texlive-xetex texlive-luatex g++ default-jdk mono-devel inkscape
+        run: |
+          sudo apt-get install -y --fix-missing libgmp-dev python3 graphviz doxygen fonts-lmodern texlive-bibtex-extra texlive-latex-extra texlive-science texlive-xetex texlive-luatex g++ default-jdk mono-devel inkscape
+          curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+          cargo install mdbook
 
       - name: "Update PATH"
         run: |
@@ -115,6 +118,10 @@ jobs:
 
       - name: "Build trace graphs" # only needed in deployments, not required for tests
         run: make tracegraphs
+        if: ${{ fromJSON(env.is_deployment) }}
+
+      - name: "Build mdBook Examples" # only needed in deployments, not required for tests
+        run: make mdbook_build
         if: ${{ fromJSON(env.is_deployment) }}
 
       - name: "Build website generator"

--- a/code/drasil-printers/lib/Language/Drasil/Format.hs
+++ b/code/drasil-printers/lib/Language/Drasil/Format.hs
@@ -9,6 +9,13 @@ data DocType = SRS | Website | Lesson
 -- | Possible formats for printer output.
 data Format = TeX | Plain | HTML | Jupyter | MDBook
 
+instance Show Format where
+  show TeX     = "PDF"
+  show Plain   = "Plain"
+  show HTML    = "HTML"
+  show Jupyter = "Jupyter"
+  show MDBook  = "mdBook"
+
 -- | Shows the different types of documents.
 instance Show DocType where
   show Lesson  = "Lesson"

--- a/code/drasil-website/lib/Drasil/Website/Example.hs
+++ b/code/drasil-website/lib/Drasil/Website/Example.hs
@@ -6,7 +6,8 @@ module Drasil.Website.Example where
 import Language.Drasil hiding (E)
 import SysInfo.Drasil (SystemInformation(..))
 import Language.Drasil.Code (Choices(..), Lang(..))
-import Data.Char (toLower, toUpper)
+import Data.Char (toLower)
+import Language.Drasil.Printers (Format(..))
 
 import qualified Drasil.DblPend.Body as DblPend (fullSI)
 import qualified Drasil.GamePhysics.Body as GamePhysics (fullSI)
@@ -86,11 +87,15 @@ individualExList :: Example -> [ItemType]
 -- No choices mean no generated code, so we do not need to display generated code and thus do not call versionList.
 individualExList ex@E{sysInfoE = SI{_sys = sys}, choicesE = [], codePath = srsP} = 
   [Flat $ namedRef (buildDrasilExSrcRef ex) (S "Drasil Source Code"),
-  Flat $ S "SRS:" +:+ namedRef (getSRSRef srsP "html" $ programName sys) (S "[HTML]") +:+ namedRef (getSRSRef srsP "pdf" $ programName sys) (S "[PDF]")]
+  Flat $ S "SRS:" +:+ namedRef (getSRSRef srsP HTML $ programName sys) (S "[HTML]") 
+  +:+ namedRef (getSRSRef srsP TeX $ programName sys) (S "[PDF]") 
+  +:+ namedRef (getSRSRef srsP MDBook $ programName sys) (S "[mdBook]")]
 -- Anything else means we need to display program information, so use versionList.
 individualExList ex@E{sysInfoE = SI{_sys = sys}, codePath = srsP} = 
   [Flat $ namedRef (buildDrasilExSrcRef ex) (S "Drasil Source Code"),
-  Flat $ S "SRS:" +:+ namedRef (getSRSRef srsP "html" $ programName sys) (S "[HTML]") +:+ namedRef (getSRSRef srsP "pdf" $ programName sys) (S "[PDF]"),
+  Flat $ S "SRS:" +:+ namedRef (getSRSRef srsP HTML $ programName sys) (S "[HTML]") 
+  +:+ namedRef (getSRSRef srsP TeX $ programName sys) (S "[PDF]")
+  +:+ namedRef (getSRSRef srsP MDBook $ programName sys) (S "[mdBook]"),
   Nested (S generatedCodeTitle) $ Bullet $ map (, Nothing) (versionList getCodeRef ex),
   Nested (S generatedCodeDocsTitle) $ Bullet $ map (, Nothing) (versionList getDoxRef noSwiftEx)]
     where
@@ -214,19 +219,20 @@ getDoxRef ex@E{sysInfoE=SI{_sys = sys}, choicesE = chcs} l verName =
       _   -> map toLower verName ++ "/" ++ convertLang l
 
 -- | Make references for each of the generated SRS files.
-getSRSRef :: FilePath -> String -> String -> Reference
-getSRSRef path sufx ex = makeURI refUID (getSRSPath path (map toLower sufx) ex) $ shortname' $ S refUID
+getSRSRef :: FilePath -> Format -> String -> Reference
+getSRSRef path format ex = makeURI refUID (getSRSPath path format ex) $ shortname' $ S refUID
   where
-    refUID = map toLower sufx ++ "Ref" ++ ex
+    refUID = show format ++ "Ref" ++ ex
 
 -- | Get the paths of where each reference exist for SRS files. Some example abbreviations have spaces,
--- so we just filter those out. The suffix should only be either html or pdf.
-getSRSPath :: FilePath -> String -> String -> FilePath
-getSRSPath path sufx ex = 
-  path
-  ++ map toLower ex -- FIXME: The majority of these `map toLower`s are implicit knowledge!!! 
-  ++ "/SRS/" ++ map toUpper sufx ++ "/"
-  ++ ex ++ "_SRS." ++ map toLower sufx
+-- so we just filter those out.
+getSRSPath :: FilePath -> Format -> String -> FilePath
+getSRSPath path format ex = path ++ map toLower ex ++ "/SRS/" ++ show format ++ "/" ++ sufx format
+  where
+    sufx MDBook = "book"
+    sufx HTML   = ex ++ "_SRS.html"
+    sufx TeX    = ex ++ "_SRS.pdf"
+    sufx _      = error "You can only get paths for TeX/HTML/MDBook."
 
 -- | Get the file paths for generated code and doxygen locations.
 getCodePath, getDoxPath :: FilePath -> String -> String -> FilePath
@@ -240,8 +246,9 @@ exampleRefs :: FilePath -> FilePath -> [Reference]
 exampleRefs codePth srsDoxPth = 
   concatMap getCodeRefDB (examples codePth srsDoxPth) ++ 
   concatMap getDoxRefDB (examples codePth srsDoxPth) ++ 
-  map (getSRSRef srsDoxPth "html" . getAbrv) (examples codePth srsDoxPth) ++ 
-  map (getSRSRef srsDoxPth "pdf" . getAbrv) (examples codePth srsDoxPth) ++ 
+  map (getSRSRef srsDoxPth HTML . getAbrv) (examples codePth srsDoxPth) ++ 
+  map (getSRSRef srsDoxPth TeX . getAbrv) (examples codePth srsDoxPth) ++ 
+  map (getSRSRef srsDoxPth MDBook . getAbrv) (examples codePth srsDoxPth) ++ 
   map buildDrasilExSrcRef (examples codePth srsDoxPth)
 
 -- | Helpers to pull code and doxygen references from an example.

--- a/code/scripts/prepare_deployment.sh
+++ b/code/scripts/prepare_deployment.sh
@@ -92,11 +92,15 @@ copy_examples() {
       target_srs_dir="./$EXAMPLE_DEST$example_name/$SRS_DEST"
       mkdir -p "$target_srs_dir/PDF"
       mkdir -p "$target_srs_dir/HTML"
+      mkdir -p "$target_srs_dir/mdBook"
       if [ -d "$example/SRS/PDF" ]; then
         cp "$example/SRS/PDF/"*.pdf "$target_srs_dir/PDF"
       fi
       if [ -d "$example/SRS/HTML" ]; then
         cp -r "$example/SRS/HTML/." "$target_srs_dir/HTML"
+      fi
+      if [ -d "$example/SRS/mdBook" ]; then
+        cp -r "$example/SRS/mdBook/book/" "$target_srs_dir/mdBook"
       fi
       if [ -d "$example/src" ]; then
         mkdir -p "$EXAMPLE_DEST$example_name/$DOX_DEST"

--- a/code/stable-website/index.html
+++ b/code/stable-website/index.html
@@ -154,7 +154,7 @@
                 <a href="https://github.com/JacquesCarette/Drasil/tree/main/code/drasil-example/dblpend">Drasil Source Code</a>
               </li>
               <li>
-                SRS: <a href="examples/dblpend/SRS/HTML/DblPend_SRS.html">[HTML]</a> <a href="examples/dblpend/SRS/PDF/DblPend_SRS.pdf">[PDF]</a>
+                SRS: <a href="examples/dblpend/SRS/HTML/DblPend_SRS.html">[HTML]</a> <a href="examples/dblpend/SRS/PDF/DblPend_SRS.pdf">[PDF]</a> <a href="examples/dblpend/SRS/mdBook/book">[mdBook]</a>
               </li>
               <li>
                 Generated Code:
@@ -181,7 +181,7 @@
                 <a href="https://github.com/JacquesCarette/Drasil/tree/main/code/drasil-example/gamephysics">Drasil Source Code</a>
               </li>
               <li>
-                SRS: <a href="examples/gamephysics/SRS/HTML/GamePhysics_SRS.html">[HTML]</a> <a href="examples/gamephysics/SRS/PDF/GamePhysics_SRS.pdf">[PDF]</a>
+                SRS: <a href="examples/gamephysics/SRS/HTML/GamePhysics_SRS.html">[HTML]</a> <a href="examples/gamephysics/SRS/PDF/GamePhysics_SRS.pdf">[PDF]</a> <a href="examples/gamephysics/SRS/mdBook/book">[mdBook]</a>
               </li>
             </ul>
           </li>
@@ -192,7 +192,7 @@
                 <a href="https://github.com/JacquesCarette/Drasil/tree/main/code/drasil-example/glassbr">Drasil Source Code</a>
               </li>
               <li>
-                SRS: <a href="examples/glassbr/SRS/HTML/GlassBR_SRS.html">[HTML]</a> <a href="examples/glassbr/SRS/PDF/GlassBR_SRS.pdf">[PDF]</a>
+                SRS: <a href="examples/glassbr/SRS/HTML/GlassBR_SRS.html">[HTML]</a> <a href="examples/glassbr/SRS/PDF/GlassBR_SRS.pdf">[PDF]</a> <a href="examples/glassbr/SRS/mdBook/book">[mdBook]</a>
               </li>
               <li>
                 Generated Code:
@@ -219,7 +219,7 @@
                 <a href="https://github.com/JacquesCarette/Drasil/tree/main/code/drasil-example/hghc">Drasil Source Code</a>
               </li>
               <li>
-                SRS: <a href="examples/hghc/SRS/HTML/HGHC_SRS.html">[HTML]</a> <a href="examples/hghc/SRS/PDF/HGHC_SRS.pdf">[PDF]</a>
+                SRS: <a href="examples/hghc/SRS/HTML/HGHC_SRS.html">[HTML]</a> <a href="examples/hghc/SRS/PDF/HGHC_SRS.pdf">[PDF]</a> <a href="examples/hghc/SRS/mdBook/book">[mdBook]</a>
               </li>
             </ul>
           </li>
@@ -230,7 +230,7 @@
                 <a href="https://github.com/JacquesCarette/Drasil/tree/main/code/drasil-example/swhsnopcm">Drasil Source Code</a>
               </li>
               <li>
-                SRS: <a href="examples/swhsnopcm/SRS/HTML/SWHSNoPCM_SRS.html">[HTML]</a> <a href="examples/swhsnopcm/SRS/PDF/SWHSNoPCM_SRS.pdf">[PDF]</a>
+                SRS: <a href="examples/swhsnopcm/SRS/HTML/SWHSNoPCM_SRS.html">[HTML]</a> <a href="examples/swhsnopcm/SRS/PDF/SWHSNoPCM_SRS.pdf">[PDF]</a> <a href="examples/swhsnopcm/SRS/mdBook/book">[mdBook]</a>
               </li>
               <li>
                 Generated Code:
@@ -257,7 +257,7 @@
                 <a href="https://github.com/JacquesCarette/Drasil/tree/main/code/drasil-example/pdcontroller">Drasil Source Code</a>
               </li>
               <li>
-                SRS: <a href="examples/pdcontroller/SRS/HTML/PDController_SRS.html">[HTML]</a> <a href="examples/pdcontroller/SRS/PDF/PDController_SRS.pdf">[PDF]</a>
+                SRS: <a href="examples/pdcontroller/SRS/HTML/PDController_SRS.html">[HTML]</a> <a href="examples/pdcontroller/SRS/PDF/PDController_SRS.pdf">[PDF]</a> <a href="examples/pdcontroller/SRS/mdBook/book">[mdBook]</a>
               </li>
               <li>
                 Generated Code:
@@ -284,7 +284,7 @@
                 <a href="https://github.com/JacquesCarette/Drasil/tree/main/code/drasil-example/projectile">Drasil Source Code</a>
               </li>
               <li>
-                SRS: <a href="examples/projectile/SRS/HTML/Projectile_SRS.html">[HTML]</a> <a href="examples/projectile/SRS/PDF/Projectile_SRS.pdf">[PDF]</a>
+                SRS: <a href="examples/projectile/SRS/HTML/Projectile_SRS.html">[HTML]</a> <a href="examples/projectile/SRS/PDF/Projectile_SRS.pdf">[PDF]</a> <a href="examples/projectile/SRS/mdBook/book">[mdBook]</a>
               </li>
               <li>
                 Generated Code:
@@ -335,7 +335,7 @@
                 <a href="https://github.com/JacquesCarette/Drasil/tree/main/code/drasil-example/sglpend">Drasil Source Code</a>
               </li>
               <li>
-                SRS: <a href="examples/sglpend/SRS/HTML/SglPend_SRS.html">[HTML]</a> <a href="examples/sglpend/SRS/PDF/SglPend_SRS.pdf">[PDF]</a>
+                SRS: <a href="examples/sglpend/SRS/HTML/SglPend_SRS.html">[HTML]</a> <a href="examples/sglpend/SRS/PDF/SglPend_SRS.pdf">[PDF]</a> <a href="examples/sglpend/SRS/mdBook/book">[mdBook]</a>
               </li>
             </ul>
           </li>
@@ -346,7 +346,7 @@
                 <a href="https://github.com/JacquesCarette/Drasil/tree/main/code/drasil-example/ssp">Drasil Source Code</a>
               </li>
               <li>
-                SRS: <a href="examples/ssp/SRS/HTML/SSP_SRS.html">[HTML]</a> <a href="examples/ssp/SRS/PDF/SSP_SRS.pdf">[PDF]</a>
+                SRS: <a href="examples/ssp/SRS/HTML/SSP_SRS.html">[HTML]</a> <a href="examples/ssp/SRS/PDF/SSP_SRS.pdf">[PDF]</a> <a href="examples/ssp/SRS/mdBook/book">[mdBook]</a>
               </li>
             </ul>
           </li>
@@ -357,7 +357,7 @@
                 <a href="https://github.com/JacquesCarette/Drasil/tree/main/code/drasil-example/swhs">Drasil Source Code</a>
               </li>
               <li>
-                SRS: <a href="examples/swhs/SRS/HTML/SWHS_SRS.html">[HTML]</a> <a href="examples/swhs/SRS/PDF/SWHS_SRS.pdf">[PDF]</a>
+                SRS: <a href="examples/swhs/SRS/HTML/SWHS_SRS.html">[HTML]</a> <a href="examples/swhs/SRS/PDF/SWHS_SRS.pdf">[PDF]</a> <a href="examples/swhs/SRS/mdBook/book">[mdBook]</a>
               </li>
             </ul>
           </li>


### PR DESCRIPTION
Closes #3857 

Working example on my [forked website](https://bilalm04.github.io/Drasil/).

Workflow Changes:
- Install mdBook using Rust and Cargo.
- Run the `make mdbook_build` target to build the mdBook examples (only on deployment).
- Update deployment script to copy over the built mdBook examples.

Website Changes:
- Generated links to the mdBook examples.
- Modified the existing function to get the SRS file paths to utilize `Format` rather than plain `String`s.
