### PR TITLE
ci: deploy using github-official artifact upload action

### DIFF
--- a/.github/workflows/Deploy.yaml
+++ b/.github/workflows/Deploy.yaml
@@ -4,6 +4,10 @@ on:
     paths: [code/**, .github/workflows/Deploy.yaml]
   workflow_dispatch:
 name: Deploy
+permissions:
+  contents: read
+  pages: write
+  id-token: write
 concurrency:
   group: deploy
   cancel-in-progress: true
@@ -109,12 +113,18 @@ jobs:
       - name: "Prepare full website deployment environment"
         run: make deploy_lite
 
-      - name: "Deploy 🚀"
-        uses: JamesIves/github-pages-deploy-action@v4.8.0
+      - name: "Upload static website as artifact"
+        uses: actions/upload-pages-artifact@v3
         with:
-          git-config-name: ${{ secrets.BOT_NAME }}
-          git-config-email: ${{ secrets.BOT_EMAIL }}
-          token: ${{ secrets.BOT_TOKEN }}
-          branch: gh-pages
-          folder: code/deploy
-          commit-message: "${{ secrets.BOT_NAME }} deploy of main@${{ github.sha }}"
+          path: code/deploy/
+
+  deploy-pages:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: deploy
+    steps:
+      - name: Deploy GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
This will stop our ever-inflating `gh-pages`-induced repo size.

To make this PR work, we _first_ need to set the GitHub Pages source to `GitHub Actions`:

<img width="1130" height="566" alt="Screenshot 2026-06-09 at 11 03 49 PM" src="https://github.com/user-attachments/assets/a3524284-fa79-4508-ae8c-37c2cffcfdc8" />

Tested on https://balacij.github.io/Drasil/ / https://github.com/JacquesCarette/Drasil/compare/main...balacij:Drasil:main