### PR TITLE
Reduce `make debug` log clutter by avoiding runtime exceptions that `createDirectoryIfMissing` works with

### DIFF
--- a/code/drasil-code/lib/Language/Drasil/Code/CodeGeneration.hs
+++ b/code/drasil-code/lib/Language/Drasil/Code/CodeGeneration.hs
@@ -12,9 +12,10 @@ import Language.Drasil.Code.Imperative.GOOL.Data (AuxData(..))
 import Drasil.GOOL (FileData(..), ModData(modDoc))
 
 import Text.PrettyPrint.HughesPJ (Doc,render)
-import System.Directory (createDirectoryIfMissing)
 import System.FilePath.Posix (takeDirectory)
 import System.IO (hPutStrLn, hClose, openFile, IOMode(WriteMode))
+
+import Utils.Drasil (createDirIfMissing)
 
 -- | Makes code from 'FileData' ('FilePath's with module data) and 'AuxData' ('FilePath's with auxiliary document information).
 makeCode :: [FileData] -> [AuxData] -> Code
@@ -32,7 +33,7 @@ createCodeFiles (Code cs) = mapM_ createCodeFile cs
 -- | Helper that uses pairs of 'Code' to create a file written with the given document at the given 'FilePath'.
 createCodeFile :: (FilePath, Doc) -> IO ()
 createCodeFile (path, code) = do
-  createDirectoryIfMissing True (takeDirectory path)
+  createDirIfMissing True (takeDirectory path)
   h <- openFile path WriteMode
   hPutStrLn h (render code)
   hClose h

--- a/code/drasil-code/lib/Language/Drasil/Code/Imperative/Generator.hs
+++ b/code/drasil-code/lib/Language/Drasil/Code/Imperative/Generator.hs
@@ -42,8 +42,9 @@ import Drasil.GProc (ProcProg)
 import qualified Drasil.GProc as Proc (GSProgram, SFile, ProgramSym(..), unCI)
 import System.Drasil hiding (systemdb)
 
-import System.Directory (setCurrentDirectory, createDirectoryIfMissing,
-  getCurrentDirectory)
+import Utils.Drasil (createDirIfMissing)
+
+import System.Directory (setCurrentDirectory, getCurrentDirectory)
 import Control.Lens ((^.))
 import Control.Monad.State (get, evalState, runState)
 import qualified Data.Set as Set (fromList)
@@ -115,7 +116,7 @@ generateCode :: (OOProg progRepr, PackageSym packRepr) => Lang ->
   PackData) -> DrasilState -> IO ()
 generateCode l unReprProg unReprPack g = do
   workingDir <- getCurrentDirectory
-  createDirectoryIfMissing False (getDir l)
+  createDirIfMissing False (getDir l)
   setCurrentDirectory (getDir l)
   let (pckg, ds) = runState (genPackage unReprProg) g
       baseAux = [ad "designLog.txt" (ds ^. designLog) | not $ isEmpty $
@@ -224,6 +225,7 @@ genModules = do
   return $ mn : inp ++ con ++ cal : out ++ moddef
 
 -- Procedural Versions --
+
 -- | Generates a package with the given 'DrasilState'. The passed
 -- un-representation functions determine which target language the package will
 -- be generated in.
@@ -232,7 +234,7 @@ generateCodeProc :: (ProcProg progRepr, PackageSym packRepr) => Lang ->
   PackData) -> DrasilState -> IO ()
 generateCodeProc l unReprProg unReprPack g = do
   workingDir <- getCurrentDirectory
-  createDirectoryIfMissing False (getDir l)
+  createDirIfMissing False (getDir l)
   setCurrentDirectory (getDir l)
   let (pckg, ds) = runState (genPackageProc unReprProg) g
       baseAux = [ad "designLog.txt" (ds ^. designLog) | not $ isEmpty $

--- a/code/drasil-code/test/Main.hs
+++ b/code/drasil-code/test/Main.hs
@@ -10,9 +10,11 @@ import qualified Drasil.GProc as Proc (unCI, ProgramSym(..), ProgData(..))
 import Language.Drasil.Code (PackageSym(..), AuxiliarySym(..), AuxData(..),
   PackData(..), unPP, unJP, unCSP, unCPPP, unSP, unJLP, ImplementationType(..))
 
+import Utils.Drasil (createDirIfMissing)
+
 import Text.PrettyPrint.HughesPJ (Doc, render)
 import Control.Monad.State (evalState, runState)
-import System.Directory (setCurrentDirectory, createDirectoryIfMissing, getCurrentDirectory)
+import System.Directory (setCurrentDirectory, getCurrentDirectory)
 import System.FilePath.Posix (takeDirectory)
 import System.IO (hClose, hPutStrLn, openFile, IOMode(WriteMode))
 import Prelude hiding (return,print,log,exp,sin,cos,tan)
@@ -28,27 +30,27 @@ import NameGenTest (nameGenTestOO, nameGenTestProc)
 main :: IO()
 main = do
   workingDir <- getCurrentDirectory
-  createDirectoryIfMissing False "java"
+  createDirIfMissing False "java"
   setCurrentDirectory "java"
   genCode (classes unJC unJP)
   setCurrentDirectory workingDir
-  createDirectoryIfMissing False "python"
+  createDirIfMissing False "python"
   setCurrentDirectory "python"
   genCode (classes unPC unPP)
   setCurrentDirectory workingDir
-  createDirectoryIfMissing False "csharp"
+  createDirIfMissing False "csharp"
   setCurrentDirectory "csharp"
   genCode (classes unCSC unCSP)
   setCurrentDirectory workingDir
-  createDirectoryIfMissing False "cpp"
+  createDirIfMissing False "cpp"
   setCurrentDirectory "cpp"
   genCode (classes unCPPC unCPPP)
   setCurrentDirectory workingDir
-  createDirectoryIfMissing False "swift"
+  createDirIfMissing False "swift"
   setCurrentDirectory "swift"
   genCode (classes unSC unSP)
   setCurrentDirectory workingDir
-  createDirectoryIfMissing False "julia"
+  createDirIfMissing False "julia"
   setCurrentDirectory "julia"
   genCode (jlClasses unJLC unJLP)
   setCurrentDirectory workingDir
@@ -104,9 +106,9 @@ createCodeFiles ns cs = mapM_ createCodeFile (zip ns cs)
 -- | Helper that creates the file and renders code.
 createCodeFile :: (Label, (FilePath, Doc)) -> IO ()
 createCodeFile (n, (path, code)) = do
-    createDirectoryIfMissing False n
+    createDirIfMissing False n
     setCurrentDirectory n
-    createDirectoryIfMissing True (takeDirectory path)
+    createDirIfMissing True (takeDirectory path)
     h <- openFile path WriteMode
     hPutStrLn h (render code)
     hClose h

--- a/code/drasil-example/projectile/lib/Drasil/Projectile/Choices.hs
+++ b/code/drasil-example/projectile/lib/Drasil/Projectile/Choices.hs
@@ -17,9 +17,9 @@ import Drasil.Projectile.Body (fullSI)
 import System.Drasil (System(SI, _sys))
 
 import Data.List (intercalate)
-import System.Directory (createDirectoryIfMissing, getCurrentDirectory, 
-  setCurrentDirectory)
+import System.Directory (getCurrentDirectory, setCurrentDirectory)
 import Data.Char (toLower)
+import Utils.Drasil (createDirIfMissing)
 
 genCodeWithChoices :: [Choices] -> IO ()
 genCodeWithChoices [] = return ()
@@ -27,7 +27,7 @@ genCodeWithChoices (c:cs) = let dir = map toLower $ codedDirName (getSysName ful
                                 getSysName SI{_sys = sysName} = programName sysName
   in do
     workingDir <- getCurrentDirectory
-    createDirectoryIfMissing False dir
+    createDirIfMissing False dir
     setCurrentDirectory dir
     genCode c (codeSpec fullSI c [])
     setCurrentDirectory workingDir

--- a/code/drasil-gen/lib/Language/Drasil/Dump.hs
+++ b/code/drasil-gen/lib/Language/Drasil/Dump.hs
@@ -4,14 +4,13 @@ module Language.Drasil.Dump where
 import qualified Database.Drasil as DB
 import System.Drasil (System, systemdb)
 
-import System.Directory
 import System.IO
 import Data.Aeson (ToJSON)
 import Data.Aeson.Encode.Pretty (encodePretty)
 import qualified Data.ByteString.Lazy.Char8 as LB
 import qualified Data.Map.Strict as SM
 
-import Utils.Drasil (invert, atLeast2)
+import Utils.Drasil (invert, atLeast2, createDirIfMissing)
 import Database.Drasil (traceTable, refbyTable, ChunkDB (termTable))
 import Control.Lens ((^.))
 import System.Environment (lookupEnv)
@@ -35,7 +34,7 @@ dumpEverything si pinfo p = do
 
 dumpEverything0 :: System -> PrintingInformation -> Path -> IO ()
 dumpEverything0 si pinfo targetPath = do
-  createDirectoryIfMissing True targetPath
+  createDirIfMissing True targetPath
   let chunkDb = si ^. systemdb
       chunkDump = DB.dumpChunkDB chunkDb
       invertedChunkDump = invert chunkDump

--- a/code/drasil-gen/lib/Language/Drasil/Generate.hs
+++ b/code/drasil-gen/lib/Language/Drasil/Generate.hs
@@ -15,8 +15,7 @@ module Language.Drasil.Generate (
 import System.IO (hClose, hPutStrLn, openFile, IOMode(WriteMode))
 import Text.PrettyPrint.HughesPJ (Doc, render)
 import Prelude hiding (id)
-import System.Directory (createDirectoryIfMissing, getCurrentDirectory,
-  setCurrentDirectory)
+import System.Directory (getCurrentDirectory, setCurrentDirectory)
 import Data.Time.Clock (getCurrentTime, utctDay)
 import Data.Time.Calendar (showGregorian)
 
@@ -38,6 +37,8 @@ import Language.Drasil.Dump
 import Drasil.GOOL (unJC, unPC, unCSC, unCPPC, unSC)
 import Drasil.GProc (unJLC)
 import Control.Lens ((^.))
+
+import Utils.Drasil (createDirIfMissing)
 
 -- | Generate a number of artifacts based on a list of recipes.
 gen :: DocSpec -> Document -> PrintingInformation -> IO ()
@@ -75,7 +76,7 @@ srsFormatError = error "We can only write TeX/HTML/JSON/MDBook (for now)."
 -- document information and printing information. Then generates the document file.
 prntDoc' :: DocType -> String -> String -> Format -> Document -> PrintingInformation -> IO ()
 prntDoc' _ dt' _ MDBook body' sm = do
-  createDirectoryIfMissing True dir
+  createDirIfMissing True dir
   mapM_ writeDocToFile con
   where 
     con = writeDoc' sm MDBook body'
@@ -85,7 +86,7 @@ prntDoc' _ dt' _ MDBook body' sm = do
       hPutStrLn outh $ render d
       hClose outh
 prntDoc' dt dt' fn format body' sm = do
-  createDirectoryIfMissing True dt'
+  createDirIfMissing True dt'
   outh <- openFile (dt' ++ "/" ++ fn ++ getExt format) WriteMode
   hPutStrLn outh $ render $ writeDoc sm dt format fn body'
   hClose outh
@@ -162,7 +163,7 @@ genCode chs spec = do
   time <- getCurrentTime
   sampData <- maybe (return []) (\sd -> readWithDataDesc sd $ sampleInputDD
     (spec ^. extInputsO)) (getSampleData chs)
-  createDirectoryIfMissing False "src"
+  createDirIfMissing False "src"
   setCurrentDirectory "src"
   let genLangCode Java = genCall Java unJC unJP
       genLangCode Python = genCall Python unPC unPP

--- a/code/drasil-printers/lib/Language/Drasil/DOT/Print.hs
+++ b/code/drasil-printers/lib/Language/Drasil/DOT/Print.hs
@@ -6,6 +6,8 @@ import Data.List (intercalate)
 import System.IO
 import System.Directory
 
+import Utils.Drasil (createDirIfMissing)
+
 -- * Types
 
 -- | Type synonym for clarity.
@@ -68,7 +70,7 @@ data GraphInfo = GI {
 -- | Creates the directory for output, gathers all individual graph output functions and calls them.
 outputDot :: FilePath -> GraphInfo -> IO ()
 outputDot outputFilePath gi = do
-    createDirectoryIfMissing False outputFilePath
+    createDirIfMissing False outputFilePath
     setCurrentDirectory outputFilePath
     mkOutputAvsA gi
     mkOutputAvsAll gi

--- a/code/drasil-utils/lib/Utils/Drasil.hs
+++ b/code/drasil-utils/lib/Utils/Drasil.hs
@@ -1,5 +1,9 @@
 -- | Gather Drasil's utility functions and re-export for easy use.
 module Utils.Drasil (
+  -- * Directory
+  -- | From "Utils.Drasil.Directory".
+  createDirIfMissing,
+
   -- * Documents
   -- | From "Utils.Drasil.Document".
   blank, indent, indentList, filterEmpty, listToDoc,
@@ -25,6 +29,7 @@ module Utils.Drasil (
   makeCSV
 ) where
 
+import Utils.Drasil.Directory
 import Utils.Drasil.Document
 import Utils.Drasil.English
 import Utils.Drasil.Lists

--- a/code/drasil-utils/lib/Utils/Drasil/Directory.hs
+++ b/code/drasil-utils/lib/Utils/Drasil/Directory.hs
@@ -1,0 +1,17 @@
+module Utils.Drasil.Directory (createDirIfMissing) where
+
+import System.Directory (createDirectoryIfMissing, doesPathExist)
+
+-- | Creates a directory if it does not already exist (optionally with all
+-- missing parent directories).
+--
+-- Implementation uses doesPathExist to check if the directory exists rather
+-- than createDirectoryIfMissing True, which would create the directory
+-- regardless of whether it exists or not, potentially leading to an error that
+-- appears in `make debug` logs.
+createDirIfMissing :: Bool -> FilePath -> IO ()
+createDirIfMissing withParents path = do
+  exists <- doesPathExist path
+  if exists
+    then pure ()
+    else createDirectoryIfMissing withParents path

--- a/code/drasil-utils/package.yaml
+++ b/code/drasil-utils/package.yaml
@@ -16,6 +16,7 @@ extra-source-files: []
 dependencies:
 - base >= 4.7 && < 5
 - containers
+- directory
 - pretty
 
 ghc-options:


### PR DESCRIPTION
The [implementation of `createDirectoryOfMissing`](https://hackage.haskell.org/package/directory-1.3.9.0/docs/src/System.Directory.html#createDirectoryIfMissing) handles errors as part of its normal routine. However, with `make debug`, GHC will compile a version of Drasil that shows all exceptions that appear during a programs runtime. This clutters the final execution of the case studies with, for example:

<details>

<summary>Some of the output from just one of the case study execution logs.</summary>

```output
  called from System.Directory.OsPath.createDirectoryIfMissing.createDir,
  called from System.Directory.OsPath.createDirectoryIfMissing.createDirs,
  called from System.Directory.OsPath.createDirectoryIfMissing,
  called from System.Directory.createDirectoryIfMissing,
  called from Language.Drasil.Code.CodeGeneration.createCodeFile,
  called from Language.Drasil.Code.CodeGeneration.createCodeFiles,
  called from Language.Drasil.Code.Imperative.Generator.generateCode,
  called from Language.Drasil.Generate.genCode.genCall,
  called from Language.Drasil.Generate.genCode.genLangCode,
  called from Language.Drasil.Generate.genCode,
  called from Main.main
*** Exception (reporting due to +RTS -xc): (THUNK), stack trace: 
  System.Posix.PosixPath.FilePath.throwErrnoPath,
  called from System.Posix.PosixPath.FilePath.throwErrnoPathIfRetry,
  called from System.Posix.PosixPath.FilePath.throwErrnoPathIfMinus1Retry_,
  called from System.Posix.Directory.PosixPath.createDirectory.\,
  called from System.Posix.PosixPath.FilePath.useAsCStringSafe.\,
  called from System.OsString.Internal.Types.Hidden.$mPS.\,
  called from System.Posix.PosixPath.FilePath.useAsCStringSafe,
  called from System.Posix.PosixPath.FilePath.withFilePath,
  called from System.Posix.Directory.PosixPath.createDirectory,
  called from System.Directory.Internal.Posix.createDirectoryInternal,
  called from System.Directory.OsPath.createDirectory,
  called from System.Directory.OsPath.createDirectoryIfMissing.createDir,
  called from System.Directory.OsPath.createDirectoryIfMissing.createDirs,
  called from System.Directory.OsPath.createDirectoryIfMissing,
  called from System.Directory.createDirectoryIfMissing,
  called from Language.Drasil.Code.CodeGeneration.createCodeFile,
  called from Language.Drasil.Code.CodeGeneration.createCodeFiles,
  called from Language.Drasil.Code.Imperative.Generator.generateCode,
  called from Language.Drasil.Generate.genCode.genCall,
  called from Language.Drasil.Generate.genCode.genLangCode,
  called from Language.Drasil.Generate.genCode,
  called from Main.main
*** Exception (reporting due to +RTS -xc): (THUNK), stack trace: 
  System.Posix.PosixPath.FilePath.throwErrnoPath,
  called from System.Posix.PosixPath.FilePath.throwErrnoPathIfRetry,
  called from System.Posix.PosixPath.FilePath.throwErrnoPathIfMinus1Retry_,
  called from System.Posix.Directory.PosixPath.createDirectory.\,
  called from System.Posix.PosixPath.FilePath.useAsCStringSafe.\,
  called from System.OsString.Internal.Types.Hidden.$mPS.\,
  called from System.Posix.PosixPath.FilePath.useAsCStringSafe,
  called from System.Posix.PosixPath.FilePath.withFilePath,
  called from System.Posix.Directory.PosixPath.createDirectory,
  called from System.Directory.Internal.Posix.createDirectoryInternal,
  called from System.Directory.OsPath.createDirectory,
  called from System.Directory.OsPath.createDirectoryIfMissing.createDir,
  called from System.Directory.OsPath.createDirectoryIfMissing.createDirs,
  called from System.Directory.OsPath.createDirectoryIfMissing,
  called from System.Directory.createDirectoryIfMissing,
  called from Language.Drasil.Code.CodeGeneration.createCodeFile,
  called from Language.Drasil.Code.CodeGeneration.createCodeFiles,
  called from Language.Drasil.Code.Imperative.Generator.generateCode,
  called from Language.Drasil.Generate.genCode.genCall,
  called from Language.Drasil.Generate.genCode.genLangCode,
  called from Language.Drasil.Generate.genCode,
  called from Main.main
*** Exception (reporting due to +RTS -xc): (THUNK), stack trace: 
  System.Posix.PosixPath.FilePath.throwErrnoPath,
  called from System.Posix.PosixPath.FilePath.throwErrnoPathIfRetry,
  called from System.Posix.PosixPath.FilePath.throwErrnoPathIfMinus1Retry_,
  called from System.Posix.Directory.PosixPath.createDirectory.\,
  called from System.Posix.PosixPath.FilePath.useAsCStringSafe.\,
  called from System.OsString.Internal.Types.Hidden.$mPS.\,
  called from System.Posix.PosixPath.FilePath.useAsCStringSafe,
  called from System.Posix.PosixPath.FilePath.withFilePath,
  called from System.Posix.Directory.PosixPath.createDirectory,
  called from System.Directory.Internal.Posix.createDirectoryInternal,
  called from System.Directory.OsPath.createDirectory,
  called from System.Directory.OsPath.createDirectoryIfMissing.createDir,
  called from System.Directory.OsPath.createDirectoryIfMissing.createDirs,
  called from System.Directory.OsPath.createDirectoryIfMissing,
  called from System.Directory.createDirectoryIfMissing,
  called from Language.Drasil.Code.CodeGeneration.createCodeFile,
  called from Language.Drasil.Code.CodeGeneration.createCodeFiles,
  called from Language.Drasil.Code.Imperative.Generator.generateCode,
  called from Language.Drasil.Generate.genCode.genCall,
  called from Language.Drasil.Generate.genCode.genLangCode,
  called from Language.Drasil.Generate.genCode,
  called from Main.main
*** Exception (reporting due to +RTS -xc): (THUNK), stack trace: 
  System.Posix.PosixPath.FilePath.throwErrnoPath,
  called from System.Posix.PosixPath.FilePath.throwErrnoPathIfRetry,
  called from System.Posix.PosixPath.FilePath.throwErrnoPathIfMinus1Retry_,
  called from System.Posix.Directory.PosixPath.createDirectory.\,
  called from System.Posix.PosixPath.FilePath.useAsCStringSafe.\,
  called from System.OsString.Internal.Types.Hidden.$mPS.\,
  called from System.Posix.PosixPath.FilePath.useAsCStringSafe,
  called from System.Posix.PosixPath.FilePath.withFilePath,
  called from System.Posix.Directory.PosixPath.createDirectory,
  called from System.Directory.Internal.Posix.createDirectoryInternal,
  called from System.Directory.OsPath.createDirectory,
  called from System.Directory.OsPath.createDirectoryIfMissing.createDir,
  called from System.Directory.OsPath.createDirectoryIfMissing.createDirs,
  called from System.Directory.OsPath.createDirectoryIfMissing,
  called from System.Directory.createDirectoryIfMissing,
  called from Language.Drasil.Code.CodeGeneration.createCodeFile,
  called from Language.Drasil.Code.CodeGeneration.createCodeFiles,
  called from Language.Drasil.Code.Imperative.Generator.generateCode,
  called from Language.Drasil.Generate.genCode.genCall,
  called from Language.Drasil.Generate.genCode.genLangCode,
  called from Language.Drasil.Generate.genCode,
  called from Main.main
*** Exception (reporting due to +RTS -xc): (THUNK), stack trace: 
  System.Posix.PosixPath.FilePath.throwErrnoPath,
  called from System.Posix.PosixPath.FilePath.throwErrnoPathIfRetry,
  called from System.Posix.PosixPath.FilePath.throwErrnoPathIfMinus1Retry_,
  called from System.Posix.Directory.PosixPath.createDirectory.\,
  called from System.Posix.PosixPath.FilePath.useAsCStringSafe.\,
  called from System.OsString.Internal.Types.Hidden.$mPS.\,
  called from System.Posix.PosixPath.FilePath.useAsCStringSafe,
  called from System.Posix.PosixPath.FilePath.withFilePath,
  called from System.Posix.Directory.PosixPath.createDirectory,
  called from System.Directory.Internal.Posix.createDirectoryInternal,
  called from System.Directory.OsPath.createDirectory,
  called from System.Directory.OsPath.createDirectoryIfMissing.createDir,
  called from System.Directory.OsPath.createDirectoryIfMissing.createDirs,
  called from System.Directory.OsPath.createDirectoryIfMissing,
  called from System.Directory.createDirectoryIfMissing,
  called from Language.Drasil.Code.CodeGeneration.createCodeFile,
  called from Language.Drasil.Code.CodeGeneration.createCodeFiles,
  called from Language.Drasil.Code.Imperative.Generator.generateCode,
  called from Language.Drasil.Generate.genCode.genCall,
  called from Language.Drasil.Generate.genCode.genLangCode,
  called from Language.Drasil.Generate.genCode,
  called from Main.main
*** Exception (reporting due to +RTS -xc): (THUNK), stack trace: 
  System.Posix.PosixPath.FilePath.throwErrnoPath,
  called from System.Posix.PosixPath.FilePath.throwErrnoPathIfRetry,
  called from System.Posix.PosixPath.FilePath.throwErrnoPathIfMinus1Retry_,
  called from System.Posix.Directory.PosixPath.createDirectory.\,
  called from System.Posix.PosixPath.FilePath.useAsCStringSafe.\,
  called from System.OsString.Internal.Types.Hidden.$mPS.\,
  called from System.Posix.PosixPath.FilePath.useAsCStringSafe,
  called from System.Posix.PosixPath.FilePath.withFilePath,
  called from System.Posix.Directory.PosixPath.createDirectory,
  called from System.Directory.Internal.Posix.createDirectoryInternal,
  called from System.Directory.OsPath.createDirectory,
  called from System.Directory.OsPath.createDirectoryIfMissing.createDir,
  called from System.Directory.OsPath.createDirectoryIfMissing.createDirs,
  called from System.Directory.OsPath.createDirectoryIfMissing,
  called from System.Directory.createDirectoryIfMissing,
  called from Language.Drasil.Code.CodeGeneration.createCodeFile,
  called from Language.Drasil.Code.CodeGeneration.createCodeFiles,
  called from Language.Drasil.Code.Imperative.Generator.generateCode,
  called from Language.Drasil.Generate.genCode.genCall,
  called from Language.Drasil.Generate.genCode.genLangCode,
  called from Language.Drasil.Generate.genCode,
  called from Main.main
*** Exception (reporting due to +RTS -xc): (THUNK), stack trace: 
  System.Posix.PosixPath.FilePath.throwErrnoPath,
  called from System.Posix.PosixPath.FilePath.throwErrnoPathIfRetry,
  called from System.Posix.PosixPath.FilePath.throwErrnoPathIfMinus1Retry_,
  called from System.Posix.Directory.PosixPath.createDirectory.\,
  called from System.Posix.PosixPath.FilePath.useAsCStringSafe.\,
  called from System.OsString.Internal.Types.Hidden.$mPS.\,
  called from System.Posix.PosixPath.FilePath.useAsCStringSafe,
  called from System.Posix.PosixPath.FilePath.withFilePath,
  called from System.Posix.Directory.PosixPath.createDirectory,
  called from System.Directory.Internal.Posix.createDirectoryInternal,
  called from System.Directory.OsPath.createDirectory,
  called from System.Directory.OsPath.createDirectoryIfMissing.createDir,
  called from System.Directory.OsPath.createDirectoryIfMissing.createDirs,
  called from System.Directory.OsPath.createDirectoryIfMissing,
  called from System.Directory.createDirectoryIfMissing,
  called from Language.Drasil.Code.CodeGeneration.createCodeFile,
  called from Language.Drasil.Code.CodeGeneration.createCodeFiles,
  called from Language.Drasil.Code.Imperative.Generator.generateCode,
  called from Language.Drasil.Generate.genCode.genCall,
  called from Language.Drasil.Generate.genCode.genLangCode,
  called from Language.Drasil.Generate.genCode,
  called from Main.main
*** Exception (reporting due to +RTS -xc): (THUNK), stack trace: 
  System.Posix.PosixPath.FilePath.throwErrnoPath,
  called from System.Posix.PosixPath.FilePath.throwErrnoPathIfRetry,
  called from System.Posix.PosixPath.FilePath.throwErrnoPathIfMinus1Retry_,
  called from System.Posix.Directory.PosixPath.createDirectory.\,
  called from System.Posix.PosixPath.FilePath.useAsCStringSafe.\,
  called from System.OsString.Internal.Types.Hidden.$mPS.\,
  called from System.Posix.PosixPath.FilePath.useAsCStringSafe,
  called from System.Posix.PosixPath.FilePath.withFilePath,
  called from System.Posix.Directory.PosixPath.createDirectory,
  called from System.Directory.Internal.Posix.createDirectoryInternal,
  called from System.Directory.OsPath.createDirectory,
  called from System.Directory.OsPath.createDirectoryIfMissing.createDir,
  called from System.Directory.OsPath.createDirectoryIfMissing.createDirs,
  called from System.Directory.OsPath.createDirectoryIfMissing,
  called from System.Directory.createDirectoryIfMissing,
  called from Language.Drasil.DOT.Print.outputDot,
  called from Language.Drasil.Generate.genDot,
  called from Main.main
```

</details>