### PR TITLE
`PDController`: Add missing LC acronym to ToAA.

### DIFF
--- a/code/drasil-example/pdcontroller/lib/Drasil/PDController/Concepts.hs
+++ b/code/drasil-example/pdcontroller/lib/Drasil/PDController/Concepts.hs
@@ -2,15 +2,16 @@ module Drasil.PDController.Concepts where
 
 import Language.Drasil
 
-import Data.Drasil.Concepts.Documentation
-       (assumption, goalStmt, physSyst, refBy, refName, requirement, srs, typUnc)
+import Data.Drasil.Concepts.Documentation (assumption, goalStmt, likelyChg,
+  physSyst, refBy, refName, requirement, srs, typUnc)
 import Data.Drasil.Concepts.Math (ode)
 import Data.Drasil.Concepts.Theory (dataDefn, genDefn, inModel, thModel)
 
 acronyms :: [CI]
-acronyms
-  = [assumption, dataDefn, genDefn, goalStmt, inModel, physSyst, requirement, refBy,
-     refName, srs, thModel, typUnc, pdControllerCI, proportionalCI, pidCI, ode]
+acronyms = [assumption, dataDefn, genDefn, goalStmt, inModel, physSyst,
+  requirement, refBy, refName, srs, thModel, typUnc, pdControllerCI,
+  proportionalCI, pidCI, ode, likelyChg]
+
 pdControllerCI, proportionalCI, pidCI :: CI
 
 pdControllerCI  = commonIdeaWithDict "pdControllerCI"  (pn "proportional derivative")          "PD"            []

--- a/code/stable/pdcontroller/SRS/HTML/PDController_SRS.html
+++ b/code/stable/pdcontroller/SRS/HTML/PDController_SRS.html
@@ -282,6 +282,10 @@
                   <td>Instance Model</td>
                 </tr>
                 <tr>
+                  <td>LC</td>
+                  <td>Likely Change</td>
+                </tr>
+                <tr>
                   <td>ODE</td>
                   <td>Ordinary Differential Equation</td>
                 </tr>

--- a/code/stable/pdcontroller/SRS/Jupyter/PDController_SRS.ipynb
+++ b/code/stable/pdcontroller/SRS/Jupyter/PDController_SRS.ipynb
@@ -115,6 +115,7 @@
     "|GD|General Definition|\n",
     "|GS|Goal Statement|\n",
     "|IM|Instance Model|\n",
+    "|LC|Likely Change|\n",
     "|ODE|Ordinary Differential Equation|\n",
     "|P|proportional|\n",
     "|PD|proportional derivative|\n",

--- a/code/stable/pdcontroller/SRS/PDF/PDController_SRS.tex
+++ b/code/stable/pdcontroller/SRS/PDF/PDController_SRS.tex
@@ -119,6 +119,8 @@ GS & Goal Statement
 \\
 IM & Instance Model
 \\
+LC & Likely Change
+\\
 ODE & Ordinary Differential Equation
 \\
 P & proportional

--- a/code/stable/pdcontroller/SRS/mdBook/src/SecTAbbAcc.md
+++ b/code/stable/pdcontroller/SRS/mdBook/src/SecTAbbAcc.md
@@ -9,6 +9,7 @@
 |GD          |General Definition                 |
 |GS          |Goal Statement                     |
 |IM          |Instance Model                     |
+|LC          |Likely Change                      |
 |ODE         |Ordinary Differential Equation     |
 |P           |proportional                       |
 |PD          |proportional derivative            |


### PR DESCRIPTION
Split off from #4363.