### PR TITLE
Collapse `PrintingConfiguration` into `PrintingInformation`.

### DIFF
--- a/code/drasil-code/lib/Language/Drasil/Code/Imperative/Generator.hs
+++ b/code/drasil-code/lib/Language/Drasil/Code/Imperative/Generator.hs
@@ -21,7 +21,7 @@ import Drasil.GOOL (OOProg, VisibilityTag(..), headers, sources, mainMod,
 import qualified Drasil.GOOL as OO (GSProgram, SFile, ProgramSym(..), unCI)
 import Drasil.GProc (ProcProg)
 import qualified Drasil.GProc as Proc (GSProgram, SFile, ProgramSym(..), unCI)
-import Language.Drasil.Printers (SingleLine(OneLine), sentenceDoc, piSys, plainConfiguration)
+import Language.Drasil.Printers (SingleLine(OneLine), sentenceDoc, piSys, Notation (Scientific))
 import Language.Drasil.Printing.Import (spec)
 import Drasil.System
 
@@ -101,7 +101,7 @@ generator l dt sd chs cs = let
   _loggedSpaces = [], -- Used to prevent duplicate logs added to design log
   currentScope = Global
 }
-  where pinfo = piSys (cs ^. systemdb) (cs ^. refTable) Implementation plainConfiguration
+  where pinfo = piSys (cs ^. systemdb) (cs ^. refTable) Implementation Scientific
         (mcm, concLog) = runState (chooseConcept chs) []
         showDate Show = dt
         showDate Hide = ""

--- a/code/drasil-gen/lib/Drasil/Generator/LessonPlan.hs
+++ b/code/drasil-gen/lib/Drasil/Generator/LessonPlan.hs
@@ -11,7 +11,7 @@ import Drasil.Build.Artifacts (createDirIfMissing)
 import Drasil.DocumentLanguage.Notebook (LsnDesc, mkNb)
 import Language.Drasil (Stage(Equational))
 import qualified Language.Drasil.Sentence.Combinators as S
-import Language.Drasil.Printers (defaultConfiguration, piSys,
+import Language.Drasil.Printers (Notation(Engineering), piSys,
   genJupyterLessonPlan)
 import Language.Drasil.Printing.Import (makeDocument)
 import Drasil.System (LessonPlan, lsnPlanRefs, systemdb, LessonPlan)
@@ -20,7 +20,7 @@ import Drasil.System (LessonPlan, lsnPlanRefs, systemdb, LessonPlan)
 exportLessonPlan :: LessonPlan -> LsnDesc -> String -> IO ()
 exportLessonPlan plan nbDecl lsnFileName = do
   let nb = mkNb plan nbDecl S.forT
-      printSetting = piSys (plan ^. systemdb) (plan ^. lsnPlanRefs) Equational defaultConfiguration
+      printSetting = piSys (plan ^. systemdb) (plan ^. lsnPlanRefs) Equational Engineering
       dir = "Lesson/"
       fn  = lsnFileName ++ ".ipynb"
       pd  = makeDocument printSetting nb

--- a/code/drasil-gen/lib/Drasil/Generator/SRS.hs
+++ b/code/drasil-gen/lib/Drasil/Generator/SRS.hs
@@ -16,7 +16,7 @@ import Language.Drasil (Stage(Equational), Document(Document, Notebook),
   ShowTableOfContents, checkToC)
 import qualified Language.Drasil.Sentence.Combinators as S
 import Language.Drasil.Printers (makeCSS, makeRequirements, genHTML, genTeX,
-  genMDBook, makeBook, defaultConfiguration, piSys, PrintingInformation,
+  genMDBook, makeBook, Notation(Engineering), piSys, PrintingInformation,
   genJupyterSRS)
 import Drasil.SRSDocument (SRSDecl, mkDoc)
 import Language.Drasil.Printing.Import (makeDocument, makeProject)
@@ -32,7 +32,7 @@ import Drasil.Generator.SRS.TypeCheck (typeCheckSI)
 exportSmithEtAlSrs :: SmithEtAlSRS -> SRSDecl -> String -> IO ()
 exportSmithEtAlSrs syst srsDecl srsFileName = do
   let (srs, syst') = mkDoc syst srsDecl S.forT
-      printfo = piSys (syst' ^. systemdb) (syst' ^. refTable) Equational defaultConfiguration
+      printfo = piSys (syst' ^. systemdb) (syst' ^. refTable) Equational Engineering
   dumpEverything syst' ".drasil/"
   typeCheckSI syst' -- FIXME: This should be done on `System` creation *or* chunk creation!
   genDoc (DocSpec (docChoices [HTML, TeX, Jupyter, MDBook]) srsFileName) srs printfo

--- a/code/drasil-gen/lib/Drasil/Generator/Website.hs
+++ b/code/drasil-gen/lib/Drasil/Generator/Website.hs
@@ -9,7 +9,7 @@ import Text.PrettyPrint.HughesPJ (render)
 
 import Drasil.Build.Artifacts (createDirIfMissing)
 import Language.Drasil (Stage(Equational), Document)
-import Language.Drasil.Printers (makeCSS, genHTML, defaultConfiguration, piSys)
+import Language.Drasil.Printers (makeCSS, genHTML, Notation(Engineering), piSys)
 import Language.Drasil.Printing.Import (makeDocument)
 import Drasil.System (DrasilWebsite, webRefs, systemdb)
 
@@ -18,7 +18,7 @@ import Drasil.Generator.Formats (Filename)
 -- | Generate a "website" (HTML file) softifact.
 exportWebsite :: DrasilWebsite -> Document -> Filename -> IO ()
 exportWebsite syst doc fileName = do
-  let printSetting = piSys (syst ^. systemdb) (syst ^. webRefs) Equational defaultConfiguration
+  let printSetting = piSys (syst ^. systemdb) (syst ^. webRefs) Equational Engineering
       dir = "Website/HTML"
       pd = makeDocument printSetting doc
 

--- a/code/drasil-printers/lib/Language/Drasil/Printers.hs
+++ b/code/drasil-printers/lib/Language/Drasil/Printers.hs
@@ -21,10 +21,7 @@ module Language.Drasil.Printers (
   -- * Markdown
   , genMDBook, makeBook, makeRequirements
   -- * Printing Information and Options
-  , PrintingInformation, piSys
-  , HasPrintingOptions (..)
-  , Notation(..)
-  , defaultConfiguration, plainConfiguration
+  , PrintingInformation, piSys, Notation(..)
 ) where
 
 import Language.Drasil.HTML.CSS (makeCSS)
@@ -38,5 +35,4 @@ import Language.Drasil.Plain.Print (SingleLine(..), sentenceDoc, exprDoc,
   codeExprDoc, symbolDoc, unitDoc, showHasSymbImpl)
 import Language.Drasil.TeX.Print (genTeX)
 import Language.Drasil.Printing.PrintingInformation (PrintingInformation,
-  HasPrintingOptions(..), Notation(..), piSys,
-  defaultConfiguration, plainConfiguration)
+  Notation(..), piSys)

--- a/code/drasil-printers/lib/Language/Drasil/Printing/Import/Literal.hs
+++ b/code/drasil-printers/lib/Language/Drasil/Printing/Import/Literal.hs
@@ -4,8 +4,8 @@ import Language.Drasil (dbl)
 import Language.Drasil.Literal.Development (Literal(..))
 
 import qualified Language.Drasil.Printing.AST as P
-import Language.Drasil.Printing.PrintingInformation (HasPrintingOptions(..),
-  PrintingInformation, Notation(Scientific, Engineering))
+import Language.Drasil.Printing.PrintingInformation (PrintingInformation,
+  Notation(..), notation)
 
 import Control.Lens ((^.))
 import Numeric (floatToDigits)
@@ -14,7 +14,7 @@ import Language.Drasil.Printing.Import.Helpers
     (digitsProcess, processExpo)
 
 literal :: Literal -> PrintingInformation -> P.Expr
-literal (Dbl d)                  sm = case sm ^. getSetting of
+literal (Dbl d)                  sm = case sm ^. notation of
   Engineering ->
      let (f, s) = processExpo $ snd $ floatToDigits 10 d in
      P.Row $ digitsProcess (map toInteger $ fst $ floatToDigits 10 d)

--- a/code/drasil-printers/lib/Language/Drasil/Printing/PrintingInformation.hs
+++ b/code/drasil-printers/lib/Language/Drasil/Printing/PrintingInformation.hs
@@ -1,15 +1,14 @@
 {-# LANGUAGE TemplateHaskell #-}
--- | Defines types and functions to gather all the information needed for printing.
+-- | Defines types and functions to gather all the information needed for
+-- printing.
 module Language.Drasil.Printing.PrintingInformation (
-    Notation(..), HasPrintingOptions(..)
-  , PrintingConfiguration, notation
-  , PrintingInformation
-  , sysdb, stg, configuration
+    PrintingInformation
+  , Notation(..)
+  , sysdb, refTable, stg, notation
   , piSys, refFind
-  , defaultConfiguration, plainConfiguration
 ) where
 
-import Control.Lens (makeLenses, Lens', (^.))
+import Control.Lens (makeLenses, (^.))
 import qualified Data.Map.Strict as M
 import Data.Maybe (fromMaybe)
 
@@ -20,42 +19,19 @@ import Language.Drasil (Stage(..), Reference)
 data Notation = Scientific
               | Engineering
 
--- | Able to be printed.
-class HasPrintingOptions c where
-    -- | Holds the printing notation.
-    getSetting :: Lens' c Notation
-
--- | Holds the printing configuration.
-newtype PrintingConfiguration = PC { _notation :: Notation }
-makeLenses ''PrintingConfiguration
-
--- | Finds the notation used for the 'PrintingConfiguration'.
-instance HasPrintingOptions  PrintingConfiguration where getSetting = notation
-
 -- | Printing information contains a database, a stage, and a printing configuration.
 data PrintingInformation =
   PI { _sysdb :: ChunkDB
      , _refTable :: M.Map UID Reference
      , _stg :: Stage
-     , _configuration :: PrintingConfiguration
+     , _notation :: Notation
      }
 makeLenses ''PrintingInformation
 
--- | Finds the notation used for the 'PrintingConfiguration' within the 'PrintingInformation'.
-instance HasPrintingOptions  PrintingInformation where getSetting  = configuration . getSetting
-
 -- | Builds a document's printing information based on the system information.
-piSys :: ChunkDB -> M.Map UID Reference -> Stage -> PrintingConfiguration -> PrintingInformation
+piSys :: ChunkDB -> M.Map UID Reference -> Stage -> Notation -> PrintingInformation
 piSys = PI
 
 refFind :: UID -> PrintingInformation -> Reference
 refFind u pinfo = fromMaybe (error $ "`" ++ show u ++ "` not found in Reference table!!!")
   $ M.lookup u $ pinfo ^. refTable
-
--- | Default configuration is for engineering.
-defaultConfiguration :: PrintingConfiguration
-defaultConfiguration = PC Engineering
-
--- | Simple printing configuration is scientific.
-plainConfiguration :: PrintingConfiguration
-plainConfiguration = PC Scientific


### PR DESCRIPTION
Why? There was only 1 option. We already have options in `PrintingInformation` (e.g., `Stage`). We realistically need to entirely re-build these types anyways. Downsizing before re-designing is helpful.