### PR TITLE
refactor: move `ncUID` constructor usage to `idea'`

### DIFF
--- a/code/drasil-lang/lib/Language/Drasil.hs
+++ b/code/drasil-lang/lib/Language/Drasil.hs
@@ -72,7 +72,7 @@ module Language.Drasil (
 
   -- *** Basic types
   -- Language.Drasil.Chunk.NamedIdea
-  , IdeaDict, idea, idea', nc, ncUID, mkIdea
+  , IdeaDict, idea, idea', nc, mkIdea
   , nw -- bad name (historical)
   -- Language.Drasil.Chunk.CommonIdea
   , CI, commonIdeaWithDict, prependAbrv

--- a/code/drasil-lang/lib/Language/Drasil/Chunk/Concept/NamedCombinators.hs
+++ b/code/drasil-lang/lib/Language/Drasil/Chunk/Concept/NamedCombinators.hs
@@ -40,7 +40,7 @@ import Control.Lens ((^.))
 
 import Drasil.Database ((+++!))
 
-import Language.Drasil.Chunk.NamedIdea (IdeaDict, ncUID)
+import Language.Drasil.Chunk.NamedIdea (IdeaDict, idea')
 import Language.Drasil.Classes (Idea, NamedIdea(..))
 import Language.Drasil.NaturalLanguage.English.NounPhrase (NP, CapitalizationRule(CapWords, Replace,
   CapFirst), NounPhrase(phraseNP, pluralNP), nounPhrase'', compoundPhrase,
@@ -238,18 +238,18 @@ a_Gen f t = nounPhrase'' (S "a" :+: f t) (S "a" :+: f t) CapFirst CapWords
 -- See 'compoundPhrase' for more on pluralNP behaviour.
 -- /Does not preserve abbreviations/.
 compoundNC :: (NamedIdea a, NamedIdea b) => a -> b -> IdeaDict
-compoundNC t1 t2 = ncUID
+compoundNC t1 t2 = idea'
   (t1 +++! t2) (compoundPhrase (t1 ^. term) (t2 ^. term))
 
 -- | Similar to 'compoundNC' but both terms are pluralized for pluralNP case.
 compoundNCPP :: (NamedIdea a, NamedIdea b) => a -> b -> IdeaDict
-compoundNCPP t1 t2 = ncUID
+compoundNCPP t1 t2 = idea'
   (t1 +++! t2) (compoundPhrase'' D.pluralNP D.pluralNP (t1 ^. term) (t2 ^. term))
 
 -- | Similar to 'compoundNC', except pluralNP cases are customizable.
 compoundNCGen :: (NamedIdea a, NamedIdea b) =>
   (NP -> NPStruct) -> (NP -> NPStruct) -> a -> b -> IdeaDict
-compoundNCGen f1 f2 t1 t2 = ncUID
+compoundNCGen f1 f2 t1 t2 = idea'
   (t1 +++! t2)
   (compoundPhrase'' f1 f2 (t1 ^. term) (t2 ^. term))
 
@@ -261,7 +261,7 @@ compoundNCPS = compoundNCGen D.pluralNP D.phraseNP
 -- Characteristics as it is the end of the first term (solutionCharacteristic)
 -- | Similar to 'compoundNC', but takes a function that is applied to the first term (eg. 'short' or 'plural').
 compoundNCGenP :: (NamedIdea a, NamedIdea b) => (NP -> NPStruct) -> a -> b -> IdeaDict
-compoundNCGenP f1 t1 t2 = ncUID
+compoundNCGenP f1 t1 t2 = idea'
   (t1 +++! t2) (compoundPhrase''' f1 (t1 ^. term) (t2 ^. term))
 
 -- FIXME: Same as above function

--- a/code/drasil-lang/lib/Language/Drasil/Chunk/Eq.hs
+++ b/code/drasil-lang/lib/Language/Drasil/Chunk/Eq.hs
@@ -25,7 +25,7 @@ import Language.Drasil.Classes (NamedIdea(term), Idea(getA),
   ConceptDomain(cdom), Express(express), Concept)
 import Language.Drasil.Chunk.DefinedQuantity (DefinedQuantityDict, DefinesQuantity(defLhs), dqd, dqd', dqdWr)
 import Language.Drasil.Chunk.Concept (cc')
-import Language.Drasil.Chunk.NamedIdea (ncUID, mkIdea)
+import Language.Drasil.Chunk.NamedIdea (idea', mkIdea)
 import Language.Drasil.Expr.Lang (Expr)
 import qualified Language.Drasil.Expr.Lang as E (Expr(C))
 import Language.Drasil.Expr.Class (ExprC(apply, sy, ($=)))
@@ -102,12 +102,12 @@ fromEqn' nm desc def symb sp =
 fromEqnSt :: IsUnit u => UID -> NP -> Sentence -> (Stage -> Symbol) ->
   Space -> u -> e -> QDefinition e
 fromEqnSt nm desc def symb sp un =
-  QD (dqd' (cc' (ncUID nm desc) def) symb sp (Just $ unitWrapper un)) []
+  QD (dqd' (cc' (idea' nm desc) def) symb sp (Just $ unitWrapper un)) []
 
 -- | Same as 'fromEqn', but symbol depends on stage and has no units.
 fromEqnSt' :: UID -> NP -> Sentence -> (Stage -> Symbol) -> Space -> e -> QDefinition e
 fromEqnSt' nm desc def symb sp =
-  QD (dqd' (cc' (ncUID nm desc) def) symb sp Nothing) []
+  QD (dqd' (cc' (idea' nm desc) def) symb sp Nothing) []
 
 -- | Same as 'fromEqnSt'', but takes a 'String' instead of a 'UID'.
 fromEqnSt'' :: String -> NP -> Sentence -> (Stage -> Symbol) -> Space -> e ->
@@ -141,7 +141,7 @@ mkFuncDef0 :: (IsChunk f, HasSymbol f, HasSpace f,
                IsChunk i, HasSymbol i, HasSpace i) =>
   f -> NP -> Sentence -> Maybe UnitDefn -> [i] -> e -> QDefinition e
 mkFuncDef0 f n s u is = QD
-  (dqd' (cc' (ncUID (f ^. uid) n) s) (symbol f)
+  (dqd' (cc' (idea' (f ^. uid) n) s) (symbol f)
     (f ^. typ) u) (map (^. uid) is)
     -- (mkFunction (map (^. typ) is) (f ^. typ)) u) (map (^. uid) is)
 

--- a/code/drasil-lang/lib/Language/Drasil/Chunk/NamedIdea.hs
+++ b/code/drasil-lang/lib/Language/Drasil/Chunk/NamedIdea.hs
@@ -6,7 +6,7 @@ module Language.Drasil.Chunk.NamedIdea (
   -- * Classes
   NamedIdea(..), Idea(..),
   -- * Constructors
-  idea, idea', nc, ncUID, nw, mkIdea,
+  idea, idea', nc, nw, mkIdea,
 ) where
 
 import Control.Lens ((^.), makeLenses, Lens')
@@ -67,7 +67,7 @@ idea' ::
   NP -> IdeaDict
 idea' u t = IdeaDict u t Nothing
 
-{-# DEPRECATED nc, ncUID, mkIdea
+{-# DEPRECATED nc, mkIdea
   "Use `idea` or `idea'` instead." #-}
 
 {-# DEPRECATED nw
@@ -76,10 +76,6 @@ idea' u t = IdeaDict u t Nothing
 -- | 'IdeaDict' constructor, takes a 'String' for its 'UID' and a term.
 nc :: String -> NP -> IdeaDict
 nc s np' = IdeaDict (mkUid s) np' Nothing
-
--- | Similar to 'nc', but takes in the 'UID' in the form of a 'UID' rather than a 'String'.
-ncUID :: UID -> NP -> IdeaDict
-ncUID u np' = IdeaDict u np' Nothing
 
 -- | 'IdeaDict' constructor, takes a 'UID', 'NP', and
 -- an abbreviation in the form of 'Maybe' 'String'.


### PR DESCRIPTION
Deals with some of the GHC deprecation warnings introduced in #5141.