### PR TITLE
Fix ambiguous performance NFR wording in GamePhysics example

### DIFF
--- a/code/drasil-example/gamephysics/lib/Drasil/GamePhysics/Requirements.hs
+++ b/code/drasil-example/gamephysics/lib/Drasil/GamePhysics/Requirements.hs
@@ -11,6 +11,8 @@ import Drasil.DocLang (mkMaintainableNFR)
 import Data.Drasil.Concepts.Documentation as Doc (body, funcReqDom, input_,
   nonFuncReqDom, output_, physicalConstraint, physicalSim, property, solutionCharSpec)
 
+import Drasil.Sentence.Combinators (addPercent)
+
 import qualified Data.Drasil.Concepts.Physics as CP (collision, elasticity,
   friction, rigidBody, space)
 import qualified Data.Drasil.Concepts.Math as CM (surface)
@@ -106,7 +108,8 @@ nonfuncReqs = [performance, correctness, usability, understandability, maintaina
 performance :: ConceptInstance
 performance = cic "performance" (foldlSent [
   S "The execution time" `S.for` S "collision detection" `S.and_` S "collision resolution shall be",
-  S "within 1 percent of the execution time of the Pymunk 2D physics library"
+  S "within" +:+ addPercent (1 :: Int) +:+
+    S "of the execution time of the Pymunk 2D physics library"
   ]) "Performance" nonFuncReqDom
 
 correctness :: ConceptInstance

--- a/code/stable/gamephysics/SRS/HTML/GamePhysics_SRS.html
+++ b/code/stable/gamephysics/SRS/HTML/GamePhysics_SRS.html
@@ -2638,7 +2638,7 @@
             <div class="list">
               <p>
                 <div id="performance">
-                  Performance: The execution time for collision detection and collision resolution shall be comparable to an existing 2D physics library on the market (e.g. Pymunk).
+                  Performance: The execution time for collision detection and collision resolution shall be within 1<em>%</em> of the execution time of the Pymunk 2D physics library.
                 </div>
               </p>
               <p>

--- a/code/stable/gamephysics/SRS/Jupyter/GamePhysics_SRS.ipynb
+++ b/code/stable/gamephysics/SRS/Jupyter/GamePhysics_SRS.ipynb
@@ -2130,7 +2130,7 @@
     "This section provides the non-functional requirements, the qualities that the software is expected to exhibit.\n",
     "\n",
     "<div id=\\\"performance\\\">\n",
-    "Performance: The execution time for collision detection and collision resolution shall be comparable to an existing 2D physics library on the market (e.g. Pymunk).\n",
+    "Performance: The execution time for collision detection and collision resolution shall be within 1$%$ of the execution time of the Pymunk 2D physics library.\n",
     "\n",
     "</div>\n",
     "<div id=\\\"correctness\\\">\n",

--- a/code/stable/gamephysics/SRS/PDF/GamePhysics_SRS.tex
+++ b/code/stable/gamephysics/SRS/PDF/GamePhysics_SRS.tex
@@ -1528,7 +1528,7 @@ This section provides the functional requirements, the tasks and behaviours that
 This section provides the non-functional requirements, the qualities that the software is expected to exhibit.
 
 \begin{description}[font=\normalfont]
-\item[Performance:\phantomsection\label{performance}]{The execution time for collision detection and collision resolution shall be comparable to an existing 2D physics library on the market (e.g. Pymunk).}
+\item[Performance:\phantomsection\label{performance}]{The execution time for collision detection and collision resolution shall be within 1$\%$ of the execution time of the Pymunk 2D physics library.}
 \item[Correctness:\phantomsection\label{correctness}]{The output of simulation results shall be compared to an existing implementation like \hyperref{http://www.pymunk.org/en/latest/}{}{}{Pymunk}.}
 \item[Usability:\phantomsection\label{usability}]{Software shall be easy to learn and use. Usability shall be measured by how long it takes a user to learn how to use the library to create a small program to simulate the movement of 2 bodies over time in space. Creating a program should take no less than 30 to 60 minutes for an intermediate to experienced programmer.}
 \item[Understandability:\phantomsection\label{understandability}]{Users of Tamias2D shall be able to learn the software with ease. Users shall be able to easily create a small program using the library. Creating a small program to simulate the movement of 2 bodies in space should take no less that 60 minutes.}

--- a/code/stable/gamephysics/SRS/mdBook/src/SecNFRs.md
+++ b/code/stable/gamephysics/SRS/mdBook/src/SecNFRs.md
@@ -4,7 +4,7 @@ This section provides the non-functional requirements, the qualities that the so
 
 <div id="performance"></div>
 
-Performance: The execution time for collision detection and collision resolution shall be comparable to an existing 2D physics library on the market (e.g. Pymunk).
+Performance: The execution time for collision detection and collision resolution shall be within 1\\(\\%\\) of the execution time of the Pymunk 2D physics library.
 
 <div id="correctness"></div>
 


### PR DESCRIPTION
Fixes ambiguous wording in the performance non-functional requirement for the GamePhysics example. The previous text used the vague term "comparable". This change replaces it with a parameterized requirement specifying execution time within (target)% of a competitor.