### PR TITLE
Enable `-Wmissing-export-lists` in `drasil-database`.

### DIFF
--- a/code/drasil-database/lib/Drasil/Database/Maps.hs
+++ b/code/drasil-database/lib/Drasil/Database/Maps.hs
@@ -1,6 +1,6 @@
-module Drasil.Database.Maps where
+module Drasil.Database.Maps (invert) where
 
-import Data.Map.Strict
+import Data.Map.Strict (Map, fromListWith, toList)
 
 invert :: Ord v => Map k [v] -> Map v [k]
 invert m = fromListWith (++) vks

--- a/code/drasil-database/package.yaml
+++ b/code/drasil-database/package.yaml
@@ -26,6 +26,7 @@ dependencies:
 ghc-options:
 - -Wall
 - -Wredundant-constraints
+- -Wmissing-export-lists
 
 library:
   source-dirs: lib


### PR DESCRIPTION
With this GHC flag enabled, we will be warned of any module missing an export list.

For the CI, that means warnings turning into errors, meaning incomplete export lists become more noticeable.