### PR TITLE
SWHSNoPCM: Remove unused citation/bibliography entry.

### DIFF
--- a/code/drasil-example/swhsnopcm/lib/Drasil/SWHSNoPCM/References.hs
+++ b/code/drasil-example/swhsnopcm/lib/Drasil/SWHSNoPCM/References.hs
@@ -5,8 +5,8 @@ import Language.Drasil
 import Data.Drasil.Citations (koothoor2013, parnasClements1986, smithEtAl2007,
   smithKoothoor2016, smithLai2005)
 
-import Drasil.SWHS.References (incroperaEtAl2007, lightstone2012)
+import Drasil.SWHS.References (incroperaEtAl2007)
 
 citations :: BibRef
-citations = [incroperaEtAl2007, koothoor2013, lightstone2012, parnasClements1986,
+citations = [incroperaEtAl2007, koothoor2013, parnasClements1986,
              smithEtAl2007, smithLai2005, smithKoothoor2016]

--- a/code/stable/swhsnopcm/SRS/HTML/SWHSNoPCM_SRS.html
+++ b/code/stable/swhsnopcm/SRS/HTML/SWHSNoPCM_SRS.html
@@ -3475,10 +3475,6 @@
           <dd>
             Koothoor, Nirmitha. <em>A Document Driven Approach to Certifying Scientific Computing Software</em>. McMaster University, Hamilton, ON, Canada: 2013. Print.
           </dd>
-          <dt id="lightstone2012">[<b>lightstone2012</b>]</dt>
-          <dd>
-            Lightstone, Marilyn. <em>Derivation of tank/pcm model</em>. 2012. From Marilyn Lightstone's Personal Notes
-          </dd>
           <dt id="parnasClements1986">[<b>parnasClements1986</b>]</dt>
           <dd>
             Parnas, David L. and Clements, P. C. "A rational design process: How and why to fake it." <em>IEEE Transactions on Software Engineering</em>, vol. 12, no. 2, Washington, USA: February, 1986. pp. 251&ndash;257. Print.

--- a/code/stable/swhsnopcm/SRS/Jupyter/SWHSNoPCM_SRS.ipynb
+++ b/code/stable/swhsnopcm/SRS/Jupyter/SWHSNoPCM_SRS.ipynb
@@ -1409,16 +1409,14 @@
     "[1]: Incropera, F. P., Dewitt, D. P., Bergman, T. L., and Lavine, A. S. <em>Fundamentals of Heat and Mass Transfer</em>. 6th. ed., Hoboken, New Jersey: John Wiley and Sons, 2007. Print.\n",
     "<a id=\"koothoor2013\"></a>\n",
     "[2]: Koothoor, Nirmitha. <em>A Document Driven Approach to Certifying Scientific Computing Software</em>. McMaster University, Hamilton, ON, Canada: 2013. Print.\n",
-    "<a id=\"lightstone2012\"></a>\n",
-    "[3]: Lightstone, Marilyn. <em>Derivation of tank/pcm model</em>. 2012. From Marilyn Lightstone's Personal Notes\n",
     "<a id=\"parnasClements1986\"></a>\n",
-    "[4]: Parnas, David L. and Clements, P. C. \"A rational design process: How and why to fake it.\" <em>IEEE Transactions on Software Engineering</em>, vol. 12, no. 2, Washington, USA: February, 1986. pp. 251&ndash;257. Print.\n",
+    "[3]: Parnas, David L. and Clements, P. C. \"A rational design process: How and why to fake it.\" <em>IEEE Transactions on Software Engineering</em>, vol. 12, no. 2, Washington, USA: February, 1986. pp. 251&ndash;257. Print.\n",
     "<a id=\"smithKoothoor2016\"></a>\n",
-    "[5]: Smith, W. Spencer and Koothoor, Nirmitha. \"A Document-Driven Method for Certifying Scientific Computing Software for Use in Nuclear Safety Analysis.\" <em>Nuclear Engineering and Technology</em>, vol. 48, no. 2, April, 2016. <a href=\"http://www.sciencedirect.com/science/article/pii/S1738573315002582\">http://www.sciencedirect.com/science/article/pii/S1738573315002582</a>. pp. 404&ndash;418.\n",
+    "[4]: Smith, W. Spencer and Koothoor, Nirmitha. \"A Document-Driven Method for Certifying Scientific Computing Software for Use in Nuclear Safety Analysis.\" <em>Nuclear Engineering and Technology</em>, vol. 48, no. 2, April, 2016. <a href=\"http://www.sciencedirect.com/science/article/pii/S1738573315002582\">http://www.sciencedirect.com/science/article/pii/S1738573315002582</a>. pp. 404&ndash;418.\n",
     "<a id=\"smithLai2005\"></a>\n",
-    "[6]: Smith, W. Spencer and Lai, Lei. \"A new requirements template for scientific computing.\" <em>Proceedings of the First International Workshop on Situational Requirements Engineering Processes - Methods, Techniques and Tools to Support Situation-Specific Requirements Engineering Processes, SREP'05</em>. Edited by PJ Agerfalk, N. Kraiem, and J. Ralyte, Paris, France: 2005. pp. 107&ndash;121. In conjunction with 13th IEEE International Requirements Engineering Conference,\n",
+    "[5]: Smith, W. Spencer and Lai, Lei. \"A new requirements template for scientific computing.\" <em>Proceedings of the First International Workshop on Situational Requirements Engineering Processes - Methods, Techniques and Tools to Support Situation-Specific Requirements Engineering Processes, SREP'05</em>. Edited by PJ Agerfalk, N. Kraiem, and J. Ralyte, Paris, France: 2005. pp. 107&ndash;121. In conjunction with 13th IEEE International Requirements Engineering Conference,\n",
     "<a id=\"smithEtAl2007\"></a>\n",
-    "[7]: Smith, W. Spencer, Lai, Lei, and Khedri, Ridha. \"Requirements Analysis for Engineering Computation: A Systematic Approach for Improving Software Reliability.\" <em>Reliable Computing, Special Issue on Reliable Engineering Computation</em>, vol. 13, no. 1, February, 2007. <a href=\"https://doi.org/10.1007/s11155-006-9020-7\">https://doi.org/10.1007/s11155-006-9020-7</a>. pp. 83&ndash;107.\n",
+    "[6]: Smith, W. Spencer, Lai, Lei, and Khedri, Ridha. \"Requirements Analysis for Engineering Computation: A Systematic Approach for Improving Software Reliability.\" <em>Reliable Computing, Special Issue on Reliable Engineering Computation</em>, vol. 13, no. 1, February, 2007. <a href=\"https://doi.org/10.1007/s11155-006-9020-7\">https://doi.org/10.1007/s11155-006-9020-7</a>. pp. 83&ndash;107.\n",
     "\n"
    ]
   }

--- a/code/stable/swhsnopcm/SRS/PDF/SWHSNoPCM_SRS.tex
+++ b/code/stable/swhsnopcm/SRS/PDF/SWHSNoPCM_SRS.tex
@@ -1224,11 +1224,6 @@ title={A Document Driven Approach to Certifying Scientific Computing Software},
 school={McMaster University},
 year={2013},
 address={Hamilton, ON, Canada}}
-@misc{lightstone2012,
-author={Lightstone, Marilyn},
-title={Derivation of tank/pcm model},
-year={2012},
-note={From Marilyn Lightstone's Personal Notes}}
 @article{parnasClements1986,
 author={Parnas, David L. and Clements, P. C.},
 title={A rational design process: How and why to fake it},

--- a/code/stable/swhsnopcm/SRS/mdBook/src/SecReferences.md
+++ b/code/stable/swhsnopcm/SRS/mdBook/src/SecReferences.md
@@ -8,22 +8,18 @@
 
 [2]: Koothoor, Nirmitha. *A Document Driven Approach to Certifying Scientific Computing Software*. McMaster University, Hamilton, ON, Canada: 2013. Print.
 
-<div id="lightstone2012"></div>
-
-[3]: Lightstone, Marilyn. *Derivation of tank/pcm model*. 2012. From Marilyn Lightstone's Personal Notes
-
 <div id="parnasClements1986"></div>
 
-[4]: Parnas, David L. and Clements, P. C. "A rational design process: How and why to fake it." *IEEE Transactions on Software Engineering*, vol. 12, no. 2, Washington, USA: February, 1986. pp. 251&ndash;257. Print.
+[3]: Parnas, David L. and Clements, P. C. "A rational design process: How and why to fake it." *IEEE Transactions on Software Engineering*, vol. 12, no. 2, Washington, USA: February, 1986. pp. 251&ndash;257. Print.
 
 <div id="smithKoothoor2016"></div>
 
-[5]: Smith, W. Spencer and Koothoor, Nirmitha. "A Document-Driven Method for Certifying Scientific Computing Software for Use in Nuclear Safety Analysis." *Nuclear Engineering and Technology*, vol. 48, no. 2, April, 2016. <http://www.sciencedirect.com/science/article/pii/S1738573315002582>. pp. 404&ndash;418.
+[4]: Smith, W. Spencer and Koothoor, Nirmitha. "A Document-Driven Method for Certifying Scientific Computing Software for Use in Nuclear Safety Analysis." *Nuclear Engineering and Technology*, vol. 48, no. 2, April, 2016. <http://www.sciencedirect.com/science/article/pii/S1738573315002582>. pp. 404&ndash;418.
 
 <div id="smithLai2005"></div>
 
-[6]: Smith, W. Spencer and Lai, Lei. "A new requirements template for scientific computing." *Proceedings of the First International Workshop on Situational Requirements Engineering Processes - Methods, Techniques and Tools to Support Situation-Specific Requirements Engineering Processes, SREP'05*. Edited by PJ Agerfalk, N. Kraiem, and J. Ralyte, Paris, France: 2005. pp. 107&ndash;121. In conjunction with 13th IEEE International Requirements Engineering Conference,
+[5]: Smith, W. Spencer and Lai, Lei. "A new requirements template for scientific computing." *Proceedings of the First International Workshop on Situational Requirements Engineering Processes - Methods, Techniques and Tools to Support Situation-Specific Requirements Engineering Processes, SREP'05*. Edited by PJ Agerfalk, N. Kraiem, and J. Ralyte, Paris, France: 2005. pp. 107&ndash;121. In conjunction with 13th IEEE International Requirements Engineering Conference,
 
 <div id="smithEtAl2007"></div>
 
-[7]: Smith, W. Spencer, Lai, Lei, and Khedri, Ridha. "Requirements Analysis for Engineering Computation: A Systematic Approach for Improving Software Reliability." *Reliable Computing, Special Issue on Reliable Engineering Computation*, vol. 13, no. 1, February, 2007. <https://doi.org/10.1007/s11155-006-9020-7>. pp. 83&ndash;107.
+[6]: Smith, W. Spencer, Lai, Lei, and Khedri, Ridha. "Requirements Analysis for Engineering Computation: A Systematic Approach for Improving Software Reliability." *Reliable Computing, Special Issue on Reliable Engineering Computation*, vol. 13, no. 1, February, 2007. <https://doi.org/10.1007/s11155-006-9020-7>. pp. 83&ndash;107.


### PR DESCRIPTION
Contributes to #4700

`lightstone2012` is only referenced in SWHS, not SWHSNoPCM. It looks like this was accidentally kept when SWHSNoPCM was created (assuming it was created by copy/pasting SWHS!).