### PR TITLE
Enable `-Wmissing-export-lists` in `drasil-build-artifacts`.

### DIFF
--- a/code/drasil-build-artifacts/package.yaml
+++ b/code/drasil-build-artifacts/package.yaml
@@ -24,6 +24,7 @@ dependencies:
 ghc-options:
 - -Wall
 - -Wredundant-constraints
+- -Wmissing-export-lists
 
 library:
   source-dirs: lib


### PR DESCRIPTION
Follow-up to #4914.