### PR TITLE
chore: add BSS to `hie.yaml` for HLS support

### DIFF
--- a/code/hie.yaml
+++ b/code/hie.yaml
@@ -45,6 +45,12 @@ cradle:
     - path: "drasil-database/lib"
       component: "drasil-database:lib"
 
+    - path: "drasil-example/bss/lib"
+      component: "bss:lib"
+
+    - path: "drasil-example/bss/app/Main.hs"
+      component: "bss:exe:bss"
+
     - path: "drasil-example/dblpend/lib"
       component: "dblpend:lib"
 


### PR DESCRIPTION
Without this PR, HLS will not show in-editor hints for BSS.