### PR TITLE
Centered figures in mdBook

### DIFF
--- a/code/drasil-printers/lib/Language/Drasil/Markdown/Helpers.hs
+++ b/code/drasil-printers/lib/Language/Drasil/Markdown/Helpers.hs
@@ -8,7 +8,8 @@ import Text.PrettyPrint (Doc, text, empty, (<>), (<+>), hcat,
 import Data.Map (lookup)
 import Language.Drasil.Printing.Helpers (ast, ($^$), vsep)
 import Language.Drasil.Printing.LayoutObj (RefMap)
-import Language.Drasil.HTML.Helpers (wrap', wrapGen', Variation(Id, Align))
+import Language.Drasil.HTML.Helpers (wrap', wrapGen', Variation(Id, Align),
+  wrapInside, tagR)
 
 -- | Angled brackets
 ang :: Doc -> Doc
@@ -32,9 +33,15 @@ ul = wrap' "ul" []
 divTag :: Doc -> Doc
 divTag l = wrapGen' hcat Id "div" l [""] empty
 
--- | Helper for setting up div for defn heading
-defnHTag :: Doc -> Doc
-defnHTag = wrapGen' vsep Align "div" (text "center") [""]
+-- | Helper for setting up centered div tags
+centeredDiv :: Doc -> Doc
+centeredDiv = wrapGen' vsep Align "div" (text "center") [""]
+
+-- | Helper for setting up centered div tags with an Id
+centeredDivId :: Doc -> Doc -> Doc
+centeredDivId l con = vsep [wrapInside "div" atrs, con, tagR "div"]
+  where
+    atrs = [(show Id, l), (show Align, text "center")]
 
 -- | Helper for setting up links to references
 reflink :: RefMap -> String -> Doc -> Doc
@@ -55,7 +62,7 @@ reflinkURI ref txt = if ref == txt then ang ref
 
 -- | Helper for setting up figures
 image :: Doc -> Doc -> Doc
-image f c =  text "!" <> reflinkURI fp c $^$ bold (caption c)
+image f c =  text "!" <> reflinkURI fp c $^$ bold c
   where
     fp = text $ "./assets/" ++ takeFileName (show f)
 

--- a/code/drasil-printers/lib/Language/Drasil/Markdown/Print.hs
+++ b/code/drasil-printers/lib/Language/Drasil/Markdown/Print.hs
@@ -31,8 +31,8 @@ import Language.Drasil.HTML.Helpers(BibFormatter(..))
 import Language.Drasil.TeX.Helpers(commandD, command2D, mkEnv)
 
 import Language.Drasil.Markdown.Helpers (heading, image, li, reflink,
-  reflinkURI, reflinkInfo, caption, bold, ul, docLength, divTag, defnHTag, em,
-  h, h')
+  reflinkURI, reflinkInfo, caption, bold, ul, docLength, divTag, centeredDiv, 
+  em, h, h', centeredDivId)
 
 -----------------------------------------------------------------
 ------------------------- mdBook SRS ----------------------------
@@ -233,7 +233,7 @@ mkDocDefn rm = map (\(f, d) -> [text f, makeLO rm (f,d)])
 
 -- | Renders the title/header of the definition table
 makeDHeaderText :: RefMap -> [(String, [LayoutObj])] -> Doc -> Doc
-makeDHeaderText rm ps l = defnHTag header
+makeDHeaderText rm ps l = centeredDiv header
   where
     lo = lookup "Label" ps
     c = maybe l (\lo' -> makeLO rm ("Label", lo')) lo 
@@ -307,7 +307,7 @@ item rm (Nested s l) = vcat [pSpec rm s, makeList rm l 0]
 
 -- | Renders figures in Markdown
 makeFigure :: Doc -> Doc -> Doc -> Doc
-makeFigure r c f = divTag r $^$ image f c
+makeFigure r c f = centeredDivId r (image f c)
 
 -----------------------------------------------------------------
 ------------------ Bibliography Printing ------------------------

--- a/code/stable/dblpend/SRS/mdBook/src/SecPhysSyst.md
+++ b/code/stable/dblpend/SRS/mdBook/src/SecPhysSyst.md
@@ -10,8 +10,10 @@ PS3: The first object.
 
 PS4: The second object.
 
-<div id="Figure:dblpend"></div>
+<div id="Figure:dblpend" align="center" >
 
 ![The physical system](./assets/dblpend.png)
 
-**<p align="center">The physical system</p>**
+**The physical system**
+
+</div>

--- a/code/stable/dblpend/SRS/mdBook/src/SecSysContext.md
+++ b/code/stable/dblpend/SRS/mdBook/src/SecSysContext.md
@@ -2,11 +2,13 @@
 
 [Fig:sysCtxDiag](./SecSysContext.md#Figure:sysCtxDiag) shows the system context. A circle represents an entity external to the software, the user in this case. A rectangle represents the software system itself (DblPend). Arrows are used to show the data flow between the system and its environment.
 
-<div id="Figure:sysCtxDiag"></div>
+<div id="Figure:sysCtxDiag" align="center" >
 
 ![System Context](./assets/SystemContextFigure.png)
 
-**<p align="center">System Context</p>**
+**System Context**
+
+</div>
 
 The interaction between the product and the user is through an application programming interface. The responsibilities of the user and the system are as follows:
 

--- a/code/stable/dblpend/SRS/mdBook/src/SecTraceMatrices.md
+++ b/code/stable/dblpend/SRS/mdBook/src/SecTraceMatrices.md
@@ -100,35 +100,45 @@ The purpose of the traceability matrices is to provide easy references on what h
 
 The purpose of the traceability graphs is also to provide easy references on what has to be additionally modified if a certain component is changed. The arrows in the graphs represent dependencies. The component at the tail of an arrow is depended on by the component at the head of that arrow. Therefore, if a component is changed, the components that it points to should also be changed. [Fig:TraceGraphAvsA](./SecTraceMatrices.md#Figure:TraceGraphAvsA) shows the dependencies of assumptions on each other. [Fig:TraceGraphAvsAll](./SecTraceMatrices.md#Figure:TraceGraphAvsAll) shows the dependencies of data definitions, theoretical models, general definitions, instance models, requirements, likely changes, and unlikely changes on the assumptions. [Fig:TraceGraphRefvsRef](./SecTraceMatrices.md#Figure:TraceGraphRefvsRef) shows the dependencies of data definitions, theoretical models, general definitions, and instance models on each other. [Fig:TraceGraphAllvsR](./SecTraceMatrices.md#Figure:TraceGraphAllvsR) shows the dependencies of requirements and goal statements on the data definitions, theoretical models, general definitions, and instance models. [Fig:TraceGraphAllvsAll](./SecTraceMatrices.md#Figure:TraceGraphAllvsAll) shows the dependencies of dependencies of assumptions, models, definitions, requirements, goals, and changes with each other.
 
-<div id="Figure:TraceGraphAvsA"></div>
+<div id="Figure:TraceGraphAvsA" align="center" >
 
 ![TraceGraphAvsA](./assets/avsa.svg)
 
-**<p align="center">TraceGraphAvsA</p>**
+**TraceGraphAvsA**
 
-<div id="Figure:TraceGraphAvsAll"></div>
+</div>
+
+<div id="Figure:TraceGraphAvsAll" align="center" >
 
 ![TraceGraphAvsAll](./assets/avsall.svg)
 
-**<p align="center">TraceGraphAvsAll</p>**
+**TraceGraphAvsAll**
 
-<div id="Figure:TraceGraphRefvsRef"></div>
+</div>
+
+<div id="Figure:TraceGraphRefvsRef" align="center" >
 
 ![TraceGraphRefvsRef](./assets/refvsref.svg)
 
-**<p align="center">TraceGraphRefvsRef</p>**
+**TraceGraphRefvsRef**
 
-<div id="Figure:TraceGraphAllvsR"></div>
+</div>
+
+<div id="Figure:TraceGraphAllvsR" align="center" >
 
 ![TraceGraphAllvsR](./assets/allvsr.svg)
 
-**<p align="center">TraceGraphAllvsR</p>**
+**TraceGraphAllvsR**
 
-<div id="Figure:TraceGraphAllvsAll"></div>
+</div>
+
+<div id="Figure:TraceGraphAllvsAll" align="center" >
 
 ![TraceGraphAllvsAll](./assets/allvsall.svg)
 
-**<p align="center">TraceGraphAllvsAll</p>**
+**TraceGraphAllvsAll**
+
+</div>
 
 For convenience, the following graphs can be found at the links below:
 

--- a/code/stable/gamephysics/SRS/mdBook/src/SecSysContext.md
+++ b/code/stable/gamephysics/SRS/mdBook/src/SecSysContext.md
@@ -2,11 +2,13 @@
 
 [Fig:sysCtxDiag](./SecSysContext.md#Figure:sysCtxDiag) shows the system context. A circle represents an entity external to the software, the user in this case. A rectangle represents the software system itself (GamePhysics). Arrows are used to show the data flow between the system and its environment.
 
-<div id="Figure:sysCtxDiag"></div>
+<div id="Figure:sysCtxDiag" align="center" >
 
 ![System Context](./assets/sysctx.png)
 
-**<p align="center">System Context</p>**
+**System Context**
+
+</div>
 
 The interaction between the product and the user is through an application programming interface. The responsibilities of the user and the system are as follows:
 

--- a/code/stable/gamephysics/SRS/mdBook/src/SecTraceMatrices.md
+++ b/code/stable/gamephysics/SRS/mdBook/src/SecTraceMatrices.md
@@ -123,35 +123,45 @@ The purpose of the traceability matrices is to provide easy references on what h
 
 The purpose of the traceability graphs is also to provide easy references on what has to be additionally modified if a certain component is changed. The arrows in the graphs represent dependencies. The component at the tail of an arrow is depended on by the component at the head of that arrow. Therefore, if a component is changed, the components that it points to should also be changed. [Fig:TraceGraphAvsA](./SecTraceMatrices.md#Figure:TraceGraphAvsA) shows the dependencies of assumptions on each other. [Fig:TraceGraphAvsAll](./SecTraceMatrices.md#Figure:TraceGraphAvsAll) shows the dependencies of data definitions, theoretical models, general definitions, instance models, requirements, likely changes, and unlikely changes on the assumptions. [Fig:TraceGraphRefvsRef](./SecTraceMatrices.md#Figure:TraceGraphRefvsRef) shows the dependencies of data definitions, theoretical models, general definitions, and instance models on each other. [Fig:TraceGraphAllvsR](./SecTraceMatrices.md#Figure:TraceGraphAllvsR) shows the dependencies of requirements and goal statements on the data definitions, theoretical models, general definitions, and instance models. [Fig:TraceGraphAllvsAll](./SecTraceMatrices.md#Figure:TraceGraphAllvsAll) shows the dependencies of dependencies of assumptions, models, definitions, requirements, goals, and changes with each other.
 
-<div id="Figure:TraceGraphAvsA"></div>
+<div id="Figure:TraceGraphAvsA" align="center" >
 
 ![TraceGraphAvsA](./assets/avsa.svg)
 
-**<p align="center">TraceGraphAvsA</p>**
+**TraceGraphAvsA**
 
-<div id="Figure:TraceGraphAvsAll"></div>
+</div>
+
+<div id="Figure:TraceGraphAvsAll" align="center" >
 
 ![TraceGraphAvsAll](./assets/avsall.svg)
 
-**<p align="center">TraceGraphAvsAll</p>**
+**TraceGraphAvsAll**
 
-<div id="Figure:TraceGraphRefvsRef"></div>
+</div>
+
+<div id="Figure:TraceGraphRefvsRef" align="center" >
 
 ![TraceGraphRefvsRef](./assets/refvsref.svg)
 
-**<p align="center">TraceGraphRefvsRef</p>**
+**TraceGraphRefvsRef**
 
-<div id="Figure:TraceGraphAllvsR"></div>
+</div>
+
+<div id="Figure:TraceGraphAllvsR" align="center" >
 
 ![TraceGraphAllvsR](./assets/allvsr.svg)
 
-**<p align="center">TraceGraphAllvsR</p>**
+**TraceGraphAllvsR**
 
-<div id="Figure:TraceGraphAllvsAll"></div>
+</div>
+
+<div id="Figure:TraceGraphAllvsAll" align="center" >
 
 ![TraceGraphAllvsAll](./assets/allvsall.svg)
 
-**<p align="center">TraceGraphAllvsAll</p>**
+**TraceGraphAllvsAll**
+
+</div>
 
 For convenience, the following graphs can be found at the links below:
 

--- a/code/stable/glassbr/SRS/mdBook/src/SecAppendix.md
+++ b/code/stable/glassbr/SRS/mdBook/src/SecAppendix.md
@@ -2,14 +2,18 @@
 
 This appendix holds the graphs ([Fig:demandVSsod](./SecAppendix.md#Figure:demandVSsod) and [Fig:dimlessloadVSaspect](./SecAppendix.md#Figure:dimlessloadVSaspect)) used for interpolating values needed in the models.
 
-<div id="Figure:demandVSsod"></div>
+<div id="Figure:demandVSsod" align="center" >
 
 ![3 second duration equivalent pressure (\\(q\\)) versus Stand off distance (SD) versus Charge weight (\\(w\\))](./assets/ASTM_F2248-09.png)
 
-**<p align="center">3 second duration equivalent pressure (\\(q\\)) versus Stand off distance (SD) versus Charge weight (\\(w\\))</p>**
+**3 second duration equivalent pressure (\\(q\\)) versus Stand off distance (SD) versus Charge weight (\\(w\\))**
 
-<div id="Figure:dimlessloadVSaspect"></div>
+</div>
+
+<div id="Figure:dimlessloadVSaspect" align="center" >
 
 ![Non dimensional lateral applied load (demand) or pressure (\\(\hat{q}\\)) versus Aspect Ratio (AR) versus Stress distribution factor (Function) (\\(J\\))](./assets/ASTM_F2248-09_BeasonEtAl.png)
 
-**<p align="center">Non dimensional lateral applied load (demand) or pressure (\\(\hat{q}\\)) versus Aspect Ratio (AR) versus Stress distribution factor (Function) (\\(J\\))</p>**
+**Non dimensional lateral applied load (demand) or pressure (\\(\hat{q}\\)) versus Aspect Ratio (AR) versus Stress distribution factor (Function) (\\(J\\))**
+
+</div>

--- a/code/stable/glassbr/SRS/mdBook/src/SecPhysSyst.md
+++ b/code/stable/glassbr/SRS/mdBook/src/SecPhysSyst.md
@@ -6,8 +6,10 @@ PS1: The glass slab.
 
 PS2: The point of explosion. Where the bomb, or any kind of man-made explosion, is located. The stand off distance is the distance between the point of explosion and the glass.
 
-<div id="Figure:physSystImage"></div>
+<div id="Figure:physSystImage" align="center" >
 
 ![The physical system](./assets/physicalsystimage.png)
 
-**<p align="center">The physical system</p>**
+**The physical system**
+
+</div>

--- a/code/stable/glassbr/SRS/mdBook/src/SecSysContext.md
+++ b/code/stable/glassbr/SRS/mdBook/src/SecSysContext.md
@@ -2,11 +2,13 @@
 
 [Fig:sysCtxDiag](./SecSysContext.md#Figure:sysCtxDiag) shows the system context. A circle represents an external entity outside the software, the user in this case. A rectangle represents the software system itself (GlassBR). Arrows are used to show the data flow between the system and its environment.
 
-<div id="Figure:sysCtxDiag"></div>
+<div id="Figure:sysCtxDiag" align="center" >
 
 ![System Context](./assets/SystemContextFigure.png)
 
-**<p align="center">System Context</p>**
+**System Context**
+
+</div>
 
 The interaction between the product and the user is through a user interface. The responsibilities of the user and the system are as follows:
 

--- a/code/stable/glassbr/SRS/mdBook/src/SecTraceMatrices.md
+++ b/code/stable/glassbr/SRS/mdBook/src/SecTraceMatrices.md
@@ -110,35 +110,45 @@ The purpose of the traceability matrices is to provide easy references on what h
 
 The purpose of the traceability graphs is also to provide easy references on what has to be additionally modified if a certain component is changed. The arrows in the graphs represent dependencies. The component at the tail of an arrow is depended on by the component at the head of that arrow. Therefore, if a component is changed, the components that it points to should also be changed. [Fig:TraceGraphAvsA](./SecTraceMatrices.md#Figure:TraceGraphAvsA) shows the dependencies of assumptions on each other. [Fig:TraceGraphAvsAll](./SecTraceMatrices.md#Figure:TraceGraphAvsAll) shows the dependencies of data definitions, theoretical models, general definitions, instance models, requirements, likely changes, and unlikely changes on the assumptions. [Fig:TraceGraphRefvsRef](./SecTraceMatrices.md#Figure:TraceGraphRefvsRef) shows the dependencies of data definitions, theoretical models, general definitions, and instance models on each other. [Fig:TraceGraphAllvsR](./SecTraceMatrices.md#Figure:TraceGraphAllvsR) shows the dependencies of requirements and goal statements on the data definitions, theoretical models, general definitions, and instance models. [Fig:TraceGraphAllvsAll](./SecTraceMatrices.md#Figure:TraceGraphAllvsAll) shows the dependencies of dependencies of assumptions, models, definitions, requirements, goals, and changes with each other.
 
-<div id="Figure:TraceGraphAvsA"></div>
+<div id="Figure:TraceGraphAvsA" align="center" >
 
 ![TraceGraphAvsA](./assets/avsa.svg)
 
-**<p align="center">TraceGraphAvsA</p>**
+**TraceGraphAvsA**
 
-<div id="Figure:TraceGraphAvsAll"></div>
+</div>
+
+<div id="Figure:TraceGraphAvsAll" align="center" >
 
 ![TraceGraphAvsAll](./assets/avsall.svg)
 
-**<p align="center">TraceGraphAvsAll</p>**
+**TraceGraphAvsAll**
 
-<div id="Figure:TraceGraphRefvsRef"></div>
+</div>
+
+<div id="Figure:TraceGraphRefvsRef" align="center" >
 
 ![TraceGraphRefvsRef](./assets/refvsref.svg)
 
-**<p align="center">TraceGraphRefvsRef</p>**
+**TraceGraphRefvsRef**
 
-<div id="Figure:TraceGraphAllvsR"></div>
+</div>
+
+<div id="Figure:TraceGraphAllvsR" align="center" >
 
 ![TraceGraphAllvsR](./assets/allvsr.svg)
 
-**<p align="center">TraceGraphAllvsR</p>**
+**TraceGraphAllvsR**
 
-<div id="Figure:TraceGraphAllvsAll"></div>
+</div>
+
+<div id="Figure:TraceGraphAllvsAll" align="center" >
 
 ![TraceGraphAllvsAll](./assets/allvsall.svg)
 
-**<p align="center">TraceGraphAllvsAll</p>**
+**TraceGraphAllvsAll**
+
+</div>
 
 For convenience, the following graphs can be found at the links below:
 

--- a/code/stable/pdcontroller/SRS/mdBook/src/SecPhysSyst.md
+++ b/code/stable/pdcontroller/SRS/mdBook/src/SecPhysSyst.md
@@ -8,8 +8,10 @@ PS2: The PD Controller.
 
 PS3: The Power Plant.
 
-<div id="Figure:pidSysDiagram"></div>
+<div id="Figure:pidSysDiagram" align="center" >
 
 ![The physical system](./assets/Fig_PDController.png)
 
-**<p align="center">The physical system</p>**
+**The physical system**
+
+</div>

--- a/code/stable/pdcontroller/SRS/mdBook/src/SecSysContext.md
+++ b/code/stable/pdcontroller/SRS/mdBook/src/SecSysContext.md
@@ -2,11 +2,13 @@
 
 [Fig:systemContextDiag](./SecSysContext.md#Figure:systemContextDiag) shows the system context. The circle represents an external entity outside the software, the user in this case. The rectangle represents the software system itself, PD Controller in this case. Arrows are used to show the data flow between the system and its environment.
 
-<div id="Figure:systemContextDiag"></div>
+<div id="Figure:systemContextDiag" align="center" >
 
 ![System Context](./assets/Fig_SystemContext.png)
 
-**<p align="center">System Context</p>**
+**System Context**
+
+</div>
 
 PD Controller is self-contained. The only external interaction is with the user. The responsibilities of the user and the system are as follows:
 

--- a/code/stable/pdcontroller/SRS/mdBook/src/SecTraceMatrices.md
+++ b/code/stable/pdcontroller/SRS/mdBook/src/SecTraceMatrices.md
@@ -79,35 +79,45 @@ The purpose of the traceability matrices is to provide easy references on what h
 
 The purpose of the traceability graphs is also to provide easy references on what has to be additionally modified if a certain component is changed. The arrows in the graphs represent dependencies. The component at the tail of an arrow is depended on by the component at the head of that arrow. Therefore, if a component is changed, the components that it points to should also be changed. [Fig:TraceGraphAvsA](./SecTraceMatrices.md#Figure:TraceGraphAvsA) shows the dependencies of assumptions on each other. [Fig:TraceGraphAvsAll](./SecTraceMatrices.md#Figure:TraceGraphAvsAll) shows the dependencies of data definitions, theoretical models, general definitions, instance models, requirements, likely changes, and unlikely changes on the assumptions. [Fig:TraceGraphRefvsRef](./SecTraceMatrices.md#Figure:TraceGraphRefvsRef) shows the dependencies of data definitions, theoretical models, general definitions, and instance models on each other. [Fig:TraceGraphAllvsR](./SecTraceMatrices.md#Figure:TraceGraphAllvsR) shows the dependencies of requirements and goal statements on the data definitions, theoretical models, general definitions, and instance models. [Fig:TraceGraphAllvsAll](./SecTraceMatrices.md#Figure:TraceGraphAllvsAll) shows the dependencies of dependencies of assumptions, models, definitions, requirements, goals, and changes with each other.
 
-<div id="Figure:TraceGraphAvsA"></div>
+<div id="Figure:TraceGraphAvsA" align="center" >
 
 ![TraceGraphAvsA](./assets/avsa.svg)
 
-**<p align="center">TraceGraphAvsA</p>**
+**TraceGraphAvsA**
 
-<div id="Figure:TraceGraphAvsAll"></div>
+</div>
+
+<div id="Figure:TraceGraphAvsAll" align="center" >
 
 ![TraceGraphAvsAll](./assets/avsall.svg)
 
-**<p align="center">TraceGraphAvsAll</p>**
+**TraceGraphAvsAll**
 
-<div id="Figure:TraceGraphRefvsRef"></div>
+</div>
+
+<div id="Figure:TraceGraphRefvsRef" align="center" >
 
 ![TraceGraphRefvsRef](./assets/refvsref.svg)
 
-**<p align="center">TraceGraphRefvsRef</p>**
+**TraceGraphRefvsRef**
 
-<div id="Figure:TraceGraphAllvsR"></div>
+</div>
+
+<div id="Figure:TraceGraphAllvsR" align="center" >
 
 ![TraceGraphAllvsR](./assets/allvsr.svg)
 
-**<p align="center">TraceGraphAllvsR</p>**
+**TraceGraphAllvsR**
 
-<div id="Figure:TraceGraphAllvsAll"></div>
+</div>
+
+<div id="Figure:TraceGraphAllvsAll" align="center" >
 
 ![TraceGraphAllvsAll](./assets/allvsall.svg)
 
-**<p align="center">TraceGraphAllvsAll</p>**
+**TraceGraphAllvsAll**
+
+</div>
 
 For convenience, the following graphs can be found at the links below:
 

--- a/code/stable/projectile/SRS/mdBook/src/SecPhysSyst.md
+++ b/code/stable/projectile/SRS/mdBook/src/SecPhysSyst.md
@@ -8,8 +8,10 @@ PS2: The projectile (with initial velocity \\({\boldsymbol{v}^{\text{i}}}\\) and
 
 PS3: The target.
 
-<div id="Figure:Launch"></div>
+<div id="Figure:Launch" align="center" >
 
 ![The physical system](./assets/Launch.jpg)
 
-**<p align="center">The physical system</p>**
+**The physical system**
+
+</div>

--- a/code/stable/projectile/SRS/mdBook/src/SecSysContext.md
+++ b/code/stable/projectile/SRS/mdBook/src/SecSysContext.md
@@ -2,11 +2,13 @@
 
 [Fig:sysCtxDiag](./SecSysContext.md#Figure:sysCtxDiag) shows the system context. A circle represents an entity external to the software, the user in this case. A rectangle represents the software system itself (Projectile). Arrows are used to show the data flow between the system and its environment.
 
-<div id="Figure:sysCtxDiag"></div>
+<div id="Figure:sysCtxDiag" align="center" >
 
 ![System Context](./assets/SystemContextFigure.png)
 
-**<p align="center">System Context</p>**
+**System Context**
+
+</div>
 
 The interaction between the product and the user is through an application programming interface. The responsibilities of the user and the system are as follows:
 

--- a/code/stable/projectile/SRS/mdBook/src/SecTraceMatrices.md
+++ b/code/stable/projectile/SRS/mdBook/src/SecTraceMatrices.md
@@ -94,35 +94,45 @@ The purpose of the traceability matrices is to provide easy references on what h
 
 The purpose of the traceability graphs is also to provide easy references on what has to be additionally modified if a certain component is changed. The arrows in the graphs represent dependencies. The component at the tail of an arrow is depended on by the component at the head of that arrow. Therefore, if a component is changed, the components that it points to should also be changed. [Fig:TraceGraphAvsA](./SecTraceMatrices.md#Figure:TraceGraphAvsA) shows the dependencies of assumptions on each other. [Fig:TraceGraphAvsAll](./SecTraceMatrices.md#Figure:TraceGraphAvsAll) shows the dependencies of data definitions, theoretical models, general definitions, instance models, requirements, likely changes, and unlikely changes on the assumptions. [Fig:TraceGraphRefvsRef](./SecTraceMatrices.md#Figure:TraceGraphRefvsRef) shows the dependencies of data definitions, theoretical models, general definitions, and instance models on each other. [Fig:TraceGraphAllvsR](./SecTraceMatrices.md#Figure:TraceGraphAllvsR) shows the dependencies of requirements and goal statements on the data definitions, theoretical models, general definitions, and instance models. [Fig:TraceGraphAllvsAll](./SecTraceMatrices.md#Figure:TraceGraphAllvsAll) shows the dependencies of dependencies of assumptions, models, definitions, requirements, goals, and changes with each other.
 
-<div id="Figure:TraceGraphAvsA"></div>
+<div id="Figure:TraceGraphAvsA" align="center" >
 
 ![TraceGraphAvsA](./assets/avsa.svg)
 
-**<p align="center">TraceGraphAvsA</p>**
+**TraceGraphAvsA**
 
-<div id="Figure:TraceGraphAvsAll"></div>
+</div>
+
+<div id="Figure:TraceGraphAvsAll" align="center" >
 
 ![TraceGraphAvsAll](./assets/avsall.svg)
 
-**<p align="center">TraceGraphAvsAll</p>**
+**TraceGraphAvsAll**
 
-<div id="Figure:TraceGraphRefvsRef"></div>
+</div>
+
+<div id="Figure:TraceGraphRefvsRef" align="center" >
 
 ![TraceGraphRefvsRef](./assets/refvsref.svg)
 
-**<p align="center">TraceGraphRefvsRef</p>**
+**TraceGraphRefvsRef**
 
-<div id="Figure:TraceGraphAllvsR"></div>
+</div>
+
+<div id="Figure:TraceGraphAllvsR" align="center" >
 
 ![TraceGraphAllvsR](./assets/allvsr.svg)
 
-**<p align="center">TraceGraphAllvsR</p>**
+**TraceGraphAllvsR**
 
-<div id="Figure:TraceGraphAllvsAll"></div>
+</div>
+
+<div id="Figure:TraceGraphAllvsAll" align="center" >
 
 ![TraceGraphAllvsAll](./assets/allvsall.svg)
 
-**<p align="center">TraceGraphAllvsAll</p>**
+**TraceGraphAllvsAll**
+
+</div>
 
 For convenience, the following graphs can be found at the links below:
 

--- a/code/stable/sglpend/SRS/mdBook/src/SecPhysSyst.md
+++ b/code/stable/sglpend/SRS/mdBook/src/SecPhysSyst.md
@@ -6,8 +6,10 @@ PS1: The rod.
 
 PS2: The mass.
 
-<div id="Figure:sglpend"></div>
+<div id="Figure:sglpend" align="center" >
 
 ![The physical system](./assets/sglpend.jpg)
 
-**<p align="center">The physical system</p>**
+**The physical system**
+
+</div>

--- a/code/stable/sglpend/SRS/mdBook/src/SecSysContext.md
+++ b/code/stable/sglpend/SRS/mdBook/src/SecSysContext.md
@@ -2,11 +2,13 @@
 
 [Fig:sysCtxDiag](./SecSysContext.md#Figure:sysCtxDiag) shows the system context. A circle represents an entity external to the software, the user in this case. A rectangle represents the software system itself (SglPend). Arrows are used to show the data flow between the system and its environment.
 
-<div id="Figure:sysCtxDiag"></div>
+<div id="Figure:sysCtxDiag" align="center" >
 
 ![System Context](./assets/SystemContextFigure.png)
 
-**<p align="center">System Context</p>**
+**System Context**
+
+</div>
 
 The interaction between the product and the user is through an application programming interface. The responsibilities of the user and the system are as follows:
 

--- a/code/stable/sglpend/SRS/mdBook/src/SecTraceMatrices.md
+++ b/code/stable/sglpend/SRS/mdBook/src/SecTraceMatrices.md
@@ -86,35 +86,45 @@ The purpose of the traceability matrices is to provide easy references on what h
 
 The purpose of the traceability graphs is also to provide easy references on what has to be additionally modified if a certain component is changed. The arrows in the graphs represent dependencies. The component at the tail of an arrow is depended on by the component at the head of that arrow. Therefore, if a component is changed, the components that it points to should also be changed. [Fig:TraceGraphAvsA](./SecTraceMatrices.md#Figure:TraceGraphAvsA) shows the dependencies of assumptions on each other. [Fig:TraceGraphAvsAll](./SecTraceMatrices.md#Figure:TraceGraphAvsAll) shows the dependencies of data definitions, theoretical models, general definitions, instance models, requirements, likely changes, and unlikely changes on the assumptions. [Fig:TraceGraphRefvsRef](./SecTraceMatrices.md#Figure:TraceGraphRefvsRef) shows the dependencies of data definitions, theoretical models, general definitions, and instance models on each other. [Fig:TraceGraphAllvsR](./SecTraceMatrices.md#Figure:TraceGraphAllvsR) shows the dependencies of requirements and goal statements on the data definitions, theoretical models, general definitions, and instance models. [Fig:TraceGraphAllvsAll](./SecTraceMatrices.md#Figure:TraceGraphAllvsAll) shows the dependencies of dependencies of assumptions, models, definitions, requirements, goals, and changes with each other.
 
-<div id="Figure:TraceGraphAvsA"></div>
+<div id="Figure:TraceGraphAvsA" align="center" >
 
 ![TraceGraphAvsA](./assets/avsa.svg)
 
-**<p align="center">TraceGraphAvsA</p>**
+**TraceGraphAvsA**
 
-<div id="Figure:TraceGraphAvsAll"></div>
+</div>
+
+<div id="Figure:TraceGraphAvsAll" align="center" >
 
 ![TraceGraphAvsAll](./assets/avsall.svg)
 
-**<p align="center">TraceGraphAvsAll</p>**
+**TraceGraphAvsAll**
 
-<div id="Figure:TraceGraphRefvsRef"></div>
+</div>
+
+<div id="Figure:TraceGraphRefvsRef" align="center" >
 
 ![TraceGraphRefvsRef](./assets/refvsref.svg)
 
-**<p align="center">TraceGraphRefvsRef</p>**
+**TraceGraphRefvsRef**
 
-<div id="Figure:TraceGraphAllvsR"></div>
+</div>
+
+<div id="Figure:TraceGraphAllvsR" align="center" >
 
 ![TraceGraphAllvsR](./assets/allvsr.svg)
 
-**<p align="center">TraceGraphAllvsR</p>**
+**TraceGraphAllvsR**
 
-<div id="Figure:TraceGraphAllvsAll"></div>
+</div>
+
+<div id="Figure:TraceGraphAllvsAll" align="center" >
 
 ![TraceGraphAllvsAll](./assets/allvsall.svg)
 
-**<p align="center">TraceGraphAllvsAll</p>**
+**TraceGraphAllvsAll**
+
+</div>
 
 For convenience, the following graphs can be found at the links below:
 

--- a/code/stable/ssp/SRS/mdBook/src/SecPhysSyst.md
+++ b/code/stable/ssp/SRS/mdBook/src/SecPhysSyst.md
@@ -6,24 +6,30 @@ PS1: A slope comprised of one soil layer.
 
 PS2: A water table, which may or may not exist.
 
-<div id="Figure:PhysicalSystem"></div>
+<div id="Figure:PhysicalSystem" align="center" >
 
 ![An example slope for analysis by SSP, where the dashed line represents the water table](./assets/PhysSyst.png)
 
-**<p align="center">An example slope for analysis by SSP, where the dashed line represents the water table</p>**
+**An example slope for analysis by SSP, where the dashed line represents the water table**
+
+</div>
 
 Morgenstern-Price analysis [morgenstern1965](./SecReferences.md#morgenstern1965) of the slope involves representing the slope as a series of vertical slices. As shown in [Fig:IndexConvention](./SecPhysSyst.md#Figure:IndexConvention), the index \\(i\\) is used to denote a value for a single slice, and an interslice value at a given index \\(i\\) refers to the value between slice \\(i\\) and adjacent slice \\(i+1\\).
 
-<div id="Figure:IndexConvention"></div>
+<div id="Figure:IndexConvention" align="center" >
 
 ![Index convention for slice and interslice values](./assets/IndexConvention.png)
 
-**<p align="center">Index convention for slice and interslice values</p>**
+**Index convention for slice and interslice values**
+
+</div>
 
 A free body diagram of the forces acting on a slice is displayed in [Fig:ForceDiagram](./SecPhysSyst.md#Figure:ForceDiagram). The specific forces and symbols will be discussed in detail in [Sec:General Definitions](./SecGDs.md#Sec:GDs) and [Sec:Data Definitions](./SecDDs.md#Sec:DDs).
 
-<div id="Figure:ForceDiagram"></div>
+<div id="Figure:ForceDiagram" align="center" >
 
 ![Free body diagram of forces acting on a slice](./assets/ForceDiagram.png)
 
-**<p align="center">Free body diagram of forces acting on a slice</p>**
+**Free body diagram of forces acting on a slice**
+
+</div>

--- a/code/stable/ssp/SRS/mdBook/src/SecSysContext.md
+++ b/code/stable/ssp/SRS/mdBook/src/SecSysContext.md
@@ -2,11 +2,13 @@
 
 [Fig:sysCtxDiag](./SecSysContext.md#Figure:sysCtxDiag) shows the system context. A circle represents an external entity outside the software. A rectangle represents the software system itself (SSP). Arrows are used to show the data flow between the system and its environment.
 
-<div id="Figure:sysCtxDiag"></div>
+<div id="Figure:sysCtxDiag" align="center" >
 
 ![System Context](./assets/SystemContextFigure.png)
 
-**<p align="center">System Context</p>**
+**System Context**
+
+</div>
 
 The responsibilities of the user and the system are as follows:
 

--- a/code/stable/ssp/SRS/mdBook/src/SecTraceMatrices.md
+++ b/code/stable/ssp/SRS/mdBook/src/SecTraceMatrices.md
@@ -168,35 +168,45 @@ The purpose of the traceability matrices is to provide easy references on what h
 
 The purpose of the traceability graphs is also to provide easy references on what has to be additionally modified if a certain component is changed. The arrows in the graphs represent dependencies. The component at the tail of an arrow is depended on by the component at the head of that arrow. Therefore, if a component is changed, the components that it points to should also be changed. [Fig:TraceGraphAvsA](./SecTraceMatrices.md#Figure:TraceGraphAvsA) shows the dependencies of assumptions on each other. [Fig:TraceGraphAvsAll](./SecTraceMatrices.md#Figure:TraceGraphAvsAll) shows the dependencies of data definitions, theoretical models, general definitions, instance models, requirements, likely changes, and unlikely changes on the assumptions. [Fig:TraceGraphRefvsRef](./SecTraceMatrices.md#Figure:TraceGraphRefvsRef) shows the dependencies of data definitions, theoretical models, general definitions, and instance models on each other. [Fig:TraceGraphAllvsR](./SecTraceMatrices.md#Figure:TraceGraphAllvsR) shows the dependencies of requirements and goal statements on the data definitions, theoretical models, general definitions, and instance models. [Fig:TraceGraphAllvsAll](./SecTraceMatrices.md#Figure:TraceGraphAllvsAll) shows the dependencies of dependencies of assumptions, models, definitions, requirements, goals, and changes with each other.
 
-<div id="Figure:TraceGraphAvsA"></div>
+<div id="Figure:TraceGraphAvsA" align="center" >
 
 ![TraceGraphAvsA](./assets/avsa.svg)
 
-**<p align="center">TraceGraphAvsA</p>**
+**TraceGraphAvsA**
 
-<div id="Figure:TraceGraphAvsAll"></div>
+</div>
+
+<div id="Figure:TraceGraphAvsAll" align="center" >
 
 ![TraceGraphAvsAll](./assets/avsall.svg)
 
-**<p align="center">TraceGraphAvsAll</p>**
+**TraceGraphAvsAll**
 
-<div id="Figure:TraceGraphRefvsRef"></div>
+</div>
+
+<div id="Figure:TraceGraphRefvsRef" align="center" >
 
 ![TraceGraphRefvsRef](./assets/refvsref.svg)
 
-**<p align="center">TraceGraphRefvsRef</p>**
+**TraceGraphRefvsRef**
 
-<div id="Figure:TraceGraphAllvsR"></div>
+</div>
+
+<div id="Figure:TraceGraphAllvsR" align="center" >
 
 ![TraceGraphAllvsR](./assets/allvsr.svg)
 
-**<p align="center">TraceGraphAllvsR</p>**
+**TraceGraphAllvsR**
 
-<div id="Figure:TraceGraphAllvsAll"></div>
+</div>
+
+<div id="Figure:TraceGraphAllvsAll" align="center" >
 
 ![TraceGraphAllvsAll](./assets/allvsall.svg)
 
-**<p align="center">TraceGraphAllvsAll</p>**
+**TraceGraphAllvsAll**
+
+</div>
 
 For convenience, the following graphs can be found at the links below:
 

--- a/code/stable/swhs/SRS/mdBook/src/SecPhysSyst.md
+++ b/code/stable/swhs/SRS/mdBook/src/SecPhysSyst.md
@@ -8,8 +8,10 @@ PS2: Heating coil at bottom of tank. (\\({q\_{\text{C}}}\\) represents the heat 
 
 PS3: PCM suspended in tank. (\\({q\_{\text{P}}}\\) represents the heat flux into the PCM from water.)
 
-<div id="Figure:Tank"></div>
+<div id="Figure:Tank" align="center" >
 
 ![Solar water heating tank, with heat flux into the water from the coil of \\({q\_{\text{C}}}\\) and heat flux into the PCM from water of \\({q\_{\text{P}}}\\)](./assets/Tank.png)
 
-**<p align="center">Solar water heating tank, with heat flux into the water from the coil of \\({q\_{\text{C}}}\\) and heat flux into the PCM from water of \\({q\_{\text{P}}}\\)</p>**
+**Solar water heating tank, with heat flux into the water from the coil of \\({q\_{\text{C}}}\\) and heat flux into the PCM from water of \\({q\_{\text{P}}}\\)**
+
+</div>

--- a/code/stable/swhs/SRS/mdBook/src/SecSysContext.md
+++ b/code/stable/swhs/SRS/mdBook/src/SecSysContext.md
@@ -2,11 +2,13 @@
 
 [Fig:SysCon](./SecSysContext.md#Figure:SysCon) shows the system context. A circle represents an external entity outside the software, the user in this case. A rectangle represents the software system itself (SWHS). Arrows are used to show the data flow between the system and its environment.
 
-<div id="Figure:SysCon"></div>
+<div id="Figure:SysCon" align="center" >
 
 ![[Fig:SysCon](./SecSysContext.md#Figure:SysCon): System Context](./assets/SystemContextFigure.png)
 
-**<p align="center">[Fig:SysCon](./SecSysContext.md#Figure:SysCon): System Context</p>**
+**[Fig:SysCon](./SecSysContext.md#Figure:SysCon): System Context**
+
+</div>
 
 SWHS is mostly self-contained. The only external interaction is through the user interface. The responsibilities of the user and the system are as follows:
 

--- a/code/stable/swhs/SRS/mdBook/src/SecTraceMatrices.md
+++ b/code/stable/swhs/SRS/mdBook/src/SecTraceMatrices.md
@@ -135,35 +135,45 @@ The purpose of the traceability matrices is to provide easy references on what h
 
 The purpose of the traceability graphs is also to provide easy references on what has to be additionally modified if a certain component is changed. The arrows in the graphs represent dependencies. The component at the tail of an arrow is depended on by the component at the head of that arrow. Therefore, if a component is changed, the components that it points to should also be changed. [Fig:TraceGraphAvsA](./SecTraceMatrices.md#Figure:TraceGraphAvsA) shows the dependencies of assumptions on each other. [Fig:TraceGraphAvsAll](./SecTraceMatrices.md#Figure:TraceGraphAvsAll) shows the dependencies of data definitions, theoretical models, general definitions, instance models, requirements, likely changes, and unlikely changes on the assumptions. [Fig:TraceGraphRefvsRef](./SecTraceMatrices.md#Figure:TraceGraphRefvsRef) shows the dependencies of data definitions, theoretical models, general definitions, and instance models on each other. [Fig:TraceGraphAllvsR](./SecTraceMatrices.md#Figure:TraceGraphAllvsR) shows the dependencies of requirements and goal statements on the data definitions, theoretical models, general definitions, and instance models. [Fig:TraceGraphAllvsAll](./SecTraceMatrices.md#Figure:TraceGraphAllvsAll) shows the dependencies of dependencies of assumptions, models, definitions, requirements, goals, and changes with each other.
 
-<div id="Figure:TraceGraphAvsA"></div>
+<div id="Figure:TraceGraphAvsA" align="center" >
 
 ![TraceGraphAvsA](./assets/avsa.svg)
 
-**<p align="center">TraceGraphAvsA</p>**
+**TraceGraphAvsA**
 
-<div id="Figure:TraceGraphAvsAll"></div>
+</div>
+
+<div id="Figure:TraceGraphAvsAll" align="center" >
 
 ![TraceGraphAvsAll](./assets/avsall.svg)
 
-**<p align="center">TraceGraphAvsAll</p>**
+**TraceGraphAvsAll**
 
-<div id="Figure:TraceGraphRefvsRef"></div>
+</div>
+
+<div id="Figure:TraceGraphRefvsRef" align="center" >
 
 ![TraceGraphRefvsRef](./assets/refvsref.svg)
 
-**<p align="center">TraceGraphRefvsRef</p>**
+**TraceGraphRefvsRef**
 
-<div id="Figure:TraceGraphAllvsR"></div>
+</div>
+
+<div id="Figure:TraceGraphAllvsR" align="center" >
 
 ![TraceGraphAllvsR](./assets/allvsr.svg)
 
-**<p align="center">TraceGraphAllvsR</p>**
+**TraceGraphAllvsR**
 
-<div id="Figure:TraceGraphAllvsAll"></div>
+</div>
+
+<div id="Figure:TraceGraphAllvsAll" align="center" >
 
 ![TraceGraphAllvsAll](./assets/allvsall.svg)
 
-**<p align="center">TraceGraphAllvsAll</p>**
+**TraceGraphAllvsAll**
+
+</div>
 
 For convenience, the following graphs can be found at the links below:
 

--- a/code/stable/swhsnopcm/SRS/mdBook/src/SecPhysSyst.md
+++ b/code/stable/swhsnopcm/SRS/mdBook/src/SecPhysSyst.md
@@ -6,8 +6,10 @@ PS1: Tank containing water.
 
 PS2: Heating coil at bottom of tank. (\\({q\_{\text{C}}}\\) represents the heat flux into the water from the coil.)
 
-<div id="Figure:Tank"></div>
+<div id="Figure:Tank" align="center" >
 
 ![Solar water heating tank, with heat flux from heating coil of \\({q\_{\text{C}}}\\)](./assets/TankWaterOnly.png)
 
-**<p align="center">Solar water heating tank, with heat flux from heating coil of \\({q\_{\text{C}}}\\)</p>**
+**Solar water heating tank, with heat flux from heating coil of \\({q\_{\text{C}}}\\)**
+
+</div>

--- a/code/stable/swhsnopcm/SRS/mdBook/src/SecSysContext.md
+++ b/code/stable/swhsnopcm/SRS/mdBook/src/SecSysContext.md
@@ -2,11 +2,13 @@
 
 [Fig:SysCon](./SecSysContext.md#Figure:SysCon) shows the system context. A circle represents an external entity outside the software, the user in this case. A rectangle represents the software system itself (SWHSNoPCM). Arrows are used to show the data flow between the system and its environment.
 
-<div id="Figure:SysCon"></div>
+<div id="Figure:SysCon" align="center" >
 
 ![[Fig:SysCon](./SecSysContext.md#Figure:SysCon): System Context](./assets/SystemContextFigure.png)
 
-**<p align="center">[Fig:SysCon](./SecSysContext.md#Figure:SysCon): System Context</p>**
+**[Fig:SysCon](./SecSysContext.md#Figure:SysCon): System Context**
+
+</div>
 
 SWHSNoPCM is mostly self-contained. The only external interaction is through the user interface. The responsibilities of the user and the system are as follows:
 

--- a/code/stable/swhsnopcm/SRS/mdBook/src/SecTraceMatrices.md
+++ b/code/stable/swhsnopcm/SRS/mdBook/src/SecTraceMatrices.md
@@ -98,35 +98,45 @@ The purpose of the traceability matrices is to provide easy references on what h
 
 The purpose of the traceability graphs is also to provide easy references on what has to be additionally modified if a certain component is changed. The arrows in the graphs represent dependencies. The component at the tail of an arrow is depended on by the component at the head of that arrow. Therefore, if a component is changed, the components that it points to should also be changed. [Fig:TraceGraphAvsA](./SecTraceMatrices.md#Figure:TraceGraphAvsA) shows the dependencies of assumptions on each other. [Fig:TraceGraphAvsAll](./SecTraceMatrices.md#Figure:TraceGraphAvsAll) shows the dependencies of data definitions, theoretical models, general definitions, instance models, requirements, likely changes, and unlikely changes on the assumptions. [Fig:TraceGraphRefvsRef](./SecTraceMatrices.md#Figure:TraceGraphRefvsRef) shows the dependencies of data definitions, theoretical models, general definitions, and instance models on each other. [Fig:TraceGraphAllvsR](./SecTraceMatrices.md#Figure:TraceGraphAllvsR) shows the dependencies of requirements and goal statements on the data definitions, theoretical models, general definitions, and instance models. [Fig:TraceGraphAllvsAll](./SecTraceMatrices.md#Figure:TraceGraphAllvsAll) shows the dependencies of dependencies of assumptions, models, definitions, requirements, goals, and changes with each other.
 
-<div id="Figure:TraceGraphAvsA"></div>
+<div id="Figure:TraceGraphAvsA" align="center" >
 
 ![TraceGraphAvsA](./assets/avsa.svg)
 
-**<p align="center">TraceGraphAvsA</p>**
+**TraceGraphAvsA**
 
-<div id="Figure:TraceGraphAvsAll"></div>
+</div>
+
+<div id="Figure:TraceGraphAvsAll" align="center" >
 
 ![TraceGraphAvsAll](./assets/avsall.svg)
 
-**<p align="center">TraceGraphAvsAll</p>**
+**TraceGraphAvsAll**
 
-<div id="Figure:TraceGraphRefvsRef"></div>
+</div>
+
+<div id="Figure:TraceGraphRefvsRef" align="center" >
 
 ![TraceGraphRefvsRef](./assets/refvsref.svg)
 
-**<p align="center">TraceGraphRefvsRef</p>**
+**TraceGraphRefvsRef**
 
-<div id="Figure:TraceGraphAllvsR"></div>
+</div>
+
+<div id="Figure:TraceGraphAllvsR" align="center" >
 
 ![TraceGraphAllvsR](./assets/allvsr.svg)
 
-**<p align="center">TraceGraphAllvsR</p>**
+**TraceGraphAllvsR**
 
-<div id="Figure:TraceGraphAllvsAll"></div>
+</div>
+
+<div id="Figure:TraceGraphAllvsAll" align="center" >
 
 ![TraceGraphAllvsAll](./assets/allvsall.svg)
 
-**<p align="center">TraceGraphAllvsAll</p>**
+**TraceGraphAllvsAll**
+
+</div>
 
 For convenience, the following graphs can be found at the links below:
 


### PR DESCRIPTION
I noticed that figures in mdBook are not automatically centered. While images that span the full width seem centered, smaller images often appear misaligned. For example, in [sglpend](https://jacquescarette.github.io/Drasil/examples/sglpend/SRS/mdBook/book/SecPhysSyst.html) and [gamephysics](https://jacquescarette.github.io/Drasil/examples/gamephysics/SRS/mdBook/book/SecSysContext.html).

In this PR, I've centered the images by adding an additional attribute in the div tag that wraps the images and captions.