### PR TITLE
move database inversion to drasil-database

### DIFF
--- a/code/drasil-database/lib/Drasil/Database.hs
+++ b/code/drasil-database/lib/Drasil/Database.hs
@@ -3,6 +3,7 @@ module Drasil.Database (
   module Drasil.Database.Chunk,
   module Drasil.Database.ChunkDB,
   module Drasil.Database.Dump,
+  module Drasil.Database.Maps,
   module Drasil.Database.TH,
   module Drasil.Database.UID,
   module Drasil.Database.UIDRef
@@ -11,6 +12,7 @@ module Drasil.Database (
 import Drasil.Database.Chunk
 import Drasil.Database.ChunkDB
 import Drasil.Database.Dump
+import Drasil.Database.Maps
 import Drasil.Database.TH
 import Drasil.Database.UID
 import Drasil.Database.UIDRef

--- a/code/drasil-database/lib/Drasil/Database/ChunkDB.hs
+++ b/code/drasil-database/lib/Drasil/Database/ChunkDB.hs
@@ -31,8 +31,8 @@ import qualified Data.Set as S
 
 import Drasil.Database.Chunk (Chunk, HasChunkRefs(chunkRefs), IsChunk,
   mkChunk, unChunk, chunkType)
+import Drasil.Database.Maps (invert)
 import Drasil.Database.UID (HasUID(..), UID)
-import Utils.Drasil (invert)
 
 -- | A chunk that depends on another.
 type Dependant = UID

--- a/code/drasil-database/lib/Drasil/Database/Maps.hs
+++ b/code/drasil-database/lib/Drasil/Database/Maps.hs
@@ -1,4 +1,4 @@
-module Utils.Drasil.Maps where
+module Drasil.Database.Maps where
 
 import Data.Map.Strict
 

--- a/code/drasil-docLang/lib/Drasil/DocumentLanguage.hs
+++ b/code/drasil-docLang/lib/Drasil/DocumentLanguage.hs
@@ -13,8 +13,6 @@ import Data.List (nub, sortBy)
 import Data.Maybe (maybeToList, mapMaybe)
 import qualified Data.Map as Map (keys)
 
-import Utils.Drasil (invert)
-
 import Drasil.DocDecl (SRSDecl, mkDocDesc)
 import qualified Drasil.DocDecl as DD
 import Drasil.DocumentLanguage.Core (AppndxSec(..), AuxConstntSec(..),
@@ -32,7 +30,7 @@ import Drasil.TraceTable (generateTraceMap)
 import Language.Drasil
 import Language.Drasil.Display (compsy)
 
-import Drasil.Database (findOrErr, ChunkDB, insertAll, UID, HasUID(..))
+import Drasil.Database (findOrErr, ChunkDB, insertAll, UID, HasUID(..), invert)
 import Drasil.Database.SearchTools (findAllDataDefns, findAllGenDefns,
   findAllInstMods, findAllTheoryMods, findAllConcInsts, findAllLabelledContent)
 

--- a/code/drasil-gen/lib/Drasil/Generator/ChunkDump.hs
+++ b/code/drasil-gen/lib/Drasil/Generator/ChunkDump.hs
@@ -13,8 +13,8 @@ import System.Environment (lookupEnv)
 import Text.PrettyPrint
 
 import Language.Drasil.Printers (PrintingInformation, printAllDebugInfo)
-import Utils.Drasil (invert, atLeast2, createDirIfMissing)
-import Drasil.Database (HasUID(..), dumpChunkDB)
+import Utils.Drasil (atLeast2, createDirIfMissing)
+import Drasil.Database (HasUID(..), dumpChunkDB, invert)
 import Drasil.System (System, systemdb, traceTable, refbyTable)
 import Drasil.Database.SearchTools (findAllIdeaDicts)
 

--- a/code/drasil-utils/lib/Utils/Drasil.hs
+++ b/code/drasil-utils/lib/Utils/Drasil.hs
@@ -19,9 +19,6 @@ module Utils.Drasil (
   foldle, foldle1,
   toColumn, mkTable,
 
-  -- * Maps
-  invert,
-
   -- ** Strings
   toPlainName, repUnd,
 
@@ -33,6 +30,5 @@ import Utils.Drasil.Directory
 import Utils.Drasil.Document
 import Utils.Drasil.English
 import Utils.Drasil.Lists
-import Utils.Drasil.Maps
 import Utils.Drasil.Strings
 import Utils.Drasil.CSV


### PR DESCRIPTION
While the function is implemented at the level of `Map`, this is taking advantage of the 'secret' of the current implementation of the tables in `ChunkDB`. Thus this is unmodular, and thus best to 'hide' back into drasil-database.