### PR TITLE
Demo: Switch `Sentence`'s `SyCh` constructor from `UID` to `UIDRef`s.

### DIFF
--- a/code/drasil-database/lib/Drasil/Database/UIDRef.hs
+++ b/code/drasil-database/lib/Drasil/Database/UIDRef.hs
@@ -1,7 +1,7 @@
 module Drasil.Database.UIDRef (
   -- * 'UID' References
-  UIDRef, hide, unhide, unhideOrErr,
-  UnitypedUIDRef, hideUni, unhideUni, unhideUniOrErr
+  UIDRef, hide, unhide, unhideOrErr, raw,
+  UnitypedUIDRef, hideUni, unhideUni, unhideUniOrErr, rawUni
 ) where
 
 import Control.Lens ((^.))
@@ -30,9 +30,13 @@ hide = UIDRef . (^. uid)
 unhide :: IsChunk t => UIDRef t -> ChunkDB -> Maybe t
 unhide (UIDRef u) = find u
 
+-- | Get the raw 'UID' from a 'UIDRef'.
+raw :: UIDRef t -> UID
+raw (UIDRef u) = u
+
 -- | Find a chunk by a 'UIDRef', erroring if not found.
 unhideOrErr :: IsChunk t => UIDRef t -> ChunkDB -> t
-unhideOrErr tu cdb = fromMaybe (error "Typed UID dereference failed.") (unhide tu cdb)
+unhideOrErr tu cdb = fromMaybe (error $ "Typed UID dereference failed for UID: " ++ show (raw tu)) (unhide tu cdb)
 
 -- | A variant of 'UIDRef' without type information about the chunk being
 -- referred to, effectively treating chunks as being "unityped."
@@ -54,3 +58,7 @@ unhideUni (UnitypedUIDRef u) = find u
 -- | Find a chunk by its 'UnitypedUIDRef', erroring if not found.
 unhideUniOrErr :: IsChunk t => UnitypedUIDRef -> ChunkDB -> t
 unhideUniOrErr tu cdb = fromMaybe (error "Untyped UID dereference failed.") (unhideUni tu cdb)
+
+-- | Get the raw 'UID' from a 'UnitypedUIDRef'.
+rawUni :: UnitypedUIDRef -> UID
+rawUni (UnitypedUIDRef u) = u

--- a/code/drasil-docLang/lib/Drasil/DocDecl.hs
+++ b/code/drasil-docLang/lib/Drasil/DocDecl.hs
@@ -15,7 +15,7 @@ import qualified Drasil.DocumentLanguage.Core as DL (DocSection(..), RefSec(..),
   ReqsSub(..), LCsSec(..), UCsSec(..), TraceabilitySec(..), AuxConstntSec(..),
   AppndxSec(..), OffShelfSolnsSec(..), DerivationDisplay)
 
-import Drasil.Database (HasUID(..), findAll)
+import Drasil.Database (HasUID(..), findAll, IsChunk)
 import Drasil.System
 import Language.Drasil hiding (sec)
 
@@ -85,9 +85,9 @@ data SCSSub where
   -- | Instance models.
   IMs            :: [Sentence] -> Fields  -> DL.DerivationDisplay -> SCSSub
   -- | Constraints.
-  Constraints    :: (HasUncertainty c, Quantity c, Constrained c, HasReasVal c, MayHaveUnit c) => Sentence -> [c] -> SCSSub
+  Constraints    :: (IsChunk c, HasUncertainty c, Quantity c, Constrained c, HasReasVal c, MayHaveUnit c) => Sentence -> [c] -> SCSSub
   -- | Properties of a correct solution.
-  CorrSolnPpties :: (Quantity c, Constrained c) => [c] -> [Contents] -> SCSSub
+  CorrSolnPpties :: (IsChunk c, Quantity c, Constrained c) => [c] -> [Contents] -> SCSSub
 
 -- | Requirements section (wraps 'ReqsSub' subsections).
 newtype ReqrmntSec = ReqsProg [ReqsSub]

--- a/code/drasil-docLang/lib/Drasil/DocumentLanguage/Core.hs
+++ b/code/drasil-docLang/lib/Drasil/DocumentLanguage/Core.hs
@@ -4,7 +4,7 @@ module Drasil.DocumentLanguage.Core where
 
 import Data.Generics.Multiplate (Multiplate(multiplate, mkPlate))
 
-import Drasil.Database (UID)
+import Drasil.Database (UID, IsChunk)
 import Language.Drasil hiding (Manual, Verb) -- Manual - Citation name conflict. FIXME: Move to different namespace
 import Theory.Drasil (DataDefinition, GenDefn, InstanceModel, TheoryModel)
 
@@ -184,11 +184,11 @@ data SCSSub where
   -- | Instance Models.
   IMs            :: [Sentence] -> Fields  -> [InstanceModel] -> DerivationDisplay -> SCSSub
   -- | Constraints.
-  Constraints    :: (HasUncertainty c, Quantity c, Constrained c, HasReasVal c, MayHaveUnit c) => Sentence -> [c] -> SCSSub
+  Constraints    :: (IsChunk c, HasUncertainty c, Quantity c, Constrained c, HasReasVal c, MayHaveUnit c) => Sentence -> [c] -> SCSSub
   --                  Sentence -> [LabelledContent] Fields  -> [UncertainWrapper] -> [ConstrainedChunk] -> SCSSub --FIXME: temporary definition?
   --FIXME: Work in Progress ^
   -- | Properties of a correct solution.
-  CorrSolnPpties :: (Quantity c, Constrained c) => [c] -> [Contents] -> SCSSub
+  CorrSolnPpties :: (IsChunk c, Quantity c, Constrained c) => [c] -> [Contents] -> SCSSub
 
 -- | Choose whether to show or hide the derivation of an expression.
 data DerivationDisplay = ShowDerivation

--- a/code/drasil-docLang/lib/Drasil/Sections/Requirements.hs
+++ b/code/drasil-docLang/lib/Drasil/Sections/Requirements.hs
@@ -17,7 +17,7 @@ import Utils.Drasil (stringList, mkTable)
 import Control.Lens ((^.))
 import Data.Bifunctor (bimap)
 
-import Drasil.Database (HasUID(..))
+import Drasil.Database (HasUID(..), IsChunk)
 import Language.Drasil
 import Language.Drasil.Chunk.Concept.NamedCombinators
 import qualified Language.Drasil.Sentence.Combinators as S
@@ -47,7 +47,7 @@ reqF = SRS.require [reqIntro]
 -- The resulting requirement sentence is of the form: "Inputs the values from
 -- @table_ref@, which define @description@". If the description is 'Nothing',
 -- the sentence is: "Inputs the values from @table_ref@".
-inReqWTab :: (Quantity q, MayHaveUnit q) => Maybe Sentence -> [q] -> (ConceptInstance, LabelledContent)
+inReqWTab :: (IsChunk q, Quantity q, MayHaveUnit q) => Maybe Sentence -> [q] -> (ConceptInstance, LabelledContent)
 inReqWTab mdesc qs = (ci, tbl)
   where
     tbl = mkInputPropsTable qs
@@ -143,7 +143,7 @@ mkSecurityNFR refAddress lbl = cic refAddress (foldlSent [
   ]) lbl nonFuncReqDom
 
 -- | Creates an Input Data Table for use in the Functional Requirments section. Takes a list of wrapped variables and something that is 'Referable'.
-mkInputPropsTable :: (Quantity i, MayHaveUnit i) =>
+mkInputPropsTable :: (IsChunk i, Quantity i, MayHaveUnit i) =>
                           [i] -> LabelledContent
 mkInputPropsTable []        = mkRawLC (Paragraph EmptyS) reqInputsRef
 mkInputPropsTable reqInputs = mkRawLC (Table [atStart symbol_, atStart description, atStart' unit_]
@@ -155,14 +155,14 @@ reqInputsRef :: Reference
 reqInputsRef = makeTabRef' (reqInput ^. uid)
 
 -- | Creates a table for use in the Functional Requirments section. Takes a list of tuples containing variables and sources, a label, and a caption.
-mkValsSourceTable :: (Quantity i, MayHaveUnit i, Concept i) =>
+mkValsSourceTable :: (IsChunk i, Quantity i, MayHaveUnit i, Concept i) =>
                           [(i, Sentence)] -> String -> Sentence -> LabelledContent
 mkValsSourceTable vals labl cap = llccTab labl $
   Table [atStart symbol_, atStart description, S "Source", atStart' unit_]
   (mkTable [ch . fst, atStart . fst, snd, toSentence . fst] $ sortBySymbolTuple vals) cap True
 
-mkQRTuple :: (HasOutput i, HasShortName i, Referable i) => [i] -> [(DefinedQuantityDict, Sentence)]
+mkQRTuple :: (IsChunk i, HasOutput i, HasShortName i, Referable i) => [i] -> [(DefinedQuantityDict, Sentence)]
 mkQRTuple = map (\c -> (c ^. output, refS c))
 
-mkQRTupleRef :: (Quantity i, MayHaveUnit i, Concept i, HasShortName r, Referable r) => [i] -> [r] -> [(DefinedQuantityDict, Sentence)]
+mkQRTupleRef :: (Quantity i, MayHaveUnit i, Concept i, HasShortName r, Referable r) =>[i] -> [r] -> [(DefinedQuantityDict, Sentence)]
 mkQRTupleRef = zipWith (curry (bimap dqdWr refS))

--- a/code/drasil-docLang/lib/Drasil/Sections/SpecificSystemDescription.hs
+++ b/code/drasil-docLang/lib/Drasil/Sections/SpecificSystemDescription.hs
@@ -26,7 +26,7 @@ import Control.Lens ((^.), over)
 import Data.Maybe
 
 -- rest of Drasil
-import Drasil.Database (UID, HasUID(..), showUID)
+import Drasil.Database (UID, HasUID(..), showUID, IsChunk)
 import Data.Drasil.Concepts.Documentation (assumption, column, constraint,
   datum, datumConstraint, inDatumConstraint, outDatumConstraint, definition,
   element, general, goalStmt, information, input_, limitation, model, output_,
@@ -200,7 +200,7 @@ inModelIntro r1 r2 r3 r4 = foldlSP [S "This", phrase section_,
   namedRef r4 (plural genDefn)]
 
 -- | Constructor for Data Constraints section. Takes a trailing 'Sentence' (use 'EmptyS' if none) and data constraints.
-datConF :: (HasUncertainty c, Quantity c, Constrained c, HasReasVal c, MayHaveUnit c) =>
+datConF :: (IsChunk c, HasUncertainty c, Quantity c, Constrained c, HasReasVal c, MayHaveUnit c) =>
   Sentence -> [c] -> Section
 datConF _ [] = SRS.datCon [mkParagraph $ emptySectSentPlu [datumConstraint]] []
 datConF t c  = SRS.datCon [dataConstraintParagraph t, LlC $ inDataConstTbl c] []
@@ -253,7 +253,7 @@ mkDataConstraintTable col rf lab = llccTab' rf $ uncurry Table
   (mkTableFromColumns col) lab True
 
 -- | Creates the input Data Constraints Table.
-inDataConstTbl :: (HasUncertainty c, Quantity c, Constrained c, HasReasVal c, MayHaveUnit c) =>
+inDataConstTbl :: (IsChunk c, HasUncertainty c, Quantity c, Constrained c, HasReasVal c, MayHaveUnit c) =>
   [c] -> LabelledContent
 inDataConstTbl qlst = mkDataConstraintTable [(S "Var", map ch $ sortBySymbol qlst),
             (titleize' physicalConstraint, map fmtPhys $ sortBySymbol qlst),
@@ -265,7 +265,7 @@ inDataConstTbl qlst = mkDataConstraintTable [(S "Var", map ch $ sortBySymbol qls
     getRVal c = fromMaybe (error $ "getRVal found no Expr for " ++ showUID c) (c ^. reasVal)
 
 -- | Creates the output Data Constraints Table.
-outDataConstTbl :: (Quantity c, Constrained c) => [c] -> LabelledContent
+outDataConstTbl :: (IsChunk c, Quantity c, Constrained c) => [c] -> LabelledContent
 outDataConstTbl qlst = mkDataConstraintTable [(S "Var", map ch qlst),
             (titleize' physicalConstraint, map fmtPhys qlst),
             (titleize' softwareConstraint, map fmtSfwr qlst)] (outDatumConstraint ^. uid) $
@@ -286,7 +286,7 @@ fmtSfwr :: (Constrained c, Quantity c) => c -> Sentence
 fmtSfwr c = foldConstraints c $ filter isSfwrC (c ^. constraints)
 
 -- | Creates the Properties of a Correct Solution section.
-propCorSolF :: (Quantity c, Constrained c) => [c] -> [Contents] -> Section
+propCorSolF :: (IsChunk c, Quantity c, Constrained c) => [c] -> [Contents] -> Section
 propCorSolF []  [] = SRS.propCorSol [mkParagraph $ emptySectSentPlu [propOfCorSol]] []
 propCorSolF [] con = SRS.propCorSol con []
 propCorSolF c  con = SRS.propCorSol ([propsIntro, LlC $ outDataConstTbl c] ++ con) []

--- a/code/drasil-docLang/lib/Drasil/Sentence/Combinators.hs
+++ b/code/drasil-docLang/lib/Drasil/Sentence/Combinators.hs
@@ -23,11 +23,10 @@ import Control.Lens ((^.))
 import Data.Decimal (DecimalRaw, realFracToDecimal)
 import Data.List (transpose)
 
-import Drasil.Database (HasUID)
+import Drasil.Database (IsChunk)
 
 import Language.Drasil (ConceptChunk, DefinesQuantity(defLhs) , UnitDefn, MayHaveUnit(..)
   , UnitalChunk , HasUnitSymbol(usymb), Quantity, Concept, Definition(defn), NamedIdea(..)
-  , HasSymbol
   , HasShortName(..) , short, atStart, titleize, phrase, plural , Section , ItemType(..), ListType(Bullet)
   , ModelExpr , refS, namedRef
   , Sentence(S, Percent, (:+:), Sy, EmptyS), eS
@@ -67,7 +66,7 @@ definedIn'' :: (Referable r, HasShortName r) => r -> Sentence
 definedIn'' q =  S "defined" `S.in_` refS q
 
 -- | Takes a 'Symbol' and its 'Reference' (does not append a period at the end!). Outputs as "@symbol@ is defined in @source@".
-definedIn''' :: (HasSymbol q, HasUID q, Referable r, HasShortName r) => q -> r -> Sentence
+definedIn''' :: (IsChunk q, Quantity q, Referable r, HasShortName r) => q -> r -> Sentence
 definedIn''' q src = ch q `S.is` S "defined in" +:+ refS src
 
 -- | Zip helper function enumerates abbreviations and zips it with list of 'ItemType':
@@ -192,7 +191,7 @@ tAndDWAcc temp = Flat $ atStart temp +:+. (sParen (short temp) `sDash` capSent (
 
 -- | Helpful combinators for making 'Sentence's into Terminologies with Definitions.
 -- Returns of the form: "@term (symbol) - termDefinition@".
-tAndDWSym :: (Concept s, Quantity a) => s -> a -> ItemType
+tAndDWSym :: (IsChunk a, Concept s, Quantity a) => s -> a -> ItemType
 tAndDWSym tD sym = Flat $ atStart tD +:+. (sParen (ch sym) `sDash` capSent (tD ^. defn))
 
 -- | Helpful combinators for making 'Sentence's into Terminologies with Definitions.

--- a/code/drasil-example/glassbr/lib/Drasil/GlassBR/Assumptions.hs
+++ b/code/drasil-example/glassbr/lib/Drasil/GlassBR/Assumptions.hs
@@ -2,6 +2,7 @@ module Drasil.GlassBR.Assumptions (assumpGT, assumpGC, assumpES, assumpSV,
   assumpGL, assumpBC, assumpRT, assumpLDFC, assumptionConstants,
   assumptions) where
 
+import Drasil.Database (IsChunk)
 import Language.Drasil hiding (organization)
 import qualified Language.Drasil.Development as D
 import qualified Drasil.DocLang.SRS as SRS (valsOfAuxCons)
@@ -84,7 +85,7 @@ responseTypeDesc :: Sentence
 responseTypeDesc = foldlSent [D.toSent $ atStartNP (the responseTy), S "considered in",
   short progName, S "is flexural"]
 
-ldfConstantDesc :: (HasSymbol c, NamedIdea c) => c -> Sentence
+ldfConstantDesc :: (IsChunk c, Quantity c) => c -> Sentence
 ldfConstantDesc mainConcept = foldlSent [S "With", phrase reference, S "to",
   refS assumpSV `sC` D.toSent (phraseNP (NP.the (value `of_`
   mainConcept))), sParen (ch mainConcept) `S.is` D.toSent (phraseNP (a_ constant))

--- a/code/drasil-example/glassbr/lib/Drasil/GlassBR/DataDefs.hs
+++ b/code/drasil-example/glassbr/lib/Drasil/GlassBR/DataDefs.hs
@@ -5,7 +5,7 @@ module Drasil.GlassBR.DataDefs (dataDefs, aspRat, glaTyFac, glaTyFacQD, gtfRef,
 import Control.Lens ((^.))
 import Prelude hiding (log, exp, sqrt)
 
-import Drasil.Database (HasUID)
+import Drasil.Database (IsChunk)
 import Language.Drasil
 import Theory.Drasil (DataDefinition, ddE)
 import qualified Language.Drasil.Sentence.Combinators as S
@@ -150,7 +150,7 @@ gtfRef = definedIn  glaTyFac
 hRef   = definedIn' hFromt (S "and is based on the nominal thicknesses")
 
 --- Helper
-stdVals :: (HasSymbol s, HasUID s) => [s] -> Sentence
+stdVals :: (IsChunk s, Quantity s) => [s] -> Sentence
 stdVals s = foldlList Comma List (map ch s) +:+ sent +:+. refS assumpSV
   where sent = case s of [ ]   -> error "stdVals needs quantities"
                          [_]   -> S "comes from"

--- a/code/drasil-example/glassbr/lib/Drasil/GlassBR/IMods.hs
+++ b/code/drasil-example/glassbr/lib/Drasil/GlassBR/IMods.hs
@@ -3,7 +3,7 @@ module Drasil.GlassBR.IMods (symb, iMods, pbIsSafe, lrIsSafe, instModIntro) wher
 import Control.Lens ((^.))
 import Prelude hiding (exp)
 
-import Drasil.Database (HasUID)
+import Drasil.Database (IsChunk)
 import Drasil.Sentence.Combinators (definedIn', definedIn)
 import Language.Drasil
 import qualified Language.Drasil.Development as D
@@ -215,6 +215,6 @@ qHtTlTolRef = definedIn  tolPre
 riskRef     = definedIn  risk
 
 -- Helper --
-interpolating :: (HasUID s, HasSymbol s, Referable f, HasShortName f) => s -> f -> Sentence
+interpolating :: (IsChunk s, Quantity s, Referable f, HasShortName f) => s -> f -> Sentence
 interpolating s f = foldlSent [ch s `S.is` S "obtained by interpolating from",
   plural datum, S "shown" `S.in_` refS f]

--- a/code/drasil-lang/lib/Language/Drasil/Chunk/Constrained.hs
+++ b/code/drasil-lang/lib/Language/Drasil/Chunk/Constrained.hs
@@ -8,7 +8,7 @@ module Language.Drasil.Chunk.Constrained (
 
 import Control.Lens ((^.), makeLenses, view)
 
-import Drasil.Database (HasUID(..))
+import Drasil.Database (HasUID(..), HasChunkRefs(..))
 
 import Language.Drasil.Chunk.Concept (cw, dcc, dccWDS)
 import Language.Drasil.Chunk.DefinedQuantity (DefinedQuantityDict, dqd, dqd', dqdWr, dqdNoUnit)
@@ -37,6 +37,9 @@ data ConstrConcept = ConstrConcept { _defq    :: DefinedQuantityDict
                                    , _reasV'  :: Maybe Expr
                                    }
 makeLenses ''ConstrConcept
+
+instance HasChunkRefs ConstrConcept where
+  chunkRefs = const mempty -- FIXME: `chunkRefs` should actually collect the referenced chunks.
 
 -- | Finds 'UID' of the 'DefinedQuantityDict' used to make the 'ConstrConcept'.
 instance HasUID        ConstrConcept where uid = defq . uid

--- a/code/drasil-lang/lib/Language/Drasil/Chunk/Eq.hs
+++ b/code/drasil-lang/lib/Language/Drasil/Chunk/Eq.hs
@@ -15,7 +15,7 @@ module Language.Drasil.Chunk.Eq (
 ) where
 
 import Control.Lens ((^.), view, lens, Lens', to)
-import Drasil.Database (UID, HasUID(..))
+import Drasil.Database (UID, HasUID(..), HasChunkRefs(..))
 
 import Language.Drasil.Chunk.UnitDefn (unitWrapper, MayHaveUnit(getUnit), UnitDefn)
 import Language.Drasil.Symbol (HasSymbol(symbol), Symbol)
@@ -39,6 +39,9 @@ import Language.Drasil.WellTyped (RequiresChecking(..))
 
 data QDefinition e where
   QD :: DefinedQuantityDict -> [UID] -> e -> QDefinition e
+
+instance HasChunkRefs (QDefinition e) where
+  chunkRefs = const mempty -- FIXME: `chunkRefs` should actually collect the referenced chunks.
 
 qdQua :: Lens' (QDefinition e) DefinedQuantityDict
 qdQua = lens (\(QD qua _ _) -> qua) (\(QD _ ins e) qua' -> QD qua' ins e)

--- a/code/drasil-lang/lib/Language/Drasil/Chunk/UncertainQuantity.hs
+++ b/code/drasil-lang/lib/Language/Drasil/Chunk/UncertainQuantity.hs
@@ -9,7 +9,7 @@ module Language.Drasil.Chunk.UncertainQuantity (
 
 import Control.Lens ((^.), makeLenses, view)
 
-import Drasil.Database (HasUID(..))
+import Drasil.Database (HasUID(..), HasChunkRefs(..))
 
 import Language.Drasil.Chunk.DefinedQuantity (dqdWr)
 import Language.Drasil.Chunk.Constrained (ConstrConcept(..), cuc')
@@ -31,6 +31,9 @@ import Language.Drasil.Uncertainty
 -- Ex. Measuring the length of a pendulum arm may be recorded with an uncertainty value.
 data UncertQ = UQ { _coco :: ConstrConcept , _unc'' :: Uncertainty }
 makeLenses ''UncertQ
+
+instance HasChunkRefs UncertQ where
+  chunkRefs = const mempty -- FIXME: `chunkRefs` should actually collect the referenced chunks.
 
 -- | Equal if 'UID's are equal.
 instance Eq             UncertQ where a == b = (a ^. uid) == (b ^. uid)

--- a/code/drasil-lang/lib/Language/Drasil/Chunk/Unital.hs
+++ b/code/drasil-lang/lib/Language/Drasil/Chunk/Unital.hs
@@ -8,7 +8,7 @@ module Language.Drasil.Chunk.Unital (
 
 import Control.Lens (makeLenses, view, (^.))
 
-import Drasil.Database (HasUID(..))
+import Drasil.Database (HasUID(..), HasChunkRefs(..))
 
 import Language.Drasil.Chunk.Concept (dccWDS,cw)
 import Language.Drasil.Chunk.DefinedQuantity (DefinedQuantityDict, dqd, dqd', dqdWr)
@@ -32,6 +32,9 @@ data UnitalChunk = UC { _defq' :: DefinedQuantityDict
                       , _uni :: UnitDefn
                       }
 makeLenses ''UnitalChunk
+
+instance HasChunkRefs UnitalChunk where
+  chunkRefs = const mempty -- FIXME: `chunkRefs` should actually collect the referenced chunks.
 
 -- | Finds 'UID' of the 'DefinedQuantityDict' used to make the 'UnitalChunk'.
 instance HasUID        UnitalChunk where uid = defq' . uid

--- a/code/drasil-lang/lib/Language/Drasil/Sentence/Generators.hs
+++ b/code/drasil-lang/lib/Language/Drasil/Sentence/Generators.hs
@@ -7,6 +7,8 @@ module Language.Drasil.Sentence.Generators (
 
 import Control.Lens ((^.))
 
+import Drasil.Database (IsChunk)
+
 import Language.Drasil.Classes (NamedIdea(..), Quantity)
 import Language.Drasil.Development.Sentence (phrase)
 import Language.Drasil.Label.Type (Referable)
@@ -26,7 +28,7 @@ fterms :: (NamedIdea c, NamedIdea d) => (NP -> NP -> t) -> c -> d -> t
 fterms f a b = f (a ^. term) (b ^. term)
 
 -- | Used when you want to say a term followed by its symbol. ex. "...using the Force F in...".
-getTandS :: (Quantity a) => a -> Sentence
+getTandS :: (IsChunk t, Quantity t) => t -> Sentence
 getTandS a = phrase a +:+ ch a
 
 -- | Uses an 'Either' type to check if a 'String' is valid -

--- a/code/drasil-printers/lib/Language/Drasil/Printing/Import/Sentence.hs
+++ b/code/drasil-printers/lib/Language/Drasil/Printing/Import/Sentence.hs
@@ -12,7 +12,7 @@ import qualified Language.Drasil.Printing.AST as P
 import Language.Drasil.Printing.PrintingInformation
   (PrintingInformation, refFind, sysdb)
 import Language.Drasil.Printing.Import.ModelExpr (modelExpr)
-import Language.Drasil.Printing.Import.Helpers (lookupT, lookupS, lookupP, lookupC')
+import Language.Drasil.Printing.Import.Helpers (lookupT, lookupS, lookupP, lookupSymb)
 import Language.Drasil.Printing.Import.Symbol (symbol, pUnit)
 
 -- * Main Function
@@ -29,7 +29,7 @@ spec _  (Sy s)                  = P.E $ pUnit s
 spec sm (NP np)                 = spec sm (toSent $ phraseNP np)
 spec _  Percent                 = P.E $ P.MO P.Perc
 spec _  (P s)                   = P.E $ symbol s
-spec sm (SyCh s)                = P.E $ symbol $ lookupC' sm s
+spec sm (SyCh s)                = P.E $ symbol $ lookupSymb sm s
 
 -- First term is the tooltip, second term is the rendered short form
 spec sm (Ch ShortStyle caps s)  = P.Tooltip (spec sm $ lookupT


### PR DESCRIPTION
Contributes to #4541.

This PR already needs to be broken up, but it's helpful to have it live as a PR that I can potentially re-purpose.