### PR TITLE
Replace manual `instance hasChunkRefs X` with `declareHasChunkRefs ''X`

### DIFF
--- a/code/drasil-code/lib/Language/Drasil/Chunk/NamedArgument.hs
+++ b/code/drasil-code/lib/Language/Drasil/Chunk/NamedArgument.hs
@@ -8,7 +8,7 @@ module Language.Drasil.Chunk.NamedArgument (
 
 import Control.Lens ((^.), makeLenses, view)
 
-import Drasil.Database (HasUID(..), HasChunkRefs(..))
+import Drasil.Database (HasUID(..), declareHasChunkRefs, Generically(..))
 import Language.Drasil (HasSpace(..), HasSymbol(..),
   Idea(..), MayHaveUnit(..), NamedIdea(..), Quantity,
   DefinedQuantityDict, Concept, dqdWr, Definition (defn), ConceptDomain (cdom))
@@ -19,10 +19,7 @@ import Drasil.Code.Classes (IsArgumentName)
 -- but with more of a focus on generating code arguments.
 newtype NamedArgument = NA {_qtd :: DefinedQuantityDict}
 makeLenses ''NamedArgument
-
-instance HasChunkRefs NamedArgument where
-  chunkRefs na = chunkRefs (na ^. qtd)
-  {-# INLINABLE chunkRefs #-}
+declareHasChunkRefs ''NamedArgument
 
 -- | Finds the 'UID' of the 'DefinedQuantityDict' used to make the 'NamedArgument'.
 instance HasUID         NamedArgument where uid = qtd . uid

--- a/code/drasil-code/lib/Language/Drasil/Chunk/Parameter.hs
+++ b/code/drasil-code/lib/Language/Drasil/Chunk/Parameter.hs
@@ -5,7 +5,7 @@ module Language.Drasil.Chunk.Parameter (
 
 import Control.Lens ((^.), makeLenses, view)
 
-import Drasil.Database (HasUID(..), HasChunkRefs(..))
+import Drasil.Database (HasUID(..), declareHasChunkRefs, Generically(..))
 import Language.Drasil hiding (Ref)
 
 import Drasil.Code.CodeVar (CodeIdea(..), CodeChunk)
@@ -18,10 +18,8 @@ data PassBy = Val | Ref
 data ParameterChunk = PC {_pcc :: CodeChunk
                          , passBy :: PassBy}
 makeLenses ''ParameterChunk
-
-instance HasChunkRefs ParameterChunk where
-  chunkRefs pc = chunkRefs (pc ^. pcc)
-  {-# INLINABLE chunkRefs #-}
+declareHasChunkRefs ''PassBy
+declareHasChunkRefs ''ParameterChunk
 
 -- | Finds the 'UID' of the 'CodeChunk' used to make the 'ParameterChunk'.
 instance HasUID      ParameterChunk where uid = pcc . uid

--- a/code/drasil-code/package.yaml
+++ b/code/drasil-code/package.yaml
@@ -11,6 +11,9 @@ description:  Please see the README on GitHub at <https://github.com/JacquesCare
 language: Haskell2010
 default-extensions:
 - StrictData
+- StandaloneDeriving
+- DerivingVia
+- DeriveGeneric
 
 extra-source-files: []
 

--- a/code/drasil-lang/lib/Drasil/Code/CodeVar.hs
+++ b/code/drasil-lang/lib/Drasil/Code/CodeVar.hs
@@ -8,7 +8,7 @@ module Drasil.Code.CodeVar (
 
 import Control.Lens ((^.), view, makeLenses, Lens')
 
-import Drasil.Database (HasUID(uid), (+++), HasChunkRefs(..))
+import Drasil.Database (HasUID(uid), (+++), declareHasChunkRefs, Generically(..))
 
 import Drasil.Code.Classes (Callable)
 import Drasil.Code.CodeExpr.Lang (CodeExpr)
@@ -45,10 +45,8 @@ data CodeChunk = CodeC { _qc  :: DefinedQuantityDict
                        , kind :: VarOrFunc  -- TODO: Jason: Once we have function spaces, I believe we won't need to store this
                        }
 makeLenses ''CodeChunk
-
-instance HasChunkRefs CodeChunk where
-  chunkRefs cc = chunkRefs (cc ^. qc)
-  {-# INLINABLE chunkRefs #-}
+declareHasChunkRefs ''VarOrFunc
+declareHasChunkRefs ''CodeChunk
 
 -- | Finds the 'UID' of the 'DefinedQuantityDict' used to make the 'CodeChunk'.
 instance HasUID        CodeChunk where uid = qc . uid
@@ -76,13 +74,7 @@ instance MayHaveUnit   CodeChunk where getUnit = getUnit . view qc
 data CodeVarChunk = CodeVC {_ccv :: CodeChunk,
                             _obv :: Maybe CodeChunk}
 makeLenses ''CodeVarChunk
-
-instance HasChunkRefs CodeVarChunk where
-  chunkRefs cvc = mconcat
-    [ chunkRefs (cvc ^. ccv)
-    , chunkRefs (cvc ^. obv)
-    ]
-  {-# INLINABLE chunkRefs #-}
+declareHasChunkRefs ''CodeVarChunk
 
 -- | Finds the 'UID' of the 'CodeChunk' used to make the 'CodeVarChunk'.
 instance HasUID        CodeVarChunk where uid = ccv . uid
@@ -121,10 +113,7 @@ listToArray c = newSpc (c ^. typ)
 -- | Chunk representing a function.
 newtype CodeFuncChunk = CodeFC {_ccf :: CodeChunk}
 makeLenses ''CodeFuncChunk
-
-instance HasChunkRefs CodeFuncChunk where
-  chunkRefs cfc = chunkRefs (cfc ^. ccf)
-  {-# INLINABLE chunkRefs #-}
+declareHasChunkRefs ''CodeFuncChunk
 
 -- | Finds the 'UID' of the 'CodeChunk' used to make the 'CodeFuncChunk'.
 instance HasUID        CodeFuncChunk where uid = ccf . uid

--- a/code/drasil-lang/lib/Language/Drasil/Chunk/CommonIdea.hs
+++ b/code/drasil-lang/lib/Language/Drasil/Chunk/CommonIdea.hs
@@ -13,8 +13,7 @@ module Language.Drasil.Chunk.CommonIdea (
 
 import Control.Lens (makeLenses, (^.), view)
 
-import Drasil.Database (UID, HasUID(uid), HasChunkRefs(..))
-import qualified Data.Set as Set
+import Drasil.Database (UID, HasUID(uid), declareHasChunkRefs, Generically(..))
 
 import Language.Drasil.Chunk.NamedIdea (IdeaDict, idea')
 import Language.Drasil.Classes (NamedIdea(term), Idea(getA),
@@ -29,13 +28,7 @@ import Language.Drasil.NaturalLanguage.English.NounPhrase.Core (NP)
 -- Ex. The term "Operating System" has the abbreviation "OS" and comes from the domain of computer science.
 data CI = CI { _nc' :: IdeaDict, _ab :: String, cdom' :: [UID]}
 makeLenses ''CI
-
-instance HasChunkRefs CI where
-  chunkRefs c = Set.unions
-    [ chunkRefs (c ^. nc')
-    , Set.fromList (cdom c)
-    ]
-  {-# INLINABLE chunkRefs #-}
+declareHasChunkRefs ''CI
 
 -- | Finds 'UID' of the 'IdeaDict' used to make the 'CI'.
 instance HasUID        CI where uid  = nc' . uid

--- a/code/drasil-lang/lib/Language/Drasil/Chunk/Concept/Core.hs
+++ b/code/drasil-lang/lib/Language/Drasil/Chunk/Concept/Core.hs
@@ -10,8 +10,7 @@ module Language.Drasil.Chunk.Concept.Core(
 
 import Control.Lens (makeLenses, (^.), view)
 
-import Drasil.Database (HasChunkRefs(..), UID, HasUID(..))
-import qualified Data.Set as Set
+import Drasil.Database (UID, HasUID(..), declareHasChunkRefs, Generically(..))
 
 import Language.Drasil.ShortName (HasShortName(..), ShortName)
 import Language.Drasil.Classes (NamedIdea(term), Idea(getA),
@@ -38,13 +37,7 @@ data ConceptChunk = ConDict { _uu :: UID -- ^ The 'UID' of the concept.
                             , cdom' :: [UID] -- ^ Domain of the concept.
                             }
 makeLenses ''ConceptChunk
-
-instance HasChunkRefs ConceptChunk where
-  chunkRefs c = Set.unions
-    [ chunkRefs (c ^. defn')
-    , Set.fromList (cdom c)
-    ]
-  {-# INLINABLE chunkRefs #-}
+declareHasChunkRefs ''ConceptChunk
 
 -- | Equal if 'UID's are equal.
 instance Eq            ConceptChunk where c1 == c2 = (c1 ^. uid) == (c2 ^. uid)
@@ -71,14 +64,7 @@ data ConceptInstance = ConInst { _ciuid :: UID
                                , ra :: String
                                , shnm :: ShortName}
 makeLenses ''ConceptInstance
-
-instance HasChunkRefs ConceptInstance where
-  chunkRefs c = Set.unions
-    [ chunkRefs (c ^. cc)
-    , chunkRefs (shortname c)
-    , Set.fromList (cdom c)
-    ]
-  {-# INLINABLE chunkRefs #-}
+declareHasChunkRefs ''ConceptInstance
 
 -- | Equal if 'UID's are equal.
 instance Eq            ConceptInstance where c1 == c2 = (c1 ^. uid) == (c2 ^. uid)

--- a/code/drasil-lang/lib/Language/Drasil/Chunk/UncertainQuantity.hs
+++ b/code/drasil-lang/lib/Language/Drasil/Chunk/UncertainQuantity.hs
@@ -11,7 +11,7 @@ module Language.Drasil.Chunk.UncertainQuantity (
 
 import Control.Lens ((^.), makeLenses, view)
 
-import Drasil.Database (HasUID(..), HasChunkRefs(..))
+import Drasil.Database (HasUID(..), declareHasChunkRefs, Generically(..))
 
 import Language.Drasil.Chunk.DefinedQuantity (dqdWr)
 import Language.Drasil.Chunk.Constrained (ConstrConcept(..), cuc')
@@ -33,10 +33,7 @@ import Language.Drasil.Uncertainty
 -- Ex. Measuring the length of a pendulum arm may be recorded with an uncertainty value.
 data UncertQ = UQ { _coco :: ConstrConcept , _unc'' :: Uncertainty }
 makeLenses ''UncertQ
-
-instance HasChunkRefs UncertQ where
-  chunkRefs u = chunkRefs (u ^. coco)
-  {-# INLINABLE chunkRefs #-}
+declareHasChunkRefs ''UncertQ
 
 -- | Equal if 'UID's are equal.
 instance Eq             UncertQ where a == b = (a ^. uid) == (b ^. uid)

--- a/code/drasil-lang/lib/Language/Drasil/Data/Citation.hs
+++ b/code/drasil-lang/lib/Language/Drasil/Data/Citation.hs
@@ -1,3 +1,4 @@
+{-# Language TemplateHaskell #-}
 -- | Contains all necessary types and constructors for citing sources in Drasil.
 module Language.Drasil.Data.Citation (
   -- * Types
@@ -24,7 +25,7 @@ module Language.Drasil.Data.Citation (
 import Control.Lens (Lens', (^.))
 import Data.Maybe (mapMaybe)
 
-import Drasil.Database (HasChunkRefs (..))
+import Drasil.Database (declareHasChunkRefs, Generically(..))
 
 import Language.Drasil.People (People, comparePeople)
 import Language.Drasil.Data.Date (Month(..))
@@ -52,10 +53,6 @@ data CiteField = Address      String
                | Volume       Int
                | Year         Int
 
-instance HasChunkRefs CiteField where
-  chunkRefs = const mempty
-  {-# INLINABLE chunkRefs #-}
-
 -- | 'Citation's should have a fields ('CiteField').
 class HasFields c where
   -- | Provides a 'Lens' to 'CiteField's.
@@ -81,9 +78,9 @@ data CitationKind = Article
                   | TechReport
                   | Unpublished
 
-instance HasChunkRefs CitationKind where
-  chunkRefs = const mempty
-  {-# INLINABLE chunkRefs #-}
+declareHasChunkRefs ''HP
+declareHasChunkRefs ''CiteField
+declareHasChunkRefs ''CitationKind
 
 -- | Smart field constructor for a 'CiteField'.
 author, editor :: People -> CiteField

--- a/code/drasil-lang/lib/Language/Drasil/Data/Date.hs
+++ b/code/drasil-lang/lib/Language/Drasil/Data/Date.hs
@@ -1,3 +1,4 @@
+{-# Language TemplateHaskell #-}
 -- | Custom type for dates, in this case Month.
 -- This should, in time, be switched out in favour of a proper package
 -- designed to handle all the complexities of dates.
@@ -5,6 +6,8 @@ module Language.Drasil.Data.Date
   ( -- * Type
     Month(..)
   ) where
+
+import Drasil.Database (declareHasChunkRefs, Generically(..))
 
 -- | Custom type for months (abbreviated).
 data Month = Jan
@@ -20,6 +23,7 @@ data Month = Jan
            | Nov
            | Dec deriving (Eq, Ord)
 
+declareHasChunkRefs ''Month
 instance Show Month where
   show Jan = "January"
   show Feb = "February"

--- a/code/drasil-lang/lib/Language/Drasil/Document/DecoratedReference.hs
+++ b/code/drasil-lang/lib/Language/Drasil/Document/DecoratedReference.hs
@@ -11,7 +11,7 @@ module Language.Drasil.Document.DecoratedReference (
 
 import Control.Lens ((^.), makeLenses, Lens')
 
-import Drasil.Database (HasUID(..), IsChunk, HasChunkRefs(..))
+import Drasil.Database (HasUID(..), IsChunk, declareHasChunkRefs, Generically(..))
 
 import Language.Drasil.Sentence (RefInfo(..))
 import Language.Drasil.Document.Reference (Reference, ref)
@@ -24,6 +24,7 @@ data DecRef = DR {
   refInfo :: RefInfo
 }
 makeLenses ''DecRef
+declareHasChunkRefs ''DecRef
 
 -- | A class that contains a list of decorated references ('DecRef's).
 class HasDecRef c where
@@ -35,9 +36,6 @@ instance Eq            DecRef where a == b = (a ^. uid) == (b ^. uid)
 -- | Finds the 'UID' of a 'Reference'.
 instance HasUID        DecRef where uid = rf . uid
 
-instance HasChunkRefs DecRef where
-  chunkRefs r = chunkRefs (r ^. rf)
-  {-# INLINABLE chunkRefs #-}
 -- | Finds the reference address contained in a 'Reference' (through a 'LblType').
 instance HasRefAddress DecRef where getRefAdd (DR r _) = getRefAdd r
 -- | Finds the shortname of the reference address used for the 'Reference'.

--- a/code/drasil-lang/lib/Language/Drasil/Document/Reference.hs
+++ b/code/drasil-lang/lib/Language/Drasil/Document/Reference.hs
@@ -11,7 +11,7 @@ module Language.Drasil.Document.Reference (
 
 import Control.Lens ((^.), makeLenses, Lens')
 
-import Drasil.Database (UID, HasUID(..), HasChunkRefs(..), IsChunk)
+import Drasil.Database (UID, HasUID(..), IsChunk, declareHasChunkRefs, Generically(..))
 
 import Language.Drasil.Label.Type (LblType, HasRefAddress(..))
 import Language.Drasil.ShortName (HasShortName(..), ShortName)
@@ -30,9 +30,7 @@ class HasReference c where
   -- | Provides a 'Lens' to the 'Reference's.
   getReferences :: Lens' c [Reference]
 
-instance HasChunkRefs Reference where
-  chunkRefs r = chunkRefs (shortname r)
-  {-# INLINABLE chunkRefs #-}
+declareHasChunkRefs ''Reference
 
 -- | Equal if 'UID's are equal.
 instance Eq            Reference where a == b = (a ^. uid) == (b ^. uid)

--- a/code/drasil-lang/lib/Language/Drasil/Label/Type.hs
+++ b/code/drasil-lang/lib/Language/Drasil/Label/Type.hs
@@ -1,3 +1,4 @@
+{-# Language TemplateHaskell #-}
 -- | Even though we do not have 'Label's per se, here we define the
 -- different ways of construction  ways to mark labels.
 module Language.Drasil.Label.Type(
@@ -11,7 +12,7 @@ module Language.Drasil.Label.Type(
   , name, (+::+), raw, defer, prepend
 ) where
 
-import Drasil.Database (UID, IsChunk)
+import Drasil.Database (UID, IsChunk, declareHasChunkRefs, Generically(..))
 
 -- | Applying different pieces of information for a reference.
 -- An RP is a decorated internal reference.
@@ -28,6 +29,9 @@ data IRefProg =
   | RS String                   -- ^ Lifts a 'String' into a 'RefProg'.
   | RConcat IRefProg IRefProg   -- ^ Concatenates with two subprograms.
   | Name                        -- ^ The 'Symbol' to insert the 'ShortName' directly.
+
+declareHasChunkRefs ''IRefProg
+declareHasChunkRefs '' LblType
 
 -- | Members must have a reference address.
 class HasRefAddress b where

--- a/code/drasil-lang/lib/Language/Drasil/People.hs
+++ b/code/drasil-lang/lib/Language/Drasil/People.hs
@@ -1,3 +1,4 @@
+{-# Language TemplateHaskell #-}
 -- | Defines types and functions to encode people, names, and naming convention.
 -- Used for referencing and authorship of work.
 module Language.Drasil.People (
@@ -13,6 +14,8 @@ module Language.Drasil.People (
   , rendPersLFM, rendPersLFM', rendPersLFM''
   , comparePeople --For sorting references
   ) where
+
+import Drasil.Database (declareHasChunkRefs, Generically(..))
 
 -- | A person can have a given name, middle name(s), and surname, as well
 -- as the naming convention they use.
@@ -31,6 +34,9 @@ data Conv = Western -- ^ Western style conventions are given name followed
                     -- followed by given name.
           | Mono  -- ^ Mononyms are for those people who have only one name (ex. Madonna).
           deriving (Eq)
+
+declareHasChunkRefs ''Conv
+declareHasChunkRefs ''Person
 
 -- | Orderes different groups of 'Person's. If two lists are the same up to a point, the citation with more 'Person's will go last.
 comparePeople :: [Person] -> [Person] -> Ordering

--- a/code/drasil-lang/lib/Language/Drasil/Sentence.hs
+++ b/code/drasil-lang/lib/Language/Drasil/Sentence.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE GADTs, PostfixOperators #-}
+{-# LANGUAGE GADTs, PostfixOperators, TemplateHaskell #-}
 {-# OPTIONS_GHC -Wno-redundant-constraints #-}
 -- | Contains Sentences and helpers functions.
 module Language.Drasil.Sentence (
@@ -16,7 +16,8 @@ module Language.Drasil.Sentence (
 
 import Data.Char (toUpper)
 
-import Drasil.Database (HasChunkRefs(..), UID, IsChunk, UIDRef, hide, raw)
+import Drasil.Database (HasChunkRefs(..), UID, IsChunk, UIDRef, hide, raw,
+  declareHasChunkRefs, Generically(..))
 
 import Language.Drasil.Chunk.NamedIdea (Idea)
 import Language.Drasil.ExprClasses (Express(express))
@@ -46,6 +47,8 @@ data RefInfo = None
              | Equation [Int]
              | Page [Int]
              | RefNote String
+
+declareHasChunkRefs ''RefInfo
 
 -- | For writing 'Sentence's via combining smaller elements.
 -- 'Sentence's are made up of some known vocabulary of things:

--- a/code/drasil-lang/lib/Language/Drasil/ShortName.hs
+++ b/code/drasil-lang/lib/Language/Drasil/ShortName.hs
@@ -1,9 +1,10 @@
+{-# LANGUAGE TemplateHaskell #-}
 -- | Short names are used for displaying references.
 module Language.Drasil.ShortName (
   ShortName, shortname', getSentSN, HasShortName(..)
 ) where
 
-import Drasil.Database (HasChunkRefs (..))
+import Drasil.Database (declareHasChunkRefs, Generically(..))
 
 import Language.Drasil.Sentence (Sentence)
 
@@ -12,9 +13,7 @@ import Language.Drasil.Sentence (Sentence)
 -- | Used for holding the short form of a name (as a 'Sentence' with a wrapper).
 newtype ShortName = ShortNm Sentence
 
-instance HasChunkRefs ShortName where
-  chunkRefs (ShortNm s) = chunkRefs s
-  {-# INLINABLE chunkRefs #-}
+declareHasChunkRefs ''ShortName
 
 -- * Class
 

--- a/code/drasil-lang/lib/Language/Drasil/Uncertainty.hs
+++ b/code/drasil-lang/lib/Language/Drasil/Uncertainty.hs
@@ -16,6 +16,7 @@ module Language.Drasil.Uncertainty (
 ) where
 
 import Control.Lens (Lens', (^.), makeLenses)
+import Drasil.Database (declareHasChunkRefs, Generically(..))
 
 import Data.Maybe (fromMaybe)
 
@@ -25,6 +26,7 @@ data Uncertainty = Uncert {
   _prec   :: Maybe Int
 }
 makeLenses ''Uncertainty
+declareHasChunkRefs ''Uncertainty
 
 -- | HasUncertainty is just a chunk with some uncertainty associated to it.
 -- This uncertainty is represented as a decimal value between 0 and 1 (percentage).

--- a/code/drasil-theory/lib/Theory/Drasil/Components/Derivation.hs
+++ b/code/drasil-theory/lib/Theory/Drasil/Components/Derivation.hs
@@ -1,3 +1,4 @@
+{-# Language TemplateHaskell #-}
 -- | For deriving equations in examples.
 module Theory.Drasil.Components.Derivation (
   -- * Types
@@ -11,6 +12,7 @@ module Theory.Drasil.Components.Derivation (
 import Control.Lens (Lens')
 
 import Language.Drasil (Sentence(EmptyS, S), (+:))
+import Drasil.Database (declareHasChunkRefs, Generically(..))
 
 -- * Type
 
@@ -18,6 +20,8 @@ import Language.Drasil (Sentence(EmptyS, S), (+:))
 -- They are rendered in order as paragraphs and equation blocks to display
 -- the derivation.
 data Derivation = Derivation Sentence [Sentence]
+
+declareHasChunkRefs ''Derivation
 
 -- * Class
 

--- a/code/drasil-theory/lib/Theory/Drasil/DataDefinition.hs
+++ b/code/drasil-theory/lib/Theory/Drasil/DataDefinition.hs
@@ -8,7 +8,8 @@ module Theory.Drasil.DataDefinition (
 
 import Control.Lens
 
-import Drasil.Database (UID, HasUID(..), showUID, HasChunkRefs(..), nsUid)
+import Drasil.Database (UID, HasUID(..), showUID, nsUid,
+  declareHasChunkRefs, Generically(..))
 import Language.Drasil
 import Language.Drasil.Document
 import Drasil.Metadata.TheoryConcepts (dataDefn)
@@ -55,13 +56,8 @@ ddPkt lpkt = lens g s
     s (DDE  qd pkt) a' = DDE  qd (pkt & lpkt .~ a')
     s (DDME qd pkt) a' = DDME qd (pkt & lpkt .~ a')
 
-instance HasChunkRefs DataDefinition where
-  chunkRefs dd = mconcat
-    [ either chunkRefs chunkRefs (qdFromDD dd)
-    , chunkRefs (dd ^. ddPkt pktSN)
-    , chunkRefs (dd ^. ddPkt pktSS)
-    ]
-  {-# INLINABLE chunkRefs #-}
+declareHasChunkRefs ''DDPkt
+declareHasChunkRefs ''DataDefinition
 
 -- | Finds the 'UID' of a 'DataDefinition where'.
 instance HasUID             DataDefinition where uid = ddPkt pktUID

--- a/code/drasil-theory/lib/Theory/Drasil/GenDefn.hs
+++ b/code/drasil-theory/lib/Theory/Drasil/GenDefn.hs
@@ -11,7 +11,7 @@ module Theory.Drasil.GenDefn (
 
 import Control.Lens ((^.), view, makeLenses)
 
-import Drasil.Database (HasUID(..), showUID, HasChunkRefs(..))
+import Drasil.Database (HasUID(..), showUID, declareHasChunkRefs, Generically(..))
 import Language.Drasil
 import Language.Drasil.Document
 import Drasil.Metadata.TheoryConcepts (genDefn)
@@ -29,15 +29,7 @@ data GenDefn = GD { _mk    :: ModelKind ModelExpr
                   , _notes :: [Sentence]
                   }
 makeLenses ''GenDefn
-
-instance HasChunkRefs GenDefn where
-  chunkRefs gdn = mconcat
-    [ chunkRefs (gdn ^. mk)
-    , chunkRefs (gdUnit gdn)
-    , chunkRefs (gdn ^. sn)
-    , chunkRefs (gdn ^. notes)
-    ]
-  {-# INLINABLE chunkRefs #-}
+declareHasChunkRefs ''GenDefn
 
 -- | Finds the 'UID' of a 'GenDefn'.
 instance HasUID             GenDefn where uid         = mk . uid

--- a/code/drasil-theory/lib/Theory/Drasil/Theory.hs
+++ b/code/drasil-theory/lib/Theory/Drasil/Theory.hs
@@ -8,7 +8,7 @@ module Theory.Drasil.Theory (
 
 import Control.Lens (view, makeLenses, (^.))
 
-import Drasil.Database (HasUID(..), showUID, HasChunkRefs(..))
+import Drasil.Database (HasUID(..), showUID, declareHasChunkRefs, Generically(..))
 import Language.Drasil
 import Language.Drasil.Document
 import Drasil.Metadata.TheoryConcepts (thModel)
@@ -41,14 +41,7 @@ data TheoryModel = TM
   , _notes :: [Sentence]
   }
 makeLenses ''TheoryModel
-
-instance HasChunkRefs TheoryModel where
-  chunkRefs tm' = mconcat
-    [ chunkRefs (tm' ^. mk)
-    , chunkRefs (lb tm')
-    , chunkRefs (tm' ^. notes)
-    ]
-  {-# INLINABLE chunkRefs #-}
+declareHasChunkRefs ''TheoryModel
 
 -- | Finds the 'UID' of a 'TheoryModel'.
 instance HasUID             TheoryModel where uid = mk . uid

--- a/code/drasil-theory/package.yaml
+++ b/code/drasil-theory/package.yaml
@@ -11,6 +11,9 @@ description:  Please see the README on GitHub at <https://github.com/JacquesCare
 language: Haskell2010
 default-extensions:
 - StrictData
+- StandaloneDeriving
+- DerivingVia
+- DeriveGeneric
 
 extra-source-files: []
 


### PR DESCRIPTION
Closes #5159

Replacing some of the manually-written `instance HasChunkRefs X` with `declareHasChunkRefs ''X`
Some types required keeping their manual instances due to the limitation of `declareHasChunkRefs ''X`, those are:
- `QDefinition`, `ConstraintSet`, `ModelKinds`, `MultiDefn`, `DefiningExpr`, `UIDRef`, `ConstrConcept`, `CodeDefinition` and `DifferentialModel` contain parameterized Kinds (* -> *)
- `Sentence` and `RelationConcept` contain Non-Vanilla Constructors
- `DefinedQuantityDict` and `PluralRule` / `NP` contain embedded Functions
- `chunk` instances:  `Drasil.Database.TH` depends on `Drasil.Database.Chunk`
- `Section` and `SecCons` are mutually dependent