### PR TITLE
Init. `CONTRIBUTING.md`: Refer reader to wiki

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,3 @@
+# Contributing
+
+Please refer to our [wiki page on contributing to Drasil](https://github.com/JacquesCarette/Drasil/wiki/Contributor's-Guide).


### PR DESCRIPTION
Since we are brushing up some things in the repo, we can create a [`CONTRIBUTING.md`](https://docs.github.com/en/communities/setting-up-your-project-for-healthy-contributions/setting-guidelines-for-repository-contributors) file that GitHub treats with some speciality (i.e., highlighting on the main repo page), similar to our `CODE_OF_CONDUCT.md` file.

Since we already have a "Contributor's Guide" wiki page, we can refer the reader to the wiki instead.