### PR TITLE
remove more (essentially) dead code

### DIFF
--- a/code/drasil-example/glassbr/lib/Drasil/GlassBR/Unitals.hs
+++ b/code/drasil-example/glassbr/lib/Drasil/GlassBR/Unitals.hs
@@ -308,8 +308,8 @@ aspectRatioCon, glBreakage, lite, glassTy, annealedGl, fTemperedGl, hStrengthGl,
 annealedGl    = cc' annealed
   (S "a flat, monolithic, glass lite which has uniform thickness where" +:+
   S "the residual surface stresses are almost zero, as defined in"+:+ refS astm2016)
-aspectRatioCon   = cc aR
-  ("the ratio of the long dimension of the glass to the short dimension of " ++
+aspectRatioCon   = cc' aR
+  (S $ "the ratio of the long dimension of the glass to the short dimension of " ++
     "the glass. For glass supported on four sides, the aspect ratio is " ++
     "always equal to or greater than 1.0. For glass supported on three " ++
     "sides, the ratio of the length of one of the supported edges " ++

--- a/code/drasil-lang/lib/Language/Drasil.hs
+++ b/code/drasil-lang/lib/Language/Drasil.hs
@@ -83,7 +83,7 @@ module Language.Drasil (
   -- Language.Drasil.Chunk.Concept.Core
   , ConceptChunk, ConceptInstance, sDom
   -- Language.Drasil.Chunk.Concept
-  , dcc, dccAWDS, dccA, dccWDS, cc, cc', ccs, cw, cic
+  , dcc, dccAWDS, dccA, dccWDS, cc', ccs, cw, cic
   -- Language.Drasil.Chunk.Relation
   , RelationConcept, makeRC
   -- Language.Drasil.Chunk.DifferentialModel

--- a/code/drasil-lang/lib/Language/Drasil/Chunk/Concept.hs
+++ b/code/drasil-lang/lib/Language/Drasil/Chunk/Concept.hs
@@ -2,7 +2,7 @@
 module Language.Drasil.Chunk.Concept (
   -- * Concept Chunks
   -- ** From an idea ('IdeaDict')
-  ConceptChunk, dcc, dccA, dccAWDS, dccWDS, cc, cc', ccs, cw,
+  ConceptChunk, dcc, dccA, dccAWDS, dccWDS, cc', ccs, cw,
   -- ** From a 'ConceptChunk'
   ConceptInstance, cic
   ) where
@@ -39,11 +39,7 @@ dccWDS :: String -> NP -> Sentence -> ConceptChunk
 dccWDS i t d = dccAWDS i t d Nothing
 
 -- | Constructor for projecting an idea into a 'ConceptChunk'. Takes the definition of the
--- 'ConceptChunk' as a 'String'. Does not allow concept domain tagging.
-cc :: Idea c => c -> String -> ConceptChunk
-cc n d = ConDict (nw n) (S d) []
-
--- | Same as 'cc', except definition is a 'Sentence'.
+-- 'ConceptChunk' as a 'Sentence. Does not allow concept domain tagging.
 cc' :: Idea c => c -> Sentence -> ConceptChunk
 cc' n d = ConDict (nw n) d []
 


### PR DESCRIPTION
cc constructor was used in a single place, so remove it since it was redundant (cc' can be used instead).