### PR TITLE
Move `isConstructor` closer to the smart constructors for `MethodInfo`.

### DIFF
--- a/code/drasil-code/lib/Language/Drasil/Code/ExtLibImport.hs
+++ b/code/drasil-code/lib/Language/Drasil/Code/ExtLibImport.hs
@@ -16,7 +16,7 @@ import Language.Drasil.Mod (Class, StateVariable, Func(..), Mod, Name,
   funcDefParams, ctorDef)
 import Language.Drasil.Code.ExternalLibrary (ExternalLibrary, Step(..),
   FunctionInterface(..), Result(..), Argument(..), ArgumentInfo(..),
-  Parameter(..), ClassInfo(..), MethodInfo(..), FuncType(..))
+  Parameter(..), ClassInfo(..), MethodInfo(..), FuncType(..), isConstructor)
 import Language.Drasil.Code.ExternalLibraryCall (ExternalLibraryCall,
   StepGroupFill(..), StepFill(..), FunctionIntFill(..), ArgumentFill(..),
   ParameterFill(..), ClassInfoFill(..), MethodInfoFill(..))
@@ -276,11 +276,6 @@ withLocalState st = do
   newS <- get
   modify (returnLocal s)
   return (st', newS)
-
--- | Predicate that is true only if then MethodInfo is a constructor.
-isConstructor :: MethodInfo -> Bool
-isConstructor CI{} = True
-isConstructor _    = False
 
 -- Error messages
 -- | Various error messages.

--- a/code/drasil-code/lib/Language/Drasil/Code/ExternalLibrary.hs
+++ b/code/drasil-code/lib/Language/Drasil/Code/ExternalLibrary.hs
@@ -8,7 +8,7 @@ module Language.Drasil.Code.ExternalLibrary (ExternalLibrary, Step(..),
   libConstructor, libConstructorMultiReqs, constructAndReturn, lockedArg,
   lockedNamedArg, inlineArg, inlineNamedArg, preDefinedArg, preDefinedNamedArg,
   functionArg, customObjArg, recordArg, lockedParam, unnamedParam, customClass,
-  implementation, constructorInfo, methodInfo, methodInfoNoReturn,
+  implementation, constructorInfo, isConstructor, methodInfo, methodInfoNoReturn,
   appendCurrSol, populateSolList, assignArrayIndex, assignSolFromObj,
   initSolListFromArray, initSolListWithVal, solveAndPopulateWhile,
   returnExprList, fixedReturn, fixedReturn', initSolWithVal
@@ -230,6 +230,11 @@ implementation = Implements
 -- | Specifies a constructor.
 constructorInfo :: CodeFuncChunk -> [Parameter] -> [Step] -> MethodInfo
 constructorInfo c = CI ("Constructor for " ++ codeName c ++ " objects")
+
+-- | Check if a 'MethodInfo' captures a constructor.
+isConstructor :: MethodInfo -> Bool
+isConstructor CI{} = True
+isConstructor _    = False
 
 -- | Specifies a method.
 methodInfo :: CodeFuncChunk -> Description -> [Parameter] -> Description ->


### PR DESCRIPTION
Reason: It should either be deleted or moved closer to `MethodInfo` because it relies on `MethodInfo` secrets.