### PR TITLE
chore: remove unused `drasil-metadata` dependency in `drasil-printers`

### DIFF
--- a/code/drasil-printers/package.yaml
+++ b/code/drasil-printers/package.yaml
@@ -25,7 +25,6 @@ dependencies:
 - drasil-build-artifacts
 - drasil-database
 - drasil-lang
-- drasil-metadata
 - drasil-theory
 - drasil-utils
 - split


### PR DESCRIPTION
`drasil-printers` is directly independent of `drasil-metadata`, indirectly dependent on it through `drasil-theory` at least.