### PR TITLE
Update hpack specification version to `0.36.0`.

### DIFF
--- a/code/drasil-build-artifacts/package.yaml
+++ b/code/drasil-build-artifacts/package.yaml
@@ -1,11 +1,12 @@
-name:                drasil-build-artifacts
-version:             0.1.1.0
-author:              "Dan Szymczak, Steven Palmer, Jacques Carette, Spencer Smith"
-maintainer:          "Jacques Carette"
-synopsis:            A framework for code and document generation for scientific software - Utils SubPackage
-github:              JacquesCarette/Drasil
-homepage:            https://jacquescarette.github.io/Drasil/
-description:         Please see the README on GitHub at <https://github.com/JacquesCarette/Drasil#readme>
+spec-version: 0.36.0
+name:         drasil-build-artifacts
+version:      0.1.1.0
+author:       "Dan Szymczak, Steven Palmer, Jacques Carette, Spencer Smith"
+maintainer:   "Jacques Carette"
+synopsis:     A framework for code and document generation for scientific software - build-artifacts SubPackage
+github:       JacquesCarette/Drasil
+homepage:     https://jacquescarette.github.io/Drasil/
+description:  Please see the README on GitHub at <https://github.com/JacquesCarette/Drasil#readme>
 
 language: Haskell2010
 default-extensions:
@@ -28,6 +29,3 @@ library:
   source-dirs: lib
   exposed-modules:
   - Drasil.Build.Artifacts
-  when:
-  - condition: false
-    other-modules: Paths_drasil_artifacts

--- a/code/drasil-build/package.yaml
+++ b/code/drasil-build/package.yaml
@@ -1,11 +1,12 @@
-name:                drasil-build
-version:             0.1.1.0
-author:              "Dan Szymczak, Steven Palmer, Jacques Carette, Spencer Smith"
-maintainer:          "Jacques Carette"
-synopsis:	           A framework for code and document generation for scientific software - Build System SubPackage
-github:              JacquesCarette/Drasil
-homepage:            https://jacquescarette.github.io/Drasil/
-description:         Please see the README on GitHub at <https://github.com/JacquesCarette/Drasil#readme>
+spec-version: 0.36.0
+name:         drasil-build
+version:      0.1.1.0
+author:       "Dan Szymczak, Steven Palmer, Jacques Carette, Spencer Smith"
+maintainer:   "Jacques Carette"
+synopsis:     A framework for code and document generation for scientific software - Build System SubPackage
+github:       JacquesCarette/Drasil
+homepage:     https://jacquescarette.github.io/Drasil/
+description:  Please see the README on GitHub at <https://github.com/JacquesCarette/Drasil#readme>
 
 language: Haskell2010
 default-extensions:
@@ -27,6 +28,3 @@ library:
   source-dirs: lib
   exposed-modules:
   - Build.Drasil
-  when:
-  - condition: false
-    other-modules: Paths_drasil_build

--- a/code/drasil-code/package.yaml
+++ b/code/drasil-code/package.yaml
@@ -1,11 +1,12 @@
-name:                drasil-code
-version:             0.1.9.0
-author:              "Dan Szymczak, Steven Palmer, Jacques Carette, Spencer Smith"
-maintainer:          "Jacques Carette"
-synopsis:	     A framework for code and document generation for scientific software - Code SubPackage
-github:              JacquesCarette/Drasil
-homepage:            https://jacquescarette.github.io/Drasil/
-description:         Please see the README on GitHub at <https://github.com/JacquesCarette/Drasil#readme>
+spec-version: 0.36.0
+name:         drasil-code
+version:      0.1.9.0
+author:       "Dan Szymczak, Steven Palmer, Jacques Carette, Spencer Smith"
+maintainer:   "Jacques Carette"
+synopsis:     A framework for code and document generation for scientific software - Code SubPackage
+github:       JacquesCarette/Drasil
+homepage:     https://jacquescarette.github.io/Drasil/
+description:  Please see the README on GitHub at <https://github.com/JacquesCarette/Drasil#readme>
 
 language: Haskell2010
 default-extensions:
@@ -44,9 +45,6 @@ library:
   - Language.Drasil.Code
   - Language.Drasil.GOOL
   - Data.Drasil.ExternalLibraries.ODELibraries
-  when:
-  - condition: false
-    other-modules: Paths_drasil_code
 
 executables:
   codegenTest:

--- a/code/drasil-data/package.yaml
+++ b/code/drasil-data/package.yaml
@@ -1,11 +1,12 @@
-name:                drasil-data
-version:             0.1.13.0
-author:              "Dan Szymczak, Steven Palmer, Jacques Carette, Spencer Smith"
-maintainer:          "Jacques Carette"
-synopsis:	           A framework for code and document generation for scientific software - Data System SubPackage
-github:              JacquesCarette/Drasil
-homepage:            https://jacquescarette.github.io/Drasil/
-description:         Please see the README on GitHub at <https://github.com/JacquesCarette/Drasil#readme>
+spec-version: 0.36.0
+name:         drasil-data
+version:      0.1.13.0
+author:       "Dan Szymczak, Steven Palmer, Jacques Carette, Spencer Smith"
+maintainer:   "Jacques Carette"
+synopsis:     A framework for code and document generation for scientific software - Data System SubPackage
+github:       JacquesCarette/Drasil
+homepage:     https://jacquescarette.github.io/Drasil/
+description:  Please see the README on GitHub at <https://github.com/JacquesCarette/Drasil#readme>
 
 language: Haskell2010
 default-extensions:
@@ -55,6 +56,3 @@ library:
   - Data.Drasil.Units.Physics
   - Data.Drasil.Units.SolidMechanics
   - Data.Drasil.Theories.Physics
-  when:
-  - condition: false
-    other-modules: Paths_drasil_data

--- a/code/drasil-database/package.yaml
+++ b/code/drasil-database/package.yaml
@@ -1,11 +1,12 @@
-name:                drasil-database
-version:             0.1.1.0
-author:              "Dan Szymczak, Steven Palmer, Jacques Carette, Spencer Smith"
-maintainer:          "Jacques Carette"
-synopsis:	           A framework for code and document generation for scientific software - Database SubPackage
-github:              JacquesCarette/Drasil
-homepage:            https://jacquescarette.github.io/Drasil/
-description:         Please see the README on GitHub at <https://github.com/JacquesCarette/Drasil#readme>
+spec-version: 0.36.0
+name:         drasil-database
+version:      0.1.1.0
+author:       "Dan Szymczak, Steven Palmer, Jacques Carette, Spencer Smith"
+maintainer:   "Jacques Carette"
+synopsis:     A framework for code and document generation for scientific software - Database SubPackage
+github:       JacquesCarette/Drasil
+homepage:     https://jacquescarette.github.io/Drasil/
+description:  Please see the README on GitHub at <https://github.com/JacquesCarette/Drasil#readme>
 
 language: Haskell2010
 default-extensions:
@@ -30,6 +31,3 @@ library:
   source-dirs: lib
   exposed-modules:
   - Drasil.Database
-  when:
-  - condition: false
-    other-modules: Paths_drasil_database

--- a/code/drasil-docLang/package.yaml
+++ b/code/drasil-docLang/package.yaml
@@ -1,11 +1,12 @@
-name:                drasil-docLang
-version:             0.1.26.0
-author:              "Dan Szymczak, Steven Palmer, Jacques Carette, Spencer Smith"
-maintainer:          "Jacques Carette"
-synopsis:	           A framework for code and document generation for scientific software - Document Language SubPackage
-github:              JacquesCarette/Drasil
-homepage:            https://jacquescarette.github.io/Drasil/
-description:         Please see the README on GitHub at <https://github.com/JacquesCarette/Drasil#readme>
+spec-version: 0.36.0
+name:         drasil-docLang
+version:      0.1.26.0
+author:       "Dan Szymczak, Steven Palmer, Jacques Carette, Spencer Smith"
+maintainer:   "Jacques Carette"
+synopsis:     A framework for code and document generation for scientific software - Document Language SubPackage
+github:       JacquesCarette/Drasil
+homepage:     https://jacquescarette.github.io/Drasil/
+description:  Please see the README on GitHub at <https://github.com/JacquesCarette/Drasil#readme>
 
 language: Haskell2010
 default-extensions:
@@ -43,6 +44,3 @@ library:
   - Drasil.DocumentLanguage.TraceabilityGraph
   - Drasil.Sentence.Combinators
   - Drasil.SRSDocument
-  when:
-  - condition: false
-    other-modules: Paths_drasil_docLang

--- a/code/drasil-example/dblpend/package.yaml
+++ b/code/drasil-example/dblpend/package.yaml
@@ -1,11 +1,12 @@
-name:                dblpend
-version:             0.1.24.0
-author:              "Dan Szymczak, Steven Palmer, Jacques Carette, Spencer Smith"
-maintainer:          "Jacques Carette"
-synopsis:	           A framework for code and document generation for scientific software - Example SubPackage
-github:              JacquesCarette/Drasil
-homepage:            https://jacquescarette.github.io/Drasil/
-description:         Please see the README on GitHub at <https://github.com/JacquesCarette/Drasil#readme>
+spec-version: 0.36.0
+name:         dblpend
+version:      0.1.24.0
+author:       "Dan Szymczak, Steven Palmer, Jacques Carette, Spencer Smith"
+maintainer:   "Jacques Carette"
+synopsis:     A framework for code and document generation for scientific software - Example SubPackage
+github:       JacquesCarette/Drasil
+homepage:     https://jacquescarette.github.io/Drasil/
+description:  Please see the README on GitHub at <https://github.com/JacquesCarette/Drasil#readme>
 
 language: Haskell2010
 default-extensions:
@@ -35,19 +36,13 @@ dependencies:
 
 library:
   source-dirs: lib
-  when:
-  - condition: false
-    other-modules: Paths_dblpend
 
 executables:
   dblpend:
     main: Main
-    source-dirs: app 
+    source-dirs: app
     ghc-options:
     - -threaded
     - -O2
     dependencies:
     - dblpend
-    when:
-    - condition: false
-      other-modules: Paths_dblpend

--- a/code/drasil-example/gamephysics/package.yaml
+++ b/code/drasil-example/gamephysics/package.yaml
@@ -1,11 +1,12 @@
-name:                gamephysics
-version:             0.1.24.0
-author:              "Dan Szymczak, Steven Palmer, Jacques Carette, Spencer Smith"
-maintainer:          "Jacques Carette"
-synopsis:	           A framework for code and document generation for scientific software - Example SubPackage
-github:              JacquesCarette/Drasil
-homepage:            https://jacquescarette.github.io/Drasil/
-description:         Please see the README on GitHub at <https://github.com/JacquesCarette/Drasil#readme>
+spec-version: 0.36.0
+name:         gamephysics
+version:      0.1.24.0
+author:       "Dan Szymczak, Steven Palmer, Jacques Carette, Spencer Smith"
+maintainer:   "Jacques Carette"
+synopsis:     A framework for code and document generation for scientific software - Example SubPackage
+github:       JacquesCarette/Drasil
+homepage:     https://jacquescarette.github.io/Drasil/
+description:  Please see the README on GitHub at <https://github.com/JacquesCarette/Drasil#readme>
 
 language: Haskell2010
 default-extensions:
@@ -38,7 +39,6 @@ library:
   when:
   - condition: false
     other-modules:
-    - Paths_gamephysics
     - Drasil.GamePhysics.GDefs
     - Drasil.GamePhysics.DesignDec.Arbiter
     - Drasil.GamePhysics.DesignDec.Vector
@@ -52,6 +52,3 @@ executables:
     - -O2
     dependencies:
     - gamephysics
-    when:
-    - condition: false
-      other-modules: Paths_gamephysics

--- a/code/drasil-example/glassbr/package.yaml
+++ b/code/drasil-example/glassbr/package.yaml
@@ -1,11 +1,12 @@
-name:                glassbr
-version:             0.1.24.0
-author:              "Dan Szymczak, Steven Palmer, Jacques Carette, Spencer Smith"
-maintainer:          "Jacques Carette"
-synopsis:	           A framework for code and document generation for scientific software - Example SubPackage
-github:              JacquesCarette/Drasil
-homepage:            https://jacquescarette.github.io/Drasil/
-description:         Please see the README on GitHub at <https://github.com/JacquesCarette/Drasil#readme>
+spec-version: 0.36.0
+name:         glassbr
+version:      0.1.24.0
+author:       "Dan Szymczak, Steven Palmer, Jacques Carette, Spencer Smith"
+maintainer:   "Jacques Carette"
+synopsis:     A framework for code and document generation for scientific software - Example SubPackage
+github:       JacquesCarette/Drasil
+homepage:     https://jacquescarette.github.io/Drasil/
+description:  Please see the README on GitHub at <https://github.com/JacquesCarette/Drasil#readme>
 
 language: Haskell2010
 default-extensions:
@@ -36,9 +37,6 @@ dependencies:
 
 library:
   source-dirs: lib
-  when:
-  - condition: false
-    other-modules: Paths_glassbr
 
 executables:
   glassbr:
@@ -49,6 +47,3 @@ executables:
     - -O2
     dependencies:
     - glassbr
-    when:
-    - condition: false
-      other-modules: Paths_glassbr

--- a/code/drasil-example/hghc/package.yaml
+++ b/code/drasil-example/hghc/package.yaml
@@ -1,11 +1,12 @@
-name:                hghc
-version:             0.1.24.0
-author:              "Dan Szymczak, Steven Palmer, Jacques Carette, Spencer Smith"
-maintainer:          "Jacques Carette"
-synopsis:	           A framework for code and document generation for scientific software - Example SubPackage
-github:              JacquesCarette/Drasil
-homepage:            https://jacquescarette.github.io/Drasil/
-description:         Please see the README on GitHub at <https://github.com/JacquesCarette/Drasil#readme>
+spec-version: 0.36.0
+name:         hghc
+version:      0.1.24.0
+author:       "Dan Szymczak, Steven Palmer, Jacques Carette, Spencer Smith"
+maintainer:   "Jacques Carette"
+synopsis:     A framework for code and document generation for scientific software - Example SubPackage
+github:       JacquesCarette/Drasil
+homepage:     https://jacquescarette.github.io/Drasil/
+description:  Please see the README on GitHub at <https://github.com/JacquesCarette/Drasil#readme>
 
 language: Haskell2010
 default-extensions:
@@ -35,19 +36,13 @@ dependencies:
 
 library:
   source-dirs: lib
-  when:
-  - condition: false
-    other-modules: Paths_hghc
 
 executables:
   hghc:
     main: Main
-    source-dirs: app 
+    source-dirs: app
     ghc-options:
     - -threaded
     - -O2
     dependencies:
     - hghc
-    when:
-    - condition: false
-      other-modules: Paths_hghc

--- a/code/drasil-example/pdcontroller/package.yaml
+++ b/code/drasil-example/pdcontroller/package.yaml
@@ -1,11 +1,12 @@
-name:                pdcontroller
-version:             0.1.24.0
-author:              "Dan Szymczak, Steven Palmer, Jacques Carette, Spencer Smith"
-maintainer:          "Jacques Carette"
-synopsis:	           A framework for code and document generation for scientific software - Example SubPackage
-github:              JacquesCarette/Drasil
-homepage:            https://jacquescarette.github.io/Drasil/
-description:         Please see the README on GitHub at <https://github.com/JacquesCarette/Drasil#readme>
+spec-version: 0.36.0
+name:         pdcontroller
+version:      0.1.24.0
+author:       "Dan Szymczak, Steven Palmer, Jacques Carette, Spencer Smith"
+maintainer:   "Jacques Carette"
+synopsis:     A framework for code and document generation for scientific software - Example SubPackage
+github:       JacquesCarette/Drasil
+homepage:     https://jacquescarette.github.io/Drasil/
+description:  Please see the README on GitHub at <https://github.com/JacquesCarette/Drasil#readme>
 
 language: Haskell2010
 default-extensions:
@@ -35,19 +36,13 @@ dependencies:
 
 library:
   source-dirs: lib
-  when:
-  - condition: false
-    other-modules: Paths_pdcontroller
 
 executables:
   pdcontroller:
     main: Main
-    source-dirs: app 
+    source-dirs: app
     ghc-options:
     - -threaded
     - -O2
     dependencies:
     - pdcontroller
-    when:
-    - condition: false
-      other-modules: Paths_pdcontroller

--- a/code/drasil-example/projectile/package.yaml
+++ b/code/drasil-example/projectile/package.yaml
@@ -1,11 +1,12 @@
-name:                projectile
-version:             0.1.24.0
-author:              "Dan Szymczak, Steven Palmer, Jacques Carette, Spencer Smith"
-maintainer:          "Jacques Carette"
-synopsis:	           A framework for code and document generation for scientific software - Example SubPackage
-github:              JacquesCarette/Drasil
-homepage:            https://jacquescarette.github.io/Drasil/
-description:         Please see the README on GitHub at <https://github.com/JacquesCarette/Drasil#readme>
+spec-version: 0.36.0
+name:         projectile
+version:      0.1.24.0
+author:       "Dan Szymczak, Steven Palmer, Jacques Carette, Spencer Smith"
+maintainer:   "Jacques Carette"
+synopsis:     A framework for code and document generation for scientific software - Example SubPackage
+github:       JacquesCarette/Drasil
+homepage:     https://jacquescarette.github.io/Drasil/
+description:  Please see the README on GitHub at <https://github.com/JacquesCarette/Drasil#readme>
 
 language: Haskell2010
 default-extensions:
@@ -35,19 +36,13 @@ dependencies:
 
 library:
   source-dirs: lib
-  when:
-  - condition: false
-    other-modules: Paths_projectile
 
 executables:
   projectile:
     main: Main
-    source-dirs: app 
+    source-dirs: app
     ghc-options:
     - -threaded
     - -O2
     dependencies:
     - projectile
-    when:
-    - condition: false
-      other-modules: Paths_projectile

--- a/code/drasil-example/sglpend/package.yaml
+++ b/code/drasil-example/sglpend/package.yaml
@@ -1,11 +1,12 @@
-name:                sglpend
-version:             0.1.24.0
-author:              "Dan Szymczak, Steven Palmer, Jacques Carette, Spencer Smith"
-maintainer:          "Jacques Carette"
-synopsis:	           A framework for code and document generation for scientific software - Example SubPackage
-github:              JacquesCarette/Drasil
-homepage:            https://jacquescarette.github.io/Drasil/
-description:         Please see the README on GitHub at <https://github.com/JacquesCarette/Drasil#readme>
+spec-version: 0.36.0
+name:         sglpend
+version:      0.1.24.0
+author:       "Dan Szymczak, Steven Palmer, Jacques Carette, Spencer Smith"
+maintainer:   "Jacques Carette"
+synopsis:     A framework for code and document generation for scientific software - Example SubPackage
+github:       JacquesCarette/Drasil
+homepage:     https://jacquescarette.github.io/Drasil/
+description:  Please see the README on GitHub at <https://github.com/JacquesCarette/Drasil#readme>
 
 language: Haskell2010
 default-extensions:
@@ -36,19 +37,13 @@ dependencies:
 
 library:
   source-dirs: lib
-  when:
-  - condition: false
-    other-modules: Paths_sglpend
 
 executables:
   sglpend:
     main: Main
-    source-dirs: app 
+    source-dirs: app
     ghc-options:
     - -threaded
     - -O2
     dependencies:
     - sglpend
-    when:
-    - condition: false
-      other-modules: Paths_sglpend

--- a/code/drasil-example/ssp/package.yaml
+++ b/code/drasil-example/ssp/package.yaml
@@ -1,11 +1,12 @@
-name:                ssp
-version:             0.1.24.0
-author:              "Dan Szymczak, Steven Palmer, Jacques Carette, Spencer Smith"
-maintainer:          "Jacques Carette"
-synopsis:	           A framework for code and document generation for scientific software - Example SubPackage
-github:              JacquesCarette/Drasil
-homepage:            https://jacquescarette.github.io/Drasil/
-description:         Please see the README on GitHub at <https://github.com/JacquesCarette/Drasil#readme>
+spec-version: 0.36.0
+name:         ssp
+version:      0.1.24.0
+author:       "Dan Szymczak, Steven Palmer, Jacques Carette, Spencer Smith"
+maintainer:   "Jacques Carette"
+synopsis:     A framework for code and document generation for scientific software - Example SubPackage
+github:       JacquesCarette/Drasil
+homepage:     https://jacquescarette.github.io/Drasil/
+description:  Please see the README on GitHub at <https://github.com/JacquesCarette/Drasil#readme>
 
 language: Haskell2010
 default-extensions:
@@ -35,19 +36,13 @@ dependencies:
 
 library:
   source-dirs: lib
-  when:
-  - condition: false
-    other-modules: Paths_ssp
 
 executables:
   ssp:
     main: Main
-    source-dirs: app 
+    source-dirs: app
     ghc-options:
     - -threaded
     - -O2
     dependencies:
     - ssp
-    when:
-    - condition: false
-      other-modules: Paths_ssp

--- a/code/drasil-example/swhs/package.yaml
+++ b/code/drasil-example/swhs/package.yaml
@@ -1,11 +1,12 @@
-name:                swhs
-version:             0.1.24.0
-author:              "Dan Szymczak, Steven Palmer, Jacques Carette, Spencer Smith"
-maintainer:          "Jacques Carette"
-synopsis:	           A framework for code and document generation for scientific software - Example SubPackage
-github:              JacquesCarette/Drasil
-homepage:            https://jacquescarette.github.io/Drasil/
-description:         Please see the README on GitHub at <https://github.com/JacquesCarette/Drasil#readme>
+spec-version: 0.36.0
+name:         swhs
+version:      0.1.24.0
+author:       "Dan Szymczak, Steven Palmer, Jacques Carette, Spencer Smith"
+maintainer:   "Jacques Carette"
+synopsis:     A framework for code and document generation for scientific software - Example SubPackage
+github:       JacquesCarette/Drasil
+homepage:     https://jacquescarette.github.io/Drasil/
+description:  Please see the README on GitHub at <https://github.com/JacquesCarette/Drasil#readme>
 
 language: Haskell2010
 default-extensions:
@@ -35,19 +36,13 @@ dependencies:
 
 library:
   source-dirs: lib
-  when:
-  - condition: false
-    other-modules: Paths_swhs
 
 executables:
   swhs:
     main: Main
-    source-dirs: app 
+    source-dirs: app
     ghc-options:
     - -threaded
     - -O2
     dependencies:
     - swhs
-    when:
-    - condition: false
-      other-modules: Paths_swhs

--- a/code/drasil-example/swhsnopcm/package.yaml
+++ b/code/drasil-example/swhsnopcm/package.yaml
@@ -1,11 +1,12 @@
-name:                swhsnopcm
-version:             0.1.24.0
-author:              "Dan Szymczak, Steven Palmer, Jacques Carette, Spencer Smith"
-maintainer:          "Jacques Carette"
-synopsis:	           A framework for code and document generation for scientific software - Example SubPackage
-github:              JacquesCarette/Drasil
-homepage:            https://jacquescarette.github.io/Drasil/
-description:         Please see the README on GitHub at <https://github.com/JacquesCarette/Drasil#readme>
+spec-version: 0.36.0
+name:         swhsnopcm
+version:      0.1.24.0
+author:       "Dan Szymczak, Steven Palmer, Jacques Carette, Spencer Smith"
+maintainer:   "Jacques Carette"
+synopsis:     A framework for code and document generation for scientific software - Example SubPackage
+github:       JacquesCarette/Drasil
+homepage:     https://jacquescarette.github.io/Drasil/
+description:  Please see the README on GitHub at <https://github.com/JacquesCarette/Drasil#readme>
 
 language: Haskell2010
 default-extensions:
@@ -43,7 +44,7 @@ library:
 executables:
   swhsnopcm:
     main: Main
-    source-dirs: app 
+    source-dirs: app
     ghc-options:
     - -threaded
     - -O2

--- a/code/drasil-example/template/package.yaml
+++ b/code/drasil-example/template/package.yaml
@@ -1,11 +1,12 @@
-name:                template
-version:             0.1.24.0
-author:              "Dan Szymczak, Steven Palmer, Jacques Carette, Spencer Smith"
-maintainer:          "Jacques Carette"
-synopsis:	           A framework for code and document generation for scientific software - Example SubPackage
-github:              JacquesCarette/Drasil
-homepage:            https://jacquescarette.github.io/Drasil/
-description:         Please see the README on GitHub at <https://github.com/JacquesCarette/Drasil#readme>
+spec-version: 0.36.0
+name:         template
+version:      0.1.24.0
+author:       "Dan Szymczak, Steven Palmer, Jacques Carette, Spencer Smith"
+maintainer:   "Jacques Carette"
+synopsis:     A framework for code and document generation for scientific software - Example SubPackage
+github:       JacquesCarette/Drasil
+homepage:     https://jacquescarette.github.io/Drasil/
+description:  Please see the README on GitHub at <https://github.com/JacquesCarette/Drasil#readme>
 
 language: Haskell2010
 default-extensions:
@@ -35,19 +36,13 @@ dependencies:
 
 library:
   source-dirs: lib
-  when:
-  - condition: false
-    other-modules: Paths_template
 
 executables:
   template:
     main: Main
-    source-dirs: app 
+    source-dirs: app
     ghc-options:
     - -threaded
     - -O2
     dependencies:
     - template
-    when:
-    - condition: false
-      other-modules: Paths_template

--- a/code/drasil-gen/package.yaml
+++ b/code/drasil-gen/package.yaml
@@ -2,7 +2,7 @@ name:                drasil-gen
 version:             0.1.3.0
 author:              "Dan Szymczak, Steven Palmer, Jacques Carette, Spencer Smith"
 maintainer:          "Jacques Carette"
-synopsis:	           A framework for code and document generation for scientific software - Utils SubPackage
+synopsis:            A framework for code and document generation for scientific software - Utils SubPackage
 github:              JacquesCarette/Drasil
 homepage:            https://jacquescarette.github.io/Drasil/
 description:         Please see the README on GitHub at <https://github.com/JacquesCarette/Drasil#readme>

--- a/code/drasil-gool/package.yaml
+++ b/code/drasil-gool/package.yaml
@@ -1,11 +1,12 @@
-name:                drasil-gool
-version:             0.1.1.0
-author:              "Dan Szymczak, Steven Palmer, Jacques Carette, Spencer Smith, Brooks MacLachlan"
-maintainer:          "Jacques Carette"
-synopsis:	           A framework for code and document generation for scientific software - GOOL SubPackage
-github:              JacquesCarette/Drasil
-homepage:            https://jacquescarette.github.io/Drasil/
-description:         Please see the README on GitHub at <https://github.com/JacquesCarette/Drasil#readme>
+spec-version: 0.36.0
+name:         drasil-gool
+version:      0.1.1.0
+author:       "Dan Szymczak, Steven Palmer, Jacques Carette, Spencer Smith, Brooks MacLachlan"
+maintainer:   "Jacques Carette"
+synopsis:     A framework for code and document generation for scientific software - GOOL SubPackage
+github:       JacquesCarette/Drasil
+homepage:     https://jacquescarette.github.io/Drasil/
+description:  Please see the README on GitHub at <https://github.com/JacquesCarette/Drasil#readme>
 
 extra-source-files: []
 
@@ -28,6 +29,3 @@ library:
   exposed-modules:
   - Drasil.GOOL
   - Drasil.GProc
-  when:
-  - condition: false
-    other-modules: Paths_drasil_gool

--- a/code/drasil-lang/package.yaml
+++ b/code/drasil-lang/package.yaml
@@ -1,11 +1,12 @@
-name:        drasil-lang
-version:     0.1.60.0
-author:      "Dan Szymczak, Steven Palmer, Jacques Carette, Spencer Smith"
-maintainer:  "Jacques Carette"
-synopsis:	   A framework for code and document generation for scientific software - Language SubPackage
-github:      JacquesCarette/Drasil
-homepage:    https://jacquescarette.github.io/Drasil/
-description: Please see the README on GitHub at <https://github.com/JacquesCarette/Drasil#readme>
+spec-version: 0.36.0
+name:         drasil-lang
+version:      0.1.60.0
+author:       "Dan Szymczak, Steven Palmer, Jacques Carette, Spencer Smith"
+maintainer:   "Jacques Carette"
+synopsis:     A framework for code and document generation for scientific software - Language SubPackage
+github:       JacquesCarette/Drasil
+homepage:     https://jacquescarette.github.io/Drasil/
+description:  Please see the README on GitHub at <https://github.com/JacquesCarette/Drasil#readme>
 
 language: Haskell2010
 default-extensions:
@@ -49,6 +50,3 @@ library:
   - Language.Drasil.NaturalLanguage.English.NounPhrase.Combinators
   - Language.Drasil.Sentence.Combinators
   - Language.Drasil.ShortHands
-  when:
-  - condition: false
-    other-modules: Paths_drasil_lang

--- a/code/drasil-metadata/package.yaml
+++ b/code/drasil-metadata/package.yaml
@@ -1,11 +1,12 @@
-name:                drasil-metadata
-version:             0.1.1.0
-author:              "Jacques Carette"
-maintainer:          "Jacques Carette"
-synopsis:	     Meta-data sub-package for Drasil
-github:              JacquesCarette/Drasil
-homepage:            https://jacquescarette.github.io/Drasil/
-description:         Please see the README on GitHub at <https://github.com/JacquesCarette/Drasil#readme>
+spec-version: 0.36.0
+name:         drasil-metadata
+version:      0.1.1.0
+author:       "Jacques Carette"
+maintainer:   "Jacques Carette"
+synopsis:     Meta-data sub-package for Drasil
+github:       JacquesCarette/Drasil
+homepage:     https://jacquescarette.github.io/Drasil/
+description:  Please see the README on GitHub at <https://github.com/JacquesCarette/Drasil#readme>
 
 language: Haskell2010
 default-extensions:
@@ -40,6 +41,3 @@ library:
   - Drasil.Metadata.SupportedSoftware
   - Drasil.Metadata.TheoryConcepts
   - Drasil.Metadata.TraceabilityGraphs
-  when:
-  - condition: false
-    other-modules: Paths_drasil_metadata

--- a/code/drasil-printers/package.yaml
+++ b/code/drasil-printers/package.yaml
@@ -1,11 +1,12 @@
-name:                drasil-printers
-version:             0.1.10.0
-author:              "Dan Szymczak, Steven Palmer, Jacques Carette, Spencer Smith"
-maintainer:          "Jacques Carette"
-synopsis:	     A framework for code and document generation for scientific software - Printers SubPackage
-github:              JacquesCarette/Drasil
-homepage:            https://jacquescarette.github.io/Drasil/
-description:         Please see the README on GitHub at <https://github.com/JacquesCarette/Drasil#readme>
+spec-version: 0.36.0
+name:         drasil-printers
+version:      0.1.10.0
+author:       "Dan Szymczak, Steven Palmer, Jacques Carette, Spencer Smith"
+maintainer:   "Jacques Carette"
+synopsis:     A framework for code and document generation for scientific software - Printers SubPackage
+github:       JacquesCarette/Drasil
+homepage:     https://jacquescarette.github.io/Drasil/
+description:  Please see the README on GitHub at <https://github.com/JacquesCarette/Drasil#readme>
 
 language: Haskell2010
 default-extensions:
@@ -37,6 +38,3 @@ library:
   exposed-modules:
   - Language.Drasil.Printers
   - Language.Drasil.Printing.Import
-  when:
-  - condition: false
-    other-modules: Paths_drasil_printers

--- a/code/drasil-system/package.yaml
+++ b/code/drasil-system/package.yaml
@@ -1,11 +1,12 @@
-name:                drasil-system
-version:             0.1.1.0
-author:              "Dan Szymczak, Steven Palmer, Jacques Carette, Spencer Smith"
-maintainer:          "Jacques Carette"
-synopsis:	     A framework for code and document generation for scientific software - System SubPackage
-github:              JacquesCarette/Drasil
-homepage:            https://jacquescarette.github.io/Drasil/
-description:         Please see the README on GitHub at <https://github.com/JacquesCarette/Drasil#readme>
+spec-version: 0.36.0
+name:         drasil-system
+version:      0.1.1.0
+author:       "Dan Szymczak, Steven Palmer, Jacques Carette, Spencer Smith"
+maintainer:   "Jacques Carette"
+synopsis:     A framework for code and document generation for scientific software - System SubPackage
+github:       JacquesCarette/Drasil
+homepage:     https://jacquescarette.github.io/Drasil/
+description:  Please see the README on GitHub at <https://github.com/JacquesCarette/Drasil#readme>
 
 language: Haskell2010
 default-extensions:
@@ -33,6 +34,3 @@ library:
   source-dirs: lib
   exposed-modules:
   - Drasil.System
-  when:
-  - condition: false
-    other-modules: Paths_drasil_system

--- a/code/drasil-theory/package.yaml
+++ b/code/drasil-theory/package.yaml
@@ -1,11 +1,12 @@
-name:                drasil-theory
-version:             0.1.0.0
-author:              "Dan Szymczak, Steven Palmer, Jacques Carette, Spencer Smith"
-maintainer:          "Jacques Carette"
-synopsis:	     A framework for code and document generation for scientific software - Theory SubPackage
-github:              JacquesCarette/Drasil
-homepage:            https://jacquescarette.github.io/Drasil/
-description:         Please see the README on GitHub at <https://github.com/JacquesCarette/Drasil#readme>
+spec-version: 0.36.0
+name:         drasil-theory
+version:      0.1.0.0
+author:       "Dan Szymczak, Steven Palmer, Jacques Carette, Spencer Smith"
+maintainer:   "Jacques Carette"
+synopsis:     A framework for code and document generation for scientific software - Theory SubPackage
+github:       JacquesCarette/Drasil
+homepage:     https://jacquescarette.github.io/Drasil/
+description:  Please see the README on GitHub at <https://github.com/JacquesCarette/Drasil#readme>
 
 language: Haskell2010
 default-extensions:
@@ -29,6 +30,3 @@ library:
   exposed-modules:
   - Theory.Drasil
   - Drasil.Database.SearchTools
-  when:
-  - condition: false
-    other-modules: Paths_drasil_theory

--- a/code/drasil-utils/package.yaml
+++ b/code/drasil-utils/package.yaml
@@ -1,11 +1,12 @@
-name:                drasil-utils
-version:             0.1.1.0
-author:              "Dan Szymczak, Steven Palmer, Jacques Carette, Spencer Smith"
-maintainer:          "Jacques Carette"
-synopsis:            A framework for code and document generation for scientific software - Utils SubPackage
-github:              JacquesCarette/Drasil
-homepage:            https://jacquescarette.github.io/Drasil/
-description:         Please see the README on GitHub at <https://github.com/JacquesCarette/Drasil#readme>
+spec-version: 0.36.0
+name:         drasil-utils
+version:      0.1.1.0
+author:       "Dan Szymczak, Steven Palmer, Jacques Carette, Spencer Smith"
+maintainer:   "Jacques Carette"
+synopsis:     A framework for code and document generation for scientific software - Utils SubPackage
+github:       JacquesCarette/Drasil
+homepage:     https://jacquescarette.github.io/Drasil/
+description:  Please see the README on GitHub at <https://github.com/JacquesCarette/Drasil#readme>
 
 language: Haskell2010
 default-extensions:
@@ -28,6 +29,3 @@ library:
   source-dirs: lib
   exposed-modules:
   - Utils.Drasil
-  when:
-  - condition: false
-    other-modules: Paths_drasil_utils

--- a/code/drasil-website/package.yaml
+++ b/code/drasil-website/package.yaml
@@ -1,10 +1,11 @@
-name:                drasil-website
-version:             0.1.0.0
-github:              JacquesCarette/Drasil
-maintainer:          "Jacques Carette"
-synopsis:            Using the Drasil generators to create Drasil's website
-homepage:            https://jacquescarette.github.io/Drasil/
-description:         Please see the README on GitHub at <https://github.com/JacquesCarette/Drasil#readme>
+spec-version: 0.36.0
+name:         drasil-website
+version:      0.1.0.0
+github:       JacquesCarette/Drasil
+maintainer:   "Jacques Carette"
+synopsis:     Using the Drasil generators to create Drasil's website
+homepage:     https://jacquescarette.github.io/Drasil/
+description:  Please see the README on GitHub at <https://github.com/JacquesCarette/Drasil#readme>
 
 language: Haskell2010
 default-extensions:
@@ -46,9 +47,6 @@ dependencies:
 
 library:
   source-dirs: lib
-  when:
-  - condition: false
-    other-modules: Paths_drasil_website
 
 executables:
   website:
@@ -59,6 +57,3 @@ executables:
     - -O2
     dependencies:
     - drasil-website
-    when:
-    - condition: false
-      other-modules: Paths_drasil_website


### PR DESCRIPTION
Updating to this specification version allows us to delete the `Paths_` hacks.

See [their README](https://github.com/sol/hpack?tab=readme-ov-file#handling-of-paths_-modules) for more information on this.