### PR TITLE
Don't use `unit_symb` for creating numeric ranges in `Sentence`s.

### DIFF
--- a/code/drasil-example/swhs/lib/Drasil/SWHS/Assumptions.hs
+++ b/code/drasil-example/swhs/lib/Drasil/SWHS/Assumptions.hs
@@ -10,16 +10,15 @@ import qualified Language.Drasil.Sentence.Combinators as S
 
 import Data.Drasil.Concepts.Documentation (system, simulation, model,
   problem, assumpDom)
-
-import Data.Drasil.Quantities.PhysicalProperties (vol)
-import Data.Drasil.Quantities.Physics (energy, time)
-import Data.Drasil.Quantities.Thermodynamics (boilPt, meltPt, temp)
-
 import Data.Drasil.Concepts.Thermodynamics as CT (heat, melting,
   lawConvCooling, heatTrans, thermalEnergy)
 import Data.Drasil.Concepts.PhysicalProperties (solid, liquid, gaseous)
 import Data.Drasil.Concepts.Math (change)
 import Data.Drasil.Concepts.Physics (mechEnergy)
+import Data.Drasil.Quantities.PhysicalProperties (vol)
+import Data.Drasil.Quantities.Physics (energy, time)
+import Data.Drasil.Quantities.Thermodynamics (boilPt, meltPt, temp)
+import Data.Drasil.SI_Units (centigrade)
 
 import Drasil.SWHS.Concepts (coil, tank, phsChgMtrl, water, perfectInsul,
   charging, discharging)
@@ -136,8 +135,8 @@ assumpS18 = foldlSent [
 assumpS19 = foldlSent [
   S "The pressure" `S.inThe` phrase tank `S.is` S "atmospheric" `sC` S "so the",
   D.toSent (phraseNP (meltPt `and_` boilPt)) `S.are` S (show (0 :: Integer)) :+:
-  Sy (unit_symb temp) `S.and_` S (show (100 :: Integer)) :+:
-  Sy (unit_symb temp) `sC` S "respectively"]
+  Sy (usymb centigrade) `S.and_` S (show (100 :: Integer)) :+:
+  Sy (usymb centigrade) `sC` S "respectively"]
 assumpS20 = foldlSent [
   S "When considering the", D.toSent (phraseNP (wVol `inThe` tank))
   `sC` D.toSent (phraseNP (vol `the_ofThe` coil)) `S.is` S "assumed to be negligible"]

--- a/code/drasil-example/swhsnopcm/lib/Drasil/SWHSNoPCM/Assumptions.hs
+++ b/code/drasil-example/swhsnopcm/lib/Drasil/SWHSNoPCM/Assumptions.hs
@@ -8,13 +8,11 @@ import qualified Language.Drasil.NaturalLanguage.English.NounPhrase.Combinators 
 import qualified Language.Drasil.Sentence.Combinators as S
 
 import Data.Drasil.Concepts.Documentation (model, assumpDom, material_)
-
+import Data.Drasil.Concepts.Thermodynamics as CT (heat)
 import Data.Drasil.Quantities.PhysicalProperties (vol)
 import Data.Drasil.Quantities.Physics (pressure)
 import Data.Drasil.Quantities.Thermodynamics (boilPt, meltPt)
-
-import Data.Drasil.Concepts.Thermodynamics as CT (heat)
-import qualified Data.Drasil.Quantities.Thermodynamics as QT (temp)
+import Data.Drasil.SI_Units (centigrade)
 
 import Drasil.SWHS.Assumptions (assumpTEO, assumpHTCC, assumpCWTAT,
   assumpLCCCW, assumpTHCCoT, assumpTHCCoL, assumpS14, assumpPIT, assumpVCN)
@@ -76,8 +74,8 @@ assumpWAL = cic "assumpWAL" (assumpS14 $ phrase material_ +:+
 assumpS13 =
   D.toSent (atStartNP (NP.the (pressure `inThe` tank))) `S.is` S "atmospheric" `sC` S "so the" +:+
   D.toSent (phraseNP (meltPt `and_` boilPt)) +:+ S "of water are" +:+
-  S (show (0 :: Integer)) :+: Sy (unit_symb QT.temp) `S.and_`
-  S (show (100 :: Integer)) :+: Sy (unit_symb QT.temp) `sC` (S "respectively" !.)
+  S (show (0 :: Integer)) :+: Sy (usymb centigrade) `S.and_`
+  S (show (100 :: Integer)) :+: Sy (usymb centigrade) `sC` (S "respectively" !.)
 
 assumpAPT = cic "assumpAPT" assumpS13
   "Atmospheric-Pressure-Tank" assumpDom


### PR DESCRIPTION
`unit_symb` very clearly exists for a good reason: getting the unit symbol of a quantity. It has one strict requirement, that the input quantity _always_ has a quantity. However:

1. As we've recently been discussing, units should be more tightly integrated with types.
2. `unit_symb` is used exclusively in creating numeric ranges. We ought to have a better way of doing that (and in a way that adds the unit symbols automatically, enforcing that both sides are the same, further using the unit of the thing it is creating a range for).