### PR TITLE
refactor(data-formats-CSV): flip parameters to `renderCSV`

### DIFF
--- a/code/drasil-data-formats/lib/Drasil/Data/Formats/CSV/Render.hs
+++ b/code/drasil-data-formats/lib/Drasil/Data/Formats/CSV/Render.hs
@@ -31,8 +31,8 @@ csvRenderOpts :: DoubleQuotationPolicy -> CSVRenderOptions
 csvRenderOpts = CSVRO
 
 -- | Render a 'CSV' to a 'Doc' with the given options.
-renderCSV :: CSV -> CSVRenderOptions -> Doc ann
-renderCSV csv (CSVRO dqp) = vcat $ map renderRow allRs
+renderCSV :: CSVRenderOptions -> CSV -> Doc ann
+renderCSV (CSVRO dqp) csv = vcat $ map renderRow allRs
   where
     rs = rows csv
     allRs = maybe rs (: rs) $ header csv

--- a/code/drasil-data-formats/test/Spec/Drasil/Data/Formats/CSV.hs
+++ b/code/drasil-data-formats/test/Spec/Drasil/Data/Formats/CSV.hs
@@ -112,16 +112,16 @@ renderCSVTests =
         "Golden Tests"
         [
           goldenTest "simpleCSV minimal" $
-            file [ps|simple_m.csv|] $ renderCSV simpleCSV minimal,
+            file [ps|simple_m.csv|] $ renderCSV minimal simpleCSV,
           goldenTest "simpleCSVnoH minimal" $
-            file [ps|simple_m_nh.csv|] $ renderCSV simpleCSVnoH minimal,
+            file [ps|simple_m_nh.csv|] $ renderCSV minimal simpleCSVnoH,
           goldenTest "simpleCSV everywhere" $
-            file [ps|simple_e.csv|] $ renderCSV simpleCSV everywhere,
+            file [ps|simple_e.csv|] $ renderCSV everywhere simpleCSV,
           goldenTest "simpleCSVnoH everywhere" $
-            file [ps|simple_e_nh.csv|] $ renderCSV simpleCSVnoH everywhere,
+            file [ps|simple_e_nh.csv|] $ renderCSV everywhere simpleCSVnoH,
           goldenTest "complexCSV minimal" $
-            file [ps|complex_m.csv|] $ renderCSV complexCSV minimal,
+            file [ps|complex_m.csv|] $ renderCSV minimal complexCSV,
           goldenTest "complexCSV everywhere" $
-            file [ps|complex_e.csv|] $ renderCSV complexCSV everywhere
+            file [ps|complex_e.csv|] $ renderCSV everywhere complexCSV
         ]
     ]

--- a/code/drasil-printers/lib/Language/Drasil/Markdown/Print.hs
+++ b/code/drasil-printers/lib/Language/Drasil/Markdown/Print.hs
@@ -80,7 +80,7 @@ makeRequirements p =
   let
     mCSV = mkCSV (Just 2) (Just ["Original", "Copy"]) (assetMat p)
     csv = either error id mCSV
-  in renderCSV csv (csvRenderOpts Minimal)
+  in renderCSV (csvRenderOpts Minimal) csv
 
 -- | FIXME: HACK: Find all figure assets from a 'Project'. This is a hack
 -- because (a) there can be assets other than figures, (b) we are searching


### PR DESCRIPTION
Depends on #5066

This order makes more sense for the soon to be added `renderJSON` (as it is recursive), and the APIs should be consistent.