### PR TITLE
refactor(`CodeSpec`): remove `nub` hack for filtering out manually created duplicate inputs & derived inputs

### DIFF
--- a/code/drasil-code/lib/Language/Drasil/CodeSpec.hs
+++ b/code/drasil-code/lib/Language/Drasil/CodeSpec.hs
@@ -169,7 +169,7 @@ oldcodeSpec sys@S.ICO{ S._inputs = ins
       -- TODO: When we have better DEModels, we should be deriving our ODE information
       --       directly from the instance models (ims) instead of directly from the choices.
       outs' = map quantvar $ NE.toList outs
-      allInputs = nub $ inputs' ++ map quantvar derived
+      allInputs = inputs' ++ map quantvar derived
       exOrder = solveExecOrder rels (allInputs ++ map quantvar cnsts) outs' db
   in OldCodeSpec {
         _pName = n,


### PR DESCRIPTION
This is currently unnecessary, as we don't have issue with this (yay!). It is also good to remove this because it does this is not the right solution for this issue (if it were to occur, and if/when it does, we should know about it). I believe our work on `drasil-code` will soon creep up on this anyways.