### PR TITLE
Projectile: chunks with acronyms do not need to be added again

### DIFF
--- a/code/drasil-example/projectile/lib/Drasil/Projectile/Body.hs
+++ b/code/drasil-example/projectile/lib/Drasil/Projectile/Body.hs
@@ -170,7 +170,6 @@ ideaDicts =
   sciCompS : doccon ++ educon ++ compcon ++ concepts ++ unitalIdeas ++
   -- CIs
   nw progName : nw inValue : map nw doccon' ++ map nw physicCon' ++
-  map nw acronyms ++
   -- ConceptChunks
   map nw [mass, errMsg, program, algorithm] ++ map nw physicCon ++ map nw mathcon ++
   -- QuantityDicts


### PR DESCRIPTION
Contributes to #4036 

Similar change to #4107, just for projectile.