### PR TITLE
Switched `instanceVarAccess` to take `SValue` instead of `SVariable`

### DIFF
--- a/code/drasil-code/lib/Language/Drasil/Code/Imperative/Import.hs
+++ b/code/drasil-code/lib/Language/Drasil/Code/Imperative/Import.hs
@@ -131,7 +131,7 @@ inputVariable Bundled Var v = do
   g <- get
   inClsName <- genICName InputParameters
   ip <- mkVar (quantvar inParams)
-  return $ if currentClass g == inClsName then instanceVarSelf v else ip $-> v
+  return $ if currentClass g == inClsName then instanceVarSelf v else (valueOf ip) $-> v
 inputVariable Bundled Const v = do
   ip <- mkVar (quantvar inParams)
   classVariable ip v
@@ -149,7 +149,7 @@ constVariable :: (OOProg r) => ConstantStructure -> ConstantRepr ->
 constVariable (Store Unbundled) _ v = return v
 constVariable (Store Bundled) Var v = do
   cs <- mkVar (quantvar consts)
-  return $ cs $-> v
+  return $ (valueOf cs) $-> v
 constVariable (Store Bundled) Const v = do
   cs <- mkVar (quantvar consts)
   classVariable cs v
@@ -182,7 +182,7 @@ mkVal v = do
   let toGOOLVal Nothing = value (v ^. uid) (codeName v) (convTypeOO t)
       toGOOLVal (Just o) = do
         ot <- codeType o
-        return $ valueOf $ instanceVarAccess (var (codeName o) (convTypeOO ot))
+        return $ valueOf $ instanceVarAccess (valueOf $ var (codeName o) (convTypeOO ot))
           (var (codeName v) (convTypeOO t))
   toGOOLVal (v ^. obv)
 
@@ -193,7 +193,7 @@ mkVar v = do
   let toGOOLVar Nothing = variable (codeName v) (convTypeOO t)
       toGOOLVar (Just o) = do
         ot <- codeType o
-        return $ instanceVarAccess (var (codeName o) (convTypeOO ot))
+        return $ instanceVarAccess (valueOf $ var (codeName o) (convTypeOO ot))
           (var (codeName v) (convTypeOO t))
   toGOOLVar (v ^. obv)
 

--- a/code/drasil-code/lib/Language/Drasil/Code/Imperative/Import.hs
+++ b/code/drasil-code/lib/Language/Drasil/Code/Imperative/Import.hs
@@ -131,7 +131,7 @@ inputVariable Bundled Var v = do
   g <- get
   inClsName <- genICName InputParameters
   ip <- mkVar (quantvar inParams)
-  return $ if currentClass g == inClsName then instanceVarSelf v else (valueOf ip) $-> v
+  return $ if currentClass g == inClsName then instanceVarSelf v else valueOf ip $-> v
 inputVariable Bundled Const v = do
   ip <- mkVar (quantvar inParams)
   classVariable ip v
@@ -149,7 +149,7 @@ constVariable :: (OOProg r) => ConstantStructure -> ConstantRepr ->
 constVariable (Store Unbundled) _ v = return v
 constVariable (Store Bundled) Var v = do
   cs <- mkVar (quantvar consts)
-  return $ (valueOf cs) $-> v
+  return $ valueOf cs $-> v
 constVariable (Store Bundled) Const v = do
   cs <- mkVar (quantvar consts)
   classVariable cs v

--- a/code/drasil-gool/lib/Drasil/GOOL/InterfaceGOOL.hs
+++ b/code/drasil-gool/lib/Drasil/GOOL/InterfaceGOOL.hs
@@ -146,11 +146,11 @@ class (VariableSym r, OOTypeSym r) => OOVariableSym r where
   -- performs any necessary imports and creates `C.v`
   extClassVarAccess :: VSType r -> SVariable r -> SVariable r
   -- | Given an instance `i` and an instance-level variable `v`, creates `i.v`
-  instanceVarAccess :: SVariable r -> SVariable r -> SVariable r
+  instanceVarAccess :: SValue r -> SVariable r -> SVariable r
   -- | Given a variable `v`, creates `self.v`
   instanceVarSelf   :: SVariable r -> SVariable r
 
-($->) :: (OOVariableSym r) => SVariable r -> SVariable r -> SVariable r
+($->) :: (OOVariableSym r) => SValue r -> SVariable r -> SVariable r
 infixl 9 $->
 ($->) = instanceVarAccess
 

--- a/code/drasil-gool/lib/Drasil/Shared/LanguageRenderer/CommonPseudoOO.hs
+++ b/code/drasil-gool/lib/Drasil/Shared/LanguageRenderer/CommonPseudoOO.hs
@@ -142,7 +142,7 @@ classVarAccess f c' v'= do
   toState $ classVarAccessCheck vr
 
 instanceVarSelf :: (OORenderSym r) => SVariable r -> SVariable r
-instanceVarSelf = IG.instanceVarAccess IG.self
+instanceVarSelf = IG.instanceVarAccess (IC.valueOf IG.self)
 
 indexOf :: (OORenderSym r) => Label -> SValue r -> SValue r -> SValue r
 indexOf f l v = IC.indexToInt $ IG.objAccess l (IG.func f IC.int [v])

--- a/code/drasil-gool/lib/Drasil/Shared/LanguageRenderer/LanguagePolymorphic.hs
+++ b/code/drasil-gool/lib/Drasil/Shared/LanguageRenderer/LanguagePolymorphic.hs
@@ -47,7 +47,7 @@ import Drasil.Shared.RendererClassesCommon (CommonRenderSym, RenderType(..),
   RenderFunction(funcFromData), FunctionElim(functionType),
   RenderStatement(stmtFromData), StatementElim(statementTerm),
   MethodTypeSym(mType), RenderParam(paramFromData), RenderMethod(commentedFunc),
-  BlockCommentSym(..))
+  BlockCommentSym(..), ValueElim (value))
 import qualified Drasil.Shared.RendererClassesCommon as S (RenderValue(call),
   InternalListFunc (listAddFunc, listAppendFunc, listAccessFunc, listSetFunc),
   RenderStatement(stmt), InternalIOStmt(..))
@@ -196,14 +196,14 @@ classVarAccessCheck v = classVarCS (variableBind v)
           "classVarAccess can only be used to access class-level variables"
         classVarCS ClassLevel = v
 
-instanceVarAccess :: (CommonRenderSym r) => SVariable r -> SVariable r -> SVariable r
+instanceVarAccess :: (CommonRenderSym r) => SValue r -> SVariable r -> SVariable r
 instanceVarAccess o' v' = do
   o <- o'
   v <- v'
   let instanceVarAccess' ClassLevel = error
         "Cannot access class-level variables through an object, use classVarAccess instead"
-      instanceVarAccess' InstanceLevel = mkVar (variableName o `access` variableName v)
-        (variableType v) (R.instanceVarAccess (RC.variable o) (RC.variable v))
+      instanceVarAccess' InstanceLevel = mkVar (render (value o) `access` variableName v)
+        (variableType v) (R.instanceVarAccess (RC.value o) (RC.variable v))
   instanceVarAccess' (variableBind v)
 
 arrayElem :: (OORenderSym r) => SValue r -> SVariable r -> SVariable r


### PR DESCRIPTION
This was annoying me for a while, and would've forced me to make `arrayLength` also take a variable for the array, because some languages encode `length` as an instance variable.

It'll also allow us to chain method calls together, e.g.

```python
[1..10].sorted().filter(isEven).map(\x -> x^2)
```
Obviously that code isn't quite valid, but the idea of it works. Each intermediate method returns a new array, which lets you chain method calls together. Letting GOOL take a value instead of a variable for the instance will allow us to do the same.