### PR TITLE
Don't allow UIDs containing colons

### DIFF
--- a/code/drasil-database/lib/Drasil/Database/UID.hs
+++ b/code/drasil-database/lib/Drasil/Database/UID.hs
@@ -41,8 +41,12 @@ instance Show UID where
   show u = intercalate ":" $ u ^. namespace ++ [u ^. baseName]
 
 -- | Smart constructor for 'UID's from raw 'String's.
+-- The raw string must not contain a colon (':'), as they are reserved
+-- for displaying namespaced 'UID's (see 'nsUid').
 mkUid :: String -> UID
-mkUid s = UID { _namespace = [], _baseName = s }
+mkUid s = if ':' `elem` s
+  then error $ "Invalid uid '" ++ s ++ "'. UIDs must not have colons."
+  else UID { _namespace = [], _baseName = s }
 
 -- | Nest a 'UID' under a namespace.
 nsUid :: String -> UID -> UID

--- a/code/drasil-lang/lib/Language/Drasil/Chunk/UnitDefn.hs
+++ b/code/drasil-lang/lib/Language/Drasil/Chunk/UnitDefn.hs
@@ -21,7 +21,7 @@ module Language.Drasil.Chunk.UnitDefn (
 import Control.Lens ((^.), makeLenses, view)
 import Control.Arrow (second)
 
-import Drasil.Database (HasChunkRefs(..), UID, HasUID(..), mkUid)
+import Drasil.Database (HasChunkRefs(..), UID, HasUID(..), mkUid, nsUid)
 
 import Language.Drasil.Chunk.Concept (ConceptChunk, cncpt''')
 import Language.Drasil.Sentence (Sentence(..))
@@ -184,13 +184,13 @@ newUnit s = makeDerU (unitCon s)
 
 -- | Smart constructor for a "fundamental" unit.
 fund :: String -> String -> String -> UnitDefn
-fund nam desc sym = UD (cncpt''' (mkUid name) (cn' nam) (S desc)) (BaseSI $ US [(Label sym, 1)]) [mkUid name]
-  where name = "unit:" ++ nam
+fund nam desc sym = UD (cncpt''' u (cn' nam) (S desc)) (BaseSI $ US [(Label sym, 1)]) [u]
+  where u = nsUid "unit" (mkUid nam)
 
 -- | Variant of the 'fund', useful for degree.
 fund' :: String -> String -> Symbol -> UnitDefn
-fund' nam desc sym = UD (cncpt''' (mkUid name) (cn' nam) (S desc)) (BaseSI $ US [(sym, 1)]) [mkUid name]
-  where name = "unit:" ++ nam
+fund' nam desc sym = UD (cncpt''' u (cn' nam) (S desc)) (BaseSI $ US [(sym, 1)]) [u]
+  where u = nsUid "unit" (mkUid nam)
 
 -- | We don't want an Ord on units, but this still allows us to compare them.
 compUnitDefn :: UnitDefn -> UnitDefn -> Ordering

--- a/code/drasil-theory/lib/Theory/Drasil/MultiDefn.hs
+++ b/code/drasil-theory/lib/Theory/Drasil/MultiDefn.hs
@@ -90,8 +90,7 @@ instance RequiresChecking (MultiDefn Expr) Expr Space where
 instance Express e => Express (MultiDefn e) where
   express q = equiv $ sy q : NE.toList (NE.map (express . (^. expr)) (q ^. rvs))
 
--- | Smart constructor for MultiDefns, does nothing special at the moment. First
--- argument is the 'String' to become a 'UID'.
+-- | Smart constructor for MultiDefns, does nothing special at the moment.
 mkMultiDefn :: UID -> DefinedQuantityDict -> Sentence -> NE.NonEmpty (DefiningExpr e) -> MultiDefn e
 mkMultiDefn u q s des
   | length des == dupsRemovedLen = MultiDefn u q s des

--- a/code/drasil-theory/lib/Theory/Drasil/MultiDefn.hs
+++ b/code/drasil-theory/lib/Theory/Drasil/MultiDefn.hs
@@ -92,11 +92,11 @@ instance Express e => Express (MultiDefn e) where
 
 -- | Smart constructor for MultiDefns, does nothing special at the moment. First
 -- argument is the 'String' to become a 'UID'.
-mkMultiDefn :: String -> DefinedQuantityDict -> Sentence -> NE.NonEmpty (DefiningExpr e) -> MultiDefn e
+mkMultiDefn :: UID -> DefinedQuantityDict -> Sentence -> NE.NonEmpty (DefiningExpr e) -> MultiDefn e
 mkMultiDefn u q s des
-  | length des == dupsRemovedLen = MultiDefn (mkUid u) q s des
+  | length des == dupsRemovedLen = MultiDefn u q s des
   | otherwise                    = error $
-      "MultiDefn `" ++ u ++ "` created with non-unique list of expressions"
+      "MultiDefn `" ++ show u ++ "` created with non-unique list of expressions"
   where
     dupsRemovedLen = length $ NE.nub des
 
@@ -104,7 +104,7 @@ mkMultiDefn u q s des
 
 -- | Smart constructor for 'MultiDefn's defining 'UID's using that of the 'DefinedQuantityDict'.
 mkMultiDefnForQuant :: DefinedQuantityDict -> Sentence -> NE.NonEmpty (DefiningExpr e) -> MultiDefn e
-mkMultiDefnForQuant q = mkMultiDefn (showUID q) q
+mkMultiDefnForQuant q = mkMultiDefn (q ^. uid) q
 
 -- | Smart constructor for 'DefiningExpr's.
 mkDefiningExpr :: String -> [UID] -> Sentence -> e -> DefiningExpr e

--- a/code/drasil-theory/lib/Theory/Drasil/MultiDefn.hs
+++ b/code/drasil-theory/lib/Theory/Drasil/MultiDefn.hs
@@ -15,7 +15,7 @@ import Control.Lens (makeLenses, view, (^.))
 import Data.List (union)
 import qualified Data.List.NonEmpty as NE
 
-import Drasil.Database (UID, HasUID(..), mkUid, showUID, HasChunkRefs(..))
+import Drasil.Database (UID, HasUID(..), mkUid, HasChunkRefs(..))
 import Language.Drasil hiding (DefiningExpr)
 
 -- | 'DefiningExpr' are the data that make up a (quantity) definition, namely


### PR DESCRIPTION
This is part of a rabbit hole that separating quantity and concept UIDs sent me down.

When `show`ing a UID, colons are used to separate the namespaces, as such if they are allowed in a non-namespaced UID, we can have the following subtle (and undesirable) behaviors: `mkUid "a:b" == nsUid "a" (mkUid "b")` is False, but `show (mkUid "a:b") == show (nsUid "a" (mkUid "b"))` is True. With these changes, evaluating the LHS results in an error in both cases.