### PR TITLE
Remove unused boolean variables in `drasil-printers`.

### DIFF
--- a/code/drasil-printers/lib/Language/Drasil/Config.hs
+++ b/code/drasil-printers/lib/Language/Drasil/Config.hs
@@ -3,27 +3,13 @@
 module Language.Drasil.Config(
   -- * Printer Configurations
   numberedSections,hyperSettings,fontSize,bibFname,
-  verboseDDDescription,
   -- * Bibliography
   StyleGuide(..),bibStyleH,bibStyleT,colAwidth,colBwidth,
-  numberedDDEquations,numberedTMEquations
 ) where
 
 -- | TeX font size.
 fontSize :: Int
 fontSize = 12
-
--- | (Currently Unused) Print verbose data definition descriptions?
-verboseDDDescription :: Bool
-verboseDDDescription = True
-
--- | (Currently Unused) TeX Only - Number Data Definition equations?
-numberedDDEquations :: Bool
-numberedDDEquations = False -- Does not affect HTML
-
--- | (Currently Unused) TeX Only - Number Theoretical Model equations?
-numberedTMEquations :: Bool
-numberedTMEquations = False
 
 -- | TeX Only - Numbered sections?
 numberedSections :: Bool


### PR DESCRIPTION
Just 3 unused booleans.