### PR TITLE
Add `weeder` to make file

### DIFF
--- a/.github/workflows/Lint.yaml
+++ b/.github/workflows/Lint.yaml
@@ -41,7 +41,7 @@ jobs:
         if: ${{ steps.filter.outputs.hs == 'true' }}
         uses: haskell-actions/hlint-setup@v2
         with: # DO NOT MODIFY THE BELOW LINE MANUALLY -- code/scripts/update_default_stackage.sh is in charge of this!
-          version: '3.4.1' # HLINT VERSION TIED TO CURRENT TARGET (LTS-20.26)
+          version: '3.6.1' # HLINT VERSION TIED TO CURRENT TARGET (LTS-22.31)
 
       - name: 'Run HLint'
         if: ${{ steps.filter.outputs.hs == 'true' }}

--- a/code/Makefile
+++ b/code/Makefile
@@ -539,6 +539,9 @@ stan: ##@Stan Run Stan static analysis tool on the Drasil packages.
 	cat drasil-*/stan.log
 #use to display stan logs, cat drasil-*/stan.log
 
+weeder:
+	weeder
+
 # Credits to "nowox" from StackOverflow: https://stackoverflow.com/a/30796664/16760741
 HELP_FUN = \
 	%help; while(<>){push@{$$help{$$2//'options'}},[$$1,$$3] \

--- a/code/drasil-build/stack.yaml
+++ b/code/drasil-build/stack.yaml
@@ -17,7 +17,7 @@
 #
 # resolver: ./custom-snapshot.yaml
 # resolver: https://example.com/snapshots/2018-01-01.yaml
-resolver: lts-20.26
+resolver: lts-22.31
 
 # User packages to be built.
 # Various formats can be used as shown in the example below.

--- a/code/drasil-code/stack.yaml
+++ b/code/drasil-code/stack.yaml
@@ -17,7 +17,7 @@
 #
 # resolver: ./custom-snapshot.yaml
 # resolver: https://example.com/snapshots/2018-01-01.yaml
-resolver: lts-20.26
+resolver: lts-22.31
 
 # User packages to be built.
 # Various formats can be used as shown in the example below.

--- a/code/drasil-codeLang/stack.yaml
+++ b/code/drasil-codeLang/stack.yaml
@@ -17,7 +17,7 @@
 #
 # resolver: ./custom-snapshot.yaml
 # resolver: https://example.com/snapshots/2018-01-01.yaml
-resolver: lts-20.26
+resolver: lts-22.31
 
 # User packages to be built.
 # Various formats can be used as shown in the example below.

--- a/code/drasil-data/stack.yaml
+++ b/code/drasil-data/stack.yaml
@@ -17,7 +17,7 @@
 #
 # resolver: ./custom-snapshot.yaml
 # resolver: https://example.com/snapshots/2018-01-01.yaml
-resolver: lts-20.26
+resolver: lts-22.31
 
 # User packages to be built.
 # Various formats can be used as shown in the example below.

--- a/code/drasil-database/stack.yaml
+++ b/code/drasil-database/stack.yaml
@@ -17,7 +17,7 @@
 #
 # resolver: ./custom-snapshot.yaml
 # resolver: https://example.com/snapshots/2018-01-01.yaml
-resolver: lts-20.26
+resolver: lts-22.31
 
 # User packages to be built.
 # Various formats can be used as shown in the example below.

--- a/code/drasil-docLang/stack.yaml
+++ b/code/drasil-docLang/stack.yaml
@@ -17,7 +17,7 @@
 #
 # resolver: ./custom-snapshot.yaml
 # resolver: https://example.com/snapshots/2018-01-01.yaml
-resolver: lts-20.26
+resolver: lts-22.31
 
 # User packages to be built.
 # Various formats can be used as shown in the example below.

--- a/code/drasil-example/dblpend/stack.yaml
+++ b/code/drasil-example/dblpend/stack.yaml
@@ -1,4 +1,4 @@
-resolver: lts-20.26
+resolver: lts-22.31
 
 packages:
 - .

--- a/code/drasil-example/gamephysics/stack.yaml
+++ b/code/drasil-example/gamephysics/stack.yaml
@@ -1,4 +1,4 @@
-resolver: lts-20.26
+resolver: lts-22.31
 
 packages:
 - .

--- a/code/drasil-example/glassbr/stack.yaml
+++ b/code/drasil-example/glassbr/stack.yaml
@@ -1,4 +1,4 @@
-resolver: lts-20.26
+resolver: lts-22.31
 
 packages:
 - .

--- a/code/drasil-example/hghc/stack.yaml
+++ b/code/drasil-example/hghc/stack.yaml
@@ -1,4 +1,4 @@
-resolver: lts-20.26
+resolver: lts-22.31
 
 packages:
 - .

--- a/code/drasil-example/pdcontroller/stack.yaml
+++ b/code/drasil-example/pdcontroller/stack.yaml
@@ -1,4 +1,4 @@
-resolver: lts-20.26
+resolver: lts-22.31
 
 packages:
 - .

--- a/code/drasil-example/projectile/stack.yaml
+++ b/code/drasil-example/projectile/stack.yaml
@@ -1,4 +1,4 @@
-resolver: lts-20.26
+resolver: lts-22.31
 
 packages:
 - .

--- a/code/drasil-example/sglpend/stack.yaml
+++ b/code/drasil-example/sglpend/stack.yaml
@@ -1,4 +1,4 @@
-resolver: lts-20.26
+resolver: lts-22.31
 
 packages:
 - .

--- a/code/drasil-example/ssp/stack.yaml
+++ b/code/drasil-example/ssp/stack.yaml
@@ -1,4 +1,4 @@
-resolver: lts-20.26
+resolver: lts-22.31
 
 packages:
 - .

--- a/code/drasil-example/swhs/stack.yaml
+++ b/code/drasil-example/swhs/stack.yaml
@@ -1,4 +1,4 @@
-resolver: lts-20.26
+resolver: lts-22.31
 
 packages:
 - .

--- a/code/drasil-example/swhsnopcm/stack.yaml
+++ b/code/drasil-example/swhsnopcm/stack.yaml
@@ -1,4 +1,4 @@
-resolver: lts-20.26
+resolver: lts-22.31
 
 packages:
 - .

--- a/code/drasil-example/template/stack.yaml
+++ b/code/drasil-example/template/stack.yaml
@@ -1,4 +1,4 @@
-resolver: lts-20.26
+resolver: lts-22.31
 
 packages:
 - .

--- a/code/drasil-gen/stack.yaml
+++ b/code/drasil-gen/stack.yaml
@@ -17,7 +17,7 @@
 #
 # resolver: ./custom-snapshot.yaml
 # resolver: https://example.com/snapshots/2018-01-01.yaml
-resolver: lts-20.26
+resolver: lts-22.31
 
 # User packages to be built.
 # Various formats can be used as shown in the example below.

--- a/code/drasil-gool/lib/Drasil/GOOL/Helpers.hs
+++ b/code/drasil-gool/lib/Drasil/GOOL/Helpers.hs
@@ -10,7 +10,7 @@ import Utils.Drasil (blank)
 import qualified Drasil.GOOL.CodeType as C (CodeType(..))
 
 import Prelude hiding ((<>))
-import Control.Applicative (liftA2, liftA3)
+import Control.Applicative (liftA3)
 import Control.Monad (liftM2, liftM3)
 import Control.Monad.State (State)
 import Data.List (intersperse)

--- a/code/drasil-gool/lib/Drasil/GOOL/LanguageRenderer/CSharpRenderer.hs
+++ b/code/drasil-gool/lib/Drasil/GOOL/LanguageRenderer/CSharpRenderer.hs
@@ -102,7 +102,6 @@ import Drasil.GOOL.State (VS, lensGStoFS, lensMStoVS, modifyReturn, revFiles,
   useVarName, genLoopIndex)
 
 import Prelude hiding (break,print,(<>),sin,cos,tan,floor)
-import Control.Applicative (liftA2)
 import Control.Lens.Zoom (zoom)
 import Control.Monad (join)
 import Control.Monad.State (modify)

--- a/code/drasil-gool/lib/Drasil/GOOL/LanguageRenderer/CppRenderer.hs
+++ b/code/drasil-gool/lib/Drasil/GOOL/LanguageRenderer/CppRenderer.hs
@@ -110,7 +110,6 @@ import Drasil.GOOL.State (CS, MS, VS, lensGStoFS, lensFStoCS, lensFStoMS,
   addIter, getIter, resetIter, useVarName, genLoopIndex)
 
 import Prelude hiding (break,print,(<>),sin,cos,tan,floor,pi,log,exp,mod,max)
-import Control.Applicative (liftA2)
 import Control.Lens.Zoom (zoom)
 import Control.Monad (join)
 import Control.Monad.State (State, modify)

--- a/code/drasil-gool/lib/Drasil/GOOL/LanguageRenderer/JavaRenderer.hs
+++ b/code/drasil-gool/lib/Drasil/GOOL/LanguageRenderer/JavaRenderer.hs
@@ -111,7 +111,6 @@ import Drasil.GOOL.State (VS, lensGStoFS, lensMStoFS, lensMStoVS, lensVStoFS,
   genLoopIndex)
 
 import Prelude hiding (break,print,sin,cos,tan,floor,(<>))
-import Control.Applicative (liftA2)
 import Control.Lens.Zoom (zoom)
 import Control.Monad (join)
 import Control.Monad.State (modify)

--- a/code/drasil-gool/lib/Drasil/GOOL/LanguageRenderer/JuliaRenderer.hs
+++ b/code/drasil-gool/lib/Drasil/GOOL/LanguageRenderer/JuliaRenderer.hs
@@ -84,7 +84,6 @@ import Drasil.GOOL.State (VS, lensGStoFS, revFiles, setFileType, lensMStoVS,
   getModuleImports, addModuleImportVS, getUsing, getLangImports, getLibImports,
   addLibImportVS, useVarName, getMainDoc, genLoopIndex, genVarNameIf)
 
-import Control.Applicative (liftA2)
 import Prelude hiding (break,print,sin,cos,tan,floor,(<>))
 import Data.Maybe (fromMaybe, isNothing)
 import Data.Functor ((<&>))

--- a/code/drasil-gool/lib/Drasil/GOOL/LanguageRenderer/PythonRenderer.hs
+++ b/code/drasil-gool/lib/Drasil/GOOL/LanguageRenderer/PythonRenderer.hs
@@ -98,7 +98,6 @@ import Drasil.GOOL.State (MS, VS, lensGStoFS, lensMStoVS, lensVStoMS, revFiles,
 
 import Prelude hiding (break,print,sin,cos,tan,floor,(<>))
 import Data.Maybe (fromMaybe)
-import Control.Applicative (liftA2)
 import Control.Lens.Zoom (zoom)
 import Control.Monad (join)
 import Control.Monad.State (modify)

--- a/code/drasil-gool/lib/Drasil/GOOL/LanguageRenderer/SwiftRenderer.hs
+++ b/code/drasil-gool/lib/Drasil/GOOL/LanguageRenderer/SwiftRenderer.hs
@@ -105,7 +105,6 @@ import Drasil.GOOL.State (MS, VS, lensGStoFS, lensFStoCS, lensFStoMS,
   genVarNameIf)
 
 import Prelude hiding (break,print,(<>),sin,cos,tan,floor)
-import Control.Applicative (liftA2)
 import Control.Lens.Zoom (zoom)
 import Control.Monad.State (modify)
 import Data.Composition ((.:))

--- a/code/drasil-gool/stack.yaml
+++ b/code/drasil-gool/stack.yaml
@@ -17,7 +17,7 @@
 #
 # resolver: ./custom-snapshot.yaml
 # resolver: https://example.com/snapshots/2018-01-01.yaml
-resolver: lts-20.26
+resolver: lts-22.31
 
 # User packages to be built.
 # Various formats can be used as shown in the example below.

--- a/code/drasil-lang/stack.yaml
+++ b/code/drasil-lang/stack.yaml
@@ -17,7 +17,7 @@
 #
 # resolver: ./custom-snapshot.yaml
 # resolver: https://example.com/snapshots/2018-01-01.yaml
-resolver: lts-20.26
+resolver: lts-22.31
 
 # User packages to be built.
 # Various formats can be used as shown in the example below.

--- a/code/drasil-metadata/stack.yaml
+++ b/code/drasil-metadata/stack.yaml
@@ -15,7 +15,7 @@
 #
 # resolver: ./custom-snapshot.yaml
 # resolver: https://example.com/snapshots/2018-01-01.yaml
-resolver: lts-20.26
+resolver: lts-22.31
 
 # User packages to be built.
 # Various formats can be used as shown in the example below.

--- a/code/drasil-printers/lib/Language/Drasil/TeX/Monad.hs
+++ b/code/drasil-printers/lib/Language/Drasil/TeX/Monad.hs
@@ -7,8 +7,6 @@ import qualified Text.PrettyPrint as TP
 
 import Language.Drasil
 
-import Control.Applicative hiding (empty)
-
 import qualified Language.Drasil.Printing.Helpers as H
 
 -----------------------------------------------------------------------------

--- a/code/drasil-printers/stack.yaml
+++ b/code/drasil-printers/stack.yaml
@@ -17,7 +17,7 @@
 #
 # resolver: ./custom-snapshot.yaml
 # resolver: https://example.com/snapshots/2018-01-01.yaml
-resolver: lts-20.26
+resolver: lts-22.31
 
 # User packages to be built.
 # Various formats can be used as shown in the example below.

--- a/code/drasil-sysinfo/stack.yaml
+++ b/code/drasil-sysinfo/stack.yaml
@@ -17,7 +17,7 @@
 #
 # resolver: ./custom-snapshot.yaml
 # resolver: https://example.com/snapshots/2018-01-01.yaml
-resolver: lts-20.26
+resolver: lts-22.31
 
 # User packages to be built.
 # Various formats can be used as shown in the example below.

--- a/code/drasil-theory/stack.yaml
+++ b/code/drasil-theory/stack.yaml
@@ -17,7 +17,7 @@
 #
 # resolver: ./custom-snapshot.yaml
 # resolver: https://example.com/snapshots/2018-01-01.yaml
-resolver: lts-20.26
+resolver: lts-22.31
 
 # User packages to be built.
 # Various formats can be used as shown in the example below.

--- a/code/drasil-utils/stack.yaml
+++ b/code/drasil-utils/stack.yaml
@@ -17,7 +17,7 @@
 #
 # resolver: ./custom-snapshot.yaml
 # resolver: https://example.com/snapshots/2018-01-01.yaml
-resolver: lts-20.26
+resolver: lts-22.31
 
 # User packages to be built.
 # Various formats can be used as shown in the example below.

--- a/code/drasil-website/stack.yaml
+++ b/code/drasil-website/stack.yaml
@@ -1,4 +1,4 @@
-resolver: lts-20.26
+resolver: lts-22.31
 
 packages:
 - .

--- a/code/scripts/ClassInstDepGen.hs
+++ b/code/scripts/ClassInstDepGen.hs
@@ -1,6 +1,6 @@
 #!/usr/bin/env stack
 {- stack script
-   --resolver lts-20.26
+   --resolver lts-22.31
    --package split
    --package directory,filepath
    --package text

--- a/code/scripts/TypeDepGen.hs
+++ b/code/scripts/TypeDepGen.hs
@@ -1,6 +1,6 @@
 #!/usr/bin/env stack
 {- stack script
-   --resolver lts-20.26
+   --resolver lts-22.31
    --package split
    --package directory,filepath
    --package text

--- a/code/stack.yaml
+++ b/code/stack.yaml
@@ -74,7 +74,7 @@ extra-deps:
 - unicode-properties-3.2.0.0@sha256:239766a6ac4322329353f6b9cd546024fd8c5f0235c8e32b3cba2d6bd245a699,1000
 - transformers-0.6.1.1@sha256:80d128763c6965dfcddca2155b3dec3bb1970d476f0c8cceb4bb28608ab75e7c,3243
 
-# The following packages are dependencies needed for 'stan', specifically tested against GHC 9.4.8.
+# The following packages are dependencies needed for 'stan' and 'weeder', 'stan' specifically tested against GHC 9.4.8.
 - clay-0.14.0@sha256:a50ba73137a39c55e89f24a7792107ec40ba07320b2c5ff7932049845c50ffc9,2204
 - dir-traverse-0.2.3.0@sha256:adcc128f201ff95131b15ffe41365dc99c50dc3fa3a910f021521dc734013bfa,2137
 - extensions-0.1.0.0@sha256:b8105dc43a57b0b3b54879e8dbb905676dfee3e8b59301fefbf2409a0fe95710,4447
@@ -94,6 +94,7 @@ extra-deps:
 - unix-2.8.5.1@sha256:3f702a252a313a7bcb56e3908a14e7f9f1b40e41b7bdc8ae8a9605a1a8686f06,9808
 - Cabal-3.12.1.0@sha256:08be296ddd941b3f9be4bd125fbb3e6857f5c707b8d10464f6f1d30c91ca3e5f,13551
 - Cabal-syntax-3.12.1.0@sha256:6dbb06fb08ff77520947fb4c1ef281c9cea5b8dc7fd9a41ad62273fa916cf4b2,7407
+
 # This configuration option allows the use of newer versions of dependencies than what is specified
 allow-newer: true
 

--- a/code/stack.yaml
+++ b/code/stack.yaml
@@ -92,7 +92,8 @@ extra-deps:
 - parsec-3.1.17.0@sha256:8407cbd428d7f640a0fff8891bd2f7aca13cebe70a5e654856f8abec9a648b56,5149
 - process-1.6.20.0@sha256:2a9393de33f18415fb8f4826957a87a94ffe8840ca8472a9b69dca6de45aca03,2790
 - unix-2.8.5.1@sha256:3f702a252a313a7bcb56e3908a14e7f9f1b40e41b7bdc8ae8a9605a1a8686f06,9808
-
+- Cabal-3.12.1.0@sha256:08be296ddd941b3f9be4bd125fbb3e6857f5c707b8d10464f6f1d30c91ca3e5f,13551
+- Cabal-syntax-3.12.1.0@sha256:6dbb06fb08ff77520947fb4c1ef281c9cea5b8dc7fd9a41ad62273fa916cf4b2,7407
 # This configuration option allows the use of newer versions of dependencies than what is specified
 allow-newer: true
 
@@ -100,7 +101,7 @@ allow-newer: true
 # In this case, it's allowing newer versions of the 'stan' package.
 allow-newer-deps:
 - stan
-- wedder
+- weeder
 - multiplate
 
 # Used only for a basic set of flags for haddock

--- a/code/stack.yaml
+++ b/code/stack.yaml
@@ -15,7 +15,7 @@
 # resolver:
 #  name: custom-snapshot
 #  location: "./custom-snapshot.yaml"
-resolver: lts-20.26
+resolver: lts-22.31
 
 ghc-options:
   "$everything": -fwrite-ide-info -hiedir=.hie
@@ -72,6 +72,7 @@ extra-deps:
 - multiplate-0.0.3@sha256:5d2ffc50d23c55008100b7a8b70f77b5fcce08c6f23822c5a6adc5b5b9356a32,1311
 - unicode-names-3.2.0.0@sha256:fef7241d93170e26265e84553090253a5e8ee207645d47cf271816f5834d07d2,470
 - unicode-properties-3.2.0.0@sha256:239766a6ac4322329353f6b9cd546024fd8c5f0235c8e32b3cba2d6bd245a699,1000
+- transformers-0.6.1.1@sha256:80d128763c6965dfcddca2155b3dec3bb1970d476f0c8cceb4bb28608ab75e7c,3243
 
 # The following packages are dependencies needed for 'stan', specifically tested against GHC 9.4.8.
 - clay-0.14.0@sha256:a50ba73137a39c55e89f24a7792107ec40ba07320b2c5ff7932049845c50ffc9,2204
@@ -84,6 +85,13 @@ extra-deps:
 - validation-selective-0.2.0.0@sha256:e1ab5482dede8bf676d729a09109c7c5f798363b9d458e4197a27afb8b48fdd3,3907
 - colourista-0.1.0.2@sha256:87b6c096563c3dc5afb1161f06891235370862fc3406406f1f10f1864e55e0a1,3364
 - slist-0.2.1.0@sha256:679013d3a03ed1f09fc46cc6ef87f94cc36a1320b2bf4fe4f91d102f85277528,3513
+- directory-1.3.8.5@sha256:fbeec9ec346e5272167f63dcb86af513b457a7b9fc36dc818e4c7b81608d612b,3166
+- exceptions-0.10.8@sha256:c31fd9b35d36196cbb14ffa5fca4de49868fd39acfeddd601fb77e742554aa67,2892
+- filepath-1.4.300.2@sha256:345cbb1afe414a09e47737e4d14cbd51891a734e67c0ef3d77a1439518bb81e8,5900
+- mtl-2.3.1@sha256:5377696d7315e2ef31a8d15d67b22d733c20cac2caf8b26756ff8524c8217e6d,1868
+- parsec-3.1.17.0@sha256:8407cbd428d7f640a0fff8891bd2f7aca13cebe70a5e654856f8abec9a648b56,5149
+- process-1.6.20.0@sha256:2a9393de33f18415fb8f4826957a87a94ffe8840ca8472a9b69dca6de45aca03,2790
+- unix-2.8.5.1@sha256:3f702a252a313a7bcb56e3908a14e7f9f1b40e41b7bdc8ae8a9605a1a8686f06,9808
 
 # This configuration option allows the use of newer versions of dependencies than what is specified
 allow-newer: true
@@ -92,6 +100,8 @@ allow-newer: true
 # In this case, it's allowing newer versions of the 'stan' package.
 allow-newer-deps:
 - stan
+- wedder
+- multiplate
 
 # Used only for a basic set of flags for haddock
 build:

--- a/code/weeder.toml
+++ b/code/weeder.toml
@@ -1,0 +1,7 @@
+roots = ["Main.main","^Paths_.*"]
+
+type-class-roots = false
+
+root-instances = [{ class = "\\.IsString$" },{ class = "\\.IsList$" }]
+
+unused-types = false


### PR DESCRIPTION
Contributes to #3710. Adds `weeder` to make file. Also updated `ghc 9.2.8` to `ghc 9.6.6` as weeder does not support `ghc 9.2.8`. When you run `weeder` it gives you a list of potential unused code. It also gives you error 228, meaning that it found multiple places with "weeds" which it thinks could be unused code.