### PR TITLE
Fix main

### DIFF
--- a/code/drasil-example/glassbr/lib/Drasil/GlassBR/Body.hs
+++ b/code/drasil-example/glassbr/lib/Drasil/GlassBR/Body.hs
@@ -48,7 +48,7 @@ import Drasil.GlassBR.Unitals (blast, blastTy, bomb, explosion, constants,
   constrained, inputs, outputs, specParamVals, glassTy,
   glassTypes, glBreakage, lateralLoad, load, loadTypes, pbTol, probBr, stressDistFac, probBreak,
   sD, termsWithAccDefn, termsWithDefsOnly, terms, dataConstraints, lDurFac,
-  isSafeProb, dimlessLoad, isSafeLoad, tolLoad, unitless, riskFun, sdfTol, symbols, unitarySymbols, derivedInputDataConstraints)
+  isSafeProb, dimlessLoad, isSafeLoad, tolLoad, riskFun, sdfTol, unitarySymbols)
 
 srs :: Document
 srs = mkDoc mkSRS (S.forGen titleize phrase) si

--- a/code/drasil-example/glassbr/lib/Drasil/GlassBR/Body.hs
+++ b/code/drasil-example/glassbr/lib/Drasil/GlassBR/Body.hs
@@ -32,8 +32,8 @@ import Data.Drasil.SI_Units (kilogram, metre, newton, pascal, second, fundamenta
 
 import Drasil.GlassBR.Assumptions (assumptionConstants, assumptions)
 import Drasil.GlassBR.Changes (likelyChgs, unlikelyChgs)
-import Drasil.GlassBR.Concepts (acronyms, blastRisk, glaPlane, glaSlab, 
-  ptOfExplsn, con', glass)
+import Drasil.GlassBR.Concepts (acronyms, blastRisk, glaPlane, glaSlab,
+  ptOfExplsn, con', glass, con)
 import Drasil.GlassBR.DataDefs (configFp)
 import qualified Drasil.GlassBR.DataDefs as GB (dataDefs)
 import Drasil.GlassBR.Figures
@@ -134,14 +134,14 @@ background = foldlSent_ [phrase explosion, S "in downtown areas are dangerous fr
   +:+ S "effect of falling glass"]
 
 symbMap :: ChunkDB
-symbMap = cdb (map qw thisSymbols) 
+symbMap = cdb thisSymbols
   (nw progName : map nw thisTerms ++ map nw unitarySymbols ++ map nw con'
   ++ map nw [riskFun, isSafeProb, isSafeLoad, sdfTol, dimlessLoad, tolLoad,
   lDurFac] ++ map nw terms ++ map nw doccon ++ map nw doccon' ++ map nw educon
   ++ [nw sciCompS] ++ map nw compcon ++ map nw mathcon ++ map nw mathcon'
   ++ map nw softwarecon ++ [nw lateralLoad, nw materialProprty]
   ++ [nw distance, nw algorithm] ++ map nw fundamentals ++ map nw derived
-  ++ map nw physicalcon) (map cw symb ++ terms ++ Doc.srsDomains)
+  ++ map nw physicalcon ++ map nw con) (map cw symb ++ terms ++ Doc.srsDomains)
   (map unitWrapper [metre, second, kilogram]
   ++ map unitWrapper [pascal, newton]) GB.dataDefs iMods [] tMods concIns
   labCon allRefs citations

--- a/code/drasil-example/glassbr/lib/Drasil/GlassBR/Symbols.hs
+++ b/code/drasil-example/glassbr/lib/Drasil/GlassBR/Symbols.hs
@@ -5,7 +5,7 @@ import Language.Drasil.Code (Mod(Mod), asVC)
 
 import Drasil.GlassBR.ModuleDefs (allMods, implVars)
 import Drasil.GlassBR.Unitals (inputs, outputs, specParamVals, symbols,
-  symbolsWithDefns, tmSymbols, interps, derivedInputDataConstraints)
+  symbolsWithDefns, tmSymbols, interps, derivedInputDataConstraints, unitless)
 
 import Data.List ((\\))
 

--- a/code/drasil-lang/lib/Language/Drasil/Chunk/CommonIdea.hs
+++ b/code/drasil-lang/lib/Language/Drasil/Chunk/CommonIdea.hs
@@ -12,7 +12,6 @@ import Language.Drasil.Chunk.NamedIdea (IdeaDict, nc)
 import Language.Drasil.Classes (NamedIdea(term), Idea(getA),
  CommonIdea(abrv), ConceptDomain(cdom))
 import Language.Drasil.NounPhrase.Core (NP)
-import Language.Drasil.Sentence (Sentence(S))
 import Drasil.Database.UID (UID, HasUID(uid))
 
 import Utils.Drasil (repUnd)


### PR DESCRIPTION
* c86882dcff513e2c5e7b31d4c2fcba45e0d5e43e effectively reverts https://github.com/JacquesCarette/Drasil/pull/4135 which #4080 was dependant on.
* #4138 seemed to be based on an older HEAD, so https://github.com/JacquesCarette/Drasil/pull/4141/commits/4b37e63d172b75ec0edaba7ce4a620767e77a25e adds missing CIs back to the term map. I'm not entirely sure where the issue happened, and bisecting would be a bit difficult, but we can if we think its important.
* 20877d3d7c5d95992a3e52c1271e2e0878af32fc clears out the remaining unused warnings, so that we can hopefully finally merge #4131 
