### PR TITLE
refactor: remove redundant `ccss'` code, clarify documentation

### DIFF
--- a/code/drasil-srs/lib/Drasil/SRS/DocumentLanguage.hs
+++ b/code/drasil-srs/lib/Drasil/SRS/DocumentLanguage.hs
@@ -28,7 +28,7 @@ import Drasil.Database.SearchTools (findAllConcInsts,
   TermAbbr, shortForm, termResolve')
 
 import Drasil.System (SmithEtAlSRS, HasSmithEtAlSRS(..), HasSystemMeta(..))
-import Drasil.SRS.GetChunks (ccss, ccss')
+import Drasil.SRS.GetChunks (resolveAllVars)
 
 -- Vocabulary
 import Drasil.Metadata.Documentation (likelyChg, section_, software, srs,
@@ -172,7 +172,7 @@ findAllRefs (Section _ cs r) = r : concatMap findRefSecCons cs
 
 -- | Constructs the unit definitions ('UnitDefn's) found in the document description ('DocDesc') from a database ('ChunkDB').
 extractUnits :: DocDesc -> ChunkDB -> [UnitDefn]
-extractUnits dd cdb = collectUnitDeps cdb $ ccss' (getDocDesc dd) (egetDocDesc dd) cdb
+extractUnits dd cdb = collectUnitDeps cdb $ resolveAllVars (getDocDesc dd) (egetDocDesc dd) cdb
 
 -- | For a given list of 'Quantity's, collects the 'UnitDefn's dependencies of
 -- their units (i.e., what units their units are defined with).
@@ -245,10 +245,10 @@ mkRefSec si dd (RefProg c l) renderedSecs = SRS.refMat [c] (map mkSubRef l)
       [tsIntro con,
                 LlC $ table Equational (sortBySymbol
                 $ filter (`hasStageSymbol` Equational)
-                (nub $ ccss' (getDocDesc dd) (egetDocDesc dd) db))
+                (nub $ resolveAllVars (getDocDesc dd) (egetDocDesc dd) db))
                 atStart] []
     mkSubRef (TSymb' f con) =
-      mkTSymb (ccss (getDocDesc dd) (egetDocDesc dd) db) f con
+      mkTSymb (resolveAllVars (getDocDesc dd) (egetDocDesc dd) db) f con
 
     mkSubRef TAandA =
       SRS.tOfAbbAcc

--- a/code/drasil-srs/lib/Drasil/SRS/GetChunks.hs
+++ b/code/drasil-srs/lib/Drasil/SRS/GetChunks.hs
@@ -1,7 +1,7 @@
 -- | Utilities to get grab certain chunks (from 'Expr', 'Sentence', etc) by
 -- 'UID' and dereference the chunk it refers to.
 module Drasil.SRS.GetChunks (
-  ccss, ccss', vars
+  resolveAllVars, vars
 ) where
 
 import qualified Data.Set as Set
@@ -11,18 +11,15 @@ import Language.Drasil.Development (sdep)
 import Language.Drasil.ModelExpr.Development (meDep)
 import Drasil.Database (ChunkDB, findOrErr)
 
--- | Gets a list of quantities ('DefinedQuantityDict') from an equation in order to print.
+-- | Extract and resolve all referenced 'DefinedQuantityDict's in a 'ModelExpr'.
 vars :: ModelExpr -> ChunkDB -> [DefinedQuantityDict]
 vars e m = map (`findOrErr` m) $ meDep e
 
--- | Gets a list of quantities ('DefinedQuantityDict') from a 'Sentence' in order to print.
+-- | Extract and resolve all referenced 'DefinedQuantityDict's in a 'Sentence'.
 vars' :: Sentence -> ChunkDB -> [DefinedQuantityDict]
 vars' a m = map (`findOrErr` m) $ Set.toList (sdep a)
 
--- | Gets a list of defined quantities ('DefinedQuantityDict's) from 'Sentence's and expressions that are contained in the database ('ChunkDB').
-ccss :: [Sentence] -> [ModelExpr] -> ChunkDB -> [DefinedQuantityDict]
-ccss s e c = concatMap (`vars'` c) s ++ concatMap (`vars` c) e
-
--- | Gets a list of quantities ('DefinedQuantityDict's) from 'Sentence's and expressions that are contained in the database ('ChunkDB').
-ccss' :: [Sentence] -> [ModelExpr] -> ChunkDB -> [DefinedQuantityDict]
-ccss' s e c = concatMap (`vars'` c) s ++ concatMap (`vars` c) e
+-- | Extract and resolve all references to 'DefinedQuantityDict's in a list of
+-- 'Sentence's and a list of 'ModelExpr's.
+resolveAllVars :: [Sentence] -> [ModelExpr] -> ChunkDB -> [DefinedQuantityDict]
+resolveAllVars s e c = concatMap (`vars'` c) s ++ concatMap (`vars` c) e


### PR DESCRIPTION
This is a follow-up to b8a2505ffb2914b57935e160cd80ab910b69ae88.