### PR TITLE
Move `RelationConcept` to `drasil-theory`.

### DIFF
--- a/code/drasil-example/pdcontroller/lib/Drasil/PDController/GenDefs.hs
+++ b/code/drasil-example/pdcontroller/lib/Drasil/PDController/GenDefs.hs
@@ -10,7 +10,7 @@ import Data.Drasil.Citations ( pidWiki )
 import Data.Drasil.Quantities.PhysicalProperties (mass)
 import Data.Drasil.Concepts.Math (equation)
 
-import Theory.Drasil (GenDefn, gd, othModel')
+import Theory.Drasil (GenDefn, gd, othModel', RelationConcept, makeRC)
 
 import Drasil.PDController.Unitals
 import Drasil.PDController.Assumptions

--- a/code/drasil-example/pdcontroller/lib/Drasil/PDController/TModel.hs
+++ b/code/drasil-example/pdcontroller/lib/Drasil/PDController/TModel.hs
@@ -14,7 +14,7 @@ import Data.Drasil.Quantities.PhysicalProperties (mass)
 import Data.Drasil.Quantities.Physics (time)
 import Data.Drasil.Quantities.Math (posInf, negInf)
 
-import Theory.Drasil (TheoryModel, tm, othModel')
+import Theory.Drasil (TheoryModel, tm, othModel', RelationConcept, makeRC)
 
 import Drasil.PDController.Assumptions
 import Drasil.PDController.Concepts

--- a/code/drasil-example/swhs/lib/Drasil/SWHS/GenDefs.hs
+++ b/code/drasil-example/swhs/lib/Drasil/SWHS/GenDefs.hs
@@ -14,7 +14,7 @@ import Language.Drasil.Chunk.Concept.NamedCombinators
 import qualified Language.Drasil.Development as D
 import qualified Language.Drasil.Sentence.Combinators as S
 import Theory.Drasil (GenDefn, gd, gdNoRefs, deModel', equationalModel', Derivation,
-  mkDerivName)
+  mkDerivName, RelationConcept, makeRC)
 import Utils.Drasil (weave)
 
 import Drasil.SWHS.Assumptions (assumpCWTAT, assumpLCCCW, assumpLCCWP,

--- a/code/drasil-example/swhs/lib/Drasil/SWHS/IMods.hs
+++ b/code/drasil-example/swhs/lib/Drasil/SWHS/IMods.hs
@@ -10,7 +10,7 @@ import qualified Language.Drasil.NaturalLanguage.English.NounPhrase.Combinators 
 import qualified Language.Drasil.Sentence.Combinators as S
 import Drasil.Sentence.Combinators (eqN, unwrap, substitute, follows, fromSources)
 import Theory.Drasil (InstanceModel, im, imNoDeriv, qwC, qwUC, deModel',
-  equationalModel, ModelKind, Derivation, mkDerivName)
+  equationalModel, ModelKind, Derivation, mkDerivName, RelationConcept, makeRC)
 import Utils.Drasil (weave)
 
 import Data.Drasil.Citations

--- a/code/drasil-lang/lib/Language/Drasil.hs
+++ b/code/drasil-lang/lib/Language/Drasil.hs
@@ -83,8 +83,6 @@ module Language.Drasil (
   , ConceptChunk, ConceptInstance, sDom
   -- Language.Drasil.Chunk.Concept
   , dcc, dccAWDS, dccA, dccWDS, cc', ccs, cw, cic
-  -- Language.Drasil.Chunk.Relation
-  , RelationConcept, makeRC
 
   -- *** Quantities and Units
   -- Language.Drasil.Chunk.Eq
@@ -299,7 +297,6 @@ import Language.Drasil.Chunk.Eq (QDefinition, fromEqn, fromEqn', fromEqnSt,
   fromEqnSt', fromEqnSt'', mkQDefSt, mkQuantDef, mkQuantDef', ec,
   mkFuncDef, mkFuncDef', mkFuncDefByQ, ConstQDef, SimpleQDef, ModelQDef)
 import Language.Drasil.Chunk.NamedIdea
-import Language.Drasil.Chunk.Relation(RelationConcept, makeRC)
 import Language.Drasil.Chunk.UncertainQuantity
 import Language.Drasil.Chunk.Unital(UnitalChunk(..), uc, uc', ucStaged, ucStaged',
   ucuc, ucw)

--- a/code/drasil-theory/lib/Theory/Drasil.hs
+++ b/code/drasil-theory/lib/Theory/Drasil.hs
@@ -30,6 +30,8 @@ module Theory.Drasil (
   , InstanceModel
   , im, imNoDeriv, imNoRefs, imNoDerivNoRefs
   , qwUC, qwC, getEqModQdsFromIm
+  -- * Relation Concepts
+  , RelationConcept, makeRC
   -- * Theory Models
   , TheoryModel
   , tm, tmNoRefs
@@ -65,4 +67,5 @@ import Theory.Drasil.InstanceModel (InstanceModel,
 import Theory.Drasil.MultiDefn (MultiDefn, DefiningExpr,
   mkDefiningExpr, mkMultiDefn,
   mkMultiDefnForQuant, multiDefnGenQD, multiDefnGenQDByUID)
+import Theory.Drasil.RelationConcept (RelationConcept, makeRC)
 import Theory.Drasil.Theory (tm, tmNoRefs, TheoryModel)

--- a/code/drasil-theory/lib/Theory/Drasil/ModelKinds.hs
+++ b/code/drasil-theory/lib/Theory/Drasil/ModelKinds.hs
@@ -20,13 +20,14 @@ import Data.Maybe (mapMaybe)
 
 import Drasil.Database (UID, HasUID(..), mkUid, nsUid, HasChunkRefs(..))
 import Language.Drasil (NamedIdea(..), NP, QDefinition, Expr,
-  RelationConcept, ConceptDomain(..), Definition(..), Idea(..), Express(..),
+  ConceptDomain(..), Definition(..), Idea(..), Express(..),
   RequiresChecking(..), Space,
   HasSpace(typ), DefiningExpr(..))
 
 import Theory.Drasil.ConstraintSet (ConstraintSet)
 import Theory.Drasil.DifferentialModel (DifferentialModel)
 import Theory.Drasil.MultiDefn (MultiDefn)
+import Theory.Drasil.RelationConcept (RelationConcept)
 
 -- | Models can be of different kinds:
 --

--- a/code/drasil-theory/lib/Theory/Drasil/RelationConcept.hs
+++ b/code/drasil-theory/lib/Theory/Drasil/RelationConcept.hs
@@ -1,6 +1,6 @@
 {-# LANGUAGE TemplateHaskell #-}
 -- | For adding a relation (expression) to a concept.
-module Language.Drasil.Chunk.Relation (
+module Theory.Drasil.RelationConcept (
   -- * Chunk Type
   RelationConcept,
   -- * Constructors
@@ -10,12 +10,7 @@ import Control.Lens (makeLenses, (^.), view)
 
 import Drasil.Database (HasUID(..), HasChunkRefs(..))
 
-import Language.Drasil.Chunk.Concept (ConceptChunk, dccWDS)
-import Language.Drasil.Classes (Express(..),
-  ConceptDomain(..), Definition(..), Idea(..), NamedIdea(..))
-import Language.Drasil.ModelExpr.Lang (ModelExpr)
-import Language.Drasil.NaturalLanguage.English.NounPhrase.Core (NP)
-import Language.Drasil.Sentence (Sentence)
+import Language.Drasil
 
 -- | For a concept ('ConceptChunk') that also has a 'Relation' ('ModelExpr') attached.
 --


### PR DESCRIPTION
Rationale: `drasil-theory` provides us with knowledge encodable in theories. We should keep these data types closer together.

We already do this for:

1. `ConstraintSet`
2. `MultiDefn`
3. `DifferentialModel`