### PR TITLE
Split `TypeableChunk` off from `IsChunk`.

### DIFF
--- a/code/drasil-database/lib/Drasil/Database/UIDRef.hs
+++ b/code/drasil-database/lib/Drasil/Database/UIDRef.hs
@@ -7,7 +7,7 @@ module Drasil.Database.UIDRef (
 import Control.Lens ((^.))
 import Data.Maybe (fromMaybe)
 
-import Drasil.Database.Chunk (IsChunk, HasChunkRefs (..))
+import Drasil.Database.Chunk (TypeableChunk, HasChunkRefs (..))
 import Drasil.Database.ChunkDB (ChunkDB, find)
 import Drasil.Database.UID (HasUID(..), UID)
 import qualified Data.Set as S (singleton)
@@ -23,15 +23,15 @@ instance HasChunkRefs (UIDRef t) where
   {-# INLINABLE chunkRefs #-}
 
 -- | Create a 'UIDRef' to a chunk.
-hide :: IsChunk t => t -> UIDRef t
+hide :: TypeableChunk t => t -> UIDRef t
 hide = UIDRef . (^. uid)
 
 -- | Find a chunk by a 'UIDRef'.
-unhide :: IsChunk t => UIDRef t -> ChunkDB -> Maybe t
+unhide :: TypeableChunk t => UIDRef t -> ChunkDB -> Maybe t
 unhide (UIDRef u) = find u
 
 -- | Find a chunk by a 'UIDRef', erroring if not found.
-unhideOrErr :: IsChunk t => UIDRef t -> ChunkDB -> t
+unhideOrErr :: TypeableChunk t => UIDRef t -> ChunkDB -> t
 unhideOrErr tu cdb = fromMaybe (error "Typed UID dereference failed.") (unhide tu cdb)
 
 -- | A variant of 'UIDRef' without type information about the chunk being
@@ -44,13 +44,13 @@ instance HasChunkRefs UnitypedUIDRef where
   {-# INLINABLE chunkRefs #-}
 
 -- | Create a 'UnitypedUIDRef' to a chunk.
-hideUni :: IsChunk t => t -> UnitypedUIDRef
+hideUni :: TypeableChunk t => t -> UnitypedUIDRef
 hideUni = UnitypedUIDRef . (^. uid)
 
 -- | Find a chunk by its 'UnitypedUIDRef'.
-unhideUni :: IsChunk t => UnitypedUIDRef -> ChunkDB -> Maybe t
+unhideUni :: TypeableChunk t => UnitypedUIDRef -> ChunkDB -> Maybe t
 unhideUni (UnitypedUIDRef u) = find u
 
 -- | Find a chunk by its 'UnitypedUIDRef', erroring if not found.
-unhideUniOrErr :: IsChunk t => UnitypedUIDRef -> ChunkDB -> t
+unhideUniOrErr :: TypeableChunk t => UnitypedUIDRef -> ChunkDB -> t
 unhideUniOrErr tu cdb = fromMaybe (error "Untyped UID dereference failed.") (unhideUni tu cdb)

--- a/code/drasil-printers/lib/Language/Drasil/Debug/Print.hs
+++ b/code/drasil-printers/lib/Language/Drasil/Debug/Print.hs
@@ -11,7 +11,7 @@ import qualified Data.Map as Map
 import Data.Typeable (Proxy (Proxy))
 import Text.PrettyPrint.HughesPJ
 
-import Drasil.Database (UID, showUID, IsChunk, findAll)
+import Drasil.Database (UID, showUID, TypeableChunk, findAll)
 import Language.Drasil
 import Theory.Drasil
 
@@ -58,7 +58,7 @@ header d = text (replicate 100 '-') $$ d $$ text (replicate 100 '-')
 -- data from the printing information field into the required display formats
 -- (often 'UID's, terms, shortnames, definitions, etc.).
 mkTableFromLenses
-  :: IsChunk a => PrintingInformation
+  :: (TypeableChunk a) => PrintingInformation
   -> Proxy a -- Data is unused, but necessary for type constraint resolution.
   -> String
   -> [PrintingInformation -> (String, a -> Doc)]


### PR DESCRIPTION
Rationale: Using `Typeable` in `IsChunk` is normally fine, but for chunks defined by parameterized types, defining typeclasses that inherit from other chunks is problematic for GHCs constraint solver. The result is needing to manually add extra `Typeable` constraints for each type parameter in the instance declaration of any lensy class looking to inherit information from other chunks.

See https://github.com/JacquesCarette/Drasil/pull/4718/changes/6a94db4f6a8ec42ac4875f1b94caa8058493a407 for example.