### PR TITLE
Use `DefinedQuantityDict` as type of `System`'s `_quants` list rather than polymorphic type

### DIFF
--- a/code/drasil-example/gamephysics/lib/Drasil/GamePhysics/Body.hs
+++ b/code/drasil-example/gamephysics/lib/Drasil/GamePhysics/Body.hs
@@ -89,10 +89,6 @@ mkSRS = [TableOfContents,
 si :: System
 si = mkSystem progName Specification [alex, luthfi, olu]
   [purp] [] [] [] ([] :: [DefinedQuantityDict])
-  -- FIXME: The _quants field should be filled in with all the symbols, however
-  -- #1658 is why this is empty, otherwise we end up with unused (and probably
-  -- should be removed) symbols. But that's for another time. This is "fine"
-  -- because _quants are only used relative to #1658.
   tMods generalDefns dataDefs iMods
   []
   inputSymbols outputSymbols inputConstraints []

--- a/code/drasil-example/swhsnopcm/lib/Drasil/SWHSNoPCM/Body.hs
+++ b/code/drasil-example/swhsnopcm/lib/Drasil/SWHSNoPCM/Body.hs
@@ -150,9 +150,6 @@ si :: System
 si = mkSystem
   progName Specification [thulasi]
   [purp] [introStartNoPCM] [scope] [motivation]
-  -- FIXME: Everything after (and including) \\ should be removed when
-  -- #1658 is resolved. Basically, _quants is used here, but
-  -- tau does not appear in the document and thus should not be displayed.
   ((map dqdWr unconstrained ++ symbolsWCodeSymbols) \\ [dqdWr tau])
   tMods genDefs NoPCM.dataDefs NoPCM.iMods
   []

--- a/code/drasil-system/lib/Drasil/System.hs
+++ b/code/drasil-system/lib/Drasil/System.hs
@@ -74,6 +74,7 @@ data System where
   , _scope        :: Scope
   , _motivation   :: Motivation
   , _quants       :: [DefinedQuantityDict]
+  -- ^ The list of quantities to be shown in generated SRS documents.
   , _theoryModels :: [TheoryModel]
   , _genDefns     :: [GenDefn]
   , _dataDefns    :: [DataDefinition]


### PR DESCRIPTION
This lets `makeClassy` generate lenses for the `_quants` field.

This PR is one step towards removing the export of `System`s `SI` constructor.