### PR TITLE
feat(`ConceptChunk`+`IdeaDict`): create new smart constructors that avoid/discourage chunk casting and nesting, deprecate old ones

### DIFF
--- a/.github/workflows/Build.yaml
+++ b/.github/workflows/Build.yaml
@@ -81,10 +81,10 @@ jobs:
         run: make stackArgs="--no-terminal" deps
 
       - name: "Build"
-        run: make code stackArgs="--no-terminal" GHCFLAGS="-Werror"
+        run: make code stackArgs="--no-terminal" GHCFLAGS="-Werror -Wwarn=deprecations"
 
       - name: "Test built artifacts against stable"
-        run: make stackArgs="--no-terminal" GHCFLAGS="-Werror" NOISY=yes
+        run: make stackArgs="--no-terminal" GHCFLAGS="-Werror -Wwarn=deprecations" NOISY=yes
 
       - name: "Compile GOOL examples"
         run: make codegenTest

--- a/.github/workflows/Deploy.yaml
+++ b/.github/workflows/Deploy.yaml
@@ -64,10 +64,10 @@ jobs:
         run: make stackArgs="--no-terminal" deps
 
       - name: "Build"
-        run: make code stackArgs="--no-terminal" GHCFLAGS="-Werror"
+        run: make code stackArgs="--no-terminal" GHCFLAGS="-Werror -Wwarn=deprecations"
 
       - name: "Test built artifacts against stable"
-        run: make stackArgs="--no-terminal" GHCFLAGS="-Werror" NOISY=yes
+        run: make stackArgs="--no-terminal" GHCFLAGS="-Werror -Wwarn=deprecations" NOISY=yes
 
       - name: "Compile GOOL examples"
         run: make codegenTest

--- a/code/drasil-lang/lib/Language/Drasil.hs
+++ b/code/drasil-lang/lib/Language/Drasil.hs
@@ -81,7 +81,7 @@ module Language.Drasil (
   -- Language.Drasil.Chunk.Concept.Core
   , ConceptChunk, ConceptInstance, sDom
   -- Language.Drasil.Chunk.Concept
-  , dcc, dccAWDS, dccA, dccWDS, cc', ccs, cw, cic
+  , cncpt, cncpt', cncpt'', dcc, dccAWDS, dccA, dccWDS, cc', cw, cic
 
   -- *** Quantities and Units
   -- Language.Drasil.Chunk.Eq

--- a/code/drasil-lang/lib/Language/Drasil.hs
+++ b/code/drasil-lang/lib/Language/Drasil.hs
@@ -72,7 +72,7 @@ module Language.Drasil (
 
   -- *** Basic types
   -- Language.Drasil.Chunk.NamedIdea
-  , nc, ncUID, IdeaDict , mkIdea
+  , IdeaDict, idea, idea', nc, ncUID, mkIdea
   , nw -- bad name (historical)
   -- Language.Drasil.Chunk.CommonIdea
   , CI, commonIdeaWithDict, prependAbrv

--- a/code/drasil-lang/lib/Language/Drasil.hs
+++ b/code/drasil-lang/lib/Language/Drasil.hs
@@ -81,7 +81,7 @@ module Language.Drasil (
   -- Language.Drasil.Chunk.Concept.Core
   , ConceptChunk, ConceptInstance, sDom
   -- Language.Drasil.Chunk.Concept
-  , cncpt, cncpt', cncpt'', dcc, dccAWDS, dccA, dccWDS, cc', cw, cic
+  , cncpt, cncpt', cncpt'', cncpt''', dcc, dccAWDS, dccA, dccWDS, cc', cw, cic
 
   -- *** Quantities and Units
   -- Language.Drasil.Chunk.Eq

--- a/code/drasil-lang/lib/Language/Drasil/Chunk/Concept.hs
+++ b/code/drasil-lang/lib/Language/Drasil/Chunk/Concept.hs
@@ -3,7 +3,8 @@
 module Language.Drasil.Chunk.Concept (
   -- * Concept Chunks
   -- ** From an idea ('IdeaDict')
-  ConceptChunk, cncpt, cncpt', cncpt'', dcc, dccA, dccAWDS, dccWDS, cc', cw,
+  ConceptChunk, cncpt, cncpt', cncpt'', cncpt''',
+  dcc, dccA, dccAWDS, dccWDS, cc', cw,
   -- ** From a 'ConceptChunk'
   ConceptInstance, cic
   ) where
@@ -15,12 +16,15 @@ import Drasil.Database (HasUID(uid), nsUid, UID)
 import Language.Drasil.Classes (Idea, ConceptDomain(cdom), Concept)
 import Language.Drasil.Chunk.Concept.Core (ConceptChunk(ConDict), ConceptInstance(ConInst))
 import Language.Drasil.Sentence (Sentence(S))
-import Language.Drasil.Chunk.NamedIdea(mkIdea, nw, nc, idea)
+import Language.Drasil.Chunk.NamedIdea(mkIdea, nw, nc, idea, idea')
 import Language.Drasil.NaturalLanguage.English.NounPhrase (NP, pn)
 import Language.Drasil.ShortName (shortname')
 import qualified Language.Drasil.Classes as D (defn)
 
---FIXME: Temporary ConceptDomain tag hacking to not break everything.
+-- FIXME: There should only be two smart constructors ultimately for
+-- `ConceptChunk`s. One with an abbreviation, the other without. In other words,
+-- only `cncpt` and `cncpt'` should exist. The other ones should not. The
+-- problem here is that dealing with the other ones requires domain analysis.
 
 -- | Construct a 'ConceptChunk'.
 cncpt :: Concept dom =>
@@ -30,23 +34,23 @@ cncpt :: Concept dom =>
   NP ->
   -- | The definition of the 'term'
   Sentence ->
-  -- | The term's abbreviation, if one exists.
-  Maybe String ->
+  -- | The term's abbreviation.
+  String ->
   -- | The domain the 'term' belongs to.
   [dom] -> ConceptChunk
-cncpt u trm defn mabbr = ConDict (idea u trm mabbr) defn . map (^. uid)
+cncpt u trm defn accAbbr = ConDict (idea u trm accAbbr) defn . map (^. uid)
 
 -- | Construct a 'ConceptChunk'.
-cncpt' ::
+cncpt' :: Concept dom =>
   -- | The 'UID'.
   UID ->
   -- | The 'term' being defined.
   NP ->
   -- | The definition of the 'term'
   Sentence ->
-  -- | The term's abbreviation, if one exists.
-  Maybe String -> ConceptChunk
-cncpt' u trm defn mabbr = cncpt u trm defn mabbr ([] :: [ConceptChunk])
+  -- | The domain the 'term' belongs to.
+  [dom] -> ConceptChunk
+cncpt' u trm defn = ConDict (idea' u trm) defn . map (^. uid)
 
 -- | Construct a 'ConceptChunk'.
 cncpt'' ::
@@ -55,11 +59,24 @@ cncpt'' ::
   -- | The 'term' being defined.
   NP ->
   -- | The definition of the 'term'
+  Sentence ->
+  -- | The term's abbreviation.
+  String -> ConceptChunk
+cncpt'' u trm defn accAbbr = cncpt u trm defn accAbbr ([] :: [ConceptChunk])
+
+-- | Construct a 'ConceptChunk'.
+cncpt''' ::
+  -- | The 'UID'.
+  UID ->
+  -- | The 'term' being defined.
+  NP ->
+  -- | The definition of the 'term'
   Sentence -> ConceptChunk
-cncpt'' u trm defn = cncpt' u trm defn Nothing
+cncpt''' u trm defn = ConDict (idea' u trm) defn []
+
 
 {-# DEPRECATED dccA, dccAWDS, dcc, dccWDS, cc', cw
-  "Smart constructors allow externally-known chunk nesting; use one of `cncpt, cncpt', cncpt''` instead." #-}
+  "Smart constructors allow externally-known chunk nesting; use one of `cncpt, cncpt', cncpt'', cncpt'''` instead." #-}
 
 -- | Smart constructor for creating a concept chunks with an abbreviation. Takes
 -- a UID (String), a term (NounPhrase), a definition (String), and an

--- a/code/drasil-lang/lib/Language/Drasil/Chunk/Concept.hs
+++ b/code/drasil-lang/lib/Language/Drasil/Chunk/Concept.hs
@@ -1,8 +1,9 @@
--- | Contains functions to create the concept related chunk types found in "Language.Drasil.Chunk.Concept.Core".
+-- | Contains functions to create the concept related chunk types found in
+-- "Language.Drasil.Chunk.Concept.Core".
 module Language.Drasil.Chunk.Concept (
   -- * Concept Chunks
   -- ** From an idea ('IdeaDict')
-  ConceptChunk, dcc, dccA, dccAWDS, dccWDS, cc', ccs, cw,
+  ConceptChunk, cncpt, cncpt', cncpt'', dcc, dccA, dccAWDS, dccWDS, cc', cw,
   -- ** From a 'ConceptChunk'
   ConceptInstance, cic
   ) where
@@ -11,49 +12,88 @@ import Control.Lens ((^.))
 
 import Drasil.Database (HasUID(uid), nsUid)
 
-import Language.Drasil.Classes (Idea, Definition(defn), ConceptDomain(cdom), Concept)
+import Language.Drasil.Classes (Idea, ConceptDomain(cdom), Concept)
 import Language.Drasil.Chunk.Concept.Core (ConceptChunk(ConDict), ConceptInstance(ConInst))
 import Language.Drasil.Sentence (Sentence(S))
-import Language.Drasil.Chunk.NamedIdea(mkIdea, nw, nc, IdeaDict)
+import Language.Drasil.Chunk.NamedIdea(mkIdea, nw, nc)
 import Language.Drasil.NaturalLanguage.English.NounPhrase (NP, pn)
 import Language.Drasil.ShortName (shortname')
+import qualified Language.Drasil.Classes as D (defn)
 
 --FIXME: Temporary ConceptDomain tag hacking to not break everything.
 
--- | Smart constructor for creating a concept chunks with an abbreviation
--- Takes a UID (String), a term (NounPhrase), a definition (String), and an abbreviation (Maybe String).
+-- | Construct a 'ConceptChunk'.
+cncpt :: Concept dom =>
+  -- | The 'UID'.
+  String ->
+  -- The 'term' being defined.
+  NP ->
+  -- | The definition of the 'term'
+  Sentence ->
+  -- | The term's abbreviation, if one exists.
+  Maybe String ->
+  -- | The domain the 'term' belongs to.
+  [dom] -> ConceptChunk
+cncpt u trm defn mabbr = ConDict (mkIdea u trm mabbr) defn . map (^. uid)
+
+-- | Construct a 'ConceptChunk'.
+cncpt' ::
+  -- | The 'UID'.
+  String ->
+  -- | The 'term' being defined.
+  NP ->
+  -- | The definition of the 'term'
+  Sentence ->
+  -- | The term's abbreviation, if one exists.
+  Maybe String -> ConceptChunk
+cncpt' u trm defn mabbr = cncpt u trm defn mabbr ([] :: [ConceptChunk])
+
+-- | Construct a 'ConceptChunk'.
+cncpt'' ::
+  -- | The 'UID'.
+  String ->
+  -- | The 'term' being defined.
+  NP ->
+  -- | The definition of the 'term'
+  Sentence -> ConceptChunk
+cncpt'' u trm defn = cncpt' u trm defn Nothing
+
+{-# DEPRECATED dccA, dccAWDS, dcc, dccWDS, cc', cw
+  "Smart constructors allow externally-known chunk nesting; use one of `cncpt, cncpt', cncpt''` instead." #-}
+
+-- | Smart constructor for creating a concept chunks with an abbreviation. Takes
+-- a UID (String), a term (NounPhrase), a definition (String), and an
+-- abbreviation (Maybe String).
 dccA :: String -> NP -> String -> Maybe String -> ConceptChunk
 dccA i ter des a = ConDict (mkIdea i ter a) (S des) []
 
 dccAWDS :: String -> NP -> Sentence -> Maybe String -> ConceptChunk
 dccAWDS i t d a = ConDict (mkIdea i t a) d []
 
+-- | Smart constructor for creating concept chunks given a 'UID', 'NounPhrase'
+-- ('NP') and definition (as a 'String').
 dcc :: String -> NP -> String -> ConceptChunk
--- | Smart constructor for creating concept chunks given a 'UID',
--- 'NounPhrase' ('NP') and definition (as a 'String').
 dcc i ter des = dccA i ter des Nothing
--- ^ Concept domain tagging is not yet implemented in this constructor.
 
 -- | Similar to 'dcc', except the definition takes a 'Sentence'.
 dccWDS :: String -> NP -> Sentence -> ConceptChunk
 dccWDS i t d = dccAWDS i t d Nothing
 
--- | Constructor for projecting an idea into a 'ConceptChunk'. Takes the definition of the
--- 'ConceptChunk' as a 'Sentence. Does not allow concept domain tagging.
+-- | Constructor for projecting an idea into a 'ConceptChunk'. Takes the
+-- definition of the 'ConceptChunk' as a 'Sentence. Does not allow concept
+-- domain tagging.
 cc' :: Idea c => c -> Sentence -> ConceptChunk
 cc' n d = ConDict (nw n) d []
 
--- | Similar to 'cc'', but allows explicit domain tagging.
-ccs :: Concept d => IdeaDict -> Sentence -> [d] -> ConceptChunk --Explicit tagging
-ccs n d l = ConDict n d $ map (^. uid) l
-
 -- | For projecting out to the 'ConceptChunk' data-type.
 cw :: Concept c => c -> ConceptChunk
-cw c = ConDict (nw c) (c ^. defn) (cdom c)
+cw c = ConDict (nw c) (c ^. D.defn) (cdom c)
 
--- | Constructor for a 'ConceptInstance'. Takes in the
--- Reference Address ('String'), a definition ('Sentence'),
--- a short name ('String'), and a domain (for explicit tagging).
+-- | Constructor for a 'ConceptInstance'. Takes in the Reference Address
+-- ('String'), a definition ('Sentence'), a short name ('String'), and a domain
+-- (for explicit tagging).
 cic :: Concept c => String -> Sentence -> String -> c -> ConceptInstance
 cic u d sn dom = ConInst (nsUid "instance" $ icc ^. uid) icc u $ shortname' (S sn)
-  where icc = ccs (nc u $ pn sn) d [dom]
+  where
+    icc = cc (nc u $ pn sn) d [dom]
+    cc n d' l = ConDict n d' $ map (^. uid) l

--- a/code/drasil-lang/lib/Language/Drasil/Chunk/Concept.hs
+++ b/code/drasil-lang/lib/Language/Drasil/Chunk/Concept.hs
@@ -10,12 +10,12 @@ module Language.Drasil.Chunk.Concept (
 
 import Control.Lens ((^.))
 
-import Drasil.Database (HasUID(uid), nsUid)
+import Drasil.Database (HasUID(uid), nsUid, UID)
 
 import Language.Drasil.Classes (Idea, ConceptDomain(cdom), Concept)
 import Language.Drasil.Chunk.Concept.Core (ConceptChunk(ConDict), ConceptInstance(ConInst))
 import Language.Drasil.Sentence (Sentence(S))
-import Language.Drasil.Chunk.NamedIdea(mkIdea, nw, nc)
+import Language.Drasil.Chunk.NamedIdea(mkIdea, nw, nc, idea)
 import Language.Drasil.NaturalLanguage.English.NounPhrase (NP, pn)
 import Language.Drasil.ShortName (shortname')
 import qualified Language.Drasil.Classes as D (defn)
@@ -25,7 +25,7 @@ import qualified Language.Drasil.Classes as D (defn)
 -- | Construct a 'ConceptChunk'.
 cncpt :: Concept dom =>
   -- | The 'UID'.
-  String ->
+  UID ->
   -- The 'term' being defined.
   NP ->
   -- | The definition of the 'term'
@@ -34,12 +34,12 @@ cncpt :: Concept dom =>
   Maybe String ->
   -- | The domain the 'term' belongs to.
   [dom] -> ConceptChunk
-cncpt u trm defn mabbr = ConDict (mkIdea u trm mabbr) defn . map (^. uid)
+cncpt u trm defn mabbr = ConDict (idea u trm mabbr) defn . map (^. uid)
 
 -- | Construct a 'ConceptChunk'.
 cncpt' ::
   -- | The 'UID'.
-  String ->
+  UID ->
   -- | The 'term' being defined.
   NP ->
   -- | The definition of the 'term'
@@ -51,7 +51,7 @@ cncpt' u trm defn mabbr = cncpt u trm defn mabbr ([] :: [ConceptChunk])
 -- | Construct a 'ConceptChunk'.
 cncpt'' ::
   -- | The 'UID'.
-  String ->
+  UID ->
   -- | The 'term' being defined.
   NP ->
   -- | The definition of the 'term'

--- a/code/drasil-lang/lib/Language/Drasil/Chunk/Concept.hs
+++ b/code/drasil-lang/lib/Language/Drasil/Chunk/Concept.hs
@@ -74,7 +74,6 @@ cncpt''' ::
   Sentence -> ConceptChunk
 cncpt''' u trm defn = ConDict (idea' u trm) defn []
 
-
 {-# DEPRECATED dccA, dccAWDS, dcc, dccWDS, cc', cw
   "Smart constructors allow externally-known chunk nesting; use one of `cncpt, cncpt', cncpt'', cncpt'''` instead." #-}
 

--- a/code/drasil-lang/lib/Language/Drasil/Chunk/NamedIdea.hs
+++ b/code/drasil-lang/lib/Language/Drasil/Chunk/NamedIdea.hs
@@ -49,11 +49,11 @@ instance NamedIdea IdeaDict where term = np
 -- | Finds the abbreviation of the 'IdeaDict'.
 instance Idea      IdeaDict where getA = mabbr
 
-idea :: UID -> NP -> Maybe String -> IdeaDict
-idea = IdeaDict
+idea :: UID -> NP -> String -> IdeaDict
+idea u t accAbbr = IdeaDict u t (Just accAbbr)
 
 idea' :: UID -> NP -> IdeaDict
-idea' u t = idea u t Nothing
+idea' u t = IdeaDict u t Nothing
 
 {-# DEPRECATED nc, ncUID, mkIdea
   "Use `idea` or `idea'` instead." #-}

--- a/code/drasil-lang/lib/Language/Drasil/Chunk/NamedIdea.hs
+++ b/code/drasil-lang/lib/Language/Drasil/Chunk/NamedIdea.hs
@@ -49,10 +49,22 @@ instance NamedIdea IdeaDict where term = np
 -- | Finds the abbreviation of the 'IdeaDict'.
 instance Idea      IdeaDict where getA = mabbr
 
-idea :: UID -> NP -> String -> IdeaDict
+-- | Construct an 'IdeaDict' (/with/ an acronym/abbreviation).
+idea ::
+  -- | The 'UID'.
+  UID ->
+  -- | The 'term' being declared.
+  NP ->
+  -- | The 'term's acronym/abbreviation.
+  String -> IdeaDict
 idea u t accAbbr = IdeaDict u t (Just accAbbr)
 
-idea' :: UID -> NP -> IdeaDict
+-- | Construct an 'IdeaDict' (/without/ an acronym/abbreviation).
+idea' ::
+  -- | The 'UID'.
+  UID ->
+  -- | The 'term' being declared.
+  NP -> IdeaDict
 idea' u t = IdeaDict u t Nothing
 
 {-# DEPRECATED nc, ncUID, mkIdea

--- a/code/drasil-lang/lib/Language/Drasil/Chunk/NamedIdea.hs
+++ b/code/drasil-lang/lib/Language/Drasil/Chunk/NamedIdea.hs
@@ -6,7 +6,7 @@ module Language.Drasil.Chunk.NamedIdea (
   -- * Classes
   NamedIdea(..), Idea(..),
   -- * Constructors
-  nc, ncUID, nw, mkIdea,
+  idea, idea', nc, ncUID, nw, mkIdea,
 ) where
 
 import Control.Lens ((^.), makeLenses, Lens')
@@ -18,29 +18,14 @@ import Language.Drasil.NaturalLanguage.English.NounPhrase.Core (NP)
 -- | A NamedIdea is a 'term' that we've identified (has a 'UID') as being worthy
 -- of naming.
 class IsChunk c => NamedIdea c where
-  -- | Lens to the term (a noun phrase).
+  -- | Lens to the term (an 'NP').
   term :: Lens' c NP
 
--- | An 'Idea' is the combination of a 'NamedIdea' and a 'CommonIdea'.
--- In other words, it /may/ have an acronym/abbreviation.
+-- | An 'Idea' is the combination of a 'NamedIdea' and a 'CommonIdea'. In other
+-- words, it /may/ have an acronym/abbreviation.
 class NamedIdea c => Idea c where
-  -- | Gets the acronym/abbreviation.
+  -- | Get the acronym/abbreviation.
   getA :: c -> Maybe String
-  --Get Abbreviation/Acronym? These might need to be separated
-  --depending on contexts, but for now I don't see a problem with it.
-
--- === DATA TYPES/INSTANCES === --
--- TODO: Add in function to check UIDs (see #2788).
--- TODO: Any constructor that takes in a UID should be built off of this one so that
--- the UID may be checked by the first TODO.
-
--- | 'IdeaDict' constructor, takes a 'String' for its 'UID' and a term.
-nc :: String -> NP -> IdeaDict
-nc s np' = IdeaDict (mkUid s) np' Nothing
-
--- | Similar to 'nc', but takes in the 'UID' in the form of a 'UID' rather than a 'String'.
-ncUID :: UID -> NP -> IdeaDict
-ncUID u np' = IdeaDict u np' Nothing
 
 -- Don't export the record accessors.
 -- | 'IdeaDict' is the canonical dictionary associated to an 'Idea'.
@@ -63,6 +48,26 @@ instance HasUID    IdeaDict where uid = uu
 instance NamedIdea IdeaDict where term = np
 -- | Finds the abbreviation of the 'IdeaDict'.
 instance Idea      IdeaDict where getA = mabbr
+
+idea :: UID -> NP -> Maybe String -> IdeaDict
+idea = IdeaDict
+
+idea' :: UID -> NP -> IdeaDict
+idea' u t = idea u t Nothing
+
+{-# DEPRECATED nc, ncUID, mkIdea
+  "Use `idea` or `idea'` instead." #-}
+
+{-# DEPRECATED nw
+  "Should not be down-casting chunks; use `idea` or `idea'` instead." #-}
+
+-- | 'IdeaDict' constructor, takes a 'String' for its 'UID' and a term.
+nc :: String -> NP -> IdeaDict
+nc s np' = IdeaDict (mkUid s) np' Nothing
+
+-- | Similar to 'nc', but takes in the 'UID' in the form of a 'UID' rather than a 'String'.
+ncUID :: UID -> NP -> IdeaDict
+ncUID u np' = IdeaDict u np' Nothing
 
 -- | 'IdeaDict' constructor, takes a 'UID', 'NP', and
 -- an abbreviation in the form of 'Maybe' 'String'.

--- a/code/drasil-metadata/lib/Drasil/Metadata/Documentation.hs
+++ b/code/drasil-metadata/lib/Drasil/Metadata/Documentation.hs
@@ -39,7 +39,7 @@ import Control.Lens ((^.))
 import Drasil.Database (mkUid)
 import Language.Drasil (CI, NP, IdeaDict, nc, cn, cn', cnIES, cnICES, cnUM,
   commonIdeaWithDict, fterms, compoundPhrase, compoundPhraseP1, titleizeNP',
-  term, ConceptChunk, cncpt, Sentence(EmptyS), dcc)
+  term, ConceptChunk, cncpt, cncpt', Sentence(EmptyS), dcc)
 import Language.Drasil.Chunk.Concept.NamedCombinators
   (combineNINI, compoundNC, compoundNCPP, of_, of_PS, ofAPS, of_NINP, theGen
   , compoundNCPSPP, and_, and_TGen, and_PP)
@@ -218,14 +218,14 @@ srsDom = dcc "srsDom" (srs ^. term) "srs"
 
 assumpDom, chgProbDom, funcReqDom, goalStmtDom, likeChgDom,
   nonFuncReqDom, reqDom, unlikeChgDom :: ConceptChunk
-assumpDom     = cncpt (mkUid "assumpDom")     (assumption ^. term)               EmptyS (Just "A")   [srsDom]
-chgProbDom    = cncpt (mkUid "chgProbDom")    (cn' "change")                     EmptyS  Nothing     [srsDom]
-funcReqDom    = cncpt (mkUid "funcReqDom")    (functionalRequirement ^. term)    EmptyS (Just "FR")  [reqDom]
-goalStmtDom   = cncpt (mkUid "goalStmtDom")   (goalStmt ^. term)                 EmptyS (Just "GS")  [srsDom]
-likeChgDom    = cncpt (mkUid "likeChgDom")    (likelyChg ^. term)                EmptyS (Just "LC")  [chgProbDom]
-nonFuncReqDom = cncpt (mkUid "nonFuncReqDom") (nonfunctionalRequirement ^. term) EmptyS (Just "NFR") [reqDom]
-reqDom        = cncpt (mkUid "reqDom")        (requirement ^. term)              EmptyS (Just "R")   [srsDom]
-unlikeChgDom  = cncpt (mkUid "unlikeChgDom")  (unlikelyChg ^. term)              EmptyS (Just "UC")  [chgProbDom]
+assumpDom     = cncpt  (mkUid "assumpDom")     (assumption ^. term)               EmptyS "A"   [srsDom]
+chgProbDom    = cncpt' (mkUid "chgProbDom")    (cn' "change")                     EmptyS       [srsDom]
+funcReqDom    = cncpt  (mkUid "funcReqDom")    (functionalRequirement ^. term)    EmptyS "FR"  [reqDom]
+goalStmtDom   = cncpt  (mkUid "goalStmtDom")   (goalStmt ^. term)                 EmptyS "GS"  [srsDom]
+likeChgDom    = cncpt  (mkUid "likeChgDom")    (likelyChg ^. term)                EmptyS "LC"  [chgProbDom]
+nonFuncReqDom = cncpt  (mkUid "nonFuncReqDom") (nonfunctionalRequirement ^. term) EmptyS "NFR" [reqDom]
+reqDom        = cncpt  (mkUid "reqDom")        (requirement ^. term)              EmptyS "R"   [srsDom]
+unlikeChgDom  = cncpt  (mkUid "unlikeChgDom")  (unlikelyChg ^. term)              EmptyS "UC"  [chgProbDom]
 
 -- FIXME: Some of the below are duplicated knowledge of the above (above preferred). None should be CIs, too.
 

--- a/code/drasil-metadata/lib/Drasil/Metadata/Documentation.hs
+++ b/code/drasil-metadata/lib/Drasil/Metadata/Documentation.hs
@@ -36,6 +36,7 @@ module Drasil.Metadata.Documentation
 import Control.Lens ((^.))
 
 -- General Drasil
+import Drasil.Database (mkUid)
 import Language.Drasil (CI, NP, IdeaDict, nc, cn, cn', cnIES, cnICES, cnUM,
   commonIdeaWithDict, fterms, compoundPhrase, compoundPhraseP1, titleizeNP',
   term, ConceptChunk, cncpt, Sentence(EmptyS), dcc)
@@ -217,14 +218,14 @@ srsDom = dcc "srsDom" (srs ^. term) "srs"
 
 assumpDom, chgProbDom, funcReqDom, goalStmtDom, likeChgDom,
   nonFuncReqDom, reqDom, unlikeChgDom :: ConceptChunk
-assumpDom     = cncpt "assumpDom"     (assumption ^. term)               EmptyS (Just "A")   [srsDom]
-chgProbDom    = cncpt "chgProbDom"    (cn' "change")                     EmptyS  Nothing     [srsDom]
-funcReqDom    = cncpt "funcReqDom"    (functionalRequirement ^. term)    EmptyS (Just "FR")  [reqDom]
-goalStmtDom   = cncpt "goalStmtDom"   (goalStmt ^. term)                 EmptyS (Just "GS")  [srsDom]
-likeChgDom    = cncpt "likeChgDom"    (likelyChg ^. term)                EmptyS (Just "LC")  [chgProbDom]
-nonFuncReqDom = cncpt "nonFuncReqDom" (nonfunctionalRequirement ^. term) EmptyS (Just "NFR") [reqDom]
-reqDom        = cncpt "reqDom"        (requirement ^. term)              EmptyS (Just "R")   [srsDom]
-unlikeChgDom  = cncpt "unlikeChgDom"  (unlikelyChg ^. term)              EmptyS (Just "UC")  [chgProbDom]
+assumpDom     = cncpt (mkUid "assumpDom")     (assumption ^. term)               EmptyS (Just "A")   [srsDom]
+chgProbDom    = cncpt (mkUid "chgProbDom")    (cn' "change")                     EmptyS  Nothing     [srsDom]
+funcReqDom    = cncpt (mkUid "funcReqDom")    (functionalRequirement ^. term)    EmptyS (Just "FR")  [reqDom]
+goalStmtDom   = cncpt (mkUid "goalStmtDom")   (goalStmt ^. term)                 EmptyS (Just "GS")  [srsDom]
+likeChgDom    = cncpt (mkUid "likeChgDom")    (likelyChg ^. term)                EmptyS (Just "LC")  [chgProbDom]
+nonFuncReqDom = cncpt (mkUid "nonFuncReqDom") (nonfunctionalRequirement ^. term) EmptyS (Just "NFR") [reqDom]
+reqDom        = cncpt (mkUid "reqDom")        (requirement ^. term)              EmptyS (Just "R")   [srsDom]
+unlikeChgDom  = cncpt (mkUid "unlikeChgDom")  (unlikelyChg ^. term)              EmptyS (Just "UC")  [chgProbDom]
 
 -- FIXME: Some of the below are duplicated knowledge of the above (above preferred). None should be CIs, too.
 

--- a/code/drasil-metadata/lib/Drasil/Metadata/Documentation.hs
+++ b/code/drasil-metadata/lib/Drasil/Metadata/Documentation.hs
@@ -38,8 +38,7 @@ import Control.Lens ((^.))
 -- General Drasil
 import Language.Drasil (CI, NP, IdeaDict, nc, cn, cn', cnIES, cnICES, cnUM,
   commonIdeaWithDict, fterms, compoundPhrase, compoundPhraseP1, titleizeNP',
-  term, ConceptChunk,
-  ccs, mkIdea, Sentence(EmptyS), dcc)
+  term, ConceptChunk, cncpt, Sentence(EmptyS), dcc)
 import Language.Drasil.Chunk.Concept.NamedCombinators
   (combineNINI, compoundNC, compoundNCPP, of_, of_PS, ofAPS, of_NINP, theGen
   , compoundNCPSPP, and_, and_TGen, and_PP)
@@ -218,14 +217,16 @@ srsDom = dcc "srsDom" (srs ^. term) "srs"
 
 assumpDom, chgProbDom, funcReqDom, goalStmtDom, likeChgDom,
   nonFuncReqDom, reqDom, unlikeChgDom :: ConceptChunk
-assumpDom     = ccs (mkIdea "assumpDom"     (assumption ^. term)               $ Just "A")        EmptyS [srsDom]
-chgProbDom    = ccs (nc "chgProbDom" $ cn' "change")                                              EmptyS [srsDom]
-funcReqDom    = ccs (mkIdea "funcReqDom"    (functionalRequirement ^. term)    $ Just "FR")       EmptyS [reqDom]
-goalStmtDom   = ccs (mkIdea "goalStmtDom"   (goalStmt ^. term)                 $ Just "GS")       EmptyS [srsDom]
-likeChgDom    = ccs (mkIdea "likeChgDom"    (likelyChg ^. term)                $ Just "LC")       EmptyS [chgProbDom]
-nonFuncReqDom = ccs (mkIdea "nonFuncReqDom" (nonfunctionalRequirement ^. term) $ Just "NFR")      EmptyS [reqDom]
-reqDom        = ccs (mkIdea "reqDom"        (requirement ^. term)              $ Just "R")        EmptyS [srsDom]
-unlikeChgDom  = ccs (mkIdea "unlikeChgDom"  (unlikelyChg ^. term)              $ Just "UC")       EmptyS [chgProbDom]
+assumpDom     = cncpt "assumpDom"     (assumption ^. term)               EmptyS (Just "A")   [srsDom]
+chgProbDom    = cncpt "chgProbDom"    (cn' "change")                     EmptyS  Nothing     [srsDom]
+funcReqDom    = cncpt "funcReqDom"    (functionalRequirement ^. term)    EmptyS (Just "FR")  [reqDom]
+goalStmtDom   = cncpt "goalStmtDom"   (goalStmt ^. term)                 EmptyS (Just "GS")  [srsDom]
+likeChgDom    = cncpt "likeChgDom"    (likelyChg ^. term)                EmptyS (Just "LC")  [chgProbDom]
+nonFuncReqDom = cncpt "nonFuncReqDom" (nonfunctionalRequirement ^. term) EmptyS (Just "NFR") [reqDom]
+reqDom        = cncpt "reqDom"        (requirement ^. term)              EmptyS (Just "R")   [srsDom]
+unlikeChgDom  = cncpt "unlikeChgDom"  (unlikelyChg ^. term)              EmptyS (Just "UC")  [chgProbDom]
+
+-- FIXME: Some of the below are duplicated knowledge of the above (above preferred). None should be CIs, too.
 
 assumption, desSpec, goalStmt, learnObj, likelyChg, mg, mis, notebook, physSyst,
   refBy, refName, requirement, sec, srs, typUnc, unlikelyChg :: CI


### PR DESCRIPTION
Contributes to #4541
Contributes to #4829

~~DISCLAIMER: This PR _will_ fail in the CI because I `DEPRECATED` the old smart constructors. We should file PRs targetting this one that remove uses of the old ones. Until all are removed and the CI is green, this PR should not be merged.~~

Why?

Let's have a look at the old ones:

```haskell
-- | Smart constructor for creating a concept chunks with an abbreviation
-- Takes a UID (String), a term (NounPhrase), a definition (String), and an abbreviation (Maybe String).
dccA :: String -> NP -> String -> Maybe String -> ConceptChunk
dccA i ter des a = ConDict (mkIdea i ter a) (S des) []
```

Uses a `String` for the description. We should be strongly discouraging this, even if it makes the code shorter, it does it in a way that encourages bad practice.

```haskell
dccAWDS :: String -> NP -> Sentence -> Maybe String -> ConceptChunk
dccAWDS i t d a = ConDict (mkIdea i t a) d []
```

Better than `dccA`, but has a confusing name, no sane description and was only a compatibility layer for when `ConceptDomain` was created and not propagated yet. We will keep this one, renaming it.

```haskell
dcc :: String -> NP -> String -> ConceptChunk
-- | Smart constructor for creating concept chunks given a 'UID',
-- 'NounPhrase' ('NP') and definition (as a 'String').
dcc i ter des = dccA i ter des Nothing
-- ^ Concept domain tagging is not yet implemented in this constructor.
```

See `dccA`'s `String` discussion.

```haskell
-- | Similar to 'dcc', except the definition takes a 'Sentence'.
dccWDS :: String -> NP -> Sentence -> ConceptChunk
dccWDS i t d = dccAWDS i t d Nothing
```

Like `dccAWDS`, more reasonable, but very confusing name.

```haskell
-- | Constructor for projecting an idea into a 'ConceptChunk'. Takes the definition of the
-- 'ConceptChunk' as a 'Sentence. Does not allow concept domain tagging.
cc' :: Idea c => c -> Sentence -> ConceptChunk
cc' n d = ConDict (nw n) d []
```

It takes something that has an `Idea` instances (and possibly already a definition), and attaches a new definition to it. This is bad for two reasons:

1. It down-casts (/projects) another chunk type.
2. It creates data that is potentially out-of-sync with the `UID` and expected type the `UID` should reference.

```haskell
-- | Similar to 'cc'', but allows explicit domain tagging.
ccs :: Concept d => IdeaDict -> Sentence -> [d] -> ConceptChunk --Explicit tagging
ccs n d l = ConDict n d $ map (^. uid) l
```

Providing a raw `IdeaDict` encourages bad practice. The `ConceptChunk` being able to nest an `IdeaDict` internally and have a unique `UID` is an operational detail (kind of hacky to de-duplicate code) that we should be hiding. Good, but bad. Also doesn't have the abbreviation support.

```haskell
-- | For projecting out to the 'ConceptChunk' data-type.
cw :: Concept c => c -> ConceptChunk
cw c = ConDict (nw c) (c ^. defn) (cdom c)
```

Down-casts another chunk type. We should never be needing to do this.

This PR creates 3 new constructors based on the old ones: `cncpt`, `cncpt'`, and `cncpt''`. `cncpt` is strongly preferred over the other two, but having the other two is good if only to avoid having to write `Nothing` everywhere to avoid abbreviations and `[]` to avoid having to write empty 'concept domains'.