### PR TITLE
Chunk Dump Tool: Remove `uids_are_just_terms.json`.

### DIFF
--- a/code/drasil-gen/lib/Drasil/Generator/ChunkDump.hs
+++ b/code/drasil-gen/lib/Drasil/Generator/ChunkDump.hs
@@ -8,15 +8,14 @@ import Data.Aeson (ToJSON)
 import Data.Aeson.Encode.Pretty (encodePretty)
 import qualified Data.ByteString.Lazy.Char8 as LB
 import qualified Data.Map.Strict as SM
-import System.IO
+import System.IO (IOMode(WriteMode), openFile, hClose, hPutStrLn)
 import System.Environment (lookupEnv)
-import Text.PrettyPrint
+import Text.PrettyPrint (render)
 
 import Language.Drasil.Printers (PrintingInformation, printAllDebugInfo)
 import Utils.Drasil (createDirIfMissing)
-import Drasil.Database (HasUID(..), dumpChunkDB, invert)
+import Drasil.Database (dumpChunkDB, invert)
 import Drasil.System (System, systemdb, traceTable, refbyTable)
-import Drasil.Database.SearchTools (findAllIdeaDicts)
 
 type Path = String
 type TargetFile = String
@@ -41,11 +40,9 @@ dumpEverything0 si pinfo targetPath = do
       (sharedUIDs, _) = SM.partition atLeast2 invertedChunkDump
       traceDump = si ^. traceTable
       refByDump = si ^. refbyTable
-      justTerms = map (^. uid) (findAllIdeaDicts chunkDb)
 
   dumpTo chunkDump $ targetPath ++ "seeds.json"
   dumpTo invertedChunkDump $ targetPath ++ "inverted_seeds.json"
-  dumpTo justTerms $ targetPath ++ "uids_are_just_terms.json"
   dumpTo sharedUIDs $ targetPath ++ "problematic_seeds.json"
   dumpTo traceDump $ targetPath ++ "trace.json"
   dumpTo refByDump $ targetPath ++ "reverse_trace.json"


### PR DESCRIPTION
`uids_are_just_terms.json` is useless because it is already contained in `seeds.json`.

`seeds.json` contains a catologue of all chunks by: `Type -> [UID]`.