### PR TITLE
`drasil-system`: Create SmithEtAl-style software requirements specification encoding.

### DIFF
--- a/code/drasil-system/lib/Drasil/SoftwareSpecifications/Requirements.hs
+++ b/code/drasil-system/lib/Drasil/SoftwareSpecifications/Requirements.hs
@@ -1,0 +1,34 @@
+{-# LANGUAGE TemplateHaskell #-}
+module Drasil.SoftwareSpecifications.Requirements (
+    RequirementsSpecification,
+    SmithEtAlReqSpec,
+    smithEtAlReq,
+    theoryModels, genDefns, dataDefns, instModels,
+    quants, inputs, outputs, constraints, constants
+) where
+
+import Control.Lens
+
+import Language.Drasil (DefinedQuantityDict, UncertQ, ConstQDef)
+import Theory.Drasil (TheoryModel, GenDefn, DataDefinition, InstanceModel)
+
+data RequirementsSpecification = SmithEtAlStyle SmithEtAlReqSpec
+
+data SmithEtAlReqSpec = SeaRS {
+  _theoryModels :: [TheoryModel],
+  _genDefns     :: [GenDefn],
+  _dataDefns    :: [DataDefinition],
+  _instModels   :: [InstanceModel],
+  _quants       :: [DefinedQuantityDict],
+  _inputs       :: [DefinedQuantityDict],
+  _outputs      :: [DefinedQuantityDict],
+  _constraints  :: [UncertQ],
+  _constants    :: [ConstQDef]
+}
+makeLenses ''SmithEtAlReqSpec
+
+smithEtAlReq :: [TheoryModel] -> [GenDefn] -> [DataDefinition] -> [InstanceModel] ->
+    [DefinedQuantityDict] -> [DefinedQuantityDict] -> [DefinedQuantityDict] ->
+    [UncertQ] -> [ConstQDef] -> RequirementsSpecification
+smithEtAlReq tms gds dds ims qs ins outs cnstrnts cnstnts =
+  SmithEtAlStyle (SeaRS tms gds dds ims qs ins outs cnstrnts cnstnts)

--- a/code/drasil-system/lib/Drasil/System.hs
+++ b/code/drasil-system/lib/Drasil/System.hs
@@ -15,17 +15,20 @@ module Drasil.System (
   whatsTheBigIdea, mkSystem,
   -- * Reference Database
   -- ** Types
-  Purpose, Background, Scope, Motivation
-  ) where
+  Purpose, Background, Scope, Motivation,
 
-import Language.Drasil hiding (kind, Notebook)
-import Theory.Drasil
-import Database.Drasil (ChunkDB)
-
-import Drasil.Metadata (runnableSoftware, website)
+  module Drasil.SoftwareSpecifications.Requirements
+) where
 
 import Control.Lens (makeClassy)
+
 import qualified Data.Drasil.Concepts.Documentation as Doc
+
+import Language.Drasil hiding (kind, Notebook)
+import Database.Drasil (ChunkDB)
+import Drasil.Metadata (runnableSoftware, website)
+
+import Drasil.SoftwareSpecifications.Requirements
 
 -- | Project Example purpose.
 type Purpose = [Sentence]
@@ -37,7 +40,7 @@ type Scope = [Sentence]
 type Motivation = [Sentence]
 
 data SystemKind =
-    Specification
+    Specification RequirementsSpecification
   | RunnableSoftware
   | Notebook
   | Website
@@ -46,7 +49,7 @@ whatsTheBigIdea :: System -> IdeaDict
 whatsTheBigIdea si = whatKind' (_kind si)
   where
     whatKind' :: SystemKind -> IdeaDict
-    whatKind' Specification = nw Doc.srs
+    whatKind' Specification{} = nw Doc.srs
     whatKind' RunnableSoftware = runnableSoftware
     whatKind' Notebook = nw Doc.notebook
     whatKind' Website = website
@@ -58,11 +61,7 @@ data System where
 --There should be a way to remove redundant "Quantity" constraint.
 -- I'm thinking for getting concepts that are also quantities, we could
 -- use a lookup of some sort from their internal (Drasil) ids.
- SI :: (CommonIdea a, Idea a,
-  Quantity e, Eq e, MayHaveUnit e, Concept e,
-  Quantity h, MayHaveUnit h, Concept h,
-  Quantity i, MayHaveUnit i, Concept i,
-  HasUID j, Constrained j) => 
+ SI :: (CommonIdea a, Idea a) => 
   { _sys          :: a
   , _kind         :: SystemKind
   , _authors      :: People
@@ -70,27 +69,12 @@ data System where
   , _background   :: Background
   , _scope        :: Scope
   , _motivation   :: Motivation
-  , _quants       :: [e]
-  , _theoryModels :: [TheoryModel]
-  , _genDefns     :: [GenDefn]
-  , _dataDefns    :: [DataDefinition]
-  , _instModels   :: [InstanceModel]
   , _configFiles  :: [String]
-  , _inputs       :: [h]
-  , _outputs      :: [i]
-  , _constraints  :: [j] --TODO: Add SymbolMap OR enough info to gen SymbolMap
-  , _constants    :: [ConstQDef]
   , _systemdb     :: ChunkDB
   } -> System
 
 makeClassy ''System
 
-mkSystem :: (CommonIdea a, Idea a,
-  Quantity e, Eq e, MayHaveUnit e, Concept e,
-  Quantity h, MayHaveUnit h, Concept h,
-  Quantity i, MayHaveUnit i, Concept i,
-  HasUID j, Constrained j) =>
-  a -> SystemKind -> People -> Purpose -> Background -> Scope -> Motivation ->
-    [e] -> [TheoryModel] -> [GenDefn] -> [DataDefinition] -> [InstanceModel] ->
-    [String] -> [h] -> [i] -> [j] -> [ConstQDef] -> ChunkDB -> System
+mkSystem :: (CommonIdea a, Idea a) => a -> SystemKind -> People -> Purpose ->
+  Background -> Scope -> Motivation -> [String] -> ChunkDB -> System
 mkSystem = SI


### PR DESCRIPTION
Contributes to #3260 and #4304 