### PR TITLE
fix(macOS/codegenTest): remove double quotes around variables inside `$(())` return code evaluation in `gooltest_build.sh`

### DIFF
--- a/code/scripts/gooltest_build.sh
+++ b/code/scripts/gooltest_build.sh
@@ -20,7 +20,7 @@ for lang in */; do
     cd "$test" || exit 1
     # shellcheck disable=SC2086
     "$MAKE" $TARGET
-    RET=$(( "$RET" || $? ))
+    RET=$(( RET || $? ))
     cd "$LANG_DIR" || exit 1
   done
   cd "$E_DIR" || exit 1


### PR DESCRIPTION
`make codegenTest` was broken on macOS because of a syntax deviation in `gooltest_build.sh` between bash versions. The CI is fine because [the Ubuntu 22.04](https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2204-Readme.md) image ships with bash 5.1 but macOS ships with bash 3.2 (!). The old version of bash does not strip quotes inside arithmetic contexts, so `gooltest_build.sh` was failing when it encountered any return code.

The error I was getting:

```console
"0" || 0 : syntax error: operand expected (error token is ""0" || 0 ")
```

This just removes the quotation marks because it works on both versions, which is easier than suggesting macOS-based developers switch to newer development tools.