### PR TITLE
HGHC: Move weakly used `ConceptChunk`s (only used for their `IdeaDict`s) to `ConceptChunk`s table.

### DIFF
--- a/code/drasil-example/hghc/lib/Drasil/HGHC/Body.hs
+++ b/code/drasil-example/hghc/lib/Drasil/HGHC/Body.hs
@@ -66,13 +66,10 @@ ideaDicts =
   -- Actual IdeaDicts
   [fp, nuclearPhys] ++ doccon ++
   -- CIs
-  nw progName : map nw doccon' ++
-  -- ConceptChunks
-  map nw mathcon
+  nw progName : map nw doccon'
 
 symbMap :: ChunkDB
-symbMap = cdb symbols ideaDicts
-  ([] :: [ConceptChunk])-- FIXME: Fill in concepts
+symbMap = cdb symbols ideaDicts mathcon
   siUnits dataDefs [] [] [] [] [] [] []
 
 tableOfAbbrvsIdeaDicts :: [IdeaDict]


### PR DESCRIPTION
Contributes to #4126 