### PR TITLE
Add bss to packages excluded from package graph

### DIFF
--- a/code/Makefile
+++ b/code/Makefile
@@ -294,7 +294,7 @@ packagedeps: graphmod check_dot
 	@echo ----------------------------
 	@echo Generating package dependency graph
 	@echo ----------------------------
-	@stack dot --prune dblpend,gamephysics,glassbr,hghc,swhsnopcm,pdcontroller,sglpend,ssp,swhs,template | tred | dot -Tpng > "$(GRAPH_FOLDER)drasil-all-pkgs-deps".png
+	@stack dot --prune bss,dblpend,gamephysics,glassbr,hghc,swhsnopcm,pdcontroller,sglpend,ssp,swhs,template | tred | dot -Tpng > "$(GRAPH_FOLDER)drasil-all-pkgs-deps".png
 
 # First build all the Drasil packages, run all examples (no traceability graphs),
 # and then build the generated mdBook projects.


### PR DESCRIPTION
This fixes bss showing up in the package graph on the website.

This could be automatically generated from the EXAMPLES variable (minus projectile), but doing this is [surprisingly annoying](https://www.gnu.org/software/make/manual/html_node/Syntax-of-Functions.html) (see the example at the bottom) to do.