### PR TITLE
Install fresh JupyterLab copy to fix broken MathJax JupyterLab-based SRSs converted into HTML

### DIFF
--- a/.github/workflows/Build.yaml
+++ b/.github/workflows/Build.yaml
@@ -129,7 +129,7 @@ jobs:
 
       - name: "Extract HTML copies of Jupyter Notebooks"
         run: |
-          sudo apt-get install -y --fix-missing jupyter
+          pip install jupyterlab
           make jupyter_html
         if: ${{ steps.changes.outputs.md == 'true' || fromJSON(env.is_deployment) }}
 


### PR DESCRIPTION
Closes #4339

You can see a demo at https://balacij.github.io/Drasil/examples/swhsnopcm/SRS/Jupyter/SWHSNoPCM_SRS.html