### PR TITLE
refactor: move `Reference` 'extractor' from `drasil-srs` to `drasil-lang`'s `.Document.Extract` module and move `UnitDefn` extractor within `drasil-srs`

### DIFF
--- a/code/drasil-lang/lib/Language/Drasil/Document/Extractors.hs
+++ b/code/drasil-lang/lib/Language/Drasil/Document/Extractors.hs
@@ -4,7 +4,8 @@ module Language.Drasil.Document.Extractors (
   extractChRefs,
   getSec,
   extractSectionsBib,
-  resolveBibliography
+  resolveBibliography,
+  extractRefs
 ) where
 
 import Control.Lens ((^.))
@@ -13,10 +14,14 @@ import Data.Maybe (mapMaybe)
 import qualified Data.Set as S
 
 import Drasil.Database (UID, ChunkDB, find)
-import Language.Drasil hiding (getCitations, Manual, Verb)
+import Language.Drasil.Chunk.Citation (Citation, BibRef)
+import Language.Drasil.Data.Citation (compareAuthYearTitle)
+import Language.Drasil.Development (lnames)
 import Language.Drasil.Document.Core
 import Language.Drasil.Document.Sections
-import Language.Drasil.Development (lnames)
+import Language.Drasil.Document.Reference
+import Language.Drasil.ModelExpr.Lang (ModelExpr)
+import Language.Drasil.Sentence (Sentence(..), eS, eS')
 
 -- | Extracts all referenced 'UID's from things that have 'RawContent's.
 extractChRefs :: HasContents a => [a] -> S.Set UID
@@ -107,3 +112,12 @@ resolveBibliography :: ChunkDB -> S.Set UID -> [Citation]
 resolveBibliography db uids = sortBy compareAuthYearTitle cites
   where
     cites = mapMaybe (`find` db) (S.toList uids)
+
+-- | Recursively find all references in a section (meant for getting at 'LabelledContent').
+extractRefs :: Section -> [Reference]
+extractRefs (Section _ cs r) = r : concatMap findRefSecCons cs
+  where
+    findRefSecCons :: SecCons -> [Reference]
+    findRefSecCons (Sub s) = extractRefs s
+    findRefSecCons (Con (LlC (LblC _ rf _))) = [rf]
+    findRefSecCons _ = []

--- a/code/drasil-lang/lib/Language/Drasil/Document/Extractors.hs
+++ b/code/drasil-lang/lib/Language/Drasil/Document/Extractors.hs
@@ -5,7 +5,7 @@ module Language.Drasil.Document.Extractors (
   getSec,
   extractSectionsBib,
   resolveBibliography,
-  extractRefs
+  extractLCRefs
 ) where
 
 import Control.Lens ((^.))
@@ -114,10 +114,10 @@ resolveBibliography db uids = sortBy compareAuthYearTitle cites
     cites = mapMaybe (`find` db) (S.toList uids)
 
 -- | Recursively find all references in a section (meant for getting at 'LabelledContent').
-extractRefs :: Section -> [Reference]
-extractRefs (Section _ cs r) = r : concatMap findRefSecCons cs
+extractLCRefs :: Section -> [Reference]
+extractLCRefs (Section _ cs r) = r : concatMap findRefSecCons cs
   where
     findRefSecCons :: SecCons -> [Reference]
-    findRefSecCons (Sub s) = extractRefs s
+    findRefSecCons (Sub s) = extractLCRefs s
     findRefSecCons (Con (LlC (LblC _ rf _))) = [rf]
     findRefSecCons _ = []

--- a/code/drasil-srs/lib/Drasil/SRS.hs
+++ b/code/drasil-srs/lib/Drasil/SRS.hs
@@ -18,7 +18,7 @@ module Drasil.SRS (
   TConvention(..), TraceabilitySec(TraceabilityProg), TSIntro(..), TUIntro(..),
   -- *** Functions
   -- Drasil.DocumentLanguage
-  mkDoc, findAllRefs,
+  mkDoc,
   -- * Subsection Functions
   -- ** Definitions and Models
   -- Drasil.DocumentLanguage.Definitions
@@ -60,7 +60,7 @@ module Drasil.SRS (
 import Drasil.SRS.DocDecl (SRSDecl, DocSection(..), ReqrmntSec(..), ReqsSub(..),
   PDSub(..), ProblemDescription(..), SSDSec(..), SSDSub(..), SCSSub(..),
   SolChSpec(..))
-import Drasil.SRS.DocumentLanguage (mkDoc, findAllRefs)
+import Drasil.SRS.DocumentLanguage (mkDoc)
 import Drasil.SRS.DocumentLanguage.Core (AppndxSec(..), AuxConstntSec(..),
   DerivationDisplay(..), DocDesc, Emphasis(..), OffShelfSolnsSec(..), GSDSec(..),
   GSDSub(UsrChars, SystCons, SysCntxt), IntroSec(..), IntroSub(..), LFunc(..),

--- a/code/drasil-srs/lib/Drasil/SRS/DocumentLanguage.hs
+++ b/code/drasil-srs/lib/Drasil/SRS/DocumentLanguage.hs
@@ -145,7 +145,7 @@ fillReferences allSections cites si = si2
     -- get old chunk database + ref database
     chkdb = si ^. systemdb
     -- get refs from SRSDecl. Should include all section labels and labelled content.
-    refsFromSRS = concatMap extractRefs allSections
+    refsFromSRS = concatMap extractLCRefs allSections
     -- get refs from the stuff already inside the chunk database
     ddefs   = si ^. dataDefns
     gdefs   = si ^. genDefns

--- a/code/drasil-srs/lib/Drasil/SRS/DocumentLanguage.hs
+++ b/code/drasil-srs/lib/Drasil/SRS/DocumentLanguage.hs
@@ -5,7 +5,7 @@
 -- Over time, we'll want to have a cleaner separation, but doing that
 -- all at once would break too much for too long.  So we start here
 -- instead.
-module Drasil.SRS.DocumentLanguage (mkDoc, findAllRefs) where
+module Drasil.SRS.DocumentLanguage (mkDoc) where
 
 -- General Haskell
 import Control.Lens ((^.), set)
@@ -145,7 +145,7 @@ fillReferences allSections cites si = si2
     -- get old chunk database + ref database
     chkdb = si ^. systemdb
     -- get refs from SRSDecl. Should include all section labels and labelled content.
-    refsFromSRS = concatMap findAllRefs allSections
+    refsFromSRS = concatMap extractRefs allSections
     -- get refs from the stuff already inside the chunk database
     ddefs   = si ^. dataDefns
     gdefs   = si ^. genDefns
@@ -159,15 +159,6 @@ fillReferences allSections cites si = si2
       ++ map ref ddefs ++ map ref gdefs ++ map ref imods
       ++ map ref tmods ++ map ref concIns
     si2 = set refTable (M.union (si ^. refTable) newRefs) si
-
--- | Recursively find all references in a section (meant for getting at 'LabelledContent').
-findAllRefs :: Section -> [Reference]
-findAllRefs (Section _ cs r) = r : concatMap findRefSecCons cs
-  where
-    findRefSecCons :: SecCons -> [Reference]
-    findRefSecCons (Sub s) = findAllRefs s
-    findRefSecCons (Con (LlC (LblC _ rf _))) = [rf]
-    findRefSecCons _ = []
 
 -- | Constructs the unit definitions ('UnitDefn's) found in the document description ('DocDesc') from a database ('ChunkDB').
 extractUnits :: DocDesc -> ChunkDB -> [UnitDefn]

--- a/code/drasil-srs/lib/Drasil/SRS/DocumentLanguage.hs
+++ b/code/drasil-srs/lib/Drasil/SRS/DocumentLanguage.hs
@@ -12,7 +12,7 @@ import Control.Lens ((^.), set)
 import Data.Either (rights)
 import Data.Function (on)
 import Data.List (nub, sortBy, (\\))
-import Data.Maybe (maybeToList, mapMaybe, isJust, fromMaybe)
+import Data.Maybe (maybeToList, isJust, fromMaybe)
 import qualified Data.Map as Map (keys)
 import qualified Data.Set as Set
 import qualified Data.Map.Strict as M
@@ -23,7 +23,7 @@ import Language.Drasil.Document
 import Language.Drasil.Display (compsy)
 import Language.Drasil.Development (shortdep)
 
-import Drasil.Database (findOrErr, ChunkDB, insertAll, UID, HasUID(..), invert)
+import Drasil.Database (ChunkDB, insertAll, UID, HasUID(..), invert)
 import Drasil.Database.SearchTools (findAllConcInsts,
   TermAbbr, shortForm, termResolve')
 
@@ -48,7 +48,7 @@ import Drasil.SRS.DocumentLanguage.Core (AppndxSec(..), AuxConstntSec(..),
   TSIntro(..), UCsSec(..), getTraceConfigUID)
 import Drasil.SRS.DocumentLanguage.Definitions (ddefn, derivation, instanceModel,
   gdefn, tmodel)
-import Drasil.SRS.ExtractDocDesc (getDocDesc, egetDocDesc)
+import Drasil.SRS.ExtractDocDesc (getDocDesc, egetDocDesc, extractUnits)
 import Drasil.SRS.TraceTable (generateTraceMap)
 
 import Drasil.SRS.Sections.TableOfAbbAndAcronyms (tableAbbAccGen)
@@ -159,18 +159,6 @@ fillReferences allSections cites si = si2
       ++ map ref ddefs ++ map ref gdefs ++ map ref imods
       ++ map ref tmods ++ map ref concIns
     si2 = set refTable (M.union (si ^. refTable) newRefs) si
-
--- | Constructs the unit definitions ('UnitDefn's) found in the document description ('DocDesc') from a database ('ChunkDB').
-extractUnits :: DocDesc -> ChunkDB -> [UnitDefn]
-extractUnits dd cdb = collectUnitDeps cdb $ resolveAllVars (getDocDesc dd) (egetDocDesc dd) cdb
-
--- | For a given list of 'Quantity's, collects the 'UnitDefn's dependencies of
--- their units (i.e., what units their units are defined with).
-collectUnitDeps :: Quantity c => ChunkDB -> [c] -> [UnitDefn]
-collectUnitDeps db = map (`findOrErr` db) . concatMap getUnits . mapMaybe (getUnitLup db)
-
-getUnitLup :: HasUID c => ChunkDB -> c -> Maybe UnitDefn
-getUnitLup m c = getUnit (findOrErr (c ^. uid) m :: DefinedQuantityDict)
 
 -- * Section Creator Functions
 

--- a/code/drasil-srs/lib/Drasil/SRS/ExtractDocDesc.hs
+++ b/code/drasil-srs/lib/Drasil/SRS/ExtractDocDesc.hs
@@ -3,21 +3,24 @@
 -- Mainly used to pull the 'UID's of chunks out of 'Sentence's and 'Expr's.
 module Drasil.SRS.ExtractDocDesc (
   getDocDesc, egetDocDesc,
-  sentencePlate
+  sentencePlate,
+  extractUnits
 ) where
 
 import Control.Lens((^.))
 import Data.Functor.Constant (Constant(Constant))
 import Data.Generics.Multiplate (appendPlate, foldFor, purePlate, preorderFold)
-import Data.Maybe (maybeToList)
+import Data.Maybe (maybeToList, mapMaybe)
 
-import Language.Drasil (Sentence, Definition(..), ModelExpr,
-  HasAdditionalNotes(..), Express(express))
+import Drasil.Database (ChunkDB, HasUID (..), findOrErr)
+import Language.Drasil (Sentence, Definition(..), ModelExpr, HasAdditionalNotes(..),
+  Express(express), DefinedQuantityDict, UnitDefn, Quantity, MayHaveUnit(..), IsUnit(..))
 import Language.Drasil.Document (HasContents, Section(Section), SecCons(..),
   sentToExp, extractSents, extractSents', extractMExprs, getSec)
 import Theory.Drasil (Derivation(..), MayHaveDerivation(..))
 
 import Drasil.SRS.DocumentLanguage.Core
+import Drasil.SRS.GetChunks (resolveAllVars)
 import Drasil.SRS.Sections.SpecificSystemDescription (inDataConstTbl, outDataConstTbl)
 
 -- | Creates a section contents plate that contains diferrent system subsections.
@@ -147,3 +150,15 @@ getDocDesc = fmGetDocDesc (sentencePlate id)
 -- description), so we use this function. But 'sentencePlate' does not include
 -- all 'Sentence's! Some only appear when rendering (at least, after
 -- `mkSections` is used on a `DocDesc` to create `[Section]`).
+
+-- | Constructs the unit definitions ('UnitDefn's) found in the document description ('DocDesc') from a database ('ChunkDB').
+extractUnits :: DocDesc -> ChunkDB -> [UnitDefn]
+extractUnits dd cdb = collectUnitDeps cdb $ resolveAllVars (getDocDesc dd) (egetDocDesc dd) cdb
+
+-- | For a given list of 'Quantity's, collects the 'UnitDefn's dependencies of
+-- their units (i.e., what units their units are defined with).
+collectUnitDeps :: Quantity c => ChunkDB -> [c] -> [UnitDefn]
+collectUnitDeps db = map (`findOrErr` db) . concatMap getUnits . mapMaybe (getUnitLup db)
+
+getUnitLup :: HasUID c => ChunkDB -> c -> Maybe UnitDefn
+getUnitLup m c = getUnit (findOrErr (c ^. uid) m :: DefinedQuantityDict)

--- a/code/drasil-website/lib/Drasil/Website/Body.hs
+++ b/code/drasil-website/lib/Drasil/Website/Body.hs
@@ -12,7 +12,6 @@ import Drasil.System (HasSystemMeta(..), mkSystemMeta)
 import Drasil.Website.Core (DrasilWebsite, mkDrasilWebsite)
 import Language.Drasil
 import Language.Drasil.Document
-import Drasil.SRS (findAllRefs)
 
 import Drasil.Website.Introduction (introSec)
 import Drasil.Website.About (aboutSec)
@@ -92,7 +91,7 @@ allRefs fl = [gitHubRef, wikiRef, infoEncodingWiki, chunksWiki, recipesWiki, pap
   ++ exampleRefs (repoRt fl) (exRt fl)
   ++ docRefs (docsRt fl)
   ++ analysisRefs (analysisRt fl) (typeGraphFolder fl) (classInstFolder fl) (graphRt fl) (packages fl)
-  ++ concatMap findAllRefs (sections fl)
+  ++ concatMap extractRefs (sections fl)
 
 -- | Used for system name and kind inside of 'si'.
 webName :: CI

--- a/code/drasil-website/lib/Drasil/Website/Body.hs
+++ b/code/drasil-website/lib/Drasil/Website/Body.hs
@@ -91,7 +91,7 @@ allRefs fl = [gitHubRef, wikiRef, infoEncodingWiki, chunksWiki, recipesWiki, pap
   ++ exampleRefs (repoRt fl) (exRt fl)
   ++ docRefs (docsRt fl)
   ++ analysisRefs (analysisRt fl) (typeGraphFolder fl) (classInstFolder fl) (graphRt fl) (packages fl)
-  ++ concatMap extractRefs (sections fl)
+  ++ concatMap extractLCRefs (sections fl)
 
 -- | Used for system name and kind inside of 'si'.
 webName :: CI


### PR DESCRIPTION
Builds on #5301

From `drasil-srs/../DocumentLanguage.hs`:

1. Moves `findAllRefs` to `drasil-lang`'s `.Document.Extractors` module (because that's where the generic 'extractors' belong). Also renames it to `extractLCRefs`.
2. Moves `extractUnits` to `ExtractDocDesc.hs` (because that's where the `DocDesc`-related chunk 'extractors' belong).