### PR TITLE
We don't need the hack anymore

### DIFF
--- a/.github/workflows/Lint.yaml
+++ b/.github/workflows/Lint.yaml
@@ -30,13 +30,6 @@ jobs:
               - '**/*.sh'
 
       # If a [l]hs file was edited, then run HLint
-      # Once we update our LTS, we can remove this step, see "Inputs": https://github.com/haskell-actions/hlint-setup
-      - name: 'Install HLint system dependencies'
-        if: ${{ steps.filter.outputs.hs == 'true' }}
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y libtinfo5
-
       - name: 'Set up HLint'
         if: ${{ steps.filter.outputs.hs == 'true' }}
         uses: haskell-actions/hlint-setup@v2


### PR DESCRIPTION
and it is broken -- `libtinfo5` is not found anymore on Ubuntu LTS 24.04.

We can probably simplify this further (see https://github.com/haskell-actions/hlint-setup ), but that can be a subsequent PR.