### PR TITLE
`drasil-docLang/../Requirements.hs`: Use `likelyChg` CI in one more `Sentence`.

### DIFF
--- a/code/drasil-docLang/lib/Drasil/Sections/Requirements.hs
+++ b/code/drasil-docLang/lib/Drasil/Sections/Requirements.hs
@@ -28,7 +28,8 @@ import Utils.Drasil (stringList, mkTable)
 -- Vocabulary
 import Drasil.Metadata.Documentation (description, funcReqDom, nonFuncReqDom,
   functionalRequirement, input_, nonfunctionalRequirement, output_, section_,
-  software, symbol_, value, reqInput, code, propOfCorSol, vavPlan, mg, mis)
+  software, symbol_, value, reqInput, code, propOfCorSol, vavPlan, mg, mis,
+  likelyChg)
 import Drasil.Metadata.Concepts.Math (unit_)
 
 -- Other docLang
@@ -98,7 +99,7 @@ nfReqIntro _  = mkParagraph $ reqIntroStart +:+. nfrReqIntroBody
 -- and a label ('String').
 mkMaintainableNFR :: String -> Integer -> String -> ConceptInstance
 mkMaintainableNFR refAddress percent lbl = cic refAddress (foldlSent [
-  S "If a likely change is made" `S.toThe`
+  S "If a", phrase likelyChg, S "is made" `S.toThe`
   S "finished software, it will take at most", addPercent percent `S.ofThe`
   S "original development time,",
   S "assuming the same development resources are available"


### PR DESCRIPTION
Split off from #4363.

This does not change much, but it is good, regardless.