### PR TITLE
PDController: Remove unused 'integral' CI.

### DIFF
--- a/code/drasil-example/pdcontroller/lib/Drasil/PDController/Concepts.hs
+++ b/code/drasil-example/pdcontroller/lib/Drasil/PDController/Concepts.hs
@@ -10,13 +10,12 @@ acronyms :: [CI]
 acronyms
   = [assumption, dataDefn, genDefn, goalStmt, inModel, physSyst, requirement, refBy, 
      refName, srs, thModel, typUnc, pdControllerCI, proportionalCI, derivativeCI,
-     integralCI, pidCI]
-pdControllerCI, proportionalCI, derivativeCI, integralCI, pidCI :: CI
+     pidCI]
+pdControllerCI, proportionalCI, derivativeCI, pidCI :: CI
 
 pdControllerCI  = commonIdeaWithDict "pdControllerCI"  (pn "proportional derivative")          "PD"            []
 proportionalCI  = commonIdeaWithDict "proportionalCI"  (pn "proportional")                     "P"             []
 derivativeCI    = commonIdeaWithDict "derivativeCI"    (pn "derivative")                       "D"             []
-integralCI      = commonIdeaWithDict "integralCI"      (pn "integral")                         "I"             []
 pidCI           = commonIdeaWithDict "pidCI"           (pn "proportional integral derivative") "PID"           []
 
 pidC, pidCL, summingPt, powerPlant, secondOrderSystem, processError,

--- a/code/stable/pdcontroller/SRS/HTML/PDController_SRS.html
+++ b/code/stable/pdcontroller/SRS/HTML/PDController_SRS.html
@@ -307,10 +307,6 @@
                   <td>Goal Statement</td>
                 </tr>
                 <tr>
-                  <td>I</td>
-                  <td>integral</td>
-                </tr>
-                <tr>
                   <td>IM</td>
                   <td>Instance Model</td>
                 </tr>

--- a/code/stable/pdcontroller/SRS/Jupyter/PDController_SRS.ipynb
+++ b/code/stable/pdcontroller/SRS/Jupyter/PDController_SRS.ipynb
@@ -120,7 +120,6 @@
     "|DD|Data Definition|\n",
     "|GD|General Definition|\n",
     "|GS|Goal Statement|\n",
-    "|I|integral|\n",
     "|IM|Instance Model|\n",
     "|P|proportional|\n",
     "|PD|proportional derivative|\n",

--- a/code/stable/pdcontroller/SRS/PDF/PDController_SRS.tex
+++ b/code/stable/pdcontroller/SRS/PDF/PDController_SRS.tex
@@ -129,8 +129,6 @@ GD & General Definition
 \\
 GS & Goal Statement
 \\
-I & integral
-\\
 IM & Instance Model
 \\
 P & proportional

--- a/code/stable/pdcontroller/SRS/mdBook/src/SecTAbbAcc.md
+++ b/code/stable/pdcontroller/SRS/mdBook/src/SecTAbbAcc.md
@@ -9,7 +9,6 @@
 |DD          |Data Definition                    |
 |GD          |General Definition                 |
 |GS          |Goal Statement                     |
-|I           |integral                           |
 |IM          |Instance Model                     |
 |P           |proportional                       |
 |PD          |proportional derivative            |


### PR DESCRIPTION
Contributes to #4363 