### PR TITLE
Refactor mainly to make dependency graph properly visible

### DIFF
--- a/code/drasil-code/lib/Data/Drasil/ExternalLibraries/ODELibraries.hs
+++ b/code/drasil-code/lib/Data/Drasil/ExternalLibraries/ODELibraries.hs
@@ -30,7 +30,6 @@ import Language.Drasil.Data.ODEInfo (ODEInfo(..), ODEOptions(..), ODEMethod(..))
 import Language.Drasil.Data.ODELibPckg (ODELibPckg(..), mkODELib, mkODELibNoPath)
 import Language.Drasil.Mod (pubStateVar, privStateVar)
 
-
 import Drasil.Code.CodeExpr
 import Drasil.Code.CodeExpr.Development
 


### PR DESCRIPTION
Don't go through Language.Drasil.Code in ODELibraries as it is internal to this package and that obscures real dependency graph