### PR TITLE
remove deprecated multilingual field from mdBook config

### DIFF
--- a/code/drasil-printers/lib/Language/Drasil/Markdown/Config.hs
+++ b/code/drasil-printers/lib/Language/Drasil/Markdown/Config.hs
@@ -19,7 +19,6 @@ makeBook :: Document -> PrintingInformation -> Doc
 makeBook (Document t _ _ _) sm = vcat [
   text "[book]",
   text "language = \"en\"",
-  text "multilingual = false",
   text "src = \"src\"",
   text "title =" <+> mkTitle sm t,
   text "[output.html]",

--- a/code/stable/dblpend/SRS/mdBook/book.toml
+++ b/code/stable/dblpend/SRS/mdBook/book.toml
@@ -1,6 +1,5 @@
 [book]
 language = "en"
-multilingual = false
 src = "src"
 title = "Software Requirements Specification for Double Pendulum"
 [output.html]

--- a/code/stable/gamephysics/SRS/mdBook/book.toml
+++ b/code/stable/gamephysics/SRS/mdBook/book.toml
@@ -1,6 +1,5 @@
 [book]
 language = "en"
-multilingual = false
 src = "src"
 title = "Software Requirements Specification for GamePhysics"
 [output.html]

--- a/code/stable/glassbr/SRS/mdBook/book.toml
+++ b/code/stable/glassbr/SRS/mdBook/book.toml
@@ -1,6 +1,5 @@
 [book]
 language = "en"
-multilingual = false
 src = "src"
 title = "Software Requirements Specification for GlassBR"
 [output.html]

--- a/code/stable/hghc/SRS/mdBook/book.toml
+++ b/code/stable/hghc/SRS/mdBook/book.toml
@@ -1,6 +1,5 @@
 [book]
 language = "en"
-multilingual = false
 src = "src"
 title = "Software Requirements Specification for HGHC"
 [output.html]

--- a/code/stable/pdcontroller/SRS/mdBook/book.toml
+++ b/code/stable/pdcontroller/SRS/mdBook/book.toml
@@ -1,6 +1,5 @@
 [book]
 language = "en"
-multilingual = false
 src = "src"
 title = "Software Requirements Specification for PD Controller"
 [output.html]

--- a/code/stable/projectile/SRS/mdBook/book.toml
+++ b/code/stable/projectile/SRS/mdBook/book.toml
@@ -1,6 +1,5 @@
 [book]
 language = "en"
-multilingual = false
 src = "src"
 title = "Software Requirements Specification for Projectile"
 [output.html]

--- a/code/stable/sglpend/SRS/mdBook/book.toml
+++ b/code/stable/sglpend/SRS/mdBook/book.toml
@@ -1,6 +1,5 @@
 [book]
 language = "en"
-multilingual = false
 src = "src"
 title = "Software Requirements Specification for Single Pendulum"
 [output.html]

--- a/code/stable/ssp/SRS/mdBook/book.toml
+++ b/code/stable/ssp/SRS/mdBook/book.toml
@@ -1,6 +1,5 @@
 [book]
 language = "en"
-multilingual = false
 src = "src"
 title = "Software Requirements Specification for Slope Stability analysis Program"
 [output.html]

--- a/code/stable/swhs/SRS/mdBook/book.toml
+++ b/code/stable/swhs/SRS/mdBook/book.toml
@@ -1,6 +1,5 @@
 [book]
 language = "en"
-multilingual = false
 src = "src"
 title = "Software Requirements Specification for Solar Water Heating Systems Incorporating PCM"
 [output.html]

--- a/code/stable/swhsnopcm/SRS/mdBook/book.toml
+++ b/code/stable/swhsnopcm/SRS/mdBook/book.toml
@@ -1,6 +1,5 @@
 [book]
 language = "en"
-multilingual = false
 src = "src"
 title = "Software Requirements Specification for Solar Water Heating System With No Phase Change Material"
 [output.html]

--- a/code/stable/template/SRS/mdBook/book.toml
+++ b/code/stable/template/SRS/mdBook/book.toml
@@ -1,6 +1,5 @@
 [book]
 language = "en"
-multilingual = false
 src = "src"
 title = "Software Requirements Specification for ProgName"
 [output.html]


### PR DESCRIPTION
Pulling @Xinlu-Y's https://github.com/JacquesCarette/Drasil/pull/4434/commits/40686164deb60742e5a623230bab348664dc0fac from #4434 to (hopefully) fix the CI: https://github.com/JacquesCarette/Drasil/actions/runs/19647614341/job/56266609038

<img width="1133" height="562" alt="Screenshot 2025-11-24 at 5 13 05 PM" src="https://github.com/user-attachments/assets/3f6f708c-62b4-467e-81a0-8e657bb30afb" />
