### PR TITLE
get rid of seldom used (and more often ill-used) commonIdea constructor.

### DIFF
--- a/code/drasil-data/lib/Data/Drasil/Concepts/Documentation.hs
+++ b/code/drasil-data/lib/Data/Drasil/Concepts/Documentation.hs
@@ -31,7 +31,7 @@ doccon = [abbAcc, abbreviation, acronym, analysis, appendix, aspect, body,
   individual, information, input_, instance_, intReader, interest, interface,
   introduction, issue, item, label, library, limitation, literacy, loss,
   material_, mainIdea, message, method_, methAndAnls, model, module_, name_,
-  nonfunctional, nonfunctionalRequirement, object, offShelf,
+  nonfunctional, nonfunctionalRequirement, notApp, object, offShelf,
   offShelfSolution, open, orgOfDoc, organization, output_, physical,
   physicalConstraint, physicalProperty, physicalSim, physicalSystem, physics,
   plan, practice, priority, problem, problemDescription, problemIntro,
@@ -53,11 +53,11 @@ doccon = [abbAcc, abbreviation, acronym, analysis, appendix, aspect, body,
 -- | Collects all documentation-related common ideas (like a concept, but with no definition).
 doccon' :: [CI]
 doccon' = [assumption, dataConst, dataDefn, desSpec, genDefn, goalStmt, inModel,
-  likelyChg, learnObj, mg, mis, notApp, notebook, physSyst, requirement, srs, thModel, typUnc,
+  likelyChg, learnObj, mg, mis, notebook, physSyst, requirement, srs, thModel, typUnc,
   unlikelyChg]
 
 assumption, desSpec, goalStmt, dataConst, likelyChg, learnObj, unlikelyChg, physSyst,
-  mg, mis, notApp, typUnc, sec, refBy, refName :: CI
+  mg, mis, typUnc, sec, refBy, refName :: CI
 
 -- * Common Ideas
 
@@ -74,7 +74,6 @@ unlikelyChg = commonIdeaWithDict "unlikelyChg" (cn' "unlikely change")          
 physSyst    = commonIdeaWithDict "physSyst"    (combineNINI physicalSystem description)              "PS"      [softEng]
 mis         = commonIdeaWithDict "mis"         (fterms compoundPhrase moduleInterface specification) "MIS"     [softEng]
 mg          = commonIdeaWithDict "mg"          (fterms compoundPhrase module_ guide)                 "MG"      [softEng]
-notApp      = commonIdea         "notApp"      (nounPhraseSP "not applicable")                       "N/A"     []
 typUnc      = commonIdeaWithDict "typUnc"      (cn' "typical uncertainty")                           "Uncert." [softEng]
 sec         = commonIdeaWithDict "section"     (cn' "section")                                       "Sec"     [documentc]
 refBy       = commonIdeaWithDict "refBy"       (cn  "referenced by")                                 "RefBy"   [documentc]
@@ -94,7 +93,7 @@ abbreviation, acronym, analysis, appendix, aspect, body, characteristic, class_,
   functional, game, general, goal, guide, implementation, individual, information,
   interest, interface, input_, instance_, intReader, introduction, issue, item,
   loss, label, library, limitation, literacy, material_, mainIdea, message, method_, module_,
-  model, name_, nonfunctional, object, offShelf, open, organization, output_,
+  model, name_, nonfunctional, notApp, object, offShelf, open, organization, output_,
   physics, physical, plan, practice, priority, problem, procedure, product_, project,
   property, purpose, quantity, realtime, review, reference, response,
   result, reviewer, safety, scope, scpOfTheProjS, second_, section_, scenario,
@@ -231,6 +230,8 @@ verification    = nc "verification"   (cn'    "verification"       )
 video           = nc "video"          (cn'    "video"              )
 year            = nc "year"           (cn'    "year"               )
 scpOfTheProjS   = nc "scpOfTheProj"   (cn'    "scope of the project") -- temporary generated for test
+
+notApp          = mkIdea "notApp" (nounPhraseSP "not applicable")   (Just "N/A")
 
 abbAcc, caseProb, charOfIR, consVals, corSol, methAndAnls, orgOfDoc, procForAnls, propOfCorSol, prpsOfDoc,
   refMat, reqInput, scpOfReq, tAuxConsts, tOfSymb, tOfUnit,

--- a/code/drasil-example/hghc/lib/Drasil/HGHC/MetaConcepts.hs
+++ b/code/drasil-example/hghc/lib/Drasil/HGHC/MetaConcepts.hs
@@ -2,5 +2,6 @@ module Drasil.HGHC.MetaConcepts (progName) where
 
 import Language.Drasil
 
+-- hack... but will have to stay until a progName is not a CI
 progName :: CI
-progName = commonIdea "hghc" (cn "HGHC") "HGHC" []
+progName = commonIdeaWithDict "hghc" (cn "HGHC") "HGHC" []

--- a/code/drasil-example/projectile/lib/Drasil/Projectile/Lesson/Body.hs
+++ b/code/drasil-example/projectile/lib/Drasil/Projectile/Lesson/Body.hs
@@ -62,7 +62,7 @@ symbols = map dqdWr [Qs.iSpeed, Qs.ixSpeed, Qs.iySpeed, Qs.speed, Qs.constAccel,
   Qs.iPos, Qs.height, horiz_velo]
 
 projectileMotionLesson :: CI
-projectileMotionLesson = commonIdea "projMotLsn" (pn "Projectile Motion Lesson") "Projectile Motion" []
+projectileMotionLesson = commonIdeaWithDict "projMotLsn" (pn "Projectile Motion Lesson") "Projectile Motion" []
 
 allRefs :: [Reference]
 allRefs = nub (figRefs ++ eqnRefs)

--- a/code/drasil-example/swhs/lib/Drasil/SWHS/MetaConcepts.hs
+++ b/code/drasil-example/swhs/lib/Drasil/SWHS/MetaConcepts.hs
@@ -2,7 +2,6 @@ module Drasil.SWHS.MetaConcepts where
 
 import Language.Drasil
 import Drasil.Metadata (materialEng)
--- import Drasil.SWHS.Concepts (phsChgMtrl)
 
 progName :: CI
 progName = commonIdeaWithDict "swhsName"   (nounPhrase "solar water heating system"
@@ -10,6 +9,6 @@ progName = commonIdeaWithDict "swhsName"   (nounPhrase "solar water heating syst
 
 -- HACK: should re-decompose this noun phrase back into components!
 progName' :: CI
-progName' = commonIdea "swhsPCM" (nounPhraseSP "solar water heating systems incorporating PCM")
+progName' = commonIdeaWithDict "swhsPCM" (nounPhraseSP "solar water heating systems incorporating PCM")
   "SWHS"
   []

--- a/code/drasil-lang/lib/Language/Drasil.hs
+++ b/code/drasil-lang/lib/Language/Drasil.hs
@@ -76,7 +76,7 @@ module Language.Drasil (
   , nc, ncUID, IdeaDict , mkIdea
   , nw -- bad name (historical)
   -- Language.Drasil.Chunk.CommonIdea
-  , CI, commonIdea, commonIdeaWithDict, prependAbrv
+  , CI, commonIdeaWithDict, prependAbrv
 
   -- *** Concepts
   -- Language.Drasil.Chunk.Concept.Core

--- a/code/drasil-lang/lib/Language/Drasil/Chunk/CommonIdea.hs
+++ b/code/drasil-lang/lib/Language/Drasil/Chunk/CommonIdea.hs
@@ -1,10 +1,12 @@
 {-# Language TemplateHaskell #-}
 -- | Contains the common idea type and respective constructors.
+-- SHOULD BE DEPRECATED. Some of the uses (for program name) should have
+-- its own chunk type. Others need examined.
 module Language.Drasil.Chunk.CommonIdea (
   -- * Common Idea datatype
   CI,
   -- * Constructors
-  commonIdea, commonIdeaWithDict,
+  commonIdeaWithDict,
   -- * Functions
   prependAbrv
 ) where
@@ -39,14 +41,13 @@ instance CommonIdea    CI where abrv = view ab
 -- | Finds the domain of a 'CI'.
 instance ConceptDomain CI where cdom = cdom'
 
--- | The commonIdea smart constructor requires a chunk id ('String'), a
--- term ('NP'), an abbreviation ('String'), and a domain (['UID']).
-commonIdea :: String -> NP -> String -> [UID] -> CI
-commonIdea s np = CI (nc s np)
-
--- | Similar to 'commonIdea', but takes a list of 'IdeaDict' (often a domain).
+-- | The commonIdeaWithDict smart constructor requires a chunk id ('String'), a
+-- term ('NP'), an abbreviation ('String'), and a
+-- list of 'IdeaDict' (should be domains).
+-- Note: should be polymorphic in 'IdeaDict', but currently causes issues with
+-- ambiguous type variables, punting for now.
 commonIdeaWithDict :: String -> NP -> String -> [IdeaDict] -> CI
-commonIdeaWithDict x y z = commonIdea x y z . map (^.uid)
+commonIdeaWithDict x y z = CI (nc x y) z . map (^.uid)
 
 -- | Prepends the abbreviation from a 'CommonIdea' to a 'String'.
 prependAbrv :: CommonIdea c => c -> String -> String

--- a/code/drasil-website/lib/Drasil/Website/Body.hs
+++ b/code/drasil-website/lib/Drasil/Website/Body.hs
@@ -105,7 +105,7 @@ allRefs fl = [gitHubRef, wikiRef, infoEncodingWiki, chunksWiki, recipesWiki, pap
 
 -- | Used for system name and kind inside of 'si'.
 webName :: CI
-webName = commonIdea "websiteName" (cn websiteTitle) "Drasil" [] -- FIXME: Improper use of a `CI`.
+webName = commonIdeaWithDict "websiteName" (cn websiteTitle) "Drasil" [] -- FIXME: Improper use of a `CI`.
 
 -- * Header Section
 


### PR DESCRIPTION
CI now has a single constructor, used everywhere.

It is still "abused" in some places. But it is easier to fix that when there is a single way to construct such. 