### PR TITLE
refactor(-gen): remove unused, ill-supported `Plain` SRS output format

### DIFF
--- a/code/drasil-gen/lib/Drasil/Generator/Formats.hs
+++ b/code/drasil-gen/lib/Drasil/Generator/Formats.hs
@@ -18,11 +18,10 @@ import Drasil.Metadata (watermark)
 type Filename = String
 
 -- | Possible formats for printer output.
-data Format = TeX | Plain | HTML | Jupyter | MDBook
+data Format = TeX | HTML | Jupyter | MDBook
 
 instance Show Format where
   show TeX     = "PDF"
-  show Plain   = "Plain"
   show HTML    = "HTML"
   show Jupyter = "Jupyter"
   show MDBook  = "mdBook"

--- a/code/drasil-gen/lib/Drasil/Generator/SRS.hs
+++ b/code/drasil-gen/lib/Drasil/Generator/SRS.hs
@@ -56,7 +56,6 @@ prntDoc d pinfo fn fmt =
                   prntMake $ DocSpec (DC [MDBook]) fn
                   prntBook d pinfo
                   prntCSV  pinfo
-    Plain   -> putStrLn "Plain-rendering is not supported."
 
 -- | Common error for when an unsupported SRS format is attempted.
 srsFormatError :: a

--- a/code/drasil-website/lib/Drasil/Website/Example.hs
+++ b/code/drasil-website/lib/Drasil/Website/Example.hs
@@ -245,7 +245,6 @@ getSRSPath path format ex = path ++ map toLower ex ++ "/SRS/" ++ show format ++ 
     sufx HTML    = ex ++ "_SRS.html"
     sufx TeX     = ex ++ "_SRS.pdf"
     sufx Jupyter = ex ++ "_SRS.html"
-    sufx Plain   = error "Plain SRS display is not supported."
 
 -- | Get the file paths for generated code and doxygen locations.
 getCodePath, getDoxPath :: FilePath -> String -> String -> FilePath


### PR DESCRIPTION
The "Plain" SRS type is unused and a bit pointless. If/when we want more formats, there are better output types to produce.