### PR TITLE
Makefile: Fix how [_]debug target sets up the debugging variables

### DIFF
--- a/code/Makefile
+++ b/code/Makefile
@@ -169,9 +169,10 @@ stackArgs += --ghc-options="$(GHCFLAGS)"
 STACK_EXEC_ARGS = --no-nix-pure
 
 # Debugging changes the arguments passed to 'stack exec' slightly.
-debug: stackArgs += $(PROFALL)
-debug: STACK_EXEC_ARGS += $(PROFEXEC)
-debug: export DEBUG_ENV = 1
+setup_debug_vars:
+	$(eval stackArgs += $(PROFALL))
+	$(eval STACK_EXEC_ARGS += $(PROFEXEC))
+	$(eval export DEBUG_ENV = 1)
 
 STACK_EXEC = stack exec $(STACK_EXEC_ARGS)
 
@@ -196,10 +197,10 @@ all: test test_website codegenTest_diff ##@Examples Run examples and test agains
 install: ##@Examples Install all example project binaries into your local binary path (see $(stack path) for local-bin-path).
 	stack install $(stackArgs)
 
-debug: test ##@Examples Run test target with better debugging tools.
+debug: setup_debug_vars test ##@Examples Run test target with better debugging tools.
 
 # Debugging individual examples
-$(DEBUG_EXAMPLES): %$(DEBUG_E_SUFFIX): %$(TEST_E_SUFFIX)
+$(DEBUG_EXAMPLES): %$(DEBUG_E_SUFFIX): setup_debug_vars %$(TEST_E_SUFFIX)
 
 pr_ready: all stan hlint ##@General Check if your current work is ready to for a PR via `all` and `hlint` and stan.
 	@echo "Your build/ and stable/ match, and your code currently passes HLint tests."
@@ -603,4 +604,4 @@ help_packages: ##@Help Lists all packages.
 		echo "  $$package"; \
 	done
 
-.PHONY: help clean clean_artifacts cleanArtifacts gool code deps hlint hot_hlint analysis tex doc debug test graphs graphmod check_stack nographs graphs website deploy_code_path deploy deploy_lite all install examples tracegraphs doxygen shellcheck mdbook_build $(GOOLTEST) $(ALL_EXPANDED_TARGETS)
+.PHONY: help setup_debug_vars clean clean_artifacts cleanArtifacts gool code deps hlint hot_hlint analysis tex doc debug test graphs graphmod check_stack nographs graphs website deploy_code_path deploy deploy_lite all install examples tracegraphs doxygen shellcheck mdbook_build $(GOOLTEST) $(ALL_EXPANDED_TARGETS)


### PR DESCRIPTION
Previously, it only worked correctly for the 'debug' target, not the 'X_debug' targets. By splitting the environment variables into a separate PHONY target, we can make sure that the environment variables are setup for both.