### PR TITLE
`configFiles`: Move from `System` to `Choices`.

### DIFF
--- a/code/drasil-code/lib/Language/Drasil/Choices.hs
+++ b/code/drasil-code/lib/Language/Drasil/Choices.hs
@@ -48,7 +48,10 @@ data Choices = Choices {
   -- | Function to get modifiable function names
   icNames :: InternalConcept -> Name,
   -- | Number of folders to go up in order to obtain the image
-  folderVal :: Int
+  folderVal :: Int,
+  -- | A list of "program configuration files" to be copied over to the exported
+  -- project, required for execution, and configurable by the user.
+  defaultConfigFiles :: [String]
 }
 
 -- | Renders program choices as a 'Sentence'.
@@ -345,7 +348,8 @@ defaultChoices = Choices {
   srsConstraints = makeConstraints Exception Warning,
   extLibs = [],
   icNames = defaultICName,
-  folderVal = 4
+  folderVal = 4,
+  defaultConfigFiles = []
 }
 
 -- | Renders 'Choices' as 'Sentence's.

--- a/code/drasil-code/lib/Language/Drasil/CodeSpec.hs
+++ b/code/drasil-code/lib/Language/Drasil/CodeSpec.hs
@@ -182,7 +182,6 @@ codeSpec si chs ms = CS {
 -- from 'System' to populate the 'OldCodeSpec' structure.
 oldcodeSpec :: S.System -> Choices -> [Mod] -> OldCodeSpec
 oldcodeSpec sys@S.SI{ S._authors = as
-                    , S._configFiles = cfp
                     , S._inputs = ins
                     , S._outputs = outs
                     , S._constraints = cs
@@ -208,7 +207,7 @@ oldcodeSpec sys@S.SI{ S._authors = as
         _extInputs = inputs',
         _derivedInputs = derived,
         _outputs = outs',
-        _configFiles = cfp,
+        _configFiles = defaultConfigFiles chs,
         _execOrder = exOrder,
         _cMap = constraintMap cs,
         _constants = const',

--- a/code/drasil-example/dblpend/lib/Drasil/DblPend/Body.hs
+++ b/code/drasil-example/dblpend/lib/Drasil/DblPend/Body.hs
@@ -95,7 +95,6 @@ si :: System
 si = mkSystem progName Specification [dong]
   [purp] [background] [scope] [motivation]
   tMods genDefns dataDefs iMods
-  []
   inputs outputs inConstraints
   constants
   symbMap allRefs

--- a/code/drasil-example/gamephysics/lib/Drasil/GamePhysics/Body.hs
+++ b/code/drasil-example/gamephysics/lib/Drasil/GamePhysics/Body.hs
@@ -90,7 +90,6 @@ si :: System
 si = mkSystem progName Specification [alex, luthfi, olu]
   [purp] [] [] []
   tMods generalDefns dataDefs iMods
-  []
   inputSymbols outputSymbols inputConstraints []
   symbMap allRefs
 

--- a/code/drasil-example/glassbr/lib/Drasil/GlassBR/Body.hs
+++ b/code/drasil-example/glassbr/lib/Drasil/GlassBR/Body.hs
@@ -40,7 +40,6 @@ import Drasil.GlassBR.Assumptions (assumptionConstants, assumptions)
 import Drasil.GlassBR.Changes (likelyChgs, unlikelyChgs)
 import Drasil.GlassBR.Concepts (acronyms, blastRisk, glaPlane, glaSlab,
   ptOfExplsn, con', glass, iGlass, lGlass)
-import Drasil.GlassBR.DataDefs (configFp)
 import qualified Drasil.GlassBR.DataDefs as GB (dataDefs)
 import Drasil.GlassBR.LabelledContent
 import Drasil.GlassBR.Goals (goals)
@@ -59,7 +58,6 @@ si :: System
 si = mkSystem progName Specification
   [nikitha, spencerSmith] [purp] [background] [scope] []
   tMods [] GB.dataDefs iMods
-  configFp
   inputs outputs constrained constants
   symbMap
   allRefs

--- a/code/drasil-example/glassbr/lib/Drasil/GlassBR/Choices.hs
+++ b/code/drasil-example/glassbr/lib/Drasil/GlassBR/Choices.hs
@@ -6,6 +6,8 @@ import Language.Drasil.Code (Choices(..), defaultChoices, Comments(..),
   ConstantRepr(..), AuxFile(..), Visibility(..), makeArchit,
   makeData, makeConstraints, makeDocConfig, makeLogConfig, makeOptFeats)
 
+import Drasil.GlassBR.DataDefs (configFp)
+
 choices :: Choices
 choices = defaultChoices {
   lang = [Python, Cpp, CSharp, Java, Swift],
@@ -15,5 +17,6 @@ choices = defaultChoices {
     (makeDocConfig [CommentFunc, CommentClass, CommentMod] Quiet Hide)
     (makeLogConfig [LogVar, LogFunc] "log.txt")
     [SampleInput "../../datafiles/glassbr/sampleInput.txt", ReadME],
-  srsConstraints = makeConstraints Exception Exception
+  srsConstraints = makeConstraints Exception Exception,
+  defaultConfigFiles = configFp
 }

--- a/code/drasil-example/hghc/lib/Drasil/HGHC/Body.hs
+++ b/code/drasil-example/hghc/lib/Drasil/HGHC/Body.hs
@@ -16,7 +16,7 @@ si :: System
 si = mkSystem
   progName Specification [spencerSmith]
   [purp] [] [] []
-  [] [] dataDefs [] []
+  [] [] dataDefs []
   htInputs htOutputs ([] :: [ConstrConcept]) []
   symbMap []
 

--- a/code/drasil-example/pdcontroller/lib/Drasil/PDController/Body.hs
+++ b/code/drasil-example/pdcontroller/lib/Drasil/PDController/Body.hs
@@ -84,7 +84,6 @@ si = mkSystem
   progName Specification [naveen]
   [purp] [background] [scope] [motivation]
   theoreticalModels genDefns dataDefinitions instanceModels
-  []
   inputs outputs (map cnstrw' inpConstrained)
   pidConstants symbMap allRefs
 

--- a/code/drasil-example/projectile/lib/Drasil/Projectile/Body.hs
+++ b/code/drasil-example/projectile/lib/Drasil/Projectile/Body.hs
@@ -127,7 +127,6 @@ si = mkSystem progName Specification
   [samCrawford, brooks, spencerSmith]
   [purp] [background] [scope] [motivation]
   tMods genDefns dataDefs iMods
-  []
   inputs outputs (map cnstrw' constrained) constants
   symbMap allRefs
 

--- a/code/drasil-example/projectile/lib/Drasil/Projectile/Lesson/Body.hs
+++ b/code/drasil-example/projectile/lib/Drasil/Projectile/Lesson/Body.hs
@@ -39,7 +39,7 @@ si :: System
 si = mkSystem
   projectileMotionLesson Notebook [spencerSmith]
   [] [] [] []
-  [] [] [] [] []
+  [] [] [] []
   ([] :: [DefinedQuantityDict]) ([] :: [DefinedQuantityDict]) ([] :: [ConstrConcept]) []
   symbMap
   allRefs

--- a/code/drasil-example/sglpend/lib/Drasil/SglPend/Body.hs
+++ b/code/drasil-example/sglpend/lib/Drasil/SglPend/Body.hs
@@ -91,7 +91,6 @@ si :: System
 si = mkSystem progName Specification [olu]
   [purp] [] [] []
   tMods genDefns dataDefs iMods
-  []
   inputs outputs inConstraints []
   symbMap allRefs
 

--- a/code/drasil-example/ssp/lib/Drasil/SSP/Body.hs
+++ b/code/drasil-example/ssp/lib/Drasil/SSP/Body.hs
@@ -61,7 +61,6 @@ si = mkSystem
   progName Specification [henryFrankis, brooks]
   [purp] [] [] []
   tMods generalDefinitions dataDefs iMods
-  []
   inputs outputs constrained []
   symbMap allRefs
 

--- a/code/drasil-example/swhs/lib/Drasil/SWHS/Body.hs
+++ b/code/drasil-example/swhs/lib/Drasil/SWHS/Body.hs
@@ -61,7 +61,6 @@ si = mkSystem
   progName' Specification [thulasi, brooks, spencerSmith]
   [purp] [] [scope] [motivation]
   tMods genDefs SWHS.dataDefs iMods
-  []
   inputs outputs constrained specParamValList
   symbMap allRefs
 

--- a/code/drasil-example/swhsnopcm/lib/Drasil/SWHSNoPCM/Body.hs
+++ b/code/drasil-example/swhsnopcm/lib/Drasil/SWHSNoPCM/Body.hs
@@ -139,7 +139,6 @@ si = mkSystem
   progName Specification [thulasi]
   [purp] [introStartNoPCM] [scope] [motivation]
   tMods genDefs NoPCM.dataDefs NoPCM.iMods
-  []
   inputs outputs
   (map cnstrw' constrained ++ map cnstrw' [tempW, watE]) (piConst : specParamValList)
   symbMap allRefs

--- a/code/drasil-example/template/lib/Drasil/Template/Body.hs
+++ b/code/drasil-example/template/lib/Drasil/Template/Body.hs
@@ -74,7 +74,6 @@ si = mkSystem
   progName Specification [authorName]
   [] [] [] []
   ([] :: [TheoryModel]) ([] :: [GenDefn]) ([] :: [DataDefinition]) ([] :: [InstanceModel])
-  []
   ([] :: [DefinedQuantityDict]) ([] :: [DefinedQuantityDict]) ([] :: [ConstrConcept]) ([] :: [ConstQDef])
   symbMap
   []

--- a/code/drasil-system/lib/Drasil/System.hs
+++ b/code/drasil-system/lib/Drasil/System.hs
@@ -77,7 +77,6 @@ data System where
   , _genDefns     :: [GenDefn]
   , _dataDefns    :: [DataDefinition]
   , _instModels   :: [InstanceModel]
-  , _configFiles  :: [String]
   , _inputs       :: [h]
   , _outputs      :: [i]
   , _constraints  :: [j] --TODO: Add SymbolMap OR enough info to gen SymbolMap
@@ -96,10 +95,10 @@ mkSystem :: (Quantity h, MayHaveUnit h, Concept h,
   HasUID j, Constrained j) =>
   CI -> SystemKind -> People -> Purpose -> Background -> Scope -> Motivation ->
     [TheoryModel] -> [GenDefn] -> [DataDefinition] -> [InstanceModel] ->
-    [String] -> [h] -> [i] -> [j] -> [ConstQDef] -> ChunkDB -> [Reference] ->
+    [h] -> [i] -> [j] -> [ConstQDef] -> ChunkDB -> [Reference] ->
     System
-mkSystem nm sk ppl prps bkgrd scp motive tms gds dds ims ss hs is js cqds db refs
-  = SI nm progName sk ppl prps bkgrd scp motive tms gds dds ims ss hs is js
+mkSystem nm sk ppl prps bkgrd scp motive tms gds dds ims hs is js cqds db refs
+  = SI nm progName sk ppl prps bkgrd scp motive tms gds dds ims hs is js
       cqds db refsMap mempty mempty
   where
     refsMap = M.fromList $ map (\x -> (x ^. uid, x)) refs

--- a/code/drasil-website/lib/Drasil/Website/Body.hs
+++ b/code/drasil-website/lib/Drasil/Website/Body.hs
@@ -67,7 +67,6 @@ si fl = mkSystem
   webName Website []
   [] [] [] []
   [] [] [] []
-  []
   ([] :: [DefinedQuantityDict]) ([] :: [DefinedQuantityDict]) ([] :: [ConstrConcept]) []
   symbMap (allRefs fl)
 


### PR DESCRIPTION
Rationale: `configFiles` is created exclusively for GlassBR's extra added `Mod`s (hand-written program modules to be generated). It is a highly _code-specific choice_. It is not necessary for generating the SRS, for example.

Realistically, this needs more design work, but I think this is an okay side-step for now to better understand what is needed from `drasil-code` and `drasil-gen` for code generation. Using raw `String`s should be an indicator.