### PR TITLE
fix(`pdcontroller`): insert `ConceptChunk`s as they are

### DIFF
--- a/code/drasil-example/pdcontroller/lib/Drasil/PDController/Body.hs
+++ b/code/drasil-example/pdcontroller/lib/Drasil/PDController/Body.hs
@@ -60,6 +60,11 @@ mkSRS
        SSDProg
          [SSDProblem $
             PDProg purp []
+              -- FIXME: When removing the manually aggregated list here, expect
+              -- duplicate UID errors! Why? `defs` is a hand-crafted list that
+              -- extends `termDefs` with non-unique chunks containing
+              -- alternative definitions for use in the `Terminology and
+              -- Definitions` section.
               [TermsAndDefs Nothing defs,
                PhySysDesc progName sysParts sysFigure [],
                Goals sysGoalInput],

--- a/code/drasil-example/pdcontroller/lib/Drasil/PDController/Body.hs
+++ b/code/drasil-example/pdcontroller/lib/Drasil/PDController/Body.hs
@@ -19,7 +19,7 @@ import Data.Drasil.Quantities.Math (posInf, negInf)
 
 import Drasil.PDController.Assumptions (assumptions)
 import Drasil.PDController.Changes (likelyChgs)
-import Drasil.PDController.Concepts (acronyms, pidC, concepts, defs,
+import Drasil.PDController.Concepts (acronyms, pidC, termDefs, defs,
   pdControllerCI, proportionalCI, piCI, pidCI)
 import Drasil.PDController.DataDefs (dataDefinitions)
 import Drasil.PDController.GenDefs (genDefns)
@@ -107,14 +107,11 @@ orgSecEnd = foldlSent [
     titleize ode, sParen (short ode), S "that models the", phrase pidC
   ]
 
-ideaDicts :: [IdeaDict]
-ideaDicts = concepts
-
 cis :: [CI]
 cis = progName : acronyms
 
 conceptChunks :: [ConceptChunk]
-conceptChunks = physicalcon ++ [linear, angular]
+conceptChunks = physicalcon ++ [linear, angular] ++ termDefs
 
 allSymbols :: [DefinedQuantityDict]
 allSymbols = map dqdWr physicscon ++ symbols ++
@@ -124,7 +121,7 @@ allSymbols = map dqdWr physicscon ++ symbols ++
 symbMap :: ChunkDB
 symbMap = withCommonKnowledge []
   allSymbols
-  ideaDicts
+  []
   cis
   conceptChunks
   ([] :: [UnitDefn])

--- a/code/drasil-example/pdcontroller/lib/Drasil/PDController/Concepts.hs
+++ b/code/drasil-example/pdcontroller/lib/Drasil/PDController/Concepts.hs
@@ -1,5 +1,5 @@
 module Drasil.PDController.Concepts (
-  acronyms, concepts, defs, simulation, processError, simulationTime, stepTime,
+  acronyms, termDefs, defs, simulation, processError, simulationTime, stepTime,
   controlVariable, propControl, derControl,
   pdControllerCI, proportionalCI, pidC, piCI, pidCI, pidCL, processVariable,
   ccDampingCoeff, ccStiffCoeff, ccFrequencyDomain, ccLaplaceTransform, ccTransferFxn,
@@ -7,8 +7,7 @@ module Drasil.PDController.Concepts (
   secondOrderSystem, summingPt, propGain, derGain, powerPlant, setPoint
 ) where
 
-import Language.Drasil (commonIdeaWithDict, dcc, nw, cn', nounPhraseSP, pn, CI,
-  ConceptChunk, IdeaDict)
+import Language.Drasil (commonIdeaWithDict, dcc, cn', nounPhraseSP, pn, CI, ConceptChunk)
 
 acronyms :: [CI]
 acronyms = [pdControllerCI, proportionalCI, piCI, pidCI]
@@ -126,9 +125,6 @@ ccDampingCoeff
 ccStiffCoeff
   = dcc "ccStiffnessCoeff" (nounPhraseSP "Stiffness coefficient")
       "Quantity that characterizes a spring's stiffness"
-
-concepts :: [IdeaDict]
-concepts = map nw termDefs
 
 defs :: [ConceptChunk]
 defs


### PR DESCRIPTION
Contributes to https://github.com/JacquesCarette/Drasil/pull/4829#issuecomment-4092462316
Contributes to #4782 
Contributes to #2873 

Builds on #5119 

Removes more `nw` usage!

Is this a fix? A refactor? I'm not sure, but I'll call it a 'fix' in the sense that we were previously 'missing' knowledge in the `ChunkDB`.