### PR TITLE
`SglPend`: Remove unused `DefinedQuantityDict` from scope.

### DIFF
--- a/code/drasil-example/sglpend/lib/Drasil/SglPend/Unitals.hs
+++ b/code/drasil-example/sglpend/lib/Drasil/SglPend/Unitals.hs
@@ -14,7 +14,7 @@ import qualified Data.Drasil.Quantities.Physics as QP (position, ixPos, xPos, fo
   angularFrequency, frequency, period)
 import Data.Drasil.Concepts.Physics (pendulum)
 import Data.Drasil.Concepts.Math as CM (angle, iAngle)
-import Data.Drasil.Quantities.Math as QM (unitVect, pi_)
+import Data.Drasil.Quantities.Math as QM (pi_)
 import Drasil.DblPend.Concepts (rod)
 import Drasil.DblPend.Unitals (lRod)
 
@@ -53,7 +53,7 @@ initialPendAngle = uc' "initialPendAngle" (cn "initial pendulum angle")
         (sub lTheta lI) Real radian
 
 unitless :: [DefinedQuantityDict]
-unitless = [QM.unitVect, QM.pi_]
+unitless = [QM.pi_]
 
 -----------------------
 -- CONSTRAINT CHUNKS --

--- a/code/stable/sglpend/SRS/HTML/SglPend_SRS.html
+++ b/code/stable/sglpend/SRS/HTML/SglPend_SRS.html
@@ -208,11 +208,6 @@
                   <td><em>kgm<sup>2</sup></em></td>
                 </tr>
                 <tr>
-                  <td><em><b>i&#770;</b></em></td>
-                  <td>Unit vector</td>
-                  <td>--</td>
-                </tr>
-                <tr>
                   <td><em>L<sub>rod</sub></em></td>
                   <td>Length of the rod</td>
                   <td><em>m</em></td>

--- a/code/stable/sglpend/SRS/Jupyter/SglPend_SRS.ipynb
+++ b/code/stable/sglpend/SRS/Jupyter/SglPend_SRS.ipynb
@@ -93,7 +93,6 @@
     "|$f$|Frequency|$Hz$|\n",
     "|$g$|Gravitational acceleration|$\\frac{m}{s^2}$|\n",
     "|$I$|Moment of inertia|$kgm^2$|\n",
-    "|$i&#770;$|Unit vector|--|\n",
     "|$L_rod$|Length of the rod|$m$|\n",
     "|$m$|Mass|$kg$|\n",
     "|$p_x$|$x$-component of position|$m$|\n",

--- a/code/stable/sglpend/SRS/PDF/SglPend_SRS.tex
+++ b/code/stable/sglpend/SRS/PDF/SglPend_SRS.tex
@@ -83,8 +83,6 @@ $\symbf{g}$ & Gravitational acceleration & $\frac{\text{m}}{\text{s}^{2}}$
 \\
 $\symbf{I}$ & Moment of inertia & $\text{kg}\text{m}^{2}$
 \\
-$\symbf{\hat{i}}$ & Unit vector & --
-\\
 ${L_{\text{rod}}}$ & Length of the rod & ${\text{m}}$
 \\
 $m$ & Mass & ${\text{kg}}$

--- a/code/stable/sglpend/SRS/mdBook/src/SecToS.md
+++ b/code/stable/sglpend/SRS/mdBook/src/SecToS.md
@@ -13,7 +13,6 @@ The symbols used in this document are summarized in the [Table of Symbols](./Sec
 |\\(f\\)                              |Frequency                                        |\\({\text{Hz}}\\)                    |
 |\\(\boldsymbol{g}\\)                 |Gravitational acceleration                       |\\(\frac{\text{m}}{\text{s}^{2}}\\)  |
 |\\(\boldsymbol{I}\\)                 |Moment of inertia                                |\\(\text{kg}\text{m}^{2}\\)          |
-|\\(\boldsymbol{\hat{i}}\\)           |Unit vector                                      |--                                   |
 |\\({L\_{\text{rod}}}\\)              |Length of the rod                                |\\({\text{m}}\\)                     |
 |\\(m\\)                              |Mass                                             |\\({\text{kg}}\\)                    |
 |\\({p\_{\text{x}}}\\)                |\\(x\\)-component of position                    |\\({\text{m}}\\)                     |


### PR DESCRIPTION
The unit vector DQD was not used anywhere in the document. Proof: It's not referenced anywhere in any of the code belonging to `SglPend`. It is only imported for render in the SRS.