### PR TITLE
Enable `-Wmissing-export-lists` in `drasil-system`.

### DIFF
--- a/code/drasil-system/package.yaml
+++ b/code/drasil-system/package.yaml
@@ -29,6 +29,7 @@ dependencies:
 ghc-options:
 - -Wall
 - -Wredundant-constraints
+- -Wmissing-export-lists
 
 library:
   source-dirs: lib


### PR DESCRIPTION
Follow-up to #4914.