### PR TITLE
Add .utf8 encoding to new String calls in Swift generator.

### DIFF
--- a/code/drasil-gool/lib/Drasil/GOOL/LanguageRenderer/SwiftRenderer.hs
+++ b/code/drasil-gool/lib/Drasil/GOOL/LanguageRenderer/SwiftRenderer.hs
@@ -877,8 +877,8 @@ swiftVoidType = typeFromData Void swiftVoid (text swiftVoid)
 
 swiftPi, swiftListSize, swiftFirst, swiftDesc, swiftUTF8, swiftVar, swiftConst,
   swiftDo, swiftFunc, swiftCtorName, swiftExtension, swiftInOut, swiftError,
-  swiftDocDir, swiftUserMask, swiftInOutArg, swiftNamedArgSep, swiftTypeSpec,
-  swiftConforms, swiftNoLabel, swiftRetType', swiftUnwrap' :: Doc
+  swiftDocDir, swiftUTF8Enc, swiftUserMask, swiftInOutArg, swiftNamedArgSep,
+  swiftTypeSpec, swiftConforms, swiftNoLabel, swiftRetType', swiftUnwrap' :: Doc
 swiftPi = text $ CP.doubleRender `access` piLabel
 swiftListSize = text "count"
 swiftFirst = text "first"
@@ -893,6 +893,7 @@ swiftExtension = text "extension"
 swiftInOut = text "inout"
 swiftError = text "Error"
 swiftDocDir = text $ "" `access` "documentDirectory"
+swiftUTF8Enc = text $ "" `access` "utf8"
 swiftUserMask = text $ "" `access` "userDomainMask"
 swiftNamedArgSep = colon <> space
 swiftInOutArg = text "&"
@@ -1028,8 +1029,12 @@ swiftReadLineFunc :: (CommonRenderSym r) => SValue r
 swiftReadLineFunc = swiftUnwrapVal $ funcApp swiftReadLine string []
 
 swiftReadFileFunc :: (CommonRenderSym r) => SValue r -> SValue r
-swiftReadFileFunc v = let contentsArg = var swiftContentsOf infile
-  in swiftTryVal $ funcAppNamedArgs CP.stringRender' string [(contentsArg, v)]
+swiftReadFileFunc v = swiftTryVal $
+  funcAppNamedArgs CP.stringRender' string [contentsArg, encodingArg]
+  where
+    encVal = mkStateVal string swiftUTF8Enc
+    contentsArg = (var swiftContentsOf infile, v)
+    encodingArg = (var "encoding" string, encVal)
 
 swiftSplitFunc :: (OORenderSym r) => Char -> SValue r -> SValue r
 swiftSplitFunc d s = let sepArg = var swiftSepBy char

--- a/code/stable/glassbr/src/swift/InputParameters.swift
+++ b/code/stable/glassbr/src/swift/InputParameters.swift
@@ -115,7 +115,7 @@ class InputParameters {
         infile = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first!.appendingPathComponent(filename)
         var goolContents: [[String]]
         do {
-            goolContents = try String(contentsOf: infile).components(separatedBy: "\n").map({(l: String) -> [String] in l.components(separatedBy: " ")})
+            goolContents = try String(contentsOf: infile, encoding: .utf8).components(separatedBy: "\n").map({(l: String) -> [String] in l.components(separatedBy: " ")})
         } catch {
             throw "Error reading from file."
         }

--- a/code/stable/glassbr/src/swift/ReadTable.swift
+++ b/code/stable/glassbr/src/swift/ReadTable.swift
@@ -104,7 +104,7 @@ func read_table(_ filename: String, _ z_vector: inout [Double], _ x_matrix: inou
     infile = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first!.appendingPathComponent(filename)
     var goolContents: [[String]]
     do {
-        goolContents = try String(contentsOf: infile).components(separatedBy: "\n").map({(l: String) -> [String] in l.components(separatedBy: " ")})
+        goolContents = try String(contentsOf: infile, encoding: .utf8).components(separatedBy: "\n").map({(l: String) -> [String] in l.components(separatedBy: " ")})
     } catch {
         throw "Error reading from file."
     }

--- a/code/stable/gooltest/swift/FileTests/main.swift
+++ b/code/stable/gooltest/swift/FileTests/main.swift
@@ -45,7 +45,7 @@ var fileToRead: URL
 fileToRead = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first!.appendingPathComponent("testText.txt")
 var goolContents: [[String]]
 do {
-    goolContents = try String(contentsOf: fileToRead).components(separatedBy: "\n").map({(l: String) -> [String] in l.components(separatedBy: " ")})
+    goolContents = try String(contentsOf: fileToRead, encoding: .utf8).components(separatedBy: "\n").map({(l: String) -> [String] in l.components(separatedBy: " ")})
 } catch {
     throw "Error reading from file."
 }

--- a/code/stable/projectile/projectile_m_l_nol_u_u_v_f/src/swift/InputParameters.swift
+++ b/code/stable/projectile/projectile_m_l_nol_u_u_v_f/src/swift/InputParameters.swift
@@ -23,7 +23,7 @@ func get_input(_ filename: String) throws -> (Float, Float, Float) {
     infile = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first!.appendingPathComponent(filename)
     var goolContents: [[String]]
     do {
-        goolContents = try String(contentsOf: infile).components(separatedBy: "\n").map({(l: String) -> [String] in l.components(separatedBy: " ")})
+        goolContents = try String(contentsOf: infile, encoding: .utf8).components(separatedBy: "\n").map({(l: String) -> [String] in l.components(separatedBy: " ")})
     } catch {
         throw "Error reading from file."
     }

--- a/code/stable/projectile/projectile_m_p_nol_b_u_v_d/src/swift/InputParameters.swift
+++ b/code/stable/projectile/projectile_m_p_nol_b_u_v_d/src/swift/InputParameters.swift
@@ -31,7 +31,7 @@ class InputParameters {
         infile = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first!.appendingPathComponent(filename)
         var goolContents: [[String]]
         do {
-            goolContents = try String(contentsOf: infile).components(separatedBy: "\n").map({(l: String) -> [String] in l.components(separatedBy: " ")})
+            goolContents = try String(contentsOf: infile, encoding: .utf8).components(separatedBy: "\n").map({(l: String) -> [String] in l.components(separatedBy: " ")})
         } catch {
             throw "Error reading from file."
         }

--- a/code/stable/projectile/projectile_u_p_l_b_b_c_d/src/swift/main.swift
+++ b/code/stable/projectile/projectile_u_p_l_b_b_c_d/src/swift/main.swift
@@ -103,7 +103,7 @@ class InputParameters {
         infile = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first!.appendingPathComponent(filename)
         var goolContents: [[String]]
         do {
-            goolContents = try String(contentsOf: infile).components(separatedBy: "\n").map({(l: String) -> [String] in l.components(separatedBy: " ")})
+            goolContents = try String(contentsOf: infile, encoding: .utf8).components(separatedBy: "\n").map({(l: String) -> [String] in l.components(separatedBy: " ")})
         } catch {
             throw "Error reading from file."
         }

--- a/code/stable/projectile/projectile_u_p_l_b_wi_v_f/src/swift/main.swift
+++ b/code/stable/projectile/projectile_u_p_l_b_wi_v_f/src/swift/main.swift
@@ -105,7 +105,7 @@ class InputParameters {
         infile = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first!.appendingPathComponent(filename)
         var goolContents: [[String]]
         do {
-            goolContents = try String(contentsOf: infile).components(separatedBy: "\n").map({(l: String) -> [String] in l.components(separatedBy: " ")})
+            goolContents = try String(contentsOf: infile, encoding: .utf8).components(separatedBy: "\n").map({(l: String) -> [String] in l.components(separatedBy: " ")})
         } catch {
             throw "Error reading from file."
         }

--- a/code/stable/projectile/projectile_u_p_nol_u_wi_v_d/src/swift/main.swift
+++ b/code/stable/projectile/projectile_u_p_nol_u_wi_v_d/src/swift/main.swift
@@ -52,7 +52,7 @@ func get_input(_ filename: String) throws -> (Double, Double, Double) {
     infile = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first!.appendingPathComponent(filename)
     var goolContents: [[String]]
     do {
-        goolContents = try String(contentsOf: infile).components(separatedBy: "\n").map({(l: String) -> [String] in l.components(separatedBy: " ")})
+        goolContents = try String(contentsOf: infile, encoding: .utf8).components(separatedBy: "\n").map({(l: String) -> [String] in l.components(separatedBy: " ")})
     } catch {
         throw "Error reading from file."
     }


### PR DESCRIPTION
Newer versions of swiftc will give large "ambiguous encoding" warnings when building the Swift code unless the encoding is explicitly noted.

This PR adds it. That being said, I'm not sure I took the right approach.