### PR TITLE
`drasil-code`: Auto-register variables defined in `Mod`s.

### DIFF
--- a/code/drasil-code/lib/Language/Drasil/CodeSpec.hs
+++ b/code/drasil-code/lib/Language/Drasil/CodeSpec.hs
@@ -174,7 +174,11 @@ codeSpec si chs ms = CS {
     els = extLibs chs
     libReqs = concatMap odeLibReqs els
     infoReqs = concatMap odeInfoReqs els
-    db' = insertAll (libReqs ++ infoReqs) $ si ^. systemdb
+    msReqs = map asVC $ concatMap (\(Mod _ _ _ _ l) -> l) ms
+    db' = insertAll libReqs
+        $ insertAll infoReqs
+        $ insertAll msReqs
+        $ si ^. systemdb
     si' = set systemdb db' si
 
 -- | Generates an 'OldCodeSpec' from 'System', 'Choices', and a list of 'Mod's.

--- a/code/drasil-example/glassbr/lib/Drasil/GlassBR/Body.hs
+++ b/code/drasil-example/glassbr/lib/Drasil/GlassBR/Body.hs
@@ -12,7 +12,6 @@ import Drasil.DocLang (auxSpecSent, termDefnF')
 import Drasil.Generator (cdb)
 import qualified Drasil.DocLang.SRS as SRS (reference, assumpt, inModel)
 import Language.Drasil.Chunk.Concept.NamedCombinators
-import Language.Drasil.Code (Mod(..), asVC)
 import qualified Language.Drasil.Sentence.Combinators as S
 import Drasil.Document.Contents (enumBulletU, foldlSP, foldlSPCol)
 import Drasil.Sentence.Combinators (bulletFlat, bulletNested, tAndDOnly, tAndDWAcc, noRefs,
@@ -46,7 +45,7 @@ import Drasil.GlassBR.LabelledContent
 import Drasil.GlassBR.Goals (goals)
 import Drasil.GlassBR.IMods (iMods, instModIntro)
 import Drasil.GlassBR.MetaConcepts (progName)
-import Drasil.GlassBR.ModuleDefs (allMods, implVars)
+import Drasil.GlassBR.ModuleDefs (implVars)
 import Drasil.GlassBR.References (astm2009, astm2012, astm2016, citations)
 import Drasil.GlassBR.Requirements (funcReqs, funcReqsTables, nonfuncReqs)
 import Drasil.GlassBR.TMods (tMods)
@@ -142,8 +141,7 @@ symbMap = cdb symbolsWCodeSymbols ideaDicts conceptChunks ([] :: [UnitDefn])
   GB.dataDefs iMods [] tMods concIns citations labCon
 
 symbolsWCodeSymbols :: [DefinedQuantityDict]
-symbolsWCodeSymbols = map asVC (concatMap (\(Mod _ _ _ _ l) -> l) allMods)
-  ++ implVars ++ symbols
+symbolsWCodeSymbols = implVars ++ symbols
 
 -- | Holds all references and links used in the document.
 allRefs :: [Reference]

--- a/code/drasil-example/glassbr/lib/Drasil/GlassBR/Unitals.hs
+++ b/code/drasil-example/glassbr/lib/Drasil/GlassBR/Unitals.hs
@@ -24,7 +24,7 @@ import Drasil.GlassBR.Units (sFlawPU)
 symbols :: [DefinedQuantityDict]
 symbols = map dqdWr inputsWUnitsUncrtn ++ map dqdWr inputsWUncrtn ++
   map dqdWr sdVector ++ tmSymbols ++ map dqdWr specParamVals ++
-  [dqdWr modElas] ++ interps ++ map dqdWr unitalSymbols ++
+  [dqdWr modElas] ++ map dqdWr unitalSymbols ++
   unitless ++ map dqdWr [probBr, stressDistFac, cnstrw' nomThick, cnstrw' glassTypeCon] ++
   map dqdWr derivedInputDataConstraints
 


### PR DESCRIPTION
This work only affects GlassBR.

This won't pass the CI yet because two _code-only_ variables (interpY and interpZ) appear in the SRS, but this code removes them from the scope of the SRS-generator's `ChunkDB`! Work will be necessary before this can be merged that: (a) removes them from the SRS and (b) hooks them through the `Choices` about how the ICO problem definition should be changed. This way, the two _code-only_ variables only appear in the `ChunkDB` associated with the code-generator.