### PR TITLE
Enable `-Wmissing-export-lists` in `drasil-utils`.

### DIFF
--- a/code/drasil-utils/package.yaml
+++ b/code/drasil-utils/package.yaml
@@ -24,6 +24,7 @@ dependencies:
 ghc-options:
 - -Wall
 - -Wredundant-constraints
+- -Wmissing-export-lists
 
 library:
   source-dirs: lib


### PR DESCRIPTION
Follow-up to #4914.