### PR TITLE
fix(projectile): insert chunks in their standard types

### DIFF
--- a/code/drasil-example/projectile/lib/Drasil/Projectile/Body.hs
+++ b/code/drasil-example/projectile/lib/Drasil/Projectile/Body.hs
@@ -38,7 +38,8 @@ import Data.Drasil.Concepts.Education(calculus, undergraduate,
 
 import Drasil.Projectile.Assumptions (assumptions)
 import Drasil.Projectile.Changes (likelyChgs)
-import Drasil.Projectile.Concepts (launcher, projectile, target, defs, projMotion, rectVel)
+import Drasil.Projectile.Concepts (launcher, projectile, target, defs,
+  ideaDicts)
 import Drasil.Projectile.DataDefs (dataDefs)
 import Drasil.Projectile.GenDefs (genDefns)
 import Drasil.Projectile.Goals (goals)
@@ -148,9 +149,6 @@ background = foldlSent_ [S "Common examples of", phrase projectile, phrase motio
 
 tMods :: [TheoryModel]
 tMods = [accelerationTM, velocityTM]
-
-ideaDicts :: [IdeaDict]
-ideaDicts = [projMotion, rectVel]
 
 cis :: [CI]
 cis = [progName]

--- a/code/drasil-example/projectile/lib/Drasil/Projectile/Concepts.hs
+++ b/code/drasil-example/projectile/lib/Drasil/Projectile/Concepts.hs
@@ -1,5 +1,5 @@
 module Drasil.Projectile.Concepts (
-  launcher, projectile, target, projMotion, defs, rectVel, concepts,
+  launcher, projectile, target, projMotion, defs, rectVel, ideaDicts,
   flightDur, offset, landPos, launAngle, launSpeed, targPos, projSpeed, projPos
 ) where
 
@@ -13,9 +13,8 @@ import Data.Drasil.Concepts.Math (angle)
 import Data.Drasil.Concepts.Physics (oneD, position, speed, motion, distance, iSpeed, time,
   rectilinear, velocity, acceleration)
 
-concepts :: [IdeaDict]
-concepts = projMotion : map nw [landingPosNC, launchNC, launchAngleNC, launchSpeedNC, offsetNC, targetPosNC,
-  rectVel] ++ map nw defs
+ideaDicts :: [IdeaDict]
+ideaDicts = [projMotion, launchNC, rectVel]
 
 durationNC, flightDurNC, landingPosNC, launchNC, launchAngleNC, launchSpeedNC, offsetNC, targetPosNC,
   rectVel :: IdeaDict

--- a/code/drasil-example/projectile/lib/Drasil/Projectile/Lesson/Body.hs
+++ b/code/drasil-example/projectile/lib/Drasil/Projectile/Lesson/Body.hs
@@ -16,7 +16,7 @@ import qualified Data.Drasil.Concepts.Physics as CCs (motion, acceleration,
 
 import Data.Drasil.People (spencerSmith)
 
-import Drasil.Projectile.Concepts (concepts)
+import Drasil.Projectile.Concepts (ideaDicts, defs)
 import Drasil.Projectile.Expressions (eqnRefs)
 
 import Drasil.Projectile.Lesson.LearnObj (learnObjContext)
@@ -44,11 +44,10 @@ symbMap = withCommonKnowledge [] symbols ideaDicts cis conceptChunks [] [] [] []
 cis :: [CI]
 cis = [projectileMotionLesson]
 
-ideaDicts :: [IdeaDict]
-ideaDicts = concepts
+
 
 conceptChunks :: [ConceptChunk]
-conceptChunks = [CCs.motion, CCs.acceleration, CCs.velocity, CCs.force,
+conceptChunks = defs ++ [CCs.motion, CCs.acceleration, CCs.velocity, CCs.force,
   CCs.verticalMotion, CCs.gravity, CCs.position]
 
 symbols :: [DefinedQuantityDict]

--- a/code/drasil-example/projectile/lib/Drasil/Projectile/Lesson/Body.hs
+++ b/code/drasil-example/projectile/lib/Drasil/Projectile/Lesson/Body.hs
@@ -44,8 +44,6 @@ symbMap = withCommonKnowledge [] symbols ideaDicts cis conceptChunks [] [] [] []
 cis :: [CI]
 cis = [projectileMotionLesson]
 
-
-
 conceptChunks :: [ConceptChunk]
 conceptChunks = defs ++ [CCs.motion, CCs.acceleration, CCs.velocity, CCs.force,
   CCs.verticalMotion, CCs.gravity, CCs.position]


### PR DESCRIPTION
Contributes to https://github.com/JacquesCarette/Drasil/pull/4829#issuecomment-4092462316
Contributes to #4782 
Contributes to #2873 

Builds on #5125

Removes the last `map nw` usage. Now there's only some spots where `nw` is used and we can finally get rid of it `nw`.
