### PR TITLE
Make all imports of `drasil-system` explicit

### DIFF
--- a/code/drasil-code/lib/Language/Drasil/Code/Imperative/Descriptions.hs
+++ b/code/drasil-code/lib/Language/Drasil/Code/Imperative/Descriptions.hs
@@ -15,7 +15,7 @@ import Data.Maybe (mapMaybe)
 
 import Drasil.Database (HasUID(..))
 import Language.Drasil
-import Drasil.System
+import Drasil.System (purpose)
 import Utils.Drasil (stringList)
 
 import Drasil.Code.CodeVar (CodeIdea(..))

--- a/code/drasil-code/lib/Language/Drasil/Code/Imperative/Generator.hs
+++ b/code/drasil-code/lib/Language/Drasil/Code/Imperative/Generator.hs
@@ -23,7 +23,7 @@ import Drasil.GProc (ProcProg)
 import qualified Drasil.GProc as Proc (GSProgram, SFile, ProgramSym(..), unCI)
 import Language.Drasil.Printers (SingleLine(OneLine), sentenceDoc, piSys, Notation (Scientific))
 import Language.Drasil.Printing.Import (spec)
-import Drasil.System
+import Drasil.System (refTable, HasSystemMeta(..))
 
 import Language.Drasil.Code.Imperative.ConceptMatch (chooseConcept)
 import Language.Drasil.Code.Imperative.Descriptions (unmodularDesc)

--- a/code/drasil-docLang/lib/Drasil/DocDecl.hs
+++ b/code/drasil-docLang/lib/Drasil/DocDecl.hs
@@ -13,7 +13,7 @@ import Control.Lens((^.))
 -- Generic Drasil
 import Language.Drasil hiding (sec)
 import Drasil.Database (HasUID(..), findAll)
-import Drasil.System
+import Drasil.System (SmithEtAlSRS, HasSmithEtAlSRS(..), systemdb)
 
 -- Vocabulary
 import Drasil.Metadata.Documentation (assumpDom, funcReqDom, goalStmtDom,

--- a/code/drasil-docLang/lib/Drasil/SRSDocument.hs
+++ b/code/drasil-docLang/lib/Drasil/SRSDocument.hs
@@ -33,7 +33,7 @@ module Drasil.SRSDocument (
   ) where
 
 import Drasil.Database (ChunkDB)
-import Drasil.System
+import Drasil.System (SmithEtAlSRS(..))
 import Drasil.DocLang (
   -- Drasil.DocumentLanguage.Core
   AppndxSec(..), AuxConstntSec(..),

--- a/code/drasil-system/lib/Drasil/System/LessonPlan.hs
+++ b/code/drasil-system/lib/Drasil/System/LessonPlan.hs
@@ -10,7 +10,7 @@ import qualified Data.Map.Strict as M
 import Drasil.Database (UID, uid)
 import Language.Drasil (Reference)
 
-import Drasil.System.Core
+import Drasil.System.Core (SystemMeta, HasSystemMeta(..))
 
 data LessonPlan = LP {
   _sm :: SystemMeta,

--- a/code/drasil-system/lib/Drasil/System/SmithEtAlSRS.hs
+++ b/code/drasil-system/lib/Drasil/System/SmithEtAlSRS.hs
@@ -28,7 +28,8 @@ import Language.Drasil (Quantity, MayHaveUnit, Concept, Reference, People, CI,
 import Theory.Drasil (TheoryModel, GenDefn, DataDefinition, InstanceModel)
 import Utils.Drasil (toPlainName)
 
-import Drasil.System.Core
+import Drasil.System.Core (SystemMeta, Background, HasSystemMeta(..),
+  mkSystemMeta, Motivation, Purpose, Scope)
 
 -- | Data structure for holding all of the requisite information about a system
 -- to be used in artifact generation.

--- a/code/drasil-website/lib/Drasil/Website/CaseStudy.hs
+++ b/code/drasil-website/lib/Drasil/Website/CaseStudy.hs
@@ -5,7 +5,7 @@ module Drasil.Website.CaseStudy where
 
 import Language.Drasil hiding (E)
 import Language.Drasil.Code hiding (CS)
-import Drasil.System
+import Drasil.System (SmithEtAlSRS)
 import Drasil.Generator (codedDirName)
 import Drasil.GOOL (CodeType(..))
 


### PR DESCRIPTION
Minor code clean up. Not essential, but good for understanding what things are used where quickly using text-based file search.