### PR TITLE
Remove unused `SectionTable` from ChunkDB.

### DIFF
--- a/code/drasil-database/lib/Database/Drasil.hs
+++ b/code/drasil-database/lib/Database/Drasil.hs
@@ -10,11 +10,11 @@ module Database.Drasil (
   , termResolve, defResolve, symbResolve
   , traceLookup, refbyLookup
   , datadefnLookup, insmodelLookup, gendefLookup, theoryModelLookup
-  , conceptinsLookup, sectionLookup, labelledconLookup, refResolve
+  , conceptinsLookup, labelledconLookup, refResolve
   -- ** Lenses
   , unitTable, traceTable, refbyTable
   , dataDefnTable, insmodelTable, gendefTable, theoryModelTable
-  , conceptinsTable, sectionTable, labelledcontentTable, refTable
+  , conceptinsTable, labelledcontentTable, refTable
   -- ** Debugging Tools
   , dumpChunkDB, DumpedChunkDB
 ) where

--- a/code/drasil-database/lib/Database/Drasil/ChunkDB.hs
+++ b/code/drasil-database/lib/Database/Drasil/ChunkDB.hs
@@ -20,11 +20,11 @@ module Database.Drasil.ChunkDB (
   termResolve, defResolve, symbResolve,
   traceLookup, refbyLookup,
   datadefnLookup, insmodelLookup, gendefLookup, theoryModelLookup,
-  conceptinsLookup, sectionLookup, labelledconLookup, refResolve,
+  conceptinsLookup, labelledconLookup, refResolve,
   -- ** Lenses
   unitTable, traceTable, refbyTable,
   dataDefnTable, insmodelTable, gendefTable, theoryModelTable,
-  conceptinsTable, sectionTable, labelledcontentTable, refTable
+  conceptinsTable, labelledcontentTable, refTable
 ) where
 
 import Language.Drasil
@@ -71,8 +71,6 @@ type GendefMap = UMap GenDefn
 type TheoryModelMap = UMap TheoryModel
 -- | Concept instance map. May hold similar information to a 'ConceptMap', but may also be referred to.
 type ConceptInstanceMap = UMap ConceptInstance
--- | A map of all the different 'Section's.
-type SectionMap = UMap Section
 -- | A map of all 'LabelledContent's.
 type LabelledContentMap = UMap LabelledContent
 -- | A map of all 'Reference's.
@@ -155,10 +153,6 @@ theoryModelLookup = uMapLookup "TheoryModel" "TheoryModelMap"
 conceptinsLookup :: UID -> ConceptInstanceMap -> ConceptInstance
 conceptinsLookup = uMapLookup "ConceptInstance" "ConceptInstanceMap"
 
--- | Looks up a 'UID' in the section table. If nothing is found, an error is thrown.
-sectionLookup :: UID -> SectionMap -> Section
-sectionLookup = uMapLookup "Section" "SectionMap"
-
 -- | Looks up a 'UID' in the labelled content table. If nothing is found, an error is thrown.
 labelledconLookup :: UID -> LabelledContentMap -> LabelledContent
 labelledconLookup = uMapLookup "LabelledContent" "LabelledContentMap"
@@ -181,7 +175,6 @@ data ChunkDB = CDB { symbolTable           :: SymbolMap
                    , _gendefTable          :: GendefMap
                    , _theoryModelTable     :: TheoryModelMap
                    , _conceptinsTable      :: ConceptInstanceMap
-                   , _sectionTable         :: SectionMap
                    , _labelledcontentTable :: LabelledContentMap
                    , _refTable             :: ReferenceMap
                    } -- TODO: Expand and add more databases
@@ -202,11 +195,11 @@ makeLenses ''ChunkDB
 --     * 'LabelledContent's (for 'LabelledContentMap').
 cdb :: (Quantity q, MayHaveUnit q, Idea t, Concept c, IsUnit u) =>
     [q] -> [t] -> [c] -> [u] -> [DataDefinition] -> [InstanceModel] ->
-    [GenDefn] -> [TheoryModel] -> [ConceptInstance] -> [Section] ->
+    [GenDefn] -> [TheoryModel] -> [ConceptInstance] ->
     [LabelledContent] -> [Reference] -> ChunkDB
-cdb s t c u d ins gd tm ci sect lc r = CDB (symbolMap s) (termMap t) (conceptMap c)
+cdb s t c u d ins gd tm ci lc r = CDB (symbolMap s) (termMap t) (conceptMap c)
   (unitMap u) Map.empty Map.empty (idMap d) (idMap ins) (idMap gd) (idMap tm)
-  (idMap ci) (idMap sect) (idMap lc) (idMap r)
+  (idMap ci) (idMap lc) (idMap r)
 
 -- | Gets the units of a 'Quantity' as 'UnitDefn's.
 collectUnits :: Quantity c => ChunkDB -> [c] -> [UnitDefn]

--- a/code/drasil-database/lib/Database/Drasil/ChunkDB.hs
+++ b/code/drasil-database/lib/Database/Drasil/ChunkDB.hs
@@ -191,7 +191,6 @@ makeLenses ''ChunkDB
 --     * 'GenDefn's (for 'GendefMap'),
 --     * 'TheoryModel's (for 'TheoryModelMap'),
 --     * 'ConceptInstance's (for 'ConceptInstanceMap'),
---     * 'Section's (for 'SectionMap'),
 --     * 'LabelledContent's (for 'LabelledContentMap').
 cdb :: (Quantity q, MayHaveUnit q, Idea t, Concept c, IsUnit u) =>
     [q] -> [t] -> [c] -> [u] -> [DataDefinition] -> [InstanceModel] ->

--- a/code/drasil-database/lib/Database/Drasil/Dump.hs
+++ b/code/drasil-database/lib/Database/Drasil/Dump.hs
@@ -1,7 +1,7 @@
 module Database.Drasil.Dump where
 
 import Language.Drasil (UID, HasUID(..))
-import Database.Drasil.ChunkDB (refTable, labelledcontentTable, sectionTable, 
+import Database.Drasil.ChunkDB (refTable, labelledcontentTable, 
   conceptinsTable, theoryModelTable, gendefTable, insmodelTable, dataDefnTable,
   unitTable, UMap, ChunkDB(termTable, symbolTable))
 
@@ -27,7 +27,6 @@ dumpChunkDB cdb =
     $ insert "generalDefinitions" (umapDump $ cdb ^. gendefTable)
     $ insert "theoryModels" (umapDump $ cdb ^. theoryModelTable)
     $ insert "conceptInstances" (umapDump $ cdb ^. conceptinsTable)
-    $ insert "sections" (umapDump $ cdb ^. sectionTable)
     $ insert "labelledContent" (umapDump $ cdb ^. labelledcontentTable)
     $ insert "references" (umapDump $ cdb ^. refTable)
       mempty

--- a/code/drasil-docLang/lib/Drasil/DocumentLanguage.hs
+++ b/code/drasil-docLang/lib/Drasil/DocumentLanguage.hs
@@ -130,11 +130,9 @@ fillSecAndLC dd si = si2
     -- extract sections and labelledcontent
     allSections = concatMap findAllSec $ mkSections si $ mkDocDesc si dd
     allLC = concatMap findAllLC allSections
-    existingSections = map (fst.snd) $ Map.assocs $ chkdb ^. sectionTable
     existingLC = map (fst.snd) $ Map.assocs $ chkdb ^. labelledcontentTable
     -- fill in the appropriate chunkdb fields
-    chkdb2 = set labelledcontentTable (idMap $ nub $ existingLC ++ allLC)
-      $ set sectionTable (idMap $ nub $ existingSections ++ allSections) chkdb
+    chkdb2 = set labelledcontentTable (idMap $ nub $ existingLC ++ allLC) chkdb
     -- return the filled in system information
     si2 = set sysinfodb chkdb2 si
     -- Helper and finder functions
@@ -169,7 +167,6 @@ fillReferences dd si@SI{_sys = sys} = si2
     imods   = map (fst.snd) $ Map.assocs $ chkdb ^. insmodelTable
     tmods   = map (fst.snd) $ Map.assocs $ chkdb ^. theoryModelTable
     concIns = map (fst.snd) $ Map.assocs $ chkdb ^. conceptinsTable
-    secs    = map (fst.snd) $ Map.assocs $ chkdb ^. sectionTable
     lblCon  = map (fst.snd) $ Map.assocs $ chkdb ^. labelledcontentTable
     cites   = citeDB si -- map (fst.snd) $ Map.assocs $ rfdb  ^. citationDB
     conins  = map (fst.snd) $ Map.assocs $ rfdb  ^. conceptDB
@@ -180,7 +177,7 @@ fillReferences dd si@SI{_sys = sys} = si2
       ++ map (ref.makeTabRef'.getTraceConfigUID) (traceMatStandard si) ++ secRefs -- secRefs can be removed once #946 is complete
       ++ traceyGraphGetRefs (programName sys) ++ map ref cites
       ++ map ref conins ++ map ref ddefs ++ map ref gdefs ++ map ref imods
-      ++ map ref tmods ++ map ref concIns ++ map ref secs ++ map ref lblCon
+      ++ map ref tmods ++ map ref concIns ++ map ref lblCon
       ++ refs) chkdb
     -- set new chunk database into system information
     si2 = set sysinfodb chkdb2 si

--- a/code/drasil-docLang/lib/Drasil/DocumentLanguage/Definitions.hs
+++ b/code/drasil-docLang/lib/Drasil/DocumentLanguage/Definitions.hs
@@ -120,7 +120,6 @@ helpToRefField t si
   | Just _ <- lookupIndex t (s ^. gendefTable)          = refS $ gendefLookup      t (s ^. gendefTable)
   | Just _ <- lookupIndex t (s ^. theoryModelTable)     = refS $ theoryModelLookup t (s ^. theoryModelTable)
   | Just _ <- lookupIndex t (s ^. conceptinsTable)      = refS $ conceptinsLookup  t (s ^. conceptinsTable)
-  | Just _ <- lookupIndex t (s ^. sectionTable)         = refS $ sectionLookup     t (s ^. sectionTable)
   | Just _ <- lookupIndex t (s ^. labelledcontentTable) = refS $ labelledconLookup t (s ^. labelledcontentTable)
   | t `elem` map  (^. uid) (citeDB si) = EmptyS
   | otherwise = error $ show t ++ "Caught."

--- a/code/drasil-docLang/lib/Drasil/DocumentLanguage/TraceabilityGraph.hs
+++ b/code/drasil-docLang/lib/Drasil/DocumentLanguage/TraceabilityGraph.hs
@@ -101,7 +101,6 @@ checkUID t si
   | Just _ <- Map.lookupIndex t (s ^. gendefTable)          = t
   | Just _ <- Map.lookupIndex t (s ^. theoryModelTable)     = t
   | Just _ <- Map.lookupIndex t (s ^. conceptinsTable)      = t
-  | Just _ <- Map.lookupIndex t (s ^. sectionTable)         = t
   | Just _ <- Map.lookupIndex t (s ^. labelledcontentTable) = t
   | t `elem` map  (^. uid) (citeDB si) = mkUid ""
   | otherwise = error $ show t ++ "Caught."
@@ -115,7 +114,6 @@ checkUIDAbbrev si t
   | Just (x, _) <- Map.lookup t (s ^. gendefTable)          = abrv x
   | Just (x, _) <- Map.lookup t (s ^. theoryModelTable)     = abrv x
   | Just (x, _) <- Map.lookup t (s ^. conceptinsTable)      = fromMaybe "" $ getA $ defResolve s $ sDom $ cdom x
-  | Just _ <- Map.lookup t (s ^. sectionTable)              = show t -- shouldn't really reach these cases
   | Just _ <- Map.lookup t (s ^. labelledcontentTable)      = show t
   | t `elem` map  (^. uid) (citeDB si) = ""
   | otherwise = error $ show t ++ "Caught."
@@ -130,7 +128,6 @@ checkUIDRefAdd si t
   | Just (x, _) <- Map.lookup t (s ^. theoryModelTable)     = getAdd $ getRefAdd x
   -- Concept instances can range from likely changes to non-functional requirements, so use domain abbreviations for labelling in addition to the reference address.
   | Just (x, _) <- Map.lookup t (s ^. conceptinsTable)      = fromMaybe "" (getA $ defResolve s $ sDom $ cdom x) ++ ":" ++ getAdd (getRefAdd x)
-  | Just _ <- Map.lookup t (s ^. sectionTable)              = show t -- shouldn't really reach these cases
   | Just _ <- Map.lookup t (s ^. labelledcontentTable)      = show t
   | t `elem` map  (^. uid) (citeDB si) = ""
   | otherwise = error $ show t ++ "Caught."

--- a/code/drasil-example/dblpend/lib/Drasil/DblPend/Body.hs
+++ b/code/drasil-example/dblpend/lib/Drasil/DblPend/Body.hs
@@ -152,7 +152,7 @@ symbMap = cdb (map (^. output) iMods ++ map qw symbolsAll)
    map nw physicscon ++ concepts ++ map nw physicalcon ++ map nw acronyms ++ map nw symbols ++ map nw [metre, hertz] ++
    [nw algorithm] ++ map nw compcon ++ map nw educon ++ map nw prodtcon)
   (map cw iMods ++ srsDomains) (map unitWrapper [metre, second, newton, kilogram, degree, radian, hertz])
-  dataDefs iMods genDefns tMods concIns [] [] allRefs
+  dataDefs iMods genDefns tMods concIns [] allRefs
 
 -- | Holds all references and links used in the document.
 allRefs :: [Reference]
@@ -160,7 +160,7 @@ allRefs = [externalLinkRef]
 
 usedDB :: ChunkDB
 usedDB = cdb ([] :: [QuantityDict]) (nw progName : map nw acronyms ++ map nw symbols) ([] :: [ConceptChunk])
-  ([] :: [UnitDefn]) [] [] [] [] [] [] [] ([] :: [Reference])
+  ([] :: [UnitDefn]) [] [] [] [] [] [] ([] :: [Reference])
 
 stdFields :: Fields
 stdFields = [DefiningEquation, Description Verbose IncludeUnits, Notes, Source, RefBy]

--- a/code/drasil-example/gamephysics/lib/Drasil/GamePhysics/Body.hs
+++ b/code/drasil-example/gamephysics/lib/Drasil/GamePhysics/Body.hs
@@ -133,9 +133,6 @@ purp = foldlSent_ [S "simulate", getAcc twoD, phrase CP.rigidBody,
 concIns :: [ConceptInstance]
 concIns = assumptions ++ goals ++ likelyChgs ++ unlikelyChgs ++ funcReqs ++ nonfuncReqs
 
-section :: [Section]
-section = extractSection srs
-
 stdFields :: Fields
 stdFields = [DefiningEquation, Description Verbose IncludeUnits, Notes, Source, RefBy]
 
@@ -157,7 +154,7 @@ symbMap = cdb (map (^. output) iMods ++ map qw symbolsAll) (nw gamePhysics :
   ++ [nw algorithm] ++ map nw derived ++ map nw fundamentals
   ++ map nw CM.mathcon ++ map nw CM.mathcon')
   (map cw defSymbols ++ srsDomains ++ map cw iMods) units dataDefs
-  iMods generalDefns tMods concIns section [] allRefs
+  iMods generalDefns tMods concIns [] allRefs
 
   -- | Holds all references and links used in the document.
 allRefs :: [Reference]
@@ -165,7 +162,7 @@ allRefs = [externalLinkRef, pymunk] ++ offShelfSolRefs
 
 usedDB :: ChunkDB
 usedDB = cdb ([] :: [QuantityDict]) (map nw symbolsAll ++ map nw acronyms)
-  ([] :: [ConceptChunk]) ([] :: [UnitDefn]) [] [] [] [] [] [] [] ([] :: [Reference])
+  ([] :: [ConceptChunk]) ([] :: [UnitDefn]) [] [] [] [] [] [] ([] :: [Reference])
 
 --FIXME: The SRS has been partly switched over to the new docLang, so some of
 -- the sections below are now redundant. I have not removed them yet, because

--- a/code/drasil-example/glassbr/lib/Drasil/GlassBR/Body.hs
+++ b/code/drasil-example/glassbr/lib/Drasil/GlassBR/Body.hs
@@ -142,7 +142,7 @@ symbMap = cdb thisSymbols (map nw acronyms ++ map nw thisSymbols ++ map nw con
    ++ [nw distance, nw algorithm] ++
   map nw fundamentals ++ map nw derived ++ map nw physicalcon)
   (map cw symb ++ terms ++ Doc.srsDomains) (map unitWrapper [metre, second, kilogram]
-  ++ map unitWrapper [pascal, newton]) GB.dataDefs iMods [] tMods concIns section
+  ++ map unitWrapper [pascal, newton]) GB.dataDefs iMods [] tMods concIns
   labCon allRefs
 
 -- | Holds all references and links used in the document.
@@ -157,13 +157,10 @@ labCon = funcReqsTables ++ [demandVsSDFig, dimlessloadVsARFig]
 
 usedDB :: ChunkDB
 usedDB = cdb ([] :: [QuantityDict]) (map nw acronyms ++ map nw thisSymbols)
- ([] :: [ConceptChunk]) ([] :: [UnitDefn]) [] [] [] [] [] [] [] ([] :: [Reference])
+ ([] :: [ConceptChunk]) ([] :: [UnitDefn]) [] [] [] [] [] [] ([] :: [Reference])
 
 refDB :: ReferenceDB
 refDB = rdb citations concIns
-
-section :: [Section]
-section = extractSection srs
 
 stdFields :: Fields
 stdFields = [DefiningEquation, Description Verbose IncludeUnits, Notes, Source, RefBy]

--- a/code/drasil-example/hghc/lib/Drasil/HGHC/Body.hs
+++ b/code/drasil-example/hghc/lib/Drasil/HGHC/Body.hs
@@ -67,9 +67,9 @@ symbMap :: ChunkDB
 symbMap = cdb symbols (map nw symbols ++ map nw doccon ++ map nw fundamentals ++ map nw derived
   ++ [nw fp, nw nuclearPhys, nw hghc, nw degree] ++ map nw doccon' ++ map nw mathcon)
   ([] :: [ConceptChunk])-- FIXME: Fill in concepts
-  siUnits dataDefs [] [] [] [] [] [] []
+  siUnits dataDefs [] [] [] [] [] []
 
 usedDB :: ChunkDB
 usedDB = cdb ([] :: [QuantityDict]) (map nw symbols)
            ([] :: [ConceptChunk]) ([] :: [UnitDefn])
-           [] [] [] [] [] [] [] ([] :: [Reference])
+           [] [] [] [] [] [] ([] :: [Reference])

--- a/code/drasil-example/pdcontroller/lib/Drasil/PDController/Body.hs
+++ b/code/drasil-example/pdcontroller/lib/Drasil/PDController/Body.hs
@@ -151,7 +151,6 @@ symbMap = cdb (map qw physicscon ++ symbolsAll ++ [qw mass, qw posInf, qw negInf
   genDefns
   theoreticalModels
   conceptInstances
-  ([] :: [Section])
   ([] :: [LabelledContent])
   allRefs
 
@@ -168,7 +167,6 @@ usedDB = cdb ([] :: [QuantityDict]) (map nw acronyms ++ map nw symbolsAll)
   ([] :: [GenDefn])
   ([] :: [TheoryModel])
   ([] :: [ConceptInstance])
-  ([] :: [Section])
   ([] :: [LabelledContent])
   ([] :: [Reference])
 

--- a/code/drasil-example/projectile/lib/Drasil/Projectile/Body.hs
+++ b/code/drasil-example/projectile/lib/Drasil/Projectile/Body.hs
@@ -177,7 +177,7 @@ symbMap = cdb (qw pi_ : map qw physicscon ++ unitalQuants ++ symbols)
     [nw sciCompS] ++ unitalIdeas ++ map nw acronyms ++ map nw symbols ++ 
     map nw educon ++ map nw [metre, radian, second] ++ map nw compcon) 
   (cw pi_ : map cw constrained ++ srsDomains) (map unitWrapper [metre, radian, second]) 
-  dataDefs iMods genDefns tMods concIns [] [] allRefs
+  dataDefs iMods genDefns tMods concIns [] allRefs
 
 -- | Holds all references and links used in the document.
 allRefs :: [Reference]
@@ -185,7 +185,7 @@ allRefs = [externalLinkRef]
 
 usedDB :: ChunkDB
 usedDB = cdb ([] :: [QuantityDict]) (nw pi_ : map nw acronyms ++ map nw symbols)
-  (cw pi_ : srsDomains) ([] :: [UnitDefn]) [] [] [] [] [] [] [] ([] :: [Reference])
+  (cw pi_ : srsDomains) ([] :: [UnitDefn]) [] [] [] [] [] [] ([] :: [Reference])
 
 stdFields :: Fields
 stdFields = [DefiningEquation, Description Verbose IncludeUnits, Notes, Source, RefBy]

--- a/code/drasil-example/projectile/lib/Drasil/Projectile/Lesson/Body.hs
+++ b/code/drasil-example/projectile/lib/Drasil/Projectile/Lesson/Body.hs
@@ -69,12 +69,12 @@ si = SI {
 symbMap :: ChunkDB
 symbMap = cdb (map qw physicscon ++ symbols) (nw projectileMotion : map nw doccon ++ 
   map nw doccon' ++ map nw physicCon ++ concepts ++ map nw mathcon ++ map nw symbols) 
-  ([] :: [ConceptChunk]) ([] :: [UnitDefn]) [] [] [] [] [] [] [] allRefs
+  ([] :: [ConceptChunk]) ([] :: [UnitDefn]) [] [] [] [] [] [] allRefs
 
 usedDB :: ChunkDB
 usedDB = cdb ([] :: [QuantityDict]) (map nw symbols :: [IdeaDict]) ([] :: [ConceptChunk])
   ([] :: [UnitDefn]) [] [] [] [] ([] :: [ConceptInstance])
-  ([] :: [Section]) ([] :: [LabelledContent]) ([] :: [Reference])
+  ([] :: [LabelledContent]) ([] :: [Reference])
 
 symbols :: [QuantityDict]
 symbols = [qw horiz_velo]

--- a/code/drasil-example/sglpend/lib/Drasil/SglPend/Body.hs
+++ b/code/drasil-example/sglpend/lib/Drasil/SglPend/Body.hs
@@ -140,7 +140,7 @@ symbMap = cdb (map (^. output) iMods ++ map qw symbols)
    map nw physicscon ++ concepts ++ map nw physicalcon ++ map nw acronyms ++ map nw symbols ++ map nw [metre, hertz] ++
    [nw algorithm] ++ map nw compcon ++ map nw educon ++ map nw prodtcon)
   (map cw iMods ++ srsDomains) (map unitWrapper [metre, second, newton, kilogram, degree, radian, hertz]) dataDefs
-  iMods genDefns tMods concIns [] [] allRefs
+  iMods genDefns tMods concIns [] allRefs
 
 -- | Holds all references and links used in the document.
 allRefs :: [Reference]
@@ -148,7 +148,7 @@ allRefs = [externalLinkRef]
 
 usedDB :: ChunkDB
 usedDB = cdb ([] :: [QuantityDict]) (nw progName : map nw acronyms ++ map nw symbols) ([] :: [ConceptChunk])
-  ([] :: [UnitDefn]) [] [] [] [] [] [] [] ([] :: [Reference])
+  ([] :: [UnitDefn]) [] [] [] [] [] [] ([] :: [Reference])
 
 refDB :: ReferenceDB
 refDB = rdb citations concIns

--- a/code/drasil-example/ssp/lib/Drasil/SSP/Body.hs
+++ b/code/drasil-example/ssp/lib/Drasil/SSP/Body.hs
@@ -148,9 +148,6 @@ units = map unitWrapper [metre, degree, kilogram, second] ++ map unitWrapper [ne
 concIns :: [ConceptInstance]
 concIns = goals ++ assumptions ++ funcReqs ++ nonFuncReqs ++ likelyChgs ++ unlikelyChgs
 
-section :: [Section]
-section = extractSection srs
-
 labCon :: [LabelledContent]
 labCon = [figPhysSyst, figIndexConv, figForceActing] ++ funcReqTables
 
@@ -167,7 +164,7 @@ symbMap = cdb (map (^. output) SSP.iMods ++ map qw symbols) (map nw symbols
   ++ map nw doccon' ++ map nw derived ++ map nw fundamentals ++ map nw educon
   ++ map nw compcon ++ [nw algorithm, nw ssp] ++ map nw units)
   (map cw SSP.iMods ++ map cw symbols ++ srsDomains) units SSP.dataDefs SSP.iMods
-  generalDefinitions tMods concIns section labCon allRefs
+  generalDefinitions tMods concIns labCon allRefs
 
 -- | Holds all references and links used in the document.
 allRefs :: [Reference]
@@ -175,7 +172,7 @@ allRefs = [externalLinkRef]
 
 usedDB :: ChunkDB
 usedDB = cdb ([] :: [QuantityDict]) (map nw symbols ++ map nw acronyms)
- ([] :: [ConceptChunk]) ([] :: [UnitDefn]) [] [] [] [] [] [] [] ([] :: [Reference])
+ ([] :: [ConceptChunk]) ([] :: [UnitDefn]) [] [] [] [] [] [] ([] :: [Reference])
 
 refDB :: ReferenceDB
 refDB = rdb citations concIns

--- a/code/drasil-example/swhs/lib/Drasil/SWHS/Body.hs
+++ b/code/drasil-example/swhs/lib/Drasil/SWHS/Body.hs
@@ -115,7 +115,7 @@ symbMap = cdb (qw (heatEInPCM ^. output) : symbolsAll) -- heatEInPCM ?
   ++ map nw fundamentals ++ map nw educon ++ map nw derived ++ map nw physicalcon ++ map nw unitalChuncks
   ++ [nw swhsPCM, nw algorithm] ++ map nw compcon ++ [nw materialProprty])
   (cw heatEInPCM : map cw symbols ++ srsDomains ++ map cw specParamValList) -- FIXME: heatEInPCM?
-  (units ++ [m_2, m_3]) SWHS.dataDefs insModel genDefs tMods concIns section [] allRefs
+  (units ++ [m_2, m_3]) SWHS.dataDefs insModel genDefs tMods concIns [] allRefs
 
 -- | Holds all references and links used in the document.
 allRefs :: [Reference]
@@ -123,7 +123,7 @@ allRefs = [externalLinkRef]
 
 usedDB :: ChunkDB
 usedDB = cdb ([] :: [QuantityDict]) (map nw symbols ++ map nw acronymsFull)
- ([] :: [ConceptChunk]) ([] :: [UnitDefn]) [] [] [] [] [] [] [] ([] :: [Reference])
+ ([] :: [ConceptChunk]) ([] :: [UnitDefn]) [] [] [] [] [] [] ([] :: [Reference])
 
 refDB :: ReferenceDB
 refDB = rdb citations concIns
@@ -182,9 +182,6 @@ insModel = [eBalanceOnWtr, eBalanceOnPCM, heatEInWtr, heatEInPCM]
 concIns :: [ConceptInstance]
 concIns = goals ++ assumptions ++ likelyChgs ++ unlikelyChgs ++ funcReqs
   ++ nfRequirements
-
-section :: [Section]
-section = extractSection srs
 
 stdFields :: Fields
 stdFields = [DefiningEquation, Description Verbose IncludeUnits, Notes, Source, RefBy]

--- a/code/drasil-example/swhsnopcm/lib/Drasil/SWHSNoPCM/Body.hs
+++ b/code/drasil-example/swhsnopcm/lib/Drasil/SWHSNoPCM/Body.hs
@@ -161,9 +161,6 @@ concIns :: [ConceptInstance]
 concIns = goals ++ funcReqs ++ nfRequirements ++ assumptions ++
  [likeChgTCVOD, likeChgTCVOL] ++ likelyChgs ++ [likeChgTLH] ++ unlikelyChgs
 
-section :: [Section]
-section = extractSection srs
-
 stdFields :: Fields
 stdFields = [DefiningEquation, Description Verbose IncludeUnits, Notes, Source, RefBy]
 
@@ -214,7 +211,7 @@ symbMap = cdb symbolsAll (nw progName : map nw symbols ++ map nw acronyms ++ map
   ++ map nw physicalcon ++ map nw unitalChuncks ++ map nw [absTol, relTol]
   ++ [nw srsSWHS, nw algorithm, nw inValue, nw htTrans, nw materialProprty, nw phsChgMtrl])
   (map cw symbols ++ srsDomains) units NoPCM.dataDefs NoPCM.iMods genDefs
-  tMods concIns section [] allRefs
+  tMods concIns [] allRefs
 
 -- | Holds all references and links used in the document.
 allRefs :: [Reference]
@@ -222,7 +219,7 @@ allRefs = [externalLinkRef, externalLinkRef']
 
 usedDB :: ChunkDB
 usedDB = cdb ([] :: [QuantityDict]) (nw progName : map nw symbols ++ map nw acronyms)
- ([] :: [ConceptChunk]) ([] :: [UnitDefn]) [] [] [] [] [] [] [] ([] :: [Reference])
+ ([] :: [ConceptChunk]) ([] :: [UnitDefn]) [] [] [] [] [] [] ([] :: [Reference])
 
 --------------------------
 --Section 2 : INTRODUCTION

--- a/code/drasil-example/template/lib/Drasil/Template/Body.hs
+++ b/code/drasil-example/template/lib/Drasil/Template/Body.hs
@@ -114,13 +114,13 @@ symbMap = cdb ([] :: [QuantityDict]) (nw progName : nw inValue : [nw errMsg,
   map nw prodtcon ++ map nw mathcon) srsDomains
   ([] :: [UnitDefn]) ([] :: [DataDefinition]) ([] :: [InstanceModel])
   ([] :: [GenDefn]) ([] :: [TheoryModel]) ([] :: [ConceptInstance])
-  ([] :: [Section]) ([] :: [LabelledContent]) ([] :: [Reference])
+  ([] :: [LabelledContent]) ([] :: [Reference])
 
 usedDB :: ChunkDB
 usedDB = cdb ([] :: [QuantityDict]) ([] :: [IdeaDict]) ([] :: [ConceptChunk])
   ([] :: [UnitDefn]) ([] :: [DataDefinition]) ([] :: [InstanceModel])
   ([] :: [GenDefn]) ([] :: [TheoryModel]) ([] :: [ConceptInstance])
-  ([] :: [Section]) ([] :: [LabelledContent]) ([] :: [Reference])
+  ([] :: [LabelledContent]) ([] :: [Reference])
 
 refDB :: ReferenceDB
 refDB = rdb citations []

--- a/code/drasil-gen/lib/Language/Drasil/Dump.hs
+++ b/code/drasil-gen/lib/Language/Drasil/Dump.hs
@@ -2,7 +2,7 @@
 module Language.Drasil.Dump where
 
 import qualified Database.Drasil as DB
-import SysInfo.Drasil (SystemInformation(_sysinfodb))
+import SysInfo.Drasil (SystemInformation, sysinfodb)
 
 import System.Directory
 import System.IO
@@ -36,7 +36,7 @@ dumpEverything si pinfo p = do
 dumpEverything0 :: SystemInformation -> PrintingInformation -> Path -> IO ()
 dumpEverything0 si pinfo targetPath = do
   createDirectoryIfMissing True targetPath
-  let chunkDb = _sysinfodb si
+  let chunkDb = si ^. sysinfodb
       chunkDump = DB.dumpChunkDB chunkDb
       invertedChunkDump = invert chunkDump
       sharedUIDs = SM.filter atLeast2 invertedChunkDump

--- a/code/drasil-lang/lib/Language/Drasil.hs
+++ b/code/drasil-lang/lib/Language/Drasil.hs
@@ -226,7 +226,7 @@ module Language.Drasil (
   -- Language.Drasil.Document
   , Document(..), ShowTableOfContents(..), DType(..), Section(..)
   , Contents(..), SecCons(..), ListType(..), ItemType(..), ListTuple
-  , LabelledContent(..), UnlabelledContent(..), HasCaption(..), extractSection
+  , LabelledContent(..), UnlabelledContent(..), HasCaption(..)
   , mkParagraph, mkRawLC, checkToC
   , llcc, ulcc
   , section, fig, figNoCap, figWithWidth, figNoCapWithWidth
@@ -314,7 +314,7 @@ import Language.Drasil.CodeExpr.Lang (CodeExpr)
 import Language.Drasil.CodeExpr.Class (CodeExprC(..))
 import Language.Drasil.Document (section, fig, figNoCap, figWithWidth, figNoCapWithWidth
   , Section(..), SecCons(..) , llcc, ulcc, Document(..)
-  , mkParagraph, mkFig, mkRawLC, ShowTableOfContents(..), checkToC, extractSection
+  , mkParagraph, mkFig, mkRawLC, ShowTableOfContents(..), checkToC
   , makeTabRef, makeFigRef, makeSecRef, makeEqnRef, makeURI
   , makeTabRef', makeFigRef', makeSecRef', makeEqnRef', makeURI')
 import Language.Drasil.Document.Core (Contents(..), ListType(..), ItemType(..), DType(..)

--- a/code/drasil-lang/lib/Language/Drasil/Document.hs
+++ b/code/drasil-lang/lib/Language/Drasil/Document.hs
@@ -119,20 +119,6 @@ mkRawLC x lb = llcc lb x
 section :: Sentence -> [Contents] -> [Section] -> Reference -> Section
 section title intro secs = Section title (map Con intro ++ map Sub secs)
 
--- | Smart constructor for retrieving the contents ('Section's) from a 'Document'.
-extractSection :: Document -> [Section]
-extractSection (Document _ _ _ sec) = concatMap getSec sec
-extractSection (Notebook _ _ sec)   = concatMap getSec sec
-
--- | Smart constructor for retrieving the subsections ('Section's) within a 'Section'.
-getSec :: Section -> [Section]
-getSec t@(Section _ sc _) = t : concatMap getSecCons sc
-
--- | Helper to retrieve subsections ('Section's) from section contents ('SecCons').
-getSecCons :: SecCons -> [Section]
-getSecCons (Sub sec) = getSec sec
-getSecCons (Con _)   = []
-
 -- | 'Figure' smart constructor with a 'Lbl' and a 'Filepath'. Assumes 100% of page width as max width. Defaults to 'WithCaption'.
 fig :: Lbl -> Filepath -> RawContent
 fig l f = Figure l f 100 WithCaption

--- a/code/drasil-printers/lib/Language/Drasil/Debug/Print.hs
+++ b/code/drasil-printers/lib/Language/Drasil/Debug/Print.hs
@@ -36,7 +36,6 @@ printAllDebugInfo pinfo = map
   , mkTableTMod
   , mkTableIMod
   , mkTableCI
-  , mkTableSec
   , mkTableLC
   , mkTableRef
   , renderUsedUIDs . mkListShowUsedUIDs]
@@ -194,14 +193,6 @@ mkTableCI pinfo = mkTableFromLenses
   "ConceptInstance"
   [openTerm, openShortName]
 
--- | Makes a table with all sections in the SRS.
-mkTableSec :: PrintingInformation -> Doc
-mkTableSec pinfo = mkTableFromLenses
-  pinfo
-  (view sectionTable)
-  "Sections"
-  [openTitle, openShortName]
-
 -- | Makes a table with all labelled content in the SRS.
 mkTableLC :: PrintingInformation -> Doc
 mkTableLC pinfo = mkTableFromLenses
@@ -313,7 +304,6 @@ mkListShowUsedUIDs PI { _ckdb = db } = sortBy (compare `on` fst)
   ++ map
     (\x -> (fst x, ["ConceptInstance"]))
     (Map.assocs $ db ^. conceptinsTable)
-  ++ map (\x -> (fst x, ["Section"])) (Map.assocs $ db ^. sectionTable)
   ++ map
     (\x -> (fst x, ["LabelledContent"]))
     (Map.assocs $ db ^. labelledcontentTable)
@@ -335,6 +325,5 @@ mkListAll db = nubOrd
   ++ map fst (Map.assocs $ db ^. gendefTable)
   ++ map fst (Map.assocs $ db ^. theoryModelTable)
   ++ map fst (Map.assocs $ db ^. conceptinsTable)
-  ++ map fst (Map.assocs $ db ^. sectionTable)
   ++ map fst (Map.assocs $ db ^. labelledcontentTable)
   ++ map fst (Map.assocs $ db ^. refTable)

--- a/code/drasil-website/lib/Drasil/Website/Body.hs
+++ b/code/drasil-website/lib/Drasil/Website/Body.hs
@@ -109,7 +109,7 @@ symbMap fl = cdb ([] :: [QuantityDict]) (map nw [webName, web, phsChgMtrl] ++
   heatTrans, sWHT, water, pidC, target, projectile, crtSlpSrf, shearForce, 
   normForce, slpSrf] ++ [nw $ fctSfty ^. defLhs] ++ [game, physics, condition, glaSlab, intrslce,
   slope, safety, factor]) ([] :: [ConceptChunk]) ([] :: [UnitDefn]) [] [] [] [] 
-  [] [] [] $ allRefs fl
+  [] [] $ allRefs fl
 
 -- | Helper to get the system name as an 'IdeaDict' from 'SystemInformation'.
 getSysName :: SystemInformation -> IdeaDict
@@ -118,7 +118,7 @@ getSysName SI{_sys = nm} = nw nm
 -- | Empty database needed for 'si' to work.
 usedDB :: ChunkDB
 usedDB = cdb ([] :: [QuantityDict]) ([] :: [IdeaDict])
-           ([] :: [ConceptChunk]) ([] :: [UnitDefn]) [] [] [] [] [] [] [] ([] :: [Reference])
+           ([] :: [ConceptChunk]) ([] :: [UnitDefn]) [] [] [] [] [] [] ([] :: [Reference])
 
 -- | Holds all references and links used in the website.
 allRefs :: FolderLocation -> [Reference]


### PR DESCRIPTION
Contributes to #2873 

Builds on #4003, #4007, #4012, and #4014. However, he only commit necessary to audit is ~~84fb89b7b0cb4dab11cf0079c66b6e08a721ec3a~~ af38c6aedcb82474a3f6f16861ebe4e520222331, assuming you're okay with the changes on the PRs this PR builds on. Why does this PR build on these PRs? Because I removed all use `SectionTable` field filling in #4014, which is dependent on the others.

Is this a step back or is this a step forward? I tend towards the latter, for two reasons:
1. I don't think that a `Section` is something we want in the ChunkDB. It is display knowledge, and all discussion of it should be restricted to 'printer'-related code.
2. With us making significant progress towards enabling `StrictData` everywhere, our next issue to focus on with #2873 is the UID conflicts (https://github.com/JacquesCarette/Drasil/issues/2873#issuecomment-2689466366). `Section`s are currently one large source of UID conflicts. With this PR, we are wiping out a non-trivial amount of those conflicts.