### PR TITLE
Move Data.Drasil.TheoryConcepts into `drasil-metadata` and rename to Drasil.Metadata.TheoryConcepts

### DIFF
--- a/code/drasil-data/lib/Data/Drasil/Concepts/Documentation.hs
+++ b/code/drasil-data/lib/Data/Drasil/Concepts/Documentation.hs
@@ -7,14 +7,15 @@
 
 module Data.Drasil.Concepts.Documentation where
 
+import Control.Lens ((^.))
+
 import Language.Drasil hiding (organization, year, label, variable)
 import Language.Drasil.Chunk.Concept.NamedCombinators
 
-import Data.Drasil.Concepts.Math (graph, unit_)
-import Drasil.Metadata (documentc, softEng)
-import Data.Drasil.TheoryConcepts (dataDefn, genDefn, inModel, thModel)
+import Drasil.Metadata (documentc, softEng, dataDefn, genDefn, inModel, thModel)
 
-import Control.Lens ((^.))
+import Data.Drasil.Concepts.Math (graph, unit_)
+
 
 -- | Collects all documentation-related named chunks (not concept-level yet).
 doccon :: [IdeaDict]

--- a/code/drasil-docLang/lib/Drasil/DocLang/SRS.hs
+++ b/code/drasil-docLang/lib/Drasil/DocLang/SRS.hs
@@ -43,7 +43,7 @@ import qualified Data.Drasil.Concepts.Documentation as Doc (appendix, assumption
   scpOfReq, scpOfTheProj, solutionCharSpec, specificsystemdescription,
   stakeholder, sysCont, systemConstraint, termAndDef, terminology, traceyMandG,
   tOfCont, tOfSymb, tOfUnit, userCharacteristic, refMat, abbAcc)
-import qualified Data.Drasil.TheoryConcepts as Doc (dataDefn, genDefn, inModel, thModel)
+import qualified Drasil.Metadata as M (dataDefn, genDefn, inModel, thModel)
 
 
 -- Ordered by appearance in SRS.
@@ -112,13 +112,13 @@ solCharSpec   cs ss = section (titleize Doc.solutionCharSpec)          cs ss sol
 -- | Assumptions section.
 assumpt       cs ss = section (titleize' Doc.assumption)               cs ss assumptLabel
 -- | Theoretical Models section.
-thModel       cs ss = section (titleize' Doc.thModel)                  cs ss thModelLabel
+thModel       cs ss = section (titleize' M.thModel)                  cs ss thModelLabel
 -- | General Definitions section.
-genDefn       cs ss = section (titleize' Doc.genDefn)                  cs ss genDefnLabel
+genDefn       cs ss = section (titleize' M.genDefn)                  cs ss genDefnLabel
 -- | Data Definitions section.
-dataDefn      cs ss = section (titleize' Doc.dataDefn)                 cs ss dataDefnLabel
+dataDefn      cs ss = section (titleize' M.dataDefn)                 cs ss dataDefnLabel
 -- | Instance Models section.
-inModel       cs ss = section (titleize' Doc.inModel)                  cs ss inModelLabel
+inModel       cs ss = section (titleize' M.inModel)                  cs ss inModelLabel
 -- | Data Constraints section.
 datCon        cs ss = section (titleize' Doc.datumConstraint)          cs ss datConLabel
 -- | Properties of a Correct Solution section.
@@ -212,10 +212,10 @@ goalStmtLabel       = makeSecRef "GoalStmt"         $ titleize' Doc.goalStmt
 
 solCharSpecLabel    = makeSecRef "SolCharSpec"      $ titleize  Doc.solutionCharSpec
 assumptLabel        = makeSecRef "Assumps"          $ titleize' Doc.assumption
-thModelLabel        = makeSecRef "TMs"              $ titleize' Doc.thModel
-genDefnLabel        = makeSecRef "GDs"              $ titleize' Doc.genDefn
-dataDefnLabel       = makeSecRef "DDs"              $ titleize' Doc.dataDefn
-inModelLabel        = makeSecRef "IMs"              $ titleize' Doc.inModel
+thModelLabel        = makeSecRef "TMs"              $ titleize' M.thModel
+genDefnLabel        = makeSecRef "GDs"              $ titleize' M.genDefn
+dataDefnLabel       = makeSecRef "DDs"              $ titleize' M.dataDefn
+inModelLabel        = makeSecRef "IMs"              $ titleize' M.inModel
 datConLabel         = makeSecRef "DataConstraints"  $ titleize' Doc.datumConstraint
 corSolPropsLabel    = makeSecRef "CorSolProps"      $ titleize' Doc.propOfCorSol
 

--- a/code/drasil-docLang/lib/Drasil/Sections/Introduction.hs
+++ b/code/drasil-docLang/lib/Drasil/Sections/Introduction.hs
@@ -18,7 +18,7 @@ import Data.Drasil.Concepts.Documentation as Doc (assumption, characteristic,
   organization, purpose, requirement, scope, section_, softwareDoc,
   softwareVAV, srs, theory, user, vavPlan, problem, problemIntro,
   information, systemConstraint, template)
-import Data.Drasil.TheoryConcepts as Doc (inModel, thModel)
+import Drasil.Metadata (inModel, thModel)
 import Data.Drasil.Citations (parnasClements1986, smithEtAl2007,
   smithKoothoor2016, smithLai2005, koothoor2013)
 import Data.Drasil.Software.Products

--- a/code/drasil-docLang/lib/Drasil/Sections/SpecificSystemDescription.hs
+++ b/code/drasil-docLang/lib/Drasil/Sections/SpecificSystemDescription.hs
@@ -37,7 +37,7 @@ import Data.Drasil.Concepts.Documentation (assumption, column, constraint,
   system, table_, term_, theory, typUnc, uncertainty, user, value, variable)
 import qualified Data.Drasil.Concepts.Documentation as DCD (sec)
 import Data.Drasil.Concepts.Math (equation, parameter)
-import Data.Drasil.TheoryConcepts (inModel, thModel, dataDefn, genDefn)
+import Drasil.Metadata (inModel, thModel, dataDefn, genDefn)
 import System.Drasil (System)
 import Drasil.DocumentLanguage.Definitions (helperRefs)
 import qualified Drasil.DocLang.SRS as SRS

--- a/code/drasil-docLang/lib/Drasil/Sections/TableOfContents.hs
+++ b/code/drasil-docLang/lib/Drasil/Sections/TableOfContents.hs
@@ -7,7 +7,7 @@ import Drasil.DocumentLanguage.Core
 import Language.Drasil.Chunk.Concept.NamedCombinators
 import qualified Drasil.DocLang.SRS as SRS
 import qualified Data.Drasil.Concepts.Documentation as Doc
-import qualified Data.Drasil.TheoryConcepts as Doc (dataDefn, genDefn, inModel, thModel)
+import Drasil.Metadata (dataDefn, genDefn, inModel, thModel)
 
 {- Layout for Table of Contents in SRS documents:
 Table of Contents
@@ -142,10 +142,10 @@ mktSSDSec (SSDProg l) =
 
     mktSubSCS :: SCSSub -> Sentence
     mktSubSCS (Assumptions _)      = namedRef SRS.assumptLabel     $ titleize' Doc.assumption
-    mktSubSCS TMs {}               = namedRef SRS.thModelLabel     $ titleize' Doc.thModel
-    mktSubSCS GDs {}               = namedRef SRS.genDefnLabel     $ titleize' Doc.genDefn
-    mktSubSCS DDs {}               = namedRef SRS.dataDefnLabel    $ titleize' Doc.dataDefn
-    mktSubSCS IMs {}               = namedRef SRS.inModelLabel     $ titleize' Doc.inModel
+    mktSubSCS TMs {}               = namedRef SRS.thModelLabel     $ titleize' thModel
+    mktSubSCS GDs {}               = namedRef SRS.genDefnLabel     $ titleize' genDefn
+    mktSubSCS DDs {}               = namedRef SRS.dataDefnLabel    $ titleize' dataDefn
+    mktSubSCS IMs {}               = namedRef SRS.inModelLabel     $ titleize' inModel
     mktSubSCS (Constraints _ _)    = namedRef SRS.datConLabel      $ titleize' Doc.datumConstraint
     mktSubSCS (CorrSolnPpties _ _) = namedRef SRS.corSolPropsLabel $ titleize' Doc.propOfCorSol
 

--- a/code/drasil-docLang/lib/Drasil/Sections/TraceabilityMandGs.hs
+++ b/code/drasil-docLang/lib/Drasil/Sections/TraceabilityMandGs.hs
@@ -16,7 +16,7 @@ import Drasil.DocumentLanguage.TraceabilityMatrix (generateTraceTableView,
 import Data.Drasil.Concepts.Documentation (assumption, assumpDom, chgProbDom,
   goalStmt, goalStmtDom, requirement, reqDom, item, section_, likelyChg,
   unlikelyChg)
-import qualified Data.Drasil.TheoryConcepts as Doc (genDefn, dataDefn, inModel, thModel)
+import Drasil.Metadata (dataDefn, genDefn, inModel, thModel)
 import Database.Drasil
 import System.Drasil
 import Language.Drasil
@@ -73,16 +73,16 @@ traceMatAssumpAssump = TraceConfig (mkUid "TraceMatAvsA") [plural assumption
 
 -- | Other assumptions of the traceability matrix
 traceMatAssumpOther :: TraceConfig
-traceMatAssumpOther = TraceConfig (mkUid "TraceMatAvsAll") [plural Doc.dataDefn,
-  plural Doc.thModel, plural Doc.genDefn, plural Doc.inModel, plural requirement,
+traceMatAssumpOther = TraceConfig (mkUid "TraceMatAvsAll") [plural dataDefn,
+  plural thModel, plural genDefn, plural inModel, plural requirement,
   plural likelyChg, pluralNP (unlikelyChg `NC.onThePP` assumption)]
   (titleize' assumption +:+ S "and Other" +:+ titleize' item) [tvAssumps]
   [tvDataDefns, tvTheoryModels, tvGenDefns, tvInsModels, tvReqs, tvChanges]
 
 -- | Refinement of the traceability matrix.
 traceMatRefinement :: TraceConfig
-traceMatRefinement = TraceConfig (mkUid "TraceMatRefvsRef") [plural Doc.dataDefn,
-  plural Doc.thModel, plural Doc.genDefn, plural Doc.inModel +:+
+traceMatRefinement = TraceConfig (mkUid "TraceMatRefvsRef") [plural dataDefn,
+  plural thModel, plural genDefn, plural inModel +:+
   S "on each other"] (titleize' item +:+ S "and Other" +:+ titleize' section_)
   [tvDataDefns, tvTheoryModels, tvGenDefns, tvInsModels]
   [tvDataDefns, tvTheoryModels, tvGenDefns, tvInsModels]
@@ -90,8 +90,8 @@ traceMatRefinement = TraceConfig (mkUid "TraceMatRefvsRef") [plural Doc.dataDefn
 -- | Records other requirements. Converts the 'System' into a 'TraceConfig'.
 traceMatOtherReq :: System -> TraceConfig
 traceMatOtherReq si = TraceConfig (mkUid "TraceMatAllvsR") [plural requirement
-  `S.and_` pluralNP (goalStmt `NC.onThePP` Doc.dataDefn), plural Doc.thModel, 
-  plural Doc.genDefn, plural Doc.inModel] (x titleize' +:+ S "and Other" +:+ 
+  `S.and_` pluralNP (goalStmt `NC.onThePP` dataDefn), plural thModel, 
+  plural genDefn, plural inModel] (x titleize' +:+ S "and Other" +:+ 
   titleize' item) [tvDataDefns, tvTheoryModels, tvGenDefns, tvInsModels, tvReqs] 
   [tvGoals, tvReqs] where
     x g = foldl' (\a (f,t) -> a `sC'` case traceMReferrers (flip f $ _systemdb si) $

--- a/code/drasil-docLang/package.yaml
+++ b/code/drasil-docLang/package.yaml
@@ -23,6 +23,7 @@ dependencies:
 - drasil-lang
 - drasil-data
 - drasil-database
+- drasil-metadata
 - drasil-printers
 - drasil-system
 - drasil-theory

--- a/code/drasil-example/dblpend/lib/Drasil/DblPend/Body.hs
+++ b/code/drasil-example/dblpend/lib/Drasil/DblPend/Body.hs
@@ -3,6 +3,7 @@ module Drasil.DblPend.Body where
 
 import Control.Lens ((^.))
 
+import Drasil.Metadata (inModel)
 import Language.Drasil hiding (organization, section)
 import Theory.Drasil (TheoryModel, output)
 import Drasil.SRSDocument
@@ -27,7 +28,6 @@ import Data.Drasil.Concepts.PhysicalProperties (mass, physicalcon)
 import Data.Drasil.Concepts.Software (program, errMsg)
 import Data.Drasil.Software.Products (prodtcon)
 import Data.Drasil.Theories.Physics (newtonSL, accelerationTM, velocityTM)
-import Data.Drasil.TheoryConcepts (inModel)
 
 import Drasil.DblPend.Figures (figMotion, sysCtxFig1)
 import Drasil.DblPend.Assumptions (assumpDouble)

--- a/code/drasil-example/dblpend/lib/Drasil/DblPend/Unitals.hs
+++ b/code/drasil-example/dblpend/lib/Drasil/DblPend/Unitals.hs
@@ -1,12 +1,13 @@
 module Drasil.DblPend.Unitals where
 
+import Drasil.Metadata (dataDefn, genDefn, inModel, thModel)
+
 import Language.Drasil
 import Language.Drasil.Display (Symbol(..))
 import Language.Drasil.ShortHands
 import Language.Drasil.Chunk.Concept.NamedCombinators
 import qualified Language.Drasil.Sentence.Combinators as S
 import Data.Drasil.Constraints (gtZeroConstr)
-import Data.Drasil.TheoryConcepts (dataDefn, genDefn, inModel, thModel)
 import Data.Drasil.Concepts.Documentation (assumption, goalStmt, physSyst,
   requirement, refBy, refName, srs, typUnc)
 import Data.Drasil.Quantities.PhysicalProperties as QPP (len, mass)

--- a/code/drasil-example/gamephysics/lib/Drasil/GamePhysics/Body.hs
+++ b/code/drasil-example/gamephysics/lib/Drasil/GamePhysics/Body.hs
@@ -1,6 +1,7 @@
 module Drasil.GamePhysics.Body where
 
 import Language.Drasil hiding (organization, section)
+import Drasil.Metadata (dataDefn, inModel)
 import Drasil.SRSDocument
 import qualified Drasil.DocLang.SRS as SRS
 import Language.Drasil.Chunk.Concept.NamedCombinators
@@ -13,7 +14,6 @@ import Data.Drasil.Concepts.Documentation as Doc (assumption, concept,
   quantity, realtime, section_, simulation, software, softwareSys,
   srsDomains, system, systemConstraint, sysCont, task, user, doccon, doccon',
   property, problemDescription)
-import Data.Drasil.TheoryConcepts as Doc (dataDefn, inModel)
 import Data.Drasil.Concepts.Education (frstYr, highSchoolCalculus,
   highSchoolPhysics, educon)
 import Data.Drasil.Concepts.Software (physLib, softwarecon)

--- a/code/drasil-example/gamephysics/lib/Drasil/GamePhysics/Concepts.hs
+++ b/code/drasil-example/gamephysics/lib/Drasil/GamePhysics/Concepts.hs
@@ -1,13 +1,14 @@
 module Drasil.GamePhysics.Concepts (centreMass, threeD, twoD, acronyms) where
 
+import Drasil.Metadata (physics, dataDefn, genDefn, inModel, thModel)
+
 import Language.Drasil
+
 import Data.Drasil.Concepts.Documentation (assumption, goalStmt, likelyChg,
   requirement, refBy, refName, srs, typUnc, unlikelyChg)
 import Data.Drasil.Concepts.Math (ode)
 import Data.Drasil.Concepts.PhysicalProperties (ctrOfMass)
 import Data.Drasil.Concepts.Physics (threeD, twoD)
-import Data.Drasil.TheoryConcepts (dataDefn, genDefn, inModel, thModel)
-import Drasil.Metadata (physics)
 
 import Control.Lens ((^.))
 

--- a/code/drasil-example/gamephysics/lib/Drasil/GamePhysics/IMods.hs
+++ b/code/drasil-example/gamephysics/lib/Drasil/GamePhysics/IMods.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE PostfixOperators #-}
 module Drasil.GamePhysics.IMods (iMods, instModIntro) where
 
+import Drasil.Metadata (inModel)
 import Language.Drasil
 import Language.Drasil.ShortHands (lJ)
 import Theory.Drasil
@@ -20,7 +21,6 @@ import Drasil.GamePhysics.TMods (newtonSL, newtonSLR)
 import Drasil.GamePhysics.Unitals (accj, forcej, massA, massj, normalVect,
   timeC, torquej, velA, velj, angAccj)
 
-import Data.Drasil.TheoryConcepts (inModel)
 
 import Data.Drasil.Concepts.Documentation (condition, goal, output_)
 import Data.Drasil.Concepts.Math (equation, ode)

--- a/code/drasil-example/glassbr/lib/Drasil/GlassBR/Body.hs
+++ b/code/drasil-example/glassbr/lib/Drasil/GlassBR/Body.hs
@@ -3,6 +3,7 @@ module Drasil.GlassBR.Body where
 
 import Control.Lens ((^.))
 import Language.Drasil hiding (organization, section, variable)
+import Drasil.Metadata as M (dataDefn, inModel, thModel)
 import Drasil.SRSDocument
 import Drasil.DocLang (auxSpecSent, termDefnF')
 import qualified Drasil.DocLang.SRS as SRS (reference, assumpt, inModel)
@@ -15,7 +16,6 @@ import Data.Drasil.Concepts.Documentation as Doc (appendix, assumption,
   environment, input_, interface, model, physical, problem, product_,
   software, softwareConstraint, softwareSys, srsDomains, standard, sysCont,
   system, term_, user, value, variable, reference, definition)
-import Data.Drasil.TheoryConcepts as Doc (dataDefn, inModel, thModel)
 import Data.Drasil.Concepts.Education as Edu (civilEng, scndYrCalculus, structuralMechanics,
   educon)
 import Data.Drasil.Concepts.Math (graph, mathcon, mathcon')
@@ -88,7 +88,7 @@ mkSRS = [TableOfContents,
     [IPurpose $ purpDoc progName Verbose,
      IScope scope,
      IChar [] (undIR ++ appStanddIR) [],
-     IOrgSec Doc.dataDefn (SRS.inModel [] []) orgOfDocIntroEnd],
+     IOrgSec M.dataDefn (SRS.inModel [] []) orgOfDocIntroEnd],
   StkhldrSec $
     StkhldrProg
       [Client progName $ phraseNP (a_ company)
@@ -189,7 +189,7 @@ termsAndDescBulletsLoadSubSec = [Nested (atStart load `sDash` capSent (load ^. d
   map tAndDOnly (drop 2 loadTypes)]
 
 solChSpecSubsections :: [CI]
-solChSpecSubsections = [thModel, inModel, Doc.dataDefn, dataConst]
+solChSpecSubsections = [thModel, inModel, dataDefn, dataConst]
 
 --Used in "Values of Auxiliary Constants" Section--
 auxiliaryConstants :: [ConstQDef]

--- a/code/drasil-example/glassbr/lib/Drasil/GlassBR/Concepts.hs
+++ b/code/drasil-example/glassbr/lib/Drasil/GlassBR/Concepts.hs
@@ -6,7 +6,7 @@ import Language.Drasil.Chunk.Concept.NamedCombinators
 import Data.Drasil.Concepts.Documentation (assumption, goalStmt, likelyChg,
   notApp, physSyst, response, requirement, refBy, refName, srs, type_, typUnc, 
   unlikelyChg)
-import Data.Drasil.TheoryConcepts (dataDefn, inModel, thModel)
+import Drasil.Metadata (dataDefn, inModel, thModel)
 
 {--}
 idglass :: IdeaDict

--- a/code/drasil-example/pdcontroller/lib/Drasil/PDController/Body.hs
+++ b/code/drasil-example/pdcontroller/lib/Drasil/PDController/Body.hs
@@ -1,6 +1,7 @@
 module Drasil.PDController.Body (pidODEInfo, printSetting, si, srs, fullSI) where
 
 import Language.Drasil
+import Drasil.Metadata (dataDefn)
 import Drasil.SRSDocument
 import qualified Drasil.DocLang.SRS as SRS (inModel)
 import qualified Language.Drasil.Sentence.Combinators as S
@@ -12,7 +13,6 @@ import Data.Drasil.Software.Products (sciCompS)
 import Data.Drasil.ExternalLibraries.ODELibraries
        (apacheODESymbols, arrayVecDepVar, odeintSymbols, osloSymbols,
         scipyODESymbols)
-import qualified Data.Drasil.TheoryConcepts as IDict (dataDefn)
 import Data.Drasil.Quantities.Physics (physicscon)
 import Data.Drasil.Concepts.PhysicalProperties (physicalcon)
 import Data.Drasil.Concepts.Physics (angular, linear) -- FIXME: should not be needed?
@@ -63,7 +63,7 @@ mkSRS
        IntroProg introPara (phrase progName)
          [IPurpose [introPurposeOfDoc], IScope introscopeOfReq,
           IChar introUserChar1 introUserChar2 [],
-          IOrgSec IDict.dataDefn (SRS.inModel [] [])
+          IOrgSec dataDefn (SRS.inModel [] [])
             (S "The instance model referred as" +:+ refS imPD +:+
                S "provides an"
                +:+ titleize ode +:+ sParen (short ode)

--- a/code/drasil-example/pdcontroller/lib/Drasil/PDController/Concepts.hs
+++ b/code/drasil-example/pdcontroller/lib/Drasil/PDController/Concepts.hs
@@ -1,9 +1,10 @@
 module Drasil.PDController.Concepts where
 
+import Drasil.Metadata
+import Language.Drasil
+
 import Data.Drasil.Concepts.Documentation
        (assumption, goalStmt, physSyst, requirement, refBy, refName, srs, typUnc)
-import Data.Drasil.TheoryConcepts
-import Language.Drasil
 
 acronyms :: [CI]
 acronyms

--- a/code/drasil-example/projectile/lib/Drasil/Projectile/Body.hs
+++ b/code/drasil-example/projectile/lib/Drasil/Projectile/Body.hs
@@ -1,5 +1,6 @@
 module Drasil.Projectile.Body (printSetting, si, srs, fullSI) where
 
+import Drasil.Metadata (dataDefn, genDefn, inModel, thModel)
 import Language.Drasil
 import Drasil.SRSDocument
 import Language.Drasil.Chunk.Concept.NamedCombinators
@@ -30,7 +31,6 @@ import Data.Drasil.Quantities.Physics (acceleration, constAccel,
 import Data.Drasil.People (brooks, samCrawford, spencerSmith)
 import Data.Drasil.SI_Units (siUnits)
 import Data.Drasil.Theories.Physics (accelerationTM, velocityTM)
-import Data.Drasil.TheoryConcepts (dataDefn, genDefn, inModel, thModel)
 import Data.Drasil.Concepts.Education(calculus, educon, undergraduate, 
   highSchoolPhysics, highSchoolCalculus)
 

--- a/code/drasil-example/sglpend/lib/Drasil/SglPend/Body.hs
+++ b/code/drasil-example/sglpend/lib/Drasil/SglPend/Body.hs
@@ -3,6 +3,7 @@ module Drasil.SglPend.Body where
 
 import Control.Lens ((^.))
 
+import Drasil.Metadata (inModel)
 import Language.Drasil hiding (organization, section)
 import Theory.Drasil (TheoryModel, output)
 import Drasil.SRSDocument
@@ -21,7 +22,6 @@ import Data.Drasil.Concepts.PhysicalProperties (mass, physicalcon)
 import Data.Drasil.Concepts.Software (program, errMsg)
 import Data.Drasil.Software.Products (prodtcon)
 import Data.Drasil.Theories.Physics (newtonSLR)
-import Data.Drasil.TheoryConcepts (inModel)
 
 import Drasil.DblPend.Body (justification, externalLinkRef, charsOfReader,
   sysCtxIntro, sysCtxDesc, sysCtxList, stdFields, scope, terms,

--- a/code/drasil-example/ssp/lib/Drasil/SSP/Body.hs
+++ b/code/drasil-example/ssp/lib/Drasil/SSP/Body.hs
@@ -10,6 +10,9 @@ import qualified Drasil.DocLang.SRS as SRS (inModel, assumpt,
 import Theory.Drasil (output)
 
 import Prelude hiding (sin, cos, tan)
+
+import Drasil.Metadata (inModel)
+
 import Language.Drasil.Chunk.Concept.NamedCombinators
 import qualified Language.Drasil.NounPhrase.Combinators as NP
 import qualified Language.Drasil.Sentence.Combinators as S
@@ -19,7 +22,6 @@ import Data.Drasil.Concepts.Documentation as Doc (analysis, assumption,
   physical, physics, problem, software, softwareSys, srsDomains, symbol_,
   sysCont, system, type_, user, value, variable, doccon, doccon',
   datumConstraint)
-import Data.Drasil.TheoryConcepts as Doc (inModel)
 import Data.Drasil.Concepts.Education (solidMechanics, undergraduate, educon)
 import Data.Drasil.Concepts.Math (equation, shape, surface, mathcon, mathcon',
   number)

--- a/code/drasil-example/ssp/lib/Drasil/SSP/Defs.hs
+++ b/code/drasil-example/ssp/lib/Drasil/SSP/Defs.hs
@@ -1,5 +1,7 @@
 module Drasil.SSP.Defs where --export all of this file
 
+import Drasil.Metadata (dataDefn, genDefn, inModel, thModel)
+
 import Language.Drasil
 import Language.Drasil.Chunk.Concept.NamedCombinators
 import qualified Language.Drasil.Sentence.Combinators as S
@@ -12,7 +14,6 @@ import Data.Drasil.Concepts.Math (surface)
 import Data.Drasil.Concepts.Physics (twoD, threeD, force, stress)
 import Data.Drasil.Concepts.PhysicalProperties (dimension, len)
 import Data.Drasil.Concepts.SolidMechanics (mobShear, normForce, nrmStrss,shearRes)
-import Data.Drasil.TheoryConcepts (dataDefn, genDefn, inModel, thModel)
 
 ----Acronyms-----
 acronyms :: [CI]

--- a/code/drasil-example/swhs/lib/Drasil/SWHS/Body.hs
+++ b/code/drasil-example/swhs/lib/Drasil/SWHS/Body.hs
@@ -11,7 +11,7 @@ import Language.Drasil.Chunk.Concept.NamedCombinators
 import qualified Language.Drasil.NounPhrase.Combinators as NP
 import qualified Language.Drasil.Sentence.Combinators as S
 
-import Data.Drasil.TheoryConcepts as Doc (inModel)
+import Drasil.Metadata (inModel)
 import Data.Drasil.Concepts.Computation (algorithm, compcon)
 import Data.Drasil.Concepts.Documentation as Doc (assumption, column,
   condition, constraint, corSol, datum, document, environment,input_, model,

--- a/code/drasil-example/swhs/lib/Drasil/SWHS/Concepts.hs
+++ b/code/drasil-example/swhs/lib/Drasil/SWHS/Concepts.hs
@@ -7,8 +7,7 @@ import Language.Drasil
 import Data.Drasil.Concepts.Documentation (assumption, goalStmt,
   likelyChg, physSyst, requirement, refBy, refName, srs, typUnc, unlikelyChg)
 import Data.Drasil.Concepts.Math (ode, parameter, rightSide)
-import Drasil.Metadata (materialEng)
-import Data.Drasil.TheoryConcepts (dataDefn, genDefn, inModel, thModel)
+import Drasil.Metadata (materialEng, dataDefn, genDefn, inModel, thModel)
 
 con :: [ConceptChunk]
 con = [charging, coil, discharging, gaussDiv,

--- a/code/drasil-example/swhsnopcm/lib/Drasil/SWHSNoPCM/Body.hs
+++ b/code/drasil-example/swhsnopcm/lib/Drasil/SWHSNoPCM/Body.hs
@@ -1,6 +1,7 @@
 module Drasil.SWHSNoPCM.Body (si, srs, printSetting, noPCMODEInfo, fullSI) where
 
 import Language.Drasil hiding (section)
+import Drasil.Metadata (inModel)
 import Drasil.SRSDocument
 import qualified Drasil.DocLang.SRS as SRS (inModel)
 import Theory.Drasil (TheoryModel)
@@ -14,7 +15,6 @@ import Data.Drasil.People (thulasi)
 
 import Data.Drasil.Concepts.Computation (algorithm, inValue)
 import Data.Drasil.Concepts.Documentation as Doc (doccon, doccon', material_, srsDomains, sysCont)
-import Data.Drasil.TheoryConcepts as Doc (inModel)
 import Data.Drasil.Concepts.Education (educon)
 import Data.Drasil.Concepts.Math (mathcon, mathcon', ode)
 import Data.Drasil.Concepts.PhysicalProperties (materialProprty, physicalcon)

--- a/code/drasil-example/template/lib/Drasil/Template/Body.hs
+++ b/code/drasil-example/template/lib/Drasil/Template/Body.hs
@@ -5,6 +5,7 @@
 
 module Drasil.Template.Body where
 
+import Drasil.Metadata
 import Language.Drasil
 import Drasil.SRSDocument
 import Theory.Drasil (DataDefinition, GenDefn, InstanceModel, TheoryModel)
@@ -16,7 +17,6 @@ import Data.Drasil.Concepts.Math (mathcon)
 
 import qualified Drasil.DocLang.SRS as SRS
 import Data.Drasil.Software.Products
-import Data.Drasil.TheoryConcepts
 import Data.Drasil.Citations
 import Drasil.DocumentLanguage.TraceabilityGraph
 import Drasil.DocLang (tunitNone)

--- a/code/drasil-metadata/lib/Drasil/Metadata.hs
+++ b/code/drasil-metadata/lib/Drasil/Metadata.hs
@@ -5,12 +5,15 @@ module Drasil.Metadata (
     -- * Domains
     module Drasil.Metadata.Domains,
     -- * Supported Software
-    module Drasil.Metadata.SupportedSoftware
+    module Drasil.Metadata.SupportedSoftware,
+    -- * Theory Concepts
+    module Drasil.Metadata.TheoryConcepts
 ) where
 
 import Drasil.Metadata.Domains
 import Drasil.Metadata.Drasil (DrasilMeta(..), drasilMetaCfg)
 import Drasil.Metadata.SupportedSoftware
+import Drasil.Metadata.TheoryConcepts
 
 -- | Drasil metadata.
 drasilMeta :: DrasilMeta

--- a/code/drasil-metadata/lib/Drasil/Metadata/TheoryConcepts.hs
+++ b/code/drasil-metadata/lib/Drasil/Metadata/TheoryConcepts.hs
@@ -1,9 +1,9 @@
 -- | Theory related Drasil concepts, used across Drasil.
-module Data.Drasil.TheoryConcepts where
+module Drasil.Metadata.TheoryConcepts where
 
 import Language.Drasil (cn', CI, commonIdeaWithDict)
 
-import Drasil.Metadata (softEng)
+import Drasil.Metadata.Domains (softEng)
 
 -- | These are internal-to-Drasil common ideas, and need to be defined at the 
 -- same time as theories.

--- a/code/drasil-theory/lib/Theory/Drasil/DataDefinition.hs
+++ b/code/drasil-theory/lib/Theory/Drasil/DataDefinition.hs
@@ -5,7 +5,7 @@ module Theory.Drasil.DataDefinition where
 
 import Control.Lens
 import Language.Drasil
-import Data.Drasil.TheoryConcepts (dataDefn)
+import Drasil.Metadata (dataDefn)
 import Theory.Drasil.Classes (HasOutput(..))
 
 -- * Types

--- a/code/drasil-theory/lib/Theory/Drasil/GenDefn.hs
+++ b/code/drasil-theory/lib/Theory/Drasil/GenDefn.hs
@@ -9,7 +9,7 @@ module Theory.Drasil.GenDefn (
   getEqModQdsFromGd) where
 
 import Language.Drasil
-import Data.Drasil.TheoryConcepts (genDefn)
+import Drasil.Metadata (genDefn)
 import Theory.Drasil.ModelKinds (ModelKind, getEqModQds)
 
 import Control.Lens ((^.), view, makeLenses)

--- a/code/drasil-theory/lib/Theory/Drasil/InstanceModel.hs
+++ b/code/drasil-theory/lib/Theory/Drasil/InstanceModel.hs
@@ -12,7 +12,7 @@ module Theory.Drasil.InstanceModel(
 
 import Language.Drasil
 import Theory.Drasil.Classes (HasInputs(inputs), HasOutput(..))
-import Data.Drasil.TheoryConcepts (inModel)
+import Drasil.Metadata (inModel)
 
 import Control.Lens ((^.), makeLenses, _1, _2) 
 import Theory.Drasil.ModelKinds (ModelKind, getEqModQds)

--- a/code/drasil-theory/lib/Theory/Drasil/Theory.hs
+++ b/code/drasil-theory/lib/Theory/Drasil/Theory.hs
@@ -11,7 +11,7 @@ module Theory.Drasil.Theory (
 import Control.Lens (Lens', view, makeLenses)
 
 import Language.Drasil
-import Data.Drasil.TheoryConcepts (thModel)
+import Drasil.Metadata (thModel)
 
 import Theory.Drasil.ModelKinds
 

--- a/code/drasil-theory/package.yaml
+++ b/code/drasil-theory/package.yaml
@@ -27,7 +27,6 @@ library:
   source-dirs: lib
   exposed-modules:
   - Theory.Drasil
-  - Data.Drasil.TheoryConcepts
   when:
   - condition: false
     other-modules: Paths_drasil_theory


### PR DESCRIPTION
Very minor, but re-organizing data around our packages is surprisingly helpful to understanding what's going on.