### PR TITLE
`drasil-docLang`: Remove `drasil-code` dependency.

### DIFF
--- a/code/drasil-docLang/package.yaml
+++ b/code/drasil-docLang/package.yaml
@@ -20,7 +20,6 @@ dependencies:
 - pretty
 - transformers
 - multiplate
-- drasil-code
 - drasil-data
 - drasil-database
 - drasil-lang


### PR DESCRIPTION
Follow-up to #4503 and #4504.