### PR TITLE
Avoid registering IdeaDicts extracted from theories in the ChunkDB.

### DIFF
--- a/code/drasil-example/dblpend/lib/Drasil/DblPend/Body.hs
+++ b/code/drasil-example/dblpend/lib/Drasil/DblPend/Body.hs
@@ -28,7 +28,7 @@ import Data.Drasil.Concepts.Software (program, errMsg)
 import Data.Drasil.Quantities.Physics (physicscon)
 import Data.Drasil.Quantities.Math (unitVect, unitVectj)
 import Data.Drasil.Software.Products (prodtcon)
-import Data.Drasil.Theories.Physics (newtonSL, accelerationTM, velocityTM, newtonSLR)
+import Data.Drasil.Theories.Physics (newtonSL, accelerationTM, velocityTM)
 import Data.Drasil.TheoryConcepts (inModel)
 
 import Drasil.DblPend.Figures (figMotion, sysCtxFig1)
@@ -152,8 +152,6 @@ ideaDicts =
   map nw [algorithm, len, mass, errMsg, program] ++ map nw physicCon ++ map nw mathcon ++ map nw physicalcon ++
   -- UnitDefns
   map nw [kilogram, newton, degree, radian, metre, hertz] ++ map nw fundamentals ++
-  -- TheoryModels
-  nw newtonSLR :
   -- DefinedQuantityDicts
   map nw [unitVect, unitVectj] ++
   -- QuantityDicts

--- a/code/drasil-example/gamephysics/lib/Drasil/GamePhysics/Body.hs
+++ b/code/drasil-example/gamephysics/lib/Drasil/GamePhysics/Body.hs
@@ -149,10 +149,6 @@ ideaDicts =
   nw algorithm : map nw softwarecon ++ map nw CP.physicCon ++ map nw CM.mathcon ++
   -- UnitDefns
   map nw derived ++ map nw fundamentals ++
-  -- GenDefns
-  map nw generalDefns ++
-  -- InstanceModels
-  map nw iMods ++
   -- QuantityDicts
   map nw symbolsAll ++ map (nw . (^. output)) iMods
 

--- a/code/drasil-example/sglpend/lib/Drasil/SglPend/Body.hs
+++ b/code/drasil-example/sglpend/lib/Drasil/SglPend/Body.hs
@@ -137,8 +137,6 @@ ideaDicts =
   map nw physicalcon ++ map nw mathcon ++
   -- QuantityDicts
   map nw symbols ++
-  -- TheoryModels
-  nw newtonSLR : 
   -- UnitDefns
   map nw [newton, degree, radian, hertz] ++
   map nw fundamentals ++

--- a/code/drasil-example/ssp/lib/Drasil/SSP/Body.hs
+++ b/code/drasil-example/ssp/lib/Drasil/SSP/Body.hs
@@ -32,7 +32,7 @@ import Data.Drasil.Concepts.SolidMechanics (mobShear, normForce, shearForce,
   shearRes, solidcon)
 import Data.Drasil.Concepts.Computation (compcon, algorithm)
 import Data.Drasil.Software.Products (prodtcon)
-import Data.Drasil.Theories.Physics (physicsTMs, weightSrc, hsPressureSrc)
+import Data.Drasil.Theories.Physics (weightSrc, hsPressureSrc)
 
 import Data.Drasil.People (brooks, henryFrankis)
 import Data.Drasil.SI_Units (degree, metre, newton, pascal, kilogram, second, derived, fundamentals)
@@ -161,12 +161,6 @@ ideaDicts =
   map nw mathcon ++ map nw solidcon ++ map nw physicalcon ++
   -- DefinedQuantityDicts
   map nw symbols ++
-  -- GeneralDefinitions
-  map nw generalDefinitions ++
-  -- InstanceModels
-  map nw iMods ++
-  -- TheoryModels
-  map nw physicsTMs ++
   -- UnitDefns
   map nw derived ++ map nw fundamentals ++ map nw units
 

--- a/code/drasil-example/swhs/lib/Drasil/SWHS/Body.hs
+++ b/code/drasil-example/swhs/lib/Drasil/SWHS/Body.hs
@@ -121,8 +121,6 @@ ideaDicts =
   map nw physicscon ++ map nw unitalChuncks ++
   -- UncertainChunks
   map nw [absTol, relTol] ++
-  -- InstanceModels
-  nw heatEInPCM :
   -- ConstQDefs
   map nw specParamValList ++
   -- UnitDefns


### PR DESCRIPTION
Contributes to #4126 

~~Builds on https://github.com/JacquesCarette/Drasil/pull/4139~~

What's odd to me about this is that only these examples had their theories registered in the `ChunkDB`! Whatever is going on here needs further investigation (at least before we merge this PR).

(I'm only marking this PR as "ready for review" to get the CI to run.)