### PR TITLE
PDController: Remove undeniably duplicate `QuantityDict`-related `IdeaDict`s

### DIFF
--- a/code/drasil-example/pdcontroller/lib/Drasil/PDController/Body.hs
+++ b/code/drasil-example/pdcontroller/lib/Drasil/PDController/Body.hs
@@ -143,11 +143,7 @@ ideaDicts =
   -- CIs
   nw progName : map nw acronyms ++ map nw mathcon' ++ map nw doccon' ++
   -- ConceptChunks
-  map nw physicalcon ++ map nw mathcon ++ map nw [linear, program, angular] ++
-  -- QuantityDicts
-  map nw symbols ++map nw symbols ++
-  -- UnitalChunks
-  map nw physicscon
+  map nw physicalcon ++ map nw mathcon ++ map nw [linear, program, angular]
 
 symbMap :: ChunkDB
 symbMap = cdb (map qw physicscon ++ symbolsAll ++ [qw mass, qw posInf, qw negInf])


### PR DESCRIPTION
Contributes to #4126

This removes most, but not all, `UID` conflicts between the `QuantityDict`s table and the `IdeaDict`s table.