### PR TITLE
docs(wiki-sidebar): remove dead link to 'Miscellaneous ideas'

### DIFF
--- a/wiki/_Sidebar.md
+++ b/wiki/_Sidebar.md
@@ -26,7 +26,6 @@
 * [Readings](Readings)
 * Misc.
   * [Journals and Societies](Journals-and-Societies)
-  * [Miscellaneous Ideas](Miscellaneous-ideas)
   * [Open Science](Open-Science)
   * [Forking Drasil & Deploying to your GitHub Pages](Forking-Drasil-&-Deploying-to-your-GitHub-Pages)
   * [Getting Started with Org Mode](Getting-Started-with-Org-Mode)


### PR DESCRIPTION
That link leads to: https://github.com/JacquesCarette/Drasil/wiki/Miscellaneous-ideas

Which is dead. GitHub prompts us to _create_ the page.