### PR TITLE
Clean up code related to building the traceability graphs in `drasil-docLang`/../`DocumentLanguage.hs`.

### DIFF
--- a/code/stable/hghc/TraceyGraph/allvsall.dot
+++ b/code/stable/hghc/TraceyGraph/allvsall.dot
@@ -1,12 +1,4 @@
 digraph allvsall {
 
 
-	dataDefn:htTransCladFuel	[shape=box, color=black, style=filled, fillcolor=paleturquoise1, label="DD:htTransCladFuel"];
-	dataDefn:htTransCladCool	[shape=box, color=black, style=filled, fillcolor=paleturquoise1, label="DD:htTransCladCool"];
-
-	subgraph DD {
-	rank="same"
-	{dataDefn:htTransCladFuel, dataDefn:htTransCladCool}
-	}
-
 }

--- a/code/stable/hghc/TraceyGraph/allvsr.dot
+++ b/code/stable/hghc/TraceyGraph/allvsr.dot
@@ -1,12 +1,4 @@
 digraph allvsr {
 
 
-	dataDefn:htTransCladFuel	[shape=box, color=black, style=filled, fillcolor=paleturquoise1, label="DD:htTransCladFuel"];
-	dataDefn:htTransCladCool	[shape=box, color=black, style=filled, fillcolor=paleturquoise1, label="DD:htTransCladCool"];
-
-	subgraph DD {
-	rank="same"
-	{dataDefn:htTransCladFuel, dataDefn:htTransCladCool}
-	}
-
 }

--- a/code/stable/hghc/TraceyGraph/avsall.dot
+++ b/code/stable/hghc/TraceyGraph/avsall.dot
@@ -1,12 +1,4 @@
 digraph avsall {
 
 
-	dataDefn:htTransCladFuel	[shape=box, color=black, style=filled, fillcolor=paleturquoise1, label="DD:htTransCladFuel"];
-	dataDefn:htTransCladCool	[shape=box, color=black, style=filled, fillcolor=paleturquoise1, label="DD:htTransCladCool"];
-
-	subgraph DD {
-	rank="same"
-	{dataDefn:htTransCladFuel, dataDefn:htTransCladCool}
-	}
-
 }

--- a/code/stable/hghc/TraceyGraph/refvsref.dot
+++ b/code/stable/hghc/TraceyGraph/refvsref.dot
@@ -1,12 +1,4 @@
 digraph refvsref {
 
 
-	dataDefn:htTransCladFuel	[shape=box, color=black, style=filled, fillcolor=paleturquoise1, label="DD:htTransCladFuel"];
-	dataDefn:htTransCladCool	[shape=box, color=black, style=filled, fillcolor=paleturquoise1, label="DD:htTransCladCool"];
-
-	subgraph DD {
-	rank="same"
-	{dataDefn:htTransCladFuel, dataDefn:htTransCladCool}
-	}
-
 }


### PR DESCRIPTION
Minor code clean up with one caveat: it now only builds the traceability graphs _if_ a traceability section was requested. Hence why HGHC has the content of its traceability graphs removed.

Why are the `.dot` files still produced? Because they're a hardcoded part of the pipeline.