### PR TITLE
Add ODE library symlinks for BSS

### DIFF
--- a/code/datafiles/bss/cpp
+++ b/code/datafiles/bss/cpp
@@ -1,0 +1,1 @@
+../odelib/cpp

--- a/code/datafiles/bss/csharp
+++ b/code/datafiles/bss/csharp
@@ -1,0 +1,1 @@
+../odelib/csharp

--- a/code/datafiles/bss/java
+++ b/code/datafiles/bss/java
@@ -1,0 +1,1 @@
+../odelib/java


### PR DESCRIPTION
This fixes `make bss_gool` (which fixes the broken build).

The issue was introduced in #5196 but not caught by CI since there were no changes to `code/stable/**/src/**`. We should probably run all steps of the CI workflow when the Makefile changes, I will keep this in mine for my CI improvements.