### PR TITLE
Enable -Wall and -Wredundant-constraints by package.yaml config.

### DIFF
--- a/code/drasil-example/dblpend/package.yaml
+++ b/code/drasil-example/dblpend/package.yaml
@@ -11,6 +11,10 @@ language: Haskell2010
 default-extensions:
 - StrictData
 
+ghc-options:
+- -Wall
+- -Wredundant-constraints
+
 extra-source-files: []
 
 dependencies:
@@ -40,8 +44,6 @@ executables:
     main: Main
     source-dirs: app 
     ghc-options:
-    - -Wall
-    - -Wredundant-constraints
     - -threaded
     - -O2
     dependencies:

--- a/code/drasil-example/gamephysics/package.yaml
+++ b/code/drasil-example/gamephysics/package.yaml
@@ -11,6 +11,10 @@ language: Haskell2010
 default-extensions:
 - StrictData
 
+ghc-options:
+- -Wall
+- -Wredundant-constraints
+
 extra-source-files: []
 
 dependencies:
@@ -42,10 +46,8 @@ library:
 executables:
   gamephysics:
     main: Main
-    source-dirs: app 
+    source-dirs: app
     ghc-options:
-    - -Wall
-    - -Wredundant-constraints
     - -threaded
     - -O2
     dependencies:

--- a/code/drasil-example/glassbr/package.yaml
+++ b/code/drasil-example/glassbr/package.yaml
@@ -11,6 +11,10 @@ language: Haskell2010
 default-extensions:
 - StrictData
 
+ghc-options:
+- -Wall
+- -Wredundant-constraints
+
 extra-source-files: []
 
 dependencies:
@@ -41,8 +45,6 @@ executables:
     main: Main
     source-dirs: app 
     ghc-options:
-    - -Wall
-    - -Wredundant-constraints
     - -threaded
     - -O2
     dependencies:

--- a/code/drasil-example/hghc/package.yaml
+++ b/code/drasil-example/hghc/package.yaml
@@ -11,6 +11,10 @@ language: Haskell2010
 default-extensions:
 - StrictData
 
+ghc-options:
+- -Wall
+- -Wredundant-constraints
+
 extra-source-files: []
 
 dependencies:
@@ -40,8 +44,6 @@ executables:
     main: Main
     source-dirs: app 
     ghc-options:
-    - -Wall
-    - -Wredundant-constraints
     - -threaded
     - -O2
     dependencies:

--- a/code/drasil-example/pdcontroller/package.yaml
+++ b/code/drasil-example/pdcontroller/package.yaml
@@ -11,6 +11,10 @@ language: Haskell2010
 default-extensions:
 - StrictData
 
+ghc-options:
+- -Wall
+- -Wredundant-constraints
+
 extra-source-files: []
 
 dependencies:
@@ -40,8 +44,6 @@ executables:
     main: Main
     source-dirs: app 
     ghc-options:
-    - -Wall
-    - -Wredundant-constraints
     - -threaded
     - -O2
     dependencies:

--- a/code/drasil-example/projectile/package.yaml
+++ b/code/drasil-example/projectile/package.yaml
@@ -11,6 +11,10 @@ language: Haskell2010
 default-extensions:
 - StrictData
 
+ghc-options:
+- -Wall
+- -Wredundant-constraints
+
 extra-source-files: []
 
 dependencies:
@@ -41,8 +45,6 @@ executables:
     main: Main
     source-dirs: app 
     ghc-options:
-    - -Wall
-    - -Wredundant-constraints
     - -threaded
     - -O2
     dependencies:

--- a/code/drasil-example/sglpend/package.yaml
+++ b/code/drasil-example/sglpend/package.yaml
@@ -11,6 +11,10 @@ language: Haskell2010
 default-extensions:
 - StrictData
 
+ghc-options:
+- -Wall
+- -Wredundant-constraints
+
 extra-source-files: []
 
 dependencies:
@@ -41,8 +45,6 @@ executables:
     main: Main
     source-dirs: app 
     ghc-options:
-    - -Wall
-    - -Wredundant-constraints
     - -threaded
     - -O2
     dependencies:

--- a/code/drasil-example/ssp/package.yaml
+++ b/code/drasil-example/ssp/package.yaml
@@ -11,6 +11,10 @@ language: Haskell2010
 default-extensions:
 - StrictData
 
+ghc-options:
+- -Wall
+- -Wredundant-constraints
+
 extra-source-files: []
 
 dependencies:
@@ -40,8 +44,6 @@ executables:
     main: Main
     source-dirs: app 
     ghc-options:
-    - -Wall
-    - -Wredundant-constraints
     - -threaded
     - -O2
     dependencies:

--- a/code/drasil-example/swhs/package.yaml
+++ b/code/drasil-example/swhs/package.yaml
@@ -11,6 +11,10 @@ language: Haskell2010
 default-extensions:
 - StrictData
 
+ghc-options:
+- -Wall
+- -Wredundant-constraints
+
 extra-source-files: []
 
 dependencies:
@@ -40,8 +44,6 @@ executables:
     main: Main
     source-dirs: app 
     ghc-options:
-    - -Wall
-    - -Wredundant-constraints
     - -threaded
     - -O2
     dependencies:

--- a/code/drasil-example/swhsnopcm/package.yaml
+++ b/code/drasil-example/swhsnopcm/package.yaml
@@ -11,6 +11,10 @@ language: Haskell2010
 default-extensions:
 - StrictData
 
+ghc-options:
+- -Wall
+- -Wredundant-constraints
+
 extra-source-files: []
 
 dependencies:
@@ -41,8 +45,6 @@ executables:
     main: Main
     source-dirs: app 
     ghc-options:
-    - -Wall
-    - -Wredundant-constraints
     - -threaded
     - -O2
     dependencies:

--- a/code/drasil-example/template/package.yaml
+++ b/code/drasil-example/template/package.yaml
@@ -11,6 +11,10 @@ language: Haskell2010
 default-extensions:
 - StrictData
 
+ghc-options:
+- -Wall
+- -Wredundant-constraints
+
 extra-source-files: []
 
 dependencies:
@@ -40,8 +44,6 @@ executables:
     main: Main
     source-dirs: app 
     ghc-options:
-    - -Wall
-    - -Wredundant-constraints
     - -threaded
     - -O2
     dependencies:

--- a/code/drasil-website/package.yaml
+++ b/code/drasil-website/package.yaml
@@ -10,6 +10,10 @@ language: Haskell2010
 default-extensions:
 - StrictData
 
+ghc-options:
+- -Wall
+- -Wredundant-constraints
+
 extra-source-files: []
 
 dependencies:
@@ -51,8 +55,6 @@ executables:
     main: Main
     source-dirs: app
     ghc-options:
-    - -Wall
-    - -Wredundant-constraints
     - -threaded
     - -O2
     dependencies:


### PR DESCRIPTION
Contributes to #4130

This will allow HLS to show more redundant* warnings in editor.