### PR TITLE
Create `raw` and `rawUni` to extract raw `UID`s from `UIDRef` and `UnitypedUIDRef`s.

### DIFF
--- a/code/drasil-database/lib/Drasil/Database/UIDRef.hs
+++ b/code/drasil-database/lib/Drasil/Database/UIDRef.hs
@@ -1,7 +1,7 @@
 module Drasil.Database.UIDRef (
   -- * 'UID' References
-  UIDRef, hide, unhide, unhideOrErr,
-  UnitypedUIDRef, hideUni, unhideUni, unhideUniOrErr
+  UIDRef, hide, unhide, unhideOrErr, raw,
+  UnitypedUIDRef, hideUni, unhideUni, unhideUniOrErr, rawUni
 ) where
 
 import Control.Lens ((^.))
@@ -34,6 +34,10 @@ unhide (UIDRef u) = find u
 unhideOrErr :: TypeableChunk t => UIDRef t -> ChunkDB -> t
 unhideOrErr tu cdb = fromMaybe (error "Typed UID dereference failed.") (unhide tu cdb)
 
+-- | Get the raw 'UID' from a 'UIDRef'.
+raw :: UIDRef t -> UID
+raw (UIDRef u) = u
+
 -- | A variant of 'UIDRef' without type information about the chunk being
 -- referred to, effectively treating chunks as being "unityped."
 newtype UnitypedUIDRef = UnitypedUIDRef UID
@@ -54,3 +58,7 @@ unhideUni (UnitypedUIDRef u) = find u
 -- | Find a chunk by its 'UnitypedUIDRef', erroring if not found.
 unhideUniOrErr :: TypeableChunk t => UnitypedUIDRef -> ChunkDB -> t
 unhideUniOrErr tu cdb = fromMaybe (error "Untyped UID dereference failed.") (unhideUni tu cdb)
+
+-- | Get the raw 'UID' from a 'UnitypedUIDRef'.
+rawUni :: UnitypedUIDRef -> UID
+rawUni (UnitypedUIDRef u) = u


### PR DESCRIPTION
Splitting this off from #4716 

These functions are helpful for extracting raw `UID`s from `UIDRef`s (and `U-UIDRef`s).

Why are they necessary? Because moving from raw `UID`-based references to `UIDRef`-based referenced is a large shift in Drasil. There is code that expects specific types (despite polymorphic type signatures) on chunk resolution, such as in the case of `D-Q-D-`s as discussed in #4716 . So, being able to unpack a `UID` and force resolution to another type is helpful. Additionally, our `HasChunkRefs` chunk reference lists are based on `UID`s. We might need a `UIDDep` type that carries an internal `TypeRep` for analytics purposes about what types of chunks each chunk depends on as well. I'm not quite sure yet. We will find a real design soon.