### PR TITLE
GlassBR: Remove unused 'not applicable' abbreviation from table of abb/accs.

### DIFF
--- a/code/drasil-example/glassbr/lib/Drasil/GlassBR/Concepts.hs
+++ b/code/drasil-example/glassbr/lib/Drasil/GlassBR/Concepts.hs
@@ -4,7 +4,7 @@ import Language.Drasil
 import Language.Drasil.Chunk.Concept.NamedCombinators
 
 import Data.Drasil.Concepts.Documentation (assumption, goalStmt, likelyChg,
-  notApp, physSyst, response, requirement, refBy, refName, srs, type_, typUnc, 
+  physSyst, response, requirement, refBy, refName, srs, type_, typUnc, 
   unlikelyChg)
 import Drasil.Metadata (dataDefn, inModel, thModel)
 
@@ -25,7 +25,7 @@ con' = [beam, blastRisk, cantilever, edge, glaPlane, glaSlab, plane,
 acronyms :: [CI]
 acronyms = [assumption, annealed, aR, dataDefn, fullyT, goalStmt, 
   glassTypeFac, heatS, iGlass, inModel, likelyChg, lDurFac, 
-  lGlass, lResistance, lShareFac, notApp, nFL, physSyst, requirement, 
+  lGlass, lResistance, lShareFac, nFL, physSyst, requirement, 
   refBy, refName, stdOffDist, srs, thModel, typUnc, unlikelyChg]
 
 annealed, aR, fullyT, glassTypeFac, heatS, lDurFac, iGlass, lGlass, 

--- a/code/stable/glassbr/SRS/HTML/GlassBR_SRS.html
+++ b/code/stable/glassbr/SRS/HTML/GlassBR_SRS.html
@@ -498,10 +498,6 @@
                   <td>Load Share Factor</td>
                 </tr>
                 <tr>
-                  <td>N/A</td>
-                  <td>Not Applicable</td>
-                </tr>
-                <tr>
                   <td>NFL</td>
                   <td>Non-Factored Load</td>
                 </tr>

--- a/code/stable/glassbr/SRS/Jupyter/GlassBR_SRS.ipynb
+++ b/code/stable/glassbr/SRS/Jupyter/GlassBR_SRS.ipynb
@@ -163,7 +163,6 @@
     "|LG|Laminated Glass|\n",
     "|LR|Load Resistance|\n",
     "|LSF|Load Share Factor|\n",
-    "|N/A|Not Applicable|\n",
     "|NFL|Non-Factored Load|\n",
     "|PS|Physical System Description|\n",
     "|R|Requirement|\n",

--- a/code/stable/glassbr/SRS/PDF/GlassBR_SRS.tex
+++ b/code/stable/glassbr/SRS/PDF/GlassBR_SRS.tex
@@ -203,8 +203,6 @@ LR & Load Resistance
 \\
 LSF & Load Share Factor
 \\
-N/A & Not Applicable
-\\
 NFL & Non-Factored Load
 \\
 PS & Physical System Description

--- a/code/stable/glassbr/SRS/mdBook/src/SecTAbbAcc.md
+++ b/code/stable/glassbr/SRS/mdBook/src/SecTAbbAcc.md
@@ -19,7 +19,6 @@
 |LG          |Laminated Glass                    |
 |LR          |Load Resistance                    |
 |LSF         |Load Share Factor                  |
-|N/A         |Not Applicable                     |
 |NFL         |Non-Factored Load                  |
 |PS          |Physical System Description        |
 |R           |Requirement                        |


### PR DESCRIPTION
Contributes to #4363.