### PR TITLE
Used the `Scope` in generated Julia code

### DIFF
--- a/code/drasil-code/lib/Language/Drasil/Code/Imperative/Generator.hs
+++ b/code/drasil-code/lib/Language/Drasil/Code/Imperative/Generator.hs
@@ -35,8 +35,8 @@ import Language.Drasil.Choices (Choices(..), Modularity(..), Architecture(..),
 import Language.Drasil.CodeSpec (CodeSpec(..), getODE)
 import Language.Drasil.Printers (SingleLine(OneLine), sentenceDoc)
 
-import Drasil.GOOL (OOProg, VisibilityTag(..), ProgData(..),
-  initialState)
+import Drasil.GOOL (OOProg, VisibilityTag(..),
+  ProgData(..), initialState)
 import qualified Drasil.GOOL as OO (GSProgram, SFile, ProgramSym(..), unCI)
 import Drasil.GProc (ProcProg)
 import qualified Drasil.GProc as Proc (GSProgram, SFile, ProgramSym(..), unCI)

--- a/code/drasil-code/lib/Language/Drasil/Code/Imperative/Import.hs
+++ b/code/drasil-code/lib/Language/Drasil/Code/Imperative/Import.hs
@@ -92,7 +92,7 @@ value u s t scp = do
       maybeInline _ _ = Nothing
       cm = concMatches g
       cdCncpt = Map.lookup u cm
-  val <- maybe (valueOf <$> variable s t scp) (convExpr scp . (^. codeExpr)) constDef
+  val <- maybe (valueOf <$> variable s t scp) (convExpr . (^. codeExpr)) constDef
   return $ maybe val conceptToGOOL cdCncpt
 
 -- | If variable is an input, construct it with 'var' and pass to inputVariable.
@@ -108,10 +108,10 @@ variable s t scp = do
       defFunc Var = \nm tp -> var nm tp scp
       defFunc Const = staticConst
   if s `elem` map codeName (inputs cs)
-    then inputVariable (inStruct g) Var (var s t scp) scp
+    then inputVariable (inStruct g) Var (var s t scp)
     else if s `elem` map codeName (constants $ codeSpec g)
       then constVariable (conStruct g) (conRepr g)
-                          ((defFunc $ conRepr g) s t) scp
+              ((defFunc $ conRepr g) s t)
       else return $ var s t scp
 
 -- | If 'Unbundled' inputs, just return variable as-is.
@@ -122,15 +122,15 @@ variable s t scp = do
 -- representation is 'Const'. Variable should be accessed through class, so
 -- 'classVariable' is called.
 inputVariable :: (OOProg r) => Structure -> ConstantRepr -> SVariable r ->
-  r (Scope r) -> GenState (SVariable r)
-inputVariable Unbundled _ v _ = return v
-inputVariable Bundled Var v scp = do
+  GenState (SVariable r)
+inputVariable Unbundled _ v = return v
+inputVariable Bundled Var v = do
   g <- get
   inClsName <- genICName InputParameters
-  ip <- mkVar (quantvar inParams) scp
+  ip <- mkVar (quantvar inParams) local -- TODO: get scope from state
   return $ if currentClass g == inClsName then objVarSelf v else ip $-> v
-inputVariable Bundled Const v scp = do
-  ip <- mkVar (quantvar inParams) scp
+inputVariable Bundled Const v = do
+  ip <- mkVar (quantvar inParams) local -- TODO: get scope from state
   classVariable ip v
 
 -- | If 'Unbundled' constants, just return variable as-is.
@@ -142,18 +142,18 @@ inputVariable Bundled Const v scp = do
 -- If constants are 'Inline'd, the generator should not be attempting to make a
 -- variable for one of the constants.
 constVariable :: (OOProg r) => ConstantStructure -> ConstantRepr ->
-  SVariable r -> r (Scope r) -> GenState (SVariable r)
-constVariable (Store Unbundled) _ v _ = return v
-constVariable (Store Bundled) Var v scp = do
-  cs <- mkVar (quantvar consts) scp
+  SVariable r -> GenState (SVariable r)
+constVariable (Store Unbundled) _ v = return v
+constVariable (Store Bundled) Var v = do
+  cs <- mkVar (quantvar consts) local -- TODO: get scope from state
   return $ cs $-> v
-constVariable (Store Bundled) Const v scp = do
-  cs <- mkVar (quantvar consts) scp
+constVariable (Store Bundled) Const v = do
+  cs <- mkVar (quantvar consts) local -- TODO: get scope from state
   classVariable cs v
-constVariable WithInputs cr v scp = do
+constVariable WithInputs cr v = do
   g <- get
-  inputVariable (inStruct g) cr v scp
-constVariable Inline _ _ _ = error $ "mkVar called on a constant, but user " ++
+  inputVariable (inStruct g) cr v
+constVariable Inline _ _ = error $ "mkVar called on a constant, but user " ++
   "chose to Inline constants. Generator has a bug."
 
 -- | For generating GOOL for a variable that is accessed through a class.
@@ -284,88 +284,80 @@ genInOutFunc f docf n desc ins' outs' b = do
     bComms bothVs) bod else f inVs outVs bothVs bod
 
 -- | Converts an 'Expr' to a GOOL Value.
-convExpr :: (OOProg r) => r (Scope r) -> CodeExpr -> GenState (SValue r)
-convExpr _ (Lit (Dbl d)) = do
+convExpr :: (OOProg r) => CodeExpr -> GenState (SValue r)
+convExpr (Lit (Dbl d)) = do
   sm <- spaceCodeType Real
   let getLiteral Double = litDouble d
       getLiteral Float = litFloat (realToFrac d)
       getLiteral _ = error "convExpr: Real space matched to invalid CodeType; should be Double or Float"
   return $ getLiteral sm
-convExpr scp (Lit (ExactDbl d)) = convExpr scp $ Lit . Dbl $ fromInteger d
-convExpr _ (Lit (Int i))      = return $ litInt i
-convExpr _ (Lit (Str s))      = return $ litString s
-convExpr _ (Lit (Perc a b)) = do
+convExpr (Lit (ExactDbl d)) = convExpr $ Lit . Dbl $ fromInteger d
+convExpr (Lit (Int i))      = return $ litInt i
+convExpr (Lit (Str s))      = return $ litString s
+convExpr (Lit (Perc a b)) = do
   sm <- spaceCodeType Rational
   let getLiteral Double = litDouble
       getLiteral Float = litFloat . realToFrac
       getLiteral _ = error "convExpr: Rational space matched to invalid CodeType; should be Double or Float"
   return $ getLiteral sm (fromIntegral a / (10 ** fromIntegral b))
-convExpr scp (AssocA Add l) = foldl1 (#+)  <$> mapM (convExpr scp) l
-convExpr scp (AssocA Mul l) = foldl1 (#*)  <$> mapM (convExpr scp) l
-convExpr scp (AssocB And l) = foldl1 (?&&) <$> mapM (convExpr scp) l
-convExpr scp (AssocB Or l)  = foldl1 (?||) <$> mapM (convExpr scp) l
-convExpr scp (C c)   = do
+convExpr (AssocA Add l) = foldl1 (#+)  <$> mapM convExpr l
+convExpr (AssocA Mul l) = foldl1 (#*)  <$> mapM convExpr l
+convExpr (AssocB And l) = foldl1 (?&&) <$> mapM convExpr l
+convExpr (AssocB Or l)  = foldl1 (?||) <$> mapM convExpr l
+convExpr (C c)   = do
   g <- get
   let v = quantvar (lookupC g c)
-  mkVal v scp
-convExpr scp (FCall c x ns) = convCall c x ns fApp libFuncAppMixedArgs scp
-convExpr scp (New c x ns) = convCall c x ns (\m _ -> ctorCall m)
-  (\m _ -> libNewObjMixedArgs m) scp
-convExpr scp (Message a m x ns) = do
+  mkVal v local -- TODO: get scope from state
+convExpr (FCall c x ns) = convCall c x ns fApp libFuncAppMixedArgs
+convExpr (New c x ns) = convCall c x ns (\m _ -> ctorCall m)
+  (\m _ -> libNewObjMixedArgs m)
+convExpr (Message a m x ns) = do
   g <- get
   let info = sysinfodb $ codeSpec g
       objCd = quantvar (symbResolve info a)
-  o <- (`mkVal` scp) objCd
+  o <- (`mkVal` local) objCd -- TODO: get scope from state
   convCall m x ns
     (\_ n t ps nas -> return (objMethodCallMixedArgs t o n ps nas))
-    (\_ n t -> objMethodCallMixedArgs t o n) scp
-convExpr scp (Field o f) = do
+    (\_ n t -> objMethodCallMixedArgs t o n)
+convExpr (Field o f) = do
   g <- get
   let ob  = quantvar (lookupC g o)
       fld = quantvar (lookupC g f)
-  v <- mkVar (ccObjVar ob fld) scp
+  v <- mkVar (ccObjVar ob fld) local -- TODO: get scope from state
   return $ valueOf v
-convExpr scp (UnaryOp o u)    = fmap (unop o) (convExpr scp u)
-convExpr scp (UnaryOpB o u)   = fmap (unopB o) (convExpr scp u)
-convExpr scp (UnaryOpVV o u)  = fmap (unopVV o) (convExpr scp u)
-convExpr scp (UnaryOpVN o u)  = fmap (unopVN o) (convExpr scp u)
-convExpr _ (ArithBinaryOp Frac (Lit (Int a)) (Lit (Int b))) = do -- hack to deal with integer division
+convExpr (UnaryOp o u)    = fmap (unop o) (convExpr u)
+convExpr (UnaryOpB o u)   = fmap (unopB o) (convExpr u)
+convExpr (UnaryOpVV o u)  = fmap (unopVV o) (convExpr u)
+convExpr (UnaryOpVN o u)  = fmap (unopVN o) (convExpr u)
+convExpr (ArithBinaryOp Frac (Lit (Int a)) (Lit (Int b))) = do -- hack to deal with integer division
   sm <- spaceCodeType Rational
   let getLiteral Double = litDouble (fromIntegral a) #/ litDouble (fromIntegral b)
       getLiteral Float = litFloat (fromIntegral a) #/ litFloat (fromIntegral b)
       getLiteral _ = error "convExpr: Rational space matched to invalid CodeType; should be Double or Float"
   return $ getLiteral sm
-convExpr scp (ArithBinaryOp o a b) = liftM2 (arithBfunc o)
-                                      (convExpr scp a) (convExpr scp b)
-convExpr scp (BoolBinaryOp o a b)  = liftM2 (boolBfunc o)
-                                      (convExpr scp a) (convExpr scp b)
-convExpr scp (LABinaryOp o a b)    = liftM2 (laBfunc o)
-                                      (convExpr scp a) (convExpr scp b)
-convExpr scp (EqBinaryOp o a b)    = liftM2 (eqBfunc o)
-                                      (convExpr scp a) (convExpr scp b)
-convExpr scp (OrdBinaryOp o a b)   = liftM2 (ordBfunc o)
-                                      (convExpr scp a) (convExpr scp b)
-convExpr scp (VVVBinaryOp o a b)   = liftM2 (vecVecVecBfunc o)
-                                      (convExpr scp a) (convExpr scp b)
-convExpr scp (VVNBinaryOp o a b)   = liftM2 (vecVecNumBfunc o)
-                                      (convExpr scp a) (convExpr scp b)
-convExpr scp (NVVBinaryOp o a b)   = liftM2 (numVecVecBfunc o)
-                                      (convExpr scp a) (convExpr scp b)
-convExpr scp (Case c l)            = doit l -- FIXME this is sub-optimal
+convExpr (ArithBinaryOp o a b) = liftM2 (arithBfunc o) (convExpr a) (convExpr b)
+convExpr (BoolBinaryOp o a b)  = liftM2 (boolBfunc o) (convExpr a) (convExpr b)
+convExpr (LABinaryOp o a b)    = liftM2 (laBfunc o) (convExpr a) (convExpr b)
+convExpr (EqBinaryOp o a b)    = liftM2 (eqBfunc o) (convExpr a) (convExpr b)
+convExpr (OrdBinaryOp o a b)   = liftM2 (ordBfunc o) (convExpr a) (convExpr b)
+convExpr (VVVBinaryOp o a b)   = liftM2 (vecVecVecBfunc o) (convExpr a) (convExpr b)
+convExpr (VVNBinaryOp o a b)   = liftM2 (vecVecNumBfunc o) (convExpr a) (convExpr b)
+convExpr (NVVBinaryOp o a b)   = liftM2 (numVecVecBfunc o) (convExpr a) (convExpr b)
+convExpr (Case c l)            = doit l -- FIXME this is sub-optimal
   where
     doit [] = error "should never happen" -- TODO: change error message?
-    doit [(e,_)] = convExpr scp e -- should always be the else clause
-    doit ((e,cond):xs) = liftM3 inlineIf (convExpr scp cond) (convExpr scp e)
-      (convExpr scp (Case c xs))
-convExpr scp (Matrix [l]) = do
-  ar <- mapM (convExpr scp) l
+    doit [(e,_)] = convExpr e -- should always be the else clause
+    doit ((e,cond):xs) = liftM3 inlineIf (convExpr cond) (convExpr e)
+      (convExpr (Case c xs))
+convExpr (Matrix [l]) = do
+  ar <- mapM convExpr l
                                     -- hd will never fail here
   return $ litArray (fmap valueType (head ar)) ar
-convExpr _ Matrix{} = error "convExpr: Matrix"
-convExpr _ Operator{} = error "convExpr: Operator"
-convExpr scp (RealI c ri)  = do
+convExpr Matrix{} = error "convExpr: Matrix"
+convExpr Operator{} = error "convExpr: Operator"
+convExpr (RealI c ri)  = do
   g <- get
-  convExpr scp $ renderRealInt (lookupC g c) ri
+  convExpr $ renderRealInt (lookupC g c) ri
 
 -- | Generates a function/method call, based on the 'UID' of the chunk representing
 -- the function, the list of argument 'Expr's, the list of named argument 'Expr's,
@@ -374,8 +366,8 @@ convExpr scp (RealI c ri)  = do
 convCall :: (OOProg r) => UID -> [CodeExpr] -> [(UID, CodeExpr)] ->
   (Name -> Name -> VSType r -> [SValue r] -> NamedArgs r ->
   GenState (SValue r)) -> (Name -> Name -> VSType r -> [SValue r]
-  -> NamedArgs r -> SValue r) -> r (Scope r) -> GenState (SValue r)
-convCall c x ns f libf scp = do
+  -> NamedArgs r -> SValue r) -> GenState (SValue r)
+convCall c x ns f libf = do
   g <- get
   let info = sysinfodb $ codeSpec g
       mem = eMap g
@@ -383,9 +375,9 @@ convCall c x ns f libf scp = do
       funcCd = quantfunc (symbResolve info c)
       funcNm = codeName funcCd
   funcTp <- codeType funcCd
-  args <- mapM (convExpr scp) x
-  nms <- mapM ((`mkVar` scp) . quantvar . symbResolve info . fst) ns
-  nargs <- mapM (convExpr scp . snd) ns
+  args <- mapM convExpr x
+  nms <- mapM ((`mkVar` local) . quantvar . symbResolve info . fst) ns -- TODO: get scope from state
+  nargs <- mapM (convExpr . snd) ns
   maybe (maybe (error $ "Call to non-existent function " ++ funcNm)
       (\m -> return $ libf m funcNm (convTypeOO funcTp) args (zip nms nargs))
       (Map.lookup funcNm lem))
@@ -520,28 +512,28 @@ genFunc :: (OOProg r) => (Name -> VSType r -> Description -> [ParameterChunk]
   [StateVariable] -> Func -> GenState (SMethod r)
 genFunc f svs (FDef (FuncDef n desc parms o rd s)) = do
   g <- get
-  stmts <- mapM (convStmt local) s
-  vars <- mapM (`mkVar` local) (fstdecl (sysinfodb $ codeSpec g) s
+  stmts <- mapM convStmt s
+  vars <- mapM (`mkVar` local) (fstdecl (sysinfodb $ codeSpec g) s -- TODO: get scope from state
     \\ (map quantvar parms ++ map stVar svs))
   t <- spaceCodeType o
   f n (convTypeOO t) desc parms rd [block $ map varDec vars, block stmts]
 genFunc _ svs (FDef (CtorDef n desc parms i s)) = do
   g <- get
-  inits <- mapM (convExpr local . snd) i
+  inits <- mapM (convExpr . snd) i
   initvars <- mapM ((\iv -> fmap (var' (codeName iv) local . convTypeOO)
     (codeType iv)) . fst) i
-  stmts <- mapM (convStmt local) s
-  vars <- mapM (`mkVar` local) (fstdecl (sysinfodb $ codeSpec g) s
+  stmts <- mapM convStmt s
+  vars <- mapM (`mkVar` local) (fstdecl (sysinfodb $ codeSpec g) s -- TODO: get scope from state
     \\ (map quantvar parms ++ map stVar svs))
   genInitConstructor n desc parms (zip initvars inits)
     [block $ map varDec vars, block stmts]
 genFunc _ _ (FData (FuncData n desc ddef)) = genDataFunc n desc ddef
 
 -- | Converts a 'FuncStmt' to a GOOL Statement.
-convStmt :: (OOProg r) => r (Scope r) -> FuncStmt -> GenState (MSStatement r)
-convStmt scp (FAsg v (Matrix [es])) = do
-  els <- mapM (convExpr scp) es
-  v' <- mkVar v scp
+convStmt :: (OOProg r) => FuncStmt -> GenState (MSStatement r)
+convStmt (FAsg v (Matrix [es])) = do
+  els <- mapM convExpr es
+  v' <- mkVar v local -- TODO: get scope from state
   t <- codeType v
   let listFunc (C.List _) = litList
       listFunc (C.Array _) = litArray
@@ -549,14 +541,14 @@ convStmt scp (FAsg v (Matrix [es])) = do
   l <- maybeLog v' local
   return $ multi $ assign v' (listFunc t (listInnerType $ fmap variableType v')
     els) : l
-convStmt scp (FAsg v e) = do
-  e' <- convExpr scp e
-  v' <- mkVar v scp
+convStmt (FAsg v e) = do
+  e' <- convExpr e
+  v' <- mkVar v local -- TODO: get scope from state
   l <- maybeLog v' local
   return $ multi $ assign v' e' : l
-convStmt scp (FAsgIndex v i e) = do
-  e' <- convExpr scp e
-  v' <- mkVar v scp
+convStmt (FAsgIndex v i e) = do
+  e' <- convExpr e
+  v' <- mkVar v local -- TODO: get scope from state
   t <- codeType v
   let asgFunc (C.List _) = valStmt $ listSet (valueOf v') (litInt i) e'
       asgFunc (C.Array _) = assign (arrayElem i v') e'
@@ -564,75 +556,75 @@ convStmt scp (FAsgIndex v i e) = do
       vi = arrayElem i v'
   l <- maybeLog vi local
   return $ multi $ asgFunc t : l
-convStmt scp (FFor v start end step st) = do
-  stmts <- mapM (convStmt scp) st
-  vari <- mkVar v scp
-  start' <- convExpr scp start
-  end' <- convExpr scp end
-  step' <- convExpr scp step
+convStmt (FFor v start end step st) = do
+  stmts <- mapM convStmt st
+  vari <- mkVar v local -- TODO: get scope from state
+  start' <- convExpr start
+  end' <- convExpr end
+  step' <- convExpr step
   return $ forRange vari start' end' step' (bodyStatements stmts)
-convStmt scp (FForEach v e st) = do
-  stmts <- mapM (convStmt scp) st
-  vari <- mkVar v scp
-  e' <- convExpr scp e
+convStmt (FForEach v e st) = do
+  stmts <- mapM convStmt st
+  vari <- mkVar v local -- TODO: get scope from state
+  e' <- convExpr e
   return $ forEach vari e' (bodyStatements stmts)
-convStmt scp (FWhile e st) = do
-  stmts <- mapM (convStmt scp) st
-  e' <- convExpr scp e
+convStmt (FWhile e st) = do
+  stmts <- mapM convStmt st
+  e' <- convExpr e
   return $ while e' (bodyStatements stmts)
-convStmt scp (FCond e tSt []) = do
-  stmts <- mapM (convStmt scp) tSt
-  e' <- convExpr scp e
+convStmt (FCond e tSt []) = do
+  stmts <- mapM convStmt tSt
+  e' <- convExpr e
   return $ ifNoElse [(e', bodyStatements stmts)]
-convStmt scp (FCond e tSt eSt) = do
-  stmt1 <- mapM (convStmt scp) tSt
-  stmt2 <- mapM (convStmt scp) eSt
-  e' <- convExpr scp e
+convStmt (FCond e tSt eSt) = do
+  stmt1 <- mapM convStmt tSt
+  stmt2 <- mapM convStmt eSt
+  e' <- convExpr e
   return $ ifCond [(e', bodyStatements stmt1)] (bodyStatements stmt2)
-convStmt scp (FRet e) = do
-  e' <- convExpr scp e
+convStmt (FRet e) = do
+  e' <- convExpr e
   return $ returnStmt e'
-convStmt _ (FThrow s) = return $ throw s
-convStmt scp (FTry t c) = do
-  stmt1 <- mapM (convStmt scp) t
-  stmt2 <- mapM (convStmt scp) c
+convStmt (FThrow s) = return $ throw s
+convStmt (FTry t c) = do
+  stmt1 <- mapM convStmt t
+  stmt2 <- mapM convStmt c
   return $ tryCatch (bodyStatements stmt1) (bodyStatements stmt2)
-convStmt _ FContinue = return continue
-convStmt scp (FDecDef v (Matrix [[]])) = do
-  vari <- mkVar v scp
+convStmt FContinue = return continue
+convStmt (FDecDef v (Matrix [[]])) = do
+  vari <- mkVar v local -- TODO: get scope from state
   let convDec (C.List _) = listDec 0 vari
       convDec (C.Array _) = arrayDec 0 vari
       convDec _ = varDec vari
   fmap convDec (codeType v)
-convStmt scp (FDecDef v e) = do
-  v' <- mkVar v scp
+convStmt (FDecDef v e) = do
+  v' <- mkVar v local
   l <- maybeLog v' local
   t <- codeType v
   let convDecDef (Matrix [lst]) = do
         let contDecDef (C.List _) = listDecDef
             contDecDef (C.Array _) = arrayDecDef
             contDecDef _ = error "Type mismatch between variable and value in declare-define FuncStmt"
-        e' <- mapM (convExpr scp) lst
+        e' <- mapM convExpr lst
         return $ contDecDef t v' e'
       convDecDef _ = do
-        e' <- convExpr scp e
+        e' <- convExpr e
         return $ varDecDef v' e'
   dd <- convDecDef e
   return $ multi $ dd : l
-convStmt scp (FFuncDef f ps sts) = do
-  f' <- mkVar (quantvar f) scp
-  pms <- mapM ((`mkVar` scp) . quantvar) ps
-  b <- mapM (convStmt scp) sts
+convStmt (FFuncDef f ps sts) = do
+  f' <- mkVar (quantvar f) local -- TODO: get scope from state
+  pms <- mapM ((`mkVar` local) . quantvar) ps -- TODO: get scope from state
+  b <- mapM convStmt sts
   return $ funcDecDef f' pms (bodyStatements b)
-convStmt scp (FVal e) = do
-  e' <- convExpr scp e
+convStmt (FVal e) = do
+  e' <- convExpr e
   return $ valStmt e'
-convStmt scp (FMulti ss) = do
-  stmts <- mapM (convStmt scp) ss
+convStmt (FMulti ss) = do
+  stmts <- mapM convStmt ss
   return $ multi stmts
-convStmt scp (FAppend a b) = do
-  a' <- convExpr scp a
-  b' <- convExpr scp b
+convStmt (FAppend a b) = do
+  a' <- convExpr a
+  b' <- convExpr b
   return $ valStmt $ listAppend a' b'
 
 -- | Generates a function that reads a file whose format is based on the passed
@@ -734,7 +726,7 @@ getEntryVarLogs lp scp = do
 -- | If 'UID' for the variable is matched to a concept, call 'conceptToGOOL' to get
 -- the GOOL code for the concept, and return.
 -- If 'UID' is for a constant and user has chosen 'Inline', convert the constant's
--- defining 'Expr' to a value with 'convExprProc'.
+-- defining 'Expr' to a value with 'convExpr'.
 -- Otherwise, just a regular variable: construct it by calling the variable, then
 -- call 'valueOf' to reference its value.
 valueProc :: (SharedProg r) => UID -> Name -> VSType r -> r (Scope r) -> GenState (SValue r)
@@ -750,14 +742,14 @@ valueProc u s t scp = do
       cm = concMatches g
       cdCncpt = Map.lookup u cm
   val <- maybe (valueOf <$> variableProc s t scp)
-                (convExprProc scp . (^. codeExpr)) constDef
+                (convExprProc . (^. codeExpr)) constDef
   return $ maybe val conceptToGOOL cdCncpt
 
--- | If variable is an input, construct it with 'var' and pass to inputVariableProc.
+-- | If variable is an input, construct it with 'var' and pass to inputVariable.
 -- If variable is a constant and 'Var' constant representation is chosen,
--- construct it with 'var' and pass to 'constVariableProc'.
+-- construct it with 'var' and pass to 'constVariable'.
 -- If variable is a constant and 'Const' constant representation is chosen,
--- construct it with 'constant' and pass to 'constVariableProc'.
+-- construct it with 'constant' and pass to 'constVariable'.
 -- If variable is neither, just construct it with 'var' and return it.
 variableProc :: (SharedProg r) => Name -> VSType r -> r (Scope r) -> GenState (SVariable r)
 variableProc s t scp = do
@@ -783,7 +775,7 @@ inputVariableProc Bundled _ _ = error "inputVariableProc: Procedural renderers d
 -- | If 'Unbundled' constants, just return variable as-is.
 -- If 'Bundled' constants, throw an error, since procedural renderers
 -- don't support 'Bundled' constants yet.
--- If constants stored 'WithInputs', call 'inputVariableProc'.
+-- If constants stored 'WithInputs', call 'inputVariable'.
 -- If constants are 'Inline'd, the generator should not be attempting to make a
 -- variable for one of the constants.
 constVariableProc :: (SharedProg r) => ConstantStructure -> ConstantRepr ->
@@ -865,8 +857,8 @@ genFuncProc :: (SharedProg r) => (Name -> VSType r -> Description -> [ParameterC
   [StateVariable] -> Func -> GenState (SMethod r)
 genFuncProc f svs (FDef (FuncDef n desc parms o rd s)) = do
   g <- get
-  stmts <- mapM (convStmtProc local) s
-  vars <- mapM (`mkVarProc` local) (fstdecl (sysinfodb $ codeSpec g) s
+  stmts <- mapM convStmtProc s
+  vars <- mapM (`mkVarProc` local) (fstdecl (sysinfodb $ codeSpec g) s -- TODO: get scope from state
     \\ (map quantvar parms ++ map stVar svs))
   t <- spaceCodeType o
   f n (convType t) desc parms rd [block $ map varDec vars, block stmts]
@@ -962,76 +954,67 @@ getEntryVarLogsProc lp scp = do
   return $ concat logs
 
 -- | Converts an 'Expr' to a GOOL Value.
-convExprProc :: (SharedProg r) => r (Scope r) -> CodeExpr -> GenState (SValue r)
-convExprProc _ (Lit (Dbl d)) = do
+convExprProc :: (SharedProg r) => CodeExpr -> GenState (SValue r)
+convExprProc (Lit (Dbl d)) = do
   sm <- spaceCodeType Real
   let getLiteral Double = litDouble d
       getLiteral Float = litFloat (realToFrac d)
       getLiteral _ = error "convExprProc: Real space matched to invalid CodeType; should be Double or Float"
   return $ getLiteral sm
-convExprProc scp (Lit (ExactDbl d)) = convExprProc scp $ Lit . Dbl $ fromInteger d
-convExprProc _ (Lit (Int i))      = return $ litInt i
-convExprProc _ (Lit (Str s))      = return $ litString s
-convExprProc _ (Lit (Perc a b)) = do
+convExprProc (Lit (ExactDbl d)) = convExprProc $ Lit . Dbl $ fromInteger d
+convExprProc (Lit (Int i))      = return $ litInt i
+convExprProc (Lit (Str s))      = return $ litString s
+convExprProc (Lit (Perc a b)) = do
   sm <- spaceCodeType Rational
   let getLiteral Double = litDouble
       getLiteral Float = litFloat . realToFrac
       getLiteral _ = error "convExprProc: Rational space matched to invalid CodeType; should be Double or Float"
   return $ getLiteral sm (fromIntegral a / (10 ** fromIntegral b))
-convExprProc scp (AssocA Add l) = foldl1 (#+)  <$> mapM (convExprProc scp) l
-convExprProc scp (AssocA Mul l) = foldl1 (#*)  <$> mapM (convExprProc scp) l
-convExprProc scp (AssocB And l) = foldl1 (?&&) <$> mapM (convExprProc scp) l
-convExprProc scp (AssocB Or l)  = foldl1 (?||) <$> mapM (convExprProc scp) l
-convExprProc scp (C c) = do
+convExprProc (AssocA Add l) = foldl1 (#+)  <$> mapM convExprProc l
+convExprProc (AssocA Mul l) = foldl1 (#*)  <$> mapM convExprProc l
+convExprProc (AssocB And l) = foldl1 (?&&) <$> mapM convExprProc l
+convExprProc (AssocB Or l)  = foldl1 (?||) <$> mapM convExprProc l
+convExprProc (C c) = do
   g <- get
   let v = quantvar (lookupC g c)
-  mkValProc v scp
-convExprProc scp (FCall c x ns) = convCallProc c x ns fAppProc
-                                    libFuncAppMixedArgs scp
-convExprProc _ (New {}) = error "convExprProc: Procedural renderers do not support object creation"
-convExprProc _ (Message {}) = error "convExprProc: Procedural renderers do not support methods"
-convExprProc _ (Field _ _) = error "convExprProc: Procedural renderers do not support object field access"
-convExprProc scp (UnaryOp o u)    = fmap (unop o) (convExprProc scp u)
-convExprProc scp (UnaryOpB o u)   = fmap (unopB o) (convExprProc scp u)
-convExprProc scp (UnaryOpVV o u)  = fmap (unopVV o) (convExprProc scp u)
-convExprProc scp (UnaryOpVN o u)  = fmap (unopVN o) (convExprProc scp u)
-convExprProc _ (ArithBinaryOp Frac (Lit (Int a)) (Lit (Int b))) = do -- hack to deal with integer division
+  mkValProc v local -- TODO: get scope from state
+convExprProc (FCall c x ns) = convCallProc c x ns fAppProc libFuncAppMixedArgs
+convExprProc (New {}) = error "convExprProc: Procedural renderers do not support object creation"
+convExprProc (Message {}) = error "convExprProc: Procedural renderers do not support methods"
+convExprProc (Field _ _) = error "convExprProc: Procedural renderers do not support object field access"
+convExprProc (UnaryOp o u)    = fmap (unop o) (convExprProc u)
+convExprProc (UnaryOpB o u)   = fmap (unopB o) (convExprProc u)
+convExprProc (UnaryOpVV o u)  = fmap (unopVV o) (convExprProc u)
+convExprProc (UnaryOpVN o u)  = fmap (unopVN o) (convExprProc u)
+convExprProc (ArithBinaryOp Frac (Lit (Int a)) (Lit (Int b))) = do -- hack to deal with integer division
   sm <- spaceCodeType Rational
   let getLiteral Double = litDouble (fromIntegral a) #/ litDouble (fromIntegral b)
       getLiteral Float = litFloat (fromIntegral a) #/ litFloat (fromIntegral b)
       getLiteral _ = error "convExprProc: Rational space matched to invalid CodeType; should be Double or Float"
   return $ getLiteral sm
-convExprProc scp (ArithBinaryOp o a b) = liftM2 (arithBfunc o)
-                                      (convExprProc scp a) (convExprProc scp b)
-convExprProc scp (BoolBinaryOp o a b)  = liftM2 (boolBfunc o)
-                                      (convExprProc scp a) (convExprProc scp b)
-convExprProc scp (LABinaryOp o a b)    = liftM2 (laBfunc o)
-                                      (convExprProc scp a) (convExprProc scp b)
-convExprProc scp (EqBinaryOp o a b)    = liftM2 (eqBfunc o)
-                                      (convExprProc scp a) (convExprProc scp b)
-convExprProc scp (OrdBinaryOp o a b)   = liftM2 (ordBfunc o)
-                                      (convExprProc scp a) (convExprProc scp b)
-convExprProc scp (VVVBinaryOp o a b)   = liftM2 (vecVecVecBfunc o)
-                                      (convExprProc scp a) (convExprProc scp b)
-convExprProc scp (VVNBinaryOp o a b)   = liftM2 (vecVecNumBfunc o)
-                                      (convExprProc scp a) (convExprProc scp b)
-convExprProc scp (NVVBinaryOp o a b)   = liftM2 (numVecVecBfunc o)
-                                      (convExprProc scp a) (convExprProc scp b)
-convExprProc scp (Case c l)            = doit l -- FIXME this is sub-optimal
+convExprProc (ArithBinaryOp o a b) = liftM2 (arithBfunc o) (convExprProc a) (convExprProc b)
+convExprProc (BoolBinaryOp o a b)  = liftM2 (boolBfunc o) (convExprProc a) (convExprProc b)
+convExprProc (LABinaryOp o a b)    = liftM2 (laBfunc o) (convExprProc a) (convExprProc b)
+convExprProc (EqBinaryOp o a b)    = liftM2 (eqBfunc o) (convExprProc a) (convExprProc b)
+convExprProc (OrdBinaryOp o a b)   = liftM2 (ordBfunc o) (convExprProc a) (convExprProc b)
+convExprProc (VVVBinaryOp o a b)   = liftM2 (vecVecVecBfunc o) (convExprProc a) (convExprProc b)
+convExprProc (VVNBinaryOp o a b)   = liftM2 (vecVecNumBfunc o) (convExprProc a) (convExprProc b)
+convExprProc (NVVBinaryOp o a b)   = liftM2 (numVecVecBfunc o) (convExprProc a) (convExprProc b)
+convExprProc (Case c l)            = doit l -- FIXME this is sub-optimal
   where
     doit [] = error "should never happen" -- TODO: change error message?
-    doit [(e,_)] = convExprProc scp e -- should always be the else clause
-    doit ((e,cond):xs) = liftM3 inlineIf (convExprProc scp cond)
-      (convExprProc scp e) (convExprProc scp (Case c xs))
-convExprProc scp (Matrix [l]) = do
-  ar <- mapM (convExprProc scp) l
+    doit [(e,_)] = convExprProc e -- should always be the else clause
+    doit ((e,cond):xs) = liftM3 inlineIf (convExprProc cond) (convExprProc e)
+      (convExprProc (Case c xs))
+convExprProc (Matrix [l]) = do
+  ar <- mapM convExprProc l
                                     -- hd will never fail here
   return $ litArray (fmap valueType (head ar)) ar
-convExprProc _ Matrix{} = error "convExprProc: Matrix"
-convExprProc _ Operator{} = error "convExprProc: Operator"
-convExprProc scp (RealI c ri)  = do
+convExprProc Matrix{} = error "convExprProc: Matrix"
+convExprProc Operator{} = error "convExprProc: Operator"
+convExprProc (RealI c ri)  = do
   g <- get
-  convExprProc scp $ renderRealInt (lookupC g c) ri
+  convExprProc $ renderRealInt (lookupC g c) ri
 
 -- | Generates a function call, based on the 'UID' of the chunk representing
 -- the function, the list of argument 'Expr's, the list of named argument 'Expr's,
@@ -1040,8 +1023,8 @@ convExprProc scp (RealI c ri)  = do
 convCallProc :: (SharedProg r) => UID -> [CodeExpr] -> [(UID, CodeExpr)] ->
   (Name -> Name -> VSType r -> [SValue r] -> NamedArgs r ->
   GenState (SValue r)) -> (Name -> Name -> VSType r -> [SValue r]
-  -> NamedArgs r -> SValue r) -> r (Scope r) -> GenState (SValue r)
-convCallProc c x ns f libf scp = do
+  -> NamedArgs r -> SValue r) -> GenState (SValue r)
+convCallProc c x ns f libf = do
   g <- get
   let info = sysinfodb $ codeSpec g
       mem = eMap g
@@ -1049,9 +1032,9 @@ convCallProc c x ns f libf scp = do
       funcCd = quantfunc (symbResolve info c)
       funcNm = codeName funcCd
   funcTp <- codeType funcCd
-  args <- mapM (convExprProc scp) x
-  nms <- mapM ((`mkVarProc` scp) . quantvar . symbResolve info . fst) ns
-  nargs <- mapM (convExprProc scp . snd) ns
+  args <- mapM convExprProc x
+  nms <- mapM ((`mkVarProc` local) . quantvar . symbResolve info . fst) ns -- TODO: get scope from state
+  nargs <- mapM (convExprProc . snd) ns
   maybe (maybe (error $ "Call to non-existent function " ++ funcNm)
       (\m -> return $ libf m funcNm (convType funcTp) args (zip nms nargs))
       (Map.lookup funcNm lem))
@@ -1059,11 +1042,10 @@ convCallProc c x ns f libf scp = do
     (Map.lookup funcNm mem)
 
 -- | Converts a 'FuncStmt' to a GOOL Statement.
-convStmtProc :: (SharedProg r) => r (Scope r) -> FuncStmt ->
-  GenState (MSStatement r)
-convStmtProc scp (FAsg v (Matrix [es])) = do
-  els <- mapM (convExprProc scp) es
-  v' <- mkVarProc v scp
+convStmtProc :: (SharedProg r) => FuncStmt -> GenState (MSStatement r)
+convStmtProc (FAsg v (Matrix [es])) = do
+  els <- mapM convExprProc es
+  v' <- mkVarProc v local -- TODO: get scope from state
   t <- codeType v
   let listFunc (C.List _) = litList
       listFunc (C.Array _) = litArray
@@ -1071,14 +1053,14 @@ convStmtProc scp (FAsg v (Matrix [es])) = do
   l <- maybeLog v' local
   return $ multi $ assign v' (listFunc t (listInnerType $ fmap variableType v')
     els) : l
-convStmtProc scp (FAsg v e) = do
-  e' <- convExprProc scp e
-  v' <- mkVarProc v scp
+convStmtProc (FAsg v e) = do
+  e' <- convExprProc e
+  v' <- mkVarProc v local -- TODO: get scope from state
   l <- maybeLog v' local
   return $ multi $ assign v' e' : l
-convStmtProc scp (FAsgIndex v i e) = do
-  e' <- convExprProc scp e
-  v' <- mkVarProc v scp
+convStmtProc (FAsgIndex v i e) = do
+  e' <- convExprProc e
+  v' <- mkVarProc v local -- TODO: get scope from state
   t <- codeType v
   let asgFunc (C.List _) = valStmt $ listSet (valueOf v') (litInt i) e'
       asgFunc (C.Array _) = assign (arrayElem i v') e'
@@ -1086,47 +1068,47 @@ convStmtProc scp (FAsgIndex v i e) = do
       vi = arrayElem i v'
   l <- maybeLog vi local
   return $ multi $ asgFunc t : l
-convStmtProc scp (FFor v start end step st) = do
-  stmts <- mapM (convStmtProc scp) st
-  vari <- mkVarProc v scp
-  start' <- convExprProc scp start
-  end' <- convExprProc scp end
-  step' <- convExprProc scp step
+convStmtProc (FFor v start end step st) = do
+  stmts <- mapM convStmtProc st
+  vari <- mkVarProc v local -- TODO: get scope from state
+  start' <- convExprProc start
+  end' <- convExprProc end
+  step' <- convExprProc step
   return $ forRange vari start' end' step' (bodyStatements stmts)
-convStmtProc scp (FForEach v e st) = do
-  stmts <- mapM (convStmtProc scp) st
-  vari <- mkVarProc v scp
-  e' <- convExprProc scp e
+convStmtProc (FForEach v e st) = do
+  stmts <- mapM convStmtProc st
+  vari <- mkVarProc v local -- TODO: get scope from state
+  e' <- convExprProc e
   return $ forEach vari e' (bodyStatements stmts)
-convStmtProc scp (FWhile e st) = do
-  stmts <- mapM (convStmtProc scp) st
-  e' <- convExprProc scp e
+convStmtProc (FWhile e st) = do
+  stmts <- mapM convStmtProc st
+  e' <- convExprProc e
   return $ while e' (bodyStatements stmts)
-convStmtProc scp (FCond e tSt []) = do
-  stmts <- mapM (convStmtProc scp) tSt
-  e' <- convExprProc scp e
+convStmtProc (FCond e tSt []) = do
+  stmts <- mapM convStmtProc tSt
+  e' <- convExprProc e
   return $ ifNoElse [(e', bodyStatements stmts)]
-convStmtProc scp (FCond e tSt eSt) = do
-  stmt1 <- mapM (convStmtProc scp) tSt
-  stmt2 <- mapM (convStmtProc scp) eSt
-  e' <- convExprProc scp e
+convStmtProc (FCond e tSt eSt) = do
+  stmt1 <- mapM convStmtProc tSt
+  stmt2 <- mapM convStmtProc eSt
+  e' <- convExprProc e
   return $ ifCond [(e', bodyStatements stmt1)] (bodyStatements stmt2)
-convStmtProc scp (FRet e) = do
-  e' <- convExprProc scp e
+convStmtProc (FRet e) = do
+  e' <- convExprProc e
   return $ returnStmt e'
-convStmtProc _ (FThrow s) = return $ throw s
-convStmtProc scp (FTry t c) = do
-  stmt1 <- mapM (convStmtProc scp) t
-  stmt2 <- mapM (convStmtProc scp) c
+convStmtProc (FThrow s) = return $ throw s
+convStmtProc (FTry t c) = do
+  stmt1 <- mapM convStmtProc t
+  stmt2 <- mapM convStmtProc c
   return $ tryCatch (bodyStatements stmt1) (bodyStatements stmt2)
-convStmtProc _ FContinue = return continue
-convStmtProc scp (FDecDef v (Matrix [[]])) = do
-  vari <- mkVarProc v scp
+convStmtProc FContinue = return continue
+convStmtProc (FDecDef v (Matrix [[]])) = do
+  vari <- mkVarProc v local -- TODO: get scope from state
   let convDec (C.List _) = listDec 0 vari
       convDec (C.Array _) = arrayDec 0 vari
       convDec _ = varDec vari
   fmap convDec (codeType v)
-convStmtProc scp (FDecDef v e) = do
+convStmtProc (FDecDef v e) = do
   v' <- mkVarProc v local
   l <- maybeLog v' local
   t <- codeType v
@@ -1134,27 +1116,27 @@ convStmtProc scp (FDecDef v e) = do
         let contDecDef (C.List _) = listDecDef
             contDecDef (C.Array _) = arrayDecDef
             contDecDef _ = error "Type mismatch between variable and value in declare-define FuncStmt"
-        e' <- mapM (convExprProc scp) lst
+        e' <- mapM convExprProc lst
         return $ contDecDef t v' e'
       convDecDef _ = do
-        e' <- convExprProc scp e
+        e' <- convExprProc e
         return $ varDecDef v' e'
   dd <- convDecDef e
   return $ multi $ dd : l
-convStmtProc scp (FFuncDef f ps sts) = do
-  f' <- mkVarProc (quantvar f) scp
-  pms <- mapM ((`mkVarProc` scp) . quantvar) ps
-  b <- mapM (convStmtProc scp) sts
+convStmtProc (FFuncDef f ps sts) = do
+  f' <- mkVarProc (quantvar f) local -- TODO: get scope from state
+  pms <- mapM ((`mkVarProc` local) . quantvar) ps -- TODO: get scope from state
+  b <- mapM convStmtProc sts
   return $ funcDecDef f' pms (bodyStatements b)
-convStmtProc scp (FVal e) = do
-  e' <- convExprProc scp e
+convStmtProc (FVal e) = do
+  e' <- convExprProc e
   return $ valStmt e'
-convStmtProc scp (FMulti ss) = do
-  stmts <- mapM (convStmtProc scp) ss
+convStmtProc (FMulti ss) = do
+  stmts <- mapM convStmtProc ss
   return $ multi stmts
-convStmtProc scp (FAppend a b) = do
-  a' <- convExprProc scp a
-  b' <- convExprProc scp b
+convStmtProc (FAppend a b) = do
+  a' <- convExprProc a
+  b' <- convExprProc b
   return $ valStmt $ listAppend a' b'
 
 -- | Generates a function that reads a file whose format is based on the passed

--- a/code/drasil-code/lib/Language/Drasil/Code/Imperative/Modules.hs
+++ b/code/drasil-code/lib/Language/Drasil/Code/Imperative/Modules.hs
@@ -95,11 +95,11 @@ genMainFunc = do
         mainFunc Program = do
           v_filename <- mkVar (quantvar inFileName) mainFn
           logInFile <- maybeLog v_filename mainFn
-          co <- initConsts mainFn
-          ip <- getInputDecl mainFn
-          ics <- genAllInputCalls mainFn
+          co <- initConsts
+          ip <- getInputDecl
+          ics <- genAllInputCalls
           varDef <- mapM (`genCalcCall` mainFn) (execOrder $ codeSpec g)
-          wo <- genOutputCall mainFn
+          wo <- genOutputCall
           return $ Just $ (if CommentFunc `elem` commented g then docMain else
             mainFunction) $ bodyStatements $ initLogFileVar (logKind g)
             ++ varDecDef v_filename (arg 0)
@@ -118,12 +118,12 @@ genMainFunc = do
 -- the InputParameters class, so 'inParams' should be declared and constructed,
 -- using 'objDecNew' if the inputs are exported by the current module, and
 -- 'extObjDecNew' if they are exported by a different module.
-getInputDecl :: (OOProg r) => r (Scope r) -> GenState (Maybe (MSStatement r))
-getInputDecl scp = do
+getInputDecl :: (OOProg r) => GenState (Maybe (MSStatement r))
+getInputDecl = do
   g <- get
-  v_params <- mkVar (quantvar inParams) scp
+  v_params <- mkVar (quantvar inParams) local -- TODO: get scope from state
   constrParams <- getInConstructorParams
-  cps <- mapM (`mkVal` scp) constrParams
+  cps <- mapM (`mkVal` local) constrParams -- TODO: get scope from state
   cname <- genICName InputParameters
   let getDecl ([],[]) = constIns (partition (flip member (eMap g) .
         codeName) (map quantvar $ constants $ codeSpec g)) (conRepr g)
@@ -152,10 +152,10 @@ getInputDecl scp = do
 -- If constants are 'Bundled' 'WithInputs', do 'Nothing'; declaration of the 'inParams'
 -- object is handled by 'getInputDecl'.
 -- If constants are 'Inlined', nothing needs to be declared.
-initConsts :: (OOProg r) => r (Scope r) -> GenState (Maybe (MSStatement r))
-initConsts scp = do
+initConsts :: (OOProg r) => GenState (Maybe (MSStatement r))
+initConsts = do
   g <- get
-  v_consts <- mkVar (quantvar consts) scp
+  v_consts <- mkVar (quantvar consts) local -- TODO: get scope from state
   cname <- genICName Constants
   let cs = constants $ codeSpec g
       getDecl (Store Unbundled) _ = declVars
@@ -164,8 +164,8 @@ initConsts scp = do
       getDecl WithInputs Bundled = return Nothing
       getDecl Inline _ = return Nothing
       declVars = do
-        vars <- mapM ((`mkVar` scp) . quantvar) cs
-        vals <- mapM (convExpr scp . (^. codeExpr)) cs
+        vars <- mapM ((`mkVar` local) . quantvar) cs -- TODO: get scope from state
+        vals <- mapM (convExpr . (^. codeExpr)) cs
         logs <- mapM (`maybeLog` mainFn) vars
         return $ Just $ multi $ zipWith (defFunc $ conRepr g) vars vals ++
           concat logs
@@ -214,7 +214,7 @@ constVarFunc Const = constVar public
 -- generated class also contains the input-related functions as private methods.
 genInputClass :: (OOProg r) => ClassType ->
   GenState (Maybe (SClass r))
-genInputClass ct = do
+genInputClass scp = do
   g <- get
   cname <- genICName InputParameters
   let ins = inputs $ codeSpec g
@@ -234,7 +234,7 @@ genInputClass ct = do
         GenState (Maybe (SClass r))
       genClass [] [] = return Nothing
       genClass inps csts = do
-        vals <- mapM (convExpr local . (^. codeExpr)) csts
+        vals <- mapM (convExpr . (^. codeExpr)) csts
         inputVars <- mapM (\x -> fmap (pubDVar . 
           var' (codeName x) local . convTypeOO) (codeType x)) inps
         constVars <- zipWithM (\c vl -> fmap (\t -> constVarFunc (conRepr g)
@@ -242,7 +242,7 @@ genInputClass ct = do
           csts vals
         let getFunc Primary = primaryClass
             getFunc Auxiliary = auxClass
-            f = getFunc ct
+            f = getFunc scp
         icDesc <- inputClassDesc
         c <- f cname Nothing icDesc (inputVars ++ constVars) constructors methods
         return $ Just c
@@ -263,7 +263,7 @@ genInputConstructor = do
       genCtor True = do
         cdesc <- inputConstructorDesc
         cparams <- getInConstructorParams
-        ics <- genAllInputCalls local
+        ics <- genAllInputCalls
         ctor <- genConstructor ipName cdesc (map pcAuto cparams)
           [block ics]
         return $ Just ctor
@@ -285,7 +285,7 @@ genInputDerived s = do
       genDerived _ = do
         ins <- getDerivedIns
         outs <- getDerivedOuts
-        bod <- mapM (\x -> genCalcBlock local CalcAssign x (x ^. codeExpr)) dvals
+        bod <- mapM (\x -> genCalcBlock CalcAssign x (x ^. codeExpr)) dvals
         desc <- dvFuncDesc
         mthd <- getFunc s dvName desc ins outs bod
         return $ Just mthd
@@ -294,7 +294,7 @@ genInputDerived s = do
 -- | Generates function that checks constraints on the input.
 genInputConstraints :: (OOProg r) => VisibilityTag ->
   GenState (Maybe (SMethod r))
-genInputConstraints v = do
+genInputConstraints s = do
   g <- get
   icName <- genICName InputConstraintsFn
   let cm = cMap $ codeSpec g
@@ -308,37 +308,37 @@ genInputConstraints v = do
         let varsList = filter (\i -> member (i ^. uid) cm) (inputs $ codeSpec g)
             sfwrCs   = map (sfwrLookup cm) varsList
             physCs   = map (physLookup cm) varsList
-        sf <- sfwrCBody sfwrCs local
-        ph <- physCBody physCs local
+        sf <- sfwrCBody sfwrCs
+        ph <- physCBody physCs
         desc <- inConsFuncDesc
-        mthd <- getFunc v icName void desc (map pcAuto parms)
+        mthd <- getFunc s icName void desc (map pcAuto parms)
           Nothing [block sf, block ph]
         return $ Just mthd
-  genConstraints (icName `elem` defSet g)
+  genConstraints $ icName `elem` defSet g
 
 -- | Generates input constraints code block for checking software constraints.
-sfwrCBody :: (OOProg r) => [(CodeVarChunk, [ConstraintCE])] -> r (Scope r) ->
+sfwrCBody :: (OOProg r) => [(CodeVarChunk, [ConstraintCE])] ->
   GenState [MSStatement r]
-sfwrCBody cs scp = do
+sfwrCBody cs = do
   g <- get
   let cb = onSfwrC g
-  chooseConstr cb cs scp
+  chooseConstr cb cs
 
 -- | Generates input constraints code block for checking physical constraints.
-physCBody :: (OOProg r) => [(CodeVarChunk, [ConstraintCE])] -> r (Scope r) ->
+physCBody :: (OOProg r) => [(CodeVarChunk, [ConstraintCE])] ->
   GenState [MSStatement r]
-physCBody cs scp = do
+physCBody cs = do
   g <- get
   let cb = onPhysC g
-  chooseConstr cb cs scp
+  chooseConstr cb cs
 
 -- | Generates conditional statements for checking constraints, where the
 -- bodies depend on user's choice of constraint violation behaviour.
 chooseConstr :: (OOProg r) => ConstraintBehaviour ->
-  [(CodeVarChunk, [ConstraintCE])] -> r (Scope r) -> GenState [MSStatement r]
-chooseConstr cb cs scp = do
-  conds <- mapM (\(q,cns) -> mapM (convExpr scp . renderC q) cns) cs
-  bods <- mapM (chooseCB cb scp) cs
+  [(CodeVarChunk, [ConstraintCE])] -> GenState [MSStatement r]
+chooseConstr cb cs = do
+  conds <- mapM (\(q,cns) -> mapM (convExpr . renderC q) cns) cs
+  bods <- mapM (chooseCB cb) cs
   return $ concat $ zipWith (zipWith (\cond bod -> ifNoElse [((?!) cond, bod)]))
     conds bods
   where chooseCB Warning = constrWarn
@@ -347,33 +347,33 @@ chooseConstr cb cs scp = do
 -- | Generates body defining constraint violation behaviour if Warning chosen from 'chooseConstr'.
 -- Prints a \"Warning\" message followed by a message that says
 -- what value was \"suggested\".
-constrWarn :: (OOProg r) => r (Scope r) -> (CodeVarChunk, [ConstraintCE]) ->
+constrWarn :: (OOProg r) => (CodeVarChunk, [ConstraintCE]) ->
   GenState [MSBody r]
-constrWarn scp c = do
+constrWarn c = do
   let q = fst c
       cs = snd c
-  msgs <- mapM (constraintViolatedMsg scp q "suggested") cs
+  msgs <- mapM (constraintViolatedMsg q "suggested") cs
   return $ map (bodyStatements . (printStr "Warning: " :)) msgs
 
 -- | Generates body defining constraint violation behaviour if Exception chosen from 'chooseConstr'.
 -- Prints a message that says what value was \"expected\",
 -- followed by throwing an exception.
-constrExc :: (OOProg r) => r (Scope r) -> (CodeVarChunk, [ConstraintCE]) ->
+constrExc :: (OOProg r) => (CodeVarChunk, [ConstraintCE]) ->
   GenState [MSBody r]
-constrExc scp c = do
+constrExc c = do
   let q = fst c
       cs = snd c
-  msgs <- mapM (constraintViolatedMsg scp q "expected") cs
+  msgs <- mapM (constraintViolatedMsg q "expected") cs
   return $ map (bodyStatements . (++ [throw "InputError"])) msgs
 
 -- | Generates statements that print a message for when a constraint is violated.
 -- Message includes the name of the cosntraint quantity, its value, and a
 -- description of the constraint that is violated.
-constraintViolatedMsg :: (OOProg r) => r (Scope r) -> CodeVarChunk -> String ->
+constraintViolatedMsg :: (OOProg r) => CodeVarChunk -> String ->
   ConstraintCE -> GenState [MSStatement r]
-constraintViolatedMsg scp q s c = do
-  pc <- printConstraint c scp
-  v <- mkVal (quantvar q) scp
+constraintViolatedMsg q s c = do
+  pc <- printConstraint c
+  v <- mkVal (quantvar q) local -- TODO: get scope from state
   return $ [printStr $ codeName q ++ " has value ",
     print v,
     printStr $ ", but is " ++ s ++ " to be "] ++ pc
@@ -381,26 +381,26 @@ constraintViolatedMsg scp q s c = do
 -- | Generates statements to print descriptions of constraints, using words and
 -- the constrained values. Constrained values are followed by printing the
 -- expression they originated from, using printExpr.
-printConstraint :: (OOProg r) => ConstraintCE -> r (Scope r) ->
+printConstraint :: (OOProg r) => ConstraintCE ->
   GenState [MSStatement r]
-printConstraint c scp = do
+printConstraint c = do
   g <- get
   let db = sysinfodb $ codeSpec g
-      printConstraint' :: (OOProg r) => ConstraintCE -> r (Scope r) ->
-        GenState [MSStatement r]
-      printConstraint' (Range _ (Bounded (_, e1) (_, e2))) s = do
-        lb <- convExpr s e1
-        ub <- convExpr s e2
+      printConstraint' :: (OOProg r) => ConstraintCE -> GenState
+        [MSStatement r]
+      printConstraint' (Range _ (Bounded (_, e1) (_, e2))) = do
+        lb <- convExpr e1
+        ub <- convExpr e2
         return $ [printStr "between ", print lb] ++ printExpr e1 db ++
           [printStr " and ", print ub] ++ printExpr e2 db ++ [printStrLn "."]
-      printConstraint' (Range _ (UpTo (_, e))) s = do
-        ub <- convExpr s e
+      printConstraint' (Range _ (UpTo (_, e))) = do
+        ub <- convExpr e
         return $ [printStr "below ", print ub] ++ printExpr e db ++
           [printStrLn "."]
-      printConstraint' (Range _ (UpFrom (_, e))) s = do
-        lb <- convExpr s e
+      printConstraint' (Range _ (UpFrom (_, e))) = do
+        lb <- convExpr e
         return $ [printStr "above ", print lb] ++ printExpr e db ++ [printStrLn "."]
-  printConstraint' c scp
+  printConstraint' c
 
 -- | Don't print expressions that are just literals, because that would be
 -- redundant (the values are already printed by printConstraint).
@@ -461,7 +461,7 @@ genConstMod = do
 -- Constants class in the class definition map, otherwise returns Nothing.
 genConstClass :: (OOProg r) => ClassType ->
   GenState (Maybe (SClass r))
-genConstClass ct = do
+genConstClass scp = do
   g <- get
   cname <- genICName Constants
   let cs = constants $ codeSpec g
@@ -469,13 +469,13 @@ genConstClass ct = do
         (Maybe (SClass r))
       genClass [] = return Nothing
       genClass vs = do
-        vals <- mapM (convExpr local . (^. codeExpr)) vs
+        vals <- mapM (convExpr . (^. codeExpr)) vs
         vars <- mapM (\x -> fmap (var' (codeName x) local . convTypeOO)
           (codeType x)) vs
         let constVars = zipWith (constVarFunc (conRepr g)) vars vals
             getFunc Primary = primaryClass
             getFunc Auxiliary = auxClass
-            f = getFunc ct
+            f = getFunc scp
         cDesc <- constClassDesc
         cls <- f cname Nothing cDesc constVars (return []) (return [])
         return $ Just cls
@@ -505,12 +505,12 @@ genCalcFunc cdef = do
   tp <- codeType cdef
   v <- mkVar (quantvar cdef) local
   blcks <- case cdef ^. defType
-            of Definition -> liftS $ genCalcBlock local CalcReturn cdef
+            of Definition -> liftS $ genCalcBlock CalcReturn cdef
                  (cdef ^. codeExpr)
                ODE -> maybe (error $ nm ++ " missing from ExtLibMap")
                  (\el -> do
-                   defStmts <- mapM (convStmt local) (el ^. defs) 
-                   stepStmts <- mapM (convStmt local) (el ^. steps)
+                   defStmts <- mapM convStmt (el ^. defs)
+                   stepStmts <- mapM convStmt (el ^. steps)
                    return [block (varDec v : defStmts),
                      block stepStmts,
                      block [returnStmt $ valueOf v]])
@@ -529,28 +529,28 @@ data CalcType = CalcAssign | CalcReturn deriving Eq
 
 -- | Generates a calculation block for the given 'CodeDefinition', and assigns the
 -- result to a variable (if 'CalcAssign') or returns the result (if 'CalcReturn').
-genCalcBlock :: (OOProg r) => r (Scope r) -> CalcType -> CodeDefinition ->
-  CodeExpr -> GenState (MSBlock r)
-genCalcBlock scp t v (Case c e) = genCaseBlock scp t v c e
-genCalcBlock scp CalcAssign v e = do
-  vv <- mkVar (quantvar v) scp
-  ee <- convExpr scp e
-  l <- maybeLog vv scp
+genCalcBlock :: (OOProg r) => CalcType -> CodeDefinition -> CodeExpr ->
+  GenState (MSBlock r)
+genCalcBlock t v (Case c e) = genCaseBlock t v c e
+genCalcBlock CalcAssign v e = do
+  vv <- mkVar (quantvar v) local
+  ee <- convExpr e
+  l <- maybeLog vv local
   return $ block $ assign vv ee : l
-genCalcBlock scp CalcReturn _ e = block <$> liftS (returnStmt <$> convExpr scp e)
+genCalcBlock CalcReturn _ e = block <$> liftS (returnStmt <$> convExpr e)
 
 -- | Generates a calculation block for a value defined by cases.
 -- If the function is defined for every case, the final case is captured by an
 -- else clause, otherwise an error-throwing else-clause is generated.
-genCaseBlock :: (OOProg r) => r (Scope r) -> CalcType -> CodeDefinition ->
-  Completeness -> [(CodeExpr, CodeExpr)] -> GenState (MSBlock r)
-genCaseBlock _ _ _ _ [] = error $ "Case expression with no cases encountered" ++
+genCaseBlock :: (OOProg r) => CalcType -> CodeDefinition -> Completeness
+  -> [(CodeExpr, CodeExpr)] -> GenState (MSBlock r)
+genCaseBlock _ _ _ [] = error $ "Case expression with no cases encountered" ++
   " in code generator"
-genCaseBlock scp t v c cs = do
-  ifs <- mapM (\(e,r) -> liftM2 (,) (convExpr scp r) (calcBody e)) (ifEs c)
+genCaseBlock t v c cs = do
+  ifs <- mapM (\(e,r) -> liftM2 (,) (convExpr r) (calcBody e)) (ifEs c)
   els <- elseE c
   return $ block [ifCond ifs els]
-  where calcBody e = fmap body $ liftS $ genCalcBlock scp t v e
+  where calcBody e = fmap body $ liftS $ genCalcBlock t v e
         ifEs Complete = init cs
         ifEs Incomplete = cs
         elseE Complete = calcBody $ fst $ last cs
@@ -611,11 +611,11 @@ genMainFuncProc = do
         mainFunc Program = do
           v_filename <- mkVarProc (quantvar inFileName) mainFn
           logInFile <- maybeLog v_filename mainFn
-          co <- initConstsProc mainFn
-          ip <- getInputDeclProc mainFn
-          ics <- genAllInputCallsProc mainFn
+          co <- initConstsProc
+          ip <- getInputDeclProc
+          ics <- genAllInputCallsProc
           varDef <- mapM (`genCalcCallProc` mainFn) (execOrder $ codeSpec g)
-          wo <- genOutputCallProc mainFn
+          wo <- genOutputCallProc
           return $ Just $ (if CommentFunc `elem` commented g then docMain else
             mainFunction) $ bodyStatements $ initLogFileVar (logKind g)
             ++ varDecDef v_filename (arg 0)
@@ -634,9 +634,8 @@ genMainFuncProc = do
 -- If constants are 'Bundled' 'WithInputs', do 'Nothing'; declaration of the 'inParams'
 -- object is handled by 'getInputDecl'.
 -- If constants are 'Inlined', nothing needs to be declared.
-initConstsProc :: (SharedProg r) => r (Scope r) ->
-  GenState (Maybe (MSStatement r))
-initConstsProc scp = do
+initConstsProc :: (SharedProg r) => GenState (Maybe (MSStatement r))
+initConstsProc = do
   g <- get
   let cs = constants $ codeSpec g
       getDecl (Store Unbundled) _ = declVars
@@ -645,8 +644,8 @@ initConstsProc scp = do
       getDecl WithInputs Bundled = return Nothing
       getDecl Inline _ = return Nothing
       declVars = do
-        vars <- mapM ((`mkVarProc` scp) . quantvar) cs
-        vals <- mapM (convExprProc scp . (^. codeExpr)) cs
+        vars <- mapM ((`mkVarProc` local) . quantvar) cs -- TODO: get scope from state
+        vals <- mapM (convExprProc . (^. codeExpr)) cs
         logs <- mapM (`maybeLog` mainFn) vars
         return $ Just $ multi $ zipWith (defFunc $ conRepr g) vars vals ++
           concat logs
@@ -703,13 +702,12 @@ checkInputClass = do
 -- the InputParameters class, so 'inParams' should be declared and constructed,
 -- using 'objDecNew' if the inputs are exported by the current module, and
 -- 'extObjDecNew' if they are exported by a different module.
-getInputDeclProc :: (SharedProg r) => r (Scope r) ->
-  GenState (Maybe (MSStatement r))
-getInputDeclProc scp = do
+getInputDeclProc :: (SharedProg r) => GenState (Maybe (MSStatement r))
+getInputDeclProc = do
   g <- get
   let getDecl ([],[]) = return Nothing
       getDecl ([],ins) = do
-        vars <- mapM (`mkVarProc` scp) ins
+        vars <- mapM (`mkVarProc` local) ins
         return $ Just $ multi $ map varDec vars
       getDecl _ = error "getInputDeclProc: Procedural renderers do not support bundled inputs"
   getDecl (partition (flip member (eMap g) . codeName)
@@ -736,12 +734,12 @@ genCalcFuncProc cdef = do
   tp <- codeType cdef
   v <- mkVarProc (quantvar cdef) local
   blcks <- case cdef ^. defType
-            of Definition -> liftS $ genCalcBlockProc local CalcReturn cdef
+            of Definition -> liftS $ genCalcBlockProc CalcReturn cdef
                  (cdef ^. codeExpr)
                ODE -> maybe (error $ nm ++ " missing from ExtLibMap")
                  (\el -> do
-                   defStmts <- mapM (convStmtProc local) (el ^. defs)
-                   stepStmts <- mapM (convStmtProc local) (el ^. steps)
+                   defStmts <- mapM convStmtProc (el ^. defs)
+                   stepStmts <- mapM convStmtProc (el ^. steps)
                    return [block (varDec v : defStmts),
                      block stepStmts,
                      block [returnStmt $ valueOf v]])
@@ -757,28 +755,28 @@ genCalcFuncProc cdef = do
 
 -- | Generates a calculation block for the given 'CodeDefinition', and assigns the
 -- result to a variable (if 'CalcAssign') or returns the result (if 'CalcReturn').
-genCalcBlockProc :: (SharedProg r) => r (Scope r) -> CalcType ->
-  CodeDefinition -> CodeExpr -> GenState (MSBlock r)
-genCalcBlockProc scp t v (Case c e) = genCaseBlockProc scp t v c e
-genCalcBlockProc scp CalcAssign v e = do
-  vv <- mkVarProc (quantvar v) scp
-  ee <- convExprProc scp e
-  l <- maybeLog vv scp
+genCalcBlockProc :: (SharedProg r) => CalcType -> CodeDefinition -> CodeExpr ->
+  GenState (MSBlock r)
+genCalcBlockProc t v (Case c e) = genCaseBlockProc t v c e
+genCalcBlockProc CalcAssign v e = do
+  vv <- mkVarProc (quantvar v) local
+  ee <- convExprProc e
+  l <- maybeLog vv local
   return $ block $ assign vv ee : l
-genCalcBlockProc scp CalcReturn _ e = block <$> liftS (returnStmt <$> convExprProc scp e)
+genCalcBlockProc CalcReturn _ e = block <$> liftS (returnStmt <$> convExprProc e)
 
 -- | Generates a calculation block for a value defined by cases.
 -- If the function is defined for every case, the final case is captured by an
 -- else clause, otherwise an error-throwing else-clause is generated.
-genCaseBlockProc :: (SharedProg r) => r (Scope r) -> CalcType -> CodeDefinition
-  -> Completeness -> [(CodeExpr, CodeExpr)] -> GenState (MSBlock r)
-genCaseBlockProc _ _ _ _ [] = error $ "Case expression with no cases encountered" ++
+genCaseBlockProc :: (SharedProg r) => CalcType -> CodeDefinition -> Completeness
+  -> [(CodeExpr, CodeExpr)] -> GenState (MSBlock r)
+genCaseBlockProc _ _ _ [] = error $ "Case expression with no cases encountered" ++
   " in code generator"
-genCaseBlockProc scp t v c cs = do
-  ifs <- mapM (\(e,r) -> liftM2 (,) (convExprProc scp r) (calcBody e)) (ifEs c)
+genCaseBlockProc t v c cs = do
+  ifs <- mapM (\(e,r) -> liftM2 (,) (convExprProc r) (calcBody e)) (ifEs c)
   els <- elseE c
   return $ block [ifCond ifs els]
-  where calcBody e = fmap body $ liftS $ genCalcBlockProc scp t v e
+  where calcBody e = fmap body $ liftS $ genCalcBlockProc t v e
         ifEs Complete = init cs
         ifEs Incomplete = cs
         elseE Complete = calcBody $ fst $ last cs
@@ -821,7 +819,7 @@ genInputDerivedProc s = do
       genDerived _ = do
         ins <- getDerivedIns
         outs <- getDerivedOuts
-        bod <- mapM (\x -> genCalcBlockProc local CalcAssign x (x ^. codeExpr)) dvals
+        bod <- mapM (\x -> genCalcBlockProc CalcAssign x (x ^. codeExpr)) dvals
         desc <- dvFuncDesc
         mthd <- getFunc s dvName desc ins outs bod
         return $ Just mthd
@@ -830,7 +828,7 @@ genInputDerivedProc s = do
 -- | Generates function that checks constraints on the input.
 genInputConstraintsProc :: (SharedProg r) => VisibilityTag ->
   GenState (Maybe (SMethod r))
-genInputConstraintsProc v = do
+genInputConstraintsProc s = do
   g <- get
   icName <- genICName InputConstraintsFn
   let cm = cMap $ codeSpec g
@@ -844,37 +842,37 @@ genInputConstraintsProc v = do
         let varsList = filter (\i -> member (i ^. uid) cm) (inputs $ codeSpec g)
             sfwrCs   = map (sfwrLookup cm) varsList
             physCs   = map (physLookup cm) varsList
-        sf <- sfwrCBodyProc sfwrCs local
-        ph <- physCBodyProc physCs local
+        sf <- sfwrCBodyProc sfwrCs
+        ph <- physCBodyProc physCs
         desc <- inConsFuncDesc
-        mthd <- getFunc v icName void desc (map pcAuto parms)
+        mthd <- getFunc s icName void desc (map pcAuto parms)
           Nothing [block sf, block ph]
         return $ Just mthd
-  genConstraints (icName `elem` defSet g)
+  genConstraints $ icName `elem` defSet g
 
 -- | Generates input constraints code block for checking software constraints.
 sfwrCBodyProc :: (SharedProg r) => [(CodeVarChunk, [ConstraintCE])] ->
-  r (Scope r) -> GenState [MSStatement r]
-sfwrCBodyProc cs scp = do
+  GenState [MSStatement r]
+sfwrCBodyProc cs = do
   g <- get
   let cb = onSfwrC g
-  chooseConstrProc cb cs scp
+  chooseConstrProc cb cs
 
 -- | Generates input constraints code block for checking physical constraints.
 physCBodyProc :: (SharedProg r) => [(CodeVarChunk, [ConstraintCE])] ->
-  r (Scope r) -> GenState [MSStatement r]
-physCBodyProc cs scp = do
+  GenState [MSStatement r]
+physCBodyProc cs = do
   g <- get
   let cb = onPhysC g
-  chooseConstrProc cb cs scp
+  chooseConstrProc cb cs
 
 -- | Generates conditional statements for checking constraints, where the
 -- bodies depend on user's choice of constraint violation behaviour.
 chooseConstrProc :: (SharedProg r) => ConstraintBehaviour ->
-  [(CodeVarChunk, [ConstraintCE])] -> r (Scope r) -> GenState [MSStatement r]
-chooseConstrProc cb cs scp = do
-  conds <- mapM (\(q,cns) -> mapM (convExprProc scp . renderC q) cns) cs
-  bods <- mapM (chooseCB cb scp) cs
+  [(CodeVarChunk, [ConstraintCE])] -> GenState [MSStatement r]
+chooseConstrProc cb cs = do
+  conds <- mapM (\(q,cns) -> mapM (convExprProc . renderC q) cns) cs
+  bods <- mapM (chooseCB cb) cs
   return $ concat $ zipWith (zipWith (\cond bod -> ifNoElse [((?!) cond, bod)]))
     conds bods
   where chooseCB Warning = constrWarnProc
@@ -883,33 +881,33 @@ chooseConstrProc cb cs scp = do
 -- | Generates body defining constraint violation behaviour if Warning chosen from 'chooseConstr'.
 -- Prints a \"Warning\" message followed by a message that says
 -- what value was \"suggested\".
-constrWarnProc :: (SharedProg r) => r (Scope r) ->
-  (CodeVarChunk, [ConstraintCE]) -> GenState [MSBody r]
-constrWarnProc scp c = do
+constrWarnProc :: (SharedProg r) => (CodeVarChunk, [ConstraintCE]) ->
+  GenState [MSBody r]
+constrWarnProc c = do
   let q = fst c
       cs = snd c
-  msgs <- mapM (constraintViolatedMsgProc scp q "suggested") cs
+  msgs <- mapM (constraintViolatedMsgProc q "suggested") cs
   return $ map (bodyStatements . (printStr "Warning: " :)) msgs
 
 -- | Generates body defining constraint violation behaviour if Exception chosen from 'chooseConstr'.
 -- Prints a message that says what value was \"expected\",
 -- followed by throwing an exception.
-constrExcProc :: (SharedProg r) => r (Scope r) ->
-  (CodeVarChunk, [ConstraintCE]) -> GenState [MSBody r]
-constrExcProc scp c = do
+constrExcProc :: (SharedProg r) => (CodeVarChunk, [ConstraintCE]) ->
+  GenState [MSBody r]
+constrExcProc c = do
   let q = fst c
       cs = snd c
-  msgs <- mapM (constraintViolatedMsgProc scp q "expected") cs
+  msgs <- mapM (constraintViolatedMsgProc q "expected") cs
   return $ map (bodyStatements . (++ [throw "InputError"])) msgs
 
 -- | Generates statements that print a message for when a constraint is violated.
 -- Message includes the name of the cosntraint quantity, its value, and a
 -- description of the constraint that is violated.
-constraintViolatedMsgProc :: (SharedProg r) => r (Scope r) -> CodeVarChunk ->
-  String -> ConstraintCE -> GenState [MSStatement r]
-constraintViolatedMsgProc scp q s c = do
-  pc <- printConstraintProc c scp
-  v <- mkValProc (quantvar q) scp
+constraintViolatedMsgProc :: (SharedProg r) => CodeVarChunk -> String ->
+  ConstraintCE -> GenState [MSStatement r]
+constraintViolatedMsgProc q s c = do
+  pc <- printConstraintProc c
+  v <- mkValProc (quantvar q) local -- TODO: get scope from state
   return $ [printStr $ codeName q ++ " has value ",
     print v,
     printStr $ ", but is " ++ s ++ " to be "] ++ pc
@@ -917,26 +915,26 @@ constraintViolatedMsgProc scp q s c = do
 -- | Generates statements to print descriptions of constraints, using words and
 -- the constrained values. Constrained values are followed by printing the
 -- expression they originated from, using printExpr.
-printConstraintProc :: (SharedProg r) => ConstraintCE -> r (Scope r) ->
+printConstraintProc :: (SharedProg r) => ConstraintCE ->
   GenState [MSStatement r]
-printConstraintProc c scp = do
+printConstraintProc c = do
   g <- get
   let db = sysinfodb $ codeSpec g
-      printConstraint' :: (SharedProg r) => ConstraintCE -> r (Scope r) ->
-        GenState [MSStatement r]
-      printConstraint' (Range _ (Bounded (_, e1) (_, e2))) s = do
-        lb <- convExprProc s e1
-        ub <- convExprProc s e2
+      printConstraint' :: (SharedProg r) => ConstraintCE -> GenState
+        [MSStatement r]
+      printConstraint' (Range _ (Bounded (_, e1) (_, e2))) = do
+        lb <- convExprProc e1
+        ub <- convExprProc e2
         return $ [printStr "between ", print lb] ++ printExpr e1 db ++
           [printStr " and ", print ub] ++ printExpr e2 db ++ [printStrLn "."]
-      printConstraint' (Range _ (UpTo (_, e))) s = do
-        ub <- convExprProc s e
+      printConstraint' (Range _ (UpTo (_, e))) = do
+        ub <- convExprProc e
         return $ [printStr "below ", print ub] ++ printExpr e db ++
           [printStrLn "."]
-      printConstraint' (Range _ (UpFrom (_, e))) s = do
-        lb <- convExprProc s e
+      printConstraint' (Range _ (UpFrom (_, e))) = do
+        lb <- convExprProc e
         return $ [printStr "above ", print lb] ++ printExpr e db ++ [printStrLn "."]
-  printConstraint' c scp
+  printConstraint' c
 
 -- | Generates a module containing the function for printing outputs.
 genOutputModProc :: (ProcProg r) => GenState [Proc.SFile r]

--- a/code/drasil-gool/lib/Drasil/GOOL/AST.hs
+++ b/code/drasil-gool/lib/Drasil/GOOL/AST.hs
@@ -1,5 +1,5 @@
 module Drasil.GOOL.AST (Terminator(..), VisibilityTag(..), ScopeTag(..),
-  ScopeData(..), sd, QualifiedName, qualName, FileType(..), isSource,
+  ScopeData(..), sd, onScope, QualifiedName, qualName, FileType(..), isSource,
   Binding(..), onBinding, BindData(bind, bindDoc), bd, FileData(filePath,
   fileMod), fileD, updateFileMod, FuncData(fType, funcDoc), fd, ModData(name,
   modDoc), md, updateMod, MethodData(mthdDoc), mthd, updateMthd, OpData(opPrec,
@@ -124,12 +124,16 @@ svd :: VisibilityTag -> Doc -> (Doc, Terminator) -> StateVarData
 svd = SVD
 
 -- Used as the underlying data type for Scopes in the Julia renderer
-data ScopeTag = Local | Global
+data ScopeTag = Local | Global deriving Eq
 
 newtype ScopeData = SD {scopeTag :: ScopeTag}
 
 sd :: ScopeTag -> ScopeData
 sd = SD
+
+onScope :: ScopeTag -> a -> a -> a
+onScope Global a _ = a
+onScope Local _ b = b
 
 -- Used as the underlying data type for Types in all renderers
 data TypeData = TD {cType :: CodeType, typeString :: String, typeDoc :: Doc}

--- a/code/drasil-gool/lib/Drasil/GOOL/AST.hs
+++ b/code/drasil-gool/lib/Drasil/GOOL/AST.hs
@@ -7,8 +7,8 @@ module Drasil.GOOL.AST (Terminator(..), VisibilityTag(..), ScopeTag(..),
   ProgData(progName, progPurp, progMods), progD, emptyProg,
   StateVarData(getStVarScp, stVar, destructSts), svd, TypeData(cType,
   typeString, typeDoc), td, ValData(valPrec, valInt, valType, val), vd,
-  updateValDoc, VarData(varBind, varName, varType, varDoc), vard, CommonThunk,
-  pureValue, vectorize, vectorize2, sumComponents, commonVecIndex,
+  updateValDoc, VarData(varBind, varName, varScope, varType, varDoc), vard,
+  CommonThunk, pureValue, vectorize, vectorize2, sumComponents, commonVecIndex,
   commonThunkElim, commonThunkDim
 ) where
 
@@ -152,9 +152,9 @@ updateValDoc f v = vd (valPrec v) (valInt v) (valType v) ((f . val) v)
 
 -- Used as the underlying data type for Variables in all renderers
 data VarData = VarD {varBind :: Binding, varName :: String, 
-  varType :: TypeData, varDoc :: Doc}
+  varScope :: ScopeData, varType :: TypeData, varDoc :: Doc}
 
-vard :: Binding -> String -> TypeData -> Doc -> VarData
+vard :: Binding -> String -> ScopeData -> TypeData -> Doc -> VarData
 vard = VarD
 
 -- Used as the underlying data type for Thunks in all renderers

--- a/code/drasil-gool/lib/Drasil/GOOL/CodeInfoOO.hs
+++ b/code/drasil-gool/lib/Drasil/GOOL/CodeInfoOO.hs
@@ -129,6 +129,7 @@ instance OOVariableSym CodeInfoOO where
 instance VariableElim CodeInfoOO where
   variableName _ = ""
   variableType _ = toCode ""
+  variableScope _ = toCode ()
 
 instance ValueSym CodeInfoOO where
   type Value CodeInfoOO = ()

--- a/code/drasil-gool/lib/Drasil/GOOL/CodeInfoProc.hs
+++ b/code/drasil-gool/lib/Drasil/GOOL/CodeInfoProc.hs
@@ -108,6 +108,7 @@ instance VariableSym CodeInfoProc where
 instance VariableElim CodeInfoProc where
   variableName _ = ""
   variableType _ = toCode ""
+  variableScope _ = toCode ()
 
 instance ValueSym CodeInfoProc where
   type Value CodeInfoProc = ()

--- a/code/drasil-gool/lib/Drasil/GOOL/InterfaceCommon.hs
+++ b/code/drasil-gool/lib/Drasil/GOOL/InterfaceCommon.hs
@@ -124,6 +124,7 @@ mainVar n = var' n mainFn
 class (VariableSym r) => VariableElim r where
   variableName :: r (Variable r) -> String
   variableType :: r (Variable r) -> r (Type r)
+  variableScope :: r (Variable r) -> r (Scope r)
 
 listVar :: (VariableSym r) => Label -> VSType r -> r (Scope r) -> SVariable r
 listVar n t = var n (listType t)

--- a/code/drasil-gool/lib/Drasil/GOOL/LanguageRenderer/AbstractProc.hs
+++ b/code/drasil-gool/lib/Drasil/GOOL/LanguageRenderer/AbstractProc.hs
@@ -6,8 +6,8 @@ module Drasil.GOOL.LanguageRenderer.AbstractProc (fileDoc, fileFromData,
 ) where
 
 import Drasil.GOOL.InterfaceCommon (Label, SMethod, MSBody, MSStatement, SValue,
-  SVariable, MSParameter, VSType, VariableElim(variableName, variableType),
-  VisibilitySym(..), getType, convType, ScopeSym(local))
+  SVariable, MSParameter, VSType, VariableElim(variableName, variableType,
+  variableScope), VisibilitySym(..), getType, convType)
 import qualified Drasil.GOOL.InterfaceCommon as IC (MethodSym(function),
   List(intToIndex), ParameterSym(param))
 import Drasil.GOOL.InterfaceProc (SFile, FSModule, FileSym (File),
@@ -87,7 +87,7 @@ arrayElem i' v' = do
   let vName = variableName v ++ "[" ++ render (RCC.value i) ++ "]"
       vType = listInnerType $ return $ variableType v
       vRender = RCC.variable v <> brackets (RCC.value i)
-  mkStateVar vName local vType vRender -- TODO: get scope from v
+  mkStateVar vName (variableScope v) vType vRender
 
 funcDecDef :: (ProcRenderSym r) => SVariable r -> [SVariable r] -> MSBody r ->
   MSStatement r

--- a/code/drasil-gool/lib/Drasil/GOOL/LanguageRenderer/AbstractProc.hs
+++ b/code/drasil-gool/lib/Drasil/GOOL/LanguageRenderer/AbstractProc.hs
@@ -7,7 +7,7 @@ module Drasil.GOOL.LanguageRenderer.AbstractProc (fileDoc, fileFromData,
 
 import Drasil.GOOL.InterfaceCommon (Label, SMethod, MSBody, MSStatement, SValue,
   SVariable, MSParameter, VSType, VariableElim(variableName, variableType),
-  VisibilitySym(..), getType, convType)
+  VisibilitySym(..), getType, convType, ScopeSym(local))
 import qualified Drasil.GOOL.InterfaceCommon as IC (MethodSym(function),
   List(intToIndex), ParameterSym(param))
 import Drasil.GOOL.InterfaceProc (SFile, FSModule, FileSym (File),
@@ -87,7 +87,7 @@ arrayElem i' v' = do
   let vName = variableName v ++ "[" ++ render (RCC.value i) ++ "]"
       vType = listInnerType $ return $ variableType v
       vRender = RCC.variable v <> brackets (RCC.value i)
-  mkStateVar vName vType vRender
+  mkStateVar vName local vType vRender -- TODO: get scope from v
 
 funcDecDef :: (ProcRenderSym r) => SVariable r -> [SVariable r] -> MSBody r ->
   MSStatement r

--- a/code/drasil-gool/lib/Drasil/GOOL/LanguageRenderer/CLike.hs
+++ b/code/drasil-gool/lib/Drasil/GOOL/LanguageRenderer/CLike.hs
@@ -13,8 +13,8 @@ import Utils.Drasil (indent)
 import Drasil.GOOL.CodeType (CodeType(..))
 import Drasil.GOOL.InterfaceCommon (Label, Library, MSBody, VSType, SVariable, 
   SValue, MSStatement, MSParameter, SMethod, MixedCall, MixedCtorCall, 
-  TypeElim(getType, getTypeString), 
-  VariableElim(..), ValueSym(Value, valueType), VisibilitySym(..))
+  TypeElim(getType, getTypeString), VariableElim(..), ValueSym(Value,
+  valueType), VisibilitySym(..), ScopeSym(local))
 import qualified Drasil.GOOL.InterfaceCommon as IC (TypeSym(bool, float),
   ValueExpression(funcAppMixedArgs), DeclStatement(varDec, varDecDef))
 import Drasil.GOOL.InterfaceGOOL (PermanenceSym(..), extNewObj, ($.))
@@ -93,7 +93,7 @@ orOp = orPrec "||"
 self :: (OORenderSym r) => SVariable r
 self = do 
   l <- zoom lensVStoMS getClassName 
-  mkStateVar R.this (IG.obj l) R.this'
+  mkStateVar R.this local (IG.obj l) R.this'
 
 -- Values --
 

--- a/code/drasil-gool/lib/Drasil/GOOL/LanguageRenderer/CSharpRenderer.hs
+++ b/code/drasil-gool/lib/Drasil/GOOL/LanguageRenderer/CSharpRenderer.hs
@@ -291,6 +291,7 @@ instance OOVariableSym CSharpCode where
 instance VariableElim CSharpCode where
   variableName = varName . unCSC
   variableType = onCodeValue varType
+  variableScope = onCodeValue varScope
 
 instance InternalVarElim CSharpCode where
   variableBind = varBind . unCSC

--- a/code/drasil-gool/lib/Drasil/GOOL/LanguageRenderer/CSharpRenderer.hs
+++ b/code/drasil-gool/lib/Drasil/GOOL/LanguageRenderer/CSharpRenderer.hs
@@ -275,7 +275,7 @@ instance ScopeSym CSharpCode where
 
 instance VariableSym CSharpCode where
   type Variable CSharpCode = VarData
-  var' n _    = G.var n
+  var'        = G.var
   constant'   = var'
   extVar      = CP.extVar
   arrayElem i = G.arrayElem (litInt i)
@@ -297,9 +297,9 @@ instance InternalVarElim CSharpCode where
   variable = varDoc . unCSC
 
 instance RenderVariable CSharpCode where
-  varFromData b n t' d = do 
+  varFromData b n s t' d = do
     t <- t'
-    toState $ on2CodeValues (vard b n) t (toCode d)
+    toState $ on3CodeValues (vard b n) s t (toCode d)
 
 instance ValueSym CSharpCode where
   type Value CSharpCode = ValData

--- a/code/drasil-gool/lib/Drasil/GOOL/LanguageRenderer/Constructors.hs
+++ b/code/drasil-gool/lib/Drasil/GOOL/LanguageRenderer/Constructors.hs
@@ -7,7 +7,7 @@ module Drasil.GOOL.LanguageRenderer.Constructors (
 ) where
 
 import Drasil.GOOL.InterfaceCommon (VSType, MSStatement, SVariable, SValue,
-  TypeSym(..), TypeElim(..), ValueSym(..))
+  TypeSym(..), TypeElim(..), ValueSym(..), ScopeSym(Scope, local))
 import Drasil.GOOL.RendererClassesCommon (CommonRenderSym, VSUnOp, VSBinOp,
   UnaryOpSym(..), BinaryOpSym(..), OpElim(uOpPrec, bOpPrec), RenderVariable(..),
   RenderValue(..), ValueElim(valuePrec), RenderStatement(..))
@@ -45,16 +45,18 @@ mkVal t = valFromData Nothing Nothing (toState t)
 -- Variables --
 
 -- | Constructs a dynamic variable in a stateful context
-mkStateVar :: (CommonRenderSym r) => String -> VSType r -> Doc -> SVariable r
+mkStateVar :: (CommonRenderSym r) => String -> r (Scope r) -> VSType r ->
+  Doc -> SVariable r
 mkStateVar = varFromData Dynamic
 
 -- | Constructs a dynamic variable in a non-stateful context
-mkVar :: (CommonRenderSym r) => String -> r (Type r) -> Doc -> SVariable r
-mkVar n t = varFromData Dynamic n (toState t)
+mkVar :: (CommonRenderSym r) => String -> r (Scope r) -> r (Type r) ->
+  Doc -> SVariable r
+mkVar n s t = varFromData Dynamic n s (toState t)
 
 -- | Constructs a static variable in a stateful context
 mkStaticVar :: (CommonRenderSym r) => String -> VSType r -> Doc -> SVariable r
-mkStaticVar = varFromData Static
+mkStaticVar n = varFromData Static n local
 
 -- Operators --
 

--- a/code/drasil-gool/lib/Drasil/GOOL/LanguageRenderer/CppRenderer.hs
+++ b/code/drasil-gool/lib/Drasil/GOOL/LanguageRenderer/CppRenderer.hs
@@ -300,6 +300,7 @@ instance (Pair p) => OOVariableSym (p CppSrcCode CppHdrCode) where
 instance (Pair p) => VariableElim (p CppSrcCode CppHdrCode) where
   variableName v = variableName $ pfst v
   variableType v = pair (variableType $ pfst v) (variableType $ psnd v)
+  variableScope v = pair (variableScope $ pfst v) (variableScope $ psnd v)
 
 instance (Pair p) => InternalVarElim (p CppSrcCode CppHdrCode) where
   variableBind v = variableBind $ pfst v
@@ -1210,6 +1211,7 @@ instance OOVariableSym CppSrcCode where
 instance VariableElim CppSrcCode where
   variableName = varName . unCPPSC
   variableType = onCodeValue varType
+  variableScope = onCodeValue varScope
 
 instance InternalVarElim CppSrcCode where
   variableBind = varBind . unCPPSC
@@ -1908,6 +1910,7 @@ instance OOVariableSym CppHdrCode where
 instance VariableElim CppHdrCode where
   variableName = varName . unCPPHC
   variableType = onCodeValue varType
+  variableScope = onCodeValue varScope
 
 instance InternalVarElim CppHdrCode where
   variableBind = varBind . unCPPHC

--- a/code/drasil-gool/lib/Drasil/GOOL/LanguageRenderer/JavaRenderer.hs
+++ b/code/drasil-gool/lib/Drasil/GOOL/LanguageRenderer/JavaRenderer.hs
@@ -282,7 +282,7 @@ instance ScopeSym JavaCode where
 
 instance VariableSym JavaCode where
   type Variable JavaCode = VarData
-  var' n _    = G.var n
+  var'        = G.var
   constant'   = var'
   extVar      = CP.extVar
   arrayElem i = G.arrayElem (litInt i)
@@ -304,9 +304,9 @@ instance InternalVarElim JavaCode where
   variable = varDoc . unJC
 
 instance RenderVariable JavaCode where
-  varFromData b n t' d =  do 
+  varFromData b n s t' d =  do 
     t <- t'
-    toState $ on2CodeValues (vard b n) t (toCode d)
+    toState $ on3CodeValues (vard b n) s t (toCode d)
 
 instance ValueSym JavaCode where
   type Value JavaCode = ValData

--- a/code/drasil-gool/lib/Drasil/GOOL/LanguageRenderer/JavaRenderer.hs
+++ b/code/drasil-gool/lib/Drasil/GOOL/LanguageRenderer/JavaRenderer.hs
@@ -298,6 +298,7 @@ instance OOVariableSym JavaCode where
 instance VariableElim JavaCode where
   variableName = varName . unJC
   variableType = onCodeValue varType
+  variableScope = onCodeValue varScope
   
 instance InternalVarElim JavaCode where
   variableBind = varBind . unJC

--- a/code/drasil-gool/lib/Drasil/GOOL/LanguageRenderer/JuliaRenderer.hs
+++ b/code/drasil-gool/lib/Drasil/GOOL/LanguageRenderer/JuliaRenderer.hs
@@ -261,6 +261,7 @@ instance VariableSym JuliaCode where
 instance VariableElim JuliaCode where
   variableName = varName . unJLC
   variableType = onCodeValue varType
+  variableScope = onCodeValue varScope
 
 instance InternalVarElim JuliaCode where
   variableBind = varBind . unJLC
@@ -700,13 +701,14 @@ jlListSlice :: (CommonRenderSym r) => SVariable r -> SValue r ->
   Maybe (SValue r) -> Maybe (SValue r) -> SValue r -> MSBlock r
 jlListSlice vn vo beg end step = do
   stepV <- zoom lensMStoVS step
+  vnew <- zoom lensMStoVS vn
 
   let mbStepV = valueInt stepV
   bName <- genVarNameIf (isNothing beg && isNothing mbStepV) "begIdx"
   eName <- genVarNameIf (isNothing mbStepV) "endIdx"
 
-  let begVar = var bName int local -- TODO: get scope from vn
-      endVar = var eName int local -- TODO: get scope from vn
+  let begVar = var bName int (variableScope vnew)
+      endVar = var eName int (variableScope vnew)
 
       (setBeg, begVal) = case (beg, mbStepV) of
         -- If we have a value for beg, just use it

--- a/code/drasil-gool/lib/Drasil/GOOL/LanguageRenderer/LanguagePolymorphic.hs
+++ b/code/drasil-gool/lib/Drasil/GOOL/LanguageRenderer/LanguagePolymorphic.hs
@@ -25,16 +25,16 @@ import Drasil.GOOL.InterfaceCommon (Label, Library, MSBody, MSBlock, VSFunction,
   NamedArgs, MixedCall, MixedCtorCall, BodySym(Body), bodyStatements, oneLiner,
   BlockSym(Block), TypeSym(Type), TypeElim(getType, getTypeString),
   VariableSym(Variable), VisibilitySym(..), VariableElim(variableName,
-  variableType), ValueSym(Value, valueType), NumericExpression((#+), (#-), (#/),
-  sin, cos, tan), Comparison(..), funcApp, StatementSym(multi),
-  AssignStatement((&++)), (&=), IOStatement(printStr, printStrLn, printFile,
-  printFileStr, printFileStrLn), ifNoElse)
+  variableType, variableScope), ValueSym(Value, valueType),
+  NumericExpression((#+), (#-), (#/), sin, cos, tan), Comparison(..), funcApp,
+  StatementSym(multi), AssignStatement((&++)), (&=), IOStatement(printStr,
+  printStrLn, printFile, printFileStr, printFileStrLn), ifNoElse)
 import qualified Drasil.GOOL.InterfaceCommon as IC (TypeSym(int, double, char,
   string, listType, arrayType, listInnerType, funcType, void), locVar,
   Literal(litInt, litFloat, litDouble, litString), VariableValue(valueOf),
   List(listSize, listAccess), StatementSym(valStmt), DeclStatement(varDecDef),
   IOStatement(print), ControlStatement(returnStmt, for), ParameterSym(param),
-  List(intToIndex), ScopeSym(local))
+  List(intToIndex))
 import Drasil.GOOL.InterfaceGOOL (SFile, FSModule, SClass, Initializers,
   CSStateVar, FileSym(File), ModuleSym(Module), newObj, objMethodCallNoParams,
   ($.), PermanenceSym(..), convTypeOO)
@@ -201,7 +201,7 @@ objVar o' v' = do
   let objVar' Static = error 
         "Cannot access static variables through an object, use classVar instead"
       objVar' Dynamic = mkVar (variableName o `access` variableName v) 
-        IC.local (variableType v) (R.objVar (RC.variable o) (RC.variable v)) -- TODO: get scope from o
+        (variableScope o) (variableType v) (R.objVar (RC.variable o) (RC.variable v))
   objVar' (variableBind v)
 
 arrayElem :: (OORenderSym r) => SValue r -> SVariable r -> SVariable r
@@ -211,7 +211,7 @@ arrayElem i' v' = do
   let vName = variableName v ++ "[" ++ render (RC.value i) ++ "]"
       vType = listInnerType $ return $ variableType v
       vRender = RC.variable v <> brackets (RC.value i)
-  mkStateVar vName IC.local vType vRender -- TODO: get scope from v
+  mkStateVar vName (variableScope v) vType vRender
 
 -- Scope --
 local :: (Monad r) => r ScopeData

--- a/code/drasil-gool/lib/Drasil/GOOL/LanguageRenderer/PythonRenderer.hs
+++ b/code/drasil-gool/lib/Drasil/GOOL/LanguageRenderer/PythonRenderer.hs
@@ -291,6 +291,7 @@ instance OOVariableSym PythonCode where
 instance VariableElim PythonCode where
   variableName = varName . unPC
   variableType = onCodeValue varType
+  variableScope = onCodeValue varScope
 
 instance InternalVarElim PythonCode where
   variableBind = varBind . unPC
@@ -549,10 +550,10 @@ instance DeclStatement PythonCode where
   listDecDef = CP.listDecDef
   arrayDec = listDec
   arrayDecDef = listDecDef
-  constDecDef v e = do
-    v' <- zoom lensMStoVS v
-    let n = toConstName $ variableName v'
-        newConst = constant n (pure (variableType v')) local -- TODO: get scope from v
+  constDecDef v' e = do
+    v <- zoom lensMStoVS v'
+    let n = toConstName $ variableName v
+        newConst = constant n (pure (variableType v)) (variableScope v)
     available <- varNameAvailable n
     if available
       then varDecDef newConst e

--- a/code/drasil-gool/lib/Drasil/GOOL/LanguageRenderer/SwiftRenderer.hs
+++ b/code/drasil-gool/lib/Drasil/GOOL/LanguageRenderer/SwiftRenderer.hs
@@ -95,7 +95,8 @@ import Drasil.GOOL.AST (Terminator(..), VisibilityTag(..), qualName, FileType(..
   CommonThunk, pureValue, vectorize, vectorize2, sumComponents, commonVecIndex,
   commonThunkElim, commonThunkDim, ScopeData)
 import Drasil.GOOL.Helpers (hicat, emptyIfNull, toCode, toState, onCodeValue,
-  onStateValue, on2CodeValues, on2StateValues, onCodeList, onStateList)
+  onStateValue, on2CodeValues, on3CodeValues, on2StateValues, onCodeList,
+  onStateList)
 import Drasil.GOOL.State (MS, VS, lensGStoFS, lensFStoCS, lensFStoMS,
   lensCStoVS, lensMStoFS, lensMStoVS, lensVStoFS, revFiles, addLangImportVS,
   getLangImports, getLibImports, setFileType, getClassName, setModuleName,
@@ -281,7 +282,7 @@ instance ScopeSym SwiftCode where
 
 instance VariableSym SwiftCode where
   type Variable SwiftCode = VarData
-  var' n _    = G.var n
+  var'        = G.var
   constant'   = var'
   extVar _ n  = var' n local
   arrayElem i = G.arrayElem (litInt i)
@@ -303,9 +304,9 @@ instance InternalVarElim SwiftCode where
   variable = varDoc . unSC
 
 instance RenderVariable SwiftCode where
-  varFromData b n t' d = do
+  varFromData b n s t' d = do
     t <- t'
-    pure $ on2CodeValues (vard b n) t (toCode d)
+    pure $ on3CodeValues (vard b n) s t (toCode d)
 
 instance ValueSym SwiftCode where
   type Value SwiftCode = ValData

--- a/code/drasil-gool/lib/Drasil/GOOL/RendererClassesCommon.hs
+++ b/code/drasil-gool/lib/Drasil/GOOL/RendererClassesCommon.hs
@@ -7,9 +7,10 @@ module Drasil.GOOL.RendererClassesCommon (
   OpElim(..), RenderVariable(..), InternalVarElim(..), RenderValue(..),
   ValueElim(..), InternalListFunc(..), RenderFunction(..), FunctionElim(..),
   InternalAssignStmt(..), InternalIOStmt(..), InternalControlStmt(..),
-  RenderStatement(..), StatementElim(..), RenderVisibility(..), VisibilityElim(..),
-  MSMthdType, MethodTypeSym(..), RenderParam(..), ParamElim(..),
-  RenderMethod(..), MethodElim(..), BlockCommentSym(..), BlockCommentElim(..),
+  RenderStatement(..), StatementElim(..), RenderVisibility(..),
+  VisibilityElim(..), MSMthdType, MethodTypeSym(..), RenderParam(..),
+  ParamElim(..), RenderMethod(..), MethodElim(..), BlockCommentSym(..),
+  BlockCommentElim(..)
 ) where
 
 import Drasil.GOOL.InterfaceCommon (Label, Library, MSBody, MSBlock, VSFunction,
@@ -21,7 +22,7 @@ import Drasil.GOOL.InterfaceCommon (Label, Library, MSBody, MSBlock, VSFunction,
   InternalList(..), VectorExpression(..), StatementSym(..), AssignStatement(..),
   DeclStatement(..), IOStatement(..), StringStatement(..), FunctionSym(..),
   FuncAppStatement(..), CommentStatement(..), ControlStatement(..),
-  VisibilitySym(..), ParameterSym(..), MethodSym(..))
+  VisibilitySym(..), ParameterSym(..), MethodSym(..), ScopeSym(Scope))
 import Drasil.GOOL.CodeType (CodeType)
 import Drasil.GOOL.AST (Binding, Terminator, VisibilityTag)
 import Drasil.GOOL.State (MS, VS)
@@ -122,7 +123,7 @@ class OpElim r where
   bOpPrec :: r (BinaryOp r) -> Int
   
 class RenderVariable r where
-  varFromData :: Binding -> String -> VSType r -> Doc -> SVariable r
+  varFromData :: Binding -> String -> r (Scope r) -> VSType r -> Doc -> SVariable r
     
 class InternalVarElim r where
   variableBind :: r (Variable r) -> Binding

--- a/code/stable/gooltest/julia/FileTests/FileTests.jl
+++ b/code/stable/gooltest/julia/FileTests/FileTests.jl
@@ -1,18 +1,18 @@
 module FileTests
 
-fileToWrite = open("testText.txt", "w")
+global fileToWrite = open("testText.txt", "w")
 print(fileToWrite, 0)
 println(fileToWrite, 0.89)
 print(fileToWrite, "ello")
 println(fileToWrite, "bye")
 println(fileToWrite, "!!")
 close(fileToWrite)
-fileToRead = open("testText.txt", "r")
-fileLine = readline(fileToRead)
+global fileToRead = open("testText.txt", "r")
+global fileLine = readline(fileToRead)
 readline(fileToRead)
-fileContents = []
+global fileContents = []
 
-fileContents = readlines(fileToRead)
+global fileContents = readlines(fileToRead)
 
 println(fileContents)
 close(fileToRead)

--- a/code/stable/gooltest/julia/HelloWorld/HelloWorld.jl
+++ b/code/stable/gooltest/julia/HelloWorld/HelloWorld.jl
@@ -10,68 +10,68 @@ include("Helper.jl")
 import .Helper
 
 # Initializing variables
-b = 5
-myOtherList = [1.0, 1.5]
-oneIndex = findfirst(x -> x == 1.0, myOtherList) - 1
+global b = 5
+global myOtherList = [1.0, 1.5]
+global oneIndex = findfirst(x -> x == 1.0, myOtherList) - 1
 println(oneIndex)
-a = length(myOtherList)
+global a = length(myOtherList)
 insert!(myOtherList, 3, 2.0)
 append!(myOtherList, 2.5)
-e = myOtherList[2]
+global e = myOtherList[2]
 myOtherList[2] = 17.4
-myName = []
-myName = split("Brooks Mac", " ")
+global myName = []
+global myName = split("Brooks Mac", " ")
 println(myName)
-boringList = [false, false, false, false, false]
+global boringList = [false, false, false, false, false]
 println(boringList)
 
 # List slicing tests
 # Create variables for list slices
-mySlicedList = []
-mySlicedList2 = []
-mySlicedList3 = []
-mySlicedList4 = []
-mySlicedList5 = []
-mySlicedList6 = []
-mySlicedList7 = []
-mySlicedList8 = []
-mySlicedList9 = []
-mySlicedList10 = []
-mySlicedList11 = []
+global mySlicedList = []
+global mySlicedList2 = []
+global mySlicedList3 = []
+global mySlicedList4 = []
+global mySlicedList5 = []
+global mySlicedList6 = []
+global mySlicedList7 = []
+global mySlicedList8 = []
+global mySlicedList9 = []
+global mySlicedList10 = []
+global mySlicedList11 = []
 
 # Create some variables for later tests
-x = 3
-y = 1
-z = -1
+global x = 3
+global y = 1
+global z = -1
 
-mySlicedList = myOtherList[2:3]
+global mySlicedList = myOtherList[2:3]
 
-mySlicedList2 = myOtherList[2:2:4]
+global mySlicedList2 = myOtherList[2:2:4]
 
-mySlicedList3 = myOtherList[2:end]
+global mySlicedList3 = myOtherList[2:end]
 
-mySlicedList4 = myOtherList[4:1]
+global mySlicedList4 = myOtherList[4:1]
 
-mySlicedList5 = myOtherList[4:-1:3]
+global mySlicedList5 = myOtherList[4:-1:3]
 
-mySlicedList6 = myOtherList[end:-1:3]
+global mySlicedList6 = myOtherList[end:-1:3]
 
-mySlicedList7 = myOtherList[4:-1:begin]
+global mySlicedList7 = myOtherList[4:-1:begin]
 
-endIdx = z > 0 ? 0 : 2
-mySlicedList8 = myOtherList[4:z:endIdx]
+global endIdx = z > 0 ? 0 : 2
+global mySlicedList8 = myOtherList[4:z:endIdx]
 
-endIdx0 = z > 0 ? y : y + 2
-mySlicedList9 = myOtherList[x + 1:z:endIdx0]
+global endIdx0 = z > 0 ? y : y + 2
+global mySlicedList9 = myOtherList[x + 1:z:endIdx0]
 
-endIdx1 = z > 0 ? length(myOtherList) : 1
-mySlicedList10 = myOtherList[3:z:endIdx1]
+global endIdx1 = z > 0 ? length(myOtherList) : 1
+global mySlicedList10 = myOtherList[3:z:endIdx1]
 
-endIdx2 = z > 0 ? length(myOtherList) : 1
-mySlicedList10 = myOtherList[3:z:endIdx2]
+global endIdx2 = z > 0 ? length(myOtherList) : 1
+global mySlicedList10 = myOtherList[3:z:endIdx2]
 
-endIdx3 = z > 0 ? x : x + 2
-mySlicedList11 = myOtherList[y + 1:z:endIdx3]
+global endIdx3 = z > 0 ? x : x + 2
+global mySlicedList11 = myOtherList[y + 1:z:endIdx3]
 
 # Print results of list slicing tests
 println("")
@@ -103,23 +103,23 @@ println(mySlicedList11)
 
 println("")
 if b >= 6
-    dummy = "dummy"
+    global dummy = "dummy"
 elseif b == 5
     # If body -----------------------------------------------------------------
-    a = 5
-    b = a + 2
-    c = b + 3
-    d = b
-    d -= a
-    c -= d
-    b += 17;
-    c += 17;
-    a += 1;
-    d += 1;
-    c -= 1
-    b -= 1
-    myList = []
-    myConst = "Imconstant";
+    global a = 5
+    global b = a + 2
+    global c = b + 3
+    global d = b
+    global d -= a
+    global c -= d
+    global b += 17
+    global c += 17
+    global a += 1
+    global d += 1
+    global c -= 1
+    global b -= 1
+    global myList = []
+    const myConst = "Imconstant";
     println(a)
     println(b)
     println(c)
@@ -127,7 +127,7 @@ elseif b == 5
     println(myOtherList)
     println(mySlicedList)
     println("Type an int")
-    d = parse(Int64, readline())
+    global d = parse(Int64, readline())
     println("Type another")
     readline()
     
@@ -173,18 +173,18 @@ else
     println("Great, no bores!")
 end
 if a == 5
-    b = 10
+    global b = 10
 elseif a == 0
-    b = 5
+    global b = 5
 else
-    b = 0
+    global b = 0
 end
 for i in 0:1:9
     println(i)
 end
 while a < 13
     println("Hello")
-    a += 1;
+    global a += 1
 end
 for num in myOtherList
     println(Helper.doubleAndAdd(num, 1.0))

--- a/code/stable/gooltest/julia/NameGenTest/NameGenTest.jl
+++ b/code/stable/gooltest/julia/NameGenTest/NameGenTest.jl
@@ -6,9 +6,9 @@ function helper(temp::Array{Int64})
     result = temp[2:3]
 end
 
-temp = [1, 2, 3]
-result = []
+global temp = [1, 2, 3]
+global result = []
 
-result = temp[2:3]
+global result = temp[2:3]
 
 end

--- a/code/stable/gooltest/julia/VectorTest/VectorTest.jl
+++ b/code/stable/gooltest/julia/VectorTest/VectorTest.jl
@@ -1,13 +1,13 @@
 module VectorTest
 
-v1 = [1.0, 1.5]
-v2 = [0.0, -1.0]
+global v1 = [1.0, 1.5]
+global v2 = [0.0, -1.0]
 for i in 0:1:length(v1) - 1
     v1[i + 1] = 2.0 * v1[i + 1] + v2[i + 1]
 end
-x = 0.0
+global x = 0.0
 for j in 0:1:length(v1) - 1
-    x += v1[j + 1] * v2[j + 1];
+    global x += v1[j + 1] * v2[j + 1]
 end
 
 end

--- a/code/stable/projectile/projectile_u_p_nol_u_wi_v_d/src/julia/Projectile.jl
+++ b/code/stable/projectile/projectile_u_p_nol_u_wi_v_d/src/julia/Projectile.jl
@@ -124,15 +124,15 @@ function write_output(s::String, d_offset::Float64, t_flight::Float64)
     close(outputfile)
 end
 
-filename = ARGS[1]
+global filename = ARGS[1]
 g = 9.8
 epsilon = 2.0e-2
 v_launch, theta, p_target = get_input(filename)
 input_constraints(v_launch, theta, p_target)
-t_flight = func_t_flight(v_launch, theta, g)
-p_land = func_p_land(v_launch, theta, g)
-d_offset = func_d_offset(p_target, p_land)
-s = func_s(p_target, epsilon, d_offset)
+global t_flight = func_t_flight(v_launch, theta, g)
+global p_land = func_p_land(v_launch, theta, g)
+global d_offset = func_d_offset(p_target, p_land)
+global s = func_s(p_target, epsilon, d_offset)
 write_output(s, d_offset, t_flight)
 
 end


### PR DESCRIPTION
This shows what we are currently able to do with the `Scope` given.  We still need to work out some decisions in #3899, but this indicates that the general direction seems to be right.

#### Changes:
- I made it so that `constDecDef` uses the `const` keyword when in the `global` scope.
- I also made it so that whenever assigning, incrementing, or decrementing a variable, if that variable is a `global` variable, the `global` keyword is used with it.
  - This is a bit overkill, and the generated code doesn't look very idiomatic because of it.  It's a good start though, and it's enough to prevent `HelloWorld.jl` from crashing when run.

#### Next steps:
- As I mentioned, we are adding way more `global` declarations than we need to.  We only need a `global` declaration if we are assigning to a `global` variable from a `local` context.  Also, I think it would look better if we add the `global` declaration once, at the top of the outermost `local` scope, rather than inline with the assignment.
- The problem is that GOOL doesn't seem to differentiate very well what kind of scope it's in.  Functions and classes are fine, but loops are just `MSStatement`s, which are too general.

Builds on #3891
Contributes to #3821 