### PR TITLE
PDController: Chunks with acronyms don't need to be added again

### DIFF
--- a/code/drasil-example/pdcontroller/lib/Drasil/PDController/Body.hs
+++ b/code/drasil-example/pdcontroller/lib/Drasil/PDController/Body.hs
@@ -141,7 +141,7 @@ ideaDicts =
   -- Actual IdeaDicts
   sciCompS : concepts ++ doccon ++
   -- CIs
-  nw progName : map nw acronyms ++ map nw mathcon' ++ map nw doccon'
+  nw progName : map nw mathcon' ++ map nw doccon'
 
 conceptChunks :: [ConceptChunk]
 conceptChunks =


### PR DESCRIPTION
Contributes to #4036 