### PR TITLE
Require that `RelativeFile`s be in canonical form as well.

### DIFF
--- a/code/drasil-utils/lib/Utils/Drasil/FilePath.hs
+++ b/code/drasil-utils/lib/Utils/Drasil/FilePath.hs
@@ -2,16 +2,27 @@ module Utils.Drasil.FilePath (
   RelativeFile, relativeFile, relFileToStr
 ) where
 
-import System.FilePath (isAbsolute, isValid, hasExtension)
+import Data.List (foldl')
+import System.FilePath (isAbsolute, isValid, hasExtension, splitDirectories)
 
--- | A valid, relative file path with an extension.
+-- | A valid, relative file path with an extension in canonical form.
 newtype RelativeFile = RF { relFileToStr :: String }
   deriving Eq
 
--- | Create a 'RelativeFile' given a raw 'String'.
+-- | Create a 'RelativeFile' given a 'String' that must be in canonical form, be
+-- a valid file path, contain a file extension, and be relative (not absolute);
+-- otherwise, an error is raised.
 relativeFile :: String -> RelativeFile
 relativeFile fp
+  | not $ isCanonical fp = error $ "`" ++ fp ++ "` is not in canonical form."
   | not $ isValid fp = error $ "`" ++ fp ++ "` is not a valid file path."
   | not $ hasExtension fp = error $ "`" ++ fp ++ "` does not contain a file extension."
   | isAbsolute fp = error $ "`" ++ fp ++ "` is an absolute file path, but a relative file path was expected."
   | otherwise = RF fp
+
+isCanonical :: String -> Bool
+isCanonical fp = foldl' step True (splitDirectories fp)
+  where
+    step _   "."  = False -- Should not include current dir
+    step _   ".." = False -- Should not "go up" directories
+    step acc _    = acc


### PR DESCRIPTION
Neglected to include this in #4665, but this is crucial for #2193.