### PR TITLE
Enable `StrictData` in `-code` and `-database`, and gut out `section` pre-filling in some ChunkDBs

### DIFF
--- a/code/drasil-code/package.yaml
+++ b/code/drasil-code/package.yaml
@@ -7,6 +7,10 @@ github:              JacquesCarette/Drasil
 homepage:            https://jacquescarette.github.io/Drasil/
 description:         Please see the README on GitHub at <https://github.com/JacquesCarette/Drasil#readme>
 
+language: Haskell2010
+default-extensions:
+- StrictData
+
 extra-source-files: []
 
 dependencies:

--- a/code/drasil-database/package.yaml
+++ b/code/drasil-database/package.yaml
@@ -7,6 +7,10 @@ github:              JacquesCarette/Drasil
 homepage:            https://jacquescarette.github.io/Drasil/
 description:         Please see the README on GitHub at <https://github.com/JacquesCarette/Drasil#readme>
 
+language: Haskell2010
+default-extensions:
+- StrictData
+
 extra-source-files: []
 
 dependencies:

--- a/code/drasil-example/gamephysics/lib/Drasil/GamePhysics/Body.hs
+++ b/code/drasil-example/gamephysics/lib/Drasil/GamePhysics/Body.hs
@@ -133,9 +133,6 @@ purp = foldlSent_ [S "simulate", getAcc twoD, phrase CP.rigidBody,
 concIns :: [ConceptInstance]
 concIns = assumptions ++ goals ++ likelyChgs ++ unlikelyChgs ++ funcReqs ++ nonfuncReqs
 
-section :: [Section]
-section = extractSection srs
-
 stdFields :: Fields
 stdFields = [DefiningEquation, Description Verbose IncludeUnits, Notes, Source, RefBy]
 
@@ -157,7 +154,7 @@ symbMap = cdb (map (^. output) iMods ++ map qw symbolsAll) (nw gamePhysics :
   ++ [nw algorithm] ++ map nw derived ++ map nw fundamentals
   ++ map nw CM.mathcon ++ map nw CM.mathcon')
   (map cw defSymbols ++ srsDomains ++ map cw iMods) units dataDefs
-  iMods generalDefns tMods concIns section [] allRefs
+  iMods generalDefns tMods concIns [] [] allRefs
 
   -- | Holds all references and links used in the document.
 allRefs :: [Reference]

--- a/code/drasil-example/glassbr/lib/Drasil/GlassBR/Body.hs
+++ b/code/drasil-example/glassbr/lib/Drasil/GlassBR/Body.hs
@@ -142,7 +142,7 @@ symbMap = cdb thisSymbols (map nw acronyms ++ map nw thisSymbols ++ map nw con
    ++ [nw distance, nw algorithm] ++
   map nw fundamentals ++ map nw derived ++ map nw physicalcon)
   (map cw symb ++ terms ++ Doc.srsDomains) (map unitWrapper [metre, second, kilogram]
-  ++ map unitWrapper [pascal, newton]) GB.dataDefs iMods [] tMods concIns section
+  ++ map unitWrapper [pascal, newton]) GB.dataDefs iMods [] tMods concIns []
   labCon allRefs
 
 -- | Holds all references and links used in the document.
@@ -161,9 +161,6 @@ usedDB = cdb ([] :: [QuantityDict]) (map nw acronyms ++ map nw thisSymbols)
 
 refDB :: ReferenceDB
 refDB = rdb citations concIns
-
-section :: [Section]
-section = extractSection srs
 
 stdFields :: Fields
 stdFields = [DefiningEquation, Description Verbose IncludeUnits, Notes, Source, RefBy]

--- a/code/drasil-example/ssp/lib/Drasil/SSP/Body.hs
+++ b/code/drasil-example/ssp/lib/Drasil/SSP/Body.hs
@@ -148,9 +148,6 @@ units = map unitWrapper [metre, degree, kilogram, second] ++ map unitWrapper [ne
 concIns :: [ConceptInstance]
 concIns = goals ++ assumptions ++ funcReqs ++ nonFuncReqs ++ likelyChgs ++ unlikelyChgs
 
-section :: [Section]
-section = extractSection srs
-
 labCon :: [LabelledContent]
 labCon = [figPhysSyst, figIndexConv, figForceActing] ++ funcReqTables
 
@@ -167,7 +164,7 @@ symbMap = cdb (map (^. output) SSP.iMods ++ map qw symbols) (map nw symbols
   ++ map nw doccon' ++ map nw derived ++ map nw fundamentals ++ map nw educon
   ++ map nw compcon ++ [nw algorithm, nw ssp] ++ map nw units)
   (map cw SSP.iMods ++ map cw symbols ++ srsDomains) units SSP.dataDefs SSP.iMods
-  generalDefinitions tMods concIns section labCon allRefs
+  generalDefinitions tMods concIns [] labCon allRefs
 
 -- | Holds all references and links used in the document.
 allRefs :: [Reference]

--- a/code/drasil-example/swhs/lib/Drasil/SWHS/Body.hs
+++ b/code/drasil-example/swhs/lib/Drasil/SWHS/Body.hs
@@ -115,7 +115,7 @@ symbMap = cdb (qw (heatEInPCM ^. output) : symbolsAll) -- heatEInPCM ?
   ++ map nw fundamentals ++ map nw educon ++ map nw derived ++ map nw physicalcon ++ map nw unitalChuncks
   ++ [nw swhsPCM, nw algorithm] ++ map nw compcon ++ [nw materialProprty])
   (cw heatEInPCM : map cw symbols ++ srsDomains ++ map cw specParamValList) -- FIXME: heatEInPCM?
-  (units ++ [m_2, m_3]) SWHS.dataDefs insModel genDefs tMods concIns section [] allRefs
+  (units ++ [m_2, m_3]) SWHS.dataDefs insModel genDefs tMods concIns [] [] allRefs
 
 -- | Holds all references and links used in the document.
 allRefs :: [Reference]
@@ -182,9 +182,6 @@ insModel = [eBalanceOnWtr, eBalanceOnPCM, heatEInWtr, heatEInPCM]
 concIns :: [ConceptInstance]
 concIns = goals ++ assumptions ++ likelyChgs ++ unlikelyChgs ++ funcReqs
   ++ nfRequirements
-
-section :: [Section]
-section = extractSection srs
 
 stdFields :: Fields
 stdFields = [DefiningEquation, Description Verbose IncludeUnits, Notes, Source, RefBy]

--- a/code/drasil-example/swhsnopcm/lib/Drasil/SWHSNoPCM/Body.hs
+++ b/code/drasil-example/swhsnopcm/lib/Drasil/SWHSNoPCM/Body.hs
@@ -161,9 +161,6 @@ concIns :: [ConceptInstance]
 concIns = goals ++ funcReqs ++ nfRequirements ++ assumptions ++
  [likeChgTCVOD, likeChgTCVOL] ++ likelyChgs ++ [likeChgTLH] ++ unlikelyChgs
 
-section :: [Section]
-section = extractSection srs
-
 stdFields :: Fields
 stdFields = [DefiningEquation, Description Verbose IncludeUnits, Notes, Source, RefBy]
 
@@ -214,7 +211,7 @@ symbMap = cdb symbolsAll (nw progName : map nw symbols ++ map nw acronyms ++ map
   ++ map nw physicalcon ++ map nw unitalChuncks ++ map nw [absTol, relTol]
   ++ [nw srsSWHS, nw algorithm, nw inValue, nw htTrans, nw materialProprty, nw phsChgMtrl])
   (map cw symbols ++ srsDomains) units NoPCM.dataDefs NoPCM.iMods genDefs
-  tMods concIns section [] allRefs
+  tMods concIns [] [] allRefs
 
 -- | Holds all references and links used in the document.
 allRefs :: [Reference]

--- a/code/drasil-gen/lib/Language/Drasil/Dump.hs
+++ b/code/drasil-gen/lib/Language/Drasil/Dump.hs
@@ -2,7 +2,7 @@
 module Language.Drasil.Dump where
 
 import qualified Database.Drasil as DB
-import SysInfo.Drasil (SystemInformation(_sysinfodb))
+import SysInfo.Drasil (SystemInformation(_sysinfodb), sysinfodb)
 
 import System.Directory
 import System.IO
@@ -36,7 +36,7 @@ dumpEverything si pinfo p = do
 dumpEverything0 :: SystemInformation -> PrintingInformation -> Path -> IO ()
 dumpEverything0 si pinfo targetPath = do
   createDirectoryIfMissing True targetPath
-  let chunkDb = _sysinfodb si
+  let chunkDb = si ^. sysinfodb
       chunkDump = DB.dumpChunkDB chunkDb
       invertedChunkDump = invert chunkDump
       sharedUIDs = SM.filter atLeast2 invertedChunkDump

--- a/code/drasil-lang/lib/Language/Drasil.hs
+++ b/code/drasil-lang/lib/Language/Drasil.hs
@@ -226,7 +226,7 @@ module Language.Drasil (
   -- Language.Drasil.Document
   , Document(..), ShowTableOfContents(..), DType(..), Section(..)
   , Contents(..), SecCons(..), ListType(..), ItemType(..), ListTuple
-  , LabelledContent(..), UnlabelledContent(..), HasCaption(..), extractSection
+  , LabelledContent(..), UnlabelledContent(..), HasCaption(..)
   , mkParagraph, mkRawLC, checkToC
   , llcc, ulcc
   , section, fig, figNoCap, figWithWidth, figNoCapWithWidth
@@ -314,7 +314,7 @@ import Language.Drasil.CodeExpr.Lang (CodeExpr)
 import Language.Drasil.CodeExpr.Class (CodeExprC(..))
 import Language.Drasil.Document (section, fig, figNoCap, figWithWidth, figNoCapWithWidth
   , Section(..), SecCons(..) , llcc, ulcc, Document(..)
-  , mkParagraph, mkFig, mkRawLC, ShowTableOfContents(..), checkToC, extractSection
+  , mkParagraph, mkFig, mkRawLC, ShowTableOfContents(..), checkToC
   , makeTabRef, makeFigRef, makeSecRef, makeEqnRef, makeURI
   , makeTabRef', makeFigRef', makeSecRef', makeEqnRef', makeURI')
 import Language.Drasil.Document.Core (Contents(..), ListType(..), ItemType(..), DType(..)

--- a/code/drasil-lang/lib/Language/Drasil/Document.hs
+++ b/code/drasil-lang/lib/Language/Drasil/Document.hs
@@ -119,20 +119,6 @@ mkRawLC x lb = llcc lb x
 section :: Sentence -> [Contents] -> [Section] -> Reference -> Section
 section title intro secs = Section title (map Con intro ++ map Sub secs)
 
--- | Smart constructor for retrieving the contents ('Section's) from a 'Document'.
-extractSection :: Document -> [Section]
-extractSection (Document _ _ _ sec) = concatMap getSec sec
-extractSection (Notebook _ _ sec)   = concatMap getSec sec
-
--- | Smart constructor for retrieving the subsections ('Section's) within a 'Section'.
-getSec :: Section -> [Section]
-getSec t@(Section _ sc _) = t : concatMap getSecCons sc
-
--- | Helper to retrieve subsections ('Section's) from section contents ('SecCons').
-getSecCons :: SecCons -> [Section]
-getSecCons (Sub sec) = getSec sec
-getSecCons (Con _)   = []
-
 -- | 'Figure' smart constructor with a 'Lbl' and a 'Filepath'. Assumes 100% of page width as max width. Defaults to 'WithCaption'.
 fig :: Lbl -> Filepath -> RawContent
 fig l f = Figure l f 100 WithCaption


### PR DESCRIPTION
Contributes to #3710 and #2873
Builds on #4003, #4007, and #4012

* Enables `StrictData` for `drasil-code` and `drasil-database`. The former was made possible by #4012 but I was hesitant to enable it until we've enabled SD in -database too. The latter is possible by the next point.
* All ChunkDB 'section tables' are automatically filled in our code generation step. For some examples, it was manually filled too. That manual code had a mutual definition chain between the system information and a chunkdb.