### PR TITLE
deprecation: don't export `nw` out of `drasil-lang` to avoid potential use

### DIFF
--- a/code/drasil-lang/lib/Language/Drasil.hs
+++ b/code/drasil-lang/lib/Language/Drasil.hs
@@ -73,7 +73,6 @@ module Language.Drasil (
   -- *** Basic types
   -- Language.Drasil.Chunk.NamedIdea
   , IdeaDict, idea, idea'
-  , nw -- bad name (historical)
   -- Language.Drasil.Chunk.CommonIdea
   , CI, commonIdeaWithDict, prependAbrv
 


### PR DESCRIPTION
Builds on #5145 