### PR TITLE
Move core references to CommonKnowledge basisCitations (#4971)

### DIFF
--- a/code/drasil-example/dblpend/lib/Drasil/DblPend/References.hs
+++ b/code/drasil-example/dblpend/lib/Drasil/DblPend/References.hs
@@ -1,12 +1,9 @@
-module Drasil.DblPend.References (citations, koothoor2013,
-  smithEtAl2007, smithLai2005, smithKoothoor2016) where
+module Drasil.DblPend.References (citations) where
 
 import Language.Drasil (BibRef)
 import Data.Drasil.Citations (accelerationWiki, velocityWiki,
- parnasClements1986, hibbeler2004, koothoor2013, smithEtAl2007, smithLai2005,
- smithKoothoor2016)
+ parnasClements1986, hibbeler2004)
 
 citations :: BibRef
 citations = [accelerationWiki, velocityWiki, hibbeler2004,
-             parnasClements1986, koothoor2013, smithEtAl2007, smithLai2005,
-             smithKoothoor2016]
+             parnasClements1986]

--- a/code/drasil-example/gamephysics/lib/Drasil/GamePhysics/References.hs
+++ b/code/drasil-example/gamephysics/lib/Drasil/GamePhysics/References.hs
@@ -2,8 +2,7 @@ module Drasil.GamePhysics.References where
 
 import Language.Drasil
 
-import Data.Drasil.Citations (koothoor2013, parnasClements1986, smithEtAl2007,
-  smithLai2005, smithKoothoor2016, dampingSource, hibbeler2004)
+import Data.Drasil.Citations (parnasClements1986, dampingSource, hibbeler2004)
 import Data.Drasil.People (dParnas, wikiAuthors)
 import qualified Language.Drasil.Sentence.Combinators as S
 
@@ -11,7 +10,6 @@ chaslesWiki, parnas1978 :: Citation
 
 citations :: BibRef
 citations = [parnas1978, chaslesWiki, parnasClements1986,
-  koothoor2013, smithEtAl2007, smithLai2005, smithKoothoor2016,
   dampingSource, hibbeler2004]
 
 --FIXME: check for references made within document

--- a/code/drasil-example/glassbr/lib/Drasil/GlassBR/References.hs
+++ b/code/drasil-example/glassbr/lib/Drasil/GlassBR/References.hs
@@ -5,15 +5,13 @@ module Drasil.GlassBR.References (
 
 import Language.Drasil
 
-import Data.Drasil.Citations (campidelli, koothoor2013,
-  smithEtAl2007, smithLai2005, smithKoothoor2016, parnasClements1986)
+import Data.Drasil.Citations (campidelli, parnasClements1986)
 import Data.Drasil.People (jmBracci, tlKohutek, wlBeason)
 
 astm2009, astm2016, astm2012, beasonEtAl1998 :: Citation
 
 citations :: BibRef
-citations = [campidelli, koothoor2013, smithEtAl2007, smithLai2005,
-             smithKoothoor2016, astm2009, astm2016, astm2012, beasonEtAl1998,
+citations = [campidelli, astm2009, astm2016, astm2012, beasonEtAl1998,
              parnasClements1986]
 
 astm2009 = cMisc [author [mononym "ASTM"],

--- a/code/drasil-example/pdcontroller/lib/Drasil/PDController/References.hs
+++ b/code/drasil-example/pdcontroller/lib/Drasil/PDController/References.hs
@@ -1,12 +1,10 @@
 module Drasil.PDController.References where
-import Data.Drasil.Citations (smithEtAl2007, smithLai2005,
-  smithKoothoor2016, koothoor2013, laplaceWiki, pidWiki)
+import Data.Drasil.Citations (laplaceWiki, pidWiki)
 
 import Language.Drasil
 
 citations :: BibRef
-citations = [johnson2008, abbasi2015, smithEtAl2007, smithLai2005,
-             smithKoothoor2016, koothoor2013, laplaceWiki, pidWiki]
+citations = [johnson2008, abbasi2015, laplaceWiki, pidWiki]
 
 johnson2008, abbasi2015 :: Citation
 

--- a/code/drasil-example/projectile/lib/Drasil/Projectile/References.hs
+++ b/code/drasil-example/projectile/lib/Drasil/Projectile/References.hs
@@ -2,10 +2,8 @@ module Drasil.Projectile.References where
 
 import Language.Drasil
 import Data.Drasil.Citations (accelerationWiki, velocityWiki,
- hibbeler2004, parnasClements1986, koothoor2013, smithKoothoor2016, smithEtAl2007,
- smithLai2005)
+ hibbeler2004, parnasClements1986)
 
 citations :: BibRef
 citations = [accelerationWiki, velocityWiki, hibbeler2004,
-             parnasClements1986, koothoor2013, smithKoothoor2016, smithEtAl2007,
-             smithLai2005]
+             parnasClements1986]

--- a/code/drasil-example/ssp/lib/Drasil/SSP/References.hs
+++ b/code/drasil-example/ssp/lib/Drasil/SSP/References.hs
@@ -2,16 +2,14 @@ module Drasil.SSP.References where
 
 import Language.Drasil
 
-import Data.Drasil.Citations (jnlCGJ, koothoor2013, parnasClements1986,
- smithEtAl2007, smithLai2005, smithKoothoor2016, hibbeler2004)
+import Data.Drasil.Citations (jnlCGJ, parnasClements1986, hibbeler2004)
 import Data.Drasil.People (bKarchewski, cfLee, dgFredlund, dStolle, dyZhu,
   grChen, jKrahn, pGuo, pjCleall, qhQian, ssLing, tltZhan, yCLi, ymChen,
   rHuston, hJosephs, nrMorgenstern, vePrice)
 
 citations :: BibRef
-citations = [chen2005, parnasClements1986, koothoor2013, fredlund1977,
-             smithEtAl2007, smithLai2005, smithKoothoor2016, li2010,
-             karchewski2012, huston2008, morgenstern1965, hibbeler2004]
+citations = [chen2005, parnasClements1986, fredlund1977,
+             li2010, karchewski2012, huston2008, morgenstern1965, hibbeler2004]
 
 chen2005, fredlund1977, li2010, karchewski2012, huston2008,
   morgenstern1965 :: Citation

--- a/code/drasil-example/swhs/lib/Drasil/SWHS/References.hs
+++ b/code/drasil-example/swhs/lib/Drasil/SWHS/References.hs
@@ -5,16 +5,14 @@ import Language.Drasil
 import Data.Drasil.People (jBueche, fIncropera, dDewitt, tBergman, aLavine,
   mLightstone)
 
-import Data.Drasil.Citations (koothoor2013, parnasClements1986,
-  smithEtAl2007, smithLai2005, smithKoothoor2016)
+import Data.Drasil.Citations (parnasClements1986)
 
 ----------------------------
 -- Section 9 : References --
 ----------------------------
 citations :: BibRef
-citations = [bueche1986, incroperaEtAl2007, koothoor2013, lightstone2012,
-             parnasClements1986, smithEtAl2007, smithLai2005,
-             smithKoothoor2016]
+citations = [bueche1986, incroperaEtAl2007, lightstone2012,
+             parnasClements1986]
 
 bueche1986, incroperaEtAl2007, lightstone2012 :: Citation
 

--- a/code/drasil-example/swhsnopcm/lib/Drasil/SWHSNoPCM/References.hs
+++ b/code/drasil-example/swhsnopcm/lib/Drasil/SWHSNoPCM/References.hs
@@ -2,11 +2,9 @@ module Drasil.SWHSNoPCM.References (citations) where
 
 import Language.Drasil
 
-import Data.Drasil.Citations (koothoor2013, parnasClements1986, smithEtAl2007,
-  smithKoothoor2016, smithLai2005)
+import Data.Drasil.Citations (parnasClements1986)
 
 import Drasil.SWHS.References (incroperaEtAl2007)
 
 citations :: BibRef
-citations = [incroperaEtAl2007, koothoor2013, parnasClements1986,
-             smithEtAl2007, smithLai2005, smithKoothoor2016]
+citations = [incroperaEtAl2007, parnasClements1986]

--- a/code/drasil-example/template/lib/Drasil/Template/Body.hs
+++ b/code/drasil-example/template/lib/Drasil/Template/Body.hs
@@ -93,8 +93,7 @@ symbMap = withCommonKnowledge []
   citations ([] :: [LabelledContent])
 
 citations :: BibRef
-citations = [parnasClements1986, koothoor2013, smithEtAl2007, smithLai2005,
-             smithKoothoor2016]
+citations = [parnasClements1986]
 
 figTemp :: LabelledContent
 figTemp = llccFig "dblpend" $ figWithWidth EmptyS

--- a/code/drasil-gen/lib/Drasil/Generator/CommonKnowledge.hs
+++ b/code/drasil-gen/lib/Drasil/Generator/CommonKnowledge.hs
@@ -6,7 +6,8 @@ module Drasil.Generator.CommonKnowledge (
 import Drasil.Database (empty, insertAll, ChunkDB, insertAllOutOfOrder12)
 import Language.Drasil (IdeaDict, nw, Citation, ConceptChunk, ConceptInstance,
   DefinedQuantityDict, UnitDefn, LabelledContent, Reference)
-import Data.Drasil.Citations (cartesianWiki, lineSource, pointSource)
+import Data.Drasil.Citations (cartesianWiki, lineSource, pointSource,
+  smithEtAl2007, smithLai2005, smithKoothoor2016, koothoor2013)
 import Data.Drasil.Concepts.Documentation (doccon, doccon', srsDomains)
 import Data.Drasil.Software.Products (prodtcon)
 import Data.Drasil.Concepts.Education (educon)
@@ -98,4 +99,5 @@ basisConceptChunks =
   [algorithm, errMsg, program] ++ srsDomains ++ mathcon
 
 basisCitations :: [Citation]
-basisCitations = [cartesianWiki, lineSource, pointSource]
+basisCitations = [cartesianWiki, lineSource, pointSource,
+  smithEtAl2007, smithLai2005, smithKoothoor2016, koothoor2013]


### PR DESCRIPTION
Closes #4971

Move smithEtAl2007, smithLai2005, smithKoothoor2016, and koothoor2013 into basisCitations in Drasil.Generator.CommonKnowledge. These four references appeared in every SmithEtAl-formatted case study's local citation list.

Updated each case study to remove the now-redundant entries from its local citations list and import:
- dblpend, gamephysics, glassbr, pdcontroller, projectile, ssp, swhs, swhsnopcm (References.hs)
- template (Body.hs has its citation list inline)

Generated SRS output is unchanged (verified via make stabilize: 0 file changes under stable/). The references now flow into every withCommonKnowledge ChunkDB via basisCitations.

Follows the pattern from #4727.