### PR TITLE
CI: Cache .stack-work and .hie

### DIFF
--- a/.github/workflows/Build.yaml
+++ b/.github/workflows/Build.yaml
@@ -54,6 +54,15 @@ jobs:
             ~/.stack
           key: ${{ runner.os }}-stack-${{ hashFiles('code/stack.yaml') }}
 
+      - name: "Restore stack work cache"
+        uses: actions/cache/restore@v6
+        with:
+          path: |
+            code/.stack-work
+            code/**/.stack-work
+            code/**/.hie
+          key: ${{ runner.os }}-stack-work
+
       - name: "Install dependencies"
         run: make stackArgs="--no-terminal" deps
 
@@ -98,6 +107,15 @@ jobs:
           path: |
             ~/.stack
           key: ${{ runner.os }}-stack-${{ hashFiles('code/stack.yaml') }}
+
+      - name: "Restore stack work cache"
+        uses: actions/cache/restore@v6
+        with:
+          path: |
+            code/.stack-work
+            code/**/.stack-work
+            code/**/.hie
+          key: ${{ runner.os }}-stack-work-haddock
 
       - name: "Generate Haddock docs (as test)"
         run: make docs

--- a/.github/workflows/Deploy.yaml
+++ b/.github/workflows/Deploy.yaml
@@ -76,6 +76,15 @@ jobs:
           path: ${{ runner.temp }}/website-artifacts.tar.gz
           archive: false
 
+      - name: "Cache stack work"
+        uses: actions/cache/save@v6
+        with:
+          path: |
+            code/.stack-work
+            code/**/.stack-work
+            code/**/.hie
+          key: ${{ runner.os }}-stack-work
+
   haddock:
     name: Haddock
     runs-on: ubuntu-latest
@@ -97,6 +106,15 @@ jobs:
         with:
           name: haddock-docs
           path: code/docs
+
+      - name: "Cache stack work"
+        uses: actions/cache/save@v6
+        with:
+          path: |
+            code/.stack-work
+            code/**/.stack-work
+            code/**/.hie
+          key: ${{ runner.os }}-stack-work-haddock
 
   gooltest:
     name: "Compile GOOL"


### PR DESCRIPTION
When main is built, a fresh cache is saved which can then be used by CI on PRs. For PRs with small or isolated changes, this can significantly speed up the build time.

See https://github.com/djarabek/Drasil/actions/runs/29031264011 for an example.