### PR TITLE
refactor: avoid `nw` usage in SRS introduction generation 

### DIFF
--- a/code/drasil-srs/lib/Drasil/SRS/Sections/Introduction.hs
+++ b/code/drasil-srs/lib/Drasil/SRS/Sections/Introduction.hs
@@ -186,7 +186,9 @@ orgIntro :: NamedIdea c => c -> Section -> Maybe Sentence -> [Contents]
 orgIntro bottom bottomSec trailingSentence =
   [ foldlSP [
       orgOfDocIntro, S "The presentation follows the standard pattern of presenting" +:+.
-      foldlList Comma List (map plural [nw goal, nw theory, nw definition, nw assumption]),
+      -- FIXME: This should be referencing specific sections, if they even
+      -- exist.
+      foldlList Comma List (map plural [goal, theory, definition] ++ [plural assumption]),
       S "For readers that would like a more bottom up approach" `sC`
       S "they can start reading the", namedRef bottomSec (plural bottom)`S.and_`
       S "trace back to find any additional information they require"


### PR DESCRIPTION
`nw` is a chunk 'extractor' that forms a whole new `IdeaDict` from something that supports every typeclass `IdeaDict` does too. As part of https://github.com/JacquesCarette/Drasil/issues/2873, we are trying to move away from rebuilding smaller versions of chunks with specific abilities to just using the whole chunk as normally.