### PR TITLE
`Projectile`: Add missing LC acronym to the ToAA.

### DIFF
--- a/code/drasil-example/projectile/lib/Drasil/Projectile/Body.hs
+++ b/code/drasil-example/projectile/lib/Drasil/Projectile/Body.hs
@@ -17,7 +17,7 @@ import Data.Drasil.Concepts.Documentation (analysis, physics,
   problem, assumption, goalStmt, physSyst, sysCont, user, software,
   refBy, refName, typUnc, example, softwareSys, system, environment,
   product_, interface, condition, physical, datum, input_, softwareConstraint,
-  output_, endUser, requirement, srs)
+  output_, endUser, requirement, srs, likelyChg)
 import qualified Data.Drasil.Concepts.Documentation as Doc (physics, variable)
 import Data.Drasil.Concepts.Math (cartesian)
 import Data.Drasil.Concepts.PhysicalProperties (mass)
@@ -294,4 +294,4 @@ constrained = [flightDur, landPos, launAngle, launSpeed, offset, targPos]
 
 acronyms :: [CI]
 acronyms = [oneD, twoD, assumption, dataDefn, genDefn, goalStmt, inModel,
-  physSyst, requirement, srs, refBy, refName, thModel, typUnc]
+  physSyst, requirement, srs, refBy, refName, thModel, typUnc, likelyChg]

--- a/code/stable/projectile/SRS/HTML/Projectile_SRS.html
+++ b/code/stable/projectile/SRS/HTML/Projectile_SRS.html
@@ -380,6 +380,10 @@
                   <td>Instance Model</td>
                 </tr>
                 <tr>
+                  <td>LC</td>
+                  <td>Likely Change</td>
+                </tr>
+                <tr>
                   <td>PS</td>
                   <td>Physical System Description</td>
                 </tr>

--- a/code/stable/projectile/SRS/Jupyter/Projectile_SRS.ipynb
+++ b/code/stable/projectile/SRS/Jupyter/Projectile_SRS.ipynb
@@ -135,6 +135,7 @@
     "|GD|General Definition|\n",
     "|GS|Goal Statement|\n",
     "|IM|Instance Model|\n",
+    "|LC|Likely Change|\n",
     "|PS|Physical System Description|\n",
     "|R|Requirement|\n",
     "|RefBy|Referenced by|\n",

--- a/code/stable/projectile/SRS/PDF/Projectile_SRS.tex
+++ b/code/stable/projectile/SRS/PDF/Projectile_SRS.tex
@@ -155,6 +155,8 @@ GS & Goal Statement
 \\
 IM & Instance Model
 \\
+LC & Likely Change
+\\
 PS & Physical System Description
 \\
 R & Requirement

--- a/code/stable/projectile/SRS/mdBook/src/SecTAbbAcc.md
+++ b/code/stable/projectile/SRS/mdBook/src/SecTAbbAcc.md
@@ -11,6 +11,7 @@
 |GD          |General Definition                 |
 |GS          |Goal Statement                     |
 |IM          |Instance Model                     |
+|LC          |Likely Change                      |
 |PS          |Physical System Description        |
 |R           |Requirement                        |
 |RefBy       |Referenced by                      |


### PR DESCRIPTION
Split off from #4363