### PR TITLE
debugging: allow usage for any system written with `concretizeAndWriteFiles`

### DIFF
--- a/code/drasil-database/lib/Drasil/Database/ChunkDB.hs
+++ b/code/drasil-database/lib/Drasil/Database/ChunkDB.hs
@@ -10,7 +10,7 @@ module Drasil.Database.ChunkDB (
   findUnused,
   find, findOrErr,
   findAll, findAll',
-  dependants, dependantsOrErr,
+  dependants, dependantsOrErr, allDependants,
   findTypeOf,
   insert, insertAll,
   -- * Temporary functions
@@ -112,6 +112,10 @@ dependants u cdb = do
 -- dependency chunk is not found.
 dependantsOrErr :: UID -> ChunkDB -> [UID]
 dependantsOrErr u = fromMaybe (error $ "Failed to find references for unknown chunk " ++ show u) . find u
+
+-- | List all chunks with dependants.
+allDependants :: ChunkDB -> M.Map UID [UID]
+allDependants = M.filter (not . null) . M.map snd . chunkTable
 
 -- | Find the type of a chunk by its 'UID'.
 findTypeOf :: UID -> ChunkDB -> Maybe TypeRep

--- a/code/drasil-database/lib/Drasil/Database/Dump.hs
+++ b/code/drasil-database/lib/Drasil/Database/Dump.hs
@@ -1,9 +1,10 @@
 module Drasil.Database.Dump (
-    ChunkType, DumpedChunkDB, dumpChunkDB
+    ChunkType, DumpedChunkDB, dumpChunkDB, dumpChunkDeps
 ) where
 
 import Drasil.Database.UID (UID)
-import Drasil.Database.ChunkDB (findAll', typesRegistered, ChunkDB)
+import Drasil.Database.ChunkDB (findAll', typesRegistered, ChunkDB, allDependants)
+import Drasil.Database.Maps (invert)
 
 import Data.Map.Strict (Map)
 import qualified Data.Map.Strict as SM
@@ -16,3 +17,11 @@ type DumpedChunkDB = Map ChunkType [UID]
 
 dumpChunkDB :: ChunkDB -> DumpedChunkDB
 dumpChunkDB cdb = SM.fromList $ map (\ty -> (show ty, findAll' ty cdb)) (typesRegistered cdb)
+
+type Dependencies = Map UID [UID]
+type Dependants = Map UID [UID]
+
+-- | Dump all chunk dependants and dependencies.
+dumpChunkDeps :: ChunkDB -> (Dependants, Dependencies)
+dumpChunkDeps db = (invert allDeps, allDeps)
+  where allDeps = allDependants db

--- a/code/drasil-gen/lib/Drasil/Generator/CaseStudyVariants.hs
+++ b/code/drasil-gen/lib/Drasil/Generator/CaseStudyVariants.hs
@@ -12,7 +12,6 @@ where
 
 import Control.Lens ((^.))
 import Data.Char (toLower)
-import Data.Maybe (maybeToList)
 
 import Drasil.FileHandling (FileLayout, OverwritePolicy(..), directory, localPath, ps,
   writeFiles)
@@ -20,7 +19,6 @@ import Drasil.SRS (SRSDecl, mkDoc, SmithEtAlSRS, programName)
 import Language.Drasil.Code (Choices)
 import qualified Language.Drasil.Sentence.Combinators as S
 
-import Drasil.Generator.ChunkDump (buildDebugData)
 import Drasil.Generator.Code (genCode, genCodeZoo)
 import Drasil.Generator.SRS (genSmithEtAlSrs)
 import Drasil.Generator.SRS.TypeCheck (typeCheckSI)
@@ -37,10 +35,8 @@ writeSmithEtAlSrs :: SmithEtAlSRS -> SRSDecl -> String -> IO ([FileLayout], Smit
 writeSmithEtAlSrs syst srsDecl srsFileName = do
   let exampleName = caseStudyBuildFolder syst
       (srs, syst') = mkDoc syst srsDecl S.forT
-  mDbgData <- buildDebugData syst'
   typeCheckSI syst' -- FIXME: This should be done on `System` creation *or* chunk creation!
-  let dbgData = maybeToList mDbgData
-      layout = dbgData ++ genSmithEtAlSrs syst' srs srsFileName
+  let layout = genSmithEtAlSrs syst' srs srsFileName
   pure (layout, syst', exampleName)
 
 -- | A case study that only outputs an SRS in each of our supported variants.

--- a/code/drasil-gen/lib/Drasil/Generator/ChunkDump.hs
+++ b/code/drasil-gen/lib/Drasil/Generator/ChunkDump.hs
@@ -2,35 +2,25 @@
 
 module Drasil.Generator.ChunkDump (
   -- * Tools for dumping a chunk database
-  buildDebugData
+  buildDebuggingFiles
 ) where
 
 import Control.Lens ((^.))
 import Data.Aeson (ToJSON)
 import Data.Aeson.Encode.Pretty (encodePretty)
-import System.Environment (lookupEnv)
 
 import Drasil.Database (dumpChunkDB, dumpChunkDeps)
-import Drasil.FileHandling (FileLayout, PathSegment, directory, file, ps)
+import Drasil.FileHandling (FileLayout, PathSegment, file, ps)
 import Drasil.System (systemdb, HasSystemMeta)
 
--- | Builds the `.drasil` chunk dump directory if the `DEBUG_ENV` environment
--- variable is non-empty.
-buildDebugData :: HasSystemMeta sys => sys -> IO (Maybe FileLayout)
-buildDebugData si = do
-  maybeDebugging <- lookupEnv "DEBUG_ENV"
-  case maybeDebugging of
-    (Just (_:_)) -> pure $ Just $ dumpEverything si
-    _ -> pure Nothing
-
--- | Internal: For debugging purposes, constructs a `FileLayout` with a dump of
--- the chunk maps.
-dumpEverything :: HasSystemMeta sys => sys -> FileLayout
-dumpEverything si =
-  directory [ps|.drasil|]
+-- | Internal: For system debugging purposes, dump everything we can to a set of
+-- files.
+buildDebuggingFiles :: HasSystemMeta sys => sys -> [FileLayout]
+buildDebuggingFiles si =
   [ dumpTo [ps|initial_chunks.json|] $ dumpChunkDB db
   , dumpTo [ps|initial_chunk_dependants.json|] dependants
   , dumpTo [ps|initial_chunk_dependencies.json|] dependencies
+  -- FIXME: One more file containing the system meta-information.
   ]
   where
     db = si ^. systemdb

--- a/code/drasil-gen/lib/Drasil/Generator/ChunkDump.hs
+++ b/code/drasil-gen/lib/Drasil/Generator/ChunkDump.hs
@@ -10,14 +10,13 @@ import Data.Aeson (ToJSON)
 import Data.Aeson.Encode.Pretty (encodePretty)
 import System.Environment (lookupEnv)
 
-import Drasil.Database (dumpChunkDB)
+import Drasil.Database (dumpChunkDB, dumpChunkDeps)
 import Drasil.FileHandling (FileLayout, PathSegment, directory, file, ps)
-import Drasil.System (systemdb)
-import Drasil.SRS (SmithEtAlSRS, traceTable, refbyTable)
+import Drasil.System (systemdb, HasSystemMeta)
 
 -- | Builds the `.drasil` chunk dump directory if the `DEBUG_ENV` environment
 -- variable is non-empty.
-buildDebugData :: SmithEtAlSRS -> IO (Maybe FileLayout)
+buildDebugData :: HasSystemMeta sys => sys -> IO (Maybe FileLayout)
 buildDebugData si = do
   maybeDebugging <- lookupEnv "DEBUG_ENV"
   case maybeDebugging of
@@ -26,13 +25,16 @@ buildDebugData si = do
 
 -- | Internal: For debugging purposes, constructs a `FileLayout` with a dump of
 -- the chunk maps.
-dumpEverything :: SmithEtAlSRS -> FileLayout
+dumpEverything :: HasSystemMeta sys => sys -> FileLayout
 dumpEverything si =
   directory [ps|.drasil|]
-  [ dumpTo [ps|seeds.json|] $ dumpChunkDB (si ^. systemdb),
-    dumpTo [ps|trace.json|] $ si ^. traceTable,
-    dumpTo [ps|reverse_trace.json|] $ si ^. refbyTable
+  [ dumpTo [ps|initial_chunks.json|] $ dumpChunkDB db
+  , dumpTo [ps|initial_chunk_dependants.json|] dependants
+  , dumpTo [ps|initial_chunk_dependencies.json|] dependencies
   ]
+  where
+    db = si ^. systemdb
+    (dependants, dependencies) = dumpChunkDeps db
 
 -- | Internal: Build a JSON file from arbitrary data.
 dumpTo :: ToJSON a => PathSegment -> a -> FileLayout

--- a/code/drasil-gen/lib/Drasil/Generator/WriteSystem.hs
+++ b/code/drasil-gen/lib/Drasil/Generator/WriteSystem.hs
@@ -8,15 +8,19 @@ module Drasil.Generator.WriteSystem
     concretizeAndWrite,
     setSystemLocale,
     WriteOptions (..),
+    DebugDataPolicy (..)
   )
 where
 
 import Control.Lens ((^.))
 import GHC.IO.Encoding (setLocaleEncoding, utf8, TextEncoding)
+import System.Environment (lookupEnv)
 
-import Drasil.FileHandling (OverwritePolicy (..), PathSegment, directory, localPath, ps, writeFiles)
+import Drasil.FileHandling (OverwritePolicy (..), PathSegment, directory, localPath, ps, writeFiles, FileLayout)
 import Drasil.System (HasSystemMeta (..), ToFiles (..))
 import Language.Drasil (CommonIdea (abrv))
+
+import Drasil.Generator.ChunkDump (buildDebuggingFiles)
 
 -- | Internal: Set system locale encoding to UTF-8.
 setSystemLocale :: IO ()
@@ -25,6 +29,21 @@ setSystemLocale = setLocaleEncoding utf8
 {-# DEPRECATED setSystemLocale
   "Use `concretizeAndWrite` instead of directly setting system locale before file-writing." #-}
 
+-- | When should debugging data be written?
+data DebugDataPolicy
+  = -- | Always.
+    AlwaysWrite
+      -- | The name of the directory to carry all debugging data files.
+      PathSegment
+  | -- | Only write debugging data if the following environment variable ('String') is non-empty.
+    CheckEnvVar
+      -- | The environment variable name.
+      String
+      -- | The name of the directory to carry all debugging data files.
+      PathSegment
+  | -- | Never.
+    NeverWrite
+
 -- | Configuration options for writing a repository of software artifacts.
 data WriteOptions = WO
   { -- | Are we allowed to overwrite files or not?
@@ -32,7 +51,9 @@ data WriteOptions = WO
     -- | What is the name of the subfolder to be created?
     localDirName :: forall sys. HasSystemMeta sys => sys -> PathSegment,
     -- | What is the expected text encoding scheme?
-    textEncoding :: TextEncoding
+    textEncoding :: TextEncoding,
+    -- | Should debugging data be written?
+    debugDataPolicy :: DebugDataPolicy
   }
 
 -- | These are the default file-writing 'WriteOptions' required for Drasil (the
@@ -44,7 +65,8 @@ data WriteOptions = WO
 -- 2. 'dirName': The example's abbreviation.
 -- 3. 'textEncoding': UTF-8.
 drasilMakefileReqOpts :: WriteOptions
-drasilMakefileReqOpts = WO OverwriteAllowed dirName utf8
+drasilMakefileReqOpts =
+  WO OverwriteAllowed dirName utf8 (CheckEnvVar "DEBUG_ENV" [ps|.drasil|])
   where
     dirName sys = let ab = abrv $ sys ^. systemMeta . sysName
                    in [ps|{ab}|]
@@ -52,6 +74,18 @@ drasilMakefileReqOpts = WO OverwriteAllowed dirName utf8
 -- FIXME: Both `abrv` usage and `sysName` usage above is dubious. We need to
 -- replace this field with something better, such as project name and project
 -- shortname (repo name).
+
+-- | Internal: 'DebugDataPolicy' eliminator.
+debugData :: HasSystemMeta sys => sys -> DebugDataPolicy -> IO (Maybe FileLayout)
+debugData _ NeverWrite = pure Nothing
+debugData sys (AlwaysWrite dirName) =
+  pure $ Just $ directory dirName $ buildDebuggingFiles sys
+debugData sys (CheckEnvVar envVar dirName) = do
+  maybeDebugging <- lookupEnv envVar
+  case maybeDebugging of
+    (Just v) | not (null v)
+      -> pure $ Just $ directory dirName $ buildDebuggingFiles sys
+    _ -> pure Nothing
 
 -- | Concretize a system into a concrete set of files and write them to disk.
 --
@@ -69,4 +103,8 @@ concretizeAndWrite ::
   IO ()
 concretizeAndWrite sys concOpts WO {..} = do
   setLocaleEncoding textEncoding
-  writeFiles overwritePolicy localPath $ directory (localDirName sys) $ toFiles sys concOpts
+  debugFiles <- debugData sys debugDataPolicy
+  let artifacts = toFiles sys concOpts
+      artifacts' = maybe artifacts (: artifacts) debugFiles
+      finalDir = directory (localDirName sys) artifacts'
+  writeFiles overwritePolicy localPath finalDir


### PR DESCRIPTION
Builds on #5287

The debugging tools are very helpful when debugging. However, previously they were only usable when an SRS was in sight.

With this PR, we generate the debugging data with the `ChunkDB` rather than through a `SmithEtAlSRS`.

We can extend this idea further (if we wanted and in a subsequent PR), letting any system also produce any kind of desired 'debugging data files' by building a typeclass:

```haskell
class DebugData sys where
   debugData :: sys -> [FileLayout]
```

and, of course, instantiating it with for each of our system types and using `debugData` in `concretizeAndWriteFiles`