### PR TITLE
refactor: don't re-export `codevars[']` through `Language.Drasil.Chunk.CodeBase`

### DIFF
--- a/code/drasil-code/lib/Language/Drasil/Chunk/Code.hs
+++ b/code/drasil-code/lib/Language/Drasil/Chunk/Code.hs
@@ -2,16 +2,14 @@
 -- | Defines chunk types for use in code generation.
 module Language.Drasil.Chunk.Code (
   CodeIdea(..), CodeChunk(..), CodeVarChunk(..), CodeFuncChunk(..),
-  VarOrFunc(..), obv, quantvar, quantfunc, ccObjVar, codevars, codevars',
+  VarOrFunc(..), DefiningCodeExpr(..), obv, quantvar, quantfunc, ccObjVar,
   listToArray, funcPrefix,
-  DefiningCodeExpr(..)
 ) where
 
 import Control.Lens ((^.), view)
 import Text.PrettyPrint.HughesPJ (render)
 
 import Language.Drasil
-import Language.Drasil.Chunk.CodeBase
 import Language.Drasil.Printers (symbolDoc)
 
 import Drasil.Code.CodeVar (CodeChunk(..), CodeIdea(..), VarOrFunc(..),

--- a/code/drasil-code/lib/Language/Drasil/Mod.hs
+++ b/code/drasil-code/lib/Language/Drasil/Mod.hs
@@ -15,8 +15,8 @@ import Drasil.GOOL (VisibilityTag(..))
 import Data.String.Extras (toPlainName)
 
 import Drasil.Code.CodeExpr (CodeExpr)
-import Language.Drasil.Chunk.Code (CodeVarChunk, CodeFuncChunk, codevars,
-  codevars', quantvar)
+import Language.Drasil.Chunk.Code (CodeVarChunk, CodeFuncChunk, quantvar)
+import Language.Drasil.Chunk.CodeBase (codevars, codevars')
 import Language.Drasil.Chunk.Parameter (ParameterChunk, pcAuto)
 import Language.Drasil.Code.DataDesc (DataDesc)
 


### PR DESCRIPTION
Builds on #5217 

Clearing up our dependency graph a bit.