### PR TITLE
Template: Move weakly used `ConceptChunk`s (only used for their `IdeaDict`s) to `ConceptChunk`s table.

### DIFF
--- a/code/drasil-example/template/lib/Drasil/Template/Body.hs
+++ b/code/drasil-example/template/lib/Drasil/Template/Body.hs
@@ -110,12 +110,13 @@ ideaDicts =
   -- Actual IdeaDicts
   doccon ++ prodtcon ++ [inValue] ++
   -- CIs
-  nw progName : map nw doccon' ++
-  -- ConceptChunks
-  map nw [errMsg, algorithm, program] ++ map nw mathcon
+  nw progName : map nw doccon'
+
+conceptChunks :: [ConceptChunk]
+conceptChunks = [errMsg, algorithm, program] ++ mathcon ++ srsDomains
 
 symbMap :: ChunkDB
-symbMap = cdb ([] :: [QuantityDict]) ideaDicts srsDomains
+symbMap = cdb ([] :: [QuantityDict]) ideaDicts conceptChunks
   ([] :: [UnitDefn]) ([] :: [DataDefinition]) ([] :: [InstanceModel])
   ([] :: [GenDefn]) ([] :: [TheoryModel]) ([] :: [ConceptInstance])
   ([] :: [LabelledContent]) ([] :: [Reference]) citations


### PR DESCRIPTION
Contributes to #4126