### PR TITLE
chore: remove unnecessary `cw` usage

### DIFF
--- a/code/drasil-data/lib/Data/Drasil/Concepts/Documentation.hs
+++ b/code/drasil-data/lib/Data/Drasil/Concepts/Documentation.hs
@@ -157,5 +157,5 @@ userInput                    = compoundNC user input_
 
 -- | List of SRS-related concepts, including SRS.
 srsDomains :: [ConceptChunk]
-srsDomains = [cw srsDom, goalStmtDom, reqDom, funcReqDom, nonFuncReqDom,
+srsDomains = [srsDom, goalStmtDom, reqDom, funcReqDom, nonFuncReqDom,
   assumpDom, chgProbDom, likeChgDom, unlikeChgDom]

--- a/code/drasil-example/swhs/lib/Drasil/SWHS/Body.hs
+++ b/code/drasil-example/swhs/lib/Drasil/SWHS/Body.hs
@@ -334,7 +334,7 @@ userChars pro = foldlSP [S "The end", phrase user `S.of_` short pro,
 -----------------------------------------
 
 terms :: [ConceptChunk]
-terms = map cw [htFlux, phaseChangeMaterial, cw heatCapSpec, thermalConduction, transient]
+terms = [htFlux, phaseChangeMaterial, cw heatCapSpec, thermalConduction, transient]
 
 -- Included heat flux and specific heat in NamedChunks even though they are
 -- already in SWHSUnits


### PR DESCRIPTION
Builds on #5119 