### PR TITLE
fix(CODEOWNERS/`drasil-data-formats`): make sure @JacquesCarette is an owner

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -43,4 +43,4 @@ code/drasil-gool/ @JacquesCarette @bmaclach
 
 # Individual Projects
 
-code/drasil-data-formats/ @balacij
+code/drasil-data-formats/ @JacquesCarette @balacij


### PR DESCRIPTION
As mentioned earlier in the same file, the CODEOWNERS file needs `@JacquesCarette` added to each item because each item overwrites the global default rule.