### PR TITLE
Re-write traceability graph generator using `Doc`s.

### DIFF
--- a/code/drasil-gen/lib/Drasil/Generator/SRS/TraceabilityGraphs.hs
+++ b/code/drasil-gen/lib/Drasil/Generator/SRS/TraceabilityGraphs.hs
@@ -1,82 +1,75 @@
 module Drasil.Generator.SRS.TraceabilityGraphs (outputDot) where
 
-import Data.List (intercalate)
-import System.IO (Handle, IOMode(WriteMode), openFile, hPutStrLn, hClose)
+import Prelude hiding ((<>))
+
 import System.Directory (setCurrentDirectory)
+import Text.PrettyPrint.HughesPJ (Doc, render, text, (<>), (<+>), vcat, nest,
+  hsep, empty)
 
 import Drasil.Build.Artifacts (createDirIfMissing)
 import Drasil.Database (UID)
 import Drasil.Metadata.TraceabilityGraphs (GraphInfo(..), NodeFamily(..),
-  Label, Colour)
+  Label)
 
--- | Creates the directory for output, gathers all individual graph output functions and calls them.
+-- | Creates the directory for output, gathers all individual graph output
+-- functions and calls them.
 outputDot :: FilePath -> GraphInfo -> IO ()
 outputDot outputFilePath gi = do
-    createDirIfMissing False outputFilePath
-    setCurrentDirectory outputFilePath
-    mkOutput gi "avsa" edgesAvsA [assumpNF]
-    mkOutput gi "avsall" edgesAvsAll [assumpNF, ddNF, tmNF, gdNF, imNF, reqNF, chgNF]
-    mkOutput gi "refvsref" edgesRefvsRef [ddNF, tmNF, gdNF, imNF]
-    mkOutput gi "allvsr" edgesAllvsR [assumpNF, ddNF, tmNF, gdNF, imNF, reqNF, gsNF]
-    mkOutput gi "allvsall" edgesAllvsAll [assumpNF, ddNF, tmNF, gdNF, imNF, reqNF, gsNF, chgNF]
-
--- ** Helpers
+  createDirIfMissing False outputFilePath
+  setCurrentDirectory outputFilePath
+  mkOutput gi "avsa" edgesAvsA [assumpNF]
+  mkOutput gi "avsall" edgesAvsAll [assumpNF, ddNF, tmNF, gdNF, imNF, reqNF, chgNF]
+  mkOutput gi "refvsref" edgesRefvsRef [ddNF, tmNF, gdNF, imNF]
+  mkOutput gi "allvsr" edgesAllvsR [assumpNF, ddNF, tmNF, gdNF, imNF, reqNF, gsNF]
+  mkOutput gi "allvsall" edgesAllvsAll [assumpNF, ddNF, tmNF, gdNF, imNF, reqNF, gsNF, chgNF]
 
 -- | General output function for making a traceability graph. Takes in the graph information, title, edge generator functions, and node family functions.
 mkOutput :: GraphInfo -> String -> (GraphInfo -> [(UID, [UID])]) -> [GraphInfo -> NodeFamily] -> IO ()
-mkOutput gi ttl getDirections getLabels = do
-    handle <- openFile (ttl ++ ".dot") WriteMode
-    hPutStrLn handle $ "digraph " ++ ttl ++ " {"
-    let labels = filterAndGI gi getLabels
-    outputSub handle (getDirections gi) labels
-    hPutStrLn handle "}"
-    hClose handle
+mkOutput gi ttl getDirections getLabels =
+  writeFile (ttl ++ ".dot") (render $ mkDot ttl (getDirections gi) (map ($ gi) getLabels))
 
--- | Graph output helper. Takes in the file handle, edges, and node families.
-outputSub :: Handle -> [(UID, [UID])] -> [NodeFamily] -> IO ()
-outputSub handle edges nodes = do
-    mapM_ (mkDirections handle) edges
-    hPutStrLn handle "\n"
-    mapM_ (mkNodes handle) nodes
+-- | Constructs the full DOT document.
+mkDot :: String -> [(UID, [UID])] -> [NodeFamily] -> Doc
+mkDot title edges families =
+  vcat
+    [ text "digraph" <+> quote title <+> text "{",
+      nest 4 $ vcat $ map vcat [map mkDirections edges, map mkNodes families],
+      text "}"
+    ]
 
--- | Prints graph edges (directions) onto a given file handle.
-mkDirections :: Handle -> (UID, [UID]) -> IO ()
-mkDirections handle ls = do
-    mapM_ (hPutStrLn handle) $ makeEdgesSub (show $ fst ls) (filter (not . null) $ map show $ snd ls)
-    where
-       -- Creates an edge between a type and its dependency (indented for subgraphs)
-        makeEdgesSub :: String -> [String] -> [String]
-        makeEdgesSub _ [] = []
-        makeEdgesSub nm (c:cs) = ("\t" ++ filterInvalidChars nm ++ " -> " ++ filterInvalidChars c ++ ";"): makeEdgesSub nm cs
-
--- | Prints graph nodes (labels) onto a given file handle.
-mkNodes :: Handle -> NodeFamily -> IO ()
-mkNodes handle NF{nodeUIDs = u, nodeLabels = ls, nfLabel = lbl, nfColour = col} = do
-    mapM_ (hPutStrLn handle . uncurry (makeNodesSub col)) $ zip ls $ map show u
-    mkSubgraph handle lbl u
-    where
-        -- Creates a node based on the kind of datatype (indented for subgraphs)
-        makeNodesSub :: Colour -> String -> String -> String
-        makeNodesSub c l nm  = "\t" ++ filterInvalidChars nm ++ "\t[shape=box, color=black, style=filled, fillcolor=" ++ c ++ ", label=\"" ++ l ++ "\"];"
-
--- | Helper that only makes a subgraph if there are elements in the subgraph. Otherwise, it returns nothing.
-mkSubgraph :: Handle -> Label -> [UID] -> IO ()
-mkSubgraph handle l u
-    | null l = return mempty
-    | otherwise = do
-             hPutStrLn handle $ "\n\tsubgraph " ++ l ++ " {"
-             hPutStrLn handle "\trank=\"same\""
-             hPutStrLn handle $ "\t{" ++ intercalate ", " (map (filterInvalidChars . show) u) ++ "}"
-             hPutStrLn handle "\t}\n"
-
--- | Gets graph labels.
-filterAndGI :: GraphInfo -> [GraphInfo -> NodeFamily] -> [NodeFamily]
-filterAndGI gi toNodes = labels
-    where
-        labels = map ($ gi) toNodes
-
--- | Helper to remove invalid characters.
-filterInvalidChars :: String -> String
-filterInvalidChars = filter (`notElem` invalidChars)
+mkDirections :: (UID, [UID]) -> Doc
+mkDirections (u, deps) = vcat $ map (mkEdge u) (filter (not . null . show) deps)
   where
-    invalidChars = "^[]!} (){->,$"
+    mkEdge src dest = quote (show src) <+> text "->" <+> quote (show dest) <> text ";"
+
+mkNodes :: NodeFamily -> Doc
+mkNodes NF {nodeUIDs = u, nodeLabels = ls, nfLabel = lbl, nfColour = col} =
+  vcat
+    [ vcat (zipWith (mkNode col) u ls),
+      mkSubgraph lbl u
+    ]
+  where
+    mkNode c n l = quote (show n)
+      <+> text "[shape=box, color=black, style=filled, fillcolor="
+      <> quote c <> text ", label=" <> quote l <> text "];"
+
+mkSubgraph :: Label -> [UID] -> Doc
+mkSubgraph title contents
+  | null title || null contents = empty
+  | otherwise =
+      vcat
+        [ text "subgraph" <+> quote title <+> text "{",
+          nest 4 $ vcat
+            [ text "rank=\"same\";",
+              hsep (map (quote . show) contents) <> text ";"
+            ],
+          text "}"
+        ]
+
+quote :: String -> Doc
+quote = text . escape
+  where
+    escape s = "\"" ++ concatMap escChar s ++ "\""
+    escChar '"' = "\\\""
+    escChar '\\' = "\\\\"
+    escChar c = [c]

--- a/code/stable/dblpend/TraceyGraph/allvsall.dot
+++ b/code/stable/dblpend/TraceyGraph/allvsall.dot
@@ -1,104 +1,88 @@
-digraph allvsall {
-	theory:v_x1 -> dataDefn:velocity;
-	theory:v_x1 -> dataDefn:p_x1;
-	theory:v_y1 -> dataDefn:velocity;
-	theory:v_y1 -> dataDefn:p_y1;
-	theory:v_x2 -> dataDefn:velocity;
-	theory:v_x2 -> dataDefn:p_x2;
-	theory:v_y2 -> dataDefn:velocity;
-	theory:v_y2 -> dataDefn:p_y2;
-	theory:angleIM1 -> theory:angleIM2;
-	theory:angleIM2 -> theory:a_x1;
-	theory:angleIM2 -> theory:a_y1;
-	theory:angleIM2 -> theory:a_x2;
-	theory:angleIM2 -> theory:a_y2;
-	theory:angleIM2 -> theory:xForce1;
-	theory:angleIM2 -> theory:yForce1;
-	theory:angleIM2 -> theory:xForce2;
-	theory:angleIM2 -> theory:yForce2;
-	theory:angleIM2 -> theory:angleIM1;
-	theory:angleIM2 -> theory:angleIM2;
-	instance:calcAng -> theory:angleIM1;
-	instance:calcAng -> theory:angleIM2;
-	instance:outputValues -> theory:angleIM1;
-	instance:outputValues -> theory:angleIM2;
-
-
-	instance:twoDMotion	[shape=box, color=black, style=filled, fillcolor=mistyrose, label="A:twoDMotion"];
-	instance:cartSys	[shape=box, color=black, style=filled, fillcolor=mistyrose, label="A:cartSys"];
-	instance:cartSysR	[shape=box, color=black, style=filled, fillcolor=mistyrose, label="A:cartSysR"];
-	instance:yAxisDir	[shape=box, color=black, style=filled, fillcolor=mistyrose, label="A:yAxisDir"];
-
-	subgraph A {
-	rank="same"
-	{instance:twoDMotion, instance:cartSys, instance:cartSysR, instance:yAxisDir}
-	}
-
-	dataDefn:velocity	[shape=box, color=black, style=filled, fillcolor=paleturquoise1, label="DD:positionGDD"];
-	dataDefn:p_x1	[shape=box, color=black, style=filled, fillcolor=paleturquoise1, label="DD:positionXDD1"];
-	dataDefn:p_y1	[shape=box, color=black, style=filled, fillcolor=paleturquoise1, label="DD:positionYDD1"];
-	dataDefn:p_x2	[shape=box, color=black, style=filled, fillcolor=paleturquoise1, label="DD:positionXDD2"];
-	dataDefn:p_y2	[shape=box, color=black, style=filled, fillcolor=paleturquoise1, label="DD:positionYDD2"];
-	dataDefn:acceleration	[shape=box, color=black, style=filled, fillcolor=paleturquoise1, label="DD:accelerationGDD"];
-	dataDefn:force	[shape=box, color=black, style=filled, fillcolor=paleturquoise1, label="DD:forceGDD"];
-
-	subgraph DD {
-	rank="same"
-	{dataDefn:velocity, dataDefn:p_x1, dataDefn:p_y1, dataDefn:p_x2, dataDefn:p_y2, dataDefn:acceleration, dataDefn:force}
-	}
-
-	theory:accelerationTM	[shape=box, color=black, style=filled, fillcolor=pink, label="TM:acceleration"];
-	theory:velocityTM	[shape=box, color=black, style=filled, fillcolor=pink, label="TM:velocity"];
-	theory:newtonSL	[shape=box, color=black, style=filled, fillcolor=pink, label="TM:NewtonSecLawMot"];
-
-	subgraph TM {
-	rank="same"
-	{theory:accelerationTM, theory:velocityTM, theory:newtonSL}
-	}
-
-	theory:v_x1	[shape=box, color=black, style=filled, fillcolor=palegreen, label="GD:velocityX1"];
-	theory:v_y1	[shape=box, color=black, style=filled, fillcolor=palegreen, label="GD:velocityY1"];
-	theory:v_x2	[shape=box, color=black, style=filled, fillcolor=palegreen, label="GD:velocityX2"];
-	theory:v_y2	[shape=box, color=black, style=filled, fillcolor=palegreen, label="GD:velocityY2"];
-	theory:a_x1	[shape=box, color=black, style=filled, fillcolor=palegreen, label="GD:accelerationX1"];
-	theory:a_y1	[shape=box, color=black, style=filled, fillcolor=palegreen, label="GD:accelerationY1"];
-	theory:a_x2	[shape=box, color=black, style=filled, fillcolor=palegreen, label="GD:accelerationX2"];
-	theory:a_y2	[shape=box, color=black, style=filled, fillcolor=palegreen, label="GD:accelerationY2"];
-	theory:xForce1	[shape=box, color=black, style=filled, fillcolor=palegreen, label="GD:xForce1"];
-	theory:yForce1	[shape=box, color=black, style=filled, fillcolor=palegreen, label="GD:yForce1"];
-	theory:xForce2	[shape=box, color=black, style=filled, fillcolor=palegreen, label="GD:xForce2"];
-	theory:yForce2	[shape=box, color=black, style=filled, fillcolor=palegreen, label="GD:yForce2"];
-
-	subgraph GD {
-	rank="same"
-	{theory:v_x1, theory:v_y1, theory:v_x2, theory:v_y2, theory:a_x1, theory:a_y1, theory:a_x2, theory:a_y2, theory:xForce1, theory:yForce1, theory:xForce2, theory:yForce2}
-	}
-
-	theory:angleIM1	[shape=box, color=black, style=filled, fillcolor=khaki1, label="IM:calOfAngle1"];
-	theory:angleIM2	[shape=box, color=black, style=filled, fillcolor=khaki1, label="IM:calOfAngle2"];
-
-	subgraph IM {
-	rank="same"
-	{theory:angleIM1, theory:angleIM2}
-	}
-
-	instance:inputValues	[shape=box, color=black, style=filled, fillcolor=ivory, label="FR:inputValues"];
-	instance:verifyInptVals	[shape=box, color=black, style=filled, fillcolor=ivory, label="FR:verifyInptVals"];
-	instance:calcAng	[shape=box, color=black, style=filled, fillcolor=ivory, label="FR:calcAng"];
-	instance:outputValues	[shape=box, color=black, style=filled, fillcolor=ivory, label="FR:outputValues"];
-	instance:correct	[shape=box, color=black, style=filled, fillcolor=ivory, label="NFR:correct"];
-	instance:portable	[shape=box, color=black, style=filled, fillcolor=ivory, label="NFR:portable"];
-
-	subgraph FR {
-	rank="same"
-	{instance:inputValues, instance:verifyInptVals, instance:calcAng, instance:outputValues, instance:correct, instance:portable}
-	}
-
-	instance:motionMass	[shape=box, color=black, style=filled, fillcolor=darkgoldenrod1, label="GS:motionMass"];
-
-	subgraph GS {
-	rank="same"
-	{instance:motionMass}
-	}
-
+digraph "allvsall" {
+    "theory:v_x1" -> "dataDefn:velocity";
+    "theory:v_x1" -> "dataDefn:p_x1";
+    "theory:v_y1" -> "dataDefn:velocity";
+    "theory:v_y1" -> "dataDefn:p_y1";
+    "theory:v_x2" -> "dataDefn:velocity";
+    "theory:v_x2" -> "dataDefn:p_x2";
+    "theory:v_y2" -> "dataDefn:velocity";
+    "theory:v_y2" -> "dataDefn:p_y2";
+    "theory:angleIM1" -> "theory:angleIM2";
+    "theory:angleIM2" -> "theory:a_x1";
+    "theory:angleIM2" -> "theory:a_y1";
+    "theory:angleIM2" -> "theory:a_x2";
+    "theory:angleIM2" -> "theory:a_y2";
+    "theory:angleIM2" -> "theory:xForce1";
+    "theory:angleIM2" -> "theory:yForce1";
+    "theory:angleIM2" -> "theory:xForce2";
+    "theory:angleIM2" -> "theory:yForce2";
+    "theory:angleIM2" -> "theory:angleIM1";
+    "theory:angleIM2" -> "theory:angleIM2";
+    "instance:calcAng" -> "theory:angleIM1";
+    "instance:calcAng" -> "theory:angleIM2";
+    "instance:outputValues" -> "theory:angleIM1";
+    "instance:outputValues" -> "theory:angleIM2";
+    "instance:twoDMotion" [shape=box, color=black, style=filled, fillcolor="mistyrose", label="A:twoDMotion"];
+    "instance:cartSys" [shape=box, color=black, style=filled, fillcolor="mistyrose", label="A:cartSys"];
+    "instance:cartSysR" [shape=box, color=black, style=filled, fillcolor="mistyrose", label="A:cartSysR"];
+    "instance:yAxisDir" [shape=box, color=black, style=filled, fillcolor="mistyrose", label="A:yAxisDir"];
+    subgraph "A" {
+        rank="same";
+        "instance:twoDMotion" "instance:cartSys" "instance:cartSysR" "instance:yAxisDir";
+    }
+    "dataDefn:velocity" [shape=box, color=black, style=filled, fillcolor="paleturquoise1", label="DD:positionGDD"];
+    "dataDefn:p_x1" [shape=box, color=black, style=filled, fillcolor="paleturquoise1", label="DD:positionXDD1"];
+    "dataDefn:p_y1" [shape=box, color=black, style=filled, fillcolor="paleturquoise1", label="DD:positionYDD1"];
+    "dataDefn:p_x2" [shape=box, color=black, style=filled, fillcolor="paleturquoise1", label="DD:positionXDD2"];
+    "dataDefn:p_y2" [shape=box, color=black, style=filled, fillcolor="paleturquoise1", label="DD:positionYDD2"];
+    "dataDefn:acceleration" [shape=box, color=black, style=filled, fillcolor="paleturquoise1", label="DD:accelerationGDD"];
+    "dataDefn:force" [shape=box, color=black, style=filled, fillcolor="paleturquoise1", label="DD:forceGDD"];
+    subgraph "DD" {
+        rank="same";
+        "dataDefn:velocity" "dataDefn:p_x1" "dataDefn:p_y1" "dataDefn:p_x2" "dataDefn:p_y2" "dataDefn:acceleration" "dataDefn:force";
+    }
+    "theory:accelerationTM" [shape=box, color=black, style=filled, fillcolor="pink", label="TM:acceleration"];
+    "theory:velocityTM" [shape=box, color=black, style=filled, fillcolor="pink", label="TM:velocity"];
+    "theory:newtonSL" [shape=box, color=black, style=filled, fillcolor="pink", label="TM:NewtonSecLawMot"];
+    subgraph "TM" {
+        rank="same";
+        "theory:accelerationTM" "theory:velocityTM" "theory:newtonSL";
+    }
+    "theory:v_x1" [shape=box, color=black, style=filled, fillcolor="palegreen", label="GD:velocityX1"];
+    "theory:v_y1" [shape=box, color=black, style=filled, fillcolor="palegreen", label="GD:velocityY1"];
+    "theory:v_x2" [shape=box, color=black, style=filled, fillcolor="palegreen", label="GD:velocityX2"];
+    "theory:v_y2" [shape=box, color=black, style=filled, fillcolor="palegreen", label="GD:velocityY2"];
+    "theory:a_x1" [shape=box, color=black, style=filled, fillcolor="palegreen", label="GD:accelerationX1"];
+    "theory:a_y1" [shape=box, color=black, style=filled, fillcolor="palegreen", label="GD:accelerationY1"];
+    "theory:a_x2" [shape=box, color=black, style=filled, fillcolor="palegreen", label="GD:accelerationX2"];
+    "theory:a_y2" [shape=box, color=black, style=filled, fillcolor="palegreen", label="GD:accelerationY2"];
+    "theory:xForce1" [shape=box, color=black, style=filled, fillcolor="palegreen", label="GD:xForce1"];
+    "theory:yForce1" [shape=box, color=black, style=filled, fillcolor="palegreen", label="GD:yForce1"];
+    "theory:xForce2" [shape=box, color=black, style=filled, fillcolor="palegreen", label="GD:xForce2"];
+    "theory:yForce2" [shape=box, color=black, style=filled, fillcolor="palegreen", label="GD:yForce2"];
+    subgraph "GD" {
+        rank="same";
+        "theory:v_x1" "theory:v_y1" "theory:v_x2" "theory:v_y2" "theory:a_x1" "theory:a_y1" "theory:a_x2" "theory:a_y2" "theory:xForce1" "theory:yForce1" "theory:xForce2" "theory:yForce2";
+    }
+    "theory:angleIM1" [shape=box, color=black, style=filled, fillcolor="khaki1", label="IM:calOfAngle1"];
+    "theory:angleIM2" [shape=box, color=black, style=filled, fillcolor="khaki1", label="IM:calOfAngle2"];
+    subgraph "IM" {
+        rank="same";
+        "theory:angleIM1" "theory:angleIM2";
+    }
+    "instance:inputValues" [shape=box, color=black, style=filled, fillcolor="ivory", label="FR:inputValues"];
+    "instance:verifyInptVals" [shape=box, color=black, style=filled, fillcolor="ivory", label="FR:verifyInptVals"];
+    "instance:calcAng" [shape=box, color=black, style=filled, fillcolor="ivory", label="FR:calcAng"];
+    "instance:outputValues" [shape=box, color=black, style=filled, fillcolor="ivory", label="FR:outputValues"];
+    "instance:correct" [shape=box, color=black, style=filled, fillcolor="ivory", label="NFR:correct"];
+    "instance:portable" [shape=box, color=black, style=filled, fillcolor="ivory", label="NFR:portable"];
+    subgraph "FR" {
+        rank="same";
+        "instance:inputValues" "instance:verifyInptVals" "instance:calcAng" "instance:outputValues" "instance:correct" "instance:portable";
+    }
+    "instance:motionMass" [shape=box, color=black, style=filled, fillcolor="darkgoldenrod1", label="GS:motionMass"];
+    subgraph "GS" {
+        rank="same";
+        "instance:motionMass";
+    }
 }

--- a/code/stable/dblpend/TraceyGraph/allvsr.dot
+++ b/code/stable/dblpend/TraceyGraph/allvsr.dot
@@ -1,85 +1,69 @@
-digraph allvsr {
-	instance:calcAng -> theory:angleIM1;
-	instance:calcAng -> theory:angleIM2;
-	instance:outputValues -> theory:angleIM1;
-	instance:outputValues -> theory:angleIM2;
-
-
-	instance:twoDMotion	[shape=box, color=black, style=filled, fillcolor=mistyrose, label="A:twoDMotion"];
-	instance:cartSys	[shape=box, color=black, style=filled, fillcolor=mistyrose, label="A:cartSys"];
-	instance:cartSysR	[shape=box, color=black, style=filled, fillcolor=mistyrose, label="A:cartSysR"];
-	instance:yAxisDir	[shape=box, color=black, style=filled, fillcolor=mistyrose, label="A:yAxisDir"];
-
-	subgraph A {
-	rank="same"
-	{instance:twoDMotion, instance:cartSys, instance:cartSysR, instance:yAxisDir}
-	}
-
-	dataDefn:velocity	[shape=box, color=black, style=filled, fillcolor=paleturquoise1, label="DD:positionGDD"];
-	dataDefn:p_x1	[shape=box, color=black, style=filled, fillcolor=paleturquoise1, label="DD:positionXDD1"];
-	dataDefn:p_y1	[shape=box, color=black, style=filled, fillcolor=paleturquoise1, label="DD:positionYDD1"];
-	dataDefn:p_x2	[shape=box, color=black, style=filled, fillcolor=paleturquoise1, label="DD:positionXDD2"];
-	dataDefn:p_y2	[shape=box, color=black, style=filled, fillcolor=paleturquoise1, label="DD:positionYDD2"];
-	dataDefn:acceleration	[shape=box, color=black, style=filled, fillcolor=paleturquoise1, label="DD:accelerationGDD"];
-	dataDefn:force	[shape=box, color=black, style=filled, fillcolor=paleturquoise1, label="DD:forceGDD"];
-
-	subgraph DD {
-	rank="same"
-	{dataDefn:velocity, dataDefn:p_x1, dataDefn:p_y1, dataDefn:p_x2, dataDefn:p_y2, dataDefn:acceleration, dataDefn:force}
-	}
-
-	theory:accelerationTM	[shape=box, color=black, style=filled, fillcolor=pink, label="TM:acceleration"];
-	theory:velocityTM	[shape=box, color=black, style=filled, fillcolor=pink, label="TM:velocity"];
-	theory:newtonSL	[shape=box, color=black, style=filled, fillcolor=pink, label="TM:NewtonSecLawMot"];
-
-	subgraph TM {
-	rank="same"
-	{theory:accelerationTM, theory:velocityTM, theory:newtonSL}
-	}
-
-	theory:v_x1	[shape=box, color=black, style=filled, fillcolor=palegreen, label="GD:velocityX1"];
-	theory:v_y1	[shape=box, color=black, style=filled, fillcolor=palegreen, label="GD:velocityY1"];
-	theory:v_x2	[shape=box, color=black, style=filled, fillcolor=palegreen, label="GD:velocityX2"];
-	theory:v_y2	[shape=box, color=black, style=filled, fillcolor=palegreen, label="GD:velocityY2"];
-	theory:a_x1	[shape=box, color=black, style=filled, fillcolor=palegreen, label="GD:accelerationX1"];
-	theory:a_y1	[shape=box, color=black, style=filled, fillcolor=palegreen, label="GD:accelerationY1"];
-	theory:a_x2	[shape=box, color=black, style=filled, fillcolor=palegreen, label="GD:accelerationX2"];
-	theory:a_y2	[shape=box, color=black, style=filled, fillcolor=palegreen, label="GD:accelerationY2"];
-	theory:xForce1	[shape=box, color=black, style=filled, fillcolor=palegreen, label="GD:xForce1"];
-	theory:yForce1	[shape=box, color=black, style=filled, fillcolor=palegreen, label="GD:yForce1"];
-	theory:xForce2	[shape=box, color=black, style=filled, fillcolor=palegreen, label="GD:xForce2"];
-	theory:yForce2	[shape=box, color=black, style=filled, fillcolor=palegreen, label="GD:yForce2"];
-
-	subgraph GD {
-	rank="same"
-	{theory:v_x1, theory:v_y1, theory:v_x2, theory:v_y2, theory:a_x1, theory:a_y1, theory:a_x2, theory:a_y2, theory:xForce1, theory:yForce1, theory:xForce2, theory:yForce2}
-	}
-
-	theory:angleIM1	[shape=box, color=black, style=filled, fillcolor=khaki1, label="IM:calOfAngle1"];
-	theory:angleIM2	[shape=box, color=black, style=filled, fillcolor=khaki1, label="IM:calOfAngle2"];
-
-	subgraph IM {
-	rank="same"
-	{theory:angleIM1, theory:angleIM2}
-	}
-
-	instance:inputValues	[shape=box, color=black, style=filled, fillcolor=ivory, label="FR:inputValues"];
-	instance:verifyInptVals	[shape=box, color=black, style=filled, fillcolor=ivory, label="FR:verifyInptVals"];
-	instance:calcAng	[shape=box, color=black, style=filled, fillcolor=ivory, label="FR:calcAng"];
-	instance:outputValues	[shape=box, color=black, style=filled, fillcolor=ivory, label="FR:outputValues"];
-	instance:correct	[shape=box, color=black, style=filled, fillcolor=ivory, label="NFR:correct"];
-	instance:portable	[shape=box, color=black, style=filled, fillcolor=ivory, label="NFR:portable"];
-
-	subgraph FR {
-	rank="same"
-	{instance:inputValues, instance:verifyInptVals, instance:calcAng, instance:outputValues, instance:correct, instance:portable}
-	}
-
-	instance:motionMass	[shape=box, color=black, style=filled, fillcolor=darkgoldenrod1, label="GS:motionMass"];
-
-	subgraph GS {
-	rank="same"
-	{instance:motionMass}
-	}
-
+digraph "allvsr" {
+    "instance:calcAng" -> "theory:angleIM1";
+    "instance:calcAng" -> "theory:angleIM2";
+    "instance:outputValues" -> "theory:angleIM1";
+    "instance:outputValues" -> "theory:angleIM2";
+    "instance:twoDMotion" [shape=box, color=black, style=filled, fillcolor="mistyrose", label="A:twoDMotion"];
+    "instance:cartSys" [shape=box, color=black, style=filled, fillcolor="mistyrose", label="A:cartSys"];
+    "instance:cartSysR" [shape=box, color=black, style=filled, fillcolor="mistyrose", label="A:cartSysR"];
+    "instance:yAxisDir" [shape=box, color=black, style=filled, fillcolor="mistyrose", label="A:yAxisDir"];
+    subgraph "A" {
+        rank="same";
+        "instance:twoDMotion" "instance:cartSys" "instance:cartSysR" "instance:yAxisDir";
+    }
+    "dataDefn:velocity" [shape=box, color=black, style=filled, fillcolor="paleturquoise1", label="DD:positionGDD"];
+    "dataDefn:p_x1" [shape=box, color=black, style=filled, fillcolor="paleturquoise1", label="DD:positionXDD1"];
+    "dataDefn:p_y1" [shape=box, color=black, style=filled, fillcolor="paleturquoise1", label="DD:positionYDD1"];
+    "dataDefn:p_x2" [shape=box, color=black, style=filled, fillcolor="paleturquoise1", label="DD:positionXDD2"];
+    "dataDefn:p_y2" [shape=box, color=black, style=filled, fillcolor="paleturquoise1", label="DD:positionYDD2"];
+    "dataDefn:acceleration" [shape=box, color=black, style=filled, fillcolor="paleturquoise1", label="DD:accelerationGDD"];
+    "dataDefn:force" [shape=box, color=black, style=filled, fillcolor="paleturquoise1", label="DD:forceGDD"];
+    subgraph "DD" {
+        rank="same";
+        "dataDefn:velocity" "dataDefn:p_x1" "dataDefn:p_y1" "dataDefn:p_x2" "dataDefn:p_y2" "dataDefn:acceleration" "dataDefn:force";
+    }
+    "theory:accelerationTM" [shape=box, color=black, style=filled, fillcolor="pink", label="TM:acceleration"];
+    "theory:velocityTM" [shape=box, color=black, style=filled, fillcolor="pink", label="TM:velocity"];
+    "theory:newtonSL" [shape=box, color=black, style=filled, fillcolor="pink", label="TM:NewtonSecLawMot"];
+    subgraph "TM" {
+        rank="same";
+        "theory:accelerationTM" "theory:velocityTM" "theory:newtonSL";
+    }
+    "theory:v_x1" [shape=box, color=black, style=filled, fillcolor="palegreen", label="GD:velocityX1"];
+    "theory:v_y1" [shape=box, color=black, style=filled, fillcolor="palegreen", label="GD:velocityY1"];
+    "theory:v_x2" [shape=box, color=black, style=filled, fillcolor="palegreen", label="GD:velocityX2"];
+    "theory:v_y2" [shape=box, color=black, style=filled, fillcolor="palegreen", label="GD:velocityY2"];
+    "theory:a_x1" [shape=box, color=black, style=filled, fillcolor="palegreen", label="GD:accelerationX1"];
+    "theory:a_y1" [shape=box, color=black, style=filled, fillcolor="palegreen", label="GD:accelerationY1"];
+    "theory:a_x2" [shape=box, color=black, style=filled, fillcolor="palegreen", label="GD:accelerationX2"];
+    "theory:a_y2" [shape=box, color=black, style=filled, fillcolor="palegreen", label="GD:accelerationY2"];
+    "theory:xForce1" [shape=box, color=black, style=filled, fillcolor="palegreen", label="GD:xForce1"];
+    "theory:yForce1" [shape=box, color=black, style=filled, fillcolor="palegreen", label="GD:yForce1"];
+    "theory:xForce2" [shape=box, color=black, style=filled, fillcolor="palegreen", label="GD:xForce2"];
+    "theory:yForce2" [shape=box, color=black, style=filled, fillcolor="palegreen", label="GD:yForce2"];
+    subgraph "GD" {
+        rank="same";
+        "theory:v_x1" "theory:v_y1" "theory:v_x2" "theory:v_y2" "theory:a_x1" "theory:a_y1" "theory:a_x2" "theory:a_y2" "theory:xForce1" "theory:yForce1" "theory:xForce2" "theory:yForce2";
+    }
+    "theory:angleIM1" [shape=box, color=black, style=filled, fillcolor="khaki1", label="IM:calOfAngle1"];
+    "theory:angleIM2" [shape=box, color=black, style=filled, fillcolor="khaki1", label="IM:calOfAngle2"];
+    subgraph "IM" {
+        rank="same";
+        "theory:angleIM1" "theory:angleIM2";
+    }
+    "instance:inputValues" [shape=box, color=black, style=filled, fillcolor="ivory", label="FR:inputValues"];
+    "instance:verifyInptVals" [shape=box, color=black, style=filled, fillcolor="ivory", label="FR:verifyInptVals"];
+    "instance:calcAng" [shape=box, color=black, style=filled, fillcolor="ivory", label="FR:calcAng"];
+    "instance:outputValues" [shape=box, color=black, style=filled, fillcolor="ivory", label="FR:outputValues"];
+    "instance:correct" [shape=box, color=black, style=filled, fillcolor="ivory", label="NFR:correct"];
+    "instance:portable" [shape=box, color=black, style=filled, fillcolor="ivory", label="NFR:portable"];
+    subgraph "FR" {
+        rank="same";
+        "instance:inputValues" "instance:verifyInptVals" "instance:calcAng" "instance:outputValues" "instance:correct" "instance:portable";
+    }
+    "instance:motionMass" [shape=box, color=black, style=filled, fillcolor="darkgoldenrod1", label="GS:motionMass"];
+    subgraph "GS" {
+        rank="same";
+        "instance:motionMass";
+    }
 }

--- a/code/stable/dblpend/TraceyGraph/avsa.dot
+++ b/code/stable/dblpend/TraceyGraph/avsa.dot
@@ -1,14 +1,10 @@
-digraph avsa {
-
-
-	instance:twoDMotion	[shape=box, color=black, style=filled, fillcolor=mistyrose, label="A:twoDMotion"];
-	instance:cartSys	[shape=box, color=black, style=filled, fillcolor=mistyrose, label="A:cartSys"];
-	instance:cartSysR	[shape=box, color=black, style=filled, fillcolor=mistyrose, label="A:cartSysR"];
-	instance:yAxisDir	[shape=box, color=black, style=filled, fillcolor=mistyrose, label="A:yAxisDir"];
-
-	subgraph A {
-	rank="same"
-	{instance:twoDMotion, instance:cartSys, instance:cartSysR, instance:yAxisDir}
-	}
-
+digraph "avsa" {
+    "instance:twoDMotion" [shape=box, color=black, style=filled, fillcolor="mistyrose", label="A:twoDMotion"];
+    "instance:cartSys" [shape=box, color=black, style=filled, fillcolor="mistyrose", label="A:cartSys"];
+    "instance:cartSysR" [shape=box, color=black, style=filled, fillcolor="mistyrose", label="A:cartSysR"];
+    "instance:yAxisDir" [shape=box, color=black, style=filled, fillcolor="mistyrose", label="A:yAxisDir"];
+    subgraph "A" {
+        rank="same";
+        "instance:twoDMotion" "instance:cartSys" "instance:cartSysR" "instance:yAxisDir";
+    }
 }

--- a/code/stable/dblpend/TraceyGraph/avsall.dot
+++ b/code/stable/dblpend/TraceyGraph/avsall.dot
@@ -1,74 +1,60 @@
-digraph avsall {
-
-
-	instance:twoDMotion	[shape=box, color=black, style=filled, fillcolor=mistyrose, label="A:twoDMotion"];
-	instance:cartSys	[shape=box, color=black, style=filled, fillcolor=mistyrose, label="A:cartSys"];
-	instance:cartSysR	[shape=box, color=black, style=filled, fillcolor=mistyrose, label="A:cartSysR"];
-	instance:yAxisDir	[shape=box, color=black, style=filled, fillcolor=mistyrose, label="A:yAxisDir"];
-
-	subgraph A {
-	rank="same"
-	{instance:twoDMotion, instance:cartSys, instance:cartSysR, instance:yAxisDir}
-	}
-
-	dataDefn:velocity	[shape=box, color=black, style=filled, fillcolor=paleturquoise1, label="DD:positionGDD"];
-	dataDefn:p_x1	[shape=box, color=black, style=filled, fillcolor=paleturquoise1, label="DD:positionXDD1"];
-	dataDefn:p_y1	[shape=box, color=black, style=filled, fillcolor=paleturquoise1, label="DD:positionYDD1"];
-	dataDefn:p_x2	[shape=box, color=black, style=filled, fillcolor=paleturquoise1, label="DD:positionXDD2"];
-	dataDefn:p_y2	[shape=box, color=black, style=filled, fillcolor=paleturquoise1, label="DD:positionYDD2"];
-	dataDefn:acceleration	[shape=box, color=black, style=filled, fillcolor=paleturquoise1, label="DD:accelerationGDD"];
-	dataDefn:force	[shape=box, color=black, style=filled, fillcolor=paleturquoise1, label="DD:forceGDD"];
-
-	subgraph DD {
-	rank="same"
-	{dataDefn:velocity, dataDefn:p_x1, dataDefn:p_y1, dataDefn:p_x2, dataDefn:p_y2, dataDefn:acceleration, dataDefn:force}
-	}
-
-	theory:accelerationTM	[shape=box, color=black, style=filled, fillcolor=pink, label="TM:acceleration"];
-	theory:velocityTM	[shape=box, color=black, style=filled, fillcolor=pink, label="TM:velocity"];
-	theory:newtonSL	[shape=box, color=black, style=filled, fillcolor=pink, label="TM:NewtonSecLawMot"];
-
-	subgraph TM {
-	rank="same"
-	{theory:accelerationTM, theory:velocityTM, theory:newtonSL}
-	}
-
-	theory:v_x1	[shape=box, color=black, style=filled, fillcolor=palegreen, label="GD:velocityX1"];
-	theory:v_y1	[shape=box, color=black, style=filled, fillcolor=palegreen, label="GD:velocityY1"];
-	theory:v_x2	[shape=box, color=black, style=filled, fillcolor=palegreen, label="GD:velocityX2"];
-	theory:v_y2	[shape=box, color=black, style=filled, fillcolor=palegreen, label="GD:velocityY2"];
-	theory:a_x1	[shape=box, color=black, style=filled, fillcolor=palegreen, label="GD:accelerationX1"];
-	theory:a_y1	[shape=box, color=black, style=filled, fillcolor=palegreen, label="GD:accelerationY1"];
-	theory:a_x2	[shape=box, color=black, style=filled, fillcolor=palegreen, label="GD:accelerationX2"];
-	theory:a_y2	[shape=box, color=black, style=filled, fillcolor=palegreen, label="GD:accelerationY2"];
-	theory:xForce1	[shape=box, color=black, style=filled, fillcolor=palegreen, label="GD:xForce1"];
-	theory:yForce1	[shape=box, color=black, style=filled, fillcolor=palegreen, label="GD:yForce1"];
-	theory:xForce2	[shape=box, color=black, style=filled, fillcolor=palegreen, label="GD:xForce2"];
-	theory:yForce2	[shape=box, color=black, style=filled, fillcolor=palegreen, label="GD:yForce2"];
-
-	subgraph GD {
-	rank="same"
-	{theory:v_x1, theory:v_y1, theory:v_x2, theory:v_y2, theory:a_x1, theory:a_y1, theory:a_x2, theory:a_y2, theory:xForce1, theory:yForce1, theory:xForce2, theory:yForce2}
-	}
-
-	theory:angleIM1	[shape=box, color=black, style=filled, fillcolor=khaki1, label="IM:calOfAngle1"];
-	theory:angleIM2	[shape=box, color=black, style=filled, fillcolor=khaki1, label="IM:calOfAngle2"];
-
-	subgraph IM {
-	rank="same"
-	{theory:angleIM1, theory:angleIM2}
-	}
-
-	instance:inputValues	[shape=box, color=black, style=filled, fillcolor=ivory, label="FR:inputValues"];
-	instance:verifyInptVals	[shape=box, color=black, style=filled, fillcolor=ivory, label="FR:verifyInptVals"];
-	instance:calcAng	[shape=box, color=black, style=filled, fillcolor=ivory, label="FR:calcAng"];
-	instance:outputValues	[shape=box, color=black, style=filled, fillcolor=ivory, label="FR:outputValues"];
-	instance:correct	[shape=box, color=black, style=filled, fillcolor=ivory, label="NFR:correct"];
-	instance:portable	[shape=box, color=black, style=filled, fillcolor=ivory, label="NFR:portable"];
-
-	subgraph FR {
-	rank="same"
-	{instance:inputValues, instance:verifyInptVals, instance:calcAng, instance:outputValues, instance:correct, instance:portable}
-	}
-
+digraph "avsall" {
+    "instance:twoDMotion" [shape=box, color=black, style=filled, fillcolor="mistyrose", label="A:twoDMotion"];
+    "instance:cartSys" [shape=box, color=black, style=filled, fillcolor="mistyrose", label="A:cartSys"];
+    "instance:cartSysR" [shape=box, color=black, style=filled, fillcolor="mistyrose", label="A:cartSysR"];
+    "instance:yAxisDir" [shape=box, color=black, style=filled, fillcolor="mistyrose", label="A:yAxisDir"];
+    subgraph "A" {
+        rank="same";
+        "instance:twoDMotion" "instance:cartSys" "instance:cartSysR" "instance:yAxisDir";
+    }
+    "dataDefn:velocity" [shape=box, color=black, style=filled, fillcolor="paleturquoise1", label="DD:positionGDD"];
+    "dataDefn:p_x1" [shape=box, color=black, style=filled, fillcolor="paleturquoise1", label="DD:positionXDD1"];
+    "dataDefn:p_y1" [shape=box, color=black, style=filled, fillcolor="paleturquoise1", label="DD:positionYDD1"];
+    "dataDefn:p_x2" [shape=box, color=black, style=filled, fillcolor="paleturquoise1", label="DD:positionXDD2"];
+    "dataDefn:p_y2" [shape=box, color=black, style=filled, fillcolor="paleturquoise1", label="DD:positionYDD2"];
+    "dataDefn:acceleration" [shape=box, color=black, style=filled, fillcolor="paleturquoise1", label="DD:accelerationGDD"];
+    "dataDefn:force" [shape=box, color=black, style=filled, fillcolor="paleturquoise1", label="DD:forceGDD"];
+    subgraph "DD" {
+        rank="same";
+        "dataDefn:velocity" "dataDefn:p_x1" "dataDefn:p_y1" "dataDefn:p_x2" "dataDefn:p_y2" "dataDefn:acceleration" "dataDefn:force";
+    }
+    "theory:accelerationTM" [shape=box, color=black, style=filled, fillcolor="pink", label="TM:acceleration"];
+    "theory:velocityTM" [shape=box, color=black, style=filled, fillcolor="pink", label="TM:velocity"];
+    "theory:newtonSL" [shape=box, color=black, style=filled, fillcolor="pink", label="TM:NewtonSecLawMot"];
+    subgraph "TM" {
+        rank="same";
+        "theory:accelerationTM" "theory:velocityTM" "theory:newtonSL";
+    }
+    "theory:v_x1" [shape=box, color=black, style=filled, fillcolor="palegreen", label="GD:velocityX1"];
+    "theory:v_y1" [shape=box, color=black, style=filled, fillcolor="palegreen", label="GD:velocityY1"];
+    "theory:v_x2" [shape=box, color=black, style=filled, fillcolor="palegreen", label="GD:velocityX2"];
+    "theory:v_y2" [shape=box, color=black, style=filled, fillcolor="palegreen", label="GD:velocityY2"];
+    "theory:a_x1" [shape=box, color=black, style=filled, fillcolor="palegreen", label="GD:accelerationX1"];
+    "theory:a_y1" [shape=box, color=black, style=filled, fillcolor="palegreen", label="GD:accelerationY1"];
+    "theory:a_x2" [shape=box, color=black, style=filled, fillcolor="palegreen", label="GD:accelerationX2"];
+    "theory:a_y2" [shape=box, color=black, style=filled, fillcolor="palegreen", label="GD:accelerationY2"];
+    "theory:xForce1" [shape=box, color=black, style=filled, fillcolor="palegreen", label="GD:xForce1"];
+    "theory:yForce1" [shape=box, color=black, style=filled, fillcolor="palegreen", label="GD:yForce1"];
+    "theory:xForce2" [shape=box, color=black, style=filled, fillcolor="palegreen", label="GD:xForce2"];
+    "theory:yForce2" [shape=box, color=black, style=filled, fillcolor="palegreen", label="GD:yForce2"];
+    subgraph "GD" {
+        rank="same";
+        "theory:v_x1" "theory:v_y1" "theory:v_x2" "theory:v_y2" "theory:a_x1" "theory:a_y1" "theory:a_x2" "theory:a_y2" "theory:xForce1" "theory:yForce1" "theory:xForce2" "theory:yForce2";
+    }
+    "theory:angleIM1" [shape=box, color=black, style=filled, fillcolor="khaki1", label="IM:calOfAngle1"];
+    "theory:angleIM2" [shape=box, color=black, style=filled, fillcolor="khaki1", label="IM:calOfAngle2"];
+    subgraph "IM" {
+        rank="same";
+        "theory:angleIM1" "theory:angleIM2";
+    }
+    "instance:inputValues" [shape=box, color=black, style=filled, fillcolor="ivory", label="FR:inputValues"];
+    "instance:verifyInptVals" [shape=box, color=black, style=filled, fillcolor="ivory", label="FR:verifyInptVals"];
+    "instance:calcAng" [shape=box, color=black, style=filled, fillcolor="ivory", label="FR:calcAng"];
+    "instance:outputValues" [shape=box, color=black, style=filled, fillcolor="ivory", label="FR:outputValues"];
+    "instance:correct" [shape=box, color=black, style=filled, fillcolor="ivory", label="NFR:correct"];
+    "instance:portable" [shape=box, color=black, style=filled, fillcolor="ivory", label="NFR:portable"];
+    subgraph "FR" {
+        rank="same";
+        "instance:inputValues" "instance:verifyInptVals" "instance:calcAng" "instance:outputValues" "instance:correct" "instance:portable";
+    }
 }

--- a/code/stable/dblpend/TraceyGraph/refvsref.dot
+++ b/code/stable/dblpend/TraceyGraph/refvsref.dot
@@ -1,71 +1,61 @@
-digraph refvsref {
-	theory:v_x1 -> dataDefn:velocity;
-	theory:v_x1 -> dataDefn:p_x1;
-	theory:v_y1 -> dataDefn:velocity;
-	theory:v_y1 -> dataDefn:p_y1;
-	theory:v_x2 -> dataDefn:velocity;
-	theory:v_x2 -> dataDefn:p_x2;
-	theory:v_y2 -> dataDefn:velocity;
-	theory:v_y2 -> dataDefn:p_y2;
-	theory:angleIM1 -> theory:angleIM2;
-	theory:angleIM2 -> theory:a_x1;
-	theory:angleIM2 -> theory:a_y1;
-	theory:angleIM2 -> theory:a_x2;
-	theory:angleIM2 -> theory:a_y2;
-	theory:angleIM2 -> theory:xForce1;
-	theory:angleIM2 -> theory:yForce1;
-	theory:angleIM2 -> theory:xForce2;
-	theory:angleIM2 -> theory:yForce2;
-	theory:angleIM2 -> theory:angleIM1;
-	theory:angleIM2 -> theory:angleIM2;
-
-
-	dataDefn:velocity	[shape=box, color=black, style=filled, fillcolor=paleturquoise1, label="DD:positionGDD"];
-	dataDefn:p_x1	[shape=box, color=black, style=filled, fillcolor=paleturquoise1, label="DD:positionXDD1"];
-	dataDefn:p_y1	[shape=box, color=black, style=filled, fillcolor=paleturquoise1, label="DD:positionYDD1"];
-	dataDefn:p_x2	[shape=box, color=black, style=filled, fillcolor=paleturquoise1, label="DD:positionXDD2"];
-	dataDefn:p_y2	[shape=box, color=black, style=filled, fillcolor=paleturquoise1, label="DD:positionYDD2"];
-	dataDefn:acceleration	[shape=box, color=black, style=filled, fillcolor=paleturquoise1, label="DD:accelerationGDD"];
-	dataDefn:force	[shape=box, color=black, style=filled, fillcolor=paleturquoise1, label="DD:forceGDD"];
-
-	subgraph DD {
-	rank="same"
-	{dataDefn:velocity, dataDefn:p_x1, dataDefn:p_y1, dataDefn:p_x2, dataDefn:p_y2, dataDefn:acceleration, dataDefn:force}
-	}
-
-	theory:accelerationTM	[shape=box, color=black, style=filled, fillcolor=pink, label="TM:acceleration"];
-	theory:velocityTM	[shape=box, color=black, style=filled, fillcolor=pink, label="TM:velocity"];
-	theory:newtonSL	[shape=box, color=black, style=filled, fillcolor=pink, label="TM:NewtonSecLawMot"];
-
-	subgraph TM {
-	rank="same"
-	{theory:accelerationTM, theory:velocityTM, theory:newtonSL}
-	}
-
-	theory:v_x1	[shape=box, color=black, style=filled, fillcolor=palegreen, label="GD:velocityX1"];
-	theory:v_y1	[shape=box, color=black, style=filled, fillcolor=palegreen, label="GD:velocityY1"];
-	theory:v_x2	[shape=box, color=black, style=filled, fillcolor=palegreen, label="GD:velocityX2"];
-	theory:v_y2	[shape=box, color=black, style=filled, fillcolor=palegreen, label="GD:velocityY2"];
-	theory:a_x1	[shape=box, color=black, style=filled, fillcolor=palegreen, label="GD:accelerationX1"];
-	theory:a_y1	[shape=box, color=black, style=filled, fillcolor=palegreen, label="GD:accelerationY1"];
-	theory:a_x2	[shape=box, color=black, style=filled, fillcolor=palegreen, label="GD:accelerationX2"];
-	theory:a_y2	[shape=box, color=black, style=filled, fillcolor=palegreen, label="GD:accelerationY2"];
-	theory:xForce1	[shape=box, color=black, style=filled, fillcolor=palegreen, label="GD:xForce1"];
-	theory:yForce1	[shape=box, color=black, style=filled, fillcolor=palegreen, label="GD:yForce1"];
-	theory:xForce2	[shape=box, color=black, style=filled, fillcolor=palegreen, label="GD:xForce2"];
-	theory:yForce2	[shape=box, color=black, style=filled, fillcolor=palegreen, label="GD:yForce2"];
-
-	subgraph GD {
-	rank="same"
-	{theory:v_x1, theory:v_y1, theory:v_x2, theory:v_y2, theory:a_x1, theory:a_y1, theory:a_x2, theory:a_y2, theory:xForce1, theory:yForce1, theory:xForce2, theory:yForce2}
-	}
-
-	theory:angleIM1	[shape=box, color=black, style=filled, fillcolor=khaki1, label="IM:calOfAngle1"];
-	theory:angleIM2	[shape=box, color=black, style=filled, fillcolor=khaki1, label="IM:calOfAngle2"];
-
-	subgraph IM {
-	rank="same"
-	{theory:angleIM1, theory:angleIM2}
-	}
-
+digraph "refvsref" {
+    "theory:v_x1" -> "dataDefn:velocity";
+    "theory:v_x1" -> "dataDefn:p_x1";
+    "theory:v_y1" -> "dataDefn:velocity";
+    "theory:v_y1" -> "dataDefn:p_y1";
+    "theory:v_x2" -> "dataDefn:velocity";
+    "theory:v_x2" -> "dataDefn:p_x2";
+    "theory:v_y2" -> "dataDefn:velocity";
+    "theory:v_y2" -> "dataDefn:p_y2";
+    "theory:angleIM1" -> "theory:angleIM2";
+    "theory:angleIM2" -> "theory:a_x1";
+    "theory:angleIM2" -> "theory:a_y1";
+    "theory:angleIM2" -> "theory:a_x2";
+    "theory:angleIM2" -> "theory:a_y2";
+    "theory:angleIM2" -> "theory:xForce1";
+    "theory:angleIM2" -> "theory:yForce1";
+    "theory:angleIM2" -> "theory:xForce2";
+    "theory:angleIM2" -> "theory:yForce2";
+    "theory:angleIM2" -> "theory:angleIM1";
+    "theory:angleIM2" -> "theory:angleIM2";
+    "dataDefn:velocity" [shape=box, color=black, style=filled, fillcolor="paleturquoise1", label="DD:positionGDD"];
+    "dataDefn:p_x1" [shape=box, color=black, style=filled, fillcolor="paleturquoise1", label="DD:positionXDD1"];
+    "dataDefn:p_y1" [shape=box, color=black, style=filled, fillcolor="paleturquoise1", label="DD:positionYDD1"];
+    "dataDefn:p_x2" [shape=box, color=black, style=filled, fillcolor="paleturquoise1", label="DD:positionXDD2"];
+    "dataDefn:p_y2" [shape=box, color=black, style=filled, fillcolor="paleturquoise1", label="DD:positionYDD2"];
+    "dataDefn:acceleration" [shape=box, color=black, style=filled, fillcolor="paleturquoise1", label="DD:accelerationGDD"];
+    "dataDefn:force" [shape=box, color=black, style=filled, fillcolor="paleturquoise1", label="DD:forceGDD"];
+    subgraph "DD" {
+        rank="same";
+        "dataDefn:velocity" "dataDefn:p_x1" "dataDefn:p_y1" "dataDefn:p_x2" "dataDefn:p_y2" "dataDefn:acceleration" "dataDefn:force";
+    }
+    "theory:accelerationTM" [shape=box, color=black, style=filled, fillcolor="pink", label="TM:acceleration"];
+    "theory:velocityTM" [shape=box, color=black, style=filled, fillcolor="pink", label="TM:velocity"];
+    "theory:newtonSL" [shape=box, color=black, style=filled, fillcolor="pink", label="TM:NewtonSecLawMot"];
+    subgraph "TM" {
+        rank="same";
+        "theory:accelerationTM" "theory:velocityTM" "theory:newtonSL";
+    }
+    "theory:v_x1" [shape=box, color=black, style=filled, fillcolor="palegreen", label="GD:velocityX1"];
+    "theory:v_y1" [shape=box, color=black, style=filled, fillcolor="palegreen", label="GD:velocityY1"];
+    "theory:v_x2" [shape=box, color=black, style=filled, fillcolor="palegreen", label="GD:velocityX2"];
+    "theory:v_y2" [shape=box, color=black, style=filled, fillcolor="palegreen", label="GD:velocityY2"];
+    "theory:a_x1" [shape=box, color=black, style=filled, fillcolor="palegreen", label="GD:accelerationX1"];
+    "theory:a_y1" [shape=box, color=black, style=filled, fillcolor="palegreen", label="GD:accelerationY1"];
+    "theory:a_x2" [shape=box, color=black, style=filled, fillcolor="palegreen", label="GD:accelerationX2"];
+    "theory:a_y2" [shape=box, color=black, style=filled, fillcolor="palegreen", label="GD:accelerationY2"];
+    "theory:xForce1" [shape=box, color=black, style=filled, fillcolor="palegreen", label="GD:xForce1"];
+    "theory:yForce1" [shape=box, color=black, style=filled, fillcolor="palegreen", label="GD:yForce1"];
+    "theory:xForce2" [shape=box, color=black, style=filled, fillcolor="palegreen", label="GD:xForce2"];
+    "theory:yForce2" [shape=box, color=black, style=filled, fillcolor="palegreen", label="GD:yForce2"];
+    subgraph "GD" {
+        rank="same";
+        "theory:v_x1" "theory:v_y1" "theory:v_x2" "theory:v_y2" "theory:a_x1" "theory:a_y1" "theory:a_x2" "theory:a_y2" "theory:xForce1" "theory:yForce1" "theory:xForce2" "theory:yForce2";
+    }
+    "theory:angleIM1" [shape=box, color=black, style=filled, fillcolor="khaki1", label="IM:calOfAngle1"];
+    "theory:angleIM2" [shape=box, color=black, style=filled, fillcolor="khaki1", label="IM:calOfAngle2"];
+    subgraph "IM" {
+        rank="same";
+        "theory:angleIM1" "theory:angleIM2";
+    }
 }

--- a/code/stable/gamephysics/TraceyGraph/allvsall.dot
+++ b/code/stable/gamephysics/TraceyGraph/allvsall.dot
@@ -1,160 +1,142 @@
-digraph allvsall {
-	dataDefn:p_CM -> instance:assumpOT;
-	dataDefn:linearDisplacement -> instance:assumpOT;
-	dataDefn:linearVelocity -> instance:assumpOT;
-	dataDefn:linearAcceleration -> instance:assumpOT;
-	dataDefn:angularDisplacement -> instance:assumpOT;
-	dataDefn:angularDisplacement -> instance:assumpOD;
-	dataDefn:angularVelocity -> instance:assumpOT;
-	dataDefn:angularVelocity -> instance:assumpOD;
-	dataDefn:angularAcceleration -> instance:assumpOT;
-	dataDefn:angularAcceleration -> instance:assumpOD;
-	dataDefn:velocityB -> instance:assumpOT;
-	dataDefn:kEnergy -> instance:assumpOT;
-	dataDefn:kEnergy -> instance:assumpOD;
-	dataDefn:kEnergy -> instance:assumpDI;
-	dataDefn:v_iAB -> instance:assumpOT;
-	dataDefn:impulseV -> instance:assumpOT;
-	dataDefn:potEnergy -> instance:assumpOT;
-	dataDefn:potEnergy -> instance:assumpOD;
-	dataDefn:potEnergy -> instance:assumpDI;
-	dataDefn:momentOfInertia -> instance:assumpOT;
-	theory:newtonSLR -> instance:assumpOD;
-	theory:gravitationalAccel -> theory:force;
-	theory:impulseS -> instance:assumpOT;
-	theory:impulseS -> instance:assumpOD;
-	theory:impulseS -> instance:assumpAD;
-	theory:impulseS -> instance:assumpCT;
-	theory:accj -> instance:assumpOT;
-	theory:accj -> instance:assumpOD;
-	theory:accj -> instance:assumpDI;
-	theory:accj -> instance:assumpCAJI;
-	theory:accj -> dataDefn:p_CM;
-	theory:accj -> dataDefn:linearDisplacement;
-	theory:accj -> dataDefn:linearVelocity;
-	theory:accj -> dataDefn:linearAcceleration;
-	theory:accj -> theory:newtonSL;
-	theory:accj -> theory:gravitationalAccel;
-	theory:angAccj -> instance:assumpOT;
-	theory:angAccj -> instance:assumpOD;
-	theory:angAccj -> instance:assumpAD;
-	theory:angAccj -> dataDefn:angularDisplacement;
-	theory:angAccj -> dataDefn:angularVelocity;
-	theory:angAccj -> dataDefn:angularAcceleration;
-	theory:angAccj -> theory:newtonSLR;
-	theory:col2DIM -> instance:assumpOT;
-	theory:col2DIM -> instance:assumpOD;
-	theory:col2DIM -> instance:assumpAD;
-	theory:col2DIM -> instance:assumpCT;
-	theory:col2DIM -> instance:assumpDI;
-	theory:col2DIM -> instance:assumpCAJI;
-	theory:col2DIM -> dataDefn:p_CM;
-	theory:col2DIM -> theory:impulseS;
-	instance:lcEC -> instance:assumpCT;
-	instance:lcID -> instance:assumpDI;
-	instance:lcIJC -> instance:assumpCAJI;
-
-
-	instance:assumpOT	[shape=box, color=black, style=filled, fillcolor=mistyrose, label="A:assumpOT"];
-	instance:assumpOD	[shape=box, color=black, style=filled, fillcolor=mistyrose, label="A:assumpOD"];
-	instance:assumpCST	[shape=box, color=black, style=filled, fillcolor=mistyrose, label="A:assumpCST"];
-	instance:assumpAD	[shape=box, color=black, style=filled, fillcolor=mistyrose, label="A:assumpAD"];
-	instance:assumpCT	[shape=box, color=black, style=filled, fillcolor=mistyrose, label="A:assumpCT"];
-	instance:assumpDI	[shape=box, color=black, style=filled, fillcolor=mistyrose, label="A:assumpDI"];
-	instance:assumpCAJI	[shape=box, color=black, style=filled, fillcolor=mistyrose, label="A:assumpCAJI"];
-
-	subgraph A {
-	rank="same"
-	{instance:assumpOT, instance:assumpOD, instance:assumpCST, instance:assumpAD, instance:assumpCT, instance:assumpDI, instance:assumpCAJI}
-	}
-
-	dataDefn:p_CM	[shape=box, color=black, style=filled, fillcolor=paleturquoise1, label="DD:ctrOfMass"];
-	dataDefn:linearDisplacement	[shape=box, color=black, style=filled, fillcolor=paleturquoise1, label="DD:linDisp"];
-	dataDefn:linearVelocity	[shape=box, color=black, style=filled, fillcolor=paleturquoise1, label="DD:linVel"];
-	dataDefn:linearAcceleration	[shape=box, color=black, style=filled, fillcolor=paleturquoise1, label="DD:linAcc"];
-	dataDefn:angularDisplacement	[shape=box, color=black, style=filled, fillcolor=paleturquoise1, label="DD:angDisp"];
-	dataDefn:angularVelocity	[shape=box, color=black, style=filled, fillcolor=paleturquoise1, label="DD:angVel"];
-	dataDefn:angularAcceleration	[shape=box, color=black, style=filled, fillcolor=paleturquoise1, label="DD:angAccel"];
-	dataDefn:velocityB	[shape=box, color=black, style=filled, fillcolor=paleturquoise1, label="DD:chaslesThm"];
-	dataDefn:torque	[shape=box, color=black, style=filled, fillcolor=paleturquoise1, label="DD:torque"];
-	dataDefn:kEnergy	[shape=box, color=black, style=filled, fillcolor=paleturquoise1, label="DD:kEnergy"];
-	dataDefn:restitutionCoef	[shape=box, color=black, style=filled, fillcolor=paleturquoise1, label="DD:coeffRestitution"];
-	dataDefn:v_iAB	[shape=box, color=black, style=filled, fillcolor=paleturquoise1, label="DD:reVeInColl"];
-	dataDefn:impulseV	[shape=box, color=black, style=filled, fillcolor=paleturquoise1, label="DD:impulseV"];
-	dataDefn:potEnergy	[shape=box, color=black, style=filled, fillcolor=paleturquoise1, label="DD:potEnergy"];
-	dataDefn:momentOfInertia	[shape=box, color=black, style=filled, fillcolor=paleturquoise1, label="DD:momentOfInertia"];
-
-	subgraph DD {
-	rank="same"
-	{dataDefn:p_CM, dataDefn:linearDisplacement, dataDefn:linearVelocity, dataDefn:linearAcceleration, dataDefn:angularDisplacement, dataDefn:angularVelocity, dataDefn:angularAcceleration, dataDefn:velocityB, dataDefn:torque, dataDefn:kEnergy, dataDefn:restitutionCoef, dataDefn:v_iAB, dataDefn:impulseV, dataDefn:potEnergy, dataDefn:momentOfInertia}
-	}
-
-	theory:newtonSL	[shape=box, color=black, style=filled, fillcolor=pink, label="TM:NewtonSecLawMot"];
-	theory:force1	[shape=box, color=black, style=filled, fillcolor=pink, label="TM:NewtonThirdLawMot"];
-	theory:force	[shape=box, color=black, style=filled, fillcolor=pink, label="TM:UniversalGravLaw"];
-	theory:newtonSLR	[shape=box, color=black, style=filled, fillcolor=pink, label="TM:NewtonSecLawRotMot"];
-
-	subgraph TM {
-	rank="same"
-	{theory:newtonSL, theory:force1, theory:force, theory:newtonSLR}
-	}
-
-	theory:gravitationalAccel	[shape=box, color=black, style=filled, fillcolor=palegreen, label="GD:accelGravity"];
-	theory:impulseS	[shape=box, color=black, style=filled, fillcolor=palegreen, label="GD:impulse"];
-
-	subgraph GD {
-	rank="same"
-	{theory:gravitationalAccel, theory:impulseS}
-	}
-
-	theory:accj	[shape=box, color=black, style=filled, fillcolor=khaki1, label="IM:transMot"];
-	theory:angAccj	[shape=box, color=black, style=filled, fillcolor=khaki1, label="IM:rotMot"];
-	theory:col2DIM	[shape=box, color=black, style=filled, fillcolor=khaki1, label="IM:col2D"];
-
-	subgraph IM {
-	rank="same"
-	{theory:accj, theory:angAccj, theory:col2DIM}
-	}
-
-	instance:simSpace	[shape=box, color=black, style=filled, fillcolor=ivory, label="FR:simSpace"];
-	instance:inputInitialConds	[shape=box, color=black, style=filled, fillcolor=ivory, label="FR:inputInitialConds"];
-	instance:inputSurfaceProps	[shape=box, color=black, style=filled, fillcolor=ivory, label="FR:inputSurfaceProps"];
-	instance:verifyPhysCons	[shape=box, color=black, style=filled, fillcolor=ivory, label="FR:verifyPhysCons"];
-	instance:calcTransOverTime	[shape=box, color=black, style=filled, fillcolor=ivory, label="FR:calcTransOverTime"];
-	instance:calcRotOverTime	[shape=box, color=black, style=filled, fillcolor=ivory, label="FR:calcRotOverTime"];
-	instance:deterColls	[shape=box, color=black, style=filled, fillcolor=ivory, label="FR:deterColls"];
-	instance:deterCollRespOverTime	[shape=box, color=black, style=filled, fillcolor=ivory, label="FR:deterCollRespOverTime"];
-	instance:performance	[shape=box, color=black, style=filled, fillcolor=ivory, label="NFR:performance"];
-	instance:correctness	[shape=box, color=black, style=filled, fillcolor=ivory, label="NFR:correctness"];
-	instance:usability	[shape=box, color=black, style=filled, fillcolor=ivory, label="NFR:usability"];
-	instance:understandability	[shape=box, color=black, style=filled, fillcolor=ivory, label="NFR:understandability"];
-	instance:maintainability	[shape=box, color=black, style=filled, fillcolor=ivory, label="NFR:maintainability"];
-
-	subgraph FR {
-	rank="same"
-	{instance:simSpace, instance:inputInitialConds, instance:inputSurfaceProps, instance:verifyPhysCons, instance:calcTransOverTime, instance:calcRotOverTime, instance:deterColls, instance:deterCollRespOverTime, instance:performance, instance:correctness, instance:usability, instance:understandability, instance:maintainability}
-	}
-
-	instance:linearGS	[shape=box, color=black, style=filled, fillcolor=darkgoldenrod1, label="GS:linearGS"];
-	instance:angularGS	[shape=box, color=black, style=filled, fillcolor=darkgoldenrod1, label="GS:angularGS"];
-
-	subgraph GS {
-	rank="same"
-	{instance:linearGS, instance:angularGS}
-	}
-
-	instance:lcVODES	[shape=box, color=black, style=filled, fillcolor=lavender, label="LC:lcVODES"];
-	instance:lcEC	[shape=box, color=black, style=filled, fillcolor=lavender, label="LC:lcEC"];
-	instance:lcID	[shape=box, color=black, style=filled, fillcolor=lavender, label="LC:lcID"];
-	instance:lcIJC	[shape=box, color=black, style=filled, fillcolor=lavender, label="LC:lcIJC"];
-	instance:ucSRB	[shape=box, color=black, style=filled, fillcolor=lavender, label="UC:ucSRB"];
-	instance:ucEI	[shape=box, color=black, style=filled, fillcolor=lavender, label="UC:ucEI"];
-	instance:ucCCS	[shape=box, color=black, style=filled, fillcolor=lavender, label="UC:ucCCS"];
-	instance:ucORB	[shape=box, color=black, style=filled, fillcolor=lavender, label="UC:ucORB"];
-
-	subgraph LC {
-	rank="same"
-	{instance:lcVODES, instance:lcEC, instance:lcID, instance:lcIJC, instance:ucSRB, instance:ucEI, instance:ucCCS, instance:ucORB}
-	}
-
+digraph "allvsall" {
+    "dataDefn:p_CM" -> "instance:assumpOT";
+    "dataDefn:linearDisplacement" -> "instance:assumpOT";
+    "dataDefn:linearVelocity" -> "instance:assumpOT";
+    "dataDefn:linearAcceleration" -> "instance:assumpOT";
+    "dataDefn:angularDisplacement" -> "instance:assumpOT";
+    "dataDefn:angularDisplacement" -> "instance:assumpOD";
+    "dataDefn:angularVelocity" -> "instance:assumpOT";
+    "dataDefn:angularVelocity" -> "instance:assumpOD";
+    "dataDefn:angularAcceleration" -> "instance:assumpOT";
+    "dataDefn:angularAcceleration" -> "instance:assumpOD";
+    "dataDefn:velocityB" -> "instance:assumpOT";
+    "dataDefn:kEnergy" -> "instance:assumpOT";
+    "dataDefn:kEnergy" -> "instance:assumpOD";
+    "dataDefn:kEnergy" -> "instance:assumpDI";
+    "dataDefn:v_i^AB" -> "instance:assumpOT";
+    "dataDefn:impulseV" -> "instance:assumpOT";
+    "dataDefn:potEnergy" -> "instance:assumpOT";
+    "dataDefn:potEnergy" -> "instance:assumpOD";
+    "dataDefn:potEnergy" -> "instance:assumpDI";
+    "dataDefn:momentOfInertia" -> "instance:assumpOT";
+    "theory:newtonSLR" -> "instance:assumpOD";
+    "theory:gravitationalAccel" -> "theory:force";
+    "theory:impulseS" -> "instance:assumpOT";
+    "theory:impulseS" -> "instance:assumpOD";
+    "theory:impulseS" -> "instance:assumpAD";
+    "theory:impulseS" -> "instance:assumpCT";
+    "theory:accj" -> "instance:assumpOT";
+    "theory:accj" -> "instance:assumpOD";
+    "theory:accj" -> "instance:assumpDI";
+    "theory:accj" -> "instance:assumpCAJI";
+    "theory:accj" -> "dataDefn:p_CM";
+    "theory:accj" -> "dataDefn:linearDisplacement";
+    "theory:accj" -> "dataDefn:linearVelocity";
+    "theory:accj" -> "dataDefn:linearAcceleration";
+    "theory:accj" -> "theory:newtonSL";
+    "theory:accj" -> "theory:gravitationalAccel";
+    "theory:angAccj" -> "instance:assumpOT";
+    "theory:angAccj" -> "instance:assumpOD";
+    "theory:angAccj" -> "instance:assumpAD";
+    "theory:angAccj" -> "dataDefn:angularDisplacement";
+    "theory:angAccj" -> "dataDefn:angularVelocity";
+    "theory:angAccj" -> "dataDefn:angularAcceleration";
+    "theory:angAccj" -> "theory:newtonSLR";
+    "theory:col2DIM" -> "instance:assumpOT";
+    "theory:col2DIM" -> "instance:assumpOD";
+    "theory:col2DIM" -> "instance:assumpAD";
+    "theory:col2DIM" -> "instance:assumpCT";
+    "theory:col2DIM" -> "instance:assumpDI";
+    "theory:col2DIM" -> "instance:assumpCAJI";
+    "theory:col2DIM" -> "dataDefn:p_CM";
+    "theory:col2DIM" -> "theory:impulseS";
+    "instance:lcEC" -> "instance:assumpCT";
+    "instance:lcID" -> "instance:assumpDI";
+    "instance:lcIJC" -> "instance:assumpCAJI";
+    "instance:assumpOT" [shape=box, color=black, style=filled, fillcolor="mistyrose", label="A:assumpOT"];
+    "instance:assumpOD" [shape=box, color=black, style=filled, fillcolor="mistyrose", label="A:assumpOD"];
+    "instance:assumpCST" [shape=box, color=black, style=filled, fillcolor="mistyrose", label="A:assumpCST"];
+    "instance:assumpAD" [shape=box, color=black, style=filled, fillcolor="mistyrose", label="A:assumpAD"];
+    "instance:assumpCT" [shape=box, color=black, style=filled, fillcolor="mistyrose", label="A:assumpCT"];
+    "instance:assumpDI" [shape=box, color=black, style=filled, fillcolor="mistyrose", label="A:assumpDI"];
+    "instance:assumpCAJI" [shape=box, color=black, style=filled, fillcolor="mistyrose", label="A:assumpCAJI"];
+    subgraph "A" {
+        rank="same";
+        "instance:assumpOT" "instance:assumpOD" "instance:assumpCST" "instance:assumpAD" "instance:assumpCT" "instance:assumpDI" "instance:assumpCAJI";
+    }
+    "dataDefn:p_CM" [shape=box, color=black, style=filled, fillcolor="paleturquoise1", label="DD:ctrOfMass"];
+    "dataDefn:linearDisplacement" [shape=box, color=black, style=filled, fillcolor="paleturquoise1", label="DD:linDisp"];
+    "dataDefn:linearVelocity" [shape=box, color=black, style=filled, fillcolor="paleturquoise1", label="DD:linVel"];
+    "dataDefn:linearAcceleration" [shape=box, color=black, style=filled, fillcolor="paleturquoise1", label="DD:linAcc"];
+    "dataDefn:angularDisplacement" [shape=box, color=black, style=filled, fillcolor="paleturquoise1", label="DD:angDisp"];
+    "dataDefn:angularVelocity" [shape=box, color=black, style=filled, fillcolor="paleturquoise1", label="DD:angVel"];
+    "dataDefn:angularAcceleration" [shape=box, color=black, style=filled, fillcolor="paleturquoise1", label="DD:angAccel"];
+    "dataDefn:velocityB" [shape=box, color=black, style=filled, fillcolor="paleturquoise1", label="DD:chaslesThm"];
+    "dataDefn:torque" [shape=box, color=black, style=filled, fillcolor="paleturquoise1", label="DD:torque"];
+    "dataDefn:kEnergy" [shape=box, color=black, style=filled, fillcolor="paleturquoise1", label="DD:kEnergy"];
+    "dataDefn:restitutionCoef" [shape=box, color=black, style=filled, fillcolor="paleturquoise1", label="DD:coeffRestitution"];
+    "dataDefn:v_i^AB" [shape=box, color=black, style=filled, fillcolor="paleturquoise1", label="DD:reVeInColl"];
+    "dataDefn:impulseV" [shape=box, color=black, style=filled, fillcolor="paleturquoise1", label="DD:impulseV"];
+    "dataDefn:potEnergy" [shape=box, color=black, style=filled, fillcolor="paleturquoise1", label="DD:potEnergy"];
+    "dataDefn:momentOfInertia" [shape=box, color=black, style=filled, fillcolor="paleturquoise1", label="DD:momentOfInertia"];
+    subgraph "DD" {
+        rank="same";
+        "dataDefn:p_CM" "dataDefn:linearDisplacement" "dataDefn:linearVelocity" "dataDefn:linearAcceleration" "dataDefn:angularDisplacement" "dataDefn:angularVelocity" "dataDefn:angularAcceleration" "dataDefn:velocityB" "dataDefn:torque" "dataDefn:kEnergy" "dataDefn:restitutionCoef" "dataDefn:v_i^AB" "dataDefn:impulseV" "dataDefn:potEnergy" "dataDefn:momentOfInertia";
+    }
+    "theory:newtonSL" [shape=box, color=black, style=filled, fillcolor="pink", label="TM:NewtonSecLawMot"];
+    "theory:force1" [shape=box, color=black, style=filled, fillcolor="pink", label="TM:NewtonThirdLawMot"];
+    "theory:force" [shape=box, color=black, style=filled, fillcolor="pink", label="TM:UniversalGravLaw"];
+    "theory:newtonSLR" [shape=box, color=black, style=filled, fillcolor="pink", label="TM:NewtonSecLawRotMot"];
+    subgraph "TM" {
+        rank="same";
+        "theory:newtonSL" "theory:force1" "theory:force" "theory:newtonSLR";
+    }
+    "theory:gravitationalAccel" [shape=box, color=black, style=filled, fillcolor="palegreen", label="GD:accelGravity"];
+    "theory:impulseS" [shape=box, color=black, style=filled, fillcolor="palegreen", label="GD:impulse"];
+    subgraph "GD" {
+        rank="same";
+        "theory:gravitationalAccel" "theory:impulseS";
+    }
+    "theory:accj" [shape=box, color=black, style=filled, fillcolor="khaki1", label="IM:transMot"];
+    "theory:angAccj" [shape=box, color=black, style=filled, fillcolor="khaki1", label="IM:rotMot"];
+    "theory:col2DIM" [shape=box, color=black, style=filled, fillcolor="khaki1", label="IM:col2D"];
+    subgraph "IM" {
+        rank="same";
+        "theory:accj" "theory:angAccj" "theory:col2DIM";
+    }
+    "instance:simSpace" [shape=box, color=black, style=filled, fillcolor="ivory", label="FR:simSpace"];
+    "instance:inputInitialConds" [shape=box, color=black, style=filled, fillcolor="ivory", label="FR:inputInitialConds"];
+    "instance:inputSurfaceProps" [shape=box, color=black, style=filled, fillcolor="ivory", label="FR:inputSurfaceProps"];
+    "instance:verifyPhysCons" [shape=box, color=black, style=filled, fillcolor="ivory", label="FR:verifyPhysCons"];
+    "instance:calcTransOverTime" [shape=box, color=black, style=filled, fillcolor="ivory", label="FR:calcTransOverTime"];
+    "instance:calcRotOverTime" [shape=box, color=black, style=filled, fillcolor="ivory", label="FR:calcRotOverTime"];
+    "instance:deterColls" [shape=box, color=black, style=filled, fillcolor="ivory", label="FR:deterColls"];
+    "instance:deterCollRespOverTime" [shape=box, color=black, style=filled, fillcolor="ivory", label="FR:deterCollRespOverTime"];
+    "instance:performance" [shape=box, color=black, style=filled, fillcolor="ivory", label="NFR:performance"];
+    "instance:correctness" [shape=box, color=black, style=filled, fillcolor="ivory", label="NFR:correctness"];
+    "instance:usability" [shape=box, color=black, style=filled, fillcolor="ivory", label="NFR:usability"];
+    "instance:understandability" [shape=box, color=black, style=filled, fillcolor="ivory", label="NFR:understandability"];
+    "instance:maintainability" [shape=box, color=black, style=filled, fillcolor="ivory", label="NFR:maintainability"];
+    subgraph "FR" {
+        rank="same";
+        "instance:simSpace" "instance:inputInitialConds" "instance:inputSurfaceProps" "instance:verifyPhysCons" "instance:calcTransOverTime" "instance:calcRotOverTime" "instance:deterColls" "instance:deterCollRespOverTime" "instance:performance" "instance:correctness" "instance:usability" "instance:understandability" "instance:maintainability";
+    }
+    "instance:linearGS" [shape=box, color=black, style=filled, fillcolor="darkgoldenrod1", label="GS:linearGS"];
+    "instance:angularGS" [shape=box, color=black, style=filled, fillcolor="darkgoldenrod1", label="GS:angularGS"];
+    subgraph "GS" {
+        rank="same";
+        "instance:linearGS" "instance:angularGS";
+    }
+    "instance:lcVODES" [shape=box, color=black, style=filled, fillcolor="lavender", label="LC:lcVODES"];
+    "instance:lcEC" [shape=box, color=black, style=filled, fillcolor="lavender", label="LC:lcEC"];
+    "instance:lcID" [shape=box, color=black, style=filled, fillcolor="lavender", label="LC:lcID"];
+    "instance:lcIJC" [shape=box, color=black, style=filled, fillcolor="lavender", label="LC:lcIJC"];
+    "instance:ucSRB" [shape=box, color=black, style=filled, fillcolor="lavender", label="UC:ucSRB"];
+    "instance:ucEI" [shape=box, color=black, style=filled, fillcolor="lavender", label="UC:ucEI"];
+    "instance:ucCCS" [shape=box, color=black, style=filled, fillcolor="lavender", label="UC:ucCCS"];
+    "instance:ucORB" [shape=box, color=black, style=filled, fillcolor="lavender", label="UC:ucORB"];
+    subgraph "LC" {
+        rank="same";
+        "instance:lcVODES" "instance:lcEC" "instance:lcID" "instance:lcIJC" "instance:ucSRB" "instance:ucEI" "instance:ucCCS" "instance:ucORB";
+    }
 }

--- a/code/stable/gamephysics/TraceyGraph/allvsr.dot
+++ b/code/stable/gamephysics/TraceyGraph/allvsr.dot
@@ -1,92 +1,76 @@
-digraph allvsr {
-
-
-	instance:assumpOT	[shape=box, color=black, style=filled, fillcolor=mistyrose, label="A:assumpOT"];
-	instance:assumpOD	[shape=box, color=black, style=filled, fillcolor=mistyrose, label="A:assumpOD"];
-	instance:assumpCST	[shape=box, color=black, style=filled, fillcolor=mistyrose, label="A:assumpCST"];
-	instance:assumpAD	[shape=box, color=black, style=filled, fillcolor=mistyrose, label="A:assumpAD"];
-	instance:assumpCT	[shape=box, color=black, style=filled, fillcolor=mistyrose, label="A:assumpCT"];
-	instance:assumpDI	[shape=box, color=black, style=filled, fillcolor=mistyrose, label="A:assumpDI"];
-	instance:assumpCAJI	[shape=box, color=black, style=filled, fillcolor=mistyrose, label="A:assumpCAJI"];
-
-	subgraph A {
-	rank="same"
-	{instance:assumpOT, instance:assumpOD, instance:assumpCST, instance:assumpAD, instance:assumpCT, instance:assumpDI, instance:assumpCAJI}
-	}
-
-	dataDefn:p_CM	[shape=box, color=black, style=filled, fillcolor=paleturquoise1, label="DD:ctrOfMass"];
-	dataDefn:linearDisplacement	[shape=box, color=black, style=filled, fillcolor=paleturquoise1, label="DD:linDisp"];
-	dataDefn:linearVelocity	[shape=box, color=black, style=filled, fillcolor=paleturquoise1, label="DD:linVel"];
-	dataDefn:linearAcceleration	[shape=box, color=black, style=filled, fillcolor=paleturquoise1, label="DD:linAcc"];
-	dataDefn:angularDisplacement	[shape=box, color=black, style=filled, fillcolor=paleturquoise1, label="DD:angDisp"];
-	dataDefn:angularVelocity	[shape=box, color=black, style=filled, fillcolor=paleturquoise1, label="DD:angVel"];
-	dataDefn:angularAcceleration	[shape=box, color=black, style=filled, fillcolor=paleturquoise1, label="DD:angAccel"];
-	dataDefn:velocityB	[shape=box, color=black, style=filled, fillcolor=paleturquoise1, label="DD:chaslesThm"];
-	dataDefn:torque	[shape=box, color=black, style=filled, fillcolor=paleturquoise1, label="DD:torque"];
-	dataDefn:kEnergy	[shape=box, color=black, style=filled, fillcolor=paleturquoise1, label="DD:kEnergy"];
-	dataDefn:restitutionCoef	[shape=box, color=black, style=filled, fillcolor=paleturquoise1, label="DD:coeffRestitution"];
-	dataDefn:v_iAB	[shape=box, color=black, style=filled, fillcolor=paleturquoise1, label="DD:reVeInColl"];
-	dataDefn:impulseV	[shape=box, color=black, style=filled, fillcolor=paleturquoise1, label="DD:impulseV"];
-	dataDefn:potEnergy	[shape=box, color=black, style=filled, fillcolor=paleturquoise1, label="DD:potEnergy"];
-	dataDefn:momentOfInertia	[shape=box, color=black, style=filled, fillcolor=paleturquoise1, label="DD:momentOfInertia"];
-
-	subgraph DD {
-	rank="same"
-	{dataDefn:p_CM, dataDefn:linearDisplacement, dataDefn:linearVelocity, dataDefn:linearAcceleration, dataDefn:angularDisplacement, dataDefn:angularVelocity, dataDefn:angularAcceleration, dataDefn:velocityB, dataDefn:torque, dataDefn:kEnergy, dataDefn:restitutionCoef, dataDefn:v_iAB, dataDefn:impulseV, dataDefn:potEnergy, dataDefn:momentOfInertia}
-	}
-
-	theory:newtonSL	[shape=box, color=black, style=filled, fillcolor=pink, label="TM:NewtonSecLawMot"];
-	theory:force1	[shape=box, color=black, style=filled, fillcolor=pink, label="TM:NewtonThirdLawMot"];
-	theory:force	[shape=box, color=black, style=filled, fillcolor=pink, label="TM:UniversalGravLaw"];
-	theory:newtonSLR	[shape=box, color=black, style=filled, fillcolor=pink, label="TM:NewtonSecLawRotMot"];
-
-	subgraph TM {
-	rank="same"
-	{theory:newtonSL, theory:force1, theory:force, theory:newtonSLR}
-	}
-
-	theory:gravitationalAccel	[shape=box, color=black, style=filled, fillcolor=palegreen, label="GD:accelGravity"];
-	theory:impulseS	[shape=box, color=black, style=filled, fillcolor=palegreen, label="GD:impulse"];
-
-	subgraph GD {
-	rank="same"
-	{theory:gravitationalAccel, theory:impulseS}
-	}
-
-	theory:accj	[shape=box, color=black, style=filled, fillcolor=khaki1, label="IM:transMot"];
-	theory:angAccj	[shape=box, color=black, style=filled, fillcolor=khaki1, label="IM:rotMot"];
-	theory:col2DIM	[shape=box, color=black, style=filled, fillcolor=khaki1, label="IM:col2D"];
-
-	subgraph IM {
-	rank="same"
-	{theory:accj, theory:angAccj, theory:col2DIM}
-	}
-
-	instance:simSpace	[shape=box, color=black, style=filled, fillcolor=ivory, label="FR:simSpace"];
-	instance:inputInitialConds	[shape=box, color=black, style=filled, fillcolor=ivory, label="FR:inputInitialConds"];
-	instance:inputSurfaceProps	[shape=box, color=black, style=filled, fillcolor=ivory, label="FR:inputSurfaceProps"];
-	instance:verifyPhysCons	[shape=box, color=black, style=filled, fillcolor=ivory, label="FR:verifyPhysCons"];
-	instance:calcTransOverTime	[shape=box, color=black, style=filled, fillcolor=ivory, label="FR:calcTransOverTime"];
-	instance:calcRotOverTime	[shape=box, color=black, style=filled, fillcolor=ivory, label="FR:calcRotOverTime"];
-	instance:deterColls	[shape=box, color=black, style=filled, fillcolor=ivory, label="FR:deterColls"];
-	instance:deterCollRespOverTime	[shape=box, color=black, style=filled, fillcolor=ivory, label="FR:deterCollRespOverTime"];
-	instance:performance	[shape=box, color=black, style=filled, fillcolor=ivory, label="NFR:performance"];
-	instance:correctness	[shape=box, color=black, style=filled, fillcolor=ivory, label="NFR:correctness"];
-	instance:usability	[shape=box, color=black, style=filled, fillcolor=ivory, label="NFR:usability"];
-	instance:understandability	[shape=box, color=black, style=filled, fillcolor=ivory, label="NFR:understandability"];
-	instance:maintainability	[shape=box, color=black, style=filled, fillcolor=ivory, label="NFR:maintainability"];
-
-	subgraph FR {
-	rank="same"
-	{instance:simSpace, instance:inputInitialConds, instance:inputSurfaceProps, instance:verifyPhysCons, instance:calcTransOverTime, instance:calcRotOverTime, instance:deterColls, instance:deterCollRespOverTime, instance:performance, instance:correctness, instance:usability, instance:understandability, instance:maintainability}
-	}
-
-	instance:linearGS	[shape=box, color=black, style=filled, fillcolor=darkgoldenrod1, label="GS:linearGS"];
-	instance:angularGS	[shape=box, color=black, style=filled, fillcolor=darkgoldenrod1, label="GS:angularGS"];
-
-	subgraph GS {
-	rank="same"
-	{instance:linearGS, instance:angularGS}
-	}
-
+digraph "allvsr" {
+    "instance:assumpOT" [shape=box, color=black, style=filled, fillcolor="mistyrose", label="A:assumpOT"];
+    "instance:assumpOD" [shape=box, color=black, style=filled, fillcolor="mistyrose", label="A:assumpOD"];
+    "instance:assumpCST" [shape=box, color=black, style=filled, fillcolor="mistyrose", label="A:assumpCST"];
+    "instance:assumpAD" [shape=box, color=black, style=filled, fillcolor="mistyrose", label="A:assumpAD"];
+    "instance:assumpCT" [shape=box, color=black, style=filled, fillcolor="mistyrose", label="A:assumpCT"];
+    "instance:assumpDI" [shape=box, color=black, style=filled, fillcolor="mistyrose", label="A:assumpDI"];
+    "instance:assumpCAJI" [shape=box, color=black, style=filled, fillcolor="mistyrose", label="A:assumpCAJI"];
+    subgraph "A" {
+        rank="same";
+        "instance:assumpOT" "instance:assumpOD" "instance:assumpCST" "instance:assumpAD" "instance:assumpCT" "instance:assumpDI" "instance:assumpCAJI";
+    }
+    "dataDefn:p_CM" [shape=box, color=black, style=filled, fillcolor="paleturquoise1", label="DD:ctrOfMass"];
+    "dataDefn:linearDisplacement" [shape=box, color=black, style=filled, fillcolor="paleturquoise1", label="DD:linDisp"];
+    "dataDefn:linearVelocity" [shape=box, color=black, style=filled, fillcolor="paleturquoise1", label="DD:linVel"];
+    "dataDefn:linearAcceleration" [shape=box, color=black, style=filled, fillcolor="paleturquoise1", label="DD:linAcc"];
+    "dataDefn:angularDisplacement" [shape=box, color=black, style=filled, fillcolor="paleturquoise1", label="DD:angDisp"];
+    "dataDefn:angularVelocity" [shape=box, color=black, style=filled, fillcolor="paleturquoise1", label="DD:angVel"];
+    "dataDefn:angularAcceleration" [shape=box, color=black, style=filled, fillcolor="paleturquoise1", label="DD:angAccel"];
+    "dataDefn:velocityB" [shape=box, color=black, style=filled, fillcolor="paleturquoise1", label="DD:chaslesThm"];
+    "dataDefn:torque" [shape=box, color=black, style=filled, fillcolor="paleturquoise1", label="DD:torque"];
+    "dataDefn:kEnergy" [shape=box, color=black, style=filled, fillcolor="paleturquoise1", label="DD:kEnergy"];
+    "dataDefn:restitutionCoef" [shape=box, color=black, style=filled, fillcolor="paleturquoise1", label="DD:coeffRestitution"];
+    "dataDefn:v_i^AB" [shape=box, color=black, style=filled, fillcolor="paleturquoise1", label="DD:reVeInColl"];
+    "dataDefn:impulseV" [shape=box, color=black, style=filled, fillcolor="paleturquoise1", label="DD:impulseV"];
+    "dataDefn:potEnergy" [shape=box, color=black, style=filled, fillcolor="paleturquoise1", label="DD:potEnergy"];
+    "dataDefn:momentOfInertia" [shape=box, color=black, style=filled, fillcolor="paleturquoise1", label="DD:momentOfInertia"];
+    subgraph "DD" {
+        rank="same";
+        "dataDefn:p_CM" "dataDefn:linearDisplacement" "dataDefn:linearVelocity" "dataDefn:linearAcceleration" "dataDefn:angularDisplacement" "dataDefn:angularVelocity" "dataDefn:angularAcceleration" "dataDefn:velocityB" "dataDefn:torque" "dataDefn:kEnergy" "dataDefn:restitutionCoef" "dataDefn:v_i^AB" "dataDefn:impulseV" "dataDefn:potEnergy" "dataDefn:momentOfInertia";
+    }
+    "theory:newtonSL" [shape=box, color=black, style=filled, fillcolor="pink", label="TM:NewtonSecLawMot"];
+    "theory:force1" [shape=box, color=black, style=filled, fillcolor="pink", label="TM:NewtonThirdLawMot"];
+    "theory:force" [shape=box, color=black, style=filled, fillcolor="pink", label="TM:UniversalGravLaw"];
+    "theory:newtonSLR" [shape=box, color=black, style=filled, fillcolor="pink", label="TM:NewtonSecLawRotMot"];
+    subgraph "TM" {
+        rank="same";
+        "theory:newtonSL" "theory:force1" "theory:force" "theory:newtonSLR";
+    }
+    "theory:gravitationalAccel" [shape=box, color=black, style=filled, fillcolor="palegreen", label="GD:accelGravity"];
+    "theory:impulseS" [shape=box, color=black, style=filled, fillcolor="palegreen", label="GD:impulse"];
+    subgraph "GD" {
+        rank="same";
+        "theory:gravitationalAccel" "theory:impulseS";
+    }
+    "theory:accj" [shape=box, color=black, style=filled, fillcolor="khaki1", label="IM:transMot"];
+    "theory:angAccj" [shape=box, color=black, style=filled, fillcolor="khaki1", label="IM:rotMot"];
+    "theory:col2DIM" [shape=box, color=black, style=filled, fillcolor="khaki1", label="IM:col2D"];
+    subgraph "IM" {
+        rank="same";
+        "theory:accj" "theory:angAccj" "theory:col2DIM";
+    }
+    "instance:simSpace" [shape=box, color=black, style=filled, fillcolor="ivory", label="FR:simSpace"];
+    "instance:inputInitialConds" [shape=box, color=black, style=filled, fillcolor="ivory", label="FR:inputInitialConds"];
+    "instance:inputSurfaceProps" [shape=box, color=black, style=filled, fillcolor="ivory", label="FR:inputSurfaceProps"];
+    "instance:verifyPhysCons" [shape=box, color=black, style=filled, fillcolor="ivory", label="FR:verifyPhysCons"];
+    "instance:calcTransOverTime" [shape=box, color=black, style=filled, fillcolor="ivory", label="FR:calcTransOverTime"];
+    "instance:calcRotOverTime" [shape=box, color=black, style=filled, fillcolor="ivory", label="FR:calcRotOverTime"];
+    "instance:deterColls" [shape=box, color=black, style=filled, fillcolor="ivory", label="FR:deterColls"];
+    "instance:deterCollRespOverTime" [shape=box, color=black, style=filled, fillcolor="ivory", label="FR:deterCollRespOverTime"];
+    "instance:performance" [shape=box, color=black, style=filled, fillcolor="ivory", label="NFR:performance"];
+    "instance:correctness" [shape=box, color=black, style=filled, fillcolor="ivory", label="NFR:correctness"];
+    "instance:usability" [shape=box, color=black, style=filled, fillcolor="ivory", label="NFR:usability"];
+    "instance:understandability" [shape=box, color=black, style=filled, fillcolor="ivory", label="NFR:understandability"];
+    "instance:maintainability" [shape=box, color=black, style=filled, fillcolor="ivory", label="NFR:maintainability"];
+    subgraph "FR" {
+        rank="same";
+        "instance:simSpace" "instance:inputInitialConds" "instance:inputSurfaceProps" "instance:verifyPhysCons" "instance:calcTransOverTime" "instance:calcRotOverTime" "instance:deterColls" "instance:deterCollRespOverTime" "instance:performance" "instance:correctness" "instance:usability" "instance:understandability" "instance:maintainability";
+    }
+    "instance:linearGS" [shape=box, color=black, style=filled, fillcolor="darkgoldenrod1", label="GS:linearGS"];
+    "instance:angularGS" [shape=box, color=black, style=filled, fillcolor="darkgoldenrod1", label="GS:angularGS"];
+    subgraph "GS" {
+        rank="same";
+        "instance:linearGS" "instance:angularGS";
+    }
 }

--- a/code/stable/gamephysics/TraceyGraph/avsa.dot
+++ b/code/stable/gamephysics/TraceyGraph/avsa.dot
@@ -1,17 +1,13 @@
-digraph avsa {
-
-
-	instance:assumpOT	[shape=box, color=black, style=filled, fillcolor=mistyrose, label="A:assumpOT"];
-	instance:assumpOD	[shape=box, color=black, style=filled, fillcolor=mistyrose, label="A:assumpOD"];
-	instance:assumpCST	[shape=box, color=black, style=filled, fillcolor=mistyrose, label="A:assumpCST"];
-	instance:assumpAD	[shape=box, color=black, style=filled, fillcolor=mistyrose, label="A:assumpAD"];
-	instance:assumpCT	[shape=box, color=black, style=filled, fillcolor=mistyrose, label="A:assumpCT"];
-	instance:assumpDI	[shape=box, color=black, style=filled, fillcolor=mistyrose, label="A:assumpDI"];
-	instance:assumpCAJI	[shape=box, color=black, style=filled, fillcolor=mistyrose, label="A:assumpCAJI"];
-
-	subgraph A {
-	rank="same"
-	{instance:assumpOT, instance:assumpOD, instance:assumpCST, instance:assumpAD, instance:assumpCT, instance:assumpDI, instance:assumpCAJI}
-	}
-
+digraph "avsa" {
+    "instance:assumpOT" [shape=box, color=black, style=filled, fillcolor="mistyrose", label="A:assumpOT"];
+    "instance:assumpOD" [shape=box, color=black, style=filled, fillcolor="mistyrose", label="A:assumpOD"];
+    "instance:assumpCST" [shape=box, color=black, style=filled, fillcolor="mistyrose", label="A:assumpCST"];
+    "instance:assumpAD" [shape=box, color=black, style=filled, fillcolor="mistyrose", label="A:assumpAD"];
+    "instance:assumpCT" [shape=box, color=black, style=filled, fillcolor="mistyrose", label="A:assumpCT"];
+    "instance:assumpDI" [shape=box, color=black, style=filled, fillcolor="mistyrose", label="A:assumpDI"];
+    "instance:assumpCAJI" [shape=box, color=black, style=filled, fillcolor="mistyrose", label="A:assumpCAJI"];
+    subgraph "A" {
+        rank="same";
+        "instance:assumpOT" "instance:assumpOD" "instance:assumpCST" "instance:assumpAD" "instance:assumpCT" "instance:assumpDI" "instance:assumpCAJI";
+    }
 }

--- a/code/stable/gamephysics/TraceyGraph/avsall.dot
+++ b/code/stable/gamephysics/TraceyGraph/avsall.dot
@@ -1,139 +1,123 @@
-digraph avsall {
-	dataDefn:p_CM -> instance:assumpOT;
-	dataDefn:linearDisplacement -> instance:assumpOT;
-	dataDefn:linearVelocity -> instance:assumpOT;
-	dataDefn:linearAcceleration -> instance:assumpOT;
-	dataDefn:angularDisplacement -> instance:assumpOT;
-	dataDefn:angularDisplacement -> instance:assumpOD;
-	dataDefn:angularVelocity -> instance:assumpOT;
-	dataDefn:angularVelocity -> instance:assumpOD;
-	dataDefn:angularAcceleration -> instance:assumpOT;
-	dataDefn:angularAcceleration -> instance:assumpOD;
-	dataDefn:velocityB -> instance:assumpOT;
-	dataDefn:kEnergy -> instance:assumpOT;
-	dataDefn:kEnergy -> instance:assumpOD;
-	dataDefn:kEnergy -> instance:assumpDI;
-	dataDefn:v_iAB -> instance:assumpOT;
-	dataDefn:impulseV -> instance:assumpOT;
-	dataDefn:potEnergy -> instance:assumpOT;
-	dataDefn:potEnergy -> instance:assumpOD;
-	dataDefn:potEnergy -> instance:assumpDI;
-	dataDefn:momentOfInertia -> instance:assumpOT;
-	theory:newtonSLR -> instance:assumpOD;
-	theory:impulseS -> instance:assumpOT;
-	theory:impulseS -> instance:assumpOD;
-	theory:impulseS -> instance:assumpAD;
-	theory:impulseS -> instance:assumpCT;
-	theory:accj -> instance:assumpOT;
-	theory:accj -> instance:assumpOD;
-	theory:accj -> instance:assumpDI;
-	theory:accj -> instance:assumpCAJI;
-	theory:angAccj -> instance:assumpOT;
-	theory:angAccj -> instance:assumpOD;
-	theory:angAccj -> instance:assumpAD;
-	theory:col2DIM -> instance:assumpOT;
-	theory:col2DIM -> instance:assumpOD;
-	theory:col2DIM -> instance:assumpAD;
-	theory:col2DIM -> instance:assumpCT;
-	theory:col2DIM -> instance:assumpDI;
-	theory:col2DIM -> instance:assumpCAJI;
-	instance:lcEC -> instance:assumpCT;
-	instance:lcID -> instance:assumpDI;
-	instance:lcIJC -> instance:assumpCAJI;
-
-
-	instance:assumpOT	[shape=box, color=black, style=filled, fillcolor=mistyrose, label="A:assumpOT"];
-	instance:assumpOD	[shape=box, color=black, style=filled, fillcolor=mistyrose, label="A:assumpOD"];
-	instance:assumpCST	[shape=box, color=black, style=filled, fillcolor=mistyrose, label="A:assumpCST"];
-	instance:assumpAD	[shape=box, color=black, style=filled, fillcolor=mistyrose, label="A:assumpAD"];
-	instance:assumpCT	[shape=box, color=black, style=filled, fillcolor=mistyrose, label="A:assumpCT"];
-	instance:assumpDI	[shape=box, color=black, style=filled, fillcolor=mistyrose, label="A:assumpDI"];
-	instance:assumpCAJI	[shape=box, color=black, style=filled, fillcolor=mistyrose, label="A:assumpCAJI"];
-
-	subgraph A {
-	rank="same"
-	{instance:assumpOT, instance:assumpOD, instance:assumpCST, instance:assumpAD, instance:assumpCT, instance:assumpDI, instance:assumpCAJI}
-	}
-
-	dataDefn:p_CM	[shape=box, color=black, style=filled, fillcolor=paleturquoise1, label="DD:ctrOfMass"];
-	dataDefn:linearDisplacement	[shape=box, color=black, style=filled, fillcolor=paleturquoise1, label="DD:linDisp"];
-	dataDefn:linearVelocity	[shape=box, color=black, style=filled, fillcolor=paleturquoise1, label="DD:linVel"];
-	dataDefn:linearAcceleration	[shape=box, color=black, style=filled, fillcolor=paleturquoise1, label="DD:linAcc"];
-	dataDefn:angularDisplacement	[shape=box, color=black, style=filled, fillcolor=paleturquoise1, label="DD:angDisp"];
-	dataDefn:angularVelocity	[shape=box, color=black, style=filled, fillcolor=paleturquoise1, label="DD:angVel"];
-	dataDefn:angularAcceleration	[shape=box, color=black, style=filled, fillcolor=paleturquoise1, label="DD:angAccel"];
-	dataDefn:velocityB	[shape=box, color=black, style=filled, fillcolor=paleturquoise1, label="DD:chaslesThm"];
-	dataDefn:torque	[shape=box, color=black, style=filled, fillcolor=paleturquoise1, label="DD:torque"];
-	dataDefn:kEnergy	[shape=box, color=black, style=filled, fillcolor=paleturquoise1, label="DD:kEnergy"];
-	dataDefn:restitutionCoef	[shape=box, color=black, style=filled, fillcolor=paleturquoise1, label="DD:coeffRestitution"];
-	dataDefn:v_iAB	[shape=box, color=black, style=filled, fillcolor=paleturquoise1, label="DD:reVeInColl"];
-	dataDefn:impulseV	[shape=box, color=black, style=filled, fillcolor=paleturquoise1, label="DD:impulseV"];
-	dataDefn:potEnergy	[shape=box, color=black, style=filled, fillcolor=paleturquoise1, label="DD:potEnergy"];
-	dataDefn:momentOfInertia	[shape=box, color=black, style=filled, fillcolor=paleturquoise1, label="DD:momentOfInertia"];
-
-	subgraph DD {
-	rank="same"
-	{dataDefn:p_CM, dataDefn:linearDisplacement, dataDefn:linearVelocity, dataDefn:linearAcceleration, dataDefn:angularDisplacement, dataDefn:angularVelocity, dataDefn:angularAcceleration, dataDefn:velocityB, dataDefn:torque, dataDefn:kEnergy, dataDefn:restitutionCoef, dataDefn:v_iAB, dataDefn:impulseV, dataDefn:potEnergy, dataDefn:momentOfInertia}
-	}
-
-	theory:newtonSL	[shape=box, color=black, style=filled, fillcolor=pink, label="TM:NewtonSecLawMot"];
-	theory:force1	[shape=box, color=black, style=filled, fillcolor=pink, label="TM:NewtonThirdLawMot"];
-	theory:force	[shape=box, color=black, style=filled, fillcolor=pink, label="TM:UniversalGravLaw"];
-	theory:newtonSLR	[shape=box, color=black, style=filled, fillcolor=pink, label="TM:NewtonSecLawRotMot"];
-
-	subgraph TM {
-	rank="same"
-	{theory:newtonSL, theory:force1, theory:force, theory:newtonSLR}
-	}
-
-	theory:gravitationalAccel	[shape=box, color=black, style=filled, fillcolor=palegreen, label="GD:accelGravity"];
-	theory:impulseS	[shape=box, color=black, style=filled, fillcolor=palegreen, label="GD:impulse"];
-
-	subgraph GD {
-	rank="same"
-	{theory:gravitationalAccel, theory:impulseS}
-	}
-
-	theory:accj	[shape=box, color=black, style=filled, fillcolor=khaki1, label="IM:transMot"];
-	theory:angAccj	[shape=box, color=black, style=filled, fillcolor=khaki1, label="IM:rotMot"];
-	theory:col2DIM	[shape=box, color=black, style=filled, fillcolor=khaki1, label="IM:col2D"];
-
-	subgraph IM {
-	rank="same"
-	{theory:accj, theory:angAccj, theory:col2DIM}
-	}
-
-	instance:simSpace	[shape=box, color=black, style=filled, fillcolor=ivory, label="FR:simSpace"];
-	instance:inputInitialConds	[shape=box, color=black, style=filled, fillcolor=ivory, label="FR:inputInitialConds"];
-	instance:inputSurfaceProps	[shape=box, color=black, style=filled, fillcolor=ivory, label="FR:inputSurfaceProps"];
-	instance:verifyPhysCons	[shape=box, color=black, style=filled, fillcolor=ivory, label="FR:verifyPhysCons"];
-	instance:calcTransOverTime	[shape=box, color=black, style=filled, fillcolor=ivory, label="FR:calcTransOverTime"];
-	instance:calcRotOverTime	[shape=box, color=black, style=filled, fillcolor=ivory, label="FR:calcRotOverTime"];
-	instance:deterColls	[shape=box, color=black, style=filled, fillcolor=ivory, label="FR:deterColls"];
-	instance:deterCollRespOverTime	[shape=box, color=black, style=filled, fillcolor=ivory, label="FR:deterCollRespOverTime"];
-	instance:performance	[shape=box, color=black, style=filled, fillcolor=ivory, label="NFR:performance"];
-	instance:correctness	[shape=box, color=black, style=filled, fillcolor=ivory, label="NFR:correctness"];
-	instance:usability	[shape=box, color=black, style=filled, fillcolor=ivory, label="NFR:usability"];
-	instance:understandability	[shape=box, color=black, style=filled, fillcolor=ivory, label="NFR:understandability"];
-	instance:maintainability	[shape=box, color=black, style=filled, fillcolor=ivory, label="NFR:maintainability"];
-
-	subgraph FR {
-	rank="same"
-	{instance:simSpace, instance:inputInitialConds, instance:inputSurfaceProps, instance:verifyPhysCons, instance:calcTransOverTime, instance:calcRotOverTime, instance:deterColls, instance:deterCollRespOverTime, instance:performance, instance:correctness, instance:usability, instance:understandability, instance:maintainability}
-	}
-
-	instance:lcVODES	[shape=box, color=black, style=filled, fillcolor=lavender, label="LC:lcVODES"];
-	instance:lcEC	[shape=box, color=black, style=filled, fillcolor=lavender, label="LC:lcEC"];
-	instance:lcID	[shape=box, color=black, style=filled, fillcolor=lavender, label="LC:lcID"];
-	instance:lcIJC	[shape=box, color=black, style=filled, fillcolor=lavender, label="LC:lcIJC"];
-	instance:ucSRB	[shape=box, color=black, style=filled, fillcolor=lavender, label="UC:ucSRB"];
-	instance:ucEI	[shape=box, color=black, style=filled, fillcolor=lavender, label="UC:ucEI"];
-	instance:ucCCS	[shape=box, color=black, style=filled, fillcolor=lavender, label="UC:ucCCS"];
-	instance:ucORB	[shape=box, color=black, style=filled, fillcolor=lavender, label="UC:ucORB"];
-
-	subgraph LC {
-	rank="same"
-	{instance:lcVODES, instance:lcEC, instance:lcID, instance:lcIJC, instance:ucSRB, instance:ucEI, instance:ucCCS, instance:ucORB}
-	}
-
+digraph "avsall" {
+    "dataDefn:p_CM" -> "instance:assumpOT";
+    "dataDefn:linearDisplacement" -> "instance:assumpOT";
+    "dataDefn:linearVelocity" -> "instance:assumpOT";
+    "dataDefn:linearAcceleration" -> "instance:assumpOT";
+    "dataDefn:angularDisplacement" -> "instance:assumpOT";
+    "dataDefn:angularDisplacement" -> "instance:assumpOD";
+    "dataDefn:angularVelocity" -> "instance:assumpOT";
+    "dataDefn:angularVelocity" -> "instance:assumpOD";
+    "dataDefn:angularAcceleration" -> "instance:assumpOT";
+    "dataDefn:angularAcceleration" -> "instance:assumpOD";
+    "dataDefn:velocityB" -> "instance:assumpOT";
+    "dataDefn:kEnergy" -> "instance:assumpOT";
+    "dataDefn:kEnergy" -> "instance:assumpOD";
+    "dataDefn:kEnergy" -> "instance:assumpDI";
+    "dataDefn:v_i^AB" -> "instance:assumpOT";
+    "dataDefn:impulseV" -> "instance:assumpOT";
+    "dataDefn:potEnergy" -> "instance:assumpOT";
+    "dataDefn:potEnergy" -> "instance:assumpOD";
+    "dataDefn:potEnergy" -> "instance:assumpDI";
+    "dataDefn:momentOfInertia" -> "instance:assumpOT";
+    "theory:newtonSLR" -> "instance:assumpOD";
+    "theory:impulseS" -> "instance:assumpOT";
+    "theory:impulseS" -> "instance:assumpOD";
+    "theory:impulseS" -> "instance:assumpAD";
+    "theory:impulseS" -> "instance:assumpCT";
+    "theory:accj" -> "instance:assumpOT";
+    "theory:accj" -> "instance:assumpOD";
+    "theory:accj" -> "instance:assumpDI";
+    "theory:accj" -> "instance:assumpCAJI";
+    "theory:angAccj" -> "instance:assumpOT";
+    "theory:angAccj" -> "instance:assumpOD";
+    "theory:angAccj" -> "instance:assumpAD";
+    "theory:col2DIM" -> "instance:assumpOT";
+    "theory:col2DIM" -> "instance:assumpOD";
+    "theory:col2DIM" -> "instance:assumpAD";
+    "theory:col2DIM" -> "instance:assumpCT";
+    "theory:col2DIM" -> "instance:assumpDI";
+    "theory:col2DIM" -> "instance:assumpCAJI";
+    "instance:lcEC" -> "instance:assumpCT";
+    "instance:lcID" -> "instance:assumpDI";
+    "instance:lcIJC" -> "instance:assumpCAJI";
+    "instance:assumpOT" [shape=box, color=black, style=filled, fillcolor="mistyrose", label="A:assumpOT"];
+    "instance:assumpOD" [shape=box, color=black, style=filled, fillcolor="mistyrose", label="A:assumpOD"];
+    "instance:assumpCST" [shape=box, color=black, style=filled, fillcolor="mistyrose", label="A:assumpCST"];
+    "instance:assumpAD" [shape=box, color=black, style=filled, fillcolor="mistyrose", label="A:assumpAD"];
+    "instance:assumpCT" [shape=box, color=black, style=filled, fillcolor="mistyrose", label="A:assumpCT"];
+    "instance:assumpDI" [shape=box, color=black, style=filled, fillcolor="mistyrose", label="A:assumpDI"];
+    "instance:assumpCAJI" [shape=box, color=black, style=filled, fillcolor="mistyrose", label="A:assumpCAJI"];
+    subgraph "A" {
+        rank="same";
+        "instance:assumpOT" "instance:assumpOD" "instance:assumpCST" "instance:assumpAD" "instance:assumpCT" "instance:assumpDI" "instance:assumpCAJI";
+    }
+    "dataDefn:p_CM" [shape=box, color=black, style=filled, fillcolor="paleturquoise1", label="DD:ctrOfMass"];
+    "dataDefn:linearDisplacement" [shape=box, color=black, style=filled, fillcolor="paleturquoise1", label="DD:linDisp"];
+    "dataDefn:linearVelocity" [shape=box, color=black, style=filled, fillcolor="paleturquoise1", label="DD:linVel"];
+    "dataDefn:linearAcceleration" [shape=box, color=black, style=filled, fillcolor="paleturquoise1", label="DD:linAcc"];
+    "dataDefn:angularDisplacement" [shape=box, color=black, style=filled, fillcolor="paleturquoise1", label="DD:angDisp"];
+    "dataDefn:angularVelocity" [shape=box, color=black, style=filled, fillcolor="paleturquoise1", label="DD:angVel"];
+    "dataDefn:angularAcceleration" [shape=box, color=black, style=filled, fillcolor="paleturquoise1", label="DD:angAccel"];
+    "dataDefn:velocityB" [shape=box, color=black, style=filled, fillcolor="paleturquoise1", label="DD:chaslesThm"];
+    "dataDefn:torque" [shape=box, color=black, style=filled, fillcolor="paleturquoise1", label="DD:torque"];
+    "dataDefn:kEnergy" [shape=box, color=black, style=filled, fillcolor="paleturquoise1", label="DD:kEnergy"];
+    "dataDefn:restitutionCoef" [shape=box, color=black, style=filled, fillcolor="paleturquoise1", label="DD:coeffRestitution"];
+    "dataDefn:v_i^AB" [shape=box, color=black, style=filled, fillcolor="paleturquoise1", label="DD:reVeInColl"];
+    "dataDefn:impulseV" [shape=box, color=black, style=filled, fillcolor="paleturquoise1", label="DD:impulseV"];
+    "dataDefn:potEnergy" [shape=box, color=black, style=filled, fillcolor="paleturquoise1", label="DD:potEnergy"];
+    "dataDefn:momentOfInertia" [shape=box, color=black, style=filled, fillcolor="paleturquoise1", label="DD:momentOfInertia"];
+    subgraph "DD" {
+        rank="same";
+        "dataDefn:p_CM" "dataDefn:linearDisplacement" "dataDefn:linearVelocity" "dataDefn:linearAcceleration" "dataDefn:angularDisplacement" "dataDefn:angularVelocity" "dataDefn:angularAcceleration" "dataDefn:velocityB" "dataDefn:torque" "dataDefn:kEnergy" "dataDefn:restitutionCoef" "dataDefn:v_i^AB" "dataDefn:impulseV" "dataDefn:potEnergy" "dataDefn:momentOfInertia";
+    }
+    "theory:newtonSL" [shape=box, color=black, style=filled, fillcolor="pink", label="TM:NewtonSecLawMot"];
+    "theory:force1" [shape=box, color=black, style=filled, fillcolor="pink", label="TM:NewtonThirdLawMot"];
+    "theory:force" [shape=box, color=black, style=filled, fillcolor="pink", label="TM:UniversalGravLaw"];
+    "theory:newtonSLR" [shape=box, color=black, style=filled, fillcolor="pink", label="TM:NewtonSecLawRotMot"];
+    subgraph "TM" {
+        rank="same";
+        "theory:newtonSL" "theory:force1" "theory:force" "theory:newtonSLR";
+    }
+    "theory:gravitationalAccel" [shape=box, color=black, style=filled, fillcolor="palegreen", label="GD:accelGravity"];
+    "theory:impulseS" [shape=box, color=black, style=filled, fillcolor="palegreen", label="GD:impulse"];
+    subgraph "GD" {
+        rank="same";
+        "theory:gravitationalAccel" "theory:impulseS";
+    }
+    "theory:accj" [shape=box, color=black, style=filled, fillcolor="khaki1", label="IM:transMot"];
+    "theory:angAccj" [shape=box, color=black, style=filled, fillcolor="khaki1", label="IM:rotMot"];
+    "theory:col2DIM" [shape=box, color=black, style=filled, fillcolor="khaki1", label="IM:col2D"];
+    subgraph "IM" {
+        rank="same";
+        "theory:accj" "theory:angAccj" "theory:col2DIM";
+    }
+    "instance:simSpace" [shape=box, color=black, style=filled, fillcolor="ivory", label="FR:simSpace"];
+    "instance:inputInitialConds" [shape=box, color=black, style=filled, fillcolor="ivory", label="FR:inputInitialConds"];
+    "instance:inputSurfaceProps" [shape=box, color=black, style=filled, fillcolor="ivory", label="FR:inputSurfaceProps"];
+    "instance:verifyPhysCons" [shape=box, color=black, style=filled, fillcolor="ivory", label="FR:verifyPhysCons"];
+    "instance:calcTransOverTime" [shape=box, color=black, style=filled, fillcolor="ivory", label="FR:calcTransOverTime"];
+    "instance:calcRotOverTime" [shape=box, color=black, style=filled, fillcolor="ivory", label="FR:calcRotOverTime"];
+    "instance:deterColls" [shape=box, color=black, style=filled, fillcolor="ivory", label="FR:deterColls"];
+    "instance:deterCollRespOverTime" [shape=box, color=black, style=filled, fillcolor="ivory", label="FR:deterCollRespOverTime"];
+    "instance:performance" [shape=box, color=black, style=filled, fillcolor="ivory", label="NFR:performance"];
+    "instance:correctness" [shape=box, color=black, style=filled, fillcolor="ivory", label="NFR:correctness"];
+    "instance:usability" [shape=box, color=black, style=filled, fillcolor="ivory", label="NFR:usability"];
+    "instance:understandability" [shape=box, color=black, style=filled, fillcolor="ivory", label="NFR:understandability"];
+    "instance:maintainability" [shape=box, color=black, style=filled, fillcolor="ivory", label="NFR:maintainability"];
+    subgraph "FR" {
+        rank="same";
+        "instance:simSpace" "instance:inputInitialConds" "instance:inputSurfaceProps" "instance:verifyPhysCons" "instance:calcTransOverTime" "instance:calcRotOverTime" "instance:deterColls" "instance:deterCollRespOverTime" "instance:performance" "instance:correctness" "instance:usability" "instance:understandability" "instance:maintainability";
+    }
+    "instance:lcVODES" [shape=box, color=black, style=filled, fillcolor="lavender", label="LC:lcVODES"];
+    "instance:lcEC" [shape=box, color=black, style=filled, fillcolor="lavender", label="LC:lcEC"];
+    "instance:lcID" [shape=box, color=black, style=filled, fillcolor="lavender", label="LC:lcID"];
+    "instance:lcIJC" [shape=box, color=black, style=filled, fillcolor="lavender", label="LC:lcIJC"];
+    "instance:ucSRB" [shape=box, color=black, style=filled, fillcolor="lavender", label="UC:ucSRB"];
+    "instance:ucEI" [shape=box, color=black, style=filled, fillcolor="lavender", label="UC:ucEI"];
+    "instance:ucCCS" [shape=box, color=black, style=filled, fillcolor="lavender", label="UC:ucCCS"];
+    "instance:ucORB" [shape=box, color=black, style=filled, fillcolor="lavender", label="UC:ucORB"];
+    subgraph "LC" {
+        rank="same";
+        "instance:lcVODES" "instance:lcEC" "instance:lcID" "instance:lcIJC" "instance:ucSRB" "instance:ucEI" "instance:ucCCS" "instance:ucORB";
+    }
 }

--- a/code/stable/gamephysics/TraceyGraph/refvsref.dot
+++ b/code/stable/gamephysics/TraceyGraph/refvsref.dot
@@ -1,65 +1,55 @@
-digraph refvsref {
-	theory:gravitationalAccel -> theory:force;
-	theory:accj -> dataDefn:p_CM;
-	theory:accj -> dataDefn:linearDisplacement;
-	theory:accj -> dataDefn:linearVelocity;
-	theory:accj -> dataDefn:linearAcceleration;
-	theory:accj -> theory:newtonSL;
-	theory:accj -> theory:gravitationalAccel;
-	theory:angAccj -> dataDefn:angularDisplacement;
-	theory:angAccj -> dataDefn:angularVelocity;
-	theory:angAccj -> dataDefn:angularAcceleration;
-	theory:angAccj -> theory:newtonSLR;
-	theory:col2DIM -> dataDefn:p_CM;
-	theory:col2DIM -> theory:impulseS;
-
-
-	dataDefn:p_CM	[shape=box, color=black, style=filled, fillcolor=paleturquoise1, label="DD:ctrOfMass"];
-	dataDefn:linearDisplacement	[shape=box, color=black, style=filled, fillcolor=paleturquoise1, label="DD:linDisp"];
-	dataDefn:linearVelocity	[shape=box, color=black, style=filled, fillcolor=paleturquoise1, label="DD:linVel"];
-	dataDefn:linearAcceleration	[shape=box, color=black, style=filled, fillcolor=paleturquoise1, label="DD:linAcc"];
-	dataDefn:angularDisplacement	[shape=box, color=black, style=filled, fillcolor=paleturquoise1, label="DD:angDisp"];
-	dataDefn:angularVelocity	[shape=box, color=black, style=filled, fillcolor=paleturquoise1, label="DD:angVel"];
-	dataDefn:angularAcceleration	[shape=box, color=black, style=filled, fillcolor=paleturquoise1, label="DD:angAccel"];
-	dataDefn:velocityB	[shape=box, color=black, style=filled, fillcolor=paleturquoise1, label="DD:chaslesThm"];
-	dataDefn:torque	[shape=box, color=black, style=filled, fillcolor=paleturquoise1, label="DD:torque"];
-	dataDefn:kEnergy	[shape=box, color=black, style=filled, fillcolor=paleturquoise1, label="DD:kEnergy"];
-	dataDefn:restitutionCoef	[shape=box, color=black, style=filled, fillcolor=paleturquoise1, label="DD:coeffRestitution"];
-	dataDefn:v_iAB	[shape=box, color=black, style=filled, fillcolor=paleturquoise1, label="DD:reVeInColl"];
-	dataDefn:impulseV	[shape=box, color=black, style=filled, fillcolor=paleturquoise1, label="DD:impulseV"];
-	dataDefn:potEnergy	[shape=box, color=black, style=filled, fillcolor=paleturquoise1, label="DD:potEnergy"];
-	dataDefn:momentOfInertia	[shape=box, color=black, style=filled, fillcolor=paleturquoise1, label="DD:momentOfInertia"];
-
-	subgraph DD {
-	rank="same"
-	{dataDefn:p_CM, dataDefn:linearDisplacement, dataDefn:linearVelocity, dataDefn:linearAcceleration, dataDefn:angularDisplacement, dataDefn:angularVelocity, dataDefn:angularAcceleration, dataDefn:velocityB, dataDefn:torque, dataDefn:kEnergy, dataDefn:restitutionCoef, dataDefn:v_iAB, dataDefn:impulseV, dataDefn:potEnergy, dataDefn:momentOfInertia}
-	}
-
-	theory:newtonSL	[shape=box, color=black, style=filled, fillcolor=pink, label="TM:NewtonSecLawMot"];
-	theory:force1	[shape=box, color=black, style=filled, fillcolor=pink, label="TM:NewtonThirdLawMot"];
-	theory:force	[shape=box, color=black, style=filled, fillcolor=pink, label="TM:UniversalGravLaw"];
-	theory:newtonSLR	[shape=box, color=black, style=filled, fillcolor=pink, label="TM:NewtonSecLawRotMot"];
-
-	subgraph TM {
-	rank="same"
-	{theory:newtonSL, theory:force1, theory:force, theory:newtonSLR}
-	}
-
-	theory:gravitationalAccel	[shape=box, color=black, style=filled, fillcolor=palegreen, label="GD:accelGravity"];
-	theory:impulseS	[shape=box, color=black, style=filled, fillcolor=palegreen, label="GD:impulse"];
-
-	subgraph GD {
-	rank="same"
-	{theory:gravitationalAccel, theory:impulseS}
-	}
-
-	theory:accj	[shape=box, color=black, style=filled, fillcolor=khaki1, label="IM:transMot"];
-	theory:angAccj	[shape=box, color=black, style=filled, fillcolor=khaki1, label="IM:rotMot"];
-	theory:col2DIM	[shape=box, color=black, style=filled, fillcolor=khaki1, label="IM:col2D"];
-
-	subgraph IM {
-	rank="same"
-	{theory:accj, theory:angAccj, theory:col2DIM}
-	}
-
+digraph "refvsref" {
+    "theory:gravitationalAccel" -> "theory:force";
+    "theory:accj" -> "dataDefn:p_CM";
+    "theory:accj" -> "dataDefn:linearDisplacement";
+    "theory:accj" -> "dataDefn:linearVelocity";
+    "theory:accj" -> "dataDefn:linearAcceleration";
+    "theory:accj" -> "theory:newtonSL";
+    "theory:accj" -> "theory:gravitationalAccel";
+    "theory:angAccj" -> "dataDefn:angularDisplacement";
+    "theory:angAccj" -> "dataDefn:angularVelocity";
+    "theory:angAccj" -> "dataDefn:angularAcceleration";
+    "theory:angAccj" -> "theory:newtonSLR";
+    "theory:col2DIM" -> "dataDefn:p_CM";
+    "theory:col2DIM" -> "theory:impulseS";
+    "dataDefn:p_CM" [shape=box, color=black, style=filled, fillcolor="paleturquoise1", label="DD:ctrOfMass"];
+    "dataDefn:linearDisplacement" [shape=box, color=black, style=filled, fillcolor="paleturquoise1", label="DD:linDisp"];
+    "dataDefn:linearVelocity" [shape=box, color=black, style=filled, fillcolor="paleturquoise1", label="DD:linVel"];
+    "dataDefn:linearAcceleration" [shape=box, color=black, style=filled, fillcolor="paleturquoise1", label="DD:linAcc"];
+    "dataDefn:angularDisplacement" [shape=box, color=black, style=filled, fillcolor="paleturquoise1", label="DD:angDisp"];
+    "dataDefn:angularVelocity" [shape=box, color=black, style=filled, fillcolor="paleturquoise1", label="DD:angVel"];
+    "dataDefn:angularAcceleration" [shape=box, color=black, style=filled, fillcolor="paleturquoise1", label="DD:angAccel"];
+    "dataDefn:velocityB" [shape=box, color=black, style=filled, fillcolor="paleturquoise1", label="DD:chaslesThm"];
+    "dataDefn:torque" [shape=box, color=black, style=filled, fillcolor="paleturquoise1", label="DD:torque"];
+    "dataDefn:kEnergy" [shape=box, color=black, style=filled, fillcolor="paleturquoise1", label="DD:kEnergy"];
+    "dataDefn:restitutionCoef" [shape=box, color=black, style=filled, fillcolor="paleturquoise1", label="DD:coeffRestitution"];
+    "dataDefn:v_i^AB" [shape=box, color=black, style=filled, fillcolor="paleturquoise1", label="DD:reVeInColl"];
+    "dataDefn:impulseV" [shape=box, color=black, style=filled, fillcolor="paleturquoise1", label="DD:impulseV"];
+    "dataDefn:potEnergy" [shape=box, color=black, style=filled, fillcolor="paleturquoise1", label="DD:potEnergy"];
+    "dataDefn:momentOfInertia" [shape=box, color=black, style=filled, fillcolor="paleturquoise1", label="DD:momentOfInertia"];
+    subgraph "DD" {
+        rank="same";
+        "dataDefn:p_CM" "dataDefn:linearDisplacement" "dataDefn:linearVelocity" "dataDefn:linearAcceleration" "dataDefn:angularDisplacement" "dataDefn:angularVelocity" "dataDefn:angularAcceleration" "dataDefn:velocityB" "dataDefn:torque" "dataDefn:kEnergy" "dataDefn:restitutionCoef" "dataDefn:v_i^AB" "dataDefn:impulseV" "dataDefn:potEnergy" "dataDefn:momentOfInertia";
+    }
+    "theory:newtonSL" [shape=box, color=black, style=filled, fillcolor="pink", label="TM:NewtonSecLawMot"];
+    "theory:force1" [shape=box, color=black, style=filled, fillcolor="pink", label="TM:NewtonThirdLawMot"];
+    "theory:force" [shape=box, color=black, style=filled, fillcolor="pink", label="TM:UniversalGravLaw"];
+    "theory:newtonSLR" [shape=box, color=black, style=filled, fillcolor="pink", label="TM:NewtonSecLawRotMot"];
+    subgraph "TM" {
+        rank="same";
+        "theory:newtonSL" "theory:force1" "theory:force" "theory:newtonSLR";
+    }
+    "theory:gravitationalAccel" [shape=box, color=black, style=filled, fillcolor="palegreen", label="GD:accelGravity"];
+    "theory:impulseS" [shape=box, color=black, style=filled, fillcolor="palegreen", label="GD:impulse"];
+    subgraph "GD" {
+        rank="same";
+        "theory:gravitationalAccel" "theory:impulseS";
+    }
+    "theory:accj" [shape=box, color=black, style=filled, fillcolor="khaki1", label="IM:transMot"];
+    "theory:angAccj" [shape=box, color=black, style=filled, fillcolor="khaki1", label="IM:rotMot"];
+    "theory:col2DIM" [shape=box, color=black, style=filled, fillcolor="khaki1", label="IM:col2D"];
+    subgraph "IM" {
+        rank="same";
+        "theory:accj" "theory:angAccj" "theory:col2DIM";
+    }
 }

--- a/code/stable/glassbr/TraceyGraph/allvsall.dot
+++ b/code/stable/glassbr/TraceyGraph/allvsall.dot
@@ -1,134 +1,118 @@
-digraph allvsall {
-	instance:assumpLDFC -> instance:assumpSV;
-	dataDefn:loadDurFactor -> instance:assumpSV;
-	dataDefn:loadDurFactor -> instance:assumpLDFC;
-	dataDefn:demandq -> dataDefn:stdOffDist;
-	dataDefn:demandq -> dataDefn:eqTNTChar;
-	theory:riskFun -> dataDefn:minThick;
-	theory:riskFun -> dataDefn:loadDurFactor;
-	theory:riskFun -> theory:stressDistFac;
-	theory:stressDistFac -> dataDefn:aR;
-	theory:stressDistFac -> theory:dimlessLoad;
-	theory:nFL -> instance:assumpSV;
-	theory:nFL -> dataDefn:minThick;
-	theory:nFL -> theory:tolLoad;
-	theory:dimlessLoad -> instance:assumpSV;
-	theory:dimlessLoad -> dataDefn:minThick;
-	theory:dimlessLoad -> dataDefn:glassTypeFac;
-	theory:dimlessLoad -> dataDefn:demandq;
-	theory:tolLoad -> dataDefn:aR;
-	theory:tolLoad -> theory:sdfTol;
-	theory:sdfTol -> instance:assumpSV;
-	theory:sdfTol -> dataDefn:minThick;
-	theory:sdfTol -> dataDefn:loadDurFactor;
-	theory:probBr -> theory:riskFun;
-	theory:lResistance -> dataDefn:glassTypeFac;
-	theory:lResistance -> theory:nFL;
-	theory:isSafePb -> theory:probBr;
-	theory:isSafePb -> theory:isSafeLR;
-	theory:isSafeLR -> dataDefn:demandq;
-	theory:isSafeLR -> theory:lResistance;
-	theory:isSafeLR -> theory:isSafePb;
-	instance:outputValsAndKnownValues -> instance:inputValues;
-	instance:outputValsAndKnownValues -> instance:sysSetValsFollowingAssumps;
-	instance:checkGlassSafety -> theory:isSafePb;
-	instance:checkGlassSafety -> theory:isSafeLR;
-	instance:calcInternalBlastRisk -> instance:assumpES;
-	instance:varValsOfmkE -> instance:assumpSV;
-	instance:varValsOfmkE -> instance:assumpLDFC;
-	instance:accMoreThanSingleLite -> instance:assumpGL;
-	instance:accMoreBoundaryConditions -> instance:assumpBC;
-	instance:considerMoreThanFlexGlass -> instance:assumpRT;
-	instance:accAlteredGlass -> instance:assumpGC;
-
-
-	instance:assumpGT	[shape=box, color=black, style=filled, fillcolor=mistyrose, label="A:assumpGT"];
-	instance:assumpGC	[shape=box, color=black, style=filled, fillcolor=mistyrose, label="A:assumpGC"];
-	instance:assumpES	[shape=box, color=black, style=filled, fillcolor=mistyrose, label="A:assumpES"];
-	instance:assumpSV	[shape=box, color=black, style=filled, fillcolor=mistyrose, label="A:assumpSV"];
-	instance:assumpGL	[shape=box, color=black, style=filled, fillcolor=mistyrose, label="A:assumpGL"];
-	instance:assumpBC	[shape=box, color=black, style=filled, fillcolor=mistyrose, label="A:assumpBC"];
-	instance:assumpRT	[shape=box, color=black, style=filled, fillcolor=mistyrose, label="A:assumpRT"];
-	instance:assumpLDFC	[shape=box, color=black, style=filled, fillcolor=mistyrose, label="A:assumpLDFC"];
-
-	subgraph A {
-	rank="same"
-	{instance:assumpGT, instance:assumpGC, instance:assumpES, instance:assumpSV, instance:assumpGL, instance:assumpBC, instance:assumpRT, instance:assumpLDFC}
-	}
-
-	dataDefn:minThick	[shape=box, color=black, style=filled, fillcolor=paleturquoise1, label="DD:minThick"];
-	dataDefn:loadDurFactor	[shape=box, color=black, style=filled, fillcolor=paleturquoise1, label="DD:loadDurFactor"];
-	dataDefn:glassTypeFac	[shape=box, color=black, style=filled, fillcolor=paleturquoise1, label="DD:gTF"];
-	dataDefn:stdOffDist	[shape=box, color=black, style=filled, fillcolor=paleturquoise1, label="DD:standOffDist"];
-	dataDefn:aR	[shape=box, color=black, style=filled, fillcolor=paleturquoise1, label="DD:aspectRatio"];
-	dataDefn:eqTNTChar	[shape=box, color=black, style=filled, fillcolor=paleturquoise1, label="DD:eqTNTW"];
-	dataDefn:demandq	[shape=box, color=black, style=filled, fillcolor=paleturquoise1, label="DD:calofDemand"];
-
-	subgraph DD {
-	rank="same"
-	{dataDefn:minThick, dataDefn:loadDurFactor, dataDefn:glassTypeFac, dataDefn:stdOffDist, dataDefn:aR, dataDefn:eqTNTChar, dataDefn:demandq}
-	}
-
-	theory:isSafeProb	[shape=box, color=black, style=filled, fillcolor=pink, label="TM:isSafeProb"];
-	theory:isSafeLoad	[shape=box, color=black, style=filled, fillcolor=pink, label="TM:isSafeLoad"];
-
-	subgraph TM {
-	rank="same"
-	{theory:isSafeProb, theory:isSafeLoad}
-	}
-
-	theory:riskFun	[shape=box, color=black, style=filled, fillcolor=khaki1, label="IM:riskFun"];
-	theory:stressDistFac	[shape=box, color=black, style=filled, fillcolor=khaki1, label="IM:stressDistFac"];
-	theory:nFL	[shape=box, color=black, style=filled, fillcolor=khaki1, label="IM:nFL"];
-	theory:dimlessLoad	[shape=box, color=black, style=filled, fillcolor=khaki1, label="IM:dimlessLoad"];
-	theory:tolLoad	[shape=box, color=black, style=filled, fillcolor=khaki1, label="IM:tolLoad"];
-	theory:sdfTol	[shape=box, color=black, style=filled, fillcolor=khaki1, label="IM:sdfTol"];
-	theory:probBr	[shape=box, color=black, style=filled, fillcolor=khaki1, label="IM:probOfBreak"];
-	theory:lResistance	[shape=box, color=black, style=filled, fillcolor=khaki1, label="IM:calofCapacity"];
-	theory:isSafePb	[shape=box, color=black, style=filled, fillcolor=khaki1, label="IM:isSafePb"];
-	theory:isSafeLR	[shape=box, color=black, style=filled, fillcolor=khaki1, label="IM:isSafeLR"];
-
-	subgraph IM {
-	rank="same"
-	{theory:riskFun, theory:stressDistFac, theory:nFL, theory:dimlessLoad, theory:tolLoad, theory:sdfTol, theory:probBr, theory:lResistance, theory:isSafePb, theory:isSafeLR}
-	}
-
-	instance:inputValues	[shape=box, color=black, style=filled, fillcolor=ivory, label="FR:inputValues"];
-	instance:sysSetValsFollowingAssumps	[shape=box, color=black, style=filled, fillcolor=ivory, label="FR:sysSetValsFollowingAssumps"];
-	instance:checkInputWithDataCons	[shape=box, color=black, style=filled, fillcolor=ivory, label="FR:checkInputWithDataCons"];
-	instance:outputValsAndKnownValues	[shape=box, color=black, style=filled, fillcolor=ivory, label="FR:outputValsAndKnownValues"];
-	instance:checkGlassSafety	[shape=box, color=black, style=filled, fillcolor=ivory, label="FR:checkGlassSafety"];
-	instance:outputValues	[shape=box, color=black, style=filled, fillcolor=ivory, label="FR:outputValues"];
-	instance:correct	[shape=box, color=black, style=filled, fillcolor=ivory, label="NFR:correct"];
-	instance:verifiable	[shape=box, color=black, style=filled, fillcolor=ivory, label="NFR:verifiable"];
-	instance:understandable	[shape=box, color=black, style=filled, fillcolor=ivory, label="NFR:understandable"];
-	instance:reusable	[shape=box, color=black, style=filled, fillcolor=ivory, label="NFR:reusable"];
-	instance:maintainable	[shape=box, color=black, style=filled, fillcolor=ivory, label="NFR:maintainable"];
-	instance:portable	[shape=box, color=black, style=filled, fillcolor=ivory, label="NFR:portable"];
-
-	subgraph FR {
-	rank="same"
-	{instance:inputValues, instance:sysSetValsFollowingAssumps, instance:checkInputWithDataCons, instance:outputValsAndKnownValues, instance:checkGlassSafety, instance:outputValues, instance:correct, instance:verifiable, instance:understandable, instance:reusable, instance:maintainable, instance:portable}
-	}
-
-	instance:willBreakGS	[shape=box, color=black, style=filled, fillcolor=darkgoldenrod1, label="GS:willBreakGS"];
-
-	subgraph GS {
-	rank="same"
-	{instance:willBreakGS}
-	}
-
-	instance:calcInternalBlastRisk	[shape=box, color=black, style=filled, fillcolor=lavender, label="LC:calcInternalBlastRisk"];
-	instance:varValsOfmkE	[shape=box, color=black, style=filled, fillcolor=lavender, label="LC:varValsOfmkE"];
-	instance:accMoreThanSingleLite	[shape=box, color=black, style=filled, fillcolor=lavender, label="LC:accMoreThanSingleLite"];
-	instance:accMoreBoundaryConditions	[shape=box, color=black, style=filled, fillcolor=lavender, label="LC:accMoreBoundaryConditions"];
-	instance:considerMoreThanFlexGlass	[shape=box, color=black, style=filled, fillcolor=lavender, label="LC:considerMoreThanFlexGlass"];
-	instance:predictWithstandOfCertDeg	[shape=box, color=black, style=filled, fillcolor=lavender, label="UC:predictWithstandOfCertDeg"];
-	instance:accAlteredGlass	[shape=box, color=black, style=filled, fillcolor=lavender, label="UC:accAlteredGlass"];
-
-	subgraph LC {
-	rank="same"
-	{instance:calcInternalBlastRisk, instance:varValsOfmkE, instance:accMoreThanSingleLite, instance:accMoreBoundaryConditions, instance:considerMoreThanFlexGlass, instance:predictWithstandOfCertDeg, instance:accAlteredGlass}
-	}
-
+digraph "allvsall" {
+    "instance:assumpLDFC" -> "instance:assumpSV";
+    "dataDefn:loadDurFactor" -> "instance:assumpSV";
+    "dataDefn:loadDurFactor" -> "instance:assumpLDFC";
+    "dataDefn:demandq" -> "dataDefn:stdOffDist";
+    "dataDefn:demandq" -> "dataDefn:eqTNTChar";
+    "theory:riskFun" -> "dataDefn:minThick";
+    "theory:riskFun" -> "dataDefn:loadDurFactor";
+    "theory:riskFun" -> "theory:stressDistFac";
+    "theory:stressDistFac" -> "dataDefn:aR";
+    "theory:stressDistFac" -> "theory:dimlessLoad";
+    "theory:nFL" -> "instance:assumpSV";
+    "theory:nFL" -> "dataDefn:minThick";
+    "theory:nFL" -> "theory:tolLoad";
+    "theory:dimlessLoad" -> "instance:assumpSV";
+    "theory:dimlessLoad" -> "dataDefn:minThick";
+    "theory:dimlessLoad" -> "dataDefn:glassTypeFac";
+    "theory:dimlessLoad" -> "dataDefn:demandq";
+    "theory:tolLoad" -> "dataDefn:aR";
+    "theory:tolLoad" -> "theory:sdfTol";
+    "theory:sdfTol" -> "instance:assumpSV";
+    "theory:sdfTol" -> "dataDefn:minThick";
+    "theory:sdfTol" -> "dataDefn:loadDurFactor";
+    "theory:probBr" -> "theory:riskFun";
+    "theory:lResistance" -> "dataDefn:glassTypeFac";
+    "theory:lResistance" -> "theory:nFL";
+    "theory:isSafePb" -> "theory:probBr";
+    "theory:isSafePb" -> "theory:isSafeLR";
+    "theory:isSafeLR" -> "dataDefn:demandq";
+    "theory:isSafeLR" -> "theory:lResistance";
+    "theory:isSafeLR" -> "theory:isSafePb";
+    "instance:outputValsAndKnownValues" -> "instance:inputValues";
+    "instance:outputValsAndKnownValues" -> "instance:sysSetValsFollowingAssumps";
+    "instance:checkGlassSafety" -> "theory:isSafePb";
+    "instance:checkGlassSafety" -> "theory:isSafeLR";
+    "instance:calcInternalBlastRisk" -> "instance:assumpES";
+    "instance:varValsOfmkE" -> "instance:assumpSV";
+    "instance:varValsOfmkE" -> "instance:assumpLDFC";
+    "instance:accMoreThanSingleLite" -> "instance:assumpGL";
+    "instance:accMoreBoundaryConditions" -> "instance:assumpBC";
+    "instance:considerMoreThanFlexGlass" -> "instance:assumpRT";
+    "instance:accAlteredGlass" -> "instance:assumpGC";
+    "instance:assumpGT" [shape=box, color=black, style=filled, fillcolor="mistyrose", label="A:assumpGT"];
+    "instance:assumpGC" [shape=box, color=black, style=filled, fillcolor="mistyrose", label="A:assumpGC"];
+    "instance:assumpES" [shape=box, color=black, style=filled, fillcolor="mistyrose", label="A:assumpES"];
+    "instance:assumpSV" [shape=box, color=black, style=filled, fillcolor="mistyrose", label="A:assumpSV"];
+    "instance:assumpGL" [shape=box, color=black, style=filled, fillcolor="mistyrose", label="A:assumpGL"];
+    "instance:assumpBC" [shape=box, color=black, style=filled, fillcolor="mistyrose", label="A:assumpBC"];
+    "instance:assumpRT" [shape=box, color=black, style=filled, fillcolor="mistyrose", label="A:assumpRT"];
+    "instance:assumpLDFC" [shape=box, color=black, style=filled, fillcolor="mistyrose", label="A:assumpLDFC"];
+    subgraph "A" {
+        rank="same";
+        "instance:assumpGT" "instance:assumpGC" "instance:assumpES" "instance:assumpSV" "instance:assumpGL" "instance:assumpBC" "instance:assumpRT" "instance:assumpLDFC";
+    }
+    "dataDefn:minThick" [shape=box, color=black, style=filled, fillcolor="paleturquoise1", label="DD:minThick"];
+    "dataDefn:loadDurFactor" [shape=box, color=black, style=filled, fillcolor="paleturquoise1", label="DD:loadDurFactor"];
+    "dataDefn:glassTypeFac" [shape=box, color=black, style=filled, fillcolor="paleturquoise1", label="DD:gTF"];
+    "dataDefn:stdOffDist" [shape=box, color=black, style=filled, fillcolor="paleturquoise1", label="DD:standOffDist"];
+    "dataDefn:aR" [shape=box, color=black, style=filled, fillcolor="paleturquoise1", label="DD:aspectRatio"];
+    "dataDefn:eqTNTChar" [shape=box, color=black, style=filled, fillcolor="paleturquoise1", label="DD:eqTNTW"];
+    "dataDefn:demandq" [shape=box, color=black, style=filled, fillcolor="paleturquoise1", label="DD:calofDemand"];
+    subgraph "DD" {
+        rank="same";
+        "dataDefn:minThick" "dataDefn:loadDurFactor" "dataDefn:glassTypeFac" "dataDefn:stdOffDist" "dataDefn:aR" "dataDefn:eqTNTChar" "dataDefn:demandq";
+    }
+    "theory:isSafeProb" [shape=box, color=black, style=filled, fillcolor="pink", label="TM:isSafeProb"];
+    "theory:isSafeLoad" [shape=box, color=black, style=filled, fillcolor="pink", label="TM:isSafeLoad"];
+    subgraph "TM" {
+        rank="same";
+        "theory:isSafeProb" "theory:isSafeLoad";
+    }
+    "theory:riskFun" [shape=box, color=black, style=filled, fillcolor="khaki1", label="IM:riskFun"];
+    "theory:stressDistFac" [shape=box, color=black, style=filled, fillcolor="khaki1", label="IM:stressDistFac"];
+    "theory:nFL" [shape=box, color=black, style=filled, fillcolor="khaki1", label="IM:nFL"];
+    "theory:dimlessLoad" [shape=box, color=black, style=filled, fillcolor="khaki1", label="IM:dimlessLoad"];
+    "theory:tolLoad" [shape=box, color=black, style=filled, fillcolor="khaki1", label="IM:tolLoad"];
+    "theory:sdfTol" [shape=box, color=black, style=filled, fillcolor="khaki1", label="IM:sdfTol"];
+    "theory:probBr" [shape=box, color=black, style=filled, fillcolor="khaki1", label="IM:probOfBreak"];
+    "theory:lResistance" [shape=box, color=black, style=filled, fillcolor="khaki1", label="IM:calofCapacity"];
+    "theory:isSafePb" [shape=box, color=black, style=filled, fillcolor="khaki1", label="IM:isSafePb"];
+    "theory:isSafeLR" [shape=box, color=black, style=filled, fillcolor="khaki1", label="IM:isSafeLR"];
+    subgraph "IM" {
+        rank="same";
+        "theory:riskFun" "theory:stressDistFac" "theory:nFL" "theory:dimlessLoad" "theory:tolLoad" "theory:sdfTol" "theory:probBr" "theory:lResistance" "theory:isSafePb" "theory:isSafeLR";
+    }
+    "instance:inputValues" [shape=box, color=black, style=filled, fillcolor="ivory", label="FR:inputValues"];
+    "instance:sysSetValsFollowingAssumps" [shape=box, color=black, style=filled, fillcolor="ivory", label="FR:sysSetValsFollowingAssumps"];
+    "instance:checkInputWithDataCons" [shape=box, color=black, style=filled, fillcolor="ivory", label="FR:checkInputWithDataCons"];
+    "instance:outputValsAndKnownValues" [shape=box, color=black, style=filled, fillcolor="ivory", label="FR:outputValsAndKnownValues"];
+    "instance:checkGlassSafety" [shape=box, color=black, style=filled, fillcolor="ivory", label="FR:checkGlassSafety"];
+    "instance:outputValues" [shape=box, color=black, style=filled, fillcolor="ivory", label="FR:outputValues"];
+    "instance:correct" [shape=box, color=black, style=filled, fillcolor="ivory", label="NFR:correct"];
+    "instance:verifiable" [shape=box, color=black, style=filled, fillcolor="ivory", label="NFR:verifiable"];
+    "instance:understandable" [shape=box, color=black, style=filled, fillcolor="ivory", label="NFR:understandable"];
+    "instance:reusable" [shape=box, color=black, style=filled, fillcolor="ivory", label="NFR:reusable"];
+    "instance:maintainable" [shape=box, color=black, style=filled, fillcolor="ivory", label="NFR:maintainable"];
+    "instance:portable" [shape=box, color=black, style=filled, fillcolor="ivory", label="NFR:portable"];
+    subgraph "FR" {
+        rank="same";
+        "instance:inputValues" "instance:sysSetValsFollowingAssumps" "instance:checkInputWithDataCons" "instance:outputValsAndKnownValues" "instance:checkGlassSafety" "instance:outputValues" "instance:correct" "instance:verifiable" "instance:understandable" "instance:reusable" "instance:maintainable" "instance:portable";
+    }
+    "instance:willBreakGS" [shape=box, color=black, style=filled, fillcolor="darkgoldenrod1", label="GS:willBreakGS"];
+    subgraph "GS" {
+        rank="same";
+        "instance:willBreakGS";
+    }
+    "instance:calcInternalBlastRisk" [shape=box, color=black, style=filled, fillcolor="lavender", label="LC:calcInternalBlastRisk"];
+    "instance:varValsOfmkE" [shape=box, color=black, style=filled, fillcolor="lavender", label="LC:varValsOfmkE"];
+    "instance:accMoreThanSingleLite" [shape=box, color=black, style=filled, fillcolor="lavender", label="LC:accMoreThanSingleLite"];
+    "instance:accMoreBoundaryConditions" [shape=box, color=black, style=filled, fillcolor="lavender", label="LC:accMoreBoundaryConditions"];
+    "instance:considerMoreThanFlexGlass" [shape=box, color=black, style=filled, fillcolor="lavender", label="LC:considerMoreThanFlexGlass"];
+    "instance:predictWithstandOfCertDeg" [shape=box, color=black, style=filled, fillcolor="lavender", label="UC:predictWithstandOfCertDeg"];
+    "instance:accAlteredGlass" [shape=box, color=black, style=filled, fillcolor="lavender", label="UC:accAlteredGlass"];
+    subgraph "LC" {
+        rank="same";
+        "instance:calcInternalBlastRisk" "instance:varValsOfmkE" "instance:accMoreThanSingleLite" "instance:accMoreBoundaryConditions" "instance:considerMoreThanFlexGlass" "instance:predictWithstandOfCertDeg" "instance:accAlteredGlass";
+    }
 }

--- a/code/stable/glassbr/TraceyGraph/allvsr.dot
+++ b/code/stable/glassbr/TraceyGraph/allvsr.dot
@@ -1,84 +1,70 @@
-digraph allvsr {
-	instance:outputValsAndKnownValues -> instance:inputValues;
-	instance:outputValsAndKnownValues -> instance:sysSetValsFollowingAssumps;
-	instance:checkGlassSafety -> theory:isSafePb;
-	instance:checkGlassSafety -> theory:isSafeLR;
-
-
-	instance:assumpGT	[shape=box, color=black, style=filled, fillcolor=mistyrose, label="A:assumpGT"];
-	instance:assumpGC	[shape=box, color=black, style=filled, fillcolor=mistyrose, label="A:assumpGC"];
-	instance:assumpES	[shape=box, color=black, style=filled, fillcolor=mistyrose, label="A:assumpES"];
-	instance:assumpSV	[shape=box, color=black, style=filled, fillcolor=mistyrose, label="A:assumpSV"];
-	instance:assumpGL	[shape=box, color=black, style=filled, fillcolor=mistyrose, label="A:assumpGL"];
-	instance:assumpBC	[shape=box, color=black, style=filled, fillcolor=mistyrose, label="A:assumpBC"];
-	instance:assumpRT	[shape=box, color=black, style=filled, fillcolor=mistyrose, label="A:assumpRT"];
-	instance:assumpLDFC	[shape=box, color=black, style=filled, fillcolor=mistyrose, label="A:assumpLDFC"];
-
-	subgraph A {
-	rank="same"
-	{instance:assumpGT, instance:assumpGC, instance:assumpES, instance:assumpSV, instance:assumpGL, instance:assumpBC, instance:assumpRT, instance:assumpLDFC}
-	}
-
-	dataDefn:minThick	[shape=box, color=black, style=filled, fillcolor=paleturquoise1, label="DD:minThick"];
-	dataDefn:loadDurFactor	[shape=box, color=black, style=filled, fillcolor=paleturquoise1, label="DD:loadDurFactor"];
-	dataDefn:glassTypeFac	[shape=box, color=black, style=filled, fillcolor=paleturquoise1, label="DD:gTF"];
-	dataDefn:stdOffDist	[shape=box, color=black, style=filled, fillcolor=paleturquoise1, label="DD:standOffDist"];
-	dataDefn:aR	[shape=box, color=black, style=filled, fillcolor=paleturquoise1, label="DD:aspectRatio"];
-	dataDefn:eqTNTChar	[shape=box, color=black, style=filled, fillcolor=paleturquoise1, label="DD:eqTNTW"];
-	dataDefn:demandq	[shape=box, color=black, style=filled, fillcolor=paleturquoise1, label="DD:calofDemand"];
-
-	subgraph DD {
-	rank="same"
-	{dataDefn:minThick, dataDefn:loadDurFactor, dataDefn:glassTypeFac, dataDefn:stdOffDist, dataDefn:aR, dataDefn:eqTNTChar, dataDefn:demandq}
-	}
-
-	theory:isSafeProb	[shape=box, color=black, style=filled, fillcolor=pink, label="TM:isSafeProb"];
-	theory:isSafeLoad	[shape=box, color=black, style=filled, fillcolor=pink, label="TM:isSafeLoad"];
-
-	subgraph TM {
-	rank="same"
-	{theory:isSafeProb, theory:isSafeLoad}
-	}
-
-	theory:riskFun	[shape=box, color=black, style=filled, fillcolor=khaki1, label="IM:riskFun"];
-	theory:stressDistFac	[shape=box, color=black, style=filled, fillcolor=khaki1, label="IM:stressDistFac"];
-	theory:nFL	[shape=box, color=black, style=filled, fillcolor=khaki1, label="IM:nFL"];
-	theory:dimlessLoad	[shape=box, color=black, style=filled, fillcolor=khaki1, label="IM:dimlessLoad"];
-	theory:tolLoad	[shape=box, color=black, style=filled, fillcolor=khaki1, label="IM:tolLoad"];
-	theory:sdfTol	[shape=box, color=black, style=filled, fillcolor=khaki1, label="IM:sdfTol"];
-	theory:probBr	[shape=box, color=black, style=filled, fillcolor=khaki1, label="IM:probOfBreak"];
-	theory:lResistance	[shape=box, color=black, style=filled, fillcolor=khaki1, label="IM:calofCapacity"];
-	theory:isSafePb	[shape=box, color=black, style=filled, fillcolor=khaki1, label="IM:isSafePb"];
-	theory:isSafeLR	[shape=box, color=black, style=filled, fillcolor=khaki1, label="IM:isSafeLR"];
-
-	subgraph IM {
-	rank="same"
-	{theory:riskFun, theory:stressDistFac, theory:nFL, theory:dimlessLoad, theory:tolLoad, theory:sdfTol, theory:probBr, theory:lResistance, theory:isSafePb, theory:isSafeLR}
-	}
-
-	instance:inputValues	[shape=box, color=black, style=filled, fillcolor=ivory, label="FR:inputValues"];
-	instance:sysSetValsFollowingAssumps	[shape=box, color=black, style=filled, fillcolor=ivory, label="FR:sysSetValsFollowingAssumps"];
-	instance:checkInputWithDataCons	[shape=box, color=black, style=filled, fillcolor=ivory, label="FR:checkInputWithDataCons"];
-	instance:outputValsAndKnownValues	[shape=box, color=black, style=filled, fillcolor=ivory, label="FR:outputValsAndKnownValues"];
-	instance:checkGlassSafety	[shape=box, color=black, style=filled, fillcolor=ivory, label="FR:checkGlassSafety"];
-	instance:outputValues	[shape=box, color=black, style=filled, fillcolor=ivory, label="FR:outputValues"];
-	instance:correct	[shape=box, color=black, style=filled, fillcolor=ivory, label="NFR:correct"];
-	instance:verifiable	[shape=box, color=black, style=filled, fillcolor=ivory, label="NFR:verifiable"];
-	instance:understandable	[shape=box, color=black, style=filled, fillcolor=ivory, label="NFR:understandable"];
-	instance:reusable	[shape=box, color=black, style=filled, fillcolor=ivory, label="NFR:reusable"];
-	instance:maintainable	[shape=box, color=black, style=filled, fillcolor=ivory, label="NFR:maintainable"];
-	instance:portable	[shape=box, color=black, style=filled, fillcolor=ivory, label="NFR:portable"];
-
-	subgraph FR {
-	rank="same"
-	{instance:inputValues, instance:sysSetValsFollowingAssumps, instance:checkInputWithDataCons, instance:outputValsAndKnownValues, instance:checkGlassSafety, instance:outputValues, instance:correct, instance:verifiable, instance:understandable, instance:reusable, instance:maintainable, instance:portable}
-	}
-
-	instance:willBreakGS	[shape=box, color=black, style=filled, fillcolor=darkgoldenrod1, label="GS:willBreakGS"];
-
-	subgraph GS {
-	rank="same"
-	{instance:willBreakGS}
-	}
-
+digraph "allvsr" {
+    "instance:outputValsAndKnownValues" -> "instance:inputValues";
+    "instance:outputValsAndKnownValues" -> "instance:sysSetValsFollowingAssumps";
+    "instance:checkGlassSafety" -> "theory:isSafePb";
+    "instance:checkGlassSafety" -> "theory:isSafeLR";
+    "instance:assumpGT" [shape=box, color=black, style=filled, fillcolor="mistyrose", label="A:assumpGT"];
+    "instance:assumpGC" [shape=box, color=black, style=filled, fillcolor="mistyrose", label="A:assumpGC"];
+    "instance:assumpES" [shape=box, color=black, style=filled, fillcolor="mistyrose", label="A:assumpES"];
+    "instance:assumpSV" [shape=box, color=black, style=filled, fillcolor="mistyrose", label="A:assumpSV"];
+    "instance:assumpGL" [shape=box, color=black, style=filled, fillcolor="mistyrose", label="A:assumpGL"];
+    "instance:assumpBC" [shape=box, color=black, style=filled, fillcolor="mistyrose", label="A:assumpBC"];
+    "instance:assumpRT" [shape=box, color=black, style=filled, fillcolor="mistyrose", label="A:assumpRT"];
+    "instance:assumpLDFC" [shape=box, color=black, style=filled, fillcolor="mistyrose", label="A:assumpLDFC"];
+    subgraph "A" {
+        rank="same";
+        "instance:assumpGT" "instance:assumpGC" "instance:assumpES" "instance:assumpSV" "instance:assumpGL" "instance:assumpBC" "instance:assumpRT" "instance:assumpLDFC";
+    }
+    "dataDefn:minThick" [shape=box, color=black, style=filled, fillcolor="paleturquoise1", label="DD:minThick"];
+    "dataDefn:loadDurFactor" [shape=box, color=black, style=filled, fillcolor="paleturquoise1", label="DD:loadDurFactor"];
+    "dataDefn:glassTypeFac" [shape=box, color=black, style=filled, fillcolor="paleturquoise1", label="DD:gTF"];
+    "dataDefn:stdOffDist" [shape=box, color=black, style=filled, fillcolor="paleturquoise1", label="DD:standOffDist"];
+    "dataDefn:aR" [shape=box, color=black, style=filled, fillcolor="paleturquoise1", label="DD:aspectRatio"];
+    "dataDefn:eqTNTChar" [shape=box, color=black, style=filled, fillcolor="paleturquoise1", label="DD:eqTNTW"];
+    "dataDefn:demandq" [shape=box, color=black, style=filled, fillcolor="paleturquoise1", label="DD:calofDemand"];
+    subgraph "DD" {
+        rank="same";
+        "dataDefn:minThick" "dataDefn:loadDurFactor" "dataDefn:glassTypeFac" "dataDefn:stdOffDist" "dataDefn:aR" "dataDefn:eqTNTChar" "dataDefn:demandq";
+    }
+    "theory:isSafeProb" [shape=box, color=black, style=filled, fillcolor="pink", label="TM:isSafeProb"];
+    "theory:isSafeLoad" [shape=box, color=black, style=filled, fillcolor="pink", label="TM:isSafeLoad"];
+    subgraph "TM" {
+        rank="same";
+        "theory:isSafeProb" "theory:isSafeLoad";
+    }
+    "theory:riskFun" [shape=box, color=black, style=filled, fillcolor="khaki1", label="IM:riskFun"];
+    "theory:stressDistFac" [shape=box, color=black, style=filled, fillcolor="khaki1", label="IM:stressDistFac"];
+    "theory:nFL" [shape=box, color=black, style=filled, fillcolor="khaki1", label="IM:nFL"];
+    "theory:dimlessLoad" [shape=box, color=black, style=filled, fillcolor="khaki1", label="IM:dimlessLoad"];
+    "theory:tolLoad" [shape=box, color=black, style=filled, fillcolor="khaki1", label="IM:tolLoad"];
+    "theory:sdfTol" [shape=box, color=black, style=filled, fillcolor="khaki1", label="IM:sdfTol"];
+    "theory:probBr" [shape=box, color=black, style=filled, fillcolor="khaki1", label="IM:probOfBreak"];
+    "theory:lResistance" [shape=box, color=black, style=filled, fillcolor="khaki1", label="IM:calofCapacity"];
+    "theory:isSafePb" [shape=box, color=black, style=filled, fillcolor="khaki1", label="IM:isSafePb"];
+    "theory:isSafeLR" [shape=box, color=black, style=filled, fillcolor="khaki1", label="IM:isSafeLR"];
+    subgraph "IM" {
+        rank="same";
+        "theory:riskFun" "theory:stressDistFac" "theory:nFL" "theory:dimlessLoad" "theory:tolLoad" "theory:sdfTol" "theory:probBr" "theory:lResistance" "theory:isSafePb" "theory:isSafeLR";
+    }
+    "instance:inputValues" [shape=box, color=black, style=filled, fillcolor="ivory", label="FR:inputValues"];
+    "instance:sysSetValsFollowingAssumps" [shape=box, color=black, style=filled, fillcolor="ivory", label="FR:sysSetValsFollowingAssumps"];
+    "instance:checkInputWithDataCons" [shape=box, color=black, style=filled, fillcolor="ivory", label="FR:checkInputWithDataCons"];
+    "instance:outputValsAndKnownValues" [shape=box, color=black, style=filled, fillcolor="ivory", label="FR:outputValsAndKnownValues"];
+    "instance:checkGlassSafety" [shape=box, color=black, style=filled, fillcolor="ivory", label="FR:checkGlassSafety"];
+    "instance:outputValues" [shape=box, color=black, style=filled, fillcolor="ivory", label="FR:outputValues"];
+    "instance:correct" [shape=box, color=black, style=filled, fillcolor="ivory", label="NFR:correct"];
+    "instance:verifiable" [shape=box, color=black, style=filled, fillcolor="ivory", label="NFR:verifiable"];
+    "instance:understandable" [shape=box, color=black, style=filled, fillcolor="ivory", label="NFR:understandable"];
+    "instance:reusable" [shape=box, color=black, style=filled, fillcolor="ivory", label="NFR:reusable"];
+    "instance:maintainable" [shape=box, color=black, style=filled, fillcolor="ivory", label="NFR:maintainable"];
+    "instance:portable" [shape=box, color=black, style=filled, fillcolor="ivory", label="NFR:portable"];
+    subgraph "FR" {
+        rank="same";
+        "instance:inputValues" "instance:sysSetValsFollowingAssumps" "instance:checkInputWithDataCons" "instance:outputValsAndKnownValues" "instance:checkGlassSafety" "instance:outputValues" "instance:correct" "instance:verifiable" "instance:understandable" "instance:reusable" "instance:maintainable" "instance:portable";
+    }
+    "instance:willBreakGS" [shape=box, color=black, style=filled, fillcolor="darkgoldenrod1", label="GS:willBreakGS"];
+    subgraph "GS" {
+        rank="same";
+        "instance:willBreakGS";
+    }
 }

--- a/code/stable/glassbr/TraceyGraph/avsa.dot
+++ b/code/stable/glassbr/TraceyGraph/avsa.dot
@@ -1,19 +1,15 @@
-digraph avsa {
-	instance:assumpLDFC -> instance:assumpSV;
-
-
-	instance:assumpGT	[shape=box, color=black, style=filled, fillcolor=mistyrose, label="A:assumpGT"];
-	instance:assumpGC	[shape=box, color=black, style=filled, fillcolor=mistyrose, label="A:assumpGC"];
-	instance:assumpES	[shape=box, color=black, style=filled, fillcolor=mistyrose, label="A:assumpES"];
-	instance:assumpSV	[shape=box, color=black, style=filled, fillcolor=mistyrose, label="A:assumpSV"];
-	instance:assumpGL	[shape=box, color=black, style=filled, fillcolor=mistyrose, label="A:assumpGL"];
-	instance:assumpBC	[shape=box, color=black, style=filled, fillcolor=mistyrose, label="A:assumpBC"];
-	instance:assumpRT	[shape=box, color=black, style=filled, fillcolor=mistyrose, label="A:assumpRT"];
-	instance:assumpLDFC	[shape=box, color=black, style=filled, fillcolor=mistyrose, label="A:assumpLDFC"];
-
-	subgraph A {
-	rank="same"
-	{instance:assumpGT, instance:assumpGC, instance:assumpES, instance:assumpSV, instance:assumpGL, instance:assumpBC, instance:assumpRT, instance:assumpLDFC}
-	}
-
+digraph "avsa" {
+    "instance:assumpLDFC" -> "instance:assumpSV";
+    "instance:assumpGT" [shape=box, color=black, style=filled, fillcolor="mistyrose", label="A:assumpGT"];
+    "instance:assumpGC" [shape=box, color=black, style=filled, fillcolor="mistyrose", label="A:assumpGC"];
+    "instance:assumpES" [shape=box, color=black, style=filled, fillcolor="mistyrose", label="A:assumpES"];
+    "instance:assumpSV" [shape=box, color=black, style=filled, fillcolor="mistyrose", label="A:assumpSV"];
+    "instance:assumpGL" [shape=box, color=black, style=filled, fillcolor="mistyrose", label="A:assumpGL"];
+    "instance:assumpBC" [shape=box, color=black, style=filled, fillcolor="mistyrose", label="A:assumpBC"];
+    "instance:assumpRT" [shape=box, color=black, style=filled, fillcolor="mistyrose", label="A:assumpRT"];
+    "instance:assumpLDFC" [shape=box, color=black, style=filled, fillcolor="mistyrose", label="A:assumpLDFC"];
+    subgraph "A" {
+        rank="same";
+        "instance:assumpGT" "instance:assumpGC" "instance:assumpES" "instance:assumpSV" "instance:assumpGL" "instance:assumpBC" "instance:assumpRT" "instance:assumpLDFC";
+    }
 }

--- a/code/stable/glassbr/TraceyGraph/avsall.dot
+++ b/code/stable/glassbr/TraceyGraph/avsall.dot
@@ -1,98 +1,84 @@
-digraph avsall {
-	dataDefn:loadDurFactor -> instance:assumpSV;
-	dataDefn:loadDurFactor -> instance:assumpLDFC;
-	theory:nFL -> instance:assumpSV;
-	theory:dimlessLoad -> instance:assumpSV;
-	theory:sdfTol -> instance:assumpSV;
-	instance:calcInternalBlastRisk -> instance:assumpES;
-	instance:varValsOfmkE -> instance:assumpSV;
-	instance:varValsOfmkE -> instance:assumpLDFC;
-	instance:accMoreThanSingleLite -> instance:assumpGL;
-	instance:accMoreBoundaryConditions -> instance:assumpBC;
-	instance:considerMoreThanFlexGlass -> instance:assumpRT;
-	instance:accAlteredGlass -> instance:assumpGC;
-
-
-	instance:assumpGT	[shape=box, color=black, style=filled, fillcolor=mistyrose, label="A:assumpGT"];
-	instance:assumpGC	[shape=box, color=black, style=filled, fillcolor=mistyrose, label="A:assumpGC"];
-	instance:assumpES	[shape=box, color=black, style=filled, fillcolor=mistyrose, label="A:assumpES"];
-	instance:assumpSV	[shape=box, color=black, style=filled, fillcolor=mistyrose, label="A:assumpSV"];
-	instance:assumpGL	[shape=box, color=black, style=filled, fillcolor=mistyrose, label="A:assumpGL"];
-	instance:assumpBC	[shape=box, color=black, style=filled, fillcolor=mistyrose, label="A:assumpBC"];
-	instance:assumpRT	[shape=box, color=black, style=filled, fillcolor=mistyrose, label="A:assumpRT"];
-	instance:assumpLDFC	[shape=box, color=black, style=filled, fillcolor=mistyrose, label="A:assumpLDFC"];
-
-	subgraph A {
-	rank="same"
-	{instance:assumpGT, instance:assumpGC, instance:assumpES, instance:assumpSV, instance:assumpGL, instance:assumpBC, instance:assumpRT, instance:assumpLDFC}
-	}
-
-	dataDefn:minThick	[shape=box, color=black, style=filled, fillcolor=paleturquoise1, label="DD:minThick"];
-	dataDefn:loadDurFactor	[shape=box, color=black, style=filled, fillcolor=paleturquoise1, label="DD:loadDurFactor"];
-	dataDefn:glassTypeFac	[shape=box, color=black, style=filled, fillcolor=paleturquoise1, label="DD:gTF"];
-	dataDefn:stdOffDist	[shape=box, color=black, style=filled, fillcolor=paleturquoise1, label="DD:standOffDist"];
-	dataDefn:aR	[shape=box, color=black, style=filled, fillcolor=paleturquoise1, label="DD:aspectRatio"];
-	dataDefn:eqTNTChar	[shape=box, color=black, style=filled, fillcolor=paleturquoise1, label="DD:eqTNTW"];
-	dataDefn:demandq	[shape=box, color=black, style=filled, fillcolor=paleturquoise1, label="DD:calofDemand"];
-
-	subgraph DD {
-	rank="same"
-	{dataDefn:minThick, dataDefn:loadDurFactor, dataDefn:glassTypeFac, dataDefn:stdOffDist, dataDefn:aR, dataDefn:eqTNTChar, dataDefn:demandq}
-	}
-
-	theory:isSafeProb	[shape=box, color=black, style=filled, fillcolor=pink, label="TM:isSafeProb"];
-	theory:isSafeLoad	[shape=box, color=black, style=filled, fillcolor=pink, label="TM:isSafeLoad"];
-
-	subgraph TM {
-	rank="same"
-	{theory:isSafeProb, theory:isSafeLoad}
-	}
-
-	theory:riskFun	[shape=box, color=black, style=filled, fillcolor=khaki1, label="IM:riskFun"];
-	theory:stressDistFac	[shape=box, color=black, style=filled, fillcolor=khaki1, label="IM:stressDistFac"];
-	theory:nFL	[shape=box, color=black, style=filled, fillcolor=khaki1, label="IM:nFL"];
-	theory:dimlessLoad	[shape=box, color=black, style=filled, fillcolor=khaki1, label="IM:dimlessLoad"];
-	theory:tolLoad	[shape=box, color=black, style=filled, fillcolor=khaki1, label="IM:tolLoad"];
-	theory:sdfTol	[shape=box, color=black, style=filled, fillcolor=khaki1, label="IM:sdfTol"];
-	theory:probBr	[shape=box, color=black, style=filled, fillcolor=khaki1, label="IM:probOfBreak"];
-	theory:lResistance	[shape=box, color=black, style=filled, fillcolor=khaki1, label="IM:calofCapacity"];
-	theory:isSafePb	[shape=box, color=black, style=filled, fillcolor=khaki1, label="IM:isSafePb"];
-	theory:isSafeLR	[shape=box, color=black, style=filled, fillcolor=khaki1, label="IM:isSafeLR"];
-
-	subgraph IM {
-	rank="same"
-	{theory:riskFun, theory:stressDistFac, theory:nFL, theory:dimlessLoad, theory:tolLoad, theory:sdfTol, theory:probBr, theory:lResistance, theory:isSafePb, theory:isSafeLR}
-	}
-
-	instance:inputValues	[shape=box, color=black, style=filled, fillcolor=ivory, label="FR:inputValues"];
-	instance:sysSetValsFollowingAssumps	[shape=box, color=black, style=filled, fillcolor=ivory, label="FR:sysSetValsFollowingAssumps"];
-	instance:checkInputWithDataCons	[shape=box, color=black, style=filled, fillcolor=ivory, label="FR:checkInputWithDataCons"];
-	instance:outputValsAndKnownValues	[shape=box, color=black, style=filled, fillcolor=ivory, label="FR:outputValsAndKnownValues"];
-	instance:checkGlassSafety	[shape=box, color=black, style=filled, fillcolor=ivory, label="FR:checkGlassSafety"];
-	instance:outputValues	[shape=box, color=black, style=filled, fillcolor=ivory, label="FR:outputValues"];
-	instance:correct	[shape=box, color=black, style=filled, fillcolor=ivory, label="NFR:correct"];
-	instance:verifiable	[shape=box, color=black, style=filled, fillcolor=ivory, label="NFR:verifiable"];
-	instance:understandable	[shape=box, color=black, style=filled, fillcolor=ivory, label="NFR:understandable"];
-	instance:reusable	[shape=box, color=black, style=filled, fillcolor=ivory, label="NFR:reusable"];
-	instance:maintainable	[shape=box, color=black, style=filled, fillcolor=ivory, label="NFR:maintainable"];
-	instance:portable	[shape=box, color=black, style=filled, fillcolor=ivory, label="NFR:portable"];
-
-	subgraph FR {
-	rank="same"
-	{instance:inputValues, instance:sysSetValsFollowingAssumps, instance:checkInputWithDataCons, instance:outputValsAndKnownValues, instance:checkGlassSafety, instance:outputValues, instance:correct, instance:verifiable, instance:understandable, instance:reusable, instance:maintainable, instance:portable}
-	}
-
-	instance:calcInternalBlastRisk	[shape=box, color=black, style=filled, fillcolor=lavender, label="LC:calcInternalBlastRisk"];
-	instance:varValsOfmkE	[shape=box, color=black, style=filled, fillcolor=lavender, label="LC:varValsOfmkE"];
-	instance:accMoreThanSingleLite	[shape=box, color=black, style=filled, fillcolor=lavender, label="LC:accMoreThanSingleLite"];
-	instance:accMoreBoundaryConditions	[shape=box, color=black, style=filled, fillcolor=lavender, label="LC:accMoreBoundaryConditions"];
-	instance:considerMoreThanFlexGlass	[shape=box, color=black, style=filled, fillcolor=lavender, label="LC:considerMoreThanFlexGlass"];
-	instance:predictWithstandOfCertDeg	[shape=box, color=black, style=filled, fillcolor=lavender, label="UC:predictWithstandOfCertDeg"];
-	instance:accAlteredGlass	[shape=box, color=black, style=filled, fillcolor=lavender, label="UC:accAlteredGlass"];
-
-	subgraph LC {
-	rank="same"
-	{instance:calcInternalBlastRisk, instance:varValsOfmkE, instance:accMoreThanSingleLite, instance:accMoreBoundaryConditions, instance:considerMoreThanFlexGlass, instance:predictWithstandOfCertDeg, instance:accAlteredGlass}
-	}
-
+digraph "avsall" {
+    "dataDefn:loadDurFactor" -> "instance:assumpSV";
+    "dataDefn:loadDurFactor" -> "instance:assumpLDFC";
+    "theory:nFL" -> "instance:assumpSV";
+    "theory:dimlessLoad" -> "instance:assumpSV";
+    "theory:sdfTol" -> "instance:assumpSV";
+    "instance:calcInternalBlastRisk" -> "instance:assumpES";
+    "instance:varValsOfmkE" -> "instance:assumpSV";
+    "instance:varValsOfmkE" -> "instance:assumpLDFC";
+    "instance:accMoreThanSingleLite" -> "instance:assumpGL";
+    "instance:accMoreBoundaryConditions" -> "instance:assumpBC";
+    "instance:considerMoreThanFlexGlass" -> "instance:assumpRT";
+    "instance:accAlteredGlass" -> "instance:assumpGC";
+    "instance:assumpGT" [shape=box, color=black, style=filled, fillcolor="mistyrose", label="A:assumpGT"];
+    "instance:assumpGC" [shape=box, color=black, style=filled, fillcolor="mistyrose", label="A:assumpGC"];
+    "instance:assumpES" [shape=box, color=black, style=filled, fillcolor="mistyrose", label="A:assumpES"];
+    "instance:assumpSV" [shape=box, color=black, style=filled, fillcolor="mistyrose", label="A:assumpSV"];
+    "instance:assumpGL" [shape=box, color=black, style=filled, fillcolor="mistyrose", label="A:assumpGL"];
+    "instance:assumpBC" [shape=box, color=black, style=filled, fillcolor="mistyrose", label="A:assumpBC"];
+    "instance:assumpRT" [shape=box, color=black, style=filled, fillcolor="mistyrose", label="A:assumpRT"];
+    "instance:assumpLDFC" [shape=box, color=black, style=filled, fillcolor="mistyrose", label="A:assumpLDFC"];
+    subgraph "A" {
+        rank="same";
+        "instance:assumpGT" "instance:assumpGC" "instance:assumpES" "instance:assumpSV" "instance:assumpGL" "instance:assumpBC" "instance:assumpRT" "instance:assumpLDFC";
+    }
+    "dataDefn:minThick" [shape=box, color=black, style=filled, fillcolor="paleturquoise1", label="DD:minThick"];
+    "dataDefn:loadDurFactor" [shape=box, color=black, style=filled, fillcolor="paleturquoise1", label="DD:loadDurFactor"];
+    "dataDefn:glassTypeFac" [shape=box, color=black, style=filled, fillcolor="paleturquoise1", label="DD:gTF"];
+    "dataDefn:stdOffDist" [shape=box, color=black, style=filled, fillcolor="paleturquoise1", label="DD:standOffDist"];
+    "dataDefn:aR" [shape=box, color=black, style=filled, fillcolor="paleturquoise1", label="DD:aspectRatio"];
+    "dataDefn:eqTNTChar" [shape=box, color=black, style=filled, fillcolor="paleturquoise1", label="DD:eqTNTW"];
+    "dataDefn:demandq" [shape=box, color=black, style=filled, fillcolor="paleturquoise1", label="DD:calofDemand"];
+    subgraph "DD" {
+        rank="same";
+        "dataDefn:minThick" "dataDefn:loadDurFactor" "dataDefn:glassTypeFac" "dataDefn:stdOffDist" "dataDefn:aR" "dataDefn:eqTNTChar" "dataDefn:demandq";
+    }
+    "theory:isSafeProb" [shape=box, color=black, style=filled, fillcolor="pink", label="TM:isSafeProb"];
+    "theory:isSafeLoad" [shape=box, color=black, style=filled, fillcolor="pink", label="TM:isSafeLoad"];
+    subgraph "TM" {
+        rank="same";
+        "theory:isSafeProb" "theory:isSafeLoad";
+    }
+    "theory:riskFun" [shape=box, color=black, style=filled, fillcolor="khaki1", label="IM:riskFun"];
+    "theory:stressDistFac" [shape=box, color=black, style=filled, fillcolor="khaki1", label="IM:stressDistFac"];
+    "theory:nFL" [shape=box, color=black, style=filled, fillcolor="khaki1", label="IM:nFL"];
+    "theory:dimlessLoad" [shape=box, color=black, style=filled, fillcolor="khaki1", label="IM:dimlessLoad"];
+    "theory:tolLoad" [shape=box, color=black, style=filled, fillcolor="khaki1", label="IM:tolLoad"];
+    "theory:sdfTol" [shape=box, color=black, style=filled, fillcolor="khaki1", label="IM:sdfTol"];
+    "theory:probBr" [shape=box, color=black, style=filled, fillcolor="khaki1", label="IM:probOfBreak"];
+    "theory:lResistance" [shape=box, color=black, style=filled, fillcolor="khaki1", label="IM:calofCapacity"];
+    "theory:isSafePb" [shape=box, color=black, style=filled, fillcolor="khaki1", label="IM:isSafePb"];
+    "theory:isSafeLR" [shape=box, color=black, style=filled, fillcolor="khaki1", label="IM:isSafeLR"];
+    subgraph "IM" {
+        rank="same";
+        "theory:riskFun" "theory:stressDistFac" "theory:nFL" "theory:dimlessLoad" "theory:tolLoad" "theory:sdfTol" "theory:probBr" "theory:lResistance" "theory:isSafePb" "theory:isSafeLR";
+    }
+    "instance:inputValues" [shape=box, color=black, style=filled, fillcolor="ivory", label="FR:inputValues"];
+    "instance:sysSetValsFollowingAssumps" [shape=box, color=black, style=filled, fillcolor="ivory", label="FR:sysSetValsFollowingAssumps"];
+    "instance:checkInputWithDataCons" [shape=box, color=black, style=filled, fillcolor="ivory", label="FR:checkInputWithDataCons"];
+    "instance:outputValsAndKnownValues" [shape=box, color=black, style=filled, fillcolor="ivory", label="FR:outputValsAndKnownValues"];
+    "instance:checkGlassSafety" [shape=box, color=black, style=filled, fillcolor="ivory", label="FR:checkGlassSafety"];
+    "instance:outputValues" [shape=box, color=black, style=filled, fillcolor="ivory", label="FR:outputValues"];
+    "instance:correct" [shape=box, color=black, style=filled, fillcolor="ivory", label="NFR:correct"];
+    "instance:verifiable" [shape=box, color=black, style=filled, fillcolor="ivory", label="NFR:verifiable"];
+    "instance:understandable" [shape=box, color=black, style=filled, fillcolor="ivory", label="NFR:understandable"];
+    "instance:reusable" [shape=box, color=black, style=filled, fillcolor="ivory", label="NFR:reusable"];
+    "instance:maintainable" [shape=box, color=black, style=filled, fillcolor="ivory", label="NFR:maintainable"];
+    "instance:portable" [shape=box, color=black, style=filled, fillcolor="ivory", label="NFR:portable"];
+    subgraph "FR" {
+        rank="same";
+        "instance:inputValues" "instance:sysSetValsFollowingAssumps" "instance:checkInputWithDataCons" "instance:outputValsAndKnownValues" "instance:checkGlassSafety" "instance:outputValues" "instance:correct" "instance:verifiable" "instance:understandable" "instance:reusable" "instance:maintainable" "instance:portable";
+    }
+    "instance:calcInternalBlastRisk" [shape=box, color=black, style=filled, fillcolor="lavender", label="LC:calcInternalBlastRisk"];
+    "instance:varValsOfmkE" [shape=box, color=black, style=filled, fillcolor="lavender", label="LC:varValsOfmkE"];
+    "instance:accMoreThanSingleLite" [shape=box, color=black, style=filled, fillcolor="lavender", label="LC:accMoreThanSingleLite"];
+    "instance:accMoreBoundaryConditions" [shape=box, color=black, style=filled, fillcolor="lavender", label="LC:accMoreBoundaryConditions"];
+    "instance:considerMoreThanFlexGlass" [shape=box, color=black, style=filled, fillcolor="lavender", label="LC:considerMoreThanFlexGlass"];
+    "instance:predictWithstandOfCertDeg" [shape=box, color=black, style=filled, fillcolor="lavender", label="UC:predictWithstandOfCertDeg"];
+    "instance:accAlteredGlass" [shape=box, color=black, style=filled, fillcolor="lavender", label="UC:accAlteredGlass"];
+    subgraph "LC" {
+        rank="same";
+        "instance:calcInternalBlastRisk" "instance:varValsOfmkE" "instance:accMoreThanSingleLite" "instance:accMoreBoundaryConditions" "instance:considerMoreThanFlexGlass" "instance:predictWithstandOfCertDeg" "instance:accAlteredGlass";
+    }
 }

--- a/code/stable/glassbr/TraceyGraph/refvsref.dot
+++ b/code/stable/glassbr/TraceyGraph/refvsref.dot
@@ -1,65 +1,57 @@
-digraph refvsref {
-	dataDefn:demandq -> dataDefn:stdOffDist;
-	dataDefn:demandq -> dataDefn:eqTNTChar;
-	theory:riskFun -> dataDefn:minThick;
-	theory:riskFun -> dataDefn:loadDurFactor;
-	theory:riskFun -> theory:stressDistFac;
-	theory:stressDistFac -> dataDefn:aR;
-	theory:stressDistFac -> theory:dimlessLoad;
-	theory:nFL -> dataDefn:minThick;
-	theory:nFL -> theory:tolLoad;
-	theory:dimlessLoad -> dataDefn:minThick;
-	theory:dimlessLoad -> dataDefn:glassTypeFac;
-	theory:dimlessLoad -> dataDefn:demandq;
-	theory:tolLoad -> dataDefn:aR;
-	theory:tolLoad -> theory:sdfTol;
-	theory:sdfTol -> dataDefn:minThick;
-	theory:sdfTol -> dataDefn:loadDurFactor;
-	theory:probBr -> theory:riskFun;
-	theory:lResistance -> dataDefn:glassTypeFac;
-	theory:lResistance -> theory:nFL;
-	theory:isSafePb -> theory:probBr;
-	theory:isSafePb -> theory:isSafeLR;
-	theory:isSafeLR -> dataDefn:demandq;
-	theory:isSafeLR -> theory:lResistance;
-	theory:isSafeLR -> theory:isSafePb;
-
-
-	dataDefn:minThick	[shape=box, color=black, style=filled, fillcolor=paleturquoise1, label="DD:minThick"];
-	dataDefn:loadDurFactor	[shape=box, color=black, style=filled, fillcolor=paleturquoise1, label="DD:loadDurFactor"];
-	dataDefn:glassTypeFac	[shape=box, color=black, style=filled, fillcolor=paleturquoise1, label="DD:gTF"];
-	dataDefn:stdOffDist	[shape=box, color=black, style=filled, fillcolor=paleturquoise1, label="DD:standOffDist"];
-	dataDefn:aR	[shape=box, color=black, style=filled, fillcolor=paleturquoise1, label="DD:aspectRatio"];
-	dataDefn:eqTNTChar	[shape=box, color=black, style=filled, fillcolor=paleturquoise1, label="DD:eqTNTW"];
-	dataDefn:demandq	[shape=box, color=black, style=filled, fillcolor=paleturquoise1, label="DD:calofDemand"];
-
-	subgraph DD {
-	rank="same"
-	{dataDefn:minThick, dataDefn:loadDurFactor, dataDefn:glassTypeFac, dataDefn:stdOffDist, dataDefn:aR, dataDefn:eqTNTChar, dataDefn:demandq}
-	}
-
-	theory:isSafeProb	[shape=box, color=black, style=filled, fillcolor=pink, label="TM:isSafeProb"];
-	theory:isSafeLoad	[shape=box, color=black, style=filled, fillcolor=pink, label="TM:isSafeLoad"];
-
-	subgraph TM {
-	rank="same"
-	{theory:isSafeProb, theory:isSafeLoad}
-	}
-
-	theory:riskFun	[shape=box, color=black, style=filled, fillcolor=khaki1, label="IM:riskFun"];
-	theory:stressDistFac	[shape=box, color=black, style=filled, fillcolor=khaki1, label="IM:stressDistFac"];
-	theory:nFL	[shape=box, color=black, style=filled, fillcolor=khaki1, label="IM:nFL"];
-	theory:dimlessLoad	[shape=box, color=black, style=filled, fillcolor=khaki1, label="IM:dimlessLoad"];
-	theory:tolLoad	[shape=box, color=black, style=filled, fillcolor=khaki1, label="IM:tolLoad"];
-	theory:sdfTol	[shape=box, color=black, style=filled, fillcolor=khaki1, label="IM:sdfTol"];
-	theory:probBr	[shape=box, color=black, style=filled, fillcolor=khaki1, label="IM:probOfBreak"];
-	theory:lResistance	[shape=box, color=black, style=filled, fillcolor=khaki1, label="IM:calofCapacity"];
-	theory:isSafePb	[shape=box, color=black, style=filled, fillcolor=khaki1, label="IM:isSafePb"];
-	theory:isSafeLR	[shape=box, color=black, style=filled, fillcolor=khaki1, label="IM:isSafeLR"];
-
-	subgraph IM {
-	rank="same"
-	{theory:riskFun, theory:stressDistFac, theory:nFL, theory:dimlessLoad, theory:tolLoad, theory:sdfTol, theory:probBr, theory:lResistance, theory:isSafePb, theory:isSafeLR}
-	}
-
+digraph "refvsref" {
+    "dataDefn:demandq" -> "dataDefn:stdOffDist";
+    "dataDefn:demandq" -> "dataDefn:eqTNTChar";
+    "theory:riskFun" -> "dataDefn:minThick";
+    "theory:riskFun" -> "dataDefn:loadDurFactor";
+    "theory:riskFun" -> "theory:stressDistFac";
+    "theory:stressDistFac" -> "dataDefn:aR";
+    "theory:stressDistFac" -> "theory:dimlessLoad";
+    "theory:nFL" -> "dataDefn:minThick";
+    "theory:nFL" -> "theory:tolLoad";
+    "theory:dimlessLoad" -> "dataDefn:minThick";
+    "theory:dimlessLoad" -> "dataDefn:glassTypeFac";
+    "theory:dimlessLoad" -> "dataDefn:demandq";
+    "theory:tolLoad" -> "dataDefn:aR";
+    "theory:tolLoad" -> "theory:sdfTol";
+    "theory:sdfTol" -> "dataDefn:minThick";
+    "theory:sdfTol" -> "dataDefn:loadDurFactor";
+    "theory:probBr" -> "theory:riskFun";
+    "theory:lResistance" -> "dataDefn:glassTypeFac";
+    "theory:lResistance" -> "theory:nFL";
+    "theory:isSafePb" -> "theory:probBr";
+    "theory:isSafePb" -> "theory:isSafeLR";
+    "theory:isSafeLR" -> "dataDefn:demandq";
+    "theory:isSafeLR" -> "theory:lResistance";
+    "theory:isSafeLR" -> "theory:isSafePb";
+    "dataDefn:minThick" [shape=box, color=black, style=filled, fillcolor="paleturquoise1", label="DD:minThick"];
+    "dataDefn:loadDurFactor" [shape=box, color=black, style=filled, fillcolor="paleturquoise1", label="DD:loadDurFactor"];
+    "dataDefn:glassTypeFac" [shape=box, color=black, style=filled, fillcolor="paleturquoise1", label="DD:gTF"];
+    "dataDefn:stdOffDist" [shape=box, color=black, style=filled, fillcolor="paleturquoise1", label="DD:standOffDist"];
+    "dataDefn:aR" [shape=box, color=black, style=filled, fillcolor="paleturquoise1", label="DD:aspectRatio"];
+    "dataDefn:eqTNTChar" [shape=box, color=black, style=filled, fillcolor="paleturquoise1", label="DD:eqTNTW"];
+    "dataDefn:demandq" [shape=box, color=black, style=filled, fillcolor="paleturquoise1", label="DD:calofDemand"];
+    subgraph "DD" {
+        rank="same";
+        "dataDefn:minThick" "dataDefn:loadDurFactor" "dataDefn:glassTypeFac" "dataDefn:stdOffDist" "dataDefn:aR" "dataDefn:eqTNTChar" "dataDefn:demandq";
+    }
+    "theory:isSafeProb" [shape=box, color=black, style=filled, fillcolor="pink", label="TM:isSafeProb"];
+    "theory:isSafeLoad" [shape=box, color=black, style=filled, fillcolor="pink", label="TM:isSafeLoad"];
+    subgraph "TM" {
+        rank="same";
+        "theory:isSafeProb" "theory:isSafeLoad";
+    }
+    "theory:riskFun" [shape=box, color=black, style=filled, fillcolor="khaki1", label="IM:riskFun"];
+    "theory:stressDistFac" [shape=box, color=black, style=filled, fillcolor="khaki1", label="IM:stressDistFac"];
+    "theory:nFL" [shape=box, color=black, style=filled, fillcolor="khaki1", label="IM:nFL"];
+    "theory:dimlessLoad" [shape=box, color=black, style=filled, fillcolor="khaki1", label="IM:dimlessLoad"];
+    "theory:tolLoad" [shape=box, color=black, style=filled, fillcolor="khaki1", label="IM:tolLoad"];
+    "theory:sdfTol" [shape=box, color=black, style=filled, fillcolor="khaki1", label="IM:sdfTol"];
+    "theory:probBr" [shape=box, color=black, style=filled, fillcolor="khaki1", label="IM:probOfBreak"];
+    "theory:lResistance" [shape=box, color=black, style=filled, fillcolor="khaki1", label="IM:calofCapacity"];
+    "theory:isSafePb" [shape=box, color=black, style=filled, fillcolor="khaki1", label="IM:isSafePb"];
+    "theory:isSafeLR" [shape=box, color=black, style=filled, fillcolor="khaki1", label="IM:isSafeLR"];
+    subgraph "IM" {
+        rank="same";
+        "theory:riskFun" "theory:stressDistFac" "theory:nFL" "theory:dimlessLoad" "theory:tolLoad" "theory:sdfTol" "theory:probBr" "theory:lResistance" "theory:isSafePb" "theory:isSafeLR";
+    }
 }

--- a/code/stable/hghc/TraceyGraph/allvsall.dot
+++ b/code/stable/hghc/TraceyGraph/allvsall.dot
@@ -1,4 +1,2 @@
-digraph allvsall {
-
-
+digraph "allvsall" {
 }

--- a/code/stable/hghc/TraceyGraph/allvsr.dot
+++ b/code/stable/hghc/TraceyGraph/allvsr.dot
@@ -1,4 +1,2 @@
-digraph allvsr {
-
-
+digraph "allvsr" {
 }

--- a/code/stable/hghc/TraceyGraph/avsa.dot
+++ b/code/stable/hghc/TraceyGraph/avsa.dot
@@ -1,4 +1,2 @@
-digraph avsa {
-
-
+digraph "avsa" {
 }

--- a/code/stable/hghc/TraceyGraph/avsall.dot
+++ b/code/stable/hghc/TraceyGraph/avsall.dot
@@ -1,4 +1,2 @@
-digraph avsall {
-
-
+digraph "avsall" {
 }

--- a/code/stable/hghc/TraceyGraph/refvsref.dot
+++ b/code/stable/hghc/TraceyGraph/refvsref.dot
@@ -1,4 +1,2 @@
-digraph refvsref {
-
-
+digraph "refvsref" {
 }

--- a/code/stable/pdcontroller/TraceyGraph/allvsall.dot
+++ b/code/stable/pdcontroller/TraceyGraph/allvsall.dot
@@ -1,115 +1,97 @@
-digraph allvsall {
-	instance:pwrPlantTxFnx -> instance:pwrPlant;
-	instance:massSpring -> instance:pwrPlant;
-	instance:dampingCoeffSpring -> instance:pwrPlant;
-	instance:stiffnessCoeffSpring -> instance:pwrPlant;
-	dataDefn:dqdProcessErrorFD -> instance:setPointConstant;
-	dataDefn:dqdProcessErrorFD -> instance:initialValue;
-	dataDefn:dqdProcessErrorFD -> theory:laplaceRC;
-	dataDefn:dqdPropControlFD -> dataDefn:dqdProcessErrorFD;
-	dataDefn:dqdPropControlFD -> theory:laplaceRC;
-	dataDefn:dqdDerivativeControlFD -> instance:unfilteredDerivative;
-	dataDefn:dqdDerivativeControlFD -> dataDefn:dqdProcessErrorFD;
-	dataDefn:dqdDerivativeControlFD -> theory:laplaceRC;
-	dataDefn:dqdCtrlVarFD -> instance:decoupled;
-	dataDefn:dqdCtrlVarFD -> instance:parallelEq;
-	dataDefn:dqdCtrlVarFD -> dataDefn:dqdPropControlFD;
-	dataDefn:dqdCtrlVarFD -> dataDefn:dqdDerivativeControlFD;
-	theory:tmSOSystemRC -> instance:pwrPlantTxFnx;
-	theory:gdPowerPlantRC -> instance:externalDisturb;
-	theory:gdPowerPlantRC -> instance:massSpring;
-	theory:gdPowerPlantRC -> instance:dampingCoeffSpring;
-	theory:gdPowerPlantRC -> instance:stiffnessCoeffSpring;
-	theory:gdPowerPlantRC -> theory:laplaceRC;
-	theory:gdPowerPlantRC -> theory:tmSOSystemRC;
-	theory:imPDRC -> instance:setPointConstant;
-	theory:imPDRC -> dataDefn:dqdProcessErrorFD;
-	theory:imPDRC -> dataDefn:dqdCtrlVarFD;
-	theory:imPDRC -> theory:invLaplaceRC;
-	theory:imPDRC -> theory:gdPowerPlantRC;
-	instance:calculateValues -> theory:imPDRC;
-	instance:outputValues -> theory:imPDRC;
-	instance:likeChgPP -> instance:massSpring;
-	instance:likeChgPP -> instance:dampingCoeffSpring;
-	instance:likeChgPP -> instance:stiffnessCoeffSpring;
-
-
-	instance:pwrPlant	[shape=box, color=black, style=filled, fillcolor=mistyrose, label="A:pwrPlant"];
-	instance:decoupled	[shape=box, color=black, style=filled, fillcolor=mistyrose, label="A:decoupled"];
-	instance:setPointConstant	[shape=box, color=black, style=filled, fillcolor=mistyrose, label="A:setPointConstant"];
-	instance:externalDisturb	[shape=box, color=black, style=filled, fillcolor=mistyrose, label="A:externalDisturb"];
-	instance:initialValue	[shape=box, color=black, style=filled, fillcolor=mistyrose, label="A:initialValue"];
-	instance:parallelEq	[shape=box, color=black, style=filled, fillcolor=mistyrose, label="A:parallelEq"];
-	instance:unfilteredDerivative	[shape=box, color=black, style=filled, fillcolor=mistyrose, label="A:unfilteredDerivative"];
-	instance:pwrPlantTxFnx	[shape=box, color=black, style=filled, fillcolor=mistyrose, label="A:pwrPlantTxFnx"];
-	instance:massSpring	[shape=box, color=black, style=filled, fillcolor=mistyrose, label="A:massSpring"];
-	instance:dampingCoeffSpring	[shape=box, color=black, style=filled, fillcolor=mistyrose, label="A:dampingCoeffSpring"];
-	instance:stiffnessCoeffSpring	[shape=box, color=black, style=filled, fillcolor=mistyrose, label="A:stiffnessCoeffSpring"];
-
-	subgraph A {
-	rank="same"
-	{instance:pwrPlant, instance:decoupled, instance:setPointConstant, instance:externalDisturb, instance:initialValue, instance:parallelEq, instance:unfilteredDerivative, instance:pwrPlantTxFnx, instance:massSpring, instance:dampingCoeffSpring, instance:stiffnessCoeffSpring}
-	}
-
-	dataDefn:dqdProcessErrorFD	[shape=box, color=black, style=filled, fillcolor=paleturquoise1, label="DD:ddProcessError"];
-	dataDefn:dqdPropControlFD	[shape=box, color=black, style=filled, fillcolor=paleturquoise1, label="DD:ddPropCtrl"];
-	dataDefn:dqdDerivativeControlFD	[shape=box, color=black, style=filled, fillcolor=paleturquoise1, label="DD:ddDerivCtrl"];
-	dataDefn:dqdCtrlVarFD	[shape=box, color=black, style=filled, fillcolor=paleturquoise1, label="DD:ddCtrlVar"];
-
-	subgraph DD {
-	rank="same"
-	{dataDefn:dqdProcessErrorFD, dataDefn:dqdPropControlFD, dataDefn:dqdDerivativeControlFD, dataDefn:dqdCtrlVarFD}
-	}
-
-	theory:laplaceRC	[shape=box, color=black, style=filled, fillcolor=pink, label="TM:laplaceTransform"];
-	theory:invLaplaceRC	[shape=box, color=black, style=filled, fillcolor=pink, label="TM:invLaplaceTransform"];
-	theory:tmSOSystemRC	[shape=box, color=black, style=filled, fillcolor=pink, label="TM:tmSOSystem"];
-
-	subgraph TM {
-	rank="same"
-	{theory:laplaceRC, theory:invLaplaceRC, theory:tmSOSystemRC}
-	}
-
-	theory:gdPowerPlantRC	[shape=box, color=black, style=filled, fillcolor=palegreen, label="GD:gdPowerPlant"];
-
-	subgraph GD {
-	rank="same"
-	{theory:gdPowerPlantRC}
-	}
-
-	theory:imPDRC	[shape=box, color=black, style=filled, fillcolor=khaki1, label="IM:pdEquationIM"];
-
-	subgraph IM {
-	rank="same"
-	{theory:imPDRC}
-	}
-
-	instance:inputValues	[shape=box, color=black, style=filled, fillcolor=ivory, label="FR:inputValues"];
-	instance:verifyInputs	[shape=box, color=black, style=filled, fillcolor=ivory, label="FR:verifyInputs"];
-	instance:calculateValues	[shape=box, color=black, style=filled, fillcolor=ivory, label="FR:calculateValues"];
-	instance:outputValues	[shape=box, color=black, style=filled, fillcolor=ivory, label="FR:outputValues"];
-	instance:portable	[shape=box, color=black, style=filled, fillcolor=ivory, label="NFR:portable"];
-	instance:security	[shape=box, color=black, style=filled, fillcolor=ivory, label="NFR:security"];
-	instance:maintainability	[shape=box, color=black, style=filled, fillcolor=ivory, label="NFR:maintainability"];
-	instance:verifiability	[shape=box, color=black, style=filled, fillcolor=ivory, label="NFR:verifiability"];
-
-	subgraph FR {
-	rank="same"
-	{instance:inputValues, instance:verifyInputs, instance:calculateValues, instance:outputValues, instance:portable, instance:security, instance:maintainability, instance:verifiability}
-	}
-
-	instance:calculateProcessVariable	[shape=box, color=black, style=filled, fillcolor=darkgoldenrod1, label="GS:calculateProcessVariable"];
-
-	subgraph GS {
-	rank="same"
-	{instance:calculateProcessVariable}
-	}
-
-	instance:likeChgPP	[shape=box, color=black, style=filled, fillcolor=lavender, label="LC:likeChgPP"];
-
-	subgraph LC {
-	rank="same"
-	{instance:likeChgPP}
-	}
-
+digraph "allvsall" {
+    "instance:pwrPlantTxFnx" -> "instance:pwrPlant";
+    "instance:massSpring" -> "instance:pwrPlant";
+    "instance:dampingCoeffSpring" -> "instance:pwrPlant";
+    "instance:stiffnessCoeffSpring" -> "instance:pwrPlant";
+    "dataDefn:dqdProcessErrorFD" -> "instance:setPointConstant";
+    "dataDefn:dqdProcessErrorFD" -> "instance:initialValue";
+    "dataDefn:dqdProcessErrorFD" -> "theory:laplaceRC";
+    "dataDefn:dqdPropControlFD" -> "dataDefn:dqdProcessErrorFD";
+    "dataDefn:dqdPropControlFD" -> "theory:laplaceRC";
+    "dataDefn:dqdDerivativeControlFD" -> "instance:unfilteredDerivative";
+    "dataDefn:dqdDerivativeControlFD" -> "dataDefn:dqdProcessErrorFD";
+    "dataDefn:dqdDerivativeControlFD" -> "theory:laplaceRC";
+    "dataDefn:dqdCtrlVarFD" -> "instance:decoupled";
+    "dataDefn:dqdCtrlVarFD" -> "instance:parallelEq";
+    "dataDefn:dqdCtrlVarFD" -> "dataDefn:dqdPropControlFD";
+    "dataDefn:dqdCtrlVarFD" -> "dataDefn:dqdDerivativeControlFD";
+    "theory:tmSOSystemRC" -> "instance:pwrPlantTxFnx";
+    "theory:gdPowerPlantRC" -> "instance:externalDisturb";
+    "theory:gdPowerPlantRC" -> "instance:massSpring";
+    "theory:gdPowerPlantRC" -> "instance:dampingCoeffSpring";
+    "theory:gdPowerPlantRC" -> "instance:stiffnessCoeffSpring";
+    "theory:gdPowerPlantRC" -> "theory:laplaceRC";
+    "theory:gdPowerPlantRC" -> "theory:tmSOSystemRC";
+    "theory:imPDRC" -> "instance:setPointConstant";
+    "theory:imPDRC" -> "dataDefn:dqdProcessErrorFD";
+    "theory:imPDRC" -> "dataDefn:dqdCtrlVarFD";
+    "theory:imPDRC" -> "theory:invLaplaceRC";
+    "theory:imPDRC" -> "theory:gdPowerPlantRC";
+    "instance:calculateValues" -> "theory:imPDRC";
+    "instance:outputValues" -> "theory:imPDRC";
+    "instance:likeChgPP" -> "instance:massSpring";
+    "instance:likeChgPP" -> "instance:dampingCoeffSpring";
+    "instance:likeChgPP" -> "instance:stiffnessCoeffSpring";
+    "instance:pwrPlant" [shape=box, color=black, style=filled, fillcolor="mistyrose", label="A:pwrPlant"];
+    "instance:decoupled" [shape=box, color=black, style=filled, fillcolor="mistyrose", label="A:decoupled"];
+    "instance:setPointConstant" [shape=box, color=black, style=filled, fillcolor="mistyrose", label="A:setPointConstant"];
+    "instance:externalDisturb" [shape=box, color=black, style=filled, fillcolor="mistyrose", label="A:externalDisturb"];
+    "instance:initialValue" [shape=box, color=black, style=filled, fillcolor="mistyrose", label="A:initialValue"];
+    "instance:parallelEq" [shape=box, color=black, style=filled, fillcolor="mistyrose", label="A:parallelEq"];
+    "instance:unfilteredDerivative" [shape=box, color=black, style=filled, fillcolor="mistyrose", label="A:unfilteredDerivative"];
+    "instance:pwrPlantTxFnx" [shape=box, color=black, style=filled, fillcolor="mistyrose", label="A:pwrPlantTxFnx"];
+    "instance:massSpring" [shape=box, color=black, style=filled, fillcolor="mistyrose", label="A:massSpring"];
+    "instance:dampingCoeffSpring" [shape=box, color=black, style=filled, fillcolor="mistyrose", label="A:dampingCoeffSpring"];
+    "instance:stiffnessCoeffSpring" [shape=box, color=black, style=filled, fillcolor="mistyrose", label="A:stiffnessCoeffSpring"];
+    subgraph "A" {
+        rank="same";
+        "instance:pwrPlant" "instance:decoupled" "instance:setPointConstant" "instance:externalDisturb" "instance:initialValue" "instance:parallelEq" "instance:unfilteredDerivative" "instance:pwrPlantTxFnx" "instance:massSpring" "instance:dampingCoeffSpring" "instance:stiffnessCoeffSpring";
+    }
+    "dataDefn:dqdProcessErrorFD" [shape=box, color=black, style=filled, fillcolor="paleturquoise1", label="DD:ddProcessError"];
+    "dataDefn:dqdPropControlFD" [shape=box, color=black, style=filled, fillcolor="paleturquoise1", label="DD:ddPropCtrl"];
+    "dataDefn:dqdDerivativeControlFD" [shape=box, color=black, style=filled, fillcolor="paleturquoise1", label="DD:ddDerivCtrl"];
+    "dataDefn:dqdCtrlVarFD" [shape=box, color=black, style=filled, fillcolor="paleturquoise1", label="DD:ddCtrlVar"];
+    subgraph "DD" {
+        rank="same";
+        "dataDefn:dqdProcessErrorFD" "dataDefn:dqdPropControlFD" "dataDefn:dqdDerivativeControlFD" "dataDefn:dqdCtrlVarFD";
+    }
+    "theory:laplaceRC" [shape=box, color=black, style=filled, fillcolor="pink", label="TM:laplaceTransform"];
+    "theory:invLaplaceRC" [shape=box, color=black, style=filled, fillcolor="pink", label="TM:invLaplaceTransform"];
+    "theory:tmSOSystemRC" [shape=box, color=black, style=filled, fillcolor="pink", label="TM:tmSOSystem"];
+    subgraph "TM" {
+        rank="same";
+        "theory:laplaceRC" "theory:invLaplaceRC" "theory:tmSOSystemRC";
+    }
+    "theory:gdPowerPlantRC" [shape=box, color=black, style=filled, fillcolor="palegreen", label="GD:gdPowerPlant"];
+    subgraph "GD" {
+        rank="same";
+        "theory:gdPowerPlantRC";
+    }
+    "theory:imPDRC" [shape=box, color=black, style=filled, fillcolor="khaki1", label="IM:pdEquationIM"];
+    subgraph "IM" {
+        rank="same";
+        "theory:imPDRC";
+    }
+    "instance:inputValues" [shape=box, color=black, style=filled, fillcolor="ivory", label="FR:inputValues"];
+    "instance:verifyInputs" [shape=box, color=black, style=filled, fillcolor="ivory", label="FR:verifyInputs"];
+    "instance:calculateValues" [shape=box, color=black, style=filled, fillcolor="ivory", label="FR:calculateValues"];
+    "instance:outputValues" [shape=box, color=black, style=filled, fillcolor="ivory", label="FR:outputValues"];
+    "instance:portable" [shape=box, color=black, style=filled, fillcolor="ivory", label="NFR:portable"];
+    "instance:security" [shape=box, color=black, style=filled, fillcolor="ivory", label="NFR:security"];
+    "instance:maintainability" [shape=box, color=black, style=filled, fillcolor="ivory", label="NFR:maintainability"];
+    "instance:verifiability" [shape=box, color=black, style=filled, fillcolor="ivory", label="NFR:verifiability"];
+    subgraph "FR" {
+        rank="same";
+        "instance:inputValues" "instance:verifyInputs" "instance:calculateValues" "instance:outputValues" "instance:portable" "instance:security" "instance:maintainability" "instance:verifiability";
+    }
+    "instance:calculateProcessVariable" [shape=box, color=black, style=filled, fillcolor="darkgoldenrod1", label="GS:calculateProcessVariable"];
+    subgraph "GS" {
+        rank="same";
+        "instance:calculateProcessVariable";
+    }
+    "instance:likeChgPP" [shape=box, color=black, style=filled, fillcolor="lavender", label="LC:likeChgPP"];
+    subgraph "LC" {
+        rank="same";
+        "instance:likeChgPP";
+    }
 }

--- a/code/stable/pdcontroller/TraceyGraph/allvsr.dot
+++ b/code/stable/pdcontroller/TraceyGraph/allvsr.dot
@@ -1,77 +1,61 @@
-digraph allvsr {
-	instance:calculateValues -> theory:imPDRC;
-	instance:outputValues -> theory:imPDRC;
-
-
-	instance:pwrPlant	[shape=box, color=black, style=filled, fillcolor=mistyrose, label="A:pwrPlant"];
-	instance:decoupled	[shape=box, color=black, style=filled, fillcolor=mistyrose, label="A:decoupled"];
-	instance:setPointConstant	[shape=box, color=black, style=filled, fillcolor=mistyrose, label="A:setPointConstant"];
-	instance:externalDisturb	[shape=box, color=black, style=filled, fillcolor=mistyrose, label="A:externalDisturb"];
-	instance:initialValue	[shape=box, color=black, style=filled, fillcolor=mistyrose, label="A:initialValue"];
-	instance:parallelEq	[shape=box, color=black, style=filled, fillcolor=mistyrose, label="A:parallelEq"];
-	instance:unfilteredDerivative	[shape=box, color=black, style=filled, fillcolor=mistyrose, label="A:unfilteredDerivative"];
-	instance:pwrPlantTxFnx	[shape=box, color=black, style=filled, fillcolor=mistyrose, label="A:pwrPlantTxFnx"];
-	instance:massSpring	[shape=box, color=black, style=filled, fillcolor=mistyrose, label="A:massSpring"];
-	instance:dampingCoeffSpring	[shape=box, color=black, style=filled, fillcolor=mistyrose, label="A:dampingCoeffSpring"];
-	instance:stiffnessCoeffSpring	[shape=box, color=black, style=filled, fillcolor=mistyrose, label="A:stiffnessCoeffSpring"];
-
-	subgraph A {
-	rank="same"
-	{instance:pwrPlant, instance:decoupled, instance:setPointConstant, instance:externalDisturb, instance:initialValue, instance:parallelEq, instance:unfilteredDerivative, instance:pwrPlantTxFnx, instance:massSpring, instance:dampingCoeffSpring, instance:stiffnessCoeffSpring}
-	}
-
-	dataDefn:dqdProcessErrorFD	[shape=box, color=black, style=filled, fillcolor=paleturquoise1, label="DD:ddProcessError"];
-	dataDefn:dqdPropControlFD	[shape=box, color=black, style=filled, fillcolor=paleturquoise1, label="DD:ddPropCtrl"];
-	dataDefn:dqdDerivativeControlFD	[shape=box, color=black, style=filled, fillcolor=paleturquoise1, label="DD:ddDerivCtrl"];
-	dataDefn:dqdCtrlVarFD	[shape=box, color=black, style=filled, fillcolor=paleturquoise1, label="DD:ddCtrlVar"];
-
-	subgraph DD {
-	rank="same"
-	{dataDefn:dqdProcessErrorFD, dataDefn:dqdPropControlFD, dataDefn:dqdDerivativeControlFD, dataDefn:dqdCtrlVarFD}
-	}
-
-	theory:laplaceRC	[shape=box, color=black, style=filled, fillcolor=pink, label="TM:laplaceTransform"];
-	theory:invLaplaceRC	[shape=box, color=black, style=filled, fillcolor=pink, label="TM:invLaplaceTransform"];
-	theory:tmSOSystemRC	[shape=box, color=black, style=filled, fillcolor=pink, label="TM:tmSOSystem"];
-
-	subgraph TM {
-	rank="same"
-	{theory:laplaceRC, theory:invLaplaceRC, theory:tmSOSystemRC}
-	}
-
-	theory:gdPowerPlantRC	[shape=box, color=black, style=filled, fillcolor=palegreen, label="GD:gdPowerPlant"];
-
-	subgraph GD {
-	rank="same"
-	{theory:gdPowerPlantRC}
-	}
-
-	theory:imPDRC	[shape=box, color=black, style=filled, fillcolor=khaki1, label="IM:pdEquationIM"];
-
-	subgraph IM {
-	rank="same"
-	{theory:imPDRC}
-	}
-
-	instance:inputValues	[shape=box, color=black, style=filled, fillcolor=ivory, label="FR:inputValues"];
-	instance:verifyInputs	[shape=box, color=black, style=filled, fillcolor=ivory, label="FR:verifyInputs"];
-	instance:calculateValues	[shape=box, color=black, style=filled, fillcolor=ivory, label="FR:calculateValues"];
-	instance:outputValues	[shape=box, color=black, style=filled, fillcolor=ivory, label="FR:outputValues"];
-	instance:portable	[shape=box, color=black, style=filled, fillcolor=ivory, label="NFR:portable"];
-	instance:security	[shape=box, color=black, style=filled, fillcolor=ivory, label="NFR:security"];
-	instance:maintainability	[shape=box, color=black, style=filled, fillcolor=ivory, label="NFR:maintainability"];
-	instance:verifiability	[shape=box, color=black, style=filled, fillcolor=ivory, label="NFR:verifiability"];
-
-	subgraph FR {
-	rank="same"
-	{instance:inputValues, instance:verifyInputs, instance:calculateValues, instance:outputValues, instance:portable, instance:security, instance:maintainability, instance:verifiability}
-	}
-
-	instance:calculateProcessVariable	[shape=box, color=black, style=filled, fillcolor=darkgoldenrod1, label="GS:calculateProcessVariable"];
-
-	subgraph GS {
-	rank="same"
-	{instance:calculateProcessVariable}
-	}
-
+digraph "allvsr" {
+    "instance:calculateValues" -> "theory:imPDRC";
+    "instance:outputValues" -> "theory:imPDRC";
+    "instance:pwrPlant" [shape=box, color=black, style=filled, fillcolor="mistyrose", label="A:pwrPlant"];
+    "instance:decoupled" [shape=box, color=black, style=filled, fillcolor="mistyrose", label="A:decoupled"];
+    "instance:setPointConstant" [shape=box, color=black, style=filled, fillcolor="mistyrose", label="A:setPointConstant"];
+    "instance:externalDisturb" [shape=box, color=black, style=filled, fillcolor="mistyrose", label="A:externalDisturb"];
+    "instance:initialValue" [shape=box, color=black, style=filled, fillcolor="mistyrose", label="A:initialValue"];
+    "instance:parallelEq" [shape=box, color=black, style=filled, fillcolor="mistyrose", label="A:parallelEq"];
+    "instance:unfilteredDerivative" [shape=box, color=black, style=filled, fillcolor="mistyrose", label="A:unfilteredDerivative"];
+    "instance:pwrPlantTxFnx" [shape=box, color=black, style=filled, fillcolor="mistyrose", label="A:pwrPlantTxFnx"];
+    "instance:massSpring" [shape=box, color=black, style=filled, fillcolor="mistyrose", label="A:massSpring"];
+    "instance:dampingCoeffSpring" [shape=box, color=black, style=filled, fillcolor="mistyrose", label="A:dampingCoeffSpring"];
+    "instance:stiffnessCoeffSpring" [shape=box, color=black, style=filled, fillcolor="mistyrose", label="A:stiffnessCoeffSpring"];
+    subgraph "A" {
+        rank="same";
+        "instance:pwrPlant" "instance:decoupled" "instance:setPointConstant" "instance:externalDisturb" "instance:initialValue" "instance:parallelEq" "instance:unfilteredDerivative" "instance:pwrPlantTxFnx" "instance:massSpring" "instance:dampingCoeffSpring" "instance:stiffnessCoeffSpring";
+    }
+    "dataDefn:dqdProcessErrorFD" [shape=box, color=black, style=filled, fillcolor="paleturquoise1", label="DD:ddProcessError"];
+    "dataDefn:dqdPropControlFD" [shape=box, color=black, style=filled, fillcolor="paleturquoise1", label="DD:ddPropCtrl"];
+    "dataDefn:dqdDerivativeControlFD" [shape=box, color=black, style=filled, fillcolor="paleturquoise1", label="DD:ddDerivCtrl"];
+    "dataDefn:dqdCtrlVarFD" [shape=box, color=black, style=filled, fillcolor="paleturquoise1", label="DD:ddCtrlVar"];
+    subgraph "DD" {
+        rank="same";
+        "dataDefn:dqdProcessErrorFD" "dataDefn:dqdPropControlFD" "dataDefn:dqdDerivativeControlFD" "dataDefn:dqdCtrlVarFD";
+    }
+    "theory:laplaceRC" [shape=box, color=black, style=filled, fillcolor="pink", label="TM:laplaceTransform"];
+    "theory:invLaplaceRC" [shape=box, color=black, style=filled, fillcolor="pink", label="TM:invLaplaceTransform"];
+    "theory:tmSOSystemRC" [shape=box, color=black, style=filled, fillcolor="pink", label="TM:tmSOSystem"];
+    subgraph "TM" {
+        rank="same";
+        "theory:laplaceRC" "theory:invLaplaceRC" "theory:tmSOSystemRC";
+    }
+    "theory:gdPowerPlantRC" [shape=box, color=black, style=filled, fillcolor="palegreen", label="GD:gdPowerPlant"];
+    subgraph "GD" {
+        rank="same";
+        "theory:gdPowerPlantRC";
+    }
+    "theory:imPDRC" [shape=box, color=black, style=filled, fillcolor="khaki1", label="IM:pdEquationIM"];
+    subgraph "IM" {
+        rank="same";
+        "theory:imPDRC";
+    }
+    "instance:inputValues" [shape=box, color=black, style=filled, fillcolor="ivory", label="FR:inputValues"];
+    "instance:verifyInputs" [shape=box, color=black, style=filled, fillcolor="ivory", label="FR:verifyInputs"];
+    "instance:calculateValues" [shape=box, color=black, style=filled, fillcolor="ivory", label="FR:calculateValues"];
+    "instance:outputValues" [shape=box, color=black, style=filled, fillcolor="ivory", label="FR:outputValues"];
+    "instance:portable" [shape=box, color=black, style=filled, fillcolor="ivory", label="NFR:portable"];
+    "instance:security" [shape=box, color=black, style=filled, fillcolor="ivory", label="NFR:security"];
+    "instance:maintainability" [shape=box, color=black, style=filled, fillcolor="ivory", label="NFR:maintainability"];
+    "instance:verifiability" [shape=box, color=black, style=filled, fillcolor="ivory", label="NFR:verifiability"];
+    subgraph "FR" {
+        rank="same";
+        "instance:inputValues" "instance:verifyInputs" "instance:calculateValues" "instance:outputValues" "instance:portable" "instance:security" "instance:maintainability" "instance:verifiability";
+    }
+    "instance:calculateProcessVariable" [shape=box, color=black, style=filled, fillcolor="darkgoldenrod1", label="GS:calculateProcessVariable"];
+    subgraph "GS" {
+        rank="same";
+        "instance:calculateProcessVariable";
+    }
 }

--- a/code/stable/pdcontroller/TraceyGraph/avsa.dot
+++ b/code/stable/pdcontroller/TraceyGraph/avsa.dot
@@ -1,25 +1,21 @@
-digraph avsa {
-	instance:pwrPlantTxFnx -> instance:pwrPlant;
-	instance:massSpring -> instance:pwrPlant;
-	instance:dampingCoeffSpring -> instance:pwrPlant;
-	instance:stiffnessCoeffSpring -> instance:pwrPlant;
-
-
-	instance:pwrPlant	[shape=box, color=black, style=filled, fillcolor=mistyrose, label="A:pwrPlant"];
-	instance:decoupled	[shape=box, color=black, style=filled, fillcolor=mistyrose, label="A:decoupled"];
-	instance:setPointConstant	[shape=box, color=black, style=filled, fillcolor=mistyrose, label="A:setPointConstant"];
-	instance:externalDisturb	[shape=box, color=black, style=filled, fillcolor=mistyrose, label="A:externalDisturb"];
-	instance:initialValue	[shape=box, color=black, style=filled, fillcolor=mistyrose, label="A:initialValue"];
-	instance:parallelEq	[shape=box, color=black, style=filled, fillcolor=mistyrose, label="A:parallelEq"];
-	instance:unfilteredDerivative	[shape=box, color=black, style=filled, fillcolor=mistyrose, label="A:unfilteredDerivative"];
-	instance:pwrPlantTxFnx	[shape=box, color=black, style=filled, fillcolor=mistyrose, label="A:pwrPlantTxFnx"];
-	instance:massSpring	[shape=box, color=black, style=filled, fillcolor=mistyrose, label="A:massSpring"];
-	instance:dampingCoeffSpring	[shape=box, color=black, style=filled, fillcolor=mistyrose, label="A:dampingCoeffSpring"];
-	instance:stiffnessCoeffSpring	[shape=box, color=black, style=filled, fillcolor=mistyrose, label="A:stiffnessCoeffSpring"];
-
-	subgraph A {
-	rank="same"
-	{instance:pwrPlant, instance:decoupled, instance:setPointConstant, instance:externalDisturb, instance:initialValue, instance:parallelEq, instance:unfilteredDerivative, instance:pwrPlantTxFnx, instance:massSpring, instance:dampingCoeffSpring, instance:stiffnessCoeffSpring}
-	}
-
+digraph "avsa" {
+    "instance:pwrPlantTxFnx" -> "instance:pwrPlant";
+    "instance:massSpring" -> "instance:pwrPlant";
+    "instance:dampingCoeffSpring" -> "instance:pwrPlant";
+    "instance:stiffnessCoeffSpring" -> "instance:pwrPlant";
+    "instance:pwrPlant" [shape=box, color=black, style=filled, fillcolor="mistyrose", label="A:pwrPlant"];
+    "instance:decoupled" [shape=box, color=black, style=filled, fillcolor="mistyrose", label="A:decoupled"];
+    "instance:setPointConstant" [shape=box, color=black, style=filled, fillcolor="mistyrose", label="A:setPointConstant"];
+    "instance:externalDisturb" [shape=box, color=black, style=filled, fillcolor="mistyrose", label="A:externalDisturb"];
+    "instance:initialValue" [shape=box, color=black, style=filled, fillcolor="mistyrose", label="A:initialValue"];
+    "instance:parallelEq" [shape=box, color=black, style=filled, fillcolor="mistyrose", label="A:parallelEq"];
+    "instance:unfilteredDerivative" [shape=box, color=black, style=filled, fillcolor="mistyrose", label="A:unfilteredDerivative"];
+    "instance:pwrPlantTxFnx" [shape=box, color=black, style=filled, fillcolor="mistyrose", label="A:pwrPlantTxFnx"];
+    "instance:massSpring" [shape=box, color=black, style=filled, fillcolor="mistyrose", label="A:massSpring"];
+    "instance:dampingCoeffSpring" [shape=box, color=black, style=filled, fillcolor="mistyrose", label="A:dampingCoeffSpring"];
+    "instance:stiffnessCoeffSpring" [shape=box, color=black, style=filled, fillcolor="mistyrose", label="A:stiffnessCoeffSpring"];
+    subgraph "A" {
+        rank="same";
+        "instance:pwrPlant" "instance:decoupled" "instance:setPointConstant" "instance:externalDisturb" "instance:initialValue" "instance:parallelEq" "instance:unfilteredDerivative" "instance:pwrPlantTxFnx" "instance:massSpring" "instance:dampingCoeffSpring" "instance:stiffnessCoeffSpring";
+    }
 }

--- a/code/stable/pdcontroller/TraceyGraph/avsall.dot
+++ b/code/stable/pdcontroller/TraceyGraph/avsall.dot
@@ -1,89 +1,73 @@
-digraph avsall {
-	dataDefn:dqdProcessErrorFD -> instance:setPointConstant;
-	dataDefn:dqdProcessErrorFD -> instance:initialValue;
-	dataDefn:dqdDerivativeControlFD -> instance:unfilteredDerivative;
-	dataDefn:dqdCtrlVarFD -> instance:decoupled;
-	dataDefn:dqdCtrlVarFD -> instance:parallelEq;
-	theory:tmSOSystemRC -> instance:pwrPlantTxFnx;
-	theory:gdPowerPlantRC -> instance:externalDisturb;
-	theory:gdPowerPlantRC -> instance:massSpring;
-	theory:gdPowerPlantRC -> instance:dampingCoeffSpring;
-	theory:gdPowerPlantRC -> instance:stiffnessCoeffSpring;
-	theory:imPDRC -> instance:setPointConstant;
-	instance:likeChgPP -> instance:massSpring;
-	instance:likeChgPP -> instance:dampingCoeffSpring;
-	instance:likeChgPP -> instance:stiffnessCoeffSpring;
-
-
-	instance:pwrPlant	[shape=box, color=black, style=filled, fillcolor=mistyrose, label="A:pwrPlant"];
-	instance:decoupled	[shape=box, color=black, style=filled, fillcolor=mistyrose, label="A:decoupled"];
-	instance:setPointConstant	[shape=box, color=black, style=filled, fillcolor=mistyrose, label="A:setPointConstant"];
-	instance:externalDisturb	[shape=box, color=black, style=filled, fillcolor=mistyrose, label="A:externalDisturb"];
-	instance:initialValue	[shape=box, color=black, style=filled, fillcolor=mistyrose, label="A:initialValue"];
-	instance:parallelEq	[shape=box, color=black, style=filled, fillcolor=mistyrose, label="A:parallelEq"];
-	instance:unfilteredDerivative	[shape=box, color=black, style=filled, fillcolor=mistyrose, label="A:unfilteredDerivative"];
-	instance:pwrPlantTxFnx	[shape=box, color=black, style=filled, fillcolor=mistyrose, label="A:pwrPlantTxFnx"];
-	instance:massSpring	[shape=box, color=black, style=filled, fillcolor=mistyrose, label="A:massSpring"];
-	instance:dampingCoeffSpring	[shape=box, color=black, style=filled, fillcolor=mistyrose, label="A:dampingCoeffSpring"];
-	instance:stiffnessCoeffSpring	[shape=box, color=black, style=filled, fillcolor=mistyrose, label="A:stiffnessCoeffSpring"];
-
-	subgraph A {
-	rank="same"
-	{instance:pwrPlant, instance:decoupled, instance:setPointConstant, instance:externalDisturb, instance:initialValue, instance:parallelEq, instance:unfilteredDerivative, instance:pwrPlantTxFnx, instance:massSpring, instance:dampingCoeffSpring, instance:stiffnessCoeffSpring}
-	}
-
-	dataDefn:dqdProcessErrorFD	[shape=box, color=black, style=filled, fillcolor=paleturquoise1, label="DD:ddProcessError"];
-	dataDefn:dqdPropControlFD	[shape=box, color=black, style=filled, fillcolor=paleturquoise1, label="DD:ddPropCtrl"];
-	dataDefn:dqdDerivativeControlFD	[shape=box, color=black, style=filled, fillcolor=paleturquoise1, label="DD:ddDerivCtrl"];
-	dataDefn:dqdCtrlVarFD	[shape=box, color=black, style=filled, fillcolor=paleturquoise1, label="DD:ddCtrlVar"];
-
-	subgraph DD {
-	rank="same"
-	{dataDefn:dqdProcessErrorFD, dataDefn:dqdPropControlFD, dataDefn:dqdDerivativeControlFD, dataDefn:dqdCtrlVarFD}
-	}
-
-	theory:laplaceRC	[shape=box, color=black, style=filled, fillcolor=pink, label="TM:laplaceTransform"];
-	theory:invLaplaceRC	[shape=box, color=black, style=filled, fillcolor=pink, label="TM:invLaplaceTransform"];
-	theory:tmSOSystemRC	[shape=box, color=black, style=filled, fillcolor=pink, label="TM:tmSOSystem"];
-
-	subgraph TM {
-	rank="same"
-	{theory:laplaceRC, theory:invLaplaceRC, theory:tmSOSystemRC}
-	}
-
-	theory:gdPowerPlantRC	[shape=box, color=black, style=filled, fillcolor=palegreen, label="GD:gdPowerPlant"];
-
-	subgraph GD {
-	rank="same"
-	{theory:gdPowerPlantRC}
-	}
-
-	theory:imPDRC	[shape=box, color=black, style=filled, fillcolor=khaki1, label="IM:pdEquationIM"];
-
-	subgraph IM {
-	rank="same"
-	{theory:imPDRC}
-	}
-
-	instance:inputValues	[shape=box, color=black, style=filled, fillcolor=ivory, label="FR:inputValues"];
-	instance:verifyInputs	[shape=box, color=black, style=filled, fillcolor=ivory, label="FR:verifyInputs"];
-	instance:calculateValues	[shape=box, color=black, style=filled, fillcolor=ivory, label="FR:calculateValues"];
-	instance:outputValues	[shape=box, color=black, style=filled, fillcolor=ivory, label="FR:outputValues"];
-	instance:portable	[shape=box, color=black, style=filled, fillcolor=ivory, label="NFR:portable"];
-	instance:security	[shape=box, color=black, style=filled, fillcolor=ivory, label="NFR:security"];
-	instance:maintainability	[shape=box, color=black, style=filled, fillcolor=ivory, label="NFR:maintainability"];
-	instance:verifiability	[shape=box, color=black, style=filled, fillcolor=ivory, label="NFR:verifiability"];
-
-	subgraph FR {
-	rank="same"
-	{instance:inputValues, instance:verifyInputs, instance:calculateValues, instance:outputValues, instance:portable, instance:security, instance:maintainability, instance:verifiability}
-	}
-
-	instance:likeChgPP	[shape=box, color=black, style=filled, fillcolor=lavender, label="LC:likeChgPP"];
-
-	subgraph LC {
-	rank="same"
-	{instance:likeChgPP}
-	}
-
+digraph "avsall" {
+    "dataDefn:dqdProcessErrorFD" -> "instance:setPointConstant";
+    "dataDefn:dqdProcessErrorFD" -> "instance:initialValue";
+    "dataDefn:dqdDerivativeControlFD" -> "instance:unfilteredDerivative";
+    "dataDefn:dqdCtrlVarFD" -> "instance:decoupled";
+    "dataDefn:dqdCtrlVarFD" -> "instance:parallelEq";
+    "theory:tmSOSystemRC" -> "instance:pwrPlantTxFnx";
+    "theory:gdPowerPlantRC" -> "instance:externalDisturb";
+    "theory:gdPowerPlantRC" -> "instance:massSpring";
+    "theory:gdPowerPlantRC" -> "instance:dampingCoeffSpring";
+    "theory:gdPowerPlantRC" -> "instance:stiffnessCoeffSpring";
+    "theory:imPDRC" -> "instance:setPointConstant";
+    "instance:likeChgPP" -> "instance:massSpring";
+    "instance:likeChgPP" -> "instance:dampingCoeffSpring";
+    "instance:likeChgPP" -> "instance:stiffnessCoeffSpring";
+    "instance:pwrPlant" [shape=box, color=black, style=filled, fillcolor="mistyrose", label="A:pwrPlant"];
+    "instance:decoupled" [shape=box, color=black, style=filled, fillcolor="mistyrose", label="A:decoupled"];
+    "instance:setPointConstant" [shape=box, color=black, style=filled, fillcolor="mistyrose", label="A:setPointConstant"];
+    "instance:externalDisturb" [shape=box, color=black, style=filled, fillcolor="mistyrose", label="A:externalDisturb"];
+    "instance:initialValue" [shape=box, color=black, style=filled, fillcolor="mistyrose", label="A:initialValue"];
+    "instance:parallelEq" [shape=box, color=black, style=filled, fillcolor="mistyrose", label="A:parallelEq"];
+    "instance:unfilteredDerivative" [shape=box, color=black, style=filled, fillcolor="mistyrose", label="A:unfilteredDerivative"];
+    "instance:pwrPlantTxFnx" [shape=box, color=black, style=filled, fillcolor="mistyrose", label="A:pwrPlantTxFnx"];
+    "instance:massSpring" [shape=box, color=black, style=filled, fillcolor="mistyrose", label="A:massSpring"];
+    "instance:dampingCoeffSpring" [shape=box, color=black, style=filled, fillcolor="mistyrose", label="A:dampingCoeffSpring"];
+    "instance:stiffnessCoeffSpring" [shape=box, color=black, style=filled, fillcolor="mistyrose", label="A:stiffnessCoeffSpring"];
+    subgraph "A" {
+        rank="same";
+        "instance:pwrPlant" "instance:decoupled" "instance:setPointConstant" "instance:externalDisturb" "instance:initialValue" "instance:parallelEq" "instance:unfilteredDerivative" "instance:pwrPlantTxFnx" "instance:massSpring" "instance:dampingCoeffSpring" "instance:stiffnessCoeffSpring";
+    }
+    "dataDefn:dqdProcessErrorFD" [shape=box, color=black, style=filled, fillcolor="paleturquoise1", label="DD:ddProcessError"];
+    "dataDefn:dqdPropControlFD" [shape=box, color=black, style=filled, fillcolor="paleturquoise1", label="DD:ddPropCtrl"];
+    "dataDefn:dqdDerivativeControlFD" [shape=box, color=black, style=filled, fillcolor="paleturquoise1", label="DD:ddDerivCtrl"];
+    "dataDefn:dqdCtrlVarFD" [shape=box, color=black, style=filled, fillcolor="paleturquoise1", label="DD:ddCtrlVar"];
+    subgraph "DD" {
+        rank="same";
+        "dataDefn:dqdProcessErrorFD" "dataDefn:dqdPropControlFD" "dataDefn:dqdDerivativeControlFD" "dataDefn:dqdCtrlVarFD";
+    }
+    "theory:laplaceRC" [shape=box, color=black, style=filled, fillcolor="pink", label="TM:laplaceTransform"];
+    "theory:invLaplaceRC" [shape=box, color=black, style=filled, fillcolor="pink", label="TM:invLaplaceTransform"];
+    "theory:tmSOSystemRC" [shape=box, color=black, style=filled, fillcolor="pink", label="TM:tmSOSystem"];
+    subgraph "TM" {
+        rank="same";
+        "theory:laplaceRC" "theory:invLaplaceRC" "theory:tmSOSystemRC";
+    }
+    "theory:gdPowerPlantRC" [shape=box, color=black, style=filled, fillcolor="palegreen", label="GD:gdPowerPlant"];
+    subgraph "GD" {
+        rank="same";
+        "theory:gdPowerPlantRC";
+    }
+    "theory:imPDRC" [shape=box, color=black, style=filled, fillcolor="khaki1", label="IM:pdEquationIM"];
+    subgraph "IM" {
+        rank="same";
+        "theory:imPDRC";
+    }
+    "instance:inputValues" [shape=box, color=black, style=filled, fillcolor="ivory", label="FR:inputValues"];
+    "instance:verifyInputs" [shape=box, color=black, style=filled, fillcolor="ivory", label="FR:verifyInputs"];
+    "instance:calculateValues" [shape=box, color=black, style=filled, fillcolor="ivory", label="FR:calculateValues"];
+    "instance:outputValues" [shape=box, color=black, style=filled, fillcolor="ivory", label="FR:outputValues"];
+    "instance:portable" [shape=box, color=black, style=filled, fillcolor="ivory", label="NFR:portable"];
+    "instance:security" [shape=box, color=black, style=filled, fillcolor="ivory", label="NFR:security"];
+    "instance:maintainability" [shape=box, color=black, style=filled, fillcolor="ivory", label="NFR:maintainability"];
+    "instance:verifiability" [shape=box, color=black, style=filled, fillcolor="ivory", label="NFR:verifiability"];
+    subgraph "FR" {
+        rank="same";
+        "instance:inputValues" "instance:verifyInputs" "instance:calculateValues" "instance:outputValues" "instance:portable" "instance:security" "instance:maintainability" "instance:verifiability";
+    }
+    "instance:likeChgPP" [shape=box, color=black, style=filled, fillcolor="lavender", label="LC:likeChgPP"];
+    subgraph "LC" {
+        rank="same";
+        "instance:likeChgPP";
+    }
 }

--- a/code/stable/pdcontroller/TraceyGraph/refvsref.dot
+++ b/code/stable/pdcontroller/TraceyGraph/refvsref.dot
@@ -1,50 +1,40 @@
-digraph refvsref {
-	dataDefn:dqdProcessErrorFD -> theory:laplaceRC;
-	dataDefn:dqdPropControlFD -> dataDefn:dqdProcessErrorFD;
-	dataDefn:dqdPropControlFD -> theory:laplaceRC;
-	dataDefn:dqdDerivativeControlFD -> dataDefn:dqdProcessErrorFD;
-	dataDefn:dqdDerivativeControlFD -> theory:laplaceRC;
-	dataDefn:dqdCtrlVarFD -> dataDefn:dqdPropControlFD;
-	dataDefn:dqdCtrlVarFD -> dataDefn:dqdDerivativeControlFD;
-	theory:gdPowerPlantRC -> theory:laplaceRC;
-	theory:gdPowerPlantRC -> theory:tmSOSystemRC;
-	theory:imPDRC -> dataDefn:dqdProcessErrorFD;
-	theory:imPDRC -> dataDefn:dqdCtrlVarFD;
-	theory:imPDRC -> theory:invLaplaceRC;
-	theory:imPDRC -> theory:gdPowerPlantRC;
-
-
-	dataDefn:dqdProcessErrorFD	[shape=box, color=black, style=filled, fillcolor=paleturquoise1, label="DD:ddProcessError"];
-	dataDefn:dqdPropControlFD	[shape=box, color=black, style=filled, fillcolor=paleturquoise1, label="DD:ddPropCtrl"];
-	dataDefn:dqdDerivativeControlFD	[shape=box, color=black, style=filled, fillcolor=paleturquoise1, label="DD:ddDerivCtrl"];
-	dataDefn:dqdCtrlVarFD	[shape=box, color=black, style=filled, fillcolor=paleturquoise1, label="DD:ddCtrlVar"];
-
-	subgraph DD {
-	rank="same"
-	{dataDefn:dqdProcessErrorFD, dataDefn:dqdPropControlFD, dataDefn:dqdDerivativeControlFD, dataDefn:dqdCtrlVarFD}
-	}
-
-	theory:laplaceRC	[shape=box, color=black, style=filled, fillcolor=pink, label="TM:laplaceTransform"];
-	theory:invLaplaceRC	[shape=box, color=black, style=filled, fillcolor=pink, label="TM:invLaplaceTransform"];
-	theory:tmSOSystemRC	[shape=box, color=black, style=filled, fillcolor=pink, label="TM:tmSOSystem"];
-
-	subgraph TM {
-	rank="same"
-	{theory:laplaceRC, theory:invLaplaceRC, theory:tmSOSystemRC}
-	}
-
-	theory:gdPowerPlantRC	[shape=box, color=black, style=filled, fillcolor=palegreen, label="GD:gdPowerPlant"];
-
-	subgraph GD {
-	rank="same"
-	{theory:gdPowerPlantRC}
-	}
-
-	theory:imPDRC	[shape=box, color=black, style=filled, fillcolor=khaki1, label="IM:pdEquationIM"];
-
-	subgraph IM {
-	rank="same"
-	{theory:imPDRC}
-	}
-
+digraph "refvsref" {
+    "dataDefn:dqdProcessErrorFD" -> "theory:laplaceRC";
+    "dataDefn:dqdPropControlFD" -> "dataDefn:dqdProcessErrorFD";
+    "dataDefn:dqdPropControlFD" -> "theory:laplaceRC";
+    "dataDefn:dqdDerivativeControlFD" -> "dataDefn:dqdProcessErrorFD";
+    "dataDefn:dqdDerivativeControlFD" -> "theory:laplaceRC";
+    "dataDefn:dqdCtrlVarFD" -> "dataDefn:dqdPropControlFD";
+    "dataDefn:dqdCtrlVarFD" -> "dataDefn:dqdDerivativeControlFD";
+    "theory:gdPowerPlantRC" -> "theory:laplaceRC";
+    "theory:gdPowerPlantRC" -> "theory:tmSOSystemRC";
+    "theory:imPDRC" -> "dataDefn:dqdProcessErrorFD";
+    "theory:imPDRC" -> "dataDefn:dqdCtrlVarFD";
+    "theory:imPDRC" -> "theory:invLaplaceRC";
+    "theory:imPDRC" -> "theory:gdPowerPlantRC";
+    "dataDefn:dqdProcessErrorFD" [shape=box, color=black, style=filled, fillcolor="paleturquoise1", label="DD:ddProcessError"];
+    "dataDefn:dqdPropControlFD" [shape=box, color=black, style=filled, fillcolor="paleturquoise1", label="DD:ddPropCtrl"];
+    "dataDefn:dqdDerivativeControlFD" [shape=box, color=black, style=filled, fillcolor="paleturquoise1", label="DD:ddDerivCtrl"];
+    "dataDefn:dqdCtrlVarFD" [shape=box, color=black, style=filled, fillcolor="paleturquoise1", label="DD:ddCtrlVar"];
+    subgraph "DD" {
+        rank="same";
+        "dataDefn:dqdProcessErrorFD" "dataDefn:dqdPropControlFD" "dataDefn:dqdDerivativeControlFD" "dataDefn:dqdCtrlVarFD";
+    }
+    "theory:laplaceRC" [shape=box, color=black, style=filled, fillcolor="pink", label="TM:laplaceTransform"];
+    "theory:invLaplaceRC" [shape=box, color=black, style=filled, fillcolor="pink", label="TM:invLaplaceTransform"];
+    "theory:tmSOSystemRC" [shape=box, color=black, style=filled, fillcolor="pink", label="TM:tmSOSystem"];
+    subgraph "TM" {
+        rank="same";
+        "theory:laplaceRC" "theory:invLaplaceRC" "theory:tmSOSystemRC";
+    }
+    "theory:gdPowerPlantRC" [shape=box, color=black, style=filled, fillcolor="palegreen", label="GD:gdPowerPlant"];
+    subgraph "GD" {
+        rank="same";
+        "theory:gdPowerPlantRC";
+    }
+    "theory:imPDRC" [shape=box, color=black, style=filled, fillcolor="khaki1", label="IM:pdEquationIM"];
+    subgraph "IM" {
+        rank="same";
+        "theory:imPDRC";
+    }
 }

--- a/code/stable/projectile/TraceyGraph/allvsall.dot
+++ b/code/stable/projectile/TraceyGraph/allvsall.dot
@@ -1,142 +1,124 @@
-digraph allvsall {
-	instance:cartSyst -> instance:neglectCurv;
-	instance:targetXAxis -> instance:neglectCurv;
-	instance:constAccel -> instance:accelXZero;
-	instance:constAccel -> instance:accelYGravity;
-	instance:constAccel -> instance:neglectDrag;
-	instance:constAccel -> instance:freeFlight;
-	instance:accelYGravity -> instance:yAxisGravity;
-	dataDefn:ixVel -> dataDefn:speed;
-	dataDefn:iyVel -> dataDefn:speed;
-	theory:projSpeed -> instance:pointMass;
-	theory:projSpeed -> instance:timeStartZero;
-	theory:projSpeed -> theory:accelerationTM;
-	theory:projPos -> instance:pointMass;
-	theory:projPos -> instance:timeStartZero;
-	theory:projPos -> theory:velocityTM;
-	theory:projPos -> theory:projSpeed;
-	theory:velocity -> instance:twoDMotion;
-	theory:velocity -> instance:cartSyst;
-	theory:velocity -> instance:constAccel;
-	theory:velocity -> instance:timeStartZero;
-	theory:velocity -> theory:projSpeed;
-	theory:position -> instance:twoDMotion;
-	theory:position -> instance:cartSyst;
-	theory:position -> instance:constAccel;
-	theory:position -> instance:timeStartZero;
-	theory:position -> theory:projPos;
-	theory:flightduration -> instance:yAxisGravity;
-	theory:flightduration -> instance:launchOrigin;
-	theory:flightduration -> instance:targetXAxis;
-	theory:flightduration -> instance:posXDirection;
-	theory:flightduration -> instance:accelYGravity;
-	theory:flightduration -> instance:timeStartZero;
-	theory:flightduration -> instance:gravAccelValue;
-	theory:flightduration -> dataDefn:iyVel;
-	theory:flightduration -> theory:position;
-	theory:landingposition -> instance:yAxisGravity;
-	theory:landingposition -> instance:launchOrigin;
-	theory:landingposition -> instance:posXDirection;
-	theory:landingposition -> instance:accelXZero;
-	theory:landingposition -> instance:gravAccelValue;
-	theory:landingposition -> dataDefn:ixVel;
-	theory:landingposition -> theory:position;
-	theory:landingposition -> theory:flightduration;
-	theory:offset -> instance:posXDirection;
-	theory:offset -> theory:landingposition;
-	instance:calcValues -> theory:flightduration;
-	instance:calcValues -> theory:landingposition;
-	instance:calcValues -> theory:offset;
-	instance:outputValues -> theory:flightduration;
-	instance:outputValues -> theory:offset;
-	instance:considerAirDrag -> instance:neglectDrag;
-
-
-	instance:twoDMotion	[shape=box, color=black, style=filled, fillcolor=mistyrose, label="A:twoDMotion"];
-	instance:cartSyst	[shape=box, color=black, style=filled, fillcolor=mistyrose, label="A:cartSyst"];
-	instance:yAxisGravity	[shape=box, color=black, style=filled, fillcolor=mistyrose, label="A:yAxisGravity"];
-	instance:launchOrigin	[shape=box, color=black, style=filled, fillcolor=mistyrose, label="A:launchOrigin"];
-	instance:targetXAxis	[shape=box, color=black, style=filled, fillcolor=mistyrose, label="A:targetXAxis"];
-	instance:posXDirection	[shape=box, color=black, style=filled, fillcolor=mistyrose, label="A:posXDirection"];
-	instance:constAccel	[shape=box, color=black, style=filled, fillcolor=mistyrose, label="A:constAccel"];
-	instance:accelXZero	[shape=box, color=black, style=filled, fillcolor=mistyrose, label="A:accelXZero"];
-	instance:accelYGravity	[shape=box, color=black, style=filled, fillcolor=mistyrose, label="A:accelYGravity"];
-	instance:neglectDrag	[shape=box, color=black, style=filled, fillcolor=mistyrose, label="A:neglectDrag"];
-	instance:pointMass	[shape=box, color=black, style=filled, fillcolor=mistyrose, label="A:pointMass"];
-	instance:freeFlight	[shape=box, color=black, style=filled, fillcolor=mistyrose, label="A:freeFlight"];
-	instance:neglectCurv	[shape=box, color=black, style=filled, fillcolor=mistyrose, label="A:neglectCurv"];
-	instance:timeStartZero	[shape=box, color=black, style=filled, fillcolor=mistyrose, label="A:timeStartZero"];
-	instance:gravAccelValue	[shape=box, color=black, style=filled, fillcolor=mistyrose, label="A:gravAccelValue"];
-
-	subgraph A {
-	rank="same"
-	{instance:twoDMotion, instance:cartSyst, instance:yAxisGravity, instance:launchOrigin, instance:targetXAxis, instance:posXDirection, instance:constAccel, instance:accelXZero, instance:accelYGravity, instance:neglectDrag, instance:pointMass, instance:freeFlight, instance:neglectCurv, instance:timeStartZero, instance:gravAccelValue}
-	}
-
-	dataDefn:speed	[shape=box, color=black, style=filled, fillcolor=paleturquoise1, label="DD:vecMag"];
-	dataDefn:ixVel	[shape=box, color=black, style=filled, fillcolor=paleturquoise1, label="DD:speedIX"];
-	dataDefn:iyVel	[shape=box, color=black, style=filled, fillcolor=paleturquoise1, label="DD:speedIY"];
-
-	subgraph DD {
-	rank="same"
-	{dataDefn:speed, dataDefn:ixVel, dataDefn:iyVel}
-	}
-
-	theory:accelerationTM	[shape=box, color=black, style=filled, fillcolor=pink, label="TM:acceleration"];
-	theory:velocityTM	[shape=box, color=black, style=filled, fillcolor=pink, label="TM:velocity"];
-
-	subgraph TM {
-	rank="same"
-	{theory:accelerationTM, theory:velocityTM}
-	}
-
-	theory:projSpeed	[shape=box, color=black, style=filled, fillcolor=palegreen, label="GD:rectVel"];
-	theory:projPos	[shape=box, color=black, style=filled, fillcolor=palegreen, label="GD:rectPos"];
-	theory:velocity	[shape=box, color=black, style=filled, fillcolor=palegreen, label="GD:velVec"];
-	theory:position	[shape=box, color=black, style=filled, fillcolor=palegreen, label="GD:posVec"];
-
-	subgraph GD {
-	rank="same"
-	{theory:projSpeed, theory:projPos, theory:velocity, theory:position}
-	}
-
-	theory:flightduration	[shape=box, color=black, style=filled, fillcolor=khaki1, label="IM:calOfLandingTime"];
-	theory:landingposition	[shape=box, color=black, style=filled, fillcolor=khaki1, label="IM:calOfLandingDist"];
-	theory:offset	[shape=box, color=black, style=filled, fillcolor=khaki1, label="IM:offsetIM"];
-
-	subgraph IM {
-	rank="same"
-	{theory:flightduration, theory:landingposition, theory:offset}
-	}
-
-	instance:inputValues	[shape=box, color=black, style=filled, fillcolor=ivory, label="FR:inputValues"];
-	instance:verifyInVals	[shape=box, color=black, style=filled, fillcolor=ivory, label="FR:verifyInVals"];
-	instance:calcValues	[shape=box, color=black, style=filled, fillcolor=ivory, label="FR:calcValues"];
-	instance:outputValues	[shape=box, color=black, style=filled, fillcolor=ivory, label="FR:outputValues"];
-	instance:correct	[shape=box, color=black, style=filled, fillcolor=ivory, label="NFR:correct"];
-	instance:verifiable	[shape=box, color=black, style=filled, fillcolor=ivory, label="NFR:verifiable"];
-	instance:understandable	[shape=box, color=black, style=filled, fillcolor=ivory, label="NFR:understandable"];
-	instance:reusable	[shape=box, color=black, style=filled, fillcolor=ivory, label="NFR:reusable"];
-	instance:maintainable	[shape=box, color=black, style=filled, fillcolor=ivory, label="NFR:maintainable"];
-	instance:portable	[shape=box, color=black, style=filled, fillcolor=ivory, label="NFR:portable"];
-
-	subgraph FR {
-	rank="same"
-	{instance:inputValues, instance:verifyInVals, instance:calcValues, instance:outputValues, instance:correct, instance:verifiable, instance:understandable, instance:reusable, instance:maintainable, instance:portable}
-	}
-
-	instance:targetHit	[shape=box, color=black, style=filled, fillcolor=darkgoldenrod1, label="GS:targetHit"];
-
-	subgraph GS {
-	rank="same"
-	{instance:targetHit}
-	}
-
-	instance:considerAirDrag	[shape=box, color=black, style=filled, fillcolor=lavender, label="LC:considerAirDrag"];
-
-	subgraph LC {
-	rank="same"
-	{instance:considerAirDrag}
-	}
-
+digraph "allvsall" {
+    "instance:cartSyst" -> "instance:neglectCurv";
+    "instance:targetXAxis" -> "instance:neglectCurv";
+    "instance:constAccel" -> "instance:accelXZero";
+    "instance:constAccel" -> "instance:accelYGravity";
+    "instance:constAccel" -> "instance:neglectDrag";
+    "instance:constAccel" -> "instance:freeFlight";
+    "instance:accelYGravity" -> "instance:yAxisGravity";
+    "dataDefn:ixVel" -> "dataDefn:speed";
+    "dataDefn:iyVel" -> "dataDefn:speed";
+    "theory:projSpeed" -> "instance:pointMass";
+    "theory:projSpeed" -> "instance:timeStartZero";
+    "theory:projSpeed" -> "theory:accelerationTM";
+    "theory:projPos" -> "instance:pointMass";
+    "theory:projPos" -> "instance:timeStartZero";
+    "theory:projPos" -> "theory:velocityTM";
+    "theory:projPos" -> "theory:projSpeed";
+    "theory:velocity" -> "instance:twoDMotion";
+    "theory:velocity" -> "instance:cartSyst";
+    "theory:velocity" -> "instance:constAccel";
+    "theory:velocity" -> "instance:timeStartZero";
+    "theory:velocity" -> "theory:projSpeed";
+    "theory:position" -> "instance:twoDMotion";
+    "theory:position" -> "instance:cartSyst";
+    "theory:position" -> "instance:constAccel";
+    "theory:position" -> "instance:timeStartZero";
+    "theory:position" -> "theory:projPos";
+    "theory:flightduration" -> "instance:yAxisGravity";
+    "theory:flightduration" -> "instance:launchOrigin";
+    "theory:flightduration" -> "instance:targetXAxis";
+    "theory:flightduration" -> "instance:posXDirection";
+    "theory:flightduration" -> "instance:accelYGravity";
+    "theory:flightduration" -> "instance:timeStartZero";
+    "theory:flightduration" -> "instance:gravAccelValue";
+    "theory:flightduration" -> "dataDefn:iyVel";
+    "theory:flightduration" -> "theory:position";
+    "theory:landingposition" -> "instance:yAxisGravity";
+    "theory:landingposition" -> "instance:launchOrigin";
+    "theory:landingposition" -> "instance:posXDirection";
+    "theory:landingposition" -> "instance:accelXZero";
+    "theory:landingposition" -> "instance:gravAccelValue";
+    "theory:landingposition" -> "dataDefn:ixVel";
+    "theory:landingposition" -> "theory:position";
+    "theory:landingposition" -> "theory:flightduration";
+    "theory:offset" -> "instance:posXDirection";
+    "theory:offset" -> "theory:landingposition";
+    "instance:calcValues" -> "theory:flightduration";
+    "instance:calcValues" -> "theory:landingposition";
+    "instance:calcValues" -> "theory:offset";
+    "instance:outputValues" -> "theory:flightduration";
+    "instance:outputValues" -> "theory:offset";
+    "instance:considerAirDrag" -> "instance:neglectDrag";
+    "instance:twoDMotion" [shape=box, color=black, style=filled, fillcolor="mistyrose", label="A:twoDMotion"];
+    "instance:cartSyst" [shape=box, color=black, style=filled, fillcolor="mistyrose", label="A:cartSyst"];
+    "instance:yAxisGravity" [shape=box, color=black, style=filled, fillcolor="mistyrose", label="A:yAxisGravity"];
+    "instance:launchOrigin" [shape=box, color=black, style=filled, fillcolor="mistyrose", label="A:launchOrigin"];
+    "instance:targetXAxis" [shape=box, color=black, style=filled, fillcolor="mistyrose", label="A:targetXAxis"];
+    "instance:posXDirection" [shape=box, color=black, style=filled, fillcolor="mistyrose", label="A:posXDirection"];
+    "instance:constAccel" [shape=box, color=black, style=filled, fillcolor="mistyrose", label="A:constAccel"];
+    "instance:accelXZero" [shape=box, color=black, style=filled, fillcolor="mistyrose", label="A:accelXZero"];
+    "instance:accelYGravity" [shape=box, color=black, style=filled, fillcolor="mistyrose", label="A:accelYGravity"];
+    "instance:neglectDrag" [shape=box, color=black, style=filled, fillcolor="mistyrose", label="A:neglectDrag"];
+    "instance:pointMass" [shape=box, color=black, style=filled, fillcolor="mistyrose", label="A:pointMass"];
+    "instance:freeFlight" [shape=box, color=black, style=filled, fillcolor="mistyrose", label="A:freeFlight"];
+    "instance:neglectCurv" [shape=box, color=black, style=filled, fillcolor="mistyrose", label="A:neglectCurv"];
+    "instance:timeStartZero" [shape=box, color=black, style=filled, fillcolor="mistyrose", label="A:timeStartZero"];
+    "instance:gravAccelValue" [shape=box, color=black, style=filled, fillcolor="mistyrose", label="A:gravAccelValue"];
+    subgraph "A" {
+        rank="same";
+        "instance:twoDMotion" "instance:cartSyst" "instance:yAxisGravity" "instance:launchOrigin" "instance:targetXAxis" "instance:posXDirection" "instance:constAccel" "instance:accelXZero" "instance:accelYGravity" "instance:neglectDrag" "instance:pointMass" "instance:freeFlight" "instance:neglectCurv" "instance:timeStartZero" "instance:gravAccelValue";
+    }
+    "dataDefn:speed" [shape=box, color=black, style=filled, fillcolor="paleturquoise1", label="DD:vecMag"];
+    "dataDefn:ixVel" [shape=box, color=black, style=filled, fillcolor="paleturquoise1", label="DD:speedIX"];
+    "dataDefn:iyVel" [shape=box, color=black, style=filled, fillcolor="paleturquoise1", label="DD:speedIY"];
+    subgraph "DD" {
+        rank="same";
+        "dataDefn:speed" "dataDefn:ixVel" "dataDefn:iyVel";
+    }
+    "theory:accelerationTM" [shape=box, color=black, style=filled, fillcolor="pink", label="TM:acceleration"];
+    "theory:velocityTM" [shape=box, color=black, style=filled, fillcolor="pink", label="TM:velocity"];
+    subgraph "TM" {
+        rank="same";
+        "theory:accelerationTM" "theory:velocityTM";
+    }
+    "theory:projSpeed" [shape=box, color=black, style=filled, fillcolor="palegreen", label="GD:rectVel"];
+    "theory:projPos" [shape=box, color=black, style=filled, fillcolor="palegreen", label="GD:rectPos"];
+    "theory:velocity" [shape=box, color=black, style=filled, fillcolor="palegreen", label="GD:velVec"];
+    "theory:position" [shape=box, color=black, style=filled, fillcolor="palegreen", label="GD:posVec"];
+    subgraph "GD" {
+        rank="same";
+        "theory:projSpeed" "theory:projPos" "theory:velocity" "theory:position";
+    }
+    "theory:flightduration" [shape=box, color=black, style=filled, fillcolor="khaki1", label="IM:calOfLandingTime"];
+    "theory:landingposition" [shape=box, color=black, style=filled, fillcolor="khaki1", label="IM:calOfLandingDist"];
+    "theory:offset" [shape=box, color=black, style=filled, fillcolor="khaki1", label="IM:offsetIM"];
+    subgraph "IM" {
+        rank="same";
+        "theory:flightduration" "theory:landingposition" "theory:offset";
+    }
+    "instance:inputValues" [shape=box, color=black, style=filled, fillcolor="ivory", label="FR:inputValues"];
+    "instance:verifyInVals" [shape=box, color=black, style=filled, fillcolor="ivory", label="FR:verifyInVals"];
+    "instance:calcValues" [shape=box, color=black, style=filled, fillcolor="ivory", label="FR:calcValues"];
+    "instance:outputValues" [shape=box, color=black, style=filled, fillcolor="ivory", label="FR:outputValues"];
+    "instance:correct" [shape=box, color=black, style=filled, fillcolor="ivory", label="NFR:correct"];
+    "instance:verifiable" [shape=box, color=black, style=filled, fillcolor="ivory", label="NFR:verifiable"];
+    "instance:understandable" [shape=box, color=black, style=filled, fillcolor="ivory", label="NFR:understandable"];
+    "instance:reusable" [shape=box, color=black, style=filled, fillcolor="ivory", label="NFR:reusable"];
+    "instance:maintainable" [shape=box, color=black, style=filled, fillcolor="ivory", label="NFR:maintainable"];
+    "instance:portable" [shape=box, color=black, style=filled, fillcolor="ivory", label="NFR:portable"];
+    subgraph "FR" {
+        rank="same";
+        "instance:inputValues" "instance:verifyInVals" "instance:calcValues" "instance:outputValues" "instance:correct" "instance:verifiable" "instance:understandable" "instance:reusable" "instance:maintainable" "instance:portable";
+    }
+    "instance:targetHit" [shape=box, color=black, style=filled, fillcolor="darkgoldenrod1", label="GS:targetHit"];
+    subgraph "GS" {
+        rank="same";
+        "instance:targetHit";
+    }
+    "instance:considerAirDrag" [shape=box, color=black, style=filled, fillcolor="lavender", label="LC:considerAirDrag"];
+    subgraph "LC" {
+        rank="same";
+        "instance:considerAirDrag";
+    }
 }

--- a/code/stable/projectile/TraceyGraph/allvsr.dot
+++ b/code/stable/projectile/TraceyGraph/allvsr.dot
@@ -1,89 +1,73 @@
-digraph allvsr {
-	instance:calcValues -> theory:flightduration;
-	instance:calcValues -> theory:landingposition;
-	instance:calcValues -> theory:offset;
-	instance:outputValues -> theory:flightduration;
-	instance:outputValues -> theory:offset;
-
-
-	instance:twoDMotion	[shape=box, color=black, style=filled, fillcolor=mistyrose, label="A:twoDMotion"];
-	instance:cartSyst	[shape=box, color=black, style=filled, fillcolor=mistyrose, label="A:cartSyst"];
-	instance:yAxisGravity	[shape=box, color=black, style=filled, fillcolor=mistyrose, label="A:yAxisGravity"];
-	instance:launchOrigin	[shape=box, color=black, style=filled, fillcolor=mistyrose, label="A:launchOrigin"];
-	instance:targetXAxis	[shape=box, color=black, style=filled, fillcolor=mistyrose, label="A:targetXAxis"];
-	instance:posXDirection	[shape=box, color=black, style=filled, fillcolor=mistyrose, label="A:posXDirection"];
-	instance:constAccel	[shape=box, color=black, style=filled, fillcolor=mistyrose, label="A:constAccel"];
-	instance:accelXZero	[shape=box, color=black, style=filled, fillcolor=mistyrose, label="A:accelXZero"];
-	instance:accelYGravity	[shape=box, color=black, style=filled, fillcolor=mistyrose, label="A:accelYGravity"];
-	instance:neglectDrag	[shape=box, color=black, style=filled, fillcolor=mistyrose, label="A:neglectDrag"];
-	instance:pointMass	[shape=box, color=black, style=filled, fillcolor=mistyrose, label="A:pointMass"];
-	instance:freeFlight	[shape=box, color=black, style=filled, fillcolor=mistyrose, label="A:freeFlight"];
-	instance:neglectCurv	[shape=box, color=black, style=filled, fillcolor=mistyrose, label="A:neglectCurv"];
-	instance:timeStartZero	[shape=box, color=black, style=filled, fillcolor=mistyrose, label="A:timeStartZero"];
-	instance:gravAccelValue	[shape=box, color=black, style=filled, fillcolor=mistyrose, label="A:gravAccelValue"];
-
-	subgraph A {
-	rank="same"
-	{instance:twoDMotion, instance:cartSyst, instance:yAxisGravity, instance:launchOrigin, instance:targetXAxis, instance:posXDirection, instance:constAccel, instance:accelXZero, instance:accelYGravity, instance:neglectDrag, instance:pointMass, instance:freeFlight, instance:neglectCurv, instance:timeStartZero, instance:gravAccelValue}
-	}
-
-	dataDefn:speed	[shape=box, color=black, style=filled, fillcolor=paleturquoise1, label="DD:vecMag"];
-	dataDefn:ixVel	[shape=box, color=black, style=filled, fillcolor=paleturquoise1, label="DD:speedIX"];
-	dataDefn:iyVel	[shape=box, color=black, style=filled, fillcolor=paleturquoise1, label="DD:speedIY"];
-
-	subgraph DD {
-	rank="same"
-	{dataDefn:speed, dataDefn:ixVel, dataDefn:iyVel}
-	}
-
-	theory:accelerationTM	[shape=box, color=black, style=filled, fillcolor=pink, label="TM:acceleration"];
-	theory:velocityTM	[shape=box, color=black, style=filled, fillcolor=pink, label="TM:velocity"];
-
-	subgraph TM {
-	rank="same"
-	{theory:accelerationTM, theory:velocityTM}
-	}
-
-	theory:projSpeed	[shape=box, color=black, style=filled, fillcolor=palegreen, label="GD:rectVel"];
-	theory:projPos	[shape=box, color=black, style=filled, fillcolor=palegreen, label="GD:rectPos"];
-	theory:velocity	[shape=box, color=black, style=filled, fillcolor=palegreen, label="GD:velVec"];
-	theory:position	[shape=box, color=black, style=filled, fillcolor=palegreen, label="GD:posVec"];
-
-	subgraph GD {
-	rank="same"
-	{theory:projSpeed, theory:projPos, theory:velocity, theory:position}
-	}
-
-	theory:flightduration	[shape=box, color=black, style=filled, fillcolor=khaki1, label="IM:calOfLandingTime"];
-	theory:landingposition	[shape=box, color=black, style=filled, fillcolor=khaki1, label="IM:calOfLandingDist"];
-	theory:offset	[shape=box, color=black, style=filled, fillcolor=khaki1, label="IM:offsetIM"];
-
-	subgraph IM {
-	rank="same"
-	{theory:flightduration, theory:landingposition, theory:offset}
-	}
-
-	instance:inputValues	[shape=box, color=black, style=filled, fillcolor=ivory, label="FR:inputValues"];
-	instance:verifyInVals	[shape=box, color=black, style=filled, fillcolor=ivory, label="FR:verifyInVals"];
-	instance:calcValues	[shape=box, color=black, style=filled, fillcolor=ivory, label="FR:calcValues"];
-	instance:outputValues	[shape=box, color=black, style=filled, fillcolor=ivory, label="FR:outputValues"];
-	instance:correct	[shape=box, color=black, style=filled, fillcolor=ivory, label="NFR:correct"];
-	instance:verifiable	[shape=box, color=black, style=filled, fillcolor=ivory, label="NFR:verifiable"];
-	instance:understandable	[shape=box, color=black, style=filled, fillcolor=ivory, label="NFR:understandable"];
-	instance:reusable	[shape=box, color=black, style=filled, fillcolor=ivory, label="NFR:reusable"];
-	instance:maintainable	[shape=box, color=black, style=filled, fillcolor=ivory, label="NFR:maintainable"];
-	instance:portable	[shape=box, color=black, style=filled, fillcolor=ivory, label="NFR:portable"];
-
-	subgraph FR {
-	rank="same"
-	{instance:inputValues, instance:verifyInVals, instance:calcValues, instance:outputValues, instance:correct, instance:verifiable, instance:understandable, instance:reusable, instance:maintainable, instance:portable}
-	}
-
-	instance:targetHit	[shape=box, color=black, style=filled, fillcolor=darkgoldenrod1, label="GS:targetHit"];
-
-	subgraph GS {
-	rank="same"
-	{instance:targetHit}
-	}
-
+digraph "allvsr" {
+    "instance:calcValues" -> "theory:flightduration";
+    "instance:calcValues" -> "theory:landingposition";
+    "instance:calcValues" -> "theory:offset";
+    "instance:outputValues" -> "theory:flightduration";
+    "instance:outputValues" -> "theory:offset";
+    "instance:twoDMotion" [shape=box, color=black, style=filled, fillcolor="mistyrose", label="A:twoDMotion"];
+    "instance:cartSyst" [shape=box, color=black, style=filled, fillcolor="mistyrose", label="A:cartSyst"];
+    "instance:yAxisGravity" [shape=box, color=black, style=filled, fillcolor="mistyrose", label="A:yAxisGravity"];
+    "instance:launchOrigin" [shape=box, color=black, style=filled, fillcolor="mistyrose", label="A:launchOrigin"];
+    "instance:targetXAxis" [shape=box, color=black, style=filled, fillcolor="mistyrose", label="A:targetXAxis"];
+    "instance:posXDirection" [shape=box, color=black, style=filled, fillcolor="mistyrose", label="A:posXDirection"];
+    "instance:constAccel" [shape=box, color=black, style=filled, fillcolor="mistyrose", label="A:constAccel"];
+    "instance:accelXZero" [shape=box, color=black, style=filled, fillcolor="mistyrose", label="A:accelXZero"];
+    "instance:accelYGravity" [shape=box, color=black, style=filled, fillcolor="mistyrose", label="A:accelYGravity"];
+    "instance:neglectDrag" [shape=box, color=black, style=filled, fillcolor="mistyrose", label="A:neglectDrag"];
+    "instance:pointMass" [shape=box, color=black, style=filled, fillcolor="mistyrose", label="A:pointMass"];
+    "instance:freeFlight" [shape=box, color=black, style=filled, fillcolor="mistyrose", label="A:freeFlight"];
+    "instance:neglectCurv" [shape=box, color=black, style=filled, fillcolor="mistyrose", label="A:neglectCurv"];
+    "instance:timeStartZero" [shape=box, color=black, style=filled, fillcolor="mistyrose", label="A:timeStartZero"];
+    "instance:gravAccelValue" [shape=box, color=black, style=filled, fillcolor="mistyrose", label="A:gravAccelValue"];
+    subgraph "A" {
+        rank="same";
+        "instance:twoDMotion" "instance:cartSyst" "instance:yAxisGravity" "instance:launchOrigin" "instance:targetXAxis" "instance:posXDirection" "instance:constAccel" "instance:accelXZero" "instance:accelYGravity" "instance:neglectDrag" "instance:pointMass" "instance:freeFlight" "instance:neglectCurv" "instance:timeStartZero" "instance:gravAccelValue";
+    }
+    "dataDefn:speed" [shape=box, color=black, style=filled, fillcolor="paleturquoise1", label="DD:vecMag"];
+    "dataDefn:ixVel" [shape=box, color=black, style=filled, fillcolor="paleturquoise1", label="DD:speedIX"];
+    "dataDefn:iyVel" [shape=box, color=black, style=filled, fillcolor="paleturquoise1", label="DD:speedIY"];
+    subgraph "DD" {
+        rank="same";
+        "dataDefn:speed" "dataDefn:ixVel" "dataDefn:iyVel";
+    }
+    "theory:accelerationTM" [shape=box, color=black, style=filled, fillcolor="pink", label="TM:acceleration"];
+    "theory:velocityTM" [shape=box, color=black, style=filled, fillcolor="pink", label="TM:velocity"];
+    subgraph "TM" {
+        rank="same";
+        "theory:accelerationTM" "theory:velocityTM";
+    }
+    "theory:projSpeed" [shape=box, color=black, style=filled, fillcolor="palegreen", label="GD:rectVel"];
+    "theory:projPos" [shape=box, color=black, style=filled, fillcolor="palegreen", label="GD:rectPos"];
+    "theory:velocity" [shape=box, color=black, style=filled, fillcolor="palegreen", label="GD:velVec"];
+    "theory:position" [shape=box, color=black, style=filled, fillcolor="palegreen", label="GD:posVec"];
+    subgraph "GD" {
+        rank="same";
+        "theory:projSpeed" "theory:projPos" "theory:velocity" "theory:position";
+    }
+    "theory:flightduration" [shape=box, color=black, style=filled, fillcolor="khaki1", label="IM:calOfLandingTime"];
+    "theory:landingposition" [shape=box, color=black, style=filled, fillcolor="khaki1", label="IM:calOfLandingDist"];
+    "theory:offset" [shape=box, color=black, style=filled, fillcolor="khaki1", label="IM:offsetIM"];
+    subgraph "IM" {
+        rank="same";
+        "theory:flightduration" "theory:landingposition" "theory:offset";
+    }
+    "instance:inputValues" [shape=box, color=black, style=filled, fillcolor="ivory", label="FR:inputValues"];
+    "instance:verifyInVals" [shape=box, color=black, style=filled, fillcolor="ivory", label="FR:verifyInVals"];
+    "instance:calcValues" [shape=box, color=black, style=filled, fillcolor="ivory", label="FR:calcValues"];
+    "instance:outputValues" [shape=box, color=black, style=filled, fillcolor="ivory", label="FR:outputValues"];
+    "instance:correct" [shape=box, color=black, style=filled, fillcolor="ivory", label="NFR:correct"];
+    "instance:verifiable" [shape=box, color=black, style=filled, fillcolor="ivory", label="NFR:verifiable"];
+    "instance:understandable" [shape=box, color=black, style=filled, fillcolor="ivory", label="NFR:understandable"];
+    "instance:reusable" [shape=box, color=black, style=filled, fillcolor="ivory", label="NFR:reusable"];
+    "instance:maintainable" [shape=box, color=black, style=filled, fillcolor="ivory", label="NFR:maintainable"];
+    "instance:portable" [shape=box, color=black, style=filled, fillcolor="ivory", label="NFR:portable"];
+    subgraph "FR" {
+        rank="same";
+        "instance:inputValues" "instance:verifyInVals" "instance:calcValues" "instance:outputValues" "instance:correct" "instance:verifiable" "instance:understandable" "instance:reusable" "instance:maintainable" "instance:portable";
+    }
+    "instance:targetHit" [shape=box, color=black, style=filled, fillcolor="darkgoldenrod1", label="GS:targetHit"];
+    subgraph "GS" {
+        rank="same";
+        "instance:targetHit";
+    }
 }

--- a/code/stable/projectile/TraceyGraph/avsa.dot
+++ b/code/stable/projectile/TraceyGraph/avsa.dot
@@ -1,32 +1,28 @@
-digraph avsa {
-	instance:cartSyst -> instance:neglectCurv;
-	instance:targetXAxis -> instance:neglectCurv;
-	instance:constAccel -> instance:accelXZero;
-	instance:constAccel -> instance:accelYGravity;
-	instance:constAccel -> instance:neglectDrag;
-	instance:constAccel -> instance:freeFlight;
-	instance:accelYGravity -> instance:yAxisGravity;
-
-
-	instance:twoDMotion	[shape=box, color=black, style=filled, fillcolor=mistyrose, label="A:twoDMotion"];
-	instance:cartSyst	[shape=box, color=black, style=filled, fillcolor=mistyrose, label="A:cartSyst"];
-	instance:yAxisGravity	[shape=box, color=black, style=filled, fillcolor=mistyrose, label="A:yAxisGravity"];
-	instance:launchOrigin	[shape=box, color=black, style=filled, fillcolor=mistyrose, label="A:launchOrigin"];
-	instance:targetXAxis	[shape=box, color=black, style=filled, fillcolor=mistyrose, label="A:targetXAxis"];
-	instance:posXDirection	[shape=box, color=black, style=filled, fillcolor=mistyrose, label="A:posXDirection"];
-	instance:constAccel	[shape=box, color=black, style=filled, fillcolor=mistyrose, label="A:constAccel"];
-	instance:accelXZero	[shape=box, color=black, style=filled, fillcolor=mistyrose, label="A:accelXZero"];
-	instance:accelYGravity	[shape=box, color=black, style=filled, fillcolor=mistyrose, label="A:accelYGravity"];
-	instance:neglectDrag	[shape=box, color=black, style=filled, fillcolor=mistyrose, label="A:neglectDrag"];
-	instance:pointMass	[shape=box, color=black, style=filled, fillcolor=mistyrose, label="A:pointMass"];
-	instance:freeFlight	[shape=box, color=black, style=filled, fillcolor=mistyrose, label="A:freeFlight"];
-	instance:neglectCurv	[shape=box, color=black, style=filled, fillcolor=mistyrose, label="A:neglectCurv"];
-	instance:timeStartZero	[shape=box, color=black, style=filled, fillcolor=mistyrose, label="A:timeStartZero"];
-	instance:gravAccelValue	[shape=box, color=black, style=filled, fillcolor=mistyrose, label="A:gravAccelValue"];
-
-	subgraph A {
-	rank="same"
-	{instance:twoDMotion, instance:cartSyst, instance:yAxisGravity, instance:launchOrigin, instance:targetXAxis, instance:posXDirection, instance:constAccel, instance:accelXZero, instance:accelYGravity, instance:neglectDrag, instance:pointMass, instance:freeFlight, instance:neglectCurv, instance:timeStartZero, instance:gravAccelValue}
-	}
-
+digraph "avsa" {
+    "instance:cartSyst" -> "instance:neglectCurv";
+    "instance:targetXAxis" -> "instance:neglectCurv";
+    "instance:constAccel" -> "instance:accelXZero";
+    "instance:constAccel" -> "instance:accelYGravity";
+    "instance:constAccel" -> "instance:neglectDrag";
+    "instance:constAccel" -> "instance:freeFlight";
+    "instance:accelYGravity" -> "instance:yAxisGravity";
+    "instance:twoDMotion" [shape=box, color=black, style=filled, fillcolor="mistyrose", label="A:twoDMotion"];
+    "instance:cartSyst" [shape=box, color=black, style=filled, fillcolor="mistyrose", label="A:cartSyst"];
+    "instance:yAxisGravity" [shape=box, color=black, style=filled, fillcolor="mistyrose", label="A:yAxisGravity"];
+    "instance:launchOrigin" [shape=box, color=black, style=filled, fillcolor="mistyrose", label="A:launchOrigin"];
+    "instance:targetXAxis" [shape=box, color=black, style=filled, fillcolor="mistyrose", label="A:targetXAxis"];
+    "instance:posXDirection" [shape=box, color=black, style=filled, fillcolor="mistyrose", label="A:posXDirection"];
+    "instance:constAccel" [shape=box, color=black, style=filled, fillcolor="mistyrose", label="A:constAccel"];
+    "instance:accelXZero" [shape=box, color=black, style=filled, fillcolor="mistyrose", label="A:accelXZero"];
+    "instance:accelYGravity" [shape=box, color=black, style=filled, fillcolor="mistyrose", label="A:accelYGravity"];
+    "instance:neglectDrag" [shape=box, color=black, style=filled, fillcolor="mistyrose", label="A:neglectDrag"];
+    "instance:pointMass" [shape=box, color=black, style=filled, fillcolor="mistyrose", label="A:pointMass"];
+    "instance:freeFlight" [shape=box, color=black, style=filled, fillcolor="mistyrose", label="A:freeFlight"];
+    "instance:neglectCurv" [shape=box, color=black, style=filled, fillcolor="mistyrose", label="A:neglectCurv"];
+    "instance:timeStartZero" [shape=box, color=black, style=filled, fillcolor="mistyrose", label="A:timeStartZero"];
+    "instance:gravAccelValue" [shape=box, color=black, style=filled, fillcolor="mistyrose", label="A:gravAccelValue"];
+    subgraph "A" {
+        rank="same";
+        "instance:twoDMotion" "instance:cartSyst" "instance:yAxisGravity" "instance:launchOrigin" "instance:targetXAxis" "instance:posXDirection" "instance:constAccel" "instance:accelXZero" "instance:accelYGravity" "instance:neglectDrag" "instance:pointMass" "instance:freeFlight" "instance:neglectCurv" "instance:timeStartZero" "instance:gravAccelValue";
+    }
 }

--- a/code/stable/projectile/TraceyGraph/avsall.dot
+++ b/code/stable/projectile/TraceyGraph/avsall.dot
@@ -1,110 +1,94 @@
-digraph avsall {
-	theory:projSpeed -> instance:pointMass;
-	theory:projSpeed -> instance:timeStartZero;
-	theory:projPos -> instance:pointMass;
-	theory:projPos -> instance:timeStartZero;
-	theory:velocity -> instance:twoDMotion;
-	theory:velocity -> instance:cartSyst;
-	theory:velocity -> instance:constAccel;
-	theory:velocity -> instance:timeStartZero;
-	theory:position -> instance:twoDMotion;
-	theory:position -> instance:cartSyst;
-	theory:position -> instance:constAccel;
-	theory:position -> instance:timeStartZero;
-	theory:flightduration -> instance:yAxisGravity;
-	theory:flightduration -> instance:launchOrigin;
-	theory:flightduration -> instance:targetXAxis;
-	theory:flightduration -> instance:posXDirection;
-	theory:flightduration -> instance:accelYGravity;
-	theory:flightduration -> instance:timeStartZero;
-	theory:flightduration -> instance:gravAccelValue;
-	theory:landingposition -> instance:yAxisGravity;
-	theory:landingposition -> instance:launchOrigin;
-	theory:landingposition -> instance:posXDirection;
-	theory:landingposition -> instance:accelXZero;
-	theory:landingposition -> instance:gravAccelValue;
-	theory:offset -> instance:posXDirection;
-	instance:considerAirDrag -> instance:neglectDrag;
-
-
-	instance:twoDMotion	[shape=box, color=black, style=filled, fillcolor=mistyrose, label="A:twoDMotion"];
-	instance:cartSyst	[shape=box, color=black, style=filled, fillcolor=mistyrose, label="A:cartSyst"];
-	instance:yAxisGravity	[shape=box, color=black, style=filled, fillcolor=mistyrose, label="A:yAxisGravity"];
-	instance:launchOrigin	[shape=box, color=black, style=filled, fillcolor=mistyrose, label="A:launchOrigin"];
-	instance:targetXAxis	[shape=box, color=black, style=filled, fillcolor=mistyrose, label="A:targetXAxis"];
-	instance:posXDirection	[shape=box, color=black, style=filled, fillcolor=mistyrose, label="A:posXDirection"];
-	instance:constAccel	[shape=box, color=black, style=filled, fillcolor=mistyrose, label="A:constAccel"];
-	instance:accelXZero	[shape=box, color=black, style=filled, fillcolor=mistyrose, label="A:accelXZero"];
-	instance:accelYGravity	[shape=box, color=black, style=filled, fillcolor=mistyrose, label="A:accelYGravity"];
-	instance:neglectDrag	[shape=box, color=black, style=filled, fillcolor=mistyrose, label="A:neglectDrag"];
-	instance:pointMass	[shape=box, color=black, style=filled, fillcolor=mistyrose, label="A:pointMass"];
-	instance:freeFlight	[shape=box, color=black, style=filled, fillcolor=mistyrose, label="A:freeFlight"];
-	instance:neglectCurv	[shape=box, color=black, style=filled, fillcolor=mistyrose, label="A:neglectCurv"];
-	instance:timeStartZero	[shape=box, color=black, style=filled, fillcolor=mistyrose, label="A:timeStartZero"];
-	instance:gravAccelValue	[shape=box, color=black, style=filled, fillcolor=mistyrose, label="A:gravAccelValue"];
-
-	subgraph A {
-	rank="same"
-	{instance:twoDMotion, instance:cartSyst, instance:yAxisGravity, instance:launchOrigin, instance:targetXAxis, instance:posXDirection, instance:constAccel, instance:accelXZero, instance:accelYGravity, instance:neglectDrag, instance:pointMass, instance:freeFlight, instance:neglectCurv, instance:timeStartZero, instance:gravAccelValue}
-	}
-
-	dataDefn:speed	[shape=box, color=black, style=filled, fillcolor=paleturquoise1, label="DD:vecMag"];
-	dataDefn:ixVel	[shape=box, color=black, style=filled, fillcolor=paleturquoise1, label="DD:speedIX"];
-	dataDefn:iyVel	[shape=box, color=black, style=filled, fillcolor=paleturquoise1, label="DD:speedIY"];
-
-	subgraph DD {
-	rank="same"
-	{dataDefn:speed, dataDefn:ixVel, dataDefn:iyVel}
-	}
-
-	theory:accelerationTM	[shape=box, color=black, style=filled, fillcolor=pink, label="TM:acceleration"];
-	theory:velocityTM	[shape=box, color=black, style=filled, fillcolor=pink, label="TM:velocity"];
-
-	subgraph TM {
-	rank="same"
-	{theory:accelerationTM, theory:velocityTM}
-	}
-
-	theory:projSpeed	[shape=box, color=black, style=filled, fillcolor=palegreen, label="GD:rectVel"];
-	theory:projPos	[shape=box, color=black, style=filled, fillcolor=palegreen, label="GD:rectPos"];
-	theory:velocity	[shape=box, color=black, style=filled, fillcolor=palegreen, label="GD:velVec"];
-	theory:position	[shape=box, color=black, style=filled, fillcolor=palegreen, label="GD:posVec"];
-
-	subgraph GD {
-	rank="same"
-	{theory:projSpeed, theory:projPos, theory:velocity, theory:position}
-	}
-
-	theory:flightduration	[shape=box, color=black, style=filled, fillcolor=khaki1, label="IM:calOfLandingTime"];
-	theory:landingposition	[shape=box, color=black, style=filled, fillcolor=khaki1, label="IM:calOfLandingDist"];
-	theory:offset	[shape=box, color=black, style=filled, fillcolor=khaki1, label="IM:offsetIM"];
-
-	subgraph IM {
-	rank="same"
-	{theory:flightduration, theory:landingposition, theory:offset}
-	}
-
-	instance:inputValues	[shape=box, color=black, style=filled, fillcolor=ivory, label="FR:inputValues"];
-	instance:verifyInVals	[shape=box, color=black, style=filled, fillcolor=ivory, label="FR:verifyInVals"];
-	instance:calcValues	[shape=box, color=black, style=filled, fillcolor=ivory, label="FR:calcValues"];
-	instance:outputValues	[shape=box, color=black, style=filled, fillcolor=ivory, label="FR:outputValues"];
-	instance:correct	[shape=box, color=black, style=filled, fillcolor=ivory, label="NFR:correct"];
-	instance:verifiable	[shape=box, color=black, style=filled, fillcolor=ivory, label="NFR:verifiable"];
-	instance:understandable	[shape=box, color=black, style=filled, fillcolor=ivory, label="NFR:understandable"];
-	instance:reusable	[shape=box, color=black, style=filled, fillcolor=ivory, label="NFR:reusable"];
-	instance:maintainable	[shape=box, color=black, style=filled, fillcolor=ivory, label="NFR:maintainable"];
-	instance:portable	[shape=box, color=black, style=filled, fillcolor=ivory, label="NFR:portable"];
-
-	subgraph FR {
-	rank="same"
-	{instance:inputValues, instance:verifyInVals, instance:calcValues, instance:outputValues, instance:correct, instance:verifiable, instance:understandable, instance:reusable, instance:maintainable, instance:portable}
-	}
-
-	instance:considerAirDrag	[shape=box, color=black, style=filled, fillcolor=lavender, label="LC:considerAirDrag"];
-
-	subgraph LC {
-	rank="same"
-	{instance:considerAirDrag}
-	}
-
+digraph "avsall" {
+    "theory:projSpeed" -> "instance:pointMass";
+    "theory:projSpeed" -> "instance:timeStartZero";
+    "theory:projPos" -> "instance:pointMass";
+    "theory:projPos" -> "instance:timeStartZero";
+    "theory:velocity" -> "instance:twoDMotion";
+    "theory:velocity" -> "instance:cartSyst";
+    "theory:velocity" -> "instance:constAccel";
+    "theory:velocity" -> "instance:timeStartZero";
+    "theory:position" -> "instance:twoDMotion";
+    "theory:position" -> "instance:cartSyst";
+    "theory:position" -> "instance:constAccel";
+    "theory:position" -> "instance:timeStartZero";
+    "theory:flightduration" -> "instance:yAxisGravity";
+    "theory:flightduration" -> "instance:launchOrigin";
+    "theory:flightduration" -> "instance:targetXAxis";
+    "theory:flightduration" -> "instance:posXDirection";
+    "theory:flightduration" -> "instance:accelYGravity";
+    "theory:flightduration" -> "instance:timeStartZero";
+    "theory:flightduration" -> "instance:gravAccelValue";
+    "theory:landingposition" -> "instance:yAxisGravity";
+    "theory:landingposition" -> "instance:launchOrigin";
+    "theory:landingposition" -> "instance:posXDirection";
+    "theory:landingposition" -> "instance:accelXZero";
+    "theory:landingposition" -> "instance:gravAccelValue";
+    "theory:offset" -> "instance:posXDirection";
+    "instance:considerAirDrag" -> "instance:neglectDrag";
+    "instance:twoDMotion" [shape=box, color=black, style=filled, fillcolor="mistyrose", label="A:twoDMotion"];
+    "instance:cartSyst" [shape=box, color=black, style=filled, fillcolor="mistyrose", label="A:cartSyst"];
+    "instance:yAxisGravity" [shape=box, color=black, style=filled, fillcolor="mistyrose", label="A:yAxisGravity"];
+    "instance:launchOrigin" [shape=box, color=black, style=filled, fillcolor="mistyrose", label="A:launchOrigin"];
+    "instance:targetXAxis" [shape=box, color=black, style=filled, fillcolor="mistyrose", label="A:targetXAxis"];
+    "instance:posXDirection" [shape=box, color=black, style=filled, fillcolor="mistyrose", label="A:posXDirection"];
+    "instance:constAccel" [shape=box, color=black, style=filled, fillcolor="mistyrose", label="A:constAccel"];
+    "instance:accelXZero" [shape=box, color=black, style=filled, fillcolor="mistyrose", label="A:accelXZero"];
+    "instance:accelYGravity" [shape=box, color=black, style=filled, fillcolor="mistyrose", label="A:accelYGravity"];
+    "instance:neglectDrag" [shape=box, color=black, style=filled, fillcolor="mistyrose", label="A:neglectDrag"];
+    "instance:pointMass" [shape=box, color=black, style=filled, fillcolor="mistyrose", label="A:pointMass"];
+    "instance:freeFlight" [shape=box, color=black, style=filled, fillcolor="mistyrose", label="A:freeFlight"];
+    "instance:neglectCurv" [shape=box, color=black, style=filled, fillcolor="mistyrose", label="A:neglectCurv"];
+    "instance:timeStartZero" [shape=box, color=black, style=filled, fillcolor="mistyrose", label="A:timeStartZero"];
+    "instance:gravAccelValue" [shape=box, color=black, style=filled, fillcolor="mistyrose", label="A:gravAccelValue"];
+    subgraph "A" {
+        rank="same";
+        "instance:twoDMotion" "instance:cartSyst" "instance:yAxisGravity" "instance:launchOrigin" "instance:targetXAxis" "instance:posXDirection" "instance:constAccel" "instance:accelXZero" "instance:accelYGravity" "instance:neglectDrag" "instance:pointMass" "instance:freeFlight" "instance:neglectCurv" "instance:timeStartZero" "instance:gravAccelValue";
+    }
+    "dataDefn:speed" [shape=box, color=black, style=filled, fillcolor="paleturquoise1", label="DD:vecMag"];
+    "dataDefn:ixVel" [shape=box, color=black, style=filled, fillcolor="paleturquoise1", label="DD:speedIX"];
+    "dataDefn:iyVel" [shape=box, color=black, style=filled, fillcolor="paleturquoise1", label="DD:speedIY"];
+    subgraph "DD" {
+        rank="same";
+        "dataDefn:speed" "dataDefn:ixVel" "dataDefn:iyVel";
+    }
+    "theory:accelerationTM" [shape=box, color=black, style=filled, fillcolor="pink", label="TM:acceleration"];
+    "theory:velocityTM" [shape=box, color=black, style=filled, fillcolor="pink", label="TM:velocity"];
+    subgraph "TM" {
+        rank="same";
+        "theory:accelerationTM" "theory:velocityTM";
+    }
+    "theory:projSpeed" [shape=box, color=black, style=filled, fillcolor="palegreen", label="GD:rectVel"];
+    "theory:projPos" [shape=box, color=black, style=filled, fillcolor="palegreen", label="GD:rectPos"];
+    "theory:velocity" [shape=box, color=black, style=filled, fillcolor="palegreen", label="GD:velVec"];
+    "theory:position" [shape=box, color=black, style=filled, fillcolor="palegreen", label="GD:posVec"];
+    subgraph "GD" {
+        rank="same";
+        "theory:projSpeed" "theory:projPos" "theory:velocity" "theory:position";
+    }
+    "theory:flightduration" [shape=box, color=black, style=filled, fillcolor="khaki1", label="IM:calOfLandingTime"];
+    "theory:landingposition" [shape=box, color=black, style=filled, fillcolor="khaki1", label="IM:calOfLandingDist"];
+    "theory:offset" [shape=box, color=black, style=filled, fillcolor="khaki1", label="IM:offsetIM"];
+    subgraph "IM" {
+        rank="same";
+        "theory:flightduration" "theory:landingposition" "theory:offset";
+    }
+    "instance:inputValues" [shape=box, color=black, style=filled, fillcolor="ivory", label="FR:inputValues"];
+    "instance:verifyInVals" [shape=box, color=black, style=filled, fillcolor="ivory", label="FR:verifyInVals"];
+    "instance:calcValues" [shape=box, color=black, style=filled, fillcolor="ivory", label="FR:calcValues"];
+    "instance:outputValues" [shape=box, color=black, style=filled, fillcolor="ivory", label="FR:outputValues"];
+    "instance:correct" [shape=box, color=black, style=filled, fillcolor="ivory", label="NFR:correct"];
+    "instance:verifiable" [shape=box, color=black, style=filled, fillcolor="ivory", label="NFR:verifiable"];
+    "instance:understandable" [shape=box, color=black, style=filled, fillcolor="ivory", label="NFR:understandable"];
+    "instance:reusable" [shape=box, color=black, style=filled, fillcolor="ivory", label="NFR:reusable"];
+    "instance:maintainable" [shape=box, color=black, style=filled, fillcolor="ivory", label="NFR:maintainable"];
+    "instance:portable" [shape=box, color=black, style=filled, fillcolor="ivory", label="NFR:portable"];
+    subgraph "FR" {
+        rank="same";
+        "instance:inputValues" "instance:verifyInVals" "instance:calcValues" "instance:outputValues" "instance:correct" "instance:verifiable" "instance:understandable" "instance:reusable" "instance:maintainable" "instance:portable";
+    }
+    "instance:considerAirDrag" [shape=box, color=black, style=filled, fillcolor="lavender", label="LC:considerAirDrag"];
+    subgraph "LC" {
+        rank="same";
+        "instance:considerAirDrag";
+    }
 }

--- a/code/stable/projectile/TraceyGraph/refvsref.dot
+++ b/code/stable/projectile/TraceyGraph/refvsref.dot
@@ -1,53 +1,43 @@
-digraph refvsref {
-	dataDefn:ixVel -> dataDefn:speed;
-	dataDefn:iyVel -> dataDefn:speed;
-	theory:projSpeed -> theory:accelerationTM;
-	theory:projPos -> theory:velocityTM;
-	theory:projPos -> theory:projSpeed;
-	theory:velocity -> theory:projSpeed;
-	theory:position -> theory:projPos;
-	theory:flightduration -> dataDefn:iyVel;
-	theory:flightduration -> theory:position;
-	theory:landingposition -> dataDefn:ixVel;
-	theory:landingposition -> theory:position;
-	theory:landingposition -> theory:flightduration;
-	theory:offset -> theory:landingposition;
-
-
-	dataDefn:speed	[shape=box, color=black, style=filled, fillcolor=paleturquoise1, label="DD:vecMag"];
-	dataDefn:ixVel	[shape=box, color=black, style=filled, fillcolor=paleturquoise1, label="DD:speedIX"];
-	dataDefn:iyVel	[shape=box, color=black, style=filled, fillcolor=paleturquoise1, label="DD:speedIY"];
-
-	subgraph DD {
-	rank="same"
-	{dataDefn:speed, dataDefn:ixVel, dataDefn:iyVel}
-	}
-
-	theory:accelerationTM	[shape=box, color=black, style=filled, fillcolor=pink, label="TM:acceleration"];
-	theory:velocityTM	[shape=box, color=black, style=filled, fillcolor=pink, label="TM:velocity"];
-
-	subgraph TM {
-	rank="same"
-	{theory:accelerationTM, theory:velocityTM}
-	}
-
-	theory:projSpeed	[shape=box, color=black, style=filled, fillcolor=palegreen, label="GD:rectVel"];
-	theory:projPos	[shape=box, color=black, style=filled, fillcolor=palegreen, label="GD:rectPos"];
-	theory:velocity	[shape=box, color=black, style=filled, fillcolor=palegreen, label="GD:velVec"];
-	theory:position	[shape=box, color=black, style=filled, fillcolor=palegreen, label="GD:posVec"];
-
-	subgraph GD {
-	rank="same"
-	{theory:projSpeed, theory:projPos, theory:velocity, theory:position}
-	}
-
-	theory:flightduration	[shape=box, color=black, style=filled, fillcolor=khaki1, label="IM:calOfLandingTime"];
-	theory:landingposition	[shape=box, color=black, style=filled, fillcolor=khaki1, label="IM:calOfLandingDist"];
-	theory:offset	[shape=box, color=black, style=filled, fillcolor=khaki1, label="IM:offsetIM"];
-
-	subgraph IM {
-	rank="same"
-	{theory:flightduration, theory:landingposition, theory:offset}
-	}
-
+digraph "refvsref" {
+    "dataDefn:ixVel" -> "dataDefn:speed";
+    "dataDefn:iyVel" -> "dataDefn:speed";
+    "theory:projSpeed" -> "theory:accelerationTM";
+    "theory:projPos" -> "theory:velocityTM";
+    "theory:projPos" -> "theory:projSpeed";
+    "theory:velocity" -> "theory:projSpeed";
+    "theory:position" -> "theory:projPos";
+    "theory:flightduration" -> "dataDefn:iyVel";
+    "theory:flightduration" -> "theory:position";
+    "theory:landingposition" -> "dataDefn:ixVel";
+    "theory:landingposition" -> "theory:position";
+    "theory:landingposition" -> "theory:flightduration";
+    "theory:offset" -> "theory:landingposition";
+    "dataDefn:speed" [shape=box, color=black, style=filled, fillcolor="paleturquoise1", label="DD:vecMag"];
+    "dataDefn:ixVel" [shape=box, color=black, style=filled, fillcolor="paleturquoise1", label="DD:speedIX"];
+    "dataDefn:iyVel" [shape=box, color=black, style=filled, fillcolor="paleturquoise1", label="DD:speedIY"];
+    subgraph "DD" {
+        rank="same";
+        "dataDefn:speed" "dataDefn:ixVel" "dataDefn:iyVel";
+    }
+    "theory:accelerationTM" [shape=box, color=black, style=filled, fillcolor="pink", label="TM:acceleration"];
+    "theory:velocityTM" [shape=box, color=black, style=filled, fillcolor="pink", label="TM:velocity"];
+    subgraph "TM" {
+        rank="same";
+        "theory:accelerationTM" "theory:velocityTM";
+    }
+    "theory:projSpeed" [shape=box, color=black, style=filled, fillcolor="palegreen", label="GD:rectVel"];
+    "theory:projPos" [shape=box, color=black, style=filled, fillcolor="palegreen", label="GD:rectPos"];
+    "theory:velocity" [shape=box, color=black, style=filled, fillcolor="palegreen", label="GD:velVec"];
+    "theory:position" [shape=box, color=black, style=filled, fillcolor="palegreen", label="GD:posVec"];
+    subgraph "GD" {
+        rank="same";
+        "theory:projSpeed" "theory:projPos" "theory:velocity" "theory:position";
+    }
+    "theory:flightduration" [shape=box, color=black, style=filled, fillcolor="khaki1", label="IM:calOfLandingTime"];
+    "theory:landingposition" [shape=box, color=black, style=filled, fillcolor="khaki1", label="IM:calOfLandingDist"];
+    "theory:offset" [shape=box, color=black, style=filled, fillcolor="khaki1", label="IM:offsetIM"];
+    subgraph "IM" {
+        rank="same";
+        "theory:flightduration" "theory:landingposition" "theory:offset";
+    }
 }

--- a/code/stable/sglpend/TraceyGraph/allvsall.dot
+++ b/code/stable/sglpend/TraceyGraph/allvsall.dot
@@ -1,87 +1,71 @@
-digraph allvsall {
-	dataDefn:angularFrequency -> dataDefn:period;
-	dataDefn:period -> dataDefn:frequency;
-	theory:angFrequencyGD -> dataDefn:frequency;
-	theory:angFrequencyGD -> theory:newtonSLR;
-	theory:periodPendGD -> dataDefn:frequency;
-	theory:periodPendGD -> dataDefn:angularFrequency;
-	theory:periodPendGD -> dataDefn:period;
-	theory:periodPendGD -> theory:angFrequencyGD;
-	theory:angularDisplacementIM -> theory:newtonSLR;
-	theory:angularDisplacementIM -> theory:angFrequencyGD;
-	instance:calcAngPos -> theory:angularDisplacementIM;
-	instance:outputValues -> theory:angularDisplacementIM;
-
-
-	instance:twoDMotion	[shape=box, color=black, style=filled, fillcolor=mistyrose, label="A:twoDMotion"];
-	instance:cartSys	[shape=box, color=black, style=filled, fillcolor=mistyrose, label="A:cartSys"];
-	instance:cartSysR	[shape=box, color=black, style=filled, fillcolor=mistyrose, label="A:cartSysR"];
-	instance:yAxisDir	[shape=box, color=black, style=filled, fillcolor=mistyrose, label="A:yAxisDir"];
-
-	subgraph A {
-	rank="same"
-	{instance:twoDMotion, instance:cartSys, instance:cartSysR, instance:yAxisDir}
-	}
-
-	dataDefn:ixPos	[shape=box, color=black, style=filled, fillcolor=paleturquoise1, label="DD:positionIX"];
-	dataDefn:iyPos	[shape=box, color=black, style=filled, fillcolor=paleturquoise1, label="DD:positionIY"];
-	dataDefn:frequency	[shape=box, color=black, style=filled, fillcolor=paleturquoise1, label="DD:frequencyDD"];
-	dataDefn:angularFrequency	[shape=box, color=black, style=filled, fillcolor=paleturquoise1, label="DD:angFrequencyDD"];
-	dataDefn:period	[shape=box, color=black, style=filled, fillcolor=paleturquoise1, label="DD:periodSHMDD"];
-
-	subgraph DD {
-	rank="same"
-	{dataDefn:ixPos, dataDefn:iyPos, dataDefn:frequency, dataDefn:angularFrequency, dataDefn:period}
-	}
-
-	theory:accelerationTM	[shape=box, color=black, style=filled, fillcolor=pink, label="TM:acceleration"];
-	theory:velocityTM	[shape=box, color=black, style=filled, fillcolor=pink, label="TM:velocity"];
-	theory:newtonSL	[shape=box, color=black, style=filled, fillcolor=pink, label="TM:NewtonSecLawMot"];
-	theory:newtonSLR	[shape=box, color=black, style=filled, fillcolor=pink, label="TM:NewtonSecLawRotMot"];
-
-	subgraph TM {
-	rank="same"
-	{theory:accelerationTM, theory:velocityTM, theory:newtonSL, theory:newtonSLR}
-	}
-
-	theory:xVel	[shape=box, color=black, style=filled, fillcolor=palegreen, label="GD:velocityIX"];
-	theory:yVel	[shape=box, color=black, style=filled, fillcolor=palegreen, label="GD:velocityIY"];
-	theory:xScalAcc	[shape=box, color=black, style=filled, fillcolor=palegreen, label="GD:accelerationIX"];
-	theory:yScalAcc	[shape=box, color=black, style=filled, fillcolor=palegreen, label="GD:accelerationIY"];
-	theory:hForceOnPendulum	[shape=box, color=black, style=filled, fillcolor=palegreen, label="GD:hForceOnPendulum"];
-	theory:vForceOnPendulum	[shape=box, color=black, style=filled, fillcolor=palegreen, label="GD:vForceOnPendulum"];
-	theory:angFrequencyGD	[shape=box, color=black, style=filled, fillcolor=palegreen, label="GD:angFrequencyGD"];
-	theory:periodPendGD	[shape=box, color=black, style=filled, fillcolor=palegreen, label="GD:periodPend"];
-
-	subgraph GD {
-	rank="same"
-	{theory:xVel, theory:yVel, theory:xScalAcc, theory:yScalAcc, theory:hForceOnPendulum, theory:vForceOnPendulum, theory:angFrequencyGD, theory:periodPendGD}
-	}
-
-	theory:angularDisplacementIM	[shape=box, color=black, style=filled, fillcolor=khaki1, label="IM:calOfAngularDisplacement"];
-
-	subgraph IM {
-	rank="same"
-	{theory:angularDisplacementIM}
-	}
-
-	instance:inputValues	[shape=box, color=black, style=filled, fillcolor=ivory, label="FR:inputValues"];
-	instance:verifyInptVals	[shape=box, color=black, style=filled, fillcolor=ivory, label="FR:verifyInptVals"];
-	instance:calcAngPos	[shape=box, color=black, style=filled, fillcolor=ivory, label="FR:calcAngPos"];
-	instance:outputValues	[shape=box, color=black, style=filled, fillcolor=ivory, label="FR:outputValues"];
-	instance:correct	[shape=box, color=black, style=filled, fillcolor=ivory, label="NFR:correct"];
-	instance:portable	[shape=box, color=black, style=filled, fillcolor=ivory, label="NFR:portable"];
-
-	subgraph FR {
-	rank="same"
-	{instance:inputValues, instance:verifyInptVals, instance:calcAngPos, instance:outputValues, instance:correct, instance:portable}
-	}
-
-	instance:motionMass	[shape=box, color=black, style=filled, fillcolor=darkgoldenrod1, label="GS:motionMass"];
-
-	subgraph GS {
-	rank="same"
-	{instance:motionMass}
-	}
-
+digraph "allvsall" {
+    "dataDefn:angularFrequency" -> "dataDefn:period";
+    "dataDefn:period" -> "dataDefn:frequency";
+    "theory:angFrequencyGD" -> "dataDefn:frequency";
+    "theory:angFrequencyGD" -> "theory:newtonSLR";
+    "theory:periodPendGD" -> "dataDefn:frequency";
+    "theory:periodPendGD" -> "dataDefn:angularFrequency";
+    "theory:periodPendGD" -> "dataDefn:period";
+    "theory:periodPendGD" -> "theory:angFrequencyGD";
+    "theory:angularDisplacementIM" -> "theory:newtonSLR";
+    "theory:angularDisplacementIM" -> "theory:angFrequencyGD";
+    "instance:calcAngPos" -> "theory:angularDisplacementIM";
+    "instance:outputValues" -> "theory:angularDisplacementIM";
+    "instance:twoDMotion" [shape=box, color=black, style=filled, fillcolor="mistyrose", label="A:twoDMotion"];
+    "instance:cartSys" [shape=box, color=black, style=filled, fillcolor="mistyrose", label="A:cartSys"];
+    "instance:cartSysR" [shape=box, color=black, style=filled, fillcolor="mistyrose", label="A:cartSysR"];
+    "instance:yAxisDir" [shape=box, color=black, style=filled, fillcolor="mistyrose", label="A:yAxisDir"];
+    subgraph "A" {
+        rank="same";
+        "instance:twoDMotion" "instance:cartSys" "instance:cartSysR" "instance:yAxisDir";
+    }
+    "dataDefn:ixPos" [shape=box, color=black, style=filled, fillcolor="paleturquoise1", label="DD:positionIX"];
+    "dataDefn:iyPos" [shape=box, color=black, style=filled, fillcolor="paleturquoise1", label="DD:positionIY"];
+    "dataDefn:frequency" [shape=box, color=black, style=filled, fillcolor="paleturquoise1", label="DD:frequencyDD"];
+    "dataDefn:angularFrequency" [shape=box, color=black, style=filled, fillcolor="paleturquoise1", label="DD:angFrequencyDD"];
+    "dataDefn:period" [shape=box, color=black, style=filled, fillcolor="paleturquoise1", label="DD:periodSHMDD"];
+    subgraph "DD" {
+        rank="same";
+        "dataDefn:ixPos" "dataDefn:iyPos" "dataDefn:frequency" "dataDefn:angularFrequency" "dataDefn:period";
+    }
+    "theory:accelerationTM" [shape=box, color=black, style=filled, fillcolor="pink", label="TM:acceleration"];
+    "theory:velocityTM" [shape=box, color=black, style=filled, fillcolor="pink", label="TM:velocity"];
+    "theory:newtonSL" [shape=box, color=black, style=filled, fillcolor="pink", label="TM:NewtonSecLawMot"];
+    "theory:newtonSLR" [shape=box, color=black, style=filled, fillcolor="pink", label="TM:NewtonSecLawRotMot"];
+    subgraph "TM" {
+        rank="same";
+        "theory:accelerationTM" "theory:velocityTM" "theory:newtonSL" "theory:newtonSLR";
+    }
+    "theory:xVel" [shape=box, color=black, style=filled, fillcolor="palegreen", label="GD:velocityIX"];
+    "theory:yVel" [shape=box, color=black, style=filled, fillcolor="palegreen", label="GD:velocityIY"];
+    "theory:xScalAcc" [shape=box, color=black, style=filled, fillcolor="palegreen", label="GD:accelerationIX"];
+    "theory:yScalAcc" [shape=box, color=black, style=filled, fillcolor="palegreen", label="GD:accelerationIY"];
+    "theory:hForceOnPendulum" [shape=box, color=black, style=filled, fillcolor="palegreen", label="GD:hForceOnPendulum"];
+    "theory:vForceOnPendulum" [shape=box, color=black, style=filled, fillcolor="palegreen", label="GD:vForceOnPendulum"];
+    "theory:angFrequencyGD" [shape=box, color=black, style=filled, fillcolor="palegreen", label="GD:angFrequencyGD"];
+    "theory:periodPendGD" [shape=box, color=black, style=filled, fillcolor="palegreen", label="GD:periodPend"];
+    subgraph "GD" {
+        rank="same";
+        "theory:xVel" "theory:yVel" "theory:xScalAcc" "theory:yScalAcc" "theory:hForceOnPendulum" "theory:vForceOnPendulum" "theory:angFrequencyGD" "theory:periodPendGD";
+    }
+    "theory:angularDisplacementIM" [shape=box, color=black, style=filled, fillcolor="khaki1", label="IM:calOfAngularDisplacement"];
+    subgraph "IM" {
+        rank="same";
+        "theory:angularDisplacementIM";
+    }
+    "instance:inputValues" [shape=box, color=black, style=filled, fillcolor="ivory", label="FR:inputValues"];
+    "instance:verifyInptVals" [shape=box, color=black, style=filled, fillcolor="ivory", label="FR:verifyInptVals"];
+    "instance:calcAngPos" [shape=box, color=black, style=filled, fillcolor="ivory", label="FR:calcAngPos"];
+    "instance:outputValues" [shape=box, color=black, style=filled, fillcolor="ivory", label="FR:outputValues"];
+    "instance:correct" [shape=box, color=black, style=filled, fillcolor="ivory", label="NFR:correct"];
+    "instance:portable" [shape=box, color=black, style=filled, fillcolor="ivory", label="NFR:portable"];
+    subgraph "FR" {
+        rank="same";
+        "instance:inputValues" "instance:verifyInptVals" "instance:calcAngPos" "instance:outputValues" "instance:correct" "instance:portable";
+    }
+    "instance:motionMass" [shape=box, color=black, style=filled, fillcolor="darkgoldenrod1", label="GS:motionMass"];
+    subgraph "GS" {
+        rank="same";
+        "instance:motionMass";
+    }
 }

--- a/code/stable/sglpend/TraceyGraph/allvsr.dot
+++ b/code/stable/sglpend/TraceyGraph/allvsr.dot
@@ -1,77 +1,61 @@
-digraph allvsr {
-	instance:calcAngPos -> theory:angularDisplacementIM;
-	instance:outputValues -> theory:angularDisplacementIM;
-
-
-	instance:twoDMotion	[shape=box, color=black, style=filled, fillcolor=mistyrose, label="A:twoDMotion"];
-	instance:cartSys	[shape=box, color=black, style=filled, fillcolor=mistyrose, label="A:cartSys"];
-	instance:cartSysR	[shape=box, color=black, style=filled, fillcolor=mistyrose, label="A:cartSysR"];
-	instance:yAxisDir	[shape=box, color=black, style=filled, fillcolor=mistyrose, label="A:yAxisDir"];
-
-	subgraph A {
-	rank="same"
-	{instance:twoDMotion, instance:cartSys, instance:cartSysR, instance:yAxisDir}
-	}
-
-	dataDefn:ixPos	[shape=box, color=black, style=filled, fillcolor=paleturquoise1, label="DD:positionIX"];
-	dataDefn:iyPos	[shape=box, color=black, style=filled, fillcolor=paleturquoise1, label="DD:positionIY"];
-	dataDefn:frequency	[shape=box, color=black, style=filled, fillcolor=paleturquoise1, label="DD:frequencyDD"];
-	dataDefn:angularFrequency	[shape=box, color=black, style=filled, fillcolor=paleturquoise1, label="DD:angFrequencyDD"];
-	dataDefn:period	[shape=box, color=black, style=filled, fillcolor=paleturquoise1, label="DD:periodSHMDD"];
-
-	subgraph DD {
-	rank="same"
-	{dataDefn:ixPos, dataDefn:iyPos, dataDefn:frequency, dataDefn:angularFrequency, dataDefn:period}
-	}
-
-	theory:accelerationTM	[shape=box, color=black, style=filled, fillcolor=pink, label="TM:acceleration"];
-	theory:velocityTM	[shape=box, color=black, style=filled, fillcolor=pink, label="TM:velocity"];
-	theory:newtonSL	[shape=box, color=black, style=filled, fillcolor=pink, label="TM:NewtonSecLawMot"];
-	theory:newtonSLR	[shape=box, color=black, style=filled, fillcolor=pink, label="TM:NewtonSecLawRotMot"];
-
-	subgraph TM {
-	rank="same"
-	{theory:accelerationTM, theory:velocityTM, theory:newtonSL, theory:newtonSLR}
-	}
-
-	theory:xVel	[shape=box, color=black, style=filled, fillcolor=palegreen, label="GD:velocityIX"];
-	theory:yVel	[shape=box, color=black, style=filled, fillcolor=palegreen, label="GD:velocityIY"];
-	theory:xScalAcc	[shape=box, color=black, style=filled, fillcolor=palegreen, label="GD:accelerationIX"];
-	theory:yScalAcc	[shape=box, color=black, style=filled, fillcolor=palegreen, label="GD:accelerationIY"];
-	theory:hForceOnPendulum	[shape=box, color=black, style=filled, fillcolor=palegreen, label="GD:hForceOnPendulum"];
-	theory:vForceOnPendulum	[shape=box, color=black, style=filled, fillcolor=palegreen, label="GD:vForceOnPendulum"];
-	theory:angFrequencyGD	[shape=box, color=black, style=filled, fillcolor=palegreen, label="GD:angFrequencyGD"];
-	theory:periodPendGD	[shape=box, color=black, style=filled, fillcolor=palegreen, label="GD:periodPend"];
-
-	subgraph GD {
-	rank="same"
-	{theory:xVel, theory:yVel, theory:xScalAcc, theory:yScalAcc, theory:hForceOnPendulum, theory:vForceOnPendulum, theory:angFrequencyGD, theory:periodPendGD}
-	}
-
-	theory:angularDisplacementIM	[shape=box, color=black, style=filled, fillcolor=khaki1, label="IM:calOfAngularDisplacement"];
-
-	subgraph IM {
-	rank="same"
-	{theory:angularDisplacementIM}
-	}
-
-	instance:inputValues	[shape=box, color=black, style=filled, fillcolor=ivory, label="FR:inputValues"];
-	instance:verifyInptVals	[shape=box, color=black, style=filled, fillcolor=ivory, label="FR:verifyInptVals"];
-	instance:calcAngPos	[shape=box, color=black, style=filled, fillcolor=ivory, label="FR:calcAngPos"];
-	instance:outputValues	[shape=box, color=black, style=filled, fillcolor=ivory, label="FR:outputValues"];
-	instance:correct	[shape=box, color=black, style=filled, fillcolor=ivory, label="NFR:correct"];
-	instance:portable	[shape=box, color=black, style=filled, fillcolor=ivory, label="NFR:portable"];
-
-	subgraph FR {
-	rank="same"
-	{instance:inputValues, instance:verifyInptVals, instance:calcAngPos, instance:outputValues, instance:correct, instance:portable}
-	}
-
-	instance:motionMass	[shape=box, color=black, style=filled, fillcolor=darkgoldenrod1, label="GS:motionMass"];
-
-	subgraph GS {
-	rank="same"
-	{instance:motionMass}
-	}
-
+digraph "allvsr" {
+    "instance:calcAngPos" -> "theory:angularDisplacementIM";
+    "instance:outputValues" -> "theory:angularDisplacementIM";
+    "instance:twoDMotion" [shape=box, color=black, style=filled, fillcolor="mistyrose", label="A:twoDMotion"];
+    "instance:cartSys" [shape=box, color=black, style=filled, fillcolor="mistyrose", label="A:cartSys"];
+    "instance:cartSysR" [shape=box, color=black, style=filled, fillcolor="mistyrose", label="A:cartSysR"];
+    "instance:yAxisDir" [shape=box, color=black, style=filled, fillcolor="mistyrose", label="A:yAxisDir"];
+    subgraph "A" {
+        rank="same";
+        "instance:twoDMotion" "instance:cartSys" "instance:cartSysR" "instance:yAxisDir";
+    }
+    "dataDefn:ixPos" [shape=box, color=black, style=filled, fillcolor="paleturquoise1", label="DD:positionIX"];
+    "dataDefn:iyPos" [shape=box, color=black, style=filled, fillcolor="paleturquoise1", label="DD:positionIY"];
+    "dataDefn:frequency" [shape=box, color=black, style=filled, fillcolor="paleturquoise1", label="DD:frequencyDD"];
+    "dataDefn:angularFrequency" [shape=box, color=black, style=filled, fillcolor="paleturquoise1", label="DD:angFrequencyDD"];
+    "dataDefn:period" [shape=box, color=black, style=filled, fillcolor="paleturquoise1", label="DD:periodSHMDD"];
+    subgraph "DD" {
+        rank="same";
+        "dataDefn:ixPos" "dataDefn:iyPos" "dataDefn:frequency" "dataDefn:angularFrequency" "dataDefn:period";
+    }
+    "theory:accelerationTM" [shape=box, color=black, style=filled, fillcolor="pink", label="TM:acceleration"];
+    "theory:velocityTM" [shape=box, color=black, style=filled, fillcolor="pink", label="TM:velocity"];
+    "theory:newtonSL" [shape=box, color=black, style=filled, fillcolor="pink", label="TM:NewtonSecLawMot"];
+    "theory:newtonSLR" [shape=box, color=black, style=filled, fillcolor="pink", label="TM:NewtonSecLawRotMot"];
+    subgraph "TM" {
+        rank="same";
+        "theory:accelerationTM" "theory:velocityTM" "theory:newtonSL" "theory:newtonSLR";
+    }
+    "theory:xVel" [shape=box, color=black, style=filled, fillcolor="palegreen", label="GD:velocityIX"];
+    "theory:yVel" [shape=box, color=black, style=filled, fillcolor="palegreen", label="GD:velocityIY"];
+    "theory:xScalAcc" [shape=box, color=black, style=filled, fillcolor="palegreen", label="GD:accelerationIX"];
+    "theory:yScalAcc" [shape=box, color=black, style=filled, fillcolor="palegreen", label="GD:accelerationIY"];
+    "theory:hForceOnPendulum" [shape=box, color=black, style=filled, fillcolor="palegreen", label="GD:hForceOnPendulum"];
+    "theory:vForceOnPendulum" [shape=box, color=black, style=filled, fillcolor="palegreen", label="GD:vForceOnPendulum"];
+    "theory:angFrequencyGD" [shape=box, color=black, style=filled, fillcolor="palegreen", label="GD:angFrequencyGD"];
+    "theory:periodPendGD" [shape=box, color=black, style=filled, fillcolor="palegreen", label="GD:periodPend"];
+    subgraph "GD" {
+        rank="same";
+        "theory:xVel" "theory:yVel" "theory:xScalAcc" "theory:yScalAcc" "theory:hForceOnPendulum" "theory:vForceOnPendulum" "theory:angFrequencyGD" "theory:periodPendGD";
+    }
+    "theory:angularDisplacementIM" [shape=box, color=black, style=filled, fillcolor="khaki1", label="IM:calOfAngularDisplacement"];
+    subgraph "IM" {
+        rank="same";
+        "theory:angularDisplacementIM";
+    }
+    "instance:inputValues" [shape=box, color=black, style=filled, fillcolor="ivory", label="FR:inputValues"];
+    "instance:verifyInptVals" [shape=box, color=black, style=filled, fillcolor="ivory", label="FR:verifyInptVals"];
+    "instance:calcAngPos" [shape=box, color=black, style=filled, fillcolor="ivory", label="FR:calcAngPos"];
+    "instance:outputValues" [shape=box, color=black, style=filled, fillcolor="ivory", label="FR:outputValues"];
+    "instance:correct" [shape=box, color=black, style=filled, fillcolor="ivory", label="NFR:correct"];
+    "instance:portable" [shape=box, color=black, style=filled, fillcolor="ivory", label="NFR:portable"];
+    subgraph "FR" {
+        rank="same";
+        "instance:inputValues" "instance:verifyInptVals" "instance:calcAngPos" "instance:outputValues" "instance:correct" "instance:portable";
+    }
+    "instance:motionMass" [shape=box, color=black, style=filled, fillcolor="darkgoldenrod1", label="GS:motionMass"];
+    subgraph "GS" {
+        rank="same";
+        "instance:motionMass";
+    }
 }

--- a/code/stable/sglpend/TraceyGraph/avsa.dot
+++ b/code/stable/sglpend/TraceyGraph/avsa.dot
@@ -1,14 +1,10 @@
-digraph avsa {
-
-
-	instance:twoDMotion	[shape=box, color=black, style=filled, fillcolor=mistyrose, label="A:twoDMotion"];
-	instance:cartSys	[shape=box, color=black, style=filled, fillcolor=mistyrose, label="A:cartSys"];
-	instance:cartSysR	[shape=box, color=black, style=filled, fillcolor=mistyrose, label="A:cartSysR"];
-	instance:yAxisDir	[shape=box, color=black, style=filled, fillcolor=mistyrose, label="A:yAxisDir"];
-
-	subgraph A {
-	rank="same"
-	{instance:twoDMotion, instance:cartSys, instance:cartSysR, instance:yAxisDir}
-	}
-
+digraph "avsa" {
+    "instance:twoDMotion" [shape=box, color=black, style=filled, fillcolor="mistyrose", label="A:twoDMotion"];
+    "instance:cartSys" [shape=box, color=black, style=filled, fillcolor="mistyrose", label="A:cartSys"];
+    "instance:cartSysR" [shape=box, color=black, style=filled, fillcolor="mistyrose", label="A:cartSysR"];
+    "instance:yAxisDir" [shape=box, color=black, style=filled, fillcolor="mistyrose", label="A:yAxisDir"];
+    subgraph "A" {
+        rank="same";
+        "instance:twoDMotion" "instance:cartSys" "instance:cartSysR" "instance:yAxisDir";
+    }
 }

--- a/code/stable/sglpend/TraceyGraph/avsall.dot
+++ b/code/stable/sglpend/TraceyGraph/avsall.dot
@@ -1,68 +1,54 @@
-digraph avsall {
-
-
-	instance:twoDMotion	[shape=box, color=black, style=filled, fillcolor=mistyrose, label="A:twoDMotion"];
-	instance:cartSys	[shape=box, color=black, style=filled, fillcolor=mistyrose, label="A:cartSys"];
-	instance:cartSysR	[shape=box, color=black, style=filled, fillcolor=mistyrose, label="A:cartSysR"];
-	instance:yAxisDir	[shape=box, color=black, style=filled, fillcolor=mistyrose, label="A:yAxisDir"];
-
-	subgraph A {
-	rank="same"
-	{instance:twoDMotion, instance:cartSys, instance:cartSysR, instance:yAxisDir}
-	}
-
-	dataDefn:ixPos	[shape=box, color=black, style=filled, fillcolor=paleturquoise1, label="DD:positionIX"];
-	dataDefn:iyPos	[shape=box, color=black, style=filled, fillcolor=paleturquoise1, label="DD:positionIY"];
-	dataDefn:frequency	[shape=box, color=black, style=filled, fillcolor=paleturquoise1, label="DD:frequencyDD"];
-	dataDefn:angularFrequency	[shape=box, color=black, style=filled, fillcolor=paleturquoise1, label="DD:angFrequencyDD"];
-	dataDefn:period	[shape=box, color=black, style=filled, fillcolor=paleturquoise1, label="DD:periodSHMDD"];
-
-	subgraph DD {
-	rank="same"
-	{dataDefn:ixPos, dataDefn:iyPos, dataDefn:frequency, dataDefn:angularFrequency, dataDefn:period}
-	}
-
-	theory:accelerationTM	[shape=box, color=black, style=filled, fillcolor=pink, label="TM:acceleration"];
-	theory:velocityTM	[shape=box, color=black, style=filled, fillcolor=pink, label="TM:velocity"];
-	theory:newtonSL	[shape=box, color=black, style=filled, fillcolor=pink, label="TM:NewtonSecLawMot"];
-	theory:newtonSLR	[shape=box, color=black, style=filled, fillcolor=pink, label="TM:NewtonSecLawRotMot"];
-
-	subgraph TM {
-	rank="same"
-	{theory:accelerationTM, theory:velocityTM, theory:newtonSL, theory:newtonSLR}
-	}
-
-	theory:xVel	[shape=box, color=black, style=filled, fillcolor=palegreen, label="GD:velocityIX"];
-	theory:yVel	[shape=box, color=black, style=filled, fillcolor=palegreen, label="GD:velocityIY"];
-	theory:xScalAcc	[shape=box, color=black, style=filled, fillcolor=palegreen, label="GD:accelerationIX"];
-	theory:yScalAcc	[shape=box, color=black, style=filled, fillcolor=palegreen, label="GD:accelerationIY"];
-	theory:hForceOnPendulum	[shape=box, color=black, style=filled, fillcolor=palegreen, label="GD:hForceOnPendulum"];
-	theory:vForceOnPendulum	[shape=box, color=black, style=filled, fillcolor=palegreen, label="GD:vForceOnPendulum"];
-	theory:angFrequencyGD	[shape=box, color=black, style=filled, fillcolor=palegreen, label="GD:angFrequencyGD"];
-	theory:periodPendGD	[shape=box, color=black, style=filled, fillcolor=palegreen, label="GD:periodPend"];
-
-	subgraph GD {
-	rank="same"
-	{theory:xVel, theory:yVel, theory:xScalAcc, theory:yScalAcc, theory:hForceOnPendulum, theory:vForceOnPendulum, theory:angFrequencyGD, theory:periodPendGD}
-	}
-
-	theory:angularDisplacementIM	[shape=box, color=black, style=filled, fillcolor=khaki1, label="IM:calOfAngularDisplacement"];
-
-	subgraph IM {
-	rank="same"
-	{theory:angularDisplacementIM}
-	}
-
-	instance:inputValues	[shape=box, color=black, style=filled, fillcolor=ivory, label="FR:inputValues"];
-	instance:verifyInptVals	[shape=box, color=black, style=filled, fillcolor=ivory, label="FR:verifyInptVals"];
-	instance:calcAngPos	[shape=box, color=black, style=filled, fillcolor=ivory, label="FR:calcAngPos"];
-	instance:outputValues	[shape=box, color=black, style=filled, fillcolor=ivory, label="FR:outputValues"];
-	instance:correct	[shape=box, color=black, style=filled, fillcolor=ivory, label="NFR:correct"];
-	instance:portable	[shape=box, color=black, style=filled, fillcolor=ivory, label="NFR:portable"];
-
-	subgraph FR {
-	rank="same"
-	{instance:inputValues, instance:verifyInptVals, instance:calcAngPos, instance:outputValues, instance:correct, instance:portable}
-	}
-
+digraph "avsall" {
+    "instance:twoDMotion" [shape=box, color=black, style=filled, fillcolor="mistyrose", label="A:twoDMotion"];
+    "instance:cartSys" [shape=box, color=black, style=filled, fillcolor="mistyrose", label="A:cartSys"];
+    "instance:cartSysR" [shape=box, color=black, style=filled, fillcolor="mistyrose", label="A:cartSysR"];
+    "instance:yAxisDir" [shape=box, color=black, style=filled, fillcolor="mistyrose", label="A:yAxisDir"];
+    subgraph "A" {
+        rank="same";
+        "instance:twoDMotion" "instance:cartSys" "instance:cartSysR" "instance:yAxisDir";
+    }
+    "dataDefn:ixPos" [shape=box, color=black, style=filled, fillcolor="paleturquoise1", label="DD:positionIX"];
+    "dataDefn:iyPos" [shape=box, color=black, style=filled, fillcolor="paleturquoise1", label="DD:positionIY"];
+    "dataDefn:frequency" [shape=box, color=black, style=filled, fillcolor="paleturquoise1", label="DD:frequencyDD"];
+    "dataDefn:angularFrequency" [shape=box, color=black, style=filled, fillcolor="paleturquoise1", label="DD:angFrequencyDD"];
+    "dataDefn:period" [shape=box, color=black, style=filled, fillcolor="paleturquoise1", label="DD:periodSHMDD"];
+    subgraph "DD" {
+        rank="same";
+        "dataDefn:ixPos" "dataDefn:iyPos" "dataDefn:frequency" "dataDefn:angularFrequency" "dataDefn:period";
+    }
+    "theory:accelerationTM" [shape=box, color=black, style=filled, fillcolor="pink", label="TM:acceleration"];
+    "theory:velocityTM" [shape=box, color=black, style=filled, fillcolor="pink", label="TM:velocity"];
+    "theory:newtonSL" [shape=box, color=black, style=filled, fillcolor="pink", label="TM:NewtonSecLawMot"];
+    "theory:newtonSLR" [shape=box, color=black, style=filled, fillcolor="pink", label="TM:NewtonSecLawRotMot"];
+    subgraph "TM" {
+        rank="same";
+        "theory:accelerationTM" "theory:velocityTM" "theory:newtonSL" "theory:newtonSLR";
+    }
+    "theory:xVel" [shape=box, color=black, style=filled, fillcolor="palegreen", label="GD:velocityIX"];
+    "theory:yVel" [shape=box, color=black, style=filled, fillcolor="palegreen", label="GD:velocityIY"];
+    "theory:xScalAcc" [shape=box, color=black, style=filled, fillcolor="palegreen", label="GD:accelerationIX"];
+    "theory:yScalAcc" [shape=box, color=black, style=filled, fillcolor="palegreen", label="GD:accelerationIY"];
+    "theory:hForceOnPendulum" [shape=box, color=black, style=filled, fillcolor="palegreen", label="GD:hForceOnPendulum"];
+    "theory:vForceOnPendulum" [shape=box, color=black, style=filled, fillcolor="palegreen", label="GD:vForceOnPendulum"];
+    "theory:angFrequencyGD" [shape=box, color=black, style=filled, fillcolor="palegreen", label="GD:angFrequencyGD"];
+    "theory:periodPendGD" [shape=box, color=black, style=filled, fillcolor="palegreen", label="GD:periodPend"];
+    subgraph "GD" {
+        rank="same";
+        "theory:xVel" "theory:yVel" "theory:xScalAcc" "theory:yScalAcc" "theory:hForceOnPendulum" "theory:vForceOnPendulum" "theory:angFrequencyGD" "theory:periodPendGD";
+    }
+    "theory:angularDisplacementIM" [shape=box, color=black, style=filled, fillcolor="khaki1", label="IM:calOfAngularDisplacement"];
+    subgraph "IM" {
+        rank="same";
+        "theory:angularDisplacementIM";
+    }
+    "instance:inputValues" [shape=box, color=black, style=filled, fillcolor="ivory", label="FR:inputValues"];
+    "instance:verifyInptVals" [shape=box, color=black, style=filled, fillcolor="ivory", label="FR:verifyInptVals"];
+    "instance:calcAngPos" [shape=box, color=black, style=filled, fillcolor="ivory", label="FR:calcAngPos"];
+    "instance:outputValues" [shape=box, color=black, style=filled, fillcolor="ivory", label="FR:outputValues"];
+    "instance:correct" [shape=box, color=black, style=filled, fillcolor="ivory", label="NFR:correct"];
+    "instance:portable" [shape=box, color=black, style=filled, fillcolor="ivory", label="NFR:portable"];
+    subgraph "FR" {
+        rank="same";
+        "instance:inputValues" "instance:verifyInptVals" "instance:calcAngPos" "instance:outputValues" "instance:correct" "instance:portable";
+    }
 }

--- a/code/stable/sglpend/TraceyGraph/refvsref.dot
+++ b/code/stable/sglpend/TraceyGraph/refvsref.dot
@@ -1,56 +1,46 @@
-digraph refvsref {
-	dataDefn:angularFrequency -> dataDefn:period;
-	dataDefn:period -> dataDefn:frequency;
-	theory:angFrequencyGD -> dataDefn:frequency;
-	theory:angFrequencyGD -> theory:newtonSLR;
-	theory:periodPendGD -> dataDefn:frequency;
-	theory:periodPendGD -> dataDefn:angularFrequency;
-	theory:periodPendGD -> dataDefn:period;
-	theory:periodPendGD -> theory:angFrequencyGD;
-	theory:angularDisplacementIM -> theory:newtonSLR;
-	theory:angularDisplacementIM -> theory:angFrequencyGD;
-
-
-	dataDefn:ixPos	[shape=box, color=black, style=filled, fillcolor=paleturquoise1, label="DD:positionIX"];
-	dataDefn:iyPos	[shape=box, color=black, style=filled, fillcolor=paleturquoise1, label="DD:positionIY"];
-	dataDefn:frequency	[shape=box, color=black, style=filled, fillcolor=paleturquoise1, label="DD:frequencyDD"];
-	dataDefn:angularFrequency	[shape=box, color=black, style=filled, fillcolor=paleturquoise1, label="DD:angFrequencyDD"];
-	dataDefn:period	[shape=box, color=black, style=filled, fillcolor=paleturquoise1, label="DD:periodSHMDD"];
-
-	subgraph DD {
-	rank="same"
-	{dataDefn:ixPos, dataDefn:iyPos, dataDefn:frequency, dataDefn:angularFrequency, dataDefn:period}
-	}
-
-	theory:accelerationTM	[shape=box, color=black, style=filled, fillcolor=pink, label="TM:acceleration"];
-	theory:velocityTM	[shape=box, color=black, style=filled, fillcolor=pink, label="TM:velocity"];
-	theory:newtonSL	[shape=box, color=black, style=filled, fillcolor=pink, label="TM:NewtonSecLawMot"];
-	theory:newtonSLR	[shape=box, color=black, style=filled, fillcolor=pink, label="TM:NewtonSecLawRotMot"];
-
-	subgraph TM {
-	rank="same"
-	{theory:accelerationTM, theory:velocityTM, theory:newtonSL, theory:newtonSLR}
-	}
-
-	theory:xVel	[shape=box, color=black, style=filled, fillcolor=palegreen, label="GD:velocityIX"];
-	theory:yVel	[shape=box, color=black, style=filled, fillcolor=palegreen, label="GD:velocityIY"];
-	theory:xScalAcc	[shape=box, color=black, style=filled, fillcolor=palegreen, label="GD:accelerationIX"];
-	theory:yScalAcc	[shape=box, color=black, style=filled, fillcolor=palegreen, label="GD:accelerationIY"];
-	theory:hForceOnPendulum	[shape=box, color=black, style=filled, fillcolor=palegreen, label="GD:hForceOnPendulum"];
-	theory:vForceOnPendulum	[shape=box, color=black, style=filled, fillcolor=palegreen, label="GD:vForceOnPendulum"];
-	theory:angFrequencyGD	[shape=box, color=black, style=filled, fillcolor=palegreen, label="GD:angFrequencyGD"];
-	theory:periodPendGD	[shape=box, color=black, style=filled, fillcolor=palegreen, label="GD:periodPend"];
-
-	subgraph GD {
-	rank="same"
-	{theory:xVel, theory:yVel, theory:xScalAcc, theory:yScalAcc, theory:hForceOnPendulum, theory:vForceOnPendulum, theory:angFrequencyGD, theory:periodPendGD}
-	}
-
-	theory:angularDisplacementIM	[shape=box, color=black, style=filled, fillcolor=khaki1, label="IM:calOfAngularDisplacement"];
-
-	subgraph IM {
-	rank="same"
-	{theory:angularDisplacementIM}
-	}
-
+digraph "refvsref" {
+    "dataDefn:angularFrequency" -> "dataDefn:period";
+    "dataDefn:period" -> "dataDefn:frequency";
+    "theory:angFrequencyGD" -> "dataDefn:frequency";
+    "theory:angFrequencyGD" -> "theory:newtonSLR";
+    "theory:periodPendGD" -> "dataDefn:frequency";
+    "theory:periodPendGD" -> "dataDefn:angularFrequency";
+    "theory:periodPendGD" -> "dataDefn:period";
+    "theory:periodPendGD" -> "theory:angFrequencyGD";
+    "theory:angularDisplacementIM" -> "theory:newtonSLR";
+    "theory:angularDisplacementIM" -> "theory:angFrequencyGD";
+    "dataDefn:ixPos" [shape=box, color=black, style=filled, fillcolor="paleturquoise1", label="DD:positionIX"];
+    "dataDefn:iyPos" [shape=box, color=black, style=filled, fillcolor="paleturquoise1", label="DD:positionIY"];
+    "dataDefn:frequency" [shape=box, color=black, style=filled, fillcolor="paleturquoise1", label="DD:frequencyDD"];
+    "dataDefn:angularFrequency" [shape=box, color=black, style=filled, fillcolor="paleturquoise1", label="DD:angFrequencyDD"];
+    "dataDefn:period" [shape=box, color=black, style=filled, fillcolor="paleturquoise1", label="DD:periodSHMDD"];
+    subgraph "DD" {
+        rank="same";
+        "dataDefn:ixPos" "dataDefn:iyPos" "dataDefn:frequency" "dataDefn:angularFrequency" "dataDefn:period";
+    }
+    "theory:accelerationTM" [shape=box, color=black, style=filled, fillcolor="pink", label="TM:acceleration"];
+    "theory:velocityTM" [shape=box, color=black, style=filled, fillcolor="pink", label="TM:velocity"];
+    "theory:newtonSL" [shape=box, color=black, style=filled, fillcolor="pink", label="TM:NewtonSecLawMot"];
+    "theory:newtonSLR" [shape=box, color=black, style=filled, fillcolor="pink", label="TM:NewtonSecLawRotMot"];
+    subgraph "TM" {
+        rank="same";
+        "theory:accelerationTM" "theory:velocityTM" "theory:newtonSL" "theory:newtonSLR";
+    }
+    "theory:xVel" [shape=box, color=black, style=filled, fillcolor="palegreen", label="GD:velocityIX"];
+    "theory:yVel" [shape=box, color=black, style=filled, fillcolor="palegreen", label="GD:velocityIY"];
+    "theory:xScalAcc" [shape=box, color=black, style=filled, fillcolor="palegreen", label="GD:accelerationIX"];
+    "theory:yScalAcc" [shape=box, color=black, style=filled, fillcolor="palegreen", label="GD:accelerationIY"];
+    "theory:hForceOnPendulum" [shape=box, color=black, style=filled, fillcolor="palegreen", label="GD:hForceOnPendulum"];
+    "theory:vForceOnPendulum" [shape=box, color=black, style=filled, fillcolor="palegreen", label="GD:vForceOnPendulum"];
+    "theory:angFrequencyGD" [shape=box, color=black, style=filled, fillcolor="palegreen", label="GD:angFrequencyGD"];
+    "theory:periodPendGD" [shape=box, color=black, style=filled, fillcolor="palegreen", label="GD:periodPend"];
+    subgraph "GD" {
+        rank="same";
+        "theory:xVel" "theory:yVel" "theory:xScalAcc" "theory:yScalAcc" "theory:hForceOnPendulum" "theory:vForceOnPendulum" "theory:angFrequencyGD" "theory:periodPendGD";
+    }
+    "theory:angularDisplacementIM" [shape=box, color=black, style=filled, fillcolor="khaki1", label="IM:calOfAngularDisplacement"];
+    subgraph "IM" {
+        rank="same";
+        "theory:angularDisplacementIM";
+    }
 }

--- a/code/stable/ssp/TraceyGraph/allvsall.dot
+++ b/code/stable/ssp/TraceyGraph/allvsall.dot
@@ -1,291 +1,273 @@
-digraph allvsall {
-	dataDefn:alpha_i -> instance:assumpSBSBISL;
-	dataDefn:beta_i -> instance:assumpSBSBISL;
-	dataDefn:l_bi -> dataDefn:alpha_i;
-	dataDefn:l_bi -> dataDefn:b_i;
-	dataDefn:l_si -> dataDefn:beta_i;
-	dataDefn:l_si -> dataDefn:b_i;
-	dataDefn:h_i -> instance:assumpSBSBISL;
-	dataDefn:h_i -> dataDefn:hR;
-	dataDefn:h_i -> dataDefn:hL;
-	dataDefn:Phi -> dataDefn:alpha_i;
-	dataDefn:Phi -> dataDefn:f_i;
-	dataDefn:Psi -> dataDefn:alpha_i;
-	dataDefn:Psi -> dataDefn:f_i;
-	dataDefn:Psi -> dataDefn:Phi;
-	theory:equilibriumCS -> instance:assumpENSL;
-	theory:mcShrSrgth -> instance:assumpSBSBISL;
-	theory:effectiveStressTM -> dataDefn:sigma;
-	theory:normForcEq -> dataDefn:alpha_i;
-	theory:normForcEq -> dataDefn:beta_i;
-	theory:normForcEq -> theory:equilibriumCS;
-	theory:normForcEq -> theory:sliceWght;
-	theory:normForcEq -> theory:srfWtrF;
-	theory:bsShrFEq -> dataDefn:alpha_i;
-	theory:bsShrFEq -> dataDefn:beta_i;
-	theory:bsShrFEq -> theory:equilibriumCS;
-	theory:bsShrFEq -> theory:sliceWght;
-	theory:bsShrFEq -> theory:srfWtrF;
-	theory:resShr -> instance:assumpSLH;
-	theory:resShr -> instance:assumpSP;
-	theory:resShr -> instance:assumpSLI;
-	theory:resShr -> instance:assumpPSC;
-	theory:resShr -> dataDefn:l_bi;
-	theory:resShr -> dataDefn:sigma;
-	theory:resShr -> dataDefn:tau;
-	theory:resShr -> theory:mcShrSrgth;
-	theory:mobShr -> instance:assumpFOS;
-	theory:mobShr -> dataDefn:l_bi;
-	theory:mobShr -> theory:factOfSafetyTM;
-	theory:mobShr -> theory:resShr;
-	theory:effNormF -> instance:assumpPSC;
-	theory:effNormF -> dataDefn:sigma;
-	theory:effNormF -> theory:effectiveStressTM;
-	theory:effNormF -> theory:baseWtrF;
-	theory:resShearWO -> dataDefn:H_i;
-	theory:resShearWO -> dataDefn:alpha_i;
-	theory:resShearWO -> dataDefn:beta_i;
-	theory:resShearWO -> dataDefn:l_bi;
-	theory:resShearWO -> theory:sliceWght;
-	theory:resShearWO -> theory:baseWtrF;
-	theory:resShearWO -> theory:srfWtrF;
-	theory:mobShearWO -> dataDefn:H_i;
-	theory:mobShearWO -> dataDefn:alpha_i;
-	theory:mobShearWO -> dataDefn:beta_i;
-	theory:mobShearWO -> theory:sliceWght;
-	theory:mobShearWO -> theory:srfWtrF;
-	theory:X_i -> instance:assumpINSFL;
-	theory:X_i -> dataDefn:f_i;
-	theory:momentEql -> instance:assumpNESSS;
-	theory:momentEql -> instance:assumpHFSM;
-	theory:momentEql -> dataDefn:alpha_i;
-	theory:momentEql -> dataDefn:beta_i;
-	theory:momentEql -> dataDefn:b_i;
-	theory:momentEql -> dataDefn:h_i;
-	theory:momentEql -> dataDefn:torque;
-	theory:momentEql -> theory:equilibriumCS;
-	theory:momentEql -> theory:weight;
-	theory:momentEql -> theory:sliceWght;
-	theory:momentEql -> theory:srfWtrF;
-	theory:weight -> theory:newtonSL;
-	theory:sliceWght -> instance:assumpSLH;
-	theory:sliceWght -> instance:assumpPSC;
-	theory:sliceWght -> instance:assumpSBSBISL;
-	theory:sliceWght -> instance:assumpWIBE;
-	theory:sliceWght -> instance:assumpWISE;
-	theory:sliceWght -> dataDefn:b_i;
-	theory:sliceWght -> theory:weight;
-	theory:baseWtrF -> instance:assumpPSC;
-	theory:baseWtrF -> instance:assumpSBSBISL;
-	theory:baseWtrF -> instance:assumpWIBE;
-	theory:baseWtrF -> instance:assumpHFSM;
-	theory:baseWtrF -> dataDefn:l_bi;
-	theory:baseWtrF -> theory:pressure;
-	theory:baseWtrF -> theory:baseWtrF;
-	theory:srfWtrF -> instance:assumpPSC;
-	theory:srfWtrF -> instance:assumpSBSBISL;
-	theory:srfWtrF -> instance:assumpWISE;
-	theory:srfWtrF -> instance:assumpHFSM;
-	theory:srfWtrF -> dataDefn:l_si;
-	theory:srfWtrF -> theory:pressure;
-	theory:srfWtrF -> theory:srfWtrF;
-	theory:FS -> instance:assumpINSFL;
-	theory:FS -> instance:assumpES;
-	theory:FS -> instance:assumpSF;
-	theory:FS -> instance:assumpSL;
-	theory:FS -> dataDefn:Phi;
-	theory:FS -> dataDefn:Psi;
-	theory:FS -> theory:normForcEq;
-	theory:FS -> theory:bsShrFEq;
-	theory:FS -> theory:mobShr;
-	theory:FS -> theory:resShearWO;
-	theory:FS -> theory:mobShearWO;
-	theory:FS -> theory:X_i;
-	theory:FS -> theory:FS;
-	theory:FS -> theory:nrmShrForIM;
-	theory:FS -> theory:intsliceFsRC;
-	theory:nrmShrForIM -> instance:assumpINSFL;
-	theory:nrmShrForIM -> instance:assumpES;
-	theory:nrmShrForIM -> instance:assumpSF;
-	theory:nrmShrForIM -> instance:assumpSL;
-	theory:nrmShrForIM -> theory:X_i;
-	theory:nrmShrForIM -> theory:momentEql;
-	theory:nrmShrForIM -> theory:FS;
-	theory:nrmShrForIM -> theory:nrmShrForIM;
-	theory:nrmShrForIM -> theory:nrmShrForNumRC;
-	theory:nrmShrForIM -> theory:nrmShrForDenRC;
-	theory:nrmShrForIM -> theory:intsliceFsRC;
-	theory:nrmShrForNumRC -> dataDefn:H_i;
-	theory:nrmShrForNumRC -> dataDefn:alpha_i;
-	theory:nrmShrForNumRC -> dataDefn:beta_i;
-	theory:nrmShrForNumRC -> dataDefn:b_i;
-	theory:nrmShrForNumRC -> dataDefn:h_i;
-	theory:nrmShrForNumRC -> theory:srfWtrF;
-	theory:nrmShrForNumRC -> theory:nrmShrForIM;
-	theory:nrmShrForDenRC -> dataDefn:b_i;
-	theory:nrmShrForDenRC -> dataDefn:f_i;
-	theory:nrmShrForDenRC -> theory:nrmShrForIM;
-	theory:intsliceFsRC -> instance:assumpES;
-	theory:intsliceFsRC -> dataDefn:Phi;
-	theory:intsliceFsRC -> dataDefn:Psi;
-	theory:intsliceFsRC -> theory:resShearWO;
-	theory:intsliceFsRC -> theory:mobShearWO;
-	theory:intsliceFsRC -> theory:FS;
-	theory:intsliceFsRC -> theory:nrmShrForIM;
-	theory:intsliceFsRC -> theory:intsliceFsRC;
-	theory:crtSlpIdIM -> instance:assumpSSC;
-	instance:determineCritSlip -> theory:FS;
-	instance:determineCritSlip -> theory:nrmShrForIM;
-	instance:determineCritSlip -> theory:intsliceFsRC;
-	instance:determineCritSlip -> theory:crtSlpIdIM;
-	instance:displayGraph -> theory:crtSlpIdIM;
-	instance:displayFS -> theory:FS;
-	instance:displayFS -> theory:nrmShrForIM;
-	instance:displayFS -> theory:intsliceFsRC;
-	instance:displayNormal -> theory:FS;
-	instance:displayNormal -> theory:nrmShrForIM;
-	instance:displayNormal -> theory:intsliceFsRC;
-	instance:displayShear -> theory:FS;
-	instance:displayShear -> theory:nrmShrForIM;
-	instance:displayShear -> theory:intsliceFsRC;
-	instance:writeToFile -> instance:displayInput;
-	instance:writeToFile -> instance:displayGraph;
-	instance:writeToFile -> instance:displayFS;
-	instance:writeToFile -> instance:displayNormal;
-	instance:writeToFile -> instance:displayShear;
-	instance:LC_inhomogeneous -> instance:assumpSLH;
-	instance:LC_seismic -> instance:assumpSF;
-	instance:LC_external -> instance:assumpSL;
-	instance:UC_normshearlinear -> instance:assumpINSFL;
-	instance:UC_2donly -> instance:assumpENSL;
-
-
-	instance:assumpSSC	[shape=box, color=black, style=filled, fillcolor=mistyrose, label="A:assumpSSC"];
-	instance:assumpFOS	[shape=box, color=black, style=filled, fillcolor=mistyrose, label="A:assumpFOS"];
-	instance:assumpSLH	[shape=box, color=black, style=filled, fillcolor=mistyrose, label="A:assumpSLH"];
-	instance:assumpSP	[shape=box, color=black, style=filled, fillcolor=mistyrose, label="A:assumpSP"];
-	instance:assumpSLI	[shape=box, color=black, style=filled, fillcolor=mistyrose, label="A:assumpSLI"];
-	instance:assumpINSFL	[shape=box, color=black, style=filled, fillcolor=mistyrose, label="A:assumpINSFL"];
-	instance:assumpPSC	[shape=box, color=black, style=filled, fillcolor=mistyrose, label="A:assumpPSC"];
-	instance:assumpENSL	[shape=box, color=black, style=filled, fillcolor=mistyrose, label="A:assumpENSL"];
-	instance:assumpSBSBISL	[shape=box, color=black, style=filled, fillcolor=mistyrose, label="A:assumpSBSBISL"];
-	instance:assumpES	[shape=box, color=black, style=filled, fillcolor=mistyrose, label="A:assumpES"];
-	instance:assumpSF	[shape=box, color=black, style=filled, fillcolor=mistyrose, label="A:assumpSF"];
-	instance:assumpSL	[shape=box, color=black, style=filled, fillcolor=mistyrose, label="A:assumpSL"];
-	instance:assumpWIBE	[shape=box, color=black, style=filled, fillcolor=mistyrose, label="A:assumpWIBE"];
-	instance:assumpWISE	[shape=box, color=black, style=filled, fillcolor=mistyrose, label="A:assumpWISE"];
-	instance:assumpNESSS	[shape=box, color=black, style=filled, fillcolor=mistyrose, label="A:assumpNESSS"];
-	instance:assumpHFSM	[shape=box, color=black, style=filled, fillcolor=mistyrose, label="A:assumpHFSM"];
-
-	subgraph A {
-	rank="same"
-	{instance:assumpSSC, instance:assumpFOS, instance:assumpSLH, instance:assumpSP, instance:assumpSLI, instance:assumpINSFL, instance:assumpPSC, instance:assumpENSL, instance:assumpSBSBISL, instance:assumpES, instance:assumpSF, instance:assumpSL, instance:assumpWIBE, instance:assumpWISE, instance:assumpNESSS, instance:assumpHFSM}
-	}
-
-	dataDefn:H_i	[shape=box, color=black, style=filled, fillcolor=paleturquoise1, label="DD:intersliceWtrF"];
-	dataDefn:alpha_i	[shape=box, color=black, style=filled, fillcolor=paleturquoise1, label="DD:angleA"];
-	dataDefn:beta_i	[shape=box, color=black, style=filled, fillcolor=paleturquoise1, label="DD:angleB"];
-	dataDefn:b_i	[shape=box, color=black, style=filled, fillcolor=paleturquoise1, label="DD:lengthB"];
-	dataDefn:l_bi	[shape=box, color=black, style=filled, fillcolor=paleturquoise1, label="DD:lengthLb"];
-	dataDefn:l_si	[shape=box, color=black, style=filled, fillcolor=paleturquoise1, label="DD:lengthLs"];
-	dataDefn:h_i	[shape=box, color=black, style=filled, fillcolor=paleturquoise1, label="DD:slcHeight"];
-	dataDefn:sigma	[shape=box, color=black, style=filled, fillcolor=paleturquoise1, label="DD:normStress"];
-	dataDefn:tau	[shape=box, color=black, style=filled, fillcolor=paleturquoise1, label="DD:tangStress"];
-	dataDefn:torque	[shape=box, color=black, style=filled, fillcolor=paleturquoise1, label="DD:torque"];
-	dataDefn:f_i	[shape=box, color=black, style=filled, fillcolor=paleturquoise1, label="DD:ratioVariation"];
-	dataDefn:Phi	[shape=box, color=black, style=filled, fillcolor=paleturquoise1, label="DD:convertFunc1"];
-	dataDefn:Psi	[shape=box, color=black, style=filled, fillcolor=paleturquoise1, label="DD:convertFunc2"];
-	dataDefn:F_xG	[shape=box, color=black, style=filled, fillcolor=paleturquoise1, label="DD:nrmForceSumDD"];
-	dataDefn:F_xH	[shape=box, color=black, style=filled, fillcolor=paleturquoise1, label="DD:watForceSumDD"];
-	dataDefn:hR	[shape=box, color=black, style=filled, fillcolor=paleturquoise1, label="DD:sliceHghtRightDD"];
-	dataDefn:hL	[shape=box, color=black, style=filled, fillcolor=paleturquoise1, label="DD:sliceHghtLeftDD"];
-
-	subgraph DD {
-	rank="same"
-	{dataDefn:H_i, dataDefn:alpha_i, dataDefn:beta_i, dataDefn:b_i, dataDefn:l_bi, dataDefn:l_si, dataDefn:h_i, dataDefn:sigma, dataDefn:tau, dataDefn:torque, dataDefn:f_i, dataDefn:Phi, dataDefn:Psi, dataDefn:F_xG, dataDefn:F_xH, dataDefn:hR, dataDefn:hL}
-	}
-
-	theory:factOfSafetyTM	[shape=box, color=black, style=filled, fillcolor=pink, label="TM:factOfSafety"];
-	theory:equilibriumCS	[shape=box, color=black, style=filled, fillcolor=pink, label="TM:equilibrium"];
-	theory:mcShrSrgth	[shape=box, color=black, style=filled, fillcolor=pink, label="TM:mcShrStrgth"];
-	theory:effectiveStressTM	[shape=box, color=black, style=filled, fillcolor=pink, label="TM:effStress"];
-	theory:newtonSL	[shape=box, color=black, style=filled, fillcolor=pink, label="TM:NewtonSecLawMot"];
-
-	subgraph TM {
-	rank="same"
-	{theory:factOfSafetyTM, theory:equilibriumCS, theory:mcShrSrgth, theory:effectiveStressTM, theory:newtonSL}
-	}
-
-	theory:normForcEq	[shape=box, color=black, style=filled, fillcolor=palegreen, label="GD:normForcEq"];
-	theory:bsShrFEq	[shape=box, color=black, style=filled, fillcolor=palegreen, label="GD:bsShrFEq"];
-	theory:resShr	[shape=box, color=black, style=filled, fillcolor=palegreen, label="GD:resShr"];
-	theory:mobShr	[shape=box, color=black, style=filled, fillcolor=palegreen, label="GD:mobShr"];
-	theory:effNormF	[shape=box, color=black, style=filled, fillcolor=palegreen, label="GD:effNormF"];
-	theory:resShearWO	[shape=box, color=black, style=filled, fillcolor=palegreen, label="GD:resShearWO"];
-	theory:mobShearWO	[shape=box, color=black, style=filled, fillcolor=palegreen, label="GD:mobShearWO"];
-	theory:X_i	[shape=box, color=black, style=filled, fillcolor=palegreen, label="GD:normShrR"];
-	theory:momentEql	[shape=box, color=black, style=filled, fillcolor=palegreen, label="GD:momentEql"];
-	theory:weight	[shape=box, color=black, style=filled, fillcolor=palegreen, label="GD:weight"];
-	theory:sliceWght	[shape=box, color=black, style=filled, fillcolor=palegreen, label="GD:sliceWght"];
-	theory:pressure	[shape=box, color=black, style=filled, fillcolor=palegreen, label="GD:hsPressure"];
-	theory:baseWtrF	[shape=box, color=black, style=filled, fillcolor=palegreen, label="GD:baseWtrF"];
-	theory:srfWtrF	[shape=box, color=black, style=filled, fillcolor=palegreen, label="GD:srfWtrF"];
-
-	subgraph GD {
-	rank="same"
-	{theory:normForcEq, theory:bsShrFEq, theory:resShr, theory:mobShr, theory:effNormF, theory:resShearWO, theory:mobShearWO, theory:X_i, theory:momentEql, theory:weight, theory:sliceWght, theory:pressure, theory:baseWtrF, theory:srfWtrF}
-	}
-
-	theory:FS	[shape=box, color=black, style=filled, fillcolor=khaki1, label="IM:fctSfty"];
-	theory:nrmShrForIM	[shape=box, color=black, style=filled, fillcolor=khaki1, label="IM:nrmShrFor"];
-	theory:nrmShrForNumRC	[shape=box, color=black, style=filled, fillcolor=khaki1, label="IM:nrmShrForNum"];
-	theory:nrmShrForDenRC	[shape=box, color=black, style=filled, fillcolor=khaki1, label="IM:nrmShrForDen"];
-	theory:intsliceFsRC	[shape=box, color=black, style=filled, fillcolor=khaki1, label="IM:intsliceFs"];
-	theory:crtSlpIdIM	[shape=box, color=black, style=filled, fillcolor=khaki1, label="IM:crtSlpId"];
-
-	subgraph IM {
-	rank="same"
-	{theory:FS, theory:nrmShrForIM, theory:nrmShrForNumRC, theory:nrmShrForDenRC, theory:intsliceFsRC, theory:crtSlpIdIM}
-	}
-
-	instance:readAndStore	[shape=box, color=black, style=filled, fillcolor=ivory, label="FR:readAndStore"];
-	instance:verifyInput	[shape=box, color=black, style=filled, fillcolor=ivory, label="FR:verifyInput"];
-	instance:determineCritSlip	[shape=box, color=black, style=filled, fillcolor=ivory, label="FR:determineCritSlip"];
-	instance:verifyOutput	[shape=box, color=black, style=filled, fillcolor=ivory, label="FR:verifyOutput"];
-	instance:displayInput	[shape=box, color=black, style=filled, fillcolor=ivory, label="FR:displayInput"];
-	instance:displayGraph	[shape=box, color=black, style=filled, fillcolor=ivory, label="FR:displayGraph"];
-	instance:displayFS	[shape=box, color=black, style=filled, fillcolor=ivory, label="FR:displayFS"];
-	instance:displayNormal	[shape=box, color=black, style=filled, fillcolor=ivory, label="FR:displayNormal"];
-	instance:displayShear	[shape=box, color=black, style=filled, fillcolor=ivory, label="FR:displayShear"];
-	instance:writeToFile	[shape=box, color=black, style=filled, fillcolor=ivory, label="FR:writeToFile"];
-	instance:correct	[shape=box, color=black, style=filled, fillcolor=ivory, label="NFR:correct"];
-	instance:understandable	[shape=box, color=black, style=filled, fillcolor=ivory, label="NFR:understandable"];
-	instance:reusable	[shape=box, color=black, style=filled, fillcolor=ivory, label="NFR:reusable"];
-	instance:maintainable	[shape=box, color=black, style=filled, fillcolor=ivory, label="NFR:maintainable"];
-
-	subgraph FR {
-	rank="same"
-	{instance:readAndStore, instance:verifyInput, instance:determineCritSlip, instance:verifyOutput, instance:displayInput, instance:displayGraph, instance:displayFS, instance:displayNormal, instance:displayShear, instance:writeToFile, instance:correct, instance:understandable, instance:reusable, instance:maintainable}
-	}
-
-	instance:identifyCritAndFS	[shape=box, color=black, style=filled, fillcolor=darkgoldenrod1, label="GS:identifyCritAndFS"];
-	instance:determineNormalF	[shape=box, color=black, style=filled, fillcolor=darkgoldenrod1, label="GS:determineNormalF"];
-	instance:determineShearF	[shape=box, color=black, style=filled, fillcolor=darkgoldenrod1, label="GS:determineShearF"];
-
-	subgraph GS {
-	rank="same"
-	{instance:identifyCritAndFS, instance:determineNormalF, instance:determineShearF}
-	}
-
-	instance:LC_inhomogeneous	[shape=box, color=black, style=filled, fillcolor=lavender, label="LC:LC_inhomogeneous"];
-	instance:LC_seismic	[shape=box, color=black, style=filled, fillcolor=lavender, label="LC:LC_seismic"];
-	instance:LC_external	[shape=box, color=black, style=filled, fillcolor=lavender, label="LC:LC_external"];
-	instance:UC_normshearlinear	[shape=box, color=black, style=filled, fillcolor=lavender, label="UC:UC_normshearlinear"];
-	instance:UC_2donly	[shape=box, color=black, style=filled, fillcolor=lavender, label="UC:UC_2donly"];
-
-	subgraph LC {
-	rank="same"
-	{instance:LC_inhomogeneous, instance:LC_seismic, instance:LC_external, instance:UC_normshearlinear, instance:UC_2donly}
-	}
-
+digraph "allvsall" {
+    "dataDefn:alpha_i" -> "instance:assumpSBSBISL";
+    "dataDefn:beta_i" -> "instance:assumpSBSBISL";
+    "dataDefn:l_b,i" -> "dataDefn:alpha_i";
+    "dataDefn:l_b,i" -> "dataDefn:b_i";
+    "dataDefn:l_s,i" -> "dataDefn:beta_i";
+    "dataDefn:l_s,i" -> "dataDefn:b_i";
+    "dataDefn:h_i" -> "instance:assumpSBSBISL";
+    "dataDefn:h_i" -> "dataDefn:h^R";
+    "dataDefn:h_i" -> "dataDefn:h^L";
+    "dataDefn:Phi" -> "dataDefn:alpha_i";
+    "dataDefn:Phi" -> "dataDefn:f_i";
+    "dataDefn:Psi" -> "dataDefn:alpha_i";
+    "dataDefn:Psi" -> "dataDefn:f_i";
+    "dataDefn:Psi" -> "dataDefn:Phi";
+    "theory:equilibriumCS" -> "instance:assumpENSL";
+    "theory:mcShrSrgth" -> "instance:assumpSBSBISL";
+    "theory:effectiveStressTM" -> "dataDefn:sigma";
+    "theory:normForcEq" -> "dataDefn:alpha_i";
+    "theory:normForcEq" -> "dataDefn:beta_i";
+    "theory:normForcEq" -> "theory:equilibriumCS";
+    "theory:normForcEq" -> "theory:sliceWght";
+    "theory:normForcEq" -> "theory:srfWtrF";
+    "theory:bsShrFEq" -> "dataDefn:alpha_i";
+    "theory:bsShrFEq" -> "dataDefn:beta_i";
+    "theory:bsShrFEq" -> "theory:equilibriumCS";
+    "theory:bsShrFEq" -> "theory:sliceWght";
+    "theory:bsShrFEq" -> "theory:srfWtrF";
+    "theory:resShr" -> "instance:assumpSLH";
+    "theory:resShr" -> "instance:assumpSP";
+    "theory:resShr" -> "instance:assumpSLI";
+    "theory:resShr" -> "instance:assumpPSC";
+    "theory:resShr" -> "dataDefn:l_b,i";
+    "theory:resShr" -> "dataDefn:sigma";
+    "theory:resShr" -> "dataDefn:tau";
+    "theory:resShr" -> "theory:mcShrSrgth";
+    "theory:mobShr" -> "instance:assumpFOS";
+    "theory:mobShr" -> "dataDefn:l_b,i";
+    "theory:mobShr" -> "theory:factOfSafetyTM";
+    "theory:mobShr" -> "theory:resShr";
+    "theory:effNormF" -> "instance:assumpPSC";
+    "theory:effNormF" -> "dataDefn:sigma";
+    "theory:effNormF" -> "theory:effectiveStressTM";
+    "theory:effNormF" -> "theory:baseWtrF";
+    "theory:resShearWO" -> "dataDefn:H_i";
+    "theory:resShearWO" -> "dataDefn:alpha_i";
+    "theory:resShearWO" -> "dataDefn:beta_i";
+    "theory:resShearWO" -> "dataDefn:l_b,i";
+    "theory:resShearWO" -> "theory:sliceWght";
+    "theory:resShearWO" -> "theory:baseWtrF";
+    "theory:resShearWO" -> "theory:srfWtrF";
+    "theory:mobShearWO" -> "dataDefn:H_i";
+    "theory:mobShearWO" -> "dataDefn:alpha_i";
+    "theory:mobShearWO" -> "dataDefn:beta_i";
+    "theory:mobShearWO" -> "theory:sliceWght";
+    "theory:mobShearWO" -> "theory:srfWtrF";
+    "theory:X_i" -> "instance:assumpINSFL";
+    "theory:X_i" -> "dataDefn:f_i";
+    "theory:momentEql" -> "instance:assumpNESSS";
+    "theory:momentEql" -> "instance:assumpHFSM";
+    "theory:momentEql" -> "dataDefn:alpha_i";
+    "theory:momentEql" -> "dataDefn:beta_i";
+    "theory:momentEql" -> "dataDefn:b_i";
+    "theory:momentEql" -> "dataDefn:h_i";
+    "theory:momentEql" -> "dataDefn:torque";
+    "theory:momentEql" -> "theory:equilibriumCS";
+    "theory:momentEql" -> "theory:weight";
+    "theory:momentEql" -> "theory:sliceWght";
+    "theory:momentEql" -> "theory:srfWtrF";
+    "theory:weight" -> "theory:newtonSL";
+    "theory:sliceWght" -> "instance:assumpSLH";
+    "theory:sliceWght" -> "instance:assumpPSC";
+    "theory:sliceWght" -> "instance:assumpSBSBISL";
+    "theory:sliceWght" -> "instance:assumpWIBE";
+    "theory:sliceWght" -> "instance:assumpWISE";
+    "theory:sliceWght" -> "dataDefn:b_i";
+    "theory:sliceWght" -> "theory:weight";
+    "theory:baseWtrF" -> "instance:assumpPSC";
+    "theory:baseWtrF" -> "instance:assumpSBSBISL";
+    "theory:baseWtrF" -> "instance:assumpWIBE";
+    "theory:baseWtrF" -> "instance:assumpHFSM";
+    "theory:baseWtrF" -> "dataDefn:l_b,i";
+    "theory:baseWtrF" -> "theory:pressure";
+    "theory:baseWtrF" -> "theory:baseWtrF";
+    "theory:srfWtrF" -> "instance:assumpPSC";
+    "theory:srfWtrF" -> "instance:assumpSBSBISL";
+    "theory:srfWtrF" -> "instance:assumpWISE";
+    "theory:srfWtrF" -> "instance:assumpHFSM";
+    "theory:srfWtrF" -> "dataDefn:l_s,i";
+    "theory:srfWtrF" -> "theory:pressure";
+    "theory:srfWtrF" -> "theory:srfWtrF";
+    "theory:FS" -> "instance:assumpINSFL";
+    "theory:FS" -> "instance:assumpES";
+    "theory:FS" -> "instance:assumpSF";
+    "theory:FS" -> "instance:assumpSL";
+    "theory:FS" -> "dataDefn:Phi";
+    "theory:FS" -> "dataDefn:Psi";
+    "theory:FS" -> "theory:normForcEq";
+    "theory:FS" -> "theory:bsShrFEq";
+    "theory:FS" -> "theory:mobShr";
+    "theory:FS" -> "theory:resShearWO";
+    "theory:FS" -> "theory:mobShearWO";
+    "theory:FS" -> "theory:X_i";
+    "theory:FS" -> "theory:FS";
+    "theory:FS" -> "theory:nrmShrForIM";
+    "theory:FS" -> "theory:intsliceFsRC";
+    "theory:nrmShrForIM" -> "instance:assumpINSFL";
+    "theory:nrmShrForIM" -> "instance:assumpES";
+    "theory:nrmShrForIM" -> "instance:assumpSF";
+    "theory:nrmShrForIM" -> "instance:assumpSL";
+    "theory:nrmShrForIM" -> "theory:X_i";
+    "theory:nrmShrForIM" -> "theory:momentEql";
+    "theory:nrmShrForIM" -> "theory:FS";
+    "theory:nrmShrForIM" -> "theory:nrmShrForIM";
+    "theory:nrmShrForIM" -> "theory:nrmShrForNumRC";
+    "theory:nrmShrForIM" -> "theory:nrmShrForDenRC";
+    "theory:nrmShrForIM" -> "theory:intsliceFsRC";
+    "theory:nrmShrForNumRC" -> "dataDefn:H_i";
+    "theory:nrmShrForNumRC" -> "dataDefn:alpha_i";
+    "theory:nrmShrForNumRC" -> "dataDefn:beta_i";
+    "theory:nrmShrForNumRC" -> "dataDefn:b_i";
+    "theory:nrmShrForNumRC" -> "dataDefn:h_i";
+    "theory:nrmShrForNumRC" -> "theory:srfWtrF";
+    "theory:nrmShrForNumRC" -> "theory:nrmShrForIM";
+    "theory:nrmShrForDenRC" -> "dataDefn:b_i";
+    "theory:nrmShrForDenRC" -> "dataDefn:f_i";
+    "theory:nrmShrForDenRC" -> "theory:nrmShrForIM";
+    "theory:intsliceFsRC" -> "instance:assumpES";
+    "theory:intsliceFsRC" -> "dataDefn:Phi";
+    "theory:intsliceFsRC" -> "dataDefn:Psi";
+    "theory:intsliceFsRC" -> "theory:resShearWO";
+    "theory:intsliceFsRC" -> "theory:mobShearWO";
+    "theory:intsliceFsRC" -> "theory:FS";
+    "theory:intsliceFsRC" -> "theory:nrmShrForIM";
+    "theory:intsliceFsRC" -> "theory:intsliceFsRC";
+    "theory:crtSlpIdIM" -> "instance:assumpSSC";
+    "instance:determineCritSlip" -> "theory:FS";
+    "instance:determineCritSlip" -> "theory:nrmShrForIM";
+    "instance:determineCritSlip" -> "theory:intsliceFsRC";
+    "instance:determineCritSlip" -> "theory:crtSlpIdIM";
+    "instance:displayGraph" -> "theory:crtSlpIdIM";
+    "instance:displayFS" -> "theory:FS";
+    "instance:displayFS" -> "theory:nrmShrForIM";
+    "instance:displayFS" -> "theory:intsliceFsRC";
+    "instance:displayNormal" -> "theory:FS";
+    "instance:displayNormal" -> "theory:nrmShrForIM";
+    "instance:displayNormal" -> "theory:intsliceFsRC";
+    "instance:displayShear" -> "theory:FS";
+    "instance:displayShear" -> "theory:nrmShrForIM";
+    "instance:displayShear" -> "theory:intsliceFsRC";
+    "instance:writeToFile" -> "instance:displayInput";
+    "instance:writeToFile" -> "instance:displayGraph";
+    "instance:writeToFile" -> "instance:displayFS";
+    "instance:writeToFile" -> "instance:displayNormal";
+    "instance:writeToFile" -> "instance:displayShear";
+    "instance:LC_inhomogeneous" -> "instance:assumpSLH";
+    "instance:LC_seismic" -> "instance:assumpSF";
+    "instance:LC_external" -> "instance:assumpSL";
+    "instance:UC_normshearlinear" -> "instance:assumpINSFL";
+    "instance:UC_2donly" -> "instance:assumpENSL";
+    "instance:assumpSSC" [shape=box, color=black, style=filled, fillcolor="mistyrose", label="A:assumpSSC"];
+    "instance:assumpFOS" [shape=box, color=black, style=filled, fillcolor="mistyrose", label="A:assumpFOS"];
+    "instance:assumpSLH" [shape=box, color=black, style=filled, fillcolor="mistyrose", label="A:assumpSLH"];
+    "instance:assumpSP" [shape=box, color=black, style=filled, fillcolor="mistyrose", label="A:assumpSP"];
+    "instance:assumpSLI" [shape=box, color=black, style=filled, fillcolor="mistyrose", label="A:assumpSLI"];
+    "instance:assumpINSFL" [shape=box, color=black, style=filled, fillcolor="mistyrose", label="A:assumpINSFL"];
+    "instance:assumpPSC" [shape=box, color=black, style=filled, fillcolor="mistyrose", label="A:assumpPSC"];
+    "instance:assumpENSL" [shape=box, color=black, style=filled, fillcolor="mistyrose", label="A:assumpENSL"];
+    "instance:assumpSBSBISL" [shape=box, color=black, style=filled, fillcolor="mistyrose", label="A:assumpSBSBISL"];
+    "instance:assumpES" [shape=box, color=black, style=filled, fillcolor="mistyrose", label="A:assumpES"];
+    "instance:assumpSF" [shape=box, color=black, style=filled, fillcolor="mistyrose", label="A:assumpSF"];
+    "instance:assumpSL" [shape=box, color=black, style=filled, fillcolor="mistyrose", label="A:assumpSL"];
+    "instance:assumpWIBE" [shape=box, color=black, style=filled, fillcolor="mistyrose", label="A:assumpWIBE"];
+    "instance:assumpWISE" [shape=box, color=black, style=filled, fillcolor="mistyrose", label="A:assumpWISE"];
+    "instance:assumpNESSS" [shape=box, color=black, style=filled, fillcolor="mistyrose", label="A:assumpNESSS"];
+    "instance:assumpHFSM" [shape=box, color=black, style=filled, fillcolor="mistyrose", label="A:assumpHFSM"];
+    subgraph "A" {
+        rank="same";
+        "instance:assumpSSC" "instance:assumpFOS" "instance:assumpSLH" "instance:assumpSP" "instance:assumpSLI" "instance:assumpINSFL" "instance:assumpPSC" "instance:assumpENSL" "instance:assumpSBSBISL" "instance:assumpES" "instance:assumpSF" "instance:assumpSL" "instance:assumpWIBE" "instance:assumpWISE" "instance:assumpNESSS" "instance:assumpHFSM";
+    }
+    "dataDefn:H_i" [shape=box, color=black, style=filled, fillcolor="paleturquoise1", label="DD:intersliceWtrF"];
+    "dataDefn:alpha_i" [shape=box, color=black, style=filled, fillcolor="paleturquoise1", label="DD:angleA"];
+    "dataDefn:beta_i" [shape=box, color=black, style=filled, fillcolor="paleturquoise1", label="DD:angleB"];
+    "dataDefn:b_i" [shape=box, color=black, style=filled, fillcolor="paleturquoise1", label="DD:lengthB"];
+    "dataDefn:l_b,i" [shape=box, color=black, style=filled, fillcolor="paleturquoise1", label="DD:lengthLb"];
+    "dataDefn:l_s,i" [shape=box, color=black, style=filled, fillcolor="paleturquoise1", label="DD:lengthLs"];
+    "dataDefn:h_i" [shape=box, color=black, style=filled, fillcolor="paleturquoise1", label="DD:slcHeight"];
+    "dataDefn:sigma" [shape=box, color=black, style=filled, fillcolor="paleturquoise1", label="DD:normStress"];
+    "dataDefn:tau" [shape=box, color=black, style=filled, fillcolor="paleturquoise1", label="DD:tangStress"];
+    "dataDefn:torque" [shape=box, color=black, style=filled, fillcolor="paleturquoise1", label="DD:torque"];
+    "dataDefn:f_i" [shape=box, color=black, style=filled, fillcolor="paleturquoise1", label="DD:ratioVariation"];
+    "dataDefn:Phi" [shape=box, color=black, style=filled, fillcolor="paleturquoise1", label="DD:convertFunc1"];
+    "dataDefn:Psi" [shape=box, color=black, style=filled, fillcolor="paleturquoise1", label="DD:convertFunc2"];
+    "dataDefn:F_x^G" [shape=box, color=black, style=filled, fillcolor="paleturquoise1", label="DD:nrmForceSumDD"];
+    "dataDefn:F_x^H" [shape=box, color=black, style=filled, fillcolor="paleturquoise1", label="DD:watForceSumDD"];
+    "dataDefn:h^R" [shape=box, color=black, style=filled, fillcolor="paleturquoise1", label="DD:sliceHghtRightDD"];
+    "dataDefn:h^L" [shape=box, color=black, style=filled, fillcolor="paleturquoise1", label="DD:sliceHghtLeftDD"];
+    subgraph "DD" {
+        rank="same";
+        "dataDefn:H_i" "dataDefn:alpha_i" "dataDefn:beta_i" "dataDefn:b_i" "dataDefn:l_b,i" "dataDefn:l_s,i" "dataDefn:h_i" "dataDefn:sigma" "dataDefn:tau" "dataDefn:torque" "dataDefn:f_i" "dataDefn:Phi" "dataDefn:Psi" "dataDefn:F_x^G" "dataDefn:F_x^H" "dataDefn:h^R" "dataDefn:h^L";
+    }
+    "theory:factOfSafetyTM" [shape=box, color=black, style=filled, fillcolor="pink", label="TM:factOfSafety"];
+    "theory:equilibriumCS" [shape=box, color=black, style=filled, fillcolor="pink", label="TM:equilibrium"];
+    "theory:mcShrSrgth" [shape=box, color=black, style=filled, fillcolor="pink", label="TM:mcShrStrgth"];
+    "theory:effectiveStressTM" [shape=box, color=black, style=filled, fillcolor="pink", label="TM:effStress"];
+    "theory:newtonSL" [shape=box, color=black, style=filled, fillcolor="pink", label="TM:NewtonSecLawMot"];
+    subgraph "TM" {
+        rank="same";
+        "theory:factOfSafetyTM" "theory:equilibriumCS" "theory:mcShrSrgth" "theory:effectiveStressTM" "theory:newtonSL";
+    }
+    "theory:normForcEq" [shape=box, color=black, style=filled, fillcolor="palegreen", label="GD:normForcEq"];
+    "theory:bsShrFEq" [shape=box, color=black, style=filled, fillcolor="palegreen", label="GD:bsShrFEq"];
+    "theory:resShr" [shape=box, color=black, style=filled, fillcolor="palegreen", label="GD:resShr"];
+    "theory:mobShr" [shape=box, color=black, style=filled, fillcolor="palegreen", label="GD:mobShr"];
+    "theory:effNormF" [shape=box, color=black, style=filled, fillcolor="palegreen", label="GD:effNormF"];
+    "theory:resShearWO" [shape=box, color=black, style=filled, fillcolor="palegreen", label="GD:resShearWO"];
+    "theory:mobShearWO" [shape=box, color=black, style=filled, fillcolor="palegreen", label="GD:mobShearWO"];
+    "theory:X_i" [shape=box, color=black, style=filled, fillcolor="palegreen", label="GD:normShrR"];
+    "theory:momentEql" [shape=box, color=black, style=filled, fillcolor="palegreen", label="GD:momentEql"];
+    "theory:weight" [shape=box, color=black, style=filled, fillcolor="palegreen", label="GD:weight"];
+    "theory:sliceWght" [shape=box, color=black, style=filled, fillcolor="palegreen", label="GD:sliceWght"];
+    "theory:pressure" [shape=box, color=black, style=filled, fillcolor="palegreen", label="GD:hsPressure"];
+    "theory:baseWtrF" [shape=box, color=black, style=filled, fillcolor="palegreen", label="GD:baseWtrF"];
+    "theory:srfWtrF" [shape=box, color=black, style=filled, fillcolor="palegreen", label="GD:srfWtrF"];
+    subgraph "GD" {
+        rank="same";
+        "theory:normForcEq" "theory:bsShrFEq" "theory:resShr" "theory:mobShr" "theory:effNormF" "theory:resShearWO" "theory:mobShearWO" "theory:X_i" "theory:momentEql" "theory:weight" "theory:sliceWght" "theory:pressure" "theory:baseWtrF" "theory:srfWtrF";
+    }
+    "theory:FS" [shape=box, color=black, style=filled, fillcolor="khaki1", label="IM:fctSfty"];
+    "theory:nrmShrForIM" [shape=box, color=black, style=filled, fillcolor="khaki1", label="IM:nrmShrFor"];
+    "theory:nrmShrForNumRC" [shape=box, color=black, style=filled, fillcolor="khaki1", label="IM:nrmShrForNum"];
+    "theory:nrmShrForDenRC" [shape=box, color=black, style=filled, fillcolor="khaki1", label="IM:nrmShrForDen"];
+    "theory:intsliceFsRC" [shape=box, color=black, style=filled, fillcolor="khaki1", label="IM:intsliceFs"];
+    "theory:crtSlpIdIM" [shape=box, color=black, style=filled, fillcolor="khaki1", label="IM:crtSlpId"];
+    subgraph "IM" {
+        rank="same";
+        "theory:FS" "theory:nrmShrForIM" "theory:nrmShrForNumRC" "theory:nrmShrForDenRC" "theory:intsliceFsRC" "theory:crtSlpIdIM";
+    }
+    "instance:readAndStore" [shape=box, color=black, style=filled, fillcolor="ivory", label="FR:readAndStore"];
+    "instance:verifyInput" [shape=box, color=black, style=filled, fillcolor="ivory", label="FR:verifyInput"];
+    "instance:determineCritSlip" [shape=box, color=black, style=filled, fillcolor="ivory", label="FR:determineCritSlip"];
+    "instance:verifyOutput" [shape=box, color=black, style=filled, fillcolor="ivory", label="FR:verifyOutput"];
+    "instance:displayInput" [shape=box, color=black, style=filled, fillcolor="ivory", label="FR:displayInput"];
+    "instance:displayGraph" [shape=box, color=black, style=filled, fillcolor="ivory", label="FR:displayGraph"];
+    "instance:displayFS" [shape=box, color=black, style=filled, fillcolor="ivory", label="FR:displayFS"];
+    "instance:displayNormal" [shape=box, color=black, style=filled, fillcolor="ivory", label="FR:displayNormal"];
+    "instance:displayShear" [shape=box, color=black, style=filled, fillcolor="ivory", label="FR:displayShear"];
+    "instance:writeToFile" [shape=box, color=black, style=filled, fillcolor="ivory", label="FR:writeToFile"];
+    "instance:correct" [shape=box, color=black, style=filled, fillcolor="ivory", label="NFR:correct"];
+    "instance:understandable" [shape=box, color=black, style=filled, fillcolor="ivory", label="NFR:understandable"];
+    "instance:reusable" [shape=box, color=black, style=filled, fillcolor="ivory", label="NFR:reusable"];
+    "instance:maintainable" [shape=box, color=black, style=filled, fillcolor="ivory", label="NFR:maintainable"];
+    subgraph "FR" {
+        rank="same";
+        "instance:readAndStore" "instance:verifyInput" "instance:determineCritSlip" "instance:verifyOutput" "instance:displayInput" "instance:displayGraph" "instance:displayFS" "instance:displayNormal" "instance:displayShear" "instance:writeToFile" "instance:correct" "instance:understandable" "instance:reusable" "instance:maintainable";
+    }
+    "instance:identifyCritAndFS" [shape=box, color=black, style=filled, fillcolor="darkgoldenrod1", label="GS:identifyCritAndFS"];
+    "instance:determineNormalF" [shape=box, color=black, style=filled, fillcolor="darkgoldenrod1", label="GS:determineNormalF"];
+    "instance:determineShearF" [shape=box, color=black, style=filled, fillcolor="darkgoldenrod1", label="GS:determineShearF"];
+    subgraph "GS" {
+        rank="same";
+        "instance:identifyCritAndFS" "instance:determineNormalF" "instance:determineShearF";
+    }
+    "instance:LC_inhomogeneous" [shape=box, color=black, style=filled, fillcolor="lavender", label="LC:LC_inhomogeneous"];
+    "instance:LC_seismic" [shape=box, color=black, style=filled, fillcolor="lavender", label="LC:LC_seismic"];
+    "instance:LC_external" [shape=box, color=black, style=filled, fillcolor="lavender", label="LC:LC_external"];
+    "instance:UC_normshearlinear" [shape=box, color=black, style=filled, fillcolor="lavender", label="UC:UC_normshearlinear"];
+    "instance:UC_2donly" [shape=box, color=black, style=filled, fillcolor="lavender", label="UC:UC_2donly"];
+    subgraph "LC" {
+        rank="same";
+        "instance:LC_inhomogeneous" "instance:LC_seismic" "instance:LC_external" "instance:UC_normshearlinear" "instance:UC_2donly";
+    }
 }

--- a/code/stable/ssp/TraceyGraph/allvsr.dot
+++ b/code/stable/ssp/TraceyGraph/allvsr.dot
@@ -1,140 +1,124 @@
-digraph allvsr {
-	instance:determineCritSlip -> theory:FS;
-	instance:determineCritSlip -> theory:nrmShrForIM;
-	instance:determineCritSlip -> theory:intsliceFsRC;
-	instance:determineCritSlip -> theory:crtSlpIdIM;
-	instance:displayGraph -> theory:crtSlpIdIM;
-	instance:displayFS -> theory:FS;
-	instance:displayFS -> theory:nrmShrForIM;
-	instance:displayFS -> theory:intsliceFsRC;
-	instance:displayNormal -> theory:FS;
-	instance:displayNormal -> theory:nrmShrForIM;
-	instance:displayNormal -> theory:intsliceFsRC;
-	instance:displayShear -> theory:FS;
-	instance:displayShear -> theory:nrmShrForIM;
-	instance:displayShear -> theory:intsliceFsRC;
-	instance:writeToFile -> instance:displayInput;
-	instance:writeToFile -> instance:displayGraph;
-	instance:writeToFile -> instance:displayFS;
-	instance:writeToFile -> instance:displayNormal;
-	instance:writeToFile -> instance:displayShear;
-
-
-	instance:assumpSSC	[shape=box, color=black, style=filled, fillcolor=mistyrose, label="A:assumpSSC"];
-	instance:assumpFOS	[shape=box, color=black, style=filled, fillcolor=mistyrose, label="A:assumpFOS"];
-	instance:assumpSLH	[shape=box, color=black, style=filled, fillcolor=mistyrose, label="A:assumpSLH"];
-	instance:assumpSP	[shape=box, color=black, style=filled, fillcolor=mistyrose, label="A:assumpSP"];
-	instance:assumpSLI	[shape=box, color=black, style=filled, fillcolor=mistyrose, label="A:assumpSLI"];
-	instance:assumpINSFL	[shape=box, color=black, style=filled, fillcolor=mistyrose, label="A:assumpINSFL"];
-	instance:assumpPSC	[shape=box, color=black, style=filled, fillcolor=mistyrose, label="A:assumpPSC"];
-	instance:assumpENSL	[shape=box, color=black, style=filled, fillcolor=mistyrose, label="A:assumpENSL"];
-	instance:assumpSBSBISL	[shape=box, color=black, style=filled, fillcolor=mistyrose, label="A:assumpSBSBISL"];
-	instance:assumpES	[shape=box, color=black, style=filled, fillcolor=mistyrose, label="A:assumpES"];
-	instance:assumpSF	[shape=box, color=black, style=filled, fillcolor=mistyrose, label="A:assumpSF"];
-	instance:assumpSL	[shape=box, color=black, style=filled, fillcolor=mistyrose, label="A:assumpSL"];
-	instance:assumpWIBE	[shape=box, color=black, style=filled, fillcolor=mistyrose, label="A:assumpWIBE"];
-	instance:assumpWISE	[shape=box, color=black, style=filled, fillcolor=mistyrose, label="A:assumpWISE"];
-	instance:assumpNESSS	[shape=box, color=black, style=filled, fillcolor=mistyrose, label="A:assumpNESSS"];
-	instance:assumpHFSM	[shape=box, color=black, style=filled, fillcolor=mistyrose, label="A:assumpHFSM"];
-
-	subgraph A {
-	rank="same"
-	{instance:assumpSSC, instance:assumpFOS, instance:assumpSLH, instance:assumpSP, instance:assumpSLI, instance:assumpINSFL, instance:assumpPSC, instance:assumpENSL, instance:assumpSBSBISL, instance:assumpES, instance:assumpSF, instance:assumpSL, instance:assumpWIBE, instance:assumpWISE, instance:assumpNESSS, instance:assumpHFSM}
-	}
-
-	dataDefn:H_i	[shape=box, color=black, style=filled, fillcolor=paleturquoise1, label="DD:intersliceWtrF"];
-	dataDefn:alpha_i	[shape=box, color=black, style=filled, fillcolor=paleturquoise1, label="DD:angleA"];
-	dataDefn:beta_i	[shape=box, color=black, style=filled, fillcolor=paleturquoise1, label="DD:angleB"];
-	dataDefn:b_i	[shape=box, color=black, style=filled, fillcolor=paleturquoise1, label="DD:lengthB"];
-	dataDefn:l_bi	[shape=box, color=black, style=filled, fillcolor=paleturquoise1, label="DD:lengthLb"];
-	dataDefn:l_si	[shape=box, color=black, style=filled, fillcolor=paleturquoise1, label="DD:lengthLs"];
-	dataDefn:h_i	[shape=box, color=black, style=filled, fillcolor=paleturquoise1, label="DD:slcHeight"];
-	dataDefn:sigma	[shape=box, color=black, style=filled, fillcolor=paleturquoise1, label="DD:normStress"];
-	dataDefn:tau	[shape=box, color=black, style=filled, fillcolor=paleturquoise1, label="DD:tangStress"];
-	dataDefn:torque	[shape=box, color=black, style=filled, fillcolor=paleturquoise1, label="DD:torque"];
-	dataDefn:f_i	[shape=box, color=black, style=filled, fillcolor=paleturquoise1, label="DD:ratioVariation"];
-	dataDefn:Phi	[shape=box, color=black, style=filled, fillcolor=paleturquoise1, label="DD:convertFunc1"];
-	dataDefn:Psi	[shape=box, color=black, style=filled, fillcolor=paleturquoise1, label="DD:convertFunc2"];
-	dataDefn:F_xG	[shape=box, color=black, style=filled, fillcolor=paleturquoise1, label="DD:nrmForceSumDD"];
-	dataDefn:F_xH	[shape=box, color=black, style=filled, fillcolor=paleturquoise1, label="DD:watForceSumDD"];
-	dataDefn:hR	[shape=box, color=black, style=filled, fillcolor=paleturquoise1, label="DD:sliceHghtRightDD"];
-	dataDefn:hL	[shape=box, color=black, style=filled, fillcolor=paleturquoise1, label="DD:sliceHghtLeftDD"];
-
-	subgraph DD {
-	rank="same"
-	{dataDefn:H_i, dataDefn:alpha_i, dataDefn:beta_i, dataDefn:b_i, dataDefn:l_bi, dataDefn:l_si, dataDefn:h_i, dataDefn:sigma, dataDefn:tau, dataDefn:torque, dataDefn:f_i, dataDefn:Phi, dataDefn:Psi, dataDefn:F_xG, dataDefn:F_xH, dataDefn:hR, dataDefn:hL}
-	}
-
-	theory:factOfSafetyTM	[shape=box, color=black, style=filled, fillcolor=pink, label="TM:factOfSafety"];
-	theory:equilibriumCS	[shape=box, color=black, style=filled, fillcolor=pink, label="TM:equilibrium"];
-	theory:mcShrSrgth	[shape=box, color=black, style=filled, fillcolor=pink, label="TM:mcShrStrgth"];
-	theory:effectiveStressTM	[shape=box, color=black, style=filled, fillcolor=pink, label="TM:effStress"];
-	theory:newtonSL	[shape=box, color=black, style=filled, fillcolor=pink, label="TM:NewtonSecLawMot"];
-
-	subgraph TM {
-	rank="same"
-	{theory:factOfSafetyTM, theory:equilibriumCS, theory:mcShrSrgth, theory:effectiveStressTM, theory:newtonSL}
-	}
-
-	theory:normForcEq	[shape=box, color=black, style=filled, fillcolor=palegreen, label="GD:normForcEq"];
-	theory:bsShrFEq	[shape=box, color=black, style=filled, fillcolor=palegreen, label="GD:bsShrFEq"];
-	theory:resShr	[shape=box, color=black, style=filled, fillcolor=palegreen, label="GD:resShr"];
-	theory:mobShr	[shape=box, color=black, style=filled, fillcolor=palegreen, label="GD:mobShr"];
-	theory:effNormF	[shape=box, color=black, style=filled, fillcolor=palegreen, label="GD:effNormF"];
-	theory:resShearWO	[shape=box, color=black, style=filled, fillcolor=palegreen, label="GD:resShearWO"];
-	theory:mobShearWO	[shape=box, color=black, style=filled, fillcolor=palegreen, label="GD:mobShearWO"];
-	theory:X_i	[shape=box, color=black, style=filled, fillcolor=palegreen, label="GD:normShrR"];
-	theory:momentEql	[shape=box, color=black, style=filled, fillcolor=palegreen, label="GD:momentEql"];
-	theory:weight	[shape=box, color=black, style=filled, fillcolor=palegreen, label="GD:weight"];
-	theory:sliceWght	[shape=box, color=black, style=filled, fillcolor=palegreen, label="GD:sliceWght"];
-	theory:pressure	[shape=box, color=black, style=filled, fillcolor=palegreen, label="GD:hsPressure"];
-	theory:baseWtrF	[shape=box, color=black, style=filled, fillcolor=palegreen, label="GD:baseWtrF"];
-	theory:srfWtrF	[shape=box, color=black, style=filled, fillcolor=palegreen, label="GD:srfWtrF"];
-
-	subgraph GD {
-	rank="same"
-	{theory:normForcEq, theory:bsShrFEq, theory:resShr, theory:mobShr, theory:effNormF, theory:resShearWO, theory:mobShearWO, theory:X_i, theory:momentEql, theory:weight, theory:sliceWght, theory:pressure, theory:baseWtrF, theory:srfWtrF}
-	}
-
-	theory:FS	[shape=box, color=black, style=filled, fillcolor=khaki1, label="IM:fctSfty"];
-	theory:nrmShrForIM	[shape=box, color=black, style=filled, fillcolor=khaki1, label="IM:nrmShrFor"];
-	theory:nrmShrForNumRC	[shape=box, color=black, style=filled, fillcolor=khaki1, label="IM:nrmShrForNum"];
-	theory:nrmShrForDenRC	[shape=box, color=black, style=filled, fillcolor=khaki1, label="IM:nrmShrForDen"];
-	theory:intsliceFsRC	[shape=box, color=black, style=filled, fillcolor=khaki1, label="IM:intsliceFs"];
-	theory:crtSlpIdIM	[shape=box, color=black, style=filled, fillcolor=khaki1, label="IM:crtSlpId"];
-
-	subgraph IM {
-	rank="same"
-	{theory:FS, theory:nrmShrForIM, theory:nrmShrForNumRC, theory:nrmShrForDenRC, theory:intsliceFsRC, theory:crtSlpIdIM}
-	}
-
-	instance:readAndStore	[shape=box, color=black, style=filled, fillcolor=ivory, label="FR:readAndStore"];
-	instance:verifyInput	[shape=box, color=black, style=filled, fillcolor=ivory, label="FR:verifyInput"];
-	instance:determineCritSlip	[shape=box, color=black, style=filled, fillcolor=ivory, label="FR:determineCritSlip"];
-	instance:verifyOutput	[shape=box, color=black, style=filled, fillcolor=ivory, label="FR:verifyOutput"];
-	instance:displayInput	[shape=box, color=black, style=filled, fillcolor=ivory, label="FR:displayInput"];
-	instance:displayGraph	[shape=box, color=black, style=filled, fillcolor=ivory, label="FR:displayGraph"];
-	instance:displayFS	[shape=box, color=black, style=filled, fillcolor=ivory, label="FR:displayFS"];
-	instance:displayNormal	[shape=box, color=black, style=filled, fillcolor=ivory, label="FR:displayNormal"];
-	instance:displayShear	[shape=box, color=black, style=filled, fillcolor=ivory, label="FR:displayShear"];
-	instance:writeToFile	[shape=box, color=black, style=filled, fillcolor=ivory, label="FR:writeToFile"];
-	instance:correct	[shape=box, color=black, style=filled, fillcolor=ivory, label="NFR:correct"];
-	instance:understandable	[shape=box, color=black, style=filled, fillcolor=ivory, label="NFR:understandable"];
-	instance:reusable	[shape=box, color=black, style=filled, fillcolor=ivory, label="NFR:reusable"];
-	instance:maintainable	[shape=box, color=black, style=filled, fillcolor=ivory, label="NFR:maintainable"];
-
-	subgraph FR {
-	rank="same"
-	{instance:readAndStore, instance:verifyInput, instance:determineCritSlip, instance:verifyOutput, instance:displayInput, instance:displayGraph, instance:displayFS, instance:displayNormal, instance:displayShear, instance:writeToFile, instance:correct, instance:understandable, instance:reusable, instance:maintainable}
-	}
-
-	instance:identifyCritAndFS	[shape=box, color=black, style=filled, fillcolor=darkgoldenrod1, label="GS:identifyCritAndFS"];
-	instance:determineNormalF	[shape=box, color=black, style=filled, fillcolor=darkgoldenrod1, label="GS:determineNormalF"];
-	instance:determineShearF	[shape=box, color=black, style=filled, fillcolor=darkgoldenrod1, label="GS:determineShearF"];
-
-	subgraph GS {
-	rank="same"
-	{instance:identifyCritAndFS, instance:determineNormalF, instance:determineShearF}
-	}
-
+digraph "allvsr" {
+    "instance:determineCritSlip" -> "theory:FS";
+    "instance:determineCritSlip" -> "theory:nrmShrForIM";
+    "instance:determineCritSlip" -> "theory:intsliceFsRC";
+    "instance:determineCritSlip" -> "theory:crtSlpIdIM";
+    "instance:displayGraph" -> "theory:crtSlpIdIM";
+    "instance:displayFS" -> "theory:FS";
+    "instance:displayFS" -> "theory:nrmShrForIM";
+    "instance:displayFS" -> "theory:intsliceFsRC";
+    "instance:displayNormal" -> "theory:FS";
+    "instance:displayNormal" -> "theory:nrmShrForIM";
+    "instance:displayNormal" -> "theory:intsliceFsRC";
+    "instance:displayShear" -> "theory:FS";
+    "instance:displayShear" -> "theory:nrmShrForIM";
+    "instance:displayShear" -> "theory:intsliceFsRC";
+    "instance:writeToFile" -> "instance:displayInput";
+    "instance:writeToFile" -> "instance:displayGraph";
+    "instance:writeToFile" -> "instance:displayFS";
+    "instance:writeToFile" -> "instance:displayNormal";
+    "instance:writeToFile" -> "instance:displayShear";
+    "instance:assumpSSC" [shape=box, color=black, style=filled, fillcolor="mistyrose", label="A:assumpSSC"];
+    "instance:assumpFOS" [shape=box, color=black, style=filled, fillcolor="mistyrose", label="A:assumpFOS"];
+    "instance:assumpSLH" [shape=box, color=black, style=filled, fillcolor="mistyrose", label="A:assumpSLH"];
+    "instance:assumpSP" [shape=box, color=black, style=filled, fillcolor="mistyrose", label="A:assumpSP"];
+    "instance:assumpSLI" [shape=box, color=black, style=filled, fillcolor="mistyrose", label="A:assumpSLI"];
+    "instance:assumpINSFL" [shape=box, color=black, style=filled, fillcolor="mistyrose", label="A:assumpINSFL"];
+    "instance:assumpPSC" [shape=box, color=black, style=filled, fillcolor="mistyrose", label="A:assumpPSC"];
+    "instance:assumpENSL" [shape=box, color=black, style=filled, fillcolor="mistyrose", label="A:assumpENSL"];
+    "instance:assumpSBSBISL" [shape=box, color=black, style=filled, fillcolor="mistyrose", label="A:assumpSBSBISL"];
+    "instance:assumpES" [shape=box, color=black, style=filled, fillcolor="mistyrose", label="A:assumpES"];
+    "instance:assumpSF" [shape=box, color=black, style=filled, fillcolor="mistyrose", label="A:assumpSF"];
+    "instance:assumpSL" [shape=box, color=black, style=filled, fillcolor="mistyrose", label="A:assumpSL"];
+    "instance:assumpWIBE" [shape=box, color=black, style=filled, fillcolor="mistyrose", label="A:assumpWIBE"];
+    "instance:assumpWISE" [shape=box, color=black, style=filled, fillcolor="mistyrose", label="A:assumpWISE"];
+    "instance:assumpNESSS" [shape=box, color=black, style=filled, fillcolor="mistyrose", label="A:assumpNESSS"];
+    "instance:assumpHFSM" [shape=box, color=black, style=filled, fillcolor="mistyrose", label="A:assumpHFSM"];
+    subgraph "A" {
+        rank="same";
+        "instance:assumpSSC" "instance:assumpFOS" "instance:assumpSLH" "instance:assumpSP" "instance:assumpSLI" "instance:assumpINSFL" "instance:assumpPSC" "instance:assumpENSL" "instance:assumpSBSBISL" "instance:assumpES" "instance:assumpSF" "instance:assumpSL" "instance:assumpWIBE" "instance:assumpWISE" "instance:assumpNESSS" "instance:assumpHFSM";
+    }
+    "dataDefn:H_i" [shape=box, color=black, style=filled, fillcolor="paleturquoise1", label="DD:intersliceWtrF"];
+    "dataDefn:alpha_i" [shape=box, color=black, style=filled, fillcolor="paleturquoise1", label="DD:angleA"];
+    "dataDefn:beta_i" [shape=box, color=black, style=filled, fillcolor="paleturquoise1", label="DD:angleB"];
+    "dataDefn:b_i" [shape=box, color=black, style=filled, fillcolor="paleturquoise1", label="DD:lengthB"];
+    "dataDefn:l_b,i" [shape=box, color=black, style=filled, fillcolor="paleturquoise1", label="DD:lengthLb"];
+    "dataDefn:l_s,i" [shape=box, color=black, style=filled, fillcolor="paleturquoise1", label="DD:lengthLs"];
+    "dataDefn:h_i" [shape=box, color=black, style=filled, fillcolor="paleturquoise1", label="DD:slcHeight"];
+    "dataDefn:sigma" [shape=box, color=black, style=filled, fillcolor="paleturquoise1", label="DD:normStress"];
+    "dataDefn:tau" [shape=box, color=black, style=filled, fillcolor="paleturquoise1", label="DD:tangStress"];
+    "dataDefn:torque" [shape=box, color=black, style=filled, fillcolor="paleturquoise1", label="DD:torque"];
+    "dataDefn:f_i" [shape=box, color=black, style=filled, fillcolor="paleturquoise1", label="DD:ratioVariation"];
+    "dataDefn:Phi" [shape=box, color=black, style=filled, fillcolor="paleturquoise1", label="DD:convertFunc1"];
+    "dataDefn:Psi" [shape=box, color=black, style=filled, fillcolor="paleturquoise1", label="DD:convertFunc2"];
+    "dataDefn:F_x^G" [shape=box, color=black, style=filled, fillcolor="paleturquoise1", label="DD:nrmForceSumDD"];
+    "dataDefn:F_x^H" [shape=box, color=black, style=filled, fillcolor="paleturquoise1", label="DD:watForceSumDD"];
+    "dataDefn:h^R" [shape=box, color=black, style=filled, fillcolor="paleturquoise1", label="DD:sliceHghtRightDD"];
+    "dataDefn:h^L" [shape=box, color=black, style=filled, fillcolor="paleturquoise1", label="DD:sliceHghtLeftDD"];
+    subgraph "DD" {
+        rank="same";
+        "dataDefn:H_i" "dataDefn:alpha_i" "dataDefn:beta_i" "dataDefn:b_i" "dataDefn:l_b,i" "dataDefn:l_s,i" "dataDefn:h_i" "dataDefn:sigma" "dataDefn:tau" "dataDefn:torque" "dataDefn:f_i" "dataDefn:Phi" "dataDefn:Psi" "dataDefn:F_x^G" "dataDefn:F_x^H" "dataDefn:h^R" "dataDefn:h^L";
+    }
+    "theory:factOfSafetyTM" [shape=box, color=black, style=filled, fillcolor="pink", label="TM:factOfSafety"];
+    "theory:equilibriumCS" [shape=box, color=black, style=filled, fillcolor="pink", label="TM:equilibrium"];
+    "theory:mcShrSrgth" [shape=box, color=black, style=filled, fillcolor="pink", label="TM:mcShrStrgth"];
+    "theory:effectiveStressTM" [shape=box, color=black, style=filled, fillcolor="pink", label="TM:effStress"];
+    "theory:newtonSL" [shape=box, color=black, style=filled, fillcolor="pink", label="TM:NewtonSecLawMot"];
+    subgraph "TM" {
+        rank="same";
+        "theory:factOfSafetyTM" "theory:equilibriumCS" "theory:mcShrSrgth" "theory:effectiveStressTM" "theory:newtonSL";
+    }
+    "theory:normForcEq" [shape=box, color=black, style=filled, fillcolor="palegreen", label="GD:normForcEq"];
+    "theory:bsShrFEq" [shape=box, color=black, style=filled, fillcolor="palegreen", label="GD:bsShrFEq"];
+    "theory:resShr" [shape=box, color=black, style=filled, fillcolor="palegreen", label="GD:resShr"];
+    "theory:mobShr" [shape=box, color=black, style=filled, fillcolor="palegreen", label="GD:mobShr"];
+    "theory:effNormF" [shape=box, color=black, style=filled, fillcolor="palegreen", label="GD:effNormF"];
+    "theory:resShearWO" [shape=box, color=black, style=filled, fillcolor="palegreen", label="GD:resShearWO"];
+    "theory:mobShearWO" [shape=box, color=black, style=filled, fillcolor="palegreen", label="GD:mobShearWO"];
+    "theory:X_i" [shape=box, color=black, style=filled, fillcolor="palegreen", label="GD:normShrR"];
+    "theory:momentEql" [shape=box, color=black, style=filled, fillcolor="palegreen", label="GD:momentEql"];
+    "theory:weight" [shape=box, color=black, style=filled, fillcolor="palegreen", label="GD:weight"];
+    "theory:sliceWght" [shape=box, color=black, style=filled, fillcolor="palegreen", label="GD:sliceWght"];
+    "theory:pressure" [shape=box, color=black, style=filled, fillcolor="palegreen", label="GD:hsPressure"];
+    "theory:baseWtrF" [shape=box, color=black, style=filled, fillcolor="palegreen", label="GD:baseWtrF"];
+    "theory:srfWtrF" [shape=box, color=black, style=filled, fillcolor="palegreen", label="GD:srfWtrF"];
+    subgraph "GD" {
+        rank="same";
+        "theory:normForcEq" "theory:bsShrFEq" "theory:resShr" "theory:mobShr" "theory:effNormF" "theory:resShearWO" "theory:mobShearWO" "theory:X_i" "theory:momentEql" "theory:weight" "theory:sliceWght" "theory:pressure" "theory:baseWtrF" "theory:srfWtrF";
+    }
+    "theory:FS" [shape=box, color=black, style=filled, fillcolor="khaki1", label="IM:fctSfty"];
+    "theory:nrmShrForIM" [shape=box, color=black, style=filled, fillcolor="khaki1", label="IM:nrmShrFor"];
+    "theory:nrmShrForNumRC" [shape=box, color=black, style=filled, fillcolor="khaki1", label="IM:nrmShrForNum"];
+    "theory:nrmShrForDenRC" [shape=box, color=black, style=filled, fillcolor="khaki1", label="IM:nrmShrForDen"];
+    "theory:intsliceFsRC" [shape=box, color=black, style=filled, fillcolor="khaki1", label="IM:intsliceFs"];
+    "theory:crtSlpIdIM" [shape=box, color=black, style=filled, fillcolor="khaki1", label="IM:crtSlpId"];
+    subgraph "IM" {
+        rank="same";
+        "theory:FS" "theory:nrmShrForIM" "theory:nrmShrForNumRC" "theory:nrmShrForDenRC" "theory:intsliceFsRC" "theory:crtSlpIdIM";
+    }
+    "instance:readAndStore" [shape=box, color=black, style=filled, fillcolor="ivory", label="FR:readAndStore"];
+    "instance:verifyInput" [shape=box, color=black, style=filled, fillcolor="ivory", label="FR:verifyInput"];
+    "instance:determineCritSlip" [shape=box, color=black, style=filled, fillcolor="ivory", label="FR:determineCritSlip"];
+    "instance:verifyOutput" [shape=box, color=black, style=filled, fillcolor="ivory", label="FR:verifyOutput"];
+    "instance:displayInput" [shape=box, color=black, style=filled, fillcolor="ivory", label="FR:displayInput"];
+    "instance:displayGraph" [shape=box, color=black, style=filled, fillcolor="ivory", label="FR:displayGraph"];
+    "instance:displayFS" [shape=box, color=black, style=filled, fillcolor="ivory", label="FR:displayFS"];
+    "instance:displayNormal" [shape=box, color=black, style=filled, fillcolor="ivory", label="FR:displayNormal"];
+    "instance:displayShear" [shape=box, color=black, style=filled, fillcolor="ivory", label="FR:displayShear"];
+    "instance:writeToFile" [shape=box, color=black, style=filled, fillcolor="ivory", label="FR:writeToFile"];
+    "instance:correct" [shape=box, color=black, style=filled, fillcolor="ivory", label="NFR:correct"];
+    "instance:understandable" [shape=box, color=black, style=filled, fillcolor="ivory", label="NFR:understandable"];
+    "instance:reusable" [shape=box, color=black, style=filled, fillcolor="ivory", label="NFR:reusable"];
+    "instance:maintainable" [shape=box, color=black, style=filled, fillcolor="ivory", label="NFR:maintainable"];
+    subgraph "FR" {
+        rank="same";
+        "instance:readAndStore" "instance:verifyInput" "instance:determineCritSlip" "instance:verifyOutput" "instance:displayInput" "instance:displayGraph" "instance:displayFS" "instance:displayNormal" "instance:displayShear" "instance:writeToFile" "instance:correct" "instance:understandable" "instance:reusable" "instance:maintainable";
+    }
+    "instance:identifyCritAndFS" [shape=box, color=black, style=filled, fillcolor="darkgoldenrod1", label="GS:identifyCritAndFS"];
+    "instance:determineNormalF" [shape=box, color=black, style=filled, fillcolor="darkgoldenrod1", label="GS:determineNormalF"];
+    "instance:determineShearF" [shape=box, color=black, style=filled, fillcolor="darkgoldenrod1", label="GS:determineShearF"];
+    subgraph "GS" {
+        rank="same";
+        "instance:identifyCritAndFS" "instance:determineNormalF" "instance:determineShearF";
+    }
 }

--- a/code/stable/ssp/TraceyGraph/avsa.dot
+++ b/code/stable/ssp/TraceyGraph/avsa.dot
@@ -1,26 +1,22 @@
-digraph avsa {
-
-
-	instance:assumpSSC	[shape=box, color=black, style=filled, fillcolor=mistyrose, label="A:assumpSSC"];
-	instance:assumpFOS	[shape=box, color=black, style=filled, fillcolor=mistyrose, label="A:assumpFOS"];
-	instance:assumpSLH	[shape=box, color=black, style=filled, fillcolor=mistyrose, label="A:assumpSLH"];
-	instance:assumpSP	[shape=box, color=black, style=filled, fillcolor=mistyrose, label="A:assumpSP"];
-	instance:assumpSLI	[shape=box, color=black, style=filled, fillcolor=mistyrose, label="A:assumpSLI"];
-	instance:assumpINSFL	[shape=box, color=black, style=filled, fillcolor=mistyrose, label="A:assumpINSFL"];
-	instance:assumpPSC	[shape=box, color=black, style=filled, fillcolor=mistyrose, label="A:assumpPSC"];
-	instance:assumpENSL	[shape=box, color=black, style=filled, fillcolor=mistyrose, label="A:assumpENSL"];
-	instance:assumpSBSBISL	[shape=box, color=black, style=filled, fillcolor=mistyrose, label="A:assumpSBSBISL"];
-	instance:assumpES	[shape=box, color=black, style=filled, fillcolor=mistyrose, label="A:assumpES"];
-	instance:assumpSF	[shape=box, color=black, style=filled, fillcolor=mistyrose, label="A:assumpSF"];
-	instance:assumpSL	[shape=box, color=black, style=filled, fillcolor=mistyrose, label="A:assumpSL"];
-	instance:assumpWIBE	[shape=box, color=black, style=filled, fillcolor=mistyrose, label="A:assumpWIBE"];
-	instance:assumpWISE	[shape=box, color=black, style=filled, fillcolor=mistyrose, label="A:assumpWISE"];
-	instance:assumpNESSS	[shape=box, color=black, style=filled, fillcolor=mistyrose, label="A:assumpNESSS"];
-	instance:assumpHFSM	[shape=box, color=black, style=filled, fillcolor=mistyrose, label="A:assumpHFSM"];
-
-	subgraph A {
-	rank="same"
-	{instance:assumpSSC, instance:assumpFOS, instance:assumpSLH, instance:assumpSP, instance:assumpSLI, instance:assumpINSFL, instance:assumpPSC, instance:assumpENSL, instance:assumpSBSBISL, instance:assumpES, instance:assumpSF, instance:assumpSL, instance:assumpWIBE, instance:assumpWISE, instance:assumpNESSS, instance:assumpHFSM}
-	}
-
+digraph "avsa" {
+    "instance:assumpSSC" [shape=box, color=black, style=filled, fillcolor="mistyrose", label="A:assumpSSC"];
+    "instance:assumpFOS" [shape=box, color=black, style=filled, fillcolor="mistyrose", label="A:assumpFOS"];
+    "instance:assumpSLH" [shape=box, color=black, style=filled, fillcolor="mistyrose", label="A:assumpSLH"];
+    "instance:assumpSP" [shape=box, color=black, style=filled, fillcolor="mistyrose", label="A:assumpSP"];
+    "instance:assumpSLI" [shape=box, color=black, style=filled, fillcolor="mistyrose", label="A:assumpSLI"];
+    "instance:assumpINSFL" [shape=box, color=black, style=filled, fillcolor="mistyrose", label="A:assumpINSFL"];
+    "instance:assumpPSC" [shape=box, color=black, style=filled, fillcolor="mistyrose", label="A:assumpPSC"];
+    "instance:assumpENSL" [shape=box, color=black, style=filled, fillcolor="mistyrose", label="A:assumpENSL"];
+    "instance:assumpSBSBISL" [shape=box, color=black, style=filled, fillcolor="mistyrose", label="A:assumpSBSBISL"];
+    "instance:assumpES" [shape=box, color=black, style=filled, fillcolor="mistyrose", label="A:assumpES"];
+    "instance:assumpSF" [shape=box, color=black, style=filled, fillcolor="mistyrose", label="A:assumpSF"];
+    "instance:assumpSL" [shape=box, color=black, style=filled, fillcolor="mistyrose", label="A:assumpSL"];
+    "instance:assumpWIBE" [shape=box, color=black, style=filled, fillcolor="mistyrose", label="A:assumpWIBE"];
+    "instance:assumpWISE" [shape=box, color=black, style=filled, fillcolor="mistyrose", label="A:assumpWISE"];
+    "instance:assumpNESSS" [shape=box, color=black, style=filled, fillcolor="mistyrose", label="A:assumpNESSS"];
+    "instance:assumpHFSM" [shape=box, color=black, style=filled, fillcolor="mistyrose", label="A:assumpHFSM"];
+    subgraph "A" {
+        rank="same";
+        "instance:assumpSSC" "instance:assumpFOS" "instance:assumpSLH" "instance:assumpSP" "instance:assumpSLI" "instance:assumpINSFL" "instance:assumpPSC" "instance:assumpENSL" "instance:assumpSBSBISL" "instance:assumpES" "instance:assumpSF" "instance:assumpSL" "instance:assumpWIBE" "instance:assumpWISE" "instance:assumpNESSS" "instance:assumpHFSM";
+    }
 }

--- a/code/stable/ssp/TraceyGraph/avsall.dot
+++ b/code/stable/ssp/TraceyGraph/avsall.dot
@@ -1,165 +1,149 @@
-digraph avsall {
-	dataDefn:alpha_i -> instance:assumpSBSBISL;
-	dataDefn:beta_i -> instance:assumpSBSBISL;
-	dataDefn:h_i -> instance:assumpSBSBISL;
-	theory:equilibriumCS -> instance:assumpENSL;
-	theory:mcShrSrgth -> instance:assumpSBSBISL;
-	theory:resShr -> instance:assumpSLH;
-	theory:resShr -> instance:assumpSP;
-	theory:resShr -> instance:assumpSLI;
-	theory:resShr -> instance:assumpPSC;
-	theory:mobShr -> instance:assumpFOS;
-	theory:effNormF -> instance:assumpPSC;
-	theory:X_i -> instance:assumpINSFL;
-	theory:momentEql -> instance:assumpNESSS;
-	theory:momentEql -> instance:assumpHFSM;
-	theory:sliceWght -> instance:assumpSLH;
-	theory:sliceWght -> instance:assumpPSC;
-	theory:sliceWght -> instance:assumpSBSBISL;
-	theory:sliceWght -> instance:assumpWIBE;
-	theory:sliceWght -> instance:assumpWISE;
-	theory:baseWtrF -> instance:assumpPSC;
-	theory:baseWtrF -> instance:assumpSBSBISL;
-	theory:baseWtrF -> instance:assumpWIBE;
-	theory:baseWtrF -> instance:assumpHFSM;
-	theory:srfWtrF -> instance:assumpPSC;
-	theory:srfWtrF -> instance:assumpSBSBISL;
-	theory:srfWtrF -> instance:assumpWISE;
-	theory:srfWtrF -> instance:assumpHFSM;
-	theory:FS -> instance:assumpINSFL;
-	theory:FS -> instance:assumpES;
-	theory:FS -> instance:assumpSF;
-	theory:FS -> instance:assumpSL;
-	theory:nrmShrForIM -> instance:assumpINSFL;
-	theory:nrmShrForIM -> instance:assumpES;
-	theory:nrmShrForIM -> instance:assumpSF;
-	theory:nrmShrForIM -> instance:assumpSL;
-	theory:intsliceFsRC -> instance:assumpES;
-	theory:crtSlpIdIM -> instance:assumpSSC;
-	instance:LC_inhomogeneous -> instance:assumpSLH;
-	instance:LC_seismic -> instance:assumpSF;
-	instance:LC_external -> instance:assumpSL;
-	instance:UC_normshearlinear -> instance:assumpINSFL;
-	instance:UC_2donly -> instance:assumpENSL;
-
-
-	instance:assumpSSC	[shape=box, color=black, style=filled, fillcolor=mistyrose, label="A:assumpSSC"];
-	instance:assumpFOS	[shape=box, color=black, style=filled, fillcolor=mistyrose, label="A:assumpFOS"];
-	instance:assumpSLH	[shape=box, color=black, style=filled, fillcolor=mistyrose, label="A:assumpSLH"];
-	instance:assumpSP	[shape=box, color=black, style=filled, fillcolor=mistyrose, label="A:assumpSP"];
-	instance:assumpSLI	[shape=box, color=black, style=filled, fillcolor=mistyrose, label="A:assumpSLI"];
-	instance:assumpINSFL	[shape=box, color=black, style=filled, fillcolor=mistyrose, label="A:assumpINSFL"];
-	instance:assumpPSC	[shape=box, color=black, style=filled, fillcolor=mistyrose, label="A:assumpPSC"];
-	instance:assumpENSL	[shape=box, color=black, style=filled, fillcolor=mistyrose, label="A:assumpENSL"];
-	instance:assumpSBSBISL	[shape=box, color=black, style=filled, fillcolor=mistyrose, label="A:assumpSBSBISL"];
-	instance:assumpES	[shape=box, color=black, style=filled, fillcolor=mistyrose, label="A:assumpES"];
-	instance:assumpSF	[shape=box, color=black, style=filled, fillcolor=mistyrose, label="A:assumpSF"];
-	instance:assumpSL	[shape=box, color=black, style=filled, fillcolor=mistyrose, label="A:assumpSL"];
-	instance:assumpWIBE	[shape=box, color=black, style=filled, fillcolor=mistyrose, label="A:assumpWIBE"];
-	instance:assumpWISE	[shape=box, color=black, style=filled, fillcolor=mistyrose, label="A:assumpWISE"];
-	instance:assumpNESSS	[shape=box, color=black, style=filled, fillcolor=mistyrose, label="A:assumpNESSS"];
-	instance:assumpHFSM	[shape=box, color=black, style=filled, fillcolor=mistyrose, label="A:assumpHFSM"];
-
-	subgraph A {
-	rank="same"
-	{instance:assumpSSC, instance:assumpFOS, instance:assumpSLH, instance:assumpSP, instance:assumpSLI, instance:assumpINSFL, instance:assumpPSC, instance:assumpENSL, instance:assumpSBSBISL, instance:assumpES, instance:assumpSF, instance:assumpSL, instance:assumpWIBE, instance:assumpWISE, instance:assumpNESSS, instance:assumpHFSM}
-	}
-
-	dataDefn:H_i	[shape=box, color=black, style=filled, fillcolor=paleturquoise1, label="DD:intersliceWtrF"];
-	dataDefn:alpha_i	[shape=box, color=black, style=filled, fillcolor=paleturquoise1, label="DD:angleA"];
-	dataDefn:beta_i	[shape=box, color=black, style=filled, fillcolor=paleturquoise1, label="DD:angleB"];
-	dataDefn:b_i	[shape=box, color=black, style=filled, fillcolor=paleturquoise1, label="DD:lengthB"];
-	dataDefn:l_bi	[shape=box, color=black, style=filled, fillcolor=paleturquoise1, label="DD:lengthLb"];
-	dataDefn:l_si	[shape=box, color=black, style=filled, fillcolor=paleturquoise1, label="DD:lengthLs"];
-	dataDefn:h_i	[shape=box, color=black, style=filled, fillcolor=paleturquoise1, label="DD:slcHeight"];
-	dataDefn:sigma	[shape=box, color=black, style=filled, fillcolor=paleturquoise1, label="DD:normStress"];
-	dataDefn:tau	[shape=box, color=black, style=filled, fillcolor=paleturquoise1, label="DD:tangStress"];
-	dataDefn:torque	[shape=box, color=black, style=filled, fillcolor=paleturquoise1, label="DD:torque"];
-	dataDefn:f_i	[shape=box, color=black, style=filled, fillcolor=paleturquoise1, label="DD:ratioVariation"];
-	dataDefn:Phi	[shape=box, color=black, style=filled, fillcolor=paleturquoise1, label="DD:convertFunc1"];
-	dataDefn:Psi	[shape=box, color=black, style=filled, fillcolor=paleturquoise1, label="DD:convertFunc2"];
-	dataDefn:F_xG	[shape=box, color=black, style=filled, fillcolor=paleturquoise1, label="DD:nrmForceSumDD"];
-	dataDefn:F_xH	[shape=box, color=black, style=filled, fillcolor=paleturquoise1, label="DD:watForceSumDD"];
-	dataDefn:hR	[shape=box, color=black, style=filled, fillcolor=paleturquoise1, label="DD:sliceHghtRightDD"];
-	dataDefn:hL	[shape=box, color=black, style=filled, fillcolor=paleturquoise1, label="DD:sliceHghtLeftDD"];
-
-	subgraph DD {
-	rank="same"
-	{dataDefn:H_i, dataDefn:alpha_i, dataDefn:beta_i, dataDefn:b_i, dataDefn:l_bi, dataDefn:l_si, dataDefn:h_i, dataDefn:sigma, dataDefn:tau, dataDefn:torque, dataDefn:f_i, dataDefn:Phi, dataDefn:Psi, dataDefn:F_xG, dataDefn:F_xH, dataDefn:hR, dataDefn:hL}
-	}
-
-	theory:factOfSafetyTM	[shape=box, color=black, style=filled, fillcolor=pink, label="TM:factOfSafety"];
-	theory:equilibriumCS	[shape=box, color=black, style=filled, fillcolor=pink, label="TM:equilibrium"];
-	theory:mcShrSrgth	[shape=box, color=black, style=filled, fillcolor=pink, label="TM:mcShrStrgth"];
-	theory:effectiveStressTM	[shape=box, color=black, style=filled, fillcolor=pink, label="TM:effStress"];
-	theory:newtonSL	[shape=box, color=black, style=filled, fillcolor=pink, label="TM:NewtonSecLawMot"];
-
-	subgraph TM {
-	rank="same"
-	{theory:factOfSafetyTM, theory:equilibriumCS, theory:mcShrSrgth, theory:effectiveStressTM, theory:newtonSL}
-	}
-
-	theory:normForcEq	[shape=box, color=black, style=filled, fillcolor=palegreen, label="GD:normForcEq"];
-	theory:bsShrFEq	[shape=box, color=black, style=filled, fillcolor=palegreen, label="GD:bsShrFEq"];
-	theory:resShr	[shape=box, color=black, style=filled, fillcolor=palegreen, label="GD:resShr"];
-	theory:mobShr	[shape=box, color=black, style=filled, fillcolor=palegreen, label="GD:mobShr"];
-	theory:effNormF	[shape=box, color=black, style=filled, fillcolor=palegreen, label="GD:effNormF"];
-	theory:resShearWO	[shape=box, color=black, style=filled, fillcolor=palegreen, label="GD:resShearWO"];
-	theory:mobShearWO	[shape=box, color=black, style=filled, fillcolor=palegreen, label="GD:mobShearWO"];
-	theory:X_i	[shape=box, color=black, style=filled, fillcolor=palegreen, label="GD:normShrR"];
-	theory:momentEql	[shape=box, color=black, style=filled, fillcolor=palegreen, label="GD:momentEql"];
-	theory:weight	[shape=box, color=black, style=filled, fillcolor=palegreen, label="GD:weight"];
-	theory:sliceWght	[shape=box, color=black, style=filled, fillcolor=palegreen, label="GD:sliceWght"];
-	theory:pressure	[shape=box, color=black, style=filled, fillcolor=palegreen, label="GD:hsPressure"];
-	theory:baseWtrF	[shape=box, color=black, style=filled, fillcolor=palegreen, label="GD:baseWtrF"];
-	theory:srfWtrF	[shape=box, color=black, style=filled, fillcolor=palegreen, label="GD:srfWtrF"];
-
-	subgraph GD {
-	rank="same"
-	{theory:normForcEq, theory:bsShrFEq, theory:resShr, theory:mobShr, theory:effNormF, theory:resShearWO, theory:mobShearWO, theory:X_i, theory:momentEql, theory:weight, theory:sliceWght, theory:pressure, theory:baseWtrF, theory:srfWtrF}
-	}
-
-	theory:FS	[shape=box, color=black, style=filled, fillcolor=khaki1, label="IM:fctSfty"];
-	theory:nrmShrForIM	[shape=box, color=black, style=filled, fillcolor=khaki1, label="IM:nrmShrFor"];
-	theory:nrmShrForNumRC	[shape=box, color=black, style=filled, fillcolor=khaki1, label="IM:nrmShrForNum"];
-	theory:nrmShrForDenRC	[shape=box, color=black, style=filled, fillcolor=khaki1, label="IM:nrmShrForDen"];
-	theory:intsliceFsRC	[shape=box, color=black, style=filled, fillcolor=khaki1, label="IM:intsliceFs"];
-	theory:crtSlpIdIM	[shape=box, color=black, style=filled, fillcolor=khaki1, label="IM:crtSlpId"];
-
-	subgraph IM {
-	rank="same"
-	{theory:FS, theory:nrmShrForIM, theory:nrmShrForNumRC, theory:nrmShrForDenRC, theory:intsliceFsRC, theory:crtSlpIdIM}
-	}
-
-	instance:readAndStore	[shape=box, color=black, style=filled, fillcolor=ivory, label="FR:readAndStore"];
-	instance:verifyInput	[shape=box, color=black, style=filled, fillcolor=ivory, label="FR:verifyInput"];
-	instance:determineCritSlip	[shape=box, color=black, style=filled, fillcolor=ivory, label="FR:determineCritSlip"];
-	instance:verifyOutput	[shape=box, color=black, style=filled, fillcolor=ivory, label="FR:verifyOutput"];
-	instance:displayInput	[shape=box, color=black, style=filled, fillcolor=ivory, label="FR:displayInput"];
-	instance:displayGraph	[shape=box, color=black, style=filled, fillcolor=ivory, label="FR:displayGraph"];
-	instance:displayFS	[shape=box, color=black, style=filled, fillcolor=ivory, label="FR:displayFS"];
-	instance:displayNormal	[shape=box, color=black, style=filled, fillcolor=ivory, label="FR:displayNormal"];
-	instance:displayShear	[shape=box, color=black, style=filled, fillcolor=ivory, label="FR:displayShear"];
-	instance:writeToFile	[shape=box, color=black, style=filled, fillcolor=ivory, label="FR:writeToFile"];
-	instance:correct	[shape=box, color=black, style=filled, fillcolor=ivory, label="NFR:correct"];
-	instance:understandable	[shape=box, color=black, style=filled, fillcolor=ivory, label="NFR:understandable"];
-	instance:reusable	[shape=box, color=black, style=filled, fillcolor=ivory, label="NFR:reusable"];
-	instance:maintainable	[shape=box, color=black, style=filled, fillcolor=ivory, label="NFR:maintainable"];
-
-	subgraph FR {
-	rank="same"
-	{instance:readAndStore, instance:verifyInput, instance:determineCritSlip, instance:verifyOutput, instance:displayInput, instance:displayGraph, instance:displayFS, instance:displayNormal, instance:displayShear, instance:writeToFile, instance:correct, instance:understandable, instance:reusable, instance:maintainable}
-	}
-
-	instance:LC_inhomogeneous	[shape=box, color=black, style=filled, fillcolor=lavender, label="LC:LC_inhomogeneous"];
-	instance:LC_seismic	[shape=box, color=black, style=filled, fillcolor=lavender, label="LC:LC_seismic"];
-	instance:LC_external	[shape=box, color=black, style=filled, fillcolor=lavender, label="LC:LC_external"];
-	instance:UC_normshearlinear	[shape=box, color=black, style=filled, fillcolor=lavender, label="UC:UC_normshearlinear"];
-	instance:UC_2donly	[shape=box, color=black, style=filled, fillcolor=lavender, label="UC:UC_2donly"];
-
-	subgraph LC {
-	rank="same"
-	{instance:LC_inhomogeneous, instance:LC_seismic, instance:LC_external, instance:UC_normshearlinear, instance:UC_2donly}
-	}
-
+digraph "avsall" {
+    "dataDefn:alpha_i" -> "instance:assumpSBSBISL";
+    "dataDefn:beta_i" -> "instance:assumpSBSBISL";
+    "dataDefn:h_i" -> "instance:assumpSBSBISL";
+    "theory:equilibriumCS" -> "instance:assumpENSL";
+    "theory:mcShrSrgth" -> "instance:assumpSBSBISL";
+    "theory:resShr" -> "instance:assumpSLH";
+    "theory:resShr" -> "instance:assumpSP";
+    "theory:resShr" -> "instance:assumpSLI";
+    "theory:resShr" -> "instance:assumpPSC";
+    "theory:mobShr" -> "instance:assumpFOS";
+    "theory:effNormF" -> "instance:assumpPSC";
+    "theory:X_i" -> "instance:assumpINSFL";
+    "theory:momentEql" -> "instance:assumpNESSS";
+    "theory:momentEql" -> "instance:assumpHFSM";
+    "theory:sliceWght" -> "instance:assumpSLH";
+    "theory:sliceWght" -> "instance:assumpPSC";
+    "theory:sliceWght" -> "instance:assumpSBSBISL";
+    "theory:sliceWght" -> "instance:assumpWIBE";
+    "theory:sliceWght" -> "instance:assumpWISE";
+    "theory:baseWtrF" -> "instance:assumpPSC";
+    "theory:baseWtrF" -> "instance:assumpSBSBISL";
+    "theory:baseWtrF" -> "instance:assumpWIBE";
+    "theory:baseWtrF" -> "instance:assumpHFSM";
+    "theory:srfWtrF" -> "instance:assumpPSC";
+    "theory:srfWtrF" -> "instance:assumpSBSBISL";
+    "theory:srfWtrF" -> "instance:assumpWISE";
+    "theory:srfWtrF" -> "instance:assumpHFSM";
+    "theory:FS" -> "instance:assumpINSFL";
+    "theory:FS" -> "instance:assumpES";
+    "theory:FS" -> "instance:assumpSF";
+    "theory:FS" -> "instance:assumpSL";
+    "theory:nrmShrForIM" -> "instance:assumpINSFL";
+    "theory:nrmShrForIM" -> "instance:assumpES";
+    "theory:nrmShrForIM" -> "instance:assumpSF";
+    "theory:nrmShrForIM" -> "instance:assumpSL";
+    "theory:intsliceFsRC" -> "instance:assumpES";
+    "theory:crtSlpIdIM" -> "instance:assumpSSC";
+    "instance:LC_inhomogeneous" -> "instance:assumpSLH";
+    "instance:LC_seismic" -> "instance:assumpSF";
+    "instance:LC_external" -> "instance:assumpSL";
+    "instance:UC_normshearlinear" -> "instance:assumpINSFL";
+    "instance:UC_2donly" -> "instance:assumpENSL";
+    "instance:assumpSSC" [shape=box, color=black, style=filled, fillcolor="mistyrose", label="A:assumpSSC"];
+    "instance:assumpFOS" [shape=box, color=black, style=filled, fillcolor="mistyrose", label="A:assumpFOS"];
+    "instance:assumpSLH" [shape=box, color=black, style=filled, fillcolor="mistyrose", label="A:assumpSLH"];
+    "instance:assumpSP" [shape=box, color=black, style=filled, fillcolor="mistyrose", label="A:assumpSP"];
+    "instance:assumpSLI" [shape=box, color=black, style=filled, fillcolor="mistyrose", label="A:assumpSLI"];
+    "instance:assumpINSFL" [shape=box, color=black, style=filled, fillcolor="mistyrose", label="A:assumpINSFL"];
+    "instance:assumpPSC" [shape=box, color=black, style=filled, fillcolor="mistyrose", label="A:assumpPSC"];
+    "instance:assumpENSL" [shape=box, color=black, style=filled, fillcolor="mistyrose", label="A:assumpENSL"];
+    "instance:assumpSBSBISL" [shape=box, color=black, style=filled, fillcolor="mistyrose", label="A:assumpSBSBISL"];
+    "instance:assumpES" [shape=box, color=black, style=filled, fillcolor="mistyrose", label="A:assumpES"];
+    "instance:assumpSF" [shape=box, color=black, style=filled, fillcolor="mistyrose", label="A:assumpSF"];
+    "instance:assumpSL" [shape=box, color=black, style=filled, fillcolor="mistyrose", label="A:assumpSL"];
+    "instance:assumpWIBE" [shape=box, color=black, style=filled, fillcolor="mistyrose", label="A:assumpWIBE"];
+    "instance:assumpWISE" [shape=box, color=black, style=filled, fillcolor="mistyrose", label="A:assumpWISE"];
+    "instance:assumpNESSS" [shape=box, color=black, style=filled, fillcolor="mistyrose", label="A:assumpNESSS"];
+    "instance:assumpHFSM" [shape=box, color=black, style=filled, fillcolor="mistyrose", label="A:assumpHFSM"];
+    subgraph "A" {
+        rank="same";
+        "instance:assumpSSC" "instance:assumpFOS" "instance:assumpSLH" "instance:assumpSP" "instance:assumpSLI" "instance:assumpINSFL" "instance:assumpPSC" "instance:assumpENSL" "instance:assumpSBSBISL" "instance:assumpES" "instance:assumpSF" "instance:assumpSL" "instance:assumpWIBE" "instance:assumpWISE" "instance:assumpNESSS" "instance:assumpHFSM";
+    }
+    "dataDefn:H_i" [shape=box, color=black, style=filled, fillcolor="paleturquoise1", label="DD:intersliceWtrF"];
+    "dataDefn:alpha_i" [shape=box, color=black, style=filled, fillcolor="paleturquoise1", label="DD:angleA"];
+    "dataDefn:beta_i" [shape=box, color=black, style=filled, fillcolor="paleturquoise1", label="DD:angleB"];
+    "dataDefn:b_i" [shape=box, color=black, style=filled, fillcolor="paleturquoise1", label="DD:lengthB"];
+    "dataDefn:l_b,i" [shape=box, color=black, style=filled, fillcolor="paleturquoise1", label="DD:lengthLb"];
+    "dataDefn:l_s,i" [shape=box, color=black, style=filled, fillcolor="paleturquoise1", label="DD:lengthLs"];
+    "dataDefn:h_i" [shape=box, color=black, style=filled, fillcolor="paleturquoise1", label="DD:slcHeight"];
+    "dataDefn:sigma" [shape=box, color=black, style=filled, fillcolor="paleturquoise1", label="DD:normStress"];
+    "dataDefn:tau" [shape=box, color=black, style=filled, fillcolor="paleturquoise1", label="DD:tangStress"];
+    "dataDefn:torque" [shape=box, color=black, style=filled, fillcolor="paleturquoise1", label="DD:torque"];
+    "dataDefn:f_i" [shape=box, color=black, style=filled, fillcolor="paleturquoise1", label="DD:ratioVariation"];
+    "dataDefn:Phi" [shape=box, color=black, style=filled, fillcolor="paleturquoise1", label="DD:convertFunc1"];
+    "dataDefn:Psi" [shape=box, color=black, style=filled, fillcolor="paleturquoise1", label="DD:convertFunc2"];
+    "dataDefn:F_x^G" [shape=box, color=black, style=filled, fillcolor="paleturquoise1", label="DD:nrmForceSumDD"];
+    "dataDefn:F_x^H" [shape=box, color=black, style=filled, fillcolor="paleturquoise1", label="DD:watForceSumDD"];
+    "dataDefn:h^R" [shape=box, color=black, style=filled, fillcolor="paleturquoise1", label="DD:sliceHghtRightDD"];
+    "dataDefn:h^L" [shape=box, color=black, style=filled, fillcolor="paleturquoise1", label="DD:sliceHghtLeftDD"];
+    subgraph "DD" {
+        rank="same";
+        "dataDefn:H_i" "dataDefn:alpha_i" "dataDefn:beta_i" "dataDefn:b_i" "dataDefn:l_b,i" "dataDefn:l_s,i" "dataDefn:h_i" "dataDefn:sigma" "dataDefn:tau" "dataDefn:torque" "dataDefn:f_i" "dataDefn:Phi" "dataDefn:Psi" "dataDefn:F_x^G" "dataDefn:F_x^H" "dataDefn:h^R" "dataDefn:h^L";
+    }
+    "theory:factOfSafetyTM" [shape=box, color=black, style=filled, fillcolor="pink", label="TM:factOfSafety"];
+    "theory:equilibriumCS" [shape=box, color=black, style=filled, fillcolor="pink", label="TM:equilibrium"];
+    "theory:mcShrSrgth" [shape=box, color=black, style=filled, fillcolor="pink", label="TM:mcShrStrgth"];
+    "theory:effectiveStressTM" [shape=box, color=black, style=filled, fillcolor="pink", label="TM:effStress"];
+    "theory:newtonSL" [shape=box, color=black, style=filled, fillcolor="pink", label="TM:NewtonSecLawMot"];
+    subgraph "TM" {
+        rank="same";
+        "theory:factOfSafetyTM" "theory:equilibriumCS" "theory:mcShrSrgth" "theory:effectiveStressTM" "theory:newtonSL";
+    }
+    "theory:normForcEq" [shape=box, color=black, style=filled, fillcolor="palegreen", label="GD:normForcEq"];
+    "theory:bsShrFEq" [shape=box, color=black, style=filled, fillcolor="palegreen", label="GD:bsShrFEq"];
+    "theory:resShr" [shape=box, color=black, style=filled, fillcolor="palegreen", label="GD:resShr"];
+    "theory:mobShr" [shape=box, color=black, style=filled, fillcolor="palegreen", label="GD:mobShr"];
+    "theory:effNormF" [shape=box, color=black, style=filled, fillcolor="palegreen", label="GD:effNormF"];
+    "theory:resShearWO" [shape=box, color=black, style=filled, fillcolor="palegreen", label="GD:resShearWO"];
+    "theory:mobShearWO" [shape=box, color=black, style=filled, fillcolor="palegreen", label="GD:mobShearWO"];
+    "theory:X_i" [shape=box, color=black, style=filled, fillcolor="palegreen", label="GD:normShrR"];
+    "theory:momentEql" [shape=box, color=black, style=filled, fillcolor="palegreen", label="GD:momentEql"];
+    "theory:weight" [shape=box, color=black, style=filled, fillcolor="palegreen", label="GD:weight"];
+    "theory:sliceWght" [shape=box, color=black, style=filled, fillcolor="palegreen", label="GD:sliceWght"];
+    "theory:pressure" [shape=box, color=black, style=filled, fillcolor="palegreen", label="GD:hsPressure"];
+    "theory:baseWtrF" [shape=box, color=black, style=filled, fillcolor="palegreen", label="GD:baseWtrF"];
+    "theory:srfWtrF" [shape=box, color=black, style=filled, fillcolor="palegreen", label="GD:srfWtrF"];
+    subgraph "GD" {
+        rank="same";
+        "theory:normForcEq" "theory:bsShrFEq" "theory:resShr" "theory:mobShr" "theory:effNormF" "theory:resShearWO" "theory:mobShearWO" "theory:X_i" "theory:momentEql" "theory:weight" "theory:sliceWght" "theory:pressure" "theory:baseWtrF" "theory:srfWtrF";
+    }
+    "theory:FS" [shape=box, color=black, style=filled, fillcolor="khaki1", label="IM:fctSfty"];
+    "theory:nrmShrForIM" [shape=box, color=black, style=filled, fillcolor="khaki1", label="IM:nrmShrFor"];
+    "theory:nrmShrForNumRC" [shape=box, color=black, style=filled, fillcolor="khaki1", label="IM:nrmShrForNum"];
+    "theory:nrmShrForDenRC" [shape=box, color=black, style=filled, fillcolor="khaki1", label="IM:nrmShrForDen"];
+    "theory:intsliceFsRC" [shape=box, color=black, style=filled, fillcolor="khaki1", label="IM:intsliceFs"];
+    "theory:crtSlpIdIM" [shape=box, color=black, style=filled, fillcolor="khaki1", label="IM:crtSlpId"];
+    subgraph "IM" {
+        rank="same";
+        "theory:FS" "theory:nrmShrForIM" "theory:nrmShrForNumRC" "theory:nrmShrForDenRC" "theory:intsliceFsRC" "theory:crtSlpIdIM";
+    }
+    "instance:readAndStore" [shape=box, color=black, style=filled, fillcolor="ivory", label="FR:readAndStore"];
+    "instance:verifyInput" [shape=box, color=black, style=filled, fillcolor="ivory", label="FR:verifyInput"];
+    "instance:determineCritSlip" [shape=box, color=black, style=filled, fillcolor="ivory", label="FR:determineCritSlip"];
+    "instance:verifyOutput" [shape=box, color=black, style=filled, fillcolor="ivory", label="FR:verifyOutput"];
+    "instance:displayInput" [shape=box, color=black, style=filled, fillcolor="ivory", label="FR:displayInput"];
+    "instance:displayGraph" [shape=box, color=black, style=filled, fillcolor="ivory", label="FR:displayGraph"];
+    "instance:displayFS" [shape=box, color=black, style=filled, fillcolor="ivory", label="FR:displayFS"];
+    "instance:displayNormal" [shape=box, color=black, style=filled, fillcolor="ivory", label="FR:displayNormal"];
+    "instance:displayShear" [shape=box, color=black, style=filled, fillcolor="ivory", label="FR:displayShear"];
+    "instance:writeToFile" [shape=box, color=black, style=filled, fillcolor="ivory", label="FR:writeToFile"];
+    "instance:correct" [shape=box, color=black, style=filled, fillcolor="ivory", label="NFR:correct"];
+    "instance:understandable" [shape=box, color=black, style=filled, fillcolor="ivory", label="NFR:understandable"];
+    "instance:reusable" [shape=box, color=black, style=filled, fillcolor="ivory", label="NFR:reusable"];
+    "instance:maintainable" [shape=box, color=black, style=filled, fillcolor="ivory", label="NFR:maintainable"];
+    subgraph "FR" {
+        rank="same";
+        "instance:readAndStore" "instance:verifyInput" "instance:determineCritSlip" "instance:verifyOutput" "instance:displayInput" "instance:displayGraph" "instance:displayFS" "instance:displayNormal" "instance:displayShear" "instance:writeToFile" "instance:correct" "instance:understandable" "instance:reusable" "instance:maintainable";
+    }
+    "instance:LC_inhomogeneous" [shape=box, color=black, style=filled, fillcolor="lavender", label="LC:LC_inhomogeneous"];
+    "instance:LC_seismic" [shape=box, color=black, style=filled, fillcolor="lavender", label="LC:LC_seismic"];
+    "instance:LC_external" [shape=box, color=black, style=filled, fillcolor="lavender", label="LC:LC_external"];
+    "instance:UC_normshearlinear" [shape=box, color=black, style=filled, fillcolor="lavender", label="UC:UC_normshearlinear"];
+    "instance:UC_2donly" [shape=box, color=black, style=filled, fillcolor="lavender", label="UC:UC_2donly"];
+    subgraph "LC" {
+        rank="same";
+        "instance:LC_inhomogeneous" "instance:LC_seismic" "instance:LC_external" "instance:UC_normshearlinear" "instance:UC_2donly";
+    }
 }

--- a/code/stable/ssp/TraceyGraph/refvsref.dot
+++ b/code/stable/ssp/TraceyGraph/refvsref.dot
@@ -1,168 +1,158 @@
-digraph refvsref {
-	dataDefn:l_bi -> dataDefn:alpha_i;
-	dataDefn:l_bi -> dataDefn:b_i;
-	dataDefn:l_si -> dataDefn:beta_i;
-	dataDefn:l_si -> dataDefn:b_i;
-	dataDefn:h_i -> dataDefn:hR;
-	dataDefn:h_i -> dataDefn:hL;
-	dataDefn:Phi -> dataDefn:alpha_i;
-	dataDefn:Phi -> dataDefn:f_i;
-	dataDefn:Psi -> dataDefn:alpha_i;
-	dataDefn:Psi -> dataDefn:f_i;
-	dataDefn:Psi -> dataDefn:Phi;
-	theory:effectiveStressTM -> dataDefn:sigma;
-	theory:normForcEq -> dataDefn:alpha_i;
-	theory:normForcEq -> dataDefn:beta_i;
-	theory:normForcEq -> theory:equilibriumCS;
-	theory:normForcEq -> theory:sliceWght;
-	theory:normForcEq -> theory:srfWtrF;
-	theory:bsShrFEq -> dataDefn:alpha_i;
-	theory:bsShrFEq -> dataDefn:beta_i;
-	theory:bsShrFEq -> theory:equilibriumCS;
-	theory:bsShrFEq -> theory:sliceWght;
-	theory:bsShrFEq -> theory:srfWtrF;
-	theory:resShr -> dataDefn:l_bi;
-	theory:resShr -> dataDefn:sigma;
-	theory:resShr -> dataDefn:tau;
-	theory:resShr -> theory:mcShrSrgth;
-	theory:mobShr -> dataDefn:l_bi;
-	theory:mobShr -> theory:factOfSafetyTM;
-	theory:mobShr -> theory:resShr;
-	theory:effNormF -> dataDefn:sigma;
-	theory:effNormF -> theory:effectiveStressTM;
-	theory:effNormF -> theory:baseWtrF;
-	theory:resShearWO -> dataDefn:H_i;
-	theory:resShearWO -> dataDefn:alpha_i;
-	theory:resShearWO -> dataDefn:beta_i;
-	theory:resShearWO -> dataDefn:l_bi;
-	theory:resShearWO -> theory:sliceWght;
-	theory:resShearWO -> theory:baseWtrF;
-	theory:resShearWO -> theory:srfWtrF;
-	theory:mobShearWO -> dataDefn:H_i;
-	theory:mobShearWO -> dataDefn:alpha_i;
-	theory:mobShearWO -> dataDefn:beta_i;
-	theory:mobShearWO -> theory:sliceWght;
-	theory:mobShearWO -> theory:srfWtrF;
-	theory:X_i -> dataDefn:f_i;
-	theory:momentEql -> dataDefn:alpha_i;
-	theory:momentEql -> dataDefn:beta_i;
-	theory:momentEql -> dataDefn:b_i;
-	theory:momentEql -> dataDefn:h_i;
-	theory:momentEql -> dataDefn:torque;
-	theory:momentEql -> theory:equilibriumCS;
-	theory:momentEql -> theory:weight;
-	theory:momentEql -> theory:sliceWght;
-	theory:momentEql -> theory:srfWtrF;
-	theory:weight -> theory:newtonSL;
-	theory:sliceWght -> dataDefn:b_i;
-	theory:sliceWght -> theory:weight;
-	theory:baseWtrF -> dataDefn:l_bi;
-	theory:baseWtrF -> theory:pressure;
-	theory:baseWtrF -> theory:baseWtrF;
-	theory:srfWtrF -> dataDefn:l_si;
-	theory:srfWtrF -> theory:pressure;
-	theory:srfWtrF -> theory:srfWtrF;
-	theory:FS -> dataDefn:Phi;
-	theory:FS -> dataDefn:Psi;
-	theory:FS -> theory:normForcEq;
-	theory:FS -> theory:bsShrFEq;
-	theory:FS -> theory:mobShr;
-	theory:FS -> theory:resShearWO;
-	theory:FS -> theory:mobShearWO;
-	theory:FS -> theory:X_i;
-	theory:FS -> theory:FS;
-	theory:FS -> theory:nrmShrForIM;
-	theory:FS -> theory:intsliceFsRC;
-	theory:nrmShrForIM -> theory:X_i;
-	theory:nrmShrForIM -> theory:momentEql;
-	theory:nrmShrForIM -> theory:FS;
-	theory:nrmShrForIM -> theory:nrmShrForIM;
-	theory:nrmShrForIM -> theory:nrmShrForNumRC;
-	theory:nrmShrForIM -> theory:nrmShrForDenRC;
-	theory:nrmShrForIM -> theory:intsliceFsRC;
-	theory:nrmShrForNumRC -> dataDefn:H_i;
-	theory:nrmShrForNumRC -> dataDefn:alpha_i;
-	theory:nrmShrForNumRC -> dataDefn:beta_i;
-	theory:nrmShrForNumRC -> dataDefn:b_i;
-	theory:nrmShrForNumRC -> dataDefn:h_i;
-	theory:nrmShrForNumRC -> theory:srfWtrF;
-	theory:nrmShrForNumRC -> theory:nrmShrForIM;
-	theory:nrmShrForDenRC -> dataDefn:b_i;
-	theory:nrmShrForDenRC -> dataDefn:f_i;
-	theory:nrmShrForDenRC -> theory:nrmShrForIM;
-	theory:intsliceFsRC -> dataDefn:Phi;
-	theory:intsliceFsRC -> dataDefn:Psi;
-	theory:intsliceFsRC -> theory:resShearWO;
-	theory:intsliceFsRC -> theory:mobShearWO;
-	theory:intsliceFsRC -> theory:FS;
-	theory:intsliceFsRC -> theory:nrmShrForIM;
-	theory:intsliceFsRC -> theory:intsliceFsRC;
-
-
-	dataDefn:H_i	[shape=box, color=black, style=filled, fillcolor=paleturquoise1, label="DD:intersliceWtrF"];
-	dataDefn:alpha_i	[shape=box, color=black, style=filled, fillcolor=paleturquoise1, label="DD:angleA"];
-	dataDefn:beta_i	[shape=box, color=black, style=filled, fillcolor=paleturquoise1, label="DD:angleB"];
-	dataDefn:b_i	[shape=box, color=black, style=filled, fillcolor=paleturquoise1, label="DD:lengthB"];
-	dataDefn:l_bi	[shape=box, color=black, style=filled, fillcolor=paleturquoise1, label="DD:lengthLb"];
-	dataDefn:l_si	[shape=box, color=black, style=filled, fillcolor=paleturquoise1, label="DD:lengthLs"];
-	dataDefn:h_i	[shape=box, color=black, style=filled, fillcolor=paleturquoise1, label="DD:slcHeight"];
-	dataDefn:sigma	[shape=box, color=black, style=filled, fillcolor=paleturquoise1, label="DD:normStress"];
-	dataDefn:tau	[shape=box, color=black, style=filled, fillcolor=paleturquoise1, label="DD:tangStress"];
-	dataDefn:torque	[shape=box, color=black, style=filled, fillcolor=paleturquoise1, label="DD:torque"];
-	dataDefn:f_i	[shape=box, color=black, style=filled, fillcolor=paleturquoise1, label="DD:ratioVariation"];
-	dataDefn:Phi	[shape=box, color=black, style=filled, fillcolor=paleturquoise1, label="DD:convertFunc1"];
-	dataDefn:Psi	[shape=box, color=black, style=filled, fillcolor=paleturquoise1, label="DD:convertFunc2"];
-	dataDefn:F_xG	[shape=box, color=black, style=filled, fillcolor=paleturquoise1, label="DD:nrmForceSumDD"];
-	dataDefn:F_xH	[shape=box, color=black, style=filled, fillcolor=paleturquoise1, label="DD:watForceSumDD"];
-	dataDefn:hR	[shape=box, color=black, style=filled, fillcolor=paleturquoise1, label="DD:sliceHghtRightDD"];
-	dataDefn:hL	[shape=box, color=black, style=filled, fillcolor=paleturquoise1, label="DD:sliceHghtLeftDD"];
-
-	subgraph DD {
-	rank="same"
-	{dataDefn:H_i, dataDefn:alpha_i, dataDefn:beta_i, dataDefn:b_i, dataDefn:l_bi, dataDefn:l_si, dataDefn:h_i, dataDefn:sigma, dataDefn:tau, dataDefn:torque, dataDefn:f_i, dataDefn:Phi, dataDefn:Psi, dataDefn:F_xG, dataDefn:F_xH, dataDefn:hR, dataDefn:hL}
-	}
-
-	theory:factOfSafetyTM	[shape=box, color=black, style=filled, fillcolor=pink, label="TM:factOfSafety"];
-	theory:equilibriumCS	[shape=box, color=black, style=filled, fillcolor=pink, label="TM:equilibrium"];
-	theory:mcShrSrgth	[shape=box, color=black, style=filled, fillcolor=pink, label="TM:mcShrStrgth"];
-	theory:effectiveStressTM	[shape=box, color=black, style=filled, fillcolor=pink, label="TM:effStress"];
-	theory:newtonSL	[shape=box, color=black, style=filled, fillcolor=pink, label="TM:NewtonSecLawMot"];
-
-	subgraph TM {
-	rank="same"
-	{theory:factOfSafetyTM, theory:equilibriumCS, theory:mcShrSrgth, theory:effectiveStressTM, theory:newtonSL}
-	}
-
-	theory:normForcEq	[shape=box, color=black, style=filled, fillcolor=palegreen, label="GD:normForcEq"];
-	theory:bsShrFEq	[shape=box, color=black, style=filled, fillcolor=palegreen, label="GD:bsShrFEq"];
-	theory:resShr	[shape=box, color=black, style=filled, fillcolor=palegreen, label="GD:resShr"];
-	theory:mobShr	[shape=box, color=black, style=filled, fillcolor=palegreen, label="GD:mobShr"];
-	theory:effNormF	[shape=box, color=black, style=filled, fillcolor=palegreen, label="GD:effNormF"];
-	theory:resShearWO	[shape=box, color=black, style=filled, fillcolor=palegreen, label="GD:resShearWO"];
-	theory:mobShearWO	[shape=box, color=black, style=filled, fillcolor=palegreen, label="GD:mobShearWO"];
-	theory:X_i	[shape=box, color=black, style=filled, fillcolor=palegreen, label="GD:normShrR"];
-	theory:momentEql	[shape=box, color=black, style=filled, fillcolor=palegreen, label="GD:momentEql"];
-	theory:weight	[shape=box, color=black, style=filled, fillcolor=palegreen, label="GD:weight"];
-	theory:sliceWght	[shape=box, color=black, style=filled, fillcolor=palegreen, label="GD:sliceWght"];
-	theory:pressure	[shape=box, color=black, style=filled, fillcolor=palegreen, label="GD:hsPressure"];
-	theory:baseWtrF	[shape=box, color=black, style=filled, fillcolor=palegreen, label="GD:baseWtrF"];
-	theory:srfWtrF	[shape=box, color=black, style=filled, fillcolor=palegreen, label="GD:srfWtrF"];
-
-	subgraph GD {
-	rank="same"
-	{theory:normForcEq, theory:bsShrFEq, theory:resShr, theory:mobShr, theory:effNormF, theory:resShearWO, theory:mobShearWO, theory:X_i, theory:momentEql, theory:weight, theory:sliceWght, theory:pressure, theory:baseWtrF, theory:srfWtrF}
-	}
-
-	theory:FS	[shape=box, color=black, style=filled, fillcolor=khaki1, label="IM:fctSfty"];
-	theory:nrmShrForIM	[shape=box, color=black, style=filled, fillcolor=khaki1, label="IM:nrmShrFor"];
-	theory:nrmShrForNumRC	[shape=box, color=black, style=filled, fillcolor=khaki1, label="IM:nrmShrForNum"];
-	theory:nrmShrForDenRC	[shape=box, color=black, style=filled, fillcolor=khaki1, label="IM:nrmShrForDen"];
-	theory:intsliceFsRC	[shape=box, color=black, style=filled, fillcolor=khaki1, label="IM:intsliceFs"];
-	theory:crtSlpIdIM	[shape=box, color=black, style=filled, fillcolor=khaki1, label="IM:crtSlpId"];
-
-	subgraph IM {
-	rank="same"
-	{theory:FS, theory:nrmShrForIM, theory:nrmShrForNumRC, theory:nrmShrForDenRC, theory:intsliceFsRC, theory:crtSlpIdIM}
-	}
-
+digraph "refvsref" {
+    "dataDefn:l_b,i" -> "dataDefn:alpha_i";
+    "dataDefn:l_b,i" -> "dataDefn:b_i";
+    "dataDefn:l_s,i" -> "dataDefn:beta_i";
+    "dataDefn:l_s,i" -> "dataDefn:b_i";
+    "dataDefn:h_i" -> "dataDefn:h^R";
+    "dataDefn:h_i" -> "dataDefn:h^L";
+    "dataDefn:Phi" -> "dataDefn:alpha_i";
+    "dataDefn:Phi" -> "dataDefn:f_i";
+    "dataDefn:Psi" -> "dataDefn:alpha_i";
+    "dataDefn:Psi" -> "dataDefn:f_i";
+    "dataDefn:Psi" -> "dataDefn:Phi";
+    "theory:effectiveStressTM" -> "dataDefn:sigma";
+    "theory:normForcEq" -> "dataDefn:alpha_i";
+    "theory:normForcEq" -> "dataDefn:beta_i";
+    "theory:normForcEq" -> "theory:equilibriumCS";
+    "theory:normForcEq" -> "theory:sliceWght";
+    "theory:normForcEq" -> "theory:srfWtrF";
+    "theory:bsShrFEq" -> "dataDefn:alpha_i";
+    "theory:bsShrFEq" -> "dataDefn:beta_i";
+    "theory:bsShrFEq" -> "theory:equilibriumCS";
+    "theory:bsShrFEq" -> "theory:sliceWght";
+    "theory:bsShrFEq" -> "theory:srfWtrF";
+    "theory:resShr" -> "dataDefn:l_b,i";
+    "theory:resShr" -> "dataDefn:sigma";
+    "theory:resShr" -> "dataDefn:tau";
+    "theory:resShr" -> "theory:mcShrSrgth";
+    "theory:mobShr" -> "dataDefn:l_b,i";
+    "theory:mobShr" -> "theory:factOfSafetyTM";
+    "theory:mobShr" -> "theory:resShr";
+    "theory:effNormF" -> "dataDefn:sigma";
+    "theory:effNormF" -> "theory:effectiveStressTM";
+    "theory:effNormF" -> "theory:baseWtrF";
+    "theory:resShearWO" -> "dataDefn:H_i";
+    "theory:resShearWO" -> "dataDefn:alpha_i";
+    "theory:resShearWO" -> "dataDefn:beta_i";
+    "theory:resShearWO" -> "dataDefn:l_b,i";
+    "theory:resShearWO" -> "theory:sliceWght";
+    "theory:resShearWO" -> "theory:baseWtrF";
+    "theory:resShearWO" -> "theory:srfWtrF";
+    "theory:mobShearWO" -> "dataDefn:H_i";
+    "theory:mobShearWO" -> "dataDefn:alpha_i";
+    "theory:mobShearWO" -> "dataDefn:beta_i";
+    "theory:mobShearWO" -> "theory:sliceWght";
+    "theory:mobShearWO" -> "theory:srfWtrF";
+    "theory:X_i" -> "dataDefn:f_i";
+    "theory:momentEql" -> "dataDefn:alpha_i";
+    "theory:momentEql" -> "dataDefn:beta_i";
+    "theory:momentEql" -> "dataDefn:b_i";
+    "theory:momentEql" -> "dataDefn:h_i";
+    "theory:momentEql" -> "dataDefn:torque";
+    "theory:momentEql" -> "theory:equilibriumCS";
+    "theory:momentEql" -> "theory:weight";
+    "theory:momentEql" -> "theory:sliceWght";
+    "theory:momentEql" -> "theory:srfWtrF";
+    "theory:weight" -> "theory:newtonSL";
+    "theory:sliceWght" -> "dataDefn:b_i";
+    "theory:sliceWght" -> "theory:weight";
+    "theory:baseWtrF" -> "dataDefn:l_b,i";
+    "theory:baseWtrF" -> "theory:pressure";
+    "theory:baseWtrF" -> "theory:baseWtrF";
+    "theory:srfWtrF" -> "dataDefn:l_s,i";
+    "theory:srfWtrF" -> "theory:pressure";
+    "theory:srfWtrF" -> "theory:srfWtrF";
+    "theory:FS" -> "dataDefn:Phi";
+    "theory:FS" -> "dataDefn:Psi";
+    "theory:FS" -> "theory:normForcEq";
+    "theory:FS" -> "theory:bsShrFEq";
+    "theory:FS" -> "theory:mobShr";
+    "theory:FS" -> "theory:resShearWO";
+    "theory:FS" -> "theory:mobShearWO";
+    "theory:FS" -> "theory:X_i";
+    "theory:FS" -> "theory:FS";
+    "theory:FS" -> "theory:nrmShrForIM";
+    "theory:FS" -> "theory:intsliceFsRC";
+    "theory:nrmShrForIM" -> "theory:X_i";
+    "theory:nrmShrForIM" -> "theory:momentEql";
+    "theory:nrmShrForIM" -> "theory:FS";
+    "theory:nrmShrForIM" -> "theory:nrmShrForIM";
+    "theory:nrmShrForIM" -> "theory:nrmShrForNumRC";
+    "theory:nrmShrForIM" -> "theory:nrmShrForDenRC";
+    "theory:nrmShrForIM" -> "theory:intsliceFsRC";
+    "theory:nrmShrForNumRC" -> "dataDefn:H_i";
+    "theory:nrmShrForNumRC" -> "dataDefn:alpha_i";
+    "theory:nrmShrForNumRC" -> "dataDefn:beta_i";
+    "theory:nrmShrForNumRC" -> "dataDefn:b_i";
+    "theory:nrmShrForNumRC" -> "dataDefn:h_i";
+    "theory:nrmShrForNumRC" -> "theory:srfWtrF";
+    "theory:nrmShrForNumRC" -> "theory:nrmShrForIM";
+    "theory:nrmShrForDenRC" -> "dataDefn:b_i";
+    "theory:nrmShrForDenRC" -> "dataDefn:f_i";
+    "theory:nrmShrForDenRC" -> "theory:nrmShrForIM";
+    "theory:intsliceFsRC" -> "dataDefn:Phi";
+    "theory:intsliceFsRC" -> "dataDefn:Psi";
+    "theory:intsliceFsRC" -> "theory:resShearWO";
+    "theory:intsliceFsRC" -> "theory:mobShearWO";
+    "theory:intsliceFsRC" -> "theory:FS";
+    "theory:intsliceFsRC" -> "theory:nrmShrForIM";
+    "theory:intsliceFsRC" -> "theory:intsliceFsRC";
+    "dataDefn:H_i" [shape=box, color=black, style=filled, fillcolor="paleturquoise1", label="DD:intersliceWtrF"];
+    "dataDefn:alpha_i" [shape=box, color=black, style=filled, fillcolor="paleturquoise1", label="DD:angleA"];
+    "dataDefn:beta_i" [shape=box, color=black, style=filled, fillcolor="paleturquoise1", label="DD:angleB"];
+    "dataDefn:b_i" [shape=box, color=black, style=filled, fillcolor="paleturquoise1", label="DD:lengthB"];
+    "dataDefn:l_b,i" [shape=box, color=black, style=filled, fillcolor="paleturquoise1", label="DD:lengthLb"];
+    "dataDefn:l_s,i" [shape=box, color=black, style=filled, fillcolor="paleturquoise1", label="DD:lengthLs"];
+    "dataDefn:h_i" [shape=box, color=black, style=filled, fillcolor="paleturquoise1", label="DD:slcHeight"];
+    "dataDefn:sigma" [shape=box, color=black, style=filled, fillcolor="paleturquoise1", label="DD:normStress"];
+    "dataDefn:tau" [shape=box, color=black, style=filled, fillcolor="paleturquoise1", label="DD:tangStress"];
+    "dataDefn:torque" [shape=box, color=black, style=filled, fillcolor="paleturquoise1", label="DD:torque"];
+    "dataDefn:f_i" [shape=box, color=black, style=filled, fillcolor="paleturquoise1", label="DD:ratioVariation"];
+    "dataDefn:Phi" [shape=box, color=black, style=filled, fillcolor="paleturquoise1", label="DD:convertFunc1"];
+    "dataDefn:Psi" [shape=box, color=black, style=filled, fillcolor="paleturquoise1", label="DD:convertFunc2"];
+    "dataDefn:F_x^G" [shape=box, color=black, style=filled, fillcolor="paleturquoise1", label="DD:nrmForceSumDD"];
+    "dataDefn:F_x^H" [shape=box, color=black, style=filled, fillcolor="paleturquoise1", label="DD:watForceSumDD"];
+    "dataDefn:h^R" [shape=box, color=black, style=filled, fillcolor="paleturquoise1", label="DD:sliceHghtRightDD"];
+    "dataDefn:h^L" [shape=box, color=black, style=filled, fillcolor="paleturquoise1", label="DD:sliceHghtLeftDD"];
+    subgraph "DD" {
+        rank="same";
+        "dataDefn:H_i" "dataDefn:alpha_i" "dataDefn:beta_i" "dataDefn:b_i" "dataDefn:l_b,i" "dataDefn:l_s,i" "dataDefn:h_i" "dataDefn:sigma" "dataDefn:tau" "dataDefn:torque" "dataDefn:f_i" "dataDefn:Phi" "dataDefn:Psi" "dataDefn:F_x^G" "dataDefn:F_x^H" "dataDefn:h^R" "dataDefn:h^L";
+    }
+    "theory:factOfSafetyTM" [shape=box, color=black, style=filled, fillcolor="pink", label="TM:factOfSafety"];
+    "theory:equilibriumCS" [shape=box, color=black, style=filled, fillcolor="pink", label="TM:equilibrium"];
+    "theory:mcShrSrgth" [shape=box, color=black, style=filled, fillcolor="pink", label="TM:mcShrStrgth"];
+    "theory:effectiveStressTM" [shape=box, color=black, style=filled, fillcolor="pink", label="TM:effStress"];
+    "theory:newtonSL" [shape=box, color=black, style=filled, fillcolor="pink", label="TM:NewtonSecLawMot"];
+    subgraph "TM" {
+        rank="same";
+        "theory:factOfSafetyTM" "theory:equilibriumCS" "theory:mcShrSrgth" "theory:effectiveStressTM" "theory:newtonSL";
+    }
+    "theory:normForcEq" [shape=box, color=black, style=filled, fillcolor="palegreen", label="GD:normForcEq"];
+    "theory:bsShrFEq" [shape=box, color=black, style=filled, fillcolor="palegreen", label="GD:bsShrFEq"];
+    "theory:resShr" [shape=box, color=black, style=filled, fillcolor="palegreen", label="GD:resShr"];
+    "theory:mobShr" [shape=box, color=black, style=filled, fillcolor="palegreen", label="GD:mobShr"];
+    "theory:effNormF" [shape=box, color=black, style=filled, fillcolor="palegreen", label="GD:effNormF"];
+    "theory:resShearWO" [shape=box, color=black, style=filled, fillcolor="palegreen", label="GD:resShearWO"];
+    "theory:mobShearWO" [shape=box, color=black, style=filled, fillcolor="palegreen", label="GD:mobShearWO"];
+    "theory:X_i" [shape=box, color=black, style=filled, fillcolor="palegreen", label="GD:normShrR"];
+    "theory:momentEql" [shape=box, color=black, style=filled, fillcolor="palegreen", label="GD:momentEql"];
+    "theory:weight" [shape=box, color=black, style=filled, fillcolor="palegreen", label="GD:weight"];
+    "theory:sliceWght" [shape=box, color=black, style=filled, fillcolor="palegreen", label="GD:sliceWght"];
+    "theory:pressure" [shape=box, color=black, style=filled, fillcolor="palegreen", label="GD:hsPressure"];
+    "theory:baseWtrF" [shape=box, color=black, style=filled, fillcolor="palegreen", label="GD:baseWtrF"];
+    "theory:srfWtrF" [shape=box, color=black, style=filled, fillcolor="palegreen", label="GD:srfWtrF"];
+    subgraph "GD" {
+        rank="same";
+        "theory:normForcEq" "theory:bsShrFEq" "theory:resShr" "theory:mobShr" "theory:effNormF" "theory:resShearWO" "theory:mobShearWO" "theory:X_i" "theory:momentEql" "theory:weight" "theory:sliceWght" "theory:pressure" "theory:baseWtrF" "theory:srfWtrF";
+    }
+    "theory:FS" [shape=box, color=black, style=filled, fillcolor="khaki1", label="IM:fctSfty"];
+    "theory:nrmShrForIM" [shape=box, color=black, style=filled, fillcolor="khaki1", label="IM:nrmShrFor"];
+    "theory:nrmShrForNumRC" [shape=box, color=black, style=filled, fillcolor="khaki1", label="IM:nrmShrForNum"];
+    "theory:nrmShrForDenRC" [shape=box, color=black, style=filled, fillcolor="khaki1", label="IM:nrmShrForDen"];
+    "theory:intsliceFsRC" [shape=box, color=black, style=filled, fillcolor="khaki1", label="IM:intsliceFs"];
+    "theory:crtSlpIdIM" [shape=box, color=black, style=filled, fillcolor="khaki1", label="IM:crtSlpId"];
+    subgraph "IM" {
+        rank="same";
+        "theory:FS" "theory:nrmShrForIM" "theory:nrmShrForNumRC" "theory:nrmShrForDenRC" "theory:intsliceFsRC" "theory:crtSlpIdIM";
+    }
 }

--- a/code/stable/swhs/TraceyGraph/allvsall.dot
+++ b/code/stable/swhs/TraceyGraph/allvsall.dot
@@ -1,215 +1,197 @@
-digraph allvsall {
-	instance:assumpCTNOD -> instance:assumpSITWP;
-	dataDefn:wVol -> instance:assumpVCN;
-	dataDefn:wVol -> dataDefn:tankVol;
-	dataDefn:meltFrac -> dataDefn:htFusion;
-	theory:consThermECS -> instance:assumpTEO;
-	theory:sensHeat -> theory:latentHtETM;
-	theory:latentHtETM -> dataDefn:meltFrac;
-	theory:nwtnCoolingTM -> instance:assumpHTCC;
-	theory:rocTempSimpRC -> instance:assumpCWTAT;
-	theory:rocTempSimpRC -> instance:assumpTPCAV;
-	theory:rocTempSimpRC -> instance:assumpDWPCoV;
-	theory:rocTempSimpRC -> instance:assumpSHECov;
-	theory:rocTempSimpRC -> theory:consThermECS;
-	theory:rocTempSimpRC -> theory:rocTempSimpRC;
-	theory:htFluxC -> instance:assumpLCCCW;
-	theory:htFluxC -> instance:assumpTHCCoT;
-	theory:htFluxC -> theory:nwtnCoolingTM;
-	theory:htFluxP -> instance:assumpLCCWP;
-	theory:htFluxP -> theory:nwtnCoolingTM;
-	theory:eBalanceOnWtrRC -> instance:assumpCWTAT;
-	theory:eBalanceOnWtrRC -> instance:assumpTPCAV;
-	theory:eBalanceOnWtrRC -> instance:assumpTHCCoL;
-	theory:eBalanceOnWtrRC -> instance:assumpCTNOD;
-	theory:eBalanceOnWtrRC -> instance:assumpSITWP;
-	theory:eBalanceOnWtrRC -> instance:assumpWAL;
-	theory:eBalanceOnWtrRC -> instance:assumpPIT;
-	theory:eBalanceOnWtrRC -> instance:assumpNIHGBWP;
-	theory:eBalanceOnWtrRC -> instance:assumpAPT;
-	theory:eBalanceOnWtrRC -> dataDefn:tauW;
-	theory:eBalanceOnWtrRC -> dataDefn:eta;
-	theory:eBalanceOnWtrRC -> theory:rocTempSimpRC;
-	theory:eBalanceOnWtrRC -> theory:htFluxC;
-	theory:eBalanceOnWtrRC -> theory:htFluxP;
-	theory:eBalanceOnWtrRC -> theory:eBalanceOnWtrRC;
-	theory:eBalanceOnWtrRC -> theory:eBalanceOnPCMRC;
-	theory:eBalanceOnPCMRC -> instance:assumpCWTAT;
-	theory:eBalanceOnPCMRC -> instance:assumpTPCAV;
-	theory:eBalanceOnPCMRC -> instance:assumpSITWP;
-	theory:eBalanceOnPCMRC -> instance:assumpPIS;
-	theory:eBalanceOnPCMRC -> instance:assumpNIHGBWP;
-	theory:eBalanceOnPCMRC -> instance:assumpVCMPN;
-	theory:eBalanceOnPCMRC -> instance:assumpNGSP;
-	theory:eBalanceOnPCMRC -> dataDefn:tauSP;
-	theory:eBalanceOnPCMRC -> dataDefn:tauLP;
-	theory:eBalanceOnPCMRC -> dataDefn:meltFrac;
-	theory:eBalanceOnPCMRC -> theory:rocTempSimpRC;
-	theory:eBalanceOnPCMRC -> theory:htFluxP;
-	theory:eBalanceOnPCMRC -> theory:eBalanceOnWtrRC;
-	theory:eBalanceOnPCMRC -> theory:heatEInPCMRC;
-	theory:heatEInWtrIM -> instance:assumpWAL;
-	theory:heatEInWtrIM -> instance:assumpAPT;
-	theory:heatEInWtrIM -> theory:sensHeat;
-	theory:heatEInPCMRC -> instance:assumpPIS;
-	theory:heatEInPCMRC -> instance:assumpNGSP;
-	theory:heatEInPCMRC -> dataDefn:htFusion;
-	theory:heatEInPCMRC -> theory:sensHeat;
-	theory:heatEInPCMRC -> theory:latentHtETM;
-	instance:findMass -> dataDefn:wMass;
-	instance:findMass -> dataDefn:wVol;
-	instance:findMass -> dataDefn:tankVol;
-	instance:findMass -> theory:eBalanceOnWtrRC;
-	instance:findMass -> theory:eBalanceOnPCMRC;
-	instance:findMass -> theory:heatEInWtrIM;
-	instance:findMass -> theory:heatEInPCMRC;
-	instance:findMass -> instance:inputValues;
-	instance:outputInputDerivVals -> dataDefn:tauW;
-	instance:outputInputDerivVals -> dataDefn:eta;
-	instance:outputInputDerivVals -> dataDefn:tauSP;
-	instance:outputInputDerivVals -> dataDefn:tauLP;
-	instance:outputInputDerivVals -> instance:inputValues;
-	instance:outputInputDerivVals -> instance:findMass;
-	instance:calcValues -> theory:eBalanceOnWtrRC;
-	instance:calcValues -> theory:eBalanceOnPCMRC;
-	instance:calcValues -> theory:heatEInWtrIM;
-	instance:calcValues -> theory:heatEInPCMRC;
-	instance:calcPCMMeltBegin -> theory:eBalanceOnPCMRC;
-	instance:calcPCMMeltEnd -> theory:eBalanceOnPCMRC;
-	instance:outputValues -> theory:eBalanceOnWtrRC;
-	instance:outputValues -> theory:eBalanceOnPCMRC;
-	instance:outputValues -> theory:heatEInWtrIM;
-	instance:outputValues -> theory:heatEInPCMRC;
-	instance:likeChgUTP -> instance:assumpTPCAV;
-	instance:likeChgTCVOD -> instance:assumpTHCCoT;
-	instance:likeChgTCVOL -> instance:assumpTHCCoL;
-	instance:likeChgDT -> instance:assumpCTNOD;
-	instance:likeChgDITPW -> instance:assumpSITWP;
-	instance:likeChgTLH -> instance:assumpPIT;
-	instance:unlikeChgWPFS -> instance:assumpWAL;
-	instance:unlikeChgWPFS -> instance:assumpNGSP;
-	instance:unlikeChgNIHG -> instance:assumpNIHGBWP;
-	instance:unlikeChgNIHG -> theory:eBalanceOnWtrRC;
-	instance:unlikeChgNIHG -> theory:eBalanceOnPCMRC;
-	instance:unlikeChgNGS -> instance:assumpNGSP;
-	instance:unlikeChgNGS -> theory:eBalanceOnPCMRC;
-	instance:unlikeChgNGS -> theory:heatEInPCMRC;
-
-
-	instance:assumpTEO	[shape=box, color=black, style=filled, fillcolor=mistyrose, label="A:assumpTEO"];
-	instance:assumpHTCC	[shape=box, color=black, style=filled, fillcolor=mistyrose, label="A:assumpHTCC"];
-	instance:assumpCWTAT	[shape=box, color=black, style=filled, fillcolor=mistyrose, label="A:assumpCWTAT"];
-	instance:assumpTPCAV	[shape=box, color=black, style=filled, fillcolor=mistyrose, label="A:assumpTPCAV"];
-	instance:assumpDWPCoV	[shape=box, color=black, style=filled, fillcolor=mistyrose, label="A:assumpDWPCoV"];
-	instance:assumpSHECov	[shape=box, color=black, style=filled, fillcolor=mistyrose, label="A:assumpSHECov"];
-	instance:assumpLCCCW	[shape=box, color=black, style=filled, fillcolor=mistyrose, label="A:assumpLCCCW"];
-	instance:assumpTHCCoT	[shape=box, color=black, style=filled, fillcolor=mistyrose, label="A:assumpTHCCoT"];
-	instance:assumpTHCCoL	[shape=box, color=black, style=filled, fillcolor=mistyrose, label="A:assumpTHCCoL"];
-	instance:assumpLCCWP	[shape=box, color=black, style=filled, fillcolor=mistyrose, label="A:assumpLCCWP"];
-	instance:assumpCTNOD	[shape=box, color=black, style=filled, fillcolor=mistyrose, label="A:assumpCTNOD"];
-	instance:assumpSITWP	[shape=box, color=black, style=filled, fillcolor=mistyrose, label="A:assumpSITWP"];
-	instance:assumpPIS	[shape=box, color=black, style=filled, fillcolor=mistyrose, label="A:assumpPIS"];
-	instance:assumpWAL	[shape=box, color=black, style=filled, fillcolor=mistyrose, label="A:assumpWAL"];
-	instance:assumpPIT	[shape=box, color=black, style=filled, fillcolor=mistyrose, label="A:assumpPIT"];
-	instance:assumpNIHGBWP	[shape=box, color=black, style=filled, fillcolor=mistyrose, label="A:assumpNIHGBWP"];
-	instance:assumpVCMPN	[shape=box, color=black, style=filled, fillcolor=mistyrose, label="A:assumpVCMPN"];
-	instance:assumpNGSP	[shape=box, color=black, style=filled, fillcolor=mistyrose, label="A:assumpNGSP"];
-	instance:assumpAPT	[shape=box, color=black, style=filled, fillcolor=mistyrose, label="A:assumpAPT"];
-	instance:assumpVCN	[shape=box, color=black, style=filled, fillcolor=mistyrose, label="A:assumpVCN"];
-
-	subgraph A {
-	rank="same"
-	{instance:assumpTEO, instance:assumpHTCC, instance:assumpCWTAT, instance:assumpTPCAV, instance:assumpDWPCoV, instance:assumpSHECov, instance:assumpLCCCW, instance:assumpTHCCoT, instance:assumpTHCCoL, instance:assumpLCCWP, instance:assumpCTNOD, instance:assumpSITWP, instance:assumpPIS, instance:assumpWAL, instance:assumpPIT, instance:assumpNIHGBWP, instance:assumpVCMPN, instance:assumpNGSP, instance:assumpAPT, instance:assumpVCN}
-	}
-
-	dataDefn:wMass	[shape=box, color=black, style=filled, fillcolor=paleturquoise1, label="DD:waterMass"];
-	dataDefn:wVol	[shape=box, color=black, style=filled, fillcolor=paleturquoise1, label="DD:waterVolume.pcm"];
-	dataDefn:tankVol	[shape=box, color=black, style=filled, fillcolor=paleturquoise1, label="DD:tankVolume"];
-	dataDefn:tauW	[shape=box, color=black, style=filled, fillcolor=paleturquoise1, label="DD:balanceDecayRate"];
-	dataDefn:eta	[shape=box, color=black, style=filled, fillcolor=paleturquoise1, label="DD:balanceDecayTime"];
-	dataDefn:tauSP	[shape=box, color=black, style=filled, fillcolor=paleturquoise1, label="DD:balanceSolidPCM"];
-	dataDefn:tauLP	[shape=box, color=black, style=filled, fillcolor=paleturquoise1, label="DD:balanceLiquidPCM"];
-	dataDefn:htFusion	[shape=box, color=black, style=filled, fillcolor=paleturquoise1, label="DD:htFusion"];
-	dataDefn:meltFrac	[shape=box, color=black, style=filled, fillcolor=paleturquoise1, label="DD:meltFrac"];
-	dataDefn:aspectRatio	[shape=box, color=black, style=filled, fillcolor=paleturquoise1, label="DD:aspectRatio"];
-
-	subgraph DD {
-	rank="same"
-	{dataDefn:wMass, dataDefn:wVol, dataDefn:tankVol, dataDefn:tauW, dataDefn:eta, dataDefn:tauSP, dataDefn:tauLP, dataDefn:htFusion, dataDefn:meltFrac, dataDefn:aspectRatio}
-	}
-
-	theory:consThermECS	[shape=box, color=black, style=filled, fillcolor=pink, label="TM:consThermE"];
-	theory:sensHeat	[shape=box, color=black, style=filled, fillcolor=pink, label="TM:sensHtE"];
-	theory:latentHtETM	[shape=box, color=black, style=filled, fillcolor=pink, label="TM:latentHtE"];
-	theory:nwtnCoolingTM	[shape=box, color=black, style=filled, fillcolor=pink, label="TM:nwtnCooling"];
-
-	subgraph TM {
-	rank="same"
-	{theory:consThermECS, theory:sensHeat, theory:latentHtETM, theory:nwtnCoolingTM}
-	}
-
-	theory:rocTempSimpRC	[shape=box, color=black, style=filled, fillcolor=palegreen, label="GD:rocTempSimp"];
-	theory:htFluxC	[shape=box, color=black, style=filled, fillcolor=palegreen, label="GD:htFluxWaterFromCoil"];
-	theory:htFluxP	[shape=box, color=black, style=filled, fillcolor=palegreen, label="GD:htFluxPCMFromWater"];
-
-	subgraph GD {
-	rank="same"
-	{theory:rocTempSimpRC, theory:htFluxC, theory:htFluxP}
-	}
-
-	theory:eBalanceOnWtrRC	[shape=box, color=black, style=filled, fillcolor=khaki1, label="IM:eBalanceOnWtr"];
-	theory:eBalanceOnPCMRC	[shape=box, color=black, style=filled, fillcolor=khaki1, label="IM:eBalanceOnPCM"];
-	theory:heatEInWtrIM	[shape=box, color=black, style=filled, fillcolor=khaki1, label="IM:heatEInWtr"];
-	theory:heatEInPCMRC	[shape=box, color=black, style=filled, fillcolor=khaki1, label="IM:heatEInPCM"];
-
-	subgraph IM {
-	rank="same"
-	{theory:eBalanceOnWtrRC, theory:eBalanceOnPCMRC, theory:heatEInWtrIM, theory:heatEInPCMRC}
-	}
-
-	instance:inputValues	[shape=box, color=black, style=filled, fillcolor=ivory, label="FR:inputValues"];
-	instance:findMass	[shape=box, color=black, style=filled, fillcolor=ivory, label="FR:findMass"];
-	instance:checkWithPhysConsts	[shape=box, color=black, style=filled, fillcolor=ivory, label="FR:checkWithPhysConsts"];
-	instance:outputInputDerivVals	[shape=box, color=black, style=filled, fillcolor=ivory, label="FR:outputInputDerivVals"];
-	instance:calcValues	[shape=box, color=black, style=filled, fillcolor=ivory, label="FR:calcValues"];
-	instance:verifyEnergyOutput	[shape=box, color=black, style=filled, fillcolor=ivory, label="FR:verifyEnergyOutput"];
-	instance:calcPCMMeltBegin	[shape=box, color=black, style=filled, fillcolor=ivory, label="FR:calcPCMMeltBegin"];
-	instance:calcPCMMeltEnd	[shape=box, color=black, style=filled, fillcolor=ivory, label="FR:calcPCMMeltEnd"];
-	instance:outputValues	[shape=box, color=black, style=filled, fillcolor=ivory, label="FR:outputValues"];
-	instance:correct	[shape=box, color=black, style=filled, fillcolor=ivory, label="NFR:correct"];
-	instance:verifiable	[shape=box, color=black, style=filled, fillcolor=ivory, label="NFR:verifiable"];
-	instance:understandable	[shape=box, color=black, style=filled, fillcolor=ivory, label="NFR:understandable"];
-	instance:reusable	[shape=box, color=black, style=filled, fillcolor=ivory, label="NFR:reusable"];
-	instance:maintainable	[shape=box, color=black, style=filled, fillcolor=ivory, label="NFR:maintainable"];
-
-	subgraph FR {
-	rank="same"
-	{instance:inputValues, instance:findMass, instance:checkWithPhysConsts, instance:outputInputDerivVals, instance:calcValues, instance:verifyEnergyOutput, instance:calcPCMMeltBegin, instance:calcPCMMeltEnd, instance:outputValues, instance:correct, instance:verifiable, instance:understandable, instance:reusable, instance:maintainable}
-	}
-
-	instance:waterTempGS	[shape=box, color=black, style=filled, fillcolor=darkgoldenrod1, label="GS:waterTempGS"];
-	instance:pcmTempGS	[shape=box, color=black, style=filled, fillcolor=darkgoldenrod1, label="GS:pcmTempGS"];
-	instance:waterEnergyGS	[shape=box, color=black, style=filled, fillcolor=darkgoldenrod1, label="GS:waterEnergyGS"];
-	instance:pcmEnergyGS	[shape=box, color=black, style=filled, fillcolor=darkgoldenrod1, label="GS:pcmEnergyGS"];
-
-	subgraph GS {
-	rank="same"
-	{instance:waterTempGS, instance:pcmTempGS, instance:waterEnergyGS, instance:pcmEnergyGS}
-	}
-
-	instance:likeChgUTP	[shape=box, color=black, style=filled, fillcolor=lavender, label="LC:likeChgUTP"];
-	instance:likeChgTCVOD	[shape=box, color=black, style=filled, fillcolor=lavender, label="LC:likeChgTCVOD"];
-	instance:likeChgTCVOL	[shape=box, color=black, style=filled, fillcolor=lavender, label="LC:likeChgTCVOL"];
-	instance:likeChgDT	[shape=box, color=black, style=filled, fillcolor=lavender, label="LC:likeChgDT"];
-	instance:likeChgDITPW	[shape=box, color=black, style=filled, fillcolor=lavender, label="LC:likeChgDITPW"];
-	instance:likeChgTLH	[shape=box, color=black, style=filled, fillcolor=lavender, label="LC:likeChgTLH"];
-	instance:unlikeChgWPFS	[shape=box, color=black, style=filled, fillcolor=lavender, label="UC:unlikeChgWPFS"];
-	instance:unlikeChgNIHG	[shape=box, color=black, style=filled, fillcolor=lavender, label="UC:unlikeChgNIHG"];
-	instance:unlikeChgNGS	[shape=box, color=black, style=filled, fillcolor=lavender, label="UC:unlikeChgNGS"];
-
-	subgraph LC {
-	rank="same"
-	{instance:likeChgUTP, instance:likeChgTCVOD, instance:likeChgTCVOL, instance:likeChgDT, instance:likeChgDITPW, instance:likeChgTLH, instance:unlikeChgWPFS, instance:unlikeChgNIHG, instance:unlikeChgNGS}
-	}
-
+digraph "allvsall" {
+    "instance:assumpCTNOD" -> "instance:assumpSITWP";
+    "dataDefn:wVol" -> "instance:assumpVCN";
+    "dataDefn:wVol" -> "dataDefn:tankVol";
+    "dataDefn:meltFrac" -> "dataDefn:htFusion";
+    "theory:consThermECS" -> "instance:assumpTEO";
+    "theory:sensHeat" -> "theory:latentHtETM";
+    "theory:latentHtETM" -> "dataDefn:meltFrac";
+    "theory:nwtnCoolingTM" -> "instance:assumpHTCC";
+    "theory:rocTempSimpRC" -> "instance:assumpCWTAT";
+    "theory:rocTempSimpRC" -> "instance:assumpTPCAV";
+    "theory:rocTempSimpRC" -> "instance:assumpDWPCoV";
+    "theory:rocTempSimpRC" -> "instance:assumpSHECov";
+    "theory:rocTempSimpRC" -> "theory:consThermECS";
+    "theory:rocTempSimpRC" -> "theory:rocTempSimpRC";
+    "theory:htFluxC" -> "instance:assumpLCCCW";
+    "theory:htFluxC" -> "instance:assumpTHCCoT";
+    "theory:htFluxC" -> "theory:nwtnCoolingTM";
+    "theory:htFluxP" -> "instance:assumpLCCWP";
+    "theory:htFluxP" -> "theory:nwtnCoolingTM";
+    "theory:eBalanceOnWtrRC" -> "instance:assumpCWTAT";
+    "theory:eBalanceOnWtrRC" -> "instance:assumpTPCAV";
+    "theory:eBalanceOnWtrRC" -> "instance:assumpTHCCoL";
+    "theory:eBalanceOnWtrRC" -> "instance:assumpCTNOD";
+    "theory:eBalanceOnWtrRC" -> "instance:assumpSITWP";
+    "theory:eBalanceOnWtrRC" -> "instance:assumpWAL";
+    "theory:eBalanceOnWtrRC" -> "instance:assumpPIT";
+    "theory:eBalanceOnWtrRC" -> "instance:assumpNIHGBWP";
+    "theory:eBalanceOnWtrRC" -> "instance:assumpAPT";
+    "theory:eBalanceOnWtrRC" -> "dataDefn:tauW";
+    "theory:eBalanceOnWtrRC" -> "dataDefn:eta";
+    "theory:eBalanceOnWtrRC" -> "theory:rocTempSimpRC";
+    "theory:eBalanceOnWtrRC" -> "theory:htFluxC";
+    "theory:eBalanceOnWtrRC" -> "theory:htFluxP";
+    "theory:eBalanceOnWtrRC" -> "theory:eBalanceOnWtrRC";
+    "theory:eBalanceOnWtrRC" -> "theory:eBalanceOnPCMRC";
+    "theory:eBalanceOnPCMRC" -> "instance:assumpCWTAT";
+    "theory:eBalanceOnPCMRC" -> "instance:assumpTPCAV";
+    "theory:eBalanceOnPCMRC" -> "instance:assumpSITWP";
+    "theory:eBalanceOnPCMRC" -> "instance:assumpPIS";
+    "theory:eBalanceOnPCMRC" -> "instance:assumpNIHGBWP";
+    "theory:eBalanceOnPCMRC" -> "instance:assumpVCMPN";
+    "theory:eBalanceOnPCMRC" -> "instance:assumpNGSP";
+    "theory:eBalanceOnPCMRC" -> "dataDefn:tauSP";
+    "theory:eBalanceOnPCMRC" -> "dataDefn:tauLP";
+    "theory:eBalanceOnPCMRC" -> "dataDefn:meltFrac";
+    "theory:eBalanceOnPCMRC" -> "theory:rocTempSimpRC";
+    "theory:eBalanceOnPCMRC" -> "theory:htFluxP";
+    "theory:eBalanceOnPCMRC" -> "theory:eBalanceOnWtrRC";
+    "theory:eBalanceOnPCMRC" -> "theory:heatEInPCMRC";
+    "theory:heatEInWtrIM" -> "instance:assumpWAL";
+    "theory:heatEInWtrIM" -> "instance:assumpAPT";
+    "theory:heatEInWtrIM" -> "theory:sensHeat";
+    "theory:heatEInPCMRC" -> "instance:assumpPIS";
+    "theory:heatEInPCMRC" -> "instance:assumpNGSP";
+    "theory:heatEInPCMRC" -> "dataDefn:htFusion";
+    "theory:heatEInPCMRC" -> "theory:sensHeat";
+    "theory:heatEInPCMRC" -> "theory:latentHtETM";
+    "instance:findMass" -> "dataDefn:wMass";
+    "instance:findMass" -> "dataDefn:wVol";
+    "instance:findMass" -> "dataDefn:tankVol";
+    "instance:findMass" -> "theory:eBalanceOnWtrRC";
+    "instance:findMass" -> "theory:eBalanceOnPCMRC";
+    "instance:findMass" -> "theory:heatEInWtrIM";
+    "instance:findMass" -> "theory:heatEInPCMRC";
+    "instance:findMass" -> "instance:inputValues";
+    "instance:outputInputDerivVals" -> "dataDefn:tauW";
+    "instance:outputInputDerivVals" -> "dataDefn:eta";
+    "instance:outputInputDerivVals" -> "dataDefn:tauSP";
+    "instance:outputInputDerivVals" -> "dataDefn:tauLP";
+    "instance:outputInputDerivVals" -> "instance:inputValues";
+    "instance:outputInputDerivVals" -> "instance:findMass";
+    "instance:calcValues" -> "theory:eBalanceOnWtrRC";
+    "instance:calcValues" -> "theory:eBalanceOnPCMRC";
+    "instance:calcValues" -> "theory:heatEInWtrIM";
+    "instance:calcValues" -> "theory:heatEInPCMRC";
+    "instance:calcPCMMeltBegin" -> "theory:eBalanceOnPCMRC";
+    "instance:calcPCMMeltEnd" -> "theory:eBalanceOnPCMRC";
+    "instance:outputValues" -> "theory:eBalanceOnWtrRC";
+    "instance:outputValues" -> "theory:eBalanceOnPCMRC";
+    "instance:outputValues" -> "theory:heatEInWtrIM";
+    "instance:outputValues" -> "theory:heatEInPCMRC";
+    "instance:likeChgUTP" -> "instance:assumpTPCAV";
+    "instance:likeChgTCVOD" -> "instance:assumpTHCCoT";
+    "instance:likeChgTCVOL" -> "instance:assumpTHCCoL";
+    "instance:likeChgDT" -> "instance:assumpCTNOD";
+    "instance:likeChgDITPW" -> "instance:assumpSITWP";
+    "instance:likeChgTLH" -> "instance:assumpPIT";
+    "instance:unlikeChgWPFS" -> "instance:assumpWAL";
+    "instance:unlikeChgWPFS" -> "instance:assumpNGSP";
+    "instance:unlikeChgNIHG" -> "instance:assumpNIHGBWP";
+    "instance:unlikeChgNIHG" -> "theory:eBalanceOnWtrRC";
+    "instance:unlikeChgNIHG" -> "theory:eBalanceOnPCMRC";
+    "instance:unlikeChgNGS" -> "instance:assumpNGSP";
+    "instance:unlikeChgNGS" -> "theory:eBalanceOnPCMRC";
+    "instance:unlikeChgNGS" -> "theory:heatEInPCMRC";
+    "instance:assumpTEO" [shape=box, color=black, style=filled, fillcolor="mistyrose", label="A:assumpTEO"];
+    "instance:assumpHTCC" [shape=box, color=black, style=filled, fillcolor="mistyrose", label="A:assumpHTCC"];
+    "instance:assumpCWTAT" [shape=box, color=black, style=filled, fillcolor="mistyrose", label="A:assumpCWTAT"];
+    "instance:assumpTPCAV" [shape=box, color=black, style=filled, fillcolor="mistyrose", label="A:assumpTPCAV"];
+    "instance:assumpDWPCoV" [shape=box, color=black, style=filled, fillcolor="mistyrose", label="A:assumpDWPCoV"];
+    "instance:assumpSHECov" [shape=box, color=black, style=filled, fillcolor="mistyrose", label="A:assumpSHECov"];
+    "instance:assumpLCCCW" [shape=box, color=black, style=filled, fillcolor="mistyrose", label="A:assumpLCCCW"];
+    "instance:assumpTHCCoT" [shape=box, color=black, style=filled, fillcolor="mistyrose", label="A:assumpTHCCoT"];
+    "instance:assumpTHCCoL" [shape=box, color=black, style=filled, fillcolor="mistyrose", label="A:assumpTHCCoL"];
+    "instance:assumpLCCWP" [shape=box, color=black, style=filled, fillcolor="mistyrose", label="A:assumpLCCWP"];
+    "instance:assumpCTNOD" [shape=box, color=black, style=filled, fillcolor="mistyrose", label="A:assumpCTNOD"];
+    "instance:assumpSITWP" [shape=box, color=black, style=filled, fillcolor="mistyrose", label="A:assumpSITWP"];
+    "instance:assumpPIS" [shape=box, color=black, style=filled, fillcolor="mistyrose", label="A:assumpPIS"];
+    "instance:assumpWAL" [shape=box, color=black, style=filled, fillcolor="mistyrose", label="A:assumpWAL"];
+    "instance:assumpPIT" [shape=box, color=black, style=filled, fillcolor="mistyrose", label="A:assumpPIT"];
+    "instance:assumpNIHGBWP" [shape=box, color=black, style=filled, fillcolor="mistyrose", label="A:assumpNIHGBWP"];
+    "instance:assumpVCMPN" [shape=box, color=black, style=filled, fillcolor="mistyrose", label="A:assumpVCMPN"];
+    "instance:assumpNGSP" [shape=box, color=black, style=filled, fillcolor="mistyrose", label="A:assumpNGSP"];
+    "instance:assumpAPT" [shape=box, color=black, style=filled, fillcolor="mistyrose", label="A:assumpAPT"];
+    "instance:assumpVCN" [shape=box, color=black, style=filled, fillcolor="mistyrose", label="A:assumpVCN"];
+    subgraph "A" {
+        rank="same";
+        "instance:assumpTEO" "instance:assumpHTCC" "instance:assumpCWTAT" "instance:assumpTPCAV" "instance:assumpDWPCoV" "instance:assumpSHECov" "instance:assumpLCCCW" "instance:assumpTHCCoT" "instance:assumpTHCCoL" "instance:assumpLCCWP" "instance:assumpCTNOD" "instance:assumpSITWP" "instance:assumpPIS" "instance:assumpWAL" "instance:assumpPIT" "instance:assumpNIHGBWP" "instance:assumpVCMPN" "instance:assumpNGSP" "instance:assumpAPT" "instance:assumpVCN";
+    }
+    "dataDefn:wMass" [shape=box, color=black, style=filled, fillcolor="paleturquoise1", label="DD:waterMass"];
+    "dataDefn:wVol" [shape=box, color=black, style=filled, fillcolor="paleturquoise1", label="DD:waterVolume.pcm"];
+    "dataDefn:tankVol" [shape=box, color=black, style=filled, fillcolor="paleturquoise1", label="DD:tankVolume"];
+    "dataDefn:tauW" [shape=box, color=black, style=filled, fillcolor="paleturquoise1", label="DD:balanceDecayRate"];
+    "dataDefn:eta" [shape=box, color=black, style=filled, fillcolor="paleturquoise1", label="DD:balanceDecayTime"];
+    "dataDefn:tauSP" [shape=box, color=black, style=filled, fillcolor="paleturquoise1", label="DD:balanceSolidPCM"];
+    "dataDefn:tauLP" [shape=box, color=black, style=filled, fillcolor="paleturquoise1", label="DD:balanceLiquidPCM"];
+    "dataDefn:htFusion" [shape=box, color=black, style=filled, fillcolor="paleturquoise1", label="DD:htFusion"];
+    "dataDefn:meltFrac" [shape=box, color=black, style=filled, fillcolor="paleturquoise1", label="DD:meltFrac"];
+    "dataDefn:aspectRatio" [shape=box, color=black, style=filled, fillcolor="paleturquoise1", label="DD:aspectRatio"];
+    subgraph "DD" {
+        rank="same";
+        "dataDefn:wMass" "dataDefn:wVol" "dataDefn:tankVol" "dataDefn:tauW" "dataDefn:eta" "dataDefn:tauSP" "dataDefn:tauLP" "dataDefn:htFusion" "dataDefn:meltFrac" "dataDefn:aspectRatio";
+    }
+    "theory:consThermECS" [shape=box, color=black, style=filled, fillcolor="pink", label="TM:consThermE"];
+    "theory:sensHeat" [shape=box, color=black, style=filled, fillcolor="pink", label="TM:sensHtE"];
+    "theory:latentHtETM" [shape=box, color=black, style=filled, fillcolor="pink", label="TM:latentHtE"];
+    "theory:nwtnCoolingTM" [shape=box, color=black, style=filled, fillcolor="pink", label="TM:nwtnCooling"];
+    subgraph "TM" {
+        rank="same";
+        "theory:consThermECS" "theory:sensHeat" "theory:latentHtETM" "theory:nwtnCoolingTM";
+    }
+    "theory:rocTempSimpRC" [shape=box, color=black, style=filled, fillcolor="palegreen", label="GD:rocTempSimp"];
+    "theory:htFluxC" [shape=box, color=black, style=filled, fillcolor="palegreen", label="GD:htFluxWaterFromCoil"];
+    "theory:htFluxP" [shape=box, color=black, style=filled, fillcolor="palegreen", label="GD:htFluxPCMFromWater"];
+    subgraph "GD" {
+        rank="same";
+        "theory:rocTempSimpRC" "theory:htFluxC" "theory:htFluxP";
+    }
+    "theory:eBalanceOnWtrRC" [shape=box, color=black, style=filled, fillcolor="khaki1", label="IM:eBalanceOnWtr"];
+    "theory:eBalanceOnPCMRC" [shape=box, color=black, style=filled, fillcolor="khaki1", label="IM:eBalanceOnPCM"];
+    "theory:heatEInWtrIM" [shape=box, color=black, style=filled, fillcolor="khaki1", label="IM:heatEInWtr"];
+    "theory:heatEInPCMRC" [shape=box, color=black, style=filled, fillcolor="khaki1", label="IM:heatEInPCM"];
+    subgraph "IM" {
+        rank="same";
+        "theory:eBalanceOnWtrRC" "theory:eBalanceOnPCMRC" "theory:heatEInWtrIM" "theory:heatEInPCMRC";
+    }
+    "instance:inputValues" [shape=box, color=black, style=filled, fillcolor="ivory", label="FR:inputValues"];
+    "instance:findMass" [shape=box, color=black, style=filled, fillcolor="ivory", label="FR:findMass"];
+    "instance:checkWithPhysConsts" [shape=box, color=black, style=filled, fillcolor="ivory", label="FR:checkWithPhysConsts"];
+    "instance:outputInputDerivVals" [shape=box, color=black, style=filled, fillcolor="ivory", label="FR:outputInputDerivVals"];
+    "instance:calcValues" [shape=box, color=black, style=filled, fillcolor="ivory", label="FR:calcValues"];
+    "instance:verifyEnergyOutput" [shape=box, color=black, style=filled, fillcolor="ivory", label="FR:verifyEnergyOutput"];
+    "instance:calcPCMMeltBegin" [shape=box, color=black, style=filled, fillcolor="ivory", label="FR:calcPCMMeltBegin"];
+    "instance:calcPCMMeltEnd" [shape=box, color=black, style=filled, fillcolor="ivory", label="FR:calcPCMMeltEnd"];
+    "instance:outputValues" [shape=box, color=black, style=filled, fillcolor="ivory", label="FR:outputValues"];
+    "instance:correct" [shape=box, color=black, style=filled, fillcolor="ivory", label="NFR:correct"];
+    "instance:verifiable" [shape=box, color=black, style=filled, fillcolor="ivory", label="NFR:verifiable"];
+    "instance:understandable" [shape=box, color=black, style=filled, fillcolor="ivory", label="NFR:understandable"];
+    "instance:reusable" [shape=box, color=black, style=filled, fillcolor="ivory", label="NFR:reusable"];
+    "instance:maintainable" [shape=box, color=black, style=filled, fillcolor="ivory", label="NFR:maintainable"];
+    subgraph "FR" {
+        rank="same";
+        "instance:inputValues" "instance:findMass" "instance:checkWithPhysConsts" "instance:outputInputDerivVals" "instance:calcValues" "instance:verifyEnergyOutput" "instance:calcPCMMeltBegin" "instance:calcPCMMeltEnd" "instance:outputValues" "instance:correct" "instance:verifiable" "instance:understandable" "instance:reusable" "instance:maintainable";
+    }
+    "instance:waterTempGS" [shape=box, color=black, style=filled, fillcolor="darkgoldenrod1", label="GS:waterTempGS"];
+    "instance:pcmTempGS" [shape=box, color=black, style=filled, fillcolor="darkgoldenrod1", label="GS:pcmTempGS"];
+    "instance:waterEnergyGS" [shape=box, color=black, style=filled, fillcolor="darkgoldenrod1", label="GS:waterEnergyGS"];
+    "instance:pcmEnergyGS" [shape=box, color=black, style=filled, fillcolor="darkgoldenrod1", label="GS:pcmEnergyGS"];
+    subgraph "GS" {
+        rank="same";
+        "instance:waterTempGS" "instance:pcmTempGS" "instance:waterEnergyGS" "instance:pcmEnergyGS";
+    }
+    "instance:likeChgUTP" [shape=box, color=black, style=filled, fillcolor="lavender", label="LC:likeChgUTP"];
+    "instance:likeChgTCVOD" [shape=box, color=black, style=filled, fillcolor="lavender", label="LC:likeChgTCVOD"];
+    "instance:likeChgTCVOL" [shape=box, color=black, style=filled, fillcolor="lavender", label="LC:likeChgTCVOL"];
+    "instance:likeChgDT" [shape=box, color=black, style=filled, fillcolor="lavender", label="LC:likeChgDT"];
+    "instance:likeChgDITPW" [shape=box, color=black, style=filled, fillcolor="lavender", label="LC:likeChgDITPW"];
+    "instance:likeChgTLH" [shape=box, color=black, style=filled, fillcolor="lavender", label="LC:likeChgTLH"];
+    "instance:unlikeChgWPFS" [shape=box, color=black, style=filled, fillcolor="lavender", label="UC:unlikeChgWPFS"];
+    "instance:unlikeChgNIHG" [shape=box, color=black, style=filled, fillcolor="lavender", label="UC:unlikeChgNIHG"];
+    "instance:unlikeChgNGS" [shape=box, color=black, style=filled, fillcolor="lavender", label="UC:unlikeChgNGS"];
+    subgraph "LC" {
+        rank="same";
+        "instance:likeChgUTP" "instance:likeChgTCVOD" "instance:likeChgTCVOL" "instance:likeChgDT" "instance:likeChgDITPW" "instance:likeChgTLH" "instance:unlikeChgWPFS" "instance:unlikeChgNIHG" "instance:unlikeChgNGS";
+    }
 }

--- a/code/stable/swhs/TraceyGraph/allvsr.dot
+++ b/code/stable/swhs/TraceyGraph/allvsr.dot
@@ -1,129 +1,113 @@
-digraph allvsr {
-	instance:findMass -> dataDefn:wMass;
-	instance:findMass -> dataDefn:wVol;
-	instance:findMass -> dataDefn:tankVol;
-	instance:findMass -> theory:eBalanceOnWtrRC;
-	instance:findMass -> theory:eBalanceOnPCMRC;
-	instance:findMass -> theory:heatEInWtrIM;
-	instance:findMass -> theory:heatEInPCMRC;
-	instance:findMass -> instance:inputValues;
-	instance:outputInputDerivVals -> dataDefn:tauW;
-	instance:outputInputDerivVals -> dataDefn:eta;
-	instance:outputInputDerivVals -> dataDefn:tauSP;
-	instance:outputInputDerivVals -> dataDefn:tauLP;
-	instance:outputInputDerivVals -> instance:inputValues;
-	instance:outputInputDerivVals -> instance:findMass;
-	instance:calcValues -> theory:eBalanceOnWtrRC;
-	instance:calcValues -> theory:eBalanceOnPCMRC;
-	instance:calcValues -> theory:heatEInWtrIM;
-	instance:calcValues -> theory:heatEInPCMRC;
-	instance:calcPCMMeltBegin -> theory:eBalanceOnPCMRC;
-	instance:calcPCMMeltEnd -> theory:eBalanceOnPCMRC;
-	instance:outputValues -> theory:eBalanceOnWtrRC;
-	instance:outputValues -> theory:eBalanceOnPCMRC;
-	instance:outputValues -> theory:heatEInWtrIM;
-	instance:outputValues -> theory:heatEInPCMRC;
-
-
-	instance:assumpTEO	[shape=box, color=black, style=filled, fillcolor=mistyrose, label="A:assumpTEO"];
-	instance:assumpHTCC	[shape=box, color=black, style=filled, fillcolor=mistyrose, label="A:assumpHTCC"];
-	instance:assumpCWTAT	[shape=box, color=black, style=filled, fillcolor=mistyrose, label="A:assumpCWTAT"];
-	instance:assumpTPCAV	[shape=box, color=black, style=filled, fillcolor=mistyrose, label="A:assumpTPCAV"];
-	instance:assumpDWPCoV	[shape=box, color=black, style=filled, fillcolor=mistyrose, label="A:assumpDWPCoV"];
-	instance:assumpSHECov	[shape=box, color=black, style=filled, fillcolor=mistyrose, label="A:assumpSHECov"];
-	instance:assumpLCCCW	[shape=box, color=black, style=filled, fillcolor=mistyrose, label="A:assumpLCCCW"];
-	instance:assumpTHCCoT	[shape=box, color=black, style=filled, fillcolor=mistyrose, label="A:assumpTHCCoT"];
-	instance:assumpTHCCoL	[shape=box, color=black, style=filled, fillcolor=mistyrose, label="A:assumpTHCCoL"];
-	instance:assumpLCCWP	[shape=box, color=black, style=filled, fillcolor=mistyrose, label="A:assumpLCCWP"];
-	instance:assumpCTNOD	[shape=box, color=black, style=filled, fillcolor=mistyrose, label="A:assumpCTNOD"];
-	instance:assumpSITWP	[shape=box, color=black, style=filled, fillcolor=mistyrose, label="A:assumpSITWP"];
-	instance:assumpPIS	[shape=box, color=black, style=filled, fillcolor=mistyrose, label="A:assumpPIS"];
-	instance:assumpWAL	[shape=box, color=black, style=filled, fillcolor=mistyrose, label="A:assumpWAL"];
-	instance:assumpPIT	[shape=box, color=black, style=filled, fillcolor=mistyrose, label="A:assumpPIT"];
-	instance:assumpNIHGBWP	[shape=box, color=black, style=filled, fillcolor=mistyrose, label="A:assumpNIHGBWP"];
-	instance:assumpVCMPN	[shape=box, color=black, style=filled, fillcolor=mistyrose, label="A:assumpVCMPN"];
-	instance:assumpNGSP	[shape=box, color=black, style=filled, fillcolor=mistyrose, label="A:assumpNGSP"];
-	instance:assumpAPT	[shape=box, color=black, style=filled, fillcolor=mistyrose, label="A:assumpAPT"];
-	instance:assumpVCN	[shape=box, color=black, style=filled, fillcolor=mistyrose, label="A:assumpVCN"];
-
-	subgraph A {
-	rank="same"
-	{instance:assumpTEO, instance:assumpHTCC, instance:assumpCWTAT, instance:assumpTPCAV, instance:assumpDWPCoV, instance:assumpSHECov, instance:assumpLCCCW, instance:assumpTHCCoT, instance:assumpTHCCoL, instance:assumpLCCWP, instance:assumpCTNOD, instance:assumpSITWP, instance:assumpPIS, instance:assumpWAL, instance:assumpPIT, instance:assumpNIHGBWP, instance:assumpVCMPN, instance:assumpNGSP, instance:assumpAPT, instance:assumpVCN}
-	}
-
-	dataDefn:wMass	[shape=box, color=black, style=filled, fillcolor=paleturquoise1, label="DD:waterMass"];
-	dataDefn:wVol	[shape=box, color=black, style=filled, fillcolor=paleturquoise1, label="DD:waterVolume.pcm"];
-	dataDefn:tankVol	[shape=box, color=black, style=filled, fillcolor=paleturquoise1, label="DD:tankVolume"];
-	dataDefn:tauW	[shape=box, color=black, style=filled, fillcolor=paleturquoise1, label="DD:balanceDecayRate"];
-	dataDefn:eta	[shape=box, color=black, style=filled, fillcolor=paleturquoise1, label="DD:balanceDecayTime"];
-	dataDefn:tauSP	[shape=box, color=black, style=filled, fillcolor=paleturquoise1, label="DD:balanceSolidPCM"];
-	dataDefn:tauLP	[shape=box, color=black, style=filled, fillcolor=paleturquoise1, label="DD:balanceLiquidPCM"];
-	dataDefn:htFusion	[shape=box, color=black, style=filled, fillcolor=paleturquoise1, label="DD:htFusion"];
-	dataDefn:meltFrac	[shape=box, color=black, style=filled, fillcolor=paleturquoise1, label="DD:meltFrac"];
-	dataDefn:aspectRatio	[shape=box, color=black, style=filled, fillcolor=paleturquoise1, label="DD:aspectRatio"];
-
-	subgraph DD {
-	rank="same"
-	{dataDefn:wMass, dataDefn:wVol, dataDefn:tankVol, dataDefn:tauW, dataDefn:eta, dataDefn:tauSP, dataDefn:tauLP, dataDefn:htFusion, dataDefn:meltFrac, dataDefn:aspectRatio}
-	}
-
-	theory:consThermECS	[shape=box, color=black, style=filled, fillcolor=pink, label="TM:consThermE"];
-	theory:sensHeat	[shape=box, color=black, style=filled, fillcolor=pink, label="TM:sensHtE"];
-	theory:latentHtETM	[shape=box, color=black, style=filled, fillcolor=pink, label="TM:latentHtE"];
-	theory:nwtnCoolingTM	[shape=box, color=black, style=filled, fillcolor=pink, label="TM:nwtnCooling"];
-
-	subgraph TM {
-	rank="same"
-	{theory:consThermECS, theory:sensHeat, theory:latentHtETM, theory:nwtnCoolingTM}
-	}
-
-	theory:rocTempSimpRC	[shape=box, color=black, style=filled, fillcolor=palegreen, label="GD:rocTempSimp"];
-	theory:htFluxC	[shape=box, color=black, style=filled, fillcolor=palegreen, label="GD:htFluxWaterFromCoil"];
-	theory:htFluxP	[shape=box, color=black, style=filled, fillcolor=palegreen, label="GD:htFluxPCMFromWater"];
-
-	subgraph GD {
-	rank="same"
-	{theory:rocTempSimpRC, theory:htFluxC, theory:htFluxP}
-	}
-
-	theory:eBalanceOnWtrRC	[shape=box, color=black, style=filled, fillcolor=khaki1, label="IM:eBalanceOnWtr"];
-	theory:eBalanceOnPCMRC	[shape=box, color=black, style=filled, fillcolor=khaki1, label="IM:eBalanceOnPCM"];
-	theory:heatEInWtrIM	[shape=box, color=black, style=filled, fillcolor=khaki1, label="IM:heatEInWtr"];
-	theory:heatEInPCMRC	[shape=box, color=black, style=filled, fillcolor=khaki1, label="IM:heatEInPCM"];
-
-	subgraph IM {
-	rank="same"
-	{theory:eBalanceOnWtrRC, theory:eBalanceOnPCMRC, theory:heatEInWtrIM, theory:heatEInPCMRC}
-	}
-
-	instance:inputValues	[shape=box, color=black, style=filled, fillcolor=ivory, label="FR:inputValues"];
-	instance:findMass	[shape=box, color=black, style=filled, fillcolor=ivory, label="FR:findMass"];
-	instance:checkWithPhysConsts	[shape=box, color=black, style=filled, fillcolor=ivory, label="FR:checkWithPhysConsts"];
-	instance:outputInputDerivVals	[shape=box, color=black, style=filled, fillcolor=ivory, label="FR:outputInputDerivVals"];
-	instance:calcValues	[shape=box, color=black, style=filled, fillcolor=ivory, label="FR:calcValues"];
-	instance:verifyEnergyOutput	[shape=box, color=black, style=filled, fillcolor=ivory, label="FR:verifyEnergyOutput"];
-	instance:calcPCMMeltBegin	[shape=box, color=black, style=filled, fillcolor=ivory, label="FR:calcPCMMeltBegin"];
-	instance:calcPCMMeltEnd	[shape=box, color=black, style=filled, fillcolor=ivory, label="FR:calcPCMMeltEnd"];
-	instance:outputValues	[shape=box, color=black, style=filled, fillcolor=ivory, label="FR:outputValues"];
-	instance:correct	[shape=box, color=black, style=filled, fillcolor=ivory, label="NFR:correct"];
-	instance:verifiable	[shape=box, color=black, style=filled, fillcolor=ivory, label="NFR:verifiable"];
-	instance:understandable	[shape=box, color=black, style=filled, fillcolor=ivory, label="NFR:understandable"];
-	instance:reusable	[shape=box, color=black, style=filled, fillcolor=ivory, label="NFR:reusable"];
-	instance:maintainable	[shape=box, color=black, style=filled, fillcolor=ivory, label="NFR:maintainable"];
-
-	subgraph FR {
-	rank="same"
-	{instance:inputValues, instance:findMass, instance:checkWithPhysConsts, instance:outputInputDerivVals, instance:calcValues, instance:verifyEnergyOutput, instance:calcPCMMeltBegin, instance:calcPCMMeltEnd, instance:outputValues, instance:correct, instance:verifiable, instance:understandable, instance:reusable, instance:maintainable}
-	}
-
-	instance:waterTempGS	[shape=box, color=black, style=filled, fillcolor=darkgoldenrod1, label="GS:waterTempGS"];
-	instance:pcmTempGS	[shape=box, color=black, style=filled, fillcolor=darkgoldenrod1, label="GS:pcmTempGS"];
-	instance:waterEnergyGS	[shape=box, color=black, style=filled, fillcolor=darkgoldenrod1, label="GS:waterEnergyGS"];
-	instance:pcmEnergyGS	[shape=box, color=black, style=filled, fillcolor=darkgoldenrod1, label="GS:pcmEnergyGS"];
-
-	subgraph GS {
-	rank="same"
-	{instance:waterTempGS, instance:pcmTempGS, instance:waterEnergyGS, instance:pcmEnergyGS}
-	}
-
+digraph "allvsr" {
+    "instance:findMass" -> "dataDefn:wMass";
+    "instance:findMass" -> "dataDefn:wVol";
+    "instance:findMass" -> "dataDefn:tankVol";
+    "instance:findMass" -> "theory:eBalanceOnWtrRC";
+    "instance:findMass" -> "theory:eBalanceOnPCMRC";
+    "instance:findMass" -> "theory:heatEInWtrIM";
+    "instance:findMass" -> "theory:heatEInPCMRC";
+    "instance:findMass" -> "instance:inputValues";
+    "instance:outputInputDerivVals" -> "dataDefn:tauW";
+    "instance:outputInputDerivVals" -> "dataDefn:eta";
+    "instance:outputInputDerivVals" -> "dataDefn:tauSP";
+    "instance:outputInputDerivVals" -> "dataDefn:tauLP";
+    "instance:outputInputDerivVals" -> "instance:inputValues";
+    "instance:outputInputDerivVals" -> "instance:findMass";
+    "instance:calcValues" -> "theory:eBalanceOnWtrRC";
+    "instance:calcValues" -> "theory:eBalanceOnPCMRC";
+    "instance:calcValues" -> "theory:heatEInWtrIM";
+    "instance:calcValues" -> "theory:heatEInPCMRC";
+    "instance:calcPCMMeltBegin" -> "theory:eBalanceOnPCMRC";
+    "instance:calcPCMMeltEnd" -> "theory:eBalanceOnPCMRC";
+    "instance:outputValues" -> "theory:eBalanceOnWtrRC";
+    "instance:outputValues" -> "theory:eBalanceOnPCMRC";
+    "instance:outputValues" -> "theory:heatEInWtrIM";
+    "instance:outputValues" -> "theory:heatEInPCMRC";
+    "instance:assumpTEO" [shape=box, color=black, style=filled, fillcolor="mistyrose", label="A:assumpTEO"];
+    "instance:assumpHTCC" [shape=box, color=black, style=filled, fillcolor="mistyrose", label="A:assumpHTCC"];
+    "instance:assumpCWTAT" [shape=box, color=black, style=filled, fillcolor="mistyrose", label="A:assumpCWTAT"];
+    "instance:assumpTPCAV" [shape=box, color=black, style=filled, fillcolor="mistyrose", label="A:assumpTPCAV"];
+    "instance:assumpDWPCoV" [shape=box, color=black, style=filled, fillcolor="mistyrose", label="A:assumpDWPCoV"];
+    "instance:assumpSHECov" [shape=box, color=black, style=filled, fillcolor="mistyrose", label="A:assumpSHECov"];
+    "instance:assumpLCCCW" [shape=box, color=black, style=filled, fillcolor="mistyrose", label="A:assumpLCCCW"];
+    "instance:assumpTHCCoT" [shape=box, color=black, style=filled, fillcolor="mistyrose", label="A:assumpTHCCoT"];
+    "instance:assumpTHCCoL" [shape=box, color=black, style=filled, fillcolor="mistyrose", label="A:assumpTHCCoL"];
+    "instance:assumpLCCWP" [shape=box, color=black, style=filled, fillcolor="mistyrose", label="A:assumpLCCWP"];
+    "instance:assumpCTNOD" [shape=box, color=black, style=filled, fillcolor="mistyrose", label="A:assumpCTNOD"];
+    "instance:assumpSITWP" [shape=box, color=black, style=filled, fillcolor="mistyrose", label="A:assumpSITWP"];
+    "instance:assumpPIS" [shape=box, color=black, style=filled, fillcolor="mistyrose", label="A:assumpPIS"];
+    "instance:assumpWAL" [shape=box, color=black, style=filled, fillcolor="mistyrose", label="A:assumpWAL"];
+    "instance:assumpPIT" [shape=box, color=black, style=filled, fillcolor="mistyrose", label="A:assumpPIT"];
+    "instance:assumpNIHGBWP" [shape=box, color=black, style=filled, fillcolor="mistyrose", label="A:assumpNIHGBWP"];
+    "instance:assumpVCMPN" [shape=box, color=black, style=filled, fillcolor="mistyrose", label="A:assumpVCMPN"];
+    "instance:assumpNGSP" [shape=box, color=black, style=filled, fillcolor="mistyrose", label="A:assumpNGSP"];
+    "instance:assumpAPT" [shape=box, color=black, style=filled, fillcolor="mistyrose", label="A:assumpAPT"];
+    "instance:assumpVCN" [shape=box, color=black, style=filled, fillcolor="mistyrose", label="A:assumpVCN"];
+    subgraph "A" {
+        rank="same";
+        "instance:assumpTEO" "instance:assumpHTCC" "instance:assumpCWTAT" "instance:assumpTPCAV" "instance:assumpDWPCoV" "instance:assumpSHECov" "instance:assumpLCCCW" "instance:assumpTHCCoT" "instance:assumpTHCCoL" "instance:assumpLCCWP" "instance:assumpCTNOD" "instance:assumpSITWP" "instance:assumpPIS" "instance:assumpWAL" "instance:assumpPIT" "instance:assumpNIHGBWP" "instance:assumpVCMPN" "instance:assumpNGSP" "instance:assumpAPT" "instance:assumpVCN";
+    }
+    "dataDefn:wMass" [shape=box, color=black, style=filled, fillcolor="paleturquoise1", label="DD:waterMass"];
+    "dataDefn:wVol" [shape=box, color=black, style=filled, fillcolor="paleturquoise1", label="DD:waterVolume.pcm"];
+    "dataDefn:tankVol" [shape=box, color=black, style=filled, fillcolor="paleturquoise1", label="DD:tankVolume"];
+    "dataDefn:tauW" [shape=box, color=black, style=filled, fillcolor="paleturquoise1", label="DD:balanceDecayRate"];
+    "dataDefn:eta" [shape=box, color=black, style=filled, fillcolor="paleturquoise1", label="DD:balanceDecayTime"];
+    "dataDefn:tauSP" [shape=box, color=black, style=filled, fillcolor="paleturquoise1", label="DD:balanceSolidPCM"];
+    "dataDefn:tauLP" [shape=box, color=black, style=filled, fillcolor="paleturquoise1", label="DD:balanceLiquidPCM"];
+    "dataDefn:htFusion" [shape=box, color=black, style=filled, fillcolor="paleturquoise1", label="DD:htFusion"];
+    "dataDefn:meltFrac" [shape=box, color=black, style=filled, fillcolor="paleturquoise1", label="DD:meltFrac"];
+    "dataDefn:aspectRatio" [shape=box, color=black, style=filled, fillcolor="paleturquoise1", label="DD:aspectRatio"];
+    subgraph "DD" {
+        rank="same";
+        "dataDefn:wMass" "dataDefn:wVol" "dataDefn:tankVol" "dataDefn:tauW" "dataDefn:eta" "dataDefn:tauSP" "dataDefn:tauLP" "dataDefn:htFusion" "dataDefn:meltFrac" "dataDefn:aspectRatio";
+    }
+    "theory:consThermECS" [shape=box, color=black, style=filled, fillcolor="pink", label="TM:consThermE"];
+    "theory:sensHeat" [shape=box, color=black, style=filled, fillcolor="pink", label="TM:sensHtE"];
+    "theory:latentHtETM" [shape=box, color=black, style=filled, fillcolor="pink", label="TM:latentHtE"];
+    "theory:nwtnCoolingTM" [shape=box, color=black, style=filled, fillcolor="pink", label="TM:nwtnCooling"];
+    subgraph "TM" {
+        rank="same";
+        "theory:consThermECS" "theory:sensHeat" "theory:latentHtETM" "theory:nwtnCoolingTM";
+    }
+    "theory:rocTempSimpRC" [shape=box, color=black, style=filled, fillcolor="palegreen", label="GD:rocTempSimp"];
+    "theory:htFluxC" [shape=box, color=black, style=filled, fillcolor="palegreen", label="GD:htFluxWaterFromCoil"];
+    "theory:htFluxP" [shape=box, color=black, style=filled, fillcolor="palegreen", label="GD:htFluxPCMFromWater"];
+    subgraph "GD" {
+        rank="same";
+        "theory:rocTempSimpRC" "theory:htFluxC" "theory:htFluxP";
+    }
+    "theory:eBalanceOnWtrRC" [shape=box, color=black, style=filled, fillcolor="khaki1", label="IM:eBalanceOnWtr"];
+    "theory:eBalanceOnPCMRC" [shape=box, color=black, style=filled, fillcolor="khaki1", label="IM:eBalanceOnPCM"];
+    "theory:heatEInWtrIM" [shape=box, color=black, style=filled, fillcolor="khaki1", label="IM:heatEInWtr"];
+    "theory:heatEInPCMRC" [shape=box, color=black, style=filled, fillcolor="khaki1", label="IM:heatEInPCM"];
+    subgraph "IM" {
+        rank="same";
+        "theory:eBalanceOnWtrRC" "theory:eBalanceOnPCMRC" "theory:heatEInWtrIM" "theory:heatEInPCMRC";
+    }
+    "instance:inputValues" [shape=box, color=black, style=filled, fillcolor="ivory", label="FR:inputValues"];
+    "instance:findMass" [shape=box, color=black, style=filled, fillcolor="ivory", label="FR:findMass"];
+    "instance:checkWithPhysConsts" [shape=box, color=black, style=filled, fillcolor="ivory", label="FR:checkWithPhysConsts"];
+    "instance:outputInputDerivVals" [shape=box, color=black, style=filled, fillcolor="ivory", label="FR:outputInputDerivVals"];
+    "instance:calcValues" [shape=box, color=black, style=filled, fillcolor="ivory", label="FR:calcValues"];
+    "instance:verifyEnergyOutput" [shape=box, color=black, style=filled, fillcolor="ivory", label="FR:verifyEnergyOutput"];
+    "instance:calcPCMMeltBegin" [shape=box, color=black, style=filled, fillcolor="ivory", label="FR:calcPCMMeltBegin"];
+    "instance:calcPCMMeltEnd" [shape=box, color=black, style=filled, fillcolor="ivory", label="FR:calcPCMMeltEnd"];
+    "instance:outputValues" [shape=box, color=black, style=filled, fillcolor="ivory", label="FR:outputValues"];
+    "instance:correct" [shape=box, color=black, style=filled, fillcolor="ivory", label="NFR:correct"];
+    "instance:verifiable" [shape=box, color=black, style=filled, fillcolor="ivory", label="NFR:verifiable"];
+    "instance:understandable" [shape=box, color=black, style=filled, fillcolor="ivory", label="NFR:understandable"];
+    "instance:reusable" [shape=box, color=black, style=filled, fillcolor="ivory", label="NFR:reusable"];
+    "instance:maintainable" [shape=box, color=black, style=filled, fillcolor="ivory", label="NFR:maintainable"];
+    subgraph "FR" {
+        rank="same";
+        "instance:inputValues" "instance:findMass" "instance:checkWithPhysConsts" "instance:outputInputDerivVals" "instance:calcValues" "instance:verifyEnergyOutput" "instance:calcPCMMeltBegin" "instance:calcPCMMeltEnd" "instance:outputValues" "instance:correct" "instance:verifiable" "instance:understandable" "instance:reusable" "instance:maintainable";
+    }
+    "instance:waterTempGS" [shape=box, color=black, style=filled, fillcolor="darkgoldenrod1", label="GS:waterTempGS"];
+    "instance:pcmTempGS" [shape=box, color=black, style=filled, fillcolor="darkgoldenrod1", label="GS:pcmTempGS"];
+    "instance:waterEnergyGS" [shape=box, color=black, style=filled, fillcolor="darkgoldenrod1", label="GS:waterEnergyGS"];
+    "instance:pcmEnergyGS" [shape=box, color=black, style=filled, fillcolor="darkgoldenrod1", label="GS:pcmEnergyGS"];
+    subgraph "GS" {
+        rank="same";
+        "instance:waterTempGS" "instance:pcmTempGS" "instance:waterEnergyGS" "instance:pcmEnergyGS";
+    }
 }

--- a/code/stable/swhs/TraceyGraph/avsa.dot
+++ b/code/stable/swhs/TraceyGraph/avsa.dot
@@ -1,31 +1,27 @@
-digraph avsa {
-	instance:assumpCTNOD -> instance:assumpSITWP;
-
-
-	instance:assumpTEO	[shape=box, color=black, style=filled, fillcolor=mistyrose, label="A:assumpTEO"];
-	instance:assumpHTCC	[shape=box, color=black, style=filled, fillcolor=mistyrose, label="A:assumpHTCC"];
-	instance:assumpCWTAT	[shape=box, color=black, style=filled, fillcolor=mistyrose, label="A:assumpCWTAT"];
-	instance:assumpTPCAV	[shape=box, color=black, style=filled, fillcolor=mistyrose, label="A:assumpTPCAV"];
-	instance:assumpDWPCoV	[shape=box, color=black, style=filled, fillcolor=mistyrose, label="A:assumpDWPCoV"];
-	instance:assumpSHECov	[shape=box, color=black, style=filled, fillcolor=mistyrose, label="A:assumpSHECov"];
-	instance:assumpLCCCW	[shape=box, color=black, style=filled, fillcolor=mistyrose, label="A:assumpLCCCW"];
-	instance:assumpTHCCoT	[shape=box, color=black, style=filled, fillcolor=mistyrose, label="A:assumpTHCCoT"];
-	instance:assumpTHCCoL	[shape=box, color=black, style=filled, fillcolor=mistyrose, label="A:assumpTHCCoL"];
-	instance:assumpLCCWP	[shape=box, color=black, style=filled, fillcolor=mistyrose, label="A:assumpLCCWP"];
-	instance:assumpCTNOD	[shape=box, color=black, style=filled, fillcolor=mistyrose, label="A:assumpCTNOD"];
-	instance:assumpSITWP	[shape=box, color=black, style=filled, fillcolor=mistyrose, label="A:assumpSITWP"];
-	instance:assumpPIS	[shape=box, color=black, style=filled, fillcolor=mistyrose, label="A:assumpPIS"];
-	instance:assumpWAL	[shape=box, color=black, style=filled, fillcolor=mistyrose, label="A:assumpWAL"];
-	instance:assumpPIT	[shape=box, color=black, style=filled, fillcolor=mistyrose, label="A:assumpPIT"];
-	instance:assumpNIHGBWP	[shape=box, color=black, style=filled, fillcolor=mistyrose, label="A:assumpNIHGBWP"];
-	instance:assumpVCMPN	[shape=box, color=black, style=filled, fillcolor=mistyrose, label="A:assumpVCMPN"];
-	instance:assumpNGSP	[shape=box, color=black, style=filled, fillcolor=mistyrose, label="A:assumpNGSP"];
-	instance:assumpAPT	[shape=box, color=black, style=filled, fillcolor=mistyrose, label="A:assumpAPT"];
-	instance:assumpVCN	[shape=box, color=black, style=filled, fillcolor=mistyrose, label="A:assumpVCN"];
-
-	subgraph A {
-	rank="same"
-	{instance:assumpTEO, instance:assumpHTCC, instance:assumpCWTAT, instance:assumpTPCAV, instance:assumpDWPCoV, instance:assumpSHECov, instance:assumpLCCCW, instance:assumpTHCCoT, instance:assumpTHCCoL, instance:assumpLCCWP, instance:assumpCTNOD, instance:assumpSITWP, instance:assumpPIS, instance:assumpWAL, instance:assumpPIT, instance:assumpNIHGBWP, instance:assumpVCMPN, instance:assumpNGSP, instance:assumpAPT, instance:assumpVCN}
-	}
-
+digraph "avsa" {
+    "instance:assumpCTNOD" -> "instance:assumpSITWP";
+    "instance:assumpTEO" [shape=box, color=black, style=filled, fillcolor="mistyrose", label="A:assumpTEO"];
+    "instance:assumpHTCC" [shape=box, color=black, style=filled, fillcolor="mistyrose", label="A:assumpHTCC"];
+    "instance:assumpCWTAT" [shape=box, color=black, style=filled, fillcolor="mistyrose", label="A:assumpCWTAT"];
+    "instance:assumpTPCAV" [shape=box, color=black, style=filled, fillcolor="mistyrose", label="A:assumpTPCAV"];
+    "instance:assumpDWPCoV" [shape=box, color=black, style=filled, fillcolor="mistyrose", label="A:assumpDWPCoV"];
+    "instance:assumpSHECov" [shape=box, color=black, style=filled, fillcolor="mistyrose", label="A:assumpSHECov"];
+    "instance:assumpLCCCW" [shape=box, color=black, style=filled, fillcolor="mistyrose", label="A:assumpLCCCW"];
+    "instance:assumpTHCCoT" [shape=box, color=black, style=filled, fillcolor="mistyrose", label="A:assumpTHCCoT"];
+    "instance:assumpTHCCoL" [shape=box, color=black, style=filled, fillcolor="mistyrose", label="A:assumpTHCCoL"];
+    "instance:assumpLCCWP" [shape=box, color=black, style=filled, fillcolor="mistyrose", label="A:assumpLCCWP"];
+    "instance:assumpCTNOD" [shape=box, color=black, style=filled, fillcolor="mistyrose", label="A:assumpCTNOD"];
+    "instance:assumpSITWP" [shape=box, color=black, style=filled, fillcolor="mistyrose", label="A:assumpSITWP"];
+    "instance:assumpPIS" [shape=box, color=black, style=filled, fillcolor="mistyrose", label="A:assumpPIS"];
+    "instance:assumpWAL" [shape=box, color=black, style=filled, fillcolor="mistyrose", label="A:assumpWAL"];
+    "instance:assumpPIT" [shape=box, color=black, style=filled, fillcolor="mistyrose", label="A:assumpPIT"];
+    "instance:assumpNIHGBWP" [shape=box, color=black, style=filled, fillcolor="mistyrose", label="A:assumpNIHGBWP"];
+    "instance:assumpVCMPN" [shape=box, color=black, style=filled, fillcolor="mistyrose", label="A:assumpVCMPN"];
+    "instance:assumpNGSP" [shape=box, color=black, style=filled, fillcolor="mistyrose", label="A:assumpNGSP"];
+    "instance:assumpAPT" [shape=box, color=black, style=filled, fillcolor="mistyrose", label="A:assumpAPT"];
+    "instance:assumpVCN" [shape=box, color=black, style=filled, fillcolor="mistyrose", label="A:assumpVCN"];
+    subgraph "A" {
+        rank="same";
+        "instance:assumpTEO" "instance:assumpHTCC" "instance:assumpCWTAT" "instance:assumpTPCAV" "instance:assumpDWPCoV" "instance:assumpSHECov" "instance:assumpLCCCW" "instance:assumpTHCCoT" "instance:assumpTHCCoL" "instance:assumpLCCWP" "instance:assumpCTNOD" "instance:assumpSITWP" "instance:assumpPIS" "instance:assumpWAL" "instance:assumpPIT" "instance:assumpNIHGBWP" "instance:assumpVCMPN" "instance:assumpNGSP" "instance:assumpAPT" "instance:assumpVCN";
+    }
 }

--- a/code/stable/swhs/TraceyGraph/avsall.dot
+++ b/code/stable/swhs/TraceyGraph/avsall.dot
@@ -1,150 +1,134 @@
-digraph avsall {
-	dataDefn:wVol -> instance:assumpVCN;
-	theory:consThermECS -> instance:assumpTEO;
-	theory:nwtnCoolingTM -> instance:assumpHTCC;
-	theory:rocTempSimpRC -> instance:assumpCWTAT;
-	theory:rocTempSimpRC -> instance:assumpTPCAV;
-	theory:rocTempSimpRC -> instance:assumpDWPCoV;
-	theory:rocTempSimpRC -> instance:assumpSHECov;
-	theory:htFluxC -> instance:assumpLCCCW;
-	theory:htFluxC -> instance:assumpTHCCoT;
-	theory:htFluxP -> instance:assumpLCCWP;
-	theory:eBalanceOnWtrRC -> instance:assumpCWTAT;
-	theory:eBalanceOnWtrRC -> instance:assumpTPCAV;
-	theory:eBalanceOnWtrRC -> instance:assumpTHCCoL;
-	theory:eBalanceOnWtrRC -> instance:assumpCTNOD;
-	theory:eBalanceOnWtrRC -> instance:assumpSITWP;
-	theory:eBalanceOnWtrRC -> instance:assumpWAL;
-	theory:eBalanceOnWtrRC -> instance:assumpPIT;
-	theory:eBalanceOnWtrRC -> instance:assumpNIHGBWP;
-	theory:eBalanceOnWtrRC -> instance:assumpAPT;
-	theory:eBalanceOnPCMRC -> instance:assumpCWTAT;
-	theory:eBalanceOnPCMRC -> instance:assumpTPCAV;
-	theory:eBalanceOnPCMRC -> instance:assumpSITWP;
-	theory:eBalanceOnPCMRC -> instance:assumpPIS;
-	theory:eBalanceOnPCMRC -> instance:assumpNIHGBWP;
-	theory:eBalanceOnPCMRC -> instance:assumpVCMPN;
-	theory:eBalanceOnPCMRC -> instance:assumpNGSP;
-	theory:heatEInWtrIM -> instance:assumpWAL;
-	theory:heatEInWtrIM -> instance:assumpAPT;
-	theory:heatEInPCMRC -> instance:assumpPIS;
-	theory:heatEInPCMRC -> instance:assumpNGSP;
-	instance:likeChgUTP -> instance:assumpTPCAV;
-	instance:likeChgTCVOD -> instance:assumpTHCCoT;
-	instance:likeChgTCVOL -> instance:assumpTHCCoL;
-	instance:likeChgDT -> instance:assumpCTNOD;
-	instance:likeChgDITPW -> instance:assumpSITWP;
-	instance:likeChgTLH -> instance:assumpPIT;
-	instance:unlikeChgWPFS -> instance:assumpWAL;
-	instance:unlikeChgWPFS -> instance:assumpNGSP;
-	instance:unlikeChgNIHG -> instance:assumpNIHGBWP;
-	instance:unlikeChgNGS -> instance:assumpNGSP;
-
-
-	instance:assumpTEO	[shape=box, color=black, style=filled, fillcolor=mistyrose, label="A:assumpTEO"];
-	instance:assumpHTCC	[shape=box, color=black, style=filled, fillcolor=mistyrose, label="A:assumpHTCC"];
-	instance:assumpCWTAT	[shape=box, color=black, style=filled, fillcolor=mistyrose, label="A:assumpCWTAT"];
-	instance:assumpTPCAV	[shape=box, color=black, style=filled, fillcolor=mistyrose, label="A:assumpTPCAV"];
-	instance:assumpDWPCoV	[shape=box, color=black, style=filled, fillcolor=mistyrose, label="A:assumpDWPCoV"];
-	instance:assumpSHECov	[shape=box, color=black, style=filled, fillcolor=mistyrose, label="A:assumpSHECov"];
-	instance:assumpLCCCW	[shape=box, color=black, style=filled, fillcolor=mistyrose, label="A:assumpLCCCW"];
-	instance:assumpTHCCoT	[shape=box, color=black, style=filled, fillcolor=mistyrose, label="A:assumpTHCCoT"];
-	instance:assumpTHCCoL	[shape=box, color=black, style=filled, fillcolor=mistyrose, label="A:assumpTHCCoL"];
-	instance:assumpLCCWP	[shape=box, color=black, style=filled, fillcolor=mistyrose, label="A:assumpLCCWP"];
-	instance:assumpCTNOD	[shape=box, color=black, style=filled, fillcolor=mistyrose, label="A:assumpCTNOD"];
-	instance:assumpSITWP	[shape=box, color=black, style=filled, fillcolor=mistyrose, label="A:assumpSITWP"];
-	instance:assumpPIS	[shape=box, color=black, style=filled, fillcolor=mistyrose, label="A:assumpPIS"];
-	instance:assumpWAL	[shape=box, color=black, style=filled, fillcolor=mistyrose, label="A:assumpWAL"];
-	instance:assumpPIT	[shape=box, color=black, style=filled, fillcolor=mistyrose, label="A:assumpPIT"];
-	instance:assumpNIHGBWP	[shape=box, color=black, style=filled, fillcolor=mistyrose, label="A:assumpNIHGBWP"];
-	instance:assumpVCMPN	[shape=box, color=black, style=filled, fillcolor=mistyrose, label="A:assumpVCMPN"];
-	instance:assumpNGSP	[shape=box, color=black, style=filled, fillcolor=mistyrose, label="A:assumpNGSP"];
-	instance:assumpAPT	[shape=box, color=black, style=filled, fillcolor=mistyrose, label="A:assumpAPT"];
-	instance:assumpVCN	[shape=box, color=black, style=filled, fillcolor=mistyrose, label="A:assumpVCN"];
-
-	subgraph A {
-	rank="same"
-	{instance:assumpTEO, instance:assumpHTCC, instance:assumpCWTAT, instance:assumpTPCAV, instance:assumpDWPCoV, instance:assumpSHECov, instance:assumpLCCCW, instance:assumpTHCCoT, instance:assumpTHCCoL, instance:assumpLCCWP, instance:assumpCTNOD, instance:assumpSITWP, instance:assumpPIS, instance:assumpWAL, instance:assumpPIT, instance:assumpNIHGBWP, instance:assumpVCMPN, instance:assumpNGSP, instance:assumpAPT, instance:assumpVCN}
-	}
-
-	dataDefn:wMass	[shape=box, color=black, style=filled, fillcolor=paleturquoise1, label="DD:waterMass"];
-	dataDefn:wVol	[shape=box, color=black, style=filled, fillcolor=paleturquoise1, label="DD:waterVolume.pcm"];
-	dataDefn:tankVol	[shape=box, color=black, style=filled, fillcolor=paleturquoise1, label="DD:tankVolume"];
-	dataDefn:tauW	[shape=box, color=black, style=filled, fillcolor=paleturquoise1, label="DD:balanceDecayRate"];
-	dataDefn:eta	[shape=box, color=black, style=filled, fillcolor=paleturquoise1, label="DD:balanceDecayTime"];
-	dataDefn:tauSP	[shape=box, color=black, style=filled, fillcolor=paleturquoise1, label="DD:balanceSolidPCM"];
-	dataDefn:tauLP	[shape=box, color=black, style=filled, fillcolor=paleturquoise1, label="DD:balanceLiquidPCM"];
-	dataDefn:htFusion	[shape=box, color=black, style=filled, fillcolor=paleturquoise1, label="DD:htFusion"];
-	dataDefn:meltFrac	[shape=box, color=black, style=filled, fillcolor=paleturquoise1, label="DD:meltFrac"];
-	dataDefn:aspectRatio	[shape=box, color=black, style=filled, fillcolor=paleturquoise1, label="DD:aspectRatio"];
-
-	subgraph DD {
-	rank="same"
-	{dataDefn:wMass, dataDefn:wVol, dataDefn:tankVol, dataDefn:tauW, dataDefn:eta, dataDefn:tauSP, dataDefn:tauLP, dataDefn:htFusion, dataDefn:meltFrac, dataDefn:aspectRatio}
-	}
-
-	theory:consThermECS	[shape=box, color=black, style=filled, fillcolor=pink, label="TM:consThermE"];
-	theory:sensHeat	[shape=box, color=black, style=filled, fillcolor=pink, label="TM:sensHtE"];
-	theory:latentHtETM	[shape=box, color=black, style=filled, fillcolor=pink, label="TM:latentHtE"];
-	theory:nwtnCoolingTM	[shape=box, color=black, style=filled, fillcolor=pink, label="TM:nwtnCooling"];
-
-	subgraph TM {
-	rank="same"
-	{theory:consThermECS, theory:sensHeat, theory:latentHtETM, theory:nwtnCoolingTM}
-	}
-
-	theory:rocTempSimpRC	[shape=box, color=black, style=filled, fillcolor=palegreen, label="GD:rocTempSimp"];
-	theory:htFluxC	[shape=box, color=black, style=filled, fillcolor=palegreen, label="GD:htFluxWaterFromCoil"];
-	theory:htFluxP	[shape=box, color=black, style=filled, fillcolor=palegreen, label="GD:htFluxPCMFromWater"];
-
-	subgraph GD {
-	rank="same"
-	{theory:rocTempSimpRC, theory:htFluxC, theory:htFluxP}
-	}
-
-	theory:eBalanceOnWtrRC	[shape=box, color=black, style=filled, fillcolor=khaki1, label="IM:eBalanceOnWtr"];
-	theory:eBalanceOnPCMRC	[shape=box, color=black, style=filled, fillcolor=khaki1, label="IM:eBalanceOnPCM"];
-	theory:heatEInWtrIM	[shape=box, color=black, style=filled, fillcolor=khaki1, label="IM:heatEInWtr"];
-	theory:heatEInPCMRC	[shape=box, color=black, style=filled, fillcolor=khaki1, label="IM:heatEInPCM"];
-
-	subgraph IM {
-	rank="same"
-	{theory:eBalanceOnWtrRC, theory:eBalanceOnPCMRC, theory:heatEInWtrIM, theory:heatEInPCMRC}
-	}
-
-	instance:inputValues	[shape=box, color=black, style=filled, fillcolor=ivory, label="FR:inputValues"];
-	instance:findMass	[shape=box, color=black, style=filled, fillcolor=ivory, label="FR:findMass"];
-	instance:checkWithPhysConsts	[shape=box, color=black, style=filled, fillcolor=ivory, label="FR:checkWithPhysConsts"];
-	instance:outputInputDerivVals	[shape=box, color=black, style=filled, fillcolor=ivory, label="FR:outputInputDerivVals"];
-	instance:calcValues	[shape=box, color=black, style=filled, fillcolor=ivory, label="FR:calcValues"];
-	instance:verifyEnergyOutput	[shape=box, color=black, style=filled, fillcolor=ivory, label="FR:verifyEnergyOutput"];
-	instance:calcPCMMeltBegin	[shape=box, color=black, style=filled, fillcolor=ivory, label="FR:calcPCMMeltBegin"];
-	instance:calcPCMMeltEnd	[shape=box, color=black, style=filled, fillcolor=ivory, label="FR:calcPCMMeltEnd"];
-	instance:outputValues	[shape=box, color=black, style=filled, fillcolor=ivory, label="FR:outputValues"];
-	instance:correct	[shape=box, color=black, style=filled, fillcolor=ivory, label="NFR:correct"];
-	instance:verifiable	[shape=box, color=black, style=filled, fillcolor=ivory, label="NFR:verifiable"];
-	instance:understandable	[shape=box, color=black, style=filled, fillcolor=ivory, label="NFR:understandable"];
-	instance:reusable	[shape=box, color=black, style=filled, fillcolor=ivory, label="NFR:reusable"];
-	instance:maintainable	[shape=box, color=black, style=filled, fillcolor=ivory, label="NFR:maintainable"];
-
-	subgraph FR {
-	rank="same"
-	{instance:inputValues, instance:findMass, instance:checkWithPhysConsts, instance:outputInputDerivVals, instance:calcValues, instance:verifyEnergyOutput, instance:calcPCMMeltBegin, instance:calcPCMMeltEnd, instance:outputValues, instance:correct, instance:verifiable, instance:understandable, instance:reusable, instance:maintainable}
-	}
-
-	instance:likeChgUTP	[shape=box, color=black, style=filled, fillcolor=lavender, label="LC:likeChgUTP"];
-	instance:likeChgTCVOD	[shape=box, color=black, style=filled, fillcolor=lavender, label="LC:likeChgTCVOD"];
-	instance:likeChgTCVOL	[shape=box, color=black, style=filled, fillcolor=lavender, label="LC:likeChgTCVOL"];
-	instance:likeChgDT	[shape=box, color=black, style=filled, fillcolor=lavender, label="LC:likeChgDT"];
-	instance:likeChgDITPW	[shape=box, color=black, style=filled, fillcolor=lavender, label="LC:likeChgDITPW"];
-	instance:likeChgTLH	[shape=box, color=black, style=filled, fillcolor=lavender, label="LC:likeChgTLH"];
-	instance:unlikeChgWPFS	[shape=box, color=black, style=filled, fillcolor=lavender, label="UC:unlikeChgWPFS"];
-	instance:unlikeChgNIHG	[shape=box, color=black, style=filled, fillcolor=lavender, label="UC:unlikeChgNIHG"];
-	instance:unlikeChgNGS	[shape=box, color=black, style=filled, fillcolor=lavender, label="UC:unlikeChgNGS"];
-
-	subgraph LC {
-	rank="same"
-	{instance:likeChgUTP, instance:likeChgTCVOD, instance:likeChgTCVOL, instance:likeChgDT, instance:likeChgDITPW, instance:likeChgTLH, instance:unlikeChgWPFS, instance:unlikeChgNIHG, instance:unlikeChgNGS}
-	}
-
+digraph "avsall" {
+    "dataDefn:wVol" -> "instance:assumpVCN";
+    "theory:consThermECS" -> "instance:assumpTEO";
+    "theory:nwtnCoolingTM" -> "instance:assumpHTCC";
+    "theory:rocTempSimpRC" -> "instance:assumpCWTAT";
+    "theory:rocTempSimpRC" -> "instance:assumpTPCAV";
+    "theory:rocTempSimpRC" -> "instance:assumpDWPCoV";
+    "theory:rocTempSimpRC" -> "instance:assumpSHECov";
+    "theory:htFluxC" -> "instance:assumpLCCCW";
+    "theory:htFluxC" -> "instance:assumpTHCCoT";
+    "theory:htFluxP" -> "instance:assumpLCCWP";
+    "theory:eBalanceOnWtrRC" -> "instance:assumpCWTAT";
+    "theory:eBalanceOnWtrRC" -> "instance:assumpTPCAV";
+    "theory:eBalanceOnWtrRC" -> "instance:assumpTHCCoL";
+    "theory:eBalanceOnWtrRC" -> "instance:assumpCTNOD";
+    "theory:eBalanceOnWtrRC" -> "instance:assumpSITWP";
+    "theory:eBalanceOnWtrRC" -> "instance:assumpWAL";
+    "theory:eBalanceOnWtrRC" -> "instance:assumpPIT";
+    "theory:eBalanceOnWtrRC" -> "instance:assumpNIHGBWP";
+    "theory:eBalanceOnWtrRC" -> "instance:assumpAPT";
+    "theory:eBalanceOnPCMRC" -> "instance:assumpCWTAT";
+    "theory:eBalanceOnPCMRC" -> "instance:assumpTPCAV";
+    "theory:eBalanceOnPCMRC" -> "instance:assumpSITWP";
+    "theory:eBalanceOnPCMRC" -> "instance:assumpPIS";
+    "theory:eBalanceOnPCMRC" -> "instance:assumpNIHGBWP";
+    "theory:eBalanceOnPCMRC" -> "instance:assumpVCMPN";
+    "theory:eBalanceOnPCMRC" -> "instance:assumpNGSP";
+    "theory:heatEInWtrIM" -> "instance:assumpWAL";
+    "theory:heatEInWtrIM" -> "instance:assumpAPT";
+    "theory:heatEInPCMRC" -> "instance:assumpPIS";
+    "theory:heatEInPCMRC" -> "instance:assumpNGSP";
+    "instance:likeChgUTP" -> "instance:assumpTPCAV";
+    "instance:likeChgTCVOD" -> "instance:assumpTHCCoT";
+    "instance:likeChgTCVOL" -> "instance:assumpTHCCoL";
+    "instance:likeChgDT" -> "instance:assumpCTNOD";
+    "instance:likeChgDITPW" -> "instance:assumpSITWP";
+    "instance:likeChgTLH" -> "instance:assumpPIT";
+    "instance:unlikeChgWPFS" -> "instance:assumpWAL";
+    "instance:unlikeChgWPFS" -> "instance:assumpNGSP";
+    "instance:unlikeChgNIHG" -> "instance:assumpNIHGBWP";
+    "instance:unlikeChgNGS" -> "instance:assumpNGSP";
+    "instance:assumpTEO" [shape=box, color=black, style=filled, fillcolor="mistyrose", label="A:assumpTEO"];
+    "instance:assumpHTCC" [shape=box, color=black, style=filled, fillcolor="mistyrose", label="A:assumpHTCC"];
+    "instance:assumpCWTAT" [shape=box, color=black, style=filled, fillcolor="mistyrose", label="A:assumpCWTAT"];
+    "instance:assumpTPCAV" [shape=box, color=black, style=filled, fillcolor="mistyrose", label="A:assumpTPCAV"];
+    "instance:assumpDWPCoV" [shape=box, color=black, style=filled, fillcolor="mistyrose", label="A:assumpDWPCoV"];
+    "instance:assumpSHECov" [shape=box, color=black, style=filled, fillcolor="mistyrose", label="A:assumpSHECov"];
+    "instance:assumpLCCCW" [shape=box, color=black, style=filled, fillcolor="mistyrose", label="A:assumpLCCCW"];
+    "instance:assumpTHCCoT" [shape=box, color=black, style=filled, fillcolor="mistyrose", label="A:assumpTHCCoT"];
+    "instance:assumpTHCCoL" [shape=box, color=black, style=filled, fillcolor="mistyrose", label="A:assumpTHCCoL"];
+    "instance:assumpLCCWP" [shape=box, color=black, style=filled, fillcolor="mistyrose", label="A:assumpLCCWP"];
+    "instance:assumpCTNOD" [shape=box, color=black, style=filled, fillcolor="mistyrose", label="A:assumpCTNOD"];
+    "instance:assumpSITWP" [shape=box, color=black, style=filled, fillcolor="mistyrose", label="A:assumpSITWP"];
+    "instance:assumpPIS" [shape=box, color=black, style=filled, fillcolor="mistyrose", label="A:assumpPIS"];
+    "instance:assumpWAL" [shape=box, color=black, style=filled, fillcolor="mistyrose", label="A:assumpWAL"];
+    "instance:assumpPIT" [shape=box, color=black, style=filled, fillcolor="mistyrose", label="A:assumpPIT"];
+    "instance:assumpNIHGBWP" [shape=box, color=black, style=filled, fillcolor="mistyrose", label="A:assumpNIHGBWP"];
+    "instance:assumpVCMPN" [shape=box, color=black, style=filled, fillcolor="mistyrose", label="A:assumpVCMPN"];
+    "instance:assumpNGSP" [shape=box, color=black, style=filled, fillcolor="mistyrose", label="A:assumpNGSP"];
+    "instance:assumpAPT" [shape=box, color=black, style=filled, fillcolor="mistyrose", label="A:assumpAPT"];
+    "instance:assumpVCN" [shape=box, color=black, style=filled, fillcolor="mistyrose", label="A:assumpVCN"];
+    subgraph "A" {
+        rank="same";
+        "instance:assumpTEO" "instance:assumpHTCC" "instance:assumpCWTAT" "instance:assumpTPCAV" "instance:assumpDWPCoV" "instance:assumpSHECov" "instance:assumpLCCCW" "instance:assumpTHCCoT" "instance:assumpTHCCoL" "instance:assumpLCCWP" "instance:assumpCTNOD" "instance:assumpSITWP" "instance:assumpPIS" "instance:assumpWAL" "instance:assumpPIT" "instance:assumpNIHGBWP" "instance:assumpVCMPN" "instance:assumpNGSP" "instance:assumpAPT" "instance:assumpVCN";
+    }
+    "dataDefn:wMass" [shape=box, color=black, style=filled, fillcolor="paleturquoise1", label="DD:waterMass"];
+    "dataDefn:wVol" [shape=box, color=black, style=filled, fillcolor="paleturquoise1", label="DD:waterVolume.pcm"];
+    "dataDefn:tankVol" [shape=box, color=black, style=filled, fillcolor="paleturquoise1", label="DD:tankVolume"];
+    "dataDefn:tauW" [shape=box, color=black, style=filled, fillcolor="paleturquoise1", label="DD:balanceDecayRate"];
+    "dataDefn:eta" [shape=box, color=black, style=filled, fillcolor="paleturquoise1", label="DD:balanceDecayTime"];
+    "dataDefn:tauSP" [shape=box, color=black, style=filled, fillcolor="paleturquoise1", label="DD:balanceSolidPCM"];
+    "dataDefn:tauLP" [shape=box, color=black, style=filled, fillcolor="paleturquoise1", label="DD:balanceLiquidPCM"];
+    "dataDefn:htFusion" [shape=box, color=black, style=filled, fillcolor="paleturquoise1", label="DD:htFusion"];
+    "dataDefn:meltFrac" [shape=box, color=black, style=filled, fillcolor="paleturquoise1", label="DD:meltFrac"];
+    "dataDefn:aspectRatio" [shape=box, color=black, style=filled, fillcolor="paleturquoise1", label="DD:aspectRatio"];
+    subgraph "DD" {
+        rank="same";
+        "dataDefn:wMass" "dataDefn:wVol" "dataDefn:tankVol" "dataDefn:tauW" "dataDefn:eta" "dataDefn:tauSP" "dataDefn:tauLP" "dataDefn:htFusion" "dataDefn:meltFrac" "dataDefn:aspectRatio";
+    }
+    "theory:consThermECS" [shape=box, color=black, style=filled, fillcolor="pink", label="TM:consThermE"];
+    "theory:sensHeat" [shape=box, color=black, style=filled, fillcolor="pink", label="TM:sensHtE"];
+    "theory:latentHtETM" [shape=box, color=black, style=filled, fillcolor="pink", label="TM:latentHtE"];
+    "theory:nwtnCoolingTM" [shape=box, color=black, style=filled, fillcolor="pink", label="TM:nwtnCooling"];
+    subgraph "TM" {
+        rank="same";
+        "theory:consThermECS" "theory:sensHeat" "theory:latentHtETM" "theory:nwtnCoolingTM";
+    }
+    "theory:rocTempSimpRC" [shape=box, color=black, style=filled, fillcolor="palegreen", label="GD:rocTempSimp"];
+    "theory:htFluxC" [shape=box, color=black, style=filled, fillcolor="palegreen", label="GD:htFluxWaterFromCoil"];
+    "theory:htFluxP" [shape=box, color=black, style=filled, fillcolor="palegreen", label="GD:htFluxPCMFromWater"];
+    subgraph "GD" {
+        rank="same";
+        "theory:rocTempSimpRC" "theory:htFluxC" "theory:htFluxP";
+    }
+    "theory:eBalanceOnWtrRC" [shape=box, color=black, style=filled, fillcolor="khaki1", label="IM:eBalanceOnWtr"];
+    "theory:eBalanceOnPCMRC" [shape=box, color=black, style=filled, fillcolor="khaki1", label="IM:eBalanceOnPCM"];
+    "theory:heatEInWtrIM" [shape=box, color=black, style=filled, fillcolor="khaki1", label="IM:heatEInWtr"];
+    "theory:heatEInPCMRC" [shape=box, color=black, style=filled, fillcolor="khaki1", label="IM:heatEInPCM"];
+    subgraph "IM" {
+        rank="same";
+        "theory:eBalanceOnWtrRC" "theory:eBalanceOnPCMRC" "theory:heatEInWtrIM" "theory:heatEInPCMRC";
+    }
+    "instance:inputValues" [shape=box, color=black, style=filled, fillcolor="ivory", label="FR:inputValues"];
+    "instance:findMass" [shape=box, color=black, style=filled, fillcolor="ivory", label="FR:findMass"];
+    "instance:checkWithPhysConsts" [shape=box, color=black, style=filled, fillcolor="ivory", label="FR:checkWithPhysConsts"];
+    "instance:outputInputDerivVals" [shape=box, color=black, style=filled, fillcolor="ivory", label="FR:outputInputDerivVals"];
+    "instance:calcValues" [shape=box, color=black, style=filled, fillcolor="ivory", label="FR:calcValues"];
+    "instance:verifyEnergyOutput" [shape=box, color=black, style=filled, fillcolor="ivory", label="FR:verifyEnergyOutput"];
+    "instance:calcPCMMeltBegin" [shape=box, color=black, style=filled, fillcolor="ivory", label="FR:calcPCMMeltBegin"];
+    "instance:calcPCMMeltEnd" [shape=box, color=black, style=filled, fillcolor="ivory", label="FR:calcPCMMeltEnd"];
+    "instance:outputValues" [shape=box, color=black, style=filled, fillcolor="ivory", label="FR:outputValues"];
+    "instance:correct" [shape=box, color=black, style=filled, fillcolor="ivory", label="NFR:correct"];
+    "instance:verifiable" [shape=box, color=black, style=filled, fillcolor="ivory", label="NFR:verifiable"];
+    "instance:understandable" [shape=box, color=black, style=filled, fillcolor="ivory", label="NFR:understandable"];
+    "instance:reusable" [shape=box, color=black, style=filled, fillcolor="ivory", label="NFR:reusable"];
+    "instance:maintainable" [shape=box, color=black, style=filled, fillcolor="ivory", label="NFR:maintainable"];
+    subgraph "FR" {
+        rank="same";
+        "instance:inputValues" "instance:findMass" "instance:checkWithPhysConsts" "instance:outputInputDerivVals" "instance:calcValues" "instance:verifyEnergyOutput" "instance:calcPCMMeltBegin" "instance:calcPCMMeltEnd" "instance:outputValues" "instance:correct" "instance:verifiable" "instance:understandable" "instance:reusable" "instance:maintainable";
+    }
+    "instance:likeChgUTP" [shape=box, color=black, style=filled, fillcolor="lavender", label="LC:likeChgUTP"];
+    "instance:likeChgTCVOD" [shape=box, color=black, style=filled, fillcolor="lavender", label="LC:likeChgTCVOD"];
+    "instance:likeChgTCVOL" [shape=box, color=black, style=filled, fillcolor="lavender", label="LC:likeChgTCVOL"];
+    "instance:likeChgDT" [shape=box, color=black, style=filled, fillcolor="lavender", label="LC:likeChgDT"];
+    "instance:likeChgDITPW" [shape=box, color=black, style=filled, fillcolor="lavender", label="LC:likeChgDITPW"];
+    "instance:likeChgTLH" [shape=box, color=black, style=filled, fillcolor="lavender", label="LC:likeChgTLH"];
+    "instance:unlikeChgWPFS" [shape=box, color=black, style=filled, fillcolor="lavender", label="UC:unlikeChgWPFS"];
+    "instance:unlikeChgNIHG" [shape=box, color=black, style=filled, fillcolor="lavender", label="UC:unlikeChgNIHG"];
+    "instance:unlikeChgNGS" [shape=box, color=black, style=filled, fillcolor="lavender", label="UC:unlikeChgNGS"];
+    subgraph "LC" {
+        rank="same";
+        "instance:likeChgUTP" "instance:likeChgTCVOD" "instance:likeChgTCVOL" "instance:likeChgDT" "instance:likeChgDITPW" "instance:likeChgTLH" "instance:unlikeChgWPFS" "instance:unlikeChgNIHG" "instance:unlikeChgNGS";
+    }
 }

--- a/code/stable/swhs/TraceyGraph/refvsref.dot
+++ b/code/stable/swhs/TraceyGraph/refvsref.dot
@@ -1,75 +1,65 @@
-digraph refvsref {
-	dataDefn:wVol -> dataDefn:tankVol;
-	dataDefn:meltFrac -> dataDefn:htFusion;
-	theory:sensHeat -> theory:latentHtETM;
-	theory:latentHtETM -> dataDefn:meltFrac;
-	theory:rocTempSimpRC -> theory:consThermECS;
-	theory:rocTempSimpRC -> theory:rocTempSimpRC;
-	theory:htFluxC -> theory:nwtnCoolingTM;
-	theory:htFluxP -> theory:nwtnCoolingTM;
-	theory:eBalanceOnWtrRC -> dataDefn:tauW;
-	theory:eBalanceOnWtrRC -> dataDefn:eta;
-	theory:eBalanceOnWtrRC -> theory:rocTempSimpRC;
-	theory:eBalanceOnWtrRC -> theory:htFluxC;
-	theory:eBalanceOnWtrRC -> theory:htFluxP;
-	theory:eBalanceOnWtrRC -> theory:eBalanceOnWtrRC;
-	theory:eBalanceOnWtrRC -> theory:eBalanceOnPCMRC;
-	theory:eBalanceOnPCMRC -> dataDefn:tauSP;
-	theory:eBalanceOnPCMRC -> dataDefn:tauLP;
-	theory:eBalanceOnPCMRC -> dataDefn:meltFrac;
-	theory:eBalanceOnPCMRC -> theory:rocTempSimpRC;
-	theory:eBalanceOnPCMRC -> theory:htFluxP;
-	theory:eBalanceOnPCMRC -> theory:eBalanceOnWtrRC;
-	theory:eBalanceOnPCMRC -> theory:heatEInPCMRC;
-	theory:heatEInWtrIM -> theory:sensHeat;
-	theory:heatEInPCMRC -> dataDefn:htFusion;
-	theory:heatEInPCMRC -> theory:sensHeat;
-	theory:heatEInPCMRC -> theory:latentHtETM;
-
-
-	dataDefn:wMass	[shape=box, color=black, style=filled, fillcolor=paleturquoise1, label="DD:waterMass"];
-	dataDefn:wVol	[shape=box, color=black, style=filled, fillcolor=paleturquoise1, label="DD:waterVolume.pcm"];
-	dataDefn:tankVol	[shape=box, color=black, style=filled, fillcolor=paleturquoise1, label="DD:tankVolume"];
-	dataDefn:tauW	[shape=box, color=black, style=filled, fillcolor=paleturquoise1, label="DD:balanceDecayRate"];
-	dataDefn:eta	[shape=box, color=black, style=filled, fillcolor=paleturquoise1, label="DD:balanceDecayTime"];
-	dataDefn:tauSP	[shape=box, color=black, style=filled, fillcolor=paleturquoise1, label="DD:balanceSolidPCM"];
-	dataDefn:tauLP	[shape=box, color=black, style=filled, fillcolor=paleturquoise1, label="DD:balanceLiquidPCM"];
-	dataDefn:htFusion	[shape=box, color=black, style=filled, fillcolor=paleturquoise1, label="DD:htFusion"];
-	dataDefn:meltFrac	[shape=box, color=black, style=filled, fillcolor=paleturquoise1, label="DD:meltFrac"];
-	dataDefn:aspectRatio	[shape=box, color=black, style=filled, fillcolor=paleturquoise1, label="DD:aspectRatio"];
-
-	subgraph DD {
-	rank="same"
-	{dataDefn:wMass, dataDefn:wVol, dataDefn:tankVol, dataDefn:tauW, dataDefn:eta, dataDefn:tauSP, dataDefn:tauLP, dataDefn:htFusion, dataDefn:meltFrac, dataDefn:aspectRatio}
-	}
-
-	theory:consThermECS	[shape=box, color=black, style=filled, fillcolor=pink, label="TM:consThermE"];
-	theory:sensHeat	[shape=box, color=black, style=filled, fillcolor=pink, label="TM:sensHtE"];
-	theory:latentHtETM	[shape=box, color=black, style=filled, fillcolor=pink, label="TM:latentHtE"];
-	theory:nwtnCoolingTM	[shape=box, color=black, style=filled, fillcolor=pink, label="TM:nwtnCooling"];
-
-	subgraph TM {
-	rank="same"
-	{theory:consThermECS, theory:sensHeat, theory:latentHtETM, theory:nwtnCoolingTM}
-	}
-
-	theory:rocTempSimpRC	[shape=box, color=black, style=filled, fillcolor=palegreen, label="GD:rocTempSimp"];
-	theory:htFluxC	[shape=box, color=black, style=filled, fillcolor=palegreen, label="GD:htFluxWaterFromCoil"];
-	theory:htFluxP	[shape=box, color=black, style=filled, fillcolor=palegreen, label="GD:htFluxPCMFromWater"];
-
-	subgraph GD {
-	rank="same"
-	{theory:rocTempSimpRC, theory:htFluxC, theory:htFluxP}
-	}
-
-	theory:eBalanceOnWtrRC	[shape=box, color=black, style=filled, fillcolor=khaki1, label="IM:eBalanceOnWtr"];
-	theory:eBalanceOnPCMRC	[shape=box, color=black, style=filled, fillcolor=khaki1, label="IM:eBalanceOnPCM"];
-	theory:heatEInWtrIM	[shape=box, color=black, style=filled, fillcolor=khaki1, label="IM:heatEInWtr"];
-	theory:heatEInPCMRC	[shape=box, color=black, style=filled, fillcolor=khaki1, label="IM:heatEInPCM"];
-
-	subgraph IM {
-	rank="same"
-	{theory:eBalanceOnWtrRC, theory:eBalanceOnPCMRC, theory:heatEInWtrIM, theory:heatEInPCMRC}
-	}
-
+digraph "refvsref" {
+    "dataDefn:wVol" -> "dataDefn:tankVol";
+    "dataDefn:meltFrac" -> "dataDefn:htFusion";
+    "theory:sensHeat" -> "theory:latentHtETM";
+    "theory:latentHtETM" -> "dataDefn:meltFrac";
+    "theory:rocTempSimpRC" -> "theory:consThermECS";
+    "theory:rocTempSimpRC" -> "theory:rocTempSimpRC";
+    "theory:htFluxC" -> "theory:nwtnCoolingTM";
+    "theory:htFluxP" -> "theory:nwtnCoolingTM";
+    "theory:eBalanceOnWtrRC" -> "dataDefn:tauW";
+    "theory:eBalanceOnWtrRC" -> "dataDefn:eta";
+    "theory:eBalanceOnWtrRC" -> "theory:rocTempSimpRC";
+    "theory:eBalanceOnWtrRC" -> "theory:htFluxC";
+    "theory:eBalanceOnWtrRC" -> "theory:htFluxP";
+    "theory:eBalanceOnWtrRC" -> "theory:eBalanceOnWtrRC";
+    "theory:eBalanceOnWtrRC" -> "theory:eBalanceOnPCMRC";
+    "theory:eBalanceOnPCMRC" -> "dataDefn:tauSP";
+    "theory:eBalanceOnPCMRC" -> "dataDefn:tauLP";
+    "theory:eBalanceOnPCMRC" -> "dataDefn:meltFrac";
+    "theory:eBalanceOnPCMRC" -> "theory:rocTempSimpRC";
+    "theory:eBalanceOnPCMRC" -> "theory:htFluxP";
+    "theory:eBalanceOnPCMRC" -> "theory:eBalanceOnWtrRC";
+    "theory:eBalanceOnPCMRC" -> "theory:heatEInPCMRC";
+    "theory:heatEInWtrIM" -> "theory:sensHeat";
+    "theory:heatEInPCMRC" -> "dataDefn:htFusion";
+    "theory:heatEInPCMRC" -> "theory:sensHeat";
+    "theory:heatEInPCMRC" -> "theory:latentHtETM";
+    "dataDefn:wMass" [shape=box, color=black, style=filled, fillcolor="paleturquoise1", label="DD:waterMass"];
+    "dataDefn:wVol" [shape=box, color=black, style=filled, fillcolor="paleturquoise1", label="DD:waterVolume.pcm"];
+    "dataDefn:tankVol" [shape=box, color=black, style=filled, fillcolor="paleturquoise1", label="DD:tankVolume"];
+    "dataDefn:tauW" [shape=box, color=black, style=filled, fillcolor="paleturquoise1", label="DD:balanceDecayRate"];
+    "dataDefn:eta" [shape=box, color=black, style=filled, fillcolor="paleturquoise1", label="DD:balanceDecayTime"];
+    "dataDefn:tauSP" [shape=box, color=black, style=filled, fillcolor="paleturquoise1", label="DD:balanceSolidPCM"];
+    "dataDefn:tauLP" [shape=box, color=black, style=filled, fillcolor="paleturquoise1", label="DD:balanceLiquidPCM"];
+    "dataDefn:htFusion" [shape=box, color=black, style=filled, fillcolor="paleturquoise1", label="DD:htFusion"];
+    "dataDefn:meltFrac" [shape=box, color=black, style=filled, fillcolor="paleturquoise1", label="DD:meltFrac"];
+    "dataDefn:aspectRatio" [shape=box, color=black, style=filled, fillcolor="paleturquoise1", label="DD:aspectRatio"];
+    subgraph "DD" {
+        rank="same";
+        "dataDefn:wMass" "dataDefn:wVol" "dataDefn:tankVol" "dataDefn:tauW" "dataDefn:eta" "dataDefn:tauSP" "dataDefn:tauLP" "dataDefn:htFusion" "dataDefn:meltFrac" "dataDefn:aspectRatio";
+    }
+    "theory:consThermECS" [shape=box, color=black, style=filled, fillcolor="pink", label="TM:consThermE"];
+    "theory:sensHeat" [shape=box, color=black, style=filled, fillcolor="pink", label="TM:sensHtE"];
+    "theory:latentHtETM" [shape=box, color=black, style=filled, fillcolor="pink", label="TM:latentHtE"];
+    "theory:nwtnCoolingTM" [shape=box, color=black, style=filled, fillcolor="pink", label="TM:nwtnCooling"];
+    subgraph "TM" {
+        rank="same";
+        "theory:consThermECS" "theory:sensHeat" "theory:latentHtETM" "theory:nwtnCoolingTM";
+    }
+    "theory:rocTempSimpRC" [shape=box, color=black, style=filled, fillcolor="palegreen", label="GD:rocTempSimp"];
+    "theory:htFluxC" [shape=box, color=black, style=filled, fillcolor="palegreen", label="GD:htFluxWaterFromCoil"];
+    "theory:htFluxP" [shape=box, color=black, style=filled, fillcolor="palegreen", label="GD:htFluxPCMFromWater"];
+    subgraph "GD" {
+        rank="same";
+        "theory:rocTempSimpRC" "theory:htFluxC" "theory:htFluxP";
+    }
+    "theory:eBalanceOnWtrRC" [shape=box, color=black, style=filled, fillcolor="khaki1", label="IM:eBalanceOnWtr"];
+    "theory:eBalanceOnPCMRC" [shape=box, color=black, style=filled, fillcolor="khaki1", label="IM:eBalanceOnPCM"];
+    "theory:heatEInWtrIM" [shape=box, color=black, style=filled, fillcolor="khaki1", label="IM:heatEInWtr"];
+    "theory:heatEInPCMRC" [shape=box, color=black, style=filled, fillcolor="khaki1", label="IM:heatEInPCM"];
+    subgraph "IM" {
+        rank="same";
+        "theory:eBalanceOnWtrRC" "theory:eBalanceOnPCMRC" "theory:heatEInWtrIM" "theory:heatEInPCMRC";
+    }
 }

--- a/code/stable/swhsnopcm/TraceyGraph/allvsall.dot
+++ b/code/stable/swhsnopcm/TraceyGraph/allvsall.dot
@@ -1,137 +1,119 @@
-digraph allvsall {
-	dataDefn:wVol -> instance:assumpVCN;
-	dataDefn:wVol -> dataDefn:tankVol;
-	theory:consThermECS -> instance:assumpTEO;
-	theory:sensHeat -> instance:assumpWAL;
-	theory:nwtnCoolingTM -> instance:assumpHTCC;
-	theory:rocTempSimpRC -> instance:assumpCWTAT;
-	theory:rocTempSimpRC -> instance:assumpDWCoW;
-	theory:rocTempSimpRC -> instance:assumpSHECoW;
-	theory:rocTempSimpRC -> theory:consThermECS;
-	theory:rocTempSimpRC -> theory:rocTempSimpRC;
-	theory:htFluxC -> instance:assumpLCCCW;
-	theory:htFluxC -> instance:assumpTHCCoT;
-	theory:htFluxC -> theory:nwtnCoolingTM;
-	theory:eBalanceOnWtrRC -> instance:assumpWAL;
-	theory:eBalanceOnWtrRC -> instance:assumpPIT;
-	theory:eBalanceOnWtrRC -> instance:assumpNIHGBW;
-	theory:eBalanceOnWtrRC -> dataDefn:tauW;
-	theory:eBalanceOnWtrRC -> theory:rocTempSimpRC;
-	theory:eBalanceOnWtrRC -> theory:htFluxC;
-	theory:heatEInWtrIM -> instance:assumpWAL;
-	theory:heatEInWtrIM -> instance:assumpAPT;
-	theory:heatEInWtrIM -> theory:sensHeat;
-	instance:findMass -> dataDefn:wMass;
-	instance:findMass -> dataDefn:wVol;
-	instance:findMass -> dataDefn:tankVol;
-	instance:findMass -> theory:eBalanceOnWtrRC;
-	instance:findMass -> instance:inputValues;
-	instance:outputInputDerivVals -> dataDefn:tauW;
-	instance:outputInputDerivVals -> instance:inputValues;
-	instance:outputInputDerivVals -> instance:findMass;
-	instance:calcValues -> theory:eBalanceOnWtrRC;
-	instance:calcValues -> theory:heatEInWtrIM;
-	instance:outputValues -> theory:eBalanceOnWtrRC;
-	instance:outputValues -> theory:heatEInWtrIM;
-	instance:likeChgTCVOD -> instance:assumpTHCCoT;
-	instance:likeChgTCVOL -> instance:assumpTHCCoL;
-	instance:likeChgDT -> instance:assumpCTNTD;
-	instance:likeChgTLH -> instance:assumpPIT;
-	instance:unlikeChgWFS -> instance:assumpWAL;
-	instance:unlikeChgNIHG -> instance:assumpNIHGBW;
-	instance:unlikeChgNIHG -> theory:eBalanceOnWtrRC;
-
-
-	instance:assumpTEO	[shape=box, color=black, style=filled, fillcolor=mistyrose, label="A:assumpTEO"];
-	instance:assumpHTCC	[shape=box, color=black, style=filled, fillcolor=mistyrose, label="A:assumpHTCC"];
-	instance:assumpCWTAT	[shape=box, color=black, style=filled, fillcolor=mistyrose, label="A:assumpCWTAT"];
-	instance:assumpDWCoW	[shape=box, color=black, style=filled, fillcolor=mistyrose, label="A:assumpDWCoW"];
-	instance:assumpSHECoW	[shape=box, color=black, style=filled, fillcolor=mistyrose, label="A:assumpSHECoW"];
-	instance:assumpLCCCW	[shape=box, color=black, style=filled, fillcolor=mistyrose, label="A:assumpLCCCW"];
-	instance:assumpTHCCoT	[shape=box, color=black, style=filled, fillcolor=mistyrose, label="A:assumpTHCCoT"];
-	instance:assumpTHCCoL	[shape=box, color=black, style=filled, fillcolor=mistyrose, label="A:assumpTHCCoL"];
-	instance:assumpCTNTD	[shape=box, color=black, style=filled, fillcolor=mistyrose, label="A:assumpCTNTD"];
-	instance:assumpWAL	[shape=box, color=black, style=filled, fillcolor=mistyrose, label="A:assumpWAL"];
-	instance:assumpPIT	[shape=box, color=black, style=filled, fillcolor=mistyrose, label="A:assumpPIT"];
-	instance:assumpNIHGBW	[shape=box, color=black, style=filled, fillcolor=mistyrose, label="A:assumpNIHGBW"];
-	instance:assumpAPT	[shape=box, color=black, style=filled, fillcolor=mistyrose, label="A:assumpAPT"];
-	instance:assumpVCN	[shape=box, color=black, style=filled, fillcolor=mistyrose, label="A:assumpVCN"];
-
-	subgraph A {
-	rank="same"
-	{instance:assumpTEO, instance:assumpHTCC, instance:assumpCWTAT, instance:assumpDWCoW, instance:assumpSHECoW, instance:assumpLCCCW, instance:assumpTHCCoT, instance:assumpTHCCoL, instance:assumpCTNTD, instance:assumpWAL, instance:assumpPIT, instance:assumpNIHGBW, instance:assumpAPT, instance:assumpVCN}
-	}
-
-	dataDefn:wMass	[shape=box, color=black, style=filled, fillcolor=paleturquoise1, label="DD:waterMass"];
-	dataDefn:wVol	[shape=box, color=black, style=filled, fillcolor=paleturquoise1, label="DD:waterVolume.nopcm"];
-	dataDefn:tankVol	[shape=box, color=black, style=filled, fillcolor=paleturquoise1, label="DD:tankVolume"];
-	dataDefn:tauW	[shape=box, color=black, style=filled, fillcolor=paleturquoise1, label="DD:balanceDecayRate"];
-
-	subgraph DD {
-	rank="same"
-	{dataDefn:wMass, dataDefn:wVol, dataDefn:tankVol, dataDefn:tauW}
-	}
-
-	theory:consThermECS	[shape=box, color=black, style=filled, fillcolor=pink, label="TM:consThermE"];
-	theory:sensHeat	[shape=box, color=black, style=filled, fillcolor=pink, label="TM:sensHtE"];
-	theory:nwtnCoolingTM	[shape=box, color=black, style=filled, fillcolor=pink, label="TM:nwtnCooling"];
-
-	subgraph TM {
-	rank="same"
-	{theory:consThermECS, theory:sensHeat, theory:nwtnCoolingTM}
-	}
-
-	theory:rocTempSimpRC	[shape=box, color=black, style=filled, fillcolor=palegreen, label="GD:rocTempSimp"];
-	theory:htFluxC	[shape=box, color=black, style=filled, fillcolor=palegreen, label="GD:htFluxWaterFromCoil"];
-
-	subgraph GD {
-	rank="same"
-	{theory:rocTempSimpRC, theory:htFluxC}
-	}
-
-	theory:eBalanceOnWtrRC	[shape=box, color=black, style=filled, fillcolor=khaki1, label="IM:eBalanceOnWtr"];
-	theory:heatEInWtrIM	[shape=box, color=black, style=filled, fillcolor=khaki1, label="IM:heatEInWtr"];
-
-	subgraph IM {
-	rank="same"
-	{theory:eBalanceOnWtrRC, theory:heatEInWtrIM}
-	}
-
-	instance:inputValues	[shape=box, color=black, style=filled, fillcolor=ivory, label="FR:inputValues"];
-	instance:findMass	[shape=box, color=black, style=filled, fillcolor=ivory, label="FR:findMass"];
-	instance:checkWithPhysConsts	[shape=box, color=black, style=filled, fillcolor=ivory, label="FR:checkWithPhysConsts"];
-	instance:outputInputDerivVals	[shape=box, color=black, style=filled, fillcolor=ivory, label="FR:outputInputDerivVals"];
-	instance:calcValues	[shape=box, color=black, style=filled, fillcolor=ivory, label="FR:calcValues"];
-	instance:outputValues	[shape=box, color=black, style=filled, fillcolor=ivory, label="FR:outputValues"];
-	instance:correct	[shape=box, color=black, style=filled, fillcolor=ivory, label="NFR:correct"];
-	instance:verifiable	[shape=box, color=black, style=filled, fillcolor=ivory, label="NFR:verifiable"];
-	instance:understandable	[shape=box, color=black, style=filled, fillcolor=ivory, label="NFR:understandable"];
-	instance:reusable	[shape=box, color=black, style=filled, fillcolor=ivory, label="NFR:reusable"];
-	instance:maintainable	[shape=box, color=black, style=filled, fillcolor=ivory, label="NFR:maintainable"];
-
-	subgraph FR {
-	rank="same"
-	{instance:inputValues, instance:findMass, instance:checkWithPhysConsts, instance:outputInputDerivVals, instance:calcValues, instance:outputValues, instance:correct, instance:verifiable, instance:understandable, instance:reusable, instance:maintainable}
-	}
-
-	instance:waterTempGS	[shape=box, color=black, style=filled, fillcolor=darkgoldenrod1, label="GS:waterTempGS"];
-	instance:waterEnergyGS	[shape=box, color=black, style=filled, fillcolor=darkgoldenrod1, label="GS:waterEnergyGS"];
-
-	subgraph GS {
-	rank="same"
-	{instance:waterTempGS, instance:waterEnergyGS}
-	}
-
-	instance:likeChgTCVOD	[shape=box, color=black, style=filled, fillcolor=lavender, label="LC:likeChgTCVOD"];
-	instance:likeChgTCVOL	[shape=box, color=black, style=filled, fillcolor=lavender, label="LC:likeChgTCVOL"];
-	instance:likeChgDT	[shape=box, color=black, style=filled, fillcolor=lavender, label="LC:likeChgDT"];
-	instance:likeChgTLH	[shape=box, color=black, style=filled, fillcolor=lavender, label="LC:likeChgTLH"];
-	instance:unlikeChgWFS	[shape=box, color=black, style=filled, fillcolor=lavender, label="UC:unlikeChgWFS"];
-	instance:unlikeChgNIHG	[shape=box, color=black, style=filled, fillcolor=lavender, label="UC:unlikeChgNIHG"];
-
-	subgraph LC {
-	rank="same"
-	{instance:likeChgTCVOD, instance:likeChgTCVOL, instance:likeChgDT, instance:likeChgTLH, instance:unlikeChgWFS, instance:unlikeChgNIHG}
-	}
-
+digraph "allvsall" {
+    "dataDefn:wVol" -> "instance:assumpVCN";
+    "dataDefn:wVol" -> "dataDefn:tankVol";
+    "theory:consThermECS" -> "instance:assumpTEO";
+    "theory:sensHeat" -> "instance:assumpWAL";
+    "theory:nwtnCoolingTM" -> "instance:assumpHTCC";
+    "theory:rocTempSimpRC" -> "instance:assumpCWTAT";
+    "theory:rocTempSimpRC" -> "instance:assumpDWCoW";
+    "theory:rocTempSimpRC" -> "instance:assumpSHECoW";
+    "theory:rocTempSimpRC" -> "theory:consThermECS";
+    "theory:rocTempSimpRC" -> "theory:rocTempSimpRC";
+    "theory:htFluxC" -> "instance:assumpLCCCW";
+    "theory:htFluxC" -> "instance:assumpTHCCoT";
+    "theory:htFluxC" -> "theory:nwtnCoolingTM";
+    "theory:eBalanceOnWtrRC" -> "instance:assumpWAL";
+    "theory:eBalanceOnWtrRC" -> "instance:assumpPIT";
+    "theory:eBalanceOnWtrRC" -> "instance:assumpNIHGBW";
+    "theory:eBalanceOnWtrRC" -> "dataDefn:tauW";
+    "theory:eBalanceOnWtrRC" -> "theory:rocTempSimpRC";
+    "theory:eBalanceOnWtrRC" -> "theory:htFluxC";
+    "theory:heatEInWtrIM" -> "instance:assumpWAL";
+    "theory:heatEInWtrIM" -> "instance:assumpAPT";
+    "theory:heatEInWtrIM" -> "theory:sensHeat";
+    "instance:findMass" -> "dataDefn:wMass";
+    "instance:findMass" -> "dataDefn:wVol";
+    "instance:findMass" -> "dataDefn:tankVol";
+    "instance:findMass" -> "theory:eBalanceOnWtrRC";
+    "instance:findMass" -> "instance:inputValues";
+    "instance:outputInputDerivVals" -> "dataDefn:tauW";
+    "instance:outputInputDerivVals" -> "instance:inputValues";
+    "instance:outputInputDerivVals" -> "instance:findMass";
+    "instance:calcValues" -> "theory:eBalanceOnWtrRC";
+    "instance:calcValues" -> "theory:heatEInWtrIM";
+    "instance:outputValues" -> "theory:eBalanceOnWtrRC";
+    "instance:outputValues" -> "theory:heatEInWtrIM";
+    "instance:likeChgTCVOD" -> "instance:assumpTHCCoT";
+    "instance:likeChgTCVOL" -> "instance:assumpTHCCoL";
+    "instance:likeChgDT" -> "instance:assumpCTNTD";
+    "instance:likeChgTLH" -> "instance:assumpPIT";
+    "instance:unlikeChgWFS" -> "instance:assumpWAL";
+    "instance:unlikeChgNIHG" -> "instance:assumpNIHGBW";
+    "instance:unlikeChgNIHG" -> "theory:eBalanceOnWtrRC";
+    "instance:assumpTEO" [shape=box, color=black, style=filled, fillcolor="mistyrose", label="A:assumpTEO"];
+    "instance:assumpHTCC" [shape=box, color=black, style=filled, fillcolor="mistyrose", label="A:assumpHTCC"];
+    "instance:assumpCWTAT" [shape=box, color=black, style=filled, fillcolor="mistyrose", label="A:assumpCWTAT"];
+    "instance:assumpDWCoW" [shape=box, color=black, style=filled, fillcolor="mistyrose", label="A:assumpDWCoW"];
+    "instance:assumpSHECoW" [shape=box, color=black, style=filled, fillcolor="mistyrose", label="A:assumpSHECoW"];
+    "instance:assumpLCCCW" [shape=box, color=black, style=filled, fillcolor="mistyrose", label="A:assumpLCCCW"];
+    "instance:assumpTHCCoT" [shape=box, color=black, style=filled, fillcolor="mistyrose", label="A:assumpTHCCoT"];
+    "instance:assumpTHCCoL" [shape=box, color=black, style=filled, fillcolor="mistyrose", label="A:assumpTHCCoL"];
+    "instance:assumpCTNTD" [shape=box, color=black, style=filled, fillcolor="mistyrose", label="A:assumpCTNTD"];
+    "instance:assumpWAL" [shape=box, color=black, style=filled, fillcolor="mistyrose", label="A:assumpWAL"];
+    "instance:assumpPIT" [shape=box, color=black, style=filled, fillcolor="mistyrose", label="A:assumpPIT"];
+    "instance:assumpNIHGBW" [shape=box, color=black, style=filled, fillcolor="mistyrose", label="A:assumpNIHGBW"];
+    "instance:assumpAPT" [shape=box, color=black, style=filled, fillcolor="mistyrose", label="A:assumpAPT"];
+    "instance:assumpVCN" [shape=box, color=black, style=filled, fillcolor="mistyrose", label="A:assumpVCN"];
+    subgraph "A" {
+        rank="same";
+        "instance:assumpTEO" "instance:assumpHTCC" "instance:assumpCWTAT" "instance:assumpDWCoW" "instance:assumpSHECoW" "instance:assumpLCCCW" "instance:assumpTHCCoT" "instance:assumpTHCCoL" "instance:assumpCTNTD" "instance:assumpWAL" "instance:assumpPIT" "instance:assumpNIHGBW" "instance:assumpAPT" "instance:assumpVCN";
+    }
+    "dataDefn:wMass" [shape=box, color=black, style=filled, fillcolor="paleturquoise1", label="DD:waterMass"];
+    "dataDefn:wVol" [shape=box, color=black, style=filled, fillcolor="paleturquoise1", label="DD:waterVolume.nopcm"];
+    "dataDefn:tankVol" [shape=box, color=black, style=filled, fillcolor="paleturquoise1", label="DD:tankVolume"];
+    "dataDefn:tauW" [shape=box, color=black, style=filled, fillcolor="paleturquoise1", label="DD:balanceDecayRate"];
+    subgraph "DD" {
+        rank="same";
+        "dataDefn:wMass" "dataDefn:wVol" "dataDefn:tankVol" "dataDefn:tauW";
+    }
+    "theory:consThermECS" [shape=box, color=black, style=filled, fillcolor="pink", label="TM:consThermE"];
+    "theory:sensHeat" [shape=box, color=black, style=filled, fillcolor="pink", label="TM:sensHtE"];
+    "theory:nwtnCoolingTM" [shape=box, color=black, style=filled, fillcolor="pink", label="TM:nwtnCooling"];
+    subgraph "TM" {
+        rank="same";
+        "theory:consThermECS" "theory:sensHeat" "theory:nwtnCoolingTM";
+    }
+    "theory:rocTempSimpRC" [shape=box, color=black, style=filled, fillcolor="palegreen", label="GD:rocTempSimp"];
+    "theory:htFluxC" [shape=box, color=black, style=filled, fillcolor="palegreen", label="GD:htFluxWaterFromCoil"];
+    subgraph "GD" {
+        rank="same";
+        "theory:rocTempSimpRC" "theory:htFluxC";
+    }
+    "theory:eBalanceOnWtrRC" [shape=box, color=black, style=filled, fillcolor="khaki1", label="IM:eBalanceOnWtr"];
+    "theory:heatEInWtrIM" [shape=box, color=black, style=filled, fillcolor="khaki1", label="IM:heatEInWtr"];
+    subgraph "IM" {
+        rank="same";
+        "theory:eBalanceOnWtrRC" "theory:heatEInWtrIM";
+    }
+    "instance:inputValues" [shape=box, color=black, style=filled, fillcolor="ivory", label="FR:inputValues"];
+    "instance:findMass" [shape=box, color=black, style=filled, fillcolor="ivory", label="FR:findMass"];
+    "instance:checkWithPhysConsts" [shape=box, color=black, style=filled, fillcolor="ivory", label="FR:checkWithPhysConsts"];
+    "instance:outputInputDerivVals" [shape=box, color=black, style=filled, fillcolor="ivory", label="FR:outputInputDerivVals"];
+    "instance:calcValues" [shape=box, color=black, style=filled, fillcolor="ivory", label="FR:calcValues"];
+    "instance:outputValues" [shape=box, color=black, style=filled, fillcolor="ivory", label="FR:outputValues"];
+    "instance:correct" [shape=box, color=black, style=filled, fillcolor="ivory", label="NFR:correct"];
+    "instance:verifiable" [shape=box, color=black, style=filled, fillcolor="ivory", label="NFR:verifiable"];
+    "instance:understandable" [shape=box, color=black, style=filled, fillcolor="ivory", label="NFR:understandable"];
+    "instance:reusable" [shape=box, color=black, style=filled, fillcolor="ivory", label="NFR:reusable"];
+    "instance:maintainable" [shape=box, color=black, style=filled, fillcolor="ivory", label="NFR:maintainable"];
+    subgraph "FR" {
+        rank="same";
+        "instance:inputValues" "instance:findMass" "instance:checkWithPhysConsts" "instance:outputInputDerivVals" "instance:calcValues" "instance:outputValues" "instance:correct" "instance:verifiable" "instance:understandable" "instance:reusable" "instance:maintainable";
+    }
+    "instance:waterTempGS" [shape=box, color=black, style=filled, fillcolor="darkgoldenrod1", label="GS:waterTempGS"];
+    "instance:waterEnergyGS" [shape=box, color=black, style=filled, fillcolor="darkgoldenrod1", label="GS:waterEnergyGS"];
+    subgraph "GS" {
+        rank="same";
+        "instance:waterTempGS" "instance:waterEnergyGS";
+    }
+    "instance:likeChgTCVOD" [shape=box, color=black, style=filled, fillcolor="lavender", label="LC:likeChgTCVOD"];
+    "instance:likeChgTCVOL" [shape=box, color=black, style=filled, fillcolor="lavender", label="LC:likeChgTCVOL"];
+    "instance:likeChgDT" [shape=box, color=black, style=filled, fillcolor="lavender", label="LC:likeChgDT"];
+    "instance:likeChgTLH" [shape=box, color=black, style=filled, fillcolor="lavender", label="LC:likeChgTLH"];
+    "instance:unlikeChgWFS" [shape=box, color=black, style=filled, fillcolor="lavender", label="UC:unlikeChgWFS"];
+    "instance:unlikeChgNIHG" [shape=box, color=black, style=filled, fillcolor="lavender", label="UC:unlikeChgNIHG"];
+    subgraph "LC" {
+        rank="same";
+        "instance:likeChgTCVOD" "instance:likeChgTCVOL" "instance:likeChgDT" "instance:likeChgTLH" "instance:unlikeChgWFS" "instance:unlikeChgNIHG";
+    }
 }

--- a/code/stable/swhsnopcm/TraceyGraph/allvsr.dot
+++ b/code/stable/swhsnopcm/TraceyGraph/allvsr.dot
@@ -1,96 +1,80 @@
-digraph allvsr {
-	instance:findMass -> dataDefn:wMass;
-	instance:findMass -> dataDefn:wVol;
-	instance:findMass -> dataDefn:tankVol;
-	instance:findMass -> theory:eBalanceOnWtrRC;
-	instance:findMass -> instance:inputValues;
-	instance:outputInputDerivVals -> dataDefn:tauW;
-	instance:outputInputDerivVals -> instance:inputValues;
-	instance:outputInputDerivVals -> instance:findMass;
-	instance:calcValues -> theory:eBalanceOnWtrRC;
-	instance:calcValues -> theory:heatEInWtrIM;
-	instance:outputValues -> theory:eBalanceOnWtrRC;
-	instance:outputValues -> theory:heatEInWtrIM;
-
-
-	instance:assumpTEO	[shape=box, color=black, style=filled, fillcolor=mistyrose, label="A:assumpTEO"];
-	instance:assumpHTCC	[shape=box, color=black, style=filled, fillcolor=mistyrose, label="A:assumpHTCC"];
-	instance:assumpCWTAT	[shape=box, color=black, style=filled, fillcolor=mistyrose, label="A:assumpCWTAT"];
-	instance:assumpDWCoW	[shape=box, color=black, style=filled, fillcolor=mistyrose, label="A:assumpDWCoW"];
-	instance:assumpSHECoW	[shape=box, color=black, style=filled, fillcolor=mistyrose, label="A:assumpSHECoW"];
-	instance:assumpLCCCW	[shape=box, color=black, style=filled, fillcolor=mistyrose, label="A:assumpLCCCW"];
-	instance:assumpTHCCoT	[shape=box, color=black, style=filled, fillcolor=mistyrose, label="A:assumpTHCCoT"];
-	instance:assumpTHCCoL	[shape=box, color=black, style=filled, fillcolor=mistyrose, label="A:assumpTHCCoL"];
-	instance:assumpCTNTD	[shape=box, color=black, style=filled, fillcolor=mistyrose, label="A:assumpCTNTD"];
-	instance:assumpWAL	[shape=box, color=black, style=filled, fillcolor=mistyrose, label="A:assumpWAL"];
-	instance:assumpPIT	[shape=box, color=black, style=filled, fillcolor=mistyrose, label="A:assumpPIT"];
-	instance:assumpNIHGBW	[shape=box, color=black, style=filled, fillcolor=mistyrose, label="A:assumpNIHGBW"];
-	instance:assumpAPT	[shape=box, color=black, style=filled, fillcolor=mistyrose, label="A:assumpAPT"];
-	instance:assumpVCN	[shape=box, color=black, style=filled, fillcolor=mistyrose, label="A:assumpVCN"];
-
-	subgraph A {
-	rank="same"
-	{instance:assumpTEO, instance:assumpHTCC, instance:assumpCWTAT, instance:assumpDWCoW, instance:assumpSHECoW, instance:assumpLCCCW, instance:assumpTHCCoT, instance:assumpTHCCoL, instance:assumpCTNTD, instance:assumpWAL, instance:assumpPIT, instance:assumpNIHGBW, instance:assumpAPT, instance:assumpVCN}
-	}
-
-	dataDefn:wMass	[shape=box, color=black, style=filled, fillcolor=paleturquoise1, label="DD:waterMass"];
-	dataDefn:wVol	[shape=box, color=black, style=filled, fillcolor=paleturquoise1, label="DD:waterVolume.nopcm"];
-	dataDefn:tankVol	[shape=box, color=black, style=filled, fillcolor=paleturquoise1, label="DD:tankVolume"];
-	dataDefn:tauW	[shape=box, color=black, style=filled, fillcolor=paleturquoise1, label="DD:balanceDecayRate"];
-
-	subgraph DD {
-	rank="same"
-	{dataDefn:wMass, dataDefn:wVol, dataDefn:tankVol, dataDefn:tauW}
-	}
-
-	theory:consThermECS	[shape=box, color=black, style=filled, fillcolor=pink, label="TM:consThermE"];
-	theory:sensHeat	[shape=box, color=black, style=filled, fillcolor=pink, label="TM:sensHtE"];
-	theory:nwtnCoolingTM	[shape=box, color=black, style=filled, fillcolor=pink, label="TM:nwtnCooling"];
-
-	subgraph TM {
-	rank="same"
-	{theory:consThermECS, theory:sensHeat, theory:nwtnCoolingTM}
-	}
-
-	theory:rocTempSimpRC	[shape=box, color=black, style=filled, fillcolor=palegreen, label="GD:rocTempSimp"];
-	theory:htFluxC	[shape=box, color=black, style=filled, fillcolor=palegreen, label="GD:htFluxWaterFromCoil"];
-
-	subgraph GD {
-	rank="same"
-	{theory:rocTempSimpRC, theory:htFluxC}
-	}
-
-	theory:eBalanceOnWtrRC	[shape=box, color=black, style=filled, fillcolor=khaki1, label="IM:eBalanceOnWtr"];
-	theory:heatEInWtrIM	[shape=box, color=black, style=filled, fillcolor=khaki1, label="IM:heatEInWtr"];
-
-	subgraph IM {
-	rank="same"
-	{theory:eBalanceOnWtrRC, theory:heatEInWtrIM}
-	}
-
-	instance:inputValues	[shape=box, color=black, style=filled, fillcolor=ivory, label="FR:inputValues"];
-	instance:findMass	[shape=box, color=black, style=filled, fillcolor=ivory, label="FR:findMass"];
-	instance:checkWithPhysConsts	[shape=box, color=black, style=filled, fillcolor=ivory, label="FR:checkWithPhysConsts"];
-	instance:outputInputDerivVals	[shape=box, color=black, style=filled, fillcolor=ivory, label="FR:outputInputDerivVals"];
-	instance:calcValues	[shape=box, color=black, style=filled, fillcolor=ivory, label="FR:calcValues"];
-	instance:outputValues	[shape=box, color=black, style=filled, fillcolor=ivory, label="FR:outputValues"];
-	instance:correct	[shape=box, color=black, style=filled, fillcolor=ivory, label="NFR:correct"];
-	instance:verifiable	[shape=box, color=black, style=filled, fillcolor=ivory, label="NFR:verifiable"];
-	instance:understandable	[shape=box, color=black, style=filled, fillcolor=ivory, label="NFR:understandable"];
-	instance:reusable	[shape=box, color=black, style=filled, fillcolor=ivory, label="NFR:reusable"];
-	instance:maintainable	[shape=box, color=black, style=filled, fillcolor=ivory, label="NFR:maintainable"];
-
-	subgraph FR {
-	rank="same"
-	{instance:inputValues, instance:findMass, instance:checkWithPhysConsts, instance:outputInputDerivVals, instance:calcValues, instance:outputValues, instance:correct, instance:verifiable, instance:understandable, instance:reusable, instance:maintainable}
-	}
-
-	instance:waterTempGS	[shape=box, color=black, style=filled, fillcolor=darkgoldenrod1, label="GS:waterTempGS"];
-	instance:waterEnergyGS	[shape=box, color=black, style=filled, fillcolor=darkgoldenrod1, label="GS:waterEnergyGS"];
-
-	subgraph GS {
-	rank="same"
-	{instance:waterTempGS, instance:waterEnergyGS}
-	}
-
+digraph "allvsr" {
+    "instance:findMass" -> "dataDefn:wMass";
+    "instance:findMass" -> "dataDefn:wVol";
+    "instance:findMass" -> "dataDefn:tankVol";
+    "instance:findMass" -> "theory:eBalanceOnWtrRC";
+    "instance:findMass" -> "instance:inputValues";
+    "instance:outputInputDerivVals" -> "dataDefn:tauW";
+    "instance:outputInputDerivVals" -> "instance:inputValues";
+    "instance:outputInputDerivVals" -> "instance:findMass";
+    "instance:calcValues" -> "theory:eBalanceOnWtrRC";
+    "instance:calcValues" -> "theory:heatEInWtrIM";
+    "instance:outputValues" -> "theory:eBalanceOnWtrRC";
+    "instance:outputValues" -> "theory:heatEInWtrIM";
+    "instance:assumpTEO" [shape=box, color=black, style=filled, fillcolor="mistyrose", label="A:assumpTEO"];
+    "instance:assumpHTCC" [shape=box, color=black, style=filled, fillcolor="mistyrose", label="A:assumpHTCC"];
+    "instance:assumpCWTAT" [shape=box, color=black, style=filled, fillcolor="mistyrose", label="A:assumpCWTAT"];
+    "instance:assumpDWCoW" [shape=box, color=black, style=filled, fillcolor="mistyrose", label="A:assumpDWCoW"];
+    "instance:assumpSHECoW" [shape=box, color=black, style=filled, fillcolor="mistyrose", label="A:assumpSHECoW"];
+    "instance:assumpLCCCW" [shape=box, color=black, style=filled, fillcolor="mistyrose", label="A:assumpLCCCW"];
+    "instance:assumpTHCCoT" [shape=box, color=black, style=filled, fillcolor="mistyrose", label="A:assumpTHCCoT"];
+    "instance:assumpTHCCoL" [shape=box, color=black, style=filled, fillcolor="mistyrose", label="A:assumpTHCCoL"];
+    "instance:assumpCTNTD" [shape=box, color=black, style=filled, fillcolor="mistyrose", label="A:assumpCTNTD"];
+    "instance:assumpWAL" [shape=box, color=black, style=filled, fillcolor="mistyrose", label="A:assumpWAL"];
+    "instance:assumpPIT" [shape=box, color=black, style=filled, fillcolor="mistyrose", label="A:assumpPIT"];
+    "instance:assumpNIHGBW" [shape=box, color=black, style=filled, fillcolor="mistyrose", label="A:assumpNIHGBW"];
+    "instance:assumpAPT" [shape=box, color=black, style=filled, fillcolor="mistyrose", label="A:assumpAPT"];
+    "instance:assumpVCN" [shape=box, color=black, style=filled, fillcolor="mistyrose", label="A:assumpVCN"];
+    subgraph "A" {
+        rank="same";
+        "instance:assumpTEO" "instance:assumpHTCC" "instance:assumpCWTAT" "instance:assumpDWCoW" "instance:assumpSHECoW" "instance:assumpLCCCW" "instance:assumpTHCCoT" "instance:assumpTHCCoL" "instance:assumpCTNTD" "instance:assumpWAL" "instance:assumpPIT" "instance:assumpNIHGBW" "instance:assumpAPT" "instance:assumpVCN";
+    }
+    "dataDefn:wMass" [shape=box, color=black, style=filled, fillcolor="paleturquoise1", label="DD:waterMass"];
+    "dataDefn:wVol" [shape=box, color=black, style=filled, fillcolor="paleturquoise1", label="DD:waterVolume.nopcm"];
+    "dataDefn:tankVol" [shape=box, color=black, style=filled, fillcolor="paleturquoise1", label="DD:tankVolume"];
+    "dataDefn:tauW" [shape=box, color=black, style=filled, fillcolor="paleturquoise1", label="DD:balanceDecayRate"];
+    subgraph "DD" {
+        rank="same";
+        "dataDefn:wMass" "dataDefn:wVol" "dataDefn:tankVol" "dataDefn:tauW";
+    }
+    "theory:consThermECS" [shape=box, color=black, style=filled, fillcolor="pink", label="TM:consThermE"];
+    "theory:sensHeat" [shape=box, color=black, style=filled, fillcolor="pink", label="TM:sensHtE"];
+    "theory:nwtnCoolingTM" [shape=box, color=black, style=filled, fillcolor="pink", label="TM:nwtnCooling"];
+    subgraph "TM" {
+        rank="same";
+        "theory:consThermECS" "theory:sensHeat" "theory:nwtnCoolingTM";
+    }
+    "theory:rocTempSimpRC" [shape=box, color=black, style=filled, fillcolor="palegreen", label="GD:rocTempSimp"];
+    "theory:htFluxC" [shape=box, color=black, style=filled, fillcolor="palegreen", label="GD:htFluxWaterFromCoil"];
+    subgraph "GD" {
+        rank="same";
+        "theory:rocTempSimpRC" "theory:htFluxC";
+    }
+    "theory:eBalanceOnWtrRC" [shape=box, color=black, style=filled, fillcolor="khaki1", label="IM:eBalanceOnWtr"];
+    "theory:heatEInWtrIM" [shape=box, color=black, style=filled, fillcolor="khaki1", label="IM:heatEInWtr"];
+    subgraph "IM" {
+        rank="same";
+        "theory:eBalanceOnWtrRC" "theory:heatEInWtrIM";
+    }
+    "instance:inputValues" [shape=box, color=black, style=filled, fillcolor="ivory", label="FR:inputValues"];
+    "instance:findMass" [shape=box, color=black, style=filled, fillcolor="ivory", label="FR:findMass"];
+    "instance:checkWithPhysConsts" [shape=box, color=black, style=filled, fillcolor="ivory", label="FR:checkWithPhysConsts"];
+    "instance:outputInputDerivVals" [shape=box, color=black, style=filled, fillcolor="ivory", label="FR:outputInputDerivVals"];
+    "instance:calcValues" [shape=box, color=black, style=filled, fillcolor="ivory", label="FR:calcValues"];
+    "instance:outputValues" [shape=box, color=black, style=filled, fillcolor="ivory", label="FR:outputValues"];
+    "instance:correct" [shape=box, color=black, style=filled, fillcolor="ivory", label="NFR:correct"];
+    "instance:verifiable" [shape=box, color=black, style=filled, fillcolor="ivory", label="NFR:verifiable"];
+    "instance:understandable" [shape=box, color=black, style=filled, fillcolor="ivory", label="NFR:understandable"];
+    "instance:reusable" [shape=box, color=black, style=filled, fillcolor="ivory", label="NFR:reusable"];
+    "instance:maintainable" [shape=box, color=black, style=filled, fillcolor="ivory", label="NFR:maintainable"];
+    subgraph "FR" {
+        rank="same";
+        "instance:inputValues" "instance:findMass" "instance:checkWithPhysConsts" "instance:outputInputDerivVals" "instance:calcValues" "instance:outputValues" "instance:correct" "instance:verifiable" "instance:understandable" "instance:reusable" "instance:maintainable";
+    }
+    "instance:waterTempGS" [shape=box, color=black, style=filled, fillcolor="darkgoldenrod1", label="GS:waterTempGS"];
+    "instance:waterEnergyGS" [shape=box, color=black, style=filled, fillcolor="darkgoldenrod1", label="GS:waterEnergyGS"];
+    subgraph "GS" {
+        rank="same";
+        "instance:waterTempGS" "instance:waterEnergyGS";
+    }
 }

--- a/code/stable/swhsnopcm/TraceyGraph/avsa.dot
+++ b/code/stable/swhsnopcm/TraceyGraph/avsa.dot
@@ -1,24 +1,20 @@
-digraph avsa {
-
-
-	instance:assumpTEO	[shape=box, color=black, style=filled, fillcolor=mistyrose, label="A:assumpTEO"];
-	instance:assumpHTCC	[shape=box, color=black, style=filled, fillcolor=mistyrose, label="A:assumpHTCC"];
-	instance:assumpCWTAT	[shape=box, color=black, style=filled, fillcolor=mistyrose, label="A:assumpCWTAT"];
-	instance:assumpDWCoW	[shape=box, color=black, style=filled, fillcolor=mistyrose, label="A:assumpDWCoW"];
-	instance:assumpSHECoW	[shape=box, color=black, style=filled, fillcolor=mistyrose, label="A:assumpSHECoW"];
-	instance:assumpLCCCW	[shape=box, color=black, style=filled, fillcolor=mistyrose, label="A:assumpLCCCW"];
-	instance:assumpTHCCoT	[shape=box, color=black, style=filled, fillcolor=mistyrose, label="A:assumpTHCCoT"];
-	instance:assumpTHCCoL	[shape=box, color=black, style=filled, fillcolor=mistyrose, label="A:assumpTHCCoL"];
-	instance:assumpCTNTD	[shape=box, color=black, style=filled, fillcolor=mistyrose, label="A:assumpCTNTD"];
-	instance:assumpWAL	[shape=box, color=black, style=filled, fillcolor=mistyrose, label="A:assumpWAL"];
-	instance:assumpPIT	[shape=box, color=black, style=filled, fillcolor=mistyrose, label="A:assumpPIT"];
-	instance:assumpNIHGBW	[shape=box, color=black, style=filled, fillcolor=mistyrose, label="A:assumpNIHGBW"];
-	instance:assumpAPT	[shape=box, color=black, style=filled, fillcolor=mistyrose, label="A:assumpAPT"];
-	instance:assumpVCN	[shape=box, color=black, style=filled, fillcolor=mistyrose, label="A:assumpVCN"];
-
-	subgraph A {
-	rank="same"
-	{instance:assumpTEO, instance:assumpHTCC, instance:assumpCWTAT, instance:assumpDWCoW, instance:assumpSHECoW, instance:assumpLCCCW, instance:assumpTHCCoT, instance:assumpTHCCoL, instance:assumpCTNTD, instance:assumpWAL, instance:assumpPIT, instance:assumpNIHGBW, instance:assumpAPT, instance:assumpVCN}
-	}
-
+digraph "avsa" {
+    "instance:assumpTEO" [shape=box, color=black, style=filled, fillcolor="mistyrose", label="A:assumpTEO"];
+    "instance:assumpHTCC" [shape=box, color=black, style=filled, fillcolor="mistyrose", label="A:assumpHTCC"];
+    "instance:assumpCWTAT" [shape=box, color=black, style=filled, fillcolor="mistyrose", label="A:assumpCWTAT"];
+    "instance:assumpDWCoW" [shape=box, color=black, style=filled, fillcolor="mistyrose", label="A:assumpDWCoW"];
+    "instance:assumpSHECoW" [shape=box, color=black, style=filled, fillcolor="mistyrose", label="A:assumpSHECoW"];
+    "instance:assumpLCCCW" [shape=box, color=black, style=filled, fillcolor="mistyrose", label="A:assumpLCCCW"];
+    "instance:assumpTHCCoT" [shape=box, color=black, style=filled, fillcolor="mistyrose", label="A:assumpTHCCoT"];
+    "instance:assumpTHCCoL" [shape=box, color=black, style=filled, fillcolor="mistyrose", label="A:assumpTHCCoL"];
+    "instance:assumpCTNTD" [shape=box, color=black, style=filled, fillcolor="mistyrose", label="A:assumpCTNTD"];
+    "instance:assumpWAL" [shape=box, color=black, style=filled, fillcolor="mistyrose", label="A:assumpWAL"];
+    "instance:assumpPIT" [shape=box, color=black, style=filled, fillcolor="mistyrose", label="A:assumpPIT"];
+    "instance:assumpNIHGBW" [shape=box, color=black, style=filled, fillcolor="mistyrose", label="A:assumpNIHGBW"];
+    "instance:assumpAPT" [shape=box, color=black, style=filled, fillcolor="mistyrose", label="A:assumpAPT"];
+    "instance:assumpVCN" [shape=box, color=black, style=filled, fillcolor="mistyrose", label="A:assumpVCN"];
+    subgraph "A" {
+        rank="same";
+        "instance:assumpTEO" "instance:assumpHTCC" "instance:assumpCWTAT" "instance:assumpDWCoW" "instance:assumpSHECoW" "instance:assumpLCCCW" "instance:assumpTHCCoT" "instance:assumpTHCCoL" "instance:assumpCTNTD" "instance:assumpWAL" "instance:assumpPIT" "instance:assumpNIHGBW" "instance:assumpAPT" "instance:assumpVCN";
+    }
 }

--- a/code/stable/swhsnopcm/TraceyGraph/avsall.dot
+++ b/code/stable/swhsnopcm/TraceyGraph/avsall.dot
@@ -1,108 +1,92 @@
-digraph avsall {
-	dataDefn:wVol -> instance:assumpVCN;
-	theory:consThermECS -> instance:assumpTEO;
-	theory:sensHeat -> instance:assumpWAL;
-	theory:nwtnCoolingTM -> instance:assumpHTCC;
-	theory:rocTempSimpRC -> instance:assumpCWTAT;
-	theory:rocTempSimpRC -> instance:assumpDWCoW;
-	theory:rocTempSimpRC -> instance:assumpSHECoW;
-	theory:htFluxC -> instance:assumpLCCCW;
-	theory:htFluxC -> instance:assumpTHCCoT;
-	theory:eBalanceOnWtrRC -> instance:assumpWAL;
-	theory:eBalanceOnWtrRC -> instance:assumpPIT;
-	theory:eBalanceOnWtrRC -> instance:assumpNIHGBW;
-	theory:heatEInWtrIM -> instance:assumpWAL;
-	theory:heatEInWtrIM -> instance:assumpAPT;
-	instance:likeChgTCVOD -> instance:assumpTHCCoT;
-	instance:likeChgTCVOL -> instance:assumpTHCCoL;
-	instance:likeChgDT -> instance:assumpCTNTD;
-	instance:likeChgTLH -> instance:assumpPIT;
-	instance:unlikeChgWFS -> instance:assumpWAL;
-	instance:unlikeChgNIHG -> instance:assumpNIHGBW;
-
-
-	instance:assumpTEO	[shape=box, color=black, style=filled, fillcolor=mistyrose, label="A:assumpTEO"];
-	instance:assumpHTCC	[shape=box, color=black, style=filled, fillcolor=mistyrose, label="A:assumpHTCC"];
-	instance:assumpCWTAT	[shape=box, color=black, style=filled, fillcolor=mistyrose, label="A:assumpCWTAT"];
-	instance:assumpDWCoW	[shape=box, color=black, style=filled, fillcolor=mistyrose, label="A:assumpDWCoW"];
-	instance:assumpSHECoW	[shape=box, color=black, style=filled, fillcolor=mistyrose, label="A:assumpSHECoW"];
-	instance:assumpLCCCW	[shape=box, color=black, style=filled, fillcolor=mistyrose, label="A:assumpLCCCW"];
-	instance:assumpTHCCoT	[shape=box, color=black, style=filled, fillcolor=mistyrose, label="A:assumpTHCCoT"];
-	instance:assumpTHCCoL	[shape=box, color=black, style=filled, fillcolor=mistyrose, label="A:assumpTHCCoL"];
-	instance:assumpCTNTD	[shape=box, color=black, style=filled, fillcolor=mistyrose, label="A:assumpCTNTD"];
-	instance:assumpWAL	[shape=box, color=black, style=filled, fillcolor=mistyrose, label="A:assumpWAL"];
-	instance:assumpPIT	[shape=box, color=black, style=filled, fillcolor=mistyrose, label="A:assumpPIT"];
-	instance:assumpNIHGBW	[shape=box, color=black, style=filled, fillcolor=mistyrose, label="A:assumpNIHGBW"];
-	instance:assumpAPT	[shape=box, color=black, style=filled, fillcolor=mistyrose, label="A:assumpAPT"];
-	instance:assumpVCN	[shape=box, color=black, style=filled, fillcolor=mistyrose, label="A:assumpVCN"];
-
-	subgraph A {
-	rank="same"
-	{instance:assumpTEO, instance:assumpHTCC, instance:assumpCWTAT, instance:assumpDWCoW, instance:assumpSHECoW, instance:assumpLCCCW, instance:assumpTHCCoT, instance:assumpTHCCoL, instance:assumpCTNTD, instance:assumpWAL, instance:assumpPIT, instance:assumpNIHGBW, instance:assumpAPT, instance:assumpVCN}
-	}
-
-	dataDefn:wMass	[shape=box, color=black, style=filled, fillcolor=paleturquoise1, label="DD:waterMass"];
-	dataDefn:wVol	[shape=box, color=black, style=filled, fillcolor=paleturquoise1, label="DD:waterVolume.nopcm"];
-	dataDefn:tankVol	[shape=box, color=black, style=filled, fillcolor=paleturquoise1, label="DD:tankVolume"];
-	dataDefn:tauW	[shape=box, color=black, style=filled, fillcolor=paleturquoise1, label="DD:balanceDecayRate"];
-
-	subgraph DD {
-	rank="same"
-	{dataDefn:wMass, dataDefn:wVol, dataDefn:tankVol, dataDefn:tauW}
-	}
-
-	theory:consThermECS	[shape=box, color=black, style=filled, fillcolor=pink, label="TM:consThermE"];
-	theory:sensHeat	[shape=box, color=black, style=filled, fillcolor=pink, label="TM:sensHtE"];
-	theory:nwtnCoolingTM	[shape=box, color=black, style=filled, fillcolor=pink, label="TM:nwtnCooling"];
-
-	subgraph TM {
-	rank="same"
-	{theory:consThermECS, theory:sensHeat, theory:nwtnCoolingTM}
-	}
-
-	theory:rocTempSimpRC	[shape=box, color=black, style=filled, fillcolor=palegreen, label="GD:rocTempSimp"];
-	theory:htFluxC	[shape=box, color=black, style=filled, fillcolor=palegreen, label="GD:htFluxWaterFromCoil"];
-
-	subgraph GD {
-	rank="same"
-	{theory:rocTempSimpRC, theory:htFluxC}
-	}
-
-	theory:eBalanceOnWtrRC	[shape=box, color=black, style=filled, fillcolor=khaki1, label="IM:eBalanceOnWtr"];
-	theory:heatEInWtrIM	[shape=box, color=black, style=filled, fillcolor=khaki1, label="IM:heatEInWtr"];
-
-	subgraph IM {
-	rank="same"
-	{theory:eBalanceOnWtrRC, theory:heatEInWtrIM}
-	}
-
-	instance:inputValues	[shape=box, color=black, style=filled, fillcolor=ivory, label="FR:inputValues"];
-	instance:findMass	[shape=box, color=black, style=filled, fillcolor=ivory, label="FR:findMass"];
-	instance:checkWithPhysConsts	[shape=box, color=black, style=filled, fillcolor=ivory, label="FR:checkWithPhysConsts"];
-	instance:outputInputDerivVals	[shape=box, color=black, style=filled, fillcolor=ivory, label="FR:outputInputDerivVals"];
-	instance:calcValues	[shape=box, color=black, style=filled, fillcolor=ivory, label="FR:calcValues"];
-	instance:outputValues	[shape=box, color=black, style=filled, fillcolor=ivory, label="FR:outputValues"];
-	instance:correct	[shape=box, color=black, style=filled, fillcolor=ivory, label="NFR:correct"];
-	instance:verifiable	[shape=box, color=black, style=filled, fillcolor=ivory, label="NFR:verifiable"];
-	instance:understandable	[shape=box, color=black, style=filled, fillcolor=ivory, label="NFR:understandable"];
-	instance:reusable	[shape=box, color=black, style=filled, fillcolor=ivory, label="NFR:reusable"];
-	instance:maintainable	[shape=box, color=black, style=filled, fillcolor=ivory, label="NFR:maintainable"];
-
-	subgraph FR {
-	rank="same"
-	{instance:inputValues, instance:findMass, instance:checkWithPhysConsts, instance:outputInputDerivVals, instance:calcValues, instance:outputValues, instance:correct, instance:verifiable, instance:understandable, instance:reusable, instance:maintainable}
-	}
-
-	instance:likeChgTCVOD	[shape=box, color=black, style=filled, fillcolor=lavender, label="LC:likeChgTCVOD"];
-	instance:likeChgTCVOL	[shape=box, color=black, style=filled, fillcolor=lavender, label="LC:likeChgTCVOL"];
-	instance:likeChgDT	[shape=box, color=black, style=filled, fillcolor=lavender, label="LC:likeChgDT"];
-	instance:likeChgTLH	[shape=box, color=black, style=filled, fillcolor=lavender, label="LC:likeChgTLH"];
-	instance:unlikeChgWFS	[shape=box, color=black, style=filled, fillcolor=lavender, label="UC:unlikeChgWFS"];
-	instance:unlikeChgNIHG	[shape=box, color=black, style=filled, fillcolor=lavender, label="UC:unlikeChgNIHG"];
-
-	subgraph LC {
-	rank="same"
-	{instance:likeChgTCVOD, instance:likeChgTCVOL, instance:likeChgDT, instance:likeChgTLH, instance:unlikeChgWFS, instance:unlikeChgNIHG}
-	}
-
+digraph "avsall" {
+    "dataDefn:wVol" -> "instance:assumpVCN";
+    "theory:consThermECS" -> "instance:assumpTEO";
+    "theory:sensHeat" -> "instance:assumpWAL";
+    "theory:nwtnCoolingTM" -> "instance:assumpHTCC";
+    "theory:rocTempSimpRC" -> "instance:assumpCWTAT";
+    "theory:rocTempSimpRC" -> "instance:assumpDWCoW";
+    "theory:rocTempSimpRC" -> "instance:assumpSHECoW";
+    "theory:htFluxC" -> "instance:assumpLCCCW";
+    "theory:htFluxC" -> "instance:assumpTHCCoT";
+    "theory:eBalanceOnWtrRC" -> "instance:assumpWAL";
+    "theory:eBalanceOnWtrRC" -> "instance:assumpPIT";
+    "theory:eBalanceOnWtrRC" -> "instance:assumpNIHGBW";
+    "theory:heatEInWtrIM" -> "instance:assumpWAL";
+    "theory:heatEInWtrIM" -> "instance:assumpAPT";
+    "instance:likeChgTCVOD" -> "instance:assumpTHCCoT";
+    "instance:likeChgTCVOL" -> "instance:assumpTHCCoL";
+    "instance:likeChgDT" -> "instance:assumpCTNTD";
+    "instance:likeChgTLH" -> "instance:assumpPIT";
+    "instance:unlikeChgWFS" -> "instance:assumpWAL";
+    "instance:unlikeChgNIHG" -> "instance:assumpNIHGBW";
+    "instance:assumpTEO" [shape=box, color=black, style=filled, fillcolor="mistyrose", label="A:assumpTEO"];
+    "instance:assumpHTCC" [shape=box, color=black, style=filled, fillcolor="mistyrose", label="A:assumpHTCC"];
+    "instance:assumpCWTAT" [shape=box, color=black, style=filled, fillcolor="mistyrose", label="A:assumpCWTAT"];
+    "instance:assumpDWCoW" [shape=box, color=black, style=filled, fillcolor="mistyrose", label="A:assumpDWCoW"];
+    "instance:assumpSHECoW" [shape=box, color=black, style=filled, fillcolor="mistyrose", label="A:assumpSHECoW"];
+    "instance:assumpLCCCW" [shape=box, color=black, style=filled, fillcolor="mistyrose", label="A:assumpLCCCW"];
+    "instance:assumpTHCCoT" [shape=box, color=black, style=filled, fillcolor="mistyrose", label="A:assumpTHCCoT"];
+    "instance:assumpTHCCoL" [shape=box, color=black, style=filled, fillcolor="mistyrose", label="A:assumpTHCCoL"];
+    "instance:assumpCTNTD" [shape=box, color=black, style=filled, fillcolor="mistyrose", label="A:assumpCTNTD"];
+    "instance:assumpWAL" [shape=box, color=black, style=filled, fillcolor="mistyrose", label="A:assumpWAL"];
+    "instance:assumpPIT" [shape=box, color=black, style=filled, fillcolor="mistyrose", label="A:assumpPIT"];
+    "instance:assumpNIHGBW" [shape=box, color=black, style=filled, fillcolor="mistyrose", label="A:assumpNIHGBW"];
+    "instance:assumpAPT" [shape=box, color=black, style=filled, fillcolor="mistyrose", label="A:assumpAPT"];
+    "instance:assumpVCN" [shape=box, color=black, style=filled, fillcolor="mistyrose", label="A:assumpVCN"];
+    subgraph "A" {
+        rank="same";
+        "instance:assumpTEO" "instance:assumpHTCC" "instance:assumpCWTAT" "instance:assumpDWCoW" "instance:assumpSHECoW" "instance:assumpLCCCW" "instance:assumpTHCCoT" "instance:assumpTHCCoL" "instance:assumpCTNTD" "instance:assumpWAL" "instance:assumpPIT" "instance:assumpNIHGBW" "instance:assumpAPT" "instance:assumpVCN";
+    }
+    "dataDefn:wMass" [shape=box, color=black, style=filled, fillcolor="paleturquoise1", label="DD:waterMass"];
+    "dataDefn:wVol" [shape=box, color=black, style=filled, fillcolor="paleturquoise1", label="DD:waterVolume.nopcm"];
+    "dataDefn:tankVol" [shape=box, color=black, style=filled, fillcolor="paleturquoise1", label="DD:tankVolume"];
+    "dataDefn:tauW" [shape=box, color=black, style=filled, fillcolor="paleturquoise1", label="DD:balanceDecayRate"];
+    subgraph "DD" {
+        rank="same";
+        "dataDefn:wMass" "dataDefn:wVol" "dataDefn:tankVol" "dataDefn:tauW";
+    }
+    "theory:consThermECS" [shape=box, color=black, style=filled, fillcolor="pink", label="TM:consThermE"];
+    "theory:sensHeat" [shape=box, color=black, style=filled, fillcolor="pink", label="TM:sensHtE"];
+    "theory:nwtnCoolingTM" [shape=box, color=black, style=filled, fillcolor="pink", label="TM:nwtnCooling"];
+    subgraph "TM" {
+        rank="same";
+        "theory:consThermECS" "theory:sensHeat" "theory:nwtnCoolingTM";
+    }
+    "theory:rocTempSimpRC" [shape=box, color=black, style=filled, fillcolor="palegreen", label="GD:rocTempSimp"];
+    "theory:htFluxC" [shape=box, color=black, style=filled, fillcolor="palegreen", label="GD:htFluxWaterFromCoil"];
+    subgraph "GD" {
+        rank="same";
+        "theory:rocTempSimpRC" "theory:htFluxC";
+    }
+    "theory:eBalanceOnWtrRC" [shape=box, color=black, style=filled, fillcolor="khaki1", label="IM:eBalanceOnWtr"];
+    "theory:heatEInWtrIM" [shape=box, color=black, style=filled, fillcolor="khaki1", label="IM:heatEInWtr"];
+    subgraph "IM" {
+        rank="same";
+        "theory:eBalanceOnWtrRC" "theory:heatEInWtrIM";
+    }
+    "instance:inputValues" [shape=box, color=black, style=filled, fillcolor="ivory", label="FR:inputValues"];
+    "instance:findMass" [shape=box, color=black, style=filled, fillcolor="ivory", label="FR:findMass"];
+    "instance:checkWithPhysConsts" [shape=box, color=black, style=filled, fillcolor="ivory", label="FR:checkWithPhysConsts"];
+    "instance:outputInputDerivVals" [shape=box, color=black, style=filled, fillcolor="ivory", label="FR:outputInputDerivVals"];
+    "instance:calcValues" [shape=box, color=black, style=filled, fillcolor="ivory", label="FR:calcValues"];
+    "instance:outputValues" [shape=box, color=black, style=filled, fillcolor="ivory", label="FR:outputValues"];
+    "instance:correct" [shape=box, color=black, style=filled, fillcolor="ivory", label="NFR:correct"];
+    "instance:verifiable" [shape=box, color=black, style=filled, fillcolor="ivory", label="NFR:verifiable"];
+    "instance:understandable" [shape=box, color=black, style=filled, fillcolor="ivory", label="NFR:understandable"];
+    "instance:reusable" [shape=box, color=black, style=filled, fillcolor="ivory", label="NFR:reusable"];
+    "instance:maintainable" [shape=box, color=black, style=filled, fillcolor="ivory", label="NFR:maintainable"];
+    subgraph "FR" {
+        rank="same";
+        "instance:inputValues" "instance:findMass" "instance:checkWithPhysConsts" "instance:outputInputDerivVals" "instance:calcValues" "instance:outputValues" "instance:correct" "instance:verifiable" "instance:understandable" "instance:reusable" "instance:maintainable";
+    }
+    "instance:likeChgTCVOD" [shape=box, color=black, style=filled, fillcolor="lavender", label="LC:likeChgTCVOD"];
+    "instance:likeChgTCVOL" [shape=box, color=black, style=filled, fillcolor="lavender", label="LC:likeChgTCVOL"];
+    "instance:likeChgDT" [shape=box, color=black, style=filled, fillcolor="lavender", label="LC:likeChgDT"];
+    "instance:likeChgTLH" [shape=box, color=black, style=filled, fillcolor="lavender", label="LC:likeChgTLH"];
+    "instance:unlikeChgWFS" [shape=box, color=black, style=filled, fillcolor="lavender", label="UC:unlikeChgWFS"];
+    "instance:unlikeChgNIHG" [shape=box, color=black, style=filled, fillcolor="lavender", label="UC:unlikeChgNIHG"];
+    subgraph "LC" {
+        rank="same";
+        "instance:likeChgTCVOD" "instance:likeChgTCVOL" "instance:likeChgDT" "instance:likeChgTLH" "instance:unlikeChgWFS" "instance:unlikeChgNIHG";
+    }
 }

--- a/code/stable/swhsnopcm/TraceyGraph/refvsref.dot
+++ b/code/stable/swhsnopcm/TraceyGraph/refvsref.dot
@@ -1,47 +1,37 @@
-digraph refvsref {
-	dataDefn:wVol -> dataDefn:tankVol;
-	theory:rocTempSimpRC -> theory:consThermECS;
-	theory:rocTempSimpRC -> theory:rocTempSimpRC;
-	theory:htFluxC -> theory:nwtnCoolingTM;
-	theory:eBalanceOnWtrRC -> dataDefn:tauW;
-	theory:eBalanceOnWtrRC -> theory:rocTempSimpRC;
-	theory:eBalanceOnWtrRC -> theory:htFluxC;
-	theory:heatEInWtrIM -> theory:sensHeat;
-
-
-	dataDefn:wMass	[shape=box, color=black, style=filled, fillcolor=paleturquoise1, label="DD:waterMass"];
-	dataDefn:wVol	[shape=box, color=black, style=filled, fillcolor=paleturquoise1, label="DD:waterVolume.nopcm"];
-	dataDefn:tankVol	[shape=box, color=black, style=filled, fillcolor=paleturquoise1, label="DD:tankVolume"];
-	dataDefn:tauW	[shape=box, color=black, style=filled, fillcolor=paleturquoise1, label="DD:balanceDecayRate"];
-
-	subgraph DD {
-	rank="same"
-	{dataDefn:wMass, dataDefn:wVol, dataDefn:tankVol, dataDefn:tauW}
-	}
-
-	theory:consThermECS	[shape=box, color=black, style=filled, fillcolor=pink, label="TM:consThermE"];
-	theory:sensHeat	[shape=box, color=black, style=filled, fillcolor=pink, label="TM:sensHtE"];
-	theory:nwtnCoolingTM	[shape=box, color=black, style=filled, fillcolor=pink, label="TM:nwtnCooling"];
-
-	subgraph TM {
-	rank="same"
-	{theory:consThermECS, theory:sensHeat, theory:nwtnCoolingTM}
-	}
-
-	theory:rocTempSimpRC	[shape=box, color=black, style=filled, fillcolor=palegreen, label="GD:rocTempSimp"];
-	theory:htFluxC	[shape=box, color=black, style=filled, fillcolor=palegreen, label="GD:htFluxWaterFromCoil"];
-
-	subgraph GD {
-	rank="same"
-	{theory:rocTempSimpRC, theory:htFluxC}
-	}
-
-	theory:eBalanceOnWtrRC	[shape=box, color=black, style=filled, fillcolor=khaki1, label="IM:eBalanceOnWtr"];
-	theory:heatEInWtrIM	[shape=box, color=black, style=filled, fillcolor=khaki1, label="IM:heatEInWtr"];
-
-	subgraph IM {
-	rank="same"
-	{theory:eBalanceOnWtrRC, theory:heatEInWtrIM}
-	}
-
+digraph "refvsref" {
+    "dataDefn:wVol" -> "dataDefn:tankVol";
+    "theory:rocTempSimpRC" -> "theory:consThermECS";
+    "theory:rocTempSimpRC" -> "theory:rocTempSimpRC";
+    "theory:htFluxC" -> "theory:nwtnCoolingTM";
+    "theory:eBalanceOnWtrRC" -> "dataDefn:tauW";
+    "theory:eBalanceOnWtrRC" -> "theory:rocTempSimpRC";
+    "theory:eBalanceOnWtrRC" -> "theory:htFluxC";
+    "theory:heatEInWtrIM" -> "theory:sensHeat";
+    "dataDefn:wMass" [shape=box, color=black, style=filled, fillcolor="paleturquoise1", label="DD:waterMass"];
+    "dataDefn:wVol" [shape=box, color=black, style=filled, fillcolor="paleturquoise1", label="DD:waterVolume.nopcm"];
+    "dataDefn:tankVol" [shape=box, color=black, style=filled, fillcolor="paleturquoise1", label="DD:tankVolume"];
+    "dataDefn:tauW" [shape=box, color=black, style=filled, fillcolor="paleturquoise1", label="DD:balanceDecayRate"];
+    subgraph "DD" {
+        rank="same";
+        "dataDefn:wMass" "dataDefn:wVol" "dataDefn:tankVol" "dataDefn:tauW";
+    }
+    "theory:consThermECS" [shape=box, color=black, style=filled, fillcolor="pink", label="TM:consThermE"];
+    "theory:sensHeat" [shape=box, color=black, style=filled, fillcolor="pink", label="TM:sensHtE"];
+    "theory:nwtnCoolingTM" [shape=box, color=black, style=filled, fillcolor="pink", label="TM:nwtnCooling"];
+    subgraph "TM" {
+        rank="same";
+        "theory:consThermECS" "theory:sensHeat" "theory:nwtnCoolingTM";
+    }
+    "theory:rocTempSimpRC" [shape=box, color=black, style=filled, fillcolor="palegreen", label="GD:rocTempSimp"];
+    "theory:htFluxC" [shape=box, color=black, style=filled, fillcolor="palegreen", label="GD:htFluxWaterFromCoil"];
+    subgraph "GD" {
+        rank="same";
+        "theory:rocTempSimpRC" "theory:htFluxC";
+    }
+    "theory:eBalanceOnWtrRC" [shape=box, color=black, style=filled, fillcolor="khaki1", label="IM:eBalanceOnWtr"];
+    "theory:heatEInWtrIM" [shape=box, color=black, style=filled, fillcolor="khaki1", label="IM:heatEInWtr"];
+    subgraph "IM" {
+        rank="same";
+        "theory:eBalanceOnWtrRC" "theory:heatEInWtrIM";
+    }
 }

--- a/code/stable/template/TraceyGraph/allvsall.dot
+++ b/code/stable/template/TraceyGraph/allvsall.dot
@@ -1,4 +1,2 @@
-digraph allvsall {
-
-
+digraph "allvsall" {
 }

--- a/code/stable/template/TraceyGraph/allvsr.dot
+++ b/code/stable/template/TraceyGraph/allvsr.dot
@@ -1,4 +1,2 @@
-digraph allvsr {
-
-
+digraph "allvsr" {
 }

--- a/code/stable/template/TraceyGraph/avsa.dot
+++ b/code/stable/template/TraceyGraph/avsa.dot
@@ -1,4 +1,2 @@
-digraph avsa {
-
-
+digraph "avsa" {
 }

--- a/code/stable/template/TraceyGraph/avsall.dot
+++ b/code/stable/template/TraceyGraph/avsall.dot
@@ -1,4 +1,2 @@
-digraph avsall {
-
-
+digraph "avsall" {
 }

--- a/code/stable/template/TraceyGraph/refvsref.dot
+++ b/code/stable/template/TraceyGraph/refvsref.dot
@@ -1,4 +1,2 @@
-digraph refvsref {
-
-
+digraph "refvsref" {
 }


### PR DESCRIPTION
See GlassBR's traceability graphs (TGs):

<img width="639" height="990" alt="Screenshot 2026-04-09 at 12 18 30 AM" src="https://github.com/user-attachments/assets/b1f3698f-aac3-4cc0-a122-6bf56953979f" />

They don't really make a lot of sense.

On looking at the traceability graph `.dot` generator, I realized a few things:

1. We do not have an internal `.dot` representation.
2. We are generating our TG-related `.dot` files with immediately file writing rather than using an intermediate encoding.
3. Our generated `.dot` files produce invalid syntax.

The goal of this PR is fix at least (2) and (3). This PR re-writes the TG-generating code to use `Doc` and fixes the output syntax. For reference, locally, the traceability graphs for GlassBR are as follows:

<img width="1182" height="641" alt="Screenshot 2026-04-09 at 12 21 37 AM" src="https://github.com/user-attachments/assets/5690b3dc-3470-4fd4-91d6-0d4b3432e3fd" />

<hr>

Note: The goal of this PR is _not_ to perfect the outputted graphs. We can deal with that another day.