### PR TITLE
Rewrite Deploy CI

### DIFF
--- a/.github/workflows/Deploy.yaml
+++ b/.github/workflows/Deploy.yaml
@@ -216,7 +216,7 @@ jobs:
         run: tar zxf $RUNNER_TEMP/website-artifacts.tar.gz
 
       - name: "Prepare full website deployment environment"
-        run: make deploy_lite SKIP_GEN=1
+        run: make deploy_lite
 
       - name: "Upload static website as artifact"
         uses: actions/upload-pages-artifact@v5

--- a/.github/workflows/Deploy.yaml
+++ b/.github/workflows/Deploy.yaml
@@ -4,10 +4,6 @@ on:
     paths: [code/**, .github/workflows/Deploy.yaml]
   workflow_dispatch:
 name: Deploy
-permissions:
-  contents: read
-  pages: write
-  id-token: write
 concurrency:
   group: deploy
   cancel-in-progress: true
@@ -16,9 +12,9 @@ defaults:
     shell: bash
     working-directory: code
 jobs:
-  deploy:
-    name: "Build, Test & Deploy"
-    runs-on: ubuntu-22.04
+  build:
+    name: "Build & Test"
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
 
@@ -26,24 +22,9 @@ jobs:
         run: |
           sudo apt-get update
 
-      - name: "Install system requirements"
+      - name: "Install requirements"
         run: |
-          sudo apt-get install -y --fix-missing libgmp-dev python3 graphviz doxygen fonts-lmodern texlive-bibtex-extra texlive-latex-extra texlive-science texlive-luatex g++ default-jdk mono-devel inkscape
-          curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
-          cargo install mdbook
-
-      - name: "Update PATH"
-        run: |
-          echo "$HOME/.local/bin" >> $GITHUB_PATH
-          echo "$HOME/.swift/usr/bin" >> $GITHUB_PATH
-          echo "$HOME/.cargo/bin" >> $GITHUB_PATH
-
-      - name: "Install Stack"
-        uses: haskell-actions/setup@v2
-        with:
-          enable-stack: true
-          stack-no-global: true
-          stack-version: 'latest'
+          sudo apt-get install -y graphviz
 
       - name: "Cache dependencies"
         uses: actions/cache@v6
@@ -52,32 +33,17 @@ jobs:
             ~/.stack
           key: ${{ runner.os }}-stack-${{ hashFiles('code/stack.yaml') }}
 
-      - name: "Clean previous run"
-        run: make clean
-
       - name: "Install dependencies"
         run: make stackArgs="--no-terminal" deps
 
       - name: "Build"
         run: make code stackArgs="--no-terminal" GHCFLAGS="-Werror -Wwarn=deprecations"
 
+      - name: "Stack Test"
+        run: make stack_test stackArgs="--no-terminal"
+
       - name: "Test built artifacts against stable"
         run: make stackArgs="--no-terminal" GHCFLAGS="-Werror -Wwarn=deprecations" NOISY=yes
-
-      - name: "Compile GOOL examples"
-        run: make codegenTest
-
-      - name: "Compile generated TeX artifacts"
-        run: make -j tex SUMMARIZE_TEX=yes
-
-      - name: "Compile generated software artifacts"
-        run: make gool
-
-      - name: "Create Doxygen for generated software artifacts"
-        run: make doxygen
-
-      - name: "Generate Haddock docs (full + std)"
-        run: FULL=1 make docs
 
       - name: "Generate module dependency graphs"
         run: make graphs
@@ -88,37 +54,185 @@ jobs:
       - name: "Convert analysis graphs into dot and circo SVGs"
         run: make convertAnalyzed
 
-      - name: "Build trace graphs"
-        run: make tracegraphs
+      - name: "Upload generated artifacts"
+        uses: actions/upload-artifact@v7
+        with:
+          name: generated
+          path: code/build
+          include-hidden-files: true
+
+      - name: "Upload gooltest artifacts"
+        uses: actions/upload-artifact@v7
+        with:
+          name: generated-gooltest
+          path: code/drasil-code/test/build
+
+      - name: "Compress website artifacts"
+        run: tar zcf $RUNNER_TEMP/website-artifacts.tar.gz analysis graphs website
+
+      - name: "Upload website artifacts"
+        uses: actions/upload-artifact@v7
+        with:
+          path: ${{ runner.temp }}/website-artifacts.tar.gz
+          archive: false
+
+  haddock:
+    name: Haddock
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: "Restore dependency cache"
+        uses: actions/cache/restore@v6
+        with:
+          path: |
+            ~/.stack
+          key: ${{ runner.os }}-stack-${{ hashFiles('code/stack.yaml') }}
+
+      - name: "Generate Haddock docs (full + std)"
+        run: make docs FULL=1
+
+      - name: "Upload Haddock docs"
+        uses: actions/upload-artifact@v7
+        with:
+          name: haddock-docs
+          path: code/docs
+
+  gooltest:
+    name: "Compile GOOL"
+    needs: build
+    runs-on: ubuntu-latest
+    env:
+      SKIP_GEN: 1
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: "Update apt package list"
+        run: |
+          sudo apt-get update
+
+      - name: "Install requirements"
+        run: |
+          sudo apt-get install -y default-jdk-headless mono-devel
+
+      - name: "Download generated artifacts"
+        uses: actions/download-artifact@v8
+        with:
+          name: generated
+          path: code/build
+
+      - name: "Download gooltest artifacts"
+        uses: actions/download-artifact@v8
+        with:
+          name: generated-gooltest
+          path: code/drasil-code/test/build
+
+      - name: "Compile GOOL Examples"
+        run: make codegenTest
+      
+      - name: "Compile generated software artifacts"
+        run: make gool
+
+  generate:
+    name: "Generate Documents"
+    needs: build
+    runs-on: ubuntu-26.04
+    env:
+      SKIP_GEN: 1
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: "Update apt package list"
+        run: |
+          sudo apt-get update
+
+      - name: "Install requirements"
+        run: |
+          sudo apt-get install -y graphviz fonts-lmodern texlive-bibtex-extra texlive-latex-extra texlive-science texlive-luatex inkscape jupyter-nbconvert doxygen
+
+      - name: "Install mdBook"
+        env:
+          MDBOOK_VERSION: 0.5.4
+        working-directory: ${{ runner.temp }}
+        run: |
+          curl -L -O https://github.com/rust-lang/mdBook/releases/download/v$MDBOOK_VERSION/mdbook-v$MDBOOK_VERSION-x86_64-unknown-linux-gnu.tar.gz
+          tar zxf mdbook-v$MDBOOK_VERSION-x86_64-unknown-linux-gnu.tar.gz
+          mkdir -p ~/.local/bin
+          mv mdbook ~/.local/bin
+          mdbook --version
+
+      - name: "Download generated artifacts"
+        uses: actions/download-artifact@v8
+        with:
+          name: generated
+          path: code/build
+
+      - name: "Compile generated TeX artifacts"
+        run: make -j4 tex SUMMARIZE_TEX=yes
 
       - name: "Build mdBook Examples"
         run: make mdbook_build
 
       - name: "Extract HTML copies of Jupyter Notebooks"
-        run: |
-          pip install jupyterlab
-          make jupyter_html
+        run: make jupyter_html
 
-      - name: "Build website generator"
-        run: make website
+      - name: "Create Doxygen for generated software artifacts"
+        run: make doxygen
 
-      - name: "Test Built Website against Stable Version"
-        run: make test_website NOISY=yes
+      - name: "Upload full generated artifacts"
+        uses: actions/upload-artifact@v7
+        with:
+          name: generated-full
+          path: code/build
+
+  prepare_deploy:
+    name: "Prepare Deployment"
+    needs: [haddock, generate]
+    runs-on: ubuntu-latest
+    env:
+      SKIP_GEN: 1
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: "Download full generated artifacts"
+        uses: actions/download-artifact@v8
+        with:
+          name: generated-full
+          path: code/build
+
+      - name: "Download Haddock docs"
+        uses: actions/download-artifact@v8
+        with:
+          name: haddock-docs
+          path: code/docs
+
+      - name: "Download website artifacts"
+        uses: actions/download-artifact@v8
+        with:
+          name: website-artifacts.tar.gz
+          path: ${{ runner.temp }}
+
+      - name: "Extract website artifacts"
+        run: tar zxf $RUNNER_TEMP/website-artifacts.tar.gz
 
       - name: "Prepare full website deployment environment"
-        run: make deploy_lite
+        run: make deploy_lite SKIP_GEN=1
 
       - name: "Upload static website as artifact"
         uses: actions/upload-pages-artifact@v5
         with:
-          path: code/deploy/
+          path: code/deploy
 
-  deploy-pages:
+  deploy:
+    name: "Deploy"
+    needs: prepare_deploy
+    runs-on: ubuntu-latest
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
-    runs-on: ubuntu-latest
-    needs: deploy
+    permissions:
+      pages: write
+      id-token: write
     steps:
       - name: Deploy GitHub Pages
         id: deployment

--- a/code/Makefile
+++ b/code/Makefile
@@ -506,6 +506,7 @@ deploy_code_path: $(DCP_EXAMPLES) ##@GOOL Find all code file paths for all examp
 
 # For more information, see the *.hs files in the drasil-website folder.
 website: ##@Deploy First builds all Drasil packages, and then executes the drasil-website.
+ifneq ($(SKIP_GEN), 1)
 	stack build $(stackBuildArgs) "drasil-website"
 	CUR_DIR="$(PWD)/" \
 	DEPLOY_FOLDER="$(CUR_DIR)$(DEPLOY_FOLDER)" \
@@ -519,6 +520,7 @@ website: ##@Deploy First builds all Drasil packages, and then executes the drasi
 	TYPEGRAPH_FOLDER="$(TYPEGRAPH_FOLDER)" \
 	CLASSINST_GRAPH_FOLDER="$(CLASSINST_GRAPH_FOLDER)" \
 	$(STACK_EXEC) -- "website"
+endif
 
 # Prepares a website folder deployable to GitHub Pages using existing artifacts.
 deploy_lite: website ##@Deploy Deploy the Drasil website without regenerating artifacts. For local development.


### PR DESCRIPTION
The workflow is now split up to run some steps in parallel, as well as being faster my minimizing the amount of dependencies that need to be installed for each step.

The workflow isn't split up quite as much as the PR CI one, as we need to combine the artifacts at the end to be able to publish the website. It's still about 2 times faster than the current one, though.

A sample run can be seen [in my fork](https://github.com/djarabek/Drasil/actions/runs/29025918436), and the published website is available at https://djarabek.github.io/Drasil/. I've clicked through the website and all the links work.