### PR TITLE
ModeExpr.Development does not need to export quite as much as it did

### DIFF
--- a/code/drasil-lang/lib/Language/Drasil/ModelExpr/Development.hs
+++ b/code/drasil-lang/lib/Language/Drasil/ModelExpr/Development.hs
@@ -2,24 +2,20 @@
 module Language.Drasil.ModelExpr.Development (
   -- * Types
 
-  -- ModelExpr
+  -- ModelExpr.Lang
     ModelExpr(..), UFunc(..), UFuncB(..), UFuncVV(..), UFuncVN(..)
   , ArithBinOp(..), BoolBinOp(..), EqBinOp(..), LABinOp(..), OrdBinOp(..)
   , SpaceBinOp(..), StatBinOp(..), VVVBinOp(..), VVNBinOp(..), NVVBinOp(..), ESSBinOp(..), ESBBinOp(..)
   , AssocArithOper(..), AssocBoolOper(..), AssocConcatOper(..)
-  , DerivType(..), Completeness(..)
+  , DerivType(..)
   -- * Functions
 
-  -- ModelExpr.Convert
-  , expr
   -- ModelExpr.Extract
   , meDep
   -- ModelExpr.Precedence
   , mePrec,precC, precB, precA
 ) where
 
-import Language.Drasil.Expr.Lang (Completeness(..))
-import Language.Drasil.ModelExpr.Convert (expr)
 import Language.Drasil.ModelExpr.Extract (meDep)
 import Language.Drasil.ModelExpr.Lang
 import Language.Drasil.ModelExpr.Precedence

--- a/code/drasil-printers/lib/Language/Drasil/Printing/Import/ModelExpr.hs
+++ b/code/drasil-printers/lib/Language/Drasil/Printing/Import/ModelExpr.hs
@@ -9,7 +9,13 @@ import Language.Drasil (DomainDesc(..), RealInterval(..), Inclusive(..),
   RTopology(..), LiteralC(int))
 import qualified Language.Drasil.Display as S (Symbol(..))
 import Language.Drasil.Literal.Development (Literal(..))
-import Language.Drasil.ModelExpr.Development
+import Language.Drasil.ModelExpr.Development (
+    ModelExpr(..), UFunc(..), UFuncB(..), UFuncVV(..), UFuncVN(..)
+  , ArithBinOp(..), BoolBinOp(..), EqBinOp(..), LABinOp(..), OrdBinOp(..)
+  , SpaceBinOp(..), StatBinOp(..), VVVBinOp(..), VVNBinOp(..), NVVBinOp(..), ESSBinOp(..), ESBBinOp(..)
+  , AssocArithOper(..), AssocBoolOper(..), AssocConcatOper(..)
+  , DerivType(..)
+  , mePrec, precC, precB, precA)
 
 import qualified Language.Drasil.Printing.AST as P
 import Language.Drasil.Printing.PrintingInformation (PrintingInformation)


### PR DESCRIPTION
because that extra stuff was not used in other packages.