### PR TITLE
Use new `DefinedQuantityDict` constructors in most places

### DIFF
--- a/code/drasil-code/lib/Language/Drasil/CodeSpec.hs
+++ b/code/drasil-code/lib/Language/Drasil/CodeSpec.hs
@@ -192,9 +192,9 @@ oldcodeSpec sys@S.ICO{ S._inputs = ins
 -- | Convert a 'Func' to an implementation-stage 'DefinedQuantityDict' representing the
 -- function.
 asVC :: Func -> DefinedQuantityDict
-asVC (FDef (FuncDef n d _ _ _ _)) = dqdNoUnit (cncpt''' (mkUid n) (nounPhraseSP n) (S d)) (Variable n) Real
-asVC (FDef (CtorDef n d _ _ _))   = dqdNoUnit (cncpt''' (mkUid n) (nounPhraseSP n) (S d)) (Variable n) Real
-asVC (FData (FuncData n d _))     = dqdNoUnit (cncpt''' (mkUid n) (nounPhraseSP n) (S d)) (Variable n) Real
+asVC (FDef (FuncDef n d _ _ _ _)) = quantNoUnit (mkUid n) (nounPhraseSP n) (S d) (Variable n) Real
+asVC (FDef (CtorDef n d _ _ _))   = quantNoUnit (mkUid n) (nounPhraseSP n) (S d) (Variable n) Real
+asVC (FData (FuncData n d _))     = quantNoUnit (mkUid n) (nounPhraseSP n) (S d) (Variable n) Real
 
 -- | Get a 'UID' of a chunk corresponding to a 'Func'.
 funcUID :: Func -> UID

--- a/code/drasil-example/bss/lib/Drasil/BinaryStar/Unitals.hs
+++ b/code/drasil-example/bss/lib/Drasil/BinaryStar/Unitals.hs
@@ -238,15 +238,15 @@ labely = label "y"
 
 -- | Summation index variable i
 index :: DefinedQuantityDict
-index = dqd' (cncpt''' (mkUid "index") (nounPhraseSP "index")
-  (S "a number representing a single body"))
-  (const lI) Integer Nothing
+index = quantNoUnit (mkUid "index") (nounPhraseSP "index")
+  (S "a number representing a single body")
+  lI Integer
 
 -- | Number of bodies n
 numbBodies :: DefinedQuantityDict
-numbBodies = dqd' (cncpt''' (mkUid "n") (nounPhraseSP "number of bodies")
-  (S "the number of point masses in the system"))
-  (const lN) Integer Nothing
+numbBodies = quantNoUnit (mkUid "n") (nounPhraseSP "number of bodies")
+  (S "the number of point masses in the system")
+  lN Integer
 
 ---------------------------------------------------------
 -- ODE state vector (for code generation)

--- a/code/drasil-example/dblpend/lib/Drasil/DblPend/GenDefs.hs
+++ b/code/drasil-example/dblpend/lib/Drasil/DblPend/GenDefs.hs
@@ -6,6 +6,7 @@ module Drasil.DblPend.GenDefs (genDefns, velXGD_1, velYGD_1,
 import Prelude hiding (cos, sin, sqrt)
 import qualified Data.List.NonEmpty as NE
 
+import Drasil.Database (mkUid)
 import Language.Drasil
 import qualified Language.Drasil.Development as D
 import Data.List.Extras (weave)
@@ -222,9 +223,9 @@ xForceGD_1 = gdNoRefs (equationalRealmU "xForce1" xForceMD_1)
 
 xForceMD_1 :: MultiDefn ModelExpr
 xForceMD_1 = mkMultiDefnForQuant quan EmptyS defns
-    where quan  = dqd' (dccA "force" (horizontalForce `onThe` firstObject)
-                    "the horizontal force acting on the first object"
-                    Nothing) (symbol force) Real (getUnit force)
+    where quan  = quantAU (mkUid "force") (horizontalForce `onThe` firstObject)
+                    (S "the horizontal force acting on the first object")
+                    Nothing (symbol force) Real (getUnit force)
           defns = NE.fromList [
                     mkDefiningExpr "xForceWithMass1"
                       [] EmptyS $ express $ forceGQD ^. defnExpr,
@@ -243,9 +244,9 @@ yForceGD_1 = gdNoRefs (equationalRealmU "yForce1" yForceMD_1)
 
 yForceMD_1 :: MultiDefn ModelExpr
 yForceMD_1 = mkMultiDefnForQuant quan EmptyS defns
-    where quan  = dqd' (dccA "force" (verticalForce `onThe` firstObject)
-                    "the vertical force acting on the first object"
-                    Nothing) (symbol force) Real (getUnit force)
+    where quan  = quantAU (mkUid "force") (verticalForce `onThe` firstObject)
+                    (S "the vertical force acting on the first object")
+                    Nothing (symbol force) Real (getUnit force)
           defns = NE.fromList [
                     mkDefiningExpr "yForceWithMass1"
                       [] EmptyS $ express $ forceGQD ^. defnExpr,
@@ -264,9 +265,9 @@ xForceGD_2 = gdNoRefs (equationalRealmU "xForce2" xForceMD_2)
 
 xForceMD_2 :: MultiDefn ModelExpr
 xForceMD_2 = mkMultiDefnForQuant quan EmptyS defns
-    where quan  = dqd' (dccA "force" (horizontalForce `onThe` secondObject)
-                    "the horizontal force acting on the second object"
-                    Nothing) (symbol force) Real (getUnit force)
+    where quan  = quantAU (mkUid "force") (horizontalForce `onThe` secondObject)
+                    (S "the horizontal force acting on the second object")
+                    Nothing (symbol force) Real (getUnit force)
           defns = NE.fromList [
                     mkDefiningExpr "xForceWithMass2"
                       [] EmptyS $ express $ forceGQD ^. defnExpr,
@@ -285,9 +286,9 @@ yForceGD_2 = gdNoRefs (equationalRealmU "yForce2" yForceMD_2)
 
 yForceMD_2 :: MultiDefn ModelExpr
 yForceMD_2 = mkMultiDefnForQuant quan EmptyS defns
-    where quan  = dqd' (dccA "force" (verticalForce `onThe` secondObject)
-                    "the vertical force acting on the second object"
-                    Nothing) (symbol force) Real (getUnit force)
+    where quan  = quantAU (mkUid "force") (verticalForce `onThe` secondObject)
+                    (S "the vertical force acting on the second object")
+                    Nothing (symbol force) Real (getUnit force)
           defns = NE.fromList [
                     mkDefiningExpr "yForceWithMass2"
                       [] EmptyS $ express $ forceGQD ^. defnExpr,

--- a/code/drasil-example/gamephysics/lib/Drasil/GamePhysics/TMods.hs
+++ b/code/drasil-example/gamephysics/lib/Drasil/GamePhysics/TMods.hs
@@ -3,6 +3,7 @@ module Drasil.GamePhysics.TMods (tMods, newtonSL, newtonSLR, newtonTL, newtonLUG
 
 import qualified Data.List.NonEmpty as NE
 
+import Drasil.Database (mkUid)
 import Language.Drasil
 import Theory.Drasil
 import qualified Language.Drasil.Sentence.Combinators as S
@@ -55,8 +56,8 @@ newtonLUG :: TheoryModel
 newtonLUG = tmNoRefs newtonLUGModel "UniversalGravLaw" newtonLUGNotes
 
 newtonForceQuant :: DefinedQuantityDict
-newtonForceQuant = dqd' (dccA "force" (nounPhraseSP "Newton's law of universal gravitation")
-                    "the gravitational force between two masses" Nothing) (symbol force) Real Nothing
+newtonForceQuant = quantNoUnit' (mkUid "force") (nounPhraseSP "Newton's law of universal gravitation")
+                    (S "the gravitational force between two masses") (symbol force) Real
 
 -- Can't include fractions within a sentence (in the part where 'r denotes the
 -- unit displacement vector, equivalent to r/||r||' (line 184)). Changed to a

--- a/code/drasil-example/gamephysics/lib/Drasil/GamePhysics/Unitals.hs
+++ b/code/drasil-example/gamephysics/lib/Drasil/GamePhysics/Unitals.hs
@@ -304,8 +304,8 @@ unitless :: [DefinedQuantityDict]
 unitless = QM.pi_ : [numParticles]
 
 numParticles :: DefinedQuantityDict
-numParticles = dqdNoUnit (cncpt''' (mkUid "n") (nounPhraseSP "number of particles in a rigid body")
-  (S "the number of particles in a rigidbody")) lN Integer
+numParticles = quantNoUnit (mkUid "n") (nounPhraseSP "number of particles in a rigid body")
+  (S "the number of particles in a rigidbody") lN Integer
 
 -----------------------
 -- CONSTRAINT CHUNKS --

--- a/code/drasil-example/glassbr/lib/Drasil/GlassBR/Unitals.hs
+++ b/code/drasil-example/glassbr/lib/Drasil/GlassBR/Unitals.hs
@@ -89,8 +89,8 @@ aspectRatio = uq (constrained' (dqdNoUnit aspectRatioCon (variable "AR") Real)
   [ physRange $ UpFrom (Inc, exactDbl 1),
     sfwrRange $ UpTo (Inc, sy arMax)] (dbl 1.5)) defaultUncrt
 
-pbTol = uq (constrained' (dqdNoUnit (cncpt''' (mkUid "pbTol") (nounPhraseSP "tolerable probability of breakage")
-  (S "the tolerable probability of breakage of the glass plate"))
+pbTol = uq (constrained' (quantNoUnit (mkUid "pbTol") (nounPhraseSP "tolerable probability of breakage")
+  (S "the tolerable probability of breakage of the glass plate")
   (sub cP (Concat [lBreak, lTol])) Real)
   [probConstr] (dbl 0.008)) (uncty 0.001 Nothing)
 
@@ -100,8 +100,8 @@ charWeight = uqcND "charWeight" (nounPhraseSP "charge weight")
     sfwrRange $ Bounded (Inc, sy cWeightMin) (Inc, sy cWeightMax)]
     (exactDbl 42) defaultUncrt
 
-tNT = uq (constrained' (dqdNoUnit (cncpt''' (mkUid "tNT") (nounPhraseSP "TNT equivalent factor")
-  (S "the TNT equivalent factor"))
+tNT = uq (constrained' (quantNoUnit (mkUid "tNT") (nounPhraseSP "TNT equivalent factor")
+  (S "the TNT equivalent factor")
   (variable "TNT") Real)
   [ gtZeroConstr ] (exactDbl 1)) defaultUncrt
 
@@ -163,9 +163,9 @@ dimMin     = mkQuantDef (uc' "dimMin"
   (S "the minimum value for one of the dimensions of the glass plate")
   (subMin lD) Real metre) (dbl 0.1)
 
-arMax     = mkQuantDef (dqdNoUnit (cncpt''' (mkUid "arMax")
+arMax     = mkQuantDef (quantNoUnit (mkUid "arMax")
   (nounPhraseSP "maximum aspect ratio")
-  (S "the maximum aspect ratio"))
+  (S "the maximum aspect ratio")
   (subMax (variable "AR")) Real) (exactDbl 5)
 
 cWeightMax = mkQuantDef (uc' "cWeightMax"
@@ -188,14 +188,14 @@ sdMin     = mkQuantDef (uc' "sdMin"
   (S "the minimum stand off distance permissible for input")
   (subMin (eqSymb standOffDist)) Real metre) (exactDbl 6)
 
-stressDistFacMin = mkQuantDef (dqdNoUnit (cncpt''' (mkUid "stressDistFacMin")
+stressDistFacMin = mkQuantDef (quantNoUnit (mkUid "stressDistFacMin")
   (nounPhraseSP "minimum value for the stress distribution factor")
-  (S "the minimum value for the stress distribution factor"))
+  (S "the minimum value for the stress distribution factor")
   (subMin (eqSymb stressDistFac)) Real) (exactDbl 1)
 
-stressDistFacMax = mkQuantDef (dqdNoUnit (cncpt''' (mkUid "stressDistFacMax")
+stressDistFacMax = mkQuantDef (quantNoUnit (mkUid "stressDistFacMax")
   (nounPhraseSP "maximum value for the stress distribution factor")
-  (S "the maximum value for the stress distribution factor"))
+  (S "the maximum value for the stress distribution factor")
   (subMax (eqSymb stressDistFac)) Real) (exactDbl 32)
 
 unitalSymbols :: [UnitalChunk]
@@ -260,36 +260,36 @@ riskFun, isSafePb, isSafeProb, isSafeLR, isSafeLoad, sdfTol,
 
 gTF, loadSF, loadDF :: DefinedQuantityDict
 
-dimlessLoad = dqdNoUnit (cncpt''' (mkUid "dimlessLoad") (nounPhraseSP "dimensionless load")
-  (S "the dimensionless load")) (hat lQ) Real
+dimlessLoad = quantNoUnit (mkUid "dimlessLoad") (nounPhraseSP "dimensionless load")
+  (S "the dimensionless load") (hat lQ) Real
 
 gTF           = dqdNoUnit glTyFac (variable "GTF") Integer
 
-isSafePb   = dqdNoUnit (cncpt''' (mkUid "isSafePb") (nounPhraseSP "probability of glass breakage safety requirement")
-  (S "the probability of glass breakage safety requirement")) (variable "isSafePb") Boolean
-isSafeProb = dqdNoUnit (cncpt''' (mkUid "isSafeProb") (nounPhraseSP "probability of failure safety requirement")
-  (S "the probability of failure safety requirement")) (variable "isSafeProb") Boolean
-isSafeLR   = dqdNoUnit (cncpt''' (mkUid "isSafeLR")   (nounPhraseSP "3 second load equivalent resistance safety requirement")
-  (S "the 3 second load equivalent resistance safety requirement")) (variable "isSafeLR") Boolean
-isSafeLoad = dqdNoUnit (cncpt''' (mkUid "isSafeLoad") (nounPhraseSP "load resistance safety requirement")
-  (S "the load resistance safety requirement")) (variable "isSafeLoad") Boolean
+isSafePb   = quantNoUnit (mkUid "isSafePb") (nounPhraseSP "probability of glass breakage safety requirement")
+  (S "the probability of glass breakage safety requirement") (variable "isSafePb") Boolean
+isSafeProb = quantNoUnit (mkUid "isSafeProb") (nounPhraseSP "probability of failure safety requirement")
+  (S "the probability of failure safety requirement") (variable "isSafeProb") Boolean
+isSafeLR   = quantNoUnit (mkUid "isSafeLR")   (nounPhraseSP "3 second load equivalent resistance safety requirement")
+  (S "the 3 second load equivalent resistance safety requirement") (variable "isSafeLR") Boolean
+isSafeLoad = quantNoUnit (mkUid "isSafeLoad") (nounPhraseSP "load resistance safety requirement")
+  (S "the load resistance safety requirement") (variable "isSafeLoad") Boolean
 
-interpY = dqdNoUnit (cncpt''' (mkUid "interpY") (nounPhraseSP "interpY")
-  (S "interpolated y")) (variable "interpY") (mkFunction [String, Real, Real] Real)
-interpZ = dqdNoUnit (cncpt''' (mkUid "interpZ") (nounPhraseSP "interpZ")
-  (S "interpolated z")) (variable "interpZ") (mkFunction [String, Real, Real] Real)
+interpY = quantNoUnit (mkUid "interpY") (nounPhraseSP "interpY")
+  (S "interpolated y") (variable "interpY") (mkFunction [String, Real, Real] Real)
+interpZ = quantNoUnit (mkUid "interpZ") (nounPhraseSP "interpZ")
+  (S "interpolated z") (variable "interpZ") (mkFunction [String, Real, Real] Real)
 
 loadDF        = dqdNoUnit loadDurFac (variable "LDF") Real
 loadSF        = dqdNoUnit loadShareFac (variable "LSF") Real
 
-riskFun = dqdNoUnit (cncpt''' (mkUid "riskFun") (nounPhraseSP "risk of failure")
-  (S "the percentage risk of the glass slab failing to resist the blast")) cB Real
+riskFun = quantNoUnit (mkUid "riskFun") (nounPhraseSP "risk of failure")
+  (S "the percentage risk of the glass slab failing to resist the blast") cB Real
 
-sdfTol = dqdNoUnit (cncpt''' (mkUid "sdfTol") (nounPhraseSP "tolerable stress distribution factor")
-  (S "the tolerable stress distribution factor")) (sub (eqSymb stressDistFac) lTol) Real
+sdfTol = quantNoUnit (mkUid "sdfTol") (nounPhraseSP "tolerable stress distribution factor")
+  (S "the tolerable stress distribution factor") (sub (eqSymb stressDistFac) lTol) Real
 
-tolLoad = dqdNoUnit (cncpt''' (mkUid "tolLoad") (nounPhraseSP "tolerable load")
-  (S "the tolerable load")) (sub (eqSymb dimlessLoad) lTol) Real
+tolLoad = quantNoUnit (mkUid "tolLoad") (nounPhraseSP "tolerable load")
+  (S "the tolerable load") (sub (eqSymb dimlessLoad) lTol) Real
 
 lBreak, lDur, lFail, lTol :: Symbol
 lBreak = label "b"

--- a/code/drasil-example/hghc/lib/Drasil/HGHC/HeatTransfer.hs
+++ b/code/drasil-example/hghc/lib/Drasil/HGHC/HeatTransfer.hs
@@ -27,17 +27,17 @@ htInputs = NE.map dqdWr htVars
 htOutputs = NE.map dqdWr qDefs
 
 cladThick, coolFilmCond, gapFilmCond, cladCond :: DefinedQuantityDict
-cladThick    = dqdNoUnit (cncpt''' (mkUid "cladThick")    (cn''' "clad thickness")
-  (S "the clad thickness"))
+cladThick    = quantNoUnit (mkUid "cladThick")    (cn''' "clad thickness")
+  (S "the clad thickness")
   (sub lTau lClad) Real
-coolFilmCond = dqdNoUnit (cncpt''' (mkUid "coolFilmCond") (cn' "initial coolant film conductance")
-  (S "the initial coolant film conductance"))
+coolFilmCond = quantNoUnit (mkUid "coolFilmCond") (cn' "initial coolant film conductance")
+  (S "the initial coolant film conductance")
   (sub lH lCoolant) Real
-gapFilmCond  = dqdNoUnit (cncpt''' (mkUid "gapFilmCond")  (cn' "initial gap film conductance")
-  (S "the initial gap film conductance"))
+gapFilmCond  = quantNoUnit (mkUid "gapFilmCond")  (cn' "initial gap film conductance")
+  (S "the initial gap film conductance")
   (sub lH lGap) Real
-cladCond     = dqdNoUnit (cncpt''' (mkUid "cladCond")     (cnIES "clad conductivity")
-  (S "the clad conductivity"))
+cladCond     = quantNoUnit (mkUid "cladCond")     (cnIES "clad conductivity")
+  (S "the clad conductivity")
   (sub lK lClad) Real
 
 htTransCladCoolEq, htTransCladFuelEq :: Expr

--- a/code/drasil-example/pdcontroller/lib/Drasil/PDController/Unitals.hs
+++ b/code/drasil-example/pdcontroller/lib/Drasil/PDController/Unitals.hs
@@ -132,59 +132,59 @@ opProcessVariable
 dqdProcessVariableTD = dqdWr opProcessVariable
 
 dqdSetPointFD
-  = dqdNoUnit (cncpt''' (mkUid "dqdSetPointFD") (setPoint `inThe` ccFrequencyDomain)
-    (S "the set point in the frequency domain")) symYrS Real
+  = quantNoUnit (mkUid "dqdSetPointFD") (setPoint `inThe` ccFrequencyDomain)
+    (S "the set point in the frequency domain") symYrS Real
 
-dqdProcessVariableFD = dqdNoUnit (cncpt''' (mkUid "dqdProcessVariableFD")
-  (processVariable `inThe` ccFrequencyDomain) (S "the process variable in the frequency domain")) symYS Real
+dqdProcessVariableFD = quantNoUnit (mkUid "dqdProcessVariableFD")
+  (processVariable `inThe` ccFrequencyDomain) (S "the process variable in the frequency domain") symYS Real
 
-dqdProcessErrorFD = dqdNoUnit (cncpt''' (mkUid "dqdProcessErrorFD") (processError `inThe`
-  ccFrequencyDomain) (S "the process error in the time domain")) symES Real
+dqdProcessErrorFD = quantNoUnit (mkUid "dqdProcessErrorFD") (processError `inThe`
+  ccFrequencyDomain) (S "the process error in the time domain") symES Real
 
-dqdPropControlFD  = dqdNoUnit (cncpt''' (mkUid "dqdPropControlFD") (propControl `inThe`
-  ccFrequencyDomain) (S "the proportional control in the frequency domain")) symPS Real
+dqdPropControlFD  = quantNoUnit (mkUid "dqdPropControlFD") (propControl `inThe`
+  ccFrequencyDomain) (S "the proportional control in the frequency domain") symPS Real
 
-dqdDerivativeControlFD = dqdNoUnit (cncpt''' (mkUid "dqdDerivativeControlFD") (derControl `inThe`
-  ccFrequencyDomain) (S "the derivative control in the frequency domain")) symDS Real
+dqdDerivativeControlFD = quantNoUnit (mkUid "dqdDerivativeControlFD") (derControl `inThe`
+  ccFrequencyDomain) (S "the derivative control in the frequency domain") symDS Real
 
-dqdCtrlVarFD = dqdNoUnit (cncpt''' (mkUid "dqdCtrlVarFD") (controlVariable `inThe`
-  ccFrequencyDomain) (S "the control variable in the frequency domain")) symCS Real
+dqdCtrlVarFD = quantNoUnit (mkUid "dqdCtrlVarFD") (controlVariable `inThe`
+  ccFrequencyDomain) (S "the control variable in the frequency domain") symCS Real
 
 dqdLaplaceTransform
-  = dqdNoUnit (cncpt''' (mkUid "dqdLaplaceTransform")
+  = quantNoUnit (mkUid "dqdLaplaceTransform")
       (pn "Laplace Transform of a function")
-      (S "the laplace transform of a function"))
+      (S "the laplace transform of a function")
       symFS
       Real
 
 dqdFreqDomain
-  = dqdNoUnit (cncpt''' (mkUid "dqdFreqDomain") (pn "Complex frequency-domain parameter")
-      (S "the complex frequency-domain parameter"))
+  = quantNoUnit (mkUid "dqdFreqDomain") (pn "Complex frequency-domain parameter")
+      (S "the complex frequency-domain parameter")
       syms
       Real
 
 dqdFxnTDomain
-  = dqdNoUnit (cncpt''' (mkUid "dqdFxnTDomain") (pn "Function in the time domain")
-      (S "a function in the time domain")) symFt
+  = quantNoUnit (mkUid "dqdFxnTDomain") (pn "Function in the time domain")
+      (S "a function in the time domain") symFt
       Real
 
 dqdInvLaplaceTransform
-  = dqdNoUnit (cncpt''' (mkUid "dqdInvLaplaceTransform")
+  = quantNoUnit (mkUid "dqdInvLaplaceTransform")
       (pn "Inverse Laplace Transform of a function")
-      (S "the inverse Laplace transform of a function"))
+      (S "the inverse Laplace transform of a function")
       syminvLaplace
       Real
 
 dqdDampingCoeff
-  = dqdNoUnit (cncpt''' (mkUid "dqdDampingCoeff") (pn "Damping coefficient of the spring")
-      (S "the damping coefficient of the spring"))
+  = quantNoUnit (mkUid "dqdDampingCoeff") (pn "Damping coefficient of the spring")
+      (S "the damping coefficient of the spring")
       symDampingCoeff
       Real
 
 -- TODO: Create a separate description for the stiffness coefficient to state
 -- that it is the "stiffness coefficient of the spring" (#4275)
 dqdStiffnessCoeff
-  = dqd (dccWDS "dqdStiffnessCoeff" (ccStiffCoeff ^. term) (ccStiffCoeff ^. defn))
+  = quant (mkUid "dqdStiffnessCoeff") (ccStiffCoeff ^. term) (ccStiffCoeff ^. defn)
       symStifnessCoeff
       Real
       second

--- a/code/drasil-example/sglpend/lib/Drasil/SglPend/GenDefs.hs
+++ b/code/drasil-example/sglpend/lib/Drasil/SglPend/GenDefs.hs
@@ -14,6 +14,7 @@ import Data.Drasil.Concepts.Physics (pendulum, weight, shm)
 import Data.Drasil.Quantities.PhysicalProperties (mass, len)
 import Data.Drasil.Theories.Physics (newtonSLR)
 
+import Drasil.Database (mkUid)
 import Language.Drasil
 import Language.Drasil.Document
 import qualified Language.Drasil.Development as D
@@ -147,9 +148,9 @@ hForceOnPendulumGD = gdNoRefs (equationalRealmU "hForceOnPendulum" hForceOnPendu
 
 hForceOnPendulumMD :: MultiDefn ModelExpr
 hForceOnPendulumMD = mkMultiDefnForQuant quan EmptyS defns
-    where quan  = dqd' (dccA "force" (horizontalForce `onThe` pendulum)
-                    "the horizontal force acting on the pendulum"
-                    Nothing) (symbol force) Real (getUnit force)
+    where quan  = quantAU (mkUid "force") (horizontalForce `onThe` pendulum)
+                    (S "the horizontal force acting on the pendulum")
+                    Nothing (symbol force) Real (getUnit force)
           defns = NE.fromList [
                     mkDefiningExpr "hForceOnPendulumViaComponent"
                       [] EmptyS $ express E.hForceOnPendulumViaComponent,
@@ -167,9 +168,9 @@ vForceOnPendulumGD = gdNoRefs (equationalRealmU "vForceOnPendulum" vForceOnPendu
 
 vForceOnPendulumMD :: MultiDefn ModelExpr
 vForceOnPendulumMD = mkMultiDefnForQuant quan EmptyS defns
-    where quan  = dqd' (dccA "force" (verticalForce `onThe` pendulum)
-                    "the vertical force acting on the pendulum"
-                    Nothing) (symbol force) Real (getUnit force)
+    where quan  = quantAU (mkUid "force") (verticalForce `onThe` pendulum)
+                    (S "the vertical force acting on the pendulum")
+                    Nothing (symbol force) Real (getUnit force)
           defns = NE.fromList [
                     mkDefiningExpr "vForceOnPendulumViaComponent"
                       [] EmptyS $ express E.vForceOnPendulumViaComponent,

--- a/code/drasil-example/ssp/lib/Drasil/SSP/Unitals.hs
+++ b/code/drasil-example/ssp/lib/Drasil/SSP/Unitals.hs
@@ -169,9 +169,9 @@ waterWeight = uqc "gamma_w" (cn "unit weight of water")
   (exactDbl 9800) defaultUncrt
 
 constF :: DefinedQuantityDict
-constF = dqd' (cncpt''' (mkUid "const_f") (nounPhraseSP "decision on f")
+constF = quantNoUnit (mkUid "const_f") (nounPhraseSP "decision on f")
   (S ("a Boolean decision on which form of f the user desires: constant if true," ++
-  " or half-sine if false"))) (const (variable "const_f")) Boolean Nothing
+  " or half-sine if false")) (variable "const_f") Boolean
 
 {-Output Variables-} --FIXME: See if there should be typical values
 fs, coords :: ConstrConcept
@@ -179,9 +179,9 @@ fs = constrained' (dqd' fsConcept (const $ sub cF lSafety) Real Nothing)
   [gtZeroConstr] (exactDbl 1)
 
 fsMin :: DefinedQuantityDict -- This is a hack to remove the use of indexing for 'min'.
-fsMin = dqd' (cncpt''' (mkUid "fsMin") (cn "minimum factor of safety")
-  (S "the minimum factor of safety associated with the critical slip surface"))
-  (const $ supMin (eqSymb fs)) Real Nothing
+fsMin = quantNoUnit (mkUid "fsMin") (cn "minimum factor of safety")
+  (S "the minimum factor of safety associated with the critical slip surface")
+  (supMin (eqSymb fs)) Real
 -- Once things are converted to the new style of instance models, this will
 -- be removed/fixed.
 
@@ -448,55 +448,55 @@ unitless = [earthqkLoadFctr, normToShear, scalFunc, numbSlices, minFunction,
 earthqkLoadFctr, normToShear, scalFunc, numbSlices,
   minFunction, mobShrC, shrResC, index, varblV :: DefinedQuantityDict
 
-earthqkLoadFctr = dqd' (cncpt''' (mkUid "K_c") (nounPhraseSP "seismic coefficient")
+earthqkLoadFctr = quantNoUnit (mkUid "K_c") (nounPhraseSP "seismic coefficient")
   (S ("the proportionality factor of force that weight pushes outwards; " ++
-   "caused by seismic earth movements")))
-  (const $ sub cK lCoeff) Real Nothing
+   "caused by seismic earth movements"))
+  (sub cK lCoeff) Real
 
-normToShear = dqd' (cncpt''' (mkUid "lambda") (nounPhraseSP "proportionality constant")
-  (S "the ratio of the interslice normal to the interslice shear force"))
-  (const lLambda) Real Nothing
+normToShear = quantNoUnit (mkUid "lambda") (nounPhraseSP "proportionality constant")
+  (S "the ratio of the interslice normal to the interslice shear force")
+  lLambda Real
 
-scalFunc = dqd' (dccWDS "f_i"
+scalFunc = quantNoUnit (mkUid "f_i")
   (nounPhraseSP "interslice normal to shear force ratio variation function")
   (S "a function" `S.of_` D.toSent (phraseNP (distance `inThe` xDir)) +:+
-   S "that describes the variation" `S.ofThe` S "interslice normal to shear ratio"))
-  (const (vec lF)) Real Nothing
+   S "that describes the variation" `S.ofThe` S "interslice normal to shear ratio")
+  (vec lF) Real
 
 -- As we're going to subtract from this, can't type it 'Natural'.
-numbSlices = dqd' (cncpt''' (mkUid "n") (nounPhraseSP "number of slices")
-  (S "the number of slices into which the slip surface is divided"))
-  (const lN) Integer Nothing
+numbSlices = quantNoUnit (mkUid "n") (nounPhraseSP "number of slices")
+  (S "the number of slices into which the slip surface is divided")
+  lN Integer
 
 -- horrible hack, but it's only used once, so...
-minFunction = dqd' (cncpt''' (mkUid "Upsilon") (nounPhraseSP "minimization function")
-  (S "generic minimization function or algorithm"))
-  (const cUpsilon) (mkFunction (replicate 10 Real) Real) Nothing
+minFunction = quantNoUnit (mkUid "Upsilon") (nounPhraseSP "minimization function")
+  (S "generic minimization function or algorithm")
+  cUpsilon (mkFunction (replicate 10 Real) Real)
 
-mobShrC = dqd' (cncpt''' (mkUid "Psi")
+mobShrC = quantNoUnit (mkUid "Psi")
   (nounPhraseSP "second function for incorporating interslice forces into shear force")
   (S ("the function for converting mobile shear " ++ wiif ++
-   ", to a calculation considering the interslice forces")))
-  (const (vec cPsi)) (Vect Real) Nothing
+   ", to a calculation considering the interslice forces"))
+  (vec cPsi) (Vect Real)
 
-shrResC = dqd' (cncpt''' (mkUid "Phi")
+shrResC = quantNoUnit (mkUid "Phi")
   (nounPhraseSP "first function for incorporating interslice forces into shear force")
   (S ("the function for converting resistive shear " ++ wiif ++
-   ", to a calculation considering the interslice forces")))
-  (const (vec cPhi)) (Vect Real) Nothing
+   ", to a calculation considering the interslice forces"))
+  (vec cPhi) (Vect Real)
 
 --------------------
 -- Index Function --
 --------------------
 
-varblV = dqd' (cncpt''' (mkUid "varblV") (nounPhraseSP "local index")
-  (S "used as a bound variable index in calculations"))
-  (const lV) Natural Nothing
+varblV = quantNoUnit (mkUid "varblV") (nounPhraseSP "local index")
+  (S "used as a bound variable index in calculations")
+  lV Natural
 
 -- As we do arithmetic on index, must type it 'Integer' right now
-index = dqd' (cncpt''' (mkUid "index") (nounPhraseSP "index")
-  (S "a number representing a single slice"))
-  (const lI) Integer Nothing
+index = quantNoUnit (mkUid "index") (nounPhraseSP "index")
+  (S "a number representing a single slice")
+  lI Integer
 
 -- FIXME: move to drasil-lang
 indx1 :: (ExprC r, LiteralC r, Quantity a) => a -> r

--- a/code/drasil-example/swhs/lib/Drasil/SWHS/Unitals.hs
+++ b/code/drasil-example/swhs/lib/Drasil/SWHS/Unitals.hs
@@ -202,37 +202,37 @@ unitless = [uNormalVect, dqdWr surface, eta, meltFrac, gradient, fracMin, consTo
 eta, meltFrac, fracMin, consTol, aspectRatio, aspectRatioMin, aspectRatioMax :: DefinedQuantityDict
 
 -- FIXME: should this have units?
-eta = dqd' (cncpt''' (mkUid "eta") (nounPhraseSP "ODE parameter related to decay rate")
-  (S "derived parameter based on rate of change of temperature of water"))
-  (const lEta) Real Nothing
+eta = quantNoUnit (mkUid "eta") (nounPhraseSP "ODE parameter related to decay rate")
+  (S "derived parameter based on rate of change of temperature of water")
+  lEta Real
 
-meltFrac = dqd' (cncpt''' (mkUid "meltFrac") (nounPhraseSP "melt fraction")
-  (S "ratio of thermal energy to amount of mass melted"))
+meltFrac = quantNoUnit (mkUid "meltFrac") (nounPhraseSP "melt fraction")
+  (S "ratio of thermal energy to amount of mass melted")
   --FIXME: Not sure if definition is exactly correct
-  (const lPhi) Real Nothing
+  lPhi Real
 
-fracMin = dqd' (cncpt''' (mkUid "fracMin")
+fracMin = quantNoUnit (mkUid "fracMin")
   (nounPhraseSP "minimum fraction of the tank volume taken up by the PCM")
-  (S "minimum fraction of the tank volume taken up by the PCM"))
-   (const $ variable "MINFRACT") Real Nothing
+  (S "minimum fraction of the tank volume taken up by the PCM")
+   (variable "MINFRACT") Real
 
-consTol = dqd' (cncpt''' (mkUid "consTol")
+consTol = quantNoUnit (mkUid "consTol")
   (nounPhraseSP "relative tolerance for conservation of energy")
-  (S "relative tolerance for conservation of energy"))
-  (const $ sub cC lTol) Real Nothing
+  (S "relative tolerance for conservation of energy")
+  (sub cC lTol) Real
 
-aspectRatio = dqd' (cncpt''' (mkUid "aspectRatio")
+aspectRatio = quantNoUnit (mkUid "aspectRatio")
   (nounPhraseSP "aspect ratio")
-  (S "ratio of tank diameter to tank length"))
-   (const $ variable "AR") Real Nothing
+  (S "ratio of tank diameter to tank length")
+   (variable "AR") Real
 
-aspectRatioMin = dqd' (cncpt''' (mkUid "aspectRatioMin")
-  (nounPhraseSP "minimum aspect ratio") (S"minimum aspect ratio"))
-   (const $ subMin (eqSymb aspectRatio)) Real Nothing
+aspectRatioMin = quantNoUnit (mkUid "aspectRatioMin")
+  (nounPhraseSP "minimum aspect ratio") (S"minimum aspect ratio")
+   (subMin (eqSymb aspectRatio)) Real
 
-aspectRatioMax = dqd' (cncpt''' (mkUid "aspectRatioMax")
-  (nounPhraseSP "maximum aspect ratio") (S "maximum aspect ratio"))
-   (const $ subMax (eqSymb aspectRatio)) Real Nothing
+aspectRatioMax = quantNoUnit (mkUid "aspectRatioMax")
+  (nounPhraseSP "maximum aspect ratio") (S "maximum aspect ratio")
+   (subMax (eqSymb aspectRatio)) Real
 
 -----------------
 -- Constraints --
@@ -435,13 +435,13 @@ pcmE = cuc' "pcmE" (nounPhraseSP "change in heat energy in the PCM")
 
 absTol, relTol :: UncertQ
 
-absTol = uq (constrained' (dqdNoUnit (cncpt''' (mkUid "absTol") (nounPhraseSP "absolute tolerance")
-  (S "the absolute tolerance")) (sub cA lTol) Real)
+absTol = uq (constrained' (quantNoUnit (mkUid "absTol") (nounPhraseSP "absolute tolerance")
+  (S "the absolute tolerance") (sub cA lTol) Real)
   [physRange $ Bounded (Exc, exactDbl 0) (Exc, exactDbl 1)]
    (dbl (10.0**(-10)))) (uncty 0.01 Nothing)
 
-relTol = uq (constrained' (dqdNoUnit (cncpt''' (mkUid "relTol") (nounPhraseSP "relative tolerance")
-  (S "the relative tolerance")) (sub cR lTol) Real)
+relTol = uq (constrained' (quantNoUnit (mkUid "relTol") (nounPhraseSP "relative tolerance")
+  (S "the relative tolerance") (sub cR lTol) Real)
   [physRange $ Bounded (Exc, exactDbl 0) (Exc, exactDbl 1)]
   (dbl (10.0**(-10)))) (uncty 0.01 Nothing)
 

--- a/code/drasil-lang/lib/Language/Drasil/Chunk/Constrained.hs
+++ b/code/drasil-lang/lib/Language/Drasil/Chunk/Constrained.hs
@@ -10,9 +10,8 @@ import Control.Lens ((^.), makeLenses, view)
 
 import Drasil.Database (HasUID(..), HasChunkRefs(..), mkUid)
 
-import Language.Drasil.Chunk.Concept (dccWDS, cncpt''')
 import Language.Drasil.Chunk.Unital (uc')
-import Language.Drasil.Chunk.DefinedQuantity (DefinedQuantityDict, dqd', dqdWr, dqdNoUnit)
+import Language.Drasil.Chunk.DefinedQuantity (DefinedQuantityDict, dqdWr, quantAU, quantNoUnit)
 import Language.Drasil.Symbol (HasSymbol(..), Symbol)
 import Language.Drasil.Classes (NamedIdea(term), Idea(getA), Express(express),
   Definition(defn), ConceptDomain(cdom), Concept, Quantity,
@@ -97,13 +96,13 @@ cuc' nam trm desc sym un space cs rv =
 cucNoUnit' :: String -> NP -> String -> Symbol
             -> Space -> [ConstraintE] -> Expr -> ConstrConcept
 cucNoUnit' nam trm desc sym space cs rv =
-  ConstrConcept (dqdNoUnit (dccWDS nam trm (S desc)) sym space) cs (Just rv) Nothing
+  ConstrConcept (quantNoUnit (mkUid nam) trm (S desc) sym space) cs (Just rv) Nothing
 
 -- | Similar to 'cuc'', but 'Symbol' is dependent on 'Stage'.
 cuc'' :: String -> NP -> String -> (Stage -> Symbol) -> UnitDefn
             -> Space -> [ConstraintE] -> Expr -> ConstrConcept
 cuc'' nam trm desc sym un space cs rv =
-  ConstrConcept (dqd' (cncpt''' (mkUid nam) trm (S desc)) sym space (Just un)) cs (Just rv) Nothing
+  ConstrConcept (quantAU (mkUid nam) trm (S desc) Nothing sym space (Just un)) cs (Just rv) Nothing
 
 -- | Similar to 'cnstrw', but types must also have a 'Concept'.
 cnstrw' :: (Quantity c, Concept c, Constrained c, HasReasVal c, MayHaveUnit c) => c -> ConstrConcept

--- a/code/drasil-lang/lib/Language/Drasil/Chunk/Eq.hs
+++ b/code/drasil-lang/lib/Language/Drasil/Chunk/Eq.hs
@@ -23,8 +23,8 @@ import Language.Drasil.Symbol (HasSymbol(symbol), Symbol)
 import Language.Drasil.Classes (NamedIdea(term), Idea(getA),
   DefiningExpr(defnExpr), Definition(defn), Quantity,
   ConceptDomain(cdom), Express(express), Concept)
-import Language.Drasil.Chunk.DefinedQuantity (DefinedQuantityDict, DefinesQuantity(defLhs), dqd, dqd', dqdWr)
-import Language.Drasil.Chunk.Concept (cncpt''')
+import Language.Drasil.Chunk.DefinedQuantity (DefinedQuantityDict, DefinesQuantity(defLhs),
+  dqdWr, quant, quantNoUnit, quant', quantNoUnit', quantAU)
 import Language.Drasil.Expr.Lang (Expr)
 import qualified Language.Drasil.Expr.Lang as E (Expr(C))
 import Language.Drasil.Expr.Class (ExprC(apply, sy, ($=)))
@@ -90,29 +90,29 @@ instance RequiresChecking (QDefinition Expr) Expr Space where
 -- 'Space', unit, and defining expression.
 fromEqn :: String -> NP -> Sentence -> Symbol -> Space -> UnitDefn -> e -> QDefinition e
 fromEqn nm desc def symb sp un =
-  QD (dqd (cncpt''' (mkUid nm) desc def) symb sp un) []
+  QD (quant (mkUid nm) desc def symb sp un) []
 
 -- | Same as 'fromEqn', but has no units.
 fromEqn' :: String -> NP -> Sentence -> Symbol -> Space -> e -> QDefinition e
 fromEqn' nm desc def symb sp =
-  QD (dqd' (cncpt''' (mkUid nm) desc def) (const symb) sp Nothing) []
+  QD (quantNoUnit (mkUid nm) desc def symb sp) []
 
 -- | Same as 'fromEqn', but symbol depends on stage.
 fromEqnSt :: UID -> NP -> Sentence -> (Stage -> Symbol) ->
   Space -> UnitDefn -> e -> QDefinition e
 fromEqnSt nm desc def symb sp un =
-  QD (dqd' (cncpt''' nm desc def) symb sp (Just un)) []
+  QD (quant' nm desc def symb sp un) []
 
 -- | Same as 'fromEqn', but symbol depends on stage and has no units.
 fromEqnSt' :: UID -> NP -> Sentence -> (Stage -> Symbol) -> Space -> e -> QDefinition e
 fromEqnSt' nm desc def symb sp =
-  QD (dqd' (cncpt''' nm desc def) symb sp Nothing) []
+  QD (quantNoUnit' nm desc def symb sp) []
 
 -- | Same as 'fromEqnSt'', but takes a 'String' instead of a 'UID'.
 fromEqnSt'' :: String -> NP -> Sentence -> (Stage -> Symbol) -> Space -> e ->
   QDefinition e
 fromEqnSt'' nm desc def symb sp =
-  QD (dqd' (cncpt''' (mkUid nm) desc def) symb sp Nothing) []
+  QD (quantNoUnit' (mkUid nm) desc def symb sp) []
 
 -- | Wrapper for fromEqnSt and fromEqnSt'
 mkQDefSt :: UID -> NP -> Sentence -> (Stage -> Symbol) -> Space ->
@@ -134,7 +134,7 @@ mkQuantDef' c t = mkQDefSt (c ^. uid) t EmptyS (symbol c) (c ^. typ) (getUnit c)
 -- equation.
 ec :: (Quantity c, MayHaveUnit c) => c -> e -> QDefinition e
 ec c = QD
-  (dqd' (cncpt''' (c ^. uid) (c ^. term) EmptyS) (symbol c) (c ^. typ) (getUnit c))
+  (quantAU (c ^. uid) (c ^. term) EmptyS Nothing (symbol c) (c ^. typ) (getUnit c))
   []
 
 {-# DEPRECATED ec "`ec` is an unsafe chunk constructor that encourages `UID` double-use." #-}
@@ -144,7 +144,7 @@ mkFuncDef0 :: (IsChunk f, HasSymbol f, HasSpace f,
                IsChunk i, HasSymbol i, HasSpace i) =>
   f -> NP -> Sentence -> Maybe UnitDefn -> [i] -> e -> QDefinition e
 mkFuncDef0 f n s u is = QD
-  (dqd' (cncpt''' (f ^. uid) n s) (symbol f) (f ^. typ) u)
+  (quantAU (f ^. uid) n s Nothing (symbol f) (f ^. typ) u)
   (map (^. uid) is)
 
 -- | Create a 'QDefinition' function with a symbol, name, term, list of inputs,

--- a/code/drasil-lang/lib/Language/Drasil/Chunk/Unital.hs
+++ b/code/drasil-lang/lib/Language/Drasil/Chunk/Unital.hs
@@ -8,11 +8,11 @@ module Language.Drasil.Chunk.Unital (
 
 import Control.Lens (makeLenses, view, (^.))
 
-import Drasil.Database (HasUID(..), HasChunkRefs(..))
+import Drasil.Database (HasUID(..), HasChunkRefs(..), mkUid)
 import qualified Data.Set as Set
 
-import Language.Drasil.Chunk.Concept (dccWDS,cw)
-import Language.Drasil.Chunk.DefinedQuantity (DefinedQuantityDict, dqd, dqd')
+import Language.Drasil.Chunk.Concept (cw)
+import Language.Drasil.Chunk.DefinedQuantity (DefinedQuantityDict, dqd, dqd', quant, quant')
 import Language.Drasil.Symbol (Symbol, HasSymbol(..))
 import Language.Drasil.Classes (NamedIdea(term), Idea(getA), Express(express),
   Definition(defn), ConceptDomain(cdom), Concept, Quantity)
@@ -72,7 +72,7 @@ uc a sym space un = UC (dqd (cw a) sym space un) un
 -- | Similar to 'uc', except it builds the 'Concept' portion of the 'UnitalChunk'
 -- from a given 'UID', term, and definition (as a 'Sentence') which are its first three arguments.
 uc' :: String -> NP -> Sentence -> Symbol -> Space -> UnitDefn -> UnitalChunk
-uc' i t d sym space un = UC (dqd (dccWDS i t d) sym space un) un
+uc' i t d sym space un = UC (quant (mkUid i) t d sym space un) un
 
 -- | Similar to 'uc', but 'Symbol' is dependent on the 'Stage'.
 ucStaged :: (Concept c) => c ->  (Stage -> Symbol) ->
@@ -82,4 +82,4 @@ ucStaged a sym space un = UC (dqd' (cw a) sym space (Just un)) un
 -- | Similar to 'uc'', but 'Symbol' is dependent on the 'Stage'.
 ucStaged' :: String -> NP -> Sentence -> (Stage -> Symbol) ->
   Space -> UnitDefn -> UnitalChunk
-ucStaged' i t d sym space un = UC (dqd' (dccWDS i t d) sym space (Just un)) un
+ucStaged' i t d sym space un = UC (quant' (mkUid i) t d sym space un) un


### PR DESCRIPTION
Anywhere where it was 'trivial' (all the required arguments were already available inline) has now been converted to the new constructors.

Contributes to #5149