### PR TITLE
Remove `moment` duplicate

### DIFF
--- a/code/drasil-data/lib/Data/Drasil/Quantities/Physics.hs
+++ b/code/drasil-data/lib/Data/Drasil/Quantities/Physics.hs
@@ -29,7 +29,7 @@ physicscon = [acceleration, angularAccel, angularDisplacement, angularVelocity,
   iyVel, kEnergy, linearAccel, linearDisplacement, linearVelocity, momentOfInertia, 
   position, potEnergy, pressure, scalarAccel, scalarPos, speed, time, torque, velocity,
   weight, xAccel, xConstAccel, xDist, xPos, xVel, yAccel, yConstAccel, yDist,
-  yPos, yVel,momentum, moment, moment2D, fOfGravity, positionVec, tension,
+  yPos, yVel,momentum, moment, fOfGravity, positionVec, tension,
   angularFrequency, period, frequency, chgMomentum]
 
 -- * Physical Quantities (With Units)


### PR DESCRIPTION
Contributes to #4036 

This fixes a duplicate error but as mentioned in #4229 it doesn't feel like the correct way to fix this. However, we need to do some more design in order to fix it properly.