### PR TITLE
CI: Loosen version constraints on 'actions/cache' dependency.

### DIFF
--- a/.github/workflows/Build.yaml
+++ b/.github/workflows/Build.yaml
@@ -64,7 +64,7 @@ jobs:
           stack-version: 'latest'
 
       - name: "Cache dependencies"
-        uses: actions/cache@v5.0.4
+        uses: actions/cache@v5
         with:
           path: |
             ~/.stack

--- a/.github/workflows/Deploy.yaml
+++ b/.github/workflows/Deploy.yaml
@@ -42,7 +42,7 @@ jobs:
           stack-version: 'latest'
 
       - name: "Cache dependencies"
-        uses: actions/cache@v5.0.4
+        uses: actions/cache@v5
         with:
           path: |
             ~/.stack


### PR DESCRIPTION
This is to avoid the dependabot PRs for minor/patch-related version changes

Only loosening this for the GitHub-owned action dependency. We have plenty of [PRs from our other deps](https://github.com/JacquesCarette/Drasil/pulls?q=is%3Apr+author%3Aapp%2Fdependabot+is%3Aclosed), but those are probably best kept version-pinned.