### PR TITLE
removed `iterators` from `MethodState`

### DIFF
--- a/code/drasil-gool/lib/Drasil/GOOL/LanguageRenderer/CppRenderer.hs
+++ b/code/drasil-gool/lib/Drasil/GOOL/LanguageRenderer/CppRenderer.hs
@@ -111,7 +111,7 @@ import Drasil.GOOL.State (CS, MS, VS, lensGStoFS, lensFStoCS, lensFStoMS,
   getHeaderDefines, addUsing, getUsing, addHeaderUsing, getHeaderUsing,
   setFileType, getModuleName, setModuleName, setClassName, getClassName,
   setCurrMain, getCurrMain, getClassMap, setVisibility, getVisibility,
-  setCurrMainFunc, getCurrMainFunc, addIter, resetIter, useVarName,
+  setCurrMainFunc, getCurrMainFunc, useVarName,
   genLoopIndex, setVarScope, getVarScope)
 
 import Prelude hiding (break,print,(<>),sin,cos,tan,floor,pi,log,exp,mod,max)
@@ -666,11 +666,7 @@ instance (Pair p) => ControlStatement (p CppSrcCode CppHdrCode) where
   forRange i initv finalv stepv = pair5 forRange forRange (zoom lensMStoVS i)
     (zoom lensMStoVS initv) (zoom lensMStoVS finalv) (zoom lensMStoVS stepv)
   forEach e' v b = do
-    e <- zoom lensMStoVS e'
-    let le = variableName e
-    modify (addIter le)
     loop <- pair3 forEach forEach (zoom lensMStoVS e') (zoom lensMStoVS v) b
-    modify (resetIter le)
     toState loop
   while v = pair2 while while (zoom lensMStoVS v)
 

--- a/code/drasil-gool/lib/Drasil/GOOL/State.hs
+++ b/code/drasil-gool/lib/Drasil/GOOL/State.hs
@@ -27,7 +27,7 @@ module Drasil.GOOL.State (
   isOutputsDeclared, addException, addExceptions, getExceptions, addCall, 
   setMainDoc, getMainDoc, setVisibility, getVisibility, setCurrMainFunc,
   getCurrMainFunc, setThrowUsed, getThrowUsed, setErrorDefined, getErrorDefined,
-  addIter, getIter, resetIter, incrementLine, incrementWord, getLineIndex,
+  incrementLine, incrementWord, getLineIndex,
   getWordIndex,  resetIndices, useVarName, genVarName, genLoopIndex,
   genVarNameIf, varNameAvailable, setVarScope, getVarScope
 ) where
@@ -42,7 +42,7 @@ import Utils.Drasil (nubSort)
 import Control.Lens (Lens', (^.), lens, makeLenses, over, set, _1, _2, both, at)
 import Control.Monad.State (State, modify, gets)
 import Data.Char (isDigit)
-import Data.List (nub, delete)
+import Data.List (nub)
 import Data.Foldable (foldl')
 import Data.Maybe (isNothing, fromMaybe)
 import Data.Map (Map)
@@ -125,7 +125,6 @@ data MethodState = MS {
                           -- documentation to function in C++
   _currMainFunc :: Bool, -- Used by C++ to put documentation for the main
                         -- function in source instead of header file
-  _iterators :: [String],
 
   -- Only used for Swift
   _contentsIndices :: (Index, Index) -- Used to keep track of the current place
@@ -271,7 +270,6 @@ initialMS = MS {
 
   _currVisibility  = Priv,
   _currMainFunc = False,
-  _iterators = [],
 
   _contentsIndices = (0,0)
 }
@@ -536,15 +534,6 @@ setErrorDefined = set (lensMStoGS . errorDefined) True
 
 getErrorDefined :: MS Bool
 getErrorDefined = gets (^. (lensMStoGS . errorDefined))
-
-addIter :: String -> MethodState -> MethodState
-addIter st = over iterators ([st]++)
-
-getIter :: MS [String]
-getIter = gets (^. iterators)
-
-resetIter :: String -> MethodState -> MethodState
-resetIter st = over iterators (delete st)
 
 incrementLine :: MethodState -> MethodState
 incrementLine = over (contentsIndices . _1) (+1)  . set (contentsIndices . _2) 0


### PR DESCRIPTION
I removed `iterators` from `MethodState` since as said in #3919 the changes that I made to the Cpp render `forEach` loop makes the iterators field in `MethodState` unnecessary.

Closes #3919