### PR TITLE
fix: use correct `resourcePath` for dblpend reference image  in `template` project

### DIFF
--- a/code/drasil-docLang/package.yaml
+++ b/code/drasil-docLang/package.yaml
@@ -42,6 +42,5 @@ library:
   - Drasil.Document.Contents
   - Drasil.DocumentLanguage.Notebook
   - Drasil.DocumentLanguage.Units
-  - Drasil.DocumentLanguage.TraceabilityGraph
   - Drasil.Sentence.Combinators
   - Drasil.SRSDocument

--- a/code/drasil-example/template/lib/Drasil/Template/Body.hs
+++ b/code/drasil-example/template/lib/Drasil/Template/Body.hs
@@ -22,7 +22,6 @@ import Data.Drasil.SI_Units (second)
 import qualified Drasil.DocLang.SRS as SRS
 import Data.Drasil.Citations
 import Data.Drasil.Concepts.Theory (inModel)
-import Drasil.DocumentLanguage.TraceabilityGraph
 
 mkSRS :: SRSDecl
 mkSRS = [TableOfContents,
@@ -139,6 +138,9 @@ symbMap = withCommonKnowledge []
 
 citations :: BibRef
 citations = [parnasClements1986]
+
+resourcePath :: String
+resourcePath = "../../../../datafiles/dblpend/" -- FIXME: Change to your resource path!
 
 figTemp :: LabelledContent
 figTemp = llccFig "dblpend" $ figWithWidth EmptyS


### PR DESCRIPTION
Not that a figure was even generated, but if it were, it should use the same resource path that `dblpend` uses (!):

https://github.com/JacquesCarette/Drasil/blob/7686ce4155dd2e74d07c1bdca6a8021aed9fd7da/code/drasil-example/dblpend/lib/Drasil/DblPend/LabelledContent.hs#L14-L19

As a result of this, we can remove one previously exposed module in `drasil-docLang`.