### PR TITLE
Implement `HasChunkRefs` for `UnitDefn`

### DIFF
--- a/code/drasil-lang/lib/Language/Drasil/Chunk/UnitDefn.hs
+++ b/code/drasil-lang/lib/Language/Drasil/Chunk/UnitDefn.hs
@@ -46,7 +46,8 @@ data UnitDefn = UD { _vc :: ConceptChunk
 makeLenses ''UnitDefn
 
 instance HasChunkRefs UnitDefn where
-  chunkRefs = const mempty -- FIXME: `chunkRefs` should actually collect the referenced chunks.
+  chunkRefs ud = chunkRefs (ud ^. vc)
+  {-# INLINABLE chunkRefs #-}
 
 -- | Finds 'UID' of the 'ConceptChunk' used to make the 'UnitDefn'.
 instance HasUID        UnitDefn where uid = vc . uid


### PR DESCRIPTION
This PR implements `HasChunkRefs` for `UnitDefn`. `chunkRefs` now tracks `refs` from the wrapped concept chunk (`vc`)