### PR TITLE
refactor: unify `Main` program entries of all case studies

### DIFF
--- a/code/drasil-example/dblpend/app/Main.hs
+++ b/code/drasil-example/dblpend/app/Main.hs
@@ -1,13 +1,9 @@
 module Main (main) where
 
-import GHC.IO.Encoding
-
-import Drasil.Generator (exportSmithEtAlSrsWCode)
+import Drasil.Generator (caseStudyMainSRSWCode)
 
 import Drasil.DblPend.Body (mkSRS, si)
 import Drasil.DblPend.Choices (choices)
 
 main :: IO ()
-main = do
-  setLocaleEncoding utf8
-  exportSmithEtAlSrsWCode si mkSRS "DblPend_SRS" choices
+main = caseStudyMainSRSWCode si mkSRS "DblPend_SRS" choices

--- a/code/drasil-example/gamephysics/app/Main.hs
+++ b/code/drasil-example/gamephysics/app/Main.hs
@@ -1,12 +1,8 @@
 module Main (main) where
 
-import GHC.IO.Encoding
-
-import Drasil.Generator (exportSmithEtAlSrs)
+import Drasil.Generator (caseStudyMainSRS)
 
 import Drasil.GamePhysics.Body (mkSRS, si)
 
 main :: IO ()
-main = do
-  setLocaleEncoding utf8
-  exportSmithEtAlSrs si mkSRS "GamePhysics_SRS"
+main = caseStudyMainSRS si mkSRS "GamePhysics_SRS"

--- a/code/drasil-example/glassbr/app/Main.hs
+++ b/code/drasil-example/glassbr/app/Main.hs
@@ -1,13 +1,9 @@
 module Main (main) where
 
-import GHC.IO.Encoding
-
-import Drasil.Generator (exportSmithEtAlSrsWCode)
+import Drasil.Generator (caseStudyMainSRSWCode)
 
 import Drasil.GlassBR.Body (mkSRS, si)
 import Drasil.GlassBR.Choices (choices)
 
 main :: IO ()
-main = do
-  setLocaleEncoding utf8
-  exportSmithEtAlSrsWCode si mkSRS "GlassBR_SRS" choices
+main = caseStudyMainSRSWCode si mkSRS "GlassBR_SRS" choices

--- a/code/drasil-example/hghc/app/Main.hs
+++ b/code/drasil-example/hghc/app/Main.hs
@@ -1,12 +1,8 @@
 module Main (main) where
 
-import GHC.IO.Encoding
-
-import Drasil.Generator (exportSmithEtAlSrs)
+import Drasil.Generator (caseStudyMainSRS)
 
 import Drasil.HGHC.Body (mkSRS, si)
 
 main :: IO ()
-main = do
-  setLocaleEncoding utf8
-  exportSmithEtAlSrs si mkSRS "HGHC_SRS"
+main = caseStudyMainSRS si mkSRS "HGHC_SRS"

--- a/code/drasil-example/pdcontroller/app/Main.hs
+++ b/code/drasil-example/pdcontroller/app/Main.hs
@@ -1,13 +1,9 @@
 module Main (main) where
 
-import GHC.IO.Encoding
-
-import Drasil.Generator (exportSmithEtAlSrsWCode)
+import Drasil.Generator (caseStudyMainSRSWCode)
 
 import Drasil.PDController.Body (mkSRS, si)
 import Drasil.PDController.Choices (choices)
 
 main :: IO ()
-main = do
-  setLocaleEncoding utf8
-  exportSmithEtAlSrsWCode si mkSRS "PDController_SRS" choices
+main = caseStudyMainSRSWCode si mkSRS "PDController_SRS" choices

--- a/code/drasil-example/projectile/app/Main.hs
+++ b/code/drasil-example/projectile/app/Main.hs
@@ -1,8 +1,6 @@
 module Main (main) where
 
-import GHC.IO.Encoding
-
-import Drasil.Generator (exportSmithEtAlSrsWCodeZoo, exportLessonPlan)
+import Drasil.Generator (caseStudyMainSRSWCodeZooWLsnPlan)
 
 import qualified Drasil.Projectile.Body as Proj (si, mkSRS)
 import qualified Drasil.Projectile.Choices as Proj (choiceCombos)
@@ -10,7 +8,5 @@ import qualified Drasil.Projectile.Choices as Proj (choiceCombos)
 import qualified Drasil.Projectile.Lesson.Body as ProjLP
 
 main :: IO ()
-main = do
-  setLocaleEncoding utf8
-  exportSmithEtAlSrsWCodeZoo Proj.si Proj.mkSRS "Projectile_SRS" Proj.choiceCombos
-  exportLessonPlan ProjLP.si ProjLP.nbDecl "Projectile_Lesson"
+main = caseStudyMainSRSWCodeZooWLsnPlan Proj.si Proj.mkSRS "Projectile_SRS"
+  Proj.choiceCombos ProjLP.si ProjLP.nbDecl "Projectile_Lesson"

--- a/code/drasil-example/sglpend/app/Main.hs
+++ b/code/drasil-example/sglpend/app/Main.hs
@@ -1,12 +1,8 @@
 module Main (main) where
 
-import GHC.IO.Encoding
-
-import Drasil.Generator (exportSmithEtAlSrs)
+import Drasil.Generator (caseStudyMainSRS)
 
 import Drasil.SglPend.Body (mkSRS, si)
 
 main :: IO ()
-main = do
-  setLocaleEncoding utf8
-  exportSmithEtAlSrs si mkSRS "SglPend_SRS"
+main = caseStudyMainSRS si mkSRS "SglPend_SRS"

--- a/code/drasil-example/ssp/app/Main.hs
+++ b/code/drasil-example/ssp/app/Main.hs
@@ -1,12 +1,8 @@
 module Main (main) where
 
-import GHC.IO.Encoding
-
-import Drasil.Generator (exportSmithEtAlSrs)
+import Drasil.Generator (caseStudyMainSRS)
 
 import Drasil.SSP.Body (mkSRS, si)
 
 main :: IO ()
-main = do
-  setLocaleEncoding utf8
-  exportSmithEtAlSrs si mkSRS "SSP_SRS"
+main = caseStudyMainSRS si mkSRS "SSP_SRS"

--- a/code/drasil-example/swhs/app/Main.hs
+++ b/code/drasil-example/swhs/app/Main.hs
@@ -1,12 +1,8 @@
 module Main (main) where
 
-import GHC.IO.Encoding
-
-import Drasil.Generator (exportSmithEtAlSrs)
+import Drasil.Generator (caseStudyMainSRS)
 
 import Drasil.SWHS.Body (mkSRS, si)
 
 main :: IO ()
-main = do
-  setLocaleEncoding utf8
-  exportSmithEtAlSrs si mkSRS "SWHS_SRS"
+main = caseStudyMainSRS si mkSRS "SWHS_SRS"

--- a/code/drasil-example/swhsnopcm/app/Main.hs
+++ b/code/drasil-example/swhsnopcm/app/Main.hs
@@ -1,13 +1,9 @@
 module Main (main) where
 
-import GHC.IO.Encoding
-
-import Drasil.Generator (exportSmithEtAlSrsWCode)
+import Drasil.Generator (caseStudyMainSRSWCode)
 
 import Drasil.SWHSNoPCM.Body (mkSRS, si)
 import Drasil.SWHSNoPCM.Choices (choices)
 
 main :: IO ()
-main = do
-  setLocaleEncoding utf8
-  exportSmithEtAlSrsWCode si mkSRS "SWHSNoPCM_SRS" choices
+main = caseStudyMainSRSWCode si mkSRS "SWHSNoPCM_SRS" choices

--- a/code/drasil-example/template/app/Main.hs
+++ b/code/drasil-example/template/app/Main.hs
@@ -1,12 +1,8 @@
 module Main (main) where
 
-import GHC.IO.Encoding
-
-import Drasil.Generator (exportSmithEtAlSrs)
+import Drasil.Generator (caseStudyMainSRS)
 
 import Drasil.Template.Body (mkSRS, si)
 
 main :: IO ()
-main = do
-  setLocaleEncoding utf8
-  exportSmithEtAlSrs si mkSRS "Template_SRS"
+main = caseStudyMainSRS si mkSRS "Template_SRS"

--- a/code/drasil-gen/lib/Drasil/Generator.hs
+++ b/code/drasil-gen/lib/Drasil/Generator.hs
@@ -1,21 +1,12 @@
-module Drasil.Generator (
-  module Drasil.Generator.ChunkDump,
-  module Drasil.Generator.Code,
-  module Drasil.Generator.CommonKnowledge,
-  module Drasil.Generator.Composed,
-  module Drasil.Generator.Formats,
-  module Drasil.Generator.LessonPlan,
-  module Drasil.Generator.SRS,
-  module Drasil.Generator.SRS.TypeCheck,
-  module Drasil.Generator.Website
-) where
+module Drasil.Generator
+  ( module Drasil.Generator.CaseStudyVariants,
+    module Drasil.Generator.Code,
+    module Drasil.Generator.CommonKnowledge,
+    module Drasil.Generator.Formats,
+  )
+where
 
-import Drasil.Generator.ChunkDump
+import Drasil.Generator.CaseStudyVariants
 import Drasil.Generator.Code
 import Drasil.Generator.CommonKnowledge
-import Drasil.Generator.Composed
 import Drasil.Generator.Formats
-import Drasil.Generator.LessonPlan
-import Drasil.Generator.SRS
-import Drasil.Generator.SRS.TypeCheck
-import Drasil.Generator.Website

--- a/code/drasil-gen/lib/Drasil/Generator/CaseStudyVariants.hs
+++ b/code/drasil-gen/lib/Drasil/Generator/CaseStudyVariants.hs
@@ -1,0 +1,61 @@
+{-# LANGUAGE QuasiQuotes #-}
+
+-- | Case study variants.
+--
+-- Each case study is expected to generate files in a specific pattern that the
+-- main `code/Makefile` expects for (a) testing and (b) website deployment.
+module Drasil.Generator.CaseStudyVariants
+  ( caseStudyMainSRS,
+    caseStudyMainSRSWCode,
+    caseStudyMainSRSWCodeZooWLsnPlan,
+    caseStudyMainDrasilWebsite,
+  )
+where
+
+import GHC.IO.Encoding (setLocaleEncoding, utf8)
+
+import Drasil.DocumentLanguage.Notebook (LsnDesc)
+import Drasil.SRSDocument (SRSDecl)
+import Drasil.System (DrasilWebsite, LessonPlan, SmithEtAlSRS)
+import Language.Drasil (Document)
+import Language.Drasil.Code (Choices)
+
+import Drasil.Generator.Composed (exportSmithEtAlSrsWCode, exportSmithEtAlSrsWCodeZoo)
+import Drasil.Generator.SRS (exportSmithEtAlSrs)
+import Drasil.Generator.LessonPlan (exportLessonPlan)
+import Drasil.Generator.Website (exportWebsite)
+
+-- | Internal: Set system locale encoding to UTF-8.
+setSystemLocale :: IO ()
+setSystemLocale = setLocaleEncoding utf8
+
+-- | A case study that only outputs an SRS in each of our supported variants.
+caseStudyMainSRS :: SmithEtAlSRS -> SRSDecl -> String -> IO ()
+caseStudyMainSRS syst srsDecl srsFileName = do
+  setSystemLocale
+  exportSmithEtAlSrs syst srsDecl srsFileName
+
+-- | A case study that outputs both an SRS in each of our supported variants as
+-- well as a single chosen software artifact in optionally many programming
+-- languages.
+caseStudyMainSRSWCode :: SmithEtAlSRS -> SRSDecl -> String -> Choices -> IO ()
+caseStudyMainSRSWCode syst srsDecl srsFileName choices = do
+  setSystemLocale
+  exportSmithEtAlSrsWCode syst srsDecl srsFileName choices
+
+-- | The same as 'caseStudyMainSRSWCode', except it also produces a
+-- JupyterNotebook-based lesson plan.
+caseStudyMainSRSWCodeZooWLsnPlan :: SmithEtAlSRS -> SRSDecl -> String
+  -> [Choices] -> LessonPlan -> LsnDesc -> String -> IO ()
+caseStudyMainSRSWCodeZooWLsnPlan syst srsDecl srsFileName  choices plan nbDecl
+  lsnFileName = do
+  setSystemLocale
+  exportSmithEtAlSrsWCodeZoo syst srsDecl srsFileName choices
+  exportLessonPlan plan nbDecl lsnFileName
+
+-- | The Drasil website binary is expected to build a `Website/HTML/` folder
+-- containing the actual website artifacts (`index.html` and `index.css`).
+caseStudyMainDrasilWebsite :: DrasilWebsite -> Document -> IO ()
+caseStudyMainDrasilWebsite syst websiteDoc = do
+  setSystemLocale
+  exportWebsite syst websiteDoc "index"

--- a/code/drasil-website/app/Main.hs
+++ b/code/drasil-website/app/Main.hs
@@ -2,10 +2,9 @@
 -- and then generate an updated Drasil website.
 module Main (main) where
 
-import GHC.IO.Encoding
 import Data.Maybe (fromMaybe)
 
-import Drasil.Generator (exportWebsite)
+import Drasil.Generator (caseStudyMainDrasilWebsite)
 import Language.Drasil (Document(Document), ShowTableOfContents(NoToC),
   namedRef, Sentence(S))
 import System.Environment (getEnv, lookupEnv)
@@ -17,8 +16,6 @@ import Drasil.Website.Body (FolderLocation (..), gitHubRef, sections,
 -- and generate the Drasil website.
 main :: IO ()
 main = do
-  setLocaleEncoding utf8
-
   -- Require the Makefile (or deploy script as it will usually be) to feed
   -- locations for where to find certain files/groups of files in the staged
   -- deploy folder.
@@ -69,4 +66,4 @@ main = do
       websiteDoc = Document (S websiteTitle) author NoToC $ sections allFolders
 
   -- generate the html document/website.
-  exportWebsite syst websiteDoc "index"
+  caseStudyMainDrasilWebsite syst websiteDoc


### PR DESCRIPTION
Builds on #4972

> This PR is broken off from [`artifactReprSRS'`](https://github.com/JacquesCarette/Drasil/tree/artifactReprSRS').

The goal here is to unify the IO parts of the case studies (hopefully only the main program entries) into a series of case study types. The next step will be to de-couple artifact generation/`FileLayout` production from IO.