### PR TITLE
Remove unused _concepts field in SystemInformation

### DIFF
--- a/code/drasil-example/dblpend/lib/Drasil/DblPend/Body.hs
+++ b/code/drasil-example/dblpend/lib/Drasil/DblPend/Body.hs
@@ -114,7 +114,6 @@ si = SI {
   _motivation  = [motivation],
   _scope       = [scope],
   _quants      = symbolsAll,
-  _concepts    = [] :: [DefinedQuantityDict],
   _instModels  = iMods,
   _datadefs    = dataDefs,
   _configFiles = [],

--- a/code/drasil-example/gamephysics/lib/Drasil/GamePhysics/Body.hs
+++ b/code/drasil-example/gamephysics/lib/Drasil/GamePhysics/Body.hs
@@ -110,7 +110,6 @@ si = SI {
   -- should be removed) symbols. But that's for another time. This is "fine"
   -- because _quants are only used relative to #1658.
   _quants      = [] :: [QuantityDict], -- map qw iMods ++ map qw symbolsAll,
-  _concepts    = [] :: [DefinedQuantityDict],
   _instModels  = iMods,
   _datadefs    = dataDefs,
   _configFiles = [],

--- a/code/drasil-example/glassbr/lib/Drasil/GlassBR/Body.hs
+++ b/code/drasil-example/glassbr/lib/Drasil/GlassBR/Body.hs
@@ -67,7 +67,6 @@ si = SI {
   _motivation  = [],
   _scope       = [scope],
   _quants      = symbolsForTable,
-  _concepts    = [] :: [DefinedQuantityDict],
   _instModels  = iMods,
   _datadefs    = GB.dataDefs,
   _configFiles = configFp,

--- a/code/drasil-example/hghc/lib/Drasil/HGHC/Body.hs
+++ b/code/drasil-example/hghc/lib/Drasil/HGHC/Body.hs
@@ -33,7 +33,6 @@ si = SI {
   _background  = [],
   _motivation  = [],
   _scope       = [],
-  _concepts    = [] :: [UnitalChunk],
   _instModels  = [], -- FIXME; empty _instModels
   _datadefs    = dataDefs,
   _configFiles = [],

--- a/code/drasil-example/pdcontroller/lib/Drasil/PDController/Body.hs
+++ b/code/drasil-example/pdcontroller/lib/Drasil/PDController/Body.hs
@@ -106,7 +106,6 @@ si = SI {
   _motivation  = [motivation],
   _scope       = [scope],
   _quants = symbolsAll,
-  _concepts = [] :: [DefinedQuantityDict],
   _datadefs = dataDefinitions,
   _instModels = instanceModels,
   _configFiles = [],

--- a/code/drasil-example/projectile/lib/Drasil/Projectile/Body.hs
+++ b/code/drasil-example/projectile/lib/Drasil/Projectile/Body.hs
@@ -140,7 +140,6 @@ si = SI {
   _motivation  = [motivation],
   _scope       = [scope],
   _quants      = symbols,
-  _concepts    = [] :: [DefinedQuantityDict],
   _instModels  = iMods,
   _datadefs    = dataDefs,
   _configFiles = [],

--- a/code/drasil-example/projectile/lib/Drasil/Projectile/Lesson/Body.hs
+++ b/code/drasil-example/projectile/lib/Drasil/Projectile/Lesson/Body.hs
@@ -52,7 +52,6 @@ si = SI {
   _motivation  = [],
   _scope       = [],
   _quants      = [] :: [QuantityDict],
-  _concepts    = [] :: [DefinedQuantityDict],
   _instModels  = [],
   _datadefs    = [],
   _configFiles = [],

--- a/code/drasil-example/sglpend/lib/Drasil/SglPend/Body.hs
+++ b/code/drasil-example/sglpend/lib/Drasil/SglPend/Body.hs
@@ -115,7 +115,6 @@ si = SI {
   _scope       = [],
   _motivation  = [],
   _quants      = symbols,
-  _concepts    = [] :: [DefinedQuantityDict],
   _instModels  = iMods,
   _datadefs    = dataDefs,
   _configFiles = [],

--- a/code/drasil-example/ssp/lib/Drasil/SSP/Body.hs
+++ b/code/drasil-example/ssp/lib/Drasil/SSP/Body.hs
@@ -77,7 +77,6 @@ si = SI {
   _motivation  = [],
   _scope       = [],
   _quants      = symbols,
-  _concepts    = [] :: [DefinedQuantityDict],
   _instModels  = SSP.iMods,
   _datadefs    = SSP.dataDefs,
   _configFiles = [],

--- a/code/drasil-example/swhs/lib/Drasil/SWHS/Body.hs
+++ b/code/drasil-example/swhs/lib/Drasil/SWHS/Body.hs
@@ -85,7 +85,6 @@ si = SI {
   _motivation  = [motivation],
   _scope       = [scope],
   _quants      = symbols,
-  _concepts    = [] :: [DefinedQuantityDict],
   _instModels  = insModel,
   _datadefs    = SWHS.dataDefs,
   _configFiles = [],

--- a/code/drasil-example/swhsnopcm/lib/Drasil/SWHSNoPCM/Body.hs
+++ b/code/drasil-example/swhsnopcm/lib/Drasil/SWHSNoPCM/Body.hs
@@ -177,7 +177,6 @@ si = SI {
   -- #1658 is resolved. Basically, _quants is used here, but 
   -- tau does not appear in the document and thus should not be displayed.
   _quants      = (map qw unconstrained ++ map qw symbolsAll) \\ [qw tau],
-  _concepts    = symbols,
   _instModels  = NoPCM.iMods,
   _datadefs    = NoPCM.dataDefs,
   _configFiles = [],

--- a/code/drasil-example/template/lib/Drasil/Template/Body.hs
+++ b/code/drasil-example/template/lib/Drasil/Template/Body.hs
@@ -94,7 +94,6 @@ si = SI {
   _motivation  = [],
   _scope       = [],
   _quants      = [] :: [QuantityDict],
-  _concepts    = [] :: [DefinedQuantityDict],
   _instModels  = [] :: [InstanceModel],
   _datadefs    = [] :: [DataDefinition],
   _configFiles = [],

--- a/code/drasil-gen/lib/Language/Drasil/TypeCheck.hs
+++ b/code/drasil-gen/lib/Language/Drasil/TypeCheck.hs
@@ -13,7 +13,7 @@ import SysInfo.Drasil (SystemInformation(SI))
 
 typeCheckSI :: SystemInformation -> IO ()
 typeCheckSI
-  (SI _ _ _ _ _ _ _ _ _ ims dds _ _ _ _ _ chks _ _)
+  (SI _ _ _ _ _ _ _ _ ims dds _ _ _ _ _ chks _ _)
   = do
     -- build a variable context (a map of UIDs to "Space"s [types])
     let cxt = M.map (\(dict, _) -> dict ^. typ) (symbolTable chks)

--- a/code/drasil-sysinfo/lib/SysInfo/Drasil/SystemInformation.hs
+++ b/code/drasil-sysinfo/lib/SysInfo/Drasil/SystemInformation.hs
@@ -40,9 +40,11 @@ data SystemInformation where
 --There should be a way to remove redundant "Quantity" constraint.
 -- I'm thinking for getting concepts that are also quantities, we could
 -- use a lookup of some sort from their internal (Drasil) ids.
- SI :: (CommonIdea a, Idea a, Idea b,
-  Quantity e, Eq e, MayHaveUnit e, Quantity f, MayHaveUnit f, Concept f, Eq f,
-  Quantity h, MayHaveUnit h, Quantity i, MayHaveUnit i,
+ SI :: (CommonIdea a, Idea a,
+  Idea b,
+  Quantity e, Eq e, MayHaveUnit e,
+  Quantity h, MayHaveUnit h,
+  Quantity i, MayHaveUnit i,
   HasUID j, Constrained j) => 
   { _sys         :: a
   , _kind        :: b
@@ -52,7 +54,6 @@ data SystemInformation where
   , _scope       :: Scope
   , _motivation  :: Motivation
   , _quants      :: [e]
-  , _concepts    :: [f]
   , _instModels  :: [InstanceModel]
   , _datadefs    :: [DataDefinition]
   , _configFiles :: [String]

--- a/code/drasil-website/lib/Drasil/Website/Body.hs
+++ b/code/drasil-website/lib/Drasil/Website/Body.hs
@@ -80,7 +80,6 @@ si fl = SI {
     _background  = [],
     _motivation  = [],
     _scope       = [],
-    _concepts    = [] :: [UnitalChunk],
     _instModels  = [],
     _datadefs    = [],
     _configFiles = [],


### PR DESCRIPTION
It's not used, and it's not clear how it should be used.