### PR TITLE
Removed link to deleted wiki page in `_Sidebar.md`

### DIFF
--- a/wiki/_Sidebar.md
+++ b/wiki/_Sidebar.md
@@ -69,7 +69,7 @@
       * [When to Use Maybe](When-to-Use-Maybe)
       * [How Should We Handle Abbreviations?](How-Should-We-Handle-Abbreviations?)
     * [DefinedQuantityDict](DefinedQuantityDict)
-    * [Concept Chunk (and Related Chunks)](<Concept-Chunk-(and-Related-Chunks)>)
+    * [Concept Chunk (and Related Chunks)](Concept-Chunk-(and-Related-Chunks))
   * [Refined Theories Version of Drasil](Refined-Theories-version-of-Drasil)
   * [Idealized Process](Idealized-Process)
   * [Chunk Redesign 2024](Chunk-Redesign-2024)


### PR DESCRIPTION
This removes the link to a deleted page that described how we might convert GOOL classes directly into procedural structs. We didn't end up doing that and I deleted the page, but not the link, in #3914. Here we delete the link.

Contributes to #4401 