### PR TITLE
Add inkscape to TeX dependencies in Build CI workflow.

### DIFF
--- a/.github/workflows/Build.yaml
+++ b/.github/workflows/Build.yaml
@@ -40,7 +40,7 @@ jobs:
       - name: "Install TeX requirements"
         if: ${{ steps.changes.outputs.tex == 'true' }}
         run: |
-          sudo apt-get install -y --fix-missing fonts-lmodern texlive-bibtex-extra texlive-latex-extra texlive-science texlive-luatex
+          sudo apt-get install -y --fix-missing fonts-lmodern texlive-bibtex-extra texlive-latex-extra texlive-science texlive-luatex inkscape
 
       - name: "Install mdBook"
         if: ${{ steps.changes.outputs.md == 'true' }}


### PR DESCRIPTION
The CI in #4363 [failed](https://github.com/JacquesCarette/Drasil/actions/runs/23077207647/job/67039725143) for an issue out of my control: system dependencies list was missing `inkscape` (a requirement for building the tex files) in the `Build & Test` workflow.

This PR fixes that.

For reference, https://github.com/JacquesCarette/Drasil/actions/runs/23119661138/job/67151286028?pr=4363 shows that this commit works (see the "Compile generated TeX artifacts" step).