### PR TITLE
Draft implementation of `SystemKind`.

### DIFF
--- a/code/drasil-docLang/lib/Drasil/DocumentLanguage.hs
+++ b/code/drasil-docLang/lib/Drasil/DocumentLanguage.hs
@@ -68,8 +68,8 @@ import Drasil.Sections.ReferenceMaterial (emptySectSentPlu)
 -- * Main Function
 -- | Creates a document from a document description, a title combinator function, and system information.
 mkDoc :: SRSDecl -> (IdeaDict -> IdeaDict -> Sentence) -> System -> Document
-mkDoc dd comb si@SI {_sys = sys, _kind = kind, _authors = docauthors} =
-  Document (nw kind `comb` nw sys) (foldlList Comma List $ map (S . name) docauthors) (findToC l) $
+mkDoc dd comb si@SI {_sys = sys, _authors = docauthors} =
+  Document (whatsTheBigIdea si `comb` nw sys) (foldlList Comma List $ map (S . name) docauthors) (findToC l) $
   mkSections fullSI l where
     fullSI = fillcdbSRS dd si
     l = mkDocDesc fullSI dd

--- a/code/drasil-docLang/lib/Drasil/DocumentLanguage/Notebook/DocumentLanguage.hs
+++ b/code/drasil-docLang/lib/Drasil/DocumentLanguage/Notebook/DocumentLanguage.hs
@@ -7,7 +7,7 @@ import Drasil.DocumentLanguage.Notebook.Core (LsnDesc, LsnChapter(..),
 
 import Language.Drasil hiding (kind)
 
-import System.Drasil (System(SI), _authors, _kind, _sys)
+import System.Drasil (System(SI), _authors, _sys, whatsTheBigIdea)
 import Drasil.GetChunks (citeDB)
 
 import qualified Drasil.DocLang.Notebook as Lsn (intro, learnObj, caseProb, example, 
@@ -15,8 +15,8 @@ import qualified Drasil.DocLang.Notebook as Lsn (intro, learnObj, caseProb, exam
 
 -- | Creates a notebook from a lesson description and system information.
 mkNb :: LsnDecl -> (IdeaDict -> IdeaDict -> Sentence) -> System -> Document
-mkNb dd comb si@SI {_sys = sys, _kind = kind, _authors = authors} =
-  Notebook (nw kind `comb` nw sys) (foldlList Comma List $ map (S . name) authors) $
+mkNb dd comb si@SI {_sys = sys, _authors = authors} =
+  Notebook (whatsTheBigIdea si `comb` nw sys) (foldlList Comma List $ map (S . name) authors) $
   mkSections si l where
     l = mkLsnDesc si dd
 

--- a/code/drasil-example/ssp/lib/Drasil/SSP/Body.hs
+++ b/code/drasil-example/ssp/lib/Drasil/SSP/Body.hs
@@ -19,7 +19,6 @@ import Data.Drasil.Concepts.Documentation as Doc (analysis, assumption,
   physical, physics, problem, software, softwareSys, srsDomains, symbol_,
   sysCont, system, type_, user, value, variable, doccon, doccon',
   datumConstraint)
-import qualified Data.Drasil.Concepts.Documentation as Doc (srs)
 import Data.Drasil.TheoryConcepts as Doc (inModel)
 import Data.Drasil.Concepts.Education (solidMechanics, undergraduate, educon)
 import Data.Drasil.Concepts.Math (equation, shape, surface, mathcon, mathcon',
@@ -53,6 +52,8 @@ import Drasil.SSP.TMods (tMods)
 import Drasil.SSP.Unitals (constrained, effCohesion, fricAngle, fs, index,
   inputs, inputsWUncrtn, outputs, symbols)
 
+import System.Drasil (System(..), SystemKind(SRS))
+
 --Document Setup--
 
 srs :: Document
@@ -70,7 +71,7 @@ resourcePath = "../../../../datafiles/ssp/"
 si :: System
 si = SI {
   _sys         = progName, 
-  _kind        = Doc.srs, 
+  _kind        = SRS, 
   _authors     = [henryFrankis, brooks],
   _purpose     = [purp],
   _background  = [],

--- a/code/drasil-example/ssp/package.yaml
+++ b/code/drasil-example/ssp/package.yaml
@@ -30,6 +30,7 @@ dependencies:
 - drasil-lang
 - drasil-metadata
 - drasil-printers
+- drasil-system
 - drasil-theory
 - drasil-utils
 

--- a/code/drasil-system/lib/System/Drasil.hs
+++ b/code/drasil-system/lib/System/Drasil.hs
@@ -1,10 +1,14 @@
 module System.Drasil (
-  -- * System Information
-    System(..)
-  -- * Lenses
-  , HasSystem(..)
+  -- * System
+  -- ** Types
+  System(..), SystemKind(..),
+  -- ** Lenses
+  HasSystem(..),
+  -- ** Functions
+  whatsTheBigIdea,
   -- * Reference Database
-  , Purpose, Background, Scope, Motivation
+  -- ** Types
+  Purpose, Background, Scope, Motivation,
 ) where
 
 import System.Drasil.System

--- a/code/drasil-system/lib/System/Drasil/System.hs
+++ b/code/drasil-system/lib/System/Drasil/System.hs
@@ -6,21 +6,24 @@
 -- https://github.com/JacquesCarette/Drasil/wiki/Creating-Your-Project-in-Drasil
 
 module System.Drasil.System (
-  -- * System Information
+  -- * System
   -- ** Types
-  System(..),
+  System(..), SystemKind(..),
   -- ** Lenses
   HasSystem(..),
+  -- ** Functions
+  whatsTheBigIdea,
   -- * Reference Database
   -- ** Types
   Purpose, Background, Scope, Motivation,
   ) where
 
-import Language.Drasil
+import Language.Drasil hiding (kind, Notebook)
 import Theory.Drasil
 import Database.Drasil (ChunkDB)
 
 import Control.Lens (makeClassy)
+import qualified Data.Drasil.Concepts.Documentation as Doc
 
 -- | Project Example purpose.
 type Purpose = [Sentence]
@@ -31,6 +34,19 @@ type Scope = [Sentence]
 -- | Project Example motivation.
 type Motivation = [Sentence]
 
+data SystemKind =
+    SRS
+  | Notebook
+  | Website
+
+whatsTheBigIdea :: System -> IdeaDict
+whatsTheBigIdea si = whatKind' (_kind si)
+  where
+    whatKind' :: SystemKind -> IdeaDict
+    whatKind' SRS = nw Doc.srs
+    whatKind' Notebook = nw Doc.notebook
+    whatKind' Website = mkIdea "website" (cn "website") (Just "web")
+
 -- | Data structure for holding all of the requisite information about a system
 -- to be used in artifact generation.
 data System where
@@ -39,13 +55,12 @@ data System where
 -- I'm thinking for getting concepts that are also quantities, we could
 -- use a lookup of some sort from their internal (Drasil) ids.
  SI :: (CommonIdea a, Idea a,
-  Idea b,
   Quantity e, Eq e, MayHaveUnit e,
   Quantity h, MayHaveUnit h,
   Quantity i, MayHaveUnit i,
   HasUID j, Constrained j) => 
   { _sys         :: a
-  , _kind        :: b
+  , _kind        :: SystemKind
   , _authors     :: People
   , _purpose     :: Purpose
   , _background  :: Background

--- a/code/drasil-system/package.yaml
+++ b/code/drasil-system/package.yaml
@@ -18,6 +18,7 @@ dependencies:
 - pretty
 - lens
 - containers
+- drasil-data
 - drasil-database
 - drasil-lang
 - drasil-theory


### PR DESCRIPTION
Contributes to #3260

Creating this PR as a draft because:

1. It's a draft implementation.
2. The CI will fail because I didn't propagate all `System`-related changes across all case studies -- only SSP.
