### PR TITLE
Added `.projectile` to `.gitignore`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ desktop.ini
 .idea
 .vscode
 .direnv
+.projectile
 
 # Drasil/Haskell
 *.cabal


### PR DESCRIPTION
My Emacs configuration uses [Projectile](https://github.com/bbatsov/projectile) to manage projects, and I put a `.projectile` file in `Drasil/code` so that it knows where the project root is. This PR adds `.projectile` to the `.gitignore` so I don't accidentally commit it.