### PR TITLE
fix(HLS/`drasil-metadata`): use `makeRelativeToProject` to let GHC/HLS pick up correct path

### DIFF
--- a/code/drasil-metadata/lib/Drasil/Metadata/Drasil.hs
+++ b/code/drasil-metadata/lib/Drasil/Metadata/Drasil.hs
@@ -4,7 +4,7 @@ module Drasil.Metadata.Drasil (DrasilMeta(..), drasilMetaCfg) where
 import Data.Maybe (fromMaybe)
 import Data.Aeson (decodeFileStrict, FromJSON, ToJSON)
 import GHC.Generics (Generic)
-import Language.Haskell.TH.Syntax (Lift, addDependentFile)
+import Language.Haskell.TH.Syntax (Lift, addDependentFile, makeRelativeToProject)
 import Language.Haskell.TH (Exp, Q, runIO)
 
 {-
@@ -24,6 +24,7 @@ instance FromJSON DrasilMeta
 drasilMetaCfg :: Q Exp
 drasilMetaCfg = do
   let fp = "lib/Drasil/Metadata/Drasil.json"
-  maybeDM <- runIO (decodeFileStrict fp :: IO (Maybe DrasilMeta))
-  addDependentFile fp
+  absPath <- makeRelativeToProject fp
+  maybeDM <- runIO (decodeFileStrict absPath :: IO (Maybe DrasilMeta))
+  addDependentFile absPath
   [| fromMaybe (error "could not read in the drasil metadata file") maybeDM |]


### PR DESCRIPTION
This PR fixes HLS support in `drasil-metadata`.

Because we have to use a relative path here, when we open up the `code/` folder in our editors, HLS spins up GHC in the `code/` folder, not the `drasil-metadata` folder. So, HLS incorrectly (not its fault! It is doing the correct thing here!) catches a bad file path when we splice `drasilMetaCfg`. This breaks HLS support in `drasil-metadata`. Using `makeRelativeToProject` fixes the file path for us automatically.