### PR TITLE
Split Build and Deploy CI workflows

### DIFF
--- a/.github/workflows/Build.yaml
+++ b/.github/workflows/Build.yaml
@@ -40,7 +40,7 @@ jobs:
       - name: "Install TeX requirements"
         if: ${{ steps.changes.outputs.tex == 'true' }}
         run: |
-          sudo apt-get install -y --fix-missing fonts-lmodern texlive-bibtex-extra texlive-latex-extra texlive-science texlive-xetex texlive-luatex
+          sudo apt-get install -y --fix-missing fonts-lmodern texlive-bibtex-extra texlive-latex-extra texlive-science texlive-luatex
 
       - name: "Install mdBook"
         if: ${{ steps.changes.outputs.md == 'true' }}

--- a/.github/workflows/Deploy.yaml
+++ b/.github/workflows/Deploy.yaml
@@ -24,7 +24,7 @@ jobs:
 
       - name: "Install system requirements"
         run: |
-          sudo apt-get install -y --fix-missing libgmp-dev python3 graphviz doxygen fonts-lmodern texlive-bibtex-extra texlive-latex-extra texlive-science texlive-xetex texlive-luatex g++ default-jdk mono-devel inkscape
+          sudo apt-get install -y --fix-missing libgmp-dev python3 graphviz doxygen fonts-lmodern texlive-bibtex-extra texlive-latex-extra texlive-science texlive-luatex g++ default-jdk mono-devel inkscape
           curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
           cargo install mdbook
 


### PR DESCRIPTION
The old single workflow ran everything on every PR, including stuff like Doxygen, 
module graphs, and code analysis that nobody looks at until deployment. So, I Separated the old `Build.yaml` into two workflows: one for PR validation, one for deployment.