### PR TITLE
Make unmodular code generation a bit more unmodular

### DIFF
--- a/code/drasil-code/lib/Language/Drasil/Choices.hs
+++ b/code/drasil-code/lib/Language/Drasil/Choices.hs
@@ -78,6 +78,7 @@ instance RenderChoices Modularity where
 -- | Program implementation options.
 data ImplementationType = Library -- ^ Generated code does not include Controller.
                         | Program -- ^ Generated code includes Controller.
+  deriving Eq
 
 -- | Renders options for program implementation.
 instance RenderChoices ImplementationType where

--- a/code/drasil-code/lib/Language/Drasil/Choices.hs
+++ b/code/drasil-code/lib/Language/Drasil/Choices.hs
@@ -78,7 +78,6 @@ instance RenderChoices Modularity where
 -- | Program implementation options.
 data ImplementationType = Library -- ^ Generated code does not include Controller.
                         | Program -- ^ Generated code includes Controller.
-  deriving Eq
 
 -- | Renders options for program implementation.
 instance RenderChoices ImplementationType where

--- a/code/drasil-code/lib/Language/Drasil/Choices.hs
+++ b/code/drasil-code/lib/Language/Drasil/Choices.hs
@@ -209,6 +209,7 @@ makeDocConfig = DocConfig
 data Comments = CommentFunc -- ^ Function/method-level comments.
               | CommentClass -- ^ Class-level comments.
               | CommentMod -- ^ File/Module-level comments.
+              | CommentVarDecls -- ^ Variable declarations comments.
               deriving Eq
 
 -- | Renders options for implementation of comments.
@@ -216,6 +217,7 @@ instance RenderChoices Comments where
   showChs CommentFunc = S "CommentFunc"
   showChs CommentClass = S "CommentClass"
   showChs CommentMod = S "CommentMod"
+  showChs CommentVarDecls = S "CommentVarDecls"
 
 -- | Doxygen file verbosity options.
 data Verbosity = Verbose | Quiet

--- a/code/drasil-code/lib/Language/Drasil/Code/Imperative/Modules.hs
+++ b/code/drasil-code/lib/Language/Drasil/Code/Imperative/Modules.hs
@@ -62,7 +62,7 @@ import Drasil.GOOL (MSBody, MSBlock, SVariable, SValue, MSStatement,
   DeclStatement(..), OODeclStatement(..), objDecNewNoParams,
   extObjDecNewNoParams, IOStatement(..), ControlStatement(..), ifNoElse,
   VisibilitySym(..), MethodSym(..), StateVarSym(..), pubDVar, convType,
-    convTypeOO, VisibilityTag(..))
+    convTypeOO, VisibilityTag(..), CommentStatement(..))
 
 import qualified Drasil.GOOL as OO (SFile)
 import Drasil.GProc (ProcProg)
@@ -114,7 +114,7 @@ modularMainFunc = do
   varDef <- mapM genCalcCall (codeSpec g ^. execOrderO)
   wo <- genOutputCall
   let mainW = if CommentFunc `elem` commented g then docMain else mainFunction
-  return $ Just $ mainW $ bodyStatements $ 
+  return $ Just $ mainW $ bodyStatements $
     initLogFileVar (logKind g) mainFn ++ varDecDef v_filename mainFn (arg 0)
     : logInFile
     -- Constants must be declared before inputs because some derived input
@@ -134,7 +134,7 @@ unmodularMainFunc = do
   varDef <- mapM declVarCalc (codeSpec g ^. execOrderO)
   wo <- genOutputCall
   let mainW = if CommentFunc `elem` commented g then docMain else mainFunction
-  return $ Just $ mainW $ bodyStatements $ 
+  return $ Just $ mainW $ bodyStatements $
     initLogFileVar (logKind g) mainFn ++ varDecDef v_filename mainFn (arg 0)
     : logInFile
     -- Constants must be declared before inputs because some derived input
@@ -150,7 +150,10 @@ declVarCalc c = do
   val' <- convExpr val
   v <- mkVar (quantvar c)
   l <- maybeLog v
-  return $ pure ((multi . (: l) . varDecDef v scp) val')
+  cmnt <- getComment c
+  let cmnt' = [comment cmnt | CommentVarDecls `elem` commented g]
+      statements = cmnt' ++ varDecDef v scp val' : l  
+  return $ pure $ multi statements
 
 -- | If there are no inputs, the 'inParams' object still needs to be declared
 -- if inputs are 'Bundled', constants are stored 'WithInputs', and constant

--- a/code/drasil-example/projectile/lib/Drasil/Projectile/Choices.hs
+++ b/code/drasil-example/projectile/lib/Drasil/Projectile/Choices.hs
@@ -117,7 +117,7 @@ baseChoices = defaultChoices {
   dataInfo = makeData Unbundled WithInputs Var,
   maps = makeMaps (matchConcepts [(piConst, [Pi])]) spaceToCodeType,
   optFeats = makeOptFeats
-    (makeDocConfig [CommentFunc, CommentClass, CommentMod] Quiet Hide)
+    (makeDocConfig [CommentFunc, CommentClass, CommentMod, CommentVarDecls] Quiet Hide)
     (makeLogConfig [] "log.txt")
     [SampleInput "../../../datafiles/projectile/sampleInput.txt", ReadME],
   srsConstraints = makeConstraints Warning Warning,

--- a/code/stable/projectile/projectile_m_l_nol_u_u_v_f/src/cpp/designLog.txt
+++ b/code/stable/projectile/projectile_m_l_nol_u_u_v_f/src/cpp/designLog.txt
@@ -6,7 +6,7 @@ Constant Representation selected as Var.
 Implementation Type selected as Library.
 Software Constraint Behaviour selected as Warning.
 Physical Constraint Behaviour selected as Warning.
-Comments selected as CommentFunc CommentClass CommentMod.
+Comments selected as CommentFunc CommentClass CommentMod CommentVarDecls.
 Dox Verbosity selected as Quiet.
 Dates selected as Hide.
 Log File Name selected as log.txt.

--- a/code/stable/projectile/projectile_m_l_nol_u_u_v_f/src/csharp/designLog.txt
+++ b/code/stable/projectile/projectile_m_l_nol_u_u_v_f/src/csharp/designLog.txt
@@ -6,7 +6,7 @@ Constant Representation selected as Var.
 Implementation Type selected as Library.
 Software Constraint Behaviour selected as Warning.
 Physical Constraint Behaviour selected as Warning.
-Comments selected as CommentFunc CommentClass CommentMod.
+Comments selected as CommentFunc CommentClass CommentMod CommentVarDecls.
 Dox Verbosity selected as Quiet.
 Dates selected as Hide.
 Log File Name selected as log.txt.

--- a/code/stable/projectile/projectile_m_l_nol_u_u_v_f/src/java/designLog.txt
+++ b/code/stable/projectile/projectile_m_l_nol_u_u_v_f/src/java/designLog.txt
@@ -6,7 +6,7 @@ Constant Representation selected as Var.
 Implementation Type selected as Library.
 Software Constraint Behaviour selected as Warning.
 Physical Constraint Behaviour selected as Warning.
-Comments selected as CommentFunc CommentClass CommentMod.
+Comments selected as CommentFunc CommentClass CommentMod CommentVarDecls.
 Dox Verbosity selected as Quiet.
 Dates selected as Hide.
 Log File Name selected as log.txt.

--- a/code/stable/projectile/projectile_m_l_nol_u_u_v_f/src/julia/designLog.txt
+++ b/code/stable/projectile/projectile_m_l_nol_u_u_v_f/src/julia/designLog.txt
@@ -6,7 +6,7 @@ Constant Representation selected as Var.
 Implementation Type selected as Library.
 Software Constraint Behaviour selected as Warning.
 Physical Constraint Behaviour selected as Warning.
-Comments selected as CommentFunc CommentClass CommentMod.
+Comments selected as CommentFunc CommentClass CommentMod CommentVarDecls.
 Dox Verbosity selected as Quiet.
 Dates selected as Hide.
 Log File Name selected as log.txt.

--- a/code/stable/projectile/projectile_m_l_nol_u_u_v_f/src/python/designLog.txt
+++ b/code/stable/projectile/projectile_m_l_nol_u_u_v_f/src/python/designLog.txt
@@ -6,7 +6,7 @@ Constant Representation selected as Var.
 Implementation Type selected as Library.
 Software Constraint Behaviour selected as Warning.
 Physical Constraint Behaviour selected as Warning.
-Comments selected as CommentFunc CommentClass CommentMod.
+Comments selected as CommentFunc CommentClass CommentMod CommentVarDecls.
 Dox Verbosity selected as Quiet.
 Dates selected as Hide.
 Log File Name selected as log.txt.

--- a/code/stable/projectile/projectile_m_l_nol_u_u_v_f/src/swift/designLog.txt
+++ b/code/stable/projectile/projectile_m_l_nol_u_u_v_f/src/swift/designLog.txt
@@ -6,7 +6,7 @@ Constant Representation selected as Var.
 Implementation Type selected as Library.
 Software Constraint Behaviour selected as Warning.
 Physical Constraint Behaviour selected as Warning.
-Comments selected as CommentFunc CommentClass CommentMod.
+Comments selected as CommentFunc CommentClass CommentMod CommentVarDecls.
 Dox Verbosity selected as Quiet.
 Dates selected as Hide.
 Log File Name selected as log.txt.

--- a/code/stable/projectile/projectile_m_p_nol_b_u_v_d/src/cpp/designLog.txt
+++ b/code/stable/projectile/projectile_m_p_nol_b_u_v_d/src/cpp/designLog.txt
@@ -6,7 +6,7 @@ Constant Representation selected as Var.
 Implementation Type selected as Program.
 Software Constraint Behaviour selected as Warning.
 Physical Constraint Behaviour selected as Warning.
-Comments selected as CommentFunc CommentClass CommentMod.
+Comments selected as CommentFunc CommentClass CommentMod CommentVarDecls.
 Dox Verbosity selected as Quiet.
 Dates selected as Hide.
 Log File Name selected as log.txt.

--- a/code/stable/projectile/projectile_m_p_nol_b_u_v_d/src/csharp/designLog.txt
+++ b/code/stable/projectile/projectile_m_p_nol_b_u_v_d/src/csharp/designLog.txt
@@ -6,7 +6,7 @@ Constant Representation selected as Var.
 Implementation Type selected as Program.
 Software Constraint Behaviour selected as Warning.
 Physical Constraint Behaviour selected as Warning.
-Comments selected as CommentFunc CommentClass CommentMod.
+Comments selected as CommentFunc CommentClass CommentMod CommentVarDecls.
 Dox Verbosity selected as Quiet.
 Dates selected as Hide.
 Log File Name selected as log.txt.

--- a/code/stable/projectile/projectile_m_p_nol_b_u_v_d/src/java/designLog.txt
+++ b/code/stable/projectile/projectile_m_p_nol_b_u_v_d/src/java/designLog.txt
@@ -6,7 +6,7 @@ Constant Representation selected as Var.
 Implementation Type selected as Program.
 Software Constraint Behaviour selected as Warning.
 Physical Constraint Behaviour selected as Warning.
-Comments selected as CommentFunc CommentClass CommentMod.
+Comments selected as CommentFunc CommentClass CommentMod CommentVarDecls.
 Dox Verbosity selected as Quiet.
 Dates selected as Hide.
 Log File Name selected as log.txt.

--- a/code/stable/projectile/projectile_m_p_nol_b_u_v_d/src/python/designLog.txt
+++ b/code/stable/projectile/projectile_m_p_nol_b_u_v_d/src/python/designLog.txt
@@ -6,7 +6,7 @@ Constant Representation selected as Var.
 Implementation Type selected as Program.
 Software Constraint Behaviour selected as Warning.
 Physical Constraint Behaviour selected as Warning.
-Comments selected as CommentFunc CommentClass CommentMod.
+Comments selected as CommentFunc CommentClass CommentMod CommentVarDecls.
 Dox Verbosity selected as Quiet.
 Dates selected as Hide.
 Log File Name selected as log.txt.

--- a/code/stable/projectile/projectile_m_p_nol_b_u_v_d/src/swift/designLog.txt
+++ b/code/stable/projectile/projectile_m_p_nol_b_u_v_d/src/swift/designLog.txt
@@ -6,7 +6,7 @@ Constant Representation selected as Var.
 Implementation Type selected as Program.
 Software Constraint Behaviour selected as Warning.
 Physical Constraint Behaviour selected as Warning.
-Comments selected as CommentFunc CommentClass CommentMod.
+Comments selected as CommentFunc CommentClass CommentMod CommentVarDecls.
 Dox Verbosity selected as Quiet.
 Dates selected as Hide.
 Log File Name selected as log.txt.

--- a/code/stable/projectile/projectile_u_p_l_b_b_c_d/src/cpp/Projectile.cpp
+++ b/code/stable/projectile/projectile_u_p_l_b_b_c_d/src/cpp/Projectile.cpp
@@ -126,25 +126,25 @@ int main(int argc, const char *argv[]) {
     outfile << " in module Projectile" << std::endl;
     outfile.close();
     InputParameters inParams = InputParameters(filename);
-    double t_flight = func_t_flight(inParams);
+    double t_flight = 2.0 * inParams.v_launch * sin(inParams.theta) / Constants::g;
     outfile.open("log.txt", std::fstream::app);
     outfile << "var 't_flight' assigned ";
     outfile << t_flight;
     outfile << " in module Projectile" << std::endl;
     outfile.close();
-    double p_land = func_p_land(inParams);
+    double p_land = 2.0 * pow(inParams.v_launch, 2.0) * sin(inParams.theta) * cos(inParams.theta) / Constants::g;
     outfile.open("log.txt", std::fstream::app);
     outfile << "var 'p_land' assigned ";
     outfile << p_land;
     outfile << " in module Projectile" << std::endl;
     outfile.close();
-    double d_offset = func_d_offset(inParams, p_land);
+    double d_offset = p_land - inParams.p_target;
     outfile.open("log.txt", std::fstream::app);
     outfile << "var 'd_offset' assigned ";
     outfile << d_offset;
     outfile << " in module Projectile" << std::endl;
     outfile.close();
-    string s = func_s(inParams, d_offset);
+    string s = fabs(d_offset / inParams.p_target) < Constants::epsilon ? "The target was hit." : d_offset < 0.0 ? "The projectile fell short." : "The projectile went long.";
     outfile.open("log.txt", std::fstream::app);
     outfile << "var 's' assigned ";
     outfile << s;
@@ -153,68 +153,6 @@ int main(int argc, const char *argv[]) {
     write_output(s, d_offset, t_flight);
     
     return 0;
-}
-
-double func_t_flight(InputParameters &inParams) {
-    ofstream outfile;
-    outfile.open("log.txt", std::fstream::app);
-    outfile << "function func_t_flight called with inputs: {" << std::endl;
-    outfile << "  inParams = ";
-    outfile << "Instance of InputParameters object" << std::endl;
-    outfile << "  }" << std::endl;
-    outfile.close();
-    
-    return 2.0 * inParams.v_launch * sin(inParams.theta) / Constants::g;
-}
-
-double func_p_land(InputParameters &inParams) {
-    ofstream outfile;
-    outfile.open("log.txt", std::fstream::app);
-    outfile << "function func_p_land called with inputs: {" << std::endl;
-    outfile << "  inParams = ";
-    outfile << "Instance of InputParameters object" << std::endl;
-    outfile << "  }" << std::endl;
-    outfile.close();
-    
-    return 2.0 * pow(inParams.v_launch, 2.0) * sin(inParams.theta) * cos(inParams.theta) / Constants::g;
-}
-
-double func_d_offset(InputParameters &inParams, double p_land) {
-    ofstream outfile;
-    outfile.open("log.txt", std::fstream::app);
-    outfile << "function func_d_offset called with inputs: {" << std::endl;
-    outfile << "  inParams = ";
-    outfile << "Instance of InputParameters object";
-    outfile << ", " << std::endl;
-    outfile << "  p_land = ";
-    outfile << p_land << std::endl;
-    outfile << "  }" << std::endl;
-    outfile.close();
-    
-    return p_land - inParams.p_target;
-}
-
-string func_s(InputParameters &inParams, double d_offset) {
-    ofstream outfile;
-    outfile.open("log.txt", std::fstream::app);
-    outfile << "function func_s called with inputs: {" << std::endl;
-    outfile << "  inParams = ";
-    outfile << "Instance of InputParameters object";
-    outfile << ", " << std::endl;
-    outfile << "  d_offset = ";
-    outfile << d_offset << std::endl;
-    outfile << "  }" << std::endl;
-    outfile.close();
-    
-    if (fabs(d_offset / inParams.p_target) < Constants::epsilon) {
-        return "The target was hit.";
-    }
-    else if (d_offset < 0.0) {
-        return "The projectile fell short.";
-    }
-    else {
-        return "The projectile went long.";
-    }
 }
 
 void write_output(string s, double d_offset, double t_flight) {

--- a/code/stable/projectile/projectile_u_p_l_b_b_c_d/src/cpp/Projectile.hpp
+++ b/code/stable/projectile/projectile_u_p_l_b_b_c_d/src/cpp/Projectile.hpp
@@ -48,32 +48,6 @@ class Constants {
         
 };
 
-/** \brief Calculates flight duration: the time when the projectile lands (s)
-    \param inParams structure holding the input values
-    \return flight duration: the time when the projectile lands (s)
-*/
-double func_t_flight(InputParameters &inParams);
-
-/** \brief Calculates landing position: the distance from the launcher to the final position of the projectile (m)
-    \param inParams structure holding the input values
-    \return landing position: the distance from the launcher to the final position of the projectile (m)
-*/
-double func_p_land(InputParameters &inParams);
-
-/** \brief Calculates distance between the target position and the landing position: the offset between the target position and the landing position (m)
-    \param inParams structure holding the input values
-    \param p_land landing position: the distance from the launcher to the final position of the projectile (m)
-    \return distance between the target position and the landing position: the offset between the target position and the landing position (m)
-*/
-double func_d_offset(InputParameters &inParams, double p_land);
-
-/** \brief Calculates output message as a string
-    \param inParams structure holding the input values
-    \param d_offset distance between the target position and the landing position: the offset between the target position and the landing position (m)
-    \return output message as a string
-*/
-string func_s(InputParameters &inParams, double d_offset);
-
 /** \brief Writes the output values to output.txt
     \param s output message as a string
     \param d_offset distance between the target position and the landing position: the offset between the target position and the landing position (m)

--- a/code/stable/projectile/projectile_u_p_l_b_b_c_d/src/csharp/Projectile.cs
+++ b/code/stable/projectile/projectile_u_p_l_b_b_c_d/src/csharp/Projectile.cs
@@ -21,111 +21,31 @@ public class Projectile {
         outfile.WriteLine(" in module Projectile");
         outfile.Close();
         InputParameters inParams = new InputParameters(filename);
-        double t_flight = func_t_flight(inParams);
+        double t_flight = 2.0 * inParams.v_launch * Math.Sin(inParams.theta) / Constants.g;
         outfile = new StreamWriter("log.txt", true);
         outfile.Write("var 't_flight' assigned ");
         outfile.Write(t_flight);
         outfile.WriteLine(" in module Projectile");
         outfile.Close();
-        double p_land = func_p_land(inParams);
+        double p_land = 2.0 * Math.Pow(inParams.v_launch, 2.0) * Math.Sin(inParams.theta) * Math.Cos(inParams.theta) / Constants.g;
         outfile = new StreamWriter("log.txt", true);
         outfile.Write("var 'p_land' assigned ");
         outfile.Write(p_land);
         outfile.WriteLine(" in module Projectile");
         outfile.Close();
-        double d_offset = func_d_offset(inParams, p_land);
+        double d_offset = p_land - inParams.p_target;
         outfile = new StreamWriter("log.txt", true);
         outfile.Write("var 'd_offset' assigned ");
         outfile.Write(d_offset);
         outfile.WriteLine(" in module Projectile");
         outfile.Close();
-        string s = func_s(inParams, d_offset);
+        string s = Math.Abs(d_offset / inParams.p_target) < Constants.epsilon ? "The target was hit." : d_offset < 0.0 ? "The projectile fell short." : "The projectile went long.";
         outfile = new StreamWriter("log.txt", true);
         outfile.Write("var 's' assigned ");
         outfile.Write(s);
         outfile.WriteLine(" in module Projectile");
         outfile.Close();
         write_output(s, d_offset, t_flight);
-    }
-    
-    /** \brief Calculates flight duration: the time when the projectile lands (s)
-        \param inParams structure holding the input values
-        \return flight duration: the time when the projectile lands (s)
-    */
-    public static double func_t_flight(InputParameters inParams) {
-        StreamWriter outfile;
-        outfile = new StreamWriter("log.txt", true);
-        outfile.WriteLine("function func_t_flight called with inputs: {");
-        outfile.Write("  inParams = ");
-        outfile.WriteLine("Instance of InputParameters object");
-        outfile.WriteLine("  }");
-        outfile.Close();
-        
-        return 2.0 * inParams.v_launch * Math.Sin(inParams.theta) / Constants.g;
-    }
-    
-    /** \brief Calculates landing position: the distance from the launcher to the final position of the projectile (m)
-        \param inParams structure holding the input values
-        \return landing position: the distance from the launcher to the final position of the projectile (m)
-    */
-    public static double func_p_land(InputParameters inParams) {
-        StreamWriter outfile;
-        outfile = new StreamWriter("log.txt", true);
-        outfile.WriteLine("function func_p_land called with inputs: {");
-        outfile.Write("  inParams = ");
-        outfile.WriteLine("Instance of InputParameters object");
-        outfile.WriteLine("  }");
-        outfile.Close();
-        
-        return 2.0 * Math.Pow(inParams.v_launch, 2.0) * Math.Sin(inParams.theta) * Math.Cos(inParams.theta) / Constants.g;
-    }
-    
-    /** \brief Calculates distance between the target position and the landing position: the offset between the target position and the landing position (m)
-        \param inParams structure holding the input values
-        \param p_land landing position: the distance from the launcher to the final position of the projectile (m)
-        \return distance between the target position and the landing position: the offset between the target position and the landing position (m)
-    */
-    public static double func_d_offset(InputParameters inParams, double p_land) {
-        StreamWriter outfile;
-        outfile = new StreamWriter("log.txt", true);
-        outfile.WriteLine("function func_d_offset called with inputs: {");
-        outfile.Write("  inParams = ");
-        outfile.Write("Instance of InputParameters object");
-        outfile.WriteLine(", ");
-        outfile.Write("  p_land = ");
-        outfile.WriteLine(p_land);
-        outfile.WriteLine("  }");
-        outfile.Close();
-        
-        return p_land - inParams.p_target;
-    }
-    
-    /** \brief Calculates output message as a string
-        \param inParams structure holding the input values
-        \param d_offset distance between the target position and the landing position: the offset between the target position and the landing position (m)
-        \return output message as a string
-    */
-    public static string func_s(InputParameters inParams, double d_offset) {
-        StreamWriter outfile;
-        outfile = new StreamWriter("log.txt", true);
-        outfile.WriteLine("function func_s called with inputs: {");
-        outfile.Write("  inParams = ");
-        outfile.Write("Instance of InputParameters object");
-        outfile.WriteLine(", ");
-        outfile.Write("  d_offset = ");
-        outfile.WriteLine(d_offset);
-        outfile.WriteLine("  }");
-        outfile.Close();
-        
-        if (Math.Abs(d_offset / inParams.p_target) < Constants.epsilon) {
-            return "The target was hit.";
-        }
-        else if (d_offset < 0.0) {
-            return "The projectile fell short.";
-        }
-        else {
-            return "The projectile went long.";
-        }
     }
     
     /** \brief Writes the output values to output.txt

--- a/code/stable/projectile/projectile_u_p_l_b_b_c_d/src/java/Projectile/Projectile.java
+++ b/code/stable/projectile/projectile_u_p_l_b_b_c_d/src/java/Projectile/Projectile.java
@@ -27,111 +27,31 @@ public class Projectile {
         outfile.println(" in module Projectile");
         outfile.close();
         InputParameters inParams = new InputParameters(filename);
-        double t_flight = func_t_flight(inParams);
+        double t_flight = 2.0 * inParams.v_launch * Math.sin(inParams.theta) / Constants.g;
         outfile = new PrintWriter(new FileWriter(new File("log.txt"), true));
         outfile.print("var 't_flight' assigned ");
         outfile.print(t_flight);
         outfile.println(" in module Projectile");
         outfile.close();
-        double p_land = func_p_land(inParams);
+        double p_land = 2.0 * Math.pow(inParams.v_launch, 2.0) * Math.sin(inParams.theta) * Math.cos(inParams.theta) / Constants.g;
         outfile = new PrintWriter(new FileWriter(new File("log.txt"), true));
         outfile.print("var 'p_land' assigned ");
         outfile.print(p_land);
         outfile.println(" in module Projectile");
         outfile.close();
-        double d_offset = func_d_offset(inParams, p_land);
+        double d_offset = p_land - inParams.p_target;
         outfile = new PrintWriter(new FileWriter(new File("log.txt"), true));
         outfile.print("var 'd_offset' assigned ");
         outfile.print(d_offset);
         outfile.println(" in module Projectile");
         outfile.close();
-        String s = func_s(inParams, d_offset);
+        String s = Math.abs(d_offset / inParams.p_target) < Constants.epsilon ? "The target was hit." : d_offset < 0.0 ? "The projectile fell short." : "The projectile went long.";
         outfile = new PrintWriter(new FileWriter(new File("log.txt"), true));
         outfile.print("var 's' assigned ");
         outfile.print(s);
         outfile.println(" in module Projectile");
         outfile.close();
         write_output(s, d_offset, t_flight);
-    }
-    
-    /** \brief Calculates flight duration: the time when the projectile lands (s)
-        \param inParams structure holding the input values
-        \return flight duration: the time when the projectile lands (s)
-    */
-    public static double func_t_flight(InputParameters inParams) throws IOException {
-        PrintWriter outfile;
-        outfile = new PrintWriter(new FileWriter(new File("log.txt"), true));
-        outfile.println("function func_t_flight called with inputs: {");
-        outfile.print("  inParams = ");
-        outfile.println("Instance of InputParameters object");
-        outfile.println("  }");
-        outfile.close();
-        
-        return 2.0 * inParams.v_launch * Math.sin(inParams.theta) / Constants.g;
-    }
-    
-    /** \brief Calculates landing position: the distance from the launcher to the final position of the projectile (m)
-        \param inParams structure holding the input values
-        \return landing position: the distance from the launcher to the final position of the projectile (m)
-    */
-    public static double func_p_land(InputParameters inParams) throws IOException {
-        PrintWriter outfile;
-        outfile = new PrintWriter(new FileWriter(new File("log.txt"), true));
-        outfile.println("function func_p_land called with inputs: {");
-        outfile.print("  inParams = ");
-        outfile.println("Instance of InputParameters object");
-        outfile.println("  }");
-        outfile.close();
-        
-        return 2.0 * Math.pow(inParams.v_launch, 2.0) * Math.sin(inParams.theta) * Math.cos(inParams.theta) / Constants.g;
-    }
-    
-    /** \brief Calculates distance between the target position and the landing position: the offset between the target position and the landing position (m)
-        \param inParams structure holding the input values
-        \param p_land landing position: the distance from the launcher to the final position of the projectile (m)
-        \return distance between the target position and the landing position: the offset between the target position and the landing position (m)
-    */
-    public static double func_d_offset(InputParameters inParams, double p_land) throws IOException {
-        PrintWriter outfile;
-        outfile = new PrintWriter(new FileWriter(new File("log.txt"), true));
-        outfile.println("function func_d_offset called with inputs: {");
-        outfile.print("  inParams = ");
-        outfile.print("Instance of InputParameters object");
-        outfile.println(", ");
-        outfile.print("  p_land = ");
-        outfile.println(p_land);
-        outfile.println("  }");
-        outfile.close();
-        
-        return p_land - inParams.p_target;
-    }
-    
-    /** \brief Calculates output message as a string
-        \param inParams structure holding the input values
-        \param d_offset distance between the target position and the landing position: the offset between the target position and the landing position (m)
-        \return output message as a string
-    */
-    public static String func_s(InputParameters inParams, double d_offset) throws IOException {
-        PrintWriter outfile;
-        outfile = new PrintWriter(new FileWriter(new File("log.txt"), true));
-        outfile.println("function func_s called with inputs: {");
-        outfile.print("  inParams = ");
-        outfile.print("Instance of InputParameters object");
-        outfile.println(", ");
-        outfile.print("  d_offset = ");
-        outfile.println(d_offset);
-        outfile.println("  }");
-        outfile.close();
-        
-        if (Math.abs(d_offset / inParams.p_target) < Constants.epsilon) {
-            return "The target was hit.";
-        }
-        else if (d_offset < 0.0) {
-            return "The projectile fell short.";
-        }
-        else {
-            return "The projectile went long.";
-        }
     }
     
     /** \brief Writes the output values to output.txt

--- a/code/stable/projectile/projectile_u_p_l_b_b_c_d/src/python/Projectile.py
+++ b/code/stable/projectile/projectile_u_p_l_b_b_c_d/src/python/Projectile.py
@@ -95,71 +95,6 @@ class Constants:
     G = 9.8
     EPSILON = 2.0e-2
 
-## \brief Calculates flight duration: the time when the projectile lands (s)
-# \param inParams structure holding the input values
-# \return flight duration: the time when the projectile lands (s)
-def func_t_flight(inParams):
-    outfile = open("log.txt", "a")
-    print("function func_t_flight called with inputs: {", file=outfile)
-    print("  inParams = ", end="", file=outfile)
-    print("Instance of InputParameters object", file=outfile)
-    print("  }", file=outfile)
-    outfile.close()
-    
-    return 2.0 * inParams.v_launch * math.sin(inParams.theta) / Constants.G
-
-## \brief Calculates landing position: the distance from the launcher to the final position of the projectile (m)
-# \param inParams structure holding the input values
-# \return landing position: the distance from the launcher to the final position of the projectile (m)
-def func_p_land(inParams):
-    outfile = open("log.txt", "a")
-    print("function func_p_land called with inputs: {", file=outfile)
-    print("  inParams = ", end="", file=outfile)
-    print("Instance of InputParameters object", file=outfile)
-    print("  }", file=outfile)
-    outfile.close()
-    
-    return 2.0 * inParams.v_launch ** 2.0 * math.sin(inParams.theta) * math.cos(inParams.theta) / Constants.G
-
-## \brief Calculates distance between the target position and the landing position: the offset between the target position and the landing position (m)
-# \param inParams structure holding the input values
-# \param p_land landing position: the distance from the launcher to the final position of the projectile (m)
-# \return distance between the target position and the landing position: the offset between the target position and the landing position (m)
-def func_d_offset(inParams, p_land):
-    outfile = open("log.txt", "a")
-    print("function func_d_offset called with inputs: {", file=outfile)
-    print("  inParams = ", end="", file=outfile)
-    print("Instance of InputParameters object", end="", file=outfile)
-    print(", ", file=outfile)
-    print("  p_land = ", end="", file=outfile)
-    print(p_land, file=outfile)
-    print("  }", file=outfile)
-    outfile.close()
-    
-    return p_land - inParams.p_target
-
-## \brief Calculates output message as a string
-# \param inParams structure holding the input values
-# \param d_offset distance between the target position and the landing position: the offset between the target position and the landing position (m)
-# \return output message as a string
-def func_s(inParams, d_offset):
-    outfile = open("log.txt", "a")
-    print("function func_s called with inputs: {", file=outfile)
-    print("  inParams = ", end="", file=outfile)
-    print("Instance of InputParameters object", end="", file=outfile)
-    print(", ", file=outfile)
-    print("  d_offset = ", end="", file=outfile)
-    print(d_offset, file=outfile)
-    print("  }", file=outfile)
-    outfile.close()
-    
-    if math.fabs(d_offset / inParams.p_target) < Constants.EPSILON:
-        return "The target was hit."
-    elif d_offset < 0.0:
-        return "The projectile fell short."
-    else:
-        return "The projectile went long."
-
 ## \brief Writes the output values to output.txt
 # \param s output message as a string
 # \param d_offset distance between the target position and the landing position: the offset between the target position and the landing position (m)
@@ -194,25 +129,25 @@ print(filename, end="", file=outfile)
 print(" in module Projectile", file=outfile)
 outfile.close()
 inParams = InputParameters(filename)
-t_flight = func_t_flight(inParams)
+t_flight = 2.0 * inParams.v_launch * math.sin(inParams.theta) / Constants.G
 outfile = open("log.txt", "a")
 print("var 't_flight' assigned ", end="", file=outfile)
 print(t_flight, end="", file=outfile)
 print(" in module Projectile", file=outfile)
 outfile.close()
-p_land = func_p_land(inParams)
+p_land = 2.0 * inParams.v_launch ** 2.0 * math.sin(inParams.theta) * math.cos(inParams.theta) / Constants.G
 outfile = open("log.txt", "a")
 print("var 'p_land' assigned ", end="", file=outfile)
 print(p_land, end="", file=outfile)
 print(" in module Projectile", file=outfile)
 outfile.close()
-d_offset = func_d_offset(inParams, p_land)
+d_offset = p_land - inParams.p_target
 outfile = open("log.txt", "a")
 print("var 'd_offset' assigned ", end="", file=outfile)
 print(d_offset, end="", file=outfile)
 print(" in module Projectile", file=outfile)
 outfile.close()
-s = func_s(inParams, d_offset)
+s = "The target was hit." if math.fabs(d_offset / inParams.p_target) < Constants.EPSILON else "The projectile fell short." if d_offset < 0.0 else "The projectile went long."
 outfile = open("log.txt", "a")
 print("var 's' assigned ", end="", file=outfile)
 print(s, end="", file=outfile)

--- a/code/stable/projectile/projectile_u_p_l_b_b_c_d/src/swift/main.swift
+++ b/code/stable/projectile/projectile_u_p_l_b_b_c_d/src/swift/main.swift
@@ -262,224 +262,6 @@ class Constants {
     
 }
 
-/** Calculates flight duration: the time when the projectile lands (s)
-    - Parameter inParams: structure holding the input values
-    - Returns: flight duration: the time when the projectile lands (s)
-*/
-func func_t_flight(_ inParams: inout InputParameters) throws -> Double {
-    var outfile: FileHandle
-    do {
-        outfile = try FileHandle(forWritingTo: FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first!.appendingPathComponent("log.txt"))
-        try outfile.seekToEnd()
-    } catch {
-        throw "Error opening file."
-    }
-    do {
-        try outfile.write(contentsOf: Data("function func_t_flight called with inputs: {".utf8))
-        try outfile.write(contentsOf: Data("\n".utf8))
-    } catch {
-        throw "Error printing to file."
-    }
-    do {
-        try outfile.write(contentsOf: Data("  inParams = ".utf8))
-    } catch {
-        throw "Error printing to file."
-    }
-    do {
-        try outfile.write(contentsOf: Data("Instance of InputParameters object".utf8))
-        try outfile.write(contentsOf: Data("\n".utf8))
-    } catch {
-        throw "Error printing to file."
-    }
-    do {
-        try outfile.write(contentsOf: Data("  }".utf8))
-        try outfile.write(contentsOf: Data("\n".utf8))
-    } catch {
-        throw "Error printing to file."
-    }
-    do {
-        try outfile.close()
-    } catch {
-        throw "Error closing file."
-    }
-    
-    return 2.0 * inParams.v_launch * sin(inParams.theta) / Constants.g
-}
-
-/** Calculates landing position: the distance from the launcher to the final position of the projectile (m)
-    - Parameter inParams: structure holding the input values
-    - Returns: landing position: the distance from the launcher to the final position of the projectile (m)
-*/
-func func_p_land(_ inParams: inout InputParameters) throws -> Double {
-    var outfile: FileHandle
-    do {
-        outfile = try FileHandle(forWritingTo: FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first!.appendingPathComponent("log.txt"))
-        try outfile.seekToEnd()
-    } catch {
-        throw "Error opening file."
-    }
-    do {
-        try outfile.write(contentsOf: Data("function func_p_land called with inputs: {".utf8))
-        try outfile.write(contentsOf: Data("\n".utf8))
-    } catch {
-        throw "Error printing to file."
-    }
-    do {
-        try outfile.write(contentsOf: Data("  inParams = ".utf8))
-    } catch {
-        throw "Error printing to file."
-    }
-    do {
-        try outfile.write(contentsOf: Data("Instance of InputParameters object".utf8))
-        try outfile.write(contentsOf: Data("\n".utf8))
-    } catch {
-        throw "Error printing to file."
-    }
-    do {
-        try outfile.write(contentsOf: Data("  }".utf8))
-        try outfile.write(contentsOf: Data("\n".utf8))
-    } catch {
-        throw "Error printing to file."
-    }
-    do {
-        try outfile.close()
-    } catch {
-        throw "Error closing file."
-    }
-    
-    return 2.0 * pow(inParams.v_launch, 2.0) * sin(inParams.theta) * cos(inParams.theta) / Constants.g
-}
-
-/** Calculates distance between the target position and the landing position: the offset between the target position and the landing position (m)
-    - Parameter inParams: structure holding the input values
-    - Parameter p_land: landing position: the distance from the launcher to the final position of the projectile (m)
-    - Returns: distance between the target position and the landing position: the offset between the target position and the landing position (m)
-*/
-func func_d_offset(_ inParams: inout InputParameters, _ p_land: Double) throws -> Double {
-    var outfile: FileHandle
-    do {
-        outfile = try FileHandle(forWritingTo: FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first!.appendingPathComponent("log.txt"))
-        try outfile.seekToEnd()
-    } catch {
-        throw "Error opening file."
-    }
-    do {
-        try outfile.write(contentsOf: Data("function func_d_offset called with inputs: {".utf8))
-        try outfile.write(contentsOf: Data("\n".utf8))
-    } catch {
-        throw "Error printing to file."
-    }
-    do {
-        try outfile.write(contentsOf: Data("  inParams = ".utf8))
-    } catch {
-        throw "Error printing to file."
-    }
-    do {
-        try outfile.write(contentsOf: Data("Instance of InputParameters object".utf8))
-    } catch {
-        throw "Error printing to file."
-    }
-    do {
-        try outfile.write(contentsOf: Data(", ".utf8))
-        try outfile.write(contentsOf: Data("\n".utf8))
-    } catch {
-        throw "Error printing to file."
-    }
-    do {
-        try outfile.write(contentsOf: Data("  p_land = ".utf8))
-    } catch {
-        throw "Error printing to file."
-    }
-    do {
-        try outfile.write(contentsOf: Data(String(p_land).utf8))
-        try outfile.write(contentsOf: Data("\n".utf8))
-    } catch {
-        throw "Error printing to file."
-    }
-    do {
-        try outfile.write(contentsOf: Data("  }".utf8))
-        try outfile.write(contentsOf: Data("\n".utf8))
-    } catch {
-        throw "Error printing to file."
-    }
-    do {
-        try outfile.close()
-    } catch {
-        throw "Error closing file."
-    }
-    
-    return p_land - inParams.p_target
-}
-
-/** Calculates output message as a string
-    - Parameter inParams: structure holding the input values
-    - Parameter d_offset: distance between the target position and the landing position: the offset between the target position and the landing position (m)
-    - Returns: output message as a string
-*/
-func func_s(_ inParams: inout InputParameters, _ d_offset: Double) throws -> String {
-    var outfile: FileHandle
-    do {
-        outfile = try FileHandle(forWritingTo: FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first!.appendingPathComponent("log.txt"))
-        try outfile.seekToEnd()
-    } catch {
-        throw "Error opening file."
-    }
-    do {
-        try outfile.write(contentsOf: Data("function func_s called with inputs: {".utf8))
-        try outfile.write(contentsOf: Data("\n".utf8))
-    } catch {
-        throw "Error printing to file."
-    }
-    do {
-        try outfile.write(contentsOf: Data("  inParams = ".utf8))
-    } catch {
-        throw "Error printing to file."
-    }
-    do {
-        try outfile.write(contentsOf: Data("Instance of InputParameters object".utf8))
-    } catch {
-        throw "Error printing to file."
-    }
-    do {
-        try outfile.write(contentsOf: Data(", ".utf8))
-        try outfile.write(contentsOf: Data("\n".utf8))
-    } catch {
-        throw "Error printing to file."
-    }
-    do {
-        try outfile.write(contentsOf: Data("  d_offset = ".utf8))
-    } catch {
-        throw "Error printing to file."
-    }
-    do {
-        try outfile.write(contentsOf: Data(String(d_offset).utf8))
-        try outfile.write(contentsOf: Data("\n".utf8))
-    } catch {
-        throw "Error printing to file."
-    }
-    do {
-        try outfile.write(contentsOf: Data("  }".utf8))
-        try outfile.write(contentsOf: Data("\n".utf8))
-    } catch {
-        throw "Error printing to file."
-    }
-    do {
-        try outfile.close()
-    } catch {
-        throw "Error closing file."
-    }
-    
-    if abs(d_offset / inParams.p_target) < Constants.epsilon {
-        return "The target was hit."
-    }
-    else if d_offset < 0.0 {
-        return "The projectile fell short."
-    }
-    else {
-        return "The projectile went long."
-    }
-}
-
 /** Writes the output values to output.txt
     - Parameter s: output message as a string
     - Parameter d_offset: distance between the target position and the landing position: the offset between the target position and the landing position (m)
@@ -630,7 +412,7 @@ do {
     throw "Error closing file."
 }
 var inParams: InputParameters = try InputParameters(filename)
-var t_flight: Double = try func_t_flight(&inParams)
+var t_flight: Double = 2.0 * inParams.v_launch * sin(inParams.theta) / Constants.g
 do {
     outfile = try FileHandle(forWritingTo: FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first!.appendingPathComponent("log.txt"))
     try outfile.seekToEnd()
@@ -658,7 +440,7 @@ do {
 } catch {
     throw "Error closing file."
 }
-var p_land: Double = try func_p_land(&inParams)
+var p_land: Double = 2.0 * pow(inParams.v_launch, 2.0) * sin(inParams.theta) * cos(inParams.theta) / Constants.g
 do {
     outfile = try FileHandle(forWritingTo: FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first!.appendingPathComponent("log.txt"))
     try outfile.seekToEnd()
@@ -686,7 +468,7 @@ do {
 } catch {
     throw "Error closing file."
 }
-var d_offset: Double = try func_d_offset(&inParams, p_land)
+var d_offset: Double = p_land - inParams.p_target
 do {
     outfile = try FileHandle(forWritingTo: FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first!.appendingPathComponent("log.txt"))
     try outfile.seekToEnd()
@@ -714,7 +496,7 @@ do {
 } catch {
     throw "Error closing file."
 }
-var s: String = try func_s(&inParams, d_offset)
+var s: String = abs(d_offset / inParams.p_target) < Constants.epsilon ? "The target was hit." : d_offset < 0.0 ? "The projectile fell short." : "The projectile went long."
 do {
     outfile = try FileHandle(forWritingTo: FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first!.appendingPathComponent("log.txt"))
     try outfile.seekToEnd()

--- a/code/stable/projectile/projectile_u_p_l_b_wi_v_f/src/cpp/Projectile.cpp
+++ b/code/stable/projectile/projectile_u_p_l_b_wi_v_f/src/cpp/Projectile.cpp
@@ -123,25 +123,25 @@ int main(int argc, const char *argv[]) {
     outfile << " in module Projectile" << std::endl;
     outfile.close();
     InputParameters inParams = InputParameters(filename);
-    float t_flight = func_t_flight(inParams);
+    float t_flight = 2.0f * inParams.v_launch * sin(inParams.theta) / inParams.g;
     outfile.open("log.txt", std::fstream::app);
     outfile << "var 't_flight' assigned ";
     outfile << t_flight;
     outfile << " in module Projectile" << std::endl;
     outfile.close();
-    float p_land = func_p_land(inParams);
+    float p_land = 2.0f * pow(inParams.v_launch, 2.0f) * sin(inParams.theta) * cos(inParams.theta) / inParams.g;
     outfile.open("log.txt", std::fstream::app);
     outfile << "var 'p_land' assigned ";
     outfile << p_land;
     outfile << " in module Projectile" << std::endl;
     outfile.close();
-    float d_offset = func_d_offset(inParams, p_land);
+    float d_offset = p_land - inParams.p_target;
     outfile.open("log.txt", std::fstream::app);
     outfile << "var 'd_offset' assigned ";
     outfile << d_offset;
     outfile << " in module Projectile" << std::endl;
     outfile.close();
-    string s = func_s(inParams, d_offset);
+    string s = fabs(d_offset / inParams.p_target) < inParams.epsilon ? "The target was hit." : d_offset < 0.0f ? "The projectile fell short." : "The projectile went long.";
     outfile.open("log.txt", std::fstream::app);
     outfile << "var 's' assigned ";
     outfile << s;
@@ -150,68 +150,6 @@ int main(int argc, const char *argv[]) {
     write_output(s, d_offset, t_flight);
     
     return 0;
-}
-
-float func_t_flight(InputParameters &inParams) {
-    ofstream outfile;
-    outfile.open("log.txt", std::fstream::app);
-    outfile << "function func_t_flight called with inputs: {" << std::endl;
-    outfile << "  inParams = ";
-    outfile << "Instance of InputParameters object" << std::endl;
-    outfile << "  }" << std::endl;
-    outfile.close();
-    
-    return 2.0f * inParams.v_launch * sin(inParams.theta) / inParams.g;
-}
-
-float func_p_land(InputParameters &inParams) {
-    ofstream outfile;
-    outfile.open("log.txt", std::fstream::app);
-    outfile << "function func_p_land called with inputs: {" << std::endl;
-    outfile << "  inParams = ";
-    outfile << "Instance of InputParameters object" << std::endl;
-    outfile << "  }" << std::endl;
-    outfile.close();
-    
-    return 2.0f * pow(inParams.v_launch, 2.0f) * sin(inParams.theta) * cos(inParams.theta) / inParams.g;
-}
-
-float func_d_offset(InputParameters &inParams, float p_land) {
-    ofstream outfile;
-    outfile.open("log.txt", std::fstream::app);
-    outfile << "function func_d_offset called with inputs: {" << std::endl;
-    outfile << "  inParams = ";
-    outfile << "Instance of InputParameters object";
-    outfile << ", " << std::endl;
-    outfile << "  p_land = ";
-    outfile << p_land << std::endl;
-    outfile << "  }" << std::endl;
-    outfile.close();
-    
-    return p_land - inParams.p_target;
-}
-
-string func_s(InputParameters &inParams, float d_offset) {
-    ofstream outfile;
-    outfile.open("log.txt", std::fstream::app);
-    outfile << "function func_s called with inputs: {" << std::endl;
-    outfile << "  inParams = ";
-    outfile << "Instance of InputParameters object";
-    outfile << ", " << std::endl;
-    outfile << "  d_offset = ";
-    outfile << d_offset << std::endl;
-    outfile << "  }" << std::endl;
-    outfile.close();
-    
-    if (fabs(d_offset / inParams.p_target) < inParams.epsilon) {
-        return "The target was hit.";
-    }
-    else if (d_offset < 0.0f) {
-        return "The projectile fell short.";
-    }
-    else {
-        return "The projectile went long.";
-    }
 }
 
 void write_output(string s, float d_offset, float t_flight) {

--- a/code/stable/projectile/projectile_u_p_l_b_wi_v_f/src/cpp/Projectile.hpp
+++ b/code/stable/projectile/projectile_u_p_l_b_wi_v_f/src/cpp/Projectile.hpp
@@ -41,32 +41,6 @@ class InputParameters {
         void input_constraints();
 };
 
-/** \brief Calculates flight duration: the time when the projectile lands (s)
-    \param inParams structure holding the input values
-    \return flight duration: the time when the projectile lands (s)
-*/
-float func_t_flight(InputParameters &inParams);
-
-/** \brief Calculates landing position: the distance from the launcher to the final position of the projectile (m)
-    \param inParams structure holding the input values
-    \return landing position: the distance from the launcher to the final position of the projectile (m)
-*/
-float func_p_land(InputParameters &inParams);
-
-/** \brief Calculates distance between the target position and the landing position: the offset between the target position and the landing position (m)
-    \param inParams structure holding the input values
-    \param p_land landing position: the distance from the launcher to the final position of the projectile (m)
-    \return distance between the target position and the landing position: the offset between the target position and the landing position (m)
-*/
-float func_d_offset(InputParameters &inParams, float p_land);
-
-/** \brief Calculates output message as a string
-    \param inParams structure holding the input values
-    \param d_offset distance between the target position and the landing position: the offset between the target position and the landing position (m)
-    \return output message as a string
-*/
-string func_s(InputParameters &inParams, float d_offset);
-
 /** \brief Writes the output values to output.txt
     \param s output message as a string
     \param d_offset distance between the target position and the landing position: the offset between the target position and the landing position (m)

--- a/code/stable/projectile/projectile_u_p_l_b_wi_v_f/src/csharp/Projectile.cs
+++ b/code/stable/projectile/projectile_u_p_l_b_wi_v_f/src/csharp/Projectile.cs
@@ -21,111 +21,31 @@ public class Projectile {
         outfile.WriteLine(" in module Projectile");
         outfile.Close();
         InputParameters inParams = new InputParameters(filename);
-        float t_flight = func_t_flight(inParams);
+        float t_flight = 2.0f * inParams.v_launch * (float)(Math.Sin(inParams.theta)) / inParams.g;
         outfile = new StreamWriter("log.txt", true);
         outfile.Write("var 't_flight' assigned ");
         outfile.Write(t_flight);
         outfile.WriteLine(" in module Projectile");
         outfile.Close();
-        float p_land = func_p_land(inParams);
+        float p_land = 2.0f * (float)(Math.Pow(inParams.v_launch, 2.0f)) * (float)(Math.Sin(inParams.theta)) * (float)(Math.Cos(inParams.theta)) / inParams.g;
         outfile = new StreamWriter("log.txt", true);
         outfile.Write("var 'p_land' assigned ");
         outfile.Write(p_land);
         outfile.WriteLine(" in module Projectile");
         outfile.Close();
-        float d_offset = func_d_offset(inParams, p_land);
+        float d_offset = p_land - inParams.p_target;
         outfile = new StreamWriter("log.txt", true);
         outfile.Write("var 'd_offset' assigned ");
         outfile.Write(d_offset);
         outfile.WriteLine(" in module Projectile");
         outfile.Close();
-        string s = func_s(inParams, d_offset);
+        string s = Math.Abs(d_offset / inParams.p_target) < inParams.epsilon ? "The target was hit." : d_offset < 0.0f ? "The projectile fell short." : "The projectile went long.";
         outfile = new StreamWriter("log.txt", true);
         outfile.Write("var 's' assigned ");
         outfile.Write(s);
         outfile.WriteLine(" in module Projectile");
         outfile.Close();
         write_output(s, d_offset, t_flight);
-    }
-    
-    /** \brief Calculates flight duration: the time when the projectile lands (s)
-        \param inParams structure holding the input values
-        \return flight duration: the time when the projectile lands (s)
-    */
-    public static float func_t_flight(InputParameters inParams) {
-        StreamWriter outfile;
-        outfile = new StreamWriter("log.txt", true);
-        outfile.WriteLine("function func_t_flight called with inputs: {");
-        outfile.Write("  inParams = ");
-        outfile.WriteLine("Instance of InputParameters object");
-        outfile.WriteLine("  }");
-        outfile.Close();
-        
-        return 2.0f * inParams.v_launch * (float)(Math.Sin(inParams.theta)) / inParams.g;
-    }
-    
-    /** \brief Calculates landing position: the distance from the launcher to the final position of the projectile (m)
-        \param inParams structure holding the input values
-        \return landing position: the distance from the launcher to the final position of the projectile (m)
-    */
-    public static float func_p_land(InputParameters inParams) {
-        StreamWriter outfile;
-        outfile = new StreamWriter("log.txt", true);
-        outfile.WriteLine("function func_p_land called with inputs: {");
-        outfile.Write("  inParams = ");
-        outfile.WriteLine("Instance of InputParameters object");
-        outfile.WriteLine("  }");
-        outfile.Close();
-        
-        return 2.0f * (float)(Math.Pow(inParams.v_launch, 2.0f)) * (float)(Math.Sin(inParams.theta)) * (float)(Math.Cos(inParams.theta)) / inParams.g;
-    }
-    
-    /** \brief Calculates distance between the target position and the landing position: the offset between the target position and the landing position (m)
-        \param inParams structure holding the input values
-        \param p_land landing position: the distance from the launcher to the final position of the projectile (m)
-        \return distance between the target position and the landing position: the offset between the target position and the landing position (m)
-    */
-    public static float func_d_offset(InputParameters inParams, float p_land) {
-        StreamWriter outfile;
-        outfile = new StreamWriter("log.txt", true);
-        outfile.WriteLine("function func_d_offset called with inputs: {");
-        outfile.Write("  inParams = ");
-        outfile.Write("Instance of InputParameters object");
-        outfile.WriteLine(", ");
-        outfile.Write("  p_land = ");
-        outfile.WriteLine(p_land);
-        outfile.WriteLine("  }");
-        outfile.Close();
-        
-        return p_land - inParams.p_target;
-    }
-    
-    /** \brief Calculates output message as a string
-        \param inParams structure holding the input values
-        \param d_offset distance between the target position and the landing position: the offset between the target position and the landing position (m)
-        \return output message as a string
-    */
-    public static string func_s(InputParameters inParams, float d_offset) {
-        StreamWriter outfile;
-        outfile = new StreamWriter("log.txt", true);
-        outfile.WriteLine("function func_s called with inputs: {");
-        outfile.Write("  inParams = ");
-        outfile.Write("Instance of InputParameters object");
-        outfile.WriteLine(", ");
-        outfile.Write("  d_offset = ");
-        outfile.WriteLine(d_offset);
-        outfile.WriteLine("  }");
-        outfile.Close();
-        
-        if (Math.Abs(d_offset / inParams.p_target) < inParams.epsilon) {
-            return "The target was hit.";
-        }
-        else if (d_offset < 0.0f) {
-            return "The projectile fell short.";
-        }
-        else {
-            return "The projectile went long.";
-        }
     }
     
     /** \brief Writes the output values to output.txt

--- a/code/stable/projectile/projectile_u_p_l_b_wi_v_f/src/java/Projectile/Projectile.java
+++ b/code/stable/projectile/projectile_u_p_l_b_wi_v_f/src/java/Projectile/Projectile.java
@@ -27,111 +27,31 @@ public class Projectile {
         outfile.println(" in module Projectile");
         outfile.close();
         InputParameters inParams = new InputParameters(filename);
-        float t_flight = func_t_flight(inParams);
+        float t_flight = 2.0f * inParams.v_launch * (float)(Math.sin(inParams.theta)) / inParams.g;
         outfile = new PrintWriter(new FileWriter(new File("log.txt"), true));
         outfile.print("var 't_flight' assigned ");
         outfile.print(t_flight);
         outfile.println(" in module Projectile");
         outfile.close();
-        float p_land = func_p_land(inParams);
+        float p_land = 2.0f * (float)(Math.pow(inParams.v_launch, 2.0f)) * (float)(Math.sin(inParams.theta)) * (float)(Math.cos(inParams.theta)) / inParams.g;
         outfile = new PrintWriter(new FileWriter(new File("log.txt"), true));
         outfile.print("var 'p_land' assigned ");
         outfile.print(p_land);
         outfile.println(" in module Projectile");
         outfile.close();
-        float d_offset = func_d_offset(inParams, p_land);
+        float d_offset = p_land - inParams.p_target;
         outfile = new PrintWriter(new FileWriter(new File("log.txt"), true));
         outfile.print("var 'd_offset' assigned ");
         outfile.print(d_offset);
         outfile.println(" in module Projectile");
         outfile.close();
-        String s = func_s(inParams, d_offset);
+        String s = Math.abs(d_offset / inParams.p_target) < inParams.epsilon ? "The target was hit." : d_offset < 0.0f ? "The projectile fell short." : "The projectile went long.";
         outfile = new PrintWriter(new FileWriter(new File("log.txt"), true));
         outfile.print("var 's' assigned ");
         outfile.print(s);
         outfile.println(" in module Projectile");
         outfile.close();
         write_output(s, d_offset, t_flight);
-    }
-    
-    /** \brief Calculates flight duration: the time when the projectile lands (s)
-        \param inParams structure holding the input values
-        \return flight duration: the time when the projectile lands (s)
-    */
-    public static float func_t_flight(InputParameters inParams) throws IOException {
-        PrintWriter outfile;
-        outfile = new PrintWriter(new FileWriter(new File("log.txt"), true));
-        outfile.println("function func_t_flight called with inputs: {");
-        outfile.print("  inParams = ");
-        outfile.println("Instance of InputParameters object");
-        outfile.println("  }");
-        outfile.close();
-        
-        return 2.0f * inParams.v_launch * (float)(Math.sin(inParams.theta)) / inParams.g;
-    }
-    
-    /** \brief Calculates landing position: the distance from the launcher to the final position of the projectile (m)
-        \param inParams structure holding the input values
-        \return landing position: the distance from the launcher to the final position of the projectile (m)
-    */
-    public static float func_p_land(InputParameters inParams) throws IOException {
-        PrintWriter outfile;
-        outfile = new PrintWriter(new FileWriter(new File("log.txt"), true));
-        outfile.println("function func_p_land called with inputs: {");
-        outfile.print("  inParams = ");
-        outfile.println("Instance of InputParameters object");
-        outfile.println("  }");
-        outfile.close();
-        
-        return 2.0f * (float)(Math.pow(inParams.v_launch, 2.0f)) * (float)(Math.sin(inParams.theta)) * (float)(Math.cos(inParams.theta)) / inParams.g;
-    }
-    
-    /** \brief Calculates distance between the target position and the landing position: the offset between the target position and the landing position (m)
-        \param inParams structure holding the input values
-        \param p_land landing position: the distance from the launcher to the final position of the projectile (m)
-        \return distance between the target position and the landing position: the offset between the target position and the landing position (m)
-    */
-    public static float func_d_offset(InputParameters inParams, float p_land) throws IOException {
-        PrintWriter outfile;
-        outfile = new PrintWriter(new FileWriter(new File("log.txt"), true));
-        outfile.println("function func_d_offset called with inputs: {");
-        outfile.print("  inParams = ");
-        outfile.print("Instance of InputParameters object");
-        outfile.println(", ");
-        outfile.print("  p_land = ");
-        outfile.println(p_land);
-        outfile.println("  }");
-        outfile.close();
-        
-        return p_land - inParams.p_target;
-    }
-    
-    /** \brief Calculates output message as a string
-        \param inParams structure holding the input values
-        \param d_offset distance between the target position and the landing position: the offset between the target position and the landing position (m)
-        \return output message as a string
-    */
-    public static String func_s(InputParameters inParams, float d_offset) throws IOException {
-        PrintWriter outfile;
-        outfile = new PrintWriter(new FileWriter(new File("log.txt"), true));
-        outfile.println("function func_s called with inputs: {");
-        outfile.print("  inParams = ");
-        outfile.print("Instance of InputParameters object");
-        outfile.println(", ");
-        outfile.print("  d_offset = ");
-        outfile.println(d_offset);
-        outfile.println("  }");
-        outfile.close();
-        
-        if (Math.abs(d_offset / inParams.p_target) < inParams.epsilon) {
-            return "The target was hit.";
-        }
-        else if (d_offset < 0.0f) {
-            return "The projectile fell short.";
-        }
-        else {
-            return "The projectile went long.";
-        }
     }
     
     /** \brief Writes the output values to output.txt

--- a/code/stable/projectile/projectile_u_p_l_b_wi_v_f/src/python/Projectile.py
+++ b/code/stable/projectile/projectile_u_p_l_b_wi_v_f/src/python/Projectile.py
@@ -93,71 +93,6 @@ class InputParameters:
             print(0.0, end="")
             print(".")
 
-## \brief Calculates flight duration: the time when the projectile lands (s)
-# \param inParams structure holding the input values
-# \return flight duration: the time when the projectile lands (s)
-def func_t_flight(inParams):
-    outfile = open("log.txt", "a")
-    print("function func_t_flight called with inputs: {", file=outfile)
-    print("  inParams = ", end="", file=outfile)
-    print("Instance of InputParameters object", file=outfile)
-    print("  }", file=outfile)
-    outfile.close()
-    
-    return 2.0 * inParams.v_launch * math.sin(inParams.theta) / inParams.g
-
-## \brief Calculates landing position: the distance from the launcher to the final position of the projectile (m)
-# \param inParams structure holding the input values
-# \return landing position: the distance from the launcher to the final position of the projectile (m)
-def func_p_land(inParams):
-    outfile = open("log.txt", "a")
-    print("function func_p_land called with inputs: {", file=outfile)
-    print("  inParams = ", end="", file=outfile)
-    print("Instance of InputParameters object", file=outfile)
-    print("  }", file=outfile)
-    outfile.close()
-    
-    return 2.0 * inParams.v_launch ** 2.0 * math.sin(inParams.theta) * math.cos(inParams.theta) / inParams.g
-
-## \brief Calculates distance between the target position and the landing position: the offset between the target position and the landing position (m)
-# \param inParams structure holding the input values
-# \param p_land landing position: the distance from the launcher to the final position of the projectile (m)
-# \return distance between the target position and the landing position: the offset between the target position and the landing position (m)
-def func_d_offset(inParams, p_land):
-    outfile = open("log.txt", "a")
-    print("function func_d_offset called with inputs: {", file=outfile)
-    print("  inParams = ", end="", file=outfile)
-    print("Instance of InputParameters object", end="", file=outfile)
-    print(", ", file=outfile)
-    print("  p_land = ", end="", file=outfile)
-    print(p_land, file=outfile)
-    print("  }", file=outfile)
-    outfile.close()
-    
-    return p_land - inParams.p_target
-
-## \brief Calculates output message as a string
-# \param inParams structure holding the input values
-# \param d_offset distance between the target position and the landing position: the offset between the target position and the landing position (m)
-# \return output message as a string
-def func_s(inParams, d_offset):
-    outfile = open("log.txt", "a")
-    print("function func_s called with inputs: {", file=outfile)
-    print("  inParams = ", end="", file=outfile)
-    print("Instance of InputParameters object", end="", file=outfile)
-    print(", ", file=outfile)
-    print("  d_offset = ", end="", file=outfile)
-    print(d_offset, file=outfile)
-    print("  }", file=outfile)
-    outfile.close()
-    
-    if math.fabs(d_offset / inParams.p_target) < inParams.epsilon:
-        return "The target was hit."
-    elif d_offset < 0.0:
-        return "The projectile fell short."
-    else:
-        return "The projectile went long."
-
 ## \brief Writes the output values to output.txt
 # \param s output message as a string
 # \param d_offset distance between the target position and the landing position: the offset between the target position and the landing position (m)
@@ -192,25 +127,25 @@ print(filename, end="", file=outfile)
 print(" in module Projectile", file=outfile)
 outfile.close()
 inParams = InputParameters(filename)
-t_flight = func_t_flight(inParams)
+t_flight = 2.0 * inParams.v_launch * math.sin(inParams.theta) / inParams.g
 outfile = open("log.txt", "a")
 print("var 't_flight' assigned ", end="", file=outfile)
 print(t_flight, end="", file=outfile)
 print(" in module Projectile", file=outfile)
 outfile.close()
-p_land = func_p_land(inParams)
+p_land = 2.0 * inParams.v_launch ** 2.0 * math.sin(inParams.theta) * math.cos(inParams.theta) / inParams.g
 outfile = open("log.txt", "a")
 print("var 'p_land' assigned ", end="", file=outfile)
 print(p_land, end="", file=outfile)
 print(" in module Projectile", file=outfile)
 outfile.close()
-d_offset = func_d_offset(inParams, p_land)
+d_offset = p_land - inParams.p_target
 outfile = open("log.txt", "a")
 print("var 'd_offset' assigned ", end="", file=outfile)
 print(d_offset, end="", file=outfile)
 print(" in module Projectile", file=outfile)
 outfile.close()
-s = func_s(inParams, d_offset)
+s = "The target was hit." if math.fabs(d_offset / inParams.p_target) < inParams.epsilon else "The projectile fell short." if d_offset < 0.0 else "The projectile went long."
 outfile = open("log.txt", "a")
 print("var 's' assigned ", end="", file=outfile)
 print(s, end="", file=outfile)

--- a/code/stable/projectile/projectile_u_p_l_b_wi_v_f/src/swift/main.swift
+++ b/code/stable/projectile/projectile_u_p_l_b_wi_v_f/src/swift/main.swift
@@ -256,224 +256,6 @@ class InputParameters {
     }
 }
 
-/** Calculates flight duration: the time when the projectile lands (s)
-    - Parameter inParams: structure holding the input values
-    - Returns: flight duration: the time when the projectile lands (s)
-*/
-func func_t_flight(_ inParams: inout InputParameters) throws -> Float {
-    var outfile: FileHandle
-    do {
-        outfile = try FileHandle(forWritingTo: FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first!.appendingPathComponent("log.txt"))
-        try outfile.seekToEnd()
-    } catch {
-        throw "Error opening file."
-    }
-    do {
-        try outfile.write(contentsOf: Data("function func_t_flight called with inputs: {".utf8))
-        try outfile.write(contentsOf: Data("\n".utf8))
-    } catch {
-        throw "Error printing to file."
-    }
-    do {
-        try outfile.write(contentsOf: Data("  inParams = ".utf8))
-    } catch {
-        throw "Error printing to file."
-    }
-    do {
-        try outfile.write(contentsOf: Data("Instance of InputParameters object".utf8))
-        try outfile.write(contentsOf: Data("\n".utf8))
-    } catch {
-        throw "Error printing to file."
-    }
-    do {
-        try outfile.write(contentsOf: Data("  }".utf8))
-        try outfile.write(contentsOf: Data("\n".utf8))
-    } catch {
-        throw "Error printing to file."
-    }
-    do {
-        try outfile.close()
-    } catch {
-        throw "Error closing file."
-    }
-    
-    return 2.0 * inParams.v_launch * sin(inParams.theta) / inParams.g
-}
-
-/** Calculates landing position: the distance from the launcher to the final position of the projectile (m)
-    - Parameter inParams: structure holding the input values
-    - Returns: landing position: the distance from the launcher to the final position of the projectile (m)
-*/
-func func_p_land(_ inParams: inout InputParameters) throws -> Float {
-    var outfile: FileHandle
-    do {
-        outfile = try FileHandle(forWritingTo: FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first!.appendingPathComponent("log.txt"))
-        try outfile.seekToEnd()
-    } catch {
-        throw "Error opening file."
-    }
-    do {
-        try outfile.write(contentsOf: Data("function func_p_land called with inputs: {".utf8))
-        try outfile.write(contentsOf: Data("\n".utf8))
-    } catch {
-        throw "Error printing to file."
-    }
-    do {
-        try outfile.write(contentsOf: Data("  inParams = ".utf8))
-    } catch {
-        throw "Error printing to file."
-    }
-    do {
-        try outfile.write(contentsOf: Data("Instance of InputParameters object".utf8))
-        try outfile.write(contentsOf: Data("\n".utf8))
-    } catch {
-        throw "Error printing to file."
-    }
-    do {
-        try outfile.write(contentsOf: Data("  }".utf8))
-        try outfile.write(contentsOf: Data("\n".utf8))
-    } catch {
-        throw "Error printing to file."
-    }
-    do {
-        try outfile.close()
-    } catch {
-        throw "Error closing file."
-    }
-    
-    return 2.0 * pow(inParams.v_launch, 2.0) * sin(inParams.theta) * cos(inParams.theta) / inParams.g
-}
-
-/** Calculates distance between the target position and the landing position: the offset between the target position and the landing position (m)
-    - Parameter inParams: structure holding the input values
-    - Parameter p_land: landing position: the distance from the launcher to the final position of the projectile (m)
-    - Returns: distance between the target position and the landing position: the offset between the target position and the landing position (m)
-*/
-func func_d_offset(_ inParams: inout InputParameters, _ p_land: Float) throws -> Float {
-    var outfile: FileHandle
-    do {
-        outfile = try FileHandle(forWritingTo: FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first!.appendingPathComponent("log.txt"))
-        try outfile.seekToEnd()
-    } catch {
-        throw "Error opening file."
-    }
-    do {
-        try outfile.write(contentsOf: Data("function func_d_offset called with inputs: {".utf8))
-        try outfile.write(contentsOf: Data("\n".utf8))
-    } catch {
-        throw "Error printing to file."
-    }
-    do {
-        try outfile.write(contentsOf: Data("  inParams = ".utf8))
-    } catch {
-        throw "Error printing to file."
-    }
-    do {
-        try outfile.write(contentsOf: Data("Instance of InputParameters object".utf8))
-    } catch {
-        throw "Error printing to file."
-    }
-    do {
-        try outfile.write(contentsOf: Data(", ".utf8))
-        try outfile.write(contentsOf: Data("\n".utf8))
-    } catch {
-        throw "Error printing to file."
-    }
-    do {
-        try outfile.write(contentsOf: Data("  p_land = ".utf8))
-    } catch {
-        throw "Error printing to file."
-    }
-    do {
-        try outfile.write(contentsOf: Data(String(p_land).utf8))
-        try outfile.write(contentsOf: Data("\n".utf8))
-    } catch {
-        throw "Error printing to file."
-    }
-    do {
-        try outfile.write(contentsOf: Data("  }".utf8))
-        try outfile.write(contentsOf: Data("\n".utf8))
-    } catch {
-        throw "Error printing to file."
-    }
-    do {
-        try outfile.close()
-    } catch {
-        throw "Error closing file."
-    }
-    
-    return p_land - inParams.p_target
-}
-
-/** Calculates output message as a string
-    - Parameter inParams: structure holding the input values
-    - Parameter d_offset: distance between the target position and the landing position: the offset between the target position and the landing position (m)
-    - Returns: output message as a string
-*/
-func func_s(_ inParams: inout InputParameters, _ d_offset: Float) throws -> String {
-    var outfile: FileHandle
-    do {
-        outfile = try FileHandle(forWritingTo: FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first!.appendingPathComponent("log.txt"))
-        try outfile.seekToEnd()
-    } catch {
-        throw "Error opening file."
-    }
-    do {
-        try outfile.write(contentsOf: Data("function func_s called with inputs: {".utf8))
-        try outfile.write(contentsOf: Data("\n".utf8))
-    } catch {
-        throw "Error printing to file."
-    }
-    do {
-        try outfile.write(contentsOf: Data("  inParams = ".utf8))
-    } catch {
-        throw "Error printing to file."
-    }
-    do {
-        try outfile.write(contentsOf: Data("Instance of InputParameters object".utf8))
-    } catch {
-        throw "Error printing to file."
-    }
-    do {
-        try outfile.write(contentsOf: Data(", ".utf8))
-        try outfile.write(contentsOf: Data("\n".utf8))
-    } catch {
-        throw "Error printing to file."
-    }
-    do {
-        try outfile.write(contentsOf: Data("  d_offset = ".utf8))
-    } catch {
-        throw "Error printing to file."
-    }
-    do {
-        try outfile.write(contentsOf: Data(String(d_offset).utf8))
-        try outfile.write(contentsOf: Data("\n".utf8))
-    } catch {
-        throw "Error printing to file."
-    }
-    do {
-        try outfile.write(contentsOf: Data("  }".utf8))
-        try outfile.write(contentsOf: Data("\n".utf8))
-    } catch {
-        throw "Error printing to file."
-    }
-    do {
-        try outfile.close()
-    } catch {
-        throw "Error closing file."
-    }
-    
-    if abs(d_offset / inParams.p_target) < inParams.epsilon {
-        return "The target was hit."
-    }
-    else if d_offset < 0.0 {
-        return "The projectile fell short."
-    }
-    else {
-        return "The projectile went long."
-    }
-}
-
 /** Writes the output values to output.txt
     - Parameter s: output message as a string
     - Parameter d_offset: distance between the target position and the landing position: the offset between the target position and the landing position (m)
@@ -624,7 +406,7 @@ do {
     throw "Error closing file."
 }
 var inParams: InputParameters = try InputParameters(filename)
-var t_flight: Float = try func_t_flight(&inParams)
+var t_flight: Float = 2.0 * inParams.v_launch * sin(inParams.theta) / inParams.g
 do {
     outfile = try FileHandle(forWritingTo: FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first!.appendingPathComponent("log.txt"))
     try outfile.seekToEnd()
@@ -652,7 +434,7 @@ do {
 } catch {
     throw "Error closing file."
 }
-var p_land: Float = try func_p_land(&inParams)
+var p_land: Float = 2.0 * pow(inParams.v_launch, 2.0) * sin(inParams.theta) * cos(inParams.theta) / inParams.g
 do {
     outfile = try FileHandle(forWritingTo: FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first!.appendingPathComponent("log.txt"))
     try outfile.seekToEnd()
@@ -680,7 +462,7 @@ do {
 } catch {
     throw "Error closing file."
 }
-var d_offset: Float = try func_d_offset(&inParams, p_land)
+var d_offset: Float = p_land - inParams.p_target
 do {
     outfile = try FileHandle(forWritingTo: FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first!.appendingPathComponent("log.txt"))
     try outfile.seekToEnd()
@@ -708,7 +490,7 @@ do {
 } catch {
     throw "Error closing file."
 }
-var s: String = try func_s(&inParams, d_offset)
+var s: String = abs(d_offset / inParams.p_target) < inParams.epsilon ? "The target was hit." : d_offset < 0.0 ? "The projectile fell short." : "The projectile went long."
 do {
     outfile = try FileHandle(forWritingTo: FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first!.appendingPathComponent("log.txt"))
     try outfile.seekToEnd()

--- a/code/stable/projectile/projectile_u_p_nol_u_wi_v_d/src/cpp/Projectile.cpp
+++ b/code/stable/projectile/projectile_u_p_nol_u_wi_v_d/src/cpp/Projectile.cpp
@@ -33,9 +33,13 @@ int main(int argc, const char *argv[]) {
     double p_target;
     get_input(filename, v_launch, theta, p_target);
     input_constraints(v_launch, theta, p_target);
+    // flight duration: the time when the projectile lands (s)
     double t_flight = 2.0 * v_launch * sin(theta) / g;
+    // landing position: the distance from the launcher to the final position of the projectile (m)
     double p_land = 2.0 * pow(v_launch, 2.0) * sin(theta) * cos(theta) / g;
+    // distance between the target position and the landing position: the offset between the target position and the landing position (m)
     double d_offset = p_land - p_target;
+    // output message as a string
     string s = fabs(d_offset / p_target) < epsilon ? "The target was hit." : d_offset < 0.0 ? "The projectile fell short." : "The projectile went long.";
     write_output(s, d_offset, t_flight);
     

--- a/code/stable/projectile/projectile_u_p_nol_u_wi_v_d/src/cpp/Projectile.cpp
+++ b/code/stable/projectile/projectile_u_p_nol_u_wi_v_d/src/cpp/Projectile.cpp
@@ -33,37 +33,13 @@ int main(int argc, const char *argv[]) {
     double p_target;
     get_input(filename, v_launch, theta, p_target);
     input_constraints(v_launch, theta, p_target);
-    double t_flight = func_t_flight(v_launch, theta, g);
-    double p_land = func_p_land(v_launch, theta, g);
-    double d_offset = func_d_offset(p_target, p_land);
-    string s = func_s(p_target, epsilon, d_offset);
+    double t_flight = 2.0 * v_launch * sin(theta) / g;
+    double p_land = 2.0 * pow(v_launch, 2.0) * sin(theta) * cos(theta) / g;
+    double d_offset = p_land - p_target;
+    string s = fabs(d_offset / p_target) < epsilon ? "The target was hit." : d_offset < 0.0 ? "The projectile fell short." : "The projectile went long.";
     write_output(s, d_offset, t_flight);
     
     return 0;
-}
-
-double func_t_flight(double v_launch, double theta, double g) {
-    return 2.0 * v_launch * sin(theta) / g;
-}
-
-double func_p_land(double v_launch, double theta, double g) {
-    return 2.0 * pow(v_launch, 2.0) * sin(theta) * cos(theta) / g;
-}
-
-double func_d_offset(double p_target, double p_land) {
-    return p_land - p_target;
-}
-
-string func_s(double p_target, double epsilon, double d_offset) {
-    if (fabs(d_offset / p_target) < epsilon) {
-        return "The target was hit.";
-    }
-    else if (d_offset < 0.0) {
-        return "The projectile fell short.";
-    }
-    else {
-        return "The projectile went long.";
-    }
 }
 
 void get_input(string filename, double &v_launch, double &theta, double &p_target) {

--- a/code/stable/projectile/projectile_u_p_nol_u_wi_v_d/src/cpp/Projectile.hpp
+++ b/code/stable/projectile/projectile_u_p_nol_u_wi_v_d/src/cpp/Projectile.hpp
@@ -16,37 +16,6 @@ using std::ifstream;
 using std::ofstream;
 using std::string;
 
-/** \brief Calculates flight duration: the time when the projectile lands (s)
-    \param v_launch launch speed: the initial speed of the projectile when launched (m/s)
-    \param theta launch angle: the angle between the launcher and a straight line from the launcher to the target (rad)
-    \param g magnitude of gravitational acceleration: the magnitude of the approximate acceleration due to gravity on Earth at sea level (m/s^2)
-    \return flight duration: the time when the projectile lands (s)
-*/
-double func_t_flight(double v_launch, double theta, double g);
-
-/** \brief Calculates landing position: the distance from the launcher to the final position of the projectile (m)
-    \param v_launch launch speed: the initial speed of the projectile when launched (m/s)
-    \param theta launch angle: the angle between the launcher and a straight line from the launcher to the target (rad)
-    \param g magnitude of gravitational acceleration: the magnitude of the approximate acceleration due to gravity on Earth at sea level (m/s^2)
-    \return landing position: the distance from the launcher to the final position of the projectile (m)
-*/
-double func_p_land(double v_launch, double theta, double g);
-
-/** \brief Calculates distance between the target position and the landing position: the offset between the target position and the landing position (m)
-    \param p_target target position: the distance from the launcher to the target (m)
-    \param p_land landing position: the distance from the launcher to the final position of the projectile (m)
-    \return distance between the target position and the landing position: the offset between the target position and the landing position (m)
-*/
-double func_d_offset(double p_target, double p_land);
-
-/** \brief Calculates output message as a string
-    \param p_target target position: the distance from the launcher to the target (m)
-    \param epsilon hit tolerance
-    \param d_offset distance between the target position and the landing position: the offset between the target position and the landing position (m)
-    \return output message as a string
-*/
-string func_s(double p_target, double epsilon, double d_offset);
-
 /** \brief Reads input from a file with the given file name
     \param filename name of the input file
     \param v_launch launch speed: the initial speed of the projectile when launched (m/s)

--- a/code/stable/projectile/projectile_u_p_nol_u_wi_v_d/src/cpp/designLog.txt
+++ b/code/stable/projectile/projectile_u_p_nol_u_wi_v_d/src/cpp/designLog.txt
@@ -6,7 +6,7 @@ Constant Representation selected as Var.
 Implementation Type selected as Program.
 Software Constraint Behaviour selected as Warning.
 Physical Constraint Behaviour selected as Warning.
-Comments selected as CommentFunc CommentClass CommentMod.
+Comments selected as CommentFunc CommentClass CommentMod CommentVarDecls.
 Dox Verbosity selected as Quiet.
 Dates selected as Hide.
 Log File Name selected as log.txt.

--- a/code/stable/projectile/projectile_u_p_nol_u_wi_v_d/src/csharp/Projectile.cs
+++ b/code/stable/projectile/projectile_u_p_nol_u_wi_v_d/src/csharp/Projectile.cs
@@ -21,9 +21,13 @@ public class Projectile {
         double p_target;
         get_input(filename, out v_launch, out theta, out p_target);
         input_constraints(v_launch, theta, p_target);
+        // flight duration: the time when the projectile lands (s)
         double t_flight = 2.0 * v_launch * Math.Sin(theta) / g;
+        // landing position: the distance from the launcher to the final position of the projectile (m)
         double p_land = 2.0 * Math.Pow(v_launch, 2.0) * Math.Sin(theta) * Math.Cos(theta) / g;
+        // distance between the target position and the landing position: the offset between the target position and the landing position (m)
         double d_offset = p_land - p_target;
+        // output message as a string
         string s = Math.Abs(d_offset / p_target) < epsilon ? "The target was hit." : d_offset < 0.0 ? "The projectile fell short." : "The projectile went long.";
         write_output(s, d_offset, t_flight);
     }

--- a/code/stable/projectile/projectile_u_p_nol_u_wi_v_d/src/csharp/Projectile.cs
+++ b/code/stable/projectile/projectile_u_p_nol_u_wi_v_d/src/csharp/Projectile.cs
@@ -21,58 +21,11 @@ public class Projectile {
         double p_target;
         get_input(filename, out v_launch, out theta, out p_target);
         input_constraints(v_launch, theta, p_target);
-        double t_flight = func_t_flight(v_launch, theta, g);
-        double p_land = func_p_land(v_launch, theta, g);
-        double d_offset = func_d_offset(p_target, p_land);
-        string s = func_s(p_target, epsilon, d_offset);
+        double t_flight = 2.0 * v_launch * Math.Sin(theta) / g;
+        double p_land = 2.0 * Math.Pow(v_launch, 2.0) * Math.Sin(theta) * Math.Cos(theta) / g;
+        double d_offset = p_land - p_target;
+        string s = Math.Abs(d_offset / p_target) < epsilon ? "The target was hit." : d_offset < 0.0 ? "The projectile fell short." : "The projectile went long.";
         write_output(s, d_offset, t_flight);
-    }
-    
-    /** \brief Calculates flight duration: the time when the projectile lands (s)
-        \param v_launch launch speed: the initial speed of the projectile when launched (m/s)
-        \param theta launch angle: the angle between the launcher and a straight line from the launcher to the target (rad)
-        \param g magnitude of gravitational acceleration: the magnitude of the approximate acceleration due to gravity on Earth at sea level (m/s^2)
-        \return flight duration: the time when the projectile lands (s)
-    */
-    public static double func_t_flight(double v_launch, double theta, double g) {
-        return 2.0 * v_launch * Math.Sin(theta) / g;
-    }
-    
-    /** \brief Calculates landing position: the distance from the launcher to the final position of the projectile (m)
-        \param v_launch launch speed: the initial speed of the projectile when launched (m/s)
-        \param theta launch angle: the angle between the launcher and a straight line from the launcher to the target (rad)
-        \param g magnitude of gravitational acceleration: the magnitude of the approximate acceleration due to gravity on Earth at sea level (m/s^2)
-        \return landing position: the distance from the launcher to the final position of the projectile (m)
-    */
-    public static double func_p_land(double v_launch, double theta, double g) {
-        return 2.0 * Math.Pow(v_launch, 2.0) * Math.Sin(theta) * Math.Cos(theta) / g;
-    }
-    
-    /** \brief Calculates distance between the target position and the landing position: the offset between the target position and the landing position (m)
-        \param p_target target position: the distance from the launcher to the target (m)
-        \param p_land landing position: the distance from the launcher to the final position of the projectile (m)
-        \return distance between the target position and the landing position: the offset between the target position and the landing position (m)
-    */
-    public static double func_d_offset(double p_target, double p_land) {
-        return p_land - p_target;
-    }
-    
-    /** \brief Calculates output message as a string
-        \param p_target target position: the distance from the launcher to the target (m)
-        \param epsilon hit tolerance
-        \param d_offset distance between the target position and the landing position: the offset between the target position and the landing position (m)
-        \return output message as a string
-    */
-    public static string func_s(double p_target, double epsilon, double d_offset) {
-        if (Math.Abs(d_offset / p_target) < epsilon) {
-            return "The target was hit.";
-        }
-        else if (d_offset < 0.0) {
-            return "The projectile fell short.";
-        }
-        else {
-            return "The projectile went long.";
-        }
     }
     
     /** \brief Reads input from a file with the given file name

--- a/code/stable/projectile/projectile_u_p_nol_u_wi_v_d/src/csharp/designLog.txt
+++ b/code/stable/projectile/projectile_u_p_nol_u_wi_v_d/src/csharp/designLog.txt
@@ -6,7 +6,7 @@ Constant Representation selected as Var.
 Implementation Type selected as Program.
 Software Constraint Behaviour selected as Warning.
 Physical Constraint Behaviour selected as Warning.
-Comments selected as CommentFunc CommentClass CommentMod.
+Comments selected as CommentFunc CommentClass CommentMod CommentVarDecls.
 Dox Verbosity selected as Quiet.
 Dates selected as Hide.
 Log File Name selected as log.txt.

--- a/code/stable/projectile/projectile_u_p_nol_u_wi_v_d/src/java/Projectile/Projectile.java
+++ b/code/stable/projectile/projectile_u_p_nol_u_wi_v_d/src/java/Projectile/Projectile.java
@@ -30,58 +30,11 @@ public class Projectile {
         theta = (double)(outputs[1]);
         p_target = (double)(outputs[2]);
         input_constraints(v_launch, theta, p_target);
-        double t_flight = func_t_flight(v_launch, theta, g);
-        double p_land = func_p_land(v_launch, theta, g);
-        double d_offset = func_d_offset(p_target, p_land);
-        String s = func_s(p_target, epsilon, d_offset);
+        double t_flight = 2.0 * v_launch * Math.sin(theta) / g;
+        double p_land = 2.0 * Math.pow(v_launch, 2.0) * Math.sin(theta) * Math.cos(theta) / g;
+        double d_offset = p_land - p_target;
+        String s = Math.abs(d_offset / p_target) < epsilon ? "The target was hit." : d_offset < 0.0 ? "The projectile fell short." : "The projectile went long.";
         write_output(s, d_offset, t_flight);
-    }
-    
-    /** \brief Calculates flight duration: the time when the projectile lands (s)
-        \param v_launch launch speed: the initial speed of the projectile when launched (m/s)
-        \param theta launch angle: the angle between the launcher and a straight line from the launcher to the target (rad)
-        \param g magnitude of gravitational acceleration: the magnitude of the approximate acceleration due to gravity on Earth at sea level (m/s^2)
-        \return flight duration: the time when the projectile lands (s)
-    */
-    public static double func_t_flight(double v_launch, double theta, double g) {
-        return 2.0 * v_launch * Math.sin(theta) / g;
-    }
-    
-    /** \brief Calculates landing position: the distance from the launcher to the final position of the projectile (m)
-        \param v_launch launch speed: the initial speed of the projectile when launched (m/s)
-        \param theta launch angle: the angle between the launcher and a straight line from the launcher to the target (rad)
-        \param g magnitude of gravitational acceleration: the magnitude of the approximate acceleration due to gravity on Earth at sea level (m/s^2)
-        \return landing position: the distance from the launcher to the final position of the projectile (m)
-    */
-    public static double func_p_land(double v_launch, double theta, double g) {
-        return 2.0 * Math.pow(v_launch, 2.0) * Math.sin(theta) * Math.cos(theta) / g;
-    }
-    
-    /** \brief Calculates distance between the target position and the landing position: the offset between the target position and the landing position (m)
-        \param p_target target position: the distance from the launcher to the target (m)
-        \param p_land landing position: the distance from the launcher to the final position of the projectile (m)
-        \return distance between the target position and the landing position: the offset between the target position and the landing position (m)
-    */
-    public static double func_d_offset(double p_target, double p_land) {
-        return p_land - p_target;
-    }
-    
-    /** \brief Calculates output message as a string
-        \param p_target target position: the distance from the launcher to the target (m)
-        \param epsilon hit tolerance
-        \param d_offset distance between the target position and the landing position: the offset between the target position and the landing position (m)
-        \return output message as a string
-    */
-    public static String func_s(double p_target, double epsilon, double d_offset) {
-        if (Math.abs(d_offset / p_target) < epsilon) {
-            return "The target was hit.";
-        }
-        else if (d_offset < 0.0) {
-            return "The projectile fell short.";
-        }
-        else {
-            return "The projectile went long.";
-        }
     }
     
     /** \brief Reads input from a file with the given file name

--- a/code/stable/projectile/projectile_u_p_nol_u_wi_v_d/src/java/Projectile/Projectile.java
+++ b/code/stable/projectile/projectile_u_p_nol_u_wi_v_d/src/java/Projectile/Projectile.java
@@ -30,9 +30,13 @@ public class Projectile {
         theta = (double)(outputs[1]);
         p_target = (double)(outputs[2]);
         input_constraints(v_launch, theta, p_target);
+        // flight duration: the time when the projectile lands (s)
         double t_flight = 2.0 * v_launch * Math.sin(theta) / g;
+        // landing position: the distance from the launcher to the final position of the projectile (m)
         double p_land = 2.0 * Math.pow(v_launch, 2.0) * Math.sin(theta) * Math.cos(theta) / g;
+        // distance between the target position and the landing position: the offset between the target position and the landing position (m)
         double d_offset = p_land - p_target;
+        // output message as a string
         String s = Math.abs(d_offset / p_target) < epsilon ? "The target was hit." : d_offset < 0.0 ? "The projectile fell short." : "The projectile went long.";
         write_output(s, d_offset, t_flight);
     }

--- a/code/stable/projectile/projectile_u_p_nol_u_wi_v_d/src/java/designLog.txt
+++ b/code/stable/projectile/projectile_u_p_nol_u_wi_v_d/src/java/designLog.txt
@@ -6,7 +6,7 @@ Constant Representation selected as Var.
 Implementation Type selected as Program.
 Software Constraint Behaviour selected as Warning.
 Physical Constraint Behaviour selected as Warning.
-Comments selected as CommentFunc CommentClass CommentMod.
+Comments selected as CommentFunc CommentClass CommentMod CommentVarDecls.
 Dox Verbosity selected as Quiet.
 Dates selected as Hide.
 Log File Name selected as log.txt.

--- a/code/stable/projectile/projectile_u_p_nol_u_wi_v_d/src/julia/designLog.txt
+++ b/code/stable/projectile/projectile_u_p_nol_u_wi_v_d/src/julia/designLog.txt
@@ -6,7 +6,7 @@ Constant Representation selected as Var.
 Implementation Type selected as Program.
 Software Constraint Behaviour selected as Warning.
 Physical Constraint Behaviour selected as Warning.
-Comments selected as CommentFunc CommentClass CommentMod.
+Comments selected as CommentFunc CommentClass CommentMod CommentVarDecls.
 Dox Verbosity selected as Quiet.
 Dates selected as Hide.
 Log File Name selected as log.txt.

--- a/code/stable/projectile/projectile_u_p_nol_u_wi_v_d/src/python/Projectile.py
+++ b/code/stable/projectile/projectile_u_p_nol_u_wi_v_d/src/python/Projectile.py
@@ -6,42 +6,6 @@
 import math
 import sys
 
-## \brief Calculates flight duration: the time when the projectile lands (s)
-# \param v_launch launch speed: the initial speed of the projectile when launched (m/s)
-# \param theta launch angle: the angle between the launcher and a straight line from the launcher to the target (rad)
-# \param g magnitude of gravitational acceleration: the magnitude of the approximate acceleration due to gravity on Earth at sea level (m/s^2)
-# \return flight duration: the time when the projectile lands (s)
-def func_t_flight(v_launch, theta, g):
-    return 2.0 * v_launch * math.sin(theta) / g
-
-## \brief Calculates landing position: the distance from the launcher to the final position of the projectile (m)
-# \param v_launch launch speed: the initial speed of the projectile when launched (m/s)
-# \param theta launch angle: the angle between the launcher and a straight line from the launcher to the target (rad)
-# \param g magnitude of gravitational acceleration: the magnitude of the approximate acceleration due to gravity on Earth at sea level (m/s^2)
-# \return landing position: the distance from the launcher to the final position of the projectile (m)
-def func_p_land(v_launch, theta, g):
-    return 2.0 * v_launch ** 2.0 * math.sin(theta) * math.cos(theta) / g
-
-## \brief Calculates distance between the target position and the landing position: the offset between the target position and the landing position (m)
-# \param p_target target position: the distance from the launcher to the target (m)
-# \param p_land landing position: the distance from the launcher to the final position of the projectile (m)
-# \return distance between the target position and the landing position: the offset between the target position and the landing position (m)
-def func_d_offset(p_target, p_land):
-    return p_land - p_target
-
-## \brief Calculates output message as a string
-# \param p_target target position: the distance from the launcher to the target (m)
-# \param epsilon hit tolerance
-# \param d_offset distance between the target position and the landing position: the offset between the target position and the landing position (m)
-# \return output message as a string
-def func_s(p_target, epsilon, d_offset):
-    if math.fabs(d_offset / p_target) < epsilon:
-        return "The target was hit."
-    elif d_offset < 0.0:
-        return "The projectile fell short."
-    else:
-        return "The projectile went long."
-
 ## \brief Reads input from a file with the given file name
 # \param filename name of the input file
 # \return launch speed: the initial speed of the projectile when launched (m/s)
@@ -111,8 +75,8 @@ g = 9.8
 epsilon = 2.0e-2
 v_launch, theta, p_target = get_input(filename)
 input_constraints(v_launch, theta, p_target)
-t_flight = func_t_flight(v_launch, theta, g)
-p_land = func_p_land(v_launch, theta, g)
-d_offset = func_d_offset(p_target, p_land)
-s = func_s(p_target, epsilon, d_offset)
+t_flight = 2.0 * v_launch * math.sin(theta) / g
+p_land = 2.0 * v_launch ** 2.0 * math.sin(theta) * math.cos(theta) / g
+d_offset = p_land - p_target
+s = "The target was hit." if math.fabs(d_offset / p_target) < epsilon else "The projectile fell short." if d_offset < 0.0 else "The projectile went long."
 write_output(s, d_offset, t_flight)

--- a/code/stable/projectile/projectile_u_p_nol_u_wi_v_d/src/python/Projectile.py
+++ b/code/stable/projectile/projectile_u_p_nol_u_wi_v_d/src/python/Projectile.py
@@ -75,8 +75,12 @@ g = 9.8
 epsilon = 2.0e-2
 v_launch, theta, p_target = get_input(filename)
 input_constraints(v_launch, theta, p_target)
+# flight duration: the time when the projectile lands (s)
 t_flight = 2.0 * v_launch * math.sin(theta) / g
+# landing position: the distance from the launcher to the final position of the projectile (m)
 p_land = 2.0 * v_launch ** 2.0 * math.sin(theta) * math.cos(theta) / g
+# distance between the target position and the landing position: the offset between the target position and the landing position (m)
 d_offset = p_land - p_target
+# output message as a string
 s = "The target was hit." if math.fabs(d_offset / p_target) < epsilon else "The projectile fell short." if d_offset < 0.0 else "The projectile went long."
 write_output(s, d_offset, t_flight)

--- a/code/stable/projectile/projectile_u_p_nol_u_wi_v_d/src/python/designLog.txt
+++ b/code/stable/projectile/projectile_u_p_nol_u_wi_v_d/src/python/designLog.txt
@@ -6,7 +6,7 @@ Constant Representation selected as Var.
 Implementation Type selected as Program.
 Software Constraint Behaviour selected as Warning.
 Physical Constraint Behaviour selected as Warning.
-Comments selected as CommentFunc CommentClass CommentMod.
+Comments selected as CommentFunc CommentClass CommentMod CommentVarDecls.
 Dox Verbosity selected as Quiet.
 Dates selected as Hide.
 Log File Name selected as log.txt.

--- a/code/stable/projectile/projectile_u_p_nol_u_wi_v_d/src/swift/designLog.txt
+++ b/code/stable/projectile/projectile_u_p_nol_u_wi_v_d/src/swift/designLog.txt
@@ -6,7 +6,7 @@ Constant Representation selected as Var.
 Implementation Type selected as Program.
 Software Constraint Behaviour selected as Warning.
 Physical Constraint Behaviour selected as Warning.
-Comments selected as CommentFunc CommentClass CommentMod.
+Comments selected as CommentFunc CommentClass CommentMod CommentVarDecls.
 Dox Verbosity selected as Quiet.
 Dates selected as Hide.
 Log File Name selected as log.txt.

--- a/code/stable/projectile/projectile_u_p_nol_u_wi_v_d/src/swift/main.swift
+++ b/code/stable/projectile/projectile_u_p_nol_u_wi_v_d/src/swift/main.swift
@@ -8,53 +8,6 @@ import Foundation
 
 extension String: Error {}
 
-/** Calculates flight duration: the time when the projectile lands (s)
-    - Parameter v_launch: launch speed: the initial speed of the projectile when launched (m/s)
-    - Parameter theta: launch angle: the angle between the launcher and a straight line from the launcher to the target (rad)
-    - Parameter g: magnitude of gravitational acceleration: the magnitude of the approximate acceleration due to gravity on Earth at sea level (m/s^2)
-    - Returns: flight duration: the time when the projectile lands (s)
-*/
-func func_t_flight(_ v_launch: Double, _ theta: Double, _ g: Double) -> Double {
-    return 2.0 * v_launch * sin(theta) / g
-}
-
-/** Calculates landing position: the distance from the launcher to the final position of the projectile (m)
-    - Parameter v_launch: launch speed: the initial speed of the projectile when launched (m/s)
-    - Parameter theta: launch angle: the angle between the launcher and a straight line from the launcher to the target (rad)
-    - Parameter g: magnitude of gravitational acceleration: the magnitude of the approximate acceleration due to gravity on Earth at sea level (m/s^2)
-    - Returns: landing position: the distance from the launcher to the final position of the projectile (m)
-*/
-func func_p_land(_ v_launch: Double, _ theta: Double, _ g: Double) -> Double {
-    return 2.0 * pow(v_launch, 2.0) * sin(theta) * cos(theta) / g
-}
-
-/** Calculates distance between the target position and the landing position: the offset between the target position and the landing position (m)
-    - Parameter p_target: target position: the distance from the launcher to the target (m)
-    - Parameter p_land: landing position: the distance from the launcher to the final position of the projectile (m)
-    - Returns: distance between the target position and the landing position: the offset between the target position and the landing position (m)
-*/
-func func_d_offset(_ p_target: Double, _ p_land: Double) -> Double {
-    return p_land - p_target
-}
-
-/** Calculates output message as a string
-    - Parameter p_target: target position: the distance from the launcher to the target (m)
-    - Parameter epsilon: hit tolerance
-    - Parameter d_offset: distance between the target position and the landing position: the offset between the target position and the landing position (m)
-    - Returns: output message as a string
-*/
-func func_s(_ p_target: Double, _ epsilon: Double, _ d_offset: Double) -> String {
-    if abs(d_offset / p_target) < epsilon {
-        return "The target was hit."
-    }
-    else if d_offset < 0.0 {
-        return "The projectile fell short."
-    }
-    else {
-        return "The projectile went long."
-    }
-}
-
 /** Reads input from a file with the given file name
     - Parameter filename: name of the input file
     - Returns: launch speed: the initial speed of the projectile when launched (m/s)
@@ -179,8 +132,8 @@ var theta: Double
 var p_target: Double
 (v_launch, theta, p_target) = try get_input(filename)
 input_constraints(v_launch, theta, p_target)
-var t_flight: Double = func_t_flight(v_launch, theta, g)
-var p_land: Double = func_p_land(v_launch, theta, g)
-var d_offset: Double = func_d_offset(p_target, p_land)
-var s: String = func_s(p_target, epsilon, d_offset)
+var t_flight: Double = 2.0 * v_launch * sin(theta) / g
+var p_land: Double = 2.0 * pow(v_launch, 2.0) * sin(theta) * cos(theta) / g
+var d_offset: Double = p_land - p_target
+var s: String = abs(d_offset / p_target) < epsilon ? "The target was hit." : d_offset < 0.0 ? "The projectile fell short." : "The projectile went long."
 try write_output(s, d_offset, t_flight)

--- a/code/stable/projectile/projectile_u_p_nol_u_wi_v_d/src/swift/main.swift
+++ b/code/stable/projectile/projectile_u_p_nol_u_wi_v_d/src/swift/main.swift
@@ -132,8 +132,12 @@ var theta: Double
 var p_target: Double
 (v_launch, theta, p_target) = try get_input(filename)
 input_constraints(v_launch, theta, p_target)
+// flight duration: the time when the projectile lands (s)
 var t_flight: Double = 2.0 * v_launch * sin(theta) / g
+// landing position: the distance from the launcher to the final position of the projectile (m)
 var p_land: Double = 2.0 * pow(v_launch, 2.0) * sin(theta) * cos(theta) / g
+// distance between the target position and the landing position: the offset between the target position and the landing position (m)
 var d_offset: Double = p_land - p_target
+// output message as a string
 var s: String = abs(d_offset / p_target) < epsilon ? "The target was hit." : d_offset < 0.0 ? "The projectile fell short." : "The projectile went long."
 try write_output(s, d_offset, t_flight)


### PR DESCRIPTION
Contributes to #1999, #3247, #3512

Not quite ready to merge yet, but, this PR makes the `Unmodular` code generation choice a bit more unmodular by removing the generated function calls in favour of inlining them.

~~Three~~ ~~Four~~ Five major issues:

1. Code comments are completely removed from the unmodular option -- the comments that previously went above the function declarations.
2. Code needs to be tidied.
3. ODE-related things are untested.
4. `GProc`-generating code is untouched.
5. I have not tested generating derived inputs yet.

I'm also not quite sure yet how we should integrate this in the options. Should these changes go under Unmodular? SuperUnmodular? SpaghettiMonster? I currently have it editing `Unmodular`.