### PR TITLE
refactor(-printers): avoid using `HDiv` hack in Jupyter Notebook generation of equation blocks

### DIFF
--- a/code/drasil-printers/lib/Language/Drasil/JSON/Print.hs
+++ b/code/drasil-printers/lib/Language/Drasil/JSON/Print.hs
@@ -79,12 +79,11 @@ printLO CodeBlock {}                    = empty
 
 -- printLO' is used for generating general notebook (lesson plans)
 printLO' :: LayoutObj -> Doc
-printLO' (HDiv ["equation"] layoutObs _)  = markdownCell $ vcat (map printLO' layoutObs)
 printLO' (Header n contents l)            = markdownCell $ nbformat (h (n + 1) <> pSpec contents) $$ refID (pSpec l)
 printLO' (Cell layoutObs)                 = vcat (map printLO' layoutObs)
 printLO' HDiv {}                          = empty
 printLO' (Paragraph contents)             = markdownCell $ nbformat (stripnewLine (show(pSpec contents)))
-printLO' (EqnBlock contents)              = nbformat mathEqn
+printLO' (EqnBlock contents)              = markdownCell $ nbformat mathEqn
   where
     toMathHelper (PL g) = PL (\_ -> g Math)
     mjDelimDisp d  = text "$$" <> stripnewLine (show d) <> text "$$"

--- a/code/drasil-printers/lib/Language/Drasil/Printing/Import/Document.hs
+++ b/code/drasil-printers/lib/Language/Drasil/Printing/Import/Document.hs
@@ -142,9 +142,7 @@ layLabelled sm x@(LblC _ _ (Table hdr lls t b)) = T.Table ["table"]
   (map (spec sm) hdr : map (map (spec sm)) lls)
   (P.S $ getAdd $ getRefAdd x)
   b (spec sm t)
-layLabelled sm x@(LblC _ _ (EqnBlock c))        = T.HDiv ["equation"]
-  [T.EqnBlock (P.E (modelExpr c sm))]
-  (P.S $ getAdd $ getRefAdd x)
+layLabelled sm (LblC _ _ (EqnBlock c))          = T.EqnBlock (P.E (modelExpr c sm))
 layLabelled sm x@(LblC _ _ (Figure c f wp hc))  = T.Figure
   (P.S $ getAdd $ getRefAdd x)
   (if hc == WithCaption then Just (spec sm c) else Nothing)
@@ -170,7 +168,7 @@ layUnlabelled :: PrintingInformation -> RawContent -> T.LayoutObj
 layUnlabelled sm (Table hdr lls t b) = T.Table ["table"]
   (map (spec sm) hdr : map (map (spec sm)) lls) (P.S "nolabel0") b (spec sm t)
 layUnlabelled sm (Paragraph c)    = T.Paragraph (spec sm c)
-layUnlabelled sm (EqnBlock c)     = T.HDiv ["equation"] [T.EqnBlock (P.E (modelExpr c sm))] P.EmptyS
+layUnlabelled sm (EqnBlock c)     = T.EqnBlock (P.E (modelExpr c sm))
 layUnlabelled sm (DerivBlock h d) = T.HDiv ["subsubsubsection"]
   (T.Header 3 (spec sm h) refr : map (layUnlabelled sm) d) refr
   where refr = P.S "nolabel1"


### PR DESCRIPTION
`LayoutObj`'s `HDiv` constructor is a hack that allows HTML documents to nest sections in a giant `div` block. This kind of constructor feels it should be avoided entirely (not sure how to do this yet).

This PR removes one unnecessary use of `HDiv` to print out single-cell equation blocks in the Jupyter Notebook generator.