### PR TITLE
Remove duplicate, unused chunk list in dblpend.

### DIFF
--- a/code/drasil-example/dblpend/lib/Drasil/DblPend/Unitals.hs
+++ b/code/drasil-example/dblpend/lib/Drasil/DblPend/Unitals.hs
@@ -38,9 +38,6 @@ outputs = [qw pendDisAngle]
 constants :: [ConstQDef]
 constants = [gravitationalAccelConst]
 
-units :: [UnitalChunk]
-units = map ucw unitalChunks
-
 unitalChunks :: [UnitalChunk]
 unitalChunks = [ 
   lenRod_1, lenRod_2, massObj_1, massObj_2, angularVel_1, angularVel_2,


### PR DESCRIPTION
Right underneath `units` in the diff is `unitalChunks`s which is the exact same thing.