### PR TITLE
refactor: move `drasil-docLang/../Document/Contents` and `../Sentence/Combinators` to `drasil-docLang`s `Language.Drasil.Document` namespace

### DIFF
--- a/code/drasil-docLang/lib/Drasil/DocumentLanguage.hs
+++ b/code/drasil-docLang/lib/Drasil/DocumentLanguage.hs
@@ -47,7 +47,6 @@ import Drasil.DocumentLanguage.Core (AppndxSec(..), AuxConstntSec(..),
   TSIntro(..), UCsSec(..), getTraceConfigUID)
 import Drasil.DocumentLanguage.Definitions (ddefn, derivation, instanceModel,
   gdefn, tmodel)
-import Drasil.Document.Contents(mkEnumSimpleD, foldlSP)
 import Drasil.ExtractDocDesc (getDocDesc, egetDocDesc, getSec, extractDocBib)
 import Drasil.TraceTable (generateTraceMap)
 

--- a/code/drasil-docLang/lib/Drasil/DocumentLanguage/Definitions.hs
+++ b/code/drasil-docLang/lib/Drasil/DocumentLanguage/Definitions.hs
@@ -26,7 +26,6 @@ import Theory.Drasil (DataDefinition, GenDefn, InstanceModel,
 
 -- local
 import Drasil.GetChunks (vars)
-import Drasil.Document.Contents (unlbldExpr)
 import Drasil.DocumentLanguage.Units (toSentenceUnitless)
 
 -- | Synonym for a list of 'Field's.

--- a/code/drasil-docLang/lib/Drasil/DocumentLanguage/TraceabilityMatrix.hs
+++ b/code/drasil-docLang/lib/Drasil/DocumentLanguage/TraceabilityMatrix.hs
@@ -21,7 +21,6 @@ import qualified Language.Drasil.Sentence.Combinators as S
 -- Vocabulary
 import Drasil.Metadata.Documentation (purpose, component, dependency,
   item, reference, traceyMatrix)
-import Drasil.Sentence.Combinators (makeTMatrix, showingCxnBw)
 
 -- Other docLang
 import Drasil.DocumentLanguage.Definitions (helpToRefField, TraceViewCat)

--- a/code/drasil-docLang/lib/Drasil/Sections/AuxiliaryConstants.hs
+++ b/code/drasil-docLang/lib/Drasil/Sections/AuxiliaryConstants.hs
@@ -14,7 +14,6 @@ import Utils.Drasil (mkTable)
 -- Other docLang
 import qualified Drasil.DocLang.SRS as SRS (valsOfAuxCons)
 import Drasil.DocumentLanguage.Units (toSentence) -- TODO: suspicious
-import Drasil.Document.Contents (foldlSP)
 import Drasil.Sections.ReferenceMaterial (emptySectSentPlu)
 
 -- Vocabulary

--- a/code/drasil-docLang/lib/Drasil/Sections/GeneralSystDesc.hs
+++ b/code/drasil-docLang/lib/Drasil/Sections/GeneralSystDesc.hs
@@ -13,7 +13,6 @@ import Drasil.Metadata.Documentation (interface, system, environment,
   userCharacteristic, systemConstraint, information, section_, sysCont)
 
 -- Other docLang
-import Drasil.Document.Contents (foldlSP)
 import qualified Drasil.DocLang.SRS as SRS (sysCon, sysCont, userChar)
 import Drasil.Sections.ReferenceMaterial (emptySectSentPlu)
 

--- a/code/drasil-docLang/lib/Drasil/Sections/Introduction.hs
+++ b/code/drasil-docLang/lib/Drasil/Sections/Introduction.hs
@@ -30,8 +30,6 @@ import qualified Drasil.DocLang.SRS as SRS (intro, prpsOfDoc, scpOfReq,
   charOfIR, orgOfDoc, goalStmt, thModel, inModel, sysCon)
 import Drasil.DocumentLanguage.Core (IntroSub(..))
 import Drasil.Sections.ReferenceMaterial(emptySectSentPlu, emptySectSentSing)
-import Drasil.Sentence.Combinators (refineChain)
-import Drasil.Document.Contents (foldlSP, foldlSP_)
 
 -----------------------
 --     Constants     --

--- a/code/drasil-docLang/lib/Drasil/Sections/Requirements.hs
+++ b/code/drasil-docLang/lib/Drasil/Sections/Requirements.hs
@@ -38,7 +38,6 @@ import Drasil.Metadata.Concepts.Math (unit_)
 import Drasil.Sections.ReferenceMaterial(emptySectSentPlu)
 import qualified Drasil.DocLang.SRS as SRS
 import Drasil.DocumentLanguage.Units (toSentence)
-import Drasil.Sentence.Combinators (addPercent)
 
 -- | Wrapper for 'reqIntro'.
 reqF :: [Section] -> Section

--- a/code/drasil-docLang/lib/Drasil/Sections/SpecificSystemDescription.hs
+++ b/code/drasil-docLang/lib/Drasil/Sections/SpecificSystemDescription.hs
@@ -48,11 +48,9 @@ import Drasil.Metadata.Concepts.Math (equation, parameter)
 import Drasil.Metadata.TheoryConcepts (inModel, thModel, dataDefn, genDefn)
 
 -- other docLang
-import Drasil.Document.Contents (enumBulletU, enumSimpleU, foldlSP, foldlSP_)
 import Drasil.DocumentLanguage.Definitions (helperRefs)
 import qualified Drasil.DocLang.SRS as SRS
 import Drasil.Sections.ReferenceMaterial(emptySectSentPlu)
-import Drasil.Sentence.Combinators (mkTableFromColumns, fmtU, typUncr)
 
 -- Takes the system and subsections.
 -- | Specific System Description section builder.

--- a/code/drasil-docLang/lib/Drasil/Sections/Stakeholders.hs
+++ b/code/drasil-docLang/lib/Drasil/Sections/Stakeholders.hs
@@ -14,7 +14,6 @@ import Drasil.Metadata.Documentation (client, customer, endUser, interest,
 
 -- other docLang
 import qualified Drasil.DocLang.SRS as SRS
-import Drasil.Document.Contents (foldlSP)
 
 -- | General stakeholders introduction.
 stakeholderIntro :: Contents

--- a/code/drasil-docLang/package.yaml
+++ b/code/drasil-docLang/package.yaml
@@ -39,10 +39,8 @@ library:
   exposed-modules:
   - Drasil.DocLang
   - Drasil.DocLang.SRS
-  - Drasil.Document.Contents
   - Drasil.DocumentLanguage.Units
   - Drasil.DocumentLanguage.TraceabilityGraph
-  - Drasil.Sentence.Combinators
   - Drasil.SRSDocument
   - Drasil.GetChunks
   - Drasil.ExtractCommon

--- a/code/drasil-example/dblpend/lib/Drasil/DblPend/Body.hs
+++ b/code/drasil-example/dblpend/lib/Drasil/DblPend/Body.hs
@@ -7,7 +7,8 @@ module Drasil.DblPend.Body (
 
 import Language.Drasil hiding (organization)
 import Language.Drasil.Document (makeURI, ulcc, Section, Contents(..),
-  LabelledContent, RawContent(..), Reference, namedRef, refS)
+  LabelledContent, RawContent(..), Reference, namedRef, refS, foldlSP,
+  foldlSPCol, bulletNested, bulletFlat)
 import qualified Language.Drasil.Development as D
 import Theory.Drasil (TheoryModel)
 import Drasil.SRSDocument
@@ -34,8 +35,6 @@ import Data.Drasil.Concepts.PhysicalProperties (mass, physicalcon)
 import Data.Drasil.Concepts.Theory (inModel)
 import Data.Drasil.Concepts.Software (program)
 import Data.Drasil.Theories.Physics (newtonSL, accelerationTM, velocityTM)
-import Drasil.Document.Contents (foldlSP, foldlSPCol)
-import Drasil.Sentence.Combinators (bulletNested, bulletFlat)
 
 import Drasil.DblPend.Assumptions (assumpDouble)
 import Drasil.DblPend.Concepts (rod, concepts, pendMotion, firstRod, secondRod, firstObject, secondObject)

--- a/code/drasil-example/dblpend/lib/Drasil/DblPend/GenDefs.hs
+++ b/code/drasil-example/dblpend/lib/Drasil/DblPend/GenDefs.hs
@@ -15,7 +15,7 @@ import qualified Language.Drasil.Sentence.Combinators as S
 import qualified Language.Drasil.NaturalLanguage.English.NounPhrase.Combinators as NP
 import Data.Drasil.Concepts.Math (xComp, yComp)
 import Data.Drasil.Quantities.Physics (velocity, acceleration, force)
-import Drasil.Sentence.Combinators (definedIn'')
+import Language.Drasil.Document (definedIn'')
 
 -- local
 import Drasil.DblPend.DataDefs

--- a/code/drasil-example/gamephysics/lib/Drasil/GamePhysics/Body.hs
+++ b/code/drasil-example/gamephysics/lib/Drasil/GamePhysics/Body.hs
@@ -7,11 +7,9 @@ import Drasil.Generator (withCommonKnowledge)
 import qualified Drasil.DocLang.SRS as SRS
 import Language.Drasil.Chunk.Concept.NamedCombinators
 import qualified Language.Drasil.Development as D
-import Drasil.Document.Contents (enumBulletU, foldlSP, foldlSPCol)
 import qualified Language.Drasil.Sentence.Combinators as S
 import Drasil.System (mkSmithEtAlICO)
 
-import Drasil.Sentence.Combinators (bulletFlat, bulletNested)
 import Data.Drasil.Concepts.Documentation as Doc (assumption, concept,
   condition, consumer, endUser, environment, game, guide, input_, interface,
   object, physical, physicalSim, physics, problem, product_, project,

--- a/code/drasil-example/gamephysics/lib/Drasil/GamePhysics/Changes.hs
+++ b/code/drasil-example/gamephysics/lib/Drasil/GamePhysics/Changes.hs
@@ -5,7 +5,7 @@ module Drasil.GamePhysics.Changes (likelyChgs, unlikelyChgs) where
 
 import Language.Drasil
 import qualified Language.Drasil.Sentence.Combinators as S
-import Drasil.Sentence.Combinators (chgsStart, maybeExpanded, maybeChanged)
+import Language.Drasil.Document (chgsStart, maybeExpanded, maybeChanged)
 
 import Data.Drasil.Concepts.Documentation as Doc (library, likeChgDom, unlikeChgDom)
 import qualified Data.Drasil.Concepts.Math as CM (ode, constraint)

--- a/code/drasil-example/gamephysics/lib/Drasil/GamePhysics/IMods.hs
+++ b/code/drasil-example/gamephysics/lib/Drasil/GamePhysics/IMods.hs
@@ -9,7 +9,6 @@ import Utils.Drasil (weave)
 import Language.Drasil.Chunk.Concept.NamedCombinators
 import qualified Language.Drasil.Development as D
 import qualified Language.Drasil.Sentence.Combinators as S
-import Drasil.Sentence.Combinators (definedIn'')
 
 import Drasil.GamePhysics.Assumptions (assumpDI, assumpCAJI)
 import Drasil.GamePhysics.Concepts (centreMass)

--- a/code/drasil-example/gamephysics/lib/Drasil/GamePhysics/Requirements.hs
+++ b/code/drasil-example/gamephysics/lib/Drasil/GamePhysics/Requirements.hs
@@ -12,8 +12,6 @@ import Drasil.DocLang (mkMaintainableNFR)
 import Data.Drasil.Concepts.Documentation as Doc (body, funcReqDom, input_,
   nonFuncReqDom, output_, physicalConstraint, physicalSim, property, solutionCharSpec)
 
-import Drasil.Sentence.Combinators (addPercent)
-
 import qualified Data.Drasil.Concepts.Physics as CP (collision, elasticity,
   friction, rigidBody, space)
 import qualified Data.Drasil.Concepts.Math as CM (surface)

--- a/code/drasil-example/glassbr/lib/Drasil/GlassBR/Body.hs
+++ b/code/drasil-example/glassbr/lib/Drasil/GlassBR/Body.hs
@@ -14,9 +14,6 @@ import qualified Drasil.DocLang.SRS as SRS (reference, assumpt, inModel)
 import Language.Drasil.Chunk.Concept.NamedCombinators
 import Language.Drasil.Code (Mod(..), asVC)
 import qualified Language.Drasil.Sentence.Combinators as S
-import Drasil.Document.Contents (enumBulletU, foldlSP, foldlSPCol)
-import Drasil.Sentence.Combinators (bulletFlat, bulletNested, tAndDOnly, tAndDWAcc, noRefs,
-  tAndDWSym)
 import Drasil.System (mkSmithEtAlICO)
 
 import Data.Drasil.Concepts.Computation (computerApp, inDatum)

--- a/code/drasil-example/glassbr/lib/Drasil/GlassBR/Changes.hs
+++ b/code/drasil-example/glassbr/lib/Drasil/GlassBR/Changes.hs
@@ -11,7 +11,6 @@ import Data.Drasil.Concepts.Documentation (condition, goal, input_, likeChgDom,
   software, system, unlikeChgDom, value, variable)
 import Data.Drasil.Concepts.Math (calculation)
 import Data.Drasil.Concepts.PhysicalProperties (flexure)
-import Drasil.Sentence.Combinators (chgsStart)
 
 import Drasil.GlassBR.Assumptions (assumpGC, assumpES, assumpSV, assumpGL,
   assumpBC, assumpRT, assumpLDFC, assumptionConstants)

--- a/code/drasil-example/glassbr/lib/Drasil/GlassBR/DataDefs.hs
+++ b/code/drasil-example/glassbr/lib/Drasil/GlassBR/DataDefs.hs
@@ -9,7 +9,6 @@ import Language.Drasil
 import Language.Drasil.Document
 import Theory.Drasil (DataDefinition, ddE)
 import qualified Language.Drasil.Sentence.Combinators as S
-import Drasil.Sentence.Combinators (definedIn', definedIn)
 
 import Data.Drasil.Concepts.Math (parameter)
 import Data.Drasil.Concepts.PhysicalProperties (dimension)

--- a/code/drasil-example/glassbr/lib/Drasil/GlassBR/IMods.hs
+++ b/code/drasil-example/glassbr/lib/Drasil/GlassBR/IMods.hs
@@ -3,7 +3,6 @@ module Drasil.GlassBR.IMods (iMods, pbIsSafe, lrIsSafe, instModIntro) where
 import Control.Lens ((^.))
 import Prelude hiding (exp)
 
-import Drasil.Sentence.Combinators (definedIn', definedIn)
 import Language.Drasil
 import Language.Drasil.Document
 import qualified Language.Drasil.Development as D

--- a/code/drasil-example/pdcontroller/lib/Drasil/PDController/Changes.hs
+++ b/code/drasil-example/pdcontroller/lib/Drasil/PDController/Changes.hs
@@ -3,7 +3,7 @@ module Drasil.PDController.Changes (likelyChgs) where
 import Language.Drasil
 import Language.Drasil.Chunk.Concept.NamedCombinators
 import qualified Language.Drasil.Development as D
-import Drasil.Sentence.Combinators (fromSources)
+import Language.Drasil.Document (fromSources)
 
 import Data.Drasil.Concepts.Documentation (likeChgDom)
 import Data.Drasil.Concepts.PhysicalProperties (mass)

--- a/code/drasil-example/pdcontroller/lib/Drasil/PDController/GenSysDesc.hs
+++ b/code/drasil-example/pdcontroller/lib/Drasil/PDController/GenSysDesc.hs
@@ -6,8 +6,6 @@ import Language.Drasil
 import Language.Drasil.Document
 import Language.Drasil.Chunk.Concept.NamedCombinators
 import qualified Language.Drasil.Development as D
-import Drasil.Document.Contents (foldlSP, foldlSPCol)
-import Drasil.Sentence.Combinators (bulletFlat, bulletNested)
 
 import Data.Drasil.Concepts.Documentation
        (environment, software, softwareSys, sysCont, system, user)

--- a/code/drasil-example/projectile/lib/Drasil/Projectile/Assumptions.hs
+++ b/code/drasil-example/projectile/lib/Drasil/Projectile/Assumptions.hs
@@ -11,7 +11,6 @@ import qualified Language.Drasil.Development as D
 import qualified Language.Drasil.Sentence.Combinators as S
 
 import qualified Drasil.DocLang.SRS as SRS (valsOfAuxCons)
-import Drasil.Sentence.Combinators (fromSources)
 
 import Data.Drasil.Concepts.Documentation (assumpDom, value, consVals)
 import Data.Drasil.Concepts.Math (cartesian, xAxis, xDir, yAxis, yDir, direction, positive)

--- a/code/drasil-example/projectile/lib/Drasil/Projectile/Body.hs
+++ b/code/drasil-example/projectile/lib/Drasil/Projectile/Body.hs
@@ -9,8 +9,6 @@ import Language.Drasil.Chunk.Concept.NamedCombinators
 import qualified Language.Drasil.NaturalLanguage.English.NounPhrase.Combinators as NP
 import qualified Language.Drasil.Sentence.Combinators as S
 import qualified Drasil.DocLang.SRS as SRS
-import Drasil.Document.Contents (foldlSP, foldlSPCol)
-import Drasil.Sentence.Combinators (bulletNested, bulletFlat)
 import Drasil.System (mkSmithEtAlICO)
 
 import Data.Drasil.Concepts.Computation (inDatum)

--- a/code/drasil-example/projectile/lib/Drasil/Projectile/Changes.hs
+++ b/code/drasil-example/projectile/lib/Drasil/Projectile/Changes.hs
@@ -3,7 +3,7 @@ module Drasil.Projectile.Changes (likelyChgs) where
 import Language.Drasil
 
 import Data.Drasil.Concepts.Documentation (likeChgDom)
-import Drasil.Sentence.Combinators (chgsStart)
+import Language.Drasil.Document (chgsStart)
 
 import Drasil.Projectile.Assumptions (neglectDrag)
 import Drasil.Projectile.Concepts (projectile)

--- a/code/drasil-example/projectile/lib/Drasil/Projectile/Expressions.hs
+++ b/code/drasil-example/projectile/lib/Drasil/Projectile/Expressions.hs
@@ -13,7 +13,6 @@ import Prelude hiding (cos, sin)
 
 import Language.Drasil
 import Language.Drasil.Document
-import Drasil.Document.Contents (lbldExpr)
 import qualified Data.Drasil.Quantities.Physics as QP (iSpeed,
   constAccel, xConstAccel, yConstAccel, ixPos, iyPos)
 import Data.Drasil.Quantities.Physics (gravitationalAccel, gravitationalAccelConst,

--- a/code/drasil-example/projectile/lib/Drasil/Projectile/GenDefs.hs
+++ b/code/drasil-example/projectile/lib/Drasil/Projectile/GenDefs.hs
@@ -12,7 +12,6 @@ import Data.Drasil.Quantities.Physics (acceleration, constAccelV, iPos, iSpeed,
   time, velocity, positionVec, speed)
 import qualified Data.Drasil.Quantities.Physics as QP (constAccel)
 import Data.Drasil.Theories.Physics (accelerationTM, velocityTM)
-import Drasil.Sentence.Combinators (fromReplace)
 import Language.Drasil
 import Language.Drasil.Document
 import Language.Drasil.Chunk.Concept.NamedCombinators

--- a/code/drasil-example/projectile/lib/Drasil/Projectile/IMods.hs
+++ b/code/drasil-example/projectile/lib/Drasil/Projectile/IMods.hs
@@ -7,7 +7,6 @@ import Data.Drasil.Concepts.Math (constraint, equation, xAxis)
 import Data.Drasil.Quantities.Math (pi_)
 import Data.Drasil.Quantities.Physics (gravitationalAccelConst, iSpeed, ixPos,
   ixVel, iyPos, iyVel, time, xConstAccel, xPos, yConstAccel, yPos)
-import Drasil.Sentence.Combinators (eqnWSource)
 
 import Language.Drasil
 import Language.Drasil.Document

--- a/code/drasil-example/projectile/lib/Drasil/Projectile/Lesson/CaseProb.hs
+++ b/code/drasil-example/projectile/lib/Drasil/Projectile/Lesson/CaseProb.hs
@@ -16,7 +16,6 @@ import Data.Drasil.Concepts.Documentation (coordinate, procedure)
 import Language.Drasil
 import Language.Drasil.Document
 import Language.Drasil.ShortHands
-import Drasil.Document.Contents (enumBulletU, foldlSP, foldlSP_)
 import qualified Language.Drasil.Sentence.Combinators as S
 import Data.Drasil.SI_Units (s_2)
 

--- a/code/drasil-example/projectile/lib/Drasil/Projectile/Lesson/Example.hs
+++ b/code/drasil-example/projectile/lib/Drasil/Projectile/Lesson/Example.hs
@@ -3,7 +3,6 @@ module Drasil.Projectile.Lesson.Example (exampleContent, horiz_velo) where
 import Data.Drasil.Concepts.Physics (velocity, height, time, acceleration, gravity, horizontalMotion)
 import qualified Data.Drasil.Quantities.Physics as QP (height, gravitationalAccel)
 import Data.Drasil.Units.Physics (velU)
-import Drasil.Document.Contents (unlbldCode, foldlSP_)
 import Language.Drasil.ShortHands (cR, lG)
 import Language.Drasil
 import Language.Drasil.Document

--- a/code/drasil-example/projectile/lib/Drasil/Projectile/Lesson/LearnObj.hs
+++ b/code/drasil-example/projectile/lib/Drasil/Projectile/Lesson/LearnObj.hs
@@ -3,7 +3,6 @@ module Drasil.Projectile.Lesson.LearnObj (learnObjContext) where
 -- Drasil
 import Data.Drasil.Concepts.Physics (motion)
 import Data.Drasil.Concepts.Math (cartesian, equation)
-import Drasil.Sentence.Combinators (bulletNested, bulletFlat)
 import Language.Drasil
 import Language.Drasil.Document
 

--- a/code/drasil-example/projectile/lib/Drasil/Projectile/Lesson/Review.hs
+++ b/code/drasil-example/projectile/lib/Drasil/Projectile/Lesson/Review.hs
@@ -8,7 +8,6 @@ import qualified Drasil.Projectile.Expressions as E (lcrectVel, lcrectPos, lcrec
 import qualified Data.Drasil.Quantities.Physics as QP (speed, time, scalarPos, iPos, iSpeed, constAccel)
 import Language.Drasil
 import Language.Drasil.Document
-import Drasil.Document.Contents (foldlSP, foldlSP_)
 import qualified Language.Drasil.Sentence.Combinators as S
 
 reviewSecs :: [Section]

--- a/code/drasil-example/sglpend/lib/Drasil/SglPend/GenDefs.hs
+++ b/code/drasil-example/sglpend/lib/Drasil/SglPend/GenDefs.hs
@@ -14,7 +14,6 @@ import Data.Drasil.Concepts.Physics (pendulum, weight, shm)
 import Data.Drasil.Quantities.PhysicalProperties (mass, len)
 import Data.Drasil.Theories.Physics (newtonSLR)
 
-import Drasil.Sentence.Combinators (definedIn, definedIn'')
 import Language.Drasil
 import Language.Drasil.Document
 import qualified Language.Drasil.Development as D

--- a/code/drasil-example/sglpend/lib/Drasil/SglPend/IMods.hs
+++ b/code/drasil-example/sglpend/lib/Drasil/SglPend/IMods.hs
@@ -9,7 +9,6 @@ import Data.Drasil.Quantities.Physics (gravitationalAccel,
 import Data.Drasil.Concepts.Math (constraint, equation, amplitude, iAngle, angle)
 import Data.Drasil.Concepts.Physics (pendulum, motion, shm)
 import Data.Drasil.Theories.Physics (newtonSLR)
-import Drasil.Sentence.Combinators (definedIn'')
 import Language.Drasil
 import Language.Drasil.Document
 import qualified Language.Drasil.Development as D

--- a/code/drasil-example/ssp/lib/Drasil/SSP/Body.hs
+++ b/code/drasil-example/ssp/lib/Drasil/SSP/Body.hs
@@ -6,14 +6,13 @@ import Prelude hiding (sin, cos, tan)
 
 import Language.Drasil hiding (Verb, number, organization, variable)
 import Language.Drasil.Document (fig, llccFig, makeURI, ulcc, Contents(..),
-  LabelledContent, RawContent(..), Reference, namedRef, refS)
+  LabelledContent, RawContent(..), Reference, namedRef, refS, foldlSP,
+  foldlSPCol, bulletNested, bulletFlat)
 import qualified Language.Drasil.Development as D
 import Drasil.SRSDocument
 import Drasil.Generator (withCommonKnowledge)
 import qualified Drasil.DocLang.SRS as SRS (inModel, assumpt,
   genDefn, dataDefn, datCon)
-import Drasil.Document.Contents (foldlSP, foldlSPCol)
-import Drasil.Sentence.Combinators (bulletNested, bulletFlat)
 import Drasil.System (mkSmithEtAlICO)
 
 import Language.Drasil.Chunk.Concept.NamedCombinators

--- a/code/drasil-example/ssp/lib/Drasil/SSP/Changes.hs
+++ b/code/drasil-example/ssp/lib/Drasil/SSP/Changes.hs
@@ -7,7 +7,6 @@ import Language.Drasil.Document
 import Language.Drasil.Chunk.Concept.NamedCombinators
 import qualified Language.Drasil.Development as D
 import qualified Language.Drasil.Sentence.Combinators as S
-import Drasil.Sentence.Combinators (chgsStart)
 
 import Data.Drasil.Concepts.Documentation (analysis, likeChgDom, model, system, unlikeChgDom)
 import Data.Drasil.Concepts.Math (calculation, zDir)

--- a/code/drasil-example/ssp/lib/Drasil/SSP/DataDefs.hs
+++ b/code/drasil-example/ssp/lib/Drasil/SSP/DataDefs.hs
@@ -13,7 +13,6 @@ import Data.Drasil.Concepts.Documentation (assumption)
 import Data.Drasil.Concepts.Math (equation)
 import Data.Drasil.Quantities.Math as QM (pi_)
 import Data.Drasil.Theories.Physics (torqueDD)
-import Drasil.Sentence.Combinators (definedIn''')
 
 import Drasil.SSP.Assumptions (assumpSBSBISL)
 import Drasil.SSP.Defs (slice)

--- a/code/drasil-example/ssp/lib/Drasil/SSP/GenDefs.hs
+++ b/code/drasil-example/ssp/lib/Drasil/SSP/GenDefs.hs
@@ -28,7 +28,6 @@ import Data.Drasil.Quantities.PhysicalProperties (specWeight)
 import Data.Drasil.Quantities.Physics (displacement, force, height,
   pressure, torque)
 import Data.Drasil.Theories.Physics (weightGD, hsPressureGD, torqueDD)
-import Drasil.Sentence.Combinators (definedIn''')
 
 import Theory.Drasil
 

--- a/code/drasil-example/ssp/lib/Drasil/SSP/IMods.hs
+++ b/code/drasil-example/ssp/lib/Drasil/SSP/IMods.hs
@@ -13,7 +13,6 @@ import Language.Drasil.Chunk.Concept.NamedCombinators
 import qualified Language.Drasil.Development as D
 import qualified Language.Drasil.Sentence.Combinators as S
 import Drasil.DocLang.SRS (propCorSol)
-import Drasil.Sentence.Combinators (definedIn'', definedIn''', eqN)
 
 -- Needed for derivations
 import Data.Drasil.Concepts.Documentation (analysis, assumption, constraint,

--- a/code/drasil-example/ssp/lib/Drasil/SSP/TMods.hs
+++ b/code/drasil-example/ssp/lib/Drasil/SSP/TMods.hs
@@ -13,7 +13,6 @@ import Theory.Drasil
 import qualified Language.Drasil.Development as D
 import Language.Drasil.Chunk.Concept.NamedCombinators
 import qualified Language.Drasil.Sentence.Combinators as S
-import Drasil.Sentence.Combinators (definedIn''')
 
 import Data.Drasil.Quantities.Physics (distance, force)
 

--- a/code/drasil-example/swhs/lib/Drasil/SWHS/Body.hs
+++ b/code/drasil-example/swhs/lib/Drasil/SWHS/Body.hs
@@ -17,9 +17,7 @@ import Language.Drasil.Chunk.Concept.NamedCombinators
 import qualified Language.Drasil.Development as D
 import qualified Language.Drasil.NaturalLanguage.English.NounPhrase.Combinators as NP
 import qualified Language.Drasil.Sentence.Combinators as S
-import Drasil.Sentence.Combinators (bulletFlat, bulletNested)
 import Drasil.System (mkSmithEtAlICO)
-import Drasil.Document.Contents (unlbldExpr, foldlSP, foldlSP_, foldlSPCol)
 
 import Data.Drasil.Concepts.Documentation as Doc (assumption, column,
   condition, constraint, corSol, datum, document, environment,input_, model,

--- a/code/drasil-example/swhs/lib/Drasil/SWHS/Changes.hs
+++ b/code/drasil-example/swhs/lib/Drasil/SWHS/Changes.hs
@@ -9,7 +9,6 @@ import qualified Language.Drasil.Sentence.Combinators as S
 
 import Data.Drasil.Concepts.Documentation (assumption, value, simulation,
   model, likeChgDom, unlikeChgDom)
-import Drasil.Sentence.Combinators (chgsStart)
 
 import Drasil.SWHS.Concepts (tank, phsChgMtrl, water)
 import Drasil.SWHS.Unitals (tempInit, tempC, tempPCM)

--- a/code/drasil-example/swhs/lib/Drasil/SWHS/GenDefs.hs
+++ b/code/drasil-example/swhs/lib/Drasil/SWHS/GenDefs.hs
@@ -8,7 +8,6 @@ import Data.Drasil.Quantities.Math (uNormalVect, surface, gradient)
 import Data.Drasil.Quantities.PhysicalProperties as QPP (vol, mass, density)
 import Data.Drasil.Quantities.Physics as QP (time)
 import Data.Drasil.Quantities.Thermodynamics as QT (heatCapSpec, temp)
-import Drasil.Sentence.Combinators (eqN)
 import Language.Drasil
 import Language.Drasil.Document
 import Language.Drasil.Chunk.Concept.NamedCombinators

--- a/code/drasil-example/swhs/lib/Drasil/SWHS/IMods.hs
+++ b/code/drasil-example/swhs/lib/Drasil/SWHS/IMods.hs
@@ -9,7 +9,6 @@ import Language.Drasil.Chunk.Concept.NamedCombinators
 import qualified Language.Drasil.Development as D
 import qualified Language.Drasil.NaturalLanguage.English.NounPhrase.Combinators as NP
 import qualified Language.Drasil.Sentence.Combinators as S
-import Drasil.Sentence.Combinators (eqN, unwrap, substitute, follows, fromSources)
 import Theory.Drasil (InstanceModel, im, imNoDeriv, qwC, qwUC, deModel',
   equationalModel, ModelKind, Derivation, mkDerivName, RelationConcept, makeRC)
 import Utils.Drasil (weave)

--- a/code/drasil-example/swhsnopcm/lib/Drasil/SWHSNoPCM/Changes.hs
+++ b/code/drasil-example/swhsnopcm/lib/Drasil/SWHSNoPCM/Changes.hs
@@ -1,7 +1,6 @@
 {-# LANGUAGE PostfixOperators #-}
 module Drasil.SWHSNoPCM.Changes (likelyChgs, unlikelyChgs) where
 
-import Drasil.Sentence.Combinators (chgsStart)
 import Language.Drasil
 import Language.Drasil.Document
 import Language.Drasil.Chunk.Concept.NamedCombinators

--- a/code/drasil-example/swhsnopcm/lib/Drasil/SWHSNoPCM/IMods.hs
+++ b/code/drasil-example/swhsnopcm/lib/Drasil/SWHSNoPCM/IMods.hs
@@ -8,7 +8,6 @@ import Data.Drasil.Concepts.Math (equation)
 import Data.Drasil.Concepts.PhysicalProperties (liquid)
 import Data.Drasil.Concepts.Thermodynamics (melting, boilPt)
 import Data.Drasil.Quantities.Physics (energy, time)
-import Drasil.Sentence.Combinators (substitute, unwrap)
 import Language.Drasil
 import Language.Drasil.Document
 import Language.Drasil.Chunk.Concept.NamedCombinators

--- a/code/drasil-lang/lib/Language/Drasil/Document.hs
+++ b/code/drasil-lang/lib/Language/Drasil/Document.hs
@@ -1,12 +1,16 @@
 -- | Document Description Language.
 module Language.Drasil.Document (
+  module Language.Drasil.Document.Contents,
   module Language.Drasil.Document.Core,
   module Language.Drasil.Document.DecoratedReference,
   module Language.Drasil.Document.Reference,
-  module Language.Drasil.Document.Sections
+  module Language.Drasil.Document.Sections,
+  module Language.Drasil.Document.SentenceCombinators
 ) where
 
+import Language.Drasil.Document.Contents
 import Language.Drasil.Document.Core
 import Language.Drasil.Document.DecoratedReference
 import Language.Drasil.Document.Reference
 import Language.Drasil.Document.Sections
+import Language.Drasil.Document.SentenceCombinators

--- a/code/drasil-lang/lib/Language/Drasil/Document/Contents.hs
+++ b/code/drasil-lang/lib/Language/Drasil/Document/Contents.hs
@@ -1,6 +1,6 @@
 -- | General functions that are useful in manipulating some Drasil types into
 -- printable 'Contents'.
-module Drasil.Document.Contents (
+module Language.Drasil.Document.Contents (
   -- * List Creation Functions
   enumBullet, enumBulletU, enumSimple,
   enumSimpleU, mkEnumSimpleD,
@@ -18,11 +18,10 @@ import Language.Drasil
   ( Definition(..), HasShortName(..), getSentSN, foldlSent_
   , foldlSent, foldlSentCol
   , Expr, Referable(refAdd), ModelExpr, Sentence (..))
-import Language.Drasil.Document
-  ( mkRawLC, ulcc, mkParagraph
-  , LabelledContent, RawContent(Enumeration, EqnBlock, CodeBlock), Contents(UlC), ListTuple
-  , ItemType(Flat), ListType(Simple), Reference)
-import Drasil.Sentence.Combinators (bulletFlat, mkEnumAbbrevList)
+import Language.Drasil.Document.Core
+import Language.Drasil.Document.Reference
+import Language.Drasil.Document.Sections
+import Language.Drasil.Document.SentenceCombinators (bulletFlat, mkEnumAbbrevList)
 
 -- | Displays a given expression and attaches a 'Reference' to it.
 lbldExpr :: ModelExpr -> Reference -> LabelledContent
@@ -101,4 +100,3 @@ foldlSP_ = mkParagraph . foldlSent_
 -- | Same as 'foldlSP' but uses 'foldlSentCol'.
 foldlSPCol :: [Sentence] -> Contents
 foldlSPCol = mkParagraph . foldlSentCol
-

--- a/code/drasil-lang/lib/Language/Drasil/Document/SentenceCombinators.hs
+++ b/code/drasil-lang/lib/Language/Drasil/Document/SentenceCombinators.hs
@@ -1,7 +1,7 @@
 {-# Language PostfixOperators, TupleSections #-}
 -- | Miscellaneous utility functions for use in various parts of document creation,
 -- but focused mainly on the 'Sentence' level
-module Drasil.Sentence.Combinators (
+module Language.Drasil.Document.SentenceCombinators (
   -- * Reference-related Functions
   -- | Attach a 'Reference' and a 'Sentence' in different ways.
   chgsStart, definedIn, definedIn', definedIn'', definedIn''',
@@ -30,7 +30,9 @@ import Language.Drasil (ConceptChunk, DefinesQuantity(defLhs) , UnitDefn, MayHav
   , Sentence(S, Percent, (:+:), Sy, EmptyS), eS
   , ch, sParen, sDash, (+:+), sC, (+:+.), (!.), (+:), capSent, fromSource, fterms
   , foldlList, SepType(Comma), FoldType(List), foldlSent , Referable)
-import Language.Drasil.Document (Section, ItemType(..), ListType(Bullet), refS, namedRef)
+import Language.Drasil.Document.Core (ItemType(..), ListType(Bullet))
+import Language.Drasil.Document.Reference (refS, namedRef)
+import Language.Drasil.Document.Sections (Section)
 import qualified Language.Drasil.Sentence.Combinators as S (are, in_, is, toThe)
 
 -- Ideally this would create a reference to the equation too.

--- a/code/drasil-website/lib/Drasil/Website/About.hs
+++ b/code/drasil-website/lib/Drasil/Website/About.hs
@@ -4,7 +4,6 @@ module Drasil.Website.About (aboutSec) where
 
 import Language.Drasil
 import Language.Drasil.Document
-import Drasil.Document.Contents (enumBulletU)
 
 -- * About Section
 


### PR DESCRIPTION
`drasil-docLang` primarily contains things related to SRS production. This PR moves more generic 'scientific document'-related things back into `drasil-lang` as a step towards:

1. Renaming `drasil-docLang` to `drasil-srs`.
2. Moving `drasil-docLang`-related things from `drasil-lang` into a new `drasil-docLang` package.

Disclaimer: I did not prioritize making each import explicit. These will change again very soon.
