### PR TITLE
refactor(`makeCSS`): remove unnecessary extra argument and rename to `genericCSS`

### DIFF
--- a/code/drasil-gen/lib/Drasil/Generator/SRS.hs
+++ b/code/drasil-gen/lib/Drasil/Generator/SRS.hs
@@ -10,7 +10,7 @@ import Control.Lens ((^.))
 import Drasil.DocLang (mkGraphInfo)
 import Drasil.FileHandling (FileLayout, directory, file, ps)
 import Language.Drasil (Stage(Equational), Document(..), checkToC)
-import Language.Drasil.Printers (makeCSS, genHTML, genTeX,
+import Language.Drasil.Printers (genericCSS, genHTML, genTeX,
   genMDBook, Notation(Engineering), piSys, PrintingInformation,
   genJupyterSRS)
 import Drasil.Makefile ((+:+), makeS, mkCheckedCommand, mkCommand,
@@ -50,7 +50,7 @@ prntDoc d pinfo fn Jupyter =
   [file [ps|{fn}.ipynb|] $ genJupyterSRS $ makeDocument pinfo d]
 prntDoc d pinfo fn HTML =
   [ file [ps|{fn}.html|] $ genHTML fn $ makeDocument pinfo d,
-    file [ps|{fn}.css|] $ makeCSS d
+    file [ps|{fn}.css|] genericCSS
   ]
 prntDoc d@(Document _ _ st _) pinfo fn TeX =
   [ file [ps|{fn}.tex|] $ genTeX (makeDocument pinfo $ checkToC d) st pinfo,

--- a/code/drasil-gen/lib/Drasil/Generator/Website.hs
+++ b/code/drasil-gen/lib/Drasil/Generator/Website.hs
@@ -11,14 +11,14 @@ import Control.Lens ((^.))
 import Drasil.FileHandling (FileLayout, file, ps)
 import Drasil.System (DrasilWebsite, systemdb, webRefs)
 import Language.Drasil (Document, Stage (Equational))
-import Language.Drasil.Printers (Notation (Engineering), genHTML, makeCSS, piSys)
+import Language.Drasil.Printers (Notation (Engineering), genHTML, genericCSS, piSys)
 import Language.Drasil.Printing.Import (makeDocument)
 
 -- | Generate Drasil's website (an HTML file with a CSS stylesheet).
 genWebsite :: DrasilWebsite -> Document -> [FileLayout]
 genWebsite syst doc =
   [ file [ps|index.html|] $ genHTML "index" pd,
-    file [ps|index.css|] $ makeCSS doc
+    file [ps|index.css|] genericCSS
   ]
   where
     printSetting = piSys (syst ^. systemdb) (syst ^. webRefs) Equational Engineering

--- a/code/drasil-printers/lib/Language/Drasil/HTML/CSS.hs
+++ b/code/drasil-printers/lib/Language/Drasil/HTML/CSS.hs
@@ -1,15 +1,14 @@
 -- | Defines functions to create accompanying .css files for HTML generators.
 module Language.Drasil.HTML.CSS (
-  makeCSS, linkCSS
+  genericCSS, linkCSS
 ) where
 
 import Text.PrettyPrint (Doc, text, vcat)
 
-import Language.Drasil (Document)
-
--- | Generates the CSS selectors necessary for a document.
-makeCSS :: Document -> Doc
-makeCSS _ = vcat [
+-- | Generic CSS used for stylizing the 'LayoutObj' language when outputted in
+-- HTML format.
+genericCSS :: Doc
+genericCSS = vcat [
 -- TODO: Autogenerate necessary css selectors only, make CSS configurable
   text "body {min-width: 400px; max-width: 1400px;}",
   text ".title {text-align: center;}",

--- a/code/drasil-printers/lib/Language/Drasil/Printers.hs
+++ b/code/drasil-printers/lib/Language/Drasil/Printers.hs
@@ -2,8 +2,8 @@ module Language.Drasil.Printers (
   -- * HTML
   -- ** Printer
     genHTML
-  -- ** Helpers
-  , makeCSS
+  -- ** CSS
+  , genericCSS
   -- * Markdown
   -- ** Printer
   , makeMd
@@ -24,7 +24,7 @@ module Language.Drasil.Printers (
   , PrintingInformation, piSys, Notation(..)
 ) where
 
-import Language.Drasil.HTML.CSS (makeCSS)
+import Language.Drasil.HTML.CSS (genericCSS)
 import Language.Drasil.HTML.Print (genHTML)
 import Language.Drasil.JSON.Print (genJupyterLessonPlan, genJupyterSRS)
 import Language.Drasil.Markdown.Print (genMDBook)


### PR DESCRIPTION
The argument was not used.