### PR TITLE
Remove chgInVelocity's self-reference.

### DIFF
--- a/code/drasil-data/lib/Data/Drasil/Concepts/Physics.hs
+++ b/code/drasil-data/lib/Data/Drasil/Concepts/Physics.hs
@@ -62,8 +62,9 @@ angular = dcc "angular" (cn' "angular")
   "denoting physical properties or quantities measured with reference to or by means of an angle"
 body = dccWDS "body" (cnIES "body")
   (S "an object with" +:+ phrase QPP.mass)
-chgInVelocity = dccWDS "chgInVelocity" (cn "change in velocity")
-  (S "the" +:+ phraseNP (chgInVelocity `ofA` rigidBody))
+chgInVelocity = dccWDS "chgInVelocity" (cn desc)
+  (S "the " +:+ S desc +:+ phrase rigidBody)
+  where desc = "change in velocity" -- TODO: This is a hack to avoid an infinite loop should we enable strict data.
 chgMomentum = dccWDS "chgMomentum" (cn' "change in momentum")
   (S "The rate of change of a body's" +:+ phrase impulseV)  
 collision = dcc "collision" (cn' "collision")


### PR DESCRIPTION
Contributes to #3710
Contributes to #2873

For both, by removing a self-reference that would cause issue for enabling `StrictData`.

Notes:
1. The solution itself is not clean. What I actually want to encode is something more like: `S "the" ++ phrase change ++ S "in" ++ phrase velocity ++ S "of a" ++ phrase rigidBody` (pseudocode) -- i.e., something that references both "change" and "velocity".
2. I'm struggling to quickly encode (1) because I'm having trouble understanding how the `Sentence` and `NounPhrase` system works.
3. Writing a ticket about (2) is more work than writing the demo code, pushing a PR, and receiving feedback.

@samm82 IIRC, you have some experience with this system. Do you have any suggestions for how I can improve this?
