### PR TITLE
Demote references table to 'not a chunk table' in `ChunkDB`

### DIFF
--- a/code/drasil-database/lib/Database/Drasil/ChunkDB.hs
+++ b/code/drasil-database/lib/Database/Drasil/ChunkDB.hs
@@ -164,20 +164,23 @@ asOrderedList = map fst . sortOn snd . map snd . Map.toList
 -- | Our chunk databases. \Must contain all maps needed in an example.\
 -- In turn, these maps must contain every chunk definition or concept 
 -- used in its respective example, else an error is thrown.
-data ChunkDB = CDB { symbolTable           :: SymbolMap
-                   , termTable             :: TermMap 
-                   , defTable              :: ConceptMap
-                   , _unitTable            :: UnitMap
-                   , _traceTable           :: TraceMap
-                   , _refbyTable           :: RefbyMap
-                   , _dataDefnTable        :: DatadefnMap
-                   , _insmodelTable        :: InsModelMap
-                   , _gendefTable          :: GendefMap
-                   , _theoryModelTable     :: TheoryModelMap
-                   , _conceptinsTable      :: ConceptInstanceMap
-                   , _labelledcontentTable :: LabelledContentMap
-                   , _refTable             :: ReferenceMap
-                   } -- TODO: Expand and add more databases
+data ChunkDB = CDB {
+  -- CHUNKS
+    symbolTable           :: SymbolMap
+  , termTable             :: TermMap 
+  , defTable              :: ConceptMap
+  , _unitTable            :: UnitMap
+  , _dataDefnTable        :: DatadefnMap
+  , _insmodelTable        :: InsModelMap
+  , _gendefTable          :: GendefMap
+  , _theoryModelTable     :: TheoryModelMap
+  , _conceptinsTable      :: ConceptInstanceMap
+  , _labelledcontentTable :: LabelledContentMap
+  -- NOT CHUNKS
+  , _traceTable           :: TraceMap
+  , _refbyTable           :: RefbyMap
+  , _refTable             :: ReferenceMap
+  }
 makeLenses ''ChunkDB
 
 -- | Smart constructor for chunk databases. Takes in the following:
@@ -196,9 +199,24 @@ cdb :: (Quantity q, MayHaveUnit q, Idea t, Concept c, IsUnit u) =>
     [q] -> [t] -> [c] -> [u] -> [DataDefinition] -> [InstanceModel] ->
     [GenDefn] -> [TheoryModel] -> [ConceptInstance] ->
     [LabelledContent] -> [Reference] -> ChunkDB
-cdb s t c u d ins gd tm ci lc r = CDB (symbolMap s) (termMap t) (conceptMap c)
-  (unitMap u) Map.empty Map.empty (idMap d) (idMap ins) (idMap gd) (idMap tm)
-  (idMap ci) (idMap lc) (idMap r)
+cdb s t c u d ins gd tm ci lc r = 
+  CDB {
+    -- CHUNKS
+    symbolTable = symbolMap s,
+    termTable = termMap t,
+    defTable = conceptMap c,
+    _unitTable = unitMap u,
+    _dataDefnTable = idMap d,
+    _insmodelTable = idMap ins,
+    _gendefTable = idMap gd,
+    _theoryModelTable = idMap tm,
+    _conceptinsTable = idMap ci,
+    _labelledcontentTable = idMap lc,
+    -- NOT CHUNKS
+    _traceTable = Map.empty,
+    _refbyTable = Map.empty,
+    _refTable = idMap r
+  }
 
 -- | Gets the units of a 'Quantity' as 'UnitDefn's.
 collectUnits :: Quantity c => ChunkDB -> [c] -> [UnitDefn]

--- a/code/drasil-database/lib/Database/Drasil/Dump.hs
+++ b/code/drasil-database/lib/Database/Drasil/Dump.hs
@@ -1,7 +1,7 @@
 module Database.Drasil.Dump where
 
 import Language.Drasil (UID, HasUID(..))
-import Database.Drasil.ChunkDB (refTable, labelledcontentTable, 
+import Database.Drasil.ChunkDB (labelledcontentTable, 
   conceptinsTable, theoryModelTable, gendefTable, insmodelTable, dataDefnTable,
   unitTable, UMap, ChunkDB(termTable, symbolTable))
 
@@ -28,5 +28,4 @@ dumpChunkDB cdb =
     $ insert "theoryModels" (umapDump $ cdb ^. theoryModelTable)
     $ insert "conceptInstances" (umapDump $ cdb ^. conceptinsTable)
     $ insert "labelledContent" (umapDump $ cdb ^. labelledcontentTable)
-    $ insert "references" (umapDump $ cdb ^. refTable)
       mempty

--- a/code/drasil-docLang/lib/Drasil/DocumentLanguage.hs
+++ b/code/drasil-docLang/lib/Drasil/DocumentLanguage.hs
@@ -160,8 +160,6 @@ fillReferences dd si@SI{_sys = sys} = si2
     -- get refs from SRSDecl. Should include all section labels and labelled content.
     refsFromSRS = concatMap findAllRefs allSections
     -- get refs from the stuff already inside the chunk database
-    inRefs  = concatMap dRefToRef ddefs ++ concatMap dRefToRef gdefs ++
-                concatMap dRefToRef imods ++ concatMap dRefToRef tmods
     ddefs   = map (fst.snd) $ Map.assocs $ chkdb ^. dataDefnTable
     gdefs   = map (fst.snd) $ Map.assocs $ chkdb ^. gendefTable
     imods   = map (fst.snd) $ Map.assocs $ chkdb ^. insmodelTable
@@ -173,7 +171,7 @@ fillReferences dd si@SI{_sys = sys} = si2
     -- search the old reference table just in case the user wants to manually add in some references
     refs    = map (fst.snd) $ Map.assocs $ chkdb ^. refTable
     -- set new reference table in the chunk database
-    chkdb2 = set refTable (idMap $ nub $ refsFromSRS ++ inRefs
+    chkdb2 = set refTable (idMap $ nub $ refsFromSRS
       ++ map (ref.makeTabRef'.getTraceConfigUID) (traceMatStandard si) ++ secRefs -- secRefs can be removed once #946 is complete
       ++ traceyGraphGetRefs (programName sys) ++ map ref cites
       ++ map ref conins ++ map ref ddefs ++ map ref gdefs ++ map ref imods

--- a/code/drasil-example/gamephysics/lib/Drasil/GamePhysics/Body.hs
+++ b/code/drasil-example/gamephysics/lib/Drasil/GamePhysics/Body.hs
@@ -38,7 +38,7 @@ import Drasil.GamePhysics.Concepts (gamePhysics, acronyms, threeD, twoD)
 import Drasil.GamePhysics.DataDefs (dataDefs)
 import Drasil.GamePhysics.Goals (goals)
 import Drasil.GamePhysics.IMods (iMods, instModIntro)
-import Drasil.GamePhysics.References (citations)
+import Drasil.GamePhysics.References (citations, uriReferences)
 import Drasil.GamePhysics.Requirements (funcReqs, nonfuncReqs, pymunk)
 import Drasil.GamePhysics.TMods (tMods)
 import Drasil.GamePhysics.Unitals (symbolsAll, outputConstraints,
@@ -155,7 +155,7 @@ symbMap = cdb (map (^. output) iMods ++ map qw symbolsAll) (nw gamePhysics :
 
   -- | Holds all references and links used in the document.
 allRefs :: [Reference]
-allRefs = [externalLinkRef, pymunk] ++ offShelfSolRefs
+allRefs = [externalLinkRef, pymunk] ++ uriReferences ++ offShelfSolRefs
 
 usedDB :: ChunkDB
 usedDB = cdb ([] :: [QuantityDict]) (map nw symbolsAll ++ map nw acronyms)

--- a/code/drasil-example/gamephysics/lib/Drasil/GamePhysics/GenDefs.hs
+++ b/code/drasil-example/gamephysics/lib/Drasil/GamePhysics/GenDefs.hs
@@ -16,6 +16,7 @@ import Drasil.GamePhysics.DataDefs (collisionAssump, rightHandAssump,
 import Data.Drasil.Concepts.Math as CM (line, cartesian)
 import qualified Data.Drasil.Quantities.PhysicalProperties as QPP (mass)
 import Drasil.GamePhysics.TMods (newtonLUG)
+import Drasil.GamePhysics.References
 
 ----- General Models -----
 
@@ -77,11 +78,6 @@ accelGravityDesc = foldlSent [S "If one of the", plural QPP.mass `S.is` S "much 
 accelGravityExpr :: PExpr
 accelGravityExpr = neg ((sy QP.gravitationalConst $* sy mLarger $/
   square (sy dispNorm)) $* sy dVect)
-
-accelGravitySrc :: Reference
-accelGravitySrc = makeURI "accelGravitySrc" "https://en.wikipedia.org/wiki/Gravitational_acceleration" $
-  shortname' $ S "Definition" `S.of_` S "Gravitational Acceleration"
-
 accelGravityDeriv :: Derivation
 accelGravityDeriv = mkDerivName (phrase QP.gravitationalAccel)
                       (weave [accelGravityDerivSentences, map eS accelGravityDerivEqns])
@@ -159,7 +155,3 @@ impulseExpr = (neg (exactDbl 1 $+ sy QP.restitutionCoef) $* sy initRelVel $.
   square (sy normalLen) $+
   (square (sy perpLenA) $/ sy momtInertA) $+
   (square (sy perpLenB) $/ sy momtInertB))
-
-impulseSrc :: Reference
-impulseSrc = makeURI "impulseSrc" "http://www.chrishecker.com/images/e/e7/Gdmphys3.pdf" $
-  shortname' $ S "Impulse for Collision Ref"

--- a/code/drasil-example/gamephysics/lib/Drasil/GamePhysics/GenDefs.hs
+++ b/code/drasil-example/gamephysics/lib/Drasil/GamePhysics/GenDefs.hs
@@ -16,7 +16,7 @@ import Drasil.GamePhysics.DataDefs (collisionAssump, rightHandAssump,
 import Data.Drasil.Concepts.Math as CM (line, cartesian)
 import qualified Data.Drasil.Quantities.PhysicalProperties as QPP (mass)
 import Drasil.GamePhysics.TMods (newtonLUG)
-import Drasil.GamePhysics.References
+import Drasil.GamePhysics.References (accelGravitySrc, impulseSrc)
 
 ----- General Models -----
 

--- a/code/drasil-example/gamephysics/lib/Drasil/GamePhysics/References.hs
+++ b/code/drasil-example/gamephysics/lib/Drasil/GamePhysics/References.hs
@@ -1,5 +1,4 @@
-module Drasil.GamePhysics.References (chaslesWiki, citations, koothoor2013,
-smithEtAl2007, smithLai2005, smithKoothoor2016) where
+module Drasil.GamePhysics.References where
 
 import Language.Drasil
 
@@ -9,6 +8,7 @@ import Data.Drasil.Citations (cartesianWiki, koothoor2013,
 import Data.Drasil.People (bWaugh, cTitus, dParnas, daAruliah, epWhite, gWilson,
   imMitchell, jBueche, kdHuff, mDavis, mdPlumblet, nChueHong, pWilson, rGuy, shdHaddock,
   wikiAuthors)
+import qualified Language.Drasil.Sentence.Combinators as S
 
 chaslesWiki, jfBeucheIntro, parnas1978, sciComp2013 :: Citation
 
@@ -43,3 +43,15 @@ sciComp2013 = cArticle
   "PLoS Biol" 2013
   [volume 12, number 1] "sciComp2013"
 
+
+uriReferences :: [Reference]
+uriReferences = [accelGravitySrc, impulseSrc]
+
+accelGravitySrc :: Reference
+accelGravitySrc = makeURI "accelGravitySrc" "https://en.wikipedia.org/wiki/Gravitational_acceleration" $
+  shortname' $ S "Definition" `S.of_` S "Gravitational Acceleration"
+
+
+impulseSrc :: Reference
+impulseSrc = makeURI "impulseSrc" "http://www.chrishecker.com/images/e/e7/Gdmphys3.pdf" $
+  shortname' $ S "Impulse for Collision Ref"

--- a/code/drasil-example/ssp/lib/Drasil/SSP/Body.hs
+++ b/code/drasil-example/ssp/lib/Drasil/SSP/Body.hs
@@ -32,7 +32,7 @@ import Data.Drasil.Concepts.SolidMechanics (mobShear, normForce, shearForce,
   shearRes, solidcon)
 import Data.Drasil.Concepts.Computation (compcon, algorithm)
 import Data.Drasil.Software.Products (prodtcon)
-import Data.Drasil.Theories.Physics (physicsTMs)
+import Data.Drasil.Theories.Physics (physicsTMs, weightSrc, hsPressureSrc)
 
 import Data.Drasil.People (brooks, henryFrankis)
 import Data.Drasil.SI_Units (degree, metre, newton, pascal, kilogram, second, derived, fundamentals)
@@ -166,7 +166,7 @@ symbMap = cdb (map (^. output) SSP.iMods ++ map qw symbols) (map nw symbols
 
 -- | Holds all references and links used in the document.
 allRefs :: [Reference]
-allRefs = [externalLinkRef]
+allRefs = [externalLinkRef, weightSrc, hsPressureSrc]
 
 usedDB :: ChunkDB
 usedDB = cdb ([] :: [QuantityDict]) (map nw symbols ++ map nw acronyms)

--- a/code/drasil-example/swhs/lib/Drasil/SWHS/Body.hs
+++ b/code/drasil-example/swhs/lib/Drasil/SWHS/Body.hs
@@ -47,8 +47,9 @@ import Drasil.SWHS.GenDefs (genDefs, htFluxWaterFromCoil, htFluxPCMFromWater)
 import Drasil.SWHS.Goals (goals)
 import Drasil.SWHS.IMods (eBalanceOnWtr, eBalanceOnPCM, heatEInWtr, heatEInPCM,
   iMods, instModIntro)
-import Drasil.SWHS.References (citations)
-import Drasil.SWHS.Requirements (funcReqs, inReqDesc, nfRequirements, verifyEnergyOutput)
+import Drasil.SWHS.References (citations, uriReferences)
+import Drasil.SWHS.Requirements (funcReqs, inReqDesc, nfRequirements, 
+  verifyEnergyOutput)
 import Drasil.SWHS.TMods (tMods)
 import Drasil.SWHS.Unitals (absTol, coilHTC, coilSA, consTol, constrained,
   htFluxC, htFluxP, inputs, inputConstraints, outputs, pcmE, pcmHTC, pcmSA,
@@ -118,11 +119,11 @@ symbMap = cdb (qw (heatEInPCM ^. output) : symbolsAll) -- heatEInPCM ?
 
 -- | Holds all references and links used in the document.
 allRefs :: [Reference]
-allRefs = [externalLinkRef]
+allRefs = [externalLinkRef] ++ uriReferences
 
 usedDB :: ChunkDB
 usedDB = cdb ([] :: [QuantityDict]) (map nw symbols ++ map nw acronymsFull)
- ([] :: [ConceptChunk]) ([] :: [UnitDefn]) [] [] [] [] [] [] ([] :: [Reference])
+ ([] :: [ConceptChunk]) ([] :: [UnitDefn]) [] [] [] [] [] [] []
 
 refDB :: ReferenceDB
 refDB = rdb citations concIns

--- a/code/drasil-example/swhs/lib/Drasil/SWHS/Body.hs
+++ b/code/drasil-example/swhs/lib/Drasil/SWHS/Body.hs
@@ -119,7 +119,7 @@ symbMap = cdb (qw (heatEInPCM ^. output) : symbolsAll) -- heatEInPCM ?
 
 -- | Holds all references and links used in the document.
 allRefs :: [Reference]
-allRefs = [externalLinkRef] ++ uriReferences
+allRefs = externalLinkRef : uriReferences
 
 usedDB :: ChunkDB
 usedDB = cdb ([] :: [QuantityDict]) (map nw symbols ++ map nw acronymsFull)

--- a/code/drasil-example/swhs/lib/Drasil/SWHS/DataDefs.hs
+++ b/code/drasil-example/swhs/lib/Drasil/SWHS/DataDefs.hs
@@ -5,6 +5,8 @@ import Theory.Drasil (DataDefinition, ddE, ddENoRefs)
 import Language.Drasil.Chunk.Concept.NamedCombinators
 import qualified Language.Drasil.Sentence.Combinators as S
 
+import Data.Drasil.Citations
+
 import Data.Drasil.Concepts.Documentation (value)
 import Data.Drasil.Concepts.Thermodynamics (heat)
 
@@ -13,8 +15,9 @@ import Data.Drasil.Quantities.Physics (energy, pressure)
 import Data.Drasil.Quantities.PhysicalProperties (mass)
 import Data.Drasil.Quantities.Thermodynamics (latentHeat)
 
+
 import Drasil.SWHS.Assumptions (assumpVCN)
-import Drasil.SWHS.References (bueche1986, koothoor2013, lightstone2012)
+import Drasil.SWHS.References (bueche1986, lightstone2012)
 import Drasil.SWHS.Unitals (aspectRatio, coilHTC, coilSA, diam, eta, htCapLP,
   htCapSP, htCapW, htFusion, latentEP, meltFrac, pcmHTC, pcmMass, pcmSA, pcmVol,
   tankLength, tankVol, tauLP, tauSP, tauW, wDensity, wMass, wVol)

--- a/code/drasil-example/swhs/lib/Drasil/SWHS/DataDefs.hs
+++ b/code/drasil-example/swhs/lib/Drasil/SWHS/DataDefs.hs
@@ -5,7 +5,7 @@ import Theory.Drasil (DataDefinition, ddE, ddENoRefs)
 import Language.Drasil.Chunk.Concept.NamedCombinators
 import qualified Language.Drasil.Sentence.Combinators as S
 
-import Data.Drasil.Citations
+import Data.Drasil.Citations (koothoor2013)
 
 import Data.Drasil.Concepts.Documentation (value)
 import Data.Drasil.Concepts.Thermodynamics (heat)

--- a/code/drasil-example/swhs/lib/Drasil/SWHS/GenDefs.hs
+++ b/code/drasil-example/swhs/lib/Drasil/SWHS/GenDefs.hs
@@ -7,7 +7,7 @@ import Theory.Drasil (GenDefn, gd, gdNoRefs, deModel', equationalModel')
 import Language.Drasil.Chunk.Concept.NamedCombinators
 import qualified Language.Drasil.Sentence.Combinators as S
 
-import Data.Drasil.Citations
+import Data.Drasil.Citations (koothoor2013)
 
 import Data.Drasil.Concepts.Math (rOfChng, unit_)
 import Data.Drasil.Concepts.Thermodynamics (lawConvCooling)

--- a/code/drasil-example/swhs/lib/Drasil/SWHS/GenDefs.hs
+++ b/code/drasil-example/swhs/lib/Drasil/SWHS/GenDefs.hs
@@ -7,6 +7,8 @@ import Theory.Drasil (GenDefn, gd, gdNoRefs, deModel', equationalModel')
 import Language.Drasil.Chunk.Concept.NamedCombinators
 import qualified Language.Drasil.Sentence.Combinators as S
 
+import Data.Drasil.Citations
+
 import Data.Drasil.Concepts.Math (rOfChng, unit_)
 import Data.Drasil.Concepts.Thermodynamics (lawConvCooling)
 
@@ -18,7 +20,6 @@ import Data.Drasil.Quantities.Thermodynamics as QT (heatCapSpec, temp)
 import Drasil.SWHS.Assumptions (assumpCWTAT, assumpLCCCW, assumpLCCWP,
   assumpTPCAV, assumpDWPCoV, assumpSHECoV, assumpTHCCoT)
 import Drasil.SWHS.Concepts (coil, gaussDiv, phaseChangeMaterial)
-import Drasil.SWHS.References (koothoor2013)
 import Drasil.SWHS.TMods (consThermE, nwtnCooling)
 import Drasil.SWHS.Unitals (coilHTC, htFluxC, htFluxIn, htFluxOut, htFluxP,
   inSA, outSA, pcmHTC, tempC, tempPCM, tempW, thFluxVect, volHtGen)

--- a/code/drasil-example/swhs/lib/Drasil/SWHS/IMods.hs
+++ b/code/drasil-example/swhs/lib/Drasil/SWHS/IMods.hs
@@ -10,6 +10,8 @@ import qualified Language.Drasil.NounPhrase.Combinators as NP
 import qualified Language.Drasil.Sentence.Combinators as S
 import Control.Lens((^.))
 
+import Data.Drasil.Citations
+
 import Data.Drasil.Concepts.Documentation (assumption, condition, constraint,
   goal, input_, solution, output_)
 import Data.Drasil.Concepts.Math (change, equation, ode, rightSide, rOfChng, surArea)
@@ -27,7 +29,6 @@ import Drasil.SWHS.DataDefs (ddHtFusion, ddMeltFrac, balanceDecayRate,
 import Drasil.SWHS.Derivations
 import Drasil.SWHS.GenDefs (htFluxWaterFromCoil, htFluxPCMFromWater, rocTempSimp)
 import Drasil.SWHS.Goals (waterTempGS, pcmTempGS, waterEnergyGS, pcmEnergyGS)
-import Drasil.SWHS.References (koothoor2013)
 import Drasil.SWHS.TMods (sensHtE, latentHtE)
 import Drasil.SWHS.Unitals (coilHTC, coilSA, eta, htFluxC, htFluxP, htCapLP,
   htCapSP, htCapW, htFusion, latentEP, meltFrac, pcmE, pcmHTC, pcmInitMltE,

--- a/code/drasil-example/swhs/lib/Drasil/SWHS/References.hs
+++ b/code/drasil-example/swhs/lib/Drasil/SWHS/References.hs
@@ -1,6 +1,4 @@
-module Drasil.SWHS.References (citations, bueche1986, incroperaEtAl2007,
-  koothoor2013, lightstone2012, parnasClements1986, smithEtAl2007,
-  smithLai2005, smithKoothoor2016) where
+module Drasil.SWHS.References where
 
 import Language.Drasil
 
@@ -38,3 +36,21 @@ lightstone2012 = cMisc [
   year 2012,
   note "From Marilyn Lightstone's Personal Notes"]
   "lightstone2012"
+
+
+uriReferences :: [Reference]
+uriReferences = [consThemESrc, latHtESrc, sensHtESrc]
+
+consThemESrc :: Reference
+consThemESrc = makeURI "consThemESrc"
+  "http://www.efunda.com/formulae/heat_transfer/conduction/overview_cond.cfm" $
+  shortname' $ S "Fourier Law of Heat Conduction and Heat Equation"
+
+latHtESrc :: Reference
+latHtESrc = makeURI "latHtESrc" "http://en.wikipedia.org/wiki/Latent_heat" $
+  shortname' $ S "Definition of Latent Heat"
+
+sensHtESrc :: Reference
+sensHtESrc = makeURI "sensHtESrc"
+  "http://en.wikipedia.org/wiki/Sensible_heat" $
+  shortname' $ S "Definition of Sensible Heat"

--- a/code/drasil-example/swhs/lib/Drasil/SWHS/TMods.hs
+++ b/code/drasil-example/swhs/lib/Drasil/SWHS/TMods.hs
@@ -1,6 +1,6 @@
 {-# LANGUAGE PostfixOperators #-}
 module Drasil.SWHS.TMods (PhaseChange(Liquid), consThermE, latentHtE,
-  nwtnCooling, sensHtE, sensHtETemplate, tMods) where
+  nwtnCooling, sensHtE, sensHtETemplate, tMods, consThemESrc) where
 
 import qualified Data.List.NonEmpty as NE
 
@@ -27,7 +27,7 @@ import Data.Drasil.Quantities.Thermodynamics (boilPt, heatCapSpec,
 import Drasil.SWHS.Assumptions (assumpHTCC, assumpTEO)
 import Drasil.SWHS.Concepts (transient)
 import Drasil.SWHS.DataDefs (ddMeltFrac)
-import Drasil.SWHS.References (incroperaEtAl2007)
+import Drasil.SWHS.References
 import Drasil.SWHS.Unitals (deltaT, htCapL, htCapS, htCapV, htTransCoeff,
   meltFrac, tau, tempEnv, thFluxVect, volHtGen)
 
@@ -52,12 +52,6 @@ consThermECS = mkConstraintSet consCC rels
 consThermERel :: ModelExpr
 consThermERel = negVec (sy gradient) $. sy thFluxVect $+ sy volHtGen $=
   sy density $* sy heatCapSpec $* pderiv (sy temp) time
-
--- the second argument is a 'ShortName'...
-consThemESrc :: Reference
-consThemESrc = makeURI "consThemESrc"
-  "http://www.efunda.com/formulae/heat_transfer/conduction/overview_cond.cfm" $
-  shortname' $ S "Fourier Law of Heat Conduction and Heat Equation"
 
 consThermENotes :: [Sentence]
 consThermENotes = map foldlSent [
@@ -91,11 +85,6 @@ sensHtEQD pc eqn desc = fromEqnSt'' "sensHeat" np desc (symbol sensHeat) (sensHe
   where np = nounPhraseSP ("Sensible heat energy" ++ case pc of
                                                        Liquid -> " (no state change)"
                                                        AllPhases -> "")
-
-sensHtESrc :: Reference
-sensHtESrc = makeURI "sensHtESrc"
-  "http://en.wikipedia.org/wiki/Sensible_heat" $
-  shortname' $ S "Definition of Sensible Heat"
 
 sensHtEEqn :: PhaseChange -> ModelExpr
 sensHtEEqn pChange = case pChange of
@@ -142,12 +131,6 @@ latentHtEFD = mkFuncDefByQ latentHeat [time] latentHtEExpr
 
 latentHtEExpr :: ModelExpr
 latentHtEExpr = defint (eqSymb tau) (exactDbl 0) (sy time) (deriv (apply1 latentHeat tau) tau)
-
--- Integrals need dTau at end
-
-latHtESrc :: Reference
-latHtESrc = makeURI "latHtESrc" "http://en.wikipedia.org/wiki/Latent_heat" $
-  shortname' $ S "Definition of Latent Heat"
 
 latentHtENotes :: [Sentence]
 latentHtENotes = map foldlSent [

--- a/code/drasil-example/swhsnopcm/lib/Drasil/SWHSNoPCM/Body.hs
+++ b/code/drasil-example/swhsnopcm/lib/Drasil/SWHSNoPCM/Body.hs
@@ -52,6 +52,7 @@ import Drasil.SWHS.Unitals (coilSAMax, deltaT, htFluxC, htFluxIn,
   htFluxOut, htCapL, htTransCoeff, inSA, outSA, tankVol, tau, tauW,
   tempEnv, tempW, thFluxVect, volHtGen, watE,
   wMass, wVol, unitalChuncks, absTol, relTol)
+import Drasil.SWHS.References (uriReferences)
 
 import Drasil.SWHSNoPCM.Assumptions
 import Drasil.SWHSNoPCM.Changes (likelyChgs, unlikelyChgs)
@@ -213,7 +214,7 @@ symbMap = cdb symbolsAll (nw progName : map nw symbols ++ map nw acronyms ++ map
 
 -- | Holds all references and links used in the document.
 allRefs :: [Reference]
-allRefs = [externalLinkRef, externalLinkRef']
+allRefs = [externalLinkRef, externalLinkRef'] ++ uriReferences
 
 usedDB :: ChunkDB
 usedDB = cdb ([] :: [QuantityDict]) (nw progName : map nw symbols ++ map nw acronyms)

--- a/code/drasil-example/swhsnopcm/lib/Drasil/SWHSNoPCM/IMods.hs
+++ b/code/drasil-example/swhsnopcm/lib/Drasil/SWHSNoPCM/IMods.hs
@@ -7,6 +7,7 @@ import Language.Drasil.Chunk.Concept.NamedCombinators
 import qualified Language.Drasil.Sentence.Combinators as S
 import Control.Lens ((^.))
 
+import Data.Drasil.Citations
 import Data.Drasil.Concepts.Documentation (goal)
 import Data.Drasil.Concepts.Math (equation)
 import Data.Drasil.Concepts.PhysicalProperties (liquid)
@@ -18,7 +19,6 @@ import Drasil.SWHS.Concepts (water)
 import Drasil.SWHS.DataDefs (balanceDecayRate)
 import Drasil.SWHS.GenDefs (htFluxWaterFromCoil)
 import Drasil.SWHS.IMods (eBalanceOnWtrDerivDesc1, eBalanceOnWtrDerivDesc3, heatEInWtr)
-import Drasil.SWHS.References (koothoor2013)
 import Drasil.SWHS.Unitals (coilHTC, coilSA, htCapW, htFluxC, tauW, tempC,
   tempInit, tempW, timeFinal, wMass)
 

--- a/code/drasil-example/swhsnopcm/lib/Drasil/SWHSNoPCM/IMods.hs
+++ b/code/drasil-example/swhsnopcm/lib/Drasil/SWHSNoPCM/IMods.hs
@@ -7,7 +7,7 @@ import Language.Drasil.Chunk.Concept.NamedCombinators
 import qualified Language.Drasil.Sentence.Combinators as S
 import Control.Lens ((^.))
 
-import Data.Drasil.Citations
+import Data.Drasil.Citations (koothoor2013)
 import Data.Drasil.Concepts.Documentation (goal)
 import Data.Drasil.Concepts.Math (equation)
 import Data.Drasil.Concepts.PhysicalProperties (liquid)

--- a/code/drasil-example/swhsnopcm/lib/Drasil/SWHSNoPCM/References.hs
+++ b/code/drasil-example/swhsnopcm/lib/Drasil/SWHSNoPCM/References.hs
@@ -2,9 +2,10 @@ module Drasil.SWHSNoPCM.References (citations) where
 
 import Language.Drasil
 
-import Data.Drasil.Citations
+import Data.Drasil.Citations (koothoor2013, parnasClements1986, smithEtAl2007,
+  smithKoothoor2016, smithLai2005)
 
-import Drasil.SWHS.References hiding (citations)
+import Drasil.SWHS.References (incroperaEtAl2007, lightstone2012)
 
 citations :: BibRef
 citations = [incroperaEtAl2007, koothoor2013, lightstone2012, parnasClements1986,

--- a/code/drasil-example/swhsnopcm/lib/Drasil/SWHSNoPCM/References.hs
+++ b/code/drasil-example/swhsnopcm/lib/Drasil/SWHSNoPCM/References.hs
@@ -2,8 +2,9 @@ module Drasil.SWHSNoPCM.References (citations) where
 
 import Language.Drasil
 
-import Drasil.SWHS.References (incroperaEtAl2007, koothoor2013, lightstone2012, 
-  parnasClements1986, smithEtAl2007, smithLai2005, smithKoothoor2016)
+import Data.Drasil.Citations
+
+import Drasil.SWHS.References hiding (citations)
 
 citations :: BibRef
 citations = [incroperaEtAl2007, koothoor2013, lightstone2012, parnasClements1986,


### PR DESCRIPTION
Contributes to #2873 

This is a bit of a silly PR, and it might not even be the correct way to go about things. The title sounds big and mighty, but it's really not doing much.

This PR:
* Reorders the tables in the `ChunkDB`, sorting by `Chunk` vs `Not a Chunk`.
* Removes automatic extraction of `Reference`s from `Sentence`s rendered in the SRS.
* Removes `Reference`s from being considered as part of "knowledge maps" we dump in `Dump.hs`, hence excluding `Reference`s when calculating conflicting `UID`s.

The goal of this PR is to remove as many UID conflicts of `Reference`s with other chunks as possible. This PR does that by silently ignoring them, kicking the rock of actually fixing this down the road.

The demotion of `Reference` to "not a chunk" is more of a semantic change. As I mentioned in https://github.com/JacquesCarette/Drasil/issues/2873#issuecomment-2693129320, `Reference`s are somewhat confused data types. Up to naming, they confuse internally generated intermediate references to displayed knowledge with purely external (actual) references. By ...., I mean ....:
* "internally generated intermediate references to displayed knowledge" (IGIRDP... 🫤 [because there's no :sigh: emoji, a double :sigh:]), I mean reference handles to chunks we render at some point in artifacts, which we can direct a readers' attention to somehow [e.g., clickable link or just plain text], such as HTML IDs, LaTeX labels, ~~URIs,~~ (URIs are NOT an example of an IGIRDP) and [not that we do this one, but...] import statements in code.
* "purely external (actual) references" (PEAR), I mean actual references. Things that we have no real internal representation of. It seems like the existing examples of (actual) references include: local file handles (e.g., images we embed) and URLs (e.g., clickable links and "sources"). These are things we have very limited control over. I think a better way of thinking of these is: "Citations that we try to pull something from."

The terminology surrounding "Reference" in Drasil is quite overloaded, and I might have gotten confused along the way, but this is the design that I see as the "right one going forward:"
* Move the IGIRDPs off into the printers (continuing to think of them as "not a chunk"). This would involve moving it to `drasil-printers` most likely, an attempt that I've already tried but failed because our printers are not ready to handle this situation in a reasonable fashion (e656c6f3b6d20bce13e97763f60402ec570efd0e -- see https://github.com/JacquesCarette/Drasil/commit/e656c6f3b6d20bce13e97763f60402ec570efd0e#r153777701 for why it fails). We need a stateful renderer that can keep track of all the chunks we render. One issue with our existing approach to creating the IGIRDPs is that we just assume that all chunks are going to be rendered (?!) so create a bunch of invalid IGIRDPs.
* Figure out an actual design for the PEARs. This might involve dealing with creating `Citation`s instead of `Reference`s and creating some sort of `CiteExternalContent` chunk that references both a citation and provides some content we can use in the renderer (that comes from the citation directly).

Because I believe this is the 'right thing to do going forward', I removed the automatic extraction of `Reference`s from `Sentence`s rendered in the SRS (via theories primarily...) so that we know which things to convert into actual chunks later on.