### PR TITLE
refactor(`drasil-docLang`): don't re-export external modules

### DIFF
--- a/code/drasil-docLang/lib/Drasil/SRSDocument.hs
+++ b/code/drasil-docLang/lib/Drasil/SRSDocument.hs
@@ -2,7 +2,6 @@
 -- This aims to reduce clutter at the top of every @Body.hs@ file in the Drasil examples.
 -- If an import is changed here, it will be changed for every example.
 module Drasil.SRSDocument (
-  SmithEtAlSRS(..),
   -- * Document section types needed for a SRS
   -- | Imported from "Drasil.DocDecl"
   SRSDecl, DocSection(..), ReqrmntSec(..), ReqsSub(..),
@@ -30,7 +29,6 @@ module Drasil.SRSDocument (
   purpDoc           -- Drasil.Sections.Introduction
   ) where
 
-import Drasil.System (SmithEtAlSRS(..))
 import Drasil.DocLang (
   -- Drasil.DocumentLanguage.Core
   AppndxSec(..), AuxConstntSec(..),

--- a/code/drasil-docLang/lib/Drasil/SRSDocument.hs
+++ b/code/drasil-docLang/lib/Drasil/SRSDocument.hs
@@ -2,9 +2,7 @@
 -- This aims to reduce clutter at the top of every @Body.hs@ file in the Drasil examples.
 -- If an import is changed here, it will be changed for every example.
 module Drasil.SRSDocument (
-  -- * Chunk database types and functions
-  -- | Imported from "Database.Drasil"
-  ChunkDB, SmithEtAlSRS(..), -- FIXME: This should not be exported here!!
+  SmithEtAlSRS(..),
   -- * Document section types needed for a SRS
   -- | Imported from "Drasil.DocDecl"
   SRSDecl, DocSection(..), ReqrmntSec(..), ReqsSub(..),
@@ -32,7 +30,6 @@ module Drasil.SRSDocument (
   purpDoc           -- Drasil.Sections.Introduction
   ) where
 
-import Drasil.Database (ChunkDB)
 import Drasil.System (SmithEtAlSRS(..))
 import Drasil.DocLang (
   -- Drasil.DocumentLanguage.Core

--- a/code/drasil-example/dblpend/lib/Drasil/DblPend/Body.hs
+++ b/code/drasil-example/dblpend/lib/Drasil/DblPend/Body.hs
@@ -12,7 +12,7 @@ import Theory.Drasil (TheoryModel)
 import Drasil.SRSDocument
 import Drasil.Generator (withCommonKnowledge)
 import qualified Drasil.DocLang.SRS as SRS
-import Drasil.System (mkSmithEtAlICO)
+import Drasil.System (SmithEtAlSRS, mkSmithEtAlICO)
 
 import Language.Drasil.Chunk.Concept.NamedCombinators
 import qualified Language.Drasil.NaturalLanguage.English.NounPhrase.Combinators as NP

--- a/code/drasil-example/dblpend/lib/Drasil/DblPend/Body.hs
+++ b/code/drasil-example/dblpend/lib/Drasil/DblPend/Body.hs
@@ -5,6 +5,7 @@ module Drasil.DblPend.Body (
   userCharacteristicsIntro, tMods
 ) where
 
+import Drasil.Database (ChunkDB)
 import Language.Drasil hiding (organization, section)
 import qualified Language.Drasil.Development as D
 import Theory.Drasil (TheoryModel)

--- a/code/drasil-example/gamephysics/lib/Drasil/GamePhysics/Body.hs
+++ b/code/drasil-example/gamephysics/lib/Drasil/GamePhysics/Body.hs
@@ -1,5 +1,6 @@
 module Drasil.GamePhysics.Body (mkSRS, si) where
 
+import Drasil.Database (ChunkDB)
 import Language.Drasil hiding (organization, section)
 import Drasil.SRSDocument
 import Drasil.Generator (withCommonKnowledge)

--- a/code/drasil-example/gamephysics/lib/Drasil/GamePhysics/Body.hs
+++ b/code/drasil-example/gamephysics/lib/Drasil/GamePhysics/Body.hs
@@ -9,7 +9,7 @@ import Language.Drasil.Chunk.Concept.NamedCombinators
 import qualified Language.Drasil.Development as D
 import Drasil.Document.Contents (enumBulletU, foldlSP, foldlSPCol)
 import qualified Language.Drasil.Sentence.Combinators as S
-import Drasil.System (mkSmithEtAlICO)
+import Drasil.System (SmithEtAlSRS, mkSmithEtAlICO)
 
 import Drasil.Sentence.Combinators (bulletFlat, bulletNested)
 import Data.Drasil.Concepts.Documentation as Doc (assumption, concept,

--- a/code/drasil-example/glassbr/lib/Drasil/GlassBR/Body.hs
+++ b/code/drasil-example/glassbr/lib/Drasil/GlassBR/Body.hs
@@ -16,7 +16,7 @@ import qualified Language.Drasil.Sentence.Combinators as S
 import Drasil.Document.Contents (enumBulletU, foldlSP, foldlSPCol)
 import Drasil.Sentence.Combinators (bulletFlat, bulletNested, tAndDOnly, tAndDWAcc, noRefs,
   tAndDWSym)
-import Drasil.System (mkSmithEtAlICO)
+import Drasil.System (SmithEtAlSRS, mkSmithEtAlICO)
 
 import Data.Drasil.Concepts.Computation (computerApp, inDatum)
 import Data.Drasil.Concepts.Documentation as Doc (appendix, assumption,

--- a/code/drasil-example/glassbr/lib/Drasil/GlassBR/Body.hs
+++ b/code/drasil-example/glassbr/lib/Drasil/GlassBR/Body.hs
@@ -3,9 +3,9 @@ module Drasil.GlassBR.Body (mkSRS, si) where
 
 import Control.Lens ((^.))
 
+import Drasil.Database (ChunkDB)
 import Language.Drasil hiding (organization, section, variable)
 import qualified Language.Drasil.Development as D
-
 import Drasil.SRSDocument
 import Drasil.DocLang (auxSpecSent, termDefnF')
 import Drasil.Generator (withCommonKnowledge)

--- a/code/drasil-example/hghc/lib/Drasil/HGHC/Body.hs
+++ b/code/drasil-example/hghc/lib/Drasil/HGHC/Body.hs
@@ -4,7 +4,7 @@ import Drasil.Database (ChunkDB)
 import Language.Drasil hiding (Manual) -- Citation name conflict. FIXME: Move to different namespace
 import Drasil.SRSDocument
 import Drasil.Generator (withCommonKnowledge)
-import Drasil.System (mkSmithEtAlICO)
+import Drasil.System (SmithEtAlSRS, mkSmithEtAlICO)
 
 import Drasil.HGHC.HeatTransfer (fp, dataDefs, htInputs, htOutputs,
     nuclearPhys, symbols)

--- a/code/drasil-example/hghc/lib/Drasil/HGHC/Body.hs
+++ b/code/drasil-example/hghc/lib/Drasil/HGHC/Body.hs
@@ -1,5 +1,6 @@
 module Drasil.HGHC.Body (si, mkSRS) where
 
+import Drasil.Database (ChunkDB)
 import Language.Drasil hiding (Manual) -- Citation name conflict. FIXME: Move to different namespace
 import Drasil.SRSDocument
 import Drasil.Generator (withCommonKnowledge)

--- a/code/drasil-example/pdcontroller/lib/Drasil/PDController/Body.hs
+++ b/code/drasil-example/pdcontroller/lib/Drasil/PDController/Body.hs
@@ -1,5 +1,6 @@
 module Drasil.PDController.Body (si, mkSRS, pidODEInfo) where
 
+import Drasil.Database (ChunkDB)
 import Language.Drasil
 import Drasil.SRSDocument
 import Drasil.Generator (withCommonKnowledge)

--- a/code/drasil-example/pdcontroller/lib/Drasil/PDController/Body.hs
+++ b/code/drasil-example/pdcontroller/lib/Drasil/PDController/Body.hs
@@ -6,7 +6,7 @@ import Drasil.SRSDocument
 import Drasil.Generator (withCommonKnowledge)
 import qualified Drasil.DocLang.SRS as SRS (inModel)
 import qualified Language.Drasil.Sentence.Combinators as S
-import Drasil.System (mkSmithEtAlICO)
+import Drasil.System (SmithEtAlSRS, mkSmithEtAlICO)
 
 import Data.Drasil.Concepts.Math (ode)
 import Data.Drasil.Quantities.Physics (physicscon)

--- a/code/drasil-example/projectile/lib/Drasil/Projectile/Body.hs
+++ b/code/drasil-example/projectile/lib/Drasil/Projectile/Body.hs
@@ -1,5 +1,6 @@
 module Drasil.Projectile.Body (si, mkSRS) where
 
+import Drasil.Database (ChunkDB)
 import Language.Drasil
 import qualified Language.Drasil.Development as D
 import Drasil.SRSDocument

--- a/code/drasil-example/projectile/lib/Drasil/Projectile/Body.hs
+++ b/code/drasil-example/projectile/lib/Drasil/Projectile/Body.hs
@@ -11,7 +11,7 @@ import qualified Language.Drasil.Sentence.Combinators as S
 import qualified Drasil.DocLang.SRS as SRS
 import Drasil.Document.Contents (foldlSP, foldlSPCol)
 import Drasil.Sentence.Combinators (bulletNested, bulletFlat)
-import Drasil.System (mkSmithEtAlICO)
+import Drasil.System (SmithEtAlSRS, mkSmithEtAlICO)
 
 import Data.Drasil.Concepts.Computation (inDatum)
 import Data.Drasil.Concepts.Documentation (analysis, physics, problem,

--- a/code/drasil-example/sglpend/lib/Drasil/SglPend/Body.hs
+++ b/code/drasil-example/sglpend/lib/Drasil/SglPend/Body.hs
@@ -12,7 +12,7 @@ import Drasil.Generator (withCommonKnowledge)
 import qualified Drasil.DocLang.SRS as SRS
 import Language.Drasil.Chunk.Concept.NamedCombinators (the)
 import qualified Language.Drasil.Sentence.Combinators as S
-import Drasil.System (mkSmithEtAlICO)
+import Drasil.System (SmithEtAlSRS, mkSmithEtAlICO)
 
 import Data.Drasil.People (olu)
 import Data.Drasil.Concepts.Physics (motion, pendulum, angular, displacement, iPos, gravitationalConst, gravity, rigidBody, weight, shm)

--- a/code/drasil-example/sglpend/lib/Drasil/SglPend/Body.hs
+++ b/code/drasil-example/sglpend/lib/Drasil/SglPend/Body.hs
@@ -3,6 +3,7 @@ module Drasil.SglPend.Body (mkSRS, si) where
 
 import Control.Lens ((^.))
 
+import Drasil.Database (ChunkDB)
 import Language.Drasil hiding (organization, section)
 import qualified Language.Drasil.Development as D
 import Theory.Drasil (TheoryModel, output)

--- a/code/drasil-example/ssp/lib/Drasil/SSP/Body.hs
+++ b/code/drasil-example/ssp/lib/Drasil/SSP/Body.hs
@@ -4,6 +4,7 @@ module Drasil.SSP.Body (si, mkSRS) where
 import qualified Data.List.NonEmpty as NE
 import Prelude hiding (sin, cos, tan)
 
+import Drasil.Database (ChunkDB)
 import Language.Drasil hiding (Verb, number, organization, section, variable)
 import qualified Language.Drasil.Development as D
 import Drasil.SRSDocument

--- a/code/drasil-example/ssp/lib/Drasil/SSP/Body.hs
+++ b/code/drasil-example/ssp/lib/Drasil/SSP/Body.hs
@@ -13,7 +13,7 @@ import qualified Drasil.DocLang.SRS as SRS (inModel, assumpt,
   genDefn, dataDefn, datCon)
 import Drasil.Document.Contents (foldlSP, foldlSPCol)
 import Drasil.Sentence.Combinators (bulletNested, bulletFlat)
-import Drasil.System (mkSmithEtAlICO)
+import Drasil.System (SmithEtAlSRS, mkSmithEtAlICO)
 
 import Language.Drasil.Chunk.Concept.NamedCombinators
 import qualified Language.Drasil.NaturalLanguage.English.NounPhrase.Combinators as NP

--- a/code/drasil-example/swhs/lib/Drasil/SWHS/Body.hs
+++ b/code/drasil-example/swhs/lib/Drasil/SWHS/Body.hs
@@ -18,7 +18,7 @@ import qualified Language.Drasil.Development as D
 import qualified Language.Drasil.NaturalLanguage.English.NounPhrase.Combinators as NP
 import qualified Language.Drasil.Sentence.Combinators as S
 import Drasil.Sentence.Combinators (bulletFlat, bulletNested)
-import Drasil.System (mkSmithEtAlICO)
+import Drasil.System (SmithEtAlSRS, mkSmithEtAlICO)
 import Drasil.Document.Contents (unlbldExpr, foldlSP, foldlSP_, foldlSPCol)
 
 import Data.Drasil.Concepts.Documentation as Doc (assumption, column,

--- a/code/drasil-example/swhs/lib/Drasil/SWHS/Body.hs
+++ b/code/drasil-example/swhs/lib/Drasil/SWHS/Body.hs
@@ -7,6 +7,7 @@ module Drasil.SWHS.Body (
 
 import Control.Lens ((^.))
 
+import Drasil.Database (ChunkDB)
 import Language.Drasil hiding (organization, section, variable)
 import Drasil.SRSDocument
 import Drasil.Generator (withCommonKnowledge)

--- a/code/drasil-example/swhsnopcm/lib/Drasil/SWHSNoPCM/Body.hs
+++ b/code/drasil-example/swhsnopcm/lib/Drasil/SWHSNoPCM/Body.hs
@@ -7,7 +7,7 @@ import Language.Drasil hiding (section)
 import Language.Drasil.Chunk.Concept.NamedCombinators
 import qualified Language.Drasil.Development as D
 import qualified Language.Drasil.Sentence.Combinators as S
-import Drasil.System (mkSmithEtAlICO)
+import Drasil.System (SmithEtAlSRS, mkSmithEtAlICO)
 import Drasil.SRSDocument
 import qualified Drasil.DocLang.SRS as SRS (inModel)
 import Drasil.Generator (withCommonKnowledge)

--- a/code/drasil-example/swhsnopcm/lib/Drasil/SWHSNoPCM/Body.hs
+++ b/code/drasil-example/swhsnopcm/lib/Drasil/SWHSNoPCM/Body.hs
@@ -2,12 +2,12 @@ module Drasil.SWHSNoPCM.Body (si, mkSRS, noPCMODEInfo) where
 
 import qualified Data.List.NonEmpty as NE
 
+import Drasil.Database (ChunkDB)
 import Language.Drasil hiding (section)
 import Language.Drasil.Chunk.Concept.NamedCombinators
 import qualified Language.Drasil.Development as D
 import qualified Language.Drasil.Sentence.Combinators as S
 import Drasil.System (mkSmithEtAlICO)
-
 import Drasil.SRSDocument
 import qualified Drasil.DocLang.SRS as SRS (inModel)
 import Drasil.Generator (withCommonKnowledge)

--- a/code/drasil-example/template/lib/Drasil/Template/Body.hs
+++ b/code/drasil-example/template/lib/Drasil/Template/Body.hs
@@ -8,6 +8,7 @@ module Drasil.Template.Body (mkSRS, si) where
 import Data.List.NonEmpty (NonEmpty((:|)))
 import qualified Data.List.NonEmpty as NE
 
+import Drasil.Database (ChunkDB)
 import Drasil.System (mkSmithEtAlICO)
 import Language.Drasil
 import Language.Drasil.Display (Symbol(Atop, Integ), Decoration(..))

--- a/code/drasil-example/template/lib/Drasil/Template/Body.hs
+++ b/code/drasil-example/template/lib/Drasil/Template/Body.hs
@@ -9,7 +9,7 @@ import Data.List.NonEmpty (NonEmpty((:|)))
 import qualified Data.List.NonEmpty as NE
 
 import Drasil.Database (ChunkDB)
-import Drasil.System (mkSmithEtAlICO)
+import Drasil.System (SmithEtAlSRS, mkSmithEtAlICO)
 import Language.Drasil
 import Language.Drasil.Display (Symbol(Atop, Integ), Decoration(..))
 import Language.Drasil.ShortHands (lT)


### PR DESCRIPTION
While this is helpful, removing this is also helpful while we re-arrange modules. Once we've rearranged some code, we should re-add this.