### PR TITLE
Exclude terms also found in `thisSymbols`

### DIFF
--- a/code/drasil-example/glassbr/lib/Drasil/GlassBR/Body.hs
+++ b/code/drasil-example/glassbr/lib/Drasil/GlassBR/Body.hs
@@ -42,13 +42,13 @@ import Drasil.GlassBR.IMods (symb, iMods, instModIntro)
 import Drasil.GlassBR.MetaConcepts (progName)
 import Drasil.GlassBR.References (astm2009, astm2012, astm2016, citations)
 import Drasil.GlassBR.Requirements (funcReqs, inReqDesc, funcReqsTables, nonfuncReqs)
-import Drasil.GlassBR.Symbols (symbolsForTable, thisSymbols)
+import Drasil.GlassBR.Symbols (symbolsForSymbolTable, thisSymbols, thisTerms)
 import Drasil.GlassBR.TMods (tMods)
 import Drasil.GlassBR.Unitals (blast, blastTy, bomb, explosion, constants,
   constrained, inputs, outputs, specParamVals, glassTy,
   glassTypes, glBreakage, lateralLoad, load, loadTypes, pbTol, probBr, stressDistFac, probBreak,
   sD, termsWithAccDefn, termsWithDefsOnly, terms, dataConstraints, lDurFac,
-  isSafeProb, dimlessLoad, isSafeLoad, tolLoad, unitless, riskFun, sdfTol, symbols, unitarySymbols)
+  isSafeProb, dimlessLoad, isSafeLoad, tolLoad, unitless, riskFun, sdfTol, symbols, unitarySymbols, derivedInputDataConstraints)
 
 srs :: Document
 srs = mkDoc mkSRS (S.forGen titleize phrase) si
@@ -68,7 +68,7 @@ si = SI {
   _background  = [background],
   _motivation  = [],
   _scope       = [scope],
-  _quants      = symbolsForTable,
+  _quants      = symbolsForSymbolTable,
   _instModels  = iMods,
   _datadefs    = GB.dataDefs,
   _configFiles = configFp,
@@ -134,8 +134,8 @@ background = foldlSent_ [phrase explosion, S "in downtown areas are dangerous fr
   +:+ S "effect of falling glass"]
 
 symbMap :: ChunkDB
-symbMap = cdb (unitless ++ map qw thisSymbols ++ map qw symbols) 
-  (nw progName : map nw thisSymbols ++ map nw unitarySymbols ++ map nw con'
+symbMap = cdb (map qw thisSymbols) 
+  (nw progName : map nw thisTerms ++ map nw unitarySymbols ++ map nw con'
   ++ map nw [riskFun, isSafeProb, isSafeLoad, sdfTol, dimlessLoad, tolLoad,
   lDurFac] ++ map nw terms ++ map nw doccon ++ map nw doccon' ++ map nw educon
   ++ [nw sciCompS] ++ map nw compcon ++ map nw mathcon ++ map nw mathcon'

--- a/code/drasil-example/glassbr/lib/Drasil/GlassBR/Body.hs
+++ b/code/drasil-example/glassbr/lib/Drasil/GlassBR/Body.hs
@@ -48,7 +48,7 @@ import Drasil.GlassBR.Unitals (blast, blastTy, bomb, explosion, constants,
   constrained, inputs, outputs, specParamVals, glassTy,
   glassTypes, glBreakage, lateralLoad, load, loadTypes, pbTol, probBr, stressDistFac, probBreak,
   sD, termsWithAccDefn, termsWithDefsOnly, terms, dataConstraints, lDurFac,
-  isSafeProb, dimlessLoad, isSafeLoad, tolLoad, unitless, riskFun, sdfTol)
+  isSafeProb, dimlessLoad, isSafeLoad, tolLoad, unitless, riskFun, sdfTol, symbols, unitarySymbols)
 
 srs :: Document
 srs = mkDoc mkSRS (S.forGen titleize phrase) si
@@ -134,14 +134,14 @@ background = foldlSent_ [phrase explosion, S "in downtown areas are dangerous fr
   +:+ S "effect of falling glass"]
 
 symbMap :: ChunkDB
-symbMap = cdb (unitless ++ thisSymbols) (nw progName : map nw thisSymbols
-  ++ map nw con' ++ map nw [riskFun, isSafeProb, isSafeLoad,
-  sdfTol, dimlessLoad, tolLoad, lDurFac] ++ map nw terms ++ map nw doccon
-  ++ map nw doccon' ++ map nw educon ++ [nw sciCompS] ++ map nw compcon
-  ++ map nw mathcon ++ map nw mathcon' ++ map nw softwarecon
-  ++ [nw lateralLoad, nw materialProprty] ++ [nw distance, nw algorithm]
-  ++ map nw fundamentals ++ map nw derived ++ map nw physicalcon)
-  (map cw symb ++ terms ++ Doc.srsDomains)
+symbMap = cdb (unitless ++ map qw thisSymbols ++ map qw symbols) 
+  (nw progName : map nw thisSymbols ++ map nw unitarySymbols ++ map nw con'
+  ++ map nw [riskFun, isSafeProb, isSafeLoad, sdfTol, dimlessLoad, tolLoad,
+  lDurFac] ++ map nw terms ++ map nw doccon ++ map nw doccon' ++ map nw educon
+  ++ [nw sciCompS] ++ map nw compcon ++ map nw mathcon ++ map nw mathcon'
+  ++ map nw softwarecon ++ [nw lateralLoad, nw materialProprty]
+  ++ [nw distance, nw algorithm] ++ map nw fundamentals ++ map nw derived
+  ++ map nw physicalcon) (map cw symb ++ terms ++ Doc.srsDomains)
   (map unitWrapper [metre, second, kilogram]
   ++ map unitWrapper [pascal, newton]) GB.dataDefs iMods [] tMods concIns
   labCon allRefs citations

--- a/code/drasil-example/glassbr/lib/Drasil/GlassBR/Symbols.hs
+++ b/code/drasil-example/glassbr/lib/Drasil/GlassBR/Symbols.hs
@@ -4,14 +4,14 @@ import Language.Drasil (QuantityDict, qw)
 import Language.Drasil.Code (Mod(Mod), asVC)
 
 import Drasil.GlassBR.ModuleDefs (allMods, implVars)
-import Drasil.GlassBR.Unitals (inputs, outputs, specParamVals, symbols,
+import Drasil.GlassBR.Unitals (inputs, outputs, specParamVals,
   symbolsWithDefns, unitless, tmSymbols, interps, derivedInputDataConstraints)
 
 import Data.List ((\\))
 
 symbolsForTable :: [QuantityDict]
 symbolsForTable = inputs ++ outputs ++ tmSymbols ++ map qw specParamVals ++ 
-  map qw symbolsWithDefns ++ map qw symbols ++ map qw derivedInputDataConstraints ++ interps
+  map qw symbolsWithDefns ++ map qw derivedInputDataConstraints ++ interps
 
   -- include all module functions as symbols
 thisSymbols :: [QuantityDict]

--- a/code/drasil-example/glassbr/lib/Drasil/GlassBR/Symbols.hs
+++ b/code/drasil-example/glassbr/lib/Drasil/GlassBR/Symbols.hs
@@ -4,16 +4,24 @@ import Language.Drasil (QuantityDict, qw)
 import Language.Drasil.Code (Mod(Mod), asVC)
 
 import Drasil.GlassBR.ModuleDefs (allMods, implVars)
-import Drasil.GlassBR.Unitals (inputs, outputs, specParamVals,
+import Drasil.GlassBR.Unitals (inputs, outputs, specParamVals, symbols,
   symbolsWithDefns, unitless, tmSymbols, interps, derivedInputDataConstraints)
 
 import Data.List ((\\))
 
-symbolsForTable :: [QuantityDict]
-symbolsForTable = inputs ++ outputs ++ tmSymbols ++ map qw specParamVals ++ 
-  map qw symbolsWithDefns ++ map qw derivedInputDataConstraints ++ interps
+symbolsForSymbolTable :: [QuantityDict]
+symbolsForSymbolTable = symbolsForTermTable ++ map qw symbols ++
+  unitless ++ map qw derivedInputDataConstraints
+
+symbolsForTermTable :: [QuantityDict]
+symbolsForTermTable = inputs ++ outputs ++ tmSymbols ++ map qw specParamVals ++ 
+  map qw symbolsWithDefns ++ interps
 
   -- include all module functions as symbols
 thisSymbols :: [QuantityDict]
 thisSymbols = (map asVC (concatMap (\(Mod _ _ _ _ l) -> l) allMods)
-  \\ symbolsForTable) ++ map qw implVars ++ symbolsForTable
+  \\ symbolsForSymbolTable) ++ map qw implVars ++ symbolsForSymbolTable
+  
+thisTerms :: [QuantityDict]
+thisTerms = (map asVC (concatMap (\(Mod _ _ _ _ l) -> l) allMods)
+  \\ symbolsForTermTable) ++ map qw implVars ++ symbolsForTermTable

--- a/code/drasil-example/glassbr/lib/Drasil/GlassBR/Unitals.hs
+++ b/code/drasil-example/glassbr/lib/Drasil/GlassBR/Unitals.hs
@@ -190,9 +190,14 @@ stressDistFacMax = mkQuantDef (vc "stressDistFacMax" (nounPhraseSP "maximum valu
   (subMax (eqSymb stressDistFac)) Real) (exactDbl 32)
 {--}
 
+unitarySymbols :: [UnitaryChunk]
+unitarySymbols = [minThick, sflawParamK, sflawParamM, loadDur]
+
+unitalSymbols :: [UnitalChunk]
+unitalSymbols = [demand, tmDemand, lRe, tmLRe, nonFactorL, eqTNTWeight]
+
 symbols :: [UnitaryChunk]
-symbols = [minThick, sflawParamK, sflawParamM, loadDur] ++
-  map mkUnitary [demand, tmDemand, lRe, tmLRe, nonFactorL, eqTNTWeight]
+symbols = unitarySymbols ++ map mkUnitary unitalSymbols
 
 minThick, sflawParamK, sflawParamM, sdx, sdy, sdz, loadDur :: UnitaryChunk
 


### PR DESCRIPTION
Contributes to #4036 

Implements #4108 without using the hack (fixes around 80% of the remaining duplicates, a bit more work to this PR will be added)