### PR TITLE
Don't export quantity-like chunks as `ConceptChunk`s for insertion in `ChunkDB`.

### DIFF
--- a/code/drasil-example/dblpend/lib/Drasil/DblPend/Body.hs
+++ b/code/drasil-example/dblpend/lib/Drasil/DblPend/Body.hs
@@ -27,7 +27,6 @@ import Data.Drasil.Concepts.Physics (gravity, physicCon', pendulum, twoD, motion
 import Data.Drasil.Concepts.PhysicalProperties (mass, physicalcon)
 import Data.Drasil.Concepts.Theory (inModel)
 import Data.Drasil.Concepts.Software (program)
-import Data.Drasil.Quantities.PhysicalProperties (len)
 import Data.Drasil.Theories.Physics (newtonSL, accelerationTM, velocityTM)
 import Drasil.Document.Contents (foldlSP, foldlSPCol)
 import Drasil.Sentence.Combinators (bulletNested, bulletFlat)
@@ -121,11 +120,8 @@ ideaDicts =
 
 conceptChunks :: [ConceptChunk]
 conceptChunks =
-  -- ConceptChunks
   physicalcon ++ [angAccel, angular, angVelo, pendulum, motion,
-  gravitationalConst, gravity] ++
-  -- UnitalChunks
-  [cw len]
+  gravitationalConst, gravity]
 
 symbMap :: ChunkDB
 symbMap = withCommonKnowledge [] symbols ideaDicts conceptChunks []

--- a/code/drasil-example/dblpend/lib/Drasil/DblPend/Unitals.hs
+++ b/code/drasil-example/dblpend/lib/Drasil/DblPend/Unitals.hs
@@ -32,7 +32,7 @@ constants :: [ConstQDef]
 constants = [gravitationalAccelConst]
 
 unitalChunks :: [UnitalChunk]
-unitalChunks = [
+unitalChunks = [len,
   lenRod_1, lenRod_2, massObj_1, massObj_2,
   pendDisAngle_1, pendDisAngle_2, angularVel_1, angularVel_2,
   xVel_1, xVel_2, yVel_1, yVel_2, xPos_1, xPos_2, yPos_1, yPos_2, xAccel_1,

--- a/code/drasil-example/gamephysics/lib/Drasil/GamePhysics/Body.hs
+++ b/code/drasil-example/gamephysics/lib/Drasil/GamePhysics/Body.hs
@@ -29,7 +29,6 @@ import qualified Data.Drasil.Concepts.Physics as CP (elasticity,
   physicCon', rigidBody, collision, damping, angular, linear, friction, joint, energy, motion, space)
 import qualified Data.Drasil.Concepts.Math as CM (cartesian, equation, law,
   mathcon', rightHand, line, point)
-import Data.Drasil.Quantities.Math (normalVect, perpVect, surface)
 import qualified Data.Drasil.Quantities.Physics as QP (force, time)
 
 import Drasil.GamePhysics.Assumptions (assumptions)
@@ -118,11 +117,7 @@ conceptChunks =
   -- ConceptChunks
   softwarecon ++ [CP.angular, CP.linear, CP.rigidBody, CP.collision,
   CP.damping, CP.friction, CP.joint, CP.energy, CP.motion, CP.space,
-  CP.elasticity] ++
-  -- DefinedQuantityDicts
-  map cw [normalVect, perpVect] ++
-  -- UnitalChunks
-  [cw surface]
+  CP.elasticity]
 
 symbMap :: ChunkDB
 symbMap = withCommonKnowledge allRefs symbols ideaDicts conceptChunks []

--- a/code/drasil-example/gamephysics/lib/Drasil/GamePhysics/Unitals.hs
+++ b/code/drasil-example/gamephysics/lib/Drasil/GamePhysics/Unitals.hs
@@ -1,5 +1,7 @@
 module Drasil.GamePhysics.Unitals where
 
+import Control.Lens ((^.))
+
 import Language.Drasil
 import Language.Drasil.Chunk.Concept.NamedCombinators
 import qualified Language.Drasil.Development as D
@@ -16,12 +18,11 @@ import qualified Data.Drasil.Quantities.Physics as QP (acceleration, angularAcce
   torque, velocity, fOfGravity, positionVec)
 
 import qualified Data.Drasil.Quantities.Math as QM (euclidNorm, normalVect,
-  orientation, perpVect, pi_, unitVect)
+  orientation, perpVect, pi_, unitVect, surface)
 import qualified Data.Drasil.Quantities.PhysicalProperties as QPP (len, mass)
 import Data.Drasil.Units.Physics (accelU, angVelU, impulseU, momtInertU,
   torqueU, velU, angAccelU)
 
-import Control.Lens((^.))
 import Data.Drasil.Constraints (gtZeroConstr)
 
 defSymbols :: [DefinedQuantityDict]
@@ -43,7 +44,7 @@ unitSymbs = map ucw [iVect, jVect, normalVect,
 
 symbols, inputSymbols, outputSymbols :: [DefinedQuantityDict]
 
-symbols = QP.restitutionCoef : unitless ++ map dqdWr unitalSymbols
+symbols = [QP.restitutionCoef, QM.normalVect, QM.perpVect] ++ unitless ++ map dqdWr unitalSymbols
 
 inputSymbols = map dqdWr [QP.position, QP.velocity, QP.force, QM.orientation,
   QP.angularVelocity, QP.linearVelocity, QP.gravitationalConst, QPP.mass,
@@ -54,7 +55,7 @@ outputSymbols = map dqdWr [QP.position, QP.velocity, QM.orientation,
   QP.angularVelocity, QP.chgMomentum, QP.chgInVelocity]
 
 unitalSymbols :: [UnitalChunk]
-unitalSymbols = [QP.acceleration, QP.angularAccel, QP.gravitationalAccel,
+unitalSymbols = [QM.surface, QP.acceleration, QP.angularAccel, QP.gravitationalAccel,
   QP.force, QP.impulseV, QP.impulseS, QP.distance, QP.displacement,
   QP.time, QP.angularDisplacement, QP.linearDisplacement, QP.linearVelocity,
   QP.linearAccel, QP.kEnergy, QP.chgInVelocity, QP.potEnergy, QP.height,

--- a/code/drasil-example/glassbr/lib/Drasil/GlassBR/Body.hs
+++ b/code/drasil-example/glassbr/lib/Drasil/GlassBR/Body.hs
@@ -31,8 +31,6 @@ import Data.Drasil.Concepts.Physics (distance)
 import Data.Drasil.Concepts.Software (correctness, verifiability,
   understandability, reusability, maintainability, portability, softwarecon)
 import Data.Drasil.Concepts.Theory as M (dataDefn, inModel, thModel)
-import Data.Drasil.Quantities.Math (mathquants, mathunitals)
-import Data.Drasil.Quantities.PhysicalProperties (physicalquants)
 
 import Data.Drasil.People (mCampidelli, nikitha, spencerSmith)
 
@@ -122,13 +120,7 @@ ideaDicts =
   map nw [progName, iGlass, lGlass] ++ map nw mathcon'
 
 conceptChunks :: [ConceptChunk]
-conceptChunks =
-  -- ConceptChunks
-  distance : concepts ++ softwarecon ++ physicalcon ++
-  -- Unital Chunks
-  map cw mathunitals ++ map cw physicalquants ++
-  -- DefinedQuantityDicts
-  map cw mathquants
+conceptChunks = distance : concepts ++ softwarecon ++ physicalcon
 
 symbMap :: ChunkDB
 symbMap = withCommonKnowledge [] symbolsWCodeSymbols ideaDicts conceptChunks []

--- a/code/drasil-example/glassbr/lib/Drasil/GlassBR/Unitals.hs
+++ b/code/drasil-example/glassbr/lib/Drasil/GlassBR/Unitals.hs
@@ -11,6 +11,8 @@ import Control.Lens ((^.))
 
 import Data.Drasil.Concepts.Math (xComp, yComp, zComp)
 import Data.Drasil.Constraints (gtZeroConstr, probConstr)
+import Data.Drasil.Quantities.Math (mathunitals, mathquants)
+import Data.Drasil.Quantities.PhysicalProperties (physicalquants)
 import Data.Drasil.Quantities.Physics (subMax, subMin, subX, subY, subZ)
 import Data.Drasil.SI_Units (kilogram, metre, millimetre, pascal, second)
 
@@ -26,7 +28,8 @@ symbols = map dqdWr inputsWUnitsUncrtn ++ map dqdWr inputsWUncrtn ++
   map dqdWr sdVector ++ tmSymbols ++ map dqdWr specParamVals ++
   [dqdWr modElas] ++ interps ++ map dqdWr unitalSymbols ++
   unitless ++ map dqdWr [probBr, stressDistFac, cnstrw' nomThick, cnstrw' glassTypeCon] ++
-  map dqdWr derivedInputDataConstraints
+  map dqdWr derivedInputDataConstraints ++
+  map dqdWr mathunitals ++ map dqdWr physicalquants ++ mathquants
 
 constrained :: [ConstrConcept]
 constrained = map cnstrw' dataConstraints ++ map cnstrw' [nomThick, glassTypeCon]

--- a/code/drasil-example/pdcontroller/lib/Drasil/PDController/Body.hs
+++ b/code/drasil-example/pdcontroller/lib/Drasil/PDController/Body.hs
@@ -120,7 +120,7 @@ conceptChunks =
 symbMap :: ChunkDB
 symbMap = withCommonKnowledge []
   (map dqdWr physicscon ++ symbols ++
-    [dqdWr mass, dqdWr posInf, dqdWr negInf] ++
+    [dqdWr mass, posInf, negInf] ++
     map dqdWr pidConstants)
   ideaDicts
   conceptChunks

--- a/code/drasil-example/sglpend/lib/Drasil/SglPend/Body.hs
+++ b/code/drasil-example/sglpend/lib/Drasil/SglPend/Body.hs
@@ -18,7 +18,6 @@ import Data.Drasil.Concepts.Math (mathcon')
 import Data.Drasil.Concepts.Physics (physicCon', motion, pendulum, angular, displacement, iPos, gravitationalConst, gravity, rigidBody, weight, shm)
 import Data.Drasil.Concepts.PhysicalProperties (mass, physicalcon)
 import Data.Drasil.Concepts.Theory (inModel)
-import Data.Drasil.Quantities.PhysicalProperties (len)
 import Data.Drasil.Theories.Physics (newtonSLR)
 
 import Drasil.DblPend.Body (justification, externalLinkRef, charsOfReader,
@@ -107,9 +106,7 @@ conceptChunks :: [ConceptChunk]
 conceptChunks =
   -- ConceptChunks
   physicalcon ++ [angular, displacement, iPos, pendulum, motion,
-  gravitationalConst, gravity, rigidBody, weight, shm] ++
-  -- Unital Chunks
-  [cw len]
+  gravitationalConst, gravity, rigidBody, weight, shm]
 
 symbMap :: ChunkDB
 symbMap = withCommonKnowledge [] (map (^. output) iMods ++ symbols) ideaDicts

--- a/code/drasil-example/sglpend/lib/Drasil/SglPend/Unitals.hs
+++ b/code/drasil-example/sglpend/lib/Drasil/SglPend/Unitals.hs
@@ -19,7 +19,7 @@ import Drasil.DblPend.Concepts (rod)
 import Drasil.DblPend.Unitals (lRod)
 
 symbols:: [DefinedQuantityDict]
-symbols = map dqdWr unitalChunks ++ unitless
+symbols = map dqdWr unitalChunks ++ unitless ++ inputs ++ outputs
 
 inputs :: [DefinedQuantityDict]
 inputs = map dqdWr [lenRod, QPP.mass, QP.angularAccel, pendDisplacementAngle, initialPendAngle]
@@ -31,7 +31,7 @@ units :: [UnitalChunk]
 units = map ucw unitalChunks
 
 unitalChunks :: [UnitalChunk]
-unitalChunks = [lenRod, QPP.mass, QP.force, QP.ixPos, QP.xPos, QP.yPos,
+unitalChunks = [QPP.len, QPP.mass, QP.force, QP.ixPos, QP.xPos, QP.yPos,
    QP.angularVelocity, QP.angularAccel, QP.gravitationalAccel, QP.tension, QP.acceleration,
    QP.yAccel, QP.xAccel, QP.yVel, QP.xVel, QP.iyPos, QP.time, QP.velocity, QP.position, QP.torque,
    QP.momentOfInertia, QP.angularDisplacement, initialPendAngle,

--- a/code/drasil-example/ssp/lib/Drasil/SSP/Body.hs
+++ b/code/drasil-example/ssp/lib/Drasil/SSP/Body.hs
@@ -26,7 +26,6 @@ import Data.Drasil.Concepts.Math (equation, shape, surface, mathcon',
   number)
 import Data.Drasil.Concepts.PhysicalProperties (dimension, mass, physicalcon)
 import Data.Drasil.Concepts.Theory (inModel)
-import Data.Drasil.Quantities.PhysicalProperties (len)
 import Data.Drasil.Concepts.Physics (cohesion, fbd, force, gravity, isotropy,
   strain, stress, time, twoD, physicCon', distance, friction, linear, velocity, position, threeD)
 import Data.Drasil.Concepts.Software (program, softwarecon)
@@ -134,11 +133,7 @@ conceptChunks :: [ConceptChunk]
 conceptChunks =
   -- ConceptChunks
   defs' ++ softwarecon ++ solidcon ++ physicalcon ++
-  [distance, friction, linear, velocity, gravity, stress, fbd, position] ++
-  -- DefinedQuantityDicts
-  [cw len] ++
-  -- UnitalChunks
-  map cw [time, surface]
+  [distance, friction, linear, velocity, gravity, stress, fbd, position]
 
 symbMap :: ChunkDB
 symbMap = withCommonKnowledge [] symbols ideaDicts conceptChunks [degree]

--- a/code/drasil-example/ssp/lib/Drasil/SSP/Unitals.hs
+++ b/code/drasil-example/ssp/lib/Drasil/SSP/Unitals.hs
@@ -21,16 +21,16 @@ import Data.Drasil.Concepts.Math (cartesian, xCoord, xDir, yCoord, yDir,
   zCoord, zDir)
 import Data.Drasil.Concepts.Physics (gravity)
 
-import Data.Drasil.Quantities.Math (area, pi_, unitVectj)
+import Data.Drasil.Quantities.Math (area, pi_, unitVectj, surface)
 import Data.Drasil.Quantities.PhysicalProperties (density, mass, specWeight,
-  vol)
+  vol, len)
 import Data.Drasil.Quantities.Physics (acceleration, displacement, distance,
   force, gravitationalAccel, height, moment2D, pressure, subX, subY, subZ,
-  supMax, supMin, torque, weight, positionVec)
+  supMax, supMin, torque, weight, positionVec, time)
 
 symbols :: [DefinedQuantityDict]
 symbols = dqdWr coords : map dqdWr inputs ++ map dqdWr outputs
-  ++ map dqdWr units ++ map dqdWr unitless
+  ++ map dqdWr units ++ unitless
 
 ---------------------------
 -- Imported UnitalChunks --
@@ -201,7 +201,8 @@ units = map ucw [accel, genericMass, genericF, genericA, genericM, genericV,
   impLoadAngle, baseWthX, baseLngth, surfLngth, midpntHght,
   porePressure, sliceHght, sliceHghtW, fx, fy, fn, ft, nrmForceSum, watForceSum,
   sliceHghtRight, sliceHghtLeft, intNormForce, shrStress, totNormStress, tangStress,
-  effectiveStress, effNormStress, dryVol, satVol, rotForce, momntArm, posVec]
+  effectiveStress, effNormStress, dryVol, satVol, rotForce, momntArm, posVec,
+  time, surface, len]
 
 accel, genericMass, genericF, genericA, genericM, genericV, genericW,
   genericSpWght, gravAccel, dens, genericH, genericP, genericR, genericT,

--- a/code/drasil-example/swhs/lib/Drasil/SWHS/Body.hs
+++ b/code/drasil-example/swhs/lib/Drasil/SWHS/Body.hs
@@ -29,7 +29,7 @@ import Data.Drasil.Concepts.Theory (inModel)
 import Data.Drasil.Concepts.Thermodynamics (enerSrc, heatTrans, htFlux,
   htTransTheo, lawConsEnergy, thermalAnalysis, thermalConduction, thermalEnergy,
   thermocon)
-import Data.Drasil.Quantities.Math (surArea, surface, uNormalVect, area)
+import Data.Drasil.Quantities.Math (surArea, surface, uNormalVect)
 import Data.Drasil.Quantities.PhysicalProperties (vol)
 import Data.Drasil.Quantities.Physics (energy, time)
 import Data.Drasil.Quantities.Thermodynamics (heatCapSpec, latentHeat)
@@ -84,9 +84,7 @@ conceptChunks :: [ConceptChunk]
 conceptChunks =
   -- ConceptChunks
   thermocon ++ softwarecon ++ physicalcon ++ con ++ [CP.energy,
-  CP.mechEnergy, CP.pressure] ++
-  -- UnitalChunks
-  map cw [surArea, area]
+  CP.mechEnergy, CP.pressure]
 
 symbMap :: ChunkDB
 symbMap = withCommonKnowledge [] symbols ideaDicts conceptChunks [] SWHS.dataDefs

--- a/code/drasil-example/swhs/lib/Drasil/SWHS/Unitals.hs
+++ b/code/drasil-example/swhs/lib/Drasil/SWHS/Unitals.hs
@@ -8,7 +8,7 @@ import Language.Drasil.Chunk.Concept.NamedCombinators
 
 import Data.Drasil.Concepts.Documentation (simulation)
 import Data.Drasil.Constraints (gtZeroConstr)
-import Data.Drasil.Quantities.Math (gradient, pi_, surArea, surface, uNormalVect)
+import Data.Drasil.Quantities.Math (gradient, pi_, surArea, surface, uNormalVect, area)
 import Data.Drasil.Quantities.PhysicalProperties (mass, density, vol)
 import Data.Drasil.Quantities.Physics (subMax, subMin, supMax, supMin, time)
 import Data.Drasil.Quantities.Thermodynamics (sensHeat, temp, meltPt,
@@ -32,8 +32,8 @@ symbols = pi_ : map dqdWr units ++ map dqdWr unitless ++ map dqdWr constrained
 -- Symbols with Units --
 
 units :: [UnitalChunk]
-units = map ucw [sensHeat, htFlux, latentHeat, temp, boilPt, meltPt,
-  vol, density] ++ map ucw [mass, time] -- ++ [tankLength, diam, coilSA]
+units = [surArea, area, sensHeat, htFlux, latentHeat, temp, boilPt, meltPt,
+  vol, density, mass, time]
 
 unitalChuncks :: [UnitalChunk]
 unitalChuncks = units ++ [inSA, outSA, htCapL, htCapS, htCapV,

--- a/code/drasil-example/swhsnopcm/lib/Drasil/SWHSNoPCM/Body.hs
+++ b/code/drasil-example/swhsnopcm/lib/Drasil/SWHSNoPCM/Body.hs
@@ -67,8 +67,9 @@ symbols = dqdWr watE : map dqdWr concepts ++ map dqdWr constrained ++
   map dqdWr specParamValList ++ map dqdWr [absTol, relTol] ++ map dqdWr outputs
 
 concepts :: [UnitalChunk]
-concepts = map ucw [tau, inSA, outSA, htCapL, htFluxIn, htFluxOut, volHtGen,
-  htTransCoeff, tankVol, deltaT, tempEnv, thFluxVect, htFluxC, wMass, wVol, tauW]
+concepts = [tau, inSA, outSA, htCapL, htFluxIn, htFluxOut, volHtGen,
+  htTransCoeff, tankVol, deltaT, tempEnv, thFluxVect, htFluxC, wMass, wVol, tauW,
+  surArea, area]
 
 symbolConcepts :: [UnitalChunk]
 symbolConcepts = map ucw [density, mass, time, vol,
@@ -158,9 +159,7 @@ conceptChunks :: [ConceptChunk]
 conceptChunks =
   -- ConceptChunks
   softwarecon ++ thermocon ++ con ++ physicalcon ++ [boilPt, latentHeat,
-  meltPt] ++ [CP.energy, CP.mechEnergy, CP.pressure] ++
-  -- DefinedQuantityDicts
-  map cw [surArea, area]
+  meltPt] ++ [CP.energy, CP.mechEnergy, CP.pressure]
 
 symbMap :: ChunkDB
 symbMap = withCommonKnowledge [] symbols ideaDicts conceptChunks [] NoPCM.dataDefs

--- a/code/drasil-example/template/lib/Drasil/Template/Body.hs
+++ b/code/drasil-example/template/lib/Drasil/Template/Body.hs
@@ -84,7 +84,7 @@ ideaDicts =
   [nw progName]
 
 conceptChunks :: [ConceptChunk]
-conceptChunks = [] :: [ConceptChunk]
+conceptChunks = []
 
 symbMap :: ChunkDB
 symbMap = withCommonKnowledge []


### PR DESCRIPTION
We currently export all quantity-like chunks as `D-Q-D-`s. Let's continue that theme until we put in the work to support `UIDRef` more and insert more kinds of chunks in to the `ChunkDB`.