### PR TITLE
`drasil-code`: Auto-register dummy quantities necessary for ODE lib use.

### DIFF
--- a/code/drasil-code/lib/Data/Drasil/ExternalLibraries/ODELibraries.hs
+++ b/code/drasil-code/lib/Data/Drasil/ExternalLibraries/ODELibraries.hs
@@ -1,13 +1,13 @@
 -- | Define and collect information about ODEs and ODE solvers from various libraries.
 module Data.Drasil.ExternalLibraries.ODELibraries (
   -- * SciPy Library (Python)
-  scipyODEPckg, scipyODESymbols,
+  scipyODEPckg,
   -- * Oslo Library (C#)
-  osloPckg, osloSymbols, arrayVecDepVar,
+  osloPckg, arrayVecDepVar,
   -- * Apache Commons (Java)
-  apacheODEPckg, apacheODESymbols,
+  apacheODEPckg,
   -- * Odeint (C++)
-  odeintPckg, odeintSymbols, diffCodeChunk,
+  odeintPckg, diffCodeChunk,
   odeInfoChunks
 ) where
 
@@ -36,7 +36,8 @@ import Language.Drasil.Mod (pubStateVar, privStateVar)
 
 -- | [SciPy](https://www.scipy.org/) ODE library package.
 scipyODEPckg :: ODELibPckg
-scipyODEPckg = mkODELibNoPath "SciPy" "1.4.1" scipyODE scipyCall [Python]
+scipyODEPckg = mkODELibNoPath "SciPy" "1.4.1" scipyODESymbols scipyODE
+  scipyCall [Python]
 
 scipyODE :: ExternalLibrary
 scipyODE = externalLib [
@@ -169,7 +170,8 @@ odeintFunc = quantfunc $ implVar "odeint_scipy" (nounPhrase
 
 -- | [Oslo](https://www.microsoft.com/en-us/research/project/open-solving-library-for-odes/) ODE library package.
 osloPckg :: ODELibPckg
-osloPckg = mkODELib "OSLO" "1.2" oslo osloCall "Microsoft.Research.Oslo.dll" [CSharp]
+osloPckg = mkODELib "OSLO" "1.2" osloSymbols oslo osloCall
+  "Microsoft.Research.Oslo.dll" [CSharp]
 
 oslo :: ExternalLibrary
 oslo = externalLib [
@@ -295,7 +297,7 @@ arrayVecDepVar info = quantvar $ implVar' (show $ dv +++ "vec")
 
 -- | [Apache Commons](https://commons.apache.org/) ODE library package.
 apacheODEPckg :: ODELibPckg
-apacheODEPckg = mkODELib "Apache" "3.6.1" apacheODE apacheODECall
+apacheODEPckg = mkODELib "Apache" "3.6.1" apacheODESymbols apacheODE apacheODECall
   "lib/commons-math3-3.6.1.jar" [Java]
 
 apacheODE :: ExternalLibrary
@@ -458,7 +460,7 @@ computeDerivatives = quantfunc $ implVar "computeDerivatives_apache" (nounPhrase
 
 -- | [odeint](https://headmyshoulder.github.io/odeint-v2/) ODE library package.
 odeintPckg :: ODELibPckg
-odeintPckg = mkODELib "odeint" "v2" odeint odeintCall "." [Cpp]
+odeintPckg = mkODELib "odeint" "v2" odeintSymbols odeint odeintCall "." [Cpp]
 
 odeint :: ExternalLibrary
 odeint = externalLib [

--- a/code/drasil-code/lib/Language/Drasil/Choices.hs
+++ b/code/drasil-code/lib/Language/Drasil/Choices.hs
@@ -1,7 +1,8 @@
 -- | Defines the design language for SCS.
 module Language.Drasil.Choices (
   Choices(..), Architecture (..), makeArchit, DataInfo(..), makeData, Maps(..),
-  makeMaps, spaceToCodeType, Constraints(..), makeConstraints, ODE(..), makeODE,
+  makeMaps, spaceToCodeType, Constraints(..), makeConstraints,
+  ODE(..), makeODE, odeLibReqs,
   DocConfig(..), makeDocConfig, LogConfig(..), makeLogConfig, OptionalFeatures(..),
   makeOptFeats, ExtLib(..), Modularity(..), Structure(..),
   ConstantStructure(..), ConstantRepr(..), ConceptMatchMap, MatchedConceptMap,
@@ -21,7 +22,7 @@ import Language.Drasil hiding (None)
 import Language.Drasil.Code.Code (spaceToCodeType)
 import Language.Drasil.Code.Lang (Lang(..))
 import Language.Drasil.Data.ODEInfo (ODEInfo)
-import Language.Drasil.Data.ODELibPckg (ODELibPckg)
+import Language.Drasil.Data.ODELibPckg (ODELibPckg (libDummyQuants))
 import Language.Drasil.Mod (Name)
 
 -- | The instruction indicates how the generated program should be written down.
@@ -314,9 +315,13 @@ data ODE = ODE{
   -- | Preferentially-ordered list ODE libraries to try.
   odeLib :: [ODELibPckg]
 }
+
 -- | Constructor to create an ODE
 makeODE :: [ODEInfo] -> [ODELibPckg] -> ODE
 makeODE = ODE
+
+odeLibReqs :: ExtLib -> [DefinedQuantityDict]
+odeLibReqs (Math ode) = concatMap libDummyQuants $ odeLib ode
 
 -- | Default choices to be used as the base from which design specifications
 -- can be built.

--- a/code/drasil-code/lib/Language/Drasil/Data/ODELibPckg.hs
+++ b/code/drasil-code/lib/Language/Drasil/Data/ODELibPckg.hs
@@ -3,6 +3,8 @@ module Language.Drasil.Data.ODELibPckg (
   ODELibPckg(..), mkODELib, mkODELibNoPath
 ) where
 
+import Language.Drasil (DefinedQuantityDict)
+
 import Language.Drasil.Code.ExternalLibrary (ExternalLibrary)
 import Language.Drasil.Code.ExternalLibraryCall (ExternalLibraryCall)
 import Language.Drasil.Code.Lang (Lang)
@@ -15,6 +17,8 @@ data ODELibPckg = ODELib {
   libName :: Name,
   -- | Version.
   libVers :: Version,
+  -- | Dummy quantities necessary for use in ODE solving.
+  libDummyQuants :: [DefinedQuantityDict],
   -- | Library specifications.
   libSpec :: ExternalLibrary,
   -- | Library call.
@@ -35,15 +39,17 @@ data ODELibPckg = ODELib {
 }
 
 -- | Makes an 'ODELibPckg' with the given name, 'ExternalLibrary' specification,
--- 'ExternalLibraryCall' specification parameterized by an 'ODEInfo', local file
--- path to the library, and list of compatible languages.
-mkODELib :: Name -> Version -> ExternalLibrary -> (ODEInfo ->
-  ExternalLibraryCall) -> FilePath -> [Lang] -> ODELibPckg
-mkODELib n v e c f = ODELib n v e c (Just f)
+-- a list of necessary dummy quantities usage relies on, 'ExternalLibraryCall'
+-- specification parameterized by an 'ODEInfo', local file path to the library,
+-- and list of compatible languages.
+mkODELib :: Name -> Version -> [DefinedQuantityDict] -> ExternalLibrary ->
+  (ODEInfo -> ExternalLibraryCall) -> FilePath -> [Lang] -> ODELibPckg
+mkODELib n v dqs e c f = ODELib n v dqs e c (Just f)
 
 -- | Makes an 'ODELibPckg' with the given name, 'ExternalLibrary' specification,
--- 'ExternalLibraryCall' specification parameterized by an 'ODEInfo', and list of
--- compatible languages.
-mkODELibNoPath :: Name -> Version -> ExternalLibrary -> (ODEInfo ->
-  ExternalLibraryCall) -> [Lang] -> ODELibPckg
-mkODELibNoPath n v e c = ODELib n v e c Nothing
+-- a list of necessary dummy quantities usage relies on, 'ExternalLibraryCall'
+-- specification parameterized by an 'ODEInfo', and list of compatible
+-- languages.
+mkODELibNoPath :: Name -> Version -> [DefinedQuantityDict] -> ExternalLibrary ->
+  (ODEInfo -> ExternalLibraryCall) -> [Lang] -> ODELibPckg
+mkODELibNoPath n v dqs e c = ODELib n v dqs e c Nothing

--- a/code/drasil-example/dblpend/lib/Drasil/DblPend/Body.hs
+++ b/code/drasil-example/dblpend/lib/Drasil/DblPend/Body.hs
@@ -43,8 +43,7 @@ import Drasil.DblPend.Unitals (lenRod_1, lenRod_2, symbols, inputs, outputs,
   inConstraints, outConstraints, acronyms, constants)
 import Drasil.DblPend.Requirements (funcReqs, nonFuncReqs, funcReqsTables)
 import Drasil.DblPend.References (citations)
-import Data.Drasil.ExternalLibraries.ODELibraries (scipyODESymbols,
-  osloSymbols, apacheODESymbols, odeintSymbols, odeInfoChunks)
+import Data.Drasil.ExternalLibraries.ODELibraries (odeInfoChunks)
 import Drasil.DblPend.ODEs (dblPenODEInfo)
 
 mkSRS :: SRSDecl
@@ -126,8 +125,7 @@ background = foldlSent_ [D.toSent $ phraseNP (a_ pendulum), S "consists" `S.of_`
 -- we need all specification-level symbols along with the code-only symbols.
 -- These symbols should be added another way.
 symbolsWCodeSymbols :: [DefinedQuantityDict]
-symbolsWCodeSymbols = symbols ++ scipyODESymbols ++ osloSymbols ++ apacheODESymbols ++ odeintSymbols
-  ++ odeInfoChunks dblPenODEInfo
+symbolsWCodeSymbols = symbols ++ odeInfoChunks dblPenODEInfo
 
 ideaDicts :: [IdeaDict]
 ideaDicts =

--- a/code/drasil-example/pdcontroller/lib/Drasil/PDController/Body.hs
+++ b/code/drasil-example/pdcontroller/lib/Drasil/PDController/Body.hs
@@ -9,9 +9,7 @@ import qualified Language.Drasil.Sentence.Combinators as S
 import Drasil.System (SystemKind(Specification), mkSystem)
 
 import Data.Drasil.Concepts.Math (mathcon', ode)
-import Data.Drasil.ExternalLibraries.ODELibraries
-       (apacheODESymbols, odeintSymbols, osloSymbols,
-        scipyODESymbols, odeInfoChunks)
+import Data.Drasil.ExternalLibraries.ODELibraries (odeInfoChunks)
 import Data.Drasil.Quantities.Physics (physicscon)
 import Data.Drasil.Concepts.PhysicalProperties (physicalcon)
 import Data.Drasil.Concepts.Physics (angular, linear) -- FIXME: should not be needed?
@@ -109,7 +107,6 @@ background = foldlSent_ [S "Automatic process control with a controller (P/PI/PD
 -- 'symbolsWCodeSymbols'.
 symbolsWCodeSymbols :: [DefinedQuantityDict]
 symbolsWCodeSymbols = symbols ++ map dqdWr pidConstants
-  ++ scipyODESymbols ++ osloSymbols ++ apacheODESymbols ++ odeintSymbols
   ++ odeInfoChunks pidODEInfo
 
 ideaDicts :: [IdeaDict]

--- a/code/drasil-example/swhsnopcm/lib/Drasil/SWHSNoPCM/Body.hs
+++ b/code/drasil-example/swhsnopcm/lib/Drasil/SWHSNoPCM/Body.hs
@@ -20,8 +20,7 @@ import Data.Drasil.Concepts.Software (softwarecon)
 import Data.Drasil.Concepts.Thermodynamics (heatCapSpec, htFlux, phaseChange,
   temp, thermalAnalysis, thermalConduction, thermocon, boilPt, latentHeat, meltPt)
 
-import Data.Drasil.ExternalLibraries.ODELibraries (scipyODESymbols, osloSymbols,
-  apacheODESymbols, odeintSymbols, odeInfoChunks)
+import Data.Drasil.ExternalLibraries.ODELibraries (odeInfoChunks)
 
 import qualified Data.Drasil.Quantities.Thermodynamics as QT (temp,
   heatCapSpec, htFlux, sensHeat)
@@ -72,8 +71,7 @@ symbols = dqdWr watE : map dqdWr concepts ++ map dqdWr constrained ++
 -- FIXME: 'symbolsWCodeSymbols' shouldn't exist. See DblPend's discussion of its
 -- 'symbolsWCodeSymbols'.
 symbolsWCodeSymbols :: [DefinedQuantityDict]
-symbolsWCodeSymbols = symbols ++ scipyODESymbols ++ osloSymbols ++ apacheODESymbols ++ odeintSymbols ++
-  odeInfoChunks noPCMODEInfo
+symbolsWCodeSymbols = symbols ++ odeInfoChunks noPCMODEInfo
 
 concepts :: [UnitalChunk]
 concepts = map ucw [tau, inSA, outSA, htCapL, htFluxIn, htFluxOut, volHtGen,


### PR DESCRIPTION
The ODE libraries rely on a basic set of quantities that are always registered in the `ChunkDB` whenever the ODE libraries are asked for. This PR automates said registration process and narrows their scope to the code generator.