### PR TITLE
Remove `con` from GlassBR `symbMap` and add `glassBR` individually, matching the structure of other examples

### DIFF
--- a/code/drasil-example/glassbr/lib/Drasil/GlassBR/Body.hs
+++ b/code/drasil-example/glassbr/lib/Drasil/GlassBR/Body.hs
@@ -132,7 +132,7 @@ background = foldlSent_ [phrase explosion, S "in downtown areas are dangerous fr
   +:+ S "effect of falling glass"]
 
 symbMap :: ChunkDB
-symbMap = cdb thisSymbols (map nw acronyms ++ map nw thisSymbols ++ map nw con
+symbMap = cdb thisSymbols (map nw acronyms ++ nw glassBR : map nw thisSymbols
   ++ map nw con' ++ map nw terms ++ map nw doccon ++ map nw doccon' ++ map nw educon
   ++ [nw sciCompS] ++ map nw compcon ++ map nw mathcon ++ map nw mathcon'
   ++ map nw softwarecon ++ map nw terms ++ [nw lateralLoad, nw materialProprty]


### PR DESCRIPTION
Contributes to #4036 

Also kind of helps with #4095 since it now has the `progName` equivalent in the `symbMap`, which is what most of the other examples do.