### PR TITLE
refactor(`package.yaml`s): minimize scope of package dependencies in each `drasil-*` subproject

### DIFF
--- a/code/drasil-assets/package.yaml
+++ b/code/drasil-assets/package.yaml
@@ -23,7 +23,6 @@ dependencies:
 - file-io >= 0.1.6
 - template-haskell
 - text
-- drasil-file-handling
 
 ghc-options:
 - -Wall
@@ -31,6 +30,8 @@ ghc-options:
 - -Wmissing-export-lists
 
 library:
+  dependencies:
+  - drasil-file-handling
   source-dirs: lib
   exposed-modules:
   - Drasil.Assets

--- a/code/drasil-code/package.yaml
+++ b/code/drasil-code/package.yaml
@@ -26,17 +26,9 @@ dependencies:
 - directory
 - filepath
 - split
-- drasil-database
 - drasil-file-handling
 - drasil-gool
-- drasil-lang
-- drasil-makefile
 - drasil-metadata
-- drasil-printers
-- drasil-srs
-- drasil-system
-- drasil-theory
-- drasil-utils
 - deriving-compat
 
 ghc-options:
@@ -45,6 +37,15 @@ ghc-options:
 - -Wmissing-export-lists
 
 library:
+  dependencies:
+  - drasil-database
+  - drasil-lang
+  - drasil-makefile
+  - drasil-printers
+  - drasil-srs
+  - drasil-system
+  - drasil-theory
+  - drasil-utils
   source-dirs: lib
   exposed-modules:
   - Language.Drasil.Code

--- a/code/drasil-example/bss/package.yaml
+++ b/code/drasil-example/bss/package.yaml
@@ -22,19 +22,16 @@ dependencies:
 - base >= 4.7 && < 5
 - lens
 - directory
-- drasil-code
-- drasil-data
-- drasil-database
-- drasil-srs
 - drasil-gen
-- drasil-gool
-- drasil-lang
-- drasil-printers
-- drasil-system
-- drasil-theory
-- drasil-utils
 
 library:
+  dependencies:
+  - drasil-code
+  - drasil-data
+  - drasil-database
+  - drasil-lang
+  - drasil-srs
+  - drasil-theory
   source-dirs: lib
   when:
   - condition: false

--- a/code/drasil-example/dblpend/package.yaml
+++ b/code/drasil-example/dblpend/package.yaml
@@ -23,19 +23,17 @@ dependencies:
 - base >= 4.7 && < 5
 - lens
 - directory
-- drasil-code
-- drasil-data
-- drasil-database
-- drasil-srs
 - drasil-gen
-- drasil-gool
-- drasil-lang
-- drasil-printers
-- drasil-system
-- drasil-theory
-- drasil-utils
 
 library:
+  dependencies:
+  - drasil-code
+  - drasil-data
+  - drasil-database
+  - drasil-lang
+  - drasil-srs
+  - drasil-theory
+  - drasil-utils
   source-dirs: lib
 
 executables:

--- a/code/drasil-example/gamephysics/package.yaml
+++ b/code/drasil-example/gamephysics/package.yaml
@@ -23,19 +23,16 @@ dependencies:
 - base >= 4.7 && < 5
 - lens
 - directory
-- drasil-code
-- drasil-data
-- drasil-database
-- drasil-srs
 - drasil-gen
-- drasil-gool
-- drasil-lang
-- drasil-printers
-- drasil-system
-- drasil-theory
-- drasil-utils
 
 library:
+  dependencies:
+  - drasil-data
+  - drasil-database
+  - drasil-lang
+  - drasil-srs
+  - drasil-theory
+  - drasil-utils
   source-dirs: lib
   when:
   - condition: false

--- a/code/drasil-example/glassbr/package.yaml
+++ b/code/drasil-example/glassbr/package.yaml
@@ -23,20 +23,18 @@ dependencies:
 - base >= 4.7 && < 5
 - lens
 - directory
-- drasil-code
-- drasil-data
-- drasil-database
-- drasil-srs
-- drasil-file-handling
 - drasil-gen
-- drasil-gool
-- drasil-lang
-- drasil-printers
-- drasil-system
-- drasil-theory
-- drasil-utils
 
 library:
+  dependencies:
+  - drasil-code
+  - drasil-data
+  - drasil-database
+  - drasil-file-handling
+  - drasil-lang
+  - drasil-printers
+  - drasil-srs
+  - drasil-theory
   source-dirs: lib
 
 executables:

--- a/code/drasil-example/hghc/package.yaml
+++ b/code/drasil-example/hghc/package.yaml
@@ -23,19 +23,15 @@ dependencies:
 - base >= 4.7 && < 5
 - lens
 - directory
-- drasil-code
-- drasil-data
-- drasil-database
-- drasil-srs
 - drasil-gen
-- drasil-gool
-- drasil-lang
-- drasil-printers
-- drasil-system
-- drasil-theory
-- drasil-utils
 
 library:
+  dependencies:
+  - drasil-data
+  - drasil-database
+  - drasil-lang
+  - drasil-srs
+  - drasil-theory
   source-dirs: lib
 
 executables:

--- a/code/drasil-example/pdcontroller/package.yaml
+++ b/code/drasil-example/pdcontroller/package.yaml
@@ -23,19 +23,17 @@ dependencies:
 - base >= 4.7 && < 5
 - lens
 - directory
-- drasil-code
-- drasil-data
-- drasil-database
-- drasil-srs
 - drasil-gen
-- drasil-gool
-- drasil-lang
-- drasil-printers
-- drasil-system
-- drasil-theory
-- drasil-utils
 
 library:
+  dependencies:
+  - drasil-code
+  - drasil-data
+  - drasil-database
+  - drasil-lang
+  - drasil-srs
+  - drasil-theory
+  - drasil-utils
   source-dirs: lib
 
 executables:

--- a/code/drasil-example/projectile-lesson/package.yaml
+++ b/code/drasil-example/projectile-lesson/package.yaml
@@ -23,21 +23,16 @@ dependencies:
 - base >= 4.7 && < 5
 - lens
 - directory
-- drasil-code
-- drasil-data
-- drasil-database
-- drasil-srs
 - drasil-gen
-- drasil-gool
 - drasil-lang
 - drasil-lesson-plan
-- drasil-printers
-- drasil-system
-- drasil-theory
-- drasil-utils
 - projectile
 
 library:
+  dependencies:
+  - drasil-data
+  - drasil-database
+  - drasil-system
   source-dirs: lib
 
 executables:

--- a/code/drasil-example/projectile/package.yaml
+++ b/code/drasil-example/projectile/package.yaml
@@ -23,20 +23,18 @@ dependencies:
 - base >= 4.7 && < 5
 - lens
 - directory
-- drasil-code
-- drasil-data
-- drasil-database
-- drasil-srs
 - drasil-gen
-- drasil-gool
-- drasil-lang
-- drasil-lesson-plan
-- drasil-printers
-- drasil-system
-- drasil-theory
-- drasil-utils
 
 library:
+  dependencies:
+  - drasil-code
+  - drasil-data
+  - drasil-database
+  - drasil-gool
+  - drasil-lang
+  - drasil-srs
+  - drasil-theory
+  - drasil-utils
   source-dirs: lib
 
 executables:

--- a/code/drasil-example/sglpend/package.yaml
+++ b/code/drasil-example/sglpend/package.yaml
@@ -23,20 +23,17 @@ dependencies:
 - base >= 4.7 && < 5
 - lens
 - directory
-- drasil-code
-- drasil-data
-- drasil-database
-- drasil-srs
 - drasil-gen
-- drasil-gool
-- drasil-lang
-- drasil-printers
-- drasil-system
-- drasil-theory
-- drasil-utils
 - dblpend
 
 library:
+  dependencies:
+  - drasil-data
+  - drasil-database
+  - drasil-lang
+  - drasil-srs
+  - drasil-theory
+  - drasil-utils
   source-dirs: lib
 
 executables:

--- a/code/drasil-example/ssp/package.yaml
+++ b/code/drasil-example/ssp/package.yaml
@@ -23,19 +23,16 @@ dependencies:
 - base >= 4.7 && < 5
 - lens
 - directory
-- drasil-code
-- drasil-data
-- drasil-database
-- drasil-srs
 - drasil-gen
-- drasil-gool
-- drasil-lang
-- drasil-printers
-- drasil-system
-- drasil-theory
-- drasil-utils
 
 library:
+  dependencies:
+  - drasil-data
+  - drasil-database
+  - drasil-lang
+  - drasil-srs
+  - drasil-theory
+  - drasil-utils
   source-dirs: lib
 
 executables:

--- a/code/drasil-example/swhs/package.yaml
+++ b/code/drasil-example/swhs/package.yaml
@@ -23,19 +23,16 @@ dependencies:
 - base >= 4.7 && < 5
 - lens
 - directory
-- drasil-code
-- drasil-data
-- drasil-database
-- drasil-srs
 - drasil-gen
-- drasil-gool
-- drasil-lang
-- drasil-printers
-- drasil-system
-- drasil-theory
-- drasil-utils
 
 library:
+  dependencies:
+  - drasil-data
+  - drasil-database
+  - drasil-lang
+  - drasil-srs
+  - drasil-theory
+  - drasil-utils
   source-dirs: lib
 
 executables:

--- a/code/drasil-example/swhsnopcm/package.yaml
+++ b/code/drasil-example/swhsnopcm/package.yaml
@@ -23,20 +23,18 @@ dependencies:
 - base >= 4.7 && < 5
 - lens
 - directory
-- drasil-code
-- drasil-data
-- drasil-database
-- drasil-srs
 - drasil-gen
-- drasil-gool
-- drasil-lang
-- drasil-printers
-- drasil-system
-- drasil-theory
-- drasil-utils
 - swhs
 
 library:
+  dependencies:
+  - drasil-code
+  - drasil-data
+  - drasil-database
+  - drasil-lang
+  - drasil-srs
+  - drasil-theory
+  - drasil-utils
   source-dirs: lib
   when:
   - condition: false

--- a/code/drasil-example/template/package.yaml
+++ b/code/drasil-example/template/package.yaml
@@ -22,19 +22,15 @@ dependencies:
 - base >= 4.7 && < 5
 - lens
 - directory
-- drasil-code
-- drasil-data
-- drasil-database
-- drasil-srs
 - drasil-gen
-- drasil-gool
-- drasil-lang
-- drasil-printers
-- drasil-system
-- drasil-theory
-- drasil-utils
 
 library:
+  dependencies:
+  - drasil-data
+  - drasil-database
+  - drasil-lang
+  - drasil-srs
+  - drasil-theory
   source-dirs: lib
 
 executables:

--- a/code/drasil-printers/package.yaml
+++ b/code/drasil-printers/package.yaml
@@ -28,7 +28,6 @@ dependencies:
 - drasil-file-handling
 - drasil-lang
 - drasil-theory
-- drasil-utils
 - prettyprinter
 - split
 - text

--- a/code/drasil-website/package.yaml
+++ b/code/drasil-website/package.yaml
@@ -25,18 +25,8 @@ dependencies:
 - split
 - directory
 - pretty
-- drasil-data
-- drasil-database
-- drasil-file-handling
-- drasil-srs
-- drasil-code
-- drasil-gool
 - drasil-gen
 - drasil-lang
-- drasil-printers
-- drasil-system
-- drasil-theory
-- drasil-utils
 - sglpend
 - dblpend
 - gamephysics
@@ -51,6 +41,15 @@ dependencies:
 - template
 
 library:
+  dependencies:
+  - drasil-code
+  - drasil-data
+  - drasil-database
+  - drasil-file-handling
+  - drasil-gool
+  - drasil-printers
+  - drasil-srs
+  - drasil-system
   source-dirs: lib
 
 executables:


### PR DESCRIPTION
This does two things:

1. Reviews our package dependencies, removing the unnecessary ones.
2. Minimizes the visibility of external package dependencies to only the libraries/tests/executables they are used by.

After this, our dep. graph changes a little bit:

**PRE:**

<img width="1042" height="543" alt="Screenshot 2026-07-10 at 12 06 33 PM" src="https://github.com/user-attachments/assets/32dbc3f9-dbe1-46a9-99bc-c9a176b3ed22" />

**POST:**

<img width="1468" height="827" alt="drasil-all-pkgs-deps" src="https://github.com/user-attachments/assets/33c6cd6e-bae9-4c16-8399-6171cbd275b8" />


