### PR TITLE
revert(`Makefile`): don't clean `build/` as often to fix Deploy workflow

### DIFF
--- a/code/Makefile
+++ b/code/Makefile
@@ -323,7 +323,7 @@ $(filter %$(BUILD_P_SUFFIX), $(BUILD_PACKAGES)): %$(BUILD_P_SUFFIX): check_stack
 # No traceability graphs will be created, only the dot files.
 # Specific example targets will have the name exampleName_gen.
 # Alternatively, you can run an example by running `stack exec exampleName`.
-$(filter %$(GEN_E_SUFFIX), $(GEN_EXAMPLES)): %$(GEN_E_SUFFIX): %$(BC_E_SUFFIX)
+$(filter %$(GEN_E_SUFFIX), $(GEN_EXAMPLES)): %$(GEN_E_SUFFIX):
 	stack build $(stackArgs) "$(EEXE)"
 	@mkdir -p "$(BUILD_FOLDER)$(EDIR)"
 	cd "$(BUILD_FOLDER)$(EDIR)" && $(STACK_EXEC) -- "$(EEXE)"
@@ -521,7 +521,7 @@ deploy_code_path: $(DCP_EXAMPLES) ##@GOOL Find all code file paths for all examp
 #--------------------------------#
 
 # For more information, see the *.hs files in the drasil-website folder.
-website: clean_Website ##@Deploy First builds all Drasil packages, and then executes the drasil-website.
+website: ##@Deploy First builds all Drasil packages, and then executes the drasil-website.
 	stack build $(stackArgs) "drasil-website"
 	CUR_DIR="$(PWD)/" \
 	DEPLOY_FOLDER="$(CUR_DIR)$(DEPLOY_FOLDER)" \

--- a/code/drasil-build-artifacts/lib/Drasil/Build/Artifacts/FileLayout.hs
+++ b/code/drasil-build-artifacts/lib/Drasil/Build/Artifacts/FileLayout.hs
@@ -9,6 +9,7 @@ module Drasil.Build.Artifacts.FileLayout
     directory,
 
     -- ** Writing
+    OverwritePolicy(..),
     writeFiles,
   )
 where
@@ -18,7 +19,7 @@ import Data.Map.Strict qualified as M
 import Data.Maybe (fromMaybe)
 import Drasil.Build.Artifacts.FilePath (PathSegment, toPath, (</>))
 import Drasil.Build.Artifacts.Render (Renderable (..))
-import System.Directory.OsPath (createDirectory, doesPathExist)
+import System.Directory.OsPath (createDirectoryIfMissing, doesPathExist)
 import System.OsPath (OsPath, decodeUtf)
 
 -- | Container for laying out files in a single container for writing to disk.
@@ -70,21 +71,34 @@ insert v =
     (fileTree v)
 {-# INLINE insert #-}
 
+-- | When writing files or creating directories, is overwriting allowed?
+data OverwritePolicy = OverwriteAllowed | NeverOverwrite
+
 -- | Write a 'FileLayout' to disk about a base path.
 --
--- Disclaimer: Fails if files/directories already exist. This is problematic for
--- case-insensitive file systems where different paths reference the same.
-writeFiles :: (Renderable doc) => OsPath -> FileLayout doc -> IO ()
-writeFiles basePath layout = do
-  let targetPath = basePath </> pathSeg layout
+-- If the given 'OverwritePolicy' is 'NeverOverwrite', this will fail if the
+-- /top-level/ target path already exists. If it is 'OverwriteAllowed', it will
+-- overwrite existing files.
+--
+-- Disclaimer: For case-insensitive file systems where different paths in the
+-- layout might reference the same on-disk path, this code will fail.
+writeFiles :: (Renderable doc) => OverwritePolicy -> OsPath -> FileLayout doc -> IO ()
+writeFiles OverwriteAllowed basePath layout = writeFiles0 basePath layout
+writeFiles NeverOverwrite basePath layout = do
   exists <- doesPathExist targetPath
   if exists
     then error $ "Path already exists: " ++ show targetPath
-    else go basePath layout
+    else writeFiles0 basePath layout
   where
-    go currentPath (FileLayout fname (File content)) =
-      renderToFile (currentPath </> fname) content
-    go currentPath (FileLayout dname (Directory children)) = do
-      let nextPath = currentPath </> dname
-      createDirectory nextPath
-      F.traverse_ (\(n, c) -> go nextPath (FileLayout n c)) (M.toList children)
+    targetPath = basePath </> pathSeg layout
+
+-- Internal: `writeFiles` internal. It will create directories as needed and
+-- blindly overwrite any existing files as designated in the layout.
+writeFiles0 :: (Renderable doc) => OsPath -> FileLayout doc -> IO ()
+writeFiles0 currentPath (FileLayout fname (File content)) =
+  renderToFile (currentPath </> fname) content
+writeFiles0 currentPath (FileLayout dname (Directory children)) = do
+  let nextPath = currentPath </> dname
+  createDirectoryIfMissing False nextPath
+  F.traverse_ (\(n, c) -> writeFiles0 nextPath (FileLayout n c)) (M.toList children)
+{-# INLINE writeFiles0 #-}

--- a/code/drasil-gen/lib/Drasil/Generator/LessonPlan.hs
+++ b/code/drasil-gen/lib/Drasil/Generator/LessonPlan.hs
@@ -6,7 +6,8 @@ module Drasil.Generator.LessonPlan (
 
 import Control.Lens ((^.))
 
-import Drasil.Build.Artifacts (directory, file, localPath, ps, writeFiles)
+import Drasil.Build.Artifacts (OverwritePolicy (..), directory, file, localPath,
+  ps, writeFiles)
 import Drasil.DocumentLanguage.Notebook (LsnDesc, mkNb)
 import Language.Drasil (Stage (Equational))
 import Language.Drasil.Printers (Notation (Engineering), genJupyterLessonPlan, piSys)
@@ -26,4 +27,4 @@ exportLessonPlan plan nbDecl lsnFileName = do
           [ file [ps|{lsnFileName}.ipynb|] $ genJupyterLessonPlan pd
           ]
 
-  writeFiles localPath artifact
+  writeFiles OverwriteAllowed localPath artifact

--- a/code/drasil-gen/lib/Drasil/Generator/SRS.hs
+++ b/code/drasil-gen/lib/Drasil/Generator/SRS.hs
@@ -8,7 +8,8 @@ import Prelude hiding (id)
 import Control.Lens ((^.))
 import Text.PrettyPrint.HughesPJ (Doc)
 
-import Drasil.Build.Artifacts (FileLayout, directory, file, localPath, ps, writeFiles)
+import Drasil.Build.Artifacts (FileLayout, OverwritePolicy(..), directory, file,
+  localPath, ps, writeFiles)
 import Drasil.DocLang (mkGraphInfo)
 import Language.Drasil (Stage(Equational), Document(..), checkToC)
 import qualified Language.Drasil.Sentence.Combinators as S
@@ -46,8 +47,8 @@ exportSmithEtAlSrs syst srsDecl srsFileName = do
             [HTML, TeX, Jupyter, MDBook]
       traceyLayout = outputDot (mkGraphInfo syst') -- FIXME: This *MUST* use syst', NOT syst (or else it misses things!)!
   -- FIXME: Ultimately, there should be a single writeFiles call.
-  writeFiles localPath srsLayout
-  writeFiles localPath traceyLayout
+  writeFiles OverwriteAllowed localPath srsLayout
+  writeFiles OverwriteAllowed localPath traceyLayout
 
 -- | Internal: Dumps the chunk maps to disk if the `DEBUG_ENV` environment
 -- variable is non-empty.
@@ -57,7 +58,7 @@ debugDump si = do
   maybeDebugging <- lookupEnv "DEBUG_ENV"
   case maybeDebugging of
     (Just (_:_)) -> do
-      writeFiles localPath $ dumpEverything si
+      writeFiles OverwriteAllowed localPath $ dumpEverything si
     _ -> mempty
 
 -- | Internal: Creates a `FileLayout` for the SRS in a specific format.

--- a/code/drasil-gen/lib/Drasil/Generator/Website.hs
+++ b/code/drasil-gen/lib/Drasil/Generator/Website.hs
@@ -6,7 +6,8 @@ module Drasil.Generator.Website
 where
 
 import Control.Lens ((^.))
-import Drasil.Build.Artifacts (directory, file, localPath, ps, writeFiles)
+import Drasil.Build.Artifacts (OverwritePolicy (..), directory, file, localPath,
+  ps, writeFiles)
 import Drasil.Generator.Formats (Filename)
 import Drasil.System (DrasilWebsite, systemdb, webRefs)
 import Language.Drasil (Document, Stage (Equational))
@@ -28,4 +29,4 @@ exportWebsite syst doc fileName = do
               ]
           ]
 
-  writeFiles localPath website
+  writeFiles OverwriteAllowed localPath website


### PR DESCRIPTION
In principle, this was a good change introduced in `FileLayout`'s `writeFiles`, but the Makefile just does not work well with this assumption because of how important file-overwriting was as as a previous assumption.

For reference, this is to fix an issue with the Deploy actions script where it wasn't picking up any recently built files because of how often the build folder was getting cleaned:

<img width="1037" height="776" alt="Screenshot 2026-05-26 at 9 03 05 PM" src="https://github.com/user-attachments/assets/d40ba3b6-da32-473b-9c0b-5c30be70ff22" />

