### PR TITLE
Modified the `codegenTest` target to check `diff` with `stable`

### DIFF
--- a/code/Makefile
+++ b/code/Makefile
@@ -308,9 +308,14 @@ $(filter %$(GEN_E_SUFFIX), $(GEN_EXAMPLES)): %$(GEN_E_SUFFIX):
 
 # Compiles GOOL examples to concrete code (Java, C++, etc.)
 $(GOOLTEST)$(GEN_E_SUFFIX):
+	- rm -rf "$(BUILD_FOLDER)$(GOOLTEST_DIR)"
+	make $(CLEAN_GF_PREFIX)$(LOG_FOLDER_NAME)
 	stack build $(stackArgs) "drasil-code:exe:$(GOOLTEST_EXE)"
 	@mkdir -p "$(BUILD_FOLDER)$(GOOLTEST_DIR)"
 	cd "$(BUILD_FOLDER)$(GOOLTEST_DIR)" && $(STACK_EXEC) -- "$(GOOLTEST_EXE)"
+	@mkdir -p "$(LOG_FOLDER)"
+	- $(DIFF) "$(STABLE_FOLDER)$(GOOLTEST_DIR)/" "$(BUILD_FOLDER)$(GOOLTEST_DIR)/" > "$(LOG_FOLDER)$(GOOLTEST_DIR)$(LOG_SUFFIX)"
+	@LOG_FOLDER="$(LOG_FOLDER)" LOG_SUFFIX="$(LOG_SUFFIX)" NOISY=$(NOISY) "$(SHELL)" "$(SCRIPT_FOLDER)log_check.sh"
 
 # Install individual Drasil examples
 $(filter %$(INSTALL_E_SUFFIX), $(INSTALL_EXAMPLES)): %$(INSTALL_E_SUFFIX):


### PR DESCRIPTION
This ensures that the generated code for GOOL tests matches that in `stable/gooltest`.  `codegenTest` is already in our CI from the looks of it, so this should prevent the cases we've had where `build/gooltest` doesn't match `stable/gooltest`.

Next steps:
- We should add `codegenTest_gen` to `make pr_ready`.
  - We probably don't want to add `codegenTest` to `make pr_ready`, as it requires that the local machine has the compilers installed for all compiled targets.
- We still don't have an automatic way of stabilize the `build/gooltest` folder.  We need to add a `make codegenTest_stabilize` option.

Closes #3678 
Contributes to #3387 