### PR TITLE
Projectile: Remove duplicate `drasil-system` dependency.

### DIFF
--- a/code/drasil-example/projectile/package.yaml
+++ b/code/drasil-example/projectile/package.yaml
@@ -31,7 +31,6 @@ dependencies:
 - drasil-metadata
 - drasil-printers
 - drasil-system
-- drasil-system
 - drasil-theory
 - drasil-utils
 


### PR DESCRIPTION
As per the title, just removing a duplicate dependency entry.