### PR TITLE
Where `X` is an SRS "Model" type, remove all `findAllX` functions.

### DIFF
--- a/code/drasil-docLang/lib/Drasil/DocumentLanguage.hs
+++ b/code/drasil-docLang/lib/Drasil/DocumentLanguage.hs
@@ -32,8 +32,7 @@ import Language.Drasil
 import Language.Drasil.Display (compsy)
 
 import Drasil.Database (findOrErr, ChunkDB, insertAll, UID, HasUID(..), invert)
-import Drasil.Database.SearchTools (findAllDataDefns, findAllGenDefns,
-  findAllInstMods, findAllTheoryMods, findAllConcInsts, findAllLabelledContent)
+import Drasil.Database.SearchTools (findAllConcInsts, findAllLabelledContent)
 
 import Drasil.System (System(SI), whatsTheBigIdea, _systemdb, HasSystem(..))
 import Drasil.GetChunks (ccss, ccss', citeDB)
@@ -138,10 +137,10 @@ fillReferences allSections si = si2
     -- get refs from SRSDecl. Should include all section labels and labelled content.
     refsFromSRS = concatMap findAllRefs allSections
     -- get refs from the stuff already inside the chunk database
-    ddefs   = findAllDataDefns chkdb
-    gdefs   = findAllGenDefns chkdb
-    imods   = findAllInstMods chkdb
-    tmods   = findAllTheoryMods chkdb
+    ddefs   = si ^. dataDefns
+    gdefs   = si ^. genDefns
+    imods   = si ^. instModels
+    tmods   = si ^. theoryModels
     concIns = findAllConcInsts chkdb
     lblCon  = findAllLabelledContent chkdb
     newRefs = M.fromList $ map (\x -> (x ^. uid, x)) $ refsFromSRS

--- a/code/drasil-docLang/lib/Drasil/Sections/TraceabilityMandGs.hs
+++ b/code/drasil-docLang/lib/Drasil/Sections/TraceabilityMandGs.hs
@@ -21,8 +21,7 @@ import Data.Drasil.Concepts.Documentation (assumption, assumpDom, chgProbDom,
   unlikelyChg)
 import Drasil.Metadata (dataDefn, genDefn, inModel, thModel, requirement)
 import Drasil.Database (mkUid)
-import Drasil.Database.SearchTools
-import Drasil.System
+import Drasil.System (System, HasSystem(..))
 import Language.Drasil
 import Language.Drasil.Chunk.Concept.NamedCombinators as NC
 import qualified Language.Drasil.Development as D
@@ -43,19 +42,19 @@ tvAssumps = traceViewCC assumpDom
 
 -- | Traceability viewing data definitions. Takes a 'UID' and a 'ChunkDB'. Returns a list of 'UID's.
 tvDataDefns :: TraceViewCat
-tvDataDefns = traceView (findAllDataDefns . (^. systemdb))
+tvDataDefns = traceView (^. dataDefns)
 
 -- | Traceability viewing general definitions. Takes a 'UID' and a 'ChunkDB'. Returns a list of 'UID's.
 tvGenDefns :: TraceViewCat
-tvGenDefns = traceView (findAllGenDefns . (^. systemdb))
+tvGenDefns = traceView (^. genDefns)
 
 -- | Traceability viewing theory models. Takes a 'UID' and a 'ChunkDB'. Returns a list of 'UID's.
 tvTheoryModels :: TraceViewCat
-tvTheoryModels = traceView (findAllTheoryMods . (^. systemdb))
+tvTheoryModels = traceView (^. theoryModels)
 
 -- | Traceability viewing instance models. Takes a 'UID' and a 'ChunkDB'. Returns a list of 'UID's.
 tvInsModels :: TraceViewCat
-tvInsModels = traceView (findAllInstMods . (^. systemdb))
+tvInsModels = traceView (^. instModels)
 
 -- | Traceability viewing goals. Takes a 'UID' and a 'ChunkDB'. Returns a list of 'UID's.
 tvGoals :: TraceViewCat

--- a/code/drasil-theory/lib/Drasil/Database/SearchTools.hs
+++ b/code/drasil-theory/lib/Drasil/Database/SearchTools.hs
@@ -1,6 +1,6 @@
-{- This code really doesn't belong here, but it didn't belong in drasil-printers either!
-   It will need to find a proper home, later. Right now, it needs to be 'here' because it
-   depends on things defined in this package
+{- This code really doesn't belong here, but it didn't belong in drasil-printers
+   either! It will need to find a proper home, later. Right now, it needs to be
+   'here' because it depends on things defined in this package
 -}
 module Drasil.Database.SearchTools where
 
@@ -58,18 +58,6 @@ defResolve f db trg
 
 defResolve' :: ChunkDB -> UID -> DomDefn
 defResolve' = defResolve DomDefn
-
-findAllDataDefns :: ChunkDB -> [DataDefinition]
-findAllDataDefns = findAll
-
-findAllGenDefns :: ChunkDB -> [GenDefn]
-findAllGenDefns = findAll
-
-findAllInstMods :: ChunkDB -> [InstanceModel]
-findAllInstMods = findAll
-
-findAllTheoryMods :: ChunkDB -> [TheoryModel]
-findAllTheoryMods = findAll
 
 findAllConcInsts :: ChunkDB -> [ConceptInstance]
 findAllConcInsts = findAll


### PR DESCRIPTION
Contributes to #4300 and #4671

These functions were used exclusively for grabbing all `X`s from the `ChunkDB` when they should have been grabbing them from the `System`. In the future, this code will be refactored again when we work on theories.