### PR TITLE
Enable `-Wmissing-export-lists` in `drasil-gen`.

### DIFF
--- a/code/drasil-gen/package.yaml
+++ b/code/drasil-gen/package.yaml
@@ -40,6 +40,7 @@ dependencies:
 ghc-options:
 - -Wall
 - -Wredundant-constraints
+- -Wmissing-export-lists
 
 library:
   source-dirs: lib


### PR DESCRIPTION
Follow-up to #4914.