### PR TITLE
Remove reference loop in standoffdistance/GlassBR.

### DIFF
--- a/code/drasil-example/glassbr/lib/Drasil/GlassBR/Unitals.hs
+++ b/code/drasil-example/glassbr/lib/Drasil/GlassBR/Unitals.hs
@@ -367,7 +367,7 @@ safeMessage   = dcc "safeMessage" (nounPhraseSP "safe")
   "For the given input parameters, the glass is considered safe."
 sD            = cc' stdOffDist
   (S "the distance from the glazing surface to the centroid of a hemispherical" +:+
-   S "high explosive charge. It is represented by the coordinates" +:+ sParen sdVectorSent)
+   S "high explosive charge")
 shortDurLoad  = dcc "shortDurLoad"       (nounPhraseSP "short duration load")
   "any load lasting 3 seconds or less"
 specA         = dcc "specA"       (nounPhraseSP "specifying authority")
@@ -396,9 +396,6 @@ constantLoadDur = mkQuantDef loadDur     $ exactDbl 3
 constantLoadSF  = mkQuantDef loadSF      $ exactDbl 1
 
 --Equations--
-
-sdVectorSent :: Sentence
-sdVectorSent = foldlsC (map ch sdVector)
 
 sdVector :: [UnitaryChunk]
 sdVector = [sdx, sdy, sdz]

--- a/code/stable/glassbr/SRS/HTML/GlassBR_SRS.html
+++ b/code/stable/glassbr/SRS/HTML/GlassBR_SRS.html
@@ -763,7 +763,7 @@
                     </ul>
                   </li>
                   <li>
-                    Stand off distance (SD) - The distance from the glazing surface to the centroid of a hemispherical high explosive charge. It is represented by the coordinates (<em>SD<sub>x</sub></em>, <em>SD<sub>y</sub></em>, <em>SD<sub>z</sub></em>).
+                    Stand off distance (SD) - The distance from the glazing surface to the centroid of a hemispherical high explosive charge.
                   </li>
                   <li>
                     Load share factor (LSF) - A multiplying factor derived from the load sharing between the double glazing, of equal or different thicknesses and types (including the layered behaviour of LG under long duration loads), in a sealed IG unit.

--- a/code/stable/glassbr/SRS/Jupyter/GlassBR_SRS.ipynb
+++ b/code/stable/glassbr/SRS/Jupyter/GlassBR_SRS.ipynb
@@ -291,7 +291,7 @@
     " - Short duration load - Any load lasting 3 seconds or less.\n",
     " - Specified design load - The magnitude in Pa (psf), type (for example, wind or snow) and duration of the load given by the specifying authority.\n",
     " - Long duration load - Any load lasting approximately 30 days.\n",
-    "- Stand off distance (SD) - The distance from the glazing surface to the centroid of a hemispherical high explosive charge. It is represented by the coordinates ($SD_x$, $SD_y$, $SD_z$).\n",
+    "- Stand off distance (SD) - The distance from the glazing surface to the centroid of a hemispherical high explosive charge.\n",
     "- Load share factor (LSF) - A multiplying factor derived from the load sharing between the double glazing, of equal or different thicknesses and types (including the layered behaviour of LG under long duration loads), in a sealed IG unit.\n",
     "- Glass type factor (GTF) - A multiplying factor for adjusting the LR of different glass type, that is, AN, FT, or HS, in monolithic glass, LG (Laminated Glass), or IG (Insulating Glass) constructions.\n",
     "- Aspect ratio (AR) - The ratio of the long dimension of the glass to the short dimension of the glass. For glass supported on four sides, the aspect ratio is always equal to or greater than 1.0. For glass supported on three sides, the ratio of the length of one of the supported edges perpendicular to the free edge, to the length of the free edge, is equal to or greater than 0.5.\n",

--- a/code/stable/glassbr/SRS/PDF/GlassBR_SRS.tex
+++ b/code/stable/glassbr/SRS/PDF/GlassBR_SRS.tex
@@ -340,7 +340,7 @@ This subsection provides a list of terms that are used in the subsequent section
 \item{Specified design load - The magnitude in Pa (psf), type (for example, wind or snow) and duration of the load given by the specifying authority.}
 \item{Long duration load - Any load lasting approximately 30 days.}
 \end{itemize}
-\item{Stand off distance (SD) - The distance from the glazing surface to the centroid of a hemispherical high explosive charge. It is represented by the coordinates (${\mathit{SD}_{\text{x}}}$, ${\mathit{SD}_{\text{y}}}$, ${\mathit{SD}_{\text{z}}}$).}
+\item{Stand off distance (SD) - The distance from the glazing surface to the centroid of a hemispherical high explosive charge.}
 \item{Load share factor (LSF) - A multiplying factor derived from the load sharing between the double glazing, of equal or different thicknesses and types (including the layered behaviour of LG under long duration loads), in a sealed IG unit.}
 \item{Glass type factor (GTF) - A multiplying factor for adjusting the LR of different glass type, that is, AN, FT, or HS, in monolithic glass, LG (Laminated Glass), or IG (Insulating Glass) constructions.}
 \item{Aspect ratio (AR) - The ratio of the long dimension of the glass to the short dimension of the glass. For glass supported on four sides, the aspect ratio is always equal to or greater than 1.0. For glass supported on three sides, the ratio of the length of one of the supported edges perpendicular to the free edge, to the length of the free edge, is equal to or greater than 0.5.}

--- a/code/stable/glassbr/SRS/mdBook/src/SecTermDefs.md
+++ b/code/stable/glassbr/SRS/mdBook/src/SecTermDefs.md
@@ -19,7 +19,7 @@ This subsection provides a list of terms that are used in the subsequent section
    - Short duration load - Any load lasting 3 seconds or less.
    - Specified design load - The magnitude in Pa (psf), type (for example, wind or snow) and duration of the load given by the specifying authority.
    - Long duration load - Any load lasting approximately 30 days.
-9. Stand off distance (SD) - The distance from the glazing surface to the centroid of a hemispherical high explosive charge. It is represented by the coordinates (\\({\mathit{SD}\_{\text{x}}}\\), \\({\mathit{SD}\_{\text{y}}}\\), \\({\mathit{SD}\_{\text{z}}}\\)).
+9. Stand off distance (SD) - The distance from the glazing surface to the centroid of a hemispherical high explosive charge.
 10. Load share factor (LSF) - A multiplying factor derived from the load sharing between the double glazing, of equal or different thicknesses and types (including the layered behaviour of LG under long duration loads), in a sealed IG unit.
 11. Glass type factor (GTF) - A multiplying factor for adjusting the LR of different glass type, that is, AN, FT, or HS, in monolithic glass, LG (Laminated Glass), or IG (Insulating Glass) constructions.
 12. Aspect ratio (AR) - The ratio of the long dimension of the glass to the short dimension of the glass. For glass supported on four sides, the aspect ratio is always equal to or greater than 1.0. For glass supported on three sides, the ratio of the length of one of the supported edges perpendicular to the free edge, to the length of the free edge, is equal to or greater than 0.5.


### PR DESCRIPTION
Contributes to #3710 
Contributes #2873

This is following discussion of #4006. Considering there's a DataDefinition that explains that $SD$ is defined by $SD_x, SD_y, SD_z$, I _think_ it's safe to make this PR, but let me know if there's a better solution!