### PR TITLE
small update for STAN

### DIFF
--- a/code/stack.yaml
+++ b/code/stack.yaml
@@ -104,6 +104,7 @@ allow-newer-deps:
 - stan
 - weeder
 - multiplate
+- extensions
 
 # Used only for a basic set of flags for haddock
 build:


### PR DESCRIPTION
I realized that the `.hie` files aren't in ghc 9.6.6 (they are still in ghc 9.2.8). You need to use `stack upgrade` before using STAN so the `.hie` files are made in ghc 9.6.6. In order for STAN to work on the new version I also had to add `extensions` to `allow-newer-deps` for STAN to work.