### PR TITLE
refactor: avoid `mkIdea` constructor in favour `idea[']`

### DIFF
--- a/code/drasil-data/lib/Data/Drasil/Concepts/Documentation.hs
+++ b/code/drasil-data/lib/Data/Drasil/Concepts/Documentation.hs
@@ -130,7 +130,7 @@ video           = idea' (mkUid "video")          (cn'    "video"              )
 year            = idea' (mkUid "year")           (cn'    "year"               )
 scpOfTheProjS   = idea' (mkUid "scpOfTheProj")   (cn'    "scope of the project") -- temporary generated for test
 
-notApp          = mkIdea "notApp" (nounPhraseSP "not applicable")   (Just "N/A")
+notApp          = idea (mkUid "notApp") (nounPhraseSP "not applicable")   "N/A"
 
 methAndAnls, procForAnls :: IdeaDict
 

--- a/code/drasil-example/glassbr/lib/Drasil/GlassBR/Concepts.hs
+++ b/code/drasil-example/glassbr/lib/Drasil/GlassBR/Concepts.hs
@@ -6,12 +6,12 @@ module Drasil.GlassBR.Concepts (
 ) where
 
 import Drasil.Database (mkUid)
-import Language.Drasil (commonIdeaWithDict, mkIdea, cn', nounPhraseSP, CI, IdeaDict, idea')
+import Language.Drasil (commonIdeaWithDict, cn', nounPhraseSP, CI, IdeaDict, idea')
 import Language.Drasil.Chunk.Concept.NamedCombinators (compoundNC)
 import Data.Drasil.Concepts.Documentation (response, type_)
 
 idglass :: IdeaDict
-idglass = mkIdea "glass" (cn' "Glass") Nothing
+idglass = idea' (mkUid "glass") (cn' "Glass")
 
 con' :: [IdeaDict]
 con' = [beam, blastRisk, cantilever, edge, glaPlane, glaSlab, plane,

--- a/code/drasil-example/projectile/lib/Drasil/Projectile/Concepts.hs
+++ b/code/drasil-example/projectile/lib/Drasil/Projectile/Concepts.hs
@@ -4,6 +4,7 @@ module Drasil.Projectile.Concepts (
 ) where
 
 import Drasil.Database (mkUid)
+import Control.Lens ((^.))
 import Language.Drasil
 import Language.Drasil.Chunk.Concept.NamedCombinators
 import qualified Language.Drasil.Development as D
@@ -15,20 +16,13 @@ import Data.Drasil.Concepts.Physics (oneD, position, speed, motion, distance, iS
   rectilinear, velocity, acceleration)
 
 ideaDicts :: [IdeaDict]
-ideaDicts = [projMotion, launchNC, rectVel]
+ideaDicts = [projMotion, launch, rectVel]
 
-durationNC, flightDurNC, landingPosNC, launchNC, launchAngleNC, launchSpeedNC, offsetNC, targetPosNC,
-  rectVel :: IdeaDict
-durationNC   = idea' (mkUid "duration") (nounPhraseSP "duration")
-launchNC     = idea' (mkUid "launch")   (nounPhraseSP "launch")
-offsetNC     = idea' (mkUid "offset")   (compoundPhrase (cn "distance between the") (targetPosNC `andThe` landingPosNC))
+launch :: IdeaDict
+launch = idea' (mkUid "launch") (nounPhraseSP "launch")
 
-flightDurNC   = compoundNC (idea' (mkUid "flight")  (nounPhraseSP "flight" )) durationNC
-landingPosNC  = compoundNC (idea' (mkUid "landing") (nounPhraseSP "landing")) position
-launchAngleNC = compoundNC launchNC angle
-launchSpeedNC = compoundNC launchNC speed
-targetPosNC   = compoundNC target position
-rectVel       = compoundNC rectilinear velocity
+rectVel :: IdeaDict
+rectVel = compoundNC rectilinear velocity
 
 projMotion :: IdeaDict
 projMotion = compoundNC projectile motion
@@ -37,27 +31,29 @@ projMotion = compoundNC projectile motion
 defs :: [ConceptChunk]
 defs = [launcher, projectile, target]
 
-launcher, projectile, target, projSpeed, projPos :: ConceptChunk
-launcher   = dcc "launcher"   (nounPhraseSP "launcher")  ("where the projectile is launched from " ++
-                                                          "and the device that does the launching")
-projectile = dcc "projectile" (nounPhraseSP "projectile") "the object to be launched at the target"
-target     = dcc "target"     (nounPhraseSP "target")     "where the projectile should be launched to"
-
-projSpeed  = dccWDS "projSpeed" (nounPhraseSP "1D speed")
+launcher, projectile, target, projSpeed, projPos, landPos, launAngle, launSpeed,
+  offset, targPos, flightDur :: ConceptChunk
+launcher   = cncpt''' (mkUid "launcher")        (nounPhraseSP "launcher")
+  (S "where the projectile is launched from and the device that does the launching")
+projectile = cncpt''' (mkUid "projectile")      (nounPhraseSP "projectile")
+  (S "the object to be launched at the target")
+target     = cncpt''' (mkUid "target")          (nounPhraseSP "target")
+  (S "where the projectile should be launched to")
+projSpeed  = cncpt''' (mkUid "projSpeed")       (nounPhraseSP "1D speed")
   (short oneD +:+ phrase speed +:+ S "under" +:+ phrase constant +:+ phrase acceleration)
-projPos    = dccWDS "projPos"   (nounPhraseSP "1D position")
+projPos    = cncpt''' (mkUid "projPos")         (nounPhraseSP "1D position")
   (short oneD +:+ phrase position +:+ S "under" +:+ phrase constant +:+ phrase speed)
-
-landPos, launAngle, launSpeed, offset, targPos, flightDur :: ConceptChunk
-landPos = cc' landingPosNC
-  (foldlSent_ [D.toSent (phraseNP (the distance)) `S.fromThe` phrase launcher `S.toThe`
-            S "final", D.toSent $ phraseNP (position `ofThe` projectile)])
-
-launAngle = cc' launchAngleNC
-  (foldlSent_ [D.toSent $ phraseNP (the angle), S "between the", phrase launcher `S.and_` S "a straight line"
-             `S.fromThe` D.toSent (phraseNP (launcher `toThe` target))])
-
-launSpeed = cc' launchSpeedNC (D.toSent (phraseNP (iSpeed `the_ofThe` projectile)) +:+ S "when launched")
-offset = cc' offsetNC (S "the offset between the" +:+ D.toSent (phraseNP (targetPosNC `andThe` landingPosNC)))
-targPos = cc' targetPosNC (D.toSent (phraseNP (the distance)) `S.fromThe` D.toSent (phraseNP (launcher `toThe` target)))
-flightDur = cc' flightDurNC (foldlSent_ [D.toSent $ phraseNP (the time), S "when the", phrase projectile, S "lands"])
+landPos    = cncpt''' (mkUid "landingposition") (compoundPhrase (nounPhraseSP "landing") (position ^. term))
+  (foldlSent_ [D.toSent (phraseNP (the distance)) `S.fromThe` phrase launcher
+    `S.toThe` S "final", D.toSent $ phraseNP (position `ofThe` projectile)])
+launAngle  = cncpt''' (mkUid "launchangle")     (compoundPhrase (launch ^. term) (angle ^. term))
+  (foldlSent_ [D.toSent $ phraseNP (the angle), S "between the", phrase launcher
+    `S.and_` S "a straight line" `S.fromThe` D.toSent (phraseNP (launcher `toThe` target))])
+launSpeed  = cncpt''' (mkUid "launchspeed")     (compoundPhrase (launch ^. term) (speed ^. term))
+  (D.toSent (phraseNP (iSpeed `the_ofThe` projectile)) +:+ S "when launched")
+offset     = cncpt''' (mkUid "offset")          (compoundPhrase (cn "distance between the") (targPos `andThe` landPos))
+  (S "the offset between the" +:+ D.toSent (phraseNP (targPos `andThe` landPos)))
+targPos    = cncpt''' (mkUid "targetposition")  (compoundPhrase (target ^. term) (position ^. term))
+  (D.toSent (phraseNP (the distance)) `S.fromThe` D.toSent (phraseNP (launcher `toThe` target)))
+flightDur  = cncpt''' (mkUid "flightduration")  (compoundPhrase (nounPhraseSP "flight") (nounPhraseSP "duration"))
+  (foldlSent_ [D.toSent $ phraseNP (the time), S "when the", phrase projectile, S "lands"])

--- a/code/drasil-example/projectile/lib/Drasil/Projectile/Unitals.hs
+++ b/code/drasil-example/projectile/lib/Drasil/Projectile/Unitals.hs
@@ -7,6 +7,7 @@ module Drasil.Projectile.Unitals (
 import Data.List.NonEmpty (NonEmpty((:|)))
 import qualified Data.List.NonEmpty as NE
 
+import Drasil.Database (mkUid)
 import Language.Drasil
 import Language.Drasil.Display (Symbol(..))
 import Language.Drasil.ShortHands (lD, lTheta, lV, lP, lT, vEpsilon)
@@ -52,4 +53,4 @@ targPos   = constrained'    (uc       C.targPos   (subStr lP "target") Real metr
 
 ---
 tol :: ConstQDef
-tol = mkQuantDef (dqdNoUnit' (dcc "tol" (nounPhraseSP "hit tolerance") "the hit tolerance") (autoStage vEpsilon) Real) (perc 2 2)
+tol = mkQuantDef (dqdNoUnit' (cncpt''' (mkUid "tol") (nounPhraseSP "hit tolerance") (S "the hit tolerance")) (autoStage vEpsilon) Real) (perc 2 2)

--- a/code/drasil-lang/lib/Language/Drasil.hs
+++ b/code/drasil-lang/lib/Language/Drasil.hs
@@ -72,7 +72,7 @@ module Language.Drasil (
 
   -- *** Basic types
   -- Language.Drasil.Chunk.NamedIdea
-  , IdeaDict, idea, idea', mkIdea
+  , IdeaDict, idea, idea'
   , nw -- bad name (historical)
   -- Language.Drasil.Chunk.CommonIdea
   , CI, commonIdeaWithDict, prependAbrv

--- a/code/drasil-lang/lib/Language/Drasil.hs
+++ b/code/drasil-lang/lib/Language/Drasil.hs
@@ -73,7 +73,6 @@ module Language.Drasil (
   -- *** Basic types
   -- Language.Drasil.Chunk.NamedIdea
   , IdeaDict, idea, idea'
-  , nw -- bad name (historical)
   -- Language.Drasil.Chunk.CommonIdea
   , CI, commonIdeaWithDict, prependAbrv
 

--- a/code/drasil-lang/lib/Language/Drasil/Chunk/Concept.hs
+++ b/code/drasil-lang/lib/Language/Drasil/Chunk/Concept.hs
@@ -16,7 +16,7 @@ import Drasil.Database (HasUID(uid), nsUid, UID, mkUid)
 import Language.Drasil.Classes (Idea, ConceptDomain(cdom), Concept)
 import Language.Drasil.Chunk.Concept.Core (ConceptChunk(ConDict), ConceptInstance(ConInst))
 import Language.Drasil.Sentence (Sentence(S))
-import Language.Drasil.Chunk.NamedIdea(mkIdea, nw, idea, idea')
+import Language.Drasil.Chunk.NamedIdea(nw, idea, idea')
 import Language.Drasil.NaturalLanguage.English.NounPhrase (NP, pn)
 import Language.Drasil.ShortName (shortname')
 import qualified Language.Drasil.Classes as D (defn)
@@ -81,10 +81,18 @@ cncpt''' u trm defn = ConDict (idea' u trm) defn []
 -- a UID (String), a term (NounPhrase), a definition (String), and an
 -- abbreviation (Maybe String).
 dccA :: String -> NP -> String -> Maybe String -> ConceptChunk
-dccA i ter des a = ConDict (mkIdea i ter a) (S des) []
+dccA i ter def a = ConDict (go a) (S def) []
+  where
+    u = mkUid i
+    go (Just accAbbr) = idea u ter accAbbr
+    go Nothing        = idea' u ter
 
 dccAWDS :: String -> NP -> Sentence -> Maybe String -> ConceptChunk
-dccAWDS i t d a = ConDict (mkIdea i t a) d []
+dccAWDS i ter def a = ConDict (go a) def []
+  where
+    u = mkUid i
+    go (Just accAbbr) = idea u ter accAbbr
+    go Nothing        = idea' u ter
 
 -- | Smart constructor for creating concept chunks given a 'UID', 'NounPhrase'
 -- ('NP') and definition (as a 'String').

--- a/code/drasil-lang/lib/Language/Drasil/Chunk/Concept.hs
+++ b/code/drasil-lang/lib/Language/Drasil/Chunk/Concept.hs
@@ -81,18 +81,16 @@ cncpt''' u trm defn = ConDict (idea' u trm) defn []
 -- a UID (String), a term (NounPhrase), a definition (String), and an
 -- abbreviation (Maybe String).
 dccA :: String -> NP -> String -> Maybe String -> ConceptChunk
-dccA i ter def a = ConDict (go a) (S def) []
+dccA i ter def a = ConDict ideaDict (S def) []
   where
     u = mkUid i
-    go (Just accAbbr) = idea u ter accAbbr
-    go Nothing        = idea' u ter
+    ideaDict = maybe (idea' u ter) (idea u ter) a
 
 dccAWDS :: String -> NP -> Sentence -> Maybe String -> ConceptChunk
-dccAWDS i ter def a = ConDict (go a) def []
+dccAWDS i ter def a = ConDict ideaDict def []
   where
     u = mkUid i
-    go (Just accAbbr) = idea u ter accAbbr
-    go Nothing        = idea' u ter
+    ideaDict = maybe (idea' u ter) (idea u ter) a
 
 -- | Smart constructor for creating concept chunks given a 'UID', 'NounPhrase'
 -- ('NP') and definition (as a 'String').

--- a/code/drasil-lang/lib/Language/Drasil/Chunk/Eq.hs
+++ b/code/drasil-lang/lib/Language/Drasil/Chunk/Eq.hs
@@ -24,8 +24,7 @@ import Language.Drasil.Classes (NamedIdea(term), Idea(getA),
   IsUnit, DefiningExpr(defnExpr), Definition(defn), Quantity,
   ConceptDomain(cdom), Express(express), Concept)
 import Language.Drasil.Chunk.DefinedQuantity (DefinedQuantityDict, DefinesQuantity(defLhs), dqd, dqd', dqdWr)
-import Language.Drasil.Chunk.Concept (cc')
-import Language.Drasil.Chunk.NamedIdea (idea')
+import Language.Drasil.Chunk.Concept (cncpt''')
 import Language.Drasil.Expr.Lang (Expr)
 import qualified Language.Drasil.Expr.Lang as E (Expr(C))
 import Language.Drasil.Expr.Class (ExprC(apply, sy, ($=)))
@@ -91,29 +90,29 @@ instance RequiresChecking (QDefinition Expr) Expr Space where
 -- 'Space', unit, and defining expression.
 fromEqn :: IsUnit u => String -> NP -> Sentence -> Symbol -> Space -> u -> e -> QDefinition e
 fromEqn nm desc def symb sp un =
-  QD (dqd (cc' (idea' (mkUid nm) desc) def) symb sp un) []
+  QD (dqd (cncpt''' (mkUid nm) desc def) symb sp un) []
 
 -- | Same as 'fromEqn', but has no units.
 fromEqn' :: String -> NP -> Sentence -> Symbol -> Space -> e -> QDefinition e
 fromEqn' nm desc def symb sp =
-  QD (dqd' (cc' (idea' (mkUid nm) desc) def) (const symb) sp Nothing) []
+  QD (dqd' (cncpt''' (mkUid nm) desc def) (const symb) sp Nothing) []
 
 -- | Same as 'fromEqn', but symbol depends on stage.
 fromEqnSt :: IsUnit u => UID -> NP -> Sentence -> (Stage -> Symbol) ->
   Space -> u -> e -> QDefinition e
 fromEqnSt nm desc def symb sp un =
-  QD (dqd' (cc' (idea' nm desc) def) symb sp (Just $ unitWrapper un)) []
+  QD (dqd' (cncpt''' nm desc def) symb sp (Just $ unitWrapper un)) []
 
 -- | Same as 'fromEqn', but symbol depends on stage and has no units.
 fromEqnSt' :: UID -> NP -> Sentence -> (Stage -> Symbol) -> Space -> e -> QDefinition e
 fromEqnSt' nm desc def symb sp =
-  QD (dqd' (cc' (idea' nm desc) def) symb sp Nothing) []
+  QD (dqd' (cncpt''' nm desc def) symb sp Nothing) []
 
 -- | Same as 'fromEqnSt'', but takes a 'String' instead of a 'UID'.
 fromEqnSt'' :: String -> NP -> Sentence -> (Stage -> Symbol) -> Space -> e ->
   QDefinition e
 fromEqnSt'' nm desc def symb sp =
-  QD (dqd' (cc' (idea' (mkUid nm) desc) def) symb sp Nothing) []
+  QD (dqd' (cncpt''' (mkUid nm) desc def) symb sp Nothing) []
 
 -- | Wrapper for fromEqnSt and fromEqnSt'
 mkQDefSt :: UID -> NP -> Sentence -> (Stage -> Symbol) -> Space ->
@@ -134,16 +133,19 @@ mkQuantDef' c t = mkQDefSt (c ^. uid) t EmptyS (symbol c) (c ^. typ) (getUnit c)
 -- | Smart constructor for QDefinitions. Requires a quantity and its defining
 -- equation.
 ec :: (Quantity c, MayHaveUnit c) => c -> e -> QDefinition e
-ec c = QD (dqd' (cc' c EmptyS) (symbol c) (c ^. typ) (getUnit c)) []
+ec c = QD
+  (dqd' (cncpt''' (c ^. uid) (c ^. term) EmptyS) (symbol c) (c ^. typ) (getUnit c))
+  []
+
+{-# DEPRECATED ec "`ec` is an unsafe chunk constructor that encourages `UID` double-use." #-}
 
 -- | Factored version of 'QDefinition' functions.
 mkFuncDef0 :: (IsChunk f, HasSymbol f, HasSpace f,
                IsChunk i, HasSymbol i, HasSpace i) =>
   f -> NP -> Sentence -> Maybe UnitDefn -> [i] -> e -> QDefinition e
 mkFuncDef0 f n s u is = QD
-  (dqd' (cc' (idea' (f ^. uid) n) s) (symbol f)
-    (f ^. typ) u) (map (^. uid) is)
-    -- (mkFunction (map (^. typ) is) (f ^. typ)) u) (map (^. uid) is)
+  (dqd' (cncpt''' (f ^. uid) n s) (symbol f) (f ^. typ) u)
+  (map (^. uid) is)
 
 -- | Create a 'QDefinition' function with a symbol, name, term, list of inputs,
 -- resultant units, and a defining Expr

--- a/code/drasil-lang/lib/Language/Drasil/Chunk/Eq.hs
+++ b/code/drasil-lang/lib/Language/Drasil/Chunk/Eq.hs
@@ -15,7 +15,7 @@ module Language.Drasil.Chunk.Eq (
 ) where
 
 import Control.Lens ((^.), view, lens, Lens', to)
-import Drasil.Database (UID, HasUID(..), HasChunkRefs(..), IsChunk)
+import Drasil.Database (UID, HasUID(..), HasChunkRefs(..), IsChunk, mkUid)
 import qualified Data.Set as Set
 
 import Language.Drasil.Chunk.UnitDefn (unitWrapper, MayHaveUnit(getUnit), UnitDefn)
@@ -25,7 +25,7 @@ import Language.Drasil.Classes (NamedIdea(term), Idea(getA),
   ConceptDomain(cdom), Express(express), Concept)
 import Language.Drasil.Chunk.DefinedQuantity (DefinedQuantityDict, DefinesQuantity(defLhs), dqd, dqd', dqdWr)
 import Language.Drasil.Chunk.Concept (cc')
-import Language.Drasil.Chunk.NamedIdea (idea', mkIdea)
+import Language.Drasil.Chunk.NamedIdea (idea')
 import Language.Drasil.Expr.Lang (Expr)
 import qualified Language.Drasil.Expr.Lang as E (Expr(C))
 import Language.Drasil.Expr.Class (ExprC(apply, sy, ($=)))
@@ -91,12 +91,12 @@ instance RequiresChecking (QDefinition Expr) Expr Space where
 -- 'Space', unit, and defining expression.
 fromEqn :: IsUnit u => String -> NP -> Sentence -> Symbol -> Space -> u -> e -> QDefinition e
 fromEqn nm desc def symb sp un =
-  QD (dqd (cc' (mkIdea nm desc Nothing) def) symb sp un) []
+  QD (dqd (cc' (idea' (mkUid nm) desc) def) symb sp un) []
 
 -- | Same as 'fromEqn', but has no units.
 fromEqn' :: String -> NP -> Sentence -> Symbol -> Space -> e -> QDefinition e
 fromEqn' nm desc def symb sp =
-  QD (dqd' (cc' (mkIdea nm desc Nothing) def) (const symb) sp Nothing) []
+  QD (dqd' (cc' (idea' (mkUid nm) desc) def) (const symb) sp Nothing) []
 
 -- | Same as 'fromEqn', but symbol depends on stage.
 fromEqnSt :: IsUnit u => UID -> NP -> Sentence -> (Stage -> Symbol) ->
@@ -113,7 +113,7 @@ fromEqnSt' nm desc def symb sp =
 fromEqnSt'' :: String -> NP -> Sentence -> (Stage -> Symbol) -> Space -> e ->
   QDefinition e
 fromEqnSt'' nm desc def symb sp =
-  QD (dqd' (cc' (mkIdea nm desc Nothing) def) symb sp Nothing) []
+  QD (dqd' (cc' (idea' (mkUid nm) desc) def) symb sp Nothing) []
 
 -- | Wrapper for fromEqnSt and fromEqnSt'
 mkQDefSt :: UID -> NP -> Sentence -> (Stage -> Symbol) -> Space ->

--- a/code/drasil-lang/lib/Language/Drasil/Chunk/NamedIdea.hs
+++ b/code/drasil-lang/lib/Language/Drasil/Chunk/NamedIdea.hs
@@ -6,13 +6,13 @@ module Language.Drasil.Chunk.NamedIdea (
   -- * Classes
   NamedIdea(..), Idea(..),
   -- * Constructors
-  idea, idea', nw, mkIdea,
+  idea, idea', nw
 ) where
 
 import Control.Lens ((^.), makeLenses, Lens')
 
-import Drasil.Database (mkUid, UID, HasUID(..), declareHasChunkRefs,
-  Generically(..), IsChunk)
+import Drasil.Database (UID, HasUID(..), declareHasChunkRefs, Generically(..),
+  IsChunk)
 import Language.Drasil.NaturalLanguage.English.NounPhrase.Core (NP)
 
 -- | A NamedIdea is a 'term' that we've identified (has a 'UID') as being worthy
@@ -67,16 +67,8 @@ idea' ::
   NP -> IdeaDict
 idea' u t = IdeaDict u t Nothing
 
-{-# DEPRECATED mkIdea
-  "Use `idea` or `idea'` instead." #-}
-
 {-# DEPRECATED nw
   "Should not be down-casting chunks; use `idea` or `idea'` instead." #-}
-
--- | 'IdeaDict' constructor, takes a 'UID', 'NP', and
--- an abbreviation in the form of 'Maybe' 'String'.
-mkIdea :: String -> NP -> Maybe String -> IdeaDict
-mkIdea s = IdeaDict (mkUid s)
 
 -- | Historical name: nw comes from 'named wrapped' from when
 -- 'NamedIdea' exported 'getA' (now in 'Idea'). But there are

--- a/code/drasil-lang/lib/Language/Drasil/Chunk/UnitDefn.hs
+++ b/code/drasil-lang/lib/Language/Drasil/Chunk/UnitDefn.hs
@@ -25,7 +25,7 @@ import Control.Arrow (second)
 
 import Drasil.Database (HasChunkRefs(..), UID, HasUID(..), mkUid)
 
-import Language.Drasil.Chunk.Concept (ConceptChunk, dcc, cc')
+import Language.Drasil.Chunk.Concept (ConceptChunk, dcc, cncpt''')
 import Language.Drasil.Classes (NamedIdea(term), Idea(getA),
   Definition(defn), ConceptDomain(cdom), HasUnitSymbol(usymb), IsUnit(udefn, getUnits))
 import Language.Drasil.NaturalLanguage.English.NounPhrase (cn,cn',NP)
@@ -125,7 +125,10 @@ unitCon s = dcc s (cn' s) s
 -- | For allowing lists to mix together chunks that are units by projecting them into a 'UnitDefn'.
 -- For now, this only works on 'UnitDefn's.
 unitWrapper :: (IsUnit u)  => u -> UnitDefn
-unitWrapper u = UD (cc' u (u ^. defn)) (Defined (usymb u) (USynonym $ usymb u)) (getUnits u)
+unitWrapper u = UD (cncpt''' (u ^. uid) (u ^. term) (u ^. defn)) (Defined (usymb u) (USynonym $ usymb u)) (getUnits u)
+
+{-# DEPRECATED unitWrapper
+  "`unitWrapper` is an unsafe chunk constructor that encourages `UID` double-use." #-}
 
 -- | Helper to get derived units if they exist.
 getSecondSymb :: UnitDefn -> Maybe USymb

--- a/code/drasil-metadata/lib/Drasil/Metadata/Domains.hs
+++ b/code/drasil-metadata/lib/Drasil/Metadata/Domains.hs
@@ -1,7 +1,8 @@
 -- | Defines domains of knowledge for use in Drasil.
 module Drasil.Metadata.Domains where
 
-import Language.Drasil (IdeaDict, mkIdea, cn')
+import Drasil.Database (mkUid)
+import Language.Drasil (IdeaDict, idea, idea', cn')
 
 -- | Various domains that are used in Drasil. May have an abbreviation.
 compScience, softEng, mathematics, progLanguage, physics, civilEng,
@@ -10,20 +11,20 @@ compScience, softEng, mathematics, progLanguage, physics, civilEng,
 --  IdeaDict     |   |      id       |       term                    |  abbreviation
 -------------------------------------------------------------------------------
 -- | For ideas, concepts, or terms related to Computer Science.
-compScience  = mkIdea  "compScience"    (cn' "Computer Science")      (Just "CS")
+compScience  = idea  (mkUid "compScience")    (cn' "Computer Science")      "CS"
 -- | For ideas, concepts, or terms related to Software Engineering.
-softEng      = mkIdea  "softEng"        (cn' "Software Engineering")  (Just "SE")
+softEng      = idea  (mkUid "softEng")        (cn' "Software Engineering")  "SE"
 -- | For ideas, concepts, or terms related to Mathematics.
-mathematics  = mkIdea  "mathematics"    (cn' "Mathematics")           Nothing
+mathematics  = idea' (mkUid "mathematics")    (cn' "Mathematics")
 -- | For ideas, concepts, or terms related to Programming Languages.
-progLanguage = mkIdea  "progLanguage"   (cn' "Programming Language")  Nothing
+progLanguage = idea' (mkUid "progLanguage")   (cn' "Programming Language")
 -- | For ideas, concepts, or terms related to Physics.
-physics      = mkIdea  "physics"        (cn' "Physics")               Nothing
+physics      = idea' (mkUid "physics")        (cn' "Physics")
 -- | For ideas, concepts, or terms related to Civil Engineering.
-civilEng     = mkIdea  "civilEng"       (cn' "Civil Engineering")     Nothing
+civilEng     = idea' (mkUid "civilEng")       (cn' "Civil Engineering")
 -- | For ideas, concepts, or terms related to Material Engineering.
-materialEng  = mkIdea  "materialEng"    (cn' "Material Engineering")  Nothing
+materialEng  = idea' (mkUid "materialEng")    (cn' "Material Engineering")
 -- | For ideas, concepts, or terms related to Documents.
-documentc    = mkIdea  "documentc"      (cn' "Document")              (Just "Doc")
+documentc    = idea  (mkUid "documentc")      (cn' "Document")              "Doc"
 -- | For ideas, concepts, or terms related to Knowledge Management.
-knowledgemng = mkIdea  "knowledgemng"   (cn' "Knowledge Management")  Nothing
+knowledgemng = idea' (mkUid "knowledgemng")   (cn' "Knowledge Management")

--- a/code/drasil-metadata/lib/Drasil/Metadata/SupportedSoftware.hs
+++ b/code/drasil-metadata/lib/Drasil/Metadata/SupportedSoftware.hs
@@ -5,8 +5,8 @@ module Drasil.Metadata.SupportedSoftware (
 ) where
 
 import Drasil.Database (mkUid)
-import Language.Drasil (IdeaDict, cn, mkIdea, idea')
+import Language.Drasil (IdeaDict, cn, idea, idea')
 
 runnableSoftware, website :: IdeaDict
-runnableSoftware = mkIdea "runnable software" (cn "runnable software") (Just "software")
+runnableSoftware = idea (mkUid "runnable software") (cn "runnable software") "software"
 website = idea' (mkUid "website") (cn "website")


### PR DESCRIPTION
Builds on #5143 

Deals with more GHC deprecation warnings introduced in #5141.

Deletes `mkIdea` along the way.