### PR TITLE
SSP: Remove unused 3D acronym from table of abb/accs.

### DIFF
--- a/code/drasil-example/ssp/lib/Drasil/SSP/Body.hs
+++ b/code/drasil-example/ssp/lib/Drasil/SSP/Body.hs
@@ -25,7 +25,7 @@ import Data.Drasil.Concepts.Math (equation, shape, surface, mathcon',
 import Data.Drasil.Concepts.PhysicalProperties (dimension, mass, physicalcon)
 import Data.Drasil.Quantities.PhysicalProperties (len)
 import Data.Drasil.Concepts.Physics (cohesion, fbd, force, gravity, isotropy,
-  strain, stress, time, twoD, physicCon', distance, friction, linear, velocity, position)
+  strain, stress, time, twoD, physicCon', distance, friction, linear, velocity, position, threeD)
 import Data.Drasil.Concepts.Software (program, softwarecon)
 import Data.Drasil.Concepts.SolidMechanics (mobShear, normForce, shearForce, 
   shearRes, solidcon)
@@ -138,7 +138,7 @@ ideaDicts =
   -- Actual IdeaDicts
   defs ++
   -- CIs
-  nw progName : map nw mathcon' ++ map nw physicCon'
+  nw progName : nw threeD : map nw mathcon' ++ map nw physicCon'
 
 conceptChunks :: [ConceptChunk]
 conceptChunks =

--- a/code/drasil-example/ssp/lib/Drasil/SSP/Defs.hs
+++ b/code/drasil-example/ssp/lib/Drasil/SSP/Defs.hs
@@ -17,7 +17,7 @@ import Data.Drasil.Concepts.SolidMechanics (mobShear, normForce, nrmStrss,shearR
 
 ----Acronyms-----
 acronyms :: [CI]
-acronyms = [twoD, threeD, assumption, dataDefn, genDefn, goalStmt, inModel, likelyChg,
+acronyms = [twoD, assumption, dataDefn, genDefn, goalStmt, inModel, likelyChg,
   physSyst, requirement, refBy, refName, srs, thModel, typUnc, unlikelyChg]
 
 defs :: [IdeaDict]

--- a/code/stable/ssp/SRS/HTML/SSP_SRS.html
+++ b/code/stable/ssp/SRS/HTML/SSP_SRS.html
@@ -819,10 +819,6 @@
                   <td>Two-Dimensional</td>
                 </tr>
                 <tr>
-                  <td>3D</td>
-                  <td>Three-Dimensional</td>
-                </tr>
-                <tr>
                   <td>A</td>
                   <td>Assumption</td>
                 </tr>

--- a/code/stable/ssp/SRS/Jupyter/SSP_SRS.ipynb
+++ b/code/stable/ssp/SRS/Jupyter/SSP_SRS.ipynb
@@ -190,7 +190,6 @@
     "|Abbreviation|Full Form|\n",
     "|:--- |:--- |\n",
     "|2D|Two-Dimensional|\n",
-    "|3D|Three-Dimensional|\n",
     "|A|Assumption|\n",
     "|DD|Data Definition|\n",
     "|GD|General Definition|\n",

--- a/code/stable/ssp/SRS/PDF/SSP_SRS.tex
+++ b/code/stable/ssp/SRS/PDF/SSP_SRS.tex
@@ -263,8 +263,6 @@ $\symbf{ω}$ & Imposed Load Angles: The angles between the external force acting
 \\
 2D & Two-Dimensional
 \\
-3D & Three-Dimensional
-\\
 A & Assumption
 \\
 DD & Data Definition

--- a/code/stable/ssp/SRS/mdBook/src/SecTAbbAcc.md
+++ b/code/stable/ssp/SRS/mdBook/src/SecTAbbAcc.md
@@ -5,7 +5,6 @@
 |Abbreviation|Full Form                          |
 |:-----------|:----------------------------------|
 |2D          |Two-Dimensional                    |
-|3D          |Three-Dimensional                  |
 |A           |Assumption                         |
 |DD          |Data Definition                    |
 |GD          |General Definition                 |


### PR DESCRIPTION
Contributes to #4363.