### PR TITLE
Include `drasil-build-artifacts` in `hie.yaml`.

### DIFF
--- a/code/hie.yaml
+++ b/code/hie.yaml
@@ -3,6 +3,9 @@ cradle:
     - path: "drasil-build/lib"
       component: "drasil-build:lib"
 
+    - path: "drasil-build-artifacts/lib"
+      component: "drasil-build-artifacts:lib"
+
     - path: "drasil-code/lib"
       component: "drasil-code:lib"
 


### PR DESCRIPTION
I neglected to update `hie.yaml` in #4847. As a reminder, this file is used by HLS for our in-editor Haskell interactions.