### PR TITLE
docs(`LessonPlan`): add a link to Ting-Yu's thesis

### DIFF
--- a/code/drasil-lesson-plan/lib/Drasil/LessonPlan/Core.hs
+++ b/code/drasil-lesson-plan/lib/Drasil/LessonPlan/Core.hs
@@ -14,6 +14,10 @@ import Language.Drasil.Document (Reference)
 
 import Drasil.System (SystemMeta, HasSystemMeta(..))
 
+-- | An abstract "lesson plan."
+--
+-- Please refer to [Ting-Yu's thesis](https://github.com/JacquesCarette/Drasil/blob/main/People/Ting-Yu/thesis.pdf)
+-- for more information.
 data LessonPlan = LP {
   _sm :: SystemMeta,
   _lessonName :: String,


### PR DESCRIPTION
@JacquesCarette recently reminded me that Ting-Yu wrote about her work on the lesson plan and that she had some valuable work and references on the structure of a lesson plan we can learn from.

This only adds a link to Ting-Yu's thesis document.