### PR TITLE
PDController: Remove duplicate `UnitDefn`-related Terms

### DIFF
--- a/code/drasil-example/pdcontroller/lib/Drasil/PDController/Body.hs
+++ b/code/drasil-example/pdcontroller/lib/Drasil/PDController/Body.hs
@@ -19,7 +19,7 @@ import Data.Drasil.Quantities.Physics (physicscon)
 import Data.Drasil.Concepts.PhysicalProperties (physicalcon)
 import Data.Drasil.Concepts.Physics (angular, linear) -- FIXME: should not be needed?
 import Data.Drasil.Quantities.PhysicalProperties (mass)
-import Data.Drasil.SI_Units (second, kilogram)
+import Data.Drasil.SI_Units (siUnits)
 import Data.Drasil.Quantities.Math (posInf, negInf)
 
 import Drasil.PDController.Assumptions (assumptions)
@@ -147,15 +147,13 @@ ideaDicts =
   -- QuantityDicts
   map nw symbols ++map nw symbols ++
   -- UnitalChunks
-  map nw physicscon ++
-  -- UnitDefns
-  map nw [second, kilogram]
+  map nw physicscon
 
 symbMap :: ChunkDB
 symbMap = cdb (map qw physicscon ++ symbolsAll ++ [qw mass, qw posInf, qw negInf])
   ideaDicts
   (map cw inpConstrained ++ srsDomains)
-  (map unitWrapper [second, kilogram])
+  siUnits
   dataDefinitions
   instanceModels
   genDefns


### PR DESCRIPTION
Contributes to #4126 