### PR TITLE
`DblPend`: Remove variables not immediately used in the SRS.

### DIFF
--- a/code/drasil-example/dblpend/lib/Drasil/DblPend/Unitals.hs
+++ b/code/drasil-example/dblpend/lib/Drasil/DblPend/Unitals.hs
@@ -44,7 +44,7 @@ unitalChunks = [
   pendDisAngle_1, pendDisAngle_2, angularVel_1, angularVel_2,
   xVel_1, xVel_2, yVel_1, yVel_2, xPos_1, xPos_2, yPos_1, yPos_2, xAccel_1,
   yAccel_1, xAccel_2, yAccel_2, angularAccel_1, angularAccel_2, tension_1,
-  tension_2, QPP.mass, QP.force, QP.gravitationalAccel, QP.tension, QP.acceleration,
+  tension_2, QPP.mass, QP.force, QP.gravitationalAccel, QP.acceleration,
   QP.time, QP.velocity, QP.position]
 
 lenRod_1, lenRod_2, massObj_1, massObj_2, angularVel_1, angularVel_2,

--- a/code/stable/dblpend/SRS/HTML/DblPend_SRS.html
+++ b/code/stable/dblpend/SRS/HTML/DblPend_SRS.html
@@ -258,11 +258,6 @@
                   <td><em>m</em></td>
                 </tr>
                 <tr>
-                  <td><em><b>T</b></em></td>
-                  <td>Tension</td>
-                  <td><em>N</em></td>
-                </tr>
-                <tr>
                   <td><em><b>T</b><sub>1</sub></em></td>
                   <td>Tension of the first object</td>
                   <td><em>N</em></td>

--- a/code/stable/dblpend/SRS/Jupyter/DblPend_SRS.ipynb
+++ b/code/stable/dblpend/SRS/Jupyter/DblPend_SRS.ipynb
@@ -103,7 +103,6 @@
     "|$p_y1$|Vertical position of the first object|$m$|\n",
     "|$p_y2$|Vertical position of the second object|$m$|\n",
     "|$p(t)$|Position|$m$|\n",
-    "|$T$|Tension|$N$|\n",
     "|$T_1$|Tension of the first object|$N$|\n",
     "|$T_2$|Tension of the second object|$N$|\n",
     "|$t$|Time|$s$|\n",

--- a/code/stable/dblpend/SRS/PDF/DblPend_SRS.tex
+++ b/code/stable/dblpend/SRS/PDF/DblPend_SRS.tex
@@ -103,8 +103,6 @@ ${p_{\text{y}2}}$ & Vertical position of the second object & ${\text{m}}$
 \\
 $\symbf{p}\text{(}t\text{)}$ & Position & ${\text{m}}$
 \\
-$\symbf{T}$ & Tension & ${\text{N}}$
-\\
 ${\symbf{T}_{1}}$ & Tension of the first object & ${\text{N}}$
 \\
 ${\symbf{T}_{2}}$ & Tension of the second object & ${\text{N}}$

--- a/code/stable/dblpend/SRS/mdBook/src/SecToS.md
+++ b/code/stable/dblpend/SRS/mdBook/src/SecToS.md
@@ -24,7 +24,6 @@ The symbols used in this document are summarized in the [Table of Symbols](./Sec
 |\\({p\_{\text{y}1}}\\)               |Vertical position of the first object       |\\({\text{m}}\\)                     |
 |\\({p\_{\text{y}2}}\\)               |Vertical position of the second object      |\\({\text{m}}\\)                     |
 |\\(\boldsymbol{p}\text{(}t\text{)}\\)|Position                                    |\\({\text{m}}\\)                     |
-|\\(\boldsymbol{T}\\)                 |Tension                                     |\\({\text{N}}\\)                     |
 |\\({\boldsymbol{T}\_{1}}\\)          |Tension of the first object                 |\\({\text{N}}\\)                     |
 |\\({\boldsymbol{T}\_{2}}\\)          |Tension of the second object                |\\({\text{N}}\\)                     |
 |\\(t\\)                              |Time                                        |\\({\text{s}}\\)                     |


### PR DESCRIPTION
Proof for `unitVect` and `pi_`: We could remove the imports. Nothing relied on them.

For tension, something did rely on them, however. But in a way that immediately uses the `NP` of `QP.tension`. This should be filed as work under a new ticket -- but this will require design work. Specifically, it will require moving `UID`-based references to other things with `NP`s.