### PR TITLE
refactor: reuse `showHasSymbolImpl` to render implementation-staged `Symbol`s

### DIFF
--- a/code/drasil-code/lib/Language/Drasil/Chunk/Code.hs
+++ b/code/drasil-code/lib/Language/Drasil/Chunk/Code.hs
@@ -5,10 +5,9 @@ module Language.Drasil.Chunk.Code (
 ) where
 
 import Control.Lens ((^.), view)
-import Text.PrettyPrint.HughesPJ (render)
 
 import Language.Drasil
-import Language.Drasil.Printers (symbolDoc)
+import Language.Drasil.Printers (showHasSymbImpl)
 
 import Drasil.Code.CodeVar (CodeChunk(..), CodeFuncChunk, CodeIdea(..),
   CodeVarChunk(..), VarOrFunc(..), ccf, ccv, qc)
@@ -20,7 +19,7 @@ import Drasil.Code.CodeVar (CodeChunk(..), CodeFuncChunk, CodeIdea(..),
 
 -- | Finds the code name of a 'CodeChunk'.
 instance CodeIdea    CodeChunk where
-  codeName = render . symbolDoc . codeSymb . view qc
+  codeName = showHasSymbImpl . view qc
   codeChunk = id
 
 -- | Finds the code name and 'CodeChunk' within a 'CodeVarChunk'.

--- a/code/drasil-printers/lib/Language/Drasil/Plain/Print.hs
+++ b/code/drasil-printers/lib/Language/Drasil/Plain/Print.hs
@@ -13,7 +13,7 @@ import Text.PrettyPrint.HughesPJ (Doc, (<>), (<+>), brackets, comma, double,
   doubleQuotes, empty, hcat, hsep, integer, parens, punctuate, space, text,
   vcat, render)
 
-import Language.Drasil (Special(..), Stage(..), Symbol, USymb(..), codeSymb)
+import Language.Drasil (Special(..), Symbol, USymb(..), codeSymb)
 import qualified Language.Drasil as L (HasSymbol(..))
 import Data.String.Extras (toPlainName)
 

--- a/code/drasil-printers/lib/Language/Drasil/Plain/Print.hs
+++ b/code/drasil-printers/lib/Language/Drasil/Plain/Print.hs
@@ -13,7 +13,7 @@ import Text.PrettyPrint.HughesPJ (Doc, (<>), (<+>), brackets, comma, double,
   doubleQuotes, empty, hcat, hsep, integer, parens, punctuate, space, text,
   vcat, render)
 
-import Language.Drasil (Special(..), Stage(..), Symbol, USymb(..))
+import Language.Drasil (Special(..), Stage(..), Symbol, USymb(..), codeSymb)
 import qualified Language.Drasil as L (HasSymbol(..))
 import Data.String.Extras (toPlainName)
 
@@ -186,4 +186,4 @@ fenceDocR Abs = text "|"
 
 -- | Helper for printing a HasSymbol in Implementation Stage
 showHasSymbImpl :: L.HasSymbol x => x -> String
-showHasSymbImpl x = render $ symbolDoc (L.symbol x Implementation)
+showHasSymbImpl = render . symbolDoc . codeSymb


### PR DESCRIPTION
I suspect we'll want to delete this code ultimately, but at least its getting reused in the meanwhile.