### PR TITLE
Simplify a function in drasil-printers

### DIFF
--- a/code/drasil-printers/lib/Language/Drasil/Printing/Import/Helpers.hs
+++ b/code/drasil-printers/lib/Language/Drasil/Printing/Import/Helpers.hs
@@ -48,11 +48,8 @@ digitsProcess [] pos coun ex
 --
 -- https://en.wikipedia.org/wiki/Scientific_notation
 processExpo :: Int -> (Int, Int)
-processExpo a
-  | mod (a - 1) 3 == 0 = (1, a - 1)
-  | mod (a - 1) 3 == 1 = (2, a - 2)
-  | mod (a - 1) 3 == 2 = (3, a - 3)
-  | otherwise = error "The cases of processExpo should be exhaustive!"
+processExpo a = (r, a - r)
+  where r = 1 + mod (a -1) 3
 
 -- * Lookup/Term Resolution Functions
 

--- a/code/drasil-printers/lib/Language/Drasil/Printing/Import/Literal.hs
+++ b/code/drasil-printers/lib/Language/Drasil/Printing/Import/Literal.hs
@@ -15,9 +15,10 @@ import Language.Drasil.Printing.Import.Helpers
 
 literal :: Literal -> PrintingInformation -> P.Expr
 literal (Dbl d)                  sm = case sm ^. getSetting of
-  Engineering -> P.Row $ digitsProcess (map toInteger $ fst $ floatToDigits 10 d)
-     (fst $ processExpo $ snd $ floatToDigits 10 d) 0
-     (toInteger $ snd $ processExpo $ snd $ floatToDigits 10 d)
+  Engineering ->
+     let (f, s) = processExpo $ snd $ floatToDigits 10 d in
+     P.Row $ digitsProcess (map toInteger $ fst $ floatToDigits 10 d)
+     f 0 (toInteger s)
   Scientific  ->  P.Dbl d
 literal (Int i)                   _ = P.Int i
 literal (ExactDbl d)              _ = P.Int d


### PR DESCRIPTION
make processExpo clearly total (and simpler). Simplify its one use while at it.