### PR TITLE
refactor(`GetChunks.hs`): remove `nub` hack that avoids duplicate `DQD` finding

### DIFF
--- a/code/drasil-docLang/lib/Drasil/GetChunks.hs
+++ b/code/drasil-docLang/lib/Drasil/GetChunks.hs
@@ -5,7 +5,7 @@ module Drasil.GetChunks (
   resolveBibliography
 ) where
 
-import Data.List (nub, sortBy)
+import Data.List (sortBy)
 import Data.Maybe (mapMaybe)
 import qualified Data.Set as Set
 
@@ -33,11 +33,11 @@ combine' a m = zipWith dqdQd (vars a m) (concpt' a m)
 
 -- | Gets a list of defined quantities ('DefinedQuantityDict's) from 'Sentence's and expressions that are contained in the database ('ChunkDB').
 ccss :: [Sentence] -> [ModelExpr] -> ChunkDB -> [DefinedQuantityDict]
-ccss s e c = nub $ concatMap (`combine` c) s ++ concatMap (`combine'` c) e
+ccss s e c = concatMap (`combine` c) s ++ concatMap (`combine'` c) e
 
 -- | Gets a list of quantities ('DefinedQuantityDict's) from 'Sentence's and expressions that are contained in the database ('ChunkDB').
 ccss' :: [Sentence] -> [ModelExpr] -> ChunkDB -> [DefinedQuantityDict]
-ccss' s e c = nub $ concatMap (`vars'` c) s ++ concatMap (`vars` c) e
+ccss' s e c = concatMap (`vars'` c) s ++ concatMap (`vars` c) e
 
 -- | Gets a list of concepts ('ConceptChunk') from a 'Sentence' in order to print.
 concpt :: Sentence -> ChunkDB -> [Sentence]


### PR DESCRIPTION
Should it arise, we should let this kind of error happen so we have reason to clean up this code correctly instead.