### PR TITLE
refactor: avoid unnecessary `CodeVarChunk` roundtrip casting through `CodeChunk`

### DIFF
--- a/code/drasil-code/lib/Language/Drasil/Code/Imperative/Parameters.hs
+++ b/code/drasil-code/lib/Language/Drasil/Code/Imperative/Parameters.hs
@@ -90,8 +90,8 @@ getConstraintParams = do
       cm = s ^. cMapO
       db = s ^. systemdbO
       varsList = filter (\i -> member (i ^. uid) cm) (s ^. inputsO)
-      reqdVals = nub $ varsList ++ map quantvar (concatMap (`constraintvars` db)
-        (getConstraints cm varsList))
+      reqdVals = nub $ varsList ++
+        concatMap (`constraintvars` db) (getConstraints cm varsList)
   icName <- genICName InputConstraintsFn
   getParams icName In reqdVals
 

--- a/code/drasil-code/lib/Language/Drasil/CodeSpec.hs
+++ b/code/drasil-code/lib/Language/Drasil/CodeSpec.hs
@@ -32,7 +32,7 @@ import Drasil.System (HasSmithEtAlSRS(..), HasSystemMeta(..), programName)
 import Theory.Drasil (DataDefinition, qdEFromDD, getEqModQdsFromIm)
 import Data.List.Extras (subsetOf)
 
-import Drasil.Code.CodeVar (CodeChunk, CodeIdea(codeChunk), CodeVarChunk, quantvar)
+import Drasil.Code.CodeVar (CodeVarChunk, quantvar)
 import Language.Drasil.Chunk.ConstraintMap (ConstraintCEMap, ConstraintCE, constraintMap)
 import Language.Drasil.Chunk.CodeDefinition (CodeDefinition, qtov, qtoc, odeDef)
 import Language.Drasil.Choices (Choices(..), Maps(..), ODE(..), ExtLib(..),
@@ -213,9 +213,7 @@ getDerivedInputs ddefs ins cnsts sm =
 getConstraints :: (HasUID c) => ConstraintCEMap -> [c] -> [ConstraintCE]
 getConstraints cm cs = concat $ mapMaybe (\c -> Map.lookup (c ^. uid) cm) cs
 
--- | Get a list of 'CodeChunk's from a constraint.
-constraintvars :: ConstraintCE -> ChunkDB -> [CodeChunk]
-constraintvars (Range _ ri) m =
-  map (codeChunk . varResolve m) $ nub $ eNamesRI ri
-constraintvars (Elem _ ri) m =
-  map (codeChunk . varResolve m) $ eDep ri
+-- | Get a list of 'CodeVarChunk's from a constraint.
+constraintvars :: ConstraintCE -> ChunkDB -> [CodeVarChunk]
+constraintvars (Range _ ri) m = map (varResolve m) $ nub $ eNamesRI ri
+constraintvars (Elem _ ri)  m = map (varResolve m) $ eDep ri


### PR DESCRIPTION
Builds on #5217 

`quantvar` casts a `DefinedQuantityDict` to a `CodeVarChunk`. `codeIdea` casts things (including `CodeVarChunk`) to a `CodeChunk`. Previously this code:

1. Casted a DQD to a CVC.
2. Casted the CVC to a CC.
3. Casted the CC back into a CVC.

This PR removes the last two casts.