### PR TITLE
drasil-utils: rename Lists→Data.List.Extras, Strings→Data.String.Extr…

### DIFF
--- a/code/drasil-code/lib/Language/Drasil/CodeSpec.hs
+++ b/code/drasil-code/lib/Language/Drasil/CodeSpec.hs
@@ -30,7 +30,7 @@ import Drasil.Code.CodeExpr.Development (expr, eNamesRI, eDep)
 import qualified Drasil.System as S
 import Drasil.System (HasSmithEtAlSRS(..), HasSystemMeta(..), programName)
 import Theory.Drasil (DataDefinition, qdEFromDD, getEqModQdsFromIm)
-import Utils.Drasil (subsetOf)
+import Data.List.Extras (subsetOf)
 
 import Drasil.Code.CodeVar (CodeChunk, CodeIdea(codeChunk), CodeVarChunk)
 import Language.Drasil.Chunk.ConstraintMap (ConstraintCEMap, ConstraintCE, constraintMap)

--- a/code/drasil-code/lib/Language/Drasil/ICOSolutionSearch.hs
+++ b/code/drasil-code/lib/Language/Drasil/ICOSolutionSearch.hs
@@ -7,7 +7,7 @@ import Data.List ((\\), intercalate, partition)
 
 import Drasil.Database (ChunkDB, showUID, HasUID)
 import Language.Drasil.Chunk.CodeDefinition (CodeDefinition, auxExprs)
-import Utils.Drasil (subsetOf)
+import Data.List.Extras (subsetOf)
 
 import Drasil.Code.CodeVar (DefiningCodeExpr(..), CodeVarChunk)
 import Language.Drasil.Chunk.CodeBase (codevars', quantvar)

--- a/code/drasil-code/lib/Language/Drasil/Mod.hs
+++ b/code/drasil-code/lib/Language/Drasil/Mod.hs
@@ -12,7 +12,7 @@ import Data.List ((\\), nub)
 import Language.Drasil (Space, MayHaveUnit, Quantity, LiteralC(int), Concept)
 import Drasil.Database (ChunkDB)
 import Drasil.GOOL (VisibilityTag(..))
-import Utils.Drasil (toPlainName)
+import Data.String.Extras (toPlainName)
 
 import Drasil.Code.CodeExpr (CodeExpr)
 import Language.Drasil.Chunk.Code (CodeVarChunk, CodeFuncChunk, codevars,

--- a/code/drasil-data/lib/Data/Drasil/Theories/Physics.hs
+++ b/code/drasil-data/lib/Data/Drasil/Theories/Physics.hs
@@ -3,7 +3,7 @@ module Data.Drasil.Theories.Physics where
 
 import Language.Drasil
 import Language.Drasil.Document
-import Utils.Drasil (weave)
+import Data.List.Extras (weave)
 import Theory.Drasil
 import qualified Language.Drasil.Sentence.Combinators as S
 

--- a/code/drasil-example/dblpend/lib/Drasil/DblPend/GenDefs.hs
+++ b/code/drasil-example/dblpend/lib/Drasil/DblPend/GenDefs.hs
@@ -8,7 +8,7 @@ import qualified Data.List.NonEmpty as NE
 
 import Language.Drasil
 import qualified Language.Drasil.Development as D
-import Utils.Drasil (weave)
+import Data.List.Extras (weave)
 import Theory.Drasil
 import Language.Drasil.Chunk.Concept.NamedCombinators
 import qualified Language.Drasil.Sentence.Combinators as S

--- a/code/drasil-example/dblpend/lib/Drasil/DblPend/IMods.hs
+++ b/code/drasil-example/dblpend/lib/Drasil/DblPend/IMods.hs
@@ -6,7 +6,7 @@ import Prelude hiding (cos, sin)
 import Language.Drasil
 import Language.Drasil.Document
 import Theory.Drasil
-import Utils.Drasil (weave)
+import Data.List.Extras (weave)
 import qualified Language.Drasil.Sentence.Combinators as S
 
 import Data.Drasil.Concepts.Documentation (condition)

--- a/code/drasil-example/gamephysics/lib/Drasil/GamePhysics/DataDefs.hs
+++ b/code/drasil-example/gamephysics/lib/Drasil/GamePhysics/DataDefs.hs
@@ -9,7 +9,7 @@ import Language.Drasil
 import Language.Drasil.Document
 
 import Theory.Drasil
-import Utils.Drasil (weave)
+import Data.List.Extras (weave)
 import Language.Drasil.Chunk.Concept.NamedCombinators
 import qualified Language.Drasil.Development as D
 import qualified Language.Drasil.Sentence.Combinators as S

--- a/code/drasil-example/gamephysics/lib/Drasil/GamePhysics/GenDefs.hs
+++ b/code/drasil-example/gamephysics/lib/Drasil/GamePhysics/GenDefs.hs
@@ -9,7 +9,7 @@ import Language.Drasil
 import Language.Drasil.Document
 import qualified Language.Drasil.Sentence.Combinators as S
 import Theory.Drasil (GenDefn, gd, equationalModel', Derivation, mkDerivName)
-import Utils.Drasil (weave)
+import Data.List.Extras (weave)
 
 import Drasil.GamePhysics.DataDefs (collisionAssump, rightHandAssump,
   rigidTwoDAssump)

--- a/code/drasil-example/gamephysics/lib/Drasil/GamePhysics/IMods.hs
+++ b/code/drasil-example/gamephysics/lib/Drasil/GamePhysics/IMods.hs
@@ -5,7 +5,7 @@ import Language.Drasil
 import Language.Drasil.Document
 import Language.Drasil.ShortHands (lJ)
 import Theory.Drasil
-import Utils.Drasil (weave)
+import Data.List.Extras (weave)
 import Language.Drasil.Chunk.Concept.NamedCombinators
 import qualified Language.Drasil.Development as D
 import qualified Language.Drasil.Sentence.Combinators as S

--- a/code/drasil-example/pdcontroller/lib/Drasil/PDController/IModel.hs
+++ b/code/drasil-example/pdcontroller/lib/Drasil/PDController/IModel.hs
@@ -9,7 +9,7 @@ import qualified Language.Drasil.Development as D
 import qualified Language.Drasil.Sentence.Combinators as S
 import Theory.Drasil (InstanceModel, im, qwC, newDEModel', Derivation, mkDerivName, DifferentialModel,
   makeASingleDE, ($**), ($^^), ($++))
-import Utils.Drasil (weave)
+import Data.List.Extras (weave)
 
 import Drasil.PDController.Assumptions
 import Drasil.PDController.Concepts

--- a/code/drasil-example/projectile/lib/Drasil/Projectile/GenDefs.hs
+++ b/code/drasil-example/projectile/lib/Drasil/Projectile/GenDefs.hs
@@ -19,7 +19,7 @@ import qualified Language.Drasil.Sentence.Combinators as S
 import qualified Language.Drasil.Development as D
 import Theory.Drasil (GenDefn, TheoryModel, gd, gdNoRefs, equationalModel', Derivation,
   mkDerivName)
-import Utils.Drasil (weave)
+import Data.List.Extras (weave)
 
 import Drasil.Projectile.Assumptions (cartSyst, constAccel, pointMass, timeStartZero, twoDMotion)
 import Drasil.Projectile.Concepts (rectVel)

--- a/code/drasil-example/projectile/lib/Drasil/Projectile/IMods.hs
+++ b/code/drasil-example/projectile/lib/Drasil/Projectile/IMods.hs
@@ -15,7 +15,7 @@ import Language.Drasil.Chunk.Concept.NamedCombinators
 import qualified Language.Drasil.Sentence.Combinators as S
 import Theory.Drasil (InstanceModel, imNoDerivNoRefs, imNoRefs, qwC, equationalModelN,
   Derivation, mkDerivName)
-import Utils.Drasil (weave)
+import Data.List.Extras (weave)
 
 import Drasil.Projectile.Assumptions (accelXZero, accelYGravity, gravAccelValue,
   launchOrigin, posXDirection, targetXAxis, timeStartZero, yAxisGravity)

--- a/code/drasil-example/sglpend/lib/Drasil/SglPend/GenDefs.hs
+++ b/code/drasil-example/sglpend/lib/Drasil/SglPend/GenDefs.hs
@@ -24,7 +24,7 @@ import Theory.Drasil (GenDefn, gdNoRefs,
     Derivation, mkDerivName,
     equationalModel', equationalModelU, equationalRealmU,
     MultiDefn, mkDefiningExpr, mkMultiDefnForQuant)
-import Utils.Drasil (weave)
+import Data.List.Extras (weave)
 
 import Drasil.SglPend.DataDefs (frequencyDD, periodSHMDD, angFrequencyDD)
 import qualified Drasil.SglPend.Derivations as D

--- a/code/drasil-example/sglpend/lib/Drasil/SglPend/IMods.hs
+++ b/code/drasil-example/sglpend/lib/Drasil/SglPend/IMods.hs
@@ -16,7 +16,7 @@ import Language.Drasil.Chunk.Concept.NamedCombinators
 import qualified Language.Drasil.Sentence.Combinators as S
 import qualified Language.Drasil.NaturalLanguage.English.NounPhrase.Combinators as NP
 import Theory.Drasil
-import Utils.Drasil (weave)
+import Data.List.Extras (weave)
 
 import Drasil.SglPend.GenDefs (angFrequencyGD)
 import Drasil.SglPend.Derivations (angularDisplacementDerivEqns)

--- a/code/drasil-example/ssp/lib/Drasil/SSP/GenDefs.hs
+++ b/code/drasil-example/ssp/lib/Drasil/SSP/GenDefs.hs
@@ -31,7 +31,7 @@ import Data.Drasil.Theories.Physics (weightGD, hsPressureGD, torqueDD)
 
 import Theory.Drasil
 
-import Utils.Drasil (weave)
+import Data.List.Extras (weave)
 
 import Drasil.SSP.Assumptions (assumpFOSL, assumpSLH, assumpSP, assumpSLI,
   assumpINSFL, assumpPSC, assumpSBSBISL, assumpWIBE, assumpWISE, assumpNESSS,

--- a/code/drasil-example/ssp/lib/Drasil/SSP/IMods.hs
+++ b/code/drasil-example/ssp/lib/Drasil/SSP/IMods.hs
@@ -8,7 +8,7 @@ import Prelude hiding (tan, product, sin, cos)
 import Language.Drasil
 import Language.Drasil.Document
 import Theory.Drasil
-import Utils.Drasil (weave)
+import Data.List.Extras (weave)
 import Language.Drasil.Chunk.Concept.NamedCombinators
 import qualified Language.Drasil.Development as D
 import qualified Language.Drasil.Sentence.Combinators as S

--- a/code/drasil-example/ssp/lib/Drasil/SSP/Requirements.hs
+++ b/code/drasil-example/ssp/lib/Drasil/SSP/Requirements.hs
@@ -12,7 +12,7 @@ import Drasil.SRS (mkInputPropsTable, mkMaintainableNFR, mkCorrectNFR,
   mkUnderstandableNFR, mkReusableNFR)
 import Drasil.SRS.Concepts (datCon, propCorSol)
 
-import Utils.Drasil (mkTable)
+import Data.List.Extras (mkTable)
 
 import Data.Drasil.Concepts.Computation (inDatum)
 import Data.Drasil.Concepts.Documentation (datum, funcReqDom, input_, name_,

--- a/code/drasil-example/swhs/lib/Drasil/SWHS/GenDefs.hs
+++ b/code/drasil-example/swhs/lib/Drasil/SWHS/GenDefs.hs
@@ -15,7 +15,7 @@ import qualified Language.Drasil.Development as D
 import qualified Language.Drasil.Sentence.Combinators as S
 import Theory.Drasil (GenDefn, gd, gdNoRefs, deModel', equationalModel', Derivation,
   mkDerivName, RelationConcept, makeRC)
-import Utils.Drasil (weave)
+import Data.List.Extras (weave)
 
 import Drasil.SWHS.Assumptions (assumpCWTAT, assumpLCCCW, assumpLCCWP,
   assumpTPCAV, assumpDWPCoV, assumpSHECoV, assumpTHCCoT)

--- a/code/drasil-example/swhs/lib/Drasil/SWHS/IMods.hs
+++ b/code/drasil-example/swhs/lib/Drasil/SWHS/IMods.hs
@@ -11,7 +11,7 @@ import qualified Language.Drasil.NaturalLanguage.English.NounPhrase.Combinators 
 import qualified Language.Drasil.Sentence.Combinators as S
 import Theory.Drasil (InstanceModel, im, imNoDeriv, qwC, qwUC, deModel',
   equationalModel, ModelKind, Derivation, mkDerivName, RelationConcept, makeRC)
-import Utils.Drasil (weave)
+import Data.List.Extras (weave)
 
 import Data.Drasil.Citations
 

--- a/code/drasil-example/swhsnopcm/lib/Drasil/SWHSNoPCM/IMods.hs
+++ b/code/drasil-example/swhsnopcm/lib/Drasil/SWHSNoPCM/IMods.hs
@@ -15,7 +15,7 @@ import qualified Language.Drasil.Development as D
 import qualified Language.Drasil.Sentence.Combinators as S
 import Theory.Drasil (InstanceModel, im, qwC, qwUC, newDEModel',
   Derivation, mkDerivName, DifferentialModel, makeASystemDE)
-import Utils.Drasil (weave)
+import Data.List.Extras (weave)
 
 -- other parts of SHWS
 import Drasil.SWHS.Concepts (water)

--- a/code/drasil-gool/lib/Drasil/Shared/State.hs
+++ b/code/drasil-gool/lib/Drasil/Shared/State.hs
@@ -37,7 +37,7 @@ import Drasil.Shared.AST (FileType(..), VisibilityTag(..), ScopeTag(..),
 import Drasil.Shared.CodeAnalysis (Exception, ExceptionType, printExc, hasLoc)
 import Drasil.Shared.CodeType (ClassName)
 
-import Utils.Drasil (nubSort)
+import Data.List.Extras (nubSort)
 
 import Control.Lens (Lens', (^.), lens, makeLenses, over, set, _1, _2, both, at)
 import Control.Monad.State (State, modify, gets)

--- a/code/drasil-lang/lib/Language/Drasil/Chunk/CommonIdea.hs
+++ b/code/drasil-lang/lib/Language/Drasil/Chunk/CommonIdea.hs
@@ -15,7 +15,7 @@ import Control.Lens (makeLenses, (^.), view)
 
 import Drasil.Database (UID, HasUID(uid), HasChunkRefs(..))
 import qualified Data.Set as Set
-import Utils.Drasil (repUnd)
+import Data.String.Extras (repUnd)
 
 import Language.Drasil.Chunk.NamedIdea (IdeaDict, nc)
 import Language.Drasil.Classes (NamedIdea(term), Idea(getA),

--- a/code/drasil-lang/lib/Language/Drasil/Document/Sections.hs
+++ b/code/drasil-lang/lib/Language/Drasil/Document/Sections.hs
@@ -11,7 +11,7 @@ module Language.Drasil.Document.Sections (
 import Control.Lens ((^.), makeLenses, view)
 
 import Drasil.Database (UID, HasUID(..), (+++.), mkUid, nsUid, HasChunkRefs(..))
-import Utils.Drasil (repUnd)
+import Data.String.Extras (repUnd)
 import qualified Data.Set as Set
 
 import Language.Drasil.ShortName (HasShortName(..), ShortName, shortname')

--- a/code/drasil-lang/lib/Language/Drasil/Expr/Class.hs
+++ b/code/drasil-lang/lib/Language/Drasil/Expr/Class.hs
@@ -14,7 +14,7 @@ import Prelude hiding (sqrt, log, sin, cos, tan, exp)
 import Control.Lens ((^.))
 
 import Drasil.Database (HasUID(..), IsChunk)
-import Utils.Drasil (toColumn)
+import Data.List.Extras (toColumn)
 
 import Language.Drasil.Symbol
 import Language.Drasil.Expr.Lang

--- a/code/drasil-lang/lib/Language/Drasil/Sentence/Fold.hs
+++ b/code/drasil-lang/lib/Language/Drasil/Sentence/Fold.hs
@@ -19,7 +19,7 @@ import Language.Drasil.Expr.Class ( ExprC(($&&), realInterval) )
 import Language.Drasil.Sentence
     ( Sentence(S, E, EmptyS, (:+:)), sParen, (+:+), sC, (+:+.), (+:) )
 import qualified Language.Drasil.Sentence.Combinators as S (and_, or_)
-import Utils.Drasil
+import Data.List.Extras (foldle, foldle1)
 import Data.Foldable (foldl')
 
 -- TODO: This looks like it should be moved to wherever uses it, it's too specific.

--- a/code/drasil-printers/lib/Language/Drasil/Plain/Print.hs
+++ b/code/drasil-printers/lib/Language/Drasil/Plain/Print.hs
@@ -15,7 +15,7 @@ import Text.PrettyPrint.HughesPJ (Doc, (<>), (<+>), brackets, comma, double,
 
 import Language.Drasil (Special(..), Stage(..), Symbol, USymb(..))
 import qualified Language.Drasil as L (HasSymbol(..))
-import Utils.Drasil (toPlainName)
+import Data.String.Extras (toPlainName)
 
 import Language.Drasil.Printing.AST (Expr(..), Spec(..), Ops(..), Fence(..),
   OverSymb(..), Fonts(..), Spacing(..), LinkType(..))

--- a/code/drasil-srs/lib/Drasil/SRS/Sections/AuxiliaryConstants.hs
+++ b/code/drasil-srs/lib/Drasil/SRS/Sections/AuxiliaryConstants.hs
@@ -9,7 +9,7 @@ import Control.Lens ((^.))
 import Drasil.Database (HasUID(..))
 import Language.Drasil
 import Language.Drasil.Document
-import Utils.Drasil (mkTable)
+import Data.List.Extras (mkTable)
 
 -- Other docLang
 import qualified Drasil.SRS.Concepts as SRS (valsOfAuxCons)

--- a/code/drasil-srs/lib/Drasil/SRS/Sections/Requirements.hs
+++ b/code/drasil-srs/lib/Drasil/SRS/Sections/Requirements.hs
@@ -25,7 +25,8 @@ import Language.Drasil.Chunk.Concept.NamedCombinators
 import qualified Language.Drasil.Sentence.Combinators as S
 import qualified Language.Drasil.Development as D
 import Theory.Drasil (HasOutput(output))
-import Utils.Drasil (stringList, mkTable)
+import Utils.Drasil (stringList)
+import Data.List.Extras (mkTable)
 
 -- Vocabulary
 import Drasil.Metadata.Documentation (description, funcReqDom, nonFuncReqDom,

--- a/code/drasil-srs/lib/Drasil/SRS/Sections/TableOfAbbAndAcronyms.hs
+++ b/code/drasil-srs/lib/Drasil/SRS/Sections/TableOfAbbAndAcronyms.hs
@@ -13,7 +13,7 @@ import Language.Drasil.Document
 import Language.Drasil.Development (toSent)
 import Drasil.Database (HasUID(..))
 import Drasil.Database.SearchTools (TermAbbr (shortForm), longForm)
-import Utils.Drasil (mkTable)
+import Data.List.Extras (mkTable)
 
 -- Vocabulary
 import Drasil.Metadata.Documentation (abbreviation, fullForm, abbAcc)

--- a/code/drasil-srs/lib/Drasil/SRS/Sections/TableOfSymbols.hs
+++ b/code/drasil-srs/lib/Drasil/SRS/Sections/TableOfSymbols.hs
@@ -11,7 +11,7 @@ import Language.Drasil hiding (Manual, Verb) -- Manual - Citation name conflict.
                                              -- Vector - Name conflict (defined in file)
 import Language.Drasil.Document
 import Drasil.Database (HasUID(..))
-import Utils.Drasil (mkTable)
+import Data.List.Extras (mkTable)
 
 -- Vocabulary
 import Drasil.Metadata.Documentation (symbol_, description, tOfSymb)

--- a/code/drasil-srs/lib/Drasil/SRS/Sections/TableOfUnits.hs
+++ b/code/drasil-srs/lib/Drasil/SRS/Sections/TableOfUnits.hs
@@ -8,7 +8,7 @@ import Control.Lens ((^.))
 -- General Drasil
 import Language.Drasil
 import Language.Drasil.Document
-import Utils.Drasil (mkTable)
+import Data.List.Extras (mkTable)
 
 -- Vocabulary
 import Drasil.Metadata.Documentation (symbol_, description, tOfUnit)

--- a/code/drasil-system/lib/Drasil/System/SmithEtAlSRS.hs
+++ b/code/drasil-system/lib/Drasil/System/SmithEtAlSRS.hs
@@ -28,7 +28,7 @@ import Language.Drasil (Quantity, MayHaveUnit, Concept, People, CI,
   Constrained, ConstQDef, abrv, DefinedQuantityDict)
 import Language.Drasil.Document (LabelledContent, Reference)
 import Theory.Drasil (TheoryModel, GenDefn, DataDefinition, InstanceModel)
-import Utils.Drasil (toPlainName)
+import Data.String.Extras (toPlainName)
 
 import Drasil.System.Core (SystemMeta, Background, HasSystemMeta(..),
   mkSystemMeta, Motivation, Purpose, Scope)

--- a/code/drasil-utils/lib/Data/List/Extras.hs
+++ b/code/drasil-utils/lib/Data/List/Extras.hs
@@ -1,5 +1,5 @@
 -- | Functions for working with lists.
-module Utils.Drasil.Lists (
+module Data.List.Extras (
   replaceAll,
   subsetOf, nubSort,
   weave,

--- a/code/drasil-utils/lib/Data/String/Extras.hs
+++ b/code/drasil-utils/lib/Data/String/Extras.hs
@@ -1,9 +1,9 @@
 -- Contains a function that removes special characters from strings.
-module Utils.Drasil.Strings (
+module Data.String.Extras (
   toPlainName, repUnd
 ) where
 
-import Utils.Drasil.Lists (replaceAll)
+import Data.List.Extras (replaceAll)
 
 -- | Replace occurences of special characters (@",~`-=!@#$%^&*+[]\\;'/|\"<>? "@)
 --   with underscores (@"_"@).

--- a/code/drasil-utils/lib/Utils/Drasil.hs
+++ b/code/drasil-utils/lib/Utils/Drasil.hs
@@ -1,10 +1,10 @@
 -- | Re-exports all utilities.
 module Utils.Drasil (
   module Utils.Drasil.English,
-  module Utils.Drasil.Lists,
-  module Utils.Drasil.Strings,
+  module Data.List.Extras,
+  module Data.String.Extras,
 ) where
 
 import Utils.Drasil.English
-import Utils.Drasil.Lists
-import Utils.Drasil.Strings
+import Data.List.Extras
+import Data.String.Extras

--- a/code/drasil-utils/lib/Utils/Drasil.hs
+++ b/code/drasil-utils/lib/Utils/Drasil.hs
@@ -1,10 +1,5 @@
 -- | Re-exports all utilities.
 module Utils.Drasil (
   module Utils.Drasil.English,
-  module Data.List.Extras,
-  module Data.String.Extras,
 ) where
-
 import Utils.Drasil.English
-import Data.List.Extras
-import Data.String.Extras

--- a/code/drasil-utils/package.yaml
+++ b/code/drasil-utils/package.yaml
@@ -27,3 +27,7 @@ library:
   source-dirs: lib
   exposed-modules:
   - Utils.Drasil
+  - Data.List.Extras
+  - Data.String.Extras
+  other-modules:
+  - Utils.Drasil.English

--- a/code/drasil-utils/package.yaml
+++ b/code/drasil-utils/package.yaml
@@ -29,5 +29,4 @@ library:
   - Utils.Drasil
   - Data.List.Extras
   - Data.String.Extras
-  other-modules:
-  - Utils.Drasil.English
+


### PR DESCRIPTION
Renames `Utils.Drasil.Lists` → `Data.List.Extras` and `Utils.Drasil.Strings` → `Data.String.Extras` within `drasil-utils`, as discussed in #1211. Updates the `Utils.Drasil` re-export module and `package.yaml` accordingly. `Utils.Drasil.English` is left unchanged pending the future `drasil-natural-language` package.