### PR TITLE
Enable StrictData wherever our tests don't fail

### DIFF
--- a/code/drasil-build/package.yaml
+++ b/code/drasil-build/package.yaml
@@ -7,6 +7,10 @@ github:              JacquesCarette/Drasil
 homepage:            https://jacquescarette.github.io/Drasil/
 description:         Please see the README on GitHub at <https://github.com/JacquesCarette/Drasil#readme>
 
+language: Haskell2010
+default-extensions:
+- StrictData
+
 extra-source-files: []
 
 dependencies:

--- a/code/drasil-codeLang/package.yaml
+++ b/code/drasil-codeLang/package.yaml
@@ -7,6 +7,10 @@ github:              JacquesCarette/Drasil
 homepage:            https://jacquescarette.github.io/Drasil/
 description:         Please see the README on GitHub at <https://github.com/JacquesCarette/Drasil#readme>
 
+language: Haskell2010
+default-extensions:
+- StrictData
+
 extra-source-files: []
 
 dependencies:

--- a/code/drasil-data/package.yaml
+++ b/code/drasil-data/package.yaml
@@ -7,6 +7,10 @@ github:              JacquesCarette/Drasil
 homepage:            https://jacquescarette.github.io/Drasil/
 description:         Please see the README on GitHub at <https://github.com/JacquesCarette/Drasil#readme>
 
+language: Haskell2010
+default-extensions:
+- StrictData
+
 extra-source-files: []
 
 dependencies:

--- a/code/drasil-docLang/package.yaml
+++ b/code/drasil-docLang/package.yaml
@@ -7,6 +7,10 @@ github:              JacquesCarette/Drasil
 homepage:            https://jacquescarette.github.io/Drasil/
 description:         Please see the README on GitHub at <https://github.com/JacquesCarette/Drasil#readme>
 
+language: Haskell2010
+default-extensions:
+- StrictData
+
 extra-source-files: []
 
 dependencies:

--- a/code/drasil-example/dblpend/package.yaml
+++ b/code/drasil-example/dblpend/package.yaml
@@ -7,6 +7,10 @@ github:              JacquesCarette/Drasil
 homepage:            https://jacquescarette.github.io/Drasil/
 description:         Please see the README on GitHub at <https://github.com/JacquesCarette/Drasil#readme>
 
+language: Haskell2010
+default-extensions:
+- StrictData
+
 extra-source-files: []
 
 dependencies:

--- a/code/drasil-example/gamephysics/package.yaml
+++ b/code/drasil-example/gamephysics/package.yaml
@@ -7,6 +7,10 @@ github:              JacquesCarette/Drasil
 homepage:            https://jacquescarette.github.io/Drasil/
 description:         Please see the README on GitHub at <https://github.com/JacquesCarette/Drasil#readme>
 
+language: Haskell2010
+default-extensions:
+- StrictData
+
 extra-source-files: []
 
 dependencies:

--- a/code/drasil-example/glassbr/package.yaml
+++ b/code/drasil-example/glassbr/package.yaml
@@ -7,6 +7,10 @@ github:              JacquesCarette/Drasil
 homepage:            https://jacquescarette.github.io/Drasil/
 description:         Please see the README on GitHub at <https://github.com/JacquesCarette/Drasil#readme>
 
+language: Haskell2010
+default-extensions:
+- StrictData
+
 extra-source-files: []
 
 dependencies:

--- a/code/drasil-example/hghc/package.yaml
+++ b/code/drasil-example/hghc/package.yaml
@@ -7,6 +7,10 @@ github:              JacquesCarette/Drasil
 homepage:            https://jacquescarette.github.io/Drasil/
 description:         Please see the README on GitHub at <https://github.com/JacquesCarette/Drasil#readme>
 
+language: Haskell2010
+default-extensions:
+- StrictData
+
 extra-source-files: []
 
 dependencies:

--- a/code/drasil-example/pdcontroller/package.yaml
+++ b/code/drasil-example/pdcontroller/package.yaml
@@ -7,6 +7,10 @@ github:              JacquesCarette/Drasil
 homepage:            https://jacquescarette.github.io/Drasil/
 description:         Please see the README on GitHub at <https://github.com/JacquesCarette/Drasil#readme>
 
+language: Haskell2010
+default-extensions:
+- StrictData
+
 extra-source-files: []
 
 dependencies:

--- a/code/drasil-example/projectile/package.yaml
+++ b/code/drasil-example/projectile/package.yaml
@@ -7,6 +7,10 @@ github:              JacquesCarette/Drasil
 homepage:            https://jacquescarette.github.io/Drasil/
 description:         Please see the README on GitHub at <https://github.com/JacquesCarette/Drasil#readme>
 
+language: Haskell2010
+default-extensions:
+- StrictData
+
 extra-source-files: []
 
 dependencies:

--- a/code/drasil-example/sglpend/package.yaml
+++ b/code/drasil-example/sglpend/package.yaml
@@ -7,6 +7,10 @@ github:              JacquesCarette/Drasil
 homepage:            https://jacquescarette.github.io/Drasil/
 description:         Please see the README on GitHub at <https://github.com/JacquesCarette/Drasil#readme>
 
+language: Haskell2010
+default-extensions:
+- StrictData
+
 extra-source-files: []
 
 dependencies:

--- a/code/drasil-example/sglpend/stack.yaml
+++ b/code/drasil-example/sglpend/stack.yaml
@@ -4,6 +4,7 @@ packages:
 - .
 - ../../drasil-build
 - ../../drasil-code
+- ../../drasil-codeLang
 - ../../drasil-data
 - ../../drasil-database
 - ../../drasil-docLang
@@ -12,8 +13,10 @@ packages:
 - ../../drasil-lang
 - ../../drasil-metadata
 - ../../drasil-printers
+- ../../drasil-sysinfo
 - ../../drasil-theory
 - ../../drasil-utils
+- ../dblpend
 
 extra-deps:
 - unicode-names-3.2.0.0@sha256:fef7241d93170e26265e84553090253a5e8ee207645d47cf271816f5834d07d2,470

--- a/code/drasil-example/ssp/package.yaml
+++ b/code/drasil-example/ssp/package.yaml
@@ -7,6 +7,10 @@ github:              JacquesCarette/Drasil
 homepage:            https://jacquescarette.github.io/Drasil/
 description:         Please see the README on GitHub at <https://github.com/JacquesCarette/Drasil#readme>
 
+language: Haskell2010
+default-extensions:
+- StrictData
+
 extra-source-files: []
 
 dependencies:

--- a/code/drasil-example/swhs/package.yaml
+++ b/code/drasil-example/swhs/package.yaml
@@ -7,6 +7,10 @@ github:              JacquesCarette/Drasil
 homepage:            https://jacquescarette.github.io/Drasil/
 description:         Please see the README on GitHub at <https://github.com/JacquesCarette/Drasil#readme>
 
+language: Haskell2010
+default-extensions:
+- StrictData
+
 extra-source-files: []
 
 dependencies:

--- a/code/drasil-example/swhsnopcm/package.yaml
+++ b/code/drasil-example/swhsnopcm/package.yaml
@@ -7,6 +7,10 @@ github:              JacquesCarette/Drasil
 homepage:            https://jacquescarette.github.io/Drasil/
 description:         Please see the README on GitHub at <https://github.com/JacquesCarette/Drasil#readme>
 
+language: Haskell2010
+default-extensions:
+- StrictData
+
 extra-source-files: []
 
 dependencies:

--- a/code/drasil-example/template/package.yaml
+++ b/code/drasil-example/template/package.yaml
@@ -7,6 +7,10 @@ github:              JacquesCarette/Drasil
 homepage:            https://jacquescarette.github.io/Drasil/
 description:         Please see the README on GitHub at <https://github.com/JacquesCarette/Drasil#readme>
 
+language: Haskell2010
+default-extensions:
+- StrictData
+
 extra-source-files: []
 
 dependencies:

--- a/code/drasil-gen/package.yaml
+++ b/code/drasil-gen/package.yaml
@@ -7,6 +7,10 @@ github:              JacquesCarette/Drasil
 homepage:            https://jacquescarette.github.io/Drasil/
 description:         Please see the README on GitHub at <https://github.com/JacquesCarette/Drasil#readme>
 
+language: Haskell2010
+default-extensions:
+- StrictData
+
 extra-source-files: []
 
 dependencies:

--- a/code/drasil-metadata/package.yaml
+++ b/code/drasil-metadata/package.yaml
@@ -7,6 +7,10 @@ github:              JacquesCarette/Drasil
 homepage:            https://jacquescarette.github.io/Drasil/
 description:         Please see the README on GitHub at <https://github.com/JacquesCarette/Drasil#readme>
 
+language: Haskell2010
+default-extensions:
+- StrictData
+
 extra-source-files: []
 
 dependencies:

--- a/code/drasil-printers/package.yaml
+++ b/code/drasil-printers/package.yaml
@@ -7,6 +7,10 @@ github:              JacquesCarette/Drasil
 homepage:            https://jacquescarette.github.io/Drasil/
 description:         Please see the README on GitHub at <https://github.com/JacquesCarette/Drasil#readme>
 
+language: Haskell2010
+default-extensions:
+- StrictData
+
 extra-source-files: []
 
 dependencies:

--- a/code/drasil-sysinfo/package.yaml
+++ b/code/drasil-sysinfo/package.yaml
@@ -7,6 +7,10 @@ github:              JacquesCarette/Drasil
 homepage:            https://jacquescarette.github.io/Drasil/
 description:         Please see the README on GitHub at <https://github.com/JacquesCarette/Drasil#readme>
 
+language: Haskell2010
+default-extensions:
+- StrictData
+
 extra-source-files: []
 
 dependencies:

--- a/code/drasil-theory/package.yaml
+++ b/code/drasil-theory/package.yaml
@@ -7,6 +7,10 @@ github:              JacquesCarette/Drasil
 homepage:            https://jacquescarette.github.io/Drasil/
 description:         Please see the README on GitHub at <https://github.com/JacquesCarette/Drasil#readme>
 
+language: Haskell2010
+default-extensions:
+- StrictData
+
 extra-source-files: []
 
 dependencies:

--- a/code/drasil-utils/package.yaml
+++ b/code/drasil-utils/package.yaml
@@ -2,7 +2,7 @@ name:                drasil-utils
 version:             0.1.1.0
 author:              "Dan Szymczak, Steven Palmer, Jacques Carette, Spencer Smith"
 maintainer:          "Jacques Carette"
-synopsis:	           A framework for code and document generation for scientific software - Utils SubPackage
+synopsis:            A framework for code and document generation for scientific software - Utils SubPackage
 github:              JacquesCarette/Drasil
 homepage:            https://jacquescarette.github.io/Drasil/
 description:         Please see the README on GitHub at <https://github.com/JacquesCarette/Drasil#readme>

--- a/code/drasil-utils/package.yaml
+++ b/code/drasil-utils/package.yaml
@@ -2,10 +2,14 @@ name:                drasil-utils
 version:             0.1.1.0
 author:              "Dan Szymczak, Steven Palmer, Jacques Carette, Spencer Smith"
 maintainer:          "Jacques Carette"
-synopsis:	     A framework for code and document generation for scientific software - Utils SubPackage
+synopsis:	           A framework for code and document generation for scientific software - Utils SubPackage
 github:              JacquesCarette/Drasil
 homepage:            https://jacquescarette.github.io/Drasil/
 description:         Please see the README on GitHub at <https://github.com/JacquesCarette/Drasil#readme>
+
+language: Haskell2010
+default-extensions:
+- StrictData
 
 extra-source-files: []
 

--- a/code/drasil-website/package.yaml
+++ b/code/drasil-website/package.yaml
@@ -6,6 +6,10 @@ synopsis:            Using the Drasil generators to create Drasil's website
 homepage:            https://jacquescarette.github.io/Drasil/
 description:         Please see the README on GitHub at <https://github.com/JacquesCarette/Drasil#readme>
 
+language: Haskell2010
+default-extensions:
+- StrictData
+
 extra-source-files: []
 
 dependencies:


### PR DESCRIPTION
Contributes to #3710, where non-strict data is a very common warning noted by `stan`.
Contributes to #2873, where we need `StrictData` to build maps of chunks with 'sane checks on insertion'.

I also manually set the language specification to `Haskell2010`. That's the default that `hpack` uses, but I think that being explicit is good here. Aside: I'm also okay with upgrading this to `GHC2021` or the more recent 2024 spec.