### PR TITLE
chore(`SmithEtAlSRS`): remove unused `_lbldCntnt` field

### DIFF
--- a/code/drasil-example/bss/lib/Drasil/BinaryStar/Body.hs
+++ b/code/drasil-example/bss/lib/Drasil/BinaryStar/Body.hs
@@ -204,7 +204,7 @@ si = mkSmithEtAlICO
   [probDescIntro] [background] [scope] [motivation]
   tMods ([] :: [GenDefn]) ([] :: [DataDefinition]) iMods
   inputs outputs inConstraints constants symbols
-  (labelledContent ++ funcReqsTables) symbMap []
+  symbMap []
 
 background :: Sentence
 background = foldlSent_ [S "Binary star systems are common in astronomy.",

--- a/code/drasil-example/dblpend/lib/Drasil/DblPend/Body.hs
+++ b/code/drasil-example/dblpend/lib/Drasil/DblPend/Body.hs
@@ -101,7 +101,7 @@ si = mkSmithEtAlICO progName [dong]
   [purp] [background] [scope] [motivation]
   tMods genDefns dataDefs iMods
   inputs outputs inConstraints constants symbols
-  labelledContent' symbMap allRefs
+  symbMap allRefs
 
 purp :: Sentence
 purp = foldlSent_ [S "predict the", phrase motion `S.ofA` S "double", phrase pendulum]

--- a/code/drasil-example/gamephysics/lib/Drasil/GamePhysics/Body.hs
+++ b/code/drasil-example/gamephysics/lib/Drasil/GamePhysics/Body.hs
@@ -89,7 +89,7 @@ si = mkSmithEtAlICO progName [alex, luthfi, olu]
   [purp] [] [] []
   tMods generalDefns dataDefs iMods
   inputSymbols outputSymbols inputConstraints [] symbols
-  labelledContent symbMap allRefs
+  symbMap allRefs
 
 purp :: Sentence
 purp = foldlSent_ [S "simulate", short twoD, phrase CP.rigidBody,

--- a/code/drasil-example/glassbr/lib/Drasil/GlassBR/Body.hs
+++ b/code/drasil-example/glassbr/lib/Drasil/GlassBR/Body.hs
@@ -53,7 +53,6 @@ si = mkSmithEtAlICO progName
   [nikitha, spencerSmith] [purp] [background] [scope] []
   tMods [] GB.dataDefs iMods
   inputs outputs constrained constants symbolsWCodeSymbols
-  labCon
   symbMap
   allRefs
 

--- a/code/drasil-example/hghc/lib/Drasil/HGHC/Body.hs
+++ b/code/drasil-example/hghc/lib/Drasil/HGHC/Body.hs
@@ -18,7 +18,7 @@ si = mkSmithEtAlICO
   [purp] [] [] []
   [] [] dataDefs []
   htInputs htOutputs ([] :: [ConstrConcept]) [] symbols
-  [] symbMap []
+  symbMap []
 
 mkSRS :: SRSDecl
 mkSRS = [TableOfContents,

--- a/code/drasil-example/pdcontroller/lib/Drasil/PDController/Body.hs
+++ b/code/drasil-example/pdcontroller/lib/Drasil/PDController/Body.hs
@@ -87,7 +87,7 @@ si = mkSmithEtAlICO
   [purp] [background] [scope] [motivation]
   theoreticalModels genDefns dataDefinitions instanceModels
   inputs outputs (map cnstrw' inpConstrained) pidConstants allSymbols
-  labelledContent' symbMap allRefs
+  symbMap allRefs
 
 purp :: Sentence
 purp = foldlSent_ [S "provide a model" `S.ofA` phrase pidC,

--- a/code/drasil-example/projectile/lib/Drasil/Projectile/Body.hs
+++ b/code/drasil-example/projectile/lib/Drasil/Projectile/Body.hs
@@ -129,7 +129,7 @@ si = mkSmithEtAlICO progName
   [purp] [background] [scope] [motivation]
   tMods genDefns dataDefs iMods
   inputs outputs (map cnstrw' constrained) constants symbols
-  labelledContent' symbMap allRefs
+  symbMap allRefs
 
 labelledContent' :: [LabelledContent]
 labelledContent' = labelledContent ++ funcReqsTables

--- a/code/drasil-example/sglpend/lib/Drasil/SglPend/Body.hs
+++ b/code/drasil-example/sglpend/lib/Drasil/SglPend/Body.hs
@@ -90,7 +90,7 @@ si = mkSmithEtAlICO progName [olu]
   [purp] [] [] []
   tMods genDefns dataDefs iMods
   inputs outputs inConstraints [] allSymbols
-  labelledContent' symbMap allRefs
+  symbMap allRefs
 
 purp :: Sentence
 purp = foldlSent_ [S "predict the", phrase motion `S.ofA` S "single", phrase pendulum]

--- a/code/drasil-example/ssp/lib/Drasil/SSP/Body.hs
+++ b/code/drasil-example/ssp/lib/Drasil/SSP/Body.hs
@@ -63,7 +63,7 @@ si = mkSmithEtAlICO
   [purp] [] [] []
   tMods generalDefinitions dataDefs iMods
   inputs outputs constrained [] symbols
-  labCon symbMap allRefs
+  symbMap allRefs
 
 mkSRS :: SRSDecl
 mkSRS = [TableOfContents,

--- a/code/drasil-example/swhs/lib/Drasil/SWHS/Body.hs
+++ b/code/drasil-example/swhs/lib/Drasil/SWHS/Body.hs
@@ -65,7 +65,7 @@ si = mkSmithEtAlICO
   [purp] [] [scope] [motivation]
   tMods genDefs SWHS.dataDefs iMods
   inputs outputs constrained specParamValList symbols
-  labelledContent' symbMap allRefs
+  symbMap allRefs
 
 purp :: Sentence
 purp = foldlSent_ [S "investigate the effect" `S.of_` S "employing",

--- a/code/drasil-example/swhsnopcm/lib/Drasil/SWHSNoPCM/Body.hs
+++ b/code/drasil-example/swhsnopcm/lib/Drasil/SWHSNoPCM/Body.hs
@@ -145,7 +145,7 @@ si = mkSmithEtAlICO
   tMods genDefs NoPCM.dataDefs NoPCM.iMods
   inputs outputs
   (map cnstrw' constrained ++ map cnstrw' [tempW, watE]) (piConst : specParamValList) symbols
-  labelledContent' symbMap allRefs
+  symbMap allRefs
 
 purp :: Sentence
 purp = foldlSent_ [S "investigate the heating" `S.of_` D.toSent (phraseNP (water `inA` sWHT))]

--- a/code/drasil-example/template/lib/Drasil/Template/Body.hs
+++ b/code/drasil-example/template/lib/Drasil/Template/Body.hs
@@ -113,7 +113,7 @@ si = mkSmithEtAlICO
   ([] :: [TheoryModel]) ([] :: [GenDefn]) dataDefs ([] :: [InstanceModel])
   inputs outputs
   ([] :: [ConstrConcept]) ([] :: [ConstQDef]) symbols
-  [] symbMap []
+  symbMap []
 
 symbols :: [DefinedQuantityDict]
 symbols = NE.toList $ inputs <> outputs

--- a/code/drasil-srs/lib/Drasil/SRS/DocumentLanguage.hs
+++ b/code/drasil-srs/lib/Drasil/SRS/DocumentLanguage.hs
@@ -128,8 +128,7 @@ buildTraceMaps sd si
         -- later generation pipeline that produces the ".dot" files for which
         -- the main Drasil Makefile converts to SVGs (via `make tracegraphs`).
         tdb = generateTraceMap sd
-    in set lbldCntnt (si ^. lbldCntnt ++ tglcs)
-     $ set systemdb (insertAll tglcs db)
+    in set systemdb (insertAll tglcs db)
      $ set traceTable tdb
      $ set refbyTable (invert tdb) si
   | otherwise = si
@@ -152,14 +151,13 @@ fillReferences allSections cites si = si2
     gdefs   = si ^. genDefns
     imods   = si ^. instModels
     tmods   = si ^. theoryModels
-    lblCon  = si ^. lbldCntnt
     concIns = findAllConcInsts chkdb
     newRefs = M.fromList $ map (\x -> (x ^. uid, x)) $ refsFromSRS
       ++ map (ref . makeTabRef' . getTraceConfigUID) (traceMatStandard si)
       ++ secRefs -- secRefs can be removed once #946 is complete
       ++ traceyGraphGetRefs ++ map ref cites
       ++ map ref ddefs ++ map ref gdefs ++ map ref imods
-      ++ map ref tmods ++ map ref concIns ++ map ref lblCon
+      ++ map ref tmods ++ map ref concIns
     si2 = set refTable (M.union (si ^. refTable) newRefs) si
 
 -- | Recursively find all references in a section (meant for getting at 'LabelledContent').

--- a/code/drasil-srs/lib/Drasil/SRS/SmithEtAlSRS.hs
+++ b/code/drasil-srs/lib/Drasil/SRS/SmithEtAlSRS.hs
@@ -26,7 +26,7 @@ import Data.Maybe (fromMaybe)
 import Drasil.Database (UID, HasUID(..), ChunkDB)
 import Language.Drasil (Quantity, MayHaveUnit, Concept, People, CI,
   Constrained, ConstQDef, abrv, DefinedQuantityDict)
-import Language.Drasil.Document (LabelledContent, Reference)
+import Language.Drasil.Document (Reference)
 import Theory.Drasil (TheoryModel, GenDefn, DataDefinition, InstanceModel)
 
 import Drasil.System (SystemMeta, Background, HasSystemMeta(..),
@@ -52,12 +52,6 @@ data SmithEtAlSRS where
   -- SRS. Why is this here? For type-checking the SRS later. Should
   -- type-checking be done on the SRS level? No. This is a temporary hack.
   , _quantities   :: [DefinedQuantityDict]
-  -- FIXME: This is a list of all labelled content required for the SRS to be
-  -- generated. In particular, this is needed for the mdBook generator which
-  -- _must_ export a CSV containing a list of all external resources that the
-  -- mdBook compiler is allowed to access. This list should be re-written as
-  -- part of a stateful renderer for the SRS instead.
-  , _lbldCntnt    :: [LabelledContent]
   -- FIXME: Hacks to be removed once 'Reference's are rebuilt.
   , _refTable     :: M.Map UID Reference
   , _refbyTable   :: M.Map UID [UID]
@@ -76,10 +70,10 @@ mkSmithEtAlICO :: (Quantity h, MayHaveUnit h, Concept h,
   CI -> People -> Purpose -> Background -> Scope -> Motivation ->
     [TheoryModel] -> [GenDefn] -> [DataDefinition] -> [InstanceModel] ->
     NE.NonEmpty h -> NE.NonEmpty i -> [j] -> [ConstQDef] -> [DefinedQuantityDict] ->
-    [LabelledContent] -> ChunkDB -> [Reference] -> SmithEtAlSRS
-mkSmithEtAlICO nm ppl prps bkgrd scp motive tms gds dds ims hs is js cqds qs lcs db refs
+    ChunkDB -> [Reference] -> SmithEtAlSRS
+mkSmithEtAlICO nm ppl prps bkgrd scp motive tms gds dds ims hs is js cqds qs db refs
   = ICO (mkSystemMeta nm ppl prps bkgrd scp motive db) progName tms gds dds ims hs is js
-      cqds qs lcs refsMap mempty mempty
+      cqds qs refsMap mempty mempty
   where
     refsMap = M.fromList $ map (\x -> (x ^. uid, x)) refs
     progName = filter (not . isSpace) $ abrv nm


### PR DESCRIPTION
#4972 looks like it did a bit more than we expected. When I rewrote how `LabelledContent` were gathered for the mdbook renderer (for it to know which files it needed to copy over for the mdbook compiler), I didn't realize that the `_lbldCntnt` field was otherwise unnecessary.