### PR TITLE
chore: remove unused `[LabelledContent]` field from `PrintingInformation`

### DIFF
--- a/code/drasil-code/lib/Language/Drasil/Code/Imperative/Generator.hs
+++ b/code/drasil-code/lib/Language/Drasil/Code/Imperative/Generator.hs
@@ -101,7 +101,7 @@ generator l dt sd chs cs = let
   _loggedSpaces = [], -- Used to prevent duplicate logs added to design log
   currentScope = Global
 }
-  where pinfo = piSys (cs ^. systemdb) (cs ^. refTable) Implementation Scientific []
+  where pinfo = piSys (cs ^. systemdb) (cs ^. refTable) Implementation Scientific
         (mcm, concLog) = runState (chooseConcept chs) []
         showDate Show = dt
         showDate Hide = ""

--- a/code/drasil-gen/lib/Drasil/Generator/LessonPlan.hs
+++ b/code/drasil-gen/lib/Drasil/Generator/LessonPlan.hs
@@ -18,7 +18,7 @@ import Drasil.System (LessonPlan, lsnPlanRefs, systemdb)
 exportLessonPlan :: LessonPlan -> LsnDesc -> String -> IO ()
 exportLessonPlan plan nbDecl lsnFileName = do
   let nb = mkNb plan nbDecl S.forT
-      printSetting = piSys (plan ^. systemdb) (plan ^. lsnPlanRefs) Equational Engineering []
+      printSetting = piSys (plan ^. systemdb) (plan ^. lsnPlanRefs) Equational Engineering
       pd = makeDocument printSetting nb
       artifact =
         directory

--- a/code/drasil-gen/lib/Drasil/Generator/SRS.hs
+++ b/code/drasil-gen/lib/Drasil/Generator/SRS.hs
@@ -20,7 +20,7 @@ import Drasil.Makefile ((+:+), makeS, mkCheckedCommand, mkCommand,
 import Drasil.Metadata (watermark)
 import Drasil.SRSDocument (SRSDecl, mkDoc)
 import Language.Drasil.Printing.Import (makeDocument, makeProject)
-import Drasil.System (SmithEtAlSRS, refTable, systemdb, lbldCntnt)
+import Drasil.System (SmithEtAlSRS, refTable, systemdb)
 import System.Environment (lookupEnv)
 
 import Drasil.Generator.ChunkDump (dumpEverything)
@@ -32,7 +32,7 @@ import Drasil.Generator.SRS.TypeCheck (typeCheckSI)
 exportSmithEtAlSrs :: SmithEtAlSRS -> SRSDecl -> String -> IO ()
 exportSmithEtAlSrs syst srsDecl srsFileName = do
   let (srs, syst') = mkDoc syst srsDecl S.forT
-      pinfo = piSys (syst' ^. systemdb) (syst' ^. refTable) Equational Engineering (syst' ^. lbldCntnt)
+      pinfo = piSys (syst' ^. systemdb) (syst' ^. refTable) Equational Engineering
   debugDump syst'
   typeCheckSI syst' -- FIXME: This should be done on `System` creation *or* chunk creation!
   let srsLayout =

--- a/code/drasil-gen/lib/Drasil/Generator/Website.hs
+++ b/code/drasil-gen/lib/Drasil/Generator/Website.hs
@@ -16,7 +16,7 @@ import Language.Drasil.Printing.Import (makeDocument)
 -- | Generate a "website" (an HTML file with a CSS stylesheet) softifact.
 exportWebsite :: DrasilWebsite -> Document -> Filename -> IO ()
 exportWebsite syst doc fileName = do
-  let printSetting = piSys (syst ^. systemdb) (syst ^. webRefs) Equational Engineering []
+  let printSetting = piSys (syst ^. systemdb) (syst ^. webRefs) Equational Engineering
       pd = makeDocument printSetting doc
       website =
         directory

--- a/code/drasil-printers/lib/Language/Drasil/Printing/PrintingInformation.hs
+++ b/code/drasil-printers/lib/Language/Drasil/Printing/PrintingInformation.hs
@@ -4,7 +4,7 @@
 module Language.Drasil.Printing.PrintingInformation (
     PrintingInformation
   , Notation(..)
-  , sysdb, refTable, stg, notation, lbldCntnt
+  , sysdb, refTable, stg, notation
   , piSys, refFind
 ) where
 
@@ -13,7 +13,7 @@ import qualified Data.Map.Strict as M
 import Data.Maybe (fromMaybe)
 
 import Drasil.Database (UID, ChunkDB)
-import Language.Drasil (Stage(..), Reference, LabelledContent)
+import Language.Drasil (Stage(..), Reference)
 
 -- | Notation can be scientific or for engineering.
 data Notation = Scientific
@@ -25,12 +25,11 @@ data PrintingInformation =
      , _refTable :: M.Map UID Reference
      , _stg :: Stage
      , _notation :: Notation
-     , _lbldCntnt :: [LabelledContent]
      }
 makeLenses ''PrintingInformation
 
 -- | Builds a document's printing information based on the system information.
-piSys :: ChunkDB -> M.Map UID Reference -> Stage -> Notation -> [LabelledContent] -> PrintingInformation
+piSys :: ChunkDB -> M.Map UID Reference -> Stage -> Notation -> PrintingInformation
 piSys = PI
 
 refFind :: UID -> PrintingInformation -> Reference


### PR DESCRIPTION
As of JacquesCarette/Drasil#4972, this field was unused!