### PR TITLE
deprecation: delete `TempHasUnit`

### DIFF
--- a/code/drasil-lang/lib/Language/Drasil/Chunk/UnitDefn.hs
+++ b/code/drasil-lang/lib/Language/Drasil/Chunk/UnitDefn.hs
@@ -4,7 +4,6 @@ module Language.Drasil.Chunk.UnitDefn (
   -- * Classes
   MayHaveUnit(getUnit),
   IsUnit(getUnits),
-  TempHasUnit(findUnit),
   -- * Chunk Type
   UnitDefn(..),
   -- * Constructors
@@ -71,10 +70,6 @@ instance IsUnit        UnitDefn where
 -- | Types may contain a unit ('UnitDefn').
 class MayHaveUnit u where
    getUnit :: u -> Maybe UnitDefn
-
--- | Temporary class to make sure chunks have a unit (in order to eventually get rid of 'MayHaveUnit').
-class TempHasUnit u where
-   findUnit :: u -> UnitDefn
 
 -- | Takes a contributing unit (['UID']) and a symbol ('USymb').
 data UnitEquation = UE {_contributingUnit :: [UID]

--- a/code/drasil-lang/lib/Language/Drasil/Chunk/Unital.hs
+++ b/code/drasil-lang/lib/Language/Drasil/Chunk/Unital.hs
@@ -16,7 +16,7 @@ import Language.Drasil.Chunk.DefinedQuantity (DefinedQuantityDict, dqd, dqd')
 import Language.Drasil.Symbol (Symbol, HasSymbol(..))
 import Language.Drasil.Classes (NamedIdea(term), Idea(getA), Express(express),
   Definition(defn), ConceptDomain(cdom), Concept, IsUnit, Quantity)
-import Language.Drasil.Chunk.UnitDefn (MayHaveUnit(getUnit), TempHasUnit(findUnit),  UnitDefn, unitWrapper)
+import Language.Drasil.Chunk.UnitDefn (MayHaveUnit(getUnit), UnitDefn, unitWrapper)
 import Language.Drasil.Expr.Class (sy)
 import Language.Drasil.NaturalLanguage.English.NounPhrase.Core (NP)
 import Language.Drasil.Space (Space(..), HasSpace(..))
@@ -58,8 +58,6 @@ instance HasSymbol     UnitalChunk where symbol c = symbol (c^.defq')
 instance Quantity      UnitalChunk where
 -- | Finds the units used to make the 'UnitalChunk'.
 instance MayHaveUnit   UnitalChunk where getUnit = Just . view uni
--- | Finds the units used to make the 'UnitalChunk'.
-instance TempHasUnit       UnitalChunk where findUnit = view uni
 -- | Equal if 'UID's are equal.
 instance Eq            UnitalChunk where c1 == c2 = (c1 ^. uid) == (c2 ^. uid)
 -- | Convert the symbol of the 'UnitalChunk' to a 'ModelExpr'.


### PR DESCRIPTION
Since this code has been written, we've changed our opinion on `Maybe` and are less apprehensive. This code is (a) unused and (b) outdated.

We can safely remove it.