### PR TITLE
`drasil-lang`: Switch `RawContent`'s `CodeBlock` constructor from using `CodeExpr` to `Expr`.

### DIFF
--- a/code/drasil-lang/lib/Drasil/Code/CodeExpr/Convert.hs
+++ b/code/drasil-lang/lib/Drasil/Code/CodeExpr/Convert.hs
@@ -58,13 +58,10 @@ realInterval (Bounded (il, el) (ir, er)) = Bounded (il, expr el) (ir, expr er)
 realInterval (UpTo (i, e))               = UpTo (i, expr e)
 realInterval (UpFrom (i, e))             = UpFrom (i, expr e)
 
-con :: E.Expr -> CodeExpr
-con = expr
-
 -- | Convert constrained expressions ('ConstraintE') into 'Constraint''CodeExpr's.
 constraint :: ConstraintE -> Constraint CodeExpr
 constraint (Range r ri) = Range r (realInterval ri)
-constraint (Elem r ri) = Elem r (con ri)
+constraint (Elem r ri) = Elem r (expr ri)
 
 -- | Convert 'DomainDesc Expr Expr' into 'DomainDesc CodeExpr CodeExpr's.
 renderDomainDesc :: DiscreteDomainDesc E.Expr E.Expr -> DiscreteDomainDesc CodeExpr CodeExpr

--- a/code/drasil-lang/lib/Language/Drasil/Document/Contents.hs
+++ b/code/drasil-lang/lib/Language/Drasil/Document/Contents.hs
@@ -10,24 +10,19 @@ module Language.Drasil.Document.Contents (
   unlbldCode
 ) where
 
-import Drasil.Code.CodeExpr.Lang (CodeExpr)
+import Control.Lens ((^.))
+
 import Language.Drasil.Classes (Definition(..))
 import Language.Drasil.ShortName (HasShortName(..), getSentSN)
 import Language.Drasil.Document (llcc, ulcc)
-import Language.Drasil.Document.Core
-    (LabelledContent,
-     RawContent(Enumeration, EqnBlock, CodeBlock),
-     Contents(UlC),
-     ListTuple,
-     ItemType(Flat),
-     ListType(Simple))
+import Language.Drasil.Document.Combinators (bulletFlat, mkEnumAbbrevList)
+import Language.Drasil.Document.Core (LabelledContent, RawContent(Enumeration,
+  EqnBlock, CodeBlock), Contents(UlC), ListTuple, ItemType(Flat), ListType(Simple))
+import Language.Drasil.Expr.Lang (Expr)
+import Language.Drasil.Label.Type ( Referable(refAdd) )
 import Language.Drasil.ModelExpr.Lang (ModelExpr)
 import Language.Drasil.Reference (Reference)
 import Language.Drasil.Sentence (Sentence (..))
-import Language.Drasil.Document.Combinators (bulletFlat, mkEnumAbbrevList)
-import Language.Drasil.Label.Type ( Referable(refAdd) )
-
-import Control.Lens ((^.))
 
 -- | Displays a given expression and attaches a 'Reference' to it.
 lbldExpr :: ModelExpr -> Reference -> LabelledContent
@@ -38,7 +33,7 @@ unlbldExpr :: ModelExpr -> Contents
 unlbldExpr c = UlC $ ulcc $ EqnBlock c
 
 -- | Unlabelled code expression
-unlbldCode :: CodeExpr -> Contents
+unlbldCode :: Expr -> Contents
 unlbldCode c = UlC $ ulcc $ CodeBlock c
 
 -- | Creates a bulleted list.

--- a/code/drasil-lang/lib/Language/Drasil/Document/Core.hs
+++ b/code/drasil-lang/lib/Language/Drasil/Document/Core.hs
@@ -2,9 +2,11 @@
 -- | Contains types and functions common to aspects of generating documents.
 module Language.Drasil.Document.Core where
 
+import Control.Lens ((^.), makeLenses, Lens', set, view)
+
 import Drasil.Database (HasChunkRefs(..), HasUID(..), UID)
 
-import Drasil.Code.CodeExpr.Lang (CodeExpr)
+import Language.Drasil.Expr.Lang (Expr)
 import Language.Drasil.Chunk.Citation (BibRef)
 import Language.Drasil.ShortName (HasShortName(shortname))
 import Language.Drasil.ModelExpr.Lang (ModelExpr)
@@ -12,8 +14,6 @@ import Language.Drasil.Label.Type (getAdd, prepend, IRefProg,
   LblType(..), Referable(..), HasRefAddress(..))
 import Language.Drasil.Reference (Reference)
 import Language.Drasil.Sentence (Sentence)
-
-import Control.Lens ((^.), makeLenses, Lens', set, view)
 
 -- * Lists
 
@@ -78,8 +78,7 @@ data RawContent =
                                              -- ^ For creating figures in a document includes whether the figure has a caption.
   | Bib BibRef                               -- ^ Grants the ability to reference something.
   | Graph [(Sentence, Sentence)] (Maybe Width) (Maybe Height) Lbl -- ^ Contain a graph with coordinates ('Sentence's), maybe a width and height, and a label ('Sentence').
-  | CodeBlock CodeExpr                       -- ^ Block for codes
-               -- TODO: Fill this one in.
+  | CodeBlock Expr                           -- ^ Block for codes
 
 -- | An identifier is just a 'String'.
 type Identifier = String

--- a/code/drasil-printers/lib/Language/Drasil/Printing/Import/Document.hs
+++ b/code/drasil-printers/lib/Language/Drasil/Printing/Import/Document.hs
@@ -1,22 +1,20 @@
 -- | Defines functions to transform Drasil-based documents into a printable version.
 module Language.Drasil.Printing.Import.Document where
 
+import Control.Lens ((^.))
+import Data.Bifunctor (bimap, second)
 import Data.Map (fromList)
 
 import Language.Drasil hiding (neg, sec, symbol, isIn, codeExpr)
+import Drasil.Code.CodeExpr.Development (expr)
 
 import qualified Language.Drasil.Printing.AST as P
 import qualified Language.Drasil.Printing.Citation as P
 import qualified Language.Drasil.Printing.LayoutObj as T
-import Language.Drasil.Printing.PrintingInformation
-  (PrintingInformation)
-
+import Language.Drasil.Printing.PrintingInformation (PrintingInformation)
 import Language.Drasil.Printing.Import.ModelExpr (modelExpr)
 import Language.Drasil.Printing.Import.CodeExpr (codeExpr)
 import Language.Drasil.Printing.Import.Sentence (spec)
-
-import Control.Lens ((^.))
-import Data.Bifunctor (bimap, second)
 
 -- * Main Function
 
@@ -155,7 +153,7 @@ layLabelled sm x@(LblC _ _ (DerivBlock h d))    = T.HDiv ["subsubsubsection"]
   where refr = P.S $ refAdd x ++ "Deriv"
 layLabelled sm (LblC _ _ (Enumeration cs))      = T.List $ makeL sm cs
 layLabelled  _ (LblC _ _ (Bib bib))             = T.Bib $ map layCite bib
-layLabelled sm (LblC _ _ (CodeBlock c))         = T.CodeBlock (P.E (codeExpr c sm))
+layLabelled sm (LblC _ _ (CodeBlock c))         = T.CodeBlock (P.E (codeExpr (expr c) sm))
 
 -- | Helper that translates 'RawContent's to a printable representation of 'T.LayoutObj'.
 -- Called internally by 'lay'.
@@ -176,7 +174,7 @@ layUnlabelled sm (Defini dtyp pairs)  = T.Definition dtyp (layPairs pairs) (P.S 
   where layPairs = map (second (map temp))
         temp  y   = layUnlabelled sm (y ^. accessContents)
 layUnlabelled  _ (Bib bib)              = T.Bib $ map layCite bib
-layUnlabelled sm (CodeBlock c)     = T.CodeBlock (P.E (codeExpr c sm))
+layUnlabelled sm (CodeBlock c)     = T.CodeBlock (P.E (codeExpr (expr c) sm))
 
 -- | For importing a bibliography.
 layCite :: Citation -> P.Citation


### PR DESCRIPTION
Contributes to #2885 

Succeeds #4428 

Why?

1. `CodeBlock` was only used in Projectile's lesson plan to display 3 variable assignments.
2. The code related to `CodeBlock` rendering for other document types was incomplete.
3. It ~~creates~~ contributes to a complex dependancy chain between `drasil-code`, `drasil-docLang`, and `drasil-printers` that forces code from those packages to live in `drasil-lang`. At the very least, it contributes to keeping `CodeExpr` in `drasil-lang`.

With this PR, we are a bit closer to being able to move `drasil-code`-related things in `drasil-lang` to `drasil-code`.

```
rg "import Drasil.Code" -ths drasil-lang/lib/Language
drasil-lang/lib/Language/Drasil.hs
300:import Drasil.Code.Classes (Callable, IsArgumentName)
301:import Drasil.Code.CodeVar (CodeIdea(..), CodeChunk(..),
304:import Drasil.Code.CodeExpr.Lang (CodeExpr)
305:import Drasil.Code.CodeExpr.Class (CodeExprC(..))
```

However, this PR alone is not enough because `drasil-code` relies on `drasil-printers` but `drasil-printers` relies on `CodeExpr`, which means if we were to move this code (the above listed `Drasil.Code.*` files) from `drasil-lang` to `drasil-code`, we could create a dependency cycle!

Subsequent PRs necessary to make that happen will involve splitting `Document`-related things from `drasil-printers` and `drasil-lang`.