### PR TITLE
Switched LaTeX package from `resizebox` to `adjustbox` for resizing expressions

### DIFF
--- a/code/drasil-printers/lib/Language/Drasil/TeX/Helpers.hs
+++ b/code/drasil-printers/lib/Language/Drasil/TeX/Helpers.hs
@@ -279,22 +279,9 @@ useTikz = usepackage "luatex85" $+$ command0 "def" <>
 -- on Monad...
 
 -- | toEqn is special; it switches to 'Math', but inserts an equation environment.
--- The 'scale' parameter determines the maximum width of the equation based on
--- the corresponding scaling command.
-toEqn :: ExprScale -> D -> D
-toEqn scale (PL g) = equation $ command2D "resizeExpression" (PL (\_ -> g Math)) (command0 (show scale))
-
--- | Represents the scaling factor for an equation.
--- 'InDef' and 'OutDef' correspond to predefined scaling commands.
--- Commands are defined in 'Preamble.hs'
-data ExprScale = InDef | OutDef
-
--- | Provides a string representation for 'ExprScale' values.
--- Used to convert 'ExprScale' to the corresponding command string.
-instance Show ExprScale where
-  show InDef  = "inDefScale"
-  show OutDef = "outDefScale"
-
+-- Uses resizeExpression macro (defined in Preamble.hs) to prevent page overflow.
+toEqn :: D -> D
+toEqn (PL g) = equation $ commandD "resizeExpression" $ PL (\_ -> g Math)
 -----------------------------------------------------------------------------
 -- | Helper(s) for String-Printing in TeX where it varies from HTML/Plaintext.
 paren, sqbrac :: String -> String

--- a/code/drasil-printers/lib/Language/Drasil/TeX/Print.hs
+++ b/code/drasil-printers/lib/Language/Drasil/TeX/Print.hs
@@ -33,7 +33,7 @@ import Language.Drasil.TeX.Helpers (author, bold, br, caption, center, centering
   empty, enumerate, externalref, figure, fraction, includegraphics, item, item',
   itemize, label, maketitle, maketoc, mathbb, mkEnv, mkEnvArgBr, mkEnvArgSq,
   mkMinipage, newline, newpage, parens, quote, sec, snref, sq, superscript,
-  symbDescription, texSym, title, toEqn, ExprScale(InDef, OutDef))
+  symbDescription, texSym, title, toEqn)
 import Language.Drasil.TeX.Monad (D, MathContext(Curr, Math, Text), (%%), ($+$),
   hpunctuate, lub, runPrint, switch, toMath, toText, unPL, vcat, vpunctuate)
 import Language.Drasil.TeX.Preamble (genPreamble)
@@ -62,7 +62,7 @@ lo :: LayoutObj -> PrintingInformation -> D
 lo (Header d t l)         _ = sec d (spec t) %% label (spec l)
 lo (HDiv _ con _)        sm = print sm con -- FIXME ignoring 2 arguments?
 lo (Paragraph contents)   _ = toText $ newline (spec contents)
-lo (EqnBlock contents)    _ = makeEquation contents OutDef
+lo (EqnBlock contents)    _ = makeEquation contents
 lo (Table _ rows r bl t)  _ = toText $ makeTable rows (spec r) bl (spec t)
 lo (Definition _ ssPs l) sm = toText $ makeDefn sm ssPs $ spec l
 lo (List l)               _ = toText $ makeList l
@@ -76,21 +76,9 @@ lo (Graph ps w h c l)    _  = toText $ makeGraph
 lo (Cell _) _               = empty
 lo (CodeBlock _) _          = empty
 
--- | Helper for converting layout objects into a more printable form.
--- This function is specific to definitions.
-lo' :: LayoutObj -> PrintingInformation -> D
-lo' (HDiv _ con _)      sm = printDef sm con
-lo' (EqnBlock contents) _  = makeEquation contents InDef
-lo' obj                 sm = lo obj sm
-
 -- | Converts layout objects into a document form.
 print :: PrintingInformation -> [LayoutObj] -> D
 print sm = foldr (($+$) . (`lo` sm)) empty
-
--- | Converts layout objects into a document form.
--- Specific to Definitions.
-printDef :: PrintingInformation -> [LayoutObj] -> D
-printDef sm = foldr (($+$) . (`lo'` sm)) empty
 
 -- | Determine wether braces and brackets are opening or closing.
 data OpenClose = Open | Close
@@ -360,15 +348,15 @@ makeDRows :: PrintingInformation -> [(String,[LayoutObj])] -> D
 makeDRows _  []      = error "No fields to create Defn table"
 makeDRows sm ls      = foldl1 (%%) $ map (\(f, d) -> 
   pure (dbs <+> text "\\midrule") %% 
-  pure (text (f ++ " & ")) <> printDef sm d) ls
+  pure (text (f ++ " & ")) <> print sm d) ls
 
 -----------------------------------------------------------------
 ------------------ EQUATION PRINTING------------------------
 -----------------------------------------------------------------
 
--- | Prints an equation with a maximum width determined by the given scale.
-makeEquation :: Spec -> ExprScale -> D
-makeEquation contents scale = toEqn scale (spec contents)
+-- | Prints an equation.
+makeEquation :: Spec -> D
+makeEquation contents = toEqn $ spec contents
 
   --TODO: Add auto-generated labels -> Need to be able to ensure labeling based
   --  on chunk (i.e. "eq:h_g" for h_g = ...

--- a/code/stable/dblpend/SRS/PDF/DblPend_SRS.tex
+++ b/code/stable/dblpend/SRS/PDF/DblPend_SRS.tex
@@ -15,8 +15,7 @@
 \usepackage{svg}
 \usepackage{float}
 \usepackage{enumitem}
-\usepackage{graphicx}
-\usepackage{calc}
+\usepackage{adjustbox}
 \usepackage{filecontents}
 \usepackage[backend=bibtex]{biblatex}
 \usepackage{url}
@@ -25,16 +24,8 @@
 \newcommand{\lt}{\ensuremath <}
 \newlist{symbDescription}{description}{1}
 \setlist[symbDescription]{noitemsep, topsep=0pt, parsep=0pt, partopsep=0pt}
-\def\inDefScale{0.8}
-\def\outDefScale{1.0}
-\newsavebox{\mybox}
-\newcommand{\resizeExpression}[2]{
-  \savebox{\mybox}{$#1$}
-  \ifdim\wd\mybox>#2\linewidth
-    \resizebox{#2\textwidth}{!}{\usebox{\mybox}}
-  \else
-    \usebox{\mybox}
-  \fi
+\newcommand{\resizeExpression}[1]{
+  \adjustbox{max width=\linewidth}{$#1$}
 }
 \bibliography{bibfile}
 \title{Software Requirements Specification for Double Pendulum}
@@ -324,7 +315,7 @@ Label & Acceleration
         
 \\ \midrule
 Equation & \begin{displaymath}
-           \resizeExpression{\symbf{a}\text{(}t\text{)}=\frac{\,d\symbf{v}\text{(}t\text{)}}{\,dt}}{\inDefScale}
+           \resizeExpression{\symbf{a}\text{(}t\text{)}=\frac{\,d\symbf{v}\text{(}t\text{)}}{\,dt}}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -353,7 +344,7 @@ Label & Velocity
         
 \\ \midrule
 Equation & \begin{displaymath}
-           \resizeExpression{\symbf{v}\text{(}t\text{)}=\frac{\,d\symbf{p}\text{(}t\text{)}}{\,dt}}{\inDefScale}
+           \resizeExpression{\symbf{v}\text{(}t\text{)}=\frac{\,d\symbf{p}\text{(}t\text{)}}{\,dt}}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -382,7 +373,7 @@ Label & Newton's second law of motion
         
 \\ \midrule
 Equation & \begin{displaymath}
-           \resizeExpression{\symbf{F}=m\,\symbf{a}\text{(}t\text{)}}{\inDefScale}
+           \resizeExpression{\symbf{F}=m\,\symbf{a}\text{(}t\text{)}}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -421,7 +412,7 @@ Units & $\frac{\text{m}}{\text{s}}$
         
 \\ \midrule
 Equation & \begin{displaymath}
-           \resizeExpression{{v_{\text{x}1}}={w_{1}}\,{L_{1}}\,\cos\left({θ_{1}}\right)}{\inDefScale}
+           \resizeExpression{{v_{\text{x}1}}={w_{1}}\,{L_{1}}\,\cos\left({θ_{1}}\right)}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -444,27 +435,27 @@ RefBy &
 At a given point in time, velocity is defined in \hyperref[DD:positionGDD]{DD:positionGDD}
 
 \begin{displaymath}
-\resizeExpression{\symbf{v}\text{(}t\text{)}=\frac{\,d\symbf{p}\text{(}t\text{)}}{\,dt}}{\outDefScale}
+\resizeExpression{\symbf{v}\text{(}t\text{)}=\frac{\,d\symbf{p}\text{(}t\text{)}}{\,dt}}
 \end{displaymath}
 We also know the horizontal position that is defined in \hyperref[DD:positionXDD1]{DD:positionXDD1}
 
 \begin{displaymath}
-\resizeExpression{{p_{\text{x}1}}={L_{1}}\,\sin\left({θ_{1}}\right)}{\outDefScale}
+\resizeExpression{{p_{\text{x}1}}={L_{1}}\,\sin\left({θ_{1}}\right)}
 \end{displaymath}
 Applying this,
 
 \begin{displaymath}
-\resizeExpression{{v_{\text{x}1}}=\frac{\,d{L_{1}}\,\sin\left({θ_{1}}\right)}{\,dt}}{\outDefScale}
+\resizeExpression{{v_{\text{x}1}}=\frac{\,d{L_{1}}\,\sin\left({θ_{1}}\right)}{\,dt}}
 \end{displaymath}
 ${L_{1}}$ is constant with respect to time, so
 
 \begin{displaymath}
-\resizeExpression{{v_{\text{x}1}}={L_{1}}\,\frac{\,d\sin\left({θ_{1}}\right)}{\,dt}}{\outDefScale}
+\resizeExpression{{v_{\text{x}1}}={L_{1}}\,\frac{\,d\sin\left({θ_{1}}\right)}{\,dt}}
 \end{displaymath}
 Therefore, using the chain rule,
 
 \begin{displaymath}
-\resizeExpression{{v_{\text{x}1}}={w_{1}}\,{L_{1}}\,\cos\left({θ_{1}}\right)}{\outDefScale}
+\resizeExpression{{v_{\text{x}1}}={w_{1}}\,{L_{1}}\,\cos\left({θ_{1}}\right)}
 \end{displaymath}
 \medskip
 \noindent
@@ -481,7 +472,7 @@ Units & $\frac{\text{m}}{\text{s}}$
         
 \\ \midrule
 Equation & \begin{displaymath}
-           \resizeExpression{{v_{\text{y}1}}={w_{1}}\,{L_{1}}\,\sin\left({θ_{1}}\right)}{\inDefScale}
+           \resizeExpression{{v_{\text{y}1}}={w_{1}}\,{L_{1}}\,\sin\left({θ_{1}}\right)}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -504,27 +495,27 @@ RefBy &
 At a given point in time, velocity is defined in \hyperref[DD:positionGDD]{DD:positionGDD}
 
 \begin{displaymath}
-\resizeExpression{\symbf{v}\text{(}t\text{)}=\frac{\,d\symbf{p}\text{(}t\text{)}}{\,dt}}{\outDefScale}
+\resizeExpression{\symbf{v}\text{(}t\text{)}=\frac{\,d\symbf{p}\text{(}t\text{)}}{\,dt}}
 \end{displaymath}
 We also know the vertical position that is defined in \hyperref[DD:positionYDD1]{DD:positionYDD1}
 
 \begin{displaymath}
-\resizeExpression{{p_{\text{y}1}}=-{L_{1}}\,\cos\left({θ_{1}}\right)}{\outDefScale}
+\resizeExpression{{p_{\text{y}1}}=-{L_{1}}\,\cos\left({θ_{1}}\right)}
 \end{displaymath}
 Applying this,
 
 \begin{displaymath}
-\resizeExpression{{v_{\text{y}1}}=-\left(\frac{\,d{L_{1}}\,\cos\left({θ_{1}}\right)}{\,dt}\right)}{\outDefScale}
+\resizeExpression{{v_{\text{y}1}}=-\left(\frac{\,d{L_{1}}\,\cos\left({θ_{1}}\right)}{\,dt}\right)}
 \end{displaymath}
 ${L_{1}}$ is constant with respect to time, so
 
 \begin{displaymath}
-\resizeExpression{{v_{\text{y}1}}=-{L_{1}}\,\frac{\,d\cos\left({θ_{1}}\right)}{\,dt}}{\outDefScale}
+\resizeExpression{{v_{\text{y}1}}=-{L_{1}}\,\frac{\,d\cos\left({θ_{1}}\right)}{\,dt}}
 \end{displaymath}
 Therefore, using the chain rule,
 
 \begin{displaymath}
-\resizeExpression{{v_{\text{y}1}}={w_{1}}\,{L_{1}}\,\sin\left({θ_{1}}\right)}{\outDefScale}
+\resizeExpression{{v_{\text{y}1}}={w_{1}}\,{L_{1}}\,\sin\left({θ_{1}}\right)}
 \end{displaymath}
 \medskip
 \noindent
@@ -541,7 +532,7 @@ Units & $\frac{\text{m}}{\text{s}}$
         
 \\ \midrule
 Equation & \begin{displaymath}
-           \resizeExpression{{v_{\text{x}2}}={v_{\text{x}1}}+{w_{2}}\,{L_{2}}\,\cos\left({θ_{2}}\right)}{\inDefScale}
+           \resizeExpression{{v_{\text{x}2}}={v_{\text{x}1}}+{w_{2}}\,{L_{2}}\,\cos\left({θ_{2}}\right)}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -565,22 +556,22 @@ RefBy &
 At a given point in time, velocity is defined in \hyperref[DD:positionGDD]{DD:positionGDD}
 
 \begin{displaymath}
-\resizeExpression{\symbf{v}\text{(}t\text{)}=\frac{\,d\symbf{p}\text{(}t\text{)}}{\,dt}}{\outDefScale}
+\resizeExpression{\symbf{v}\text{(}t\text{)}=\frac{\,d\symbf{p}\text{(}t\text{)}}{\,dt}}
 \end{displaymath}
 We also know the horizontal position that is defined in \hyperref[DD:positionXDD2]{DD:positionXDD2}
 
 \begin{displaymath}
-\resizeExpression{{p_{\text{x}2}}={p_{\text{x}1}}+{L_{2}}\,\sin\left({θ_{2}}\right)}{\outDefScale}
+\resizeExpression{{p_{\text{x}2}}={p_{\text{x}1}}+{L_{2}}\,\sin\left({θ_{2}}\right)}
 \end{displaymath}
 Applying this,
 
 \begin{displaymath}
-\resizeExpression{{v_{\text{x}2}}=\frac{\,d{p_{\text{x}1}}+{L_{2}}\,\sin\left({θ_{2}}\right)}{\,dt}}{\outDefScale}
+\resizeExpression{{v_{\text{x}2}}=\frac{\,d{p_{\text{x}1}}+{L_{2}}\,\sin\left({θ_{2}}\right)}{\,dt}}
 \end{displaymath}
 ${L_{1}}$ is constant with respect to time, so
 
 \begin{displaymath}
-\resizeExpression{{v_{\text{x}2}}={v_{\text{x}1}}+{w_{2}}\,{L_{2}}\,\cos\left({θ_{2}}\right)}{\outDefScale}
+\resizeExpression{{v_{\text{x}2}}={v_{\text{x}1}}+{w_{2}}\,{L_{2}}\,\cos\left({θ_{2}}\right)}
 \end{displaymath}
 \medskip
 \noindent
@@ -597,7 +588,7 @@ Units & $\frac{\text{m}}{\text{s}}$
         
 \\ \midrule
 Equation & \begin{displaymath}
-           \resizeExpression{{v_{\text{y}2}}={v_{\text{y}1}}+{w_{2}}\,{L_{2}}\,\sin\left({θ_{2}}\right)}{\inDefScale}
+           \resizeExpression{{v_{\text{y}2}}={v_{\text{y}1}}+{w_{2}}\,{L_{2}}\,\sin\left({θ_{2}}\right)}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -621,22 +612,22 @@ RefBy &
 At a given point in time, velocity is defined in \hyperref[DD:positionGDD]{DD:positionGDD}
 
 \begin{displaymath}
-\resizeExpression{\symbf{v}\text{(}t\text{)}=\frac{\,d\symbf{p}\text{(}t\text{)}}{\,dt}}{\outDefScale}
+\resizeExpression{\symbf{v}\text{(}t\text{)}=\frac{\,d\symbf{p}\text{(}t\text{)}}{\,dt}}
 \end{displaymath}
 We also know the vertical position that is defined in \hyperref[DD:positionYDD2]{DD:positionYDD2}
 
 \begin{displaymath}
-\resizeExpression{{p_{\text{y}2}}={p_{\text{y}1}}-{L_{2}}\,\cos\left({θ_{2}}\right)}{\outDefScale}
+\resizeExpression{{p_{\text{y}2}}={p_{\text{y}1}}-{L_{2}}\,\cos\left({θ_{2}}\right)}
 \end{displaymath}
 Applying this,
 
 \begin{displaymath}
-\resizeExpression{{v_{\text{y}2}}=-\left(\frac{\,d{p_{\text{y}1}}-{L_{2}}\,\cos\left({θ_{2}}\right)}{\,dt}\right)}{\outDefScale}
+\resizeExpression{{v_{\text{y}2}}=-\left(\frac{\,d{p_{\text{y}1}}-{L_{2}}\,\cos\left({θ_{2}}\right)}{\,dt}\right)}
 \end{displaymath}
 Therefore, using the chain rule,
 
 \begin{displaymath}
-\resizeExpression{{v_{\text{y}2}}={v_{\text{y}1}}+{w_{2}}\,{L_{2}}\,\sin\left({θ_{2}}\right)}{\outDefScale}
+\resizeExpression{{v_{\text{y}2}}={v_{\text{y}1}}+{w_{2}}\,{L_{2}}\,\sin\left({θ_{2}}\right)}
 \end{displaymath}
 \medskip
 \noindent
@@ -653,7 +644,7 @@ Units & $\frac{\text{m}}{\text{s}^{2}}$
         
 \\ \midrule
 Equation & \begin{displaymath}
-           \resizeExpression{{a_{\text{x}1}}=-{w_{1}}^{2}\,{L_{1}}\,\sin\left({θ_{1}}\right)+{α_{1}}\,{L_{1}}\,\cos\left({θ_{1}}\right)}{\inDefScale}
+           \resizeExpression{{a_{\text{x}1}}=-{w_{1}}^{2}\,{L_{1}}\,\sin\left({θ_{1}}\right)+{α_{1}}\,{L_{1}}\,\cos\left({θ_{1}}\right)}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -678,27 +669,27 @@ RefBy & \hyperref[IM:calOfAngle2]{IM:calOfAngle2}
 Our acceleration is:
 
 \begin{displaymath}
-\resizeExpression{\symbf{a}\text{(}t\text{)}=\frac{\,d\symbf{v}\text{(}t\text{)}}{\,dt}}{\outDefScale}
+\resizeExpression{\symbf{a}\text{(}t\text{)}=\frac{\,d\symbf{v}\text{(}t\text{)}}{\,dt}}
 \end{displaymath}
 Earlier, we found the horizontal velocity to be
 
 \begin{displaymath}
-\resizeExpression{{v_{\text{x}1}}={w_{1}}\,{L_{1}}\,\cos\left({θ_{1}}\right)}{\outDefScale}
+\resizeExpression{{v_{\text{x}1}}={w_{1}}\,{L_{1}}\,\cos\left({θ_{1}}\right)}
 \end{displaymath}
 Applying this to our equation for acceleration
 
 \begin{displaymath}
-\resizeExpression{{a_{\text{x}1}}=\frac{\,d{w_{1}}\,{L_{1}}\,\cos\left({θ_{1}}\right)}{\,dt}}{\outDefScale}
+\resizeExpression{{a_{\text{x}1}}=\frac{\,d{w_{1}}\,{L_{1}}\,\cos\left({θ_{1}}\right)}{\,dt}}
 \end{displaymath}
 By the product and chain rules, we find
 
 \begin{displaymath}
-\resizeExpression{{a_{\text{x}1}}=\frac{\,d{w_{1}}}{\,dt}\,{L_{1}}\,\cos\left({θ_{1}}\right)-{w_{1}}\,{L_{1}}\,\sin\left({θ_{1}}\right)\,\frac{\,d{θ_{1}}}{\,dt}}{\outDefScale}
+\resizeExpression{{a_{\text{x}1}}=\frac{\,d{w_{1}}}{\,dt}\,{L_{1}}\,\cos\left({θ_{1}}\right)-{w_{1}}\,{L_{1}}\,\sin\left({θ_{1}}\right)\,\frac{\,d{θ_{1}}}{\,dt}}
 \end{displaymath}
 Simplifying,
 
 \begin{displaymath}
-\resizeExpression{{a_{\text{x}1}}=-{w_{1}}^{2}\,{L_{1}}\,\sin\left({θ_{1}}\right)+{α_{1}}\,{L_{1}}\,\cos\left({θ_{1}}\right)}{\outDefScale}
+\resizeExpression{{a_{\text{x}1}}=-{w_{1}}^{2}\,{L_{1}}\,\sin\left({θ_{1}}\right)+{α_{1}}\,{L_{1}}\,\cos\left({θ_{1}}\right)}
 \end{displaymath}
 \medskip
 \noindent
@@ -715,7 +706,7 @@ Units & $\frac{\text{m}}{\text{s}^{2}}$
         
 \\ \midrule
 Equation & \begin{displaymath}
-           \resizeExpression{{a_{\text{y}1}}={w_{1}}^{2}\,{L_{1}}\,\cos\left({θ_{1}}\right)+{α_{1}}\,{L_{1}}\,\sin\left({θ_{1}}\right)}{\inDefScale}
+           \resizeExpression{{a_{\text{y}1}}={w_{1}}^{2}\,{L_{1}}\,\cos\left({θ_{1}}\right)+{α_{1}}\,{L_{1}}\,\sin\left({θ_{1}}\right)}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -740,27 +731,27 @@ RefBy & \hyperref[IM:calOfAngle2]{IM:calOfAngle2}
 Our acceleration is:
 
 \begin{displaymath}
-\resizeExpression{\symbf{a}\text{(}t\text{)}=\frac{\,d\symbf{v}\text{(}t\text{)}}{\,dt}}{\outDefScale}
+\resizeExpression{\symbf{a}\text{(}t\text{)}=\frac{\,d\symbf{v}\text{(}t\text{)}}{\,dt}}
 \end{displaymath}
 Earlier, we found the vertical velocity to be
 
 \begin{displaymath}
-\resizeExpression{{v_{\text{y}1}}={w_{1}}\,{L_{1}}\,\sin\left({θ_{1}}\right)}{\outDefScale}
+\resizeExpression{{v_{\text{y}1}}={w_{1}}\,{L_{1}}\,\sin\left({θ_{1}}\right)}
 \end{displaymath}
 Applying this to our equation for acceleration
 
 \begin{displaymath}
-\resizeExpression{{a_{\text{y}1}}=\frac{\,d{w_{1}}\,{L_{1}}\,\sin\left({θ_{1}}\right)}{\,dt}}{\outDefScale}
+\resizeExpression{{a_{\text{y}1}}=\frac{\,d{w_{1}}\,{L_{1}}\,\sin\left({θ_{1}}\right)}{\,dt}}
 \end{displaymath}
 By the product and chain rules, we find
 
 \begin{displaymath}
-\resizeExpression{{a_{\text{y}1}}=\frac{\,d{w_{1}}}{\,dt}\,{L_{1}}\,\sin\left({θ_{1}}\right)+{w_{1}}\,{L_{1}}\,\cos\left({θ_{1}}\right)\,\frac{\,d{θ_{1}}}{\,dt}}{\outDefScale}
+\resizeExpression{{a_{\text{y}1}}=\frac{\,d{w_{1}}}{\,dt}\,{L_{1}}\,\sin\left({θ_{1}}\right)+{w_{1}}\,{L_{1}}\,\cos\left({θ_{1}}\right)\,\frac{\,d{θ_{1}}}{\,dt}}
 \end{displaymath}
 Simplifying,
 
 \begin{displaymath}
-\resizeExpression{{a_{\text{y}1}}={w_{1}}^{2}\,{L_{1}}\,\cos\left({θ_{1}}\right)+{α_{1}}\,{L_{1}}\,\sin\left({θ_{1}}\right)}{\outDefScale}
+\resizeExpression{{a_{\text{y}1}}={w_{1}}^{2}\,{L_{1}}\,\cos\left({θ_{1}}\right)+{α_{1}}\,{L_{1}}\,\sin\left({θ_{1}}\right)}
 \end{displaymath}
 \medskip
 \noindent
@@ -777,7 +768,7 @@ Units & $\frac{\text{m}}{\text{s}^{2}}$
         
 \\ \midrule
 Equation & \begin{displaymath}
-           \resizeExpression{{a_{\text{x}2}}={a_{\text{x}1}}-{w_{2}}^{2}\,{L_{2}}\,\sin\left({θ_{2}}\right)+{α_{2}}\,{L_{2}}\,\cos\left({θ_{2}}\right)}{\inDefScale}
+           \resizeExpression{{a_{\text{x}2}}={a_{\text{x}1}}-{w_{2}}^{2}\,{L_{2}}\,\sin\left({θ_{2}}\right)+{α_{2}}\,{L_{2}}\,\cos\left({θ_{2}}\right)}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -803,22 +794,22 @@ RefBy & \hyperref[IM:calOfAngle2]{IM:calOfAngle2}
 Our acceleration is:
 
 \begin{displaymath}
-\resizeExpression{\symbf{a}\text{(}t\text{)}=\frac{\,d\symbf{v}\text{(}t\text{)}}{\,dt}}{\outDefScale}
+\resizeExpression{\symbf{a}\text{(}t\text{)}=\frac{\,d\symbf{v}\text{(}t\text{)}}{\,dt}}
 \end{displaymath}
 Earlier, we found the horizontal velocity to be
 
 \begin{displaymath}
-\resizeExpression{{v_{\text{x}2}}={v_{\text{x}1}}+{w_{2}}\,{L_{2}}\,\cos\left({θ_{2}}\right)}{\outDefScale}
+\resizeExpression{{v_{\text{x}2}}={v_{\text{x}1}}+{w_{2}}\,{L_{2}}\,\cos\left({θ_{2}}\right)}
 \end{displaymath}
 Applying this to our equation for acceleration
 
 \begin{displaymath}
-\resizeExpression{{a_{\text{x}2}}=\frac{\,d{v_{\text{x}1}}+{w_{2}}\,{L_{2}}\,\cos\left({θ_{2}}\right)}{\,dt}}{\outDefScale}
+\resizeExpression{{a_{\text{x}2}}=\frac{\,d{v_{\text{x}1}}+{w_{2}}\,{L_{2}}\,\cos\left({θ_{2}}\right)}{\,dt}}
 \end{displaymath}
 By the product and chain rules, we find
 
 \begin{displaymath}
-\resizeExpression{{a_{\text{x}2}}={a_{\text{x}1}}-{w_{2}}^{2}\,{L_{2}}\,\sin\left({θ_{2}}\right)+{α_{2}}\,{L_{2}}\,\cos\left({θ_{2}}\right)}{\outDefScale}
+\resizeExpression{{a_{\text{x}2}}={a_{\text{x}1}}-{w_{2}}^{2}\,{L_{2}}\,\sin\left({θ_{2}}\right)+{α_{2}}\,{L_{2}}\,\cos\left({θ_{2}}\right)}
 \end{displaymath}
 \medskip
 \noindent
@@ -835,7 +826,7 @@ Units & $\frac{\text{m}}{\text{s}^{2}}$
         
 \\ \midrule
 Equation & \begin{displaymath}
-           \resizeExpression{{a_{\text{y}2}}={a_{\text{y}1}}+{w_{2}}^{2}\,{L_{2}}\,\cos\left({θ_{2}}\right)+{α_{2}}\,{L_{2}}\,\sin\left({θ_{2}}\right)}{\inDefScale}
+           \resizeExpression{{a_{\text{y}2}}={a_{\text{y}1}}+{w_{2}}^{2}\,{L_{2}}\,\cos\left({θ_{2}}\right)+{α_{2}}\,{L_{2}}\,\sin\left({θ_{2}}\right)}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -861,22 +852,22 @@ RefBy & \hyperref[IM:calOfAngle2]{IM:calOfAngle2}
 Our acceleration is:
 
 \begin{displaymath}
-\resizeExpression{\symbf{a}\text{(}t\text{)}=\frac{\,d\symbf{v}\text{(}t\text{)}}{\,dt}}{\outDefScale}
+\resizeExpression{\symbf{a}\text{(}t\text{)}=\frac{\,d\symbf{v}\text{(}t\text{)}}{\,dt}}
 \end{displaymath}
 Earlier, we found the horizontal velocity to be
 
 \begin{displaymath}
-\resizeExpression{{v_{\text{y}2}}={v_{\text{y}1}}+{w_{2}}\,{L_{2}}\,\sin\left({θ_{2}}\right)}{\outDefScale}
+\resizeExpression{{v_{\text{y}2}}={v_{\text{y}1}}+{w_{2}}\,{L_{2}}\,\sin\left({θ_{2}}\right)}
 \end{displaymath}
 Applying this to our equation for acceleration
 
 \begin{displaymath}
-\resizeExpression{{a_{\text{y}2}}=\frac{\,d{v_{\text{y}1}}+{w_{2}}\,{L_{2}}\,\sin\left({θ_{2}}\right)}{\,dt}}{\outDefScale}
+\resizeExpression{{a_{\text{y}2}}=\frac{\,d{v_{\text{y}1}}+{w_{2}}\,{L_{2}}\,\sin\left({θ_{2}}\right)}{\,dt}}
 \end{displaymath}
 By the product and chain rules, we find
 
 \begin{displaymath}
-\resizeExpression{{a_{\text{y}2}}={a_{\text{y}1}}+{w_{2}}^{2}\,{L_{2}}\,\cos\left({θ_{2}}\right)+{α_{2}}\,{L_{2}}\,\sin\left({θ_{2}}\right)}{\outDefScale}
+\resizeExpression{{a_{\text{y}2}}={a_{\text{y}1}}+{w_{2}}^{2}\,{L_{2}}\,\cos\left({θ_{2}}\right)+{α_{2}}\,{L_{2}}\,\sin\left({θ_{2}}\right)}
 \end{displaymath}
 \medskip
 \noindent
@@ -893,7 +884,7 @@ Units & ${\text{N}}$
         
 \\ \midrule
 Equation & \begin{displaymath}
-           \resizeExpression{\symbf{F}=m \symbf{a}\text{(}t\text{)}=-{\symbf{T}_{1}}\,\sin\left({θ_{1}}\right)+{\symbf{T}_{2}}\,\sin\left({θ_{2}}\right)}{\inDefScale}
+           \resizeExpression{\symbf{F}=m \symbf{a}\text{(}t\text{)}=-{\symbf{T}_{1}}\,\sin\left({θ_{1}}\right)+{\symbf{T}_{2}}\,\sin\left({θ_{2}}\right)}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -918,7 +909,7 @@ RefBy & \hyperref[IM:calOfAngle2]{IM:calOfAngle2}
 \paragraph{Detailed derivation of force on the first object:}
 \label{GD:xForce1Deriv}
 \begin{displaymath}
-\resizeExpression{\symbf{F}=m \symbf{a}\text{(}t\text{)}=-{\symbf{T}_{1}}\,\sin\left({θ_{1}}\right)+{\symbf{T}_{2}}\,\sin\left({θ_{2}}\right)}{\outDefScale}
+\resizeExpression{\symbf{F}=m \symbf{a}\text{(}t\text{)}=-{\symbf{T}_{1}}\,\sin\left({θ_{1}}\right)+{\symbf{T}_{2}}\,\sin\left({θ_{2}}\right)}
 \end{displaymath}
 \medskip
 \noindent
@@ -935,7 +926,7 @@ Units & ${\text{N}}$
         
 \\ \midrule
 Equation & \begin{displaymath}
-           \resizeExpression{\symbf{F}=m \symbf{a}\text{(}t\text{)}={\symbf{T}_{1}}\,\cos\left({θ_{1}}\right)-{\symbf{T}_{2}}\,\cos\left({θ_{2}}\right)-{m_{1}}\,\symbf{g}}{\inDefScale}
+           \resizeExpression{\symbf{F}=m \symbf{a}\text{(}t\text{)}={\symbf{T}_{1}}\,\cos\left({θ_{1}}\right)-{\symbf{T}_{2}}\,\cos\left({θ_{2}}\right)-{m_{1}}\,\symbf{g}}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -962,7 +953,7 @@ RefBy & \hyperref[IM:calOfAngle2]{IM:calOfAngle2}
 \paragraph{Detailed derivation of force on the first object:}
 \label{GD:yForce1Deriv}
 \begin{displaymath}
-\resizeExpression{\symbf{F}=m \symbf{a}\text{(}t\text{)}={\symbf{T}_{1}}\,\cos\left({θ_{1}}\right)-{\symbf{T}_{2}}\,\cos\left({θ_{2}}\right)-{m_{1}}\,\symbf{g}}{\outDefScale}
+\resizeExpression{\symbf{F}=m \symbf{a}\text{(}t\text{)}={\symbf{T}_{1}}\,\cos\left({θ_{1}}\right)-{\symbf{T}_{2}}\,\cos\left({θ_{2}}\right)-{m_{1}}\,\symbf{g}}
 \end{displaymath}
 \medskip
 \noindent
@@ -979,7 +970,7 @@ Units & ${\text{N}}$
         
 \\ \midrule
 Equation & \begin{displaymath}
-           \resizeExpression{\symbf{F}=m \symbf{a}\text{(}t\text{)}=-{\symbf{T}_{2}}\,\sin\left({θ_{2}}\right)}{\inDefScale}
+           \resizeExpression{\symbf{F}=m \symbf{a}\text{(}t\text{)}=-{\symbf{T}_{2}}\,\sin\left({θ_{2}}\right)}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -1002,7 +993,7 @@ RefBy & \hyperref[IM:calOfAngle2]{IM:calOfAngle2}
 \paragraph{Detailed derivation of force on the second object:}
 \label{GD:xForce2Deriv}
 \begin{displaymath}
-\resizeExpression{\symbf{F}=m \symbf{a}\text{(}t\text{)}=-{\symbf{T}_{2}}\,\sin\left({θ_{2}}\right)}{\outDefScale}
+\resizeExpression{\symbf{F}=m \symbf{a}\text{(}t\text{)}=-{\symbf{T}_{2}}\,\sin\left({θ_{2}}\right)}
 \end{displaymath}
 \medskip
 \noindent
@@ -1019,7 +1010,7 @@ Units & ${\text{N}}$
         
 \\ \midrule
 Equation & \begin{displaymath}
-           \resizeExpression{\symbf{F}=m \symbf{a}\text{(}t\text{)}={\symbf{T}_{2}}\,\cos\left({θ_{2}}\right)-{m_{2}}\,\symbf{g}}{\inDefScale}
+           \resizeExpression{\symbf{F}=m \symbf{a}\text{(}t\text{)}={\symbf{T}_{2}}\,\cos\left({θ_{2}}\right)-{m_{2}}\,\symbf{g}}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -1044,7 +1035,7 @@ RefBy & \hyperref[IM:calOfAngle2]{IM:calOfAngle2}
 \paragraph{Detailed derivation of force on the second object:}
 \label{GD:yForce2Deriv}
 \begin{displaymath}
-\resizeExpression{\symbf{F}=m \symbf{a}\text{(}t\text{)}={\symbf{T}_{2}}\,\cos\left({θ_{2}}\right)-{m_{2}}\,\symbf{g}}{\outDefScale}
+\resizeExpression{\symbf{F}=m \symbf{a}\text{(}t\text{)}={\symbf{T}_{2}}\,\cos\left({θ_{2}}\right)-{m_{2}}\,\symbf{g}}
 \end{displaymath}
 \subsubsection{Data Definitions}
 \label{Sec:DDs}
@@ -1068,7 +1059,7 @@ Units & $\frac{\text{m}}{\text{s}}$
         
 \\ \midrule
 Equation & \begin{displaymath}
-           \resizeExpression{\symbf{v}\text{(}t\text{)}=\frac{\,d\symbf{p}\text{(}t\text{)}}{\,dt}}{\inDefScale}
+           \resizeExpression{\symbf{v}\text{(}t\text{)}=\frac{\,d\symbf{p}\text{(}t\text{)}}{\,dt}}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -1104,7 +1095,7 @@ Units & ${\text{m}}$
         
 \\ \midrule
 Equation & \begin{displaymath}
-           \resizeExpression{{p_{\text{x}1}}={L_{1}}\,\sin\left({θ_{1}}\right)}{\inDefScale}
+           \resizeExpression{{p_{\text{x}1}}={L_{1}}\,\sin\left({θ_{1}}\right)}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -1145,7 +1136,7 @@ Units & ${\text{m}}$
         
 \\ \midrule
 Equation & \begin{displaymath}
-           \resizeExpression{{p_{\text{y}1}}=-{L_{1}}\,\cos\left({θ_{1}}\right)}{\inDefScale}
+           \resizeExpression{{p_{\text{y}1}}=-{L_{1}}\,\cos\left({θ_{1}}\right)}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -1186,7 +1177,7 @@ Units & ${\text{m}}$
         
 \\ \midrule
 Equation & \begin{displaymath}
-           \resizeExpression{{p_{\text{x}2}}={p_{\text{x}1}}+{L_{2}}\,\sin\left({θ_{2}}\right)}{\inDefScale}
+           \resizeExpression{{p_{\text{x}2}}={p_{\text{x}1}}+{L_{2}}\,\sin\left({θ_{2}}\right)}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -1228,7 +1219,7 @@ Units & ${\text{m}}$
         
 \\ \midrule
 Equation & \begin{displaymath}
-           \resizeExpression{{p_{\text{y}2}}={p_{\text{y}1}}-{L_{2}}\,\cos\left({θ_{2}}\right)}{\inDefScale}
+           \resizeExpression{{p_{\text{y}2}}={p_{\text{y}1}}-{L_{2}}\,\cos\left({θ_{2}}\right)}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -1270,7 +1261,7 @@ Units & $\frac{\text{m}}{\text{s}^{2}}$
         
 \\ \midrule
 Equation & \begin{displaymath}
-           \resizeExpression{\symbf{a}\text{(}t\text{)}=\frac{\,d\symbf{v}\text{(}t\text{)}}{\,dt}}{\inDefScale}
+           \resizeExpression{\symbf{a}\text{(}t\text{)}=\frac{\,d\symbf{v}\text{(}t\text{)}}{\,dt}}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -1305,7 +1296,7 @@ Units & ${\text{N}}$
         
 \\ \midrule
 Equation & \begin{displaymath}
-           \resizeExpression{\symbf{F}=m \symbf{a}\text{(}t\text{)}}{\inDefScale}
+           \resizeExpression{\symbf{F}=m \symbf{a}\text{(}t\text{)}}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -1344,22 +1335,22 @@ Output & ${θ_{1}}$
          
 \\ \midrule
 Input Constraints & \begin{displaymath}
-                    \resizeExpression{{L_{1}}\gt{}0}{\inDefScale}
+                    \resizeExpression{{L_{1}}\gt{}0}
                     \end{displaymath}
                     \begin{displaymath}
-                    \resizeExpression{{L_{2}}\gt{}0}{\inDefScale}
+                    \resizeExpression{{L_{2}}\gt{}0}
                     \end{displaymath}
                     \begin{displaymath}
-                    \resizeExpression{{m_{1}}\gt{}0}{\inDefScale}
+                    \resizeExpression{{m_{1}}\gt{}0}
                     \end{displaymath}
                     \begin{displaymath}
-                    \resizeExpression{{m_{2}}\gt{}0}{\inDefScale}
+                    \resizeExpression{{m_{2}}\gt{}0}
                     \end{displaymath}
 \\ \midrule
 Output Constraints & 
 \\ \midrule
 Equation & \begin{displaymath}
-           \resizeExpression{{α_{1}}\left({θ_{1}},{θ_{2}},{w_{1}},{w_{2}}\right)=\frac{-g\,\left(2\,{m_{1}}+{m_{2}}\right)\,\sin\left({θ_{1}}\right)-{m_{2}}\,g\,\sin\left({θ_{1}}-2\,{θ_{2}}\right)-2\,\sin\left({θ_{1}}-{θ_{2}}\right)\,{m_{2}}\,\left({w_{2}}^{2}\,{L_{2}}+{w_{1}}^{2}\,{L_{1}}\,\cos\left({θ_{1}}-{θ_{2}}\right)\right)}{{L_{1}}\,\left(2\,{m_{1}}+{m_{2}}-{m_{2}}\,\cos\left(2\,{θ_{1}}-2\,{θ_{2}}\right)\right)}}{\inDefScale}
+           \resizeExpression{{α_{1}}\left({θ_{1}},{θ_{2}},{w_{1}},{w_{2}}\right)=\frac{-g\,\left(2\,{m_{1}}+{m_{2}}\right)\,\sin\left({θ_{1}}\right)-{m_{2}}\,g\,\sin\left({θ_{1}}-2\,{θ_{2}}\right)-2\,\sin\left({θ_{1}}-{θ_{2}}\right)\,{m_{2}}\,\left({w_{2}}^{2}\,{L_{2}}+{w_{1}}^{2}\,{L_{1}}\,\cos\left({θ_{1}}-{θ_{2}}\right)\right)}{{L_{1}}\,\left(2\,{m_{1}}+{m_{2}}-{m_{2}}\,\cos\left(2\,{θ_{1}}-2\,{θ_{2}}\right)\right)}}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -1405,22 +1396,22 @@ Output & ${θ_{2}}$
          
 \\ \midrule
 Input Constraints & \begin{displaymath}
-                    \resizeExpression{{L_{1}}\gt{}0}{\inDefScale}
+                    \resizeExpression{{L_{1}}\gt{}0}
                     \end{displaymath}
                     \begin{displaymath}
-                    \resizeExpression{{L_{2}}\gt{}0}{\inDefScale}
+                    \resizeExpression{{L_{2}}\gt{}0}
                     \end{displaymath}
                     \begin{displaymath}
-                    \resizeExpression{{m_{1}}\gt{}0}{\inDefScale}
+                    \resizeExpression{{m_{1}}\gt{}0}
                     \end{displaymath}
                     \begin{displaymath}
-                    \resizeExpression{{m_{2}}\gt{}0}{\inDefScale}
+                    \resizeExpression{{m_{2}}\gt{}0}
                     \end{displaymath}
 \\ \midrule
 Output Constraints & 
 \\ \midrule
 Equation & \begin{displaymath}
-           \resizeExpression{{α_{2}}\left({θ_{1}},{θ_{2}},{w_{1}},{w_{2}}\right)=\frac{2\,\sin\left({θ_{1}}-{θ_{2}}\right)\,\left({w_{1}}^{2}\,{L_{1}}\,\left({m_{1}}+{m_{2}}\right)+g\,\left({m_{1}}+{m_{2}}\right)\,\cos\left({θ_{1}}\right)+{w_{2}}^{2}\,{L_{2}}\,{m_{2}}\,\cos\left({θ_{1}}-{θ_{2}}\right)\right)}{{L_{2}}\,\left(2\,{m_{1}}+{m_{2}}-{m_{2}}\,\cos\left(2\,{θ_{1}}-2\,{θ_{2}}\right)\right)}}{\inDefScale}
+           \resizeExpression{{α_{2}}\left({θ_{1}},{θ_{2}},{w_{1}},{w_{2}}\right)=\frac{2\,\sin\left({θ_{1}}-{θ_{2}}\right)\,\left({w_{1}}^{2}\,{L_{1}}\,\left({m_{1}}+{m_{2}}\right)+g\,\left({m_{1}}+{m_{2}}\right)\,\cos\left({θ_{1}}\right)+{w_{2}}^{2}\,{L_{2}}\,{m_{2}}\,\cos\left({θ_{1}}-{θ_{2}}\right)\right)}{{L_{2}}\,\left(2\,{m_{1}}+{m_{2}}-{m_{2}}\,\cos\left(2\,{θ_{1}}-2\,{θ_{2}}\right)\right)}}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -1453,39 +1444,39 @@ RefBy & \hyperref[outputValues]{FR:Output-Values}, \hyperref[calcAng]{FR:Calcula
 By solving equations \hyperref[GD:xForce2]{GD:xForce2} and \hyperref[GD:yForce2]{GD:yForce2} for ${\symbf{T}_{2}}\,\sin\left({θ_{2}}\right)$ and ${\symbf{T}_{2}}\,\cos\left({θ_{2}}\right)$ and then substituting into equation \hyperref[GD:xForce1]{GD:xForce1} and \hyperref[GD:yForce1]{GD:yForce1} , We can get equations 1 and 2:
 
 \begin{displaymath}
-\resizeExpression{{m_{1}}\,{a_{\text{x}1}}=-{\symbf{T}_{1}}\,\sin\left({θ_{1}}\right)-{m_{2}}\,{a_{\text{x}2}}}{\outDefScale}
+\resizeExpression{{m_{1}}\,{a_{\text{x}1}}=-{\symbf{T}_{1}}\,\sin\left({θ_{1}}\right)-{m_{2}}\,{a_{\text{x}2}}}
 \end{displaymath}
 
 \begin{displaymath}
-\resizeExpression{{m_{1}}\,{a_{\text{y}1}}={\symbf{T}_{1}}\,\cos\left({θ_{1}}\right)-{m_{2}}\,{a_{\text{y}2}}-{m_{2}}\,g-{m_{1}}\,g}{\outDefScale}
+\resizeExpression{{m_{1}}\,{a_{\text{y}1}}={\symbf{T}_{1}}\,\cos\left({θ_{1}}\right)-{m_{2}}\,{a_{\text{y}2}}-{m_{2}}\,g-{m_{1}}\,g}
 \end{displaymath}
 Multiply the equation 1 by $\cos\left({θ_{1}}\right)$ and the equation 2 by $\sin\left({θ_{1}}\right)$ and rearrange to get:
 
 \begin{displaymath}
-\resizeExpression{{\symbf{T}_{1}}\,\sin\left({θ_{1}}\right)\,\cos\left({θ_{1}}\right)=-\cos\left({θ_{1}}\right)\,\left({m_{1}}\,{a_{\text{x}1}}+{m_{2}}\,{a_{\text{x}2}}\right)}{\outDefScale}
+\resizeExpression{{\symbf{T}_{1}}\,\sin\left({θ_{1}}\right)\,\cos\left({θ_{1}}\right)=-\cos\left({θ_{1}}\right)\,\left({m_{1}}\,{a_{\text{x}1}}+{m_{2}}\,{a_{\text{x}2}}\right)}
 \end{displaymath}
 
 \begin{displaymath}
-\resizeExpression{{\symbf{T}_{1}}\,\sin\left({θ_{1}}\right)\,\cos\left({θ_{1}}\right)=\sin\left({θ_{1}}\right)\,\left({m_{1}}\,{a_{\text{y}1}}+{m_{2}}\,{a_{\text{y}2}}+{m_{2}}\,g+{m_{1}}\,g\right)}{\outDefScale}
+\resizeExpression{{\symbf{T}_{1}}\,\sin\left({θ_{1}}\right)\,\cos\left({θ_{1}}\right)=\sin\left({θ_{1}}\right)\,\left({m_{1}}\,{a_{\text{y}1}}+{m_{2}}\,{a_{\text{y}2}}+{m_{2}}\,g+{m_{1}}\,g\right)}
 \end{displaymath}
 This leads to the equation 3
 
 \begin{displaymath}
-\resizeExpression{\sin\left({θ_{1}}\right)\,\left({m_{1}}\,{a_{\text{y}1}}+{m_{2}}\,{a_{\text{y}2}}+{m_{2}}\,g+{m_{1}}\,g\right)=-\cos\left({θ_{1}}\right)\,\left({m_{1}}\,{a_{\text{x}1}}+{m_{2}}\,{a_{\text{x}2}}\right)}{\outDefScale}
+\resizeExpression{\sin\left({θ_{1}}\right)\,\left({m_{1}}\,{a_{\text{y}1}}+{m_{2}}\,{a_{\text{y}2}}+{m_{2}}\,g+{m_{1}}\,g\right)=-\cos\left({θ_{1}}\right)\,\left({m_{1}}\,{a_{\text{x}1}}+{m_{2}}\,{a_{\text{x}2}}\right)}
 \end{displaymath}
 Next, multiply equation \hyperref[GD:xForce2]{GD:xForce2} by $\cos\left({θ_{2}}\right)$ and equation \hyperref[GD:yForce2]{GD:yForce2} by $\sin\left({θ_{2}}\right)$ and rearrange to get:
 
 \begin{displaymath}
-\resizeExpression{{\symbf{T}_{2}}\,\sin\left({θ_{2}}\right)\,\cos\left({θ_{2}}\right)=-\cos\left({θ_{2}}\right)\,{m_{2}}\,{a_{\text{x}2}}}{\outDefScale}
+\resizeExpression{{\symbf{T}_{2}}\,\sin\left({θ_{2}}\right)\,\cos\left({θ_{2}}\right)=-\cos\left({θ_{2}}\right)\,{m_{2}}\,{a_{\text{x}2}}}
 \end{displaymath}
 
 \begin{displaymath}
-\resizeExpression{{\symbf{T}_{1}}\,\sin\left({θ_{2}}\right)\,\cos\left({θ_{2}}\right)=\sin\left({θ_{2}}\right)\,\left({m_{2}}\,{a_{\text{y}2}}+{m_{2}}\,g\right)}{\outDefScale}
+\resizeExpression{{\symbf{T}_{1}}\,\sin\left({θ_{2}}\right)\,\cos\left({θ_{2}}\right)=\sin\left({θ_{2}}\right)\,\left({m_{2}}\,{a_{\text{y}2}}+{m_{2}}\,g\right)}
 \end{displaymath}
 which leads to equation 4
 
 \begin{displaymath}
-\resizeExpression{\sin\left({θ_{2}}\right)\,\left({m_{2}}\,{a_{\text{y}2}}+{m_{2}}\,g\right)=-\cos\left({θ_{2}}\right)\,{m_{2}}\,{a_{\text{x}2}}}{\outDefScale}
+\resizeExpression{\sin\left({θ_{2}}\right)\,\left({m_{2}}\,{a_{\text{y}2}}+{m_{2}}\,g\right)=-\cos\left({θ_{2}}\right)\,{m_{2}}\,{a_{\text{x}2}}}
 \end{displaymath}
 By giving equations \hyperref[GD:accelerationX1]{GD:accelerationX1} and \hyperref[GD:accelerationX2]{GD:accelerationX2} and \hyperref[GD:accelerationY1]{GD:accelerationY1} and \hyperref[GD:accelerationY2]{GD:accelerationY2} plus additional two equations, 3 and 4, we can get \hyperref[IM:calOfAngle1]{IM:calOfAngle1} and \hyperref[IM:calOfAngle2]{IM:calOfAngle2} via a computer algebra program:
 

--- a/code/stable/gamephysics/SRS/PDF/GamePhysics_SRS.tex
+++ b/code/stable/gamephysics/SRS/PDF/GamePhysics_SRS.tex
@@ -15,8 +15,7 @@
 \usepackage{svg}
 \usepackage{float}
 \usepackage{enumitem}
-\usepackage{graphicx}
-\usepackage{calc}
+\usepackage{adjustbox}
 \usepackage{filecontents}
 \usepackage[backend=bibtex]{biblatex}
 \usepackage{url}
@@ -25,16 +24,8 @@
 \newcommand{\lt}{\ensuremath <}
 \newlist{symbDescription}{description}{1}
 \setlist[symbDescription]{noitemsep, topsep=0pt, parsep=0pt, partopsep=0pt}
-\def\inDefScale{0.8}
-\def\outDefScale{1.0}
-\newsavebox{\mybox}
-\newcommand{\resizeExpression}[2]{
-  \savebox{\mybox}{$#1$}
-  \ifdim\wd\mybox>#2\linewidth
-    \resizebox{#2\textwidth}{!}{\usebox{\mybox}}
-  \else
-    \usebox{\mybox}
-  \fi
+\newcommand{\resizeExpression}[1]{
+  \adjustbox{max width=\linewidth}{$#1$}
 }
 \bibliography{bibfile}
 \title{Software Requirements Specification for GamePhysics}
@@ -381,7 +372,7 @@ Label & Newton's second law of motion
         
 \\ \midrule
 Equation & \begin{displaymath}
-           \resizeExpression{\symbf{F}=m\,\symbf{a}\text{(}t\text{)}}{\inDefScale}
+           \resizeExpression{\symbf{F}=m\,\symbf{a}\text{(}t\text{)}}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -414,7 +405,7 @@ Label & Newton's third law of motion
         
 \\ \midrule
 Equation & \begin{displaymath}
-           \resizeExpression{{\symbf{F}_{1}}=-{\symbf{F}_{2}}}{\inDefScale}
+           \resizeExpression{{\symbf{F}_{1}}=-{\symbf{F}_{2}}}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -445,7 +436,7 @@ Label & Newton's law of universal gravitation
         
 \\ \midrule
 Equation & \begin{displaymath}
-           \resizeExpression{\symbf{F}=G\,\frac{{m_{1}}\,{m_{2}}}{\|\symbf{d}\|^{2}}\,\symbf{\hat{d}}=G\,\frac{{m_{1}}\,{m_{2}}}{\|\symbf{d}\|^{2}}\,\frac{\symbf{d}}{\|\symbf{d}\|}}{\inDefScale}
+           \resizeExpression{\symbf{F}=G\,\frac{{m_{1}}\,{m_{2}}}{\|\symbf{d}\|^{2}}\,\symbf{\hat{d}}=G\,\frac{{m_{1}}\,{m_{2}}}{\|\symbf{d}\|^{2}}\,\frac{\symbf{d}}{\|\symbf{d}\|}}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -482,7 +473,7 @@ Label & Newton's second law for rotational motion
         
 \\ \midrule
 Equation & \begin{displaymath}
-           \resizeExpression{\symbf{τ}=\symbf{I}\,α}{\inDefScale}
+           \resizeExpression{\symbf{τ}=\symbf{I}\,α}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -524,7 +515,7 @@ Units & $\frac{\text{m}}{\text{s}^{2}}$
         
 \\ \midrule
 Equation & \begin{displaymath}
-           \resizeExpression{\symbf{g}=-\frac{G\,M}{\|\symbf{d}\|^{2}}\,\symbf{\hat{d}}}{\inDefScale}
+           \resizeExpression{\symbf{g}=-\frac{G\,M}{\|\symbf{d}\|^{2}}\,\symbf{\hat{d}}}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -552,27 +543,27 @@ RefBy & \hyperref[IM:transMot]{IM:transMot}
 From \hyperref[TM:UniversalGravLaw]{Newton's law of universal gravitation}, we have:
 
 \begin{displaymath}
-\resizeExpression{\symbf{F}=\frac{G\,{m_{1}}\,{m_{2}}}{{\|\symbf{d}\|^{2}}}\,\symbf{\hat{d}}}{\outDefScale}
+\resizeExpression{\symbf{F}=\frac{G\,{m_{1}}\,{m_{2}}}{{\|\symbf{d}\|^{2}}}\,\symbf{\hat{d}}}
 \end{displaymath}
 The above equation governs the gravitational attraction between two bodies. Suppose that one of the bodies is significantly more massive than the other, so that we concern ourselves with the force the massive body exerts on the lighter body. Further, suppose that the Cartesian coordinate system is chosen such that this force acts on a line which lies along one of the principal axes. Then our unit vector directed from the center of the large mass to the center of the smaller mass $\symbf{\hat{d}}$ for the x or y axes is:
 
 \begin{displaymath}
-\resizeExpression{\symbf{\hat{d}}=\frac{\symbf{d}}{\|\symbf{d}\|}}{\outDefScale}
+\resizeExpression{\symbf{\hat{d}}=\frac{\symbf{d}}{\|\symbf{d}\|}}
 \end{displaymath}
 Given the above assumptions, let $M$ and $m$ be the mass of the massive and light body respectively. Equating $\symbf{F}$ above with Newton's second law for the force experienced by the light body, we get:
 
 \begin{displaymath}
-\resizeExpression{{\symbf{F}_{\symbf{g}}}=G\,\frac{M\,m}{{\|\symbf{d}\|^{2}}}\,\symbf{\hat{d}}=m\,\symbf{g}}{\outDefScale}
+\resizeExpression{{\symbf{F}_{\symbf{g}}}=G\,\frac{M\,m}{{\|\symbf{d}\|^{2}}}\,\symbf{\hat{d}}=m\,\symbf{g}}
 \end{displaymath}
 where $\symbf{g}$ is the gravitational acceleration. Dividing the above equation by $m$,  we have:
 
 \begin{displaymath}
-\resizeExpression{G\,\frac{M}{{\|\symbf{d}\|^{2}}}\,\symbf{\hat{d}}=\symbf{g}}{\outDefScale}
+\resizeExpression{G\,\frac{M}{{\|\symbf{d}\|^{2}}}\,\symbf{\hat{d}}=\symbf{g}}
 \end{displaymath}
 and thus the negative sign indicates that the force is an attractive force:
 
 \begin{displaymath}
-\resizeExpression{\symbf{g}=-G\,\frac{M}{{\|\symbf{d}\|^{2}}}\,\symbf{\hat{d}}}{\outDefScale}
+\resizeExpression{\symbf{g}=-G\,\frac{M}{{\|\symbf{d}\|^{2}}}\,\symbf{\hat{d}}}
 \end{displaymath}
 \medskip
 \noindent
@@ -589,7 +580,7 @@ Units & $\text{N}\text{s}$
         
 \\ \midrule
 Equation & \begin{displaymath}
-           \resizeExpression{j=\frac{-\left(1+{C_{\text{R}}}\right)\,{{\symbf{v}\text{(}t\text{)}_{\text{i}}}^{\text{A}\text{B}}}\cdot{}\symbf{n}}{\left(\frac{1}{{m_{\text{A}}}}+\frac{1}{{m_{\text{B}}}}\right)\,\|\symbf{n}\|^{2}+\frac{\|{\symbf{u}_{\text{A}\text{P}}}\text{*}\symbf{n}\|^{2}}{{\symbf{I}_{\text{A}}}}+\frac{\|{\symbf{u}_{\text{B}\text{P}}}\text{*}\symbf{n}\|^{2}}{{\symbf{I}_{\text{B}}}}}}{\inDefScale}
+           \resizeExpression{j=\frac{-\left(1+{C_{\text{R}}}\right)\,{{\symbf{v}\text{(}t\text{)}_{\text{i}}}^{\text{A}\text{B}}}\cdot{}\symbf{n}}{\left(\frac{1}{{m_{\text{A}}}}+\frac{1}{{m_{\text{B}}}}\right)\,\|\symbf{n}\|^{2}+\frac{\|{\symbf{u}_{\text{A}\text{P}}}\text{*}\symbf{n}\|^{2}}{{\symbf{I}_{\text{A}}}}+\frac{\|{\symbf{u}_{\text{B}\text{P}}}\text{*}\symbf{n}\|^{2}}{{\symbf{I}_{\text{B}}}}}}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -644,7 +635,7 @@ Units & ${\text{m}}$
         
 \\ \midrule
 Equation & \begin{displaymath}
-           \resizeExpression{{\symbf{p}\text{(}t\text{)}_{\text{CM}}}=\frac{\displaystyle\sum{{m_{j}}\,{\symbf{p}\text{(}t\text{)}_{j}}}}{{m_{T}}}}{\inDefScale}
+           \resizeExpression{{\symbf{p}\text{(}t\text{)}_{\text{CM}}}=\frac{\displaystyle\sum{{m_{j}}\,{\symbf{p}\text{(}t\text{)}_{j}}}}{{m_{T}}}}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -684,7 +675,7 @@ Units & ${\text{m}}$
         
 \\ \midrule
 Equation & \begin{displaymath}
-           \resizeExpression{u\text{(}t\text{)}=\frac{\,d\symbf{p}\text{(}t\text{)}\left(t\right)}{\,dt}}{\inDefScale}
+           \resizeExpression{u\text{(}t\text{)}=\frac{\,d\symbf{p}\text{(}t\text{)}\left(t\right)}{\,dt}}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -723,7 +714,7 @@ Units & $\frac{\text{m}}{\text{s}}$
         
 \\ \midrule
 Equation & \begin{displaymath}
-           \resizeExpression{v\text{(}t\text{)}=\frac{\,d\symbf{u}\left(t\right)}{\,dt}}{\inDefScale}
+           \resizeExpression{v\text{(}t\text{)}=\frac{\,d\symbf{u}\left(t\right)}{\,dt}}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -762,7 +753,7 @@ Units & $\frac{\text{m}}{\text{s}^{2}}$
         
 \\ \midrule
 Equation & \begin{displaymath}
-           \resizeExpression{a\text{(}t\text{)}=\frac{\,d\symbf{v}\text{(}t\text{)}\left(t\right)}{\,dt}}{\inDefScale}
+           \resizeExpression{a\text{(}t\text{)}=\frac{\,d\symbf{v}\text{(}t\text{)}\left(t\right)}{\,dt}}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -801,7 +792,7 @@ Units & ${\text{rad}}$
         
 \\ \midrule
 Equation & \begin{displaymath}
-           \resizeExpression{θ=\frac{\,dϕ\left(t\right)}{\,dt}}{\inDefScale}
+           \resizeExpression{θ=\frac{\,dϕ\left(t\right)}{\,dt}}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -840,7 +831,7 @@ Units & $\frac{\text{rad}}{\text{s}}$
         
 \\ \midrule
 Equation & \begin{displaymath}
-           \resizeExpression{ω=\frac{\,dθ\left(t\right)}{\,dt}}{\inDefScale}
+           \resizeExpression{ω=\frac{\,dθ\left(t\right)}{\,dt}}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -879,7 +870,7 @@ Units & $\frac{\text{rad}}{\text{s}^{2}}$
         
 \\ \midrule
 Equation & \begin{displaymath}
-           \resizeExpression{α=\frac{\,dω\left(t\right)}{\,dt}}{\inDefScale}
+           \resizeExpression{α=\frac{\,dω\left(t\right)}{\,dt}}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -918,7 +909,7 @@ Units & $\frac{\text{m}}{\text{s}}$
         
 \\ \midrule
 Equation & \begin{displaymath}
-           \resizeExpression{{\symbf{v}\text{(}t\text{)}_{\text{B}}}={\symbf{v}\text{(}t\text{)}_{\text{O}}}+ω\times{\symbf{u}_{\text{O}\text{B}}}}{\inDefScale}
+           \resizeExpression{{\symbf{v}\text{(}t\text{)}_{\text{B}}}={\symbf{v}\text{(}t\text{)}_{\text{O}}}+ω\times{\symbf{u}_{\text{O}\text{B}}}}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -959,7 +950,7 @@ Units & $\text{N}\text{m}$
         
 \\ \midrule
 Equation & \begin{displaymath}
-           \resizeExpression{\symbf{τ}=\symbf{r}\times\symbf{F}}{\inDefScale}
+           \resizeExpression{\symbf{τ}=\symbf{r}\times\symbf{F}}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -997,7 +988,7 @@ Units & ${\text{J}}$
         
 \\ \midrule
 Equation & \begin{displaymath}
-           \resizeExpression{KE=m\,\frac{\|\symbf{v}\text{(}t\text{)}\|^{2}}{2}}{\inDefScale}
+           \resizeExpression{KE=m\,\frac{\|\symbf{v}\text{(}t\text{)}\|^{2}}{2}}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -1039,7 +1030,7 @@ Units & Unitless
         
 \\ \midrule
 Equation & \begin{displaymath}
-           \resizeExpression{{C_{\text{R}}}=-\left(\frac{{{\symbf{v}\text{(}t\text{)}_{\text{f}}}^{\text{A}\text{B}}}\cdot{}\symbf{n}}{{{\symbf{v}\text{(}t\text{)}_{\text{i}}}^{\text{A}\text{B}}}\cdot{}\symbf{n}}\right)}{\inDefScale}
+           \resizeExpression{{C_{\text{R}}}=-\left(\frac{{{\symbf{v}\text{(}t\text{)}_{\text{f}}}^{\text{A}\text{B}}}\cdot{}\symbf{n}}{{{\symbf{v}\text{(}t\text{)}_{\text{i}}}^{\text{A}\text{B}}}\cdot{}\symbf{n}}\right)}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -1078,7 +1069,7 @@ Units & $\frac{\text{m}}{\text{s}}$
         
 \\ \midrule
 Equation & \begin{displaymath}
-           \resizeExpression{{{\symbf{v}\text{(}t\text{)}_{\text{i}}}^{\text{A}\text{B}}}={\symbf{v}\text{(}t\text{)}^{\text{A}\text{P}}}-{\symbf{v}\text{(}t\text{)}^{\text{B}\text{P}}}}{\inDefScale}
+           \resizeExpression{{{\symbf{v}\text{(}t\text{)}_{\text{i}}}^{\text{A}\text{B}}}={\symbf{v}\text{(}t\text{)}^{\text{A}\text{P}}}-{\symbf{v}\text{(}t\text{)}^{\text{B}\text{P}}}}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -1118,7 +1109,7 @@ Units & $\text{N}\text{s}$
         
 \\ \midrule
 Equation & \begin{displaymath}
-           \resizeExpression{\symbf{J}=m\,Δ\symbf{v}}{\inDefScale}
+           \resizeExpression{\symbf{J}=m\,Δ\symbf{v}}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -1145,17 +1136,17 @@ RefBy &
 Newton's second law of motion states:
 
 \begin{displaymath}
-\resizeExpression{\symbf{F}=m\,\symbf{a}\text{(}t\text{)}=m\,\frac{\,d\symbf{v}\text{(}t\text{)}}{\,dt}}{\outDefScale}
+\resizeExpression{\symbf{F}=m\,\symbf{a}\text{(}t\text{)}=m\,\frac{\,d\symbf{v}\text{(}t\text{)}}{\,dt}}
 \end{displaymath}
 Rearranging:
 
 \begin{displaymath}
-\resizeExpression{\int_{{t_{1}}}^{{t_{2}}}{\symbf{F}}\,dt=m\,\left(\int_{{\symbf{v}\text{(}t\text{)}_{1}}}^{{\symbf{v}\text{(}t\text{)}_{2}}}{1}\,d\symbf{v}\text{(}t\text{)}\right)}{\outDefScale}
+\resizeExpression{\int_{{t_{1}}}^{{t_{2}}}{\symbf{F}}\,dt=m\,\left(\int_{{\symbf{v}\text{(}t\text{)}_{1}}}^{{\symbf{v}\text{(}t\text{)}_{2}}}{1}\,d\symbf{v}\text{(}t\text{)}\right)}
 \end{displaymath}
 Integrating the right hand side:
 
 \begin{displaymath}
-\resizeExpression{\int_{{t_{1}}}^{{t_{2}}}{\symbf{F}}\,dt=m\,{\symbf{v}\text{(}t\text{)}_{2}}-m\,{\symbf{v}\text{(}t\text{)}_{1}}=m\,Δ\symbf{v}}{\outDefScale}
+\resizeExpression{\int_{{t_{1}}}^{{t_{2}}}{\symbf{F}}\,dt=m\,{\symbf{v}\text{(}t\text{)}_{2}}-m\,{\symbf{v}\text{(}t\text{)}_{1}}=m\,Δ\symbf{v}}
 \end{displaymath}
 \medskip
 \noindent
@@ -1175,7 +1166,7 @@ Units & ${\text{J}}$
         
 \\ \midrule
 Equation & \begin{displaymath}
-           \resizeExpression{PE=m\,\symbf{g}\,h}{\inDefScale}
+           \resizeExpression{PE=m\,\symbf{g}\,h}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -1218,7 +1209,7 @@ Units & $\text{kg}\text{m}^{2}$
         
 \\ \midrule
 Equation & \begin{displaymath}
-           \resizeExpression{\symbf{I}=\displaystyle\sum{{m_{j}}\,{d_{j}}^{2}}}{\inDefScale}
+           \resizeExpression{\symbf{I}=\displaystyle\sum{{m_{j}}\,{d_{j}}^{2}}}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -1264,25 +1255,25 @@ Output & ${\symbf{a}\text{(}t\text{)}_{j}}$
          
 \\ \midrule
 Input Constraints & \begin{displaymath}
-                    \resizeExpression{{\symbf{v}\text{(}t\text{)}_{j}}\gt{}0}{\inDefScale}
+                    \resizeExpression{{\symbf{v}\text{(}t\text{)}_{j}}\gt{}0}
                     \end{displaymath}
                     \begin{displaymath}
-                    \resizeExpression{t\gt{}0}{\inDefScale}
+                    \resizeExpression{t\gt{}0}
                     \end{displaymath}
                     \begin{displaymath}
-                    \resizeExpression{\symbf{g}\gt{}0}{\inDefScale}
+                    \resizeExpression{\symbf{g}\gt{}0}
                     \end{displaymath}
                     \begin{displaymath}
-                    \resizeExpression{{\symbf{F}_{j}}\gt{}0}{\inDefScale}
+                    \resizeExpression{{\symbf{F}_{j}}\gt{}0}
                     \end{displaymath}
                     \begin{displaymath}
-                    \resizeExpression{{m_{j}}\gt{}0}{\inDefScale}
+                    \resizeExpression{{m_{j}}\gt{}0}
                     \end{displaymath}
 \\ \midrule
 Output Constraints & 
 \\ \midrule
 Equation & \begin{displaymath}
-           \resizeExpression{{\symbf{a}\text{(}t\text{)}_{j}}=\symbf{g}+\frac{{\symbf{F}_{j}}\left(t\right)}{{m_{j}}}}{\inDefScale}
+           \resizeExpression{{\symbf{a}\text{(}t\text{)}_{j}}=\symbf{g}+\frac{{\symbf{F}_{j}}\left(t\right)}{{m_{j}}}}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -1315,12 +1306,12 @@ RefBy &
 We may calculate the total acceleration of rigid body $j$ by calculating the derivative of it's velocity with respect to time (from \hyperref[DD:linAcc]{DD:linAcc}).
 
 \begin{displaymath}
-\resizeExpression{{α_{j}}=\frac{\,d{\symbf{v}\text{(}t\text{)}_{j}}\left(t\right)}{\,dt}}{\outDefScale}
+\resizeExpression{{α_{j}}=\frac{\,d{\symbf{v}\text{(}t\text{)}_{j}}\left(t\right)}{\,dt}}
 \end{displaymath}
 Performing the derivative, we obtain:
 
 \begin{displaymath}
-\resizeExpression{{\symbf{a}\text{(}t\text{)}_{j}}=\symbf{g}+\frac{{\symbf{F}_{j}}\left(t\right)}{{m_{j}}}}{\outDefScale}
+\resizeExpression{{\symbf{a}\text{(}t\text{)}_{j}}=\symbf{g}+\frac{{\symbf{F}_{j}}\left(t\right)}{{m_{j}}}}
 \end{displaymath}
 \medskip
 \noindent
@@ -1340,24 +1331,24 @@ Output & ${α_{j}}$
          
 \\ \midrule
 Input Constraints & \begin{displaymath}
-                    \resizeExpression{ω\gt{}0}{\inDefScale}
+                    \resizeExpression{ω\gt{}0}
                     \end{displaymath}
                     \begin{displaymath}
-                    \resizeExpression{t\gt{}0}{\inDefScale}
+                    \resizeExpression{t\gt{}0}
                     \end{displaymath}
                     \begin{displaymath}
-                    \resizeExpression{{\symbf{τ}_{j}}\gt{}0}{\inDefScale}
+                    \resizeExpression{{\symbf{τ}_{j}}\gt{}0}
                     \end{displaymath}
                     \begin{displaymath}
-                    \resizeExpression{\symbf{I}\gt{}0}{\inDefScale}
+                    \resizeExpression{\symbf{I}\gt{}0}
                     \end{displaymath}
 \\ \midrule
 Output Constraints & \begin{displaymath}
-                     \resizeExpression{{α_{j}}\gt{}0}{\inDefScale}
+                     \resizeExpression{{α_{j}}\gt{}0}
                      \end{displaymath}
 \\ \midrule
 Equation & \begin{displaymath}
-           \resizeExpression{{α_{j}}=\frac{{\symbf{τ}_{j}}\left(t\right)}{\symbf{I}}}{\inDefScale}
+           \resizeExpression{{α_{j}}=\frac{{\symbf{τ}_{j}}\left(t\right)}{\symbf{I}}}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -1387,12 +1378,12 @@ RefBy &
 We may calculate the total angular acceleration of rigid body $j$ by calculating the derivative of its angular velocity with respect to time (from \hyperref[DD:angAccel]{DD:angAccel}).
 
 \begin{displaymath}
-\resizeExpression{{α_{j}}=\frac{\,dω\left(t\right)}{\,dt}}{\outDefScale}
+\resizeExpression{{α_{j}}=\frac{\,dω\left(t\right)}{\,dt}}
 \end{displaymath}
 Performing the derivative, we obtain:
 
 \begin{displaymath}
-\resizeExpression{{α_{j}}=\frac{{\symbf{τ}_{j}}\left(t\right)}{\symbf{I}}}{\outDefScale}
+\resizeExpression{{α_{j}}=\frac{{\symbf{τ}_{j}}\left(t\right)}{\symbf{I}}}
 \end{displaymath}
 \medskip
 \noindent
@@ -1412,24 +1403,24 @@ Output & ${t_{\text{c}}}$
          
 \\ \midrule
 Input Constraints & \begin{displaymath}
-                    \resizeExpression{t\gt{}0}{\inDefScale}
+                    \resizeExpression{t\gt{}0}
                     \end{displaymath}
                     \begin{displaymath}
-                    \resizeExpression{j\gt{}0}{\inDefScale}
+                    \resizeExpression{j\gt{}0}
                     \end{displaymath}
                     \begin{displaymath}
-                    \resizeExpression{{m_{\text{A}}}\gt{}0}{\inDefScale}
+                    \resizeExpression{{m_{\text{A}}}\gt{}0}
                     \end{displaymath}
                     \begin{displaymath}
-                    \resizeExpression{\symbf{n}\gt{}0}{\inDefScale}
+                    \resizeExpression{\symbf{n}\gt{}0}
                     \end{displaymath}
 \\ \midrule
 Output Constraints & \begin{displaymath}
-                     \resizeExpression{{t_{\text{c}}}\gt{}0}{\inDefScale}
+                     \resizeExpression{{t_{\text{c}}}\gt{}0}
                      \end{displaymath}
 \\ \midrule
 Equation & \begin{displaymath}
-           \resizeExpression{{\symbf{v}\text{(}t\text{)}_{\text{A}}}\left({t_{\text{c}}}\right)={\symbf{v}\text{(}t\text{)}_{\text{A}}}\left(t\right)+\frac{j}{{m_{\text{A}}}}\,\symbf{n}}{\inDefScale}
+           \resizeExpression{{\symbf{v}\text{(}t\text{)}_{\text{A}}}\left({t_{\text{c}}}\right)={\symbf{v}\text{(}t\text{)}_{\text{A}}}\left(t\right)+\frac{j}{{m_{\text{A}}}}\,\symbf{n}}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}

--- a/code/stable/glassbr/SRS/PDF/GlassBR_SRS.tex
+++ b/code/stable/glassbr/SRS/PDF/GlassBR_SRS.tex
@@ -15,8 +15,7 @@
 \usepackage{svg}
 \usepackage{float}
 \usepackage{enumitem}
-\usepackage{graphicx}
-\usepackage{calc}
+\usepackage{adjustbox}
 \usepackage{filecontents}
 \usepackage[backend=bibtex]{biblatex}
 \usepackage{url}
@@ -25,16 +24,8 @@
 \newcommand{\lt}{\ensuremath <}
 \newlist{symbDescription}{description}{1}
 \setlist[symbDescription]{noitemsep, topsep=0pt, parsep=0pt, partopsep=0pt}
-\def\inDefScale{0.8}
-\def\outDefScale{1.0}
-\newsavebox{\mybox}
-\newcommand{\resizeExpression}[2]{
-  \savebox{\mybox}{$#1$}
-  \ifdim\wd\mybox>#2\linewidth
-    \resizebox{#2\textwidth}{!}{\usebox{\mybox}}
-  \else
-    \usebox{\mybox}
-  \fi
+\newcommand{\resizeExpression}[1]{
+  \adjustbox{max width=\linewidth}{$#1$}
 }
 \bibliography{bibfile}
 \title{Software Requirements Specification for GlassBR}
@@ -411,7 +402,7 @@ Label & Safety Probability
         
 \\ \midrule
 Equation & \begin{displaymath}
-           \resizeExpression{\mathit{isSafeProb}={P_{\text{f}}}\lt{}{P_{\text{f}\text{tol}}}}{\inDefScale}
+           \resizeExpression{\mathit{isSafeProb}={P_{\text{f}}}\lt{}{P_{\text{f}\text{tol}}}}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -443,7 +434,7 @@ Label & Safety Load
         
 \\ \midrule
 Equation & \begin{displaymath}
-           \resizeExpression{\mathit{isSafeLoad}=\mathit{capacity}\gt{}\mathit{Load}}{\inDefScale}
+           \resizeExpression{\mathit{isSafeLoad}=\mathit{capacity}\gt{}\mathit{Load}}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -502,7 +493,7 @@ Equation & \begin{displaymath}
                                                15.09, & t=16.0\\
                                                18.26, & t=19.0\\
                                                21.44, & t=22.0
-                                               \end{cases}}{\inDefScale}
+                                               \end{cases}}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -540,7 +531,7 @@ Units & Unitless
         
 \\ \midrule
 Equation & \begin{displaymath}
-           \resizeExpression{\mathit{LDF}=\left(\frac{{t_{\text{d}}}}{60}\right)^{\frac{m}{16}}}{\inDefScale}
+           \resizeExpression{\mathit{LDF}=\left(\frac{{t_{\text{d}}}}{60}\right)^{\frac{m}{16}}}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -585,7 +576,7 @@ Equation & \begin{displaymath}
                                           1, & g=\text{``AN''}\\
                                           4, & g=\text{``FT''}\\
                                           2, & g=\text{``HS''}
-                                          \end{cases}}{\inDefScale}
+                                          \end{cases}}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -627,7 +618,7 @@ Units & ${\text{m}}$
         
 \\ \midrule
 Equation & \begin{displaymath}
-           \resizeExpression{\mathit{SD}=\sqrt{{\mathit{SD}_{\text{x}}}^{2}+{\mathit{SD}_{\text{y}}}^{2}+{\mathit{SD}_{\text{z}}}^{2}}}{\inDefScale}
+           \resizeExpression{\mathit{SD}=\sqrt{{\mathit{SD}_{\text{x}}}^{2}+{\mathit{SD}_{\text{y}}}^{2}+{\mathit{SD}_{\text{z}}}^{2}}}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -664,7 +655,7 @@ Units & Unitless
         
 \\ \midrule
 Equation & \begin{displaymath}
-           \resizeExpression{\mathit{AR}=\frac{a}{b}}{\inDefScale}
+           \resizeExpression{\mathit{AR}=\frac{a}{b}}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -703,7 +694,7 @@ Units & ${\text{kg}}$
         
 \\ \midrule
 Equation & \begin{displaymath}
-           \resizeExpression{{w_{\mathit{TNT}}}=w\,\mathit{TNT}}{\inDefScale}
+           \resizeExpression{{w_{\mathit{TNT}}}=w\,\mathit{TNT}}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -739,7 +730,7 @@ Units & ${\text{Pa}}$
         
 \\ \midrule
 Equation & \begin{displaymath}
-           \resizeExpression{q=\mathit{interpY}\left(\text{``TSD.txt''},\mathit{SD},{w_{\mathit{TNT}}}\right)}{\inDefScale}
+           \resizeExpression{q=\mathit{interpY}\left(\text{``TSD.txt''},\mathit{SD},{w_{\mathit{TNT}}}\right)}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -785,16 +776,16 @@ Output & $B$
          
 \\ \midrule
 Input Constraints & \begin{displaymath}
-                    \resizeExpression{a\gt{}0}{\inDefScale}
+                    \resizeExpression{a\gt{}0}
                     \end{displaymath}
                     \begin{displaymath}
-                    \resizeExpression{0\lt{}b\leq{}a}{\inDefScale}
+                    \resizeExpression{0\lt{}b\leq{}a}
                     \end{displaymath}
 \\ \midrule
 Output Constraints & 
 \\ \midrule
 Equation & \begin{displaymath}
-           \resizeExpression{B=\frac{k}{\left(a\,b\right)^{m-1}}\,\left(E\,h^{2}\right)^{m}\,\mathit{LDF}\,e^{J}}{\inDefScale}
+           \resizeExpression{B=\frac{k}{\left(a\,b\right)^{m-1}}\,\left(E\,h^{2}\right)^{m}\,\mathit{LDF}\,e^{J}}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -845,15 +836,15 @@ Output & $J$
          
 \\ \midrule
 Input Constraints & \begin{displaymath}
-                    \resizeExpression{\mathit{AR}\geq{}1}{\inDefScale}
+                    \resizeExpression{\mathit{AR}\geq{}1}
                     \end{displaymath}
 \\ \midrule
 Output Constraints & \begin{displaymath}
-                     \resizeExpression{{J_{\text{min}}}\leq{}J\leq{}{J_{\text{max}}}}{\inDefScale}
+                     \resizeExpression{{J_{\text{min}}}\leq{}J\leq{}{J_{\text{max}}}}
                      \end{displaymath}
 \\ \midrule
 Equation & \begin{displaymath}
-           \resizeExpression{J=\mathit{interpZ}\left(\text{``SDF.txt''},\mathit{AR},\hat{q}\right)}{\inDefScale}
+           \resizeExpression{J=\mathit{interpZ}\left(\text{``SDF.txt''},\mathit{AR},\hat{q}\right)}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -897,16 +888,16 @@ Output & $\mathit{NFL}$
          
 \\ \midrule
 Input Constraints & \begin{displaymath}
-                    \resizeExpression{a\gt{}0}{\inDefScale}
+                    \resizeExpression{a\gt{}0}
                     \end{displaymath}
                     \begin{displaymath}
-                    \resizeExpression{0\lt{}b\leq{}a}{\inDefScale}
+                    \resizeExpression{0\lt{}b\leq{}a}
                     \end{displaymath}
 \\ \midrule
 Output Constraints & 
 \\ \midrule
 Equation & \begin{displaymath}
-           \resizeExpression{\mathit{NFL}=\frac{{\hat{q}_{\text{tol}}}\,E\,h^{4}}{\left(a\,b\right)^{2}}}{\inDefScale}
+           \resizeExpression{\mathit{NFL}=\frac{{\hat{q}_{\text{tol}}}\,E\,h^{4}}{\left(a\,b\right)^{2}}}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -954,16 +945,16 @@ Output & $\hat{q}$
          
 \\ \midrule
 Input Constraints & \begin{displaymath}
-                    \resizeExpression{a\gt{}0}{\inDefScale}
+                    \resizeExpression{a\gt{}0}
                     \end{displaymath}
                     \begin{displaymath}
-                    \resizeExpression{0\lt{}b\leq{}a}{\inDefScale}
+                    \resizeExpression{0\lt{}b\leq{}a}
                     \end{displaymath}
 \\ \midrule
 Output Constraints & 
 \\ \midrule
 Equation & \begin{displaymath}
-           \resizeExpression{\hat{q}=\frac{q\,\left(a\,b\right)^{2}}{E\,h^{4}\,\mathit{GTF}}}{\inDefScale}
+           \resizeExpression{\hat{q}=\frac{q\,\left(a\,b\right)^{2}}{E\,h^{4}\,\mathit{GTF}}}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -1014,13 +1005,13 @@ Output & ${\hat{q}_{\text{tol}}}$
          
 \\ \midrule
 Input Constraints & \begin{displaymath}
-                    \resizeExpression{\mathit{AR}\geq{}1}{\inDefScale}
+                    \resizeExpression{\mathit{AR}\geq{}1}
                     \end{displaymath}
 \\ \midrule
 Output Constraints & 
 \\ \midrule
 Equation & \begin{displaymath}
-           \resizeExpression{{\hat{q}_{\text{tol}}}=\mathit{interpY}\left(\text{``SDF.txt''},\mathit{AR},{J_{\text{tol}}}\right)}{\inDefScale}
+           \resizeExpression{{\hat{q}_{\text{tol}}}=\mathit{interpY}\left(\text{``SDF.txt''},\mathit{AR},{J_{\text{tol}}}\right)}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -1064,19 +1055,19 @@ Output & ${J_{\text{tol}}}$
          
 \\ \midrule
 Input Constraints & \begin{displaymath}
-                    \resizeExpression{0\leq{}{P_{\text{b}\text{tol}}}\leq{}1}{\inDefScale}
+                    \resizeExpression{0\leq{}{P_{\text{b}\text{tol}}}\leq{}1}
                     \end{displaymath}
                     \begin{displaymath}
-                    \resizeExpression{a\gt{}0}{\inDefScale}
+                    \resizeExpression{a\gt{}0}
                     \end{displaymath}
                     \begin{displaymath}
-                    \resizeExpression{0\lt{}b\leq{}a}{\inDefScale}
+                    \resizeExpression{0\lt{}b\leq{}a}
                     \end{displaymath}
 \\ \midrule
 Output Constraints & 
 \\ \midrule
 Equation & \begin{displaymath}
-           \resizeExpression{{J_{\text{tol}}}=\ln\left(\ln\left(\frac{1}{1-{P_{\text{b}\text{tol}}}}\right)\,\frac{\left(a\,b\right)^{m-1}}{k\,\left(E\,h^{2}\right)^{m}\,\mathit{LDF}}\right)}{\inDefScale}
+           \resizeExpression{{J_{\text{tol}}}=\ln\left(\ln\left(\frac{1}{1-{P_{\text{b}\text{tol}}}}\right)\,\frac{\left(a\,b\right)^{m-1}}{k\,\left(E\,h^{2}\right)^{m}\,\mathit{LDF}}\right)}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -1131,11 +1122,11 @@ Output & ${P_{\text{b}}}$
 Input Constraints & 
 \\ \midrule
 Output Constraints & \begin{displaymath}
-                     \resizeExpression{0\leq{}{P_{\text{b}}}\leq{}1}{\inDefScale}
+                     \resizeExpression{0\leq{}{P_{\text{b}}}\leq{}1}
                      \end{displaymath}
 \\ \midrule
 Equation & \begin{displaymath}
-           \resizeExpression{{P_{\text{b}}}=1-e^{-B}}{\inDefScale}
+           \resizeExpression{{P_{\text{b}}}=1-e^{-B}}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -1177,7 +1168,7 @@ Input Constraints &
 Output Constraints & 
 \\ \midrule
 Equation & \begin{displaymath}
-           \resizeExpression{\mathit{LR}=\mathit{NFL}\,\mathit{GTF}\,\mathit{LSF}}{\inDefScale}
+           \resizeExpression{\mathit{LR}=\mathit{NFL}\,\mathit{GTF}\,\mathit{LSF}}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -1221,16 +1212,16 @@ Output & $\mathit{isSafePb}$
          
 \\ \midrule
 Input Constraints & \begin{displaymath}
-                    \resizeExpression{0\leq{}{P_{\text{b}}}\leq{}1}{\inDefScale}
+                    \resizeExpression{0\leq{}{P_{\text{b}}}\leq{}1}
                     \end{displaymath}
                     \begin{displaymath}
-                    \resizeExpression{0\leq{}{P_{\text{b}\text{tol}}}\leq{}1}{\inDefScale}
+                    \resizeExpression{0\leq{}{P_{\text{b}\text{tol}}}\leq{}1}
                     \end{displaymath}
 \\ \midrule
 Output Constraints & 
 \\ \midrule
 Equation & \begin{displaymath}
-           \resizeExpression{\mathit{isSafePb}={P_{\text{b}}}\lt{}{P_{\text{b}\text{tol}}}}{\inDefScale}
+           \resizeExpression{\mathit{isSafePb}={P_{\text{b}}}\lt{}{P_{\text{b}\text{tol}}}}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -1273,16 +1264,16 @@ Output & $\mathit{isSafeLR}$
          
 \\ \midrule
 Input Constraints & \begin{displaymath}
-                    \resizeExpression{\mathit{LR}\gt{}0}{\inDefScale}
+                    \resizeExpression{\mathit{LR}\gt{}0}
                     \end{displaymath}
                     \begin{displaymath}
-                    \resizeExpression{q\gt{}0}{\inDefScale}
+                    \resizeExpression{q\gt{}0}
                     \end{displaymath}
 \\ \midrule
 Output Constraints & 
 \\ \midrule
 Equation & \begin{displaymath}
-           \resizeExpression{\mathit{isSafeLR}=\mathit{LR}\gt{}q}{\inDefScale}
+           \resizeExpression{\mathit{isSafeLR}=\mathit{LR}\gt{}q}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}

--- a/code/stable/hghc/SRS/PDF/HGHC_SRS.tex
+++ b/code/stable/hghc/SRS/PDF/HGHC_SRS.tex
@@ -11,24 +11,15 @@
 \usepackage{tabularx}
 \usepackage{booktabs}
 \usepackage{caption}
-\usepackage{graphicx}
-\usepackage{calc}
+\usepackage{adjustbox}
 \usepackage{enumitem}
 \setmathfont{Latin Modern Math}
 \newcommand{\gt}{\ensuremath >}
 \newcommand{\lt}{\ensuremath <}
 \newlist{symbDescription}{description}{1}
 \setlist[symbDescription]{noitemsep, topsep=0pt, parsep=0pt, partopsep=0pt}
-\def\inDefScale{0.8}
-\def\outDefScale{1.0}
-\newsavebox{\mybox}
-\newcommand{\resizeExpression}[2]{
-  \savebox{\mybox}{$#1$}
-  \ifdim\wd\mybox>#2\linewidth
-    \resizebox{#2\textwidth}{!}{\usebox{\mybox}}
-  \else
-    \usebox{\mybox}
-  \fi
+\newcommand{\resizeExpression}[1]{
+  \adjustbox{max width=\linewidth}{$#1$}
 }
 \title{Software Requirements Specification for HGHC}
 \author{W. Spencer Smith}
@@ -116,7 +107,7 @@ Units & $\frac{\text{W}}{\text{m}^{2}{}^{\circ}\text{C}}$
         
 \\ \midrule
 Equation & \begin{displaymath}
-           \resizeExpression{{h_{\text{g}}}=\frac{2\,{k_{\text{c}}}\,{h_{\text{p}}}}{2\,{k_{\text{c}}}+{τ_{\text{c}}}\,{h_{\text{p}}}}}{\inDefScale}
+           \resizeExpression{{h_{\text{g}}}=\frac{2\,{k_{\text{c}}}\,{h_{\text{p}}}}{2\,{k_{\text{c}}}+{τ_{\text{c}}}\,{h_{\text{p}}}}}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -147,7 +138,7 @@ Units & $\frac{\text{W}}{\text{m}^{2}{}^{\circ}\text{C}}$
         
 \\ \midrule
 Equation & \begin{displaymath}
-           \resizeExpression{{h_{\text{c}}}=\frac{2\,{k_{\text{c}}}\,{h_{\text{b}}}}{2\,{k_{\text{c}}}+{τ_{\text{c}}}\,{h_{\text{b}}}}}{\inDefScale}
+           \resizeExpression{{h_{\text{c}}}=\frac{2\,{k_{\text{c}}}\,{h_{\text{b}}}}{2\,{k_{\text{c}}}+{τ_{\text{c}}}\,{h_{\text{b}}}}}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}

--- a/code/stable/pdcontroller/SRS/PDF/PDController_SRS.tex
+++ b/code/stable/pdcontroller/SRS/PDF/PDController_SRS.tex
@@ -15,8 +15,7 @@
 \usepackage{svg}
 \usepackage{float}
 \usepackage{enumitem}
-\usepackage{graphicx}
-\usepackage{calc}
+\usepackage{adjustbox}
 \usepackage{filecontents}
 \usepackage[backend=bibtex]{biblatex}
 \usepackage{url}
@@ -25,16 +24,8 @@
 \newcommand{\lt}{\ensuremath <}
 \newlist{symbDescription}{description}{1}
 \setlist[symbDescription]{noitemsep, topsep=0pt, parsep=0pt, partopsep=0pt}
-\def\inDefScale{0.8}
-\def\outDefScale{1.0}
-\newsavebox{\mybox}
-\newcommand{\resizeExpression}[2]{
-  \savebox{\mybox}{$#1$}
-  \ifdim\wd\mybox>#2\linewidth
-    \resizebox{#2\textwidth}{!}{\usebox{\mybox}}
-  \else
-    \usebox{\mybox}
-  \fi
+\newcommand{\resizeExpression}[1]{
+  \adjustbox{max width=\linewidth}{$#1$}
 }
 \bibliography{bibfile}
 \title{Software Requirements Specification for PD Controller}
@@ -322,7 +313,7 @@ Label & Laplace Transform
         
 \\ \midrule
 Equation & \begin{displaymath}
-           \resizeExpression{{F_{\text{s}}}=\int_{\mathit{-∞}}^{∞}{{f_{\text{t}}}\,e^{-s\,t}}\,dt}{\inDefScale}
+           \resizeExpression{{F_{\text{s}}}=\int_{\mathit{-∞}}^{∞}{{f_{\text{t}}}\,e^{-s\,t}}\,dt}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -356,7 +347,7 @@ Label & Inverse Laplace Transform
         
 \\ \midrule
 Equation & \begin{displaymath}
-           \resizeExpression{{f_{\text{t}}}=\mathit{L⁻¹[F(s)]}}{\inDefScale}
+           \resizeExpression{{f_{\text{t}}}=\mathit{L⁻¹[F(s)]}}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -388,7 +379,7 @@ Label & Second Order Mass-Spring-Damper System
         
 \\ \midrule
 Equation & \begin{displaymath}
-           \resizeExpression{\frac{1}{m\,s^{2}+c\,s+k}}{\inDefScale}
+           \resizeExpression{\frac{1}{m\,s^{2}+c\,s+k}}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -426,7 +417,7 @@ Label & The Transfer Function of the Power Plant
         
 \\ \midrule
 Equation & \begin{displaymath}
-           \resizeExpression{\frac{1}{s^{2}+s+20}}{\inDefScale}
+           \resizeExpression{\frac{1}{s^{2}+s+20}}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -467,7 +458,7 @@ Units & Unitless
         
 \\ \midrule
 Equation & \begin{displaymath}
-           \resizeExpression{{E_{\text{s}}}={R_{\text{s}}}-{Y_{\text{s}}}}{\inDefScale}
+           \resizeExpression{{E_{\text{s}}}={R_{\text{s}}}-{Y_{\text{s}}}}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -506,7 +497,7 @@ Units & Unitless
         
 \\ \midrule
 Equation & \begin{displaymath}
-           \resizeExpression{{P_{\text{s}}}={K_{\text{p}}}\,{E_{\text{s}}}}{\inDefScale}
+           \resizeExpression{{P_{\text{s}}}={K_{\text{p}}}\,{E_{\text{s}}}}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -545,7 +536,7 @@ Units & Unitless
         
 \\ \midrule
 Equation & \begin{displaymath}
-           \resizeExpression{{D_{\text{s}}}={K_{\text{d}}}\,{E_{\text{s}}}\,s}{\inDefScale}
+           \resizeExpression{{D_{\text{s}}}={K_{\text{d}}}\,{E_{\text{s}}}\,s}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -585,7 +576,7 @@ Units & Unitless
         
 \\ \midrule
 Equation & \begin{displaymath}
-           \resizeExpression{{C_{\text{s}}}={E_{\text{s}}}\,\left({K_{\text{p}}}+{K_{\text{d}}}\,s\right)}{\inDefScale}
+           \resizeExpression{{C_{\text{s}}}={E_{\text{s}}}\,\left({K_{\text{p}}}+{K_{\text{d}}}\,s\right)}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -630,21 +621,21 @@ Output & ${y_{\text{t}}}$
          
 \\ \midrule
 Input Constraints & \begin{displaymath}
-                    \resizeExpression{{r_{\text{t}}}\gt{}0}{\inDefScale}
+                    \resizeExpression{{r_{\text{t}}}\gt{}0}
                     \end{displaymath}
                     \begin{displaymath}
-                    \resizeExpression{{K_{\text{p}}}\gt{}0}{\inDefScale}
+                    \resizeExpression{{K_{\text{p}}}\gt{}0}
                     \end{displaymath}
                     \begin{displaymath}
-                    \resizeExpression{{K_{\text{d}}}\gt{}0}{\inDefScale}
+                    \resizeExpression{{K_{\text{d}}}\gt{}0}
                     \end{displaymath}
 \\ \midrule
 Output Constraints & \begin{displaymath}
-                     \resizeExpression{{y_{\text{t}}}\gt{}0}{\inDefScale}
+                     \resizeExpression{{y_{\text{t}}}\gt{}0}
                      \end{displaymath}
 \\ \midrule
 Equation & \begin{displaymath}
-           \resizeExpression{\frac{\,d^{2}{y_{\text{t}}}}{\,dt^{2}}+\left(1+{K_{\text{d}}}\right)\,\frac{\,d{y_{\text{t}}}}{\,dt}+\left(20+{K_{\text{p}}}\right)\,{{y_{\text{t}}}}={r_{\text{t}}}\,{K_{\text{p}}}}{\inDefScale}
+           \resizeExpression{\frac{\,d^{2}{y_{\text{t}}}}{\,dt^{2}}+\left(1+{K_{\text{d}}}\right)\,\frac{\,d{y_{\text{t}}}}{\,dt}+\left(20+{K_{\text{p}}}\right)\,{{y_{\text{t}}}}={r_{\text{t}}}\,{K_{\text{p}}}}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -669,22 +660,22 @@ RefBy & \hyperref[outputValues]{FR:Output-Values} and \hyperref[calculateValues]
 The Process Variable ${Y_{\text{s}}}$ in a PD Control Loop is the product of the Process Error (from \hyperref[DD:ddProcessError]{DD:ddProcessError}), Control Variable (from \hyperref[DD:ddCtrlVar]{DD:ddCtrlVar}), and the Power Plant (from \hyperref[GD:gdPowerPlant]{GD:gdPowerPlant}).
 
 \begin{displaymath}
-\resizeExpression{{Y_{\text{s}}}=\left({R_{\text{s}}}-{Y_{\text{s}}}\right)\,\left({K_{\text{p}}}+{K_{\text{d}}}\,s\right)\,\frac{1}{s^{2}+s+20}}{\outDefScale}
+\resizeExpression{{Y_{\text{s}}}=\left({R_{\text{s}}}-{Y_{\text{s}}}\right)\,\left({K_{\text{p}}}+{K_{\text{d}}}\,s\right)\,\frac{1}{s^{2}+s+20}}
 \end{displaymath}
 Substituting the values and rearranging the equation.
 
 \begin{displaymath}
-\resizeExpression{s^{2}\,{Y_{\text{s}}}+\left(1+{K_{\text{d}}}\right)\,{Y_{\text{s}}}\,s+\left(20+{K_{\text{p}}}\right)\,{Y_{\text{s}}}-{R_{\text{s}}}\,s\,{K_{\text{d}}}-{R_{\text{s}}}\,{K_{\text{p}}}=0}{\outDefScale}
+\resizeExpression{s^{2}\,{Y_{\text{s}}}+\left(1+{K_{\text{d}}}\right)\,{Y_{\text{s}}}\,s+\left(20+{K_{\text{p}}}\right)\,{Y_{\text{s}}}-{R_{\text{s}}}\,s\,{K_{\text{d}}}-{R_{\text{s}}}\,{K_{\text{p}}}=0}
 \end{displaymath}
 Computing the Inverse Laplace Transform of a function (from \hyperref[TM:invLaplaceTransform]{TM:invLaplaceTransform}) of the equation.
 
 \begin{displaymath}
-\resizeExpression{\frac{\,d\frac{\,d{y_{\text{t}}}}{\,dt}}{\,dt}+\left(1+{K_{\text{d}}}\right)\,\frac{\,d{y_{\text{t}}}}{\,dt}+\left(20+{K_{\text{p}}}\right)\,{y_{\text{t}}}-{K_{\text{d}}}\,\frac{\,d{r_{\text{t}}}}{\,dt}-{r_{\text{t}}}\,{K_{\text{p}}}=0}{\outDefScale}
+\resizeExpression{\frac{\,d\frac{\,d{y_{\text{t}}}}{\,dt}}{\,dt}+\left(1+{K_{\text{d}}}\right)\,\frac{\,d{y_{\text{t}}}}{\,dt}+\left(20+{K_{\text{p}}}\right)\,{y_{\text{t}}}-{K_{\text{d}}}\,\frac{\,d{r_{\text{t}}}}{\,dt}-{r_{\text{t}}}\,{K_{\text{p}}}=0}
 \end{displaymath}
 The Set-Point ${r_{\text{t}}}$ is a step function and a constant (from \hyperref[setPoint]{A:Set-Point}). Therefore the differential of the set point is zero. Hence the equation reduces to
 
 \begin{displaymath}
-\resizeExpression{\frac{\,d\frac{\,d{y_{\text{t}}}}{\,dt}}{\,dt}+\left(1+{K_{\text{d}}}\right)\,\frac{\,d{y_{\text{t}}}}{\,dt}+\left(20+{K_{\text{p}}}\right)\,{y_{\text{t}}}-{r_{\text{t}}}\,{K_{\text{p}}}=0}{\outDefScale}
+\resizeExpression{\frac{\,d\frac{\,d{y_{\text{t}}}}{\,dt}}{\,dt}+\left(1+{K_{\text{d}}}\right)\,\frac{\,d{y_{\text{t}}}}{\,dt}+\left(20+{K_{\text{p}}}\right)\,{y_{\text{t}}}-{r_{\text{t}}}\,{K_{\text{p}}}=0}
 \end{displaymath}
 \subsubsection{Data Constraints}
 \label{Sec:DataConstraints}

--- a/code/stable/projectile/SRS/PDF/Projectile_SRS.tex
+++ b/code/stable/projectile/SRS/PDF/Projectile_SRS.tex
@@ -15,8 +15,7 @@
 \usepackage{svg}
 \usepackage{float}
 \usepackage{enumitem}
-\usepackage{graphicx}
-\usepackage{calc}
+\usepackage{adjustbox}
 \usepackage{filecontents}
 \usepackage[backend=bibtex]{biblatex}
 \usepackage{url}
@@ -25,16 +24,8 @@
 \newcommand{\lt}{\ensuremath <}
 \newlist{symbDescription}{description}{1}
 \setlist[symbDescription]{noitemsep, topsep=0pt, parsep=0pt, partopsep=0pt}
-\def\inDefScale{0.8}
-\def\outDefScale{1.0}
-\newsavebox{\mybox}
-\newcommand{\resizeExpression}[2]{
-  \savebox{\mybox}{$#1$}
-  \ifdim\wd\mybox>#2\linewidth
-    \resizebox{#2\textwidth}{!}{\usebox{\mybox}}
-  \else
-    \usebox{\mybox}
-  \fi
+\newcommand{\resizeExpression}[1]{
+  \adjustbox{max width=\linewidth}{$#1$}
 }
 \bibliography{bibfile}
 \title{Software Requirements Specification for Projectile}
@@ -330,7 +321,7 @@ Label & Acceleration
         
 \\ \midrule
 Equation & \begin{displaymath}
-           \resizeExpression{\symbf{a}\text{(}t\text{)}=\frac{\,d\symbf{v}\text{(}t\text{)}}{\,dt}}{\inDefScale}
+           \resizeExpression{\symbf{a}\text{(}t\text{)}=\frac{\,d\symbf{v}\text{(}t\text{)}}{\,dt}}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -360,7 +351,7 @@ Label & Velocity
         
 \\ \midrule
 Equation & \begin{displaymath}
-           \resizeExpression{\symbf{v}\text{(}t\text{)}=\frac{\,d\symbf{p}\text{(}t\text{)}}{\,dt}}{\inDefScale}
+           \resizeExpression{\symbf{v}\text{(}t\text{)}=\frac{\,d\symbf{p}\text{(}t\text{)}}{\,dt}}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -397,7 +388,7 @@ Units & $\frac{\text{m}}{\text{s}}$
         
 \\ \midrule
 Equation & \begin{displaymath}
-           \resizeExpression{v\text{(}t\text{)}={v^{\text{i}}}+{a^{c}}\,t}{\inDefScale}
+           \resizeExpression{v\text{(}t\text{)}={v^{\text{i}}}+{a^{c}}\,t}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -421,17 +412,17 @@ RefBy & \hyperref[GD:velVec]{GD:velVec} and \hyperref[GD:rectPos]{GD:rectPos}
 Assume we have rectilinear motion of a particle (of negligible size and shape, from \hyperref[pointMass]{A:pointMass}); that is, motion in a straight line. The velocity is $v$ and the acceleration is $a$. The motion in \hyperref[TM:acceleration]{TM:acceleration} is now one-dimensional with a constant acceleration, represented by ${a^{c}}$. The initial velocity (at $t=0$, from \hyperref[timeStartZero]{A:timeStartZero}) is represented by ${v^{\text{i}}}$. From \hyperref[TM:acceleration]{TM:acceleration} in 1D, and using the above symbols we have:
 
 \begin{displaymath}
-\resizeExpression{{a^{c}}=\frac{\,dv}{\,dt}}{\outDefScale}
+\resizeExpression{{a^{c}}=\frac{\,dv}{\,dt}}
 \end{displaymath}
 Rearranging and integrating, we have:
 
 \begin{displaymath}
-\resizeExpression{\int_{{v^{\text{i}}}}^{v}{1}\,dv=\int_{0}^{t}{{a^{c}}}\,dt}{\outDefScale}
+\resizeExpression{\int_{{v^{\text{i}}}}^{v}{1}\,dv=\int_{0}^{t}{{a^{c}}}\,dt}
 \end{displaymath}
 Performing the integration, we have the required equation:
 
 \begin{displaymath}
-\resizeExpression{v\text{(}t\text{)}={v^{\text{i}}}+{a^{c}}\,t}{\outDefScale}
+\resizeExpression{v\text{(}t\text{)}={v^{\text{i}}}+{a^{c}}\,t}
 \end{displaymath}
 \medskip
 \noindent
@@ -448,7 +439,7 @@ Units & ${\text{m}}$
         
 \\ \midrule
 Equation & \begin{displaymath}
-           \resizeExpression{p\text{(}t\text{)}={p^{\text{i}}}+{v^{\text{i}}}\,t+\frac{{a^{c}}\,t^{2}}{2}}{\inDefScale}
+           \resizeExpression{p\text{(}t\text{)}={p^{\text{i}}}+{v^{\text{i}}}\,t+\frac{{a^{c}}\,t^{2}}{2}}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -473,22 +464,22 @@ RefBy & \hyperref[GD:posVec]{GD:posVec}
 Assume we have rectilinear motion of a particle (of negligible size and shape, from \hyperref[pointMass]{A:pointMass}); that is, motion in a straight line. The position is $p$ and the velocity is $v$. The motion in \hyperref[TM:velocity]{TM:velocity} is now one-dimensional. The initial position (at $t=0$, from \hyperref[timeStartZero]{A:timeStartZero}) is represented by ${p^{\text{i}}}$. From \hyperref[TM:velocity]{TM:velocity} in 1D, and using the above symbols we have:
 
 \begin{displaymath}
-\resizeExpression{v=\frac{\,dp}{\,dt}}{\outDefScale}
+\resizeExpression{v=\frac{\,dp}{\,dt}}
 \end{displaymath}
 Rearranging and integrating, we have:
 
 \begin{displaymath}
-\resizeExpression{\int_{{p^{\text{i}}}}^{p}{1}\,dp=\int_{0}^{t}{v}\,dt}{\outDefScale}
+\resizeExpression{\int_{{p^{\text{i}}}}^{p}{1}\,dp=\int_{0}^{t}{v}\,dt}
 \end{displaymath}
 From \hyperref[GD:rectVel]{GD:rectVel}, we can replace $v$:
 
 \begin{displaymath}
-\resizeExpression{\int_{{p^{\text{i}}}}^{p}{1}\,dp=\int_{0}^{t}{{v^{\text{i}}}+{a^{c}}\,t}\,dt}{\outDefScale}
+\resizeExpression{\int_{{p^{\text{i}}}}^{p}{1}\,dp=\int_{0}^{t}{{v^{\text{i}}}+{a^{c}}\,t}\,dt}
 \end{displaymath}
 Performing the integration, we have the required equation:
 
 \begin{displaymath}
-\resizeExpression{p\text{(}t\text{)}={p^{\text{i}}}+{v^{\text{i}}}\,t+\frac{{a^{c}}\,t^{2}}{2}}{\outDefScale}
+\resizeExpression{p\text{(}t\text{)}={p^{\text{i}}}+{v^{\text{i}}}\,t+\frac{{a^{c}}\,t^{2}}{2}}
 \end{displaymath}
 \medskip
 \noindent
@@ -508,7 +499,7 @@ Equation & \begin{displaymath}
            \resizeExpression{\symbf{v}\text{(}t\text{)}=\begin{bmatrix}
                                                         {{v_{\text{x}}}^{\text{i}}}+{{a_{\text{x}}}^{\text{c}}}\,t\\
                                                         {{v_{\text{y}}}^{\text{i}}}+{{a_{\text{y}}}^{\text{c}}}\,t
-                                                        \end{bmatrix}}{\inDefScale}
+                                                        \end{bmatrix}}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -548,7 +539,7 @@ For a two-dimensional Cartesian coordinate system (\hyperref[twoDMotion]{A:twoDM
 \resizeExpression{\symbf{v}\text{(}t\text{)}=\begin{bmatrix}
                                              {{v_{\text{x}}}^{\text{i}}}+{{a_{\text{x}}}^{\text{c}}}\,t\\
                                              {{v_{\text{y}}}^{\text{i}}}+{{a_{\text{y}}}^{\text{c}}}\,t
-                                             \end{bmatrix}}{\outDefScale}
+                                             \end{bmatrix}}
 \end{displaymath}
 \medskip
 \noindent
@@ -568,7 +559,7 @@ Equation & \begin{displaymath}
            \resizeExpression{\symbf{p}\text{(}t\text{)}=\begin{bmatrix}
                                                         {{p_{\text{x}}}^{\text{i}}}+{{v_{\text{x}}}^{\text{i}}}\,t+\frac{{{a_{\text{x}}}^{\text{c}}}\,t^{2}}{2}\\
                                                         {{p_{\text{y}}}^{\text{i}}}+{{v_{\text{y}}}^{\text{i}}}\,t+\frac{{{a_{\text{y}}}^{\text{c}}}\,t^{2}}{2}
-                                                        \end{bmatrix}}{\inDefScale}
+                                                        \end{bmatrix}}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -614,7 +605,7 @@ For a two-dimensional Cartesian coordinate system (\hyperref[twoDMotion]{A:twoDM
 \resizeExpression{\symbf{p}\text{(}t\text{)}=\begin{bmatrix}
                                              {{p_{\text{x}}}^{\text{i}}}+{{v_{\text{x}}}^{\text{i}}}\,t+\frac{{{a_{\text{x}}}^{\text{c}}}\,t^{2}}{2}\\
                                              {{p_{\text{y}}}^{\text{i}}}+{{v_{\text{y}}}^{\text{i}}}\,t+\frac{{{a_{\text{y}}}^{\text{c}}}\,t^{2}}{2}
-                                             \end{bmatrix}}{\outDefScale}
+                                             \end{bmatrix}}
 \end{displaymath}
 \subsubsection{Data Definitions}
 \label{Sec:DDs}
@@ -638,7 +629,7 @@ Units & $\frac{\text{m}}{\text{s}}$
         
 \\ \midrule
 Equation & \begin{displaymath}
-           \resizeExpression{v=\|\symbf{v}\text{(}t\text{)}\|}{\inDefScale}
+           \resizeExpression{v=\|\symbf{v}\text{(}t\text{)}\|}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -676,7 +667,7 @@ Units & $\frac{\text{m}}{\text{s}}$
         
 \\ \midrule
 Equation & \begin{displaymath}
-           \resizeExpression{{{v_{\text{x}}}^{\text{i}}}={v^{\text{i}}}\,\cos\left(θ\right)}{\inDefScale}
+           \resizeExpression{{{v_{\text{x}}}^{\text{i}}}={v^{\text{i}}}\,\cos\left(θ\right)}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -717,7 +708,7 @@ Units & $\frac{\text{m}}{\text{s}}$
         
 \\ \midrule
 Equation & \begin{displaymath}
-           \resizeExpression{{{v_{\text{y}}}^{\text{i}}}={v^{\text{i}}}\,\sin\left(θ\right)}{\inDefScale}
+           \resizeExpression{{{v_{\text{y}}}^{\text{i}}}={v^{\text{i}}}\,\sin\left(θ\right)}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -762,18 +753,18 @@ Output & ${t_{\text{flight}}}$
          
 \\ \midrule
 Input Constraints & \begin{displaymath}
-                    \resizeExpression{{v_{\text{launch}}}\gt{}0}{\inDefScale}
+                    \resizeExpression{{v_{\text{launch}}}\gt{}0}
                     \end{displaymath}
                     \begin{displaymath}
-                    \resizeExpression{0\lt{}θ\lt{}\frac{π}{2}}{\inDefScale}
+                    \resizeExpression{0\lt{}θ\lt{}\frac{π}{2}}
                     \end{displaymath}
 \\ \midrule
 Output Constraints & \begin{displaymath}
-                     \resizeExpression{{t_{\text{flight}}}\gt{}0}{\inDefScale}
+                     \resizeExpression{{t_{\text{flight}}}\gt{}0}
                      \end{displaymath}
 \\ \midrule
 Equation & \begin{displaymath}
-           \resizeExpression{{t_{\text{flight}}}=\frac{2\,{v_{\text{launch}}}\,\sin\left(θ\right)}{g}}{\inDefScale}
+           \resizeExpression{{t_{\text{flight}}}=\frac{2\,{v_{\text{launch}}}\,\sin\left(θ\right)}{g}}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -804,27 +795,27 @@ RefBy & \hyperref[IM:calOfLandingDist]{IM:calOfLandingDist}, \hyperref[outputVal
 We know that ${{p_{\text{y}}}^{\text{i}}}=0$ (\hyperref[launchOrigin]{A:launchOrigin}) and ${{a_{\text{y}}}^{\text{c}}}=-g$ (\hyperref[accelYGravity]{A:accelYGravity}). Substituting these values into the y-direction of \hyperref[GD:posVec]{GD:posVec} gives us:
 
 \begin{displaymath}
-\resizeExpression{{p_{\text{y}}}={{v_{\text{y}}}^{\text{i}}}\,t-\frac{g\,t^{2}}{2}}{\outDefScale}
+\resizeExpression{{p_{\text{y}}}={{v_{\text{y}}}^{\text{i}}}\,t-\frac{g\,t^{2}}{2}}
 \end{displaymath}
 To find the time that the projectile lands, we want to find the $t$ value (${t_{\text{flight}}}$) where ${p_{\text{y}}}=0$ (since the target is on the $x$-axis from \hyperref[targetXAxis]{A:targetXAxis}). From the equation above we get:
 
 \begin{displaymath}
-\resizeExpression{{{v_{\text{y}}}^{\text{i}}}\,{t_{\text{flight}}}-\frac{g\,{t_{\text{flight}}}^{2}}{2}=0}{\outDefScale}
+\resizeExpression{{{v_{\text{y}}}^{\text{i}}}\,{t_{\text{flight}}}-\frac{g\,{t_{\text{flight}}}^{2}}{2}=0}
 \end{displaymath}
 Dividing by ${t_{\text{flight}}}$ (with the constraint ${t_{\text{flight}}}\gt{}0$) gives us:
 
 \begin{displaymath}
-\resizeExpression{{{v_{\text{y}}}^{\text{i}}}-\frac{g\,{t_{\text{flight}}}}{2}=0}{\outDefScale}
+\resizeExpression{{{v_{\text{y}}}^{\text{i}}}-\frac{g\,{t_{\text{flight}}}}{2}=0}
 \end{displaymath}
 Solving for ${t_{\text{flight}}}$ gives us:
 
 \begin{displaymath}
-\resizeExpression{{t_{\text{flight}}}=\frac{2\,{{v_{\text{y}}}^{\text{i}}}}{g}}{\outDefScale}
+\resizeExpression{{t_{\text{flight}}}=\frac{2\,{{v_{\text{y}}}^{\text{i}}}}{g}}
 \end{displaymath}
 From \hyperref[DD:speedIY]{DD:speedIY} (with ${v^{\text{i}}}={v_{\text{launch}}}$) we can replace ${{v_{\text{y}}}^{\text{i}}}$:
 
 \begin{displaymath}
-\resizeExpression{{t_{\text{flight}}}=\frac{2\,{v_{\text{launch}}}\,\sin\left(θ\right)}{g}}{\outDefScale}
+\resizeExpression{{t_{\text{flight}}}=\frac{2\,{v_{\text{launch}}}\,\sin\left(θ\right)}{g}}
 \end{displaymath}
 \medskip
 \noindent
@@ -844,18 +835,18 @@ Output & ${p_{\text{land}}}$
          
 \\ \midrule
 Input Constraints & \begin{displaymath}
-                    \resizeExpression{{v_{\text{launch}}}\gt{}0}{\inDefScale}
+                    \resizeExpression{{v_{\text{launch}}}\gt{}0}
                     \end{displaymath}
                     \begin{displaymath}
-                    \resizeExpression{0\lt{}θ\lt{}\frac{π}{2}}{\inDefScale}
+                    \resizeExpression{0\lt{}θ\lt{}\frac{π}{2}}
                     \end{displaymath}
 \\ \midrule
 Output Constraints & \begin{displaymath}
-                     \resizeExpression{{p_{\text{land}}}\gt{}0}{\inDefScale}
+                     \resizeExpression{{p_{\text{land}}}\gt{}0}
                      \end{displaymath}
 \\ \midrule
 Equation & \begin{displaymath}
-           \resizeExpression{{p_{\text{land}}}=\frac{2\,{v_{\text{launch}}}^{2}\,\sin\left(θ\right)\,\cos\left(θ\right)}{g}}{\inDefScale}
+           \resizeExpression{{p_{\text{land}}}=\frac{2\,{v_{\text{launch}}}^{2}\,\sin\left(θ\right)\,\cos\left(θ\right)}{g}}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -886,22 +877,22 @@ RefBy & \hyperref[IM:offsetIM]{IM:offsetIM} and \hyperref[calcValues]{FR:Calcula
 We know that ${{p_{\text{x}}}^{\text{i}}}=0$ (\hyperref[launchOrigin]{A:launchOrigin}) and ${{a_{\text{x}}}^{\text{c}}}=0$ (\hyperref[accelXZero]{A:accelXZero}). Substituting these values into the x-direction of \hyperref[GD:posVec]{GD:posVec} gives us:
 
 \begin{displaymath}
-\resizeExpression{{p_{\text{x}}}={{v_{\text{x}}}^{\text{i}}}\,t}{\outDefScale}
+\resizeExpression{{p_{\text{x}}}={{v_{\text{x}}}^{\text{i}}}\,t}
 \end{displaymath}
 To find the landing position, we want to find the ${p_{\text{x}}}$ value (${p_{\text{land}}}$) at flight duration (from \hyperref[IM:calOfLandingTime]{IM:calOfLandingTime}):
 
 \begin{displaymath}
-\resizeExpression{{p_{\text{land}}}=\frac{{{v_{\text{x}}}^{\text{i}}}\cdot{}2\,{v_{\text{launch}}}\,\sin\left(θ\right)}{g}}{\outDefScale}
+\resizeExpression{{p_{\text{land}}}=\frac{{{v_{\text{x}}}^{\text{i}}}\cdot{}2\,{v_{\text{launch}}}\,\sin\left(θ\right)}{g}}
 \end{displaymath}
 From \hyperref[DD:speedIX]{DD:speedIX} (with ${v^{\text{i}}}={v_{\text{launch}}}$) we can replace ${{v_{\text{x}}}^{\text{i}}}$:
 
 \begin{displaymath}
-\resizeExpression{{p_{\text{land}}}=\frac{{v_{\text{launch}}}\,\cos\left(θ\right)\cdot{}2\,{v_{\text{launch}}}\,\sin\left(θ\right)}{g}}{\outDefScale}
+\resizeExpression{{p_{\text{land}}}=\frac{{v_{\text{launch}}}\,\cos\left(θ\right)\cdot{}2\,{v_{\text{launch}}}\,\sin\left(θ\right)}{g}}
 \end{displaymath}
 Rearranging this gives us the required equation:
 
 \begin{displaymath}
-\resizeExpression{{p_{\text{land}}}=\frac{2\,{v_{\text{launch}}}^{2}\,\sin\left(θ\right)\,\cos\left(θ\right)}{g}}{\outDefScale}
+\resizeExpression{{p_{\text{land}}}=\frac{2\,{v_{\text{launch}}}^{2}\,\sin\left(θ\right)\,\cos\left(θ\right)}{g}}
 \end{displaymath}
 \medskip
 \noindent
@@ -921,16 +912,16 @@ Output & ${d_{\text{offset}}}$
          
 \\ \midrule
 Input Constraints & \begin{displaymath}
-                    \resizeExpression{{p_{\text{land}}}\gt{}0}{\inDefScale}
+                    \resizeExpression{{p_{\text{land}}}\gt{}0}
                     \end{displaymath}
                     \begin{displaymath}
-                    \resizeExpression{{p_{\text{target}}}\gt{}0}{\inDefScale}
+                    \resizeExpression{{p_{\text{target}}}\gt{}0}
                     \end{displaymath}
 \\ \midrule
 Output Constraints & 
 \\ \midrule
 Equation & \begin{displaymath}
-           \resizeExpression{{d_{\text{offset}}}={p_{\text{land}}}-{p_{\text{target}}}}{\inDefScale}
+           \resizeExpression{{d_{\text{offset}}}={p_{\text{land}}}-{p_{\text{target}}}}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -971,10 +962,10 @@ Output & $s$
          
 \\ \midrule
 Input Constraints & \begin{displaymath}
-                    \resizeExpression{{d_{\text{offset}}}\gt{}-{p_{\text{target}}}}{\inDefScale}
+                    \resizeExpression{{d_{\text{offset}}}\gt{}-{p_{\text{target}}}}
                     \end{displaymath}
                     \begin{displaymath}
-                    \resizeExpression{{p_{\text{target}}}\gt{}0}{\inDefScale}
+                    \resizeExpression{{p_{\text{target}}}\gt{}0}
                     \end{displaymath}
 \\ \midrule
 Output Constraints & 
@@ -984,7 +975,7 @@ Equation & \begin{displaymath}
                                \text{``The target was hit.''}, & |\frac{{d_{\text{offset}}}}{{p_{\text{target}}}}|\lt{}ε\\
                                \text{``The projectile fell short.''}, & {d_{\text{offset}}}\lt{}0\\
                                \text{``The projectile went long.''}, & {d_{\text{offset}}}\gt{}0
-                               \end{cases}}{\inDefScale}
+                               \end{cases}}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}

--- a/code/stable/sglpend/SRS/PDF/SglPend_SRS.tex
+++ b/code/stable/sglpend/SRS/PDF/SglPend_SRS.tex
@@ -15,8 +15,7 @@
 \usepackage{svg}
 \usepackage{float}
 \usepackage{enumitem}
-\usepackage{graphicx}
-\usepackage{calc}
+\usepackage{adjustbox}
 \usepackage{filecontents}
 \usepackage[backend=bibtex]{biblatex}
 \usepackage{url}
@@ -25,16 +24,8 @@
 \newcommand{\lt}{\ensuremath <}
 \newlist{symbDescription}{description}{1}
 \setlist[symbDescription]{noitemsep, topsep=0pt, parsep=0pt, partopsep=0pt}
-\def\inDefScale{0.8}
-\def\outDefScale{1.0}
-\newsavebox{\mybox}
-\newcommand{\resizeExpression}[2]{
-  \savebox{\mybox}{$#1$}
-  \ifdim\wd\mybox>#2\linewidth
-    \resizebox{#2\textwidth}{!}{\usebox{\mybox}}
-  \else
-    \usebox{\mybox}
-  \fi
+\newcommand{\resizeExpression}[1]{
+  \adjustbox{max width=\linewidth}{$#1$}
 }
 \bibliography{bibfile}
 \title{Software Requirements Specification for Single Pendulum}
@@ -308,7 +299,7 @@ Label & Acceleration
         
 \\ \midrule
 Equation & \begin{displaymath}
-           \resizeExpression{\symbf{a}\text{(}t\text{)}=\frac{\,d\symbf{v}\text{(}t\text{)}}{\,dt}}{\inDefScale}
+           \resizeExpression{\symbf{a}\text{(}t\text{)}=\frac{\,d\symbf{v}\text{(}t\text{)}}{\,dt}}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -337,7 +328,7 @@ Label & Velocity
         
 \\ \midrule
 Equation & \begin{displaymath}
-           \resizeExpression{\symbf{v}\text{(}t\text{)}=\frac{\,d\symbf{p}\text{(}t\text{)}}{\,dt}}{\inDefScale}
+           \resizeExpression{\symbf{v}\text{(}t\text{)}=\frac{\,d\symbf{p}\text{(}t\text{)}}{\,dt}}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -366,7 +357,7 @@ Label & Newton's second law of motion
         
 \\ \midrule
 Equation & \begin{displaymath}
-           \resizeExpression{\symbf{F}=m\,\symbf{a}\text{(}t\text{)}}{\inDefScale}
+           \resizeExpression{\symbf{F}=m\,\symbf{a}\text{(}t\text{)}}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -398,7 +389,7 @@ Label & Newton's second law for rotational motion
         
 \\ \midrule
 Equation & \begin{displaymath}
-           \resizeExpression{\symbf{τ}=\symbf{I}\,α}{\inDefScale}
+           \resizeExpression{\symbf{τ}=\symbf{I}\,α}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -438,7 +429,7 @@ Units & $\frac{\text{m}}{\text{s}}$
         
 \\ \midrule
 Equation & \begin{displaymath}
-           \resizeExpression{{v_{\text{x}}}=ω\,{L_{\text{rod}}}\,\cos\left({θ_{p}}\right)}{\inDefScale}
+           \resizeExpression{{v_{\text{x}}}=ω\,{L_{\text{rod}}}\,\cos\left({θ_{p}}\right)}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -461,27 +452,27 @@ RefBy &
 At a given point in time, velocity may be defined as
 
 \begin{displaymath}
-\resizeExpression{\symbf{v}\text{(}t\text{)}=\frac{\,d\symbf{p}\text{(}t\text{)}}{\,dt}}{\outDefScale}
+\resizeExpression{\symbf{v}\text{(}t\text{)}=\frac{\,d\symbf{p}\text{(}t\text{)}}{\,dt}}
 \end{displaymath}
 We also know the horizontal position
 
 \begin{displaymath}
-\resizeExpression{{p_{\text{x}}}={L_{\text{rod}}}\,\sin\left({θ_{p}}\right)}{\outDefScale}
+\resizeExpression{{p_{\text{x}}}={L_{\text{rod}}}\,\sin\left({θ_{p}}\right)}
 \end{displaymath}
 Applying this,
 
 \begin{displaymath}
-\resizeExpression{{v_{\text{x}}}=\frac{\,d{L_{\text{rod}}}\,\sin\left({θ_{p}}\right)}{\,dt}}{\outDefScale}
+\resizeExpression{{v_{\text{x}}}=\frac{\,d{L_{\text{rod}}}\,\sin\left({θ_{p}}\right)}{\,dt}}
 \end{displaymath}
 ${L_{\text{rod}}}$ is constant with respect to time, so
 
 \begin{displaymath}
-\resizeExpression{{v_{\text{x}}}={L_{\text{rod}}}\,\frac{\,d\sin\left({θ_{p}}\right)}{\,dt}}{\outDefScale}
+\resizeExpression{{v_{\text{x}}}={L_{\text{rod}}}\,\frac{\,d\sin\left({θ_{p}}\right)}{\,dt}}
 \end{displaymath}
 Therefore, using the chain rule,
 
 \begin{displaymath}
-\resizeExpression{{v_{\text{x}}}=ω\,{L_{\text{rod}}}\,\cos\left({θ_{p}}\right)}{\outDefScale}
+\resizeExpression{{v_{\text{x}}}=ω\,{L_{\text{rod}}}\,\cos\left({θ_{p}}\right)}
 \end{displaymath}
 \medskip
 \noindent
@@ -498,7 +489,7 @@ Units & $\frac{\text{m}}{\text{s}}$
         
 \\ \midrule
 Equation & \begin{displaymath}
-           \resizeExpression{{v_{\text{y}}}=ω\,{L_{\text{rod}}}\,\sin\left({θ_{p}}\right)}{\inDefScale}
+           \resizeExpression{{v_{\text{y}}}=ω\,{L_{\text{rod}}}\,\sin\left({θ_{p}}\right)}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -521,27 +512,27 @@ RefBy &
 At a given point in time, velocity may be defined as
 
 \begin{displaymath}
-\resizeExpression{\symbf{v}\text{(}t\text{)}=\frac{\,d\symbf{p}\text{(}t\text{)}}{\,dt}}{\outDefScale}
+\resizeExpression{\symbf{v}\text{(}t\text{)}=\frac{\,d\symbf{p}\text{(}t\text{)}}{\,dt}}
 \end{displaymath}
 We also know the vertical position
 
 \begin{displaymath}
-\resizeExpression{{p_{\text{y}}}=-{L_{\text{rod}}}\,\cos\left({θ_{p}}\right)}{\outDefScale}
+\resizeExpression{{p_{\text{y}}}=-{L_{\text{rod}}}\,\cos\left({θ_{p}}\right)}
 \end{displaymath}
 Applying this,
 
 \begin{displaymath}
-\resizeExpression{{v_{\text{y}}}=-\left(\frac{\,d{L_{\text{rod}}}\,\cos\left({θ_{p}}\right)}{\,dt}\right)}{\outDefScale}
+\resizeExpression{{v_{\text{y}}}=-\left(\frac{\,d{L_{\text{rod}}}\,\cos\left({θ_{p}}\right)}{\,dt}\right)}
 \end{displaymath}
 ${L_{\text{rod}}}$ is constant with respect to time, so
 
 \begin{displaymath}
-\resizeExpression{{v_{\text{y}}}=-{L_{\text{rod}}}\,\frac{\,d\cos\left({θ_{p}}\right)}{\,dt}}{\outDefScale}
+\resizeExpression{{v_{\text{y}}}=-{L_{\text{rod}}}\,\frac{\,d\cos\left({θ_{p}}\right)}{\,dt}}
 \end{displaymath}
 Therefore, using the chain rule,
 
 \begin{displaymath}
-\resizeExpression{{v_{\text{y}}}=ω\,{L_{\text{rod}}}\,\sin\left({θ_{p}}\right)}{\outDefScale}
+\resizeExpression{{v_{\text{y}}}=ω\,{L_{\text{rod}}}\,\sin\left({θ_{p}}\right)}
 \end{displaymath}
 \medskip
 \noindent
@@ -558,7 +549,7 @@ Units & $\frac{\text{m}}{\text{s}^{2}}$
         
 \\ \midrule
 Equation & \begin{displaymath}
-           \resizeExpression{{a_{\text{x}}}=-ω^{2}\,{L_{\text{rod}}}\,\sin\left({θ_{p}}\right)+α\,{L_{\text{rod}}}\,\cos\left({θ_{p}}\right)}{\inDefScale}
+           \resizeExpression{{a_{\text{x}}}=-ω^{2}\,{L_{\text{rod}}}\,\sin\left({θ_{p}}\right)+α\,{L_{\text{rod}}}\,\cos\left({θ_{p}}\right)}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -582,27 +573,27 @@ RefBy &
 Our acceleration is:
 
 \begin{displaymath}
-\resizeExpression{\symbf{a}\text{(}t\text{)}=\frac{\,d\symbf{v}\text{(}t\text{)}}{\,dt}}{\outDefScale}
+\resizeExpression{\symbf{a}\text{(}t\text{)}=\frac{\,d\symbf{v}\text{(}t\text{)}}{\,dt}}
 \end{displaymath}
 Earlier, we found the horizontal velocity to be
 
 \begin{displaymath}
-\resizeExpression{{v_{\text{x}}}=ω\,{L_{\text{rod}}}\,\cos\left({θ_{p}}\right)}{\outDefScale}
+\resizeExpression{{v_{\text{x}}}=ω\,{L_{\text{rod}}}\,\cos\left({θ_{p}}\right)}
 \end{displaymath}
 Applying this to our equation for acceleration
 
 \begin{displaymath}
-\resizeExpression{{a_{\text{x}}}=\frac{\,dω\,{L_{\text{rod}}}\,\cos\left({θ_{p}}\right)}{\,dt}}{\outDefScale}
+\resizeExpression{{a_{\text{x}}}=\frac{\,dω\,{L_{\text{rod}}}\,\cos\left({θ_{p}}\right)}{\,dt}}
 \end{displaymath}
 By the product and chain rules, we find
 
 \begin{displaymath}
-\resizeExpression{{a_{\text{x}}}=\frac{\,dω}{\,dt}\,{L_{\text{rod}}}\,\cos\left({θ_{p}}\right)-ω\,{L_{\text{rod}}}\,\sin\left({θ_{p}}\right)\,\frac{\,d{θ_{p}}}{\,dt}}{\outDefScale}
+\resizeExpression{{a_{\text{x}}}=\frac{\,dω}{\,dt}\,{L_{\text{rod}}}\,\cos\left({θ_{p}}\right)-ω\,{L_{\text{rod}}}\,\sin\left({θ_{p}}\right)\,\frac{\,d{θ_{p}}}{\,dt}}
 \end{displaymath}
 Simplifying,
 
 \begin{displaymath}
-\resizeExpression{{a_{\text{x}}}=-ω^{2}\,{L_{\text{rod}}}\,\sin\left({θ_{p}}\right)+α\,{L_{\text{rod}}}\,\cos\left({θ_{p}}\right)}{\outDefScale}
+\resizeExpression{{a_{\text{x}}}=-ω^{2}\,{L_{\text{rod}}}\,\sin\left({θ_{p}}\right)+α\,{L_{\text{rod}}}\,\cos\left({θ_{p}}\right)}
 \end{displaymath}
 \medskip
 \noindent
@@ -619,7 +610,7 @@ Units & $\frac{\text{m}}{\text{s}^{2}}$
         
 \\ \midrule
 Equation & \begin{displaymath}
-           \resizeExpression{{a_{\text{y}}}=ω^{2}\,{L_{\text{rod}}}\,\cos\left({θ_{p}}\right)+α\,{L_{\text{rod}}}\,\sin\left({θ_{p}}\right)}{\inDefScale}
+           \resizeExpression{{a_{\text{y}}}=ω^{2}\,{L_{\text{rod}}}\,\cos\left({θ_{p}}\right)+α\,{L_{\text{rod}}}\,\sin\left({θ_{p}}\right)}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -643,27 +634,27 @@ RefBy &
 Our acceleration is:
 
 \begin{displaymath}
-\resizeExpression{\symbf{a}\text{(}t\text{)}=\frac{\,d\symbf{v}\text{(}t\text{)}}{\,dt}}{\outDefScale}
+\resizeExpression{\symbf{a}\text{(}t\text{)}=\frac{\,d\symbf{v}\text{(}t\text{)}}{\,dt}}
 \end{displaymath}
 Earlier, we found the vertical velocity to be
 
 \begin{displaymath}
-\resizeExpression{{v_{\text{y}}}=ω\,{L_{\text{rod}}}\,\sin\left({θ_{p}}\right)}{\outDefScale}
+\resizeExpression{{v_{\text{y}}}=ω\,{L_{\text{rod}}}\,\sin\left({θ_{p}}\right)}
 \end{displaymath}
 Applying this to our equation for acceleration
 
 \begin{displaymath}
-\resizeExpression{{a_{\text{y}}}=\frac{\,dω\,{L_{\text{rod}}}\,\sin\left({θ_{p}}\right)}{\,dt}}{\outDefScale}
+\resizeExpression{{a_{\text{y}}}=\frac{\,dω\,{L_{\text{rod}}}\,\sin\left({θ_{p}}\right)}{\,dt}}
 \end{displaymath}
 By the product and chain rules, we find
 
 \begin{displaymath}
-\resizeExpression{{a_{\text{y}}}=\frac{\,dω}{\,dt}\,{L_{\text{rod}}}\,\sin\left({θ_{p}}\right)+ω\,{L_{\text{rod}}}\,\cos\left({θ_{p}}\right)\,\frac{\,d{θ_{p}}}{\,dt}}{\outDefScale}
+\resizeExpression{{a_{\text{y}}}=\frac{\,dω}{\,dt}\,{L_{\text{rod}}}\,\sin\left({θ_{p}}\right)+ω\,{L_{\text{rod}}}\,\cos\left({θ_{p}}\right)\,\frac{\,d{θ_{p}}}{\,dt}}
 \end{displaymath}
 Simplifying,
 
 \begin{displaymath}
-\resizeExpression{{a_{\text{y}}}=ω^{2}\,{L_{\text{rod}}}\,\cos\left({θ_{p}}\right)+α\,{L_{\text{rod}}}\,\sin\left({θ_{p}}\right)}{\outDefScale}
+\resizeExpression{{a_{\text{y}}}=ω^{2}\,{L_{\text{rod}}}\,\cos\left({θ_{p}}\right)+α\,{L_{\text{rod}}}\,\sin\left({θ_{p}}\right)}
 \end{displaymath}
 \medskip
 \noindent
@@ -680,7 +671,7 @@ Units & ${\text{N}}$
         
 \\ \midrule
 Equation & \begin{displaymath}
-           \resizeExpression{\symbf{F}=m\,{a_{\text{x}}}=-\symbf{T}\,\sin\left({θ_{p}}\right)}{\inDefScale}
+           \resizeExpression{\symbf{F}=m\,{a_{\text{x}}}=-\symbf{T}\,\sin\left({θ_{p}}\right)}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -702,7 +693,7 @@ RefBy &
 \paragraph{Detailed derivation of force on the pendulum:}
 \label{GD:hForceOnPendulumDeriv}
 \begin{displaymath}
-\resizeExpression{\symbf{F}=m\,{a_{\text{x}}}=-\symbf{T}\,\sin\left({θ_{p}}\right)}{\outDefScale}
+\resizeExpression{\symbf{F}=m\,{a_{\text{x}}}=-\symbf{T}\,\sin\left({θ_{p}}\right)}
 \end{displaymath}
 \medskip
 \noindent
@@ -719,7 +710,7 @@ Units & ${\text{N}}$
         
 \\ \midrule
 Equation & \begin{displaymath}
-           \resizeExpression{\symbf{F}=m\,{a_{\text{y}}}=\symbf{T}\,\cos\left({θ_{p}}\right)-m\,\symbf{g}}{\inDefScale}
+           \resizeExpression{\symbf{F}=m\,{a_{\text{y}}}=\symbf{T}\,\cos\left({θ_{p}}\right)-m\,\symbf{g}}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -742,7 +733,7 @@ RefBy &
 \paragraph{Detailed derivation of force on the pendulum:}
 \label{GD:vForceOnPendulumDeriv}
 \begin{displaymath}
-\resizeExpression{\symbf{F}=m\,{a_{\text{y}}}=\symbf{T}\,\cos\left({θ_{p}}\right)-m\,\symbf{g}}{\outDefScale}
+\resizeExpression{\symbf{F}=m\,{a_{\text{y}}}=\symbf{T}\,\cos\left({θ_{p}}\right)-m\,\symbf{g}}
 \end{displaymath}
 \medskip
 \noindent
@@ -759,7 +750,7 @@ Units & ${\text{s}}$
         
 \\ \midrule
 Equation & \begin{displaymath}
-           \resizeExpression{Ω=\sqrt{\frac{\symbf{g}}{{L_{\text{rod}}}}}}{\inDefScale}
+           \resizeExpression{Ω=\sqrt{\frac{\symbf{g}}{{L_{\text{rod}}}}}}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -785,37 +776,37 @@ RefBy & \hyperref[GD:periodPend]{GD:periodPend} and \hyperref[IM:calOfAngularDis
 Consider the torque on a pendulum defined in \hyperref[TM:NewtonSecLawRotMot]{TM:NewtonSecLawRotMot}. The force providing the restoring torque is the component of weight of the pendulum bob that acts along the arc length. The torque is the length of the string ${L_{\text{rod}}}$ multiplied by the component of the net force that is perpendicular to the radius of the arc. The minus sign indicates the torque acts in the opposite direction of the angular displacement:
 
 \begin{displaymath}
-\resizeExpression{\symbf{τ}=-{L_{\text{rod}}}\,m\,\symbf{g}\,\sin\left({θ_{p}}\right)}{\outDefScale}
+\resizeExpression{\symbf{τ}=-{L_{\text{rod}}}\,m\,\symbf{g}\,\sin\left({θ_{p}}\right)}
 \end{displaymath}
 So then
 
 \begin{displaymath}
-\resizeExpression{\symbf{I}\,α=-{L_{\text{rod}}}\,m\,\symbf{g}\,\sin\left({θ_{p}}\right)}{\outDefScale}
+\resizeExpression{\symbf{I}\,α=-{L_{\text{rod}}}\,m\,\symbf{g}\,\sin\left({θ_{p}}\right)}
 \end{displaymath}
 Therefore,
 
 \begin{displaymath}
-\resizeExpression{\symbf{I}\,\frac{\,d\frac{\,d{θ_{p}}}{\,dt}}{\,dt}=-{L_{\text{rod}}}\,m\,\symbf{g}\,\sin\left({θ_{p}}\right)}{\outDefScale}
+\resizeExpression{\symbf{I}\,\frac{\,d\frac{\,d{θ_{p}}}{\,dt}}{\,dt}=-{L_{\text{rod}}}\,m\,\symbf{g}\,\sin\left({θ_{p}}\right)}
 \end{displaymath}
 Substituting for $\symbf{I}$
 
 \begin{displaymath}
-\resizeExpression{m\,{L_{\text{rod}}}^{2}\,\frac{\,d\frac{\,d{θ_{p}}}{\,dt}}{\,dt}=-{L_{\text{rod}}}\,m\,\symbf{g}\,\sin\left({θ_{p}}\right)}{\outDefScale}
+\resizeExpression{m\,{L_{\text{rod}}}^{2}\,\frac{\,d\frac{\,d{θ_{p}}}{\,dt}}{\,dt}=-{L_{\text{rod}}}\,m\,\symbf{g}\,\sin\left({θ_{p}}\right)}
 \end{displaymath}
 Crossing out $m$ and ${L_{\text{rod}}}$ we have
 
 \begin{displaymath}
-\resizeExpression{\frac{\,d\frac{\,d{θ_{p}}}{\,dt}}{\,dt}=-\left(\frac{\symbf{g}}{{L_{\text{rod}}}}\right)\,\sin\left({θ_{p}}\right)}{\outDefScale}
+\resizeExpression{\frac{\,d\frac{\,d{θ_{p}}}{\,dt}}{\,dt}=-\left(\frac{\symbf{g}}{{L_{\text{rod}}}}\right)\,\sin\left({θ_{p}}\right)}
 \end{displaymath}
 For small angles, we approximate sin ${θ_{p}}$ to ${θ_{p}}$
 
 \begin{displaymath}
-\resizeExpression{\frac{\,d\frac{\,d{θ_{p}}}{\,dt}}{\,dt}=-\left(\frac{\symbf{g}}{{L_{\text{rod}}}}\right)\,{θ_{p}}}{\outDefScale}
+\resizeExpression{\frac{\,d\frac{\,d{θ_{p}}}{\,dt}}{\,dt}=-\left(\frac{\symbf{g}}{{L_{\text{rod}}}}\right)\,{θ_{p}}}
 \end{displaymath}
 Because this equation, has the same form as the equation for simple harmonic motion the solution is easy to find.  The angular frequency
 
 \begin{displaymath}
-\resizeExpression{Ω=\sqrt{\frac{\symbf{g}}{{L_{\text{rod}}}}}}{\outDefScale}
+\resizeExpression{Ω=\sqrt{\frac{\symbf{g}}{{L_{\text{rod}}}}}}
 \end{displaymath}
 \medskip
 \noindent
@@ -832,7 +823,7 @@ Units & ${\text{s}}$
         
 \\ \midrule
 Equation & \begin{displaymath}
-           \resizeExpression{T=2\,π\,\sqrt{\frac{{L_{\text{rod}}}}{\symbf{g}}}}{\inDefScale}
+           \resizeExpression{T=2\,π\,\sqrt{\frac{{L_{\text{rod}}}}{\symbf{g}}}}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -858,12 +849,12 @@ RefBy &
 The period of the pendulum can be defined from the general definition for the equation of \hyperref[GD:angFrequencyGD]{angular frequency}
 
 \begin{displaymath}
-\resizeExpression{Ω=\sqrt{\frac{\symbf{g}}{{L_{\text{rod}}}}}}{\outDefScale}
+\resizeExpression{Ω=\sqrt{\frac{\symbf{g}}{{L_{\text{rod}}}}}}
 \end{displaymath}
 Therefore from the data definition of the equation for \hyperref[DD:angFrequencyDD]{angular frequency}, we have
 
 \begin{displaymath}
-\resizeExpression{T=2\,π\,\sqrt{\frac{{L_{\text{rod}}}}{\symbf{g}}}}{\outDefScale}
+\resizeExpression{T=2\,π\,\sqrt{\frac{{L_{\text{rod}}}}{\symbf{g}}}}
 \end{displaymath}
 \subsubsection{Data Definitions}
 \label{Sec:DDs}
@@ -887,7 +878,7 @@ Units & ${\text{m}}$
         
 \\ \midrule
 Equation & \begin{displaymath}
-           \resizeExpression{{{p_{\text{x}}}^{\text{i}}}={L_{\text{rod}}}\,\sin\left({θ_{i}}\right)}{\inDefScale}
+           \resizeExpression{{{p_{\text{x}}}^{\text{i}}}={L_{\text{rod}}}\,\sin\left({θ_{i}}\right)}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -927,7 +918,7 @@ Units & ${\text{m}}$
         
 \\ \midrule
 Equation & \begin{displaymath}
-           \resizeExpression{{{p_{\text{y}}}^{\text{i}}}=-{L_{\text{rod}}}\,\cos\left({θ_{i}}\right)}{\inDefScale}
+           \resizeExpression{{{p_{\text{y}}}^{\text{i}}}=-{L_{\text{rod}}}\,\cos\left({θ_{i}}\right)}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -967,7 +958,7 @@ Units & ${\text{Hz}}$
         
 \\ \midrule
 Equation & \begin{displaymath}
-           \resizeExpression{f=\frac{1}{T}}{\inDefScale}
+           \resizeExpression{f=\frac{1}{T}}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -1005,7 +996,7 @@ Units & ${\text{s}}$
         
 \\ \midrule
 Equation & \begin{displaymath}
-           \resizeExpression{Ω=\frac{2\,π}{T}}{\inDefScale}
+           \resizeExpression{Ω=\frac{2\,π}{T}}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -1044,7 +1035,7 @@ Units & ${\text{s}}$
         
 \\ \midrule
 Equation & \begin{displaymath}
-           \resizeExpression{T=\frac{1}{f}}{\inDefScale}
+           \resizeExpression{T=\frac{1}{f}}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -1086,21 +1077,21 @@ Output & ${θ_{p}}$
          
 \\ \midrule
 Input Constraints & \begin{displaymath}
-                    \resizeExpression{{L_{\text{rod}}}\gt{}0}{\inDefScale}
+                    \resizeExpression{{L_{\text{rod}}}\gt{}0}
                     \end{displaymath}
                     \begin{displaymath}
-                    \resizeExpression{{θ_{i}}\gt{}0}{\inDefScale}
+                    \resizeExpression{{θ_{i}}\gt{}0}
                     \end{displaymath}
                     \begin{displaymath}
-                    \resizeExpression{\symbf{g}\gt{}0}{\inDefScale}
+                    \resizeExpression{\symbf{g}\gt{}0}
                     \end{displaymath}
 \\ \midrule
 Output Constraints & \begin{displaymath}
-                     \resizeExpression{{θ_{p}}\gt{}0}{\inDefScale}
+                     \resizeExpression{{θ_{p}}\gt{}0}
                      \end{displaymath}
 \\ \midrule
 Equation & \begin{displaymath}
-           \resizeExpression{{θ_{p}}\left(t\right)={θ_{i}}\,\cos\left(Ω\,t\right)}{\inDefScale}
+           \resizeExpression{{θ_{p}}\left(t\right)={θ_{i}}\,\cos\left(Ω\,t\right)}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -1127,27 +1118,27 @@ RefBy & \hyperref[outputValues]{FR:Output-Values} and \hyperref[calcAngPos]{FR:C
 When the pendulum is displaced to an initial angle and released, the pendulum swings back and forth with periodic motion. By applying \hyperref[TM:NewtonSecLawRotMot]{Newton's second law for rotational motion}, the equation of motion for the pendulum may be obtained:
 
 \begin{displaymath}
-\resizeExpression{\symbf{τ}=\symbf{I}\,α}{\outDefScale}
+\resizeExpression{\symbf{τ}=\symbf{I}\,α}
 \end{displaymath}
 Where $\symbf{τ}$ denotes the torque, $\symbf{I}$ denotes the moment of inertia and $α$ denotes the angular acceleration. This implies:
 
 \begin{displaymath}
-\resizeExpression{-m\,\symbf{g}\,\sin\left({θ_{p}}\right)\,{L_{\text{rod}}}=m\,{L_{\text{rod}}}^{2}\,\frac{\,d\frac{\,d{θ_{p}}}{\,dt}}{\,dt}}{\outDefScale}
+\resizeExpression{-m\,\symbf{g}\,\sin\left({θ_{p}}\right)\,{L_{\text{rod}}}=m\,{L_{\text{rod}}}^{2}\,\frac{\,d\frac{\,d{θ_{p}}}{\,dt}}{\,dt}}
 \end{displaymath}
 And rearranged as:
 
 \begin{displaymath}
-\resizeExpression{\frac{\,d\frac{\,d{θ_{p}}}{\,dt}}{\,dt}+\frac{\symbf{g}}{{L_{\text{rod}}}}\,\sin\left({θ_{p}}\right)=0}{\outDefScale}
+\resizeExpression{\frac{\,d\frac{\,d{θ_{p}}}{\,dt}}{\,dt}+\frac{\symbf{g}}{{L_{\text{rod}}}}\,\sin\left({θ_{p}}\right)=0}
 \end{displaymath}
 If the amplitude of angular displacement is small enough, we can approximate $\sin\left({θ_{p}}\right)={θ_{p}}$ for the purpose of a simple pendulum at very small angles. Then the equation of motion reduces to the equation of simple harmonic motion:
 
 \begin{displaymath}
-\resizeExpression{\frac{\,d\frac{\,d{θ_{p}}}{\,dt}}{\,dt}+\frac{\symbf{g}}{{L_{\text{rod}}}}\,{θ_{p}}=0}{\outDefScale}
+\resizeExpression{\frac{\,d\frac{\,d{θ_{p}}}{\,dt}}{\,dt}+\frac{\symbf{g}}{{L_{\text{rod}}}}\,{θ_{p}}=0}
 \end{displaymath}
 Thus the simple harmonic motion is:
 
 \begin{displaymath}
-\resizeExpression{{θ_{p}}\left(t\right)={θ_{i}}\,\cos\left(Ω\,t\right)}{\outDefScale}
+\resizeExpression{{θ_{p}}\left(t\right)={θ_{i}}\,\cos\left(Ω\,t\right)}
 \end{displaymath}
 \subsubsection{Data Constraints}
 \label{Sec:DataConstraints}

--- a/code/stable/ssp/SRS/PDF/SSP_SRS.tex
+++ b/code/stable/ssp/SRS/PDF/SSP_SRS.tex
@@ -15,8 +15,7 @@
 \usepackage{svg}
 \usepackage{float}
 \usepackage{enumitem}
-\usepackage{graphicx}
-\usepackage{calc}
+\usepackage{adjustbox}
 \usepackage{filecontents}
 \usepackage[backend=bibtex]{biblatex}
 \usepackage{url}
@@ -25,16 +24,8 @@
 \newcommand{\lt}{\ensuremath <}
 \newlist{symbDescription}{description}{1}
 \setlist[symbDescription]{noitemsep, topsep=0pt, parsep=0pt, partopsep=0pt}
-\def\inDefScale{0.8}
-\def\outDefScale{1.0}
-\newsavebox{\mybox}
-\newcommand{\resizeExpression}[2]{
-  \savebox{\mybox}{$#1$}
-  \ifdim\wd\mybox>#2\linewidth
-    \resizebox{#2\textwidth}{!}{\usebox{\mybox}}
-  \else
-    \usebox{\mybox}
-  \fi
+\newcommand{\resizeExpression}[1]{
+  \adjustbox{max width=\linewidth}{$#1$}
 }
 \bibliography{bibfile}
 \title{Software Requirements Specification for Slope Stability analysis Program}
@@ -484,7 +475,7 @@ Label & Factor of safety
         
 \\ \midrule
 Equation & \begin{displaymath}
-           \resizeExpression{{F_{\text{S}}}=\frac{P}{S}}{\inDefScale}
+           \resizeExpression{{F_{\text{S}}}=\frac{P}{S}}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -514,13 +505,13 @@ Label & Equilibrium
         
 \\ \midrule
 Equation & \begin{displaymath}
-           \resizeExpression{\displaystyle\sum{{F_{\text{x}}}}=0}{\inDefScale}
+           \resizeExpression{\displaystyle\sum{{F_{\text{x}}}}=0}
            \end{displaymath}
            \begin{displaymath}
-           \resizeExpression{\displaystyle\sum{{F_{\text{y}}}}=0}{\inDefScale}
+           \resizeExpression{\displaystyle\sum{{F_{\text{y}}}}=0}
            \end{displaymath}
            \begin{displaymath}
-           \resizeExpression{\displaystyle\sum{M}=0}{\inDefScale}
+           \resizeExpression{\displaystyle\sum{M}=0}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -557,7 +548,7 @@ Label & Mohr-Coulumb shear strength
         
 \\ \midrule
 Equation & \begin{displaymath}
-           \resizeExpression{{τ^{\text{f}}}={σ_{N}}'\,\tan\left(φ'\right)+c'}{\inDefScale}
+           \resizeExpression{{τ^{\text{f}}}={σ_{N}}'\,\tan\left(φ'\right)+c'}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -591,7 +582,7 @@ Label & Effective stress
         
 \\ \midrule
 Equation & \begin{displaymath}
-           \resizeExpression{σ'=σ-u}{\inDefScale}
+           \resizeExpression{σ'=σ-u}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -624,7 +615,7 @@ Label & Newton's second law of motion
         
 \\ \midrule
 Equation & \begin{displaymath}
-           \resizeExpression{\symbf{F}=m\,\symbf{a}\text{(}t\text{)}}{\inDefScale}
+           \resizeExpression{\symbf{F}=m\,\symbf{a}\text{(}t\text{)}}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -664,7 +655,7 @@ Units & $\frac{\text{N}}{\text{m}}$
         
 \\ \midrule
 Equation & \begin{displaymath}
-           \resizeExpression{{\symbf{N}}_{i}=\left({\symbf{W}}_{i}-{\symbf{X}}_{i-1}+{\symbf{X}}_{i}+{\symbf{U}_{\text{g},i}}\,\cos\left({\symbf{β}}_{i}\right)+{\symbf{Q}}_{i}\,\cos\left({\symbf{ω}}_{i}\right)\right)\,\cos\left({\symbf{α}}_{i}\right)+\left(-{K_{\text{c}}}\,{\symbf{W}}_{i}-{\symbf{G}}_{i}+{\symbf{G}}_{i-1}-{\symbf{H}}_{i}+{\symbf{H}}_{i-1}+{\symbf{U}_{\text{g},i}}\,\sin\left({\symbf{β}}_{i}\right)+{\symbf{Q}}_{i}\,\sin\left({\symbf{ω}}_{i}\right)\right)\,\sin\left({\symbf{α}}_{i}\right)}{\inDefScale}
+           \resizeExpression{{\symbf{N}}_{i}=\left({\symbf{W}}_{i}-{\symbf{X}}_{i-1}+{\symbf{X}}_{i}+{\symbf{U}_{\text{g},i}}\,\cos\left({\symbf{β}}_{i}\right)+{\symbf{Q}}_{i}\,\cos\left({\symbf{ω}}_{i}\right)\right)\,\cos\left({\symbf{α}}_{i}\right)+\left(-{K_{\text{c}}}\,{\symbf{W}}_{i}-{\symbf{G}}_{i}+{\symbf{G}}_{i-1}-{\symbf{H}}_{i}+{\symbf{H}}_{i-1}+{\symbf{U}_{\text{g},i}}\,\sin\left({\symbf{β}}_{i}\right)+{\symbf{Q}}_{i}\,\sin\left({\symbf{ω}}_{i}\right)\right)\,\sin\left({\symbf{α}}_{i}\right)}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -713,7 +704,7 @@ Units & $\frac{\text{N}}{\text{m}}$
         
 \\ \midrule
 Equation & \begin{displaymath}
-           \resizeExpression{{\symbf{S}}_{i}=\left({\symbf{W}}_{i}-{\symbf{X}}_{i-1}+{\symbf{X}}_{i}+{\symbf{U}_{\text{g},i}}\,\cos\left({\symbf{β}}_{i}\right)+{\symbf{Q}}_{i}\,\cos\left({\symbf{ω}}_{i}\right)\right)\,\sin\left({\symbf{α}}_{i}\right)-\left(-{K_{\text{c}}}\,{\symbf{W}}_{i}-{\symbf{G}}_{i}+{\symbf{G}}_{i-1}-{\symbf{H}}_{i}+{\symbf{H}}_{i-1}+{\symbf{U}_{\text{g},i}}\,\sin\left({\symbf{β}}_{i}\right)+{\symbf{Q}}_{i}\,\sin\left({\symbf{ω}}_{i}\right)\right)\,\cos\left({\symbf{α}}_{i}\right)}{\inDefScale}
+           \resizeExpression{{\symbf{S}}_{i}=\left({\symbf{W}}_{i}-{\symbf{X}}_{i-1}+{\symbf{X}}_{i}+{\symbf{U}_{\text{g},i}}\,\cos\left({\symbf{β}}_{i}\right)+{\symbf{Q}}_{i}\,\cos\left({\symbf{ω}}_{i}\right)\right)\,\sin\left({\symbf{α}}_{i}\right)-\left(-{K_{\text{c}}}\,{\symbf{W}}_{i}-{\symbf{G}}_{i}+{\symbf{G}}_{i-1}-{\symbf{H}}_{i}+{\symbf{H}}_{i-1}+{\symbf{U}_{\text{g},i}}\,\sin\left({\symbf{β}}_{i}\right)+{\symbf{Q}}_{i}\,\sin\left({\symbf{ω}}_{i}\right)\right)\,\cos\left({\symbf{α}}_{i}\right)}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -762,7 +753,7 @@ Units & $\frac{\text{N}}{\text{m}}$
         
 \\ \midrule
 Equation & \begin{displaymath}
-           \resizeExpression{{\symbf{P}}_{i}={\symbf{N'}}_{i}\,\tan\left({φ'}_{i}\right)+{c'}_{i}\,{\symbf{L}_{b,i}}}{\inDefScale}
+           \resizeExpression{{\symbf{P}}_{i}={\symbf{N'}}_{i}\,\tan\left({φ'}_{i}\right)+{c'}_{i}\,{\symbf{L}_{b,i}}}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -805,7 +796,7 @@ Units & $\frac{\text{N}}{\text{m}}$
         
 \\ \midrule
 Equation & \begin{displaymath}
-           \resizeExpression{{\symbf{S}}_{i}=\frac{{\symbf{P}}_{i}}{{F_{\text{S}}}}=\frac{{\symbf{N'}}_{i}\,\tan\left({φ'}_{i}\right)+{c'}_{i}\,{\symbf{L}_{b,i}}}{{F_{\text{S}}}}}{\inDefScale}
+           \resizeExpression{{\symbf{S}}_{i}=\frac{{\symbf{P}}_{i}}{{F_{\text{S}}}}=\frac{{\symbf{N'}}_{i}\,\tan\left({φ'}_{i}\right)+{c'}_{i}\,{\symbf{L}_{b,i}}}{{F_{\text{S}}}}}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -850,7 +841,7 @@ Units & $\frac{\text{N}}{\text{m}}$
         
 \\ \midrule
 Equation & \begin{displaymath}
-           \resizeExpression{{\symbf{N'}}_{i}={\symbf{N}}_{i}-{\symbf{U}_{\text{b},i}}}{\inDefScale}
+           \resizeExpression{{\symbf{N'}}_{i}={\symbf{N}}_{i}-{\symbf{U}_{\text{b},i}}}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -890,7 +881,7 @@ Units & $\frac{\text{N}}{\text{m}}$
         
 \\ \midrule
 Equation & \begin{displaymath}
-           \resizeExpression{{\symbf{R}}_{i}=\left(\left({\symbf{W}}_{i}+{\symbf{U}_{\text{g},i}}\,\cos\left({\symbf{β}}_{i}\right)\right)\,\cos\left({\symbf{α}}_{i}\right)+\left(-{\symbf{H}}_{i}+{\symbf{H}}_{i-1}+{\symbf{U}_{\text{g},i}}\,\sin\left({\symbf{β}}_{i}\right)\right)\,\sin\left({\symbf{α}}_{i}\right)-{\symbf{U}_{\text{b},i}}\right)\,\tan\left({φ'}_{i}\right)+{c'}_{i}\,{\symbf{L}_{b,i}}}{\inDefScale}
+           \resizeExpression{{\symbf{R}}_{i}=\left(\left({\symbf{W}}_{i}+{\symbf{U}_{\text{g},i}}\,\cos\left({\symbf{β}}_{i}\right)\right)\,\cos\left({\symbf{α}}_{i}\right)+\left(-{\symbf{H}}_{i}+{\symbf{H}}_{i-1}+{\symbf{U}_{\text{g},i}}\,\sin\left({\symbf{β}}_{i}\right)\right)\,\sin\left({\symbf{α}}_{i}\right)-{\symbf{U}_{\text{b},i}}\right)\,\tan\left({φ'}_{i}\right)+{c'}_{i}\,{\symbf{L}_{b,i}}}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -934,7 +925,7 @@ Units & $\frac{\text{N}}{\text{m}}$
         
 \\ \midrule
 Equation & \begin{displaymath}
-           \resizeExpression{{\symbf{T}}_{i}=\left({\symbf{W}}_{i}+{\symbf{U}_{\text{g},i}}\,\cos\left({\symbf{β}}_{i}\right)\right)\,\sin\left({\symbf{α}}_{i}\right)-\left(-{\symbf{H}}_{i}+{\symbf{H}}_{i-1}+{\symbf{U}_{\text{g},i}}\,\sin\left({\symbf{β}}_{i}\right)\right)\,\cos\left({\symbf{α}}_{i}\right)}{\inDefScale}
+           \resizeExpression{{\symbf{T}}_{i}=\left({\symbf{W}}_{i}+{\symbf{U}_{\text{g},i}}\,\cos\left({\symbf{β}}_{i}\right)\right)\,\sin\left({\symbf{α}}_{i}\right)-\left(-{\symbf{H}}_{i}+{\symbf{H}}_{i-1}+{\symbf{U}_{\text{g},i}}\,\sin\left({\symbf{β}}_{i}\right)\right)\,\cos\left({\symbf{α}}_{i}\right)}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -974,7 +965,7 @@ Units & $\frac{\text{N}}{\text{m}}$
         
 \\ \midrule
 Equation & \begin{displaymath}
-           \resizeExpression{\symbf{X}=λ\,\symbf{f}\,\symbf{G}}{\inDefScale}
+           \resizeExpression{\symbf{X}=λ\,\symbf{f}\,\symbf{G}}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -1011,7 +1002,7 @@ Units & ${\text{N}}$
         
 \\ \midrule
 Equation & \begin{displaymath}
-           \resizeExpression{0=-{\symbf{G}}_{i}\,\left({\symbf{h}_{\text{z},i}}+\frac{{\symbf{b}}_{i}}{2}\,\tan\left({\symbf{α}}_{i}\right)\right)+{\symbf{G}}_{i-1}\,\left({\symbf{h}_{\text{z},i-1}}-\frac{{\symbf{b}}_{i}}{2}\,\tan\left({\symbf{α}}_{i}\right)\right)-{\symbf{H}}_{i}\,\left(\frac{1}{3}\,{\symbf{h}_{\text{z,w},i}}+\frac{{\symbf{b}}_{i}}{2}\,\tan\left({\symbf{α}}_{i}\right)\right)+{\symbf{H}}_{i-1}\,\left(\frac{1}{3}\,{\symbf{h}_{\text{z,w},i-1}}-\frac{{\symbf{b}}_{i}}{2}\,\tan\left({\symbf{α}}_{i}\right)\right)+\frac{{\symbf{b}}_{i}}{2}\,\left({\symbf{X}}_{i}+{\symbf{X}}_{i-1}\right)+\frac{-{K_{\text{c}}}\,{\symbf{W}}_{i}\,{\symbf{h}}_{i}}{2}+{\symbf{U}_{\text{g},i}}\,\sin\left({\symbf{β}}_{i}\right)\,{\symbf{h}}_{i}+{\symbf{Q}}_{i}\,\sin\left({\symbf{ω}}_{i}\right)\,{\symbf{h}}_{i}}{\inDefScale}
+           \resizeExpression{0=-{\symbf{G}}_{i}\,\left({\symbf{h}_{\text{z},i}}+\frac{{\symbf{b}}_{i}}{2}\,\tan\left({\symbf{α}}_{i}\right)\right)+{\symbf{G}}_{i-1}\,\left({\symbf{h}_{\text{z},i-1}}-\frac{{\symbf{b}}_{i}}{2}\,\tan\left({\symbf{α}}_{i}\right)\right)-{\symbf{H}}_{i}\,\left(\frac{1}{3}\,{\symbf{h}_{\text{z,w},i}}+\frac{{\symbf{b}}_{i}}{2}\,\tan\left({\symbf{α}}_{i}\right)\right)+{\symbf{H}}_{i-1}\,\left(\frac{1}{3}\,{\symbf{h}_{\text{z,w},i-1}}-\frac{{\symbf{b}}_{i}}{2}\,\tan\left({\symbf{α}}_{i}\right)\right)+\frac{{\symbf{b}}_{i}}{2}\,\left({\symbf{X}}_{i}+{\symbf{X}}_{i-1}\right)+\frac{-{K_{\text{c}}}\,{\symbf{W}}_{i}\,{\symbf{h}}_{i}}{2}+{\symbf{U}_{\text{g},i}}\,\sin\left({\symbf{β}}_{i}\right)\,{\symbf{h}}_{i}+{\symbf{Q}}_{i}\,\sin\left({\symbf{ω}}_{i}\right)\,{\symbf{h}}_{i}}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -1049,72 +1040,72 @@ RefBy & \hyperref[IM:nrmShrFor]{IM:nrmShrFor}
 Moment is equal to torque, so the equation from \hyperref[DD:torque]{DD:torque} will be used to calculate moments:
 
 \begin{displaymath}
-\resizeExpression{\symbf{τ}=\symbf{u}\times\symbf{F}}{\outDefScale}
+\resizeExpression{\symbf{τ}=\symbf{u}\times\symbf{F}}
 \end{displaymath}
 Considering one dimension, with moments in the clockwise direction as positive and moments in the counterclockwise direction as negative, and replacing the torque symbol with the moment symbol, the equation simplifies to:
 
 \begin{displaymath}
-\resizeExpression{M={F_{\text{rot}}}\,r}{\outDefScale}
+\resizeExpression{M={F_{\text{rot}}}\,r}
 \end{displaymath}
 where ${F_{\text{rot}}}$ is the force causing rotation and $r$ is the length of the moment arm, or the distance between the force and the axis about which the rotation acts. To represent the moment equilibrium, the moments from each force acting on a slice must be considered and added together. The forces acting on a slice are all shown in \hyperref[Figure:ForceDiagram]{Fig:ForceDiagram}. The midpoint of the base of a slice is considered as the axis of rotation, from which the length of the moment arm is measured. Considering first the interslice normal force acting on slice interface $i$, the moment is negative because the force tends to rotate the slice in a counterclockwise direction, and the length of the moment arm is the height of the force plus the difference in height between the base at slice interface $i$ and the base at the midpoint of slice $i$. Thus, the moment is expressed as:
 
 \begin{displaymath}
-\resizeExpression{-{\symbf{G}}_{i}\,\left({\symbf{h}_{\text{z},i}}+\frac{{\symbf{b}}_{i}}{2}\,\tan\left({\symbf{α}}_{i}\right)\right)}{\outDefScale}
+\resizeExpression{-{\symbf{G}}_{i}\,\left({\symbf{h}_{\text{z},i}}+\frac{{\symbf{b}}_{i}}{2}\,\tan\left({\symbf{α}}_{i}\right)\right)}
 \end{displaymath}
 For the $i-1$th slice interface, the moment is similar but in the opposite direction:
 
 \begin{displaymath}
-\resizeExpression{{\symbf{G}}_{i-1}\,\left({\symbf{h}_{\text{z},i-1}}-\frac{{\symbf{b}}_{i}}{2}\,\tan\left({\symbf{α}}_{i}\right)\right)}{\outDefScale}
+\resizeExpression{{\symbf{G}}_{i-1}\,\left({\symbf{h}_{\text{z},i-1}}-\frac{{\symbf{b}}_{i}}{2}\,\tan\left({\symbf{α}}_{i}\right)\right)}
 \end{displaymath}
 Next, the interslice normal water force is considered. This force is zero at the height of the water table, then increases linearly towards the base of the slice due to the increasing water pressure. For such a triangular distribution, the resultant force acts at one-third of the height. Thus, for the interslice normal water force acting on slice interface $i$, the moment is:
 
 \begin{displaymath}
-\resizeExpression{-{\symbf{H}}_{i}\,\left(\frac{1}{3}\,{\symbf{h}_{\text{z,w},i}}+\frac{{\symbf{b}}_{i}}{2}\,\tan\left({\symbf{α}}_{i}\right)\right)}{\outDefScale}
+\resizeExpression{-{\symbf{H}}_{i}\,\left(\frac{1}{3}\,{\symbf{h}_{\text{z,w},i}}+\frac{{\symbf{b}}_{i}}{2}\,\tan\left({\symbf{α}}_{i}\right)\right)}
 \end{displaymath}
 The moment for the interslice normal water force acting on slice interface $i-1$ is:
 
 \begin{displaymath}
-\resizeExpression{{\symbf{H}}_{i-1}\,\left(\frac{1}{3}\,{\symbf{h}_{\text{z,w},i-1}}+\frac{{\symbf{b}}_{i}}{2}\,\tan\left({\symbf{α}}_{i}\right)\right)}{\outDefScale}
+\resizeExpression{{\symbf{H}}_{i-1}\,\left(\frac{1}{3}\,{\symbf{h}_{\text{z,w},i-1}}+\frac{{\symbf{b}}_{i}}{2}\,\tan\left({\symbf{α}}_{i}\right)\right)}
 \end{displaymath}
 The interslice shear force at slice interface $i$ tends to rotate in the clockwise direction, and the length of the moment arm is the length from the slice edge to the slice midpoint, equivalent to half of the width of the slice, so the moment is:
 
 \begin{displaymath}
-\resizeExpression{{\symbf{X}}_{i}\,\frac{{\symbf{b}}_{i}}{2}}{\outDefScale}
+\resizeExpression{{\symbf{X}}_{i}\,\frac{{\symbf{b}}_{i}}{2}}
 \end{displaymath}
 The interslice shear force at slice interface $i-1$ also tends to rotate in the clockwise direction, and has the same length of the moment arm, so the moment is:
 
 \begin{displaymath}
-\resizeExpression{{\symbf{X}}_{i-1}\,\frac{{\symbf{b}}_{i}}{2}}{\outDefScale}
+\resizeExpression{{\symbf{X}}_{i-1}\,\frac{{\symbf{b}}_{i}}{2}}
 \end{displaymath}
 Seismic forces act over the entire height of the slice. For each horizontal segment of the slice, the seismic force is ${K_{\text{c}}}\,{\symbf{W}}_{i}$ where ${\symbf{W}}_{i}$ can be expressed as $γ\,{\symbf{b}}_{i}\,y$ using \hyperref[GD:weight]{GD:weight} where $y$ is the height of the segment under consideration. The corresponding length of the moment arm is $y$, the height from the base of the slice to the segment under consideration. In reality, the forces near the surface of the soil mass are slightly different due to the slope of the surface, but this difference is assumed to be negligible (\hyperref[assumpNESSS]{A:Negligible-Effect-Surface-Slope-Seismic}). The resultant moment from the forces on all of the segments with an equivalent resultant length of the moment arm is determined by taking the integral over the slice height. The forces tend to rotate in the counterclockwise direction, so the moment is negative:
 
 \begin{displaymath}
-\resizeExpression{-\int_{0}^{{\symbf{h}}_{i}}{{K_{\text{c}}}\,γ\,{\symbf{b}}_{i}\,y}\,dy}{\outDefScale}
+\resizeExpression{-\int_{0}^{{\symbf{h}}_{i}}{{K_{\text{c}}}\,γ\,{\symbf{b}}_{i}\,y}\,dy}
 \end{displaymath}
 Solving the definite integral yields:
 
 \begin{displaymath}
-\resizeExpression{-{K_{\text{c}}}\,γ\,{\symbf{b}}_{i}\,\frac{{\symbf{h}}_{i}^{2}}{2}}{\outDefScale}
+\resizeExpression{-{K_{\text{c}}}\,γ\,{\symbf{b}}_{i}\,\frac{{\symbf{h}}_{i}^{2}}{2}}
 \end{displaymath}
 Using \hyperref[GD:weight]{GD:weight} again to express $γ\,{\symbf{b}}_{i}\,{\symbf{h}}_{i}$ as ${\symbf{W}}_{i}$, the moment is:
 
 \begin{displaymath}
-\resizeExpression{-{K_{\text{c}}}\,{\symbf{W}}_{i}\,\frac{{\symbf{h}}_{i}}{2}}{\outDefScale}
+\resizeExpression{-{K_{\text{c}}}\,{\symbf{W}}_{i}\,\frac{{\symbf{h}}_{i}}{2}}
 \end{displaymath}
 The surface hydrostatic force acts into the midpoint of the surface of the slice (\hyperref[assumpHFSM]{A:Hydrostatic-Force-Slice-Midpoint}). Thus, the vertical component of the force acts directly towards the point of rotation, and has a moment of zero. The horizontal component of the force tends to rotate in a clockwise direction and the length of the moment arm is the entire height of the slice. Thus, the moment is:
 
 \begin{displaymath}
-\resizeExpression{{\symbf{U}_{\text{g},i}}\,\sin\left({\symbf{β}}_{i}\right)\,{\symbf{h}}_{i}}{\outDefScale}
+\resizeExpression{{\symbf{U}_{\text{g},i}}\,\sin\left({\symbf{β}}_{i}\right)\,{\symbf{h}}_{i}}
 \end{displaymath}
 The external force again acts into the midpoint of the slice surface, so the vertical component does not contribute to the moment, and the length of the moment arm is again the entire height of the slice. The moment is:
 
 \begin{displaymath}
-\resizeExpression{{\symbf{Q}}_{i}\,\sin\left({\symbf{ω}}_{i}\right)\,{\symbf{h}}_{i}}{\outDefScale}
+\resizeExpression{{\symbf{Q}}_{i}\,\sin\left({\symbf{ω}}_{i}\right)\,{\symbf{h}}_{i}}
 \end{displaymath}
 The base hydrostatic force and slice weight both act in the direction of the point of rotation (\hyperref[assumpHFSM]{A:Hydrostatic-Force-Slice-Midpoint}), therefore both have moments of zero. Thus, all of the moments have been determined. The moment equilibrium is then represented by the sum of all moments:
 
 \begin{displaymath}
-\resizeExpression{0=-{\symbf{G}}_{i}\,\left({\symbf{h}_{\text{z},i}}+\frac{{\symbf{b}}_{i}}{2}\,\tan\left({\symbf{α}}_{i}\right)\right)+{\symbf{G}}_{i-1}\,\left({\symbf{h}_{\text{z},i-1}}-\frac{{\symbf{b}}_{i}}{2}\,\tan\left({\symbf{α}}_{i}\right)\right)-{\symbf{H}}_{i}\,\left(\frac{1}{3}\,{\symbf{h}_{\text{z,w},i}}+\frac{{\symbf{b}}_{i}}{2}\,\tan\left({\symbf{α}}_{i}\right)\right)+{\symbf{H}}_{i-1}\,\left(\frac{1}{3}\,{\symbf{h}_{\text{z,w},i-1}}-\frac{{\symbf{b}}_{i}}{2}\,\tan\left({\symbf{α}}_{i}\right)\right)+\frac{{\symbf{b}}_{i}}{2}\,\left({\symbf{X}}_{i}+{\symbf{X}}_{i-1}\right)+\frac{-{K_{\text{c}}}\,{\symbf{W}}_{i}\,{\symbf{h}}_{i}}{2}+{\symbf{U}_{\text{g},i}}\,\sin\left({\symbf{β}}_{i}\right)\,{\symbf{h}}_{i}+{\symbf{Q}}_{i}\,\sin\left({\symbf{ω}}_{i}\right)\,{\symbf{h}}_{i}}{\outDefScale}
+\resizeExpression{0=-{\symbf{G}}_{i}\,\left({\symbf{h}_{\text{z},i}}+\frac{{\symbf{b}}_{i}}{2}\,\tan\left({\symbf{α}}_{i}\right)\right)+{\symbf{G}}_{i-1}\,\left({\symbf{h}_{\text{z},i-1}}-\frac{{\symbf{b}}_{i}}{2}\,\tan\left({\symbf{α}}_{i}\right)\right)-{\symbf{H}}_{i}\,\left(\frac{1}{3}\,{\symbf{h}_{\text{z,w},i}}+\frac{{\symbf{b}}_{i}}{2}\,\tan\left({\symbf{α}}_{i}\right)\right)+{\symbf{H}}_{i-1}\,\left(\frac{1}{3}\,{\symbf{h}_{\text{z,w},i-1}}-\frac{{\symbf{b}}_{i}}{2}\,\tan\left({\symbf{α}}_{i}\right)\right)+\frac{{\symbf{b}}_{i}}{2}\,\left({\symbf{X}}_{i}+{\symbf{X}}_{i-1}\right)+\frac{-{K_{\text{c}}}\,{\symbf{W}}_{i}\,{\symbf{h}}_{i}}{2}+{\symbf{U}_{\text{g},i}}\,\sin\left({\symbf{β}}_{i}\right)\,{\symbf{h}}_{i}+{\symbf{Q}}_{i}\,\sin\left({\symbf{ω}}_{i}\right)\,{\symbf{h}}_{i}}
 \end{displaymath}
 \medskip
 \noindent
@@ -1131,7 +1122,7 @@ Units & ${\text{N}}$
         
 \\ \midrule
 Equation & \begin{displaymath}
-           \resizeExpression{W=V\,γ}{\inDefScale}
+           \resizeExpression{W=V\,γ}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -1157,22 +1148,22 @@ Under the influence of gravity, and assuming a 2D Cartesian coordinate system wi
 \resizeExpression{\symbf{a}\text{(}t\text{)}=\begin{bmatrix}
                                              0\\
                                              \symbf{g}\,\symbf{\hat{j}}
-                                             \end{bmatrix}}{\outDefScale}
+                                             \end{bmatrix}}
 \end{displaymath}
 Since there is only one non-zero vector component, the scalar value $W$ will be used for the weight. In this scenario, Newton's second law of motion from \hyperref[TM:NewtonSecLawMot]{TM:NewtonSecLawMot} can be expressed as:
 
 \begin{displaymath}
-\resizeExpression{W=m\,\symbf{g}}{\outDefScale}
+\resizeExpression{W=m\,\symbf{g}}
 \end{displaymath}
 Mass can be expressed as density multiplied by volume, resulting in:
 
 \begin{displaymath}
-\resizeExpression{W=ρ\,V\,\symbf{g}}{\outDefScale}
+\resizeExpression{W=ρ\,V\,\symbf{g}}
 \end{displaymath}
 Substituting specific weight as the product of density and gravitational acceleration yields:
 
 \begin{displaymath}
-\resizeExpression{W=V\,γ}{\outDefScale}
+\resizeExpression{W=V\,γ}
 \end{displaymath}
 \medskip
 \noindent
@@ -1193,7 +1184,7 @@ Equation & \begin{displaymath}
                                                                            \left({\symbf{y}_{\text{slope},i}}-{\symbf{y}_{\text{slip},i}}+{\symbf{y}_{\text{slope},i-1}}-{\symbf{y}_{\text{slip},i-1}}\right)\,{γ_{\text{sat}}}, & {\symbf{y}_{\text{wt},i}}\gt{}{\symbf{y}_{\text{slope},i}}\lor{}{\symbf{y}_{\text{wt},i-1}}\gt{}{\symbf{y}_{\text{slope},i-1}}\\
                                                                            \left({\symbf{y}_{\text{slope},i}}-{\symbf{y}_{\text{wt},i}}+{\symbf{y}_{\text{slope},i-1}}-{\symbf{y}_{\text{wt},i-1}}\right)\,{γ_{\text{dry}}}+\left({\symbf{y}_{\text{wt},i}}-{\symbf{y}_{\text{slip},i}}+{\symbf{y}_{\text{wt},i-1}}-{\symbf{y}_{\text{slip},i-1}}\right)\,{γ_{\text{sat}}}, & {\symbf{y}_{\text{slope},i}}\geq{}{\symbf{y}_{\text{wt},i}}\geq{}{\symbf{y}_{\text{slip},i}}\land{}{\symbf{y}_{\text{slope},i-1}}\geq{}{\symbf{y}_{\text{wt},i-1}}\geq{}{\symbf{y}_{\text{slip},i-1}}\\
                                                                            \left({\symbf{y}_{\text{slope},i}}-{\symbf{y}_{\text{slip},i}}+{\symbf{y}_{\text{slope},i-1}}-{\symbf{y}_{\text{slip},i-1}}\right)\,{γ_{\text{dry}}}, & {\symbf{y}_{\text{wt},i}}\lt{}{\symbf{y}_{\text{slip},i}}\lor{}{\symbf{y}_{\text{wt},i-1}}\lt{}{\symbf{y}_{\text{slip},i-1}}
-                                                                           \end{cases}}{\inDefScale}
+                                                                           \end{cases}}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -1224,32 +1215,32 @@ RefBy & \hyperref[GD:resShearWO]{GD:resShearWO}, \hyperref[GD:normForcEq]{GD:nor
 For the case where the water table is above the slope surface, the weights come from the weight of the saturated soil. Substituting values for saturated soil into the equation for weight from \hyperref[GD:weight]{GD:weight} yields:
 
 \begin{displaymath}
-\resizeExpression{{\symbf{W}}_{i}={\symbf{V}_{\text{sat},i}}\,{γ_{\text{sat}}}}{\outDefScale}
+\resizeExpression{{\symbf{W}}_{i}={\symbf{V}_{\text{sat},i}}\,{γ_{\text{sat}}}}
 \end{displaymath}
 Due to \hyperref[assumpPSC]{A:Plane-Strain-Conditions}, only two dimensions are considered, so the areas of saturated soil are considered instead of the volumes of saturated soil. Any given slice has a trapezoidal shape. The area of a trapezoid is the average of the lengths of the parallel sides multiplied by the length between the parallel sides. The parallel sides in this case are the interslice edges and the length between them is the width of the slice. Thus, the weights are defined as:
 
 \begin{displaymath}
-\resizeExpression{{\symbf{W}}_{i}={\symbf{b}}_{i}\,\frac{1}{2}\,\left({\symbf{y}_{\text{slope},i}}-{\symbf{y}_{\text{slip},i}}+{\symbf{y}_{\text{slope},i-1}}-{\symbf{y}_{\text{slip},i-1}}\right)\,{γ_{\text{sat}}}}{\outDefScale}
+\resizeExpression{{\symbf{W}}_{i}={\symbf{b}}_{i}\,\frac{1}{2}\,\left({\symbf{y}_{\text{slope},i}}-{\symbf{y}_{\text{slip},i}}+{\symbf{y}_{\text{slope},i-1}}-{\symbf{y}_{\text{slip},i-1}}\right)\,{γ_{\text{sat}}}}
 \end{displaymath}
 For the case where the water table is below the slip surface, the weights come from the weight of the dry soil. Substituting values for dry soil into the equation for weight from \hyperref[GD:weight]{GD:weight} yields:
 
 \begin{displaymath}
-\resizeExpression{{\symbf{W}}_{i}={\symbf{V}_{\text{dry},i}}\,{γ_{\text{dry}}}}{\outDefScale}
+\resizeExpression{{\symbf{W}}_{i}={\symbf{V}_{\text{dry},i}}\,{γ_{\text{dry}}}}
 \end{displaymath}
 \hyperref[assumpPSC]{A:Plane-Strain-Conditions} again allows for two-dimensional analysis so the areas of dry soil are considered instead of the volumes of dry soil. The trapezoidal slice shape is the same as in the previous case, so the weights are defined as:
 
 \begin{displaymath}
-\resizeExpression{{\symbf{W}}_{i}={\symbf{b}}_{i}\,\frac{1}{2}\,\left({\symbf{y}_{\text{slope},i}}-{\symbf{y}_{\text{slip},i}}+{\symbf{y}_{\text{slope},i-1}}-{\symbf{y}_{\text{slip},i-1}}\right)\,{γ_{\text{dry}}}}{\outDefScale}
+\resizeExpression{{\symbf{W}}_{i}={\symbf{b}}_{i}\,\frac{1}{2}\,\left({\symbf{y}_{\text{slope},i}}-{\symbf{y}_{\text{slip},i}}+{\symbf{y}_{\text{slope},i-1}}-{\symbf{y}_{\text{slip},i-1}}\right)\,{γ_{\text{dry}}}}
 \end{displaymath}
 For the case where the water table is between the slope surface and slip surface, the weights are the sums of the weights of the dry portions and weights of the saturated portions of the soil. Substituting values for dry and saturated soil into the equation for weight from \hyperref[GD:weight]{GD:weight} and adding them together yields:
 
 \begin{displaymath}
-\resizeExpression{{\symbf{W}}_{i}={\symbf{V}_{\text{dry},i}}\,{γ_{\text{dry}}}+{\symbf{V}_{\text{sat},i}}\,{γ_{\text{sat}}}}{\outDefScale}
+\resizeExpression{{\symbf{W}}_{i}={\symbf{V}_{\text{dry},i}}\,{γ_{\text{dry}}}+{\symbf{V}_{\text{sat},i}}\,{γ_{\text{sat}}}}
 \end{displaymath}
 \hyperref[assumpPSC]{A:Plane-Strain-Conditions} again allows for two-dimensional analysis so the areas of dry soil and areas of saturated soil are considered instead of the volumes of dry soil and volumes of saturated soil. The water table is assumed to only intersect a slice surface or base at a slice edge (\hyperref[assumpWISE]{A:Water-Intersects-Surface-Edge}, \hyperref[assumpWIBE]{A:Water-Intersects-Base-Edge}), so the dry and saturated portions each have trapezoidal shape. For the dry portion, the parallel sides of the trapezoid are the lengths between the slope surface and water table at the slice edges. For the saturated portion, the parallel sides of the trapezoid are the lengths between the water table and slip surface at the slice edges. Thus, the weights are defined as:
 
 \begin{displaymath}
-\resizeExpression{{\symbf{W}}_{i}={\symbf{b}}_{i}\,\frac{1}{2}\,\left(\left({\symbf{y}_{\text{slope},i}}-{\symbf{y}_{\text{wt},i}}+{\symbf{y}_{\text{slope},i-1}}-{\symbf{y}_{\text{wt},i-1}}\right)\,{γ_{\text{dry}}}+\left({\symbf{y}_{\text{wt},i}}-{\symbf{y}_{\text{slip},i}}+{\symbf{y}_{\text{wt},i-1}}-{\symbf{y}_{\text{slip},i-1}}\right)\,{γ_{\text{sat}}}\right)}{\outDefScale}
+\resizeExpression{{\symbf{W}}_{i}={\symbf{b}}_{i}\,\frac{1}{2}\,\left(\left({\symbf{y}_{\text{slope},i}}-{\symbf{y}_{\text{wt},i}}+{\symbf{y}_{\text{slope},i-1}}-{\symbf{y}_{\text{wt},i-1}}\right)\,{γ_{\text{dry}}}+\left({\symbf{y}_{\text{wt},i}}-{\symbf{y}_{\text{slip},i}}+{\symbf{y}_{\text{wt},i-1}}-{\symbf{y}_{\text{slip},i-1}}\right)\,{γ_{\text{sat}}}\right)}
 \end{displaymath}
 \medskip
 \noindent
@@ -1266,7 +1257,7 @@ Units & ${\text{Pa}}$
         
 \\ \midrule
 Equation & \begin{displaymath}
-           \resizeExpression{p=γ\,h}{\inDefScale}
+           \resizeExpression{p=γ\,h}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -1305,7 +1296,7 @@ Equation & \begin{displaymath}
            \resizeExpression{{\symbf{U}_{\text{b},i}}={\symbf{L}_{b,i}}\,{γ_{w}}\,\frac{1}{2}\,\begin{cases}
                                                                                                {\symbf{y}_{\text{wt},i}}-{\symbf{y}_{\text{slip},i}}+{\symbf{y}_{\text{wt},i-1}}-{\symbf{y}_{\text{slip},i-1}}, & {\symbf{y}_{\text{wt},i}}\gt{}{\symbf{y}_{\text{slip},i}}\lor{}{\symbf{y}_{\text{wt},i-1}}\gt{}{\symbf{y}_{\text{slip},i-1}}\\
                                                                                                0, & {\symbf{y}_{\text{wt},i}}\leq{}{\symbf{y}_{\text{slip},i}}\land{}{\symbf{y}_{\text{wt},i-1}}\leq{}{\symbf{y}_{\text{slip},i-1}}
-                                                                                               \end{cases}}{\inDefScale}
+                                                                                               \end{cases}}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -1334,17 +1325,17 @@ RefBy & \hyperref[GD:resShearWO]{GD:resShearWO}, \hyperref[GD:effNormF]{GD:effNo
 The base hydrostatic forces come from the hydrostatic pressure exerted by the water above the base of each slice. The equation for hydrostatic pressure from \hyperref[GD:hsPressure]{GD:hsPressure} is:
 
 \begin{displaymath}
-\resizeExpression{p=γ\,h}{\outDefScale}
+\resizeExpression{p=γ\,h}
 \end{displaymath}
 The specific weight in this case is the unit weight of water ${γ_{w}}$. The height in this case is the height from the slice base to the water table. This height is measured from the midpoint of the slice because the resultant hydrostatic force is assumed to act at the slice midpoint (\hyperref[assumpHFSM]{A:Hydrostatic-Force-Slice-Midpoint}). The height at the midpoint is the average of the height at slice interface $i$ and the height at slice interface $i-1$:
 
 \begin{displaymath}
-\resizeExpression{\frac{1}{2}\,\left({\symbf{y}_{\text{wt},i}}-{\symbf{y}_{\text{slip},i}}+{\symbf{y}_{\text{wt},i-1}}-{\symbf{y}_{\text{slip},i-1}}\right)}{\outDefScale}
+\resizeExpression{\frac{1}{2}\,\left({\symbf{y}_{\text{wt},i}}-{\symbf{y}_{\text{slip},i}}+{\symbf{y}_{\text{wt},i-1}}-{\symbf{y}_{\text{slip},i-1}}\right)}
 \end{displaymath}
 Due to \hyperref[assumpPSC]{A:Plane-Strain-Conditions}, only two dimensions are considered, so the base hydrostatic forces are expressed as forces per meter. The pressures acting on the slices can thus be converted to base hydrostatic forces by multiplying by the corresponding length of the slice base ${\symbf{L}_{b,i}}$, assuming the water table does not intersect a slice base except at a slice edge (\hyperref[assumpWIBE]{A:Water-Intersects-Base-Edge}). Thus, in the case where the height of the water table is above the height of the slip surface, the base hydrostatic forces are defined as:
 
 \begin{displaymath}
-\resizeExpression{{\symbf{U}_{\text{b},i}}={\symbf{L}_{b,i}}\,{γ_{w}}\,\frac{1}{2}\,\left({\symbf{y}_{\text{wt},i}}-{\symbf{y}_{\text{slip},i}}+{\symbf{y}_{\text{wt},i-1}}-{\symbf{y}_{\text{slip},i-1}}\right)}{\outDefScale}
+\resizeExpression{{\symbf{U}_{\text{b},i}}={\symbf{L}_{b,i}}\,{γ_{w}}\,\frac{1}{2}\,\left({\symbf{y}_{\text{wt},i}}-{\symbf{y}_{\text{slip},i}}+{\symbf{y}_{\text{wt},i-1}}-{\symbf{y}_{\text{slip},i-1}}\right)}
 \end{displaymath}
 This equation is the non-zero case of \hyperref[GD:baseWtrF]{GD:baseWtrF}. The zero case is when the height of the water table is below the height of the slip surface, so there is no hydrostatic force.
 
@@ -1366,7 +1357,7 @@ Equation & \begin{displaymath}
            \resizeExpression{{\symbf{U}_{\text{g},i}}={\symbf{L}_{s,i}}\,{γ_{w}}\,\frac{1}{2}\,\begin{cases}
                                                                                                {\symbf{y}_{\text{wt},i}}-{\symbf{y}_{\text{slope},i}}+{\symbf{y}_{\text{wt},i-1}}-{\symbf{y}_{\text{slope},i-1}}, & {\symbf{y}_{\text{wt},i}}\gt{}{\symbf{y}_{\text{slope},i}}\lor{}{\symbf{y}_{\text{wt},i-1}}\gt{}{\symbf{y}_{\text{slope},i-1}}\\
                                                                                                0, & {\symbf{y}_{\text{wt},i}}\leq{}{\symbf{y}_{\text{slope},i}}\land{}{\symbf{y}_{\text{wt},i-1}}\leq{}{\symbf{y}_{\text{slope},i-1}}
-                                                                                               \end{cases}}{\inDefScale}
+                                                                                               \end{cases}}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -1395,17 +1386,17 @@ RefBy & \hyperref[GD:srfWtrF]{GD:srfWtrF}, \hyperref[GD:resShearWO]{GD:resShearW
 The surface hydrostatic forces come from the hydrostatic pressure exerted by the water above the surface of each slice. The equation for hydrostatic pressure from \hyperref[GD:hsPressure]{GD:hsPressure} is:
 
 \begin{displaymath}
-\resizeExpression{p=γ\,h}{\outDefScale}
+\resizeExpression{p=γ\,h}
 \end{displaymath}
 The specific weight in this case is the unit weight of water ${γ_{w}}$. The height in this case is the height from the slice surface to the water table. This height is measured from the midpoint of the slice because the resultant hydrostatic force is assumed to act at the slice midpoint (\hyperref[assumpHFSM]{A:Hydrostatic-Force-Slice-Midpoint}). The height at the midpoint is the average of the height at slice interface $i$ and the height at slice interface $i-1$:
 
 \begin{displaymath}
-\resizeExpression{\frac{1}{2}\,\left({\symbf{y}_{\text{wt},i}}-{\symbf{y}_{\text{slope},i}}+{\symbf{y}_{\text{wt},i-1}}-{\symbf{y}_{\text{slope},i-1}}\right)}{\outDefScale}
+\resizeExpression{\frac{1}{2}\,\left({\symbf{y}_{\text{wt},i}}-{\symbf{y}_{\text{slope},i}}+{\symbf{y}_{\text{wt},i-1}}-{\symbf{y}_{\text{slope},i-1}}\right)}
 \end{displaymath}
 Due to \hyperref[assumpPSC]{A:Plane-Strain-Conditions}, only two dimensions are considered, so the surface hydrostatic forces are expressed as forces per meter. The pressures acting on the slices can thus be converted to surface hydrostatic forces by multiplying by the corresponding length of the slice surface ${\symbf{L}_{s,i}}$, assuming the water table does not intersect a slice surface except at a slice edge (\hyperref[assumpWISE]{A:Water-Intersects-Surface-Edge}). Thus, in the case where the height of the water table is above the height of the slope surface, the surface hydrostatic forces are defined as:
 
 \begin{displaymath}
-\resizeExpression{{\symbf{U}_{\text{g},i}}={\symbf{L}_{s,i}}\,{γ_{w}}\,\frac{1}{2}\,\left({\symbf{y}_{\text{wt},i}}-{\symbf{y}_{\text{slope},i}}+{\symbf{y}_{\text{wt},i-1}}-{\symbf{y}_{\text{slope},i-1}}\right)}{\outDefScale}
+\resizeExpression{{\symbf{U}_{\text{g},i}}={\symbf{L}_{s,i}}\,{γ_{w}}\,\frac{1}{2}\,\left({\symbf{y}_{\text{wt},i}}-{\symbf{y}_{\text{slope},i}}+{\symbf{y}_{\text{wt},i-1}}-{\symbf{y}_{\text{slope},i-1}}\right)}
 \end{displaymath}
 This equation is the non-zero case of \hyperref[GD:srfWtrF]{GD:srfWtrF}. The zero case is when the height of the water table is below the height of the slope surface, so there is no hydrostatic force.
 
@@ -1435,7 +1426,7 @@ Equation & \begin{displaymath}
                                        \frac{\left({\symbf{y}_{\text{slope},i}}-{\symbf{y}_{\text{slip},i}}\right)^{2}}{2}\,{γ_{w}}+\left({\symbf{y}_{\text{wt},i}}-{\symbf{y}_{\text{slope},i}}\right)^{2}\,{γ_{w}}, & {\symbf{y}_{\text{wt},i}}\geq{}{\symbf{y}_{\text{slope},i}}\\
                                        \frac{\left({\symbf{y}_{\text{wt},i}}-{\symbf{y}_{\text{slip},i}}\right)^{2}}{2}\,{γ_{w}}, & {\symbf{y}_{\text{slope},i}}\gt{}{\symbf{y}_{\text{wt},i}}\land{}{\symbf{y}_{\text{wt},i}}\gt{}{\symbf{y}_{\text{slip},i}}\\
                                        0, & {\symbf{y}_{\text{wt},i}}\leq{}{\symbf{y}_{\text{slip},i}}
-                                       \end{cases}}{\inDefScale}
+                                       \end{cases}}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -1474,7 +1465,7 @@ Units & ${{}^{\circ}}$
         
 \\ \midrule
 Equation & \begin{displaymath}
-           \resizeExpression{\symbf{α}=\arctan\left(\frac{{\symbf{y}_{\text{slip},i}}-{\symbf{y}_{\text{slip},i-1}}}{{\symbf{x}_{\text{slip},i}}-{\symbf{x}_{\text{slip},i-1}}}\right)}{\inDefScale}
+           \resizeExpression{\symbf{α}=\arctan\left(\frac{{\symbf{y}_{\text{slip},i}}-{\symbf{y}_{\text{slip},i-1}}}{{\symbf{x}_{\text{slip},i}}-{\symbf{x}_{\text{slip},i-1}}}\right)}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -1514,7 +1505,7 @@ Units & ${{}^{\circ}}$
         
 \\ \midrule
 Equation & \begin{displaymath}
-           \resizeExpression{\symbf{β}=\arctan\left(\frac{{\symbf{y}_{\text{slope},i}}-{\symbf{y}_{\text{slope},i-1}}}{{\symbf{x}_{\text{slope},i}}-{\symbf{x}_{\text{slope},i-1}}}\right)}{\inDefScale}
+           \resizeExpression{\symbf{β}=\arctan\left(\frac{{\symbf{y}_{\text{slope},i}}-{\symbf{y}_{\text{slope},i-1}}}{{\symbf{x}_{\text{slope},i}}-{\symbf{x}_{\text{slope},i-1}}}\right)}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -1554,7 +1545,7 @@ Units & ${\text{m}}$
         
 \\ \midrule
 Equation & \begin{displaymath}
-           \resizeExpression{\symbf{b}={\symbf{x}_{\text{slip},i}}-{\symbf{x}_{\text{slip},i-1}}}{\inDefScale}
+           \resizeExpression{\symbf{b}={\symbf{x}_{\text{slip},i}}-{\symbf{x}_{\text{slip},i-1}}}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -1590,7 +1581,7 @@ Units & ${\text{m}}$
         
 \\ \midrule
 Equation & \begin{displaymath}
-           \resizeExpression{{\symbf{L}_{b}}={\symbf{b}}_{i}\,\sec\left({\symbf{α}}_{i}\right)}{\inDefScale}
+           \resizeExpression{{\symbf{L}_{b}}={\symbf{b}}_{i}\,\sec\left({\symbf{α}}_{i}\right)}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -1630,7 +1621,7 @@ Units & ${\text{m}}$
         
 \\ \midrule
 Equation & \begin{displaymath}
-           \resizeExpression{{\symbf{L}_{s}}={\symbf{b}}_{i}\,\sec\left({\symbf{β}}_{i}\right)}{\inDefScale}
+           \resizeExpression{{\symbf{L}_{s}}={\symbf{b}}_{i}\,\sec\left({\symbf{β}}_{i}\right)}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -1670,7 +1661,7 @@ Units & ${\text{m}}$
         
 \\ \midrule
 Equation & \begin{displaymath}
-           \resizeExpression{\symbf{h}=\frac{1}{2}\,\left({{\symbf{h}^{\text{R}}}}_{i}+{{\symbf{h}^{\text{L}}}}_{i}\right)}{\inDefScale}
+           \resizeExpression{\symbf{h}=\frac{1}{2}\,\left({{\symbf{h}^{\text{R}}}}_{i}+{{\symbf{h}^{\text{L}}}}_{i}\right)}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -1712,7 +1703,7 @@ Units & ${\text{Pa}}$
         
 \\ \midrule
 Equation & \begin{displaymath}
-           \resizeExpression{σ=\frac{{F_{\text{n}}}}{A}}{\inDefScale}
+           \resizeExpression{σ=\frac{{F_{\text{n}}}}{A}}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -1748,7 +1739,7 @@ Units & ${\text{Pa}}$
         
 \\ \midrule
 Equation & \begin{displaymath}
-           \resizeExpression{τ=\frac{{F_{\text{t}}}}{A}}{\inDefScale}
+           \resizeExpression{τ=\frac{{F_{\text{t}}}}{A}}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -1784,7 +1775,7 @@ Units & $\text{N}\text{m}$
         
 \\ \midrule
 Equation & \begin{displaymath}
-           \resizeExpression{\symbf{τ}=\symbf{r}\times\symbf{F}}{\inDefScale}
+           \resizeExpression{\symbf{τ}=\symbf{r}\times\symbf{F}}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -1826,7 +1817,7 @@ Equation & \begin{displaymath}
            \resizeExpression{\symbf{f}=\begin{cases}
                                        1, & \mathit{const\_f}\\
                                        \sin\left(π\,\frac{{\symbf{x}_{\text{slip},i}}-{\symbf{x}_{\text{slip},0}}}{{\symbf{x}_{\text{slip},n}}-{\symbf{x}_{\text{slip},0}}}\right), & \neg{}\mathit{const\_f}
-                                       \end{cases}}{\inDefScale}
+                                       \end{cases}}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -1865,7 +1856,7 @@ Units & Unitless
         
 \\ \midrule
 Equation & \begin{displaymath}
-           \resizeExpression{\symbf{Φ}=\left(λ\,{\symbf{f}}_{i}\,\cos\left({\symbf{α}}_{i}\right)-\sin\left({\symbf{α}}_{i}\right)\right)\,\tan\left(φ'\right)-\left(λ\,{\symbf{f}}_{i}\,\sin\left({\symbf{α}}_{i}\right)+\cos\left({\symbf{α}}_{i}\right)\right)\,{F_{\text{S}}}}{\inDefScale}
+           \resizeExpression{\symbf{Φ}=\left(λ\,{\symbf{f}}_{i}\,\cos\left({\symbf{α}}_{i}\right)-\sin\left({\symbf{α}}_{i}\right)\right)\,\tan\left(φ'\right)-\left(λ\,{\symbf{f}}_{i}\,\sin\left({\symbf{α}}_{i}\right)+\cos\left({\symbf{α}}_{i}\right)\right)\,{F_{\text{S}}}}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -1908,7 +1899,7 @@ Units & Unitless
         
 \\ \midrule
 Equation & \begin{displaymath}
-           \resizeExpression{\symbf{Ψ}=\frac{\left(λ\,{\symbf{f}}_{i}\,\cos\left({\symbf{α}}_{i}\right)-\sin\left({\symbf{α}}_{i}\right)\right)\,\tan\left(φ'\right)-\left(λ\,{\symbf{f}}_{i}\,\sin\left({\symbf{α}}_{i}\right)+\cos\left({\symbf{α}}_{i}\right)\right)\,{F_{\text{S}}}}{{\symbf{Φ}}_{i-1}}}{\inDefScale}
+           \resizeExpression{\symbf{Ψ}=\frac{\left(λ\,{\symbf{f}}_{i}\,\cos\left({\symbf{α}}_{i}\right)-\sin\left({\symbf{α}}_{i}\right)\right)\,\tan\left(φ'\right)-\left(λ\,{\symbf{f}}_{i}\,\sin\left({\symbf{α}}_{i}\right)+\cos\left({\symbf{α}}_{i}\right)\right)\,{F_{\text{S}}}}{{\symbf{Φ}}_{i-1}}}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -1952,7 +1943,7 @@ Units & ${\text{N}}$
         
 \\ \midrule
 Equation & \begin{displaymath}
-           \resizeExpression{{{\symbf{F}_{\text{x}}}^{\text{G}}}={\symbf{G}}_{i}+{\symbf{G}}_{i-1}}{\inDefScale}
+           \resizeExpression{{{\symbf{F}_{\text{x}}}^{\text{G}}}={\symbf{G}}_{i}+{\symbf{G}}_{i-1}}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -1987,7 +1978,7 @@ Units & ${\text{N}}$
         
 \\ \midrule
 Equation & \begin{displaymath}
-           \resizeExpression{{{\symbf{F}_{\text{x}}}^{\text{H}}}={\symbf{H}}_{i}+{\symbf{H}}_{i-1}}{\inDefScale}
+           \resizeExpression{{{\symbf{F}_{\text{x}}}^{\text{H}}}={\symbf{H}}_{i}+{\symbf{H}}_{i-1}}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -2022,7 +2013,7 @@ Units & ${\text{m}}$
         
 \\ \midrule
 Equation & \begin{displaymath}
-           \resizeExpression{{\symbf{h}^{\text{R}}}={\symbf{y}_{\text{slope},i}}-{\symbf{y}_{\text{slip},i}}}{\inDefScale}
+           \resizeExpression{{\symbf{h}^{\text{R}}}={\symbf{y}_{\text{slope},i}}-{\symbf{y}_{\text{slip},i}}}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -2059,7 +2050,7 @@ Units & ${\text{m}}$
         
 \\ \midrule
 Equation & \begin{displaymath}
-           \resizeExpression{{\symbf{h}^{\text{L}}}={\symbf{y}_{\text{slope},i-1}}-{\symbf{y}_{\text{slip},i-1}}}{\inDefScale}
+           \resizeExpression{{\symbf{h}^{\text{L}}}={\symbf{y}_{\text{slope},i-1}}-{\symbf{y}_{\text{slip},i-1}}}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -2108,7 +2099,7 @@ Input Constraints &
 Output Constraints & 
 \\ \midrule
 Equation & \begin{displaymath}
-           \resizeExpression{{F_{\text{S}}}=\frac{\displaystyle\sum_{i=1}^{n-1}{{\symbf{R}}_{i}\,\displaystyle\prod_{v=i}^{n-1}{{\symbf{Ψ}}_{v}}}+{\symbf{R}}_{n}}{\displaystyle\sum_{i=1}^{n-1}{{\symbf{T}}_{i}\,\displaystyle\prod_{v=i}^{n-1}{{\symbf{Ψ}}_{v}}}+{\symbf{T}}_{n}}}{\inDefScale}
+           \resizeExpression{{F_{\text{S}}}=\frac{\displaystyle\sum_{i=1}^{n-1}{{\symbf{R}}_{i}\,\displaystyle\prod_{v=i}^{n-1}{{\symbf{Ψ}}_{v}}}+{\symbf{R}}_{n}}{\displaystyle\sum_{i=1}^{n-1}{{\symbf{T}}_{i}\,\displaystyle\prod_{v=i}^{n-1}{{\symbf{Ψ}}_{v}}}+{\symbf{T}}_{n}}}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -2138,114 +2129,114 @@ RefBy & \hyperref[IM:intsliceFs]{IM:intsliceFs}, \hyperref[IM:fctSfty]{IM:fctSft
 The mobilized shear force defined in \hyperref[GD:bsShrFEq]{GD:bsShrFEq} can be substituted into the definition of mobilized shear force based on the factor of safety, from \hyperref[GD:mobShr]{GD:mobShr} yielding Equation (1) below:
 
 \begin{displaymath}
-\resizeExpression{\left({\symbf{W}}_{i}-{\symbf{X}}_{i-1}+{\symbf{X}}_{i}+{\symbf{U}_{\text{g},i}}\,\cos\left({\symbf{β}}_{i}\right)+{\symbf{Q}}_{i}\,\cos\left({\symbf{ω}}_{i}\right)\right)\,\sin\left({\symbf{α}}_{i}\right)-\left(-{K_{\text{c}}}\,{\symbf{W}}_{i}-{\symbf{G}}_{i}+{\symbf{G}}_{i-1}-{\symbf{H}}_{i}+{\symbf{H}}_{i-1}+{\symbf{U}_{\text{g},i}}\,\sin\left({\symbf{β}}_{i}\right)+{\symbf{Q}}_{i}\,\sin\left({\symbf{ω}}_{i}\right)\right)\,\cos\left({\symbf{α}}_{i}\right)=\frac{{\symbf{N'}}_{i}\,\tan\left(φ'\right)+c'\,{\symbf{L}_{b,i}}}{{F_{\text{S}}}}}{\outDefScale}
+\resizeExpression{\left({\symbf{W}}_{i}-{\symbf{X}}_{i-1}+{\symbf{X}}_{i}+{\symbf{U}_{\text{g},i}}\,\cos\left({\symbf{β}}_{i}\right)+{\symbf{Q}}_{i}\,\cos\left({\symbf{ω}}_{i}\right)\right)\,\sin\left({\symbf{α}}_{i}\right)-\left(-{K_{\text{c}}}\,{\symbf{W}}_{i}-{\symbf{G}}_{i}+{\symbf{G}}_{i-1}-{\symbf{H}}_{i}+{\symbf{H}}_{i-1}+{\symbf{U}_{\text{g},i}}\,\sin\left({\symbf{β}}_{i}\right)+{\symbf{Q}}_{i}\,\sin\left({\symbf{ω}}_{i}\right)\right)\,\cos\left({\symbf{α}}_{i}\right)=\frac{{\symbf{N'}}_{i}\,\tan\left(φ'\right)+c'\,{\symbf{L}_{b,i}}}{{F_{\text{S}}}}}
 \end{displaymath}
 An expression for the effective normal forces, $\symbf{N'}$, can be derived by substituting the normal forces equilibrium from \hyperref[GD:normForcEq]{GD:normForcEq} into the definition for effective normal forces from \hyperref[GD:resShearWO]{GD:resShearWO}. This results in Equation (2):
 
 \begin{displaymath}
-\resizeExpression{{\symbf{N'}}_{i}=\left({\symbf{W}}_{i}-{\symbf{X}}_{i-1}+{\symbf{X}}_{i}+{\symbf{U}_{\text{g},i}}\,\cos\left({\symbf{β}}_{i}\right)+{\symbf{Q}}_{i}\,\cos\left({\symbf{ω}}_{i}\right)\right)\,\cos\left({\symbf{α}}_{i}\right)+\left(-{K_{\text{c}}}\,{\symbf{W}}_{i}-{\symbf{G}}_{i}+{\symbf{G}}_{i-1}-{\symbf{H}}_{i}+{\symbf{H}}_{i-1}+{\symbf{U}_{\text{g},i}}\,\sin\left({\symbf{β}}_{i}\right)+{\symbf{Q}}_{i}\,\sin\left({\symbf{ω}}_{i}\right)\right)\,\sin\left({\symbf{α}}_{i}\right)-{\symbf{U}_{\text{b},i}}}{\outDefScale}
+\resizeExpression{{\symbf{N'}}_{i}=\left({\symbf{W}}_{i}-{\symbf{X}}_{i-1}+{\symbf{X}}_{i}+{\symbf{U}_{\text{g},i}}\,\cos\left({\symbf{β}}_{i}\right)+{\symbf{Q}}_{i}\,\cos\left({\symbf{ω}}_{i}\right)\right)\,\cos\left({\symbf{α}}_{i}\right)+\left(-{K_{\text{c}}}\,{\symbf{W}}_{i}-{\symbf{G}}_{i}+{\symbf{G}}_{i-1}-{\symbf{H}}_{i}+{\symbf{H}}_{i-1}+{\symbf{U}_{\text{g},i}}\,\sin\left({\symbf{β}}_{i}\right)+{\symbf{Q}}_{i}\,\sin\left({\symbf{ω}}_{i}\right)\right)\,\sin\left({\symbf{α}}_{i}\right)-{\symbf{U}_{\text{b},i}}}
 \end{displaymath}
 Substituting Equation (2) into Equation (1) gives:
 
 \begin{displaymath}
-\resizeExpression{\left({\symbf{W}}_{i}-{\symbf{X}}_{i-1}+{\symbf{X}}_{i}+{\symbf{U}_{\text{g},i}}\,\cos\left({\symbf{β}}_{i}\right)+{\symbf{Q}}_{i}\,\cos\left({\symbf{ω}}_{i}\right)\right)\,\sin\left({\symbf{α}}_{i}\right)-\left(-{K_{\text{c}}}\,{\symbf{W}}_{i}-{\symbf{G}}_{i}+{\symbf{G}}_{i-1}-{\symbf{H}}_{i}+{\symbf{H}}_{i-1}+{\symbf{U}_{\text{g},i}}\,\sin\left({\symbf{β}}_{i}\right)+{\symbf{Q}}_{i}\,\sin\left({\symbf{ω}}_{i}\right)\right)\,\cos\left({\symbf{α}}_{i}\right)=\frac{\left(\left({\symbf{W}}_{i}-{\symbf{X}}_{i-1}+{\symbf{X}}_{i}+{\symbf{U}_{\text{g},i}}\,\cos\left({\symbf{β}}_{i}\right)+{\symbf{Q}}_{i}\,\cos\left({\symbf{ω}}_{i}\right)\right)\,\cos\left({\symbf{α}}_{i}\right)+\left(-{K_{\text{c}}}\,{\symbf{W}}_{i}-{\symbf{G}}_{i}+{\symbf{G}}_{i-1}-{\symbf{H}}_{i}+{\symbf{H}}_{i-1}+{\symbf{U}_{\text{g},i}}\,\sin\left({\symbf{β}}_{i}\right)+{\symbf{Q}}_{i}\,\sin\left({\symbf{ω}}_{i}\right)\right)\,\sin\left({\symbf{α}}_{i}\right)-{\symbf{U}_{\text{b},i}}\right)\,\tan\left(φ'\right)+c'\,{\symbf{L}_{b,i}}}{{F_{\text{S}}}}}{\outDefScale}
+\resizeExpression{\left({\symbf{W}}_{i}-{\symbf{X}}_{i-1}+{\symbf{X}}_{i}+{\symbf{U}_{\text{g},i}}\,\cos\left({\symbf{β}}_{i}\right)+{\symbf{Q}}_{i}\,\cos\left({\symbf{ω}}_{i}\right)\right)\,\sin\left({\symbf{α}}_{i}\right)-\left(-{K_{\text{c}}}\,{\symbf{W}}_{i}-{\symbf{G}}_{i}+{\symbf{G}}_{i-1}-{\symbf{H}}_{i}+{\symbf{H}}_{i-1}+{\symbf{U}_{\text{g},i}}\,\sin\left({\symbf{β}}_{i}\right)+{\symbf{Q}}_{i}\,\sin\left({\symbf{ω}}_{i}\right)\right)\,\cos\left({\symbf{α}}_{i}\right)=\frac{\left(\left({\symbf{W}}_{i}-{\symbf{X}}_{i-1}+{\symbf{X}}_{i}+{\symbf{U}_{\text{g},i}}\,\cos\left({\symbf{β}}_{i}\right)+{\symbf{Q}}_{i}\,\cos\left({\symbf{ω}}_{i}\right)\right)\,\cos\left({\symbf{α}}_{i}\right)+\left(-{K_{\text{c}}}\,{\symbf{W}}_{i}-{\symbf{G}}_{i}+{\symbf{G}}_{i-1}-{\symbf{H}}_{i}+{\symbf{H}}_{i-1}+{\symbf{U}_{\text{g},i}}\,\sin\left({\symbf{β}}_{i}\right)+{\symbf{Q}}_{i}\,\sin\left({\symbf{ω}}_{i}\right)\right)\,\sin\left({\symbf{α}}_{i}\right)-{\symbf{U}_{\text{b},i}}\right)\,\tan\left(φ'\right)+c'\,{\symbf{L}_{b,i}}}{{F_{\text{S}}}}}
 \end{displaymath}
 Since the interslice shear forces $\symbf{X}$ and interslice normal forces $\symbf{G}$ are unknown, they are separated from the other terms as follows:
 
 \begin{displaymath}
-\resizeExpression{\left({\symbf{W}}_{i}+{\symbf{U}_{\text{g},i}}\,\cos\left({\symbf{β}}_{i}\right)+{\symbf{Q}}_{i}\,\cos\left({\symbf{ω}}_{i}\right)\right)\,\sin\left({\symbf{α}}_{i}\right)-\left(-{K_{\text{c}}}\,{\symbf{W}}_{i}-{\symbf{H}}_{i}+{\symbf{H}}_{i-1}+{\symbf{U}_{\text{g},i}}\,\sin\left({\symbf{β}}_{i}\right)+{\symbf{Q}}_{i}\,\sin\left({\symbf{ω}}_{i}\right)\right)\,\cos\left({\symbf{α}}_{i}\right)-\left(-{\symbf{G}}_{i}+{\symbf{G}}_{i-1}\right)\,\cos\left({\symbf{α}}_{i}\right)+\left(-{\symbf{X}}_{i-1}+{\symbf{X}}_{i}\right)\,\sin\left({\symbf{α}}_{i}\right)=\frac{\left(\left({\symbf{W}}_{i}+{\symbf{U}_{\text{g},i}}\,\cos\left({\symbf{β}}_{i}\right)+{\symbf{Q}}_{i}\,\cos\left({\symbf{ω}}_{i}\right)\right)\,\cos\left({\symbf{α}}_{i}\right)+\left(-{K_{\text{c}}}\,{\symbf{W}}_{i}-{\symbf{H}}_{i}+{\symbf{H}}_{i-1}+{\symbf{U}_{\text{g},i}}\,\sin\left({\symbf{β}}_{i}\right)+{\symbf{Q}}_{i}\,\sin\left({\symbf{ω}}_{i}\right)\right)\,\sin\left({\symbf{α}}_{i}\right)+\left(-{\symbf{G}}_{i}+{\symbf{G}}_{i-1}\right)\,\sin\left({\symbf{α}}_{i}\right)+\left(-{\symbf{X}}_{i-1}+{\symbf{X}}_{i}\right)\,\cos\left({\symbf{α}}_{i}\right)-{\symbf{U}_{\text{b},i}}\right)\,\tan\left(φ'\right)+c'\,{\symbf{L}_{b,i}}}{{F_{\text{S}}}}}{\outDefScale}
+\resizeExpression{\left({\symbf{W}}_{i}+{\symbf{U}_{\text{g},i}}\,\cos\left({\symbf{β}}_{i}\right)+{\symbf{Q}}_{i}\,\cos\left({\symbf{ω}}_{i}\right)\right)\,\sin\left({\symbf{α}}_{i}\right)-\left(-{K_{\text{c}}}\,{\symbf{W}}_{i}-{\symbf{H}}_{i}+{\symbf{H}}_{i-1}+{\symbf{U}_{\text{g},i}}\,\sin\left({\symbf{β}}_{i}\right)+{\symbf{Q}}_{i}\,\sin\left({\symbf{ω}}_{i}\right)\right)\,\cos\left({\symbf{α}}_{i}\right)-\left(-{\symbf{G}}_{i}+{\symbf{G}}_{i-1}\right)\,\cos\left({\symbf{α}}_{i}\right)+\left(-{\symbf{X}}_{i-1}+{\symbf{X}}_{i}\right)\,\sin\left({\symbf{α}}_{i}\right)=\frac{\left(\left({\symbf{W}}_{i}+{\symbf{U}_{\text{g},i}}\,\cos\left({\symbf{β}}_{i}\right)+{\symbf{Q}}_{i}\,\cos\left({\symbf{ω}}_{i}\right)\right)\,\cos\left({\symbf{α}}_{i}\right)+\left(-{K_{\text{c}}}\,{\symbf{W}}_{i}-{\symbf{H}}_{i}+{\symbf{H}}_{i-1}+{\symbf{U}_{\text{g},i}}\,\sin\left({\symbf{β}}_{i}\right)+{\symbf{Q}}_{i}\,\sin\left({\symbf{ω}}_{i}\right)\right)\,\sin\left({\symbf{α}}_{i}\right)+\left(-{\symbf{G}}_{i}+{\symbf{G}}_{i-1}\right)\,\sin\left({\symbf{α}}_{i}\right)+\left(-{\symbf{X}}_{i-1}+{\symbf{X}}_{i}\right)\,\cos\left({\symbf{α}}_{i}\right)-{\symbf{U}_{\text{b},i}}\right)\,\tan\left(φ'\right)+c'\,{\symbf{L}_{b,i}}}{{F_{\text{S}}}}}
 \end{displaymath}
 Applying assumptions \hyperref[assumpSF]{A:Seismic-Force} and \hyperref[assumpSL]{A:Surface-Load}, which state that the seismic coefficient and the external forces, respectively, are zero, allows for further simplification as shown below:
 
 \begin{displaymath}
-\resizeExpression{\left({\symbf{W}}_{i}+{\symbf{U}_{\text{g},i}}\,\cos\left({\symbf{β}}_{i}\right)\right)\,\sin\left({\symbf{α}}_{i}\right)-\left(-{\symbf{H}}_{i}+{\symbf{H}}_{i-1}+{\symbf{U}_{\text{g},i}}\,\sin\left({\symbf{β}}_{i}\right)\right)\,\cos\left({\symbf{α}}_{i}\right)-\left(-{\symbf{G}}_{i}+{\symbf{G}}_{i-1}\right)\,\cos\left({\symbf{α}}_{i}\right)+\left(-{\symbf{X}}_{i-1}+{\symbf{X}}_{i}\right)\,\sin\left({\symbf{α}}_{i}\right)=\frac{\left(\left({\symbf{W}}_{i}+{\symbf{U}_{\text{g},i}}\,\cos\left({\symbf{β}}_{i}\right)\right)\,\cos\left({\symbf{α}}_{i}\right)+\left(-{\symbf{H}}_{i}+{\symbf{H}}_{i-1}+{\symbf{U}_{\text{g},i}}\,\sin\left({\symbf{β}}_{i}\right)\right)\,\sin\left({\symbf{α}}_{i}\right)+\left(-{\symbf{G}}_{i}+{\symbf{G}}_{i-1}\right)\,\sin\left({\symbf{α}}_{i}\right)+\left(-{\symbf{X}}_{i-1}+{\symbf{X}}_{i}\right)\,\cos\left({\symbf{α}}_{i}\right)-{\symbf{U}_{\text{b},i}}\right)\,\tan\left(φ'\right)+c'\,{\symbf{L}_{b,i}}}{{F_{\text{S}}}}}{\outDefScale}
+\resizeExpression{\left({\symbf{W}}_{i}+{\symbf{U}_{\text{g},i}}\,\cos\left({\symbf{β}}_{i}\right)\right)\,\sin\left({\symbf{α}}_{i}\right)-\left(-{\symbf{H}}_{i}+{\symbf{H}}_{i-1}+{\symbf{U}_{\text{g},i}}\,\sin\left({\symbf{β}}_{i}\right)\right)\,\cos\left({\symbf{α}}_{i}\right)-\left(-{\symbf{G}}_{i}+{\symbf{G}}_{i-1}\right)\,\cos\left({\symbf{α}}_{i}\right)+\left(-{\symbf{X}}_{i-1}+{\symbf{X}}_{i}\right)\,\sin\left({\symbf{α}}_{i}\right)=\frac{\left(\left({\symbf{W}}_{i}+{\symbf{U}_{\text{g},i}}\,\cos\left({\symbf{β}}_{i}\right)\right)\,\cos\left({\symbf{α}}_{i}\right)+\left(-{\symbf{H}}_{i}+{\symbf{H}}_{i-1}+{\symbf{U}_{\text{g},i}}\,\sin\left({\symbf{β}}_{i}\right)\right)\,\sin\left({\symbf{α}}_{i}\right)+\left(-{\symbf{G}}_{i}+{\symbf{G}}_{i-1}\right)\,\sin\left({\symbf{α}}_{i}\right)+\left(-{\symbf{X}}_{i-1}+{\symbf{X}}_{i}\right)\,\cos\left({\symbf{α}}_{i}\right)-{\symbf{U}_{\text{b},i}}\right)\,\tan\left(φ'\right)+c'\,{\symbf{L}_{b,i}}}{{F_{\text{S}}}}}
 \end{displaymath}
 The definitions of \hyperref[GD:resShearWO]{GD:resShearWO} and \hyperref[GD:mobShearWO]{GD:mobShearWO} are present in this equation, and thus can be replaced by ${\symbf{R}}_{i}$ and ${\symbf{T}}_{i}$, respectively:
 
 \begin{displaymath}
-\resizeExpression{{\symbf{T}}_{i}+\left(-{\symbf{X}}_{i-1}+{\symbf{X}}_{i}\right)\,\sin\left({\symbf{α}}_{i}\right)-\left(-{\symbf{G}}_{i}+{\symbf{G}}_{i-1}\right)\,\cos\left({\symbf{α}}_{i}\right)=\frac{{\symbf{R}}_{i}+\left(\left(-{\symbf{X}}_{i-1}+{\symbf{X}}_{i}\right)\,\cos\left({\symbf{α}}_{i}\right)+\left(-{\symbf{G}}_{i}+{\symbf{G}}_{i-1}\right)\,\sin\left({\symbf{α}}_{i}\right)\right)\,\tan\left(φ'\right)}{{F_{\text{S}}}}}{\outDefScale}
+\resizeExpression{{\symbf{T}}_{i}+\left(-{\symbf{X}}_{i-1}+{\symbf{X}}_{i}\right)\,\sin\left({\symbf{α}}_{i}\right)-\left(-{\symbf{G}}_{i}+{\symbf{G}}_{i-1}\right)\,\cos\left({\symbf{α}}_{i}\right)=\frac{{\symbf{R}}_{i}+\left(\left(-{\symbf{X}}_{i-1}+{\symbf{X}}_{i}\right)\,\cos\left({\symbf{α}}_{i}\right)+\left(-{\symbf{G}}_{i}+{\symbf{G}}_{i-1}\right)\,\sin\left({\symbf{α}}_{i}\right)\right)\,\tan\left(φ'\right)}{{F_{\text{S}}}}}
 \end{displaymath}
 The interslice shear forces $\symbf{X}$ can be expressed in terms of the interslice normal forces $\symbf{G}$ using \hyperref[assumpINSFL]{A:Interslice-Norm-Shear-Forces-Linear} and \hyperref[GD:normShrR]{GD:normShrR}, resulting in:
 
 \begin{displaymath}
-\resizeExpression{{\symbf{T}}_{i}+\left(-λ\,{\symbf{f}}_{i-1}\,{\symbf{G}}_{i-1}+λ\,{\symbf{f}}_{i}\,{\symbf{G}}_{i}\right)\,\sin\left({\symbf{α}}_{i}\right)-\left(-{\symbf{G}}_{i}+{\symbf{G}}_{i-1}\right)\,\cos\left({\symbf{α}}_{i}\right)=\frac{{\symbf{R}}_{i}+\left(\left(-λ\,{\symbf{f}}_{i-1}\,{\symbf{G}}_{i-1}+λ\,{\symbf{f}}_{i}\,{\symbf{G}}_{i}\right)\,\cos\left({\symbf{α}}_{i}\right)+\left(-{\symbf{G}}_{i}+{\symbf{G}}_{i-1}\right)\,\sin\left({\symbf{α}}_{i}\right)\right)\,\tan\left(φ'\right)}{{F_{\text{S}}}}}{\outDefScale}
+\resizeExpression{{\symbf{T}}_{i}+\left(-λ\,{\symbf{f}}_{i-1}\,{\symbf{G}}_{i-1}+λ\,{\symbf{f}}_{i}\,{\symbf{G}}_{i}\right)\,\sin\left({\symbf{α}}_{i}\right)-\left(-{\symbf{G}}_{i}+{\symbf{G}}_{i-1}\right)\,\cos\left({\symbf{α}}_{i}\right)=\frac{{\symbf{R}}_{i}+\left(\left(-λ\,{\symbf{f}}_{i-1}\,{\symbf{G}}_{i-1}+λ\,{\symbf{f}}_{i}\,{\symbf{G}}_{i}\right)\,\cos\left({\symbf{α}}_{i}\right)+\left(-{\symbf{G}}_{i}+{\symbf{G}}_{i-1}\right)\,\sin\left({\symbf{α}}_{i}\right)\right)\,\tan\left(φ'\right)}{{F_{\text{S}}}}}
 \end{displaymath}
 Rearranging yields the following:
 
 \begin{displaymath}
-\resizeExpression{{\symbf{G}}_{i}\,\left(\left(λ\,{\symbf{f}}_{i}\,\cos\left({\symbf{α}}_{i}\right)-\sin\left({\symbf{α}}_{i}\right)\right)\,\tan\left(φ'\right)-\left(λ\,{\symbf{f}}_{i}\,\sin\left({\symbf{α}}_{i}\right)+\cos\left({\symbf{α}}_{i}\right)\right)\,{F_{\text{S}}}\right)={\symbf{G}}_{i-1}\,\left(\left(λ\,{\symbf{f}}_{i-1}\,\cos\left({\symbf{α}}_{i}\right)-\sin\left({\symbf{α}}_{i}\right)\right)\,\tan\left(φ'\right)-\left(λ\,{\symbf{f}}_{i-1}\,\sin\left({\symbf{α}}_{i}\right)+\cos\left({\symbf{α}}_{i}\right)\right)\,{F_{\text{S}}}\right)+{F_{\text{S}}}\,{\symbf{T}}_{i}-{\symbf{R}}_{i}}{\outDefScale}
+\resizeExpression{{\symbf{G}}_{i}\,\left(\left(λ\,{\symbf{f}}_{i}\,\cos\left({\symbf{α}}_{i}\right)-\sin\left({\symbf{α}}_{i}\right)\right)\,\tan\left(φ'\right)-\left(λ\,{\symbf{f}}_{i}\,\sin\left({\symbf{α}}_{i}\right)+\cos\left({\symbf{α}}_{i}\right)\right)\,{F_{\text{S}}}\right)={\symbf{G}}_{i-1}\,\left(\left(λ\,{\symbf{f}}_{i-1}\,\cos\left({\symbf{α}}_{i}\right)-\sin\left({\symbf{α}}_{i}\right)\right)\,\tan\left(φ'\right)-\left(λ\,{\symbf{f}}_{i-1}\,\sin\left({\symbf{α}}_{i}\right)+\cos\left({\symbf{α}}_{i}\right)\right)\,{F_{\text{S}}}\right)+{F_{\text{S}}}\,{\symbf{T}}_{i}-{\symbf{R}}_{i}}
 \end{displaymath}
 The definitions for $\symbf{Φ}$ and $\symbf{Ψ}$ from \hyperref[DD:convertFunc1]{DD:convertFunc1} and \hyperref[DD:convertFunc2]{DD:convertFunc2} simplify the above to Equation (3):
 
 \begin{displaymath}
-\resizeExpression{{\symbf{G}}_{i}\,{\symbf{Φ}}_{i}={\symbf{Ψ}}_{i-1}\,{\symbf{G}}_{i-1}\,{\symbf{Φ}}_{i-1}+{F_{\text{S}}}\,{\symbf{T}}_{i}-{\symbf{R}}_{i}}{\outDefScale}
+\resizeExpression{{\symbf{G}}_{i}\,{\symbf{Φ}}_{i}={\symbf{Ψ}}_{i-1}\,{\symbf{G}}_{i-1}\,{\symbf{Φ}}_{i-1}+{F_{\text{S}}}\,{\symbf{T}}_{i}-{\symbf{R}}_{i}}
 \end{displaymath}
 Versions of Equation (3) instantiated for slices 1 to $n$ are shown below:
 
 \begin{displaymath}
-\resizeExpression{{\symbf{G}}_{1}\,{\symbf{Φ}}_{1}={\symbf{Ψ}}_{0}\,{\symbf{G}}_{0}\,{\symbf{Φ}}_{0}+{F_{\text{S}}}\,{\symbf{T}}_{1}-{\symbf{R}}_{1}}{\outDefScale}
+\resizeExpression{{\symbf{G}}_{1}\,{\symbf{Φ}}_{1}={\symbf{Ψ}}_{0}\,{\symbf{G}}_{0}\,{\symbf{Φ}}_{0}+{F_{\text{S}}}\,{\symbf{T}}_{1}-{\symbf{R}}_{1}}
 \end{displaymath}
 \begin{displaymath}
-\resizeExpression{{\symbf{G}}_{2}\,{\symbf{Φ}}_{2}={\symbf{Ψ}}_{1}\,{\symbf{G}}_{1}\,{\symbf{Φ}}_{1}+{F_{\text{S}}}\,{\symbf{T}}_{2}-{\symbf{R}}_{2}}{\outDefScale}
+\resizeExpression{{\symbf{G}}_{2}\,{\symbf{Φ}}_{2}={\symbf{Ψ}}_{1}\,{\symbf{G}}_{1}\,{\symbf{Φ}}_{1}+{F_{\text{S}}}\,{\symbf{T}}_{2}-{\symbf{R}}_{2}}
 \end{displaymath}
 \begin{displaymath}
-\resizeExpression{{\symbf{G}}_{3}\,{\symbf{Φ}}_{3}={\symbf{Ψ}}_{2}\,{\symbf{G}}_{2}\,{\symbf{Φ}}_{2}+{F_{\text{S}}}\,{\symbf{T}}_{3}-{\symbf{R}}_{3}}{\outDefScale}
+\resizeExpression{{\symbf{G}}_{3}\,{\symbf{Φ}}_{3}={\symbf{Ψ}}_{2}\,{\symbf{G}}_{2}\,{\symbf{Φ}}_{2}+{F_{\text{S}}}\,{\symbf{T}}_{3}-{\symbf{R}}_{3}}
 \end{displaymath}
 ...
 
 \begin{displaymath}
-\resizeExpression{{\symbf{G}}_{n-2}\,{\symbf{Φ}}_{n-2}={\symbf{Ψ}}_{n-3}\,{\symbf{G}}_{n-3}\,{\symbf{Φ}}_{n-3}+{F_{\text{S}}}\,{\symbf{T}}_{n-2}-{\symbf{R}}_{n-2}}{\outDefScale}
+\resizeExpression{{\symbf{G}}_{n-2}\,{\symbf{Φ}}_{n-2}={\symbf{Ψ}}_{n-3}\,{\symbf{G}}_{n-3}\,{\symbf{Φ}}_{n-3}+{F_{\text{S}}}\,{\symbf{T}}_{n-2}-{\symbf{R}}_{n-2}}
 \end{displaymath}
 \begin{displaymath}
-\resizeExpression{{\symbf{G}}_{n-1}\,{\symbf{Φ}}_{n-1}={\symbf{Ψ}}_{n-2}\,{\symbf{G}}_{n-2}\,{\symbf{Φ}}_{n-2}+{F_{\text{S}}}\,{\symbf{T}}_{n-1}-{\symbf{R}}_{n-1}}{\outDefScale}
+\resizeExpression{{\symbf{G}}_{n-1}\,{\symbf{Φ}}_{n-1}={\symbf{Ψ}}_{n-2}\,{\symbf{G}}_{n-2}\,{\symbf{Φ}}_{n-2}+{F_{\text{S}}}\,{\symbf{T}}_{n-1}-{\symbf{R}}_{n-1}}
 \end{displaymath}
 \begin{displaymath}
-\resizeExpression{{\symbf{G}}_{n}\,{\symbf{Φ}}_{n}={\symbf{Ψ}}_{n-1}\,{\symbf{G}}_{n-1}\,{\symbf{Φ}}_{n-1}+{F_{\text{S}}}\,{\symbf{T}}_{n}-{\symbf{R}}_{n}}{\outDefScale}
+\resizeExpression{{\symbf{G}}_{n}\,{\symbf{Φ}}_{n}={\symbf{Ψ}}_{n-1}\,{\symbf{G}}_{n-1}\,{\symbf{Φ}}_{n-1}+{F_{\text{S}}}\,{\symbf{T}}_{n}-{\symbf{R}}_{n}}
 \end{displaymath}
 Applying \hyperref[assumpES]{A:Edge-Slices}, which says that ${\symbf{G}}_{0}$ and ${\symbf{G}}_{n}$ are zero, results in the following special cases: Equation (8) for the first slice:
 
 \begin{displaymath}
-\resizeExpression{{\symbf{G}}_{1}\,{\symbf{Φ}}_{1}={F_{\text{S}}}\,{\symbf{T}}_{1}-{\symbf{R}}_{1}}{\outDefScale}
+\resizeExpression{{\symbf{G}}_{1}\,{\symbf{Φ}}_{1}={F_{\text{S}}}\,{\symbf{T}}_{1}-{\symbf{R}}_{1}}
 \end{displaymath}
 and Equation (9) for the $n$th slice:
 
 \begin{displaymath}
-\resizeExpression{-\left(\frac{{F_{\text{S}}}\,{\symbf{T}}_{n}-{\symbf{R}}_{n}}{{\symbf{Ψ}}_{n-1}}\right)={\symbf{G}}_{n-1}\,{\symbf{Φ}}_{n-1}}{\outDefScale}
+\resizeExpression{-\left(\frac{{F_{\text{S}}}\,{\symbf{T}}_{n}-{\symbf{R}}_{n}}{{\symbf{Ψ}}_{n-1}}\right)={\symbf{G}}_{n-1}\,{\symbf{Φ}}_{n-1}}
 \end{displaymath}
 Substituting Equation (8) into Equation (4) yields Equation (10):
 
 \begin{displaymath}
-\resizeExpression{{\symbf{G}}_{2}\,{\symbf{Φ}}_{2}={\symbf{Ψ}}_{1}\,\left({F_{\text{S}}}\,{\symbf{T}}_{1}-{\symbf{R}}_{1}\right)+{F_{\text{S}}}\,{\symbf{T}}_{2}-{\symbf{R}}_{2}}{\outDefScale}
+\resizeExpression{{\symbf{G}}_{2}\,{\symbf{Φ}}_{2}={\symbf{Ψ}}_{1}\,\left({F_{\text{S}}}\,{\symbf{T}}_{1}-{\symbf{R}}_{1}\right)+{F_{\text{S}}}\,{\symbf{T}}_{2}-{\symbf{R}}_{2}}
 \end{displaymath}
 which can be substituted into Equation (5) to get Equation (11):
 
 \begin{displaymath}
-\resizeExpression{{\symbf{G}}_{3}\,{\symbf{Φ}}_{3}={\symbf{Ψ}}_{2}\,\left({\symbf{Ψ}}_{1}\,\left({F_{\text{S}}}\,{\symbf{T}}_{1}-{\symbf{R}}_{1}\right)+{F_{\text{S}}}\,{\symbf{T}}_{2}-{\symbf{R}}_{2}\right)+{F_{\text{S}}}\,{\symbf{T}}_{3}-{\symbf{R}}_{3}}{\outDefScale}
+\resizeExpression{{\symbf{G}}_{3}\,{\symbf{Φ}}_{3}={\symbf{Ψ}}_{2}\,\left({\symbf{Ψ}}_{1}\,\left({F_{\text{S}}}\,{\symbf{T}}_{1}-{\symbf{R}}_{1}\right)+{F_{\text{S}}}\,{\symbf{T}}_{2}-{\symbf{R}}_{2}\right)+{F_{\text{S}}}\,{\symbf{T}}_{3}-{\symbf{R}}_{3}}
 \end{displaymath}
 and so on until Equation (12) is obtained from Equation (7):
 
 \begin{displaymath}
-\resizeExpression{{\symbf{G}}_{n-1}\,{\symbf{Φ}}_{n-1}={\symbf{Ψ}}_{n-2}\,\left({\symbf{Ψ}}_{n-3}\,\left({\symbf{Ψ}}_{1}\,\left({F_{\text{S}}}\,{\symbf{T}}_{1}-{\symbf{R}}_{1}\right)+{F_{\text{S}}}\,{\symbf{T}}_{2}-{\symbf{R}}_{2}\right)+{F_{\text{S}}}\,{\symbf{T}}_{n-2}-{\symbf{R}}_{n-2}\right)+{F_{\text{S}}}\,{\symbf{T}}_{n-1}-{\symbf{R}}_{n-1}}{\outDefScale}
+\resizeExpression{{\symbf{G}}_{n-1}\,{\symbf{Φ}}_{n-1}={\symbf{Ψ}}_{n-2}\,\left({\symbf{Ψ}}_{n-3}\,\left({\symbf{Ψ}}_{1}\,\left({F_{\text{S}}}\,{\symbf{T}}_{1}-{\symbf{R}}_{1}\right)+{F_{\text{S}}}\,{\symbf{T}}_{2}-{\symbf{R}}_{2}\right)+{F_{\text{S}}}\,{\symbf{T}}_{n-2}-{\symbf{R}}_{n-2}\right)+{F_{\text{S}}}\,{\symbf{T}}_{n-1}-{\symbf{R}}_{n-1}}
 \end{displaymath}
 Equation (9) can then be substituted into the left-hand side of Equation (12), resulting in:
 
 \begin{displaymath}
-\resizeExpression{-\left(\frac{{F_{\text{S}}}\,{\symbf{T}}_{n}-{\symbf{R}}_{n}}{{\symbf{Ψ}}_{n-1}}\right)={\symbf{Ψ}}_{n-2}\,\left({\symbf{Ψ}}_{n-3}\,\left({\symbf{Ψ}}_{1}\,\left({F_{\text{S}}}\,{\symbf{T}}_{1}-{\symbf{R}}_{1}\right)+{F_{\text{S}}}\,{\symbf{T}}_{2}-{\symbf{R}}_{2}\right)+{F_{\text{S}}}\,{\symbf{T}}_{n-2}-{\symbf{R}}_{n-2}\right)+{F_{\text{S}}}\,{\symbf{T}}_{n-1}-{\symbf{R}}_{n-1}}{\outDefScale}
+\resizeExpression{-\left(\frac{{F_{\text{S}}}\,{\symbf{T}}_{n}-{\symbf{R}}_{n}}{{\symbf{Ψ}}_{n-1}}\right)={\symbf{Ψ}}_{n-2}\,\left({\symbf{Ψ}}_{n-3}\,\left({\symbf{Ψ}}_{1}\,\left({F_{\text{S}}}\,{\symbf{T}}_{1}-{\symbf{R}}_{1}\right)+{F_{\text{S}}}\,{\symbf{T}}_{2}-{\symbf{R}}_{2}\right)+{F_{\text{S}}}\,{\symbf{T}}_{n-2}-{\symbf{R}}_{n-2}\right)+{F_{\text{S}}}\,{\symbf{T}}_{n-1}-{\symbf{R}}_{n-1}}
 \end{displaymath}
 This can be rearranged by multiplying both sides by ${\symbf{Ψ}}_{n-1}$ and then distributing the multiplication of each $\symbf{Ψ}$ over addition to obtain:
 
 \begin{displaymath}
-\resizeExpression{-\left({F_{\text{S}}}\,{\symbf{T}}_{n}-{\symbf{R}}_{n}\right)={\symbf{Ψ}}_{n-1}\,{\symbf{Ψ}}_{n-2}\,{\symbf{Ψ}}_{1}\,\left({F_{\text{S}}}\,{\symbf{T}}_{1}-{\symbf{R}}_{1}\right)+{\symbf{Ψ}}_{n-1}\,{\symbf{Ψ}}_{n-2}\,{\symbf{Ψ}}_{2}\,\left({F_{\text{S}}}\,{\symbf{T}}_{2}-{\symbf{R}}_{2}\right)+{\symbf{Ψ}}_{n-1}\,\left({F_{\text{S}}}\,{\symbf{T}}_{n-1}-{\symbf{R}}_{n-1}\right)}{\outDefScale}
+\resizeExpression{-\left({F_{\text{S}}}\,{\symbf{T}}_{n}-{\symbf{R}}_{n}\right)={\symbf{Ψ}}_{n-1}\,{\symbf{Ψ}}_{n-2}\,{\symbf{Ψ}}_{1}\,\left({F_{\text{S}}}\,{\symbf{T}}_{1}-{\symbf{R}}_{1}\right)+{\symbf{Ψ}}_{n-1}\,{\symbf{Ψ}}_{n-2}\,{\symbf{Ψ}}_{2}\,\left({F_{\text{S}}}\,{\symbf{T}}_{2}-{\symbf{R}}_{2}\right)+{\symbf{Ψ}}_{n-1}\,\left({F_{\text{S}}}\,{\symbf{T}}_{n-1}-{\symbf{R}}_{n-1}\right)}
 \end{displaymath}
 The multiplication of the $\symbf{Ψ}$ terms can be further distributed over the subtractions, resulting in the equation having terms that each either contain an $\symbf{R}$ or a $\symbf{T}$. The equation can then be rearranged so terms containing an $\symbf{R}$ are on one side of the equality, and terms containing a $\symbf{T}$ are on the other. The multiplication by the factor of safety is common to all of the $\symbf{T}$ terms, and thus can be factored out, resulting in:
 
 \begin{displaymath}
-\resizeExpression{{F_{\text{S}}}\,\left({\symbf{Ψ}}_{n-1}\,{\symbf{Ψ}}_{n-2}\,{\symbf{Ψ}}_{1}\,{\symbf{T}}_{1}+{\symbf{Ψ}}_{n-1}\,{\symbf{Ψ}}_{n-2}\,{\symbf{Ψ}}_{2}\,{\symbf{T}}_{2}+{\symbf{Ψ}}_{n-1}\,{\symbf{T}}_{n-1}+{\symbf{T}}_{n}\right)={\symbf{Ψ}}_{n-1}\,{\symbf{Ψ}}_{n-2}\,{\symbf{Ψ}}_{1}\,{\symbf{R}}_{1}+{\symbf{Ψ}}_{n-1}\,{\symbf{Ψ}}_{n-2}\,{\symbf{Ψ}}_{2}\,{\symbf{R}}_{2}+{\symbf{Ψ}}_{n-1}\,{\symbf{R}}_{n-1}+{\symbf{R}}_{n}}{\outDefScale}
+\resizeExpression{{F_{\text{S}}}\,\left({\symbf{Ψ}}_{n-1}\,{\symbf{Ψ}}_{n-2}\,{\symbf{Ψ}}_{1}\,{\symbf{T}}_{1}+{\symbf{Ψ}}_{n-1}\,{\symbf{Ψ}}_{n-2}\,{\symbf{Ψ}}_{2}\,{\symbf{T}}_{2}+{\symbf{Ψ}}_{n-1}\,{\symbf{T}}_{n-1}+{\symbf{T}}_{n}\right)={\symbf{Ψ}}_{n-1}\,{\symbf{Ψ}}_{n-2}\,{\symbf{Ψ}}_{1}\,{\symbf{R}}_{1}+{\symbf{Ψ}}_{n-1}\,{\symbf{Ψ}}_{n-2}\,{\symbf{Ψ}}_{2}\,{\symbf{R}}_{2}+{\symbf{Ψ}}_{n-1}\,{\symbf{R}}_{n-1}+{\symbf{R}}_{n}}
 \end{displaymath}
 Isolating the factor of safety on the left-hand side and using compact notation for the products and sums yields Equation (13), which can also be seen in \hyperref[IM:fctSfty]{IM:fctSfty}:
 
 \begin{displaymath}
-\resizeExpression{{F_{\text{S}}}=\frac{\displaystyle\sum_{i=1}^{n-1}{{\symbf{R}}_{i}\,\displaystyle\prod_{v=i}^{n-1}{{\symbf{Ψ}}_{v}}}+{\symbf{R}}_{n}}{\displaystyle\sum_{i=1}^{n-1}{{\symbf{T}}_{i}\,\displaystyle\prod_{v=i}^{n-1}{{\symbf{Ψ}}_{v}}}+{\symbf{T}}_{n}}}{\outDefScale}
+\resizeExpression{{F_{\text{S}}}=\frac{\displaystyle\sum_{i=1}^{n-1}{{\symbf{R}}_{i}\,\displaystyle\prod_{v=i}^{n-1}{{\symbf{Ψ}}_{v}}}+{\symbf{R}}_{n}}{\displaystyle\sum_{i=1}^{n-1}{{\symbf{T}}_{i}\,\displaystyle\prod_{v=i}^{n-1}{{\symbf{Ψ}}_{v}}}+{\symbf{T}}_{n}}}
 \end{displaymath}
 ${F_{\text{S}}}$ depends on the unknowns $λ$ (\hyperref[IM:nrmShrFor]{IM:nrmShrFor}) and $\symbf{G}$ (\hyperref[IM:intsliceFs]{IM:intsliceFs}).
 
@@ -2271,7 +2262,7 @@ Input Constraints &
 Output Constraints & 
 \\ \midrule
 Equation & \begin{displaymath}
-           \resizeExpression{λ=\frac{\displaystyle\sum_{i=1}^{n}{{\symbf{C}_{\text{num},i}}}}{\displaystyle\sum_{i=1}^{n}{{\symbf{C}_{\text{den},i}}}}}{\inDefScale}
+           \resizeExpression{λ=\frac{\displaystyle\sum_{i=1}^{n}{{\symbf{C}_{\text{num},i}}}}{\displaystyle\sum_{i=1}^{n}{{\symbf{C}_{\text{den},i}}}}}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -2298,22 +2289,22 @@ RefBy & \hyperref[IM:nrmShrForNum]{IM:nrmShrForNum}, \hyperref[IM:nrmShrForDen]{
 From the moment equilibrium of \hyperref[GD:momentEql]{GD:momentEql} with the primary assumption for the Morgenstern-Price method of \hyperref[assumpINSFL]{A:Interslice-Norm-Shear-Forces-Linear} and associated definition \hyperref[GD:normShrR]{GD:normShrR}, Equation (14) can be derived:
 
 \begin{displaymath}
-\resizeExpression{0=-{\symbf{G}}_{i}\,\left({\symbf{h}_{\text{z},i}}+\frac{{\symbf{b}}_{i}}{2}\,\tan\left({\symbf{α}}_{i}\right)\right)+{\symbf{G}}_{i-1}\,\left({\symbf{h}_{\text{z},i-1}}-\frac{{\symbf{b}}_{i}}{2}\,\tan\left({\symbf{α}}_{i}\right)\right)-{\symbf{H}}_{i}\,\left(\frac{1}{3}\,{\symbf{h}_{\text{z,w},i}}+\frac{{\symbf{b}}_{i}}{2}\,\tan\left({\symbf{α}}_{i}\right)\right)+{\symbf{H}}_{i-1}\,\left(\frac{1}{3}\,{\symbf{h}_{\text{z,w},i-1}}-\frac{{\symbf{b}}_{i}}{2}\,\tan\left({\symbf{α}}_{i}\right)\right)+λ\,\frac{{\symbf{b}}_{i}}{2}\,\left({\symbf{G}}_{i}\,{\symbf{f}}_{i}+{\symbf{G}}_{i-1}\,{\symbf{f}}_{i-1}\right)+\frac{-{K_{\text{c}}}\,{\symbf{W}}_{i}\,{\symbf{h}}_{i}}{2}+{\symbf{U}_{\text{g},i}}\,\sin\left({\symbf{β}}_{i}\right)\,{\symbf{h}}_{i}+{\symbf{Q}}_{i}\,\sin\left({\symbf{ω}}_{i}\right)\,{\symbf{h}}_{i}}{\outDefScale}
+\resizeExpression{0=-{\symbf{G}}_{i}\,\left({\symbf{h}_{\text{z},i}}+\frac{{\symbf{b}}_{i}}{2}\,\tan\left({\symbf{α}}_{i}\right)\right)+{\symbf{G}}_{i-1}\,\left({\symbf{h}_{\text{z},i-1}}-\frac{{\symbf{b}}_{i}}{2}\,\tan\left({\symbf{α}}_{i}\right)\right)-{\symbf{H}}_{i}\,\left(\frac{1}{3}\,{\symbf{h}_{\text{z,w},i}}+\frac{{\symbf{b}}_{i}}{2}\,\tan\left({\symbf{α}}_{i}\right)\right)+{\symbf{H}}_{i-1}\,\left(\frac{1}{3}\,{\symbf{h}_{\text{z,w},i-1}}-\frac{{\symbf{b}}_{i}}{2}\,\tan\left({\symbf{α}}_{i}\right)\right)+λ\,\frac{{\symbf{b}}_{i}}{2}\,\left({\symbf{G}}_{i}\,{\symbf{f}}_{i}+{\symbf{G}}_{i-1}\,{\symbf{f}}_{i-1}\right)+\frac{-{K_{\text{c}}}\,{\symbf{W}}_{i}\,{\symbf{h}}_{i}}{2}+{\symbf{U}_{\text{g},i}}\,\sin\left({\symbf{β}}_{i}\right)\,{\symbf{h}}_{i}+{\symbf{Q}}_{i}\,\sin\left({\symbf{ω}}_{i}\right)\,{\symbf{h}}_{i}}
 \end{displaymath}
 Rearranging the equation in terms of $λ$ leads to Equation (15):
 
 \begin{displaymath}
-\resizeExpression{λ=\frac{-{\symbf{G}}_{i}\,\left({\symbf{h}_{\text{z},i}}+\frac{{\symbf{b}}_{i}}{2}\,\tan\left({\symbf{α}}_{i}\right)\right)+{\symbf{G}}_{i-1}\,\left({\symbf{h}_{\text{z},i-1}}-\frac{{\symbf{b}}_{i}}{2}\,\tan\left({\symbf{α}}_{i}\right)\right)-{\symbf{H}}_{i}\,\left(\frac{1}{3}\,{\symbf{h}_{\text{z,w},i}}+\frac{{\symbf{b}}_{i}}{2}\,\tan\left({\symbf{α}}_{i}\right)\right)+{\symbf{H}}_{i-1}\,\left(\frac{1}{3}\,{\symbf{h}_{\text{z,w},i-1}}-\frac{{\symbf{b}}_{i}}{2}\,\tan\left({\symbf{α}}_{i}\right)\right)+\frac{-{K_{\text{c}}}\,{\symbf{W}}_{i}\,{\symbf{h}}_{i}}{2}+{\symbf{U}_{\text{g},i}}\,\sin\left({\symbf{β}}_{i}\right)\,{\symbf{h}}_{i}+{\symbf{Q}}_{i}\,\sin\left({\symbf{ω}}_{i}\right)\,{\symbf{h}}_{i}}{-\frac{{\symbf{b}}_{i}}{2}\,\left({\symbf{G}}_{i}\,{\symbf{f}}_{i}+{\symbf{G}}_{i-1}\,{\symbf{f}}_{i-1}\right)}}{\outDefScale}
+\resizeExpression{λ=\frac{-{\symbf{G}}_{i}\,\left({\symbf{h}_{\text{z},i}}+\frac{{\symbf{b}}_{i}}{2}\,\tan\left({\symbf{α}}_{i}\right)\right)+{\symbf{G}}_{i-1}\,\left({\symbf{h}_{\text{z},i-1}}-\frac{{\symbf{b}}_{i}}{2}\,\tan\left({\symbf{α}}_{i}\right)\right)-{\symbf{H}}_{i}\,\left(\frac{1}{3}\,{\symbf{h}_{\text{z,w},i}}+\frac{{\symbf{b}}_{i}}{2}\,\tan\left({\symbf{α}}_{i}\right)\right)+{\symbf{H}}_{i-1}\,\left(\frac{1}{3}\,{\symbf{h}_{\text{z,w},i-1}}-\frac{{\symbf{b}}_{i}}{2}\,\tan\left({\symbf{α}}_{i}\right)\right)+\frac{-{K_{\text{c}}}\,{\symbf{W}}_{i}\,{\symbf{h}}_{i}}{2}+{\symbf{U}_{\text{g},i}}\,\sin\left({\symbf{β}}_{i}\right)\,{\symbf{h}}_{i}+{\symbf{Q}}_{i}\,\sin\left({\symbf{ω}}_{i}\right)\,{\symbf{h}}_{i}}{-\frac{{\symbf{b}}_{i}}{2}\,\left({\symbf{G}}_{i}\,{\symbf{f}}_{i}+{\symbf{G}}_{i-1}\,{\symbf{f}}_{i-1}\right)}}
 \end{displaymath}
 This equation can be simplified by applying assumptions \hyperref[assumpSF]{A:Seismic-Force} and \hyperref[assumpSL]{A:Surface-Load}, which state that the seismic and external forces, respectively, are zero:
 
 \begin{displaymath}
-\resizeExpression{λ=\frac{-{\symbf{G}}_{i}\,\left({\symbf{h}_{\text{z},i}}+\frac{{\symbf{b}}_{i}}{2}\,\tan\left({\symbf{α}}_{i}\right)\right)+{\symbf{G}}_{i-1}\,\left({\symbf{h}_{\text{z},i-1}}-\frac{{\symbf{b}}_{i}}{2}\,\tan\left({\symbf{α}}_{i}\right)\right)-{\symbf{H}}_{i}\,\left(\frac{1}{3}\,{\symbf{h}_{\text{z,w},i}}+\frac{{\symbf{b}}_{i}}{2}\,\tan\left({\symbf{α}}_{i}\right)\right)+{\symbf{H}}_{i-1}\,\left(\frac{1}{3}\,{\symbf{h}_{\text{z,w},i-1}}-\frac{{\symbf{b}}_{i}}{2}\,\tan\left({\symbf{α}}_{i}\right)\right)+{\symbf{U}_{\text{g},i}}\,\sin\left({\symbf{β}}_{i}\right)\,{\symbf{h}}_{i}}{-\frac{{\symbf{b}}_{i}}{2}\,\left({\symbf{G}}_{i}\,{\symbf{f}}_{i}+{\symbf{G}}_{i-1}\,{\symbf{f}}_{i-1}\right)}}{\outDefScale}
+\resizeExpression{λ=\frac{-{\symbf{G}}_{i}\,\left({\symbf{h}_{\text{z},i}}+\frac{{\symbf{b}}_{i}}{2}\,\tan\left({\symbf{α}}_{i}\right)\right)+{\symbf{G}}_{i-1}\,\left({\symbf{h}_{\text{z},i-1}}-\frac{{\symbf{b}}_{i}}{2}\,\tan\left({\symbf{α}}_{i}\right)\right)-{\symbf{H}}_{i}\,\left(\frac{1}{3}\,{\symbf{h}_{\text{z,w},i}}+\frac{{\symbf{b}}_{i}}{2}\,\tan\left({\symbf{α}}_{i}\right)\right)+{\symbf{H}}_{i-1}\,\left(\frac{1}{3}\,{\symbf{h}_{\text{z,w},i-1}}-\frac{{\symbf{b}}_{i}}{2}\,\tan\left({\symbf{α}}_{i}\right)\right)+{\symbf{U}_{\text{g},i}}\,\sin\left({\symbf{β}}_{i}\right)\,{\symbf{h}}_{i}}{-\frac{{\symbf{b}}_{i}}{2}\,\left({\symbf{G}}_{i}\,{\symbf{f}}_{i}+{\symbf{G}}_{i-1}\,{\symbf{f}}_{i-1}\right)}}
 \end{displaymath}
 Taking the summation of all slices, and applying \hyperref[assumpES]{A:Edge-Slices} to set ${\symbf{G}}_{0}$, ${\symbf{G}}_{n}$, ${\symbf{H}}_{0}$, and ${\symbf{H}}_{n}$ equal to zero, a general equation for the proportionality constant $λ$ is developed in Equation (16), which combines \hyperref[IM:nrmShrFor]{IM:nrmShrFor}, \hyperref[IM:nrmShrForNum]{IM:nrmShrForNum}, and \hyperref[IM:nrmShrForDen]{IM:nrmShrForDen}:
 
 \begin{displaymath}
-\resizeExpression{λ=\frac{\displaystyle\sum_{i=1}^{n}{{\symbf{b}}_{i}\,\left({{\symbf{F}_{\text{x}}}^{\text{G}}}+{{\symbf{F}_{\text{x}}}^{\text{H}}}\right)\,\tan\left({\symbf{α}}_{i}\right)+{\symbf{h}}_{i}\,-2\,{\symbf{U}_{\text{g},i}}\,\sin\left({\symbf{β}}_{i}\right)}}{\displaystyle\sum_{i=1}^{n}{{\symbf{b}}_{i}\,\left({\symbf{G}}_{i}\,{\symbf{f}}_{i}+{\symbf{G}}_{i-1}\,{\symbf{f}}_{i-1}\right)}}}{\outDefScale}
+\resizeExpression{λ=\frac{\displaystyle\sum_{i=1}^{n}{{\symbf{b}}_{i}\,\left({{\symbf{F}_{\text{x}}}^{\text{G}}}+{{\symbf{F}_{\text{x}}}^{\text{H}}}\right)\,\tan\left({\symbf{α}}_{i}\right)+{\symbf{h}}_{i}\,-2\,{\symbf{U}_{\text{g},i}}\,\sin\left({\symbf{β}}_{i}\right)}}{\displaystyle\sum_{i=1}^{n}{{\symbf{b}}_{i}\,\left({\symbf{G}}_{i}\,{\symbf{f}}_{i}+{\symbf{G}}_{i-1}\,{\symbf{f}}_{i-1}\right)}}}
 \end{displaymath}
 Equation (16) for $λ$ is a function of the unknown interslice normal forces $\symbf{G}$ (\hyperref[IM:intsliceFs]{IM:intsliceFs}) which itself depends on the unknown factor of safety ${F_{\text{S}}}$ (\hyperref[IM:fctSfty]{IM:fctSfty}).
 
@@ -2343,7 +2334,7 @@ Equation & \begin{displaymath}
                                                         {\symbf{b}}_{1}\,\left({\symbf{G}}_{1}+{\symbf{H}}_{1}\right)\,\tan\left({\symbf{α}}_{1}\right), & i=1\\
                                                         {\symbf{b}}_{i}\,\left({{\symbf{F}_{\text{x}}}^{\text{G}}}+{{\symbf{F}_{\text{x}}}^{\text{H}}}\right)\,\tan\left({\symbf{α}}_{i}\right)+\symbf{h}\,-2\,{\symbf{U}_{\text{g},i}}\,\sin\left({\symbf{β}}_{i}\right), & 2\leq{}i\leq{}n-1\\
                                                         {\symbf{b}}_{n}\,\left({\symbf{G}}_{n-1}+{\symbf{H}}_{n-1}\right)\,\tan\left({\symbf{α}}_{n-1}\right), & i=n
-                                                        \end{cases}}{\inDefScale}
+                                                        \end{cases}}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -2403,7 +2394,7 @@ Equation & \begin{displaymath}
                                                         {\symbf{b}}_{1}\,{\symbf{f}}_{1}\,{\symbf{G}}_{1}, & i=1\\
                                                         {\symbf{b}}_{i}\,\left({\symbf{f}}_{i}\,{\symbf{G}}_{i}+{\symbf{f}}_{i-1}\,{\symbf{G}}_{i-1}\right), & 2\leq{}i\leq{}n-1\\
                                                         {\symbf{b}}_{n}\,{\symbf{G}}_{n-1}\,{\symbf{f}}_{n-1}, & i=n
-                                                        \end{cases}}{\inDefScale}
+                                                        \end{cases}}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -2457,7 +2448,7 @@ Equation & \begin{displaymath}
                                              \frac{{F_{\text{S}}}\,{\symbf{T}}_{1}-{\symbf{R}}_{1}}{{\symbf{Φ}}_{1}}, & i=1\\
                                              \frac{{\symbf{Ψ}}_{i-1}\,{\symbf{G}}_{i-1}+{F_{\text{S}}}\,{\symbf{T}}_{i}-{\symbf{R}}_{i}}{{\symbf{Φ}}_{i}}, & 2\leq{}i\leq{}n-1\\
                                              0, & i=0\lor{}i=n
-                                             \end{cases}}{\inDefScale}
+                                             \end{cases}}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -2488,12 +2479,12 @@ RefBy & \hyperref[IM:intsliceFs]{IM:intsliceFs}, \hyperref[IM:fctSfty]{IM:fctSft
 This derivation is identical to the derivation for \hyperref[IM:fctSfty]{IM:fctSfty} up until Equation (3) shown again below:
 
 \begin{displaymath}
-\resizeExpression{{\symbf{G}}_{i}\,{\symbf{Φ}}_{i}={\symbf{Ψ}}_{i-1}\,{\symbf{G}}_{i-1}\,{\symbf{Φ}}_{i-1}+{F_{\text{S}}}\,{\symbf{T}}_{i}-{\symbf{R}}_{i}}{\outDefScale}
+\resizeExpression{{\symbf{G}}_{i}\,{\symbf{Φ}}_{i}={\symbf{Ψ}}_{i-1}\,{\symbf{G}}_{i-1}\,{\symbf{Φ}}_{i-1}+{F_{\text{S}}}\,{\symbf{T}}_{i}-{\symbf{R}}_{i}}
 \end{displaymath}
 A simple rearrangement of Equation (3) leads to Equation (17), also seen in \hyperref[IM:intsliceFs]{IM:intsliceFs}:
 
 \begin{displaymath}
-\resizeExpression{{\symbf{G}}_{i}=\frac{{\symbf{Ψ}}_{i-1}\,{\symbf{G}}_{i-1}+{F_{\text{S}}}\,{\symbf{T}}_{i}-{\symbf{R}}_{i}}{{\symbf{Φ}}_{i}}}{\outDefScale}
+\resizeExpression{{\symbf{G}}_{i}=\frac{{\symbf{Ψ}}_{i-1}\,{\symbf{G}}_{i-1}+{F_{\text{S}}}\,{\symbf{T}}_{i}-{\symbf{R}}_{i}}{{\symbf{Φ}}_{i}}}
 \end{displaymath}
 The cases shown in \hyperref[IM:intsliceFs]{IM:intsliceFs} for when $i=0$, $i=1$, or $i=n$ are derived by applying \hyperref[assumpES]{A:Edge-Slices}, which says that ${\symbf{G}}_{0}$ and ${\symbf{G}}_{n}$ are zero, to Equation (17). $\symbf{G}$ depends on the unknowns ${F_{\text{S}}}$ (\hyperref[IM:fctSfty]{IM:fctSfty}) and $λ$ (\hyperref[IM:nrmShrFor]{IM:nrmShrFor}).
 
@@ -2519,7 +2510,7 @@ Input Constraints &
 Output Constraints & 
 \\ \midrule
 Equation & \begin{displaymath}
-           \resizeExpression{{\symbf{x}_{\text{slope}}}={\symbf{y}_{\text{slope}}}}{\inDefScale}
+           \resizeExpression{{\symbf{x}_{\text{slope}}}={\symbf{y}_{\text{slope}}}}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}

--- a/code/stable/swhs/SRS/PDF/SWHS_SRS.tex
+++ b/code/stable/swhs/SRS/PDF/SWHS_SRS.tex
@@ -15,8 +15,7 @@
 \usepackage{svg}
 \usepackage{float}
 \usepackage{enumitem}
-\usepackage{graphicx}
-\usepackage{calc}
+\usepackage{adjustbox}
 \usepackage{filecontents}
 \usepackage[backend=bibtex]{biblatex}
 \usepackage{url}
@@ -25,16 +24,8 @@
 \newcommand{\lt}{\ensuremath <}
 \newlist{symbDescription}{description}{1}
 \setlist[symbDescription]{noitemsep, topsep=0pt, parsep=0pt, partopsep=0pt}
-\def\inDefScale{0.8}
-\def\outDefScale{1.0}
-\newsavebox{\mybox}
-\newcommand{\resizeExpression}[2]{
-  \savebox{\mybox}{$#1$}
-  \ifdim\wd\mybox>#2\linewidth
-    \resizebox{#2\textwidth}{!}{\usebox{\mybox}}
-  \else
-    \usebox{\mybox}
-  \fi
+\newcommand{\resizeExpression}[1]{
+  \adjustbox{max width=\linewidth}{$#1$}
 }
 \bibliography{bibfile}
 \title{Software Requirements Specification for Solar Water Heating Systems Incorporating PCM}
@@ -460,7 +451,7 @@ Label & Conservation of thermal energy
         
 \\ \midrule
 Equation & \begin{displaymath}
-           \resizeExpression{-∇\cdot{}\symbf{q}+g=ρ\,C\,\frac{\,\partial{}T}{\,\partial{}t}}{\inDefScale}
+           \resizeExpression{-∇\cdot{}\symbf{q}+g=ρ\,C\,\frac{\,\partial{}T}{\,\partial{}t}}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -503,7 +494,7 @@ Equation & \begin{displaymath}
                                {C^{\text{S}}}\,m\,ΔT, & T\lt{}{T_{\text{melt}}}\\
                                {C^{\text{L}}}\,m\,ΔT, & {T_{\text{melt}}}\lt{}T\lt{}{T_{\text{boil}}}\\
                                {C^{\text{V}}}\,m\,ΔT, & {T_{\text{boil}}}\lt{}T
-                               \end{cases}}{\inDefScale}
+                               \end{cases}}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -542,7 +533,7 @@ Label & Latent heat energy
         
 \\ \midrule
 Equation & \begin{displaymath}
-           \resizeExpression{Q\left(t\right)=\int_{0}^{t}{\frac{\,dQ\left(τ\right)}{\,dτ}}\,dτ}{\inDefScale}
+           \resizeExpression{Q\left(t\right)=\int_{0}^{t}{\frac{\,dQ\left(τ\right)}{\,dτ}}\,dτ}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -583,7 +574,7 @@ Label & Newton's law of cooling
         
 \\ \midrule
 Equation & \begin{displaymath}
-           \resizeExpression{q\left(t\right)=h\,ΔT\left(t\right)}{\inDefScale}
+           \resizeExpression{q\left(t\right)=h\,ΔT\left(t\right)}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -625,7 +616,7 @@ Label & Simplified rate of change of temperature
         
 \\ \midrule
 Equation & \begin{displaymath}
-           \resizeExpression{m\,C\,\frac{\,dT}{\,dt}={q_{\text{in}}}\,{A_{\text{in}}}-{q_{\text{out}}}\,{A_{\text{out}}}+g\,V}{\inDefScale}
+           \resizeExpression{m\,C\,\frac{\,dT}{\,dt}={q_{\text{in}}}\,{A_{\text{in}}}-{q_{\text{out}}}\,{A_{\text{out}}}+g\,V}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -655,27 +646,27 @@ RefBy & \hyperref[GD:rocTempSimp]{GD:rocTempSimp}, \hyperref[IM:eBalanceOnWtr]{I
 Integrating \hyperref[TM:consThermE]{TM:consThermE} over a volume ($V$), we have:
 
 \begin{displaymath}
-\resizeExpression{-\int_{V}{∇\cdot{}\symbf{q}}\,dV+\int_{V}{g}\,dV=\int_{V}{ρ\,C\,\frac{\,\partial{}T}{\,\partial{}t}}\,dV}{\outDefScale}
+\resizeExpression{-\int_{V}{∇\cdot{}\symbf{q}}\,dV+\int_{V}{g}\,dV=\int_{V}{ρ\,C\,\frac{\,\partial{}T}{\,\partial{}t}}\,dV}
 \end{displaymath}
 Applying Gauss's Divergence Theorem to the first term over the surface $S$ of the volume, with $\symbf{q}$ as the thermal flux vector for the surface and $\symbf{\hat{n}}$ as a unit outward normal vector for a surface:
 
 \begin{displaymath}
-\resizeExpression{-\int_{S}{\symbf{q}\cdot{}\symbf{\hat{n}}}\,dS+\int_{V}{g}\,dV=\int_{V}{ρ\,C\,\frac{\,\partial{}T}{\,\partial{}t}}\,dV}{\outDefScale}
+\resizeExpression{-\int_{S}{\symbf{q}\cdot{}\symbf{\hat{n}}}\,dS+\int_{V}{g}\,dV=\int_{V}{ρ\,C\,\frac{\,\partial{}T}{\,\partial{}t}}\,dV}
 \end{displaymath}
 We consider an arbitrary volume. The volumetric heat generation per unit volume is assumed constant. Then Equation (1) can be written as:
 
 \begin{displaymath}
-\resizeExpression{{q_{\text{in}}}\,{A_{\text{in}}}-{q_{\text{out}}}\,{A_{\text{out}}}+g\,V=\int_{V}{ρ\,C\,\frac{\,\partial{}T}{\,\partial{}t}}\,dV}{\outDefScale}
+\resizeExpression{{q_{\text{in}}}\,{A_{\text{in}}}-{q_{\text{out}}}\,{A_{\text{out}}}+g\,V=\int_{V}{ρ\,C\,\frac{\,\partial{}T}{\,\partial{}t}}\,dV}
 \end{displaymath}
 Where ${q_{\text{in}}}$, ${q_{\text{out}}}$, ${A_{\text{in}}}$, and ${A_{\text{out}}}$ are explained in \hyperref[GD:rocTempSimp]{GD:rocTempSimp}. The integral over the surface could be simplified because the thermal flux is assumed constant over ${A_{\text{in}}}$ and ${A_{\text{out}}}$ and $0$ on all other surfaces. Outward flux is considered positive. Assuming $ρ$, $C$, and $T$ are constant over the volume, which is true in our case by \hyperref[assumpCWTAT]{A:Constant-Water-Temp-Across-Tank}, \hyperref[assumpTPCAV]{A:Temp-PCM-Constant-Across-Volume}, \hyperref[assumpDWPCoV]{A:Density-Water-PCM-Constant-over-Volume}, and \hyperref[assumpSHECov]{A:Specific-Heat-Energy-Constant-over-Volume}, we have:
 
 \begin{displaymath}
-\resizeExpression{ρ\,C\,V\,\frac{\,dT}{\,dt}={q_{\text{in}}}\,{A_{\text{in}}}-{q_{\text{out}}}\,{A_{\text{out}}}+g\,V}{\outDefScale}
+\resizeExpression{ρ\,C\,V\,\frac{\,dT}{\,dt}={q_{\text{in}}}\,{A_{\text{in}}}-{q_{\text{out}}}\,{A_{\text{out}}}+g\,V}
 \end{displaymath}
 Using the fact that $ρ$=$m$/$V$, Equation (2) can be written as:
 
 \begin{displaymath}
-\resizeExpression{m\,C\,\frac{\,dT}{\,dt}={q_{\text{in}}}\,{A_{\text{in}}}-{q_{\text{out}}}\,{A_{\text{out}}}+g\,V}{\outDefScale}
+\resizeExpression{m\,C\,\frac{\,dT}{\,dt}={q_{\text{in}}}\,{A_{\text{in}}}-{q_{\text{out}}}\,{A_{\text{out}}}+g\,V}
 \end{displaymath}
 \medskip
 \noindent
@@ -692,7 +683,7 @@ Units & $\frac{\text{W}}{\text{m}^{2}}$
         
 \\ \midrule
 Equation & \begin{displaymath}
-           \resizeExpression{{q_{\text{C}}}={h_{\text{C}}}\,\left({T_{\text{C}}}-{T_{\text{W}}}\left(t\right)\right)}{\inDefScale}
+           \resizeExpression{{q_{\text{C}}}={h_{\text{C}}}\,\left({T_{\text{C}}}-{T_{\text{W}}}\left(t\right)\right)}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -732,7 +723,7 @@ Units & $\frac{\text{W}}{\text{m}^{2}}$
         
 \\ \midrule
 Equation & \begin{displaymath}
-           \resizeExpression{{q_{\text{P}}}={h_{\text{P}}}\,\left({T_{\text{W}}}\left(t\right)-{T_{\text{P}}}\left(t\right)\right)}{\inDefScale}
+           \resizeExpression{{q_{\text{P}}}={h_{\text{P}}}\,\left({T_{\text{W}}}\left(t\right)-{T_{\text{P}}}\left(t\right)\right)}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -777,7 +768,7 @@ Units & ${\text{kg}}$
         
 \\ \midrule
 Equation & \begin{displaymath}
-           \resizeExpression{{m_{\text{W}}}={V_{\text{W}}}\,{ρ_{\text{W}}}}{\inDefScale}
+           \resizeExpression{{m_{\text{W}}}={V_{\text{W}}}\,{ρ_{\text{W}}}}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -813,7 +804,7 @@ Units & ${\text{m}^{3}}$
         
 \\ \midrule
 Equation & \begin{displaymath}
-           \resizeExpression{{V_{\text{W}}}={V_{\text{tank}}}-{V_{\text{P}}}}{\inDefScale}
+           \resizeExpression{{V_{\text{W}}}={V_{\text{tank}}}-{V_{\text{P}}}}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -852,7 +843,7 @@ Units & ${\text{m}^{3}}$
         
 \\ \midrule
 Equation & \begin{displaymath}
-           \resizeExpression{{V_{\text{tank}}}=π\,\left(\frac{D}{2}\right)^{2}\,L}{\inDefScale}
+           \resizeExpression{{V_{\text{tank}}}=π\,\left(\frac{D}{2}\right)^{2}\,L}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -889,7 +880,7 @@ Units & ${\text{s}}$
         
 \\ \midrule
 Equation & \begin{displaymath}
-           \resizeExpression{{τ_{\text{W}}}=\frac{{m_{\text{W}}}\,{C_{\text{W}}}}{{h_{\text{C}}}\,{A_{\text{C}}}}}{\inDefScale}
+           \resizeExpression{{τ_{\text{W}}}=\frac{{m_{\text{W}}}\,{C_{\text{W}}}}{{h_{\text{C}}}\,{A_{\text{C}}}}}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -927,7 +918,7 @@ Units & Unitless
         
 \\ \midrule
 Equation & \begin{displaymath}
-           \resizeExpression{η=\frac{{h_{\text{P}}}\,{A_{\text{P}}}}{{h_{\text{C}}}\,{A_{\text{C}}}}}{\inDefScale}
+           \resizeExpression{η=\frac{{h_{\text{P}}}\,{A_{\text{P}}}}{{h_{\text{C}}}\,{A_{\text{C}}}}}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -965,7 +956,7 @@ Units & ${\text{s}}$
         
 \\ \midrule
 Equation & \begin{displaymath}
-           \resizeExpression{{{τ_{\text{P}}}^{\text{S}}}=\frac{{m_{\text{P}}}\,{{C_{\text{P}}}^{\text{S}}}}{{h_{\text{P}}}\,{A_{\text{P}}}}}{\inDefScale}
+           \resizeExpression{{{τ_{\text{P}}}^{\text{S}}}=\frac{{m_{\text{P}}}\,{{C_{\text{P}}}^{\text{S}}}}{{h_{\text{P}}}\,{A_{\text{P}}}}}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -1003,7 +994,7 @@ Units & ${\text{s}}$
         
 \\ \midrule
 Equation & \begin{displaymath}
-           \resizeExpression{{{τ_{\text{P}}}^{\text{L}}}=\frac{{m_{\text{P}}}\,{{C_{\text{P}}}^{\text{L}}}}{{h_{\text{P}}}\,{A_{\text{P}}}}}{\inDefScale}
+           \resizeExpression{{{τ_{\text{P}}}^{\text{L}}}=\frac{{m_{\text{P}}}\,{{C_{\text{P}}}^{\text{L}}}}{{h_{\text{P}}}\,{A_{\text{P}}}}}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -1041,7 +1032,7 @@ Units & $\frac{\text{J}}{\text{kg}}$
         
 \\ \midrule
 Equation & \begin{displaymath}
-           \resizeExpression{{H_{\text{f}}}=\frac{Q}{m}}{\inDefScale}
+           \resizeExpression{{H_{\text{f}}}=\frac{Q}{m}}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -1080,7 +1071,7 @@ Units & Unitless
         
 \\ \midrule
 Equation & \begin{displaymath}
-           \resizeExpression{ϕ=\frac{{Q_{\text{P}}}}{{H_{\text{f}}}\,{m_{\text{P}}}}}{\inDefScale}
+           \resizeExpression{ϕ=\frac{{Q_{\text{P}}}}{{H_{\text{f}}}\,{m_{\text{P}}}}}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -1122,7 +1113,7 @@ Units & Unitless
         
 \\ \midrule
 Equation & \begin{displaymath}
-           \resizeExpression{\mathit{AR}=\frac{D}{L}}{\inDefScale}
+           \resizeExpression{\mathit{AR}=\frac{D}{L}}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -1163,13 +1154,13 @@ Output & ${T_{\text{W}}}$
          
 \\ \midrule
 Input Constraints & \begin{displaymath}
-                    \resizeExpression{{T_{\text{C}}}\gt{}{T_{\text{init}}}}{\inDefScale}
+                    \resizeExpression{{T_{\text{C}}}\gt{}{T_{\text{init}}}}
                     \end{displaymath}
 \\ \midrule
 Output Constraints & 
 \\ \midrule
 Equation & \begin{displaymath}
-           \resizeExpression{\frac{\,d{T_{\text{W}}}}{\,dt}=\frac{1}{{τ_{\text{W}}}}\,\left({T_{\text{C}}}-{T_{\text{W}}}\left(t\right)+η\,\left({T_{\text{P}}}\left(t\right)-{T_{\text{W}}}\left(t\right)\right)\right)}{\inDefScale}
+           \resizeExpression{\frac{\,d{T_{\text{W}}}}{\,dt}=\frac{1}{{τ_{\text{W}}}}\,\left({T_{\text{C}}}-{T_{\text{W}}}\left(t\right)+η\,\left({T_{\text{P}}}\left(t\right)-{T_{\text{W}}}\left(t\right)\right)\right)}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -1208,37 +1199,37 @@ RefBy & \hyperref[IM:eBalanceOnWtr]{IM:eBalanceOnWtr}, \hyperref[IM:eBalanceOnPC
 To find the rate of change of ${T_{\text{W}}}$, we look at the energy balance on water. The volume being considered is the volume of water in the tank ${V_{\text{W}}}$, which has mass ${m_{\text{W}}}$ and specific heat capacity, ${C_{\text{W}}}$. Heat transfer occurs in the water from the heating coil as ${q_{\text{C}}}$ (\hyperref[GD:htFluxWaterFromCoil]{GD:htFluxWaterFromCoil}) and from the water into the PCM as ${q_{\text{P}}}$ (\hyperref[GD:htFluxPCMFromWater]{GD:htFluxPCMFromWater}), over areas ${A_{\text{C}}}$ and ${A_{\text{P}}}$, respectively. The thermal flux is constant over ${A_{\text{C}}}$, since the temperature of the heating coil is assumed to not vary along its length (\hyperref[assumpTHCCoL]{A:Temp-Heating-Coil-Constant-over-Length}), and the thermal flux is constant over ${A_{\text{P}}}$, since the temperature of the PCM is the same throughout its volume (\hyperref[assumpTPCAV]{A:Temp-PCM-Constant-Across-Volume}) and the water is fully mixed (\hyperref[assumpCWTAT]{A:Constant-Water-Temp-Across-Tank}). No heat transfer occurs to the outside of the tank, since it has been assumed to be perfectly insulated (\hyperref[assumpPIT]{A:Perfect-Insulation-Tank}). Since the assumption is made that no internal heat is generated (\hyperref[assumpNIHGBWP]{A:No-Internal-Heat-Generation-By-Water-PCM}), $g=0$. Therefore, the equation for \hyperref[GD:rocTempSimp]{GD:rocTempSimp} can be written as:
 
 \begin{displaymath}
-\resizeExpression{{m_{\text{W}}}\,{C_{\text{W}}}\,\frac{\,d{T_{\text{W}}}}{\,dt}={q_{\text{C}}}\,{A_{\text{C}}}-{q_{\text{P}}}\,{A_{\text{P}}}}{\outDefScale}
+\resizeExpression{{m_{\text{W}}}\,{C_{\text{W}}}\,\frac{\,d{T_{\text{W}}}}{\,dt}={q_{\text{C}}}\,{A_{\text{C}}}-{q_{\text{P}}}\,{A_{\text{P}}}}
 \end{displaymath}
 Using \hyperref[GD:htFluxWaterFromCoil]{GD:htFluxWaterFromCoil} for ${q_{\text{C}}}$ and \hyperref[GD:htFluxPCMFromWater]{GD:htFluxPCMFromWater} for ${q_{\text{P}}}$, this can be written as:
 
 \begin{displaymath}
-\resizeExpression{{m_{\text{W}}}\,{C_{\text{W}}}\,\frac{\,d{T_{\text{W}}}}{\,dt}={h_{\text{C}}}\,{A_{\text{C}}}\,\left({T_{\text{C}}}-{T_{\text{W}}}\right)-{h_{\text{P}}}\,{A_{\text{P}}}\,\left({T_{\text{W}}}-{T_{\text{P}}}\right)}{\outDefScale}
+\resizeExpression{{m_{\text{W}}}\,{C_{\text{W}}}\,\frac{\,d{T_{\text{W}}}}{\,dt}={h_{\text{C}}}\,{A_{\text{C}}}\,\left({T_{\text{C}}}-{T_{\text{W}}}\right)-{h_{\text{P}}}\,{A_{\text{P}}}\,\left({T_{\text{W}}}-{T_{\text{P}}}\right)}
 \end{displaymath}
 Dividing Equation (2) by ${m_{\text{W}}}\,{C_{\text{W}}}$, we obtain:
 
 \begin{displaymath}
-\resizeExpression{\frac{\,d{T_{\text{W}}}}{\,dt}=\frac{{h_{\text{C}}}\,{A_{\text{C}}}}{{m_{\text{W}}}\,{C_{\text{W}}}}\,\left({T_{\text{C}}}-{T_{\text{W}}}\right)-\frac{{h_{\text{P}}}\,{A_{\text{P}}}}{{m_{\text{W}}}\,{C_{\text{W}}}}\,\left({T_{\text{W}}}-{T_{\text{P}}}\right)}{\outDefScale}
+\resizeExpression{\frac{\,d{T_{\text{W}}}}{\,dt}=\frac{{h_{\text{C}}}\,{A_{\text{C}}}}{{m_{\text{W}}}\,{C_{\text{W}}}}\,\left({T_{\text{C}}}-{T_{\text{W}}}\right)-\frac{{h_{\text{P}}}\,{A_{\text{P}}}}{{m_{\text{W}}}\,{C_{\text{W}}}}\,\left({T_{\text{W}}}-{T_{\text{P}}}\right)}
 \end{displaymath}
 Factoring the negative sign out of the second term of the right-hand side (RHS) of Equation (3) and multiplying it by ${h_{\text{C}}}$ ${A_{\text{C}}}$ / ${h_{\text{C}}}$ ${A_{\text{C}}}$ yields:
 
 \begin{displaymath}
-\resizeExpression{\frac{\,d{T_{\text{W}}}}{\,dt}=\frac{{h_{\text{C}}}\,{A_{\text{C}}}}{{m_{\text{W}}}\,{C_{\text{W}}}}\,\left({T_{\text{C}}}-{T_{\text{W}}}\right)+\frac{{h_{\text{C}}}\,{A_{\text{C}}}}{{h_{\text{C}}}\,{A_{\text{C}}}}\,\frac{{h_{\text{P}}}\,{A_{\text{P}}}}{{m_{\text{W}}}\,{C_{\text{W}}}}\,\left({T_{\text{P}}}-{T_{\text{W}}}\right)}{\outDefScale}
+\resizeExpression{\frac{\,d{T_{\text{W}}}}{\,dt}=\frac{{h_{\text{C}}}\,{A_{\text{C}}}}{{m_{\text{W}}}\,{C_{\text{W}}}}\,\left({T_{\text{C}}}-{T_{\text{W}}}\right)+\frac{{h_{\text{C}}}\,{A_{\text{C}}}}{{h_{\text{C}}}\,{A_{\text{C}}}}\,\frac{{h_{\text{P}}}\,{A_{\text{P}}}}{{m_{\text{W}}}\,{C_{\text{W}}}}\,\left({T_{\text{P}}}-{T_{\text{W}}}\right)}
 \end{displaymath}
 Rearranging this equation gives us:
 
 \begin{displaymath}
-\resizeExpression{\frac{\,d{T_{\text{W}}}}{\,dt}=\frac{{h_{\text{C}}}\,{A_{\text{C}}}}{{m_{\text{W}}}\,{C_{\text{W}}}}\,\left({T_{\text{C}}}-{T_{\text{W}}}\right)+\frac{{h_{\text{P}}}\,{A_{\text{P}}}}{{h_{\text{C}}}\,{A_{\text{C}}}}\,\frac{{h_{\text{C}}}\,{A_{\text{C}}}}{{m_{\text{W}}}\,{C_{\text{W}}}}\,\left({T_{\text{P}}}-{T_{\text{W}}}\right)}{\outDefScale}
+\resizeExpression{\frac{\,d{T_{\text{W}}}}{\,dt}=\frac{{h_{\text{C}}}\,{A_{\text{C}}}}{{m_{\text{W}}}\,{C_{\text{W}}}}\,\left({T_{\text{C}}}-{T_{\text{W}}}\right)+\frac{{h_{\text{P}}}\,{A_{\text{P}}}}{{h_{\text{C}}}\,{A_{\text{C}}}}\,\frac{{h_{\text{C}}}\,{A_{\text{C}}}}{{m_{\text{W}}}\,{C_{\text{W}}}}\,\left({T_{\text{P}}}-{T_{\text{W}}}\right)}
 \end{displaymath}
 By substituting ${τ_{\text{W}}}$ (from \hyperref[DD:balanceDecayRate]{DD:balanceDecayRate}) and $η$ (from \hyperref[DD:balanceDecayTime]{DD:balanceDecayTime}), this can be written as:
 
 \begin{displaymath}
-\resizeExpression{\frac{\,d{T_{\text{W}}}}{\,dt}=\frac{1}{{τ_{\text{W}}}}\,\left({T_{\text{C}}}-{T_{\text{W}}}\right)+\frac{η}{{τ_{\text{W}}}}\,\left({T_{\text{P}}}-{T_{\text{W}}}\right)}{\outDefScale}
+\resizeExpression{\frac{\,d{T_{\text{W}}}}{\,dt}=\frac{1}{{τ_{\text{W}}}}\,\left({T_{\text{C}}}-{T_{\text{W}}}\right)+\frac{η}{{τ_{\text{W}}}}\,\left({T_{\text{P}}}-{T_{\text{W}}}\right)}
 \end{displaymath}
 Finally, factoring out $\frac{1}{{τ_{\text{W}}}}$, we are left with the governing ODE for \hyperref[IM:eBalanceOnWtr]{IM:eBalanceOnWtr}:
 
 \begin{displaymath}
-\resizeExpression{\frac{\,d{T_{\text{W}}}}{\,dt}=\frac{1}{{τ_{\text{W}}}}\,\left({T_{\text{C}}}-{T_{\text{W}}}+η\,\left({T_{\text{P}}}-{T_{\text{W}}}\right)\right)}{\outDefScale}
+\resizeExpression{\frac{\,d{T_{\text{W}}}}{\,dt}=\frac{1}{{τ_{\text{W}}}}\,\left({T_{\text{C}}}-{T_{\text{W}}}+η\,\left({T_{\text{P}}}-{T_{\text{W}}}\right)\right)}
 \end{displaymath}
 \medskip
 \noindent
@@ -1258,7 +1249,7 @@ Output & ${T_{\text{P}}}$
          
 \\ \midrule
 Input Constraints & \begin{displaymath}
-                    \resizeExpression{{{T_{\text{melt}}}^{\text{P}}}\gt{}{T_{\text{init}}}}{\inDefScale}
+                    \resizeExpression{{{T_{\text{melt}}}^{\text{P}}}\gt{}{T_{\text{init}}}}
                     \end{displaymath}
 \\ \midrule
 Output Constraints & 
@@ -1268,7 +1259,7 @@ Equation & \begin{displaymath}
                                                             \frac{1}{{{τ_{\text{P}}}^{\text{S}}}}\,\left({T_{\text{W}}}\left(t\right)-{T_{\text{P}}}\left(t\right)\right), & {T_{\text{P}}}\lt{}{{T_{\text{melt}}}^{\text{P}}}\\
                                                             \frac{1}{{{τ_{\text{P}}}^{\text{L}}}}\,\left({T_{\text{W}}}\left(t\right)-{T_{\text{P}}}\left(t\right)\right), & {T_{\text{P}}}\gt{}{{T_{\text{melt}}}^{\text{P}}}\\
                                                             0, & {T_{\text{P}}}={{T_{\text{melt}}}^{\text{P}}}\land{}0\lt{}ϕ\lt{}1
-                                                            \end{cases}}{\inDefScale}
+                                                            \end{cases}}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -1308,22 +1299,22 @@ RefBy & \hyperref[IM:eBalanceOnWtr]{IM:eBalanceOnWtr}, \hyperref[unlikeChgNIHG]{
 To find the rate of change of ${T_{\text{P}}}$, we look at the energy balance on the PCM. The volume being considered is the volume of PCM (${V_{\text{P}}}$). The derivation that follows is initially for the solid PCM. The mass of phase change material is ${m_{\text{P}}}$ and the specific heat capacity of PCM as a solid is ${{C_{\text{P}}}^{\text{S}}}$. The heat flux into the PCM from water is ${q_{\text{P}}}$ (\hyperref[GD:htFluxPCMFromWater]{GD:htFluxPCMFromWater}) over phase change material surface area ${A_{\text{P}}}$. The thermal flux is constant over ${A_{\text{P}}}$, since the temperature of the PCM is the same throughout its volume (\hyperref[assumpTPCAV]{A:Temp-PCM-Constant-Across-Volume}) and the water is fully mixed (\hyperref[assumpCWTAT]{A:Constant-Water-Temp-Across-Tank}). There is no heat flux output from the PCM. Assuming no volumetric heat generation per unit volume (\hyperref[assumpNIHGBWP]{A:No-Internal-Heat-Generation-By-Water-PCM}), $g=0$, the equation for \hyperref[GD:rocTempSimp]{GD:rocTempSimp} can be written as:
 
 \begin{displaymath}
-\resizeExpression{{m_{\text{P}}}\,{{C_{\text{P}}}^{\text{S}}}\,\frac{\,d{T_{\text{P}}}}{\,dt}={q_{\text{P}}}\,{A_{\text{P}}}}{\outDefScale}
+\resizeExpression{{m_{\text{P}}}\,{{C_{\text{P}}}^{\text{S}}}\,\frac{\,d{T_{\text{P}}}}{\,dt}={q_{\text{P}}}\,{A_{\text{P}}}}
 \end{displaymath}
 Using \hyperref[GD:htFluxPCMFromWater]{GD:htFluxPCMFromWater} for ${q_{\text{P}}}$, this equation can be written as:
 
 \begin{displaymath}
-\resizeExpression{{m_{\text{P}}}\,{{C_{\text{P}}}^{\text{S}}}\,\frac{\,d{T_{\text{P}}}}{\,dt}={h_{\text{P}}}\,{A_{\text{P}}}\,\left({T_{\text{W}}}-{T_{\text{P}}}\right)}{\outDefScale}
+\resizeExpression{{m_{\text{P}}}\,{{C_{\text{P}}}^{\text{S}}}\,\frac{\,d{T_{\text{P}}}}{\,dt}={h_{\text{P}}}\,{A_{\text{P}}}\,\left({T_{\text{W}}}-{T_{\text{P}}}\right)}
 \end{displaymath}
 Dividing by ${m_{\text{P}}}$ ${{C_{\text{P}}}^{\text{S}}}$ we obtain:
 
 \begin{displaymath}
-\resizeExpression{\frac{\,d{T_{\text{P}}}}{\,dt}=\frac{{h_{\text{P}}}\,{A_{\text{P}}}}{{m_{\text{P}}}\,{{C_{\text{P}}}^{\text{S}}}}\,\left({T_{\text{W}}}-{T_{\text{P}}}\right)}{\outDefScale}
+\resizeExpression{\frac{\,d{T_{\text{P}}}}{\,dt}=\frac{{h_{\text{P}}}\,{A_{\text{P}}}}{{m_{\text{P}}}\,{{C_{\text{P}}}^{\text{S}}}}\,\left({T_{\text{W}}}-{T_{\text{P}}}\right)}
 \end{displaymath}
 By substituting ${{τ_{\text{P}}}^{\text{S}}}$ (from \hyperref[DD:balanceSolidPCM]{DD:balanceSolidPCM}), this can be written as:
 
 \begin{displaymath}
-\resizeExpression{\frac{\,d{T_{\text{P}}}}{\,dt}=\frac{1}{{{τ_{\text{P}}}^{\text{S}}}}\,\left({T_{\text{W}}}-{T_{\text{P}}}\right)}{\outDefScale}
+\resizeExpression{\frac{\,d{T_{\text{P}}}}{\,dt}=\frac{1}{{{τ_{\text{P}}}^{\text{S}}}}\,\left({T_{\text{W}}}-{T_{\text{P}}}\right)}
 \end{displaymath}
 Equation (4) applies for the solid PCM. In the case where all of the PCM is melted, the same derivation applies, except that ${{C_{\text{P}}}^{\text{S}}}$ is replaced by ${{C_{\text{P}}}^{\text{L}}}$, and thus ${{τ_{\text{P}}}^{\text{S}}}$ is replaced by ${{τ_{\text{P}}}^{\text{L}}}$. Although a small change in surface area would be expected with melting, this is not included, since the volume change of the PCM with melting is assumed to be negligible (\hyperref[assumpVCMPN]{A:Volume-Change-Melting-PCM-Negligible}).
 
@@ -1353,7 +1344,7 @@ Input Constraints &
 Output Constraints & 
 \\ \midrule
 Equation & \begin{displaymath}
-           \resizeExpression{{E_{\text{W}}}\left(t\right)={C_{\text{W}}}\,{m_{\text{W}}}\,\left({T_{\text{W}}}\left(t\right)-{T_{\text{init}}}\right)}{\inDefScale}
+           \resizeExpression{{E_{\text{W}}}\left(t\right)={C_{\text{W}}}\,{m_{\text{W}}}\,\left({T_{\text{W}}}\left(t\right)-{T_{\text{init}}}\right)}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -1399,7 +1390,7 @@ Output & ${E_{\text{P}}}$
          
 \\ \midrule
 Input Constraints & \begin{displaymath}
-                    \resizeExpression{{{T_{\text{melt}}}^{\text{P}}}\gt{}{T_{\text{init}}}}{\inDefScale}
+                    \resizeExpression{{{T_{\text{melt}}}^{\text{P}}}\gt{}{T_{\text{init}}}}
                     \end{displaymath}
 \\ \midrule
 Output Constraints & 
@@ -1409,7 +1400,7 @@ Equation & \begin{displaymath}
                                             {{C_{\text{P}}}^{\text{S}}}\,{m_{\text{P}}}\,\left({T_{\text{P}}}\left(t\right)-{T_{\text{init}}}\right), & {T_{\text{P}}}\lt{}{{T_{\text{melt}}}^{\text{P}}}\\
                                             {{{E_{\text{P}}}_{\text{melt}}}^{\text{init}}}+{H_{\text{f}}}\,{m_{\text{P}}}+{{C_{\text{P}}}^{\text{L}}}\,{m_{\text{P}}}\,\left({T_{\text{P}}}\left(t\right)-{{T_{\text{melt}}}^{\text{P}}}\right), & {T_{\text{P}}}\gt{}{{T_{\text{melt}}}^{\text{P}}}\\
                                             {{{E_{\text{P}}}_{\text{melt}}}^{\text{init}}}+{Q_{\text{P}}}\left(t\right), & {T_{\text{P}}}={{T_{\text{melt}}}^{\text{P}}}\land{}0\lt{}ϕ\lt{}1
-                                            \end{cases}}{\inDefScale}
+                                            \end{cases}}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -1518,12 +1509,12 @@ ${E_{\text{P}}}$ & ${E_{\text{P}}}\geq{}0$
 A correct solution must exhibit the law of conservation of energy. This means that the change in heat energy in the water should equal the difference between the total energy input from the heating coil and the energy output to the PCM. This can be shown as an equation by taking \hyperref[GD:htFluxWaterFromCoil]{GD:htFluxWaterFromCoil} and \hyperref[GD:htFluxPCMFromWater]{GD:htFluxPCMFromWater}, multiplying each by their respective surface area of heat transfer, and integrating each over the simulation time, as follows:
 
 \begin{displaymath}
-\resizeExpression{{E_{\text{W}}}=\int_{0}^{t}{{h_{\text{C}}}\,{A_{\text{C}}}\,\left({T_{\text{C}}}-{T_{\text{W}}}\left(t\right)\right)}\,dt-\int_{0}^{t}{{h_{\text{P}}}\,{A_{\text{P}}}\,\left({T_{\text{W}}}\left(t\right)-{T_{\text{P}}}\left(t\right)\right)}\,dt}{\outDefScale}
+\resizeExpression{{E_{\text{W}}}=\int_{0}^{t}{{h_{\text{C}}}\,{A_{\text{C}}}\,\left({T_{\text{C}}}-{T_{\text{W}}}\left(t\right)\right)}\,dt-\int_{0}^{t}{{h_{\text{P}}}\,{A_{\text{P}}}\,\left({T_{\text{W}}}\left(t\right)-{T_{\text{P}}}\left(t\right)\right)}\,dt}
 \end{displaymath}
 In addition, the change in heat energy in the PCM should equal the energy input to the PCM from the water. This can be expressed as
 
 \begin{displaymath}
-\resizeExpression{{E_{\text{P}}}=\int_{0}^{t}{{h_{\text{P}}}\,{A_{\text{P}}}\,\left({T_{\text{W}}}\left(t\right)-{T_{\text{P}}}\left(t\right)\right)}\,dt}{\outDefScale}
+\resizeExpression{{E_{\text{P}}}=\int_{0}^{t}{{h_{\text{P}}}\,{A_{\text{P}}}\,\left({T_{\text{W}}}\left(t\right)-{T_{\text{P}}}\left(t\right)\right)}\,dt}
 \end{displaymath}
 Equations (FIXME: Equation 7) and (FIXME: Equation 8) can be used as ``sanity'' checks to gain confidence in any solution computed by SWHS. The relative error between the results computed by SWHS and the results calculated from the RHS of these equations should be less than ${C_{\text{tol}}}$ \hyperref[verifyEnergyOutput]{FR:Verify-Energy-Output-Follow-Conservation-of-Energy}.
 

--- a/code/stable/swhsnopcm/SRS/PDF/SWHSNoPCM_SRS.tex
+++ b/code/stable/swhsnopcm/SRS/PDF/SWHSNoPCM_SRS.tex
@@ -15,8 +15,7 @@
 \usepackage{svg}
 \usepackage{float}
 \usepackage{enumitem}
-\usepackage{graphicx}
-\usepackage{calc}
+\usepackage{adjustbox}
 \usepackage{filecontents}
 \usepackage[backend=bibtex]{biblatex}
 \usepackage{url}
@@ -25,16 +24,8 @@
 \newcommand{\lt}{\ensuremath <}
 \newlist{symbDescription}{description}{1}
 \setlist[symbDescription]{noitemsep, topsep=0pt, parsep=0pt, partopsep=0pt}
-\def\inDefScale{0.8}
-\def\outDefScale{1.0}
-\newsavebox{\mybox}
-\newcommand{\resizeExpression}[2]{
-  \savebox{\mybox}{$#1$}
-  \ifdim\wd\mybox>#2\linewidth
-    \resizebox{#2\textwidth}{!}{\usebox{\mybox}}
-  \else
-    \usebox{\mybox}
-  \fi
+\newcommand{\resizeExpression}[1]{
+  \adjustbox{max width=\linewidth}{$#1$}
 }
 \bibliography{bibfile}
 \title{Software Requirements Specification for Solar Water Heating Systems}
@@ -370,7 +361,7 @@ Label & Conservation of thermal energy
         
 \\ \midrule
 Equation & \begin{displaymath}
-           \resizeExpression{-∇\cdot{}\symbf{q}+g=ρ\,C\,\frac{\,\partial{}T}{\,\partial{}t}}{\inDefScale}
+           \resizeExpression{-∇\cdot{}\symbf{q}+g=ρ\,C\,\frac{\,\partial{}T}{\,\partial{}t}}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -409,7 +400,7 @@ Label & Sensible heat energy (no state change)
         
 \\ \midrule
 Equation & \begin{displaymath}
-           \resizeExpression{E={C^{\text{L}}}\,m\,ΔT}{\inDefScale}
+           \resizeExpression{E={C^{\text{L}}}\,m\,ΔT}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -443,7 +434,7 @@ Label & Newton's law of cooling
         
 \\ \midrule
 Equation & \begin{displaymath}
-           \resizeExpression{q\left(t\right)=h\,ΔT\left(t\right)}{\inDefScale}
+           \resizeExpression{q\left(t\right)=h\,ΔT\left(t\right)}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -485,7 +476,7 @@ Label & Simplified rate of change of temperature
         
 \\ \midrule
 Equation & \begin{displaymath}
-           \resizeExpression{m\,C\,\frac{\,dT}{\,dt}={q_{\text{in}}}\,{A_{\text{in}}}-{q_{\text{out}}}\,{A_{\text{out}}}+g\,V}{\inDefScale}
+           \resizeExpression{m\,C\,\frac{\,dT}{\,dt}={q_{\text{in}}}\,{A_{\text{in}}}-{q_{\text{out}}}\,{A_{\text{out}}}+g\,V}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -515,27 +506,27 @@ RefBy & \hyperref[GD:rocTempSimp]{GD:rocTempSimp} and \hyperref[IM:eBalanceOnWtr
 Integrating \hyperref[TM:consThermE]{TM:consThermE} over a volume ($V$), we have:
 
 \begin{displaymath}
-\resizeExpression{-\int_{V}{∇\cdot{}\symbf{q}}\,dV+\int_{V}{g}\,dV=\int_{V}{ρ\,C\,\frac{\,\partial{}T}{\,\partial{}t}}\,dV}{\outDefScale}
+\resizeExpression{-\int_{V}{∇\cdot{}\symbf{q}}\,dV+\int_{V}{g}\,dV=\int_{V}{ρ\,C\,\frac{\,\partial{}T}{\,\partial{}t}}\,dV}
 \end{displaymath}
 Applying Gauss's Divergence Theorem to the first term over the surface $S$ of the volume, with $\symbf{q}$ as the thermal flux vector for the surface and $\symbf{\hat{n}}$ as a unit outward normal vector for a surface:
 
 \begin{displaymath}
-\resizeExpression{-\int_{S}{\symbf{q}\cdot{}\symbf{\hat{n}}}\,dS+\int_{V}{g}\,dV=\int_{V}{ρ\,C\,\frac{\,\partial{}T}{\,\partial{}t}}\,dV}{\outDefScale}
+\resizeExpression{-\int_{S}{\symbf{q}\cdot{}\symbf{\hat{n}}}\,dS+\int_{V}{g}\,dV=\int_{V}{ρ\,C\,\frac{\,\partial{}T}{\,\partial{}t}}\,dV}
 \end{displaymath}
 We consider an arbitrary volume. The volumetric heat generation per unit volume is assumed constant. Then Equation (1) can be written as:
 
 \begin{displaymath}
-\resizeExpression{{q_{\text{in}}}\,{A_{\text{in}}}-{q_{\text{out}}}\,{A_{\text{out}}}+g\,V=\int_{V}{ρ\,C\,\frac{\,\partial{}T}{\,\partial{}t}}\,dV}{\outDefScale}
+\resizeExpression{{q_{\text{in}}}\,{A_{\text{in}}}-{q_{\text{out}}}\,{A_{\text{out}}}+g\,V=\int_{V}{ρ\,C\,\frac{\,\partial{}T}{\,\partial{}t}}\,dV}
 \end{displaymath}
 Where ${q_{\text{in}}}$, ${q_{\text{out}}}$, ${A_{\text{in}}}$, and ${A_{\text{out}}}$ are explained in \hyperref[GD:rocTempSimp]{GD:rocTempSimp}. Assuming $ρ$, $C$, and $T$ are constant over the volume, which is true in our case by \hyperref[assumpCWTAT]{A:Constant-Water-Temp-Across-Tank}, \hyperref[assumpDWCoW]{A:Density-Water-Constant-over-Volume}, and \hyperref[assumpSHECoW]{A:Specific-Heat-Energy-Constant-over-Volume}, we have:
 
 \begin{displaymath}
-\resizeExpression{ρ\,C\,V\,\frac{\,dT}{\,dt}={q_{\text{in}}}\,{A_{\text{in}}}-{q_{\text{out}}}\,{A_{\text{out}}}+g\,V}{\outDefScale}
+\resizeExpression{ρ\,C\,V\,\frac{\,dT}{\,dt}={q_{\text{in}}}\,{A_{\text{in}}}-{q_{\text{out}}}\,{A_{\text{out}}}+g\,V}
 \end{displaymath}
 Using the fact that $ρ$=$m$/$V$, Equation (2) can be written as:
 
 \begin{displaymath}
-\resizeExpression{m\,C\,\frac{\,dT}{\,dt}={q_{\text{in}}}\,{A_{\text{in}}}-{q_{\text{out}}}\,{A_{\text{out}}}+g\,V}{\outDefScale}
+\resizeExpression{m\,C\,\frac{\,dT}{\,dt}={q_{\text{in}}}\,{A_{\text{in}}}-{q_{\text{out}}}\,{A_{\text{out}}}+g\,V}
 \end{displaymath}
 \medskip
 \noindent
@@ -552,7 +543,7 @@ Units & $\frac{\text{W}}{\text{m}^{2}}$
         
 \\ \midrule
 Equation & \begin{displaymath}
-           \resizeExpression{{q_{\text{C}}}={h_{\text{C}}}\,\left({T_{\text{C}}}-{T_{\text{W}}}\left(t\right)\right)}{\inDefScale}
+           \resizeExpression{{q_{\text{C}}}={h_{\text{C}}}\,\left({T_{\text{C}}}-{T_{\text{W}}}\left(t\right)\right)}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -599,7 +590,7 @@ Units & ${\text{kg}}$
         
 \\ \midrule
 Equation & \begin{displaymath}
-           \resizeExpression{{m_{\text{W}}}={V_{\text{W}}}\,{ρ_{\text{W}}}}{\inDefScale}
+           \resizeExpression{{m_{\text{W}}}={V_{\text{W}}}\,{ρ_{\text{W}}}}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -635,7 +626,7 @@ Units & ${\text{m}^{3}}$
         
 \\ \midrule
 Equation & \begin{displaymath}
-           \resizeExpression{{V_{\text{W}}}={V_{\text{tank}}}}{\inDefScale}
+           \resizeExpression{{V_{\text{W}}}={V_{\text{tank}}}}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -673,7 +664,7 @@ Units & ${\text{m}^{3}}$
         
 \\ \midrule
 Equation & \begin{displaymath}
-           \resizeExpression{{V_{\text{tank}}}=π\,\left(\frac{D}{2}\right)^{2}\,L}{\inDefScale}
+           \resizeExpression{{V_{\text{tank}}}=π\,\left(\frac{D}{2}\right)^{2}\,L}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -710,7 +701,7 @@ Units & ${\text{s}}$
         
 \\ \midrule
 Equation & \begin{displaymath}
-           \resizeExpression{{τ_{\text{W}}}=\frac{{m_{\text{W}}}\,{C_{\text{W}}}}{{h_{\text{C}}}\,{A_{\text{C}}}}}{\inDefScale}
+           \resizeExpression{{τ_{\text{W}}}=\frac{{m_{\text{W}}}\,{C_{\text{W}}}}{{h_{\text{C}}}\,{A_{\text{C}}}}}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -754,13 +745,13 @@ Output & ${T_{\text{W}}}$
          
 \\ \midrule
 Input Constraints & \begin{displaymath}
-                    \resizeExpression{{T_{\text{C}}}\geq{}{T_{\text{init}}}}{\inDefScale}
+                    \resizeExpression{{T_{\text{C}}}\geq{}{T_{\text{init}}}}
                     \end{displaymath}
 \\ \midrule
 Output Constraints & 
 \\ \midrule
 Equation & \begin{displaymath}
-           \resizeExpression{\frac{\,d{T_{\text{W}}}}{\,dt}+\frac{1}{{τ_{\text{W}}}}\,{{T_{\text{W}}}}=\frac{1}{{τ_{\text{W}}}}\,{T_{\text{C}}}}{\inDefScale}
+           \resizeExpression{\frac{\,d{T_{\text{W}}}}{\,dt}+\frac{1}{{τ_{\text{W}}}}\,{{T_{\text{W}}}}=\frac{1}{{τ_{\text{W}}}}\,{T_{\text{C}}}}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}
@@ -789,22 +780,22 @@ RefBy & \hyperref[unlikeChgNIHG]{UC:No-Internal-Heat-Generation}, \hyperref[outp
 To find the rate of change of ${T_{\text{W}}}$, we look at the energy balance on water. The volume being considered is the volume of water in the tank ${V_{\text{W}}}$, which has mass ${m_{\text{W}}}$ and specific heat capacity, ${C_{\text{W}}}$. Heat transfer occurs in the water from the heating coil as ${q_{\text{C}}}$ (\hyperref[GD:htFluxWaterFromCoil]{GD:htFluxWaterFromCoil}), over area ${A_{\text{C}}}$. No heat transfer occurs to the outside of the tank, since it has been assumed to be perfectly insulated (\hyperref[assumpPIT]{A:Perfect-Insulation-Tank}). Since the assumption is made that no internal heat is generated (\hyperref[assumpNIHGBW]{A:No-Internal-Heat-Generation-By-Water}), $g=0$. Therefore, the equation for \hyperref[GD:rocTempSimp]{GD:rocTempSimp} can be written as:
 
 \begin{displaymath}
-\resizeExpression{{m_{\text{W}}}\,{C_{\text{W}}}\,\frac{\,d{T_{\text{W}}}}{\,dt}={q_{\text{C}}}\,{A_{\text{C}}}}{\outDefScale}
+\resizeExpression{{m_{\text{W}}}\,{C_{\text{W}}}\,\frac{\,d{T_{\text{W}}}}{\,dt}={q_{\text{C}}}\,{A_{\text{C}}}}
 \end{displaymath}
 Using \hyperref[GD:htFluxWaterFromCoil]{GD:htFluxWaterFromCoil} for ${q_{\text{C}}}$, this can be written as:
 
 \begin{displaymath}
-\resizeExpression{{m_{\text{W}}}\,{C_{\text{W}}}\,\frac{\,d{T_{\text{W}}}}{\,dt}={h_{\text{C}}}\,{A_{\text{C}}}\,\left({T_{\text{C}}}-{T_{\text{W}}}\right)}{\outDefScale}
+\resizeExpression{{m_{\text{W}}}\,{C_{\text{W}}}\,\frac{\,d{T_{\text{W}}}}{\,dt}={h_{\text{C}}}\,{A_{\text{C}}}\,\left({T_{\text{C}}}-{T_{\text{W}}}\right)}
 \end{displaymath}
 Dividing Equation (2) by ${m_{\text{W}}}\,{C_{\text{W}}}$, we obtain:
 
 \begin{displaymath}
-\resizeExpression{\frac{\,d{T_{\text{W}}}}{\,dt}=\frac{{h_{\text{C}}}\,{A_{\text{C}}}}{{m_{\text{W}}}\,{C_{\text{W}}}}\,\left({T_{\text{C}}}-{T_{\text{W}}}\right)}{\outDefScale}
+\resizeExpression{\frac{\,d{T_{\text{W}}}}{\,dt}=\frac{{h_{\text{C}}}\,{A_{\text{C}}}}{{m_{\text{W}}}\,{C_{\text{W}}}}\,\left({T_{\text{C}}}-{T_{\text{W}}}\right)}
 \end{displaymath}
 By substituting ${τ_{\text{W}}}$ (from \hyperref[DD:balanceDecayRate]{DD:balanceDecayRate}), this can be written as:
 
 \begin{displaymath}
-\resizeExpression{\frac{\,d{T_{\text{W}}}}{\,dt}=\frac{1}{{τ_{\text{W}}}}\,\left({T_{\text{C}}}-{T_{\text{W}}}\right)}{\outDefScale}
+\resizeExpression{\frac{\,d{T_{\text{W}}}}{\,dt}=\frac{1}{{τ_{\text{W}}}}\,\left({T_{\text{C}}}-{T_{\text{W}}}\right)}
 \end{displaymath}
 \medskip
 \noindent
@@ -828,7 +819,7 @@ Input Constraints &
 Output Constraints & 
 \\ \midrule
 Equation & \begin{displaymath}
-           \resizeExpression{{E_{\text{W}}}\left(t\right)={C_{\text{W}}}\,{m_{\text{W}}}\,\left({T_{\text{W}}}\left(t\right)-{T_{\text{init}}}\right)}{\inDefScale}
+           \resizeExpression{{E_{\text{W}}}\left(t\right)={C_{\text{W}}}\,{m_{\text{W}}}\,\left({T_{\text{W}}}\left(t\right)-{T_{\text{init}}}\right)}
            \end{displaymath}
 \\ \midrule
 Description & \begin{symbDescription}


### PR DESCRIPTION
Contributes to #718
Builds on #3910

In #3910, I used the `resizebox` package to resize the block equations; however, I have switched to the `adjustbox` package as I found it to be better overall.

### Pros of using `adjustbox` instead:

- No need for a scale parameter.
  - `adjustbox` is "smarter" and can automatically determine when scaling is necessary. 
    - This resulted in the removal of the `if` conditions in the custom LaTeX command.
    - We also don't need `lo'` and the `InDef` and `OutDef` params as the package automatically handles the scaling factor.
- `adjustbox` can resize an expression directly; no need for a `savebox`. 


Rendered PDF remains the same as #3910. Switching to the `adjustbox` package cleaned up both the generated TeX code and the written Drasil code.