### PR TITLE
Remove `Theory` usage in `HasChunkRefs TheoryModel` typeclass instance.

### DIFF
--- a/code/drasil-theory/lib/Theory/Drasil/Theory.hs
+++ b/code/drasil-theory/lib/Theory/Drasil/Theory.hs
@@ -62,11 +62,6 @@ makeLenses ''TheoryModel
 instance HasChunkRefs TheoryModel where
   chunkRefs tm' = mconcat
     [ chunkRefs (tm' ^. mk)
-    , chunkRefs (tm' ^. vctx)
-    , chunkRefs (tm' ^. quan)
-    , chunkRefs (tm' ^. ops)
-    , chunkRefs (tm' ^. defq)
-    , chunkRefs (tm' ^. dfun)
     , chunkRefs (lb tm')
     , chunkRefs (tm' ^. notes)
     ]


### PR DESCRIPTION
Contributes to #4791

All of the dependencies established by these previously used fields are also established through the internal `ModelKinds` of a `TheoryModel`. Hence, we can remove their usage.