### PR TITLE
`Choices` configuration files: Require they be valid, relative file paths with file extensions.

### DIFF
--- a/code/drasil-code/lib/Language/Drasil/Choices.hs
+++ b/code/drasil-code/lib/Language/Drasil/Choices.hs
@@ -9,18 +9,17 @@ module Language.Drasil.Choices (
   CodeConcept(..), matchConcepts, SpaceMatch, matchSpaces, ImplementationType(..),
   ConstraintBehaviour(..), Comments(..), Verbosity(..), Visibility(..),
   Logging(..), AuxFile(..), getSampleData, hasSampleInput, defaultChoices,
-  choicesSent, showChs, InternalConcept(..),
-  RelativeFile, relativeFile, relFileToStr
+  choicesSent, showChs, InternalConcept(..)
 ) where
 
 import Control.Lens ((^.))
 import Data.Map (Map)
 import qualified Data.Map as Map
-import System.FilePath (isAbsolute, isValid, hasExtension)
 
 import Drasil.Database (UID, HasUID (..))
 import Drasil.GOOL (CodeType)
 import Language.Drasil hiding (None)
+import Utils.Drasil (RelativeFile)
 
 import Data.Drasil.ExternalLibraries.ODELibraries (odeInfoChunks)
 
@@ -409,15 +408,3 @@ defaultICName InputFormat         = "InputFormat"
 defaultICName OutputFormat        = "OutputFormat"
 defaultICName Calculations        = "Calculations"
 defaultICName Constants           = "Constants"
-
--- | A valid, relative file path with an extension.
-newtype RelativeFile = RF { relFileToStr :: String }
-  deriving Eq
-
--- | Create a 'RelativeFile' given a raw 'String'.
-relativeFile :: String -> RelativeFile
-relativeFile fp
-  | not $ isValid fp = error $ "`" ++ fp ++ "` is not a valid file path."
-  | not $ hasExtension fp = error $ "`" ++ fp ++ "` does not contain a file extension."
-  | isAbsolute fp = error $ "`" ++ fp ++ "` is an absolute file path, but a relative file path was expected."
-  | otherwise = RF fp

--- a/code/drasil-code/lib/Language/Drasil/Code.hs
+++ b/code/drasil-code/lib/Language/Drasil/Code.hs
@@ -9,7 +9,6 @@ module Language.Drasil.Code (
   OptionalFeatures(..), makeOptFeats, ExtLib(..), ImplementationType(..), Logging(..),
   Modularity(..), Structure(..), ConstantStructure(..), ConstantRepr(..),
   CodeConcept(..), matchConcepts, SpaceMatch, matchSpaces, AuxFile(..),
-  RelativeFile, relativeFile, relFileToStr,
   getSampleData, Visibility(..), defaultChoices, CodeSpec(..), OldCodeSpec(..), codeSpec,
   HasOldCodeSpec(..), funcUID, asVC, ($:=), Mod(Mod), StateVariable, Func, FuncStmt(..), pubStateVar,
   privStateVar, fDecDef, ffor, fforRange, funcData, funcDef, packmod,
@@ -87,7 +86,7 @@ import Language.Drasil.Choices (Choices(..), Comments(..), Verbosity(..),
   Visibility(..), defaultChoices, makeArchit, Architecture(..), DataInfo(..),
   makeData, Maps(..), makeMaps, spaceToCodeType, makeConstraints, makeODE,
   makeDocConfig, makeLogConfig, LogConfig(..), OptionalFeatures(..),
-  makeOptFeats, ExtLib(..), RelativeFile, relativeFile, relFileToStr)
+  makeOptFeats, ExtLib(..))
 import Language.Drasil.CodeSpec (CodeSpec(..), OldCodeSpec(..), HasOldCodeSpec(..),
   codeSpec, funcUID, asVC)
 import Language.Drasil.Mod (($:=), Mod(Mod), StateVariable, Func, FuncStmt(..),

--- a/code/drasil-code/lib/Language/Drasil/Code/Imperative/README.hs
+++ b/code/drasil-code/lib/Language/Drasil/Code/Imperative/README.hs
@@ -10,8 +10,9 @@ import Text.PrettyPrint.HughesPJ (Doc, empty)
 
 import Language.Drasil.Printers (makeMd, introInfo, verInfo, unsupOS,
     extLibSec, instDoc, endNote, whatInfo)
+import Utils.Drasil (RelativeFile, relFileToStr)
 
-import Language.Drasil.Choices (ImplementationType(..), RelativeFile, relFileToStr)
+import Language.Drasil.Choices (ImplementationType(..))
 import Language.Drasil.Mod (Name, Version)
 
 -- | Language name.

--- a/code/drasil-code/lib/Language/Drasil/CodeSpec.hs
+++ b/code/drasil-code/lib/Language/Drasil/CodeSpec.hs
@@ -16,13 +16,13 @@ import Drasil.Code.CodeExpr.Development (expr, eNamesRI, eDep)
 import qualified Drasil.System as S
 import Drasil.System (HasSystem(..), programName)
 import Theory.Drasil (DataDefinition, qdEFromDD, getEqModQdsFromIm)
-import Utils.Drasil (subsetOf)
+import Utils.Drasil (subsetOf, RelativeFile)
 
 import Drasil.Code.CodeVar (CodeChunk, CodeIdea(codeChunk), CodeVarChunk)
 import Language.Drasil.Chunk.ConstraintMap (ConstraintCEMap, ConstraintCE, constraintMap)
 import Language.Drasil.Chunk.CodeDefinition (CodeDefinition, qtov, qtoc, odeDef)
 import Language.Drasil.Choices (Choices(..), Maps(..), ODE(..), ExtLib(..),
-  odeLibReqs, odeInfoReqs, RelativeFile)
+  odeLibReqs, odeInfoReqs)
 import Language.Drasil.Chunk.CodeBase (quantvar, codevars, varResolve)
 import Language.Drasil.Mod (Func(..), FuncData(..), FuncDef(..), Mod(..), Name)
 import Language.Drasil.ICOSolutionSearch (Def, solveExecOrder)

--- a/code/drasil-example/glassbr/lib/Drasil/GlassBR/Choices.hs
+++ b/code/drasil-example/glassbr/lib/Drasil/GlassBR/Choices.hs
@@ -4,8 +4,8 @@ import Language.Drasil.Code (Choices(..), defaultChoices, Comments(..),
   Verbosity(..), ConstraintBehaviour(..), ImplementationType(..), Lang(..),
   Logging(..), Modularity(..), Structure(..), ConstantStructure(..),
   ConstantRepr(..), AuxFile(..), Visibility(..), makeArchit,
-  makeData, makeConstraints, makeDocConfig, makeLogConfig, makeOptFeats,
-  RelativeFile, relativeFile)
+  makeData, makeConstraints, makeDocConfig, makeLogConfig, makeOptFeats)
+import Utils.Drasil (RelativeFile, relativeFile)
 
 import Drasil.GlassBR.ModuleDefs (allMods)
 

--- a/code/drasil-utils/lib/Utils/Drasil.hs
+++ b/code/drasil-utils/lib/Utils/Drasil.hs
@@ -13,17 +13,21 @@ module Utils.Drasil (
   -- | From "Utils.Drasil.English".
   capitalize, stringList,
 
+  -- * FilePath
+  -- | From "Utils.Drasil.FilePath"
+  RelativeFile, relativeFile, relFileToStr,
+
   -- * Lists
   -- | From "Utils.Drasil.Lists". General functions involving lists.
   replaceAll, subsetOf, nubSort, weave, foldle, foldle1, toColumn, mkTable,
 
   -- ** Strings
   toPlainName, repUnd,
-
 ) where
 
 import Utils.Drasil.Directory
 import Utils.Drasil.Document
 import Utils.Drasil.English
+import Utils.Drasil.FilePath
 import Utils.Drasil.Lists
 import Utils.Drasil.Strings

--- a/code/drasil-utils/lib/Utils/Drasil/FilePath.hs
+++ b/code/drasil-utils/lib/Utils/Drasil/FilePath.hs
@@ -1,0 +1,17 @@
+module Utils.Drasil.FilePath (
+  RelativeFile, relativeFile, relFileToStr
+) where
+
+import System.FilePath (isAbsolute, isValid, hasExtension)
+
+-- | A valid, relative file path with an extension.
+newtype RelativeFile = RF { relFileToStr :: String }
+  deriving Eq
+
+-- | Create a 'RelativeFile' given a raw 'String'.
+relativeFile :: String -> RelativeFile
+relativeFile fp
+  | not $ isValid fp = error $ "`" ++ fp ++ "` is not a valid file path."
+  | not $ hasExtension fp = error $ "`" ++ fp ++ "` does not contain a file extension."
+  | isAbsolute fp = error $ "`" ++ fp ++ "` is an absolute file path, but a relative file path was expected."
+  | otherwise = RF fp

--- a/code/drasil-utils/package.yaml
+++ b/code/drasil-utils/package.yaml
@@ -17,6 +17,7 @@ dependencies:
 - base >= 4.7 && < 5
 - containers
 - directory
+- filepath
 - pretty
 
 ghc-options:


### PR DESCRIPTION
Closes #2193

Stumbled upon the issue and figured this would be a simple enough solution for now at least.

I'm not quite sure how we feel about `drasil-utils` anymore, but `RelativeFile` is probably a type that belongs there. What do we think?