### PR TITLE
Removed `.md` from GOOL/GProc wiki link

### DIFF
--- a/wiki/_Sidebar.md
+++ b/wiki/_Sidebar.md
@@ -21,7 +21,7 @@
   * [Printing Information](Printing-Information-Guide)
   * [Sub-packages](SubPackages)
   * [Folders](Folder-layout)
-    * [GOOL/GProc Overview](GOOL-GProc%20Overview.md)
+    * [GOOL/GProc Overview](GOOL-GProc%20Overview)
   * [Quantifying Productivity and Ease of Use](Quantifying-Productivity-and-Ease-of-Use)
 * Design
   * [Attributes and Chunks](Attributes-and-Chunks)


### PR DESCRIPTION
Third time's the charm (hopefully)

Apparently I left the `.md` in the internal link, and that causes GitHub to link it to a plaintext version of the file instead. This PR fixes that.