### PR TITLE
fix(`dependantsOrErr`): check with `dependants` instead of `find`

### DIFF
--- a/code/drasil-database/lib/Drasil/Database/ChunkDB.hs
+++ b/code/drasil-database/lib/Drasil/Database/ChunkDB.hs
@@ -111,7 +111,7 @@ dependants u cdb = do
 -- | Find all chunks that depend on a specific one, throwing a hard error if the
 -- dependency chunk is not found.
 dependantsOrErr :: UID -> ChunkDB -> [UID]
-dependantsOrErr u = fromMaybe (error $ "Failed to find references for unknown chunk " ++ show u) . find u
+dependantsOrErr u = fromMaybe (error $ "Failed to find references for unknown chunk " ++ show u) . dependants u
 
 -- | Find the type of a chunk by its 'UID'.
 findTypeOf :: UID -> ChunkDB -> Maybe TypeRep


### PR DESCRIPTION
Previously, this would always fail because `find` will never return a list of `UID`s (because those are not even "chunks," let alone ones we insert in the `ChunkDB`!).