### PR TITLE
Update 'template' example to include inputs and outputs

### DIFF
--- a/code/drasil-example/template/lib/Drasil/Template/Body.hs
+++ b/code/drasil-example/template/lib/Drasil/Template/Body.hs
@@ -7,6 +7,8 @@ module Drasil.Template.Body (mkSRS, si) where
 
 import Drasil.System (mkSmithEtAlICO)
 import Language.Drasil
+import Language.Drasil.Display
+import Language.Drasil.ShortHands (lT)
 import Drasil.SRSDocument
 import Drasil.DocLang (tunitNone)
 import Drasil.Generator (withCommonKnowledge)
@@ -16,6 +18,7 @@ import qualified Drasil.DocLang.SRS as SRS
 import Data.Drasil.Citations
 import Data.Drasil.Concepts.Theory (inModel)
 import Drasil.DocumentLanguage.TraceabilityGraph
+import Data.Drasil.SI_Units (second)
 
 mkSRS :: SRSDecl
 mkSRS = [TableOfContents,
@@ -69,12 +72,22 @@ mkSRS = [TableOfContents,
      AuxConsProg progName [],
   Bibliography]
 
+t0 :: DefinedQuantityDict
+t0 = dqd (dcc "t0" (cn' "start time") "the start time") (sub lT (Integ 0)) Real second
+
+t1 :: DefinedQuantityDict
+t1 = dqd (dcc "t1" (cn' "end time") "the end time") (sub lT (Integ 1)) Real second
+
+dt :: DefinedQuantityDict
+dt = dqd (dcc "td" (cn' "time delta") "the time delta") (Atop Delta lT) Real second
+
 si :: SmithEtAlSRS
 si = mkSmithEtAlICO
   progName [authorName]
   [] [] [] []
   ([] :: [TheoryModel]) ([] :: [GenDefn]) ([] :: [DataDefinition]) ([] :: [InstanceModel])
-  ([] :: [DefinedQuantityDict]) ([] :: [DefinedQuantityDict]) ([] :: [ConstrConcept]) ([] :: [ConstQDef]) []
+  ([t0, dt] :: [DefinedQuantityDict]) ([t1] :: [DefinedQuantityDict])
+  ([] :: [ConstrConcept]) ([] :: [ConstQDef]) []
   [] symbMap []
 
 ideaDicts :: [IdeaDict]


### PR DESCRIPTION
Contributes to #3652

#4953 Switches inputs and outputs to be `NonEmpty` lists, so we need some inputs and outputs in the template. Ideally these inputs and outputs form a small, but logical, example. Jason suggested a program that computes $t_1 = t_0 + \Delta t$.

In general, I think the template overall needs a lot of work to be considered a useful template. It does not follow the same structure as the other examples (it only provides `Main.hs` and `Body.hs`).