### PR TITLE
`drasil-code`: Re-order all imports.

### DIFF
--- a/code/drasil-code/lib/Data/Drasil/ExternalLibraries/ODELibraries.hs
+++ b/code/drasil-code/lib/Data/Drasil/ExternalLibraries/ODELibraries.hs
@@ -20,6 +20,8 @@ import Language.Drasil (HasSymbol(symbol), MayHaveUnit(getUnit),
   Definition (defn), (+:+), Sentence (S), DefinedQuantityDict, dqdWr, implVarAU')
 import Language.Drasil.Display (Symbol(Label, Concat))
 
+import Drasil.Code.CodeExpr
+import Drasil.Code.CodeExpr.Development
 import Language.Drasil.Chunk.Code (CodeVarChunk, CodeFuncChunk,
   quantvar, quantfunc, listToArray)
 import Language.Drasil.Chunk.NamedArgument (NamedArgument, narg)
@@ -29,9 +31,6 @@ import Language.Drasil.Code.ExternalLibraryCall
 import Language.Drasil.Data.ODEInfo (ODEInfo(..), ODEOptions(..), ODEMethod(..))
 import Language.Drasil.Data.ODELibPckg (ODELibPckg(..), mkODELib, mkODELibNoPath)
 import Language.Drasil.Mod (pubStateVar, privStateVar)
-
-import Drasil.Code.CodeExpr
-import Drasil.Code.CodeExpr.Development
 
 -- SciPy Library (Python)
 

--- a/code/drasil-code/lib/Language/Drasil/Choices.hs
+++ b/code/drasil-code/lib/Language/Drasil/Choices.hs
@@ -17,6 +17,7 @@ import qualified Data.Map as Map
 import Drasil.Database (UID, HasUID (..))
 import Drasil.GOOL (CodeType)
 import Language.Drasil hiding (None)
+
 import Language.Drasil.Code.Code (spaceToCodeType)
 import Language.Drasil.Code.Lang (Lang(..))
 import Language.Drasil.Data.ODEInfo (ODEInfo)

--- a/code/drasil-code/lib/Language/Drasil/Chunk/CodeBase.hs
+++ b/code/drasil-code/lib/Language/Drasil/Chunk/CodeBase.hs
@@ -1,10 +1,11 @@
 module Language.Drasil.Chunk.CodeBase where
 
 import Drasil.Database (ChunkDB, findOrErr, UID)
+import Language.Drasil
+
 import Drasil.Code.CodeExpr.Development
 import Drasil.Code.CodeVar (CodeChunk(..), VarOrFunc(..), CodeFuncChunk(..),
   CodeVarChunk(..))
-import Language.Drasil
 
 -- | Construct a 'CodeVarChunk' from a 'Quantity'.
 quantvar :: (Quantity c, MayHaveUnit c, Concept c) => c -> CodeVarChunk

--- a/code/drasil-code/lib/Language/Drasil/Chunk/CodeDefinition.hs
+++ b/code/drasil-code/lib/Language/Drasil/Chunk/CodeDefinition.hs
@@ -5,9 +5,10 @@ module Language.Drasil.Chunk.CodeDefinition (
 
 import Control.Lens ((^.), makeLenses, view)
 
-import Drasil.Code.CodeExpr.Development (CodeExpr, expr, CanGenCode(..))
 import Drasil.Database (HasUID (..))
 import Language.Drasil
+
+import Drasil.Code.CodeExpr.Development (CodeExpr, expr, CanGenCode(..))
 import Language.Drasil.Chunk.Code
 import Language.Drasil.Data.ODEInfo (ODEInfo(..), ODEOptions(..))
 

--- a/code/drasil-code/lib/Language/Drasil/Chunk/ConstraintMap.hs
+++ b/code/drasil-code/lib/Language/Drasil/Chunk/ConstraintMap.hs
@@ -6,8 +6,9 @@ import Control.Lens ((^.))
 import qualified Data.Map as Map
 
 import Drasil.Database (UID, HasUID(..))
-import Drasil.Code.CodeExpr.Development (CodeExpr, constraint)
 import Language.Drasil (Constraint, Constrained(..), isPhysC, isSfwrC)
+
+import Drasil.Code.CodeExpr.Development (CodeExpr, constraint)
 
 -- | Type synonym for 'Constraint CodeExpr'
 type ConstraintCE = Constraint CodeExpr

--- a/code/drasil-code/lib/Language/Drasil/Chunk/NamedArgument.hs
+++ b/code/drasil-code/lib/Language/Drasil/Chunk/NamedArgument.hs
@@ -8,13 +8,12 @@ module Language.Drasil.Chunk.NamedArgument (
 
 import Control.Lens ((^.), makeLenses, view)
 
-import Drasil.Code.Classes (IsArgumentName)
-
 import Drasil.Database (HasUID(..))
 import Language.Drasil (HasSpace(..), HasSymbol(..),
   Idea(..), MayHaveUnit(..), NamedIdea(..), Quantity,
   DefinedQuantityDict, Concept, dqdWr, Definition (defn), ConceptDomain (cdom))
 
+import Drasil.Code.Classes (IsArgumentName)
 -- | Any quantity can be a named argument (wrapper for 'DefinedQuantityDict'),
 -- but with more of a focus on generating code arguments.
 newtype NamedArgument = NA {_qtd :: DefinedQuantityDict}

--- a/code/drasil-code/lib/Language/Drasil/Chunk/Parameter.hs
+++ b/code/drasil-code/lib/Language/Drasil/Chunk/Parameter.hs
@@ -7,6 +7,7 @@ import Control.Lens ((^.), makeLenses, view)
 
 import Drasil.Database (HasUID(..))
 import Language.Drasil hiding (Ref)
+
 import Language.Drasil.Chunk.Code (CodeIdea(..), CodeChunk)
 
 -- | Determines whether a parameter is passed by value or by reference.

--- a/code/drasil-code/lib/Language/Drasil/Code.hs
+++ b/code/drasil-code/lib/Language/Drasil/Code.hs
@@ -47,17 +47,14 @@ module Language.Drasil.Code (
 
 import Prelude hiding (break, print, return, log, exp)
 
+import Drasil.Code.CodeExpr (field)
 import Language.Drasil.Code.Imperative.Generator (generator, generateCode,
   generateCodeProc)
-
 import Language.Drasil.Code.Imperative.ReadInput (readWithDataDesc,
   sampleInputDD)
-
 import Language.Drasil.Code.CodeGeneration (makeCode, createCodeFiles)
-
 import Language.Drasil.Code.DataDesc (junkLine, multiLine, repeated, singleLine,
   singleton)
-
 import Language.Drasil.Code.ExternalLibrary (ExternalLibrary, Step,
   FunctionInterface, Argument, externalLib, choiceSteps, choiceStep,
   mandatoryStep, mandatorySteps, callStep, libFunction, libMethod,
@@ -80,9 +77,7 @@ import Language.Drasil.Code.ExternalLibraryCall (ExternalLibraryCall,
   assignArrayIndexFill, assignSolFromObjFill, initSolListFromArrayFill,
   initSolListWithValFill, solveAndPopulateWhileFill, returnExprListFill,
   fixedStatementFill, fixedStatementFill', initSolWithValFill)
-
 import Language.Drasil.Code.Lang (Lang(..))
-
 import Language.Drasil.Choices (Choices(..), Comments(..), Verbosity(..),
   ConstraintBehaviour(..), ImplementationType(..), Logging(..), Modularity(..),
   Structure(..), ConstantStructure(..), ConstantRepr(..), CodeConcept(..),
@@ -91,9 +86,6 @@ import Language.Drasil.Choices (Choices(..), Comments(..), Verbosity(..),
   makeData, Maps(..), makeMaps, spaceToCodeType, makeConstraints, makeODE,
   makeDocConfig, makeLogConfig, LogConfig(..), OptionalFeatures(..),
   makeOptFeats, ExtLib(..))
-
-import Drasil.Code.CodeExpr (field)
-
 import Language.Drasil.CodeSpec (CodeSpec(..), OldCodeSpec(..), HasOldCodeSpec(..),
   codeSpec, funcUID, asVC)
 import Language.Drasil.Mod (($:=), Mod(Mod), StateVariable, Func, FuncStmt(..),
@@ -105,5 +97,4 @@ import Language.Drasil.Data.ODEInfo (ODEInfo(..), odeInfo, odeInfo', ODEOptions(
   odeOptions, ODEMethod(..))
 import Language.Drasil.Data.ODELibPckg (ODELibPckg(..), mkODELib,
   mkODELibNoPath)
-
 import Language.Drasil.Code.CodeQuantityDicts (codeDQDs)

--- a/code/drasil-code/lib/Language/Drasil/Code/Code.hs
+++ b/code/drasil-code/lib/Language/Drasil/Code/Code.hs
@@ -2,14 +2,14 @@
 module Language.Drasil.Code.Code (
     Code(..),
     spaceToCodeType
-    ) where
+) where
+
+import Data.List.NonEmpty (toList)
+import Text.PrettyPrint.HughesPJ (Doc)
 
 import qualified Language.Drasil as S (Space(..))
 
 import Drasil.GOOL (CodeType(..))
-
-import Text.PrettyPrint.HughesPJ (Doc)
-import Data.List.NonEmpty (toList)
 
 -- | Represents the generated code as a list of file names and rendered code pairs.
 newtype Code = Code { unCode :: [(FilePath, Doc)]}

--- a/code/drasil-code/lib/Language/Drasil/Code/CodeGeneration.hs
+++ b/code/drasil-code/lib/Language/Drasil/Code/CodeGeneration.hs
@@ -6,16 +6,15 @@ module Language.Drasil.Code.CodeGeneration (
   createCodeFiles
 ) where
 
-import Language.Drasil.Code.Code (Code(..))
-import Language.Drasil.Code.Imperative.GOOL.Data (AuxData(..))
-
-import Drasil.GOOL (FileData(..), ModData(modDoc))
-
-import Text.PrettyPrint.HughesPJ (Doc,render)
 import System.FilePath.Posix (takeDirectory)
 import System.IO (hPutStrLn, hClose, openFile, IOMode(WriteMode))
+import Text.PrettyPrint.HughesPJ (Doc,render)
 
+import Drasil.GOOL (FileData(..), ModData(modDoc))
 import Utils.Drasil (createDirIfMissing)
+
+import Language.Drasil.Code.Code (Code(..))
+import Language.Drasil.Code.Imperative.GOOL.Data (AuxData(..))
 
 -- | Makes code from 'FileData' ('FilePath's with module data) and 'AuxData' ('FilePath's with auxiliary document information).
 makeCode :: [FileData] -> [AuxData] -> Code

--- a/code/drasil-code/lib/Language/Drasil/Code/DataDesc.hs
+++ b/code/drasil-code/lib/Language/Drasil/Code/DataDesc.hs
@@ -1,9 +1,9 @@
 module Language.Drasil.Code.DataDesc where
 
-import Language.Drasil.Chunk.Code (CodeVarChunk)
-
 import Data.List (nub)
 import Data.List.NonEmpty (NonEmpty(..), fromList)
+
+import Language.Drasil.Chunk.Code (CodeVarChunk)
 
 -- | A 'DataItem' is just a 'CodeVarChunk' (a piece of data).
 type DataItem = CodeVarChunk

--- a/code/drasil-code/lib/Language/Drasil/Code/ExtLibImport.hs
+++ b/code/drasil-code/lib/Language/Drasil/Code/ExtLibImport.hs
@@ -4,9 +4,18 @@
 module Language.Drasil.Code.ExtLibImport (ExtLibState(..), auxMods, defs,
   imports, modExports, steps, genExternalLibraryCall) where
 
+import Prelude hiding ((!!))
+import Control.Lens (makeLenses, (^.), over)
+import Control.Monad (zipWithM)
+import Control.Monad.State (State, execState, get, modify)
+import Data.List (nub, partition)
+import Data.List.NonEmpty (NonEmpty(..), (!!), toList)
+import Data.Maybe (isJust)
+
+import Language.Drasil (HasSpace(typ), getActorName)
+
 import Drasil.Code.CodeExpr (CodeExpr, ($&&), applyWithNamedArgs,
   msgWithNamedArgs, new, newWithNamedArgs, sy)
-import Language.Drasil (HasSpace(typ), getActorName)
 import Language.Drasil.Chunk.Code (CodeVarChunk, CodeFuncChunk, codeName,
   ccObjVar)
 import Language.Drasil.Chunk.Parameter (ParameterChunk)
@@ -20,14 +29,6 @@ import Language.Drasil.Code.ExternalLibrary (ExternalLibrary, Step(..),
 import Language.Drasil.Code.ExternalLibraryCall (ExternalLibraryCall,
   StepGroupFill(..), StepFill(..), FunctionIntFill(..), ArgumentFill(..),
   ParameterFill(..), ClassInfoFill(..), MethodInfoFill(..))
-
-import Control.Lens (makeLenses, (^.), over)
-import Control.Monad (zipWithM)
-import Control.Monad.State (State, execState, get, modify)
-import Data.List (nub, partition)
-import Data.List.NonEmpty (NonEmpty(..), (!!), toList)
-import Data.Maybe (isJust)
-import Prelude hiding ((!!))
 
 -- | State object used during interpretation of an 'ExternalLibrary' and
 -- 'ExternalLibraryCall'.

--- a/code/drasil-code/lib/Language/Drasil/Code/Imperative/Build/AST.hs
+++ b/code/drasil-code/lib/Language/Drasil/Code/Imperative/Build/AST.hs
@@ -1,4 +1,5 @@
 module Language.Drasil.Code.Imperative.Build.AST where
+
 import Build.Drasil (makeS, MakeString, mkImplicitVar, mkWindowsVar, mkOSVar,
   Command, mkCheckedCommand, Dependencies)
 

--- a/code/drasil-code/lib/Language/Drasil/Code/Imperative/Build/Import.hs
+++ b/code/drasil-code/lib/Language/Drasil/Code/Imperative/Build/Import.hs
@@ -2,23 +2,21 @@ module Language.Drasil.Code.Imperative.Build.Import (
   makeBuild
 ) where
 
-import Language.Drasil.Code.Imperative.Build.AST (asFragment, DocConfig(..),
-  BuildConfig(BuildConfig), BuildDependencies(..), Ext(..), includeExt,
-  NameOpts, nameOpts, packSep, Runnable(Runnable), BuildName(..), RunType(..))
-
-import Drasil.GOOL (FileData(..), ProgData(..), GOOLState(..), headers, sources,
-  mainMod)
-
-import Build.Drasil (Annotation, (+:+), genMake, makeS, MakeString, mkFile, mkRule,
-  mkCheckedCommand, mkFreeVar, RuleTransformer(makeRule))
-
-import Data.Containers.ListUtils (nubOrd)
-
 import Control.Lens ((^.))
+import Data.Containers.ListUtils (nubOrd)
 import Data.Maybe (maybeToList)
 import System.FilePath.Posix (takeExtension, takeBaseName)
 import Text.PrettyPrint.HughesPJ (Doc)
 import Utils.Drasil (capitalize)
+
+import Language.Drasil.Code.Imperative.Build.AST (asFragment, DocConfig(..),
+  BuildConfig(BuildConfig), BuildDependencies(..), Ext(..), includeExt,
+  NameOpts, nameOpts, packSep, Runnable(Runnable), BuildName(..), RunType(..))
+
+import Build.Drasil (Annotation, (+:+), genMake, makeS, MakeString, mkFile, mkRule,
+  mkCheckedCommand, mkFreeVar, RuleTransformer(makeRule))
+import Drasil.GOOL (FileData(..), ProgData(..), GOOLState(..), headers, sources,
+  mainMod)
 import Drasil.Metadata (watermark)
 
 -- | Holds all the needed information to run a program.

--- a/code/drasil-code/lib/Language/Drasil/Code/Imperative/Doxygen/Import.hs
+++ b/code/drasil-code/lib/Language/Drasil/Code/Imperative/Doxygen/Import.hs
@@ -2,16 +2,15 @@ module Language.Drasil.Code.Imperative.Doxygen.Import (
   makeDoxConfig, yes, no
 ) where
 
-import Utils.Drasil (blank)
-
-import Drasil.GOOL (GOOLState, headers, mainMod)
-
-import Language.Drasil.Choices (Verbosity(..))
-
+import Control.Lens ((^.))
 import Data.List (intersperse, nub)
 import Data.Maybe (maybeToList)
-import Control.Lens ((^.))
 import Text.PrettyPrint.HughesPJ (Doc, (<+>), text, hcat, vcat)
+
+import Drasil.GOOL (GOOLState, headers, mainMod)
+import Utils.Drasil (blank)
+
+import Language.Drasil.Choices (Verbosity(..))
 
 -- | A 'Doc' that holds optimized choices for configuring doxygen files.
 type OptimizeChoice = Doc

--- a/code/drasil-code/lib/Language/Drasil/Code/Imperative/DrasilState.hs
+++ b/code/drasil-code/lib/Language/Drasil/Code/Imperative/DrasilState.hs
@@ -8,6 +8,7 @@ module Language.Drasil.Code.Imperative.DrasilState (
 import Control.Lens ((^.), makeLenses, over)
 import Control.Monad.State (State, gets)
 import Data.List (nub)
+import Data.Containers.ListUtils (nubOrd)
 import Data.Set (Set)
 import Data.Map (Map, fromList)
 import Text.PrettyPrint.HughesPJ (Doc, ($$))
@@ -15,8 +16,6 @@ import Text.PrettyPrint.HughesPJ (Doc, ($$))
 import Language.Drasil (Space, Expr)
 import Language.Drasil.Printers (PrintingInformation)
 import Drasil.GOOL (VisibilityTag(..), CodeType)
-
-import Data.Containers.ListUtils (nubOrd)
 
 import Drasil.Code.CodeVar (CodeIdea(..))
 import Language.Drasil.Chunk.ConstraintMap (ConstraintCE)

--- a/code/drasil-code/lib/Language/Drasil/Code/Imperative/FunctionCalls.hs
+++ b/code/drasil-code/lib/Language/Drasil/Code/Imperative/FunctionCalls.hs
@@ -4,6 +4,12 @@ module Language.Drasil.Code.Imperative.FunctionCalls (
   genCalcCall, genCalcCallProc, genOutputCall, genOutputCallProc
 ) where
 
+import Data.List ((\\), intersect)
+import qualified Data.Map as Map (lookup)
+import Data.Maybe (catMaybes)
+import Control.Applicative ((<|>))
+import Control.Monad.State (get)
+
 import Language.Drasil.Code.Imperative.GenerateGOOL (fApp, fAppProc, fAppInOut,
   fAppInOutProc)
 import Language.Drasil.Code.Imperative.Helpers (convScope)
@@ -23,12 +29,6 @@ import Language.Drasil.Choices (InternalConcept(..))
 import Drasil.GOOL (VSType, SValue, MSStatement, SharedProg, OOProg,
   TypeSym(..), VariableValue(..), StatementSym(..), DeclStatement(..),
   convType, convTypeOO)
-
-import Data.List ((\\), intersect)
-import qualified Data.Map as Map (lookup)
-import Data.Maybe (catMaybes)
-import Control.Applicative ((<|>))
-import Control.Monad.State (get)
 
 -- | Generates calls to all of the input-related functions. First is the call to
 -- the function for reading inputs, then the function for calculating derived

--- a/code/drasil-code/lib/Language/Drasil/Code/Imperative/GOOL/Data.hs
+++ b/code/drasil-code/lib/Language/Drasil/Code/Imperative/GOOL/Data.hs
@@ -3,9 +3,9 @@ module Language.Drasil.Code.Imperative.GOOL.Data (AuxData(auxFilePath, auxDoc),
   ad, PackData(packProg, packAux), packD
 ) where
 
-import Drasil.GOOL (ProgData)
-
 import Text.PrettyPrint.HughesPJ (Doc, isEmpty)
+
+import Drasil.GOOL (ProgData)
 
 -- | The underlying data type for auxiliary files in all renderers.
 data AuxData = AD {auxFilePath :: FilePath, auxDoc :: Doc}

--- a/code/drasil-code/lib/Language/Drasil/Code/Imperative/GOOL/LanguageRenderer/CSharpRenderer.hs
+++ b/code/drasil-code/lib/Language/Drasil/Code/Imperative/GOOL/LanguageRenderer/CSharpRenderer.hs
@@ -1,10 +1,15 @@
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE PostfixOperators #-}
-
 -- | The logic to render C# auxiliary files is contained in this module
 module Language.Drasil.Code.Imperative.GOOL.LanguageRenderer.CSharpRenderer (
   CSharpProject(..)
 ) where
+
+import Prelude hiding (break,print,(<>),sin,cos,tan,floor)
+import qualified Prelude as P ((<>))
+import Text.PrettyPrint.HughesPJ (Doc)
+
+import Drasil.GOOL (onCodeList, csName, csVersion)
 
 import Language.Drasil.Choices (ImplementationType(..))
 import Language.Drasil.Code.Imperative.GOOL.ClassInterface (PackageSym(..), AuxiliarySym(..))
@@ -18,12 +23,6 @@ import Language.Drasil.Code.Imperative.GOOL.Data (AuxData(..), ad, PackData(..),
 import Language.Drasil.Code.Imperative.Build.AST (BuildConfig, Runnable,
   asFragment, buildAll, nativeBinary, osClassDefault, executable, sharedLibrary)
 import Language.Drasil.Code.Imperative.Doxygen.Import (no)
-
-import Drasil.GOOL (onCodeList, csName, csVersion)
-
-import Prelude hiding (break,print,(<>),sin,cos,tan,floor)
-import qualified Prelude as P ((<>))
-import Text.PrettyPrint.HughesPJ (Doc)
 
 -- | Holds a C# project.
 newtype CSharpProject a = CSP {unCSP :: a}

--- a/code/drasil-code/lib/Language/Drasil/Code/Imperative/GOOL/LanguageRenderer/CppRenderer.hs
+++ b/code/drasil-code/lib/Language/Drasil/Code/Imperative/GOOL/LanguageRenderer/CppRenderer.hs
@@ -1,11 +1,15 @@
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE PostfixOperators #-}
-
 -- | The logic to render C++ auxiliary files is contained in this module
 module Language.Drasil.Code.Imperative.GOOL.LanguageRenderer.CppRenderer (
   CppProject(..)
 ) where
+
+import Prelude hiding (break,print,(<>),sin,cos,tan,floor,const,log,exp)
+import Text.PrettyPrint.HughesPJ (Doc)
+
+import Drasil.GOOL (onCodeList, cppName, cppVersion)
 
 import Language.Drasil.Choices (ImplementationType(..))
 import Language.Drasil.Code.Imperative.GOOL.ClassInterface (PackageSym(..), AuxiliarySym(..))
@@ -19,11 +23,6 @@ import Language.Drasil.Code.Imperative.GOOL.Data (AuxData(..), ad,
 import Language.Drasil.Code.Imperative.Build.AST (BuildConfig, Runnable,
   asFragment, buildAll, cppCompiler, nativeBinary, executable, sharedLibrary)
 import Language.Drasil.Code.Imperative.Doxygen.Import (no)
-
-import Drasil.GOOL (onCodeList, cppName, cppVersion)
-
-import Prelude hiding (break,print,(<>),sin,cos,tan,floor,const,log,exp)
-import Text.PrettyPrint.HughesPJ (Doc)
 
 -- | Holds a C++ project.
 newtype CppProject a = CPPP {unCPPP :: a}

--- a/code/drasil-code/lib/Language/Drasil/Code/Imperative/GOOL/LanguageRenderer/JavaRenderer.hs
+++ b/code/drasil-code/lib/Language/Drasil/Code/Imperative/GOOL/LanguageRenderer/JavaRenderer.hs
@@ -1,10 +1,15 @@
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE PostfixOperators #-}
-
 -- | The logic to render Java auxiliary files is contained in this module
 module Language.Drasil.Code.Imperative.GOOL.LanguageRenderer.JavaRenderer (
   JavaProject(..)
 ) where
+
+import Prelude hiding (break,print,sin,cos,tan,floor,(<>))
+import Data.List (intercalate)
+import Text.PrettyPrint.HughesPJ (Doc)
+
+import Drasil.GOOL (onCodeList, jName, jVersion)
 
 import Language.Drasil.Choices (ImplementationType(..))
 import Language.Drasil.Code.Imperative.GOOL.ClassInterface (PackageSym(..), AuxiliarySym(..))
@@ -19,12 +24,6 @@ import Language.Drasil.Code.Imperative.Build.AST (BuildConfig, BuildName(..),
   buildAllAdditionalName, includeExt, inCodePackage, interp, mainModule,
   mainModuleFile, packSep, withExt)
 import Language.Drasil.Code.Imperative.Doxygen.Import (yes)
-
-import Drasil.GOOL (onCodeList, jName, jVersion)
-
-import Data.List (intercalate)
-import Prelude hiding (break,print,sin,cos,tan,floor,(<>))
-import Text.PrettyPrint.HughesPJ (Doc)
 
 -- | Name options for Java files.
 jNameOpts :: NameOpts

--- a/code/drasil-code/lib/Language/Drasil/Code/Imperative/GOOL/LanguageRenderer/JuliaRenderer.hs
+++ b/code/drasil-code/lib/Language/Drasil/Code/Imperative/GOOL/LanguageRenderer/JuliaRenderer.hs
@@ -1,9 +1,13 @@
 {-# LANGUAGE TypeFamilies #-}
-
 -- | The logic to render Julia auxiliary files is contained in this module
 module Language.Drasil.Code.Imperative.GOOL.LanguageRenderer.JuliaRenderer (
   JuliaProject(..)
 ) where
+
+import Prelude hiding (break,print,(<>),sin,cos,tan,floor)
+import Text.PrettyPrint.HughesPJ (Doc, empty)
+
+import Drasil.GProc (onCodeList, jlName, jlVersion)
 
 import Language.Drasil.Code.Imperative.GOOL.ClassInterface (PackageSym(..), AuxiliarySym(..))
 import Language.Drasil.Code.Imperative.ReadMe.Import (ReadMeInfo(..))
@@ -13,11 +17,6 @@ import qualified
 import Language.Drasil.Code.Imperative.GOOL.Data (AuxData(..), ad, PackData(..),
   packD)
 import Language.Drasil.Code.Imperative.Build.AST (Runnable, DocConfig(..), interpMM)
-
-import Drasil.GProc (onCodeList, jlName, jlVersion)
-
-import Prelude hiding (break,print,(<>),sin,cos,tan,floor)
-import Text.PrettyPrint.HughesPJ (Doc, empty)
 
 -- | Holds a Julia project
 newtype JuliaProject a = JLP {unJLP :: a}

--- a/code/drasil-code/lib/Language/Drasil/Code/Imperative/GOOL/LanguageRenderer/LanguagePolymorphic.hs
+++ b/code/drasil-code/lib/Language/Drasil/Code/Imperative/GOOL/LanguageRenderer/LanguagePolymorphic.hs
@@ -5,8 +5,8 @@ module Language.Drasil.Code.Imperative.GOOL.LanguageRenderer.LanguagePolymorphic
 ) where
 
 import Language.Drasil (Expr)
-
 import Drasil.GOOL (ProgData, GOOLState)
+import Language.Drasil.Printers (PrintingInformation)
 
 import Language.Drasil.Choices (Comments, ImplementationType(..), Verbosity)
 import Language.Drasil.Code.DataDesc (DataDesc)
@@ -18,10 +18,8 @@ import Language.Drasil.Code.Imperative.WriteInput (makeInputFile)
 import Language.Drasil.Code.Imperative.WriteReadMe (makeReadMe)
 import Language.Drasil.Code.Imperative.GOOL.LanguageRenderer (doxConfigName,
   makefileName, sampleInputName, readMeName)
-
 import Language.Drasil.Code.Imperative.GOOL.ClassInterface (AuxiliarySym(Auxiliary, AuxHelper, auxHelperDoc, auxFromData))
 import Language.Drasil.Code.Imperative.ReadMe.Import (ReadMeInfo(..))
-import Language.Drasil.Printers (PrintingInformation)
 
 -- | Defines a Doxygen configuration file.
 doxConfig :: (AuxiliarySym r) => r (AuxHelper r) -> String ->

--- a/code/drasil-code/lib/Language/Drasil/Code/Imperative/GOOL/LanguageRenderer/PythonRenderer.hs
+++ b/code/drasil-code/lib/Language/Drasil/Code/Imperative/GOOL/LanguageRenderer/PythonRenderer.hs
@@ -1,13 +1,16 @@
 {-# LANGUAGE TypeFamilies #-}
-
 -- | The logic to render Python auxiliary files is contained in this module
 module Language.Drasil.Code.Imperative.GOOL.LanguageRenderer.PythonRenderer (
   PythonProject(..)
 ) where
 
+import Prelude hiding (break,print,sin,cos,tan,floor,(<>))
+import Text.PrettyPrint.HughesPJ (Doc)
+
+import Drasil.GOOL (onCodeList, pyName, pyVersion)
+
 import Language.Drasil.Code.Imperative.GOOL.ClassInterface (PackageSym(..), AuxiliarySym(..))
 import Language.Drasil.Code.Imperative.ReadMe.Import (ReadMeInfo(..))
-
 import qualified
   Language.Drasil.Code.Imperative.GOOL.LanguageRenderer.LanguagePolymorphic as
   G (doxConfig, readMe, sampleInput, makefile, noRunIfLib, doxDocConfig,
@@ -16,11 +19,6 @@ import Language.Drasil.Code.Imperative.GOOL.Data (AuxData(..), ad, PackData(..),
   packD)
 import Language.Drasil.Code.Imperative.Build.AST (Runnable, interpMM)
 import Language.Drasil.Code.Imperative.Doxygen.Import (yes)
-
-import Drasil.GOOL (onCodeList, pyName, pyVersion)
-
-import Prelude hiding (break,print,sin,cos,tan,floor,(<>))
-import Text.PrettyPrint.HughesPJ (Doc)
 
 -- | Holds a Python project.
 newtype PythonProject a = PP {unPP :: a}

--- a/code/drasil-code/lib/Language/Drasil/Code/Imperative/GOOL/LanguageRenderer/SwiftRenderer.hs
+++ b/code/drasil-code/lib/Language/Drasil/Code/Imperative/GOOL/LanguageRenderer/SwiftRenderer.hs
@@ -1,13 +1,17 @@
 {-# LANGUAGE TypeFamilies #-}
-
 -- | The logic to render Swift auxiliary files is contained in this module
 module Language.Drasil.Code.Imperative.GOOL.LanguageRenderer.SwiftRenderer (
   SwiftProject(..)
 ) where
 
+import Prelude hiding (break,print,(<>),sin,cos,tan,floor)
+import Text.PrettyPrint.HughesPJ (Doc, empty)
+
 import Language.Drasil.Choices (ImplementationType(..))
 import Language.Drasil.Code.Imperative.GOOL.ClassInterface (PackageSym(..), AuxiliarySym(..))
 import Language.Drasil.Code.Imperative.ReadMe.Import (ReadMeInfo(..))
+
+import Drasil.GOOL (onCodeList, swiftName, swiftVersion)
 
 import qualified
   Language.Drasil.Code.Imperative.GOOL.LanguageRenderer.LanguagePolymorphic as
@@ -16,11 +20,6 @@ import Language.Drasil.Code.Imperative.GOOL.Data (AuxData(..), ad, PackData(..),
   packD)
 import Language.Drasil.Code.Imperative.Build.AST (BuildConfig, Runnable,
   DocConfig(..), asFragment, buildAll, nativeBinary, executable, sharedLibrary)
-
-import Drasil.GOOL (onCodeList, swiftName, swiftVersion)
-
-import Prelude hiding (break,print,(<>),sin,cos,tan,floor)
-import Text.PrettyPrint.HughesPJ (Doc, empty)
 
 -- | Holds a Swift project.
 newtype SwiftProject a = SP {unSP :: a}

--- a/code/drasil-code/lib/Language/Drasil/Code/Imperative/GenODE.hs
+++ b/code/drasil-code/lib/Language/Drasil/Code/Imperative/GenODE.hs
@@ -2,7 +2,11 @@ module Language.Drasil.Code.Imperative.GenODE (
   chooseODELib
 ) where
 
+import Control.Monad.State (State, modify)
+
 import Language.Drasil (Sentence(..), (+:+.))
+
+import Language.Drasil.Choices (ODE(..))
 import Language.Drasil.Code.ExtLibImport (ExtLibState(..),
   genExternalLibraryCall)
 import Language.Drasil.Code.Lang (Lang(..))
@@ -10,9 +14,6 @@ import Language.Drasil.Chunk.Code (codeName)
 import Language.Drasil.Chunk.CodeDefinition (odeDef)
 import Language.Drasil.Mod (Name, Version)
 import Language.Drasil.Data.ODELibPckg (ODELibPckg(..))
-
-import Control.Monad.State (State, modify)
-import Language.Drasil.Choices (ODE(..))
 
 -- | Holds the generation information for an ordinary differential equation.
 type ODEGenInfo = (Maybe FilePath, [(Name, ExtLibState)], (Name,Version))

--- a/code/drasil-code/lib/Language/Drasil/Code/Imperative/GenerateGOOL.hs
+++ b/code/drasil-code/lib/Language/Drasil/Code/Imperative/GenerateGOOL.hs
@@ -4,6 +4,12 @@ module Language.Drasil.Code.Imperative.GenerateGOOL (ClassType(..),
   fAppInOut, fAppInOutProc
 ) where
 
+import Data.Bifunctor (second)
+import qualified Data.Map as Map (lookup)
+import Data.Maybe (catMaybes)
+import Control.Monad.State (get, modify)
+import Control.Lens ((^.))
+
 import Language.Drasil hiding (List)
 import Language.Drasil.Code.Imperative.DrasilState (GenState, DrasilState(..))
 import Language.Drasil.Code.Imperative.GOOL.ClassInterface (AuxiliarySym(..))
@@ -21,12 +27,6 @@ import qualified Drasil.GOOL as OO (SFile, FileSym(..), ModuleSym(..))
 
 import Drasil.GProc (ProcProg)
 import qualified Drasil.GProc as Proc (SFile, FileSym(..), ModuleSym(..))
-
-import Data.Bifunctor (second)
-import qualified Data.Map as Map (lookup)
-import Data.Maybe (catMaybes)
-import Control.Monad.State (get, modify)
-import Control.Lens ((^.))
 
 -- | Defines a GOOL module. If the user chose 'CommentMod', the module will have
 -- Doxygen comments. If the user did not choose 'CommentMod' but did choose

--- a/code/drasil-code/lib/Language/Drasil/Code/Imperative/Generator.hs
+++ b/code/drasil-code/lib/Language/Drasil/Code/Imperative/Generator.hs
@@ -3,7 +3,25 @@ module Language.Drasil.Code.Imperative.Generator (
   generator, generateCode, generateCodeProc
 ) where
 
+import Control.Lens ((^.))
+import Control.Monad.State (get, evalState, runState)
+import qualified Data.Set as Set (fromList)
+import Data.Map (fromList, member, keys, elems)
+import Data.Maybe (maybeToList, catMaybes)
+import System.Directory (setCurrentDirectory, getCurrentDirectory)
+import Text.PrettyPrint.HughesPJ (isEmpty, vcat)
+
 import Language.Drasil
+import Drasil.GOOL (OOProg, VisibilityTag(..),
+  ProgData(..), initialState)
+import qualified Drasil.GOOL as OO (GSProgram, SFile, ProgramSym(..), unCI)
+import Drasil.GProc (ProcProg)
+import qualified Drasil.GProc as Proc (GSProgram, SFile, ProgramSym(..), unCI)
+import Language.Drasil.Printers (SingleLine(OneLine), sentenceDoc, piSys, plainConfiguration)
+import Language.Drasil.Printing.Import (spec)
+import Drasil.System
+import Utils.Drasil (createDirIfMissing)
+
 import Language.Drasil.Code.Imperative.ConceptMatch (chooseConcept)
 import Language.Drasil.Code.Imperative.Descriptions (unmodularDesc)
 import Language.Drasil.Code.Imperative.SpaceMatch (chooseSpace)
@@ -33,25 +51,6 @@ import Language.Drasil.Choices (Choices(..), Modularity(..), Architecture(..),
   Visibility(..), DataInfo(..), Constraints(..), choicesSent, DocConfig(..),
   LogConfig(..), OptionalFeatures(..), InternalConcept(..))
 import Language.Drasil.CodeSpec (CodeSpec(..), HasOldCodeSpec(..), getODE)
-import Language.Drasil.Printers (SingleLine(OneLine), sentenceDoc, piSys, plainConfiguration)
-import Language.Drasil.Printing.Import (spec)
-
-import Drasil.GOOL (OOProg, VisibilityTag(..),
-  ProgData(..), initialState)
-import qualified Drasil.GOOL as OO (GSProgram, SFile, ProgramSym(..), unCI)
-import Drasil.GProc (ProcProg)
-import qualified Drasil.GProc as Proc (GSProgram, SFile, ProgramSym(..), unCI)
-import Drasil.System
-
-import Utils.Drasil (createDirIfMissing)
-
-import System.Directory (setCurrentDirectory, getCurrentDirectory)
-import Control.Lens ((^.))
-import Control.Monad.State (get, evalState, runState)
-import qualified Data.Set as Set (fromList)
-import Data.Map (fromList, member, keys, elems)
-import Data.Maybe (maybeToList, catMaybes)
-import Text.PrettyPrint.HughesPJ (isEmpty, vcat)
 
 -- | Initializes the generator's 'DrasilState'.
 -- 'String' parameter is a string representing the date.

--- a/code/drasil-code/lib/Language/Drasil/Code/Imperative/Helpers.hs
+++ b/code/drasil-code/lib/Language/Drasil/Code/Imperative/Helpers.hs
@@ -2,15 +2,16 @@ module Language.Drasil.Code.Imperative.Helpers (
   liftS, lookupC, convScope
 ) where
 
+import Control.Lens ((^.))
+import Control.Monad.State (State)
+
 import Drasil.Database (UID, findOrErr)
 import Language.Drasil (DefinedQuantityDict)
+import Drasil.GOOL (SharedProg, ScopeSym(..))
+
 import Language.Drasil.Code.Imperative.DrasilState (DrasilState(..),
   ScopeType(..))
 import Language.Drasil.CodeSpec (HasOldCodeSpec(..))
-import Drasil.GOOL (SharedProg, ScopeSym(..))
-
-import Control.Monad.State (State)
-import Control.Lens ((^.))
 
 -- | Puts a state-dependent value into a singleton list.
 liftS :: State a b -> State a [b]

--- a/code/drasil-code/lib/Language/Drasil/Code/Imperative/Import.hs
+++ b/code/drasil-code/lib/Language/Drasil/Code/Imperative/Import.hs
@@ -8,6 +8,13 @@ module Language.Drasil.Code.Imperative.Import (codeType, spaceCodeType,
   genModClasses, readData, readDataProc, renderC
 ) where
 
+import Prelude hiding (sin, cos, tan, log, exp)
+import Control.Lens ((^.))
+import qualified Data.Map as Map (lookup)
+import Control.Monad (liftM2,liftM3)
+import Control.Monad.State (get, modify)
+import Data.List ((\\), intersect)
+
 import Drasil.Code.CodeExpr (sy, ($<), ($>), ($<=), ($>=), ($&&), in')
 import qualified Drasil.Code.CodeExpr.Development as S (CodeExpr(..))
 import Drasil.Code.CodeExpr.Development (CodeExpr(..), ArithBinOp(..),
@@ -58,13 +65,6 @@ import qualified Drasil.GOOL as OO (SFile)
 import qualified Drasil.GOOL as C (CodeType(List, Array))
 import Drasil.GProc (ProcProg)
 import qualified Drasil.GProc as Proc (SFile)
-
-import Prelude hiding (sin, cos, tan, log, exp)
-import Data.List ((\\), intersect)
-import qualified Data.Map as Map (lookup)
-import Control.Monad (liftM2,liftM3)
-import Control.Monad.State (get, modify)
-import Control.Lens ((^.))
 
 -- | Gets a chunk's 'CodeType', by checking which 'CodeType' the user has chosen to
 -- match the chunk's 'Space' to.

--- a/code/drasil-code/lib/Language/Drasil/Code/Imperative/Logging.hs
+++ b/code/drasil-code/lib/Language/Drasil/Code/Imperative/Logging.hs
@@ -2,6 +2,9 @@ module Language.Drasil.Code.Imperative.Logging (
   maybeLog, logBody, loggedMethod, varLogFile
 ) where
 
+import Control.Lens.Zoom (zoom)
+import Control.Monad.State (get)
+
 import Language.Drasil.Code.Imperative.DrasilState (GenState, DrasilState(..))
 import Language.Drasil.Choices (Logging(..))
 
@@ -9,9 +12,6 @@ import Drasil.GOOL (Label, MSBody, MSBlock, SVariable, SValue, MSStatement,
   SharedProg, BodySym(..), BlockSym(..), TypeSym(..), var, VariableElim(..),
   Literal(..), VariableValue(..), StatementSym(..), DeclStatement(..),
   IOStatement(..), lensMStoVS, ScopeSym(..))
-
-import Control.Lens.Zoom (zoom)
-import Control.Monad.State (get)
 
 -- | Generates a statement that logs the given variable's value, if the user
 -- chose to turn on logging of variable assignments.

--- a/code/drasil-code/lib/Language/Drasil/Code/Imperative/Modules.hs
+++ b/code/drasil-code/lib/Language/Drasil/Code/Imperative/Modules.hs
@@ -9,10 +9,35 @@ module Language.Drasil.Code.Imperative.Modules (
   genOutputFormat, genOutputFormatProc, genSampleInput
 ) where
 
-import Drasil.Code.CodeExpr.Development
+import Prelude hiding (print)
+import Data.List (intersperse, partition)
+import Data.Map ((!), elems, member)
+import qualified Data.Map as Map (lookup, filter)
+import Data.Maybe (maybeToList, catMaybes)
+import Control.Monad (liftM2, zipWithM)
+import Control.Monad.State (get, gets, modify)
+import Control.Lens ((^.))
+import Text.PrettyPrint.HughesPJ (render)
+import Data.Deriving.Internal (interleave)
 
 import Drasil.Database (HasUID(..))
 import Language.Drasil (Constraint(..), RealInterval(..))
+import Language.Drasil.Printers (SingleLine(OneLine), codeExprDoc, showHasSymbImpl, PrintingInformation)
+import qualified Language.Drasil.Printing.Import as PI (codeExpr)
+import Drasil.GOOL (MSBody, MSBlock, SVariable, SValue, MSStatement,
+  SMethod, CSStateVar, SClass, SharedProg, OOProg, BodySym(..), bodyStatements,
+  oneLiner, BlockSym(..), PermanenceSym(..), TypeSym(..), VariableSym(..),
+  ScopeSym(..), Literal(..), VariableValue(..), CommandLineArgs(..),
+  BooleanExpression(..), StatementSym(..), AssignStatement(..),
+  DeclStatement(..), OODeclStatement(..), objDecNewNoParams,
+  extObjDecNewNoParams, IOStatement(..), ControlStatement(..), ifNoElse,
+  VisibilitySym(..), MethodSym(..), StateVarSym(..), pubDVar, convType,
+    convTypeOO, VisibilityTag(..))
+import qualified Drasil.GOOL as OO (SFile)
+import Drasil.GProc (ProcProg)
+import qualified Drasil.GProc as Proc (SFile)
+
+import Drasil.Code.CodeExpr.Development
 import Language.Drasil.Code.Imperative.Comments (getCommentBrief)
 import Language.Drasil.Code.Imperative.Descriptions (constClassDesc,
   constModDesc, dvFuncDesc, inConsFuncDesc, inFmtFuncDesc, inputClassDesc,
@@ -51,33 +76,6 @@ import Language.Drasil.Choices (Comments(..), ConstantStructure(..),
   Logging(..), Structure(..), hasSampleInput, InternalConcept(..))
 import Language.Drasil.CodeSpec (HasOldCodeSpec(..))
 import Language.Drasil.Expr.Development (Completeness(..))
-import Language.Drasil.Printers (SingleLine(OneLine), codeExprDoc, showHasSymbImpl, PrintingInformation)
-import qualified Language.Drasil.Printing.Import as PI (codeExpr)
-
-import Drasil.GOOL (MSBody, MSBlock, SVariable, SValue, MSStatement,
-  SMethod, CSStateVar, SClass, SharedProg, OOProg, BodySym(..), bodyStatements,
-  oneLiner, BlockSym(..), PermanenceSym(..), TypeSym(..), VariableSym(..),
-  ScopeSym(..), Literal(..), VariableValue(..), CommandLineArgs(..),
-  BooleanExpression(..), StatementSym(..), AssignStatement(..),
-  DeclStatement(..), OODeclStatement(..), objDecNewNoParams,
-  extObjDecNewNoParams, IOStatement(..), ControlStatement(..), ifNoElse,
-  VisibilitySym(..), MethodSym(..), StateVarSym(..), pubDVar, convType,
-    convTypeOO, VisibilityTag(..))
-
-import qualified Drasil.GOOL as OO (SFile)
-import Drasil.GProc (ProcProg)
-import qualified Drasil.GProc as Proc (SFile)
-
-import Prelude hiding (print)
-import Data.List (intersperse, partition)
-import Data.Map ((!), elems, member)
-import qualified Data.Map as Map (lookup, filter)
-import Data.Maybe (maybeToList, catMaybes)
-import Control.Monad (liftM2, zipWithM)
-import Control.Monad.State (get, gets, modify)
-import Control.Lens ((^.))
-import Text.PrettyPrint.HughesPJ (render)
-import Data.Deriving.Internal (interleave)
 
 type ConstraintCE = Constraint CodeExpr
 

--- a/code/drasil-code/lib/Language/Drasil/Code/Imperative/Parameters.hs
+++ b/code/drasil-code/lib/Language/Drasil/Code/Imperative/Parameters.hs
@@ -9,10 +9,10 @@ import Data.List (nub, (\\), delete)
 import Data.Map (member, notMember)
 import qualified Data.Map as Map (lookup)
 
-import Drasil.Code.CodeVar (CodeIdea(..), DefiningCodeExpr(..), CodeVarChunk)
+import Language.Drasil hiding (isIn)
 import Drasil.Database (HasUID(..))
 
-import Language.Drasil hiding (isIn)
+import Drasil.Code.CodeVar (CodeIdea(..), DefiningCodeExpr(..), CodeVarChunk)
 import Language.Drasil.Chunk.CodeDefinition (CodeDefinition, auxExprs)
 import Language.Drasil.Chunk.CodeBase
 import Language.Drasil.Choices (Structure(..), ConstantStructure(..),

--- a/code/drasil-code/lib/Language/Drasil/Code/Imperative/ReadInput.hs
+++ b/code/drasil-code/lib/Language/Drasil/Code/Imperative/ReadInput.hs
@@ -3,16 +3,17 @@ module Language.Drasil.Code.Imperative.ReadInput (
   sampleInputDD, readWithDataDesc
 ) where
 
-import Language.Drasil hiding (Data, Matrix)
-import Language.Drasil.Code.DataDesc (DataDesc'(..), Data'(..), DataItem'(..),
-  Delimiter, dataDesc, junk, list, singleton')
-import Language.Drasil.Chunk.Code (CodeVarChunk)
-import Language.Drasil.Expr.Development (Expr(Matrix))
-
 import Control.Lens ((^.))
 import Data.List (intersperse, isPrefixOf, transpose)
 import Data.List.Split (splitOn)
 import Data.List.NonEmpty (NonEmpty(..), toList)
+
+import Language.Drasil hiding (Data, Matrix)
+import Language.Drasil.Expr.Development (Expr(Matrix))
+
+import Language.Drasil.Code.DataDesc (DataDesc'(..), Data'(..), DataItem'(..),
+  Delimiter, dataDesc, junk, list, singleton')
+import Language.Drasil.Chunk.Code (CodeVarChunk)
 
 -- | Reads data from a file and converts the values to 'Expr's. The file must be
 -- formatted according to the 'DataDesc'' passed as a parameter.

--- a/code/drasil-code/lib/Language/Drasil/Code/Imperative/SpaceMatch.hs
+++ b/code/drasil-code/lib/Language/Drasil/Code/Imperative/SpaceMatch.hs
@@ -2,16 +2,16 @@ module Language.Drasil.Code.Imperative.SpaceMatch (
   chooseSpace
 ) where
 
+import Control.Monad.State (modify)
+import Text.PrettyPrint.HughesPJ (Doc, text)
+
+import Drasil.GOOL (CodeType(..))
 import Language.Drasil
+
 import Language.Drasil.Choices (Choices(..), Maps(..))
 import Language.Drasil.Code.Imperative.DrasilState (GenState, MatchedSpaces,
   addToDesignLog, addLoggedSpace)
 import Language.Drasil.Code.Lang (Lang(..))
-
-import Drasil.GOOL (CodeType(..))
-
-import Control.Monad.State (modify)
-import Text.PrettyPrint.HughesPJ (Doc, text)
 
 -- | Concretizes the 'spaceMatch' in 'Choices' to a 'MatchedSpace' based on target language.
 chooseSpace :: Lang -> Choices -> MatchedSpaces

--- a/code/drasil-code/lib/Language/Drasil/Code/Imperative/WriteInput.hs
+++ b/code/drasil-code/lib/Language/Drasil/Code/Imperative/WriteInput.hs
@@ -2,18 +2,19 @@ module Language.Drasil.Code.Imperative.WriteInput (
   makeInputFile
 ) where
 
+import Data.List (intersperse, transpose)
+import Text.PrettyPrint.HughesPJ (Doc, (<+>), char, empty, hcat, parens, space,
+  text, vcat)
+
 import Utils.Drasil (blank)
 import Language.Drasil hiding (space, Matrix)
-import Language.Drasil.Code.DataDesc (DataDesc, Data(..), Delim,
-  LinePattern(..), getDataInputs, isJunk)
 import Language.Drasil.Expr.Development (Expr(Matrix))
 import Language.Drasil.Printers (SingleLine(OneLine), exprDoc, sentenceDoc,
   unitDoc, PrintingInformation)
 import Language.Drasil.Printing.Import (expr, spec)
 
-import Data.List (intersperse, transpose)
-import Text.PrettyPrint.HughesPJ (Doc, (<+>), char, empty, hcat, parens, space,
-  text, vcat)
+import Language.Drasil.Code.DataDesc (DataDesc, Data(..), Delim,
+  LinePattern(..), getDataInputs, isJunk)
 
 -- | Generate a sample input file.
 makeInputFile :: PrintingInformation -> DataDesc -> [Expr] -> Doc

--- a/code/drasil-code/lib/Language/Drasil/Code/Imperative/WriteReadMe.hs
+++ b/code/drasil-code/lib/Language/Drasil/Code/Imperative/WriteReadMe.hs
@@ -2,14 +2,15 @@ module Language.Drasil.Code.Imperative.WriteReadMe (
   makeReadMe
 ) where
 
-import Language.Drasil.Choices (ImplementationType(..))
+import Prelude hiding ((<>))
+import Data.List.NonEmpty (nonEmpty, toList)
+import Text.PrettyPrint.HughesPJ (Doc, empty)
+
 import Language.Drasil.Printers (makeMd, introInfo, verInfo, unsupOS,
     extLibSec, instDoc, endNote, whatInfo)
-import Language.Drasil.Code.Imperative.ReadMe.Import (ReadMeInfo(..))
 
-import Prelude hiding ((<>))
-import Text.PrettyPrint.HughesPJ (Doc, empty)
-import Data.List.NonEmpty (nonEmpty, toList)
+import Language.Drasil.Choices (ImplementationType(..))
+import Language.Drasil.Code.Imperative.ReadMe.Import (ReadMeInfo(..))
 
 -- | Generates a README file.
 makeReadMe :: ReadMeInfo -> Doc

--- a/code/drasil-code/lib/Language/Drasil/CodeSpec.hs
+++ b/code/drasil-code/lib/Language/Drasil/CodeSpec.hs
@@ -4,7 +4,6 @@
 module Language.Drasil.CodeSpec where
 
 import Prelude hiding (const)
-
 import Control.Lens ((^.), makeLenses, Lens', makeClassyFor)
 import Data.List (nub, (\\))
 import qualified Data.Map as Map

--- a/code/drasil-code/lib/Language/Drasil/Data/ODEInfo.hs
+++ b/code/drasil-code/lib/Language/Drasil/Data/ODEInfo.hs
@@ -3,10 +3,11 @@ module Language.Drasil.Data.ODEInfo (
   ODEInfo(..), odeInfo, odeInfo', ODEOptions(..), odeOptions, ODEMethod(..)
 ) where
 
-import Drasil.Code.CodeExpr.Development
-import Language.Drasil.Chunk.Code (CodeVarChunk)
 import Theory.Drasil (makeAODESolverFormat, formEquations,
   DifferentialModel(..), ODESolverFormat(..), InitialValueProblem(..))
+
+import Drasil.Code.CodeExpr.Development
+import Language.Drasil.Chunk.Code (CodeVarChunk)
 import Language.Drasil.Chunk.CodeBase (quantvar)
 
 -- This may be temporary, but need a structure to hold ODE info for now.


### PR DESCRIPTION
Re-order according to the following scheme:

```haskell
Prelude
<External libraries>

<Internal libraries (other Drasil libraries)>

<Local modules>
```