### PR TITLE
Make the `HasUID` lens read-only

### DIFF
--- a/code/drasil-example/ssp/lib/Drasil/SSP/GenDefs.hs
+++ b/code/drasil-example/ssp/lib/Drasil/SSP/GenDefs.hs
@@ -150,7 +150,8 @@ resShrDeriv = mkDerivNoHeader [foldlSent [S "Derived by substituting",
 
 --
 mobShr :: RelationConcept
-mobShr = addRelToCC mobShrI "mobShr" mobShrRel -- genDef4Label
+mobShr = makeRC "mobShr" (nounPhraseSP "mobilized shear force")
+           mobShrDesc mobShrRel
 
 mobShrRel :: Relation
 mobShrRel = inxi mobShrI $= inxi shrResI $/ sy fs $= shrResEqn $/ sy fs

--- a/code/drasil-lang/lib/Language/Drasil.hs
+++ b/code/drasil-lang/lib/Language/Drasil.hs
@@ -98,7 +98,7 @@ module Language.Drasil (
   -- Language.Drasil.Chunk.Concept
   , dcc, dccWDS, cc, cc', ccs, cw, cic
   -- Language.Drasil.Chunk.Relation
-  , RelationConcept, makeRC, addRelToCC
+  , RelationConcept, makeRC
   -- Language.Drasil.Chunk.DifferentialModel
   , DifferentialModel(..), ODESolverFormat(..), InitialValueProblem(..), ($^^),($**), ($++)
   , makeAODESolverFormat, makeAIVP, formEquations, makeASystemDE, makeASingleDE
@@ -359,7 +359,7 @@ import Language.Drasil.Chunk.Eq (QDefinition, fromEqn, fromEqn', fromEqnSt,
   mkFuncDef, mkFuncDef', mkFuncDefByQ)
 import Language.Drasil.Chunk.NamedIdea
 import Language.Drasil.Chunk.Quantity
-import Language.Drasil.Chunk.Relation(RelationConcept, makeRC, addRelToCC)
+import Language.Drasil.Chunk.Relation(RelationConcept, makeRC)
 import Language.Drasil.Chunk.DifferentialModel(DifferentialModel(..), ODESolverFormat(..),
   InitialValueProblem(..), ($^^), ($**), ($++), makeAODESolverFormat, makeAIVP, makeASystemDE, 
   makeASingleDE, formEquations)

--- a/code/drasil-lang/lib/Language/Drasil/Chunk/Relation.hs
+++ b/code/drasil-lang/lib/Language/Drasil/Chunk/Relation.hs
@@ -4,17 +4,17 @@ module Language.Drasil.Chunk.Relation (
   -- * Chunk Type
   RelationConcept,
   -- * Constructors
-  makeRC, addRelToCC) where
+  makeRC) where
 
-import Control.Lens (makeLenses, (^.), view, set)
+import Control.Lens (makeLenses, (^.), view)
 
-import Language.Drasil.Chunk.Concept (ConceptChunk, dccWDS, cw)
-import Language.Drasil.Classes (Express(..), Concept,
+import Language.Drasil.Chunk.Concept (ConceptChunk, dccWDS)
+import Language.Drasil.Classes (Express(..),
   ConceptDomain(..), Definition(..), Idea(..), NamedIdea(..))
 import Language.Drasil.ModelExpr.Lang (ModelExpr)
 import Language.Drasil.NounPhrase.Core (NP)
 import Language.Drasil.Sentence (Sentence)
-import Language.Drasil.UID (HasUID(..), mkUid)
+import Language.Drasil.UID (HasUID(..))
 
 -- | For a concept ('ConceptChunk') that also has a 'Relation' ('ModelExpr') attached.
 --
@@ -43,7 +43,3 @@ instance Express       RelationConcept where express = (^. rel)
 makeRC :: Express e => String -> NP -> Sentence -> e -> RelationConcept
 makeRC rID rTerm rDefn = RC (dccWDS rID rTerm rDefn) . express
 
--- FIXME: Doesn't check UIDs. See TODOs in NamedIdea.hs
--- | Create a new 'RelationConcept' from an old 'Concept'. Takes a 'Concept', new 'UID' and relation.
-addRelToCC :: (Express e, Concept c) => c -> String -> e -> RelationConcept
-addRelToCC c rID = RC (set uid (mkUid rID) (cw c)) . express

--- a/code/drasil-lang/lib/Language/Drasil/UID.hs
+++ b/code/drasil-lang/lib/Language/Drasil/UID.hs
@@ -16,12 +16,12 @@ import Data.List (intercalate)
 import Data.Text (pack)
 import GHC.Generics
 
-import Control.Lens (Lens', makeLenses, (^.), view, over)
+import Control.Lens (Getter, makeLenses, (^.), view, over)
 
 -- | The most basic item: having a unique identifier key, here a UID.
 class HasUID c where
   -- | Provides a /unique/ id for internal Drasil use.
-  uid :: Lens' c UID
+  uid :: Getter c UID
 
 -- | A @UID@ is a 'unique identifier' for things that we will put into our database
 -- of information. We use a newtype wrapper to make sure we are only using

--- a/code/drasil-theory/lib/Theory/Drasil/DataDefinition.hs
+++ b/code/drasil-theory/lib/Theory/Drasil/DataDefinition.hs
@@ -66,7 +66,7 @@ ddPkt lpkt = lens g s
     s (DDME qd pkt) a' = DDME qd (pkt & lpkt .~ a')
 
 -- | Finds the 'UID' of a 'DataDefinition where'.
-instance HasUID             DataDefinition where uid = ddQD uid uid
+instance HasUID             DataDefinition where uid = ddQDGetter uid uid
 -- | Finds the term ('NP') of the 'QDefinition' used to make the 'DataDefinition where'.
 instance NamedIdea          DataDefinition where term = ddQD term term
 -- | Finds the idea contained in the 'QDefinition' used to make the 'DataDefinition where'.

--- a/code/drasil-theory/lib/Theory/Drasil/ModelKinds.hs
+++ b/code/drasil-theory/lib/Theory/Drasil/ModelKinds.hs
@@ -10,7 +10,7 @@ module Theory.Drasil.ModelKinds (
   newDEModel', deModel', equationalConstraints', equationalModel', equationalRealm', othModel',
   equationalModelU, equationalModelN, equationalRealmU, equationalRealmN,
   -- * Lenses
-  setMk, elimMk, lensMk,
+  setMk, elimMk, lensMk, getterMk,
   -- * Functions
   getEqModQds
   ) where
@@ -123,7 +123,7 @@ othModel' :: RelationConcept -> ModelKind e
 othModel' rc = MK (OthModel rc) (modelNs $ rc ^. uid) (rc ^. term)
 
 -- | Finds the 'UID' of the 'ModelKinds'.
-instance HasUID        (ModelKinds e) where uid     = lensMk uid uid uid uid uid
+instance HasUID        (ModelKinds e) where uid     = getterMk uid uid uid uid uid
 -- | Finds the term ('NP') of the 'ModelKinds'.
 instance NamedIdea     (ModelKinds e) where term    = lensMk term term term term term
 -- | Finds the idea of the 'ModelKinds'.
@@ -201,6 +201,17 @@ lensMk ld lr lcs lq lmd = lens g s
           g = elimMk ld lr lcs lq lmd
           s :: ModelKinds e -> a -> ModelKinds e
           s mk_ = setMk mk_ ld lr lcs lq lmd
+
+-- | Make a 'Getter' for 'ModelKinds'.
+getterMk :: forall e a.
+     Getter DifferentialModel a
+  -> Getter RelationConcept a 
+  -> Getter (ConstraintSet e) a 
+  -> Getter (QDefinition e) a 
+  -> Getter (MultiDefn e) a
+  -> Getter (ModelKinds e) a
+getterMk gd gr gcs gq gmd = to $ \modelKinds ->
+    elimMk gd gr gcs gq gmd modelKinds
 
 -- | Extract a list of 'QDefinition's from a list of 'ModelKinds'.
 getEqModQds :: [ModelKind e] -> [QDefinition e]


### PR DESCRIPTION
As discussed in https://github.com/JacquesCarette/Drasil/issues/3524 , the `uid` field was previously implemented as a `Lens`, which allowed for modification. However, after switching `uid` to a `Getter`, the `uid` field became read-only, which affected functions that relied on setting the `uid` value, such as `addRelToCC`.

### Key Changes:
- Removed `addRelToCC` Function: The `addRelToCC` function, which previously allowed modification of the `uid` field using the `set` function, has been removed due to its incompatibility with the read-only `Getter` implementation.

- Direct RelationConcept Creation: Modified the `mobShr` definition to create RelationConcept directly with appropriate properties using functions like `makeRC` instead of relying on the removed `addRelToCC` function.