### PR TITLE
Remove unneeded hedgehog dependency

### DIFF
--- a/code/drasil-assets/package.yaml
+++ b/code/drasil-assets/package.yaml
@@ -43,8 +43,6 @@ tests:
     - drasil-assets
     - drasil-file-handling
     - drasil-testing-kit
-    - hedgehog
     - tasty
-    - tasty-hedgehog
     - tasty-hunit
     - prettyprinter

--- a/code/drasil-file-handling/package.yaml
+++ b/code/drasil-file-handling/package.yaml
@@ -47,7 +47,5 @@ tests:
     main: Main.hs
     dependencies:
     - drasil-testing-kit
-    - hedgehog
     - tasty
-    - tasty-hedgehog
     - tasty-hunit


### PR DESCRIPTION
We don't currently use it for any tests.