### PR TITLE
Moved `spaceToCodeType` into Choices.hs

### DIFF
--- a/code/drasil-code/lib/Language/Drasil/Choices.hs
+++ b/code/drasil-code/lib/Language/Drasil/Choices.hs
@@ -15,15 +15,17 @@ module Language.Drasil.Choices (
 import Control.Lens ((^.))
 import Data.Map (Map)
 import qualified Data.Map as Map
+import Data.List.NonEmpty (toList)
 
 import Drasil.Database (UID, HasUID (..))
-import Drasil.GOOL (CodeType)
-import Language.Drasil hiding (None)
+import Drasil.GOOL (CodeType(..))
+import Language.Drasil (SimpleQDef, Sentence(..), Space, DefinedQuantityDict,
+  foldlSent_, (+:+), (+:+.))
+import qualified Language.Drasil as S (Space(..))
 import Utils.Drasil (RelativeFile)
 
 import Data.Drasil.ExternalLibraries.ODELibraries (odeInfoChunks)
 
-import Language.Drasil.Code.PackageFiles (spaceToCodeType)
 import Language.Drasil.Code.Lang (Lang(..))
 import Language.Drasil.Data.ODEInfo (ODEInfo)
 import Language.Drasil.Data.ODELibPckg (ODELibPckg (libDummyQuants))
@@ -366,6 +368,25 @@ defaultChoices = Choices {
   extraMods = [],
   handWiredDefs = []
 }
+
+-- | Default mapping between 'Space' and 'CodeType'.
+spaceToCodeType :: S.Space -> [CodeType]
+spaceToCodeType S.Integer        = [Integer]
+spaceToCodeType S.Natural        = [Integer]
+spaceToCodeType S.Real           = [Double, Float]
+spaceToCodeType S.Rational       = [Double, Float]
+spaceToCodeType S.Boolean        = [Boolean]
+spaceToCodeType S.Char           = [Char]
+spaceToCodeType S.String         = [String]
+spaceToCodeType (S.Vect s)       = map List (spaceToCodeType s)
+spaceToCodeType (S.Matrix _ _ s) = map (List . List) (spaceToCodeType s)
+spaceToCodeType (S.Set s)        = map List (spaceToCodeType s)
+spaceToCodeType (S.Array s)      = map Array (spaceToCodeType s)
+spaceToCodeType (S.Actor s)      = [Object s]
+spaceToCodeType S.Void           = [Void]
+spaceToCodeType (S.Function i t) = [Func is ts | is <- ins, ts <- trgs]
+    where trgs = spaceToCodeType t
+          ins  = map spaceToCodeType (toList i)
 
 -- | Renders 'Choices' as 'Sentence's.
 choicesSent :: Choices -> [Sentence]

--- a/code/drasil-code/lib/Language/Drasil/Code/PackageFiles.hs
+++ b/code/drasil-code/lib/Language/Drasil/Code/PackageFiles.hs
@@ -3,14 +3,11 @@
 module Language.Drasil.Code.PackageFiles (
     consolidatePackageFiles,
     createPackageFiles,
-    spaceToCodeType
 ) where
 
 import Text.PrettyPrint.HughesPJ ( Doc, Doc, render )
-import Data.List.NonEmpty (toList)
 
-import Drasil.GOOL (CodeType(..), FileData(..), ModData(modDoc))
-import qualified Language.Drasil as S (Space(..))
+import Drasil.GOOL (FileData(..), ModData(modDoc))
 import Utils.Drasil (createDirIfMissing)
 
 import Language.Drasil.Code.FileData (FileAndContents(fileDoc))
@@ -42,22 +39,3 @@ createPackageFile (path, contents) = do
   h <- openFile path WriteMode
   hPutStrLn h (render contents)
   hClose h
-
--- | Default mapping between 'Space' and 'CodeType'.
-spaceToCodeType :: S.Space -> [CodeType]
-spaceToCodeType S.Integer        = [Integer]
-spaceToCodeType S.Natural        = [Integer]
-spaceToCodeType S.Real           = [Double, Float]
-spaceToCodeType S.Rational       = [Double, Float]
-spaceToCodeType S.Boolean        = [Boolean]
-spaceToCodeType S.Char           = [Char]
-spaceToCodeType S.String         = [String]
-spaceToCodeType (S.Vect s)       = map List (spaceToCodeType s)
-spaceToCodeType (S.Matrix _ _ s) = map (List . List) (spaceToCodeType s)
-spaceToCodeType (S.Set s)        = map List (spaceToCodeType s)
-spaceToCodeType (S.Array s)      = map Array (spaceToCodeType s)
-spaceToCodeType (S.Actor s)      = [Object s]
-spaceToCodeType S.Void           = [Void]
-spaceToCodeType (S.Function i t) = [Func is ts | is <- ins, ts <- trgs]
-    where trgs = spaceToCodeType t
-          ins  = map spaceToCodeType (toList i)


### PR DESCRIPTION
Contributes to #4653 

As noted in the issue, the `spaceToCodetype` function seemed quite out-of-place in `PackageFiles.hs`. `Choices.hs` is the only place in `drasil-code` where it is used (it's also used in the examples), so I put it into that file.