### PR TITLE
Makefile: Ignore 'make debug'-related junk when running diffs

### DIFF
--- a/code/Makefile
+++ b/code/Makefile
@@ -112,7 +112,7 @@ ALL_EXPANDED_TARGETS = $(foreach P, $(PACKAGE_GEN_TARGET), $($(P)_PACKAGES)) $(f
 #-------------------------------#
 
 # make variables/configuration
-DIFF = diff --strip-trailing-cr -r -X ../.gitignore
+DIFF = diff --strip-trailing-cr -r -X ../.gitignore --exclude='*.prof' --exclude='.drasil' # Excludes are to ignore the data the 'debug'-related targets generate.
 LOG_SUFFIX = _log.log
 MIN_STACK_VER = 2.3.1  # Match stack.yaml see PR #2142 for more info.
 CACHED_MSV_FILE = .drasil-min-stack-ver


### PR DESCRIPTION
Contributes to JacquesCarette/Drasil#3557