### PR TITLE
Remove the unused `findAllIdeaDicts`.

### DIFF
--- a/code/drasil-printers/lib/Drasil/Database/SearchTools.hs
+++ b/code/drasil-printers/lib/Drasil/Database/SearchTools.hs
@@ -67,9 +67,6 @@ findAllTheoryMods = findAll
 findAllConcInsts :: ChunkDB -> [ConceptInstance]
 findAllConcInsts = findAll
 
-findAllIdeaDicts :: ChunkDB -> [IdeaDict]
-findAllIdeaDicts = findAll
-
 findAllDefinedQuantities :: ChunkDB -> [DefinedQuantityDict]
 findAllDefinedQuantities = findAll
 


### PR DESCRIPTION
Contributes to #4671.

Unused as of #4673