### PR TITLE
refactor: simplify code related to finding chunks references in a `Sentence`

### DIFF
--- a/code/drasil-lang/lib/Language/Drasil.hs
+++ b/code/drasil-lang/lib/Language/Drasil.hs
@@ -89,7 +89,7 @@ module Language.Drasil (
   , mkQDefSt, mkQuantDef, mkQuantDef', ec
   , mkFuncDef, mkFuncDef', mkFuncDefByQ
   -- Language.Drasil.Chunk.DefinedQuantity
-  , DefinedQuantityDict, dqd, dqd', dqdNoUnit, dqdNoUnit', dqdQd, dqdWr
+  , DefinedQuantityDict, dqd, dqd', dqdNoUnit, dqdNoUnit', dqdWr
   , DefinesQuantity(defLhs), implVar, implVar', implVarAU'
   -- Language.Drasil.Chunk.Unital
   , UnitalChunk(..), uc, uc', ucStaged, ucStaged'

--- a/code/drasil-lang/lib/Language/Drasil/Chunk/DefinedQuantity.hs
+++ b/code/drasil-lang/lib/Language/Drasil/Chunk/DefinedQuantity.hs
@@ -6,7 +6,7 @@ module Language.Drasil.Chunk.DefinedQuantity (
   -- * Type classes
   DefinesQuantity(defLhs),
   -- * Constructors
-  dqd, dqdNoUnit, dqdNoUnit', dqd', dqdQd, dqdWr,
+  dqd, dqdNoUnit, dqdNoUnit', dqd', dqdWr,
   implVar, implVar', implVarAU, implVarAU'
 ) where
 
@@ -18,7 +18,7 @@ import qualified Data.Set as Set
 import Language.Drasil.Symbol (HasSymbol(symbol), Symbol (Empty))
 import Language.Drasil.Classes (NamedIdea(term), Idea(getA), Concept, Express(..),
   Definition(defn), ConceptDomain(cdom), IsUnit, Quantity)
-import Language.Drasil.Chunk.Concept (ConceptChunk, cw, dcc, dccWDS, dccA, dccAWDS, cc')
+import Language.Drasil.Chunk.Concept (ConceptChunk, cw, dcc, dccWDS, dccA, dccAWDS)
 import Language.Drasil.Expr.Class (sy)
 import Language.Drasil.Chunk.UnitDefn (UnitDefn, unitWrapper,
   MayHaveUnit(getUnit))
@@ -90,10 +90,6 @@ dqd' = DQD
 -- | When the input already has all the necessary information. A 'projection' operator from some a type with instances of listed classes to a 'DefinedQuantityDict'.
 dqdWr :: (Quantity c, Concept c, MayHaveUnit c) => c -> DefinedQuantityDict
 dqdWr c = DQD (cw c) (symbol c) (c ^. typ) (getUnit c)
-
--- | When we want to merge a quantity and a concept. This is suspicious.
-dqdQd :: (Quantity c, MayHaveUnit c) => c -> Sentence -> DefinedQuantityDict
-dqdQd c cc = DQD (cc' c cc) (symbol c) (c ^. typ) (getUnit c)
 
 -- | Makes a variable that is implementation-only.
 implVar :: String -> NP -> String -> Space -> Symbol -> DefinedQuantityDict

--- a/code/drasil-srs/lib/Drasil/SRS/GetChunks.hs
+++ b/code/drasil-srs/lib/Drasil/SRS/GetChunks.hs
@@ -1,7 +1,7 @@
 -- | Utilities to get grab certain chunks (from 'Expr', 'Sentence', etc) by
 -- 'UID' and dereference the chunk it refers to.
 module Drasil.SRS.GetChunks (
-  ccss, ccss', combine, vars
+  ccss, ccss', vars
 ) where
 
 import qualified Data.Set as Set
@@ -10,7 +10,6 @@ import Language.Drasil
 import Language.Drasil.Development (sdep)
 import Language.Drasil.ModelExpr.Development (meDep)
 import Drasil.Database (ChunkDB, findOrErr)
-import Drasil.Database.SearchTools (defResolve', DomDefn(definition))
 
 -- | Gets a list of quantities ('DefinedQuantityDict') from an equation in order to print.
 vars :: ModelExpr -> ChunkDB -> [DefinedQuantityDict]
@@ -20,26 +19,10 @@ vars e m = map (`findOrErr` m) $ meDep e
 vars' :: Sentence -> ChunkDB -> [DefinedQuantityDict]
 vars' a m = map (`findOrErr` m) $ Set.toList (sdep a)
 
--- | Combines the functions of 'vars' and 'concpt' to create a list of 'DefinedQuantityDict's from a 'Sentence'.
-combine :: Sentence -> ChunkDB -> [DefinedQuantityDict]
-combine a m = zipWith dqdQd (vars' a m) (concpt a m)
-
--- | Combines the functions of 'vars' and 'concpt' to create a list of 'DefinedQuantityDict's from an equation.
-combine' :: ModelExpr -> ChunkDB -> [DefinedQuantityDict]
-combine' a m = zipWith dqdQd (vars a m) (concpt' a m)
-
 -- | Gets a list of defined quantities ('DefinedQuantityDict's) from 'Sentence's and expressions that are contained in the database ('ChunkDB').
 ccss :: [Sentence] -> [ModelExpr] -> ChunkDB -> [DefinedQuantityDict]
-ccss s e c = concatMap (`combine` c) s ++ concatMap (`combine'` c) e
+ccss s e c = concatMap (`vars'` c) s ++ concatMap (`vars` c) e
 
 -- | Gets a list of quantities ('DefinedQuantityDict's) from 'Sentence's and expressions that are contained in the database ('ChunkDB').
 ccss' :: [Sentence] -> [ModelExpr] -> ChunkDB -> [DefinedQuantityDict]
 ccss' s e c = concatMap (`vars'` c) s ++ concatMap (`vars` c) e
-
--- | Gets a list of concepts ('ConceptChunk') from a 'Sentence' in order to print.
-concpt :: Sentence -> ChunkDB -> [Sentence]
-concpt a m = map (definition . defResolve' m) $ Set.toList (sdep a)
-
--- | Gets a list of concepts ('ConceptChunk') from an expression in order to print.
-concpt' :: ModelExpr -> ChunkDB -> [Sentence]
-concpt' a m = map (definition . defResolve' m) $ meDep a


### PR DESCRIPTION
Thanks to #2873 and #4272 this code is a lot cleaner! No need to merge a `ConceptChunk` with a `QuantityDict` to retrieve the original description associated with a quantity.