### PR TITLE
change some `nub` to `nubOrd`

### DIFF
--- a/code/drasil-code/lib/Language/Drasil/Chunk/CodeBase.hs
+++ b/code/drasil-code/lib/Language/Drasil/Chunk/CodeBase.hs
@@ -5,8 +5,6 @@ import Database.Drasil (ChunkDB, symbResolve)
 import Language.Drasil
 import Language.Drasil.CodeExpr.Development
 
-import Data.List (nub)
-
 -- | Construct a 'CodeVarChunk' from a 'Quantity'.
 quantvar :: (Quantity c, MayHaveUnit c) => c -> CodeVarChunk
 quantvar c = CodeVC (CodeC (qw c) Var) Nothing
@@ -21,7 +19,7 @@ codevars e m = map (varResolve m) $ eDep e
 
 -- | Get a list of 'CodeChunk's from an equation (no functions).
 codevars' :: CodeExpr -> ChunkDB -> [CodeVarChunk]
-codevars' e m = map (varResolve m) $ nub $ eDep' e
+codevars' e m = map (varResolve m) $ eDep' e
 
 -- | Make a 'CodeVarChunk' from a 'UID' in the 'ChunkDB'.
 varResolve :: ChunkDB -> UID -> CodeVarChunk

--- a/code/drasil-code/lib/Language/Drasil/Code/Imperative/Build/Import.hs
+++ b/code/drasil-code/lib/Language/Drasil/Code/Imperative/Build/Import.hs
@@ -12,9 +12,10 @@ import Drasil.GOOL (FileData(..), ProgData(..), GOOLState(..), headers, sources,
 import Build.Drasil (Annotation, (+:+), genMake, makeS, MakeString, mkFile, mkRule,
   mkCheckedCommand, mkFreeVar, RuleTransformer(makeRule))
 
+import Data.Containers.ListUtils (nubOrd)
+
 import Control.Lens ((^.))
 import Data.Maybe (maybeToList)
-import Data.List (nub)
 import System.FilePath.Posix (takeExtension, takeBaseName)
 import Text.PrettyPrint.HughesPJ (Doc)
 import Utils.Drasil (capitalize)
@@ -82,7 +83,7 @@ getCompilerInput (BcSingle n) s p = [renderBuildName s p nameOpts n]
 
 -- | Helper that retrieves commented files.
 getCommentedFiles :: GOOLState -> [MakeString]
-getCommentedFiles s = map makeS (nub (s ^. headers ++
+getCommentedFiles s = map makeS (nubOrd (s ^. headers ++
   maybeToList (s ^. mainMod)))
 
 -- | Helper that builds and runs a target.

--- a/code/drasil-code/lib/Language/Drasil/Code/Imperative/DrasilState.hs
+++ b/code/drasil-code/lib/Language/Drasil/Code/Imperative/DrasilState.hs
@@ -8,6 +8,8 @@ module Language.Drasil.Code.Imperative.DrasilState (
 import Language.Drasil
 import Drasil.GOOL (VisibilityTag(..), CodeType)
 
+import Data.Containers.ListUtils (nubOrd)
+
 import Language.Drasil.Chunk.ConstraintMap (ConstraintCE)
 import Language.Drasil.Code.ExtLibImport (ExtLibState)
 import Language.Drasil.Choices (Choices(..), Architecture (..), DataInfo(..),
@@ -107,7 +109,7 @@ modExportMap cs@CodeSpec {
   constants = cns
   } chs@Choices {
     architecture = m
-  } ms = fromList $ nub $ concatMap mpair ms
+  } ms = fromList $ nubOrd $ concatMap mpair ms
     ++ getExpInput prn chs ins
     ++ getExpConstants prn chs cns
     ++ getExpDerived prn chs ds

--- a/code/drasil-code/lib/Language/Drasil/CodeSpec.hs
+++ b/code/drasil-code/lib/Language/Drasil/CodeSpec.hs
@@ -192,4 +192,4 @@ getConstraints cm cs = concat $ mapMaybe (\c -> Map.lookup (c ^. uid) cm) cs
 -- | Get a list of 'CodeChunk's from a constraint.
 constraintvars :: ConstraintCE -> ChunkDB -> [CodeChunk]
 constraintvars (Range _ ri) m =
-  map (codeChunk . varResolve m) $ nub $ eNamesRI ri
+  map (codeChunk . varResolve m) $ eNamesRI ri

--- a/code/drasil-docLang/lib/Drasil/DocumentLanguage.hs
+++ b/code/drasil-docLang/lib/Drasil/DocumentLanguage.hs
@@ -434,7 +434,7 @@ mkTraceabilitySec (TraceabilityProg progs) si@SI{_sys = sys} = TG.traceMGF trace
 
 -- | Helper to get headers of rows and columns
 header :: ([UID] -> [UID]) -> SystemInformation -> [Sentence]
-header f = TM.traceMHeader (f . nub . Map.keys . (^. refbyTable))
+header f = TM.traceMHeader (f . Map.keys . (^. refbyTable))
 
 -- ** Off the Shelf Solutions
 

--- a/code/drasil-docLang/lib/Drasil/DocumentLanguage/TraceabilityMatrix.hs
+++ b/code/drasil-docLang/lib/Drasil/DocumentLanguage/TraceabilityMatrix.hs
@@ -12,8 +12,10 @@ import Data.Drasil.Concepts.Documentation (purpose, component, dependency,
 
 import Drasil.DocumentLanguage.Definitions (helpToRefField)
 
+import Data.Containers.ListUtils (nubOrd)
+
 import Control.Lens ((^.), Getting)
-import Data.List (nub)
+
 import qualified Data.Map as Map
 
 -- * Types
@@ -49,11 +51,11 @@ generateTraceTableView u desc cols rows c = llcc (makeTabRef' u) $ Table
 
 -- | Helper that finds the traceability matrix references (things being referenced).
 traceMReferees :: ([UID] -> [UID]) -> ChunkDB -> [UID]
-traceMReferees f = f . nub . Map.keys . (^. refbyTable)
+traceMReferees f = f . nubOrd . Map.keys . (^. refbyTable)
 
 -- | Helper that finds the traceability matrix references (things that are referring to other things).
 traceMReferrers :: ([UID] -> [UID]) -> ChunkDB -> [UID]
-traceMReferrers f = f . nub . concat . Map.elems . (^. refbyTable)
+traceMReferrers f = f . nubOrd . concat . Map.elems . (^. refbyTable)
 
 -- | Helper that finds the header of a traceability matrix.
 traceMHeader :: (ChunkDB -> [UID]) -> SystemInformation -> [Sentence]

--- a/code/drasil-gool/lib/Drasil/GOOL/State.hs
+++ b/code/drasil-gool/lib/Drasil/GOOL/State.hs
@@ -476,7 +476,7 @@ callMapTransClosure = over callMap tClosure
         traceCalls :: Map QualifiedName [QualifiedName] -> [QualifiedName] -> 
           [QualifiedName]
         traceCalls _ [] = []
-        traceCalls cm (c:cs) = nub $ c : traceCalls cm (nub $ cs ++ 
+        traceCalls cm (c:cs) = c : traceCalls cm (cs ++ 
           Map.findWithDefault [] c cm)
 
 updateMEMWithCalls :: GOOLState -> GOOLState

--- a/code/drasil-lang/lib/Language/Drasil/CodeExpr/Extract.hs
+++ b/code/drasil-lang/lib/Language/Drasil/CodeExpr/Extract.hs
@@ -8,7 +8,7 @@ import Language.Drasil.UID (UID)
 
 import Language.Drasil.CodeExpr.Lang (CodeExpr(..))
 
-import Data.List (nub)
+import Data.Containers.ListUtils (nubOrd)
 
 -- | Generic traverse of all expressions that could lead to names.
 eNames :: CodeExpr -> [UID]
@@ -90,8 +90,8 @@ eNamesRI' (UpFrom il)     = eNames' (snd il)
 
 -- | Get dependencies from an equation.
 eDep :: CodeExpr -> [UID]
-eDep = nub . eNames
+eDep = nubOrd . eNames
 
 -- | Get dependencies from an equation, without functions.
 eDep' :: CodeExpr -> [UID]
-eDep' = nub . eNames'
+eDep' = nubOrd . eNames'

--- a/code/drasil-lang/lib/Language/Drasil/Expr/Extract.hs
+++ b/code/drasil-lang/lib/Language/Drasil/Expr/Extract.hs
@@ -1,7 +1,7 @@
 -- | Extract UIDs from an expression so that they can be looked up in the chunk database and rendered.
 module Language.Drasil.Expr.Extract where
 
-import Data.List (nub)
+import Data.Containers.ListUtils (nubOrd)
 
 import Language.Drasil.Expr.Lang (Expr(..))
 import Language.Drasil.Space (RealInterval(..))
@@ -76,4 +76,4 @@ eNamesRI' (UpFrom il)     = eNames' (snd il)
 
 -- | Get dependencies from an equation.  
 eDep :: Expr -> [UID]
-eDep = nub . eNames
+eDep = nubOrd . eNames

--- a/code/drasil-lang/lib/Language/Drasil/ModelExpr/Extract.hs
+++ b/code/drasil-lang/lib/Language/Drasil/ModelExpr/Extract.hs
@@ -1,7 +1,7 @@
 -- | Defines functions to find Chunk UIDs within 'ModelExpr's.
 module Language.Drasil.ModelExpr.Extract where
 
-import Data.List (nub)
+import Data.Containers.ListUtils (nubOrd)
 
 import Language.Drasil.ModelExpr.Lang (ModelExpr(..))
 import Language.Drasil.Space (RealInterval(..))
@@ -86,4 +86,4 @@ meNamesRI' (UpFrom il)     = meNames' (snd il)
 
 -- | Get dependencies from an equation.  
 meDep :: ModelExpr -> [UID]
-meDep = nub . meNames
+meDep = nubOrd . meNames

--- a/code/drasil-lang/lib/Language/Drasil/Sentence/Extract.hs
+++ b/code/drasil-lang/lib/Language/Drasil/Sentence/Extract.hs
@@ -2,11 +2,11 @@
 -- chunk database in order to render terms, symbols, and references properly.
 module Language.Drasil.Sentence.Extract(sdep, shortdep, lnames, lnames') where
 
-import Data.List (nub)
 import Language.Drasil.UID (UID)
 import Language.Drasil.Sentence(Sentence(..), SentenceStyle(..))
 import Language.Drasil.ModelExpr.Extract (meNames)
 
+import Data.Containers.ListUtils (nubOrd)
 
 -- | Generic traverse of all positions that could lead to /symbolic/ 'UID's from 'Sentence's.
 getUIDs :: Sentence -> [UID]
@@ -45,11 +45,11 @@ getUIDshort EmptyS              = []
 -- And now implement the exported traversals all in terms of the above
 -- | This is to collect /symbolic/ 'UID's that are printed out as a 'Symbol'.
 sdep :: Sentence -> [UID]
-sdep = nub . getUIDs
+sdep = nubOrd . getUIDs
 
 -- This is to collect symbolic 'UID's that are printed out as an /abbreviation/.
 shortdep :: Sentence -> [UID]
-shortdep = nub . getUIDshort
+shortdep = nubOrd . getUIDshort
 
 -- | Generic traverse of all positions that could lead to /reference/ 'UID's from 'Sentence's.
 lnames :: Sentence -> [UID]

--- a/code/drasil-printers/lib/Language/Drasil/Debug/Print.hs
+++ b/code/drasil-printers/lib/Language/Drasil/Debug/Print.hs
@@ -8,7 +8,7 @@ import           Database.Drasil
 import           Utils.Drasil (stringList)
 import qualified Data.Map as Map
 import           Control.Lens ((^.), view)
-import           Data.List (nub, sort, sortBy)
+import           Data.List (sort, sortBy)
 import           Data.Foldable (foldl')
 import           Data.Maybe (fromMaybe)
 import           Data.Bifunctor (second)
@@ -17,6 +17,8 @@ import           Text.PrettyPrint.HughesPJ
 import           Language.Drasil.Plain.Print
 import           Language.Drasil.Printing.PrintingInformation
 import           Prelude hiding ((<>))
+
+import Data.Containers.ListUtils (nubOrd)
 
 -- * Main Function
 -- | Gathers all printing functions and creates the debugging tables from them.
@@ -321,7 +323,7 @@ mkListShowUsedUIDs PI { _ckdb = db } = sortBy (compare `on` fst)
 -- Currently Unused
 -- | Get all 'UID's from a database ('ChunkDB').
 mkListAll :: ChunkDB -> [UID]
-mkListAll db = nub
+mkListAll db = nubOrd
   $ sort
   $ map fst (Map.assocs $ symbolTable db)
   ++ map fst (Map.assocs $ termTable db)

--- a/code/drasil-utils/lib/Utils/Drasil/Lists.hs
+++ b/code/drasil-utils/lib/Utils/Drasil/Lists.hs
@@ -3,6 +3,8 @@ module Utils.Drasil.Lists where
 
 import Data.List
 
+import Data.Containers.ListUtils (nubOrd)
+
 -- | Check if list has at least 2 elements.
 atLeast2 :: [a] -> Bool
 atLeast2 (_:_:_) = True
@@ -21,7 +23,7 @@ xs `subsetOf` ys = all (`elem` ys) xs
 
 -- | Sort a list, removing all duplicates
 nubSort :: Ord a => [a] -> [a]
-nubSort = nub . sort
+nubSort = nubOrd . sort
 
 -- | Interweaves two lists together @[[a,b,c],[d,e,f]] -> [a,d,b,e,c,f]@.
 weave :: [[a]] -> [a]

--- a/code/scripts/ClassInstDepGen.hs
+++ b/code/scripts/ClassInstDepGen.hs
@@ -27,6 +27,7 @@ import Data.List.Split (splitOn)
 import DataPrinters.Dot
 import DataPrinters.HTML
 
+import Data.Containers.ListUtils (nubOrd)
 
 ------------
 -- Data types used in the generation of dependency tables and graphs
@@ -210,8 +211,8 @@ mkEntryPack = map $ \(n, es) -> makeEntryPack n $ filter isEntryEmpty $ map entr
     -- only take the information needed to construct a graph from a full entry
     entryToSmallEntry :: Entry -> SmallEntry
     entryToSmallEntry Entry{dataTypes = dts, newtypes = nts, classes = clss, classInstances = clsinst} = 
-      makeSmallEntry (dts ++ nts) (nub $ map className clss)
-      (nub $ concatMap snd (mkPkgEdges clsinst) \\ map className clss) $ mkPkgEdges clsinst
+      makeSmallEntry (dts ++ nts) (nubOrd $ map className clss)
+      (nubOrd $ concatMap snd (mkPkgEdges clsinst) \\ map className clss) $ mkPkgEdges clsinst
 
 -- Cleanup function to get rid of empty SmallEntries
 isEntryEmpty :: SmallEntry -> Bool

--- a/code/scripts/SourceCodeReaderT.hs
+++ b/code/scripts/SourceCodeReaderT.hs
@@ -12,6 +12,8 @@ import Data.Char (isUpper)
 
 import DirectoryController as DC (FileName)
 
+import Data.Containers.ListUtils (nubOrd)
+
 -- Synonyms for clarity
 type DataName = String
 type NewtypeName = String
@@ -316,7 +318,7 @@ getTypes = map (\l -> TD {tdName = filterName $ fst l, tdContent = filterContent
 
 -- Combines multiple filter functions. For type contents.
 filterContents :: [String] -> [String]
-filterContents = nub . filter (not . null) . map filterName
+filterContents = nubOrd . filter (not . null) . map filterName
 
 -- Combines the below three filter functions. For type names.
 filterName :: String -> String


### PR DESCRIPTION
This is a continuation of #3761. I changed any `nub`s that were used on things that are `Ord` to `nubOrd`. This is becuase `nub` has O(n^2) and `nubOrd` has O(n\log(n)). 
![image](https://github.com/user-attachments/assets/8ec54e0a-7c52-4659-bff4-6e0771a211e6)
