### PR TITLE
pdcontroller intro template 3529

### DIFF
--- a/code/drasil-example/pdcontroller/lib/Drasil/PDController/IntroSection.hs
+++ b/code/drasil-example/pdcontroller/lib/Drasil/PDController/IntroSection.hs
@@ -9,16 +9,13 @@ import Drasil.PDController.MetaConcepts (progName)
 introPara, introPurposeOfDoc, introscopeOfReq :: Sentence
 
 -- template
-background1, background2, background3 :: Sentence
-background1 = S "Automatic process control with a controller (P/PI/PD/PID) is used"
-background2 = S "in a variety of applications such as thermostats and automobile"
-background3 = S "cruise-control."
+background :: Sentence
+background = S "Automatic process control with a controller (P/PI/PD/PID) is used in a variety of applications such as thermostats and automobile cruise-control."
 longProgramName, shortProgramName :: Sentence
 longProgramName  = phrase progName
 shortProgramName = sParen (S "PDC")
-
-originalArtifactClause, goal :: Sentence
-originalArtifactClause =
+origin, goal :: Sentence
+origin =
   S ", which is based on the original, manually created version of"
   +:+ namedRef externalLinkRef (S "PD Controller")
 goal =
@@ -27,13 +24,11 @@ goal =
   +:+ S "that can be used to tune the gain constants before deployment"
 
 introPara = foldlSent
-  [ background1
-  , background2
-  , background3
+  [ background
   , S "This document describes the requirements of a program called"
       +:+ longProgramName
       +:+ shortProgramName
-      +:+ originalArtifactClause
+      +:+ origin
       +:+ goal
   ]
 


### PR DESCRIPTION
This PR is under [this issue](https://github.com/JacquesCarette/Drasil/issues/3529).

I tried to summarize two new general templates. They share the same second paragraph:
Template A:
\<BACKGROUND PROBLEM/CONTEXT\>. 
This document describes the requirements of a program called \<LONG PROGRAM NAME\> (\<SHORT PROGRAM NAME\>)[, which is based on \<ORIGINAL ARTIFACT/LINK\>], whose goal is to \<PURPOSE\>.
The following section provides an overview of the SRS for <SHORT PROGRAM NAME>. It explains the purpose of this document, the scope of the requirements, the characteristics of the intended reader, and the organization of the document.
Template B:
\<BACKGROUND PROBLEM/CONTEXT\>. 
This document describes the requirements of a program called \<LONG PROGRAM NAME\> (\<SHORT PROGRAM NAME\>), whose goal is to \<PURPOSE\>.
The following section provides an overview of the SRS for \<SHORT PROGRAM NAME\>. It explains the purpose of this document, the scope of the requirements, the characteristics of the intended reader, and the organization of the document.


Right now the new introduction section looks like this:
Automatic process control with a controller (P/PI/PD/PID) is used in a variety of applications such as thermostats and automobile cruise-control. This document describes the requirements of a program called PD Controller (PDC) , which is based on the original, manually created version of [PD Controller](https://github.com/muralidn/CAS741-Fall20/tree/master) , whose goal is to provide a model of a PD Controller that can be used to tune the gain constants before deployment.
The following section provides an overview of the Software Requirements Specification (SRS) for PD Controller. This section explains the purpose of this document, the scope of the requirements, the characteristics of the intended reader, and the organization of the document.



I tried to apply the template A into PDController example and implemented a little change on IntroSection.hs of PDController.
"which is based on the original, ..." will only be in this example, but only this one. [answering this comment](https://github.com/JacquesCarette/Drasil/issues/3529#issuecomment-3353357186)
Once these two templates are approved, I will apply them to other examples.