### PR TITLE
Resize long expressions in LaTeX to prevent overflow

### DIFF
--- a/code/drasil-printers/lib/Language/Drasil/TeX/Helpers.hs
+++ b/code/drasil-printers/lib/Language/Drasil/TeX/Helpers.hs
@@ -1,7 +1,7 @@
 -- | Defines helper functions used in printing LaTeX documents.
 module Language.Drasil.TeX.Helpers where
 
-import Text.PrettyPrint (text)
+import Text.PrettyPrint (text, double)
 import qualified Text.PrettyPrint as TP
 
 import Language.Drasil (MaxWidthPercent)
@@ -276,8 +276,10 @@ useTikz = usepackage "luatex85" $+$ command0 "def" <>
 -- on Monad...
 
 -- | toEqn is special; it switches to 'Math', but inserts an equation environment.
-toEqn :: D -> D
-toEqn (PL g) = equation $ PL (\_ -> g Math)
+-- The 'scale' parameter determines the maximum width of the equation, 
+-- calculated as scale * page width.
+toEqn :: Double -> D -> D
+toEqn scale (PL g) = equation $ command2D "resizeExpression" (PL (\_ -> g Math)) (pure (double scale))
 
 -----------------------------------------------------------------------------
 -- | Helper(s) for String-Printing in TeX where it varies from HTML/Plaintext.

--- a/code/drasil-printers/lib/Language/Drasil/TeX/Helpers.hs
+++ b/code/drasil-printers/lib/Language/Drasil/TeX/Helpers.hs
@@ -1,7 +1,7 @@
 -- | Defines helper functions used in printing LaTeX documents.
 module Language.Drasil.TeX.Helpers where
 
-import Text.PrettyPrint (text, double)
+import Text.PrettyPrint (text)
 import qualified Text.PrettyPrint as TP
 
 import Language.Drasil (MaxWidthPercent)
@@ -279,10 +279,21 @@ useTikz = usepackage "luatex85" $+$ command0 "def" <>
 -- on Monad...
 
 -- | toEqn is special; it switches to 'Math', but inserts an equation environment.
--- The 'scale' parameter determines the maximum width of the equation, 
--- calculated as scale * page width.
-toEqn :: Double -> D -> D
-toEqn scale (PL g) = equation $ command2D "resizeExpression" (PL (\_ -> g Math)) (pure (double scale))
+-- The 'scale' parameter determines the maximum width of the equation based on
+-- the corresponding scaling command.
+toEqn :: ExprScale -> D -> D
+toEqn scale (PL g) = equation $ command2D "resizeExpression" (PL (\_ -> g Math)) (command0 (show scale))
+
+-- | Represents the scaling factor for an equation.
+-- 'InDef' and 'OutDef' correspond to predefined scaling commands.
+-- Commands are defined in 'Preamble.hs'
+data ExprScale = InDef | OutDef
+
+-- | Provides a string representation for 'ExprScale' values.
+-- Used to convert 'ExprScale' to the corresponding command string.
+instance Show ExprScale where
+  show InDef  = "inDefScale"
+  show OutDef = "outDefScale"
 
 -----------------------------------------------------------------------------
 -- | Helper(s) for String-Printing in TeX where it varies from HTML/Plaintext.

--- a/code/drasil-printers/lib/Language/Drasil/TeX/Helpers.hs
+++ b/code/drasil-printers/lib/Language/Drasil/TeX/Helpers.hs
@@ -25,10 +25,7 @@ import Data.List (isSuffixOf)
 -- | Helper for adding fencing symbols.
 br, sq, parens, quote :: D -> D
 -- | Curly braces.
-br x = lb <> x <> rb
-  where
-  lb = pure $ text "{"
-  rb = pure $ text "}"
+br x = lbrace <> x <> rbrace
 -- | Square brackets.
 sq x = ls <> x <> rs
   where
@@ -44,6 +41,12 @@ quote x = lq <> x <> rq
   where
   lq = pure $ text "``"
   rq = pure $ text "''"
+
+lbrace, rbrace :: D
+-- | Helper for opening curly brace.
+lbrace = pure $ text "{"
+-- | Helper for closing curly brace.
+rbrace = pure $ text "}"
 
 -- | 0-argument command.
 command0 :: String -> D

--- a/code/drasil-printers/lib/Language/Drasil/TeX/Monad.hs
+++ b/code/drasil-printers/lib/Language/Drasil/TeX/Monad.hs
@@ -109,6 +109,10 @@ vpunctuate x = tpRunPrint (TP.vcat . TP.punctuate x)
 -- Combine 'TP.hcat' and 'TP.punctuate'.
 hpunctuate :: TP.Doc -> [D] -> D
 hpunctuate x = tpRunPrint (TP.hcat . TP.punctuate x)
+
+-- | Nest a 'D' by a specified indentation level.
+nest :: Int -> D -> D
+nest i (PL f) = PL $ \ctx -> TP.nest i (f ctx)
 --------
 -- | MathContext operations.
 lub :: MathContext -> MathContext -> MathContext

--- a/code/drasil-printers/lib/Language/Drasil/TeX/Preamble.hs
+++ b/code/drasil-printers/lib/Language/Drasil/TeX/Preamble.hs
@@ -7,7 +7,7 @@ import Text.PrettyPrint (text)
 import Language.Drasil.Printing.LayoutObj (LayoutObj(..))
 import Language.Drasil.TeX.Monad (D, vcat, (%%))
 import Language.Drasil.TeX.Helpers (docclass, command, command1o, command2, command3,
-  usepackage, command0)
+  usepackage, command0, lbrace, rbrace)
 import Language.Drasil.Printing.Helpers (sq, brace)
 
 import Language.Drasil.Config (hyperSettings, fontSize, bibFname)
@@ -94,14 +94,14 @@ addDef SymbDescriptionP1 = command3 "newlist" "symbDescription" "description" "1
 addDef SymbDescriptionP2 = command1o "setlist" (Just "symbDescription") "noitemsep, topsep=0pt, parsep=0pt, partopsep=0pt"
 addDef SaveBox       = command "newsavebox" "\\mybox"
 addDef ResizeExpr    = vcat [
-    command "newcommand" "\\resizeExpression" <> pure (sq "2") <> pure (text "{"),
+    command "newcommand" "\\resizeExpression" <> pure (sq "2") <> lbrace,
     command2 "savebox" "\\mybox" "$#1$",
     command0 "ifdim" <> command0 "wd" <> command0 "mybox" <> pure (text ">#2") <> command0 "linewidth",
     command3 "resizebox" "#2\\textwidth" "!" ("\\usebox" ++ brace "\\mybox"),
     command0 "else",
     command "usebox" "\\mybox",
     command0 "fi",
-    pure (text "}")
+    rbrace
   ]
 
 -- | Generates LaTeX document preamble.

--- a/code/drasil-printers/lib/Language/Drasil/TeX/Preamble.hs
+++ b/code/drasil-printers/lib/Language/Drasil/TeX/Preamble.hs
@@ -7,7 +7,7 @@ import Text.PrettyPrint (text)
 import Language.Drasil.Printing.LayoutObj (LayoutObj(..))
 import Language.Drasil.TeX.Monad (D, vcat, (%%), nest)
 import Language.Drasil.TeX.Helpers (docclass, command, command1o, command2, command3,
-  usepackage, command0, lbrace, rbrace)
+  usepackage, command0, lbrace, rbrace, ExprScale(InDef, OutDef))
 import Language.Drasil.Printing.Helpers (sq, brace)
 
 import Language.Drasil.Config (hyperSettings, fontSize, bibFname)
@@ -81,6 +81,8 @@ data Def = Bibliography
          | SymbDescriptionP1
          | SymbDescriptionP2
          | SaveBox
+         | InDefScale
+         | OutDefScale
          | ResizeExpr
          deriving Eq
 
@@ -93,6 +95,8 @@ addDef SetMathFont   = command "setmathfont" "Latin Modern Math"
 addDef SymbDescriptionP1 = command3 "newlist" "symbDescription" "description" "1"
 addDef SymbDescriptionP2 = command1o "setlist" (Just "symbDescription") "noitemsep, topsep=0pt, parsep=0pt, partopsep=0pt"
 addDef SaveBox       = command "newsavebox" "\\mybox"
+addDef InDefScale    = command0 "def" <> command (show InDef)  "0.8"
+addDef OutDefScale   = command0 "def" <> command (show OutDef) "1.0"
 addDef ResizeExpr = vcat [
     command "newcommand" "\\resizeExpression" <> pure (sq "2") <> lbrace,
     nest 2 $ vcat [
@@ -138,6 +142,6 @@ parseDoc los' =
     parseDoc' Header{}     = ([], [])
     parseDoc' Paragraph{}  = ([], [])
     parseDoc' List{}       = ([EnumItem], [])
-    parseDoc' EqnBlock{}   = ([Graphicx, Calc], [SaveBox, ResizeExpr])
+    parseDoc' EqnBlock{}   = ([Graphicx, Calc], [InDefScale, OutDefScale, SaveBox, ResizeExpr])
     parseDoc' Cell{}       = ([], [])
     parseDoc' CodeBlock{}  = ([], [])

--- a/code/drasil-printers/lib/Language/Drasil/TeX/Preamble.hs
+++ b/code/drasil-printers/lib/Language/Drasil/TeX/Preamble.hs
@@ -5,7 +5,7 @@ import Data.List (nub)
 
 import Text.PrettyPrint (text)
 import Language.Drasil.Printing.LayoutObj (LayoutObj(..))
-import Language.Drasil.TeX.Monad (D, vcat, (%%))
+import Language.Drasil.TeX.Monad (D, vcat, (%%), nest)
 import Language.Drasil.TeX.Helpers (docclass, command, command1o, command2, command3,
   usepackage, command0, lbrace, rbrace)
 import Language.Drasil.Printing.Helpers (sq, brace)
@@ -93,14 +93,16 @@ addDef SetMathFont   = command "setmathfont" "Latin Modern Math"
 addDef SymbDescriptionP1 = command3 "newlist" "symbDescription" "description" "1"
 addDef SymbDescriptionP2 = command1o "setlist" (Just "symbDescription") "noitemsep, topsep=0pt, parsep=0pt, partopsep=0pt"
 addDef SaveBox       = command "newsavebox" "\\mybox"
-addDef ResizeExpr    = vcat [
+addDef ResizeExpr = vcat [
     command "newcommand" "\\resizeExpression" <> pure (sq "2") <> lbrace,
-    command2 "savebox" "\\mybox" "$#1$",
-    command0 "ifdim" <> command0 "wd" <> command0 "mybox" <> pure (text ">#2") <> command0 "linewidth",
-    command3 "resizebox" "#2\\textwidth" "!" ("\\usebox" ++ brace "\\mybox"),
-    command0 "else",
-    command "usebox" "\\mybox",
-    command0 "fi",
+    nest 2 $ vcat [
+        command2 "savebox" "\\mybox" "$#1$",
+        command0 "ifdim" <> command0 "wd" <> command0 "mybox" <> pure (text ">#2") <> command0 "linewidth",
+        nest 2 $ command3 "resizebox" "#2\\textwidth" "!" ("\\usebox" ++ brace "\\mybox"),
+        command0 "else",
+        nest 2 $ command "usebox" "\\mybox",
+        command0 "fi"
+      ],
     rbrace
   ]
 

--- a/code/drasil-printers/lib/Language/Drasil/TeX/Print.hs
+++ b/code/drasil-printers/lib/Language/Drasil/TeX/Print.hs
@@ -79,9 +79,9 @@ lo (CodeBlock _) _          = empty
 -- | Helper for converting layout objects into a more printable form.
 -- This function is specific to definitions.
 lo' :: LayoutObj -> PrintingInformation -> D
-lo' (HDiv _ con _)      sm = print' sm con
+lo' (HDiv _ con _)      sm = printDef sm con
 lo' (EqnBlock contents) _  = makeEquation contents 0.8
-lo' obj sm                 = lo obj sm
+lo' obj                 sm = lo obj sm
 
 -- | Converts layout objects into a document form.
 print :: PrintingInformation -> [LayoutObj] -> D
@@ -89,8 +89,8 @@ print sm = foldr (($+$) . (`lo` sm)) empty
 
 -- | Converts layout objects into a document form.
 -- Specific to Definitions.
-print' :: PrintingInformation -> [LayoutObj] -> D
-print' sm = foldr (($+$) . (`lo'` sm)) empty
+printDef :: PrintingInformation -> [LayoutObj] -> D
+printDef sm = foldr (($+$) . (`lo'` sm)) empty
 
 -- | Determine wether braces and brackets are opening or closing.
 data OpenClose = Open | Close
@@ -358,8 +358,9 @@ makeDefTable sm ps l = mkEnvArgBr "tabular" (col rr colAwidth ++ col (rr ++ "\\a
 -- | Helper that makes the rows of a definition table.
 makeDRows :: PrintingInformation -> [(String,[LayoutObj])] -> D
 makeDRows _  []      = error "No fields to create Defn table"
-makeDRows sm ls      = foldl1 (%%) $ map (\(f, d) -> dBoilerplate %%  pure (text (f ++ " & ")) <> print' sm d) ls
-  where dBoilerplate = pure $ dbs <+> text "\\midrule"
+makeDRows sm ls      = foldl1 (%%) $ map (\(f, d) -> 
+  pure (dbs <+> text "\\midrule") %% 
+  pure (text (f ++ " & ")) <> printDef sm d) ls
 
 -----------------------------------------------------------------
 ------------------ EQUATION PRINTING------------------------

--- a/code/drasil-printers/lib/Language/Drasil/TeX/Print.hs
+++ b/code/drasil-printers/lib/Language/Drasil/TeX/Print.hs
@@ -33,7 +33,7 @@ import Language.Drasil.TeX.Helpers (author, bold, br, caption, center, centering
   empty, enumerate, externalref, figure, fraction, includegraphics, item, item',
   itemize, label, maketitle, maketoc, mathbb, mkEnv, mkEnvArgBr, mkEnvArgSq,
   mkMinipage, newline, newpage, parens, quote, sec, snref, sq, superscript,
-  symbDescription, texSym, title, toEqn)
+  symbDescription, texSym, title, toEqn, ExprScale(InDef, OutDef))
 import Language.Drasil.TeX.Monad (D, MathContext(Curr, Math, Text), (%%), ($+$),
   hpunctuate, lub, runPrint, switch, toMath, toText, unPL, vcat, vpunctuate)
 import Language.Drasil.TeX.Preamble (genPreamble)
@@ -62,7 +62,7 @@ lo :: LayoutObj -> PrintingInformation -> D
 lo (Header d t l)         _ = sec d (spec t) %% label (spec l)
 lo (HDiv _ con _)        sm = print sm con -- FIXME ignoring 2 arguments?
 lo (Paragraph contents)   _ = toText $ newline (spec contents)
-lo (EqnBlock contents)    _ = makeEquation contents 1
+lo (EqnBlock contents)    _ = makeEquation contents OutDef
 lo (Table _ rows r bl t)  _ = toText $ makeTable rows (spec r) bl (spec t)
 lo (Definition _ ssPs l) sm = toText $ makeDefn sm ssPs $ spec l
 lo (List l)               _ = toText $ makeList l
@@ -80,7 +80,7 @@ lo (CodeBlock _) _          = empty
 -- This function is specific to definitions.
 lo' :: LayoutObj -> PrintingInformation -> D
 lo' (HDiv _ con _)      sm = printDef sm con
-lo' (EqnBlock contents) _  = makeEquation contents 0.8
+lo' (EqnBlock contents) _  = makeEquation contents InDef
 lo' obj                 sm = lo obj sm
 
 -- | Converts layout objects into a document form.
@@ -366,8 +366,8 @@ makeDRows sm ls      = foldl1 (%%) $ map (\(f, d) ->
 ------------------ EQUATION PRINTING------------------------
 -----------------------------------------------------------------
 
--- | Prints an equation with a max width of scale * page width.
-makeEquation :: Spec -> Double -> D
+-- | Prints an equation with a maximum width determined by the given scale.
+makeEquation :: Spec -> ExprScale -> D
 makeEquation contents scale = toEqn scale (spec contents)
 
   --TODO: Add auto-generated labels -> Need to be able to ensure labeling based

--- a/code/stable/dblpend/SRS/PDF/DblPend_SRS.tex
+++ b/code/stable/dblpend/SRS/PDF/DblPend_SRS.tex
@@ -25,6 +25,8 @@
 \newcommand{\lt}{\ensuremath <}
 \newlist{symbDescription}{description}{1}
 \setlist[symbDescription]{noitemsep, topsep=0pt, parsep=0pt, partopsep=0pt}
+\def\inDefScale{0.8}
+\def\outDefScale{1.0}
 \newsavebox{\mybox}
 \newcommand{\resizeExpression}[2]{
   \savebox{\mybox}{$#1$}
@@ -322,7 +324,7 @@ Label & Acceleration
         
 \\ \midrule
 Equation & \begin{displaymath}
-           \resizeExpression{\symbf{a}\text{(}t\text{)}=\frac{\,d\symbf{v}\text{(}t\text{)}}{\,dt}}{0.8}
+           \resizeExpression{\symbf{a}\text{(}t\text{)}=\frac{\,d\symbf{v}\text{(}t\text{)}}{\,dt}}{\inDefScale}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -351,7 +353,7 @@ Label & Velocity
         
 \\ \midrule
 Equation & \begin{displaymath}
-           \resizeExpression{\symbf{v}\text{(}t\text{)}=\frac{\,d\symbf{p}\text{(}t\text{)}}{\,dt}}{0.8}
+           \resizeExpression{\symbf{v}\text{(}t\text{)}=\frac{\,d\symbf{p}\text{(}t\text{)}}{\,dt}}{\inDefScale}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -380,7 +382,7 @@ Label & Newton's second law of motion
         
 \\ \midrule
 Equation & \begin{displaymath}
-           \resizeExpression{\symbf{F}=m\,\symbf{a}\text{(}t\text{)}}{0.8}
+           \resizeExpression{\symbf{F}=m\,\symbf{a}\text{(}t\text{)}}{\inDefScale}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -419,7 +421,7 @@ Units & $\frac{\text{m}}{\text{s}}$
         
 \\ \midrule
 Equation & \begin{displaymath}
-           \resizeExpression{{v_{\text{x}1}}={w_{1}}\,{L_{1}}\,\cos\left({θ_{1}}\right)}{0.8}
+           \resizeExpression{{v_{\text{x}1}}={w_{1}}\,{L_{1}}\,\cos\left({θ_{1}}\right)}{\inDefScale}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -442,27 +444,27 @@ RefBy &
 At a given point in time, velocity is defined in \hyperref[DD:positionGDD]{DD:positionGDD}
 
 \begin{displaymath}
-\resizeExpression{\symbf{v}\text{(}t\text{)}=\frac{\,d\symbf{p}\text{(}t\text{)}}{\,dt}}{1.0}
+\resizeExpression{\symbf{v}\text{(}t\text{)}=\frac{\,d\symbf{p}\text{(}t\text{)}}{\,dt}}{\outDefScale}
 \end{displaymath}
 We also know the horizontal position that is defined in \hyperref[DD:positionXDD1]{DD:positionXDD1}
 
 \begin{displaymath}
-\resizeExpression{{p_{\text{x}1}}={L_{1}}\,\sin\left({θ_{1}}\right)}{1.0}
+\resizeExpression{{p_{\text{x}1}}={L_{1}}\,\sin\left({θ_{1}}\right)}{\outDefScale}
 \end{displaymath}
 Applying this,
 
 \begin{displaymath}
-\resizeExpression{{v_{\text{x}1}}=\frac{\,d{L_{1}}\,\sin\left({θ_{1}}\right)}{\,dt}}{1.0}
+\resizeExpression{{v_{\text{x}1}}=\frac{\,d{L_{1}}\,\sin\left({θ_{1}}\right)}{\,dt}}{\outDefScale}
 \end{displaymath}
 ${L_{1}}$ is constant with respect to time, so
 
 \begin{displaymath}
-\resizeExpression{{v_{\text{x}1}}={L_{1}}\,\frac{\,d\sin\left({θ_{1}}\right)}{\,dt}}{1.0}
+\resizeExpression{{v_{\text{x}1}}={L_{1}}\,\frac{\,d\sin\left({θ_{1}}\right)}{\,dt}}{\outDefScale}
 \end{displaymath}
 Therefore, using the chain rule,
 
 \begin{displaymath}
-\resizeExpression{{v_{\text{x}1}}={w_{1}}\,{L_{1}}\,\cos\left({θ_{1}}\right)}{1.0}
+\resizeExpression{{v_{\text{x}1}}={w_{1}}\,{L_{1}}\,\cos\left({θ_{1}}\right)}{\outDefScale}
 \end{displaymath}
 \medskip
 \noindent
@@ -479,7 +481,7 @@ Units & $\frac{\text{m}}{\text{s}}$
         
 \\ \midrule
 Equation & \begin{displaymath}
-           \resizeExpression{{v_{\text{y}1}}={w_{1}}\,{L_{1}}\,\sin\left({θ_{1}}\right)}{0.8}
+           \resizeExpression{{v_{\text{y}1}}={w_{1}}\,{L_{1}}\,\sin\left({θ_{1}}\right)}{\inDefScale}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -502,27 +504,27 @@ RefBy &
 At a given point in time, velocity is defined in \hyperref[DD:positionGDD]{DD:positionGDD}
 
 \begin{displaymath}
-\resizeExpression{\symbf{v}\text{(}t\text{)}=\frac{\,d\symbf{p}\text{(}t\text{)}}{\,dt}}{1.0}
+\resizeExpression{\symbf{v}\text{(}t\text{)}=\frac{\,d\symbf{p}\text{(}t\text{)}}{\,dt}}{\outDefScale}
 \end{displaymath}
 We also know the vertical position that is defined in \hyperref[DD:positionYDD1]{DD:positionYDD1}
 
 \begin{displaymath}
-\resizeExpression{{p_{\text{y}1}}=-{L_{1}}\,\cos\left({θ_{1}}\right)}{1.0}
+\resizeExpression{{p_{\text{y}1}}=-{L_{1}}\,\cos\left({θ_{1}}\right)}{\outDefScale}
 \end{displaymath}
 Applying this,
 
 \begin{displaymath}
-\resizeExpression{{v_{\text{y}1}}=-\left(\frac{\,d{L_{1}}\,\cos\left({θ_{1}}\right)}{\,dt}\right)}{1.0}
+\resizeExpression{{v_{\text{y}1}}=-\left(\frac{\,d{L_{1}}\,\cos\left({θ_{1}}\right)}{\,dt}\right)}{\outDefScale}
 \end{displaymath}
 ${L_{1}}$ is constant with respect to time, so
 
 \begin{displaymath}
-\resizeExpression{{v_{\text{y}1}}=-{L_{1}}\,\frac{\,d\cos\left({θ_{1}}\right)}{\,dt}}{1.0}
+\resizeExpression{{v_{\text{y}1}}=-{L_{1}}\,\frac{\,d\cos\left({θ_{1}}\right)}{\,dt}}{\outDefScale}
 \end{displaymath}
 Therefore, using the chain rule,
 
 \begin{displaymath}
-\resizeExpression{{v_{\text{y}1}}={w_{1}}\,{L_{1}}\,\sin\left({θ_{1}}\right)}{1.0}
+\resizeExpression{{v_{\text{y}1}}={w_{1}}\,{L_{1}}\,\sin\left({θ_{1}}\right)}{\outDefScale}
 \end{displaymath}
 \medskip
 \noindent
@@ -539,7 +541,7 @@ Units & $\frac{\text{m}}{\text{s}}$
         
 \\ \midrule
 Equation & \begin{displaymath}
-           \resizeExpression{{v_{\text{x}2}}={v_{\text{x}1}}+{w_{2}}\,{L_{2}}\,\cos\left({θ_{2}}\right)}{0.8}
+           \resizeExpression{{v_{\text{x}2}}={v_{\text{x}1}}+{w_{2}}\,{L_{2}}\,\cos\left({θ_{2}}\right)}{\inDefScale}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -563,22 +565,22 @@ RefBy &
 At a given point in time, velocity is defined in \hyperref[DD:positionGDD]{DD:positionGDD}
 
 \begin{displaymath}
-\resizeExpression{\symbf{v}\text{(}t\text{)}=\frac{\,d\symbf{p}\text{(}t\text{)}}{\,dt}}{1.0}
+\resizeExpression{\symbf{v}\text{(}t\text{)}=\frac{\,d\symbf{p}\text{(}t\text{)}}{\,dt}}{\outDefScale}
 \end{displaymath}
 We also know the horizontal position that is defined in \hyperref[DD:positionXDD2]{DD:positionXDD2}
 
 \begin{displaymath}
-\resizeExpression{{p_{\text{x}2}}={p_{\text{x}1}}+{L_{2}}\,\sin\left({θ_{2}}\right)}{1.0}
+\resizeExpression{{p_{\text{x}2}}={p_{\text{x}1}}+{L_{2}}\,\sin\left({θ_{2}}\right)}{\outDefScale}
 \end{displaymath}
 Applying this,
 
 \begin{displaymath}
-\resizeExpression{{v_{\text{x}2}}=\frac{\,d{p_{\text{x}1}}+{L_{2}}\,\sin\left({θ_{2}}\right)}{\,dt}}{1.0}
+\resizeExpression{{v_{\text{x}2}}=\frac{\,d{p_{\text{x}1}}+{L_{2}}\,\sin\left({θ_{2}}\right)}{\,dt}}{\outDefScale}
 \end{displaymath}
 ${L_{1}}$ is constant with respect to time, so
 
 \begin{displaymath}
-\resizeExpression{{v_{\text{x}2}}={v_{\text{x}1}}+{w_{2}}\,{L_{2}}\,\cos\left({θ_{2}}\right)}{1.0}
+\resizeExpression{{v_{\text{x}2}}={v_{\text{x}1}}+{w_{2}}\,{L_{2}}\,\cos\left({θ_{2}}\right)}{\outDefScale}
 \end{displaymath}
 \medskip
 \noindent
@@ -595,7 +597,7 @@ Units & $\frac{\text{m}}{\text{s}}$
         
 \\ \midrule
 Equation & \begin{displaymath}
-           \resizeExpression{{v_{\text{y}2}}={v_{\text{y}1}}+{w_{2}}\,{L_{2}}\,\sin\left({θ_{2}}\right)}{0.8}
+           \resizeExpression{{v_{\text{y}2}}={v_{\text{y}1}}+{w_{2}}\,{L_{2}}\,\sin\left({θ_{2}}\right)}{\inDefScale}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -619,22 +621,22 @@ RefBy &
 At a given point in time, velocity is defined in \hyperref[DD:positionGDD]{DD:positionGDD}
 
 \begin{displaymath}
-\resizeExpression{\symbf{v}\text{(}t\text{)}=\frac{\,d\symbf{p}\text{(}t\text{)}}{\,dt}}{1.0}
+\resizeExpression{\symbf{v}\text{(}t\text{)}=\frac{\,d\symbf{p}\text{(}t\text{)}}{\,dt}}{\outDefScale}
 \end{displaymath}
 We also know the vertical position that is defined in \hyperref[DD:positionYDD2]{DD:positionYDD2}
 
 \begin{displaymath}
-\resizeExpression{{p_{\text{y}2}}={p_{\text{y}1}}-{L_{2}}\,\cos\left({θ_{2}}\right)}{1.0}
+\resizeExpression{{p_{\text{y}2}}={p_{\text{y}1}}-{L_{2}}\,\cos\left({θ_{2}}\right)}{\outDefScale}
 \end{displaymath}
 Applying this,
 
 \begin{displaymath}
-\resizeExpression{{v_{\text{y}2}}=-\left(\frac{\,d{p_{\text{y}1}}-{L_{2}}\,\cos\left({θ_{2}}\right)}{\,dt}\right)}{1.0}
+\resizeExpression{{v_{\text{y}2}}=-\left(\frac{\,d{p_{\text{y}1}}-{L_{2}}\,\cos\left({θ_{2}}\right)}{\,dt}\right)}{\outDefScale}
 \end{displaymath}
 Therefore, using the chain rule,
 
 \begin{displaymath}
-\resizeExpression{{v_{\text{y}2}}={v_{\text{y}1}}+{w_{2}}\,{L_{2}}\,\sin\left({θ_{2}}\right)}{1.0}
+\resizeExpression{{v_{\text{y}2}}={v_{\text{y}1}}+{w_{2}}\,{L_{2}}\,\sin\left({θ_{2}}\right)}{\outDefScale}
 \end{displaymath}
 \medskip
 \noindent
@@ -651,7 +653,7 @@ Units & $\frac{\text{m}}{\text{s}^{2}}$
         
 \\ \midrule
 Equation & \begin{displaymath}
-           \resizeExpression{{a_{\text{x}1}}=-{w_{1}}^{2}\,{L_{1}}\,\sin\left({θ_{1}}\right)+{α_{1}}\,{L_{1}}\,\cos\left({θ_{1}}\right)}{0.8}
+           \resizeExpression{{a_{\text{x}1}}=-{w_{1}}^{2}\,{L_{1}}\,\sin\left({θ_{1}}\right)+{α_{1}}\,{L_{1}}\,\cos\left({θ_{1}}\right)}{\inDefScale}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -676,27 +678,27 @@ RefBy & \hyperref[IM:calOfAngle2]{IM:calOfAngle2}
 Our acceleration is:
 
 \begin{displaymath}
-\resizeExpression{\symbf{a}\text{(}t\text{)}=\frac{\,d\symbf{v}\text{(}t\text{)}}{\,dt}}{1.0}
+\resizeExpression{\symbf{a}\text{(}t\text{)}=\frac{\,d\symbf{v}\text{(}t\text{)}}{\,dt}}{\outDefScale}
 \end{displaymath}
 Earlier, we found the horizontal velocity to be
 
 \begin{displaymath}
-\resizeExpression{{v_{\text{x}1}}={w_{1}}\,{L_{1}}\,\cos\left({θ_{1}}\right)}{1.0}
+\resizeExpression{{v_{\text{x}1}}={w_{1}}\,{L_{1}}\,\cos\left({θ_{1}}\right)}{\outDefScale}
 \end{displaymath}
 Applying this to our equation for acceleration
 
 \begin{displaymath}
-\resizeExpression{{a_{\text{x}1}}=\frac{\,d{w_{1}}\,{L_{1}}\,\cos\left({θ_{1}}\right)}{\,dt}}{1.0}
+\resizeExpression{{a_{\text{x}1}}=\frac{\,d{w_{1}}\,{L_{1}}\,\cos\left({θ_{1}}\right)}{\,dt}}{\outDefScale}
 \end{displaymath}
 By the product and chain rules, we find
 
 \begin{displaymath}
-\resizeExpression{{a_{\text{x}1}}=\frac{\,d{w_{1}}}{\,dt}\,{L_{1}}\,\cos\left({θ_{1}}\right)-{w_{1}}\,{L_{1}}\,\sin\left({θ_{1}}\right)\,\frac{\,d{θ_{1}}}{\,dt}}{1.0}
+\resizeExpression{{a_{\text{x}1}}=\frac{\,d{w_{1}}}{\,dt}\,{L_{1}}\,\cos\left({θ_{1}}\right)-{w_{1}}\,{L_{1}}\,\sin\left({θ_{1}}\right)\,\frac{\,d{θ_{1}}}{\,dt}}{\outDefScale}
 \end{displaymath}
 Simplifying,
 
 \begin{displaymath}
-\resizeExpression{{a_{\text{x}1}}=-{w_{1}}^{2}\,{L_{1}}\,\sin\left({θ_{1}}\right)+{α_{1}}\,{L_{1}}\,\cos\left({θ_{1}}\right)}{1.0}
+\resizeExpression{{a_{\text{x}1}}=-{w_{1}}^{2}\,{L_{1}}\,\sin\left({θ_{1}}\right)+{α_{1}}\,{L_{1}}\,\cos\left({θ_{1}}\right)}{\outDefScale}
 \end{displaymath}
 \medskip
 \noindent
@@ -713,7 +715,7 @@ Units & $\frac{\text{m}}{\text{s}^{2}}$
         
 \\ \midrule
 Equation & \begin{displaymath}
-           \resizeExpression{{a_{\text{y}1}}={w_{1}}^{2}\,{L_{1}}\,\cos\left({θ_{1}}\right)+{α_{1}}\,{L_{1}}\,\sin\left({θ_{1}}\right)}{0.8}
+           \resizeExpression{{a_{\text{y}1}}={w_{1}}^{2}\,{L_{1}}\,\cos\left({θ_{1}}\right)+{α_{1}}\,{L_{1}}\,\sin\left({θ_{1}}\right)}{\inDefScale}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -738,27 +740,27 @@ RefBy & \hyperref[IM:calOfAngle2]{IM:calOfAngle2}
 Our acceleration is:
 
 \begin{displaymath}
-\resizeExpression{\symbf{a}\text{(}t\text{)}=\frac{\,d\symbf{v}\text{(}t\text{)}}{\,dt}}{1.0}
+\resizeExpression{\symbf{a}\text{(}t\text{)}=\frac{\,d\symbf{v}\text{(}t\text{)}}{\,dt}}{\outDefScale}
 \end{displaymath}
 Earlier, we found the vertical velocity to be
 
 \begin{displaymath}
-\resizeExpression{{v_{\text{y}1}}={w_{1}}\,{L_{1}}\,\sin\left({θ_{1}}\right)}{1.0}
+\resizeExpression{{v_{\text{y}1}}={w_{1}}\,{L_{1}}\,\sin\left({θ_{1}}\right)}{\outDefScale}
 \end{displaymath}
 Applying this to our equation for acceleration
 
 \begin{displaymath}
-\resizeExpression{{a_{\text{y}1}}=\frac{\,d{w_{1}}\,{L_{1}}\,\sin\left({θ_{1}}\right)}{\,dt}}{1.0}
+\resizeExpression{{a_{\text{y}1}}=\frac{\,d{w_{1}}\,{L_{1}}\,\sin\left({θ_{1}}\right)}{\,dt}}{\outDefScale}
 \end{displaymath}
 By the product and chain rules, we find
 
 \begin{displaymath}
-\resizeExpression{{a_{\text{y}1}}=\frac{\,d{w_{1}}}{\,dt}\,{L_{1}}\,\sin\left({θ_{1}}\right)+{w_{1}}\,{L_{1}}\,\cos\left({θ_{1}}\right)\,\frac{\,d{θ_{1}}}{\,dt}}{1.0}
+\resizeExpression{{a_{\text{y}1}}=\frac{\,d{w_{1}}}{\,dt}\,{L_{1}}\,\sin\left({θ_{1}}\right)+{w_{1}}\,{L_{1}}\,\cos\left({θ_{1}}\right)\,\frac{\,d{θ_{1}}}{\,dt}}{\outDefScale}
 \end{displaymath}
 Simplifying,
 
 \begin{displaymath}
-\resizeExpression{{a_{\text{y}1}}={w_{1}}^{2}\,{L_{1}}\,\cos\left({θ_{1}}\right)+{α_{1}}\,{L_{1}}\,\sin\left({θ_{1}}\right)}{1.0}
+\resizeExpression{{a_{\text{y}1}}={w_{1}}^{2}\,{L_{1}}\,\cos\left({θ_{1}}\right)+{α_{1}}\,{L_{1}}\,\sin\left({θ_{1}}\right)}{\outDefScale}
 \end{displaymath}
 \medskip
 \noindent
@@ -775,7 +777,7 @@ Units & $\frac{\text{m}}{\text{s}^{2}}$
         
 \\ \midrule
 Equation & \begin{displaymath}
-           \resizeExpression{{a_{\text{x}2}}={a_{\text{x}1}}-{w_{2}}^{2}\,{L_{2}}\,\sin\left({θ_{2}}\right)+{α_{2}}\,{L_{2}}\,\cos\left({θ_{2}}\right)}{0.8}
+           \resizeExpression{{a_{\text{x}2}}={a_{\text{x}1}}-{w_{2}}^{2}\,{L_{2}}\,\sin\left({θ_{2}}\right)+{α_{2}}\,{L_{2}}\,\cos\left({θ_{2}}\right)}{\inDefScale}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -801,22 +803,22 @@ RefBy & \hyperref[IM:calOfAngle2]{IM:calOfAngle2}
 Our acceleration is:
 
 \begin{displaymath}
-\resizeExpression{\symbf{a}\text{(}t\text{)}=\frac{\,d\symbf{v}\text{(}t\text{)}}{\,dt}}{1.0}
+\resizeExpression{\symbf{a}\text{(}t\text{)}=\frac{\,d\symbf{v}\text{(}t\text{)}}{\,dt}}{\outDefScale}
 \end{displaymath}
 Earlier, we found the horizontal velocity to be
 
 \begin{displaymath}
-\resizeExpression{{v_{\text{x}2}}={v_{\text{x}1}}+{w_{2}}\,{L_{2}}\,\cos\left({θ_{2}}\right)}{1.0}
+\resizeExpression{{v_{\text{x}2}}={v_{\text{x}1}}+{w_{2}}\,{L_{2}}\,\cos\left({θ_{2}}\right)}{\outDefScale}
 \end{displaymath}
 Applying this to our equation for acceleration
 
 \begin{displaymath}
-\resizeExpression{{a_{\text{x}2}}=\frac{\,d{v_{\text{x}1}}+{w_{2}}\,{L_{2}}\,\cos\left({θ_{2}}\right)}{\,dt}}{1.0}
+\resizeExpression{{a_{\text{x}2}}=\frac{\,d{v_{\text{x}1}}+{w_{2}}\,{L_{2}}\,\cos\left({θ_{2}}\right)}{\,dt}}{\outDefScale}
 \end{displaymath}
 By the product and chain rules, we find
 
 \begin{displaymath}
-\resizeExpression{{a_{\text{x}2}}={a_{\text{x}1}}-{w_{2}}^{2}\,{L_{2}}\,\sin\left({θ_{2}}\right)+{α_{2}}\,{L_{2}}\,\cos\left({θ_{2}}\right)}{1.0}
+\resizeExpression{{a_{\text{x}2}}={a_{\text{x}1}}-{w_{2}}^{2}\,{L_{2}}\,\sin\left({θ_{2}}\right)+{α_{2}}\,{L_{2}}\,\cos\left({θ_{2}}\right)}{\outDefScale}
 \end{displaymath}
 \medskip
 \noindent
@@ -833,7 +835,7 @@ Units & $\frac{\text{m}}{\text{s}^{2}}$
         
 \\ \midrule
 Equation & \begin{displaymath}
-           \resizeExpression{{a_{\text{y}2}}={a_{\text{y}1}}+{w_{2}}^{2}\,{L_{2}}\,\cos\left({θ_{2}}\right)+{α_{2}}\,{L_{2}}\,\sin\left({θ_{2}}\right)}{0.8}
+           \resizeExpression{{a_{\text{y}2}}={a_{\text{y}1}}+{w_{2}}^{2}\,{L_{2}}\,\cos\left({θ_{2}}\right)+{α_{2}}\,{L_{2}}\,\sin\left({θ_{2}}\right)}{\inDefScale}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -859,22 +861,22 @@ RefBy & \hyperref[IM:calOfAngle2]{IM:calOfAngle2}
 Our acceleration is:
 
 \begin{displaymath}
-\resizeExpression{\symbf{a}\text{(}t\text{)}=\frac{\,d\symbf{v}\text{(}t\text{)}}{\,dt}}{1.0}
+\resizeExpression{\symbf{a}\text{(}t\text{)}=\frac{\,d\symbf{v}\text{(}t\text{)}}{\,dt}}{\outDefScale}
 \end{displaymath}
 Earlier, we found the horizontal velocity to be
 
 \begin{displaymath}
-\resizeExpression{{v_{\text{y}2}}={v_{\text{y}1}}+{w_{2}}\,{L_{2}}\,\sin\left({θ_{2}}\right)}{1.0}
+\resizeExpression{{v_{\text{y}2}}={v_{\text{y}1}}+{w_{2}}\,{L_{2}}\,\sin\left({θ_{2}}\right)}{\outDefScale}
 \end{displaymath}
 Applying this to our equation for acceleration
 
 \begin{displaymath}
-\resizeExpression{{a_{\text{y}2}}=\frac{\,d{v_{\text{y}1}}+{w_{2}}\,{L_{2}}\,\sin\left({θ_{2}}\right)}{\,dt}}{1.0}
+\resizeExpression{{a_{\text{y}2}}=\frac{\,d{v_{\text{y}1}}+{w_{2}}\,{L_{2}}\,\sin\left({θ_{2}}\right)}{\,dt}}{\outDefScale}
 \end{displaymath}
 By the product and chain rules, we find
 
 \begin{displaymath}
-\resizeExpression{{a_{\text{y}2}}={a_{\text{y}1}}+{w_{2}}^{2}\,{L_{2}}\,\cos\left({θ_{2}}\right)+{α_{2}}\,{L_{2}}\,\sin\left({θ_{2}}\right)}{1.0}
+\resizeExpression{{a_{\text{y}2}}={a_{\text{y}1}}+{w_{2}}^{2}\,{L_{2}}\,\cos\left({θ_{2}}\right)+{α_{2}}\,{L_{2}}\,\sin\left({θ_{2}}\right)}{\outDefScale}
 \end{displaymath}
 \medskip
 \noindent
@@ -891,7 +893,7 @@ Units & ${\text{N}}$
         
 \\ \midrule
 Equation & \begin{displaymath}
-           \resizeExpression{\symbf{F}=m \symbf{a}\text{(}t\text{)}=-{\symbf{T}_{1}}\,\sin\left({θ_{1}}\right)+{\symbf{T}_{2}}\,\sin\left({θ_{2}}\right)}{0.8}
+           \resizeExpression{\symbf{F}=m \symbf{a}\text{(}t\text{)}=-{\symbf{T}_{1}}\,\sin\left({θ_{1}}\right)+{\symbf{T}_{2}}\,\sin\left({θ_{2}}\right)}{\inDefScale}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -916,7 +918,7 @@ RefBy & \hyperref[IM:calOfAngle2]{IM:calOfAngle2}
 \paragraph{Detailed derivation of force on the first object:}
 \label{GD:xForce1Deriv}
 \begin{displaymath}
-\resizeExpression{\symbf{F}=m \symbf{a}\text{(}t\text{)}=-{\symbf{T}_{1}}\,\sin\left({θ_{1}}\right)+{\symbf{T}_{2}}\,\sin\left({θ_{2}}\right)}{1.0}
+\resizeExpression{\symbf{F}=m \symbf{a}\text{(}t\text{)}=-{\symbf{T}_{1}}\,\sin\left({θ_{1}}\right)+{\symbf{T}_{2}}\,\sin\left({θ_{2}}\right)}{\outDefScale}
 \end{displaymath}
 \medskip
 \noindent
@@ -933,7 +935,7 @@ Units & ${\text{N}}$
         
 \\ \midrule
 Equation & \begin{displaymath}
-           \resizeExpression{\symbf{F}=m \symbf{a}\text{(}t\text{)}={\symbf{T}_{1}}\,\cos\left({θ_{1}}\right)-{\symbf{T}_{2}}\,\cos\left({θ_{2}}\right)-{m_{1}}\,\symbf{g}}{0.8}
+           \resizeExpression{\symbf{F}=m \symbf{a}\text{(}t\text{)}={\symbf{T}_{1}}\,\cos\left({θ_{1}}\right)-{\symbf{T}_{2}}\,\cos\left({θ_{2}}\right)-{m_{1}}\,\symbf{g}}{\inDefScale}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -960,7 +962,7 @@ RefBy & \hyperref[IM:calOfAngle2]{IM:calOfAngle2}
 \paragraph{Detailed derivation of force on the first object:}
 \label{GD:yForce1Deriv}
 \begin{displaymath}
-\resizeExpression{\symbf{F}=m \symbf{a}\text{(}t\text{)}={\symbf{T}_{1}}\,\cos\left({θ_{1}}\right)-{\symbf{T}_{2}}\,\cos\left({θ_{2}}\right)-{m_{1}}\,\symbf{g}}{1.0}
+\resizeExpression{\symbf{F}=m \symbf{a}\text{(}t\text{)}={\symbf{T}_{1}}\,\cos\left({θ_{1}}\right)-{\symbf{T}_{2}}\,\cos\left({θ_{2}}\right)-{m_{1}}\,\symbf{g}}{\outDefScale}
 \end{displaymath}
 \medskip
 \noindent
@@ -977,7 +979,7 @@ Units & ${\text{N}}$
         
 \\ \midrule
 Equation & \begin{displaymath}
-           \resizeExpression{\symbf{F}=m \symbf{a}\text{(}t\text{)}=-{\symbf{T}_{2}}\,\sin\left({θ_{2}}\right)}{0.8}
+           \resizeExpression{\symbf{F}=m \symbf{a}\text{(}t\text{)}=-{\symbf{T}_{2}}\,\sin\left({θ_{2}}\right)}{\inDefScale}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -1000,7 +1002,7 @@ RefBy & \hyperref[IM:calOfAngle2]{IM:calOfAngle2}
 \paragraph{Detailed derivation of force on the second object:}
 \label{GD:xForce2Deriv}
 \begin{displaymath}
-\resizeExpression{\symbf{F}=m \symbf{a}\text{(}t\text{)}=-{\symbf{T}_{2}}\,\sin\left({θ_{2}}\right)}{1.0}
+\resizeExpression{\symbf{F}=m \symbf{a}\text{(}t\text{)}=-{\symbf{T}_{2}}\,\sin\left({θ_{2}}\right)}{\outDefScale}
 \end{displaymath}
 \medskip
 \noindent
@@ -1017,7 +1019,7 @@ Units & ${\text{N}}$
         
 \\ \midrule
 Equation & \begin{displaymath}
-           \resizeExpression{\symbf{F}=m \symbf{a}\text{(}t\text{)}={\symbf{T}_{2}}\,\cos\left({θ_{2}}\right)-{m_{2}}\,\symbf{g}}{0.8}
+           \resizeExpression{\symbf{F}=m \symbf{a}\text{(}t\text{)}={\symbf{T}_{2}}\,\cos\left({θ_{2}}\right)-{m_{2}}\,\symbf{g}}{\inDefScale}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -1042,7 +1044,7 @@ RefBy & \hyperref[IM:calOfAngle2]{IM:calOfAngle2}
 \paragraph{Detailed derivation of force on the second object:}
 \label{GD:yForce2Deriv}
 \begin{displaymath}
-\resizeExpression{\symbf{F}=m \symbf{a}\text{(}t\text{)}={\symbf{T}_{2}}\,\cos\left({θ_{2}}\right)-{m_{2}}\,\symbf{g}}{1.0}
+\resizeExpression{\symbf{F}=m \symbf{a}\text{(}t\text{)}={\symbf{T}_{2}}\,\cos\left({θ_{2}}\right)-{m_{2}}\,\symbf{g}}{\outDefScale}
 \end{displaymath}
 \subsubsection{Data Definitions}
 \label{Sec:DDs}
@@ -1066,7 +1068,7 @@ Units & $\frac{\text{m}}{\text{s}}$
         
 \\ \midrule
 Equation & \begin{displaymath}
-           \resizeExpression{\symbf{v}\text{(}t\text{)}=\frac{\,d\symbf{p}\text{(}t\text{)}}{\,dt}}{0.8}
+           \resizeExpression{\symbf{v}\text{(}t\text{)}=\frac{\,d\symbf{p}\text{(}t\text{)}}{\,dt}}{\inDefScale}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -1102,7 +1104,7 @@ Units & ${\text{m}}$
         
 \\ \midrule
 Equation & \begin{displaymath}
-           \resizeExpression{{p_{\text{x}1}}={L_{1}}\,\sin\left({θ_{1}}\right)}{0.8}
+           \resizeExpression{{p_{\text{x}1}}={L_{1}}\,\sin\left({θ_{1}}\right)}{\inDefScale}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -1143,7 +1145,7 @@ Units & ${\text{m}}$
         
 \\ \midrule
 Equation & \begin{displaymath}
-           \resizeExpression{{p_{\text{y}1}}=-{L_{1}}\,\cos\left({θ_{1}}\right)}{0.8}
+           \resizeExpression{{p_{\text{y}1}}=-{L_{1}}\,\cos\left({θ_{1}}\right)}{\inDefScale}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -1184,7 +1186,7 @@ Units & ${\text{m}}$
         
 \\ \midrule
 Equation & \begin{displaymath}
-           \resizeExpression{{p_{\text{x}2}}={p_{\text{x}1}}+{L_{2}}\,\sin\left({θ_{2}}\right)}{0.8}
+           \resizeExpression{{p_{\text{x}2}}={p_{\text{x}1}}+{L_{2}}\,\sin\left({θ_{2}}\right)}{\inDefScale}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -1226,7 +1228,7 @@ Units & ${\text{m}}$
         
 \\ \midrule
 Equation & \begin{displaymath}
-           \resizeExpression{{p_{\text{y}2}}={p_{\text{y}1}}-{L_{2}}\,\cos\left({θ_{2}}\right)}{0.8}
+           \resizeExpression{{p_{\text{y}2}}={p_{\text{y}1}}-{L_{2}}\,\cos\left({θ_{2}}\right)}{\inDefScale}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -1268,7 +1270,7 @@ Units & $\frac{\text{m}}{\text{s}^{2}}$
         
 \\ \midrule
 Equation & \begin{displaymath}
-           \resizeExpression{\symbf{a}\text{(}t\text{)}=\frac{\,d\symbf{v}\text{(}t\text{)}}{\,dt}}{0.8}
+           \resizeExpression{\symbf{a}\text{(}t\text{)}=\frac{\,d\symbf{v}\text{(}t\text{)}}{\,dt}}{\inDefScale}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -1303,7 +1305,7 @@ Units & ${\text{N}}$
         
 \\ \midrule
 Equation & \begin{displaymath}
-           \resizeExpression{\symbf{F}=m \symbf{a}\text{(}t\text{)}}{0.8}
+           \resizeExpression{\symbf{F}=m \symbf{a}\text{(}t\text{)}}{\inDefScale}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -1342,22 +1344,22 @@ Output & ${θ_{1}}$
          
 \\ \midrule
 Input Constraints & \begin{displaymath}
-                    \resizeExpression{{L_{1}}\gt{}0}{0.8}
+                    \resizeExpression{{L_{1}}\gt{}0}{\inDefScale}
                     \end{displaymath}
                     \begin{displaymath}
-                    \resizeExpression{{L_{2}}\gt{}0}{0.8}
+                    \resizeExpression{{L_{2}}\gt{}0}{\inDefScale}
                     \end{displaymath}
                     \begin{displaymath}
-                    \resizeExpression{{m_{1}}\gt{}0}{0.8}
+                    \resizeExpression{{m_{1}}\gt{}0}{\inDefScale}
                     \end{displaymath}
                     \begin{displaymath}
-                    \resizeExpression{{m_{2}}\gt{}0}{0.8}
+                    \resizeExpression{{m_{2}}\gt{}0}{\inDefScale}
                     \end{displaymath}
 \\ \midrule
 Output Constraints & 
 \\ \midrule
 Equation & \begin{displaymath}
-           \resizeExpression{{α_{1}}\left({θ_{1}},{θ_{2}},{w_{1}},{w_{2}}\right)=\frac{-g\,\left(2\,{m_{1}}+{m_{2}}\right)\,\sin\left({θ_{1}}\right)-{m_{2}}\,g\,\sin\left({θ_{1}}-2\,{θ_{2}}\right)-2\,\sin\left({θ_{1}}-{θ_{2}}\right)\,{m_{2}}\,\left({w_{2}}^{2}\,{L_{2}}+{w_{1}}^{2}\,{L_{1}}\,\cos\left({θ_{1}}-{θ_{2}}\right)\right)}{{L_{1}}\,\left(2\,{m_{1}}+{m_{2}}-{m_{2}}\,\cos\left(2\,{θ_{1}}-2\,{θ_{2}}\right)\right)}}{0.8}
+           \resizeExpression{{α_{1}}\left({θ_{1}},{θ_{2}},{w_{1}},{w_{2}}\right)=\frac{-g\,\left(2\,{m_{1}}+{m_{2}}\right)\,\sin\left({θ_{1}}\right)-{m_{2}}\,g\,\sin\left({θ_{1}}-2\,{θ_{2}}\right)-2\,\sin\left({θ_{1}}-{θ_{2}}\right)\,{m_{2}}\,\left({w_{2}}^{2}\,{L_{2}}+{w_{1}}^{2}\,{L_{1}}\,\cos\left({θ_{1}}-{θ_{2}}\right)\right)}{{L_{1}}\,\left(2\,{m_{1}}+{m_{2}}-{m_{2}}\,\cos\left(2\,{θ_{1}}-2\,{θ_{2}}\right)\right)}}{\inDefScale}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -1403,22 +1405,22 @@ Output & ${θ_{2}}$
          
 \\ \midrule
 Input Constraints & \begin{displaymath}
-                    \resizeExpression{{L_{1}}\gt{}0}{0.8}
+                    \resizeExpression{{L_{1}}\gt{}0}{\inDefScale}
                     \end{displaymath}
                     \begin{displaymath}
-                    \resizeExpression{{L_{2}}\gt{}0}{0.8}
+                    \resizeExpression{{L_{2}}\gt{}0}{\inDefScale}
                     \end{displaymath}
                     \begin{displaymath}
-                    \resizeExpression{{m_{1}}\gt{}0}{0.8}
+                    \resizeExpression{{m_{1}}\gt{}0}{\inDefScale}
                     \end{displaymath}
                     \begin{displaymath}
-                    \resizeExpression{{m_{2}}\gt{}0}{0.8}
+                    \resizeExpression{{m_{2}}\gt{}0}{\inDefScale}
                     \end{displaymath}
 \\ \midrule
 Output Constraints & 
 \\ \midrule
 Equation & \begin{displaymath}
-           \resizeExpression{{α_{2}}\left({θ_{1}},{θ_{2}},{w_{1}},{w_{2}}\right)=\frac{2\,\sin\left({θ_{1}}-{θ_{2}}\right)\,\left({w_{1}}^{2}\,{L_{1}}\,\left({m_{1}}+{m_{2}}\right)+g\,\left({m_{1}}+{m_{2}}\right)\,\cos\left({θ_{1}}\right)+{w_{2}}^{2}\,{L_{2}}\,{m_{2}}\,\cos\left({θ_{1}}-{θ_{2}}\right)\right)}{{L_{2}}\,\left(2\,{m_{1}}+{m_{2}}-{m_{2}}\,\cos\left(2\,{θ_{1}}-2\,{θ_{2}}\right)\right)}}{0.8}
+           \resizeExpression{{α_{2}}\left({θ_{1}},{θ_{2}},{w_{1}},{w_{2}}\right)=\frac{2\,\sin\left({θ_{1}}-{θ_{2}}\right)\,\left({w_{1}}^{2}\,{L_{1}}\,\left({m_{1}}+{m_{2}}\right)+g\,\left({m_{1}}+{m_{2}}\right)\,\cos\left({θ_{1}}\right)+{w_{2}}^{2}\,{L_{2}}\,{m_{2}}\,\cos\left({θ_{1}}-{θ_{2}}\right)\right)}{{L_{2}}\,\left(2\,{m_{1}}+{m_{2}}-{m_{2}}\,\cos\left(2\,{θ_{1}}-2\,{θ_{2}}\right)\right)}}{\inDefScale}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -1451,39 +1453,39 @@ RefBy & \hyperref[outputValues]{FR:Output-Values}, \hyperref[calcAng]{FR:Calcula
 By solving equations \hyperref[GD:xForce2]{GD:xForce2} and \hyperref[GD:yForce2]{GD:yForce2} for ${\symbf{T}_{2}}\,\sin\left({θ_{2}}\right)$ and ${\symbf{T}_{2}}\,\cos\left({θ_{2}}\right)$ and then substituting into equation \hyperref[GD:xForce1]{GD:xForce1} and \hyperref[GD:yForce1]{GD:yForce1} , We can get equations 1 and 2:
 
 \begin{displaymath}
-\resizeExpression{{m_{1}}\,{a_{\text{x}1}}=-{\symbf{T}_{1}}\,\sin\left({θ_{1}}\right)-{m_{2}}\,{a_{\text{x}2}}}{1.0}
+\resizeExpression{{m_{1}}\,{a_{\text{x}1}}=-{\symbf{T}_{1}}\,\sin\left({θ_{1}}\right)-{m_{2}}\,{a_{\text{x}2}}}{\outDefScale}
 \end{displaymath}
 
 \begin{displaymath}
-\resizeExpression{{m_{1}}\,{a_{\text{y}1}}={\symbf{T}_{1}}\,\cos\left({θ_{1}}\right)-{m_{2}}\,{a_{\text{y}2}}-{m_{2}}\,g-{m_{1}}\,g}{1.0}
+\resizeExpression{{m_{1}}\,{a_{\text{y}1}}={\symbf{T}_{1}}\,\cos\left({θ_{1}}\right)-{m_{2}}\,{a_{\text{y}2}}-{m_{2}}\,g-{m_{1}}\,g}{\outDefScale}
 \end{displaymath}
 Multiply the equation 1 by $\cos\left({θ_{1}}\right)$ and the equation 2 by $\sin\left({θ_{1}}\right)$ and rearrange to get:
 
 \begin{displaymath}
-\resizeExpression{{\symbf{T}_{1}}\,\sin\left({θ_{1}}\right)\,\cos\left({θ_{1}}\right)=-\cos\left({θ_{1}}\right)\,\left({m_{1}}\,{a_{\text{x}1}}+{m_{2}}\,{a_{\text{x}2}}\right)}{1.0}
+\resizeExpression{{\symbf{T}_{1}}\,\sin\left({θ_{1}}\right)\,\cos\left({θ_{1}}\right)=-\cos\left({θ_{1}}\right)\,\left({m_{1}}\,{a_{\text{x}1}}+{m_{2}}\,{a_{\text{x}2}}\right)}{\outDefScale}
 \end{displaymath}
 
 \begin{displaymath}
-\resizeExpression{{\symbf{T}_{1}}\,\sin\left({θ_{1}}\right)\,\cos\left({θ_{1}}\right)=\sin\left({θ_{1}}\right)\,\left({m_{1}}\,{a_{\text{y}1}}+{m_{2}}\,{a_{\text{y}2}}+{m_{2}}\,g+{m_{1}}\,g\right)}{1.0}
+\resizeExpression{{\symbf{T}_{1}}\,\sin\left({θ_{1}}\right)\,\cos\left({θ_{1}}\right)=\sin\left({θ_{1}}\right)\,\left({m_{1}}\,{a_{\text{y}1}}+{m_{2}}\,{a_{\text{y}2}}+{m_{2}}\,g+{m_{1}}\,g\right)}{\outDefScale}
 \end{displaymath}
 This leads to the equation 3
 
 \begin{displaymath}
-\resizeExpression{\sin\left({θ_{1}}\right)\,\left({m_{1}}\,{a_{\text{y}1}}+{m_{2}}\,{a_{\text{y}2}}+{m_{2}}\,g+{m_{1}}\,g\right)=-\cos\left({θ_{1}}\right)\,\left({m_{1}}\,{a_{\text{x}1}}+{m_{2}}\,{a_{\text{x}2}}\right)}{1.0}
+\resizeExpression{\sin\left({θ_{1}}\right)\,\left({m_{1}}\,{a_{\text{y}1}}+{m_{2}}\,{a_{\text{y}2}}+{m_{2}}\,g+{m_{1}}\,g\right)=-\cos\left({θ_{1}}\right)\,\left({m_{1}}\,{a_{\text{x}1}}+{m_{2}}\,{a_{\text{x}2}}\right)}{\outDefScale}
 \end{displaymath}
 Next, multiply equation \hyperref[GD:xForce2]{GD:xForce2} by $\cos\left({θ_{2}}\right)$ and equation \hyperref[GD:yForce2]{GD:yForce2} by $\sin\left({θ_{2}}\right)$ and rearrange to get:
 
 \begin{displaymath}
-\resizeExpression{{\symbf{T}_{2}}\,\sin\left({θ_{2}}\right)\,\cos\left({θ_{2}}\right)=-\cos\left({θ_{2}}\right)\,{m_{2}}\,{a_{\text{x}2}}}{1.0}
+\resizeExpression{{\symbf{T}_{2}}\,\sin\left({θ_{2}}\right)\,\cos\left({θ_{2}}\right)=-\cos\left({θ_{2}}\right)\,{m_{2}}\,{a_{\text{x}2}}}{\outDefScale}
 \end{displaymath}
 
 \begin{displaymath}
-\resizeExpression{{\symbf{T}_{1}}\,\sin\left({θ_{2}}\right)\,\cos\left({θ_{2}}\right)=\sin\left({θ_{2}}\right)\,\left({m_{2}}\,{a_{\text{y}2}}+{m_{2}}\,g\right)}{1.0}
+\resizeExpression{{\symbf{T}_{1}}\,\sin\left({θ_{2}}\right)\,\cos\left({θ_{2}}\right)=\sin\left({θ_{2}}\right)\,\left({m_{2}}\,{a_{\text{y}2}}+{m_{2}}\,g\right)}{\outDefScale}
 \end{displaymath}
 which leads to equation 4
 
 \begin{displaymath}
-\resizeExpression{\sin\left({θ_{2}}\right)\,\left({m_{2}}\,{a_{\text{y}2}}+{m_{2}}\,g\right)=-\cos\left({θ_{2}}\right)\,{m_{2}}\,{a_{\text{x}2}}}{1.0}
+\resizeExpression{\sin\left({θ_{2}}\right)\,\left({m_{2}}\,{a_{\text{y}2}}+{m_{2}}\,g\right)=-\cos\left({θ_{2}}\right)\,{m_{2}}\,{a_{\text{x}2}}}{\outDefScale}
 \end{displaymath}
 By giving equations \hyperref[GD:accelerationX1]{GD:accelerationX1} and \hyperref[GD:accelerationX2]{GD:accelerationX2} and \hyperref[GD:accelerationY1]{GD:accelerationY1} and \hyperref[GD:accelerationY2]{GD:accelerationY2} plus additional two equations, 3 and 4, we can get \hyperref[IM:calOfAngle1]{IM:calOfAngle1} and \hyperref[IM:calOfAngle2]{IM:calOfAngle2} via a computer algebra program:
 

--- a/code/stable/dblpend/SRS/PDF/DblPend_SRS.tex
+++ b/code/stable/dblpend/SRS/PDF/DblPend_SRS.tex
@@ -15,6 +15,8 @@
 \usepackage{svg}
 \usepackage{float}
 \usepackage{enumitem}
+\usepackage{graphicx}
+\usepackage{calc}
 \usepackage{filecontents}
 \usepackage[backend=bibtex]{biblatex}
 \usepackage{url}
@@ -23,6 +25,15 @@
 \newcommand{\lt}{\ensuremath <}
 \newlist{symbDescription}{description}{1}
 \setlist[symbDescription]{noitemsep, topsep=0pt, parsep=0pt, partopsep=0pt}
+\newsavebox{\mybox}
+\newcommand{\resizeExpression}[2]{
+\savebox{\mybox}{$#1$}
+\ifdim\wd\mybox>#2\linewidth
+\resizebox{#2\textwidth}{!}{\usebox{\mybox}}
+\else
+\usebox{\mybox}
+\fi
+}
 \bibliography{bibfile}
 \title{Software Requirements Specification for Double Pendulum}
 \author{Dong Chen}
@@ -311,7 +322,7 @@ Label & Acceleration
         
 \\ \midrule
 Equation & \begin{displaymath}
-           \symbf{a}\text{(}t\text{)}=\frac{\,d\symbf{v}\text{(}t\text{)}}{\,dt}
+           \resizeExpression{\symbf{a}\text{(}t\text{)}=\frac{\,d\symbf{v}\text{(}t\text{)}}{\,dt}}{0.8}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -340,7 +351,7 @@ Label & Velocity
         
 \\ \midrule
 Equation & \begin{displaymath}
-           \symbf{v}\text{(}t\text{)}=\frac{\,d\symbf{p}\text{(}t\text{)}}{\,dt}
+           \resizeExpression{\symbf{v}\text{(}t\text{)}=\frac{\,d\symbf{p}\text{(}t\text{)}}{\,dt}}{0.8}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -369,7 +380,7 @@ Label & Newton's second law of motion
         
 \\ \midrule
 Equation & \begin{displaymath}
-           \symbf{F}=m\,\symbf{a}\text{(}t\text{)}
+           \resizeExpression{\symbf{F}=m\,\symbf{a}\text{(}t\text{)}}{0.8}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -408,7 +419,7 @@ Units & $\frac{\text{m}}{\text{s}}$
         
 \\ \midrule
 Equation & \begin{displaymath}
-           {v_{\text{x}1}}={w_{1}}\,{L_{1}}\,\cos\left({θ_{1}}\right)
+           \resizeExpression{{v_{\text{x}1}}={w_{1}}\,{L_{1}}\,\cos\left({θ_{1}}\right)}{0.8}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -431,27 +442,27 @@ RefBy &
 At a given point in time, velocity is defined in \hyperref[DD:positionGDD]{DD:positionGDD}
 
 \begin{displaymath}
-\symbf{v}\text{(}t\text{)}=\frac{\,d\symbf{p}\text{(}t\text{)}}{\,dt}
+\resizeExpression{\symbf{v}\text{(}t\text{)}=\frac{\,d\symbf{p}\text{(}t\text{)}}{\,dt}}{1.0}
 \end{displaymath}
 We also know the horizontal position that is defined in \hyperref[DD:positionXDD1]{DD:positionXDD1}
 
 \begin{displaymath}
-{p_{\text{x}1}}={L_{1}}\,\sin\left({θ_{1}}\right)
+\resizeExpression{{p_{\text{x}1}}={L_{1}}\,\sin\left({θ_{1}}\right)}{1.0}
 \end{displaymath}
 Applying this,
 
 \begin{displaymath}
-{v_{\text{x}1}}=\frac{\,d{L_{1}}\,\sin\left({θ_{1}}\right)}{\,dt}
+\resizeExpression{{v_{\text{x}1}}=\frac{\,d{L_{1}}\,\sin\left({θ_{1}}\right)}{\,dt}}{1.0}
 \end{displaymath}
 ${L_{1}}$ is constant with respect to time, so
 
 \begin{displaymath}
-{v_{\text{x}1}}={L_{1}}\,\frac{\,d\sin\left({θ_{1}}\right)}{\,dt}
+\resizeExpression{{v_{\text{x}1}}={L_{1}}\,\frac{\,d\sin\left({θ_{1}}\right)}{\,dt}}{1.0}
 \end{displaymath}
 Therefore, using the chain rule,
 
 \begin{displaymath}
-{v_{\text{x}1}}={w_{1}}\,{L_{1}}\,\cos\left({θ_{1}}\right)
+\resizeExpression{{v_{\text{x}1}}={w_{1}}\,{L_{1}}\,\cos\left({θ_{1}}\right)}{1.0}
 \end{displaymath}
 \medskip
 \noindent
@@ -468,7 +479,7 @@ Units & $\frac{\text{m}}{\text{s}}$
         
 \\ \midrule
 Equation & \begin{displaymath}
-           {v_{\text{y}1}}={w_{1}}\,{L_{1}}\,\sin\left({θ_{1}}\right)
+           \resizeExpression{{v_{\text{y}1}}={w_{1}}\,{L_{1}}\,\sin\left({θ_{1}}\right)}{0.8}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -491,27 +502,27 @@ RefBy &
 At a given point in time, velocity is defined in \hyperref[DD:positionGDD]{DD:positionGDD}
 
 \begin{displaymath}
-\symbf{v}\text{(}t\text{)}=\frac{\,d\symbf{p}\text{(}t\text{)}}{\,dt}
+\resizeExpression{\symbf{v}\text{(}t\text{)}=\frac{\,d\symbf{p}\text{(}t\text{)}}{\,dt}}{1.0}
 \end{displaymath}
 We also know the vertical position that is defined in \hyperref[DD:positionYDD1]{DD:positionYDD1}
 
 \begin{displaymath}
-{p_{\text{y}1}}=-{L_{1}}\,\cos\left({θ_{1}}\right)
+\resizeExpression{{p_{\text{y}1}}=-{L_{1}}\,\cos\left({θ_{1}}\right)}{1.0}
 \end{displaymath}
 Applying this,
 
 \begin{displaymath}
-{v_{\text{y}1}}=-\left(\frac{\,d{L_{1}}\,\cos\left({θ_{1}}\right)}{\,dt}\right)
+\resizeExpression{{v_{\text{y}1}}=-\left(\frac{\,d{L_{1}}\,\cos\left({θ_{1}}\right)}{\,dt}\right)}{1.0}
 \end{displaymath}
 ${L_{1}}$ is constant with respect to time, so
 
 \begin{displaymath}
-{v_{\text{y}1}}=-{L_{1}}\,\frac{\,d\cos\left({θ_{1}}\right)}{\,dt}
+\resizeExpression{{v_{\text{y}1}}=-{L_{1}}\,\frac{\,d\cos\left({θ_{1}}\right)}{\,dt}}{1.0}
 \end{displaymath}
 Therefore, using the chain rule,
 
 \begin{displaymath}
-{v_{\text{y}1}}={w_{1}}\,{L_{1}}\,\sin\left({θ_{1}}\right)
+\resizeExpression{{v_{\text{y}1}}={w_{1}}\,{L_{1}}\,\sin\left({θ_{1}}\right)}{1.0}
 \end{displaymath}
 \medskip
 \noindent
@@ -528,7 +539,7 @@ Units & $\frac{\text{m}}{\text{s}}$
         
 \\ \midrule
 Equation & \begin{displaymath}
-           {v_{\text{x}2}}={v_{\text{x}1}}+{w_{2}}\,{L_{2}}\,\cos\left({θ_{2}}\right)
+           \resizeExpression{{v_{\text{x}2}}={v_{\text{x}1}}+{w_{2}}\,{L_{2}}\,\cos\left({θ_{2}}\right)}{0.8}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -552,22 +563,22 @@ RefBy &
 At a given point in time, velocity is defined in \hyperref[DD:positionGDD]{DD:positionGDD}
 
 \begin{displaymath}
-\symbf{v}\text{(}t\text{)}=\frac{\,d\symbf{p}\text{(}t\text{)}}{\,dt}
+\resizeExpression{\symbf{v}\text{(}t\text{)}=\frac{\,d\symbf{p}\text{(}t\text{)}}{\,dt}}{1.0}
 \end{displaymath}
 We also know the horizontal position that is defined in \hyperref[DD:positionXDD2]{DD:positionXDD2}
 
 \begin{displaymath}
-{p_{\text{x}2}}={p_{\text{x}1}}+{L_{2}}\,\sin\left({θ_{2}}\right)
+\resizeExpression{{p_{\text{x}2}}={p_{\text{x}1}}+{L_{2}}\,\sin\left({θ_{2}}\right)}{1.0}
 \end{displaymath}
 Applying this,
 
 \begin{displaymath}
-{v_{\text{x}2}}=\frac{\,d{p_{\text{x}1}}+{L_{2}}\,\sin\left({θ_{2}}\right)}{\,dt}
+\resizeExpression{{v_{\text{x}2}}=\frac{\,d{p_{\text{x}1}}+{L_{2}}\,\sin\left({θ_{2}}\right)}{\,dt}}{1.0}
 \end{displaymath}
 ${L_{1}}$ is constant with respect to time, so
 
 \begin{displaymath}
-{v_{\text{x}2}}={v_{\text{x}1}}+{w_{2}}\,{L_{2}}\,\cos\left({θ_{2}}\right)
+\resizeExpression{{v_{\text{x}2}}={v_{\text{x}1}}+{w_{2}}\,{L_{2}}\,\cos\left({θ_{2}}\right)}{1.0}
 \end{displaymath}
 \medskip
 \noindent
@@ -584,7 +595,7 @@ Units & $\frac{\text{m}}{\text{s}}$
         
 \\ \midrule
 Equation & \begin{displaymath}
-           {v_{\text{y}2}}={v_{\text{y}1}}+{w_{2}}\,{L_{2}}\,\sin\left({θ_{2}}\right)
+           \resizeExpression{{v_{\text{y}2}}={v_{\text{y}1}}+{w_{2}}\,{L_{2}}\,\sin\left({θ_{2}}\right)}{0.8}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -608,22 +619,22 @@ RefBy &
 At a given point in time, velocity is defined in \hyperref[DD:positionGDD]{DD:positionGDD}
 
 \begin{displaymath}
-\symbf{v}\text{(}t\text{)}=\frac{\,d\symbf{p}\text{(}t\text{)}}{\,dt}
+\resizeExpression{\symbf{v}\text{(}t\text{)}=\frac{\,d\symbf{p}\text{(}t\text{)}}{\,dt}}{1.0}
 \end{displaymath}
 We also know the vertical position that is defined in \hyperref[DD:positionYDD2]{DD:positionYDD2}
 
 \begin{displaymath}
-{p_{\text{y}2}}={p_{\text{y}1}}-{L_{2}}\,\cos\left({θ_{2}}\right)
+\resizeExpression{{p_{\text{y}2}}={p_{\text{y}1}}-{L_{2}}\,\cos\left({θ_{2}}\right)}{1.0}
 \end{displaymath}
 Applying this,
 
 \begin{displaymath}
-{v_{\text{y}2}}=-\left(\frac{\,d{p_{\text{y}1}}-{L_{2}}\,\cos\left({θ_{2}}\right)}{\,dt}\right)
+\resizeExpression{{v_{\text{y}2}}=-\left(\frac{\,d{p_{\text{y}1}}-{L_{2}}\,\cos\left({θ_{2}}\right)}{\,dt}\right)}{1.0}
 \end{displaymath}
 Therefore, using the chain rule,
 
 \begin{displaymath}
-{v_{\text{y}2}}={v_{\text{y}1}}+{w_{2}}\,{L_{2}}\,\sin\left({θ_{2}}\right)
+\resizeExpression{{v_{\text{y}2}}={v_{\text{y}1}}+{w_{2}}\,{L_{2}}\,\sin\left({θ_{2}}\right)}{1.0}
 \end{displaymath}
 \medskip
 \noindent
@@ -640,7 +651,7 @@ Units & $\frac{\text{m}}{\text{s}^{2}}$
         
 \\ \midrule
 Equation & \begin{displaymath}
-           {a_{\text{x}1}}=-{w_{1}}^{2}\,{L_{1}}\,\sin\left({θ_{1}}\right)+{α_{1}}\,{L_{1}}\,\cos\left({θ_{1}}\right)
+           \resizeExpression{{a_{\text{x}1}}=-{w_{1}}^{2}\,{L_{1}}\,\sin\left({θ_{1}}\right)+{α_{1}}\,{L_{1}}\,\cos\left({θ_{1}}\right)}{0.8}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -665,27 +676,27 @@ RefBy & \hyperref[IM:calOfAngle2]{IM:calOfAngle2}
 Our acceleration is:
 
 \begin{displaymath}
-\symbf{a}\text{(}t\text{)}=\frac{\,d\symbf{v}\text{(}t\text{)}}{\,dt}
+\resizeExpression{\symbf{a}\text{(}t\text{)}=\frac{\,d\symbf{v}\text{(}t\text{)}}{\,dt}}{1.0}
 \end{displaymath}
 Earlier, we found the horizontal velocity to be
 
 \begin{displaymath}
-{v_{\text{x}1}}={w_{1}}\,{L_{1}}\,\cos\left({θ_{1}}\right)
+\resizeExpression{{v_{\text{x}1}}={w_{1}}\,{L_{1}}\,\cos\left({θ_{1}}\right)}{1.0}
 \end{displaymath}
 Applying this to our equation for acceleration
 
 \begin{displaymath}
-{a_{\text{x}1}}=\frac{\,d{w_{1}}\,{L_{1}}\,\cos\left({θ_{1}}\right)}{\,dt}
+\resizeExpression{{a_{\text{x}1}}=\frac{\,d{w_{1}}\,{L_{1}}\,\cos\left({θ_{1}}\right)}{\,dt}}{1.0}
 \end{displaymath}
 By the product and chain rules, we find
 
 \begin{displaymath}
-{a_{\text{x}1}}=\frac{\,d{w_{1}}}{\,dt}\,{L_{1}}\,\cos\left({θ_{1}}\right)-{w_{1}}\,{L_{1}}\,\sin\left({θ_{1}}\right)\,\frac{\,d{θ_{1}}}{\,dt}
+\resizeExpression{{a_{\text{x}1}}=\frac{\,d{w_{1}}}{\,dt}\,{L_{1}}\,\cos\left({θ_{1}}\right)-{w_{1}}\,{L_{1}}\,\sin\left({θ_{1}}\right)\,\frac{\,d{θ_{1}}}{\,dt}}{1.0}
 \end{displaymath}
 Simplifying,
 
 \begin{displaymath}
-{a_{\text{x}1}}=-{w_{1}}^{2}\,{L_{1}}\,\sin\left({θ_{1}}\right)+{α_{1}}\,{L_{1}}\,\cos\left({θ_{1}}\right)
+\resizeExpression{{a_{\text{x}1}}=-{w_{1}}^{2}\,{L_{1}}\,\sin\left({θ_{1}}\right)+{α_{1}}\,{L_{1}}\,\cos\left({θ_{1}}\right)}{1.0}
 \end{displaymath}
 \medskip
 \noindent
@@ -702,7 +713,7 @@ Units & $\frac{\text{m}}{\text{s}^{2}}$
         
 \\ \midrule
 Equation & \begin{displaymath}
-           {a_{\text{y}1}}={w_{1}}^{2}\,{L_{1}}\,\cos\left({θ_{1}}\right)+{α_{1}}\,{L_{1}}\,\sin\left({θ_{1}}\right)
+           \resizeExpression{{a_{\text{y}1}}={w_{1}}^{2}\,{L_{1}}\,\cos\left({θ_{1}}\right)+{α_{1}}\,{L_{1}}\,\sin\left({θ_{1}}\right)}{0.8}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -727,27 +738,27 @@ RefBy & \hyperref[IM:calOfAngle2]{IM:calOfAngle2}
 Our acceleration is:
 
 \begin{displaymath}
-\symbf{a}\text{(}t\text{)}=\frac{\,d\symbf{v}\text{(}t\text{)}}{\,dt}
+\resizeExpression{\symbf{a}\text{(}t\text{)}=\frac{\,d\symbf{v}\text{(}t\text{)}}{\,dt}}{1.0}
 \end{displaymath}
 Earlier, we found the vertical velocity to be
 
 \begin{displaymath}
-{v_{\text{y}1}}={w_{1}}\,{L_{1}}\,\sin\left({θ_{1}}\right)
+\resizeExpression{{v_{\text{y}1}}={w_{1}}\,{L_{1}}\,\sin\left({θ_{1}}\right)}{1.0}
 \end{displaymath}
 Applying this to our equation for acceleration
 
 \begin{displaymath}
-{a_{\text{y}1}}=\frac{\,d{w_{1}}\,{L_{1}}\,\sin\left({θ_{1}}\right)}{\,dt}
+\resizeExpression{{a_{\text{y}1}}=\frac{\,d{w_{1}}\,{L_{1}}\,\sin\left({θ_{1}}\right)}{\,dt}}{1.0}
 \end{displaymath}
 By the product and chain rules, we find
 
 \begin{displaymath}
-{a_{\text{y}1}}=\frac{\,d{w_{1}}}{\,dt}\,{L_{1}}\,\sin\left({θ_{1}}\right)+{w_{1}}\,{L_{1}}\,\cos\left({θ_{1}}\right)\,\frac{\,d{θ_{1}}}{\,dt}
+\resizeExpression{{a_{\text{y}1}}=\frac{\,d{w_{1}}}{\,dt}\,{L_{1}}\,\sin\left({θ_{1}}\right)+{w_{1}}\,{L_{1}}\,\cos\left({θ_{1}}\right)\,\frac{\,d{θ_{1}}}{\,dt}}{1.0}
 \end{displaymath}
 Simplifying,
 
 \begin{displaymath}
-{a_{\text{y}1}}={w_{1}}^{2}\,{L_{1}}\,\cos\left({θ_{1}}\right)+{α_{1}}\,{L_{1}}\,\sin\left({θ_{1}}\right)
+\resizeExpression{{a_{\text{y}1}}={w_{1}}^{2}\,{L_{1}}\,\cos\left({θ_{1}}\right)+{α_{1}}\,{L_{1}}\,\sin\left({θ_{1}}\right)}{1.0}
 \end{displaymath}
 \medskip
 \noindent
@@ -764,7 +775,7 @@ Units & $\frac{\text{m}}{\text{s}^{2}}$
         
 \\ \midrule
 Equation & \begin{displaymath}
-           {a_{\text{x}2}}={a_{\text{x}1}}-{w_{2}}^{2}\,{L_{2}}\,\sin\left({θ_{2}}\right)+{α_{2}}\,{L_{2}}\,\cos\left({θ_{2}}\right)
+           \resizeExpression{{a_{\text{x}2}}={a_{\text{x}1}}-{w_{2}}^{2}\,{L_{2}}\,\sin\left({θ_{2}}\right)+{α_{2}}\,{L_{2}}\,\cos\left({θ_{2}}\right)}{0.8}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -790,22 +801,22 @@ RefBy & \hyperref[IM:calOfAngle2]{IM:calOfAngle2}
 Our acceleration is:
 
 \begin{displaymath}
-\symbf{a}\text{(}t\text{)}=\frac{\,d\symbf{v}\text{(}t\text{)}}{\,dt}
+\resizeExpression{\symbf{a}\text{(}t\text{)}=\frac{\,d\symbf{v}\text{(}t\text{)}}{\,dt}}{1.0}
 \end{displaymath}
 Earlier, we found the horizontal velocity to be
 
 \begin{displaymath}
-{v_{\text{x}2}}={v_{\text{x}1}}+{w_{2}}\,{L_{2}}\,\cos\left({θ_{2}}\right)
+\resizeExpression{{v_{\text{x}2}}={v_{\text{x}1}}+{w_{2}}\,{L_{2}}\,\cos\left({θ_{2}}\right)}{1.0}
 \end{displaymath}
 Applying this to our equation for acceleration
 
 \begin{displaymath}
-{a_{\text{x}2}}=\frac{\,d{v_{\text{x}1}}+{w_{2}}\,{L_{2}}\,\cos\left({θ_{2}}\right)}{\,dt}
+\resizeExpression{{a_{\text{x}2}}=\frac{\,d{v_{\text{x}1}}+{w_{2}}\,{L_{2}}\,\cos\left({θ_{2}}\right)}{\,dt}}{1.0}
 \end{displaymath}
 By the product and chain rules, we find
 
 \begin{displaymath}
-{a_{\text{x}2}}={a_{\text{x}1}}-{w_{2}}^{2}\,{L_{2}}\,\sin\left({θ_{2}}\right)+{α_{2}}\,{L_{2}}\,\cos\left({θ_{2}}\right)
+\resizeExpression{{a_{\text{x}2}}={a_{\text{x}1}}-{w_{2}}^{2}\,{L_{2}}\,\sin\left({θ_{2}}\right)+{α_{2}}\,{L_{2}}\,\cos\left({θ_{2}}\right)}{1.0}
 \end{displaymath}
 \medskip
 \noindent
@@ -822,7 +833,7 @@ Units & $\frac{\text{m}}{\text{s}^{2}}$
         
 \\ \midrule
 Equation & \begin{displaymath}
-           {a_{\text{y}2}}={a_{\text{y}1}}+{w_{2}}^{2}\,{L_{2}}\,\cos\left({θ_{2}}\right)+{α_{2}}\,{L_{2}}\,\sin\left({θ_{2}}\right)
+           \resizeExpression{{a_{\text{y}2}}={a_{\text{y}1}}+{w_{2}}^{2}\,{L_{2}}\,\cos\left({θ_{2}}\right)+{α_{2}}\,{L_{2}}\,\sin\left({θ_{2}}\right)}{0.8}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -848,22 +859,22 @@ RefBy & \hyperref[IM:calOfAngle2]{IM:calOfAngle2}
 Our acceleration is:
 
 \begin{displaymath}
-\symbf{a}\text{(}t\text{)}=\frac{\,d\symbf{v}\text{(}t\text{)}}{\,dt}
+\resizeExpression{\symbf{a}\text{(}t\text{)}=\frac{\,d\symbf{v}\text{(}t\text{)}}{\,dt}}{1.0}
 \end{displaymath}
 Earlier, we found the horizontal velocity to be
 
 \begin{displaymath}
-{v_{\text{y}2}}={v_{\text{y}1}}+{w_{2}}\,{L_{2}}\,\sin\left({θ_{2}}\right)
+\resizeExpression{{v_{\text{y}2}}={v_{\text{y}1}}+{w_{2}}\,{L_{2}}\,\sin\left({θ_{2}}\right)}{1.0}
 \end{displaymath}
 Applying this to our equation for acceleration
 
 \begin{displaymath}
-{a_{\text{y}2}}=\frac{\,d{v_{\text{y}1}}+{w_{2}}\,{L_{2}}\,\sin\left({θ_{2}}\right)}{\,dt}
+\resizeExpression{{a_{\text{y}2}}=\frac{\,d{v_{\text{y}1}}+{w_{2}}\,{L_{2}}\,\sin\left({θ_{2}}\right)}{\,dt}}{1.0}
 \end{displaymath}
 By the product and chain rules, we find
 
 \begin{displaymath}
-{a_{\text{y}2}}={a_{\text{y}1}}+{w_{2}}^{2}\,{L_{2}}\,\cos\left({θ_{2}}\right)+{α_{2}}\,{L_{2}}\,\sin\left({θ_{2}}\right)
+\resizeExpression{{a_{\text{y}2}}={a_{\text{y}1}}+{w_{2}}^{2}\,{L_{2}}\,\cos\left({θ_{2}}\right)+{α_{2}}\,{L_{2}}\,\sin\left({θ_{2}}\right)}{1.0}
 \end{displaymath}
 \medskip
 \noindent
@@ -880,7 +891,7 @@ Units & ${\text{N}}$
         
 \\ \midrule
 Equation & \begin{displaymath}
-           \symbf{F}=m \symbf{a}\text{(}t\text{)}=-{\symbf{T}_{1}}\,\sin\left({θ_{1}}\right)+{\symbf{T}_{2}}\,\sin\left({θ_{2}}\right)
+           \resizeExpression{\symbf{F}=m \symbf{a}\text{(}t\text{)}=-{\symbf{T}_{1}}\,\sin\left({θ_{1}}\right)+{\symbf{T}_{2}}\,\sin\left({θ_{2}}\right)}{0.8}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -905,7 +916,7 @@ RefBy & \hyperref[IM:calOfAngle2]{IM:calOfAngle2}
 \paragraph{Detailed derivation of force on the first object:}
 \label{GD:xForce1Deriv}
 \begin{displaymath}
-\symbf{F}=m \symbf{a}\text{(}t\text{)}=-{\symbf{T}_{1}}\,\sin\left({θ_{1}}\right)+{\symbf{T}_{2}}\,\sin\left({θ_{2}}\right)
+\resizeExpression{\symbf{F}=m \symbf{a}\text{(}t\text{)}=-{\symbf{T}_{1}}\,\sin\left({θ_{1}}\right)+{\symbf{T}_{2}}\,\sin\left({θ_{2}}\right)}{1.0}
 \end{displaymath}
 \medskip
 \noindent
@@ -922,7 +933,7 @@ Units & ${\text{N}}$
         
 \\ \midrule
 Equation & \begin{displaymath}
-           \symbf{F}=m \symbf{a}\text{(}t\text{)}={\symbf{T}_{1}}\,\cos\left({θ_{1}}\right)-{\symbf{T}_{2}}\,\cos\left({θ_{2}}\right)-{m_{1}}\,\symbf{g}
+           \resizeExpression{\symbf{F}=m \symbf{a}\text{(}t\text{)}={\symbf{T}_{1}}\,\cos\left({θ_{1}}\right)-{\symbf{T}_{2}}\,\cos\left({θ_{2}}\right)-{m_{1}}\,\symbf{g}}{0.8}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -949,7 +960,7 @@ RefBy & \hyperref[IM:calOfAngle2]{IM:calOfAngle2}
 \paragraph{Detailed derivation of force on the first object:}
 \label{GD:yForce1Deriv}
 \begin{displaymath}
-\symbf{F}=m \symbf{a}\text{(}t\text{)}={\symbf{T}_{1}}\,\cos\left({θ_{1}}\right)-{\symbf{T}_{2}}\,\cos\left({θ_{2}}\right)-{m_{1}}\,\symbf{g}
+\resizeExpression{\symbf{F}=m \symbf{a}\text{(}t\text{)}={\symbf{T}_{1}}\,\cos\left({θ_{1}}\right)-{\symbf{T}_{2}}\,\cos\left({θ_{2}}\right)-{m_{1}}\,\symbf{g}}{1.0}
 \end{displaymath}
 \medskip
 \noindent
@@ -966,7 +977,7 @@ Units & ${\text{N}}$
         
 \\ \midrule
 Equation & \begin{displaymath}
-           \symbf{F}=m \symbf{a}\text{(}t\text{)}=-{\symbf{T}_{2}}\,\sin\left({θ_{2}}\right)
+           \resizeExpression{\symbf{F}=m \symbf{a}\text{(}t\text{)}=-{\symbf{T}_{2}}\,\sin\left({θ_{2}}\right)}{0.8}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -989,7 +1000,7 @@ RefBy & \hyperref[IM:calOfAngle2]{IM:calOfAngle2}
 \paragraph{Detailed derivation of force on the second object:}
 \label{GD:xForce2Deriv}
 \begin{displaymath}
-\symbf{F}=m \symbf{a}\text{(}t\text{)}=-{\symbf{T}_{2}}\,\sin\left({θ_{2}}\right)
+\resizeExpression{\symbf{F}=m \symbf{a}\text{(}t\text{)}=-{\symbf{T}_{2}}\,\sin\left({θ_{2}}\right)}{1.0}
 \end{displaymath}
 \medskip
 \noindent
@@ -1006,7 +1017,7 @@ Units & ${\text{N}}$
         
 \\ \midrule
 Equation & \begin{displaymath}
-           \symbf{F}=m \symbf{a}\text{(}t\text{)}={\symbf{T}_{2}}\,\cos\left({θ_{2}}\right)-{m_{2}}\,\symbf{g}
+           \resizeExpression{\symbf{F}=m \symbf{a}\text{(}t\text{)}={\symbf{T}_{2}}\,\cos\left({θ_{2}}\right)-{m_{2}}\,\symbf{g}}{0.8}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -1031,7 +1042,7 @@ RefBy & \hyperref[IM:calOfAngle2]{IM:calOfAngle2}
 \paragraph{Detailed derivation of force on the second object:}
 \label{GD:yForce2Deriv}
 \begin{displaymath}
-\symbf{F}=m \symbf{a}\text{(}t\text{)}={\symbf{T}_{2}}\,\cos\left({θ_{2}}\right)-{m_{2}}\,\symbf{g}
+\resizeExpression{\symbf{F}=m \symbf{a}\text{(}t\text{)}={\symbf{T}_{2}}\,\cos\left({θ_{2}}\right)-{m_{2}}\,\symbf{g}}{1.0}
 \end{displaymath}
 \subsubsection{Data Definitions}
 \label{Sec:DDs}
@@ -1055,7 +1066,7 @@ Units & $\frac{\text{m}}{\text{s}}$
         
 \\ \midrule
 Equation & \begin{displaymath}
-           \symbf{v}\text{(}t\text{)}=\frac{\,d\symbf{p}\text{(}t\text{)}}{\,dt}
+           \resizeExpression{\symbf{v}\text{(}t\text{)}=\frac{\,d\symbf{p}\text{(}t\text{)}}{\,dt}}{0.8}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -1091,7 +1102,7 @@ Units & ${\text{m}}$
         
 \\ \midrule
 Equation & \begin{displaymath}
-           {p_{\text{x}1}}={L_{1}}\,\sin\left({θ_{1}}\right)
+           \resizeExpression{{p_{\text{x}1}}={L_{1}}\,\sin\left({θ_{1}}\right)}{0.8}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -1132,7 +1143,7 @@ Units & ${\text{m}}$
         
 \\ \midrule
 Equation & \begin{displaymath}
-           {p_{\text{y}1}}=-{L_{1}}\,\cos\left({θ_{1}}\right)
+           \resizeExpression{{p_{\text{y}1}}=-{L_{1}}\,\cos\left({θ_{1}}\right)}{0.8}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -1173,7 +1184,7 @@ Units & ${\text{m}}$
         
 \\ \midrule
 Equation & \begin{displaymath}
-           {p_{\text{x}2}}={p_{\text{x}1}}+{L_{2}}\,\sin\left({θ_{2}}\right)
+           \resizeExpression{{p_{\text{x}2}}={p_{\text{x}1}}+{L_{2}}\,\sin\left({θ_{2}}\right)}{0.8}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -1215,7 +1226,7 @@ Units & ${\text{m}}$
         
 \\ \midrule
 Equation & \begin{displaymath}
-           {p_{\text{y}2}}={p_{\text{y}1}}-{L_{2}}\,\cos\left({θ_{2}}\right)
+           \resizeExpression{{p_{\text{y}2}}={p_{\text{y}1}}-{L_{2}}\,\cos\left({θ_{2}}\right)}{0.8}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -1257,7 +1268,7 @@ Units & $\frac{\text{m}}{\text{s}^{2}}$
         
 \\ \midrule
 Equation & \begin{displaymath}
-           \symbf{a}\text{(}t\text{)}=\frac{\,d\symbf{v}\text{(}t\text{)}}{\,dt}
+           \resizeExpression{\symbf{a}\text{(}t\text{)}=\frac{\,d\symbf{v}\text{(}t\text{)}}{\,dt}}{0.8}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -1292,7 +1303,7 @@ Units & ${\text{N}}$
         
 \\ \midrule
 Equation & \begin{displaymath}
-           \symbf{F}=m \symbf{a}\text{(}t\text{)}
+           \resizeExpression{\symbf{F}=m \symbf{a}\text{(}t\text{)}}{0.8}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -1331,22 +1342,22 @@ Output & ${θ_{1}}$
          
 \\ \midrule
 Input Constraints & \begin{displaymath}
-                    {L_{1}}\gt{}0
+                    \resizeExpression{{L_{1}}\gt{}0}{0.8}
                     \end{displaymath}
                     \begin{displaymath}
-                    {L_{2}}\gt{}0
+                    \resizeExpression{{L_{2}}\gt{}0}{0.8}
                     \end{displaymath}
                     \begin{displaymath}
-                    {m_{1}}\gt{}0
+                    \resizeExpression{{m_{1}}\gt{}0}{0.8}
                     \end{displaymath}
                     \begin{displaymath}
-                    {m_{2}}\gt{}0
+                    \resizeExpression{{m_{2}}\gt{}0}{0.8}
                     \end{displaymath}
 \\ \midrule
 Output Constraints & 
 \\ \midrule
 Equation & \begin{displaymath}
-           {α_{1}}\left({θ_{1}},{θ_{2}},{w_{1}},{w_{2}}\right)=\frac{-g\,\left(2\,{m_{1}}+{m_{2}}\right)\,\sin\left({θ_{1}}\right)-{m_{2}}\,g\,\sin\left({θ_{1}}-2\,{θ_{2}}\right)-2\,\sin\left({θ_{1}}-{θ_{2}}\right)\,{m_{2}}\,\left({w_{2}}^{2}\,{L_{2}}+{w_{1}}^{2}\,{L_{1}}\,\cos\left({θ_{1}}-{θ_{2}}\right)\right)}{{L_{1}}\,\left(2\,{m_{1}}+{m_{2}}-{m_{2}}\,\cos\left(2\,{θ_{1}}-2\,{θ_{2}}\right)\right)}
+           \resizeExpression{{α_{1}}\left({θ_{1}},{θ_{2}},{w_{1}},{w_{2}}\right)=\frac{-g\,\left(2\,{m_{1}}+{m_{2}}\right)\,\sin\left({θ_{1}}\right)-{m_{2}}\,g\,\sin\left({θ_{1}}-2\,{θ_{2}}\right)-2\,\sin\left({θ_{1}}-{θ_{2}}\right)\,{m_{2}}\,\left({w_{2}}^{2}\,{L_{2}}+{w_{1}}^{2}\,{L_{1}}\,\cos\left({θ_{1}}-{θ_{2}}\right)\right)}{{L_{1}}\,\left(2\,{m_{1}}+{m_{2}}-{m_{2}}\,\cos\left(2\,{θ_{1}}-2\,{θ_{2}}\right)\right)}}{0.8}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -1392,22 +1403,22 @@ Output & ${θ_{2}}$
          
 \\ \midrule
 Input Constraints & \begin{displaymath}
-                    {L_{1}}\gt{}0
+                    \resizeExpression{{L_{1}}\gt{}0}{0.8}
                     \end{displaymath}
                     \begin{displaymath}
-                    {L_{2}}\gt{}0
+                    \resizeExpression{{L_{2}}\gt{}0}{0.8}
                     \end{displaymath}
                     \begin{displaymath}
-                    {m_{1}}\gt{}0
+                    \resizeExpression{{m_{1}}\gt{}0}{0.8}
                     \end{displaymath}
                     \begin{displaymath}
-                    {m_{2}}\gt{}0
+                    \resizeExpression{{m_{2}}\gt{}0}{0.8}
                     \end{displaymath}
 \\ \midrule
 Output Constraints & 
 \\ \midrule
 Equation & \begin{displaymath}
-           {α_{2}}\left({θ_{1}},{θ_{2}},{w_{1}},{w_{2}}\right)=\frac{2\,\sin\left({θ_{1}}-{θ_{2}}\right)\,\left({w_{1}}^{2}\,{L_{1}}\,\left({m_{1}}+{m_{2}}\right)+g\,\left({m_{1}}+{m_{2}}\right)\,\cos\left({θ_{1}}\right)+{w_{2}}^{2}\,{L_{2}}\,{m_{2}}\,\cos\left({θ_{1}}-{θ_{2}}\right)\right)}{{L_{2}}\,\left(2\,{m_{1}}+{m_{2}}-{m_{2}}\,\cos\left(2\,{θ_{1}}-2\,{θ_{2}}\right)\right)}
+           \resizeExpression{{α_{2}}\left({θ_{1}},{θ_{2}},{w_{1}},{w_{2}}\right)=\frac{2\,\sin\left({θ_{1}}-{θ_{2}}\right)\,\left({w_{1}}^{2}\,{L_{1}}\,\left({m_{1}}+{m_{2}}\right)+g\,\left({m_{1}}+{m_{2}}\right)\,\cos\left({θ_{1}}\right)+{w_{2}}^{2}\,{L_{2}}\,{m_{2}}\,\cos\left({θ_{1}}-{θ_{2}}\right)\right)}{{L_{2}}\,\left(2\,{m_{1}}+{m_{2}}-{m_{2}}\,\cos\left(2\,{θ_{1}}-2\,{θ_{2}}\right)\right)}}{0.8}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -1440,39 +1451,39 @@ RefBy & \hyperref[outputValues]{FR:Output-Values}, \hyperref[calcAng]{FR:Calcula
 By solving equations \hyperref[GD:xForce2]{GD:xForce2} and \hyperref[GD:yForce2]{GD:yForce2} for ${\symbf{T}_{2}}\,\sin\left({θ_{2}}\right)$ and ${\symbf{T}_{2}}\,\cos\left({θ_{2}}\right)$ and then substituting into equation \hyperref[GD:xForce1]{GD:xForce1} and \hyperref[GD:yForce1]{GD:yForce1} , We can get equations 1 and 2:
 
 \begin{displaymath}
-{m_{1}}\,{a_{\text{x}1}}=-{\symbf{T}_{1}}\,\sin\left({θ_{1}}\right)-{m_{2}}\,{a_{\text{x}2}}
+\resizeExpression{{m_{1}}\,{a_{\text{x}1}}=-{\symbf{T}_{1}}\,\sin\left({θ_{1}}\right)-{m_{2}}\,{a_{\text{x}2}}}{1.0}
 \end{displaymath}
 
 \begin{displaymath}
-{m_{1}}\,{a_{\text{y}1}}={\symbf{T}_{1}}\,\cos\left({θ_{1}}\right)-{m_{2}}\,{a_{\text{y}2}}-{m_{2}}\,g-{m_{1}}\,g
+\resizeExpression{{m_{1}}\,{a_{\text{y}1}}={\symbf{T}_{1}}\,\cos\left({θ_{1}}\right)-{m_{2}}\,{a_{\text{y}2}}-{m_{2}}\,g-{m_{1}}\,g}{1.0}
 \end{displaymath}
 Multiply the equation 1 by $\cos\left({θ_{1}}\right)$ and the equation 2 by $\sin\left({θ_{1}}\right)$ and rearrange to get:
 
 \begin{displaymath}
-{\symbf{T}_{1}}\,\sin\left({θ_{1}}\right)\,\cos\left({θ_{1}}\right)=-\cos\left({θ_{1}}\right)\,\left({m_{1}}\,{a_{\text{x}1}}+{m_{2}}\,{a_{\text{x}2}}\right)
+\resizeExpression{{\symbf{T}_{1}}\,\sin\left({θ_{1}}\right)\,\cos\left({θ_{1}}\right)=-\cos\left({θ_{1}}\right)\,\left({m_{1}}\,{a_{\text{x}1}}+{m_{2}}\,{a_{\text{x}2}}\right)}{1.0}
 \end{displaymath}
 
 \begin{displaymath}
-{\symbf{T}_{1}}\,\sin\left({θ_{1}}\right)\,\cos\left({θ_{1}}\right)=\sin\left({θ_{1}}\right)\,\left({m_{1}}\,{a_{\text{y}1}}+{m_{2}}\,{a_{\text{y}2}}+{m_{2}}\,g+{m_{1}}\,g\right)
+\resizeExpression{{\symbf{T}_{1}}\,\sin\left({θ_{1}}\right)\,\cos\left({θ_{1}}\right)=\sin\left({θ_{1}}\right)\,\left({m_{1}}\,{a_{\text{y}1}}+{m_{2}}\,{a_{\text{y}2}}+{m_{2}}\,g+{m_{1}}\,g\right)}{1.0}
 \end{displaymath}
 This leads to the equation 3
 
 \begin{displaymath}
-\sin\left({θ_{1}}\right)\,\left({m_{1}}\,{a_{\text{y}1}}+{m_{2}}\,{a_{\text{y}2}}+{m_{2}}\,g+{m_{1}}\,g\right)=-\cos\left({θ_{1}}\right)\,\left({m_{1}}\,{a_{\text{x}1}}+{m_{2}}\,{a_{\text{x}2}}\right)
+\resizeExpression{\sin\left({θ_{1}}\right)\,\left({m_{1}}\,{a_{\text{y}1}}+{m_{2}}\,{a_{\text{y}2}}+{m_{2}}\,g+{m_{1}}\,g\right)=-\cos\left({θ_{1}}\right)\,\left({m_{1}}\,{a_{\text{x}1}}+{m_{2}}\,{a_{\text{x}2}}\right)}{1.0}
 \end{displaymath}
 Next, multiply equation \hyperref[GD:xForce2]{GD:xForce2} by $\cos\left({θ_{2}}\right)$ and equation \hyperref[GD:yForce2]{GD:yForce2} by $\sin\left({θ_{2}}\right)$ and rearrange to get:
 
 \begin{displaymath}
-{\symbf{T}_{2}}\,\sin\left({θ_{2}}\right)\,\cos\left({θ_{2}}\right)=-\cos\left({θ_{2}}\right)\,{m_{2}}\,{a_{\text{x}2}}
+\resizeExpression{{\symbf{T}_{2}}\,\sin\left({θ_{2}}\right)\,\cos\left({θ_{2}}\right)=-\cos\left({θ_{2}}\right)\,{m_{2}}\,{a_{\text{x}2}}}{1.0}
 \end{displaymath}
 
 \begin{displaymath}
-{\symbf{T}_{1}}\,\sin\left({θ_{2}}\right)\,\cos\left({θ_{2}}\right)=\sin\left({θ_{2}}\right)\,\left({m_{2}}\,{a_{\text{y}2}}+{m_{2}}\,g\right)
+\resizeExpression{{\symbf{T}_{1}}\,\sin\left({θ_{2}}\right)\,\cos\left({θ_{2}}\right)=\sin\left({θ_{2}}\right)\,\left({m_{2}}\,{a_{\text{y}2}}+{m_{2}}\,g\right)}{1.0}
 \end{displaymath}
 which leads to equation 4
 
 \begin{displaymath}
-\sin\left({θ_{2}}\right)\,\left({m_{2}}\,{a_{\text{y}2}}+{m_{2}}\,g\right)=-\cos\left({θ_{2}}\right)\,{m_{2}}\,{a_{\text{x}2}}
+\resizeExpression{\sin\left({θ_{2}}\right)\,\left({m_{2}}\,{a_{\text{y}2}}+{m_{2}}\,g\right)=-\cos\left({θ_{2}}\right)\,{m_{2}}\,{a_{\text{x}2}}}{1.0}
 \end{displaymath}
 By giving equations \hyperref[GD:accelerationX1]{GD:accelerationX1} and \hyperref[GD:accelerationX2]{GD:accelerationX2} and \hyperref[GD:accelerationY1]{GD:accelerationY1} and \hyperref[GD:accelerationY2]{GD:accelerationY2} plus additional two equations, 3 and 4, we can get \hyperref[IM:calOfAngle1]{IM:calOfAngle1} and \hyperref[IM:calOfAngle2]{IM:calOfAngle2} via a computer algebra program:
 

--- a/code/stable/dblpend/SRS/PDF/DblPend_SRS.tex
+++ b/code/stable/dblpend/SRS/PDF/DblPend_SRS.tex
@@ -27,12 +27,12 @@
 \setlist[symbDescription]{noitemsep, topsep=0pt, parsep=0pt, partopsep=0pt}
 \newsavebox{\mybox}
 \newcommand{\resizeExpression}[2]{
-\savebox{\mybox}{$#1$}
-\ifdim\wd\mybox>#2\linewidth
-\resizebox{#2\textwidth}{!}{\usebox{\mybox}}
-\else
-\usebox{\mybox}
-\fi
+  \savebox{\mybox}{$#1$}
+  \ifdim\wd\mybox>#2\linewidth
+    \resizebox{#2\textwidth}{!}{\usebox{\mybox}}
+  \else
+    \usebox{\mybox}
+  \fi
 }
 \bibliography{bibfile}
 \title{Software Requirements Specification for Double Pendulum}

--- a/code/stable/gamephysics/SRS/PDF/GamePhysics_SRS.tex
+++ b/code/stable/gamephysics/SRS/PDF/GamePhysics_SRS.tex
@@ -15,6 +15,8 @@
 \usepackage{svg}
 \usepackage{float}
 \usepackage{enumitem}
+\usepackage{graphicx}
+\usepackage{calc}
 \usepackage{filecontents}
 \usepackage[backend=bibtex]{biblatex}
 \usepackage{url}
@@ -23,6 +25,15 @@
 \newcommand{\lt}{\ensuremath <}
 \newlist{symbDescription}{description}{1}
 \setlist[symbDescription]{noitemsep, topsep=0pt, parsep=0pt, partopsep=0pt}
+\newsavebox{\mybox}
+\newcommand{\resizeExpression}[2]{
+\savebox{\mybox}{$#1$}
+\ifdim\wd\mybox>#2\linewidth
+\resizebox{#2\textwidth}{!}{\usebox{\mybox}}
+\else
+\usebox{\mybox}
+\fi
+}
 \bibliography{bibfile}
 \title{Software Requirements Specification for GamePhysics}
 \author{Alex Halliwushka, Luthfi Mawarid, and Olu Owojaiye}
@@ -368,7 +379,7 @@ Label & Newton's second law of motion
         
 \\ \midrule
 Equation & \begin{displaymath}
-           \symbf{F}=m\,\symbf{a}\text{(}t\text{)}
+           \resizeExpression{\symbf{F}=m\,\symbf{a}\text{(}t\text{)}}{0.8}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -401,7 +412,7 @@ Label & Newton's third law of motion
         
 \\ \midrule
 Equation & \begin{displaymath}
-           {\symbf{F}_{1}}=-{\symbf{F}_{2}}
+           \resizeExpression{{\symbf{F}_{1}}=-{\symbf{F}_{2}}}{0.8}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -432,7 +443,7 @@ Label & Newton's law of universal gravitation
         
 \\ \midrule
 Equation & \begin{displaymath}
-           \symbf{F}=G\,\frac{{m_{1}}\,{m_{2}}}{\|\symbf{d}\|^{2}}\,\symbf{\hat{d}}=G\,\frac{{m_{1}}\,{m_{2}}}{\|\symbf{d}\|^{2}}\,\frac{\symbf{d}}{\|\symbf{d}\|}
+           \resizeExpression{\symbf{F}=G\,\frac{{m_{1}}\,{m_{2}}}{\|\symbf{d}\|^{2}}\,\symbf{\hat{d}}=G\,\frac{{m_{1}}\,{m_{2}}}{\|\symbf{d}\|^{2}}\,\frac{\symbf{d}}{\|\symbf{d}\|}}{0.8}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -469,7 +480,7 @@ Label & Newton's second law for rotational motion
         
 \\ \midrule
 Equation & \begin{displaymath}
-           \symbf{τ}=\symbf{I}\,α
+           \resizeExpression{\symbf{τ}=\symbf{I}\,α}{0.8}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -511,7 +522,7 @@ Units & $\frac{\text{m}}{\text{s}^{2}}$
         
 \\ \midrule
 Equation & \begin{displaymath}
-           \symbf{g}=-\frac{G\,M}{\|\symbf{d}\|^{2}}\,\symbf{\hat{d}}
+           \resizeExpression{\symbf{g}=-\frac{G\,M}{\|\symbf{d}\|^{2}}\,\symbf{\hat{d}}}{0.8}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -539,27 +550,27 @@ RefBy & \hyperref[IM:transMot]{IM:transMot}
 From \hyperref[TM:UniversalGravLaw]{Newton's law of universal gravitation}, we have:
 
 \begin{displaymath}
-\symbf{F}=\frac{G\,{m_{1}}\,{m_{2}}}{{\|\symbf{d}\|^{2}}}\,\symbf{\hat{d}}
+\resizeExpression{\symbf{F}=\frac{G\,{m_{1}}\,{m_{2}}}{{\|\symbf{d}\|^{2}}}\,\symbf{\hat{d}}}{1.0}
 \end{displaymath}
 The above equation governs the gravitational attraction between two bodies. Suppose that one of the bodies is significantly more massive than the other, so that we concern ourselves with the force the massive body exerts on the lighter body. Further, suppose that the Cartesian coordinate system is chosen such that this force acts on a line which lies along one of the principal axes. Then our unit vector directed from the center of the large mass to the center of the smaller mass $\symbf{\hat{d}}$ for the x or y axes is:
 
 \begin{displaymath}
-\symbf{\hat{d}}=\frac{\symbf{d}}{\|\symbf{d}\|}
+\resizeExpression{\symbf{\hat{d}}=\frac{\symbf{d}}{\|\symbf{d}\|}}{1.0}
 \end{displaymath}
 Given the above assumptions, let $M$ and $m$ be the mass of the massive and light body respectively. Equating $\symbf{F}$ above with Newton's second law for the force experienced by the light body, we get:
 
 \begin{displaymath}
-{\symbf{F}_{\symbf{g}}}=G\,\frac{M\,m}{{\|\symbf{d}\|^{2}}}\,\symbf{\hat{d}}=m\,\symbf{g}
+\resizeExpression{{\symbf{F}_{\symbf{g}}}=G\,\frac{M\,m}{{\|\symbf{d}\|^{2}}}\,\symbf{\hat{d}}=m\,\symbf{g}}{1.0}
 \end{displaymath}
 where $\symbf{g}$ is the gravitational acceleration. Dividing the above equation by $m$,  we have:
 
 \begin{displaymath}
-G\,\frac{M}{{\|\symbf{d}\|^{2}}}\,\symbf{\hat{d}}=\symbf{g}
+\resizeExpression{G\,\frac{M}{{\|\symbf{d}\|^{2}}}\,\symbf{\hat{d}}=\symbf{g}}{1.0}
 \end{displaymath}
 and thus the negative sign indicates that the force is an attractive force:
 
 \begin{displaymath}
-\symbf{g}=-G\,\frac{M}{{\|\symbf{d}\|^{2}}}\,\symbf{\hat{d}}
+\resizeExpression{\symbf{g}=-G\,\frac{M}{{\|\symbf{d}\|^{2}}}\,\symbf{\hat{d}}}{1.0}
 \end{displaymath}
 \medskip
 \noindent
@@ -576,7 +587,7 @@ Units & $\text{N}\text{s}$
         
 \\ \midrule
 Equation & \begin{displaymath}
-           j=\frac{-\left(1+{C_{\text{R}}}\right)\,{{\symbf{v}\text{(}t\text{)}_{\text{i}}}^{\text{A}\text{B}}}\cdot{}\symbf{n}}{\left(\frac{1}{{m_{\text{A}}}}+\frac{1}{{m_{\text{B}}}}\right)\,\|\symbf{n}\|^{2}+\frac{\|{\symbf{u}_{\text{A}\text{P}}}\text{*}\symbf{n}\|^{2}}{{\symbf{I}_{\text{A}}}}+\frac{\|{\symbf{u}_{\text{B}\text{P}}}\text{*}\symbf{n}\|^{2}}{{\symbf{I}_{\text{B}}}}}
+           \resizeExpression{j=\frac{-\left(1+{C_{\text{R}}}\right)\,{{\symbf{v}\text{(}t\text{)}_{\text{i}}}^{\text{A}\text{B}}}\cdot{}\symbf{n}}{\left(\frac{1}{{m_{\text{A}}}}+\frac{1}{{m_{\text{B}}}}\right)\,\|\symbf{n}\|^{2}+\frac{\|{\symbf{u}_{\text{A}\text{P}}}\text{*}\symbf{n}\|^{2}}{{\symbf{I}_{\text{A}}}}+\frac{\|{\symbf{u}_{\text{B}\text{P}}}\text{*}\symbf{n}\|^{2}}{{\symbf{I}_{\text{B}}}}}}{0.8}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -631,7 +642,7 @@ Units & ${\text{m}}$
         
 \\ \midrule
 Equation & \begin{displaymath}
-           {\symbf{p}\text{(}t\text{)}_{\text{CM}}}=\frac{\displaystyle\sum{{m_{j}}\,{\symbf{p}\text{(}t\text{)}_{j}}}}{{m_{T}}}
+           \resizeExpression{{\symbf{p}\text{(}t\text{)}_{\text{CM}}}=\frac{\displaystyle\sum{{m_{j}}\,{\symbf{p}\text{(}t\text{)}_{j}}}}{{m_{T}}}}{0.8}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -671,7 +682,7 @@ Units & ${\text{m}}$
         
 \\ \midrule
 Equation & \begin{displaymath}
-           u\text{(}t\text{)}=\frac{\,d\symbf{p}\text{(}t\text{)}\left(t\right)}{\,dt}
+           \resizeExpression{u\text{(}t\text{)}=\frac{\,d\symbf{p}\text{(}t\text{)}\left(t\right)}{\,dt}}{0.8}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -710,7 +721,7 @@ Units & $\frac{\text{m}}{\text{s}}$
         
 \\ \midrule
 Equation & \begin{displaymath}
-           v\text{(}t\text{)}=\frac{\,d\symbf{u}\left(t\right)}{\,dt}
+           \resizeExpression{v\text{(}t\text{)}=\frac{\,d\symbf{u}\left(t\right)}{\,dt}}{0.8}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -749,7 +760,7 @@ Units & $\frac{\text{m}}{\text{s}^{2}}$
         
 \\ \midrule
 Equation & \begin{displaymath}
-           a\text{(}t\text{)}=\frac{\,d\symbf{v}\text{(}t\text{)}\left(t\right)}{\,dt}
+           \resizeExpression{a\text{(}t\text{)}=\frac{\,d\symbf{v}\text{(}t\text{)}\left(t\right)}{\,dt}}{0.8}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -788,7 +799,7 @@ Units & ${\text{rad}}$
         
 \\ \midrule
 Equation & \begin{displaymath}
-           θ=\frac{\,dϕ\left(t\right)}{\,dt}
+           \resizeExpression{θ=\frac{\,dϕ\left(t\right)}{\,dt}}{0.8}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -827,7 +838,7 @@ Units & $\frac{\text{rad}}{\text{s}}$
         
 \\ \midrule
 Equation & \begin{displaymath}
-           ω=\frac{\,dθ\left(t\right)}{\,dt}
+           \resizeExpression{ω=\frac{\,dθ\left(t\right)}{\,dt}}{0.8}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -866,7 +877,7 @@ Units & $\frac{\text{rad}}{\text{s}^{2}}$
         
 \\ \midrule
 Equation & \begin{displaymath}
-           α=\frac{\,dω\left(t\right)}{\,dt}
+           \resizeExpression{α=\frac{\,dω\left(t\right)}{\,dt}}{0.8}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -905,7 +916,7 @@ Units & $\frac{\text{m}}{\text{s}}$
         
 \\ \midrule
 Equation & \begin{displaymath}
-           {\symbf{v}\text{(}t\text{)}_{\text{B}}}={\symbf{v}\text{(}t\text{)}_{\text{O}}}+ω\times{\symbf{u}_{\text{O}\text{B}}}
+           \resizeExpression{{\symbf{v}\text{(}t\text{)}_{\text{B}}}={\symbf{v}\text{(}t\text{)}_{\text{O}}}+ω\times{\symbf{u}_{\text{O}\text{B}}}}{0.8}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -946,7 +957,7 @@ Units & $\text{N}\text{m}$
         
 \\ \midrule
 Equation & \begin{displaymath}
-           \symbf{τ}=\symbf{r}\times\symbf{F}
+           \resizeExpression{\symbf{τ}=\symbf{r}\times\symbf{F}}{0.8}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -984,7 +995,7 @@ Units & ${\text{J}}$
         
 \\ \midrule
 Equation & \begin{displaymath}
-           KE=m\,\frac{\|\symbf{v}\text{(}t\text{)}\|^{2}}{2}
+           \resizeExpression{KE=m\,\frac{\|\symbf{v}\text{(}t\text{)}\|^{2}}{2}}{0.8}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -1026,7 +1037,7 @@ Units & Unitless
         
 \\ \midrule
 Equation & \begin{displaymath}
-           {C_{\text{R}}}=-\left(\frac{{{\symbf{v}\text{(}t\text{)}_{\text{f}}}^{\text{A}\text{B}}}\cdot{}\symbf{n}}{{{\symbf{v}\text{(}t\text{)}_{\text{i}}}^{\text{A}\text{B}}}\cdot{}\symbf{n}}\right)
+           \resizeExpression{{C_{\text{R}}}=-\left(\frac{{{\symbf{v}\text{(}t\text{)}_{\text{f}}}^{\text{A}\text{B}}}\cdot{}\symbf{n}}{{{\symbf{v}\text{(}t\text{)}_{\text{i}}}^{\text{A}\text{B}}}\cdot{}\symbf{n}}\right)}{0.8}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -1065,7 +1076,7 @@ Units & $\frac{\text{m}}{\text{s}}$
         
 \\ \midrule
 Equation & \begin{displaymath}
-           {{\symbf{v}\text{(}t\text{)}_{\text{i}}}^{\text{A}\text{B}}}={\symbf{v}\text{(}t\text{)}^{\text{A}\text{P}}}-{\symbf{v}\text{(}t\text{)}^{\text{B}\text{P}}}
+           \resizeExpression{{{\symbf{v}\text{(}t\text{)}_{\text{i}}}^{\text{A}\text{B}}}={\symbf{v}\text{(}t\text{)}^{\text{A}\text{P}}}-{\symbf{v}\text{(}t\text{)}^{\text{B}\text{P}}}}{0.8}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -1105,7 +1116,7 @@ Units & $\text{N}\text{s}$
         
 \\ \midrule
 Equation & \begin{displaymath}
-           \symbf{J}=m\,Δ\symbf{v}
+           \resizeExpression{\symbf{J}=m\,Δ\symbf{v}}{0.8}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -1132,17 +1143,17 @@ RefBy &
 Newton's second law of motion states:
 
 \begin{displaymath}
-\symbf{F}=m\,\symbf{a}\text{(}t\text{)}=m\,\frac{\,d\symbf{v}\text{(}t\text{)}}{\,dt}
+\resizeExpression{\symbf{F}=m\,\symbf{a}\text{(}t\text{)}=m\,\frac{\,d\symbf{v}\text{(}t\text{)}}{\,dt}}{1.0}
 \end{displaymath}
 Rearranging:
 
 \begin{displaymath}
-\int_{{t_{1}}}^{{t_{2}}}{\symbf{F}}\,dt=m\,\left(\int_{{\symbf{v}\text{(}t\text{)}_{1}}}^{{\symbf{v}\text{(}t\text{)}_{2}}}{1}\,d\symbf{v}\text{(}t\text{)}\right)
+\resizeExpression{\int_{{t_{1}}}^{{t_{2}}}{\symbf{F}}\,dt=m\,\left(\int_{{\symbf{v}\text{(}t\text{)}_{1}}}^{{\symbf{v}\text{(}t\text{)}_{2}}}{1}\,d\symbf{v}\text{(}t\text{)}\right)}{1.0}
 \end{displaymath}
 Integrating the right hand side:
 
 \begin{displaymath}
-\int_{{t_{1}}}^{{t_{2}}}{\symbf{F}}\,dt=m\,{\symbf{v}\text{(}t\text{)}_{2}}-m\,{\symbf{v}\text{(}t\text{)}_{1}}=m\,Δ\symbf{v}
+\resizeExpression{\int_{{t_{1}}}^{{t_{2}}}{\symbf{F}}\,dt=m\,{\symbf{v}\text{(}t\text{)}_{2}}-m\,{\symbf{v}\text{(}t\text{)}_{1}}=m\,Δ\symbf{v}}{1.0}
 \end{displaymath}
 \medskip
 \noindent
@@ -1162,7 +1173,7 @@ Units & ${\text{J}}$
         
 \\ \midrule
 Equation & \begin{displaymath}
-           PE=m\,\symbf{g}\,h
+           \resizeExpression{PE=m\,\symbf{g}\,h}{0.8}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -1205,7 +1216,7 @@ Units & $\text{kg}\text{m}^{2}$
         
 \\ \midrule
 Equation & \begin{displaymath}
-           \symbf{I}=\displaystyle\sum{{m_{j}}\,{d_{j}}^{2}}
+           \resizeExpression{\symbf{I}=\displaystyle\sum{{m_{j}}\,{d_{j}}^{2}}}{0.8}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -1251,25 +1262,25 @@ Output & ${\symbf{a}\text{(}t\text{)}_{j}}$
          
 \\ \midrule
 Input Constraints & \begin{displaymath}
-                    {\symbf{v}\text{(}t\text{)}_{j}}\gt{}0
+                    \resizeExpression{{\symbf{v}\text{(}t\text{)}_{j}}\gt{}0}{0.8}
                     \end{displaymath}
                     \begin{displaymath}
-                    t\gt{}0
+                    \resizeExpression{t\gt{}0}{0.8}
                     \end{displaymath}
                     \begin{displaymath}
-                    \symbf{g}\gt{}0
+                    \resizeExpression{\symbf{g}\gt{}0}{0.8}
                     \end{displaymath}
                     \begin{displaymath}
-                    {\symbf{F}_{j}}\gt{}0
+                    \resizeExpression{{\symbf{F}_{j}}\gt{}0}{0.8}
                     \end{displaymath}
                     \begin{displaymath}
-                    {m_{j}}\gt{}0
+                    \resizeExpression{{m_{j}}\gt{}0}{0.8}
                     \end{displaymath}
 \\ \midrule
 Output Constraints & 
 \\ \midrule
 Equation & \begin{displaymath}
-           {\symbf{a}\text{(}t\text{)}_{j}}=\symbf{g}+\frac{{\symbf{F}_{j}}\left(t\right)}{{m_{j}}}
+           \resizeExpression{{\symbf{a}\text{(}t\text{)}_{j}}=\symbf{g}+\frac{{\symbf{F}_{j}}\left(t\right)}{{m_{j}}}}{0.8}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -1302,12 +1313,12 @@ RefBy &
 We may calculate the total acceleration of rigid body $j$ by calculating the derivative of it's velocity with respect to time (from \hyperref[DD:linAcc]{DD:linAcc}).
 
 \begin{displaymath}
-{α_{j}}=\frac{\,d{\symbf{v}\text{(}t\text{)}_{j}}\left(t\right)}{\,dt}
+\resizeExpression{{α_{j}}=\frac{\,d{\symbf{v}\text{(}t\text{)}_{j}}\left(t\right)}{\,dt}}{1.0}
 \end{displaymath}
 Performing the derivative, we obtain:
 
 \begin{displaymath}
-{\symbf{a}\text{(}t\text{)}_{j}}=\symbf{g}+\frac{{\symbf{F}_{j}}\left(t\right)}{{m_{j}}}
+\resizeExpression{{\symbf{a}\text{(}t\text{)}_{j}}=\symbf{g}+\frac{{\symbf{F}_{j}}\left(t\right)}{{m_{j}}}}{1.0}
 \end{displaymath}
 \medskip
 \noindent
@@ -1327,24 +1338,24 @@ Output & ${α_{j}}$
          
 \\ \midrule
 Input Constraints & \begin{displaymath}
-                    ω\gt{}0
+                    \resizeExpression{ω\gt{}0}{0.8}
                     \end{displaymath}
                     \begin{displaymath}
-                    t\gt{}0
+                    \resizeExpression{t\gt{}0}{0.8}
                     \end{displaymath}
                     \begin{displaymath}
-                    {\symbf{τ}_{j}}\gt{}0
+                    \resizeExpression{{\symbf{τ}_{j}}\gt{}0}{0.8}
                     \end{displaymath}
                     \begin{displaymath}
-                    \symbf{I}\gt{}0
+                    \resizeExpression{\symbf{I}\gt{}0}{0.8}
                     \end{displaymath}
 \\ \midrule
 Output Constraints & \begin{displaymath}
-                     {α_{j}}\gt{}0
+                     \resizeExpression{{α_{j}}\gt{}0}{0.8}
                      \end{displaymath}
 \\ \midrule
 Equation & \begin{displaymath}
-           {α_{j}}=\frac{{\symbf{τ}_{j}}\left(t\right)}{\symbf{I}}
+           \resizeExpression{{α_{j}}=\frac{{\symbf{τ}_{j}}\left(t\right)}{\symbf{I}}}{0.8}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -1374,12 +1385,12 @@ RefBy &
 We may calculate the total angular acceleration of rigid body $j$ by calculating the derivative of its angular velocity with respect to time (from \hyperref[DD:angAccel]{DD:angAccel}).
 
 \begin{displaymath}
-{α_{j}}=\frac{\,dω\left(t\right)}{\,dt}
+\resizeExpression{{α_{j}}=\frac{\,dω\left(t\right)}{\,dt}}{1.0}
 \end{displaymath}
 Performing the derivative, we obtain:
 
 \begin{displaymath}
-{α_{j}}=\frac{{\symbf{τ}_{j}}\left(t\right)}{\symbf{I}}
+\resizeExpression{{α_{j}}=\frac{{\symbf{τ}_{j}}\left(t\right)}{\symbf{I}}}{1.0}
 \end{displaymath}
 \medskip
 \noindent
@@ -1399,24 +1410,24 @@ Output & ${t_{\text{c}}}$
          
 \\ \midrule
 Input Constraints & \begin{displaymath}
-                    t\gt{}0
+                    \resizeExpression{t\gt{}0}{0.8}
                     \end{displaymath}
                     \begin{displaymath}
-                    j\gt{}0
+                    \resizeExpression{j\gt{}0}{0.8}
                     \end{displaymath}
                     \begin{displaymath}
-                    {m_{\text{A}}}\gt{}0
+                    \resizeExpression{{m_{\text{A}}}\gt{}0}{0.8}
                     \end{displaymath}
                     \begin{displaymath}
-                    \symbf{n}\gt{}0
+                    \resizeExpression{\symbf{n}\gt{}0}{0.8}
                     \end{displaymath}
 \\ \midrule
 Output Constraints & \begin{displaymath}
-                     {t_{\text{c}}}\gt{}0
+                     \resizeExpression{{t_{\text{c}}}\gt{}0}{0.8}
                      \end{displaymath}
 \\ \midrule
 Equation & \begin{displaymath}
-           {\symbf{v}\text{(}t\text{)}_{\text{A}}}\left({t_{\text{c}}}\right)={\symbf{v}\text{(}t\text{)}_{\text{A}}}\left(t\right)+\frac{j}{{m_{\text{A}}}}\,\symbf{n}
+           \resizeExpression{{\symbf{v}\text{(}t\text{)}_{\text{A}}}\left({t_{\text{c}}}\right)={\symbf{v}\text{(}t\text{)}_{\text{A}}}\left(t\right)+\frac{j}{{m_{\text{A}}}}\,\symbf{n}}{0.8}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}

--- a/code/stable/gamephysics/SRS/PDF/GamePhysics_SRS.tex
+++ b/code/stable/gamephysics/SRS/PDF/GamePhysics_SRS.tex
@@ -25,6 +25,8 @@
 \newcommand{\lt}{\ensuremath <}
 \newlist{symbDescription}{description}{1}
 \setlist[symbDescription]{noitemsep, topsep=0pt, parsep=0pt, partopsep=0pt}
+\def\inDefScale{0.8}
+\def\outDefScale{1.0}
 \newsavebox{\mybox}
 \newcommand{\resizeExpression}[2]{
   \savebox{\mybox}{$#1$}
@@ -379,7 +381,7 @@ Label & Newton's second law of motion
         
 \\ \midrule
 Equation & \begin{displaymath}
-           \resizeExpression{\symbf{F}=m\,\symbf{a}\text{(}t\text{)}}{0.8}
+           \resizeExpression{\symbf{F}=m\,\symbf{a}\text{(}t\text{)}}{\inDefScale}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -412,7 +414,7 @@ Label & Newton's third law of motion
         
 \\ \midrule
 Equation & \begin{displaymath}
-           \resizeExpression{{\symbf{F}_{1}}=-{\symbf{F}_{2}}}{0.8}
+           \resizeExpression{{\symbf{F}_{1}}=-{\symbf{F}_{2}}}{\inDefScale}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -443,7 +445,7 @@ Label & Newton's law of universal gravitation
         
 \\ \midrule
 Equation & \begin{displaymath}
-           \resizeExpression{\symbf{F}=G\,\frac{{m_{1}}\,{m_{2}}}{\|\symbf{d}\|^{2}}\,\symbf{\hat{d}}=G\,\frac{{m_{1}}\,{m_{2}}}{\|\symbf{d}\|^{2}}\,\frac{\symbf{d}}{\|\symbf{d}\|}}{0.8}
+           \resizeExpression{\symbf{F}=G\,\frac{{m_{1}}\,{m_{2}}}{\|\symbf{d}\|^{2}}\,\symbf{\hat{d}}=G\,\frac{{m_{1}}\,{m_{2}}}{\|\symbf{d}\|^{2}}\,\frac{\symbf{d}}{\|\symbf{d}\|}}{\inDefScale}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -480,7 +482,7 @@ Label & Newton's second law for rotational motion
         
 \\ \midrule
 Equation & \begin{displaymath}
-           \resizeExpression{\symbf{τ}=\symbf{I}\,α}{0.8}
+           \resizeExpression{\symbf{τ}=\symbf{I}\,α}{\inDefScale}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -522,7 +524,7 @@ Units & $\frac{\text{m}}{\text{s}^{2}}$
         
 \\ \midrule
 Equation & \begin{displaymath}
-           \resizeExpression{\symbf{g}=-\frac{G\,M}{\|\symbf{d}\|^{2}}\,\symbf{\hat{d}}}{0.8}
+           \resizeExpression{\symbf{g}=-\frac{G\,M}{\|\symbf{d}\|^{2}}\,\symbf{\hat{d}}}{\inDefScale}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -550,27 +552,27 @@ RefBy & \hyperref[IM:transMot]{IM:transMot}
 From \hyperref[TM:UniversalGravLaw]{Newton's law of universal gravitation}, we have:
 
 \begin{displaymath}
-\resizeExpression{\symbf{F}=\frac{G\,{m_{1}}\,{m_{2}}}{{\|\symbf{d}\|^{2}}}\,\symbf{\hat{d}}}{1.0}
+\resizeExpression{\symbf{F}=\frac{G\,{m_{1}}\,{m_{2}}}{{\|\symbf{d}\|^{2}}}\,\symbf{\hat{d}}}{\outDefScale}
 \end{displaymath}
 The above equation governs the gravitational attraction between two bodies. Suppose that one of the bodies is significantly more massive than the other, so that we concern ourselves with the force the massive body exerts on the lighter body. Further, suppose that the Cartesian coordinate system is chosen such that this force acts on a line which lies along one of the principal axes. Then our unit vector directed from the center of the large mass to the center of the smaller mass $\symbf{\hat{d}}$ for the x or y axes is:
 
 \begin{displaymath}
-\resizeExpression{\symbf{\hat{d}}=\frac{\symbf{d}}{\|\symbf{d}\|}}{1.0}
+\resizeExpression{\symbf{\hat{d}}=\frac{\symbf{d}}{\|\symbf{d}\|}}{\outDefScale}
 \end{displaymath}
 Given the above assumptions, let $M$ and $m$ be the mass of the massive and light body respectively. Equating $\symbf{F}$ above with Newton's second law for the force experienced by the light body, we get:
 
 \begin{displaymath}
-\resizeExpression{{\symbf{F}_{\symbf{g}}}=G\,\frac{M\,m}{{\|\symbf{d}\|^{2}}}\,\symbf{\hat{d}}=m\,\symbf{g}}{1.0}
+\resizeExpression{{\symbf{F}_{\symbf{g}}}=G\,\frac{M\,m}{{\|\symbf{d}\|^{2}}}\,\symbf{\hat{d}}=m\,\symbf{g}}{\outDefScale}
 \end{displaymath}
 where $\symbf{g}$ is the gravitational acceleration. Dividing the above equation by $m$,  we have:
 
 \begin{displaymath}
-\resizeExpression{G\,\frac{M}{{\|\symbf{d}\|^{2}}}\,\symbf{\hat{d}}=\symbf{g}}{1.0}
+\resizeExpression{G\,\frac{M}{{\|\symbf{d}\|^{2}}}\,\symbf{\hat{d}}=\symbf{g}}{\outDefScale}
 \end{displaymath}
 and thus the negative sign indicates that the force is an attractive force:
 
 \begin{displaymath}
-\resizeExpression{\symbf{g}=-G\,\frac{M}{{\|\symbf{d}\|^{2}}}\,\symbf{\hat{d}}}{1.0}
+\resizeExpression{\symbf{g}=-G\,\frac{M}{{\|\symbf{d}\|^{2}}}\,\symbf{\hat{d}}}{\outDefScale}
 \end{displaymath}
 \medskip
 \noindent
@@ -587,7 +589,7 @@ Units & $\text{N}\text{s}$
         
 \\ \midrule
 Equation & \begin{displaymath}
-           \resizeExpression{j=\frac{-\left(1+{C_{\text{R}}}\right)\,{{\symbf{v}\text{(}t\text{)}_{\text{i}}}^{\text{A}\text{B}}}\cdot{}\symbf{n}}{\left(\frac{1}{{m_{\text{A}}}}+\frac{1}{{m_{\text{B}}}}\right)\,\|\symbf{n}\|^{2}+\frac{\|{\symbf{u}_{\text{A}\text{P}}}\text{*}\symbf{n}\|^{2}}{{\symbf{I}_{\text{A}}}}+\frac{\|{\symbf{u}_{\text{B}\text{P}}}\text{*}\symbf{n}\|^{2}}{{\symbf{I}_{\text{B}}}}}}{0.8}
+           \resizeExpression{j=\frac{-\left(1+{C_{\text{R}}}\right)\,{{\symbf{v}\text{(}t\text{)}_{\text{i}}}^{\text{A}\text{B}}}\cdot{}\symbf{n}}{\left(\frac{1}{{m_{\text{A}}}}+\frac{1}{{m_{\text{B}}}}\right)\,\|\symbf{n}\|^{2}+\frac{\|{\symbf{u}_{\text{A}\text{P}}}\text{*}\symbf{n}\|^{2}}{{\symbf{I}_{\text{A}}}}+\frac{\|{\symbf{u}_{\text{B}\text{P}}}\text{*}\symbf{n}\|^{2}}{{\symbf{I}_{\text{B}}}}}}{\inDefScale}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -642,7 +644,7 @@ Units & ${\text{m}}$
         
 \\ \midrule
 Equation & \begin{displaymath}
-           \resizeExpression{{\symbf{p}\text{(}t\text{)}_{\text{CM}}}=\frac{\displaystyle\sum{{m_{j}}\,{\symbf{p}\text{(}t\text{)}_{j}}}}{{m_{T}}}}{0.8}
+           \resizeExpression{{\symbf{p}\text{(}t\text{)}_{\text{CM}}}=\frac{\displaystyle\sum{{m_{j}}\,{\symbf{p}\text{(}t\text{)}_{j}}}}{{m_{T}}}}{\inDefScale}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -682,7 +684,7 @@ Units & ${\text{m}}$
         
 \\ \midrule
 Equation & \begin{displaymath}
-           \resizeExpression{u\text{(}t\text{)}=\frac{\,d\symbf{p}\text{(}t\text{)}\left(t\right)}{\,dt}}{0.8}
+           \resizeExpression{u\text{(}t\text{)}=\frac{\,d\symbf{p}\text{(}t\text{)}\left(t\right)}{\,dt}}{\inDefScale}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -721,7 +723,7 @@ Units & $\frac{\text{m}}{\text{s}}$
         
 \\ \midrule
 Equation & \begin{displaymath}
-           \resizeExpression{v\text{(}t\text{)}=\frac{\,d\symbf{u}\left(t\right)}{\,dt}}{0.8}
+           \resizeExpression{v\text{(}t\text{)}=\frac{\,d\symbf{u}\left(t\right)}{\,dt}}{\inDefScale}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -760,7 +762,7 @@ Units & $\frac{\text{m}}{\text{s}^{2}}$
         
 \\ \midrule
 Equation & \begin{displaymath}
-           \resizeExpression{a\text{(}t\text{)}=\frac{\,d\symbf{v}\text{(}t\text{)}\left(t\right)}{\,dt}}{0.8}
+           \resizeExpression{a\text{(}t\text{)}=\frac{\,d\symbf{v}\text{(}t\text{)}\left(t\right)}{\,dt}}{\inDefScale}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -799,7 +801,7 @@ Units & ${\text{rad}}$
         
 \\ \midrule
 Equation & \begin{displaymath}
-           \resizeExpression{θ=\frac{\,dϕ\left(t\right)}{\,dt}}{0.8}
+           \resizeExpression{θ=\frac{\,dϕ\left(t\right)}{\,dt}}{\inDefScale}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -838,7 +840,7 @@ Units & $\frac{\text{rad}}{\text{s}}$
         
 \\ \midrule
 Equation & \begin{displaymath}
-           \resizeExpression{ω=\frac{\,dθ\left(t\right)}{\,dt}}{0.8}
+           \resizeExpression{ω=\frac{\,dθ\left(t\right)}{\,dt}}{\inDefScale}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -877,7 +879,7 @@ Units & $\frac{\text{rad}}{\text{s}^{2}}$
         
 \\ \midrule
 Equation & \begin{displaymath}
-           \resizeExpression{α=\frac{\,dω\left(t\right)}{\,dt}}{0.8}
+           \resizeExpression{α=\frac{\,dω\left(t\right)}{\,dt}}{\inDefScale}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -916,7 +918,7 @@ Units & $\frac{\text{m}}{\text{s}}$
         
 \\ \midrule
 Equation & \begin{displaymath}
-           \resizeExpression{{\symbf{v}\text{(}t\text{)}_{\text{B}}}={\symbf{v}\text{(}t\text{)}_{\text{O}}}+ω\times{\symbf{u}_{\text{O}\text{B}}}}{0.8}
+           \resizeExpression{{\symbf{v}\text{(}t\text{)}_{\text{B}}}={\symbf{v}\text{(}t\text{)}_{\text{O}}}+ω\times{\symbf{u}_{\text{O}\text{B}}}}{\inDefScale}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -957,7 +959,7 @@ Units & $\text{N}\text{m}$
         
 \\ \midrule
 Equation & \begin{displaymath}
-           \resizeExpression{\symbf{τ}=\symbf{r}\times\symbf{F}}{0.8}
+           \resizeExpression{\symbf{τ}=\symbf{r}\times\symbf{F}}{\inDefScale}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -995,7 +997,7 @@ Units & ${\text{J}}$
         
 \\ \midrule
 Equation & \begin{displaymath}
-           \resizeExpression{KE=m\,\frac{\|\symbf{v}\text{(}t\text{)}\|^{2}}{2}}{0.8}
+           \resizeExpression{KE=m\,\frac{\|\symbf{v}\text{(}t\text{)}\|^{2}}{2}}{\inDefScale}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -1037,7 +1039,7 @@ Units & Unitless
         
 \\ \midrule
 Equation & \begin{displaymath}
-           \resizeExpression{{C_{\text{R}}}=-\left(\frac{{{\symbf{v}\text{(}t\text{)}_{\text{f}}}^{\text{A}\text{B}}}\cdot{}\symbf{n}}{{{\symbf{v}\text{(}t\text{)}_{\text{i}}}^{\text{A}\text{B}}}\cdot{}\symbf{n}}\right)}{0.8}
+           \resizeExpression{{C_{\text{R}}}=-\left(\frac{{{\symbf{v}\text{(}t\text{)}_{\text{f}}}^{\text{A}\text{B}}}\cdot{}\symbf{n}}{{{\symbf{v}\text{(}t\text{)}_{\text{i}}}^{\text{A}\text{B}}}\cdot{}\symbf{n}}\right)}{\inDefScale}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -1076,7 +1078,7 @@ Units & $\frac{\text{m}}{\text{s}}$
         
 \\ \midrule
 Equation & \begin{displaymath}
-           \resizeExpression{{{\symbf{v}\text{(}t\text{)}_{\text{i}}}^{\text{A}\text{B}}}={\symbf{v}\text{(}t\text{)}^{\text{A}\text{P}}}-{\symbf{v}\text{(}t\text{)}^{\text{B}\text{P}}}}{0.8}
+           \resizeExpression{{{\symbf{v}\text{(}t\text{)}_{\text{i}}}^{\text{A}\text{B}}}={\symbf{v}\text{(}t\text{)}^{\text{A}\text{P}}}-{\symbf{v}\text{(}t\text{)}^{\text{B}\text{P}}}}{\inDefScale}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -1116,7 +1118,7 @@ Units & $\text{N}\text{s}$
         
 \\ \midrule
 Equation & \begin{displaymath}
-           \resizeExpression{\symbf{J}=m\,Δ\symbf{v}}{0.8}
+           \resizeExpression{\symbf{J}=m\,Δ\symbf{v}}{\inDefScale}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -1143,17 +1145,17 @@ RefBy &
 Newton's second law of motion states:
 
 \begin{displaymath}
-\resizeExpression{\symbf{F}=m\,\symbf{a}\text{(}t\text{)}=m\,\frac{\,d\symbf{v}\text{(}t\text{)}}{\,dt}}{1.0}
+\resizeExpression{\symbf{F}=m\,\symbf{a}\text{(}t\text{)}=m\,\frac{\,d\symbf{v}\text{(}t\text{)}}{\,dt}}{\outDefScale}
 \end{displaymath}
 Rearranging:
 
 \begin{displaymath}
-\resizeExpression{\int_{{t_{1}}}^{{t_{2}}}{\symbf{F}}\,dt=m\,\left(\int_{{\symbf{v}\text{(}t\text{)}_{1}}}^{{\symbf{v}\text{(}t\text{)}_{2}}}{1}\,d\symbf{v}\text{(}t\text{)}\right)}{1.0}
+\resizeExpression{\int_{{t_{1}}}^{{t_{2}}}{\symbf{F}}\,dt=m\,\left(\int_{{\symbf{v}\text{(}t\text{)}_{1}}}^{{\symbf{v}\text{(}t\text{)}_{2}}}{1}\,d\symbf{v}\text{(}t\text{)}\right)}{\outDefScale}
 \end{displaymath}
 Integrating the right hand side:
 
 \begin{displaymath}
-\resizeExpression{\int_{{t_{1}}}^{{t_{2}}}{\symbf{F}}\,dt=m\,{\symbf{v}\text{(}t\text{)}_{2}}-m\,{\symbf{v}\text{(}t\text{)}_{1}}=m\,Δ\symbf{v}}{1.0}
+\resizeExpression{\int_{{t_{1}}}^{{t_{2}}}{\symbf{F}}\,dt=m\,{\symbf{v}\text{(}t\text{)}_{2}}-m\,{\symbf{v}\text{(}t\text{)}_{1}}=m\,Δ\symbf{v}}{\outDefScale}
 \end{displaymath}
 \medskip
 \noindent
@@ -1173,7 +1175,7 @@ Units & ${\text{J}}$
         
 \\ \midrule
 Equation & \begin{displaymath}
-           \resizeExpression{PE=m\,\symbf{g}\,h}{0.8}
+           \resizeExpression{PE=m\,\symbf{g}\,h}{\inDefScale}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -1216,7 +1218,7 @@ Units & $\text{kg}\text{m}^{2}$
         
 \\ \midrule
 Equation & \begin{displaymath}
-           \resizeExpression{\symbf{I}=\displaystyle\sum{{m_{j}}\,{d_{j}}^{2}}}{0.8}
+           \resizeExpression{\symbf{I}=\displaystyle\sum{{m_{j}}\,{d_{j}}^{2}}}{\inDefScale}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -1262,25 +1264,25 @@ Output & ${\symbf{a}\text{(}t\text{)}_{j}}$
          
 \\ \midrule
 Input Constraints & \begin{displaymath}
-                    \resizeExpression{{\symbf{v}\text{(}t\text{)}_{j}}\gt{}0}{0.8}
+                    \resizeExpression{{\symbf{v}\text{(}t\text{)}_{j}}\gt{}0}{\inDefScale}
                     \end{displaymath}
                     \begin{displaymath}
-                    \resizeExpression{t\gt{}0}{0.8}
+                    \resizeExpression{t\gt{}0}{\inDefScale}
                     \end{displaymath}
                     \begin{displaymath}
-                    \resizeExpression{\symbf{g}\gt{}0}{0.8}
+                    \resizeExpression{\symbf{g}\gt{}0}{\inDefScale}
                     \end{displaymath}
                     \begin{displaymath}
-                    \resizeExpression{{\symbf{F}_{j}}\gt{}0}{0.8}
+                    \resizeExpression{{\symbf{F}_{j}}\gt{}0}{\inDefScale}
                     \end{displaymath}
                     \begin{displaymath}
-                    \resizeExpression{{m_{j}}\gt{}0}{0.8}
+                    \resizeExpression{{m_{j}}\gt{}0}{\inDefScale}
                     \end{displaymath}
 \\ \midrule
 Output Constraints & 
 \\ \midrule
 Equation & \begin{displaymath}
-           \resizeExpression{{\symbf{a}\text{(}t\text{)}_{j}}=\symbf{g}+\frac{{\symbf{F}_{j}}\left(t\right)}{{m_{j}}}}{0.8}
+           \resizeExpression{{\symbf{a}\text{(}t\text{)}_{j}}=\symbf{g}+\frac{{\symbf{F}_{j}}\left(t\right)}{{m_{j}}}}{\inDefScale}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -1313,12 +1315,12 @@ RefBy &
 We may calculate the total acceleration of rigid body $j$ by calculating the derivative of it's velocity with respect to time (from \hyperref[DD:linAcc]{DD:linAcc}).
 
 \begin{displaymath}
-\resizeExpression{{α_{j}}=\frac{\,d{\symbf{v}\text{(}t\text{)}_{j}}\left(t\right)}{\,dt}}{1.0}
+\resizeExpression{{α_{j}}=\frac{\,d{\symbf{v}\text{(}t\text{)}_{j}}\left(t\right)}{\,dt}}{\outDefScale}
 \end{displaymath}
 Performing the derivative, we obtain:
 
 \begin{displaymath}
-\resizeExpression{{\symbf{a}\text{(}t\text{)}_{j}}=\symbf{g}+\frac{{\symbf{F}_{j}}\left(t\right)}{{m_{j}}}}{1.0}
+\resizeExpression{{\symbf{a}\text{(}t\text{)}_{j}}=\symbf{g}+\frac{{\symbf{F}_{j}}\left(t\right)}{{m_{j}}}}{\outDefScale}
 \end{displaymath}
 \medskip
 \noindent
@@ -1338,24 +1340,24 @@ Output & ${α_{j}}$
          
 \\ \midrule
 Input Constraints & \begin{displaymath}
-                    \resizeExpression{ω\gt{}0}{0.8}
+                    \resizeExpression{ω\gt{}0}{\inDefScale}
                     \end{displaymath}
                     \begin{displaymath}
-                    \resizeExpression{t\gt{}0}{0.8}
+                    \resizeExpression{t\gt{}0}{\inDefScale}
                     \end{displaymath}
                     \begin{displaymath}
-                    \resizeExpression{{\symbf{τ}_{j}}\gt{}0}{0.8}
+                    \resizeExpression{{\symbf{τ}_{j}}\gt{}0}{\inDefScale}
                     \end{displaymath}
                     \begin{displaymath}
-                    \resizeExpression{\symbf{I}\gt{}0}{0.8}
+                    \resizeExpression{\symbf{I}\gt{}0}{\inDefScale}
                     \end{displaymath}
 \\ \midrule
 Output Constraints & \begin{displaymath}
-                     \resizeExpression{{α_{j}}\gt{}0}{0.8}
+                     \resizeExpression{{α_{j}}\gt{}0}{\inDefScale}
                      \end{displaymath}
 \\ \midrule
 Equation & \begin{displaymath}
-           \resizeExpression{{α_{j}}=\frac{{\symbf{τ}_{j}}\left(t\right)}{\symbf{I}}}{0.8}
+           \resizeExpression{{α_{j}}=\frac{{\symbf{τ}_{j}}\left(t\right)}{\symbf{I}}}{\inDefScale}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -1385,12 +1387,12 @@ RefBy &
 We may calculate the total angular acceleration of rigid body $j$ by calculating the derivative of its angular velocity with respect to time (from \hyperref[DD:angAccel]{DD:angAccel}).
 
 \begin{displaymath}
-\resizeExpression{{α_{j}}=\frac{\,dω\left(t\right)}{\,dt}}{1.0}
+\resizeExpression{{α_{j}}=\frac{\,dω\left(t\right)}{\,dt}}{\outDefScale}
 \end{displaymath}
 Performing the derivative, we obtain:
 
 \begin{displaymath}
-\resizeExpression{{α_{j}}=\frac{{\symbf{τ}_{j}}\left(t\right)}{\symbf{I}}}{1.0}
+\resizeExpression{{α_{j}}=\frac{{\symbf{τ}_{j}}\left(t\right)}{\symbf{I}}}{\outDefScale}
 \end{displaymath}
 \medskip
 \noindent
@@ -1410,24 +1412,24 @@ Output & ${t_{\text{c}}}$
          
 \\ \midrule
 Input Constraints & \begin{displaymath}
-                    \resizeExpression{t\gt{}0}{0.8}
+                    \resizeExpression{t\gt{}0}{\inDefScale}
                     \end{displaymath}
                     \begin{displaymath}
-                    \resizeExpression{j\gt{}0}{0.8}
+                    \resizeExpression{j\gt{}0}{\inDefScale}
                     \end{displaymath}
                     \begin{displaymath}
-                    \resizeExpression{{m_{\text{A}}}\gt{}0}{0.8}
+                    \resizeExpression{{m_{\text{A}}}\gt{}0}{\inDefScale}
                     \end{displaymath}
                     \begin{displaymath}
-                    \resizeExpression{\symbf{n}\gt{}0}{0.8}
+                    \resizeExpression{\symbf{n}\gt{}0}{\inDefScale}
                     \end{displaymath}
 \\ \midrule
 Output Constraints & \begin{displaymath}
-                     \resizeExpression{{t_{\text{c}}}\gt{}0}{0.8}
+                     \resizeExpression{{t_{\text{c}}}\gt{}0}{\inDefScale}
                      \end{displaymath}
 \\ \midrule
 Equation & \begin{displaymath}
-           \resizeExpression{{\symbf{v}\text{(}t\text{)}_{\text{A}}}\left({t_{\text{c}}}\right)={\symbf{v}\text{(}t\text{)}_{\text{A}}}\left(t\right)+\frac{j}{{m_{\text{A}}}}\,\symbf{n}}{0.8}
+           \resizeExpression{{\symbf{v}\text{(}t\text{)}_{\text{A}}}\left({t_{\text{c}}}\right)={\symbf{v}\text{(}t\text{)}_{\text{A}}}\left(t\right)+\frac{j}{{m_{\text{A}}}}\,\symbf{n}}{\inDefScale}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}

--- a/code/stable/gamephysics/SRS/PDF/GamePhysics_SRS.tex
+++ b/code/stable/gamephysics/SRS/PDF/GamePhysics_SRS.tex
@@ -27,12 +27,12 @@
 \setlist[symbDescription]{noitemsep, topsep=0pt, parsep=0pt, partopsep=0pt}
 \newsavebox{\mybox}
 \newcommand{\resizeExpression}[2]{
-\savebox{\mybox}{$#1$}
-\ifdim\wd\mybox>#2\linewidth
-\resizebox{#2\textwidth}{!}{\usebox{\mybox}}
-\else
-\usebox{\mybox}
-\fi
+  \savebox{\mybox}{$#1$}
+  \ifdim\wd\mybox>#2\linewidth
+    \resizebox{#2\textwidth}{!}{\usebox{\mybox}}
+  \else
+    \usebox{\mybox}
+  \fi
 }
 \bibliography{bibfile}
 \title{Software Requirements Specification for GamePhysics}

--- a/code/stable/glassbr/SRS/PDF/GlassBR_SRS.tex
+++ b/code/stable/glassbr/SRS/PDF/GlassBR_SRS.tex
@@ -15,6 +15,8 @@
 \usepackage{svg}
 \usepackage{float}
 \usepackage{enumitem}
+\usepackage{graphicx}
+\usepackage{calc}
 \usepackage{filecontents}
 \usepackage[backend=bibtex]{biblatex}
 \usepackage{url}
@@ -23,6 +25,15 @@
 \newcommand{\lt}{\ensuremath <}
 \newlist{symbDescription}{description}{1}
 \setlist[symbDescription]{noitemsep, topsep=0pt, parsep=0pt, partopsep=0pt}
+\newsavebox{\mybox}
+\newcommand{\resizeExpression}[2]{
+\savebox{\mybox}{$#1$}
+\ifdim\wd\mybox>#2\linewidth
+\resizebox{#2\textwidth}{!}{\usebox{\mybox}}
+\else
+\usebox{\mybox}
+\fi
+}
 \bibliography{bibfile}
 \title{Software Requirements Specification for GlassBR}
 \author{Nikitha Krithnan and W. Spencer Smith}
@@ -398,7 +409,7 @@ Label & Safety Probability
         
 \\ \midrule
 Equation & \begin{displaymath}
-           \mathit{isSafeProb}={P_{\text{f}}}\lt{}{P_{\text{f}\text{tol}}}
+           \resizeExpression{\mathit{isSafeProb}={P_{\text{f}}}\lt{}{P_{\text{f}\text{tol}}}}{0.8}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -430,7 +441,7 @@ Label & Safety Load
         
 \\ \midrule
 Equation & \begin{displaymath}
-           \mathit{isSafeLoad}=\mathit{capacity}\gt{}\mathit{Load}
+           \resizeExpression{\mathit{isSafeLoad}=\mathit{capacity}\gt{}\mathit{Load}}{0.8}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -476,20 +487,20 @@ Units & ${\text{m}}$
         
 \\ \midrule
 Equation & \begin{displaymath}
-           h=\frac{1}{1000}\,\begin{cases}
-                             2.16, & t=2.5\\
-                             2.59, & t=2.7\\
-                             2.92, & t=3.0\\
-                             3.78, & t=4.0\\
-                             4.57, & t=5.0\\
-                             5.56, & t=6.0\\
-                             7.42, & t=8.0\\
-                             9.02, & t=10.0\\
-                             11.91, & t=12.0\\
-                             15.09, & t=16.0\\
-                             18.26, & t=19.0\\
-                             21.44, & t=22.0
-                             \end{cases}
+           \resizeExpression{h=\frac{1}{1000}\,\begin{cases}
+                                               2.16, & t=2.5\\
+                                               2.59, & t=2.7\\
+                                               2.92, & t=3.0\\
+                                               3.78, & t=4.0\\
+                                               4.57, & t=5.0\\
+                                               5.56, & t=6.0\\
+                                               7.42, & t=8.0\\
+                                               9.02, & t=10.0\\
+                                               11.91, & t=12.0\\
+                                               15.09, & t=16.0\\
+                                               18.26, & t=19.0\\
+                                               21.44, & t=22.0
+                                               \end{cases}}{0.8}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -527,7 +538,7 @@ Units & Unitless
         
 \\ \midrule
 Equation & \begin{displaymath}
-           \mathit{LDF}=\left(\frac{{t_{\text{d}}}}{60}\right)^{\frac{m}{16}}
+           \resizeExpression{\mathit{LDF}=\left(\frac{{t_{\text{d}}}}{60}\right)^{\frac{m}{16}}}{0.8}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -568,11 +579,11 @@ Units & Unitless
         
 \\ \midrule
 Equation & \begin{displaymath}
-           \mathit{GTF}=\begin{cases}
-                        1, & g=\text{``AN''}\\
-                        4, & g=\text{``FT''}\\
-                        2, & g=\text{``HS''}
-                        \end{cases}
+           \resizeExpression{\mathit{GTF}=\begin{cases}
+                                          1, & g=\text{``AN''}\\
+                                          4, & g=\text{``FT''}\\
+                                          2, & g=\text{``HS''}
+                                          \end{cases}}{0.8}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -614,7 +625,7 @@ Units & ${\text{m}}$
         
 \\ \midrule
 Equation & \begin{displaymath}
-           \mathit{SD}=\sqrt{{\mathit{SD}_{\text{x}}}^{2}+{\mathit{SD}_{\text{y}}}^{2}+{\mathit{SD}_{\text{z}}}^{2}}
+           \resizeExpression{\mathit{SD}=\sqrt{{\mathit{SD}_{\text{x}}}^{2}+{\mathit{SD}_{\text{y}}}^{2}+{\mathit{SD}_{\text{z}}}^{2}}}{0.8}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -651,7 +662,7 @@ Units & Unitless
         
 \\ \midrule
 Equation & \begin{displaymath}
-           \mathit{AR}=\frac{a}{b}
+           \resizeExpression{\mathit{AR}=\frac{a}{b}}{0.8}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -690,7 +701,7 @@ Units & ${\text{kg}}$
         
 \\ \midrule
 Equation & \begin{displaymath}
-           {w_{\mathit{TNT}}}=w\,\mathit{TNT}
+           \resizeExpression{{w_{\mathit{TNT}}}=w\,\mathit{TNT}}{0.8}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -726,7 +737,7 @@ Units & ${\text{Pa}}$
         
 \\ \midrule
 Equation & \begin{displaymath}
-           q=\mathit{interpY}\left(\text{``TSD.txt''},\mathit{SD},{w_{\mathit{TNT}}}\right)
+           \resizeExpression{q=\mathit{interpY}\left(\text{``TSD.txt''},\mathit{SD},{w_{\mathit{TNT}}}\right)}{0.8}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -772,16 +783,16 @@ Output & $B$
          
 \\ \midrule
 Input Constraints & \begin{displaymath}
-                    a\gt{}0
+                    \resizeExpression{a\gt{}0}{0.8}
                     \end{displaymath}
                     \begin{displaymath}
-                    0\lt{}b\leq{}a
+                    \resizeExpression{0\lt{}b\leq{}a}{0.8}
                     \end{displaymath}
 \\ \midrule
 Output Constraints & 
 \\ \midrule
 Equation & \begin{displaymath}
-           B=\frac{k}{\left(a\,b\right)^{m-1}}\,\left(E\,h^{2}\right)^{m}\,\mathit{LDF}\,e^{J}
+           \resizeExpression{B=\frac{k}{\left(a\,b\right)^{m-1}}\,\left(E\,h^{2}\right)^{m}\,\mathit{LDF}\,e^{J}}{0.8}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -832,15 +843,15 @@ Output & $J$
          
 \\ \midrule
 Input Constraints & \begin{displaymath}
-                    \mathit{AR}\geq{}1
+                    \resizeExpression{\mathit{AR}\geq{}1}{0.8}
                     \end{displaymath}
 \\ \midrule
 Output Constraints & \begin{displaymath}
-                     {J_{\text{min}}}\leq{}J\leq{}{J_{\text{max}}}
+                     \resizeExpression{{J_{\text{min}}}\leq{}J\leq{}{J_{\text{max}}}}{0.8}
                      \end{displaymath}
 \\ \midrule
 Equation & \begin{displaymath}
-           J=\mathit{interpZ}\left(\text{``SDF.txt''},\mathit{AR},\hat{q}\right)
+           \resizeExpression{J=\mathit{interpZ}\left(\text{``SDF.txt''},\mathit{AR},\hat{q}\right)}{0.8}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -884,16 +895,16 @@ Output & $\mathit{NFL}$
          
 \\ \midrule
 Input Constraints & \begin{displaymath}
-                    a\gt{}0
+                    \resizeExpression{a\gt{}0}{0.8}
                     \end{displaymath}
                     \begin{displaymath}
-                    0\lt{}b\leq{}a
+                    \resizeExpression{0\lt{}b\leq{}a}{0.8}
                     \end{displaymath}
 \\ \midrule
 Output Constraints & 
 \\ \midrule
 Equation & \begin{displaymath}
-           \mathit{NFL}=\frac{{\hat{q}_{\text{tol}}}\,E\,h^{4}}{\left(a\,b\right)^{2}}
+           \resizeExpression{\mathit{NFL}=\frac{{\hat{q}_{\text{tol}}}\,E\,h^{4}}{\left(a\,b\right)^{2}}}{0.8}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -941,16 +952,16 @@ Output & $\hat{q}$
          
 \\ \midrule
 Input Constraints & \begin{displaymath}
-                    a\gt{}0
+                    \resizeExpression{a\gt{}0}{0.8}
                     \end{displaymath}
                     \begin{displaymath}
-                    0\lt{}b\leq{}a
+                    \resizeExpression{0\lt{}b\leq{}a}{0.8}
                     \end{displaymath}
 \\ \midrule
 Output Constraints & 
 \\ \midrule
 Equation & \begin{displaymath}
-           \hat{q}=\frac{q\,\left(a\,b\right)^{2}}{E\,h^{4}\,\mathit{GTF}}
+           \resizeExpression{\hat{q}=\frac{q\,\left(a\,b\right)^{2}}{E\,h^{4}\,\mathit{GTF}}}{0.8}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -1001,13 +1012,13 @@ Output & ${\hat{q}_{\text{tol}}}$
          
 \\ \midrule
 Input Constraints & \begin{displaymath}
-                    \mathit{AR}\geq{}1
+                    \resizeExpression{\mathit{AR}\geq{}1}{0.8}
                     \end{displaymath}
 \\ \midrule
 Output Constraints & 
 \\ \midrule
 Equation & \begin{displaymath}
-           {\hat{q}_{\text{tol}}}=\mathit{interpY}\left(\text{``SDF.txt''},\mathit{AR},{J_{\text{tol}}}\right)
+           \resizeExpression{{\hat{q}_{\text{tol}}}=\mathit{interpY}\left(\text{``SDF.txt''},\mathit{AR},{J_{\text{tol}}}\right)}{0.8}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -1051,19 +1062,19 @@ Output & ${J_{\text{tol}}}$
          
 \\ \midrule
 Input Constraints & \begin{displaymath}
-                    0\leq{}{P_{\text{b}\text{tol}}}\leq{}1
+                    \resizeExpression{0\leq{}{P_{\text{b}\text{tol}}}\leq{}1}{0.8}
                     \end{displaymath}
                     \begin{displaymath}
-                    a\gt{}0
+                    \resizeExpression{a\gt{}0}{0.8}
                     \end{displaymath}
                     \begin{displaymath}
-                    0\lt{}b\leq{}a
+                    \resizeExpression{0\lt{}b\leq{}a}{0.8}
                     \end{displaymath}
 \\ \midrule
 Output Constraints & 
 \\ \midrule
 Equation & \begin{displaymath}
-           {J_{\text{tol}}}=\ln\left(\ln\left(\frac{1}{1-{P_{\text{b}\text{tol}}}}\right)\,\frac{\left(a\,b\right)^{m-1}}{k\,\left(E\,h^{2}\right)^{m}\,\mathit{LDF}}\right)
+           \resizeExpression{{J_{\text{tol}}}=\ln\left(\ln\left(\frac{1}{1-{P_{\text{b}\text{tol}}}}\right)\,\frac{\left(a\,b\right)^{m-1}}{k\,\left(E\,h^{2}\right)^{m}\,\mathit{LDF}}\right)}{0.8}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -1118,11 +1129,11 @@ Output & ${P_{\text{b}}}$
 Input Constraints & 
 \\ \midrule
 Output Constraints & \begin{displaymath}
-                     0\leq{}{P_{\text{b}}}\leq{}1
+                     \resizeExpression{0\leq{}{P_{\text{b}}}\leq{}1}{0.8}
                      \end{displaymath}
 \\ \midrule
 Equation & \begin{displaymath}
-           {P_{\text{b}}}=1-e^{-B}
+           \resizeExpression{{P_{\text{b}}}=1-e^{-B}}{0.8}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -1164,7 +1175,7 @@ Input Constraints &
 Output Constraints & 
 \\ \midrule
 Equation & \begin{displaymath}
-           \mathit{LR}=\mathit{NFL}\,\mathit{GTF}\,\mathit{LSF}
+           \resizeExpression{\mathit{LR}=\mathit{NFL}\,\mathit{GTF}\,\mathit{LSF}}{0.8}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -1208,16 +1219,16 @@ Output & $\mathit{isSafePb}$
          
 \\ \midrule
 Input Constraints & \begin{displaymath}
-                    0\leq{}{P_{\text{b}}}\leq{}1
+                    \resizeExpression{0\leq{}{P_{\text{b}}}\leq{}1}{0.8}
                     \end{displaymath}
                     \begin{displaymath}
-                    0\leq{}{P_{\text{b}\text{tol}}}\leq{}1
+                    \resizeExpression{0\leq{}{P_{\text{b}\text{tol}}}\leq{}1}{0.8}
                     \end{displaymath}
 \\ \midrule
 Output Constraints & 
 \\ \midrule
 Equation & \begin{displaymath}
-           \mathit{isSafePb}={P_{\text{b}}}\lt{}{P_{\text{b}\text{tol}}}
+           \resizeExpression{\mathit{isSafePb}={P_{\text{b}}}\lt{}{P_{\text{b}\text{tol}}}}{0.8}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -1260,16 +1271,16 @@ Output & $\mathit{isSafeLR}$
          
 \\ \midrule
 Input Constraints & \begin{displaymath}
-                    \mathit{LR}\gt{}0
+                    \resizeExpression{\mathit{LR}\gt{}0}{0.8}
                     \end{displaymath}
                     \begin{displaymath}
-                    q\gt{}0
+                    \resizeExpression{q\gt{}0}{0.8}
                     \end{displaymath}
 \\ \midrule
 Output Constraints & 
 \\ \midrule
 Equation & \begin{displaymath}
-           \mathit{isSafeLR}=\mathit{LR}\gt{}q
+           \resizeExpression{\mathit{isSafeLR}=\mathit{LR}\gt{}q}{0.8}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}

--- a/code/stable/glassbr/SRS/PDF/GlassBR_SRS.tex
+++ b/code/stable/glassbr/SRS/PDF/GlassBR_SRS.tex
@@ -25,6 +25,8 @@
 \newcommand{\lt}{\ensuremath <}
 \newlist{symbDescription}{description}{1}
 \setlist[symbDescription]{noitemsep, topsep=0pt, parsep=0pt, partopsep=0pt}
+\def\inDefScale{0.8}
+\def\outDefScale{1.0}
 \newsavebox{\mybox}
 \newcommand{\resizeExpression}[2]{
   \savebox{\mybox}{$#1$}
@@ -409,7 +411,7 @@ Label & Safety Probability
         
 \\ \midrule
 Equation & \begin{displaymath}
-           \resizeExpression{\mathit{isSafeProb}={P_{\text{f}}}\lt{}{P_{\text{f}\text{tol}}}}{0.8}
+           \resizeExpression{\mathit{isSafeProb}={P_{\text{f}}}\lt{}{P_{\text{f}\text{tol}}}}{\inDefScale}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -441,7 +443,7 @@ Label & Safety Load
         
 \\ \midrule
 Equation & \begin{displaymath}
-           \resizeExpression{\mathit{isSafeLoad}=\mathit{capacity}\gt{}\mathit{Load}}{0.8}
+           \resizeExpression{\mathit{isSafeLoad}=\mathit{capacity}\gt{}\mathit{Load}}{\inDefScale}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -500,7 +502,7 @@ Equation & \begin{displaymath}
                                                15.09, & t=16.0\\
                                                18.26, & t=19.0\\
                                                21.44, & t=22.0
-                                               \end{cases}}{0.8}
+                                               \end{cases}}{\inDefScale}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -538,7 +540,7 @@ Units & Unitless
         
 \\ \midrule
 Equation & \begin{displaymath}
-           \resizeExpression{\mathit{LDF}=\left(\frac{{t_{\text{d}}}}{60}\right)^{\frac{m}{16}}}{0.8}
+           \resizeExpression{\mathit{LDF}=\left(\frac{{t_{\text{d}}}}{60}\right)^{\frac{m}{16}}}{\inDefScale}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -583,7 +585,7 @@ Equation & \begin{displaymath}
                                           1, & g=\text{``AN''}\\
                                           4, & g=\text{``FT''}\\
                                           2, & g=\text{``HS''}
-                                          \end{cases}}{0.8}
+                                          \end{cases}}{\inDefScale}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -625,7 +627,7 @@ Units & ${\text{m}}$
         
 \\ \midrule
 Equation & \begin{displaymath}
-           \resizeExpression{\mathit{SD}=\sqrt{{\mathit{SD}_{\text{x}}}^{2}+{\mathit{SD}_{\text{y}}}^{2}+{\mathit{SD}_{\text{z}}}^{2}}}{0.8}
+           \resizeExpression{\mathit{SD}=\sqrt{{\mathit{SD}_{\text{x}}}^{2}+{\mathit{SD}_{\text{y}}}^{2}+{\mathit{SD}_{\text{z}}}^{2}}}{\inDefScale}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -662,7 +664,7 @@ Units & Unitless
         
 \\ \midrule
 Equation & \begin{displaymath}
-           \resizeExpression{\mathit{AR}=\frac{a}{b}}{0.8}
+           \resizeExpression{\mathit{AR}=\frac{a}{b}}{\inDefScale}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -701,7 +703,7 @@ Units & ${\text{kg}}$
         
 \\ \midrule
 Equation & \begin{displaymath}
-           \resizeExpression{{w_{\mathit{TNT}}}=w\,\mathit{TNT}}{0.8}
+           \resizeExpression{{w_{\mathit{TNT}}}=w\,\mathit{TNT}}{\inDefScale}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -737,7 +739,7 @@ Units & ${\text{Pa}}$
         
 \\ \midrule
 Equation & \begin{displaymath}
-           \resizeExpression{q=\mathit{interpY}\left(\text{``TSD.txt''},\mathit{SD},{w_{\mathit{TNT}}}\right)}{0.8}
+           \resizeExpression{q=\mathit{interpY}\left(\text{``TSD.txt''},\mathit{SD},{w_{\mathit{TNT}}}\right)}{\inDefScale}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -783,16 +785,16 @@ Output & $B$
          
 \\ \midrule
 Input Constraints & \begin{displaymath}
-                    \resizeExpression{a\gt{}0}{0.8}
+                    \resizeExpression{a\gt{}0}{\inDefScale}
                     \end{displaymath}
                     \begin{displaymath}
-                    \resizeExpression{0\lt{}b\leq{}a}{0.8}
+                    \resizeExpression{0\lt{}b\leq{}a}{\inDefScale}
                     \end{displaymath}
 \\ \midrule
 Output Constraints & 
 \\ \midrule
 Equation & \begin{displaymath}
-           \resizeExpression{B=\frac{k}{\left(a\,b\right)^{m-1}}\,\left(E\,h^{2}\right)^{m}\,\mathit{LDF}\,e^{J}}{0.8}
+           \resizeExpression{B=\frac{k}{\left(a\,b\right)^{m-1}}\,\left(E\,h^{2}\right)^{m}\,\mathit{LDF}\,e^{J}}{\inDefScale}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -843,15 +845,15 @@ Output & $J$
          
 \\ \midrule
 Input Constraints & \begin{displaymath}
-                    \resizeExpression{\mathit{AR}\geq{}1}{0.8}
+                    \resizeExpression{\mathit{AR}\geq{}1}{\inDefScale}
                     \end{displaymath}
 \\ \midrule
 Output Constraints & \begin{displaymath}
-                     \resizeExpression{{J_{\text{min}}}\leq{}J\leq{}{J_{\text{max}}}}{0.8}
+                     \resizeExpression{{J_{\text{min}}}\leq{}J\leq{}{J_{\text{max}}}}{\inDefScale}
                      \end{displaymath}
 \\ \midrule
 Equation & \begin{displaymath}
-           \resizeExpression{J=\mathit{interpZ}\left(\text{``SDF.txt''},\mathit{AR},\hat{q}\right)}{0.8}
+           \resizeExpression{J=\mathit{interpZ}\left(\text{``SDF.txt''},\mathit{AR},\hat{q}\right)}{\inDefScale}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -895,16 +897,16 @@ Output & $\mathit{NFL}$
          
 \\ \midrule
 Input Constraints & \begin{displaymath}
-                    \resizeExpression{a\gt{}0}{0.8}
+                    \resizeExpression{a\gt{}0}{\inDefScale}
                     \end{displaymath}
                     \begin{displaymath}
-                    \resizeExpression{0\lt{}b\leq{}a}{0.8}
+                    \resizeExpression{0\lt{}b\leq{}a}{\inDefScale}
                     \end{displaymath}
 \\ \midrule
 Output Constraints & 
 \\ \midrule
 Equation & \begin{displaymath}
-           \resizeExpression{\mathit{NFL}=\frac{{\hat{q}_{\text{tol}}}\,E\,h^{4}}{\left(a\,b\right)^{2}}}{0.8}
+           \resizeExpression{\mathit{NFL}=\frac{{\hat{q}_{\text{tol}}}\,E\,h^{4}}{\left(a\,b\right)^{2}}}{\inDefScale}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -952,16 +954,16 @@ Output & $\hat{q}$
          
 \\ \midrule
 Input Constraints & \begin{displaymath}
-                    \resizeExpression{a\gt{}0}{0.8}
+                    \resizeExpression{a\gt{}0}{\inDefScale}
                     \end{displaymath}
                     \begin{displaymath}
-                    \resizeExpression{0\lt{}b\leq{}a}{0.8}
+                    \resizeExpression{0\lt{}b\leq{}a}{\inDefScale}
                     \end{displaymath}
 \\ \midrule
 Output Constraints & 
 \\ \midrule
 Equation & \begin{displaymath}
-           \resizeExpression{\hat{q}=\frac{q\,\left(a\,b\right)^{2}}{E\,h^{4}\,\mathit{GTF}}}{0.8}
+           \resizeExpression{\hat{q}=\frac{q\,\left(a\,b\right)^{2}}{E\,h^{4}\,\mathit{GTF}}}{\inDefScale}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -1012,13 +1014,13 @@ Output & ${\hat{q}_{\text{tol}}}$
          
 \\ \midrule
 Input Constraints & \begin{displaymath}
-                    \resizeExpression{\mathit{AR}\geq{}1}{0.8}
+                    \resizeExpression{\mathit{AR}\geq{}1}{\inDefScale}
                     \end{displaymath}
 \\ \midrule
 Output Constraints & 
 \\ \midrule
 Equation & \begin{displaymath}
-           \resizeExpression{{\hat{q}_{\text{tol}}}=\mathit{interpY}\left(\text{``SDF.txt''},\mathit{AR},{J_{\text{tol}}}\right)}{0.8}
+           \resizeExpression{{\hat{q}_{\text{tol}}}=\mathit{interpY}\left(\text{``SDF.txt''},\mathit{AR},{J_{\text{tol}}}\right)}{\inDefScale}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -1062,19 +1064,19 @@ Output & ${J_{\text{tol}}}$
          
 \\ \midrule
 Input Constraints & \begin{displaymath}
-                    \resizeExpression{0\leq{}{P_{\text{b}\text{tol}}}\leq{}1}{0.8}
+                    \resizeExpression{0\leq{}{P_{\text{b}\text{tol}}}\leq{}1}{\inDefScale}
                     \end{displaymath}
                     \begin{displaymath}
-                    \resizeExpression{a\gt{}0}{0.8}
+                    \resizeExpression{a\gt{}0}{\inDefScale}
                     \end{displaymath}
                     \begin{displaymath}
-                    \resizeExpression{0\lt{}b\leq{}a}{0.8}
+                    \resizeExpression{0\lt{}b\leq{}a}{\inDefScale}
                     \end{displaymath}
 \\ \midrule
 Output Constraints & 
 \\ \midrule
 Equation & \begin{displaymath}
-           \resizeExpression{{J_{\text{tol}}}=\ln\left(\ln\left(\frac{1}{1-{P_{\text{b}\text{tol}}}}\right)\,\frac{\left(a\,b\right)^{m-1}}{k\,\left(E\,h^{2}\right)^{m}\,\mathit{LDF}}\right)}{0.8}
+           \resizeExpression{{J_{\text{tol}}}=\ln\left(\ln\left(\frac{1}{1-{P_{\text{b}\text{tol}}}}\right)\,\frac{\left(a\,b\right)^{m-1}}{k\,\left(E\,h^{2}\right)^{m}\,\mathit{LDF}}\right)}{\inDefScale}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -1129,11 +1131,11 @@ Output & ${P_{\text{b}}}$
 Input Constraints & 
 \\ \midrule
 Output Constraints & \begin{displaymath}
-                     \resizeExpression{0\leq{}{P_{\text{b}}}\leq{}1}{0.8}
+                     \resizeExpression{0\leq{}{P_{\text{b}}}\leq{}1}{\inDefScale}
                      \end{displaymath}
 \\ \midrule
 Equation & \begin{displaymath}
-           \resizeExpression{{P_{\text{b}}}=1-e^{-B}}{0.8}
+           \resizeExpression{{P_{\text{b}}}=1-e^{-B}}{\inDefScale}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -1175,7 +1177,7 @@ Input Constraints &
 Output Constraints & 
 \\ \midrule
 Equation & \begin{displaymath}
-           \resizeExpression{\mathit{LR}=\mathit{NFL}\,\mathit{GTF}\,\mathit{LSF}}{0.8}
+           \resizeExpression{\mathit{LR}=\mathit{NFL}\,\mathit{GTF}\,\mathit{LSF}}{\inDefScale}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -1219,16 +1221,16 @@ Output & $\mathit{isSafePb}$
          
 \\ \midrule
 Input Constraints & \begin{displaymath}
-                    \resizeExpression{0\leq{}{P_{\text{b}}}\leq{}1}{0.8}
+                    \resizeExpression{0\leq{}{P_{\text{b}}}\leq{}1}{\inDefScale}
                     \end{displaymath}
                     \begin{displaymath}
-                    \resizeExpression{0\leq{}{P_{\text{b}\text{tol}}}\leq{}1}{0.8}
+                    \resizeExpression{0\leq{}{P_{\text{b}\text{tol}}}\leq{}1}{\inDefScale}
                     \end{displaymath}
 \\ \midrule
 Output Constraints & 
 \\ \midrule
 Equation & \begin{displaymath}
-           \resizeExpression{\mathit{isSafePb}={P_{\text{b}}}\lt{}{P_{\text{b}\text{tol}}}}{0.8}
+           \resizeExpression{\mathit{isSafePb}={P_{\text{b}}}\lt{}{P_{\text{b}\text{tol}}}}{\inDefScale}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -1271,16 +1273,16 @@ Output & $\mathit{isSafeLR}$
          
 \\ \midrule
 Input Constraints & \begin{displaymath}
-                    \resizeExpression{\mathit{LR}\gt{}0}{0.8}
+                    \resizeExpression{\mathit{LR}\gt{}0}{\inDefScale}
                     \end{displaymath}
                     \begin{displaymath}
-                    \resizeExpression{q\gt{}0}{0.8}
+                    \resizeExpression{q\gt{}0}{\inDefScale}
                     \end{displaymath}
 \\ \midrule
 Output Constraints & 
 \\ \midrule
 Equation & \begin{displaymath}
-           \resizeExpression{\mathit{isSafeLR}=\mathit{LR}\gt{}q}{0.8}
+           \resizeExpression{\mathit{isSafeLR}=\mathit{LR}\gt{}q}{\inDefScale}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}

--- a/code/stable/glassbr/SRS/PDF/GlassBR_SRS.tex
+++ b/code/stable/glassbr/SRS/PDF/GlassBR_SRS.tex
@@ -27,12 +27,12 @@
 \setlist[symbDescription]{noitemsep, topsep=0pt, parsep=0pt, partopsep=0pt}
 \newsavebox{\mybox}
 \newcommand{\resizeExpression}[2]{
-\savebox{\mybox}{$#1$}
-\ifdim\wd\mybox>#2\linewidth
-\resizebox{#2\textwidth}{!}{\usebox{\mybox}}
-\else
-\usebox{\mybox}
-\fi
+  \savebox{\mybox}{$#1$}
+  \ifdim\wd\mybox>#2\linewidth
+    \resizebox{#2\textwidth}{!}{\usebox{\mybox}}
+  \else
+    \usebox{\mybox}
+  \fi
 }
 \bibliography{bibfile}
 \title{Software Requirements Specification for GlassBR}

--- a/code/stable/hghc/SRS/PDF/HGHC_SRS.tex
+++ b/code/stable/hghc/SRS/PDF/HGHC_SRS.tex
@@ -11,12 +11,23 @@
 \usepackage{tabularx}
 \usepackage{booktabs}
 \usepackage{caption}
+\usepackage{graphicx}
+\usepackage{calc}
 \usepackage{enumitem}
 \setmathfont{Latin Modern Math}
 \newcommand{\gt}{\ensuremath >}
 \newcommand{\lt}{\ensuremath <}
 \newlist{symbDescription}{description}{1}
 \setlist[symbDescription]{noitemsep, topsep=0pt, parsep=0pt, partopsep=0pt}
+\newsavebox{\mybox}
+\newcommand{\resizeExpression}[2]{
+\savebox{\mybox}{$#1$}
+\ifdim\wd\mybox>#2\linewidth
+\resizebox{#2\textwidth}{!}{\usebox{\mybox}}
+\else
+\usebox{\mybox}
+\fi
+}
 \title{Software Requirements Specification for HGHC}
 \author{W. Spencer Smith}
 \begin{document}
@@ -103,7 +114,7 @@ Units & $\frac{\text{W}}{\text{m}^{2}{}^{\circ}\text{C}}$
         
 \\ \midrule
 Equation & \begin{displaymath}
-           {h_{\text{g}}}=\frac{2\,{k_{\text{c}}}\,{h_{\text{p}}}}{2\,{k_{\text{c}}}+{τ_{\text{c}}}\,{h_{\text{p}}}}
+           \resizeExpression{{h_{\text{g}}}=\frac{2\,{k_{\text{c}}}\,{h_{\text{p}}}}{2\,{k_{\text{c}}}+{τ_{\text{c}}}\,{h_{\text{p}}}}}{0.8}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -134,7 +145,7 @@ Units & $\frac{\text{W}}{\text{m}^{2}{}^{\circ}\text{C}}$
         
 \\ \midrule
 Equation & \begin{displaymath}
-           {h_{\text{c}}}=\frac{2\,{k_{\text{c}}}\,{h_{\text{b}}}}{2\,{k_{\text{c}}}+{τ_{\text{c}}}\,{h_{\text{b}}}}
+           \resizeExpression{{h_{\text{c}}}=\frac{2\,{k_{\text{c}}}\,{h_{\text{b}}}}{2\,{k_{\text{c}}}+{τ_{\text{c}}}\,{h_{\text{b}}}}}{0.8}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}

--- a/code/stable/hghc/SRS/PDF/HGHC_SRS.tex
+++ b/code/stable/hghc/SRS/PDF/HGHC_SRS.tex
@@ -19,6 +19,8 @@
 \newcommand{\lt}{\ensuremath <}
 \newlist{symbDescription}{description}{1}
 \setlist[symbDescription]{noitemsep, topsep=0pt, parsep=0pt, partopsep=0pt}
+\def\inDefScale{0.8}
+\def\outDefScale{1.0}
 \newsavebox{\mybox}
 \newcommand{\resizeExpression}[2]{
   \savebox{\mybox}{$#1$}
@@ -114,7 +116,7 @@ Units & $\frac{\text{W}}{\text{m}^{2}{}^{\circ}\text{C}}$
         
 \\ \midrule
 Equation & \begin{displaymath}
-           \resizeExpression{{h_{\text{g}}}=\frac{2\,{k_{\text{c}}}\,{h_{\text{p}}}}{2\,{k_{\text{c}}}+{τ_{\text{c}}}\,{h_{\text{p}}}}}{0.8}
+           \resizeExpression{{h_{\text{g}}}=\frac{2\,{k_{\text{c}}}\,{h_{\text{p}}}}{2\,{k_{\text{c}}}+{τ_{\text{c}}}\,{h_{\text{p}}}}}{\inDefScale}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -145,7 +147,7 @@ Units & $\frac{\text{W}}{\text{m}^{2}{}^{\circ}\text{C}}$
         
 \\ \midrule
 Equation & \begin{displaymath}
-           \resizeExpression{{h_{\text{c}}}=\frac{2\,{k_{\text{c}}}\,{h_{\text{b}}}}{2\,{k_{\text{c}}}+{τ_{\text{c}}}\,{h_{\text{b}}}}}{0.8}
+           \resizeExpression{{h_{\text{c}}}=\frac{2\,{k_{\text{c}}}\,{h_{\text{b}}}}{2\,{k_{\text{c}}}+{τ_{\text{c}}}\,{h_{\text{b}}}}}{\inDefScale}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}

--- a/code/stable/hghc/SRS/PDF/HGHC_SRS.tex
+++ b/code/stable/hghc/SRS/PDF/HGHC_SRS.tex
@@ -21,12 +21,12 @@
 \setlist[symbDescription]{noitemsep, topsep=0pt, parsep=0pt, partopsep=0pt}
 \newsavebox{\mybox}
 \newcommand{\resizeExpression}[2]{
-\savebox{\mybox}{$#1$}
-\ifdim\wd\mybox>#2\linewidth
-\resizebox{#2\textwidth}{!}{\usebox{\mybox}}
-\else
-\usebox{\mybox}
-\fi
+  \savebox{\mybox}{$#1$}
+  \ifdim\wd\mybox>#2\linewidth
+    \resizebox{#2\textwidth}{!}{\usebox{\mybox}}
+  \else
+    \usebox{\mybox}
+  \fi
 }
 \title{Software Requirements Specification for HGHC}
 \author{W. Spencer Smith}

--- a/code/stable/pdcontroller/SRS/PDF/PDController_SRS.tex
+++ b/code/stable/pdcontroller/SRS/PDF/PDController_SRS.tex
@@ -15,6 +15,8 @@
 \usepackage{svg}
 \usepackage{float}
 \usepackage{enumitem}
+\usepackage{graphicx}
+\usepackage{calc}
 \usepackage{filecontents}
 \usepackage[backend=bibtex]{biblatex}
 \usepackage{url}
@@ -23,6 +25,15 @@
 \newcommand{\lt}{\ensuremath <}
 \newlist{symbDescription}{description}{1}
 \setlist[symbDescription]{noitemsep, topsep=0pt, parsep=0pt, partopsep=0pt}
+\newsavebox{\mybox}
+\newcommand{\resizeExpression}[2]{
+\savebox{\mybox}{$#1$}
+\ifdim\wd\mybox>#2\linewidth
+\resizebox{#2\textwidth}{!}{\usebox{\mybox}}
+\else
+\usebox{\mybox}
+\fi
+}
 \bibliography{bibfile}
 \title{Software Requirements Specification for PD Controller}
 \author{Naveen Ganesh Muralidharan}
@@ -309,7 +320,7 @@ Label & Laplace Transform
         
 \\ \midrule
 Equation & \begin{displaymath}
-           {F_{\text{s}}}=\int_{\mathit{-∞}}^{∞}{{f_{\text{t}}}\,e^{-s\,t}}\,dt
+           \resizeExpression{{F_{\text{s}}}=\int_{\mathit{-∞}}^{∞}{{f_{\text{t}}}\,e^{-s\,t}}\,dt}{0.8}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -343,7 +354,7 @@ Label & Inverse Laplace Transform
         
 \\ \midrule
 Equation & \begin{displaymath}
-           {f_{\text{t}}}=\mathit{L⁻¹[F(s)]}
+           \resizeExpression{{f_{\text{t}}}=\mathit{L⁻¹[F(s)]}}{0.8}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -375,7 +386,7 @@ Label & Second Order Mass-Spring-Damper System
         
 \\ \midrule
 Equation & \begin{displaymath}
-           \frac{1}{m\,s^{2}+c\,s+k}
+           \resizeExpression{\frac{1}{m\,s^{2}+c\,s+k}}{0.8}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -413,7 +424,7 @@ Label & The Transfer Function of the Power Plant
         
 \\ \midrule
 Equation & \begin{displaymath}
-           \frac{1}{s^{2}+s+20}
+           \resizeExpression{\frac{1}{s^{2}+s+20}}{0.8}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -454,7 +465,7 @@ Units & Unitless
         
 \\ \midrule
 Equation & \begin{displaymath}
-           {E_{\text{s}}}={R_{\text{s}}}-{Y_{\text{s}}}
+           \resizeExpression{{E_{\text{s}}}={R_{\text{s}}}-{Y_{\text{s}}}}{0.8}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -493,7 +504,7 @@ Units & Unitless
         
 \\ \midrule
 Equation & \begin{displaymath}
-           {P_{\text{s}}}={K_{\text{p}}}\,{E_{\text{s}}}
+           \resizeExpression{{P_{\text{s}}}={K_{\text{p}}}\,{E_{\text{s}}}}{0.8}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -532,7 +543,7 @@ Units & Unitless
         
 \\ \midrule
 Equation & \begin{displaymath}
-           {D_{\text{s}}}={K_{\text{d}}}\,{E_{\text{s}}}\,s
+           \resizeExpression{{D_{\text{s}}}={K_{\text{d}}}\,{E_{\text{s}}}\,s}{0.8}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -572,7 +583,7 @@ Units & Unitless
         
 \\ \midrule
 Equation & \begin{displaymath}
-           {C_{\text{s}}}={E_{\text{s}}}\,\left({K_{\text{p}}}+{K_{\text{d}}}\,s\right)
+           \resizeExpression{{C_{\text{s}}}={E_{\text{s}}}\,\left({K_{\text{p}}}+{K_{\text{d}}}\,s\right)}{0.8}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -617,21 +628,21 @@ Output & ${y_{\text{t}}}$
          
 \\ \midrule
 Input Constraints & \begin{displaymath}
-                    {r_{\text{t}}}\gt{}0
+                    \resizeExpression{{r_{\text{t}}}\gt{}0}{0.8}
                     \end{displaymath}
                     \begin{displaymath}
-                    {K_{\text{p}}}\gt{}0
+                    \resizeExpression{{K_{\text{p}}}\gt{}0}{0.8}
                     \end{displaymath}
                     \begin{displaymath}
-                    {K_{\text{d}}}\gt{}0
+                    \resizeExpression{{K_{\text{d}}}\gt{}0}{0.8}
                     \end{displaymath}
 \\ \midrule
 Output Constraints & \begin{displaymath}
-                     {y_{\text{t}}}\gt{}0
+                     \resizeExpression{{y_{\text{t}}}\gt{}0}{0.8}
                      \end{displaymath}
 \\ \midrule
 Equation & \begin{displaymath}
-           \frac{\,d^{2}{y_{\text{t}}}}{\,dt^{2}}+\left(1+{K_{\text{d}}}\right)\,\frac{\,d{y_{\text{t}}}}{\,dt}+\left(20+{K_{\text{p}}}\right)\,{{y_{\text{t}}}}={r_{\text{t}}}\,{K_{\text{p}}}
+           \resizeExpression{\frac{\,d^{2}{y_{\text{t}}}}{\,dt^{2}}+\left(1+{K_{\text{d}}}\right)\,\frac{\,d{y_{\text{t}}}}{\,dt}+\left(20+{K_{\text{p}}}\right)\,{{y_{\text{t}}}}={r_{\text{t}}}\,{K_{\text{p}}}}{0.8}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -656,22 +667,22 @@ RefBy & \hyperref[outputValues]{FR:Output-Values} and \hyperref[calculateValues]
 The Process Variable ${Y_{\text{s}}}$ in a PD Control Loop is the product of the Process Error (from \hyperref[DD:ddProcessError]{DD:ddProcessError}), Control Variable (from \hyperref[DD:ddCtrlVar]{DD:ddCtrlVar}), and the Power Plant (from \hyperref[GD:gdPowerPlant]{GD:gdPowerPlant}).
 
 \begin{displaymath}
-{Y_{\text{s}}}=\left({R_{\text{s}}}-{Y_{\text{s}}}\right)\,\left({K_{\text{p}}}+{K_{\text{d}}}\,s\right)\,\frac{1}{s^{2}+s+20}
+\resizeExpression{{Y_{\text{s}}}=\left({R_{\text{s}}}-{Y_{\text{s}}}\right)\,\left({K_{\text{p}}}+{K_{\text{d}}}\,s\right)\,\frac{1}{s^{2}+s+20}}{1.0}
 \end{displaymath}
 Substituting the values and rearranging the equation.
 
 \begin{displaymath}
-s^{2}\,{Y_{\text{s}}}+\left(1+{K_{\text{d}}}\right)\,{Y_{\text{s}}}\,s+\left(20+{K_{\text{p}}}\right)\,{Y_{\text{s}}}-{R_{\text{s}}}\,s\,{K_{\text{d}}}-{R_{\text{s}}}\,{K_{\text{p}}}=0
+\resizeExpression{s^{2}\,{Y_{\text{s}}}+\left(1+{K_{\text{d}}}\right)\,{Y_{\text{s}}}\,s+\left(20+{K_{\text{p}}}\right)\,{Y_{\text{s}}}-{R_{\text{s}}}\,s\,{K_{\text{d}}}-{R_{\text{s}}}\,{K_{\text{p}}}=0}{1.0}
 \end{displaymath}
 Computing the Inverse Laplace Transform of a function (from \hyperref[TM:invLaplaceTransform]{TM:invLaplaceTransform}) of the equation.
 
 \begin{displaymath}
-\frac{\,d\frac{\,d{y_{\text{t}}}}{\,dt}}{\,dt}+\left(1+{K_{\text{d}}}\right)\,\frac{\,d{y_{\text{t}}}}{\,dt}+\left(20+{K_{\text{p}}}\right)\,{y_{\text{t}}}-{K_{\text{d}}}\,\frac{\,d{r_{\text{t}}}}{\,dt}-{r_{\text{t}}}\,{K_{\text{p}}}=0
+\resizeExpression{\frac{\,d\frac{\,d{y_{\text{t}}}}{\,dt}}{\,dt}+\left(1+{K_{\text{d}}}\right)\,\frac{\,d{y_{\text{t}}}}{\,dt}+\left(20+{K_{\text{p}}}\right)\,{y_{\text{t}}}-{K_{\text{d}}}\,\frac{\,d{r_{\text{t}}}}{\,dt}-{r_{\text{t}}}\,{K_{\text{p}}}=0}{1.0}
 \end{displaymath}
 The Set-Point ${r_{\text{t}}}$ is a step function and a constant (from \hyperref[setPoint]{A:Set-Point}). Therefore the differential of the set point is zero. Hence the equation reduces to
 
 \begin{displaymath}
-\frac{\,d\frac{\,d{y_{\text{t}}}}{\,dt}}{\,dt}+\left(1+{K_{\text{d}}}\right)\,\frac{\,d{y_{\text{t}}}}{\,dt}+\left(20+{K_{\text{p}}}\right)\,{y_{\text{t}}}-{r_{\text{t}}}\,{K_{\text{p}}}=0
+\resizeExpression{\frac{\,d\frac{\,d{y_{\text{t}}}}{\,dt}}{\,dt}+\left(1+{K_{\text{d}}}\right)\,\frac{\,d{y_{\text{t}}}}{\,dt}+\left(20+{K_{\text{p}}}\right)\,{y_{\text{t}}}-{r_{\text{t}}}\,{K_{\text{p}}}=0}{1.0}
 \end{displaymath}
 \subsubsection{Data Constraints}
 \label{Sec:DataConstraints}

--- a/code/stable/pdcontroller/SRS/PDF/PDController_SRS.tex
+++ b/code/stable/pdcontroller/SRS/PDF/PDController_SRS.tex
@@ -25,6 +25,8 @@
 \newcommand{\lt}{\ensuremath <}
 \newlist{symbDescription}{description}{1}
 \setlist[symbDescription]{noitemsep, topsep=0pt, parsep=0pt, partopsep=0pt}
+\def\inDefScale{0.8}
+\def\outDefScale{1.0}
 \newsavebox{\mybox}
 \newcommand{\resizeExpression}[2]{
   \savebox{\mybox}{$#1$}
@@ -320,7 +322,7 @@ Label & Laplace Transform
         
 \\ \midrule
 Equation & \begin{displaymath}
-           \resizeExpression{{F_{\text{s}}}=\int_{\mathit{-∞}}^{∞}{{f_{\text{t}}}\,e^{-s\,t}}\,dt}{0.8}
+           \resizeExpression{{F_{\text{s}}}=\int_{\mathit{-∞}}^{∞}{{f_{\text{t}}}\,e^{-s\,t}}\,dt}{\inDefScale}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -354,7 +356,7 @@ Label & Inverse Laplace Transform
         
 \\ \midrule
 Equation & \begin{displaymath}
-           \resizeExpression{{f_{\text{t}}}=\mathit{L⁻¹[F(s)]}}{0.8}
+           \resizeExpression{{f_{\text{t}}}=\mathit{L⁻¹[F(s)]}}{\inDefScale}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -386,7 +388,7 @@ Label & Second Order Mass-Spring-Damper System
         
 \\ \midrule
 Equation & \begin{displaymath}
-           \resizeExpression{\frac{1}{m\,s^{2}+c\,s+k}}{0.8}
+           \resizeExpression{\frac{1}{m\,s^{2}+c\,s+k}}{\inDefScale}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -424,7 +426,7 @@ Label & The Transfer Function of the Power Plant
         
 \\ \midrule
 Equation & \begin{displaymath}
-           \resizeExpression{\frac{1}{s^{2}+s+20}}{0.8}
+           \resizeExpression{\frac{1}{s^{2}+s+20}}{\inDefScale}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -465,7 +467,7 @@ Units & Unitless
         
 \\ \midrule
 Equation & \begin{displaymath}
-           \resizeExpression{{E_{\text{s}}}={R_{\text{s}}}-{Y_{\text{s}}}}{0.8}
+           \resizeExpression{{E_{\text{s}}}={R_{\text{s}}}-{Y_{\text{s}}}}{\inDefScale}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -504,7 +506,7 @@ Units & Unitless
         
 \\ \midrule
 Equation & \begin{displaymath}
-           \resizeExpression{{P_{\text{s}}}={K_{\text{p}}}\,{E_{\text{s}}}}{0.8}
+           \resizeExpression{{P_{\text{s}}}={K_{\text{p}}}\,{E_{\text{s}}}}{\inDefScale}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -543,7 +545,7 @@ Units & Unitless
         
 \\ \midrule
 Equation & \begin{displaymath}
-           \resizeExpression{{D_{\text{s}}}={K_{\text{d}}}\,{E_{\text{s}}}\,s}{0.8}
+           \resizeExpression{{D_{\text{s}}}={K_{\text{d}}}\,{E_{\text{s}}}\,s}{\inDefScale}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -583,7 +585,7 @@ Units & Unitless
         
 \\ \midrule
 Equation & \begin{displaymath}
-           \resizeExpression{{C_{\text{s}}}={E_{\text{s}}}\,\left({K_{\text{p}}}+{K_{\text{d}}}\,s\right)}{0.8}
+           \resizeExpression{{C_{\text{s}}}={E_{\text{s}}}\,\left({K_{\text{p}}}+{K_{\text{d}}}\,s\right)}{\inDefScale}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -628,21 +630,21 @@ Output & ${y_{\text{t}}}$
          
 \\ \midrule
 Input Constraints & \begin{displaymath}
-                    \resizeExpression{{r_{\text{t}}}\gt{}0}{0.8}
+                    \resizeExpression{{r_{\text{t}}}\gt{}0}{\inDefScale}
                     \end{displaymath}
                     \begin{displaymath}
-                    \resizeExpression{{K_{\text{p}}}\gt{}0}{0.8}
+                    \resizeExpression{{K_{\text{p}}}\gt{}0}{\inDefScale}
                     \end{displaymath}
                     \begin{displaymath}
-                    \resizeExpression{{K_{\text{d}}}\gt{}0}{0.8}
+                    \resizeExpression{{K_{\text{d}}}\gt{}0}{\inDefScale}
                     \end{displaymath}
 \\ \midrule
 Output Constraints & \begin{displaymath}
-                     \resizeExpression{{y_{\text{t}}}\gt{}0}{0.8}
+                     \resizeExpression{{y_{\text{t}}}\gt{}0}{\inDefScale}
                      \end{displaymath}
 \\ \midrule
 Equation & \begin{displaymath}
-           \resizeExpression{\frac{\,d^{2}{y_{\text{t}}}}{\,dt^{2}}+\left(1+{K_{\text{d}}}\right)\,\frac{\,d{y_{\text{t}}}}{\,dt}+\left(20+{K_{\text{p}}}\right)\,{{y_{\text{t}}}}={r_{\text{t}}}\,{K_{\text{p}}}}{0.8}
+           \resizeExpression{\frac{\,d^{2}{y_{\text{t}}}}{\,dt^{2}}+\left(1+{K_{\text{d}}}\right)\,\frac{\,d{y_{\text{t}}}}{\,dt}+\left(20+{K_{\text{p}}}\right)\,{{y_{\text{t}}}}={r_{\text{t}}}\,{K_{\text{p}}}}{\inDefScale}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -667,22 +669,22 @@ RefBy & \hyperref[outputValues]{FR:Output-Values} and \hyperref[calculateValues]
 The Process Variable ${Y_{\text{s}}}$ in a PD Control Loop is the product of the Process Error (from \hyperref[DD:ddProcessError]{DD:ddProcessError}), Control Variable (from \hyperref[DD:ddCtrlVar]{DD:ddCtrlVar}), and the Power Plant (from \hyperref[GD:gdPowerPlant]{GD:gdPowerPlant}).
 
 \begin{displaymath}
-\resizeExpression{{Y_{\text{s}}}=\left({R_{\text{s}}}-{Y_{\text{s}}}\right)\,\left({K_{\text{p}}}+{K_{\text{d}}}\,s\right)\,\frac{1}{s^{2}+s+20}}{1.0}
+\resizeExpression{{Y_{\text{s}}}=\left({R_{\text{s}}}-{Y_{\text{s}}}\right)\,\left({K_{\text{p}}}+{K_{\text{d}}}\,s\right)\,\frac{1}{s^{2}+s+20}}{\outDefScale}
 \end{displaymath}
 Substituting the values and rearranging the equation.
 
 \begin{displaymath}
-\resizeExpression{s^{2}\,{Y_{\text{s}}}+\left(1+{K_{\text{d}}}\right)\,{Y_{\text{s}}}\,s+\left(20+{K_{\text{p}}}\right)\,{Y_{\text{s}}}-{R_{\text{s}}}\,s\,{K_{\text{d}}}-{R_{\text{s}}}\,{K_{\text{p}}}=0}{1.0}
+\resizeExpression{s^{2}\,{Y_{\text{s}}}+\left(1+{K_{\text{d}}}\right)\,{Y_{\text{s}}}\,s+\left(20+{K_{\text{p}}}\right)\,{Y_{\text{s}}}-{R_{\text{s}}}\,s\,{K_{\text{d}}}-{R_{\text{s}}}\,{K_{\text{p}}}=0}{\outDefScale}
 \end{displaymath}
 Computing the Inverse Laplace Transform of a function (from \hyperref[TM:invLaplaceTransform]{TM:invLaplaceTransform}) of the equation.
 
 \begin{displaymath}
-\resizeExpression{\frac{\,d\frac{\,d{y_{\text{t}}}}{\,dt}}{\,dt}+\left(1+{K_{\text{d}}}\right)\,\frac{\,d{y_{\text{t}}}}{\,dt}+\left(20+{K_{\text{p}}}\right)\,{y_{\text{t}}}-{K_{\text{d}}}\,\frac{\,d{r_{\text{t}}}}{\,dt}-{r_{\text{t}}}\,{K_{\text{p}}}=0}{1.0}
+\resizeExpression{\frac{\,d\frac{\,d{y_{\text{t}}}}{\,dt}}{\,dt}+\left(1+{K_{\text{d}}}\right)\,\frac{\,d{y_{\text{t}}}}{\,dt}+\left(20+{K_{\text{p}}}\right)\,{y_{\text{t}}}-{K_{\text{d}}}\,\frac{\,d{r_{\text{t}}}}{\,dt}-{r_{\text{t}}}\,{K_{\text{p}}}=0}{\outDefScale}
 \end{displaymath}
 The Set-Point ${r_{\text{t}}}$ is a step function and a constant (from \hyperref[setPoint]{A:Set-Point}). Therefore the differential of the set point is zero. Hence the equation reduces to
 
 \begin{displaymath}
-\resizeExpression{\frac{\,d\frac{\,d{y_{\text{t}}}}{\,dt}}{\,dt}+\left(1+{K_{\text{d}}}\right)\,\frac{\,d{y_{\text{t}}}}{\,dt}+\left(20+{K_{\text{p}}}\right)\,{y_{\text{t}}}-{r_{\text{t}}}\,{K_{\text{p}}}=0}{1.0}
+\resizeExpression{\frac{\,d\frac{\,d{y_{\text{t}}}}{\,dt}}{\,dt}+\left(1+{K_{\text{d}}}\right)\,\frac{\,d{y_{\text{t}}}}{\,dt}+\left(20+{K_{\text{p}}}\right)\,{y_{\text{t}}}-{r_{\text{t}}}\,{K_{\text{p}}}=0}{\outDefScale}
 \end{displaymath}
 \subsubsection{Data Constraints}
 \label{Sec:DataConstraints}

--- a/code/stable/pdcontroller/SRS/PDF/PDController_SRS.tex
+++ b/code/stable/pdcontroller/SRS/PDF/PDController_SRS.tex
@@ -27,12 +27,12 @@
 \setlist[symbDescription]{noitemsep, topsep=0pt, parsep=0pt, partopsep=0pt}
 \newsavebox{\mybox}
 \newcommand{\resizeExpression}[2]{
-\savebox{\mybox}{$#1$}
-\ifdim\wd\mybox>#2\linewidth
-\resizebox{#2\textwidth}{!}{\usebox{\mybox}}
-\else
-\usebox{\mybox}
-\fi
+  \savebox{\mybox}{$#1$}
+  \ifdim\wd\mybox>#2\linewidth
+    \resizebox{#2\textwidth}{!}{\usebox{\mybox}}
+  \else
+    \usebox{\mybox}
+  \fi
 }
 \bibliography{bibfile}
 \title{Software Requirements Specification for PD Controller}

--- a/code/stable/projectile/SRS/PDF/Projectile_SRS.tex
+++ b/code/stable/projectile/SRS/PDF/Projectile_SRS.tex
@@ -25,6 +25,8 @@
 \newcommand{\lt}{\ensuremath <}
 \newlist{symbDescription}{description}{1}
 \setlist[symbDescription]{noitemsep, topsep=0pt, parsep=0pt, partopsep=0pt}
+\def\inDefScale{0.8}
+\def\outDefScale{1.0}
 \newsavebox{\mybox}
 \newcommand{\resizeExpression}[2]{
   \savebox{\mybox}{$#1$}
@@ -328,7 +330,7 @@ Label & Acceleration
         
 \\ \midrule
 Equation & \begin{displaymath}
-           \resizeExpression{\symbf{a}\text{(}t\text{)}=\frac{\,d\symbf{v}\text{(}t\text{)}}{\,dt}}{0.8}
+           \resizeExpression{\symbf{a}\text{(}t\text{)}=\frac{\,d\symbf{v}\text{(}t\text{)}}{\,dt}}{\inDefScale}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -358,7 +360,7 @@ Label & Velocity
         
 \\ \midrule
 Equation & \begin{displaymath}
-           \resizeExpression{\symbf{v}\text{(}t\text{)}=\frac{\,d\symbf{p}\text{(}t\text{)}}{\,dt}}{0.8}
+           \resizeExpression{\symbf{v}\text{(}t\text{)}=\frac{\,d\symbf{p}\text{(}t\text{)}}{\,dt}}{\inDefScale}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -395,7 +397,7 @@ Units & $\frac{\text{m}}{\text{s}}$
         
 \\ \midrule
 Equation & \begin{displaymath}
-           \resizeExpression{v\text{(}t\text{)}={v^{\text{i}}}+{a^{c}}\,t}{0.8}
+           \resizeExpression{v\text{(}t\text{)}={v^{\text{i}}}+{a^{c}}\,t}{\inDefScale}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -419,17 +421,17 @@ RefBy & \hyperref[GD:velVec]{GD:velVec} and \hyperref[GD:rectPos]{GD:rectPos}
 Assume we have rectilinear motion of a particle (of negligible size and shape, from \hyperref[pointMass]{A:pointMass}); that is, motion in a straight line. The velocity is $v$ and the acceleration is $a$. The motion in \hyperref[TM:acceleration]{TM:acceleration} is now one-dimensional with a constant acceleration, represented by ${a^{c}}$. The initial velocity (at $t=0$, from \hyperref[timeStartZero]{A:timeStartZero}) is represented by ${v^{\text{i}}}$. From \hyperref[TM:acceleration]{TM:acceleration} in 1D, and using the above symbols we have:
 
 \begin{displaymath}
-\resizeExpression{{a^{c}}=\frac{\,dv}{\,dt}}{1.0}
+\resizeExpression{{a^{c}}=\frac{\,dv}{\,dt}}{\outDefScale}
 \end{displaymath}
 Rearranging and integrating, we have:
 
 \begin{displaymath}
-\resizeExpression{\int_{{v^{\text{i}}}}^{v}{1}\,dv=\int_{0}^{t}{{a^{c}}}\,dt}{1.0}
+\resizeExpression{\int_{{v^{\text{i}}}}^{v}{1}\,dv=\int_{0}^{t}{{a^{c}}}\,dt}{\outDefScale}
 \end{displaymath}
 Performing the integration, we have the required equation:
 
 \begin{displaymath}
-\resizeExpression{v\text{(}t\text{)}={v^{\text{i}}}+{a^{c}}\,t}{1.0}
+\resizeExpression{v\text{(}t\text{)}={v^{\text{i}}}+{a^{c}}\,t}{\outDefScale}
 \end{displaymath}
 \medskip
 \noindent
@@ -446,7 +448,7 @@ Units & ${\text{m}}$
         
 \\ \midrule
 Equation & \begin{displaymath}
-           \resizeExpression{p\text{(}t\text{)}={p^{\text{i}}}+{v^{\text{i}}}\,t+\frac{{a^{c}}\,t^{2}}{2}}{0.8}
+           \resizeExpression{p\text{(}t\text{)}={p^{\text{i}}}+{v^{\text{i}}}\,t+\frac{{a^{c}}\,t^{2}}{2}}{\inDefScale}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -471,22 +473,22 @@ RefBy & \hyperref[GD:posVec]{GD:posVec}
 Assume we have rectilinear motion of a particle (of negligible size and shape, from \hyperref[pointMass]{A:pointMass}); that is, motion in a straight line. The position is $p$ and the velocity is $v$. The motion in \hyperref[TM:velocity]{TM:velocity} is now one-dimensional. The initial position (at $t=0$, from \hyperref[timeStartZero]{A:timeStartZero}) is represented by ${p^{\text{i}}}$. From \hyperref[TM:velocity]{TM:velocity} in 1D, and using the above symbols we have:
 
 \begin{displaymath}
-\resizeExpression{v=\frac{\,dp}{\,dt}}{1.0}
+\resizeExpression{v=\frac{\,dp}{\,dt}}{\outDefScale}
 \end{displaymath}
 Rearranging and integrating, we have:
 
 \begin{displaymath}
-\resizeExpression{\int_{{p^{\text{i}}}}^{p}{1}\,dp=\int_{0}^{t}{v}\,dt}{1.0}
+\resizeExpression{\int_{{p^{\text{i}}}}^{p}{1}\,dp=\int_{0}^{t}{v}\,dt}{\outDefScale}
 \end{displaymath}
 From \hyperref[GD:rectVel]{GD:rectVel}, we can replace $v$:
 
 \begin{displaymath}
-\resizeExpression{\int_{{p^{\text{i}}}}^{p}{1}\,dp=\int_{0}^{t}{{v^{\text{i}}}+{a^{c}}\,t}\,dt}{1.0}
+\resizeExpression{\int_{{p^{\text{i}}}}^{p}{1}\,dp=\int_{0}^{t}{{v^{\text{i}}}+{a^{c}}\,t}\,dt}{\outDefScale}
 \end{displaymath}
 Performing the integration, we have the required equation:
 
 \begin{displaymath}
-\resizeExpression{p\text{(}t\text{)}={p^{\text{i}}}+{v^{\text{i}}}\,t+\frac{{a^{c}}\,t^{2}}{2}}{1.0}
+\resizeExpression{p\text{(}t\text{)}={p^{\text{i}}}+{v^{\text{i}}}\,t+\frac{{a^{c}}\,t^{2}}{2}}{\outDefScale}
 \end{displaymath}
 \medskip
 \noindent
@@ -506,7 +508,7 @@ Equation & \begin{displaymath}
            \resizeExpression{\symbf{v}\text{(}t\text{)}=\begin{bmatrix}
                                                         {{v_{\text{x}}}^{\text{i}}}+{{a_{\text{x}}}^{\text{c}}}\,t\\
                                                         {{v_{\text{y}}}^{\text{i}}}+{{a_{\text{y}}}^{\text{c}}}\,t
-                                                        \end{bmatrix}}{0.8}
+                                                        \end{bmatrix}}{\inDefScale}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -546,7 +548,7 @@ For a two-dimensional Cartesian coordinate system (\hyperref[twoDMotion]{A:twoDM
 \resizeExpression{\symbf{v}\text{(}t\text{)}=\begin{bmatrix}
                                              {{v_{\text{x}}}^{\text{i}}}+{{a_{\text{x}}}^{\text{c}}}\,t\\
                                              {{v_{\text{y}}}^{\text{i}}}+{{a_{\text{y}}}^{\text{c}}}\,t
-                                             \end{bmatrix}}{1.0}
+                                             \end{bmatrix}}{\outDefScale}
 \end{displaymath}
 \medskip
 \noindent
@@ -566,7 +568,7 @@ Equation & \begin{displaymath}
            \resizeExpression{\symbf{p}\text{(}t\text{)}=\begin{bmatrix}
                                                         {{p_{\text{x}}}^{\text{i}}}+{{v_{\text{x}}}^{\text{i}}}\,t+\frac{{{a_{\text{x}}}^{\text{c}}}\,t^{2}}{2}\\
                                                         {{p_{\text{y}}}^{\text{i}}}+{{v_{\text{y}}}^{\text{i}}}\,t+\frac{{{a_{\text{y}}}^{\text{c}}}\,t^{2}}{2}
-                                                        \end{bmatrix}}{0.8}
+                                                        \end{bmatrix}}{\inDefScale}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -612,7 +614,7 @@ For a two-dimensional Cartesian coordinate system (\hyperref[twoDMotion]{A:twoDM
 \resizeExpression{\symbf{p}\text{(}t\text{)}=\begin{bmatrix}
                                              {{p_{\text{x}}}^{\text{i}}}+{{v_{\text{x}}}^{\text{i}}}\,t+\frac{{{a_{\text{x}}}^{\text{c}}}\,t^{2}}{2}\\
                                              {{p_{\text{y}}}^{\text{i}}}+{{v_{\text{y}}}^{\text{i}}}\,t+\frac{{{a_{\text{y}}}^{\text{c}}}\,t^{2}}{2}
-                                             \end{bmatrix}}{1.0}
+                                             \end{bmatrix}}{\outDefScale}
 \end{displaymath}
 \subsubsection{Data Definitions}
 \label{Sec:DDs}
@@ -636,7 +638,7 @@ Units & $\frac{\text{m}}{\text{s}}$
         
 \\ \midrule
 Equation & \begin{displaymath}
-           \resizeExpression{v=\|\symbf{v}\text{(}t\text{)}\|}{0.8}
+           \resizeExpression{v=\|\symbf{v}\text{(}t\text{)}\|}{\inDefScale}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -674,7 +676,7 @@ Units & $\frac{\text{m}}{\text{s}}$
         
 \\ \midrule
 Equation & \begin{displaymath}
-           \resizeExpression{{{v_{\text{x}}}^{\text{i}}}={v^{\text{i}}}\,\cos\left(θ\right)}{0.8}
+           \resizeExpression{{{v_{\text{x}}}^{\text{i}}}={v^{\text{i}}}\,\cos\left(θ\right)}{\inDefScale}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -715,7 +717,7 @@ Units & $\frac{\text{m}}{\text{s}}$
         
 \\ \midrule
 Equation & \begin{displaymath}
-           \resizeExpression{{{v_{\text{y}}}^{\text{i}}}={v^{\text{i}}}\,\sin\left(θ\right)}{0.8}
+           \resizeExpression{{{v_{\text{y}}}^{\text{i}}}={v^{\text{i}}}\,\sin\left(θ\right)}{\inDefScale}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -760,18 +762,18 @@ Output & ${t_{\text{flight}}}$
          
 \\ \midrule
 Input Constraints & \begin{displaymath}
-                    \resizeExpression{{v_{\text{launch}}}\gt{}0}{0.8}
+                    \resizeExpression{{v_{\text{launch}}}\gt{}0}{\inDefScale}
                     \end{displaymath}
                     \begin{displaymath}
-                    \resizeExpression{0\lt{}θ\lt{}\frac{π}{2}}{0.8}
+                    \resizeExpression{0\lt{}θ\lt{}\frac{π}{2}}{\inDefScale}
                     \end{displaymath}
 \\ \midrule
 Output Constraints & \begin{displaymath}
-                     \resizeExpression{{t_{\text{flight}}}\gt{}0}{0.8}
+                     \resizeExpression{{t_{\text{flight}}}\gt{}0}{\inDefScale}
                      \end{displaymath}
 \\ \midrule
 Equation & \begin{displaymath}
-           \resizeExpression{{t_{\text{flight}}}=\frac{2\,{v_{\text{launch}}}\,\sin\left(θ\right)}{g}}{0.8}
+           \resizeExpression{{t_{\text{flight}}}=\frac{2\,{v_{\text{launch}}}\,\sin\left(θ\right)}{g}}{\inDefScale}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -802,27 +804,27 @@ RefBy & \hyperref[IM:calOfLandingDist]{IM:calOfLandingDist}, \hyperref[outputVal
 We know that ${{p_{\text{y}}}^{\text{i}}}=0$ (\hyperref[launchOrigin]{A:launchOrigin}) and ${{a_{\text{y}}}^{\text{c}}}=-g$ (\hyperref[accelYGravity]{A:accelYGravity}). Substituting these values into the y-direction of \hyperref[GD:posVec]{GD:posVec} gives us:
 
 \begin{displaymath}
-\resizeExpression{{p_{\text{y}}}={{v_{\text{y}}}^{\text{i}}}\,t-\frac{g\,t^{2}}{2}}{1.0}
+\resizeExpression{{p_{\text{y}}}={{v_{\text{y}}}^{\text{i}}}\,t-\frac{g\,t^{2}}{2}}{\outDefScale}
 \end{displaymath}
 To find the time that the projectile lands, we want to find the $t$ value (${t_{\text{flight}}}$) where ${p_{\text{y}}}=0$ (since the target is on the $x$-axis from \hyperref[targetXAxis]{A:targetXAxis}). From the equation above we get:
 
 \begin{displaymath}
-\resizeExpression{{{v_{\text{y}}}^{\text{i}}}\,{t_{\text{flight}}}-\frac{g\,{t_{\text{flight}}}^{2}}{2}=0}{1.0}
+\resizeExpression{{{v_{\text{y}}}^{\text{i}}}\,{t_{\text{flight}}}-\frac{g\,{t_{\text{flight}}}^{2}}{2}=0}{\outDefScale}
 \end{displaymath}
 Dividing by ${t_{\text{flight}}}$ (with the constraint ${t_{\text{flight}}}\gt{}0$) gives us:
 
 \begin{displaymath}
-\resizeExpression{{{v_{\text{y}}}^{\text{i}}}-\frac{g\,{t_{\text{flight}}}}{2}=0}{1.0}
+\resizeExpression{{{v_{\text{y}}}^{\text{i}}}-\frac{g\,{t_{\text{flight}}}}{2}=0}{\outDefScale}
 \end{displaymath}
 Solving for ${t_{\text{flight}}}$ gives us:
 
 \begin{displaymath}
-\resizeExpression{{t_{\text{flight}}}=\frac{2\,{{v_{\text{y}}}^{\text{i}}}}{g}}{1.0}
+\resizeExpression{{t_{\text{flight}}}=\frac{2\,{{v_{\text{y}}}^{\text{i}}}}{g}}{\outDefScale}
 \end{displaymath}
 From \hyperref[DD:speedIY]{DD:speedIY} (with ${v^{\text{i}}}={v_{\text{launch}}}$) we can replace ${{v_{\text{y}}}^{\text{i}}}$:
 
 \begin{displaymath}
-\resizeExpression{{t_{\text{flight}}}=\frac{2\,{v_{\text{launch}}}\,\sin\left(θ\right)}{g}}{1.0}
+\resizeExpression{{t_{\text{flight}}}=\frac{2\,{v_{\text{launch}}}\,\sin\left(θ\right)}{g}}{\outDefScale}
 \end{displaymath}
 \medskip
 \noindent
@@ -842,18 +844,18 @@ Output & ${p_{\text{land}}}$
          
 \\ \midrule
 Input Constraints & \begin{displaymath}
-                    \resizeExpression{{v_{\text{launch}}}\gt{}0}{0.8}
+                    \resizeExpression{{v_{\text{launch}}}\gt{}0}{\inDefScale}
                     \end{displaymath}
                     \begin{displaymath}
-                    \resizeExpression{0\lt{}θ\lt{}\frac{π}{2}}{0.8}
+                    \resizeExpression{0\lt{}θ\lt{}\frac{π}{2}}{\inDefScale}
                     \end{displaymath}
 \\ \midrule
 Output Constraints & \begin{displaymath}
-                     \resizeExpression{{p_{\text{land}}}\gt{}0}{0.8}
+                     \resizeExpression{{p_{\text{land}}}\gt{}0}{\inDefScale}
                      \end{displaymath}
 \\ \midrule
 Equation & \begin{displaymath}
-           \resizeExpression{{p_{\text{land}}}=\frac{2\,{v_{\text{launch}}}^{2}\,\sin\left(θ\right)\,\cos\left(θ\right)}{g}}{0.8}
+           \resizeExpression{{p_{\text{land}}}=\frac{2\,{v_{\text{launch}}}^{2}\,\sin\left(θ\right)\,\cos\left(θ\right)}{g}}{\inDefScale}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -884,22 +886,22 @@ RefBy & \hyperref[IM:offsetIM]{IM:offsetIM} and \hyperref[calcValues]{FR:Calcula
 We know that ${{p_{\text{x}}}^{\text{i}}}=0$ (\hyperref[launchOrigin]{A:launchOrigin}) and ${{a_{\text{x}}}^{\text{c}}}=0$ (\hyperref[accelXZero]{A:accelXZero}). Substituting these values into the x-direction of \hyperref[GD:posVec]{GD:posVec} gives us:
 
 \begin{displaymath}
-\resizeExpression{{p_{\text{x}}}={{v_{\text{x}}}^{\text{i}}}\,t}{1.0}
+\resizeExpression{{p_{\text{x}}}={{v_{\text{x}}}^{\text{i}}}\,t}{\outDefScale}
 \end{displaymath}
 To find the landing position, we want to find the ${p_{\text{x}}}$ value (${p_{\text{land}}}$) at flight duration (from \hyperref[IM:calOfLandingTime]{IM:calOfLandingTime}):
 
 \begin{displaymath}
-\resizeExpression{{p_{\text{land}}}=\frac{{{v_{\text{x}}}^{\text{i}}}\cdot{}2\,{v_{\text{launch}}}\,\sin\left(θ\right)}{g}}{1.0}
+\resizeExpression{{p_{\text{land}}}=\frac{{{v_{\text{x}}}^{\text{i}}}\cdot{}2\,{v_{\text{launch}}}\,\sin\left(θ\right)}{g}}{\outDefScale}
 \end{displaymath}
 From \hyperref[DD:speedIX]{DD:speedIX} (with ${v^{\text{i}}}={v_{\text{launch}}}$) we can replace ${{v_{\text{x}}}^{\text{i}}}$:
 
 \begin{displaymath}
-\resizeExpression{{p_{\text{land}}}=\frac{{v_{\text{launch}}}\,\cos\left(θ\right)\cdot{}2\,{v_{\text{launch}}}\,\sin\left(θ\right)}{g}}{1.0}
+\resizeExpression{{p_{\text{land}}}=\frac{{v_{\text{launch}}}\,\cos\left(θ\right)\cdot{}2\,{v_{\text{launch}}}\,\sin\left(θ\right)}{g}}{\outDefScale}
 \end{displaymath}
 Rearranging this gives us the required equation:
 
 \begin{displaymath}
-\resizeExpression{{p_{\text{land}}}=\frac{2\,{v_{\text{launch}}}^{2}\,\sin\left(θ\right)\,\cos\left(θ\right)}{g}}{1.0}
+\resizeExpression{{p_{\text{land}}}=\frac{2\,{v_{\text{launch}}}^{2}\,\sin\left(θ\right)\,\cos\left(θ\right)}{g}}{\outDefScale}
 \end{displaymath}
 \medskip
 \noindent
@@ -919,16 +921,16 @@ Output & ${d_{\text{offset}}}$
          
 \\ \midrule
 Input Constraints & \begin{displaymath}
-                    \resizeExpression{{p_{\text{land}}}\gt{}0}{0.8}
+                    \resizeExpression{{p_{\text{land}}}\gt{}0}{\inDefScale}
                     \end{displaymath}
                     \begin{displaymath}
-                    \resizeExpression{{p_{\text{target}}}\gt{}0}{0.8}
+                    \resizeExpression{{p_{\text{target}}}\gt{}0}{\inDefScale}
                     \end{displaymath}
 \\ \midrule
 Output Constraints & 
 \\ \midrule
 Equation & \begin{displaymath}
-           \resizeExpression{{d_{\text{offset}}}={p_{\text{land}}}-{p_{\text{target}}}}{0.8}
+           \resizeExpression{{d_{\text{offset}}}={p_{\text{land}}}-{p_{\text{target}}}}{\inDefScale}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -969,10 +971,10 @@ Output & $s$
          
 \\ \midrule
 Input Constraints & \begin{displaymath}
-                    \resizeExpression{{d_{\text{offset}}}\gt{}-{p_{\text{target}}}}{0.8}
+                    \resizeExpression{{d_{\text{offset}}}\gt{}-{p_{\text{target}}}}{\inDefScale}
                     \end{displaymath}
                     \begin{displaymath}
-                    \resizeExpression{{p_{\text{target}}}\gt{}0}{0.8}
+                    \resizeExpression{{p_{\text{target}}}\gt{}0}{\inDefScale}
                     \end{displaymath}
 \\ \midrule
 Output Constraints & 
@@ -982,7 +984,7 @@ Equation & \begin{displaymath}
                                \text{``The target was hit.''}, & |\frac{{d_{\text{offset}}}}{{p_{\text{target}}}}|\lt{}ε\\
                                \text{``The projectile fell short.''}, & {d_{\text{offset}}}\lt{}0\\
                                \text{``The projectile went long.''}, & {d_{\text{offset}}}\gt{}0
-                               \end{cases}}{0.8}
+                               \end{cases}}{\inDefScale}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}

--- a/code/stable/projectile/SRS/PDF/Projectile_SRS.tex
+++ b/code/stable/projectile/SRS/PDF/Projectile_SRS.tex
@@ -27,12 +27,12 @@
 \setlist[symbDescription]{noitemsep, topsep=0pt, parsep=0pt, partopsep=0pt}
 \newsavebox{\mybox}
 \newcommand{\resizeExpression}[2]{
-\savebox{\mybox}{$#1$}
-\ifdim\wd\mybox>#2\linewidth
-\resizebox{#2\textwidth}{!}{\usebox{\mybox}}
-\else
-\usebox{\mybox}
-\fi
+  \savebox{\mybox}{$#1$}
+  \ifdim\wd\mybox>#2\linewidth
+    \resizebox{#2\textwidth}{!}{\usebox{\mybox}}
+  \else
+    \usebox{\mybox}
+  \fi
 }
 \bibliography{bibfile}
 \title{Software Requirements Specification for Projectile}

--- a/code/stable/projectile/SRS/PDF/Projectile_SRS.tex
+++ b/code/stable/projectile/SRS/PDF/Projectile_SRS.tex
@@ -15,6 +15,8 @@
 \usepackage{svg}
 \usepackage{float}
 \usepackage{enumitem}
+\usepackage{graphicx}
+\usepackage{calc}
 \usepackage{filecontents}
 \usepackage[backend=bibtex]{biblatex}
 \usepackage{url}
@@ -23,6 +25,15 @@
 \newcommand{\lt}{\ensuremath <}
 \newlist{symbDescription}{description}{1}
 \setlist[symbDescription]{noitemsep, topsep=0pt, parsep=0pt, partopsep=0pt}
+\newsavebox{\mybox}
+\newcommand{\resizeExpression}[2]{
+\savebox{\mybox}{$#1$}
+\ifdim\wd\mybox>#2\linewidth
+\resizebox{#2\textwidth}{!}{\usebox{\mybox}}
+\else
+\usebox{\mybox}
+\fi
+}
 \bibliography{bibfile}
 \title{Software Requirements Specification for Projectile}
 \author{Samuel J. Crawford, Brooks MacLachlan, and W. Spencer Smith}
@@ -317,7 +328,7 @@ Label & Acceleration
         
 \\ \midrule
 Equation & \begin{displaymath}
-           \symbf{a}\text{(}t\text{)}=\frac{\,d\symbf{v}\text{(}t\text{)}}{\,dt}
+           \resizeExpression{\symbf{a}\text{(}t\text{)}=\frac{\,d\symbf{v}\text{(}t\text{)}}{\,dt}}{0.8}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -347,7 +358,7 @@ Label & Velocity
         
 \\ \midrule
 Equation & \begin{displaymath}
-           \symbf{v}\text{(}t\text{)}=\frac{\,d\symbf{p}\text{(}t\text{)}}{\,dt}
+           \resizeExpression{\symbf{v}\text{(}t\text{)}=\frac{\,d\symbf{p}\text{(}t\text{)}}{\,dt}}{0.8}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -384,7 +395,7 @@ Units & $\frac{\text{m}}{\text{s}}$
         
 \\ \midrule
 Equation & \begin{displaymath}
-           v\text{(}t\text{)}={v^{\text{i}}}+{a^{c}}\,t
+           \resizeExpression{v\text{(}t\text{)}={v^{\text{i}}}+{a^{c}}\,t}{0.8}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -408,17 +419,17 @@ RefBy & \hyperref[GD:velVec]{GD:velVec} and \hyperref[GD:rectPos]{GD:rectPos}
 Assume we have rectilinear motion of a particle (of negligible size and shape, from \hyperref[pointMass]{A:pointMass}); that is, motion in a straight line. The velocity is $v$ and the acceleration is $a$. The motion in \hyperref[TM:acceleration]{TM:acceleration} is now one-dimensional with a constant acceleration, represented by ${a^{c}}$. The initial velocity (at $t=0$, from \hyperref[timeStartZero]{A:timeStartZero}) is represented by ${v^{\text{i}}}$. From \hyperref[TM:acceleration]{TM:acceleration} in 1D, and using the above symbols we have:
 
 \begin{displaymath}
-{a^{c}}=\frac{\,dv}{\,dt}
+\resizeExpression{{a^{c}}=\frac{\,dv}{\,dt}}{1.0}
 \end{displaymath}
 Rearranging and integrating, we have:
 
 \begin{displaymath}
-\int_{{v^{\text{i}}}}^{v}{1}\,dv=\int_{0}^{t}{{a^{c}}}\,dt
+\resizeExpression{\int_{{v^{\text{i}}}}^{v}{1}\,dv=\int_{0}^{t}{{a^{c}}}\,dt}{1.0}
 \end{displaymath}
 Performing the integration, we have the required equation:
 
 \begin{displaymath}
-v\text{(}t\text{)}={v^{\text{i}}}+{a^{c}}\,t
+\resizeExpression{v\text{(}t\text{)}={v^{\text{i}}}+{a^{c}}\,t}{1.0}
 \end{displaymath}
 \medskip
 \noindent
@@ -435,7 +446,7 @@ Units & ${\text{m}}$
         
 \\ \midrule
 Equation & \begin{displaymath}
-           p\text{(}t\text{)}={p^{\text{i}}}+{v^{\text{i}}}\,t+\frac{{a^{c}}\,t^{2}}{2}
+           \resizeExpression{p\text{(}t\text{)}={p^{\text{i}}}+{v^{\text{i}}}\,t+\frac{{a^{c}}\,t^{2}}{2}}{0.8}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -460,22 +471,22 @@ RefBy & \hyperref[GD:posVec]{GD:posVec}
 Assume we have rectilinear motion of a particle (of negligible size and shape, from \hyperref[pointMass]{A:pointMass}); that is, motion in a straight line. The position is $p$ and the velocity is $v$. The motion in \hyperref[TM:velocity]{TM:velocity} is now one-dimensional. The initial position (at $t=0$, from \hyperref[timeStartZero]{A:timeStartZero}) is represented by ${p^{\text{i}}}$. From \hyperref[TM:velocity]{TM:velocity} in 1D, and using the above symbols we have:
 
 \begin{displaymath}
-v=\frac{\,dp}{\,dt}
+\resizeExpression{v=\frac{\,dp}{\,dt}}{1.0}
 \end{displaymath}
 Rearranging and integrating, we have:
 
 \begin{displaymath}
-\int_{{p^{\text{i}}}}^{p}{1}\,dp=\int_{0}^{t}{v}\,dt
+\resizeExpression{\int_{{p^{\text{i}}}}^{p}{1}\,dp=\int_{0}^{t}{v}\,dt}{1.0}
 \end{displaymath}
 From \hyperref[GD:rectVel]{GD:rectVel}, we can replace $v$:
 
 \begin{displaymath}
-\int_{{p^{\text{i}}}}^{p}{1}\,dp=\int_{0}^{t}{{v^{\text{i}}}+{a^{c}}\,t}\,dt
+\resizeExpression{\int_{{p^{\text{i}}}}^{p}{1}\,dp=\int_{0}^{t}{{v^{\text{i}}}+{a^{c}}\,t}\,dt}{1.0}
 \end{displaymath}
 Performing the integration, we have the required equation:
 
 \begin{displaymath}
-p\text{(}t\text{)}={p^{\text{i}}}+{v^{\text{i}}}\,t+\frac{{a^{c}}\,t^{2}}{2}
+\resizeExpression{p\text{(}t\text{)}={p^{\text{i}}}+{v^{\text{i}}}\,t+\frac{{a^{c}}\,t^{2}}{2}}{1.0}
 \end{displaymath}
 \medskip
 \noindent
@@ -492,10 +503,10 @@ Units & $\frac{\text{m}}{\text{s}}$
         
 \\ \midrule
 Equation & \begin{displaymath}
-           \symbf{v}\text{(}t\text{)}=\begin{bmatrix}
-                                      {{v_{\text{x}}}^{\text{i}}}+{{a_{\text{x}}}^{\text{c}}}\,t\\
-                                      {{v_{\text{y}}}^{\text{i}}}+{{a_{\text{y}}}^{\text{c}}}\,t
-                                      \end{bmatrix}
+           \resizeExpression{\symbf{v}\text{(}t\text{)}=\begin{bmatrix}
+                                                        {{v_{\text{x}}}^{\text{i}}}+{{a_{\text{x}}}^{\text{c}}}\,t\\
+                                                        {{v_{\text{y}}}^{\text{i}}}+{{a_{\text{y}}}^{\text{c}}}\,t
+                                                        \end{bmatrix}}{0.8}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -532,10 +543,10 @@ For a two-dimensional Cartesian coordinate system (\hyperref[twoDMotion]{A:twoDM
                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      \end{bmatrix}$. Since we have a Cartesian coordinate system, \hyperref[GD:rectVel]{GD:rectVel} can be applied to each coordinate of the velocity vector to yield the required equation:
 
 \begin{displaymath}
-\symbf{v}\text{(}t\text{)}=\begin{bmatrix}
-                           {{v_{\text{x}}}^{\text{i}}}+{{a_{\text{x}}}^{\text{c}}}\,t\\
-                           {{v_{\text{y}}}^{\text{i}}}+{{a_{\text{y}}}^{\text{c}}}\,t
-                           \end{bmatrix}
+\resizeExpression{\symbf{v}\text{(}t\text{)}=\begin{bmatrix}
+                                             {{v_{\text{x}}}^{\text{i}}}+{{a_{\text{x}}}^{\text{c}}}\,t\\
+                                             {{v_{\text{y}}}^{\text{i}}}+{{a_{\text{y}}}^{\text{c}}}\,t
+                                             \end{bmatrix}}{1.0}
 \end{displaymath}
 \medskip
 \noindent
@@ -552,10 +563,10 @@ Units & ${\text{m}}$
         
 \\ \midrule
 Equation & \begin{displaymath}
-           \symbf{p}\text{(}t\text{)}=\begin{bmatrix}
-                                      {{p_{\text{x}}}^{\text{i}}}+{{v_{\text{x}}}^{\text{i}}}\,t+\frac{{{a_{\text{x}}}^{\text{c}}}\,t^{2}}{2}\\
-                                      {{p_{\text{y}}}^{\text{i}}}+{{v_{\text{y}}}^{\text{i}}}\,t+\frac{{{a_{\text{y}}}^{\text{c}}}\,t^{2}}{2}
-                                      \end{bmatrix}
+           \resizeExpression{\symbf{p}\text{(}t\text{)}=\begin{bmatrix}
+                                                        {{p_{\text{x}}}^{\text{i}}}+{{v_{\text{x}}}^{\text{i}}}\,t+\frac{{{a_{\text{x}}}^{\text{c}}}\,t^{2}}{2}\\
+                                                        {{p_{\text{y}}}^{\text{i}}}+{{v_{\text{y}}}^{\text{i}}}\,t+\frac{{{a_{\text{y}}}^{\text{c}}}\,t^{2}}{2}
+                                                        \end{bmatrix}}{0.8}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -598,10 +609,10 @@ For a two-dimensional Cartesian coordinate system (\hyperref[twoDMotion]{A:twoDM
                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          \end{bmatrix}$. Since we have a Cartesian coordinate system, \hyperref[GD:rectPos]{GD:rectPos} can be applied to each coordinate of the position vector to yield the required equation:
 
 \begin{displaymath}
-\symbf{p}\text{(}t\text{)}=\begin{bmatrix}
-                           {{p_{\text{x}}}^{\text{i}}}+{{v_{\text{x}}}^{\text{i}}}\,t+\frac{{{a_{\text{x}}}^{\text{c}}}\,t^{2}}{2}\\
-                           {{p_{\text{y}}}^{\text{i}}}+{{v_{\text{y}}}^{\text{i}}}\,t+\frac{{{a_{\text{y}}}^{\text{c}}}\,t^{2}}{2}
-                           \end{bmatrix}
+\resizeExpression{\symbf{p}\text{(}t\text{)}=\begin{bmatrix}
+                                             {{p_{\text{x}}}^{\text{i}}}+{{v_{\text{x}}}^{\text{i}}}\,t+\frac{{{a_{\text{x}}}^{\text{c}}}\,t^{2}}{2}\\
+                                             {{p_{\text{y}}}^{\text{i}}}+{{v_{\text{y}}}^{\text{i}}}\,t+\frac{{{a_{\text{y}}}^{\text{c}}}\,t^{2}}{2}
+                                             \end{bmatrix}}{1.0}
 \end{displaymath}
 \subsubsection{Data Definitions}
 \label{Sec:DDs}
@@ -625,7 +636,7 @@ Units & $\frac{\text{m}}{\text{s}}$
         
 \\ \midrule
 Equation & \begin{displaymath}
-           v=\|\symbf{v}\text{(}t\text{)}\|
+           \resizeExpression{v=\|\symbf{v}\text{(}t\text{)}\|}{0.8}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -663,7 +674,7 @@ Units & $\frac{\text{m}}{\text{s}}$
         
 \\ \midrule
 Equation & \begin{displaymath}
-           {{v_{\text{x}}}^{\text{i}}}={v^{\text{i}}}\,\cos\left(θ\right)
+           \resizeExpression{{{v_{\text{x}}}^{\text{i}}}={v^{\text{i}}}\,\cos\left(θ\right)}{0.8}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -704,7 +715,7 @@ Units & $\frac{\text{m}}{\text{s}}$
         
 \\ \midrule
 Equation & \begin{displaymath}
-           {{v_{\text{y}}}^{\text{i}}}={v^{\text{i}}}\,\sin\left(θ\right)
+           \resizeExpression{{{v_{\text{y}}}^{\text{i}}}={v^{\text{i}}}\,\sin\left(θ\right)}{0.8}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -749,18 +760,18 @@ Output & ${t_{\text{flight}}}$
          
 \\ \midrule
 Input Constraints & \begin{displaymath}
-                    {v_{\text{launch}}}\gt{}0
+                    \resizeExpression{{v_{\text{launch}}}\gt{}0}{0.8}
                     \end{displaymath}
                     \begin{displaymath}
-                    0\lt{}θ\lt{}\frac{π}{2}
+                    \resizeExpression{0\lt{}θ\lt{}\frac{π}{2}}{0.8}
                     \end{displaymath}
 \\ \midrule
 Output Constraints & \begin{displaymath}
-                     {t_{\text{flight}}}\gt{}0
+                     \resizeExpression{{t_{\text{flight}}}\gt{}0}{0.8}
                      \end{displaymath}
 \\ \midrule
 Equation & \begin{displaymath}
-           {t_{\text{flight}}}=\frac{2\,{v_{\text{launch}}}\,\sin\left(θ\right)}{g}
+           \resizeExpression{{t_{\text{flight}}}=\frac{2\,{v_{\text{launch}}}\,\sin\left(θ\right)}{g}}{0.8}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -791,27 +802,27 @@ RefBy & \hyperref[IM:calOfLandingDist]{IM:calOfLandingDist}, \hyperref[outputVal
 We know that ${{p_{\text{y}}}^{\text{i}}}=0$ (\hyperref[launchOrigin]{A:launchOrigin}) and ${{a_{\text{y}}}^{\text{c}}}=-g$ (\hyperref[accelYGravity]{A:accelYGravity}). Substituting these values into the y-direction of \hyperref[GD:posVec]{GD:posVec} gives us:
 
 \begin{displaymath}
-{p_{\text{y}}}={{v_{\text{y}}}^{\text{i}}}\,t-\frac{g\,t^{2}}{2}
+\resizeExpression{{p_{\text{y}}}={{v_{\text{y}}}^{\text{i}}}\,t-\frac{g\,t^{2}}{2}}{1.0}
 \end{displaymath}
 To find the time that the projectile lands, we want to find the $t$ value (${t_{\text{flight}}}$) where ${p_{\text{y}}}=0$ (since the target is on the $x$-axis from \hyperref[targetXAxis]{A:targetXAxis}). From the equation above we get:
 
 \begin{displaymath}
-{{v_{\text{y}}}^{\text{i}}}\,{t_{\text{flight}}}-\frac{g\,{t_{\text{flight}}}^{2}}{2}=0
+\resizeExpression{{{v_{\text{y}}}^{\text{i}}}\,{t_{\text{flight}}}-\frac{g\,{t_{\text{flight}}}^{2}}{2}=0}{1.0}
 \end{displaymath}
 Dividing by ${t_{\text{flight}}}$ (with the constraint ${t_{\text{flight}}}\gt{}0$) gives us:
 
 \begin{displaymath}
-{{v_{\text{y}}}^{\text{i}}}-\frac{g\,{t_{\text{flight}}}}{2}=0
+\resizeExpression{{{v_{\text{y}}}^{\text{i}}}-\frac{g\,{t_{\text{flight}}}}{2}=0}{1.0}
 \end{displaymath}
 Solving for ${t_{\text{flight}}}$ gives us:
 
 \begin{displaymath}
-{t_{\text{flight}}}=\frac{2\,{{v_{\text{y}}}^{\text{i}}}}{g}
+\resizeExpression{{t_{\text{flight}}}=\frac{2\,{{v_{\text{y}}}^{\text{i}}}}{g}}{1.0}
 \end{displaymath}
 From \hyperref[DD:speedIY]{DD:speedIY} (with ${v^{\text{i}}}={v_{\text{launch}}}$) we can replace ${{v_{\text{y}}}^{\text{i}}}$:
 
 \begin{displaymath}
-{t_{\text{flight}}}=\frac{2\,{v_{\text{launch}}}\,\sin\left(θ\right)}{g}
+\resizeExpression{{t_{\text{flight}}}=\frac{2\,{v_{\text{launch}}}\,\sin\left(θ\right)}{g}}{1.0}
 \end{displaymath}
 \medskip
 \noindent
@@ -831,18 +842,18 @@ Output & ${p_{\text{land}}}$
          
 \\ \midrule
 Input Constraints & \begin{displaymath}
-                    {v_{\text{launch}}}\gt{}0
+                    \resizeExpression{{v_{\text{launch}}}\gt{}0}{0.8}
                     \end{displaymath}
                     \begin{displaymath}
-                    0\lt{}θ\lt{}\frac{π}{2}
+                    \resizeExpression{0\lt{}θ\lt{}\frac{π}{2}}{0.8}
                     \end{displaymath}
 \\ \midrule
 Output Constraints & \begin{displaymath}
-                     {p_{\text{land}}}\gt{}0
+                     \resizeExpression{{p_{\text{land}}}\gt{}0}{0.8}
                      \end{displaymath}
 \\ \midrule
 Equation & \begin{displaymath}
-           {p_{\text{land}}}=\frac{2\,{v_{\text{launch}}}^{2}\,\sin\left(θ\right)\,\cos\left(θ\right)}{g}
+           \resizeExpression{{p_{\text{land}}}=\frac{2\,{v_{\text{launch}}}^{2}\,\sin\left(θ\right)\,\cos\left(θ\right)}{g}}{0.8}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -873,22 +884,22 @@ RefBy & \hyperref[IM:offsetIM]{IM:offsetIM} and \hyperref[calcValues]{FR:Calcula
 We know that ${{p_{\text{x}}}^{\text{i}}}=0$ (\hyperref[launchOrigin]{A:launchOrigin}) and ${{a_{\text{x}}}^{\text{c}}}=0$ (\hyperref[accelXZero]{A:accelXZero}). Substituting these values into the x-direction of \hyperref[GD:posVec]{GD:posVec} gives us:
 
 \begin{displaymath}
-{p_{\text{x}}}={{v_{\text{x}}}^{\text{i}}}\,t
+\resizeExpression{{p_{\text{x}}}={{v_{\text{x}}}^{\text{i}}}\,t}{1.0}
 \end{displaymath}
 To find the landing position, we want to find the ${p_{\text{x}}}$ value (${p_{\text{land}}}$) at flight duration (from \hyperref[IM:calOfLandingTime]{IM:calOfLandingTime}):
 
 \begin{displaymath}
-{p_{\text{land}}}=\frac{{{v_{\text{x}}}^{\text{i}}}\cdot{}2\,{v_{\text{launch}}}\,\sin\left(θ\right)}{g}
+\resizeExpression{{p_{\text{land}}}=\frac{{{v_{\text{x}}}^{\text{i}}}\cdot{}2\,{v_{\text{launch}}}\,\sin\left(θ\right)}{g}}{1.0}
 \end{displaymath}
 From \hyperref[DD:speedIX]{DD:speedIX} (with ${v^{\text{i}}}={v_{\text{launch}}}$) we can replace ${{v_{\text{x}}}^{\text{i}}}$:
 
 \begin{displaymath}
-{p_{\text{land}}}=\frac{{v_{\text{launch}}}\,\cos\left(θ\right)\cdot{}2\,{v_{\text{launch}}}\,\sin\left(θ\right)}{g}
+\resizeExpression{{p_{\text{land}}}=\frac{{v_{\text{launch}}}\,\cos\left(θ\right)\cdot{}2\,{v_{\text{launch}}}\,\sin\left(θ\right)}{g}}{1.0}
 \end{displaymath}
 Rearranging this gives us the required equation:
 
 \begin{displaymath}
-{p_{\text{land}}}=\frac{2\,{v_{\text{launch}}}^{2}\,\sin\left(θ\right)\,\cos\left(θ\right)}{g}
+\resizeExpression{{p_{\text{land}}}=\frac{2\,{v_{\text{launch}}}^{2}\,\sin\left(θ\right)\,\cos\left(θ\right)}{g}}{1.0}
 \end{displaymath}
 \medskip
 \noindent
@@ -908,16 +919,16 @@ Output & ${d_{\text{offset}}}$
          
 \\ \midrule
 Input Constraints & \begin{displaymath}
-                    {p_{\text{land}}}\gt{}0
+                    \resizeExpression{{p_{\text{land}}}\gt{}0}{0.8}
                     \end{displaymath}
                     \begin{displaymath}
-                    {p_{\text{target}}}\gt{}0
+                    \resizeExpression{{p_{\text{target}}}\gt{}0}{0.8}
                     \end{displaymath}
 \\ \midrule
 Output Constraints & 
 \\ \midrule
 Equation & \begin{displaymath}
-           {d_{\text{offset}}}={p_{\text{land}}}-{p_{\text{target}}}
+           \resizeExpression{{d_{\text{offset}}}={p_{\text{land}}}-{p_{\text{target}}}}{0.8}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -958,20 +969,20 @@ Output & $s$
          
 \\ \midrule
 Input Constraints & \begin{displaymath}
-                    {d_{\text{offset}}}\gt{}-{p_{\text{target}}}
+                    \resizeExpression{{d_{\text{offset}}}\gt{}-{p_{\text{target}}}}{0.8}
                     \end{displaymath}
                     \begin{displaymath}
-                    {p_{\text{target}}}\gt{}0
+                    \resizeExpression{{p_{\text{target}}}\gt{}0}{0.8}
                     \end{displaymath}
 \\ \midrule
 Output Constraints & 
 \\ \midrule
 Equation & \begin{displaymath}
-           s=\begin{cases}
-             \text{``The target was hit.''}, & |\frac{{d_{\text{offset}}}}{{p_{\text{target}}}}|\lt{}ε\\
-             \text{``The projectile fell short.''}, & {d_{\text{offset}}}\lt{}0\\
-             \text{``The projectile went long.''}, & {d_{\text{offset}}}\gt{}0
-             \end{cases}
+           \resizeExpression{s=\begin{cases}
+                               \text{``The target was hit.''}, & |\frac{{d_{\text{offset}}}}{{p_{\text{target}}}}|\lt{}ε\\
+                               \text{``The projectile fell short.''}, & {d_{\text{offset}}}\lt{}0\\
+                               \text{``The projectile went long.''}, & {d_{\text{offset}}}\gt{}0
+                               \end{cases}}{0.8}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}

--- a/code/stable/sglpend/SRS/PDF/SglPend_SRS.tex
+++ b/code/stable/sglpend/SRS/PDF/SglPend_SRS.tex
@@ -15,6 +15,8 @@
 \usepackage{svg}
 \usepackage{float}
 \usepackage{enumitem}
+\usepackage{graphicx}
+\usepackage{calc}
 \usepackage{filecontents}
 \usepackage[backend=bibtex]{biblatex}
 \usepackage{url}
@@ -23,6 +25,15 @@
 \newcommand{\lt}{\ensuremath <}
 \newlist{symbDescription}{description}{1}
 \setlist[symbDescription]{noitemsep, topsep=0pt, parsep=0pt, partopsep=0pt}
+\newsavebox{\mybox}
+\newcommand{\resizeExpression}[2]{
+\savebox{\mybox}{$#1$}
+\ifdim\wd\mybox>#2\linewidth
+\resizebox{#2\textwidth}{!}{\usebox{\mybox}}
+\else
+\usebox{\mybox}
+\fi
+}
 \bibliography{bibfile}
 \title{Software Requirements Specification for Single Pendulum}
 \author{Olu Owojaiye}
@@ -295,7 +306,7 @@ Label & Acceleration
         
 \\ \midrule
 Equation & \begin{displaymath}
-           \symbf{a}\text{(}t\text{)}=\frac{\,d\symbf{v}\text{(}t\text{)}}{\,dt}
+           \resizeExpression{\symbf{a}\text{(}t\text{)}=\frac{\,d\symbf{v}\text{(}t\text{)}}{\,dt}}{0.8}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -324,7 +335,7 @@ Label & Velocity
         
 \\ \midrule
 Equation & \begin{displaymath}
-           \symbf{v}\text{(}t\text{)}=\frac{\,d\symbf{p}\text{(}t\text{)}}{\,dt}
+           \resizeExpression{\symbf{v}\text{(}t\text{)}=\frac{\,d\symbf{p}\text{(}t\text{)}}{\,dt}}{0.8}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -353,7 +364,7 @@ Label & Newton's second law of motion
         
 \\ \midrule
 Equation & \begin{displaymath}
-           \symbf{F}=m\,\symbf{a}\text{(}t\text{)}
+           \resizeExpression{\symbf{F}=m\,\symbf{a}\text{(}t\text{)}}{0.8}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -385,7 +396,7 @@ Label & Newton's second law for rotational motion
         
 \\ \midrule
 Equation & \begin{displaymath}
-           \symbf{τ}=\symbf{I}\,α
+           \resizeExpression{\symbf{τ}=\symbf{I}\,α}{0.8}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -425,7 +436,7 @@ Units & $\frac{\text{m}}{\text{s}}$
         
 \\ \midrule
 Equation & \begin{displaymath}
-           {v_{\text{x}}}=ω\,{L_{\text{rod}}}\,\cos\left({θ_{p}}\right)
+           \resizeExpression{{v_{\text{x}}}=ω\,{L_{\text{rod}}}\,\cos\left({θ_{p}}\right)}{0.8}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -448,27 +459,27 @@ RefBy &
 At a given point in time, velocity may be defined as
 
 \begin{displaymath}
-\symbf{v}\text{(}t\text{)}=\frac{\,d\symbf{p}\text{(}t\text{)}}{\,dt}
+\resizeExpression{\symbf{v}\text{(}t\text{)}=\frac{\,d\symbf{p}\text{(}t\text{)}}{\,dt}}{1.0}
 \end{displaymath}
 We also know the horizontal position
 
 \begin{displaymath}
-{p_{\text{x}}}={L_{\text{rod}}}\,\sin\left({θ_{p}}\right)
+\resizeExpression{{p_{\text{x}}}={L_{\text{rod}}}\,\sin\left({θ_{p}}\right)}{1.0}
 \end{displaymath}
 Applying this,
 
 \begin{displaymath}
-{v_{\text{x}}}=\frac{\,d{L_{\text{rod}}}\,\sin\left({θ_{p}}\right)}{\,dt}
+\resizeExpression{{v_{\text{x}}}=\frac{\,d{L_{\text{rod}}}\,\sin\left({θ_{p}}\right)}{\,dt}}{1.0}
 \end{displaymath}
 ${L_{\text{rod}}}$ is constant with respect to time, so
 
 \begin{displaymath}
-{v_{\text{x}}}={L_{\text{rod}}}\,\frac{\,d\sin\left({θ_{p}}\right)}{\,dt}
+\resizeExpression{{v_{\text{x}}}={L_{\text{rod}}}\,\frac{\,d\sin\left({θ_{p}}\right)}{\,dt}}{1.0}
 \end{displaymath}
 Therefore, using the chain rule,
 
 \begin{displaymath}
-{v_{\text{x}}}=ω\,{L_{\text{rod}}}\,\cos\left({θ_{p}}\right)
+\resizeExpression{{v_{\text{x}}}=ω\,{L_{\text{rod}}}\,\cos\left({θ_{p}}\right)}{1.0}
 \end{displaymath}
 \medskip
 \noindent
@@ -485,7 +496,7 @@ Units & $\frac{\text{m}}{\text{s}}$
         
 \\ \midrule
 Equation & \begin{displaymath}
-           {v_{\text{y}}}=ω\,{L_{\text{rod}}}\,\sin\left({θ_{p}}\right)
+           \resizeExpression{{v_{\text{y}}}=ω\,{L_{\text{rod}}}\,\sin\left({θ_{p}}\right)}{0.8}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -508,27 +519,27 @@ RefBy &
 At a given point in time, velocity may be defined as
 
 \begin{displaymath}
-\symbf{v}\text{(}t\text{)}=\frac{\,d\symbf{p}\text{(}t\text{)}}{\,dt}
+\resizeExpression{\symbf{v}\text{(}t\text{)}=\frac{\,d\symbf{p}\text{(}t\text{)}}{\,dt}}{1.0}
 \end{displaymath}
 We also know the vertical position
 
 \begin{displaymath}
-{p_{\text{y}}}=-{L_{\text{rod}}}\,\cos\left({θ_{p}}\right)
+\resizeExpression{{p_{\text{y}}}=-{L_{\text{rod}}}\,\cos\left({θ_{p}}\right)}{1.0}
 \end{displaymath}
 Applying this,
 
 \begin{displaymath}
-{v_{\text{y}}}=-\left(\frac{\,d{L_{\text{rod}}}\,\cos\left({θ_{p}}\right)}{\,dt}\right)
+\resizeExpression{{v_{\text{y}}}=-\left(\frac{\,d{L_{\text{rod}}}\,\cos\left({θ_{p}}\right)}{\,dt}\right)}{1.0}
 \end{displaymath}
 ${L_{\text{rod}}}$ is constant with respect to time, so
 
 \begin{displaymath}
-{v_{\text{y}}}=-{L_{\text{rod}}}\,\frac{\,d\cos\left({θ_{p}}\right)}{\,dt}
+\resizeExpression{{v_{\text{y}}}=-{L_{\text{rod}}}\,\frac{\,d\cos\left({θ_{p}}\right)}{\,dt}}{1.0}
 \end{displaymath}
 Therefore, using the chain rule,
 
 \begin{displaymath}
-{v_{\text{y}}}=ω\,{L_{\text{rod}}}\,\sin\left({θ_{p}}\right)
+\resizeExpression{{v_{\text{y}}}=ω\,{L_{\text{rod}}}\,\sin\left({θ_{p}}\right)}{1.0}
 \end{displaymath}
 \medskip
 \noindent
@@ -545,7 +556,7 @@ Units & $\frac{\text{m}}{\text{s}^{2}}$
         
 \\ \midrule
 Equation & \begin{displaymath}
-           {a_{\text{x}}}=-ω^{2}\,{L_{\text{rod}}}\,\sin\left({θ_{p}}\right)+α\,{L_{\text{rod}}}\,\cos\left({θ_{p}}\right)
+           \resizeExpression{{a_{\text{x}}}=-ω^{2}\,{L_{\text{rod}}}\,\sin\left({θ_{p}}\right)+α\,{L_{\text{rod}}}\,\cos\left({θ_{p}}\right)}{0.8}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -569,27 +580,27 @@ RefBy &
 Our acceleration is:
 
 \begin{displaymath}
-\symbf{a}\text{(}t\text{)}=\frac{\,d\symbf{v}\text{(}t\text{)}}{\,dt}
+\resizeExpression{\symbf{a}\text{(}t\text{)}=\frac{\,d\symbf{v}\text{(}t\text{)}}{\,dt}}{1.0}
 \end{displaymath}
 Earlier, we found the horizontal velocity to be
 
 \begin{displaymath}
-{v_{\text{x}}}=ω\,{L_{\text{rod}}}\,\cos\left({θ_{p}}\right)
+\resizeExpression{{v_{\text{x}}}=ω\,{L_{\text{rod}}}\,\cos\left({θ_{p}}\right)}{1.0}
 \end{displaymath}
 Applying this to our equation for acceleration
 
 \begin{displaymath}
-{a_{\text{x}}}=\frac{\,dω\,{L_{\text{rod}}}\,\cos\left({θ_{p}}\right)}{\,dt}
+\resizeExpression{{a_{\text{x}}}=\frac{\,dω\,{L_{\text{rod}}}\,\cos\left({θ_{p}}\right)}{\,dt}}{1.0}
 \end{displaymath}
 By the product and chain rules, we find
 
 \begin{displaymath}
-{a_{\text{x}}}=\frac{\,dω}{\,dt}\,{L_{\text{rod}}}\,\cos\left({θ_{p}}\right)-ω\,{L_{\text{rod}}}\,\sin\left({θ_{p}}\right)\,\frac{\,d{θ_{p}}}{\,dt}
+\resizeExpression{{a_{\text{x}}}=\frac{\,dω}{\,dt}\,{L_{\text{rod}}}\,\cos\left({θ_{p}}\right)-ω\,{L_{\text{rod}}}\,\sin\left({θ_{p}}\right)\,\frac{\,d{θ_{p}}}{\,dt}}{1.0}
 \end{displaymath}
 Simplifying,
 
 \begin{displaymath}
-{a_{\text{x}}}=-ω^{2}\,{L_{\text{rod}}}\,\sin\left({θ_{p}}\right)+α\,{L_{\text{rod}}}\,\cos\left({θ_{p}}\right)
+\resizeExpression{{a_{\text{x}}}=-ω^{2}\,{L_{\text{rod}}}\,\sin\left({θ_{p}}\right)+α\,{L_{\text{rod}}}\,\cos\left({θ_{p}}\right)}{1.0}
 \end{displaymath}
 \medskip
 \noindent
@@ -606,7 +617,7 @@ Units & $\frac{\text{m}}{\text{s}^{2}}$
         
 \\ \midrule
 Equation & \begin{displaymath}
-           {a_{\text{y}}}=ω^{2}\,{L_{\text{rod}}}\,\cos\left({θ_{p}}\right)+α\,{L_{\text{rod}}}\,\sin\left({θ_{p}}\right)
+           \resizeExpression{{a_{\text{y}}}=ω^{2}\,{L_{\text{rod}}}\,\cos\left({θ_{p}}\right)+α\,{L_{\text{rod}}}\,\sin\left({θ_{p}}\right)}{0.8}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -630,27 +641,27 @@ RefBy &
 Our acceleration is:
 
 \begin{displaymath}
-\symbf{a}\text{(}t\text{)}=\frac{\,d\symbf{v}\text{(}t\text{)}}{\,dt}
+\resizeExpression{\symbf{a}\text{(}t\text{)}=\frac{\,d\symbf{v}\text{(}t\text{)}}{\,dt}}{1.0}
 \end{displaymath}
 Earlier, we found the vertical velocity to be
 
 \begin{displaymath}
-{v_{\text{y}}}=ω\,{L_{\text{rod}}}\,\sin\left({θ_{p}}\right)
+\resizeExpression{{v_{\text{y}}}=ω\,{L_{\text{rod}}}\,\sin\left({θ_{p}}\right)}{1.0}
 \end{displaymath}
 Applying this to our equation for acceleration
 
 \begin{displaymath}
-{a_{\text{y}}}=\frac{\,dω\,{L_{\text{rod}}}\,\sin\left({θ_{p}}\right)}{\,dt}
+\resizeExpression{{a_{\text{y}}}=\frac{\,dω\,{L_{\text{rod}}}\,\sin\left({θ_{p}}\right)}{\,dt}}{1.0}
 \end{displaymath}
 By the product and chain rules, we find
 
 \begin{displaymath}
-{a_{\text{y}}}=\frac{\,dω}{\,dt}\,{L_{\text{rod}}}\,\sin\left({θ_{p}}\right)+ω\,{L_{\text{rod}}}\,\cos\left({θ_{p}}\right)\,\frac{\,d{θ_{p}}}{\,dt}
+\resizeExpression{{a_{\text{y}}}=\frac{\,dω}{\,dt}\,{L_{\text{rod}}}\,\sin\left({θ_{p}}\right)+ω\,{L_{\text{rod}}}\,\cos\left({θ_{p}}\right)\,\frac{\,d{θ_{p}}}{\,dt}}{1.0}
 \end{displaymath}
 Simplifying,
 
 \begin{displaymath}
-{a_{\text{y}}}=ω^{2}\,{L_{\text{rod}}}\,\cos\left({θ_{p}}\right)+α\,{L_{\text{rod}}}\,\sin\left({θ_{p}}\right)
+\resizeExpression{{a_{\text{y}}}=ω^{2}\,{L_{\text{rod}}}\,\cos\left({θ_{p}}\right)+α\,{L_{\text{rod}}}\,\sin\left({θ_{p}}\right)}{1.0}
 \end{displaymath}
 \medskip
 \noindent
@@ -667,7 +678,7 @@ Units & ${\text{N}}$
         
 \\ \midrule
 Equation & \begin{displaymath}
-           \symbf{F}=m\,{a_{\text{x}}}=-\symbf{T}\,\sin\left({θ_{p}}\right)
+           \resizeExpression{\symbf{F}=m\,{a_{\text{x}}}=-\symbf{T}\,\sin\left({θ_{p}}\right)}{0.8}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -689,7 +700,7 @@ RefBy &
 \paragraph{Detailed derivation of force on the pendulum:}
 \label{GD:hForceOnPendulumDeriv}
 \begin{displaymath}
-\symbf{F}=m\,{a_{\text{x}}}=-\symbf{T}\,\sin\left({θ_{p}}\right)
+\resizeExpression{\symbf{F}=m\,{a_{\text{x}}}=-\symbf{T}\,\sin\left({θ_{p}}\right)}{1.0}
 \end{displaymath}
 \medskip
 \noindent
@@ -706,7 +717,7 @@ Units & ${\text{N}}$
         
 \\ \midrule
 Equation & \begin{displaymath}
-           \symbf{F}=m\,{a_{\text{y}}}=\symbf{T}\,\cos\left({θ_{p}}\right)-m\,\symbf{g}
+           \resizeExpression{\symbf{F}=m\,{a_{\text{y}}}=\symbf{T}\,\cos\left({θ_{p}}\right)-m\,\symbf{g}}{0.8}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -729,7 +740,7 @@ RefBy &
 \paragraph{Detailed derivation of force on the pendulum:}
 \label{GD:vForceOnPendulumDeriv}
 \begin{displaymath}
-\symbf{F}=m\,{a_{\text{y}}}=\symbf{T}\,\cos\left({θ_{p}}\right)-m\,\symbf{g}
+\resizeExpression{\symbf{F}=m\,{a_{\text{y}}}=\symbf{T}\,\cos\left({θ_{p}}\right)-m\,\symbf{g}}{1.0}
 \end{displaymath}
 \medskip
 \noindent
@@ -746,7 +757,7 @@ Units & ${\text{s}}$
         
 \\ \midrule
 Equation & \begin{displaymath}
-           Ω=\sqrt{\frac{\symbf{g}}{{L_{\text{rod}}}}}
+           \resizeExpression{Ω=\sqrt{\frac{\symbf{g}}{{L_{\text{rod}}}}}}{0.8}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -772,37 +783,37 @@ RefBy & \hyperref[GD:periodPend]{GD:periodPend} and \hyperref[IM:calOfAngularDis
 Consider the torque on a pendulum defined in \hyperref[TM:NewtonSecLawRotMot]{TM:NewtonSecLawRotMot}. The force providing the restoring torque is the component of weight of the pendulum bob that acts along the arc length. The torque is the length of the string ${L_{\text{rod}}}$ multiplied by the component of the net force that is perpendicular to the radius of the arc. The minus sign indicates the torque acts in the opposite direction of the angular displacement:
 
 \begin{displaymath}
-\symbf{τ}=-{L_{\text{rod}}}\,m\,\symbf{g}\,\sin\left({θ_{p}}\right)
+\resizeExpression{\symbf{τ}=-{L_{\text{rod}}}\,m\,\symbf{g}\,\sin\left({θ_{p}}\right)}{1.0}
 \end{displaymath}
 So then
 
 \begin{displaymath}
-\symbf{I}\,α=-{L_{\text{rod}}}\,m\,\symbf{g}\,\sin\left({θ_{p}}\right)
+\resizeExpression{\symbf{I}\,α=-{L_{\text{rod}}}\,m\,\symbf{g}\,\sin\left({θ_{p}}\right)}{1.0}
 \end{displaymath}
 Therefore,
 
 \begin{displaymath}
-\symbf{I}\,\frac{\,d\frac{\,d{θ_{p}}}{\,dt}}{\,dt}=-{L_{\text{rod}}}\,m\,\symbf{g}\,\sin\left({θ_{p}}\right)
+\resizeExpression{\symbf{I}\,\frac{\,d\frac{\,d{θ_{p}}}{\,dt}}{\,dt}=-{L_{\text{rod}}}\,m\,\symbf{g}\,\sin\left({θ_{p}}\right)}{1.0}
 \end{displaymath}
 Substituting for $\symbf{I}$
 
 \begin{displaymath}
-m\,{L_{\text{rod}}}^{2}\,\frac{\,d\frac{\,d{θ_{p}}}{\,dt}}{\,dt}=-{L_{\text{rod}}}\,m\,\symbf{g}\,\sin\left({θ_{p}}\right)
+\resizeExpression{m\,{L_{\text{rod}}}^{2}\,\frac{\,d\frac{\,d{θ_{p}}}{\,dt}}{\,dt}=-{L_{\text{rod}}}\,m\,\symbf{g}\,\sin\left({θ_{p}}\right)}{1.0}
 \end{displaymath}
 Crossing out $m$ and ${L_{\text{rod}}}$ we have
 
 \begin{displaymath}
-\frac{\,d\frac{\,d{θ_{p}}}{\,dt}}{\,dt}=-\left(\frac{\symbf{g}}{{L_{\text{rod}}}}\right)\,\sin\left({θ_{p}}\right)
+\resizeExpression{\frac{\,d\frac{\,d{θ_{p}}}{\,dt}}{\,dt}=-\left(\frac{\symbf{g}}{{L_{\text{rod}}}}\right)\,\sin\left({θ_{p}}\right)}{1.0}
 \end{displaymath}
 For small angles, we approximate sin ${θ_{p}}$ to ${θ_{p}}$
 
 \begin{displaymath}
-\frac{\,d\frac{\,d{θ_{p}}}{\,dt}}{\,dt}=-\left(\frac{\symbf{g}}{{L_{\text{rod}}}}\right)\,{θ_{p}}
+\resizeExpression{\frac{\,d\frac{\,d{θ_{p}}}{\,dt}}{\,dt}=-\left(\frac{\symbf{g}}{{L_{\text{rod}}}}\right)\,{θ_{p}}}{1.0}
 \end{displaymath}
 Because this equation, has the same form as the equation for simple harmonic motion the solution is easy to find.  The angular frequency
 
 \begin{displaymath}
-Ω=\sqrt{\frac{\symbf{g}}{{L_{\text{rod}}}}}
+\resizeExpression{Ω=\sqrt{\frac{\symbf{g}}{{L_{\text{rod}}}}}}{1.0}
 \end{displaymath}
 \medskip
 \noindent
@@ -819,7 +830,7 @@ Units & ${\text{s}}$
         
 \\ \midrule
 Equation & \begin{displaymath}
-           T=2\,π\,\sqrt{\frac{{L_{\text{rod}}}}{\symbf{g}}}
+           \resizeExpression{T=2\,π\,\sqrt{\frac{{L_{\text{rod}}}}{\symbf{g}}}}{0.8}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -845,12 +856,12 @@ RefBy &
 The period of the pendulum can be defined from the general definition for the equation of \hyperref[GD:angFrequencyGD]{angular frequency}
 
 \begin{displaymath}
-Ω=\sqrt{\frac{\symbf{g}}{{L_{\text{rod}}}}}
+\resizeExpression{Ω=\sqrt{\frac{\symbf{g}}{{L_{\text{rod}}}}}}{1.0}
 \end{displaymath}
 Therefore from the data definition of the equation for \hyperref[DD:angFrequencyDD]{angular frequency}, we have
 
 \begin{displaymath}
-T=2\,π\,\sqrt{\frac{{L_{\text{rod}}}}{\symbf{g}}}
+\resizeExpression{T=2\,π\,\sqrt{\frac{{L_{\text{rod}}}}{\symbf{g}}}}{1.0}
 \end{displaymath}
 \subsubsection{Data Definitions}
 \label{Sec:DDs}
@@ -874,7 +885,7 @@ Units & ${\text{m}}$
         
 \\ \midrule
 Equation & \begin{displaymath}
-           {{p_{\text{x}}}^{\text{i}}}={L_{\text{rod}}}\,\sin\left({θ_{i}}\right)
+           \resizeExpression{{{p_{\text{x}}}^{\text{i}}}={L_{\text{rod}}}\,\sin\left({θ_{i}}\right)}{0.8}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -914,7 +925,7 @@ Units & ${\text{m}}$
         
 \\ \midrule
 Equation & \begin{displaymath}
-           {{p_{\text{y}}}^{\text{i}}}=-{L_{\text{rod}}}\,\cos\left({θ_{i}}\right)
+           \resizeExpression{{{p_{\text{y}}}^{\text{i}}}=-{L_{\text{rod}}}\,\cos\left({θ_{i}}\right)}{0.8}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -954,7 +965,7 @@ Units & ${\text{Hz}}$
         
 \\ \midrule
 Equation & \begin{displaymath}
-           f=\frac{1}{T}
+           \resizeExpression{f=\frac{1}{T}}{0.8}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -992,7 +1003,7 @@ Units & ${\text{s}}$
         
 \\ \midrule
 Equation & \begin{displaymath}
-           Ω=\frac{2\,π}{T}
+           \resizeExpression{Ω=\frac{2\,π}{T}}{0.8}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -1031,7 +1042,7 @@ Units & ${\text{s}}$
         
 \\ \midrule
 Equation & \begin{displaymath}
-           T=\frac{1}{f}
+           \resizeExpression{T=\frac{1}{f}}{0.8}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -1073,21 +1084,21 @@ Output & ${θ_{p}}$
          
 \\ \midrule
 Input Constraints & \begin{displaymath}
-                    {L_{\text{rod}}}\gt{}0
+                    \resizeExpression{{L_{\text{rod}}}\gt{}0}{0.8}
                     \end{displaymath}
                     \begin{displaymath}
-                    {θ_{i}}\gt{}0
+                    \resizeExpression{{θ_{i}}\gt{}0}{0.8}
                     \end{displaymath}
                     \begin{displaymath}
-                    \symbf{g}\gt{}0
+                    \resizeExpression{\symbf{g}\gt{}0}{0.8}
                     \end{displaymath}
 \\ \midrule
 Output Constraints & \begin{displaymath}
-                     {θ_{p}}\gt{}0
+                     \resizeExpression{{θ_{p}}\gt{}0}{0.8}
                      \end{displaymath}
 \\ \midrule
 Equation & \begin{displaymath}
-           {θ_{p}}\left(t\right)={θ_{i}}\,\cos\left(Ω\,t\right)
+           \resizeExpression{{θ_{p}}\left(t\right)={θ_{i}}\,\cos\left(Ω\,t\right)}{0.8}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -1114,27 +1125,27 @@ RefBy & \hyperref[outputValues]{FR:Output-Values} and \hyperref[calcAngPos]{FR:C
 When the pendulum is displaced to an initial angle and released, the pendulum swings back and forth with periodic motion. By applying \hyperref[TM:NewtonSecLawRotMot]{Newton's second law for rotational motion}, the equation of motion for the pendulum may be obtained:
 
 \begin{displaymath}
-\symbf{τ}=\symbf{I}\,α
+\resizeExpression{\symbf{τ}=\symbf{I}\,α}{1.0}
 \end{displaymath}
 Where $\symbf{τ}$ denotes the torque, $\symbf{I}$ denotes the moment of inertia and $α$ denotes the angular acceleration. This implies:
 
 \begin{displaymath}
--m\,\symbf{g}\,\sin\left({θ_{p}}\right)\,{L_{\text{rod}}}=m\,{L_{\text{rod}}}^{2}\,\frac{\,d\frac{\,d{θ_{p}}}{\,dt}}{\,dt}
+\resizeExpression{-m\,\symbf{g}\,\sin\left({θ_{p}}\right)\,{L_{\text{rod}}}=m\,{L_{\text{rod}}}^{2}\,\frac{\,d\frac{\,d{θ_{p}}}{\,dt}}{\,dt}}{1.0}
 \end{displaymath}
 And rearranged as:
 
 \begin{displaymath}
-\frac{\,d\frac{\,d{θ_{p}}}{\,dt}}{\,dt}+\frac{\symbf{g}}{{L_{\text{rod}}}}\,\sin\left({θ_{p}}\right)=0
+\resizeExpression{\frac{\,d\frac{\,d{θ_{p}}}{\,dt}}{\,dt}+\frac{\symbf{g}}{{L_{\text{rod}}}}\,\sin\left({θ_{p}}\right)=0}{1.0}
 \end{displaymath}
 If the amplitude of angular displacement is small enough, we can approximate $\sin\left({θ_{p}}\right)={θ_{p}}$ for the purpose of a simple pendulum at very small angles. Then the equation of motion reduces to the equation of simple harmonic motion:
 
 \begin{displaymath}
-\frac{\,d\frac{\,d{θ_{p}}}{\,dt}}{\,dt}+\frac{\symbf{g}}{{L_{\text{rod}}}}\,{θ_{p}}=0
+\resizeExpression{\frac{\,d\frac{\,d{θ_{p}}}{\,dt}}{\,dt}+\frac{\symbf{g}}{{L_{\text{rod}}}}\,{θ_{p}}=0}{1.0}
 \end{displaymath}
 Thus the simple harmonic motion is:
 
 \begin{displaymath}
-{θ_{p}}\left(t\right)={θ_{i}}\,\cos\left(Ω\,t\right)
+\resizeExpression{{θ_{p}}\left(t\right)={θ_{i}}\,\cos\left(Ω\,t\right)}{1.0}
 \end{displaymath}
 \subsubsection{Data Constraints}
 \label{Sec:DataConstraints}

--- a/code/stable/sglpend/SRS/PDF/SglPend_SRS.tex
+++ b/code/stable/sglpend/SRS/PDF/SglPend_SRS.tex
@@ -25,6 +25,8 @@
 \newcommand{\lt}{\ensuremath <}
 \newlist{symbDescription}{description}{1}
 \setlist[symbDescription]{noitemsep, topsep=0pt, parsep=0pt, partopsep=0pt}
+\def\inDefScale{0.8}
+\def\outDefScale{1.0}
 \newsavebox{\mybox}
 \newcommand{\resizeExpression}[2]{
   \savebox{\mybox}{$#1$}
@@ -306,7 +308,7 @@ Label & Acceleration
         
 \\ \midrule
 Equation & \begin{displaymath}
-           \resizeExpression{\symbf{a}\text{(}t\text{)}=\frac{\,d\symbf{v}\text{(}t\text{)}}{\,dt}}{0.8}
+           \resizeExpression{\symbf{a}\text{(}t\text{)}=\frac{\,d\symbf{v}\text{(}t\text{)}}{\,dt}}{\inDefScale}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -335,7 +337,7 @@ Label & Velocity
         
 \\ \midrule
 Equation & \begin{displaymath}
-           \resizeExpression{\symbf{v}\text{(}t\text{)}=\frac{\,d\symbf{p}\text{(}t\text{)}}{\,dt}}{0.8}
+           \resizeExpression{\symbf{v}\text{(}t\text{)}=\frac{\,d\symbf{p}\text{(}t\text{)}}{\,dt}}{\inDefScale}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -364,7 +366,7 @@ Label & Newton's second law of motion
         
 \\ \midrule
 Equation & \begin{displaymath}
-           \resizeExpression{\symbf{F}=m\,\symbf{a}\text{(}t\text{)}}{0.8}
+           \resizeExpression{\symbf{F}=m\,\symbf{a}\text{(}t\text{)}}{\inDefScale}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -396,7 +398,7 @@ Label & Newton's second law for rotational motion
         
 \\ \midrule
 Equation & \begin{displaymath}
-           \resizeExpression{\symbf{τ}=\symbf{I}\,α}{0.8}
+           \resizeExpression{\symbf{τ}=\symbf{I}\,α}{\inDefScale}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -436,7 +438,7 @@ Units & $\frac{\text{m}}{\text{s}}$
         
 \\ \midrule
 Equation & \begin{displaymath}
-           \resizeExpression{{v_{\text{x}}}=ω\,{L_{\text{rod}}}\,\cos\left({θ_{p}}\right)}{0.8}
+           \resizeExpression{{v_{\text{x}}}=ω\,{L_{\text{rod}}}\,\cos\left({θ_{p}}\right)}{\inDefScale}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -459,27 +461,27 @@ RefBy &
 At a given point in time, velocity may be defined as
 
 \begin{displaymath}
-\resizeExpression{\symbf{v}\text{(}t\text{)}=\frac{\,d\symbf{p}\text{(}t\text{)}}{\,dt}}{1.0}
+\resizeExpression{\symbf{v}\text{(}t\text{)}=\frac{\,d\symbf{p}\text{(}t\text{)}}{\,dt}}{\outDefScale}
 \end{displaymath}
 We also know the horizontal position
 
 \begin{displaymath}
-\resizeExpression{{p_{\text{x}}}={L_{\text{rod}}}\,\sin\left({θ_{p}}\right)}{1.0}
+\resizeExpression{{p_{\text{x}}}={L_{\text{rod}}}\,\sin\left({θ_{p}}\right)}{\outDefScale}
 \end{displaymath}
 Applying this,
 
 \begin{displaymath}
-\resizeExpression{{v_{\text{x}}}=\frac{\,d{L_{\text{rod}}}\,\sin\left({θ_{p}}\right)}{\,dt}}{1.0}
+\resizeExpression{{v_{\text{x}}}=\frac{\,d{L_{\text{rod}}}\,\sin\left({θ_{p}}\right)}{\,dt}}{\outDefScale}
 \end{displaymath}
 ${L_{\text{rod}}}$ is constant with respect to time, so
 
 \begin{displaymath}
-\resizeExpression{{v_{\text{x}}}={L_{\text{rod}}}\,\frac{\,d\sin\left({θ_{p}}\right)}{\,dt}}{1.0}
+\resizeExpression{{v_{\text{x}}}={L_{\text{rod}}}\,\frac{\,d\sin\left({θ_{p}}\right)}{\,dt}}{\outDefScale}
 \end{displaymath}
 Therefore, using the chain rule,
 
 \begin{displaymath}
-\resizeExpression{{v_{\text{x}}}=ω\,{L_{\text{rod}}}\,\cos\left({θ_{p}}\right)}{1.0}
+\resizeExpression{{v_{\text{x}}}=ω\,{L_{\text{rod}}}\,\cos\left({θ_{p}}\right)}{\outDefScale}
 \end{displaymath}
 \medskip
 \noindent
@@ -496,7 +498,7 @@ Units & $\frac{\text{m}}{\text{s}}$
         
 \\ \midrule
 Equation & \begin{displaymath}
-           \resizeExpression{{v_{\text{y}}}=ω\,{L_{\text{rod}}}\,\sin\left({θ_{p}}\right)}{0.8}
+           \resizeExpression{{v_{\text{y}}}=ω\,{L_{\text{rod}}}\,\sin\left({θ_{p}}\right)}{\inDefScale}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -519,27 +521,27 @@ RefBy &
 At a given point in time, velocity may be defined as
 
 \begin{displaymath}
-\resizeExpression{\symbf{v}\text{(}t\text{)}=\frac{\,d\symbf{p}\text{(}t\text{)}}{\,dt}}{1.0}
+\resizeExpression{\symbf{v}\text{(}t\text{)}=\frac{\,d\symbf{p}\text{(}t\text{)}}{\,dt}}{\outDefScale}
 \end{displaymath}
 We also know the vertical position
 
 \begin{displaymath}
-\resizeExpression{{p_{\text{y}}}=-{L_{\text{rod}}}\,\cos\left({θ_{p}}\right)}{1.0}
+\resizeExpression{{p_{\text{y}}}=-{L_{\text{rod}}}\,\cos\left({θ_{p}}\right)}{\outDefScale}
 \end{displaymath}
 Applying this,
 
 \begin{displaymath}
-\resizeExpression{{v_{\text{y}}}=-\left(\frac{\,d{L_{\text{rod}}}\,\cos\left({θ_{p}}\right)}{\,dt}\right)}{1.0}
+\resizeExpression{{v_{\text{y}}}=-\left(\frac{\,d{L_{\text{rod}}}\,\cos\left({θ_{p}}\right)}{\,dt}\right)}{\outDefScale}
 \end{displaymath}
 ${L_{\text{rod}}}$ is constant with respect to time, so
 
 \begin{displaymath}
-\resizeExpression{{v_{\text{y}}}=-{L_{\text{rod}}}\,\frac{\,d\cos\left({θ_{p}}\right)}{\,dt}}{1.0}
+\resizeExpression{{v_{\text{y}}}=-{L_{\text{rod}}}\,\frac{\,d\cos\left({θ_{p}}\right)}{\,dt}}{\outDefScale}
 \end{displaymath}
 Therefore, using the chain rule,
 
 \begin{displaymath}
-\resizeExpression{{v_{\text{y}}}=ω\,{L_{\text{rod}}}\,\sin\left({θ_{p}}\right)}{1.0}
+\resizeExpression{{v_{\text{y}}}=ω\,{L_{\text{rod}}}\,\sin\left({θ_{p}}\right)}{\outDefScale}
 \end{displaymath}
 \medskip
 \noindent
@@ -556,7 +558,7 @@ Units & $\frac{\text{m}}{\text{s}^{2}}$
         
 \\ \midrule
 Equation & \begin{displaymath}
-           \resizeExpression{{a_{\text{x}}}=-ω^{2}\,{L_{\text{rod}}}\,\sin\left({θ_{p}}\right)+α\,{L_{\text{rod}}}\,\cos\left({θ_{p}}\right)}{0.8}
+           \resizeExpression{{a_{\text{x}}}=-ω^{2}\,{L_{\text{rod}}}\,\sin\left({θ_{p}}\right)+α\,{L_{\text{rod}}}\,\cos\left({θ_{p}}\right)}{\inDefScale}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -580,27 +582,27 @@ RefBy &
 Our acceleration is:
 
 \begin{displaymath}
-\resizeExpression{\symbf{a}\text{(}t\text{)}=\frac{\,d\symbf{v}\text{(}t\text{)}}{\,dt}}{1.0}
+\resizeExpression{\symbf{a}\text{(}t\text{)}=\frac{\,d\symbf{v}\text{(}t\text{)}}{\,dt}}{\outDefScale}
 \end{displaymath}
 Earlier, we found the horizontal velocity to be
 
 \begin{displaymath}
-\resizeExpression{{v_{\text{x}}}=ω\,{L_{\text{rod}}}\,\cos\left({θ_{p}}\right)}{1.0}
+\resizeExpression{{v_{\text{x}}}=ω\,{L_{\text{rod}}}\,\cos\left({θ_{p}}\right)}{\outDefScale}
 \end{displaymath}
 Applying this to our equation for acceleration
 
 \begin{displaymath}
-\resizeExpression{{a_{\text{x}}}=\frac{\,dω\,{L_{\text{rod}}}\,\cos\left({θ_{p}}\right)}{\,dt}}{1.0}
+\resizeExpression{{a_{\text{x}}}=\frac{\,dω\,{L_{\text{rod}}}\,\cos\left({θ_{p}}\right)}{\,dt}}{\outDefScale}
 \end{displaymath}
 By the product and chain rules, we find
 
 \begin{displaymath}
-\resizeExpression{{a_{\text{x}}}=\frac{\,dω}{\,dt}\,{L_{\text{rod}}}\,\cos\left({θ_{p}}\right)-ω\,{L_{\text{rod}}}\,\sin\left({θ_{p}}\right)\,\frac{\,d{θ_{p}}}{\,dt}}{1.0}
+\resizeExpression{{a_{\text{x}}}=\frac{\,dω}{\,dt}\,{L_{\text{rod}}}\,\cos\left({θ_{p}}\right)-ω\,{L_{\text{rod}}}\,\sin\left({θ_{p}}\right)\,\frac{\,d{θ_{p}}}{\,dt}}{\outDefScale}
 \end{displaymath}
 Simplifying,
 
 \begin{displaymath}
-\resizeExpression{{a_{\text{x}}}=-ω^{2}\,{L_{\text{rod}}}\,\sin\left({θ_{p}}\right)+α\,{L_{\text{rod}}}\,\cos\left({θ_{p}}\right)}{1.0}
+\resizeExpression{{a_{\text{x}}}=-ω^{2}\,{L_{\text{rod}}}\,\sin\left({θ_{p}}\right)+α\,{L_{\text{rod}}}\,\cos\left({θ_{p}}\right)}{\outDefScale}
 \end{displaymath}
 \medskip
 \noindent
@@ -617,7 +619,7 @@ Units & $\frac{\text{m}}{\text{s}^{2}}$
         
 \\ \midrule
 Equation & \begin{displaymath}
-           \resizeExpression{{a_{\text{y}}}=ω^{2}\,{L_{\text{rod}}}\,\cos\left({θ_{p}}\right)+α\,{L_{\text{rod}}}\,\sin\left({θ_{p}}\right)}{0.8}
+           \resizeExpression{{a_{\text{y}}}=ω^{2}\,{L_{\text{rod}}}\,\cos\left({θ_{p}}\right)+α\,{L_{\text{rod}}}\,\sin\left({θ_{p}}\right)}{\inDefScale}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -641,27 +643,27 @@ RefBy &
 Our acceleration is:
 
 \begin{displaymath}
-\resizeExpression{\symbf{a}\text{(}t\text{)}=\frac{\,d\symbf{v}\text{(}t\text{)}}{\,dt}}{1.0}
+\resizeExpression{\symbf{a}\text{(}t\text{)}=\frac{\,d\symbf{v}\text{(}t\text{)}}{\,dt}}{\outDefScale}
 \end{displaymath}
 Earlier, we found the vertical velocity to be
 
 \begin{displaymath}
-\resizeExpression{{v_{\text{y}}}=ω\,{L_{\text{rod}}}\,\sin\left({θ_{p}}\right)}{1.0}
+\resizeExpression{{v_{\text{y}}}=ω\,{L_{\text{rod}}}\,\sin\left({θ_{p}}\right)}{\outDefScale}
 \end{displaymath}
 Applying this to our equation for acceleration
 
 \begin{displaymath}
-\resizeExpression{{a_{\text{y}}}=\frac{\,dω\,{L_{\text{rod}}}\,\sin\left({θ_{p}}\right)}{\,dt}}{1.0}
+\resizeExpression{{a_{\text{y}}}=\frac{\,dω\,{L_{\text{rod}}}\,\sin\left({θ_{p}}\right)}{\,dt}}{\outDefScale}
 \end{displaymath}
 By the product and chain rules, we find
 
 \begin{displaymath}
-\resizeExpression{{a_{\text{y}}}=\frac{\,dω}{\,dt}\,{L_{\text{rod}}}\,\sin\left({θ_{p}}\right)+ω\,{L_{\text{rod}}}\,\cos\left({θ_{p}}\right)\,\frac{\,d{θ_{p}}}{\,dt}}{1.0}
+\resizeExpression{{a_{\text{y}}}=\frac{\,dω}{\,dt}\,{L_{\text{rod}}}\,\sin\left({θ_{p}}\right)+ω\,{L_{\text{rod}}}\,\cos\left({θ_{p}}\right)\,\frac{\,d{θ_{p}}}{\,dt}}{\outDefScale}
 \end{displaymath}
 Simplifying,
 
 \begin{displaymath}
-\resizeExpression{{a_{\text{y}}}=ω^{2}\,{L_{\text{rod}}}\,\cos\left({θ_{p}}\right)+α\,{L_{\text{rod}}}\,\sin\left({θ_{p}}\right)}{1.0}
+\resizeExpression{{a_{\text{y}}}=ω^{2}\,{L_{\text{rod}}}\,\cos\left({θ_{p}}\right)+α\,{L_{\text{rod}}}\,\sin\left({θ_{p}}\right)}{\outDefScale}
 \end{displaymath}
 \medskip
 \noindent
@@ -678,7 +680,7 @@ Units & ${\text{N}}$
         
 \\ \midrule
 Equation & \begin{displaymath}
-           \resizeExpression{\symbf{F}=m\,{a_{\text{x}}}=-\symbf{T}\,\sin\left({θ_{p}}\right)}{0.8}
+           \resizeExpression{\symbf{F}=m\,{a_{\text{x}}}=-\symbf{T}\,\sin\left({θ_{p}}\right)}{\inDefScale}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -700,7 +702,7 @@ RefBy &
 \paragraph{Detailed derivation of force on the pendulum:}
 \label{GD:hForceOnPendulumDeriv}
 \begin{displaymath}
-\resizeExpression{\symbf{F}=m\,{a_{\text{x}}}=-\symbf{T}\,\sin\left({θ_{p}}\right)}{1.0}
+\resizeExpression{\symbf{F}=m\,{a_{\text{x}}}=-\symbf{T}\,\sin\left({θ_{p}}\right)}{\outDefScale}
 \end{displaymath}
 \medskip
 \noindent
@@ -717,7 +719,7 @@ Units & ${\text{N}}$
         
 \\ \midrule
 Equation & \begin{displaymath}
-           \resizeExpression{\symbf{F}=m\,{a_{\text{y}}}=\symbf{T}\,\cos\left({θ_{p}}\right)-m\,\symbf{g}}{0.8}
+           \resizeExpression{\symbf{F}=m\,{a_{\text{y}}}=\symbf{T}\,\cos\left({θ_{p}}\right)-m\,\symbf{g}}{\inDefScale}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -740,7 +742,7 @@ RefBy &
 \paragraph{Detailed derivation of force on the pendulum:}
 \label{GD:vForceOnPendulumDeriv}
 \begin{displaymath}
-\resizeExpression{\symbf{F}=m\,{a_{\text{y}}}=\symbf{T}\,\cos\left({θ_{p}}\right)-m\,\symbf{g}}{1.0}
+\resizeExpression{\symbf{F}=m\,{a_{\text{y}}}=\symbf{T}\,\cos\left({θ_{p}}\right)-m\,\symbf{g}}{\outDefScale}
 \end{displaymath}
 \medskip
 \noindent
@@ -757,7 +759,7 @@ Units & ${\text{s}}$
         
 \\ \midrule
 Equation & \begin{displaymath}
-           \resizeExpression{Ω=\sqrt{\frac{\symbf{g}}{{L_{\text{rod}}}}}}{0.8}
+           \resizeExpression{Ω=\sqrt{\frac{\symbf{g}}{{L_{\text{rod}}}}}}{\inDefScale}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -783,37 +785,37 @@ RefBy & \hyperref[GD:periodPend]{GD:periodPend} and \hyperref[IM:calOfAngularDis
 Consider the torque on a pendulum defined in \hyperref[TM:NewtonSecLawRotMot]{TM:NewtonSecLawRotMot}. The force providing the restoring torque is the component of weight of the pendulum bob that acts along the arc length. The torque is the length of the string ${L_{\text{rod}}}$ multiplied by the component of the net force that is perpendicular to the radius of the arc. The minus sign indicates the torque acts in the opposite direction of the angular displacement:
 
 \begin{displaymath}
-\resizeExpression{\symbf{τ}=-{L_{\text{rod}}}\,m\,\symbf{g}\,\sin\left({θ_{p}}\right)}{1.0}
+\resizeExpression{\symbf{τ}=-{L_{\text{rod}}}\,m\,\symbf{g}\,\sin\left({θ_{p}}\right)}{\outDefScale}
 \end{displaymath}
 So then
 
 \begin{displaymath}
-\resizeExpression{\symbf{I}\,α=-{L_{\text{rod}}}\,m\,\symbf{g}\,\sin\left({θ_{p}}\right)}{1.0}
+\resizeExpression{\symbf{I}\,α=-{L_{\text{rod}}}\,m\,\symbf{g}\,\sin\left({θ_{p}}\right)}{\outDefScale}
 \end{displaymath}
 Therefore,
 
 \begin{displaymath}
-\resizeExpression{\symbf{I}\,\frac{\,d\frac{\,d{θ_{p}}}{\,dt}}{\,dt}=-{L_{\text{rod}}}\,m\,\symbf{g}\,\sin\left({θ_{p}}\right)}{1.0}
+\resizeExpression{\symbf{I}\,\frac{\,d\frac{\,d{θ_{p}}}{\,dt}}{\,dt}=-{L_{\text{rod}}}\,m\,\symbf{g}\,\sin\left({θ_{p}}\right)}{\outDefScale}
 \end{displaymath}
 Substituting for $\symbf{I}$
 
 \begin{displaymath}
-\resizeExpression{m\,{L_{\text{rod}}}^{2}\,\frac{\,d\frac{\,d{θ_{p}}}{\,dt}}{\,dt}=-{L_{\text{rod}}}\,m\,\symbf{g}\,\sin\left({θ_{p}}\right)}{1.0}
+\resizeExpression{m\,{L_{\text{rod}}}^{2}\,\frac{\,d\frac{\,d{θ_{p}}}{\,dt}}{\,dt}=-{L_{\text{rod}}}\,m\,\symbf{g}\,\sin\left({θ_{p}}\right)}{\outDefScale}
 \end{displaymath}
 Crossing out $m$ and ${L_{\text{rod}}}$ we have
 
 \begin{displaymath}
-\resizeExpression{\frac{\,d\frac{\,d{θ_{p}}}{\,dt}}{\,dt}=-\left(\frac{\symbf{g}}{{L_{\text{rod}}}}\right)\,\sin\left({θ_{p}}\right)}{1.0}
+\resizeExpression{\frac{\,d\frac{\,d{θ_{p}}}{\,dt}}{\,dt}=-\left(\frac{\symbf{g}}{{L_{\text{rod}}}}\right)\,\sin\left({θ_{p}}\right)}{\outDefScale}
 \end{displaymath}
 For small angles, we approximate sin ${θ_{p}}$ to ${θ_{p}}$
 
 \begin{displaymath}
-\resizeExpression{\frac{\,d\frac{\,d{θ_{p}}}{\,dt}}{\,dt}=-\left(\frac{\symbf{g}}{{L_{\text{rod}}}}\right)\,{θ_{p}}}{1.0}
+\resizeExpression{\frac{\,d\frac{\,d{θ_{p}}}{\,dt}}{\,dt}=-\left(\frac{\symbf{g}}{{L_{\text{rod}}}}\right)\,{θ_{p}}}{\outDefScale}
 \end{displaymath}
 Because this equation, has the same form as the equation for simple harmonic motion the solution is easy to find.  The angular frequency
 
 \begin{displaymath}
-\resizeExpression{Ω=\sqrt{\frac{\symbf{g}}{{L_{\text{rod}}}}}}{1.0}
+\resizeExpression{Ω=\sqrt{\frac{\symbf{g}}{{L_{\text{rod}}}}}}{\outDefScale}
 \end{displaymath}
 \medskip
 \noindent
@@ -830,7 +832,7 @@ Units & ${\text{s}}$
         
 \\ \midrule
 Equation & \begin{displaymath}
-           \resizeExpression{T=2\,π\,\sqrt{\frac{{L_{\text{rod}}}}{\symbf{g}}}}{0.8}
+           \resizeExpression{T=2\,π\,\sqrt{\frac{{L_{\text{rod}}}}{\symbf{g}}}}{\inDefScale}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -856,12 +858,12 @@ RefBy &
 The period of the pendulum can be defined from the general definition for the equation of \hyperref[GD:angFrequencyGD]{angular frequency}
 
 \begin{displaymath}
-\resizeExpression{Ω=\sqrt{\frac{\symbf{g}}{{L_{\text{rod}}}}}}{1.0}
+\resizeExpression{Ω=\sqrt{\frac{\symbf{g}}{{L_{\text{rod}}}}}}{\outDefScale}
 \end{displaymath}
 Therefore from the data definition of the equation for \hyperref[DD:angFrequencyDD]{angular frequency}, we have
 
 \begin{displaymath}
-\resizeExpression{T=2\,π\,\sqrt{\frac{{L_{\text{rod}}}}{\symbf{g}}}}{1.0}
+\resizeExpression{T=2\,π\,\sqrt{\frac{{L_{\text{rod}}}}{\symbf{g}}}}{\outDefScale}
 \end{displaymath}
 \subsubsection{Data Definitions}
 \label{Sec:DDs}
@@ -885,7 +887,7 @@ Units & ${\text{m}}$
         
 \\ \midrule
 Equation & \begin{displaymath}
-           \resizeExpression{{{p_{\text{x}}}^{\text{i}}}={L_{\text{rod}}}\,\sin\left({θ_{i}}\right)}{0.8}
+           \resizeExpression{{{p_{\text{x}}}^{\text{i}}}={L_{\text{rod}}}\,\sin\left({θ_{i}}\right)}{\inDefScale}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -925,7 +927,7 @@ Units & ${\text{m}}$
         
 \\ \midrule
 Equation & \begin{displaymath}
-           \resizeExpression{{{p_{\text{y}}}^{\text{i}}}=-{L_{\text{rod}}}\,\cos\left({θ_{i}}\right)}{0.8}
+           \resizeExpression{{{p_{\text{y}}}^{\text{i}}}=-{L_{\text{rod}}}\,\cos\left({θ_{i}}\right)}{\inDefScale}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -965,7 +967,7 @@ Units & ${\text{Hz}}$
         
 \\ \midrule
 Equation & \begin{displaymath}
-           \resizeExpression{f=\frac{1}{T}}{0.8}
+           \resizeExpression{f=\frac{1}{T}}{\inDefScale}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -1003,7 +1005,7 @@ Units & ${\text{s}}$
         
 \\ \midrule
 Equation & \begin{displaymath}
-           \resizeExpression{Ω=\frac{2\,π}{T}}{0.8}
+           \resizeExpression{Ω=\frac{2\,π}{T}}{\inDefScale}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -1042,7 +1044,7 @@ Units & ${\text{s}}$
         
 \\ \midrule
 Equation & \begin{displaymath}
-           \resizeExpression{T=\frac{1}{f}}{0.8}
+           \resizeExpression{T=\frac{1}{f}}{\inDefScale}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -1084,21 +1086,21 @@ Output & ${θ_{p}}$
          
 \\ \midrule
 Input Constraints & \begin{displaymath}
-                    \resizeExpression{{L_{\text{rod}}}\gt{}0}{0.8}
+                    \resizeExpression{{L_{\text{rod}}}\gt{}0}{\inDefScale}
                     \end{displaymath}
                     \begin{displaymath}
-                    \resizeExpression{{θ_{i}}\gt{}0}{0.8}
+                    \resizeExpression{{θ_{i}}\gt{}0}{\inDefScale}
                     \end{displaymath}
                     \begin{displaymath}
-                    \resizeExpression{\symbf{g}\gt{}0}{0.8}
+                    \resizeExpression{\symbf{g}\gt{}0}{\inDefScale}
                     \end{displaymath}
 \\ \midrule
 Output Constraints & \begin{displaymath}
-                     \resizeExpression{{θ_{p}}\gt{}0}{0.8}
+                     \resizeExpression{{θ_{p}}\gt{}0}{\inDefScale}
                      \end{displaymath}
 \\ \midrule
 Equation & \begin{displaymath}
-           \resizeExpression{{θ_{p}}\left(t\right)={θ_{i}}\,\cos\left(Ω\,t\right)}{0.8}
+           \resizeExpression{{θ_{p}}\left(t\right)={θ_{i}}\,\cos\left(Ω\,t\right)}{\inDefScale}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -1125,27 +1127,27 @@ RefBy & \hyperref[outputValues]{FR:Output-Values} and \hyperref[calcAngPos]{FR:C
 When the pendulum is displaced to an initial angle and released, the pendulum swings back and forth with periodic motion. By applying \hyperref[TM:NewtonSecLawRotMot]{Newton's second law for rotational motion}, the equation of motion for the pendulum may be obtained:
 
 \begin{displaymath}
-\resizeExpression{\symbf{τ}=\symbf{I}\,α}{1.0}
+\resizeExpression{\symbf{τ}=\symbf{I}\,α}{\outDefScale}
 \end{displaymath}
 Where $\symbf{τ}$ denotes the torque, $\symbf{I}$ denotes the moment of inertia and $α$ denotes the angular acceleration. This implies:
 
 \begin{displaymath}
-\resizeExpression{-m\,\symbf{g}\,\sin\left({θ_{p}}\right)\,{L_{\text{rod}}}=m\,{L_{\text{rod}}}^{2}\,\frac{\,d\frac{\,d{θ_{p}}}{\,dt}}{\,dt}}{1.0}
+\resizeExpression{-m\,\symbf{g}\,\sin\left({θ_{p}}\right)\,{L_{\text{rod}}}=m\,{L_{\text{rod}}}^{2}\,\frac{\,d\frac{\,d{θ_{p}}}{\,dt}}{\,dt}}{\outDefScale}
 \end{displaymath}
 And rearranged as:
 
 \begin{displaymath}
-\resizeExpression{\frac{\,d\frac{\,d{θ_{p}}}{\,dt}}{\,dt}+\frac{\symbf{g}}{{L_{\text{rod}}}}\,\sin\left({θ_{p}}\right)=0}{1.0}
+\resizeExpression{\frac{\,d\frac{\,d{θ_{p}}}{\,dt}}{\,dt}+\frac{\symbf{g}}{{L_{\text{rod}}}}\,\sin\left({θ_{p}}\right)=0}{\outDefScale}
 \end{displaymath}
 If the amplitude of angular displacement is small enough, we can approximate $\sin\left({θ_{p}}\right)={θ_{p}}$ for the purpose of a simple pendulum at very small angles. Then the equation of motion reduces to the equation of simple harmonic motion:
 
 \begin{displaymath}
-\resizeExpression{\frac{\,d\frac{\,d{θ_{p}}}{\,dt}}{\,dt}+\frac{\symbf{g}}{{L_{\text{rod}}}}\,{θ_{p}}=0}{1.0}
+\resizeExpression{\frac{\,d\frac{\,d{θ_{p}}}{\,dt}}{\,dt}+\frac{\symbf{g}}{{L_{\text{rod}}}}\,{θ_{p}}=0}{\outDefScale}
 \end{displaymath}
 Thus the simple harmonic motion is:
 
 \begin{displaymath}
-\resizeExpression{{θ_{p}}\left(t\right)={θ_{i}}\,\cos\left(Ω\,t\right)}{1.0}
+\resizeExpression{{θ_{p}}\left(t\right)={θ_{i}}\,\cos\left(Ω\,t\right)}{\outDefScale}
 \end{displaymath}
 \subsubsection{Data Constraints}
 \label{Sec:DataConstraints}

--- a/code/stable/sglpend/SRS/PDF/SglPend_SRS.tex
+++ b/code/stable/sglpend/SRS/PDF/SglPend_SRS.tex
@@ -27,12 +27,12 @@
 \setlist[symbDescription]{noitemsep, topsep=0pt, parsep=0pt, partopsep=0pt}
 \newsavebox{\mybox}
 \newcommand{\resizeExpression}[2]{
-\savebox{\mybox}{$#1$}
-\ifdim\wd\mybox>#2\linewidth
-\resizebox{#2\textwidth}{!}{\usebox{\mybox}}
-\else
-\usebox{\mybox}
-\fi
+  \savebox{\mybox}{$#1$}
+  \ifdim\wd\mybox>#2\linewidth
+    \resizebox{#2\textwidth}{!}{\usebox{\mybox}}
+  \else
+    \usebox{\mybox}
+  \fi
 }
 \bibliography{bibfile}
 \title{Software Requirements Specification for Single Pendulum}

--- a/code/stable/ssp/SRS/PDF/SSP_SRS.tex
+++ b/code/stable/ssp/SRS/PDF/SSP_SRS.tex
@@ -25,6 +25,8 @@
 \newcommand{\lt}{\ensuremath <}
 \newlist{symbDescription}{description}{1}
 \setlist[symbDescription]{noitemsep, topsep=0pt, parsep=0pt, partopsep=0pt}
+\def\inDefScale{0.8}
+\def\outDefScale{1.0}
 \newsavebox{\mybox}
 \newcommand{\resizeExpression}[2]{
   \savebox{\mybox}{$#1$}
@@ -482,7 +484,7 @@ Label & Factor of safety
         
 \\ \midrule
 Equation & \begin{displaymath}
-           \resizeExpression{{F_{\text{S}}}=\frac{P}{S}}{0.8}
+           \resizeExpression{{F_{\text{S}}}=\frac{P}{S}}{\inDefScale}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -512,13 +514,13 @@ Label & Equilibrium
         
 \\ \midrule
 Equation & \begin{displaymath}
-           \resizeExpression{\displaystyle\sum{{F_{\text{x}}}}=0}{0.8}
+           \resizeExpression{\displaystyle\sum{{F_{\text{x}}}}=0}{\inDefScale}
            \end{displaymath}
            \begin{displaymath}
-           \resizeExpression{\displaystyle\sum{{F_{\text{y}}}}=0}{0.8}
+           \resizeExpression{\displaystyle\sum{{F_{\text{y}}}}=0}{\inDefScale}
            \end{displaymath}
            \begin{displaymath}
-           \resizeExpression{\displaystyle\sum{M}=0}{0.8}
+           \resizeExpression{\displaystyle\sum{M}=0}{\inDefScale}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -555,7 +557,7 @@ Label & Mohr-Coulumb shear strength
         
 \\ \midrule
 Equation & \begin{displaymath}
-           \resizeExpression{{τ^{\text{f}}}={σ_{N}}'\,\tan\left(φ'\right)+c'}{0.8}
+           \resizeExpression{{τ^{\text{f}}}={σ_{N}}'\,\tan\left(φ'\right)+c'}{\inDefScale}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -589,7 +591,7 @@ Label & Effective stress
         
 \\ \midrule
 Equation & \begin{displaymath}
-           \resizeExpression{σ'=σ-u}{0.8}
+           \resizeExpression{σ'=σ-u}{\inDefScale}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -622,7 +624,7 @@ Label & Newton's second law of motion
         
 \\ \midrule
 Equation & \begin{displaymath}
-           \resizeExpression{\symbf{F}=m\,\symbf{a}\text{(}t\text{)}}{0.8}
+           \resizeExpression{\symbf{F}=m\,\symbf{a}\text{(}t\text{)}}{\inDefScale}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -662,7 +664,7 @@ Units & $\frac{\text{N}}{\text{m}}$
         
 \\ \midrule
 Equation & \begin{displaymath}
-           \resizeExpression{{\symbf{N}}_{i}=\left({\symbf{W}}_{i}-{\symbf{X}}_{i-1}+{\symbf{X}}_{i}+{\symbf{U}_{\text{g},i}}\,\cos\left({\symbf{β}}_{i}\right)+{\symbf{Q}}_{i}\,\cos\left({\symbf{ω}}_{i}\right)\right)\,\cos\left({\symbf{α}}_{i}\right)+\left(-{K_{\text{c}}}\,{\symbf{W}}_{i}-{\symbf{G}}_{i}+{\symbf{G}}_{i-1}-{\symbf{H}}_{i}+{\symbf{H}}_{i-1}+{\symbf{U}_{\text{g},i}}\,\sin\left({\symbf{β}}_{i}\right)+{\symbf{Q}}_{i}\,\sin\left({\symbf{ω}}_{i}\right)\right)\,\sin\left({\symbf{α}}_{i}\right)}{0.8}
+           \resizeExpression{{\symbf{N}}_{i}=\left({\symbf{W}}_{i}-{\symbf{X}}_{i-1}+{\symbf{X}}_{i}+{\symbf{U}_{\text{g},i}}\,\cos\left({\symbf{β}}_{i}\right)+{\symbf{Q}}_{i}\,\cos\left({\symbf{ω}}_{i}\right)\right)\,\cos\left({\symbf{α}}_{i}\right)+\left(-{K_{\text{c}}}\,{\symbf{W}}_{i}-{\symbf{G}}_{i}+{\symbf{G}}_{i-1}-{\symbf{H}}_{i}+{\symbf{H}}_{i-1}+{\symbf{U}_{\text{g},i}}\,\sin\left({\symbf{β}}_{i}\right)+{\symbf{Q}}_{i}\,\sin\left({\symbf{ω}}_{i}\right)\right)\,\sin\left({\symbf{α}}_{i}\right)}{\inDefScale}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -711,7 +713,7 @@ Units & $\frac{\text{N}}{\text{m}}$
         
 \\ \midrule
 Equation & \begin{displaymath}
-           \resizeExpression{{\symbf{S}}_{i}=\left({\symbf{W}}_{i}-{\symbf{X}}_{i-1}+{\symbf{X}}_{i}+{\symbf{U}_{\text{g},i}}\,\cos\left({\symbf{β}}_{i}\right)+{\symbf{Q}}_{i}\,\cos\left({\symbf{ω}}_{i}\right)\right)\,\sin\left({\symbf{α}}_{i}\right)-\left(-{K_{\text{c}}}\,{\symbf{W}}_{i}-{\symbf{G}}_{i}+{\symbf{G}}_{i-1}-{\symbf{H}}_{i}+{\symbf{H}}_{i-1}+{\symbf{U}_{\text{g},i}}\,\sin\left({\symbf{β}}_{i}\right)+{\symbf{Q}}_{i}\,\sin\left({\symbf{ω}}_{i}\right)\right)\,\cos\left({\symbf{α}}_{i}\right)}{0.8}
+           \resizeExpression{{\symbf{S}}_{i}=\left({\symbf{W}}_{i}-{\symbf{X}}_{i-1}+{\symbf{X}}_{i}+{\symbf{U}_{\text{g},i}}\,\cos\left({\symbf{β}}_{i}\right)+{\symbf{Q}}_{i}\,\cos\left({\symbf{ω}}_{i}\right)\right)\,\sin\left({\symbf{α}}_{i}\right)-\left(-{K_{\text{c}}}\,{\symbf{W}}_{i}-{\symbf{G}}_{i}+{\symbf{G}}_{i-1}-{\symbf{H}}_{i}+{\symbf{H}}_{i-1}+{\symbf{U}_{\text{g},i}}\,\sin\left({\symbf{β}}_{i}\right)+{\symbf{Q}}_{i}\,\sin\left({\symbf{ω}}_{i}\right)\right)\,\cos\left({\symbf{α}}_{i}\right)}{\inDefScale}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -760,7 +762,7 @@ Units & $\frac{\text{N}}{\text{m}}$
         
 \\ \midrule
 Equation & \begin{displaymath}
-           \resizeExpression{{\symbf{P}}_{i}={\symbf{N'}}_{i}\,\tan\left({φ'}_{i}\right)+{c'}_{i}\,{\symbf{L}_{b,i}}}{0.8}
+           \resizeExpression{{\symbf{P}}_{i}={\symbf{N'}}_{i}\,\tan\left({φ'}_{i}\right)+{c'}_{i}\,{\symbf{L}_{b,i}}}{\inDefScale}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -803,7 +805,7 @@ Units & $\frac{\text{N}}{\text{m}}$
         
 \\ \midrule
 Equation & \begin{displaymath}
-           \resizeExpression{{\symbf{S}}_{i}=\frac{{\symbf{P}}_{i}}{{F_{\text{S}}}}=\frac{{\symbf{N'}}_{i}\,\tan\left({φ'}_{i}\right)+{c'}_{i}\,{\symbf{L}_{b,i}}}{{F_{\text{S}}}}}{0.8}
+           \resizeExpression{{\symbf{S}}_{i}=\frac{{\symbf{P}}_{i}}{{F_{\text{S}}}}=\frac{{\symbf{N'}}_{i}\,\tan\left({φ'}_{i}\right)+{c'}_{i}\,{\symbf{L}_{b,i}}}{{F_{\text{S}}}}}{\inDefScale}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -848,7 +850,7 @@ Units & $\frac{\text{N}}{\text{m}}$
         
 \\ \midrule
 Equation & \begin{displaymath}
-           \resizeExpression{{\symbf{N'}}_{i}={\symbf{N}}_{i}-{\symbf{U}_{\text{b},i}}}{0.8}
+           \resizeExpression{{\symbf{N'}}_{i}={\symbf{N}}_{i}-{\symbf{U}_{\text{b},i}}}{\inDefScale}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -888,7 +890,7 @@ Units & $\frac{\text{N}}{\text{m}}$
         
 \\ \midrule
 Equation & \begin{displaymath}
-           \resizeExpression{{\symbf{R}}_{i}=\left(\left({\symbf{W}}_{i}+{\symbf{U}_{\text{g},i}}\,\cos\left({\symbf{β}}_{i}\right)\right)\,\cos\left({\symbf{α}}_{i}\right)+\left(-{\symbf{H}}_{i}+{\symbf{H}}_{i-1}+{\symbf{U}_{\text{g},i}}\,\sin\left({\symbf{β}}_{i}\right)\right)\,\sin\left({\symbf{α}}_{i}\right)-{\symbf{U}_{\text{b},i}}\right)\,\tan\left({φ'}_{i}\right)+{c'}_{i}\,{\symbf{L}_{b,i}}}{0.8}
+           \resizeExpression{{\symbf{R}}_{i}=\left(\left({\symbf{W}}_{i}+{\symbf{U}_{\text{g},i}}\,\cos\left({\symbf{β}}_{i}\right)\right)\,\cos\left({\symbf{α}}_{i}\right)+\left(-{\symbf{H}}_{i}+{\symbf{H}}_{i-1}+{\symbf{U}_{\text{g},i}}\,\sin\left({\symbf{β}}_{i}\right)\right)\,\sin\left({\symbf{α}}_{i}\right)-{\symbf{U}_{\text{b},i}}\right)\,\tan\left({φ'}_{i}\right)+{c'}_{i}\,{\symbf{L}_{b,i}}}{\inDefScale}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -932,7 +934,7 @@ Units & $\frac{\text{N}}{\text{m}}$
         
 \\ \midrule
 Equation & \begin{displaymath}
-           \resizeExpression{{\symbf{T}}_{i}=\left({\symbf{W}}_{i}+{\symbf{U}_{\text{g},i}}\,\cos\left({\symbf{β}}_{i}\right)\right)\,\sin\left({\symbf{α}}_{i}\right)-\left(-{\symbf{H}}_{i}+{\symbf{H}}_{i-1}+{\symbf{U}_{\text{g},i}}\,\sin\left({\symbf{β}}_{i}\right)\right)\,\cos\left({\symbf{α}}_{i}\right)}{0.8}
+           \resizeExpression{{\symbf{T}}_{i}=\left({\symbf{W}}_{i}+{\symbf{U}_{\text{g},i}}\,\cos\left({\symbf{β}}_{i}\right)\right)\,\sin\left({\symbf{α}}_{i}\right)-\left(-{\symbf{H}}_{i}+{\symbf{H}}_{i-1}+{\symbf{U}_{\text{g},i}}\,\sin\left({\symbf{β}}_{i}\right)\right)\,\cos\left({\symbf{α}}_{i}\right)}{\inDefScale}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -972,7 +974,7 @@ Units & $\frac{\text{N}}{\text{m}}$
         
 \\ \midrule
 Equation & \begin{displaymath}
-           \resizeExpression{\symbf{X}=λ\,\symbf{f}\,\symbf{G}}{0.8}
+           \resizeExpression{\symbf{X}=λ\,\symbf{f}\,\symbf{G}}{\inDefScale}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -1009,7 +1011,7 @@ Units & ${\text{N}}$
         
 \\ \midrule
 Equation & \begin{displaymath}
-           \resizeExpression{0=-{\symbf{G}}_{i}\,\left({\symbf{h}_{\text{z},i}}+\frac{{\symbf{b}}_{i}}{2}\,\tan\left({\symbf{α}}_{i}\right)\right)+{\symbf{G}}_{i-1}\,\left({\symbf{h}_{\text{z},i-1}}-\frac{{\symbf{b}}_{i}}{2}\,\tan\left({\symbf{α}}_{i}\right)\right)-{\symbf{H}}_{i}\,\left(\frac{1}{3}\,{\symbf{h}_{\text{z,w},i}}+\frac{{\symbf{b}}_{i}}{2}\,\tan\left({\symbf{α}}_{i}\right)\right)+{\symbf{H}}_{i-1}\,\left(\frac{1}{3}\,{\symbf{h}_{\text{z,w},i-1}}-\frac{{\symbf{b}}_{i}}{2}\,\tan\left({\symbf{α}}_{i}\right)\right)+\frac{{\symbf{b}}_{i}}{2}\,\left({\symbf{X}}_{i}+{\symbf{X}}_{i-1}\right)+\frac{-{K_{\text{c}}}\,{\symbf{W}}_{i}\,{\symbf{h}}_{i}}{2}+{\symbf{U}_{\text{g},i}}\,\sin\left({\symbf{β}}_{i}\right)\,{\symbf{h}}_{i}+{\symbf{Q}}_{i}\,\sin\left({\symbf{ω}}_{i}\right)\,{\symbf{h}}_{i}}{0.8}
+           \resizeExpression{0=-{\symbf{G}}_{i}\,\left({\symbf{h}_{\text{z},i}}+\frac{{\symbf{b}}_{i}}{2}\,\tan\left({\symbf{α}}_{i}\right)\right)+{\symbf{G}}_{i-1}\,\left({\symbf{h}_{\text{z},i-1}}-\frac{{\symbf{b}}_{i}}{2}\,\tan\left({\symbf{α}}_{i}\right)\right)-{\symbf{H}}_{i}\,\left(\frac{1}{3}\,{\symbf{h}_{\text{z,w},i}}+\frac{{\symbf{b}}_{i}}{2}\,\tan\left({\symbf{α}}_{i}\right)\right)+{\symbf{H}}_{i-1}\,\left(\frac{1}{3}\,{\symbf{h}_{\text{z,w},i-1}}-\frac{{\symbf{b}}_{i}}{2}\,\tan\left({\symbf{α}}_{i}\right)\right)+\frac{{\symbf{b}}_{i}}{2}\,\left({\symbf{X}}_{i}+{\symbf{X}}_{i-1}\right)+\frac{-{K_{\text{c}}}\,{\symbf{W}}_{i}\,{\symbf{h}}_{i}}{2}+{\symbf{U}_{\text{g},i}}\,\sin\left({\symbf{β}}_{i}\right)\,{\symbf{h}}_{i}+{\symbf{Q}}_{i}\,\sin\left({\symbf{ω}}_{i}\right)\,{\symbf{h}}_{i}}{\inDefScale}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -1047,72 +1049,72 @@ RefBy & \hyperref[IM:nrmShrFor]{IM:nrmShrFor}
 Moment is equal to torque, so the equation from \hyperref[DD:torque]{DD:torque} will be used to calculate moments:
 
 \begin{displaymath}
-\resizeExpression{\symbf{τ}=\symbf{u}\times\symbf{F}}{1.0}
+\resizeExpression{\symbf{τ}=\symbf{u}\times\symbf{F}}{\outDefScale}
 \end{displaymath}
 Considering one dimension, with moments in the clockwise direction as positive and moments in the counterclockwise direction as negative, and replacing the torque symbol with the moment symbol, the equation simplifies to:
 
 \begin{displaymath}
-\resizeExpression{M={F_{\text{rot}}}\,r}{1.0}
+\resizeExpression{M={F_{\text{rot}}}\,r}{\outDefScale}
 \end{displaymath}
 where ${F_{\text{rot}}}$ is the force causing rotation and $r$ is the length of the moment arm, or the distance between the force and the axis about which the rotation acts. To represent the moment equilibrium, the moments from each force acting on a slice must be considered and added together. The forces acting on a slice are all shown in \hyperref[Figure:ForceDiagram]{Fig:ForceDiagram}. The midpoint of the base of a slice is considered as the axis of rotation, from which the length of the moment arm is measured. Considering first the interslice normal force acting on slice interface $i$, the moment is negative because the force tends to rotate the slice in a counterclockwise direction, and the length of the moment arm is the height of the force plus the difference in height between the base at slice interface $i$ and the base at the midpoint of slice $i$. Thus, the moment is expressed as:
 
 \begin{displaymath}
-\resizeExpression{-{\symbf{G}}_{i}\,\left({\symbf{h}_{\text{z},i}}+\frac{{\symbf{b}}_{i}}{2}\,\tan\left({\symbf{α}}_{i}\right)\right)}{1.0}
+\resizeExpression{-{\symbf{G}}_{i}\,\left({\symbf{h}_{\text{z},i}}+\frac{{\symbf{b}}_{i}}{2}\,\tan\left({\symbf{α}}_{i}\right)\right)}{\outDefScale}
 \end{displaymath}
 For the $i-1$th slice interface, the moment is similar but in the opposite direction:
 
 \begin{displaymath}
-\resizeExpression{{\symbf{G}}_{i-1}\,\left({\symbf{h}_{\text{z},i-1}}-\frac{{\symbf{b}}_{i}}{2}\,\tan\left({\symbf{α}}_{i}\right)\right)}{1.0}
+\resizeExpression{{\symbf{G}}_{i-1}\,\left({\symbf{h}_{\text{z},i-1}}-\frac{{\symbf{b}}_{i}}{2}\,\tan\left({\symbf{α}}_{i}\right)\right)}{\outDefScale}
 \end{displaymath}
 Next, the interslice normal water force is considered. This force is zero at the height of the water table, then increases linearly towards the base of the slice due to the increasing water pressure. For such a triangular distribution, the resultant force acts at one-third of the height. Thus, for the interslice normal water force acting on slice interface $i$, the moment is:
 
 \begin{displaymath}
-\resizeExpression{-{\symbf{H}}_{i}\,\left(\frac{1}{3}\,{\symbf{h}_{\text{z,w},i}}+\frac{{\symbf{b}}_{i}}{2}\,\tan\left({\symbf{α}}_{i}\right)\right)}{1.0}
+\resizeExpression{-{\symbf{H}}_{i}\,\left(\frac{1}{3}\,{\symbf{h}_{\text{z,w},i}}+\frac{{\symbf{b}}_{i}}{2}\,\tan\left({\symbf{α}}_{i}\right)\right)}{\outDefScale}
 \end{displaymath}
 The moment for the interslice normal water force acting on slice interface $i-1$ is:
 
 \begin{displaymath}
-\resizeExpression{{\symbf{H}}_{i-1}\,\left(\frac{1}{3}\,{\symbf{h}_{\text{z,w},i-1}}+\frac{{\symbf{b}}_{i}}{2}\,\tan\left({\symbf{α}}_{i}\right)\right)}{1.0}
+\resizeExpression{{\symbf{H}}_{i-1}\,\left(\frac{1}{3}\,{\symbf{h}_{\text{z,w},i-1}}+\frac{{\symbf{b}}_{i}}{2}\,\tan\left({\symbf{α}}_{i}\right)\right)}{\outDefScale}
 \end{displaymath}
 The interslice shear force at slice interface $i$ tends to rotate in the clockwise direction, and the length of the moment arm is the length from the slice edge to the slice midpoint, equivalent to half of the width of the slice, so the moment is:
 
 \begin{displaymath}
-\resizeExpression{{\symbf{X}}_{i}\,\frac{{\symbf{b}}_{i}}{2}}{1.0}
+\resizeExpression{{\symbf{X}}_{i}\,\frac{{\symbf{b}}_{i}}{2}}{\outDefScale}
 \end{displaymath}
 The interslice shear force at slice interface $i-1$ also tends to rotate in the clockwise direction, and has the same length of the moment arm, so the moment is:
 
 \begin{displaymath}
-\resizeExpression{{\symbf{X}}_{i-1}\,\frac{{\symbf{b}}_{i}}{2}}{1.0}
+\resizeExpression{{\symbf{X}}_{i-1}\,\frac{{\symbf{b}}_{i}}{2}}{\outDefScale}
 \end{displaymath}
 Seismic forces act over the entire height of the slice. For each horizontal segment of the slice, the seismic force is ${K_{\text{c}}}\,{\symbf{W}}_{i}$ where ${\symbf{W}}_{i}$ can be expressed as $γ\,{\symbf{b}}_{i}\,y$ using \hyperref[GD:weight]{GD:weight} where $y$ is the height of the segment under consideration. The corresponding length of the moment arm is $y$, the height from the base of the slice to the segment under consideration. In reality, the forces near the surface of the soil mass are slightly different due to the slope of the surface, but this difference is assumed to be negligible (\hyperref[assumpNESSS]{A:Negligible-Effect-Surface-Slope-Seismic}). The resultant moment from the forces on all of the segments with an equivalent resultant length of the moment arm is determined by taking the integral over the slice height. The forces tend to rotate in the counterclockwise direction, so the moment is negative:
 
 \begin{displaymath}
-\resizeExpression{-\int_{0}^{{\symbf{h}}_{i}}{{K_{\text{c}}}\,γ\,{\symbf{b}}_{i}\,y}\,dy}{1.0}
+\resizeExpression{-\int_{0}^{{\symbf{h}}_{i}}{{K_{\text{c}}}\,γ\,{\symbf{b}}_{i}\,y}\,dy}{\outDefScale}
 \end{displaymath}
 Solving the definite integral yields:
 
 \begin{displaymath}
-\resizeExpression{-{K_{\text{c}}}\,γ\,{\symbf{b}}_{i}\,\frac{{\symbf{h}}_{i}^{2}}{2}}{1.0}
+\resizeExpression{-{K_{\text{c}}}\,γ\,{\symbf{b}}_{i}\,\frac{{\symbf{h}}_{i}^{2}}{2}}{\outDefScale}
 \end{displaymath}
 Using \hyperref[GD:weight]{GD:weight} again to express $γ\,{\symbf{b}}_{i}\,{\symbf{h}}_{i}$ as ${\symbf{W}}_{i}$, the moment is:
 
 \begin{displaymath}
-\resizeExpression{-{K_{\text{c}}}\,{\symbf{W}}_{i}\,\frac{{\symbf{h}}_{i}}{2}}{1.0}
+\resizeExpression{-{K_{\text{c}}}\,{\symbf{W}}_{i}\,\frac{{\symbf{h}}_{i}}{2}}{\outDefScale}
 \end{displaymath}
 The surface hydrostatic force acts into the midpoint of the surface of the slice (\hyperref[assumpHFSM]{A:Hydrostatic-Force-Slice-Midpoint}). Thus, the vertical component of the force acts directly towards the point of rotation, and has a moment of zero. The horizontal component of the force tends to rotate in a clockwise direction and the length of the moment arm is the entire height of the slice. Thus, the moment is:
 
 \begin{displaymath}
-\resizeExpression{{\symbf{U}_{\text{g},i}}\,\sin\left({\symbf{β}}_{i}\right)\,{\symbf{h}}_{i}}{1.0}
+\resizeExpression{{\symbf{U}_{\text{g},i}}\,\sin\left({\symbf{β}}_{i}\right)\,{\symbf{h}}_{i}}{\outDefScale}
 \end{displaymath}
 The external force again acts into the midpoint of the slice surface, so the vertical component does not contribute to the moment, and the length of the moment arm is again the entire height of the slice. The moment is:
 
 \begin{displaymath}
-\resizeExpression{{\symbf{Q}}_{i}\,\sin\left({\symbf{ω}}_{i}\right)\,{\symbf{h}}_{i}}{1.0}
+\resizeExpression{{\symbf{Q}}_{i}\,\sin\left({\symbf{ω}}_{i}\right)\,{\symbf{h}}_{i}}{\outDefScale}
 \end{displaymath}
 The base hydrostatic force and slice weight both act in the direction of the point of rotation (\hyperref[assumpHFSM]{A:Hydrostatic-Force-Slice-Midpoint}), therefore both have moments of zero. Thus, all of the moments have been determined. The moment equilibrium is then represented by the sum of all moments:
 
 \begin{displaymath}
-\resizeExpression{0=-{\symbf{G}}_{i}\,\left({\symbf{h}_{\text{z},i}}+\frac{{\symbf{b}}_{i}}{2}\,\tan\left({\symbf{α}}_{i}\right)\right)+{\symbf{G}}_{i-1}\,\left({\symbf{h}_{\text{z},i-1}}-\frac{{\symbf{b}}_{i}}{2}\,\tan\left({\symbf{α}}_{i}\right)\right)-{\symbf{H}}_{i}\,\left(\frac{1}{3}\,{\symbf{h}_{\text{z,w},i}}+\frac{{\symbf{b}}_{i}}{2}\,\tan\left({\symbf{α}}_{i}\right)\right)+{\symbf{H}}_{i-1}\,\left(\frac{1}{3}\,{\symbf{h}_{\text{z,w},i-1}}-\frac{{\symbf{b}}_{i}}{2}\,\tan\left({\symbf{α}}_{i}\right)\right)+\frac{{\symbf{b}}_{i}}{2}\,\left({\symbf{X}}_{i}+{\symbf{X}}_{i-1}\right)+\frac{-{K_{\text{c}}}\,{\symbf{W}}_{i}\,{\symbf{h}}_{i}}{2}+{\symbf{U}_{\text{g},i}}\,\sin\left({\symbf{β}}_{i}\right)\,{\symbf{h}}_{i}+{\symbf{Q}}_{i}\,\sin\left({\symbf{ω}}_{i}\right)\,{\symbf{h}}_{i}}{1.0}
+\resizeExpression{0=-{\symbf{G}}_{i}\,\left({\symbf{h}_{\text{z},i}}+\frac{{\symbf{b}}_{i}}{2}\,\tan\left({\symbf{α}}_{i}\right)\right)+{\symbf{G}}_{i-1}\,\left({\symbf{h}_{\text{z},i-1}}-\frac{{\symbf{b}}_{i}}{2}\,\tan\left({\symbf{α}}_{i}\right)\right)-{\symbf{H}}_{i}\,\left(\frac{1}{3}\,{\symbf{h}_{\text{z,w},i}}+\frac{{\symbf{b}}_{i}}{2}\,\tan\left({\symbf{α}}_{i}\right)\right)+{\symbf{H}}_{i-1}\,\left(\frac{1}{3}\,{\symbf{h}_{\text{z,w},i-1}}-\frac{{\symbf{b}}_{i}}{2}\,\tan\left({\symbf{α}}_{i}\right)\right)+\frac{{\symbf{b}}_{i}}{2}\,\left({\symbf{X}}_{i}+{\symbf{X}}_{i-1}\right)+\frac{-{K_{\text{c}}}\,{\symbf{W}}_{i}\,{\symbf{h}}_{i}}{2}+{\symbf{U}_{\text{g},i}}\,\sin\left({\symbf{β}}_{i}\right)\,{\symbf{h}}_{i}+{\symbf{Q}}_{i}\,\sin\left({\symbf{ω}}_{i}\right)\,{\symbf{h}}_{i}}{\outDefScale}
 \end{displaymath}
 \medskip
 \noindent
@@ -1129,7 +1131,7 @@ Units & ${\text{N}}$
         
 \\ \midrule
 Equation & \begin{displaymath}
-           \resizeExpression{W=V\,γ}{0.8}
+           \resizeExpression{W=V\,γ}{\inDefScale}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -1155,22 +1157,22 @@ Under the influence of gravity, and assuming a 2D Cartesian coordinate system wi
 \resizeExpression{\symbf{a}\text{(}t\text{)}=\begin{bmatrix}
                                              0\\
                                              \symbf{g}\,\symbf{\hat{j}}
-                                             \end{bmatrix}}{1.0}
+                                             \end{bmatrix}}{\outDefScale}
 \end{displaymath}
 Since there is only one non-zero vector component, the scalar value $W$ will be used for the weight. In this scenario, Newton's second law of motion from \hyperref[TM:NewtonSecLawMot]{TM:NewtonSecLawMot} can be expressed as:
 
 \begin{displaymath}
-\resizeExpression{W=m\,\symbf{g}}{1.0}
+\resizeExpression{W=m\,\symbf{g}}{\outDefScale}
 \end{displaymath}
 Mass can be expressed as density multiplied by volume, resulting in:
 
 \begin{displaymath}
-\resizeExpression{W=ρ\,V\,\symbf{g}}{1.0}
+\resizeExpression{W=ρ\,V\,\symbf{g}}{\outDefScale}
 \end{displaymath}
 Substituting specific weight as the product of density and gravitational acceleration yields:
 
 \begin{displaymath}
-\resizeExpression{W=V\,γ}{1.0}
+\resizeExpression{W=V\,γ}{\outDefScale}
 \end{displaymath}
 \medskip
 \noindent
@@ -1191,7 +1193,7 @@ Equation & \begin{displaymath}
                                                                            \left({\symbf{y}_{\text{slope},i}}-{\symbf{y}_{\text{slip},i}}+{\symbf{y}_{\text{slope},i-1}}-{\symbf{y}_{\text{slip},i-1}}\right)\,{γ_{\text{sat}}}, & {\symbf{y}_{\text{wt},i}}\gt{}{\symbf{y}_{\text{slope},i}}\lor{}{\symbf{y}_{\text{wt},i-1}}\gt{}{\symbf{y}_{\text{slope},i-1}}\\
                                                                            \left({\symbf{y}_{\text{slope},i}}-{\symbf{y}_{\text{wt},i}}+{\symbf{y}_{\text{slope},i-1}}-{\symbf{y}_{\text{wt},i-1}}\right)\,{γ_{\text{dry}}}+\left({\symbf{y}_{\text{wt},i}}-{\symbf{y}_{\text{slip},i}}+{\symbf{y}_{\text{wt},i-1}}-{\symbf{y}_{\text{slip},i-1}}\right)\,{γ_{\text{sat}}}, & {\symbf{y}_{\text{slope},i}}\geq{}{\symbf{y}_{\text{wt},i}}\geq{}{\symbf{y}_{\text{slip},i}}\land{}{\symbf{y}_{\text{slope},i-1}}\geq{}{\symbf{y}_{\text{wt},i-1}}\geq{}{\symbf{y}_{\text{slip},i-1}}\\
                                                                            \left({\symbf{y}_{\text{slope},i}}-{\symbf{y}_{\text{slip},i}}+{\symbf{y}_{\text{slope},i-1}}-{\symbf{y}_{\text{slip},i-1}}\right)\,{γ_{\text{dry}}}, & {\symbf{y}_{\text{wt},i}}\lt{}{\symbf{y}_{\text{slip},i}}\lor{}{\symbf{y}_{\text{wt},i-1}}\lt{}{\symbf{y}_{\text{slip},i-1}}
-                                                                           \end{cases}}{0.8}
+                                                                           \end{cases}}{\inDefScale}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -1222,32 +1224,32 @@ RefBy & \hyperref[GD:resShearWO]{GD:resShearWO}, \hyperref[GD:normForcEq]{GD:nor
 For the case where the water table is above the slope surface, the weights come from the weight of the saturated soil. Substituting values for saturated soil into the equation for weight from \hyperref[GD:weight]{GD:weight} yields:
 
 \begin{displaymath}
-\resizeExpression{{\symbf{W}}_{i}={\symbf{V}_{\text{sat},i}}\,{γ_{\text{sat}}}}{1.0}
+\resizeExpression{{\symbf{W}}_{i}={\symbf{V}_{\text{sat},i}}\,{γ_{\text{sat}}}}{\outDefScale}
 \end{displaymath}
 Due to \hyperref[assumpPSC]{A:Plane-Strain-Conditions}, only two dimensions are considered, so the areas of saturated soil are considered instead of the volumes of saturated soil. Any given slice has a trapezoidal shape. The area of a trapezoid is the average of the lengths of the parallel sides multiplied by the length between the parallel sides. The parallel sides in this case are the interslice edges and the length between them is the width of the slice. Thus, the weights are defined as:
 
 \begin{displaymath}
-\resizeExpression{{\symbf{W}}_{i}={\symbf{b}}_{i}\,\frac{1}{2}\,\left({\symbf{y}_{\text{slope},i}}-{\symbf{y}_{\text{slip},i}}+{\symbf{y}_{\text{slope},i-1}}-{\symbf{y}_{\text{slip},i-1}}\right)\,{γ_{\text{sat}}}}{1.0}
+\resizeExpression{{\symbf{W}}_{i}={\symbf{b}}_{i}\,\frac{1}{2}\,\left({\symbf{y}_{\text{slope},i}}-{\symbf{y}_{\text{slip},i}}+{\symbf{y}_{\text{slope},i-1}}-{\symbf{y}_{\text{slip},i-1}}\right)\,{γ_{\text{sat}}}}{\outDefScale}
 \end{displaymath}
 For the case where the water table is below the slip surface, the weights come from the weight of the dry soil. Substituting values for dry soil into the equation for weight from \hyperref[GD:weight]{GD:weight} yields:
 
 \begin{displaymath}
-\resizeExpression{{\symbf{W}}_{i}={\symbf{V}_{\text{dry},i}}\,{γ_{\text{dry}}}}{1.0}
+\resizeExpression{{\symbf{W}}_{i}={\symbf{V}_{\text{dry},i}}\,{γ_{\text{dry}}}}{\outDefScale}
 \end{displaymath}
 \hyperref[assumpPSC]{A:Plane-Strain-Conditions} again allows for two-dimensional analysis so the areas of dry soil are considered instead of the volumes of dry soil. The trapezoidal slice shape is the same as in the previous case, so the weights are defined as:
 
 \begin{displaymath}
-\resizeExpression{{\symbf{W}}_{i}={\symbf{b}}_{i}\,\frac{1}{2}\,\left({\symbf{y}_{\text{slope},i}}-{\symbf{y}_{\text{slip},i}}+{\symbf{y}_{\text{slope},i-1}}-{\symbf{y}_{\text{slip},i-1}}\right)\,{γ_{\text{dry}}}}{1.0}
+\resizeExpression{{\symbf{W}}_{i}={\symbf{b}}_{i}\,\frac{1}{2}\,\left({\symbf{y}_{\text{slope},i}}-{\symbf{y}_{\text{slip},i}}+{\symbf{y}_{\text{slope},i-1}}-{\symbf{y}_{\text{slip},i-1}}\right)\,{γ_{\text{dry}}}}{\outDefScale}
 \end{displaymath}
 For the case where the water table is between the slope surface and slip surface, the weights are the sums of the weights of the dry portions and weights of the saturated portions of the soil. Substituting values for dry and saturated soil into the equation for weight from \hyperref[GD:weight]{GD:weight} and adding them together yields:
 
 \begin{displaymath}
-\resizeExpression{{\symbf{W}}_{i}={\symbf{V}_{\text{dry},i}}\,{γ_{\text{dry}}}+{\symbf{V}_{\text{sat},i}}\,{γ_{\text{sat}}}}{1.0}
+\resizeExpression{{\symbf{W}}_{i}={\symbf{V}_{\text{dry},i}}\,{γ_{\text{dry}}}+{\symbf{V}_{\text{sat},i}}\,{γ_{\text{sat}}}}{\outDefScale}
 \end{displaymath}
 \hyperref[assumpPSC]{A:Plane-Strain-Conditions} again allows for two-dimensional analysis so the areas of dry soil and areas of saturated soil are considered instead of the volumes of dry soil and volumes of saturated soil. The water table is assumed to only intersect a slice surface or base at a slice edge (\hyperref[assumpWISE]{A:Water-Intersects-Surface-Edge}, \hyperref[assumpWIBE]{A:Water-Intersects-Base-Edge}), so the dry and saturated portions each have trapezoidal shape. For the dry portion, the parallel sides of the trapezoid are the lengths between the slope surface and water table at the slice edges. For the saturated portion, the parallel sides of the trapezoid are the lengths between the water table and slip surface at the slice edges. Thus, the weights are defined as:
 
 \begin{displaymath}
-\resizeExpression{{\symbf{W}}_{i}={\symbf{b}}_{i}\,\frac{1}{2}\,\left(\left({\symbf{y}_{\text{slope},i}}-{\symbf{y}_{\text{wt},i}}+{\symbf{y}_{\text{slope},i-1}}-{\symbf{y}_{\text{wt},i-1}}\right)\,{γ_{\text{dry}}}+\left({\symbf{y}_{\text{wt},i}}-{\symbf{y}_{\text{slip},i}}+{\symbf{y}_{\text{wt},i-1}}-{\symbf{y}_{\text{slip},i-1}}\right)\,{γ_{\text{sat}}}\right)}{1.0}
+\resizeExpression{{\symbf{W}}_{i}={\symbf{b}}_{i}\,\frac{1}{2}\,\left(\left({\symbf{y}_{\text{slope},i}}-{\symbf{y}_{\text{wt},i}}+{\symbf{y}_{\text{slope},i-1}}-{\symbf{y}_{\text{wt},i-1}}\right)\,{γ_{\text{dry}}}+\left({\symbf{y}_{\text{wt},i}}-{\symbf{y}_{\text{slip},i}}+{\symbf{y}_{\text{wt},i-1}}-{\symbf{y}_{\text{slip},i-1}}\right)\,{γ_{\text{sat}}}\right)}{\outDefScale}
 \end{displaymath}
 \medskip
 \noindent
@@ -1264,7 +1266,7 @@ Units & ${\text{Pa}}$
         
 \\ \midrule
 Equation & \begin{displaymath}
-           \resizeExpression{p=γ\,h}{0.8}
+           \resizeExpression{p=γ\,h}{\inDefScale}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -1303,7 +1305,7 @@ Equation & \begin{displaymath}
            \resizeExpression{{\symbf{U}_{\text{b},i}}={\symbf{L}_{b,i}}\,{γ_{w}}\,\frac{1}{2}\,\begin{cases}
                                                                                                {\symbf{y}_{\text{wt},i}}-{\symbf{y}_{\text{slip},i}}+{\symbf{y}_{\text{wt},i-1}}-{\symbf{y}_{\text{slip},i-1}}, & {\symbf{y}_{\text{wt},i}}\gt{}{\symbf{y}_{\text{slip},i}}\lor{}{\symbf{y}_{\text{wt},i-1}}\gt{}{\symbf{y}_{\text{slip},i-1}}\\
                                                                                                0, & {\symbf{y}_{\text{wt},i}}\leq{}{\symbf{y}_{\text{slip},i}}\land{}{\symbf{y}_{\text{wt},i-1}}\leq{}{\symbf{y}_{\text{slip},i-1}}
-                                                                                               \end{cases}}{0.8}
+                                                                                               \end{cases}}{\inDefScale}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -1332,17 +1334,17 @@ RefBy & \hyperref[GD:resShearWO]{GD:resShearWO}, \hyperref[GD:effNormF]{GD:effNo
 The base hydrostatic forces come from the hydrostatic pressure exerted by the water above the base of each slice. The equation for hydrostatic pressure from \hyperref[GD:hsPressure]{GD:hsPressure} is:
 
 \begin{displaymath}
-\resizeExpression{p=γ\,h}{1.0}
+\resizeExpression{p=γ\,h}{\outDefScale}
 \end{displaymath}
 The specific weight in this case is the unit weight of water ${γ_{w}}$. The height in this case is the height from the slice base to the water table. This height is measured from the midpoint of the slice because the resultant hydrostatic force is assumed to act at the slice midpoint (\hyperref[assumpHFSM]{A:Hydrostatic-Force-Slice-Midpoint}). The height at the midpoint is the average of the height at slice interface $i$ and the height at slice interface $i-1$:
 
 \begin{displaymath}
-\resizeExpression{\frac{1}{2}\,\left({\symbf{y}_{\text{wt},i}}-{\symbf{y}_{\text{slip},i}}+{\symbf{y}_{\text{wt},i-1}}-{\symbf{y}_{\text{slip},i-1}}\right)}{1.0}
+\resizeExpression{\frac{1}{2}\,\left({\symbf{y}_{\text{wt},i}}-{\symbf{y}_{\text{slip},i}}+{\symbf{y}_{\text{wt},i-1}}-{\symbf{y}_{\text{slip},i-1}}\right)}{\outDefScale}
 \end{displaymath}
 Due to \hyperref[assumpPSC]{A:Plane-Strain-Conditions}, only two dimensions are considered, so the base hydrostatic forces are expressed as forces per meter. The pressures acting on the slices can thus be converted to base hydrostatic forces by multiplying by the corresponding length of the slice base ${\symbf{L}_{b,i}}$, assuming the water table does not intersect a slice base except at a slice edge (\hyperref[assumpWIBE]{A:Water-Intersects-Base-Edge}). Thus, in the case where the height of the water table is above the height of the slip surface, the base hydrostatic forces are defined as:
 
 \begin{displaymath}
-\resizeExpression{{\symbf{U}_{\text{b},i}}={\symbf{L}_{b,i}}\,{γ_{w}}\,\frac{1}{2}\,\left({\symbf{y}_{\text{wt},i}}-{\symbf{y}_{\text{slip},i}}+{\symbf{y}_{\text{wt},i-1}}-{\symbf{y}_{\text{slip},i-1}}\right)}{1.0}
+\resizeExpression{{\symbf{U}_{\text{b},i}}={\symbf{L}_{b,i}}\,{γ_{w}}\,\frac{1}{2}\,\left({\symbf{y}_{\text{wt},i}}-{\symbf{y}_{\text{slip},i}}+{\symbf{y}_{\text{wt},i-1}}-{\symbf{y}_{\text{slip},i-1}}\right)}{\outDefScale}
 \end{displaymath}
 This equation is the non-zero case of \hyperref[GD:baseWtrF]{GD:baseWtrF}. The zero case is when the height of the water table is below the height of the slip surface, so there is no hydrostatic force.
 
@@ -1364,7 +1366,7 @@ Equation & \begin{displaymath}
            \resizeExpression{{\symbf{U}_{\text{g},i}}={\symbf{L}_{s,i}}\,{γ_{w}}\,\frac{1}{2}\,\begin{cases}
                                                                                                {\symbf{y}_{\text{wt},i}}-{\symbf{y}_{\text{slope},i}}+{\symbf{y}_{\text{wt},i-1}}-{\symbf{y}_{\text{slope},i-1}}, & {\symbf{y}_{\text{wt},i}}\gt{}{\symbf{y}_{\text{slope},i}}\lor{}{\symbf{y}_{\text{wt},i-1}}\gt{}{\symbf{y}_{\text{slope},i-1}}\\
                                                                                                0, & {\symbf{y}_{\text{wt},i}}\leq{}{\symbf{y}_{\text{slope},i}}\land{}{\symbf{y}_{\text{wt},i-1}}\leq{}{\symbf{y}_{\text{slope},i-1}}
-                                                                                               \end{cases}}{0.8}
+                                                                                               \end{cases}}{\inDefScale}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -1393,17 +1395,17 @@ RefBy & \hyperref[GD:srfWtrF]{GD:srfWtrF}, \hyperref[GD:resShearWO]{GD:resShearW
 The surface hydrostatic forces come from the hydrostatic pressure exerted by the water above the surface of each slice. The equation for hydrostatic pressure from \hyperref[GD:hsPressure]{GD:hsPressure} is:
 
 \begin{displaymath}
-\resizeExpression{p=γ\,h}{1.0}
+\resizeExpression{p=γ\,h}{\outDefScale}
 \end{displaymath}
 The specific weight in this case is the unit weight of water ${γ_{w}}$. The height in this case is the height from the slice surface to the water table. This height is measured from the midpoint of the slice because the resultant hydrostatic force is assumed to act at the slice midpoint (\hyperref[assumpHFSM]{A:Hydrostatic-Force-Slice-Midpoint}). The height at the midpoint is the average of the height at slice interface $i$ and the height at slice interface $i-1$:
 
 \begin{displaymath}
-\resizeExpression{\frac{1}{2}\,\left({\symbf{y}_{\text{wt},i}}-{\symbf{y}_{\text{slope},i}}+{\symbf{y}_{\text{wt},i-1}}-{\symbf{y}_{\text{slope},i-1}}\right)}{1.0}
+\resizeExpression{\frac{1}{2}\,\left({\symbf{y}_{\text{wt},i}}-{\symbf{y}_{\text{slope},i}}+{\symbf{y}_{\text{wt},i-1}}-{\symbf{y}_{\text{slope},i-1}}\right)}{\outDefScale}
 \end{displaymath}
 Due to \hyperref[assumpPSC]{A:Plane-Strain-Conditions}, only two dimensions are considered, so the surface hydrostatic forces are expressed as forces per meter. The pressures acting on the slices can thus be converted to surface hydrostatic forces by multiplying by the corresponding length of the slice surface ${\symbf{L}_{s,i}}$, assuming the water table does not intersect a slice surface except at a slice edge (\hyperref[assumpWISE]{A:Water-Intersects-Surface-Edge}). Thus, in the case where the height of the water table is above the height of the slope surface, the surface hydrostatic forces are defined as:
 
 \begin{displaymath}
-\resizeExpression{{\symbf{U}_{\text{g},i}}={\symbf{L}_{s,i}}\,{γ_{w}}\,\frac{1}{2}\,\left({\symbf{y}_{\text{wt},i}}-{\symbf{y}_{\text{slope},i}}+{\symbf{y}_{\text{wt},i-1}}-{\symbf{y}_{\text{slope},i-1}}\right)}{1.0}
+\resizeExpression{{\symbf{U}_{\text{g},i}}={\symbf{L}_{s,i}}\,{γ_{w}}\,\frac{1}{2}\,\left({\symbf{y}_{\text{wt},i}}-{\symbf{y}_{\text{slope},i}}+{\symbf{y}_{\text{wt},i-1}}-{\symbf{y}_{\text{slope},i-1}}\right)}{\outDefScale}
 \end{displaymath}
 This equation is the non-zero case of \hyperref[GD:srfWtrF]{GD:srfWtrF}. The zero case is when the height of the water table is below the height of the slope surface, so there is no hydrostatic force.
 
@@ -1433,7 +1435,7 @@ Equation & \begin{displaymath}
                                        \frac{\left({\symbf{y}_{\text{slope},i}}-{\symbf{y}_{\text{slip},i}}\right)^{2}}{2}\,{γ_{w}}+\left({\symbf{y}_{\text{wt},i}}-{\symbf{y}_{\text{slope},i}}\right)^{2}\,{γ_{w}}, & {\symbf{y}_{\text{wt},i}}\geq{}{\symbf{y}_{\text{slope},i}}\\
                                        \frac{\left({\symbf{y}_{\text{wt},i}}-{\symbf{y}_{\text{slip},i}}\right)^{2}}{2}\,{γ_{w}}, & {\symbf{y}_{\text{slope},i}}\gt{}{\symbf{y}_{\text{wt},i}}\land{}{\symbf{y}_{\text{wt},i}}\gt{}{\symbf{y}_{\text{slip},i}}\\
                                        0, & {\symbf{y}_{\text{wt},i}}\leq{}{\symbf{y}_{\text{slip},i}}
-                                       \end{cases}}{0.8}
+                                       \end{cases}}{\inDefScale}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -1472,7 +1474,7 @@ Units & ${{}^{\circ}}$
         
 \\ \midrule
 Equation & \begin{displaymath}
-           \resizeExpression{\symbf{α}=\arctan\left(\frac{{\symbf{y}_{\text{slip},i}}-{\symbf{y}_{\text{slip},i-1}}}{{\symbf{x}_{\text{slip},i}}-{\symbf{x}_{\text{slip},i-1}}}\right)}{0.8}
+           \resizeExpression{\symbf{α}=\arctan\left(\frac{{\symbf{y}_{\text{slip},i}}-{\symbf{y}_{\text{slip},i-1}}}{{\symbf{x}_{\text{slip},i}}-{\symbf{x}_{\text{slip},i-1}}}\right)}{\inDefScale}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -1512,7 +1514,7 @@ Units & ${{}^{\circ}}$
         
 \\ \midrule
 Equation & \begin{displaymath}
-           \resizeExpression{\symbf{β}=\arctan\left(\frac{{\symbf{y}_{\text{slope},i}}-{\symbf{y}_{\text{slope},i-1}}}{{\symbf{x}_{\text{slope},i}}-{\symbf{x}_{\text{slope},i-1}}}\right)}{0.8}
+           \resizeExpression{\symbf{β}=\arctan\left(\frac{{\symbf{y}_{\text{slope},i}}-{\symbf{y}_{\text{slope},i-1}}}{{\symbf{x}_{\text{slope},i}}-{\symbf{x}_{\text{slope},i-1}}}\right)}{\inDefScale}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -1552,7 +1554,7 @@ Units & ${\text{m}}$
         
 \\ \midrule
 Equation & \begin{displaymath}
-           \resizeExpression{\symbf{b}={\symbf{x}_{\text{slip},i}}-{\symbf{x}_{\text{slip},i-1}}}{0.8}
+           \resizeExpression{\symbf{b}={\symbf{x}_{\text{slip},i}}-{\symbf{x}_{\text{slip},i-1}}}{\inDefScale}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -1588,7 +1590,7 @@ Units & ${\text{m}}$
         
 \\ \midrule
 Equation & \begin{displaymath}
-           \resizeExpression{{\symbf{L}_{b}}={\symbf{b}}_{i}\,\sec\left({\symbf{α}}_{i}\right)}{0.8}
+           \resizeExpression{{\symbf{L}_{b}}={\symbf{b}}_{i}\,\sec\left({\symbf{α}}_{i}\right)}{\inDefScale}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -1628,7 +1630,7 @@ Units & ${\text{m}}$
         
 \\ \midrule
 Equation & \begin{displaymath}
-           \resizeExpression{{\symbf{L}_{s}}={\symbf{b}}_{i}\,\sec\left({\symbf{β}}_{i}\right)}{0.8}
+           \resizeExpression{{\symbf{L}_{s}}={\symbf{b}}_{i}\,\sec\left({\symbf{β}}_{i}\right)}{\inDefScale}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -1668,7 +1670,7 @@ Units & ${\text{m}}$
         
 \\ \midrule
 Equation & \begin{displaymath}
-           \resizeExpression{\symbf{h}=\frac{1}{2}\,\left({{\symbf{h}^{\text{R}}}}_{i}+{{\symbf{h}^{\text{L}}}}_{i}\right)}{0.8}
+           \resizeExpression{\symbf{h}=\frac{1}{2}\,\left({{\symbf{h}^{\text{R}}}}_{i}+{{\symbf{h}^{\text{L}}}}_{i}\right)}{\inDefScale}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -1710,7 +1712,7 @@ Units & ${\text{Pa}}$
         
 \\ \midrule
 Equation & \begin{displaymath}
-           \resizeExpression{σ=\frac{{F_{\text{n}}}}{A}}{0.8}
+           \resizeExpression{σ=\frac{{F_{\text{n}}}}{A}}{\inDefScale}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -1746,7 +1748,7 @@ Units & ${\text{Pa}}$
         
 \\ \midrule
 Equation & \begin{displaymath}
-           \resizeExpression{τ=\frac{{F_{\text{t}}}}{A}}{0.8}
+           \resizeExpression{τ=\frac{{F_{\text{t}}}}{A}}{\inDefScale}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -1782,7 +1784,7 @@ Units & $\text{N}\text{m}$
         
 \\ \midrule
 Equation & \begin{displaymath}
-           \resizeExpression{\symbf{τ}=\symbf{r}\times\symbf{F}}{0.8}
+           \resizeExpression{\symbf{τ}=\symbf{r}\times\symbf{F}}{\inDefScale}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -1824,7 +1826,7 @@ Equation & \begin{displaymath}
            \resizeExpression{\symbf{f}=\begin{cases}
                                        1, & \mathit{const\_f}\\
                                        \sin\left(π\,\frac{{\symbf{x}_{\text{slip},i}}-{\symbf{x}_{\text{slip},0}}}{{\symbf{x}_{\text{slip},n}}-{\symbf{x}_{\text{slip},0}}}\right), & \neg{}\mathit{const\_f}
-                                       \end{cases}}{0.8}
+                                       \end{cases}}{\inDefScale}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -1863,7 +1865,7 @@ Units & Unitless
         
 \\ \midrule
 Equation & \begin{displaymath}
-           \resizeExpression{\symbf{Φ}=\left(λ\,{\symbf{f}}_{i}\,\cos\left({\symbf{α}}_{i}\right)-\sin\left({\symbf{α}}_{i}\right)\right)\,\tan\left(φ'\right)-\left(λ\,{\symbf{f}}_{i}\,\sin\left({\symbf{α}}_{i}\right)+\cos\left({\symbf{α}}_{i}\right)\right)\,{F_{\text{S}}}}{0.8}
+           \resizeExpression{\symbf{Φ}=\left(λ\,{\symbf{f}}_{i}\,\cos\left({\symbf{α}}_{i}\right)-\sin\left({\symbf{α}}_{i}\right)\right)\,\tan\left(φ'\right)-\left(λ\,{\symbf{f}}_{i}\,\sin\left({\symbf{α}}_{i}\right)+\cos\left({\symbf{α}}_{i}\right)\right)\,{F_{\text{S}}}}{\inDefScale}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -1906,7 +1908,7 @@ Units & Unitless
         
 \\ \midrule
 Equation & \begin{displaymath}
-           \resizeExpression{\symbf{Ψ}=\frac{\left(λ\,{\symbf{f}}_{i}\,\cos\left({\symbf{α}}_{i}\right)-\sin\left({\symbf{α}}_{i}\right)\right)\,\tan\left(φ'\right)-\left(λ\,{\symbf{f}}_{i}\,\sin\left({\symbf{α}}_{i}\right)+\cos\left({\symbf{α}}_{i}\right)\right)\,{F_{\text{S}}}}{{\symbf{Φ}}_{i-1}}}{0.8}
+           \resizeExpression{\symbf{Ψ}=\frac{\left(λ\,{\symbf{f}}_{i}\,\cos\left({\symbf{α}}_{i}\right)-\sin\left({\symbf{α}}_{i}\right)\right)\,\tan\left(φ'\right)-\left(λ\,{\symbf{f}}_{i}\,\sin\left({\symbf{α}}_{i}\right)+\cos\left({\symbf{α}}_{i}\right)\right)\,{F_{\text{S}}}}{{\symbf{Φ}}_{i-1}}}{\inDefScale}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -1950,7 +1952,7 @@ Units & ${\text{N}}$
         
 \\ \midrule
 Equation & \begin{displaymath}
-           \resizeExpression{{{\symbf{F}_{\text{x}}}^{\text{G}}}={\symbf{G}}_{i}+{\symbf{G}}_{i-1}}{0.8}
+           \resizeExpression{{{\symbf{F}_{\text{x}}}^{\text{G}}}={\symbf{G}}_{i}+{\symbf{G}}_{i-1}}{\inDefScale}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -1985,7 +1987,7 @@ Units & ${\text{N}}$
         
 \\ \midrule
 Equation & \begin{displaymath}
-           \resizeExpression{{{\symbf{F}_{\text{x}}}^{\text{H}}}={\symbf{H}}_{i}+{\symbf{H}}_{i-1}}{0.8}
+           \resizeExpression{{{\symbf{F}_{\text{x}}}^{\text{H}}}={\symbf{H}}_{i}+{\symbf{H}}_{i-1}}{\inDefScale}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -2020,7 +2022,7 @@ Units & ${\text{m}}$
         
 \\ \midrule
 Equation & \begin{displaymath}
-           \resizeExpression{{\symbf{h}^{\text{R}}}={\symbf{y}_{\text{slope},i}}-{\symbf{y}_{\text{slip},i}}}{0.8}
+           \resizeExpression{{\symbf{h}^{\text{R}}}={\symbf{y}_{\text{slope},i}}-{\symbf{y}_{\text{slip},i}}}{\inDefScale}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -2057,7 +2059,7 @@ Units & ${\text{m}}$
         
 \\ \midrule
 Equation & \begin{displaymath}
-           \resizeExpression{{\symbf{h}^{\text{L}}}={\symbf{y}_{\text{slope},i-1}}-{\symbf{y}_{\text{slip},i-1}}}{0.8}
+           \resizeExpression{{\symbf{h}^{\text{L}}}={\symbf{y}_{\text{slope},i-1}}-{\symbf{y}_{\text{slip},i-1}}}{\inDefScale}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -2106,7 +2108,7 @@ Input Constraints &
 Output Constraints & 
 \\ \midrule
 Equation & \begin{displaymath}
-           \resizeExpression{{F_{\text{S}}}=\frac{\displaystyle\sum_{i=1}^{n-1}{{\symbf{R}}_{i}\,\displaystyle\prod_{v=i}^{n-1}{{\symbf{Ψ}}_{v}}}+{\symbf{R}}_{n}}{\displaystyle\sum_{i=1}^{n-1}{{\symbf{T}}_{i}\,\displaystyle\prod_{v=i}^{n-1}{{\symbf{Ψ}}_{v}}}+{\symbf{T}}_{n}}}{0.8}
+           \resizeExpression{{F_{\text{S}}}=\frac{\displaystyle\sum_{i=1}^{n-1}{{\symbf{R}}_{i}\,\displaystyle\prod_{v=i}^{n-1}{{\symbf{Ψ}}_{v}}}+{\symbf{R}}_{n}}{\displaystyle\sum_{i=1}^{n-1}{{\symbf{T}}_{i}\,\displaystyle\prod_{v=i}^{n-1}{{\symbf{Ψ}}_{v}}}+{\symbf{T}}_{n}}}{\inDefScale}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -2136,114 +2138,114 @@ RefBy & \hyperref[IM:intsliceFs]{IM:intsliceFs}, \hyperref[IM:fctSfty]{IM:fctSft
 The mobilized shear force defined in \hyperref[GD:bsShrFEq]{GD:bsShrFEq} can be substituted into the definition of mobilized shear force based on the factor of safety, from \hyperref[GD:mobShr]{GD:mobShr} yielding Equation (1) below:
 
 \begin{displaymath}
-\resizeExpression{\left({\symbf{W}}_{i}-{\symbf{X}}_{i-1}+{\symbf{X}}_{i}+{\symbf{U}_{\text{g},i}}\,\cos\left({\symbf{β}}_{i}\right)+{\symbf{Q}}_{i}\,\cos\left({\symbf{ω}}_{i}\right)\right)\,\sin\left({\symbf{α}}_{i}\right)-\left(-{K_{\text{c}}}\,{\symbf{W}}_{i}-{\symbf{G}}_{i}+{\symbf{G}}_{i-1}-{\symbf{H}}_{i}+{\symbf{H}}_{i-1}+{\symbf{U}_{\text{g},i}}\,\sin\left({\symbf{β}}_{i}\right)+{\symbf{Q}}_{i}\,\sin\left({\symbf{ω}}_{i}\right)\right)\,\cos\left({\symbf{α}}_{i}\right)=\frac{{\symbf{N'}}_{i}\,\tan\left(φ'\right)+c'\,{\symbf{L}_{b,i}}}{{F_{\text{S}}}}}{1.0}
+\resizeExpression{\left({\symbf{W}}_{i}-{\symbf{X}}_{i-1}+{\symbf{X}}_{i}+{\symbf{U}_{\text{g},i}}\,\cos\left({\symbf{β}}_{i}\right)+{\symbf{Q}}_{i}\,\cos\left({\symbf{ω}}_{i}\right)\right)\,\sin\left({\symbf{α}}_{i}\right)-\left(-{K_{\text{c}}}\,{\symbf{W}}_{i}-{\symbf{G}}_{i}+{\symbf{G}}_{i-1}-{\symbf{H}}_{i}+{\symbf{H}}_{i-1}+{\symbf{U}_{\text{g},i}}\,\sin\left({\symbf{β}}_{i}\right)+{\symbf{Q}}_{i}\,\sin\left({\symbf{ω}}_{i}\right)\right)\,\cos\left({\symbf{α}}_{i}\right)=\frac{{\symbf{N'}}_{i}\,\tan\left(φ'\right)+c'\,{\symbf{L}_{b,i}}}{{F_{\text{S}}}}}{\outDefScale}
 \end{displaymath}
 An expression for the effective normal forces, $\symbf{N'}$, can be derived by substituting the normal forces equilibrium from \hyperref[GD:normForcEq]{GD:normForcEq} into the definition for effective normal forces from \hyperref[GD:resShearWO]{GD:resShearWO}. This results in Equation (2):
 
 \begin{displaymath}
-\resizeExpression{{\symbf{N'}}_{i}=\left({\symbf{W}}_{i}-{\symbf{X}}_{i-1}+{\symbf{X}}_{i}+{\symbf{U}_{\text{g},i}}\,\cos\left({\symbf{β}}_{i}\right)+{\symbf{Q}}_{i}\,\cos\left({\symbf{ω}}_{i}\right)\right)\,\cos\left({\symbf{α}}_{i}\right)+\left(-{K_{\text{c}}}\,{\symbf{W}}_{i}-{\symbf{G}}_{i}+{\symbf{G}}_{i-1}-{\symbf{H}}_{i}+{\symbf{H}}_{i-1}+{\symbf{U}_{\text{g},i}}\,\sin\left({\symbf{β}}_{i}\right)+{\symbf{Q}}_{i}\,\sin\left({\symbf{ω}}_{i}\right)\right)\,\sin\left({\symbf{α}}_{i}\right)-{\symbf{U}_{\text{b},i}}}{1.0}
+\resizeExpression{{\symbf{N'}}_{i}=\left({\symbf{W}}_{i}-{\symbf{X}}_{i-1}+{\symbf{X}}_{i}+{\symbf{U}_{\text{g},i}}\,\cos\left({\symbf{β}}_{i}\right)+{\symbf{Q}}_{i}\,\cos\left({\symbf{ω}}_{i}\right)\right)\,\cos\left({\symbf{α}}_{i}\right)+\left(-{K_{\text{c}}}\,{\symbf{W}}_{i}-{\symbf{G}}_{i}+{\symbf{G}}_{i-1}-{\symbf{H}}_{i}+{\symbf{H}}_{i-1}+{\symbf{U}_{\text{g},i}}\,\sin\left({\symbf{β}}_{i}\right)+{\symbf{Q}}_{i}\,\sin\left({\symbf{ω}}_{i}\right)\right)\,\sin\left({\symbf{α}}_{i}\right)-{\symbf{U}_{\text{b},i}}}{\outDefScale}
 \end{displaymath}
 Substituting Equation (2) into Equation (1) gives:
 
 \begin{displaymath}
-\resizeExpression{\left({\symbf{W}}_{i}-{\symbf{X}}_{i-1}+{\symbf{X}}_{i}+{\symbf{U}_{\text{g},i}}\,\cos\left({\symbf{β}}_{i}\right)+{\symbf{Q}}_{i}\,\cos\left({\symbf{ω}}_{i}\right)\right)\,\sin\left({\symbf{α}}_{i}\right)-\left(-{K_{\text{c}}}\,{\symbf{W}}_{i}-{\symbf{G}}_{i}+{\symbf{G}}_{i-1}-{\symbf{H}}_{i}+{\symbf{H}}_{i-1}+{\symbf{U}_{\text{g},i}}\,\sin\left({\symbf{β}}_{i}\right)+{\symbf{Q}}_{i}\,\sin\left({\symbf{ω}}_{i}\right)\right)\,\cos\left({\symbf{α}}_{i}\right)=\frac{\left(\left({\symbf{W}}_{i}-{\symbf{X}}_{i-1}+{\symbf{X}}_{i}+{\symbf{U}_{\text{g},i}}\,\cos\left({\symbf{β}}_{i}\right)+{\symbf{Q}}_{i}\,\cos\left({\symbf{ω}}_{i}\right)\right)\,\cos\left({\symbf{α}}_{i}\right)+\left(-{K_{\text{c}}}\,{\symbf{W}}_{i}-{\symbf{G}}_{i}+{\symbf{G}}_{i-1}-{\symbf{H}}_{i}+{\symbf{H}}_{i-1}+{\symbf{U}_{\text{g},i}}\,\sin\left({\symbf{β}}_{i}\right)+{\symbf{Q}}_{i}\,\sin\left({\symbf{ω}}_{i}\right)\right)\,\sin\left({\symbf{α}}_{i}\right)-{\symbf{U}_{\text{b},i}}\right)\,\tan\left(φ'\right)+c'\,{\symbf{L}_{b,i}}}{{F_{\text{S}}}}}{1.0}
+\resizeExpression{\left({\symbf{W}}_{i}-{\symbf{X}}_{i-1}+{\symbf{X}}_{i}+{\symbf{U}_{\text{g},i}}\,\cos\left({\symbf{β}}_{i}\right)+{\symbf{Q}}_{i}\,\cos\left({\symbf{ω}}_{i}\right)\right)\,\sin\left({\symbf{α}}_{i}\right)-\left(-{K_{\text{c}}}\,{\symbf{W}}_{i}-{\symbf{G}}_{i}+{\symbf{G}}_{i-1}-{\symbf{H}}_{i}+{\symbf{H}}_{i-1}+{\symbf{U}_{\text{g},i}}\,\sin\left({\symbf{β}}_{i}\right)+{\symbf{Q}}_{i}\,\sin\left({\symbf{ω}}_{i}\right)\right)\,\cos\left({\symbf{α}}_{i}\right)=\frac{\left(\left({\symbf{W}}_{i}-{\symbf{X}}_{i-1}+{\symbf{X}}_{i}+{\symbf{U}_{\text{g},i}}\,\cos\left({\symbf{β}}_{i}\right)+{\symbf{Q}}_{i}\,\cos\left({\symbf{ω}}_{i}\right)\right)\,\cos\left({\symbf{α}}_{i}\right)+\left(-{K_{\text{c}}}\,{\symbf{W}}_{i}-{\symbf{G}}_{i}+{\symbf{G}}_{i-1}-{\symbf{H}}_{i}+{\symbf{H}}_{i-1}+{\symbf{U}_{\text{g},i}}\,\sin\left({\symbf{β}}_{i}\right)+{\symbf{Q}}_{i}\,\sin\left({\symbf{ω}}_{i}\right)\right)\,\sin\left({\symbf{α}}_{i}\right)-{\symbf{U}_{\text{b},i}}\right)\,\tan\left(φ'\right)+c'\,{\symbf{L}_{b,i}}}{{F_{\text{S}}}}}{\outDefScale}
 \end{displaymath}
 Since the interslice shear forces $\symbf{X}$ and interslice normal forces $\symbf{G}$ are unknown, they are separated from the other terms as follows:
 
 \begin{displaymath}
-\resizeExpression{\left({\symbf{W}}_{i}+{\symbf{U}_{\text{g},i}}\,\cos\left({\symbf{β}}_{i}\right)+{\symbf{Q}}_{i}\,\cos\left({\symbf{ω}}_{i}\right)\right)\,\sin\left({\symbf{α}}_{i}\right)-\left(-{K_{\text{c}}}\,{\symbf{W}}_{i}-{\symbf{H}}_{i}+{\symbf{H}}_{i-1}+{\symbf{U}_{\text{g},i}}\,\sin\left({\symbf{β}}_{i}\right)+{\symbf{Q}}_{i}\,\sin\left({\symbf{ω}}_{i}\right)\right)\,\cos\left({\symbf{α}}_{i}\right)-\left(-{\symbf{G}}_{i}+{\symbf{G}}_{i-1}\right)\,\cos\left({\symbf{α}}_{i}\right)+\left(-{\symbf{X}}_{i-1}+{\symbf{X}}_{i}\right)\,\sin\left({\symbf{α}}_{i}\right)=\frac{\left(\left({\symbf{W}}_{i}+{\symbf{U}_{\text{g},i}}\,\cos\left({\symbf{β}}_{i}\right)+{\symbf{Q}}_{i}\,\cos\left({\symbf{ω}}_{i}\right)\right)\,\cos\left({\symbf{α}}_{i}\right)+\left(-{K_{\text{c}}}\,{\symbf{W}}_{i}-{\symbf{H}}_{i}+{\symbf{H}}_{i-1}+{\symbf{U}_{\text{g},i}}\,\sin\left({\symbf{β}}_{i}\right)+{\symbf{Q}}_{i}\,\sin\left({\symbf{ω}}_{i}\right)\right)\,\sin\left({\symbf{α}}_{i}\right)+\left(-{\symbf{G}}_{i}+{\symbf{G}}_{i-1}\right)\,\sin\left({\symbf{α}}_{i}\right)+\left(-{\symbf{X}}_{i-1}+{\symbf{X}}_{i}\right)\,\cos\left({\symbf{α}}_{i}\right)-{\symbf{U}_{\text{b},i}}\right)\,\tan\left(φ'\right)+c'\,{\symbf{L}_{b,i}}}{{F_{\text{S}}}}}{1.0}
+\resizeExpression{\left({\symbf{W}}_{i}+{\symbf{U}_{\text{g},i}}\,\cos\left({\symbf{β}}_{i}\right)+{\symbf{Q}}_{i}\,\cos\left({\symbf{ω}}_{i}\right)\right)\,\sin\left({\symbf{α}}_{i}\right)-\left(-{K_{\text{c}}}\,{\symbf{W}}_{i}-{\symbf{H}}_{i}+{\symbf{H}}_{i-1}+{\symbf{U}_{\text{g},i}}\,\sin\left({\symbf{β}}_{i}\right)+{\symbf{Q}}_{i}\,\sin\left({\symbf{ω}}_{i}\right)\right)\,\cos\left({\symbf{α}}_{i}\right)-\left(-{\symbf{G}}_{i}+{\symbf{G}}_{i-1}\right)\,\cos\left({\symbf{α}}_{i}\right)+\left(-{\symbf{X}}_{i-1}+{\symbf{X}}_{i}\right)\,\sin\left({\symbf{α}}_{i}\right)=\frac{\left(\left({\symbf{W}}_{i}+{\symbf{U}_{\text{g},i}}\,\cos\left({\symbf{β}}_{i}\right)+{\symbf{Q}}_{i}\,\cos\left({\symbf{ω}}_{i}\right)\right)\,\cos\left({\symbf{α}}_{i}\right)+\left(-{K_{\text{c}}}\,{\symbf{W}}_{i}-{\symbf{H}}_{i}+{\symbf{H}}_{i-1}+{\symbf{U}_{\text{g},i}}\,\sin\left({\symbf{β}}_{i}\right)+{\symbf{Q}}_{i}\,\sin\left({\symbf{ω}}_{i}\right)\right)\,\sin\left({\symbf{α}}_{i}\right)+\left(-{\symbf{G}}_{i}+{\symbf{G}}_{i-1}\right)\,\sin\left({\symbf{α}}_{i}\right)+\left(-{\symbf{X}}_{i-1}+{\symbf{X}}_{i}\right)\,\cos\left({\symbf{α}}_{i}\right)-{\symbf{U}_{\text{b},i}}\right)\,\tan\left(φ'\right)+c'\,{\symbf{L}_{b,i}}}{{F_{\text{S}}}}}{\outDefScale}
 \end{displaymath}
 Applying assumptions \hyperref[assumpSF]{A:Seismic-Force} and \hyperref[assumpSL]{A:Surface-Load}, which state that the seismic coefficient and the external forces, respectively, are zero, allows for further simplification as shown below:
 
 \begin{displaymath}
-\resizeExpression{\left({\symbf{W}}_{i}+{\symbf{U}_{\text{g},i}}\,\cos\left({\symbf{β}}_{i}\right)\right)\,\sin\left({\symbf{α}}_{i}\right)-\left(-{\symbf{H}}_{i}+{\symbf{H}}_{i-1}+{\symbf{U}_{\text{g},i}}\,\sin\left({\symbf{β}}_{i}\right)\right)\,\cos\left({\symbf{α}}_{i}\right)-\left(-{\symbf{G}}_{i}+{\symbf{G}}_{i-1}\right)\,\cos\left({\symbf{α}}_{i}\right)+\left(-{\symbf{X}}_{i-1}+{\symbf{X}}_{i}\right)\,\sin\left({\symbf{α}}_{i}\right)=\frac{\left(\left({\symbf{W}}_{i}+{\symbf{U}_{\text{g},i}}\,\cos\left({\symbf{β}}_{i}\right)\right)\,\cos\left({\symbf{α}}_{i}\right)+\left(-{\symbf{H}}_{i}+{\symbf{H}}_{i-1}+{\symbf{U}_{\text{g},i}}\,\sin\left({\symbf{β}}_{i}\right)\right)\,\sin\left({\symbf{α}}_{i}\right)+\left(-{\symbf{G}}_{i}+{\symbf{G}}_{i-1}\right)\,\sin\left({\symbf{α}}_{i}\right)+\left(-{\symbf{X}}_{i-1}+{\symbf{X}}_{i}\right)\,\cos\left({\symbf{α}}_{i}\right)-{\symbf{U}_{\text{b},i}}\right)\,\tan\left(φ'\right)+c'\,{\symbf{L}_{b,i}}}{{F_{\text{S}}}}}{1.0}
+\resizeExpression{\left({\symbf{W}}_{i}+{\symbf{U}_{\text{g},i}}\,\cos\left({\symbf{β}}_{i}\right)\right)\,\sin\left({\symbf{α}}_{i}\right)-\left(-{\symbf{H}}_{i}+{\symbf{H}}_{i-1}+{\symbf{U}_{\text{g},i}}\,\sin\left({\symbf{β}}_{i}\right)\right)\,\cos\left({\symbf{α}}_{i}\right)-\left(-{\symbf{G}}_{i}+{\symbf{G}}_{i-1}\right)\,\cos\left({\symbf{α}}_{i}\right)+\left(-{\symbf{X}}_{i-1}+{\symbf{X}}_{i}\right)\,\sin\left({\symbf{α}}_{i}\right)=\frac{\left(\left({\symbf{W}}_{i}+{\symbf{U}_{\text{g},i}}\,\cos\left({\symbf{β}}_{i}\right)\right)\,\cos\left({\symbf{α}}_{i}\right)+\left(-{\symbf{H}}_{i}+{\symbf{H}}_{i-1}+{\symbf{U}_{\text{g},i}}\,\sin\left({\symbf{β}}_{i}\right)\right)\,\sin\left({\symbf{α}}_{i}\right)+\left(-{\symbf{G}}_{i}+{\symbf{G}}_{i-1}\right)\,\sin\left({\symbf{α}}_{i}\right)+\left(-{\symbf{X}}_{i-1}+{\symbf{X}}_{i}\right)\,\cos\left({\symbf{α}}_{i}\right)-{\symbf{U}_{\text{b},i}}\right)\,\tan\left(φ'\right)+c'\,{\symbf{L}_{b,i}}}{{F_{\text{S}}}}}{\outDefScale}
 \end{displaymath}
 The definitions of \hyperref[GD:resShearWO]{GD:resShearWO} and \hyperref[GD:mobShearWO]{GD:mobShearWO} are present in this equation, and thus can be replaced by ${\symbf{R}}_{i}$ and ${\symbf{T}}_{i}$, respectively:
 
 \begin{displaymath}
-\resizeExpression{{\symbf{T}}_{i}+\left(-{\symbf{X}}_{i-1}+{\symbf{X}}_{i}\right)\,\sin\left({\symbf{α}}_{i}\right)-\left(-{\symbf{G}}_{i}+{\symbf{G}}_{i-1}\right)\,\cos\left({\symbf{α}}_{i}\right)=\frac{{\symbf{R}}_{i}+\left(\left(-{\symbf{X}}_{i-1}+{\symbf{X}}_{i}\right)\,\cos\left({\symbf{α}}_{i}\right)+\left(-{\symbf{G}}_{i}+{\symbf{G}}_{i-1}\right)\,\sin\left({\symbf{α}}_{i}\right)\right)\,\tan\left(φ'\right)}{{F_{\text{S}}}}}{1.0}
+\resizeExpression{{\symbf{T}}_{i}+\left(-{\symbf{X}}_{i-1}+{\symbf{X}}_{i}\right)\,\sin\left({\symbf{α}}_{i}\right)-\left(-{\symbf{G}}_{i}+{\symbf{G}}_{i-1}\right)\,\cos\left({\symbf{α}}_{i}\right)=\frac{{\symbf{R}}_{i}+\left(\left(-{\symbf{X}}_{i-1}+{\symbf{X}}_{i}\right)\,\cos\left({\symbf{α}}_{i}\right)+\left(-{\symbf{G}}_{i}+{\symbf{G}}_{i-1}\right)\,\sin\left({\symbf{α}}_{i}\right)\right)\,\tan\left(φ'\right)}{{F_{\text{S}}}}}{\outDefScale}
 \end{displaymath}
 The interslice shear forces $\symbf{X}$ can be expressed in terms of the interslice normal forces $\symbf{G}$ using \hyperref[assumpINSFL]{A:Interslice-Norm-Shear-Forces-Linear} and \hyperref[GD:normShrR]{GD:normShrR}, resulting in:
 
 \begin{displaymath}
-\resizeExpression{{\symbf{T}}_{i}+\left(-λ\,{\symbf{f}}_{i-1}\,{\symbf{G}}_{i-1}+λ\,{\symbf{f}}_{i}\,{\symbf{G}}_{i}\right)\,\sin\left({\symbf{α}}_{i}\right)-\left(-{\symbf{G}}_{i}+{\symbf{G}}_{i-1}\right)\,\cos\left({\symbf{α}}_{i}\right)=\frac{{\symbf{R}}_{i}+\left(\left(-λ\,{\symbf{f}}_{i-1}\,{\symbf{G}}_{i-1}+λ\,{\symbf{f}}_{i}\,{\symbf{G}}_{i}\right)\,\cos\left({\symbf{α}}_{i}\right)+\left(-{\symbf{G}}_{i}+{\symbf{G}}_{i-1}\right)\,\sin\left({\symbf{α}}_{i}\right)\right)\,\tan\left(φ'\right)}{{F_{\text{S}}}}}{1.0}
+\resizeExpression{{\symbf{T}}_{i}+\left(-λ\,{\symbf{f}}_{i-1}\,{\symbf{G}}_{i-1}+λ\,{\symbf{f}}_{i}\,{\symbf{G}}_{i}\right)\,\sin\left({\symbf{α}}_{i}\right)-\left(-{\symbf{G}}_{i}+{\symbf{G}}_{i-1}\right)\,\cos\left({\symbf{α}}_{i}\right)=\frac{{\symbf{R}}_{i}+\left(\left(-λ\,{\symbf{f}}_{i-1}\,{\symbf{G}}_{i-1}+λ\,{\symbf{f}}_{i}\,{\symbf{G}}_{i}\right)\,\cos\left({\symbf{α}}_{i}\right)+\left(-{\symbf{G}}_{i}+{\symbf{G}}_{i-1}\right)\,\sin\left({\symbf{α}}_{i}\right)\right)\,\tan\left(φ'\right)}{{F_{\text{S}}}}}{\outDefScale}
 \end{displaymath}
 Rearranging yields the following:
 
 \begin{displaymath}
-\resizeExpression{{\symbf{G}}_{i}\,\left(\left(λ\,{\symbf{f}}_{i}\,\cos\left({\symbf{α}}_{i}\right)-\sin\left({\symbf{α}}_{i}\right)\right)\,\tan\left(φ'\right)-\left(λ\,{\symbf{f}}_{i}\,\sin\left({\symbf{α}}_{i}\right)+\cos\left({\symbf{α}}_{i}\right)\right)\,{F_{\text{S}}}\right)={\symbf{G}}_{i-1}\,\left(\left(λ\,{\symbf{f}}_{i-1}\,\cos\left({\symbf{α}}_{i}\right)-\sin\left({\symbf{α}}_{i}\right)\right)\,\tan\left(φ'\right)-\left(λ\,{\symbf{f}}_{i-1}\,\sin\left({\symbf{α}}_{i}\right)+\cos\left({\symbf{α}}_{i}\right)\right)\,{F_{\text{S}}}\right)+{F_{\text{S}}}\,{\symbf{T}}_{i}-{\symbf{R}}_{i}}{1.0}
+\resizeExpression{{\symbf{G}}_{i}\,\left(\left(λ\,{\symbf{f}}_{i}\,\cos\left({\symbf{α}}_{i}\right)-\sin\left({\symbf{α}}_{i}\right)\right)\,\tan\left(φ'\right)-\left(λ\,{\symbf{f}}_{i}\,\sin\left({\symbf{α}}_{i}\right)+\cos\left({\symbf{α}}_{i}\right)\right)\,{F_{\text{S}}}\right)={\symbf{G}}_{i-1}\,\left(\left(λ\,{\symbf{f}}_{i-1}\,\cos\left({\symbf{α}}_{i}\right)-\sin\left({\symbf{α}}_{i}\right)\right)\,\tan\left(φ'\right)-\left(λ\,{\symbf{f}}_{i-1}\,\sin\left({\symbf{α}}_{i}\right)+\cos\left({\symbf{α}}_{i}\right)\right)\,{F_{\text{S}}}\right)+{F_{\text{S}}}\,{\symbf{T}}_{i}-{\symbf{R}}_{i}}{\outDefScale}
 \end{displaymath}
 The definitions for $\symbf{Φ}$ and $\symbf{Ψ}$ from \hyperref[DD:convertFunc1]{DD:convertFunc1} and \hyperref[DD:convertFunc2]{DD:convertFunc2} simplify the above to Equation (3):
 
 \begin{displaymath}
-\resizeExpression{{\symbf{G}}_{i}\,{\symbf{Φ}}_{i}={\symbf{Ψ}}_{i-1}\,{\symbf{G}}_{i-1}\,{\symbf{Φ}}_{i-1}+{F_{\text{S}}}\,{\symbf{T}}_{i}-{\symbf{R}}_{i}}{1.0}
+\resizeExpression{{\symbf{G}}_{i}\,{\symbf{Φ}}_{i}={\symbf{Ψ}}_{i-1}\,{\symbf{G}}_{i-1}\,{\symbf{Φ}}_{i-1}+{F_{\text{S}}}\,{\symbf{T}}_{i}-{\symbf{R}}_{i}}{\outDefScale}
 \end{displaymath}
 Versions of Equation (3) instantiated for slices 1 to $n$ are shown below:
 
 \begin{displaymath}
-\resizeExpression{{\symbf{G}}_{1}\,{\symbf{Φ}}_{1}={\symbf{Ψ}}_{0}\,{\symbf{G}}_{0}\,{\symbf{Φ}}_{0}+{F_{\text{S}}}\,{\symbf{T}}_{1}-{\symbf{R}}_{1}}{1.0}
+\resizeExpression{{\symbf{G}}_{1}\,{\symbf{Φ}}_{1}={\symbf{Ψ}}_{0}\,{\symbf{G}}_{0}\,{\symbf{Φ}}_{0}+{F_{\text{S}}}\,{\symbf{T}}_{1}-{\symbf{R}}_{1}}{\outDefScale}
 \end{displaymath}
 \begin{displaymath}
-\resizeExpression{{\symbf{G}}_{2}\,{\symbf{Φ}}_{2}={\symbf{Ψ}}_{1}\,{\symbf{G}}_{1}\,{\symbf{Φ}}_{1}+{F_{\text{S}}}\,{\symbf{T}}_{2}-{\symbf{R}}_{2}}{1.0}
+\resizeExpression{{\symbf{G}}_{2}\,{\symbf{Φ}}_{2}={\symbf{Ψ}}_{1}\,{\symbf{G}}_{1}\,{\symbf{Φ}}_{1}+{F_{\text{S}}}\,{\symbf{T}}_{2}-{\symbf{R}}_{2}}{\outDefScale}
 \end{displaymath}
 \begin{displaymath}
-\resizeExpression{{\symbf{G}}_{3}\,{\symbf{Φ}}_{3}={\symbf{Ψ}}_{2}\,{\symbf{G}}_{2}\,{\symbf{Φ}}_{2}+{F_{\text{S}}}\,{\symbf{T}}_{3}-{\symbf{R}}_{3}}{1.0}
+\resizeExpression{{\symbf{G}}_{3}\,{\symbf{Φ}}_{3}={\symbf{Ψ}}_{2}\,{\symbf{G}}_{2}\,{\symbf{Φ}}_{2}+{F_{\text{S}}}\,{\symbf{T}}_{3}-{\symbf{R}}_{3}}{\outDefScale}
 \end{displaymath}
 ...
 
 \begin{displaymath}
-\resizeExpression{{\symbf{G}}_{n-2}\,{\symbf{Φ}}_{n-2}={\symbf{Ψ}}_{n-3}\,{\symbf{G}}_{n-3}\,{\symbf{Φ}}_{n-3}+{F_{\text{S}}}\,{\symbf{T}}_{n-2}-{\symbf{R}}_{n-2}}{1.0}
+\resizeExpression{{\symbf{G}}_{n-2}\,{\symbf{Φ}}_{n-2}={\symbf{Ψ}}_{n-3}\,{\symbf{G}}_{n-3}\,{\symbf{Φ}}_{n-3}+{F_{\text{S}}}\,{\symbf{T}}_{n-2}-{\symbf{R}}_{n-2}}{\outDefScale}
 \end{displaymath}
 \begin{displaymath}
-\resizeExpression{{\symbf{G}}_{n-1}\,{\symbf{Φ}}_{n-1}={\symbf{Ψ}}_{n-2}\,{\symbf{G}}_{n-2}\,{\symbf{Φ}}_{n-2}+{F_{\text{S}}}\,{\symbf{T}}_{n-1}-{\symbf{R}}_{n-1}}{1.0}
+\resizeExpression{{\symbf{G}}_{n-1}\,{\symbf{Φ}}_{n-1}={\symbf{Ψ}}_{n-2}\,{\symbf{G}}_{n-2}\,{\symbf{Φ}}_{n-2}+{F_{\text{S}}}\,{\symbf{T}}_{n-1}-{\symbf{R}}_{n-1}}{\outDefScale}
 \end{displaymath}
 \begin{displaymath}
-\resizeExpression{{\symbf{G}}_{n}\,{\symbf{Φ}}_{n}={\symbf{Ψ}}_{n-1}\,{\symbf{G}}_{n-1}\,{\symbf{Φ}}_{n-1}+{F_{\text{S}}}\,{\symbf{T}}_{n}-{\symbf{R}}_{n}}{1.0}
+\resizeExpression{{\symbf{G}}_{n}\,{\symbf{Φ}}_{n}={\symbf{Ψ}}_{n-1}\,{\symbf{G}}_{n-1}\,{\symbf{Φ}}_{n-1}+{F_{\text{S}}}\,{\symbf{T}}_{n}-{\symbf{R}}_{n}}{\outDefScale}
 \end{displaymath}
 Applying \hyperref[assumpES]{A:Edge-Slices}, which says that ${\symbf{G}}_{0}$ and ${\symbf{G}}_{n}$ are zero, results in the following special cases: Equation (8) for the first slice:
 
 \begin{displaymath}
-\resizeExpression{{\symbf{G}}_{1}\,{\symbf{Φ}}_{1}={F_{\text{S}}}\,{\symbf{T}}_{1}-{\symbf{R}}_{1}}{1.0}
+\resizeExpression{{\symbf{G}}_{1}\,{\symbf{Φ}}_{1}={F_{\text{S}}}\,{\symbf{T}}_{1}-{\symbf{R}}_{1}}{\outDefScale}
 \end{displaymath}
 and Equation (9) for the $n$th slice:
 
 \begin{displaymath}
-\resizeExpression{-\left(\frac{{F_{\text{S}}}\,{\symbf{T}}_{n}-{\symbf{R}}_{n}}{{\symbf{Ψ}}_{n-1}}\right)={\symbf{G}}_{n-1}\,{\symbf{Φ}}_{n-1}}{1.0}
+\resizeExpression{-\left(\frac{{F_{\text{S}}}\,{\symbf{T}}_{n}-{\symbf{R}}_{n}}{{\symbf{Ψ}}_{n-1}}\right)={\symbf{G}}_{n-1}\,{\symbf{Φ}}_{n-1}}{\outDefScale}
 \end{displaymath}
 Substituting Equation (8) into Equation (4) yields Equation (10):
 
 \begin{displaymath}
-\resizeExpression{{\symbf{G}}_{2}\,{\symbf{Φ}}_{2}={\symbf{Ψ}}_{1}\,\left({F_{\text{S}}}\,{\symbf{T}}_{1}-{\symbf{R}}_{1}\right)+{F_{\text{S}}}\,{\symbf{T}}_{2}-{\symbf{R}}_{2}}{1.0}
+\resizeExpression{{\symbf{G}}_{2}\,{\symbf{Φ}}_{2}={\symbf{Ψ}}_{1}\,\left({F_{\text{S}}}\,{\symbf{T}}_{1}-{\symbf{R}}_{1}\right)+{F_{\text{S}}}\,{\symbf{T}}_{2}-{\symbf{R}}_{2}}{\outDefScale}
 \end{displaymath}
 which can be substituted into Equation (5) to get Equation (11):
 
 \begin{displaymath}
-\resizeExpression{{\symbf{G}}_{3}\,{\symbf{Φ}}_{3}={\symbf{Ψ}}_{2}\,\left({\symbf{Ψ}}_{1}\,\left({F_{\text{S}}}\,{\symbf{T}}_{1}-{\symbf{R}}_{1}\right)+{F_{\text{S}}}\,{\symbf{T}}_{2}-{\symbf{R}}_{2}\right)+{F_{\text{S}}}\,{\symbf{T}}_{3}-{\symbf{R}}_{3}}{1.0}
+\resizeExpression{{\symbf{G}}_{3}\,{\symbf{Φ}}_{3}={\symbf{Ψ}}_{2}\,\left({\symbf{Ψ}}_{1}\,\left({F_{\text{S}}}\,{\symbf{T}}_{1}-{\symbf{R}}_{1}\right)+{F_{\text{S}}}\,{\symbf{T}}_{2}-{\symbf{R}}_{2}\right)+{F_{\text{S}}}\,{\symbf{T}}_{3}-{\symbf{R}}_{3}}{\outDefScale}
 \end{displaymath}
 and so on until Equation (12) is obtained from Equation (7):
 
 \begin{displaymath}
-\resizeExpression{{\symbf{G}}_{n-1}\,{\symbf{Φ}}_{n-1}={\symbf{Ψ}}_{n-2}\,\left({\symbf{Ψ}}_{n-3}\,\left({\symbf{Ψ}}_{1}\,\left({F_{\text{S}}}\,{\symbf{T}}_{1}-{\symbf{R}}_{1}\right)+{F_{\text{S}}}\,{\symbf{T}}_{2}-{\symbf{R}}_{2}\right)+{F_{\text{S}}}\,{\symbf{T}}_{n-2}-{\symbf{R}}_{n-2}\right)+{F_{\text{S}}}\,{\symbf{T}}_{n-1}-{\symbf{R}}_{n-1}}{1.0}
+\resizeExpression{{\symbf{G}}_{n-1}\,{\symbf{Φ}}_{n-1}={\symbf{Ψ}}_{n-2}\,\left({\symbf{Ψ}}_{n-3}\,\left({\symbf{Ψ}}_{1}\,\left({F_{\text{S}}}\,{\symbf{T}}_{1}-{\symbf{R}}_{1}\right)+{F_{\text{S}}}\,{\symbf{T}}_{2}-{\symbf{R}}_{2}\right)+{F_{\text{S}}}\,{\symbf{T}}_{n-2}-{\symbf{R}}_{n-2}\right)+{F_{\text{S}}}\,{\symbf{T}}_{n-1}-{\symbf{R}}_{n-1}}{\outDefScale}
 \end{displaymath}
 Equation (9) can then be substituted into the left-hand side of Equation (12), resulting in:
 
 \begin{displaymath}
-\resizeExpression{-\left(\frac{{F_{\text{S}}}\,{\symbf{T}}_{n}-{\symbf{R}}_{n}}{{\symbf{Ψ}}_{n-1}}\right)={\symbf{Ψ}}_{n-2}\,\left({\symbf{Ψ}}_{n-3}\,\left({\symbf{Ψ}}_{1}\,\left({F_{\text{S}}}\,{\symbf{T}}_{1}-{\symbf{R}}_{1}\right)+{F_{\text{S}}}\,{\symbf{T}}_{2}-{\symbf{R}}_{2}\right)+{F_{\text{S}}}\,{\symbf{T}}_{n-2}-{\symbf{R}}_{n-2}\right)+{F_{\text{S}}}\,{\symbf{T}}_{n-1}-{\symbf{R}}_{n-1}}{1.0}
+\resizeExpression{-\left(\frac{{F_{\text{S}}}\,{\symbf{T}}_{n}-{\symbf{R}}_{n}}{{\symbf{Ψ}}_{n-1}}\right)={\symbf{Ψ}}_{n-2}\,\left({\symbf{Ψ}}_{n-3}\,\left({\symbf{Ψ}}_{1}\,\left({F_{\text{S}}}\,{\symbf{T}}_{1}-{\symbf{R}}_{1}\right)+{F_{\text{S}}}\,{\symbf{T}}_{2}-{\symbf{R}}_{2}\right)+{F_{\text{S}}}\,{\symbf{T}}_{n-2}-{\symbf{R}}_{n-2}\right)+{F_{\text{S}}}\,{\symbf{T}}_{n-1}-{\symbf{R}}_{n-1}}{\outDefScale}
 \end{displaymath}
 This can be rearranged by multiplying both sides by ${\symbf{Ψ}}_{n-1}$ and then distributing the multiplication of each $\symbf{Ψ}$ over addition to obtain:
 
 \begin{displaymath}
-\resizeExpression{-\left({F_{\text{S}}}\,{\symbf{T}}_{n}-{\symbf{R}}_{n}\right)={\symbf{Ψ}}_{n-1}\,{\symbf{Ψ}}_{n-2}\,{\symbf{Ψ}}_{1}\,\left({F_{\text{S}}}\,{\symbf{T}}_{1}-{\symbf{R}}_{1}\right)+{\symbf{Ψ}}_{n-1}\,{\symbf{Ψ}}_{n-2}\,{\symbf{Ψ}}_{2}\,\left({F_{\text{S}}}\,{\symbf{T}}_{2}-{\symbf{R}}_{2}\right)+{\symbf{Ψ}}_{n-1}\,\left({F_{\text{S}}}\,{\symbf{T}}_{n-1}-{\symbf{R}}_{n-1}\right)}{1.0}
+\resizeExpression{-\left({F_{\text{S}}}\,{\symbf{T}}_{n}-{\symbf{R}}_{n}\right)={\symbf{Ψ}}_{n-1}\,{\symbf{Ψ}}_{n-2}\,{\symbf{Ψ}}_{1}\,\left({F_{\text{S}}}\,{\symbf{T}}_{1}-{\symbf{R}}_{1}\right)+{\symbf{Ψ}}_{n-1}\,{\symbf{Ψ}}_{n-2}\,{\symbf{Ψ}}_{2}\,\left({F_{\text{S}}}\,{\symbf{T}}_{2}-{\symbf{R}}_{2}\right)+{\symbf{Ψ}}_{n-1}\,\left({F_{\text{S}}}\,{\symbf{T}}_{n-1}-{\symbf{R}}_{n-1}\right)}{\outDefScale}
 \end{displaymath}
 The multiplication of the $\symbf{Ψ}$ terms can be further distributed over the subtractions, resulting in the equation having terms that each either contain an $\symbf{R}$ or a $\symbf{T}$. The equation can then be rearranged so terms containing an $\symbf{R}$ are on one side of the equality, and terms containing a $\symbf{T}$ are on the other. The multiplication by the factor of safety is common to all of the $\symbf{T}$ terms, and thus can be factored out, resulting in:
 
 \begin{displaymath}
-\resizeExpression{{F_{\text{S}}}\,\left({\symbf{Ψ}}_{n-1}\,{\symbf{Ψ}}_{n-2}\,{\symbf{Ψ}}_{1}\,{\symbf{T}}_{1}+{\symbf{Ψ}}_{n-1}\,{\symbf{Ψ}}_{n-2}\,{\symbf{Ψ}}_{2}\,{\symbf{T}}_{2}+{\symbf{Ψ}}_{n-1}\,{\symbf{T}}_{n-1}+{\symbf{T}}_{n}\right)={\symbf{Ψ}}_{n-1}\,{\symbf{Ψ}}_{n-2}\,{\symbf{Ψ}}_{1}\,{\symbf{R}}_{1}+{\symbf{Ψ}}_{n-1}\,{\symbf{Ψ}}_{n-2}\,{\symbf{Ψ}}_{2}\,{\symbf{R}}_{2}+{\symbf{Ψ}}_{n-1}\,{\symbf{R}}_{n-1}+{\symbf{R}}_{n}}{1.0}
+\resizeExpression{{F_{\text{S}}}\,\left({\symbf{Ψ}}_{n-1}\,{\symbf{Ψ}}_{n-2}\,{\symbf{Ψ}}_{1}\,{\symbf{T}}_{1}+{\symbf{Ψ}}_{n-1}\,{\symbf{Ψ}}_{n-2}\,{\symbf{Ψ}}_{2}\,{\symbf{T}}_{2}+{\symbf{Ψ}}_{n-1}\,{\symbf{T}}_{n-1}+{\symbf{T}}_{n}\right)={\symbf{Ψ}}_{n-1}\,{\symbf{Ψ}}_{n-2}\,{\symbf{Ψ}}_{1}\,{\symbf{R}}_{1}+{\symbf{Ψ}}_{n-1}\,{\symbf{Ψ}}_{n-2}\,{\symbf{Ψ}}_{2}\,{\symbf{R}}_{2}+{\symbf{Ψ}}_{n-1}\,{\symbf{R}}_{n-1}+{\symbf{R}}_{n}}{\outDefScale}
 \end{displaymath}
 Isolating the factor of safety on the left-hand side and using compact notation for the products and sums yields Equation (13), which can also be seen in \hyperref[IM:fctSfty]{IM:fctSfty}:
 
 \begin{displaymath}
-\resizeExpression{{F_{\text{S}}}=\frac{\displaystyle\sum_{i=1}^{n-1}{{\symbf{R}}_{i}\,\displaystyle\prod_{v=i}^{n-1}{{\symbf{Ψ}}_{v}}}+{\symbf{R}}_{n}}{\displaystyle\sum_{i=1}^{n-1}{{\symbf{T}}_{i}\,\displaystyle\prod_{v=i}^{n-1}{{\symbf{Ψ}}_{v}}}+{\symbf{T}}_{n}}}{1.0}
+\resizeExpression{{F_{\text{S}}}=\frac{\displaystyle\sum_{i=1}^{n-1}{{\symbf{R}}_{i}\,\displaystyle\prod_{v=i}^{n-1}{{\symbf{Ψ}}_{v}}}+{\symbf{R}}_{n}}{\displaystyle\sum_{i=1}^{n-1}{{\symbf{T}}_{i}\,\displaystyle\prod_{v=i}^{n-1}{{\symbf{Ψ}}_{v}}}+{\symbf{T}}_{n}}}{\outDefScale}
 \end{displaymath}
 ${F_{\text{S}}}$ depends on the unknowns $λ$ (\hyperref[IM:nrmShrFor]{IM:nrmShrFor}) and $\symbf{G}$ (\hyperref[IM:intsliceFs]{IM:intsliceFs}).
 
@@ -2269,7 +2271,7 @@ Input Constraints &
 Output Constraints & 
 \\ \midrule
 Equation & \begin{displaymath}
-           \resizeExpression{λ=\frac{\displaystyle\sum_{i=1}^{n}{{\symbf{C}_{\text{num},i}}}}{\displaystyle\sum_{i=1}^{n}{{\symbf{C}_{\text{den},i}}}}}{0.8}
+           \resizeExpression{λ=\frac{\displaystyle\sum_{i=1}^{n}{{\symbf{C}_{\text{num},i}}}}{\displaystyle\sum_{i=1}^{n}{{\symbf{C}_{\text{den},i}}}}}{\inDefScale}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -2296,22 +2298,22 @@ RefBy & \hyperref[IM:nrmShrForNum]{IM:nrmShrForNum}, \hyperref[IM:nrmShrForDen]{
 From the moment equilibrium of \hyperref[GD:momentEql]{GD:momentEql} with the primary assumption for the Morgenstern-Price method of \hyperref[assumpINSFL]{A:Interslice-Norm-Shear-Forces-Linear} and associated definition \hyperref[GD:normShrR]{GD:normShrR}, Equation (14) can be derived:
 
 \begin{displaymath}
-\resizeExpression{0=-{\symbf{G}}_{i}\,\left({\symbf{h}_{\text{z},i}}+\frac{{\symbf{b}}_{i}}{2}\,\tan\left({\symbf{α}}_{i}\right)\right)+{\symbf{G}}_{i-1}\,\left({\symbf{h}_{\text{z},i-1}}-\frac{{\symbf{b}}_{i}}{2}\,\tan\left({\symbf{α}}_{i}\right)\right)-{\symbf{H}}_{i}\,\left(\frac{1}{3}\,{\symbf{h}_{\text{z,w},i}}+\frac{{\symbf{b}}_{i}}{2}\,\tan\left({\symbf{α}}_{i}\right)\right)+{\symbf{H}}_{i-1}\,\left(\frac{1}{3}\,{\symbf{h}_{\text{z,w},i-1}}-\frac{{\symbf{b}}_{i}}{2}\,\tan\left({\symbf{α}}_{i}\right)\right)+λ\,\frac{{\symbf{b}}_{i}}{2}\,\left({\symbf{G}}_{i}\,{\symbf{f}}_{i}+{\symbf{G}}_{i-1}\,{\symbf{f}}_{i-1}\right)+\frac{-{K_{\text{c}}}\,{\symbf{W}}_{i}\,{\symbf{h}}_{i}}{2}+{\symbf{U}_{\text{g},i}}\,\sin\left({\symbf{β}}_{i}\right)\,{\symbf{h}}_{i}+{\symbf{Q}}_{i}\,\sin\left({\symbf{ω}}_{i}\right)\,{\symbf{h}}_{i}}{1.0}
+\resizeExpression{0=-{\symbf{G}}_{i}\,\left({\symbf{h}_{\text{z},i}}+\frac{{\symbf{b}}_{i}}{2}\,\tan\left({\symbf{α}}_{i}\right)\right)+{\symbf{G}}_{i-1}\,\left({\symbf{h}_{\text{z},i-1}}-\frac{{\symbf{b}}_{i}}{2}\,\tan\left({\symbf{α}}_{i}\right)\right)-{\symbf{H}}_{i}\,\left(\frac{1}{3}\,{\symbf{h}_{\text{z,w},i}}+\frac{{\symbf{b}}_{i}}{2}\,\tan\left({\symbf{α}}_{i}\right)\right)+{\symbf{H}}_{i-1}\,\left(\frac{1}{3}\,{\symbf{h}_{\text{z,w},i-1}}-\frac{{\symbf{b}}_{i}}{2}\,\tan\left({\symbf{α}}_{i}\right)\right)+λ\,\frac{{\symbf{b}}_{i}}{2}\,\left({\symbf{G}}_{i}\,{\symbf{f}}_{i}+{\symbf{G}}_{i-1}\,{\symbf{f}}_{i-1}\right)+\frac{-{K_{\text{c}}}\,{\symbf{W}}_{i}\,{\symbf{h}}_{i}}{2}+{\symbf{U}_{\text{g},i}}\,\sin\left({\symbf{β}}_{i}\right)\,{\symbf{h}}_{i}+{\symbf{Q}}_{i}\,\sin\left({\symbf{ω}}_{i}\right)\,{\symbf{h}}_{i}}{\outDefScale}
 \end{displaymath}
 Rearranging the equation in terms of $λ$ leads to Equation (15):
 
 \begin{displaymath}
-\resizeExpression{λ=\frac{-{\symbf{G}}_{i}\,\left({\symbf{h}_{\text{z},i}}+\frac{{\symbf{b}}_{i}}{2}\,\tan\left({\symbf{α}}_{i}\right)\right)+{\symbf{G}}_{i-1}\,\left({\symbf{h}_{\text{z},i-1}}-\frac{{\symbf{b}}_{i}}{2}\,\tan\left({\symbf{α}}_{i}\right)\right)-{\symbf{H}}_{i}\,\left(\frac{1}{3}\,{\symbf{h}_{\text{z,w},i}}+\frac{{\symbf{b}}_{i}}{2}\,\tan\left({\symbf{α}}_{i}\right)\right)+{\symbf{H}}_{i-1}\,\left(\frac{1}{3}\,{\symbf{h}_{\text{z,w},i-1}}-\frac{{\symbf{b}}_{i}}{2}\,\tan\left({\symbf{α}}_{i}\right)\right)+\frac{-{K_{\text{c}}}\,{\symbf{W}}_{i}\,{\symbf{h}}_{i}}{2}+{\symbf{U}_{\text{g},i}}\,\sin\left({\symbf{β}}_{i}\right)\,{\symbf{h}}_{i}+{\symbf{Q}}_{i}\,\sin\left({\symbf{ω}}_{i}\right)\,{\symbf{h}}_{i}}{-\frac{{\symbf{b}}_{i}}{2}\,\left({\symbf{G}}_{i}\,{\symbf{f}}_{i}+{\symbf{G}}_{i-1}\,{\symbf{f}}_{i-1}\right)}}{1.0}
+\resizeExpression{λ=\frac{-{\symbf{G}}_{i}\,\left({\symbf{h}_{\text{z},i}}+\frac{{\symbf{b}}_{i}}{2}\,\tan\left({\symbf{α}}_{i}\right)\right)+{\symbf{G}}_{i-1}\,\left({\symbf{h}_{\text{z},i-1}}-\frac{{\symbf{b}}_{i}}{2}\,\tan\left({\symbf{α}}_{i}\right)\right)-{\symbf{H}}_{i}\,\left(\frac{1}{3}\,{\symbf{h}_{\text{z,w},i}}+\frac{{\symbf{b}}_{i}}{2}\,\tan\left({\symbf{α}}_{i}\right)\right)+{\symbf{H}}_{i-1}\,\left(\frac{1}{3}\,{\symbf{h}_{\text{z,w},i-1}}-\frac{{\symbf{b}}_{i}}{2}\,\tan\left({\symbf{α}}_{i}\right)\right)+\frac{-{K_{\text{c}}}\,{\symbf{W}}_{i}\,{\symbf{h}}_{i}}{2}+{\symbf{U}_{\text{g},i}}\,\sin\left({\symbf{β}}_{i}\right)\,{\symbf{h}}_{i}+{\symbf{Q}}_{i}\,\sin\left({\symbf{ω}}_{i}\right)\,{\symbf{h}}_{i}}{-\frac{{\symbf{b}}_{i}}{2}\,\left({\symbf{G}}_{i}\,{\symbf{f}}_{i}+{\symbf{G}}_{i-1}\,{\symbf{f}}_{i-1}\right)}}{\outDefScale}
 \end{displaymath}
 This equation can be simplified by applying assumptions \hyperref[assumpSF]{A:Seismic-Force} and \hyperref[assumpSL]{A:Surface-Load}, which state that the seismic and external forces, respectively, are zero:
 
 \begin{displaymath}
-\resizeExpression{λ=\frac{-{\symbf{G}}_{i}\,\left({\symbf{h}_{\text{z},i}}+\frac{{\symbf{b}}_{i}}{2}\,\tan\left({\symbf{α}}_{i}\right)\right)+{\symbf{G}}_{i-1}\,\left({\symbf{h}_{\text{z},i-1}}-\frac{{\symbf{b}}_{i}}{2}\,\tan\left({\symbf{α}}_{i}\right)\right)-{\symbf{H}}_{i}\,\left(\frac{1}{3}\,{\symbf{h}_{\text{z,w},i}}+\frac{{\symbf{b}}_{i}}{2}\,\tan\left({\symbf{α}}_{i}\right)\right)+{\symbf{H}}_{i-1}\,\left(\frac{1}{3}\,{\symbf{h}_{\text{z,w},i-1}}-\frac{{\symbf{b}}_{i}}{2}\,\tan\left({\symbf{α}}_{i}\right)\right)+{\symbf{U}_{\text{g},i}}\,\sin\left({\symbf{β}}_{i}\right)\,{\symbf{h}}_{i}}{-\frac{{\symbf{b}}_{i}}{2}\,\left({\symbf{G}}_{i}\,{\symbf{f}}_{i}+{\symbf{G}}_{i-1}\,{\symbf{f}}_{i-1}\right)}}{1.0}
+\resizeExpression{λ=\frac{-{\symbf{G}}_{i}\,\left({\symbf{h}_{\text{z},i}}+\frac{{\symbf{b}}_{i}}{2}\,\tan\left({\symbf{α}}_{i}\right)\right)+{\symbf{G}}_{i-1}\,\left({\symbf{h}_{\text{z},i-1}}-\frac{{\symbf{b}}_{i}}{2}\,\tan\left({\symbf{α}}_{i}\right)\right)-{\symbf{H}}_{i}\,\left(\frac{1}{3}\,{\symbf{h}_{\text{z,w},i}}+\frac{{\symbf{b}}_{i}}{2}\,\tan\left({\symbf{α}}_{i}\right)\right)+{\symbf{H}}_{i-1}\,\left(\frac{1}{3}\,{\symbf{h}_{\text{z,w},i-1}}-\frac{{\symbf{b}}_{i}}{2}\,\tan\left({\symbf{α}}_{i}\right)\right)+{\symbf{U}_{\text{g},i}}\,\sin\left({\symbf{β}}_{i}\right)\,{\symbf{h}}_{i}}{-\frac{{\symbf{b}}_{i}}{2}\,\left({\symbf{G}}_{i}\,{\symbf{f}}_{i}+{\symbf{G}}_{i-1}\,{\symbf{f}}_{i-1}\right)}}{\outDefScale}
 \end{displaymath}
 Taking the summation of all slices, and applying \hyperref[assumpES]{A:Edge-Slices} to set ${\symbf{G}}_{0}$, ${\symbf{G}}_{n}$, ${\symbf{H}}_{0}$, and ${\symbf{H}}_{n}$ equal to zero, a general equation for the proportionality constant $λ$ is developed in Equation (16), which combines \hyperref[IM:nrmShrFor]{IM:nrmShrFor}, \hyperref[IM:nrmShrForNum]{IM:nrmShrForNum}, and \hyperref[IM:nrmShrForDen]{IM:nrmShrForDen}:
 
 \begin{displaymath}
-\resizeExpression{λ=\frac{\displaystyle\sum_{i=1}^{n}{{\symbf{b}}_{i}\,\left({{\symbf{F}_{\text{x}}}^{\text{G}}}+{{\symbf{F}_{\text{x}}}^{\text{H}}}\right)\,\tan\left({\symbf{α}}_{i}\right)+{\symbf{h}}_{i}\,-2\,{\symbf{U}_{\text{g},i}}\,\sin\left({\symbf{β}}_{i}\right)}}{\displaystyle\sum_{i=1}^{n}{{\symbf{b}}_{i}\,\left({\symbf{G}}_{i}\,{\symbf{f}}_{i}+{\symbf{G}}_{i-1}\,{\symbf{f}}_{i-1}\right)}}}{1.0}
+\resizeExpression{λ=\frac{\displaystyle\sum_{i=1}^{n}{{\symbf{b}}_{i}\,\left({{\symbf{F}_{\text{x}}}^{\text{G}}}+{{\symbf{F}_{\text{x}}}^{\text{H}}}\right)\,\tan\left({\symbf{α}}_{i}\right)+{\symbf{h}}_{i}\,-2\,{\symbf{U}_{\text{g},i}}\,\sin\left({\symbf{β}}_{i}\right)}}{\displaystyle\sum_{i=1}^{n}{{\symbf{b}}_{i}\,\left({\symbf{G}}_{i}\,{\symbf{f}}_{i}+{\symbf{G}}_{i-1}\,{\symbf{f}}_{i-1}\right)}}}{\outDefScale}
 \end{displaymath}
 Equation (16) for $λ$ is a function of the unknown interslice normal forces $\symbf{G}$ (\hyperref[IM:intsliceFs]{IM:intsliceFs}) which itself depends on the unknown factor of safety ${F_{\text{S}}}$ (\hyperref[IM:fctSfty]{IM:fctSfty}).
 
@@ -2341,7 +2343,7 @@ Equation & \begin{displaymath}
                                                         {\symbf{b}}_{1}\,\left({\symbf{G}}_{1}+{\symbf{H}}_{1}\right)\,\tan\left({\symbf{α}}_{1}\right), & i=1\\
                                                         {\symbf{b}}_{i}\,\left({{\symbf{F}_{\text{x}}}^{\text{G}}}+{{\symbf{F}_{\text{x}}}^{\text{H}}}\right)\,\tan\left({\symbf{α}}_{i}\right)+\symbf{h}\,-2\,{\symbf{U}_{\text{g},i}}\,\sin\left({\symbf{β}}_{i}\right), & 2\leq{}i\leq{}n-1\\
                                                         {\symbf{b}}_{n}\,\left({\symbf{G}}_{n-1}+{\symbf{H}}_{n-1}\right)\,\tan\left({\symbf{α}}_{n-1}\right), & i=n
-                                                        \end{cases}}{0.8}
+                                                        \end{cases}}{\inDefScale}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -2401,7 +2403,7 @@ Equation & \begin{displaymath}
                                                         {\symbf{b}}_{1}\,{\symbf{f}}_{1}\,{\symbf{G}}_{1}, & i=1\\
                                                         {\symbf{b}}_{i}\,\left({\symbf{f}}_{i}\,{\symbf{G}}_{i}+{\symbf{f}}_{i-1}\,{\symbf{G}}_{i-1}\right), & 2\leq{}i\leq{}n-1\\
                                                         {\symbf{b}}_{n}\,{\symbf{G}}_{n-1}\,{\symbf{f}}_{n-1}, & i=n
-                                                        \end{cases}}{0.8}
+                                                        \end{cases}}{\inDefScale}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -2455,7 +2457,7 @@ Equation & \begin{displaymath}
                                              \frac{{F_{\text{S}}}\,{\symbf{T}}_{1}-{\symbf{R}}_{1}}{{\symbf{Φ}}_{1}}, & i=1\\
                                              \frac{{\symbf{Ψ}}_{i-1}\,{\symbf{G}}_{i-1}+{F_{\text{S}}}\,{\symbf{T}}_{i}-{\symbf{R}}_{i}}{{\symbf{Φ}}_{i}}, & 2\leq{}i\leq{}n-1\\
                                              0, & i=0\lor{}i=n
-                                             \end{cases}}{0.8}
+                                             \end{cases}}{\inDefScale}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -2486,12 +2488,12 @@ RefBy & \hyperref[IM:intsliceFs]{IM:intsliceFs}, \hyperref[IM:fctSfty]{IM:fctSft
 This derivation is identical to the derivation for \hyperref[IM:fctSfty]{IM:fctSfty} up until Equation (3) shown again below:
 
 \begin{displaymath}
-\resizeExpression{{\symbf{G}}_{i}\,{\symbf{Φ}}_{i}={\symbf{Ψ}}_{i-1}\,{\symbf{G}}_{i-1}\,{\symbf{Φ}}_{i-1}+{F_{\text{S}}}\,{\symbf{T}}_{i}-{\symbf{R}}_{i}}{1.0}
+\resizeExpression{{\symbf{G}}_{i}\,{\symbf{Φ}}_{i}={\symbf{Ψ}}_{i-1}\,{\symbf{G}}_{i-1}\,{\symbf{Φ}}_{i-1}+{F_{\text{S}}}\,{\symbf{T}}_{i}-{\symbf{R}}_{i}}{\outDefScale}
 \end{displaymath}
 A simple rearrangement of Equation (3) leads to Equation (17), also seen in \hyperref[IM:intsliceFs]{IM:intsliceFs}:
 
 \begin{displaymath}
-\resizeExpression{{\symbf{G}}_{i}=\frac{{\symbf{Ψ}}_{i-1}\,{\symbf{G}}_{i-1}+{F_{\text{S}}}\,{\symbf{T}}_{i}-{\symbf{R}}_{i}}{{\symbf{Φ}}_{i}}}{1.0}
+\resizeExpression{{\symbf{G}}_{i}=\frac{{\symbf{Ψ}}_{i-1}\,{\symbf{G}}_{i-1}+{F_{\text{S}}}\,{\symbf{T}}_{i}-{\symbf{R}}_{i}}{{\symbf{Φ}}_{i}}}{\outDefScale}
 \end{displaymath}
 The cases shown in \hyperref[IM:intsliceFs]{IM:intsliceFs} for when $i=0$, $i=1$, or $i=n$ are derived by applying \hyperref[assumpES]{A:Edge-Slices}, which says that ${\symbf{G}}_{0}$ and ${\symbf{G}}_{n}$ are zero, to Equation (17). $\symbf{G}$ depends on the unknowns ${F_{\text{S}}}$ (\hyperref[IM:fctSfty]{IM:fctSfty}) and $λ$ (\hyperref[IM:nrmShrFor]{IM:nrmShrFor}).
 
@@ -2517,7 +2519,7 @@ Input Constraints &
 Output Constraints & 
 \\ \midrule
 Equation & \begin{displaymath}
-           \resizeExpression{{\symbf{x}_{\text{slope}}}={\symbf{y}_{\text{slope}}}}{0.8}
+           \resizeExpression{{\symbf{x}_{\text{slope}}}={\symbf{y}_{\text{slope}}}}{\inDefScale}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}

--- a/code/stable/ssp/SRS/PDF/SSP_SRS.tex
+++ b/code/stable/ssp/SRS/PDF/SSP_SRS.tex
@@ -27,12 +27,12 @@
 \setlist[symbDescription]{noitemsep, topsep=0pt, parsep=0pt, partopsep=0pt}
 \newsavebox{\mybox}
 \newcommand{\resizeExpression}[2]{
-\savebox{\mybox}{$#1$}
-\ifdim\wd\mybox>#2\linewidth
-\resizebox{#2\textwidth}{!}{\usebox{\mybox}}
-\else
-\usebox{\mybox}
-\fi
+  \savebox{\mybox}{$#1$}
+  \ifdim\wd\mybox>#2\linewidth
+    \resizebox{#2\textwidth}{!}{\usebox{\mybox}}
+  \else
+    \usebox{\mybox}
+  \fi
 }
 \bibliography{bibfile}
 \title{Software Requirements Specification for Slope Stability analysis Program}

--- a/code/stable/ssp/SRS/PDF/SSP_SRS.tex
+++ b/code/stable/ssp/SRS/PDF/SSP_SRS.tex
@@ -15,6 +15,8 @@
 \usepackage{svg}
 \usepackage{float}
 \usepackage{enumitem}
+\usepackage{graphicx}
+\usepackage{calc}
 \usepackage{filecontents}
 \usepackage[backend=bibtex]{biblatex}
 \usepackage{url}
@@ -23,6 +25,15 @@
 \newcommand{\lt}{\ensuremath <}
 \newlist{symbDescription}{description}{1}
 \setlist[symbDescription]{noitemsep, topsep=0pt, parsep=0pt, partopsep=0pt}
+\newsavebox{\mybox}
+\newcommand{\resizeExpression}[2]{
+\savebox{\mybox}{$#1$}
+\ifdim\wd\mybox>#2\linewidth
+\resizebox{#2\textwidth}{!}{\usebox{\mybox}}
+\else
+\usebox{\mybox}
+\fi
+}
 \bibliography{bibfile}
 \title{Software Requirements Specification for Slope Stability analysis Program}
 \author{Henry Frankis and Brooks MacLachlan}
@@ -471,7 +482,7 @@ Label & Factor of safety
         
 \\ \midrule
 Equation & \begin{displaymath}
-           {F_{\text{S}}}=\frac{P}{S}
+           \resizeExpression{{F_{\text{S}}}=\frac{P}{S}}{0.8}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -501,13 +512,13 @@ Label & Equilibrium
         
 \\ \midrule
 Equation & \begin{displaymath}
-           \displaystyle\sum{{F_{\text{x}}}}=0
+           \resizeExpression{\displaystyle\sum{{F_{\text{x}}}}=0}{0.8}
            \end{displaymath}
            \begin{displaymath}
-           \displaystyle\sum{{F_{\text{y}}}}=0
+           \resizeExpression{\displaystyle\sum{{F_{\text{y}}}}=0}{0.8}
            \end{displaymath}
            \begin{displaymath}
-           \displaystyle\sum{M}=0
+           \resizeExpression{\displaystyle\sum{M}=0}{0.8}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -544,7 +555,7 @@ Label & Mohr-Coulumb shear strength
         
 \\ \midrule
 Equation & \begin{displaymath}
-           {τ^{\text{f}}}={σ_{N}}'\,\tan\left(φ'\right)+c'
+           \resizeExpression{{τ^{\text{f}}}={σ_{N}}'\,\tan\left(φ'\right)+c'}{0.8}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -578,7 +589,7 @@ Label & Effective stress
         
 \\ \midrule
 Equation & \begin{displaymath}
-           σ'=σ-u
+           \resizeExpression{σ'=σ-u}{0.8}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -611,7 +622,7 @@ Label & Newton's second law of motion
         
 \\ \midrule
 Equation & \begin{displaymath}
-           \symbf{F}=m\,\symbf{a}\text{(}t\text{)}
+           \resizeExpression{\symbf{F}=m\,\symbf{a}\text{(}t\text{)}}{0.8}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -651,7 +662,7 @@ Units & $\frac{\text{N}}{\text{m}}$
         
 \\ \midrule
 Equation & \begin{displaymath}
-           {\symbf{N}}_{i}=\left({\symbf{W}}_{i}-{\symbf{X}}_{i-1}+{\symbf{X}}_{i}+{\symbf{U}_{\text{g},i}}\,\cos\left({\symbf{β}}_{i}\right)+{\symbf{Q}}_{i}\,\cos\left({\symbf{ω}}_{i}\right)\right)\,\cos\left({\symbf{α}}_{i}\right)+\left(-{K_{\text{c}}}\,{\symbf{W}}_{i}-{\symbf{G}}_{i}+{\symbf{G}}_{i-1}-{\symbf{H}}_{i}+{\symbf{H}}_{i-1}+{\symbf{U}_{\text{g},i}}\,\sin\left({\symbf{β}}_{i}\right)+{\symbf{Q}}_{i}\,\sin\left({\symbf{ω}}_{i}\right)\right)\,\sin\left({\symbf{α}}_{i}\right)
+           \resizeExpression{{\symbf{N}}_{i}=\left({\symbf{W}}_{i}-{\symbf{X}}_{i-1}+{\symbf{X}}_{i}+{\symbf{U}_{\text{g},i}}\,\cos\left({\symbf{β}}_{i}\right)+{\symbf{Q}}_{i}\,\cos\left({\symbf{ω}}_{i}\right)\right)\,\cos\left({\symbf{α}}_{i}\right)+\left(-{K_{\text{c}}}\,{\symbf{W}}_{i}-{\symbf{G}}_{i}+{\symbf{G}}_{i-1}-{\symbf{H}}_{i}+{\symbf{H}}_{i-1}+{\symbf{U}_{\text{g},i}}\,\sin\left({\symbf{β}}_{i}\right)+{\symbf{Q}}_{i}\,\sin\left({\symbf{ω}}_{i}\right)\right)\,\sin\left({\symbf{α}}_{i}\right)}{0.8}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -700,7 +711,7 @@ Units & $\frac{\text{N}}{\text{m}}$
         
 \\ \midrule
 Equation & \begin{displaymath}
-           {\symbf{S}}_{i}=\left({\symbf{W}}_{i}-{\symbf{X}}_{i-1}+{\symbf{X}}_{i}+{\symbf{U}_{\text{g},i}}\,\cos\left({\symbf{β}}_{i}\right)+{\symbf{Q}}_{i}\,\cos\left({\symbf{ω}}_{i}\right)\right)\,\sin\left({\symbf{α}}_{i}\right)-\left(-{K_{\text{c}}}\,{\symbf{W}}_{i}-{\symbf{G}}_{i}+{\symbf{G}}_{i-1}-{\symbf{H}}_{i}+{\symbf{H}}_{i-1}+{\symbf{U}_{\text{g},i}}\,\sin\left({\symbf{β}}_{i}\right)+{\symbf{Q}}_{i}\,\sin\left({\symbf{ω}}_{i}\right)\right)\,\cos\left({\symbf{α}}_{i}\right)
+           \resizeExpression{{\symbf{S}}_{i}=\left({\symbf{W}}_{i}-{\symbf{X}}_{i-1}+{\symbf{X}}_{i}+{\symbf{U}_{\text{g},i}}\,\cos\left({\symbf{β}}_{i}\right)+{\symbf{Q}}_{i}\,\cos\left({\symbf{ω}}_{i}\right)\right)\,\sin\left({\symbf{α}}_{i}\right)-\left(-{K_{\text{c}}}\,{\symbf{W}}_{i}-{\symbf{G}}_{i}+{\symbf{G}}_{i-1}-{\symbf{H}}_{i}+{\symbf{H}}_{i-1}+{\symbf{U}_{\text{g},i}}\,\sin\left({\symbf{β}}_{i}\right)+{\symbf{Q}}_{i}\,\sin\left({\symbf{ω}}_{i}\right)\right)\,\cos\left({\symbf{α}}_{i}\right)}{0.8}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -749,7 +760,7 @@ Units & $\frac{\text{N}}{\text{m}}$
         
 \\ \midrule
 Equation & \begin{displaymath}
-           {\symbf{P}}_{i}={\symbf{N'}}_{i}\,\tan\left({φ'}_{i}\right)+{c'}_{i}\,{\symbf{L}_{b,i}}
+           \resizeExpression{{\symbf{P}}_{i}={\symbf{N'}}_{i}\,\tan\left({φ'}_{i}\right)+{c'}_{i}\,{\symbf{L}_{b,i}}}{0.8}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -792,7 +803,7 @@ Units & $\frac{\text{N}}{\text{m}}$
         
 \\ \midrule
 Equation & \begin{displaymath}
-           {\symbf{S}}_{i}=\frac{{\symbf{P}}_{i}}{{F_{\text{S}}}}=\frac{{\symbf{N'}}_{i}\,\tan\left({φ'}_{i}\right)+{c'}_{i}\,{\symbf{L}_{b,i}}}{{F_{\text{S}}}}
+           \resizeExpression{{\symbf{S}}_{i}=\frac{{\symbf{P}}_{i}}{{F_{\text{S}}}}=\frac{{\symbf{N'}}_{i}\,\tan\left({φ'}_{i}\right)+{c'}_{i}\,{\symbf{L}_{b,i}}}{{F_{\text{S}}}}}{0.8}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -837,7 +848,7 @@ Units & $\frac{\text{N}}{\text{m}}$
         
 \\ \midrule
 Equation & \begin{displaymath}
-           {\symbf{N'}}_{i}={\symbf{N}}_{i}-{\symbf{U}_{\text{b},i}}
+           \resizeExpression{{\symbf{N'}}_{i}={\symbf{N}}_{i}-{\symbf{U}_{\text{b},i}}}{0.8}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -877,7 +888,7 @@ Units & $\frac{\text{N}}{\text{m}}$
         
 \\ \midrule
 Equation & \begin{displaymath}
-           {\symbf{R}}_{i}=\left(\left({\symbf{W}}_{i}+{\symbf{U}_{\text{g},i}}\,\cos\left({\symbf{β}}_{i}\right)\right)\,\cos\left({\symbf{α}}_{i}\right)+\left(-{\symbf{H}}_{i}+{\symbf{H}}_{i-1}+{\symbf{U}_{\text{g},i}}\,\sin\left({\symbf{β}}_{i}\right)\right)\,\sin\left({\symbf{α}}_{i}\right)-{\symbf{U}_{\text{b},i}}\right)\,\tan\left({φ'}_{i}\right)+{c'}_{i}\,{\symbf{L}_{b,i}}
+           \resizeExpression{{\symbf{R}}_{i}=\left(\left({\symbf{W}}_{i}+{\symbf{U}_{\text{g},i}}\,\cos\left({\symbf{β}}_{i}\right)\right)\,\cos\left({\symbf{α}}_{i}\right)+\left(-{\symbf{H}}_{i}+{\symbf{H}}_{i-1}+{\symbf{U}_{\text{g},i}}\,\sin\left({\symbf{β}}_{i}\right)\right)\,\sin\left({\symbf{α}}_{i}\right)-{\symbf{U}_{\text{b},i}}\right)\,\tan\left({φ'}_{i}\right)+{c'}_{i}\,{\symbf{L}_{b,i}}}{0.8}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -921,7 +932,7 @@ Units & $\frac{\text{N}}{\text{m}}$
         
 \\ \midrule
 Equation & \begin{displaymath}
-           {\symbf{T}}_{i}=\left({\symbf{W}}_{i}+{\symbf{U}_{\text{g},i}}\,\cos\left({\symbf{β}}_{i}\right)\right)\,\sin\left({\symbf{α}}_{i}\right)-\left(-{\symbf{H}}_{i}+{\symbf{H}}_{i-1}+{\symbf{U}_{\text{g},i}}\,\sin\left({\symbf{β}}_{i}\right)\right)\,\cos\left({\symbf{α}}_{i}\right)
+           \resizeExpression{{\symbf{T}}_{i}=\left({\symbf{W}}_{i}+{\symbf{U}_{\text{g},i}}\,\cos\left({\symbf{β}}_{i}\right)\right)\,\sin\left({\symbf{α}}_{i}\right)-\left(-{\symbf{H}}_{i}+{\symbf{H}}_{i-1}+{\symbf{U}_{\text{g},i}}\,\sin\left({\symbf{β}}_{i}\right)\right)\,\cos\left({\symbf{α}}_{i}\right)}{0.8}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -961,7 +972,7 @@ Units & $\frac{\text{N}}{\text{m}}$
         
 \\ \midrule
 Equation & \begin{displaymath}
-           \symbf{X}=λ\,\symbf{f}\,\symbf{G}
+           \resizeExpression{\symbf{X}=λ\,\symbf{f}\,\symbf{G}}{0.8}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -998,7 +1009,7 @@ Units & ${\text{N}}$
         
 \\ \midrule
 Equation & \begin{displaymath}
-           0=-{\symbf{G}}_{i}\,\left({\symbf{h}_{\text{z},i}}+\frac{{\symbf{b}}_{i}}{2}\,\tan\left({\symbf{α}}_{i}\right)\right)+{\symbf{G}}_{i-1}\,\left({\symbf{h}_{\text{z},i-1}}-\frac{{\symbf{b}}_{i}}{2}\,\tan\left({\symbf{α}}_{i}\right)\right)-{\symbf{H}}_{i}\,\left(\frac{1}{3}\,{\symbf{h}_{\text{z,w},i}}+\frac{{\symbf{b}}_{i}}{2}\,\tan\left({\symbf{α}}_{i}\right)\right)+{\symbf{H}}_{i-1}\,\left(\frac{1}{3}\,{\symbf{h}_{\text{z,w},i-1}}-\frac{{\symbf{b}}_{i}}{2}\,\tan\left({\symbf{α}}_{i}\right)\right)+\frac{{\symbf{b}}_{i}}{2}\,\left({\symbf{X}}_{i}+{\symbf{X}}_{i-1}\right)+\frac{-{K_{\text{c}}}\,{\symbf{W}}_{i}\,{\symbf{h}}_{i}}{2}+{\symbf{U}_{\text{g},i}}\,\sin\left({\symbf{β}}_{i}\right)\,{\symbf{h}}_{i}+{\symbf{Q}}_{i}\,\sin\left({\symbf{ω}}_{i}\right)\,{\symbf{h}}_{i}
+           \resizeExpression{0=-{\symbf{G}}_{i}\,\left({\symbf{h}_{\text{z},i}}+\frac{{\symbf{b}}_{i}}{2}\,\tan\left({\symbf{α}}_{i}\right)\right)+{\symbf{G}}_{i-1}\,\left({\symbf{h}_{\text{z},i-1}}-\frac{{\symbf{b}}_{i}}{2}\,\tan\left({\symbf{α}}_{i}\right)\right)-{\symbf{H}}_{i}\,\left(\frac{1}{3}\,{\symbf{h}_{\text{z,w},i}}+\frac{{\symbf{b}}_{i}}{2}\,\tan\left({\symbf{α}}_{i}\right)\right)+{\symbf{H}}_{i-1}\,\left(\frac{1}{3}\,{\symbf{h}_{\text{z,w},i-1}}-\frac{{\symbf{b}}_{i}}{2}\,\tan\left({\symbf{α}}_{i}\right)\right)+\frac{{\symbf{b}}_{i}}{2}\,\left({\symbf{X}}_{i}+{\symbf{X}}_{i-1}\right)+\frac{-{K_{\text{c}}}\,{\symbf{W}}_{i}\,{\symbf{h}}_{i}}{2}+{\symbf{U}_{\text{g},i}}\,\sin\left({\symbf{β}}_{i}\right)\,{\symbf{h}}_{i}+{\symbf{Q}}_{i}\,\sin\left({\symbf{ω}}_{i}\right)\,{\symbf{h}}_{i}}{0.8}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -1036,72 +1047,72 @@ RefBy & \hyperref[IM:nrmShrFor]{IM:nrmShrFor}
 Moment is equal to torque, so the equation from \hyperref[DD:torque]{DD:torque} will be used to calculate moments:
 
 \begin{displaymath}
-\symbf{τ}=\symbf{u}\times\symbf{F}
+\resizeExpression{\symbf{τ}=\symbf{u}\times\symbf{F}}{1.0}
 \end{displaymath}
 Considering one dimension, with moments in the clockwise direction as positive and moments in the counterclockwise direction as negative, and replacing the torque symbol with the moment symbol, the equation simplifies to:
 
 \begin{displaymath}
-M={F_{\text{rot}}}\,r
+\resizeExpression{M={F_{\text{rot}}}\,r}{1.0}
 \end{displaymath}
 where ${F_{\text{rot}}}$ is the force causing rotation and $r$ is the length of the moment arm, or the distance between the force and the axis about which the rotation acts. To represent the moment equilibrium, the moments from each force acting on a slice must be considered and added together. The forces acting on a slice are all shown in \hyperref[Figure:ForceDiagram]{Fig:ForceDiagram}. The midpoint of the base of a slice is considered as the axis of rotation, from which the length of the moment arm is measured. Considering first the interslice normal force acting on slice interface $i$, the moment is negative because the force tends to rotate the slice in a counterclockwise direction, and the length of the moment arm is the height of the force plus the difference in height between the base at slice interface $i$ and the base at the midpoint of slice $i$. Thus, the moment is expressed as:
 
 \begin{displaymath}
--{\symbf{G}}_{i}\,\left({\symbf{h}_{\text{z},i}}+\frac{{\symbf{b}}_{i}}{2}\,\tan\left({\symbf{α}}_{i}\right)\right)
+\resizeExpression{-{\symbf{G}}_{i}\,\left({\symbf{h}_{\text{z},i}}+\frac{{\symbf{b}}_{i}}{2}\,\tan\left({\symbf{α}}_{i}\right)\right)}{1.0}
 \end{displaymath}
 For the $i-1$th slice interface, the moment is similar but in the opposite direction:
 
 \begin{displaymath}
-{\symbf{G}}_{i-1}\,\left({\symbf{h}_{\text{z},i-1}}-\frac{{\symbf{b}}_{i}}{2}\,\tan\left({\symbf{α}}_{i}\right)\right)
+\resizeExpression{{\symbf{G}}_{i-1}\,\left({\symbf{h}_{\text{z},i-1}}-\frac{{\symbf{b}}_{i}}{2}\,\tan\left({\symbf{α}}_{i}\right)\right)}{1.0}
 \end{displaymath}
 Next, the interslice normal water force is considered. This force is zero at the height of the water table, then increases linearly towards the base of the slice due to the increasing water pressure. For such a triangular distribution, the resultant force acts at one-third of the height. Thus, for the interslice normal water force acting on slice interface $i$, the moment is:
 
 \begin{displaymath}
--{\symbf{H}}_{i}\,\left(\frac{1}{3}\,{\symbf{h}_{\text{z,w},i}}+\frac{{\symbf{b}}_{i}}{2}\,\tan\left({\symbf{α}}_{i}\right)\right)
+\resizeExpression{-{\symbf{H}}_{i}\,\left(\frac{1}{3}\,{\symbf{h}_{\text{z,w},i}}+\frac{{\symbf{b}}_{i}}{2}\,\tan\left({\symbf{α}}_{i}\right)\right)}{1.0}
 \end{displaymath}
 The moment for the interslice normal water force acting on slice interface $i-1$ is:
 
 \begin{displaymath}
-{\symbf{H}}_{i-1}\,\left(\frac{1}{3}\,{\symbf{h}_{\text{z,w},i-1}}+\frac{{\symbf{b}}_{i}}{2}\,\tan\left({\symbf{α}}_{i}\right)\right)
+\resizeExpression{{\symbf{H}}_{i-1}\,\left(\frac{1}{3}\,{\symbf{h}_{\text{z,w},i-1}}+\frac{{\symbf{b}}_{i}}{2}\,\tan\left({\symbf{α}}_{i}\right)\right)}{1.0}
 \end{displaymath}
 The interslice shear force at slice interface $i$ tends to rotate in the clockwise direction, and the length of the moment arm is the length from the slice edge to the slice midpoint, equivalent to half of the width of the slice, so the moment is:
 
 \begin{displaymath}
-{\symbf{X}}_{i}\,\frac{{\symbf{b}}_{i}}{2}
+\resizeExpression{{\symbf{X}}_{i}\,\frac{{\symbf{b}}_{i}}{2}}{1.0}
 \end{displaymath}
 The interslice shear force at slice interface $i-1$ also tends to rotate in the clockwise direction, and has the same length of the moment arm, so the moment is:
 
 \begin{displaymath}
-{\symbf{X}}_{i-1}\,\frac{{\symbf{b}}_{i}}{2}
+\resizeExpression{{\symbf{X}}_{i-1}\,\frac{{\symbf{b}}_{i}}{2}}{1.0}
 \end{displaymath}
 Seismic forces act over the entire height of the slice. For each horizontal segment of the slice, the seismic force is ${K_{\text{c}}}\,{\symbf{W}}_{i}$ where ${\symbf{W}}_{i}$ can be expressed as $γ\,{\symbf{b}}_{i}\,y$ using \hyperref[GD:weight]{GD:weight} where $y$ is the height of the segment under consideration. The corresponding length of the moment arm is $y$, the height from the base of the slice to the segment under consideration. In reality, the forces near the surface of the soil mass are slightly different due to the slope of the surface, but this difference is assumed to be negligible (\hyperref[assumpNESSS]{A:Negligible-Effect-Surface-Slope-Seismic}). The resultant moment from the forces on all of the segments with an equivalent resultant length of the moment arm is determined by taking the integral over the slice height. The forces tend to rotate in the counterclockwise direction, so the moment is negative:
 
 \begin{displaymath}
--\int_{0}^{{\symbf{h}}_{i}}{{K_{\text{c}}}\,γ\,{\symbf{b}}_{i}\,y}\,dy
+\resizeExpression{-\int_{0}^{{\symbf{h}}_{i}}{{K_{\text{c}}}\,γ\,{\symbf{b}}_{i}\,y}\,dy}{1.0}
 \end{displaymath}
 Solving the definite integral yields:
 
 \begin{displaymath}
--{K_{\text{c}}}\,γ\,{\symbf{b}}_{i}\,\frac{{\symbf{h}}_{i}^{2}}{2}
+\resizeExpression{-{K_{\text{c}}}\,γ\,{\symbf{b}}_{i}\,\frac{{\symbf{h}}_{i}^{2}}{2}}{1.0}
 \end{displaymath}
 Using \hyperref[GD:weight]{GD:weight} again to express $γ\,{\symbf{b}}_{i}\,{\symbf{h}}_{i}$ as ${\symbf{W}}_{i}$, the moment is:
 
 \begin{displaymath}
--{K_{\text{c}}}\,{\symbf{W}}_{i}\,\frac{{\symbf{h}}_{i}}{2}
+\resizeExpression{-{K_{\text{c}}}\,{\symbf{W}}_{i}\,\frac{{\symbf{h}}_{i}}{2}}{1.0}
 \end{displaymath}
 The surface hydrostatic force acts into the midpoint of the surface of the slice (\hyperref[assumpHFSM]{A:Hydrostatic-Force-Slice-Midpoint}). Thus, the vertical component of the force acts directly towards the point of rotation, and has a moment of zero. The horizontal component of the force tends to rotate in a clockwise direction and the length of the moment arm is the entire height of the slice. Thus, the moment is:
 
 \begin{displaymath}
-{\symbf{U}_{\text{g},i}}\,\sin\left({\symbf{β}}_{i}\right)\,{\symbf{h}}_{i}
+\resizeExpression{{\symbf{U}_{\text{g},i}}\,\sin\left({\symbf{β}}_{i}\right)\,{\symbf{h}}_{i}}{1.0}
 \end{displaymath}
 The external force again acts into the midpoint of the slice surface, so the vertical component does not contribute to the moment, and the length of the moment arm is again the entire height of the slice. The moment is:
 
 \begin{displaymath}
-{\symbf{Q}}_{i}\,\sin\left({\symbf{ω}}_{i}\right)\,{\symbf{h}}_{i}
+\resizeExpression{{\symbf{Q}}_{i}\,\sin\left({\symbf{ω}}_{i}\right)\,{\symbf{h}}_{i}}{1.0}
 \end{displaymath}
 The base hydrostatic force and slice weight both act in the direction of the point of rotation (\hyperref[assumpHFSM]{A:Hydrostatic-Force-Slice-Midpoint}), therefore both have moments of zero. Thus, all of the moments have been determined. The moment equilibrium is then represented by the sum of all moments:
 
 \begin{displaymath}
-0=-{\symbf{G}}_{i}\,\left({\symbf{h}_{\text{z},i}}+\frac{{\symbf{b}}_{i}}{2}\,\tan\left({\symbf{α}}_{i}\right)\right)+{\symbf{G}}_{i-1}\,\left({\symbf{h}_{\text{z},i-1}}-\frac{{\symbf{b}}_{i}}{2}\,\tan\left({\symbf{α}}_{i}\right)\right)-{\symbf{H}}_{i}\,\left(\frac{1}{3}\,{\symbf{h}_{\text{z,w},i}}+\frac{{\symbf{b}}_{i}}{2}\,\tan\left({\symbf{α}}_{i}\right)\right)+{\symbf{H}}_{i-1}\,\left(\frac{1}{3}\,{\symbf{h}_{\text{z,w},i-1}}-\frac{{\symbf{b}}_{i}}{2}\,\tan\left({\symbf{α}}_{i}\right)\right)+\frac{{\symbf{b}}_{i}}{2}\,\left({\symbf{X}}_{i}+{\symbf{X}}_{i-1}\right)+\frac{-{K_{\text{c}}}\,{\symbf{W}}_{i}\,{\symbf{h}}_{i}}{2}+{\symbf{U}_{\text{g},i}}\,\sin\left({\symbf{β}}_{i}\right)\,{\symbf{h}}_{i}+{\symbf{Q}}_{i}\,\sin\left({\symbf{ω}}_{i}\right)\,{\symbf{h}}_{i}
+\resizeExpression{0=-{\symbf{G}}_{i}\,\left({\symbf{h}_{\text{z},i}}+\frac{{\symbf{b}}_{i}}{2}\,\tan\left({\symbf{α}}_{i}\right)\right)+{\symbf{G}}_{i-1}\,\left({\symbf{h}_{\text{z},i-1}}-\frac{{\symbf{b}}_{i}}{2}\,\tan\left({\symbf{α}}_{i}\right)\right)-{\symbf{H}}_{i}\,\left(\frac{1}{3}\,{\symbf{h}_{\text{z,w},i}}+\frac{{\symbf{b}}_{i}}{2}\,\tan\left({\symbf{α}}_{i}\right)\right)+{\symbf{H}}_{i-1}\,\left(\frac{1}{3}\,{\symbf{h}_{\text{z,w},i-1}}-\frac{{\symbf{b}}_{i}}{2}\,\tan\left({\symbf{α}}_{i}\right)\right)+\frac{{\symbf{b}}_{i}}{2}\,\left({\symbf{X}}_{i}+{\symbf{X}}_{i-1}\right)+\frac{-{K_{\text{c}}}\,{\symbf{W}}_{i}\,{\symbf{h}}_{i}}{2}+{\symbf{U}_{\text{g},i}}\,\sin\left({\symbf{β}}_{i}\right)\,{\symbf{h}}_{i}+{\symbf{Q}}_{i}\,\sin\left({\symbf{ω}}_{i}\right)\,{\symbf{h}}_{i}}{1.0}
 \end{displaymath}
 \medskip
 \noindent
@@ -1118,7 +1129,7 @@ Units & ${\text{N}}$
         
 \\ \midrule
 Equation & \begin{displaymath}
-           W=V\,γ
+           \resizeExpression{W=V\,γ}{0.8}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -1141,25 +1152,25 @@ RefBy & \hyperref[GD:sliceWght]{GD:sliceWght} and \hyperref[GD:momentEql]{GD:mom
 Under the influence of gravity, and assuming a 2D Cartesian coordinate system with down as positive, an object has an acceleration vector of:
 
 \begin{displaymath}
-\symbf{a}\text{(}t\text{)}=\begin{bmatrix}
-                           0\\
-                           \symbf{g}\,\symbf{\hat{j}}
-                           \end{bmatrix}
+\resizeExpression{\symbf{a}\text{(}t\text{)}=\begin{bmatrix}
+                                             0\\
+                                             \symbf{g}\,\symbf{\hat{j}}
+                                             \end{bmatrix}}{1.0}
 \end{displaymath}
 Since there is only one non-zero vector component, the scalar value $W$ will be used for the weight. In this scenario, Newton's second law of motion from \hyperref[TM:NewtonSecLawMot]{TM:NewtonSecLawMot} can be expressed as:
 
 \begin{displaymath}
-W=m\,\symbf{g}
+\resizeExpression{W=m\,\symbf{g}}{1.0}
 \end{displaymath}
 Mass can be expressed as density multiplied by volume, resulting in:
 
 \begin{displaymath}
-W=ρ\,V\,\symbf{g}
+\resizeExpression{W=ρ\,V\,\symbf{g}}{1.0}
 \end{displaymath}
 Substituting specific weight as the product of density and gravitational acceleration yields:
 
 \begin{displaymath}
-W=V\,γ
+\resizeExpression{W=V\,γ}{1.0}
 \end{displaymath}
 \medskip
 \noindent
@@ -1176,11 +1187,11 @@ Units & $\frac{\text{N}}{\text{m}}$
         
 \\ \midrule
 Equation & \begin{displaymath}
-           {\symbf{W}}_{i}={\symbf{b}}_{i}\,\frac{1}{2}\,\begin{cases}
-                                                         \left({\symbf{y}_{\text{slope},i}}-{\symbf{y}_{\text{slip},i}}+{\symbf{y}_{\text{slope},i-1}}-{\symbf{y}_{\text{slip},i-1}}\right)\,{γ_{\text{sat}}}, & {\symbf{y}_{\text{wt},i}}\gt{}{\symbf{y}_{\text{slope},i}}\lor{}{\symbf{y}_{\text{wt},i-1}}\gt{}{\symbf{y}_{\text{slope},i-1}}\\
-                                                         \left({\symbf{y}_{\text{slope},i}}-{\symbf{y}_{\text{wt},i}}+{\symbf{y}_{\text{slope},i-1}}-{\symbf{y}_{\text{wt},i-1}}\right)\,{γ_{\text{dry}}}+\left({\symbf{y}_{\text{wt},i}}-{\symbf{y}_{\text{slip},i}}+{\symbf{y}_{\text{wt},i-1}}-{\symbf{y}_{\text{slip},i-1}}\right)\,{γ_{\text{sat}}}, & {\symbf{y}_{\text{slope},i}}\geq{}{\symbf{y}_{\text{wt},i}}\geq{}{\symbf{y}_{\text{slip},i}}\land{}{\symbf{y}_{\text{slope},i-1}}\geq{}{\symbf{y}_{\text{wt},i-1}}\geq{}{\symbf{y}_{\text{slip},i-1}}\\
-                                                         \left({\symbf{y}_{\text{slope},i}}-{\symbf{y}_{\text{slip},i}}+{\symbf{y}_{\text{slope},i-1}}-{\symbf{y}_{\text{slip},i-1}}\right)\,{γ_{\text{dry}}}, & {\symbf{y}_{\text{wt},i}}\lt{}{\symbf{y}_{\text{slip},i}}\lor{}{\symbf{y}_{\text{wt},i-1}}\lt{}{\symbf{y}_{\text{slip},i-1}}
-                                                         \end{cases}
+           \resizeExpression{{\symbf{W}}_{i}={\symbf{b}}_{i}\,\frac{1}{2}\,\begin{cases}
+                                                                           \left({\symbf{y}_{\text{slope},i}}-{\symbf{y}_{\text{slip},i}}+{\symbf{y}_{\text{slope},i-1}}-{\symbf{y}_{\text{slip},i-1}}\right)\,{γ_{\text{sat}}}, & {\symbf{y}_{\text{wt},i}}\gt{}{\symbf{y}_{\text{slope},i}}\lor{}{\symbf{y}_{\text{wt},i-1}}\gt{}{\symbf{y}_{\text{slope},i-1}}\\
+                                                                           \left({\symbf{y}_{\text{slope},i}}-{\symbf{y}_{\text{wt},i}}+{\symbf{y}_{\text{slope},i-1}}-{\symbf{y}_{\text{wt},i-1}}\right)\,{γ_{\text{dry}}}+\left({\symbf{y}_{\text{wt},i}}-{\symbf{y}_{\text{slip},i}}+{\symbf{y}_{\text{wt},i-1}}-{\symbf{y}_{\text{slip},i-1}}\right)\,{γ_{\text{sat}}}, & {\symbf{y}_{\text{slope},i}}\geq{}{\symbf{y}_{\text{wt},i}}\geq{}{\symbf{y}_{\text{slip},i}}\land{}{\symbf{y}_{\text{slope},i-1}}\geq{}{\symbf{y}_{\text{wt},i-1}}\geq{}{\symbf{y}_{\text{slip},i-1}}\\
+                                                                           \left({\symbf{y}_{\text{slope},i}}-{\symbf{y}_{\text{slip},i}}+{\symbf{y}_{\text{slope},i-1}}-{\symbf{y}_{\text{slip},i-1}}\right)\,{γ_{\text{dry}}}, & {\symbf{y}_{\text{wt},i}}\lt{}{\symbf{y}_{\text{slip},i}}\lor{}{\symbf{y}_{\text{wt},i-1}}\lt{}{\symbf{y}_{\text{slip},i-1}}
+                                                                           \end{cases}}{0.8}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -1211,32 +1222,32 @@ RefBy & \hyperref[GD:resShearWO]{GD:resShearWO}, \hyperref[GD:normForcEq]{GD:nor
 For the case where the water table is above the slope surface, the weights come from the weight of the saturated soil. Substituting values for saturated soil into the equation for weight from \hyperref[GD:weight]{GD:weight} yields:
 
 \begin{displaymath}
-{\symbf{W}}_{i}={\symbf{V}_{\text{sat},i}}\,{γ_{\text{sat}}}
+\resizeExpression{{\symbf{W}}_{i}={\symbf{V}_{\text{sat},i}}\,{γ_{\text{sat}}}}{1.0}
 \end{displaymath}
 Due to \hyperref[assumpPSC]{A:Plane-Strain-Conditions}, only two dimensions are considered, so the areas of saturated soil are considered instead of the volumes of saturated soil. Any given slice has a trapezoidal shape. The area of a trapezoid is the average of the lengths of the parallel sides multiplied by the length between the parallel sides. The parallel sides in this case are the interslice edges and the length between them is the width of the slice. Thus, the weights are defined as:
 
 \begin{displaymath}
-{\symbf{W}}_{i}={\symbf{b}}_{i}\,\frac{1}{2}\,\left({\symbf{y}_{\text{slope},i}}-{\symbf{y}_{\text{slip},i}}+{\symbf{y}_{\text{slope},i-1}}-{\symbf{y}_{\text{slip},i-1}}\right)\,{γ_{\text{sat}}}
+\resizeExpression{{\symbf{W}}_{i}={\symbf{b}}_{i}\,\frac{1}{2}\,\left({\symbf{y}_{\text{slope},i}}-{\symbf{y}_{\text{slip},i}}+{\symbf{y}_{\text{slope},i-1}}-{\symbf{y}_{\text{slip},i-1}}\right)\,{γ_{\text{sat}}}}{1.0}
 \end{displaymath}
 For the case where the water table is below the slip surface, the weights come from the weight of the dry soil. Substituting values for dry soil into the equation for weight from \hyperref[GD:weight]{GD:weight} yields:
 
 \begin{displaymath}
-{\symbf{W}}_{i}={\symbf{V}_{\text{dry},i}}\,{γ_{\text{dry}}}
+\resizeExpression{{\symbf{W}}_{i}={\symbf{V}_{\text{dry},i}}\,{γ_{\text{dry}}}}{1.0}
 \end{displaymath}
 \hyperref[assumpPSC]{A:Plane-Strain-Conditions} again allows for two-dimensional analysis so the areas of dry soil are considered instead of the volumes of dry soil. The trapezoidal slice shape is the same as in the previous case, so the weights are defined as:
 
 \begin{displaymath}
-{\symbf{W}}_{i}={\symbf{b}}_{i}\,\frac{1}{2}\,\left({\symbf{y}_{\text{slope},i}}-{\symbf{y}_{\text{slip},i}}+{\symbf{y}_{\text{slope},i-1}}-{\symbf{y}_{\text{slip},i-1}}\right)\,{γ_{\text{dry}}}
+\resizeExpression{{\symbf{W}}_{i}={\symbf{b}}_{i}\,\frac{1}{2}\,\left({\symbf{y}_{\text{slope},i}}-{\symbf{y}_{\text{slip},i}}+{\symbf{y}_{\text{slope},i-1}}-{\symbf{y}_{\text{slip},i-1}}\right)\,{γ_{\text{dry}}}}{1.0}
 \end{displaymath}
 For the case where the water table is between the slope surface and slip surface, the weights are the sums of the weights of the dry portions and weights of the saturated portions of the soil. Substituting values for dry and saturated soil into the equation for weight from \hyperref[GD:weight]{GD:weight} and adding them together yields:
 
 \begin{displaymath}
-{\symbf{W}}_{i}={\symbf{V}_{\text{dry},i}}\,{γ_{\text{dry}}}+{\symbf{V}_{\text{sat},i}}\,{γ_{\text{sat}}}
+\resizeExpression{{\symbf{W}}_{i}={\symbf{V}_{\text{dry},i}}\,{γ_{\text{dry}}}+{\symbf{V}_{\text{sat},i}}\,{γ_{\text{sat}}}}{1.0}
 \end{displaymath}
 \hyperref[assumpPSC]{A:Plane-Strain-Conditions} again allows for two-dimensional analysis so the areas of dry soil and areas of saturated soil are considered instead of the volumes of dry soil and volumes of saturated soil. The water table is assumed to only intersect a slice surface or base at a slice edge (\hyperref[assumpWISE]{A:Water-Intersects-Surface-Edge}, \hyperref[assumpWIBE]{A:Water-Intersects-Base-Edge}), so the dry and saturated portions each have trapezoidal shape. For the dry portion, the parallel sides of the trapezoid are the lengths between the slope surface and water table at the slice edges. For the saturated portion, the parallel sides of the trapezoid are the lengths between the water table and slip surface at the slice edges. Thus, the weights are defined as:
 
 \begin{displaymath}
-{\symbf{W}}_{i}={\symbf{b}}_{i}\,\frac{1}{2}\,\left(\left({\symbf{y}_{\text{slope},i}}-{\symbf{y}_{\text{wt},i}}+{\symbf{y}_{\text{slope},i-1}}-{\symbf{y}_{\text{wt},i-1}}\right)\,{γ_{\text{dry}}}+\left({\symbf{y}_{\text{wt},i}}-{\symbf{y}_{\text{slip},i}}+{\symbf{y}_{\text{wt},i-1}}-{\symbf{y}_{\text{slip},i-1}}\right)\,{γ_{\text{sat}}}\right)
+\resizeExpression{{\symbf{W}}_{i}={\symbf{b}}_{i}\,\frac{1}{2}\,\left(\left({\symbf{y}_{\text{slope},i}}-{\symbf{y}_{\text{wt},i}}+{\symbf{y}_{\text{slope},i-1}}-{\symbf{y}_{\text{wt},i-1}}\right)\,{γ_{\text{dry}}}+\left({\symbf{y}_{\text{wt},i}}-{\symbf{y}_{\text{slip},i}}+{\symbf{y}_{\text{wt},i-1}}-{\symbf{y}_{\text{slip},i-1}}\right)\,{γ_{\text{sat}}}\right)}{1.0}
 \end{displaymath}
 \medskip
 \noindent
@@ -1253,7 +1264,7 @@ Units & ${\text{Pa}}$
         
 \\ \midrule
 Equation & \begin{displaymath}
-           p=γ\,h
+           \resizeExpression{p=γ\,h}{0.8}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -1289,10 +1300,10 @@ Units & $\frac{\text{N}}{\text{m}}$
         
 \\ \midrule
 Equation & \begin{displaymath}
-           {\symbf{U}_{\text{b},i}}={\symbf{L}_{b,i}}\,{γ_{w}}\,\frac{1}{2}\,\begin{cases}
-                                                                             {\symbf{y}_{\text{wt},i}}-{\symbf{y}_{\text{slip},i}}+{\symbf{y}_{\text{wt},i-1}}-{\symbf{y}_{\text{slip},i-1}}, & {\symbf{y}_{\text{wt},i}}\gt{}{\symbf{y}_{\text{slip},i}}\lor{}{\symbf{y}_{\text{wt},i-1}}\gt{}{\symbf{y}_{\text{slip},i-1}}\\
-                                                                             0, & {\symbf{y}_{\text{wt},i}}\leq{}{\symbf{y}_{\text{slip},i}}\land{}{\symbf{y}_{\text{wt},i-1}}\leq{}{\symbf{y}_{\text{slip},i-1}}
-                                                                             \end{cases}
+           \resizeExpression{{\symbf{U}_{\text{b},i}}={\symbf{L}_{b,i}}\,{γ_{w}}\,\frac{1}{2}\,\begin{cases}
+                                                                                               {\symbf{y}_{\text{wt},i}}-{\symbf{y}_{\text{slip},i}}+{\symbf{y}_{\text{wt},i-1}}-{\symbf{y}_{\text{slip},i-1}}, & {\symbf{y}_{\text{wt},i}}\gt{}{\symbf{y}_{\text{slip},i}}\lor{}{\symbf{y}_{\text{wt},i-1}}\gt{}{\symbf{y}_{\text{slip},i-1}}\\
+                                                                                               0, & {\symbf{y}_{\text{wt},i}}\leq{}{\symbf{y}_{\text{slip},i}}\land{}{\symbf{y}_{\text{wt},i-1}}\leq{}{\symbf{y}_{\text{slip},i-1}}
+                                                                                               \end{cases}}{0.8}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -1321,17 +1332,17 @@ RefBy & \hyperref[GD:resShearWO]{GD:resShearWO}, \hyperref[GD:effNormF]{GD:effNo
 The base hydrostatic forces come from the hydrostatic pressure exerted by the water above the base of each slice. The equation for hydrostatic pressure from \hyperref[GD:hsPressure]{GD:hsPressure} is:
 
 \begin{displaymath}
-p=γ\,h
+\resizeExpression{p=γ\,h}{1.0}
 \end{displaymath}
 The specific weight in this case is the unit weight of water ${γ_{w}}$. The height in this case is the height from the slice base to the water table. This height is measured from the midpoint of the slice because the resultant hydrostatic force is assumed to act at the slice midpoint (\hyperref[assumpHFSM]{A:Hydrostatic-Force-Slice-Midpoint}). The height at the midpoint is the average of the height at slice interface $i$ and the height at slice interface $i-1$:
 
 \begin{displaymath}
-\frac{1}{2}\,\left({\symbf{y}_{\text{wt},i}}-{\symbf{y}_{\text{slip},i}}+{\symbf{y}_{\text{wt},i-1}}-{\symbf{y}_{\text{slip},i-1}}\right)
+\resizeExpression{\frac{1}{2}\,\left({\symbf{y}_{\text{wt},i}}-{\symbf{y}_{\text{slip},i}}+{\symbf{y}_{\text{wt},i-1}}-{\symbf{y}_{\text{slip},i-1}}\right)}{1.0}
 \end{displaymath}
 Due to \hyperref[assumpPSC]{A:Plane-Strain-Conditions}, only two dimensions are considered, so the base hydrostatic forces are expressed as forces per meter. The pressures acting on the slices can thus be converted to base hydrostatic forces by multiplying by the corresponding length of the slice base ${\symbf{L}_{b,i}}$, assuming the water table does not intersect a slice base except at a slice edge (\hyperref[assumpWIBE]{A:Water-Intersects-Base-Edge}). Thus, in the case where the height of the water table is above the height of the slip surface, the base hydrostatic forces are defined as:
 
 \begin{displaymath}
-{\symbf{U}_{\text{b},i}}={\symbf{L}_{b,i}}\,{γ_{w}}\,\frac{1}{2}\,\left({\symbf{y}_{\text{wt},i}}-{\symbf{y}_{\text{slip},i}}+{\symbf{y}_{\text{wt},i-1}}-{\symbf{y}_{\text{slip},i-1}}\right)
+\resizeExpression{{\symbf{U}_{\text{b},i}}={\symbf{L}_{b,i}}\,{γ_{w}}\,\frac{1}{2}\,\left({\symbf{y}_{\text{wt},i}}-{\symbf{y}_{\text{slip},i}}+{\symbf{y}_{\text{wt},i-1}}-{\symbf{y}_{\text{slip},i-1}}\right)}{1.0}
 \end{displaymath}
 This equation is the non-zero case of \hyperref[GD:baseWtrF]{GD:baseWtrF}. The zero case is when the height of the water table is below the height of the slip surface, so there is no hydrostatic force.
 
@@ -1350,10 +1361,10 @@ Units & $\frac{\text{N}}{\text{m}}$
         
 \\ \midrule
 Equation & \begin{displaymath}
-           {\symbf{U}_{\text{g},i}}={\symbf{L}_{s,i}}\,{γ_{w}}\,\frac{1}{2}\,\begin{cases}
-                                                                             {\symbf{y}_{\text{wt},i}}-{\symbf{y}_{\text{slope},i}}+{\symbf{y}_{\text{wt},i-1}}-{\symbf{y}_{\text{slope},i-1}}, & {\symbf{y}_{\text{wt},i}}\gt{}{\symbf{y}_{\text{slope},i}}\lor{}{\symbf{y}_{\text{wt},i-1}}\gt{}{\symbf{y}_{\text{slope},i-1}}\\
-                                                                             0, & {\symbf{y}_{\text{wt},i}}\leq{}{\symbf{y}_{\text{slope},i}}\land{}{\symbf{y}_{\text{wt},i-1}}\leq{}{\symbf{y}_{\text{slope},i-1}}
-                                                                             \end{cases}
+           \resizeExpression{{\symbf{U}_{\text{g},i}}={\symbf{L}_{s,i}}\,{γ_{w}}\,\frac{1}{2}\,\begin{cases}
+                                                                                               {\symbf{y}_{\text{wt},i}}-{\symbf{y}_{\text{slope},i}}+{\symbf{y}_{\text{wt},i-1}}-{\symbf{y}_{\text{slope},i-1}}, & {\symbf{y}_{\text{wt},i}}\gt{}{\symbf{y}_{\text{slope},i}}\lor{}{\symbf{y}_{\text{wt},i-1}}\gt{}{\symbf{y}_{\text{slope},i-1}}\\
+                                                                                               0, & {\symbf{y}_{\text{wt},i}}\leq{}{\symbf{y}_{\text{slope},i}}\land{}{\symbf{y}_{\text{wt},i-1}}\leq{}{\symbf{y}_{\text{slope},i-1}}
+                                                                                               \end{cases}}{0.8}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -1382,17 +1393,17 @@ RefBy & \hyperref[GD:srfWtrF]{GD:srfWtrF}, \hyperref[GD:resShearWO]{GD:resShearW
 The surface hydrostatic forces come from the hydrostatic pressure exerted by the water above the surface of each slice. The equation for hydrostatic pressure from \hyperref[GD:hsPressure]{GD:hsPressure} is:
 
 \begin{displaymath}
-p=γ\,h
+\resizeExpression{p=γ\,h}{1.0}
 \end{displaymath}
 The specific weight in this case is the unit weight of water ${γ_{w}}$. The height in this case is the height from the slice surface to the water table. This height is measured from the midpoint of the slice because the resultant hydrostatic force is assumed to act at the slice midpoint (\hyperref[assumpHFSM]{A:Hydrostatic-Force-Slice-Midpoint}). The height at the midpoint is the average of the height at slice interface $i$ and the height at slice interface $i-1$:
 
 \begin{displaymath}
-\frac{1}{2}\,\left({\symbf{y}_{\text{wt},i}}-{\symbf{y}_{\text{slope},i}}+{\symbf{y}_{\text{wt},i-1}}-{\symbf{y}_{\text{slope},i-1}}\right)
+\resizeExpression{\frac{1}{2}\,\left({\symbf{y}_{\text{wt},i}}-{\symbf{y}_{\text{slope},i}}+{\symbf{y}_{\text{wt},i-1}}-{\symbf{y}_{\text{slope},i-1}}\right)}{1.0}
 \end{displaymath}
 Due to \hyperref[assumpPSC]{A:Plane-Strain-Conditions}, only two dimensions are considered, so the surface hydrostatic forces are expressed as forces per meter. The pressures acting on the slices can thus be converted to surface hydrostatic forces by multiplying by the corresponding length of the slice surface ${\symbf{L}_{s,i}}$, assuming the water table does not intersect a slice surface except at a slice edge (\hyperref[assumpWISE]{A:Water-Intersects-Surface-Edge}). Thus, in the case where the height of the water table is above the height of the slope surface, the surface hydrostatic forces are defined as:
 
 \begin{displaymath}
-{\symbf{U}_{\text{g},i}}={\symbf{L}_{s,i}}\,{γ_{w}}\,\frac{1}{2}\,\left({\symbf{y}_{\text{wt},i}}-{\symbf{y}_{\text{slope},i}}+{\symbf{y}_{\text{wt},i-1}}-{\symbf{y}_{\text{slope},i-1}}\right)
+\resizeExpression{{\symbf{U}_{\text{g},i}}={\symbf{L}_{s,i}}\,{γ_{w}}\,\frac{1}{2}\,\left({\symbf{y}_{\text{wt},i}}-{\symbf{y}_{\text{slope},i}}+{\symbf{y}_{\text{wt},i-1}}-{\symbf{y}_{\text{slope},i-1}}\right)}{1.0}
 \end{displaymath}
 This equation is the non-zero case of \hyperref[GD:srfWtrF]{GD:srfWtrF}. The zero case is when the height of the water table is below the height of the slope surface, so there is no hydrostatic force.
 
@@ -1418,11 +1429,11 @@ Units & $\frac{\text{N}}{\text{m}}$
         
 \\ \midrule
 Equation & \begin{displaymath}
-           \symbf{H}=\begin{cases}
-                     \frac{\left({\symbf{y}_{\text{slope},i}}-{\symbf{y}_{\text{slip},i}}\right)^{2}}{2}\,{γ_{w}}+\left({\symbf{y}_{\text{wt},i}}-{\symbf{y}_{\text{slope},i}}\right)^{2}\,{γ_{w}}, & {\symbf{y}_{\text{wt},i}}\geq{}{\symbf{y}_{\text{slope},i}}\\
-                     \frac{\left({\symbf{y}_{\text{wt},i}}-{\symbf{y}_{\text{slip},i}}\right)^{2}}{2}\,{γ_{w}}, & {\symbf{y}_{\text{slope},i}}\gt{}{\symbf{y}_{\text{wt},i}}\land{}{\symbf{y}_{\text{wt},i}}\gt{}{\symbf{y}_{\text{slip},i}}\\
-                     0, & {\symbf{y}_{\text{wt},i}}\leq{}{\symbf{y}_{\text{slip},i}}
-                     \end{cases}
+           \resizeExpression{\symbf{H}=\begin{cases}
+                                       \frac{\left({\symbf{y}_{\text{slope},i}}-{\symbf{y}_{\text{slip},i}}\right)^{2}}{2}\,{γ_{w}}+\left({\symbf{y}_{\text{wt},i}}-{\symbf{y}_{\text{slope},i}}\right)^{2}\,{γ_{w}}, & {\symbf{y}_{\text{wt},i}}\geq{}{\symbf{y}_{\text{slope},i}}\\
+                                       \frac{\left({\symbf{y}_{\text{wt},i}}-{\symbf{y}_{\text{slip},i}}\right)^{2}}{2}\,{γ_{w}}, & {\symbf{y}_{\text{slope},i}}\gt{}{\symbf{y}_{\text{wt},i}}\land{}{\symbf{y}_{\text{wt},i}}\gt{}{\symbf{y}_{\text{slip},i}}\\
+                                       0, & {\symbf{y}_{\text{wt},i}}\leq{}{\symbf{y}_{\text{slip},i}}
+                                       \end{cases}}{0.8}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -1461,7 +1472,7 @@ Units & ${{}^{\circ}}$
         
 \\ \midrule
 Equation & \begin{displaymath}
-           \symbf{α}=\arctan\left(\frac{{\symbf{y}_{\text{slip},i}}-{\symbf{y}_{\text{slip},i-1}}}{{\symbf{x}_{\text{slip},i}}-{\symbf{x}_{\text{slip},i-1}}}\right)
+           \resizeExpression{\symbf{α}=\arctan\left(\frac{{\symbf{y}_{\text{slip},i}}-{\symbf{y}_{\text{slip},i-1}}}{{\symbf{x}_{\text{slip},i}}-{\symbf{x}_{\text{slip},i-1}}}\right)}{0.8}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -1501,7 +1512,7 @@ Units & ${{}^{\circ}}$
         
 \\ \midrule
 Equation & \begin{displaymath}
-           \symbf{β}=\arctan\left(\frac{{\symbf{y}_{\text{slope},i}}-{\symbf{y}_{\text{slope},i-1}}}{{\symbf{x}_{\text{slope},i}}-{\symbf{x}_{\text{slope},i-1}}}\right)
+           \resizeExpression{\symbf{β}=\arctan\left(\frac{{\symbf{y}_{\text{slope},i}}-{\symbf{y}_{\text{slope},i-1}}}{{\symbf{x}_{\text{slope},i}}-{\symbf{x}_{\text{slope},i-1}}}\right)}{0.8}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -1541,7 +1552,7 @@ Units & ${\text{m}}$
         
 \\ \midrule
 Equation & \begin{displaymath}
-           \symbf{b}={\symbf{x}_{\text{slip},i}}-{\symbf{x}_{\text{slip},i-1}}
+           \resizeExpression{\symbf{b}={\symbf{x}_{\text{slip},i}}-{\symbf{x}_{\text{slip},i-1}}}{0.8}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -1577,7 +1588,7 @@ Units & ${\text{m}}$
         
 \\ \midrule
 Equation & \begin{displaymath}
-           {\symbf{L}_{b}}={\symbf{b}}_{i}\,\sec\left({\symbf{α}}_{i}\right)
+           \resizeExpression{{\symbf{L}_{b}}={\symbf{b}}_{i}\,\sec\left({\symbf{α}}_{i}\right)}{0.8}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -1617,7 +1628,7 @@ Units & ${\text{m}}$
         
 \\ \midrule
 Equation & \begin{displaymath}
-           {\symbf{L}_{s}}={\symbf{b}}_{i}\,\sec\left({\symbf{β}}_{i}\right)
+           \resizeExpression{{\symbf{L}_{s}}={\symbf{b}}_{i}\,\sec\left({\symbf{β}}_{i}\right)}{0.8}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -1657,7 +1668,7 @@ Units & ${\text{m}}$
         
 \\ \midrule
 Equation & \begin{displaymath}
-           \symbf{h}=\frac{1}{2}\,\left({{\symbf{h}^{\text{R}}}}_{i}+{{\symbf{h}^{\text{L}}}}_{i}\right)
+           \resizeExpression{\symbf{h}=\frac{1}{2}\,\left({{\symbf{h}^{\text{R}}}}_{i}+{{\symbf{h}^{\text{L}}}}_{i}\right)}{0.8}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -1699,7 +1710,7 @@ Units & ${\text{Pa}}$
         
 \\ \midrule
 Equation & \begin{displaymath}
-           σ=\frac{{F_{\text{n}}}}{A}
+           \resizeExpression{σ=\frac{{F_{\text{n}}}}{A}}{0.8}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -1735,7 +1746,7 @@ Units & ${\text{Pa}}$
         
 \\ \midrule
 Equation & \begin{displaymath}
-           τ=\frac{{F_{\text{t}}}}{A}
+           \resizeExpression{τ=\frac{{F_{\text{t}}}}{A}}{0.8}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -1771,7 +1782,7 @@ Units & $\text{N}\text{m}$
         
 \\ \midrule
 Equation & \begin{displaymath}
-           \symbf{τ}=\symbf{r}\times\symbf{F}
+           \resizeExpression{\symbf{τ}=\symbf{r}\times\symbf{F}}{0.8}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -1810,10 +1821,10 @@ Units & Unitless
         
 \\ \midrule
 Equation & \begin{displaymath}
-           \symbf{f}=\begin{cases}
-                     1, & \mathit{const\_f}\\
-                     \sin\left(π\,\frac{{\symbf{x}_{\text{slip},i}}-{\symbf{x}_{\text{slip},0}}}{{\symbf{x}_{\text{slip},n}}-{\symbf{x}_{\text{slip},0}}}\right), & \neg{}\mathit{const\_f}
-                     \end{cases}
+           \resizeExpression{\symbf{f}=\begin{cases}
+                                       1, & \mathit{const\_f}\\
+                                       \sin\left(π\,\frac{{\symbf{x}_{\text{slip},i}}-{\symbf{x}_{\text{slip},0}}}{{\symbf{x}_{\text{slip},n}}-{\symbf{x}_{\text{slip},0}}}\right), & \neg{}\mathit{const\_f}
+                                       \end{cases}}{0.8}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -1852,7 +1863,7 @@ Units & Unitless
         
 \\ \midrule
 Equation & \begin{displaymath}
-           \symbf{Φ}=\left(λ\,{\symbf{f}}_{i}\,\cos\left({\symbf{α}}_{i}\right)-\sin\left({\symbf{α}}_{i}\right)\right)\,\tan\left(φ'\right)-\left(λ\,{\symbf{f}}_{i}\,\sin\left({\symbf{α}}_{i}\right)+\cos\left({\symbf{α}}_{i}\right)\right)\,{F_{\text{S}}}
+           \resizeExpression{\symbf{Φ}=\left(λ\,{\symbf{f}}_{i}\,\cos\left({\symbf{α}}_{i}\right)-\sin\left({\symbf{α}}_{i}\right)\right)\,\tan\left(φ'\right)-\left(λ\,{\symbf{f}}_{i}\,\sin\left({\symbf{α}}_{i}\right)+\cos\left({\symbf{α}}_{i}\right)\right)\,{F_{\text{S}}}}{0.8}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -1895,7 +1906,7 @@ Units & Unitless
         
 \\ \midrule
 Equation & \begin{displaymath}
-           \symbf{Ψ}=\frac{\left(λ\,{\symbf{f}}_{i}\,\cos\left({\symbf{α}}_{i}\right)-\sin\left({\symbf{α}}_{i}\right)\right)\,\tan\left(φ'\right)-\left(λ\,{\symbf{f}}_{i}\,\sin\left({\symbf{α}}_{i}\right)+\cos\left({\symbf{α}}_{i}\right)\right)\,{F_{\text{S}}}}{{\symbf{Φ}}_{i-1}}
+           \resizeExpression{\symbf{Ψ}=\frac{\left(λ\,{\symbf{f}}_{i}\,\cos\left({\symbf{α}}_{i}\right)-\sin\left({\symbf{α}}_{i}\right)\right)\,\tan\left(φ'\right)-\left(λ\,{\symbf{f}}_{i}\,\sin\left({\symbf{α}}_{i}\right)+\cos\left({\symbf{α}}_{i}\right)\right)\,{F_{\text{S}}}}{{\symbf{Φ}}_{i-1}}}{0.8}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -1939,7 +1950,7 @@ Units & ${\text{N}}$
         
 \\ \midrule
 Equation & \begin{displaymath}
-           {{\symbf{F}_{\text{x}}}^{\text{G}}}={\symbf{G}}_{i}+{\symbf{G}}_{i-1}
+           \resizeExpression{{{\symbf{F}_{\text{x}}}^{\text{G}}}={\symbf{G}}_{i}+{\symbf{G}}_{i-1}}{0.8}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -1974,7 +1985,7 @@ Units & ${\text{N}}$
         
 \\ \midrule
 Equation & \begin{displaymath}
-           {{\symbf{F}_{\text{x}}}^{\text{H}}}={\symbf{H}}_{i}+{\symbf{H}}_{i-1}
+           \resizeExpression{{{\symbf{F}_{\text{x}}}^{\text{H}}}={\symbf{H}}_{i}+{\symbf{H}}_{i-1}}{0.8}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -2009,7 +2020,7 @@ Units & ${\text{m}}$
         
 \\ \midrule
 Equation & \begin{displaymath}
-           {\symbf{h}^{\text{R}}}={\symbf{y}_{\text{slope},i}}-{\symbf{y}_{\text{slip},i}}
+           \resizeExpression{{\symbf{h}^{\text{R}}}={\symbf{y}_{\text{slope},i}}-{\symbf{y}_{\text{slip},i}}}{0.8}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -2046,7 +2057,7 @@ Units & ${\text{m}}$
         
 \\ \midrule
 Equation & \begin{displaymath}
-           {\symbf{h}^{\text{L}}}={\symbf{y}_{\text{slope},i-1}}-{\symbf{y}_{\text{slip},i-1}}
+           \resizeExpression{{\symbf{h}^{\text{L}}}={\symbf{y}_{\text{slope},i-1}}-{\symbf{y}_{\text{slip},i-1}}}{0.8}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -2095,7 +2106,7 @@ Input Constraints &
 Output Constraints & 
 \\ \midrule
 Equation & \begin{displaymath}
-           {F_{\text{S}}}=\frac{\displaystyle\sum_{i=1}^{n-1}{{\symbf{R}}_{i}\,\displaystyle\prod_{v=i}^{n-1}{{\symbf{Ψ}}_{v}}}+{\symbf{R}}_{n}}{\displaystyle\sum_{i=1}^{n-1}{{\symbf{T}}_{i}\,\displaystyle\prod_{v=i}^{n-1}{{\symbf{Ψ}}_{v}}}+{\symbf{T}}_{n}}
+           \resizeExpression{{F_{\text{S}}}=\frac{\displaystyle\sum_{i=1}^{n-1}{{\symbf{R}}_{i}\,\displaystyle\prod_{v=i}^{n-1}{{\symbf{Ψ}}_{v}}}+{\symbf{R}}_{n}}{\displaystyle\sum_{i=1}^{n-1}{{\symbf{T}}_{i}\,\displaystyle\prod_{v=i}^{n-1}{{\symbf{Ψ}}_{v}}}+{\symbf{T}}_{n}}}{0.8}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -2125,114 +2136,114 @@ RefBy & \hyperref[IM:intsliceFs]{IM:intsliceFs}, \hyperref[IM:fctSfty]{IM:fctSft
 The mobilized shear force defined in \hyperref[GD:bsShrFEq]{GD:bsShrFEq} can be substituted into the definition of mobilized shear force based on the factor of safety, from \hyperref[GD:mobShr]{GD:mobShr} yielding Equation (1) below:
 
 \begin{displaymath}
-\left({\symbf{W}}_{i}-{\symbf{X}}_{i-1}+{\symbf{X}}_{i}+{\symbf{U}_{\text{g},i}}\,\cos\left({\symbf{β}}_{i}\right)+{\symbf{Q}}_{i}\,\cos\left({\symbf{ω}}_{i}\right)\right)\,\sin\left({\symbf{α}}_{i}\right)-\left(-{K_{\text{c}}}\,{\symbf{W}}_{i}-{\symbf{G}}_{i}+{\symbf{G}}_{i-1}-{\symbf{H}}_{i}+{\symbf{H}}_{i-1}+{\symbf{U}_{\text{g},i}}\,\sin\left({\symbf{β}}_{i}\right)+{\symbf{Q}}_{i}\,\sin\left({\symbf{ω}}_{i}\right)\right)\,\cos\left({\symbf{α}}_{i}\right)=\frac{{\symbf{N'}}_{i}\,\tan\left(φ'\right)+c'\,{\symbf{L}_{b,i}}}{{F_{\text{S}}}}
+\resizeExpression{\left({\symbf{W}}_{i}-{\symbf{X}}_{i-1}+{\symbf{X}}_{i}+{\symbf{U}_{\text{g},i}}\,\cos\left({\symbf{β}}_{i}\right)+{\symbf{Q}}_{i}\,\cos\left({\symbf{ω}}_{i}\right)\right)\,\sin\left({\symbf{α}}_{i}\right)-\left(-{K_{\text{c}}}\,{\symbf{W}}_{i}-{\symbf{G}}_{i}+{\symbf{G}}_{i-1}-{\symbf{H}}_{i}+{\symbf{H}}_{i-1}+{\symbf{U}_{\text{g},i}}\,\sin\left({\symbf{β}}_{i}\right)+{\symbf{Q}}_{i}\,\sin\left({\symbf{ω}}_{i}\right)\right)\,\cos\left({\symbf{α}}_{i}\right)=\frac{{\symbf{N'}}_{i}\,\tan\left(φ'\right)+c'\,{\symbf{L}_{b,i}}}{{F_{\text{S}}}}}{1.0}
 \end{displaymath}
 An expression for the effective normal forces, $\symbf{N'}$, can be derived by substituting the normal forces equilibrium from \hyperref[GD:normForcEq]{GD:normForcEq} into the definition for effective normal forces from \hyperref[GD:resShearWO]{GD:resShearWO}. This results in Equation (2):
 
 \begin{displaymath}
-{\symbf{N'}}_{i}=\left({\symbf{W}}_{i}-{\symbf{X}}_{i-1}+{\symbf{X}}_{i}+{\symbf{U}_{\text{g},i}}\,\cos\left({\symbf{β}}_{i}\right)+{\symbf{Q}}_{i}\,\cos\left({\symbf{ω}}_{i}\right)\right)\,\cos\left({\symbf{α}}_{i}\right)+\left(-{K_{\text{c}}}\,{\symbf{W}}_{i}-{\symbf{G}}_{i}+{\symbf{G}}_{i-1}-{\symbf{H}}_{i}+{\symbf{H}}_{i-1}+{\symbf{U}_{\text{g},i}}\,\sin\left({\symbf{β}}_{i}\right)+{\symbf{Q}}_{i}\,\sin\left({\symbf{ω}}_{i}\right)\right)\,\sin\left({\symbf{α}}_{i}\right)-{\symbf{U}_{\text{b},i}}
+\resizeExpression{{\symbf{N'}}_{i}=\left({\symbf{W}}_{i}-{\symbf{X}}_{i-1}+{\symbf{X}}_{i}+{\symbf{U}_{\text{g},i}}\,\cos\left({\symbf{β}}_{i}\right)+{\symbf{Q}}_{i}\,\cos\left({\symbf{ω}}_{i}\right)\right)\,\cos\left({\symbf{α}}_{i}\right)+\left(-{K_{\text{c}}}\,{\symbf{W}}_{i}-{\symbf{G}}_{i}+{\symbf{G}}_{i-1}-{\symbf{H}}_{i}+{\symbf{H}}_{i-1}+{\symbf{U}_{\text{g},i}}\,\sin\left({\symbf{β}}_{i}\right)+{\symbf{Q}}_{i}\,\sin\left({\symbf{ω}}_{i}\right)\right)\,\sin\left({\symbf{α}}_{i}\right)-{\symbf{U}_{\text{b},i}}}{1.0}
 \end{displaymath}
 Substituting Equation (2) into Equation (1) gives:
 
 \begin{displaymath}
-\left({\symbf{W}}_{i}-{\symbf{X}}_{i-1}+{\symbf{X}}_{i}+{\symbf{U}_{\text{g},i}}\,\cos\left({\symbf{β}}_{i}\right)+{\symbf{Q}}_{i}\,\cos\left({\symbf{ω}}_{i}\right)\right)\,\sin\left({\symbf{α}}_{i}\right)-\left(-{K_{\text{c}}}\,{\symbf{W}}_{i}-{\symbf{G}}_{i}+{\symbf{G}}_{i-1}-{\symbf{H}}_{i}+{\symbf{H}}_{i-1}+{\symbf{U}_{\text{g},i}}\,\sin\left({\symbf{β}}_{i}\right)+{\symbf{Q}}_{i}\,\sin\left({\symbf{ω}}_{i}\right)\right)\,\cos\left({\symbf{α}}_{i}\right)=\frac{\left(\left({\symbf{W}}_{i}-{\symbf{X}}_{i-1}+{\symbf{X}}_{i}+{\symbf{U}_{\text{g},i}}\,\cos\left({\symbf{β}}_{i}\right)+{\symbf{Q}}_{i}\,\cos\left({\symbf{ω}}_{i}\right)\right)\,\cos\left({\symbf{α}}_{i}\right)+\left(-{K_{\text{c}}}\,{\symbf{W}}_{i}-{\symbf{G}}_{i}+{\symbf{G}}_{i-1}-{\symbf{H}}_{i}+{\symbf{H}}_{i-1}+{\symbf{U}_{\text{g},i}}\,\sin\left({\symbf{β}}_{i}\right)+{\symbf{Q}}_{i}\,\sin\left({\symbf{ω}}_{i}\right)\right)\,\sin\left({\symbf{α}}_{i}\right)-{\symbf{U}_{\text{b},i}}\right)\,\tan\left(φ'\right)+c'\,{\symbf{L}_{b,i}}}{{F_{\text{S}}}}
+\resizeExpression{\left({\symbf{W}}_{i}-{\symbf{X}}_{i-1}+{\symbf{X}}_{i}+{\symbf{U}_{\text{g},i}}\,\cos\left({\symbf{β}}_{i}\right)+{\symbf{Q}}_{i}\,\cos\left({\symbf{ω}}_{i}\right)\right)\,\sin\left({\symbf{α}}_{i}\right)-\left(-{K_{\text{c}}}\,{\symbf{W}}_{i}-{\symbf{G}}_{i}+{\symbf{G}}_{i-1}-{\symbf{H}}_{i}+{\symbf{H}}_{i-1}+{\symbf{U}_{\text{g},i}}\,\sin\left({\symbf{β}}_{i}\right)+{\symbf{Q}}_{i}\,\sin\left({\symbf{ω}}_{i}\right)\right)\,\cos\left({\symbf{α}}_{i}\right)=\frac{\left(\left({\symbf{W}}_{i}-{\symbf{X}}_{i-1}+{\symbf{X}}_{i}+{\symbf{U}_{\text{g},i}}\,\cos\left({\symbf{β}}_{i}\right)+{\symbf{Q}}_{i}\,\cos\left({\symbf{ω}}_{i}\right)\right)\,\cos\left({\symbf{α}}_{i}\right)+\left(-{K_{\text{c}}}\,{\symbf{W}}_{i}-{\symbf{G}}_{i}+{\symbf{G}}_{i-1}-{\symbf{H}}_{i}+{\symbf{H}}_{i-1}+{\symbf{U}_{\text{g},i}}\,\sin\left({\symbf{β}}_{i}\right)+{\symbf{Q}}_{i}\,\sin\left({\symbf{ω}}_{i}\right)\right)\,\sin\left({\symbf{α}}_{i}\right)-{\symbf{U}_{\text{b},i}}\right)\,\tan\left(φ'\right)+c'\,{\symbf{L}_{b,i}}}{{F_{\text{S}}}}}{1.0}
 \end{displaymath}
 Since the interslice shear forces $\symbf{X}$ and interslice normal forces $\symbf{G}$ are unknown, they are separated from the other terms as follows:
 
 \begin{displaymath}
-\left({\symbf{W}}_{i}+{\symbf{U}_{\text{g},i}}\,\cos\left({\symbf{β}}_{i}\right)+{\symbf{Q}}_{i}\,\cos\left({\symbf{ω}}_{i}\right)\right)\,\sin\left({\symbf{α}}_{i}\right)-\left(-{K_{\text{c}}}\,{\symbf{W}}_{i}-{\symbf{H}}_{i}+{\symbf{H}}_{i-1}+{\symbf{U}_{\text{g},i}}\,\sin\left({\symbf{β}}_{i}\right)+{\symbf{Q}}_{i}\,\sin\left({\symbf{ω}}_{i}\right)\right)\,\cos\left({\symbf{α}}_{i}\right)-\left(-{\symbf{G}}_{i}+{\symbf{G}}_{i-1}\right)\,\cos\left({\symbf{α}}_{i}\right)+\left(-{\symbf{X}}_{i-1}+{\symbf{X}}_{i}\right)\,\sin\left({\symbf{α}}_{i}\right)=\frac{\left(\left({\symbf{W}}_{i}+{\symbf{U}_{\text{g},i}}\,\cos\left({\symbf{β}}_{i}\right)+{\symbf{Q}}_{i}\,\cos\left({\symbf{ω}}_{i}\right)\right)\,\cos\left({\symbf{α}}_{i}\right)+\left(-{K_{\text{c}}}\,{\symbf{W}}_{i}-{\symbf{H}}_{i}+{\symbf{H}}_{i-1}+{\symbf{U}_{\text{g},i}}\,\sin\left({\symbf{β}}_{i}\right)+{\symbf{Q}}_{i}\,\sin\left({\symbf{ω}}_{i}\right)\right)\,\sin\left({\symbf{α}}_{i}\right)+\left(-{\symbf{G}}_{i}+{\symbf{G}}_{i-1}\right)\,\sin\left({\symbf{α}}_{i}\right)+\left(-{\symbf{X}}_{i-1}+{\symbf{X}}_{i}\right)\,\cos\left({\symbf{α}}_{i}\right)-{\symbf{U}_{\text{b},i}}\right)\,\tan\left(φ'\right)+c'\,{\symbf{L}_{b,i}}}{{F_{\text{S}}}}
+\resizeExpression{\left({\symbf{W}}_{i}+{\symbf{U}_{\text{g},i}}\,\cos\left({\symbf{β}}_{i}\right)+{\symbf{Q}}_{i}\,\cos\left({\symbf{ω}}_{i}\right)\right)\,\sin\left({\symbf{α}}_{i}\right)-\left(-{K_{\text{c}}}\,{\symbf{W}}_{i}-{\symbf{H}}_{i}+{\symbf{H}}_{i-1}+{\symbf{U}_{\text{g},i}}\,\sin\left({\symbf{β}}_{i}\right)+{\symbf{Q}}_{i}\,\sin\left({\symbf{ω}}_{i}\right)\right)\,\cos\left({\symbf{α}}_{i}\right)-\left(-{\symbf{G}}_{i}+{\symbf{G}}_{i-1}\right)\,\cos\left({\symbf{α}}_{i}\right)+\left(-{\symbf{X}}_{i-1}+{\symbf{X}}_{i}\right)\,\sin\left({\symbf{α}}_{i}\right)=\frac{\left(\left({\symbf{W}}_{i}+{\symbf{U}_{\text{g},i}}\,\cos\left({\symbf{β}}_{i}\right)+{\symbf{Q}}_{i}\,\cos\left({\symbf{ω}}_{i}\right)\right)\,\cos\left({\symbf{α}}_{i}\right)+\left(-{K_{\text{c}}}\,{\symbf{W}}_{i}-{\symbf{H}}_{i}+{\symbf{H}}_{i-1}+{\symbf{U}_{\text{g},i}}\,\sin\left({\symbf{β}}_{i}\right)+{\symbf{Q}}_{i}\,\sin\left({\symbf{ω}}_{i}\right)\right)\,\sin\left({\symbf{α}}_{i}\right)+\left(-{\symbf{G}}_{i}+{\symbf{G}}_{i-1}\right)\,\sin\left({\symbf{α}}_{i}\right)+\left(-{\symbf{X}}_{i-1}+{\symbf{X}}_{i}\right)\,\cos\left({\symbf{α}}_{i}\right)-{\symbf{U}_{\text{b},i}}\right)\,\tan\left(φ'\right)+c'\,{\symbf{L}_{b,i}}}{{F_{\text{S}}}}}{1.0}
 \end{displaymath}
 Applying assumptions \hyperref[assumpSF]{A:Seismic-Force} and \hyperref[assumpSL]{A:Surface-Load}, which state that the seismic coefficient and the external forces, respectively, are zero, allows for further simplification as shown below:
 
 \begin{displaymath}
-\left({\symbf{W}}_{i}+{\symbf{U}_{\text{g},i}}\,\cos\left({\symbf{β}}_{i}\right)\right)\,\sin\left({\symbf{α}}_{i}\right)-\left(-{\symbf{H}}_{i}+{\symbf{H}}_{i-1}+{\symbf{U}_{\text{g},i}}\,\sin\left({\symbf{β}}_{i}\right)\right)\,\cos\left({\symbf{α}}_{i}\right)-\left(-{\symbf{G}}_{i}+{\symbf{G}}_{i-1}\right)\,\cos\left({\symbf{α}}_{i}\right)+\left(-{\symbf{X}}_{i-1}+{\symbf{X}}_{i}\right)\,\sin\left({\symbf{α}}_{i}\right)=\frac{\left(\left({\symbf{W}}_{i}+{\symbf{U}_{\text{g},i}}\,\cos\left({\symbf{β}}_{i}\right)\right)\,\cos\left({\symbf{α}}_{i}\right)+\left(-{\symbf{H}}_{i}+{\symbf{H}}_{i-1}+{\symbf{U}_{\text{g},i}}\,\sin\left({\symbf{β}}_{i}\right)\right)\,\sin\left({\symbf{α}}_{i}\right)+\left(-{\symbf{G}}_{i}+{\symbf{G}}_{i-1}\right)\,\sin\left({\symbf{α}}_{i}\right)+\left(-{\symbf{X}}_{i-1}+{\symbf{X}}_{i}\right)\,\cos\left({\symbf{α}}_{i}\right)-{\symbf{U}_{\text{b},i}}\right)\,\tan\left(φ'\right)+c'\,{\symbf{L}_{b,i}}}{{F_{\text{S}}}}
+\resizeExpression{\left({\symbf{W}}_{i}+{\symbf{U}_{\text{g},i}}\,\cos\left({\symbf{β}}_{i}\right)\right)\,\sin\left({\symbf{α}}_{i}\right)-\left(-{\symbf{H}}_{i}+{\symbf{H}}_{i-1}+{\symbf{U}_{\text{g},i}}\,\sin\left({\symbf{β}}_{i}\right)\right)\,\cos\left({\symbf{α}}_{i}\right)-\left(-{\symbf{G}}_{i}+{\symbf{G}}_{i-1}\right)\,\cos\left({\symbf{α}}_{i}\right)+\left(-{\symbf{X}}_{i-1}+{\symbf{X}}_{i}\right)\,\sin\left({\symbf{α}}_{i}\right)=\frac{\left(\left({\symbf{W}}_{i}+{\symbf{U}_{\text{g},i}}\,\cos\left({\symbf{β}}_{i}\right)\right)\,\cos\left({\symbf{α}}_{i}\right)+\left(-{\symbf{H}}_{i}+{\symbf{H}}_{i-1}+{\symbf{U}_{\text{g},i}}\,\sin\left({\symbf{β}}_{i}\right)\right)\,\sin\left({\symbf{α}}_{i}\right)+\left(-{\symbf{G}}_{i}+{\symbf{G}}_{i-1}\right)\,\sin\left({\symbf{α}}_{i}\right)+\left(-{\symbf{X}}_{i-1}+{\symbf{X}}_{i}\right)\,\cos\left({\symbf{α}}_{i}\right)-{\symbf{U}_{\text{b},i}}\right)\,\tan\left(φ'\right)+c'\,{\symbf{L}_{b,i}}}{{F_{\text{S}}}}}{1.0}
 \end{displaymath}
 The definitions of \hyperref[GD:resShearWO]{GD:resShearWO} and \hyperref[GD:mobShearWO]{GD:mobShearWO} are present in this equation, and thus can be replaced by ${\symbf{R}}_{i}$ and ${\symbf{T}}_{i}$, respectively:
 
 \begin{displaymath}
-{\symbf{T}}_{i}+\left(-{\symbf{X}}_{i-1}+{\symbf{X}}_{i}\right)\,\sin\left({\symbf{α}}_{i}\right)-\left(-{\symbf{G}}_{i}+{\symbf{G}}_{i-1}\right)\,\cos\left({\symbf{α}}_{i}\right)=\frac{{\symbf{R}}_{i}+\left(\left(-{\symbf{X}}_{i-1}+{\symbf{X}}_{i}\right)\,\cos\left({\symbf{α}}_{i}\right)+\left(-{\symbf{G}}_{i}+{\symbf{G}}_{i-1}\right)\,\sin\left({\symbf{α}}_{i}\right)\right)\,\tan\left(φ'\right)}{{F_{\text{S}}}}
+\resizeExpression{{\symbf{T}}_{i}+\left(-{\symbf{X}}_{i-1}+{\symbf{X}}_{i}\right)\,\sin\left({\symbf{α}}_{i}\right)-\left(-{\symbf{G}}_{i}+{\symbf{G}}_{i-1}\right)\,\cos\left({\symbf{α}}_{i}\right)=\frac{{\symbf{R}}_{i}+\left(\left(-{\symbf{X}}_{i-1}+{\symbf{X}}_{i}\right)\,\cos\left({\symbf{α}}_{i}\right)+\left(-{\symbf{G}}_{i}+{\symbf{G}}_{i-1}\right)\,\sin\left({\symbf{α}}_{i}\right)\right)\,\tan\left(φ'\right)}{{F_{\text{S}}}}}{1.0}
 \end{displaymath}
 The interslice shear forces $\symbf{X}$ can be expressed in terms of the interslice normal forces $\symbf{G}$ using \hyperref[assumpINSFL]{A:Interslice-Norm-Shear-Forces-Linear} and \hyperref[GD:normShrR]{GD:normShrR}, resulting in:
 
 \begin{displaymath}
-{\symbf{T}}_{i}+\left(-λ\,{\symbf{f}}_{i-1}\,{\symbf{G}}_{i-1}+λ\,{\symbf{f}}_{i}\,{\symbf{G}}_{i}\right)\,\sin\left({\symbf{α}}_{i}\right)-\left(-{\symbf{G}}_{i}+{\symbf{G}}_{i-1}\right)\,\cos\left({\symbf{α}}_{i}\right)=\frac{{\symbf{R}}_{i}+\left(\left(-λ\,{\symbf{f}}_{i-1}\,{\symbf{G}}_{i-1}+λ\,{\symbf{f}}_{i}\,{\symbf{G}}_{i}\right)\,\cos\left({\symbf{α}}_{i}\right)+\left(-{\symbf{G}}_{i}+{\symbf{G}}_{i-1}\right)\,\sin\left({\symbf{α}}_{i}\right)\right)\,\tan\left(φ'\right)}{{F_{\text{S}}}}
+\resizeExpression{{\symbf{T}}_{i}+\left(-λ\,{\symbf{f}}_{i-1}\,{\symbf{G}}_{i-1}+λ\,{\symbf{f}}_{i}\,{\symbf{G}}_{i}\right)\,\sin\left({\symbf{α}}_{i}\right)-\left(-{\symbf{G}}_{i}+{\symbf{G}}_{i-1}\right)\,\cos\left({\symbf{α}}_{i}\right)=\frac{{\symbf{R}}_{i}+\left(\left(-λ\,{\symbf{f}}_{i-1}\,{\symbf{G}}_{i-1}+λ\,{\symbf{f}}_{i}\,{\symbf{G}}_{i}\right)\,\cos\left({\symbf{α}}_{i}\right)+\left(-{\symbf{G}}_{i}+{\symbf{G}}_{i-1}\right)\,\sin\left({\symbf{α}}_{i}\right)\right)\,\tan\left(φ'\right)}{{F_{\text{S}}}}}{1.0}
 \end{displaymath}
 Rearranging yields the following:
 
 \begin{displaymath}
-{\symbf{G}}_{i}\,\left(\left(λ\,{\symbf{f}}_{i}\,\cos\left({\symbf{α}}_{i}\right)-\sin\left({\symbf{α}}_{i}\right)\right)\,\tan\left(φ'\right)-\left(λ\,{\symbf{f}}_{i}\,\sin\left({\symbf{α}}_{i}\right)+\cos\left({\symbf{α}}_{i}\right)\right)\,{F_{\text{S}}}\right)={\symbf{G}}_{i-1}\,\left(\left(λ\,{\symbf{f}}_{i-1}\,\cos\left({\symbf{α}}_{i}\right)-\sin\left({\symbf{α}}_{i}\right)\right)\,\tan\left(φ'\right)-\left(λ\,{\symbf{f}}_{i-1}\,\sin\left({\symbf{α}}_{i}\right)+\cos\left({\symbf{α}}_{i}\right)\right)\,{F_{\text{S}}}\right)+{F_{\text{S}}}\,{\symbf{T}}_{i}-{\symbf{R}}_{i}
+\resizeExpression{{\symbf{G}}_{i}\,\left(\left(λ\,{\symbf{f}}_{i}\,\cos\left({\symbf{α}}_{i}\right)-\sin\left({\symbf{α}}_{i}\right)\right)\,\tan\left(φ'\right)-\left(λ\,{\symbf{f}}_{i}\,\sin\left({\symbf{α}}_{i}\right)+\cos\left({\symbf{α}}_{i}\right)\right)\,{F_{\text{S}}}\right)={\symbf{G}}_{i-1}\,\left(\left(λ\,{\symbf{f}}_{i-1}\,\cos\left({\symbf{α}}_{i}\right)-\sin\left({\symbf{α}}_{i}\right)\right)\,\tan\left(φ'\right)-\left(λ\,{\symbf{f}}_{i-1}\,\sin\left({\symbf{α}}_{i}\right)+\cos\left({\symbf{α}}_{i}\right)\right)\,{F_{\text{S}}}\right)+{F_{\text{S}}}\,{\symbf{T}}_{i}-{\symbf{R}}_{i}}{1.0}
 \end{displaymath}
 The definitions for $\symbf{Φ}$ and $\symbf{Ψ}$ from \hyperref[DD:convertFunc1]{DD:convertFunc1} and \hyperref[DD:convertFunc2]{DD:convertFunc2} simplify the above to Equation (3):
 
 \begin{displaymath}
-{\symbf{G}}_{i}\,{\symbf{Φ}}_{i}={\symbf{Ψ}}_{i-1}\,{\symbf{G}}_{i-1}\,{\symbf{Φ}}_{i-1}+{F_{\text{S}}}\,{\symbf{T}}_{i}-{\symbf{R}}_{i}
+\resizeExpression{{\symbf{G}}_{i}\,{\symbf{Φ}}_{i}={\symbf{Ψ}}_{i-1}\,{\symbf{G}}_{i-1}\,{\symbf{Φ}}_{i-1}+{F_{\text{S}}}\,{\symbf{T}}_{i}-{\symbf{R}}_{i}}{1.0}
 \end{displaymath}
 Versions of Equation (3) instantiated for slices 1 to $n$ are shown below:
 
 \begin{displaymath}
-{\symbf{G}}_{1}\,{\symbf{Φ}}_{1}={\symbf{Ψ}}_{0}\,{\symbf{G}}_{0}\,{\symbf{Φ}}_{0}+{F_{\text{S}}}\,{\symbf{T}}_{1}-{\symbf{R}}_{1}
+\resizeExpression{{\symbf{G}}_{1}\,{\symbf{Φ}}_{1}={\symbf{Ψ}}_{0}\,{\symbf{G}}_{0}\,{\symbf{Φ}}_{0}+{F_{\text{S}}}\,{\symbf{T}}_{1}-{\symbf{R}}_{1}}{1.0}
 \end{displaymath}
 \begin{displaymath}
-{\symbf{G}}_{2}\,{\symbf{Φ}}_{2}={\symbf{Ψ}}_{1}\,{\symbf{G}}_{1}\,{\symbf{Φ}}_{1}+{F_{\text{S}}}\,{\symbf{T}}_{2}-{\symbf{R}}_{2}
+\resizeExpression{{\symbf{G}}_{2}\,{\symbf{Φ}}_{2}={\symbf{Ψ}}_{1}\,{\symbf{G}}_{1}\,{\symbf{Φ}}_{1}+{F_{\text{S}}}\,{\symbf{T}}_{2}-{\symbf{R}}_{2}}{1.0}
 \end{displaymath}
 \begin{displaymath}
-{\symbf{G}}_{3}\,{\symbf{Φ}}_{3}={\symbf{Ψ}}_{2}\,{\symbf{G}}_{2}\,{\symbf{Φ}}_{2}+{F_{\text{S}}}\,{\symbf{T}}_{3}-{\symbf{R}}_{3}
+\resizeExpression{{\symbf{G}}_{3}\,{\symbf{Φ}}_{3}={\symbf{Ψ}}_{2}\,{\symbf{G}}_{2}\,{\symbf{Φ}}_{2}+{F_{\text{S}}}\,{\symbf{T}}_{3}-{\symbf{R}}_{3}}{1.0}
 \end{displaymath}
 ...
 
 \begin{displaymath}
-{\symbf{G}}_{n-2}\,{\symbf{Φ}}_{n-2}={\symbf{Ψ}}_{n-3}\,{\symbf{G}}_{n-3}\,{\symbf{Φ}}_{n-3}+{F_{\text{S}}}\,{\symbf{T}}_{n-2}-{\symbf{R}}_{n-2}
+\resizeExpression{{\symbf{G}}_{n-2}\,{\symbf{Φ}}_{n-2}={\symbf{Ψ}}_{n-3}\,{\symbf{G}}_{n-3}\,{\symbf{Φ}}_{n-3}+{F_{\text{S}}}\,{\symbf{T}}_{n-2}-{\symbf{R}}_{n-2}}{1.0}
 \end{displaymath}
 \begin{displaymath}
-{\symbf{G}}_{n-1}\,{\symbf{Φ}}_{n-1}={\symbf{Ψ}}_{n-2}\,{\symbf{G}}_{n-2}\,{\symbf{Φ}}_{n-2}+{F_{\text{S}}}\,{\symbf{T}}_{n-1}-{\symbf{R}}_{n-1}
+\resizeExpression{{\symbf{G}}_{n-1}\,{\symbf{Φ}}_{n-1}={\symbf{Ψ}}_{n-2}\,{\symbf{G}}_{n-2}\,{\symbf{Φ}}_{n-2}+{F_{\text{S}}}\,{\symbf{T}}_{n-1}-{\symbf{R}}_{n-1}}{1.0}
 \end{displaymath}
 \begin{displaymath}
-{\symbf{G}}_{n}\,{\symbf{Φ}}_{n}={\symbf{Ψ}}_{n-1}\,{\symbf{G}}_{n-1}\,{\symbf{Φ}}_{n-1}+{F_{\text{S}}}\,{\symbf{T}}_{n}-{\symbf{R}}_{n}
+\resizeExpression{{\symbf{G}}_{n}\,{\symbf{Φ}}_{n}={\symbf{Ψ}}_{n-1}\,{\symbf{G}}_{n-1}\,{\symbf{Φ}}_{n-1}+{F_{\text{S}}}\,{\symbf{T}}_{n}-{\symbf{R}}_{n}}{1.0}
 \end{displaymath}
 Applying \hyperref[assumpES]{A:Edge-Slices}, which says that ${\symbf{G}}_{0}$ and ${\symbf{G}}_{n}$ are zero, results in the following special cases: Equation (8) for the first slice:
 
 \begin{displaymath}
-{\symbf{G}}_{1}\,{\symbf{Φ}}_{1}={F_{\text{S}}}\,{\symbf{T}}_{1}-{\symbf{R}}_{1}
+\resizeExpression{{\symbf{G}}_{1}\,{\symbf{Φ}}_{1}={F_{\text{S}}}\,{\symbf{T}}_{1}-{\symbf{R}}_{1}}{1.0}
 \end{displaymath}
 and Equation (9) for the $n$th slice:
 
 \begin{displaymath}
--\left(\frac{{F_{\text{S}}}\,{\symbf{T}}_{n}-{\symbf{R}}_{n}}{{\symbf{Ψ}}_{n-1}}\right)={\symbf{G}}_{n-1}\,{\symbf{Φ}}_{n-1}
+\resizeExpression{-\left(\frac{{F_{\text{S}}}\,{\symbf{T}}_{n}-{\symbf{R}}_{n}}{{\symbf{Ψ}}_{n-1}}\right)={\symbf{G}}_{n-1}\,{\symbf{Φ}}_{n-1}}{1.0}
 \end{displaymath}
 Substituting Equation (8) into Equation (4) yields Equation (10):
 
 \begin{displaymath}
-{\symbf{G}}_{2}\,{\symbf{Φ}}_{2}={\symbf{Ψ}}_{1}\,\left({F_{\text{S}}}\,{\symbf{T}}_{1}-{\symbf{R}}_{1}\right)+{F_{\text{S}}}\,{\symbf{T}}_{2}-{\symbf{R}}_{2}
+\resizeExpression{{\symbf{G}}_{2}\,{\symbf{Φ}}_{2}={\symbf{Ψ}}_{1}\,\left({F_{\text{S}}}\,{\symbf{T}}_{1}-{\symbf{R}}_{1}\right)+{F_{\text{S}}}\,{\symbf{T}}_{2}-{\symbf{R}}_{2}}{1.0}
 \end{displaymath}
 which can be substituted into Equation (5) to get Equation (11):
 
 \begin{displaymath}
-{\symbf{G}}_{3}\,{\symbf{Φ}}_{3}={\symbf{Ψ}}_{2}\,\left({\symbf{Ψ}}_{1}\,\left({F_{\text{S}}}\,{\symbf{T}}_{1}-{\symbf{R}}_{1}\right)+{F_{\text{S}}}\,{\symbf{T}}_{2}-{\symbf{R}}_{2}\right)+{F_{\text{S}}}\,{\symbf{T}}_{3}-{\symbf{R}}_{3}
+\resizeExpression{{\symbf{G}}_{3}\,{\symbf{Φ}}_{3}={\symbf{Ψ}}_{2}\,\left({\symbf{Ψ}}_{1}\,\left({F_{\text{S}}}\,{\symbf{T}}_{1}-{\symbf{R}}_{1}\right)+{F_{\text{S}}}\,{\symbf{T}}_{2}-{\symbf{R}}_{2}\right)+{F_{\text{S}}}\,{\symbf{T}}_{3}-{\symbf{R}}_{3}}{1.0}
 \end{displaymath}
 and so on until Equation (12) is obtained from Equation (7):
 
 \begin{displaymath}
-{\symbf{G}}_{n-1}\,{\symbf{Φ}}_{n-1}={\symbf{Ψ}}_{n-2}\,\left({\symbf{Ψ}}_{n-3}\,\left({\symbf{Ψ}}_{1}\,\left({F_{\text{S}}}\,{\symbf{T}}_{1}-{\symbf{R}}_{1}\right)+{F_{\text{S}}}\,{\symbf{T}}_{2}-{\symbf{R}}_{2}\right)+{F_{\text{S}}}\,{\symbf{T}}_{n-2}-{\symbf{R}}_{n-2}\right)+{F_{\text{S}}}\,{\symbf{T}}_{n-1}-{\symbf{R}}_{n-1}
+\resizeExpression{{\symbf{G}}_{n-1}\,{\symbf{Φ}}_{n-1}={\symbf{Ψ}}_{n-2}\,\left({\symbf{Ψ}}_{n-3}\,\left({\symbf{Ψ}}_{1}\,\left({F_{\text{S}}}\,{\symbf{T}}_{1}-{\symbf{R}}_{1}\right)+{F_{\text{S}}}\,{\symbf{T}}_{2}-{\symbf{R}}_{2}\right)+{F_{\text{S}}}\,{\symbf{T}}_{n-2}-{\symbf{R}}_{n-2}\right)+{F_{\text{S}}}\,{\symbf{T}}_{n-1}-{\symbf{R}}_{n-1}}{1.0}
 \end{displaymath}
 Equation (9) can then be substituted into the left-hand side of Equation (12), resulting in:
 
 \begin{displaymath}
--\left(\frac{{F_{\text{S}}}\,{\symbf{T}}_{n}-{\symbf{R}}_{n}}{{\symbf{Ψ}}_{n-1}}\right)={\symbf{Ψ}}_{n-2}\,\left({\symbf{Ψ}}_{n-3}\,\left({\symbf{Ψ}}_{1}\,\left({F_{\text{S}}}\,{\symbf{T}}_{1}-{\symbf{R}}_{1}\right)+{F_{\text{S}}}\,{\symbf{T}}_{2}-{\symbf{R}}_{2}\right)+{F_{\text{S}}}\,{\symbf{T}}_{n-2}-{\symbf{R}}_{n-2}\right)+{F_{\text{S}}}\,{\symbf{T}}_{n-1}-{\symbf{R}}_{n-1}
+\resizeExpression{-\left(\frac{{F_{\text{S}}}\,{\symbf{T}}_{n}-{\symbf{R}}_{n}}{{\symbf{Ψ}}_{n-1}}\right)={\symbf{Ψ}}_{n-2}\,\left({\symbf{Ψ}}_{n-3}\,\left({\symbf{Ψ}}_{1}\,\left({F_{\text{S}}}\,{\symbf{T}}_{1}-{\symbf{R}}_{1}\right)+{F_{\text{S}}}\,{\symbf{T}}_{2}-{\symbf{R}}_{2}\right)+{F_{\text{S}}}\,{\symbf{T}}_{n-2}-{\symbf{R}}_{n-2}\right)+{F_{\text{S}}}\,{\symbf{T}}_{n-1}-{\symbf{R}}_{n-1}}{1.0}
 \end{displaymath}
 This can be rearranged by multiplying both sides by ${\symbf{Ψ}}_{n-1}$ and then distributing the multiplication of each $\symbf{Ψ}$ over addition to obtain:
 
 \begin{displaymath}
--\left({F_{\text{S}}}\,{\symbf{T}}_{n}-{\symbf{R}}_{n}\right)={\symbf{Ψ}}_{n-1}\,{\symbf{Ψ}}_{n-2}\,{\symbf{Ψ}}_{1}\,\left({F_{\text{S}}}\,{\symbf{T}}_{1}-{\symbf{R}}_{1}\right)+{\symbf{Ψ}}_{n-1}\,{\symbf{Ψ}}_{n-2}\,{\symbf{Ψ}}_{2}\,\left({F_{\text{S}}}\,{\symbf{T}}_{2}-{\symbf{R}}_{2}\right)+{\symbf{Ψ}}_{n-1}\,\left({F_{\text{S}}}\,{\symbf{T}}_{n-1}-{\symbf{R}}_{n-1}\right)
+\resizeExpression{-\left({F_{\text{S}}}\,{\symbf{T}}_{n}-{\symbf{R}}_{n}\right)={\symbf{Ψ}}_{n-1}\,{\symbf{Ψ}}_{n-2}\,{\symbf{Ψ}}_{1}\,\left({F_{\text{S}}}\,{\symbf{T}}_{1}-{\symbf{R}}_{1}\right)+{\symbf{Ψ}}_{n-1}\,{\symbf{Ψ}}_{n-2}\,{\symbf{Ψ}}_{2}\,\left({F_{\text{S}}}\,{\symbf{T}}_{2}-{\symbf{R}}_{2}\right)+{\symbf{Ψ}}_{n-1}\,\left({F_{\text{S}}}\,{\symbf{T}}_{n-1}-{\symbf{R}}_{n-1}\right)}{1.0}
 \end{displaymath}
 The multiplication of the $\symbf{Ψ}$ terms can be further distributed over the subtractions, resulting in the equation having terms that each either contain an $\symbf{R}$ or a $\symbf{T}$. The equation can then be rearranged so terms containing an $\symbf{R}$ are on one side of the equality, and terms containing a $\symbf{T}$ are on the other. The multiplication by the factor of safety is common to all of the $\symbf{T}$ terms, and thus can be factored out, resulting in:
 
 \begin{displaymath}
-{F_{\text{S}}}\,\left({\symbf{Ψ}}_{n-1}\,{\symbf{Ψ}}_{n-2}\,{\symbf{Ψ}}_{1}\,{\symbf{T}}_{1}+{\symbf{Ψ}}_{n-1}\,{\symbf{Ψ}}_{n-2}\,{\symbf{Ψ}}_{2}\,{\symbf{T}}_{2}+{\symbf{Ψ}}_{n-1}\,{\symbf{T}}_{n-1}+{\symbf{T}}_{n}\right)={\symbf{Ψ}}_{n-1}\,{\symbf{Ψ}}_{n-2}\,{\symbf{Ψ}}_{1}\,{\symbf{R}}_{1}+{\symbf{Ψ}}_{n-1}\,{\symbf{Ψ}}_{n-2}\,{\symbf{Ψ}}_{2}\,{\symbf{R}}_{2}+{\symbf{Ψ}}_{n-1}\,{\symbf{R}}_{n-1}+{\symbf{R}}_{n}
+\resizeExpression{{F_{\text{S}}}\,\left({\symbf{Ψ}}_{n-1}\,{\symbf{Ψ}}_{n-2}\,{\symbf{Ψ}}_{1}\,{\symbf{T}}_{1}+{\symbf{Ψ}}_{n-1}\,{\symbf{Ψ}}_{n-2}\,{\symbf{Ψ}}_{2}\,{\symbf{T}}_{2}+{\symbf{Ψ}}_{n-1}\,{\symbf{T}}_{n-1}+{\symbf{T}}_{n}\right)={\symbf{Ψ}}_{n-1}\,{\symbf{Ψ}}_{n-2}\,{\symbf{Ψ}}_{1}\,{\symbf{R}}_{1}+{\symbf{Ψ}}_{n-1}\,{\symbf{Ψ}}_{n-2}\,{\symbf{Ψ}}_{2}\,{\symbf{R}}_{2}+{\symbf{Ψ}}_{n-1}\,{\symbf{R}}_{n-1}+{\symbf{R}}_{n}}{1.0}
 \end{displaymath}
 Isolating the factor of safety on the left-hand side and using compact notation for the products and sums yields Equation (13), which can also be seen in \hyperref[IM:fctSfty]{IM:fctSfty}:
 
 \begin{displaymath}
-{F_{\text{S}}}=\frac{\displaystyle\sum_{i=1}^{n-1}{{\symbf{R}}_{i}\,\displaystyle\prod_{v=i}^{n-1}{{\symbf{Ψ}}_{v}}}+{\symbf{R}}_{n}}{\displaystyle\sum_{i=1}^{n-1}{{\symbf{T}}_{i}\,\displaystyle\prod_{v=i}^{n-1}{{\symbf{Ψ}}_{v}}}+{\symbf{T}}_{n}}
+\resizeExpression{{F_{\text{S}}}=\frac{\displaystyle\sum_{i=1}^{n-1}{{\symbf{R}}_{i}\,\displaystyle\prod_{v=i}^{n-1}{{\symbf{Ψ}}_{v}}}+{\symbf{R}}_{n}}{\displaystyle\sum_{i=1}^{n-1}{{\symbf{T}}_{i}\,\displaystyle\prod_{v=i}^{n-1}{{\symbf{Ψ}}_{v}}}+{\symbf{T}}_{n}}}{1.0}
 \end{displaymath}
 ${F_{\text{S}}}$ depends on the unknowns $λ$ (\hyperref[IM:nrmShrFor]{IM:nrmShrFor}) and $\symbf{G}$ (\hyperref[IM:intsliceFs]{IM:intsliceFs}).
 
@@ -2258,7 +2269,7 @@ Input Constraints &
 Output Constraints & 
 \\ \midrule
 Equation & \begin{displaymath}
-           λ=\frac{\displaystyle\sum_{i=1}^{n}{{\symbf{C}_{\text{num},i}}}}{\displaystyle\sum_{i=1}^{n}{{\symbf{C}_{\text{den},i}}}}
+           \resizeExpression{λ=\frac{\displaystyle\sum_{i=1}^{n}{{\symbf{C}_{\text{num},i}}}}{\displaystyle\sum_{i=1}^{n}{{\symbf{C}_{\text{den},i}}}}}{0.8}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -2285,22 +2296,22 @@ RefBy & \hyperref[IM:nrmShrForNum]{IM:nrmShrForNum}, \hyperref[IM:nrmShrForDen]{
 From the moment equilibrium of \hyperref[GD:momentEql]{GD:momentEql} with the primary assumption for the Morgenstern-Price method of \hyperref[assumpINSFL]{A:Interslice-Norm-Shear-Forces-Linear} and associated definition \hyperref[GD:normShrR]{GD:normShrR}, Equation (14) can be derived:
 
 \begin{displaymath}
-0=-{\symbf{G}}_{i}\,\left({\symbf{h}_{\text{z},i}}+\frac{{\symbf{b}}_{i}}{2}\,\tan\left({\symbf{α}}_{i}\right)\right)+{\symbf{G}}_{i-1}\,\left({\symbf{h}_{\text{z},i-1}}-\frac{{\symbf{b}}_{i}}{2}\,\tan\left({\symbf{α}}_{i}\right)\right)-{\symbf{H}}_{i}\,\left(\frac{1}{3}\,{\symbf{h}_{\text{z,w},i}}+\frac{{\symbf{b}}_{i}}{2}\,\tan\left({\symbf{α}}_{i}\right)\right)+{\symbf{H}}_{i-1}\,\left(\frac{1}{3}\,{\symbf{h}_{\text{z,w},i-1}}-\frac{{\symbf{b}}_{i}}{2}\,\tan\left({\symbf{α}}_{i}\right)\right)+λ\,\frac{{\symbf{b}}_{i}}{2}\,\left({\symbf{G}}_{i}\,{\symbf{f}}_{i}+{\symbf{G}}_{i-1}\,{\symbf{f}}_{i-1}\right)+\frac{-{K_{\text{c}}}\,{\symbf{W}}_{i}\,{\symbf{h}}_{i}}{2}+{\symbf{U}_{\text{g},i}}\,\sin\left({\symbf{β}}_{i}\right)\,{\symbf{h}}_{i}+{\symbf{Q}}_{i}\,\sin\left({\symbf{ω}}_{i}\right)\,{\symbf{h}}_{i}
+\resizeExpression{0=-{\symbf{G}}_{i}\,\left({\symbf{h}_{\text{z},i}}+\frac{{\symbf{b}}_{i}}{2}\,\tan\left({\symbf{α}}_{i}\right)\right)+{\symbf{G}}_{i-1}\,\left({\symbf{h}_{\text{z},i-1}}-\frac{{\symbf{b}}_{i}}{2}\,\tan\left({\symbf{α}}_{i}\right)\right)-{\symbf{H}}_{i}\,\left(\frac{1}{3}\,{\symbf{h}_{\text{z,w},i}}+\frac{{\symbf{b}}_{i}}{2}\,\tan\left({\symbf{α}}_{i}\right)\right)+{\symbf{H}}_{i-1}\,\left(\frac{1}{3}\,{\symbf{h}_{\text{z,w},i-1}}-\frac{{\symbf{b}}_{i}}{2}\,\tan\left({\symbf{α}}_{i}\right)\right)+λ\,\frac{{\symbf{b}}_{i}}{2}\,\left({\symbf{G}}_{i}\,{\symbf{f}}_{i}+{\symbf{G}}_{i-1}\,{\symbf{f}}_{i-1}\right)+\frac{-{K_{\text{c}}}\,{\symbf{W}}_{i}\,{\symbf{h}}_{i}}{2}+{\symbf{U}_{\text{g},i}}\,\sin\left({\symbf{β}}_{i}\right)\,{\symbf{h}}_{i}+{\symbf{Q}}_{i}\,\sin\left({\symbf{ω}}_{i}\right)\,{\symbf{h}}_{i}}{1.0}
 \end{displaymath}
 Rearranging the equation in terms of $λ$ leads to Equation (15):
 
 \begin{displaymath}
-λ=\frac{-{\symbf{G}}_{i}\,\left({\symbf{h}_{\text{z},i}}+\frac{{\symbf{b}}_{i}}{2}\,\tan\left({\symbf{α}}_{i}\right)\right)+{\symbf{G}}_{i-1}\,\left({\symbf{h}_{\text{z},i-1}}-\frac{{\symbf{b}}_{i}}{2}\,\tan\left({\symbf{α}}_{i}\right)\right)-{\symbf{H}}_{i}\,\left(\frac{1}{3}\,{\symbf{h}_{\text{z,w},i}}+\frac{{\symbf{b}}_{i}}{2}\,\tan\left({\symbf{α}}_{i}\right)\right)+{\symbf{H}}_{i-1}\,\left(\frac{1}{3}\,{\symbf{h}_{\text{z,w},i-1}}-\frac{{\symbf{b}}_{i}}{2}\,\tan\left({\symbf{α}}_{i}\right)\right)+\frac{-{K_{\text{c}}}\,{\symbf{W}}_{i}\,{\symbf{h}}_{i}}{2}+{\symbf{U}_{\text{g},i}}\,\sin\left({\symbf{β}}_{i}\right)\,{\symbf{h}}_{i}+{\symbf{Q}}_{i}\,\sin\left({\symbf{ω}}_{i}\right)\,{\symbf{h}}_{i}}{-\frac{{\symbf{b}}_{i}}{2}\,\left({\symbf{G}}_{i}\,{\symbf{f}}_{i}+{\symbf{G}}_{i-1}\,{\symbf{f}}_{i-1}\right)}
+\resizeExpression{λ=\frac{-{\symbf{G}}_{i}\,\left({\symbf{h}_{\text{z},i}}+\frac{{\symbf{b}}_{i}}{2}\,\tan\left({\symbf{α}}_{i}\right)\right)+{\symbf{G}}_{i-1}\,\left({\symbf{h}_{\text{z},i-1}}-\frac{{\symbf{b}}_{i}}{2}\,\tan\left({\symbf{α}}_{i}\right)\right)-{\symbf{H}}_{i}\,\left(\frac{1}{3}\,{\symbf{h}_{\text{z,w},i}}+\frac{{\symbf{b}}_{i}}{2}\,\tan\left({\symbf{α}}_{i}\right)\right)+{\symbf{H}}_{i-1}\,\left(\frac{1}{3}\,{\symbf{h}_{\text{z,w},i-1}}-\frac{{\symbf{b}}_{i}}{2}\,\tan\left({\symbf{α}}_{i}\right)\right)+\frac{-{K_{\text{c}}}\,{\symbf{W}}_{i}\,{\symbf{h}}_{i}}{2}+{\symbf{U}_{\text{g},i}}\,\sin\left({\symbf{β}}_{i}\right)\,{\symbf{h}}_{i}+{\symbf{Q}}_{i}\,\sin\left({\symbf{ω}}_{i}\right)\,{\symbf{h}}_{i}}{-\frac{{\symbf{b}}_{i}}{2}\,\left({\symbf{G}}_{i}\,{\symbf{f}}_{i}+{\symbf{G}}_{i-1}\,{\symbf{f}}_{i-1}\right)}}{1.0}
 \end{displaymath}
 This equation can be simplified by applying assumptions \hyperref[assumpSF]{A:Seismic-Force} and \hyperref[assumpSL]{A:Surface-Load}, which state that the seismic and external forces, respectively, are zero:
 
 \begin{displaymath}
-λ=\frac{-{\symbf{G}}_{i}\,\left({\symbf{h}_{\text{z},i}}+\frac{{\symbf{b}}_{i}}{2}\,\tan\left({\symbf{α}}_{i}\right)\right)+{\symbf{G}}_{i-1}\,\left({\symbf{h}_{\text{z},i-1}}-\frac{{\symbf{b}}_{i}}{2}\,\tan\left({\symbf{α}}_{i}\right)\right)-{\symbf{H}}_{i}\,\left(\frac{1}{3}\,{\symbf{h}_{\text{z,w},i}}+\frac{{\symbf{b}}_{i}}{2}\,\tan\left({\symbf{α}}_{i}\right)\right)+{\symbf{H}}_{i-1}\,\left(\frac{1}{3}\,{\symbf{h}_{\text{z,w},i-1}}-\frac{{\symbf{b}}_{i}}{2}\,\tan\left({\symbf{α}}_{i}\right)\right)+{\symbf{U}_{\text{g},i}}\,\sin\left({\symbf{β}}_{i}\right)\,{\symbf{h}}_{i}}{-\frac{{\symbf{b}}_{i}}{2}\,\left({\symbf{G}}_{i}\,{\symbf{f}}_{i}+{\symbf{G}}_{i-1}\,{\symbf{f}}_{i-1}\right)}
+\resizeExpression{λ=\frac{-{\symbf{G}}_{i}\,\left({\symbf{h}_{\text{z},i}}+\frac{{\symbf{b}}_{i}}{2}\,\tan\left({\symbf{α}}_{i}\right)\right)+{\symbf{G}}_{i-1}\,\left({\symbf{h}_{\text{z},i-1}}-\frac{{\symbf{b}}_{i}}{2}\,\tan\left({\symbf{α}}_{i}\right)\right)-{\symbf{H}}_{i}\,\left(\frac{1}{3}\,{\symbf{h}_{\text{z,w},i}}+\frac{{\symbf{b}}_{i}}{2}\,\tan\left({\symbf{α}}_{i}\right)\right)+{\symbf{H}}_{i-1}\,\left(\frac{1}{3}\,{\symbf{h}_{\text{z,w},i-1}}-\frac{{\symbf{b}}_{i}}{2}\,\tan\left({\symbf{α}}_{i}\right)\right)+{\symbf{U}_{\text{g},i}}\,\sin\left({\symbf{β}}_{i}\right)\,{\symbf{h}}_{i}}{-\frac{{\symbf{b}}_{i}}{2}\,\left({\symbf{G}}_{i}\,{\symbf{f}}_{i}+{\symbf{G}}_{i-1}\,{\symbf{f}}_{i-1}\right)}}{1.0}
 \end{displaymath}
 Taking the summation of all slices, and applying \hyperref[assumpES]{A:Edge-Slices} to set ${\symbf{G}}_{0}$, ${\symbf{G}}_{n}$, ${\symbf{H}}_{0}$, and ${\symbf{H}}_{n}$ equal to zero, a general equation for the proportionality constant $λ$ is developed in Equation (16), which combines \hyperref[IM:nrmShrFor]{IM:nrmShrFor}, \hyperref[IM:nrmShrForNum]{IM:nrmShrForNum}, and \hyperref[IM:nrmShrForDen]{IM:nrmShrForDen}:
 
 \begin{displaymath}
-λ=\frac{\displaystyle\sum_{i=1}^{n}{{\symbf{b}}_{i}\,\left({{\symbf{F}_{\text{x}}}^{\text{G}}}+{{\symbf{F}_{\text{x}}}^{\text{H}}}\right)\,\tan\left({\symbf{α}}_{i}\right)+{\symbf{h}}_{i}\,-2\,{\symbf{U}_{\text{g},i}}\,\sin\left({\symbf{β}}_{i}\right)}}{\displaystyle\sum_{i=1}^{n}{{\symbf{b}}_{i}\,\left({\symbf{G}}_{i}\,{\symbf{f}}_{i}+{\symbf{G}}_{i-1}\,{\symbf{f}}_{i-1}\right)}}
+\resizeExpression{λ=\frac{\displaystyle\sum_{i=1}^{n}{{\symbf{b}}_{i}\,\left({{\symbf{F}_{\text{x}}}^{\text{G}}}+{{\symbf{F}_{\text{x}}}^{\text{H}}}\right)\,\tan\left({\symbf{α}}_{i}\right)+{\symbf{h}}_{i}\,-2\,{\symbf{U}_{\text{g},i}}\,\sin\left({\symbf{β}}_{i}\right)}}{\displaystyle\sum_{i=1}^{n}{{\symbf{b}}_{i}\,\left({\symbf{G}}_{i}\,{\symbf{f}}_{i}+{\symbf{G}}_{i-1}\,{\symbf{f}}_{i-1}\right)}}}{1.0}
 \end{displaymath}
 Equation (16) for $λ$ is a function of the unknown interslice normal forces $\symbf{G}$ (\hyperref[IM:intsliceFs]{IM:intsliceFs}) which itself depends on the unknown factor of safety ${F_{\text{S}}}$ (\hyperref[IM:fctSfty]{IM:fctSfty}).
 
@@ -2326,11 +2337,11 @@ Input Constraints &
 Output Constraints & 
 \\ \midrule
 Equation & \begin{displaymath}
-           {\symbf{C}_{\text{num},i}}=\begin{cases}
-                                      {\symbf{b}}_{1}\,\left({\symbf{G}}_{1}+{\symbf{H}}_{1}\right)\,\tan\left({\symbf{α}}_{1}\right), & i=1\\
-                                      {\symbf{b}}_{i}\,\left({{\symbf{F}_{\text{x}}}^{\text{G}}}+{{\symbf{F}_{\text{x}}}^{\text{H}}}\right)\,\tan\left({\symbf{α}}_{i}\right)+\symbf{h}\,-2\,{\symbf{U}_{\text{g},i}}\,\sin\left({\symbf{β}}_{i}\right), & 2\leq{}i\leq{}n-1\\
-                                      {\symbf{b}}_{n}\,\left({\symbf{G}}_{n-1}+{\symbf{H}}_{n-1}\right)\,\tan\left({\symbf{α}}_{n-1}\right), & i=n
-                                      \end{cases}
+           \resizeExpression{{\symbf{C}_{\text{num},i}}=\begin{cases}
+                                                        {\symbf{b}}_{1}\,\left({\symbf{G}}_{1}+{\symbf{H}}_{1}\right)\,\tan\left({\symbf{α}}_{1}\right), & i=1\\
+                                                        {\symbf{b}}_{i}\,\left({{\symbf{F}_{\text{x}}}^{\text{G}}}+{{\symbf{F}_{\text{x}}}^{\text{H}}}\right)\,\tan\left({\symbf{α}}_{i}\right)+\symbf{h}\,-2\,{\symbf{U}_{\text{g},i}}\,\sin\left({\symbf{β}}_{i}\right), & 2\leq{}i\leq{}n-1\\
+                                                        {\symbf{b}}_{n}\,\left({\symbf{G}}_{n-1}+{\symbf{H}}_{n-1}\right)\,\tan\left({\symbf{α}}_{n-1}\right), & i=n
+                                                        \end{cases}}{0.8}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -2386,11 +2397,11 @@ Input Constraints &
 Output Constraints & 
 \\ \midrule
 Equation & \begin{displaymath}
-           {\symbf{C}_{\text{den},i}}=\begin{cases}
-                                      {\symbf{b}}_{1}\,{\symbf{f}}_{1}\,{\symbf{G}}_{1}, & i=1\\
-                                      {\symbf{b}}_{i}\,\left({\symbf{f}}_{i}\,{\symbf{G}}_{i}+{\symbf{f}}_{i-1}\,{\symbf{G}}_{i-1}\right), & 2\leq{}i\leq{}n-1\\
-                                      {\symbf{b}}_{n}\,{\symbf{G}}_{n-1}\,{\symbf{f}}_{n-1}, & i=n
-                                      \end{cases}
+           \resizeExpression{{\symbf{C}_{\text{den},i}}=\begin{cases}
+                                                        {\symbf{b}}_{1}\,{\symbf{f}}_{1}\,{\symbf{G}}_{1}, & i=1\\
+                                                        {\symbf{b}}_{i}\,\left({\symbf{f}}_{i}\,{\symbf{G}}_{i}+{\symbf{f}}_{i-1}\,{\symbf{G}}_{i-1}\right), & 2\leq{}i\leq{}n-1\\
+                                                        {\symbf{b}}_{n}\,{\symbf{G}}_{n-1}\,{\symbf{f}}_{n-1}, & i=n
+                                                        \end{cases}}{0.8}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -2440,11 +2451,11 @@ Input Constraints &
 Output Constraints & 
 \\ \midrule
 Equation & \begin{displaymath}
-           {\symbf{G}}_{i}=\begin{cases}
-                           \frac{{F_{\text{S}}}\,{\symbf{T}}_{1}-{\symbf{R}}_{1}}{{\symbf{Φ}}_{1}}, & i=1\\
-                           \frac{{\symbf{Ψ}}_{i-1}\,{\symbf{G}}_{i-1}+{F_{\text{S}}}\,{\symbf{T}}_{i}-{\symbf{R}}_{i}}{{\symbf{Φ}}_{i}}, & 2\leq{}i\leq{}n-1\\
-                           0, & i=0\lor{}i=n
-                           \end{cases}
+           \resizeExpression{{\symbf{G}}_{i}=\begin{cases}
+                                             \frac{{F_{\text{S}}}\,{\symbf{T}}_{1}-{\symbf{R}}_{1}}{{\symbf{Φ}}_{1}}, & i=1\\
+                                             \frac{{\symbf{Ψ}}_{i-1}\,{\symbf{G}}_{i-1}+{F_{\text{S}}}\,{\symbf{T}}_{i}-{\symbf{R}}_{i}}{{\symbf{Φ}}_{i}}, & 2\leq{}i\leq{}n-1\\
+                                             0, & i=0\lor{}i=n
+                                             \end{cases}}{0.8}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -2475,12 +2486,12 @@ RefBy & \hyperref[IM:intsliceFs]{IM:intsliceFs}, \hyperref[IM:fctSfty]{IM:fctSft
 This derivation is identical to the derivation for \hyperref[IM:fctSfty]{IM:fctSfty} up until Equation (3) shown again below:
 
 \begin{displaymath}
-{\symbf{G}}_{i}\,{\symbf{Φ}}_{i}={\symbf{Ψ}}_{i-1}\,{\symbf{G}}_{i-1}\,{\symbf{Φ}}_{i-1}+{F_{\text{S}}}\,{\symbf{T}}_{i}-{\symbf{R}}_{i}
+\resizeExpression{{\symbf{G}}_{i}\,{\symbf{Φ}}_{i}={\symbf{Ψ}}_{i-1}\,{\symbf{G}}_{i-1}\,{\symbf{Φ}}_{i-1}+{F_{\text{S}}}\,{\symbf{T}}_{i}-{\symbf{R}}_{i}}{1.0}
 \end{displaymath}
 A simple rearrangement of Equation (3) leads to Equation (17), also seen in \hyperref[IM:intsliceFs]{IM:intsliceFs}:
 
 \begin{displaymath}
-{\symbf{G}}_{i}=\frac{{\symbf{Ψ}}_{i-1}\,{\symbf{G}}_{i-1}+{F_{\text{S}}}\,{\symbf{T}}_{i}-{\symbf{R}}_{i}}{{\symbf{Φ}}_{i}}
+\resizeExpression{{\symbf{G}}_{i}=\frac{{\symbf{Ψ}}_{i-1}\,{\symbf{G}}_{i-1}+{F_{\text{S}}}\,{\symbf{T}}_{i}-{\symbf{R}}_{i}}{{\symbf{Φ}}_{i}}}{1.0}
 \end{displaymath}
 The cases shown in \hyperref[IM:intsliceFs]{IM:intsliceFs} for when $i=0$, $i=1$, or $i=n$ are derived by applying \hyperref[assumpES]{A:Edge-Slices}, which says that ${\symbf{G}}_{0}$ and ${\symbf{G}}_{n}$ are zero, to Equation (17). $\symbf{G}$ depends on the unknowns ${F_{\text{S}}}$ (\hyperref[IM:fctSfty]{IM:fctSfty}) and $λ$ (\hyperref[IM:nrmShrFor]{IM:nrmShrFor}).
 
@@ -2506,7 +2517,7 @@ Input Constraints &
 Output Constraints & 
 \\ \midrule
 Equation & \begin{displaymath}
-           {\symbf{x}_{\text{slope}}}={\symbf{y}_{\text{slope}}}
+           \resizeExpression{{\symbf{x}_{\text{slope}}}={\symbf{y}_{\text{slope}}}}{0.8}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}

--- a/code/stable/swhs/SRS/PDF/SWHS_SRS.tex
+++ b/code/stable/swhs/SRS/PDF/SWHS_SRS.tex
@@ -15,6 +15,8 @@
 \usepackage{svg}
 \usepackage{float}
 \usepackage{enumitem}
+\usepackage{graphicx}
+\usepackage{calc}
 \usepackage{filecontents}
 \usepackage[backend=bibtex]{biblatex}
 \usepackage{url}
@@ -23,6 +25,15 @@
 \newcommand{\lt}{\ensuremath <}
 \newlist{symbDescription}{description}{1}
 \setlist[symbDescription]{noitemsep, topsep=0pt, parsep=0pt, partopsep=0pt}
+\newsavebox{\mybox}
+\newcommand{\resizeExpression}[2]{
+\savebox{\mybox}{$#1$}
+\ifdim\wd\mybox>#2\linewidth
+\resizebox{#2\textwidth}{!}{\usebox{\mybox}}
+\else
+\usebox{\mybox}
+\fi
+}
 \bibliography{bibfile}
 \title{Software Requirements Specification for Solar Water Heating Systems Incorporating PCM}
 \author{Thulasi Jegatheesan, Brooks MacLachlan, and W. Spencer Smith}
@@ -447,7 +458,7 @@ Label & Conservation of thermal energy
         
 \\ \midrule
 Equation & \begin{displaymath}
-           -∇\cdot{}\symbf{q}+g=ρ\,C\,\frac{\,\partial{}T}{\,\partial{}t}
+           \resizeExpression{-∇\cdot{}\symbf{q}+g=ρ\,C\,\frac{\,\partial{}T}{\,\partial{}t}}{0.8}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -486,11 +497,11 @@ Label & Sensible heat energy
         
 \\ \midrule
 Equation & \begin{displaymath}
-           E=\begin{cases}
-             {C^{\text{S}}}\,m\,ΔT, & T\lt{}{T_{\text{melt}}}\\
-             {C^{\text{L}}}\,m\,ΔT, & {T_{\text{melt}}}\lt{}T\lt{}{T_{\text{boil}}}\\
-             {C^{\text{V}}}\,m\,ΔT, & {T_{\text{boil}}}\lt{}T
-             \end{cases}
+           \resizeExpression{E=\begin{cases}
+                               {C^{\text{S}}}\,m\,ΔT, & T\lt{}{T_{\text{melt}}}\\
+                               {C^{\text{L}}}\,m\,ΔT, & {T_{\text{melt}}}\lt{}T\lt{}{T_{\text{boil}}}\\
+                               {C^{\text{V}}}\,m\,ΔT, & {T_{\text{boil}}}\lt{}T
+                               \end{cases}}{0.8}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -529,7 +540,7 @@ Label & Latent heat energy
         
 \\ \midrule
 Equation & \begin{displaymath}
-           Q\left(t\right)=\int_{0}^{t}{\frac{\,dQ\left(τ\right)}{\,dτ}}\,dτ
+           \resizeExpression{Q\left(t\right)=\int_{0}^{t}{\frac{\,dQ\left(τ\right)}{\,dτ}}\,dτ}{0.8}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -570,7 +581,7 @@ Label & Newton's law of cooling
         
 \\ \midrule
 Equation & \begin{displaymath}
-           q\left(t\right)=h\,ΔT\left(t\right)
+           \resizeExpression{q\left(t\right)=h\,ΔT\left(t\right)}{0.8}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -612,7 +623,7 @@ Label & Simplified rate of change of temperature
         
 \\ \midrule
 Equation & \begin{displaymath}
-           m\,C\,\frac{\,dT}{\,dt}={q_{\text{in}}}\,{A_{\text{in}}}-{q_{\text{out}}}\,{A_{\text{out}}}+g\,V
+           \resizeExpression{m\,C\,\frac{\,dT}{\,dt}={q_{\text{in}}}\,{A_{\text{in}}}-{q_{\text{out}}}\,{A_{\text{out}}}+g\,V}{0.8}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -642,27 +653,27 @@ RefBy & \hyperref[GD:rocTempSimp]{GD:rocTempSimp}, \hyperref[IM:eBalanceOnWtr]{I
 Integrating \hyperref[TM:consThermE]{TM:consThermE} over a volume ($V$), we have:
 
 \begin{displaymath}
--\int_{V}{∇\cdot{}\symbf{q}}\,dV+\int_{V}{g}\,dV=\int_{V}{ρ\,C\,\frac{\,\partial{}T}{\,\partial{}t}}\,dV
+\resizeExpression{-\int_{V}{∇\cdot{}\symbf{q}}\,dV+\int_{V}{g}\,dV=\int_{V}{ρ\,C\,\frac{\,\partial{}T}{\,\partial{}t}}\,dV}{1.0}
 \end{displaymath}
 Applying Gauss's Divergence Theorem to the first term over the surface $S$ of the volume, with $\symbf{q}$ as the thermal flux vector for the surface and $\symbf{\hat{n}}$ as a unit outward normal vector for a surface:
 
 \begin{displaymath}
--\int_{S}{\symbf{q}\cdot{}\symbf{\hat{n}}}\,dS+\int_{V}{g}\,dV=\int_{V}{ρ\,C\,\frac{\,\partial{}T}{\,\partial{}t}}\,dV
+\resizeExpression{-\int_{S}{\symbf{q}\cdot{}\symbf{\hat{n}}}\,dS+\int_{V}{g}\,dV=\int_{V}{ρ\,C\,\frac{\,\partial{}T}{\,\partial{}t}}\,dV}{1.0}
 \end{displaymath}
 We consider an arbitrary volume. The volumetric heat generation per unit volume is assumed constant. Then Equation (1) can be written as:
 
 \begin{displaymath}
-{q_{\text{in}}}\,{A_{\text{in}}}-{q_{\text{out}}}\,{A_{\text{out}}}+g\,V=\int_{V}{ρ\,C\,\frac{\,\partial{}T}{\,\partial{}t}}\,dV
+\resizeExpression{{q_{\text{in}}}\,{A_{\text{in}}}-{q_{\text{out}}}\,{A_{\text{out}}}+g\,V=\int_{V}{ρ\,C\,\frac{\,\partial{}T}{\,\partial{}t}}\,dV}{1.0}
 \end{displaymath}
 Where ${q_{\text{in}}}$, ${q_{\text{out}}}$, ${A_{\text{in}}}$, and ${A_{\text{out}}}$ are explained in \hyperref[GD:rocTempSimp]{GD:rocTempSimp}. The integral over the surface could be simplified because the thermal flux is assumed constant over ${A_{\text{in}}}$ and ${A_{\text{out}}}$ and $0$ on all other surfaces. Outward flux is considered positive. Assuming $ρ$, $C$, and $T$ are constant over the volume, which is true in our case by \hyperref[assumpCWTAT]{A:Constant-Water-Temp-Across-Tank}, \hyperref[assumpTPCAV]{A:Temp-PCM-Constant-Across-Volume}, \hyperref[assumpDWPCoV]{A:Density-Water-PCM-Constant-over-Volume}, and \hyperref[assumpSHECov]{A:Specific-Heat-Energy-Constant-over-Volume}, we have:
 
 \begin{displaymath}
-ρ\,C\,V\,\frac{\,dT}{\,dt}={q_{\text{in}}}\,{A_{\text{in}}}-{q_{\text{out}}}\,{A_{\text{out}}}+g\,V
+\resizeExpression{ρ\,C\,V\,\frac{\,dT}{\,dt}={q_{\text{in}}}\,{A_{\text{in}}}-{q_{\text{out}}}\,{A_{\text{out}}}+g\,V}{1.0}
 \end{displaymath}
 Using the fact that $ρ$=$m$/$V$, Equation (2) can be written as:
 
 \begin{displaymath}
-m\,C\,\frac{\,dT}{\,dt}={q_{\text{in}}}\,{A_{\text{in}}}-{q_{\text{out}}}\,{A_{\text{out}}}+g\,V
+\resizeExpression{m\,C\,\frac{\,dT}{\,dt}={q_{\text{in}}}\,{A_{\text{in}}}-{q_{\text{out}}}\,{A_{\text{out}}}+g\,V}{1.0}
 \end{displaymath}
 \medskip
 \noindent
@@ -679,7 +690,7 @@ Units & $\frac{\text{W}}{\text{m}^{2}}$
         
 \\ \midrule
 Equation & \begin{displaymath}
-           {q_{\text{C}}}={h_{\text{C}}}\,\left({T_{\text{C}}}-{T_{\text{W}}}\left(t\right)\right)
+           \resizeExpression{{q_{\text{C}}}={h_{\text{C}}}\,\left({T_{\text{C}}}-{T_{\text{W}}}\left(t\right)\right)}{0.8}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -719,7 +730,7 @@ Units & $\frac{\text{W}}{\text{m}^{2}}$
         
 \\ \midrule
 Equation & \begin{displaymath}
-           {q_{\text{P}}}={h_{\text{P}}}\,\left({T_{\text{W}}}\left(t\right)-{T_{\text{P}}}\left(t\right)\right)
+           \resizeExpression{{q_{\text{P}}}={h_{\text{P}}}\,\left({T_{\text{W}}}\left(t\right)-{T_{\text{P}}}\left(t\right)\right)}{0.8}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -764,7 +775,7 @@ Units & ${\text{kg}}$
         
 \\ \midrule
 Equation & \begin{displaymath}
-           {m_{\text{W}}}={V_{\text{W}}}\,{ρ_{\text{W}}}
+           \resizeExpression{{m_{\text{W}}}={V_{\text{W}}}\,{ρ_{\text{W}}}}{0.8}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -800,7 +811,7 @@ Units & ${\text{m}^{3}}$
         
 \\ \midrule
 Equation & \begin{displaymath}
-           {V_{\text{W}}}={V_{\text{tank}}}-{V_{\text{P}}}
+           \resizeExpression{{V_{\text{W}}}={V_{\text{tank}}}-{V_{\text{P}}}}{0.8}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -839,7 +850,7 @@ Units & ${\text{m}^{3}}$
         
 \\ \midrule
 Equation & \begin{displaymath}
-           {V_{\text{tank}}}=π\,\left(\frac{D}{2}\right)^{2}\,L
+           \resizeExpression{{V_{\text{tank}}}=π\,\left(\frac{D}{2}\right)^{2}\,L}{0.8}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -876,7 +887,7 @@ Units & ${\text{s}}$
         
 \\ \midrule
 Equation & \begin{displaymath}
-           {τ_{\text{W}}}=\frac{{m_{\text{W}}}\,{C_{\text{W}}}}{{h_{\text{C}}}\,{A_{\text{C}}}}
+           \resizeExpression{{τ_{\text{W}}}=\frac{{m_{\text{W}}}\,{C_{\text{W}}}}{{h_{\text{C}}}\,{A_{\text{C}}}}}{0.8}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -914,7 +925,7 @@ Units & Unitless
         
 \\ \midrule
 Equation & \begin{displaymath}
-           η=\frac{{h_{\text{P}}}\,{A_{\text{P}}}}{{h_{\text{C}}}\,{A_{\text{C}}}}
+           \resizeExpression{η=\frac{{h_{\text{P}}}\,{A_{\text{P}}}}{{h_{\text{C}}}\,{A_{\text{C}}}}}{0.8}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -952,7 +963,7 @@ Units & ${\text{s}}$
         
 \\ \midrule
 Equation & \begin{displaymath}
-           {{τ_{\text{P}}}^{\text{S}}}=\frac{{m_{\text{P}}}\,{{C_{\text{P}}}^{\text{S}}}}{{h_{\text{P}}}\,{A_{\text{P}}}}
+           \resizeExpression{{{τ_{\text{P}}}^{\text{S}}}=\frac{{m_{\text{P}}}\,{{C_{\text{P}}}^{\text{S}}}}{{h_{\text{P}}}\,{A_{\text{P}}}}}{0.8}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -990,7 +1001,7 @@ Units & ${\text{s}}$
         
 \\ \midrule
 Equation & \begin{displaymath}
-           {{τ_{\text{P}}}^{\text{L}}}=\frac{{m_{\text{P}}}\,{{C_{\text{P}}}^{\text{L}}}}{{h_{\text{P}}}\,{A_{\text{P}}}}
+           \resizeExpression{{{τ_{\text{P}}}^{\text{L}}}=\frac{{m_{\text{P}}}\,{{C_{\text{P}}}^{\text{L}}}}{{h_{\text{P}}}\,{A_{\text{P}}}}}{0.8}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -1028,7 +1039,7 @@ Units & $\frac{\text{J}}{\text{kg}}$
         
 \\ \midrule
 Equation & \begin{displaymath}
-           {H_{\text{f}}}=\frac{Q}{m}
+           \resizeExpression{{H_{\text{f}}}=\frac{Q}{m}}{0.8}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -1067,7 +1078,7 @@ Units & Unitless
         
 \\ \midrule
 Equation & \begin{displaymath}
-           ϕ=\frac{{Q_{\text{P}}}}{{H_{\text{f}}}\,{m_{\text{P}}}}
+           \resizeExpression{ϕ=\frac{{Q_{\text{P}}}}{{H_{\text{f}}}\,{m_{\text{P}}}}}{0.8}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -1109,7 +1120,7 @@ Units & Unitless
         
 \\ \midrule
 Equation & \begin{displaymath}
-           \mathit{AR}=\frac{D}{L}
+           \resizeExpression{\mathit{AR}=\frac{D}{L}}{0.8}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -1150,13 +1161,13 @@ Output & ${T_{\text{W}}}$
          
 \\ \midrule
 Input Constraints & \begin{displaymath}
-                    {T_{\text{C}}}\gt{}{T_{\text{init}}}
+                    \resizeExpression{{T_{\text{C}}}\gt{}{T_{\text{init}}}}{0.8}
                     \end{displaymath}
 \\ \midrule
 Output Constraints & 
 \\ \midrule
 Equation & \begin{displaymath}
-           \frac{\,d{T_{\text{W}}}}{\,dt}=\frac{1}{{τ_{\text{W}}}}\,\left({T_{\text{C}}}-{T_{\text{W}}}\left(t\right)+η\,\left({T_{\text{P}}}\left(t\right)-{T_{\text{W}}}\left(t\right)\right)\right)
+           \resizeExpression{\frac{\,d{T_{\text{W}}}}{\,dt}=\frac{1}{{τ_{\text{W}}}}\,\left({T_{\text{C}}}-{T_{\text{W}}}\left(t\right)+η\,\left({T_{\text{P}}}\left(t\right)-{T_{\text{W}}}\left(t\right)\right)\right)}{0.8}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -1195,37 +1206,37 @@ RefBy & \hyperref[IM:eBalanceOnWtr]{IM:eBalanceOnWtr}, \hyperref[IM:eBalanceOnPC
 To find the rate of change of ${T_{\text{W}}}$, we look at the energy balance on water. The volume being considered is the volume of water in the tank ${V_{\text{W}}}$, which has mass ${m_{\text{W}}}$ and specific heat capacity, ${C_{\text{W}}}$. Heat transfer occurs in the water from the heating coil as ${q_{\text{C}}}$ (\hyperref[GD:htFluxWaterFromCoil]{GD:htFluxWaterFromCoil}) and from the water into the PCM as ${q_{\text{P}}}$ (\hyperref[GD:htFluxPCMFromWater]{GD:htFluxPCMFromWater}), over areas ${A_{\text{C}}}$ and ${A_{\text{P}}}$, respectively. The thermal flux is constant over ${A_{\text{C}}}$, since the temperature of the heating coil is assumed to not vary along its length (\hyperref[assumpTHCCoL]{A:Temp-Heating-Coil-Constant-over-Length}), and the thermal flux is constant over ${A_{\text{P}}}$, since the temperature of the PCM is the same throughout its volume (\hyperref[assumpTPCAV]{A:Temp-PCM-Constant-Across-Volume}) and the water is fully mixed (\hyperref[assumpCWTAT]{A:Constant-Water-Temp-Across-Tank}). No heat transfer occurs to the outside of the tank, since it has been assumed to be perfectly insulated (\hyperref[assumpPIT]{A:Perfect-Insulation-Tank}). Since the assumption is made that no internal heat is generated (\hyperref[assumpNIHGBWP]{A:No-Internal-Heat-Generation-By-Water-PCM}), $g=0$. Therefore, the equation for \hyperref[GD:rocTempSimp]{GD:rocTempSimp} can be written as:
 
 \begin{displaymath}
-{m_{\text{W}}}\,{C_{\text{W}}}\,\frac{\,d{T_{\text{W}}}}{\,dt}={q_{\text{C}}}\,{A_{\text{C}}}-{q_{\text{P}}}\,{A_{\text{P}}}
+\resizeExpression{{m_{\text{W}}}\,{C_{\text{W}}}\,\frac{\,d{T_{\text{W}}}}{\,dt}={q_{\text{C}}}\,{A_{\text{C}}}-{q_{\text{P}}}\,{A_{\text{P}}}}{1.0}
 \end{displaymath}
 Using \hyperref[GD:htFluxWaterFromCoil]{GD:htFluxWaterFromCoil} for ${q_{\text{C}}}$ and \hyperref[GD:htFluxPCMFromWater]{GD:htFluxPCMFromWater} for ${q_{\text{P}}}$, this can be written as:
 
 \begin{displaymath}
-{m_{\text{W}}}\,{C_{\text{W}}}\,\frac{\,d{T_{\text{W}}}}{\,dt}={h_{\text{C}}}\,{A_{\text{C}}}\,\left({T_{\text{C}}}-{T_{\text{W}}}\right)-{h_{\text{P}}}\,{A_{\text{P}}}\,\left({T_{\text{W}}}-{T_{\text{P}}}\right)
+\resizeExpression{{m_{\text{W}}}\,{C_{\text{W}}}\,\frac{\,d{T_{\text{W}}}}{\,dt}={h_{\text{C}}}\,{A_{\text{C}}}\,\left({T_{\text{C}}}-{T_{\text{W}}}\right)-{h_{\text{P}}}\,{A_{\text{P}}}\,\left({T_{\text{W}}}-{T_{\text{P}}}\right)}{1.0}
 \end{displaymath}
 Dividing Equation (2) by ${m_{\text{W}}}\,{C_{\text{W}}}$, we obtain:
 
 \begin{displaymath}
-\frac{\,d{T_{\text{W}}}}{\,dt}=\frac{{h_{\text{C}}}\,{A_{\text{C}}}}{{m_{\text{W}}}\,{C_{\text{W}}}}\,\left({T_{\text{C}}}-{T_{\text{W}}}\right)-\frac{{h_{\text{P}}}\,{A_{\text{P}}}}{{m_{\text{W}}}\,{C_{\text{W}}}}\,\left({T_{\text{W}}}-{T_{\text{P}}}\right)
+\resizeExpression{\frac{\,d{T_{\text{W}}}}{\,dt}=\frac{{h_{\text{C}}}\,{A_{\text{C}}}}{{m_{\text{W}}}\,{C_{\text{W}}}}\,\left({T_{\text{C}}}-{T_{\text{W}}}\right)-\frac{{h_{\text{P}}}\,{A_{\text{P}}}}{{m_{\text{W}}}\,{C_{\text{W}}}}\,\left({T_{\text{W}}}-{T_{\text{P}}}\right)}{1.0}
 \end{displaymath}
 Factoring the negative sign out of the second term of the right-hand side (RHS) of Equation (3) and multiplying it by ${h_{\text{C}}}$ ${A_{\text{C}}}$ / ${h_{\text{C}}}$ ${A_{\text{C}}}$ yields:
 
 \begin{displaymath}
-\frac{\,d{T_{\text{W}}}}{\,dt}=\frac{{h_{\text{C}}}\,{A_{\text{C}}}}{{m_{\text{W}}}\,{C_{\text{W}}}}\,\left({T_{\text{C}}}-{T_{\text{W}}}\right)+\frac{{h_{\text{C}}}\,{A_{\text{C}}}}{{h_{\text{C}}}\,{A_{\text{C}}}}\,\frac{{h_{\text{P}}}\,{A_{\text{P}}}}{{m_{\text{W}}}\,{C_{\text{W}}}}\,\left({T_{\text{P}}}-{T_{\text{W}}}\right)
+\resizeExpression{\frac{\,d{T_{\text{W}}}}{\,dt}=\frac{{h_{\text{C}}}\,{A_{\text{C}}}}{{m_{\text{W}}}\,{C_{\text{W}}}}\,\left({T_{\text{C}}}-{T_{\text{W}}}\right)+\frac{{h_{\text{C}}}\,{A_{\text{C}}}}{{h_{\text{C}}}\,{A_{\text{C}}}}\,\frac{{h_{\text{P}}}\,{A_{\text{P}}}}{{m_{\text{W}}}\,{C_{\text{W}}}}\,\left({T_{\text{P}}}-{T_{\text{W}}}\right)}{1.0}
 \end{displaymath}
 Rearranging this equation gives us:
 
 \begin{displaymath}
-\frac{\,d{T_{\text{W}}}}{\,dt}=\frac{{h_{\text{C}}}\,{A_{\text{C}}}}{{m_{\text{W}}}\,{C_{\text{W}}}}\,\left({T_{\text{C}}}-{T_{\text{W}}}\right)+\frac{{h_{\text{P}}}\,{A_{\text{P}}}}{{h_{\text{C}}}\,{A_{\text{C}}}}\,\frac{{h_{\text{C}}}\,{A_{\text{C}}}}{{m_{\text{W}}}\,{C_{\text{W}}}}\,\left({T_{\text{P}}}-{T_{\text{W}}}\right)
+\resizeExpression{\frac{\,d{T_{\text{W}}}}{\,dt}=\frac{{h_{\text{C}}}\,{A_{\text{C}}}}{{m_{\text{W}}}\,{C_{\text{W}}}}\,\left({T_{\text{C}}}-{T_{\text{W}}}\right)+\frac{{h_{\text{P}}}\,{A_{\text{P}}}}{{h_{\text{C}}}\,{A_{\text{C}}}}\,\frac{{h_{\text{C}}}\,{A_{\text{C}}}}{{m_{\text{W}}}\,{C_{\text{W}}}}\,\left({T_{\text{P}}}-{T_{\text{W}}}\right)}{1.0}
 \end{displaymath}
 By substituting ${τ_{\text{W}}}$ (from \hyperref[DD:balanceDecayRate]{DD:balanceDecayRate}) and $η$ (from \hyperref[DD:balanceDecayTime]{DD:balanceDecayTime}), this can be written as:
 
 \begin{displaymath}
-\frac{\,d{T_{\text{W}}}}{\,dt}=\frac{1}{{τ_{\text{W}}}}\,\left({T_{\text{C}}}-{T_{\text{W}}}\right)+\frac{η}{{τ_{\text{W}}}}\,\left({T_{\text{P}}}-{T_{\text{W}}}\right)
+\resizeExpression{\frac{\,d{T_{\text{W}}}}{\,dt}=\frac{1}{{τ_{\text{W}}}}\,\left({T_{\text{C}}}-{T_{\text{W}}}\right)+\frac{η}{{τ_{\text{W}}}}\,\left({T_{\text{P}}}-{T_{\text{W}}}\right)}{1.0}
 \end{displaymath}
 Finally, factoring out $\frac{1}{{τ_{\text{W}}}}$, we are left with the governing ODE for \hyperref[IM:eBalanceOnWtr]{IM:eBalanceOnWtr}:
 
 \begin{displaymath}
-\frac{\,d{T_{\text{W}}}}{\,dt}=\frac{1}{{τ_{\text{W}}}}\,\left({T_{\text{C}}}-{T_{\text{W}}}+η\,\left({T_{\text{P}}}-{T_{\text{W}}}\right)\right)
+\resizeExpression{\frac{\,d{T_{\text{W}}}}{\,dt}=\frac{1}{{τ_{\text{W}}}}\,\left({T_{\text{C}}}-{T_{\text{W}}}+η\,\left({T_{\text{P}}}-{T_{\text{W}}}\right)\right)}{1.0}
 \end{displaymath}
 \medskip
 \noindent
@@ -1245,17 +1256,17 @@ Output & ${T_{\text{P}}}$
          
 \\ \midrule
 Input Constraints & \begin{displaymath}
-                    {{T_{\text{melt}}}^{\text{P}}}\gt{}{T_{\text{init}}}
+                    \resizeExpression{{{T_{\text{melt}}}^{\text{P}}}\gt{}{T_{\text{init}}}}{0.8}
                     \end{displaymath}
 \\ \midrule
 Output Constraints & 
 \\ \midrule
 Equation & \begin{displaymath}
-           \frac{\,d{T_{\text{P}}}}{\,dt}=\begin{cases}
-                                          \frac{1}{{{τ_{\text{P}}}^{\text{S}}}}\,\left({T_{\text{W}}}\left(t\right)-{T_{\text{P}}}\left(t\right)\right), & {T_{\text{P}}}\lt{}{{T_{\text{melt}}}^{\text{P}}}\\
-                                          \frac{1}{{{τ_{\text{P}}}^{\text{L}}}}\,\left({T_{\text{W}}}\left(t\right)-{T_{\text{P}}}\left(t\right)\right), & {T_{\text{P}}}\gt{}{{T_{\text{melt}}}^{\text{P}}}\\
-                                          0, & {T_{\text{P}}}={{T_{\text{melt}}}^{\text{P}}}\land{}0\lt{}ϕ\lt{}1
-                                          \end{cases}
+           \resizeExpression{\frac{\,d{T_{\text{P}}}}{\,dt}=\begin{cases}
+                                                            \frac{1}{{{τ_{\text{P}}}^{\text{S}}}}\,\left({T_{\text{W}}}\left(t\right)-{T_{\text{P}}}\left(t\right)\right), & {T_{\text{P}}}\lt{}{{T_{\text{melt}}}^{\text{P}}}\\
+                                                            \frac{1}{{{τ_{\text{P}}}^{\text{L}}}}\,\left({T_{\text{W}}}\left(t\right)-{T_{\text{P}}}\left(t\right)\right), & {T_{\text{P}}}\gt{}{{T_{\text{melt}}}^{\text{P}}}\\
+                                                            0, & {T_{\text{P}}}={{T_{\text{melt}}}^{\text{P}}}\land{}0\lt{}ϕ\lt{}1
+                                                            \end{cases}}{0.8}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -1295,22 +1306,22 @@ RefBy & \hyperref[IM:eBalanceOnWtr]{IM:eBalanceOnWtr}, \hyperref[unlikeChgNIHG]{
 To find the rate of change of ${T_{\text{P}}}$, we look at the energy balance on the PCM. The volume being considered is the volume of PCM (${V_{\text{P}}}$). The derivation that follows is initially for the solid PCM. The mass of phase change material is ${m_{\text{P}}}$ and the specific heat capacity of PCM as a solid is ${{C_{\text{P}}}^{\text{S}}}$. The heat flux into the PCM from water is ${q_{\text{P}}}$ (\hyperref[GD:htFluxPCMFromWater]{GD:htFluxPCMFromWater}) over phase change material surface area ${A_{\text{P}}}$. The thermal flux is constant over ${A_{\text{P}}}$, since the temperature of the PCM is the same throughout its volume (\hyperref[assumpTPCAV]{A:Temp-PCM-Constant-Across-Volume}) and the water is fully mixed (\hyperref[assumpCWTAT]{A:Constant-Water-Temp-Across-Tank}). There is no heat flux output from the PCM. Assuming no volumetric heat generation per unit volume (\hyperref[assumpNIHGBWP]{A:No-Internal-Heat-Generation-By-Water-PCM}), $g=0$, the equation for \hyperref[GD:rocTempSimp]{GD:rocTempSimp} can be written as:
 
 \begin{displaymath}
-{m_{\text{P}}}\,{{C_{\text{P}}}^{\text{S}}}\,\frac{\,d{T_{\text{P}}}}{\,dt}={q_{\text{P}}}\,{A_{\text{P}}}
+\resizeExpression{{m_{\text{P}}}\,{{C_{\text{P}}}^{\text{S}}}\,\frac{\,d{T_{\text{P}}}}{\,dt}={q_{\text{P}}}\,{A_{\text{P}}}}{1.0}
 \end{displaymath}
 Using \hyperref[GD:htFluxPCMFromWater]{GD:htFluxPCMFromWater} for ${q_{\text{P}}}$, this equation can be written as:
 
 \begin{displaymath}
-{m_{\text{P}}}\,{{C_{\text{P}}}^{\text{S}}}\,\frac{\,d{T_{\text{P}}}}{\,dt}={h_{\text{P}}}\,{A_{\text{P}}}\,\left({T_{\text{W}}}-{T_{\text{P}}}\right)
+\resizeExpression{{m_{\text{P}}}\,{{C_{\text{P}}}^{\text{S}}}\,\frac{\,d{T_{\text{P}}}}{\,dt}={h_{\text{P}}}\,{A_{\text{P}}}\,\left({T_{\text{W}}}-{T_{\text{P}}}\right)}{1.0}
 \end{displaymath}
 Dividing by ${m_{\text{P}}}$ ${{C_{\text{P}}}^{\text{S}}}$ we obtain:
 
 \begin{displaymath}
-\frac{\,d{T_{\text{P}}}}{\,dt}=\frac{{h_{\text{P}}}\,{A_{\text{P}}}}{{m_{\text{P}}}\,{{C_{\text{P}}}^{\text{S}}}}\,\left({T_{\text{W}}}-{T_{\text{P}}}\right)
+\resizeExpression{\frac{\,d{T_{\text{P}}}}{\,dt}=\frac{{h_{\text{P}}}\,{A_{\text{P}}}}{{m_{\text{P}}}\,{{C_{\text{P}}}^{\text{S}}}}\,\left({T_{\text{W}}}-{T_{\text{P}}}\right)}{1.0}
 \end{displaymath}
 By substituting ${{τ_{\text{P}}}^{\text{S}}}$ (from \hyperref[DD:balanceSolidPCM]{DD:balanceSolidPCM}), this can be written as:
 
 \begin{displaymath}
-\frac{\,d{T_{\text{P}}}}{\,dt}=\frac{1}{{{τ_{\text{P}}}^{\text{S}}}}\,\left({T_{\text{W}}}-{T_{\text{P}}}\right)
+\resizeExpression{\frac{\,d{T_{\text{P}}}}{\,dt}=\frac{1}{{{τ_{\text{P}}}^{\text{S}}}}\,\left({T_{\text{W}}}-{T_{\text{P}}}\right)}{1.0}
 \end{displaymath}
 Equation (4) applies for the solid PCM. In the case where all of the PCM is melted, the same derivation applies, except that ${{C_{\text{P}}}^{\text{S}}}$ is replaced by ${{C_{\text{P}}}^{\text{L}}}$, and thus ${{τ_{\text{P}}}^{\text{S}}}$ is replaced by ${{τ_{\text{P}}}^{\text{L}}}$. Although a small change in surface area would be expected with melting, this is not included, since the volume change of the PCM with melting is assumed to be negligible (\hyperref[assumpVCMPN]{A:Volume-Change-Melting-PCM-Negligible}).
 
@@ -1340,7 +1351,7 @@ Input Constraints &
 Output Constraints & 
 \\ \midrule
 Equation & \begin{displaymath}
-           {E_{\text{W}}}\left(t\right)={C_{\text{W}}}\,{m_{\text{W}}}\,\left({T_{\text{W}}}\left(t\right)-{T_{\text{init}}}\right)
+           \resizeExpression{{E_{\text{W}}}\left(t\right)={C_{\text{W}}}\,{m_{\text{W}}}\,\left({T_{\text{W}}}\left(t\right)-{T_{\text{init}}}\right)}{0.8}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -1386,17 +1397,17 @@ Output & ${E_{\text{P}}}$
          
 \\ \midrule
 Input Constraints & \begin{displaymath}
-                    {{T_{\text{melt}}}^{\text{P}}}\gt{}{T_{\text{init}}}
+                    \resizeExpression{{{T_{\text{melt}}}^{\text{P}}}\gt{}{T_{\text{init}}}}{0.8}
                     \end{displaymath}
 \\ \midrule
 Output Constraints & 
 \\ \midrule
 Equation & \begin{displaymath}
-           {E_{\text{P}}}=\begin{cases}
-                          {{C_{\text{P}}}^{\text{S}}}\,{m_{\text{P}}}\,\left({T_{\text{P}}}\left(t\right)-{T_{\text{init}}}\right), & {T_{\text{P}}}\lt{}{{T_{\text{melt}}}^{\text{P}}}\\
-                          {{{E_{\text{P}}}_{\text{melt}}}^{\text{init}}}+{H_{\text{f}}}\,{m_{\text{P}}}+{{C_{\text{P}}}^{\text{L}}}\,{m_{\text{P}}}\,\left({T_{\text{P}}}\left(t\right)-{{T_{\text{melt}}}^{\text{P}}}\right), & {T_{\text{P}}}\gt{}{{T_{\text{melt}}}^{\text{P}}}\\
-                          {{{E_{\text{P}}}_{\text{melt}}}^{\text{init}}}+{Q_{\text{P}}}\left(t\right), & {T_{\text{P}}}={{T_{\text{melt}}}^{\text{P}}}\land{}0\lt{}ϕ\lt{}1
-                          \end{cases}
+           \resizeExpression{{E_{\text{P}}}=\begin{cases}
+                                            {{C_{\text{P}}}^{\text{S}}}\,{m_{\text{P}}}\,\left({T_{\text{P}}}\left(t\right)-{T_{\text{init}}}\right), & {T_{\text{P}}}\lt{}{{T_{\text{melt}}}^{\text{P}}}\\
+                                            {{{E_{\text{P}}}_{\text{melt}}}^{\text{init}}}+{H_{\text{f}}}\,{m_{\text{P}}}+{{C_{\text{P}}}^{\text{L}}}\,{m_{\text{P}}}\,\left({T_{\text{P}}}\left(t\right)-{{T_{\text{melt}}}^{\text{P}}}\right), & {T_{\text{P}}}\gt{}{{T_{\text{melt}}}^{\text{P}}}\\
+                                            {{{E_{\text{P}}}_{\text{melt}}}^{\text{init}}}+{Q_{\text{P}}}\left(t\right), & {T_{\text{P}}}={{T_{\text{melt}}}^{\text{P}}}\land{}0\lt{}ϕ\lt{}1
+                                            \end{cases}}{0.8}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -1505,12 +1516,12 @@ ${E_{\text{P}}}$ & ${E_{\text{P}}}\geq{}0$
 A correct solution must exhibit the law of conservation of energy. This means that the change in heat energy in the water should equal the difference between the total energy input from the heating coil and the energy output to the PCM. This can be shown as an equation by taking \hyperref[GD:htFluxWaterFromCoil]{GD:htFluxWaterFromCoil} and \hyperref[GD:htFluxPCMFromWater]{GD:htFluxPCMFromWater}, multiplying each by their respective surface area of heat transfer, and integrating each over the simulation time, as follows:
 
 \begin{displaymath}
-{E_{\text{W}}}=\int_{0}^{t}{{h_{\text{C}}}\,{A_{\text{C}}}\,\left({T_{\text{C}}}-{T_{\text{W}}}\left(t\right)\right)}\,dt-\int_{0}^{t}{{h_{\text{P}}}\,{A_{\text{P}}}\,\left({T_{\text{W}}}\left(t\right)-{T_{\text{P}}}\left(t\right)\right)}\,dt
+\resizeExpression{{E_{\text{W}}}=\int_{0}^{t}{{h_{\text{C}}}\,{A_{\text{C}}}\,\left({T_{\text{C}}}-{T_{\text{W}}}\left(t\right)\right)}\,dt-\int_{0}^{t}{{h_{\text{P}}}\,{A_{\text{P}}}\,\left({T_{\text{W}}}\left(t\right)-{T_{\text{P}}}\left(t\right)\right)}\,dt}{1.0}
 \end{displaymath}
 In addition, the change in heat energy in the PCM should equal the energy input to the PCM from the water. This can be expressed as
 
 \begin{displaymath}
-{E_{\text{P}}}=\int_{0}^{t}{{h_{\text{P}}}\,{A_{\text{P}}}\,\left({T_{\text{W}}}\left(t\right)-{T_{\text{P}}}\left(t\right)\right)}\,dt
+\resizeExpression{{E_{\text{P}}}=\int_{0}^{t}{{h_{\text{P}}}\,{A_{\text{P}}}\,\left({T_{\text{W}}}\left(t\right)-{T_{\text{P}}}\left(t\right)\right)}\,dt}{1.0}
 \end{displaymath}
 Equations (FIXME: Equation 7) and (FIXME: Equation 8) can be used as ``sanity'' checks to gain confidence in any solution computed by SWHS. The relative error between the results computed by SWHS and the results calculated from the RHS of these equations should be less than ${C_{\text{tol}}}$ \hyperref[verifyEnergyOutput]{FR:Verify-Energy-Output-Follow-Conservation-of-Energy}.
 

--- a/code/stable/swhs/SRS/PDF/SWHS_SRS.tex
+++ b/code/stable/swhs/SRS/PDF/SWHS_SRS.tex
@@ -25,6 +25,8 @@
 \newcommand{\lt}{\ensuremath <}
 \newlist{symbDescription}{description}{1}
 \setlist[symbDescription]{noitemsep, topsep=0pt, parsep=0pt, partopsep=0pt}
+\def\inDefScale{0.8}
+\def\outDefScale{1.0}
 \newsavebox{\mybox}
 \newcommand{\resizeExpression}[2]{
   \savebox{\mybox}{$#1$}
@@ -458,7 +460,7 @@ Label & Conservation of thermal energy
         
 \\ \midrule
 Equation & \begin{displaymath}
-           \resizeExpression{-∇\cdot{}\symbf{q}+g=ρ\,C\,\frac{\,\partial{}T}{\,\partial{}t}}{0.8}
+           \resizeExpression{-∇\cdot{}\symbf{q}+g=ρ\,C\,\frac{\,\partial{}T}{\,\partial{}t}}{\inDefScale}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -501,7 +503,7 @@ Equation & \begin{displaymath}
                                {C^{\text{S}}}\,m\,ΔT, & T\lt{}{T_{\text{melt}}}\\
                                {C^{\text{L}}}\,m\,ΔT, & {T_{\text{melt}}}\lt{}T\lt{}{T_{\text{boil}}}\\
                                {C^{\text{V}}}\,m\,ΔT, & {T_{\text{boil}}}\lt{}T
-                               \end{cases}}{0.8}
+                               \end{cases}}{\inDefScale}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -540,7 +542,7 @@ Label & Latent heat energy
         
 \\ \midrule
 Equation & \begin{displaymath}
-           \resizeExpression{Q\left(t\right)=\int_{0}^{t}{\frac{\,dQ\left(τ\right)}{\,dτ}}\,dτ}{0.8}
+           \resizeExpression{Q\left(t\right)=\int_{0}^{t}{\frac{\,dQ\left(τ\right)}{\,dτ}}\,dτ}{\inDefScale}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -581,7 +583,7 @@ Label & Newton's law of cooling
         
 \\ \midrule
 Equation & \begin{displaymath}
-           \resizeExpression{q\left(t\right)=h\,ΔT\left(t\right)}{0.8}
+           \resizeExpression{q\left(t\right)=h\,ΔT\left(t\right)}{\inDefScale}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -623,7 +625,7 @@ Label & Simplified rate of change of temperature
         
 \\ \midrule
 Equation & \begin{displaymath}
-           \resizeExpression{m\,C\,\frac{\,dT}{\,dt}={q_{\text{in}}}\,{A_{\text{in}}}-{q_{\text{out}}}\,{A_{\text{out}}}+g\,V}{0.8}
+           \resizeExpression{m\,C\,\frac{\,dT}{\,dt}={q_{\text{in}}}\,{A_{\text{in}}}-{q_{\text{out}}}\,{A_{\text{out}}}+g\,V}{\inDefScale}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -653,27 +655,27 @@ RefBy & \hyperref[GD:rocTempSimp]{GD:rocTempSimp}, \hyperref[IM:eBalanceOnWtr]{I
 Integrating \hyperref[TM:consThermE]{TM:consThermE} over a volume ($V$), we have:
 
 \begin{displaymath}
-\resizeExpression{-\int_{V}{∇\cdot{}\symbf{q}}\,dV+\int_{V}{g}\,dV=\int_{V}{ρ\,C\,\frac{\,\partial{}T}{\,\partial{}t}}\,dV}{1.0}
+\resizeExpression{-\int_{V}{∇\cdot{}\symbf{q}}\,dV+\int_{V}{g}\,dV=\int_{V}{ρ\,C\,\frac{\,\partial{}T}{\,\partial{}t}}\,dV}{\outDefScale}
 \end{displaymath}
 Applying Gauss's Divergence Theorem to the first term over the surface $S$ of the volume, with $\symbf{q}$ as the thermal flux vector for the surface and $\symbf{\hat{n}}$ as a unit outward normal vector for a surface:
 
 \begin{displaymath}
-\resizeExpression{-\int_{S}{\symbf{q}\cdot{}\symbf{\hat{n}}}\,dS+\int_{V}{g}\,dV=\int_{V}{ρ\,C\,\frac{\,\partial{}T}{\,\partial{}t}}\,dV}{1.0}
+\resizeExpression{-\int_{S}{\symbf{q}\cdot{}\symbf{\hat{n}}}\,dS+\int_{V}{g}\,dV=\int_{V}{ρ\,C\,\frac{\,\partial{}T}{\,\partial{}t}}\,dV}{\outDefScale}
 \end{displaymath}
 We consider an arbitrary volume. The volumetric heat generation per unit volume is assumed constant. Then Equation (1) can be written as:
 
 \begin{displaymath}
-\resizeExpression{{q_{\text{in}}}\,{A_{\text{in}}}-{q_{\text{out}}}\,{A_{\text{out}}}+g\,V=\int_{V}{ρ\,C\,\frac{\,\partial{}T}{\,\partial{}t}}\,dV}{1.0}
+\resizeExpression{{q_{\text{in}}}\,{A_{\text{in}}}-{q_{\text{out}}}\,{A_{\text{out}}}+g\,V=\int_{V}{ρ\,C\,\frac{\,\partial{}T}{\,\partial{}t}}\,dV}{\outDefScale}
 \end{displaymath}
 Where ${q_{\text{in}}}$, ${q_{\text{out}}}$, ${A_{\text{in}}}$, and ${A_{\text{out}}}$ are explained in \hyperref[GD:rocTempSimp]{GD:rocTempSimp}. The integral over the surface could be simplified because the thermal flux is assumed constant over ${A_{\text{in}}}$ and ${A_{\text{out}}}$ and $0$ on all other surfaces. Outward flux is considered positive. Assuming $ρ$, $C$, and $T$ are constant over the volume, which is true in our case by \hyperref[assumpCWTAT]{A:Constant-Water-Temp-Across-Tank}, \hyperref[assumpTPCAV]{A:Temp-PCM-Constant-Across-Volume}, \hyperref[assumpDWPCoV]{A:Density-Water-PCM-Constant-over-Volume}, and \hyperref[assumpSHECov]{A:Specific-Heat-Energy-Constant-over-Volume}, we have:
 
 \begin{displaymath}
-\resizeExpression{ρ\,C\,V\,\frac{\,dT}{\,dt}={q_{\text{in}}}\,{A_{\text{in}}}-{q_{\text{out}}}\,{A_{\text{out}}}+g\,V}{1.0}
+\resizeExpression{ρ\,C\,V\,\frac{\,dT}{\,dt}={q_{\text{in}}}\,{A_{\text{in}}}-{q_{\text{out}}}\,{A_{\text{out}}}+g\,V}{\outDefScale}
 \end{displaymath}
 Using the fact that $ρ$=$m$/$V$, Equation (2) can be written as:
 
 \begin{displaymath}
-\resizeExpression{m\,C\,\frac{\,dT}{\,dt}={q_{\text{in}}}\,{A_{\text{in}}}-{q_{\text{out}}}\,{A_{\text{out}}}+g\,V}{1.0}
+\resizeExpression{m\,C\,\frac{\,dT}{\,dt}={q_{\text{in}}}\,{A_{\text{in}}}-{q_{\text{out}}}\,{A_{\text{out}}}+g\,V}{\outDefScale}
 \end{displaymath}
 \medskip
 \noindent
@@ -690,7 +692,7 @@ Units & $\frac{\text{W}}{\text{m}^{2}}$
         
 \\ \midrule
 Equation & \begin{displaymath}
-           \resizeExpression{{q_{\text{C}}}={h_{\text{C}}}\,\left({T_{\text{C}}}-{T_{\text{W}}}\left(t\right)\right)}{0.8}
+           \resizeExpression{{q_{\text{C}}}={h_{\text{C}}}\,\left({T_{\text{C}}}-{T_{\text{W}}}\left(t\right)\right)}{\inDefScale}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -730,7 +732,7 @@ Units & $\frac{\text{W}}{\text{m}^{2}}$
         
 \\ \midrule
 Equation & \begin{displaymath}
-           \resizeExpression{{q_{\text{P}}}={h_{\text{P}}}\,\left({T_{\text{W}}}\left(t\right)-{T_{\text{P}}}\left(t\right)\right)}{0.8}
+           \resizeExpression{{q_{\text{P}}}={h_{\text{P}}}\,\left({T_{\text{W}}}\left(t\right)-{T_{\text{P}}}\left(t\right)\right)}{\inDefScale}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -775,7 +777,7 @@ Units & ${\text{kg}}$
         
 \\ \midrule
 Equation & \begin{displaymath}
-           \resizeExpression{{m_{\text{W}}}={V_{\text{W}}}\,{ρ_{\text{W}}}}{0.8}
+           \resizeExpression{{m_{\text{W}}}={V_{\text{W}}}\,{ρ_{\text{W}}}}{\inDefScale}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -811,7 +813,7 @@ Units & ${\text{m}^{3}}$
         
 \\ \midrule
 Equation & \begin{displaymath}
-           \resizeExpression{{V_{\text{W}}}={V_{\text{tank}}}-{V_{\text{P}}}}{0.8}
+           \resizeExpression{{V_{\text{W}}}={V_{\text{tank}}}-{V_{\text{P}}}}{\inDefScale}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -850,7 +852,7 @@ Units & ${\text{m}^{3}}$
         
 \\ \midrule
 Equation & \begin{displaymath}
-           \resizeExpression{{V_{\text{tank}}}=π\,\left(\frac{D}{2}\right)^{2}\,L}{0.8}
+           \resizeExpression{{V_{\text{tank}}}=π\,\left(\frac{D}{2}\right)^{2}\,L}{\inDefScale}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -887,7 +889,7 @@ Units & ${\text{s}}$
         
 \\ \midrule
 Equation & \begin{displaymath}
-           \resizeExpression{{τ_{\text{W}}}=\frac{{m_{\text{W}}}\,{C_{\text{W}}}}{{h_{\text{C}}}\,{A_{\text{C}}}}}{0.8}
+           \resizeExpression{{τ_{\text{W}}}=\frac{{m_{\text{W}}}\,{C_{\text{W}}}}{{h_{\text{C}}}\,{A_{\text{C}}}}}{\inDefScale}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -925,7 +927,7 @@ Units & Unitless
         
 \\ \midrule
 Equation & \begin{displaymath}
-           \resizeExpression{η=\frac{{h_{\text{P}}}\,{A_{\text{P}}}}{{h_{\text{C}}}\,{A_{\text{C}}}}}{0.8}
+           \resizeExpression{η=\frac{{h_{\text{P}}}\,{A_{\text{P}}}}{{h_{\text{C}}}\,{A_{\text{C}}}}}{\inDefScale}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -963,7 +965,7 @@ Units & ${\text{s}}$
         
 \\ \midrule
 Equation & \begin{displaymath}
-           \resizeExpression{{{τ_{\text{P}}}^{\text{S}}}=\frac{{m_{\text{P}}}\,{{C_{\text{P}}}^{\text{S}}}}{{h_{\text{P}}}\,{A_{\text{P}}}}}{0.8}
+           \resizeExpression{{{τ_{\text{P}}}^{\text{S}}}=\frac{{m_{\text{P}}}\,{{C_{\text{P}}}^{\text{S}}}}{{h_{\text{P}}}\,{A_{\text{P}}}}}{\inDefScale}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -1001,7 +1003,7 @@ Units & ${\text{s}}$
         
 \\ \midrule
 Equation & \begin{displaymath}
-           \resizeExpression{{{τ_{\text{P}}}^{\text{L}}}=\frac{{m_{\text{P}}}\,{{C_{\text{P}}}^{\text{L}}}}{{h_{\text{P}}}\,{A_{\text{P}}}}}{0.8}
+           \resizeExpression{{{τ_{\text{P}}}^{\text{L}}}=\frac{{m_{\text{P}}}\,{{C_{\text{P}}}^{\text{L}}}}{{h_{\text{P}}}\,{A_{\text{P}}}}}{\inDefScale}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -1039,7 +1041,7 @@ Units & $\frac{\text{J}}{\text{kg}}$
         
 \\ \midrule
 Equation & \begin{displaymath}
-           \resizeExpression{{H_{\text{f}}}=\frac{Q}{m}}{0.8}
+           \resizeExpression{{H_{\text{f}}}=\frac{Q}{m}}{\inDefScale}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -1078,7 +1080,7 @@ Units & Unitless
         
 \\ \midrule
 Equation & \begin{displaymath}
-           \resizeExpression{ϕ=\frac{{Q_{\text{P}}}}{{H_{\text{f}}}\,{m_{\text{P}}}}}{0.8}
+           \resizeExpression{ϕ=\frac{{Q_{\text{P}}}}{{H_{\text{f}}}\,{m_{\text{P}}}}}{\inDefScale}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -1120,7 +1122,7 @@ Units & Unitless
         
 \\ \midrule
 Equation & \begin{displaymath}
-           \resizeExpression{\mathit{AR}=\frac{D}{L}}{0.8}
+           \resizeExpression{\mathit{AR}=\frac{D}{L}}{\inDefScale}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -1161,13 +1163,13 @@ Output & ${T_{\text{W}}}$
          
 \\ \midrule
 Input Constraints & \begin{displaymath}
-                    \resizeExpression{{T_{\text{C}}}\gt{}{T_{\text{init}}}}{0.8}
+                    \resizeExpression{{T_{\text{C}}}\gt{}{T_{\text{init}}}}{\inDefScale}
                     \end{displaymath}
 \\ \midrule
 Output Constraints & 
 \\ \midrule
 Equation & \begin{displaymath}
-           \resizeExpression{\frac{\,d{T_{\text{W}}}}{\,dt}=\frac{1}{{τ_{\text{W}}}}\,\left({T_{\text{C}}}-{T_{\text{W}}}\left(t\right)+η\,\left({T_{\text{P}}}\left(t\right)-{T_{\text{W}}}\left(t\right)\right)\right)}{0.8}
+           \resizeExpression{\frac{\,d{T_{\text{W}}}}{\,dt}=\frac{1}{{τ_{\text{W}}}}\,\left({T_{\text{C}}}-{T_{\text{W}}}\left(t\right)+η\,\left({T_{\text{P}}}\left(t\right)-{T_{\text{W}}}\left(t\right)\right)\right)}{\inDefScale}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -1206,37 +1208,37 @@ RefBy & \hyperref[IM:eBalanceOnWtr]{IM:eBalanceOnWtr}, \hyperref[IM:eBalanceOnPC
 To find the rate of change of ${T_{\text{W}}}$, we look at the energy balance on water. The volume being considered is the volume of water in the tank ${V_{\text{W}}}$, which has mass ${m_{\text{W}}}$ and specific heat capacity, ${C_{\text{W}}}$. Heat transfer occurs in the water from the heating coil as ${q_{\text{C}}}$ (\hyperref[GD:htFluxWaterFromCoil]{GD:htFluxWaterFromCoil}) and from the water into the PCM as ${q_{\text{P}}}$ (\hyperref[GD:htFluxPCMFromWater]{GD:htFluxPCMFromWater}), over areas ${A_{\text{C}}}$ and ${A_{\text{P}}}$, respectively. The thermal flux is constant over ${A_{\text{C}}}$, since the temperature of the heating coil is assumed to not vary along its length (\hyperref[assumpTHCCoL]{A:Temp-Heating-Coil-Constant-over-Length}), and the thermal flux is constant over ${A_{\text{P}}}$, since the temperature of the PCM is the same throughout its volume (\hyperref[assumpTPCAV]{A:Temp-PCM-Constant-Across-Volume}) and the water is fully mixed (\hyperref[assumpCWTAT]{A:Constant-Water-Temp-Across-Tank}). No heat transfer occurs to the outside of the tank, since it has been assumed to be perfectly insulated (\hyperref[assumpPIT]{A:Perfect-Insulation-Tank}). Since the assumption is made that no internal heat is generated (\hyperref[assumpNIHGBWP]{A:No-Internal-Heat-Generation-By-Water-PCM}), $g=0$. Therefore, the equation for \hyperref[GD:rocTempSimp]{GD:rocTempSimp} can be written as:
 
 \begin{displaymath}
-\resizeExpression{{m_{\text{W}}}\,{C_{\text{W}}}\,\frac{\,d{T_{\text{W}}}}{\,dt}={q_{\text{C}}}\,{A_{\text{C}}}-{q_{\text{P}}}\,{A_{\text{P}}}}{1.0}
+\resizeExpression{{m_{\text{W}}}\,{C_{\text{W}}}\,\frac{\,d{T_{\text{W}}}}{\,dt}={q_{\text{C}}}\,{A_{\text{C}}}-{q_{\text{P}}}\,{A_{\text{P}}}}{\outDefScale}
 \end{displaymath}
 Using \hyperref[GD:htFluxWaterFromCoil]{GD:htFluxWaterFromCoil} for ${q_{\text{C}}}$ and \hyperref[GD:htFluxPCMFromWater]{GD:htFluxPCMFromWater} for ${q_{\text{P}}}$, this can be written as:
 
 \begin{displaymath}
-\resizeExpression{{m_{\text{W}}}\,{C_{\text{W}}}\,\frac{\,d{T_{\text{W}}}}{\,dt}={h_{\text{C}}}\,{A_{\text{C}}}\,\left({T_{\text{C}}}-{T_{\text{W}}}\right)-{h_{\text{P}}}\,{A_{\text{P}}}\,\left({T_{\text{W}}}-{T_{\text{P}}}\right)}{1.0}
+\resizeExpression{{m_{\text{W}}}\,{C_{\text{W}}}\,\frac{\,d{T_{\text{W}}}}{\,dt}={h_{\text{C}}}\,{A_{\text{C}}}\,\left({T_{\text{C}}}-{T_{\text{W}}}\right)-{h_{\text{P}}}\,{A_{\text{P}}}\,\left({T_{\text{W}}}-{T_{\text{P}}}\right)}{\outDefScale}
 \end{displaymath}
 Dividing Equation (2) by ${m_{\text{W}}}\,{C_{\text{W}}}$, we obtain:
 
 \begin{displaymath}
-\resizeExpression{\frac{\,d{T_{\text{W}}}}{\,dt}=\frac{{h_{\text{C}}}\,{A_{\text{C}}}}{{m_{\text{W}}}\,{C_{\text{W}}}}\,\left({T_{\text{C}}}-{T_{\text{W}}}\right)-\frac{{h_{\text{P}}}\,{A_{\text{P}}}}{{m_{\text{W}}}\,{C_{\text{W}}}}\,\left({T_{\text{W}}}-{T_{\text{P}}}\right)}{1.0}
+\resizeExpression{\frac{\,d{T_{\text{W}}}}{\,dt}=\frac{{h_{\text{C}}}\,{A_{\text{C}}}}{{m_{\text{W}}}\,{C_{\text{W}}}}\,\left({T_{\text{C}}}-{T_{\text{W}}}\right)-\frac{{h_{\text{P}}}\,{A_{\text{P}}}}{{m_{\text{W}}}\,{C_{\text{W}}}}\,\left({T_{\text{W}}}-{T_{\text{P}}}\right)}{\outDefScale}
 \end{displaymath}
 Factoring the negative sign out of the second term of the right-hand side (RHS) of Equation (3) and multiplying it by ${h_{\text{C}}}$ ${A_{\text{C}}}$ / ${h_{\text{C}}}$ ${A_{\text{C}}}$ yields:
 
 \begin{displaymath}
-\resizeExpression{\frac{\,d{T_{\text{W}}}}{\,dt}=\frac{{h_{\text{C}}}\,{A_{\text{C}}}}{{m_{\text{W}}}\,{C_{\text{W}}}}\,\left({T_{\text{C}}}-{T_{\text{W}}}\right)+\frac{{h_{\text{C}}}\,{A_{\text{C}}}}{{h_{\text{C}}}\,{A_{\text{C}}}}\,\frac{{h_{\text{P}}}\,{A_{\text{P}}}}{{m_{\text{W}}}\,{C_{\text{W}}}}\,\left({T_{\text{P}}}-{T_{\text{W}}}\right)}{1.0}
+\resizeExpression{\frac{\,d{T_{\text{W}}}}{\,dt}=\frac{{h_{\text{C}}}\,{A_{\text{C}}}}{{m_{\text{W}}}\,{C_{\text{W}}}}\,\left({T_{\text{C}}}-{T_{\text{W}}}\right)+\frac{{h_{\text{C}}}\,{A_{\text{C}}}}{{h_{\text{C}}}\,{A_{\text{C}}}}\,\frac{{h_{\text{P}}}\,{A_{\text{P}}}}{{m_{\text{W}}}\,{C_{\text{W}}}}\,\left({T_{\text{P}}}-{T_{\text{W}}}\right)}{\outDefScale}
 \end{displaymath}
 Rearranging this equation gives us:
 
 \begin{displaymath}
-\resizeExpression{\frac{\,d{T_{\text{W}}}}{\,dt}=\frac{{h_{\text{C}}}\,{A_{\text{C}}}}{{m_{\text{W}}}\,{C_{\text{W}}}}\,\left({T_{\text{C}}}-{T_{\text{W}}}\right)+\frac{{h_{\text{P}}}\,{A_{\text{P}}}}{{h_{\text{C}}}\,{A_{\text{C}}}}\,\frac{{h_{\text{C}}}\,{A_{\text{C}}}}{{m_{\text{W}}}\,{C_{\text{W}}}}\,\left({T_{\text{P}}}-{T_{\text{W}}}\right)}{1.0}
+\resizeExpression{\frac{\,d{T_{\text{W}}}}{\,dt}=\frac{{h_{\text{C}}}\,{A_{\text{C}}}}{{m_{\text{W}}}\,{C_{\text{W}}}}\,\left({T_{\text{C}}}-{T_{\text{W}}}\right)+\frac{{h_{\text{P}}}\,{A_{\text{P}}}}{{h_{\text{C}}}\,{A_{\text{C}}}}\,\frac{{h_{\text{C}}}\,{A_{\text{C}}}}{{m_{\text{W}}}\,{C_{\text{W}}}}\,\left({T_{\text{P}}}-{T_{\text{W}}}\right)}{\outDefScale}
 \end{displaymath}
 By substituting ${τ_{\text{W}}}$ (from \hyperref[DD:balanceDecayRate]{DD:balanceDecayRate}) and $η$ (from \hyperref[DD:balanceDecayTime]{DD:balanceDecayTime}), this can be written as:
 
 \begin{displaymath}
-\resizeExpression{\frac{\,d{T_{\text{W}}}}{\,dt}=\frac{1}{{τ_{\text{W}}}}\,\left({T_{\text{C}}}-{T_{\text{W}}}\right)+\frac{η}{{τ_{\text{W}}}}\,\left({T_{\text{P}}}-{T_{\text{W}}}\right)}{1.0}
+\resizeExpression{\frac{\,d{T_{\text{W}}}}{\,dt}=\frac{1}{{τ_{\text{W}}}}\,\left({T_{\text{C}}}-{T_{\text{W}}}\right)+\frac{η}{{τ_{\text{W}}}}\,\left({T_{\text{P}}}-{T_{\text{W}}}\right)}{\outDefScale}
 \end{displaymath}
 Finally, factoring out $\frac{1}{{τ_{\text{W}}}}$, we are left with the governing ODE for \hyperref[IM:eBalanceOnWtr]{IM:eBalanceOnWtr}:
 
 \begin{displaymath}
-\resizeExpression{\frac{\,d{T_{\text{W}}}}{\,dt}=\frac{1}{{τ_{\text{W}}}}\,\left({T_{\text{C}}}-{T_{\text{W}}}+η\,\left({T_{\text{P}}}-{T_{\text{W}}}\right)\right)}{1.0}
+\resizeExpression{\frac{\,d{T_{\text{W}}}}{\,dt}=\frac{1}{{τ_{\text{W}}}}\,\left({T_{\text{C}}}-{T_{\text{W}}}+η\,\left({T_{\text{P}}}-{T_{\text{W}}}\right)\right)}{\outDefScale}
 \end{displaymath}
 \medskip
 \noindent
@@ -1256,7 +1258,7 @@ Output & ${T_{\text{P}}}$
          
 \\ \midrule
 Input Constraints & \begin{displaymath}
-                    \resizeExpression{{{T_{\text{melt}}}^{\text{P}}}\gt{}{T_{\text{init}}}}{0.8}
+                    \resizeExpression{{{T_{\text{melt}}}^{\text{P}}}\gt{}{T_{\text{init}}}}{\inDefScale}
                     \end{displaymath}
 \\ \midrule
 Output Constraints & 
@@ -1266,7 +1268,7 @@ Equation & \begin{displaymath}
                                                             \frac{1}{{{τ_{\text{P}}}^{\text{S}}}}\,\left({T_{\text{W}}}\left(t\right)-{T_{\text{P}}}\left(t\right)\right), & {T_{\text{P}}}\lt{}{{T_{\text{melt}}}^{\text{P}}}\\
                                                             \frac{1}{{{τ_{\text{P}}}^{\text{L}}}}\,\left({T_{\text{W}}}\left(t\right)-{T_{\text{P}}}\left(t\right)\right), & {T_{\text{P}}}\gt{}{{T_{\text{melt}}}^{\text{P}}}\\
                                                             0, & {T_{\text{P}}}={{T_{\text{melt}}}^{\text{P}}}\land{}0\lt{}ϕ\lt{}1
-                                                            \end{cases}}{0.8}
+                                                            \end{cases}}{\inDefScale}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -1306,22 +1308,22 @@ RefBy & \hyperref[IM:eBalanceOnWtr]{IM:eBalanceOnWtr}, \hyperref[unlikeChgNIHG]{
 To find the rate of change of ${T_{\text{P}}}$, we look at the energy balance on the PCM. The volume being considered is the volume of PCM (${V_{\text{P}}}$). The derivation that follows is initially for the solid PCM. The mass of phase change material is ${m_{\text{P}}}$ and the specific heat capacity of PCM as a solid is ${{C_{\text{P}}}^{\text{S}}}$. The heat flux into the PCM from water is ${q_{\text{P}}}$ (\hyperref[GD:htFluxPCMFromWater]{GD:htFluxPCMFromWater}) over phase change material surface area ${A_{\text{P}}}$. The thermal flux is constant over ${A_{\text{P}}}$, since the temperature of the PCM is the same throughout its volume (\hyperref[assumpTPCAV]{A:Temp-PCM-Constant-Across-Volume}) and the water is fully mixed (\hyperref[assumpCWTAT]{A:Constant-Water-Temp-Across-Tank}). There is no heat flux output from the PCM. Assuming no volumetric heat generation per unit volume (\hyperref[assumpNIHGBWP]{A:No-Internal-Heat-Generation-By-Water-PCM}), $g=0$, the equation for \hyperref[GD:rocTempSimp]{GD:rocTempSimp} can be written as:
 
 \begin{displaymath}
-\resizeExpression{{m_{\text{P}}}\,{{C_{\text{P}}}^{\text{S}}}\,\frac{\,d{T_{\text{P}}}}{\,dt}={q_{\text{P}}}\,{A_{\text{P}}}}{1.0}
+\resizeExpression{{m_{\text{P}}}\,{{C_{\text{P}}}^{\text{S}}}\,\frac{\,d{T_{\text{P}}}}{\,dt}={q_{\text{P}}}\,{A_{\text{P}}}}{\outDefScale}
 \end{displaymath}
 Using \hyperref[GD:htFluxPCMFromWater]{GD:htFluxPCMFromWater} for ${q_{\text{P}}}$, this equation can be written as:
 
 \begin{displaymath}
-\resizeExpression{{m_{\text{P}}}\,{{C_{\text{P}}}^{\text{S}}}\,\frac{\,d{T_{\text{P}}}}{\,dt}={h_{\text{P}}}\,{A_{\text{P}}}\,\left({T_{\text{W}}}-{T_{\text{P}}}\right)}{1.0}
+\resizeExpression{{m_{\text{P}}}\,{{C_{\text{P}}}^{\text{S}}}\,\frac{\,d{T_{\text{P}}}}{\,dt}={h_{\text{P}}}\,{A_{\text{P}}}\,\left({T_{\text{W}}}-{T_{\text{P}}}\right)}{\outDefScale}
 \end{displaymath}
 Dividing by ${m_{\text{P}}}$ ${{C_{\text{P}}}^{\text{S}}}$ we obtain:
 
 \begin{displaymath}
-\resizeExpression{\frac{\,d{T_{\text{P}}}}{\,dt}=\frac{{h_{\text{P}}}\,{A_{\text{P}}}}{{m_{\text{P}}}\,{{C_{\text{P}}}^{\text{S}}}}\,\left({T_{\text{W}}}-{T_{\text{P}}}\right)}{1.0}
+\resizeExpression{\frac{\,d{T_{\text{P}}}}{\,dt}=\frac{{h_{\text{P}}}\,{A_{\text{P}}}}{{m_{\text{P}}}\,{{C_{\text{P}}}^{\text{S}}}}\,\left({T_{\text{W}}}-{T_{\text{P}}}\right)}{\outDefScale}
 \end{displaymath}
 By substituting ${{τ_{\text{P}}}^{\text{S}}}$ (from \hyperref[DD:balanceSolidPCM]{DD:balanceSolidPCM}), this can be written as:
 
 \begin{displaymath}
-\resizeExpression{\frac{\,d{T_{\text{P}}}}{\,dt}=\frac{1}{{{τ_{\text{P}}}^{\text{S}}}}\,\left({T_{\text{W}}}-{T_{\text{P}}}\right)}{1.0}
+\resizeExpression{\frac{\,d{T_{\text{P}}}}{\,dt}=\frac{1}{{{τ_{\text{P}}}^{\text{S}}}}\,\left({T_{\text{W}}}-{T_{\text{P}}}\right)}{\outDefScale}
 \end{displaymath}
 Equation (4) applies for the solid PCM. In the case where all of the PCM is melted, the same derivation applies, except that ${{C_{\text{P}}}^{\text{S}}}$ is replaced by ${{C_{\text{P}}}^{\text{L}}}$, and thus ${{τ_{\text{P}}}^{\text{S}}}$ is replaced by ${{τ_{\text{P}}}^{\text{L}}}$. Although a small change in surface area would be expected with melting, this is not included, since the volume change of the PCM with melting is assumed to be negligible (\hyperref[assumpVCMPN]{A:Volume-Change-Melting-PCM-Negligible}).
 
@@ -1351,7 +1353,7 @@ Input Constraints &
 Output Constraints & 
 \\ \midrule
 Equation & \begin{displaymath}
-           \resizeExpression{{E_{\text{W}}}\left(t\right)={C_{\text{W}}}\,{m_{\text{W}}}\,\left({T_{\text{W}}}\left(t\right)-{T_{\text{init}}}\right)}{0.8}
+           \resizeExpression{{E_{\text{W}}}\left(t\right)={C_{\text{W}}}\,{m_{\text{W}}}\,\left({T_{\text{W}}}\left(t\right)-{T_{\text{init}}}\right)}{\inDefScale}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -1397,7 +1399,7 @@ Output & ${E_{\text{P}}}$
          
 \\ \midrule
 Input Constraints & \begin{displaymath}
-                    \resizeExpression{{{T_{\text{melt}}}^{\text{P}}}\gt{}{T_{\text{init}}}}{0.8}
+                    \resizeExpression{{{T_{\text{melt}}}^{\text{P}}}\gt{}{T_{\text{init}}}}{\inDefScale}
                     \end{displaymath}
 \\ \midrule
 Output Constraints & 
@@ -1407,7 +1409,7 @@ Equation & \begin{displaymath}
                                             {{C_{\text{P}}}^{\text{S}}}\,{m_{\text{P}}}\,\left({T_{\text{P}}}\left(t\right)-{T_{\text{init}}}\right), & {T_{\text{P}}}\lt{}{{T_{\text{melt}}}^{\text{P}}}\\
                                             {{{E_{\text{P}}}_{\text{melt}}}^{\text{init}}}+{H_{\text{f}}}\,{m_{\text{P}}}+{{C_{\text{P}}}^{\text{L}}}\,{m_{\text{P}}}\,\left({T_{\text{P}}}\left(t\right)-{{T_{\text{melt}}}^{\text{P}}}\right), & {T_{\text{P}}}\gt{}{{T_{\text{melt}}}^{\text{P}}}\\
                                             {{{E_{\text{P}}}_{\text{melt}}}^{\text{init}}}+{Q_{\text{P}}}\left(t\right), & {T_{\text{P}}}={{T_{\text{melt}}}^{\text{P}}}\land{}0\lt{}ϕ\lt{}1
-                                            \end{cases}}{0.8}
+                                            \end{cases}}{\inDefScale}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -1516,12 +1518,12 @@ ${E_{\text{P}}}$ & ${E_{\text{P}}}\geq{}0$
 A correct solution must exhibit the law of conservation of energy. This means that the change in heat energy in the water should equal the difference between the total energy input from the heating coil and the energy output to the PCM. This can be shown as an equation by taking \hyperref[GD:htFluxWaterFromCoil]{GD:htFluxWaterFromCoil} and \hyperref[GD:htFluxPCMFromWater]{GD:htFluxPCMFromWater}, multiplying each by their respective surface area of heat transfer, and integrating each over the simulation time, as follows:
 
 \begin{displaymath}
-\resizeExpression{{E_{\text{W}}}=\int_{0}^{t}{{h_{\text{C}}}\,{A_{\text{C}}}\,\left({T_{\text{C}}}-{T_{\text{W}}}\left(t\right)\right)}\,dt-\int_{0}^{t}{{h_{\text{P}}}\,{A_{\text{P}}}\,\left({T_{\text{W}}}\left(t\right)-{T_{\text{P}}}\left(t\right)\right)}\,dt}{1.0}
+\resizeExpression{{E_{\text{W}}}=\int_{0}^{t}{{h_{\text{C}}}\,{A_{\text{C}}}\,\left({T_{\text{C}}}-{T_{\text{W}}}\left(t\right)\right)}\,dt-\int_{0}^{t}{{h_{\text{P}}}\,{A_{\text{P}}}\,\left({T_{\text{W}}}\left(t\right)-{T_{\text{P}}}\left(t\right)\right)}\,dt}{\outDefScale}
 \end{displaymath}
 In addition, the change in heat energy in the PCM should equal the energy input to the PCM from the water. This can be expressed as
 
 \begin{displaymath}
-\resizeExpression{{E_{\text{P}}}=\int_{0}^{t}{{h_{\text{P}}}\,{A_{\text{P}}}\,\left({T_{\text{W}}}\left(t\right)-{T_{\text{P}}}\left(t\right)\right)}\,dt}{1.0}
+\resizeExpression{{E_{\text{P}}}=\int_{0}^{t}{{h_{\text{P}}}\,{A_{\text{P}}}\,\left({T_{\text{W}}}\left(t\right)-{T_{\text{P}}}\left(t\right)\right)}\,dt}{\outDefScale}
 \end{displaymath}
 Equations (FIXME: Equation 7) and (FIXME: Equation 8) can be used as ``sanity'' checks to gain confidence in any solution computed by SWHS. The relative error between the results computed by SWHS and the results calculated from the RHS of these equations should be less than ${C_{\text{tol}}}$ \hyperref[verifyEnergyOutput]{FR:Verify-Energy-Output-Follow-Conservation-of-Energy}.
 

--- a/code/stable/swhs/SRS/PDF/SWHS_SRS.tex
+++ b/code/stable/swhs/SRS/PDF/SWHS_SRS.tex
@@ -27,12 +27,12 @@
 \setlist[symbDescription]{noitemsep, topsep=0pt, parsep=0pt, partopsep=0pt}
 \newsavebox{\mybox}
 \newcommand{\resizeExpression}[2]{
-\savebox{\mybox}{$#1$}
-\ifdim\wd\mybox>#2\linewidth
-\resizebox{#2\textwidth}{!}{\usebox{\mybox}}
-\else
-\usebox{\mybox}
-\fi
+  \savebox{\mybox}{$#1$}
+  \ifdim\wd\mybox>#2\linewidth
+    \resizebox{#2\textwidth}{!}{\usebox{\mybox}}
+  \else
+    \usebox{\mybox}
+  \fi
 }
 \bibliography{bibfile}
 \title{Software Requirements Specification for Solar Water Heating Systems Incorporating PCM}

--- a/code/stable/swhsnopcm/SRS/PDF/SWHSNoPCM_SRS.tex
+++ b/code/stable/swhsnopcm/SRS/PDF/SWHSNoPCM_SRS.tex
@@ -27,12 +27,12 @@
 \setlist[symbDescription]{noitemsep, topsep=0pt, parsep=0pt, partopsep=0pt}
 \newsavebox{\mybox}
 \newcommand{\resizeExpression}[2]{
-\savebox{\mybox}{$#1$}
-\ifdim\wd\mybox>#2\linewidth
-\resizebox{#2\textwidth}{!}{\usebox{\mybox}}
-\else
-\usebox{\mybox}
-\fi
+  \savebox{\mybox}{$#1$}
+  \ifdim\wd\mybox>#2\linewidth
+    \resizebox{#2\textwidth}{!}{\usebox{\mybox}}
+  \else
+    \usebox{\mybox}
+  \fi
 }
 \bibliography{bibfile}
 \title{Software Requirements Specification for Solar Water Heating Systems}

--- a/code/stable/swhsnopcm/SRS/PDF/SWHSNoPCM_SRS.tex
+++ b/code/stable/swhsnopcm/SRS/PDF/SWHSNoPCM_SRS.tex
@@ -15,6 +15,8 @@
 \usepackage{svg}
 \usepackage{float}
 \usepackage{enumitem}
+\usepackage{graphicx}
+\usepackage{calc}
 \usepackage{filecontents}
 \usepackage[backend=bibtex]{biblatex}
 \usepackage{url}
@@ -23,6 +25,15 @@
 \newcommand{\lt}{\ensuremath <}
 \newlist{symbDescription}{description}{1}
 \setlist[symbDescription]{noitemsep, topsep=0pt, parsep=0pt, partopsep=0pt}
+\newsavebox{\mybox}
+\newcommand{\resizeExpression}[2]{
+\savebox{\mybox}{$#1$}
+\ifdim\wd\mybox>#2\linewidth
+\resizebox{#2\textwidth}{!}{\usebox{\mybox}}
+\else
+\usebox{\mybox}
+\fi
+}
 \bibliography{bibfile}
 \title{Software Requirements Specification for Solar Water Heating Systems}
 \author{Thulasi Jegatheesan}
@@ -357,7 +368,7 @@ Label & Conservation of thermal energy
         
 \\ \midrule
 Equation & \begin{displaymath}
-           -∇\cdot{}\symbf{q}+g=ρ\,C\,\frac{\,\partial{}T}{\,\partial{}t}
+           \resizeExpression{-∇\cdot{}\symbf{q}+g=ρ\,C\,\frac{\,\partial{}T}{\,\partial{}t}}{0.8}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -396,7 +407,7 @@ Label & Sensible heat energy (no state change)
         
 \\ \midrule
 Equation & \begin{displaymath}
-           E={C^{\text{L}}}\,m\,ΔT
+           \resizeExpression{E={C^{\text{L}}}\,m\,ΔT}{0.8}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -430,7 +441,7 @@ Label & Newton's law of cooling
         
 \\ \midrule
 Equation & \begin{displaymath}
-           q\left(t\right)=h\,ΔT\left(t\right)
+           \resizeExpression{q\left(t\right)=h\,ΔT\left(t\right)}{0.8}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -472,7 +483,7 @@ Label & Simplified rate of change of temperature
         
 \\ \midrule
 Equation & \begin{displaymath}
-           m\,C\,\frac{\,dT}{\,dt}={q_{\text{in}}}\,{A_{\text{in}}}-{q_{\text{out}}}\,{A_{\text{out}}}+g\,V
+           \resizeExpression{m\,C\,\frac{\,dT}{\,dt}={q_{\text{in}}}\,{A_{\text{in}}}-{q_{\text{out}}}\,{A_{\text{out}}}+g\,V}{0.8}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -502,27 +513,27 @@ RefBy & \hyperref[GD:rocTempSimp]{GD:rocTempSimp} and \hyperref[IM:eBalanceOnWtr
 Integrating \hyperref[TM:consThermE]{TM:consThermE} over a volume ($V$), we have:
 
 \begin{displaymath}
--\int_{V}{∇\cdot{}\symbf{q}}\,dV+\int_{V}{g}\,dV=\int_{V}{ρ\,C\,\frac{\,\partial{}T}{\,\partial{}t}}\,dV
+\resizeExpression{-\int_{V}{∇\cdot{}\symbf{q}}\,dV+\int_{V}{g}\,dV=\int_{V}{ρ\,C\,\frac{\,\partial{}T}{\,\partial{}t}}\,dV}{1.0}
 \end{displaymath}
 Applying Gauss's Divergence Theorem to the first term over the surface $S$ of the volume, with $\symbf{q}$ as the thermal flux vector for the surface and $\symbf{\hat{n}}$ as a unit outward normal vector for a surface:
 
 \begin{displaymath}
--\int_{S}{\symbf{q}\cdot{}\symbf{\hat{n}}}\,dS+\int_{V}{g}\,dV=\int_{V}{ρ\,C\,\frac{\,\partial{}T}{\,\partial{}t}}\,dV
+\resizeExpression{-\int_{S}{\symbf{q}\cdot{}\symbf{\hat{n}}}\,dS+\int_{V}{g}\,dV=\int_{V}{ρ\,C\,\frac{\,\partial{}T}{\,\partial{}t}}\,dV}{1.0}
 \end{displaymath}
 We consider an arbitrary volume. The volumetric heat generation per unit volume is assumed constant. Then Equation (1) can be written as:
 
 \begin{displaymath}
-{q_{\text{in}}}\,{A_{\text{in}}}-{q_{\text{out}}}\,{A_{\text{out}}}+g\,V=\int_{V}{ρ\,C\,\frac{\,\partial{}T}{\,\partial{}t}}\,dV
+\resizeExpression{{q_{\text{in}}}\,{A_{\text{in}}}-{q_{\text{out}}}\,{A_{\text{out}}}+g\,V=\int_{V}{ρ\,C\,\frac{\,\partial{}T}{\,\partial{}t}}\,dV}{1.0}
 \end{displaymath}
 Where ${q_{\text{in}}}$, ${q_{\text{out}}}$, ${A_{\text{in}}}$, and ${A_{\text{out}}}$ are explained in \hyperref[GD:rocTempSimp]{GD:rocTempSimp}. Assuming $ρ$, $C$, and $T$ are constant over the volume, which is true in our case by \hyperref[assumpCWTAT]{A:Constant-Water-Temp-Across-Tank}, \hyperref[assumpDWCoW]{A:Density-Water-Constant-over-Volume}, and \hyperref[assumpSHECoW]{A:Specific-Heat-Energy-Constant-over-Volume}, we have:
 
 \begin{displaymath}
-ρ\,C\,V\,\frac{\,dT}{\,dt}={q_{\text{in}}}\,{A_{\text{in}}}-{q_{\text{out}}}\,{A_{\text{out}}}+g\,V
+\resizeExpression{ρ\,C\,V\,\frac{\,dT}{\,dt}={q_{\text{in}}}\,{A_{\text{in}}}-{q_{\text{out}}}\,{A_{\text{out}}}+g\,V}{1.0}
 \end{displaymath}
 Using the fact that $ρ$=$m$/$V$, Equation (2) can be written as:
 
 \begin{displaymath}
-m\,C\,\frac{\,dT}{\,dt}={q_{\text{in}}}\,{A_{\text{in}}}-{q_{\text{out}}}\,{A_{\text{out}}}+g\,V
+\resizeExpression{m\,C\,\frac{\,dT}{\,dt}={q_{\text{in}}}\,{A_{\text{in}}}-{q_{\text{out}}}\,{A_{\text{out}}}+g\,V}{1.0}
 \end{displaymath}
 \medskip
 \noindent
@@ -539,7 +550,7 @@ Units & $\frac{\text{W}}{\text{m}^{2}}$
         
 \\ \midrule
 Equation & \begin{displaymath}
-           {q_{\text{C}}}={h_{\text{C}}}\,\left({T_{\text{C}}}-{T_{\text{W}}}\left(t\right)\right)
+           \resizeExpression{{q_{\text{C}}}={h_{\text{C}}}\,\left({T_{\text{C}}}-{T_{\text{W}}}\left(t\right)\right)}{0.8}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -586,7 +597,7 @@ Units & ${\text{kg}}$
         
 \\ \midrule
 Equation & \begin{displaymath}
-           {m_{\text{W}}}={V_{\text{W}}}\,{ρ_{\text{W}}}
+           \resizeExpression{{m_{\text{W}}}={V_{\text{W}}}\,{ρ_{\text{W}}}}{0.8}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -622,7 +633,7 @@ Units & ${\text{m}^{3}}$
         
 \\ \midrule
 Equation & \begin{displaymath}
-           {V_{\text{W}}}={V_{\text{tank}}}
+           \resizeExpression{{V_{\text{W}}}={V_{\text{tank}}}}{0.8}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -660,7 +671,7 @@ Units & ${\text{m}^{3}}$
         
 \\ \midrule
 Equation & \begin{displaymath}
-           {V_{\text{tank}}}=π\,\left(\frac{D}{2}\right)^{2}\,L
+           \resizeExpression{{V_{\text{tank}}}=π\,\left(\frac{D}{2}\right)^{2}\,L}{0.8}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -697,7 +708,7 @@ Units & ${\text{s}}$
         
 \\ \midrule
 Equation & \begin{displaymath}
-           {τ_{\text{W}}}=\frac{{m_{\text{W}}}\,{C_{\text{W}}}}{{h_{\text{C}}}\,{A_{\text{C}}}}
+           \resizeExpression{{τ_{\text{W}}}=\frac{{m_{\text{W}}}\,{C_{\text{W}}}}{{h_{\text{C}}}\,{A_{\text{C}}}}}{0.8}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -741,13 +752,13 @@ Output & ${T_{\text{W}}}$
          
 \\ \midrule
 Input Constraints & \begin{displaymath}
-                    {T_{\text{C}}}\geq{}{T_{\text{init}}}
+                    \resizeExpression{{T_{\text{C}}}\geq{}{T_{\text{init}}}}{0.8}
                     \end{displaymath}
 \\ \midrule
 Output Constraints & 
 \\ \midrule
 Equation & \begin{displaymath}
-           \frac{\,d{T_{\text{W}}}}{\,dt}+\frac{1}{{τ_{\text{W}}}}\,{{T_{\text{W}}}}=\frac{1}{{τ_{\text{W}}}}\,{T_{\text{C}}}
+           \resizeExpression{\frac{\,d{T_{\text{W}}}}{\,dt}+\frac{1}{{τ_{\text{W}}}}\,{{T_{\text{W}}}}=\frac{1}{{τ_{\text{W}}}}\,{T_{\text{C}}}}{0.8}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -776,22 +787,22 @@ RefBy & \hyperref[unlikeChgNIHG]{UC:No-Internal-Heat-Generation}, \hyperref[outp
 To find the rate of change of ${T_{\text{W}}}$, we look at the energy balance on water. The volume being considered is the volume of water in the tank ${V_{\text{W}}}$, which has mass ${m_{\text{W}}}$ and specific heat capacity, ${C_{\text{W}}}$. Heat transfer occurs in the water from the heating coil as ${q_{\text{C}}}$ (\hyperref[GD:htFluxWaterFromCoil]{GD:htFluxWaterFromCoil}), over area ${A_{\text{C}}}$. No heat transfer occurs to the outside of the tank, since it has been assumed to be perfectly insulated (\hyperref[assumpPIT]{A:Perfect-Insulation-Tank}). Since the assumption is made that no internal heat is generated (\hyperref[assumpNIHGBW]{A:No-Internal-Heat-Generation-By-Water}), $g=0$. Therefore, the equation for \hyperref[GD:rocTempSimp]{GD:rocTempSimp} can be written as:
 
 \begin{displaymath}
-{m_{\text{W}}}\,{C_{\text{W}}}\,\frac{\,d{T_{\text{W}}}}{\,dt}={q_{\text{C}}}\,{A_{\text{C}}}
+\resizeExpression{{m_{\text{W}}}\,{C_{\text{W}}}\,\frac{\,d{T_{\text{W}}}}{\,dt}={q_{\text{C}}}\,{A_{\text{C}}}}{1.0}
 \end{displaymath}
 Using \hyperref[GD:htFluxWaterFromCoil]{GD:htFluxWaterFromCoil} for ${q_{\text{C}}}$, this can be written as:
 
 \begin{displaymath}
-{m_{\text{W}}}\,{C_{\text{W}}}\,\frac{\,d{T_{\text{W}}}}{\,dt}={h_{\text{C}}}\,{A_{\text{C}}}\,\left({T_{\text{C}}}-{T_{\text{W}}}\right)
+\resizeExpression{{m_{\text{W}}}\,{C_{\text{W}}}\,\frac{\,d{T_{\text{W}}}}{\,dt}={h_{\text{C}}}\,{A_{\text{C}}}\,\left({T_{\text{C}}}-{T_{\text{W}}}\right)}{1.0}
 \end{displaymath}
 Dividing Equation (2) by ${m_{\text{W}}}\,{C_{\text{W}}}$, we obtain:
 
 \begin{displaymath}
-\frac{\,d{T_{\text{W}}}}{\,dt}=\frac{{h_{\text{C}}}\,{A_{\text{C}}}}{{m_{\text{W}}}\,{C_{\text{W}}}}\,\left({T_{\text{C}}}-{T_{\text{W}}}\right)
+\resizeExpression{\frac{\,d{T_{\text{W}}}}{\,dt}=\frac{{h_{\text{C}}}\,{A_{\text{C}}}}{{m_{\text{W}}}\,{C_{\text{W}}}}\,\left({T_{\text{C}}}-{T_{\text{W}}}\right)}{1.0}
 \end{displaymath}
 By substituting ${τ_{\text{W}}}$ (from \hyperref[DD:balanceDecayRate]{DD:balanceDecayRate}), this can be written as:
 
 \begin{displaymath}
-\frac{\,d{T_{\text{W}}}}{\,dt}=\frac{1}{{τ_{\text{W}}}}\,\left({T_{\text{C}}}-{T_{\text{W}}}\right)
+\resizeExpression{\frac{\,d{T_{\text{W}}}}{\,dt}=\frac{1}{{τ_{\text{W}}}}\,\left({T_{\text{C}}}-{T_{\text{W}}}\right)}{1.0}
 \end{displaymath}
 \medskip
 \noindent
@@ -815,7 +826,7 @@ Input Constraints &
 Output Constraints & 
 \\ \midrule
 Equation & \begin{displaymath}
-           {E_{\text{W}}}\left(t\right)={C_{\text{W}}}\,{m_{\text{W}}}\,\left({T_{\text{W}}}\left(t\right)-{T_{\text{init}}}\right)
+           \resizeExpression{{E_{\text{W}}}\left(t\right)={C_{\text{W}}}\,{m_{\text{W}}}\,\left({T_{\text{W}}}\left(t\right)-{T_{\text{init}}}\right)}{0.8}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}

--- a/code/stable/swhsnopcm/SRS/PDF/SWHSNoPCM_SRS.tex
+++ b/code/stable/swhsnopcm/SRS/PDF/SWHSNoPCM_SRS.tex
@@ -25,6 +25,8 @@
 \newcommand{\lt}{\ensuremath <}
 \newlist{symbDescription}{description}{1}
 \setlist[symbDescription]{noitemsep, topsep=0pt, parsep=0pt, partopsep=0pt}
+\def\inDefScale{0.8}
+\def\outDefScale{1.0}
 \newsavebox{\mybox}
 \newcommand{\resizeExpression}[2]{
   \savebox{\mybox}{$#1$}
@@ -368,7 +370,7 @@ Label & Conservation of thermal energy
         
 \\ \midrule
 Equation & \begin{displaymath}
-           \resizeExpression{-∇\cdot{}\symbf{q}+g=ρ\,C\,\frac{\,\partial{}T}{\,\partial{}t}}{0.8}
+           \resizeExpression{-∇\cdot{}\symbf{q}+g=ρ\,C\,\frac{\,\partial{}T}{\,\partial{}t}}{\inDefScale}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -407,7 +409,7 @@ Label & Sensible heat energy (no state change)
         
 \\ \midrule
 Equation & \begin{displaymath}
-           \resizeExpression{E={C^{\text{L}}}\,m\,ΔT}{0.8}
+           \resizeExpression{E={C^{\text{L}}}\,m\,ΔT}{\inDefScale}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -441,7 +443,7 @@ Label & Newton's law of cooling
         
 \\ \midrule
 Equation & \begin{displaymath}
-           \resizeExpression{q\left(t\right)=h\,ΔT\left(t\right)}{0.8}
+           \resizeExpression{q\left(t\right)=h\,ΔT\left(t\right)}{\inDefScale}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -483,7 +485,7 @@ Label & Simplified rate of change of temperature
         
 \\ \midrule
 Equation & \begin{displaymath}
-           \resizeExpression{m\,C\,\frac{\,dT}{\,dt}={q_{\text{in}}}\,{A_{\text{in}}}-{q_{\text{out}}}\,{A_{\text{out}}}+g\,V}{0.8}
+           \resizeExpression{m\,C\,\frac{\,dT}{\,dt}={q_{\text{in}}}\,{A_{\text{in}}}-{q_{\text{out}}}\,{A_{\text{out}}}+g\,V}{\inDefScale}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -513,27 +515,27 @@ RefBy & \hyperref[GD:rocTempSimp]{GD:rocTempSimp} and \hyperref[IM:eBalanceOnWtr
 Integrating \hyperref[TM:consThermE]{TM:consThermE} over a volume ($V$), we have:
 
 \begin{displaymath}
-\resizeExpression{-\int_{V}{∇\cdot{}\symbf{q}}\,dV+\int_{V}{g}\,dV=\int_{V}{ρ\,C\,\frac{\,\partial{}T}{\,\partial{}t}}\,dV}{1.0}
+\resizeExpression{-\int_{V}{∇\cdot{}\symbf{q}}\,dV+\int_{V}{g}\,dV=\int_{V}{ρ\,C\,\frac{\,\partial{}T}{\,\partial{}t}}\,dV}{\outDefScale}
 \end{displaymath}
 Applying Gauss's Divergence Theorem to the first term over the surface $S$ of the volume, with $\symbf{q}$ as the thermal flux vector for the surface and $\symbf{\hat{n}}$ as a unit outward normal vector for a surface:
 
 \begin{displaymath}
-\resizeExpression{-\int_{S}{\symbf{q}\cdot{}\symbf{\hat{n}}}\,dS+\int_{V}{g}\,dV=\int_{V}{ρ\,C\,\frac{\,\partial{}T}{\,\partial{}t}}\,dV}{1.0}
+\resizeExpression{-\int_{S}{\symbf{q}\cdot{}\symbf{\hat{n}}}\,dS+\int_{V}{g}\,dV=\int_{V}{ρ\,C\,\frac{\,\partial{}T}{\,\partial{}t}}\,dV}{\outDefScale}
 \end{displaymath}
 We consider an arbitrary volume. The volumetric heat generation per unit volume is assumed constant. Then Equation (1) can be written as:
 
 \begin{displaymath}
-\resizeExpression{{q_{\text{in}}}\,{A_{\text{in}}}-{q_{\text{out}}}\,{A_{\text{out}}}+g\,V=\int_{V}{ρ\,C\,\frac{\,\partial{}T}{\,\partial{}t}}\,dV}{1.0}
+\resizeExpression{{q_{\text{in}}}\,{A_{\text{in}}}-{q_{\text{out}}}\,{A_{\text{out}}}+g\,V=\int_{V}{ρ\,C\,\frac{\,\partial{}T}{\,\partial{}t}}\,dV}{\outDefScale}
 \end{displaymath}
 Where ${q_{\text{in}}}$, ${q_{\text{out}}}$, ${A_{\text{in}}}$, and ${A_{\text{out}}}$ are explained in \hyperref[GD:rocTempSimp]{GD:rocTempSimp}. Assuming $ρ$, $C$, and $T$ are constant over the volume, which is true in our case by \hyperref[assumpCWTAT]{A:Constant-Water-Temp-Across-Tank}, \hyperref[assumpDWCoW]{A:Density-Water-Constant-over-Volume}, and \hyperref[assumpSHECoW]{A:Specific-Heat-Energy-Constant-over-Volume}, we have:
 
 \begin{displaymath}
-\resizeExpression{ρ\,C\,V\,\frac{\,dT}{\,dt}={q_{\text{in}}}\,{A_{\text{in}}}-{q_{\text{out}}}\,{A_{\text{out}}}+g\,V}{1.0}
+\resizeExpression{ρ\,C\,V\,\frac{\,dT}{\,dt}={q_{\text{in}}}\,{A_{\text{in}}}-{q_{\text{out}}}\,{A_{\text{out}}}+g\,V}{\outDefScale}
 \end{displaymath}
 Using the fact that $ρ$=$m$/$V$, Equation (2) can be written as:
 
 \begin{displaymath}
-\resizeExpression{m\,C\,\frac{\,dT}{\,dt}={q_{\text{in}}}\,{A_{\text{in}}}-{q_{\text{out}}}\,{A_{\text{out}}}+g\,V}{1.0}
+\resizeExpression{m\,C\,\frac{\,dT}{\,dt}={q_{\text{in}}}\,{A_{\text{in}}}-{q_{\text{out}}}\,{A_{\text{out}}}+g\,V}{\outDefScale}
 \end{displaymath}
 \medskip
 \noindent
@@ -550,7 +552,7 @@ Units & $\frac{\text{W}}{\text{m}^{2}}$
         
 \\ \midrule
 Equation & \begin{displaymath}
-           \resizeExpression{{q_{\text{C}}}={h_{\text{C}}}\,\left({T_{\text{C}}}-{T_{\text{W}}}\left(t\right)\right)}{0.8}
+           \resizeExpression{{q_{\text{C}}}={h_{\text{C}}}\,\left({T_{\text{C}}}-{T_{\text{W}}}\left(t\right)\right)}{\inDefScale}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -597,7 +599,7 @@ Units & ${\text{kg}}$
         
 \\ \midrule
 Equation & \begin{displaymath}
-           \resizeExpression{{m_{\text{W}}}={V_{\text{W}}}\,{ρ_{\text{W}}}}{0.8}
+           \resizeExpression{{m_{\text{W}}}={V_{\text{W}}}\,{ρ_{\text{W}}}}{\inDefScale}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -633,7 +635,7 @@ Units & ${\text{m}^{3}}$
         
 \\ \midrule
 Equation & \begin{displaymath}
-           \resizeExpression{{V_{\text{W}}}={V_{\text{tank}}}}{0.8}
+           \resizeExpression{{V_{\text{W}}}={V_{\text{tank}}}}{\inDefScale}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -671,7 +673,7 @@ Units & ${\text{m}^{3}}$
         
 \\ \midrule
 Equation & \begin{displaymath}
-           \resizeExpression{{V_{\text{tank}}}=π\,\left(\frac{D}{2}\right)^{2}\,L}{0.8}
+           \resizeExpression{{V_{\text{tank}}}=π\,\left(\frac{D}{2}\right)^{2}\,L}{\inDefScale}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -708,7 +710,7 @@ Units & ${\text{s}}$
         
 \\ \midrule
 Equation & \begin{displaymath}
-           \resizeExpression{{τ_{\text{W}}}=\frac{{m_{\text{W}}}\,{C_{\text{W}}}}{{h_{\text{C}}}\,{A_{\text{C}}}}}{0.8}
+           \resizeExpression{{τ_{\text{W}}}=\frac{{m_{\text{W}}}\,{C_{\text{W}}}}{{h_{\text{C}}}\,{A_{\text{C}}}}}{\inDefScale}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -752,13 +754,13 @@ Output & ${T_{\text{W}}}$
          
 \\ \midrule
 Input Constraints & \begin{displaymath}
-                    \resizeExpression{{T_{\text{C}}}\geq{}{T_{\text{init}}}}{0.8}
+                    \resizeExpression{{T_{\text{C}}}\geq{}{T_{\text{init}}}}{\inDefScale}
                     \end{displaymath}
 \\ \midrule
 Output Constraints & 
 \\ \midrule
 Equation & \begin{displaymath}
-           \resizeExpression{\frac{\,d{T_{\text{W}}}}{\,dt}+\frac{1}{{τ_{\text{W}}}}\,{{T_{\text{W}}}}=\frac{1}{{τ_{\text{W}}}}\,{T_{\text{C}}}}{0.8}
+           \resizeExpression{\frac{\,d{T_{\text{W}}}}{\,dt}+\frac{1}{{τ_{\text{W}}}}\,{{T_{\text{W}}}}=\frac{1}{{τ_{\text{W}}}}\,{T_{\text{C}}}}{\inDefScale}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -787,22 +789,22 @@ RefBy & \hyperref[unlikeChgNIHG]{UC:No-Internal-Heat-Generation}, \hyperref[outp
 To find the rate of change of ${T_{\text{W}}}$, we look at the energy balance on water. The volume being considered is the volume of water in the tank ${V_{\text{W}}}$, which has mass ${m_{\text{W}}}$ and specific heat capacity, ${C_{\text{W}}}$. Heat transfer occurs in the water from the heating coil as ${q_{\text{C}}}$ (\hyperref[GD:htFluxWaterFromCoil]{GD:htFluxWaterFromCoil}), over area ${A_{\text{C}}}$. No heat transfer occurs to the outside of the tank, since it has been assumed to be perfectly insulated (\hyperref[assumpPIT]{A:Perfect-Insulation-Tank}). Since the assumption is made that no internal heat is generated (\hyperref[assumpNIHGBW]{A:No-Internal-Heat-Generation-By-Water}), $g=0$. Therefore, the equation for \hyperref[GD:rocTempSimp]{GD:rocTempSimp} can be written as:
 
 \begin{displaymath}
-\resizeExpression{{m_{\text{W}}}\,{C_{\text{W}}}\,\frac{\,d{T_{\text{W}}}}{\,dt}={q_{\text{C}}}\,{A_{\text{C}}}}{1.0}
+\resizeExpression{{m_{\text{W}}}\,{C_{\text{W}}}\,\frac{\,d{T_{\text{W}}}}{\,dt}={q_{\text{C}}}\,{A_{\text{C}}}}{\outDefScale}
 \end{displaymath}
 Using \hyperref[GD:htFluxWaterFromCoil]{GD:htFluxWaterFromCoil} for ${q_{\text{C}}}$, this can be written as:
 
 \begin{displaymath}
-\resizeExpression{{m_{\text{W}}}\,{C_{\text{W}}}\,\frac{\,d{T_{\text{W}}}}{\,dt}={h_{\text{C}}}\,{A_{\text{C}}}\,\left({T_{\text{C}}}-{T_{\text{W}}}\right)}{1.0}
+\resizeExpression{{m_{\text{W}}}\,{C_{\text{W}}}\,\frac{\,d{T_{\text{W}}}}{\,dt}={h_{\text{C}}}\,{A_{\text{C}}}\,\left({T_{\text{C}}}-{T_{\text{W}}}\right)}{\outDefScale}
 \end{displaymath}
 Dividing Equation (2) by ${m_{\text{W}}}\,{C_{\text{W}}}$, we obtain:
 
 \begin{displaymath}
-\resizeExpression{\frac{\,d{T_{\text{W}}}}{\,dt}=\frac{{h_{\text{C}}}\,{A_{\text{C}}}}{{m_{\text{W}}}\,{C_{\text{W}}}}\,\left({T_{\text{C}}}-{T_{\text{W}}}\right)}{1.0}
+\resizeExpression{\frac{\,d{T_{\text{W}}}}{\,dt}=\frac{{h_{\text{C}}}\,{A_{\text{C}}}}{{m_{\text{W}}}\,{C_{\text{W}}}}\,\left({T_{\text{C}}}-{T_{\text{W}}}\right)}{\outDefScale}
 \end{displaymath}
 By substituting ${τ_{\text{W}}}$ (from \hyperref[DD:balanceDecayRate]{DD:balanceDecayRate}), this can be written as:
 
 \begin{displaymath}
-\resizeExpression{\frac{\,d{T_{\text{W}}}}{\,dt}=\frac{1}{{τ_{\text{W}}}}\,\left({T_{\text{C}}}-{T_{\text{W}}}\right)}{1.0}
+\resizeExpression{\frac{\,d{T_{\text{W}}}}{\,dt}=\frac{1}{{τ_{\text{W}}}}\,\left({T_{\text{C}}}-{T_{\text{W}}}\right)}{\outDefScale}
 \end{displaymath}
 \medskip
 \noindent
@@ -826,7 +828,7 @@ Input Constraints &
 Output Constraints & 
 \\ \midrule
 Equation & \begin{displaymath}
-           \resizeExpression{{E_{\text{W}}}\left(t\right)={C_{\text{W}}}\,{m_{\text{W}}}\,\left({T_{\text{W}}}\left(t\right)-{T_{\text{init}}}\right)}{0.8}
+           \resizeExpression{{E_{\text{W}}}\left(t\right)={C_{\text{W}}}\,{m_{\text{W}}}\,\left({T_{\text{W}}}\left(t\right)-{T_{\text{init}}}\right)}{\inDefScale}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}


### PR DESCRIPTION
Contributes to #718 

- Detailed description in https://github.com/JacquesCarette/Drasil/issues/718#issuecomment-2263312386.
- Adjusts block equations within definition tables to 80% of the page width if they overflow.
- Adjusts standard block equations to the full page width if they overflow.

To save you the trouble of compiling, here is a precompiled example of [SSP_SRS.pdf](https://github.com/user-attachments/files/16512476/SSP_SRS.pdf) for your reference.
