### PR TITLE
Remove an upside down dependency in drasil-lang

### DIFF
--- a/code/drasil-lang/lib/Language/Drasil/Document/Combinators.hs
+++ b/code/drasil-lang/lib/Language/Drasil/Document/Combinators.hs
@@ -16,7 +16,9 @@ module Language.Drasil.Document.Combinators (
   bulletFlat, bulletNested, itemRefToSent, makeTMatrix, mkEnumAbbrevList,
   mkTableFromColumns, noRefs, refineChain,
   tAndDOnly, tAndDWAcc, tAndDWSym,
-  zipSentList
+  zipSentList,
+  -- * Folds that produce Content
+  foldlSP, foldlSP_, foldlSPCol
 ) where
 
 import Control.Lens ((^.))
@@ -34,15 +36,16 @@ import Language.Drasil.Classes (HasUnitSymbol(usymb), Quantity, Concept,
 import Language.Drasil.ShortName (HasShortName(..))
 import Language.Drasil.Development.Sentence (short, atStart, titleize,
   phrase, plural)
-import Language.Drasil.Document (Section)
-import Language.Drasil.Document.Core (ItemType(..), ListType(Bullet))
+import Language.Drasil.Document (mkParagraph, Section)
+import Language.Drasil.Document.Core (ItemType(..), ListType(Bullet), Contents)
 import Language.Drasil.ModelExpr.Lang (ModelExpr)
 import Language.Drasil.NounPhrase.Core (NP)
 import Language.Drasil.Reference (refS, namedRef)
 import Language.Drasil.Sentence (Sentence(S, Percent, (:+:), Sy, EmptyS), eS,
   ch, sParen, sDash, (+:+), sC, (+:+.), (!.), (+:), capSent)
 import Language.Drasil.Symbol
-import Language.Drasil.Sentence.Fold (foldlList, SepType(Comma), FoldType(List), foldlSent)
+import Language.Drasil.Sentence.Fold (foldlList, SepType(Comma), FoldType(List), foldlSent,
+  foldlSent_, foldlSentCol)
 import qualified Language.Drasil.Sentence.Combinators as S (are, in_, is, toThe)
 import Language.Drasil.Label.Type
 
@@ -244,3 +247,16 @@ checkValidStr s (x:xs)
 -- @compoundPhrase (t1 ^. term) (t2 ^. term)@.
 fterms :: (NamedIdea c, NamedIdea d) => (NP -> NP -> t) -> c -> d -> t
 fterms f a b = f (a ^. term) (b ^. term)
+
+-- | Fold sentences then turns into content using 'foldlSent'.
+foldlSP :: [Sentence] -> Contents
+foldlSP = mkParagraph . foldlSent
+
+-- | Same as 'foldlSP' but uses 'foldlSent_'.
+foldlSP_ :: [Sentence] -> Contents
+foldlSP_ = mkParagraph . foldlSent_
+
+-- | Same as 'foldlSP' but uses 'foldlSentCol'.
+foldlSPCol :: [Sentence] -> Contents
+foldlSPCol = mkParagraph . foldlSentCol
+

--- a/code/drasil-lang/lib/Language/Drasil/Sentence/Fold.hs
+++ b/code/drasil-lang/lib/Language/Drasil/Sentence/Fold.hs
@@ -8,15 +8,13 @@ module Language.Drasil.Sentence.Fold (
   -- ** Expression-related
   foldConstraints,
   -- ** Sentence-related
-  foldlEnumList, foldlList, foldlSP, foldlSP_, foldlSPCol,
+  foldlEnumList, foldlList,
   foldlSent, foldlSent_, foldlSentCol, foldlsC, foldNums, numList
 ) where
 
 import Language.Drasil.Classes ( Express(express), Quantity )
 import Language.Drasil.Constraint
     ( Constraint(Range, Elem), ConstraintE )
-import Language.Drasil.Document ( mkParagraph )
-import Language.Drasil.Document.Core ( Contents )
 import Language.Drasil.Expr.Class ( ExprC(($&&), realInterval) )
 import Language.Drasil.Sentence
     ( Sentence(S, E, EmptyS, (:+:)), sParen, (+:+), sC, (+:+.), (+:) )
@@ -45,18 +43,6 @@ foldlSent_ = foldl' (+:+) EmptyS
 -- | 'foldlSent' but ends with colon.
 foldlSentCol :: [Sentence] -> Sentence
 foldlSentCol = foldle (+:+) (+:) EmptyS
-
--- | Fold sentences then turns into content using 'foldlSent'.
-foldlSP :: [Sentence] -> Contents
-foldlSP = mkParagraph . foldlSent
-
--- | Same as 'foldlSP' but uses 'foldlSent_'.
-foldlSP_ :: [Sentence] -> Contents
-foldlSP_ = mkParagraph . foldlSent_
-
--- | Same as 'foldlSP' but uses 'foldlSentCol'.
-foldlSPCol :: [Sentence] -> Contents
-foldlSPCol = mkParagraph . foldlSentCol
 
 -- | Folds a list of elements separated by commas, including the last element.
 foldlsC :: [Sentence] -> Sentence


### PR DESCRIPTION
Language.Drasil.Sentence.Fold should not depend on Language.Drasil.Document. So move the offerences to Language.Drasil.Document.Combinators.