### PR TITLE
HGHC: Remove undeniably duplicate `QuantityDict`-related  `IdeaDict`s

### DIFF
--- a/code/drasil-example/hghc/lib/Drasil/HGHC/Body.hs
+++ b/code/drasil-example/hghc/lib/Drasil/HGHC/Body.hs
@@ -68,10 +68,7 @@ ideaDicts =
   -- CIs
   nw progName : map nw doccon' ++
   -- ConceptChunks
-  map nw mathcon ++
-  -- QuantityDicts
-  map nw symbols
-
+  map nw mathcon
 
 symbMap :: ChunkDB
 symbMap = cdb symbols ideaDicts


### PR DESCRIPTION
Contributes to #4126

For HGHC, this removes all the problematic cross-table `UID` conflicts!