### PR TITLE
SWHS: Move weakly used `ConceptChunk`s (only used for their `IdeaDict`s) to `ConceptChunk`s table.

### DIFF
--- a/code/drasil-example/swhs/lib/Drasil/SWHS/Body.hs
+++ b/code/drasil-example/swhs/lib/Drasil/SWHS/Body.hs
@@ -105,22 +105,28 @@ ideaDicts =
   materialProprty : prodtcon ++ doccon ++ educon ++ compcon ++
   -- CIs
   map nw [progName', progName] ++ map nw acronymsFull ++ map nw doccon' ++
-  map nw mathcon' ++ 
+  map nw mathcon'
+
+conceptChunks :: [ConceptChunk]
+conceptChunks =
   -- ConceptChunks
-  nw algorithm : map nw thermocon ++ map nw softwarecon ++ map nw physicCon ++
-  map nw mathcon ++ map nw physicalcon ++ map nw con
+  algorithm : thermocon ++ softwarecon ++ physicCon ++ mathcon ++
+  physicalcon ++ con ++ srsDomains ++
+  -- InstanceModels
+  cw heatEInPCM :
+  -- DefinedQuantityDicts
+  map cw symbols ++
+  -- ConstQDefs
+  map cw specParamValList
 
 symbMap :: ChunkDB
-symbMap = cdb (qw (heatEInPCM ^. output) : symbolsAll) -- heatEInPCM ?
-  ideaDicts
-  (cw heatEInPCM : map cw symbols ++ srsDomains ++ map cw specParamValList) -- FIXME: heatEInPCM?
+symbMap = cdb (qw (heatEInPCM ^. output) : symbolsAll) ideaDicts conceptChunks
   siUnits SWHS.dataDefs insModel genDefs tMods concIns [] allRefs citations
 
 tableOfAbbrvsIdeaDicts :: [IdeaDict]
 tableOfAbbrvsIdeaDicts =
   -- CIs
   nw progName : map nw acronymsFull ++
-  -- DefinedQuantityDicts
   -- DefinedQuantityDicts
   map nw symbols
 


### PR DESCRIPTION
Contributes to #4126