### PR TITLE
Fixed the wiki link for GOOL/GProc Overview

### DIFF
--- a/wiki/_Sidebar.md
+++ b/wiki/_Sidebar.md
@@ -70,7 +70,7 @@
       * [When to Use Maybe](When-to-Use-Maybe)
       * [How Should We Handle Abbreviations?](How-Should-We-Handle-Abbreviations?)
     * [DefinedQuantityDict](DefinedQuantityDict)
-    * [Concept Chunk (and Related Chunks)](<Concept-Chunk-(and-Related-Chunks)>)
+    * [Concept Chunk (and Related Chunks)](Concept-Chunk-(and-Related-Chunks))
   * [Refined Theories Version of Drasil](Refined-Theories-version-of-Drasil)
   * [Idealized Process](Idealized-Process)
   * [Chunk Redesign 2024](Chunk-Redesign-2024)


### PR DESCRIPTION
In #4403 I had it as an absolute link instead of a local link. We were going to leave it, but then I noticed that when you click on it in the sidebar, it opens the file as a code file instead of as part of the wiki. I.e. the title doesn't display at the top, and the sidebar doesn't appear, etc. This commit changes it to a local link, and should bring back the correct behaviour.