### PR TITLE
refactor: use `cncpt''` instead of `dccWDS`

### DIFF
--- a/code/drasil-data/lib/Data/Drasil/Concepts/Computation.hs
+++ b/code/drasil-data/lib/Data/Drasil/Concepts/Computation.hs
@@ -5,7 +5,7 @@ module Data.Drasil.Concepts.Computation
   ) where
 
 import Language.Drasil (dcc, nc, cn', commonIdeaWithDict, Sentence,
-  ConceptChunk, CI, IdeaDict, dccWDS)
+  ConceptChunk, CI, IdeaDict, cncpt'')
 import Language.Drasil.Chunk.Concept.NamedCombinators
 
 import Data.Drasil.Concepts.Documentation (datum, input_, literacy, output_,
@@ -19,7 +19,7 @@ absTolerance = dcc "absTolerance"   (cn' "Absolute tolerance") "a fixed number t
 relTolerance = dcc "relTolerance"   (cn' "Relative tolerance") " maximum amount of error that the user is willing to allow in the solution"
 
 modCalcDesc :: Sentence -> ConceptChunk
-modCalcDesc = dccWDS "modCalcDesc" (cn' "calculation")
+modCalcDesc = cncpt'' "modCalcDesc" (cn' "calculation")
 
 -- | Collects all computing-related named chunks (not concept-level yet).
 compcon :: [IdeaDict]

--- a/code/drasil-data/lib/Data/Drasil/Concepts/Math.hs
+++ b/code/drasil-data/lib/Data/Drasil/Concepts/Math.hs
@@ -42,7 +42,7 @@ angle       = dcc "angle"        (cn' "angle")                   "the amount of 
 area        = dcc "area"         (cn' "area")                    "a part of an object or surface"
 axis        = dcc "axis"         (cn' "axis")                    "a fixed reference line for the measurement of coordinates"
 calculation = dcc "calculation"  (cn' "calculation")             "a mathematical determination of the size or number of something"
-cartesian   = dccWDS "cartesian" (pn' "Cartesian coordinate system") $ D.S "a coordinate system that specifies each point uniquely in a plane by a set" `S.of_`
+cartesian   = cncpt'' "cartesian" (pn' "Cartesian coordinate system") $ D.S "a coordinate system that specifies each point uniquely in a plane by a set" `S.of_`
                                                                   D.S "numerical coordinates, which are the signed distances to the point from" +:+
                                                                   D.S "two fixed perpendicular oriented lines, measured in the same unit of length" +:+
                                                                   fromSource cartesianWiki
@@ -60,7 +60,7 @@ gradient     = dcc "gradient"     (cn' "gradient")                "degree of ste
 laplaceTransform = dcc "laplaceTransform" (cn' "laplace transform") ("An integral transform that converts a function of a real variable t " ++
                                                                      "(often time) to a function of a complex variable s (complex frequency)")
 law          = dcc "law"          (cn' "law")                     "a generalization based on a fact or event perceived to be recurrent"
-line         = dccWDS "line"      (pn' "line")                    $ D.S "An interval between two points" +:+
+line         = cncpt'' "line"      (pn' "line")                    $ D.S "An interval between two points" +:+
                                                                   fromSource lineSource
 matrix       = dcc "matrix"       (cnICES "matrix")               ("A rectangular array of quantities or expressions in rows and columns that" ++
                                                                  "is treated as a single entity and manipulated according to particular rules")
@@ -75,7 +75,7 @@ posInf       = dcc "PosInf"       (cn' "Positive Infinity")      "the limit of a
 negInf       = dcc "NegInf"       (cn' "Negative Infinity")      "Opposite of positive infinity"
 positive     = dcc "positive"     (cn' "positive")               "greater than zero"
 negative     = dcc "negative"     (cn' "negative")               "less than zero"
-point        = dccWDS "point"     (pn' "point")                   $ D.S "An exact location, it has no size, only position" +:+
+point        = cncpt'' "point"     (pn' "point")                   $ D.S "An exact location, it has no size, only position" +:+
                                                                   fromSource pointSource
 probability  = dcc "probability"  (cnIES "probability")          "The likelihood of an event to occur"
 rate         = dcc "rate"         (cn' "rate")                   "Ratio that compares two quantities having different units of measure"

--- a/code/drasil-data/lib/Data/Drasil/Concepts/Physics.hs
+++ b/code/drasil-data/lib/Data/Drasil/Concepts/Physics.hs
@@ -55,29 +55,29 @@ oneD   = commonIdeaWithDict "oneD"   (cn "one-dimensional")   "1D" [mathematics,
 twoD   = commonIdeaWithDict "twoD"   (cn "two-dimensional")   "2D" [mathematics, physics]
 threeD = commonIdeaWithDict "threeD" (cn "three-dimensional") "3D" [mathematics, physics]
 
-acceleration = dccWDS "acceleration" (cn' "acceleration")
+acceleration = cncpt'' "acceleration" (cn' "acceleration")
   (S "the rate of change of a body's" +:+ phrase velocity)
 angular = dcc "angular" (cn' "angular")
   "denoting physical properties or quantities measured with reference to or by means of an angle"
-body = dccWDS "physicsBody" (cnIES "body")
+body = cncpt'' "physicsBody" (cnIES "body")
   (S "an object with" +:+ phrase QPP.mass)
-chgInVelocity = dccWDS "chgInVelocity" (cn desc)
+chgInVelocity = cncpt'' "chgInVelocity" (cn desc)
   (S "the " +:+ S desc +:+ phrase rigidBody)
   where desc = "change in velocity" -- TODO: This is a hack to avoid an infinite loop should we enable strict data.
-chgMomentum = dccWDS "chgMomentum" (cn' "change in momentum")
+chgMomentum = cncpt'' "chgMomentum" (cn' "change in momentum")
   (S "The rate of change of a body's" +:+ phrase impulseV)
 collision = dcc "collision" (cn' "collision")
   "an encounter between particles resulting in an exchange or transformation of energy"
-cohesion = dccWDS "cohesion" (cn "cohesion")
+cohesion = cncpt'' "cohesion" (cn "cohesion")
   (S "an attractive" +:+ phrase force +:+ S "between adjacent particles that holds the matter together")
-compression = dccWDS "compression" (cn' "compression")
+compression = cncpt'' "compression" (cn' "compression")
   (S "a" +:+ phrase stress +:+ S "that causes displacement of the body towards its center")
-damping = dccWDS "damping" (pn' "damping")
+damping = cncpt'' "damping" (pn' "damping")
   $ S "an influence within or upon an oscillatory system that has the effect of reducing," +:+
   S "restricting or preventing its oscillations" +:+ fromSource dampingSource
 dampingCoeff = dcc "dampingCoeff" (cn' "damping coefficient")
  "Quantity that characterizes a second order system's oscillatory response"
-displacement = dccWDS "displacement" (cn' "displacement")
+displacement = cncpt'' "displacement" (cn' "displacement")
   (S "the change in" +:+ (position ^. defn))
 distance = dcc "distance" (cn' "distance")
   "the interval measured along a path connecting two locations"
@@ -104,46 +104,46 @@ gravitationalConst = dcc "gravitationalConst" (cn "gravitational constant")
   "the empirical physical constant used to show the force between two objects caused by gravity"
 gravitationalMagnitude = dcc "gravitationalMagnitude" (cn "magnitude of gravitational acceleration")
   "the magnitude of the approximate acceleration due to gravity on Earth at sea level"
-height = dccWDS "height" (cn' "height")
+height = cncpt'' "height" (cn' "height")
   (S "the" +:+ phrase distance +:+ S "above a reference point for a point of interest")
-horizontalMotion = dccWDS "horizontalMotion" (cn "horizontal motion")
+horizontalMotion = cncpt'' "horizontalMotion" (cn "horizontal motion")
   (S "the result of the tendency of any object in motion to remain in motion at constant velocity")
-isotropy = dccWDS "isotropy" (cn "isotropy")
+isotropy = cncpt'' "isotropy" (cn "isotropy")
   (S "a condition where the" +:+ (phrase value `S.ofA` phrase property) `S.is`
    S "independent of the direction in which it is measured")
 joint = dcc "joint" (cn' "joint")
   "a connection between two rigid bodies which allows movement with one or more degrees of freedom"
-kEnergy = dccWDS "kEnergy" (cn "kinetic energy")
+kEnergy = cncpt'' "kEnergy" (cn "kinetic energy")
   (S "measure" `S.the_ofThe` phrase energy +:+ S "a body possesses due to its motion")
-kinematics = dccWDS "kinematics" (cn "kinematics")
+kinematics = cncpt'' "kinematics" (cn "kinematics")
   (S "branch" `S.of_` phrase mechanics +:+ S "that describes the motion" `S.of_`
     S "objects without reference to the causes of motion")
 linear = dcc "linear" (cn' "linear")
   "arranged in or extending along a straight or nearly straight line"
 mechEnergy = dcc "mechEnergy" (cn "mechanical energy")
   "the energy that comes from motion and position"
-momentum = dccWDS "momentum" (cn "momentum")
+momentum = cncpt'' "momentum" (cn "momentum")
   ( S "the quantity of motion" `S.of_` S "a moving body, measured as a product" `S.of_`
   (phrase QPP.mass `S.and_` phrase velocity))
-moment = dccWDS "moment" (cn' "moment")
+moment = cncpt'' "moment" (cn' "moment")
   (S "A measure of the tendency of a body to rotate about a specific" +:+ phrase point `S.or_` phrase axis)
-moment2D = dccWDS "moment2D" (cn' "moment")
+moment2D = cncpt'' "moment2D" (cn' "moment")
   (S "A measure of the tendency of a body to rotate about a specific" +:+ phrase point `S.or_` phrase axis)
-motion = dccWDS "motion" (cn "motion")
+motion = cncpt'' "motion" (cn "motion")
   (S "change in position of a physical body over time")
-period = dccWDS "period" (cn' "period")
+period = cncpt'' "period" (cn' "period")
    (S "the" +:+ phrase time +:+ S "required for one complete cycle of vibration to pass a given point.")
-pendulum = dccWDS "pendulum" (cn "pendulum")
+pendulum = cncpt'' "pendulum" (cn "pendulum")
  (S "a body suspended from a fixed support so that it swings freely back and forth under the influence"
        `S.of_` phrase gravity)
 position = dcc "position" (cn' "position")
   "an object's location relative to a reference point"
-positionVec = dccWDS "positionVec" (cn' "position vector")
+positionVec = cncpt'' "positionVec" (cn' "position vector")
    (S "a vector from the origin" `S.ofThe` phrase cartesian +:+ S "defined"
     `S.toThe` phrase point +:+ S "where the" +:+ phrase force +:+ S "is applied")
-potEnergy = dccWDS "potEnergy" (cn "potential energy")
+potEnergy = cncpt'' "potEnergy" (cn "potential energy")
   (S "measure" `S.the_ofThe` phrase energy +:+ S "held by an object because of its" +:+ phrase position)
-pressure = dccWDS "pressure" (cn' "pressure")
+pressure = cncpt'' "pressure" (cn' "pressure")
   (S "a" +:+ phrase force +:+ S "exerted over an area")
 rectilinear = dcc "rectilinear" (cn "rectilinear")
   "occurring in one dimension"
@@ -151,33 +151,33 @@ rigidBody = dcc "rigidBody" (cnIES "rigid body")
   "a solid body in which deformation is neglected"
 space = dcc "space" (cn' "space")
   "a two-dimensional extent where objects and events have relative positions and directions"
-scalarAccel = dccWDS "scalarAccel" (cn' "scalar acceleration")
+scalarAccel = cncpt'' "scalarAccel" (cn' "scalar acceleration")
   (S "magnitude" `S.the_ofThe` phrase acceleration +:+ S "vector")
-scalarPos = dccWDS "scalarPos" (cn' "scalar position")
+scalarPos = cncpt'' "scalarPos" (cn' "scalar position")
   (S "magnitude" `S.the_ofThe` phrase position +:+ S "vector")
 shm = dcc "SHM" (nounPhraseSP "simple harmonic motion") ("Periodic motion through an equilibrium position. " ++
                                                         "The motion is sinusoidal in time and demonstrates a" ++
                                                         " single resonant frequency") -- source: Wikipedia
-speed = dccWDS "speed" (cn' "speed")
+speed = cncpt'' "speed" (cn' "speed")
   (S "magnitude" `S.the_ofThe` phrase velocity +:+ S "vector")
 stiffCoeff = dcc "stiffnessCoeff" (cn' "stiffness coefficient")
  "Quantity that characterizes a spring's stiffness"
-strain = dccWDS "strain" (cn' "strain")
+strain = cncpt'' "strain" (cn' "strain")
   (S "a measure of deformation representing the" +:+ phrase displacement +:+
    S "between particles in the body relative to a reference length")
   --definition of strain used in SSP, can be made clearer
 stress = dcc "stress" (cn''' "stress")
   "the ratio of an applied force to a cross-sectional area"
   --definition of stress used in SSP, can be made clearer
-tension = dccWDS "tension" (cn' "tension")
+tension = cncpt'' "tension" (cn' "tension")
   (S "a" +:+ phrase stress +:+ S "that causes displacement of the body away from its center")
 time = dcc "time" (cn' "time")
   "the indefinite continued progress of existence and events in the past, present, and future regarded as a whole"
 torque = dcc "torque" (cn' "torque")
   "a twisting force that tends to cause rotation"
-velocity = dccWDS "velocity" (cnIES "velocity")
+velocity = cncpt'' "velocity" (cnIES "velocity")
   (S "the rate of change of a body's" +:+ phrase position)
-verticalMotion = dccWDS "verticalMotion" (cn "vertical motion")
+verticalMotion = cncpt'' "verticalMotion" (cn "vertical motion")
   (S " the movement of the object against the gravitational pull")
 weight = dcc "weight" (cn' "weight")
   "the gravitational force acting on an object"
@@ -186,36 +186,36 @@ weight = dcc "weight" (cn' "weight")
 -- FIXME: Complete all variants?
 -- FIXME: Pull out commonalities?
 
-xDist = dccWDS "xDist" (distance `inThe` xDir) (titleize distance `S.inThe` phrase xDir)
-yDist = dccWDS "yDist" (distance `inThe` yDir) (titleize distance `S.inThe` phrase yDir)
+xDist = cncpt'' "xDist" (distance `inThe` xDir) (titleize distance `S.inThe` phrase xDir)
+yDist = cncpt'' "yDist" (distance `inThe` yDir) (titleize distance `S.inThe` phrase yDir)
 
-iPos = dccWDS "iPos" (cn "initial position") (S "The" +:+ phrase position +:+ S "at the body's initial point")
-xPos = dccWDS "xPos" (xComp `of_` position) (S "The" +:+ NP (xComp `of_` position))
-yPos = dccWDS "yPos" (yComp `of_` position) (S "The" +:+ NP (yComp `of_` position))
+iPos = cncpt'' "iPos" (cn "initial position") (S "The" +:+ phrase position +:+ S "at the body's initial point")
+xPos = cncpt'' "xPos" (xComp `of_` position) (S "The" +:+ NP (xComp `of_` position))
+yPos = cncpt'' "yPos" (yComp `of_` position) (S "The" +:+ NP (yComp `of_` position))
 
-ixPos = dccWDS "ixPos" (xComp `of_` iPos) (S "The" +:+ NP (xComp `of_` iPos))
-iyPos = dccWDS "iyPos" (yComp `of_` iPos) (S "The" +:+ NP (yComp `of_` iPos))
+ixPos = cncpt'' "ixPos" (xComp `of_` iPos) (S "The" +:+ NP (xComp `of_` iPos))
+iyPos = cncpt'' "iyPos" (yComp `of_` iPos) (S "The" +:+ NP (yComp `of_` iPos))
 
-fSpeed = dccWDS "fSpeed" (cn "final speed")   (S "The" +:+ phrase speed +:+ S "at the body's final point")
-iSpeed = dccWDS "iSpeed" (cn "initial speed") (S "The" +:+ phrase speed +:+ S "at the body's initial point")
+fSpeed = cncpt'' "fSpeed" (cn "final speed")   (S "The" +:+ phrase speed +:+ S "at the body's final point")
+iSpeed = cncpt'' "iSpeed" (cn "initial speed") (S "The" +:+ phrase speed +:+ S "at the body's initial point")
 
-ixSpeed = dccWDS "ixSpeed" (xComp `of_` iSpeed) (S "The" +:+ NP (xComp `of_` iSpeed))
-iySpeed = dccWDS "iySpeed" (yComp `of_` iSpeed) (S "The" +:+ NP (yComp `of_` iSpeed))
+ixSpeed = cncpt'' "ixSpeed" (xComp `of_` iSpeed) (S "The" +:+ NP (xComp `of_` iSpeed))
+iySpeed = cncpt'' "iySpeed" (yComp `of_` iSpeed) (S "The" +:+ NP (yComp `of_` iSpeed))
 
-fVel = dccWDS "fVel" (cn "final velocity")   (S "The" +:+ phrase velocity +:+ S "at the body's final point")
-iVel = dccWDS "iVel" (cn "initial velocity") (S "The" +:+ phrase velocity +:+ S "at the body's initial point")
-xVel = dccWDS "xVel" (xComp `of_` velocity) (S "The" +:+ NP (xComp `of_` velocity))
-yVel = dccWDS "yVel" (yComp `of_` velocity) (S "The" +:+ NP (yComp `of_` velocity))
+fVel = cncpt'' "fVel" (cn "final velocity")   (S "The" +:+ phrase velocity +:+ S "at the body's final point")
+iVel = cncpt'' "iVel" (cn "initial velocity") (S "The" +:+ phrase velocity +:+ S "at the body's initial point")
+xVel = cncpt'' "xVel" (xComp `of_` velocity) (S "The" +:+ NP (xComp `of_` velocity))
+yVel = cncpt'' "yVel" (yComp `of_` velocity) (S "The" +:+ NP (yComp `of_` velocity))
 
-ixVel = dccWDS "ixVel" (xComp `of_` iVel) (S "The" +:+ NP (xComp `of_` iVel))
-iyVel = dccWDS "iyVel" (yComp `of_` iVel) (S "The" +:+ NP (yComp `of_` iVel))
+ixVel = cncpt'' "ixVel" (xComp `of_` iVel) (S "The" +:+ NP (xComp `of_` iVel))
+iyVel = cncpt'' "iyVel" (yComp `of_` iVel) (S "The" +:+ NP (yComp `of_` iVel))
 
-xAccel = dccWDS "xScalAcc" (xComp `of_` acceleration) (S "The" +:+ NP (xComp `of_` acceleration))
-yAccel = dccWDS "yScalAcc" (yComp `of_` acceleration) (S "The" +:+ NP (yComp `of_` acceleration))
+xAccel = cncpt'' "xScalAcc" (xComp `of_` acceleration) (S "The" +:+ NP (xComp `of_` acceleration))
+yAccel = cncpt'' "yScalAcc" (yComp `of_` acceleration) (S "The" +:+ NP (yComp `of_` acceleration))
 
-constAccelV = dccWDS "constAccelV" (cn "constant acceleration vector") (S "The" +:+ phrase constAccel +:+ S "vector")
-xConstAccel = dccWDS "xConstAccel" (xComp `of_` constAccel) (S "The" +:+ NP (xComp `of_` constAccel))
-yConstAccel = dccWDS "yConstAccel" (yComp `of_` constAccel) (S "The" +:+ NP (yComp `of_` constAccel))
+constAccelV = cncpt'' "constAccelV" (cn "constant acceleration vector") (S "The" +:+ phrase constAccel +:+ S "vector")
+xConstAccel = cncpt'' "xConstAccel" (xComp `of_` constAccel) (S "The" +:+ NP (xComp `of_` constAccel))
+yConstAccel = cncpt'' "yConstAccel" (yComp `of_` constAccel) (S "The" +:+ NP (yComp `of_` constAccel))
 
 --FIXME: COMBINATION HACK (for all below)
 --FIXME: should use compoundPhrase instead? Or better yet, use combineNINI instead of interacting with the terms directly?

--- a/code/drasil-data/lib/Data/Drasil/Concepts/Software.hs
+++ b/code/drasil-data/lib/Data/Drasil/Concepts/Software.hs
@@ -79,7 +79,7 @@ hwHiding = dcc "hwHiding" (cn "hardware hiding")
    " for the rest of the system to use")
 
 modBehavHiding :: ConceptChunk
-modBehavHiding = dccWDS "modBehavHiding" (cn "behaviour hiding") (foldlSent_
+modBehavHiding = cncpt'' "modBehavHiding" (cn "behaviour hiding") (foldlSent_
   [S "includes programs that provide externally visible behaviour of the",
    S "system as specified in the", phrase srs, sParen $ short srs +:+. S "documents",
    S "This module serves as a communication layer between the hardware-hiding module",
@@ -90,7 +90,7 @@ modControl :: ConceptChunk
 modControl = dcc "modControl" (cn' "control module") "provides the main program"
 
 modSfwrDecision :: ConceptChunk
-modSfwrDecision = dccWDS "modSfwrDecision" (cn' "software decision module") (foldlSent_
+modSfwrDecision = cncpt'' "modSfwrDecision" (cn' "software decision module") (foldlSent_
   [S "includes", plural dataStruct `S.and_` plural algorithm,
    S "used in the system that do not provide direct interaction with the user"])
 
@@ -99,7 +99,7 @@ modInputFormat = dcc "modInputFormat" (cn' "input format module")
   "converts the input data into the data structure used by the input parameters module"
 
 modInputParam :: ConceptChunk
-modInputParam = dccWDS "modInputParam" (cn' "input parameter module") (foldlSent_
+modInputParam = cncpt'' "modInputParam" (cn' "input parameter module") (foldlSent_
   [S "stores the parameters needed for the program, including" +:+. foldlList Comma List
    [S "material properties", S "processing conditions", S "numerical parameters"],
    S "The values can be read as needed. This module knows how many parameters it stores"])
@@ -110,46 +110,46 @@ modInputConstraint = dcc "modInputConstraint" (cn' "input constraint module")
    "a constraint is violated")
 
 modInputVerif :: ConceptChunk
-modInputVerif = dccWDS "modInputVerif" (cn' "input verification module") (foldlSent
+modInputVerif = cncpt'' "modInputVerif" (cn' "input verification module") (foldlSent
   [S "verifies that the", plural inParam, S "comply with", phrase physical `S.and_`
    plural softwareConstraint, S "Throws an error if a parameter violates a" +:+.
    phrase physicalConstraint, S "Throws a warning if a parameter violates a",
    phrase softwareConstraint])
 
 modDerivedVal :: ConceptChunk
-modDerivedVal = dccWDS "modDerivedVal" (cn' "derived value module") (foldlSent_
+modDerivedVal = cncpt'' "modDerivedVal" (cn' "derived value module") (foldlSent_
   [S "defines the", plural equation, S "transforming the initial", plural input_,
    S "into derived", plural quantity])
 
 modInterpolation :: ConceptChunk
-modInterpolation = dccWDS "modInterpolation" (cn "interpolation module") (foldlSent_
+modInterpolation = cncpt'' "modInterpolation" (cn "interpolation module") (foldlSent_
   [S "provides the", plural equation, S "that take the", plural inParam `S.and_`
    S "interpolation data" `S.and_` S "return an interpolated value"])
 
 modInterpDatum :: ConceptChunk
-modInterpDatum = dccWDS "modInterpDatum" (cn "interpolation datum module") (foldlSent_
+modInterpDatum = cncpt'' "modInterpDatum" (cn "interpolation datum module") (foldlSent_
   [S "converts the input interpolation data into the", phrase dataStruct,
    S "used by the", phrase modInterpolation])
 
 {-- Concept Chunks for Modules  --}
 
 modSeqServ :: ConceptChunk
-modSeqServ = dccWDS "modSeqServ" (cn' "sequence data structure")
+modSeqServ = cncpt'' "modSeqServ" (cn' "sequence data structure")
   (S "Provides array manipulation operations, such as" +:+ foldlList Comma List
    [S "building an array", S "accessing a specific entry", S "slicing an array"])
 
 modLinkedServ :: ConceptChunk
-modLinkedServ = dccWDS "modLinkedServ" (cn' "linked data structure")
+modLinkedServ = cncpt'' "modLinkedServ" (cn' "linked data structure")
   (S "Provides tree manipulation operations, such as" +:+ foldlList Comma List
    [S "building a tree", S "accessing a specific entry"])
 
 modAssocServ :: ConceptChunk
-modAssocServ = dccWDS "modAssocServ" (cn' "associative data structure")
+modAssocServ = cncpt'' "modAssocServ" (cn' "associative data structure")
   (S "Provides operations on hash tables, such as" +:+ foldlList Comma List
    [S "building a hash table", S "accessing a specific entry"])
 
 modVectorServ :: ConceptChunk
-modVectorServ = dccWDS "modVectorServ" (cn' "vector")
+modVectorServ = cncpt'' "modVectorServ" (cn' "vector")
   (S "Provides vector operations such as" +:+ foldlList Comma List [S "addition",
    S "scalar and vector multiplication", S "dot and cross products", S "rotations"])
 
@@ -157,12 +157,12 @@ modPlotDesc :: ConceptChunk
 modPlotDesc = dcc "modPlotDesc" (cn' "plotting") "provides a plot function"
 
 modOutputfDescFun :: Sentence -> ConceptChunk
-modOutputfDescFun desc = dccWDS "modOutputfDescFun" (cn' "output format")
+modOutputfDescFun desc = cncpt'' "modOutputfDescFun" (cn' "output format")
   (S "outputs the results of the calculations, including the" +:+ desc)
 
 -- ODE Solver Module
 modOdeDesc :: ConceptChunk
-modOdeDesc = dccWDS "modOdeDesc" (nounPhraseSP "ODE solver")
+modOdeDesc = cncpt'' "modOdeDesc" (nounPhraseSP "ODE solver")
   (S "provides solvers that take the" +:+ foldlList Comma List
    [S "governing equation", S "initial conditions", S "numerical parameters"] `S.and_`
    S "solve them")

--- a/code/drasil-data/lib/Data/Drasil/Concepts/SolidMechanics.hs
+++ b/code/drasil-data/lib/Data/Drasil/Concepts/SolidMechanics.hs
@@ -14,29 +14,29 @@ solidcon = [elastMod, mobShear, normForce, nrmStrss, poissnsR, shearForce,
 elastMod, mobShear, normForce, nrmStrss, poissnsR, shearForce,
   shearRes, stffness :: ConceptChunk
 
-elastMod   = dccWDS "elastMod" (cn "elastic modulus")
+elastMod   = cncpt'' "elastMod" (cn "elastic modulus")
   (S "the ratio of the" +:+ phrase stress +:+
   S "exerted on a body to the resulting" +:+ phrase strain)
 
-mobShear   = dccWDS "mobShear" (cn "mobilized shear force")
+mobShear   = cncpt'' "mobShear" (cn "mobilized shear force")
   (S "the" +:+ phrase shearForce +:+ S "in the direction of potential motion" `sC`
   S "thus encouraging motion along the plane")
 
-normForce  = dccWDS "normForce" (cn' "normal force")
+normForce  = cncpt'' "normForce" (cn' "normal force")
   (S "a" +:+ phrase force +:+ S "applied perpendicular to the plane of the material")
 
-nrmStrss   = dccWDS "nrmStrss" (cn "normal stress")
+nrmStrss   = cncpt'' "nrmStrss" (cn "normal stress")
   (S "the" +:+ phrase stress +:+  S "exerted perpendicular to the plane of the object")
 
-poissnsR   = dccWDS "poissnsR" (nounPhraseSP "Poisson's ratio")
+poissnsR   = cncpt'' "poissnsR" (nounPhraseSP "Poisson's ratio")
   (S "the ratio of perpendicular" +:+ phrase strain +:+ S "to parallel" +:+ phrase strain)
 
-shearRes   = dccWDS "shearRes" (cn "resistive shear force")
+shearRes   = cncpt'' "shearRes" (cn "resistive shear force")
   (S "the" +:+ phrase shearForce +:+ S "in the direction opposite to the direction" +:+
   S "of potential motion, thus hindering motion along the plane")
 
-shearForce = dccWDS "shearForce" (cn' "shear force")
+shearForce = cncpt'' "shearForce" (cn' "shear force")
   (S "a" +:+ phrase force +:+ S "applied parallel to the plane of the material")
 
-stffness   = dccWDS "stffness" (cn "stiffness")
+stffness   = cncpt'' "stffness" (cn "stiffness")
   (S "the extent a body resists" +:+ phrase strain)

--- a/code/drasil-data/lib/Data/Drasil/Units/Thermodynamics.hs
+++ b/code/drasil-data/lib/Data/Drasil/Units/Thermodynamics.hs
@@ -1,21 +1,21 @@
 -- | Units related to the field of thermodynamics.
 module Data.Drasil.Units.Thermodynamics where
 
-import Language.Drasil (dccWDS, cnIES, cn, cn', cn'', dcc, Sentence(S),
+import Language.Drasil (cncpt'', cnIES, cn, cn', cn'', dcc, Sentence(S),
   UnitDefn, (/:), (*:), (/$), newUnit, makeDerU)
 
 import Data.Drasil.SI_Units (centigrade, joule, kilogram, watt, m_2, m_3)
 
 heatCapacity :: UnitDefn
-heatCapacity = makeDerU (dccWDS "heatCapacity" (cnIES "heat capacity")
+heatCapacity = makeDerU (cncpt'' "heatCapacity" (cnIES "heat capacity")
   (S "heat capacity (constant pressure)")) (joule /: centigrade)
 
 heatCapSpec :: UnitDefn --Specific heat capacity
-heatCapSpec = makeDerU (dccWDS "heatCapSpec" (cn' "specific heat")
+heatCapSpec = makeDerU (cncpt'' "heatCapSpec" (cn' "specific heat")
   (S "heat capacity per unit mass")) (joule /$ (kilogram *: centigrade))
 
 thermalFlux :: UnitDefn
-thermalFlux = makeDerU (dccWDS "thermalFlux" (cn'' "heat flux")
+thermalFlux = makeDerU (cncpt'' "thermalFlux" (cn'' "heat flux")
   (S "the rate of heat energy transfer per unit area")) (watt /: m_2)
 
 heatTransferCoef :: UnitDefn

--- a/code/drasil-example/bss/lib/Drasil/BinaryStar/TMods.hs
+++ b/code/drasil-example/bss/lib/Drasil/BinaryStar/TMods.hs
@@ -48,7 +48,7 @@ centerOfMassRels =
 
 centerOfMassCS :: ConstraintSet ModelExpr
 centerOfMassCS = mkConstraintSet
-  (dccWDS "centerOfMassCS"
+  (cncpt'' "centerOfMassCS"
     (nounPhraseSP "center-of-mass constraint")
     centerOfMassNote) $
   NE.fromList centerOfMassRels

--- a/code/drasil-example/gamephysics/lib/Drasil/GamePhysics/Unitals.hs
+++ b/code/drasil-example/gamephysics/lib/Drasil/GamePhysics/Unitals.hs
@@ -78,21 +78,21 @@ unitalTerms = [iVect, jVect, normalVect, posCM, posj, massj, mTot, accj, angAccj
 --FIXME: "A" is not being capitalized when it should be.
 forceParam, massParam, timeParam :: String -> String -> Symbol -> UnitalChunk
 forceParam n w s = uc
- (dccWDS ("force" ++ n) (cn $ "force exerted by the " ++ w ++
+ (cncpt'' ("force" ++ n) (cn $ "force exerted by the " ++ w ++
   " body (on another body)") (phrase QP.force))
   (sub (eqSymb QP.force) s) Real newton
 
 massParam n w s = uc
- (dccWDS ("mass" ++ n) (cn $ "mass of the " ++ w ++ " body")
+ (cncpt'' ("mass" ++ n) (cn $ "mass of the " ++ w ++ " body")
   (phrase QPP.mass)) (sub (eqSymb QPP.mass) s) Real kilogram
 
 timeParam n w s = uc
- (dccWDS ("time" ++ n) (cn $ "time at a point in " ++ w ++ " body ")
+ (cncpt'' ("time" ++ n) (cn $ "time at a point in " ++ w ++ " body ")
   (phrase QP.time)) (sub (eqSymb QP.time) s) Real second
 
 contParam :: String -> String -> Symbol -> Symbol -> UnitalChunk
 contParam n m w s = uc
- (dccWDS ("r_" ++ n ++ m) contdispN (phrase QP.displacement))
+ (cncpt'' ("r_" ++ n ++ m) contdispN (phrase QP.displacement))
   (sub (eqSymb QP.displacement) (Concat [w, s])) Real metre
   where contdispN = cn $ "displacement vector between the centre of mass of rigid body " ++
                          n ++ " and contact point " ++ m
@@ -100,32 +100,32 @@ contParam n m w s = uc
 angParam, momtParam, perpParam, rigidParam, velBodyParam, velParam :: String -> Symbol -> UnitalChunk
 
 angParam n w = uc
- (dccWDS ("angular velocity" ++ n) (compoundPhrase'
+ (cncpt'' ("angular velocity" ++ n) (compoundPhrase'
   (cn $ n ++ " body's") (QP.angularVelocity ^. term))
   (phrase QP.angularVelocity)) (sub (eqSymb QP.angularVelocity) w) Real angVelU
 
 momtParam n w = uc
- (dccWDS ("momentOfInertia" ++ n) (compoundPhrase'
+ (cncpt'' ("momentOfInertia" ++ n) (compoundPhrase'
   (QP.momentOfInertia ^. term) (cn $ "of rigid body " ++ n))
   (phrase QP.momentOfInertia)) (sub (eqSymb QP.momentOfInertia) w) Real momtInertU
 
 perpParam n w = uc
- (dccWDS ("|| r_A" ++ n ++ " x n ||")
+ (cncpt'' ("|| r_A" ++ n ++ " x n ||")
   (compoundPhrase' (QPP.len `ofThe` QM.perpVect)
   (cn $ "to the contact displacement vector of rigid body " ++ n))
   (phrase QM.perpVect)) (Atop Magnitude $ Concat [w, label "*", --should be x for cross
   eqSymb QM.perpVect]) Real metre
 
 rigidParam n w = uc
- (dccWDS ("rig_mass" ++ n) (compoundPhrase' (QPP.mass ^. term)
+ (cncpt'' ("rig_mass" ++ n) (compoundPhrase' (QPP.mass ^. term)
   (cn $ "of rigid body " ++ n)) (phrase QPP.mass)) (sub (eqSymb QPP.mass) w) Real kilogram
 
 velBodyParam n w = uc
- (dccWDS ("velocity" ++ n) (compoundPhrase' (QP.velocity ^. term)
+ (cncpt'' ("velocity" ++ n) (compoundPhrase' (QP.velocity ^. term)
   (cn $ "of the  " ++ n ++ " body")) (phrase QP.velocity)) (sub (eqSymb QP.velocity) w) Real velU
 
 velParam n w = uc
- (dccWDS ("velocity" ++ n) (compoundPhrase' (QP.velocity ^. term)
+ (cncpt'' ("velocity" ++ n) (compoundPhrase' (QP.velocity ^. term)
   (cn $ "at point " ++ n)) (phrase QP.velocity)) (sub (eqSymb QP.velocity) w) Real velU
 
 -----------------------
@@ -140,26 +140,26 @@ iVect, jVect, normalVect, force_1, force_2, forcej, mass_1, mass_2,
   momtInertK, pointOfCollision, contDispK, collisionImpulse, finRelVel,
   velAP, velBP, time_1, time_2, velo_1, velo_2, rRot, mLarger, distMass, dVect :: UnitalChunk
 
-iVect = uc (dccWDS "unitVectI" (compoundPhrase' (cn "horizontal")
+iVect = uc (cncpt'' "unitVectI" (compoundPhrase' (cn "horizontal")
                (QM.unitVect ^. term)) (phrase QM.unitVect))
                (eqSymb QM.unitVect) Real metre
-jVect       = uc (dccWDS "unitVectJ" (compoundPhrase' (cn "vertical")
+jVect       = uc (cncpt'' "unitVectJ" (compoundPhrase' (cn "vertical")
                (QM.unitVect ^. term)) (phrase QM.unitVect)) (vec $ hat lJ) Real metre
-normalVect  = uc (dccWDS "normalVect" (compoundPhrase (cn "collision") (QM.normalVect ^. term))
+normalVect  = uc (cncpt'' "normalVect" (compoundPhrase (cn "collision") (QM.normalVect ^. term))
                  (phrase QM.normalVect))
                    (eqSymb QM.normalVect) (Vect Real) metre
 
-dVect = uc (dccWDS "unitVectD"
+dVect = uc (cncpt'' "unitVectD"
           (cn "unit vector directed from the center of the large mass to the center of the smaller mass")
                    (phrase QM.unitVect)) (vec (hat lD)) Real metre
 
-dispNorm = uc (dccWDS "euclideanNormDisp" (cn "Euclidean norm of the distance between the center of mass of two bodies")
+dispNorm = uc (cncpt'' "euclideanNormDisp" (cn "Euclidean norm of the distance between the center of mass of two bodies")
                (phrase QM.euclidNorm) ) (eqSymb QM.euclidNorm) Real metre
 
-distMass = uc (dccWDS "distMass" (cn "distance between the center of mass of the rigid bodies")
+distMass = uc (cncpt'' "distMass" (cn "distance between the center of mass of the rigid bodies")
                  (phrase QP.distance)) (vec lD) Real metre
 
-sqrDist = uc (dccWDS "euclideanNorm" (cn' "squared distance")
+sqrDist = uc (cncpt'' "euclideanNorm" (cn' "squared distance")
                (phrase QM.euclidNorm)) (sup (eqSymb QM.euclidNorm)
                label2) Real m_2
 
@@ -174,88 +174,88 @@ posCM = uc' "p_CM" (nounPhraseSP "Center of Mass")
   (S "FIXME: Define this or remove the need for definitions")
   (sub (eqSymb QP.position) lCMass) Real metre
 
-massj = uc (dccWDS "m_j" (compoundPhrase' (QPP.mass ^. term)
+massj = uc (cncpt'' "m_j" (compoundPhrase' (QPP.mass ^. term)
                 (cn "of the j-th particle")) (phrase QPP.mass))
                 (sub (eqSymb QPP.mass) lJ) Real kilogram
 
-posj = uc (dccWDS "p_j" (compoundPhrase' (QP.position ^. term)
+posj = uc (cncpt'' "p_j" (compoundPhrase' (QP.position ^. term)
                (cn "vector of the j-th particle")) (phrase QP.position))
                (sub (eqSymb QP.position) lJ) Real metre
 
-accj = uc (dccWDS "accj" (compoundPhrase' (cn "j-th body's")
+accj = uc (cncpt'' "accj" (compoundPhrase' (cn "j-th body's")
                (QP.acceleration ^. term)) (phrase QP.acceleration))
                (sub (eqSymb QP.acceleration) lJ) Real accelU
 
 -- FIXME: Using the titleized version in the same style as 'accj' above does not render properly.
 --        Oddly, stable breaks differently when trying to use 'nounPhraseSent' or 'combineNPNI'. See #2650.
-angAccj = uc (dccWDS "angAccj" (nounPhrase'' n n CapWords CapWords) (phrase QP.angularAccel))
+angAccj = uc (cncpt'' "angAccj" (nounPhrase'' n n CapWords CapWords) (phrase QP.angularAccel))
                (sub (eqSymb QP.angularAccel) lJ) Real angAccelU
   where
     n :: D.NPStruct
     n = D.S "j-th body's" D.:+: phraseNP (QP.angularAccel ^. term)
 
-velj = uc (dccWDS "velj" (compoundPhrase' (QP.velocity ^. term)
+velj = uc (cncpt'' "velj" (compoundPhrase' (QP.velocity ^. term)
                (cn "of the j-th body")) (phrase QP.velocity))
                (sub (eqSymb QP.velocity) lJ) Real velU
 
-torquej = uc (dccWDS "torquej"
+torquej = uc (cncpt'' "torquej"
                (cn "torque applied to the j-th body")
                (phrase QP.torque)) (sub (eqSymb QP.torque) lJ) Real torqueU
 
-mTot = uc (dccWDS "M_T" (compoundPhrase' (cn "total mass of the")
+mTot = uc (cncpt'' "M_T" (compoundPhrase' (cn "total mass of the")
                  (CP.rigidBody ^. term)) (phrase QPP.mass))
                  (sub (eqSymb QPP.mass) cT) Real kilogram
 
-mLarger = uc (dccWDS "mLarger" (compoundPhrase' (cn "mass of the larger")
+mLarger = uc (cncpt'' "mLarger" (compoundPhrase' (cn "mass of the larger")
                  (CP.rigidBody ^. term)) (phrase QPP.mass)) cM Real kilogram
 
-timeC = uc (dccWDS "timeC" (cn "denotes the time at collision")
+timeC = uc (cncpt'' "timeC" (cn "denotes the time at collision")
                 (phrase QP.time)) (sub (eqSymb QP.time) lColl) Real second
 
-initRelVel = uc (dccWDS "v_i^AB" (compoundPhrase'
+initRelVel = uc (cncpt'' "v_i^AB" (compoundPhrase'
                  (compoundPhrase' (cn "initial relative") (QP.velocity ^. term))
                  (cn "between rigid bodies of A and B")) (phrase QP.velocity))
                  (sup (sub (eqSymb QP.velocity) QP.initial) (Concat [lBodyA, lBodyB])) (Vect Real) velU
 
-finRelVel = uc (dccWDS "v_f^AB" (compoundPhrase'
+finRelVel = uc (cncpt'' "v_f^AB" (compoundPhrase'
                  (compoundPhrase' (cn "final relative") (QP.velocity ^. term))
                  (cn "between rigid bodies of A and B")) (phrase QP.velocity))
                  (sup (sub (eqSymb QP.velocity) QP.final) (Concat [lBodyA, lBodyB])) (Vect Real) velU
 
-massIRigidBody = uc (dccWDS "massj" (compoundPhrase' (QPP.mass ^. term)
+massIRigidBody = uc (cncpt'' "massj" (compoundPhrase' (QPP.mass ^. term)
                 (cn "of the j-th rigid body")) (phrase QPP.mass))
                 (sub (eqSymb QPP.mass) lJ) Real kilogram
-normalLen = uc (dccWDS "length of the normal vector" (
+normalLen = uc (cncpt'' "length of the normal vector" (
                   QPP.len `ofThe` QM.normalVect)
                   (phrase QM.normalVect))
                   (Atop Magnitude $ eqSymb QM.normalVect) Real metre
 
-rRot = uc (dccWDS "r_j" (compoundPhrase' (QP.distance ^. term)
+rRot = uc (cncpt'' "r_j" (compoundPhrase' (QP.distance ^. term)
                 (cn "between the j-th particle and the axis of rotation")) (phrase QP.distance))
                 (sub (eqSymb QP.distance) lJ) Real metre
 
-timeT = uc (dccWDS "t" (cn "point in time") (phrase QP.time))
+timeT = uc (cncpt'' "t" (cn "point in time") (phrase QP.time))
                 (eqSymb QP.time) Real second
 
-inittime = uc (dccWDS "t_0" (cn "denotes the initial time")
+inittime = uc (cncpt'' "t_0" (cn "denotes the initial time")
                 (phrase QP.time)) (sub (eqSymb QP.time) label0) Real second
 
-pointOfCollision = uc (dccWDS "point_c" (cn "point of collision")
+pointOfCollision = uc (cncpt'' "point_c" (cn "point of collision")
                  (S "point")) cP Real metre
 
-collisionImpulse = uc (dccWDS "collisionImp" (compoundPhrase'
+collisionImpulse = uc (cncpt'' "collisionImp" (compoundPhrase'
                 (cn "collision") (QP.impulseS ^. term)) (phrase QP.impulseS))
                 (eqSymb QP.impulseS) Real impulseU
 
-forcej = uc (dccWDS "forcej" (compoundPhrase'
+forcej = uc (cncpt'' "forcej" (compoundPhrase'
       (QP.force ^. term) (cn "applied to the j-th body at time t"))
       (phrase QP.force)) (sub (eqSymb QP.force) lJ) Real newton
 
-velAP = uc (dccWDS "v^AP" (compoundPhrase' (QP.velocity ^. term)
+velAP = uc (cncpt'' "v^AP" (compoundPhrase' (QP.velocity ^. term)
               (cn "of the point of collision P in body A"))
               (phrase QP.velocity)) (sup (eqSymb QP.velocity)(Concat [lBodyA, lPoint]))
               (Vect Real) velU
-velBP = uc (dccWDS "v^BP" (compoundPhrase' (QP.velocity ^. term)
+velBP = uc (cncpt'' "v^BP" (compoundPhrase' (QP.velocity ^. term)
               (cn "of the point of collision P in body B"))
               (phrase QP.velocity)) (sup (eqSymb QP.velocity)(Concat [lBodyB, lPoint]))
               (Vect Real) velU

--- a/code/drasil-example/glassbr/lib/Drasil/GlassBR/Unitals.hs
+++ b/code/drasil-example/glassbr/lib/Drasil/GlassBR/Unitals.hs
@@ -347,7 +347,7 @@ fTemperedGl   = cc' fullyT
   S "been subjected to a special heat treatment process where the residual",
   S "surface compression is not less than 69 MPa (10 000 psi) or the edge",
   S "compression not less than 67 MPa (9700 psi), as defined in", refS astm2012])
-glassGeo      = dccWDS "glassGeo"    (cnIES "glass geometry")
+glassGeo      = cncpt'' "glassGeo"    (cnIES "glass geometry")
   (S "the glass geometry based inputs include the dimensions of the" +:+
     foldlList Comma List [phrase glaPlane, phrase glassTy, phrase responseTy])
 glassTy       = dcc "glassTy"     (cn' "glass type") "type of glass"
@@ -391,7 +391,7 @@ nonFactoredL  = cc' nFL
   S "per 1000 for monolithic", short annealed, S "glass"])
 notSafe       = dcc "notSafe"     (nounPhraseSP "not safe")
   "For the given input parameters, the glass is NOT considered safe."
-probBreak     = dccWDS "probBr" (nounPhraseSP "probability of breakage")
+probBreak     = cncpt'' "probBr" (nounPhraseSP "probability of breakage")
   (foldlSent_ [S "the fraction of glass lites or plies that would break at the",
   S "first occurrence of a specified load and duration, typically expressed",
   S "in lites per 1000", sParen $ refS astm2016])

--- a/code/drasil-example/pdcontroller/lib/Drasil/PDController/Unitals.hs
+++ b/code/drasil-example/pdcontroller/lib/Drasil/PDController/Unitals.hs
@@ -183,7 +183,7 @@ dqdDampingCoeff
 -- TODO: Create a separate description for the stiffness coefficient to state
 -- that it is the "stiffness coefficient of the spring" (#4275)
 dqdStiffnessCoeff
-  = dqd (dccWDS "dqdStiffnessCoeff" (ccStiffCoeff ^. term) (ccStiffCoeff ^. defn))
+  = dqd (cncpt'' "dqdStiffnessCoeff" (ccStiffCoeff ^. term) (ccStiffCoeff ^. defn))
       symStifnessCoeff
       Real
       second

--- a/code/drasil-example/projectile/lib/Drasil/Projectile/Concepts.hs
+++ b/code/drasil-example/projectile/lib/Drasil/Projectile/Concepts.hs
@@ -42,9 +42,9 @@ launcher   = dcc "launcher"   (nounPhraseSP "launcher")  ("where the projectile 
 projectile = dcc "projectile" (nounPhraseSP "projectile") "the object to be launched at the target"
 target     = dcc "target"     (nounPhraseSP "target")     "where the projectile should be launched to"
 
-projSpeed  = dccWDS "projSpeed" (nounPhraseSP "1D speed")
+projSpeed  = cncpt'' "projSpeed" (nounPhraseSP "1D speed")
   (short oneD +:+ phrase speed +:+ S "under" +:+ phrase constant +:+ phrase acceleration)
-projPos    = dccWDS "projPos"   (nounPhraseSP "1D position")
+projPos    = cncpt'' "projPos"   (nounPhraseSP "1D position")
   (short oneD +:+ phrase position +:+ S "under" +:+ phrase constant +:+ phrase speed)
 
 landPos, launAngle, launSpeed, offset, targPos, flightDur :: ConceptChunk

--- a/code/drasil-example/ssp/lib/Drasil/SSP/Defs.hs
+++ b/code/drasil-example/ssp/lib/Drasil/SSP/Defs.hs
@@ -58,19 +58,19 @@ stabAnalysis = compoundNC stability analysis
 ssa = compoundNC slope stabAnalysis
 
 effFandS, slpSrf, crtSlpSrf, plnStrn, fsConcept, waterTable :: ConceptChunk
-effFandS = dccWDS "effective forces and stresses"
+effFandS = cncpt'' "effective forces and stresses"
   (cn "effective forces and stresses")
   (D.toSent (atStartNP (the normForce)) `S.or_` phrase nrmStrss +:+
   S "carried by the" +:+ phrase soil +:+ S "skeleton" `sC`
   S "composed of the effective" +:+ phrase force `S.or_` phrase stress `S.andThe`
   phrase force `S.or_` phrase stress +:+ S "exerted by water")
 
-slpSrf = dccWDS "slip surface" (slpSrfCon ^. term)
+slpSrf = cncpt'' "slip surface" (slpSrfCon ^. term)
   (D.toSent (atStartNP (a_ surface)) +:+ S "within a" +:+ phrase slope +:+ S "that has the" +:+
   S "potential to fail or displace due to load or other" +:+ plural force)
 
 --FIXME: move to Concepts/soldMechanics.hs? They are too specific though
-plnStrn = dccWDS "plane strain" (cn' "plane strain")
+plnStrn = cncpt'' "plane strain" (cn' "plane strain")
   (S "A condition where the resultant" +:+ plural stress +:+ S "in one of" +:+
   S "the directions" `S.ofA` phrase threeD +:+ S "material can be" +:+
   S "approximated as zero. This condition results when a body is" +:+
@@ -80,12 +80,12 @@ plnStrn = dccWDS "plane strain" (cn' "plane strain")
   S "infinite" +:+ atStart' stress +:+ S "in the direction" `S.ofThe` S "dominant" +:+
   phrase dimension +:+ S "can be approximated as zero")
 
-crtSlpSrf = dccWDS "critical slip surface" (cn' "critical slip surface")
+crtSlpSrf = cncpt'' "critical slip surface" (cn' "critical slip surface")
   (D.toSent (atStartNP (slpSrf `ofThe` slope)) +:+
   S "that has the lowest" +:+ phrase fsConcept `sC`
   S "and is therefore most likely to experience failure")
 
-fsConcept = dccWDS "FS" factorOfSafety
+fsConcept = cncpt'' "FS" factorOfSafety
   (S "The global stability metric" `S.ofA` D.toSent (phraseNP (slpSrf `ofA` slope)) `sC`
   S "defined as the ratio" `S.of_` phrase shearRes +:+
   S "to" +:+ phrase mobShear)

--- a/code/drasil-example/ssp/lib/Drasil/SSP/GenDefs.hs
+++ b/code/drasil-example/ssp/lib/Drasil/SSP/GenDefs.hs
@@ -253,7 +253,7 @@ mobShearWODesc = (foldlList Comma List [slcWght `definedIn'''` sliceWghtGD,
 --
 momentEqlModel :: ModelKind ModelExpr
 momentEqlModel = equationalConstraints' $
-  mkConstraintSet (dccWDS "momentEql" (nounPhraseSP "moment equilibrium") momEqlDesc) $
+  mkConstraintSet (cncpt'' "momentEql" (nounPhraseSP "moment equilibrium") momEqlDesc) $
   NE.fromList [express momEqlExpr]
 
 momEqlExpr :: Expr

--- a/code/drasil-example/ssp/lib/Drasil/SSP/TMods.hs
+++ b/code/drasil-example/ssp/lib/Drasil/SSP/TMods.hs
@@ -60,7 +60,7 @@ equilibriumRels = map (($= int 0) . sumAll (variable "i") . sy) [fx, fy, generic
 -- FIXME: variable "i" is a hack. But we need to sum over something!
 equilibriumCS :: ConstraintSet ModelExpr
 equilibriumCS = mkConstraintSet
-  (dccWDS "equilibriumCS" (nounPhraseSP "equilibrium") eqDesc) $
+  (cncpt'' "equilibriumCS" (nounPhraseSP "equilibrium") eqDesc) $
   NE.fromList equilibriumRels
 -- makeRC "equilibriumRC" (nounPhraseSP "equilibrium") eqDesc eqRel
 

--- a/code/drasil-example/ssp/lib/Drasil/SSP/Unitals.hs
+++ b/code/drasil-example/ssp/lib/Drasil/SSP/Unitals.hs
@@ -456,7 +456,7 @@ normToShear = dqd' (dcc "lambda" (nounPhraseSP "proportionality constant")
   "the ratio of the interslice normal to the interslice shear force")
   (const lLambda) Real Nothing
 
-scalFunc = dqd' (dccWDS "f_i"
+scalFunc = dqd' (cncpt'' "f_i"
   (nounPhraseSP "interslice normal to shear force ratio variation function")
   (S "a function" `S.of_` D.toSent (phraseNP (distance `inThe` xDir)) +:+
    S "that describes the variation" `S.ofThe` S "interslice normal to shear ratio"))

--- a/code/drasil-example/swhs/lib/Drasil/SWHS/TMods.hs
+++ b/code/drasil-example/swhs/lib/Drasil/SWHS/TMods.hs
@@ -46,7 +46,7 @@ consThermE = tm (equationalConstraints' consThermECS) [dRef consThemESrc]
 
 consThermECS :: ConstraintSet ModelExpr
 consThermECS = mkConstraintSet consCC rels
-  where consCC = dccWDS "consThermECS"
+  where consCC = cncpt'' "consThermECS"
           (nounPhraseSP "Conservation of thermal energy") (lawConsEnergy ^. defn)
         rels   = NE.fromList [consThermERel]
 

--- a/code/drasil-lang/lib/Language/Drasil.hs
+++ b/code/drasil-lang/lib/Language/Drasil.hs
@@ -81,7 +81,7 @@ module Language.Drasil (
   -- Language.Drasil.Chunk.Concept.Core
   , ConceptChunk, ConceptInstance, sDom
   -- Language.Drasil.Chunk.Concept
-  , cncpt, cncpt', cncpt'', dcc, dccAWDS, dccA, dccWDS, cc', cw, cic
+  , cncpt, cncpt', cncpt'', dcc, dccAWDS, dccA, cc', cw, cic
 
   -- *** Quantities and Units
   -- Language.Drasil.Chunk.Eq

--- a/code/drasil-lang/lib/Language/Drasil/Chunk/Concept.hs
+++ b/code/drasil-lang/lib/Language/Drasil/Chunk/Concept.hs
@@ -3,7 +3,7 @@
 module Language.Drasil.Chunk.Concept (
   -- * Concept Chunks
   -- ** From an idea ('IdeaDict')
-  ConceptChunk, cncpt, cncpt', cncpt'', dcc, dccA, dccAWDS, dccWDS, cc', cw,
+  ConceptChunk, cncpt, cncpt', cncpt'', dcc, dccA, dccAWDS, cc', cw,
   -- ** From a 'ConceptChunk'
   ConceptInstance, cic
   ) where
@@ -58,7 +58,7 @@ cncpt'' ::
   Sentence -> ConceptChunk
 cncpt'' u trm defn = cncpt' u trm defn Nothing
 
-{-# DEPRECATED dccA, dccAWDS, dcc, dccWDS, cc', cw
+{-# DEPRECATED dccA, dccAWDS, dcc, cc', cw
   "Smart constructors allow externally-known chunk nesting; use one of `cncpt, cncpt', cncpt''` instead." #-}
 
 -- | Smart constructor for creating a concept chunks with an abbreviation. Takes
@@ -74,10 +74,6 @@ dccAWDS i t d a = ConDict (mkIdea i t a) d []
 -- ('NP') and definition (as a 'String').
 dcc :: String -> NP -> String -> ConceptChunk
 dcc i ter des = dccA i ter des Nothing
-
--- | Similar to 'dcc', except the definition takes a 'Sentence'.
-dccWDS :: String -> NP -> Sentence -> ConceptChunk
-dccWDS i t d = dccAWDS i t d Nothing
 
 -- | Constructor for projecting an idea into a 'ConceptChunk'. Takes the
 -- definition of the 'ConceptChunk' as a 'Sentence. Does not allow concept

--- a/code/drasil-lang/lib/Language/Drasil/Chunk/Constrained.hs
+++ b/code/drasil-lang/lib/Language/Drasil/Chunk/Constrained.hs
@@ -10,7 +10,7 @@ import Control.Lens ((^.), makeLenses, view)
 
 import Drasil.Database (HasUID(..), HasChunkRefs(..))
 
-import Language.Drasil.Chunk.Concept (dcc, dccWDS)
+import Language.Drasil.Chunk.Concept (dcc, cncpt'')
 import Language.Drasil.Chunk.Unital (uc')
 import Language.Drasil.Chunk.DefinedQuantity (DefinedQuantityDict, dqd', dqdWr, dqdNoUnit)
 import Language.Drasil.Symbol (HasSymbol(..), Symbol)
@@ -97,7 +97,7 @@ cuc' nam trm desc sym un space cs rv =
 cucNoUnit' :: String -> NP -> String -> Symbol
             -> Space -> [ConstraintE] -> Expr -> ConstrConcept
 cucNoUnit' nam trm desc sym space cs rv =
-  ConstrConcept (dqdNoUnit (dccWDS nam trm (S desc)) sym space) cs (Just rv) Nothing
+  ConstrConcept (dqdNoUnit (cncpt'' nam trm (S desc)) sym space) cs (Just rv) Nothing
 
 -- | Similar to 'cuc'', but 'Symbol' is dependent on 'Stage'.
 cuc'' :: (IsUnit u) => String -> NP -> String -> (Stage -> Symbol) -> u

--- a/code/drasil-lang/lib/Language/Drasil/Chunk/DefinedQuantity.hs
+++ b/code/drasil-lang/lib/Language/Drasil/Chunk/DefinedQuantity.hs
@@ -18,7 +18,7 @@ import qualified Data.Set as Set
 import Language.Drasil.Symbol (HasSymbol(symbol), Symbol (Empty))
 import Language.Drasil.Classes (NamedIdea(term), Idea(getA), Concept, Express(..),
   Definition(defn), ConceptDomain(cdom), IsUnit, Quantity)
-import Language.Drasil.Chunk.Concept (ConceptChunk, cw, dcc, dccWDS, dccA, dccAWDS)
+import Language.Drasil.Chunk.Concept (ConceptChunk, cw, dcc, cncpt'', dccA, dccAWDS)
 import Language.Drasil.Expr.Class (sy)
 import Language.Drasil.Chunk.UnitDefn (UnitDefn, unitWrapper,
   MayHaveUnit(getUnit))
@@ -101,7 +101,7 @@ implVar i ter desc sp sym = dqdNoUnit' (dcc i ter desc) f sp
 
 -- | Similar to 'implVar', but takes in a 'Sentence' for the description rather than a 'String'.
 implVar' :: String -> NP -> Sentence -> Space -> Symbol -> DefinedQuantityDict
-implVar' i ter desc sp sym = dqdNoUnit' (dccWDS i ter desc) f sp
+implVar' i ter desc sp sym = dqdNoUnit' (cncpt'' i ter desc) f sp
   where
     f :: Stage -> Symbol
     f Implementation = sym

--- a/code/drasil-lang/lib/Language/Drasil/Chunk/Unital.hs
+++ b/code/drasil-lang/lib/Language/Drasil/Chunk/Unital.hs
@@ -11,7 +11,7 @@ import Control.Lens (makeLenses, view, (^.))
 import Drasil.Database (HasUID(..), HasChunkRefs(..))
 import qualified Data.Set as Set
 
-import Language.Drasil.Chunk.Concept (dccWDS,cw)
+import Language.Drasil.Chunk.Concept (cncpt'',cw)
 import Language.Drasil.Chunk.DefinedQuantity (DefinedQuantityDict, dqd, dqd')
 import Language.Drasil.Symbol (Symbol, HasSymbol(..))
 import Language.Drasil.Classes (NamedIdea(term), Idea(getA), Express(express),
@@ -75,7 +75,7 @@ uc a sym space c = UC (dqd (cw a) sym space un) un
 -- | Similar to 'uc', except it builds the 'Concept' portion of the 'UnitalChunk'
 -- from a given 'UID', term, and definition (as a 'Sentence') which are its first three arguments.
 uc' :: (IsUnit u) => String -> NP -> Sentence -> Symbol -> Space -> u -> UnitalChunk
-uc' i t d sym space u = UC (dqd (dccWDS i t d) sym space un) un
+uc' i t d sym space u = UC (dqd (cncpt'' i t d) sym space un) un
  where un = unitWrapper u
 
 -- | Similar to 'uc', but 'Symbol' is dependent on the 'Stage'.
@@ -87,5 +87,5 @@ ucStaged a sym space u = UC (dqd' (cw a) sym space (Just un)) un
 -- | Similar to 'uc'', but 'Symbol' is dependent on the 'Stage'.
 ucStaged' :: (IsUnit u) => String -> NP -> Sentence -> (Stage -> Symbol) ->
   Space -> u -> UnitalChunk
-ucStaged' i t d sym space u = UC (dqd' (dccWDS i t d) sym space (Just un)) un
+ucStaged' i t d sym space u = UC (dqd' (cncpt'' i t d) sym space (Just un)) un
  where un = unitWrapper u

--- a/code/drasil-theory/lib/Theory/Drasil/DifferentialModel.hs
+++ b/code/drasil-theory/lib/Theory/Drasil/DifferentialModel.hs
@@ -17,7 +17,7 @@ import Data.List (find)
 import Drasil.Database (HasUID(uid), HasChunkRefs(..))
 
 import Language.Drasil
-  (ConceptChunk, dccWDS, Express(..), ConceptDomain(..), Definition(..), Idea(..), NamedIdea(..)
+  (ConceptChunk, cncpt'', Express(..), ConceptDomain(..), Definition(..), Idea(..), NamedIdea(..)
   , ModelExpr, NP, Sentence, Expr, UnitalChunk, ModelExprC(nthderiv, equiv)
   , ExprC(..), columnVec, ConstrConcept, LiteralC(exactDbl, int), RequiresChecking (requiredChecks)
   , Space, HasSpace (..), dqdWr)
@@ -174,7 +174,7 @@ makeASystemDE indepVar' depVar' coeffs unks const' id' term' defn'
   error "The length of each row vector in coefficients need to equal to the length of unknowns vector"
  | not $ isUnknownDescending unks =
   error "The order of giving unknowns need to be descending"
- | otherwise = SystemOfLinearODEs indepVar' depVar' coeffs unks const'(dccWDS id' term' defn')
+ | otherwise = SystemOfLinearODEs indepVar' depVar' coeffs unks const'(cncpt'' id' term' defn')
 
 -- | Create a 'DifferentialModel' by the input language
 makeASingleDE :: UnitalChunk -> ConstrConcept -> LHS -> Expr-> String -> NP -> Sentence -> DifferentialModel
@@ -183,7 +183,7 @@ makeASingleDE indepVar'' depVar'' lhs const'' id'' term'' defn''
   error "Length of coefficients matrix should equal to the length of the constant vector"
  | not $ isCoeffsMatchUnknowns coeffs unks =
   error "The length of each row vector in coefficients need to equal to the length of unknowns vector"
- | otherwise = SystemOfLinearODEs indepVar'' depVar'' coeffs unks [const''](dccWDS id'' term'' defn'')
+ | otherwise = SystemOfLinearODEs indepVar'' depVar'' coeffs unks [const''](cncpt'' id'' term'' defn'')
   where unks = createAllUnknowns(findHighestOrder lhs ^. unk) depVar''
         coeffs = [createCoefficients lhs unks]
 

--- a/code/drasil-theory/lib/Theory/Drasil/RelationConcept.hs
+++ b/code/drasil-theory/lib/Theory/Drasil/RelationConcept.hs
@@ -41,4 +41,4 @@ instance Express       RelationConcept where express = (^. rel)
 
 -- | Create a 'RelationConcept' from a given 'UID', term ('NP'), definition ('Sentence'), and 'Relation'.
 makeRC :: Express e => String -> NP -> Sentence -> e -> RelationConcept
-makeRC rID rTerm rDefn = RC (dccWDS rID rTerm rDefn) . express
+makeRC rID rTerm rDefn = RC (cncpt'' rID rTerm rDefn) . express


### PR DESCRIPTION
Contributes to #5141

Behold! The power of `find . -name "*.hs" -exec sed -i '' -E "s/dccWDS/cncpt''/g" {} +`.

Replaces `dccWDS` with more appropriately named `cncpt''` smart constructor of `ConceptChunk`s.

(This will still fail the CI because there are other deprecation warnings.)
