### PR TITLE
Remove `Type` Type Family

### DIFF
--- a/code/drasil-gool/lib/Drasil/GOOL/CodeInfoOO.hs
+++ b/code/drasil-gool/lib/Drasil/GOOL/CodeInfoOO.hs
@@ -8,10 +8,10 @@ import Drasil.Shared.InterfaceCommon (MSBody, VSType, SValue, MSStatement,
   VariableSym(..), VariableElim(..), ValueSym(..), Argument(..), Literal(..),
   MathConstant(..), VariableValue(..), CommandLineArgs(..),
   NumericExpression(..), BooleanExpression(..), Comparison(..),
-  ValueExpression(..), List(..), Set(..), InternalList(..), ThunkSym(..), VectorType(..),
-  VectorDecl(..), VectorThunk(..), VectorExpression(..), ThunkAssign(..),
-  StatementSym(..), AssignStatement(..), DeclStatement(..), IOStatement(..),
-  StringStatement(..), FunctionSym(..), FuncAppStatement(..),
+  ValueExpression(..), List(..), Set(..), InternalList(..), ThunkSym(..),
+  VectorType(..), VectorDecl(..), VectorThunk(..), VectorExpression(..),
+  ThunkAssign(..), StatementSym(..), AssignStatement(..), DeclStatement(..),
+  IOStatement(..), StringStatement(..), FunctionSym(..), FuncAppStatement(..),
   CommentStatement(..), ControlStatement(..), ScopeSym(..), ParameterSym(..),
   MethodSym(..), VisibilitySym(..), BinderSym(..))
 import Drasil.GOOL.InterfaceGOOL (OOProg, ProgramSym(..), FileSym(..),
@@ -21,7 +21,7 @@ import Drasil.GOOL.InterfaceGOOL (OOProg, ProgramSym(..), FileSym(..),
   OOFunctionSym(..), GetSet(..), OODeclStatement(..), OOFuncAppStatement(..),
   ObserverPattern(..), StrategyPattern(..))
 import Drasil.Shared.CodeType (CodeType(Void))
-import Drasil.Shared.AST (VisibilityTag(..), qualName)
+import Drasil.Shared.AST (VisibilityTag(..), qualName, TypeData(..), td)
 import Drasil.Shared.CodeAnalysis (ExceptionType(..))
 import Drasil.Shared.Helpers (toCode, toState)
 import Drasil.Shared.State (GOOLState, VS, lensGStoFS, lensFStoCS, lensFStoMS,
@@ -34,6 +34,7 @@ import Control.Monad.State (State, modify)
 import qualified Control.Monad.State as S (get)
 import Control.Lens.Zoom (zoom)
 import Data.Maybe (fromMaybe)
+import Text.PrettyPrint.HughesPJ (empty)
 
 newtype CodeInfoOO a = CI {unCI :: a} deriving Eq
 
@@ -84,27 +85,27 @@ instance BlockSym CodeInfoOO where
 
 instance TypeSym CodeInfoOO where
   type Type CodeInfoOO = String
-  bool              = noInfoType
-  int               = noInfoType
-  float             = noInfoType
-  double            = noInfoType
-  char              = noInfoType
-  string            = noInfoType
-  infile            = noInfoType
-  outfile           = noInfoType
-  setType       _   = noInfoType
-  listType      _   = noInfoType
-  arrayType     _   = noInfoType
-  listInnerType _   = noInfoType
-  funcType      _ _ = noInfoType
-  void              = noInfoType
+  bool              = noInfoVSType
+  int               = noInfoVSType
+  float             = noInfoVSType
+  double            = noInfoVSType
+  char              = noInfoVSType
+  string            = noInfoVSType
+  infile            = noInfoVSType
+  outfile           = noInfoVSType
+  setType       _   = noInfoVSType
+  listType      _   = noInfoVSType
+  arrayType     _   = noInfoVSType
+  listInnerType _   = noInfoVSType
+  funcType      _ _ = noInfoVSType
+  void              = noInfoVSType
 
 instance OOTypeSym CodeInfoOO where
-  obj               = toState . toCode
+  obj             _ = noInfoVSType
 
 instance TypeElim CodeInfoOO where
   getType _     = Void
-  getTypeString = unCI
+  getTypeString = typeString . unCI
 
 instance ScopeSym CodeInfoOO where
   type Scope CodeInfoOO = ()
@@ -129,11 +130,11 @@ instance OOVariableSym CodeInfoOO where
 
 instance VariableElim CodeInfoOO where
   variableName _ = ""
-  variableType _ = toCode ""
+  variableType _ = noInfoType
 
 instance ValueSym CodeInfoOO where
   type Value CodeInfoOO = ()
-  valueType _ = toCode ""
+  valueType _ = noInfoType
 
 instance OOValueSym CodeInfoOO
 
@@ -276,7 +277,7 @@ instance ThunkAssign CodeInfoOO where
   thunkAssign _ = zoom lensMStoVS . execute1
 
 instance VectorType CodeInfoOO where
-  vecType _ = noInfoType
+  vecType _ = noInfoVSType
 
 instance VectorDecl CodeInfoOO where
   vecDec  _ _ _ = noInfo
@@ -483,8 +484,11 @@ instance ModuleSym CodeInfoOO where
 noInfo :: State s (CodeInfoOO ())
 noInfo = toState $ toCode ()
 
-noInfoType :: State s (CodeInfoOO String)
-noInfoType = toState $ toCode ""
+noInfoType :: CodeInfoOO TypeData
+noInfoType = return $ td Void "" empty
+
+noInfoVSType :: VSType CodeInfoOO
+noInfoVSType = return noInfoType
 
 updateMEMandCM :: String -> MSBody CodeInfoOO -> SMethod CodeInfoOO
 updateMEMandCM n b = do

--- a/code/drasil-gool/lib/Drasil/GOOL/CodeInfoOO.hs
+++ b/code/drasil-gool/lib/Drasil/GOOL/CodeInfoOO.hs
@@ -84,7 +84,6 @@ instance BlockSym CodeInfoOO where
   block = executeList
 
 instance TypeSym CodeInfoOO where
-  type Type CodeInfoOO = String
   bool              = noInfoVSType
   int               = noInfoVSType
   float             = noInfoVSType

--- a/code/drasil-gool/lib/Drasil/GOOL/LanguageRenderer/CSharpRenderer.hs
+++ b/code/drasil-gool/lib/Drasil/GOOL/LanguageRenderer/CSharpRenderer.hs
@@ -199,7 +199,6 @@ instance BlockElim CSharpCode where
   block = unCSC
 
 instance TypeSym CSharpCode where
-  type Type CSharpCode = TypeData
   bool = addSystemImport csBoolType
   int = CP.int
   float = C.float

--- a/code/drasil-gool/lib/Drasil/GOOL/LanguageRenderer/CppRenderer.hs
+++ b/code/drasil-gool/lib/Drasil/GOOL/LanguageRenderer/CppRenderer.hs
@@ -2854,7 +2854,7 @@ cppsIntFunc f s t ps b = do
   pms <- sequence ps
   toCode . mthd (snd $ unCPPSC s) . f tp pms <$> b
 
-cpphMethod :: (CommonRenderSym r) => Label -> r (Type r) -> [r (Parameter r)] -> Doc
+cpphMethod :: (CommonRenderSym r) => Label -> r TypeData -> [r (Parameter r)] -> Doc
 cpphMethod n t ps = (if isDtor n then empty else RC.type' t) <+> text n
   <> parens (parameterList ps) <> endStatement
 

--- a/code/drasil-gool/lib/Drasil/GOOL/LanguageRenderer/CppRenderer.hs
+++ b/code/drasil-gool/lib/Drasil/GOOL/LanguageRenderer/CppRenderer.hs
@@ -211,7 +211,6 @@ instance (Pair p) => BlockElim (p CppSrcCode CppHdrCode) where
   block b = RC.block $ pfst b
 
 instance (Pair p) => TypeSym (p CppSrcCode CppHdrCode) where
-  type Type (p CppSrcCode CppHdrCode) = TypeData
   bool = on2StateValues pair bool bool
   int = on2StateValues pair int int
   float = on2StateValues pair float float
@@ -1123,7 +1122,6 @@ instance BlockElim CppSrcCode where
   block = unCPPSC
 
 instance TypeSym CppSrcCode where
-  type Type CppSrcCode = TypeData
   bool = cppBoolType
   int = CP.int
   float = C.float
@@ -1861,7 +1859,6 @@ instance BlockElim CppHdrCode where
   block = unCPPHC
 
 instance TypeSym CppHdrCode where
-  type Type CppHdrCode = TypeData
   bool = cppBoolType
   int = CP.int
   float = C.float
@@ -2837,14 +2834,14 @@ cppConstructor ps is b = getClassName >>= (\n -> join $ (\tp pms ivars ivals
   n <*> sequence ps <*> mapM (zoom lensMStoVS . fst) is <*> mapM (zoom
   lensMStoVS . snd) is <*> b)
 
-cppsFunction :: Label -> CppSrcCode (Type CppSrcCode) ->
+cppsFunction :: Label -> CppSrcCode TypeData ->
   [CppSrcCode (Parameter CppSrcCode)] -> CppSrcCode (Body CppSrcCode) -> Doc
 cppsFunction n t ps b = vcat [
   RC.type' t <+> text n <> parens (parameterList ps) <+> bodyStart,
   indent (RC.body b),
   bodyEnd]
 
-cppsIntFunc :: (CppSrcCode (Type CppSrcCode) ->
+cppsIntFunc :: (CppSrcCode TypeData ->
   [CppSrcCode (Parameter CppSrcCode)] -> CppSrcCode (Body CppSrcCode) -> Doc)
   -> CppSrcCode (Visibility CppSrcCode) -> MSMthdType CppSrcCode ->
   [MSParameter CppSrcCode] -> MSBody CppSrcCode -> SMethod CppSrcCode

--- a/code/drasil-gool/lib/Drasil/GOOL/LanguageRenderer/JavaRenderer.hs
+++ b/code/drasil-gool/lib/Drasil/GOOL/LanguageRenderer/JavaRenderer.hs
@@ -199,7 +199,6 @@ instance BlockElim JavaCode where
   block = unJC
 
 instance TypeSym JavaCode where
-  type Type JavaCode = TypeData
   bool = jBoolType
   int = CP.int
   float = C.float

--- a/code/drasil-gool/lib/Drasil/GOOL/LanguageRenderer/JavaRenderer.hs
+++ b/code/drasil-gool/lib/Drasil/GOOL/LanguageRenderer/JavaRenderer.hs
@@ -1045,7 +1045,7 @@ jStringSplit = on2StateValues (\vnew s -> RC.variable vnew <+> equals <+>
   new' <+> RC.type' (variableType vnew) <> parens (RC.value s))
 
 jMethod :: (OORenderSym r) => Label -> [String] -> r (Visibility r) -> r (Permanence r)
-  -> r (Type r) -> [r (Parameter r)] -> r (Body r) -> Doc
+  -> r TypeData -> [r (Parameter r)] -> r (Body r) -> Doc
 jMethod n es s p t ps b = vcat [
   RC.visibility s <+> RC.perm p <+> RC.type' t <+> text n <>
     parens (parameterList ps) <+> emptyIfNull es (throwsLabel <+>

--- a/code/drasil-gool/lib/Drasil/GOOL/LanguageRenderer/PythonRenderer.hs
+++ b/code/drasil-gool/lib/Drasil/GOOL/LanguageRenderer/PythonRenderer.hs
@@ -188,7 +188,6 @@ instance BlockElim PythonCode where
   block = unPC
 
 instance TypeSym PythonCode where
-  type Type PythonCode = TypeData
   bool = typeFromData Boolean "" empty
   int = CP.int
   float = error pyFloatError

--- a/code/drasil-gool/lib/Drasil/GOOL/LanguageRenderer/SwiftRenderer.hs
+++ b/code/drasil-gool/lib/Drasil/GOOL/LanguageRenderer/SwiftRenderer.hs
@@ -200,7 +200,6 @@ instance BlockElim SwiftCode where
   block = unSC
 
 instance TypeSym SwiftCode where
-  type Type SwiftCode = TypeData
   bool = CS.bool
   int = swiftIntType
   float = CP.float

--- a/code/drasil-gool/lib/Drasil/GProc/CodeInfoProc.hs
+++ b/code/drasil-gool/lib/Drasil/GProc/CodeInfoProc.hs
@@ -75,7 +75,6 @@ instance BlockSym CodeInfoProc where
   block = executeList
 
 instance TypeSym CodeInfoProc where
-  type Type CodeInfoProc = String
   bool              = noInfoVSType
   int               = noInfoVSType
   float             = noInfoVSType

--- a/code/drasil-gool/lib/Drasil/GProc/CodeInfoProc.hs
+++ b/code/drasil-gool/lib/Drasil/GProc/CodeInfoProc.hs
@@ -3,8 +3,8 @@
 -- Performs code analysis on the GOOL code
 module Drasil.GProc.CodeInfoProc (CodeInfoProc(..)) where
 
-import Drasil.Shared.InterfaceCommon (MSBody, SValue, MSStatement, SMethod,
-  SharedProg, BodySym(..), BlockSym(..), TypeSym(..), TypeElim(..),
+import Drasil.Shared.InterfaceCommon (MSBody, SValue, VSType, MSStatement,
+  SMethod, SharedProg, BodySym(..), BlockSym(..), TypeSym(..), TypeElim(..),
   ScopeSym(..), VariableSym(..), VariableElim(..), ValueSym(..), Argument(..),
   Literal(..), MathConstant(..), VariableValue(..), CommandLineArgs(..),
   NumericExpression(..), BooleanExpression(..), Comparison(..),
@@ -17,7 +17,7 @@ import Drasil.Shared.InterfaceCommon (MSBody, SValue, MSStatement, SMethod,
 import Drasil.GProc.InterfaceProc (ProcProg, ProgramSym(..), FileSym(..),
   ModuleSym(..))
 import Drasil.Shared.CodeType (CodeType(Void))
-import Drasil.Shared.AST (VisibilityTag(..), qualName)
+import Drasil.Shared.AST (VisibilityTag(..), qualName, TypeData(..), td)
 import Drasil.Shared.CodeAnalysis (ExceptionType(..))
 import Drasil.Shared.Helpers (toCode, toState)
 import Drasil.Shared.State (GOOLState, VS, lensGStoFS, lensFStoMS, lensMStoVS,
@@ -29,6 +29,7 @@ import Control.Monad.State (State, modify)
 import qualified Control.Monad.State as S (get)
 import Control.Lens.Zoom (zoom)
 import Data.Maybe (fromMaybe)
+import Text.PrettyPrint.HughesPJ (empty)
 
 newtype CodeInfoProc a = CI {unCI :: a} deriving Eq
 
@@ -75,24 +76,24 @@ instance BlockSym CodeInfoProc where
 
 instance TypeSym CodeInfoProc where
   type Type CodeInfoProc = String
-  bool              = noInfoType
-  int               = noInfoType
-  float             = noInfoType
-  double            = noInfoType
-  char              = noInfoType
-  string            = noInfoType
-  infile            = noInfoType
-  outfile           = noInfoType
-  listType      _   = noInfoType
-  setType      _   = noInfoType
-  arrayType     _   = noInfoType
-  listInnerType _   = noInfoType
-  funcType      _ _ = noInfoType
-  void              = noInfoType
+  bool              = noInfoVSType
+  int               = noInfoVSType
+  float             = noInfoVSType
+  double            = noInfoVSType
+  char              = noInfoVSType
+  string            = noInfoVSType
+  infile            = noInfoVSType
+  outfile           = noInfoVSType
+  listType      _   = noInfoVSType
+  setType      _   = noInfoVSType
+  arrayType     _   = noInfoVSType
+  listInnerType _   = noInfoVSType
+  funcType      _ _ = noInfoVSType
+  void              = noInfoVSType
 
 instance TypeElim CodeInfoProc where
   getType _     = Void
-  getTypeString = unCI
+  getTypeString = typeString . unCI
 
 instance ScopeSym CodeInfoProc where
   type Scope CodeInfoProc = ()
@@ -109,11 +110,11 @@ instance VariableSym CodeInfoProc where
 
 instance VariableElim CodeInfoProc where
   variableName _ = ""
-  variableType _ = toCode ""
+  variableType _ = noInfoType
 
 instance ValueSym CodeInfoProc where
   type Value CodeInfoProc = ()
-  valueType _ = toCode ""
+  valueType _ = noInfoType
 
 instance Argument CodeInfoProc where
   pointerArg = id
@@ -229,7 +230,7 @@ instance ThunkAssign CodeInfoProc where
   thunkAssign _ = zoom lensMStoVS . execute1
 
 instance VectorType CodeInfoProc where
-  vecType _ = noInfoType
+  vecType _ = noInfoVSType
 
 instance VectorDecl CodeInfoProc where
   vecDec  _ _ _ = noInfo
@@ -376,8 +377,11 @@ instance ModuleSym CodeInfoProc where
 noInfo :: State s (CodeInfoProc ())
 noInfo = toState $ toCode ()
 
-noInfoType :: State s (CodeInfoProc String)
-noInfoType = toState $ toCode ""
+noInfoType :: CodeInfoProc TypeData
+noInfoType = return $ td Void "" empty
+
+noInfoVSType :: VSType CodeInfoProc
+noInfoVSType = return noInfoType
 
 updateMEMandCM :: String -> MSBody CodeInfoProc -> SMethod CodeInfoProc
 updateMEMandCM n b = do

--- a/code/drasil-gool/lib/Drasil/GProc/LanguageRenderer/JuliaRenderer.hs
+++ b/code/drasil-gool/lib/Drasil/GProc/LanguageRenderer/JuliaRenderer.hs
@@ -285,7 +285,7 @@ instance RenderVariable JuliaCode where
 
 instance ValueSym JuliaCode where
   type Value JuliaCode = ValData
-  valueType = onCodeValue valType
+  valueType v = valType <$> v
 
 instance Argument JuliaCode where
   pointerArg = id

--- a/code/drasil-gool/lib/Drasil/GProc/LanguageRenderer/JuliaRenderer.hs
+++ b/code/drasil-gool/lib/Drasil/GProc/LanguageRenderer/JuliaRenderer.hs
@@ -177,7 +177,6 @@ instance BlockElim JuliaCode where
   block = unJLC
 
 instance TypeSym JuliaCode where
-  type Type JuliaCode = TypeData
   bool = CS.bool
   int = jlIntType
   float = jlFloatType

--- a/code/drasil-gool/lib/Drasil/Shared/InterfaceCommon.hs
+++ b/code/drasil-gool/lib/Drasil/Shared/InterfaceCommon.hs
@@ -73,7 +73,6 @@ class (StatementSym r) => BlockSym r where
 type VSType a = VS (a TypeData)
 
 class TypeSym r where
-  type Type r
   bool          :: VSType r
   int           :: VSType r -- This is 32-bit signed ints except in Python,
                             -- which has unlimited precision ints; and Julia,

--- a/code/drasil-gool/lib/Drasil/Shared/InterfaceCommon.hs
+++ b/code/drasil-gool/lib/Drasil/Shared/InterfaceCommon.hs
@@ -27,7 +27,7 @@ module Drasil.Shared.InterfaceCommon (
 import Data.Bifunctor (first)
 import qualified Data.Kind as K (Type)
 
-import Drasil.Shared.AST (ScopeData(..), ScopeTag(..))
+import Drasil.Shared.AST (ScopeData(..), ScopeTag(..), TypeData)
 import Drasil.Shared.CodeType (CodeType(..))
 import Drasil.Shared.State (MS, VS)
 
@@ -70,7 +70,7 @@ class (StatementSym r) => BlockSym r where
   type Block r
   block   :: [MSStatement r] -> MSBlock r
 
-type VSType a = VS (a (Type a))
+type VSType a = VS (a TypeData)
 
 class TypeSym r where
   type Type r
@@ -92,8 +92,8 @@ class TypeSym r where
   void          :: VSType r
 
 class (TypeSym r) => TypeElim r where
-  getType :: r (Type r) -> CodeType
-  getTypeString :: r (Type r) -> String
+  getType :: r TypeData -> CodeType
+  getTypeString :: r TypeData -> String
 
 class ScopeSym r where
   type Scope r
@@ -114,7 +114,7 @@ class (TypeSym r) => VariableSym r where
 
 class (VariableSym r) => VariableElim r where
   variableName :: r (Variable r) -> String
-  variableType :: r (Variable r) -> r (Type r)
+  variableType :: r (Variable r) -> r TypeData
 
 listVar :: (VariableSym r) => Label -> VSType r -> SVariable r
 listVar n t = var n (listType t)
@@ -126,7 +126,7 @@ type SValue a = VS (a (Value a))
 
 class (TypeSym r) => ValueSym r where
   type Value r
-  valueType :: r (Value r) -> r (Type r)
+  valueType :: r (Value r) -> r TypeData
 
 class (ValueSym r) => Argument r where
   pointerArg :: SValue r -> SValue r
@@ -238,7 +238,7 @@ class (TypeSym r) => BinderSym r where
 
 class (BinderSym r) => BinderElim r where
   binderName :: r (Binder r) -> String
-  binderType :: r (Binder r) -> r (Type r)
+  binderType :: r (Binder r) -> r TypeData
 
 -- for values that can include expressions
 class (VariableSym r, ValueSym r) => ValueExpression r where

--- a/code/drasil-gool/lib/Drasil/Shared/LanguageRenderer.hs
+++ b/code/drasil-gool/lib/Drasil/Shared/LanguageRenderer.hs
@@ -30,9 +30,9 @@ import Utils.Drasil (capitalize, stringList)
 
 import Drasil.Shared.CodeType (CodeType(..))
 import Drasil.Shared.InterfaceCommon (Label, Library, SValue, BodySym(Body),
-  TypeSym(Type), TypeElim(..), VariableSym(Variable), VariableElim(..),
-  ValueSym(..), StatementSym(Statement), VisibilitySym(Visibility),
-  ParameterSym(Parameter), BinderSym(..))
+  TypeElim(..), VariableSym(Variable), VariableElim(..), ValueSym(..),
+  StatementSym(Statement), VisibilitySym(Visibility), ParameterSym(Parameter),
+  BinderSym(..))
 import Drasil.GOOL.InterfaceGOOL (PermanenceSym(Permanence))
 import Drasil.Shared.RendererClassesCommon (CommonRenderSym)
 import qualified Drasil.Shared.RendererClassesCommon as RC (BodyElim(..),
@@ -213,7 +213,7 @@ param v = RC.type' (variableType v) <+> RC.variable v
 -- Method --
 
 method :: (OORenderSym r) => Label -> r (Visibility r) -> r (Permanence r) ->
-  r (Type r) -> [r (Parameter r)] -> r (Body r) -> Doc
+  r TypeData -> [r (Parameter r)] -> r (Body r) -> Doc
 method n s p t ps b = vcat [
   RC.visibility s <+> RC.perm p <+> RC.type' t <+> text n <>
     parens (parameterList ps) <+> lbrace,

--- a/code/drasil-gool/lib/Drasil/Shared/LanguageRenderer/Constructors.hs
+++ b/code/drasil-gool/lib/Drasil/Shared/LanguageRenderer/Constructors.hs
@@ -13,7 +13,7 @@ import Drasil.Shared.RendererClassesCommon (CommonRenderSym, VSUnOp, VSBinOp,
   RenderValue(..), ValueElim(valuePrec), RenderStatement(..))
 import qualified Drasil.Shared.RendererClassesCommon as RC (uOp, bOp, value)
 import Drasil.Shared.LanguageRenderer (unOpDocD, unOpDocD', binOpDocD, binOpDocD')
-import Drasil.Shared.AST (Terminator(..), Binding(..), OpData, od)
+import Drasil.Shared.AST (Terminator(..), Binding(..), OpData, od, TypeData)
 import Drasil.Shared.CodeType (CodeType(..))
 import Drasil.Shared.Helpers (toCode, toState, on2StateValues)
 import Drasil.Shared.State (VS)
@@ -39,7 +39,7 @@ mkStateVal :: (CommonRenderSym r) => VSType r -> Doc -> SValue r
 mkStateVal = valFromData Nothing Nothing
 
 -- | Constructs a value in a non-stateful context
-mkVal :: (CommonRenderSym r) => r (Type r) -> Doc -> SValue r
+mkVal :: (CommonRenderSym r) => r TypeData -> Doc -> SValue r
 mkVal t = valFromData Nothing Nothing (toState t)
 
 -- Variables --
@@ -49,7 +49,7 @@ mkStateVar :: (CommonRenderSym r) => String -> VSType r -> Doc -> SVariable r
 mkStateVar = varFromData Dynamic
 
 -- | Constructs a dynamic variable in a non-stateful context
-mkVar :: (CommonRenderSym r) => String -> r (Type r) -> Doc -> SVariable r
+mkVar :: (CommonRenderSym r) => String -> r TypeData -> Doc -> SVariable r
 mkVar n t = varFromData Dynamic n (toState t)
 
 -- | Constructs a static variable in a stateful context
@@ -127,7 +127,7 @@ unExprNumDbl u' v' = do
   unExprCastFloat (valueType v) w
 
 -- Only used by unExprNumDbl
-unExprCastFloat :: (CommonRenderSym r) => r (Type r) -> r (Value r) -> SValue r
+unExprCastFloat :: (CommonRenderSym r) => r TypeData -> r (Value r) -> SValue r
 unExprCastFloat t = castType (getType t) . toState
   where castType Float = cast float
         castType _ = id
@@ -171,7 +171,7 @@ binExprNumDbl' b' v1' v2' = do
   binExprCastFloat t1 t2 e
 
 -- Only used by binExprNumDbl'
-binExprCastFloat :: (CommonRenderSym r) => r (Type r) -> r (Type r) -> r (Value r) ->
+binExprCastFloat :: (CommonRenderSym r) => r TypeData -> r TypeData -> r (Value r) ->
   SValue r
 binExprCastFloat t1 t2 = castType (getType t1) (getType t2) . toState
   where castType Float _ = cast float
@@ -212,7 +212,7 @@ exprRender' f b' v1' v2' = do
   v2 <- v2'
   toState $ f b v1 v2
 
-mkExpr :: (CommonRenderSym r) => Int -> r (Type r) -> Doc -> SValue r
+mkExpr :: (CommonRenderSym r) => Int -> r TypeData -> Doc -> SValue r
 mkExpr p t = valFromData (Just p) Nothing (toState t)
 
 binOpDocDRend :: (CommonRenderSym r) => r (BinaryOp r) -> r (Value r) ->

--- a/code/drasil-gool/lib/Drasil/Shared/LanguageRenderer/LanguagePolymorphic.hs
+++ b/code/drasil-gool/lib/Drasil/Shared/LanguageRenderer/LanguagePolymorphic.hs
@@ -25,7 +25,7 @@ import Drasil.Shared.CodeType (CodeType(..), ClassName)
 import Drasil.Shared.InterfaceCommon (Label, Library, MSBody, MSBlock, VSFunction,
   VSType, SVariable, SValue, MSStatement, MSParameter, SMethod, NamedArgs,
   MixedCall, MixedCtorCall, BodySym(Body), bodyStatements, oneLiner,
-  BlockSym(Block), TypeSym(Type), TypeElim(getType, getTypeString),
+  BlockSym(Block), TypeElim(getType, getTypeString),
   VariableSym(Variable), VisibilitySym(..), VariableElim(variableName,
   variableType), ValueSym(Value, valueType), NumericExpression((#+), (#-), (#/),
   sin, cos, tan), Comparison(..), funcApp, StatementSym(multi),
@@ -64,7 +64,7 @@ import qualified Drasil.GOOL.RendererClassesOO as S (RenderFile(fileFromData),
 import qualified Drasil.GOOL.RendererClassesOO as RC (ClassElim(..),
   ModuleElim(..))
 import Drasil.Shared.AST (Binding(..), Terminator(..), isSource, ScopeTag(Local),
-  ScopeData, sd)
+  ScopeData, sd, TypeData)
 import Drasil.Shared.Helpers (doubleQuotedText, vibcat, emptyIfEmpty, toCode,
   toState, onStateValue, on2StateValues, onStateList, getInnerType, getNestDegree,
   on2StateWrapped)
@@ -475,7 +475,7 @@ tryCatch f = on2StateWrapped (\tb1 tb2 -> mkStmtNoEnd (f tb1 tb2))
 
 -- Methods --
 
-construct :: (CommonRenderSym r) => Label -> MS (r (Type r))
+construct :: (CommonRenderSym r) => Label -> MS (r TypeData)
 construct n = zoom lensMStoVS $ typeFromData (Object n) n empty
 
 param :: (CommonRenderSym r) => (r (Variable r) -> Doc) -> SVariable r ->

--- a/code/drasil-gool/lib/Drasil/Shared/RendererClassesCommon.hs
+++ b/code/drasil-gool/lib/Drasil/Shared/RendererClassesCommon.hs
@@ -25,7 +25,7 @@ import Drasil.Shared.InterfaceCommon (Label, Library, MSBody, MSBlock, VSFunctio
   VisibilitySym(..), ParameterSym(..), MethodSym(..), ScopeSym(..),
   BinderElim(..), BinderSym (..))
 import Drasil.Shared.CodeType (CodeType)
-import Drasil.Shared.AST (Binding, Terminator, VisibilityTag, ScopeData)
+import Drasil.Shared.AST (Binding, Terminator, VisibilityTag, ScopeData, TypeData)
 import Drasil.Shared.State (MS, VS)
 
 import Control.Monad.State (State)
@@ -78,7 +78,7 @@ class RenderType r where
   typeFromData :: CodeType -> String -> Doc -> VSType r
 
 class InternalTypeElim r where
-  type' :: r (Type r) -> Doc
+  type' :: r TypeData -> Doc
 
 type VSUnOp a = VS (a (UnaryOp a))
 
@@ -177,7 +177,7 @@ class RenderFunction r where
   funcFromData :: Doc -> VSType r -> VSFunction r
 
 class FunctionElim r where
-  functionType :: r (Function r) -> r (Type r)
+  functionType :: r (Function r) -> r TypeData
   function :: r (Function r) -> Doc
 
 class InternalAssignStmt r where
@@ -211,7 +211,7 @@ class RenderParam r where
 
 class ParamElim r where
   parameterName :: r (Parameter r) -> Label
-  parameterType :: r (Parameter r) -> r (Type r)
+  parameterType :: r (Parameter r) -> r TypeData
   parameter     :: r (Parameter r) -> Doc
 
 class BlockCommentSym r where


### PR DESCRIPTION
Contributes to #4360. The removal of type families seems to be necessary to allow us to remove the global `GOOLState`, so this is a good start. Thanks to @balacij for picking out `TypeSym` as a potential starting point!

