### PR TITLE
refactor: avoid `nw` usage in symbol convention declarations

### DIFF
--- a/code/drasil-example/hghc/lib/Drasil/HGHC/Body.hs
+++ b/code/drasil-example/hghc/lib/Drasil/HGHC/Body.hs
@@ -24,7 +24,7 @@ si = mkSmithEtAlICO
 mkSRS :: SRSDecl
 mkSRS = [TableOfContents,
     RefSec $
-    RefProg intro [TUnits, tsymb [TSPurpose, SymbConvention [Lit $ nw nuclearPhys, Manual $ nw fp]]],
+    RefProg intro [TUnits, tsymb [TSPurpose, SymbConvention [Lit nuclearPhys, Manual fp]]],
     IntroSec $
     IntroProg introPara (phrase progName) [],
     SSDSec $ SSDProg [

--- a/code/drasil-example/swhs/lib/Drasil/SWHS/Body.hs
+++ b/code/drasil-example/swhs/lib/Drasil/SWHS/Body.hs
@@ -146,7 +146,7 @@ mkSRS = [TableOfContents,
 
 tSymbIntro :: [TSIntro]
 tSymbIntro = [TSPurpose, SymbConvention
-  [Lit (nw heatTrans), Doc' (nw progName)], SymbOrder, VectorUnits]
+  [Lit heatTrans, Doc' progName], SymbOrder, VectorUnits]
 
 insModel :: [InstanceModel]
 insModel = [eBalanceOnWtr, eBalanceOnPCM, heatEInWtr, heatEInPCM]

--- a/code/drasil-example/swhsnopcm/lib/Drasil/SWHSNoPCM/Body.hs
+++ b/code/drasil-example/swhsnopcm/lib/Drasil/SWHSNoPCM/Body.hs
@@ -91,7 +91,7 @@ mkSRS :: SRSDecl
 mkSRS = [TableOfContents,
   RefSec $ RefProg intro
   [TUnits,
-   tsymb [TSPurpose, SymbConvention [Lit $ nw htTrans, Doc' $ nw progName], SymbOrder, VectorUnits],
+   tsymb [TSPurpose, SymbConvention [Lit htTrans, Doc' progName], SymbOrder, VectorUnits],
    TAandA],
   IntroSec $
     IntroProg (introStart +:+ introStartNoPCM) (introEnd (plural progName) progName)

--- a/code/drasil-srs/lib/Drasil/SRS/DocumentLanguage/Core.hs
+++ b/code/drasil-srs/lib/Drasil/SRS/DocumentLanguage/Core.hs
@@ -12,7 +12,7 @@ module Drasil.SRS.DocumentLanguage.Core (
 
 import Data.Generics.Multiplate (Multiplate(multiplate, mkPlate))
 
-import Drasil.Database (UID)
+import Drasil.Database (UID, IsChunk)
 import Language.Drasil hiding (Manual, Verb) -- Manual - Citation name conflict. FIXME: Move to different namespace
 import Language.Drasil.Document
 import Theory.Drasil (DataDefinition, GenDefn, InstanceModel, TheoryModel)
@@ -80,13 +80,15 @@ instance Show Emphasis where
   show Italics = "italics"
 
 -- | Types of literature.
-data Literature = Lit Topic -- ^ Literature (with a Topic).
-                | Doc Topic -- ^ Existing documentation for (singular topic).
-                | Doc' Topic -- ^ Existing documentation for (plural version of topic).
-                | Manual Topic -- ^ Manual.
-
--- | Type synonym for clarity.
-type Topic = IdeaDict
+data Literature where
+  -- | Literature (with a topic).
+  Lit :: (IsChunk t, NamedIdea t) => t -> Literature
+  -- | Existing documentation for (singular topic).
+  Doc :: (IsChunk t, NamedIdea t) => t -> Literature
+  -- | Existing documentation for (plural version of topic).
+  Doc' :: (IsChunk t, NamedIdea t) => t -> Literature
+  -- | Manual.
+  Manual :: (IsChunk t, NamedIdea t) => t -> Literature
 
 -- | For creating the table of units introduction.
 data TUIntro = System -- ^ System of units (defaults to SI).


### PR DESCRIPTION
Builds on #5127 

Removes more `nw` usage in an operational way.

Does not contribute to using `UID`s/`UIDRef`s instead of embedding whole chunks, but it might be a good one to give as an example to fix. From a quick search with github issues, I don't see anything discussing this. I'll have to look for that later.