### PR TITLE
Move `MVar` field accessors, constructors, destructors closer to `MVar`'s definition.

### DIFF
--- a/code/drasil-build/lib/Build/Drasil/Make/Helpers.hs
+++ b/code/drasil-build/lib/Build/Drasil/Make/Helpers.hs
@@ -2,7 +2,8 @@
 module Build.Drasil.Make.Helpers where
 
 import Build.Drasil.Make.AST (Command(C), Rule(R))
-import Build.Drasil.Make.MakeString (MakeString(Mc, Mr, Mv), MVar(Free, Implicit, Os))
+import Build.Drasil.Make.MakeString (MakeString(..), MVar, varName, win, mac,
+  linux, isOsVar)
 
 import Data.List (nubBy)
 import Text.PrettyPrint (Doc, empty, nest, text, vcat, ($+$))
@@ -10,21 +11,6 @@ import Text.PrettyPrint (Doc, empty, nest, text, vcat, ($+$))
 -- | Assignment operator ("=").
 ($=) :: MVar -> String -> Doc
 a $= b = text $ varName a ++ "=" ++ b
-
--- | Extracts information for Windows OS from a variable.
-win :: MVar -> String
-win (Os _ w _ _) = w
-win _ = error "Expected Os Variable"
-
--- | Extracts information for Mac OS from a variable.
-mac :: MVar -> String
-mac (Os _ _ m _) = m
-mac _ = error "Expected Os Variable"
-
--- | Extracts information for Linux OS from a variable.
-linux :: MVar -> String
-linux (Os _ _ _ l) = l
-linux _ = error "Expected Os Variable"
 
 -- | Defines variables dependent on OS.
 defineOsVars :: (MVar -> String) -> [MVar] -> Doc
@@ -52,12 +38,6 @@ uniqueVars :: [MVar] -> [MVar]
 uniqueVars = nubBy (\x y -> varName x == varName y && (x == y ||
         error ("Found disparate variable definitions for " ++ varName x)))
 
--- | Extracts the variable name from a Makefile variable.
-varName :: MVar -> String
-varName (Free s) = s
-varName (Implicit s) = s
-varName (Os s _ _ _) = s
-
 -- | Extracts variables from a Makefile rule.
 extractVars :: Rule -> [MVar]
 extractVars (R _ t d _ cs) = concatMap getVars $ t : d ++ map (\(C s _) -> s) cs
@@ -67,11 +47,6 @@ getVars :: MakeString -> [MVar]
 getVars (Mr _) = []
 getVars (Mv v) = [v]
 getVars (Mc a b) = getVars a ++ getVars b
-
--- | Checks if a variable is OS dependent.
-isOsVar :: MVar -> Bool
-isOsVar Os{} = True
-isOsVar _ = False
 
 -- | Helper for prepending common features to a Makefile.
 addCommonFeatures :: [Rule] -> Doc -> Doc

--- a/code/drasil-build/lib/Build/Drasil/Make/MakeString.hs
+++ b/code/drasil-build/lib/Build/Drasil/Make/MakeString.hs
@@ -63,3 +63,29 @@ mkImplicitVar = Mv . Implicit
 -- | Constructor for 'Free' variables.
 mkFreeVar :: VarName -> MakeString
 mkFreeVar = Mv . Free
+
+-- | Extracts the variable name from a Makefile variable.
+varName :: MVar -> String
+varName (Free s) = s
+varName (Implicit s) = s
+varName (Os s _ _ _) = s
+
+-- | Extracts information for Windows OS from a variable.
+win :: MVar -> String
+win (Os _ w _ _) = w
+win _ = error "Expected Os Variable"
+
+-- | Extracts information for Mac OS from a variable.
+mac :: MVar -> String
+mac (Os _ _ m _) = m
+mac _ = error "Expected Os Variable"
+
+-- | Extracts information for Linux OS from a variable.
+linux :: MVar -> String
+linux (Os _ _ _ l) = l
+linux _ = error "Expected Os Variable"
+
+-- | Checks if a variable is OS dependent.
+isOsVar :: MVar -> Bool
+isOsVar Os{} = True
+isOsVar _ = False


### PR DESCRIPTION
Moving from a "`Helpers`" file to `Build.Drasil.Make.MakeString`, which is where `MVar` is defined.