### PR TITLE
Fix bibliography hyperlinks

### DIFF
--- a/code/drasil-printers/lib/Language/Drasil/HTML/Helpers.hs
+++ b/code/drasil-printers/lib/Language/Drasil/HTML/Helpers.hs
@@ -131,13 +131,11 @@ descWrap = flip (wrapGen Class "dt")
 
 -- | Helper for wrapping divisions or sections.
 -- | Arguments: Wrapper text, attribute value, body text
-refwrap' :: Maybe String -> Doc -> Doc -> Doc
-refwrap' a = flip (wrapGen Id tag) [""]
-  where
-    tag = maybe "div" id a
+refwrap' :: String -> Doc -> Doc -> Doc
+refwrap' a = flip (wrapGen Id a) [""]
 
 refwrap :: Doc -> Doc -> Doc
-refwrap = refwrap' Nothing
+refwrap = refwrap' "div"
 
 -- | Helper for setting up links to references.
 reflink :: String -> Doc -> Doc

--- a/code/drasil-printers/lib/Language/Drasil/HTML/Helpers.hs
+++ b/code/drasil-printers/lib/Language/Drasil/HTML/Helpers.hs
@@ -10,7 +10,6 @@ import Language.Drasil hiding (Expr)
 
 --import Language.Drasil.Document (Document, MaxWidthPercent)
 import Language.Drasil.Printing.AST (Expr, Spec)
-import Data.Maybe (fromMaybe)
 
 -- | Data type that carries functions that vary
 -- for bib printing
@@ -131,10 +130,11 @@ descWrap :: [String] -> Doc -> Doc -> Doc
 descWrap = flip (wrapGen Class "dt")
 
 -- | Helper for wrapping divisions or sections.
+-- | Arguments: Wrapper text, attribute value, body text
 refwrap' :: Maybe String -> Doc -> Doc -> Doc
 refwrap' a = flip (wrapGen Id tag) [""]
   where
-    tag = fromMaybe "div" a
+    tag = maybe "div" id a
 
 refwrap :: Doc -> Doc -> Doc
 refwrap = refwrap' Nothing

--- a/code/drasil-printers/lib/Language/Drasil/HTML/Helpers.hs
+++ b/code/drasil-printers/lib/Language/Drasil/HTML/Helpers.hs
@@ -130,7 +130,7 @@ descWrap :: [String] -> Doc -> Doc -> Doc
 descWrap = flip (wrapGen Class "dt")
 
 -- | Helper for wrapping divisions or sections.
--- Arguments: Wrapper element typeWrapper element type/tag (e.g., p, div, a), attribute value, body text
+-- Arguments: Wrapper element type/tag (e.g., p, div, a), attribute value, body text
 refwrap' :: String -> Doc -> Doc -> Doc
 refwrap' a = flip (wrapGen Id a) [""]
 

--- a/code/drasil-printers/lib/Language/Drasil/HTML/Helpers.hs
+++ b/code/drasil-printers/lib/Language/Drasil/HTML/Helpers.hs
@@ -10,6 +10,7 @@ import Language.Drasil hiding (Expr)
 
 --import Language.Drasil.Document (Document, MaxWidthPercent)
 import Language.Drasil.Printing.AST (Expr, Spec)
+import Data.Maybe (fromMaybe)
 
 -- | Data type that carries functions that vary
 -- for bib printing
@@ -92,7 +93,7 @@ wrap' a = wrapGen' hcat Class a empty
 -- | Helper for wrapping HTML tags.
 -- The fourth argument provides class names for the CSS.
 wrapGen' :: ([Doc] -> Doc) -> Variation -> String -> Doc -> [String] -> Doc -> Doc
-wrapGen' sepf _ s _ [] = \x -> 
+wrapGen' sepf _ s _ [] = \x ->
   sepf [text $ "<" ++ s ++ ">", indent x, tagR s]
 wrapGen' sepf Class s _ ts = \x ->
   let val = text $ foldr1 (++) (intersperse " " ts)
@@ -107,7 +108,7 @@ wrapGen = wrapGen' cat
 
 -- | Helper for creating a left HTML tag with a single attribute.
 tagL :: String -> Variation -> Doc -> Doc
-tagL t a v = text ("<" ++ t ++ " " ++ show a ++ "=\"") <> v <> text "\">" 
+tagL t a v = text ("<" ++ t ++ " " ++ show a ++ "=\"") <> v <> text "\">"
 
 -- | Helper for creating a right HTML closing tag.
 tagR :: String -> Doc
@@ -130,8 +131,13 @@ descWrap :: [String] -> Doc -> Doc -> Doc
 descWrap = flip (wrapGen Class "dt")
 
 -- | Helper for wrapping divisions or sections.
+refwrap' :: Maybe String -> Doc -> Doc -> Doc
+refwrap' a = flip (wrapGen Id tag) [""]
+  where
+    tag = fromMaybe "div" a
+
 refwrap :: Doc -> Doc -> Doc
-refwrap = flip (wrapGen Id "div") [""]
+refwrap = refwrap' Nothing
 
 -- | Helper for setting up links to references.
 reflink :: String -> Doc -> Doc
@@ -147,7 +153,7 @@ reflinkURI rf txt = text ("<a href=\"" ++ rf ++ "\">") <> txt <> text "</a>"
 
 -- | Helper for setting up figures.
 image :: Doc -> Maybe Doc -> MaxWidthPercent -> Doc
-image f Nothing wp = 
+image f Nothing wp =
   figure $ vcat [img $ [("src", f), ("alt", text "")] ++ [("width", text $ show wp ++ "%") | wp /= 100]]
 image f (Just c) wp =
   figure $ vcat [img $ [("src", f), ("alt", c)] ++ [("width", text $ show wp ++ "%") | wp /= 100], figcaption $ text "Figure: " <> c]
@@ -193,7 +199,7 @@ indent = nest 2
 --                   (makeCases ps pExpr)
 
 -- | Build case expressions.
-makeCases :: [(Expr,Expr)] -> (Expr -> Doc) -> Doc                 
+makeCases :: [(Expr,Expr)] -> (Expr -> Doc) -> Doc
 makeCases [] _ = empty
 makeCases (p:ps) pExpr = spanTag [] (pExpr (fst p) <> text " , " <>
                           spanTag ["case"] (pExpr (snd p))) $$

--- a/code/drasil-printers/lib/Language/Drasil/HTML/Helpers.hs
+++ b/code/drasil-printers/lib/Language/Drasil/HTML/Helpers.hs
@@ -130,7 +130,7 @@ descWrap :: [String] -> Doc -> Doc -> Doc
 descWrap = flip (wrapGen Class "dt")
 
 -- | Helper for wrapping divisions or sections.
--- | Arguments: Wrapper text, attribute value, body text
+-- Arguments: Wrapper element typeWrapper element type/tag (e.g., p, div, a), attribute value, body text
 refwrap' :: String -> Doc -> Doc -> Doc
 refwrap' a = flip (wrapGen Id a) [""]
 

--- a/code/drasil-printers/lib/Language/Drasil/HTML/Print.hs
+++ b/code/drasil-printers/lib/Language/Drasil/HTML/Print.hs
@@ -345,7 +345,7 @@ makeFigure r c f wp = refwrap r (image f c wp)
 
 -- | Renders assumptions, requirements, likely changes.
 makeRefList :: Doc -> Doc -> Doc
-makeRefList l a = refwrap' (Just "dt") l (brackets $ bold l) $$ dd a
+makeRefList l a = refwrap' "dt" l (brackets $ bold l) $$ dd a
 
 ---------------------
 --HTML bibliography--

--- a/code/drasil-printers/lib/Language/Drasil/HTML/Print.hs
+++ b/code/drasil-printers/lib/Language/Drasil/HTML/Print.hs
@@ -22,8 +22,8 @@ import qualified Language.Drasil as L
 import Language.Drasil.HTML.Monad (unPH)
 import Language.Drasil.HTML.Helpers (articleTitle, author, ba, body, bold,
   caption, divTag, em, h, headTag, html, image, li, ol, pa,
-  paragraph, reflink, reflinkInfo, reflinkURI, refwrap, sub, sup, table, td,
-  th, title, tr, ul, dl, dd, descWrap, BibFormatter(..))
+  paragraph, reflink, reflinkInfo, reflinkURI, refwrap, refwrap', sub, sup, table, td,
+  th, title, tr, ul, dl, dd, BibFormatter(..))
 import Language.Drasil.HTML.CSS (linkCSS)
 
 import Language.Drasil.Config (StyleGuide(APA, MLA, Chicago), bibStyleH)
@@ -345,7 +345,7 @@ makeFigure r c f wp = refwrap r (image f c wp)
 
 -- | Renders assumptions, requirements, likely changes.
 makeRefList :: Doc -> Doc -> Doc
-makeRefList l a = descWrap ["reference-label"] l (brackets $ bold l) $$ dd a
+makeRefList l a = refwrap' (Just "dt") l (brackets $ bold l) $$ dd a
 
 ---------------------
 --HTML bibliography--

--- a/code/stable/dblpend/SRS/HTML/DblPend_SRS.html
+++ b/code/stable/dblpend/SRS/HTML/DblPend_SRS.html
@@ -3941,39 +3941,39 @@
       <div class="section">
         <h1>References</h1>
         <dl class="reference-list">
-          <dt class="reference-label">[<b>hibbeler2004</b>]</dt>
+          <dt id="hibbeler2004">[<b>hibbeler2004</b>]</dt>
           <dd>
             Hibbeler, R. C. <em>Engineering Mechanics: Dynamics</em>. Pearson Prentice Hall, 2004. Print.
           </dd>
-          <dt class="reference-label">[<b>koothoor2013</b>]</dt>
+          <dt id="koothoor2013">[<b>koothoor2013</b>]</dt>
           <dd>
             Koothoor, Nirmitha. <em>A Document Driven Approach to Certifying Scientific Computing Software</em>. McMaster University, Hamilton, ON, Canada: 2013. Print.
           </dd>
-          <dt class="reference-label">[<b>parnasClements1986</b>]</dt>
+          <dt id="parnasClements1986">[<b>parnasClements1986</b>]</dt>
           <dd>
             Parnas, David L. and Clements, P. C. "A rational design process: How and why to fake it." <em>IEEE Transactions on Software Engineering</em>, vol. 12, no. 2, Washington, USA: February, 1986. pp. 251&ndash;257. Print.
           </dd>
-          <dt class="reference-label">[<b>smithKoothoor2016</b>]</dt>
+          <dt id="smithKoothoor2016">[<b>smithKoothoor2016</b>]</dt>
           <dd>
             Smith, W. Spencer and Koothoor, Nirmitha. "A Document-Driven Method for Certifying Scientific Computing Software for Use in Nuclear Safety Analysis." <em>Nuclear Engineering and Technology</em>, vol. 48, no. 2, April, 2016. <a href="http://www.sciencedirect.com/science/article/pii/S1738573315002582">http://www.sciencedirect.com/science/article/pii/S1738573315002582</a>. pp. 404&ndash;418.
           </dd>
-          <dt class="reference-label">[<b>smithLai2005</b>]</dt>
+          <dt id="smithLai2005">[<b>smithLai2005</b>]</dt>
           <dd>
             Smith, W. Spencer and Lai, Lei. "A new requirements template for scientific computing." <em>Proceedings of the First International Workshop on Situational Requirements Engineering Processes - Methods, Techniques and Tools to Support Situation-Specific Requirements Engineering Processes, SREP'05</em>. Edited by PJ Agerfalk, N. Kraiem, and J. Ralyte, Paris, France: 2005. pp. 107&ndash;121. In conjunction with 13th IEEE International Requirements Engineering Conference,
           </dd>
-          <dt class="reference-label">[<b>smithEtAl2007</b>]</dt>
+          <dt id="smithEtAl2007">[<b>smithEtAl2007</b>]</dt>
           <dd>
             Smith, W. Spencer, Lai, Lei, and Khedri, Ridha. "Requirements Analysis for Engineering Computation: A Systematic Approach for Improving Software Reliability." <em>Reliable Computing, Special Issue on Reliable Engineering Computation</em>, vol. 13, no. 1, February, 2007. <a href="https://doi.org/10.1007/s11155-006-9020-7">https://doi.org/10.1007/s11155-006-9020-7</a>. pp. 83&ndash;107.
           </dd>
-          <dt class="reference-label">[<b>accelerationWiki</b>]</dt>
+          <dt id="accelerationWiki">[<b>accelerationWiki</b>]</dt>
           <dd>
             Wikipedia Contributors. <em>Acceleration</em>. June, 2019. <a href="https://en.wikipedia.org/wiki/Acceleration">https://en.wikipedia.org/wiki/Acceleration</a>.
           </dd>
-          <dt class="reference-label">[<b>cartesianWiki</b>]</dt>
+          <dt id="cartesianWiki">[<b>cartesianWiki</b>]</dt>
           <dd>
             Wikipedia Contributors. <em>Cartesian coordinate system</em>. June, 2019. <a href="https://en.wikipedia.org/wiki/Cartesian_coordinate_system">https://en.wikipedia.org/wiki/Cartesian_coordinate_system</a>.
           </dd>
-          <dt class="reference-label">[<b>velocityWiki</b>]</dt>
+          <dt id="velocityWiki">[<b>velocityWiki</b>]</dt>
           <dd>
             Wikipedia Contributors. <em>Velocity</em>. June, 2019. <a href="https://en.wikipedia.org/wiki/Velocity">https://en.wikipedia.org/wiki/Velocity</a>.
           </dd>

--- a/code/stable/gamephysics/SRS/HTML/GamePhysics_SRS.html
+++ b/code/stable/gamephysics/SRS/HTML/GamePhysics_SRS.html
@@ -4713,55 +4713,55 @@
       <div class="section">
         <h1>References</h1>
         <dl class="reference-list">
-          <dt class="reference-label">[<b>jfBeucheIntro</b>]</dt>
+          <dt id="jfBeucheIntro">[<b>jfBeucheIntro</b>]</dt>
           <dd>
             Bueche, J. Frederick. <em>Introduction to Physics for Scientists, Fourth Edition</em>. Mcgraw-Hill College, 1986.
           </dd>
-          <dt class="reference-label">[<b>koothoor2013</b>]</dt>
+          <dt id="koothoor2013">[<b>koothoor2013</b>]</dt>
           <dd>
             Koothoor, Nirmitha. <em>A Document Driven Approach to Certifying Scientific Computing Software</em>. McMaster University, Hamilton, ON, Canada: 2013. Print.
           </dd>
-          <dt class="reference-label">[<b>parnas1978</b>]</dt>
+          <dt id="parnas1978">[<b>parnas1978</b>]</dt>
           <dd>
             Parnas, David L. "Designing Software for Ease of Extension and Contraction." <em>ICSE '78: Proceedings of the 3rd international conference on Software engineering</em>. 1978. pp. 264&ndash;277.
           </dd>
-          <dt class="reference-label">[<b>parnasClements1986</b>]</dt>
+          <dt id="parnasClements1986">[<b>parnasClements1986</b>]</dt>
           <dd>
             Parnas, David L. and Clements, P. C. "A rational design process: How and why to fake it." <em>IEEE Transactions on Software Engineering</em>, vol. 12, no. 2, Washington, USA: February, 1986. pp. 251&ndash;257. Print.
           </dd>
-          <dt class="reference-label">[<b>pointSource</b>]</dt>
+          <dt id="pointSource">[<b>pointSource</b>]</dt>
           <dd>
             Pierce, Rod. <em>Point</em>. May, 2017. <a href="https://www.mathsisfun.com/geometry/point.html">https://www.mathsisfun.com/geometry/point.html</a>.
           </dd>
-          <dt class="reference-label">[<b>smithKoothoor2016</b>]</dt>
+          <dt id="smithKoothoor2016">[<b>smithKoothoor2016</b>]</dt>
           <dd>
             Smith, W. Spencer and Koothoor, Nirmitha. "A Document-Driven Method for Certifying Scientific Computing Software for Use in Nuclear Safety Analysis." <em>Nuclear Engineering and Technology</em>, vol. 48, no. 2, April, 2016. <a href="http://www.sciencedirect.com/science/article/pii/S1738573315002582">http://www.sciencedirect.com/science/article/pii/S1738573315002582</a>. pp. 404&ndash;418.
           </dd>
-          <dt class="reference-label">[<b>smithLai2005</b>]</dt>
+          <dt id="smithLai2005">[<b>smithLai2005</b>]</dt>
           <dd>
             Smith, W. Spencer and Lai, Lei. "A new requirements template for scientific computing." <em>Proceedings of the First International Workshop on Situational Requirements Engineering Processes - Methods, Techniques and Tools to Support Situation-Specific Requirements Engineering Processes, SREP'05</em>. Edited by PJ Agerfalk, N. Kraiem, and J. Ralyte, Paris, France: 2005. pp. 107&ndash;121. In conjunction with 13th IEEE International Requirements Engineering Conference,
           </dd>
-          <dt class="reference-label">[<b>smithEtAl2007</b>]</dt>
+          <dt id="smithEtAl2007">[<b>smithEtAl2007</b>]</dt>
           <dd>
             Smith, W. Spencer, Lai, Lei, and Khedri, Ridha. "Requirements Analysis for Engineering Computation: A Systematic Approach for Improving Software Reliability." <em>Reliable Computing, Special Issue on Reliable Engineering Computation</em>, vol. 13, no. 1, February, 2007. <a href="https://doi.org/10.1007/s11155-006-9020-7">https://doi.org/10.1007/s11155-006-9020-7</a>. pp. 83&ndash;107.
           </dd>
-          <dt class="reference-label">[<b>lineSource</b>]</dt>
+          <dt id="lineSource">[<b>lineSource</b>]</dt>
           <dd>
             The Editors of Encyclopaedia Britannica. <em>Line</em>. June, 2019. <a href="https://www.britannica.com/science/line-mathematics">https://www.britannica.com/science/line-mathematics</a>.
           </dd>
-          <dt class="reference-label">[<b>chaslesWiki</b>]</dt>
+          <dt id="chaslesWiki">[<b>chaslesWiki</b>]</dt>
           <dd>
             Wikipedia Contributors. <em>Chasles' theorem (kinematics)</em>. November, 2018. <a href="https://en.wikipedia.org/wiki/Chasles'_theorem_(kinematics)">https://en.wikipedia.org/wiki/Chasles'_theorem_(kinematics)</a>.
           </dd>
-          <dt class="reference-label">[<b>cartesianWiki</b>]</dt>
+          <dt id="cartesianWiki">[<b>cartesianWiki</b>]</dt>
           <dd>
             Wikipedia Contributors. <em>Cartesian coordinate system</em>. June, 2019. <a href="https://en.wikipedia.org/wiki/Cartesian_coordinate_system">https://en.wikipedia.org/wiki/Cartesian_coordinate_system</a>.
           </dd>
-          <dt class="reference-label">[<b>dampingSource</b>]</dt>
+          <dt id="dampingSource">[<b>dampingSource</b>]</dt>
           <dd>
             Wikipedia Contributors. <em>Damping</em>. July, 2019. <a href="https://en.wikipedia.org/wiki/Damping_ratio">https://en.wikipedia.org/wiki/Damping_ratio</a>.
           </dd>
-          <dt class="reference-label">[<b>sciComp2013</b>]</dt>
+          <dt id="sciComp2013">[<b>sciComp2013</b>]</dt>
           <dd>
             Wilson, Greg, Aruliah, D. A., Titus, C., Chue Hong, Neil P., Davis, Matt, Guy, Richard T., Haddock, Steven H. D., Huff, Kathryn D., Mitchell, Ian M., Plumblet, Mark D., Waugh, Ben, White, Ethan P., and Wilson, Paul. "Best Practices for Scientific Computing, 2013." <em>PLoS Biol</em>, vol. 12, no. 1, 2013. Print.
           </dd>

--- a/code/stable/glassbr/SRS/HTML/GlassBR_SRS.html
+++ b/code/stable/glassbr/SRS/HTML/GlassBR_SRS.html
@@ -4387,43 +4387,43 @@
       <div class="section">
         <h1>References</h1>
         <dl class="reference-list">
-          <dt class="reference-label">[<b>astm2009</b>]</dt>
+          <dt id="astm2009">[<b>astm2009</b>]</dt>
           <dd>
             ASTM. <em>Standard Practice for Determining Load Resistance of Glass in Buildings</em>. <em>Standard E1300-09a</em>. ASTM International, 2009. <a href="https://www.astm.org">https://www.astm.org</a>.
           </dd>
-          <dt class="reference-label">[<b>astm2012</b>]</dt>
+          <dt id="astm2012">[<b>astm2012</b>]</dt>
           <dd>
             ASTM. <em>Standard Specification for Heat-Strengthened and Fully Tempered Flat Glass</em>. West Conshohocken, PA: ASTM International, 2012. <a href="https://doi.org/10.1520/C1048-12E01">https://doi.org/10.1520/C1048-12E01</a>.
           </dd>
-          <dt class="reference-label">[<b>astm2016</b>]</dt>
+          <dt id="astm2016">[<b>astm2016</b>]</dt>
           <dd>
             ASTM. <em>Standard specification for Flat Glass</em>. West Conshohocken, PA: ASTM International, 2016. <a href="https://doi.org/10.1520/C1036-16">https://doi.org/10.1520/C1036-16</a>.
           </dd>
-          <dt class="reference-label">[<b>beasonEtAl1998</b>]</dt>
+          <dt id="beasonEtAl1998">[<b>beasonEtAl1998</b>]</dt>
           <dd>
             Beason, W. Lynn, Kohutek, Terry L., and Bracci, Joseph M. <em>Basis for ASTME E 1300 Annealed Glass Thickness Selection Charts</em>. <em>ASCE Library</em>. February, 1998. <a href="https://doi.org/10.1061/(ASCE)0733-9445(1998)124:2(215)">https://doi.org/10.1061/(ASCE)0733-9445(1998)124:2(215)</a>.
           </dd>
-          <dt class="reference-label">[<b>campidelli</b>]</dt>
+          <dt id="campidelli">[<b>campidelli</b>]</dt>
           <dd>
             Campidelli, Manuel. "Glass-BR Software for the design and risk assessment of glass facades subjected to blast loading."
           </dd>
-          <dt class="reference-label">[<b>koothoor2013</b>]</dt>
+          <dt id="koothoor2013">[<b>koothoor2013</b>]</dt>
           <dd>
             Koothoor, Nirmitha. <em>A Document Driven Approach to Certifying Scientific Computing Software</em>. McMaster University, Hamilton, ON, Canada: 2013. Print.
           </dd>
-          <dt class="reference-label">[<b>parnasClements1986</b>]</dt>
+          <dt id="parnasClements1986">[<b>parnasClements1986</b>]</dt>
           <dd>
             Parnas, David L. and Clements, P. C. "A rational design process: How and why to fake it." <em>IEEE Transactions on Software Engineering</em>, vol. 12, no. 2, Washington, USA: February, 1986. pp. 251&ndash;257. Print.
           </dd>
-          <dt class="reference-label">[<b>smithKoothoor2016</b>]</dt>
+          <dt id="smithKoothoor2016">[<b>smithKoothoor2016</b>]</dt>
           <dd>
             Smith, W. Spencer and Koothoor, Nirmitha. "A Document-Driven Method for Certifying Scientific Computing Software for Use in Nuclear Safety Analysis." <em>Nuclear Engineering and Technology</em>, vol. 48, no. 2, April, 2016. <a href="http://www.sciencedirect.com/science/article/pii/S1738573315002582">http://www.sciencedirect.com/science/article/pii/S1738573315002582</a>. pp. 404&ndash;418.
           </dd>
-          <dt class="reference-label">[<b>smithLai2005</b>]</dt>
+          <dt id="smithLai2005">[<b>smithLai2005</b>]</dt>
           <dd>
             Smith, W. Spencer and Lai, Lei. "A new requirements template for scientific computing." <em>Proceedings of the First International Workshop on Situational Requirements Engineering Processes - Methods, Techniques and Tools to Support Situation-Specific Requirements Engineering Processes, SREP'05</em>. Edited by PJ Agerfalk, N. Kraiem, and J. Ralyte, Paris, France: 2005. pp. 107&ndash;121. In conjunction with 13th IEEE International Requirements Engineering Conference,
           </dd>
-          <dt class="reference-label">[<b>smithEtAl2007</b>]</dt>
+          <dt id="smithEtAl2007">[<b>smithEtAl2007</b>]</dt>
           <dd>
             Smith, W. Spencer, Lai, Lei, and Khedri, Ridha. "Requirements Analysis for Engineering Computation: A Systematic Approach for Improving Software Reliability." <em>Reliable Computing, Special Issue on Reliable Engineering Computation</em>, vol. 13, no. 1, February, 2007. <a href="https://doi.org/10.1007/s11155-006-9020-7">https://doi.org/10.1007/s11155-006-9020-7</a>. pp. 83&ndash;107.
           </dd>

--- a/code/stable/pdcontroller/SRS/HTML/PDController_SRS.html
+++ b/code/stable/pdcontroller/SRS/HTML/PDController_SRS.html
@@ -2284,35 +2284,35 @@
       <div class="section">
         <h1>References</h1>
         <dl class="reference-list">
-          <dt class="reference-label">[<b>abbasi2015</b>]</dt>
+          <dt id="abbasi2015">[<b>abbasi2015</b>]</dt>
           <dd>
             Abbasi, Nasser M. <em>A differential equation view of closed loop control systems</em>. November, 2020. <a href="https://www.12000.org/my_notes/connecting_systems/report.htm">https://www.12000.org/my_notes/connecting_systems/report.htm</a>.
           </dd>
-          <dt class="reference-label">[<b>johnson2008</b>]</dt>
+          <dt id="johnson2008">[<b>johnson2008</b>]</dt>
           <dd>
             Johnson, Michael A. and Moradi, Mohammad H. <em>PID Control: New Identification and Design Methods, Chapter 1</em>. Springer Science and Business Media, 2006. Print.
           </dd>
-          <dt class="reference-label">[<b>koothoor2013</b>]</dt>
+          <dt id="koothoor2013">[<b>koothoor2013</b>]</dt>
           <dd>
             Koothoor, Nirmitha. <em>A Document Driven Approach to Certifying Scientific Computing Software</em>. McMaster University, Hamilton, ON, Canada: 2013. Print.
           </dd>
-          <dt class="reference-label">[<b>smithKoothoor2016</b>]</dt>
+          <dt id="smithKoothoor2016">[<b>smithKoothoor2016</b>]</dt>
           <dd>
             Smith, W. Spencer and Koothoor, Nirmitha. "A Document-Driven Method for Certifying Scientific Computing Software for Use in Nuclear Safety Analysis." <em>Nuclear Engineering and Technology</em>, vol. 48, no. 2, April, 2016. <a href="http://www.sciencedirect.com/science/article/pii/S1738573315002582">http://www.sciencedirect.com/science/article/pii/S1738573315002582</a>. pp. 404&ndash;418.
           </dd>
-          <dt class="reference-label">[<b>smithLai2005</b>]</dt>
+          <dt id="smithLai2005">[<b>smithLai2005</b>]</dt>
           <dd>
             Smith, W. Spencer and Lai, Lei. "A new requirements template for scientific computing." <em>Proceedings of the First International Workshop on Situational Requirements Engineering Processes - Methods, Techniques and Tools to Support Situation-Specific Requirements Engineering Processes, SREP'05</em>. Edited by PJ Agerfalk, N. Kraiem, and J. Ralyte, Paris, France: 2005. pp. 107&ndash;121. In conjunction with 13th IEEE International Requirements Engineering Conference,
           </dd>
-          <dt class="reference-label">[<b>smithEtAl2007</b>]</dt>
+          <dt id="smithEtAl2007">[<b>smithEtAl2007</b>]</dt>
           <dd>
             Smith, W. Spencer, Lai, Lei, and Khedri, Ridha. "Requirements Analysis for Engineering Computation: A Systematic Approach for Improving Software Reliability." <em>Reliable Computing, Special Issue on Reliable Engineering Computation</em>, vol. 13, no. 1, February, 2007. <a href="https://doi.org/10.1007/s11155-006-9020-7">https://doi.org/10.1007/s11155-006-9020-7</a>. pp. 83&ndash;107.
           </dd>
-          <dt class="reference-label">[<b>laplaceWiki</b>]</dt>
+          <dt id="laplaceWiki">[<b>laplaceWiki</b>]</dt>
           <dd>
             Wikipedia Contributors. <em>Laplace transform</em>. November, 2020. <a href="https://en.wikipedia.org/wiki/Laplace_transform">https://en.wikipedia.org/wiki/Laplace_transform</a>.
           </dd>
-          <dt class="reference-label">[<b>pidWiki</b>]</dt>
+          <dt id="pidWiki">[<b>pidWiki</b>]</dt>
           <dd>
             Wikipedia Contributors. <em>PID controller</em>. October, 2020. <a href="https://en.wikipedia.org/wiki/PID_controller">https://en.wikipedia.org/wiki/PID_controller</a>.
           </dd>

--- a/code/stable/projectile/SRS/HTML/Projectile_SRS.html
+++ b/code/stable/projectile/SRS/HTML/Projectile_SRS.html
@@ -3282,39 +3282,39 @@
       <div class="section">
         <h1>References</h1>
         <dl class="reference-list">
-          <dt class="reference-label">[<b>hibbeler2004</b>]</dt>
+          <dt id="hibbeler2004">[<b>hibbeler2004</b>]</dt>
           <dd>
             Hibbeler, R. C. <em>Engineering Mechanics: Dynamics</em>. Pearson Prentice Hall, 2004. Print.
           </dd>
-          <dt class="reference-label">[<b>koothoor2013</b>]</dt>
+          <dt id="koothoor2013">[<b>koothoor2013</b>]</dt>
           <dd>
             Koothoor, Nirmitha. <em>A Document Driven Approach to Certifying Scientific Computing Software</em>. McMaster University, Hamilton, ON, Canada: 2013. Print.
           </dd>
-          <dt class="reference-label">[<b>parnasClements1986</b>]</dt>
+          <dt id="parnasClements1986">[<b>parnasClements1986</b>]</dt>
           <dd>
             Parnas, David L. and Clements, P. C. "A rational design process: How and why to fake it." <em>IEEE Transactions on Software Engineering</em>, vol. 12, no. 2, Washington, USA: February, 1986. pp. 251&ndash;257. Print.
           </dd>
-          <dt class="reference-label">[<b>smithKoothoor2016</b>]</dt>
+          <dt id="smithKoothoor2016">[<b>smithKoothoor2016</b>]</dt>
           <dd>
             Smith, W. Spencer and Koothoor, Nirmitha. "A Document-Driven Method for Certifying Scientific Computing Software for Use in Nuclear Safety Analysis." <em>Nuclear Engineering and Technology</em>, vol. 48, no. 2, April, 2016. <a href="http://www.sciencedirect.com/science/article/pii/S1738573315002582">http://www.sciencedirect.com/science/article/pii/S1738573315002582</a>. pp. 404&ndash;418.
           </dd>
-          <dt class="reference-label">[<b>smithLai2005</b>]</dt>
+          <dt id="smithLai2005">[<b>smithLai2005</b>]</dt>
           <dd>
             Smith, W. Spencer and Lai, Lei. "A new requirements template for scientific computing." <em>Proceedings of the First International Workshop on Situational Requirements Engineering Processes - Methods, Techniques and Tools to Support Situation-Specific Requirements Engineering Processes, SREP'05</em>. Edited by PJ Agerfalk, N. Kraiem, and J. Ralyte, Paris, France: 2005. pp. 107&ndash;121. In conjunction with 13th IEEE International Requirements Engineering Conference,
           </dd>
-          <dt class="reference-label">[<b>smithEtAl2007</b>]</dt>
+          <dt id="smithEtAl2007">[<b>smithEtAl2007</b>]</dt>
           <dd>
             Smith, W. Spencer, Lai, Lei, and Khedri, Ridha. "Requirements Analysis for Engineering Computation: A Systematic Approach for Improving Software Reliability." <em>Reliable Computing, Special Issue on Reliable Engineering Computation</em>, vol. 13, no. 1, February, 2007. <a href="https://doi.org/10.1007/s11155-006-9020-7">https://doi.org/10.1007/s11155-006-9020-7</a>. pp. 83&ndash;107.
           </dd>
-          <dt class="reference-label">[<b>accelerationWiki</b>]</dt>
+          <dt id="accelerationWiki">[<b>accelerationWiki</b>]</dt>
           <dd>
             Wikipedia Contributors. <em>Acceleration</em>. June, 2019. <a href="https://en.wikipedia.org/wiki/Acceleration">https://en.wikipedia.org/wiki/Acceleration</a>.
           </dd>
-          <dt class="reference-label">[<b>cartesianWiki</b>]</dt>
+          <dt id="cartesianWiki">[<b>cartesianWiki</b>]</dt>
           <dd>
             Wikipedia Contributors. <em>Cartesian coordinate system</em>. June, 2019. <a href="https://en.wikipedia.org/wiki/Cartesian_coordinate_system">https://en.wikipedia.org/wiki/Cartesian_coordinate_system</a>.
           </dd>
-          <dt class="reference-label">[<b>velocityWiki</b>]</dt>
+          <dt id="velocityWiki">[<b>velocityWiki</b>]</dt>
           <dd>
             Wikipedia Contributors. <em>Velocity</em>. June, 2019. <a href="https://en.wikipedia.org/wiki/Velocity">https://en.wikipedia.org/wiki/Velocity</a>.
           </dd>

--- a/code/stable/sglpend/SRS/HTML/SglPend_SRS.html
+++ b/code/stable/sglpend/SRS/HTML/SglPend_SRS.html
@@ -2910,39 +2910,39 @@
       <div class="section">
         <h1>References</h1>
         <dl class="reference-list">
-          <dt class="reference-label">[<b>hibbeler2004</b>]</dt>
+          <dt id="hibbeler2004">[<b>hibbeler2004</b>]</dt>
           <dd>
             Hibbeler, R. C. <em>Engineering Mechanics: Dynamics</em>. Pearson Prentice Hall, 2004. Print.
           </dd>
-          <dt class="reference-label">[<b>koothoor2013</b>]</dt>
+          <dt id="koothoor2013">[<b>koothoor2013</b>]</dt>
           <dd>
             Koothoor, Nirmitha. <em>A Document Driven Approach to Certifying Scientific Computing Software</em>. McMaster University, Hamilton, ON, Canada: 2013. Print.
           </dd>
-          <dt class="reference-label">[<b>parnasClements1986</b>]</dt>
+          <dt id="parnasClements1986">[<b>parnasClements1986</b>]</dt>
           <dd>
             Parnas, David L. and Clements, P. C. "A rational design process: How and why to fake it." <em>IEEE Transactions on Software Engineering</em>, vol. 12, no. 2, Washington, USA: February, 1986. pp. 251&ndash;257. Print.
           </dd>
-          <dt class="reference-label">[<b>smithKoothoor2016</b>]</dt>
+          <dt id="smithKoothoor2016">[<b>smithKoothoor2016</b>]</dt>
           <dd>
             Smith, W. Spencer and Koothoor, Nirmitha. "A Document-Driven Method for Certifying Scientific Computing Software for Use in Nuclear Safety Analysis." <em>Nuclear Engineering and Technology</em>, vol. 48, no. 2, April, 2016. <a href="http://www.sciencedirect.com/science/article/pii/S1738573315002582">http://www.sciencedirect.com/science/article/pii/S1738573315002582</a>. pp. 404&ndash;418.
           </dd>
-          <dt class="reference-label">[<b>smithLai2005</b>]</dt>
+          <dt id="smithLai2005">[<b>smithLai2005</b>]</dt>
           <dd>
             Smith, W. Spencer and Lai, Lei. "A new requirements template for scientific computing." <em>Proceedings of the First International Workshop on Situational Requirements Engineering Processes - Methods, Techniques and Tools to Support Situation-Specific Requirements Engineering Processes, SREP'05</em>. Edited by PJ Agerfalk, N. Kraiem, and J. Ralyte, Paris, France: 2005. pp. 107&ndash;121. In conjunction with 13th IEEE International Requirements Engineering Conference,
           </dd>
-          <dt class="reference-label">[<b>smithEtAl2007</b>]</dt>
+          <dt id="smithEtAl2007">[<b>smithEtAl2007</b>]</dt>
           <dd>
             Smith, W. Spencer, Lai, Lei, and Khedri, Ridha. "Requirements Analysis for Engineering Computation: A Systematic Approach for Improving Software Reliability." <em>Reliable Computing, Special Issue on Reliable Engineering Computation</em>, vol. 13, no. 1, February, 2007. <a href="https://doi.org/10.1007/s11155-006-9020-7">https://doi.org/10.1007/s11155-006-9020-7</a>. pp. 83&ndash;107.
           </dd>
-          <dt class="reference-label">[<b>accelerationWiki</b>]</dt>
+          <dt id="accelerationWiki">[<b>accelerationWiki</b>]</dt>
           <dd>
             Wikipedia Contributors. <em>Acceleration</em>. June, 2019. <a href="https://en.wikipedia.org/wiki/Acceleration">https://en.wikipedia.org/wiki/Acceleration</a>.
           </dd>
-          <dt class="reference-label">[<b>cartesianWiki</b>]</dt>
+          <dt id="cartesianWiki">[<b>cartesianWiki</b>]</dt>
           <dd>
             Wikipedia Contributors. <em>Cartesian coordinate system</em>. June, 2019. <a href="https://en.wikipedia.org/wiki/Cartesian_coordinate_system">https://en.wikipedia.org/wiki/Cartesian_coordinate_system</a>.
           </dd>
-          <dt class="reference-label">[<b>velocityWiki</b>]</dt>
+          <dt id="velocityWiki">[<b>velocityWiki</b>]</dt>
           <dd>
             Wikipedia Contributors. <em>Velocity</em>. June, 2019. <a href="https://en.wikipedia.org/wiki/Velocity">https://en.wikipedia.org/wiki/Velocity</a>.
           </dd>

--- a/code/stable/ssp/SRS/HTML/SSP_SRS.html
+++ b/code/stable/ssp/SRS/HTML/SSP_SRS.html
@@ -9399,47 +9399,47 @@
       <div class="section">
         <h1>References</h1>
         <dl class="reference-list">
-          <dt class="reference-label">[<b>fredlund1977</b>]</dt>
+          <dt id="fredlund1977">[<b>fredlund1977</b>]</dt>
           <dd>
             Fredlund, D. G. and Krahn, J. "Comparison of slope stability methods of analysis." <em>Canadian Geotechnical Journal</em>, vol. 14, no. 3, April, 1977. pp. 429&ndash;439. Print.
           </dd>
-          <dt class="reference-label">[<b>huston2008</b>]</dt>
+          <dt id="huston2008">[<b>huston2008</b>]</dt>
           <dd>
             Huston, Ronald and Josephs, Harold. <em>Practical stress analysis in engineering design</em>. 3rd. ed., CRC Press, 2008. Print.
           </dd>
-          <dt class="reference-label">[<b>karchewski2012</b>]</dt>
+          <dt id="karchewski2012">[<b>karchewski2012</b>]</dt>
           <dd>
             Canadian Geotechnical Society, Karchewski, Brandon, Guo, Peijun, and Stolle, Dieter. "Influence of inherent anisotropy of soil strength on limit equilibrium slope stability analysis." <em>Proceedings of the 65th annual Canadian GeoTechnical Conference</em>. Winnipeg, MB, Canada: 2012.
           </dd>
-          <dt class="reference-label">[<b>koothoor2013</b>]</dt>
+          <dt id="koothoor2013">[<b>koothoor2013</b>]</dt>
           <dd>
             Koothoor, Nirmitha. <em>A Document Driven Approach to Certifying Scientific Computing Software</em>. McMaster University, Hamilton, ON, Canada: 2013. Print.
           </dd>
-          <dt class="reference-label">[<b>morgenstern1965</b>]</dt>
+          <dt id="morgenstern1965">[<b>morgenstern1965</b>]</dt>
           <dd>
             Morgenstern, N. R. and Price, P. E. "The analysis of the stability of general slip surfaces." <em>Géotechnique</em>, no. 15, January, 1965. pp. 79&ndash;93. Print.
           </dd>
-          <dt class="reference-label">[<b>parnasClements1986</b>]</dt>
+          <dt id="parnasClements1986">[<b>parnasClements1986</b>]</dt>
           <dd>
             Parnas, David L. and Clements, P. C. "A rational design process: How and why to fake it." <em>IEEE Transactions on Software Engineering</em>, vol. 12, no. 2, Washington, USA: February, 1986. pp. 251&ndash;257. Print.
           </dd>
-          <dt class="reference-label">[<b>chen2005</b>]</dt>
+          <dt id="chen2005">[<b>chen2005</b>]</dt>
           <dd>
             Qian, Q. H., Zhu, D. Y., Lee, C. F., and Chen, G. R. "A concise algorithm for computing the factor of safety using the morgenstern price method." <em>Canadian Geotechnical Journal</em>, vol. 42, no. 1, February, 2005. pp. 272&ndash;278. Print.
           </dd>
-          <dt class="reference-label">[<b>smithKoothoor2016</b>]</dt>
+          <dt id="smithKoothoor2016">[<b>smithKoothoor2016</b>]</dt>
           <dd>
             Smith, W. Spencer and Koothoor, Nirmitha. "A Document-Driven Method for Certifying Scientific Computing Software for Use in Nuclear Safety Analysis." <em>Nuclear Engineering and Technology</em>, vol. 48, no. 2, April, 2016. <a href="http://www.sciencedirect.com/science/article/pii/S1738573315002582">http://www.sciencedirect.com/science/article/pii/S1738573315002582</a>. pp. 404&ndash;418.
           </dd>
-          <dt class="reference-label">[<b>smithLai2005</b>]</dt>
+          <dt id="smithLai2005">[<b>smithLai2005</b>]</dt>
           <dd>
             Smith, W. Spencer and Lai, Lei. "A new requirements template for scientific computing." <em>Proceedings of the First International Workshop on Situational Requirements Engineering Processes - Methods, Techniques and Tools to Support Situation-Specific Requirements Engineering Processes, SREP'05</em>. Edited by PJ Agerfalk, N. Kraiem, and J. Ralyte, Paris, France: 2005. pp. 107&ndash;121. In conjunction with 13th IEEE International Requirements Engineering Conference,
           </dd>
-          <dt class="reference-label">[<b>smithEtAl2007</b>]</dt>
+          <dt id="smithEtAl2007">[<b>smithEtAl2007</b>]</dt>
           <dd>
             Smith, W. Spencer, Lai, Lei, and Khedri, Ridha. "Requirements Analysis for Engineering Computation: A Systematic Approach for Improving Software Reliability." <em>Reliable Computing, Special Issue on Reliable Engineering Computation</em>, vol. 13, no. 1, February, 2007. <a href="https://doi.org/10.1007/s11155-006-9020-7">https://doi.org/10.1007/s11155-006-9020-7</a>. pp. 83&ndash;107.
           </dd>
-          <dt class="reference-label">[<b>li2010</b>]</dt>
+          <dt id="li2010">[<b>li2010</b>]</dt>
           <dd>
             Yu-Chao, Li, Yun-Min, Chen, Zhan, Tony L. T., Sao-Sheng, Ling, and Cleall, Peter John. "An efficient approach for locating the critical slip surface in slope stability analyses using a real-coded genetic algorithm." <em>Canadian Geotechnical Journal</em>, vol. 47, no. 7, June, 2010. pp. 806&ndash;820. Print.
           </dd>

--- a/code/stable/swhs/SRS/HTML/SWHS_SRS.html
+++ b/code/stable/swhs/SRS/HTML/SWHS_SRS.html
@@ -6303,35 +6303,35 @@
       <div class="section">
         <h1>References</h1>
         <dl class="reference-list">
-          <dt class="reference-label">[<b>bueche1986</b>]</dt>
+          <dt id="bueche1986">[<b>bueche1986</b>]</dt>
           <dd>
             Bueche, J. Frederick. <em>Introduction to Physics for Scientists</em>. 4th. ed., New York City, New York: McGraw Hill, 1986. Print.
           </dd>
-          <dt class="reference-label">[<b>incroperaEtAl2007</b>]</dt>
+          <dt id="incroperaEtAl2007">[<b>incroperaEtAl2007</b>]</dt>
           <dd>
             Incropera, F. P., Dewitt, D. P., Bergman, T. L., and Lavine, A. S. <em>Fundamentals of Heat and Mass Transfer</em>. 6th. ed., Hoboken, New Jersey: John Wiley and Sons, 2007. Print.
           </dd>
-          <dt class="reference-label">[<b>koothoor2013</b>]</dt>
+          <dt id="koothoor2013">[<b>koothoor2013</b>]</dt>
           <dd>
             Koothoor, Nirmitha. <em>A Document Driven Approach to Certifying Scientific Computing Software</em>. McMaster University, Hamilton, ON, Canada: 2013. Print.
           </dd>
-          <dt class="reference-label">[<b>lightstone2012</b>]</dt>
+          <dt id="lightstone2012">[<b>lightstone2012</b>]</dt>
           <dd>
             Lightstone, Marilyn. <em>Derivation of tank/pcm model</em>. 2012. From Marilyn Lightstone's Personal Notes
           </dd>
-          <dt class="reference-label">[<b>parnasClements1986</b>]</dt>
+          <dt id="parnasClements1986">[<b>parnasClements1986</b>]</dt>
           <dd>
             Parnas, David L. and Clements, P. C. "A rational design process: How and why to fake it." <em>IEEE Transactions on Software Engineering</em>, vol. 12, no. 2, Washington, USA: February, 1986. pp. 251&ndash;257. Print.
           </dd>
-          <dt class="reference-label">[<b>smithKoothoor2016</b>]</dt>
+          <dt id="smithKoothoor2016">[<b>smithKoothoor2016</b>]</dt>
           <dd>
             Smith, W. Spencer and Koothoor, Nirmitha. "A Document-Driven Method for Certifying Scientific Computing Software for Use in Nuclear Safety Analysis." <em>Nuclear Engineering and Technology</em>, vol. 48, no. 2, April, 2016. <a href="http://www.sciencedirect.com/science/article/pii/S1738573315002582">http://www.sciencedirect.com/science/article/pii/S1738573315002582</a>. pp. 404&ndash;418.
           </dd>
-          <dt class="reference-label">[<b>smithLai2005</b>]</dt>
+          <dt id="smithLai2005">[<b>smithLai2005</b>]</dt>
           <dd>
             Smith, W. Spencer and Lai, Lei. "A new requirements template for scientific computing." <em>Proceedings of the First International Workshop on Situational Requirements Engineering Processes - Methods, Techniques and Tools to Support Situation-Specific Requirements Engineering Processes, SREP'05</em>. Edited by PJ Agerfalk, N. Kraiem, and J. Ralyte, Paris, France: 2005. pp. 107&ndash;121. In conjunction with 13th IEEE International Requirements Engineering Conference,
           </dd>
-          <dt class="reference-label">[<b>smithEtAl2007</b>]</dt>
+          <dt id="smithEtAl2007">[<b>smithEtAl2007</b>]</dt>
           <dd>
             Smith, W. Spencer, Lai, Lei, and Khedri, Ridha. "Requirements Analysis for Engineering Computation: A Systematic Approach for Improving Software Reliability." <em>Reliable Computing, Special Issue on Reliable Engineering Computation</em>, vol. 13, no. 1, February, 2007. <a href="https://doi.org/10.1007/s11155-006-9020-7">https://doi.org/10.1007/s11155-006-9020-7</a>. pp. 83&ndash;107.
           </dd>

--- a/code/stable/swhsnopcm/SRS/HTML/SWHSNoPCM_SRS.html
+++ b/code/stable/swhsnopcm/SRS/HTML/SWHSNoPCM_SRS.html
@@ -3465,31 +3465,31 @@
       <div class="section">
         <h1>References</h1>
         <dl class="reference-list">
-          <dt class="reference-label">[<b>incroperaEtAl2007</b>]</dt>
+          <dt id="incroperaEtAl2007">[<b>incroperaEtAl2007</b>]</dt>
           <dd>
             Incropera, F. P., Dewitt, D. P., Bergman, T. L., and Lavine, A. S. <em>Fundamentals of Heat and Mass Transfer</em>. 6th. ed., Hoboken, New Jersey: John Wiley and Sons, 2007. Print.
           </dd>
-          <dt class="reference-label">[<b>koothoor2013</b>]</dt>
+          <dt id="koothoor2013">[<b>koothoor2013</b>]</dt>
           <dd>
             Koothoor, Nirmitha. <em>A Document Driven Approach to Certifying Scientific Computing Software</em>. McMaster University, Hamilton, ON, Canada: 2013. Print.
           </dd>
-          <dt class="reference-label">[<b>lightstone2012</b>]</dt>
+          <dt id="lightstone2012">[<b>lightstone2012</b>]</dt>
           <dd>
             Lightstone, Marilyn. <em>Derivation of tank/pcm model</em>. 2012. From Marilyn Lightstone's Personal Notes
           </dd>
-          <dt class="reference-label">[<b>parnasClements1986</b>]</dt>
+          <dt id="parnasClements1986">[<b>parnasClements1986</b>]</dt>
           <dd>
             Parnas, David L. and Clements, P. C. "A rational design process: How and why to fake it." <em>IEEE Transactions on Software Engineering</em>, vol. 12, no. 2, Washington, USA: February, 1986. pp. 251&ndash;257. Print.
           </dd>
-          <dt class="reference-label">[<b>smithKoothoor2016</b>]</dt>
+          <dt id="smithKoothoor2016">[<b>smithKoothoor2016</b>]</dt>
           <dd>
             Smith, W. Spencer and Koothoor, Nirmitha. "A Document-Driven Method for Certifying Scientific Computing Software for Use in Nuclear Safety Analysis." <em>Nuclear Engineering and Technology</em>, vol. 48, no. 2, April, 2016. <a href="http://www.sciencedirect.com/science/article/pii/S1738573315002582">http://www.sciencedirect.com/science/article/pii/S1738573315002582</a>. pp. 404&ndash;418.
           </dd>
-          <dt class="reference-label">[<b>smithLai2005</b>]</dt>
+          <dt id="smithLai2005">[<b>smithLai2005</b>]</dt>
           <dd>
             Smith, W. Spencer and Lai, Lei. "A new requirements template for scientific computing." <em>Proceedings of the First International Workshop on Situational Requirements Engineering Processes - Methods, Techniques and Tools to Support Situation-Specific Requirements Engineering Processes, SREP'05</em>. Edited by PJ Agerfalk, N. Kraiem, and J. Ralyte, Paris, France: 2005. pp. 107&ndash;121. In conjunction with 13th IEEE International Requirements Engineering Conference,
           </dd>
-          <dt class="reference-label">[<b>smithEtAl2007</b>]</dt>
+          <dt id="smithEtAl2007">[<b>smithEtAl2007</b>]</dt>
           <dd>
             Smith, W. Spencer, Lai, Lei, and Khedri, Ridha. "Requirements Analysis for Engineering Computation: A Systematic Approach for Improving Software Reliability." <em>Reliable Computing, Special Issue on Reliable Engineering Computation</em>, vol. 13, no. 1, February, 2007. <a href="https://doi.org/10.1007/s11155-006-9020-7">https://doi.org/10.1007/s11155-006-9020-7</a>. pp. 83&ndash;107.
           </dd>

--- a/code/stable/template/SRS/HTML/Template_SRS.html
+++ b/code/stable/template/SRS/HTML/Template_SRS.html
@@ -338,23 +338,23 @@
       <div class="section">
         <h1>References</h1>
         <dl class="reference-list">
-          <dt class="reference-label">[<b>koothoor2013</b>]</dt>
+          <dt id="koothoor2013">[<b>koothoor2013</b>]</dt>
           <dd>
             Koothoor, Nirmitha. <em>A Document Driven Approach to Certifying Scientific Computing Software</em>. McMaster University, Hamilton, ON, Canada: 2013. Print.
           </dd>
-          <dt class="reference-label">[<b>parnasClements1986</b>]</dt>
+          <dt id="parnasClements1986">[<b>parnasClements1986</b>]</dt>
           <dd>
             Parnas, David L. and Clements, P. C. "A rational design process: How and why to fake it." <em>IEEE Transactions on Software Engineering</em>, vol. 12, no. 2, Washington, USA: February, 1986. pp. 251&ndash;257. Print.
           </dd>
-          <dt class="reference-label">[<b>smithKoothoor2016</b>]</dt>
+          <dt id="smithKoothoor2016">[<b>smithKoothoor2016</b>]</dt>
           <dd>
             Smith, W. Spencer and Koothoor, Nirmitha. "A Document-Driven Method for Certifying Scientific Computing Software for Use in Nuclear Safety Analysis." <em>Nuclear Engineering and Technology</em>, vol. 48, no. 2, April, 2016. <a href="http://www.sciencedirect.com/science/article/pii/S1738573315002582">http://www.sciencedirect.com/science/article/pii/S1738573315002582</a>. pp. 404&ndash;418.
           </dd>
-          <dt class="reference-label">[<b>smithLai2005</b>]</dt>
+          <dt id="smithLai2005">[<b>smithLai2005</b>]</dt>
           <dd>
             Smith, W. Spencer and Lai, Lei. "A new requirements template for scientific computing." <em>Proceedings of the First International Workshop on Situational Requirements Engineering Processes - Methods, Techniques and Tools to Support Situation-Specific Requirements Engineering Processes, SREP'05</em>. Edited by PJ Agerfalk, N. Kraiem, and J. Ralyte, Paris, France: 2005. pp. 107&ndash;121. In conjunction with 13th IEEE International Requirements Engineering Conference,
           </dd>
-          <dt class="reference-label">[<b>smithEtAl2007</b>]</dt>
+          <dt id="smithEtAl2007">[<b>smithEtAl2007</b>]</dt>
           <dd>
             Smith, W. Spencer, Lai, Lei, and Khedri, Ridha. "Requirements Analysis for Engineering Computation: A Systematic Approach for Improving Software Reliability." <em>Reliable Computing, Special Issue on Reliable Engineering Computation</em>, vol. 13, no. 1, February, 2007. <a href="https://doi.org/10.1007/s11155-006-9020-7">https://doi.org/10.1007/s11155-006-9020-7</a>. pp. 83&ndash;107.
           </dd>


### PR DESCRIPTION
Closes #4046 (based on [this comment](https://github.com/JacquesCarette/Drasil/pull/4056#discussion_r2083239546))
Visually the output is the same, however I cleaned up the code a bit. Instead of having a new function `descWrap` I just generalized `refwrap` to work with different tags rather than just div to avoid repeating ourselves as much.

Also, instead of having `reference-label` attached to the list items, I realized it was not actually needed and just reverted to the old ids to fix the hyperlinks.