### PR TITLE
Add workaround for inkscape crash

### DIFF
--- a/.github/workflows/Build.yaml
+++ b/.github/workflows/Build.yaml
@@ -145,8 +145,6 @@ jobs:
     if: ${{ needs.build.outputs.tex == 'true' }}
     env:
       SKIP_GEN: 1
-      # Workaround rare inkscape crash: https://gitlab.com/inkscape/inkscape/-/work_items/4716#note_1898150983
-      SELF_CALL: 1
     steps:
       - uses: actions/checkout@v7
 

--- a/.github/workflows/Build.yaml
+++ b/.github/workflows/Build.yaml
@@ -145,6 +145,8 @@ jobs:
     if: ${{ needs.build.outputs.tex == 'true' }}
     env:
       SKIP_GEN: 1
+      # Workaround rare inkscape crash: https://gitlab.com/inkscape/inkscape/-/work_items/4716#note_1898150983
+      SELF_CALL: 1
     steps:
       - uses: actions/checkout@v7
 

--- a/code/scripts/tex_build.sh
+++ b/code/scripts/tex_build.sh
@@ -22,6 +22,9 @@ else
   IMODE=nonstopmode
 fi
 
+# Workaround rare inkscape crash: https://gitlab.com/inkscape/inkscape/-/work_items/4716#note_1898150983
+export SELF_CALL=1
+
 GEN_NAME_SUFFIX=_SRS
 
 cd "$BUILD_FOLDER$EDIR"/SRS/PDF || exit 1


### PR DESCRIPTION
Not really tested, but hopefully fixes the issue. I've only had the crash come up once since limiting to 4 LaTeX processes at a time (`-j4`).