### PR TITLE
Implement HasChunkRefs for drasil-code chunks

### DIFF
--- a/code/drasil-code/lib/Language/Drasil/Chunk/CodeDefinition.hs
+++ b/code/drasil-code/lib/Language/Drasil/Chunk/CodeDefinition.hs
@@ -24,7 +24,8 @@ data CodeDefinition = CD { _cchunk   :: CodeChunk
 makeLenses ''CodeDefinition
 
 instance HasChunkRefs CodeDefinition where
-  chunkRefs = const mempty -- FIXME: `chunkRefs` should actually collect the referenced chunks.
+  chunkRefs cd = chunkRefs (cd ^. cchunk)
+  {-# INLINABLE chunkRefs #-}
 
 -- | Finds the 'UID' of the 'CodeChunk' used to make the 'CodeDefinition'.
 instance HasUID           CodeDefinition where uid = cchunk . uid

--- a/code/drasil-code/lib/Language/Drasil/Chunk/NamedArgument.hs
+++ b/code/drasil-code/lib/Language/Drasil/Chunk/NamedArgument.hs
@@ -21,7 +21,8 @@ newtype NamedArgument = NA {_qtd :: DefinedQuantityDict}
 makeLenses ''NamedArgument
 
 instance HasChunkRefs NamedArgument where
-  chunkRefs = const mempty -- FIXME: `chunkRefs` should actually collect the referenced chunks.
+  chunkRefs na = chunkRefs (na ^. qtd)
+  {-# INLINABLE chunkRefs #-}
 
 -- | Finds the 'UID' of the 'DefinedQuantityDict' used to make the 'NamedArgument'.
 instance HasUID         NamedArgument where uid = qtd . uid

--- a/code/drasil-code/lib/Language/Drasil/Chunk/Parameter.hs
+++ b/code/drasil-code/lib/Language/Drasil/Chunk/Parameter.hs
@@ -19,7 +19,8 @@ data ParameterChunk = PC {_pcc :: CodeChunk
 makeLenses ''ParameterChunk
 
 instance HasChunkRefs ParameterChunk where
-  chunkRefs = const mempty -- FIXME: `chunkRefs` should actually collect the referenced chunks.
+  chunkRefs pc = chunkRefs (pc ^. pcc)
+  {-# INLINABLE chunkRefs #-}
 
 -- | Finds the 'UID' of the 'CodeChunk' used to make the 'ParameterChunk'.
 instance HasUID      ParameterChunk where uid = pcc . uid

--- a/code/drasil-lang/lib/Drasil/Code/CodeVar.hs
+++ b/code/drasil-lang/lib/Drasil/Code/CodeVar.hs
@@ -42,7 +42,8 @@ data CodeChunk = CodeC { _qc  :: DefinedQuantityDict
 makeLenses ''CodeChunk
 
 instance HasChunkRefs CodeChunk where
-  chunkRefs = const mempty -- FIXME: `chunkRefs` should actually collect the referenced chunks.
+  chunkRefs cc = chunkRefs (cc ^. qc)
+  {-# INLINABLE chunkRefs #-}
 
 -- | Finds the 'UID' of the 'DefinedQuantityDict' used to make the 'CodeChunk'.
 instance HasUID        CodeChunk where uid = qc . uid
@@ -72,7 +73,11 @@ data CodeVarChunk = CodeVC {_ccv :: CodeChunk,
 makeLenses ''CodeVarChunk
 
 instance HasChunkRefs CodeVarChunk where
-  chunkRefs = const mempty -- FIXME: `chunkRefs` should actually collect the referenced chunks.
+  chunkRefs cvc = mconcat
+    [ chunkRefs (cvc ^. ccv)
+    , chunkRefs (cvc ^. obv)
+    ]
+  {-# INLINABLE chunkRefs #-}
 
 -- | Finds the 'UID' of the 'CodeChunk' used to make the 'CodeVarChunk'.
 instance HasUID        CodeVarChunk where uid = ccv . uid
@@ -100,7 +105,8 @@ newtype CodeFuncChunk = CodeFC {_ccf :: CodeChunk}
 makeLenses ''CodeFuncChunk
 
 instance HasChunkRefs CodeFuncChunk where
-  chunkRefs = const mempty -- FIXME: `chunkRefs` should actually collect the referenced chunks.
+  chunkRefs cfc = chunkRefs (cfc ^. ccf)
+  {-# INLINABLE chunkRefs #-}
 
 -- | Finds the 'UID' of the 'CodeChunk' used to make the 'CodeFuncChunk'.
 instance HasUID        CodeFuncChunk where uid = ccf . uid


### PR DESCRIPTION
This PR implements `HasChunkRefs` for the remaining drasil-code chunk types:
`NamedArgument, ParameterChunk, CodeChunk, CodeVarChunk, CodeFuncChunk, and CodeDefinition`