### PR TITLE
refactor: avoid considerable `cc'` usage

### DIFF
--- a/code/drasil-example/projectile/lib/Drasil/Projectile/Concepts.hs
+++ b/code/drasil-example/projectile/lib/Drasil/Projectile/Concepts.hs
@@ -4,6 +4,7 @@ module Drasil.Projectile.Concepts (
 ) where
 
 import Drasil.Database (mkUid)
+import Control.Lens ((^.))
 import Language.Drasil
 import Language.Drasil.Chunk.Concept.NamedCombinators
 import qualified Language.Drasil.Development as D
@@ -15,20 +16,13 @@ import Data.Drasil.Concepts.Physics (oneD, position, speed, motion, distance, iS
   rectilinear, velocity, acceleration)
 
 ideaDicts :: [IdeaDict]
-ideaDicts = [projMotion, launchNC, rectVel]
+ideaDicts = [projMotion, launch, rectVel]
 
-durationNC, flightDurNC, landingPosNC, launchNC, launchAngleNC, launchSpeedNC, offsetNC, targetPosNC,
-  rectVel :: IdeaDict
-durationNC   = idea' (mkUid "duration") (nounPhraseSP "duration")
-launchNC     = idea' (mkUid "launch")   (nounPhraseSP "launch")
-offsetNC     = idea' (mkUid "offset")   (compoundPhrase (cn "distance between the") (targetPosNC `andThe` landingPosNC))
+launch :: IdeaDict
+launch = idea' (mkUid "launch") (nounPhraseSP "launch")
 
-flightDurNC   = compoundNC (idea' (mkUid "flight")  (nounPhraseSP "flight" )) durationNC
-landingPosNC  = compoundNC (idea' (mkUid "landing") (nounPhraseSP "landing")) position
-launchAngleNC = compoundNC launchNC angle
-launchSpeedNC = compoundNC launchNC speed
-targetPosNC   = compoundNC target position
-rectVel       = compoundNC rectilinear velocity
+rectVel :: IdeaDict
+rectVel = compoundNC rectilinear velocity
 
 projMotion :: IdeaDict
 projMotion = compoundNC projectile motion
@@ -37,27 +31,29 @@ projMotion = compoundNC projectile motion
 defs :: [ConceptChunk]
 defs = [launcher, projectile, target]
 
-launcher, projectile, target, projSpeed, projPos :: ConceptChunk
-launcher   = dcc "launcher"   (nounPhraseSP "launcher")  ("where the projectile is launched from " ++
-                                                          "and the device that does the launching")
-projectile = dcc "projectile" (nounPhraseSP "projectile") "the object to be launched at the target"
-target     = dcc "target"     (nounPhraseSP "target")     "where the projectile should be launched to"
-
-projSpeed  = dccWDS "projSpeed" (nounPhraseSP "1D speed")
+launcher, projectile, target, projSpeed, projPos, landPos, launAngle, launSpeed,
+  offset, targPos, flightDur :: ConceptChunk
+launcher   = cncpt''' (mkUid "launcher")        (nounPhraseSP "launcher")
+  (S "where the projectile is launched from and the device that does the launching")
+projectile = cncpt''' (mkUid "projectile")      (nounPhraseSP "projectile")
+  (S "the object to be launched at the target")
+target     = cncpt''' (mkUid "target")          (nounPhraseSP "target")
+  (S "where the projectile should be launched to")
+projSpeed  = cncpt''' (mkUid "projSpeed")       (nounPhraseSP "1D speed")
   (short oneD +:+ phrase speed +:+ S "under" +:+ phrase constant +:+ phrase acceleration)
-projPos    = dccWDS "projPos"   (nounPhraseSP "1D position")
+projPos    = cncpt''' (mkUid "projPos")         (nounPhraseSP "1D position")
   (short oneD +:+ phrase position +:+ S "under" +:+ phrase constant +:+ phrase speed)
-
-landPos, launAngle, launSpeed, offset, targPos, flightDur :: ConceptChunk
-landPos = cc' landingPosNC
-  (foldlSent_ [D.toSent (phraseNP (the distance)) `S.fromThe` phrase launcher `S.toThe`
-            S "final", D.toSent $ phraseNP (position `ofThe` projectile)])
-
-launAngle = cc' launchAngleNC
-  (foldlSent_ [D.toSent $ phraseNP (the angle), S "between the", phrase launcher `S.and_` S "a straight line"
-             `S.fromThe` D.toSent (phraseNP (launcher `toThe` target))])
-
-launSpeed = cc' launchSpeedNC (D.toSent (phraseNP (iSpeed `the_ofThe` projectile)) +:+ S "when launched")
-offset = cc' offsetNC (S "the offset between the" +:+ D.toSent (phraseNP (targetPosNC `andThe` landingPosNC)))
-targPos = cc' targetPosNC (D.toSent (phraseNP (the distance)) `S.fromThe` D.toSent (phraseNP (launcher `toThe` target)))
-flightDur = cc' flightDurNC (foldlSent_ [D.toSent $ phraseNP (the time), S "when the", phrase projectile, S "lands"])
+landPos    = cncpt''' (mkUid "landingposition") (compoundPhrase (nounPhraseSP "landing") (position ^. term))
+  (foldlSent_ [D.toSent (phraseNP (the distance)) `S.fromThe` phrase launcher
+    `S.toThe` S "final", D.toSent $ phraseNP (position `ofThe` projectile)])
+launAngle  = cncpt''' (mkUid "launchangle")     (compoundPhrase (launch ^. term) (angle ^. term))
+  (foldlSent_ [D.toSent $ phraseNP (the angle), S "between the", phrase launcher
+    `S.and_` S "a straight line" `S.fromThe` D.toSent (phraseNP (launcher `toThe` target))])
+launSpeed  = cncpt''' (mkUid "launchspeed")     (compoundPhrase (launch ^. term) (speed ^. term))
+  (D.toSent (phraseNP (iSpeed `the_ofThe` projectile)) +:+ S "when launched")
+offset     = cncpt''' (mkUid "offset")          (compoundPhrase (cn "distance between the") (targPos `andThe` landPos))
+  (S "the offset between the" +:+ D.toSent (phraseNP (targPos `andThe` landPos)))
+targPos    = cncpt''' (mkUid "targetposition")  (compoundPhrase (target ^. term) (position ^. term))
+  (D.toSent (phraseNP (the distance)) `S.fromThe` D.toSent (phraseNP (launcher `toThe` target)))
+flightDur  = cncpt''' (mkUid "flightduration")  (compoundPhrase (nounPhraseSP "flight") (nounPhraseSP "duration"))
+  (foldlSent_ [D.toSent $ phraseNP (the time), S "when the", phrase projectile, S "lands"])

--- a/code/drasil-example/projectile/lib/Drasil/Projectile/Unitals.hs
+++ b/code/drasil-example/projectile/lib/Drasil/Projectile/Unitals.hs
@@ -7,6 +7,7 @@ module Drasil.Projectile.Unitals (
 import Data.List.NonEmpty (NonEmpty((:|)))
 import qualified Data.List.NonEmpty as NE
 
+import Drasil.Database (mkUid)
 import Language.Drasil
 import Language.Drasil.Display (Symbol(..))
 import Language.Drasil.ShortHands (lD, lTheta, lV, lP, lT, vEpsilon)
@@ -52,4 +53,4 @@ targPos   = constrained'    (uc       C.targPos   (subStr lP "target") Real metr
 
 ---
 tol :: ConstQDef
-tol = mkQuantDef (dqdNoUnit' (dcc "tol" (nounPhraseSP "hit tolerance") "the hit tolerance") (autoStage vEpsilon) Real) (perc 2 2)
+tol = mkQuantDef (dqdNoUnit' (cncpt''' (mkUid "tol") (nounPhraseSP "hit tolerance") (S "the hit tolerance")) (autoStage vEpsilon) Real) (perc 2 2)

--- a/code/drasil-lang/lib/Language/Drasil/Chunk/Eq.hs
+++ b/code/drasil-lang/lib/Language/Drasil/Chunk/Eq.hs
@@ -24,8 +24,7 @@ import Language.Drasil.Classes (NamedIdea(term), Idea(getA),
   IsUnit, DefiningExpr(defnExpr), Definition(defn), Quantity,
   ConceptDomain(cdom), Express(express), Concept)
 import Language.Drasil.Chunk.DefinedQuantity (DefinedQuantityDict, DefinesQuantity(defLhs), dqd, dqd', dqdWr)
-import Language.Drasil.Chunk.Concept (cc')
-import Language.Drasil.Chunk.NamedIdea (idea')
+import Language.Drasil.Chunk.Concept (cncpt''')
 import Language.Drasil.Expr.Lang (Expr)
 import qualified Language.Drasil.Expr.Lang as E (Expr(C))
 import Language.Drasil.Expr.Class (ExprC(apply, sy, ($=)))
@@ -91,29 +90,29 @@ instance RequiresChecking (QDefinition Expr) Expr Space where
 -- 'Space', unit, and defining expression.
 fromEqn :: IsUnit u => String -> NP -> Sentence -> Symbol -> Space -> u -> e -> QDefinition e
 fromEqn nm desc def symb sp un =
-  QD (dqd (cc' (idea' (mkUid nm) desc) def) symb sp un) []
+  QD (dqd (cncpt''' (mkUid nm) desc def) symb sp un) []
 
 -- | Same as 'fromEqn', but has no units.
 fromEqn' :: String -> NP -> Sentence -> Symbol -> Space -> e -> QDefinition e
 fromEqn' nm desc def symb sp =
-  QD (dqd' (cc' (idea' (mkUid nm) desc) def) (const symb) sp Nothing) []
+  QD (dqd' (cncpt''' (mkUid nm) desc def) (const symb) sp Nothing) []
 
 -- | Same as 'fromEqn', but symbol depends on stage.
 fromEqnSt :: IsUnit u => UID -> NP -> Sentence -> (Stage -> Symbol) ->
   Space -> u -> e -> QDefinition e
 fromEqnSt nm desc def symb sp un =
-  QD (dqd' (cc' (idea' nm desc) def) symb sp (Just $ unitWrapper un)) []
+  QD (dqd' (cncpt''' nm desc def) symb sp (Just $ unitWrapper un)) []
 
 -- | Same as 'fromEqn', but symbol depends on stage and has no units.
 fromEqnSt' :: UID -> NP -> Sentence -> (Stage -> Symbol) -> Space -> e -> QDefinition e
 fromEqnSt' nm desc def symb sp =
-  QD (dqd' (cc' (idea' nm desc) def) symb sp Nothing) []
+  QD (dqd' (cncpt''' nm desc def) symb sp Nothing) []
 
 -- | Same as 'fromEqnSt'', but takes a 'String' instead of a 'UID'.
 fromEqnSt'' :: String -> NP -> Sentence -> (Stage -> Symbol) -> Space -> e ->
   QDefinition e
 fromEqnSt'' nm desc def symb sp =
-  QD (dqd' (cc' (idea' (mkUid nm) desc) def) symb sp Nothing) []
+  QD (dqd' (cncpt''' (mkUid nm) desc def) symb sp Nothing) []
 
 -- | Wrapper for fromEqnSt and fromEqnSt'
 mkQDefSt :: UID -> NP -> Sentence -> (Stage -> Symbol) -> Space ->
@@ -134,16 +133,19 @@ mkQuantDef' c t = mkQDefSt (c ^. uid) t EmptyS (symbol c) (c ^. typ) (getUnit c)
 -- | Smart constructor for QDefinitions. Requires a quantity and its defining
 -- equation.
 ec :: (Quantity c, MayHaveUnit c) => c -> e -> QDefinition e
-ec c = QD (dqd' (cc' c EmptyS) (symbol c) (c ^. typ) (getUnit c)) []
+ec c = QD
+  (dqd' (cncpt''' (c ^. uid) (c ^. term) EmptyS) (symbol c) (c ^. typ) (getUnit c))
+  []
+
+{-# DEPRECATED ec "`ec` is an unsafe chunk constructor that encourages `UID` double-use." #-}
 
 -- | Factored version of 'QDefinition' functions.
 mkFuncDef0 :: (IsChunk f, HasSymbol f, HasSpace f,
                IsChunk i, HasSymbol i, HasSpace i) =>
   f -> NP -> Sentence -> Maybe UnitDefn -> [i] -> e -> QDefinition e
 mkFuncDef0 f n s u is = QD
-  (dqd' (cc' (idea' (f ^. uid) n) s) (symbol f)
-    (f ^. typ) u) (map (^. uid) is)
-    -- (mkFunction (map (^. typ) is) (f ^. typ)) u) (map (^. uid) is)
+  (dqd' (cncpt''' (f ^. uid) n s) (symbol f) (f ^. typ) u)
+  (map (^. uid) is)
 
 -- | Create a 'QDefinition' function with a symbol, name, term, list of inputs,
 -- resultant units, and a defining Expr

--- a/code/drasil-lang/lib/Language/Drasil/Chunk/UnitDefn.hs
+++ b/code/drasil-lang/lib/Language/Drasil/Chunk/UnitDefn.hs
@@ -25,7 +25,7 @@ import Control.Arrow (second)
 
 import Drasil.Database (HasChunkRefs(..), UID, HasUID(..), mkUid)
 
-import Language.Drasil.Chunk.Concept (ConceptChunk, dcc, cc')
+import Language.Drasil.Chunk.Concept (ConceptChunk, dcc, cncpt''')
 import Language.Drasil.Classes (NamedIdea(term), Idea(getA),
   Definition(defn), ConceptDomain(cdom), HasUnitSymbol(usymb), IsUnit(udefn, getUnits))
 import Language.Drasil.NaturalLanguage.English.NounPhrase (cn,cn',NP)
@@ -125,7 +125,10 @@ unitCon s = dcc s (cn' s) s
 -- | For allowing lists to mix together chunks that are units by projecting them into a 'UnitDefn'.
 -- For now, this only works on 'UnitDefn's.
 unitWrapper :: (IsUnit u)  => u -> UnitDefn
-unitWrapper u = UD (cc' u (u ^. defn)) (Defined (usymb u) (USynonym $ usymb u)) (getUnits u)
+unitWrapper u = UD (cncpt''' (u ^. uid) (u ^. term) (u ^. defn)) (Defined (usymb u) (USynonym $ usymb u)) (getUnits u)
+
+{-# DEPRECATED unitWrapper
+  "`unitWrapper` is an unsafe chunk constructor that encourages `UID` double-use." #-}
 
 -- | Helper to get derived units if they exist.
 getSecondSymb :: UnitDefn -> Maybe USymb


### PR DESCRIPTION
Builds on #5146 

`cc'` is one of the deprecated `ConceptChunk` constructors.
