### PR TITLE
Removed "Functions to Generate SRS" From Sidebar

### DIFF
--- a/wiki/_Sidebar.md
+++ b/wiki/_Sidebar.md
@@ -17,7 +17,6 @@
   * [Combinators](Combinator-Documentation)
   * [Guidelines for Adding New Types and Typeclasses](Guidelines-for-Adding-New-Types-and-Typeclasses-in-Drasil)
   * [References](Reference-Design-and-Documentation)
-  * [Functions to Generate SRS Documents](Functions-to-Generate-SRS-Documents)
   * [Printing Information](Printing-Information-Guide)
   * [Sub-packages](SubPackages)
   * [Folders](Folder-layout)


### PR DESCRIPTION
In #4469, I forgot to remove the reference to the page from the sidebar. This PR fixes that.