### PR TITLE
`drasil-database`/`ChunkDB`: Remove unneeded `UMap`s.

### DIFF
--- a/code/drasil-docLang/lib/Drasil/DocumentLanguage.hs
+++ b/code/drasil-docLang/lib/Drasil/DocumentLanguage.hs
@@ -11,7 +11,7 @@ import Control.Lens ((^.), set)
 import Data.Function (on)
 import Data.List (nub, sortBy)
 import Data.Maybe (maybeToList, mapMaybe)
-import qualified Data.Map as Map (elems, assocs, keys)
+import qualified Data.Map as Map (elems, keys)
 
 import Utils.Drasil (invert)
 
@@ -32,7 +32,7 @@ import Drasil.TraceTable (generateTraceMap)
 import Language.Drasil hiding (kind)
 import Language.Drasil.Display (compsy)
 
-import Database.Drasil (findOrErr, idMap, ChunkDB(..))
+import Database.Drasil (findOrErr, ChunkDB(..))
 import Drasil.Database.SearchTools (findAllDataDefns, findAllGenDefns,
   findAllInstMods, findAllTheoryMods, findAllConcInsts)
 
@@ -69,6 +69,7 @@ import Drasil.Sections.ReferenceMaterial (emptySectSentPlu)
 
 import qualified Data.Drasil.Concepts.Documentation as Doc (likelyChg, section_,
   software, unlikelyChg)
+import qualified Data.Map.Strict as M
 
 -- * Main Function
 
@@ -107,13 +108,12 @@ fillLC sd si@SI{ _sys = sn }
     chkdb = si ^. systemdb
     -- Pre-generate a copy of all required LabelledContents (i.e., traceability
     -- graphs) for insertion in the ChunkDB.
-    createdLCs = genTraceGraphLabCons $ programName sn
+    createdLCs = M.fromList $ map (\x -> (x ^. uid, x)) $ genTraceGraphLabCons $ programName sn
     -- FIXME: This is a semi-hack. This is only strictly necessary for the
     -- traceability graphs. Those are all chunks that should exist but not be
     -- handled like this. They should be created and included in the
     -- meta-ChunkDB of `drasil-docLang`.
-    existingLC = map (fst . snd) $ Map.assocs $ labelledcontentTable chkdb
-    chkdb2 = chkdb { labelledcontentTable = idMap $ nub $ existingLC ++ createdLCs }
+    chkdb2 = chkdb { labelledcontentTable = M.union (labelledcontentTable chkdb) createdLCs }
     si2 = set systemdb chkdb2 si
 
     containsTraceSec :: DocDesc -> Bool
@@ -136,17 +136,15 @@ fillReferences allSections si@SI{_sys = sys} = si2
     imods   = findAllInstMods chkdb
     tmods   = findAllTheoryMods chkdb
     concIns = findAllConcInsts chkdb
-    lblCon  = map fst $ Map.elems $ labelledcontentTable chkdb
-    -- search the old reference table just in case the user wants to manually add in some references
-    refs    = map fst $ Map.elems $ refTable chkdb
-    -- set new reference table in the chunk database
-    chkdb2 = chkdb { refTable = idMap $ nub $ refsFromSRS
+    lblCon  = Map.elems $ labelledcontentTable chkdb
+    newRefs = M.fromList $ map (\x -> (x ^. uid, x)) $ refsFromSRS
       ++ map (ref . makeTabRef' . getTraceConfigUID) (traceMatStandard si)
       ++ secRefs -- secRefs can be removed once #946 is complete
       ++ traceyGraphGetRefs (programName sys) ++ map ref cites
       ++ map ref ddefs ++ map ref gdefs ++ map ref imods
       ++ map ref tmods ++ map ref concIns ++ map ref lblCon
-      ++ refs }
+    -- set new reference table in the chunk database
+    chkdb2 = chkdb { refTable = M.union (refTable chkdb) newRefs }
     -- set new chunk database into system information
     si2 = set systemdb chkdb2 si
 


### PR DESCRIPTION
`UMap`s were ordered maps. The ordering isn't really needed for the two uses we have of them: `Reference`s and `LabelledContent`.