### PR TITLE
Specialized use of  `OORenderSym` and `ProcRenderSym`

### DIFF
--- a/code/drasil-gool/lib/Drasil/GOOL/InterfaceGOOL.hs
+++ b/code/drasil-gool/lib/Drasil/GOOL/InterfaceGOOL.hs
@@ -39,7 +39,7 @@ class (SharedProg r vis smt, OOStatement r smt, ProgramSym r vis smt,
 
 class (SharedStatement r smt, GetSet r, InternalValueExp r, OOFuncAppStatement r smt,
   OOVariableValue r, OODeclStatement r smt, OOFuncAppStatement r smt,
-  OOValueExpression r
+  OOFunctionSym r, OOValueExpression r
   ) => OOStatement r smt
 
 type GSProgram a = GS (a (Program a))

--- a/code/drasil-gool/lib/Drasil/GOOL/LanguageRenderer/CSharpRenderer.hs
+++ b/code/drasil-gool/lib/Drasil/GOOL/LanguageRenderer/CSharpRenderer.hs
@@ -887,7 +887,7 @@ csAssert condition errorMessage = vcat [
 csDiscardInput :: SValue CSharpCode -> MS (CSharpCode (Doc, Terminator))
 csDiscardInput = valStmt
 
-csFileInput :: (OORenderSym r vis smt) => SValue r -> SValue r
+csFileInput :: (InternalValueExp r) => SValue r -> SValue r
 csFileInput f = objMethodCallNoParams string f csReadLine
 
 csInput :: VS (CSharpCode TypeData) -> SValue CSharpCode -> SValue CSharpCode
@@ -904,10 +904,10 @@ csInput tp inFn = do
         csInputImport t = if t `elem` [Integer, Float, Double, Boolean, Char]
           then addSystemImport else id
 
-csOpenFileR :: (OORenderSym r vis smt) => SValue r -> VS (r TypeData) -> SValue r
+csOpenFileR :: (OOValueExpression r) => SValue r -> VS (r TypeData) -> SValue r
 csOpenFileR n r = newObj r [n]
 
-csOpenFileWorA :: (OORenderSym r vis smt) => SValue r ->
+csOpenFileWorA :: (OOValueExpression r) => SValue r ->
   VS (r TypeData) -> SValue r -> SValue r
 csOpenFileWorA n w a = newObj w [n, a]
 

--- a/code/drasil-gool/lib/Drasil/GOOL/LanguageRenderer/CommonGOOL.hs
+++ b/code/drasil-gool/lib/Drasil/GOOL/LanguageRenderer/CommonGOOL.hs
@@ -8,10 +8,10 @@ module Drasil.GOOL.LanguageRenderer.CommonGOOL (
 import Drasil.Shared.InterfaceCommon (UnRepr(..), TypeElim(..), SVariable,
   SValue, NamedArgs, VariableElim(..), TypeSym(void), IndexTranslator(..),
   getCodeType, StatementSym (valStmt), StatementSym(..))
-import Drasil.GOOL.InterfaceGOOL (objMethodCall, convTypeOO)
+import Drasil.GOOL.InterfaceGOOL (objMethodCall, convTypeOO, InternalValueExp,
+  OOTypeSym)
 import Drasil.Shared.RendererClassesCommon (ScopeElim(..), RenderValue(..),
   InternalVarElim, RenderStatement, ValueElim)
-import Drasil.GOOL.RendererClassesOO (OORenderSym)
 import Drasil.Shared.LanguageRenderer.Constructors (mkStmt)
 import Drasil.Shared.LanguageRenderer (dot)
 import Drasil.GOOL.Renderers (renderType, renderConstDecDef)
@@ -50,12 +50,17 @@ classMethodCall f t cls vs ns = do
   c <- cls
   call Nothing (Just $ renderType c <> dot) f t vs ns
 
-listAppend :: (OORenderSym r vis smt) => String -> SValue r -> SValue r -> MS (r smt)
+listAppend
+  :: (InternalValueExp r, StatementSym r smt)
+  => String -> SValue r -> SValue r -> MS (r smt)
 listAppend fnName list val = valStmt $ objMethodCall void list fnName [val]
 
-listAdd :: (OORenderSym r vis smt) => String -> SValue r -> SValue r -> SValue r -> MS (r smt)
+listAdd
+  :: (IndexTranslator r, InternalValueExp r, StatementSym r smt)
+  => String -> SValue r -> SValue r -> SValue r -> MS (r smt)
 listAdd fnName list idx val = valStmt $ objMethodCall void list fnName [intToIndex idx, val]
 
-innerType :: (OORenderSym r vis smt, TypeElim r) =>
-  VS (r TypeData) -> VS (r TypeData)
+innerType
+  :: (TypeElim r, OOTypeSym r)
+  => VS (r TypeData) -> VS (r TypeData)
 innerType t = t >>= (convTypeOO . getInnerType . getCodeType)

--- a/code/drasil-gool/lib/Drasil/GOOL/LanguageRenderer/CppRenderer.hs
+++ b/code/drasil-gool/lib/Drasil/GOOL/LanguageRenderer/CppRenderer.hs
@@ -1047,6 +1047,7 @@ instance ProgramSym CppSrcCode (Doc, VisibilityTag) (Doc, Terminator) where
   type Program CppSrcCode = ProgData
   prog n st = onStateList (onCodeList (progD n st)) . map (zoom lensGStoFS)
 instance SharedStatement CppSrcCode (Doc, Terminator) where
+instance OOStatement CppSrcCode (Doc, Terminator) where
 
 instance CommonRenderSym CppSrcCode (Doc, VisibilityTag) (Doc, Terminator)
 instance OORenderSym CppSrcCode (Doc, VisibilityTag) (Doc, Terminator)
@@ -1786,6 +1787,8 @@ instance Monad CppHdrCode where
 
 instance CommonRenderSym CppHdrCode (Doc, VisibilityTag) (Doc, Terminator)
 instance OORenderSym CppHdrCode (Doc, VisibilityTag) (Doc, Terminator)
+instance SharedStatement CppHdrCode (Doc, Terminator) where
+instance OOStatement CppHdrCode (Doc, Terminator) where
 
 instance UnRepr CppHdrCode contents where
   unRepr = unCPPHC
@@ -2788,7 +2791,11 @@ cppInput vr i = addAlgorithmImport $ addLimitsImport $ do
   multi [mkStmt (RC.value inFn <+> streamR <+> RC.variable v),
     valStmt $ ignoreFunc '\n' i]
 
-cppOpenFile :: (OORenderSym r vis smt) => Label -> SVariable r -> SValue r -> MS (r smt)
+cppOpenFile
+  ::  Label
+  -> SVariable CppSrcCode
+  -> SValue CppSrcCode
+  -> MS (CppSrcCode (Doc, Terminator))
 cppOpenFile mode f n = valStmt $ objMethodCall void (valueOf f) cppOpen [n,
   mkStateVal void $ text mode]
 
@@ -2895,15 +2902,19 @@ cppForEach bStart bEnd forEachLabel inLbl e' v' b' = do
     indent $ RC.body b,
     bEnd]
 
-cppLitSet :: (OORenderSym r vis smt) => (VS (r TypeData) -> VS (r TypeData)) ->
-  VS (r TypeData) -> [SValue r] -> SValue r
+cppLitSet
+  :: (RenderValue r, ValueElim r)
+  => (VS (r TypeData) -> VS (r TypeData)) -> VS (r TypeData) -> [SValue r] -> SValue r
 cppLitSet f t' es' = do
   es <- sequence es'
   lt <- f t'
   mkVal lt ( braces (valueList es))
 
-cpphStateVarDef :: (OORenderSym r vis smt) => Doc -> r (Attachment r) ->
-  SVariable r -> SValue r -> CS Doc
+cpphStateVarDef
+  :: Doc
+  -> CppHdrCode (Attachment CppHdrCode)
+  -> SVariable CppHdrCode
+  -> SValue CppHdrCode -> CS Doc
 cpphStateVarDef s p vr vl = onStateValue (R.stateVar s (RC.perm p) .
   RC.statement) (zoom lensCStoMS $ stmt $ onAttachment (binding p)
   (varDec vr local) (varDecDef vr local vl))

--- a/code/drasil-gool/lib/Drasil/GOOL/LanguageRenderer/JavaRenderer.hs
+++ b/code/drasil-gool/lib/Drasil/GOOL/LanguageRenderer/JavaRenderer.hs
@@ -885,12 +885,12 @@ jLitArray t' es' = do
   mkVal lt (new' <+> renderType lt
     <+> braces (valueList es))
 
-jFileType :: (OORenderSym r vis smt) => VS (r TypeData)
+jFileType :: (OOTypeSym r) => VS (r TypeData)
 jFileType = do
   tpf <- obj jFile
   modifyReturn (addLangImportVS $ ioImport jFile) tpf
 
-jFileWriterType :: (OORenderSym r vis smt) => VS (r TypeData)
+jFileWriterType :: (OOTypeSym r) => VS (r TypeData)
 jFileWriterType = do
   tpf <- obj jFileWriter
   modifyReturn (addLangImportVS $ ioImport jFileWriter) tpf
@@ -925,7 +925,7 @@ jHasNextLineFunc = func jHasNextLine bool []
 jCharAtFunc :: VS (JavaCode FuncData)
 jCharAtFunc = func jCharAt char [litInt 0]
 
-jSplitFunc :: (OORenderSym r vis smt) => Char -> VS (r FuncData)
+jSplitFunc :: (Literal r, OOFunctionSym r) => Char -> VS (r FuncData)
 jSplitFunc d = func jSplit (listType string) [litString [d]]
 
 jEquality :: SValue JavaCode -> SValue JavaCode -> SValue JavaCode
@@ -1010,10 +1010,10 @@ jInput vr inFn = do
       jInput' _ = error "Attempt to read value of unreadable type"
   jInput' (getCodeType $ variableType v)
 
-jOpenFileR :: (OORenderSym r vis smt) => SValue r -> VS (r TypeData) -> SValue r
+jOpenFileR :: (OOValueExpression r) => SValue r -> VS (r TypeData) -> SValue r
 jOpenFileR n t = newObj t [newObj jFileType [n]]
 
-jOpenFileWorA :: (OORenderSym r vis smt) => SValue r -> VS (r TypeData) ->
+jOpenFileWorA :: (OOValueExpression r) => SValue r -> VS (r TypeData) ->
   SValue r -> SValue r
 jOpenFileWorA n t wa = newObj t
   [newObj jFileWriterType [newObj jFileType [n], wa]]
@@ -1099,8 +1099,9 @@ jDocInOut f desc is os bs b = docFuncRepr  functionDox desc (map fst $ bs ++ is)
   where rets = "array containing the following values:" : map fst bs ++
           map fst os
 
-jExtraClass :: (OORenderSym r vis smt) => Label -> Maybe Label ->
-  [CSStateVar r] -> [SMethod r] -> [SMethod r] -> SClass r
+jExtraClass
+  :: (RenderClass r vis, RenderVisibility r vis)
+  => Label -> Maybe Label -> [CSStateVar r] -> [SMethod r] -> [SMethod r] -> SClass r
 jExtraClass n = intClass n (visibilityFromData Priv empty) . inherit
 
 addCallExcsCurrMod :: String -> VS ()

--- a/code/drasil-gool/lib/Drasil/GOOL/LanguageRenderer/PythonRenderer.hs
+++ b/code/drasil-gool/lib/Drasil/GOOL/LanguageRenderer/PythonRenderer.hs
@@ -890,16 +890,18 @@ addmathImport = (>>) $ modify (addLangImportVS pyMath)
 mathFunc :: (Monad r) => String -> VSOp r
 mathFunc = addmathImport . unOpPrec . access pyMath
 
-splitFunc :: (OORenderSym r vis smt) => Char -> VS (r FuncData)
+splitFunc :: (Literal r, OOFunctionSym r) => Char -> VS (r FuncData)
 splitFunc d = func pySplit (listType string) [litString [d]]
 
-readline, readlines :: (OORenderSym r vis smt) => SValue r -> SValue r
+readline, readlines :: (InternalValueExp r) => SValue r -> SValue r
 readline f = objMethodCall string f pyReadline []
 readlines f = objMethodCall (listType string) f pyReadlines []
 
-readInt, readDouble, readString :: (OORenderSym r vis smt) => SValue r -> SValue r
+readInt, readDouble :: (ValueExpression r) => SValue r -> SValue r
 readInt inSrc = funcApp pyInt int [inSrc]
 readDouble inSrc = funcApp pyDouble double [inSrc]
+
+readString :: (InternalValueExp r) => SValue r -> SValue r
 readString inSrc = objMethodCall string inSrc pyRstrip []
 
 range :: (ValueExpression r) => SValue r -> SValue r -> SValue r -> SValue r

--- a/code/drasil-gool/lib/Drasil/GOOL/LanguageRenderer/SwiftRenderer.hs
+++ b/code/drasil-gool/lib/Drasil/GOOL/LanguageRenderer/SwiftRenderer.hs
@@ -73,11 +73,11 @@ import qualified Drasil.Shared.LanguageRenderer.LanguagePolymorphic as G (
   listAccess, getFunc, setFunc, stmt, loopStmt, emptyStmt, assign, subAssign,
   objDecNew, print, returnStmt, valStmt, comment, throw, ifCond, tryCatch,
   construct, param, method, getMethod, setMethod, initStmts, function, docFunc,
-  buildClass, implementingClass, docClass, commentedClass, modFromData, fileDoc,
-  fileFromData, defaultOptSpace, local)
+  buildClass, implementingClass, docClass, commentedClass, modFromData, docMod,
+  fileDoc, fileFromData, defaultOptSpace, local)
 import qualified Drasil.Shared.LanguageRenderer.Common as CS
 import qualified Drasil.Shared.LanguageRenderer.CommonPseudoOO as CP (
-  classVarAccess, intClass, buildModule, docMod', contains, bindingError,
+  classVarAccess, intClass, buildModule, modDoc', contains, bindingError,
   notNull, listDecDef, destructorError, stateVarDef, constVar, litArray,
   extraClass, doubleRender, double, openFileR, openFileW, self, multiAssign,
   multiReturn, listDec, listSet, funcDecDef, inOutCall, forLoopError, mainBody,
@@ -156,7 +156,7 @@ instance FileSym SwiftCode Doc (Doc, Terminator) where
     modify (setFileType Combined)
     G.fileDoc swiftExt top bottom m
 
-  docMod = CP.docMod' swiftExt
+  docMod = G.docMod CP.modDoc' swiftExt
 
 instance RenderFile SwiftCode where
   top _ = toCode empty
@@ -978,7 +978,8 @@ swiftCast t' v' = do
         getCodeType (valueType v) == String then swiftUnwrapVal else id
   unwrap $ mkStateVal (pure t) (R.castObj (renderType t) (RC.value v))
 
-swiftIndexFunc :: (OORenderSym r vis smt) => SValue r -> SValue r -> SValue r
+swiftIndexFunc
+  :: (InternalValueExp r, VariableSym r) => SValue r -> SValue r -> SValue r
 swiftIndexFunc l v' = do
   v <- v'
   let t = pure $ valueType v
@@ -998,7 +999,7 @@ swiftStrideFunc beg end step = let t = listType int
 swiftMapFunc :: (InternalValueExp r) => SValue r -> SValue r -> SValue r
 swiftMapFunc lst f = objMethodCall (onStateValue valueType lst) lst swiftMap [f]
 
-swiftWriteFunc :: (OORenderSym r vis smt) => SValue r -> SValue r -> SValue r
+swiftWriteFunc :: SValue SwiftCode -> SValue SwiftCode -> SValue SwiftCode
 swiftWriteFunc v f = let contentsArg = var swiftContentsOf (obj swiftData)
   in swiftTryVal $ objMethodCallNamedArgs void f swiftWrite
     [(contentsArg, newObj (obj swiftData) [v $. funcFromData (R.func swiftUTF8)
@@ -1017,15 +1018,19 @@ swiftReadFileFunc v = swiftTryVal $
     contentsArg = (var swiftContentsOf infile, v)
     encodingArg = (var "encoding" string, encVal)
 
-swiftSplitFunc :: (OORenderSym r vis smt) => Char -> SValue r -> SValue r
+swiftSplitFunc
+  :: (InternalValueExp r, Literal r, VariableSym r)
+  => Char -> SValue r -> SValue r
 swiftSplitFunc d s = let sepArg = var swiftSepBy char
   in objMethodCallNamedArgs (listType string) s swiftSplit [(sepArg, litChar d)]
 
-swiftJoinedFunc :: (OORenderSym r vis smt) => Char -> SValue r -> SValue r
+swiftJoinedFunc
+  :: (InternalValueExp r, Literal r, VariableSym r)
+  => Char -> SValue r -> SValue r
 swiftJoinedFunc d s = let sepArg = var swiftSep char
   in objMethodCallNamedArgs string s swiftJoined [(sepArg, litChar d)]
 
-swiftIndexOf :: (OORenderSym r vis smt) => SValue r -> SValue r -> SValue r
+swiftIndexOf :: SValue SwiftCode -> SValue SwiftCode -> SValue SwiftCode
 swiftIndexOf = swiftUnwrapVal .: swiftIndexFunc
 
 -- | Swift's syntactic sugar for list slicing.
@@ -1094,8 +1099,7 @@ swiftInput vr vl = do
         | otherwise = error "Attempt to read value of unreadable type"
   swiftInput' (getCodeType $ variableType vr')
 
-swiftOpenFile :: (OORenderSym r vis smt) => SValue r ->
-  VS (r TypeData) -> SValue r
+swiftOpenFile :: SValue SwiftCode -> VS (SwiftCode TypeData) -> SValue SwiftCode
 swiftOpenFile n t = let forArg = var swiftFor (obj swiftSearchDir)
                         dirVal = mkStateVal (obj swiftSearchDir) swiftDocDir
                         inArg = var swiftIn (obj swiftPathMask)
@@ -1104,14 +1108,13 @@ swiftOpenFile n t = let forArg = var swiftFor (obj swiftSearchDir)
     funcAppNamedArgs swiftUrls (listType t) [(forArg, dirVal), (inArg, maskVal)]
     $. funcFromData (R.func swiftFirst) t) swiftAppendPath [n]
 
-swiftOpenFileHdl :: (OORenderSym r vis smt, Monad r) => SValue r ->
-  VS (r TypeData) -> SValue r
+swiftOpenFileHdl :: SValue SwiftCode -> VS (SwiftCode TypeData) -> SValue SwiftCode
 swiftOpenFileHdl n t = let forWritingArg = var swiftWriteTo swiftFileType
   in swiftTryVal $ funcAppNamedArgs swiftFileHdl outfile
     [(forWritingArg, swiftOpenFile n t)]
 
-swiftOpenFileWA :: (OORenderSym r vis smt, Monad r) => Bool ->
-  SVariable r -> SValue r -> MS (r smt)
+swiftOpenFileWA
+  :: Bool -> SVariable SwiftCode -> SValue SwiftCode -> MS (SwiftCode (Doc, Terminator))
 swiftOpenFileWA app f' n' = tryCatch
     (bodyStatements [CP.openFileW (\f n _ -> swiftOpenFileHdl f n) f' n',
       if app
@@ -1134,8 +1137,8 @@ swiftCloseFile f' = do
       swClose _ = error "closeFile called on non-file-typed value"
   swClose (getCodeType $ valueType f)
 
-swiftReadFile :: (OORenderSym r vis (Doc, Terminator)) => SVariable r ->
-  SValue r -> MS (r (Doc, Terminator))
+swiftReadFile
+  :: SVariable SwiftCode -> SValue SwiftCode -> MS (SwiftCode (Doc, Terminator))
 swiftReadFile v f =
   let l_binder = binder "l" string
       l_var = var "l" string
@@ -1216,8 +1219,11 @@ swiftMethod n s p t ps b = do
     indent $ RC.body bod,
     bodyEnd])
 
-swiftConstructor :: (OORenderSym r vis smt) => [MS (r ParamData)] ->
-  Initializers r -> MSBody r -> SMethod r
+swiftConstructor
+  :: [MS (SwiftCode ParamData)]
+  -> Initializers SwiftCode
+  -> MSBody SwiftCode
+  -> SMethod SwiftCode
 swiftConstructor ps is b = do
   pms <- sequence ps
   bod <- multiBody [G.initStmts is, b]
@@ -1248,7 +1254,7 @@ swiftStringError = do
 swiftClassDoc :: ClassDocRenderer
 swiftClassDoc desc = [desc | not (null desc)]
 
-typeDfltVal :: (OORenderSym r vis smt) => CodeType -> SValue r
+typeDfltVal :: (Literal r, OOTypeSym r) => CodeType -> SValue r
 typeDfltVal Boolean = litFalse
 typeDfltVal Integer = litInt 0
 typeDfltVal Float = litFloat 0.0

--- a/code/drasil-gool/lib/Drasil/GOOL/Renderers.hs
+++ b/code/drasil-gool/lib/Drasil/GOOL/Renderers.hs
@@ -11,9 +11,9 @@ import Drasil.Shared.InterfaceCommon (UnRepr(..), VariableSym(..),
   VariableElim(..), ValueSym(..), BodySym(..))
 import Drasil.GOOL.InterfaceGOOL (AttachmentSym(..))
 import Drasil.Shared.RendererClassesCommon (InternalVarElim(..),
-  VisibilityElim(..), ValueElim(..))
+  VisibilityElim(..), ValueElim(..), ParamElim)
 import qualified Drasil.Shared.RendererClassesCommon as RC (BodyElim(..))
-import Drasil.GOOL.RendererClassesOO (OORenderSym, PermElim(..))
+import Drasil.GOOL.RendererClassesOO (PermElim(..))
 import Drasil.Shared.LanguageRenderer (parameterList, new', constDec')
 import Drasil.Shared.AST (TypeData(..), ParamData)
 
@@ -24,13 +24,25 @@ import Text.PrettyPrint.HughesPJ (Doc, (<+>), (<>), vcat, text, lbrace, rbrace,
 renderType :: (UnRepr r TypeData) => r TypeData -> Doc
 renderType = typeDoc . unRepr
 
-renderParam :: (OORenderSym r vis smt, UnRepr r TypeData) =>
-  r (Variable r) -> Doc
+renderParam
+  :: (InternalVarElim r, UnRepr r TypeData, VariableElim r)
+  => r (Variable r) -> Doc
 renderParam v = renderType (variableType v) <+> variable v
 
-renderMethod :: (OORenderSym r vis smt, UnRepr r TypeData) => String ->
-  r vis -> r (Attachment r) -> r TypeData -> [r ParamData] ->
-  r (Body r) -> Doc
+renderMethod
+  :: ( RC.BodyElim r
+     , ParamElim r
+     , PermElim r
+     , UnRepr r TypeData
+     , VisibilityElim r vis
+     )
+  => String
+  -> r vis
+  -> r (Attachment r)
+  -> r TypeData
+  -> [r ParamData]
+  -> r (Body r)
+  -> Doc
 renderMethod n s p t ps b = vcat [
   visibility s <+> perm p <+> renderType t <+> text n <>
     (parens (parameterList ps) <+> lbrace),

--- a/code/drasil-gool/lib/Drasil/GProc/LanguageRenderer/AbstractProc.hs
+++ b/code/drasil-gool/lib/Drasil/GProc/LanguageRenderer/AbstractProc.hs
@@ -12,12 +12,8 @@ import Drasil.Shared.InterfaceCommon (Label, SMethod, MSBody, SValue, SVariable,
 import qualified Drasil.Shared.InterfaceCommon as IC
 import Drasil.GProc.InterfaceProc (SFile, FSModule, FileSym (File),
   ModuleSym(Module))
-import qualified Drasil.Shared.RendererClassesCommon as RCC (MethodElim(..),
-  BlockCommentSym(..), ValueElim(value), MethodTypeSym(mType),
-  ScopeElim(scopeData))
-import Drasil.GProc.RendererClassesProc (ProcRenderSym)
-import qualified Drasil.GProc.RendererClassesProc as RCP (RenderFile(..),
-  ModuleElim(..), RenderMod(..), ProcRenderMethod(intFunc))
+import qualified Drasil.Shared.RendererClassesCommon as RC
+import qualified Drasil.GProc.RendererClassesProc as RP
 import Drasil.Shared.AST (isSource, ScopeData, TypeData, ParamData)
 import Drasil.Shared.Helpers (vibcat, toState, emptyIfEmpty, getInnerType,
   onStateValue)
@@ -37,19 +33,20 @@ import Text.PrettyPrint.HughesPJ (Doc, isEmpty, brackets, (<>), render)
 
 -- Files --
 
-fileDoc :: (ProcRenderSym r vis smt) => String -> FSModule r -> SFile r
+fileDoc :: (RP.RenderFile r) => String -> FSModule r -> SFile r
 fileDoc ext md = do
   m <- md
   nm <- getModuleName
   let fp = addExt ext nm
-  RCP.fileFromData fp (toState m)
+  RP.fileFromData fp (toState m)
 
-fileFromData :: (ProcRenderSym r vis smt) => (FilePath -> r (Module r) ->
-  r (File r)) -> FilePath -> FSModule r -> SFile r
+fileFromData
+  :: (RP.ModuleElim r)
+  => (FilePath -> r (Module r) -> r (File r)) -> FilePath -> FSModule r -> SFile r
 fileFromData f fpath mdl' = do
   -- Add this file to list of files as long as it is not empty
   mdl <- mdl'
-  modify (\s -> if isEmpty (RCP.module' mdl)
+  modify (\s -> if isEmpty (RP.module' mdl)
     then s
     else over lensFStoGS (addFile (s ^. currFileType) fpath) $
       -- If this is the main source file, set it as the main module in the state
@@ -60,19 +57,21 @@ fileFromData f fpath mdl' = do
 
 -- Parameters: Module name, Doc for imports, Doc to put at bottom of module,
 -- methods
-buildModule :: (ProcRenderSym r vis smt) => Label -> FS Doc -> FS Doc ->
-  [SMethod r] -> FSModule r
-buildModule n imps bot fs = RCP.modFromData n (do
+buildModule
+  :: (RC.MethodElim r, RP.RenderMod r)
+  => Label -> FS Doc -> FS Doc -> [SMethod r] -> FSModule r
+buildModule n imps bot fs = RP.modFromData n (do
   fns <- mapM (zoom lensFStoMS) fs
   is <- imps
   bt <- bot
-  let fnDocs = vibcat (map RCC.method fns ++ [bt])
+  let fnDocs = vibcat (map RC.method fns ++ [bt])
   return $ emptyIfEmpty fnDocs (vibcat (filter (not . isEmpty) [is, fnDocs])))
 
-docMod :: (ProcRenderSym r vis smt) => String -> String -> String -> [String] ->
-  String -> SFile r -> SFile r
-docMod e d wm a dt fl = RCP.commentedMod fl
-  (RCC.docComment $ CP.modDoc' d wm a dt . addExt e <$> getModuleName)
+docMod
+  :: (RP.RenderFile r)
+  => String -> String -> String -> [String] -> String -> SFile r -> SFile r
+docMod e d wm a dt fl = RP.commentedMod fl
+  (RC.docComment $ CP.modDoc' d wm a dt . addExt e <$> getModuleName)
 
 modFromData :: Label -> (Doc -> r (Module r)) -> FS Doc -> FSModule r
 modFromData n f d = modify (setModuleName n) >> onStateValue f d
@@ -96,28 +95,29 @@ listAdd
 listAdd fnName list idx val = IC.valStmt $
   funcApp fnName IC.void [list, IC.intToIndex idx, val]
 
-arrayElem :: (ProcRenderSym r vis smt, IC.TypeElim r) =>
-  SValue r -> SValue r -> SVariable r
+arrayElem
+  :: (IndexTranslator r, RC.RenderVariable r, IC.TypeElim r, RC.ValueElim r)
+  => SValue r -> SValue r -> SVariable r
 arrayElem arr' i' = do
   i <- IC.intToIndex i'
   arr <- arr'
-  let vName = render $ RCC.value arr
+  let vName = render $ RC.value arr
       vType = innerType $ return $ IC.valueType arr
-      vRender = RCC.value arr <> brackets (RCC.value i)
+      vRender = RC.value arr <> brackets (RC.value i)
   mkStateVar vName vType vRender
 
-funcDecDef :: (ProcRenderSym r vis smt) => SVariable r -> r ScopeData ->
+funcDecDef :: (RP.ProcRenderSym r vis smt) => SVariable r -> r ScopeData ->
   [SVariable r] -> MSBody r -> MS (r smt)
 funcDecDef v scp ps b = do
   vr <- zoom lensMStoVS v
   modify $ useVarName $ variableName vr
-  modify $ setVarScope (variableName vr) (RCC.scopeData scp)
+  modify $ setVarScope (variableName vr) (RC.scopeData scp)
   s <- get
   f <- IC.function (variableName vr) private (return $ variableType vr)
     (map IC.param ps) b
   modify (L.set currParameters (s ^. currParameters))
-  mkStmtNoEnd $ RCC.method f
+  mkStmtNoEnd $ RC.method f
 
-function :: (ProcRenderSym r vis smt) => Label -> r vis -> VS (r TypeData) ->
+function :: (RP.ProcRenderMethod r vis) => Label -> r vis -> VS (r TypeData) ->
   [MS (r ParamData)] -> MSBody r -> SMethod r
-function n s t = RCP.intFunc False n s (RCC.mType t)
+function n s t = RP.intFunc False n s (RC.mType t)

--- a/code/drasil-gool/lib/Drasil/GProc/Renderers.hs
+++ b/code/drasil-gool/lib/Drasil/GProc/Renderers.hs
@@ -8,7 +8,6 @@ module Drasil.GProc.Renderers (
 import Drasil.Shared.InterfaceCommon (UnRepr(..), VariableSym(..),
   VariableElim(..), ValueSym(..))
 import Drasil.Shared.RendererClassesCommon (InternalVarElim(..), ValueElim(..))
-import Drasil.GProc.RendererClassesProc (ProcRenderSym)
 import Drasil.Shared.LanguageRenderer (new', constDec')
 import Drasil.Shared.CodeType (CodeType(..))
 import Drasil.Shared.AST (TypeData(..))
@@ -21,8 +20,9 @@ renderType tp = case cType $ unRepr tp of
     (Object _) -> error "Classes are not supported in procedural languages"
     _ -> typeDoc $ unRepr tp
 
-renderParam :: (ProcRenderSym r vis smt, UnRepr r TypeData) =>
-  r (Variable r) -> Doc
+renderParam
+  :: (InternalVarElim r, UnRepr r TypeData, VariableElim r)
+  => r (Variable r) -> Doc
 renderParam v = renderType (variableType v) <+> variable v
 
 renderListDec

--- a/code/drasil-gool/lib/Drasil/Shared/LanguageRenderer/CLike.hs
+++ b/code/drasil-gool/lib/Drasil/Shared/LanguageRenderer/CLike.hs
@@ -17,29 +17,22 @@ import Drasil.Shared.InterfaceCommon (UnRepr(..), Label, Library, MSBody,
   TypeElim(..), SVariable, SValue, SMethod, MixedCall, MixedCtorCall,
   VariableSym(..), VariableValue(..), VariableElim(..),
   ValueSym(Value, valueType), getCodeType, getTypeString)
-import qualified Drasil.Shared.InterfaceCommon as IC (TypeSym(bool, float, int),
-  ValueExpression(funcAppMixedArgs), DeclStatement(varDec, setDec, varDecDef))
+import qualified Drasil.Shared.InterfaceCommon as IC
 import Drasil.GOOL.InterfaceGOOL (AttachmentSym(..), extNewObj,
   objMethodCallNoParams, ($->))
-import qualified Drasil.GOOL.InterfaceGOOL as IG (OOTypeSym(obj),
-  OOValueExpression(newObjMixedArgs))
+import qualified Drasil.GOOL.InterfaceGOOL as IG
 import Drasil.Shared.RendererClassesCommon (MSMthdType,
   InternalVarElim(variableBind), RenderValue(valFromData), ValueElim(valuePrec),
   ScopeElim(scopeData))
-import qualified Drasil.Shared.RendererClassesCommon as S (
-  RenderStatement(stmt, loopStmt))
-import qualified Drasil.Shared.RendererClassesCommon as RC (BodyElim(..),
-  InternalVarElim(variable), ValueElim(value), StatementElim(statement))
-import Drasil.GOOL.RendererClassesOO (OORenderSym,
-  OORenderMethod(intMethod))
-import qualified Drasil.GOOL.RendererClassesOO as RC (PermElim(..))
+import qualified Drasil.Shared.RendererClassesCommon as RC
+import Drasil.GOOL.RendererClassesOO (OORenderMethod(intMethod))
 import Drasil.GOOL.Renderers (renderType)
+import qualified Drasil.GOOL.RendererClassesOO as RO
 import Drasil.Shared.AST (AttachmentTag(..), Terminator(..), ScopeData,
   TypeData, ParamData)
 import Drasil.Shared.Helpers (angles, toState, onStateValue)
 import Drasil.Shared.LanguageRenderer (forLabel, whileLabel, containing)
-import qualified Drasil.Shared.LanguageRenderer as R (switch, addAssign,
-  increment, decrement, this', this)
+import qualified Drasil.Shared.LanguageRenderer as R
 import Drasil.Shared.LanguageRenderer.Constructors (typeFromData, mkStmt,
   mkStmtNoEnd, mkStateVal, mkStateVar, VSOp, unOpPrec, andPrec, orPrec)
 import Drasil.Shared.State (MS, VS, lensMStoVS, lensVStoMS, addLibImportVS,
@@ -51,7 +44,7 @@ import Control.Monad.State (modify)
 import Control.Lens.Zoom (zoom)
 import Text.PrettyPrint.HughesPJ (Doc, text, (<>), (<+>), parens, vcat, semi,
   equals, empty)
-import qualified Text.PrettyPrint.HughesPJ as D (float)
+import qualified Text.PrettyPrint.HughesPJ as D
 
 -- Types --
 
@@ -101,7 +94,7 @@ orOp :: (Monad r) => VSOp r
 orOp = orPrec "||"
 -- Variables --
 
-self :: (OORenderSym r vis smt) => SVariable r
+self :: (IG.OOTypeSym r, RC.RenderVariable r) => SVariable r
 self = do
   l <- zoom lensVStoMS getClassName
   mkStateVar R.this (IG.obj l) R.this'
@@ -132,45 +125,53 @@ libFuncAppMixedArgs :: (IC.ValueExpression r) => Library -> MixedCall r
 libFuncAppMixedArgs l n t vs ns = modify (addLibImportVS l) >>
   IC.funcAppMixedArgs n t vs ns
 
-libNewObjMixedArgs :: (OORenderSym r vis smt) => Library -> MixedCtorCall r
+libNewObjMixedArgs :: (IG.OOValueExpression r) => Library -> MixedCtorCall r
 libNewObjMixedArgs l tp vs ns = modify (addLibImportVS l) >>
   IG.newObjMixedArgs tp vs ns
 
 -- Functions --
 
-listSize :: (OORenderSym r vis smt) => String -> SValue r -> SValue r
+listSize :: (IG.InternalValueExp r) => String -> SValue r -> SValue r
 listSize fnName list = objMethodCallNoParams IC.int list fnName
 
-listSize' :: (OORenderSym r vis smt) => String -> SValue r -> SValue r
+listSize' :: (IG.OOVariableSym r, VariableValue r) => String -> SValue r -> SValue r
 listSize' lengthName list = valueOf $ list $-> var lengthName IC.int
 
 -- Statements --
 
 increment
-  :: (InternalVarElim r, S.RenderStatement r smt, ValueElim r)
+  :: (InternalVarElim r, RC.RenderStatement r smt, ValueElim r)
   => SVariable r -> SValue r -> MS (r smt)
 increment vr' v'= do
   vr <- zoom lensMStoVS vr'
   v <- zoom lensMStoVS v'
   mkStmt $ R.addAssign vr v
 
-increment1 :: (InternalVarElim r, S.RenderStatement r smt) => SVariable r -> MS (r smt)
+increment1 :: (InternalVarElim r, RC.RenderStatement r smt) => SVariable r -> MS (r smt)
 increment1 vr' = do
   vr <- zoom lensMStoVS vr'
   (mkStmt . R.increment) vr
 
-decrement1 :: (InternalVarElim r, S.RenderStatement r smt) => SVariable r -> MS (r smt)
+decrement1 :: (InternalVarElim r, RC.RenderStatement r smt) => SVariable r -> MS (r smt)
 decrement1 vr' = do
   vr <- zoom lensMStoVS vr'
   (mkStmt . R.decrement) vr
 
-varDec :: (OORenderSym r vis smt, UnRepr r TypeData, TypeElim r) =>
-  r (Attachment r) -> r (Attachment r) -> Doc -> SVariable r -> r ScopeData -> MS (r smt)
+varDec
+  :: ( InternalVarElim r
+     , RO.PermElim r
+     , RC.RenderStatement r smt
+     , ScopeElim r
+     , UnRepr r TypeData
+     , TypeElim r
+     , VariableElim r
+     )
+  => r (Attachment r) -> r (Attachment r) -> Doc -> SVariable r -> r ScopeData -> MS (r smt)
 varDec s d pdoc v' scp = do
   v <- zoom lensMStoVS v'
   modify $ useVarName (variableName v)
   modify $ setVarScope (variableName v) (scopeData scp)
-  mkStmt (RC.perm (bind $ variableBind v)
+  mkStmt (RO.perm (bind $ variableBind v)
     <+> renderType (variableType v) <+> (ptrdoc (getCodeType (variableType v)) <>
     RC.variable v))
   where bind ClassLevel = s
@@ -181,7 +182,7 @@ varDec s d pdoc v' scp = do
 
 varDecDef
   :: ( IC.DeclStatement r smt
-     , S.RenderStatement r smt
+     , RC.RenderStatement r smt
      , RC.StatementElim r smt
      , ValueElim r
      )
@@ -195,7 +196,7 @@ varDecDef t vr scp vl' = do
 
 setDecDef
   :: ( IC.DeclStatement r smt
-     , S.RenderStatement r smt
+     , RC.RenderStatement r smt
      , RC.StatementElim r smt
      , ValueElim r
      )
@@ -208,15 +209,16 @@ setDecDef t vr scp vl' = do
   stmtCtor t (RC.statement vd <+> equals <+> RC.value vl)
 
 listDec
-  :: (IC.DeclStatement r smt, S.RenderStatement r smt, RC.StatementElim r smt)
+  :: (IC.DeclStatement r smt, RC.RenderStatement r smt, RC.StatementElim r smt)
   => (r (Value r) -> Doc) -> SValue r -> SVariable r -> r ScopeData -> MS (r smt)
 listDec f vl v scp = do
   sz <- zoom lensMStoVS vl
   vd <- IC.varDec v scp
   mkStmt (RC.statement vd <> f sz)
 
-extObjDecNew :: (OORenderSym r vis smt) => Library -> SVariable r ->
-  r ScopeData -> [SValue r] -> MS (r smt)
+extObjDecNew
+  :: (IC.DeclStatement r smt, IG.OOValueExpression r, VariableElim r)
+  => Library -> SVariable r -> r ScopeData -> [SValue r] -> MS (r smt)
 extObjDecNew l v scp vs = IC.varDecDef v scp
   (extNewObj l (onStateValue variableType v) vs)
 
@@ -224,7 +226,7 @@ extObjDecNew l v scp vs = IC.varDecDef v scp
 -- 2nd parameter is a statement to end every case with
 switch
   :: ( RC.BodyElim r
-     , S.RenderStatement r smt
+     , RC.RenderStatement r smt
      , RC.StatementElim r smt
      , ValueElim r
      )
@@ -235,7 +237,7 @@ switch
   -> MSBody r
   -> MS (r smt)
 switch f st v cs bod = do
-  s <- S.stmt st
+  s <- RC.stmt st
   val <- zoom lensMStoVS v
   vals <- mapM (zoom lensMStoVS . fst) cs
   bods <- mapM snd cs
@@ -244,7 +246,7 @@ switch f st v cs bod = do
 
 for
   :: ( RC.BodyElim r
-     , S.RenderStatement r smt
+     , RC.RenderStatement r smt
      , RC.StatementElim r smt
      , ValueElim r
      )
@@ -256,9 +258,9 @@ for
   -> MSBody r
   -> MS (r smt)
 for bStart bEnd sInit vGuard sUpdate b = do
-  initl <- S.loopStmt sInit
+  initl <- RC.loopStmt sInit
   guard <- zoom lensMStoVS vGuard
-  upd <- S.loopStmt sUpdate
+  upd <- RC.loopStmt sUpdate
   bod <- b
   mkStmtNoEnd $ vcat [
     forLabel <+> parens (RC.statement initl <> semi <+> RC.value guard <>
@@ -268,7 +270,7 @@ for bStart bEnd sInit vGuard sUpdate b = do
 
 -- Doc function parameter is applied to the render of the while-condition
 while
-  :: (RC.BodyElim r, S.RenderStatement r smt, ValueElim r)
+  :: (RC.BodyElim r, RC.RenderStatement r smt, ValueElim r)
   => (Doc -> Doc) -> Doc -> Doc -> SValue r -> MSBody r -> MS (r smt)
 while f bStart bEnd v' b'= do
   v <- zoom lensMStoVS v'
@@ -279,7 +281,7 @@ while f bStart bEnd v' b'= do
 
 -- Methods --
 
-intFunc :: (OORenderSym r vis smt) => Bool -> Label -> r vis ->
+intFunc :: (OORenderMethod r vis) => Bool -> Label -> r vis ->
   r (Attachment r) -> MSMthdType r -> [MS (r ParamData)] -> MSBody r ->
   SMethod r
 intFunc = intMethod

--- a/code/drasil-gool/lib/Drasil/Shared/LanguageRenderer/CommonPseudoOO.hs
+++ b/code/drasil-gool/lib/Drasil/Shared/LanguageRenderer/CommonPseudoOO.hs
@@ -2,9 +2,9 @@
 
 -- | Implementations defined here are valid in some, but not all, language renderers
 module Drasil.Shared.LanguageRenderer.CommonPseudoOO (
-  int, constructor, doxFunc, doxClass, doxMod, docMod', modDoc', functionDoc,
-  extVar, classVarAccess, indexOf, contains, containsInt, discardFileLine,
-  intClass, funcType, buildModule, arrayType, pi, printSt, arrayDec, arrayDecDef,
+  int, constructor, doxFunc, doxClass, doxMod, modDoc', functionDoc, extVar,
+  classVarAccess, indexOf, contains, containsInt, discardFileLine, intClass,
+  funcType, buildModule, arrayType, pi, printSt, arrayDec, arrayDecDef,
   openFileA, forEach, docMain, mainFunction, buildModule', call', listSizeFunc,
   listAccessFunc', string, docInOutFunc, bindingError, extFuncAppMixedArgs,
   notNull, listDecDef, destructorError, stateVarDef, constVar, litArray, litSet,
@@ -31,32 +31,23 @@ import Drasil.Shared.InterfaceCommon (UnRepr(..), varDecDef, bool,
 import qualified Drasil.Shared.InterfaceCommon as IC
 import Drasil.GOOL.InterfaceGOOL (SFile, FSModule, SClass, CSStateVar,
   OOTypeSym(obj), AttachmentSym(..), Initializers, objMethodCallNoParams,
-  objMethodCall)
-import qualified Drasil.GOOL.InterfaceGOOL as IG (ClassSym(buildClass),
-  OOFunctionSym(..))
+  objMethodCall, OOStatement)
+import qualified Drasil.GOOL.InterfaceGOOL as IG
 import Drasil.Shared.RendererClassesCommon (CommonRenderSym, RenderBody(..),
   RenderType(..), RenderVariable(varFromData), InternalVarElim(variableBind),
   MethodTypeSym(mType), RenderMethod(commentedFunc, mthdFromData),
   BlockCommentSym(..), ScopeElim(scopeData))
-import qualified Drasil.Shared.RendererClassesCommon as S
-import qualified Drasil.Shared.RendererClassesCommon as RC (import',
-  BodyElim(..), InternalVarElim(variable), ValueElim(..),
-  StatementElim(statement), VisibilityElim(..), MethodElim(..))
+import qualified Drasil.Shared.RendererClassesCommon as RC
 import Drasil.Shared.Helpers (vibcat, toCode, toState, onCodeValue, onStateValue,
   onStateList)
 import Drasil.GOOL.RendererClassesOO (OORenderSym, OORenderMethod(intMethod),
   ParentSpec)
-import qualified Drasil.GOOL.RendererClassesOO as S (OOMethodTypeSym(construct),
-  OORenderMethod(intFunc), RenderClass(intClass, inherit),
-  RenderMod(modFromData))
-import qualified Drasil.GOOL.RendererClassesOO as RC (PermElim(..),
-  StateVarElim(..), ClassElim(..))
+import qualified Drasil.GOOL.RendererClassesOO as RG
 import Drasil.Shared.LanguageRenderer (listAccessFunc, array', new', args, array,
   listSep, access, mathFunc, ModuleDocRenderer, FuncDocRenderer, functionDox,
   classDox, moduleDox, variableList, valueList, intValue)
 import Drasil.GOOL.Renderers (renderType)
-import qualified Drasil.Shared.LanguageRenderer as R (self, self', module',
-  print, stateVar, stateVarList)
+import qualified Drasil.Shared.LanguageRenderer as R
 import Drasil.Shared.LanguageRenderer.Constructors (mkStmt, mkStmtNoEnd,
   mkStateVal, mkStateVar, typeFromData, mkVar)
 import Drasil.Shared.LanguageRenderer.LanguagePolymorphic (
@@ -73,7 +64,7 @@ import Prelude hiding (print,pi,(<>))
 import Data.List (sort, intercalate)
 import Control.Monad.State (get, modify)
 import Control.Lens ((^.))
-import qualified Control.Lens as L (set)
+import qualified Control.Lens as L
 import Control.Lens.Zoom (zoom)
 import Text.PrettyPrint.HughesPJ (Doc, text, empty, render, (<>), (<+>), parens,
   brackets, braces, colon, vcat, equals)
@@ -101,19 +92,20 @@ intRender = "int"
 int :: (Monad r) => VS (r TypeData)
 int = typeFromData Integer intRender (text intRender)
 
-constructor :: (OORenderSym r vis smt) => Label -> [MS (r ParamData)] ->
-  Initializers r -> MSBody r -> SMethod r
+constructor
+  :: (OORenderSym r vis smt, OOStatement r smt)
+  => Label -> [MS (r ParamData)] -> Initializers r -> MSBody r -> SMethod r
 constructor fName ps is b = getClassName >>= (\c -> intMethod False fName
-  public instanceLevel (S.construct c) ps (S.multiBody [initStmts is, b]))
+  public instanceLevel (RG.construct c) ps (RC.multiBody [initStmts is, b]))
 
 doxFunc :: (RenderMethod r) => String -> [String] -> Maybe String ->
   SMethod r -> SMethod r
 doxFunc = docFunc functionDox
 
-doxClass :: (OORenderSym r vis smt) => String -> SClass r -> SClass r
+doxClass :: (RG.RenderClass r vis) => String -> SClass r -> SClass r
 doxClass = docClass classDox
 
-doxMod :: (OORenderSym r vis smt) => String -> String -> String -> [String] ->
+doxMod :: (RG.RenderFile r) => String -> String -> String -> [String] ->
   String -> SFile r -> SFile r
 doxMod = docMod moduleDox
 
@@ -130,27 +122,40 @@ classVarAccess f c' v'= do
     (toState $ variableType v) (f (renderType c) (RC.variable v))
   toState $ classVarAccessCheck vr
 
-indexOf :: (OORenderSym r vis smt) => Label -> SValue r -> SValue r -> SValue r
+indexOf
+  :: (IC.IndexTranslator r, IG.OOFunctionSym r)
+  => Label -> SValue r -> SValue r -> SValue r
 indexOf f l v = IC.indexToInt $ IG.objAccess l (IG.func f IC.int [v])
 
-contains :: (OORenderSym r vis smt) => Label -> SValue r -> SValue r -> SValue r
+contains :: (IG.OOFunctionSym r) => Label -> SValue r -> SValue r -> SValue r
 contains f s v = IG.objAccess s (IG.func f IC.bool [v])
 
-containsInt :: (OORenderSym r vis smt) => Label -> Label -> SValue r -> SValue r -> SValue r
+containsInt
+  :: (Comparison r, IG.OOFunctionSym r)
+  => Label -> Label -> SValue r -> SValue r -> SValue r
 containsInt f fn s v = contains f s v ?!= IG.objAccess s (IG.func fn IC.bool [])
 
-discardFileLine :: (OORenderSym r vis smt) => Label -> SValue r -> MS (r smt)
+discardFileLine
+  :: (IG.InternalValueExp r, IC.StatementSym r smt)
+  => Label -> SValue r -> MS (r smt)
 discardFileLine n f = IC.valStmt $ objMethodCallNoParams IC.string f n
 
 -- | An internal function for creating a class.
 --   Parameters: render function, class name, scope, parent, class variables,
 --               constructor(s), methods
-intClass :: (OORenderSym r vis smt, Monad r) => (Label -> Doc -> Doc -> Doc ->
-  Doc -> Doc) -> Label -> r vis -> r ParentSpec -> [CSStateVar r] ->
-  [SMethod r] -> [SMethod r] -> CS (r Doc)
+intClass
+  :: (RC.MethodElim r, Monad r, RG.StateVarElim r, RC.VisibilityElim r vis)
+  => (Label -> Doc -> Doc -> Doc -> Doc -> Doc)
+  -> Label
+  -> r vis
+  -> r ParentSpec
+  -> [CSStateVar r]
+  -> [SMethod r]
+  -> [SMethod r]
+  -> CS (r Doc)
 intClass f n s i svrs cstrs mths = do
   modify (setClassName n)
-  svs <- onStateList (R.stateVarList . map RC.stateVar) svrs
+  svs <- onStateList (R.stateVarList . map RG.stateVar) svrs
   ms <- onStateList (vibcat . map RC.method) (map (zoom lensCStoMS) (cstrs ++ mths))
   return $ onCodeValue (\p -> f n p (RC.visibility s) svs ms) i
 
@@ -159,15 +164,16 @@ intClass f n s i svrs cstrs mths = do
 -- Parameters: Module name, Doc for imports, Doc to put at top of module (but
 -- after imports), Doc to put at bottom of module, methods, classes
 -- Renamed top to topDoc to fix shadowing error with RendererClassesOO top
-buildModule :: (OORenderSym r vis smt) => Label -> FS Doc -> FS Doc -> FS Doc ->
-  [SMethod r] -> [SClass r] -> FSModule r
-buildModule n imps topDoc bot fs cs = S.modFromData n (do
+buildModule
+  :: (RG.ClassElim r, RC.MethodElim r, RG.RenderMod r)
+  => Label -> FS Doc -> FS Doc -> FS Doc -> [SMethod r] -> [SClass r] -> FSModule r
+buildModule n imps topDoc bot fs cs = RG.modFromData n (do
   cls <- mapM (zoom lensFStoCS) cs
   fns <- mapM (zoom lensFStoMS) fs
   is <- imps
   tp <- topDoc
   bt <- bot
-  return $ R.module' is (vibcat (tp : map RC.class' cls))
+  return $ R.module' is (vibcat (tp : map RG.class' cls))
     (vibcat (map RC.method fns ++ [bt])))
 
 -- Java and C# --
@@ -179,10 +185,12 @@ arrayType t' = do
   typeFromData (Array (getCodeType t))
     (getTypeString t ++ array) (renderType t <> brackets empty)
 
-pi :: (S.RenderValue r, TypeSym r) => SValue r
+pi :: (RC.RenderValue r, TypeSym r) => SValue r
 pi = mkStateVal IC.double (text $ mathFunc "PI")
 
-printSt :: (S.RenderStatement r smt, RC.ValueElim r) => SValue r -> SValue r -> MS (r smt)
+printSt
+  :: (RC.RenderStatement r smt, RC.ValueElim r)
+  => SValue r -> SValue r -> MS (r smt)
 printSt va' vb' = do
   va <- zoom lensMStoVS va'
   vb <- zoom lensMStoVS vb'
@@ -192,7 +200,7 @@ arrayDec
   :: ( ScopeElim r
      , UnRepr r TypeData
      , InternalVarElim r
-     , S.RenderStatement r smt
+     , RC.RenderStatement r smt
      , RC.ValueElim r
      , VariableElim r
      )
@@ -209,7 +217,7 @@ arrayDec n vr scp = do
 
 arrayDecDef
   :: ( IC.DeclStatement r smt
-     , S.RenderStatement r smt
+     , RC.RenderStatement r smt
      , RC.StatementElim r smt
      , RC.ValueElim r
      )
@@ -230,7 +238,7 @@ openFileA f vr vl = vr &= f vl outfile IC.litTrue
 forEach
   :: ( RC.BodyElim r
      , InternalVarElim r
-     , S.RenderStatement r smt
+     , RC.RenderStatement r smt
      , UnRepr r TypeData
      , RC.ValueElim r
      , VariableElim r
@@ -254,9 +262,16 @@ docMain :: (OORenderSym r vis smt) => MSBody r -> SMethod r
 docMain b = commentedFunc (docComment $ toState $ functionDox
   mainDesc [(args, argsDesc)] []) (IC.mainFunction b)
 
-mainFunction :: (OORenderSym r vis smt, UnRepr r TypeData, Monad r) =>
-  VS (r TypeData) -> Label -> MSBody r -> SMethod r
-mainFunction s n = S.intFunc True n public classLevel (mType IC.void)
+mainFunction
+  :: ( AttachmentSym r
+     , OORenderMethod r vis
+     , IC.ParameterSym r
+     , UnRepr r TypeData
+     , Monad r
+     , VisibilitySym r vis
+     )
+  => VS (r TypeData) -> Label -> MSBody r -> SMethod r
+mainFunction s n = RG.intFunc True n public classLevel (mType IC.void)
   [IC.param (IC.var args (s >>= (\argT -> typeFromData (List String)
   (render (renderType argT) ++ array) (renderType argT <> array'))))]
 
@@ -266,9 +281,15 @@ mainFunction s n = S.intFunc True n public classLevel (mType IC.void)
 --   is is the import statements
 --   ms is the class methods
 --   cs is the classes
-buildModule' :: (OORenderSym r vis smt, UnRepr r Doc) => Label ->
-  (String -> r Doc) -> [Label] -> [SMethod r] -> [SClass r] -> FSModule r
-buildModule' n inc is ms cs = S.modFromData n (do
+buildModule'
+  :: (OORenderSym r vis smt, UnRepr r Doc)
+  => Label
+  -> (String -> r Doc)
+  -> [Label]
+  -> [SMethod r]
+  -> [SClass r]
+  -> FSModule r
+buildModule' n inc is ms cs = RG.modFromData n (do
   cls <- mapM (zoom lensFStoCS)
           (if null ms then cs else IG.buildClass Nothing [] [] ms : cs)
   lis <- getLangImports
@@ -276,13 +297,13 @@ buildModule' n inc is ms cs = S.modFromData n (do
   mis <- getModuleImports
   return $ vibcat [
     vcat (map (RC.import' . inc) (lis ++ sort (is ++ libis) ++ mis)),
-    vibcat (map RC.class' cls)])
+    vibcat (map RG.class' cls)])
 
 -- Java and C++ --
 
 -- | First parameter is language name, rest similar to call from RendererClassesCommon
 call'
-  :: (InternalVarElim r, S.RenderValue r, RC.ValueElim r)
+  :: (InternalVarElim r, RC.RenderValue r, RC.ValueElim r)
   => String -> Maybe Library -> Maybe Doc -> MixedCall r
 call' l _ _ _ _ _ (_:_) = error $ namedArgError l
 call' _ l o n t ps ns = call empty l o n t ps ns
@@ -290,17 +311,12 @@ call' _ l o n t ps ns = call empty l o n t ps ns
 namedArgError :: String -> String
 namedArgError l = "Named arguments not supported in " ++ l
 
-listSizeFunc
-  :: (OORenderSym r vis smt)
-  => VS (r FuncData)
+listSizeFunc :: (IG.OOFunctionSym r) => VS (r FuncData)
 listSizeFunc = IG.func "size" IC.int []
 
 listAccessFunc'
-  :: (OORenderSym r vis smt, TypeElim r)
-  => Label
-  -> VS (r TypeData)
-  -> SValue r
-  -> VS (r FuncData)
+  :: (IG.OOFunctionSym r, TypeElim r)
+  => Label -> VS (r TypeData) -> SValue r -> VS (r FuncData)
 listAccessFunc' f t i = IG.func f t [intValue i]
 
 -- C# and C++ --
@@ -351,55 +367,59 @@ setDecDef v scp vals = do
   let st = IC.litSet (innerType $ return $ variableType vr) vals
   IC.varDecDef (return vr) scp st
 
-setDec :: (OORenderSym r vis smt) => (r (Value r) -> Doc) -> SValue r ->
-  SVariable r -> r ScopeData -> MS (r smt)
+setDec
+  :: (IC.DeclStatement r smt, RC.RenderStatement r smt, RC.StatementElim r smt)
+  => (r (Value r) -> Doc) -> SValue r -> SVariable r -> r ScopeData -> MS (r smt)
 setDec f vl v scp = do
   sz <- zoom lensMStoVS vl
   vd <- IC.varDec v scp
   mkStmt (RC.statement vd <> f sz)
 
-setMethodCall :: (OORenderSym r vis smt) => Label -> SValue r ->  SValue r -> SValue r
+setMethodCall
+  :: (IG.InternalValueExp r) => Label -> SValue r ->  SValue r -> SValue r
 setMethodCall n a b = objMethodCall (innerType $ onStateValue valueType a) a n [b]
 
 destructorError :: String -> String
 destructorError l = "Destructors not allowed in " ++ l
 
-stateVarDef :: (OORenderSym r vis smt, Monad r) => r vis ->
-  r (Attachment r) -> SVariable r -> SValue r -> CS (r Doc)
+stateVarDef
+  :: (OORenderSym r vis smt, Monad r)
+  => r vis -> r (Attachment r) -> SVariable r -> SValue r -> CS (r Doc)
 stateVarDef s p vr vl = zoom lensCStoMS $ onStateValue (toCode . R.stateVar
-  (RC.visibility  s) (RC.perm p) . RC.statement)
-  (S.stmt $ IC.varDecDef vr IC.local vl)
+  (RC.visibility  s) (RG.perm p) . RC.statement)
+  (RC.stmt $ IC.varDecDef vr IC.local vl)
 
 constVar :: (CommonRenderSym r vis smt, Monad r) => Doc -> r vis ->
   SVariable r -> SValue r -> CS (r Doc)
 constVar p s vr vl = zoom lensCStoMS $ onStateValue (toCode . R.stateVar
-  (RC.visibility s) p . RC.statement) (S.stmt $ IC.constDecDef vr IC.local vl)
+  (RC.visibility s) p . RC.statement) (RC.stmt $ IC.constDecDef vr IC.local vl)
 
 -- Python, Java, C++, and Swift --
 
 litArray
-  :: (S.RenderValue r, IC.TypeSym r, RC.ValueElim r)
+  :: (RC.RenderValue r, IC.TypeSym r, RC.ValueElim r)
   => (Doc -> Doc) -> VS (r TypeData) -> [SValue r] -> SValue r
 litArray f t es = sequence es >>= (\elems -> mkStateVal (IC.arrayType t)
   (f $ valueList elems))
 
 litSet
-  :: (S.RenderValue r, IC.TypeSym r, RC.ValueElim r)
+  :: (RC.RenderValue r, IC.TypeSym r, RC.ValueElim r)
   => (Doc -> Doc) -> (Doc -> Doc) -> VS (r TypeData) -> [SValue r] -> SValue r
 litSet f1 f2 t es = sequence es >>= (\elems -> mkStateVal (IC.arrayType t)
   (f1 $ f2 $ valueList elems))
 
 litSetFunc
-  :: (S.RenderValue r, IC.TypeSym r, RC.ValueElim r)
+  :: (RC.RenderValue r, IC.TypeSym r, RC.ValueElim r)
   => String -> VS (r TypeData) -> [SValue r] -> SValue r
 litSetFunc s t es = sequence es >>= (\elems -> mkStateVal (IC.arrayType t)
   (text s <> parens (valueList elems)))
 
 -- Python, C#, C++, and Swift--
 
-extraClass :: (OORenderSym r vis smt) =>  Label -> Maybe Label ->
-  [CSStateVar r] -> [SMethod r] -> [SMethod r] -> SClass r
-extraClass n = S.intClass n public . S.inherit
+extraClass
+  :: (RG.RenderClass r vis, VisibilitySym r vis)
+  =>  Label -> Maybe Label -> [CSStateVar r] -> [SMethod r] -> [SMethod r] -> SClass r
+extraClass n = RG.intClass n public . RG.inherit
 
 -- Java, C#, and Swift --
 
@@ -425,22 +445,23 @@ openFileW
   -> MS (r smt)
 openFileW f vr vl = vr &= f vl outfile IC.litFalse
 
-stateVar :: (OORenderSym r vis smt, Monad r) => r vis ->
-  r (Attachment r) -> SVariable r -> CS (r Doc)
+stateVar
+  :: (Monad r, OORenderSym r vis smt)
+  => r vis -> r (Attachment r) -> SVariable r -> CS (r Doc)
 stateVar s p v = zoom lensCStoMS $ onStateValue (toCode . R.stateVar
-  (RC.visibility s) (RC.perm p) . RC.statement) (S.stmt $ IC.varDec v IC.local)
+  (RC.visibility s) (RG.perm p) . RC.statement) (RC.stmt $ IC.varDec v IC.local)
 
 -- Python and Swift --
 
-self :: (OORenderSym r vis smt) => SVariable r
+self :: (OOTypeSym r, RenderVariable r) => SVariable r
 self = zoom lensVStoMS getClassName >>= (\l -> mkStateVar R.self (obj l)
   R.self')
 
 multiAssign
   :: ( IC.AssignStatement r smt
      , InternalVarElim r
-     , S.RenderValue r
-     , S.RenderVariable r
+     , RC.RenderValue r
+     , RC.RenderVariable r
      , RC.ValueElim r
      )
   => (Doc -> Doc) -> [SVariable r] -> [SValue r] -> MS (r smt)
@@ -458,7 +479,7 @@ multiAssign f vars vals = if length vals /= 1 && length vars /= length vals
     mkStateVal IC.void (wrapIfMult vls (valueList vls))
 
 multiReturn
-  :: (IC.ControlStatement r smt, S.RenderValue r, RC.ValueElim r)
+  :: (IC.ControlStatement r smt, RC.RenderValue r, RC.ValueElim r)
   => (Doc -> Doc) -> [SValue r] -> MS (r smt)
 multiReturn _ [] = error "Attempt to write return statement with no values."
 multiReturn _ [v] = returnStmt v
@@ -471,8 +492,9 @@ listDec
   => SVariable r -> r ScopeData -> MS (r smt)
 listDec v scp = listDecDef v scp []
 
-funcDecDef :: (OORenderSym r vis smt) => SVariable r -> r ScopeData ->
-  [SVariable r] -> MSBody r -> MS (r smt)
+funcDecDef
+  :: (OORenderSym r vis smt)
+  => SVariable r -> r ScopeData -> [SVariable r] -> MSBody r -> MS (r smt)
 funcDecDef v scp ps b = do
   vr <- zoom lensMStoVS v
   modify $ useVarName $ variableName vr
@@ -484,7 +506,7 @@ funcDecDef v scp ps b = do
   mkStmtNoEnd $ RC.method f
 
 inOutCall
-  :: (S.InternalAssignStmt r smt, IC.StatementSym r smt, IC.VariableValue r)
+  :: (RC.InternalAssignStmt r smt, IC.StatementSym r smt, IC.VariableValue r)
   => (Label -> VS (r TypeData) -> [SValue r] -> SValue r)
   -> Label
   -> [SValue r]
@@ -492,7 +514,7 @@ inOutCall
   -> [SVariable r]
   -> MS (r smt)
 inOutCall f n ins [] [] = IC.valStmt $ f n IC.void ins
-inOutCall f n ins outs both = S.multiAssign rets [f n IC.void (map IC.valueOf
+inOutCall f n ins outs both = RC.multiAssign rets [f n IC.void (map IC.valueOf
   both ++ ins)]
   where rets = both ++ outs
 
@@ -500,7 +522,7 @@ forLoopError :: String -> String
 forLoopError l = "Classic for loops not available in " ++ l ++ ", use " ++
   "forRange, forEach, or while instead"
 
-mainBody :: (RC.BodyElim r, S.RenderMethod r) => MSBody r -> SMethod r
+mainBody :: (RC.BodyElim r, RC.RenderMethod r) => MSBody r -> SMethod r
 mainBody b = do
   modify setCurrMain
   bod <- b
@@ -508,7 +530,7 @@ mainBody b = do
   mthdFromData Pub empty
 
 inOutFunc
-  :: ( S.InternalControlStmt r smt
+  :: ( RC.InternalControlStmt r smt
      , IC.SharedStatement r smt
      , RenderBody r
      , RenderType r
@@ -525,7 +547,7 @@ inOutFunc f ins outs both b = f
   (multiType $ map (onStateValue variableType) rets)
   (map IC.pointerParam both ++ map IC.param ins)
   (multiBody [bodyStatements $ map (`IC.varDec` IC.local) outs, b,
-    oneLiner $ S.multiReturn $ map IC.valueOf rets])
+    oneLiner $ RC.multiReturn $ map IC.valueOf rets])
   where rets = both ++ outs
 
 docInOutFunc'
@@ -561,11 +583,6 @@ inherit n = toCode $ maybe empty ((colon <+>) . text) n
 
 implements :: (Monad r) => [Label] -> r ParentSpec
 implements is = toCode $ colon <+> text (intercalate listSep is)
-
--- TODO: put docMod' back in Swift renderer, as it is no longer common.
-docMod' :: (OORenderSym r vis smt) => String -> String -> String -> [String] ->
-  String -> SFile r -> SFile r
-docMod' = docMod modDoc'
 
 -- | Generates Markdown/DocC style module doc comment.  Useful for Swift, which follows
 -- DocC, Julia, which uses Markdown, and any other language that doesn't have
@@ -624,8 +641,8 @@ argExists i = listSize IC.argsList ?> IC.litInt (fromIntegral $ i+1)
 listSet
   :: ( IC.AssignStatement r smt
      , IC.IndexTranslator r
-     , S.RenderVariable r
-     , S.ValueElim r
+     , RC.RenderVariable r
+     , RC.ValueElim r
      )
   => SValue r -> SValue r -> SValue r -> MS (r smt)
 listSet list idx val = do
@@ -640,13 +657,13 @@ listSet list idx val = do
 -- | Convert an integer to an index in a 1-indexed language
 --   Since GOOL is 0-indexed, we need to add 1
 intToIndex'
-  :: (IC.Literal r, IC.NumericExpression r, S.RenderValue r, RC.ValueElim r)
+  :: (IC.Literal r, IC.NumericExpression r, RC.RenderValue r, RC.ValueElim r)
   => SValue r -> SValue r
 intToIndex' v = v `smartAdd` IC.litInt 1
 
 -- | Convert an index to an integer in a 1-indexed language
 --   Since GOOL is 0-indexed, we need to subtract 1
 indexToInt'
-  :: (IC.Literal r, IC.NumericExpression r, S.RenderValue r, RC.ValueElim r)
+  :: (IC.Literal r, IC.NumericExpression r, RC.RenderValue r, RC.ValueElim r)
   => SValue r -> SValue r
 indexToInt' v = v `smartSub` IC.litInt 1

--- a/code/drasil-gool/lib/Drasil/Shared/LanguageRenderer/LanguagePolymorphic.hs
+++ b/code/drasil-gool/lib/Drasil/Shared/LanguageRenderer/LanguagePolymorphic.hs
@@ -32,9 +32,9 @@ import Drasil.Shared.InterfaceCommon (UnRepr(..), Label, Library, MSBody,
   ifNoElse, convType, VSBinder, BinderElim(..), getCodeType, getTypeString,
   ValueExpression)
 import qualified Drasil.Shared.InterfaceCommon as IC
-import Drasil.GOOL.InterfaceGOOL (SFile, FSModule, SClass, Initializers,
-  CSStateVar, FileSym(File), ModuleSym(Module), newObj, objMethodCallNoParams,
-  ($.), AttachmentSym(..))
+import Drasil.GOOL.InterfaceGOOL (OOStatement, SFile, FSModule, SClass,
+  Initializers, CSStateVar, FileSym(File), ModuleSym(Module), newObj,
+  objMethodCallNoParams, ($.), AttachmentSym(..))
 import qualified Drasil.GOOL.InterfaceGOOL as IG
 import Drasil.Shared.RendererClassesCommon (InternalVarElim(variableBind),
   RenderValue(valFromData), RenderFunction(funcFromData),
@@ -194,7 +194,9 @@ instanceVarAccess o' v' = do
         (variableType v) (R.instanceVarAccess (RC.value o) (RC.variable v))
   instanceVarAccess' (variableBind v)
 
-arrayElem :: (OORenderSym r vis smt) => SValue r -> SValue r -> SVariable r
+arrayElem
+  :: (IC.IndexTranslator r, RenderVariable r, ValueElim r)
+  => SValue r -> SValue r -> SVariable r
 arrayElem arr' i' = do
   i <- IC.intToIndex i'
   arr <- arr'
@@ -293,10 +295,12 @@ func
   => Label -> VS (r TypeData) -> [SValue r] -> VS (r FuncData)
 func l t vs = funcApp l t vs >>= ((`funcFromData` t) . R.func . RC.value)
 
-get :: (OORenderSym r vis smt) => SValue r -> SVariable r -> SValue r
+get
+  :: (RO.InternalGetSet r, IG.OOFunctionSym r)
+  => SValue r -> SVariable r -> SValue r
 get v vToGet = v $. RO.getFunc vToGet
 
-set :: (OORenderSym r vis smt) => SValue r -> SVariable r -> SValue r -> SValue r
+set :: (RO.InternalGetSet r, IG.OOFunctionSym r) => SValue r -> SVariable r -> SValue r -> SValue r
 set v vToSet toVal = v $. RO.setFunc (onStateValue valueType v) vToSet toVal
 
 -- TODO [Brandon Bosman, 06/10/2026]: Figure out what to do with this
@@ -323,18 +327,14 @@ listAccess v i = do
   mkVal (RC.functionType f) (RC.value v' <> RC.function f)
 
 getFunc
-  :: (OORenderSym r vis smt)
-  => SVariable r
-  -> VS (r FuncData)
+  :: (IG.OOFunctionSym r, VariableElim r)
+  => SVariable r -> VS (r FuncData)
 getFunc v = v >>= (\vr -> IG.func (getterName $ variableName vr)
   (toState $ variableType vr) [])
 
 setFunc
-  :: (OORenderSym r vis smt)
-  => VS (r TypeData)
-  -> SVariable r
-  -> SValue r
-  -> VS (r FuncData)
+  :: (IG.OOFunctionSym r, VariableElim r)
+  => VS (r TypeData) -> SVariable r -> SValue r -> VS (r FuncData)
 setFunc t v toVal = v >>= (\vr -> IG.func (setterName $ variableName vr) t
   [toVal])
 
@@ -371,8 +371,9 @@ subAssign t vr' v' = do
   v <- zoom lensMStoVS v'
   stmtFromData (R.subAssign vr v) t
 
-objDecNew :: (OORenderSym r vis smt) => SVariable r -> r ScopeData -> [SValue r]
-  -> MS (r smt)
+objDecNew
+  :: (IC.DeclStatement r smt, IG.OOValueExpression r, VariableElim r)
+  => SVariable r -> r ScopeData -> [SValue r] -> MS (r smt)
 objDecNew v scp vs = IC.varDecDef v scp (newObj (onStateValue variableType v) vs)
 
 printList :: (IC.SharedStatement r smt) => Integer -> SValue r ->
@@ -414,7 +415,9 @@ print newLn f printFn v = zoom lensMStoVS v >>= print' . getCodeType . valueType
         prLnFn = if newLn then maybe printStrLn printFileStrLn f else maybe
           printStr printFileStr f
 
-closeFile :: (OORenderSym r vis smt) => Label -> SValue r -> MS (r smt)
+closeFile
+  :: (IG.InternalValueExp r, StatementSym r smt)
+  => Label -> SValue r -> MS (r smt)
 closeFile n f = IC.valStmt $ objMethodCallNoParams IC.void f n
 
 returnStmt
@@ -500,8 +503,15 @@ param f v' = do
   modify $ useVarName n
   paramFromData v' $ f v
 
-method :: (OORenderSym r vis smt) => Label -> r vis -> r (Attachment r) ->
-  VS (r TypeData) -> [MS (r ParamData)] -> MSBody r -> SMethod r
+method
+  :: (OORenderMethod r vis)
+  => Label
+  -> r vis
+  -> r (Attachment r)
+  -> VS (r TypeData)
+  -> [MS (r ParamData)]
+  -> MSBody r
+  -> SMethod r
 method n s p t = intMethod False n s p (mType t)
 
 getMethod :: (OORenderSym r vis smt) => SVariable r -> SMethod r
@@ -514,11 +524,12 @@ setMethod v = zoom lensMStoVS v >>= (\vr -> IG.method (setterName $ variableName
   vr) public instanceLevel IC.void [IC.param v] setBody)
   where setBody = oneLiner $ IG.instanceVarSelf v &= IC.valueOf v
 
-initStmts :: (OORenderSym r vis smt) => Initializers r -> MSBody r
+initStmts :: (OOStatement r smt) => Initializers r -> MSBody r
 initStmts = bodyStatements . map (\(vr, vl) -> IG.instanceVarSelf vr &= vl)
 
-function :: (OORenderSym r vis smt) => Label -> r vis -> VS (r TypeData) ->
-  [MS (r ParamData)] -> MSBody r -> SMethod r
+function
+  :: (AttachmentSym r, OORenderMethod r vis)
+  => Label -> r vis -> VS (r TypeData) -> [MS (r ParamData)] -> MSBody r -> SMethod r
 function n s t = RO.intFunc False n s classLevel (mType t)
 
 docFuncRepr :: (RenderMethod r) => FuncDocRenderer -> String ->
@@ -532,21 +543,25 @@ docFunc f desc pComms rComm = docFuncRepr f desc pComms (maybeToList rComm)
 
 -- Classes --
 
-buildClass :: (OORenderSym r vis smt) =>  Maybe Label -> [CSStateVar r] ->
-  [SMethod r] -> [SMethod r] -> SClass r
+buildClass
+  :: (RenderClass r vis, VisibilitySym r vis)
+  =>  Maybe Label -> [CSStateVar r] -> [SMethod r] -> [SMethod r] -> SClass r
 buildClass p stVars constructors methods = do
   n <- zoom lensCStoFS getModuleName
   RO.intClass n public (inherit p) stVars constructors methods
 
-implementingClass :: (OORenderSym r vis smt) => Label -> [Label] ->
+implementingClass :: (RenderClass r vis, VisibilitySym r vis) => Label -> [Label] ->
   [CSStateVar r] -> [SMethod r] -> [SMethod r] -> SClass r
 implementingClass n is = RO.intClass n public (implements is)
 
-docClass :: (OORenderSym r vis smt) => ClassDocRenderer -> String -> SClass r -> SClass r
+docClass
+  :: (RenderClass r vis)
+  => ClassDocRenderer -> String -> SClass r -> SClass r
 docClass cdr d = RO.commentedClass (docComment $ toState $ cdr d)
 
-commentedClass :: (OORenderSym r vis smt, Monad r) => CS (r Doc) -> SClass r
-  -> CS (r Doc)
+commentedClass
+  :: (RC.BlockCommentElim r, RO.ClassElim r, Monad r)
+  => CS (r Doc) -> SClass r -> CS (r Doc)
 commentedClass = on2StateValues (\cmt cs -> toCode $ R.commentedItem
   (RC.blockComment' cmt) (RO.class' cs))
 
@@ -557,8 +572,9 @@ modFromData n f d = modify (setModuleName n) >> onStateValue f d
 
 -- Files --
 
-fileDoc :: (OORenderSym r vis smt) => String -> (r (Module r) -> r (Block r)) ->
-  r (Block r) -> FSModule r -> SFile r
+fileDoc
+  :: (RC.BlockElim r, RenderMod r, RenderFile r)
+  => String -> (r (Module r) -> r (Block r)) -> r (Block r) -> FSModule r -> SFile r
 fileDoc ext topb botb mdl = do
   m <- mdl
   nm <- getModuleName
@@ -575,13 +591,22 @@ fileDoc ext topb botb mdl = do
 --   a is a list of authors
 --   dt is the date
 --   fl is the file
-docMod :: (OORenderSym r vis smt) => ModuleDocRenderer -> String -> String ->
-  String -> [String] -> String -> SFile r -> SFile r
+docMod
+  :: (RenderFile r)
+  => ModuleDocRenderer
+  -> String
+  -> String
+  -> String
+  -> [String]
+  -> String
+  -> SFile r
+  -> SFile r
 docMod mdr e wm d a dt fl = commentedMod fl (docComment $ mdr wm d a dt . addExt e
   <$> getModuleName)
 
-fileFromData :: (OORenderSym r vis smt) => (FilePath -> r (Module r) ->
-  r (File r)) -> FilePath -> FSModule r -> SFile r
+fileFromData
+  :: (RO.ModuleElim r)
+  => (FilePath -> r (Module r) -> r (File r)) -> FilePath -> FSModule r -> SFile r
 fileFromData f fpath mdl' = do
   -- Add this file to list of files as long as it is not empty
   mdl <- mdl'

--- a/code/drasil-gool/lib/Drasil/Shared/LanguageRenderer/LanguagePolymorphic.hs
+++ b/code/drasil-gool/lib/Drasil/Shared/LanguageRenderer/LanguagePolymorphic.hs
@@ -31,38 +31,22 @@ import Drasil.Shared.InterfaceCommon (UnRepr(..), Label, Library, MSBody,
   IOStatement(printStr, printStrLn, printFile, printFileStr, printFileStrLn),
   ifNoElse, convType, VSBinder, BinderElim(..), getCodeType, getTypeString,
   ValueExpression)
-import qualified Drasil.Shared.InterfaceCommon as IC (TypeSym(int, double, char,
-  string, arrayType, innerType, funcType, void), VariableSym(var),
-  Literal(litInt, litFloat, litDouble, litString), VariableValue(valueOf),
-  List(listSize, listAccess), StatementSym(valStmt), DeclStatement(varDecDef),
-  IOStatement(print), ControlStatement(returnStmt, for, forEach),
-  ParameterSym(param), IndexTranslator(intToIndex), ScopeSym(local),
-  NumericExpression, SharedStatement)
+import qualified Drasil.Shared.InterfaceCommon as IC
 import Drasil.GOOL.InterfaceGOOL (SFile, FSModule, SClass, Initializers,
   CSStateVar, FileSym(File), ModuleSym(Module), newObj, objMethodCallNoParams,
   ($.), AttachmentSym(..))
-import qualified Drasil.GOOL.InterfaceGOOL as IG (
-  instanceVarSelf, OOMethodSym(method), OOFunctionSym(func))
+import qualified Drasil.GOOL.InterfaceGOOL as IG
 import Drasil.Shared.RendererClassesCommon (InternalVarElim(variableBind),
   RenderValue(valFromData), RenderFunction(funcFromData),
   FunctionElim(functionType), RenderStatement(stmtFromData),
   StatementElim(statementTerm), MethodTypeSym(mType), RenderParam(paramFromData),
   RenderMethod(commentedFunc), BlockCommentSym(..), ValueElim (value),
   RenderVariable)
-import qualified Drasil.Shared.RendererClassesCommon as S (RenderValue(call),
-  InternalListFunc (listAccessFunc), RenderStatement(stmt),
-  InternalIOStmt(..))
-import qualified Drasil.Shared.RendererClassesCommon as RC (BodyElim(..),
-  BlockElim(..), InternalVarElim(variable), ValueElim(value, valueInt),
-  FunctionElim(..), StatementElim(statement), BlockCommentElim(..))
+import qualified Drasil.Shared.RendererClassesCommon as RC
 import Drasil.GOOL.RendererClassesOO (OORenderSym, RenderFile(commentedMod),
   OORenderMethod(intMethod), RenderClass(inherit, implements),
   RenderMod(updateModuleDoc))
-import qualified Drasil.GOOL.RendererClassesOO as S (RenderFile(fileFromData),
-  InternalGetSet(getFunc, setFunc), OORenderMethod(intFunc),
-  RenderClass(intClass, commentedClass))
-import qualified Drasil.GOOL.RendererClassesOO as RC (ClassElim(..),
-  ModuleElim(..))
+import qualified Drasil.GOOL.RendererClassesOO as RO
 import Drasil.Shared.AST (AttachmentTag(..), Terminator(..), isSource,
   ScopeTag(Local), ScopeData, sd, TypeData(..), BinderD, ParamData, FuncData)
 import Drasil.Shared.Helpers (doubleQuotedText, vibcat, emptyIfEmpty, toCode,
@@ -71,9 +55,7 @@ import Drasil.Shared.Helpers (doubleQuotedText, vibcat, emptyIfEmpty, toCode,
 import Drasil.Shared.LanguageRenderer (dot, ifLabel, elseLabel, access, addExt,
   FuncDocRenderer, ClassDocRenderer, ModuleDocRenderer, getterName, setterName,
   valueList, namedArgList)
-import qualified Drasil.Shared.LanguageRenderer as R (file, block, assign,
-  subAssign, return', comment, getTerm, var, instanceVarAccess, arg, func,
-  objAccess, commentedItem)
+import qualified Drasil.Shared.LanguageRenderer as R
 import Drasil.Shared.LanguageRenderer.Constructors (mkStmtNoEnd, mkStateVal,
   mkVal, mkStateVar, mkVar, mkClassVar, VSOp, unOpPrec, compEqualPrec, compPrec,
   addPrec, multPrec, typeFromData)
@@ -88,7 +70,7 @@ import Control.Lens ((^.), over)
 import Control.Lens.Zoom (zoom)
 import Text.PrettyPrint.HughesPJ (Doc, text, empty, render, (<>), (<+>), ($+$),
   parens, brackets, integer, vcat, comma, isEmpty, space)
-import qualified Text.PrettyPrint.HughesPJ as D (char, double)
+import qualified Text.PrettyPrint.HughesPJ as D
 
 -- Bodies --
 
@@ -100,7 +82,7 @@ multiBody bs = onStateList (toCode . vibcat) $ map (onStateValue RC.body) bs
 block
   :: (Monad r, RenderStatement r smt, StatementElim r smt)
   => [MS (r smt)] -> MS (r Doc)
-block sts = onStateList (toCode . R.block . map RC.statement) (map S.stmt sts)
+block sts = onStateList (toCode . R.block . map RC.statement) (map RC.stmt sts)
 
 multiBlock :: (RC.BlockElim r, Monad r) => [MSBlock r] -> MS (r Doc)
 multiBlock bs = onStateList (toCode . vibcat) $ map (onStateValue RC.block) bs
@@ -274,14 +256,14 @@ call sep lib o n t pas nas = do
     (zip nms nargs))
 
 funcAppMixedArgs :: (RenderValue r) => MixedCall r
-funcAppMixedArgs = S.call Nothing Nothing
+funcAppMixedArgs = RC.call Nothing Nothing
 
 newObjMixedArgs
   :: (RenderValue r, UnRepr r TypeData)
   => String -> MixedCtorCall r
 newObjMixedArgs s tp vs ns = do
   t <- tp
-  S.call Nothing Nothing (s ++ getTypeString t) (return t) vs ns
+  RC.call Nothing Nothing (s ++ getTypeString t) (return t) vs ns
 
 lambda
   :: (BinderElim r, RenderValue r, ValueSym r)
@@ -301,7 +283,7 @@ objAccess = on2StateWrapped (\v f-> mkVal (functionType f)
 objMethodCall
   :: (RenderValue r, ValueElim r)
   => Label -> VS (r TypeData) -> SValue r -> [SValue r] -> NamedArgs r -> SValue r
-objMethodCall f t ob vs ns = ob >>= (\o -> S.call Nothing
+objMethodCall f t ob vs ns = ob >>= (\o -> RC.call Nothing
   (Just $ RC.value o <> dot) f t vs ns)
 
 -- Functions --
@@ -312,15 +294,15 @@ func
 func l t vs = funcApp l t vs >>= ((`funcFromData` t) . R.func . RC.value)
 
 get :: (OORenderSym r vis smt) => SValue r -> SVariable r -> SValue r
-get v vToGet = v $. S.getFunc vToGet
+get v vToGet = v $. RO.getFunc vToGet
 
 set :: (OORenderSym r vis smt) => SValue r -> SVariable r -> SValue r -> SValue r
-set v vToSet toVal = v $. S.setFunc (onStateValue valueType v) vToSet toVal
+set v vToSet toVal = v $. RO.setFunc (onStateValue valueType v) vToSet toVal
 
 -- TODO [Brandon Bosman, 06/10/2026]: Figure out what to do with this
 listAccess
   :: ( IC.IndexTranslator r
-     , S.InternalListFunc r
+     , RC.InternalListFunc r
      , FunctionElim r
      , RenderFunction r
      , RenderValue r
@@ -332,8 +314,8 @@ listAccess v i = do
   v' <- v
   let i' = IC.intToIndex i
       t  = IC.innerType $ return $ valueType v'
-      checkType (List _) = S.listAccessFunc t i'
-      checkType (Set _) = S.listAccessFunc t i'
+      checkType (List _) = RC.listAccessFunc t i'
+      checkType (Set _) = RC.listAccessFunc t i'
       checkType (Array _) = i' >>=
                               (\ix -> funcFromData (brackets (RC.value ix)) t)
       checkType _ = error "listAccess called on non-list-type value"
@@ -368,7 +350,7 @@ stmt s' = do
 loopStmt
   :: (RenderStatement r smt, StatementElim r smt)
   => MS (r smt) -> MS (r smt)
-loopStmt = S.stmt . setEmpty
+loopStmt = RC.stmt . setEmpty
 
 emptyStmt :: (RenderStatement r smt) => MS (r smt)
 emptyStmt = mkStmtNoEnd empty
@@ -420,13 +402,13 @@ printObj :: ClassName -> (String -> MS (r smt)) -> MS (r smt)
 printObj n prLnFn = prLnFn $ "Instance of " ++ n ++ " object"
 
 print
-  :: (S.InternalIOStmt r smt, IC.SharedStatement r smt, TypeElim r)
+  :: (RC.InternalIOStmt r smt, IC.SharedStatement r smt, TypeElim r)
   => Bool -> Maybe (SValue r) -> SValue r -> SValue r -> MS (r smt)
 print newLn f printFn v = zoom lensMStoVS v >>= print' . getCodeType . valueType
   where print' (List t) = printList (getNestDegree 1 t) v prFn prStrFn prLnFn
         print' (Object n) = printObj n prLnFn
         print' (Set t) = printSet (getNestDegree 1 t) v prFn prStrFn prLnFn (convType t)
-        print' _ = S.printSt newLn f printFn v
+        print' _ = RC.printSt newLn f printFn v
         prFn = maybe IC.print printFile f
         prStrFn = maybe printStr printFileStr f
         prLnFn = if newLn then maybe printStrLn printFileStrLn f else maybe
@@ -537,7 +519,7 @@ initStmts = bodyStatements . map (\(vr, vl) -> IG.instanceVarSelf vr &= vl)
 
 function :: (OORenderSym r vis smt) => Label -> r vis -> VS (r TypeData) ->
   [MS (r ParamData)] -> MSBody r -> SMethod r
-function n s t = S.intFunc False n s classLevel (mType t)
+function n s t = RO.intFunc False n s classLevel (mType t)
 
 docFuncRepr :: (RenderMethod r) => FuncDocRenderer -> String ->
   [String] -> [String] -> SMethod r -> SMethod r
@@ -554,19 +536,19 @@ buildClass :: (OORenderSym r vis smt) =>  Maybe Label -> [CSStateVar r] ->
   [SMethod r] -> [SMethod r] -> SClass r
 buildClass p stVars constructors methods = do
   n <- zoom lensCStoFS getModuleName
-  S.intClass n public (inherit p) stVars constructors methods
+  RO.intClass n public (inherit p) stVars constructors methods
 
 implementingClass :: (OORenderSym r vis smt) => Label -> [Label] ->
   [CSStateVar r] -> [SMethod r] -> [SMethod r] -> SClass r
-implementingClass n is = S.intClass n public (implements is)
+implementingClass n is = RO.intClass n public (implements is)
 
 docClass :: (OORenderSym r vis smt) => ClassDocRenderer -> String -> SClass r -> SClass r
-docClass cdr d = S.commentedClass (docComment $ toState $ cdr d)
+docClass cdr d = RO.commentedClass (docComment $ toState $ cdr d)
 
 commentedClass :: (OORenderSym r vis smt, Monad r) => CS (r Doc) -> SClass r
   -> CS (r Doc)
 commentedClass = on2StateValues (\cmt cs -> toCode $ R.commentedItem
-  (RC.blockComment' cmt) (RC.class' cs))
+  (RC.blockComment' cmt) (RO.class' cs))
 
 -- Modules --
 
@@ -583,7 +565,7 @@ fileDoc ext topb botb mdl = do
   let fp = addExt ext nm
       updm = updateModuleDoc (\d -> emptyIfEmpty d
         (R.file (RC.block $ topb m) d (RC.block botb))) m
-  S.fileFromData fp (toState updm)
+  RO.fileFromData fp (toState updm)
 
 -- | Generates a file for a documented module.
 --   mdr is a function that takes description, author, and module name and
@@ -603,7 +585,7 @@ fileFromData :: (OORenderSym r vis smt) => (FilePath -> r (Module r) ->
 fileFromData f fpath mdl' = do
   -- Add this file to list of files as long as it is not empty
   mdl <- mdl'
-  modify (\s -> if isEmpty (RC.module' mdl)
+  modify (\s -> if isEmpty (RO.module' mdl)
     then s
     else over lensFStoGS (addFile (s ^. currFileType) fpath) $
       -- If this is the main source file, set it as the main module in the state

--- a/code/drasil-gool/lib/Drasil/Shared/LanguageRenderer/Macros.hs
+++ b/code/drasil-gool/lib/Drasil/Shared/LanguageRenderer/Macros.hs
@@ -15,14 +15,13 @@ import Drasil.Shared.InterfaceCommon (Label, MSBody, MSBlock, SVariable, SValue,
   BooleanExpression((?&&), (?||)), at, StatementSym(..),
   AssignStatement((&+=), (&-=), (&++)), (&=), convScope)
 import qualified Drasil.Shared.InterfaceCommon as IC
-import Drasil.GOOL.InterfaceGOOL (($.), observerListName)
+import Drasil.GOOL.InterfaceGOOL (($.), observerListName, OOStatement)
 import Drasil.Shared.RendererClassesCommon (RenderValue(cast),
   ValueElim(valueInt))
 import qualified Drasil.Shared.RendererClassesCommon as S (
   RenderStatement(stmt), RenderValue)
 import qualified Drasil.Shared.RendererClassesCommon as RC (BodyElim(..),
   StatementElim(statement))
-import Drasil.GOOL.RendererClassesOO (OORenderSym)
 import Drasil.Shared.Helpers (toCode, onStateValue, on2StateValues)
 import Drasil.Shared.State (MS, VS, MS, lensMStoVS, genVarName, genLoopIndex,
   genVarNameIf, getVarScope)
@@ -218,26 +217,20 @@ obsList :: (IC.VariableValue r) => VS (r TypeData) -> SValue r
 obsList t = IC.valueOf $ listOf observerListName t
 
 notify
-  :: (OORenderSym r vis smt)
-  => VS (r TypeData)
-  -> VS (r FuncData)
-  -> MSBody r
+  :: (OOStatement r smt)
+  => VS (r TypeData) -> VS (r FuncData) -> MSBody r
 notify t f = oneLiner $ IC.valStmt $ at (obsList t) observerIdxVal $. f
 
 notifyObservers
-  :: (OORenderSym r vis smt)
-  => VS (r FuncData)
-  -> VS (r TypeData)
-  -> MS (r smt)
+  :: (OOStatement r smt)
+  => VS (r FuncData) -> VS (r TypeData) -> MS (r smt)
 notifyObservers f t = IC.for initv (observerIdxVal ?< IC.listSize (obsList t))
   (observerIndex &++) (notify t f)
   where initv = IC.varDecDef observerIndex IC.local $ IC.litInt 0
 
 notifyObservers'
-  :: (OORenderSym r vis smt)
-  => VS (r FuncData)
-  -> VS (r TypeData)
-  -> MS (r smt)
+  :: (OOStatement r smt)
+  => VS (r FuncData) -> VS (r TypeData) -> MS (r smt)
 notifyObservers' f t = IC.forRange observerIndex initv (IC.listSize $ obsList t )
     (IC.litInt 1) (notify t f)
     where initv = IC.litInt 0

--- a/code/drasil-gool/lib/Drasil/Shared/RendererClassesCommon.hs
+++ b/code/drasil-gool/lib/Drasil/Shared/RendererClassesCommon.hs
@@ -47,8 +47,6 @@ class (AssignStatement r smt, DeclStatement r smt, IOStatement r smt,
   ParameterSym r, ScopeElim r
   ) => CommonRenderSym r vis smt
 
--- TODO: split into multiple files, and create ProcRenderSym (or rename them both to RenderSym?)
-
 -- Common Typeclasses --
 
 class ImportSym r where


### PR DESCRIPTION
Builds on #5297 
Contributes to #5233 

This should be the last "Specialized" PR. After this is merged I can get back to removing unused type families and converting the rest to typeclass parameters with fundeps.