### PR TITLE
Demote IdeaDicts/'terms' table to 'not a chunk'

### DIFF
--- a/code/drasil-database/lib/Database/Drasil/ChunkDB.hs
+++ b/code/drasil-database/lib/Database/Drasil/ChunkDB.hs
@@ -165,7 +165,6 @@ asOrderedList = map fst . sortOn snd . map snd . Map.toList
 data ChunkDB = CDB {
   -- CHUNKS
     symbolTable           :: SymbolMap
-  , termTable             :: TermMap 
   , defTable              :: ConceptMap
   , _unitTable            :: UnitMap
   , _dataDefnTable        :: DatadefnMap
@@ -175,6 +174,7 @@ data ChunkDB = CDB {
   , _conceptinsTable      :: ConceptInstanceMap
   , _citationTable        :: CitationMap
   -- NOT CHUNKS
+  , termTable             :: TermMap 
   , _labelledcontentTable :: LabelledContentMap -- TODO: LabelledContent needs to be rebuilt. See JacquesCarette/Drasil#4023.
   , _refTable             :: ReferenceMap -- TODO: References need to be rebuilt. See JacquesCarette/Drasil#4022.
   , _traceTable           :: TraceMap
@@ -202,7 +202,6 @@ cdb s t c u d ins gd tm ci lc r cits =
   CDB {
     -- CHUNKS
     symbolTable = symbolMap s,
-    termTable = termMap $ t ++ termsHACK,
     defTable = conceptMap c,
     _unitTable = unitMap u,
     _dataDefnTable = idMap d,
@@ -212,6 +211,7 @@ cdb s t c u d ins gd tm ci lc r cits =
     _conceptinsTable = idMap ci,
     _citationTable = idMap cits,
     -- NOT CHUNKS
+    termTable = termMap $ t ++ termsHACK,
     _labelledcontentTable = idMap lc,
     _traceTable = Map.empty,
     _refbyTable = Map.empty,

--- a/code/drasil-database/lib/Database/Drasil/Dump.hs
+++ b/code/drasil-database/lib/Database/Drasil/Dump.hs
@@ -3,7 +3,7 @@ module Database.Drasil.Dump where
 import Language.Drasil (UID, HasUID(..))
 import Database.Drasil.ChunkDB (conceptinsTable, theoryModelTable, gendefTable,
   insmodelTable, dataDefnTable, unitTable, citationTable, UMap,
-  ChunkDB(termTable, symbolTable))
+  ChunkDB(symbolTable))
 
 import Data.Map.Strict (Map, insert)
 import qualified Data.Map.Strict as SM
@@ -19,7 +19,6 @@ umapDump = map ((^. uid) . fst) . SM.elems
 dumpChunkDB :: ChunkDB -> DumpedChunkDB
 dumpChunkDB cdb = 
       insert "symbols" (umapDump $ symbolTable cdb)
-    $ insert "terms" (umapDump $ termTable cdb)
     $ insert "concepts" (umapDump $ cdb ^. conceptinsTable)
     $ insert "units" (umapDump $ cdb ^. unitTable)
     $ insert "dataDefinitions" (umapDump $ cdb ^. dataDefnTable)


### PR DESCRIPTION
Contributes to #2873

The `IdeaDict`s map is essentially a cache of known 'terms'. This PR removes it from consideration of being a 'chunk' because they contain only information about a single word. In the future, we can also remove the `IdeaDict` type entirely in favour of just referring to the 'term's themselves (via `NP`), but I'm not yet confident we want that.

With this PR, the majority of the problematic conflicting `UID`s appearing in the `problematic_seeds.json` file is from conflicts between `Concept`s and `ConceptInstance`s.