### PR TITLE
Build test deps during `make deps`.

### DIFF
--- a/code/Makefile
+++ b/code/Makefile
@@ -234,7 +234,7 @@ graphmod: check_stack ##@Checks Check that we can generate dot graphs.
 #----------------------------------------------------------#
 
 deps: check_stack ##@Dependencies Build only dependencies.
-	- stack build $(stackArgs) --only-dependencies
+	- stack build $(stackBuildArgs) --only-dependencies
 
 #-------------------------------------------------#
 #--- Targets that affect all packages/examples ---#


### PR DESCRIPTION
If we don't include `--test`, then the testing deps are not built.