### PR TITLE
refactor: use `Data.Set.member` operation to check if a chunk is already inserted into the `ChunkDB` instead of `elem`

### DIFF
--- a/code/drasil-database/lib/Drasil/Database/ChunkDB.hs
+++ b/code/drasil-database/lib/Drasil/Database/ChunkDB.hs
@@ -153,7 +153,7 @@ insert0 cdb c = cdb'
 -- chunk).
 insert :: TypeableChunk a => a -> ChunkDB -> ChunkDB
 insert c cdb
-  | c ^. uid `elem` chunkRefs c =
+  | S.member (c ^. uid) $ chunkRefs c =
       error $ "Chunk `" ++ show (c ^. uid) ++ "` cannot reference itself as a dependancy."
   | typeOf c == typeRep (Proxy @ChunkDB) =
       error "Insertion of ChunkDBs in ChunkDBs is disallowed; please perform unions with them instead."


### PR DESCRIPTION
Why? Because `elem` is $O(N)$ while `Data.Set.member` is $O(\log N)$.

For reference:
<https://hackage-content.haskell.org/package/base-4.22.0.0/docs/Data-Foldable.html#g:23>

> It is perhaps worth noting that since the elem function in the Foldable class carries only an Eq constraint on the element type, search for the presence or absence of an element in the structure generally takes O(n) time, even for ordered structures like Set that are potentially capable of performing the search faster. (The member function of the Set module carries an Ord constraint, and can perform the search in O(log n) time).