### PR TITLE
Demote 'LabelledContent' to 'not a chunk' until they're dealt with properly

### DIFF
--- a/code/drasil-database/lib/Database/Drasil.hs
+++ b/code/drasil-database/lib/Database/Drasil.hs
@@ -10,7 +10,7 @@ module Database.Drasil (
   , termResolve, defResolve, symbResolve
   , traceLookup, refbyLookup
   , datadefnLookup, insmodelLookup, gendefLookup, theoryModelLookup
-  , conceptinsLookup, labelledconLookup, refResolve
+  , conceptinsLookup, refResolve
   -- ** Lenses
   , unitTable, traceTable, refbyTable
   , dataDefnTable, insmodelTable, gendefTable, theoryModelTable

--- a/code/drasil-database/lib/Database/Drasil/ChunkDB.hs
+++ b/code/drasil-database/lib/Database/Drasil/ChunkDB.hs
@@ -20,7 +20,7 @@ module Database.Drasil.ChunkDB (
   termResolve, defResolve, symbResolve,
   traceLookup, refbyLookup,
   datadefnLookup, insmodelLookup, gendefLookup, theoryModelLookup,
-  conceptinsLookup, labelledconLookup, refResolve,
+  conceptinsLookup, refResolve,
   -- ** Lenses
   unitTable, traceTable, refbyTable,
   dataDefnTable, insmodelTable, gendefTable, theoryModelTable,
@@ -153,10 +153,6 @@ theoryModelLookup = uMapLookup "TheoryModel" "TheoryModelMap"
 conceptinsLookup :: UID -> ConceptInstanceMap -> ConceptInstance
 conceptinsLookup = uMapLookup "ConceptInstance" "ConceptInstanceMap"
 
--- | Looks up a 'UID' in the labelled content table. If nothing is found, an error is thrown.
-labelledconLookup :: UID -> LabelledContentMap -> LabelledContent
-labelledconLookup = uMapLookup "LabelledContent" "LabelledContentMap"
-
 -- | Gets an ordered list of @a@ from any @a@ that is of type 'UMap'.
 asOrderedList :: UMap a -> [a]
 asOrderedList = map fst . sortOn snd . map snd . Map.toList
@@ -175,11 +171,11 @@ data ChunkDB = CDB {
   , _gendefTable          :: GendefMap
   , _theoryModelTable     :: TheoryModelMap
   , _conceptinsTable      :: ConceptInstanceMap
-  , _labelledcontentTable :: LabelledContentMap
   -- NOT CHUNKS
+  , _labelledcontentTable :: LabelledContentMap -- TODO: LabelledContent needs to be rebuilt. See JacquesCarette/Drasil#4023.
+  , _refTable             :: ReferenceMap -- TODO: References need to be rebuilt. See JacquesCarette/Drasil#4022.
   , _traceTable           :: TraceMap
   , _refbyTable           :: RefbyMap
-  , _refTable             :: ReferenceMap
   }
 makeLenses ''ChunkDB
 

--- a/code/drasil-database/lib/Database/Drasil/Dump.hs
+++ b/code/drasil-database/lib/Database/Drasil/Dump.hs
@@ -1,9 +1,8 @@
 module Database.Drasil.Dump where
 
 import Language.Drasil (UID, HasUID(..))
-import Database.Drasil.ChunkDB (labelledcontentTable, 
-  conceptinsTable, theoryModelTable, gendefTable, insmodelTable, dataDefnTable,
-  unitTable, UMap, ChunkDB(termTable, symbolTable))
+import Database.Drasil.ChunkDB (conceptinsTable, theoryModelTable, gendefTable,
+  insmodelTable, dataDefnTable, unitTable, UMap, ChunkDB(termTable, symbolTable))
 
 import Data.Map.Strict (Map, insert)
 import qualified Data.Map.Strict as SM
@@ -27,5 +26,4 @@ dumpChunkDB cdb =
     $ insert "generalDefinitions" (umapDump $ cdb ^. gendefTable)
     $ insert "theoryModels" (umapDump $ cdb ^. theoryModelTable)
     $ insert "conceptInstances" (umapDump $ cdb ^. conceptinsTable)
-    $ insert "labelledContent" (umapDump $ cdb ^. labelledcontentTable)
       mempty

--- a/code/drasil-docLang/lib/Drasil/DocumentLanguage.hs
+++ b/code/drasil-docLang/lib/Drasil/DocumentLanguage.hs
@@ -100,11 +100,11 @@ fillSecAndLC dd si = si2
     chkdb2 = set labelledcontentTable (idMap $ nub $ existingLC ++ allLC) chkdb
     -- return the filled in system information
     si2 = set sysinfodb chkdb2 si
-    
+
     -- Helper and finder functions
     findAllSec :: Section -> [Section]
     findAllSec s@(Section _ cs _) = s : concatMap findAllSubSec cs
-    
+
     findAllSubSec :: SecCons -> [Section]
     findAllSubSec (Sub s) = findAllSec s
     findAllSubSec _ = []
@@ -114,7 +114,7 @@ fillSecAndLC dd si = si2
 
     findLCSecCons :: SecCons -> [LabelledContent]
     findLCSecCons (Sub s) = findAllLC s
-    findLCSecCons (Con (LlC lblcons)) = [lblcons]
+    findLCSecCons (Con (LlC lblcons@(LblC {_ctype = Figure {}}))) = [lblcons]
     findLCSecCons _ = []
 
 -- | Takes in existing information from the Chunk database to construct a database of references.
@@ -201,7 +201,7 @@ mkSections si dd = map doit dd
     doit (IntroSec is)        = mkIntroSec si is
     doit (StkhldrSec sts)     = mkStkhldrSec sts
     doit (SSDSec ss)          = mkSSDSec si ss
-    doit (AuxConstntSec acs)  = mkAuxConsSec acs 
+    doit (AuxConstntSec acs)  = mkAuxConsSec acs
     doit Bibliography         = mkBib (citeDB si)
     doit (GSDSec gs')         = mkGSDSec gs'
     doit (ReqrmntSec r)       = mkReqrmntSec r
@@ -238,10 +238,10 @@ mkRefSec si dd (RefProg c l) = SRS.refMat [c] (map (mkSubRef si) l)
     -- error out because some of the symbols in tables are only `QuantityDict`s, and thus
     -- missing a `Concept`.
     mkSubRef SI {_quants = v, _sysinfodb = cdb} (TSymb con) =
-      SRS.tOfSymb 
+      SRS.tOfSymb
       [tsIntro con,
                 LlC $ table Equational (sortBySymbol
-                $ filter (`hasStageSymbol` Equational) 
+                $ filter (`hasStageSymbol` Equational)
                 (nub $ map qw v ++ ccss' (getDocDesc dd) (egetDocDesc dd) cdb))
                 atStart] []
     mkSubRef SI {_sysinfodb = cdb} (TSymb' f con) =
@@ -255,7 +255,7 @@ mkTSymb :: (Quantity e, Concept e, Eq e, MayHaveUnit e) =>
 mkTSymb v f c = SRS.tOfSymb [tsIntro c,
   LlC $ table Equational
     (sortBy (compsy `on` eqSymb) $ filter (`hasStageSymbol` Equational) (nub v))
-    (lf f)] 
+    (lf f)]
     []
   where lf Term = atStart
         lf Defn = capSent . (^. defn)
@@ -319,7 +319,7 @@ mkSSDProb _ (PDProg prob subSec subPD) = SSD.probDescF prob (subSec ++ map mkSub
   where mkSubPD (TermsAndDefs sen concepts) = SSD.termDefnF sen concepts
         mkSubPD (PhySysDesc prog parts dif extra) = SSD.physSystDesc prog parts dif extra
         mkSubPD (Goals ins g) = SSD.goalStmtF ins (mkEnumSimpleD g) (length g)
-                
+
 
 -- | Helper for making the Solution Characteristics Specification section.
 mkSolChSpec :: SystemInformation -> SolChSpec -> Section
@@ -392,7 +392,7 @@ mkTraceabilitySec (TraceabilityProg progs) si@SI{_sys = sys} = TG.traceMGF trace
   where
     trace = map (\(TraceConfig u _ desc cols rows) ->
       TM.generateTraceTableView u desc cols rows si) fProgs
-    fProgs = filter (\(TraceConfig _ _ _ cols rows) -> 
+    fProgs = filter (\(TraceConfig _ _ _ cols rows) ->
       not $ null (header (TM.layoutUIDs rows sidb) si)
          || null (header (TM.layoutUIDs cols sidb) si)) progs
     sidb = si ^. sysinfodb
@@ -405,7 +405,7 @@ header f = TM.traceMHeader (f . Map.keys . (^. refbyTable))
 
 -- | Helper for making the Off-the-Shelf Solutions section.
 mkOffShelfSolnSec :: OffShelfSolnsSec -> Section
-mkOffShelfSolnSec (OffShelfSolnsProg cs) = SRS.offShelfSol cs [] 
+mkOffShelfSolnSec (OffShelfSolnsProg cs) = SRS.offShelfSol cs []
 
 -- ** Auxiliary Constants
 

--- a/code/drasil-docLang/lib/Drasil/DocumentLanguage/Definitions.hs
+++ b/code/drasil-docLang/lib/Drasil/DocumentLanguage/Definitions.hs
@@ -120,7 +120,6 @@ helpToRefField t si
   | Just _ <- lookupIndex t (s ^. gendefTable)          = refS $ gendefLookup      t (s ^. gendefTable)
   | Just _ <- lookupIndex t (s ^. theoryModelTable)     = refS $ theoryModelLookup t (s ^. theoryModelTable)
   | Just _ <- lookupIndex t (s ^. conceptinsTable)      = refS $ conceptinsLookup  t (s ^. conceptinsTable)
-  | Just _ <- lookupIndex t (s ^. labelledcontentTable) = refS $ labelledconLookup t (s ^. labelledcontentTable)
   | t `elem` map  (^. uid) (citeDB si) = EmptyS
   | otherwise = error $ show t ++ "Caught."
   where s = _sysinfodb si

--- a/code/drasil-docLang/lib/Drasil/DocumentLanguage/TraceabilityGraph.hs
+++ b/code/drasil-docLang/lib/Drasil/DocumentLanguage/TraceabilityGraph.hs
@@ -164,8 +164,10 @@ traceGLst :: Contents
 traceGLst = UlC $ ulcc $ Enumeration $ Bullet $ map (, Nothing) folderList'
 
 -- | The Traceability Graph contents.
-traceGCon :: String -> [Contents]
-traceGCon ex = map LlC (zipWith (traceGraphLC ex) traceGFiles traceGUIDs) ++ [mkParagraph $ S "For convenience, the following graphs can be found at the links below:", traceGLst]
+traceGCon :: String -> [Contents] -- FIXME: HACK: We're generating "LlC"s of the traceability graphs multiple times... See DocumentLanguage.hs' mkTraceabilitySec for the other spot.
+traceGCon ex = map LlC (zipWith (traceGraphLC ex) traceGFiles traceGUIDs)
+            ++ [mkParagraph $ S "For convenience, the following graphs can be\
+               \ found at the links below:", traceGLst]
 
 -- | Generates traceability graphs as figures on an SRS document.
 traceGraphLC :: String -> FilePath -> UID -> LabelledContent

--- a/code/drasil-printers/lib/Language/Drasil/Markdown/Config.hs
+++ b/code/drasil-printers/lib/Language/Drasil/Markdown/Config.hs
@@ -29,20 +29,30 @@ makeBook (Document t _ _ _) sm = vcat [
   ]
 makeBook _ _ = error "Type not supported: Notebook."
 
--- | Prints the .csv file mapping the original 
--- filepaths of assets to the location mdBook uses.
+-- | Prints the .csv file mapping the original filepaths of assets to the
+-- location mdBook uses.
 makeRequirements :: PrintingInformation -> Doc
 makeRequirements sm = makeCSV $ ["Original", "Copy"] : assetMat sm
 
--- | Helper function to render the title
--- 'Sentence' as a 'Doc'
+-- | Render a title 'Sentence'.
 mkTitle :: PrintingInformation -> Sentence -> Doc
 mkTitle sm t = text "\"" <> pSpec empty (spec sm t) <> text "\""
 
--- | Helper function to map the original filepaths of assets
--- to the location mdBook uses.
+-- | Map the original filepaths of assets to the location mdBook generator
+-- needs.
 assetMat :: PrintingInformation -> [[Filepath]]
 assetMat (PI {_ckdb = cdb}) = 
   [[fp, "src/assets/" ++ takeFileName fp] 
   | (LblC { _ctype = Figure _ fp _ _ }, _) <- elems $ cdb ^. labelledcontentTable
   ]
+  -- FIXME: HACK: Almost nothing should ever be "gathering everything" from a
+  -- ChunkDB unless it is intended to do something highly generic, such as an
+  -- analysis, like walking along a UID-tree to build the "trace graphs." We
+  -- should not be using this as part of the renderer, however, to search for
+  -- all $x$ for rendering. The ChunkDB is allowed to have more knowledge in it
+  -- than we strictly need for a specific use of Drasil. To get the point
+  -- across, we should be able to merge ALL of our individual ChunkDBs in
+  -- Drasil, feed the same ChunkDBs into the SmithEtAl generator along with the
+  -- /specific/ problem descriptions and generate the exact same artifacts. The
+  -- fact that there would be knowledge/chunks in the ChunkDB that the generator
+  -- would never access should have no impact.


### PR DESCRIPTION
Contributes to #2873

This is similar to #4022. I will annotate the PR.

Here is an excerpt from `DblPend`'s output debug information, and unfortunately, this information is largely unused as a 'chunk'.

```
LabelledContent:
----------------------------------------------------------------------------------------------------
UID                           Short Name                    Content Type
----------------------------------------------------------------------------------------------------
aR                            aspectRatio                   Definition or Model
demandq                       calofDemand                   Definition or Model
eqTNTChar                     eqTNTW                        Definition or Model
glassTypeFac                  gTF                           Definition or Model
loadDurFactor                 loadDurFactor                 Definition or Model
minThick                      minThick                      Definition or Model
stdOffDist                    standOffDist                  Definition or Model
doc:InDataConstraints         InDataConstraints             Table
doc:OutDataConstraints        OutDataConstraints            Table
doc:ReqAssignments            ReqAssignments                Table
doc:ReqInputs                 ReqInputs                     Table
doc:ReqOutputs                ReqOutputs                    Table
doc:TAbbAcc                   TAbbAcc                       Table
doc:TAuxConsts                TAuxConsts                    Table
doc:ToS                       ToS                           Table
doc:ToU                       ToU                           Table
doc:TraceGraphAllvsAll        TraceGraphAllvsAll            Figure
doc:TraceGraphAllvsR          TraceGraphAllvsR              Figure
doc:TraceGraphAvsA            TraceGraphAvsA                Figure
doc:TraceGraphAvsAll          TraceGraphAvsAll              Figure
doc:TraceGraphRefvsRef        TraceGraphRefvsRef            Figure
doc:TraceMatAllvsR            TraceMatAllvsR                Table
doc:TraceMatAvsA              TraceMatAvsA                  Table
doc:TraceMatAvsAll            TraceMatAvsAll                Table
doc:TraceMatRefvsRef          TraceMatRefvsRef              Table
doc:demandVSsod               demandVSsod                   Figure
doc:dimlessloadVSaspect       dimlessloadVSaspect           Figure
doc:physSystImage             physSystImage                 Figure
doc:sysCtxDiag                sysCtxDiag                    Figure
theory:dimlessLoad            dimlessLoad                   Definition or Model
theory:isSafeLR               isSafeLR                      Definition or Model
theory:isSafeLoad             isSafeLoad                    Definition or Model
theory:isSafePb               isSafePb                      Definition or Model
theory:isSafeProb             isSafeProb                    Definition or Model
theory:lResistance            calofCapacity                 Definition or Model
theory:nFL                    nFL                           Definition or Model
theory:probBr                 probOfBreak                   Definition or Model
theory:riskFun                riskFun                       Definition or Model
theory:sdfTol                 sdfTol                        Definition or Model
theory:stressDistFac          stressDistFac                 Definition or Model
theory:tolLoad                tolLoad                       Definition or Model

```