### PR TITLE
Chunk Dump Tool: Remove export of UIDs tied to at least 2 different types and the "inverted" chunk dump.

### DIFF
--- a/code/drasil-gen/lib/Drasil/Generator/ChunkDump.hs
+++ b/code/drasil-gen/lib/Drasil/Generator/ChunkDump.hs
@@ -7,14 +7,13 @@ import Control.Lens ((^.))
 import Data.Aeson (ToJSON)
 import Data.Aeson.Encode.Pretty (encodePretty)
 import qualified Data.ByteString.Lazy.Char8 as LB
-import qualified Data.Map.Strict as SM
 import System.IO (IOMode(WriteMode), openFile, hClose, hPutStrLn)
 import System.Environment (lookupEnv)
 import Text.PrettyPrint (render)
 
 import Language.Drasil.Printers (PrintingInformation, printAllDebugInfo)
 import Utils.Drasil (createDirIfMissing)
-import Drasil.Database (dumpChunkDB, invert)
+import Drasil.Database (dumpChunkDB)
 import Drasil.System (System, systemdb, traceTable, refbyTable)
 
 type Path = String
@@ -36,22 +35,14 @@ dumpEverything0 si pinfo targetPath = do
   createDirIfMissing True targetPath
   let chunkDb = si ^. systemdb
       chunkDump = dumpChunkDB chunkDb
-      invertedChunkDump = invert chunkDump
-      (sharedUIDs, _) = SM.partition atLeast2 invertedChunkDump
       traceDump = si ^. traceTable
       refByDump = si ^. refbyTable
 
   dumpTo chunkDump $ targetPath ++ "seeds.json"
-  dumpTo invertedChunkDump $ targetPath ++ "inverted_seeds.json"
-  dumpTo sharedUIDs $ targetPath ++ "problematic_seeds.json"
   dumpTo traceDump $ targetPath ++ "trace.json"
   dumpTo refByDump $ targetPath ++ "reverse_trace.json"
 
   dumpChunkTables si pinfo $ targetPath ++ "tables.txt"
-
-atLeast2 :: [a] -> Bool
-atLeast2 (_:_:_) = True
-atLeast2 _       = False
 
 -- FIXME: This is more of a general utility than it is drasil-database specific
 dumpTo :: ToJSON a => a -> TargetFile -> IO ()


### PR DESCRIPTION
Builds on #4673

Both can be removed as a result of the work https://github.com/JacquesCarette/Drasil/pull/4320 depended on. That work involved ensuring that there were no `UID` that was re-used. Hence, the two files showing:

* f : UID -> [Type]
* [UID], where length (f UID) > 1

Are pointless.

The first is unnecessary and the second is always empty.