### PR TITLE
Re-write `weave` to truly only accept two arguments.

### DIFF
--- a/code/drasil-data/lib/Data/Drasil/Theories/Physics.hs
+++ b/code/drasil-data/lib/Data/Drasil/Theories/Physics.hs
@@ -42,7 +42,7 @@ weightSrc = makeURI "weightSrc" "https://en.wikipedia.org/wiki/Weight" $
   shortname' $ S "Definition of Weight"
 
 weightDeriv :: Derivation
-weightDeriv = mkDerivName (phrase QP.weight) $ weave [weightDerivSentences, weightDerivEqns]
+weightDeriv = mkDerivName (phrase QP.weight) $ weave weightDerivSentences weightDerivEqns
 
 weightDerivSentences, weightDerivEqns :: [Sentence]
 weightDerivSentences = map foldlSentCol [weightDerivAccelSentence,

--- a/code/drasil-example/dblpend/lib/Drasil/DblPend/GenDefs.hs
+++ b/code/drasil-example/dblpend/lib/Drasil/DblPend/GenDefs.hs
@@ -43,7 +43,7 @@ velXQD_1 = mkQuantDef' xVel_1 (the xComp `NP.of_` (velocity `ofThe` firstObject)
 -- lable and equation
 
 velXDeriv_1 :: Derivation
-velXDeriv_1 = mkDerivName (D.toSent $ phraseNP (NP.the (xComp `of_` velocity))) (weave [velXDerivSents_1, velXDerivEqns_1])
+velXDeriv_1 = mkDerivName (D.toSent $ phraseNP (NP.the (xComp `of_` velocity))) (weave velXDerivSents_1 velXDerivEqns_1)
 -- title paragraph and weave the explained words and refined equation
 
 velXDerivSents_1 :: [Sentence]
@@ -71,7 +71,7 @@ velYQD_1 :: ModelQDef
 velYQD_1 = mkQuantDef' yVel_1 (the yComp `NP.of_` (velocity `ofThe` firstObject)) E.velYExpr_1
 
 velYDeriv_1 :: Derivation
-velYDeriv_1 = mkDerivName (D.toSent $ phraseNP (NP.the (yComp `of_` velocity))) (weave [velYDerivSents_1, velYDerivEqns_1])
+velYDeriv_1 = mkDerivName (D.toSent $ phraseNP (NP.the (yComp `of_` velocity))) (weave velYDerivSents_1 velYDerivEqns_1)
 
 velYDerivSents_1 :: [Sentence]
 velYDerivSents_1 = [velDerivSent1, velYDerivSent2_1, velDerivSent3, velDerivSent4, velDerivSent5]
@@ -92,7 +92,7 @@ velXQD_2 :: ModelQDef
 velXQD_2 = mkQuantDef' xVel_2 (the xComp `NP.of_` (velocity `ofThe` secondObject)) E.velXExpr_2
 
 velXDeriv_2 :: Derivation
-velXDeriv_2 = mkDerivName (D.toSent $ phraseNP (NP.the (xComp `of_` velocity))) (weave [velXDerivSents_2, velXDerivEqns_2])
+velXDeriv_2 = mkDerivName (D.toSent $ phraseNP (NP.the (xComp `of_` velocity))) (weave velXDerivSents_2 velXDerivEqns_2)
 
 velXDerivSents_2 :: [Sentence]
 velXDerivSents_2 = [velDerivSent1, velXDerivSent2_2, velDerivSent3, velDerivSent4]
@@ -113,7 +113,7 @@ velYQD_2 :: ModelQDef
 velYQD_2 = mkQuantDef' yVel_2 (the yComp `NP.of_` (velocity `ofThe` secondObject)) E.velYExpr_2
 
 velYDeriv_2 :: Derivation
-velYDeriv_2 = mkDerivName (D.toSent $ phraseNP (NP.the (yComp `of_` velocity))) (weave [velYDerivSents_2, velYDerivEqns_2])
+velYDeriv_2 = mkDerivName (D.toSent $ phraseNP (NP.the (yComp `of_` velocity))) (weave velYDerivSents_2 velYDerivEqns_2)
 
 velYDerivSents_2 :: [Sentence]
 velYDerivSents_2 = [velDerivSent1,velYDerivSent2_2,velDerivSent3,velDerivSent5]
@@ -134,7 +134,7 @@ accelXQD_1 :: ModelQDef
 accelXQD_1 = mkQuantDef' xAccel_1 (the xComp `NP.of_` (acceleration `ofThe` firstObject)) E.accelXExpr_1
 
 accelXDeriv_1:: Derivation
-accelXDeriv_1 = mkDerivName (D.toSent $ phraseNP (NP.the (xComp `of_` acceleration))) (weave [accelXDerivSents_1, accelXDerivEqns_1])
+accelXDeriv_1 = mkDerivName (D.toSent $ phraseNP (NP.the (xComp `of_` acceleration))) (weave accelXDerivSents_1 accelXDerivEqns_1)
 
 accelXDerivSents_1:: [Sentence]
 accelXDerivSents_1 = [accelDerivSent1, accelXDerivSent2_1, accelDerivSent3, accelDerivSent4, accelDerivSent5]
@@ -160,7 +160,7 @@ accelYQD_1 :: ModelQDef
 accelYQD_1 = mkQuantDef' yAccel_1 (the yComp `NP.of_` (acceleration `ofThe` firstObject)) E.accelYExpr_1
 
 accelYDeriv_1:: Derivation
-accelYDeriv_1 = mkDerivName (D.toSent $ phraseNP (NP.the (yComp `of_` acceleration))) (weave [accelYDerivSents_1, accelYDerivEqns_1])
+accelYDeriv_1 = mkDerivName (D.toSent $ phraseNP (NP.the (yComp `of_` acceleration))) (weave accelYDerivSents_1 accelYDerivEqns_1)
 
 accelYDerivSents_1 :: [Sentence]
 accelYDerivSents_1 = [accelDerivSent1, accelYDerivSent2_1, accelDerivSent3, accelDerivSent4, accelDerivSent5]
@@ -181,7 +181,7 @@ accelXQD_2 :: ModelQDef
 accelXQD_2 = mkQuantDef' xAccel_2 (the xComp `NP.of_` (acceleration `ofThe` secondObject)) E.accelXExpr_2
 
 accelXDeriv_2 :: Derivation
-accelXDeriv_2 = mkDerivName (D.toSent $ phraseNP (NP.the (xComp `of_` acceleration))) (weave [accelXDerivSents_2, accelXDerivEqns_2])
+accelXDeriv_2 = mkDerivName (D.toSent $ phraseNP (NP.the (xComp `of_` acceleration))) (weave accelXDerivSents_2 accelXDerivEqns_2)
 
 accelXDerivSents_2 :: [Sentence]
 accelXDerivSents_2 = [accelDerivSent1, accelXDerivSent2_2, accelDerivSent3, accelDerivSent4]
@@ -202,7 +202,7 @@ accelYQD_2 :: ModelQDef
 accelYQD_2 = mkQuantDef' yAccel_2 (the yComp `NP.of_` (acceleration `ofThe` secondObject)) E.accelYExpr_2
 
 accelYDeriv_2 :: Derivation
-accelYDeriv_2 = mkDerivName (D.toSent $ phraseNP (NP.the (yComp `of_` acceleration))) (weave [accelYDerivSents_2, accelYDerivEqns_2])
+accelYDeriv_2 = mkDerivName (D.toSent $ phraseNP (NP.the (yComp `of_` acceleration))) (weave accelYDerivSents_2 accelYDerivEqns_2)
 
 accelYDerivSents_2 :: [Sentence]
 accelYDerivSents_2 = [accelDerivSent1, accelYDerivSent2_2, accelDerivSent3, accelDerivSent4]

--- a/code/drasil-example/dblpend/lib/Drasil/DblPend/IMods.hs
+++ b/code/drasil-example/dblpend/lib/Drasil/DblPend/IMods.hs
@@ -89,4 +89,4 @@ angleFD_2 = mkFuncDefByQ angularAccel_2
   [pendDisAngle_1, pendDisAngle_2, angularVel_1, angularVel_2] angularAccelExpr_2
 
 angleDeriv_2 :: Derivation
-angleDeriv_2 = mkDerivName (phrase pendDisAngle_2) (weave [angleDerivSents, map eS angularAccelDerivEqns])
+angleDeriv_2 = mkDerivName (phrase pendDisAngle_2) (weave angleDerivSents $ map eS angularAccelDerivEqns)

--- a/code/drasil-example/gamephysics/lib/Drasil/GamePhysics/DataDefs.hs
+++ b/code/drasil-example/gamephysics/lib/Drasil/GamePhysics/DataDefs.hs
@@ -227,7 +227,7 @@ impulseVDesc = foldlSent [S "An", getTandS QP.impulseV, S "occurs when a",
   getTandS QP.force, S "acts over a body over an interval" `S.of_` phrase QP.time]
 
 impulseVDeriv :: Derivation
-impulseVDeriv = mkDerivName (phrase QP.impulseV) (weave [impulseVDerivSentences, map eS impulseVDerivEqns])
+impulseVDeriv = mkDerivName (phrase QP.impulseV) (weave impulseVDerivSentences $ map eS impulseVDerivEqns)
 
 impulseVDerivSentences :: [Sentence]
 impulseVDerivSentences = map foldlSentCol [impulseVDerivSentence1,

--- a/code/drasil-example/gamephysics/lib/Drasil/GamePhysics/GenDefs.hs
+++ b/code/drasil-example/gamephysics/lib/Drasil/GamePhysics/GenDefs.hs
@@ -80,7 +80,7 @@ accelGravityExpr = neg ((sy QP.gravitationalConst $* sy mLarger $/
   square (sy dispNorm)) $* sy dVect)
 accelGravityDeriv :: Derivation
 accelGravityDeriv = mkDerivName (phrase QP.gravitationalAccel)
-                      (weave [accelGravityDerivSentences, map eS accelGravityDerivEqns])
+                      (weave accelGravityDerivSentences $ map eS accelGravityDerivEqns)
 
 accelGravityDerivSentences :: [Sentence]
 accelGravityDerivSentences = map foldlSentCol [accelGravityDerivSentence1,

--- a/code/drasil-example/gamephysics/lib/Drasil/GamePhysics/IMods.hs
+++ b/code/drasil-example/gamephysics/lib/Drasil/GamePhysics/IMods.hs
@@ -66,7 +66,7 @@ transMotOutputs = foldlSent [D.toSent (atStartNP (output_ `the_ofThe` inModel)),
 
 transMotDeriv :: Derivation
 transMotDeriv = mkDerivName (phrase transMot)
-      (weave [transMotDerivStmts, transMotDerivEqns])
+      (weave transMotDerivStmts transMotDerivEqns)
 
 transMotDerivStmts :: [Sentence]
 transMotDerivStmts = [
@@ -103,7 +103,7 @@ rotMotDesc = foldlSent [S "The above", phrase equation, S "for the total",
 
 rotMotDeriv :: Derivation
 rotMotDeriv = mkDerivName (phrase rotMot)
-      (weave [rotMotDerivStmts, rotMotDerivEqns])
+      (weave rotMotDerivStmts rotMotDerivEqns)
 
 rotMotDerivStmts :: [Sentence]
 rotMotDerivStmts = [

--- a/code/drasil-example/pdcontroller/lib/Drasil/PDController/IModel.hs
+++ b/code/drasil-example/pdcontroller/lib/Drasil/PDController/IModel.hs
@@ -57,7 +57,7 @@ imPDRC
 imDeriv :: Derivation
 imDeriv
   = mkDerivName (phrase processVariable)
-      (weave [imDerivStmts, map eS imDerivEqns])
+      (weave imDerivStmts $ map eS imDerivEqns)
 
 imDerivStmts :: [Sentence]
 imDerivStmts = [derivStmt1, derivStmt2, derivStmt3, derivStmt4]

--- a/code/drasil-example/projectile/lib/Drasil/Projectile/GenDefs.hs
+++ b/code/drasil-example/projectile/lib/Drasil/Projectile/GenDefs.hs
@@ -43,7 +43,7 @@ rectVelQD = mkQuantDef' projSpeed
 
 rectVelDeriv :: Derivation
 rectVelDeriv = mkDerivName (phrase rectVel)
-               (weave [rectVelDerivSents, rectVelDerivEqns])
+               (weave rectVelDerivSents rectVelDerivEqns)
 
 rectVelDerivSents :: [Sentence]
 rectVelDerivSents = [rectDeriv velocity acceleration motSent iVel accelerationTM, rearrAndIntSent, performIntSent]
@@ -67,7 +67,7 @@ rectPosQD = mkQuantDef' projPos
 
 rectPosDeriv :: Derivation
 rectPosDeriv = mkDerivName (phrase rectilinear +:+ phrase position)
-               (weave [rectPosDerivSents, rectPosDerivEqns])
+               (weave rectPosDerivSents rectPosDerivEqns)
 
 rectPosDerivSents :: [Sentence]
 rectPosDerivSents = [rectDeriv position velocity motSent iPos velocityTM,

--- a/code/drasil-example/projectile/lib/Drasil/Projectile/IMods.hs
+++ b/code/drasil-example/projectile/lib/Drasil/Projectile/IMods.hs
@@ -42,7 +42,7 @@ timeQD :: SimpleQDef
 timeQD = mkQuantDef flightDur E.flightDur'
 
 timeDeriv :: Derivation
-timeDeriv = mkDerivName (phrase flightDur) (weave [timeDerivSents, map eS timeDerivEqns])
+timeDeriv = mkDerivName (phrase flightDur) (weave timeDerivSents $ map eS timeDerivEqns)
 
 timeDerivSents :: [Sentence]
 timeDerivSents = [timeDerivSent1, timeDerivSent2, timeDerivSent3, timeDerivSent4, timeDerivSent5]
@@ -81,7 +81,7 @@ landPosQD :: SimpleQDef
 landPosQD = mkQuantDef landPos E.landPosExpr
 
 landPosDeriv :: Derivation
-landPosDeriv = mkDerivName (phrase landPos) (weave [landPosDerivSents, map eS landPosDerivEqns])
+landPosDeriv = mkDerivName (phrase landPos) (weave landPosDerivSents $ map eS landPosDerivEqns)
 
 landPosDerivSents :: [Sentence]
 landPosDerivSents = [landPosDerivSent1, landPosDerivSent2, landPosDerivSent3, landPosDerivSent4]

--- a/code/drasil-example/sglpend/lib/Drasil/SglPend/GenDefs.hs
+++ b/code/drasil-example/sglpend/lib/Drasil/SglPend/GenDefs.hs
@@ -48,7 +48,7 @@ velocityIXQD = mkQuantDef' xVel (the xComp `NP.of_` (velocity `ofThe` pendulum))
 
 velocityIXDeriv :: Derivation
 velocityIXDeriv = mkDerivName (D.toSent $ phraseNP (NP.the (xComp `of_` velocity)))
-  (weave [velocityIXDerivSents, velocityIXDerivEqns])
+  (weave velocityIXDerivSents velocityIXDerivEqns)
 
 velocityIXDerivSents :: [Sentence]
 velocityIXDerivSents = [velocityDerivSent1, velocityIXDerivSent2, velocityDerivSent3,
@@ -75,7 +75,7 @@ velocityIYQD = mkQuantDef' yVel (the yComp `NP.of_` (velocity `ofThe` pendulum))
 
 velocityIYDeriv :: Derivation
 velocityIYDeriv = mkDerivName (D.toSent $ phraseNP (NP.the (yComp `of_` velocity)))
-  (weave [velocityIYDerivSents, velocityIYDerivEqns])
+  (weave velocityIYDerivSents velocityIYDerivEqns)
 
 velocityIYDerivSents :: [Sentence]
 velocityIYDerivSents = [velocityDerivSent1, velocityIYDerivSent2, velocityDerivSent3,
@@ -98,7 +98,7 @@ accelerationIXQD = mkQuantDef' xAccel (the xComp `NP.of_` (acceleration `ofThe` 
 
 accelerationIXDeriv :: Derivation
 accelerationIXDeriv = mkDerivName (D.toSent $ phraseNP (NP.the (xComp `of_` acceleration)))
-  (weave [accelerationIXDerivSents, accelerationIXDerivEqns])
+  (weave accelerationIXDerivSents accelerationIXDerivEqns)
 
 accelerationIXDerivSents :: [Sentence]
 accelerationIXDerivSents = [accelerationDerivSent1, accelerationIXDerivSent2, accelerationDerivSent3,
@@ -127,7 +127,7 @@ accelerationIYQD = mkQuantDef' yAccel (the yComp `NP.of_` (acceleration `ofThe` 
 
 accelerationIYDeriv :: Derivation
 accelerationIYDeriv = mkDerivName (D.toSent $ phraseNP (NP.the (yComp `of_` acceleration)))
-  (weave [accelerationIYDerivSents, accelerationIYDerivEqns])
+  (weave accelerationIYDerivSents accelerationIYDerivEqns)
 
 accelerationIYDerivSents :: [Sentence]
 accelerationIYDerivSents = [accelerationDerivSent1, accelerationIYDerivSent2, accelerationDerivSent3,
@@ -191,7 +191,7 @@ angFrequencyQD = mkQuantDef' angularFrequency (angularFrequency `the_ofThe` pend
 
 angFrequencyDeriv :: Derivation
 angFrequencyDeriv = mkDerivName (D.toSent $ phraseNP (angularFrequency `the_ofThe` pendulum))
-  (weave [angFrequencyDerivSents, map eS D.angFrequencyDerivEqns])
+  (weave angFrequencyDerivSents $ map eS D.angFrequencyDerivEqns)
 
 angFrequencyDerivSents :: [Sentence]
 angFrequencyDerivSents = [angFrequencyDerivSent1, angFrequencyDerivSent2, angFrequencyDerivSent3,
@@ -231,7 +231,7 @@ periodPendQD = mkQuantDef' period (NP.the (period `ofThe` pendulum)) $ express E
 
 periodPendDeriv :: Derivation
 periodPendDeriv = mkDerivName (D.toSent $ phraseNP (NP.the (period `ofThe` pendulum)))
-  (weave [periodPendDerivSents, map eS D.periodPendDerivEqns])
+  (weave periodPendDerivSents $ map eS D.periodPendDerivEqns)
 
 periodPendDerivSents :: [Sentence]
 periodPendDerivSents = [periodPendDerivSent1, periodPendDerivSent2]

--- a/code/drasil-example/sglpend/lib/Drasil/SglPend/IMods.hs
+++ b/code/drasil-example/sglpend/lib/Drasil/SglPend/IMods.hs
@@ -44,7 +44,7 @@ angularDisplacementFD = mkFuncDefByQ pendDisplacementAngle
   [time] angularDisplacementExpr
 
 angularDisplacementDeriv :: Derivation
-angularDisplacementDeriv = mkDerivName (phrase angularDisplacement) (weave [angularDisplacementDerivSents, map eS angularDisplacementDerivEqns])
+angularDisplacementDeriv = mkDerivName (phrase angularDisplacement) (weave angularDisplacementDerivSents $ map eS angularDisplacementDerivEqns)
 
 angularDisplacementDerivSents :: [Sentence]
 angularDisplacementDerivSents = [angularDisplacementDerivSent1, angularDisplacementDerivSent2, angularDisplacementDerivSent3,

--- a/code/drasil-example/ssp/lib/Drasil/SSP/GenDefs.hs
+++ b/code/drasil-example/ssp/lib/Drasil/SSP/GenDefs.hs
@@ -271,7 +271,7 @@ momEqlDesc = foldlSent [S "This", phrase equation, S "satisfies",
   surfAngle `definedIn'''` angleB]]
 
 momEqlDeriv :: Derivation
-momEqlDeriv = mkDerivNoHeader (weave [momEqlDerivSentences, momEqlDerivEqns])
+momEqlDeriv = mkDerivNoHeader (weave momEqlDerivSentences momEqlDerivEqns)
 
 momEqlDerivSentences :: [Sentence]
 momEqlDerivSentences = map foldlSentCol [momEqlDerivTorqueSentence,
@@ -486,7 +486,7 @@ sliceWghtNotes = foldlSent [S "This", phrase equation, S "is based on the",
   sParen (refS assumpSLH), baseWthX `definedIn'''` lengthB]
 
 sliceWghtDeriv :: Derivation
-sliceWghtDeriv = mkDerivNoHeader (weave [sliceWghtDerivSentences, sliceWghtDerivEqns])
+sliceWghtDeriv = mkDerivNoHeader (weave sliceWghtDerivSentences sliceWghtDerivEqns)
 
 sliceWghtDerivEqns :: [Sentence]
 sliceWghtDerivEqns = map eS [sliceWghtDerivSatCaseWeightEqn,
@@ -609,7 +609,7 @@ bsWtrFNotes = foldlSent [S "This", phrase equation, S "is based on the",
   baseLngth `definedIn'''` lengthLb]
 
 bsWtrFDeriv :: Derivation
-bsWtrFDeriv = mkDerivNoHeader (weave [bsWtrFDerivSentences, bsWtrFDerivEqns] ++
+bsWtrFDeriv = mkDerivNoHeader (weave bsWtrFDerivSentences bsWtrFDerivEqns ++
   bsWtrFDerivEndSentence)
 
 bsWtrFDerivEqns :: [Sentence]
@@ -692,7 +692,7 @@ srfWtrFNotes = foldlSent [S "This", phrase equation, S "is based on the",
   surfLngth `definedIn'''` lengthLs]
 
 srfWtrFDeriv :: Derivation
-srfWtrFDeriv = mkDerivNoHeader (weave [srfWtrFDerivSentences, srfWtrFDerivEqns] ++
+srfWtrFDeriv = mkDerivNoHeader (weave srfWtrFDerivSentences srfWtrFDerivEqns ++
   srfWtrFDerivEndSentence)
 
 srfWtrFDerivEqns :: [Sentence]

--- a/code/drasil-example/ssp/lib/Drasil/SSP/IMods.hs
+++ b/code/drasil-example/ssp/lib/Drasil/SSP/IMods.hs
@@ -75,10 +75,10 @@ fctSftyDesc = foldlList Comma List [shearRNoIntsl `definedIn'''` resShearWOGD,
   shearFNoIntsl `definedIn'''` mobShearWOGD]
 
 fctSftyDeriv :: Derivation
-fctSftyDeriv = mkDerivNoHeader (weave [fctSftyDerivSentences1, map eS fctSftyDerivEqns1] ++
+fctSftyDeriv = mkDerivNoHeader (weave fctSftyDerivSentences1 (map eS fctSftyDerivEqns1) ++
   map eS [fctSftyDerivEqn10b, fctSftyDerivEqn10c] ++ [fctSftyDerivEllipsis] ++
   map eS [fctSftyDerivEqn10d, fctSftyDerivEqn10e, fctSftyDerivEqn10f] ++
-  weave [fctSftyDerivSentences2, map eS fctSftyDerivEqns2] ++
+  weave fctSftyDerivSentences2 (map eS fctSftyDerivEqns2) ++
   fctSftyDerivSentence20)
 
 fctSftyDerivSentences1 :: [Sentence]
@@ -395,7 +395,7 @@ nrmShrFDesc = nrmShearNum `definedIn'''`
   nrmShrForDen !.)
 
 nrmShrDeriv :: Derivation
-nrmShrDeriv = mkDerivNoHeader (weave [nrmShrDerivationSentences, map eS nrmShrDerivEqns] ++
+nrmShrDeriv = mkDerivNoHeader (weave nrmShrDerivationSentences (map eS nrmShrDerivEqns) ++
   nrmShrDerivSentence5)
 
 nrmShrDerivSentence1 :: [Sentence]
@@ -556,7 +556,7 @@ sliceFsDesc = (foldlList Comma List [shearFNoIntsl `definedIn'''` mobShearWOGD,
   mobShrC `definedIn'''` convertFunc2] !.)
 
 intrSlcDeriv :: Derivation
-intrSlcDeriv = mkDerivNoHeader (weave [intrSlcDerivationSentences, map eS intrSlcDerivEqns] ++ intrSlcDerivSentence3)
+intrSlcDeriv = mkDerivNoHeader (weave intrSlcDerivationSentences (map eS intrSlcDerivEqns) ++ intrSlcDerivSentence3)
 
 intrSlcDerivSentence1 :: [Sentence]
 intrSlcDerivSentence1 = [S "This derivation" `S.is` S "identical to the derivation for",

--- a/code/drasil-example/swhs/lib/Drasil/SWHS/GenDefs.hs
+++ b/code/drasil-example/swhs/lib/Drasil/SWHS/GenDefs.hs
@@ -90,7 +90,7 @@ newtonLawNote u a c = foldlSent [ch u `S.is` S "found by assuming that",
 
 rocTempSimpDeriv :: Sentence -> [ConceptInstance] -> Derivation
 rocTempSimpDeriv s a = mkDerivName (S "simplified" +:+ D.toSent (phraseNP (rOfChng `of_` temp)))
-  (weave [rocTempSimpDerivSent s a, map eS rocTempSimpDerivEqns])
+  (weave (rocTempSimpDerivSent s a) $ map eS rocTempSimpDerivEqns)
 
 rocTempSimpDerivSent :: Sentence -> [ConceptInstance] -> [Sentence]
 rocTempSimpDerivSent s a = map foldlSentCol [rocTempDerivInteg, rocTempDerivGauss,

--- a/code/drasil-example/swhs/lib/Drasil/SWHS/IMods.hs
+++ b/code/drasil-example/swhs/lib/Drasil/SWHS/IMods.hs
@@ -89,7 +89,7 @@ balWtrDesc = map foldlSent [
 -- type Derivation = [Sentence]
 eBalanceOnWtrDeriv :: Derivation
 eBalanceOnWtrDeriv = mkDerivName (D.toSent (phraseNP (the energy)) +:+ S "balance on water")
-  (weave [eBalanceOnWtrDerivSentences, map eS eBalanceOnWtrDerivEqnsIM1])
+  (weave eBalanceOnWtrDerivSentences $ map eS eBalanceOnWtrDerivEqnsIM1)
 
 eBalanceOnWtrDerivSentences :: [Sentence]
 eBalanceOnWtrDerivSentences = [eBalanceOnWtrDerivDesc1 htTransEnd overAreas extraAssumps assumpNIHGBWP,
@@ -203,7 +203,7 @@ balPCMNotes = map foldlSent [
 eBalanceOnPCMDeriv :: Derivation
 eBalanceOnPCMDeriv = mkDerivName (D.toSent (phraseNP (the energy)) +:+
   S "balance" `S.onThe` S "PCM during sensible heating phase")
-  (weave [eBalanceOnPCMDerivSentences, map eS eBalanceOnPCMDerivEqnsIM2]
+  (weave eBalanceOnPCMDerivSentences (map eS eBalanceOnPCMDerivEqnsIM2)
   ++ [eBalanceOnPCMDerivDesc5, eBalanceOnPCMDerivDesc6, eBalanceOnPCMDerivDesc7])
 
 eBalanceOnPCMDerivSentences :: [Sentence]

--- a/code/drasil-example/swhsnopcm/lib/Drasil/SWHSNoPCM/IMods.hs
+++ b/code/drasil-example/swhsnopcm/lib/Drasil/SWHSNoPCM/IMods.hs
@@ -76,7 +76,7 @@ balWtrNotes = map foldlSent [
 ----------------------------------------------
 eBalanceOnWtrDeriv :: Derivation
 eBalanceOnWtrDeriv = mkDerivName (D.toSent (phraseNP (the energy)) +:+ S "balance on water")
-  (weave [eBalanceOnWtrDerivSentences, map eS eBalanceOnWtrDerivEqns])
+  (weave eBalanceOnWtrDerivSentences $ map eS eBalanceOnWtrDerivEqns)
 
 eBalanceOnWtrDerivSentences :: [Sentence]
 eBalanceOnWtrDerivSentences = [eBalanceOnWtrDerivDesc1 EmptyS (S "over area" +:+ ch coilSA) EmptyS assumpNIHGBW,

--- a/code/drasil-utils/lib/Utils/Drasil/Lists.hs
+++ b/code/drasil-utils/lib/Utils/Drasil/Lists.hs
@@ -7,7 +7,7 @@ module Utils.Drasil.Lists (
   toColumn, mkTable
 ) where
 
-import Data.List (sort, transpose)
+import Data.List (sort)
 
 import Data.Containers.ListUtils (nubOrd)
 
@@ -27,8 +27,9 @@ nubSort :: Ord a => [a] -> [a]
 nubSort = nubOrd . sort
 
 -- | Interweaves two lists together @[[a,b,c],[d,e,f]] -> [a,d,b,e,c,f]@.
-weave :: [[a]] -> [a]
-weave = concat . transpose
+weave :: [a] -> [a] -> [a]
+weave [] ys = ys
+weave (x:xs) ys = x : weave ys xs
 
 -- | Fold that applies @f@ to all but the last element and @g@ to the last
 -- element and the accumulator given an initial value, @z@.


### PR DESCRIPTION
And remove reliance on `transpose`.

Contributes to #4806 