### PR TITLE
GamePhysics: Move `defSymbols` to TermMap to avoid duplicates

### DIFF
--- a/code/drasil-example/gamephysics/lib/Drasil/GamePhysics/Body.hs
+++ b/code/drasil-example/gamephysics/lib/Drasil/GamePhysics/Body.hs
@@ -139,16 +139,16 @@ ideaDicts =
   doccon ++ educon ++ prodtcon ++
   -- CIs
   map nw [progName, centreMass] ++ map nw doccon' ++ map nw CM.mathcon' ++
-  map nw CP.physicCon'
+  map nw CP.physicCon' ++
+  -- DefinedQuantityDicts
+  map nw defSymbols
   
 conceptChunks :: [ConceptChunk]
 conceptChunks = 
   -- ConceptChunks
   algorithm : softwarecon ++ CP.physicCon ++ CM.mathcon ++ srsDomains ++
   -- InstanceModels
-  map cw iMods ++
-  -- DefinedQuantityDicts
-  map cw defSymbols
+  map cw iMods
 
 symbMap :: ChunkDB
 symbMap = cdb symbolsAll ideaDicts conceptChunks


### PR DESCRIPTION
Contributes to #4036

After making this change I realized that it might only hurt with resolving #4126; maybe @balacij could take a look to see if this is a good change or not? I am not sure what is more of a priority at this point, having no duplicates within chunk tables or no duplicates across _all_ chunk tables.

