### PR TITLE
Rename `Drasil.Generator.Generate` to `Drasil.Generator.Composed`.

### DIFF
--- a/code/drasil-gen/lib/Drasil/Generator.hs
+++ b/code/drasil-gen/lib/Drasil/Generator.hs
@@ -2,8 +2,8 @@ module Drasil.Generator (
   module Drasil.Generator.BaseChunkDB,
   module Drasil.Generator.ChunkDump,
   module Drasil.Generator.Code,
+  module Drasil.Generator.Composed,
   module Drasil.Generator.Formats,
-  module Drasil.Generator.Generate,
   module Drasil.Generator.LessonPlan,
   module Drasil.Generator.SRS,
   module Drasil.Generator.SRS.TypeCheck,
@@ -13,8 +13,8 @@ module Drasil.Generator (
 import Drasil.Generator.BaseChunkDB
 import Drasil.Generator.ChunkDump
 import Drasil.Generator.Code
+import Drasil.Generator.Composed
 import Drasil.Generator.Formats
-import Drasil.Generator.Generate
 import Drasil.Generator.LessonPlan
 import Drasil.Generator.SRS
 import Drasil.Generator.SRS.TypeCheck

--- a/code/drasil-gen/lib/Drasil/Generator/Composed.hs
+++ b/code/drasil-gen/lib/Drasil/Generator/Composed.hs
@@ -1,5 +1,5 @@
 -- | Defines Drasil generator functions.
-module Drasil.Generator.Generate (
+module Drasil.Generator.Composed (
   -- * Generators
   exportSmithEtAlSrsWCode, exportSmithEtAlSrsWCodeZoo,
 ) where


### PR DESCRIPTION
Closes #4680

The remaining functions in it are composed generators.