### PR TITLE
Create `DrasilConcept` typeclass that directs to a chunk that defines the meaning of the instantiated class' name.

### DIFF
--- a/code/drasil-docLang/lib/Drasil/DocumentLanguage.hs
+++ b/code/drasil-docLang/lib/Drasil/DocumentLanguage.hs
@@ -66,6 +66,7 @@ import Data.Maybe (maybeToList)
 import Drasil.Sections.ReferenceMaterial (emptySectSentPlu)
 
 -- * Main Function
+
 -- | Creates a document from a document description, a title combinator function, and system information.
 mkDoc :: SRSDecl -> (IdeaDict -> IdeaDict -> Sentence) -> System -> Document
 mkDoc dd comb si@SI {_sys = sys, _kind = kind, _authors = docauthors} =

--- a/code/drasil-lang/lib/Language/Drasil.hs
+++ b/code/drasil-lang/lib/Language/Drasil.hs
@@ -58,6 +58,7 @@ module Language.Drasil (
   , Definition(defn)
   , ConceptDomain(cdom)
   , Concept
+  , DrasilConcept(metaConcept)
   , HasSpace(typ)
   , HasUnitSymbol(usymb)
   , Quantity
@@ -334,9 +335,11 @@ import Language.Drasil.Unicode (RenderSpecial(..), Special(..))
 import Drasil.Database.UID
     (UID, HasUID(..), (+++), (+++.), (+++!), mkUid, nsUid, showUID)
 import Language.Drasil.Symbol (HasSymbol(symbol), Decoration, Symbol)
-import Language.Drasil.Classes (Definition(defn), ConceptDomain(cdom), Concept, HasUnitSymbol(usymb),
-  IsUnit(getUnits), CommonIdea(abrv), HasAdditionalNotes(getNotes), Constrained(constraints),
-  HasReasVal(reasVal), DefiningExpr(defnExpr), Quantity, Express(..))
+import Language.Drasil.Classes (Definition(defn), ConceptDomain(cdom),
+  CommonIdea(abrv), Concept, DrasilConcept(metaConcept),
+  HasUnitSymbol(usymb), IsUnit(getUnits),HasAdditionalNotes(getNotes),
+  Constrained(constraints), HasReasVal(reasVal), DefiningExpr(defnExpr),
+  Quantity, Express(..))
 import Language.Drasil.Derivation (Derivation(Derivation), mkDeriv, mkDerivName, mkDerivNoHeader, MayHaveDerivation(..))
 import Language.Drasil.Data.Date (Month(..))
 import Language.Drasil.Chunk.Citation (

--- a/code/drasil-lang/lib/Language/Drasil/Classes.hs
+++ b/code/drasil-lang/lib/Language/Drasil/Classes.hs
@@ -36,7 +36,7 @@ import Language.Drasil.Space (HasSpace)
 import Language.Drasil.Sentence (Sentence)
 import Drasil.Database.UID (UID)
 
-import Control.Lens (Lens')
+import Control.Lens (Lens', Getter)
 
 -- TODO: conceptual typeclass?
 -- TODO: I was thinking of splitting QDefinitions into Definitions with 2 type variables
@@ -61,11 +61,15 @@ class ConceptDomain c where
   -- ^ /cdom/ should be exported for use by the
   -- Drasil framework, but should not be exported beyond that.
 
--- TODO: conceptual type synonym?
 -- | Concepts are 'Idea's with definitions and domains.
 type Concept c = (Idea c, Definition c, ConceptDomain c)
--- TODO: Would the below make this a bit better to work with?
---        type Concept = forall c. (Idea c, Definition c, ConceptDomain c) => c
+
+-- | What does this chunk type encode?
+-- 
+-- All chunk types in Drasil should instantiate this class.
+class DrasilConcept c where
+  -- | Provide the 'UID' to the 'ConceptChunk' that explains what 'c' is.
+  metaConcept :: Getter c UID
 
 -- | CommonIdea is a 'NamedIdea' with the additional
 -- constraint that it __must__ have an abbreviation. This is the main

--- a/code/drasil-lang/lib/Language/Drasil/Classes.hs
+++ b/code/drasil-lang/lib/Language/Drasil/Classes.hs
@@ -7,9 +7,10 @@ module Language.Drasil.Classes (
     NamedIdea(term)
   , Idea(getA)
   , CommonIdea(abrv)
-  , Concept
   , Definition(defn)
   , ConceptDomain(cdom)
+  , Concept
+  , DrasilConcept(metaConcept)
   , Quantity
   , HasUnitSymbol(usymb)
   , HasReasVal(reasVal)


### PR DESCRIPTION
Contributes to #3314 

I'm a little bit confused now by what `DrasilConcept` should be doing, and I think we need to clarify the terminology. This PR should most likely not be merged as-is.

### Braindump

The 'Concept' typeclass provides information about the specific thing that an instance of a chunk (of type 'c') embodies. So, when I went to build `DrasilConcept`, I figured that it should point to the related `ConceptChunk` that explains what 'c' means (e.g., a `ConceptChunk` that defines what `Theory Model` means). And that's how I ended up with this implementation:

```haskell
-- | What does this chunk type encode?
-- 
-- All chunk types in Drasil should instantiate this class.
class DrasilConcept c where
  -- | Provide the 'UID' to the 'ConceptChunk' that defines the concept type.
  metaConcept :: Getter c UID
```

Now three questions immediately arose:

#### 1. Why point to another chunk?

##### 1.1. Why to _another chunk_?

Well, that's just working on an assumption: that we want to capture "metadata" chunks as well, and keep them in close proximity to our "data" chunks, capturing information about their relationships.

##### 1.2. Why _only point_?

Because the other chunk should exist already, and duplicating the type class fields with "meta" versions is unnecessary.

#### 2. Why point to a `ConceptChunk` specifically?

In my head, this was just the most obvious thing to point to because we need to be able to point to something that defines our Drasil terminology, and using our current `ChunkDB`, we need to be able to resolve references to a single type. `ConceptChunk` is the most appropriate because it is the infimum of all chunks that instantiate `Concept`. But it might not be the right thing. As @JacquesCarette mentioned in https://github.com/JacquesCarette/Drasil/issues/3314#issuecomment-3053378405: 

> Concept is great because it defines things by "what information must be present" instead of by "a concrete representation".

So, an alternative design might look like the following, where it points towards another chunk that must have the necessary "conceptual" information:

```haskell
-- | What does this chunk type encode?
-- 
-- All chunk types in Drasil should instantiate this class.
class Concept cd => DrasilConcept c cd where
  -- | Provide the 'UID' to a chunk (of type 'cd') that explains what 'c' is.
  metaConcept :: Getter c cd
```

Or, there could be yet another alternative version that recreates the 5 requirements of `Concept` (i.e., term, maybe abbreviation, concept domain, definition, `UID`) a bit more 'directly' (immediately returning the values), perhaps without the `UID`.

#### 3. Hold on. Where do mandatory abbreviations fit in?

Recall: @JacquesCarette mentioned `DrasilConcept` in https://github.com/JacquesCarette/Drasil/issues/3314#issuecomment-2116307350:

> What's implicit in the above is that we need to split DrasilConcept out from Concept, i.e. those concepts that we use for ourselves can have much higher requirements, such as making the abbreviation manditory.

The context is `CI`, which is essentially an `IdeaDict` (recall: vocabulary: noun + maybe abbreviation) with the requirement that the abbreviation _must_ exist. Now, a `CI` could not fulfill the requirements of a `Concept` because it has no definition of the noun it declares.

##### 3.1. Should `CI` also carry a definition?

If some concepts so common/required to have an abbreviation, shouldn't they also be required to have a (prose) definition as well?

### Additional Notes

In the future, when we have typed `UID` references, the `UID` references should also be typed. This might be something good to consider in current design.
