### PR TITLE
stage 1 of moving Document from drasil-lang to drasil-docLang

### DIFF
--- a/code/drasil-docLang/lib/Drasil/Document/Contents.hs
+++ b/code/drasil-docLang/lib/Drasil/Document/Contents.hs
@@ -1,6 +1,6 @@
 -- | General functions that are useful in manipulating some Drasil types into
 -- printable 'Contents'.
-module Language.Drasil.Document.Contents (
+module Drasil.Document.Contents (
   -- * List Creation Functions
   enumBullet, enumBulletU, enumSimple,
   enumSimpleU, mkEnumSimpleD,
@@ -12,17 +12,10 @@ module Language.Drasil.Document.Contents (
 
 import Control.Lens ((^.))
 
-import Language.Drasil.Classes (Definition(..))
-import Language.Drasil.ShortName (HasShortName(..), getSentSN)
-import Language.Drasil.Document (mkRawLC, ulcc)
-import Language.Drasil.Document.Combinators (bulletFlat, mkEnumAbbrevList)
-import Language.Drasil.Document.Core (LabelledContent, RawContent(Enumeration,
-  EqnBlock, CodeBlock), Contents(UlC), ListTuple, ItemType(Flat), ListType(Simple))
-import Language.Drasil.Expr.Lang (Expr)
-import Language.Drasil.Label.Type ( Referable(refAdd) )
-import Language.Drasil.ModelExpr.Lang (ModelExpr)
-import Language.Drasil.Reference (Reference)
-import Language.Drasil.Sentence (Sentence (..))
+import Language.Drasil
+  ( Definition(..), HasShortName(..), getSentSN, mkRawLC, ulcc, bulletFlat, mkEnumAbbrevList
+  , LabelledContent, RawContent(Enumeration, EqnBlock, CodeBlock), Contents(UlC), ListTuple
+  , ItemType(Flat), ListType(Simple), Expr, Referable(refAdd), ModelExpr, Reference, Sentence (..))
 
 -- | Displays a given expression and attaches a 'Reference' to it.
 lbldExpr :: ModelExpr -> Reference -> LabelledContent

--- a/code/drasil-docLang/lib/Drasil/DocumentLanguage.hs
+++ b/code/drasil-docLang/lib/Drasil/DocumentLanguage.hs
@@ -26,6 +26,7 @@ import Drasil.DocumentLanguage.Core (AppndxSec(..), AuxConstntSec(..),
   TSIntro(..), UCsSec(..), getTraceConfigUID)
 import Drasil.DocumentLanguage.Definitions (ddefn, derivation, instanceModel,
   gdefn, tmodel)
+import Drasil.Document.Contents(mkEnumSimpleD)
 import Drasil.ExtractDocDesc (getDocDesc, egetDocDesc)
 import Drasil.TraceTable (generateTraceMap)
 

--- a/code/drasil-docLang/lib/Drasil/DocumentLanguage/Definitions.hs
+++ b/code/drasil-docLang/lib/Drasil/DocumentLanguage/Definitions.hs
@@ -15,15 +15,16 @@ import Data.List (nub)
 import Data.Maybe (mapMaybe)
 
 -- rest of Drasil
-import Language.Drasil
 import Drasil.Database (ChunkDB, UID, HasUID(..), find)
 import Drasil.System (System(_systemdb), systemdb, refbyLookup)
+import Language.Drasil
 import Theory.Drasil (DataDefinition, GenDefn, InstanceModel, Theory(..),
   TheoryModel, HasInputs(inputs), HasOutput(output, out_constraints), qdFromDD,
   Derivation(Derivation), MayHaveDerivation(derivations))
 
 -- local
 import Drasil.GetChunks (vars)
+import Drasil.Document.Contents (unlbldExpr)
 import Drasil.DocumentLanguage.Units (toSentenceUnitless)
 
 -- | Synonym for a list of 'Field's.

--- a/code/drasil-docLang/lib/Drasil/Sections/SpecificSystemDescription.hs
+++ b/code/drasil-docLang/lib/Drasil/Sections/SpecificSystemDescription.hs
@@ -22,14 +22,11 @@ module Drasil.Sections.SpecificSystemDescription (
   tmStub, ddStub, gdStub, imStub, pdStub
 ) where
 
-import Drasil.Database (UID, HasUID(..), showUID)
-import Language.Drasil hiding (variable)
-import Language.Drasil.Chunk.Concept.NamedCombinators
-import qualified Language.Drasil.NounPhrase.Combinators as NP
-import qualified Language.Drasil.Sentence.Combinators as S
-import qualified Language.Drasil.Development as D
-import Drasil.Sections.ReferenceMaterial(emptySectSentPlu)
+import Control.Lens ((^.), over)
+import Data.Maybe
 
+-- rest of Drasil
+import Drasil.Database (UID, HasUID(..), showUID)
 import Data.Drasil.Concepts.Documentation (assumption, column, constraint,
   datum, datumConstraint, inDatumConstraint, outDatumConstraint, definition,
   element, general, goalStmt, information, input_, limitation, model, output_,
@@ -41,11 +38,17 @@ import qualified Data.Drasil.Concepts.Documentation as DCD (sec)
 import Data.Drasil.Concepts.Math (equation, parameter)
 import Drasil.Metadata (inModel, thModel, dataDefn, genDefn)
 import Drasil.System (System)
+import Language.Drasil hiding (variable)
+import Language.Drasil.Chunk.Concept.NamedCombinators
+import qualified Language.Drasil.NounPhrase.Combinators as NP
+import qualified Language.Drasil.Sentence.Combinators as S
+import qualified Language.Drasil.Development as D
+
+-- local
+import Drasil.Document.Contents (enumBulletU, enumSimpleU)
 import Drasil.DocumentLanguage.Definitions (helperRefs)
 import qualified Drasil.DocLang.SRS as SRS
-
-import Control.Lens ((^.), over)
-import Data.Maybe
+import Drasil.Sections.ReferenceMaterial(emptySectSentPlu)
 
 -- Takes the system and subsections.
 -- | Specific System Description section builder.

--- a/code/drasil-docLang/package.yaml
+++ b/code/drasil-docLang/package.yaml
@@ -39,6 +39,7 @@ library:
   - Drasil.DocLang
   - Drasil.DocLang.Notebook
   - Drasil.DocLang.SRS
+  - Drasil.Document.Contents
   - Drasil.DocumentLanguage.Units
   - Drasil.DocumentLanguage.TraceabilityGraph
   - Drasil.SRSDocument

--- a/code/drasil-example/gamephysics/lib/Drasil/GamePhysics/Body.hs
+++ b/code/drasil-example/gamephysics/lib/Drasil/GamePhysics/Body.hs
@@ -10,6 +10,7 @@ import qualified Language.Drasil.Development as D
 import qualified Language.Drasil.Sentence.Combinators as S
 import Drasil.System (SystemKind(Specification), mkSystem)
 
+import Drasil.Document.Contents (enumBulletU)
 import Data.Drasil.Concepts.Documentation as Doc (assumption, concept,
   condition, consumer, endUser, environment, game, guide, input_, interface,
   object, physical, physicalSim, physics, problem, product_, project,

--- a/code/drasil-example/glassbr/lib/Drasil/GlassBR/Body.hs
+++ b/code/drasil-example/glassbr/lib/Drasil/GlassBR/Body.hs
@@ -8,6 +8,7 @@ import qualified Language.Drasil.Development as D
 
 import Drasil.Metadata as M (dataDefn, inModel, thModel)
 import Drasil.SRSDocument
+import Drasil.Document.Contents (enumBulletU)
 import Drasil.DocLang (auxSpecSent, termDefnF')
 import Drasil.Generator (cdb)
 import qualified Drasil.DocLang.SRS as SRS (reference, assumpt, inModel)

--- a/code/drasil-example/projectile/lib/Drasil/Projectile/Expressions.hs
+++ b/code/drasil-example/projectile/lib/Drasil/Projectile/Expressions.hs
@@ -7,6 +7,7 @@ module Drasil.Projectile.Expressions where
 import Prelude hiding (cos, sin)
 
 import Language.Drasil
+import Drasil.Document.Contents (lbldExpr)
 import qualified Data.Drasil.Quantities.Physics as QP (iSpeed,
   constAccel, xConstAccel, yConstAccel, ixPos, iyPos)
 import Data.Drasil.Quantities.Physics (gravitationalAccel, gravitationalAccelConst,

--- a/code/drasil-example/projectile/lib/Drasil/Projectile/Lesson/CaseProb.hs
+++ b/code/drasil-example/projectile/lib/Drasil/Projectile/Lesson/CaseProb.hs
@@ -17,6 +17,7 @@ import Language.Drasil
 import Language.Drasil.ShortHands
 import qualified Language.Drasil.Sentence.Combinators as S
 import Data.Drasil.SI_Units (s_2)
+import Drasil.Document.Contents (enumBulletU)
 
 caseProbCont :: [Contents]
 caseProbCont = [projMotionHead, motionContextP1, LlC figCSandA, motionContextP2,

--- a/code/drasil-example/projectile/lib/Drasil/Projectile/Lesson/Example.hs
+++ b/code/drasil-example/projectile/lib/Drasil/Projectile/Lesson/Example.hs
@@ -3,6 +3,7 @@ module Drasil.Projectile.Lesson.Example where
 import Data.Drasil.Concepts.Physics (velocity, height, time, acceleration, gravity, horizontalMotion)
 import qualified Data.Drasil.Quantities.Physics as QP (height, gravitationalAccel)
 import Data.Drasil.Units.Physics (velU)
+import Drasil.Document.Contents (unlbldCode)
 import Language.Drasil.ShortHands (cR, lG)
 import Language.Drasil
 import qualified Language.Drasil.Sentence.Combinators as S

--- a/code/drasil-example/swhs/lib/Drasil/SWHS/Body.hs
+++ b/code/drasil-example/swhs/lib/Drasil/SWHS/Body.hs
@@ -13,6 +13,7 @@ import qualified Language.Drasil.Development as D
 import qualified Language.Drasil.NounPhrase.Combinators as NP
 import qualified Language.Drasil.Sentence.Combinators as S
 import Drasil.System (SystemKind(Specification), mkSystem)
+import Drasil.Document.Contents (unlbldExpr)
 
 import Drasil.Metadata (inModel)
 import Data.Drasil.Concepts.Documentation as Doc (assumption, column,

--- a/code/drasil-lang/lib/Language/Drasil.hs
+++ b/code/drasil-lang/lib/Language/Drasil.hs
@@ -218,10 +218,6 @@ module Language.Drasil (
   , makeTabRef, makeFigRef, makeSecRef, makeEqnRef, makeURI
   , makeTabRef', makeFigRef', makeSecRef', makeEqnRef', makeURI'
 
-  -- | Language.Drasil.Document.Contents
-  , enumBullet, enumBulletU, enumSimple, enumSimpleU, mkEnumSimpleD
-  , lbldExpr, unlbldExpr, unlbldCode
-
   -- * Document combinators
   -- | From "Language.Drasil.Document.Combinators". General sorting functions, useful combinators,
   -- and various functions to work with Drasil [Chunk](https://github.com/JacquesCarette/Drasil/wiki/Chunks) types.
@@ -300,8 +296,6 @@ import Language.Drasil.Document.Core (Contents(..), ListType(..), ItemType(..), 
   , RawContent(..), ListTuple, MaxWidthPercent
   , HasContents(accessContents)
   , LabelledContent(..), UnlabelledContent(..), HasCaption(..))
-import Language.Drasil.Document.Contents (lbldExpr, unlbldExpr, unlbldCode
-  , enumBullet, enumBulletU, enumSimple, enumSimpleU, mkEnumSimpleD)
 import Language.Drasil.Document.Combinators
 import Language.Drasil.Unicode (RenderSpecial(..), Special(..))
 import Language.Drasil.Symbol (HasSymbol(symbol), Decoration, Symbol)

--- a/code/drasil-website/lib/Drasil/Website/About.hs
+++ b/code/drasil-website/lib/Drasil/Website/About.hs
@@ -3,6 +3,7 @@
 module Drasil.Website.About where
 
 import Language.Drasil
+import Drasil.Document.Contents (enumBulletU)
 
 -- * About Section
 


### PR DESCRIPTION
Everything to do with documents should be in docLang. Move the module highest (not lowest!) in the dependency chain first, because it can be moved cleanly.

The next module already needs lots of refactoring before it can be dealt with. For one, it doesn't have to do with documents, it's just named that way. Second, it is a massive hodge-podge of stuff that belongs elsewhere.