### PR TITLE
Remove `unitWrapper`

### DIFF
--- a/code/drasil-lang/lib/Language/Drasil.hs
+++ b/code/drasil-lang/lib/Language/Drasil.hs
@@ -99,7 +99,7 @@ module Language.Drasil (
   , scale, shift
   , derUC, derUC', derUC''
   , fund, fund', compUnitDefn, derCUC, derCUC', derCUC''
-  , unitWrapper, getCu, MayHaveUnit(getUnit)
+  , getCu, MayHaveUnit(getUnit)
 
   -- *** Constrained and Uncertain Values
   -- Language.Drasil.Constraint
@@ -301,4 +301,4 @@ import Language.Drasil.Chunk.UnitDefn (UnitDefn(..)
   , scale, shift
   , derUC, derUC', derUC''
   , fund, fund', compUnitDefn, derCUC, derCUC', derCUC''
-  , unitWrapper, getCu, MayHaveUnit(getUnit))
+  , getCu, MayHaveUnit(getUnit))

--- a/code/drasil-lang/lib/Language/Drasil/Chunk/Constrained.hs
+++ b/code/drasil-lang/lib/Language/Drasil/Chunk/Constrained.hs
@@ -16,9 +16,9 @@ import Language.Drasil.Chunk.DefinedQuantity (DefinedQuantityDict, dqd', dqdWr, 
 import Language.Drasil.Symbol (HasSymbol(..), Symbol)
 import Language.Drasil.Classes (NamedIdea(term), Idea(getA), Express(express),
   Definition(defn), ConceptDomain(cdom), Concept, Quantity,
-  IsUnit, Constrained(constraints), HasReasVal(reasVal), MayHaveRationale(rationale))
+  Constrained(constraints), HasReasVal(reasVal), MayHaveRationale(rationale))
 import Language.Drasil.Constraint (ConstraintE)
-import Language.Drasil.Chunk.UnitDefn (unitWrapper, MayHaveUnit(getUnit))
+import Language.Drasil.Chunk.UnitDefn (MayHaveUnit(getUnit), UnitDefn)
 import Language.Drasil.Expr.Lang (Expr(..))
 import Language.Drasil.Expr.Class (sy)
 import Language.Drasil.NaturalLanguage.English.NounPhrase.Core (NP)
@@ -88,7 +88,7 @@ constrainedWithRationale :: (Concept c, MayHaveUnit c, Quantity c) =>
 constrainedWithRationale q cs rv r = ConstrConcept (dqdWr q) cs (Just rv) (Just r)
 
 -- | Creates a constrained unitary chunk from a 'UID', term ('NP'), description ('String'), 'Symbol', unit, 'Space', 'Constraint's, and an 'Expr'.
-cuc' :: (IsUnit u) => String -> NP -> String -> Symbol -> u
+cuc' :: String -> NP -> String -> Symbol -> UnitDefn
             -> Space -> [ConstraintE] -> Expr -> ConstrConcept
 cuc' nam trm desc sym un space cs rv =
   ConstrConcept (dqdWr (uc' nam trm (S desc) sym space un)) cs (Just rv) Nothing
@@ -100,11 +100,10 @@ cucNoUnit' nam trm desc sym space cs rv =
   ConstrConcept (dqdNoUnit (dccWDS nam trm (S desc)) sym space) cs (Just rv) Nothing
 
 -- | Similar to 'cuc'', but 'Symbol' is dependent on 'Stage'.
-cuc'' :: (IsUnit u) => String -> NP -> String -> (Stage -> Symbol) -> u
+cuc'' :: String -> NP -> String -> (Stage -> Symbol) -> UnitDefn
             -> Space -> [ConstraintE] -> Expr -> ConstrConcept
 cuc'' nam trm desc sym un space cs rv =
-  ConstrConcept (dqd' (dcc nam trm desc) sym space (Just uu)) cs (Just rv) Nothing
-  where uu = unitWrapper un
+  ConstrConcept (dqd' (dcc nam trm desc) sym space (Just un)) cs (Just rv) Nothing
 
 -- | Similar to 'cnstrw', but types must also have a 'Concept'.
 cnstrw' :: (Quantity c, Concept c, Constrained c, HasReasVal c, MayHaveUnit c) => c -> ConstrConcept

--- a/code/drasil-lang/lib/Language/Drasil/Chunk/DefinedQuantity.hs
+++ b/code/drasil-lang/lib/Language/Drasil/Chunk/DefinedQuantity.hs
@@ -17,11 +17,10 @@ import qualified Data.Set as Set
 
 import Language.Drasil.Symbol (HasSymbol(symbol), Symbol (Empty))
 import Language.Drasil.Classes (NamedIdea(term), Idea(getA), Concept, Express(..),
-  Definition(defn), ConceptDomain(cdom), IsUnit, Quantity)
+  Definition(defn), ConceptDomain(cdom), Quantity)
 import Language.Drasil.Chunk.Concept (ConceptChunk, cw, dcc, dccWDS, dccA, dccAWDS)
 import Language.Drasil.Expr.Class (sy)
-import Language.Drasil.Chunk.UnitDefn (UnitDefn, unitWrapper,
-  MayHaveUnit(getUnit))
+import Language.Drasil.Chunk.UnitDefn (UnitDefn, MayHaveUnit(getUnit))
 import Language.Drasil.Space (Space, HasSpace(..))
 import Language.Drasil.Stages (Stage (Implementation, Equational))
 import Language.Drasil.NaturalLanguage.English.NounPhrase.Core (NP)
@@ -73,8 +72,8 @@ instance MayHaveUnit   DefinedQuantityDict where getUnit = view unit'
 instance Express       DefinedQuantityDict where express = sy
 
 -- | Smart constructor that creates a DefinedQuantityDict with a 'ConceptChunk', a 'Symbol' independent of 'Stage', a 'Space', and a unit.
-dqd :: (IsUnit u) => ConceptChunk -> Symbol -> Space -> u -> DefinedQuantityDict
-dqd c s sp = DQD c (const s) sp . Just . unitWrapper
+dqd :: ConceptChunk -> Symbol -> Space -> UnitDefn -> DefinedQuantityDict
+dqd c s sp = DQD c (const s) sp . Just
 
 -- | Similar to 'dqd', but without any units.
 dqdNoUnit :: ConceptChunk -> Symbol -> Space -> DefinedQuantityDict

--- a/code/drasil-lang/lib/Language/Drasil/Chunk/Eq.hs
+++ b/code/drasil-lang/lib/Language/Drasil/Chunk/Eq.hs
@@ -18,10 +18,10 @@ import Control.Lens ((^.), view, lens, Lens', to)
 import Drasil.Database (UID, HasUID(..), HasChunkRefs(..), IsChunk, mkUid)
 import qualified Data.Set as Set
 
-import Language.Drasil.Chunk.UnitDefn (unitWrapper, MayHaveUnit(getUnit), UnitDefn)
+import Language.Drasil.Chunk.UnitDefn (MayHaveUnit(getUnit), UnitDefn)
 import Language.Drasil.Symbol (HasSymbol(symbol), Symbol)
 import Language.Drasil.Classes (NamedIdea(term), Idea(getA),
-  IsUnit, DefiningExpr(defnExpr), Definition(defn), Quantity,
+  DefiningExpr(defnExpr), Definition(defn), Quantity,
   ConceptDomain(cdom), Express(express), Concept)
 import Language.Drasil.Chunk.DefinedQuantity (DefinedQuantityDict, DefinesQuantity(defLhs), dqd, dqd', dqdWr)
 import Language.Drasil.Chunk.Concept (cncpt''')
@@ -88,7 +88,7 @@ instance RequiresChecking (QDefinition Expr) Expr Space where
 
 -- | Create a 'QDefinition' with a 'UID' (as a 'String'), term ('NP'), definition ('Sentence'), 'Symbol',
 -- 'Space', unit, and defining expression.
-fromEqn :: IsUnit u => String -> NP -> Sentence -> Symbol -> Space -> u -> e -> QDefinition e
+fromEqn :: String -> NP -> Sentence -> Symbol -> Space -> UnitDefn -> e -> QDefinition e
 fromEqn nm desc def symb sp un =
   QD (dqd (cncpt''' (mkUid nm) desc def) symb sp un) []
 
@@ -98,10 +98,10 @@ fromEqn' nm desc def symb sp =
   QD (dqd' (cncpt''' (mkUid nm) desc def) (const symb) sp Nothing) []
 
 -- | Same as 'fromEqn', but symbol depends on stage.
-fromEqnSt :: IsUnit u => UID -> NP -> Sentence -> (Stage -> Symbol) ->
-  Space -> u -> e -> QDefinition e
+fromEqnSt :: UID -> NP -> Sentence -> (Stage -> Symbol) ->
+  Space -> UnitDefn -> e -> QDefinition e
 fromEqnSt nm desc def symb sp un =
-  QD (dqd' (cncpt''' nm desc def) symb sp (Just $ unitWrapper un)) []
+  QD (dqd' (cncpt''' nm desc def) symb sp (Just un)) []
 
 -- | Same as 'fromEqn', but symbol depends on stage and has no units.
 fromEqnSt' :: UID -> NP -> Sentence -> (Stage -> Symbol) -> Space -> e -> QDefinition e
@@ -150,10 +150,9 @@ mkFuncDef0 f n s u is = QD
 -- | Create a 'QDefinition' function with a symbol, name, term, list of inputs,
 -- resultant units, and a defining Expr
 mkFuncDef :: (IsChunk f, HasSymbol f, HasSpace f,
-              IsChunk i, HasSymbol i, HasSpace i,
-              IsUnit u) =>
-  f -> NP -> Sentence -> u -> [i] -> e -> QDefinition e
-mkFuncDef f n s u = mkFuncDef0 f n s (Just $ unitWrapper u)
+              IsChunk i, HasSymbol i, HasSpace i) =>
+  f -> NP -> Sentence -> UnitDefn -> [i] -> e -> QDefinition e
+mkFuncDef f n s u = mkFuncDef0 f n s (Just u)
 
 -- | Create a 'QDefinition' function with a symbol, name, term, list of inputs,
 -- and a defining Expr

--- a/code/drasil-lang/lib/Language/Drasil/Chunk/UncertainQuantity.hs
+++ b/code/drasil-lang/lib/Language/Drasil/Chunk/UncertainQuantity.hs
@@ -18,9 +18,9 @@ import Language.Drasil.Chunk.Constrained (ConstrConcept(..), cuc')
 import Language.Drasil.Symbol
 import Language.Drasil.Classes (NamedIdea(term), Idea(getA), Express(express),
   Definition(defn), ConceptDomain(cdom), Concept, Quantity,
-  IsUnit, Constrained(constraints), HasReasVal(reasVal), MayHaveRationale(rationale))
+  Constrained(constraints), HasReasVal(reasVal), MayHaveRationale(rationale))
 import Language.Drasil.Constraint (ConstraintE)
-import Language.Drasil.Chunk.UnitDefn (MayHaveUnit(getUnit))
+import Language.Drasil.Chunk.UnitDefn (MayHaveUnit(getUnit), UnitDefn)
 import Language.Drasil.Expr.Lang (Expr)
 import Language.Drasil.Expr.Class (sy)
 import Language.Drasil.NaturalLanguage.English.NounPhrase.Core (NP)
@@ -77,12 +77,12 @@ uq q = UQ (ConstrConcept (dqdWr q) (q ^. constraints) (q ^. reasVal) Nothing)
 
 --FIXME: this is kind of crazy and probably shouldn't be used!
 -- | Uncertainty quantity ('uq') but with a constraint.
-uqc :: (IsUnit u) => String -> NP -> String -> Symbol -> u -> Space
+uqc :: String -> NP -> String -> Symbol -> UnitDefn -> Space
                 -> [ConstraintE] -> Expr -> Uncertainty -> UncertQ
 uqc nam trm desc sym un space cs val = uq (cuc' nam trm desc sym un space cs val)
 
 -- | Uncertainty quantity constraint ('uqc') without a description.
-uqcND :: (IsUnit u) => String -> NP -> Symbol -> u -> Space -> [ConstraintE]
+uqcND :: String -> NP -> Symbol -> UnitDefn -> Space -> [ConstraintE]
                   -> Expr -> Uncertainty -> UncertQ
 uqcND nam trm sym un space cs val = uq (cuc' nam trm "" sym un space cs val)
 

--- a/code/drasil-lang/lib/Language/Drasil/Chunk/UnitDefn.hs
+++ b/code/drasil-lang/lib/Language/Drasil/Chunk/UnitDefn.hs
@@ -10,7 +10,6 @@ module Language.Drasil.Chunk.UnitDefn (
   makeDerU, newUnit,
   derUC, derUC', derUC'',
   fund, fund', derCUC, derCUC', derCUC'',
-  unitWrapper,
   -- * Unit Combinators ('UnitEquation's)
   (^:), (/:), (*:), (*$), (/$), (^$),
   -- * Unit Relation Functions
@@ -24,7 +23,7 @@ import Control.Arrow (second)
 
 import Drasil.Database (HasChunkRefs(..), UID, HasUID(..), mkUid)
 
-import Language.Drasil.Chunk.Concept (ConceptChunk, dcc, cncpt''')
+import Language.Drasil.Chunk.Concept (ConceptChunk, dcc)
 import Language.Drasil.Classes (NamedIdea(term), Idea(getA),
   Definition(defn), ConceptDomain(cdom), HasUnitSymbol(usymb), IsUnit(udefn, getUnits))
 import Language.Drasil.NaturalLanguage.English.NounPhrase (cn,cn',NP)
@@ -116,14 +115,6 @@ derUC'' a b c s u = UD (dcc a b c) (DerivedSI (US [(s,1)]) (fromUDefn u) u) []
 unitCon :: String -> ConceptChunk
 unitCon s = dcc s (cn' s) s
 ---------------------------------------------------------
-
--- | For allowing lists to mix together chunks that are units by projecting them into a 'UnitDefn'.
--- For now, this only works on 'UnitDefn's.
-unitWrapper :: (IsUnit u)  => u -> UnitDefn
-unitWrapper u = UD (cncpt''' (u ^. uid) (u ^. term) (u ^. defn)) (Defined (usymb u) (USynonym $ usymb u)) (getUnits u)
-
-{-# DEPRECATED unitWrapper
-  "`unitWrapper` is an unsafe chunk constructor that encourages `UID` double-use." #-}
 
 -- | Helper to get derived units if they exist.
 getSecondSymb :: UnitDefn -> Maybe USymb

--- a/code/drasil-lang/lib/Language/Drasil/Chunk/Unital.hs
+++ b/code/drasil-lang/lib/Language/Drasil/Chunk/Unital.hs
@@ -15,8 +15,8 @@ import Language.Drasil.Chunk.Concept (dccWDS,cw)
 import Language.Drasil.Chunk.DefinedQuantity (DefinedQuantityDict, dqd, dqd')
 import Language.Drasil.Symbol (Symbol, HasSymbol(..))
 import Language.Drasil.Classes (NamedIdea(term), Idea(getA), Express(express),
-  Definition(defn), ConceptDomain(cdom), Concept, IsUnit, Quantity)
-import Language.Drasil.Chunk.UnitDefn (MayHaveUnit(getUnit), UnitDefn, unitWrapper)
+  Definition(defn), ConceptDomain(cdom), Concept, Quantity)
+import Language.Drasil.Chunk.UnitDefn (MayHaveUnit(getUnit), UnitDefn)
 import Language.Drasil.Expr.Class (sy)
 import Language.Drasil.NaturalLanguage.English.NounPhrase.Core (NP)
 import Language.Drasil.Space (Space(..), HasSpace(..))
@@ -66,24 +66,20 @@ instance Express       UnitalChunk where express = sy
 --{BEGIN HELPER FUNCTIONS}--
 
 -- | Used to create a 'UnitalChunk' from a 'Concept', 'Symbol', and 'Unit'.
-uc :: (Concept c, IsUnit u) => c -> Symbol -> Space -> u -> UnitalChunk
-uc a sym space c = UC (dqd (cw a) sym space un) un
- where un = unitWrapper c
+uc :: (Concept c) => c -> Symbol -> Space -> UnitDefn -> UnitalChunk
+uc a sym space un = UC (dqd (cw a) sym space un) un
 
 -- | Similar to 'uc', except it builds the 'Concept' portion of the 'UnitalChunk'
 -- from a given 'UID', term, and definition (as a 'Sentence') which are its first three arguments.
-uc' :: (IsUnit u) => String -> NP -> Sentence -> Symbol -> Space -> u -> UnitalChunk
-uc' i t d sym space u = UC (dqd (dccWDS i t d) sym space un) un
- where un = unitWrapper u
+uc' :: String -> NP -> Sentence -> Symbol -> Space -> UnitDefn -> UnitalChunk
+uc' i t d sym space un = UC (dqd (dccWDS i t d) sym space un) un
 
 -- | Similar to 'uc', but 'Symbol' is dependent on the 'Stage'.
-ucStaged :: (Concept c, IsUnit u) => c ->  (Stage -> Symbol) ->
-  Space -> u -> UnitalChunk
-ucStaged a sym space u = UC (dqd' (cw a) sym space (Just un)) un
- where un = unitWrapper u
+ucStaged :: (Concept c) => c ->  (Stage -> Symbol) ->
+  Space -> UnitDefn -> UnitalChunk
+ucStaged a sym space un = UC (dqd' (cw a) sym space (Just un)) un
 
 -- | Similar to 'uc'', but 'Symbol' is dependent on the 'Stage'.
-ucStaged' :: (IsUnit u) => String -> NP -> Sentence -> (Stage -> Symbol) ->
-  Space -> u -> UnitalChunk
-ucStaged' i t d sym space u = UC (dqd' (dccWDS i t d) sym space (Just un)) un
- where un = unitWrapper u
+ucStaged' :: String -> NP -> Sentence -> (Stage -> Symbol) ->
+  Space -> UnitDefn -> UnitalChunk
+ucStaged' i t d sym space un = UC (dqd' (dccWDS i t d) sym space (Just un)) un

--- a/code/drasil-theory/lib/Theory/Drasil/GenDefn.hs
+++ b/code/drasil-theory/lib/Theory/Drasil/GenDefn.hs
@@ -73,17 +73,17 @@ instance Referable          GenDefn where
   renderRef l = RP (prepend $ abrv l) (refAdd l)
 
 -- | Smart constructor for general definitions.
-gd :: IsUnit u => ModelKind ModelExpr -> Maybe u ->
+gd :: ModelKind ModelExpr -> Maybe UnitDefn ->
   Maybe Derivation -> [DecRef] -> String -> [Sentence] -> GenDefn
 gd mkind _   _     []   _  = error $ "Source field of " ++ showUID mkind ++ " is empty"
 gd mkind u derivs refs sn_ =
-  GD mkind (fmap unitWrapper u) derivs refs (shortname' $ S sn_) (prependAbrv genDefn sn_)
+  GD mkind u derivs refs (shortname' $ S sn_) (prependAbrv genDefn sn_)
 
 -- | Smart constructor for general definitions with no references.
-gdNoRefs :: IsUnit u => ModelKind ModelExpr -> Maybe u ->
+gdNoRefs :: ModelKind ModelExpr -> Maybe UnitDefn ->
   Maybe Derivation -> String -> [Sentence] -> GenDefn
 gdNoRefs mkind u derivs sn_ =
-  GD mkind (fmap unitWrapper u) derivs [] (shortname' $ S sn_) (prependAbrv genDefn sn_)
+  GD mkind u derivs [] (shortname' $ S sn_) (prependAbrv genDefn sn_)
 
 -- | Grab all related 'QDefinitions' from a list of general definitions.
 getEqModQdsFromGd :: [GenDefn] -> [ModelQDef]


### PR DESCRIPTION
Contributes to #5149 

We do so by replacing `(IsUnit u) => u` with `UnitDefn`, which removes the need for `unitWrapper`. `unitWrapper` was effectively an identity function, since it constructs a `UnitDefn` from something that is an instance of `IsUnit`, however the only instance of `IsUnit` is `UnitDefn`.

Additionally, me and Jason discussed and determined that it doesn't make sense for units to be polymorphic. We should have everything we need to capture any unit in `UnitDefn`. I will investigate removing `IsUnit` entirely in a followup PR.