### PR TITLE
Fix: Add missing package type dependency and class instance graphs for website

### DIFF
--- a/code/Makefile
+++ b/code/Makefile
@@ -7,7 +7,7 @@ SHELL = bash
 #--------------------------------------------#
 
 # List of all known packages
-PACKAGES = lang metadata code docLang printers build theory gool data database gen utils website
+PACKAGES = build build-artifacts code data database docLang gen gool lang metadata printers system theory utils website
 PACKAGES_E = $(PACKAGES) example
 
 # and associated package-level suffixes
@@ -334,7 +334,6 @@ $(GOOLTEST)$(GEN_E_SUFFIX):
 	stack build $(stackArgs) "drasil-code:exe:$(GOOLTEST_EXE)"
 	@mkdir -p "$(BUILD_FOLDER)$(GOOLTEST_DIR)"
 	cd "$(BUILD_FOLDER)$(GOOLTEST_DIR)" && $(STACK_EXEC) -- "$(GOOLTEST_EXE)"
-
 
 $(GOOLTEST)$(TEST_E_SUFFIX): $(GOOLTEST)$(GEN_E_SUFFIX) $(CLEAN_GF_PREFIX)$(LOG_FOLDER_NAME)
 	@mkdir -p "$(LOG_FOLDER)"

--- a/code/scripts/ClassInstDepGen.hs
+++ b/code/scripts/ClassInstDepGen.hs
@@ -14,12 +14,10 @@
 module ClassInstDepGen (main) where
 
 import Data.List
-import Data.Maybe
 import System.IO
 import System.Directory
 import System.FilePath (takeDirectory)
 import Control.Monad
-import qualified Data.Map as Map
 import qualified DirectoryController as DC (createFolder, createFile, finder,
   getDirectories, DrasilPack, FileName, FolderName, File(..), Folder(..))
 import SourceCodeReaderCI as SCR (extractEntryData, EntryData(..))
@@ -122,19 +120,11 @@ main = do
   -- gets names + filepaths of all drasil- packages/directories
   drctyList <- DC.getDirectories codeDirectory "drasil-"
 
-  -- imports configuration settings (drasil- package names + class types order)
-  (packageNames,classInstOrd) <- config scriptsDirectory
-
-  -- uses ordering (imported from config file) iff imported ordering is complete
-  let ordered
-        | ldL == lpN = map (getFolder drctyDict) packageNames
-        | otherwise = drctyList
-      (ldL,lpN) = (length drctyList,length packageNames)
-      -- creates dictionary (Map.Map format) from drasil- directories list
-      drctyDict = Map.fromList $ map toDictList drctyList
+  let packageNames = map DC.folderDrasilPack drctyList
+      classInstOrd = [Haskell, Drasil, GOOL]
 
   -- all files + filepaths stored here; obtained from ordered list using finder
-  allFiles <- mapM DC.finder ordered
+  allFiles <- mapM DC.finder drctyList
 
   -- adds newline File entries (to separate Files by drasil- package)
   let rawFileData = intercalate [DC.createFile "" "" "newline"] allFiles
@@ -271,31 +261,6 @@ separateN :: [EntryString] -> [EntryString]
 separateN = concatMap (splitOn "\n")
 
 -------------
--- Configuration file parser
--------------
-
--- import configurations function (drasil- package + class instance orderings)
-config :: FilePath -> IO ([String],[ClassType])
-config configFilePath = do
-  setCurrentDirectory configFilePath
-  c <- readFile "DTG_Config.txt"
-  let l = map words $ filter isInfoLine (lines c)
-      -- FIXME: use real parser to extract settings from config file
-      -- will improve error messages regarding config file settings
-      (packageNames,classInstOrd) = (head l, map toClassType (l !! 1))
-  return (packageNames,classInstOrd)
-
--- used to filter out info lines (i.e. removes comment and empty lines)
-isInfoLine :: String -> Bool
-isInfoLine line = (line /="") && not ("#" `isPrefixOf` line)
-
--- converts string to classtype (for use by config function)
-toClassType :: String -> ClassType
-toClassType "Haskell" = Haskell
-toClassType "Drasil"  = Drasil
-toClassType "GOOL"    = GOOL
-
--------------
 -- Data formatting functions and other helpers
 -------------
 
@@ -388,14 +353,6 @@ compileEntryData ordClassInsts entry filename = do
 
   -- mapM_ print (lines output)
   return output
-
--- gets folder from dictionary using folder name (iff it exists in dictionary)
-getFolder :: Map.Map DC.FolderName DC.Folder -> DC.FolderName -> DC.Folder
-getFolder dict name = fromMaybe (error $ "Could not find " ++ name) $ Map.lookup name dict
-
--- converts list to dictionary list format (for use by drasil- directories only)
-toDictList :: DC.Folder -> (DC.FolderName,DC.Folder)
-toDictList folder = (DC.folderDrasilPack folder,folder)
 
 -- gets raw Entries, extracts classes and orders them with config file settings
 ordClasses :: [ClassType] -> [Entry] -> [Class]

--- a/code/scripts/DTG_Config.txt
+++ b/code/scripts/DTG_Config.txt
@@ -1,5 +1,0 @@
-# all drasil- packs (lowercase, space separated, in order of display in output file)
-lang metadata code docLang printers build theory gool data database example gen utils website artifacts
-
-# all class types (capitalized, space separated, in order of display in output file)
-Haskell Drasil GOOL

--- a/code/scripts/TypeDepGen.hs
+++ b/code/scripts/TypeDepGen.hs
@@ -12,12 +12,10 @@
 module TypeDepGen (main) where
 
 import Data.List
-import Data.Maybe
 import System.IO
 import System.Directory
 import System.FilePath (takeDirectory)
 import Control.Monad
-import qualified Data.Map as Map
 import qualified DirectoryController as DC (createFolder, createFile, finder,
   getDirectories, DrasilPack, FileName, FolderName, File(..), Folder(..))
 import SourceCodeReaderT as SCRT (extractEntryData, EntryData(..),
@@ -52,19 +50,10 @@ main = do
   -- gets names + filepaths of all drasil- packages/directories
   drctyList <- DC.getDirectories codeDirectory "drasil-"
 
-  -- imports configuration settings (drasil- package names + class types order)
-  packageNames <- config scriptsDirectory
-
-  -- uses ordering (imported from config file) iff imported ordering is complete
-  let ordered
-        | ldL == lpN = map (getFolder drctyDict) packageNames
-        | otherwise = drctyList
-      (ldL,lpN) = (length drctyList,length packageNames)
-      -- creates dictionary (Map.Map format) from drasil- directories list
-      drctyDict = Map.fromList $ map toDictList drctyList
+  let packageNames = map DC.folderDrasilPack drctyList
 
   -- all files + filepaths stored here; obtained from ordered list using finder
-  allFiles <- mapM DC.finder ordered
+  allFiles <- mapM DC.finder drctyList
 
   -- creates Entry instances (w/ file data) from File instances (File -> Entry)
   rawEntryData <- zipWithM (createEntry codeDirectory) (concat allFiles) (map DC.fileName (concat allFiles))
@@ -189,17 +178,6 @@ makeEntry :: DC.DrasilPack -> DC.FileName -> FilePath -> [DataDeclRecord] ->
 makeEntry drpk fn fp dtR dtC ntd td = Entry {drasilPack=drpk,fileName=fn,
   filePath=fp,dataTypeRecords=dtR, dataTypeConstructors=dtC, newtypes=ntd, types=td}
 
--- import configurations function (drasil- packages)
-config :: FilePath -> IO [String]
-config configFilePath = do
-  setCurrentDirectory configFilePath
-  c <- readFile "DTG_Config.txt"
-  let l = map words $ filter isInfoLine (lines c)
-      -- FIXME: use real parser to extract settings from config file
-      -- will improve error messages regarding config file settings
-      packageNames = head l
-  return packageNames
-
 -- creates an entry for each file (new Entry data-oriented format)
 createEntry :: FilePath -> DC.File -> DC.FileName -> IO Entry
 -- creates actual file entries
@@ -220,15 +198,3 @@ createEntry homeDirectory file filename = do
 
   let entry = makeEntry drpk fn efp dataTypeDeclR dataTypeDeclC newtypeDecl typeDecl
   return entry
-
--- used to filter out info lines (i.e. removes comment and empty lines)
-isInfoLine :: String -> Bool
-isInfoLine line = (line /="") && not ("#" `isPrefixOf` line)
-
--- gets folder from dictionary using folder name (iff it exists in dictionary)
-getFolder :: Map.Map DC.FolderName DC.Folder -> DC.FolderName -> DC.Folder
-getFolder dict name = fromJust $ Map.lookup name dict
-
--- converts list to dictionary list format (for use by drasil- directories only)
-toDictList :: DC.Folder -> (DC.FolderName,DC.Folder)
-toDictList folder = (DC.folderDrasilPack folder,folder)

--- a/code/stable-website/index.html
+++ b/code/stable-website/index.html
@@ -572,46 +572,6 @@
                 </tr>
                 <tr>
                   <td>
-                    <a href="analysis/TypeDependencyGraphs/lang.svg">drasil-lang Types</a>
-                  </td>
-                  <td>
-                    <a href="analysis/ClassInstDep/packagegraphs/lang.svg">drasil-lang Class Instances</a>
-                  </td>
-                </tr>
-                <tr>
-                  <td>
-                    <a href="analysis/TypeDependencyGraphs/metadata.svg">drasil-metadata Types</a>
-                  </td>
-                  <td>
-                    <a href="analysis/ClassInstDep/packagegraphs/metadata.svg">drasil-metadata Class Instances</a>
-                  </td>
-                </tr>
-                <tr>
-                  <td>
-                    <a href="analysis/TypeDependencyGraphs/code.svg">drasil-code Types</a>
-                  </td>
-                  <td>
-                    <a href="analysis/ClassInstDep/packagegraphs/code.svg">drasil-code Class Instances</a>
-                  </td>
-                </tr>
-                <tr>
-                  <td>
-                    <a href="analysis/TypeDependencyGraphs/docLang.svg">drasil-docLang Types</a>
-                  </td>
-                  <td>
-                    <a href="analysis/ClassInstDep/packagegraphs/docLang.svg">drasil-docLang Class Instances</a>
-                  </td>
-                </tr>
-                <tr>
-                  <td>
-                    <a href="analysis/TypeDependencyGraphs/printers.svg">drasil-printers Types</a>
-                  </td>
-                  <td>
-                    <a href="analysis/ClassInstDep/packagegraphs/printers.svg">drasil-printers Class Instances</a>
-                  </td>
-                </tr>
-                <tr>
-                  <td>
                     <a href="analysis/TypeDependencyGraphs/build.svg">drasil-build Types</a>
                   </td>
                   <td>
@@ -620,18 +580,18 @@
                 </tr>
                 <tr>
                   <td>
-                    <a href="analysis/TypeDependencyGraphs/theory.svg">drasil-theory Types</a>
+                    <a href="analysis/TypeDependencyGraphs/build-artifacts.svg">drasil-build-artifacts Types</a>
                   </td>
                   <td>
-                    <a href="analysis/ClassInstDep/packagegraphs/theory.svg">drasil-theory Class Instances</a>
+                    <a href="analysis/ClassInstDep/packagegraphs/build-artifacts.svg">drasil-build-artifacts Class Instances</a>
                   </td>
                 </tr>
                 <tr>
                   <td>
-                    <a href="analysis/TypeDependencyGraphs/gool.svg">drasil-gool Types</a>
+                    <a href="analysis/TypeDependencyGraphs/code.svg">drasil-code Types</a>
                   </td>
                   <td>
-                    <a href="analysis/ClassInstDep/packagegraphs/gool.svg">drasil-gool Class Instances</a>
+                    <a href="analysis/ClassInstDep/packagegraphs/code.svg">drasil-code Class Instances</a>
                   </td>
                 </tr>
                 <tr>
@@ -652,10 +612,66 @@
                 </tr>
                 <tr>
                   <td>
+                    <a href="analysis/TypeDependencyGraphs/docLang.svg">drasil-docLang Types</a>
+                  </td>
+                  <td>
+                    <a href="analysis/ClassInstDep/packagegraphs/docLang.svg">drasil-docLang Class Instances</a>
+                  </td>
+                </tr>
+                <tr>
+                  <td>
                     <a href="analysis/TypeDependencyGraphs/gen.svg">drasil-gen Types</a>
                   </td>
                   <td>
                     <a href="analysis/ClassInstDep/packagegraphs/gen.svg">drasil-gen Class Instances</a>
+                  </td>
+                </tr>
+                <tr>
+                  <td>
+                    <a href="analysis/TypeDependencyGraphs/gool.svg">drasil-gool Types</a>
+                  </td>
+                  <td>
+                    <a href="analysis/ClassInstDep/packagegraphs/gool.svg">drasil-gool Class Instances</a>
+                  </td>
+                </tr>
+                <tr>
+                  <td>
+                    <a href="analysis/TypeDependencyGraphs/lang.svg">drasil-lang Types</a>
+                  </td>
+                  <td>
+                    <a href="analysis/ClassInstDep/packagegraphs/lang.svg">drasil-lang Class Instances</a>
+                  </td>
+                </tr>
+                <tr>
+                  <td>
+                    <a href="analysis/TypeDependencyGraphs/metadata.svg">drasil-metadata Types</a>
+                  </td>
+                  <td>
+                    <a href="analysis/ClassInstDep/packagegraphs/metadata.svg">drasil-metadata Class Instances</a>
+                  </td>
+                </tr>
+                <tr>
+                  <td>
+                    <a href="analysis/TypeDependencyGraphs/printers.svg">drasil-printers Types</a>
+                  </td>
+                  <td>
+                    <a href="analysis/ClassInstDep/packagegraphs/printers.svg">drasil-printers Class Instances</a>
+                  </td>
+                </tr>
+                <tr>
+                  <td>
+                    <a href="analysis/TypeDependencyGraphs/system.svg">drasil-system Types</a>
+                  </td>
+                  <td>
+                    <a href="analysis/ClassInstDep/packagegraphs/system.svg">drasil-system Class Instances</a>
+                  </td>
+                </tr>
+                <tr>
+                  <td>
+                    <a href="analysis/TypeDependencyGraphs/theory.svg">drasil-theory Types</a>
+                  </td>
+                  <td>
+                    <a href="analysis/ClassInstDep/packagegraphs/theory.svg">drasil-theory Class Instances</a>
                   </td>
                 </tr>
                 <tr>
@@ -700,17 +716,21 @@
               </figure>
             </div>
             <ul class="list">
-              <li><a href="graphs/drasil-lang.pdf">drasil-lang</a></li>
-              <li><a href="graphs/drasil-metadata.pdf">drasil-metadata</a></li>
-              <li><a href="graphs/drasil-code.pdf">drasil-code</a></li>
-              <li><a href="graphs/drasil-docLang.pdf">drasil-docLang</a></li>
-              <li><a href="graphs/drasil-printers.pdf">drasil-printers</a></li>
               <li><a href="graphs/drasil-build.pdf">drasil-build</a></li>
-              <li><a href="graphs/drasil-theory.pdf">drasil-theory</a></li>
-              <li><a href="graphs/drasil-gool.pdf">drasil-gool</a></li>
+              <li>
+                <a href="graphs/drasil-build-artifacts.pdf">drasil-build-artifacts</a>
+              </li>
+              <li><a href="graphs/drasil-code.pdf">drasil-code</a></li>
               <li><a href="graphs/drasil-data.pdf">drasil-data</a></li>
               <li><a href="graphs/drasil-database.pdf">drasil-database</a></li>
+              <li><a href="graphs/drasil-docLang.pdf">drasil-docLang</a></li>
               <li><a href="graphs/drasil-gen.pdf">drasil-gen</a></li>
+              <li><a href="graphs/drasil-gool.pdf">drasil-gool</a></li>
+              <li><a href="graphs/drasil-lang.pdf">drasil-lang</a></li>
+              <li><a href="graphs/drasil-metadata.pdf">drasil-metadata</a></li>
+              <li><a href="graphs/drasil-printers.pdf">drasil-printers</a></li>
+              <li><a href="graphs/drasil-system.pdf">drasil-system</a></li>
+              <li><a href="graphs/drasil-theory.pdf">drasil-theory</a></li>
               <li><a href="graphs/drasil-utils.pdf">drasil-utils</a></li>
               <li><a href="graphs/drasil-website.pdf">drasil-website</a></li>
               <li><a href="graphs/drasil-example.pdf">drasil-example</a></li>


### PR DESCRIPTION
Issues:

1. The website does [not show all packages](file:///Users/jasonbalaci/Programming/Drasil/Drasil/code/deploy/index.html#Sec:TypeAndClassGraphs) in the `Sec:TypeAndClassGraphs` section.
2. The website would lead to 404s if we were to try because the graphs are not built.

It looks like there is a bit of a synchronization issue caused by out-of-sync package lists in `DTG_Config.txt` and the `Makefile` versus our actual list of packages. This PR removes reliance on `DTG_Config.txt` (one source of synchrony issues) and updates the list of packages in the Makefile.

With this PR, the website is updated for the newly-generated graphs and shows all of our packages.

However, through this PR, I found that the generated `.dot` files have the same issue that #4879 solved.