### PR TITLE
Remove hack for automatically extracting IdeaDicts from DataDefinitions.

### DIFF
--- a/code/drasil-database/lib/Database/Drasil/ChunkDB.hs
+++ b/code/drasil-database/lib/Database/Drasil/ChunkDB.hs
@@ -230,7 +230,7 @@ cdb s t c u d ins gd tm ci lc r cits =
   CDB {
     -- CHUNKS
     symbolTable = symbolMap s,
-    termTable = termMap $ t ++ termsHACK,
+    termTable = termMap t,
     conceptChunkTable = conceptMap c,
     _unitTable = unitMap u,
     _dataDefnTable = idMap "DataDefnMap" d,
@@ -245,8 +245,6 @@ cdb s t c u d ins gd tm ci lc r cits =
     _refbyTable = Map.empty,
     _refTable = idMap "RefMap" r
   }
-  where
-    termsHACK = map nw d
 
 -- | Gets the units of a 'Quantity' as 'UnitDefn's.
 collectUnits :: Quantity c => ChunkDB -> [c] -> [UnitDefn]


### PR DESCRIPTION
Contributes to #4126 

This hack was previously there because our data definitions have unique UIDs, unlike the majority of our chunks at the moment. So extracting `IdeaDict`s was necessary for the `termResolve` function to find an `IdeaDict`.

This change is possible because https://github.com/JacquesCarette/Drasil/commit/ac3ec2db97a96d39107849c89f7118715bcffecf makes the use of the "term map" really about "getting terms" rather than `IdeaDict`s.