### PR TITLE
Capture abbreviations in ConceptChunk constructors

### DIFF
--- a/code/drasil-example/dblpend/lib/Drasil/DblPend/GenDefs.hs
+++ b/code/drasil-example/dblpend/lib/Drasil/DblPend/GenDefs.hs
@@ -218,8 +218,9 @@ xForceGD_1 = gdNoRefs (equationalRealmU "xForce1" xForceMD_1)
 
 xForceMD_1 :: MultiDefn ModelExpr
 xForceMD_1 = mkMultiDefnForQuant quant EmptyS defns
-    where quant = mkQuant' "force" (horizontalForce `onThe` firstObject)
-                    Nothing Real (symbol force) (getUnit force)
+    where quant = dqd' (dccWDS "force" (horizontalForce `onThe` firstObject)
+                    (S "the horizontal force acting on the first object"))
+                    (symbol force) Real (getUnit force)
           defns = NE.fromList [
                     mkDefiningExpr "xForceWithMass1"
                       [] EmptyS $ express $ forceGQD ^. defnExpr,
@@ -238,8 +239,9 @@ yForceGD_1 = gdNoRefs (equationalRealmU "yForce1" yForceMD_1)
 
 yForceMD_1 :: MultiDefn ModelExpr
 yForceMD_1 = mkMultiDefnForQuant quant EmptyS defns
-    where quant = mkQuant' "force" (verticalForce `onThe` firstObject)
-                    Nothing Real (symbol force) (getUnit force)
+    where quant = dqd' (dccWDS "force" (verticalForce `onThe` firstObject)
+                    (S "the vertical force acting on the first object"))
+                    (symbol force) Real (getUnit force)
           defns = NE.fromList [
                     mkDefiningExpr "yForceWithMass1"
                       [] EmptyS $ express $ forceGQD ^. defnExpr,
@@ -258,8 +260,9 @@ xForceGD_2 = gdNoRefs (equationalRealmU "xForce2" xForceMD_2)
 
 xForceMD_2 :: MultiDefn ModelExpr
 xForceMD_2 = mkMultiDefnForQuant quant EmptyS defns
-    where quant = mkQuant' "force" (horizontalForce `onThe` secondObject)
-                    Nothing Real (symbol force) (getUnit force)
+    where quant = dqd' (dccWDS "force" (horizontalForce `onThe` secondObject)
+                    (S "the horizontal force acting on the second object"))
+                    (symbol force) Real (getUnit force)
           defns = NE.fromList [
                     mkDefiningExpr "xForceWithMass2"
                       [] EmptyS $ express $ forceGQD ^. defnExpr,
@@ -278,8 +281,9 @@ yForceGD_2 = gdNoRefs (equationalRealmU "yForce2" yForceMD_2)
 
 yForceMD_2 :: MultiDefn ModelExpr
 yForceMD_2 = mkMultiDefnForQuant quant EmptyS defns
-    where quant = mkQuant' "force" (verticalForce `onThe` secondObject)
-                    Nothing Real (symbol force) (getUnit force)
+    where quant = dqd' (dccWDS "force" (verticalForce `onThe` secondObject)
+                    (S "the vertical force acting on the second object"))
+                    (symbol force) Real (getUnit force)
           defns = NE.fromList [
                     mkDefiningExpr "yForceWithMass2"
                       [] EmptyS $ express $ forceGQD ^. defnExpr,

--- a/code/drasil-example/gamephysics/lib/Drasil/GamePhysics/TMods.hs
+++ b/code/drasil-example/gamephysics/lib/Drasil/GamePhysics/TMods.hs
@@ -58,8 +58,9 @@ newtonLUG = tmNoRefs newtonLUGModel
   qw dispNorm, qw dVect, qw distMass] ([] :: [ConceptChunk])
   [] [express newtonLUGModel] [] "UniversalGravLaw" newtonLUGNotes
 
-newtonForceQuant :: QuantityDict
-newtonForceQuant = mkQuant' "force" (nounPhraseSP "Newton's law of universal gravitation") Nothing Real (symbol force) Nothing
+newtonForceQuant :: DefinedQuantityDict
+newtonForceQuant = dqd' (dcc "force" (nounPhraseSP "Newton's law of universal gravitation") 
+                    "the gravitational force between two masses") (symbol force) Real Nothing
 
 -- Can't include fractions within a sentence (in the part where 'r denotes the
 -- unit displacement vector, equivalent to r/||r||' (line 184)). Changed to a

--- a/code/drasil-example/sglpend/lib/Drasil/SglPend/GenDefs.hs
+++ b/code/drasil-example/sglpend/lib/Drasil/SglPend/GenDefs.hs
@@ -142,8 +142,9 @@ hForceOnPendulumGD = gdNoRefs (equationalRealmU "hForceOnPendulum" hForceOnPendu
 
 hForceOnPendulumMD :: MultiDefn ModelExpr
 hForceOnPendulumMD = mkMultiDefnForQuant quant EmptyS defns
-    where quant = mkQuant' "force" (horizontalForce `onThe` pendulum)
-                    Nothing Real (symbol force) (getUnit force)
+    where quant = dqd' (dccWDS "force" (horizontalForce `onThe` pendulum)
+                    (S "the horizontal force acting on the pendulum"))
+                    (symbol force) Real (getUnit force)
           defns = NE.fromList [
                     mkDefiningExpr "hForceOnPendulumViaComponent"
                       [] EmptyS $ express E.hForceOnPendulumViaComponent,
@@ -161,8 +162,9 @@ vForceOnPendulumGD = gdNoRefs (equationalRealmU "vForceOnPendulum" vForceOnPendu
 
 vForceOnPendulumMD :: MultiDefn ModelExpr
 vForceOnPendulumMD = mkMultiDefnForQuant quant EmptyS defns
-    where quant = mkQuant' "force" (verticalForce `onThe` pendulum)
-                    Nothing Real (symbol force) (getUnit force)
+    where quant = dqd' (dccWDS "force" (verticalForce `onThe` pendulum)
+                    (S "the vertical force acting on the pendulum"))
+                    (symbol force) Real (getUnit force)
           defns = NE.fromList [
                     mkDefiningExpr "vForceOnPendulumViaComponent"
                       [] EmptyS $ express E.vForceOnPendulumViaComponent,

--- a/code/drasil-lang/lib/Language/Drasil/Chunk/Concept.hs
+++ b/code/drasil-lang/lib/Language/Drasil/Chunk/Concept.hs
@@ -2,7 +2,7 @@
 module Language.Drasil.Chunk.Concept (
   -- * Concept Chunks
   -- ** From an idea ('IdeaDict')
-  ConceptChunk, dcc, dccWDS, cc, cc', ccs, cw,
+  ConceptChunk, dcc, dccA, dccAWDS, dccWDS, cc, cc', ccs, cw,
   -- ** From a 'ConceptChunk'
   ConceptInstance, cic
   ) where
@@ -18,16 +18,24 @@ import Drasil.Database.UID (HasUID(uid), nsUid)
 import Control.Lens ((^.))
 
 --FIXME: Temporary ConceptDomain tag hacking to not break everything. 
- 
+
+-- | Smart constructor for creating a concept chunks with an abbreviation
+-- Takes a UID (String), a term (NounPhrase), a definition (String), and an abbreviation (Maybe String).
+dccA :: String -> NP -> String -> Maybe String -> ConceptChunk
+dccA i ter des a = ConDict (mkIdea i ter a) (S des) []
+
+dccAWDS :: String -> NP -> Sentence -> Maybe String -> ConceptChunk
+dccAWDS i t d a = ConDict (mkIdea i t a) d []
+
 dcc :: String -> NP -> String -> ConceptChunk 
 -- | Smart constructor for creating concept chunks given a 'UID', 
 -- 'NounPhrase' ('NP') and definition (as a 'String').
-dcc i ter des = ConDict (mkIdea i ter Nothing) (S des) []
+dcc i ter des = dccA i ter des Nothing
 -- ^ Concept domain tagging is not yet implemented in this constructor.
 
 -- | Similar to 'dcc', except the definition takes a 'Sentence'.
 dccWDS :: String -> NP -> Sentence -> ConceptChunk
-dccWDS i t d = ConDict (mkIdea i t Nothing) d []
+dccWDS i t d = dccAWDS i t d Nothing
 
 -- | Constructor for projecting an idea into a 'ConceptChunk'. Takes the definition of the 
 -- 'ConceptChunk' as a 'String'. Does not allow concept domain tagging.

--- a/code/drasil-theory/lib/Theory/Drasil/MultiDefn.hs
+++ b/code/drasil-theory/lib/Theory/Drasil/MultiDefn.hs
@@ -47,7 +47,7 @@ data MultiDefn e = MultiDefn{
   -- | UID
   _rUid :: UID,
   -- | Underlying quantity it defines.
-  _qd :: QuantityDict,
+  _qd :: DefinedQuantityDict,
   -- | Explanation of the different ways we can define a quantity.
   _rDesc :: Sentence,
   -- | All possible ways we can define the related quantity.
@@ -78,7 +78,7 @@ instance Express e => Express (MultiDefn e) where
 
 -- | Smart constructor for MultiDefns, does nothing special at the moment. First
 -- argument is the 'String' to become a 'UID'.
-mkMultiDefn :: String -> QuantityDict -> Sentence -> NE.NonEmpty (DefiningExpr e) -> MultiDefn e
+mkMultiDefn :: String -> DefinedQuantityDict -> Sentence -> NE.NonEmpty (DefiningExpr e) -> MultiDefn e
 mkMultiDefn u q s des
   | length des == dupsRemovedLen = MultiDefn (mkUid u) q s des
   | otherwise                    = error $
@@ -89,7 +89,7 @@ mkMultiDefn u q s des
 -- Should showUID be used here?
 
 -- | Smart constructor for 'MultiDefn's defining 'UID's using that of the 'QuantityDict'.
-mkMultiDefnForQuant :: QuantityDict -> Sentence -> NE.NonEmpty (DefiningExpr e) -> MultiDefn e
+mkMultiDefnForQuant :: DefinedQuantityDict -> Sentence -> NE.NonEmpty (DefiningExpr e) -> MultiDefn e
 mkMultiDefnForQuant q = mkMultiDefn (showUID q) q
 
 -- | Smart constructor for 'DefiningExpr's.


### PR DESCRIPTION
Contributes to #4284 

`mkQuant'` originally took an abbreviation, and all of our ConceptChunk constructors that I have been using to build DefinedQuantityDicts did not have the ability to take an abbreviation. This fixes that issue.