### PR TITLE
GlassBR: Make input type of `standardValuesDesc` less specific (any quantity is fine).

### DIFF
--- a/code/drasil-example/glassbr/lib/Drasil/GlassBR/Assumptions.hs
+++ b/code/drasil-example/glassbr/lib/Drasil/GlassBR/Assumptions.hs
@@ -64,10 +64,10 @@ explainScenarioDesc :: Sentence
 explainScenarioDesc = foldlSent [S "This", phrase system, S "only considers the external",
   D.toSent $ phraseNP (combineNINI explosion scenario), S "for its", plural calculation]
 
-standardValuesDesc :: UnitalChunk -> Sentence
-standardValuesDesc mainIdea = foldlSent [D.toSent $ atStartNP' (the value), S "provided in",
-  refS $ SRS.valsOfAuxCons ([]::[Contents]) ([]::[Section]), S "are assumed for the", phrase mainIdea,
-  sParen (ch mainIdea) `sC` S "and the", plural materialProprty `S.of_`
+standardValuesDesc :: Quantity q => q -> Sentence
+standardValuesDesc q = foldlSent [D.toSent $ atStartNP' (the value), S "provided in",
+  refS $ SRS.valsOfAuxCons ([]::[Contents]) ([]::[Section]), S "are assumed for the", phrase q,
+  sParen (ch q) `sC` S "and the", plural materialProprty `S.of_`
   foldlList Comma List (map ch (take 3 assumptionConstants))]
 
 glassLiteDesc :: Sentence


### PR DESCRIPTION
I don't quite understand why having `loadDur` (load duration) as an argument here is necessary, but I suppose that we can reuse this somewhat generic description.

The point of this is to look for locations where `UnitalChunk` is _actually_ necessary and remove the areas where it isn't.