### PR TITLE
fix two bugs in types

### DIFF
--- a/code/drasil-data/lib/Data/Drasil/Quantities/Physics.hs
+++ b/code/drasil-data/lib/Data/Drasil/Quantities/Physics.hs
@@ -84,7 +84,7 @@ scalarPos              = uc CP.scalarPos              lP                        
 tension                = uc CP.tension                (vec cT)                                    Real        newton
 time                   = uc CP.time                   lT                                          Real        second
 torque                 = uc CP.torque                 (vec lTau)                                  Real        torqueU
-velocity               = uc CP.velocity               (Concat [vec lV, label "(", lT, label ")"]) Real        velU
+velocity               = uc CP.velocity               (Concat [vec lV, label "(", lT, label ")"]) (Vect Real) velU
 weight                 = uc CP.weight                 cW                                          Real        newton
 fOfGravity             = uc CP.fOfGravity             (sub (vec cF) (vec lG))                     Real        newton
 

--- a/code/drasil-lang/lib/Language/Drasil/Expr/Lang.hs
+++ b/code/drasil-lang/lib/Language/Drasil/Expr/Lang.hs
@@ -372,7 +372,7 @@ instance Typed Expr Space where
   infer cxt (UnaryOpVN Norm e) = do
     et <- infer cxt e
     assertRealVector et (\sp -> "Vector norm only applies to vectors of real numbers. Received `" ++ sp ++ "`.")
-    pure et
+    pure S.Real
 
   infer cxt (UnaryOpVN Dim e) = do
     et <- infer cxt e


### PR DESCRIPTION
1. velocity was not a `Vect Real`
2. type inference of vector norm did not return a `Real` !

This fixes both type checking warnings from Projectile.