### PR TITLE
Cleaned up the `generateCode` function

### DIFF
--- a/code/drasil-code/lib/Language/Drasil/Code/Imperative/Generator.hs
+++ b/code/drasil-code/lib/Language/Drasil/Code/Imperative/Generator.hs
@@ -128,11 +128,10 @@ generateCode l unReprProg unReprPack g = do
   setCurrentDirectory (getDir l)
   let (pckg, ds) = runState (genPackage unReprProg) g
       (PackageData prog progDossier) = unReprPack pckg
-      baseDossier = [fileAndContents "designLog.txt" (ds ^. designLog) |
-          not $ isEmpty $ ds ^. designLog] ++ progDossier
-      dossier
-        | l == Python = fileAndContents "__init__.py" mempty : baseDossier
-        | otherwise   = baseDossier
+      designLogFile = [fileAndContents "designLog.txt" (ds ^. designLog) |
+                        not $ isEmpty $ ds ^. designLog]
+      initFile = [fileAndContents "__init__.py" mempty | l == Python]
+      dossier = progDossier ++ designLogFile ++ initFile
       packageFiles = map
         hasPathAndDocToFileAndContents (progMods prog)
         ++ dossier
@@ -246,8 +245,9 @@ generateCodeProc l unReprProg unReprPack g = do
   setCurrentDirectory (getDir l)
   let (pckg, ds) = runState (genPackageProc unReprProg) g
       (PackageData prog progDossier) = unReprPack pckg
-      dossier = [fileAndContents "designLog.txt" (ds ^. designLog) |
-          not $ isEmpty $ ds ^. designLog] ++ progDossier
+      designLogFile = [fileAndContents "designLog.txt" (ds ^. designLog) |
+                        not $ isEmpty $ ds ^. designLog]
+      dossier =  progDossier ++ designLogFile
       packageFiles = map
         hasPathAndDocToFileAndContents (progMods prog)
         ++ dossier


### PR DESCRIPTION
Closes #4714 

(Closes because everything else there has either been fixed or moved to a separate issue)

This addresses the [comment](https://github.com/JacquesCarette/Drasil/issues/4714#issuecomment-3915993353) I had there where I noted that we might not need the level of polymorphism we had been discussing, and maybe it's better to just write cleaner code :smile:

Let me know if you think that a `HasCodeFiles` typeclass would still be helpful. I gave my argument against it in the comment (linked above), but it's possible that it could have other benefits I'm not thinking of.

I also cleaned up some other logic while I was at it, and renamed any `*aux` variables to `*dossier`.