### PR TITLE
`frequency` is added twice in `physicscon`, remove duplicate

### DIFF
--- a/code/drasil-data/lib/Data/Drasil/Quantities/Physics.hs
+++ b/code/drasil-data/lib/Data/Drasil/Quantities/Physics.hs
@@ -30,7 +30,7 @@ physicscon = [acceleration, angularAccel, angularDisplacement, angularVelocity,
   position, potEnergy, pressure, scalarAccel, scalarPos, speed, time, torque, velocity,
   weight, xAccel, xConstAccel, xDist, xPos, xVel, yAccel, yConstAccel, yDist,
   yPos, yVel,momentum, moment, moment2D, fOfGravity, positionVec, tension,
-  angularFrequency, period, frequency, chgMomentum]
+  angularFrequency, period, chgMomentum]
 
 -- * Physical Quantities (With Units)
 


### PR DESCRIPTION
Contributes to #4036 