### PR TITLE
chore: remove unused `drasil-utils` dependency in `drasil-database`

### DIFF
--- a/code/drasil-database/package.yaml
+++ b/code/drasil-database/package.yaml
@@ -21,7 +21,6 @@ dependencies:
 - lens
 - template-haskell
 - text
-- drasil-utils
 
 ghc-options:
 - -Wall


### PR DESCRIPTION
Closes #5104 

Succeeds #5105.