### PR TITLE
refactor: move document-generic 'extractors' from `drasil-docLang` to `drasil-lang`

### DIFF
--- a/code/drasil-docLang/lib/Drasil/DocumentLanguage.hs
+++ b/code/drasil-docLang/lib/Drasil/DocumentLanguage.hs
@@ -47,7 +47,8 @@ import Drasil.DocumentLanguage.Core (AppndxSec(..), AuxConstntSec(..),
   TSIntro(..), UCsSec(..), getTraceConfigUID)
 import Drasil.DocumentLanguage.Definitions (ddefn, derivation, instanceModel,
   gdefn, tmodel)
-import Drasil.ExtractDocDesc (getDocDesc, egetDocDesc, getSec, extractSectionsBib)
+import Drasil.ExtractCommon (getSec, extractSectionsBib)
+import Drasil.ExtractDocDesc (getDocDesc, egetDocDesc)
 import Drasil.TraceTable (generateTraceMap)
 
 import Drasil.Sections.TableOfAbbAndAcronyms (tableAbbAccGen)

--- a/code/drasil-docLang/lib/Drasil/DocumentLanguage.hs
+++ b/code/drasil-docLang/lib/Drasil/DocumentLanguage.hs
@@ -47,7 +47,6 @@ import Drasil.DocumentLanguage.Core (AppndxSec(..), AuxConstntSec(..),
   TSIntro(..), UCsSec(..), getTraceConfigUID)
 import Drasil.DocumentLanguage.Definitions (ddefn, derivation, instanceModel,
   gdefn, tmodel)
-import Drasil.ExtractCommon (getSec, extractSectionsBib)
 import Drasil.ExtractDocDesc (getDocDesc, egetDocDesc)
 import Drasil.TraceTable (generateTraceMap)
 

--- a/code/drasil-docLang/lib/Drasil/DocumentLanguage.hs
+++ b/code/drasil-docLang/lib/Drasil/DocumentLanguage.hs
@@ -47,7 +47,7 @@ import Drasil.DocumentLanguage.Core (AppndxSec(..), AuxConstntSec(..),
   TSIntro(..), UCsSec(..), getTraceConfigUID)
 import Drasil.DocumentLanguage.Definitions (ddefn, derivation, instanceModel,
   gdefn, tmodel)
-import Drasil.ExtractDocDesc (getDocDesc, egetDocDesc, getSec, extractDocBib)
+import Drasil.ExtractDocDesc (getDocDesc, egetDocDesc, getSec, extractSectionsBib)
 import Drasil.TraceTable (generateTraceMap)
 
 import Drasil.Sections.TableOfAbbAndAcronyms (tableAbbAccGen)
@@ -90,7 +90,7 @@ mkDoc si srsDecl headingComb =
       -- well as 'Citation's.
       sections = mkSections si dd Nothing
       -- Extract all referenced 'Citations' from the pre-generated artifact.
-      refdCites = extractDocBib si sections
+      refdCites = extractSectionsBib (si ^. systemdb) sections
       -- Injects "traceability" maps into the 'ChunkDB' and adds missing
       -- 'LabelledContent' (the generated traceability-related tables).
       si' = buildTraceMaps dd $ fillReferences sections refdCites si

--- a/code/drasil-docLang/lib/Drasil/ExtractCommon.hs
+++ b/code/drasil-docLang/lib/Drasil/ExtractCommon.hs
@@ -3,19 +3,20 @@ module Drasil.ExtractCommon (
   extractSents, extractSents',
   extractChRefs,
   getSec,
-  extractSectionsBib
+  extractSectionsBib,
+  resolveBibliography
 ) where
 
-import Control.Lens((^.))
+import Control.Lens ((^.))
+import Data.List (sortBy)
+import Data.Maybe (mapMaybe)
 import qualified Data.Set as S
 
-import Drasil.Database (UID, ChunkDB)
+import Drasil.Database (UID, ChunkDB, find)
 import Language.Drasil hiding (getCitations, Manual, Verb)
 import Language.Drasil.Document (HasContents(..), RawContent(..), ListType(..),
   ItemType(..), ListTuple, Section (..), SecCons (..))
 import Language.Drasil.Development (lnames)
-
-import Drasil.GetChunks (resolveBibliography)
 
 -- | Extracts all referenced 'UID's from things that have 'RawContent's.
 extractChRefs :: HasContents a => [a] -> S.Set UID
@@ -95,3 +96,14 @@ extractSectionsBib :: ChunkDB -> [Section] -> BibRef
 extractSectionsBib db = resolveBibliography db . extractAllSecRefs
   where
     extractAllSecRefs = S.unions . map (S.unions . map lnames . getSec)
+
+-- | Given a 'ChunkDB' and a set of 'UID's, looks up the corresponding
+-- 'Citation's and returns them sorted by author, year, and title.
+--
+-- FIXME: This function assumes that all 'UID's in the set correspond to
+-- 'Citation's in the database. If a 'UID' does not correspond to a 'Citation',
+-- it is simply ignored. This should rather rely on a set of 'UIDRef Citation's.
+resolveBibliography :: ChunkDB -> S.Set UID -> [Citation]
+resolveBibliography db uids = sortBy compareAuthYearTitle cites
+  where
+    cites = mapMaybe (`find` db) (S.toList uids)

--- a/code/drasil-docLang/lib/Drasil/ExtractCommon.hs
+++ b/code/drasil-docLang/lib/Drasil/ExtractCommon.hs
@@ -1,17 +1,21 @@
 module Drasil.ExtractCommon (
   sentToExp, extractMExprs,
   extractSents, extractSents',
-  extractChRefs
+  extractChRefs,
+  getSec,
+  extractSectionsBib
 ) where
 
 import Control.Lens((^.))
 import qualified Data.Set as S
 
-import Drasil.Database (UID)
+import Drasil.Database (UID, ChunkDB)
 import Language.Drasil hiding (getCitations, Manual, Verb)
 import Language.Drasil.Document (HasContents(..), RawContent(..), ListType(..),
-  ItemType(..), ListTuple)
+  ItemType(..), ListTuple, Section (..), SecCons (..))
 import Language.Drasil.Development (lnames)
+
+import Drasil.GetChunks (resolveBibliography)
 
 -- | Extracts all referenced 'UID's from things that have 'RawContent's.
 extractChRefs :: HasContents a => [a] -> S.Set UID
@@ -74,3 +78,20 @@ extractSents = go . (^. accessContents)
 -- | Extracts 'Sentence's from a list of 'Contents'.
 extractSents' :: HasContents a => [a] -> [Sentence]
 extractSents' = concatMap extractSents
+
+-- | Extracts 'Sentence's from a 'Section'.
+getSec :: Section -> [Sentence]
+getSec (Section t sc _ ) = t : concatMap getSecCon sc
+
+-- | Extracts 'Sentence's from section contents.
+getSecCon :: SecCons -> [Sentence]
+getSecCon (Sub s) = getSec s
+getSecCon (Con c) = extractSents c
+
+-- | Extract bibliography entries from generated sections. This version extracts
+-- from fully expanded Sections, capturing citations that are only created
+-- during document generation (like those in orgOfDocIntro).
+extractSectionsBib :: ChunkDB -> [Section] -> BibRef
+extractSectionsBib db = resolveBibliography db . extractAllSecRefs
+  where
+    extractAllSecRefs = S.unions . map (S.unions . map lnames . getSec)

--- a/code/drasil-docLang/lib/Drasil/ExtractCommon.hs
+++ b/code/drasil-docLang/lib/Drasil/ExtractCommon.hs
@@ -9,7 +9,8 @@ import qualified Data.Set as S
 
 import Drasil.Database (UID)
 import Language.Drasil hiding (getCitations, Manual, Verb)
-import Language.Drasil.Document
+import Language.Drasil.Document (HasContents(..), RawContent(..), ListType(..),
+  ItemType(..), ListTuple)
 import Language.Drasil.Development (lnames)
 
 -- | Extracts all referenced 'UID's from things that have 'RawContent's.

--- a/code/drasil-docLang/lib/Drasil/ExtractDocDesc.hs
+++ b/code/drasil-docLang/lib/Drasil/ExtractDocDesc.hs
@@ -13,11 +13,11 @@ import Data.Maybe (maybeToList)
 
 import Language.Drasil (Sentence, Definition(..), ModelExpr,
   HasAdditionalNotes(..), Express(express))
-import Language.Drasil.Document (HasContents, Section(Section), SecCons(..))
+import Language.Drasil.Document (HasContents, Section(Section), SecCons(..),
+  sentToExp, extractSents, extractSents', extractMExprs, getSec)
 import Theory.Drasil (Derivation(..), MayHaveDerivation(..))
 
 import Drasil.DocumentLanguage.Core
-import Drasil.ExtractCommon (sentToExp, extractSents, extractSents', extractMExprs, getSec)
 import Drasil.Sections.SpecificSystemDescription (inDataConstTbl, outDataConstTbl)
 
 -- | Creates a section contents plate that contains diferrent system subsections.

--- a/code/drasil-docLang/lib/Drasil/ExtractDocDesc.hs
+++ b/code/drasil-docLang/lib/Drasil/ExtractDocDesc.hs
@@ -15,8 +15,9 @@ import Data.Maybe (maybeToList)
 import qualified Data.Set as S
 
 import Drasil.Database (ChunkDB)
-import Language.Drasil hiding (getCitations, Manual, Verb)
-import Language.Drasil.Document
+import Language.Drasil (BibRef, Sentence, Definition(..), ModelExpr,
+  HasAdditionalNotes(..), Express(express))
+import Language.Drasil.Document (HasContents, Section(Section), SecCons(..))
 import Language.Drasil.Development (lnames)
 import Theory.Drasil (Derivation(..), MayHaveDerivation(..))
 

--- a/code/drasil-docLang/lib/Drasil/ExtractDocDesc.hs
+++ b/code/drasil-docLang/lib/Drasil/ExtractDocDesc.hs
@@ -3,27 +3,21 @@
 -- Mainly used to pull the 'UID's of chunks out of 'Sentence's and 'Expr's.
 module Drasil.ExtractDocDesc (
   getDocDesc, egetDocDesc,
-  sentencePlate,
-  getSec,
-  extractSectionsBib
+  sentencePlate
 ) where
 
 import Control.Lens((^.))
 import Data.Functor.Constant (Constant(Constant))
 import Data.Generics.Multiplate (appendPlate, foldFor, purePlate, preorderFold)
 import Data.Maybe (maybeToList)
-import qualified Data.Set as S
 
-import Drasil.Database (ChunkDB)
-import Language.Drasil (BibRef, Sentence, Definition(..), ModelExpr,
+import Language.Drasil (Sentence, Definition(..), ModelExpr,
   HasAdditionalNotes(..), Express(express))
 import Language.Drasil.Document (HasContents, Section(Section), SecCons(..))
-import Language.Drasil.Development (lnames)
 import Theory.Drasil (Derivation(..), MayHaveDerivation(..))
 
 import Drasil.DocumentLanguage.Core
-import Drasil.ExtractCommon (sentToExp, extractSents, extractSents', extractMExprs)
-import Drasil.GetChunks (resolveBibliography)
+import Drasil.ExtractCommon (sentToExp, extractSents, extractSents', extractMExprs, getSec)
 import Drasil.Sections.SpecificSystemDescription (inDataConstTbl, outDataConstTbl)
 
 -- | Creates a section contents plate that contains diferrent system subsections.
@@ -153,20 +147,3 @@ getDocDesc = fmGetDocDesc (sentencePlate id)
 -- description), so we use this function. But 'sentencePlate' does not include
 -- all 'Sentence's! Some only appear when rendering (at least, after
 -- `mkSections` is used on a `DocDesc` to create `[Section]`).
-
--- | Extracts 'Sentence's from a 'Section'.
-getSec :: Section -> [Sentence]
-getSec (Section t sc _ ) = t : concatMap getSecCon sc
-
--- | Extracts 'Sentence's from section contents.
-getSecCon :: SecCons -> [Sentence]
-getSecCon (Sub s) = getSec s
-getSecCon (Con c) = extractSents c
-
--- | Extract bibliography entries from generated sections. This version extracts
--- from fully expanded Sections, capturing citations that are only created
--- during document generation (like those in orgOfDocIntro).
-extractSectionsBib :: ChunkDB -> [Section] -> BibRef
-extractSectionsBib db = resolveBibliography db . extractAllSecRefs
-  where
-    extractAllSecRefs = S.unions . map (S.unions . map lnames . getSec)

--- a/code/drasil-docLang/lib/Drasil/ExtractDocDesc.hs
+++ b/code/drasil-docLang/lib/Drasil/ExtractDocDesc.hs
@@ -5,7 +5,7 @@ module Drasil.ExtractDocDesc (
   getDocDesc, egetDocDesc,
   sentencePlate,
   getSec,
-  extractDocBib
+  extractSectionsBib
 ) where
 
 import Control.Lens((^.))
@@ -13,10 +13,11 @@ import Data.Functor.Constant (Constant(Constant))
 import Data.Generics.Multiplate (appendPlate, foldFor, purePlate, preorderFold)
 import Data.Maybe (maybeToList)
 import qualified Data.Set as S
+
+import Drasil.Database (ChunkDB)
 import Language.Drasil hiding (getCitations, Manual, Verb)
 import Language.Drasil.Document
 import Language.Drasil.Development (lnames)
-import Drasil.System (SmithEtAlSRS, systemdb)
 import Theory.Drasil (Derivation(..), MayHaveDerivation(..))
 
 import Drasil.DocumentLanguage.Core
@@ -164,7 +165,7 @@ getSecCon (Con c) = extractSents c
 -- | Extract bibliography entries from generated sections. This version extracts
 -- from fully expanded Sections, capturing citations that are only created
 -- during document generation (like those in orgOfDocIntro).
-extractDocBib :: SmithEtAlSRS -> [Section] -> BibRef
-extractDocBib si = resolveBibliography (si ^. systemdb) . extractAllSecRefs
+extractSectionsBib :: ChunkDB -> [Section] -> BibRef
+extractSectionsBib db = resolveBibliography db . extractAllSecRefs
   where
     extractAllSecRefs = S.unions . map (S.unions . map lnames . getSec)

--- a/code/drasil-docLang/lib/Drasil/GetChunks.hs
+++ b/code/drasil-docLang/lib/Drasil/GetChunks.hs
@@ -1,18 +1,16 @@
 -- | Utilities to get grab certain chunks (from 'Expr', 'Sentence', etc) by
 -- 'UID' and dereference the chunk it refers to.
 module Drasil.GetChunks (
-  ccss, ccss', combine, vars,
-  resolveBibliography
+  ccss, ccss', combine, vars
 ) where
 
-import Data.List (nub, sortBy)
-import Data.Maybe (mapMaybe)
+import Data.List (nub)
 import qualified Data.Set as Set
 
 import Language.Drasil
 import Language.Drasil.Development (sdep)
 import Language.Drasil.ModelExpr.Development (meDep)
-import Drasil.Database (ChunkDB, findOrErr, find, UID)
+import Drasil.Database (ChunkDB, findOrErr)
 import Drasil.Database.SearchTools (defResolve', DomDefn(definition))
 
 -- | Gets a list of quantities ('DefinedQuantityDict') from an equation in order to print.
@@ -46,14 +44,3 @@ concpt a m = map (definition . defResolve' m) $ Set.toList (sdep a)
 -- | Gets a list of concepts ('ConceptChunk') from an expression in order to print.
 concpt' :: ModelExpr -> ChunkDB -> [Sentence]
 concpt' a m = map (definition . defResolve' m) $ meDep a
-
--- | Given a 'ChunkDB' and a set of 'UID's, looks up the corresponding
--- 'Citation's and returns them sorted by author, year, and title.
---
--- FIXME: This function assumes that all 'UID's in the set correspond to
--- 'Citation's in the database. If a 'UID' does not correspond to a 'Citation',
--- it is simply ignored. This should rather rely on a set of 'UIDRef Citation's.
-resolveBibliography :: ChunkDB -> Set.Set UID -> [Citation]
-resolveBibliography db uids = sortBy compareAuthYearTitle cites
-  where
-    cites = mapMaybe (`find` db) (Set.toList uids)

--- a/code/drasil-docLang/package.yaml
+++ b/code/drasil-docLang/package.yaml
@@ -40,5 +40,3 @@ library:
   - Drasil.DocLang
   - Drasil.DocLang.SRS
   - Drasil.SRSDocument
-  - Drasil.GetChunks
-  - Drasil.ExtractDocDesc

--- a/code/drasil-docLang/package.yaml
+++ b/code/drasil-docLang/package.yaml
@@ -41,6 +41,5 @@ library:
   - Drasil.DocLang.SRS
   - Drasil.Document.Contents
   - Drasil.DocumentLanguage.Notebook
-  - Drasil.DocumentLanguage.Units
   - Drasil.Sentence.Combinators
   - Drasil.SRSDocument

--- a/code/drasil-docLang/package.yaml
+++ b/code/drasil-docLang/package.yaml
@@ -42,6 +42,5 @@ library:
   - Drasil.Document.Contents
   - Drasil.DocumentLanguage.Notebook
   - Drasil.DocumentLanguage.Units
-  - Drasil.DocumentLanguage.TraceabilityGraph
   - Drasil.Sentence.Combinators
   - Drasil.SRSDocument

--- a/code/drasil-docLang/package.yaml
+++ b/code/drasil-docLang/package.yaml
@@ -41,5 +41,4 @@ library:
   - Drasil.DocLang.SRS
   - Drasil.SRSDocument
   - Drasil.GetChunks
-  - Drasil.ExtractCommon
   - Drasil.ExtractDocDesc

--- a/code/drasil-example/template/lib/Drasil/Template/Body.hs
+++ b/code/drasil-example/template/lib/Drasil/Template/Body.hs
@@ -22,7 +22,6 @@ import Data.Drasil.SI_Units (second)
 import qualified Drasil.DocLang.SRS as SRS
 import Data.Drasil.Citations
 import Data.Drasil.Concepts.Theory (inModel)
-import Drasil.DocumentLanguage.TraceabilityGraph
 
 mkSRS :: SRSDecl
 mkSRS = [TableOfContents,
@@ -139,6 +138,9 @@ symbMap = withCommonKnowledge []
 
 citations :: BibRef
 citations = [parnasClements1986]
+
+resourcePath :: String
+resourcePath = "../../../../datafiles/dblpend/" -- FIXME: Change to your resource path!
 
 figTemp :: LabelledContent
 figTemp = llccFig "dblpend" $ figWithWidth EmptyS

--- a/code/drasil-lang/lib/Language/Drasil/Document.hs
+++ b/code/drasil-lang/lib/Language/Drasil/Document.hs
@@ -3,6 +3,7 @@ module Language.Drasil.Document (
   module Language.Drasil.Document.Contents,
   module Language.Drasil.Document.Core,
   module Language.Drasil.Document.DecoratedReference,
+  module Language.Drasil.Document.Extractors,
   module Language.Drasil.Document.Reference,
   module Language.Drasil.Document.Sections,
   module Language.Drasil.Document.SentenceCombinators
@@ -11,6 +12,7 @@ module Language.Drasil.Document (
 import Language.Drasil.Document.Contents
 import Language.Drasil.Document.Core
 import Language.Drasil.Document.DecoratedReference
+import Language.Drasil.Document.Extractors
 import Language.Drasil.Document.Reference
 import Language.Drasil.Document.Sections
 import Language.Drasil.Document.SentenceCombinators

--- a/code/drasil-lang/lib/Language/Drasil/Document/Extractors.hs
+++ b/code/drasil-lang/lib/Language/Drasil/Document/Extractors.hs
@@ -14,7 +14,6 @@ import qualified Data.Set as S
 
 import Drasil.Database (UID, ChunkDB, find)
 import Language.Drasil hiding (getCitations, Manual, Verb)
-import Language.Drasil.Document.Contents
 import Language.Drasil.Document.Core
 import Language.Drasil.Document.Sections
 import Language.Drasil.Development (lnames)

--- a/code/drasil-lang/lib/Language/Drasil/Document/Extractors.hs
+++ b/code/drasil-lang/lib/Language/Drasil/Document/Extractors.hs
@@ -1,4 +1,4 @@
-module Drasil.ExtractCommon (
+module Language.Drasil.Document.Extractors (
   sentToExp, extractMExprs,
   extractSents, extractSents',
   extractChRefs,
@@ -14,8 +14,9 @@ import qualified Data.Set as S
 
 import Drasil.Database (UID, ChunkDB, find)
 import Language.Drasil hiding (getCitations, Manual, Verb)
-import Language.Drasil.Document (HasContents(..), RawContent(..), ListType(..),
-  ItemType(..), ListTuple, Section (..), SecCons (..))
+import Language.Drasil.Document.Contents
+import Language.Drasil.Document.Core
+import Language.Drasil.Document.Sections
 import Language.Drasil.Development (lnames)
 
 -- | Extracts all referenced 'UID's from things that have 'RawContent's.

--- a/code/drasil-lang/lib/Language/Drasil/Document/Sections.hs
+++ b/code/drasil-lang/lib/Language/Drasil/Document/Sections.hs
@@ -39,16 +39,6 @@ data Section = Section
              }
 makeLenses ''Section
 
-{-
-data Section = Section
-             { depth  :: Depth
-             , header :: SecHeader
-             , cons   :: Content
-             }
-
-data SecHeader = SecHeader Title Reference
-data Content   = Content   Contents
--}
 -- | Finds the 'UID' of a 'Section'.
 instance HasUID        Section where uid = lab . uid
 

--- a/code/drasil-lesson-plan/lib/Drasil/LessonPlan/ExtractLsnDesc.hs
+++ b/code/drasil-lesson-plan/lib/Drasil/LessonPlan/ExtractLsnDesc.hs
@@ -9,8 +9,7 @@ import Language.Drasil.Document
 
 import Drasil.GetChunks (resolveBibliography)
 import Drasil.LessonPlan.Core
-import Drasil.ExtractCommon (extractChRefs)
-import Drasil.ExtractDocDesc (getSec)
+import Drasil.ExtractCommon (extractChRefs, getSec)
 import Language.Drasil.Development (lnames)
 
 findAllInConsSecs :: [Contents] -> [Section] -> S.Set UID

--- a/code/drasil-lesson-plan/lib/Drasil/LessonPlan/ExtractLsnDesc.hs
+++ b/code/drasil-lesson-plan/lib/Drasil/LessonPlan/ExtractLsnDesc.hs
@@ -7,9 +7,8 @@ import Drasil.Database (UID, ChunkDB)
 import Language.Drasil
 import Language.Drasil.Document
 
-import Drasil.GetChunks (resolveBibliography)
 import Drasil.LessonPlan.Core
-import Drasil.ExtractCommon (extractChRefs, getSec)
+import Drasil.ExtractCommon (extractChRefs, getSec, resolveBibliography)
 import Language.Drasil.Development (lnames)
 
 findAllInConsSecs :: [Contents] -> [Section] -> S.Set UID

--- a/code/drasil-lesson-plan/lib/Drasil/LessonPlan/ExtractLsnDesc.hs
+++ b/code/drasil-lesson-plan/lib/Drasil/LessonPlan/ExtractLsnDesc.hs
@@ -8,7 +8,6 @@ import Language.Drasil
 import Language.Drasil.Document
 
 import Drasil.LessonPlan.Core
-import Drasil.ExtractCommon (extractChRefs, getSec, resolveBibliography)
 import Language.Drasil.Development (lnames)
 
 findAllInConsSecs :: [Contents] -> [Section] -> S.Set UID

--- a/code/drasil-lesson-plan/package.yaml
+++ b/code/drasil-lesson-plan/package.yaml
@@ -22,7 +22,6 @@ dependencies:
 - transformers
 - multiplate
 - drasil-database
-- drasil-docLang
 - drasil-lang
 - drasil-metadata
 - drasil-system

--- a/code/drasil-lesson-plan/stack.yaml
+++ b/code/drasil-lesson-plan/stack.yaml
@@ -3,7 +3,6 @@ resolver: lts-22.44
 packages:
 - .
 - ../drasil-database
-- ../drasil-docLang
 - ../drasil-lang
 - ../drasil-metadata
 - ../drasil-system


### PR DESCRIPTION
Builds on #5089, #5090, #5091.

Aside: _If there is a merge conflict between #5089 and #5090 if one is merged before the other, merging this PR directly into `main` may solve them for us._

The title sounds backwards, but it isn't :) It's just time to rename `drasil-docLang` to `drasil-srs` and to move the "`drasil-docLang`" (the things we expect to be in this package) related things from `drasil-lang` into a (new) `drasil-doc-lang` package (or `drasil-scidoc`, `drasil-generic-sci-doc`, `drasil-gsd`, etc.).

This PR:

1. Moves more of the 'generic document-sentence extractors' from `drasil-docLang` to `drasil-lang`'s new `Language.Drasil.Document` namespace.
2. Remove the import of `drasil-docLang` from `drasil-lesson-plan`.
3. Removes more exported modules from `drasil-docLang`.