### PR TITLE
refactor: remove redundant `map dqdWr`

### DIFF
--- a/code/drasil-example/swhs/lib/Drasil/SWHS/Unitals.hs
+++ b/code/drasil-example/swhs/lib/Drasil/SWHS/Unitals.hs
@@ -26,7 +26,7 @@ import Data.List.NonEmpty (NonEmpty((:|)))
 import qualified Data.List.NonEmpty as NE
 
 symbols :: [DefinedQuantityDict]
-symbols = pi_ : map dqdWr units ++ map dqdWr unitless ++ map dqdWr constrained
+symbols = pi_ : map dqdWr units ++ unitless ++ map dqdWr constrained
  ++ map dqdWr unitalChuncks ++ map dqdWr specParamValList ++
    map dqdWr [htFusionMin, htFusionMax, coilSAMax] ++
    map dqdWr [absTol, relTol]


### PR DESCRIPTION
A result of analysis done for #5154.

`unitless` was already of type `[DefinedQuantityDict]`.