### PR TITLE
Move `drasil-utils/lib/Utils/Drasil/Document.hs` to `drasil-build-artifacts/lib/Drasil/Build/Artifacts/Document.hs`.

### DIFF
--- a/code/drasil-build-artifacts/lib/Drasil/Build/Artifacts.hs
+++ b/code/drasil-build-artifacts/lib/Drasil/Build/Artifacts.hs
@@ -1,13 +1,15 @@
 module Drasil.Build.Artifacts (
   module Drasil.Build.Artifacts.Classes,
   module Drasil.Build.Artifacts.Directory,
+  module Drasil.Build.Artifacts.Document,
   module Drasil.Build.Artifacts.FileData,
   module Drasil.Build.Artifacts.FileIO,
-  module Drasil.Build.Artifacts.FilePath
+  module Drasil.Build.Artifacts.FilePath,
 ) where
 
 import Drasil.Build.Artifacts.Classes
 import Drasil.Build.Artifacts.Directory
+import Drasil.Build.Artifacts.Document
 import Drasil.Build.Artifacts.FileData
 import Drasil.Build.Artifacts.FileIO
 import Drasil.Build.Artifacts.FilePath

--- a/code/drasil-build-artifacts/lib/Drasil/Build/Artifacts/Document.hs
+++ b/code/drasil-build-artifacts/lib/Drasil/Build/Artifacts/Document.hs
@@ -1,5 +1,5 @@
 -- | Common 'Doc'-related functions for writting printers with a little more clarity.
-module Utils.Drasil.Document (blank, indent, indentList, contSep, filterEmpty,
+module Drasil.Build.Artifacts.Document (blank, indent, indentList, contSep, filterEmpty,
   listToDoc, Separator) where
 
 import Text.PrettyPrint.HughesPJ (Doc, text, vcat, nest, hsep, comma, isEmpty,

--- a/code/drasil-code/lib/Language/Drasil/Code/Imperative/Doxygen/Import.hs
+++ b/code/drasil-code/lib/Language/Drasil/Code/Imperative/Doxygen/Import.hs
@@ -7,7 +7,7 @@ import Data.List (intersperse, nub)
 import Data.Maybe (maybeToList)
 import Text.PrettyPrint.HughesPJ (Doc, (<+>), text, hcat, vcat)
 
-import Utils.Drasil (blank)
+import Drasil.Build.Artifacts (blank)
 
 import Language.Drasil.Choices (Verbosity(..))
 import Language.Drasil.SoftwareDossier.SoftwareDossierSym (SoftwareDossierState,

--- a/code/drasil-code/lib/Language/Drasil/Code/Imperative/WriteInput.hs
+++ b/code/drasil-code/lib/Language/Drasil/Code/Imperative/WriteInput.hs
@@ -6,7 +6,7 @@ import Data.List (intersperse, transpose)
 import Text.PrettyPrint.HughesPJ (Doc, (<+>), char, empty, hcat, parens, space,
   text, vcat)
 
-import Utils.Drasil (blank)
+import Drasil.Build.Artifacts (blank)
 import Language.Drasil hiding (space, Matrix)
 import Language.Drasil.Expr.Development (Expr(Matrix))
 import Language.Drasil.Printers (SingleLine(OneLine), exprDoc, sentenceDoc,

--- a/code/drasil-gool/lib/Drasil/GOOL/LanguageRenderer/CSharpRenderer.hs
+++ b/code/drasil-gool/lib/Drasil/GOOL/LanguageRenderer/CSharpRenderer.hs
@@ -7,7 +7,7 @@ module Drasil.GOOL.LanguageRenderer.CSharpRenderer (
   CSharpCode(..), csName, csVersion
 ) where
 
-import Utils.Drasil (indent)
+import Drasil.Build.Artifacts (indent)
 
 import Drasil.Shared.CodeType (CodeType(..))
 import Drasil.Shared.InterfaceCommon (SharedProg, Label, MSBody, VSType,

--- a/code/drasil-gool/lib/Drasil/GOOL/LanguageRenderer/CppRenderer.hs
+++ b/code/drasil-gool/lib/Drasil/GOOL/LanguageRenderer/CppRenderer.hs
@@ -9,7 +9,7 @@ module Drasil.GOOL.LanguageRenderer.CppRenderer (
   CppSrcCode(..), CppHdrCode(..), CppCode(..), unCPPC, cppName, cppVersion
 ) where
 
-import Utils.Drasil (blank, indent, indentList)
+import Drasil.Build.Artifacts (blank, indent, indentList)
 
 import Drasil.Shared.CodeType (CodeType(..))
 import Drasil.Shared.InterfaceCommon (SharedProg, Label, MSBody, VSType,

--- a/code/drasil-gool/lib/Drasil/GOOL/LanguageRenderer/JavaRenderer.hs
+++ b/code/drasil-gool/lib/Drasil/GOOL/LanguageRenderer/JavaRenderer.hs
@@ -7,7 +7,7 @@ module Drasil.GOOL.LanguageRenderer.JavaRenderer (
   JavaCode(..), jName, jVersion
 ) where
 
-import Utils.Drasil (indent)
+import Drasil.Build.Artifacts (indent)
 
 import Drasil.Shared.CodeType (CodeType(..))
 import Drasil.Shared.InterfaceCommon (SharedProg, Label, MSBody, VSType,

--- a/code/drasil-gool/lib/Drasil/GOOL/LanguageRenderer/PythonRenderer.hs
+++ b/code/drasil-gool/lib/Drasil/GOOL/LanguageRenderer/PythonRenderer.hs
@@ -6,7 +6,7 @@ module Drasil.GOOL.LanguageRenderer.PythonRenderer (
   PythonCode(..), pyName, pyVersion
 ) where
 
-import Utils.Drasil (blank, indent)
+import Drasil.Build.Artifacts (blank, indent)
 
 import Drasil.Shared.CodeType (CodeType(..))
 import Drasil.Shared.InterfaceCommon (SharedProg, Label, Library, VSType,

--- a/code/drasil-gool/lib/Drasil/GOOL/LanguageRenderer/SwiftRenderer.hs
+++ b/code/drasil-gool/lib/Drasil/GOOL/LanguageRenderer/SwiftRenderer.hs
@@ -7,7 +7,7 @@ module Drasil.GOOL.LanguageRenderer.SwiftRenderer (
   SwiftCode(..), swiftName, swiftVersion
 ) where
 
-import Utils.Drasil (indent)
+import Drasil.Build.Artifacts (indent)
 
 import Drasil.Shared.CodeType (CodeType(..))
 import Drasil.Shared.InterfaceCommon (SharedProg, Label, MSBody, MSBlock, VSType,

--- a/code/drasil-gool/lib/Drasil/GProc/LanguageRenderer/JuliaRenderer.hs
+++ b/code/drasil-gool/lib/Drasil/GProc/LanguageRenderer/JuliaRenderer.hs
@@ -8,7 +8,7 @@ module Drasil.GProc.LanguageRenderer.JuliaRenderer (
   JuliaCode(..), jlName, jlVersion
 ) where
 
-import Utils.Drasil (indent)
+import Drasil.Build.Artifacts (indent)
 
 import Drasil.Shared.CodeType (CodeType(..))
 import Drasil.Shared.InterfaceCommon (SharedProg, Label, VSType, SValue, litZero,

--- a/code/drasil-gool/lib/Drasil/Shared/Helpers.hs
+++ b/code/drasil-gool/lib/Drasil/Shared/Helpers.hs
@@ -5,10 +5,6 @@ module Drasil.Shared.Helpers (angles, doubleQuotedText, hicat, vicat, vibcat,
   getNestDegree
 ) where
 
-import Utils.Drasil (blank)
-
-import qualified Drasil.Shared.CodeType as C (CodeType(..))
-
 import Prelude hiding ((<>))
 import Control.Applicative (liftA3)
 import Control.Monad (liftM2, liftM3)
@@ -16,6 +12,10 @@ import Control.Monad.State (State)
 import Data.List (intersperse)
 import Text.PrettyPrint.HughesPJ (Doc, vcat, hcat, text, char, doubleQuotes,
   (<>), empty, isEmpty)
+
+import Drasil.Build.Artifacts (blank)
+
+import qualified Drasil.Shared.CodeType as C (CodeType(..))
 
 angles :: Doc -> Doc
 angles d = char '<' <> d <> char '>'

--- a/code/drasil-gool/lib/Drasil/Shared/LanguageRenderer.hs
+++ b/code/drasil-gool/lib/Drasil/Shared/LanguageRenderer.hs
@@ -25,7 +25,8 @@ module Drasil.Shared.LanguageRenderer (
   appendToBody, surroundBody, getterName, setterName, intValue
 ) where
 
-import Utils.Drasil (blank, capitalize, indent, indentList, stringList)
+import Drasil.Build.Artifacts (blank, indent, indentList)
+import Utils.Drasil (capitalize, stringList)
 
 import Drasil.Shared.CodeType (CodeType(..))
 import Drasil.Shared.InterfaceCommon (Label, Library, SValue, BodySym(Body),

--- a/code/drasil-gool/lib/Drasil/Shared/LanguageRenderer/CLike.hs
+++ b/code/drasil-gool/lib/Drasil/Shared/LanguageRenderer/CLike.hs
@@ -8,7 +8,7 @@ module Drasil.Shared.LanguageRenderer.CLike (charRender, float, double, char,
   intFunc, multiAssignError, multiReturnError, multiTypeError
 ) where
 
-import Utils.Drasil (indent)
+import Drasil.Build.Artifacts (indent)
 
 import Drasil.Shared.CodeType (CodeType(..))
 import Drasil.Shared.InterfaceCommon (Label, Library, MSBody, VSType, SVariable,

--- a/code/drasil-gool/lib/Drasil/Shared/LanguageRenderer/CommonPseudoOO.hs
+++ b/code/drasil-gool/lib/Drasil/Shared/LanguageRenderer/CommonPseudoOO.hs
@@ -13,7 +13,8 @@ module Drasil.Shared.LanguageRenderer.CommonPseudoOO (int, constructor, doxFunc,
   listAdd, listAppend, intToIndex, indexToInt, intToIndex', indexToInt',
   varDecDef, openFileR', openFileW', openFileA', argExists, global, setMethodCall) where
 
-import Utils.Drasil (indent, stringList)
+import Utils.Drasil (stringList)
+import Drasil.Build.Artifacts (indent)
 
 import Drasil.Shared.CodeType (CodeType(..))
 

--- a/code/drasil-gool/lib/Drasil/Shared/LanguageRenderer/LanguagePolymorphic.hs
+++ b/code/drasil-gool/lib/Drasil/Shared/LanguageRenderer/LanguagePolymorphic.hs
@@ -19,7 +19,7 @@ module Drasil.Shared.LanguageRenderer.LanguagePolymorphic (fileFromData,
   defaultOptSpace, smartAdd, smartSub
 ) where
 
-import Utils.Drasil (indent)
+import Drasil.Build.Artifacts (indent)
 
 import Drasil.Shared.CodeType (CodeType(..), ClassName)
 import Drasil.Shared.InterfaceCommon (Label, Library, MSBody, MSBlock, VSFunction,

--- a/code/drasil-printers/lib/Language/Drasil/Markdown/CreateMd.hs
+++ b/code/drasil-printers/lib/Language/Drasil/Markdown/CreateMd.hs
@@ -10,7 +10,7 @@ import Prelude hiding ((<>))
 import Text.PrettyPrint.HughesPJ (Doc, empty, isEmpty, vcat, text, (<+>),
     (<>), punctuate, hsep)
 
-import Utils.Drasil (contSep, filterEmpty, listToDoc, Separator)
+import Drasil.Build.Artifacts (contSep, filterEmpty, listToDoc, Separator)
 
 import Language.Drasil.Printing.Helpers (upcase)
 

--- a/code/drasil-printers/package.yaml
+++ b/code/drasil-printers/package.yaml
@@ -22,6 +22,7 @@ dependencies:
 - MissingH
 - filepath
 - directory
+- drasil-build-artifacts
 - drasil-database
 - drasil-lang
 - drasil-metadata

--- a/code/drasil-utils/lib/Utils/Drasil.hs
+++ b/code/drasil-utils/lib/Utils/Drasil.hs
@@ -1,12 +1,10 @@
 -- | Re-exports all utilities.
 module Utils.Drasil (
-  module Utils.Drasil.Document,
   module Utils.Drasil.English,
   module Utils.Drasil.Lists,
   module Utils.Drasil.Strings,
 ) where
 
-import Utils.Drasil.Document
 import Utils.Drasil.English
 import Utils.Drasil.Lists
 import Utils.Drasil.Strings

--- a/code/drasil-utils/lib/Utils/Drasil/Document.hs
+++ b/code/drasil-utils/lib/Utils/Drasil/Document.hs
@@ -2,7 +2,8 @@
 module Utils.Drasil.Document (blank, indent, indentList, contSep, filterEmpty,
   listToDoc, Separator) where
 
-import Text.PrettyPrint.HughesPJ
+import Text.PrettyPrint.HughesPJ (Doc, text, vcat, nest, hsep, comma, isEmpty,
+  punctuate)
 
 -- | Separates document sections.
 type Separator = Doc

--- a/code/drasil-utils/package.yaml
+++ b/code/drasil-utils/package.yaml
@@ -17,8 +17,6 @@ extra-source-files: []
 dependencies:
 - base >= 4.7 && < 5
 - containers
-- directory
-- filepath
 
 ghc-options:
 - -Wall

--- a/code/drasil-utils/package.yaml
+++ b/code/drasil-utils/package.yaml
@@ -19,7 +19,6 @@ dependencies:
 - containers
 - directory
 - filepath
-- pretty
 
 ghc-options:
 - -Wall


### PR DESCRIPTION
Rationale: This is a file of tools related to building artifacts. That
is now the goal of `drasil-build-artifacts`.
