### PR TITLE
Fix input UID duplicates being added to GlassBR ChunkDB

### DIFF
--- a/code/drasil-example/glassbr/lib/Drasil/GlassBR/Body.hs
+++ b/code/drasil-example/glassbr/lib/Drasil/GlassBR/Body.hs
@@ -44,9 +44,9 @@ import Drasil.GlassBR.Requirements (funcReqs, inReqDesc, funcReqsTables, nonfunc
 import Drasil.GlassBR.Symbols (symbolsForTable, thisSymbols)
 import Drasil.GlassBR.TMods (tMods)
 import Drasil.GlassBR.Unitals (blast, blastTy, bomb, explosion, constants,
-  constrained, inputDataConstraints, inputs, outputs, specParamVals, glassTy,
+  constrained, inputs, outputs, specParamVals, glassTy,
   glassTypes, glBreakage, lateralLoad, load, loadTypes, pbTol, probBr, stressDistFac, probBreak,
-  sD, termsWithAccDefn, termsWithDefsOnly, terms)
+  sD, termsWithAccDefn, termsWithDefsOnly, terms, dataConstraints)
 
 srs :: Document
 srs = mkDoc mkSRS (S.forGen titleize phrase) si
@@ -107,7 +107,7 @@ mkSRS = [TableOfContents,
         , GDs [] [] HideDerivation -- No Gen Defs for GlassBR
         , DDs [] ([Label, Symbol, Units] ++ stdFields) ShowDerivation
         , IMs [instModIntro] ([Label, Input, Output, InConstraints, OutConstraints] ++ stdFields) HideDerivation
-        , Constraints auxSpecSent inputDataConstraints
+        , Constraints auxSpecSent dataConstraints
         , CorrSolnPpties [probBr, stressDistFac] []
         ]
       ],

--- a/code/drasil-example/glassbr/lib/Drasil/GlassBR/Symbols.hs
+++ b/code/drasil-example/glassbr/lib/Drasil/GlassBR/Symbols.hs
@@ -8,15 +8,15 @@ import Theory.Drasil (output)
 
 import Drasil.GlassBR.IMods (iMods)
 import Drasil.GlassBR.ModuleDefs (allMods, implVars)
-import Drasil.GlassBR.Unitals (inputDataConstraints, inputs, outputs, 
-  specParamVals, symbols, symbolsWithDefns, unitless, tmSymbols, interps)
+import Drasil.GlassBR.Unitals (inputDataConstraints, inputs, outputs,
+  specParamVals, symbols, symbolsWithDefns, unitless, tmSymbols, interps, derivedInputDataConstraints)
 
 import Data.List ((\\))
 
 symbolsForTable :: [QuantityDict]
 symbolsForTable = inputs ++ outputs ++ tmSymbols ++ map qw specParamVals ++ 
   map qw symbolsWithDefns ++ map qw symbols ++ map qw unitless ++
-  map qw inputDataConstraints ++ interps
+  map qw derivedInputDataConstraints ++ interps
 
   -- include all module functions as symbols
 thisSymbols :: [QuantityDict]

--- a/code/drasil-example/glassbr/lib/Drasil/GlassBR/Unitals.hs
+++ b/code/drasil-example/glassbr/lib/Drasil/GlassBR/Unitals.hs
@@ -31,8 +31,9 @@ modElas = uc' "modElas" (nounPhraseSP "modulus of elasticity of glass")
 {--}
 
 constrained :: [ConstrainedChunk]
-constrained = map cnstrw inputDataConstraints ++
-  [cnstrw probBr, cnstrw probFail, cnstrw stressDistFac, cnstrw nomThick, cnstrw glassTypeCon]
+constrained = map cnstrw dataConstraints ++ [nomThick, cnstrw glassTypeCon]
+ -- map cnstrw inputDataConstraints ++ map cnstrw derivedInputDataConstraints -- ++
+  -- [cnstrw probBr, cnstrw probFail, cnstrw stressDistFac, cnstrw nomThick, cnstrw glassTypeCon]
 
 plateLen, plateWidth, aspectRatio, charWeight, standOffDist :: UncertQ
 pbTol, tNT :: UncertainChunk
@@ -49,26 +50,33 @@ inputs = map qw inputsWUnitsUncrtn ++ map qw inputsWUncrtn ++
 inputsWUnitsUncrtn :: [UncertQ]
 inputsWUnitsUncrtn = [plateLen, plateWidth, charWeight]
 
---derived inputs with units and uncertainties
-derivedInsWUnitsUncrtn :: [UncertQ]
-derivedInsWUnitsUncrtn = [standOffDist]
-
 --inputs with uncertainties and no units
 inputsWUncrtn :: [UncertainChunk]
 inputsWUncrtn = [pbTol, tNT]
-
---derived inputs with uncertainties and no units
-derivedInsWUncrtn :: [UncertQ]
-derivedInsWUncrtn = [aspectRatio]
 
 --inputs with no uncertainties
 inputsNoUncrtn :: [ConstrainedChunk]
 inputsNoUncrtn = [cnstrw glassTypeCon, nomThick]
 
+--derived inputs with units and uncertainties
+derivedInsWUnitsUncrtn :: [UncertQ]
+derivedInsWUnitsUncrtn = [standOffDist]
+
+--derived inputs with uncertainties and no units
+derivedInsWUncrtn :: [UncertQ]
+derivedInsWUncrtn = [aspectRatio]
+
 inputDataConstraints :: [UncertainChunk]
 inputDataConstraints = map uncrtnw inputsWUnitsUncrtn ++
-  map uncrtnw inputsWUncrtn ++ map uncrtnw derivedInsWUnitsUncrtn ++
-  map uncrtnw derivedInsWUncrtn
+  map uncrtnw inputsWUncrtn
+
+derivedInputDataConstraints :: [UncertainChunk]
+derivedInputDataConstraints = map uncrtnw derivedInsWUnitsUncrtn
+  ++ map uncrtnw derivedInsWUncrtn
+
+dataConstraints :: [UncertainChunk]
+dataConstraints = inputDataConstraints ++ derivedInputDataConstraints
+
 
 plateLen = uqcND "plateLen" (nounPhraseSP "plate length (long dimension)")
   lA metre Real


### PR DESCRIPTION
Closes #4064 

I am currently in the process of placing individual changes that contribute to #4036 in separate PRs, this fixes some duplicates related to `inputs` and `inputDataConstraints` having duplicate UIDs.