### PR TITLE
Make export list of `Language.Drasil.ModelExpr.Extract` explicit and fix external use of internal function.

### DIFF
--- a/code/drasil-lang/lib/Language/Drasil/ModelExpr/Extract.hs
+++ b/code/drasil-lang/lib/Language/Drasil/ModelExpr/Extract.hs
@@ -1,5 +1,5 @@
 -- | Defines functions to find Chunk UIDs within 'ModelExpr's.
-module Language.Drasil.ModelExpr.Extract where
+module Language.Drasil.ModelExpr.Extract (meDep) where
 
 import Data.Containers.ListUtils (nubOrd)
 
@@ -7,6 +7,10 @@ import Drasil.Database (UID)
 
 import Language.Drasil.ModelExpr.Lang (ModelExpr(..))
 import Language.Drasil.Space (RealInterval(..))
+
+-- | Get dependencies from an equation.
+meDep :: ModelExpr -> [UID]
+meDep = nubOrd . meNames
 
 -- | Generic traverse of all expressions that could lead to names.
 meNames :: ModelExpr -> [UID]
@@ -47,10 +51,3 @@ meNamesRI :: RealInterval ModelExpr ModelExpr -> [UID]
 meNamesRI (Bounded (_, il) (_, iu)) = meNames il ++ meNames iu
 meNamesRI (UpTo (_, iu))            = meNames iu
 meNamesRI (UpFrom (_, il))          = meNames il
-
----------------------------------------------------------------------------
--- And now implement the exported traversals all in terms of the above
-
--- | Get dependencies from an equation.
-meDep :: ModelExpr -> [UID]
-meDep = nubOrd . meNames

--- a/code/drasil-lang/lib/Language/Drasil/Sentence.hs
+++ b/code/drasil-lang/lib/Language/Drasil/Sentence.hs
@@ -21,7 +21,7 @@ import Drasil.Database (HasChunkRefs(..), HasUID(..), UID, IsChunk)
 
 import Language.Drasil.ExprClasses (Express(express))
 import Language.Drasil.ModelExpr.Lang (ModelExpr)
-import Language.Drasil.ModelExpr.Extract (meNames)
+import Language.Drasil.ModelExpr.Extract (meDep)
 import Language.Drasil.NaturalLanguage.English.NounPhrase.Core (NP)
 import Language.Drasil.UnitLang (USymb)
 import Language.Drasil.Symbol (HasSymbol, Symbol)
@@ -168,7 +168,7 @@ getUIDs Ref {}              = []
 getUIDs Percent             = []
 getUIDs ((:+:) a b)         = getUIDs a ++ getUIDs b
 getUIDs (Quote a)           = getUIDs a
-getUIDs (E a)               = meNames a
+getUIDs (E a)               = meDep a
 getUIDs EmptyS              = []
 
 -- | Generic traverse of all positions that could lead to /symbolic/ and /abbreviated/ 'UID's from 'Sentence's


### PR DESCRIPTION
Builds on #4773 

`meNames` was meant to be an internal function. This PR keeps it as such, adjusting external use to use the intended function: `meDep`.