### PR TITLE
Changed `sdep` to return `Set UID`

### DIFF
--- a/code/drasil-docLang/lib/Drasil/GetChunks.hs
+++ b/code/drasil-docLang/lib/Drasil/GetChunks.hs
@@ -4,6 +4,7 @@ module Drasil.GetChunks (ccss, ccss', combine, vars, citeDB) where
 
 import Control.Lens ((^.))
 import Data.List (nub, sortBy)
+import qualified Data.Set as Set
 
 import Language.Drasil
 import Language.Drasil.Development
@@ -18,7 +19,7 @@ vars e m = map (`findOrErr` m) $ meDep e
 
 -- | Gets a list of quantities ('DefinedQuantityDict') from a 'Sentence' in order to print.
 vars' :: Sentence -> ChunkDB -> [DefinedQuantityDict]
-vars' a m = map (`findOrErr` m) $ sdep a
+vars' a m = map (`findOrErr` m) $ Set.toList (sdep a)
 
 -- | Combines the functions of 'vars' and 'concpt' to create a list of 'DefinedQuantityDict's from a 'Sentence'.
 combine :: Sentence -> ChunkDB -> [DefinedQuantityDict]
@@ -38,7 +39,7 @@ ccss' s e c = nub $ concatMap (`vars'` c) s ++ concatMap (`vars` c) e
 
 -- | Gets a list of concepts ('ConceptChunk') from a 'Sentence' in order to print.
 concpt :: Sentence -> ChunkDB -> [Sentence]
-concpt a m = map (definition . defResolve' m) $ sdep a
+concpt a m = map (definition . defResolve' m) $ Set.toList (sdep a)
 
 -- | Gets a list of concepts ('ConceptChunk') from an expression in order to print.
 concpt' :: ModelExpr -> ChunkDB -> [Sentence]

--- a/code/drasil-lang/lib/Language/Drasil/Sentence.hs
+++ b/code/drasil-lang/lib/Language/Drasil/Sentence.hs
@@ -195,8 +195,8 @@ getUIDshort EmptyS              = []
 -----------------------------------------------------------------------------
 -- And now implement the exported traversals all in terms of the above
 -- | This is to collect /symbolic/ 'UID's that are printed out as a 'Symbol'.
-sdep :: Sentence -> [UID]
-sdep = nubOrd . getUIDs
+sdep :: Sentence -> Set.Set UID
+sdep = Set.fromList . getUIDs
 {-# INLINE sdep #-}
 
 -- This is to collect symbolic 'UID's that are printed out as an /abbreviation/.
@@ -226,7 +226,7 @@ lnames' = concatMap lnames
 {-# INLINE lnames' #-}
 
 sentenceRefs :: Sentence -> Set.Set UID
-sentenceRefs sent = Set.fromList (lnames sent ++ sdep sent ++ shortdep sent)
+sentenceRefs sent = Set.unions [Set.fromList (lnames sent), sdep sent, Set.fromList (shortdep sent)]
 {-# INLINE sentenceRefs #-}
 
 instance HasChunkRefs Sentence where


### PR DESCRIPTION
- `sdep` now returns `Set UID` instead of `[UID]`
- Update `sentenceRefs` to union sets
- Convert sdep results to list(`GetChunks`)
