### PR TITLE
swhsnopcm: Remove extra added copy of tempW to symbols list.

### DIFF
--- a/code/drasil-example/swhsnopcm/lib/Drasil/SWHSNoPCM/Body.hs
+++ b/code/drasil-example/swhsnopcm/lib/Drasil/SWHSNoPCM/Body.hs
@@ -83,8 +83,7 @@ printSetting = piSys (fullSI ^. systemdb) Equational defaultConfiguration
 
 -- This contains the list of symbols used throughout the document
 symbols :: [DefinedQuantityDict]
-symbols = map dqdWr concepts ++ map dqdWr constrained
- ++ map dqdWr [tempW, watE]
+symbols = dqdWr watE : map dqdWr concepts ++ map dqdWr constrained
 
 symbolsAll :: [DefinedQuantityDict] --FIXME: Why is PCM (swhsSymbolsAll) here?
                                --Can't generate without SWHS-specific symbols like pcmHTC and pcmSA


### PR DESCRIPTION
Before:

```
cd "build/swhsnopcm" && stack exec --no-nix-pure -- "swhsnopcm"
WARNING! Overwriting `tempW` :: DefinedQuantityDict
WARNING! Overwriting `instance:findMass` :: ConceptInstance
WARNING! Overwriting `instance:checkWithPhysConsts` :: ConceptInstance
WARNING! Overwriting `instance:outputInputDerivVals` :: ConceptInstance
WARNING! Overwriting `instance:calcValues` :: ConceptInstance
WARNING! Overwriting `instance:outputValues` :: ConceptInstance
```

After:

```
cd "build/swhsnopcm" && stack exec --no-nix-pure -- "swhsnopcm"
WARNING! Overwriting `instance:findMass` :: ConceptInstance
WARNING! Overwriting `instance:checkWithPhysConsts` :: ConceptInstance
WARNING! Overwriting `instance:outputInputDerivVals` :: ConceptInstance
WARNING! Overwriting `instance:calcValues` :: ConceptInstance
WARNING! Overwriting `instance:outputValues` :: ConceptInstance
```

(`tempW` is automatically added through `odeInfoChunks noPCMODEInfo` later in the file I edited in this PR.)