### PR TITLE
<Help Needed> Trying to remove GOOL imports from ClassInterface

### DIFF
--- a/code/drasil-code/lib/Language/Drasil/Code/Imperative/Build/Import.hs
+++ b/code/drasil-code/lib/Language/Drasil/Code/Imperative/Build/Import.hs
@@ -20,15 +20,15 @@ import Drasil.GOOL (FileData(..), ProgData(..), GOOLState(..), headers, sources,
 import Drasil.Metadata (watermark)
 
 -- | Holds all the needed information to run a program.
-data CodeHarness progRepr = Ch {
+data CodeHarness stateRepr progRepr = Ch {
   buildConfig :: Maybe BuildConfig,
   runnable :: Maybe Runnable,
-  goolState :: GOOLState,
+  goolState :: stateRepr,
   progData :: progRepr,
   docConfig :: Maybe DocConfig}
 
 -- | Transforms information in 'CodeHarness' into a list of Makefile rules.
-instance RuleTransformer (CodeHarness progRepr) where
+instance RuleTransformer (CodeHarness stateRepr progRepr) where
   makeRule (Ch b r s m d) = maybe [mkRule (openingComments m) buildTarget [] []]
     (\(BuildConfig comp onm anm bt) ->
     let outnm = maybe (asFragment "") (renderBuildName s m nameOpts) onm
@@ -91,7 +91,7 @@ buildRunTarget fn (Interpreter i) = foldr (+:+) mempty $ i ++ [fn]
 
 -- | Creates a Makefile.
 makeBuild :: Maybe DocConfig -> Maybe BuildConfig -> Maybe Runnable ->
-  GOOLState -> progRepr -> Doc
+  stateRepr -> progRepr -> Doc
 makeBuild d b r s p = genMake [Ch {
   buildConfig = b,
   runnable = r,

--- a/code/drasil-code/lib/Language/Drasil/Code/Imperative/GOOL/ClassInterface.hs
+++ b/code/drasil-code/lib/Language/Drasil/Code/Imperative/GOOL/ClassInterface.hs
@@ -7,7 +7,6 @@ module Language.Drasil.Code.Imperative.GOOL.ClassInterface (
 
 import Text.PrettyPrint.HughesPJ (Doc)
 
-import Drasil.GOOL (GOOLState)
 import Language.Drasil.Printers (PrintingInformation)
 
 import Language.Drasil (Expr)
@@ -23,12 +22,12 @@ import Language.Drasil.Code.Imperative.README (ReadMeInfo(..))
 -- omptimize doxygen document, information necessary for a makefile,
 -- auxiliary helper documents
 class AuxiliarySym r where
-  doxConfig :: String -> GOOLState -> Verbosity -> r FileAndContents
+  doxConfig :: String -> stateRepr -> Verbosity -> r FileAndContents
   readMe ::  ReadMeInfo -> r FileAndContents
 
   optimizeDox :: r Doc
 
-  makefile :: [FilePath] -> ImplementationType -> [Comments] -> GOOLState ->
+  makefile :: [FilePath] -> ImplementationType -> [Comments] -> stateRepr ->
     progRepr -> r FileAndContents
 
   auxHelperDoc :: r Doc -> Doc

--- a/code/drasil-code/lib/Language/Drasil/Code/Imperative/GOOL/LanguageRenderer/LanguagePolymorphic.hs
+++ b/code/drasil-code/lib/Language/Drasil/Code/Imperative/GOOL/LanguageRenderer/LanguagePolymorphic.hs
@@ -6,8 +6,6 @@ module Language.Drasil.Code.Imperative.GOOL.LanguageRenderer.LanguagePolymorphic
 
 import Text.PrettyPrint.HughesPJ (Doc)
 
-import Drasil.GOOL (GOOLState)
-
 import Language.Drasil.Choices (Comments, ImplementationType(..), Verbosity)
 import Language.Drasil.Code.Imperative.Doxygen.Import (makeDoxConfig)
 import Language.Drasil.Code.Imperative.Build.AST (BuildConfig, Runnable,
@@ -22,7 +20,7 @@ import Language.Drasil.Code.Imperative.README (ReadMeInfo(..), makeReadMe)
 
 -- | Defines a Doxygen configuration file.
 doxConfig :: (AuxiliarySym r, Applicative r) => r Doc -> String ->
-  GOOLState -> Verbosity -> r FileAndContents
+  stateRepr -> Verbosity -> r FileAndContents
 doxConfig opt pName s v = auxFromData doxConfigName (makeDoxConfig pName s
   (auxHelperDoc opt) v)
 
@@ -32,7 +30,7 @@ readMe rmi= auxFromData readMeName (makeReadMe rmi)
 
 -- | Defines a Makefile.
 makefile :: (Applicative r) => Maybe BuildConfig -> Maybe Runnable ->
-  Maybe DocConfig -> GOOLState -> progRepr -> r FileAndContents
+  Maybe DocConfig -> stateRepr -> progRepr -> r FileAndContents
 makefile bc r d s p = auxFromData makefileName (makeBuild d bc r s p)
 
 -- | Changes a 'Runnable' to 'Nothing' if the user chose 'Library' for the 'ImplementationType'.


### PR DESCRIPTION
I've been trying to remove the GOOL imports from ClassInterface as discussed in #4652, but I keep running into the same problems. The implementations of the methods have to be generic, which causes issues when they need to, for example, access a record field of `ProgData`. Specifically, `LanguagePolymorphic` and `Import` have errors.

I'm a bit stumped with this one. Maybe the deeper issue is that we need to know all about the program in order to run the `doxConfig` and `makefile` functions. Either way, I think we'll need to either decide not to remove the GOOL import or move some other stuff around first.