### PR TITLE
refactor: move `LessonPlan` "system" from `drasil-system` to `drasil-lesson-plan`

### DIFF
--- a/code/drasil-example/projectile/lib/Drasil/Projectile/Lesson/Body.hs
+++ b/code/drasil-example/projectile/lib/Drasil/Projectile/Lesson/Body.hs
@@ -5,9 +5,8 @@ import Language.Drasil
 import Language.Drasil.Document
 import Drasil.Database (ChunkDB)
 import Drasil.Generator (withCommonKnowledge)
-import Drasil.System (LessonPlan, mkSystemMeta, mkLessonPlan)
-
-import Drasil.LessonPlan (LsnDesc, LsnChapter(BibSec, LearnObj, Review, CaseProb, Example))
+import Drasil.LessonPlan (LessonPlan, mkLessonPlan, LsnDesc, LsnChapter(..))
+import Drasil.System (mkSystemMeta)
 
 import qualified Data.Drasil.Quantities.Physics as Qs (iSpeed, ixSpeed, iySpeed,
   speed, constAccel, gravitationalAccel, xAccel, yAccel, time, ixPos, iyPos,

--- a/code/drasil-gen/lib/Drasil/Generator/CaseStudyVariants.hs
+++ b/code/drasil-gen/lib/Drasil/Generator/CaseStudyVariants.hs
@@ -18,9 +18,9 @@ import GHC.IO.Encoding (setLocaleEncoding, utf8)
 
 import Drasil.FileHandling (FileLayout, OverwritePolicy(..), directory, localPath, ps,
   writeFiles)
-import Drasil.LessonPlan (LsnDesc)
+import Drasil.LessonPlan (LsnDesc, LessonPlan)
 import Drasil.SRS (SRSDecl, mkDoc)
-import Drasil.System (DrasilWebsite, LessonPlan, SmithEtAlSRS, programName)
+import Drasil.System (DrasilWebsite, SmithEtAlSRS, programName)
 import Language.Drasil.Code (Choices)
 import qualified Language.Drasil.Sentence.Combinators as S
 

--- a/code/drasil-gen/lib/Drasil/Generator/LessonPlan.hs
+++ b/code/drasil-gen/lib/Drasil/Generator/LessonPlan.hs
@@ -8,13 +8,13 @@ where
 import Control.Lens ((^.))
 
 import Drasil.FileHandling (FileLayout, file, ps)
-import Drasil.LessonPlan (LsnDesc, render)
+import Drasil.LessonPlan (LsnDesc, LessonPlan, render, lsnPlanRefs)
+import Drasil.System (HasSystemMeta(..))
 import Language.Drasil (Stage (Equational))
 import Language.Drasil.Printers (Notation (Engineering), piSys)
 import qualified Language.Drasil.Printers as P (genJupyterLessonPlan)
 import Language.Drasil.Printing.Import (makeDocument)
 import qualified Language.Drasil.Sentence.Combinators as S
-import Drasil.System (LessonPlan, lsnPlanRefs, systemdb)
 
 -- | Generate a Lesson Plan (an interactive JupyterNotebook).
 genJupyterLessonPlan :: LessonPlan -> LsnDesc -> String -> FileLayout

--- a/code/drasil-lesson-plan/lib/Drasil/LessonPlan.hs
+++ b/code/drasil-lesson-plan/lib/Drasil/LessonPlan.hs
@@ -1,7 +1,9 @@
 module Drasil.LessonPlan (
+  module Drasil.LessonPlan.Core,
   module Drasil.LessonPlan.Document,
   module Drasil.LessonPlan.Renderer
 ) where
 
+import Drasil.LessonPlan.Core
 import Drasil.LessonPlan.Document
 import Drasil.LessonPlan.Renderer

--- a/code/drasil-lesson-plan/lib/Drasil/LessonPlan/Core.hs
+++ b/code/drasil-lesson-plan/lib/Drasil/LessonPlan/Core.hs
@@ -1,4 +1,5 @@
-module Drasil.System.LessonPlan (
+{-# LANGUAGE TemplateHaskell #-}
+module Drasil.LessonPlan.Core (
   LessonPlan,
   mkLessonPlan,
   lsnPlanRefs
@@ -10,7 +11,7 @@ import qualified Data.Map.Strict as M
 import Drasil.Database (UID, uid)
 import Language.Drasil.Document (Reference)
 
-import Drasil.System.Core (SystemMeta, HasSystemMeta(..))
+import Drasil.System (SystemMeta, HasSystemMeta(..))
 
 data LessonPlan = LP {
   _sm :: SystemMeta,

--- a/code/drasil-lesson-plan/lib/Drasil/LessonPlan/Renderer.hs
+++ b/code/drasil-lesson-plan/lib/Drasil/LessonPlan/Renderer.hs
@@ -8,11 +8,12 @@ import Language.Drasil (Sentence(S), CI, foldlList, SepType(Comma),
   FoldType(List), fullName, Idea, titleize, titleize')
 import Language.Drasil.Document (Section, Document(Notebook), Contents(UlC),
   ulcc, RawContent(Bib), section, makeSecRef)
-import Drasil.System (LessonPlan, HasSystemMeta(..))
+import Drasil.System (HasSystemMeta(..))
 import Drasil.Metadata.Documentation (notebook)
 import qualified Drasil.Metadata.Documentation as Doc (caseProb, introduction,
   learnObj, review, summary, example, appendix, reference)
 
+import Drasil.LessonPlan.Core (LessonPlan)
 import Drasil.LessonPlan.Document (LsnDesc, LsnChapter(..))
 import Drasil.LessonPlan.ExtractBib (extractBib)
 

--- a/code/drasil-system/lib/Drasil/System.hs
+++ b/code/drasil-system/lib/Drasil/System.hs
@@ -1,11 +1,9 @@
 module Drasil.System (
   module Drasil.System.Core,
   module Drasil.System.DrasilWebsite,
-  module Drasil.System.LessonPlan,
   module Drasil.System.SmithEtAlSRS
 ) where
 
 import Drasil.System.Core
 import Drasil.System.DrasilWebsite
-import Drasil.System.LessonPlan
 import Drasil.System.SmithEtAlSRS


### PR DESCRIPTION
Builds on #5114 

Follow-up to https://github.com/JacquesCarette/Drasil/pull/5114#issuecomment-4673586479