### PR TITLE
Move `drasil-code`-related components of `drasil-lang` to a corner of `drasil-lang`

### DIFF
--- a/code/drasil-code/lib/Data/Drasil/ExternalLibraries/ODELibraries.hs
+++ b/code/drasil-code/lib/Data/Drasil/ExternalLibraries/ODELibraries.hs
@@ -38,8 +38,9 @@ import Language.Drasil.Code (Lang(..), ExternalLibrary, Step, Argument,
   ODEInfo(..), ODEOptions(..), ODEMethod(..), ODELibPckg, mkODELib,
   mkODELibNoPath, pubStateVar, privStateVar,
   NamedArgument, narg)
-import Language.Drasil.CodeExpr
-import Language.Drasil.CodeExpr.Development
+
+import Drasil.Code.CodeExpr
+import Drasil.Code.CodeExpr.Development
 
 import Control.Lens ((^.), _1, _2, over)
 

--- a/code/drasil-code/lib/Language/Drasil/Chunk/CodeBase.hs
+++ b/code/drasil-code/lib/Language/Drasil/Chunk/CodeBase.hs
@@ -1,9 +1,8 @@
 module Language.Drasil.Chunk.CodeBase where
 
 import Database.Drasil (ChunkDB, symbResolve)
-
+import Drasil.Code.CodeExpr.Development
 import Language.Drasil
-import Language.Drasil.CodeExpr.Development
 
 -- | Construct a 'CodeVarChunk' from a 'Quantity'.
 quantvar :: (Quantity c, MayHaveUnit c) => c -> CodeVarChunk

--- a/code/drasil-code/lib/Language/Drasil/Chunk/CodeDefinition.hs
+++ b/code/drasil-code/lib/Language/Drasil/Chunk/CodeDefinition.hs
@@ -3,9 +3,9 @@ module Language.Drasil.Chunk.CodeDefinition (
   CodeDefinition, DefinitionType(..), qtoc, qtov, odeDef, auxExprs, defType,
 ) where
 
+import Drasil.Code.CodeExpr.Development (expr, CanGenCode(..))
 import Language.Drasil
 import Language.Drasil.Chunk.Code (quantvar, quantfunc)
-import Language.Drasil.CodeExpr.Development (expr, CanGenCode(..))
 import Language.Drasil.Data.ODEInfo (ODEInfo(..), ODEOptions(..))
 
 import Control.Lens ((^.), makeLenses, view)

--- a/code/drasil-code/lib/Language/Drasil/Chunk/ConstraintMap.hs
+++ b/code/drasil-code/lib/Language/Drasil/Chunk/ConstraintMap.hs
@@ -4,9 +4,9 @@ module Language.Drasil.Chunk.ConstraintMap (ConstraintCEMap, ConstraintCE,
 
 import Control.Lens ((^.))
 
+import Drasil.Code.CodeExpr.Development (CodeExpr, constraint)
 import Language.Drasil (Constraint, HasUID(..), UID, Constrained(..),
   isPhysC, isSfwrC)
-import Language.Drasil.CodeExpr.Development (CodeExpr, constraint)
 import qualified Data.Map as Map
 
 -- | Type synonym for 'Constraint CodeExpr'

--- a/code/drasil-code/lib/Language/Drasil/Code.hs
+++ b/code/drasil-code/lib/Language/Drasil/Code.hs
@@ -93,24 +93,18 @@ import Language.Drasil.Choices (Choices(..), Comments(..), Verbosity(..),
   makeDocConfig, makeLogConfig, LogConfig(..), OptionalFeatures(..),
   makeOptFeats, ExtLib(..))
 
+import Drasil.Code.CodeExpr (field)
+
 import Language.Drasil.CodeSpec (CodeSpec(..), OldCodeSpec(..), HasOldCodeSpec(..), 
   codeSpec, funcUID, asVC)
-
 import Language.Drasil.Mod (($:=), Mod(Mod), StateVariable, Func, FuncStmt(..),
   pubStateVar, privStateVar, fDecDef, ffor, fforRange, funcData, funcDef, packmod)
-
 import Language.Drasil.Code.Imperative.GOOL.ClassInterface (PackageSym(..),
   AuxiliarySym(..))
-
 import Language.Drasil.Code.Imperative.GOOL.Data (AuxData(..), PackData(..))
-
 import Language.Drasil.Chunk.Code (CodeChunk, CodeVarChunk, CodeFuncChunk,
   quantvar, quantfunc, ccObjVar, listToArray)
-
 import Language.Drasil.Chunk.NamedArgument (NamedArgument, narg)
-
-import Language.Drasil.CodeExpr (field)
-
 import Language.Drasil.Data.ODEInfo (ODEInfo(..), odeInfo, odeInfo', ODEOptions(..),
   odeOptions, ODEMethod(..))
 import Language.Drasil.Data.ODELibPckg (ODELibPckg(..), mkODELib,

--- a/code/drasil-code/lib/Language/Drasil/Code/ExtLibImport.hs
+++ b/code/drasil-code/lib/Language/Drasil/Code/ExtLibImport.hs
@@ -4,14 +4,13 @@
 module Language.Drasil.Code.ExtLibImport (ExtLibState(..), auxMods, defs,
   imports, modExports, steps, genExternalLibraryCall) where
 
+import Drasil.Code.CodeExpr (CodeExpr, ($&&), applyWithNamedArgs,
+  msgWithNamedArgs, new, newWithNamedArgs, sy)
 import Language.Drasil (HasSpace(typ), getActorName)
-
 import Language.Drasil.Chunk.Code (CodeVarChunk, CodeFuncChunk, codeName,
   ccObjVar)
 import Language.Drasil.Chunk.Parameter (ParameterChunk)
 import Language.Drasil.Chunk.NamedArgument (NamedArgument)
-import Language.Drasil.CodeExpr (CodeExpr, ($&&), applyWithNamedArgs,
-  msgWithNamedArgs, new, newWithNamedArgs, sy)
 import Language.Drasil.Mod (Class, StateVariable, Func(..), Mod, Name,
   Description, packmodRequires, classDef, classImplements, FuncStmt(..),
   funcDefParams, ctorDef)

--- a/code/drasil-code/lib/Language/Drasil/Code/ExternalLibrary.hs
+++ b/code/drasil-code/lib/Language/Drasil/Code/ExternalLibrary.hs
@@ -14,12 +14,12 @@ module Language.Drasil.Code.ExternalLibrary (ExternalLibrary, Step(..),
   returnExprList, fixedReturn, fixedReturn', initSolWithVal
 ) where
 
+import Drasil.Code.CodeExpr.Development
+import Drasil.Code.CodeExpr
 import Language.Drasil (Space, HasSpace(typ))
 import Language.Drasil.Chunk.Code (CodeVarChunk, CodeFuncChunk, codeName)
 import Language.Drasil.Chunk.Parameter (ParameterChunk, pcAuto)
 import Language.Drasil.Chunk.NamedArgument (NamedArgument)
-import Language.Drasil.CodeExpr.Development
-import Language.Drasil.CodeExpr
 import Language.Drasil.Mod (FuncStmt(..), Description)
 
 import Control.Lens ((^.))

--- a/code/drasil-code/lib/Language/Drasil/Code/Imperative/Import.hs
+++ b/code/drasil-code/lib/Language/Drasil/Code/Imperative/Import.hs
@@ -8,15 +8,15 @@ module Language.Drasil.Code.Imperative.Import (codeType, spaceCodeType,
   genModClasses, readData, readDataProc, renderC
 ) where
 
-import Language.Drasil (HasSymbol, HasUID(..), HasSpace(..),
-  Space (Rational, Real), RealInterval(..), UID, Constraint(..), Inclusive (..))
-import Database.Drasil (symbResolve)
-import Language.Drasil.CodeExpr (sy, ($<), ($>), ($<=), ($>=), ($&&), in')
-import qualified Language.Drasil.CodeExpr.Development as S (CodeExpr(..))
-import Language.Drasil.CodeExpr.Development (CodeExpr(..), ArithBinOp(..),
+import Drasil.Code.CodeExpr (sy, ($<), ($>), ($<=), ($>=), ($&&), in')
+import qualified Drasil.Code.CodeExpr.Development as S (CodeExpr(..))
+import Drasil.Code.CodeExpr.Development (CodeExpr(..), ArithBinOp(..),
   AssocArithOper(..), AssocBoolOper(..), AssocConcatOper(..), BoolBinOp(..), EqBinOp(..),
   LABinOp(..), OrdBinOp(..), UFunc(..), UFuncB(..), UFuncVV(..), UFuncVN(..),
   VVNBinOp(..), VVVBinOp(..), NVVBinOp(..), ESSBinOp(..), ESBBinOp(..))
+import Language.Drasil (HasSymbol, HasUID(..), HasSpace(..),
+  Space (Rational, Real), RealInterval(..), UID, Constraint(..), Inclusive (..))
+import Database.Drasil (symbResolve)
 import Language.Drasil.Code.Imperative.Comments (getComment)
 import Language.Drasil.Code.Imperative.ConceptMatch (conceptToGOOL)
 import Language.Drasil.Code.Imperative.GenerateGOOL (auxClass, fApp, fAppProc,

--- a/code/drasil-code/lib/Language/Drasil/Code/Imperative/Modules.hs
+++ b/code/drasil-code/lib/Language/Drasil/Code/Imperative/Modules.hs
@@ -8,10 +8,12 @@ module Language.Drasil.Code.Imperative.Modules (
   genCalcModProc, genCalcFunc, genCalcFuncProc, genOutputMod, genOutputModProc,
   genOutputFormat, genOutputFormatProc, genSampleInput
 ) where
+
+import Database.Drasil (ChunkDB)
+import Drasil.Code.CodeExpr.Development
+
 import Language.Drasil (Constraint(..), RealInterval(..),
   HasUID(uid), Stage(..))
-import Database.Drasil (ChunkDB)
-import Language.Drasil.CodeExpr.Development
 import Language.Drasil.Code.Imperative.Comments (getComment)
 import Language.Drasil.Code.Imperative.Descriptions (constClassDesc,
   constModDesc, dvFuncDesc, inConsFuncDesc, inFmtFuncDesc, inputClassDesc,

--- a/code/drasil-code/lib/Language/Drasil/CodeSpec.hs
+++ b/code/drasil-code/lib/Language/Drasil/CodeSpec.hs
@@ -6,6 +6,7 @@ module Language.Drasil.CodeSpec where
 import Language.Drasil hiding (None, new)
 import Language.Drasil.Display (Symbol(Variable))
 import Database.Drasil
+import Drasil.Code.CodeExpr.Development (expr, eNamesRI, eDep)
 import qualified System.Drasil as SI
 import System.Drasil (HasSystem(..))
 
@@ -15,7 +16,6 @@ import Language.Drasil.Chunk.ConstraintMap (ConstraintCEMap, ConstraintCE, const
 import Language.Drasil.Chunk.CodeDefinition (CodeDefinition, qtov, qtoc, odeDef,
   auxExprs)
 import Language.Drasil.Choices (Choices(..), Maps(..), ODE(..), ExtLib(..))
-import Language.Drasil.CodeExpr.Development (expr, eNamesRI, eDep)
 import Language.Drasil.Chunk.CodeBase
 import Language.Drasil.Mod (Func(..), FuncData(..), FuncDef(..), Mod(..), Name)
 

--- a/code/drasil-code/lib/Language/Drasil/Data/ODEInfo.hs
+++ b/code/drasil-code/lib/Language/Drasil/Data/ODEInfo.hs
@@ -3,8 +3,8 @@ module Language.Drasil.Data.ODEInfo (
   ODEInfo(..), odeInfo, odeInfo', ODEOptions(..), odeOptions, ODEMethod(..)
 ) where
 
+import Drasil.Code.CodeExpr.Development
 import Language.Drasil.Chunk.Code (CodeVarChunk)
-import Language.Drasil.CodeExpr.Development
 import Language.Drasil(makeAODESolverFormat, formEquations,
   DifferentialModel(..), ODESolverFormat(..), InitialValueProblem(..))
 import Language.Drasil.Chunk.CodeBase (quantvar)

--- a/code/drasil-example/glassbr/lib/Drasil/GlassBR/ModuleDefs.hs
+++ b/code/drasil-example/glassbr/lib/Drasil/GlassBR/ModuleDefs.hs
@@ -4,14 +4,14 @@
 
 module Drasil.GlassBR.ModuleDefs (allMods, implVars, interpY, interpZ) where
 
+import Drasil.Code.CodeExpr (CodeExpr, LiteralC(int))
 import Language.Drasil (QuantityDict, Space(..), implVar, nounPhraseSP,
-  label, sub, HasSymbol(..), HasUID, Symbol)
+  label, sub, HasSymbol(..), HasUID, Symbol, ExprC(..))
 import Language.Drasil.Display (Symbol(..))
 import Language.Drasil.ShortHands
 import Language.Drasil.Code (($:=), Func, FuncStmt(..), Mod, 
   asVC, funcDef, fDecDef, ffor, funcData, quantvar, 
   multiLine, packmod, repeated, singleLine)
-import Language.Drasil.CodeExpr
 import qualified Drasil.GlassBR.Unitals as U
 import Language.Drasil.Printers
 

--- a/code/drasil-example/pdcontroller/lib/Drasil/PDController/ODEs.hs
+++ b/code/drasil-example/pdcontroller/lib/Drasil/PDController/ODEs.hs
@@ -1,12 +1,11 @@
 module Drasil.PDController.ODEs where
 
+import Language.Drasil (LiteralC(exactDbl), ExprC(sy), InitialValueProblem, makeAIVP)
 import Language.Drasil.Code (odeInfo', odeOptions, quantvar, ODEInfo,
     ODEMethod(RK45), ODEOptions)
-import Language.Drasil.CodeExpr (LiteralC(exactDbl), ExprC(sy))
 
 import Drasil.PDController.Unitals (qdSetPointTD, qdPropGain, qdDerivGain,
     qdSimTime, qdStepTime, odeRelTolConst, odeAbsTolConst)
-import Language.Drasil(InitialValueProblem, makeAIVP)
 import Drasil.PDController.IModel(imPDRC)
 
 

--- a/code/drasil-lang/lib/Drasil/Code/Classes.hs
+++ b/code/drasil-lang/lib/Drasil/Code/Classes.hs
@@ -1,0 +1,13 @@
+module Drasil.Code.Classes (
+  -- * Classes
+  IsArgumentName,
+  Callable
+) where
+
+import Language.Drasil.Symbol (HasSymbol)
+
+-- | Some chunks can be called like functions.
+class HasSymbol c => Callable c
+
+-- | Members must have a named argument.
+class HasSymbol c => IsArgumentName c where

--- a/code/drasil-lang/lib/Drasil/Code/CodeExpr.hs
+++ b/code/drasil-lang/lib/Drasil/Code/CodeExpr.hs
@@ -1,6 +1,6 @@
 {-# OPTIONS_GHC -fno-warn-redundant-constraints #-}
 -- | Re-export CodeExpr constructors.
-module Language.Drasil.CodeExpr (
+module Drasil.Code.CodeExpr (
   CodeExpr,
   CodeExprC(..), ExprC(..), LiteralC(..),
   expr
@@ -10,7 +10,7 @@ import Prelude hiding (exp, sin, cos, tan, sqrt, log)
 
 import Language.Drasil.Expr.Class (ExprC(..))
 import Language.Drasil.Literal.Class (LiteralC(..))
-import Language.Drasil.CodeExpr.Lang (CodeExpr)
-import Language.Drasil.CodeExpr.Convert (expr) -- TODO: Remove.
 
-import Language.Drasil.CodeExpr.Class (CodeExprC(..))
+import Drasil.Code.CodeExpr.Class (CodeExprC(..))
+import Drasil.Code.CodeExpr.Convert (expr) -- TODO: Remove.
+import Drasil.Code.CodeExpr.Lang (CodeExpr)

--- a/code/drasil-lang/lib/Drasil/Code/CodeExpr/Class.hs
+++ b/code/drasil-lang/lib/Drasil/Code/CodeExpr/Class.hs
@@ -1,13 +1,13 @@
-module Language.Drasil.CodeExpr.Class where
+module Drasil.Code.CodeExpr.Class where
 
 import Drasil.Code.Classes (IsArgumentName, Callable)
+import Drasil.Code.CodeExpr.Lang (CodeExpr(FCall, New, Message, Field))
 import Drasil.Code.CodeVar (CodeIdea, CodeVarChunk)
 import Drasil.Database.UID (HasUID(..))
 
 import Language.Drasil.Symbol (HasSymbol)
 import Language.Drasil.Space (Space(Actor), HasSpace(..))
 import Language.Drasil.Expr.Class (ExprC(..))
-import Language.Drasil.CodeExpr.Lang (CodeExpr(FCall, New, Message, Field))
 
 import Control.Lens ( (^.) )
 

--- a/code/drasil-lang/lib/Drasil/Code/CodeExpr/Convert.hs
+++ b/code/drasil-lang/lib/Drasil/Code/CodeExpr/Convert.hs
@@ -1,5 +1,5 @@
 {-# LANGUAGE GADTs #-}
-module Language.Drasil.CodeExpr.Convert (
+module Drasil.Code.CodeExpr.Convert (
     expr, realInterval, constraint,
     CanGenCode(..)
 ) where
@@ -10,7 +10,7 @@ import qualified Language.Drasil.Expr.Lang as E
 import qualified Language.Drasil.Expr.Development as LD
 import qualified Language.Drasil.Literal.Development as LL
 
-import Language.Drasil.CodeExpr.Lang
+import Drasil.Code.CodeExpr.Lang
 
 import Data.Bifunctor (Bifunctor(bimap))
 

--- a/code/drasil-lang/lib/Drasil/Code/CodeExpr/Development.hs
+++ b/code/drasil-lang/lib/Drasil/Code/CodeExpr/Development.hs
@@ -1,5 +1,5 @@
 -- | Re-exporting modules
-module Language.Drasil.CodeExpr.Development (
+module Drasil.Code.CodeExpr.Development (
     -- CodeExpr
     CodeExpr(..), 
     ArithBinOp(..), EqBinOp(..), BoolBinOp(..), LABinOp(..), OrdBinOp(..),
@@ -16,12 +16,12 @@ module Language.Drasil.CodeExpr.Development (
     expr, realInterval, constraint, CanGenCode(..)
 ) where
 
-import Language.Drasil.CodeExpr.Lang (CodeExpr(..),
+import Drasil.Code.CodeExpr.Lang (CodeExpr(..),
     UFuncVV(..), UFuncVN(..), UFuncB(..), UFunc(..),
     AssocBoolOper(..), AssocArithOper(..), AssocConcatOper(..),VVNBinOp(..), NVVBinOp(..), ESSBinOp(..), ESBBinOp(..),
     VVVBinOp(..), OrdBinOp(..), LABinOp(..), BoolBinOp(..), EqBinOp(..),
     ArithBinOp(..))
-import Language.Drasil.CodeExpr.Class (CodeExprC(..))
-import Language.Drasil.CodeExpr.Extract (eDep, eDep', eNamesRI, eNamesRI')
-import Language.Drasil.CodeExpr.Precedence (eprec, precA, precB)
-import Language.Drasil.CodeExpr.Convert (expr, realInterval, constraint, CanGenCode(..))
+import Drasil.Code.CodeExpr.Class (CodeExprC(..))
+import Drasil.Code.CodeExpr.Extract (eDep, eDep', eNamesRI, eNamesRI')
+import Drasil.Code.CodeExpr.Precedence (eprec, precA, precB)
+import Drasil.Code.CodeExpr.Convert (expr, realInterval, constraint, CanGenCode(..))

--- a/code/drasil-lang/lib/Drasil/Code/CodeExpr/Extract.hs
+++ b/code/drasil-lang/lib/Drasil/Code/CodeExpr/Extract.hs
@@ -1,4 +1,4 @@
-module Language.Drasil.CodeExpr.Extract (
+module Drasil.Code.CodeExpr.Extract (
     eDep, eDep',
     eNamesRI, eNamesRI'
 ) where
@@ -6,7 +6,7 @@ module Language.Drasil.CodeExpr.Extract (
 import Language.Drasil.Space (RealInterval(..))
 import Drasil.Database.UID (UID)
 
-import Language.Drasil.CodeExpr.Lang (CodeExpr(..))
+import Drasil.Code.CodeExpr.Lang (CodeExpr(..))
 
 import Data.Containers.ListUtils (nubOrd)
 

--- a/code/drasil-lang/lib/Drasil/Code/CodeExpr/Lang.hs
+++ b/code/drasil-lang/lib/Drasil/Code/CodeExpr/Lang.hs
@@ -1,14 +1,13 @@
 {-# LANGUAGE GADTs #-}
-
-module Language.Drasil.CodeExpr.Lang where
+module Drasil.Code.CodeExpr.Lang where
 
 import Prelude hiding (sqrt)
 
+import Drasil.Database.UID (UID)
 import Language.Drasil.Expr.Lang (Completeness)
 import Language.Drasil.Literal.Class (LiteralC(..))
 import Language.Drasil.Literal.Lang (Literal(..))
 import Language.Drasil.Space (Space, RealInterval, DiscreteDomainDesc)
-import Drasil.Database.UID (UID)
 
 -- * Operators (mostly binary)
 

--- a/code/drasil-lang/lib/Drasil/Code/CodeExpr/Precedence.hs
+++ b/code/drasil-lang/lib/Drasil/Code/CodeExpr/Precedence.hs
@@ -1,6 +1,6 @@
-module Language.Drasil.CodeExpr.Precedence (precA, precB, eprec) where
+module Drasil.Code.CodeExpr.Precedence (precA, precB, eprec) where
 
-import Language.Drasil.CodeExpr.Lang (CodeExpr(..), UFuncVV, UFuncVN, UFuncB(..),
+import Drasil.Code.CodeExpr.Lang (CodeExpr(..), UFuncVV, UFuncVN, UFuncB(..),
     UFunc(..), AssocBoolOper(..), AssocArithOper(..), VVNBinOp, NVVBinOp,
     VVVBinOp, OrdBinOp, LABinOp, BoolBinOp, EqBinOp, ArithBinOp(..), AssocConcatOper(..), ESSBinOp, ESBBinOp)
 

--- a/code/drasil-lang/lib/Drasil/Code/CodeVar.hs
+++ b/code/drasil-lang/lib/Drasil/Code/CodeVar.hs
@@ -6,6 +6,7 @@ import Data.Char (isSpace)
 import Control.Lens ((^.), view, makeLenses, Lens')
 
 import Drasil.Code.Classes (Callable)
+import Drasil.Code.CodeExpr.Lang (CodeExpr)
 import Drasil.Database.UID (HasUID(uid), (+++))
 
 import Language.Drasil.Classes (CommonIdea(abrv), Quantity, Idea(getA), NamedIdea(..))
@@ -14,8 +15,6 @@ import Language.Drasil.Space (HasSpace(..), Space(..))
 import Language.Drasil.Symbol (HasSymbol(symbol))
 import Language.Drasil.Chunk.UnitDefn (MayHaveUnit(getUnit))
 import Language.Drasil.Stages (Stage(..))
-
-import Language.Drasil.CodeExpr.Lang (CodeExpr)
 
 import Utils.Drasil (toPlainName)
 

--- a/code/drasil-lang/lib/Drasil/Code/CodeVar.hs
+++ b/code/drasil-lang/lib/Drasil/Code/CodeVar.hs
@@ -1,6 +1,6 @@
 {-# LANGUAGE TemplateHaskell #-}
 -- | Defines chunk types for use in code generation.
-module Language.Drasil.Chunk.CodeVar where
+module Drasil.Code.CodeVar where
 
 import Data.Char (isSpace)
 import Control.Lens ((^.), view, makeLenses, Lens')

--- a/code/drasil-lang/lib/Language/Drasil.hs
+++ b/code/drasil-lang/lib/Language/Drasil.hs
@@ -301,6 +301,9 @@ module Language.Drasil (
 import Prelude hiding (log, sin, cos, tan, sqrt, id, return, print, break, exp, product)
 
 import Drasil.Code.Classes (Callable, IsArgumentName)
+import Drasil.Code.CodeVar (CodeIdea(..), CodeChunk(..), 
+  CodeVarChunk(..), CodeFuncChunk(..), VarOrFunc(..), obv, qc, ccf, ccv, 
+  listToArray, programName, funcPrefix, DefiningCodeExpr(..))
 
 import Language.Drasil.WellTyped (RequiresChecking(..), Typed(..), TypingContext,
   TypeError, inferFromContext, temporaryIndent)
@@ -344,9 +347,6 @@ import Language.Drasil.Chunk.Citation (
   , cInBookACP, cInBookECP, cInBookAC, cInBookEC, cInBookAP, cInBookEP
   , cInCollection, cInProceedings, cManual, cMThesis, cMisc, cPhDThesis
   , cProceedings, cTechReport, cUnpublished)
-import Language.Drasil.Chunk.CodeVar (CodeIdea(..), CodeChunk(..), 
-  CodeVarChunk(..), CodeFuncChunk(..), VarOrFunc(..), obv, qc, ccf, ccv, 
-  listToArray, programName, funcPrefix, DefiningCodeExpr(..))
 import Language.Drasil.Chunk.CommonIdea
 import Language.Drasil.Chunk.Concept
 import Language.Drasil.Chunk.Concept.Core (sDom) -- exported for drasil-database FIXME: move to development package?

--- a/code/drasil-lang/lib/Language/Drasil.hs
+++ b/code/drasil-lang/lib/Language/Drasil.hs
@@ -304,6 +304,8 @@ import Drasil.Code.Classes (Callable, IsArgumentName)
 import Drasil.Code.CodeVar (CodeIdea(..), CodeChunk(..), 
   CodeVarChunk(..), CodeFuncChunk(..), VarOrFunc(..), obv, qc, ccf, ccv, 
   listToArray, programName, funcPrefix, DefiningCodeExpr(..))
+import Drasil.Code.CodeExpr.Lang (CodeExpr)
+import Drasil.Code.CodeExpr.Class (CodeExprC(..))
 
 import Language.Drasil.WellTyped (RequiresChecking(..), Typed(..), TypingContext,
   TypeError, inferFromContext, temporaryIndent)
@@ -316,8 +318,6 @@ import Language.Drasil.Literal.Class (LiteralC(..))
 import Language.Drasil.Literal.Lang (Literal)
 import Language.Drasil.ModelExpr.Class (ModelExprC(..))
 import Language.Drasil.ModelExpr.Lang (ModelExpr, DerivType, ModelExpr(Spc))
-import Language.Drasil.CodeExpr.Lang (CodeExpr)
-import Language.Drasil.CodeExpr.Class (CodeExprC(..))
 import Language.Drasil.Document (section, fig, figNoCap, figWithWidth, figNoCapWithWidth
   , Section(..), SecCons(..) , llcc, ulcc, Document(..)
   , mkParagraph, mkFig, mkRawLC, ShowTableOfContents(..), checkToC

--- a/code/drasil-lang/lib/Language/Drasil.hs
+++ b/code/drasil-lang/lib/Language/Drasil.hs
@@ -300,6 +300,8 @@ module Language.Drasil (
 
 import Prelude hiding (log, sin, cos, tan, sqrt, id, return, print, break, exp, product)
 
+import Drasil.Code.Classes (Callable, IsArgumentName)
+
 import Language.Drasil.WellTyped (RequiresChecking(..), Typed(..), TypingContext,
   TypeError, inferFromContext, temporaryIndent)
 
@@ -331,8 +333,7 @@ import Drasil.Database.UID
 import Language.Drasil.Symbol (HasSymbol(symbol), Decoration, Symbol)
 import Language.Drasil.Classes (Definition(defn), ConceptDomain(cdom), Concept, HasUnitSymbol(usymb),
   IsUnit(getUnits), CommonIdea(abrv), HasAdditionalNotes(getNotes), Constrained(constraints),
-  HasReasVal(reasVal), DefiningExpr(defnExpr), Quantity, Callable,
-  IsArgumentName, Express(..))
+  HasReasVal(reasVal), DefiningExpr(defnExpr), Quantity, Express(..))
 import Language.Drasil.Derivation (Derivation(Derivation), mkDeriv, mkDerivName, mkDerivNoHeader, MayHaveDerivation(..))
 import Language.Drasil.Data.Date (Month(..))
 import Language.Drasil.Chunk.Citation (

--- a/code/drasil-lang/lib/Language/Drasil/Chunk/CodeVar.hs
+++ b/code/drasil-lang/lib/Language/Drasil/Chunk/CodeVar.hs
@@ -5,11 +5,13 @@ module Language.Drasil.Chunk.CodeVar where
 import Data.Char (isSpace)
 import Control.Lens ((^.), view, makeLenses, Lens')
 
-import Language.Drasil.Classes (CommonIdea(abrv), Quantity, Idea(getA), NamedIdea(..), Callable)
+import Drasil.Code.Classes (Callable)
+import Drasil.Database.UID (HasUID(uid), (+++))
+
+import Language.Drasil.Classes (CommonIdea(abrv), Quantity, Idea(getA), NamedIdea(..))
 import Language.Drasil.Chunk.Quantity (QuantityDict, implVar')
 import Language.Drasil.Space (HasSpace(..), Space(..))
 import Language.Drasil.Symbol (HasSymbol(symbol))
-import Drasil.Database.UID (HasUID(uid), (+++))
 import Language.Drasil.Chunk.UnitDefn (MayHaveUnit(getUnit))
 import Language.Drasil.Stages (Stage(..))
 

--- a/code/drasil-lang/lib/Language/Drasil/Classes.hs
+++ b/code/drasil-lang/lib/Language/Drasil/Classes.hs
@@ -14,8 +14,6 @@ module Language.Drasil.Classes (
   , HasUnitSymbol(usymb)
   , HasReasVal(reasVal)
   , Constrained(constraints)
-  , Callable
-  , IsArgumentName
   , HasAdditionalNotes(getNotes)
     -- the unsorted rest
   , IsUnit(udefn, getUnits)
@@ -102,11 +100,6 @@ class (Idea c, HasSpace c, HasSymbol c) => Quantity c where
 --   uncert :: Lens' c (Uncertainty)
 --   replaced with HasUncertainty
 
--- TODO: This looks like it should be moved into drasil-code/?-base, it doesn't seem to be used enough atm.
---       ...but, Dr. Carette also mentioned these are dubious, maybe we should remove it?
--- | Some chunks can be called like functions.
-class (HasSymbol c) => Callable c
-
 -----------------------------------------------------
 -- Below are for units only
 -- | Some chunks store a unit symbol.
@@ -135,7 +128,3 @@ class DefiningExpr c where
   --   TODO: Well, technically, `e` doesn't need to be an "expression" of any sorts.
   --         It just needs to be _something_, and it would have approximately have same meaning.
   defnExpr :: Lens' (c e) e
-
--- TODO: This should be moved to `drasil-code-base`.
--- | Members must have a named argument.
-class (HasSymbol c) => IsArgumentName c where

--- a/code/drasil-lang/lib/Language/Drasil/CodeExpr/Class.hs
+++ b/code/drasil-lang/lib/Language/Drasil/CodeExpr/Class.hs
@@ -1,11 +1,11 @@
 module Language.Drasil.CodeExpr.Class where
 
 import Drasil.Code.Classes (IsArgumentName, Callable)
+import Drasil.Code.CodeVar (CodeIdea, CodeVarChunk)
 import Drasil.Database.UID (HasUID(..))
 
 import Language.Drasil.Symbol (HasSymbol)
 import Language.Drasil.Space (Space(Actor), HasSpace(..))
-import Language.Drasil.Chunk.CodeVar (CodeIdea, CodeVarChunk)
 import Language.Drasil.Expr.Class (ExprC(..))
 import Language.Drasil.CodeExpr.Lang (CodeExpr(FCall, New, Message, Field))
 

--- a/code/drasil-lang/lib/Language/Drasil/CodeExpr/Class.hs
+++ b/code/drasil-lang/lib/Language/Drasil/CodeExpr/Class.hs
@@ -1,7 +1,8 @@
 module Language.Drasil.CodeExpr.Class where
 
-import Language.Drasil.Classes(IsArgumentName, Callable)
+import Drasil.Code.Classes (IsArgumentName, Callable)
 import Drasil.Database.UID (HasUID(..))
+
 import Language.Drasil.Symbol (HasSymbol)
 import Language.Drasil.Space (Space(Actor), HasSpace(..))
 import Language.Drasil.Chunk.CodeVar (CodeIdea, CodeVarChunk)

--- a/code/drasil-lang/lib/Language/Drasil/Document/Contents.hs
+++ b/code/drasil-lang/lib/Language/Drasil/Document/Contents.hs
@@ -10,6 +10,7 @@ module Language.Drasil.Document.Contents (
   unlbldCode
 ) where
 
+import Drasil.Code.CodeExpr.Lang (CodeExpr)
 import Language.Drasil.Classes (Definition(..))
 import Language.Drasil.ShortName (HasShortName(..), getSentSN)
 import Language.Drasil.Document (llcc, ulcc)
@@ -21,7 +22,6 @@ import Language.Drasil.Document.Core
      ItemType(Flat),
      ListType(Simple))
 import Language.Drasil.ModelExpr.Lang (ModelExpr)
-import Language.Drasil.CodeExpr.Lang (CodeExpr)
 import Language.Drasil.Reference (Reference)
 import Language.Drasil.Sentence (Sentence (..))
 import Language.Drasil.Document.Combinators (bulletFlat, mkEnumAbbrevList)

--- a/code/drasil-lang/lib/Language/Drasil/Document/Core.hs
+++ b/code/drasil-lang/lib/Language/Drasil/Document/Core.hs
@@ -5,9 +5,9 @@ module Language.Drasil.Document.Core where
 import Language.Drasil.Chunk.Citation (BibRef)
 
 import Drasil.Database.UID (HasUID(..))
+import Drasil.Code.CodeExpr.Lang (CodeExpr)
 import Language.Drasil.ShortName (HasShortName(shortname))
 import Language.Drasil.ModelExpr.Lang (ModelExpr)
-import Language.Drasil.CodeExpr.Lang (CodeExpr)
 import Language.Drasil.Label.Type (getAdd, prepend, IRefProg,
   LblType(..), Referable(..), HasRefAddress(..))
 import Language.Drasil.Reference (Reference)

--- a/code/drasil-lang/lib/Language/Drasil/Expr/Class.hs
+++ b/code/drasil-lang/lib/Language/Drasil/Expr/Class.hs
@@ -12,14 +12,14 @@ import Prelude hiding (sqrt, log, sin, cos, tan, exp)
 
 import Control.Lens ((^.))
 
+import Drasil.Database.UID (HasUID(..))
+import qualified Drasil.Code.CodeExpr.Lang as C
 import Language.Drasil.Symbol
 import Language.Drasil.Expr.Lang
 import Language.Drasil.Literal.Lang
 import Language.Drasil.Space (DomainDesc(..), RTopology(..), RealInterval, Space)
 import qualified Language.Drasil.ModelExpr.Lang as M
-import qualified Language.Drasil.CodeExpr.Lang as C
 import Language.Drasil.Literal.Class (LiteralC(..))
-import Drasil.Database.UID (HasUID(..))
 
 import Utils.Drasil (toColumn)
 

--- a/code/drasil-lang/package.yaml
+++ b/code/drasil-lang/package.yaml
@@ -31,6 +31,8 @@ ghc-options:
 library:
   source-dirs: lib
   exposed-modules:
+  - Drasil.Code.CodeExpr
+  - Drasil.Code.CodeExpr.Development
   - Language.Drasil
   - Language.Drasil.Chunk.Concept.NamedCombinators
   - Language.Drasil.Development
@@ -38,8 +40,6 @@ library:
   - Language.Drasil.Expr.Development
   - Language.Drasil.Literal.Development
   - Language.Drasil.ModelExpr.Development
-  - Language.Drasil.CodeExpr.Development
-  - Language.Drasil.CodeExpr
   - Language.Drasil.NounPhrase.Combinators
   - Language.Drasil.Sentence.Combinators
   - Language.Drasil.ShortHands

--- a/code/drasil-printers/lib/Language/Drasil/Plain/Print.hs
+++ b/code/drasil-printers/lib/Language/Drasil/Plain/Print.hs
@@ -8,9 +8,9 @@ module Language.Drasil.Plain.Print (
 ) where
 
 import Database.Drasil (ChunkDB)
+import qualified Drasil.Code.CodeExpr.Development as C (CodeExpr)
 import Language.Drasil (Sentence, Special(..), Stage(..), Symbol, USymb(..))
 import qualified Language.Drasil as L (Expr, HasSymbol(..))
-import qualified Language.Drasil.CodeExpr.Development as C (CodeExpr)
 import Language.Drasil.Printing.AST (Expr(..), Spec(..), Ops(..), Fence(..), 
   OverSymb(..), Fonts(..), Spacing(..), LinkType(..))
 import Language.Drasil.Printing.Import (expr, codeExpr, spec, symbol)

--- a/code/drasil-printers/lib/Language/Drasil/Printing/Import/CodeExpr.hs
+++ b/code/drasil-printers/lib/Language/Drasil/Printing/Import/CodeExpr.hs
@@ -3,10 +3,11 @@
 -- | Defines functions to render 'CodeExpr's as printable 'P.Expr's.
 module Language.Drasil.Printing.Import.CodeExpr (codeExpr) where
 
+import Drasil.Code.CodeExpr.Development
+
 import Language.Drasil (DomainDesc(..), Inclusive(..),
   RTopology(..), RealInterval(..), UID, LiteralC (int))
 import qualified Language.Drasil.Display as S (Symbol(..))
-import Language.Drasil.CodeExpr.Development
 import Language.Drasil.Literal.Development
 
 import qualified Language.Drasil.Printing.AST as P


### PR DESCRIPTION
Contributes to #2885 

Q: @JacquesCarette  Do you want PRs like this to be split up by commit? If so, is it okay for one to depend on the previous?