### PR TITLE
Add `mexpress` to `Express` typeclass; a function for expressing something as a series of facts rather than a single one as `express` normally expects.

### DIFF
--- a/code/drasil-lang/lib/Language/Drasil.hs
+++ b/code/drasil-lang/lib/Language/Drasil.hs
@@ -60,7 +60,7 @@ module Language.Drasil (
   , HasAdditionalNotes(getNotes)
   , IsUnit(getUnits)
   , DefiningExpr(defnExpr)
-  , Express(express)
+  , Express(..)
   -- *** References
   -- Language.Drasil.Symbol
   , HasRefAddress(getRefAdd)
@@ -260,6 +260,7 @@ import Language.Drasil.Expr.Class (ExprC(..),
   frac, recip_, square, half, oneHalf, oneThird, apply1, apply2,
   m2x2, vec2D, dgnl2x2, rowVec, columnVec, mkSet, PExpr)
 import Language.Drasil.Expr.Lang (Expr, Completeness, Relation)
+import Language.Drasil.ExprClasses (Express(..))
 import Language.Drasil.Literal.Class (LiteralC(..))
 import Language.Drasil.Literal.Lang (Literal)
 import Language.Drasil.ModelExpr.Class (ModelExprC(..))
@@ -277,7 +278,7 @@ import Language.Drasil.Unicode (RenderSpecial(..), Special(..))
 import Language.Drasil.Symbol (HasSymbol(symbol), Decoration, Symbol)
 import Language.Drasil.Classes (Definition(defn), ConceptDomain(cdom), Concept, HasUnitSymbol(usymb),
   IsUnit(getUnits), CommonIdea(abrv), HasAdditionalNotes(getNotes), Constrained(constraints),
-  HasReasVal(reasVal), DefiningExpr(defnExpr), Quantity, Express(..))
+  HasReasVal(reasVal), DefiningExpr(defnExpr), Quantity)
 import Language.Drasil.Data.Date (Month(..))
 import Language.Drasil.Chunk.Citation (
     Citation, EntryID, BibRef

--- a/code/drasil-lang/lib/Language/Drasil/Classes.hs
+++ b/code/drasil-lang/lib/Language/Drasil/Classes.hs
@@ -19,7 +19,7 @@ module Language.Drasil.Classes (
   , IsUnit(udefn, getUnits)
   , UnitEq(uniteq)
     -- ** Expr and expressions
-  , Express(express)
+  , Express(express, mexpress)
   , DefiningExpr(defnExpr)
   ) where
 
@@ -34,7 +34,7 @@ import Language.Drasil.Chunk.NamedIdea (Idea(..), NamedIdea(..))
 import Language.Drasil.Constraint (ConstraintE)
 import Language.Drasil.UnitLang (UDefn, USymb)
 import Language.Drasil.Expr.Lang (Expr)
-import Language.Drasil.ExprClasses (Express(express))
+import Language.Drasil.ExprClasses (Express(express, mexpress))
 import Language.Drasil.Space (HasSpace)
 import Language.Drasil.Sentence (Sentence)
 

--- a/code/drasil-lang/lib/Language/Drasil/ExprClasses.hs
+++ b/code/drasil-lang/lib/Language/Drasil/ExprClasses.hs
@@ -1,14 +1,24 @@
 -- | Defines classes for use with Drasil's expression language.
-module Language.Drasil.ExprClasses where
+module Language.Drasil.ExprClasses (Express(..)) where
+
+import qualified Data.List.NonEmpty as NE
 
 import Language.Drasil.Expr.Lang (Expr)
 import Language.Drasil.ModelExpr.Lang (ModelExpr(Lit))
 import Language.Drasil.ModelExpr.Convert (expr)
 import Language.Drasil.Literal.Lang (Literal)
+import Language.Drasil.Expr.Class (($&&))
 
--- | Data that can be expressed using 'ModelExpr'.
+-- | Express something axiomatically.
 class Express c where
+  -- | Express something as a single fact.
   express :: c -> ModelExpr
+  -- | Express something as a series of facts.
+  mexpress :: c -> NE.NonEmpty ModelExpr
+
+  express = foldr1 ($&&) . mexpress
+  mexpress = NE.singleton . express
+  {-# MINIMAL express | mexpress #-}
 
 instance Express Literal where
   express = Lit
@@ -20,3 +30,9 @@ instance Express Expr where
 -- | No change, it's already a 'ModelExpr'.
 instance Express ModelExpr where
   express = id
+
+instance Express t => Express [t] where
+  mexpress = (express <$>) . NE.fromList
+
+instance Express t => Express (NE.NonEmpty t) where
+  mexpress = (express <$>)

--- a/code/drasil-theory/lib/Theory/Drasil/ConstraintSet.hs
+++ b/code/drasil-theory/lib/Theory/Drasil/ConstraintSet.hs
@@ -45,7 +45,7 @@ instance ConceptDomain (ConstraintSet e) where cdom = cdom . (^. con)
 -- | The complete 'ModelExpr' of a ConstraintSet is the logical conjunction of
 --   all the underlying relations (e.g., `a $&& b $&& ... $&& z`).
 instance Express e => Express (ConstraintSet e) where
-  express = foldr1 ($&&) . map express . NE.toList . (^. invs)
+  mexpress = mexpress . (^. invs)
 -- | Exposes all relations and an expectation of the type of a relation (Bool)
 instance RequiresChecking (ConstraintSet Expr) Expr Space where
   requiredChecks cs = map (,Boolean) $ NE.toList (cs ^. invs)

--- a/code/drasil-theory/lib/Theory/Drasil/ModelKinds.hs
+++ b/code/drasil-theory/lib/Theory/Drasil/ModelKinds.hs
@@ -149,7 +149,7 @@ instance Definition    (ModelKinds e) where defn    = lensMk defn defn defn defn
 instance ConceptDomain (ModelKinds e) where cdom    = elimMk (to cdom) (to cdom) (to cdom) (to cdom) (to cdom)
 -- | Rewrites the underlying model using 'ModelExpr'
 instance Express e => Express (ModelKinds e) where
-  express = elimMk (to express) (to express) (to express) (to express) (to express)
+  mexpress = elimMk (to mexpress) (to mexpress) (to mexpress) (to mexpress) (to mexpress)
 -- | Expose all expressions that need to be type-checked for theories that need
 --   expose 'Expr's.
 instance RequiresChecking (ModelKinds Expr) Expr Space where
@@ -182,7 +182,7 @@ instance Definition    (ModelKind e) where defn    = mk . defn
 instance ConceptDomain (ModelKind e) where cdom    = cdom . (^. mk)
 -- | Rewrites the underlying model using 'ModelExpr'
 instance Express e => Express (ModelKind e) where
-  express = express . (^. mk)
+  mexpress = mexpress . (^. mk)
 -- | Expose all expressions that need to be type-checked for theories that need
 --   expose 'Expr's.
 instance RequiresChecking (ModelKind Expr) Expr Space where


### PR DESCRIPTION
Contributes to #4791 
Contributes to #4793

Follows @JacquesCarette's https://github.com/JacquesCarette/Drasil/pull/4793#discussion_r2885735294