### PR TITLE
Fix chunk dump bug

### DIFF
--- a/code/drasil-database/lib/Database/Drasil/Dump.hs
+++ b/code/drasil-database/lib/Database/Drasil/Dump.hs
@@ -3,7 +3,7 @@ module Database.Drasil.Dump where
 import Language.Drasil (UID, HasUID(..))
 import Database.Drasil.ChunkDB (conceptinsTable, theoryModelTable, gendefTable,
   insmodelTable, dataDefnTable, unitTable, citationTable, UMap,
-  ChunkDB(termTable, symbolTable))
+  ChunkDB(termTable, symbolTable, defTable))
 
 import Data.Map.Strict (Map, insert)
 import qualified Data.Map.Strict as SM
@@ -20,7 +20,7 @@ dumpChunkDB :: ChunkDB -> DumpedChunkDB
 dumpChunkDB cdb = 
       insert "symbols" (umapDump $ symbolTable cdb)
     $ insert "terms" (umapDump $ termTable cdb)
-    $ insert "concepts" (umapDump $ cdb ^. conceptinsTable)
+    $ insert "concepts" (umapDump $ defTable cdb)
     $ insert "units" (umapDump $ cdb ^. unitTable)
     $ insert "dataDefinitions" (umapDump $ cdb ^. dataDefnTable)
     $ insert "instanceModels" (umapDump $ cdb ^. insmodelTable)


### PR DESCRIPTION
Contributes to #2873

This PR corrects the record for which things we have duplicate `UID`s for. Previously we were dumping the wrong `concepts` table! We were dumping the concept instances and concept chunks from the same concept instances table.

Taking `gamephysics` as an example, the new `problematic_seeds.json` file contains items of the following form:
```json
{
    "M_T": [
        "symbols",
        "concepts"
    ],
...
    "theory:accj": [
        "instanceModels",
        "concepts"
    ],
...
}
```
