### PR TITLE
Debugger: Disable printing ConceptChunk definitions.

### DIFF
--- a/code/drasil-printers/lib/Language/Drasil/Debug/Print.hs
+++ b/code/drasil-printers/lib/Language/Drasil/Debug/Print.hs
@@ -143,7 +143,9 @@ mkTableConcepts pinfo = mkTableFromLenses
   pinfo
   conceptChunkTable
   "Concepts"
-  [openTerm, openDefinition]
+  [openTerm] -- FIXME: `openDefinition` ommited because some ConceptChunks
+             -- contain references to non-existent `Reference`s (which are only
+             -- created at SRS generation time).
 
 -- | Makes a table with all units used in the SRS.
 mkTableUnitDefn :: PrintingInformation -> Doc


### PR DESCRIPTION
Contributes to #4126

Unfortunately, some `ConceptChunk` definitions refer to the `Reference`s of other chunks, but those `Reference`s don't exist until the SRS code generator runs. Before then (e.g., when we want to dump the initial chunk database), the `ConceptChunk` table will contain invalid references.