### PR TITLE
 Move `*.hs` files from `scripts/` to `drasil-meta-analysis`

### DIFF
--- a/code/Makefile
+++ b/code/Makefile
@@ -7,7 +7,7 @@ SHELL = bash
 #--------------------------------------------#
 
 # List of all known packages
-PACKAGES = build-artifacts code data database docLang gen gool lang makefile metadata printers system theory utils website
+PACKAGES = build-artifacts code data database docLang gen gool lang makefile metadata meta-analysis printers system theory utils website
 PACKAGES_E = $(PACKAGES) example
 
 # and associated package-level suffixes
@@ -449,8 +449,8 @@ $(filter %$(GRAPH_P_SUFFIX), $(GRAPH_PACKAGES)): %$(GRAPH_P_SUFFIX): graphmod ch
 analysis: graphmod ##@Analysis Generate a table and some graphs to analyze Drasil's class, datatype, and instance structures.
 	rm -rf "./$(ANALYSIS_FOLDER)"
 	@mkdir -p "$(ANALYSIS_FOLDER)"
-	cd $(SCRIPT_FOLDER) && stack ClassInstDepGen.hs
-	cd $(SCRIPT_FOLDER) && stack TypeDepGen.hs
+	stack run classinstdepgen
+	stack run typedepgen
 	@echo "Analysis complete. Please see '$(ANALYSIS_FOLDER)' folder."
 
 convertAnalyzed: ##@Analysis Convert analyzed dot graphs into SVGs.

--- a/code/drasil-meta-analysis/app/classinstdepgen/ClassInstDepGen.hs
+++ b/code/drasil-meta-analysis/app/classinstdepgen/ClassInstDepGen.hs
@@ -7,10 +7,9 @@ module ClassInstDepGen (main) where
 import Data.List
 import System.IO
 import System.Directory
-import System.FilePath (takeDirectory)
 import Control.Monad
-import qualified Drasil.Meta.Analysis.DirectoryController as DC (createFolder, createFile, finder,
-  getDirectories, DrasilPack, FileName, FolderName, File(..), Folder(..))
+import qualified Drasil.Meta.Analysis.DirectoryController as DC (createFile, finder,
+  getDirectories, DrasilPack, FileName, File(..))
 import Drasil.Meta.Analysis.SourceCodeReaderCI as SCR (extractEntryData, EntryData(..))
 import Data.List.Split (splitOn)
 import Drasil.Meta.Analysis.DataPrinters.Dot
@@ -76,8 +75,8 @@ instance Show ClassType where
 -- makes Entry data instance
 makeEntry :: DC.DrasilPack -> DC.FileName -> FilePath -> [DataType] ->
   [Newtype] -> [Class] -> [ClassInstance] -> Entry
-makeEntry drpk fn fp dtl ntl cls clsint = Entry {drasilPack=drpk, fileName = fn,
-  filePath = fp, dataTypes = dtl, newtypes = ntl, classes = cls, classInstances = clsint}
+makeEntry drpk fn fp dtl ntl clss clsint = Entry {drasilPack=drpk, fileName = fn,
+  filePath = fp, dataTypes = dtl, newtypes = ntl, classes = clss, classInstances = clsint}
 
 -- makes Class data instance
 makeClass :: ClassType -> ClassName -> Class
@@ -85,7 +84,7 @@ makeClass clstp clsnm = Class {className = clsnm, classType = clstp}
 
 -- makes ClassInstance data instance
 makeClassInstance :: (DNType,ClassName) -> ClassInstance
-makeClassInstance (dnt,cls) = ClassInstance {dnType = dnt, clsInstName = cls}
+makeClassInstance (dnt,clss) = ClassInstance {dnType = dnt, clsInstName = clss}
 
 -- makes SmallEntry data instance
 makeSmallEntry :: [String] -> [ClassName] -> [ClassName] -> [Edges] -> SmallEntry
@@ -109,8 +108,7 @@ main = do
   -- gets names + filepaths of all drasil- packages/directories
   drctyList <- DC.getDirectories codeDirectory "drasil-"
 
-  let packageNames = map DC.folderDrasilPack drctyList
-      classInstOrd = [Haskell, Drasil, GOOL]
+  let classInstOrd = [Haskell, Drasil, GOOL]
 
   -- all files + filepaths stored here; obtained from ordered list using finder
   allFiles <- mapM DC.finder drctyList
@@ -207,7 +205,7 @@ escapeDotID = map go
 
 -- Helper to convert class instances into graph edges.
 mkPkgEdges :: [ClassInstance] -> [Edges]
-mkPkgEdges cis = concatOver2 $ map (\ClassInstance {dnType = typ, clsInstName = cls} -> (escapeDotID typ, [escapeDotID cls])) cis
+mkPkgEdges cis = concatOver2 $ map (\ClassInstance {dnType = typ, clsInstName = clss} -> (escapeDotID typ, [escapeDotID clss])) cis
 
 -- Helper to concatenate tuples based on the first part of the tuple
 -- (if two elements have the same thing for the first part of the tuple, concatenate the second parts)
@@ -279,10 +277,10 @@ createEntry homeDirectory file filename = do
         | drpk == "gool" = GOOL
         | otherwise = Drasil
 
-  let cls = map (makeClass clstp) classNames
+  let clss = map (makeClass clstp) classNames
       clsint = map makeClassInstance stripInstances
 
-  let entry = makeEntry drpk fn efp dtl ntl cls clsint
+  let entry = makeEntry drpk fn efp dtl ntl clss clsint
   return entry
 
 -- creates entrystring for each entry (contains lines for each entry's data)
@@ -290,7 +288,7 @@ compileEntryData :: [ClassName] -> Entry -> DC.FileName -> IO EntryString
 -- creates blank line entrystring to separate file entries by drasil- package
 compileEntryData _ _ "newline" = return "\t"
 -- creates entrystrings for actual file entries
-compileEntryData ordClassInsts entry filename = do
+compileEntryData ordClassInsts entry _ = do
 
   -- joins data, newtype and class values/placeholders (first data entry line)
   let f d n c = intercalate "," [drpk,fp,fn,d,n,c]
@@ -303,7 +301,7 @@ compileEntryData ordClassInsts entry filename = do
       entryClassInsts = classInstances entry
 
   -- guards determine how to handle first data entry line
-  let entry = hEnt dataNames newtypeNames classNames
+  let entryLine = hEnt dataNames newtypeNames classNames
       hEnt (x:_) _ _ = f x "\t" "\t"
       hEnt _ (x:_) _ = f "\t" x "\t"
       hEnt _ _ (x:_) = f "\t" "\t" x
@@ -329,19 +327,20 @@ compileEntryData ordClassInsts entry filename = do
 
   -- guards determine how to handle overall file entry output
   -- for single line entry data vs. multi-line entry data
-  let output = tEnt (length entryData) dtRefLines ntRefLines entryData
-      tEnt 0 _ _ _          = entry
+  let genOutput = tEnt (length entryData) dtRefLines ntRefLines entryData
+      tEnt 0 _ _ _          = entryLine
       tEnt 1 (x:_) _ _      = fstl x
       tEnt 1 _ (x:_) _      = fstl x
-      tEnt 1 _ _ _          = entry
+      tEnt 1 _ _ _          = entryLine
       tEnt _ (x:_) _ (_:xs) = fstl x ++ "\n" ++ sbE xs
       tEnt _ _ (x:_) (_:xs) = fstl x ++ "\n" ++ sbE xs
-      tEnt _ _ _ (_:xs)     = entry ++ "\n" ++ sbE xs
-      fstl = join' entry
+      tEnt _ _ _ (_:xs)     = entryLine ++ "\n" ++ sbE xs
+      tEnt _ _ _ _          = error "Unexpected case"
+      fstl = join' entryLine
       sbE  = intercalate "\n"
 
   -- mapM_ print (lines output)
-  return output
+  return genOutput
 
 -- gets raw Entries, extracts classes and orders them with config file settings
 ordClasses :: [ClassType] -> [Entry] -> [Class]

--- a/code/drasil-meta-analysis/app/classinstdepgen/ClassInstDepGen.hs
+++ b/code/drasil-meta-analysis/app/classinstdepgen/ClassInstDepGen.hs
@@ -102,11 +102,9 @@ makeEntryPack nm ents = EP {dPack = nm, pkgEntries = ents}
 -- main controller function; initiates function calls to generate output file
 main :: IO ()
 main = do
-  -- directory variables (for scripts, code and output directories)
-  scriptsDirectory <- getCurrentDirectory
-  -- obtains code directory and output directory filepaths
-  let codeDirectory = takeDirectory scriptsDirectory
-      outputDirectory = codeDirectory ++ "/analysis/ClassInstDep"
+  -- directory variables (for code and output directories)
+  codeDirectory <- getCurrentDirectory
+  let outputDirectory = codeDirectory ++ "/analysis/ClassInstDep"
 
   -- gets names + filepaths of all drasil- packages/directories
   drctyList <- DC.getDirectories codeDirectory "drasil-"

--- a/code/drasil-meta-analysis/app/classinstdepgen/ClassInstDepGen.hs
+++ b/code/drasil-meta-analysis/app/classinstdepgen/ClassInstDepGen.hs
@@ -1,12 +1,3 @@
-#!/usr/bin/env stack
-{- stack script
-   --resolver lts-22.44
-   --package split
-   --package directory,filepath
-   --package text
-   --package containers
--}
-
 -- FIXME: use real parser (Low Priority; see line 267)
 -- | Data table generator. Uses information from SourceCodeReader.hs
 -- to organize all types, classes, and instances in Drasil.
@@ -18,12 +9,12 @@ import System.IO
 import System.Directory
 import System.FilePath (takeDirectory)
 import Control.Monad
-import qualified DirectoryController as DC (createFolder, createFile, finder,
+import qualified Drasil.Meta.Analysis.DirectoryController as DC (createFolder, createFile, finder,
   getDirectories, DrasilPack, FileName, FolderName, File(..), Folder(..))
-import SourceCodeReaderCI as SCR (extractEntryData, EntryData(..))
+import Drasil.Meta.Analysis.SourceCodeReaderCI as SCR (extractEntryData, EntryData(..))
 import Data.List.Split (splitOn)
-import DataPrinters.Dot
-import DataPrinters.HTML
+import Drasil.Meta.Analysis.DataPrinters.Dot
+import Drasil.Meta.Analysis.DataPrinters.HTML
 
 import Data.Containers.ListUtils (nubOrd)
 

--- a/code/drasil-meta-analysis/app/typedepgen/TypeDepGen.hs
+++ b/code/drasil-meta-analysis/app/typedepgen/TypeDepGen.hs
@@ -1,12 +1,3 @@
-#!/usr/bin/env stack
-{- stack script
-   --resolver lts-22.44
-   --package split
-   --package directory,filepath
-   --package text
-   --package containers
--}
-
 -- FIXME: use real parser (Low Priority; see line 189)
 -- | Creates graphs showing the dependency of one type upon another.
 module TypeDepGen (main) where
@@ -16,14 +7,14 @@ import System.IO
 import System.Directory
 import System.FilePath (takeDirectory)
 import Control.Monad
-import qualified DirectoryController as DC (createFolder, createFile, finder,
+import qualified Drasil.Meta.Analysis.DirectoryController as DC (createFolder, createFile, finder,
   getDirectories, DrasilPack, FileName, FolderName, File(..), Folder(..))
-import SourceCodeReaderT as SCRT (extractEntryData, EntryData(..),
+import Drasil.Meta.Analysis.SourceCodeReaderT as SCRT (extractEntryData, EntryData(..),
   DataDeclRecord(..), DataDeclConstruct(..), NewtypeDecl(..), TypeDecl(..),
   DataTypeDeclaration(..))
 import Data.List.Split (splitOn)
 import Data.Char (toLower)
-import DataPrinters.Dot
+import Drasil.Meta.Analysis.DataPrinters.Dot
 
 type EntryString = String
 type Colour = String

--- a/code/drasil-meta-analysis/app/typedepgen/TypeDepGen.hs
+++ b/code/drasil-meta-analysis/app/typedepgen/TypeDepGen.hs
@@ -32,11 +32,9 @@ data Entry = Entry { drasilPack :: DC.DrasilPack
 -- main controller function; initiates function calls to generate output file
 main :: IO ()
 main = do
-  -- directory variables (for scripts, code and output directories)
-  scriptsDirectory <- getCurrentDirectory
-  -- obtains code directory and output directory filepaths
-  let codeDirectory = takeDirectory scriptsDirectory
-      outputDirectory = codeDirectory ++ "/analysis/TypeDependencyGraphs"
+  -- directory variables (for, code and output directories)
+  codeDirectory <- getCurrentDirectory
+  let outputDirectory = codeDirectory ++ "/analysis/TypeDependencyGraphs"
 
   -- gets names + filepaths of all drasil- packages/directories
   drctyList <- DC.getDirectories codeDirectory "drasil-"

--- a/code/drasil-meta-analysis/app/typedepgen/TypeDepGen.hs
+++ b/code/drasil-meta-analysis/app/typedepgen/TypeDepGen.hs
@@ -5,18 +5,15 @@ module TypeDepGen (main) where
 import Data.List
 import System.IO
 import System.Directory
-import System.FilePath (takeDirectory)
 import Control.Monad
-import qualified Drasil.Meta.Analysis.DirectoryController as DC (createFolder, createFile, finder,
-  getDirectories, DrasilPack, FileName, FolderName, File(..), Folder(..))
+import qualified Drasil.Meta.Analysis.DirectoryController as DC (finder,
+  getDirectories, DrasilPack, FileName, File(..), Folder(..))
 import Drasil.Meta.Analysis.SourceCodeReaderT as SCRT (extractEntryData, EntryData(..),
   DataDeclRecord(..), DataDeclConstruct(..), NewtypeDecl(..), TypeDecl(..),
   DataTypeDeclaration(..))
-import Data.List.Split (splitOn)
 import Data.Char (toLower)
 import Drasil.Meta.Analysis.DataPrinters.Dot
 
-type EntryString = String
 type Colour = String
 
 -- Entry data type for storing entry data for each file entry

--- a/code/drasil-meta-analysis/lib/Drasil/Meta/Analysis/DataPrinters/Dot.hs
+++ b/code/drasil-meta-analysis/lib/Drasil/Meta/Analysis/DataPrinters/Dot.hs
@@ -1,5 +1,5 @@
 -- To generalize the use of dot printers in generating graphs
-module DataPrinters.Dot (digraph, subgraph,
+module Drasil.Meta.Analysis.DataPrinters.Dot (digraph, subgraph,
   makeEdgesDi, makeEdgesSub, makeNodesDi, makeNodesSub, replaceInvalidChars) where
 
 import System.IO

--- a/code/drasil-meta-analysis/lib/Drasil/Meta/Analysis/DataPrinters/HTML.hs
+++ b/code/drasil-meta-analysis/lib/Drasil/Meta/Analysis/DataPrinters/HTML.hs
@@ -1,4 +1,7 @@
-module Drasil.Meta.Analysis.DataPrinters.HTML where
+module Drasil.Meta.Analysis.DataPrinters.HTML (
+  mkhtmlTitle, mkhtmlHeader, mkhtmlEmptyCell, mkhtmlRow,
+  htmlDataTableTitle, htmlConfig, htmlEnd
+) where
 
 import Data.List.Split (splitOn)
 

--- a/code/drasil-meta-analysis/lib/Drasil/Meta/Analysis/DataPrinters/HTML.hs
+++ b/code/drasil-meta-analysis/lib/Drasil/Meta/Analysis/DataPrinters/HTML.hs
@@ -1,4 +1,4 @@
-module DataPrinters.HTML where
+module Drasil.Meta.Analysis.DataPrinters.HTML where
 
 import Data.List.Split (splitOn)
 

--- a/code/drasil-meta-analysis/lib/Drasil/Meta/Analysis/DirectoryController.hs
+++ b/code/drasil-meta-analysis/lib/Drasil/Meta/Analysis/DirectoryController.hs
@@ -1,5 +1,5 @@
 -- | Directory controller for SourceCodeReader.hs and SourceCodeReaderTypes.hs.
-module DirectoryController (createFolder, createFile, finder, getDirectories,
+module Drasil.Meta.Analysis.DirectoryController (createFolder, createFile, finder, getDirectories,
   DrasilPack, FileName, FolderName, File(..), Folder(..)) where
 
 import Data.List

--- a/code/drasil-meta-analysis/lib/Drasil/Meta/Analysis/DirectoryController.hs
+++ b/code/drasil-meta-analysis/lib/Drasil/Meta/Analysis/DirectoryController.hs
@@ -3,7 +3,6 @@ module Drasil.Meta.Analysis.DirectoryController (createFolder, createFile, finde
   DrasilPack, FileName, FolderName, File(..), Folder(..)) where
 
 import Data.List
-import System.IO
 import System.Directory
 import System.FilePath (joinPath)
 
@@ -68,9 +67,9 @@ finder folder = do
 getDirectories :: FilePath -> FilterPrefix -> IO [Folder]
 getDirectories directoryPath filterPrefix = do
   -- all raw directory contents
-  all <- listDirectory directoryPath
+  allPaths <- listDirectory directoryPath
   -- raw drasil- package directories + package names
-  let rawPackages = sort $ filter (isPrefixOf filterPrefix) all
+  let rawPackages = sort $ filter (isPrefixOf filterPrefix) allPaths
       packageNames = map (\\"drasil-") rawPackages
   -- convert list of directories into folder data types
       directories = zipWith (createFolder directoryPath) packageNames rawPackages

--- a/code/drasil-meta-analysis/lib/Drasil/Meta/Analysis/SourceCodeReaderCI.hs
+++ b/code/drasil-meta-analysis/lib/Drasil/Meta/Analysis/SourceCodeReaderCI.hs
@@ -58,7 +58,7 @@ stripWS = T.unpack . T.strip . T.pack
 -- enforces strict file reading; files can be closed to avoid memory exhaustion
 forceRead :: [a0] -> ()
 forceRead [] = ()
-forceRead (x:xs) = forceRead xs
+forceRead (_:xs) = forceRead xs
 
 -- index number, class + script lines, indexes list (for multi-line classes)
 getIndexes :: Int -> [String] -> [String] -> [Int]

--- a/code/drasil-meta-analysis/lib/Drasil/Meta/Analysis/SourceCodeReaderCI.hs
+++ b/code/drasil-meta-analysis/lib/Drasil/Meta/Analysis/SourceCodeReaderCI.hs
@@ -1,14 +1,14 @@
 -- | Source code reader for all types, classes, and instances in Drasil.
 -- Only records the names of types and classes, not contents.
 -- Meant to show instances of types within classes.
-module SourceCodeReaderCI (extractEntryData, EntryData(..)) where
+module Drasil.Meta.Analysis.SourceCodeReaderCI (extractEntryData, EntryData(..)) where
 
 import Data.List
 import System.IO
 import System.Directory
 import qualified Data.Text as T
 
-import DirectoryController as DC (FileName)
+import Drasil.Meta.Analysis.DirectoryController as DC (FileName)
 
 type DataName = String
 type NewtypeName = String

--- a/code/drasil-meta-analysis/lib/Drasil/Meta/Analysis/SourceCodeReaderT.hs
+++ b/code/drasil-meta-analysis/lib/Drasil/Meta/Analysis/SourceCodeReaderT.hs
@@ -116,7 +116,8 @@ removeNewlineGuard = filterNewline (const True) (isPrefixOf "|")
 
 -- Gets rid of automatically derived instances since we only care about type dependencies.
 removeDeriving :: [String] -> [String]
-removeDeriving = mapIf (isInfixOf "deriving ") $ \l -> unwords (take (fromJust (elemIndex "deriving" (words l))) $ words l )
+-- FIXME: we use `"deriving" ++ " "` so that this line doesn't crash while trying to analyze itself.
+removeDeriving = mapIf (isInfixOf ("deriving" ++ " ")) $ \l -> unwords (take (fromJust (elemIndex "deriving" (words l))) $ words l )
 
 -- Removes comments that are a part of datatype lines (drops everything after the comment symbol).
 removeComments :: [String] -> [String]

--- a/code/drasil-meta-analysis/lib/Drasil/Meta/Analysis/SourceCodeReaderT.hs
+++ b/code/drasil-meta-analysis/lib/Drasil/Meta/Analysis/SourceCodeReaderT.hs
@@ -348,5 +348,5 @@ stripWS = T.unpack . T.strip . T.pack
 -- enforces strict file reading; files can be closed to avoid memory exhaustion
 forceRead :: [a0] -> ()
 forceRead [] = ()
-forceRead (x:xs) = forceRead xs
+forceRead (_:xs) = forceRead xs
 

--- a/code/drasil-meta-analysis/lib/Drasil/Meta/Analysis/SourceCodeReaderT.hs
+++ b/code/drasil-meta-analysis/lib/Drasil/Meta/Analysis/SourceCodeReaderT.hs
@@ -1,5 +1,5 @@
 -- | Source code reader for type dependency graphs of all Drasil types.
-module SourceCodeReaderT (extractEntryData, EntryData(..), DataDeclRecord(..),
+module Drasil.Meta.Analysis.SourceCodeReaderT (extractEntryData, EntryData(..), DataDeclRecord(..),
  DataDeclConstruct(..), NewtypeDecl(..), TypeDecl(..), DataTypeDeclaration(..)) where
 
 import Data.List
@@ -10,7 +10,7 @@ import qualified Data.List.Split as L
 import Data.Maybe (fromJust)
 import Data.Char (isUpper)
 
-import DirectoryController as DC (FileName)
+import Drasil.Meta.Analysis.DirectoryController as DC (FileName)
 
 import Data.Containers.ListUtils (nubOrd)
 
@@ -116,7 +116,7 @@ removeNewlineGuard = filterNewline (const True) (isPrefixOf "|")
 
 -- Gets rid of automatically derived instances since we only care about type dependencies.
 removeDeriving :: [String] -> [String]
-removeDeriving = mapIf (isInfixOf "deriving ") $ \l -> unwords (take (fromJust (elemIndex "deriving" (words l))) $ words l)
+removeDeriving = mapIf (isInfixOf "deriving ") $ \l -> unwords (take (fromJust (elemIndex "deriving" (words l))) $ words l )
 
 -- Removes comments that are a part of datatype lines (drops everything after the comment symbol).
 removeComments :: [String] -> [String]

--- a/code/drasil-meta-analysis/package.yaml
+++ b/code/drasil-meta-analysis/package.yaml
@@ -1,0 +1,44 @@
+spec-version: 0.36.0
+name:         drasil-meta-analysis
+version:      0.1.1.0
+author:       "Dan Szymczak, Steven Palmer, Jacques Carette, Spencer Smith"
+maintainer:   "Jacques Carette"
+synopsis:     A framework for code and document generation for scientific software - meta-analysis SubPackage
+github:       JacquesCarette/Drasil
+homepage:     https://jacquescarette.github.io/Drasil/
+description:  Please see the README on GitHub at <https://github.com/JacquesCarette/Drasil#readme>
+
+language: Haskell2010
+default-extensions:
+- StrictData
+
+extra-source-files: []
+
+dependencies:
+- base >= 4.7 && < 5
+- containers
+- directory
+- filepath
+- split
+- text
+
+ghc-options:
+- -Wall
+- -Wredundant-constraints
+- -Wmissing-export-lists
+
+library:
+  source-dirs: lib
+
+executables:
+  classinstdepgen:
+    main: ClassInstDepGen
+    source-dirs: app/classinstdepgen
+    dependencies:
+    - drasil-meta-analysis
+
+  typedepgen:
+    main: TypeDepGen
+    source-dirs: app/typedepgen
+    dependencies:
+    - drasil-meta-analysis

--- a/code/drasil-meta-analysis/stack.yaml
+++ b/code/drasil-meta-analysis/stack.yaml
@@ -1,0 +1,4 @@
+resolver: lts-22.44
+
+packages:
+- .

--- a/code/hie.yaml
+++ b/code/hie.yaml
@@ -4,7 +4,7 @@ cradle:
       component: "drasil-build-artifacts:lib"
 
     - path: "drasil-build-artifacts/test"
-      component: "drasil-build-artifacts:test:layout-test"
+      component: "drasil-build-artifacts:test:drasil-build-artifacts-test"
 
     - path: "drasil-code/lib"
       component: "drasil-code:lib"
@@ -119,6 +119,15 @@ cradle:
 
     - path: "drasil-makefile/lib"
       component: "drasil-makefile:lib"
+
+    - path: "drasil-meta-analysis/lib"
+      component: "drasil-meta-analysis:lib"
+
+    - path: "drasil-meta-analysis/app/classinstdepgen/ClassInstDepGen.hs"
+      component: "drasil-meta-analysis:exe:classinstdepgen"
+
+    - path: "drasil-meta-analysis/app/typedepgen/TypeDepGen.hs"
+      component: "drasil-meta-analysis:exe:typedepgen"
 
     - path: "drasil-metadata/lib"
       component: "drasil-metadata:lib"

--- a/code/stable-website/index.html
+++ b/code/stable-website/index.html
@@ -652,6 +652,14 @@
                 </tr>
                 <tr>
                   <td>
+                    <a href="analysis/TypeDependencyGraphs/meta-analysis.svg">drasil-meta-analysis Types</a>
+                  </td>
+                  <td>
+                    <a href="analysis/ClassInstDep/packagegraphs/meta-analysis.svg">drasil-meta-analysis Class Instances</a>
+                  </td>
+                </tr>
+                <tr>
+                  <td>
                     <a href="analysis/TypeDependencyGraphs/printers.svg">drasil-printers Types</a>
                   </td>
                   <td>
@@ -728,6 +736,9 @@
               <li><a href="graphs/drasil-lang.pdf">drasil-lang</a></li>
               <li><a href="graphs/drasil-makefile.pdf">drasil-makefile</a></li>
               <li><a href="graphs/drasil-metadata.pdf">drasil-metadata</a></li>
+              <li>
+                <a href="graphs/drasil-meta-analysis.pdf">drasil-meta-analysis</a>
+              </li>
               <li><a href="graphs/drasil-printers.pdf">drasil-printers</a></li>
               <li><a href="graphs/drasil-system.pdf">drasil-system</a></li>
               <li><a href="graphs/drasil-theory.pdf">drasil-theory</a></li>

--- a/code/stack.yaml
+++ b/code/stack.yaml
@@ -53,6 +53,7 @@ packages:
 - drasil-docLang
 - drasil-makefile
 - drasil-metadata
+- drasil-meta-analysis
 - drasil-website
 - drasil-example/dblpend
 - drasil-example/sglpend


### PR DESCRIPTION
Closes #4966

Further cleanups and improvements to these scripts are still needed, but that can wait for future PRs.