### PR TITLE
Move `findAllDefinedQuantities` from `.SearchTools` to `drasil-gen`'s `.TypeCheck`.

### DIFF
--- a/code/drasil-gen/lib/Drasil/Generator/SRS/TypeCheck.hs
+++ b/code/drasil-gen/lib/Drasil/Generator/SRS/TypeCheck.hs
@@ -10,10 +10,9 @@ import Data.Either (isLeft, lefts)
 import Data.List (partition)
 import qualified Data.Map.Strict as M
 
-import Drasil.Database (UID, HasUID(..))
-import Drasil.Database.SearchTools (findAllDefinedQuantities)
+import Drasil.Database (UID, HasUID(..), ChunkDB, findAll)
 import Language.Drasil (Expr, Space, temporaryIndent, HasSpace(typ),
-  RequiresChecking(..), TypeError, Typed(check))
+  RequiresChecking(..), TypeError, Typed(check), DefinedQuantityDict)
 import Drasil.System (System, HasSystem (instModels, dataDefns, systemdb))
 
 -- Note: this should be externally configurable wrt verbosity!
@@ -74,3 +73,6 @@ typeCheckSI sys = do
     -- TODO: When we want to have Drasil panic on type-errors, use the following code:
     -- add back import: Control.Monad (when)
     -- when (any isRight formattedChkd) $ error "Type errors occurred, please check your expressions and adjust accordingly"
+
+findAllDefinedQuantities :: ChunkDB -> [DefinedQuantityDict]
+findAllDefinedQuantities = findAll

--- a/code/drasil-theory/lib/Drasil/Database/SearchTools.hs
+++ b/code/drasil-theory/lib/Drasil/Database/SearchTools.hs
@@ -62,9 +62,6 @@ defResolve' = defResolve DomDefn
 findAllConcInsts :: ChunkDB -> [ConceptInstance]
 findAllConcInsts = findAll
 
-findAllDefinedQuantities :: ChunkDB -> [DefinedQuantityDict]
-findAllDefinedQuantities = findAll
-
 findAllCitations :: ChunkDB -> [Citation]
 findAllCitations = findAll
 


### PR DESCRIPTION
Contributes to #4713 by moving it to its sole usage site.