### PR TITLE
Made fixes to the Julia renderer

### DIFF
--- a/code/drasil-gool/lib/Drasil/GOOL/LanguageRenderer/CommonPseudoOO.hs
+++ b/code/drasil-gool/lib/Drasil/GOOL/LanguageRenderer/CommonPseudoOO.hs
@@ -418,7 +418,7 @@ multiReturn f vs = do
   returnStmt $ mkStateVal IC.void $ f $ valueList vs'
 
 listDec :: (CommonRenderSym r) => SVariable r -> r (Scope r) -> MSStatement r
-listDec v scp = IC.varDecDef v scp $ IC.litList (onStateValue variableType v) []
+listDec v scp = listDecDef v scp []
 
 funcDecDef :: (OORenderSym r) => SVariable r -> r (Scope r) -> [SVariable r] ->
   MSBody r -> MSStatement r

--- a/code/stable/gooltest/julia/FileTests/FileTests.jl
+++ b/code/stable/gooltest/julia/FileTests/FileTests.jl
@@ -11,7 +11,7 @@ global fileToRead = open("testText.txt", "r")
 global fileLine = readline(fileToRead)
 readline(fileToRead)
 @assert fileLine != "" "First line should not be empty."
-global fileContents = []
+global fileContents = String[]
 
 global fileContents = readlines(fileToRead)
 

--- a/code/stable/gooltest/julia/HelloWorld/HelloWorld.jl
+++ b/code/stable/gooltest/julia/HelloWorld/HelloWorld.jl
@@ -20,7 +20,7 @@ insert!(myOtherList, 3, 2.0)
 append!(myOtherList, 2.5)
 global e = myOtherList[2]
 myOtherList[2] = 17.4
-global myName = []
+global myName = String[]
 global myName = split("Brooks Mac", " ")
 println(myName)
 global boringList = [false, false, false, false, false]
@@ -31,17 +31,17 @@ println(boringList)
 
 # List slicing tests
 # Create variables for list slices
-global mySlicedList = []
-global mySlicedList2 = []
-global mySlicedList3 = []
-global mySlicedList4 = []
-global mySlicedList5 = []
-global mySlicedList6 = []
-global mySlicedList7 = []
-global mySlicedList8 = []
-global mySlicedList9 = []
-global mySlicedList10 = []
-global mySlicedList11 = []
+global mySlicedList = Float64[]
+global mySlicedList2 = Float64[]
+global mySlicedList3 = Float64[]
+global mySlicedList4 = Float64[]
+global mySlicedList5 = Float64[]
+global mySlicedList6 = Float64[]
+global mySlicedList7 = Float64[]
+global mySlicedList8 = Float64[]
+global mySlicedList9 = Float64[]
+global mySlicedList10 = Float64[]
+global mySlicedList11 = Float64[]
 
 # Create some variables for later tests
 global x = 3
@@ -122,7 +122,7 @@ elseif b == 5
     global d += 1;
     global c -= 1
     global b -= 1
-    global myList = []
+    global myList = Int64[]
     const myConst = "Imconstant";
     println(myConst)
     println(a)

--- a/code/stable/gooltest/julia/NameGenTest/NameGenTest.jl
+++ b/code/stable/gooltest/julia/NameGenTest/NameGenTest.jl
@@ -1,7 +1,7 @@
 module NameGenTest
 
 function helper(temp::Array{Int64})
-    result = []
+    result = Int64[]
     
     result = temp[2:3]
     
@@ -9,7 +9,7 @@ function helper(temp::Array{Int64})
 end
 
 global temp = [1, 2, 3]
-global result = []
+global result = Int64[]
 
 global result = temp[2:3]
 


### PR DESCRIPTION
There were two problems I discovered while implementing ODEs in Julia:
- Importing external libraries didn't work correctly.
- The types of empty lists was `Any` instead of its specific type.
  - Julia automatically assigns `[]` the type `Array{Any}`, which is problematic if you need its type to be `Array{Float64}`, for example.  I fixed it to add the type if the list is empty.  For example, an empty list of doubles is now represented as `Float64[]`.  This is in line with how the Julia REPL prints lists, and removes the potential of type errors.

This PR fixes those two issues.

Note on the `listDec` from `CommonPseudoOO.hs`: I'm not exactly sure why this only affects Julia, but previously it was giving lists the wrong level of type nesting (e.g. `List<List<Integer>>` instead of `List<Integer>`.  This PR fixes that, and also simplifies the implementation overall.