### PR TITLE
Move `dcc` usage to `cncpt'''`

### DIFF
--- a/code/drasil-code/lib/Language/Drasil/CodeSpec.hs
+++ b/code/drasil-code/lib/Language/Drasil/CodeSpec.hs
@@ -25,7 +25,7 @@ import qualified Data.List.NonEmpty as NE
 import Drasil.FileHandling.Legacy (RelativeFile)
 import Language.Drasil hiding (None)
 import Language.Drasil.Display (Symbol(Variable))
-import Drasil.Database (ChunkDB, UID, HasUID(..), insertAll)
+import Drasil.Database (ChunkDB, UID, HasUID(..), insertAll, mkUid)
 import Drasil.Code.CodeExpr.Development (expr, eNamesRI, eDep)
 import qualified Drasil.System as S
 import Drasil.System (HasSmithEtAlSRS(..), HasSystemMeta(..), programName)
@@ -192,9 +192,9 @@ oldcodeSpec sys@S.ICO{ S._inputs = ins
 -- | Convert a 'Func' to an implementation-stage 'DefinedQuantityDict' representing the
 -- function.
 asVC :: Func -> DefinedQuantityDict
-asVC (FDef (FuncDef n d _ _ _ _)) = dqdNoUnit (dcc n (nounPhraseSP n) d) (Variable n) Real
-asVC (FDef (CtorDef n d _ _ _))   = dqdNoUnit (dcc n (nounPhraseSP n) d) (Variable n) Real
-asVC (FData (FuncData n d _))     = dqdNoUnit (dcc n (nounPhraseSP n) d) (Variable n) Real
+asVC (FDef (FuncDef n d _ _ _ _)) = dqdNoUnit (cncpt''' (mkUid n) (nounPhraseSP n) (S d)) (Variable n) Real
+asVC (FDef (CtorDef n d _ _ _))   = dqdNoUnit (cncpt''' (mkUid n) (nounPhraseSP n) (S d)) (Variable n) Real
+asVC (FData (FuncData n d _))     = dqdNoUnit (cncpt''' (mkUid n) (nounPhraseSP n) (S d)) (Variable n) Real
 
 -- | Get a 'UID' of a chunk corresponding to a 'Func'.
 funcUID :: Func -> UID

--- a/code/drasil-data/lib/Data/Drasil/Concepts/Computation.hs
+++ b/code/drasil-data/lib/Data/Drasil/Concepts/Computation.hs
@@ -5,8 +5,8 @@ module Data.Drasil.Concepts.Computation
   ) where
 
 import Drasil.Database (mkUid)
-import Language.Drasil (dcc, cn', commonIdeaWithDict, Sentence,
-  ConceptChunk, CI, IdeaDict, dccWDS, idea')
+import Language.Drasil (cn', commonIdeaWithDict, Sentence(..),
+  ConceptChunk, CI, IdeaDict, dccWDS, idea', cncpt''')
 import Language.Drasil.Chunk.Concept.NamedCombinators
 
 import Data.Drasil.Concepts.Documentation (datum, input_, literacy, output_,
@@ -16,8 +16,10 @@ import Drasil.Metadata.Concepts.Computation (algorithm)
 import Drasil.Metadata.Domains (compScience)
 
 absTolerance, relTolerance:: ConceptChunk
-absTolerance = dcc "absTolerance"   (cn' "Absolute tolerance") "a fixed number that is used to make direct comparisons"
-relTolerance = dcc "relTolerance"   (cn' "Relative tolerance") " maximum amount of error that the user is willing to allow in the solution"
+absTolerance = cncpt''' (mkUid "absTolerance") (cn' "Absolute tolerance")
+  (S "a fixed number that is used to make direct comparisons")
+relTolerance = cncpt''' (mkUid "relTolerance") (cn' "Relative tolerance")
+  (S " maximum amount of error that the user is willing to allow in the solution")
 
 modCalcDesc :: Sentence -> ConceptChunk
 modCalcDesc = dccWDS "modCalcDesc" (cn' "calculation")

--- a/code/drasil-data/lib/Data/Drasil/Concepts/Math.hs
+++ b/code/drasil-data/lib/Data/Drasil/Concepts/Math.hs
@@ -11,7 +11,6 @@ import qualified Language.Drasil as D
 import Language.Drasil.Chunk.Concept.NamedCombinators
 import Language.Drasil.Development (NPStruct(P, S, (:-:)))
 import Language.Drasil.ShortHands (lX, lY, lZ)
-import Drasil.Database (mkUid)
 
 -- Othr Vocabulary
 import Drasil.Metadata.Domains (mathematics)

--- a/code/drasil-data/lib/Data/Drasil/Concepts/Math.hs
+++ b/code/drasil-data/lib/Data/Drasil/Concepts/Math.hs
@@ -10,6 +10,7 @@ import qualified Language.Drasil as D
 import Language.Drasil.Chunk.Concept.NamedCombinators
 import Language.Drasil.Development (NPStruct(P, S, (:-:)))
 import Language.Drasil.ShortHands (lX, lY, lZ)
+import Drasil.Database (mkUid)
 
 -- Othr Vocabulary
 import Drasil.Metadata.Domains (mathematics)
@@ -37,69 +38,68 @@ amplitude, angle, area, axis, calculation, cartesian, centre, change, component,
   rOfChng, rate, rightHand, shape, surArea, surface, unitV, vector, xAxis, xCoord, xComp, xDir,
   yAxis, yCoord,  yComp, yDir, zAxis, zCoord, zComp, zDir, iAngle :: ConceptChunk
 
-amplitude   = dcc "amplitude"    (nounPhraseSP "amplitude")      "The peak deviation of a function from zero"
-angle       = dcc "angle"        (cn' "angle")                   "the amount of rotation needed to bring one line or plane into coincidence with another"
-area        = dcc "area"         (cn' "area")                    "a part of an object or surface"
-axis        = dcc "axis"         (cn' "axis")                    "a fixed reference line for the measurement of coordinates"
-calculation = dcc "calculation"  (cn' "calculation")             "a mathematical determination of the size or number of something"
+amplitude   = cncpt''' (mkUid "amplitude")   (nounPhraseSP "amplitude")  (D.S "The peak deviation of a function from zero")
+angle       = cncpt''' (mkUid "angle")       (cn' "angle")               (D.S "the amount of rotation needed to bring one line or plane into coincidence with another")
+area        = cncpt''' (mkUid "area")        (cn' "area")                (D.S "a part of an object or surface")
+axis        = cncpt''' (mkUid "axis")        (cn' "axis")                (D.S "a fixed reference line for the measurement of coordinates")
+calculation = cncpt''' (mkUid "calculation") (cn' "calculation")         (D.S "a mathematical determination of the size or number of something")
 cartesian   = dccWDS "cartesian" (pn' "Cartesian coordinate system") $ D.S "a coordinate system that specifies each point uniquely in a plane by a set" `S.of_`
                                                                   D.S "numerical coordinates, which are the signed distances to the point from" +:+
                                                                   D.S "two fixed perpendicular oriented lines, measured in the same unit of length" +:+
                                                                   fromSource cartesianWiki
-centre       = dcc "centre"       (cn' "centre")                  "the middle point of an object"
-change       = dcc "change"       (cn' "change")                  "Difference between relative start and end states of an object"
-component    = dcc "mathComponent"    (nounPhrase "component" "components") ("The scalar quantity defining the contribution " ++
-                                                                  "of a vector in one of the coordinate directions")
-constraint   = dcc "mathConstraint" (cn' "constraint")              "A condition that the solution must satisfy"
-diameter     = dcc "diameter"     (cn' "diameter")                ("Any straight line segment that passes through the center of the circle" ++
-                                                                  "and whose endpoints lie on the circle.")
-direction    = dcc "direction"    (cn' "direction")               "'which way' a vector points, extending from the tail to the tip"
-euclidSpace  = dcc "euclidSpace"  (cn' "Euclidean")               ("Denoting the system of geometry corresponding to the geometry of ordinary" ++
-                                                                  "experience")
-gradient     = dcc "gradient"     (cn' "gradient")                "degree of steepness of a graph at any point"
-laplaceTransform = dcc "laplaceTransform" (cn' "laplace transform") ("An integral transform that converts a function of a real variable t " ++
-                                                                     "(often time) to a function of a complex variable s (complex frequency)")
-law          = dcc "law"          (cn' "law")                     "a generalization based on a fact or event perceived to be recurrent"
-line         = dccWDS "line"      (pn' "line")                    $ D.S "An interval between two points" +:+
-                                                                  fromSource lineSource
-matrix       = dcc "matrix"       (cnICES "matrix")               ("A rectangular array of quantities or expressions in rows and columns that" ++
-                                                                 "is treated as a single entity and manipulated according to particular rules")
-norm        = dcc "norm"         (cn' "norm")                    "the positive length or size of a vector"
-normal      = dcc "normal"       (cn' "normal" )                 "an object that is perpendicular to a given object"
-number      = dcc "number"       (cn' "number")                  "a mathematical object used to count, measure, and label"
-orient      = dcc "orientation"  (cn' "orientation")             "the relative physical position or direction of something"
-origin      = dcc "origin"       (cn' "origin")                  "a fixed point of reference for the geometry of the surrounding space"
-perp         = dcc "perp"         (cn' "perpendicular")          "At right angles"
-pi_          = dcc "pi"           (cn' "ratio of circumference to diameter for any circle") "The ratio of a circle's circumference to its diameter"
-posInf       = dcc "PosInf"       (cn' "Positive Infinity")      "the limit of a sequence or function that eventually exceeds any prescribed bound"
-negInf       = dcc "NegInf"       (cn' "Negative Infinity")      "Opposite of positive infinity"
-positive     = dcc "positive"     (cn' "positive")               "greater than zero"
-negative     = dcc "negative"     (cn' "negative")               "less than zero"
+centre       = cncpt''' (mkUid "centre")        (cn' "centre")           (D.S "the middle point of an object")
+change       = cncpt''' (mkUid "change")        (cn' "change")           (D.S "Difference between relative start and end states of an object")
+component    = cncpt''' (mkUid "mathComponent") (nounPhrase "component" "components") (D.S ("The scalar quantity defining the contribution " ++
+                                                                        "of a vector in one of the coordinate directions"))
+constraint   = cncpt''' (mkUid "mathConstraint") (cn' "constraint")      (D.S "A condition that the solution must satisfy")
+diameter     = cncpt''' (mkUid "diameter")       (cn' "diameter")        (D.S ("Any straight line segment that passes through the center of the circle" ++
+                                                                         "and whose endpoints lie on the circle."))
+direction    = cncpt''' (mkUid "direction")      (cn' "direction")       (D.S "'which way' a vector points, extending from the tail to the tip")
+euclidSpace  = cncpt''' (mkUid "euclidSpace")    (cn' "Euclidean")       (D.S ("Denoting the system of geometry corresponding to the geometry of ordinary" ++
+                                                                         "experience"))
+gradient     = cncpt'''  (mkUid "gradient")      (cn' "gradient")        (D.S "degree of steepness of a graph at any point")
+laplaceTransform = cncpt''' (mkUid "laplaceTransform") (cn' "laplace transform") (D.S ("An integral transform that converts a function of a real variable t "
+                                                                         ++ "(often time) to a function of a complex variable s (complex frequency)"))
+law          = cncpt''' (mkUid "law") (cn' "law")                        (D.S "a generalization based on a fact or event perceived to be recurrent")
+line         = dccWDS "line"          (pn' "line")                       $ D.S "An interval between two points" +:+ fromSource lineSource
+matrix       = cncpt''' (mkUid "matrix") (cnICES "matrix")               (D.S ("A rectangular array of quantities or expressions in rows and columns that" ++
+                                                                         "is treated as a single entity and manipulated according to particular rules"))
+norm         = cncpt''' (mkUid "norm")         (cn' "norm")              (D.S "the positive length or size of a vector")
+normal       = cncpt''' (mkUid "normal")       (cn' "normal" )           (D.S "an object that is perpendicular to a given object")
+number       = cncpt''' (mkUid "number")       (cn' "number")            (D.S "a mathematical object used to count, measure, and label")
+orient       = cncpt''' (mkUid "orientation")  (cn' "orientation")       (D.S "the relative physical position or direction of something")
+origin       = cncpt''' (mkUid "origin")       (cn' "origin")            (D.S "a fixed point of reference for the geometry of the surrounding space")
+perp         = cncpt''' (mkUid "perp")         (cn' "perpendicular")     (D.S "At right angles")
+pi_          = cncpt''' (mkUid "pi")           (cn' "ratio of circumference to diameter for any circle") (D.S "The ratio of a circle's circumference to its diameter")
+posInf       = cncpt''' (mkUid "PosInf")       (cn' "Positive Infinity") (D.S "the limit of a sequence or function that eventually exceeds any prescribed bound")
+negInf       = cncpt''' (mkUid "NegInf")       (cn' "Negative Infinity") (D.S "Opposite of positive infinity")
+positive     = cncpt''' (mkUid "positive")     (cn' "positive")          (D.S "greater than zero")
+negative     = cncpt''' (mkUid "negative")     (cn' "negative")          (D.S "less than zero")
 point        = dccWDS "point"     (pn' "point")                   $ D.S "An exact location, it has no size, only position" +:+
                                                                   fromSource pointSource
-probability  = dcc "probability"  (cnIES "probability")          "The likelihood of an event to occur"
-rate         = dcc "rate"         (cn' "rate")                   "Ratio that compares two quantities having different units of measure"
-rightHand    = dcc "rightHand"    (cn' "right-handed coordinate system")  "A coordinate system where the positive z-axis comes out of the screen"
-shape        = dcc "shape"        (cn' "shape")                  "The outline of an area or figure"
-surface      = dcc "surface"      (cn' "surface")                "The outer or topmost boundary of an object"
-vector       = dcc "vector"       (cn' "vector")                 "Object with magnitude and direction"
+probability  = cncpt''' (mkUid "probability")  (cnIES "probability")     (D.S "The likelihood of an event to occur")
+rate         = cncpt''' (mkUid "rate")         (cn' "rate")              (D.S "Ratio that compares two quantities having different units of measure")
+rightHand    = cncpt''' (mkUid "rightHand")    (cn' "right-handed coordinate system") (D.S "A coordinate system where the positive z-axis comes out of the screen")
+shape        = cncpt''' (mkUid "shape")        (cn' "shape")             (D.S "The outline of an area or figure")
+surface      = cncpt''' (mkUid "surface")      (cn' "surface")           (D.S "The outer or topmost boundary of an object")
+vector       = cncpt''' (mkUid "vector")       (cn' "vector")            (D.S "Object with magnitude and direction")
 
-xAxis = dcc "xAxis" (nounPhraseSent $ P lX :-: S "-axis") "the primary axis of a system of coordinates"
-yAxis = dcc "yAxis" (nounPhraseSent $ P lY :-: S "-axis") "the secondary axis of a system of coordinates"
-zAxis = dcc "zAxis" (nounPhraseSent $ P lZ :-: S "-axis") "the tertiary axis of a system of coordinates"
+xAxis = cncpt''' (mkUid "xAxis") (nounPhraseSent $ P lX :-: S "-axis")   (D.S "the primary axis of a system of coordinates")
+yAxis = cncpt''' (mkUid "yAxis") (nounPhraseSent $ P lY :-: S "-axis")   (D.S "the secondary axis of a system of coordinates")
+zAxis = cncpt''' (mkUid "zAxis") (nounPhraseSent $ P lZ :-: S "-axis")   (D.S "the tertiary axis of a system of coordinates")
 
-xCoord = dcc "xCoord" (nounPhraseSent $ P lX :-: S "-coordinate") "the location of the point on the x-axis"
-yCoord = dcc "yCoord" (nounPhraseSent $ P lY :-: S "-coordinate") "the location of the point on the y-axis"
-zCoord = dcc "zCoord" (nounPhraseSent $ P lZ :-: S "-coordinate") "the location of the point on the z-axis"
+xCoord = cncpt''' (mkUid "xCoord") (nounPhraseSent $ P lX :-: S "-coordinate") (D.S "the location of the point on the x-axis")
+yCoord = cncpt''' (mkUid "yCoord") (nounPhraseSent $ P lY :-: S "-coordinate") (D.S "the location of the point on the y-axis")
+zCoord = cncpt''' (mkUid "zCoord") (nounPhraseSent $ P lZ :-: S "-coordinate") (D.S "the location of the point on the z-axis")
 
-xComp = dcc "xComp" (nounPhraseSent $ P lX :-: S "-component") "the component of a vector in the x-direction"
-yComp = dcc "yComp" (nounPhraseSent $ P lY :-: S "-component") "the component of a vector in the y-direction"
-zComp = dcc "zComp" (nounPhraseSent $ P lZ :-: S "-component") "the component of a vector in the z-direction"
+xComp = cncpt''' (mkUid "xComp") (nounPhraseSent $ P lX :-: S "-component") (D.S "the component of a vector in the x-direction")
+yComp = cncpt''' (mkUid "yComp") (nounPhraseSent $ P lY :-: S "-component") (D.S "the component of a vector in the y-direction")
+zComp = cncpt''' (mkUid "zComp") (nounPhraseSent $ P lZ :-: S "-component") (D.S "the component of a vector in the z-direction")
 
-xDir = dcc "xDir" (nounPhraseSent $ P lX :-: S "-direction") "the direction aligned with the x-axis"
-yDir = dcc "yDir" (nounPhraseSent $ P lY :-: S "-direction") "the direction aligned with the y-axis"
-zDir = dcc "zDir" (nounPhraseSent $ P lZ :-: S "-direction") "the direction aligned with the z-axis"
-iAngle = dcc "iAngle" (cn "initial angle")                      "The initial angle where the body is being displaced"
+xDir = cncpt''' (mkUid "xDir") (nounPhraseSent $ P lX :-: S "-direction") (D.S "the direction aligned with the x-axis")
+yDir = cncpt''' (mkUid "yDir") (nounPhraseSent $ P lY :-: S "-direction") (D.S "the direction aligned with the y-axis")
+zDir = cncpt''' (mkUid "zDir") (nounPhraseSent $ P lZ :-: S "-direction") (D.S "the direction aligned with the z-axis")
+iAngle = cncpt''' (mkUid "iAngle") (cn "initial angle")                   (D.S "The initial angle where the body is being displaced")
 
 de, leftSide, ode, pde, rightSide :: CI
 --FIXME: use nounphrase instead of cn'
@@ -112,9 +112,9 @@ rightSide = commonIdeaWithDict "rightSide" (nounPhrase "right-hand side" "right-
 
 --FIXME: COMBINATION HACK (all below)
 -- do we really need fterms here? Would combineNINI work?
-euclidN = dcc "euclidNorm"    (combineNINI euclidSpace norm) "euclidean norm"
-normalV = dcc "normal vector" (combineNINI normal vector) "unit outward normal vector for a surface"
-perpV   = dcc "perp_vect"     (combineNINI perp vector) "vector perpendicular or 90 degrees to another vector"
-rOfChng = dcc "rOfChng"       (rate `of_` change) "ratio between a change in one variable relative to a corresponding change in another"
-surArea = dcc "surArea"       (combineNINI surface area) "a measure of the total area that the surface of the object occupies"
-unitV   = dcc "unit_vect"     (combineNINI unit_ vector) "a vector that has a magnitude of one"
+euclidN = cncpt''' (mkUid "euclidNorm")    (combineNINI euclidSpace norm) (D.S "euclidean norm")
+normalV = cncpt''' (mkUid "normal vector") (combineNINI normal vector)    (D.S "unit outward normal vector for a surface")
+perpV   = cncpt''' (mkUid "perp_vect")     (combineNINI perp vector)      (D.S "vector perpendicular or 90 degrees to another vector")
+rOfChng = cncpt''' (mkUid "rOfChng")       (rate `of_` change) (D.S "ratio between a change in one variable relative to a corresponding change in another")
+surArea = cncpt''' (mkUid "surArea")       (combineNINI surface area)     (D.S "a measure of the total area that the surface of the object occupies")
+unitV   = cncpt''' (mkUid "unit_vect")     (combineNINI unit_ vector)     (D.S "a vector that has a magnitude of one")

--- a/code/drasil-data/lib/Data/Drasil/Concepts/PhysicalProperties.hs
+++ b/code/drasil-data/lib/Data/Drasil/Concepts/PhysicalProperties.hs
@@ -3,6 +3,7 @@ module Data.Drasil.Concepts.PhysicalProperties where
 
 import Language.Drasil
 import Language.Drasil.Chunk.Concept.NamedCombinators
+import Drasil.Database (mkUid)
 
 import Data.Drasil.Concepts.Documentation (material_, property)
 import Data.Drasil.Concepts.Math (centre)
@@ -16,18 +17,18 @@ physicalcon = [gaseous, liquid, solid, ctrOfMass, dimension, flexure]
 gaseous, liquid, solid, ctrOfMass, density, specWeight, mass, len, dimension,
   vol, flexure :: ConceptChunk
 
-gaseous    = dcc "gaseous"    (cn''' "gas"          ) "gaseous state"
-liquid     = dcc "liquid"     (cn' "liquid"         ) "liquid state"
-solid      = dcc "solid"      (cn' "solid"          ) "solid state"
-ctrOfMass  = dcc "ctrOfMass"  (centre `of_PS` mass  ) "the mean location of the distribution of mass of the object"
-dimension  = dcc "dimension"  (cn' "dimension"      ) "any of a set of basic kinds of quantity, as mass, length, and time"
-density    = dcc "density"    (cnIES "density"      ) "the mass per unit volume"
-specWeight = dcc "specWeight" (cn' "specific weight") "the weight per unit volume"
-flexure    = dcc "flexure"    (cn' "flexure"        ) "a bent or curved part"
-len        = dcc "length"     (cn' "length"         ) ("the straight-line distance between two points along an object, " ++
-                                                       "typically used to represent the size of an object from one end to the other")
-mass       = dcc "mass"       (cn''' "mass"         ) "the quantity of matter in a body"
-vol        = dcc "volume"     (cn' "volume"         ) "the amount of space that a substance or object occupies"
+gaseous    = cncpt''' (mkUid "gaseous")    (cn''' "gas"          ) (S "gaseous state")
+liquid     = cncpt''' (mkUid "liquid")     (cn' "liquid"         ) (S "liquid state")
+solid      = cncpt''' (mkUid "solid")      (cn' "solid"          ) (S "solid state")
+ctrOfMass  = cncpt''' (mkUid "ctrOfMass")  (centre `of_PS` mass  ) (S "the mean location of the distribution of mass of the object")
+dimension  = cncpt''' (mkUid "dimension")  (cn' "dimension"      ) (S "any of a set of basic kinds of quantity, as mass, length, and time")
+density    = cncpt''' (mkUid "density")    (cnIES "density"      ) (S "the mass per unit volume")
+specWeight = cncpt''' (mkUid "specWeight") (cn' "specific weight") (S "the weight per unit volume")
+flexure    = cncpt''' (mkUid "flexure")    (cn' "flexure"        ) (S "a bent or curved part")
+len        = cncpt''' (mkUid "length")     (cn' "length"         ) (S ("the straight-line distance between two points along an object, " ++
+                                                       "typically used to represent the size of an object from one end to the other"))
+mass       = cncpt''' (mkUid "mass")       (cn''' "mass"         ) (S "the quantity of matter in a body")
+vol        = cncpt''' (mkUid "volume")     (cn' "volume"         ) (S "the amount of space that a substance or object occupies")
 
 materialProprty :: IdeaDict
 materialProprty = compoundNC material_ property

--- a/code/drasil-data/lib/Data/Drasil/Concepts/Physics.hs
+++ b/code/drasil-data/lib/Data/Drasil/Concepts/Physics.hs
@@ -5,6 +5,7 @@ module Data.Drasil.Concepts.Physics where
 import Language.Drasil hiding (space)
 import qualified Language.Drasil.Sentence.Combinators as S
 import Language.Drasil.Chunk.Concept.NamedCombinators
+import Drasil.Database (mkUid)
 
 import Drasil.Metadata.Domains (mathematics, physics)
 import Data.Drasil.Concepts.Documentation (property, value)
@@ -57,8 +58,8 @@ threeD = commonIdeaWithDict "threeD" (cn "three-dimensional") "3D" [mathematics,
 
 acceleration = dccWDS "acceleration" (cn' "acceleration")
   (S "the rate of change of a body's" +:+ phrase velocity)
-angular = dcc "angular" (cn' "angular")
-  "denoting physical properties or quantities measured with reference to or by means of an angle"
+angular = cncpt''' (mkUid "angular") (cn' "angular")
+  (S "denoting physical properties or quantities measured with reference to or by means of an angle")
 body = dccWDS "physicsBody" (cnIES "body")
   (S "an object with" +:+ phrase QPP.mass)
 chgInVelocity = dccWDS "chgInVelocity" (cn desc)
@@ -66,8 +67,8 @@ chgInVelocity = dccWDS "chgInVelocity" (cn desc)
   where desc = "change in velocity" -- TODO: This is a hack to avoid an infinite loop should we enable strict data.
 chgMomentum = dccWDS "chgMomentum" (cn' "change in momentum")
   (S "The rate of change of a body's" +:+ phrase impulseV)
-collision = dcc "collision" (cn' "collision")
-  "an encounter between particles resulting in an exchange or transformation of energy"
+collision = cncpt''' (mkUid "collision") (cn' "collision")
+  (S "an encounter between particles resulting in an exchange or transformation of energy")
 cohesion = dccWDS "cohesion" (cn "cohesion")
   (S "an attractive" +:+ phrase force +:+ S "between adjacent particles that holds the matter together")
 compression = dccWDS "compression" (cn' "compression")
@@ -75,35 +76,35 @@ compression = dccWDS "compression" (cn' "compression")
 damping = dccWDS "damping" (pn' "damping")
   $ S "an influence within or upon an oscillatory system that has the effect of reducing," +:+
   S "restricting or preventing its oscillations" +:+ fromSource dampingSource
-dampingCoeff = dcc "dampingCoeff" (cn' "damping coefficient")
- "Quantity that characterizes a second order system's oscillatory response"
+dampingCoeff = cncpt''' (mkUid "dampingCoeff") (cn' "damping coefficient")
+ (S "Quantity that characterizes a second order system's oscillatory response")
 displacement = dccWDS "displacement" (cn' "displacement")
   (S "the change in" +:+ (position ^. defn))
-distance = dcc "distance" (cn' "distance")
-  "the interval measured along a path connecting two locations"
-elasticity = dcc "elasticity" (cnIES "elasticity")
-  "the ratio of the relative velocities of two colliding objects after and before a collision"
-energy = dcc "energy" (cn "energy")
-  "power derived from the utilization of physical or chemical resources"
-fbd = dcc "FBD" (cn' "free body diagram")
-  ("a graphical illustration used to visualize the applied forces, movements, and resulting " ++
-   "reactions on a body in a steady state condition")
-force = dcc "force" (cn' "force")
-  "an interaction that tends to produce change in the motion of an object"
-frequency = dcc "frequency" (cn' "frequency")
-  "the number of occurrences of a repeating event per unit of time"
-friction = dcc "friction" (cn' "friction")
-  "the force resisting the relative motion of two surfaces"
-fOfGravity = dcc "fOfGravity" (cn "force of gravity")
-  "the force exerted by gravity on an object"
-gravity = dcc "gravity" (cn "gravity")
-  "the force that attracts one physical body with mass to another"
-gravitationalAccel = dcc "gravitationalAccel" (cn "gravitational acceleration")
-  "the approximate acceleration due to gravity on Earth at sea level"
-gravitationalConst = dcc "gravitationalConst" (cn "gravitational constant")
-  "the empirical physical constant used to show the force between two objects caused by gravity"
-gravitationalMagnitude = dcc "gravitationalMagnitude" (cn "magnitude of gravitational acceleration")
-  "the magnitude of the approximate acceleration due to gravity on Earth at sea level"
+distance = cncpt''' (mkUid "distance") (cn' "distance")
+  (S "the interval measured along a path connecting two locations")
+elasticity = cncpt''' (mkUid "elasticity") (cnIES "elasticity")
+  (S "the ratio of the relative velocities of two colliding objects after and before a collision")
+energy = cncpt''' (mkUid "energy") (cn "energy")
+  (S "power derived from the utilization of physical or chemical resources")
+fbd = cncpt''' (mkUid "FBD") (cn' "free body diagram")
+  (S ("a graphical illustration used to visualize the applied forces, movements, and resulting " ++
+   "reactions on a body in a steady state condition"))
+force = cncpt''' (mkUid "force") (cn' "force")
+  (S "an interaction that tends to produce change in the motion of an object")
+frequency = cncpt''' (mkUid "frequency") (cn' "frequency")
+  (S "the number of occurrences of a repeating event per unit of time")
+friction = cncpt''' (mkUid "friction") (cn' "friction")
+  (S "the force resisting the relative motion of two surfaces")
+fOfGravity = cncpt''' (mkUid "fOfGravity") (cn "force of gravity")
+  (S "the force exerted by gravity on an object")
+gravity = cncpt''' (mkUid "gravity") (cn "gravity")
+  (S "the force that attracts one physical body with mass to another")
+gravitationalAccel = cncpt''' (mkUid "gravitationalAccel") (cn "gravitational acceleration")
+  (S "the approximate acceleration due to gravity on Earth at sea level")
+gravitationalConst = cncpt''' (mkUid "gravitationalConst") (cn "gravitational constant")
+  (S "the empirical physical constant used to show the force between two objects caused by gravity")
+gravitationalMagnitude = cncpt''' (mkUid "gravitationalMagnitude") (cn "magnitude of gravitational acceleration")
+  (S "the magnitude of the approximate acceleration due to gravity on Earth at sea level")
 height = dccWDS "height" (cn' "height")
   (S "the" +:+ phrase distance +:+ S "above a reference point for a point of interest")
 horizontalMotion = dccWDS "horizontalMotion" (cn "horizontal motion")
@@ -111,17 +112,17 @@ horizontalMotion = dccWDS "horizontalMotion" (cn "horizontal motion")
 isotropy = dccWDS "isotropy" (cn "isotropy")
   (S "a condition where the" +:+ (phrase value `S.ofA` phrase property) `S.is`
    S "independent of the direction in which it is measured")
-joint = dcc "joint" (cn' "joint")
-  "a connection between two rigid bodies which allows movement with one or more degrees of freedom"
+joint = cncpt''' (mkUid "joint") (cn' "joint")
+  (S "a connection between two rigid bodies which allows movement with one or more degrees of freedom")
 kEnergy = dccWDS "kEnergy" (cn "kinetic energy")
   (S "measure" `S.the_ofThe` phrase energy +:+ S "a body possesses due to its motion")
 kinematics = dccWDS "kinematics" (cn "kinematics")
   (S "branch" `S.of_` phrase mechanics +:+ S "that describes the motion" `S.of_`
     S "objects without reference to the causes of motion")
-linear = dcc "linear" (cn' "linear")
-  "arranged in or extending along a straight or nearly straight line"
-mechEnergy = dcc "mechEnergy" (cn "mechanical energy")
-  "the energy that comes from motion and position"
+linear = cncpt''' (mkUid "linear") (cn' "linear")
+  (S "arranged in or extending along a straight or nearly straight line")
+mechEnergy = cncpt''' (mkUid "mechEnergy") (cn "mechanical energy")
+  (S "the energy that comes from motion and position")
 momentum = dccWDS "momentum" (cn "momentum")
   ( S "the quantity of motion" `S.of_` S "a moving body, measured as a product" `S.of_`
   (phrase QPP.mass `S.and_` phrase velocity))
@@ -136,8 +137,8 @@ period = dccWDS "period" (cn' "period")
 pendulum = dccWDS "pendulum" (cn "pendulum")
  (S "a body suspended from a fixed support so that it swings freely back and forth under the influence"
        `S.of_` phrase gravity)
-position = dcc "position" (cn' "position")
-  "an object's location relative to a reference point"
+position = cncpt''' (mkUid "position") (cn' "position")
+  (S "an object's location relative to a reference point")
 positionVec = dccWDS "positionVec" (cn' "position vector")
    (S "a vector from the origin" `S.ofThe` phrase cartesian +:+ S "defined"
     `S.toThe` phrase point +:+ S "where the" +:+ phrase force +:+ S "is applied")
@@ -145,42 +146,42 @@ potEnergy = dccWDS "potEnergy" (cn "potential energy")
   (S "measure" `S.the_ofThe` phrase energy +:+ S "held by an object because of its" +:+ phrase position)
 pressure = dccWDS "pressure" (cn' "pressure")
   (S "a" +:+ phrase force +:+ S "exerted over an area")
-rectilinear = dcc "rectilinear" (cn "rectilinear")
-  "occurring in one dimension"
-rigidBody = dcc "rigidBody" (cnIES "rigid body")
-  "a solid body in which deformation is neglected"
-space = dcc "space" (cn' "space")
-  "a two-dimensional extent where objects and events have relative positions and directions"
+rectilinear = cncpt''' (mkUid "rectilinear") (cn "rectilinear")
+  (S "occurring in one dimension")
+rigidBody = cncpt''' (mkUid "rigidBody") (cnIES "rigid body")
+  (S "a solid body in which deformation is neglected")
+space = cncpt''' (mkUid "space") (cn' "space")
+  (S "a two-dimensional extent where objects and events have relative positions and directions")
 scalarAccel = dccWDS "scalarAccel" (cn' "scalar acceleration")
   (S "magnitude" `S.the_ofThe` phrase acceleration +:+ S "vector")
 scalarPos = dccWDS "scalarPos" (cn' "scalar position")
   (S "magnitude" `S.the_ofThe` phrase position +:+ S "vector")
-shm = dcc "SHM" (nounPhraseSP "simple harmonic motion") ("Periodic motion through an equilibrium position. " ++
+shm = cncpt''' (mkUid "SHM") (nounPhraseSP "simple harmonic motion") (S ("Periodic motion through an equilibrium position. " ++
                                                         "The motion is sinusoidal in time and demonstrates a" ++
-                                                        " single resonant frequency") -- source: Wikipedia
+                                                        " single resonant frequency")) -- source: Wikipedia
 speed = dccWDS "speed" (cn' "speed")
   (S "magnitude" `S.the_ofThe` phrase velocity +:+ S "vector")
-stiffCoeff = dcc "stiffnessCoeff" (cn' "stiffness coefficient")
- "Quantity that characterizes a spring's stiffness"
+stiffCoeff = cncpt''' (mkUid "stiffnessCoeff") (cn' "stiffness coefficient")
+  (S "Quantity that characterizes a spring's stiffness")
 strain = dccWDS "strain" (cn' "strain")
   (S "a measure of deformation representing the" +:+ phrase displacement +:+
    S "between particles in the body relative to a reference length")
   --definition of strain used in SSP, can be made clearer
-stress = dcc "stress" (cn''' "stress")
-  "the ratio of an applied force to a cross-sectional area"
+stress = cncpt''' (mkUid "stress") (cn''' "stress")
+  (S "the ratio of an applied force to a cross-sectional area")
   --definition of stress used in SSP, can be made clearer
 tension = dccWDS "tension" (cn' "tension")
   (S "a" +:+ phrase stress +:+ S "that causes displacement of the body away from its center")
-time = dcc "time" (cn' "time")
-  "the indefinite continued progress of existence and events in the past, present, and future regarded as a whole"
-torque = dcc "torque" (cn' "torque")
-  "a twisting force that tends to cause rotation"
+time = cncpt''' (mkUid "time") (cn' "time")
+  (S "the indefinite continued progress of existence and events in the past, present, and future regarded as a whole")
+torque = cncpt''' (mkUid "torque") (cn' "torque")
+  (S "a twisting force that tends to cause rotation")
 velocity = dccWDS "velocity" (cnIES "velocity")
   (S "the rate of change of a body's" +:+ phrase position)
 verticalMotion = dccWDS "verticalMotion" (cn "vertical motion")
   (S " the movement of the object against the gravitational pull")
-weight = dcc "weight" (cn' "weight")
-  "the gravitational force acting on an object"
+weight = cncpt''' (mkUid "weight") (cn' "weight")
+  (S "the gravitational force acting on an object")
 
 -- Some variants of distance, speed, velocity, and scalar acceleration
 -- FIXME: Complete all variants?
@@ -219,32 +220,32 @@ yConstAccel = dccWDS "yConstAccel" (yComp `of_` constAccel) (S "The" +:+ NP (yCo
 
 --FIXME: COMBINATION HACK (for all below)
 --FIXME: should use compoundPhrase instead? Or better yet, use combineNINI instead of interacting with the terms directly?
-angDisp = dcc "angularDisplacement" (combineNINI angular displacement)
-  "the angle through which an object moves on a circular path"
-angVelo = dcc "angularVelocity" (combineNINI angular velocity)
-  "the rate of change of angular position of a rotating body"
-angAccel = dcc "angularAcceleration" (combineNINI angular acceleration)
-  "the rate of change of angular velocity"
-constAccel = dcc "constantAcceleration" (cn "constant acceleration")
-  "a one-dimensional acceleration that is constant"
-linDisp = dcc "linearDisplacement" (combineNINI linear displacement)
-  "movement in one direction along a single axis"
-linVelo = dcc "linearVelocity" (combineNINI linear velocity)
-  "the speed of a moving object, dependent on the perspective taken"
-linAccel = dcc "linearAcceleration" (combineNINI linear acceleration)
-  "the rate of change of velocity without a change in direction"
+angDisp = cncpt''' (mkUid "angularDisplacement") (combineNINI angular displacement)
+  (S "the angle through which an object moves on a circular path")
+angVelo = cncpt''' (mkUid "angularVelocity") (combineNINI angular velocity)
+  (S "the rate of change of angular position of a rotating body")
+angAccel = cncpt''' (mkUid "angularAcceleration") (combineNINI angular acceleration)
+  (S "the rate of change of angular velocity")
+constAccel = cncpt''' (mkUid "constantAcceleration") (cn "constant acceleration")
+  (S "a one-dimensional acceleration that is constant")
+linDisp = cncpt''' (mkUid "linearDisplacement") (combineNINI linear displacement)
+  (S "movement in one direction along a single axis")
+linVelo = cncpt''' (mkUid "linearVelocity") (combineNINI linear velocity)
+  (S "the speed of a moving object, dependent on the perspective taken")
+linAccel = cncpt''' (mkUid "linearAcceleration") (combineNINI linear acceleration)
+  (S "the rate of change of velocity without a change in direction")
 
 -- The following feel like they're missing something/need to be more
 -- descriptive. See issue tracker for details.
 -- FIXME: plurals below?
-restitutionCoef = dcc "restitutionCoef" (cn "coefficient of restitution")
-  "a measure of the restitution of a collision between two objects"
-momentOfInertia = dcc "momentOfInertia" (cn "moment of inertia")
-  "a quantity expressing a body's tendency to resist angular acceleration"
-angFreq = dcc "angularFrequency" (cn "angular frequency")
-  "the frequency of a periodic process, wave system etc, per unit time."
+restitutionCoef = cncpt''' (mkUid "restitutionCoef") (cn "coefficient of restitution")
+  (S "a measure of the restitution of a collision between two objects")
+momentOfInertia = cncpt''' (mkUid "momentOfInertia") (cn "moment of inertia")
+  (S "a quantity expressing a body's tendency to resist angular acceleration")
+angFreq = cncpt''' (mkUid "angularFrequency") (cn "angular frequency")
+  (S "the frequency of a periodic process, wave system etc, per unit time.")
 --FIXME: These two should be built off "impulse"
-impulseV = dcc "impulseV" (cn "impulse (vector)")
-  "a force acting briefly on a body and producing a finite change of momentum in a given direction"
-impulseS = dcc "impulseS" (cn "impulse (scalar)")
-  "a force acting briefly on a body and producing a finite change of momentum"
+impulseV = cncpt''' (mkUid "impulseV") (cn "impulse (vector)")
+  (S "a force acting briefly on a body and producing a finite change of momentum in a given direction")
+impulseS = cncpt''' (mkUid "impulseS") (cn "impulse (scalar)")
+  (S "a force acting briefly on a body and producing a finite change of momentum")

--- a/code/drasil-data/lib/Data/Drasil/Concepts/Physics.hs
+++ b/code/drasil-data/lib/Data/Drasil/Concepts/Physics.hs
@@ -6,7 +6,6 @@ import Drasil.Database (mkUid)
 import Language.Drasil hiding (space)
 import qualified Language.Drasil.Sentence.Combinators as S
 import Language.Drasil.Chunk.Concept.NamedCombinators
-import Drasil.Database (mkUid)
 
 import Drasil.Metadata.Domains (mathematics, physics)
 import Data.Drasil.Concepts.Documentation (property, value)

--- a/code/drasil-data/lib/Data/Drasil/Concepts/Software.hs
+++ b/code/drasil-data/lib/Data/Drasil/Concepts/Software.hs
@@ -4,6 +4,7 @@ module Data.Drasil.Concepts.Software where
 import Language.Drasil
 import qualified Language.Drasil.Sentence.Combinators as S
 import Drasil.Metadata.Documentation (srs)
+import Drasil.Database (mkUid)
 
 import Data.Drasil.Concepts.Computation (algorithm, dataStruct, inParam)
 import Data.Drasil.Concepts.Documentation (input_, physical, physicalConstraint,
@@ -20,14 +21,14 @@ softwarecon = [correctness, verifiability, physLib,
 
 c, errMsg, physLib, program :: ConceptChunk
 
-c       = dcc "c" (pn "C")
-  "the C programming language"
-physLib = dcc "physLib" (cnIES "physics library")
-  "a programming library which provides functions for modelling physical phenomenon"
-program = dcc "program" (cn' "program")
-  "a series of coded software instructions to control the operation of a computer or other machine"
-errMsg  = dcc "errMsg" (cn' "error message")
-  "a message that indicates an incorrect instruction has been given, or that there is an error resulting from faulty software"
+c       = cncpt''' (mkUid "c") (pn "C")
+  (S "the C programming language")
+physLib = cncpt''' (mkUid "physLib") (cnIES "physics library")
+  (S "a programming library which provides functions for modelling physical phenomenon")
+program = cncpt''' (mkUid "program") (cn' "program")
+  (S "a series of coded software instructions to control the operation of a computer or other machine")
+errMsg  = cncpt''' (mkUid "errMsg") (cn' "error message")
+  (S "a message that indicates an incorrect instruction has been given, or that there is an error resulting from faulty software")
 
 -- * Non-functional Requirements
 
@@ -37,36 +38,36 @@ accuracy, correctness, maintainability, performance, performanceSpd, portability
 qualOfBeing :: String -> String
 qualOfBeing s = "the quality or state of being" ++ s
 
-accuracy          = dcc "accuracy"          (nounPhraseSP "accuracy")
-  $ qualOfBeing "correct or precise"
+accuracy          = cncpt''' (mkUid "accuracy")          (nounPhraseSP "accuracy")
+  (S $ qualOfBeing "correct or precise")
 
-correctness       = dcc "correctness"       (nounPhraseSP "correctness")
-  $ qualOfBeing "free from error"
+correctness       = cncpt''' (mkUid "correctness")       (nounPhraseSP "correctness")
+  (S $ qualOfBeing "free from error")
 
-maintainability   = dcc "maintainability"   (nounPhraseSP "maintainability")
-  "the probability of performing a successful repair action within a given time"
+maintainability   = cncpt''' (mkUid "maintainability")   (nounPhraseSP "maintainability")
+  (S "the probability of performing a successful repair action within a given time")
 
-performance       = dcc "performance"       (nounPhraseSP "performance")
-  "the action or process of carrying out or accomplishing an action, task, or function"
+performance       = cncpt''' (mkUid "performance")       (nounPhraseSP "performance")
+  (S "the action or process of carrying out or accomplishing an action, task, or function")
 
-performanceSpd    = dcc "performanceSpd"    (cn' "performance speed")
-  "the action or process of carrying out or accomplishing an action, task, or function quickly"
+performanceSpd    = cncpt''' (mkUid "performanceSpd")    (cn' "performance speed")
+  (S "the action or process of carrying out or accomplishing an action, task, or function quickly")
 
-portability       = dcc "portability"       (nounPhraseSP "portability")
-  "the ability of software to be transferred from one machine or system to another"
+portability       = cncpt''' (mkUid "portability")       (nounPhraseSP "portability")
+  (S "the ability of software to be transferred from one machine or system to another")
 
-reliability       = dcc "reliability"       (nounPhraseSP "reliability")
-  ("the degree to which the result of a measurement, calculation," ++
-  "or specification can be depended on to be accurate")
+reliability       = cncpt''' (mkUid "reliability")       (nounPhraseSP "reliability")
+  (S ("the degree to which the result of a measurement, calculation," ++
+  "or specification can be depended on to be accurate"))
 
-reusability       = dcc "reusability"       (nounPhraseSP "reusability")
-  "the use of existing assets in some form within the software product development process"
+reusability       = cncpt''' (mkUid "reusability")       (nounPhraseSP "reusability")
+  (S "the use of existing assets in some form within the software product development process")
 
-understandability = dcc "understandability" (nounPhraseSP "understandability")
-  $ qualOfBeing "understandable"
+understandability = cncpt''' (mkUid "understandability") (nounPhraseSP "understandability")
+  (S $ qualOfBeing "understandable")
 
-verifiability     = dcc "verifiability"     (nounPhraseSP "verifiability")
-  $ qualOfBeing "capable of being verified, confirmed, or substantiated"
+verifiability     = cncpt''' (mkUid "verifiability")     (nounPhraseSP "verifiability")
+  (S $ qualOfBeing "capable of being verified, confirmed, or substantiated")
 
 -- * Module Concepts
 
@@ -74,9 +75,9 @@ verifiability     = dcc "verifiability"     (nounPhraseSP "verifiability")
 
 --FIXME: "hiding" is not a noun.
 hwHiding :: ConceptChunk
-hwHiding = dcc "hwHiding" (cn "hardware hiding")
-  ("hides the exact details of the hardware, and provides a uniform interface" ++
-   " for the rest of the system to use")
+hwHiding = cncpt''' (mkUid "hwHiding") (cn "hardware hiding")
+  (S ("hides the exact details of the hardware, and provides a uniform interface" ++
+   " for the rest of the system to use"))
 
 modBehavHiding :: ConceptChunk
 modBehavHiding = dccWDS "modBehavHiding" (cn "behaviour hiding") (foldlSent_
@@ -87,7 +88,7 @@ modBehavHiding = dccWDS "modBehavHiding" (cn "behaviour hiding") (foldlSent_
    S "to change if there are changes in the", short srs])
 
 modControl :: ConceptChunk
-modControl = dcc "modControl" (cn' "control module") "provides the main program"
+modControl = cncpt''' (mkUid "modControl") (cn' "control module") (S "provides the main program")
 
 modSfwrDecision :: ConceptChunk
 modSfwrDecision = dccWDS "modSfwrDecision" (cn' "software decision module") (foldlSent_
@@ -95,8 +96,8 @@ modSfwrDecision = dccWDS "modSfwrDecision" (cn' "software decision module") (fol
    S "used in the system that do not provide direct interaction with the user"])
 
 modInputFormat :: ConceptChunk
-modInputFormat = dcc "modInputFormat" (cn' "input format module")
-  "converts the input data into the data structure used by the input parameters module"
+modInputFormat = cncpt''' (mkUid "modInputFormat") (cn' "input format module")
+  (S "converts the input data into the data structure used by the input parameters module")
 
 modInputParam :: ConceptChunk
 modInputParam = dccWDS "modInputParam" (cn' "input parameter module") (foldlSent_
@@ -105,9 +106,9 @@ modInputParam = dccWDS "modInputParam" (cn' "input parameter module") (foldlSent
    S "The values can be read as needed. This module knows how many parameters it stores"])
 
 modInputConstraint :: ConceptChunk
-modInputConstraint = dcc "modInputConstraint" (cn' "input constraint module")
-  ("defines the constraints on the input data and gives an error if " ++
-   "a constraint is violated")
+modInputConstraint = cncpt''' (mkUid "modInputConstraint") (cn' "input constraint module")
+  (S ("defines the constraints on the input data and gives an error if " ++
+   "a constraint is violated"))
 
 modInputVerif :: ConceptChunk
 modInputVerif = dccWDS "modInputVerif" (cn' "input verification module") (foldlSent
@@ -154,7 +155,7 @@ modVectorServ = dccWDS "modVectorServ" (cn' "vector")
    S "scalar and vector multiplication", S "dot and cross products", S "rotations"])
 
 modPlotDesc :: ConceptChunk
-modPlotDesc = dcc "modPlotDesc" (cn' "plotting") "provides a plot function"
+modPlotDesc = cncpt''' (mkUid "modPlotDesc") (cn' "plotting") (S "provides a plot function")
 
 modOutputfDescFun :: Sentence -> ConceptChunk
 modOutputfDescFun desc = dccWDS "modOutputfDescFun" (cn' "output format")

--- a/code/drasil-data/lib/Data/Drasil/Concepts/Thermodynamics.hs
+++ b/code/drasil-data/lib/Data/Drasil/Concepts/Thermodynamics.hs
@@ -4,6 +4,7 @@ module Data.Drasil.Concepts.Thermodynamics where
 import Language.Drasil
 --import Utils.Drasil
 import Language.Drasil.Chunk.Concept.NamedCombinators
+import Drasil.Database (mkUid)
 
 import Data.Drasil.Concepts.Documentation (source, theory)
 import Data.Drasil.Concepts.Physics (energy)
@@ -21,55 +22,55 @@ boilPt, boiling, degree_', enerSrc, heat, heatCapSpec, heatTrans, htFlux,
 
 -- FIXME: "Boiling" is not a noun. How should we deal with it?
 --    Same for "Melting"
-boiling           = dcc "boiling"           (cn "boiling")
-                      "the phase change from liquid to vapour"
-boilPt            = dcc "boilPt"            (cn' "boiling point temperature")
-                      "the temperature at which a substance changes from liquid to vapour"
-degree_'          = dcc "thermo_degree"     (cn' "degree")
-                      "a measure of the warmth or coldness of an object or substance"
-heat              = dcc "heat"              (cn "heat")
-                      ("Noun: The amount of heat energy inside a body. " ++
-                      "Verb: To transfer thermal energy to a body") -- FIXME: there shouldn't be two definitions in one
-heatTrans         = dcc "heatTrans"         (cn' "heat transfer")
-                      ("the generation, use, conversion, and exchange of thermal " ++
-                      "energy and heat between physical systems")
-heatCapSpec       = dcc "heatCapSpec"       (cnIES "specific heat capacity")
-                      ("the amount of energy required to raise the temperature " ++
-                      "of the unit mass of a given substance by a given amount")
-htFlux            = dcc "htFlux"            (cn'' "heat flux")
-                      ("the rate of thermal energy transfer through a given " ++
-                      "surface per unit time")
-latentHeat        = dcc "latentHeat"        (cn' "latent heat")
-                      ("the heat required to convert a solid into a liquid or " ++
-                      "vapor, or a liquid into a vapor, without change of temperature")
-lawConsEnergy     = dcc "lawConsEnergy"     (nounPhraseSP "law of conservation of energy")
-                      "the law that energy is conserved"
-lawConvCooling    = dcc "lawConvCooling"    (nounPhraseSP "Newton's law of cooling")
-                      "Newton's law of convective cooling"
-melting           = dcc "melting"           (cn "melting")
-                      "the phase change from solid to liquid"
-meltPt            = dcc "meltPt"            (cn' "melting point temperature")
-                      "the temperature at which a substance changes from liquid to vapour"
-phaseChange       = dcc "phaseChange"       (cn' "phase change")
-                      "a change of state"
-sensHeat          = dcc "sensHeat"          (cn' "sensible heat")
-                      ("heat exchanged by a body in which the exchange of heat " ++
+boiling           = cncpt''' (mkUid "boiling")           (cn "boiling")
+                      (S "the phase change from liquid to vapour")
+boilPt            = cncpt''' (mkUid "boilPt")            (cn' "boiling point temperature")
+                      (S "the temperature at which a substance changes from liquid to vapour")
+degree_'          = cncpt''' (mkUid "thermo_degree")     (cn' "degree")
+                      (S "a measure of the warmth or coldness of an object or substance")
+heat              = cncpt''' (mkUid "heat")              (cn "heat")
+                      (S ("Noun: The amount of heat energy inside a body. " ++
+                      "Verb: To transfer thermal energy to a body")) -- FIXME: there shouldn't be two definitions in one
+heatTrans         = cncpt''' (mkUid "heatTrans")         (cn' "heat transfer")
+                      (S ("the generation, use, conversion, and exchange of thermal " ++
+                      "energy and heat between physical systems"))
+heatCapSpec       = cncpt''' (mkUid "heatCapSpec")       (cnIES "specific heat capacity")
+                      (S ("the amount of energy required to raise the temperature " ++
+                      "of the unit mass of a given substance by a given amount"))
+htFlux            = cncpt''' (mkUid "htFlux")            (cn'' "heat flux")
+                      (S ("the rate of thermal energy transfer through a given " ++
+                      "surface per unit time"))
+latentHeat        = cncpt''' (mkUid "latentHeat")        (cn' "latent heat")
+                      (S ("the heat required to convert a solid into a liquid or " ++
+                      "vapor, or a liquid into a vapor, without change of temperature"))
+lawConsEnergy     = cncpt''' (mkUid "lawConsEnergy")     (nounPhraseSP "law of conservation of energy")
+                      (S "the law that energy is conserved")
+lawConvCooling    = cncpt''' (mkUid "lawConvCooling")    (nounPhraseSP "Newton's law of cooling")
+                      (S "Newton's law of convective cooling")
+melting           = cncpt''' (mkUid "melting")           (cn "melting")
+                      (S "the phase change from solid to liquid")
+meltPt            = cncpt''' (mkUid "meltPt")            (cn' "melting point temperature")
+                      (S "the temperature at which a substance changes from liquid to vapour")
+phaseChange       = cncpt''' (mkUid "phaseChange")       (cn' "phase change")
+                      (S "a change of state")
+sensHeat          = cncpt''' (mkUid "sensHeat")          (cn' "sensible heat")
+                      (S ("heat exchanged by a body in which the exchange of heat " ++
                       "changes the temperature and some macroscopic variables of " ++
-                      "the body or system, but leaves others unchanged")
-temp              = dcc "temperature"       (cn' "temperature")
-                      "the degree or intensity of heat present in a substance or object"
-thermalAnalysis   = dcc "thermalAnalysis"
+                      "the body or system, but leaves others unchanged"))
+temp              = cncpt''' (mkUid "temperature")       (cn' "temperature")
+                      (S "the degree or intensity of heat present in a substance or object")
+thermalAnalysis   = cncpt''' (mkUid "thermalAnalysis")
                       (cnIP "thermal analysis" (IrregPlur (\x -> init (init x) ++ "es")))
-                      "the study of material properties as they change with temperature"
-thermalConduction = dcc "thermalConduction" (nounPhraseSP "thermal conduction")
-                      "the transfer of heat energy through a substance"
-thermalConductor  = dcc "thermalConductor"  (cn' "thermal conductor")
-                      "an object through which thermal energy can be transferred easily"
-thermalEnergy     = dcc "thermalEnergy"     (cnIES "thermal energy")
-                      "the energy that comes from heat"
+                      (S "the study of material properties as they change with temperature")
+thermalConduction = cncpt''' (mkUid "thermalConduction") (nounPhraseSP "thermal conduction")
+                      (S "the transfer of heat energy through a substance")
+thermalConductor  = cncpt''' (mkUid "thermalConductor")  (cn' "thermal conductor")
+                      (S "an object through which thermal energy can be transferred easily")
+thermalEnergy     = cncpt''' (mkUid "thermalEnergy")     (cnIES "thermal energy")
+                      (S "the energy that comes from heat")
 
-enerSrc           = dcc "enerSrc"     (combineNINI energy source)
-                      "a source from which useful energy can be extracted"
-htTransTheo       = dcc "htTransTheo" (combineNINI heatTrans theory)
-                      ("the theory predicting the energy transfer that may take " ++
-                      "place between material bodies as a result of temperature difference")
+enerSrc           = cncpt''' (mkUid "enerSrc")     (combineNINI energy source)
+                      (S "a source from which useful energy can be extracted")
+htTransTheo       = cncpt''' (mkUid "htTransTheo") (combineNINI heatTrans theory)
+                      (S ("the theory predicting the energy transfer that may take " ++
+                      "place between material bodies as a result of temperature difference"))

--- a/code/drasil-data/lib/Data/Drasil/SI_Units.hs
+++ b/code/drasil-data/lib/Data/Drasil/SI_Units.hs
@@ -4,6 +4,7 @@ module Data.Drasil.SI_Units where
 import Language.Drasil
 import Language.Drasil.Display
 import Language.Drasil.ShortHands (cOmega)
+import Drasil.Database (mkUid)
 
 -- * Lists of Units
 
@@ -141,12 +142,12 @@ weber = derCUC' "weber"
   "weber" "magnetic flux" (label "Wb") (volt *: second)
 
 specificE :: UnitDefn
-specificE = makeDerU (dcc "specificE" (cnIES "specific energy")
-  "energy per unit mass") (joule /: kilogram)
+specificE = makeDerU (cncpt''' (mkUid "specificE") (cnIES "specific energy")
+  (S "energy per unit mass")) (joule /: kilogram)
 
 specificWeight :: UnitDefn
-specificWeight = makeDerU (dcc "specificWeight" (cn' "specific weight")
-  "weight per unit volume") (newton *$ (metre ^: (-3)))
+specificWeight = makeDerU (cncpt''' (mkUid "specificWeight") (cn' "specific weight")
+  (S "weight per unit volume")) (newton *$ (metre ^: (-3)))
 
 -- FIXME: Need to add pi
 --degrees = DUC

--- a/code/drasil-data/lib/Data/Drasil/Units/Physics.hs
+++ b/code/drasil-data/lib/Data/Drasil/Units/Physics.hs
@@ -3,7 +3,8 @@ module Data.Drasil.Units.Physics where
 
 import Data.Drasil.SI_Units (metre, radian, s_2, second, newton, kilogram,
   m_2, m_3, newton)
-import Language.Drasil (cn, dcc, newUnit, UnitDefn, (/:), (/$), (*:), makeDerU)
+import Language.Drasil (cn, newUnit, UnitDefn, (/:), (/$), (*:), makeDerU, cncpt''', Sentence(..))
+import Drasil.Database (mkUid)
 
 accelU, angVelU, angAccelU, forcePerMeterU, momtInertU, momentOfForceU,
  impulseU, springConstU, torqueU, velU :: UnitDefn
@@ -21,5 +22,5 @@ velU            = newUnit "velocity"             $ metre /: second
 
 gravConstU :: UnitDefn
 
-gravConstU = makeDerU (dcc "gravConstU" (cn "gravitational constant")
-  "universal gravitational constant") (m_3 /$ (kilogram *: s_2))
+gravConstU = makeDerU (cncpt''' (mkUid "gravConstU") (cn "gravitational constant")
+  (S "universal gravitational constant")) (m_3 /$ (kilogram *: s_2))

--- a/code/drasil-data/lib/Data/Drasil/Units/Thermodynamics.hs
+++ b/code/drasil-data/lib/Data/Drasil/Units/Thermodynamics.hs
@@ -1,8 +1,9 @@
 -- | Units related to the field of thermodynamics.
 module Data.Drasil.Units.Thermodynamics where
 
-import Language.Drasil (dccWDS, cnIES, cn, cn', cn'', dcc, Sentence(S),
-  UnitDefn, (/:), (*:), (/$), newUnit, makeDerU)
+import Drasil.Database (mkUid)
+import Language.Drasil (dccWDS, cnIES, cn, cn', cn'', Sentence(S),
+  UnitDefn, (/:), (*:), (/$), newUnit, makeDerU, cncpt''')
 
 import Data.Drasil.SI_Units (centigrade, joule, kilogram, watt, m_2, m_3)
 
@@ -22,5 +23,5 @@ heatTransferCoef :: UnitDefn
 heatTransferCoef = newUnit "heat transfer coefficient" (watt /$ (m_2 *: centigrade))
 
 volHtGenU :: UnitDefn
-volHtGenU = makeDerU (dcc "volHtGenU" (cn "volumetric heat generation")
-  "the rate of heat energy generation per unit volume") (watt /: m_3)
+volHtGenU = makeDerU (cncpt''' (mkUid "volHtGenU") (cn "volumetric heat generation")
+  (S "the rate of heat energy generation per unit volume")) (watt /: m_3)

--- a/code/drasil-example/bss/lib/Drasil/BinaryStar/Concepts.hs
+++ b/code/drasil-example/bss/lib/Drasil/BinaryStar/Concepts.hs
@@ -38,48 +38,48 @@ ccsFortermsAndDefsTbl = [binaryStarSys, starBody, gravInteraction, newtonLUG,
 
 -- | T1: binary star system
 binaryStarSys :: ConceptChunk
-binaryStarSys = dcc "binaryStarSys" (nounPhraseSP "binary star system")
-  "a system consisting of two stars that orbit around their common center of mass due to gravitational interaction"
+binaryStarSys = cncpt''' (mkUid "binaryStarSys") (nounPhraseSP "binary star system")
+  (S "a system consisting of two stars that orbit around their common center of mass due to gravitational interaction")
 
 -- | T2: star
 starBody :: ConceptChunk
-starBody = dcc "starBody" (cn' "star")
-  "a massive astronomical object that is treated as a point mass in this context"
+starBody = cncpt''' (mkUid "starBody") (cn' "star")
+  (S "a massive astronomical object that is treated as a point mass in this context")
 
 -- | T3: gravitational interaction
 gravInteraction :: ConceptChunk
-gravInteraction = dcc "gravInteraction" (nounPhraseSP "gravitational interaction")
-  "the mutual attractive force between two masses as described by Newtonian gravity"
+gravInteraction = cncpt''' (mkUid "gravInteraction") (nounPhraseSP "gravitational interaction")
+  (S "the mutual attractive force between two masses as described by Newtonian gravity")
 
 -- | T3b: Newton's law of universal gravitation
 newtonLUG :: ConceptChunk
-newtonLUG = dcc "newtonLUG" (nounPhraseSP "Newton's law of universal gravitation")
-  "the law stating that every mass attracts every other mass with a force proportional to the product of their masses and inversely proportional to the square of the distance between them"
+newtonLUG = cncpt''' (mkUid "newtonLUG") (nounPhraseSP "Newton's law of universal gravitation")
+  (S "the law stating that every mass attracts every other mass with a force proportional to the product of their masses and inversely proportional to the square of the distance between them")
 
 -- | T4: initial conditions
 initialConditions :: ConceptChunk
-initialConditions = dcc "initialConditions" (nounPhraseSP "initial conditions")
-  "the positions and velocities of the stars at the start of the simulation"
+initialConditions = cncpt''' (mkUid "initialConditions") (nounPhraseSP "initial conditions")
+  (S "the positions and velocities of the stars at the start of the simulation")
 
 -- | T5: trajectory
 trajectory :: ConceptChunk
-trajectory = dcc "trajectory" (cn' "trajectory")
-  "the path traced by a star in space as a function of time"
+trajectory = cncpt''' (mkUid "trajectory") (cn' "trajectory")
+  (S "the path traced by a star in space as a function of time")
 
 -- | T6: center of mass
 centerOfMass :: ConceptChunk
-centerOfMass = dcc "centerOfMass" (nounPhraseSP "center of mass")
-  "the point representing the average position of the mass distribution of the system"
+centerOfMass = cncpt''' (mkUid "centerOfMass") (nounPhraseSP "center of mass")
+  (S "the point representing the average position of the mass distribution of the system")
 
 -- | T7: inertial reference frame
 inertialRefFrame :: ConceptChunk
-inertialRefFrame = dcc "inertialRefFrame" (nounPhraseSP "inertial reference frame")
-  "a reference frame in which Newton's laws of motion are valid without the introduction of fictitious forces"
+inertialRefFrame = cncpt''' (mkUid "inertialRefFrame") (nounPhraseSP "inertial reference frame")
+  (S "a reference frame in which Newton's laws of motion are valid without the introduction of fictitious forces")
 
 -- | T8: simulation time span
 simTimeSpan :: ConceptChunk
-simTimeSpan = dcc "simTimeSpan" (nounPhraseSP "simulation time span")
-  "the duration over which the evolution of the system is computed"
+simTimeSpan = cncpt''' (mkUid "simTimeSpan") (nounPhraseSP "simulation time span")
+  (S "the duration over which the evolution of the system is computed")
 
 ---------------------------------------------------------
 -- Terms reused from drasil-data (already defined)

--- a/code/drasil-example/bss/lib/Drasil/BinaryStar/Unitals.hs
+++ b/code/drasil-example/bss/lib/Drasil/BinaryStar/Unitals.hs
@@ -6,6 +6,7 @@ import Language.Drasil.Display (Symbol(..))
 import Language.Drasil.ShortHands
 import Language.Drasil.Chunk.Concept.NamedCombinators
 import qualified Language.Drasil.Sentence.Combinators as S
+import Drasil.Database(mkUid)
 
 import Data.List.NonEmpty (NonEmpty((:|)))
 import qualified Data.List.NonEmpty as NE
@@ -237,14 +238,14 @@ labely = label "y"
 
 -- | Summation index variable i
 index :: DefinedQuantityDict
-index = dqd' (dcc "index" (nounPhraseSP "index")
-  "a number representing a single body")
+index = dqd' (cncpt''' (mkUid "index") (nounPhraseSP "index")
+  (S "a number representing a single body"))
   (const lI) Integer Nothing
 
 -- | Number of bodies n
 numbBodies :: DefinedQuantityDict
-numbBodies = dqd' (dcc "n" (nounPhraseSP "number of bodies")
-  "the number of point masses in the system")
+numbBodies = dqd' (cncpt''' (mkUid "n") (nounPhraseSP "number of bodies")
+  (S "the number of point masses in the system"))
   (const lN) Integer Nothing
 
 ---------------------------------------------------------

--- a/code/drasil-example/dblpend/lib/Drasil/DblPend/Concepts.hs
+++ b/code/drasil-example/dblpend/lib/Drasil/DblPend/Concepts.hs
@@ -40,4 +40,5 @@ defs :: [ConceptChunk]
 defs = [arcLen]
 
 arcLen :: ConceptChunk
-arcLen = dcc "arc length" (nounPhraseSP "arc length") "the distance between two points on a curve"
+arcLen = cncpt''' (mkUid "arc length") (nounPhraseSP "arc length")
+  (S "the distance between two points on a curve")

--- a/code/drasil-example/gamephysics/lib/Drasil/GamePhysics/Unitals.hs
+++ b/code/drasil-example/gamephysics/lib/Drasil/GamePhysics/Unitals.hs
@@ -16,6 +16,7 @@ import Language.Drasil.Chunk.Concept.NamedCombinators
 import qualified Language.Drasil.Development as D
 import Language.Drasil.Display (Symbol(..), Decoration(Magnitude))
 import Language.Drasil.ShortHands
+import Drasil.Database(mkUid)
 
 import Data.Drasil.SI_Units(kilogram, metre, m_2, newton, second)
 import qualified Data.Drasil.Concepts.Physics as CP (rigidBody)
@@ -303,8 +304,8 @@ unitless :: [DefinedQuantityDict]
 unitless = QM.pi_ : [numParticles]
 
 numParticles :: DefinedQuantityDict
-numParticles = dqdNoUnit (dcc "n" (nounPhraseSP "number of particles in a rigid body")
-  "the number of particles in a rigidbody") lN Integer
+numParticles = dqdNoUnit (cncpt''' (mkUid "n") (nounPhraseSP "number of particles in a rigid body")
+  (S "the number of particles in a rigidbody")) lN Integer
 
 -----------------------
 -- CONSTRAINT CHUNKS --

--- a/code/drasil-example/glassbr/lib/Drasil/GlassBR/Unitals.hs
+++ b/code/drasil-example/glassbr/lib/Drasil/GlassBR/Unitals.hs
@@ -5,6 +5,7 @@ import Language.Drasil.Display (Symbol(..))
 import Language.Drasil.NaturalLanguage.English.NounPhrase.Combinators (parensNP)
 import Language.Drasil.ShortHands
 import Language.Drasil.Chunk.Concept.NamedCombinators
+import Drasil.Database(mkUid)
 
 import Prelude hiding (log)
 import Control.Lens ((^.))
@@ -88,8 +89,8 @@ aspectRatio = uq (constrained' (dqdNoUnit aspectRatioCon (variable "AR") Real)
   [ physRange $ UpFrom (Inc, exactDbl 1),
     sfwrRange $ UpTo (Inc, sy arMax)] (dbl 1.5)) defaultUncrt
 
-pbTol = uq (constrained' (dqdNoUnit (dcc "pbTol" (nounPhraseSP "tolerable probability of breakage")
-  "the tolerable probability of breakage of the glass plate")
+pbTol = uq (constrained' (dqdNoUnit (cncpt''' (mkUid "pbTol") (nounPhraseSP "tolerable probability of breakage")
+  (S "the tolerable probability of breakage of the glass plate"))
   (sub cP (Concat [lBreak, lTol])) Real)
   [probConstr] (dbl 0.008)) (uncty 0.001 Nothing)
 
@@ -99,8 +100,8 @@ charWeight = uqcND "charWeight" (nounPhraseSP "charge weight")
     sfwrRange $ Bounded (Inc, sy cWeightMin) (Inc, sy cWeightMax)]
     (exactDbl 42) defaultUncrt
 
-tNT = uq (constrained' (dqdNoUnit (dcc "tNT" (nounPhraseSP "TNT equivalent factor")
-  "the TNT equivalent factor")
+tNT = uq (constrained' (dqdNoUnit (cncpt''' (mkUid "tNT") (nounPhraseSP "TNT equivalent factor")
+  (S "the TNT equivalent factor"))
   (variable "TNT") Real)
   [ gtZeroConstr ] (exactDbl 1)) defaultUncrt
 
@@ -162,9 +163,9 @@ dimMin     = mkQuantDef (uc' "dimMin"
   (S "the minimum value for one of the dimensions of the glass plate")
   (subMin lD) Real metre) (dbl 0.1)
 
-arMax     = mkQuantDef (dqdNoUnit (dcc "arMax"
+arMax     = mkQuantDef (dqdNoUnit (cncpt''' (mkUid "arMax")
   (nounPhraseSP "maximum aspect ratio")
-  "the maximum aspect ratio")
+  (S "the maximum aspect ratio"))
   (subMax (variable "AR")) Real) (exactDbl 5)
 
 cWeightMax = mkQuantDef (uc' "cWeightMax"
@@ -187,14 +188,14 @@ sdMin     = mkQuantDef (uc' "sdMin"
   (S "the minimum stand off distance permissible for input")
   (subMin (eqSymb standOffDist)) Real metre) (exactDbl 6)
 
-stressDistFacMin = mkQuantDef (dqdNoUnit (dcc "stressDistFacMin"
+stressDistFacMin = mkQuantDef (dqdNoUnit (cncpt''' (mkUid "stressDistFacMin")
   (nounPhraseSP "minimum value for the stress distribution factor")
-  "the minimum value for the stress distribution factor")
+  (S "the minimum value for the stress distribution factor"))
   (subMin (eqSymb stressDistFac)) Real) (exactDbl 1)
 
-stressDistFacMax = mkQuantDef (dqdNoUnit (dcc "stressDistFacMax"
+stressDistFacMax = mkQuantDef (dqdNoUnit (cncpt''' (mkUid "stressDistFacMax")
   (nounPhraseSP "maximum value for the stress distribution factor")
-  "the maximum value for the stress distribution factor")
+  (S "the maximum value for the stress distribution factor"))
   (subMax (eqSymb stressDistFac)) Real) (exactDbl 32)
 
 unitalSymbols :: [UnitalChunk]
@@ -259,36 +260,36 @@ riskFun, isSafePb, isSafeProb, isSafeLR, isSafeLoad, sdfTol,
 
 gTF, loadSF, loadDF :: DefinedQuantityDict
 
-dimlessLoad = dqdNoUnit (dcc "dimlessLoad" (nounPhraseSP "dimensionless load")
-  "the dimensionless load") (hat lQ) Real
+dimlessLoad = dqdNoUnit (cncpt''' (mkUid "dimlessLoad") (nounPhraseSP "dimensionless load")
+  (S "the dimensionless load")) (hat lQ) Real
 
 gTF           = dqdNoUnit glTyFac (variable "GTF") Integer
 
-isSafePb   = dqdNoUnit (dcc "isSafePb" (nounPhraseSP "probability of glass breakage safety requirement")
-  "the probability of glass breakage safety requirement") (variable "isSafePb") Boolean
-isSafeProb = dqdNoUnit (dcc "isSafeProb" (nounPhraseSP "probability of failure safety requirement")
-  "the probability of failure safety requirement") (variable "isSafeProb") Boolean
-isSafeLR   = dqdNoUnit (dcc "isSafeLR"   (nounPhraseSP "3 second load equivalent resistance safety requirement")
-  "the 3 second load equivalent resistance safety requirement") (variable "isSafeLR") Boolean
-isSafeLoad = dqdNoUnit (dcc "isSafeLoad" (nounPhraseSP "load resistance safety requirement")
-  "the load resistance safety requirement") (variable "isSafeLoad") Boolean
+isSafePb   = dqdNoUnit (cncpt''' (mkUid "isSafePb") (nounPhraseSP "probability of glass breakage safety requirement")
+  (S "the probability of glass breakage safety requirement")) (variable "isSafePb") Boolean
+isSafeProb = dqdNoUnit (cncpt''' (mkUid "isSafeProb") (nounPhraseSP "probability of failure safety requirement")
+  (S "the probability of failure safety requirement")) (variable "isSafeProb") Boolean
+isSafeLR   = dqdNoUnit (cncpt''' (mkUid "isSafeLR")   (nounPhraseSP "3 second load equivalent resistance safety requirement")
+  (S "the 3 second load equivalent resistance safety requirement")) (variable "isSafeLR") Boolean
+isSafeLoad = dqdNoUnit (cncpt''' (mkUid "isSafeLoad") (nounPhraseSP "load resistance safety requirement")
+  (S "the load resistance safety requirement")) (variable "isSafeLoad") Boolean
 
-interpY = dqdNoUnit (dcc "interpY" (nounPhraseSP "interpY")
-  "interpolated y") (variable "interpY") (mkFunction [String, Real, Real] Real)
-interpZ = dqdNoUnit (dcc "interpZ" (nounPhraseSP "interpZ")
-  "interpolated z") (variable "interpZ") (mkFunction [String, Real, Real] Real)
+interpY = dqdNoUnit (cncpt''' (mkUid "interpY") (nounPhraseSP "interpY")
+  (S "interpolated y")) (variable "interpY") (mkFunction [String, Real, Real] Real)
+interpZ = dqdNoUnit (cncpt''' (mkUid "interpZ") (nounPhraseSP "interpZ")
+  (S "interpolated z")) (variable "interpZ") (mkFunction [String, Real, Real] Real)
 
 loadDF        = dqdNoUnit loadDurFac (variable "LDF") Real
 loadSF        = dqdNoUnit loadShareFac (variable "LSF") Real
 
-riskFun = dqdNoUnit (dcc "riskFun" (nounPhraseSP "risk of failure")
-  "the percentage risk of the glass slab failing to resist the blast") cB Real
+riskFun = dqdNoUnit (cncpt''' (mkUid "riskFun") (nounPhraseSP "risk of failure")
+  (S "the percentage risk of the glass slab failing to resist the blast")) cB Real
 
-sdfTol = dqdNoUnit (dcc "sdfTol" (nounPhraseSP "tolerable stress distribution factor")
-  "the tolerable stress distribution factor") (sub (eqSymb stressDistFac) lTol) Real
+sdfTol = dqdNoUnit (cncpt''' (mkUid "sdfTol") (nounPhraseSP "tolerable stress distribution factor")
+  (S "the tolerable stress distribution factor")) (sub (eqSymb stressDistFac) lTol) Real
 
-tolLoad = dqdNoUnit (dcc "tolLoad" (nounPhraseSP "tolerable load")
-  "the tolerable load") (sub (eqSymb dimlessLoad) lTol) Real
+tolLoad = dqdNoUnit (cncpt''' (mkUid "tolLoad") (nounPhraseSP "tolerable load")
+  (S "the tolerable load")) (sub (eqSymb dimlessLoad) lTol) Real
 
 lBreak, lDur, lFail, lTol :: Symbol
 lBreak = label "b"

--- a/code/drasil-example/hghc/lib/Drasil/HGHC/HeatTransfer.hs
+++ b/code/drasil-example/hghc/lib/Drasil/HGHC/HeatTransfer.hs
@@ -27,17 +27,17 @@ htInputs = NE.map dqdWr htVars
 htOutputs = NE.map dqdWr qDefs
 
 cladThick, coolFilmCond, gapFilmCond, cladCond :: DefinedQuantityDict
-cladThick    = dqdNoUnit (dcc "cladThick"    (cn''' "clad thickness")
-  "the clad thickness")
+cladThick    = dqdNoUnit (cncpt''' (mkUid "cladThick")    (cn''' "clad thickness")
+  (S "the clad thickness"))
   (sub lTau lClad) Real
-coolFilmCond = dqdNoUnit (dcc "coolFilmCond" (cn' "initial coolant film conductance")
-  "the initial coolant film conductance")
+coolFilmCond = dqdNoUnit (cncpt''' (mkUid "coolFilmCond") (cn' "initial coolant film conductance")
+  (S "the initial coolant film conductance"))
   (sub lH lCoolant) Real
-gapFilmCond  = dqdNoUnit (dcc "gapFilmCond"  (cn' "initial gap film conductance")
-  "the initial gap film conductance")
+gapFilmCond  = dqdNoUnit (cncpt''' (mkUid "gapFilmCond")  (cn' "initial gap film conductance")
+  (S "the initial gap film conductance"))
   (sub lH lGap) Real
-cladCond     = dqdNoUnit (dcc "cladCond"     (cnIES "clad conductivity")
-  "the clad conductivity")
+cladCond     = dqdNoUnit (cncpt''' (mkUid "cladCond")     (cnIES "clad conductivity")
+  (S "the clad conductivity"))
   (sub lK lClad) Real
 
 htTransCladCoolEq, htTransCladFuelEq :: Expr

--- a/code/drasil-example/pdcontroller/lib/Drasil/PDController/Concepts.hs
+++ b/code/drasil-example/pdcontroller/lib/Drasil/PDController/Concepts.hs
@@ -7,7 +7,9 @@ module Drasil.PDController.Concepts (
   secondOrderSystem, summingPt, propGain, derGain, powerPlant, setPoint
 ) where
 
-import Language.Drasil (commonIdeaWithDict, dcc, cn', nounPhraseSP, pn, CI, ConceptChunk)
+import Language.Drasil (commonIdeaWithDict, cn', nounPhraseSP, pn, CI, ConceptChunk,
+  cncpt''', Sentence(..))
+import Drasil.Database (mkUid)
 
 acronyms :: [CI]
 acronyms = [pdControllerCI, proportionalCI, piCI, pidCI]
@@ -24,107 +26,107 @@ pidC, pidCL, summingPt, powerPlant, secondOrderSystem, processError,
       ccLaplaceTransform, controlVariable, stepTime, ccAbsTolerance,
       ccRelTolerance, ccTransferFxn, ccDampingCoeff, ccStiffCoeff :: ConceptChunk
 pidCL
-  = dcc "pdCtrlLoop" (nounPhraseSP "PD Control Loop") ("Closed-Loop control " ++
-        "system with PD Controller, Summing Point and Power Plant")
+  = cncpt''' (mkUid "pdCtrlLoop") (nounPhraseSP "PD Control Loop") (S ("Closed-Loop control " ++
+        "system with PD Controller, Summing Point and Power Plant"))
 
 pidC
-  = dcc "pdController" (nounPhraseSP "PD Controller")
-        "Proportional-Derivative Controller"
+  = cncpt''' (mkUid "pdController") (nounPhraseSP "PD Controller")
+        (S "Proportional-Derivative Controller")
 
 summingPt
-  = dcc "summingPoint" (nounPhraseSP "Summing Point") ("Control block where " ++
+  = cncpt''' (mkUid "summingPoint") (nounPhraseSP "Summing Point") (S ("Control block where " ++
         "the difference between the Set-Point and the Process Variable " ++
-        "is computed")
+        "is computed"))
 
 powerPlant
-  = dcc "powerPlant" (nounPhraseSP "Power Plant")
-      "A second order system to be controlled"
+  = cncpt''' (mkUid "powerPlant") (nounPhraseSP "Power Plant")
+      (S "A second order system to be controlled")
 
 secondOrderSystem
-  = dcc "secondOrderSystem" (nounPhraseSP "Second Order System")
-      ("A system whose input-output relationship is denoted by a second-order "
-         ++ "differential equation")
+  = cncpt''' (mkUid "secondOrderSystem") (nounPhraseSP "Second Order System")
+      (S ("A system whose input-output relationship is denoted by a second-order "
+         ++ "differential equation"))
 
 processError
-  = dcc "processError" (nounPhraseSP "Process Error")
-      ("Input to the PID controller. Process Error is the difference between the "
-         ++ "Set-Point and the Process Variable")
+  = cncpt''' (mkUid "processError") (nounPhraseSP "Process Error")
+      (S ("Input to the PID controller. Process Error is the difference between the "
+         ++ "Set-Point and the Process Variable"))
 
-stepTime = dcc "stepTime" (nounPhraseSP "Step Time") "Simulation step time"
+stepTime = cncpt''' (mkUid "stepTime") (nounPhraseSP "Step Time") (S "Simulation step time")
 
 simulationTime
-  = dcc "simulationTime" (nounPhraseSP "Simulation Time")
-      "Total execution time of the PD simulation"
+  = cncpt''' (mkUid "simulationTime") (nounPhraseSP "Simulation Time")
+      (S "Total execution time of the PD simulation")
 
 processVariable
-  = dcc "processVariable" (nounPhraseSP "Process Variable")
-      "The output value from the power plant"
+  = cncpt''' (mkUid "processVariable") (nounPhraseSP "Process Variable")
+      (S "The output value from the power plant")
 
 controlVariable
-  = dcc "controlVariable" (nounPhraseSP "Control Variable")
-      "The Control Variable is the output of the PD controller"
+  = cncpt''' (mkUid "controlVariable") (nounPhraseSP "Control Variable")
+      (S "The Control Variable is the output of the PD controller")
 
 setPoint
-  = dcc "setPoint" (nounPhraseSP "Set-Point")
-      ("The desired value that the control system must reach. This also knows "
-         ++ "as the reference variable")
+  = cncpt''' (mkUid "setPoint") (nounPhraseSP "Set-Point")
+      (S ("The desired value that the control system must reach. This also knows "
+         ++ "as the reference variable"))
 
 propGain
-  = dcc "propGain" (nounPhraseSP "Proportional Gain")
-      "Gain constant of the proportional controller"
+  = cncpt''' (mkUid "propGain") (nounPhraseSP "Proportional Gain")
+      (S "Gain constant of the proportional controller")
 
 derGain
-  = dcc "derGain" (nounPhraseSP "Derivative Gain")
-      "Gain constant of the derivative controller"
+  = cncpt''' (mkUid "derGain") (nounPhraseSP "Derivative Gain")
+      (S "Gain constant of the derivative controller")
 
 propControl
-  = dcc "propControl" (nounPhraseSP "Proportional control")
-      ("A linear feedback control system where correction is applied to the controlled " ++
-      "variable which is proportional to the difference between desired and measured values")
+  = cncpt''' (mkUid "propControl") (nounPhraseSP "Proportional control")
+      (S ("A linear feedback control system where correction is applied to the controlled " ++
+      "variable which is proportional to the difference between desired and measured values"))
 
 derControl
-  = dcc "derControl" (nounPhraseSP "Derivative control")
-      ("Monitors the rate of change of the error signal and contributes a component " ++
-      "of the output signal (proportional to a derivative of the error signal)")
+  = cncpt''' (mkUid "derControl") (nounPhraseSP "Derivative control")
+      (S ("Monitors the rate of change of the error signal and contributes a component " ++
+      "of the output signal (proportional to a derivative of the error signal)"))
 
 simulation
-  = dcc "simulation" (cn' "simulation")
-      "Simulation of the PD controller"
+  = cncpt''' (mkUid "simulation") (cn' "simulation")
+      (S "Simulation of the PD controller")
 
 ccFrequencyDomain
-  = dcc "frequencyDomain" (nounPhraseSP "frequency domain")
-      ("The analysis of mathematical functions in terms of frequency, instead "
-         ++ "of time")
+  = cncpt''' (mkUid "frequencyDomain") (nounPhraseSP "frequency domain")
+      (S ("The analysis of mathematical functions in terms of frequency, instead "
+         ++ "of time"))
 
 ccTimeDomain
-  = dcc "timeDomain" (nounPhraseSP "time domain")
-      "The analysis of mathematical functions in terms of time"
+  = cncpt''' (mkUid "timeDomain") (nounPhraseSP "time domain")
+      (S "The analysis of mathematical functions in terms of time")
 
 ccLaplaceTransform
-  = dcc "laplaceTransform" (cn' "Laplace transform")
-      ("An integral transform that converts a function of a real variable t " ++
-         "(often time) to a function of a complex variable s (complex frequency)")
+  = cncpt''' (mkUid "laplaceTransform") (cn' "Laplace transform")
+      (S ("An integral transform that converts a function of a real variable t " ++
+         "(often time) to a function of a complex variable s (complex frequency)"))
 
 ccAbsTolerance
-  = dcc "absoluteTolerance" (nounPhraseSP "Absolute Tolerance")
-      "Absolute tolerance for the integrator"
+  = cncpt''' (mkUid "absoluteTolerance") (nounPhraseSP "Absolute Tolerance")
+      (S "Absolute tolerance for the integrator")
 
 ccRelTolerance
-  = dcc "relativeTolerance" (nounPhraseSP "Relative Tolerance")
-      "Relative tolerance for the integrator"
+  = cncpt''' (mkUid "relativeTolerance") (nounPhraseSP "Relative Tolerance")
+      (S "Relative tolerance for the integrator")
 
 ccTransferFxn
-  = dcc "transferFxn" (nounPhraseSP "Transfer Function")
-      ("The Transfer Function of a system is the ratio of the output to the input"
-         ++ " functions in the frequency domain")
+  = cncpt''' (mkUid "transferFxn") (nounPhraseSP "Transfer Function")
+      (S ("The Transfer Function of a system is the ratio of the output to the input"
+         ++ " functions in the frequency domain"))
 
 ccDampingCoeff
-  = dcc "dampingCoeff" (nounPhraseSP "Damping Coefficient")
-      "Quantity that characterizes a second order system's oscillatory response"
+  = cncpt''' (mkUid "dampingCoeff") (nounPhraseSP "Damping Coefficient")
+      (S "Quantity that characterizes a second order system's oscillatory response")
 
 ccStiffCoeff
-  = dcc "ccStiffnessCoeff" (nounPhraseSP "Stiffness coefficient")
-      "Quantity that characterizes a spring's stiffness"
+  = cncpt''' (mkUid "ccStiffnessCoeff") (nounPhraseSP "Stiffness coefficient")
+      (S "Quantity that characterizes a spring's stiffness")
 
 defs :: [ConceptChunk]
 defs

--- a/code/drasil-example/pdcontroller/lib/Drasil/PDController/Unitals.hs
+++ b/code/drasil-example/pdcontroller/lib/Drasil/PDController/Unitals.hs
@@ -13,6 +13,7 @@ module Drasil.PDController.Unitals (
 import Data.List.NonEmpty (NonEmpty((:|)))
 import qualified Data.List.NonEmpty as NE
 
+import Drasil.Database (mkUid)
 import Data.Drasil.Constraints (gtZeroConstr)
 import Data.Drasil.SI_Units (second)
 import Language.Drasil
@@ -131,52 +132,52 @@ opProcessVariable
 dqdProcessVariableTD = dqdWr opProcessVariable
 
 dqdSetPointFD
-  = dqdNoUnit (dcc "dqdSetPointFD" (setPoint `inThe` ccFrequencyDomain)
-    "the set point in the frequency domain") symYrS Real
+  = dqdNoUnit (cncpt''' (mkUid "dqdSetPointFD") (setPoint `inThe` ccFrequencyDomain)
+    (S "the set point in the frequency domain")) symYrS Real
 
-dqdProcessVariableFD = dqdNoUnit (dcc "dqdProcessVariableFD"
-  (processVariable `inThe` ccFrequencyDomain) "the process variable in the frequency domain") symYS Real
+dqdProcessVariableFD = dqdNoUnit (cncpt''' (mkUid "dqdProcessVariableFD")
+  (processVariable `inThe` ccFrequencyDomain) (S "the process variable in the frequency domain")) symYS Real
 
-dqdProcessErrorFD = dqdNoUnit (dcc "dqdProcessErrorFD" (processError `inThe`
-  ccFrequencyDomain) "the process error in the time domain") symES Real
+dqdProcessErrorFD = dqdNoUnit (cncpt''' (mkUid "dqdProcessErrorFD") (processError `inThe`
+  ccFrequencyDomain) (S "the process error in the time domain")) symES Real
 
-dqdPropControlFD  = dqdNoUnit (dcc "dqdPropControlFD" (propControl `inThe`
-  ccFrequencyDomain) "the proportional control in the frequency domain") symPS Real
+dqdPropControlFD  = dqdNoUnit (cncpt''' (mkUid "dqdPropControlFD") (propControl `inThe`
+  ccFrequencyDomain) (S "the proportional control in the frequency domain")) symPS Real
 
-dqdDerivativeControlFD = dqdNoUnit (dcc "dqdDerivativeControlFD" (derControl `inThe`
-  ccFrequencyDomain) "the derivative control in the frequency domain") symDS Real
+dqdDerivativeControlFD = dqdNoUnit (cncpt''' (mkUid "dqdDerivativeControlFD") (derControl `inThe`
+  ccFrequencyDomain) (S "the derivative control in the frequency domain")) symDS Real
 
-dqdCtrlVarFD = dqdNoUnit (dcc "dqdCtrlVarFD" (controlVariable `inThe`
-  ccFrequencyDomain) "the control variable in the frequency domain") symCS Real
+dqdCtrlVarFD = dqdNoUnit (cncpt''' (mkUid "dqdCtrlVarFD") (controlVariable `inThe`
+  ccFrequencyDomain) (S "the control variable in the frequency domain")) symCS Real
 
 dqdLaplaceTransform
-  = dqdNoUnit (dcc "dqdLaplaceTransform"
+  = dqdNoUnit (cncpt''' (mkUid "dqdLaplaceTransform")
       (pn "Laplace Transform of a function")
-      "the laplace transform of a function")
+      (S "the laplace transform of a function"))
       symFS
       Real
 
 dqdFreqDomain
-  = dqdNoUnit (dcc "dqdFreqDomain" (pn "Complex frequency-domain parameter")
-      "the complex frequency-domain parameter")
+  = dqdNoUnit (cncpt''' (mkUid "dqdFreqDomain") (pn "Complex frequency-domain parameter")
+      (S "the complex frequency-domain parameter"))
       syms
       Real
 
 dqdFxnTDomain
-  = dqdNoUnit (dcc "dqdFxnTDomain" (pn "Function in the time domain")
-      "a function in the time domain") symFt
+  = dqdNoUnit (cncpt''' (mkUid "dqdFxnTDomain") (pn "Function in the time domain")
+      (S "a function in the time domain")) symFt
       Real
 
 dqdInvLaplaceTransform
-  = dqdNoUnit (dcc "dqdInvLaplaceTransform"
+  = dqdNoUnit (cncpt''' (mkUid "dqdInvLaplaceTransform")
       (pn "Inverse Laplace Transform of a function")
-      "the inverse Laplace transform of a function")
+      (S "the inverse Laplace transform of a function"))
       syminvLaplace
       Real
 
 dqdDampingCoeff
-  = dqdNoUnit (dcc "dqdDampingCoeff" (pn "Damping coefficient of the spring")
-      "the damping coefficient of the spring")
+  = dqdNoUnit (cncpt''' (mkUid "dqdDampingCoeff") (pn "Damping coefficient of the spring")
+      (S "the damping coefficient of the spring"))
       symDampingCoeff
       Real
 

--- a/code/drasil-example/ssp/lib/Drasil/SSP/Defs.hs
+++ b/code/drasil-example/ssp/lib/Drasil/SSP/Defs.hs
@@ -93,8 +93,8 @@ fsConcept = dccWDS "FS" factorOfSafety
 -- OLD DEFN: Stability metric. How likely a slip surface is to
 -- experience failure through slipping.
 
-waterTable = dcc "water table" (cn' "water table") ("The upper boundary of a" ++
-  " saturated zone in the ground")
+waterTable = cncpt''' (mkUid "water table") (cn' "water table") (S ("The upper boundary of a" ++
+  " saturated zone in the ground"))
 
 --
 factor :: IdeaDict --FIXME: this is here becuase this phrase is
@@ -112,5 +112,7 @@ maxim = idea' (mkUid "maximum") (cn' "maximum")
 
 -- Some sentences want plurals (because of arrays) of things that are normally singular.
 xCoords, yCoords :: ConceptChunk
-xCoords = dcc "xCoords" (nounPhraseSent $ D.P lX D.:-: D.S "-coordinates") "the location of the points on the x-axis"
-yCoords = dcc "yCoords" (nounPhraseSent $ D.P lY D.:-: D.S "-coordinates") "the location of the points on the y-axis"
+xCoords = cncpt''' (mkUid "xCoords") (nounPhraseSent $ D.P lX D.:-: D.S "-coordinates")
+  (S "the location of the points on the x-axis")
+yCoords = cncpt''' (mkUid "yCoords") (nounPhraseSent $ D.P lY D.:-: D.S "-coordinates")
+  (S "the location of the points on the y-axis")

--- a/code/drasil-example/ssp/lib/Drasil/SSP/Unitals.hs
+++ b/code/drasil-example/ssp/lib/Drasil/SSP/Unitals.hs
@@ -12,6 +12,7 @@ import qualified Language.Drasil.Development as D
 import qualified Language.Drasil.NaturalLanguage.English.NounPhrase.Combinators as NP
 import qualified Language.Drasil.Sentence.Combinators as S
 
+import Drasil.Database (mkUid)
 import Drasil.SSP.Defs (fsConcept,slpSrf,minim,maxim,waterTable,slope,xCoords,yCoords)
 
 import Data.Drasil.Constraints (gtZeroConstr)
@@ -168,9 +169,9 @@ waterWeight = uqc "gamma_w" (cn "unit weight of water")
   (exactDbl 9800) defaultUncrt
 
 constF :: DefinedQuantityDict
-constF = dqd' (dcc "const_f" (nounPhraseSP "decision on f")
-  ("a Boolean decision on which form of f the user desires: constant if true," ++
-  " or half-sine if false")) (const (variable "const_f")) Boolean Nothing
+constF = dqd' (cncpt''' (mkUid "const_f") (nounPhraseSP "decision on f")
+  (S ("a Boolean decision on which form of f the user desires: constant if true," ++
+  " or half-sine if false"))) (const (variable "const_f")) Boolean Nothing
 
 {-Output Variables-} --FIXME: See if there should be typical values
 fs, coords :: ConstrConcept
@@ -178,8 +179,8 @@ fs = constrained' (dqd' fsConcept (const $ sub cF lSafety) Real Nothing)
   [gtZeroConstr] (exactDbl 1)
 
 fsMin :: DefinedQuantityDict -- This is a hack to remove the use of indexing for 'min'.
-fsMin = dqd' (dcc "fsMin" (cn "minimum factor of safety")
-  "the minimum factor of safety associated with the critical slip surface")
+fsMin = dqd' (cncpt''' (mkUid "fsMin") (cn "minimum factor of safety")
+  (S "the minimum factor of safety associated with the critical slip surface"))
   (const $ supMin (eqSymb fs)) Real Nothing
 -- Once things are converted to the new style of instance models, this will
 -- be removed/fixed.
@@ -447,13 +448,13 @@ unitless = [earthqkLoadFctr, normToShear, scalFunc, numbSlices, minFunction,
 earthqkLoadFctr, normToShear, scalFunc, numbSlices,
   minFunction, mobShrC, shrResC, index, varblV :: DefinedQuantityDict
 
-earthqkLoadFctr = dqd' (dcc "K_c" (nounPhraseSP "seismic coefficient")
-  ("the proportionality factor of force that weight pushes outwards; " ++
-   "caused by seismic earth movements"))
+earthqkLoadFctr = dqd' (cncpt''' (mkUid "K_c") (nounPhraseSP "seismic coefficient")
+  (S ("the proportionality factor of force that weight pushes outwards; " ++
+   "caused by seismic earth movements")))
   (const $ sub cK lCoeff) Real Nothing
 
-normToShear = dqd' (dcc "lambda" (nounPhraseSP "proportionality constant")
-  "the ratio of the interslice normal to the interslice shear force")
+normToShear = dqd' (cncpt''' (mkUid "lambda") (nounPhraseSP "proportionality constant")
+  (S "the ratio of the interslice normal to the interslice shear force"))
   (const lLambda) Real Nothing
 
 scalFunc = dqd' (dccWDS "f_i"
@@ -463,38 +464,38 @@ scalFunc = dqd' (dccWDS "f_i"
   (const (vec lF)) Real Nothing
 
 -- As we're going to subtract from this, can't type it 'Natural'.
-numbSlices = dqd' (dcc "n" (nounPhraseSP "number of slices")
-  "the number of slices into which the slip surface is divided")
+numbSlices = dqd' (cncpt''' (mkUid "n") (nounPhraseSP "number of slices")
+  (S "the number of slices into which the slip surface is divided"))
   (const lN) Integer Nothing
 
 -- horrible hack, but it's only used once, so...
-minFunction = dqd' (dcc "Upsilon" (nounPhraseSP "minimization function")
-  "generic minimization function or algorithm")
+minFunction = dqd' (cncpt''' (mkUid "Upsilon") (nounPhraseSP "minimization function")
+  (S "generic minimization function or algorithm"))
   (const cUpsilon) (mkFunction (replicate 10 Real) Real) Nothing
 
-mobShrC = dqd' (dcc "Psi"
+mobShrC = dqd' (cncpt''' (mkUid "Psi")
   (nounPhraseSP "second function for incorporating interslice forces into shear force")
-  ("the function for converting mobile shear " ++ wiif ++
-   ", to a calculation considering the interslice forces"))
+  (S ("the function for converting mobile shear " ++ wiif ++
+   ", to a calculation considering the interslice forces")))
   (const (vec cPsi)) (Vect Real) Nothing
 
-shrResC = dqd' (dcc "Phi"
+shrResC = dqd' (cncpt''' (mkUid "Phi")
   (nounPhraseSP "first function for incorporating interslice forces into shear force")
-  ("the function for converting resistive shear " ++ wiif ++
-   ", to a calculation considering the interslice forces"))
+  (S ("the function for converting resistive shear " ++ wiif ++
+   ", to a calculation considering the interslice forces")))
   (const (vec cPhi)) (Vect Real) Nothing
 
 --------------------
 -- Index Function --
 --------------------
 
-varblV = dqd' (dcc "varblV" (nounPhraseSP "local index")
-  "used as a bound variable index in calculations")
+varblV = dqd' (cncpt''' (mkUid "varblV") (nounPhraseSP "local index")
+  (S "used as a bound variable index in calculations"))
   (const lV) Natural Nothing
 
 -- As we do arithmetic on index, must type it 'Integer' right now
-index = dqd' (dcc "index" (nounPhraseSP "index")
-  "a number representing a single slice")
+index = dqd' (cncpt''' (mkUid "index") (nounPhraseSP "index")
+  (S "a number representing a single slice"))
   (const lI) Integer Nothing
 
 -- FIXME: move to drasil-lang

--- a/code/drasil-example/swhs/lib/Drasil/SWHS/Concepts.hs
+++ b/code/drasil-example/swhs/lib/Drasil/SWHS/Concepts.hs
@@ -8,6 +8,8 @@ import Control.Lens ((^.))
 import Language.Drasil
 import qualified Language.Drasil.NaturalLanguage.English.NounPhrase.Combinators as NP
 
+import Drasil.Database (mkUid)
+
 import Data.Drasil.Concepts.Math (parameter)
 import Data.Drasil.Domains (materialEng)
 
@@ -26,40 +28,40 @@ charging, coil, discharging, gaussDiv,
   perfectInsul, phaseChangeMaterial, tank,
   tankPCM, transient, water, sWHT, tankParam :: ConceptChunk
 
-charging = dcc "charging" (nounPhraseSP "charging") "charging of the tank"
+charging = cncpt''' (mkUid "charging") (nounPhraseSP "charging") (S "charging of the tank")
 
-coil = dcc "coil" (cn' "heating coil")
-  "coil in tank that heats by absorbing solar energy"
+coil = cncpt''' (mkUid "coil") (cn' "heating coil")
+  (S "coil in tank that heats by absorbing solar energy")
 
-discharging = dcc "discharging" (nounPhraseSP "discharging")
-  "discharging of the tank"
+discharging = cncpt''' (mkUid "discharging") (nounPhraseSP "discharging")
+  (S "discharging of the tank")
 
-transient = dcc "transient" (nounPhraseSP "transient") "changing with time"
+transient = cncpt''' (mkUid "transient") (nounPhraseSP "transient") (S "changing with time")
 
-gaussDiv = dcc "gaussDiv" (nounPhraseSP "gauss's divergence theorem")
-  ("a result that relates the flow of a vector field through a surface" ++
-  "to the behavior of the vector field inside the surface")
+gaussDiv = cncpt''' (mkUid "gaussDiv") (nounPhraseSP "gauss's divergence theorem")
+  (S ("a result that relates the flow of a vector field through a surface" ++
+  "to the behavior of the vector field inside the surface"))
 --TODO: Physical property.
 
-perfectInsul = dcc "perfectInsul" (nounPhraseSP "perfectly insulated")
-  ("describes the property of a material not allowing" ++
-  "heat transfer through its boundaries")
+perfectInsul = cncpt''' (mkUid "perfectInsul") (nounPhraseSP "perfectly insulated")
+  (S ("describes the property of a material not allowing" ++
+  "heat transfer through its boundaries"))
 
-phaseChangeMaterial = dcc "pcm" (phsChgMtrl ^. term)
-  ("a substance that uses phase changes (such as melting) to absorb or " ++
-  "release large amounts of heat at a constant temperature")
+phaseChangeMaterial = cncpt''' (mkUid "pcm") (phsChgMtrl ^. term)
+  (S ("a substance that uses phase changes (such as melting) to absorb or " ++
+  "release large amounts of heat at a constant temperature"))
 
-tankParam = dcc "tankParam" (compoundPhrase' (tank ^. term)
+tankParam = cncpt''' (mkUid "tankParam") (compoundPhrase' (tank ^. term)
   (parameter ^. term))
-  "values associated with the tank"
+  (S "values associated with the tank")
 
-tank  = dcc "tank"  (cn' "tank") "enclosure containing some kind of substance"
-sWHT  = dcc "sWHT"  (cn' "solar water heating tank") "solar water heating tank"
-water = dcc "water" (cn' "water") "the liquid with which the tank is filled"
+tank  = cncpt''' (mkUid "tank")  (cn' "tank") (S "enclosure containing some kind of substance")
+sWHT  = cncpt''' (mkUid "sWHT")  (cn' "solar water heating tank") (S "solar water heating tank")
+water = cncpt''' (mkUid "water") (cn' "water") (S "the liquid with which the tank is filled")
 
 -- TODO: extract 'PCM' from 'phsChgMtrl' again instead of hard-coding it
-tankPCM = dcc "tankPCM" (nounPhrase''
+tankPCM = cncpt''' (mkUid "tankPCM") (nounPhrase''
   (phraseNP (sWHT ^. term) NP.:+: NP.S "incorporating PCM")
   (phraseNP (sWHT ^. term) NP.:+: NP.S "incorporating PCM")
   CapFirst CapWords)
-  "solar water heating tank incorporating phase change material"
+  (S "solar water heating tank incorporating phase change material")

--- a/code/drasil-example/swhs/lib/Drasil/SWHS/Concepts.hs
+++ b/code/drasil-example/swhs/lib/Drasil/SWHS/Concepts.hs
@@ -9,8 +9,6 @@ import Drasil.Database (mkUid)
 import Language.Drasil
 import qualified Language.Drasil.NaturalLanguage.English.NounPhrase.Combinators as NP
 
-import Drasil.Database (mkUid)
-
 import Data.Drasil.Concepts.Math (parameter)
 import Data.Drasil.Domains (materialEng)
 

--- a/code/drasil-example/swhs/lib/Drasil/SWHS/Unitals.hs
+++ b/code/drasil-example/swhs/lib/Drasil/SWHS/Unitals.hs
@@ -19,6 +19,7 @@ import Data.Drasil.Units.PhysicalProperties (densityU)
 import qualified Data.Drasil.Units.Thermodynamics as UT (heatTransferCoef,
   heatCapSpec, thermalFlux, volHtGenU)
 
+import Drasil.Database (mkUid)
 import Drasil.SWHS.Concepts (water, phsChgMtrl)
 
 import Control.Lens ((^.))
@@ -201,36 +202,36 @@ unitless = [uNormalVect, dqdWr surface, eta, meltFrac, gradient, fracMin, consTo
 eta, meltFrac, fracMin, consTol, aspectRatio, aspectRatioMin, aspectRatioMax :: DefinedQuantityDict
 
 -- FIXME: should this have units?
-eta = dqd' (dcc "eta" (nounPhraseSP "ODE parameter related to decay rate")
-  "derived parameter based on rate of change of temperature of water")
+eta = dqd' (cncpt''' (mkUid "eta") (nounPhraseSP "ODE parameter related to decay rate")
+  (S "derived parameter based on rate of change of temperature of water"))
   (const lEta) Real Nothing
 
-meltFrac = dqd' (dcc "meltFrac" (nounPhraseSP "melt fraction")
-  "ratio of thermal energy to amount of mass melted")
+meltFrac = dqd' (cncpt''' (mkUid "meltFrac") (nounPhraseSP "melt fraction")
+  (S "ratio of thermal energy to amount of mass melted"))
   --FIXME: Not sure if definition is exactly correct
   (const lPhi) Real Nothing
 
-fracMin = dqd' (dcc "fracMin"
+fracMin = dqd' (cncpt''' (mkUid "fracMin")
   (nounPhraseSP "minimum fraction of the tank volume taken up by the PCM")
-  "minimum fraction of the tank volume taken up by the PCM")
+  (S "minimum fraction of the tank volume taken up by the PCM"))
    (const $ variable "MINFRACT") Real Nothing
 
-consTol = dqd' (dcc "consTol"
+consTol = dqd' (cncpt''' (mkUid "consTol")
   (nounPhraseSP "relative tolerance for conservation of energy")
-  "relative tolerance for conservation of energy")
+  (S "relative tolerance for conservation of energy"))
   (const $ sub cC lTol) Real Nothing
 
-aspectRatio = dqd' (dcc "aspectRatio"
+aspectRatio = dqd' (cncpt''' (mkUid "aspectRatio")
   (nounPhraseSP "aspect ratio")
-  "ratio of tank diameter to tank length")
+  (S "ratio of tank diameter to tank length"))
    (const $ variable "AR") Real Nothing
 
-aspectRatioMin = dqd' (dcc "aspectRatioMin"
-  (nounPhraseSP "minimum aspect ratio") "minimum aspect ratio")
+aspectRatioMin = dqd' (cncpt''' (mkUid "aspectRatioMin")
+  (nounPhraseSP "minimum aspect ratio") (S"minimum aspect ratio"))
    (const $ subMin (eqSymb aspectRatio)) Real Nothing
 
-aspectRatioMax = dqd' (dcc "aspectRatioMax"
-  (nounPhraseSP "maximum aspect ratio") "maximum aspect ratio")
+aspectRatioMax = dqd' (cncpt''' (mkUid "aspectRatioMax")
+  (nounPhraseSP "maximum aspect ratio") (S "maximum aspect ratio"))
    (const $ subMax (eqSymb aspectRatio)) Real Nothing
 
 -----------------
@@ -434,13 +435,13 @@ pcmE = cuc' "pcmE" (nounPhraseSP "change in heat energy in the PCM")
 
 absTol, relTol :: UncertQ
 
-absTol = uq (constrained' (dqdNoUnit (dcc "absTol" (nounPhraseSP "absolute tolerance")
-  "the absolute tolerance") (sub cA lTol) Real)
+absTol = uq (constrained' (dqdNoUnit (cncpt''' (mkUid "absTol") (nounPhraseSP "absolute tolerance")
+  (S "the absolute tolerance")) (sub cA lTol) Real)
   [physRange $ Bounded (Exc, exactDbl 0) (Exc, exactDbl 1)]
    (dbl (10.0**(-10)))) (uncty 0.01 Nothing)
 
-relTol = uq (constrained' (dqdNoUnit (dcc "relTol" (nounPhraseSP "relative tolerance")
-  "the relative tolerance") (sub cR lTol) Real)
+relTol = uq (constrained' (dqdNoUnit (cncpt''' (mkUid "relTol") (nounPhraseSP "relative tolerance")
+  (S "the relative tolerance")) (sub cR lTol) Real)
   [physRange $ Bounded (Exc, exactDbl 0) (Exc, exactDbl 1)]
   (dbl (10.0**(-10)))) (uncty 0.01 Nothing)
 

--- a/code/drasil-example/template/lib/Drasil/Template/Body.hs
+++ b/code/drasil-example/template/lib/Drasil/Template/Body.hs
@@ -8,7 +8,7 @@ module Drasil.Template.Body (mkSRS, si) where
 import Data.List.NonEmpty (NonEmpty((:|)))
 import qualified Data.List.NonEmpty as NE
 
-import Drasil.Database (ChunkDB)
+import Drasil.Database (ChunkDB, mkUid)
 import Drasil.System (SmithEtAlSRS, mkSmithEtAlICO)
 import Language.Drasil
 import Language.Drasil.Document
@@ -83,13 +83,13 @@ outputs :: NE.NonEmpty DefinedQuantityDict
 outputs = NE.singleton (dqdWr t1)
 
 t0 :: UnitalChunk
-t0 = uc (dcc "t0" (cn' "start time") "the start time") (sub lT (Integ 0)) Real second
+t0 = uc (cncpt''' (mkUid "t0") (cn' "start time") (S "the start time")) (sub lT (Integ 0)) Real second
 
 t1 :: UnitalChunk
-t1 = uc (dcc "t1" (cn' "end time") "the end time") (sub lT (Integ 1)) Real second
+t1 = uc (cncpt''' (mkUid "t1") (cn' "end time") (S "the end time")) (sub lT (Integ 1)) Real second
 
 dt :: UnitalChunk
-dt = uc (dcc "dt" (cn' "time delta") "the time delta") (Atop Delta lT) Real second
+dt = uc (cncpt''' (mkUid "dt") (cn' "time delta") (S "the time delta")) (Atop Delta lT) Real second
 
 inputValues :: ConceptInstance
 inputValuesTable :: LabelledContent

--- a/code/drasil-lang/lib/Language/Drasil.hs
+++ b/code/drasil-lang/lib/Language/Drasil.hs
@@ -80,7 +80,7 @@ module Language.Drasil (
   -- Language.Drasil.Chunk.Concept.Core
   , ConceptChunk, ConceptInstance, sDom
   -- Language.Drasil.Chunk.Concept
-  , cncpt, cncpt', cncpt'', cncpt''', dcc, dccAWDS, dccA, dccWDS, cw, cic
+  , cncpt, cncpt', cncpt'', cncpt''', dccAWDS, dccA, dccWDS, cw, cic
 
   -- *** Quantities and Units
   -- Language.Drasil.Chunk.Eq

--- a/code/drasil-lang/lib/Language/Drasil/Chunk/Concept.hs
+++ b/code/drasil-lang/lib/Language/Drasil/Chunk/Concept.hs
@@ -4,7 +4,7 @@ module Language.Drasil.Chunk.Concept (
   -- * Concept Chunks
   -- ** From an idea ('IdeaDict')
   ConceptChunk, cncpt, cncpt', cncpt'', cncpt''',
-  dcc, dccA, dccAWDS, dccWDS, cw,
+  dccA, dccAWDS, dccWDS, cw,
   -- ** From a 'ConceptChunk'
   ConceptInstance, cic
   ) where
@@ -74,7 +74,7 @@ cncpt''' ::
   Sentence -> ConceptChunk
 cncpt''' u trm defn = ConDict (idea' u trm) defn []
 
-{-# DEPRECATED dccA, dccAWDS, dcc, dccWDS
+{-# DEPRECATED dccA, dccAWDS, dccWDS
   "Old smart constructor; use one of `cncpt`, `cncpt'`, `cncpt''`, `cncpt'''` instead." #-}
 
 -- | Smart constructor for creating a concept chunks with an abbreviation. Takes
@@ -91,11 +91,6 @@ dccAWDS i ter def a = ConDict ideaDict def []
   where
     u = mkUid i
     ideaDict = maybe (idea' u ter) (idea u ter) a
-
--- | Smart constructor for creating concept chunks given a 'UID', 'NounPhrase'
--- ('NP') and definition (as a 'String').
-dcc :: String -> NP -> String -> ConceptChunk
-dcc i ter des = dccA i ter des Nothing
 
 -- | Similar to 'dcc', except the definition takes a 'Sentence'.
 dccWDS :: String -> NP -> Sentence -> ConceptChunk

--- a/code/drasil-lang/lib/Language/Drasil/Chunk/Constrained.hs
+++ b/code/drasil-lang/lib/Language/Drasil/Chunk/Constrained.hs
@@ -8,9 +8,9 @@ module Language.Drasil.Chunk.Constrained (
 
 import Control.Lens ((^.), makeLenses, view)
 
-import Drasil.Database (HasUID(..), HasChunkRefs(..))
+import Drasil.Database (HasUID(..), HasChunkRefs(..), mkUid)
 
-import Language.Drasil.Chunk.Concept (dcc, dccWDS)
+import Language.Drasil.Chunk.Concept (dccWDS, cncpt''')
 import Language.Drasil.Chunk.Unital (uc')
 import Language.Drasil.Chunk.DefinedQuantity (DefinedQuantityDict, dqd', dqdWr, dqdNoUnit)
 import Language.Drasil.Symbol (HasSymbol(..), Symbol)
@@ -103,7 +103,7 @@ cucNoUnit' nam trm desc sym space cs rv =
 cuc'' :: (IsUnit u) => String -> NP -> String -> (Stage -> Symbol) -> u
             -> Space -> [ConstraintE] -> Expr -> ConstrConcept
 cuc'' nam trm desc sym un space cs rv =
-  ConstrConcept (dqd' (dcc nam trm desc) sym space (Just uu)) cs (Just rv) Nothing
+  ConstrConcept (dqd' (cncpt''' (mkUid nam) trm (S desc)) sym space (Just uu)) cs (Just rv) Nothing
   where uu = unitWrapper un
 
 -- | Similar to 'cnstrw', but types must also have a 'Concept'.

--- a/code/drasil-lang/lib/Language/Drasil/Chunk/DefinedQuantity.hs
+++ b/code/drasil-lang/lib/Language/Drasil/Chunk/DefinedQuantity.hs
@@ -12,20 +12,20 @@ module Language.Drasil.Chunk.DefinedQuantity (
 
 import Control.Lens ((^.), makeLenses, view, Getter)
 
-import Drasil.Database (HasChunkRefs(..), HasUID(..))
+import Drasil.Database (HasChunkRefs(..), HasUID(..), mkUid)
 import qualified Data.Set as Set
 
 import Language.Drasil.Symbol (HasSymbol(symbol), Symbol (Empty))
 import Language.Drasil.Classes (NamedIdea(term), Idea(getA), Concept, Express(..),
   Definition(defn), ConceptDomain(cdom), IsUnit, Quantity)
-import Language.Drasil.Chunk.Concept (ConceptChunk, cw, dcc, dccWDS, dccA, dccAWDS)
+import Language.Drasil.Chunk.Concept (ConceptChunk, cw, dccWDS, dccA, dccAWDS, cncpt''')
 import Language.Drasil.Expr.Class (sy)
 import Language.Drasil.Chunk.UnitDefn (UnitDefn, unitWrapper,
   MayHaveUnit(getUnit))
 import Language.Drasil.Space (Space, HasSpace(..))
 import Language.Drasil.Stages (Stage (Implementation, Equational))
 import Language.Drasil.NaturalLanguage.English.NounPhrase.Core (NP)
-import Language.Drasil.Sentence (Sentence)
+import Language.Drasil.Sentence (Sentence(..))
 
 -- | DefinedQuantityDict is the combination of a 'Concept' and a 'Quantity'.
 -- Contains a 'ConceptChunk', a 'Symbol' dependent on 'Stage', a 'Space', and maybe a 'UnitDefn'.
@@ -93,7 +93,7 @@ dqdWr c = DQD (cw c) (symbol c) (c ^. typ) (getUnit c)
 
 -- | Makes a variable that is implementation-only.
 implVar :: String -> NP -> String -> Space -> Symbol -> DefinedQuantityDict
-implVar i ter desc sp sym = dqdNoUnit' (dcc i ter desc) f sp
+implVar i ter desc sp sym = dqdNoUnit' (cncpt''' (mkUid i) ter (S desc)) f sp
   where
     f :: Stage -> Symbol
     f Implementation = sym

--- a/code/drasil-lang/lib/Language/Drasil/Chunk/UnitDefn.hs
+++ b/code/drasil-lang/lib/Language/Drasil/Chunk/UnitDefn.hs
@@ -24,7 +24,8 @@ import Control.Arrow (second)
 
 import Drasil.Database (HasChunkRefs(..), UID, HasUID(..), mkUid)
 
-import Language.Drasil.Chunk.Concept (ConceptChunk, dcc, cncpt''')
+import Language.Drasil.Chunk.Concept (ConceptChunk, cncpt''')
+import Language.Drasil.Sentence (Sentence(..))
 import Language.Drasil.Classes (NamedIdea(term), Idea(getA),
   Definition(defn), ConceptDomain(cdom), HasUnitSymbol(usymb), IsUnit(udefn, getUnits))
 import Language.Drasil.NaturalLanguage.English.NounPhrase (cn,cn',NP)
@@ -89,32 +90,32 @@ makeDerU concept eqn = UD concept (Defined (usymb eqn) (USynonym $ usymb eqn)) (
 -- FIXME: Shouldn't need to use the UID constructor here.
 derCUC, derCUC' :: String -> String -> String -> Symbol -> UnitEquation -> UnitDefn
 -- | Create a 'SI_Unit' with two 'Symbol' representations. The created 'NP' is self-plural.
-derCUC a b c s ue = UD (dcc a (cn b) c) (DerivedSI (US [(s,1)]) (usymb ue) (USynonym $ usymb ue)) [mkUid a]
+derCUC a b c s ue = UD (cncpt''' (mkUid a) (cn b) (S c)) (DerivedSI (US [(s,1)]) (usymb ue) (USynonym $ usymb ue)) [mkUid a]
 -- | Similar to 'derCUC', but the created 'NP' has the 'AddS' plural rule.
-derCUC' a b c s ue = UD (dcc a (cn' b) c) (DerivedSI (US [(s,1)]) (usymb ue) (USynonym $ usymb ue)) [mkUid a]
+derCUC' a b c s ue = UD (cncpt''' (mkUid a) (cn' b) (S c)) (DerivedSI (US [(s,1)]) (usymb ue) (USynonym $ usymb ue)) [mkUid a]
 
 -- | Create a derived unit chunk from a 'UID', term ('String'), definition,
 -- 'Symbol', and unit equation.
 derUC, derUC' :: String -> String -> String -> Symbol -> UDefn -> UnitDefn
 -- | Uses self-plural term.
-derUC  a b c s u = UD (dcc a (cn b) c) (DerivedSI (US [(s,1)]) (fromUDefn u) u) []
+derUC  a b c s u = UD (cncpt''' (mkUid a) (cn b) (S c)) (DerivedSI (US [(s,1)]) (fromUDefn u) u) []
 -- | Uses term that pluralizes by adding "s" to the end.
-derUC' a b c s u = UD (dcc a (cn' b) c) (DerivedSI (US [(s,1)]) (fromUDefn u) u) []
+derUC' a b c s u = UD (cncpt''' (mkUid a) (cn' b) (S c)) (DerivedSI (US [(s,1)]) (fromUDefn u) u) []
 
 -- | Create a derived unit chunk from a 'UID', term ('NP'), definition,
 -- 'Symbol', and unit equation.
 derCUC'' :: String -> NP -> String -> Symbol -> UnitEquation -> UnitDefn
-derCUC'' a b c s ue = UD (dcc a b c) (DerivedSI (US [(s,1)]) (usymb ue) (USynonym $ usymb ue)) (getCu ue)
+derCUC'' a b c s ue = UD (cncpt''' (mkUid a) b (S c)) (DerivedSI (US [(s,1)]) (usymb ue) (USynonym $ usymb ue)) (getCu ue)
 -- | Create a derived unit chunk from a 'UID', term ('NP'), definition,
 -- 'Symbol', and unit equation.
 derUC'' :: String -> NP -> String -> Symbol -> UDefn -> UnitDefn
-derUC'' a b c s u = UD (dcc a b c) (DerivedSI (US [(s,1)]) (fromUDefn u) u) []
+derUC'' a b c s u = UD (cncpt''' (mkUid a) b (S c)) (DerivedSI (US [(s,1)]) (fromUDefn u) u) []
 
 --FIXME: Make this use a meaningful identifier.
 -- | Helper for fundamental unit concept chunk creation. Uses the same 'String'
 -- for the identifier, term, and definition.
 unitCon :: String -> ConceptChunk
-unitCon s = dcc s (cn' s) s
+unitCon s = cncpt''' (mkUid s) (cn' s) (S s)
 ---------------------------------------------------------
 
 -- | For allowing lists to mix together chunks that are units by projecting them into a 'UnitDefn'.
@@ -192,12 +193,12 @@ newUnit s = makeDerU (unitCon s)
 
 -- | Smart constructor for a "fundamental" unit.
 fund :: String -> String -> String -> UnitDefn
-fund nam desc sym = UD (dcc name (cn' nam) desc) (BaseSI $ US [(Label sym, 1)]) [mkUid name]
+fund nam desc sym = UD (cncpt''' (mkUid name) (cn' nam) (S desc)) (BaseSI $ US [(Label sym, 1)]) [mkUid name]
   where name = "unit:" ++ nam
 
 -- | Variant of the 'fund', useful for degree.
 fund' :: String -> String -> Symbol -> UnitDefn
-fund' nam desc sym = UD (dcc name (cn' nam) desc) (BaseSI $ US [(sym, 1)]) [mkUid name]
+fund' nam desc sym = UD (cncpt''' (mkUid name) (cn' nam) (S desc)) (BaseSI $ US [(sym, 1)]) [mkUid name]
   where name = "unit:" ++ nam
 
 -- | We don't want an Ord on units, but this still allows us to compare them.

--- a/code/drasil-metadata/lib/Drasil/Metadata/Concepts/Computation.hs
+++ b/code/drasil-metadata/lib/Drasil/Metadata/Concepts/Computation.hs
@@ -1,8 +1,9 @@
 -- | Defines concepts used in computing, to be used internally.
 module Drasil.Metadata.Concepts.Computation (algorithm) where
 
-import Language.Drasil (dcc, cn', ConceptChunk)
+import Language.Drasil (cn', ConceptChunk, cncpt''', Sentence(..))
+import Drasil.Database (mkUid)
 
 algorithm :: ConceptChunk
-algorithm = dcc "algorithm" (cn' "algorithm")
-  "a series of steps to be followed in calculations and problem-solving operations"
+algorithm = cncpt''' (mkUid "algorithm") (cn' "algorithm")
+  (S "a series of steps to be followed in calculations and problem-solving operations")

--- a/code/drasil-metadata/lib/Drasil/Metadata/Concepts/Math.hs
+++ b/code/drasil-metadata/lib/Drasil/Metadata/Concepts/Math.hs
@@ -1,9 +1,13 @@
 module Drasil.Metadata.Concepts.Math (equation, graph, parameter, unit_) where
 
-import Language.Drasil (dcc, cn', ConceptChunk)
+import Language.Drasil (cn', ConceptChunk, Sentence(..), cncpt''')
+import Drasil.Database (mkUid)
 
 equation, graph, parameter, unit_ :: ConceptChunk
-equation     = dcc "equation"    (cn' "equation")               "A statement that the values of two mathematical expressions are equal "
-graph        = dcc "graph"       (cn' "graph")                  "A diagram showing the relation between variable quantities"
-parameter   = dcc "parameter"    (cn' "parameter")              "a quantity whose value is selected depending on particular circumstances"
-unit_        = dcc "unit"        (cn' "unit")                   "Identity element"
+equation     = cncpt''' (mkUid "equation")  (cn' "equation")
+  (S "A statement that the values of two mathematical expressions are equal ")
+graph        = cncpt''' (mkUid "graph")     (cn' "graph")
+  (S "A diagram showing the relation between variable quantities")
+parameter    = cncpt''' (mkUid "parameter") (cn' "parameter")
+  (S "a quantity whose value is selected depending on particular circumstances")
+unit_        = cncpt''' (mkUid "unit")      (cn' "unit") (S "Identity element")

--- a/code/drasil-metadata/lib/Drasil/Metadata/Documentation.hs
+++ b/code/drasil-metadata/lib/Drasil/Metadata/Documentation.hs
@@ -39,7 +39,7 @@ import Control.Lens ((^.))
 import Drasil.Database (mkUid)
 import Language.Drasil (CI, NP, IdeaDict, cn, cn', cnIES, cnICES, cnUM,
   commonIdeaWithDict, fterms, compoundPhrase, compoundPhraseP1, titleizeNP',
-  term, ConceptChunk, cncpt, cncpt', Sentence(EmptyS), dcc, idea')
+  term, ConceptChunk, cncpt, cncpt', Sentence(EmptyS), idea', cncpt''', Sentence(..))
 import Language.Drasil.Chunk.Concept.NamedCombinators
   (combineNINI, compoundNC, compoundNCPP, of_, of_PS, ofAPS, of_NINP, theGen
   , compoundNCPSPP, and_, and_TGen, and_PP)
@@ -214,7 +214,7 @@ traceyMandG         = idea' (mkUid "traceyMandG")        (and_TGen (\t -> titlei
 
 -- | Root SRS Domain.
 srsDom :: ConceptChunk
-srsDom = dcc "srsDom" (srs ^. term) "srs"
+srsDom = cncpt''' (mkUid "srsDom") (srs ^. term) (S "srs")
 
 assumpDom, chgProbDom, funcReqDom, goalStmtDom, likeChgDom,
   nonFuncReqDom, reqDom, unlikeChgDom :: ConceptChunk


### PR DESCRIPTION
Depends on #5148 

Deals with `dcc` deprecation introduced in #5141 