### PR TITLE
Remove `cuc` constructor, creating DefinedQuantityDicts instead

### DIFF
--- a/code/drasil-example/glassbr/lib/Drasil/GlassBR/Symbols.hs
+++ b/code/drasil-example/glassbr/lib/Drasil/GlassBR/Symbols.hs
@@ -13,7 +13,7 @@ import Data.List ((\\))
 
 symbolsForSymbolTable :: [QuantityDict]
 symbolsForSymbolTable = symbolsForTermTable ++ map qw unitalSymbols ++
-  unitless ++ map qw [probBr, stressDistFac, nomThick, cnstrw glassTypeCon] ++
+  unitless ++ map qw [probBr, stressDistFac, cnstrw nomThick, cnstrw glassTypeCon] ++
   map qw derivedInputDataConstraints
 
 symbolsForTermTable :: [QuantityDict]

--- a/code/drasil-example/glassbr/lib/Drasil/GlassBR/Unitals.hs
+++ b/code/drasil-example/glassbr/lib/Drasil/GlassBR/Unitals.hs
@@ -22,14 +22,13 @@ import Drasil.GlassBR.Units (sFlawPU)
 {--}
 
 constrained :: [ConstrainedChunk]
-constrained = map cnstrw dataConstraints ++ [nomThick, cnstrw glassTypeCon]
+constrained = map cnstrw dataConstraints ++ map cnstrw [nomThick, glassTypeCon]
  -- map cnstrw inputDataConstraints ++ map cnstrw derivedInputDataConstraints -- ++
   -- [cnstrw probBr, cnstrw probFail, cnstrw stressDistFac, cnstrw nomThick, cnstrw glassTypeCon]
 
 plateLen, plateWidth, aspectRatio, charWeight, standOffDist :: UncertQ
 pbTol, tNT :: UncertainChunk
-nomThick :: ConstrainedChunk
-glassTypeCon :: ConstrConcept
+glassTypeCon, nomThick :: ConstrConcept
 
 {--}
 
@@ -47,7 +46,7 @@ inputsWUncrtn = [pbTol, tNT]
 
 --inputs with no uncertainties
 inputsNoUncrtn :: [ConstrainedChunk]
-inputsNoUncrtn = [cnstrw glassTypeCon, nomThick]
+inputsNoUncrtn = map cnstrw [glassTypeCon, nomThick]
 
 --derived inputs with units and uncertainties
 derivedInsWUnitsUncrtn :: [UncertQ]
@@ -102,9 +101,10 @@ standOffDist = uq (constrained' (uc sD (variable "SD") Real metre)
   [ gtZeroConstr,
     sfwrRange $ Bounded (Inc, sy sdMin) (Inc, sy sdMax)] (exactDbl 45)) defaultUncrt
 
-nomThick = cuc "nomThick"
+nomThick = cuc' "nomThick"
   (nounPhraseSent $ S "nominal thickness t is in" +:+ eS (mkSet Rational (map dbl nominalThicknesses)))
-  lT millimetre {-Discrete nominalThicknesses, but not implemented-} Rational
+  "the specified standard thickness of the glass plate" lT millimetre
+  {-Discrete nominalThicknesses, but not implemented-} Rational
   [sfwrElem $ mkSet Rational (map dbl nominalThicknesses)] $ exactDbl 8 -- for testing
 
 glassTypeCon = constrainedNRV' (dqdNoUnit glassTy lG String)

--- a/code/drasil-lang/lib/Language/Drasil.hs
+++ b/code/drasil-lang/lib/Language/Drasil.hs
@@ -132,7 +132,7 @@ module Language.Drasil (
   , physRange, sfwrRange, physElem, sfwrElem, isPhysC, isSfwrC
   -- Language.Drasil.Chunk.Constrained
   , ConstrainedChunk(..), ConstrConcept(..)
-  , cuc, cvc, constrained', cuc', cuc'', constrainedNRV'
+  , cvc, constrained', cuc', cuc'', constrainedNRV'
   , cnstrw, cnstrw'
   -- Language.Drasil.Chunk.UncertainQuantity
   , UncertainChunk(..), UncertQ, uq, uqc, uqcND, uncrtnChunk, uvc

--- a/code/drasil-lang/lib/Language/Drasil/Chunk/Constrained.hs
+++ b/code/drasil-lang/lib/Language/Drasil/Chunk/Constrained.hs
@@ -3,7 +3,7 @@
 module Language.Drasil.Chunk.Constrained (
   -- * Constrained Chunks
   -- ** From an Idea
-  ConstrainedChunk(..), cuc, cvc, cnstrw,
+  ConstrainedChunk(..), cvc, cnstrw,
   -- ** From a Concept
   ConstrConcept(..),
   cnstrw', constrained', constrainedNRV', cuc', cuc'') where
@@ -14,7 +14,6 @@ import Language.Drasil.Chunk.Concept (cw, dcc)
 import Language.Drasil.Chunk.DefinedQuantity (DefinedQuantityDict, dqd, dqd', dqdWr)
 import Language.Drasil.Chunk.Quantity (QuantityDict, qw, vc)
 import Language.Drasil.Chunk.Unital (uc')
-import Language.Drasil.Chunk.Unitary (unitary)
 import Language.Drasil.Symbol (HasSymbol(..), Symbol)
 import Language.Drasil.Classes (NamedIdea(term), Idea(getA), Express(express),
   Definition(defn), ConceptDomain(cdom), Concept, Quantity,
@@ -60,11 +59,6 @@ instance HasReasVal    ConstrainedChunk where reasVal     = reasV
 instance Eq            ConstrainedChunk where c1 == c2 = (c1 ^. qd . uid) == (c2 ^. qd . uid)
 -- | Finds units contained in the 'QuantityDict' used to make the 'ConstrainedChunk'.
 instance MayHaveUnit   ConstrainedChunk where getUnit = getUnit . view qd
-
--- | Creates a constrained unitary chunk from a 'UID', term ('NP'), 'Symbol', unit, 'Space', 'Constraint's, and an 'Expr'.
-cuc :: (IsUnit u) => String -> NP -> Symbol -> u
-  -> Space -> [ConstraintE] -> Expr -> ConstrainedChunk
-cuc i t s u space cs rv = ConstrainedChunk (qw (unitary i t s u space)) cs (Just rv)
 
 -- | Creates a constrained unitary chunk from a 'UID', term ('NP'), 'Symbol', 'Space', 'Constraint's, and a 'Maybe' 'Expr' (Similar to 'cuc' but no units).
 cvc :: String -> NP -> Symbol -> Space -> [ConstraintE] -> Maybe Expr -> ConstrainedChunk


### PR DESCRIPTION
Contributes to #4272

Since `cuc` is removed, `unitary` is no longer nested in any other functions. Now `unitary` would just need to be fixed to support DefinedQuantityDicts, and then its uses updated with definitions.