### PR TITLE
Make `newtonLawNote` accept more than just `UnitalChunk`s as quantity input being 'found'.

### DIFF
--- a/code/drasil-example/swhs/lib/Drasil/SWHS/GenDefs.hs
+++ b/code/drasil-example/swhs/lib/Drasil/SWHS/GenDefs.hs
@@ -78,7 +78,7 @@ htFluxPCMFromWaterQD = mkQuantDef htFluxP htFluxPCMFromWaterExpr
 htFluxPCMFromWaterExpr :: ModelExpr
 htFluxPCMFromWaterExpr = sy pcmHTC $* (apply1 tempW time $- apply1 tempPCM time)
 
-newtonLawNote :: UnitalChunk -> ConceptInstance -> ConceptChunk -> Sentence
+newtonLawNote :: Quantity q => q -> ConceptInstance -> ConceptChunk -> Sentence
 newtonLawNote u a c = foldlSent [ch u `S.is` S "found by assuming that",
   phrase lawConvCooling, S "applies" +:+. sParen (refS a), S "This law",
   sParen (S "defined" `S.in_` refS nwtnCooling) `S.is` S "used on",


### PR DESCRIPTION
Ulterior motive: seeing where `UnitalChunk` is absolutely necessary. It's not in this case, and this note can be simplified to make it more readable than reusable.