### PR TITLE
Skip compiling generated artifacts when stable src unchanged

### DIFF
--- a/.github/workflows/Build.yaml
+++ b/.github/workflows/Build.yaml
@@ -28,6 +28,8 @@ jobs:
             md:
               - code/stable/**/*.md
               - code/stable/**/book.toml
+            artifacts:
+              - 'code/stable/**/src/**'
 
       - name: "Update apt package list"
         run: |
@@ -93,6 +95,7 @@ jobs:
         if: ${{ steps.changes.outputs.tex == 'true' }}
 
       - name: "Compile generated software artifacts"
+        if: ${{ steps.changes.outputs.artifacts == 'true' }}
         run: make gool
 
       - name: "Generate Haddock docs (as test)"


### PR DESCRIPTION
Added a path filter for `code/stable/**/src/**` to skip `make gool` when those files haven't changed, same pattern as the TeX and mdBook steps.

I considered #4214 (separate workflow), but `make gool` only takes ~33s out of ~6min total, not worth a separate workflow that would need to redo the full build setup. A simple `if` condition is enough.

Relates to #4214, #3258.