### PR TITLE
Projectile: `outputMessage` chunk is already added in symbol table, unecessary in term table

### DIFF
--- a/code/drasil-example/projectile/lib/Drasil/Projectile/Body.hs
+++ b/code/drasil-example/projectile/lib/Drasil/Projectile/Body.hs
@@ -167,7 +167,7 @@ tMods = [accelerationTM, velocityTM]
 ideaDicts :: [IdeaDict]
 ideaDicts =
   -- Actual IdeaDicts
-  [sciCompS, projMotion, rectVel] ++ doccon ++ educon ++ compcon ++ unitalIdeas ++
+  [sciCompS, projMotion, rectVel] ++ doccon ++ educon ++ compcon ++
   -- CIs
   nw progName : map nw doccon' ++ map nw physicCon'
 
@@ -309,9 +309,6 @@ outputs = [message, qw offset, qw flightDur]
 
 unitalQuants :: [QuantityDict]
 unitalQuants = message : map qw constrained
-
-unitalIdeas :: [IdeaDict]
-unitalIdeas = [nw message]
 
 inConstraints :: [UncertQ]
 inConstraints = [launAngleUnc, launSpeedUnc, targPosUnc]


### PR DESCRIPTION
Contributes to #4126 

The chunk `outputMessage` is already added in the `unitalQuants` list, and is not needed in the `unitalIdeas` list. `unitalIdeas` had this chunk as its only entry, so it can be removed as well.