### PR TITLE
Removed extra period

### DIFF
--- a/code/stable/gamephysics/SRS/HTML/GamePhysics_SRS.html
+++ b/code/stable/gamephysics/SRS/HTML/GamePhysics_SRS.html
@@ -757,7 +757,7 @@
                     Cartesian coordinate system: A coordinate system that specifies each point uniquely in a plane by a set of numerical coordinates, which are the signed distances to the point from two fixed perpendicular oriented lines, measured in the same unit of length (from <a href=#cartesianWiki>cartesianWiki</a>).
                   </li>
                   <li>
-                    Right-handed coordinate system: A coordinate system where the positive z-axis comes out of the screen..
+                    Right-handed coordinate system: A coordinate system where the positive z-axis comes out of the screen.
                   </li>
                   <li>
                     line: An interval between two points (from <a href=#lineSource>lineSource</a>).

--- a/code/stable/gamephysics/SRS/PDF/GamePhysics_SRS.tex
+++ b/code/stable/gamephysics/SRS/PDF/GamePhysics_SRS.tex
@@ -326,7 +326,7 @@ This subsection provides a list of terms that are used in the subsequent section
 \item{Elasticity: The ratio of the relative velocities of two colliding objects after and before a collision.}
 \item{Centre of mass: The mean location of the distribution of mass of the object.}
 \item{Cartesian coordinate system: A coordinate system that specifies each point uniquely in a plane by a set of numerical coordinates, which are the signed distances to the point from two fixed perpendicular oriented lines, measured in the same unit of length (from \cite{cartesianWiki}).}
-\item{Right-handed coordinate system: A coordinate system where the positive z-axis comes out of the screen..}
+\item{Right-handed coordinate system: A coordinate system where the positive z-axis comes out of the screen.}
 \item{line: An interval between two points (from \cite{lineSource}).}
 \item{point: An exact location, it has no size, only position (from \cite{pointSource}).}
 \item{damping: An influence within or upon an oscillatory system that has the effect of reducing, restricting or preventing its oscillations (from \cite{dampingSource}).}

--- a/code/stable/gamephysics/SRS/mdBook/src/SecTermDefs.md
+++ b/code/stable/gamephysics/SRS/mdBook/src/SecTermDefs.md
@@ -6,7 +6,7 @@ This subsection provides a list of terms that are used in the subsequent section
 - Elasticity: The ratio of the relative velocities of two colliding objects after and before a collision.
 - Centre of mass: The mean location of the distribution of mass of the object.
 - Cartesian coordinate system: A coordinate system that specifies each point uniquely in a plane by a set of numerical coordinates, which are the signed distances to the point from two fixed perpendicular oriented lines, measured in the same unit of length (from [cartesianWiki](./SecReferences.md#cartesianWiki)).
-- Right-handed coordinate system: A coordinate system where the positive z-axis comes out of the screen..
+- Right-handed coordinate system: A coordinate system where the positive z-axis comes out of the screen.
 - line: An interval between two points (from [lineSource](./SecReferences.md#lineSource)).
 - point: An exact location, it has no size, only position (from [pointSource](./SecReferences.md#pointSource)).
 - damping: An influence within or upon an oscillatory system that has the effect of reducing, restricting or preventing its oscillations (from [dampingSource](./SecReferences.md#dampingSource)).


### PR DESCRIPTION
#4152: Removed at the end of the definition for a Right-handed coordinate system.