### PR TITLE
Remove 'DblPend' from DblPend's Table of Abbreviations and Acronyms

### DIFF
--- a/code/drasil-example/dblpend/lib/Drasil/DblPend/Body.hs
+++ b/code/drasil-example/dblpend/lib/Drasil/DblPend/Body.hs
@@ -124,7 +124,7 @@ abbreviationsList =
   -- DefinedQuantityDict abbreviations
   map nw symbols ++
   -- Other acronyms/abbreviations
-  nw progName : map nw acronyms
+  map nw acronyms
 
 conceptChunks :: [ConceptChunk]
 conceptChunks =

--- a/code/stable/dblpend/SRS/HTML/DblPend_SRS.html
+++ b/code/stable/dblpend/SRS/HTML/DblPend_SRS.html
@@ -359,10 +359,6 @@
                   <td>Data Definition</td>
                 </tr>
                 <tr>
-                  <td>DblPend</td>
-                  <td>Double Pendulum</td>
-                </tr>
-                <tr>
                   <td>GD</td>
                   <td>General Definition</td>
                 </tr>

--- a/code/stable/dblpend/SRS/Jupyter/DblPend_SRS.ipynb
+++ b/code/stable/dblpend/SRS/Jupyter/DblPend_SRS.ipynb
@@ -130,7 +130,6 @@
     "|2D|Two-Dimensional|\n",
     "|A|Assumption|\n",
     "|DD|Data Definition|\n",
-    "|DblPend|Double Pendulum|\n",
     "|GD|General Definition|\n",
     "|GS|Goal Statement|\n",
     "|IM|Instance Model|\n",

--- a/code/stable/dblpend/SRS/PDF/DblPend_SRS.tex
+++ b/code/stable/dblpend/SRS/PDF/DblPend_SRS.tex
@@ -147,8 +147,6 @@ A & Assumption
 \\
 DD & Data Definition
 \\
-DblPend & Double Pendulum
-\\
 GD & General Definition
 \\
 GS & Goal Statement

--- a/code/stable/dblpend/SRS/mdBook/src/SecTAbbAcc.md
+++ b/code/stable/dblpend/SRS/mdBook/src/SecTAbbAcc.md
@@ -7,7 +7,6 @@
 |2D          |Two-Dimensional                    |
 |A           |Assumption                         |
 |DD          |Data Definition                    |
-|DblPend     |Double Pendulum                    |
 |GD          |General Definition                 |
 |GS          |Goal Statement                     |
 |IM          |Instance Model                     |


### PR DESCRIPTION
Spawns from https://github.com/JacquesCarette/Drasil/pull/4363#discussion_r2492498010