### PR TITLE
Moved and renamed LanguageRenderer.hs

### DIFF
--- a/code/drasil-code/lib/Language/Drasil/Code/FileNames.hs
+++ b/code/drasil-code/lib/Language/Drasil/Code/FileNames.hs
@@ -1,4 +1,4 @@
-module Language.Drasil.Code.Imperative.GOOL.LanguageRenderer (
+module Language.Drasil.Code.FileNames (
   -- * Common Syntax
   doxConfigName, makefileName, sampleInputName, readMeName
 ) where
@@ -17,4 +17,3 @@ makefileName = "Makefile"
 sampleInputName = "input.txt"
 -- | "README.md".
 readMeName = "README.md"
-

--- a/code/drasil-code/lib/Language/Drasil/Code/Imperative/GOOL/LanguageRenderer/LanguagePolymorphic.hs
+++ b/code/drasil-code/lib/Language/Drasil/Code/Imperative/GOOL/LanguageRenderer/LanguagePolymorphic.hs
@@ -15,8 +15,8 @@ import Language.Drasil.Code.Imperative.Build.AST (BuildConfig, Runnable,
   DocConfig, doxygenDocConfig)
 import Language.Drasil.Code.Imperative.Build.Import (makeBuild)
 import Language.Drasil.Code.Imperative.WriteInput (makeInputFile)
-import Language.Drasil.Code.Imperative.GOOL.LanguageRenderer (doxConfigName,
-  makefileName, sampleInputName, readMeName)
+import Language.Drasil.Code.FileNames (doxConfigName, makefileName,
+  sampleInputName, readMeName)
 import Language.Drasil.Code.Imperative.GOOL.ClassInterface (AuxiliarySym(Auxiliary, AuxHelper, auxHelperDoc, auxFromData))
 import Language.Drasil.Code.Imperative.README (ReadMeInfo(..), makeReadMe)
 

--- a/code/drasil-code/lib/Language/Drasil/Code/Imperative/Generator.hs
+++ b/code/drasil-code/lib/Language/Drasil/Code/Imperative/Generator.hs
@@ -44,7 +44,7 @@ import Language.Drasil.Code.Imperative.DrasilState (GenState, DrasilState(..),
 import Language.Drasil.Code.Imperative.GOOL.ClassInterface (PackageSym(..), AuxiliarySym(..))
 import Language.Drasil.Code.Imperative.README (ReadMeInfo(..))
 import Language.Drasil.Code.FileData (PackageData(..), fileAndContents)
-import Language.Drasil.Code.Imperative.GOOL.LanguageRenderer(sampleInputName)
+import Language.Drasil.Code.FileNames(sampleInputName)
 import Language.Drasil.Code.ExtLibImport (auxMods, imports, modExports)
 import Language.Drasil.Code.Lang (Lang(..))
 import Language.Drasil.Choices (Choices(..), Modularity(..), Architecture(..),


### PR DESCRIPTION
See #4641 for my discussion. After thinking about it some more, I don't think it makes sense to merge this file with either of the candidates I discussed there. For now I think it makes the most sense to follow #4643 and move/rename this file so that its name and location match its contents and intent.

`FileNames` was the best name I could think of. It's a bit vague about _what kind of_ file names, but `HardCodedFileNames` seems a bit verbose. Maybe we can update it when we settle on a name for "auxiliary" project files.

Closes #4641 