### PR TITLE
Renamed `listInnerType` to `innerType`

### DIFF
--- a/code/drasil-code/lib/Language/Drasil/Code/Imperative/Import.hs
+++ b/code/drasil-code/lib/Language/Drasil/Code/Imperative/Import.hs
@@ -584,7 +584,7 @@ convStmt (FAsg v (Matrix [es])) = do
       listFunc (C.Array _) = litArray
       listFunc _ = error "Type mismatch between variable and value in assignment FuncStmt"
   l <- maybeLog vlog v'
-  return $ multi $ assign v' (listFunc t (listInnerType $ fmap variableType v')
+  return $ multi $ assign v' (listFunc t (innerType $ fmap variableType v')
     els) : l
 convStmt (FAsg v e) = do
   e' <- convExpr e
@@ -753,7 +753,7 @@ readData ddef = do
         clearTemp :: (OOProg r) => String -> DataItem -> r ScopeData ->
           GenState (MSStatement r)
         clearTemp sfx v scp = fmap (\t -> listDecDef (var (codeName v ++ sfx)
-          (listInnerType $ convTypeOO t)) scp []) (codeType v)
+          (innerType $ convTypeOO t)) scp []) (codeType v)
         ---------------
         appendTemps :: (OOProg r) => Maybe String -> [DataItem]
           -> [GenState (MSStatement r)]
@@ -770,7 +770,7 @@ readData ddef = do
 getEntryVars :: (OOVariableSym r, InstanceVarSelfSym r, VariableElim r,
   VariableValue r) => Maybe String -> LinePattern -> GenState [SVariable r]
 getEntryVars s lp = mapM (maybe mkVar (\st v -> codeType v >>=
-  (variable (codeName v ++ st) . listInnerType . convTypeOO))
+  (variable (codeName v ++ st) . innerType . convTypeOO))
     s) (getPatternInputs lp)
 
 -- | Get entry variable logs.
@@ -994,7 +994,7 @@ readDataProc ddef = do
         clearTemp :: (SharedProg r) => String -> DataItem -> r ScopeData ->
           GenState (MSStatement r)
         clearTemp sfx v scp = fmap (\t -> listDecDef (var (codeName v ++ sfx)
-          (listInnerType $ convType t)) scp []) (codeType v)
+          (innerType $ convType t)) scp []) (codeType v)
         ---------------
         appendTemps :: (SharedProg r) => Maybe String -> [DataItem]
           -> [GenState (MSStatement r)]
@@ -1011,7 +1011,7 @@ readDataProc ddef = do
 getEntryVarsProc :: (VariableSym r) => Maybe String -> LinePattern ->
   GenState [SVariable r]
 getEntryVarsProc s lp = mapM (maybe mkVarProc (\st v -> codeType v >>=
-  (variableProc (codeName v ++ st) . listInnerType . convType))
+  (variableProc (codeName v ++ st) . innerType . convType))
     s) (getPatternInputs lp)
 
 -- | Get entry variable logs.
@@ -1131,7 +1131,7 @@ convStmtProc (FAsg v (Matrix [es])) = do
       listFunc (C.Array _) = litArray
       listFunc _ = error "Type mismatch between variable and value in assignment FuncStmt"
   l <- maybeLog vlog v'
-  return $ multi $ assign v' (listFunc t (listInnerType $ fmap variableType v')
+  return $ multi $ assign v' (listFunc t (innerType $ fmap variableType v')
     els) : l
 convStmtProc (FAsg v e) = do
   e' <- convExprProc e

--- a/code/drasil-gool/lib/Drasil/GOOL/CodeInfoOO.hs
+++ b/code/drasil-gool/lib/Drasil/GOOL/CodeInfoOO.hs
@@ -102,7 +102,7 @@ instance TypeSym CodeInfoOO where
   setType       _   = noInfoVSType
   listType      _   = noInfoVSType
   arrayType     _   = noInfoVSType
-  listInnerType _   = noInfoVSType
+  innerType _   = noInfoVSType
   funcType      _ _ = noInfoVSType
   void              = noInfoVSType
 

--- a/code/drasil-gool/lib/Drasil/GOOL/LanguageRenderer/CSharpRenderer.hs
+++ b/code/drasil-gool/lib/Drasil/GOOL/LanguageRenderer/CSharpRenderer.hs
@@ -67,7 +67,7 @@ import Drasil.Shared.LanguageRenderer.Constructors (mkStmt,  mkStmtNoEnd,
   mkStateVal, mkVal, typeFromData, VSOp, unOpPrec, powerPrec, unExpr, unExpr',
   unExprNumDbl, typeUnExpr, binExpr, binExprNumDbl', typeBinExpr)
 import qualified Drasil.Shared.LanguageRenderer.LanguagePolymorphic as G (
-  multiBody, block, multiBlock, listInnerType, obj, csc, sec, cot, negateOp,
+  multiBody, block, multiBlock, innerType, obj, csc, sec, cot, negateOp,
   equalOp, notEqualOp, greaterOp, greaterEqualOp, lessOp, lessEqualOp, plusOp,
   minusOp, multOp, divideOp, moduloOp, var, classVar, instanceVarAccess,
   arrayElem, litChar, litDouble, litInt, litString, valueOf, arg, argsList,
@@ -222,7 +222,7 @@ instance TypeSym CSharpCode where
   setType t = do
     modify (addLangImportVS csGeneric)
     C.setType csSet t
-  listInnerType = G.listInnerType
+  innerType = G.innerType
   funcType = csFuncType
   void = C.void
 

--- a/code/drasil-gool/lib/Drasil/GOOL/LanguageRenderer/CSharpRenderer.hs
+++ b/code/drasil-gool/lib/Drasil/GOOL/LanguageRenderer/CSharpRenderer.hs
@@ -67,16 +67,16 @@ import Drasil.Shared.LanguageRenderer.Constructors (mkStmt,  mkStmtNoEnd,
   mkStateVal, mkVal, typeFromData, VSOp, unOpPrec, powerPrec, unExpr, unExpr',
   unExprNumDbl, typeUnExpr, binExpr, binExprNumDbl', typeBinExpr)
 import qualified Drasil.Shared.LanguageRenderer.LanguagePolymorphic as G (
-  multiBody, block, multiBlock, innerType, obj, csc, sec, cot, negateOp,
-  equalOp, notEqualOp, greaterOp, greaterEqualOp, lessOp, lessEqualOp, plusOp,
-  minusOp, multOp, divideOp, moduloOp, var, classVar, instanceVarAccess,
-  arrayElem, litChar, litDouble, litInt, litString, valueOf, arg, argsList,
-  objAccess, objMethodCall, call, funcAppMixedArgs, newObjMixedArgs, lambda,
-  func, get, set, listAccess, listSet, getFunc, setFunc, stmt, loopStmt,
-  emptyStmt, assign, subAssign, objDecNew, print, closeFile, returnStmt, valStmt,
-  comment, throw, ifCond, tryCatch, construct, param, method, getMethod,
-  setMethod, function, buildClass, implementingClass, commentedClass,
-  modFromData, fileDoc, fileFromData, defaultOptSpace, local)
+  multiBody, block, multiBlock, obj, csc, sec, cot, negateOp, equalOp,
+  notEqualOp, greaterOp, greaterEqualOp, lessOp, lessEqualOp, plusOp, minusOp,
+  multOp, divideOp, moduloOp, var, classVar, instanceVarAccess, arrayElem,
+  litChar, litDouble, litInt, litString, valueOf, arg, argsList, objAccess,
+  objMethodCall, call, funcAppMixedArgs, newObjMixedArgs, lambda, func, get, set,
+  listAccess, listSet, getFunc, setFunc, stmt, loopStmt, emptyStmt, assign,
+  subAssign, objDecNew, print, closeFile, returnStmt, valStmt, comment, throw,
+  ifCond, tryCatch, construct, param, method, getMethod, setMethod, function,
+  buildClass, implementingClass, commentedClass, modFromData, fileDoc,
+  fileFromData, defaultOptSpace, local)
 import qualified Drasil.Shared.LanguageRenderer.CommonPseudoOO as CP (
   arrayDec, arrayDecDef, arrayType, bindingError, buildModule', classVarAccess,
   constVar, constructor, contains, destructorError, discardFileLine, docInOutFunc,
@@ -85,7 +85,7 @@ import qualified Drasil.Shared.LanguageRenderer.CommonPseudoOO as CP (
   listDecDef, mainFunction, notNull, instanceVarSelf, openFileA, openFileR, openFileW,
   pi, printSt, setMethodCall, stateVar, stateVarDef, string)
 import qualified Drasil.GOOL.LanguageRenderer.CommonGOOL as CG (constDecDef,
-  classMethodCall, listAppend, listAdd)
+  classMethodCall, listAppend, listAdd, innerType)
 
 import qualified Drasil.Shared.LanguageRenderer.CLike as C (setType, float, double, char,
   listType, void, notOp, andOp, orOp, self, litTrue, litFalse, litFloat,
@@ -222,7 +222,7 @@ instance TypeSym CSharpCode where
   setType t = do
     modify (addLangImportVS csGeneric)
     C.setType csSet t
-  innerType = G.innerType
+  innerType = CG.innerType
   funcType = csFuncType
   void = C.void
 

--- a/code/drasil-gool/lib/Drasil/GOOL/LanguageRenderer/CommonGOOL.hs
+++ b/code/drasil-gool/lib/Drasil/GOOL/LanguageRenderer/CommonGOOL.hs
@@ -2,12 +2,13 @@
 -- | Contains common implementations specific to GOOL
 
 module Drasil.GOOL.LanguageRenderer.CommonGOOL (
-  constDecDef, classMethodCall, listAppend, listAdd
+  constDecDef, classMethodCall, listAppend, listAdd, innerType
 ) where
 
 import Drasil.Shared.InterfaceCommon (UnRepr(..), SVariable, SValue, VSType,
-  MSStatement, NamedArgs, VariableElim(..), TypeSym(..), IndexTranslator(..))
-import Drasil.GOOL.InterfaceGOOL (objMethodCall)
+  MSStatement, NamedArgs, VariableElim(..), TypeSym(void), IndexTranslator(..),
+  getCodeType)
+import Drasil.GOOL.InterfaceGOOL (objMethodCall, convTypeOO)
 import Drasil.Shared.RendererClassesCommon (CommonRenderSym, ScopeElim(..),
   RenderValue(..))
 import Drasil.GOOL.RendererClassesOO (OORenderSym)
@@ -16,6 +17,7 @@ import Drasil.Shared.LanguageRenderer (dot)
 import Drasil.GOOL.Renderers (renderType, renderConstDecDef)
 import Drasil.Shared.AST (TypeData, ScopeData)
 import Drasil.Shared.State (lensMStoVS, useVarName, setVarScope)
+import Drasil.Shared.Helpers (getInnerType)
 
 import Control.Lens.Zoom (zoom)
 import Control.Monad.State (modify)
@@ -41,3 +43,6 @@ listAppend fnName list val = objMethodCall void list fnName [val]
 
 listAdd :: (OORenderSym r) => String -> SValue r -> SValue r -> SValue r -> SValue r
 listAdd fnName list idx val = objMethodCall void list fnName [intToIndex idx, val]
+
+innerType :: (OORenderSym r, UnRepr r TypeData) => VSType r -> VSType r
+innerType t = t >>= (convTypeOO . getInnerType . getCodeType)

--- a/code/drasil-gool/lib/Drasil/GOOL/LanguageRenderer/CppRenderer.hs
+++ b/code/drasil-gool/lib/Drasil/GOOL/LanguageRenderer/CppRenderer.hs
@@ -71,9 +71,9 @@ import Drasil.Shared.LanguageRenderer.Constructors (mkStmt, mkStmtNoEnd,
   mkStateVal, mkVal, mkStateVar, mkVar, typeFromData, VSOp, mkOp, unOpPrec,
   powerPrec, unExpr, unExpr', typeUnExpr, binExpr, binExpr', typeBinExpr)
 import qualified Drasil.Shared.LanguageRenderer.LanguagePolymorphic as G (
-  multiBody, block, multiBlock, innerType, obj, negateOp, csc, sec, cot,
-  equalOp, notEqualOp, greaterOp, greaterEqualOp, lessOp, lessEqualOp, plusOp,
-  minusOp, multOp, divideOp, moduloOp, var, classVar, instanceVarAccess, arrayElem,
+  multiBody, block, multiBlock, obj, negateOp, csc, sec, cot, equalOp,
+  notEqualOp, greaterOp, greaterEqualOp, lessOp, lessEqualOp, plusOp, minusOp,
+  multOp, divideOp, moduloOp, var, classVar, instanceVarAccess, arrayElem,
   litChar, litDouble, litInt, litString, valueOf, arg, objAccess, objMethodCall,
   funcAppMixedArgs, newObjMixedArgs, lambda, func, get, set, listAccess, listSet,
   getFunc, setFunc, stmt, loopStmt, emptyStmt, assign, subAssign, objDecNew,
@@ -87,7 +87,7 @@ import qualified Drasil.Shared.LanguageRenderer.CommonPseudoOO as CP (int,
   call', listAccessFunc', containsInt, string, docInOutFunc, extraClass,
   intToIndex, indexToInt, global, setMethodCall)
 import qualified Drasil.GOOL.LanguageRenderer.CommonGOOL as CG (constDecDef,
-  listAppend)
+  listAppend, innerType)
 import qualified Drasil.Shared.LanguageRenderer.CLike as C (charRender, float,
   double, char, listType, void, notOp, andOp, orOp, self, litTrue, litFalse,
   litFloat, inlineIf, libFuncAppMixedArgs, libNewObjMixedArgs, listSize,
@@ -1154,7 +1154,7 @@ instance TypeSym CppSrcCode where
     modify (addUsing cppSet . addLangImportVS cppSet)
     C.setType cppSet t
   arrayType = listType
-  innerType = G.innerType
+  innerType = CG.innerType
   funcType = cppFuncType
   void = C.void
 
@@ -1898,7 +1898,7 @@ instance TypeSym CppHdrCode where
     modify (addHeaderUsing cppSet . addHeaderLangImport cppSet)
     C.setType cppSet t
   arrayType = listType
-  innerType = G.innerType
+  innerType = CG.innerType
   funcType = CS.funcType
   void = C.void
 
@@ -2520,10 +2520,10 @@ iterator t = do
     cppIterType $ listType t
 
 iterBegin :: SValue CppSrcCode -> SValue CppSrcCode
-iterBegin v = v $. cppIterBeginFunc (G.innerType $ onStateValue valueType v)
+iterBegin v = v $. cppIterBeginFunc (innerType $ onStateValue valueType v)
 
 iterEnd :: SValue CppSrcCode -> SValue CppSrcCode
-iterEnd v = v $. cppIterEndFunc (G.innerType $ onStateValue valueType v)
+iterEnd v = v $. cppIterEndFunc (innerType $ onStateValue valueType v)
 
 arrayDecBase :: SVariable CppSrcCode -> CppSrcCode ScopeData -> MS Doc
 arrayDecBase vr scp = do

--- a/code/drasil-gool/lib/Drasil/GOOL/LanguageRenderer/CppRenderer.hs
+++ b/code/drasil-gool/lib/Drasil/GOOL/LanguageRenderer/CppRenderer.hs
@@ -71,7 +71,7 @@ import Drasil.Shared.LanguageRenderer.Constructors (mkStmt, mkStmtNoEnd,
   mkStateVal, mkVal, mkStateVar, mkVar, typeFromData, VSOp, mkOp, unOpPrec,
   powerPrec, unExpr, unExpr', typeUnExpr, binExpr, binExpr', typeBinExpr)
 import qualified Drasil.Shared.LanguageRenderer.LanguagePolymorphic as G (
-  multiBody, block, multiBlock, listInnerType, obj, negateOp, csc, sec, cot,
+  multiBody, block, multiBlock, innerType, obj, negateOp, csc, sec, cot,
   equalOp, notEqualOp, greaterOp, greaterEqualOp, lessOp, lessEqualOp, plusOp,
   minusOp, multOp, divideOp, moduloOp, var, classVar, instanceVarAccess, arrayElem,
   litChar, litDouble, litInt, litString, valueOf, arg, objAccess, objMethodCall,
@@ -232,7 +232,7 @@ instance (Pair p) => TypeSym (p CppSrcCode CppHdrCode) where
   listType = pair1 listType listType
   setType = pair1 setType setType
   arrayType = pair1 arrayType arrayType
-  listInnerType = pair1 listInnerType listInnerType
+  innerType = pair1 innerType innerType
   funcType = pair1List1Val funcType funcType
   void = on2StateValues pair void void
 
@@ -1154,7 +1154,7 @@ instance TypeSym CppSrcCode where
     modify (addUsing cppSet . addLangImportVS cppSet)
     C.setType cppSet t
   arrayType = listType
-  listInnerType = G.listInnerType
+  innerType = G.innerType
   funcType = cppFuncType
   void = C.void
 
@@ -1898,7 +1898,7 @@ instance TypeSym CppHdrCode where
     modify (addHeaderUsing cppSet . addHeaderLangImport cppSet)
     C.setType cppSet t
   arrayType = listType
-  listInnerType = G.listInnerType
+  innerType = G.innerType
   funcType = CS.funcType
   void = C.void
 
@@ -2520,10 +2520,10 @@ iterator t = do
     cppIterType $ listType t
 
 iterBegin :: SValue CppSrcCode -> SValue CppSrcCode
-iterBegin v = v $. cppIterBeginFunc (G.listInnerType $ onStateValue valueType v)
+iterBegin v = v $. cppIterBeginFunc (G.innerType $ onStateValue valueType v)
 
 iterEnd :: SValue CppSrcCode -> SValue CppSrcCode
-iterEnd v = v $. cppIterEndFunc (G.listInnerType $ onStateValue valueType v)
+iterEnd v = v $. cppIterEndFunc (G.innerType $ onStateValue valueType v)
 
 arrayDecBase :: SVariable CppSrcCode -> CppSrcCode ScopeData -> MS Doc
 arrayDecBase vr scp = do

--- a/code/drasil-gool/lib/Drasil/GOOL/LanguageRenderer/JavaRenderer.hs
+++ b/code/drasil-gool/lib/Drasil/GOOL/LanguageRenderer/JavaRenderer.hs
@@ -68,9 +68,9 @@ import Drasil.Shared.LanguageRenderer.Constructors (mkStmt, mkStateVal, mkVal,
   typeFromData, VSOp, unOpPrec, powerPrec, unExpr, unExpr', unExprNumDbl,
   typeUnExpr, binExpr, binExprNumDbl', typeBinExpr, typeFromData)
 import qualified Drasil.Shared.LanguageRenderer.LanguagePolymorphic as G (
-  multiBody, block, multiBlock, innerType, obj, csc, sec, cot, negateOp,
-  equalOp, notEqualOp, greaterOp, greaterEqualOp, lessOp, lessEqualOp, plusOp,
-  minusOp, multOp, divideOp, moduloOp, var, classVar, instanceVarAccess, arrayElem,
+  multiBody, block, multiBlock, obj, csc, sec, cot, negateOp, equalOp,
+  notEqualOp, greaterOp, greaterEqualOp, lessOp, lessEqualOp, plusOp, minusOp,
+  multOp, divideOp, moduloOp, var, classVar, instanceVarAccess, arrayElem,
   litChar, litDouble, litInt, litString, valueOf, arg, argsList, objAccess,
   objMethodCall, funcAppMixedArgs, newObjMixedArgs, lambda, func, get, set,
   listAccess, listSet, getFunc, setFunc, stmt, loopStmt, emptyStmt, assign,
@@ -89,7 +89,7 @@ import qualified Drasil.Shared.LanguageRenderer.Macros as M (ifExists,
   runStrategy, listSlice, stringListVals, stringListLists, forRange,
   notifyObservers)
 import qualified Drasil.GOOL.LanguageRenderer.CommonGOOL as CG (classMethodCall,
-  listAppend, listAdd)
+  listAppend, listAdd, innerType)
 import Drasil.Shared.AST (Terminator(..), VisibilityTag(..), qualName,
   FileType(..), FileData(..), fileD, FuncData(..), fd, ModData(..), md,
   updateMod, MethodData(..), mthd, updateMthd, OpData(..), ParamData(..), pd,
@@ -217,7 +217,7 @@ instance TypeSym JavaCode where
   listType = jListType
   setType = jSetType
   arrayType = CP.arrayType
-  innerType = G.innerType
+  innerType = CG.innerType
   funcType = CS.funcType -- TODO [Brandon Bosman, 05/11/2026]: fix this to work with lambda types
   void = C.void
 

--- a/code/drasil-gool/lib/Drasil/GOOL/LanguageRenderer/JavaRenderer.hs
+++ b/code/drasil-gool/lib/Drasil/GOOL/LanguageRenderer/JavaRenderer.hs
@@ -68,7 +68,7 @@ import Drasil.Shared.LanguageRenderer.Constructors (mkStmt, mkStateVal, mkVal,
   typeFromData, VSOp, unOpPrec, powerPrec, unExpr, unExpr', unExprNumDbl,
   typeUnExpr, binExpr, binExprNumDbl', typeBinExpr, typeFromData)
 import qualified Drasil.Shared.LanguageRenderer.LanguagePolymorphic as G (
-  multiBody, block, multiBlock, listInnerType, obj, csc, sec, cot, negateOp,
+  multiBody, block, multiBlock, innerType, obj, csc, sec, cot, negateOp,
   equalOp, notEqualOp, greaterOp, greaterEqualOp, lessOp, lessEqualOp, plusOp,
   minusOp, multOp, divideOp, moduloOp, var, classVar, instanceVarAccess, arrayElem,
   litChar, litDouble, litInt, litString, valueOf, arg, argsList, objAccess,
@@ -217,7 +217,7 @@ instance TypeSym JavaCode where
   listType = jListType
   setType = jSetType
   arrayType = CP.arrayType
-  listInnerType = G.listInnerType
+  innerType = G.innerType
   funcType = CS.funcType -- TODO [Brandon Bosman, 05/11/2026]: fix this to work with lambda types
   void = C.void
 

--- a/code/drasil-gool/lib/Drasil/GOOL/LanguageRenderer/PythonRenderer.hs
+++ b/code/drasil-gool/lib/Drasil/GOOL/LanguageRenderer/PythonRenderer.hs
@@ -65,22 +65,22 @@ import Drasil.Shared.LanguageRenderer.Constructors (mkStmtNoEnd, mkStateVal,
   orPrec, inPrec, unExpr, unExpr', typeUnExpr, binExpr, typeBinExpr, mkClassVar,
   typeFromData)
 import qualified Drasil.Shared.LanguageRenderer.LanguagePolymorphic as G (
-  multiBody, block, multiBlock, innerType, obj, negateOp, csc, sec, cot,
-  equalOp, notEqualOp, greaterOp, greaterEqualOp, lessOp, lessEqualOp, plusOp,
-  minusOp, multOp, divideOp, moduloOp, var, classVar, instanceVarAccess,
-  arrayElem, litChar, litDouble, litInt, litString, valueOf, arg, argsList,
-  objAccess, objMethodCall, call, funcAppMixedArgs, newObjMixedArgs, lambda,
-  func, get, set, listAccess, listSet, getFunc, setFunc, stmt, loopStmt,
-  emptyStmt, assign, subAssign, objDecNew, print, closeFile, returnStmt, valStmt,
-  comment, throw, ifCond, tryCatch, construct, param, method, getMethod,
-  setMethod, function, buildClass, implementingClass, commentedClass,
-  modFromData, fileDoc, fileFromData, local)
+  multiBody, block, multiBlock, obj, negateOp, csc, sec, cot, equalOp,
+  notEqualOp, greaterOp, greaterEqualOp, lessOp, lessEqualOp, plusOp, minusOp,
+  multOp, divideOp, moduloOp, var, classVar, instanceVarAccess, arrayElem,
+  litChar, litDouble, litInt, litString, valueOf, arg, argsList, objAccess,
+  objMethodCall, call, funcAppMixedArgs, newObjMixedArgs, lambda, func, get, set,
+  listAccess, listSet, getFunc, setFunc, stmt, loopStmt, emptyStmt, assign,
+  subAssign, objDecNew, print, closeFile, returnStmt, valStmt, comment, throw,
+  ifCond, tryCatch, construct, param, method, getMethod, setMethod, function,
+  buildClass, implementingClass, commentedClass, modFromData, fileDoc,
+  fileFromData, local)
 import qualified Drasil.Shared.LanguageRenderer.CommonPseudoOO as CP
 import qualified Drasil.Shared.LanguageRenderer.Macros as M (ifExists,
   decrement1, increment1, runStrategy, stringListVals, stringListLists,
   notifyObservers', arrayDecAsList)
 import qualified Drasil.GOOL.LanguageRenderer.CommonGOOL as CG (classMethodCall,
-  listAppend, listAdd)
+  listAppend, listAdd, innerType)
 import Drasil.Shared.AST (Terminator(..), FileType(..), FileData(..), fileD,
   FuncData(..), fd, ModData(..), md, updateMod, MethodData(..), mthd,
   updateMthd, OpData(..), ParamData(..), pd, ProgData(..), progD, TypeData(..),
@@ -207,7 +207,7 @@ instance TypeSym PythonCode where
   listType t' = t' >>=(\t -> typeFromData (List (getCodeType t)) "" empty)
   setType t' = t' >>=(\t -> typeFromData (Set (getCodeType t)) "" empty)
   arrayType = listType
-  innerType = G.innerType
+  innerType = CG.innerType
   funcType = CS.funcType
   void = typeFromData Void pyVoid (text pyVoid)
 

--- a/code/drasil-gool/lib/Drasil/GOOL/LanguageRenderer/PythonRenderer.hs
+++ b/code/drasil-gool/lib/Drasil/GOOL/LanguageRenderer/PythonRenderer.hs
@@ -65,7 +65,7 @@ import Drasil.Shared.LanguageRenderer.Constructors (mkStmtNoEnd, mkStateVal,
   orPrec, inPrec, unExpr, unExpr', typeUnExpr, binExpr, typeBinExpr, mkClassVar,
   typeFromData)
 import qualified Drasil.Shared.LanguageRenderer.LanguagePolymorphic as G (
-  multiBody, block, multiBlock, listInnerType, obj, negateOp, csc, sec, cot,
+  multiBody, block, multiBlock, innerType, obj, negateOp, csc, sec, cot,
   equalOp, notEqualOp, greaterOp, greaterEqualOp, lessOp, lessEqualOp, plusOp,
   minusOp, multOp, divideOp, moduloOp, var, classVar, instanceVarAccess,
   arrayElem, litChar, litDouble, litInt, litString, valueOf, arg, argsList,
@@ -207,7 +207,7 @@ instance TypeSym PythonCode where
   listType t' = t' >>=(\t -> typeFromData (List (getCodeType t)) "" empty)
   setType t' = t' >>=(\t -> typeFromData (Set (getCodeType t)) "" empty)
   arrayType = listType
-  listInnerType = G.listInnerType
+  innerType = G.innerType
   funcType = CS.funcType
   void = typeFromData Void pyVoid (text pyVoid)
 

--- a/code/drasil-gool/lib/Drasil/GOOL/LanguageRenderer/SwiftRenderer.hs
+++ b/code/drasil-gool/lib/Drasil/GOOL/LanguageRenderer/SwiftRenderer.hs
@@ -68,16 +68,16 @@ import Drasil.Shared.LanguageRenderer.Constructors (mkStmtNoEnd, mkStateVal,
   mkVal, typeFromData, VSOp, unOpPrec, powerPrec, unExpr, unExpr', typeUnExpr,
   binExpr, binExpr', typeBinExpr, typeFromData)
 import qualified Drasil.Shared.LanguageRenderer.LanguagePolymorphic as G (
-  multiBody, block, multiBlock, innerType, obj, csc, sec, cot, negateOp,
-  equalOp, notEqualOp, greaterOp, greaterEqualOp, lessOp, lessEqualOp, plusOp,
-  minusOp, multOp, divideOp, moduloOp, var, classVar, instanceVarAccess,
-  arrayElem, litChar, litDouble, litInt, litString, valueOf, arg, argsList,
-  objAccess, objMethodCall, call, funcAppMixedArgs, newObjMixedArgs, lambda,
-  func, get, set, listAccess, listSet, getFunc, setFunc, stmt, loopStmt,
-  emptyStmt, assign, subAssign, objDecNew, print, returnStmt, valStmt, comment,
-  throw, ifCond, tryCatch, construct, param, method, getMethod, setMethod,
-  initStmts, function, docFunc, buildClass, implementingClass, docClass,
-  commentedClass, modFromData, fileDoc, fileFromData, defaultOptSpace, local)
+  multiBody, block, multiBlock, obj, csc, sec, cot, negateOp, equalOp,
+  notEqualOp, greaterOp, greaterEqualOp, lessOp, lessEqualOp, plusOp, minusOp,
+  multOp, divideOp, moduloOp, var, classVar, instanceVarAccess, arrayElem,
+  litChar, litDouble, litInt, litString, valueOf, arg, argsList, objAccess,
+  objMethodCall, call, funcAppMixedArgs, newObjMixedArgs, lambda, func, get, set,
+  listAccess, listSet, getFunc, setFunc, stmt, loopStmt, emptyStmt, assign,
+  subAssign, objDecNew, print, returnStmt, valStmt, comment, throw, ifCond,
+  tryCatch, construct, param, method, getMethod, setMethod, initStmts, function,
+  docFunc, buildClass, implementingClass, docClass, commentedClass, modFromData,
+  fileDoc, fileFromData, defaultOptSpace, local)
 import qualified Drasil.Shared.LanguageRenderer.Common as CS
 import qualified Drasil.Shared.LanguageRenderer.CommonPseudoOO as CP (
   classVarAccess, instanceVarSelf, intClass, buildModule, docMod', contains,
@@ -93,7 +93,7 @@ import qualified Drasil.Shared.LanguageRenderer.Macros as M (ifExists, decrement
   increment1, runStrategy, stringListVals, stringListLists, notifyObservers',
   makeSetterVal, arrayDecAsList)
 import qualified Drasil.GOOL.LanguageRenderer.CommonGOOL as CG (classMethodCall,
-  listAppend)
+  listAppend, innerType)
 import Drasil.Shared.AST (Terminator(..), VisibilityTag(..), qualName, FileType(..),
   FileData(..), fileD, FuncData(..), fd, ModData(..), md, updateMod,
   MethodData(..), mthd, updateMthd, OpData(..), ParamData(..), pd, ProgData(..),
@@ -219,7 +219,7 @@ instance TypeSym SwiftCode where
   listType = swiftListType
   arrayType = listType -- For now, treating arrays and lists the same, like we do for Python
   setType = listType
-  innerType = G.innerType
+  innerType = CG.innerType
   funcType = swiftFuncType
   void = swiftVoidType
 

--- a/code/drasil-gool/lib/Drasil/GOOL/LanguageRenderer/SwiftRenderer.hs
+++ b/code/drasil-gool/lib/Drasil/GOOL/LanguageRenderer/SwiftRenderer.hs
@@ -68,7 +68,7 @@ import Drasil.Shared.LanguageRenderer.Constructors (mkStmtNoEnd, mkStateVal,
   mkVal, typeFromData, VSOp, unOpPrec, powerPrec, unExpr, unExpr', typeUnExpr,
   binExpr, binExpr', typeBinExpr, typeFromData)
 import qualified Drasil.Shared.LanguageRenderer.LanguagePolymorphic as G (
-  multiBody, block, multiBlock, listInnerType, obj, csc, sec, cot, negateOp,
+  multiBody, block, multiBlock, innerType, obj, csc, sec, cot, negateOp,
   equalOp, notEqualOp, greaterOp, greaterEqualOp, lessOp, lessEqualOp, plusOp,
   minusOp, multOp, divideOp, moduloOp, var, classVar, instanceVarAccess,
   arrayElem, litChar, litDouble, litInt, litString, valueOf, arg, argsList,
@@ -219,7 +219,7 @@ instance TypeSym SwiftCode where
   listType = swiftListType
   arrayType = listType -- For now, treating arrays and lists the same, like we do for Python
   setType = listType
-  listInnerType = G.listInnerType
+  innerType = G.innerType
   funcType = swiftFuncType
   void = swiftVoidType
 

--- a/code/drasil-gool/lib/Drasil/GProc/CodeInfoProc.hs
+++ b/code/drasil-gool/lib/Drasil/GProc/CodeInfoProc.hs
@@ -91,7 +91,7 @@ instance TypeSym CodeInfoProc where
   listType      _   = noInfoVSType
   setType      _   = noInfoVSType
   arrayType     _   = noInfoVSType
-  listInnerType _   = noInfoVSType
+  innerType _   = noInfoVSType
   funcType      _ _ = noInfoVSType
   void              = noInfoVSType
 

--- a/code/drasil-gool/lib/Drasil/GProc/LanguageRenderer/AbstractProc.hs
+++ b/code/drasil-gool/lib/Drasil/GProc/LanguageRenderer/AbstractProc.hs
@@ -2,7 +2,7 @@
 {-# LANGUAGE FlexibleContexts #-}
 
 module Drasil.GProc.LanguageRenderer.AbstractProc (fileDoc, fileFromData,
-  buildModule, docMod, modFromData, listInnerType, arrayElem, listAppend,
+  buildModule, docMod, modFromData, innerType, arrayElem, listAppend,
   listAdd, funcDecDef, function
 ) where
 
@@ -82,8 +82,8 @@ modFromData n f d = modify (setModuleName n) >> onStateValue f d
 
 -- Lists and Arrays --
 
-listInnerType :: (ProcRenderSym r, UnRepr r TypeData) => VSType r -> VSType r
-listInnerType t = t >>= (convType . getInnerType . getCodeType)
+innerType :: (ProcRenderSym r, UnRepr r TypeData) => VSType r -> VSType r
+innerType t = t >>= (convType . getInnerType . getCodeType)
 
 -- | Call to append a value to a list using a function call
 listAppend :: (CommonRenderSym r) => String -> SValue r -> SValue r -> SValue r
@@ -99,7 +99,7 @@ arrayElem i' v' = do
   i <- IC.intToIndex i'
   v <- v'
   let vName = variableName v -- Slight hack; we used to add `++ "[" ++ render (RCC.value i) ++ "]"`
-      vType = listInnerType $ return $ variableType v
+      vType = innerType $ return $ variableType v
       vRender = RCC.variable v <> brackets (RCC.value i)
   mkStateVar vName vType vRender
 

--- a/code/drasil-gool/lib/Drasil/GProc/LanguageRenderer/JuliaRenderer.hs
+++ b/code/drasil-gool/lib/Drasil/GProc/LanguageRenderer/JuliaRenderer.hs
@@ -78,7 +78,7 @@ import qualified Drasil.Shared.LanguageRenderer.CLike as C (litTrue, litFalse,
 
 import qualified Drasil.GProc.LanguageRenderer.AbstractProc as A (fileDoc,
   fileFromData, buildModule, docMod, modFromData, listAppend, listAdd,
-  listInnerType, arrayElem, funcDecDef, function)
+  innerType, arrayElem, funcDecDef, function)
 import qualified Drasil.Shared.LanguageRenderer.Macros as M (increment1,
   decrement1, ifExists, stringListVals, stringListLists, arrayDecAsList)
 import Drasil.Shared.AST (Terminator(..), FileType(..), FileData(..), fileD,
@@ -193,7 +193,7 @@ instance TypeSym JuliaCode where
   listType = jlListType
   setType = jlSetType
   arrayType = listType -- Treat arrays and lists the same, as in Python
-  listInnerType = A.listInnerType
+  innerType = A.innerType
   funcType = CS.funcType
   void = jlVoidType
 

--- a/code/drasil-gool/lib/Drasil/GProc/LanguageRenderer/MatlabRenderer.hs
+++ b/code/drasil-gool/lib/Drasil/GProc/LanguageRenderer/MatlabRenderer.hs
@@ -134,7 +134,7 @@ instance TypeSym MatlabCode where
   listType = undefined
   setType = undefined
   arrayType = undefined
-  listInnerType = undefined
+  innerType = undefined
   funcType = undefined
   void = undefined
 

--- a/code/drasil-gool/lib/Drasil/Shared/InterfaceCommon.hs
+++ b/code/drasil-gool/lib/Drasil/Shared/InterfaceCommon.hs
@@ -93,7 +93,7 @@ class TypeSym r where
   listType      :: VSType r -> VSType r
   setType       :: VSType r -> VSType r
   arrayType     :: VSType r -> VSType r
-  listInnerType :: VSType r -> VSType r
+  innerType :: VSType r -> VSType r
   funcType      :: [VSType r] -> VSType r -> VSType r
   void          :: VSType r
 

--- a/code/drasil-gool/lib/Drasil/Shared/LanguageRenderer/CommonPseudoOO.hs
+++ b/code/drasil-gool/lib/Drasil/Shared/LanguageRenderer/CommonPseudoOO.hs
@@ -24,7 +24,7 @@ import Drasil.Shared.CodeType (CodeType(..))
 import Drasil.Shared.InterfaceCommon (UnRepr(..), varDecDef, bool,
   extFuncAppMixedArgs,funcType, extVar, Label, Library, MSBody, VSFunction,
   VSType, SVariable, Value, SValue, MSStatement, MSParameter, SMethod,
-  MixedCall, bodyStatements, oneLiner, TypeSym(infile, outfile, listInnerType),
+  MixedCall, bodyStatements, oneLiner, TypeSym(infile, outfile, innerType),
   getCodeType, getTypeString, VariableElim(variableName, variableType),
   ValueSym(valueType), Comparison(..), (&=), ControlStatement(returnStmt),
   VisibilitySym(..), MethodSym(function), funcApp, listSize)
@@ -200,7 +200,7 @@ arrayDec n vr scp = do
   modify $ useVarName $ variableName v
   modify $ setVarScope (variableName v) (scopeData scp)
   let tp = variableType v
-  innerTp <- zoom lensMStoVS $ listInnerType $ return tp
+  innerTp <- zoom lensMStoVS $ innerType $ return tp
   mkStmt $ renderType tp <+> RC.variable v <+> equals <+> new' <+>
     renderType innerTp <> brackets (RC.value sz)
 
@@ -307,13 +307,13 @@ listDecDef :: (CommonRenderSym r) => SVariable r -> r ScopeData ->
   [SValue r] -> MSStatement r
 listDecDef v scp vals = do
   vr <- zoom lensMStoVS v
-  let lst = IC.litList (listInnerType $ return $ variableType vr) vals
+  let lst = IC.litList (innerType $ return $ variableType vr) vals
   IC.varDecDef (return vr) scp lst
 
 setDecDef :: (CommonRenderSym r) => SVariable r -> r ScopeData -> [SValue r] -> MSStatement r
 setDecDef v scp vals = do
   vr <- zoom lensMStoVS v
-  let st = IC.litSet (listInnerType $ return $ variableType vr) vals
+  let st = IC.litSet (innerType $ return $ variableType vr) vals
   IC.varDecDef (return vr) scp st
 
 setDec :: (OORenderSym r) => (r (Value r) -> Doc) -> SValue r -> SVariable r -> r ScopeData -> MSStatement r
@@ -323,7 +323,7 @@ setDec f vl v scp = do
   mkStmt (RC.statement vd <> f sz)
 
 setMethodCall :: (OORenderSym r) => Label -> SValue r ->  SValue r -> SValue r
-setMethodCall n a b = objMethodCall (listInnerType $ onStateValue valueType a) a n [b]
+setMethodCall n a b = objMethodCall (innerType $ onStateValue valueType a) a n [b]
 
 destructorError :: String -> String
 destructorError l = "Destructors not allowed in " ++ l

--- a/code/drasil-gool/lib/Drasil/Shared/LanguageRenderer/LanguagePolymorphic.hs
+++ b/code/drasil-gool/lib/Drasil/Shared/LanguageRenderer/LanguagePolymorphic.hs
@@ -5,7 +5,7 @@
 
 -- | Implementations defined here are valid for any language renderer.
 module Drasil.Shared.LanguageRenderer.LanguagePolymorphic (fileFromData,
-  multiBody, block, multiBlock, listInnerType, obj, negateOp, csc, sec,
+  multiBody, block, multiBlock, innerType, obj, negateOp, csc, sec,
   cot, equalOp, notEqualOp, greaterOp, greaterEqualOp, lessOp, lessEqualOp,
   plusOp, minusOp, multOp, divideOp, moduloOp, var, classVar, instanceVarAccess,
   classVarAccessCheck, arrayElem, local, litChar, litDouble, litInt, litString,
@@ -31,7 +31,7 @@ import Drasil.Shared.InterfaceCommon (UnRepr(..), Label, Library, MSBody,
   IOStatement(printStr, printStrLn, printFile, printFileStr, printFileStrLn),
   ifNoElse, convType, VSBinder, BinderElim(..), getCodeType, getTypeString)
 import qualified Drasil.Shared.InterfaceCommon as IC (TypeSym(int, double, char,
-  string, arrayType, listInnerType, funcType, void), VariableSym(var),
+  string, arrayType, innerType, funcType, void), VariableSym(var),
   Literal(litInt, litFloat, litDouble, litString), VariableValue(valueOf),
   List(listSize, listAccess), StatementSym(valStmt), DeclStatement(varDecDef),
   IOStatement(print), ControlStatement(returnStmt, for, forEach), ParameterSym(param),
@@ -103,8 +103,8 @@ multiBlock bs = onStateList (toCode . vibcat) $ map (onStateValue RC.block) bs
 
 -- Types --
 
-listInnerType :: (OORenderSym r, UnRepr r TypeData) => VSType r -> VSType r
-listInnerType t = t >>= (convTypeOO . getInnerType . getCodeType)
+innerType :: (OORenderSym r, UnRepr r TypeData) => VSType r -> VSType r
+innerType t = t >>= (convTypeOO . getInnerType . getCodeType)
 
 obj :: (Monad r) => ClassName -> VSType r
 obj n = typeFromData (Object n) n (text n)
@@ -210,7 +210,7 @@ arrayElem i' v' = do
   i <- IC.intToIndex i'
   v <- v'
   let vName = variableName v ++ "[" ++ render (RC.value i) ++ "]"
-      vType = listInnerType $ return $ variableType v
+      vType = innerType $ return $ variableType v
       vRender = RC.variable v <> brackets (RC.value i)
   mkStateVar vName vType vRender
 
@@ -301,7 +301,7 @@ listAccess :: (CommonRenderSym r, UnRepr r TypeData) => SValue r -> SValue r -> 
 listAccess v i = do
   v' <- v
   let i' = IC.intToIndex i
-      t  = IC.listInnerType $ return $ valueType v'
+      t  = IC.innerType $ return $ valueType v'
       checkType (List _) = S.listAccessFunc t i'
       checkType (Set _) = S.listAccessFunc t i'
       checkType (Array _) = i' >>=

--- a/code/drasil-gool/lib/Drasil/Shared/LanguageRenderer/LanguagePolymorphic.hs
+++ b/code/drasil-gool/lib/Drasil/Shared/LanguageRenderer/LanguagePolymorphic.hs
@@ -5,9 +5,9 @@
 
 -- | Implementations defined here are valid for any language renderer.
 module Drasil.Shared.LanguageRenderer.LanguagePolymorphic (fileFromData,
-  multiBody, block, multiBlock, innerType, obj, negateOp, csc, sec,
-  cot, equalOp, notEqualOp, greaterOp, greaterEqualOp, lessOp, lessEqualOp,
-  plusOp, minusOp, multOp, divideOp, moduloOp, var, classVar, instanceVarAccess,
+  multiBody, block, multiBlock, obj, negateOp, csc, sec, cot, equalOp,
+  notEqualOp, greaterOp, greaterEqualOp, lessOp, lessEqualOp, plusOp, minusOp,
+  multOp, divideOp, moduloOp, var, classVar, instanceVarAccess,
   classVarAccessCheck, arrayElem, local, litChar, litDouble, litInt, litString,
   valueOf, arg, argsList, call, funcAppMixedArgs, newObjMixedArgs, lambda,
   objAccess, objMethodCall, func, get, set, listAccess, listSet, getFunc,
@@ -38,7 +38,7 @@ import qualified Drasil.Shared.InterfaceCommon as IC (TypeSym(int, double, char,
   IndexTranslator(intToIndex), ScopeSym(local))
 import Drasil.GOOL.InterfaceGOOL (SFile, FSModule, SClass, Initializers,
   CSStateVar, FileSym(File), ModuleSym(Module), newObj, objMethodCallNoParams,
-  ($.), AttachmentSym(..), convTypeOO)
+  ($.), AttachmentSym(..))
 import qualified Drasil.GOOL.InterfaceGOOL as IG (
   InstanceVarSelfSym(..), OOMethodSym(method), OOFunctionSym(func))
 import Drasil.Shared.RendererClassesCommon (CommonRenderSym,
@@ -64,8 +64,8 @@ import qualified Drasil.GOOL.RendererClassesOO as RC (ClassElim(..),
 import Drasil.Shared.AST (AttachmentTag(..), Terminator(..), isSource, ScopeTag(Local),
   ScopeData, sd, TypeData(..), BinderD)
 import Drasil.Shared.Helpers (doubleQuotedText, vibcat, emptyIfEmpty, toCode,
-  toState, onStateValue, on2StateValues, onStateList, getInnerType,
-  getNestDegree, on2StateWrapped)
+  toState, onStateValue, on2StateValues, onStateList, getNestDegree,
+  on2StateWrapped)
 import Drasil.Shared.LanguageRenderer (dot, ifLabel, elseLabel, access, addExt,
   FuncDocRenderer, ClassDocRenderer, ModuleDocRenderer, getterName, setterName,
   valueList, namedArgList)
@@ -102,9 +102,6 @@ multiBlock :: (CommonRenderSym r, Monad r) => [MSBlock r] -> MS (r Doc)
 multiBlock bs = onStateList (toCode . vibcat) $ map (onStateValue RC.block) bs
 
 -- Types --
-
-innerType :: (OORenderSym r, UnRepr r TypeData) => VSType r -> VSType r
-innerType t = t >>= (convTypeOO . getInnerType . getCodeType)
 
 obj :: (Monad r) => ClassName -> VSType r
 obj n = typeFromData (Object n) n (text n)
@@ -205,12 +202,12 @@ instanceVarAccess o' v' = do
         (variableType v) (R.instanceVarAccess (RC.value o) (RC.variable v))
   instanceVarAccess' (variableBind v)
 
-arrayElem :: (OORenderSym r, UnRepr r TypeData) => SValue r -> SVariable r -> SVariable r
+arrayElem :: (OORenderSym r) => SValue r -> SVariable r -> SVariable r
 arrayElem i' v' = do
   i <- IC.intToIndex i'
   v <- v'
   let vName = variableName v ++ "[" ++ render (RC.value i) ++ "]"
-      vType = innerType $ return $ variableType v
+      vType = IC.innerType $ return $ variableType v
       vRender = RC.variable v <> brackets (RC.value i)
   mkStateVar vName vType vRender
 

--- a/code/drasil-gool/lib/Drasil/Shared/LanguageRenderer/LoggingFor.hs
+++ b/code/drasil-gool/lib/Drasil/Shared/LanguageRenderer/LoggingFor.hs
@@ -124,7 +124,7 @@ instance TypeSym (LoggingFor lang) where
   listType = listType
   setType = setType
   arrayType = arrayType
-  listInnerType = listInnerType
+  innerType = innerType
   funcType = funcType
   void = void
 

--- a/code/drasil-gool/lib/Drasil/Shared/LanguageRenderer/Macros.hs
+++ b/code/drasil-gool/lib/Drasil/Shared/LanguageRenderer/Macros.hs
@@ -16,7 +16,7 @@ import Drasil.Shared.InterfaceCommon (UnRepr(..), Label, MSBody, MSBlock,
   BooleanExpression((?&&), (?||)), at, StatementSym(multi),
   AssignStatement((&+=), (&-=), (&++)), (&=), convScope)
 import qualified Drasil.Shared.InterfaceCommon as IC (BlockSym(block),
-  TypeSym(int, listInnerType), VariableSym(var), ScopeSym(..), Literal(..),
+  TypeSym(int, innerType), VariableSym(var), ScopeSym(..), Literal(..),
   VariableValue(valueOf), ValueExpression(notNull),
   List(listSize, listAppend, listAccess), IndexTranslator(intToIndex),
   StatementSym(valStmt, emptyStmt), AssignStatement(assign),
@@ -168,7 +168,7 @@ stringListLists lsts sl = do
       (IC.litInt 1) (bodyStatements $ appendLists (map IC.valueOf lsts) 0)
     appendLists [] _ = []
     appendLists (v:vs) n = IC.valStmt (IC.listAppend v (cast
-      (IC.listInnerType $ onStateValue valueType v)
+      (IC.innerType $ onStateValue valueType v)
       (IC.listAccess sl ((v_i #* numLists) #+ IC.litInt n))))
       : appendLists vs (n+1)
     numLists = IC.litInt (toInteger $ length lsts)
@@ -206,7 +206,7 @@ notifyObservers' f t = IC.forRange observerIndex initv (IC.listSize $ obsList t 
 arrayDecAsList :: (CommonRenderSym r) => Integer -> SVariable r -> r ScopeData -> MSStatement r
 arrayDecAsList len vr scp = do
   vr' <- zoom lensMStoVS vr
-  let innerTp = IC.listInnerType $ return $ variableType vr'
+  let innerTp = IC.innerType $ return $ variableType vr'
   i <- genVarName [] "i"
   multi [
     IC.varDecDef vr scp (IC.litList innerTp []),


### PR DESCRIPTION
And moved the OO implementation from `LanguagePolymorphic` to `CommonGOOL`.

Closes #5178 

I was tempted to change it from a method to a pair of functions (for GOOL and GProc), but too many other things rely on it. I would have had to separate too many other functions into OO and Proc counterparts, so leaving it as a method seems cleaner.