### PR TITLE
Reuse `fullSI` in all examples

### DIFF
--- a/code/drasil-docLang/lib/Drasil/DocumentLanguage.hs
+++ b/code/drasil-docLang/lib/Drasil/DocumentLanguage.hs
@@ -70,13 +70,14 @@ import qualified Data.Drasil.Concepts.Documentation as Doc (likelyChg, section_,
   software, unlikelyChg)
 
 -- * Main Function
+
 -- | Creates a document from a document description, a title combinator function, and system information.
 mkDoc :: SRSDecl -> (IdeaDict -> IdeaDict -> Sentence) -> System -> Document
 mkDoc dd comb si@SI {_sys = sys, _authors = docauthors} =
   Document (whatsTheBigIdea si `comb` nw sys) (foldlList Comma List $ map (S . name) docauthors) (findToC l) $
-  mkSections fullSI l where
-    fullSI = fillcdbSRS dd si
-    l = mkDocDesc fullSI dd
+  mkSections si l
+  where
+    l = mkDocDesc si dd
 
 -- * Functions to Fill 'ChunkDB'
 

--- a/code/drasil-example/dblpend/lib/Drasil/DblPend/Body.hs
+++ b/code/drasil-example/dblpend/lib/Drasil/DblPend/Body.hs
@@ -48,7 +48,7 @@ import Drasil.DblPend.ODEs (dblPenODEInfo)
 import Drasil.System (SystemKind(Specification), mkSystem)
 
 srs :: Document
-srs = mkDoc mkSRS (S.forGen titleize phrase) si
+srs = mkDoc mkSRS (S.forGen titleize phrase) fullSI
 
 fullSI :: System
 fullSI = fillcdbSRS mkSRS si

--- a/code/drasil-example/gamephysics/lib/Drasil/GamePhysics/Body.hs
+++ b/code/drasil-example/gamephysics/lib/Drasil/GamePhysics/Body.hs
@@ -46,7 +46,7 @@ import Drasil.GamePhysics.GenDefs (generalDefns)
 import Drasil.System (SystemKind(Specification), mkSystem)
 
 srs :: Document
-srs = mkDoc mkSRS (S.forGen titleize short) si
+srs = mkDoc mkSRS (S.forGen titleize short) fullSI
 
 fullSI :: System
 fullSI = fillcdbSRS mkSRS si

--- a/code/drasil-example/glassbr/lib/Drasil/GlassBR/Body.hs
+++ b/code/drasil-example/glassbr/lib/Drasil/GlassBR/Body.hs
@@ -50,7 +50,7 @@ import Drasil.System (SystemKind(Specification), mkSystem)
 import Data.Drasil.Quantities.PhysicalProperties (physicalquants)
 
 srs :: Document
-srs = mkDoc mkSRS (S.forGen titleize phrase) si
+srs = mkDoc mkSRS (S.forGen titleize phrase) fullSI
 
 fullSI :: System
 fullSI = fillcdbSRS mkSRS si

--- a/code/drasil-example/hghc/lib/Drasil/HGHC/Body.hs
+++ b/code/drasil-example/hghc/lib/Drasil/HGHC/Body.hs
@@ -14,7 +14,7 @@ import Data.Drasil.People (spencerSmith)
 import Data.Drasil.Concepts.Thermodynamics as CT (heatTrans)
 
 srs :: Document
-srs = mkDoc mkSRS S.forT si
+srs = mkDoc mkSRS S.forT fullSI
 
 fullSI :: System
 fullSI = fillcdbSRS mkSRS si

--- a/code/drasil-example/pdcontroller/lib/Drasil/PDController/Body.hs
+++ b/code/drasil-example/pdcontroller/lib/Drasil/PDController/Body.hs
@@ -43,7 +43,7 @@ naveen :: Person
 naveen = person "Naveen Ganesh" "Muralidharan"
 
 srs :: Document
-srs = mkDoc mkSRS (S.forGen titleize phrase) si
+srs = mkDoc mkSRS (S.forGen titleize phrase) fullSI
 
 fullSI :: System
 fullSI = fillcdbSRS mkSRS si

--- a/code/drasil-example/projectile/lib/Drasil/Projectile/Body.hs
+++ b/code/drasil-example/projectile/lib/Drasil/Projectile/Body.hs
@@ -50,7 +50,7 @@ import Theory.Drasil (TheoryModel)
 import Drasil.System (SystemKind(Specification), mkSystem)
 
 srs :: Document
-srs = mkDoc mkSRS (S.forGen titleize phrase) si
+srs = mkDoc mkSRS (S.forGen titleize phrase) fullSI
 
 fullSI :: System
 fullSI = fillcdbSRS mkSRS si

--- a/code/drasil-example/sglpend/lib/Drasil/SglPend/Body.hs
+++ b/code/drasil-example/sglpend/lib/Drasil/SglPend/Body.hs
@@ -41,7 +41,7 @@ import Drasil.SglPend.Requirements (funcReqs)
 import Drasil.System (SystemKind(Specification), mkSystem)
 
 srs :: Document
-srs = mkDoc mkSRS (S.forGen titleize phrase) si
+srs = mkDoc mkSRS (S.forGen titleize phrase) fullSI
 
 fullSI :: System
 fullSI = fillcdbSRS mkSRS si

--- a/code/drasil-example/ssp/lib/Drasil/SSP/Body.hs
+++ b/code/drasil-example/ssp/lib/Drasil/SSP/Body.hs
@@ -53,7 +53,7 @@ import Drasil.SSP.Unitals (constrained, effCohesion, fricAngle, fs, index,
 --Document Setup--
 
 srs :: Document
-srs = mkDoc mkSRS S.forT si
+srs = mkDoc mkSRS S.forT fullSI
 
 printSetting :: PrintingInformation
 printSetting = piSys fullSI Equational defaultConfiguration

--- a/code/drasil-example/swhs/lib/Drasil/SWHS/Body.hs
+++ b/code/drasil-example/swhs/lib/Drasil/SWHS/Body.hs
@@ -58,7 +58,7 @@ import Drasil.System (SystemKind(Specification), mkSystem)
 -------------------------------------------------------------------------------
 
 srs :: Document
-srs = mkDoc mkSRS S.forT si
+srs = mkDoc mkSRS S.forT fullSI
 
 fullSI :: System
 fullSI = fillcdbSRS mkSRS si

--- a/code/drasil-example/swhsnopcm/lib/Drasil/SWHSNoPCM/Body.hs
+++ b/code/drasil-example/swhsnopcm/lib/Drasil/SWHSNoPCM/Body.hs
@@ -65,7 +65,7 @@ import Drasil.SWHSNoPCM.Unitals (inputs, constrained, unconstrained,
 import Drasil.System (SystemKind(Specification), mkSystem)
 
 srs :: Document
-srs = mkDoc mkSRS S.forT si
+srs = mkDoc mkSRS S.forT fullSI
 
 fullSI :: System
 fullSI = fillcdbSRS mkSRS si

--- a/code/drasil-example/template/lib/Drasil/Template/Body.hs
+++ b/code/drasil-example/template/lib/Drasil/Template/Body.hs
@@ -19,7 +19,7 @@ import Drasil.DocumentLanguage.TraceabilityGraph
 import Drasil.DocLang (tunitNone)
 
 srs :: Document
-srs = mkDoc mkSRS (S.forGen titleize phrase) si
+srs = mkDoc mkSRS (S.forGen titleize phrase) fullSI
 
 fullSI :: System
 fullSI = fillcdbSRS mkSRS si


### PR DESCRIPTION
`fullSI` is calculated once in all of our `Body.hs` files and then again in `DocumentLanguage.hs`' `mkDoc` function.

With #4423 and this PR, we can look more into each of our `fullSI`'s and figure out where those should really belong. I suspect that should be something we completely push into `drasil-docLang` functionality. Right now, there's significant duplication, and the way information flows is a bit difficult to decipher.