### PR TITLE
Rewrite PR CI Workflow

### DIFF
--- a/.github/workflows/Build.yaml
+++ b/.github/workflows/Build.yaml
@@ -13,69 +13,43 @@ defaults:
 jobs:
   build:
     name: "Build & Test"
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
+    outputs:
+      tex: ${{ steps.changes.outputs.tex}}
+      md: ${{ steps.changes.outputs.md }}
+      gencode: ${{ steps.changes.outputs.gencode }}
     steps:
       - uses: actions/checkout@v7
 
-      - name: "Search changes for applicable tests"
+      - name: "Detect changes"
         uses: dorny/paths-filter@v4
         id: changes
         with:
           filters: |
+            # This section is referenced in all the below sections
+            # Paths added here are core/build files that should trigger all optional steps
+            build: &build
+              - '.github/workflows/Build.yaml'
+              - 'code/Makefile'
+              - 'code/scripts/**'
             tex:
+              - *build
               - 'code/stable/**/*.tex'
             md:
+              - *build
               - code/stable/**/*.md
               - code/stable/**/book.toml
-            artifacts:
+            gencode:
+              - *build
               - 'code/stable/**/src/**'
-
-      - name: "Update apt package list"
-        run: |
-          sudo apt-get update
-
-      - name: "Install core system requirements"
-        run: |
-          sudo apt-get install -y --fix-missing libgmp-dev python3 graphviz g++ default-jdk mono-devel
-
-      - name: "Install TeX requirements"
-        if: ${{ steps.changes.outputs.tex == 'true' }}
-        run: |
-          sudo apt-get install -y --fix-missing fonts-lmodern texlive-bibtex-extra texlive-latex-extra texlive-science texlive-luatex inkscape
-
-      - name: "Install mdBook"
-        if: ${{ steps.changes.outputs.md == 'true' }}
-        run: |
-          curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
-          cargo install mdbook
-
-      - name: "Update PATH"
-        run: |
-          echo "$HOME/.local/bin" >> $GITHUB_PATH
-          echo "$HOME/.swift/usr/bin" >> $GITHUB_PATH
-          echo "$HOME/.cargo/bin" >> $GITHUB_PATH
-
-      - name: "Install Stack"
-        uses: haskell-actions/setup@v2
-        with:
-          enable-stack: true
-          stack-no-global: true
-          stack-version: 'latest'
+              - 'code/drasil-code/test/golden/**'
 
       - name: "Cache dependencies"
         uses: actions/cache@v6
         with:
           path: |
             ~/.stack
-            ~/.cabal/packages
-            ~/.cabal/store
-            code/.stack-work/
-            code/website/.stack-work/
-            ~/.local/bin/graphmod
-          key: ${{ runner.os }}-store-${{ hashFiles('code/stack.yaml') }}
-
-      - name: "Clean previous run"
-        run: make clean
+          key: ${{ runner.os }}-stack-${{ hashFiles('code/stack.yaml') }}
 
       - name: "Install dependencies"
         run: make stackArgs="--no-terminal" deps
@@ -83,29 +57,139 @@ jobs:
       - name: "Build"
         run: make code stackArgs="--no-terminal" GHCFLAGS="-Werror -Wwarn=deprecations"
 
+      - name: "Stack Test"
+        run: make stack_test stackArgs="--no-terminal"
+
       - name: "Test built artifacts against stable"
-        run: make stackArgs="--no-terminal" GHCFLAGS="-Werror -Wwarn=deprecations" NOISY=yes
+        run: make test test_website NOISY=yes
 
-      - name: "Compile GOOL examples"
-        run: make codegenTest
+      - name: "Upload logs on failure"
+        if: ${{ failure() }}
+        uses: actions/upload-artifact@v7
+        with:
+          name: diff-logs
+          path: code/logs
 
-      - name: "Compile generated TeX artifacts"
-        run: make -j tex SUMMARIZE_TEX=yes
-        if: ${{ steps.changes.outputs.tex == 'true' }}
+      - name: "Upload generated artifacts"
+        uses: actions/upload-artifact@v7
+        with:
+          name: generated
+          path: code/build
+          include-hidden-files: true
 
-      - name: "Compile generated software artifacts"
-        if: ${{ steps.changes.outputs.artifacts == 'true' }}
-        run: make gool
+      - name: "Upload gooltest artifacts"
+        uses: actions/upload-artifact@v7
+        with:
+          name: generated-gooltest
+          path: code/drasil-code/test/build
+
+  haddock:
+    name: Haddock
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: "Restore dependency cache"
+        uses: actions/cache/restore@v6
+        with:
+          path: |
+            ~/.stack
+          key: ${{ runner.os }}-stack-${{ hashFiles('code/stack.yaml') }}
 
       - name: "Generate Haddock docs (as test)"
         run: make docs
 
+  gooltest:
+    name: "Compile GOOL"
+    needs: build
+    runs-on: ubuntu-24.04
+    if: ${{ needs.build.outputs.gencode == 'true' }}
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: "Update apt package list"
+        run: |
+          sudo apt-get update
+
+      - name: "Install requirements"
+        run: |
+          sudo apt-get install -y default-jdk-headless mono-devel
+
+      - name: "Download generated artifacts"
+        uses: actions/download-artifact@v8
+        with:
+          name: generated
+          path: code/build
+
+      - name: "Download gooltest artifacts"
+        uses: actions/download-artifact@v8
+        with:
+          name: generated-gooltest
+          path: code/drasil-code/test/build
+
+      - name: "Compile GOOL Examples"
+        run: make codegenTest SKIP_GEN=1
+      
+      - name: "Compile generated software artifacts"
+        run: make gool SKIP_GEN=1
+
+  latex:
+    name: LaTeX
+    needs: build
+    runs-on: ubuntu-26.04 # Ubuntu 26 has newer TeX packages that are significantly faster
+    if: ${{ needs.build.outputs.tex == 'true' }}
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: "Update apt package list"
+        run: |
+          sudo apt-get update
+
+      - name: "Install TeX requirements"
+        run: |
+          sudo apt-get install -y graphviz fonts-lmodern texlive-bibtex-extra texlive-latex-extra texlive-science texlive-luatex inkscape
+
+      - name: "Download generated artifacts"
+        uses: actions/download-artifact@v8
+        with:
+          name: generated
+          path: code/build
+
+      - name: "Compile generated TeX artifacts"
+        run: make -j4 tex SKIP_GEN=1 SUMMARIZE_TEX=yes
+
+  mdbook:
+    name: mdBook
+    needs: build
+    runs-on: ubuntu-24.04
+    if: ${{ needs.build.outputs.md == 'true' }}
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: "Update apt package list"
+        run: |
+          sudo apt-get update
+
+      - name: "Install requirements"
+        run: |
+          sudo apt-get install -y graphviz
+
+      - name: "Install mdBook"
+        env:
+          MDBOOK_VERSION: 0.5.4
+        working-directory: ${{ runner.temp }}
+        run: |
+          curl -L -O https://github.com/rust-lang/mdBook/releases/download/v$MDBOOK_VERSION/mdbook-v$MDBOOK_VERSION-x86_64-unknown-linux-gnu.tar.gz
+          tar zxf mdbook-v$MDBOOK_VERSION-x86_64-unknown-linux-gnu.tar.gz
+          mkdir -p ~/.local/bin
+          mv mdbook ~/.local/bin
+          mdbook --version
+
+      - name: "Download generated artifacts"
+        uses: actions/download-artifact@v8
+        with:
+          name: generated
+          path: code/build
+
       - name: "Build mdBook Examples"
-        run: make mdbook_build
-        if: ${{ steps.changes.outputs.md == 'true' }}
-
-      - name: "Build website generator"
-        run: make website
-
-      - name: "Test Built Website against Stable Version"
-        run: make test_website NOISY=yes
+        run: make mdbook_build SKIP_GEN=1

--- a/.github/workflows/Build.yaml
+++ b/.github/workflows/Build.yaml
@@ -16,7 +16,8 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       tex: ${{ steps.changes.outputs.tex}}
-      md: ${{ steps.changes.outputs.md }}
+      mdbook: ${{ steps.changes.outputs.mdbook }}
+      jupyter: ${{ steps.changes.outputs.jupyter }}
       gencode: ${{ steps.changes.outputs.gencode }}
     steps:
       - uses: actions/checkout@v7
@@ -34,11 +35,13 @@ jobs:
               - 'code/scripts/**'
             tex:
               - *build
-              - 'code/stable/**/*.tex'
-            md:
+              - 'code/stable/*/SRS/PDF/**'
+            mdbook:
               - *build
-              - code/stable/**/*.md
-              - code/stable/**/book.toml
+              - 'code/stable/*/SRS/mdBook/**'
+            jupyter:
+              - *build
+              - 'code/stable/**/*.ipynb'
             gencode:
               - *build
               - 'code/stable/**/src/**'
@@ -166,7 +169,7 @@ jobs:
     name: mdBook
     needs: build
     runs-on: ubuntu-latest
-    if: ${{ needs.build.outputs.md == 'true' }}
+    if: ${{ needs.build.outputs.mdbook == 'true' }}
     env:
       SKIP_GEN: 1
     steps:
@@ -199,3 +202,25 @@ jobs:
 
       - name: "Build mdBook Examples"
         run: make mdbook_build
+
+  jupyter:
+    name: Jupyter
+    needs: build
+    runs-on: ubuntu-latest
+    if: ${{ needs.build.outputs.jupyter == 'true' }}
+    env:
+      SKIP_GEN: 1
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: "Install Jupyter"
+        run: pip install jupyterlab
+
+      - name: "Download generated artifacts"
+        uses: actions/download-artifact@v8
+        with:
+          name: generated
+          path: code/build
+
+      - name: "Extract HTML copies of Jupyter Notebooks"
+        run: make jupyter_html

--- a/.github/workflows/Build.yaml
+++ b/.github/workflows/Build.yaml
@@ -13,7 +13,7 @@ defaults:
 jobs:
   build:
     name: "Build & Test"
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-latest
     outputs:
       tex: ${{ steps.changes.outputs.tex}}
       md: ${{ steps.changes.outputs.md }}
@@ -85,7 +85,7 @@ jobs:
 
   haddock:
     name: Haddock
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
 
@@ -102,7 +102,7 @@ jobs:
   gooltest:
     name: "Compile GOOL"
     needs: build
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-latest
     if: ${{ needs.build.outputs.gencode == 'true' }}
     steps:
       - uses: actions/checkout@v7
@@ -161,7 +161,7 @@ jobs:
   mdbook:
     name: mdBook
     needs: build
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-latest
     if: ${{ needs.build.outputs.md == 'true' }}
     steps:
       - uses: actions/checkout@v7

--- a/.github/workflows/Build.yaml
+++ b/.github/workflows/Build.yaml
@@ -213,8 +213,13 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
-      - name: "Install Jupyter"
-        run: pip install jupyterlab
+      - name: "Update apt package list"
+        run: |
+          sudo apt-get update
+
+      - name: "Install requirements"
+        run: |
+          sudo apt-get install -y jupyter-nbconvert
 
       - name: "Download generated artifacts"
         uses: actions/download-artifact@v8

--- a/.github/workflows/Build.yaml
+++ b/.github/workflows/Build.yaml
@@ -104,6 +104,8 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     if: ${{ needs.build.outputs.gencode == 'true' }}
+    env:
+      SKIP_GEN: 1
     steps:
       - uses: actions/checkout@v7
 
@@ -128,16 +130,18 @@ jobs:
           path: code/drasil-code/test/build
 
       - name: "Compile GOOL Examples"
-        run: make codegenTest SKIP_GEN=1
+        run: make codegenTest
       
       - name: "Compile generated software artifacts"
-        run: make gool SKIP_GEN=1
+        run: make gool
 
   latex:
     name: LaTeX
     needs: build
     runs-on: ubuntu-26.04 # Ubuntu 26 has newer TeX packages that are significantly faster
     if: ${{ needs.build.outputs.tex == 'true' }}
+    env:
+      SKIP_GEN: 1
     steps:
       - uses: actions/checkout@v7
 
@@ -156,13 +160,15 @@ jobs:
           path: code/build
 
       - name: "Compile generated TeX artifacts"
-        run: make -j4 tex SKIP_GEN=1 SUMMARIZE_TEX=yes
+        run: make -j4 tex SUMMARIZE_TEX=yes
 
   mdbook:
     name: mdBook
     needs: build
     runs-on: ubuntu-latest
     if: ${{ needs.build.outputs.md == 'true' }}
+    env:
+      SKIP_GEN: 1
     steps:
       - uses: actions/checkout@v7
 
@@ -192,4 +198,4 @@ jobs:
           path: code/build
 
       - name: "Build mdBook Examples"
-        run: make mdbook_build SKIP_GEN=1
+        run: make mdbook_build

--- a/.github/workflows/Deploy.yaml
+++ b/.github/workflows/Deploy.yaml
@@ -50,12 +50,7 @@ jobs:
         with:
           path: |
             ~/.stack
-            ~/.cabal/packages
-            ~/.cabal/store
-            code/.stack-work/
-            code/website/.stack-work/
-            ~/.local/bin/graphmod
-          key: ${{ runner.os }}-store-${{ hashFiles('code/stack.yaml') }}
+          key: ${{ runner.os }}-stack-${{ hashFiles('code/stack.yaml') }}
 
       - name: "Clean previous run"
         run: make clean

--- a/code/Makefile
+++ b/code/Makefile
@@ -271,6 +271,9 @@ test_website: $(CLEAN_GF_PREFIX)$(LOG_FOLDER_NAME) website ##@Website Test fresh
 	@echo ---------------------------------------
 	@LOG_FOLDER="$(LOG_FOLDER)" LOG_SUFFIX="$(LOG_SUFFIX)" NOISY=$(NOISY) "$(SHELL)" "$(SCRIPT_FOLDER)log_check.sh"
 
+stack_test: code ##@General Run stack tests
+	stack test $(stackArgs) --no-interleaved-output
+
 # First build all the Drasil packages, run all examples (no traceability graphs),
 # and then overwrite contents in the stable folder with currently generated ones.
 stabilize: $(STABILIZE_EXAMPLES) ##@Examples Overwrites the stable folder with up-to-date artifacts.
@@ -325,17 +328,21 @@ $(filter %$(BUILD_P_SUFFIX), $(BUILD_PACKAGES)): %$(BUILD_P_SUFFIX): check_stack
 # Specific example targets will have the name exampleName_gen.
 # Alternatively, you can run an example by running `stack exec exampleName`.
 $(filter %$(GEN_E_SUFFIX), $(GEN_EXAMPLES)): %$(GEN_E_SUFFIX):
+ifneq ($(SKIP_GEN), 1)
 	stack build $(stackBuildArgs) "$(EEXE)"
 	@mkdir -p "$(BUILD_FOLDER)"
 	cd "$(BUILD_FOLDER)" && $(STACK_EXEC) -- "$(EEXE)"
+endif
 
 # Compiles GOOL examples to concrete code (Java, C++, etc.)
 # We first build the codegenTest to catch any build errors
 # Then we run the codeGenTest, ignoring the exit code and not printing any output,
 # which will write the generated code to the build folder.
 $(GOOLTEST)$(GEN_E_SUFFIX):
+ifneq ($(SKIP_GEN), 1)
 	stack build $(stackBuildArgs) drasil-code
 	-stack test $(stackArgs) "drasil-code:test:$(GOOLTEST_EXE)" --test-arguments="--quiet"
+endif
 
 $(GOOLTEST)$(TEST_E_SUFFIX):
 	stack test $(stackArgs) "drasil-code:test:$(GOOLTEST_EXE)"
@@ -347,7 +354,7 @@ $(filter %$(INSTALL_E_SUFFIX), $(INSTALL_EXAMPLES)): %$(INSTALL_E_SUFFIX):
 # Same as above targets; run individual examples but create traceability graphs
 # for each example run. Needs Graphviz to run. Graphs generate in svg, pdf, and png formats.
 # Specific example targets will have the name exampleName_trace_graph.
-$(filter %$(TRACE_GRAPH_SUFFIX), $(TRACE_GRAPH_EXAMPLES)): %$(TRACE_GRAPH_SUFFIX): %$(GEN_E_SUFFIX) graphmod
+$(filter %$(TRACE_GRAPH_SUFFIX), $(TRACE_GRAPH_EXAMPLES)): %$(TRACE_GRAPH_SUFFIX): %$(GEN_E_SUFFIX)
 	@echo Making traceability graphs for "$(EEXE)"
 	@if [ -d "$(BUILD_FOLDER)$(EDIR)/$(TRACEY_GRAPH_FOLDER)" ]; then \
 		cd "$(BUILD_FOLDER)$(EDIR)/$(TRACEY_GRAPH_FOLDER)" && for graph in $(TRACEY_GRAPH_NAMES); do \


### PR DESCRIPTION
The workflow is now split up to run several steps in parallel, as well as being faster my minimizing the amount of dependencies that need to be installed for each step.

In future PRs, I will improve the other workflows (mainly the Deploy workflow) in a similar manner to this one.