### PR TITLE
Switched `Method` from type family to parameter with fundep

### DIFF
--- a/code/drasil-code/lib/Language/Drasil/Code/Imperative/GenerateGOOL.hs
+++ b/code/drasil-code/lib/Language/Drasil/Code/Imperative/GenerateGOOL.hs
@@ -24,11 +24,11 @@ import Language.Drasil.Mod (Name, Description, Import)
 import Drasil.Metadata (watermark)
 import Drasil.System (HasSystemMeta(..), HasSmithEtAlSRS(..))
 
-import Drasil.GOOL (SVariable, SValue, SMethod, CSStateVar, SClass, NamedArgs,
+import Drasil.GOOL (SVariable, SValue, CSStateVar, SClass, NamedArgs,
   OOProg, MS, VS, TypeData, ValueSym(..), Argument(..), ValueExpression(..),
   OOValueExpression(..), SelfSym(..), VariableValue(..), FuncAppStatement(..),
-  OOFuncAppStatement(..), ClassSym(..), CodeType(..), TypeElim(..),
-  objMethodCallMixedArgs, OOStatement)
+  OOFuncAppStatement(..), ClassSym(..), MethodSym(..), CodeType(..),
+  TypeElim(..), objMethodCallMixedArgs, OOStatement)
 import qualified Drasil.GOOL as OO (SFile, FileSym(..), ModuleSym(..))
 
 -- | Defines a GOOL module. If the user chose 'CommentMod', the module will have
@@ -37,7 +37,7 @@ import qualified Drasil.GOOL as OO (SFile, FileSym(..), ModuleSym(..))
 -- documents the file name, because without this Doxygen will not find the
 -- function-level comments in the file.
 genModuleWithImports :: (OOProg r vis smt) => Name -> Description ->
-  [Import] -> [GenState (Maybe (SMethod r))] -> [GenState (Maybe (SClass r))] ->
+  [Import] -> [GenState (Maybe (MS (r (Method r))))] -> [GenState (Maybe (SClass r))] ->
   GenState (OO.SFile r)
 genModuleWithImports n desc is maybeMs maybeCs = do
   g <- get
@@ -52,7 +52,7 @@ genModuleWithImports n desc is maybeMs maybeCs = do
 
 -- | Generates a module for when imports do not need to be explicitly stated.
 genModule :: (OOProg r vis smt) => Name -> Description ->
-  [GenState (Maybe (SMethod r))] -> [GenState (Maybe (SClass r))] ->
+  [GenState (Maybe (MS (r (Method r))))] -> [GenState (Maybe (SClass r))] ->
   GenState (OO.SFile r)
 genModule n desc = genModuleWithImports n desc []
 
@@ -83,8 +83,8 @@ data ClassType = Primary | Auxiliary
 -- state variables, and methods. The 'Maybe' 'Name' parameter is the name of the
 -- interface the class implements, if applicable.
 mkClass :: (ClassSym r vis smt) => ClassType -> Name -> Maybe Name ->
-  Description -> [CSStateVar r] -> GenState [SMethod r] ->
-    GenState [SMethod r] -> GenState (SClass r)
+  Description -> [CSStateVar r] -> GenState [MS (r (Method r))] ->
+    GenState [MS (r (Method r))] -> GenState (SClass r)
 mkClass s n l desc vs cstrs mths = do
   g <- get
   modify (\ds -> ds {currentClass = n})
@@ -102,13 +102,13 @@ mkClass s n l desc vs cstrs mths = do
 
 -- | Generates a primary class.
 primaryClass :: (ClassSym r vis smt) => Name -> Maybe Name -> Description ->
-  [CSStateVar r] -> GenState [SMethod r] -> GenState [SMethod r] ->
+  [CSStateVar r] -> GenState [MS (r (Method r))] -> GenState [MS (r (Method r))] ->
   GenState (SClass r)
 primaryClass = mkClass Primary
 
 -- | Generates an auxiliary class (for when a module contains multiple classes).
 auxClass :: (ClassSym r vis smt) => Name -> Maybe Name -> Description ->
-  [CSStateVar r] -> GenState [SMethod r] -> GenState [SMethod r] ->
+  [CSStateVar r] -> GenState [MS (r (Method r))] -> GenState [MS (r (Method r))] ->
   GenState (SClass r)
 auxClass = mkClass Auxiliary
 
@@ -178,7 +178,7 @@ fAppInOut m n ins outs both = do
 -- documents the file name, because without this Doxygen will not find the
 -- function-level comments in the file.
 genModuleWithImportsProc :: (ProcProg r vis smt) => Name -> Description ->
-  [Import] -> [GenState (Maybe (SMethod r))] -> GenState (Proc.SFile r)
+  [Import] -> [GenState (Maybe (MS (r (Method r))))] -> GenState (Proc.SFile r)
 genModuleWithImportsProc n desc is maybeMs = do
   g <- get
   modify (\s -> s { currentModule = n })
@@ -191,7 +191,7 @@ genModuleWithImportsProc n desc is maybeMs = do
 
 -- | Generates a module for when imports do not need to be explicitly stated.
 genModuleProc :: (ProcProg r vis smt) => Name -> Description ->
-  [GenState (Maybe (SMethod r))] -> GenState (Proc.SFile r)
+  [GenState (Maybe (MS (r (Method r))))] -> GenState (Proc.SFile r)
 genModuleProc n desc = genModuleWithImportsProc n desc []
 
 -- | Function call generator.

--- a/code/drasil-code/lib/Language/Drasil/Code/Imperative/GenerateGOOL.hs
+++ b/code/drasil-code/lib/Language/Drasil/Code/Imperative/GenerateGOOL.hs
@@ -27,8 +27,8 @@ import Drasil.System (HasSystemMeta(..), HasSmithEtAlSRS(..))
 import Drasil.GOOL (SVariable, SValue, CSStateVar, SClass, NamedArgs,
   OOProg, MS, VS, TypeData, ValueSym(..), Argument(..), ValueExpression(..),
   OOValueExpression(..), SelfSym(..), VariableValue(..), FuncAppStatement(..),
-  OOFuncAppStatement(..), ClassSym(..), MethodSym(..), CodeType(..),
-  TypeElim(..), objMethodCallMixedArgs, OOStatement)
+  OOFuncAppStatement(..), ClassSym(..), CodeType(..), TypeElim(..),
+  objMethodCallMixedArgs, OOStatement)
 import qualified Drasil.GOOL as OO (SFile, FileSym(..), ModuleSym(..))
 
 -- | Defines a GOOL module. If the user chose 'CommentMod', the module will have
@@ -36,8 +36,8 @@ import qualified Drasil.GOOL as OO (SFile, FileSym(..), ModuleSym(..))
 -- 'CommentFunc', a module-level Doxygen comment is still created, though it only
 -- documents the file name, because without this Doxygen will not find the
 -- function-level comments in the file.
-genModuleWithImports :: (OOProg r vis smt) => Name -> Description ->
-  [Import] -> [GenState (Maybe (MS (r (Method r))))] -> [GenState (Maybe (SClass r))] ->
+genModuleWithImports :: (OOProg r vis smt md) => Name -> Description ->
+  [Import] -> [GenState (Maybe (MS (r md)))] -> [GenState (Maybe (SClass r))] ->
   GenState (OO.SFile r)
 genModuleWithImports n desc is maybeMs maybeCs = do
   g <- get
@@ -51,8 +51,8 @@ genModuleWithImports n desc is maybeMs maybeCs = do
   return $ commMod $ OO.fileDoc $ OO.buildModule n is (catMaybes ms) (catMaybes cs)
 
 -- | Generates a module for when imports do not need to be explicitly stated.
-genModule :: (OOProg r vis smt) => Name -> Description ->
-  [GenState (Maybe (MS (r (Method r))))] -> [GenState (Maybe (SClass r))] ->
+genModule :: (OOProg r vis smt md) => Name -> Description ->
+  [GenState (Maybe (MS (r md)))] -> [GenState (Maybe (SClass r))] ->
   GenState (OO.SFile r)
 genModule n desc = genModuleWithImports n desc []
 
@@ -82,9 +82,9 @@ data ClassType = Primary | Auxiliary
 -- | Generates a primary or auxiliary class with the given name, description,
 -- state variables, and methods. The 'Maybe' 'Name' parameter is the name of the
 -- interface the class implements, if applicable.
-mkClass :: (ClassSym r vis smt) => ClassType -> Name -> Maybe Name ->
-  Description -> [CSStateVar r] -> GenState [MS (r (Method r))] ->
-    GenState [MS (r (Method r))] -> GenState (SClass r)
+mkClass :: (ClassSym r vis smt md) => ClassType -> Name -> Maybe Name ->
+  Description -> [CSStateVar r] -> GenState [MS (r md)] ->
+    GenState [MS (r md)] -> GenState (SClass r)
 mkClass s n l desc vs cstrs mths = do
   g <- get
   modify (\ds -> ds {currentClass = n})
@@ -101,14 +101,14 @@ mkClass s n l desc vs cstrs mths = do
     else c
 
 -- | Generates a primary class.
-primaryClass :: (ClassSym r vis smt) => Name -> Maybe Name -> Description ->
-  [CSStateVar r] -> GenState [MS (r (Method r))] -> GenState [MS (r (Method r))] ->
+primaryClass :: (ClassSym r vis smt md) => Name -> Maybe Name -> Description ->
+  [CSStateVar r] -> GenState [MS (r md)] -> GenState [MS (r md)] ->
   GenState (SClass r)
 primaryClass = mkClass Primary
 
 -- | Generates an auxiliary class (for when a module contains multiple classes).
-auxClass :: (ClassSym r vis smt) => Name -> Maybe Name -> Description ->
-  [CSStateVar r] -> GenState [MS (r (Method r))] -> GenState [MS (r (Method r))] ->
+auxClass :: (ClassSym r vis smt md) => Name -> Maybe Name -> Description ->
+  [CSStateVar r] -> GenState [MS (r md)] -> GenState [MS (r md)] ->
   GenState (SClass r)
 auxClass = mkClass Auxiliary
 
@@ -177,8 +177,8 @@ fAppInOut m n ins outs both = do
 -- 'CommentFunc', a module-level Doxygen comment is still created, though it only
 -- documents the file name, because without this Doxygen will not find the
 -- function-level comments in the file.
-genModuleWithImportsProc :: (ProcProg r vis smt) => Name -> Description ->
-  [Import] -> [GenState (Maybe (MS (r (Method r))))] -> GenState (Proc.SFile r)
+genModuleWithImportsProc :: (ProcProg r vis smt md) => Name -> Description ->
+  [Import] -> [GenState (Maybe (MS (r md)))] -> GenState (Proc.SFile r)
 genModuleWithImportsProc n desc is maybeMs = do
   g <- get
   modify (\s -> s { currentModule = n })
@@ -190,8 +190,8 @@ genModuleWithImportsProc n desc is maybeMs = do
   return $ commMod $ Proc.fileDoc $ Proc.buildModule n is (catMaybes ms)
 
 -- | Generates a module for when imports do not need to be explicitly stated.
-genModuleProc :: (ProcProg r vis smt) => Name -> Description ->
-  [GenState (Maybe (MS (r (Method r))))] -> GenState (Proc.SFile r)
+genModuleProc :: (ProcProg r vis smt md) => Name -> Description ->
+  [GenState (Maybe (MS (r md)))] -> GenState (Proc.SFile r)
 genModuleProc n desc = genModuleWithImportsProc n desc []
 
 -- | Function call generator.

--- a/code/drasil-code/lib/Language/Drasil/Code/Imperative/Generator.hs
+++ b/code/drasil-code/lib/Language/Drasil/Code/Imperative/Generator.hs
@@ -119,7 +119,7 @@ generator l dt sd chs cs = let
 -- OO Versions --
 
 data SomeProgGenerator where
-  SomeProgGenerator :: forall repr vis smt. (OOProg repr vis smt) =>
+  SomeProgGenerator :: forall repr vis smt md. (OOProg repr vis smt md) =>
     (repr (OO.Program repr) -> ProgData) -> SomeProgGenerator
 
 -- | Generates a package with the given 'DrasilState'. The passed
@@ -175,7 +175,7 @@ insertFile (p, d) m =
 -- package will be generated in.
 -- GOOL's static code analysis interpreter is called to initialize the state
 -- used by the language renderer.
-genPackage :: (OOProg progRepr vis smt, SoftwareDossierSym packRepr, Monad packRepr) =>
+genPackage :: (OOProg progRepr vis smt md, SoftwareDossierSym packRepr, Monad packRepr) =>
   (progRepr (OO.Program progRepr) -> ProgData) -> GenState (packRepr PackageData)
 genPackage unRepr = do
   g <- get
@@ -215,7 +215,7 @@ genPackage unRepr = do
   return $ package pd (m:catMaybes [i,rm,d])
 
 -- | Generates an SCS program based on the problem and the user's design choices.
-genProgram :: (OOProg r vis smt) => GenState (OO.GSProgram r)
+genProgram :: (OOProg r vis smt md) => GenState (OO.GSProgram r)
 genProgram = do
   g <- get
   ms <- chooseModules $ g ^. modular
@@ -226,12 +226,12 @@ genProgram = do
 
 -- | Generates either a single module or many modules, based on the users choice
 -- of modularity.
-chooseModules :: (OOProg r vis smt) => Modularity -> GenState [OO.SFile r]
+chooseModules :: (OOProg r vis smt md) => Modularity -> GenState [OO.SFile r]
 chooseModules Unmodular = liftS genUnmodular
 chooseModules Modular = genModules
 
 -- | Generates an entire SCS program as a single module.
-genUnmodular :: (OOProg r vis smt) => GenState (OO.SFile r)
+genUnmodular :: (OOProg r vis smt md) => GenState (OO.SFile r)
 genUnmodular = do
   g <- get
   umDesc <- unmodularDesc
@@ -250,7 +250,7 @@ genUnmodular = do
       ++ map (fmap Just) (concatMap genModClasses $ modules g))
 
 -- | Generates all modules for an SCS program.
-genModules :: (OOProg r vis smt) => GenState [OO.SFile r]
+genModules :: (OOProg r vis smt md) => GenState [OO.SFile r]
 genModules = do
   g <- get
   mn     <- genMain
@@ -266,9 +266,13 @@ genModules = do
 -- | Generates a package with the given 'DrasilState'. The passed
 -- un-representation functions determine which target language the package will
 -- be generated in.
-generateCodeProc :: (ProcProg progRepr vis smt, SoftwareDossierSym packRepr, Monad packRepr) =>
-  Lang -> (progRepr (Proc.Program progRepr) -> ProgData) ->
-  (packRepr PackageData -> PackageData) -> DrasilState -> FileLayout
+generateCodeProc
+  :: (ProcProg progRepr vis smt md, SoftwareDossierSym packRepr, Monad packRepr)
+  => Lang
+  -> (progRepr (Proc.Program progRepr) -> ProgData)
+  -> (packRepr PackageData -> PackageData)
+  -> DrasilState
+  -> FileLayout
 generateCodeProc l unReprProg unReprPack g =
   let dirName = getDir l
       (pckg, ds) = runState (genPackageProc unReprProg) g
@@ -288,9 +292,10 @@ generateCodeProc l unReprProg unReprPack g =
 -- package will be generated in.
 -- GOOL's static code analysis interpreter is called to initialize the state
 -- used by the language renderer.
-genPackageProc :: (ProcProg progRepr vis smt, SoftwareDossierSym packRepr, Monad packRepr) =>
-  (progRepr (Proc.Program progRepr) -> ProgData) ->
-  GenState (packRepr PackageData)
+genPackageProc
+  :: (ProcProg progRepr vis smt md, SoftwareDossierSym packRepr, Monad packRepr)
+  => (progRepr (Proc.Program progRepr) -> ProgData)
+  -> GenState (packRepr PackageData)
 genPackageProc unRepr = do
   g <- get
   p <- genProgramProc
@@ -326,7 +331,7 @@ genPackageProc unRepr = do
   return $ package pd (m:catMaybes [i,rm,d])
 
 -- | Generates an SCS program based on the problem and the user's design choices.
-genProgramProc :: (ProcProg r vis smt) => GenState (Proc.GSProgram r)
+genProgramProc :: (ProcProg r vis smt md) => GenState (Proc.GSProgram r)
 genProgramProc = do
   g <- get
   ms <- chooseModulesProc $ g ^. modular
@@ -336,12 +341,14 @@ genProgramProc = do
 
 -- | Generates either a single module or many modules, based on the users choice
 -- of modularity.
-chooseModulesProc :: (ProcProg r vis smt) => Modularity -> GenState [Proc.SFile r]
+chooseModulesProc
+  :: (ProcProg r vis smt md)
+  => Modularity -> GenState [Proc.SFile r]
 chooseModulesProc Unmodular = liftS genUnmodularProc
 chooseModulesProc Modular = genModulesProc
 
 -- | Generates an entire SCS program as a single module.
-genUnmodularProc :: (ProcProg r vis smt) => GenState (Proc.SFile r)
+genUnmodularProc :: (ProcProg r vis smt md) => GenState (Proc.SFile r)
 genUnmodularProc = do
   g <- get
   umDesc <- unmodularDesc
@@ -359,7 +366,7 @@ genUnmodularProc = do
               genInputConstraintsProc Pub] ++ [genOutputFormatProc]))
 
 -- | Generates all modules for an SCS program.
-genModulesProc :: (ProcProg r vis smt) => GenState [Proc.SFile r]
+genModulesProc :: (ProcProg r vis smt md) => GenState [Proc.SFile r]
 genModulesProc = do
   g <- get
   mn     <- genMainProc

--- a/code/drasil-code/lib/Language/Drasil/Code/Imperative/Import.hs
+++ b/code/drasil-code/lib/Language/Drasil/Code/Imperative/Import.hs
@@ -219,47 +219,47 @@ mkParam p = do
         paramFunc Val = param
 
 -- | Generates a public function.
-publicFunc :: (OOProg r vis smt) => Label -> VS (r TypeData) -> Description ->
+publicFunc :: (OOProg r vis smt md) => Label -> VS (r TypeData) -> Description ->
   [ParameterChunk] -> Maybe Description -> [MSBlock r] ->
-  GenState (MS (r (Method r)))
+  GenState (MS (r md))
 publicFunc n t desc ps r b = do
   modify (\st -> st {currentScope = Local})
   genMethod (function n public t) n desc ps r b
 
 -- | Generates a public method.
-publicMethod :: (OOProg r vis smt) => Label -> VS (r TypeData) -> Description ->
+publicMethod :: (OOProg r vis smt md) => Label -> VS (r TypeData) -> Description ->
   [ParameterChunk] -> Maybe Description -> [MSBlock r] ->
-  GenState (MS (r (Method r)))
+  GenState (MS (r md))
 publicMethod n t = do
   genMethod (method n public instanceLevel t) n
 
 -- | Generates a private method.
-privateMethod :: (OOProg r vis smt) => Label -> VS (r TypeData) -> Description ->
+privateMethod :: (OOProg r vis smt md) => Label -> VS (r TypeData) -> Description ->
   [ParameterChunk] -> Maybe Description -> [MSBlock r] ->
-  GenState (MS (r (Method r)))
+  GenState (MS (r md))
 privateMethod n t = do
   genMethod (method n private instanceLevel t) n
 
 -- | Generates a public function, defined by its inputs and outputs.
-publicInOutFunc :: (OOProg r vis smt) => Label -> Description -> [CodeVarChunk] ->
-  [CodeVarChunk] -> [MSBlock r] -> GenState (MS (r (Method r)))
+publicInOutFunc :: (OOProg r vis smt md) => Label -> Description -> [CodeVarChunk] ->
+  [CodeVarChunk] -> [MSBlock r] -> GenState (MS (r md))
 publicInOutFunc n = genInOutFunc (inOutFunc n public) (docInOutFunc n public) n
 
 -- | Generates a private method, defined by its inputs and outputs.
-privateInOutMethod :: (OOProg r vis smt) => Label -> Description -> [CodeVarChunk] ->
-  [CodeVarChunk] -> [MSBlock r] -> GenState (MS (r (Method r)))
+privateInOutMethod :: (OOProg r vis smt md) => Label -> Description -> [CodeVarChunk] ->
+  [CodeVarChunk] -> [MSBlock r] -> GenState (MS (r md))
 privateInOutMethod n = genInOutFunc (inOutMethod n private instanceLevel)
   (docInOutMethod n private instanceLevel) n
 
 -- | Generates a constructor.
-genConstructor :: (OOProg r vis smt) => Label -> Description -> [ParameterChunk] ->
-  [MSBlock r] -> GenState (MS (r (Method r)))
+genConstructor :: (OOProg r vis smt md) => Label -> Description -> [ParameterChunk] ->
+  [MSBlock r] -> GenState (MS (r md))
 genConstructor n desc p = do
   genMethod nonInitConstructor n desc p Nothing
 
 -- | Generates a constructor that includes initialization of variables.
-genInitConstructor :: (OOProg r vis smt) => Label -> Description -> [ParameterChunk]
-  -> Initializers r -> [MSBlock r] -> GenState (MS (r (Method r)))
+genInitConstructor :: (OOProg r vis smt md) => Label -> Description -> [ParameterChunk]
+  -> Initializers r -> [MSBlock r] -> GenState (MS (r md))
 genInitConstructor n desc p is = genMethod (`constructor` is) n desc p
   Nothing
 
@@ -267,14 +267,14 @@ genInitConstructor n desc p is = genMethod (`constructor` is) n desc p
 -- parameters are the method's name, description, list of parameters,
 -- description of what is returned (if applicable), and body.
 genMethod
-  :: (OOProg r vis smt)
-  => ([MS (r ParamData)] -> MSBody r -> MS (r (Method r)))
+  :: (OOProg r vis smt md)
+  => ([MS (r ParamData)] -> MSBody r -> MS (r md))
   -> Label
   -> Description
   -> [ParameterChunk]
   -> Maybe Description
   -> [MSBlock r]
-  -> GenState (MS (r (Method r)))
+  -> GenState (MS (r md))
 genMethod f n desc p r b = do
   g <- get
   vars <- mapM (mkVar . quantvar) p
@@ -291,14 +291,14 @@ genMethod f n desc p r b = do
 -- list of inputs, list of outputs, and body.
 genInOutFunc
   :: (OOStatement r smt, VariableElim r)
-  => ([SVariable r] -> [SVariable r] -> [SVariable r] -> MSBody r -> MS (r (Method r)))
-  -> (String -> [(String, SVariable r)] -> [(String, SVariable r)] -> [(String, SVariable r)] -> MSBody r -> MS (r (Method r)))
+  => ([SVariable r] -> [SVariable r] -> [SVariable r] -> MSBody r -> MS (r md))
+  -> (String -> [(String, SVariable r)] -> [(String, SVariable r)] -> [(String, SVariable r)] -> MSBody r -> MS (r md))
   -> Label
   -> Description
   -> [CodeVarChunk]
   -> [CodeVarChunk]
   -> [MSBlock r]
-  -> GenState (MS (r (Method r)))
+  -> GenState (MS (r md))
 genInOutFunc f docf n desc ins' outs' b = do
   g <- get
   modify (\st -> st {currentScope = Local})
@@ -532,7 +532,7 @@ elementSetBoolBfunc SContains = S.contains
 -- medium hacks --
 
 -- | Converts a 'Mod' to GOOL.
-genModDef :: (OOProg r vis smt) =>
+genModDef :: (OOProg r vis smt md) =>
   Mod -> GenState (OO.SFile r)
 genModDef (Mod n desc is cs fs) = genModuleWithImports n desc is (map (fmap
   Just . genFunc publicFunc []) fs)
@@ -541,18 +541,20 @@ genModDef (Mod n desc is cs fs) = genModuleWithImports n desc is (map (fmap
                 map (fmap Just . genClass auxClass) cls)
 
 -- | Converts a 'Mod'\'s functions to GOOL.
-genModFuncs :: (OOProg r vis smt) => Mod -> [GenState (MS (r (Method r)))]
+genModFuncs :: (OOProg r vis smt md) => Mod -> [GenState (MS (r md))]
 genModFuncs (Mod _ _ _ _ fs) = map (genFunc publicFunc []) fs
 
 -- | Converts a 'Mod'\'s classes to GOOL.
-genModClasses :: (OOProg r vis smt) => Mod -> [GenState (SClass r)]
+genModClasses :: (OOProg r vis smt md) => Mod -> [GenState (SClass r)]
 genModClasses (Mod _ _ _ cs _) = map (genClass auxClass) cs
 
 -- | Converts a Class (from the Mod AST) to GOOL.
 -- The class generator to use is passed as a parameter.
-genClass :: (OOProg r vis smt) => (Name -> Maybe Name -> Description ->
-  [CSStateVar r] -> GenState [MS (r (Method r))] -> GenState [MS (r (Method r))] ->
-  GenState (SClass r)) -> M.Class -> GenState (SClass r)
+genClass
+  :: (OOProg r vis smt md)
+  => (Name -> Maybe Name -> Description -> [CSStateVar r] -> GenState [MS (r md)] -> GenState [MS (r md)] -> GenState (SClass r))
+  -> M.Class
+  -> GenState (SClass r)
 genClass f (M.ClassDef n i desc svs cs ms) = let svar Pub = pubDVar
                                                  svar Priv = privDVar
   in do
@@ -567,9 +569,12 @@ genClass f (M.ClassDef n i desc svs cs ms) = let svar Pub = pubDVar
 -- variable declaration statements for any undeclared variables. For methods,
 -- the list of StateVariables is needed so they can be included in the list of
 -- declared variables.
-genFunc :: (OOProg r vis smt) => (Name -> VS (r TypeData) -> Description ->
-  [ParameterChunk] -> Maybe Description -> [MSBlock r] ->
-  GenState (MS (r (Method r)))) -> [StateVariable] -> Func -> GenState (MS (r (Method r)))
+genFunc
+  :: (OOProg r vis smt md)
+  => (Name -> VS (r TypeData) -> Description -> [ParameterChunk] -> Maybe Description -> [MSBlock r] -> GenState (MS (r md)))
+  -> [StateVariable]
+  -> Func
+  -> GenState (MS (r md))
 genFunc f svs (FDef (FuncDef n desc parms o rd s)) = do
   g <- get
   modify (\st -> st {currentScope = Local})
@@ -694,7 +699,9 @@ convStmt (FAppend a b) = do
 
 -- | Generates a function that reads a file whose format is based on the passed
 -- 'DataDesc'.
-genDataFunc :: (OOProg r vis smt) => Name -> Description -> DataDesc -> GenState (MS (r (Method r)))
+genDataFunc
+  :: (OOProg r vis smt md)
+  => Name -> Description -> DataDesc -> GenState (MS (r md))
 genDataFunc nameTitle desc ddef = do
   let parms = getInputs ddef
   bod <- readData ddef
@@ -873,7 +880,7 @@ mkVarProc v = do
   toGOOLVar (v ^. obv)
 
 -- | Converts a 'Mod' to GOOL.
-genModDefProc :: (ProcProg r vis smt) => Mod -> GenState (Proc.SFile r)
+genModDefProc :: (ProcProg r vis smt md) => Mod -> GenState (Proc.SFile r)
 genModDefProc (Mod n desc is cs fs) = case cs of
   [] -> genModuleWithImportsProc n desc is
           (map (fmap Just . genFuncProc publicFuncProc []) fs)
@@ -889,22 +896,28 @@ mkParamProc p = do
 
 -- | Generates a public function.
 publicFuncProc
-  :: (SharedProg r vis smt)
+  :: (SharedProg r vis smt md)
   => Label
   -> VS (r TypeData)
   -> Description
   -> [ParameterChunk]
   -> Maybe Description
   -> [MSBlock r]
-  -> GenState (MS (r (Method r)))
+  -> GenState (MS (r md))
 publicFuncProc n t desc ps r b = do
   modify (\st -> st {currentScope = Local})
   genMethodProc (function n public t) n desc ps r b
 
 -- | Generates a private function.
-privateFuncProc :: (SharedProg r vis smt) => Label -> VS (r TypeData) -> Description ->
-  [ParameterChunk] -> Maybe Description -> [MSBlock r] ->
-  GenState (MS (r (Method r)))
+privateFuncProc
+  :: (SharedProg r vis smt md)
+  => Label
+  -> VS (r TypeData)
+  -> Description
+  -> [ParameterChunk]
+  -> Maybe Description
+  -> [MSBlock r]
+  -> GenState (MS (r md))
 privateFuncProc n t desc ps r b = do
   modify (\st -> st {currentScope = Local})
   genMethodProc (function n private t) n desc ps r b
@@ -912,9 +925,15 @@ privateFuncProc n t desc ps r b = do
 -- | Generates a function or method using the passed GOOL constructor. Other
 -- parameters are the method's name, description, list of parameters,
 -- description of what is returned (if applicable), and body.
-genMethodProc :: (SharedProg r vis smt) => ([MS (r ParamData)] -> MSBody r -> MS (r (Method r))) ->
-  Label -> Description -> [ParameterChunk] -> Maybe Description -> [MSBlock r]
-  -> GenState (MS (r (Method r)))
+genMethodProc
+  :: (SharedProg r vis smt md)
+  => ([MS (r ParamData)] -> MSBody r -> MS (r md))
+  -> Label
+  -> Description
+  -> [ParameterChunk]
+  -> Maybe Description
+  -> [MSBlock r]
+  -> GenState (MS (r md))
 genMethodProc f n desc p r b = do
   g <- get
   vars <- mapM (mkVarProc . quantvar) p
@@ -930,9 +949,12 @@ genMethodProc f n desc p r b = do
 -- variable declaration statements for any undeclared variables. For methods,
 -- the list of StateVariables is needed so they can be included in the list of
 -- declared variables.
-genFuncProc :: (SharedProg r vis smt, NativeVector r) => (Name -> VS (r TypeData) ->
-  Description -> [ParameterChunk] -> Maybe Description -> [MSBlock r] ->
-  GenState (MS (r (Method r)))) -> [StateVariable] -> Func -> GenState (MS (r (Method r)))
+genFuncProc
+  :: (SharedProg r vis smt md, NativeVector r)
+  => (Name -> VS (r TypeData) -> Description -> [ParameterChunk] -> Maybe Description -> [MSBlock r] -> GenState (MS (r md)))
+  -> [StateVariable]
+  -> Func
+  -> GenState (MS (r md))
 genFuncProc f svs (FDef (FuncDef n desc parms o rd s)) = do
   g <- get
   modify (\st -> st {currentScope = Local})
@@ -945,7 +967,9 @@ genFuncProc _ _ (FDef (CtorDef {})) = error "genFuncProc: Procedural renderers d
 genFuncProc _ _ (FData (FuncData n desc ddef)) = genDataFuncProc n desc ddef
 
 -- | Converts a 'Mod'\'s functions to GOOL.
-genModFuncsProc :: (SharedProg r vis smt, NativeVector r) => Mod -> [GenState (MS (r (Method r)))]
+genModFuncsProc
+  :: (SharedProg r vis smt md, NativeVector r)
+  => Mod -> [GenState (MS (r md))]
 genModFuncsProc (Mod _ _ _ _ fs) = map (genFuncProc publicFuncProc []) fs
 
 -- this is really ugly!!
@@ -1241,8 +1265,9 @@ convStmtProc (FAppend a b) = do
 
 -- | Generates a function that reads a file whose format is based on the passed
 -- 'DataDesc'.
-genDataFuncProc :: (SharedProg r vis smt, NativeVector r) => Name -> Description -> DataDesc ->
-  GenState (MS (r (Method r)))
+genDataFuncProc
+  :: (SharedProg r vis smt md, NativeVector r)
+  => Name -> Description -> DataDesc -> GenState (MS (r md))
 genDataFuncProc nameTitle desc ddef = do
   let parms = getInputs ddef
   bod <- readDataProc ddef
@@ -1250,13 +1275,25 @@ genDataFuncProc nameTitle desc ddef = do
     Nothing bod
 
 -- | Generates a public function, defined by its inputs and outputs.
-publicInOutFuncProc :: (SharedProg r vis smt) => Label -> Description ->
-  [CodeVarChunk] -> [CodeVarChunk] -> [MSBlock r] -> GenState (MS (r (Method r)))
+publicInOutFuncProc
+  :: (SharedProg r vis smt md)
+  => Label
+  -> Description
+  -> [CodeVarChunk]
+  -> [CodeVarChunk]
+  -> [MSBlock r]
+  -> GenState (MS (r md))
 publicInOutFuncProc n = genInOutFuncProc (inOutFunc n public) (docInOutFunc n public) n
 
 -- | Generates a private function, defined by its inputs and outputs.
-privateInOutFuncProc :: (SharedProg r vis smt) => Label -> Description ->
-  [CodeVarChunk] -> [CodeVarChunk] -> [MSBlock r] -> GenState (MS (r (Method r)))
+privateInOutFuncProc
+  :: (SharedProg r vis smt md)
+  => Label
+  -> Description
+  -> [CodeVarChunk]
+  -> [CodeVarChunk]
+  -> [MSBlock r]
+  -> GenState (MS (r md))
 privateInOutFuncProc n = genInOutFuncProc (inOutFunc n private) (docInOutFunc n private) n
 
 -- | Generates a function or method defined by its inputs and outputs.
@@ -1265,14 +1302,14 @@ privateInOutFuncProc n = genInOutFuncProc (inOutFunc n private) (docInOutFunc n 
 -- list of inputs, list of outputs, and body.
 genInOutFuncProc
   :: (SharedStatement r smt, VariableElim r)
-  => ([SVariable r] -> [SVariable r] -> [SVariable r] -> MSBody r -> MS (r (Method r)))
-  -> (String -> [(String, SVariable r)] -> [(String, SVariable r)] -> [(String, SVariable r)] -> MSBody r -> MS (r (Method r)))
+  => ([SVariable r] -> [SVariable r] -> [SVariable r] -> MSBody r -> MS (r md))
+  -> (String -> [(String, SVariable r)] -> [(String, SVariable r)] -> [(String, SVariable r)] -> MSBody r -> MS (r md))
   -> Label
   -> Description
   -> [CodeVarChunk]
   -> [CodeVarChunk]
   -> [MSBlock r]
-  -> GenState (MS (r (Method r)))
+  -> GenState (MS (r md))
 genInOutFuncProc f docf n desc ins' outs' b = do
   g <- get
   modify (\st -> st {currentScope = Local})

--- a/code/drasil-code/lib/Language/Drasil/Code/Imperative/Import.hs
+++ b/code/drasil-code/lib/Language/Drasil/Code/Imperative/Import.hs
@@ -50,20 +50,20 @@ import Language.Drasil.Mod (Func(..), FuncData(..), FuncDef(..), FuncStmt(..),
 import qualified Language.Drasil.Mod as M (Class(..))
 import Language.Drasil.Printers (showHasSymbImpl)
 
-import Drasil.GOOL (Label, MSBody, MSBlock, SVariable, SValue, SMethod,
-  CSStateVar, SClass, NamedArgs, Initializers, SharedProg, OOProg, MS, VS,
-  AttachmentSym(..), bodyStatements, BlockSym(..), TypeSym(..), VariableSym(..),
-  VariableElim(..), VariableValue(..), ScopeSym(..), ScopeData,
-  OOVariableSym(..), SelfSym(..), instanceVarSelf, VariableElim(..), ($->),
-  ValueSym(..), Literal(..), VariableValue(..), NumericExpression(..),
-  BooleanExpression(..), Comparison(..), ValueExpression(..),
-  OOValueExpression(..), objMethodCallMixedArgs, Reference(..), Array(..),
-  List(..), StatementSym(..), AssignStatement(..), DeclStatement(..),
-  IOStatement(..), StringStatement(..), ControlStatement(..), ifNoElse,
-  VisibilitySym(..), ParameterSym(..), MethodSym(..), OOMethodSym(..), pubDVar,
-  privDVar, nonInitConstructor, convType, convTypeOO, VisibilityTag(..),
-  CodeType(..), onStateValue, TypeData, ParamData, SharedStatement, TypeElim,
-  OODeclStatement, OOVariableValue, OOStatement)
+import Drasil.GOOL (Label, MSBody, MSBlock, SVariable, SValue, CSStateVar,
+  SClass, NamedArgs, Initializers, SharedProg, OOProg, MS, VS, AttachmentSym(..),
+  bodyStatements, BlockSym(..), TypeSym(..), VariableSym(..), VariableElim(..),
+  VariableValue(..), ScopeSym(..), ScopeData, OOVariableSym(..), SelfSym(..),
+  instanceVarSelf, VariableElim(..), ($->), ValueSym(..), Literal(..),
+  VariableValue(..), NumericExpression(..), BooleanExpression(..),
+  Comparison(..), ValueExpression(..), OOValueExpression(..),
+  objMethodCallMixedArgs, Reference(..), Array(..), List(..), StatementSym(..),
+  AssignStatement(..), DeclStatement(..), IOStatement(..), StringStatement(..),
+  ControlStatement(..), ifNoElse, VisibilitySym(..), ParameterSym(..),
+  MethodSym(..), OOMethodSym(..), pubDVar, privDVar, nonInitConstructor,
+  convType, convTypeOO, VisibilityTag(..), CodeType(..), onStateValue, TypeData,
+  ParamData, SharedStatement, TypeElim, OODeclStatement, OOVariableValue,
+  OOStatement)
 import qualified Drasil.GOOL as S (Set(..)) -- TODO [Brandon Bosman, 07/09/2026]: Merge this with OO
 import qualified Drasil.GOOL as OO (SFile)
 import qualified Drasil.GOOL as C (CodeType(List, Array))
@@ -221,7 +221,7 @@ mkParam p = do
 -- | Generates a public function.
 publicFunc :: (OOProg r vis smt) => Label -> VS (r TypeData) -> Description ->
   [ParameterChunk] -> Maybe Description -> [MSBlock r] ->
-  GenState (SMethod r)
+  GenState (MS (r (Method r)))
 publicFunc n t desc ps r b = do
   modify (\st -> st {currentScope = Local})
   genMethod (function n public t) n desc ps r b
@@ -229,37 +229,37 @@ publicFunc n t desc ps r b = do
 -- | Generates a public method.
 publicMethod :: (OOProg r vis smt) => Label -> VS (r TypeData) -> Description ->
   [ParameterChunk] -> Maybe Description -> [MSBlock r] ->
-  GenState (SMethod r)
+  GenState (MS (r (Method r)))
 publicMethod n t = do
   genMethod (method n public instanceLevel t) n
 
 -- | Generates a private method.
 privateMethod :: (OOProg r vis smt) => Label -> VS (r TypeData) -> Description ->
   [ParameterChunk] -> Maybe Description -> [MSBlock r] ->
-  GenState (SMethod r)
+  GenState (MS (r (Method r)))
 privateMethod n t = do
   genMethod (method n private instanceLevel t) n
 
 -- | Generates a public function, defined by its inputs and outputs.
 publicInOutFunc :: (OOProg r vis smt) => Label -> Description -> [CodeVarChunk] ->
-  [CodeVarChunk] -> [MSBlock r] -> GenState (SMethod r)
+  [CodeVarChunk] -> [MSBlock r] -> GenState (MS (r (Method r)))
 publicInOutFunc n = genInOutFunc (inOutFunc n public) (docInOutFunc n public) n
 
 -- | Generates a private method, defined by its inputs and outputs.
 privateInOutMethod :: (OOProg r vis smt) => Label -> Description -> [CodeVarChunk] ->
-  [CodeVarChunk] -> [MSBlock r] -> GenState (SMethod r)
+  [CodeVarChunk] -> [MSBlock r] -> GenState (MS (r (Method r)))
 privateInOutMethod n = genInOutFunc (inOutMethod n private instanceLevel)
   (docInOutMethod n private instanceLevel) n
 
 -- | Generates a constructor.
 genConstructor :: (OOProg r vis smt) => Label -> Description -> [ParameterChunk] ->
-  [MSBlock r] -> GenState (SMethod r)
+  [MSBlock r] -> GenState (MS (r (Method r)))
 genConstructor n desc p = do
   genMethod nonInitConstructor n desc p Nothing
 
 -- | Generates a constructor that includes initialization of variables.
 genInitConstructor :: (OOProg r vis smt) => Label -> Description -> [ParameterChunk]
-  -> Initializers r -> [MSBlock r] -> GenState (SMethod r)
+  -> Initializers r -> [MSBlock r] -> GenState (MS (r (Method r)))
 genInitConstructor n desc p is = genMethod (`constructor` is) n desc p
   Nothing
 
@@ -268,13 +268,13 @@ genInitConstructor n desc p is = genMethod (`constructor` is) n desc p
 -- description of what is returned (if applicable), and body.
 genMethod
   :: (OOProg r vis smt)
-  => ([MS (r ParamData)] -> MSBody r -> SMethod r)
+  => ([MS (r ParamData)] -> MSBody r -> MS (r (Method r)))
   -> Label
   -> Description
   -> [ParameterChunk]
   -> Maybe Description
   -> [MSBlock r]
-  -> GenState (SMethod r)
+  -> GenState (MS (r (Method r)))
 genMethod f n desc p r b = do
   g <- get
   vars <- mapM (mkVar . quantvar) p
@@ -291,14 +291,14 @@ genMethod f n desc p r b = do
 -- list of inputs, list of outputs, and body.
 genInOutFunc
   :: (OOStatement r smt, VariableElim r)
-  => ([SVariable r] -> [SVariable r] -> [SVariable r] -> MSBody r -> SMethod r)
-  -> (String -> [(String, SVariable r)] -> [(String, SVariable r)] -> [(String, SVariable r)] -> MSBody r -> SMethod r)
+  => ([SVariable r] -> [SVariable r] -> [SVariable r] -> MSBody r -> MS (r (Method r)))
+  -> (String -> [(String, SVariable r)] -> [(String, SVariable r)] -> [(String, SVariable r)] -> MSBody r -> MS (r (Method r)))
   -> Label
   -> Description
   -> [CodeVarChunk]
   -> [CodeVarChunk]
   -> [MSBlock r]
-  -> GenState (SMethod r)
+  -> GenState (MS (r (Method r)))
 genInOutFunc f docf n desc ins' outs' b = do
   g <- get
   modify (\st -> st {currentScope = Local})
@@ -541,7 +541,7 @@ genModDef (Mod n desc is cs fs) = genModuleWithImports n desc is (map (fmap
                 map (fmap Just . genClass auxClass) cls)
 
 -- | Converts a 'Mod'\'s functions to GOOL.
-genModFuncs :: (OOProg r vis smt) => Mod -> [GenState (SMethod r)]
+genModFuncs :: (OOProg r vis smt) => Mod -> [GenState (MS (r (Method r)))]
 genModFuncs (Mod _ _ _ _ fs) = map (genFunc publicFunc []) fs
 
 -- | Converts a 'Mod'\'s classes to GOOL.
@@ -551,7 +551,7 @@ genModClasses (Mod _ _ _ cs _) = map (genClass auxClass) cs
 -- | Converts a Class (from the Mod AST) to GOOL.
 -- The class generator to use is passed as a parameter.
 genClass :: (OOProg r vis smt) => (Name -> Maybe Name -> Description ->
-  [CSStateVar r] -> GenState [SMethod r] -> GenState [SMethod r] ->
+  [CSStateVar r] -> GenState [MS (r (Method r))] -> GenState [MS (r (Method r))] ->
   GenState (SClass r)) -> M.Class -> GenState (SClass r)
 genClass f (M.ClassDef n i desc svs cs ms) = let svar Pub = pubDVar
                                                  svar Priv = privDVar
@@ -569,7 +569,7 @@ genClass f (M.ClassDef n i desc svs cs ms) = let svar Pub = pubDVar
 -- declared variables.
 genFunc :: (OOProg r vis smt) => (Name -> VS (r TypeData) -> Description ->
   [ParameterChunk] -> Maybe Description -> [MSBlock r] ->
-  GenState (SMethod r)) -> [StateVariable] -> Func -> GenState (SMethod r)
+  GenState (MS (r (Method r)))) -> [StateVariable] -> Func -> GenState (MS (r (Method r)))
 genFunc f svs (FDef (FuncDef n desc parms o rd s)) = do
   g <- get
   modify (\st -> st {currentScope = Local})
@@ -694,7 +694,7 @@ convStmt (FAppend a b) = do
 
 -- | Generates a function that reads a file whose format is based on the passed
 -- 'DataDesc'.
-genDataFunc :: (OOProg r vis smt) => Name -> Description -> DataDesc -> GenState (SMethod r)
+genDataFunc :: (OOProg r vis smt) => Name -> Description -> DataDesc -> GenState (MS (r (Method r)))
 genDataFunc nameTitle desc ddef = do
   let parms = getInputs ddef
   bod <- readData ddef
@@ -896,7 +896,7 @@ publicFuncProc
   -> [ParameterChunk]
   -> Maybe Description
   -> [MSBlock r]
-  -> GenState (SMethod r)
+  -> GenState (MS (r (Method r)))
 publicFuncProc n t desc ps r b = do
   modify (\st -> st {currentScope = Local})
   genMethodProc (function n public t) n desc ps r b
@@ -904,7 +904,7 @@ publicFuncProc n t desc ps r b = do
 -- | Generates a private function.
 privateFuncProc :: (SharedProg r vis smt) => Label -> VS (r TypeData) -> Description ->
   [ParameterChunk] -> Maybe Description -> [MSBlock r] ->
-  GenState (SMethod r)
+  GenState (MS (r (Method r)))
 privateFuncProc n t desc ps r b = do
   modify (\st -> st {currentScope = Local})
   genMethodProc (function n private t) n desc ps r b
@@ -912,9 +912,9 @@ privateFuncProc n t desc ps r b = do
 -- | Generates a function or method using the passed GOOL constructor. Other
 -- parameters are the method's name, description, list of parameters,
 -- description of what is returned (if applicable), and body.
-genMethodProc :: (SharedProg r vis smt) => ([MS (r ParamData)] -> MSBody r -> SMethod r) ->
+genMethodProc :: (SharedProg r vis smt) => ([MS (r ParamData)] -> MSBody r -> MS (r (Method r))) ->
   Label -> Description -> [ParameterChunk] -> Maybe Description -> [MSBlock r]
-  -> GenState (SMethod r)
+  -> GenState (MS (r (Method r)))
 genMethodProc f n desc p r b = do
   g <- get
   vars <- mapM (mkVarProc . quantvar) p
@@ -932,7 +932,7 @@ genMethodProc f n desc p r b = do
 -- declared variables.
 genFuncProc :: (SharedProg r vis smt, NativeVector r) => (Name -> VS (r TypeData) ->
   Description -> [ParameterChunk] -> Maybe Description -> [MSBlock r] ->
-  GenState (SMethod r)) -> [StateVariable] -> Func -> GenState (SMethod r)
+  GenState (MS (r (Method r)))) -> [StateVariable] -> Func -> GenState (MS (r (Method r)))
 genFuncProc f svs (FDef (FuncDef n desc parms o rd s)) = do
   g <- get
   modify (\st -> st {currentScope = Local})
@@ -945,7 +945,7 @@ genFuncProc _ _ (FDef (CtorDef {})) = error "genFuncProc: Procedural renderers d
 genFuncProc _ _ (FData (FuncData n desc ddef)) = genDataFuncProc n desc ddef
 
 -- | Converts a 'Mod'\'s functions to GOOL.
-genModFuncsProc :: (SharedProg r vis smt, NativeVector r) => Mod -> [GenState (SMethod r)]
+genModFuncsProc :: (SharedProg r vis smt, NativeVector r) => Mod -> [GenState (MS (r (Method r)))]
 genModFuncsProc (Mod _ _ _ _ fs) = map (genFuncProc publicFuncProc []) fs
 
 -- this is really ugly!!
@@ -1242,7 +1242,7 @@ convStmtProc (FAppend a b) = do
 -- | Generates a function that reads a file whose format is based on the passed
 -- 'DataDesc'.
 genDataFuncProc :: (SharedProg r vis smt, NativeVector r) => Name -> Description -> DataDesc ->
-  GenState (SMethod r)
+  GenState (MS (r (Method r)))
 genDataFuncProc nameTitle desc ddef = do
   let parms = getInputs ddef
   bod <- readDataProc ddef
@@ -1251,12 +1251,12 @@ genDataFuncProc nameTitle desc ddef = do
 
 -- | Generates a public function, defined by its inputs and outputs.
 publicInOutFuncProc :: (SharedProg r vis smt) => Label -> Description ->
-  [CodeVarChunk] -> [CodeVarChunk] -> [MSBlock r] -> GenState (SMethod r)
+  [CodeVarChunk] -> [CodeVarChunk] -> [MSBlock r] -> GenState (MS (r (Method r)))
 publicInOutFuncProc n = genInOutFuncProc (inOutFunc n public) (docInOutFunc n public) n
 
 -- | Generates a private function, defined by its inputs and outputs.
 privateInOutFuncProc :: (SharedProg r vis smt) => Label -> Description ->
-  [CodeVarChunk] -> [CodeVarChunk] -> [MSBlock r] -> GenState (SMethod r)
+  [CodeVarChunk] -> [CodeVarChunk] -> [MSBlock r] -> GenState (MS (r (Method r)))
 privateInOutFuncProc n = genInOutFuncProc (inOutFunc n private) (docInOutFunc n private) n
 
 -- | Generates a function or method defined by its inputs and outputs.
@@ -1265,14 +1265,14 @@ privateInOutFuncProc n = genInOutFuncProc (inOutFunc n private) (docInOutFunc n 
 -- list of inputs, list of outputs, and body.
 genInOutFuncProc
   :: (SharedStatement r smt, VariableElim r)
-  => ([SVariable r] -> [SVariable r] -> [SVariable r] -> MSBody r -> SMethod r)
-  -> (String -> [(String, SVariable r)] -> [(String, SVariable r)] -> [(String, SVariable r)] -> MSBody r -> SMethod r)
+  => ([SVariable r] -> [SVariable r] -> [SVariable r] -> MSBody r -> MS (r (Method r)))
+  -> (String -> [(String, SVariable r)] -> [(String, SVariable r)] -> [(String, SVariable r)] -> MSBody r -> MS (r (Method r)))
   -> Label
   -> Description
   -> [CodeVarChunk]
   -> [CodeVarChunk]
   -> [MSBlock r]
-  -> GenState (SMethod r)
+  -> GenState (MS (r (Method r)))
 genInOutFuncProc f docf n desc ins' outs' b = do
   g <- get
   modify (\st -> st {currentScope = Local})

--- a/code/drasil-code/lib/Language/Drasil/Code/Imperative/Modules.hs
+++ b/code/drasil-code/lib/Language/Drasil/Code/Imperative/Modules.hs
@@ -86,7 +86,7 @@ type ConstraintCE = Constraint CodeExpr
 ---- MAIN ---
 
 -- | Generates a controller module.
-genMain :: (OOProg r vis smt) => GenState (OO.SFile r)
+genMain :: (OOProg r vis smt md) => GenState (OO.SFile r)
 genMain = genModule "Control" "Controls the flow of the program"
   [genMainFunc] []
 
@@ -95,7 +95,7 @@ genMain = genModule "Control" "Controls the flow of the program"
 -- functions for reading input values, calculating derived inputs, checking
 -- constraints, calculating outputs, and printing outputs.
 -- Returns Nothing if the user chose to generate a library.
-genMainFunc :: (OOProg r vis smt) => GenState (Maybe (MS (r (Method r))))
+genMainFunc :: (OOProg r vis smt md) => GenState (Maybe (MS (r md)))
 genMainFunc = do
     g <- get
     let mainFunc Library = return Nothing
@@ -199,11 +199,11 @@ initLogFileVar l scp = [varDec varLogFile scp | LogVar `elem` l]
 ------- INPUT ----------
 
 -- | Generates a single module containing all input-related components.
-genInputMod :: (OOProg r vis smt) => GenState [OO.SFile r]
+genInputMod :: (OOProg r vis smt md) => GenState [OO.SFile r]
 genInputMod = do
   ipDesc <- modDesc inputParametersDesc
   cname <- genICName InputParameters
-  let genMod :: (OOProg r vis smt) => Maybe (SClass r) -> GenState (OO.SFile r)
+  let genMod :: (OOProg r vis smt md) => Maybe (SClass r) -> GenState (OO.SFile r)
       genMod Nothing = genModule cname ipDesc [genInputFormat Pub,
         genInputDerived Pub, genInputConstraints Pub] []
       genMod _ = genModule cname ipDesc [] [genInputClass Primary]
@@ -225,7 +225,7 @@ constVarFunc Const = constVar public
 -- the InputParameters class containing the inputs and constants as state
 -- variables. If the InputParameters constructor is also exported, then the
 -- generated class also contains the input-related functions as private methods.
-genInputClass :: (OOProg r vis smt) => ClassType -> GenState (Maybe (SClass r))
+genInputClass :: (OOProg r vis smt md) => ClassType -> GenState (Maybe (SClass r))
 genInputClass scp = do
   g <- get
   modify (\st -> st {currentScope = Local})
@@ -234,16 +234,16 @@ genInputClass scp = do
       cs = g ^. constDefns
       filt :: (CodeIdea c) => [c] -> [c]
       filt = filter ((Just cname ==) . flip Map.lookup (clsMap g) . codeName)
-      constructors :: (OOProg r vis smt) => GenState [MS (r (Method r))]
+      constructors :: (OOProg r vis smt md) => GenState [MS (r md)]
       constructors = if cname `elem` defSet g
         then concat <$> mapM (fmap maybeToList) [genInputConstructor]
         else return []
-      methods :: (OOProg r vis smt) => GenState [MS (r (Method r))]
+      methods :: (OOProg r vis smt md) => GenState [MS (r md)]
       methods = if cname `elem` defSet g
         then concat <$> mapM (fmap maybeToList) [genInputFormat Priv,
         genInputDerived Priv, genInputConstraints Priv]
         else return []
-      genClass :: (OOProg r vis smt) => [CodeVarChunk] ->
+      genClass :: (OOProg r vis smt md) => [CodeVarChunk] ->
         [CodeDefinition] -> GenState (Maybe (SClass r))
       genClass [] [] = return Nothing
       genClass inps csts = do
@@ -264,7 +264,7 @@ genInputClass scp = do
 -- | Generates a constructor for the input class, where the constructor calls the
 -- input-related functions. Returns 'Nothing' if no input-related functions are
 -- generated.
-genInputConstructor :: (OOProg r vis smt) => GenState (Maybe (MS (r (Method r))))
+genInputConstructor :: (OOProg r vis smt md) => GenState (Maybe (MS (r md)))
 genInputConstructor = do
   g <- get
   ipName <- genICName InputParameters
@@ -284,7 +284,7 @@ genInputConstructor = do
     dvName, icName]
 
 -- | Generates a function for calculating derived inputs.
-genInputDerived :: (OOProg r vis smt) => VisibilityTag -> GenState (Maybe (MS (r (Method r))))
+genInputDerived :: (OOProg r vis smt md) => VisibilityTag -> GenState (Maybe (MS (r md)))
 genInputDerived s = do
   g <- get
   modify (\st -> st {currentScope = Local})
@@ -292,7 +292,7 @@ genInputDerived s = do
   let dvals = g ^. derivedInputs
       getFunc Pub = publicInOutFunc
       getFunc Priv = privateInOutMethod
-      genDerived :: (OOProg r vis smt) => Bool -> GenState (Maybe (MS (r (Method r))))
+      genDerived :: (OOProg r vis smt md) => Bool -> GenState (Maybe (MS (r md)))
       genDerived False = return Nothing
       genDerived _ = do
         ins <- getDerivedIns
@@ -304,8 +304,9 @@ genInputDerived s = do
   genDerived $ dvName `elem` defSet g
 
 -- | Generates function that checks constraints on the input.
-genInputConstraints :: (OOProg r vis smt) => VisibilityTag ->
-  GenState (Maybe (MS (r (Method r))))
+genInputConstraints
+  :: (OOProg r vis smt md)
+  => VisibilityTag -> GenState (Maybe (MS (r md)))
 genInputConstraints s = do
   g <- get
   modify (\st -> st {currentScope = Local})
@@ -313,8 +314,8 @@ genInputConstraints s = do
   let cm = g ^. cMap
       getFunc Pub = publicFunc
       getFunc Priv = privateMethod
-      genConstraints :: (OOProg r vis smt) => Bool -> GenState
-        (Maybe (MS (r (Method r))))
+      genConstraints :: (OOProg r vis smt md) => Bool -> GenState
+        (Maybe (MS (r md)))
       genConstraints False = return Nothing
       genConstraints _ = do
         parms <- getConstraintParams
@@ -453,7 +454,9 @@ printExpr Lit{} _     = []
 printExpr e     pinfo = [printStr $ " " ++ render (parens (oneLineCodeExprDoc pinfo e))]
 
 -- | | Generates a function for reading inputs from a file.
-genInputFormat :: (OOProg r vis smt) => VisibilityTag -> GenState (Maybe (MS (r (Method r))))
+genInputFormat
+  :: (OOProg r vis smt md)
+  => VisibilityTag -> GenState (Maybe (MS (r md)))
 genInputFormat s = do
   g <- get
   modify (\st -> st {currentScope = Local})
@@ -461,7 +464,7 @@ genInputFormat s = do
   giName <- genICName GetInput
   let getFunc Pub = publicInOutFunc
       getFunc Priv = privateInOutMethod
-      genInFormat :: (OOProg r vis smt) => Bool -> GenState (Maybe (MS (r (Method r))))
+      genInFormat :: (OOProg r vis smt md) => Bool -> GenState (Maybe (MS (r md)))
       genInFormat False = return Nothing
       genInFormat _ = do
         ins <- getInputFormatIns
@@ -493,7 +496,7 @@ genSampleInput = do
 ----- CONSTANTS -----
 
 -- | Generates a module containing the class where constants are stored.
-genConstMod :: (OOProg r vis smt) => GenState [OO.SFile r]
+genConstMod :: (OOProg r vis smt md) => GenState [OO.SFile r]
 genConstMod = do
   cDesc <- modDesc $ liftS constModDesc
   cName <- genICName Constants
@@ -502,7 +505,7 @@ genConstMod = do
 -- | Generates a class to store constants, if constants are mapped to the
 -- Constants class in the class definition map, otherwise returns Nothing.
 genConstClass
-  :: (OOProg r vis smt)
+  :: (OOProg r vis smt md)
   => ClassType -> GenState (Maybe (SClass r))
 genConstClass scp = do
   g <- get
@@ -510,7 +513,7 @@ genConstClass scp = do
   cname <- genICName Constants
   let cs = g ^. constDefns
       genClass
-        :: (OOProg r vis smt)
+        :: (OOProg r vis smt md)
         => [CodeDefinition] -> GenState (Maybe (SClass r))
       genClass [] = return Nothing
       genClass vs = do
@@ -530,7 +533,7 @@ genConstClass scp = do
 ------- CALC ----------
 
 -- | Generates a module containing calculation functions.
-genCalcMod :: (OOProg r vis smt) => GenState (OO.SFile r)
+genCalcMod :: (OOProg r vis smt md) => GenState (OO.SFile r)
 genCalcMod = do
   g <- get
   cName <- genICName Calculations
@@ -541,7 +544,7 @@ genCalcMod = do
 -- | Generates a calculation function corresponding to the 'CodeDefinition'.
 -- For solving ODEs, the 'ExtLibState' containing the information needed to
 -- generate code is found by looking it up in the external library map.
-genCalcFunc :: (OOProg r vis smt) => CodeDefinition -> GenState (MS (r (Method r)))
+genCalcFunc :: (OOProg r vis smt md) => CodeDefinition -> GenState (MS (r md))
 genCalcFunc cdef = do
   g <- get
   modify (\st -> st {currentScope = Local})
@@ -611,19 +614,21 @@ genCaseBlock t v c cs = do
 ----- OUTPUT -------
 
 -- | Generates a module containing the function for printing outputs.
-genOutputMod :: (OOProg r vis smt) => GenState [OO.SFile r]
+genOutputMod :: (OOProg r vis smt md) => GenState [OO.SFile r]
 genOutputMod = do
   ofName <- genICName OutputFormat
   ofDesc <- modDesc $ liftS outputFormatDesc
   liftS $ genModule ofName ofDesc [genOutputFormat] []
 
 -- | Generates a function for printing output values.
-genOutputFormat :: (OOProg r vis smt) => GenState (Maybe (MS (r (Method r))))
+genOutputFormat :: (OOProg r vis smt md) => GenState (Maybe (MS (r md)))
 genOutputFormat = do
   g <- get
   modify (\st -> st {currentScope = Local})
   woName <- genICName WriteOutput
-  let genOutput :: (OOProg r vis smt) => Maybe String -> GenState (Maybe (MS (r (Method r))))
+  let genOutput
+        :: (OOProg r vis smt md)
+        => Maybe String -> GenState (Maybe (MS (r md)))
       genOutput Nothing = return Nothing
       genOutput (Just _) = do
         let l_outfile = "outputfile"
@@ -648,7 +653,7 @@ genOutputFormat = do
 -- Procedural Versions --
 
 -- | Generates a controller module.
-genMainProc :: (ProcProg r vis smt) => GenState (Proc.SFile r)
+genMainProc :: (ProcProg r vis smt md) => GenState (Proc.SFile r)
 genMainProc = genModuleProc "Control" "Controls the flow of the program"
   [genMainFuncProc]
 
@@ -658,8 +663,8 @@ genMainProc = genModuleProc "Control" "Controls the flow of the program"
 -- constraints, calculating outputs, and printing outputs.
 -- Returns Nothing if the user chose to generate a library.
 genMainFuncProc
-  :: (NativeVector r, SharedProg r vis smt)
-  => GenState (Maybe (MS (r (Method r))))
+  :: (NativeVector r, SharedProg r vis smt md)
+  => GenState (Maybe (MS (r md)))
 genMainFuncProc = do
     g <- get
     let mainFunc Library = return Nothing
@@ -726,11 +731,11 @@ checkConstClass = do
     . codeName) cs
 
 -- | Generates a single module containing all input-related components.
-genInputModProc :: (ProcProg r vis smt) => GenState [Proc.SFile r]
+genInputModProc :: (ProcProg r vis smt md) => GenState [Proc.SFile r]
 genInputModProc = do
   ipDesc <- modDesc inputParametersDesc
   cname <- genICName InputParameters
-  let genMod :: (ProcProg r vis smt) => Bool ->
+  let genMod :: (ProcProg r vis smt md) => Bool ->
         GenState (Proc.SFile r)
       genMod False = genModuleProc cname ipDesc [genInputFormatProc Pub,
         genInputDerivedProc Pub, genInputConstraintsProc Pub]
@@ -774,7 +779,7 @@ getInputDeclProc = do
     (g ^. inputs))
 
 -- | Generates a module containing calculation functions.
-genCalcModProc :: (ProcProg r vis smt) => GenState (Proc.SFile r)
+genCalcModProc :: (ProcProg r vis smt md) => GenState (Proc.SFile r)
 genCalcModProc = do
   g <- get
   cName <- genICName Calculations
@@ -786,8 +791,8 @@ genCalcModProc = do
 -- For solving ODEs, the 'ExtLibState' containing the information needed to
 -- generate code is found by looking it up in the external library map.
 genCalcFuncProc
-  :: (NativeVector r, SharedProg r vis smt)
-  => CodeDefinition -> GenState (MS (r (Method r)))
+  :: (NativeVector r, SharedProg r vis smt md)
+  => CodeDefinition -> GenState (MS (r md))
 genCalcFuncProc cdef = do
   g <- get
   modify (\st -> st {currentScope = Local})
@@ -852,8 +857,9 @@ genCaseBlockProc t v c cs = do
           "Undefined case encountered in function " ++ codeName v
 
 -- | | Generates a function for reading inputs from a file.
-genInputFormatProc :: (SharedProg r vis smt, NativeVector r) => VisibilityTag ->
-  GenState (Maybe (MS (r (Method r))))
+genInputFormatProc
+  :: (SharedProg r vis smt md, NativeVector r)
+  => VisibilityTag -> GenState (Maybe (MS (r md)))
 genInputFormatProc s = do
   g <- get
   modify (\st -> st {currentScope = Local})
@@ -861,8 +867,9 @@ genInputFormatProc s = do
   giName <- genICName GetInput
   let getFunc Pub = publicInOutFuncProc
       getFunc Priv = privateInOutFuncProc
-      genInFormat :: (SharedProg r vis smt, NativeVector r) => Bool -> GenState
-        (Maybe (MS (r (Method r))))
+      genInFormat
+        :: (SharedProg r vis smt md, NativeVector r)
+        => Bool -> GenState (Maybe (MS (r md)))
       genInFormat False = return Nothing
       genInFormat _ = do
         ins <- getInputFormatIns
@@ -874,8 +881,9 @@ genInputFormatProc s = do
   genInFormat $ giName `elem` defSet g
 
 -- | Generates a function for calculating derived inputs.
-genInputDerivedProc :: (SharedProg r vis smt, NativeVector r) => VisibilityTag ->
-  GenState (Maybe (MS (r (Method r))))
+genInputDerivedProc
+  :: (SharedProg r vis smt md, NativeVector r)
+  => VisibilityTag -> GenState (Maybe (MS (r md)))
 genInputDerivedProc s = do
   g <- get
   modify (\st -> st {currentScope = Local})
@@ -883,8 +891,9 @@ genInputDerivedProc s = do
   let dvals = g ^. derivedInputs
       getFunc Pub = publicInOutFuncProc
       getFunc Priv = privateInOutFuncProc
-      genDerived :: (SharedProg r vis smt, NativeVector r) => Bool -> GenState
-        (Maybe (MS (r (Method r))))
+      genDerived
+        :: (SharedProg r vis smt md, NativeVector r)
+        => Bool -> GenState (Maybe (MS (r md)))
       genDerived False = return Nothing
       genDerived _ = do
         ins <- getDerivedIns
@@ -896,8 +905,9 @@ genInputDerivedProc s = do
   genDerived $ dvName `elem` defSet g
 
 -- | Generates function that checks constraints on the input.
-genInputConstraintsProc :: (SharedProg r vis smt, NativeVector r) => VisibilityTag ->
-  GenState (Maybe (MS (r (Method r))))
+genInputConstraintsProc
+  :: (SharedProg r vis smt md, NativeVector r)
+  => VisibilityTag -> GenState (Maybe (MS (r md)))
 genInputConstraintsProc s = do
   g <- get
   modify (\st -> st {currentScope = Local})
@@ -905,8 +915,9 @@ genInputConstraintsProc s = do
   let cm = g ^. cMap
       getFunc Pub = publicFuncProc
       getFunc Priv = privateFuncProc
-      genConstraints :: (SharedProg r vis smt, NativeVector r) => Bool -> GenState
-        (Maybe (MS (r (Method r))))
+      genConstraints
+        :: (SharedProg r vis smt md, NativeVector r)
+        => Bool -> GenState (Maybe (MS (r md)))
       genConstraints False = return Nothing
       genConstraints _ = do
         parms <- getConstraintParams
@@ -1035,22 +1046,23 @@ printConstraintProc c = do
   printConstraint' c
 
 -- | Generates a module containing the function for printing outputs.
-genOutputModProc :: (ProcProg r vis smt) => GenState [Proc.SFile r]
+genOutputModProc :: (ProcProg r vis smt md) => GenState [Proc.SFile r]
 genOutputModProc = do
   ofName <- genICName OutputFormat
   ofDesc <- modDesc $ liftS outputFormatDesc
   liftS $ genModuleProc ofName ofDesc [genOutputFormatProc]
 
 -- | Generates a function for printing output values.
-genOutputFormatProc :: (SharedProg r vis smt, NativeVector r) => GenState (Maybe (MS (r (Method r))))
+genOutputFormatProc
+  :: (SharedProg r vis smt md, NativeVector r)
+  => GenState (Maybe (MS (r md)))
 genOutputFormatProc = do
   g <- get
   modify (\st -> st {currentScope = Local})
   woName <- genICName WriteOutput
   let genOutput
-        :: (NativeVector r, SharedProg r vis smt)
-        => Maybe String
-        -> GenState (Maybe (MS (r (Method r))))
+        :: (NativeVector r, SharedProg r vis smt md)
+        => Maybe String -> GenState (Maybe (MS (r md)))
       genOutput Nothing = return Nothing
       genOutput (Just _) = do
         let l_outfile = "outputfile"

--- a/code/drasil-code/lib/Language/Drasil/Code/Imperative/Modules.hs
+++ b/code/drasil-code/lib/Language/Drasil/Code/Imperative/Modules.hs
@@ -26,14 +26,14 @@ import Language.Drasil (Constraint(..), RealInterval(..), HasSpace(typ),
   Space(..))
 import Language.Drasil.Printers (showHasSymbImpl, PrintingInformation,
   oneLineCodeExprDoc)
-import Drasil.GOOL (MSBody, MSBlock, SVariable, SValue, MS, SMethod, CSStateVar,
-  SClass, SharedProg, OOProg, BodySym(..), bodyStatements, oneLiner,
-  BlockSym(..), AttachmentSym(..), TypeSym(..), VariableSym(..), ScopeSym(..),
-  ScopeData, Literal(..), VariableValue(..), CommandLineArgs(..),
-  NumericExpression(..), BooleanExpression(..), Comparison(..), List(..),
-  StatementSym(..), AssignStatement(..), DeclStatement(..), OODeclStatement(..),
-  objDecNewNoParams, extObjDecNewNoParams, IOStatement(..), ControlStatement(..),
-  ifNoElse, VisibilitySym(..), MethodSym(..), StateVarSym(..), pubDVar, convType,
+import Drasil.GOOL (MSBody, MSBlock, SVariable, SValue, MS, CSStateVar, SClass,
+  SharedProg, OOProg, BodySym(..), bodyStatements, oneLiner, BlockSym(..),
+  AttachmentSym(..), TypeSym(..), VariableSym(..), ScopeSym(..), ScopeData,
+  Literal(..), VariableValue(..), CommandLineArgs(..), NumericExpression(..),
+  BooleanExpression(..), Comparison(..), List(..), StatementSym(..),
+  AssignStatement(..), DeclStatement(..), OODeclStatement(..), objDecNewNoParams,
+  extObjDecNewNoParams, IOStatement(..), ControlStatement(..), ifNoElse,
+  VisibilitySym(..), MethodSym(..), StateVarSym(..), pubDVar, convType,
   convTypeOO, VisibilityTag(..), SharedStatement, TypeElim, VariableElim,
   OOStatement)
 import qualified Drasil.GOOL as OO (SFile)
@@ -95,7 +95,7 @@ genMain = genModule "Control" "Controls the flow of the program"
 -- functions for reading input values, calculating derived inputs, checking
 -- constraints, calculating outputs, and printing outputs.
 -- Returns Nothing if the user chose to generate a library.
-genMainFunc :: (OOProg r vis smt) => GenState (Maybe (SMethod r))
+genMainFunc :: (OOProg r vis smt) => GenState (Maybe (MS (r (Method r))))
 genMainFunc = do
     g <- get
     let mainFunc Library = return Nothing
@@ -234,11 +234,11 @@ genInputClass scp = do
       cs = g ^. constDefns
       filt :: (CodeIdea c) => [c] -> [c]
       filt = filter ((Just cname ==) . flip Map.lookup (clsMap g) . codeName)
-      constructors :: (OOProg r vis smt) => GenState [SMethod r]
+      constructors :: (OOProg r vis smt) => GenState [MS (r (Method r))]
       constructors = if cname `elem` defSet g
         then concat <$> mapM (fmap maybeToList) [genInputConstructor]
         else return []
-      methods :: (OOProg r vis smt) => GenState [SMethod r]
+      methods :: (OOProg r vis smt) => GenState [MS (r (Method r))]
       methods = if cname `elem` defSet g
         then concat <$> mapM (fmap maybeToList) [genInputFormat Priv,
         genInputDerived Priv, genInputConstraints Priv]
@@ -264,7 +264,7 @@ genInputClass scp = do
 -- | Generates a constructor for the input class, where the constructor calls the
 -- input-related functions. Returns 'Nothing' if no input-related functions are
 -- generated.
-genInputConstructor :: (OOProg r vis smt) => GenState (Maybe (SMethod r))
+genInputConstructor :: (OOProg r vis smt) => GenState (Maybe (MS (r (Method r))))
 genInputConstructor = do
   g <- get
   ipName <- genICName InputParameters
@@ -284,7 +284,7 @@ genInputConstructor = do
     dvName, icName]
 
 -- | Generates a function for calculating derived inputs.
-genInputDerived :: (OOProg r vis smt) => VisibilityTag -> GenState (Maybe (SMethod r))
+genInputDerived :: (OOProg r vis smt) => VisibilityTag -> GenState (Maybe (MS (r (Method r))))
 genInputDerived s = do
   g <- get
   modify (\st -> st {currentScope = Local})
@@ -292,7 +292,7 @@ genInputDerived s = do
   let dvals = g ^. derivedInputs
       getFunc Pub = publicInOutFunc
       getFunc Priv = privateInOutMethod
-      genDerived :: (OOProg r vis smt) => Bool -> GenState (Maybe (SMethod r))
+      genDerived :: (OOProg r vis smt) => Bool -> GenState (Maybe (MS (r (Method r))))
       genDerived False = return Nothing
       genDerived _ = do
         ins <- getDerivedIns
@@ -305,7 +305,7 @@ genInputDerived s = do
 
 -- | Generates function that checks constraints on the input.
 genInputConstraints :: (OOProg r vis smt) => VisibilityTag ->
-  GenState (Maybe (SMethod r))
+  GenState (Maybe (MS (r (Method r))))
 genInputConstraints s = do
   g <- get
   modify (\st -> st {currentScope = Local})
@@ -314,7 +314,7 @@ genInputConstraints s = do
       getFunc Pub = publicFunc
       getFunc Priv = privateMethod
       genConstraints :: (OOProg r vis smt) => Bool -> GenState
-        (Maybe (SMethod r))
+        (Maybe (MS (r (Method r))))
       genConstraints False = return Nothing
       genConstraints _ = do
         parms <- getConstraintParams
@@ -453,7 +453,7 @@ printExpr Lit{} _     = []
 printExpr e     pinfo = [printStr $ " " ++ render (parens (oneLineCodeExprDoc pinfo e))]
 
 -- | | Generates a function for reading inputs from a file.
-genInputFormat :: (OOProg r vis smt) => VisibilityTag -> GenState (Maybe (SMethod r))
+genInputFormat :: (OOProg r vis smt) => VisibilityTag -> GenState (Maybe (MS (r (Method r))))
 genInputFormat s = do
   g <- get
   modify (\st -> st {currentScope = Local})
@@ -461,7 +461,7 @@ genInputFormat s = do
   giName <- genICName GetInput
   let getFunc Pub = publicInOutFunc
       getFunc Priv = privateInOutMethod
-      genInFormat :: (OOProg r vis smt) => Bool -> GenState (Maybe (SMethod r))
+      genInFormat :: (OOProg r vis smt) => Bool -> GenState (Maybe (MS (r (Method r))))
       genInFormat False = return Nothing
       genInFormat _ = do
         ins <- getInputFormatIns
@@ -541,7 +541,7 @@ genCalcMod = do
 -- | Generates a calculation function corresponding to the 'CodeDefinition'.
 -- For solving ODEs, the 'ExtLibState' containing the information needed to
 -- generate code is found by looking it up in the external library map.
-genCalcFunc :: (OOProg r vis smt) => CodeDefinition -> GenState (SMethod r)
+genCalcFunc :: (OOProg r vis smt) => CodeDefinition -> GenState (MS (r (Method r)))
 genCalcFunc cdef = do
   g <- get
   modify (\st -> st {currentScope = Local})
@@ -618,12 +618,12 @@ genOutputMod = do
   liftS $ genModule ofName ofDesc [genOutputFormat] []
 
 -- | Generates a function for printing output values.
-genOutputFormat :: (OOProg r vis smt) => GenState (Maybe (SMethod r))
+genOutputFormat :: (OOProg r vis smt) => GenState (Maybe (MS (r (Method r))))
 genOutputFormat = do
   g <- get
   modify (\st -> st {currentScope = Local})
   woName <- genICName WriteOutput
-  let genOutput :: (OOProg r vis smt) => Maybe String -> GenState (Maybe (SMethod r))
+  let genOutput :: (OOProg r vis smt) => Maybe String -> GenState (Maybe (MS (r (Method r))))
       genOutput Nothing = return Nothing
       genOutput (Just _) = do
         let l_outfile = "outputfile"
@@ -659,7 +659,7 @@ genMainProc = genModuleProc "Control" "Controls the flow of the program"
 -- Returns Nothing if the user chose to generate a library.
 genMainFuncProc
   :: (NativeVector r, SharedProg r vis smt)
-  => GenState (Maybe (SMethod r))
+  => GenState (Maybe (MS (r (Method r))))
 genMainFuncProc = do
     g <- get
     let mainFunc Library = return Nothing
@@ -787,7 +787,7 @@ genCalcModProc = do
 -- generate code is found by looking it up in the external library map.
 genCalcFuncProc
   :: (NativeVector r, SharedProg r vis smt)
-  => CodeDefinition -> GenState (SMethod r)
+  => CodeDefinition -> GenState (MS (r (Method r)))
 genCalcFuncProc cdef = do
   g <- get
   modify (\st -> st {currentScope = Local})
@@ -853,7 +853,7 @@ genCaseBlockProc t v c cs = do
 
 -- | | Generates a function for reading inputs from a file.
 genInputFormatProc :: (SharedProg r vis smt, NativeVector r) => VisibilityTag ->
-  GenState (Maybe (SMethod r))
+  GenState (Maybe (MS (r (Method r))))
 genInputFormatProc s = do
   g <- get
   modify (\st -> st {currentScope = Local})
@@ -862,7 +862,7 @@ genInputFormatProc s = do
   let getFunc Pub = publicInOutFuncProc
       getFunc Priv = privateInOutFuncProc
       genInFormat :: (SharedProg r vis smt, NativeVector r) => Bool -> GenState
-        (Maybe (SMethod r))
+        (Maybe (MS (r (Method r))))
       genInFormat False = return Nothing
       genInFormat _ = do
         ins <- getInputFormatIns
@@ -875,7 +875,7 @@ genInputFormatProc s = do
 
 -- | Generates a function for calculating derived inputs.
 genInputDerivedProc :: (SharedProg r vis smt, NativeVector r) => VisibilityTag ->
-  GenState (Maybe (SMethod r))
+  GenState (Maybe (MS (r (Method r))))
 genInputDerivedProc s = do
   g <- get
   modify (\st -> st {currentScope = Local})
@@ -884,7 +884,7 @@ genInputDerivedProc s = do
       getFunc Pub = publicInOutFuncProc
       getFunc Priv = privateInOutFuncProc
       genDerived :: (SharedProg r vis smt, NativeVector r) => Bool -> GenState
-        (Maybe (SMethod r))
+        (Maybe (MS (r (Method r))))
       genDerived False = return Nothing
       genDerived _ = do
         ins <- getDerivedIns
@@ -897,7 +897,7 @@ genInputDerivedProc s = do
 
 -- | Generates function that checks constraints on the input.
 genInputConstraintsProc :: (SharedProg r vis smt, NativeVector r) => VisibilityTag ->
-  GenState (Maybe (SMethod r))
+  GenState (Maybe (MS (r (Method r))))
 genInputConstraintsProc s = do
   g <- get
   modify (\st -> st {currentScope = Local})
@@ -906,7 +906,7 @@ genInputConstraintsProc s = do
       getFunc Pub = publicFuncProc
       getFunc Priv = privateFuncProc
       genConstraints :: (SharedProg r vis smt, NativeVector r) => Bool -> GenState
-        (Maybe (SMethod r))
+        (Maybe (MS (r (Method r))))
       genConstraints False = return Nothing
       genConstraints _ = do
         parms <- getConstraintParams
@@ -1042,7 +1042,7 @@ genOutputModProc = do
   liftS $ genModuleProc ofName ofDesc [genOutputFormatProc]
 
 -- | Generates a function for printing output values.
-genOutputFormatProc :: (SharedProg r vis smt, NativeVector r) => GenState (Maybe (SMethod r))
+genOutputFormatProc :: (SharedProg r vis smt, NativeVector r) => GenState (Maybe (MS (r (Method r))))
 genOutputFormatProc = do
   g <- get
   modify (\st -> st {currentScope = Local})
@@ -1050,7 +1050,7 @@ genOutputFormatProc = do
   let genOutput
         :: (NativeVector r, SharedProg r vis smt)
         => Maybe String
-        -> GenState (Maybe (SMethod r))
+        -> GenState (Maybe (MS (r (Method r))))
       genOutput Nothing = return Nothing
       genOutput (Just _) = do
         let l_outfile = "outputfile"

--- a/code/drasil-code/test/FileTests.hs
+++ b/code/drasil-code/test/FileTests.hs
@@ -13,21 +13,21 @@ import qualified Drasil.GProc as GProc (GSProgram, ProgramSym(..), FileSym(..),
   ModuleSym(..))
 
 -- | Creates a program in GOOL to test reading and writing to files.
-fileTestsOO :: (OOProg r vis smt) => OO.GSProgram r
+fileTestsOO :: (OOProg r vis smt md) => OO.GSProgram r
 fileTestsOO = OO.prog "FileTests" "" [OO.fileDoc (OO.buildModule "FileTests" []
   [fileTestMethod] [])]
 
 -- | Creates a program in GProc to test reading and writing to files.
-fileTestsProc :: (ProcProg r vis smt) => GProc.GSProgram r
+fileTestsProc :: (ProcProg r vis smt md) => GProc.GSProgram r
 fileTestsProc = GProc.prog "FileTests" "" [GProc.fileDoc (GProc.buildModule
   "FileTests" [] [fileTestMethod])]
 
 -- | File test method starts with 'writeStory' and ends with 'goodBye'.
-fileTestMethod :: (SharedProg r vis smt) => MS (r (Method r))
+fileTestMethod :: (SharedProg r vis smt md) => MS (r md)
 fileTestMethod = mainFunction (body [writeStory, block [readStory], goodBye])
 
 -- | Generates functions that write to the file.
-writeStory :: (SharedProg r vis smt) => MSBlock r
+writeStory :: (SharedProg r vis smt md) => MSBlock r
 writeStory = block [
   varDec (var "fileToWrite" outfile) mainFn,
 
@@ -49,13 +49,13 @@ writeStory = block [
   listDec 0 (var "fileContents" (listType string)) mainFn]
 
 -- | Generates functions to read from a file.
-readStory :: (SharedProg r vis smt) => MS (r smt)
+readStory :: (SharedProg r vis smt md) => MS (r smt)
 readStory = getFileInputAll (valueOf $ var "fileToRead" infile)
   (var "fileContents" (listType string))
 
 -- | Prints the result of the 'readStory' function. Should be the same as
 -- what was given in 'writeStory'.
-goodBye :: (SharedProg r vis smt) => MSBlock r
+goodBye :: (SharedProg r vis smt md) => MSBlock r
 goodBye = block [
   printLn (valueOf $ var "fileContents" (listType string)),
   assert (listSize (valueOf (var "fileContents" (listType string))) ?> litInt 0)

--- a/code/drasil-code/test/FileTests.hs
+++ b/code/drasil-code/test/FileTests.hs
@@ -2,10 +2,10 @@
 -- and write to files. See stable/gooltest for more details on what is generated through this.
 module FileTests (fileTestsOO, fileTestsProc) where
 
-import Drasil.GOOL (MSBlock, SMethod, MS, SharedProg, OOProg,
-  BodySym(..), BlockSym(..), TypeSym(..), DeclStatement(..), IOStatement(..),
-  ControlStatement(..), VariableSym(var), Literal(..), VariableValue(..),
-  Comparison(..), List(..), MethodSym(..), ScopeSym(..))
+import Drasil.GOOL (MSBlock, MS, SharedProg, OOProg, BodySym(..), BlockSym(..),
+  TypeSym(..), DeclStatement(..), IOStatement(..), ControlStatement(..),
+  VariableSym(var), Literal(..), VariableValue(..), Comparison(..), List(..),
+  MethodSym(..), ScopeSym(..))
 import qualified Drasil.GOOL as OO (GSProgram, ProgramSym(..), FileSym(..),
   ModuleSym(..))
 import Drasil.GProc (ProcProg)
@@ -23,7 +23,7 @@ fileTestsProc = GProc.prog "FileTests" "" [GProc.fileDoc (GProc.buildModule
   "FileTests" [] [fileTestMethod])]
 
 -- | File test method starts with 'writeStory' and ends with 'goodBye'.
-fileTestMethod :: (SharedProg r vis smt) => SMethod r
+fileTestMethod :: (SharedProg r vis smt) => MS (r (Method r))
 fileTestMethod = mainFunction (body [writeStory, block [readStory], goodBye])
 
 -- | Generates functions that write to the file.

--- a/code/drasil-code/test/GOOL/Observer.hs
+++ b/code/drasil-code/test/GOOL/Observer.hs
@@ -1,11 +1,11 @@
 -- | Part of the PatternTest GOOL tests. Defines an Observer class.
 module GOOL.Observer (observer, observerName, printNum, x) where
 
-import Drasil.GOOL (SFile, SVariable, SMethod, SClass, OOProg, FileSym(..),
+import Drasil.GOOL (SFile, SVariable, SClass, OOProg, MS, FileSym(..),
   AttachmentSym(..), oneLiner, TypeSym(..), IOStatement(..), VariableSym(..),
   SelfSym(..), instanceVarSelf, Literal(..), VariableValue(..), OOVariableValue,
-  VisibilitySym(..), OOMethodSym(..), initializer, StateVarSym(..), ClassSym(..),
-  ModuleSym(..))
+  VisibilitySym(..), MethodSym(..), OOMethodSym(..), initializer,
+  StateVarSym(..), ClassSym(..), ModuleSym(..))
 import Prelude hiding (return,print,log,exp,sin,cos,tan)
 
 observerName, observerDesc, printNum :: String
@@ -36,11 +36,11 @@ helperClass = buildClass Nothing [stateVar public instanceLevel x]
   [observerConstructor] [printNumMethod, getMethod x, setMethod x]
 
 -- | Default value for observer class is 5.
-observerConstructor :: (OOMethodSym r vis smt, Literal r) => SMethod r
+observerConstructor :: (OOMethodSym r vis smt, Literal r) => MS (r (Method r))
 observerConstructor = initializer [] [(x, litInt 5)]
 
 -- | Create the @printNum@ method.
 printNumMethod :: (OOMethodSym r vis smt, IOStatement r smt,
-  OOVariableValue r) => SMethod r
+  OOVariableValue r) => MS (r (Method r))
 printNumMethod = method printNum public instanceLevel void [] $
   oneLiner $ printLn $ valueOf selfX

--- a/code/drasil-code/test/GOOL/Observer.hs
+++ b/code/drasil-code/test/GOOL/Observer.hs
@@ -4,8 +4,8 @@ module GOOL.Observer (observer, observerName, printNum, x) where
 import Drasil.GOOL (SFile, SVariable, SClass, OOProg, MS, FileSym(..),
   AttachmentSym(..), oneLiner, TypeSym(..), IOStatement(..), VariableSym(..),
   SelfSym(..), instanceVarSelf, Literal(..), VariableValue(..), OOVariableValue,
-  VisibilitySym(..), MethodSym(..), OOMethodSym(..), initializer,
-  StateVarSym(..), ClassSym(..), ModuleSym(..))
+  VisibilitySym(..), OOMethodSym(..), initializer, StateVarSym(..), ClassSym(..),
+  ModuleSym(..))
 import Prelude hiding (return,print,log,exp,sin,cos,tan)
 
 observerName, observerDesc, printNum :: String
@@ -17,7 +17,7 @@ observerDesc = "This is an arbitrary class acting as an Observer"
 printNum = "printNum"
 
 -- | Creates the observer class.
-observer :: (OOProg r vis smt) => SFile r
+observer :: (OOProg r vis smt md) => SFile r
 observer = fileDoc (buildModule observerName [] [] [docClass observerDesc
   helperClass])
 
@@ -30,17 +30,17 @@ selfX :: (SelfSym r, VariableValue r) => SVariable r
 selfX = instanceVarSelf x
 
 -- | Helper function to create the class.
-helperClass :: (ClassSym r vis smt, IOStatement r smt, Literal r,
+helperClass :: (ClassSym r vis smt md, IOStatement r smt, Literal r,
   OOVariableValue r) => SClass r
 helperClass = buildClass Nothing [stateVar public instanceLevel x]
   [observerConstructor] [printNumMethod, getMethod x, setMethod x]
 
 -- | Default value for observer class is 5.
-observerConstructor :: (OOMethodSym r vis smt, Literal r) => MS (r (Method r))
+observerConstructor :: (OOMethodSym r vis smt md, Literal r) => MS (r md)
 observerConstructor = initializer [] [(x, litInt 5)]
 
 -- | Create the @printNum@ method.
-printNumMethod :: (OOMethodSym r vis smt, IOStatement r smt,
-  OOVariableValue r) => MS (r (Method r))
+printNumMethod :: (OOMethodSym r vis smt md, IOStatement r smt,
+  OOVariableValue r) => MS (r md)
 printNumMethod = method printNum public instanceLevel void [] $
   oneLiner $ printLn $ valueOf selfX

--- a/code/drasil-code/test/GOOL/PatternTest.hs
+++ b/code/drasil-code/test/GOOL/PatternTest.hs
@@ -2,14 +2,13 @@
 -- the Observer class both work.
 module GOOL.PatternTest (patternTest) where
 
-import Drasil.GOOL (GSProgram, SVariable, SValue, SMethod, OOProg, VS,
-  ProgramSym(..), FileSym(..), BodySym(..), oneLiner, BlockSym(..),
-  TypeSym(..), OOTypeSym(..), StatementSym(..), DeclStatement(..),
-  IOStatement(..), initObserverList, addObserver, VariableSym(var),
-  OOVariableSym(..), ScopeSym(..), Literal(..), VariableValue(..),
-  OOValueExpression(..), extNewObj, OOFunctionSym(..), GetSet(..),
-  ObserverPattern(..), StrategyPattern(..), MethodSym(..), ModuleSym(..),
-  TypeData)
+import Drasil.GOOL (GSProgram, SVariable, SValue, OOProg, MS, VS, ProgramSym(..),
+  FileSym(..), BodySym(..), oneLiner, BlockSym(..), TypeSym(..), OOTypeSym(..),
+  StatementSym(..), DeclStatement(..), IOStatement(..), initObserverList,
+  addObserver, VariableSym(var), OOVariableSym(..), ScopeSym(..), Literal(..),
+  VariableValue(..), OOValueExpression(..), extNewObj, OOFunctionSym(..),
+  GetSet(..), ObserverPattern(..), StrategyPattern(..), MethodSym(..),
+  ModuleSym(..), TypeData)
 import Prelude hiding (return,print,log,exp,sin,cos,tan)
 import GOOL.Observer (observer, observerName, printNum, x)
 
@@ -43,7 +42,7 @@ patternTest = prog progName "" [fileDoc (buildModule progName []
   [patternTestMainMethod] []), observer]
 
 -- | Creates the main function for PatternTest.
-patternTestMainMethod :: (OOProg r vis smt) => SMethod r
+patternTestMainMethod :: (OOProg r vis smt) => MS (r (Method r))
 patternTestMainMethod = mainFunction (body [block [
   varDec n mainFn],
 

--- a/code/drasil-code/test/GOOL/PatternTest.hs
+++ b/code/drasil-code/test/GOOL/PatternTest.hs
@@ -37,12 +37,12 @@ newObserver :: (OOValueExpression r) => SValue r
 newObserver = extNewObj observerName observerType []
 
 -- | Creates the pattern test program.
-patternTest :: (OOProg r vis smt) => GSProgram r
+patternTest :: (OOProg r vis smt md) => GSProgram r
 patternTest = prog progName "" [fileDoc (buildModule progName []
   [patternTestMainMethod] []), observer]
 
 -- | Creates the main function for PatternTest.
-patternTestMainMethod :: (OOProg r vis smt) => MS (r (Method r))
+patternTestMainMethod :: (OOProg r vis smt md) => MS (r md)
 patternTestMainMethod = mainFunction (body [block [
   varDec n mainFn],
 

--- a/code/drasil-code/test/HelloWorld.hs
+++ b/code/drasil-code/test/HelloWorld.hs
@@ -25,13 +25,13 @@ import Prelude hiding (return,print,log,exp,sin,cos,tan,const)
 import Helper (helperOO, helperProc)
 
 -- | Creates the HelloWorld program and necessary files.
-helloWorldOO :: (OOProg r vis smt) => OO.GSProgram r
+helloWorldOO :: (OOProg r vis smt md) => OO.GSProgram r
 helloWorldOO = OO.prog "HelloWorld" "" [OO.docMod description watermark
   ["Brooks MacLachlan"] "" $ OO.fileDoc (OO.buildModule "HelloWorld" []
   [helloWorldMainOO] [helloWorldClass]), helperOO]
 
 -- | Creates the HelloWorld program and necessary files.
-helloWorldProc :: (ProcProg r vis smt) => GProc.GSProgram r
+helloWorldProc :: (ProcProg r vis smt md) => GProc.GSProgram r
 helloWorldProc = GProc.prog "HelloWorld" "" [GProc.docMod description
   watermark
   ["Brooks MacLachlan"] "" $ GProc.fileDoc (GProc.buildModule "HelloWorld" []
@@ -42,11 +42,11 @@ description :: String
 description = "Tests various GOOL functions. It should run without errors."
 
 -- | Variable for a list of doubles
-myOtherList :: (SharedProg r vis smt) => SVariable r
+myOtherList :: (SharedProg r vis smt md) => SVariable r
 myOtherList = var "myOtherList" (listType double)
 
 -- | Main function. Initializes variables and combines all the helper functions defined below.
-helloWorldMainOO :: (OOProg r vis smt) => MS (r (Method r))
+helloWorldMainOO :: (OOProg r vis smt md) => MS (r md)
 helloWorldMainOO = mainFunction (body ([ helloInitVariables, objectTests] ++ listSliceTests
     ++ [block [printLn $ litString "", ifCond [
       (valueOf (var "b" int) ?>= litInt 6, bodyStatements [
@@ -57,7 +57,7 @@ helloWorldMainOO = mainFunction (body ([ helloInitVariables, objectTests] ++ lis
       helloForEachLoop, helloTryCatch]]))
 
 -- | Main function. Initializes variables and combines all the helper functions defined below.
-helloWorldMainProc :: (ProcProg r vis smt) => MS (r (Method r))
+helloWorldMainProc :: (ProcProg r vis smt md) => MS (r md)
 helloWorldMainProc = mainFunction (body ([ helloInitVariables] ++ listSliceTests
     ++ [block [printLn $ litString "", ifCond [
       (valueOf (var "b" int) ?>= litInt 6, bodyStatements [
@@ -67,7 +67,7 @@ helloWorldMainProc = mainFunction (body ([ helloInitVariables] ++ listSliceTests
       helloForEachLoop, helloTryCatch]]))
 
 -- | Initialize variables used in the generated program.
-helloInitVariables :: (SharedProg r vis smt) => MSBlock r
+helloInitVariables :: (SharedProg r vis smt md) => MSBlock r
 helloInitVariables = block [comment "Initializing variables",
   varDec (var "a" int) mainFn,
   varDecDef (var "b" int) mainFn (litInt 5),
@@ -117,7 +117,7 @@ helloInitVariables = block [comment "Initializing variables",
   assert (contains (valueOf (var "s" (setType int))) (litInt 7))
     (litString "Set s should contain 7")]
 
-objectTests :: (OOProg r vis smt) => MSBlock r
+objectTests :: (OOProg r vis smt md) => MSBlock r
 objectTests = block [comment "Object tests",
   varDecDef (var "t1" (obj "TestClass")) mainFn (newObj (obj "TestClass") [litInt 5]),
   varDecDef (var "t2" (obj "TestClass")) mainFn (newObj (obj "TestClass") [litInt 4]),
@@ -138,7 +138,7 @@ objectTests = block [comment "Object tests",
 
 mySlicedList, mySlicedList2, mySlicedList3, mySlicedList4, mySlicedList5,
   mySlicedList6, mySlicedList7, mySlicedList8, mySlicedList9,
-  mySlicedList10, mySlicedList11 :: (SharedProg r vis smt) => SVariable r
+  mySlicedList10, mySlicedList11 :: (SharedProg r vis smt md) => SVariable r
 mySlicedList = var "mySlicedList" (listType double)
 mySlicedList2 = var "mySlicedList2" (listType double)
 mySlicedList3 = var "mySlicedList3" (listType double)
@@ -151,7 +151,7 @@ mySlicedList9 = var "mySlicedList9" (listType double)
 mySlicedList10 = var "mySlicedList10" (listType double)
 mySlicedList11 = var "mySlicedList11" (listType double)
 
-listSliceTests :: (SharedProg r vis smt) => [MSBlock r]
+listSliceTests :: (SharedProg r vis smt md) => [MSBlock r]
 listSliceTests = [
 
   -- | Declare variables for list slices
@@ -270,7 +270,7 @@ listSliceTests = [
 
 -- | Create an If statement.
 {-# ANN module "HLint: ignore Evaluate" #-}
-helloIfBody :: (SharedProg r vis smt) => MSBody r
+helloIfBody :: (SharedProg r vis smt md) => MSBody r
 helloIfBody = addComments "If body" (body [
   block [
     varDec (var "c" int) mainFn,
@@ -338,44 +338,44 @@ helloIfBody = addComments "If body" (body [
     printLn (cot (litDouble 1.0))]])
 
 -- | Print the 5th given argument.
-helloElseBody :: (SharedProg r vis smt) => MSBody r
+helloElseBody :: (SharedProg r vis smt md) => MSBody r
 helloElseBody = bodyStatements [printLn (arg 5)]
 
 -- | If-else statement checking if a list is empty.
-helloIfExists :: (SharedProg r vis smt) => MS (r smt)
+helloIfExists :: (SharedProg r vis smt md) => MS (r smt)
 helloIfExists = ifExists (valueOf $ var "boringList" (listType bool))
   (oneLiner (printStrLn "Ew, boring list!")) (oneLiner (printStrLn "Great, no bores!"))
 
 -- | Creates a switch statement.
-helloSwitch :: (SharedProg r vis smt) => MS (r smt)
+helloSwitch :: (SharedProg r vis smt md) => MS (r smt)
 helloSwitch = switch (valueOf $ var "a" int) [(litInt 5, oneLiner (var "b" int &= litInt 10)),
   (litInt 0, oneLiner (var "b" int &= litInt 5))]
   (oneLiner (var "b" int &= litInt 0))
 
 -- | Creates a for loop.
-helloForLoop :: (SharedProg r vis smt) => MS (r smt)
+helloForLoop :: (SharedProg r vis smt md) => MS (r smt)
 helloForLoop = forRange i (litInt 0) (litInt 9) (litInt 1) (oneLiner (printLn
   (valueOf i)))
   where i = var "i" int
 
 -- | Creates a while loop.
-helloWhileLoop :: (SharedProg r vis smt) => MS (r smt)
+helloWhileLoop :: (SharedProg r vis smt md) => MS (r smt)
 helloWhileLoop = while (valueOf (var "a" int) ?< litInt 13) (bodyStatements
   [printStrLn "Hello", (&++) (var "a" int)])
 
 -- | Creates a for-each loop.
-helloForEachLoop :: (SharedProg r vis smt) => MS (r smt)
+helloForEachLoop :: (SharedProg r vis smt md) => MS (r smt)
 helloForEachLoop = forEach i (valueOf myOtherList)
   (oneLiner (printLn (extFuncApp "Helper" "doubleAndAdd" double [valueOf i,
   litDouble 1.0])))
   where i = var "num" double
 
 -- | Creates a try statement to catch an intentional error.
-helloTryCatch :: (SharedProg r vis smt) => MS (r smt)
+helloTryCatch :: (SharedProg r vis smt md) => MS (r smt)
 helloTryCatch = tryCatch (oneLiner (throw "Good-bye!"))
   (oneLiner (printStrLn "Caught intentional error"))
 
-helloWorldClass :: (OOProg r vis smt) => SClass r
+helloWorldClass :: (OOProg r vis smt md) => SClass r
 helloWorldClass = extraClass "TestClass" Nothing
   [stateVar public instanceLevel (var "a" int)]
   [initializer [param $ var "a" int]

--- a/code/drasil-code/test/HelloWorld.hs
+++ b/code/drasil-code/test/HelloWorld.hs
@@ -3,10 +3,10 @@
 -- Should run print statements, basic loops, math, and create a helper module without errors.
 module HelloWorld (helloWorldOO, helloWorldProc) where
 
-import Drasil.GOOL (MSBody, MSBlock, SMethod, SClass, SVariable, MS, SharedProg,
-  OOProg, BodySym(..), bodyStatements, oneLiner, BlockSym(..), listSlice,
-  TypeSym(..), OOTypeSym(..), StatementSym(..), AssignStatement(..), (&=),
-  DeclStatement(..), IOStatement(..), StringStatement(..), CommentStatement(..),
+import Drasil.GOOL (MSBody, MSBlock, SClass, SVariable, MS, SharedProg, OOProg,
+  BodySym(..), bodyStatements, oneLiner, BlockSym(..), listSlice, TypeSym(..),
+  OOTypeSym(..), StatementSym(..), AssignStatement(..), (&=), DeclStatement(..),
+  IOStatement(..), StringStatement(..), CommentStatement(..),
   ControlStatement(..), VariableSym(..), OOVariableSym(..), SelfSym(..),
   StateVarSym(..), ClassSym(..), ScopeSym(..), Literal(..), VariableValue(..),
   VisibilitySym(..), CommandLineArgs(..), AttachmentSym(..),
@@ -46,7 +46,7 @@ myOtherList :: (SharedProg r vis smt) => SVariable r
 myOtherList = var "myOtherList" (listType double)
 
 -- | Main function. Initializes variables and combines all the helper functions defined below.
-helloWorldMainOO :: (OOProg r vis smt) => SMethod r
+helloWorldMainOO :: (OOProg r vis smt) => MS (r (Method r))
 helloWorldMainOO = mainFunction (body ([ helloInitVariables, objectTests] ++ listSliceTests
     ++ [block [printLn $ litString "", ifCond [
       (valueOf (var "b" int) ?>= litInt 6, bodyStatements [
@@ -57,7 +57,7 @@ helloWorldMainOO = mainFunction (body ([ helloInitVariables, objectTests] ++ lis
       helloForEachLoop, helloTryCatch]]))
 
 -- | Main function. Initializes variables and combines all the helper functions defined below.
-helloWorldMainProc :: (ProcProg r vis smt) => SMethod r
+helloWorldMainProc :: (ProcProg r vis smt) => MS (r (Method r))
 helloWorldMainProc = mainFunction (body ([ helloInitVariables] ++ listSliceTests
     ++ [block [printLn $ litString "", ifCond [
       (valueOf (var "b" int) ?>= litInt 6, bodyStatements [

--- a/code/drasil-code/test/Helper.hs
+++ b/code/drasil-code/test/Helper.hs
@@ -1,7 +1,7 @@
 -- | Makes the helper file for the GOOL HelloWorld tests.
 module Helper (helperOO, helperProc) where
 
-import Drasil.GOOL (SMethod, SharedProg, OOProg, bodyStatements, TypeSym(..),
+import Drasil.GOOL (SharedProg, OOProg, MS, bodyStatements, TypeSym(..),
   DeclStatement(..), ControlStatement(..), (&=), VariableSym(var), Literal(..),
   VariableValue(..), NumericExpression(..), VisibilitySym(..), ParameterSym(..),
   MethodSym(..), ScopeSym(local))
@@ -20,7 +20,7 @@ helperProc :: (ProcProg r vis smt) => GProc.SFile r
 helperProc = GProc.fileDoc (GProc.buildModule "Helper" [] [doubleAndAdd])
 
 -- | Creates a function that doubles the arguments and adds them together.
-doubleAndAdd :: (SharedProg r vis smt) => SMethod r
+doubleAndAdd :: (SharedProg r vis smt) => MS (r (Method r))
 doubleAndAdd = docFunc "This function adds two numbers"
   ["First number to add", "Second number to add"] (Just "Sum") $
   function "doubleAndAdd"  public double

--- a/code/drasil-code/test/Helper.hs
+++ b/code/drasil-code/test/Helper.hs
@@ -12,15 +12,15 @@ import qualified Drasil.GProc as GProc (SFile, FileSym(..), ModuleSym(..))
 import Prelude hiding (return,print,log,exp,sin,cos,tan)
 
 -- | Creates Helper module that contains an addition function.
-helperOO :: (OOProg r vis smt) => OO.SFile r
+helperOO :: (OOProg r vis smt md) => OO.SFile r
 helperOO = OO.fileDoc (OO.buildModule "Helper" [] [doubleAndAdd] [])
 
 -- | Creates Helper module that contains an addition function.
-helperProc :: (ProcProg r vis smt) => GProc.SFile r
+helperProc :: (ProcProg r vis smt md) => GProc.SFile r
 helperProc = GProc.fileDoc (GProc.buildModule "Helper" [] [doubleAndAdd])
 
 -- | Creates a function that doubles the arguments and adds them together.
-doubleAndAdd :: (SharedProg r vis smt) => MS (r (Method r))
+doubleAndAdd :: (SharedProg r vis smt md) => MS (r md)
 doubleAndAdd = docFunc "This function adds two numbers"
   ["First number to add", "Second number to add"] (Just "Sum") $
   function "doubleAndAdd"  public double

--- a/code/drasil-code/test/Main.hs
+++ b/code/drasil-code/test/Main.hs
@@ -56,7 +56,7 @@ codeGenTestGroup =
     ]
 
 goolTestGroup :: String ->
-  (forall r vis smt. (OOProg r vis smt) => OO.GSProgram r) -> TestTree
+  (forall r vis smt md. (OOProg r vis smt md) => OO.GSProgram r) -> TestTree
 goolTestGroup n p =
   goldenTestingGroup
     ([osp|test/build|] </> [ps|{n}|])
@@ -70,7 +70,7 @@ goolTestGroup n p =
     ]
 
 gProcTestGroup :: String ->
-  (forall r vis smt. (ProcProg r vis smt) => Proc.GSProgram r) -> TestTree
+  (forall r vis smt md. (ProcProg r vis smt md) => Proc.GSProgram r) -> TestTree
 gProcTestGroup n p =
   goldenTestingGroup
     ([osp|test/build|] </> [ps|{n}|])
@@ -80,7 +80,7 @@ gProcTestGroup n p =
     ]
 
 gProcMatlabTestGroup :: String ->
-  (forall r vis smt. (ProcProg r vis smt, NativeVector r) =>
+  (forall r vis smt md. (ProcProg r vis smt md, NativeVector r) =>
     Proc.GSProgram r) -> TestTree
 gProcMatlabTestGroup n p =
   goldenTestingGroup
@@ -90,9 +90,9 @@ gProcMatlabTestGroup n p =
     [ goldenTest "matlab" $ directory [ps|matlab|] $ genCodeProcNoMake unMLC unMLP p
     ]
 
-genCodeProcNoMake :: (ProcProg r vis smt, Monad r') =>
+genCodeProcNoMake :: (ProcProg r vis smt md, Monad r') =>
   (r (Proc.Program r) -> ProgData) -> (r' PackageData -> PackageData) ->
-  (forall s vis' smt'. (ProcProg s vis' smt', NativeVector s) =>
+  (forall s vis' smt' md'. (ProcProg s vis' smt' md', NativeVector s) =>
     Proc.GSProgram s) ->
   [FileLayout]
 genCodeProcNoMake unRepr unRepr' p =
@@ -101,18 +101,18 @@ genCodeProcNoMake unRepr unRepr' p =
     (PackageData prog aux) = unRepr' $ package (unRepr p') []
   in seq gs' $ toFileLayout (progMods prog) ++ aux
 
-genCodeGOOL :: (OOProg r vis smt, SoftwareDossierSym r', Monad r') =>
+genCodeGOOL :: (OOProg r vis smt md, SoftwareDossierSym r', Monad r') =>
   (r (OO.Program r) -> ProgData) -> (r' PackageData -> PackageData) ->
-  (forall s vis' smt'. (OOProg s vis' smt') => OO.GSProgram s) -> [FileLayout]
+  (forall s vis' smt' md'. (OOProg s vis' smt' md') => OO.GSProgram s) -> [FileLayout]
 genCodeGOOL unRepr unRepr' p =
   let
     gs = OO.unCI (evalState p initialState)
     (p', gs') = runState p gs
   in genCode' (unRepr p') gs' unRepr'
 
-genCodeProc :: (ProcProg r vis smt, SoftwareDossierSym r', Monad r') =>
+genCodeProc :: (ProcProg r vis smt md, SoftwareDossierSym r', Monad r') =>
   (r (Proc.Program r) -> ProgData) -> (r' PackageData -> PackageData) ->
-  (forall s vis' smt'. (ProcProg s vis' smt') => Proc.GSProgram s) -> [FileLayout]
+  (forall s vis' smt' md'. (ProcProg s vis' smt' md') => Proc.GSProgram s) -> [FileLayout]
 genCodeProc unRepr unRepr' p =
   let
     (p', gs') = runState p initialState

--- a/code/drasil-code/test/NameGenTest.hs
+++ b/code/drasil-code/test/NameGenTest.hs
@@ -10,15 +10,15 @@ import Drasil.GProc (ProcProg)
 import qualified Drasil.GProc as GProc (GSProgram, ProgramSym(..), FileSym(..),
   ModuleSym(..))
 
-nameGenTestOO :: OOProg r vis smt => OO.GSProgram r
+nameGenTestOO :: OOProg r vis smt md => OO.GSProgram r
 nameGenTestOO = OO.prog "NameGenTest" "" [OO.fileDoc $ OO.buildModule
   "NameGenTest" [] [main, helper] []]
 
-nameGenTestProc :: ProcProg r vis smt => GProc.GSProgram r
+nameGenTestProc :: ProcProg r vis smt md => GProc.GSProgram r
 nameGenTestProc = GProc.prog "NameGenTest" "" [GProc.fileDoc $ GProc.buildModule
   "NameGenTest" [] [main, helper]]
 
-helper :: SharedProg r vis smt => MS (r (Method r))
+helper :: SharedProg r vis smt md => MS (r md)
 helper = function "helper" private void [param temp] $ body
   [block [listDec 2 result local],
     listSlice result (valueOf temp) (Just (litInt 1)) (Just (litInt 3)) Nothing,
@@ -27,7 +27,7 @@ helper = function "helper" private void [param temp] $ body
     temp = var "temp" (listType int)
     result = var "result" (listType int)
 
-main :: SharedProg r vis smt => MS (r (Method r))
+main :: SharedProg r vis smt md => MS (r md)
 main = mainFunction $ body
   [block [
     listDecDef temp mainFn [litInt 1, litInt 2, litInt 3],

--- a/code/drasil-code/test/NameGenTest.hs
+++ b/code/drasil-code/test/NameGenTest.hs
@@ -1,6 +1,6 @@
 module NameGenTest (nameGenTestOO, nameGenTestProc) where
 
-import Drasil.GOOL (SMethod, SharedProg, OOProg, BodySym(..), BlockSym(..),
+import Drasil.GOOL (SharedProg, OOProg, MS, BodySym(..), BlockSym(..),
   TypeSym(..), VariableSym(var), Literal(..), DeclStatement(..),
   ControlStatement(..), MethodSym(..), VariableValue(..), Comparison(..),
   listSlice, List(..), ParameterSym(..), VisibilitySym(..), ScopeSym(..))
@@ -18,7 +18,7 @@ nameGenTestProc :: ProcProg r vis smt => GProc.GSProgram r
 nameGenTestProc = GProc.prog "NameGenTest" "" [GProc.fileDoc $ GProc.buildModule
   "NameGenTest" [] [main, helper]]
 
-helper :: SharedProg r vis smt => SMethod r
+helper :: SharedProg r vis smt => MS (r (Method r))
 helper = function "helper" private void [param temp] $ body
   [block [listDec 2 result local],
     listSlice result (valueOf temp) (Just (litInt 1)) (Just (litInt 3)) Nothing,
@@ -27,7 +27,7 @@ helper = function "helper" private void [param temp] $ body
     temp = var "temp" (listType int)
     result = var "result" (listType int)
 
-main :: SharedProg r vis smt => SMethod r
+main :: SharedProg r vis smt => MS (r (Method r))
 main = mainFunction $ body
   [block [
     listDecDef temp mainFn [litInt 1, litInt 2, litInt 3],

--- a/code/drasil-code/test/OOVector.hs
+++ b/code/drasil-code/test/OOVector.hs
@@ -32,19 +32,19 @@ localV = var "v" (arrayType double)
 thisV :: (SelfSym r, VariableValue r) => SVariable r
 thisV = instanceVarSelf localV
 
-dimension :: OOProg r vis smt => SMethod r
+dimension :: OOProg r vis smt => MS (r (Method r))
 dimension = docFunc "Returns the dimension of this vector." [] (Just "The dimension of the vector.") $
   method "dimension" public instanceLevel int [] $ bodyStatements [
     returnStmt $ arrayLength (valueOf thisV)
   ]
 
-magnitude :: OOProg r vis smt => SMethod r
+magnitude :: OOProg r vis smt => MS (r (Method r))
 magnitude = docFunc "Calculate the Euclidean norm (magnitude) of this vector."
   [] (Just "The magnitude.") $
   pubMethod "magnitude" double [] $ oneLiner $
     returnStmt (classMethodCall double (obj "Vector") "dot" [maybeDeref $ valueOf self, maybeDeref $ valueOf self] #/^)
 
-norm :: OOProg r vis smt => SMethod r
+norm :: OOProg r vis smt => MS (r (Method r))
 norm = docFunc "Calculate unit vector of this vector."
   [] (Just "A new unit vector.") $
   method "norm" public classLevel (obj "Vector") [param v] $ bodyStatements [
@@ -55,7 +55,7 @@ norm = docFunc "Calculate unit vector of this vector."
   where v = vecVar "v"
         mag = var "mag" double
 
-dot :: OOProg r vis smt => SMethod r
+dot :: OOProg r vis smt => MS (r (Method r))
 dot = docFunc "Calculate the dot product of two vectors."
   ["First vector.", "Second vector."] (Just "The dot product.") $
   method "dot" public classLevel double [param v1, param v2] $ bodyStatements [
@@ -74,7 +74,7 @@ dot = docFunc "Calculate the dot product of two vectors."
         res = var "res" double
         i = var "i" int
 
-add :: OOProg r vis smt => SMethod r
+add :: OOProg r vis smt => MS (r (Method r))
 add = docFunc "Calculate the resultant vector of two vectors."
   ["First vector.", "Second vector."] (Just "The resultant vector.") $
   method "add" public classLevel (obj "Vector") [param v1, param v2] $ bodyStatements [
@@ -92,7 +92,7 @@ add = docFunc "Calculate the resultant vector of two vectors."
         res = var "res" (arrayType double)
         i = var "i" int
 
-scale :: OOProg r vis smt => SMethod r
+scale :: OOProg r vis smt => MS (r (Method r))
 scale = docFunc "Scale this vector by a factor."
   ["Scalar factor."] (Just "A new scaled vector.") $
   method "scale" public classLevel (obj "Vector") [param v, param s] $ bodyStatements [
@@ -107,11 +107,11 @@ scale = docFunc "Scale this vector by a factor."
         res = var "res" (arrayType double)
         i = var "i" int
 
-print_ :: OOProg r vis smt => SMethod r
+print_ :: OOProg r vis smt => MS (r (Method r))
 print_ = docFunc "Prints the vector elements to console." [] Nothing $
   pubMethod "printSelf" void [] $ oneLiner $ printLn $ valueOf thisV
 
-main :: OOProg r vis smt => SMethod r
+main :: OOProg r vis smt => MS (r (Method r))
 main = mainFunction $ body [
     block [
       arrayDecDef ds1 mainFn [litDouble 1.0, litDouble 2.0, litDouble 3.0],

--- a/code/drasil-code/test/OOVector.hs
+++ b/code/drasil-code/test/OOVector.hs
@@ -4,11 +4,11 @@ module OOVector (ooVector) where
 import Drasil.GOOL
 import Prelude hiding (return,print,log,exp,sin,cos,tan)
 
-ooVector :: OOProg r vis smt => GSProgram r
+ooVector :: OOProg r vis smt md => GSProgram r
 ooVector = prog "OOVector" "" [fileDoc (buildModule "OOVector" []
   [main] [vectorClass])]
 
-vectorClass :: OOProg r vis smt => SClass r
+vectorClass :: OOProg r vis smt md => SClass r
 vectorClass = docClass "Vectors of doubles and common vector-related operations." $
   extraClass "Vector" Nothing [stateVar private instanceLevel localV]
   [docFunc "Construct a vector from an array of doubles." ["The doubles."] Nothing $
@@ -32,19 +32,19 @@ localV = var "v" (arrayType double)
 thisV :: (SelfSym r, VariableValue r) => SVariable r
 thisV = instanceVarSelf localV
 
-dimension :: OOProg r vis smt => MS (r (Method r))
+dimension :: OOProg r vis smt md => MS (r md)
 dimension = docFunc "Returns the dimension of this vector." [] (Just "The dimension of the vector.") $
   method "dimension" public instanceLevel int [] $ bodyStatements [
     returnStmt $ arrayLength (valueOf thisV)
   ]
 
-magnitude :: OOProg r vis smt => MS (r (Method r))
+magnitude :: OOProg r vis smt md => MS (r md)
 magnitude = docFunc "Calculate the Euclidean norm (magnitude) of this vector."
   [] (Just "The magnitude.") $
   pubMethod "magnitude" double [] $ oneLiner $
     returnStmt (classMethodCall double (obj "Vector") "dot" [maybeDeref $ valueOf self, maybeDeref $ valueOf self] #/^)
 
-norm :: OOProg r vis smt => MS (r (Method r))
+norm :: OOProg r vis smt md => MS (r md)
 norm = docFunc "Calculate unit vector of this vector."
   [] (Just "A new unit vector.") $
   method "norm" public classLevel (obj "Vector") [param v] $ bodyStatements [
@@ -55,7 +55,7 @@ norm = docFunc "Calculate unit vector of this vector."
   where v = vecVar "v"
         mag = var "mag" double
 
-dot :: OOProg r vis smt => MS (r (Method r))
+dot :: OOProg r vis smt md => MS (r md)
 dot = docFunc "Calculate the dot product of two vectors."
   ["First vector.", "Second vector."] (Just "The dot product.") $
   method "dot" public classLevel double [param v1, param v2] $ bodyStatements [
@@ -74,7 +74,7 @@ dot = docFunc "Calculate the dot product of two vectors."
         res = var "res" double
         i = var "i" int
 
-add :: OOProg r vis smt => MS (r (Method r))
+add :: OOProg r vis smt md => MS (r md)
 add = docFunc "Calculate the resultant vector of two vectors."
   ["First vector.", "Second vector."] (Just "The resultant vector.") $
   method "add" public classLevel (obj "Vector") [param v1, param v2] $ bodyStatements [
@@ -92,7 +92,7 @@ add = docFunc "Calculate the resultant vector of two vectors."
         res = var "res" (arrayType double)
         i = var "i" int
 
-scale :: OOProg r vis smt => MS (r (Method r))
+scale :: OOProg r vis smt md => MS (r md)
 scale = docFunc "Scale this vector by a factor."
   ["Scalar factor."] (Just "A new scaled vector.") $
   method "scale" public classLevel (obj "Vector") [param v, param s] $ bodyStatements [
@@ -107,11 +107,11 @@ scale = docFunc "Scale this vector by a factor."
         res = var "res" (arrayType double)
         i = var "i" int
 
-print_ :: OOProg r vis smt => MS (r (Method r))
+print_ :: OOProg r vis smt md => MS (r md)
 print_ = docFunc "Prints the vector elements to console." [] Nothing $
   pubMethod "printSelf" void [] $ oneLiner $ printLn $ valueOf thisV
 
-main :: OOProg r vis smt => MS (r (Method r))
+main :: OOProg r vis smt md => MS (r md)
 main = mainFunction $ body [
     block [
       arrayDecDef ds1 mainFn [litDouble 1.0, litDouble 2.0, litDouble 3.0],

--- a/code/drasil-code/test/VectorTest.hs
+++ b/code/drasil-code/test/VectorTest.hs
@@ -3,9 +3,8 @@
 -- indexing, and dot products.
 module VectorTest (vectorTestProc) where
 
-import Drasil.GProc (SMethod, ProcProg, bodyStatements, TypeSym(..),
-  VariableSym(..), Literal(..), VariableValue(..), DeclStatement(..),
-  ScopeSym(..), MethodSym(..),
+import Drasil.GProc (ProcProg, MS, bodyStatements, TypeSym(..), VariableSym(..),
+  Literal(..), VariableValue(..), DeclStatement(..), ScopeSym(..), MethodSym(..),
   VisibilitySym(..), ParameterSym(..), ControlStatement(..), NativeVector(..),
   List(..))
 import qualified Drasil.GProc as GProc (GSProgram, ProgramSym(..), FileSym(..),
@@ -22,7 +21,7 @@ vectorTestProc = GProc.prog "VectorTest" ""
 
 -- | Takes two vectors and stores each vector operation's result, returning
 -- their dot product.
-vectorOps :: (ProcProg r vis smt) => SMethod r
+vectorOps :: (ProcProg r vis smt) => MS (r (Method r))
 vectorOps =
   function "vectorOps" public double [param (var "a" double), param (var "b" double)]
   (bodyStatements

--- a/code/drasil-code/test/VectorTest.hs
+++ b/code/drasil-code/test/VectorTest.hs
@@ -14,14 +14,14 @@ import Drasil.Metadata (watermark)
 import Prelude hiding (return,print,log,exp,sin,cos,tan)
 
 -- | A program with one function that applies each vector operation.
-vectorTestProc :: (ProcProg r vis smt) => GProc.GSProgram r
+vectorTestProc :: (ProcProg r vis smt md) => GProc.GSProgram r
 vectorTestProc = GProc.prog "VectorTest" ""
   [GProc.docMod "Tests native vector operations." watermark ["Drasil"] "" $
     GProc.fileDoc (GProc.buildModule "VectorTest" [] [vectorOps])]
 
 -- | Takes two vectors and stores each vector operation's result, returning
 -- their dot product.
-vectorOps :: (ProcProg r vis smt) => MS (r (Method r))
+vectorOps :: (ProcProg r vis smt md) => MS (r md)
 vectorOps =
   function "vectorOps" public double [param (var "a" double), param (var "b" double)]
   (bodyStatements

--- a/code/drasil-gen/lib/Drasil/Generator/Code.hs
+++ b/code/drasil-gen/lib/Drasil/Generator/Code.hs
@@ -51,7 +51,7 @@ genCode syst chs = directory [ps|src|] <$> traverse genLangCode (lang chs)
     genLangCode Matlab = genCallProc Matlab unMLC unMLP
 
     genCall
-      :: (OOProg progRepr vis smt, SoftwareDossierSym packRepr, Monad packRepr)
+      :: (OOProg progRepr vis smt md, SoftwareDossierSym packRepr, Monad packRepr)
       => Lang
       -> (progRepr (OO.Program progRepr) -> ProgData)
       -> (packRepr PackageData -> PackageData)
@@ -64,7 +64,7 @@ genCode syst chs = directory [ps|src|] <$> traverse genLangCode (lang chs)
       pure $ generateCode lng realUnProgRepr unPackRepr $ generator lng time samples chs spec
 
     genCallProc
-      :: (ProcProg progRepr vis smt, SoftwareDossierSym packRepr, Monad packRepr)
+      :: (ProcProg progRepr vis smt md, SoftwareDossierSym packRepr, Monad packRepr)
       => Lang
       -> (progRepr (Proc.Program progRepr) -> ProgData)
       -> (packRepr PackageData -> PackageData)

--- a/code/drasil-gool/lib/Drasil/GOOL.hs
+++ b/code/drasil-gool/lib/Drasil/GOOL.hs
@@ -1,7 +1,7 @@
 -- | re-export smart constructors for external code writing
 module Drasil.GOOL (Label, GSProgram, SFile, MSBody, MSBlock, MS, VS, SVariable,
-  SValue, SMethod, CSStateVar, SClass, FSModule, NamedArgs, Initializers,
-  SharedProg, SharedStatement, OOProg, OOStatement, ProgramSym(..), FileSym(..),
+  SValue, CSStateVar, SClass, FSModule, NamedArgs, Initializers, SharedProg,
+  SharedStatement, OOProg, OOStatement, ProgramSym(..), FileSym(..),
   AttachmentSym(..), BodySym(..), bodyStatements, oneLiner, BlockSym(..),
   TypeSym(..), OOTypeSym(..), BinderSym(..), StatementSym(..),
   AssignStatement(..), (&=), DeclStatement(..), OODeclStatement(..),
@@ -33,8 +33,8 @@ module Drasil.GOOL (Label, GSProgram, SFile, MSBody, MSBlock, MS, VS, SVariable,
   ) where
 
 import Drasil.Shared.InterfaceCommon (Label, MSBody, MSBlock, SVariable, SValue,
-  SMethod, NamedArgs, SharedProg, SharedStatement, BodySym(..), bodyStatements,
-  oneLiner, BlockSym(..), TypeSym(..), BinderSym(..), StatementSym(..),
+  NamedArgs, SharedProg, SharedStatement, BodySym(..), bodyStatements, oneLiner,
+  BlockSym(..), TypeSym(..), BinderSym(..), StatementSym(..),
   AssignStatement(..), (&=), DeclStatement(..), IOStatement(..),
   StringStatement(..), FunctionSym, FuncAppStatement(..), CommentStatement(..),
   ControlStatement(..), switchAsIf, ifNoElse, VariableSym(..), extVar,

--- a/code/drasil-gool/lib/Drasil/GOOL/CodeInfoOO.hs
+++ b/code/drasil-gool/lib/Drasil/GOOL/CodeInfoOO.hs
@@ -6,7 +6,7 @@
 module Drasil.GOOL.CodeInfoOO (CodeInfoOO(..)) where
 
 import Drasil.Shared.InterfaceCommon (UnRepr(..), MSBody, VSBinder, SValue,
-  SMethod, SharedProg, SharedStatement, BodySym(..), BlockSym(..), TypeSym(..),
+  SharedProg, SharedStatement, BodySym(..), BlockSym(..), TypeSym(..),
   TypeElim(..), VariableSym(..), VariableElim(..), ValueSym(..), Argument(..),
   Literal(..), MathConstant(..), VariableValue(..), CommandLineArgs(..),
   NumericExpression(..), BooleanExpression(..), Comparison(..),
@@ -486,7 +486,7 @@ noInfoScope = return $ sd Global -- Hack
 noInfoBinder :: VSBinder CodeInfoOO
 noInfoBinder = return $ return $ bindFormD "" (td Void "" empty) -- Hack
 
-updateMEMandCM :: String -> MSBody CodeInfoOO -> SMethod CodeInfoOO
+updateMEMandCM :: String -> MSBody CodeInfoOO -> MS (CodeInfoOO (Method CodeInfoOO))
 updateMEMandCM n b = do
   _ <- b
   modify (updateCallMap n . updateMethodExcMap n)

--- a/code/drasil-gool/lib/Drasil/GOOL/CodeInfoOO.hs
+++ b/code/drasil-gool/lib/Drasil/GOOL/CodeInfoOO.hs
@@ -52,15 +52,15 @@ instance Applicative CodeInfoOO where
 instance Monad CodeInfoOO where
   CI x >>= f = f x
 
-instance SharedProg CodeInfoOO () ()
+instance SharedProg CodeInfoOO () () ()
 instance SharedStatement CodeInfoOO ()
 instance OOStatement CodeInfoOO ()
-instance OOProg CodeInfoOO () ()
+instance OOProg CodeInfoOO () () ()
 
 instance UnRepr CodeInfoOO contents where
   unRepr = unCI
 
-instance ProgramSym CodeInfoOO () () where
+instance ProgramSym CodeInfoOO () () () where
   type Program CodeInfoOO = GOOLState
   prog _ _ fs = do
     mapM_ (zoom lensGStoFS) fs
@@ -68,7 +68,7 @@ instance ProgramSym CodeInfoOO () () where
     s <- S.get
     toState $ toCode s
 
-instance FileSym CodeInfoOO () () where
+instance FileSym CodeInfoOO () () () where
   type File CodeInfoOO = ()
   fileDoc = execute1
 
@@ -415,8 +415,7 @@ instance ParameterSym CodeInfoOO where
   param        _ = return $ return $ error "The return value of this isn't used, and the thunk shouldn't fire."
   pointerParam _ = return $ return $ error "The return value of this isn't used, and the thunk shouldn't fire."
 
-instance MethodSym CodeInfoOO () () where
-  type Method CodeInfoOO = ()
+instance MethodSym CodeInfoOO () () () where
   docMain = updateMEMandCM "main"
   function n _ _ _ = updateMEMandCM n
   mainFunction = updateMEMandCM "main"
@@ -427,7 +426,7 @@ instance MethodSym CodeInfoOO () () where
   inOutFunc      n _ _ _ _     = updateMEMandCM n
   docInOutFunc   n _ _ _ _ _   = updateMEMandCM n
 
-instance OOMethodSym CodeInfoOO () () where
+instance OOMethodSym CodeInfoOO () () () where
   method n _ _ _ _ = updateMEMandCM n
   getMethod _ = noInfo
   setMethod _ = noInfo
@@ -447,7 +446,7 @@ instance StateVarSym CodeInfoOO () where
   stateVarDef _ _ _ _ = noInfo
   constVar    _ _ _   = noInfo
 
-instance ClassSym CodeInfoOO () () where
+instance ClassSym CodeInfoOO () () () where
   type Class CodeInfoOO = ()
   buildClass _ _ cs ms = do
     n <- zoom lensCStoFS getModuleName
@@ -467,7 +466,7 @@ instance ClassSym CodeInfoOO () () where
     _ <- c
     noInfo
 
-instance ModuleSym CodeInfoOO () () where
+instance ModuleSym CodeInfoOO () () () where
   type Module CodeInfoOO = ()
   buildModule n _ funcs classes = do
     modify (setModuleName n)
@@ -486,7 +485,7 @@ noInfoScope = return $ sd Global -- Hack
 noInfoBinder :: VSBinder CodeInfoOO
 noInfoBinder = return $ return $ bindFormD "" (td Void "" empty) -- Hack
 
-updateMEMandCM :: String -> MSBody CodeInfoOO -> MS (CodeInfoOO (Method CodeInfoOO))
+updateMEMandCM :: String -> MSBody CodeInfoOO -> MS (CodeInfoOO ())
 updateMEMandCM n b = do
   _ <- b
   modify (updateCallMap n . updateMethodExcMap n)

--- a/code/drasil-gool/lib/Drasil/GOOL/InterfaceGOOL.hs
+++ b/code/drasil-gool/lib/Drasil/GOOL/InterfaceGOOL.hs
@@ -21,11 +21,11 @@ module Drasil.GOOL.InterfaceGOOL (
 
 import Drasil.Shared.InterfaceCommon (
   -- Types
-  Label, Library, MSBody, MSBlock, SVariable, SValue, NamedArgs, SMethod,
-  MixedCtorCall, PosCall, PosCtorCall, InOutCall, InOutFunc, DocInOutFunc,
+  Label, Library, MSBody, MSBlock, SVariable, SValue, NamedArgs, MixedCtorCall,
+  PosCall, PosCtorCall, InOutCall, InOutFunc, DocInOutFunc,
   -- Typeclasses
   SharedProg, SharedStatement, BodySym(body), TypeSym(..), FunctionSym,
-  MethodSym, VariableSym(var), ValueSym(valueType), VariableValue(valueOf),
+  MethodSym(..), VariableSym(var), ValueSym(valueType), VariableValue(valueOf),
   ValueExpression, List(listSize, listAdd), listOf, StatementSym(..),
   DeclStatement(listDecDef), FuncAppStatement, VisibilitySym(..), convType)
 import Drasil.Shared.CodeType (CodeType(..), ClassName)
@@ -62,7 +62,7 @@ type FSModule a = FS (a (Module a))
 class (ClassSym r vis smt) => ModuleSym r vis smt where
   type Module r
   -- Module name, import names, module functions, module classes
-  buildModule :: Label -> [Label] -> [SMethod r] -> [SClass r] -> FSModule r
+  buildModule :: Label -> [Label] -> [MS (r (Method r))] -> [SClass r] -> FSModule r
 
 type SClass a = CS (a (Class a))
 
@@ -70,16 +70,16 @@ class (OOMethodSym r vis smt, StateVarSym r vis) => ClassSym r vis smt where
   type Class r
   -- | Main external method for creating a class.
   --   Inputs: parent class, variables, constructor(s), methods
-  buildClass :: Maybe Label -> [CSStateVar r] -> [SMethod r] ->
-    [SMethod r] -> SClass r
+  buildClass :: Maybe Label -> [CSStateVar r] -> [MS (r (Method r))] ->
+    [MS (r (Method r))] -> SClass r
   -- | Creates an extra class.
   --   Inputs: class name, the rest are the same as buildClass.
-  extraClass :: Label -> Maybe Label -> [CSStateVar r] -> [SMethod r] ->
-    [SMethod r] -> SClass r
+  extraClass :: Label -> Maybe Label -> [CSStateVar r] -> [MS (r (Method r))] ->
+    [MS (r (Method r))] -> SClass r
   -- | Creates a class implementing interfaces.
   --   Inputs: class name, interface names, variables, constructor(s), methods
-  implementingClass :: Label -> [Label] -> [CSStateVar r] -> [SMethod r] ->
-    [SMethod r] -> SClass r
+  implementingClass :: Label -> [Label] -> [CSStateVar r] -> [MS (r (Method r))] ->
+    [MS (r (Method r))] -> SClass r
 
   docClass :: String -> SClass r -> SClass r
 
@@ -87,29 +87,29 @@ type Initializers r = [(SVariable r, SValue r)]
 
 class (MethodSym r vis smt, AttachmentSym r) => OOMethodSym r vis smt where
   method      :: Label -> r vis -> r (Attachment r) -> VS (r TypeData) ->
-    [MS (r ParamData)] -> MSBody r -> SMethod r
-  getMethod   :: SVariable r -> SMethod r
-  setMethod   :: SVariable r -> SMethod r
-  constructor :: [MS (r ParamData)] -> Initializers r -> MSBody r -> SMethod r
+    [MS (r ParamData)] -> MSBody r -> MS (r (Method r))
+  getMethod   :: SVariable r -> MS (r (Method r))
+  setMethod   :: SVariable r -> MS (r (Method r))
+  constructor :: [MS (r ParamData)] -> Initializers r -> MSBody r -> MS (r (Method r))
 
   -- inOutMethod and docInOutMethod both need the Attachment parameter
   inOutMethod :: Label -> r vis -> r (Attachment r) -> InOutFunc r
   docInOutMethod :: Label -> r vis -> r (Attachment r) -> DocInOutFunc r
 
 privMethod :: (OOMethodSym r vis smt) => Label -> VS (r TypeData) ->
-  [MS (r ParamData)] -> MSBody r -> SMethod r
+  [MS (r ParamData)] -> MSBody r -> MS (r (Method r))
 privMethod n = method n private instanceLevel
 
 pubMethod :: (OOMethodSym r vis smt) => Label -> VS (r TypeData) ->
-  [MS (r ParamData)] -> MSBody r -> SMethod r
+  [MS (r ParamData)] -> MSBody r -> MS (r (Method r))
 pubMethod n = method n public instanceLevel
 
 initializer :: (OOMethodSym r vis smt) => [MS (r ParamData)] ->
-  Initializers r -> SMethod r
+  Initializers r -> MS (r (Method r))
 initializer ps is = constructor ps is (body [])
 
 nonInitConstructor :: (OOMethodSym r vis smt) => [MS (r ParamData)] ->
-  MSBody r -> SMethod r
+  MSBody r -> MS (r (Method r))
 nonInitConstructor ps = constructor ps []
 
 type CSStateVar a = CS (a (StateVar a))

--- a/code/drasil-gool/lib/Drasil/GOOL/InterfaceGOOL.hs
+++ b/code/drasil-gool/lib/Drasil/GOOL/InterfaceGOOL.hs
@@ -33,9 +33,9 @@ import Drasil.Shared.Helpers (onStateValue)
 import Drasil.Shared.State (GS, FS, CS, MS, VS)
 import Drasil.Shared.AST (ScopeData, TypeData, ParamData, FuncData)
 
-class (SharedProg r vis smt, OOStatement r smt, ProgramSym r vis smt,
+class (SharedProg r vis smt md, OOStatement r smt, ProgramSym r vis smt md,
   ObserverPattern r smt, StrategyPattern r smt
-  ) => OOProg r vis smt
+  ) => OOProg r vis smt md
 
 class (SharedStatement r smt, GetSet r, InternalValueExp r, OOFuncAppStatement r smt,
   OOVariableValue r, OODeclStatement r smt, OOFuncAppStatement r smt,
@@ -44,13 +44,13 @@ class (SharedStatement r smt, GetSet r, InternalValueExp r, OOFuncAppStatement r
 
 type GSProgram a = GS (a (Program a))
 
-class (FileSym r vis smt) => ProgramSym r vis smt where
+class (FileSym r vis smt md) => ProgramSym r vis smt md where
   type Program r
   prog :: Label -> Label -> [SFile r] -> GSProgram r
 
 type SFile a = FS (a (File a))
 
-class (ModuleSym r vis smt) => FileSym r vis smt where
+class (ModuleSym r vis smt md) => FileSym r vis smt md where
   type File r
   fileDoc :: FSModule r -> SFile r
 
@@ -59,57 +59,57 @@ class (ModuleSym r vis smt) => FileSym r vis smt where
 
 type FSModule a = FS (a (Module a))
 
-class (ClassSym r vis smt) => ModuleSym r vis smt where
+class (ClassSym r vis smt md) => ModuleSym r vis smt md where
   type Module r
   -- Module name, import names, module functions, module classes
-  buildModule :: Label -> [Label] -> [MS (r (Method r))] -> [SClass r] -> FSModule r
+  buildModule :: Label -> [Label] -> [MS (r md)] -> [SClass r] -> FSModule r
 
 type SClass a = CS (a (Class a))
 
-class (OOMethodSym r vis smt, StateVarSym r vis) => ClassSym r vis smt where
+class (OOMethodSym r vis smt md, StateVarSym r vis) => ClassSym r vis smt md where
   type Class r
   -- | Main external method for creating a class.
   --   Inputs: parent class, variables, constructor(s), methods
-  buildClass :: Maybe Label -> [CSStateVar r] -> [MS (r (Method r))] ->
-    [MS (r (Method r))] -> SClass r
+  buildClass :: Maybe Label -> [CSStateVar r] -> [MS (r md)] ->
+    [MS (r md)] -> SClass r
   -- | Creates an extra class.
   --   Inputs: class name, the rest are the same as buildClass.
-  extraClass :: Label -> Maybe Label -> [CSStateVar r] -> [MS (r (Method r))] ->
-    [MS (r (Method r))] -> SClass r
+  extraClass :: Label -> Maybe Label -> [CSStateVar r] -> [MS (r md)] ->
+    [MS (r md)] -> SClass r
   -- | Creates a class implementing interfaces.
   --   Inputs: class name, interface names, variables, constructor(s), methods
-  implementingClass :: Label -> [Label] -> [CSStateVar r] -> [MS (r (Method r))] ->
-    [MS (r (Method r))] -> SClass r
+  implementingClass :: Label -> [Label] -> [CSStateVar r] -> [MS (r md)] ->
+    [MS (r md)] -> SClass r
 
   docClass :: String -> SClass r -> SClass r
 
 type Initializers r = [(SVariable r, SValue r)]
 
-class (MethodSym r vis smt, AttachmentSym r) => OOMethodSym r vis smt where
+class (MethodSym r vis smt md, AttachmentSym r) => OOMethodSym r vis smt md where
   method      :: Label -> r vis -> r (Attachment r) -> VS (r TypeData) ->
-    [MS (r ParamData)] -> MSBody r -> MS (r (Method r))
-  getMethod   :: SVariable r -> MS (r (Method r))
-  setMethod   :: SVariable r -> MS (r (Method r))
-  constructor :: [MS (r ParamData)] -> Initializers r -> MSBody r -> MS (r (Method r))
+    [MS (r ParamData)] -> MSBody r -> MS (r md)
+  getMethod   :: SVariable r -> MS (r md)
+  setMethod   :: SVariable r -> MS (r md)
+  constructor :: [MS (r ParamData)] -> Initializers r -> MSBody r -> MS (r md)
 
   -- inOutMethod and docInOutMethod both need the Attachment parameter
-  inOutMethod :: Label -> r vis -> r (Attachment r) -> InOutFunc r
-  docInOutMethod :: Label -> r vis -> r (Attachment r) -> DocInOutFunc r
+  inOutMethod :: Label -> r vis -> r (Attachment r) -> InOutFunc r md
+  docInOutMethod :: Label -> r vis -> r (Attachment r) -> DocInOutFunc r md
 
-privMethod :: (OOMethodSym r vis smt) => Label -> VS (r TypeData) ->
-  [MS (r ParamData)] -> MSBody r -> MS (r (Method r))
+privMethod :: (OOMethodSym r vis smt md) => Label -> VS (r TypeData) ->
+  [MS (r ParamData)] -> MSBody r -> MS (r md)
 privMethod n = method n private instanceLevel
 
-pubMethod :: (OOMethodSym r vis smt) => Label -> VS (r TypeData) ->
-  [MS (r ParamData)] -> MSBody r -> MS (r (Method r))
+pubMethod :: (OOMethodSym r vis smt md) => Label -> VS (r TypeData) ->
+  [MS (r ParamData)] -> MSBody r -> MS (r md)
 pubMethod n = method n public instanceLevel
 
-initializer :: (OOMethodSym r vis smt) => [MS (r ParamData)] ->
-  Initializers r -> MS (r (Method r))
+initializer :: (OOMethodSym r vis smt md) => [MS (r ParamData)] ->
+  Initializers r -> MS (r md)
 initializer ps is = constructor ps is (body [])
 
-nonInitConstructor :: (OOMethodSym r vis smt) => [MS (r ParamData)] ->
-  MSBody r -> MS (r (Method r))
+nonInitConstructor :: (OOMethodSym r vis smt md) => [MS (r ParamData)] ->
+  MSBody r -> MS (r md)
 nonInitConstructor ps = constructor ps []
 
 type CSStateVar a = CS (a (StateVar a))

--- a/code/drasil-gool/lib/Drasil/GOOL/LanguageRenderer/CSharpRenderer.hs
+++ b/code/drasil-gool/lib/Drasil/GOOL/LanguageRenderer/CSharpRenderer.hs
@@ -14,7 +14,7 @@ import Drasil.FileHandling.Legacy (indent)
 
 import Drasil.Shared.CodeType (CodeType(..))
 import Drasil.Shared.InterfaceCommon (UnRepr(..), SharedProg, SharedStatement,
-  Label, MSBody, SVariable, SValue, SMethod, BodySym(..), oneLiner, BlockSym(..),
+  Label, MSBody, SVariable, SValue, BodySym(..), oneLiner, BlockSym(..),
   TypeSym(..), TypeElim(..), getTypeString, VariableSym(..), VisibilitySym(..),
   VariableElim(..), ValueSym(..), Argument(..), Literal(..), MathConstant(..),
   VariableValue(..), CommandLineArgs(..), NumericExpression(..),
@@ -933,9 +933,9 @@ csVarDec ClassLevel _ = error "ClassLevel variables can't be declared locally to
 csVarDec InstanceLevel d = d
 
 csInOut :: (VS (CSharpCode TypeData) -> [MS (CSharpCode ParamData)] ->
-  MSBody CSharpCode -> SMethod CSharpCode) ->
+  MSBody CSharpCode -> MS (CSharpCode (Method CSharpCode))) ->
   [SVariable CSharpCode] -> [SVariable CSharpCode] -> [SVariable CSharpCode] ->
-  MSBody CSharpCode -> SMethod CSharpCode
+  MSBody CSharpCode -> MS (CSharpCode (Method CSharpCode))
 csInOut f ins [v] [] b = f (onStateValue variableType v) (map param ins)
   (on3StateValues (on3CodeValues surroundBody) (varDec v local) b (returnStmt $
   valueOf v))

--- a/code/drasil-gool/lib/Drasil/GOOL/LanguageRenderer/CSharpRenderer.hs
+++ b/code/drasil-gool/lib/Drasil/GOOL/LanguageRenderer/CSharpRenderer.hs
@@ -132,25 +132,25 @@ instance Applicative CSharpCode where
 instance Monad CSharpCode where
   CSC x >>= f = f x
 
-instance SharedProg CSharpCode Doc (Doc, Terminator)
+instance SharedProg CSharpCode Doc (Doc, Terminator) MethodData
 instance SharedStatement CSharpCode (Doc, Terminator)
 instance OOStatement CSharpCode (Doc, Terminator)
-instance OOProg CSharpCode Doc (Doc, Terminator)
+instance OOProg CSharpCode Doc (Doc, Terminator) MethodData
 
-instance ProgramSym CSharpCode Doc (Doc, Terminator) where
+instance ProgramSym CSharpCode Doc (Doc, Terminator) MethodData where
   type Program CSharpCode = ProgData
   prog n st files = do
     fs <- mapM (zoom lensGStoFS) files
     modify revFiles
     pure $ onCodeList (progD n st) fs
 
-instance CommonRenderSym CSharpCode Doc (Doc, Terminator)
-instance OORenderSym CSharpCode Doc (Doc, Terminator)
+instance CommonRenderSym CSharpCode Doc (Doc, Terminator) MethodData
+instance OORenderSym CSharpCode Doc (Doc, Terminator) MethodData
 
 instance UnRepr CSharpCode contents where
   unRepr = unCSC
 
-instance FileSym CSharpCode Doc (Doc, Terminator) where
+instance FileSym CSharpCode Doc (Doc, Terminator) MethodData where
   type File CSharpCode = FileData
   fileDoc m = do
     modify (setFileType Combined)
@@ -647,8 +647,7 @@ instance ParamElim CSharpCode where
   parameterType = variableType . onCodeValue paramVar
   parameter = paramDoc . unCSC
 
-instance MethodSym CSharpCode Doc (Doc, Terminator) where
-  type Method CSharpCode = MethodData
+instance MethodSym CSharpCode Doc (Doc, Terminator) MethodData where
   docMain = CP.docMain
   function = G.function
   mainFunction = CP.mainFunction string csMain
@@ -657,7 +656,7 @@ instance MethodSym CSharpCode Doc (Doc, Terminator) where
   inOutFunc n s = csInOut (function n s)
   docInOutFunc n s = CP.docInOutFunc (inOutFunc n s)
 
-instance OOMethodSym CSharpCode Doc (Doc, Terminator) where
+instance OOMethodSym CSharpCode Doc (Doc, Terminator) MethodData where
   method = G.method
   getMethod = G.getMethod
   setMethod = G.setMethod
@@ -666,13 +665,13 @@ instance OOMethodSym CSharpCode Doc (Doc, Terminator) where
   inOutMethod n s p = csInOut (method n s p)
   docInOutMethod n s p = CP.docInOutFunc (inOutMethod n s p)
 
-instance RenderMethod CSharpCode where
+instance RenderMethod CSharpCode MethodData where
   commentedFunc cmt m = on2StateValues (on2CodeValues updateMthd) m
     (onStateValue (onCodeValue R.commentedItem) cmt)
 
   mthdFromData _ d = toState $ toCode $ mthd d
 
-instance OORenderMethod CSharpCode Doc where
+instance OORenderMethod CSharpCode Doc MethodData where
   intMethod m n s p t ps b = do
     modify (if m then setCurrMain else id)
     tp <- t
@@ -681,7 +680,7 @@ instance OORenderMethod CSharpCode Doc where
   intFunc = C.intFunc
   destructor _ = error $ CP.destructorError csName
 
-instance MethodElim CSharpCode where
+instance MethodElim CSharpCode MethodData where
   method = mthdDoc . unCSC
 
 instance StateVarSym CSharpCode Doc where
@@ -693,7 +692,7 @@ instance StateVarSym CSharpCode Doc where
 instance StateVarElim CSharpCode where
   stateVar = unCSC
 
-instance ClassSym CSharpCode Doc (Doc, Terminator) where
+instance ClassSym CSharpCode Doc (Doc, Terminator) MethodData where
   type Class CSharpCode = Doc
   buildClass = G.buildClass
   extraClass = CP.extraClass
@@ -701,7 +700,7 @@ instance ClassSym CSharpCode Doc (Doc, Terminator) where
 
   docClass = CP.doxClass
 
-instance RenderClass CSharpCode Doc where
+instance RenderClass CSharpCode Doc MethodData where
   intClass = CP.intClass R.class'
 
   inherit = CP.inherit
@@ -712,7 +711,7 @@ instance RenderClass CSharpCode Doc where
 instance ClassElim CSharpCode where
   class' = unCSC
 
-instance ModuleSym CSharpCode Doc (Doc, Terminator) where
+instance ModuleSym CSharpCode Doc (Doc, Terminator) MethodData where
   type Module CSharpCode = ModData
   buildModule n = CP.buildModule' n langImport
 
@@ -933,9 +932,9 @@ csVarDec ClassLevel _ = error "ClassLevel variables can't be declared locally to
 csVarDec InstanceLevel d = d
 
 csInOut :: (VS (CSharpCode TypeData) -> [MS (CSharpCode ParamData)] ->
-  MSBody CSharpCode -> MS (CSharpCode (Method CSharpCode))) ->
+  MSBody CSharpCode -> MS (CSharpCode md)) ->
   [SVariable CSharpCode] -> [SVariable CSharpCode] -> [SVariable CSharpCode] ->
-  MSBody CSharpCode -> MS (CSharpCode (Method CSharpCode))
+  MSBody CSharpCode -> MS (CSharpCode md)
 csInOut f ins [v] [] b = f (onStateValue variableType v) (map param ins)
   (on3StateValues (on3CodeValues surroundBody) (varDec v local) b (returnStmt $
   valueOf v))

--- a/code/drasil-gool/lib/Drasil/GOOL/LanguageRenderer/CppRenderer.hs
+++ b/code/drasil-gool/lib/Drasil/GOOL/LanguageRenderer/CppRenderer.hs
@@ -142,14 +142,14 @@ hdrToSrc :: CppHdrCode a -> CppSrcCode a
 hdrToSrc (CPPHC a) = CPPSC a
 
 instance (Pair p) => SharedProg (p CppSrcCode CppHdrCode)
-  (Doc, VisibilityTag) (Doc, Terminator)
+  (Doc, VisibilityTag) (Doc, Terminator) MethodData
 instance (Pair p) => SharedStatement (p CppSrcCode CppHdrCode) (Doc, Terminator)
 instance (Pair p) => OOStatement (p CppSrcCode CppHdrCode) (Doc, Terminator)
 instance (Pair p) => OOProg (p CppSrcCode CppHdrCode)
-  (Doc, VisibilityTag) (Doc, Terminator)
+  (Doc, VisibilityTag) (Doc, Terminator) MethodData
 
 instance (Pair p) => ProgramSym (p CppSrcCode CppHdrCode)
-    (Doc, VisibilityTag) (Doc, Terminator) where
+    (Doc, VisibilityTag) (Doc, Terminator) MethodData where
   type Program (p CppSrcCode CppHdrCode) = ProgData
   prog n st mods = do
     m <-  mapM (zoom lensGStoFS) mods
@@ -160,13 +160,13 @@ instance (Pair p) => ProgramSym (p CppSrcCode CppHdrCode)
     pure $ pair p1 (toCode emptyProg)
 
 instance (Pair p) => CommonRenderSym (p CppSrcCode CppHdrCode)
-  (Doc, VisibilityTag) (Doc, Terminator)
+  (Doc, VisibilityTag) (Doc, Terminator) MethodData
 
 instance (Pair p) => UnRepr (p CppSrcCode CppHdrCode) contents where
   unRepr c = unCPPSC $ pfst c
 
 instance (Pair p) => FileSym (p CppSrcCode CppHdrCode)
-    (Doc, VisibilityTag) (Doc, Terminator) where
+    (Doc, VisibilityTag) (Doc, Terminator) MethodData where
   type File (p CppSrcCode CppHdrCode) = FileData
   fileDoc = pair1 fileDoc fileDoc
 
@@ -719,8 +719,7 @@ instance (Pair p) => ParamElim (p CppSrcCode CppHdrCode) where
   parameter p = RC.parameter $ pfst p
 
 instance (Pair p) => MethodSym (p CppSrcCode CppHdrCode)
-    (Doc, VisibilityTag) (Doc, Terminator) where
-  type Method (p CppSrcCode CppHdrCode) = MethodData
+    (Doc, VisibilityTag) (Doc, Terminator) MethodData where
   docMain = pair1 docMain docMain
   function n s t = pairValListVal
     (function n (pfst s)) (function n (psnd s))
@@ -742,7 +741,7 @@ instance (Pair p) => MethodSym (p CppSrcCode CppHdrCode)
     (map (zoom lensMStoVS . snd) bs)
 
 instance (Pair p) => OOMethodSym (p CppSrcCode CppHdrCode)
-    (Doc, VisibilityTag) (Doc, Terminator) where
+    (Doc, VisibilityTag) (Doc, Terminator) MethodData where
   method n s p t = pairValListVal
     (method n (pfst s) (pfst p)) (method n (psnd s) (psnd p))
     (zoom lensMStoVS t)
@@ -765,20 +764,20 @@ instance (Pair p) => OOMethodSym (p CppSrcCode CppHdrCode)
     (map (zoom lensMStoVS . snd) is) (map (zoom lensMStoVS . snd) os)
     (map (zoom lensMStoVS . snd) bs)
 
-instance (Pair p) => RenderMethod (p CppSrcCode CppHdrCode) where
+instance (Pair p) => RenderMethod (p CppSrcCode CppHdrCode) MethodData where
   commentedFunc = pair2 commentedFunc commentedFunc
 
   mthdFromData s d = on2StateValues pair (mthdFromData s d) (mthdFromData s d)
 
 instance (Pair p) => OORenderMethod (p CppSrcCode CppHdrCode)
-    (Doc, VisibilityTag) where
+    (Doc, VisibilityTag) MethodData where
   intMethod m n s p = pairValListVal
     (intMethod m n (pfst s) (pfst p)) (intMethod m n (psnd s) (psnd p))
   intFunc m n s p = pairValListVal
     (intFunc m n (pfst s) (pfst p)) (intFunc m n (psnd s) (psnd p))
   destructor = pair1List destructor destructor . map (zoom lensMStoCS)
 
-instance (Pair p) => MethodElim (p CppSrcCode CppHdrCode) where
+instance (Pair p) => MethodElim (p CppSrcCode CppHdrCode) MethodData where
   method m = RC.method $ pfst m
 
 instance (Pair p) => StateVarSym (p CppSrcCode CppHdrCode)
@@ -796,7 +795,7 @@ instance (Pair p) => StateVarElim (p CppSrcCode CppHdrCode) where
   stateVar v = RC.stateVar $ pfst v
 
 instance (Pair p) => ClassSym (p CppSrcCode CppHdrCode)
-    (Doc, VisibilityTag) (Doc, Terminator) where
+    (Doc, VisibilityTag) (Doc, Terminator) MethodData where
   type Class (p CppSrcCode CppHdrCode) = Doc
   buildClass p vs cs fs = do
     n <- zoom lensCStoFS getModuleName
@@ -813,7 +812,7 @@ instance (Pair p) => ClassSym (p CppSrcCode CppHdrCode)
   docClass d = pair1 (docClass d) (docClass d)
 
 instance (Pair p) => RenderClass (p CppSrcCode CppHdrCode)
-    (Doc, VisibilityTag) where
+    (Doc, VisibilityTag) MethodData where
   intClass n s i vs cs fs = pair3Lists
     (intClass n (pfst s) (pfst i)) (intClass n (psnd s) (psnd i))
     vs (map (zoom lensCStoMS) cs) (map (zoom lensCStoMS) fs)
@@ -827,7 +826,7 @@ instance (Pair p) => ClassElim (p CppSrcCode CppHdrCode) where
   class' c = RC.class' $ pfst c
 
 instance (Pair p) => ModuleSym (p CppSrcCode CppHdrCode)
-    (Doc, VisibilityTag) (Doc, Terminator) where
+    (Doc, VisibilityTag) (Doc, Terminator) MethodData where
   type Module (p CppSrcCode CppHdrCode) = ModData
   buildModule n is ms cs = do
     modify (setModuleName n)
@@ -1043,19 +1042,19 @@ instance Applicative CppSrcCode where
 instance Monad CppSrcCode where
   CPPSC x >>= f = f x
 
-instance ProgramSym CppSrcCode (Doc, VisibilityTag) (Doc, Terminator) where
+instance ProgramSym CppSrcCode (Doc, VisibilityTag) (Doc, Terminator) MethodData where
   type Program CppSrcCode = ProgData
   prog n st = onStateList (onCodeList (progD n st)) . map (zoom lensGStoFS)
 instance SharedStatement CppSrcCode (Doc, Terminator) where
 instance OOStatement CppSrcCode (Doc, Terminator) where
 
-instance CommonRenderSym CppSrcCode (Doc, VisibilityTag) (Doc, Terminator)
-instance OORenderSym CppSrcCode (Doc, VisibilityTag) (Doc, Terminator)
+instance CommonRenderSym CppSrcCode (Doc, VisibilityTag) (Doc, Terminator) MethodData
+instance OORenderSym CppSrcCode (Doc, VisibilityTag) (Doc, Terminator) MethodData
 
 instance UnRepr CppSrcCode contents where
   unRepr = unCPPSC
 
-instance FileSym CppSrcCode (Doc, VisibilityTag) (Doc, Terminator) where
+instance FileSym CppSrcCode (Doc, VisibilityTag) (Doc, Terminator) MethodData where
   type File CppSrcCode = FileData
   fileDoc m = do
     modify (setFileType Source)
@@ -1648,8 +1647,7 @@ instance ParamElim CppSrcCode where
   parameterType = variableType . onCodeValue paramVar
   parameter = paramDoc . unCPPSC
 
-instance MethodSym CppSrcCode (Doc, VisibilityTag) (Doc, Terminator) where
-  type Method CppSrcCode = MethodData
+instance MethodSym CppSrcCode (Doc, VisibilityTag) (Doc, Terminator) MethodData where
   docMain b = commentedFunc (docComment $ toState $ functionDox mainDesc
     [(argc, argcDesc), (argv, argvDesc)] [mainReturnDesc]) (mainFunction b)
   function = G.function
@@ -1667,7 +1665,7 @@ instance MethodSym CppSrcCode (Doc, VisibilityTag) (Doc, Terminator) where
   inOutFunc n s = cppsInOut (function n s)
   docInOutFunc n s = CP.docInOutFunc (inOutFunc n s)
 
-instance OOMethodSym CppSrcCode (Doc, VisibilityTag) (Doc, Terminator) where
+instance OOMethodSym CppSrcCode (Doc, VisibilityTag) (Doc, Terminator) MethodData where
   method = G.method
   getMethod = G.getMethod
   setMethod = G.setMethod
@@ -1676,12 +1674,12 @@ instance OOMethodSym CppSrcCode (Doc, VisibilityTag) (Doc, Terminator) where
   inOutMethod n s p = cppsInOut (method n s p)
   docInOutMethod n s p = CP.docInOutFunc (inOutMethod n s p)
 
-instance RenderMethod CppSrcCode where
+instance RenderMethod CppSrcCode MethodData where
   commentedFunc = cppCommentedFunc Source
 
   mthdFromData s d = toState $ toCode $ mthd s d
 
-instance OORenderMethod CppSrcCode (Doc, VisibilityTag) where
+instance OORenderMethod CppSrcCode (Doc, VisibilityTag) MethodData where
   intMethod m n s _ t ps b = do
     modify (if m then setCurrMain else id)
     c <- getClassName
@@ -1699,7 +1697,7 @@ instance OORenderMethod CppSrcCode (Doc, VisibilityTag) where
           bodyStatements $ loopIndexDec : deleteStatements
     in getClassName >>= (\n -> pubMethod ('~':n) void [] dbody)
 
-instance MethodElim CppSrcCode where
+instance MethodElim CppSrcCode MethodData where
   method = mthdDoc . unCPPSC
 
 instance StateVarSym CppSrcCode (Doc, VisibilityTag) where
@@ -1712,7 +1710,7 @@ instance StateVarSym CppSrcCode (Doc, VisibilityTag) where
 instance StateVarElim CppSrcCode where
   stateVar = stVar . unCPPSC
 
-instance ClassSym CppSrcCode (Doc, VisibilityTag) (Doc, Terminator) where
+instance ClassSym CppSrcCode (Doc, VisibilityTag) (Doc, Terminator) MethodData where
   type Class CppSrcCode = Doc
   buildClass = G.buildClass
   extraClass = CP.extraClass
@@ -1720,7 +1718,7 @@ instance ClassSym CppSrcCode (Doc, VisibilityTag) (Doc, Terminator) where
 
   docClass = CP.doxClass
 
-instance RenderClass CppSrcCode (Doc, VisibilityTag) where
+instance RenderClass CppSrcCode (Doc, VisibilityTag) MethodData where
   intClass n _ _ vs cs fs = do
     modify (setClassName n)
     on2StateLists cppsClass vs (map (zoom lensCStoMS) $ cs ++ fs ++ [destructor vs])
@@ -1734,7 +1732,7 @@ instance RenderClass CppSrcCode (Doc, VisibilityTag) where
 instance ClassElim CppSrcCode where
   class' = unCPPSC
 
-instance ModuleSym CppSrcCode (Doc, VisibilityTag) (Doc, Terminator) where
+instance ModuleSym CppSrcCode (Doc, VisibilityTag) (Doc, Terminator) MethodData where
   type Module CppSrcCode = ModData
   buildModule n is ms cs = CP.buildModule n (do
     ds <- getDefines
@@ -1785,15 +1783,15 @@ instance Applicative CppHdrCode where
 instance Monad CppHdrCode where
   CPPHC x >>= f = f x
 
-instance CommonRenderSym CppHdrCode (Doc, VisibilityTag) (Doc, Terminator)
-instance OORenderSym CppHdrCode (Doc, VisibilityTag) (Doc, Terminator)
+instance CommonRenderSym CppHdrCode (Doc, VisibilityTag) (Doc, Terminator) MethodData
+instance OORenderSym CppHdrCode (Doc, VisibilityTag) (Doc, Terminator) MethodData
 instance SharedStatement CppHdrCode (Doc, Terminator) where
 instance OOStatement CppHdrCode (Doc, Terminator) where
 
 instance UnRepr CppHdrCode contents where
   unRepr = unCPPHC
 
-instance FileSym CppHdrCode (Doc, VisibilityTag) (Doc, Terminator) where
+instance FileSym CppHdrCode (Doc, VisibilityTag) (Doc, Terminator) MethodData where
   type File CppHdrCode = FileData
   fileDoc m = do
     modify (setFileType Header)
@@ -2293,8 +2291,7 @@ instance ParamElim CppHdrCode where
   parameterType = variableType . onCodeValue paramVar
   parameter = paramDoc . unCPPHC
 
-instance MethodSym CppHdrCode (Doc, VisibilityTag) (Doc, Terminator) where
-  type Method CppHdrCode = MethodData
+instance MethodSym CppHdrCode (Doc, VisibilityTag) (Doc, Terminator) MethodData where
   docMain = mainFunction
   function = G.function
   mainFunction _ = modifyReturn (setVisibility Pub) $ toCode $ mthd Pub empty
@@ -2303,7 +2300,7 @@ instance MethodSym CppHdrCode (Doc, VisibilityTag) (Doc, Terminator) where
   inOutFunc n s = cpphInOut (function n s)
   docInOutFunc n s = CP.docInOutFunc (inOutFunc n s)
 
-instance OOMethodSym CppHdrCode (Doc, VisibilityTag) (Doc, Terminator) where
+instance OOMethodSym CppHdrCode (Doc, VisibilityTag) (Doc, Terminator) MethodData where
   method = G.method
   getMethod v = zoom lensMStoVS v >>= (\v' -> method (getterName $ variableName
     v') public instanceLevel (toState $ variableType v') [] (toState $ toCode empty))
@@ -2314,12 +2311,12 @@ instance OOMethodSym CppHdrCode (Doc, VisibilityTag) (Doc, Terminator) where
   inOutMethod n s p = cpphInOut (method n s p)
   docInOutMethod n s p = CP.docInOutFunc (inOutMethod n s p)
 
-instance RenderMethod CppHdrCode where
+instance RenderMethod CppHdrCode MethodData where
   commentedFunc = cppCommentedFunc Header
 
   mthdFromData s d = toState $ toCode $ mthd s d
 
-instance OORenderMethod CppHdrCode (Doc, VisibilityTag) where
+instance OORenderMethod CppHdrCode (Doc, VisibilityTag) MethodData where
   intMethod _ n s a t ps _ = do
     modify (setVisibility (snd $ unCPPHC s))
     tp <- t
@@ -2328,12 +2325,12 @@ instance OORenderMethod CppHdrCode (Doc, VisibilityTag) where
   intFunc _ = cpphIntFunc
   destructor vars = do
     n <- getClassName
-    m <- pubMethod ('~':n) void [] (pure (toCode empty)) :: MS (CppHdrCode (Method CppHdrCode))
+    m <- pubMethod ('~':n) void [] (pure (toCode empty)) :: MS (CppHdrCode MethodData)
     vs <- mapM (zoom lensMStoCS) vars
     pure $ toCode $ mthd Pub (emptyIfEmpty
       (vcat (map (RC.statement . onCodeValue destructSts) vs)) (RC.method m))
 
-instance MethodElim CppHdrCode where
+instance MethodElim CppHdrCode MethodData where
   method = mthdDoc . unCPPHC
 
 instance StateVarSym CppHdrCode (Doc, VisibilityTag) where
@@ -2352,7 +2349,7 @@ instance StateVarSym CppHdrCode (Doc, VisibilityTag) where
 instance StateVarElim CppHdrCode where
   stateVar = stVar . unCPPHC
 
-instance ClassSym CppHdrCode (Doc, VisibilityTag) (Doc, Terminator) where
+instance ClassSym CppHdrCode (Doc, VisibilityTag) (Doc, Terminator) MethodData where
   type Class CppHdrCode = Doc
   buildClass = G.buildClass
   extraClass = CP.extraClass
@@ -2360,7 +2357,7 @@ instance ClassSym CppHdrCode (Doc, VisibilityTag) (Doc, Terminator) where
 
   docClass = CP.doxClass
 
-instance RenderClass CppHdrCode (Doc, VisibilityTag) where
+instance RenderClass CppHdrCode (Doc, VisibilityTag) MethodData where
   intClass n _ i vs cstrs mths = do
     modify (setClassName n)
     vars <- sequence vs
@@ -2377,7 +2374,7 @@ instance RenderClass CppHdrCode (Doc, VisibilityTag) where
 instance ClassElim CppHdrCode where
   class' = unCPPHC
 
-instance ModuleSym CppHdrCode (Doc, VisibilityTag) (Doc, Terminator) where
+instance ModuleSym CppHdrCode (Doc, VisibilityTag) (Doc, Terminator) MethodData where
   type Module CppHdrCode = ModData
   buildModule n is = CP.buildModule n (do
     ds <- getHeaderDefines
@@ -2816,7 +2813,7 @@ cppsMethod is n c t ps b = emptyIfEmpty (RC.body b <> initList) $
         initList = hicat listSep' is
 
 cppConstructor :: [MS (CppSrcCode ParamData)] ->
-  NamedArgs CppSrcCode -> MSBody CppSrcCode -> MS (CppSrcCode (Method CppSrcCode))
+  NamedArgs CppSrcCode -> MSBody CppSrcCode -> MS (CppSrcCode MethodData)
 cppConstructor ps is b = getClassName >>= (\n -> join $ (\tp pms ivars ivals
   bod -> if null is then CP.constructor n ps is b else modify (setVisibility Pub) >>
   toState (toCode $ mthd Pub (cppsMethod (zipWith (\ivar ival -> RC.variable
@@ -2834,7 +2831,7 @@ cppsFunction n t ps b = vcat [
 cppsIntFunc :: (CppSrcCode TypeData -> [CppSrcCode ParamData] ->
   CppSrcCode (Body CppSrcCode) -> Doc) -> CppSrcCode (Doc, VisibilityTag) ->
   MSMthdType CppSrcCode -> [MS (CppSrcCode ParamData)] ->
-  MSBody CppSrcCode -> MS (CppSrcCode (Method CppSrcCode))
+  MSBody CppSrcCode -> MS (CppSrcCode MethodData)
 cppsIntFunc f s t ps b = do
   modify (setVisibility (snd $ unCPPSC s))
   tp <- t
@@ -2843,7 +2840,7 @@ cppsIntFunc f s t ps b = do
 
 cpphIntFunc :: Label -> CppHdrCode (Doc, VisibilityTag) ->
   CppHdrCode (Attachment CppHdrCode) -> MSMthdType CppHdrCode ->
-  [MS (CppHdrCode ParamData)] -> MSBody CppHdrCode -> MS (CppHdrCode (Method CppHdrCode))
+  [MS (CppHdrCode ParamData)] -> MSBody CppHdrCode -> MS (CppHdrCode MethodData)
 cpphIntFunc n s _ t ps _ = do
     modify (setVisibility (snd $ unCPPHC s))
     tp <- t
@@ -2920,20 +2917,20 @@ cpphStateVarDef s p vr vl = onStateValue (R.stateVar s (RC.perm p) .
   (varDec vr local) (varDecDef vr local vl))
 
 cpphVarsFuncsList :: VisibilityTag -> [CppHdrCode (StateVar CppHdrCode)] ->
-  [CppHdrCode (Method CppHdrCode)] -> Doc
+  [CppHdrCode MethodData] -> Doc
 cpphVarsFuncsList st vs fs =
   let visVs = [RC.stateVar v | v <- vs, getStVarScp (unCPPHC v) == st]
       visFs = [RC.method f | f <- fs, getMthdScp (unCPPHC f) == st]
   in vcat $ visVs ++ (if null visVs then empty else blank) : visFs
 
 cppsClass :: [CppSrcCode (StateVar CppSrcCode)] ->
-  [CppSrcCode (Method CppSrcCode)] -> CppSrcCode (Class CppSrcCode)
+  [CppSrcCode MethodData] -> CppSrcCode (Class CppSrcCode)
 cppsClass vs fs = toCode $ vibcat $ vcat vars : funcs
   where vars = map RC.stateVar vs
         funcs = map RC.method fs
 
 cpphClass :: Label -> CppHdrCode ParentSpec ->
-  [CppHdrCode (StateVar CppHdrCode)] -> [CppHdrCode (Method CppHdrCode)] ->
+  [CppHdrCode (StateVar CppHdrCode)] -> [CppHdrCode MethodData] ->
   CppHdrCode (Doc, VisibilityTag) -> CppHdrCode (Doc, VisibilityTag) ->
   CppHdrCode (Class CppHdrCode)
 cpphClass n ps vars funcs pub priv = let
@@ -2961,8 +2958,8 @@ cppInOutCall f n ins outs both = valStmt $ f n void (map valueOf both ++ ins
 
 cppsInOut :: (VS (CppSrcCode TypeData) ->
   [MS (CppSrcCode ParamData)] -> MSBody CppSrcCode ->
-  MS (CppSrcCode (Method CppSrcCode))) -> [SVariable CppSrcCode] -> [SVariable CppSrcCode] ->
-  [SVariable CppSrcCode] -> MSBody CppSrcCode -> MS (CppSrcCode (Method CppSrcCode))
+  MS (CppSrcCode md)) -> [SVariable CppSrcCode] -> [SVariable CppSrcCode] ->
+  [SVariable CppSrcCode] -> MSBody CppSrcCode -> MS (CppSrcCode md)
 cppsInOut f ins [v] [] b = f (onStateValue variableType v)
   (cppInOutParams ins [v] []) (on3StateValues (on3CodeValues surroundBody)
   (varDec v local) b (returnStmt $ valueOf v))
@@ -2973,8 +2970,8 @@ cppsInOut f ins outs both b = f void (cppInOutParams ins outs both) b
 
 cpphInOut :: (VS (CppHdrCode TypeData) ->
   [MS (CppHdrCode ParamData)] -> MSBody CppHdrCode ->
-  MS (CppHdrCode (Method CppHdrCode))) -> [SVariable CppHdrCode] -> [SVariable CppHdrCode] ->
-  [SVariable CppHdrCode] -> MSBody CppHdrCode -> MS (CppHdrCode (Method CppHdrCode))
+  MS (CppHdrCode md)) -> [SVariable CppHdrCode] -> [SVariable CppHdrCode] ->
+  [SVariable CppHdrCode] -> MSBody CppHdrCode -> MS (CppHdrCode md)
 cpphInOut f ins [v] [] b = f (onStateValue variableType v)
   (cppInOutParams ins [v] []) b
 cpphInOut f ins [] [v] b = f (onStateValue variableType v)

--- a/code/drasil-gool/lib/Drasil/GOOL/LanguageRenderer/CppRenderer.hs
+++ b/code/drasil-gool/lib/Drasil/GOOL/LanguageRenderer/CppRenderer.hs
@@ -15,10 +15,10 @@ import Drasil.FileHandling.Legacy (blank, indent, indentList)
 
 import Drasil.Shared.CodeType (CodeType(..))
 import Drasil.Shared.InterfaceCommon (UnRepr(..), SharedProg, SharedStatement,
-  Label, MSBody, SVariable, SValue, SMethod, NamedArgs, BodySym(..),
-  bodyStatements, oneLiner, BlockSym(..), TypeSym(..), TypeElim(..),
-  getTypeString, VariableSym(..), VisibilitySym(..), VariableElim(..),
-  ValueSym(..), Argument(..), Literal(..), MathConstant(..), VariableValue(..),
+  Label, MSBody, SVariable, SValue, NamedArgs, BodySym(..), bodyStatements,
+  oneLiner, BlockSym(..), TypeSym(..), TypeElim(..), getTypeString,
+  VariableSym(..), VisibilitySym(..), VariableElim(..), ValueSym(..),
+  Argument(..), Literal(..), MathConstant(..), VariableValue(..),
   CommandLineArgs(..), NumericExpression(..), BooleanExpression(..),
   Comparison(..), ValueExpression(..), funcApp, extFuncApp, IndexTranslator(..),
   Reference(..), Array(..), List(..), Set(..), InternalList(..),
@@ -2328,7 +2328,7 @@ instance OORenderMethod CppHdrCode (Doc, VisibilityTag) where
   intFunc _ = cpphIntFunc
   destructor vars = do
     n <- getClassName
-    m <- pubMethod ('~':n) void [] (pure (toCode empty)) :: SMethod CppHdrCode
+    m <- pubMethod ('~':n) void [] (pure (toCode empty)) :: MS (CppHdrCode (Method CppHdrCode))
     vs <- mapM (zoom lensMStoCS) vars
     pure $ toCode $ mthd Pub (emptyIfEmpty
       (vcat (map (RC.statement . onCodeValue destructSts) vs)) (RC.method m))
@@ -2816,7 +2816,7 @@ cppsMethod is n c t ps b = emptyIfEmpty (RC.body b <> initList) $
         initList = hicat listSep' is
 
 cppConstructor :: [MS (CppSrcCode ParamData)] ->
-  NamedArgs CppSrcCode -> MSBody CppSrcCode -> SMethod CppSrcCode
+  NamedArgs CppSrcCode -> MSBody CppSrcCode -> MS (CppSrcCode (Method CppSrcCode))
 cppConstructor ps is b = getClassName >>= (\n -> join $ (\tp pms ivars ivals
   bod -> if null is then CP.constructor n ps is b else modify (setVisibility Pub) >>
   toState (toCode $ mthd Pub (cppsMethod (zipWith (\ivar ival -> RC.variable
@@ -2834,7 +2834,7 @@ cppsFunction n t ps b = vcat [
 cppsIntFunc :: (CppSrcCode TypeData -> [CppSrcCode ParamData] ->
   CppSrcCode (Body CppSrcCode) -> Doc) -> CppSrcCode (Doc, VisibilityTag) ->
   MSMthdType CppSrcCode -> [MS (CppSrcCode ParamData)] ->
-  MSBody CppSrcCode -> SMethod CppSrcCode
+  MSBody CppSrcCode -> MS (CppSrcCode (Method CppSrcCode))
 cppsIntFunc f s t ps b = do
   modify (setVisibility (snd $ unCPPSC s))
   tp <- t
@@ -2843,7 +2843,7 @@ cppsIntFunc f s t ps b = do
 
 cpphIntFunc :: Label -> CppHdrCode (Doc, VisibilityTag) ->
   CppHdrCode (Attachment CppHdrCode) -> MSMthdType CppHdrCode ->
-  [MS (CppHdrCode ParamData)] -> MSBody CppHdrCode -> SMethod CppHdrCode
+  [MS (CppHdrCode ParamData)] -> MSBody CppHdrCode -> MS (CppHdrCode (Method CppHdrCode))
 cpphIntFunc n s _ t ps _ = do
     modify (setVisibility (snd $ unCPPHC s))
     tp <- t
@@ -2961,8 +2961,8 @@ cppInOutCall f n ins outs both = valStmt $ f n void (map valueOf both ++ ins
 
 cppsInOut :: (VS (CppSrcCode TypeData) ->
   [MS (CppSrcCode ParamData)] -> MSBody CppSrcCode ->
-  SMethod CppSrcCode) -> [SVariable CppSrcCode] -> [SVariable CppSrcCode] ->
-  [SVariable CppSrcCode] -> MSBody CppSrcCode -> SMethod CppSrcCode
+  MS (CppSrcCode (Method CppSrcCode))) -> [SVariable CppSrcCode] -> [SVariable CppSrcCode] ->
+  [SVariable CppSrcCode] -> MSBody CppSrcCode -> MS (CppSrcCode (Method CppSrcCode))
 cppsInOut f ins [v] [] b = f (onStateValue variableType v)
   (cppInOutParams ins [v] []) (on3StateValues (on3CodeValues surroundBody)
   (varDec v local) b (returnStmt $ valueOf v))
@@ -2973,8 +2973,8 @@ cppsInOut f ins outs both b = f void (cppInOutParams ins outs both) b
 
 cpphInOut :: (VS (CppHdrCode TypeData) ->
   [MS (CppHdrCode ParamData)] -> MSBody CppHdrCode ->
-  SMethod CppHdrCode) -> [SVariable CppHdrCode] -> [SVariable CppHdrCode] ->
-  [SVariable CppHdrCode] -> MSBody CppHdrCode -> SMethod CppHdrCode
+  MS (CppHdrCode (Method CppHdrCode))) -> [SVariable CppHdrCode] -> [SVariable CppHdrCode] ->
+  [SVariable CppHdrCode] -> MSBody CppHdrCode -> MS (CppHdrCode (Method CppHdrCode))
 cpphInOut f ins [v] [] b = f (onStateValue variableType v)
   (cppInOutParams ins [v] []) b
 cpphInOut f ins [] [v] b = f (onStateValue variableType v)

--- a/code/drasil-gool/lib/Drasil/GOOL/LanguageRenderer/JavaRenderer.hs
+++ b/code/drasil-gool/lib/Drasil/GOOL/LanguageRenderer/JavaRenderer.hs
@@ -14,7 +14,7 @@ import Drasil.FileHandling.Legacy (indent)
 
 import Drasil.Shared.CodeType (CodeType(..))
 import Drasil.Shared.InterfaceCommon (UnRepr(..), SharedProg, SharedStatement,
-  Label, MSBody, SVariable, SValue, SMethod, BodySym(..), oneLiner, BlockSym(..),
+  Label, MSBody, SVariable, SValue, BodySym(..), oneLiner, BlockSym(..),
   TypeSym(..), TypeElim(..), getTypeString, VariableSym(..), VisibilitySym(..),
   VariableElim(..),ValueSym(..), Argument(..), Literal(..), MathConstant(..),
   VariableValue(..), CommandLineArgs(..), NumericExpression(..),
@@ -1057,9 +1057,9 @@ jInOutCall f n ins outs both = fCall rets
           (f n jArrayType (map valueOf both ++ ins)) : jAssignFromArray 0 xs))
 
 jInOut :: (VS (JavaCode TypeData) -> [MS (JavaCode ParamData)] ->
-  MSBody JavaCode -> SMethod JavaCode) -> [SVariable JavaCode] ->
+  MSBody JavaCode -> MS (JavaCode (Method JavaCode))) -> [SVariable JavaCode] ->
   [SVariable JavaCode] -> [SVariable JavaCode] -> MSBody JavaCode ->
-  SMethod JavaCode
+  MS (JavaCode (Method JavaCode))
 jInOut f ins [] [] b = f void (map param ins) b
 jInOut f ins [v] [] b = f (onStateValue variableType v) (map param ins)
   (on3StateValues (on3CodeValues surroundBody) (varDec v local) b (returnStmt $
@@ -1085,9 +1085,9 @@ jInOut f ins outs both b = f (returnTp rets)
         rets = both ++ outs
 
 jDocInOut :: (RenderMethod r) => ([SVariable r] ->
-  [SVariable r] -> [SVariable r] -> MSBody r -> SMethod r) -> String ->
+  [SVariable r] -> [SVariable r] -> MSBody r -> MS (r (Method r))) -> String ->
   [(String, SVariable r)] -> [(String, SVariable r)] ->
-  [(String, SVariable r)] -> MSBody r -> SMethod r
+  [(String, SVariable r)] -> MSBody r -> MS (r (Method r))
 jDocInOut f desc is [] [] b = docFuncRepr functionDox desc (map fst is) []
   (f (map snd is) [] [] b)
 jDocInOut f desc is [o] [] b = docFuncRepr functionDox desc (map fst is)
@@ -1101,7 +1101,7 @@ jDocInOut f desc is os bs b = docFuncRepr  functionDox desc (map fst $ bs ++ is)
 
 jExtraClass
   :: (RenderClass r vis, RenderVisibility r vis)
-  => Label -> Maybe Label -> [CSStateVar r] -> [SMethod r] -> [SMethod r] -> SClass r
+  => Label -> Maybe Label -> [CSStateVar r] -> [MS (r (Method r))] -> [MS (r (Method r))] -> SClass r
 jExtraClass n = intClass n (visibilityFromData Priv empty) . inherit
 
 addCallExcsCurrMod :: String -> VS ()

--- a/code/drasil-gool/lib/Drasil/GOOL/LanguageRenderer/JavaRenderer.hs
+++ b/code/drasil-gool/lib/Drasil/GOOL/LanguageRenderer/JavaRenderer.hs
@@ -132,24 +132,24 @@ instance Applicative JavaCode where
 instance Monad JavaCode where
   JC x >>= f = f x
 
-instance SharedProg JavaCode Doc (Doc, Terminator)
+instance SharedProg JavaCode Doc (Doc, Terminator) MethodData
 instance SharedStatement JavaCode (Doc, Terminator)
 instance OOStatement JavaCode (Doc, Terminator)
-instance OOProg JavaCode Doc (Doc, Terminator)
+instance OOProg JavaCode Doc (Doc, Terminator) MethodData
 
-instance ProgramSym JavaCode Doc (Doc, Terminator) where
+instance ProgramSym JavaCode Doc (Doc, Terminator) MethodData where
   type Program JavaCode = ProgData
   prog n st fs = modifyReturnList (map (zoom lensGStoFS) fs) (revFiles .
     addProgNameToPaths n) (onCodeList (progD n st . map (R.package n
     endStatement)))
 
-instance CommonRenderSym JavaCode Doc (Doc, Terminator)
-instance OORenderSym JavaCode Doc (Doc, Terminator)
+instance CommonRenderSym JavaCode Doc (Doc, Terminator) MethodData
+instance OORenderSym JavaCode Doc (Doc, Terminator) MethodData
 
 instance UnRepr JavaCode contents where
   unRepr = unJC
 
-instance FileSym JavaCode Doc (Doc, Terminator) where
+instance FileSym JavaCode Doc (Doc, Terminator) MethodData where
   type File JavaCode = FileData
   fileDoc m = do
     modify (setFileType Combined)
@@ -670,8 +670,7 @@ instance ParamElim JavaCode where
   parameterType = variableType . onCodeValue paramVar
   parameter = paramDoc . unJC
 
-instance MethodSym JavaCode Doc (Doc, Terminator) where
-  type Method JavaCode = MethodData
+instance MethodSym JavaCode Doc (Doc, Terminator) MethodData where
   docMain = CP.docMain
   function = G.function
   mainFunction = CP.mainFunction string mainFunc
@@ -680,7 +679,7 @@ instance MethodSym JavaCode Doc (Doc, Terminator) where
   inOutFunc n s = jInOut (function n s)
   docInOutFunc n s = jDocInOut (inOutFunc n s)
 
-instance OOMethodSym JavaCode Doc (Doc, Terminator) where
+instance OOMethodSym JavaCode Doc (Doc, Terminator) MethodData where
   method = G.method
   getMethod = G.getMethod
   setMethod = G.setMethod
@@ -689,13 +688,13 @@ instance OOMethodSym JavaCode Doc (Doc, Terminator) where
   inOutMethod n s p = jInOut (method n s p)
   docInOutMethod n s p = jDocInOut (inOutMethod n s p)
 
-instance RenderMethod JavaCode where
+instance RenderMethod JavaCode MethodData where
   commentedFunc cmt m = on2StateValues (on2CodeValues updateMthd) m
     (onStateValue (onCodeValue R.commentedItem) cmt)
 
   mthdFromData _ d = toState $ toCode $ mthd d
 
-instance OORenderMethod JavaCode Doc where
+instance OORenderMethod JavaCode Doc MethodData where
   intMethod m n s p t ps b = do
     tp <- t
     pms <- sequence ps
@@ -710,7 +709,7 @@ instance OORenderMethod JavaCode Doc where
   intFunc = C.intFunc
   destructor _ = error $ CP.destructorError jName
 
-instance MethodElim JavaCode where
+instance MethodElim JavaCode MethodData where
   method = mthdDoc . unJC
 
 instance StateVarSym JavaCode Doc where
@@ -722,7 +721,7 @@ instance StateVarSym JavaCode Doc where
 instance StateVarElim JavaCode where
   stateVar = unJC
 
-instance ClassSym JavaCode Doc (Doc, Terminator) where
+instance ClassSym JavaCode Doc (Doc, Terminator) MethodData where
   type Class JavaCode = Doc
   buildClass = G.buildClass
   extraClass = jExtraClass
@@ -730,7 +729,7 @@ instance ClassSym JavaCode Doc (Doc, Terminator) where
 
   docClass = CP.doxClass
 
-instance RenderClass JavaCode Doc where
+instance RenderClass JavaCode Doc MethodData where
   intClass = CP.intClass R.class'
 
   inherit n = toCode $ maybe empty ((jExtends <+>) . text) n
@@ -741,7 +740,7 @@ instance RenderClass JavaCode Doc where
 instance ClassElim JavaCode where
   class' = unJC
 
-instance ModuleSym JavaCode Doc (Doc, Terminator) where
+instance ModuleSym JavaCode Doc (Doc, Terminator) MethodData where
   type Module JavaCode = ModData
   buildModule n = CP.buildModule' n langImport
 
@@ -1057,9 +1056,9 @@ jInOutCall f n ins outs both = fCall rets
           (f n jArrayType (map valueOf both ++ ins)) : jAssignFromArray 0 xs))
 
 jInOut :: (VS (JavaCode TypeData) -> [MS (JavaCode ParamData)] ->
-  MSBody JavaCode -> MS (JavaCode (Method JavaCode))) -> [SVariable JavaCode] ->
+  MSBody JavaCode -> MS (JavaCode md)) -> [SVariable JavaCode] ->
   [SVariable JavaCode] -> [SVariable JavaCode] -> MSBody JavaCode ->
-  MS (JavaCode (Method JavaCode))
+  MS (JavaCode md)
 jInOut f ins [] [] b = f void (map param ins) b
 jInOut f ins [v] [] b = f (onStateValue variableType v) (map param ins)
   (on3StateValues (on3CodeValues surroundBody) (varDec v local) b (returnStmt $
@@ -1084,10 +1083,10 @@ jInOut f ins outs both b = f (returnTp rets)
         decls = multi $ map (`varDec` local) outs
         rets = both ++ outs
 
-jDocInOut :: (RenderMethod r) => ([SVariable r] ->
-  [SVariable r] -> [SVariable r] -> MSBody r -> MS (r (Method r))) -> String ->
+jDocInOut :: (RenderMethod r md) => ([SVariable r] ->
+  [SVariable r] -> [SVariable r] -> MSBody r -> MS (r md)) -> String ->
   [(String, SVariable r)] -> [(String, SVariable r)] ->
-  [(String, SVariable r)] -> MSBody r -> MS (r (Method r))
+  [(String, SVariable r)] -> MSBody r -> MS (r md)
 jDocInOut f desc is [] [] b = docFuncRepr functionDox desc (map fst is) []
   (f (map snd is) [] [] b)
 jDocInOut f desc is [o] [] b = docFuncRepr functionDox desc (map fst is)
@@ -1100,8 +1099,8 @@ jDocInOut f desc is os bs b = docFuncRepr  functionDox desc (map fst $ bs ++ is)
           map fst os
 
 jExtraClass
-  :: (RenderClass r vis, RenderVisibility r vis)
-  => Label -> Maybe Label -> [CSStateVar r] -> [MS (r (Method r))] -> [MS (r (Method r))] -> SClass r
+  :: (RenderClass r vis md, RenderVisibility r vis)
+  => Label -> Maybe Label -> [CSStateVar r] -> [MS (r md)] -> [MS (r md)] -> SClass r
 jExtraClass n = intClass n (visibilityFromData Priv empty) . inherit
 
 addCallExcsCurrMod :: String -> VS ()

--- a/code/drasil-gool/lib/Drasil/GOOL/LanguageRenderer/PythonRenderer.hs
+++ b/code/drasil-gool/lib/Drasil/GOOL/LanguageRenderer/PythonRenderer.hs
@@ -121,25 +121,25 @@ instance Applicative PythonCode where
 instance Monad PythonCode where
   PC x >>= f = f x
 
-instance SharedProg PythonCode Doc (Doc, Terminator)
+instance SharedProg PythonCode Doc (Doc, Terminator) MethodData
 instance SharedStatement PythonCode (Doc, Terminator)
 instance OOStatement PythonCode (Doc, Terminator)
-instance OOProg PythonCode Doc (Doc, Terminator)
+instance OOProg PythonCode Doc (Doc, Terminator) MethodData
 
-instance ProgramSym PythonCode Doc (Doc, Terminator) where
+instance ProgramSym PythonCode Doc (Doc, Terminator) MethodData where
   type Program PythonCode = ProgData
   prog n st files = do
     fs <- mapM (zoom lensGStoFS) files
     modify revFiles
     pure $ onCodeList (progD n st) fs
 
-instance CommonRenderSym PythonCode Doc (Doc, Terminator)
-instance OORenderSym PythonCode Doc (Doc, Terminator)
+instance CommonRenderSym PythonCode Doc (Doc, Terminator) MethodData
+instance OORenderSym PythonCode Doc (Doc, Terminator) MethodData
 
 instance UnRepr PythonCode contents where
   unRepr = unPC
 
-instance FileSym PythonCode Doc (Doc, Terminator) where
+instance FileSym PythonCode Doc (Doc, Terminator) MethodData where
   type File PythonCode = FileData
   fileDoc m = do
     modify (setFileType Combined)
@@ -654,8 +654,7 @@ instance ParamElim PythonCode where
   parameterType = variableType . onCodeValue paramVar
   parameter = paramDoc . unPC
 
-instance MethodSym PythonCode Doc (Doc, Terminator) where
-  type Method PythonCode = MethodData
+instance MethodSym PythonCode Doc (Doc, Terminator) MethodData where
   docMain = mainFunction
   function = G.function
   mainFunction = CP.mainBody
@@ -664,7 +663,7 @@ instance MethodSym PythonCode Doc (Doc, Terminator) where
   inOutFunc n s = CP.inOutFunc (function n s)
   docInOutFunc n s = CP.docInOutFunc' functionDox (inOutFunc n s)
 
-instance OOMethodSym PythonCode Doc (Doc, Terminator) where
+instance OOMethodSym PythonCode Doc (Doc, Terminator) MethodData where
   method = G.method
   getMethod = G.getMethod
   setMethod = G.setMethod
@@ -673,13 +672,13 @@ instance OOMethodSym PythonCode Doc (Doc, Terminator) where
   inOutMethod n s p = CP.inOutFunc (method n s p)
   docInOutMethod n s p = CP.docInOutFunc' functionDox (inOutMethod n s p)
 
-instance RenderMethod PythonCode where
+instance RenderMethod PythonCode MethodData where
   commentedFunc cmt m = on2StateValues (on2CodeValues updateMthd) m
     (onStateValue (onCodeValue R.commentedItem) cmt)
 
   mthdFromData _ d = toState $ toCode $ mthd d
 
-instance OORenderMethod PythonCode Doc where
+instance OORenderMethod PythonCode Doc MethodData where
   intMethod m n _ a _ ps b = do
     modify (if m then setCurrMain else id)
     sl <- zoom lensMStoVS self
@@ -692,7 +691,7 @@ instance OORenderMethod PythonCode Doc where
     pure $ toCode $ mthd $ pyFunction n pms bd
   destructor _ = error $ CP.destructorError pyName
 
-instance MethodElim PythonCode where
+instance MethodElim PythonCode MethodData where
   method = mthdDoc . unPC
 
 instance StateVarSym PythonCode Doc where
@@ -705,7 +704,7 @@ instance StateVarSym PythonCode Doc where
 instance StateVarElim PythonCode where
   stateVar = unPC
 
-instance ClassSym PythonCode Doc (Doc, Terminator) where
+instance ClassSym PythonCode Doc (Doc, Terminator) MethodData where
   type Class PythonCode = Doc
   buildClass par sVars cstrs = if length cstrs <= 1
                                   then G.buildClass par sVars cstrs
@@ -721,7 +720,7 @@ instance ClassSym PythonCode Doc (Doc, Terminator) where
 
   docClass = CP.doxClass
 
-instance RenderClass PythonCode Doc where
+instance RenderClass PythonCode Doc MethodData where
   intClass = CP.intClass pyClass
 
   inherit n = toCode $ maybe empty (parens . text) n
@@ -732,7 +731,7 @@ instance RenderClass PythonCode Doc where
 instance ClassElim PythonCode where
   class' = unPC
 
-instance ModuleSym PythonCode Doc (Doc, Terminator) where
+instance ModuleSym PythonCode Doc (Doc, Terminator) MethodData where
   type Module PythonCode = ModData
   buildModule n is = CP.buildModule n (do
     lis <- getLangImports

--- a/code/drasil-gool/lib/Drasil/GOOL/LanguageRenderer/SwiftRenderer.hs
+++ b/code/drasil-gool/lib/Drasil/GOOL/LanguageRenderer/SwiftRenderer.hs
@@ -132,25 +132,25 @@ instance Applicative SwiftCode where
 instance Monad SwiftCode where
   SC x >>= f = f x
 
-instance SharedProg SwiftCode Doc (Doc, Terminator)
+instance SharedProg SwiftCode Doc (Doc, Terminator) MethodData
 instance SharedStatement SwiftCode (Doc, Terminator)
 instance OOStatement SwiftCode (Doc, Terminator)
-instance OOProg SwiftCode Doc (Doc, Terminator)
+instance OOProg SwiftCode Doc (Doc, Terminator) MethodData
 
-instance ProgramSym SwiftCode Doc (Doc, Terminator) where
+instance ProgramSym SwiftCode Doc (Doc, Terminator) MethodData where
   type Program SwiftCode = ProgData
   prog n st files = do
     fs <- mapM (zoom lensGStoFS) files
     modify revFiles
     pure $ onCodeList (progD n st) fs
 
-instance CommonRenderSym SwiftCode Doc (Doc, Terminator)
-instance OORenderSym SwiftCode Doc (Doc, Terminator)
+instance CommonRenderSym SwiftCode Doc (Doc, Terminator) MethodData
+instance OORenderSym SwiftCode Doc (Doc, Terminator) MethodData
 
 instance UnRepr SwiftCode contents where
   unRepr = unSC
 
-instance FileSym SwiftCode Doc (Doc, Terminator) where
+instance FileSym SwiftCode Doc (Doc, Terminator) MethodData where
   type File SwiftCode = FileData
   fileDoc m = do
     modify (setFileType Combined)
@@ -688,8 +688,7 @@ instance ParamElim SwiftCode where
   parameterType = variableType . onCodeValue paramVar
   parameter = paramDoc . unSC
 
-instance MethodSym SwiftCode Doc (Doc, Terminator) where
-  type Method SwiftCode = MethodData
+instance MethodSym SwiftCode Doc (Doc, Terminator) MethodData where
   docMain = mainFunction
   function = G.function
   mainFunction = CP.mainBody
@@ -699,7 +698,7 @@ instance MethodSym SwiftCode Doc (Doc, Terminator) where
 
   docInOutFunc n s = CP.docInOutFunc' CP.functionDoc (inOutFunc n s)
 
-instance OOMethodSym SwiftCode Doc (Doc, Terminator) where
+instance OOMethodSym SwiftCode Doc (Doc, Terminator) MethodData where
   method = G.method
   getMethod = G.getMethod
   setMethod = G.setMethod
@@ -708,18 +707,18 @@ instance OOMethodSym SwiftCode Doc (Doc, Terminator) where
   inOutMethod n s p = CP.inOutFunc (method n s p)
   docInOutMethod n s p = CP.docInOutFunc' CP.functionDoc (inOutMethod n s p)
 
-instance RenderMethod SwiftCode where
+instance RenderMethod SwiftCode MethodData where
   commentedFunc cmt m = on2StateValues (on2CodeValues updateMthd) m
     (onStateValue (onCodeValue R.commentedItem) cmt)
 
   mthdFromData _ d = toState $ toCode $ mthd d
 
-instance OORenderMethod SwiftCode Doc where
+instance OORenderMethod SwiftCode Doc MethodData where
   intMethod _ = swiftMethod
   intFunc _ n s _ = swiftMethod n s instanceLevel
   destructor _ = error $ CP.destructorError swiftName
 
-instance MethodElim SwiftCode where
+instance MethodElim SwiftCode MethodData where
   method = mthdDoc . unSC
 
 instance StateVarSym SwiftCode Doc where
@@ -733,7 +732,7 @@ instance StateVarSym SwiftCode Doc where
 instance StateVarElim SwiftCode where
   stateVar = unSC
 
-instance ClassSym SwiftCode Doc (Doc, Terminator) where
+instance ClassSym SwiftCode Doc (Doc, Terminator) MethodData where
   type Class SwiftCode = Doc
   buildClass = G.buildClass
   extraClass = CP.extraClass
@@ -741,7 +740,7 @@ instance ClassSym SwiftCode Doc (Doc, Terminator) where
 
   docClass = G.docClass swiftClassDoc
 
-instance RenderClass SwiftCode Doc where
+instance RenderClass SwiftCode Doc MethodData where
   intClass = CP.intClass R.class'
 
   inherit = CP.inherit
@@ -752,7 +751,7 @@ instance RenderClass SwiftCode Doc where
 instance ClassElim SwiftCode where
   class' = unSC
 
-instance ModuleSym SwiftCode Doc (Doc, Terminator) where
+instance ModuleSym SwiftCode Doc (Doc, Terminator) MethodData where
   type Module SwiftCode = ModData
   buildModule n is fs cs = do
     modify (setModuleName n) -- This needs to be set before the functions/
@@ -1204,7 +1203,7 @@ swiftParam io v = swiftNoLabel <+> RC.variable v <> swiftTypeSpec <+> io
 
 swiftMethod :: Label -> SwiftCode Doc ->
   SwiftCode (Attachment SwiftCode) -> MSMthdType SwiftCode ->
-  [MS (SwiftCode ParamData)] -> MSBody SwiftCode -> MS (SwiftCode (Method SwiftCode))
+  [MS (SwiftCode ParamData)] -> MSBody SwiftCode -> MS (SwiftCode MethodData)
 swiftMethod n s p t ps b = do
   tp <- t
   pms <- sequence ps
@@ -1223,7 +1222,7 @@ swiftConstructor
   :: [MS (SwiftCode ParamData)]
   -> Initializers SwiftCode
   -> MSBody SwiftCode
-  -> MS (SwiftCode (Method SwiftCode))
+  -> MS (SwiftCode MethodData)
 swiftConstructor ps is b = do
   pms <- sequence ps
   bod <- multiBody [G.initStmts is, b]

--- a/code/drasil-gool/lib/Drasil/GOOL/LanguageRenderer/SwiftRenderer.hs
+++ b/code/drasil-gool/lib/Drasil/GOOL/LanguageRenderer/SwiftRenderer.hs
@@ -14,7 +14,7 @@ import Drasil.FileHandling.Legacy (indent)
 
 import Drasil.Shared.CodeType (CodeType(..))
 import Drasil.Shared.InterfaceCommon (UnRepr(..), SharedProg, SharedStatement,
-  Label, MSBody, MSBlock, SVariable, SValue, SMethod, BodySym(..), oneLiner,
+  Label, MSBody, MSBlock, SVariable, SValue, BodySym(..), oneLiner,
   bodyStatements, BlockSym(..), TypeSym(..), TypeElim(..), getTypeString,
   VariableSym(..), VisibilitySym(..), VariableElim(..), ValueSym(..),
   Argument(..), Literal(..), MathConstant(..), VariableValue(..),
@@ -1204,7 +1204,7 @@ swiftParam io v = swiftNoLabel <+> RC.variable v <> swiftTypeSpec <+> io
 
 swiftMethod :: Label -> SwiftCode Doc ->
   SwiftCode (Attachment SwiftCode) -> MSMthdType SwiftCode ->
-  [MS (SwiftCode ParamData)] -> MSBody SwiftCode -> SMethod SwiftCode
+  [MS (SwiftCode ParamData)] -> MSBody SwiftCode -> MS (SwiftCode (Method SwiftCode))
 swiftMethod n s p t ps b = do
   tp <- t
   pms <- sequence ps
@@ -1223,7 +1223,7 @@ swiftConstructor
   :: [MS (SwiftCode ParamData)]
   -> Initializers SwiftCode
   -> MSBody SwiftCode
-  -> SMethod SwiftCode
+  -> MS (SwiftCode (Method SwiftCode))
 swiftConstructor ps is b = do
   pms <- sequence ps
   bod <- multiBody [G.initStmts is, b]

--- a/code/drasil-gool/lib/Drasil/GOOL/RendererClassesOO.hs
+++ b/code/drasil-gool/lib/Drasil/GOOL/RendererClassesOO.hs
@@ -8,7 +8,7 @@ module Drasil.GOOL.RendererClassesOO (
 ) where
 
 import Drasil.Shared.InterfaceCommon (Label, MSBody, SVariable, SValue,
-  BlockSym(..), MethodSym(..))
+  BlockSym(..))
 import qualified Drasil.GOOL.InterfaceGOOL as IG (SFile, FSModule, SClass,
   CSStateVar, OOVariableValue, OOValueExpression(..), InternalValueExp(..),
   FileSym(..), ModuleSym(..), ClassSym(..), AttachmentSym(..), GetSet(..),
@@ -21,13 +21,13 @@ import Text.PrettyPrint.HughesPJ (Doc)
 import Drasil.Shared.RendererClassesCommon (MSMthdType, CommonRenderSym,
   BlockCommentSym(..), MethodTypeSym(..), RenderMethod(..))
 
-class (CommonRenderSym r vis smt, IG.FileSym r vis smt,
+class (CommonRenderSym r vis smt md, IG.FileSym r vis smt md,
   IG.InternalValueExp r, IG.GetSet r, IG.ObserverPattern r smt,
   IG.StrategyPattern r smt, IG.OOVariableValue r,
-  IG.OOValueExpression r, RenderClass r vis, ClassElim r, RenderFile r,
-  InternalGetSet r, OORenderMethod r vis, RenderMod r, ModuleElim r,
+  IG.OOValueExpression r, RenderClass r vis md, ClassElim r, RenderFile r,
+  InternalGetSet r, OORenderMethod r vis md, RenderMod r, ModuleElim r,
   StateVarElim r, PermElim r
-  ) => OORenderSym r vis smt
+  ) => OORenderSym r vis smt md
 
 -- OO-Only Typeclasses --
 
@@ -53,27 +53,27 @@ class InternalGetSet r where
 class (MethodTypeSym r) => OOMethodTypeSym r where
   construct :: Label -> MSMthdType r
 
-class (RenderMethod r, OOMethodTypeSym r) => OORenderMethod r vis | r -> vis where
+class (RenderMethod r md, OOMethodTypeSym r) => OORenderMethod r vis md | r -> vis where
   -- | Main method?, name, public/private, classLevel/instanceLevel,
   --   return type, parameters, body
   intMethod     :: Bool -> Label -> r vis -> r (IG.Attachment r) ->
-    MSMthdType r -> [MS (r ParamData)] -> MSBody r -> MS (r (Method r))
+    MSMthdType r -> [MS (r ParamData)] -> MSBody r -> MS (r md)
   -- | True for main function, name, public/private, classLevel/instanceLevel,
   --   return type, parameters, body
   intFunc       :: Bool -> Label -> r vis -> r (IG.Attachment r)
-    -> MSMthdType r -> [MS (r ParamData)] -> MSBody r -> MS (r (Method r))
+    -> MSMthdType r -> [MS (r ParamData)] -> MSBody r -> MS (r md)
 
-  destructor :: [IG.CSStateVar r] -> MS (r (Method r))
+  destructor :: [IG.CSStateVar r] -> MS (r md)
 
 class StateVarElim r where
   stateVar :: r (IG.StateVar r) -> Doc
 
 type ParentSpec = Doc
 
-class (BlockCommentSym r) => RenderClass r vis | r -> vis where
+class (BlockCommentSym r) => RenderClass r vis md | r -> vis md where
   -- class name, visibility, parent, state variables, constructor(s), methods
   intClass :: Label -> r vis -> r ParentSpec -> [IG.CSStateVar r]
-    -> [MS (r (Method r))] -> [MS (r (Method r))] -> IG.SClass r
+    -> [MS (r md)] -> [MS (r md)] -> IG.SClass r
 
   inherit :: Maybe Label -> r ParentSpec
   implements :: [Label] -> r ParentSpec

--- a/code/drasil-gool/lib/Drasil/GOOL/RendererClassesOO.hs
+++ b/code/drasil-gool/lib/Drasil/GOOL/RendererClassesOO.hs
@@ -7,8 +7,8 @@ module Drasil.GOOL.RendererClassesOO (
   ModuleElim(..), OORenderMethod(..), OOMethodTypeSym(..)
 ) where
 
-import Drasil.Shared.InterfaceCommon (Label, MSBody, SVariable, SValue, SMethod,
-  BlockSym(..))
+import Drasil.Shared.InterfaceCommon (Label, MSBody, SVariable, SValue,
+  BlockSym(..), MethodSym(..))
 import qualified Drasil.GOOL.InterfaceGOOL as IG (SFile, FSModule, SClass,
   CSStateVar, OOVariableValue, OOValueExpression(..), InternalValueExp(..),
   FileSym(..), ModuleSym(..), ClassSym(..), AttachmentSym(..), GetSet(..),
@@ -57,13 +57,13 @@ class (RenderMethod r, OOMethodTypeSym r) => OORenderMethod r vis | r -> vis whe
   -- | Main method?, name, public/private, classLevel/instanceLevel,
   --   return type, parameters, body
   intMethod     :: Bool -> Label -> r vis -> r (IG.Attachment r) ->
-    MSMthdType r -> [MS (r ParamData)] -> MSBody r -> SMethod r
+    MSMthdType r -> [MS (r ParamData)] -> MSBody r -> MS (r (Method r))
   -- | True for main function, name, public/private, classLevel/instanceLevel,
   --   return type, parameters, body
   intFunc       :: Bool -> Label -> r vis -> r (IG.Attachment r)
-    -> MSMthdType r -> [MS (r ParamData)] -> MSBody r -> SMethod r
+    -> MSMthdType r -> [MS (r ParamData)] -> MSBody r -> MS (r (Method r))
 
-  destructor :: [IG.CSStateVar r] -> SMethod r
+  destructor :: [IG.CSStateVar r] -> MS (r (Method r))
 
 class StateVarElim r where
   stateVar :: r (IG.StateVar r) -> Doc
@@ -73,7 +73,7 @@ type ParentSpec = Doc
 class (BlockCommentSym r) => RenderClass r vis | r -> vis where
   -- class name, visibility, parent, state variables, constructor(s), methods
   intClass :: Label -> r vis -> r ParentSpec -> [IG.CSStateVar r]
-    -> [SMethod r] -> [SMethod r] -> IG.SClass r
+    -> [MS (r (Method r))] -> [MS (r (Method r))] -> IG.SClass r
 
   inherit :: Maybe Label -> r ParentSpec
   implements :: [Label] -> r ParentSpec

--- a/code/drasil-gool/lib/Drasil/GProc.hs
+++ b/code/drasil-gool/lib/Drasil/GProc.hs
@@ -1,6 +1,6 @@
 -- | re-export smart constructors for external code writing
-module Drasil.GProc (Label, GSProgram, SFile, MSBody, MSBlock, VS, SVariable,
-  SValue, SMethod, FSModule, NamedArgs, SharedProg, SharedStatement, ProcProg,
+module Drasil.GProc (Label, GSProgram, SFile, MSBody, MSBlock, MS, VS, SVariable,
+  SValue, FSModule, NamedArgs, SharedProg, SharedStatement, ProcProg,
   ProgramSym(..), FileSym(..), BodySym(..), bodyStatements, oneLiner,
   BlockSym(..), TypeSym(..), BinderSym(..), StatementSym(..),
   AssignStatement(..), (&=), DeclStatement(..), IOStatement(..),
@@ -22,8 +22,8 @@ module Drasil.GProc (Label, GSProgram, SFile, MSBody, MSBlock, VS, SVariable,
   ) where
 
 import Drasil.Shared.InterfaceCommon (Label, MSBody, MSBlock, SVariable, SValue,
-  SMethod, NamedArgs, SharedProg, SharedStatement, BodySym(..), bodyStatements,
-  oneLiner, BlockSym(..), TypeSym(..), BinderSym(..), StatementSym(..),
+  NamedArgs, SharedProg, SharedStatement, BodySym(..), bodyStatements, oneLiner,
+  BlockSym(..), TypeSym(..), BinderSym(..), StatementSym(..),
   AssignStatement(..), (&=), DeclStatement(..), IOStatement(..),
   StringStatement(..), FunctionSym, FuncAppStatement(..), CommentStatement(..),
   ControlStatement(..), switchAsIf, ifNoElse, VariableSym(..), extVar,
@@ -44,7 +44,7 @@ import Drasil.Shared.AST (FileData(..), ScopeData(..), ModData(..), ProgData(..)
 
 import Drasil.Shared.CodeType (CodeType(..))
 
-import Drasil.Shared.State (VS, GOOLState(..), lensMStoVS, headers, sources,
+import Drasil.Shared.State (MS, VS, GOOLState(..), lensMStoVS, headers, sources,
   mainMod, initialState)
 
 import Drasil.Shared.Helpers (onStateValue, onCodeList)

--- a/code/drasil-gool/lib/Drasil/GProc/InterfaceProc.hs
+++ b/code/drasil-gool/lib/Drasil/GProc/InterfaceProc.hs
@@ -12,18 +12,18 @@ import Drasil.Shared.InterfaceCommon (Label, SharedProg, MethodSym(..),
   NativeVector)
 import Drasil.Shared.State (GS, FS, MS)
 
-class (SharedProg r vis smt, ProgramSym r vis smt,
-  NativeVector r) => ProcProg r vis smt
+class (SharedProg r vis smt md, ProgramSym r vis smt md,
+  NativeVector r) => ProcProg r vis smt md
 
 type GSProgram a = GS (a (Program a))
 
-class (FileSym r vis smt) => ProgramSym r vis smt where
+class (FileSym r vis smt md) => ProgramSym r vis smt md where
   type Program r
   prog :: Label -> Label -> [SFile r] -> GSProgram r
 
 type SFile a = FS (a (File a))
 
-class (ModuleSym r vis smt) => FileSym r vis smt where
+class (ModuleSym r vis smt md) => FileSym r vis smt md where
   type File r
   fileDoc :: FSModule r -> SFile r
 
@@ -32,7 +32,7 @@ class (ModuleSym r vis smt) => FileSym r vis smt where
 
 type FSModule a = FS (a (Module a))
 
-class (MethodSym r vis smt) => ModuleSym r vis smt where
+class (MethodSym r vis smt md) => ModuleSym r vis smt md where
   type Module r
   -- Module name, import names, module functions
-  buildModule :: Label -> [Label] -> [MS (r (Method r))] -> FSModule r
+  buildModule :: Label -> [Label] -> [MS (r md)] -> FSModule r

--- a/code/drasil-gool/lib/Drasil/GProc/InterfaceProc.hs
+++ b/code/drasil-gool/lib/Drasil/GProc/InterfaceProc.hs
@@ -8,9 +8,9 @@ module Drasil.GProc.InterfaceProc (
   ProcProg, ProgramSym(..), FileSym(..), ModuleSym(..)
   ) where
 
-import Drasil.Shared.InterfaceCommon (Label, SMethod, SharedProg,
-  MethodSym, NativeVector)
-import Drasil.Shared.State (GS, FS)
+import Drasil.Shared.InterfaceCommon (Label, SharedProg, MethodSym(..),
+  NativeVector)
+import Drasil.Shared.State (GS, FS, MS)
 
 class (SharedProg r vis smt, ProgramSym r vis smt,
   NativeVector r) => ProcProg r vis smt
@@ -35,4 +35,4 @@ type FSModule a = FS (a (Module a))
 class (MethodSym r vis smt) => ModuleSym r vis smt where
   type Module r
   -- Module name, import names, module functions
-  buildModule :: Label -> [Label] -> [SMethod r] -> FSModule r
+  buildModule :: Label -> [Label] -> [MS (r (Method r))] -> FSModule r

--- a/code/drasil-gool/lib/Drasil/GProc/LanguageRenderer/AbstractProc.hs
+++ b/code/drasil-gool/lib/Drasil/GProc/LanguageRenderer/AbstractProc.hs
@@ -8,8 +8,7 @@ module Drasil.GProc.LanguageRenderer.AbstractProc (fileDoc, fileFromData,
 
 import Drasil.Shared.InterfaceCommon (Label, MSBody, SValue, SVariable,
   VariableElim(variableName, variableType), VisibilitySym(..), funcApp,
-  getCodeType, convType, MethodSym(Method), StatementSym, ValueExpression,
-  IndexTranslator)
+  getCodeType, convType, StatementSym, ValueExpression, IndexTranslator)
 import qualified Drasil.Shared.InterfaceCommon as IC
 import Drasil.GProc.InterfaceProc (SFile, FSModule, FileSym (File),
   ModuleSym(Module))
@@ -59,8 +58,8 @@ fileFromData f fpath mdl' = do
 -- Parameters: Module name, Doc for imports, Doc to put at bottom of module,
 -- methods
 buildModule
-  :: (RC.MethodElim r, RP.RenderMod r)
-  => Label -> FS Doc -> FS Doc -> [MS (r (Method r))] -> FSModule r
+  :: (RC.MethodElim r md, RP.RenderMod r)
+  => Label -> FS Doc -> FS Doc -> [MS (r md)] -> FSModule r
 buildModule n imps bot fs = RP.modFromData n (do
   fns <- mapM (zoom lensFStoMS) fs
   is <- imps
@@ -107,7 +106,7 @@ arrayElem arr' i' = do
       vRender = RC.value arr <> brackets (RC.value i)
   mkStateVar vName vType vRender
 
-funcDecDef :: (RP.ProcRenderSym r vis smt) => SVariable r -> r ScopeData ->
+funcDecDef :: (RP.ProcRenderSym r vis smt md) => SVariable r -> r ScopeData ->
   [SVariable r] -> MSBody r -> MS (r smt)
 funcDecDef v scp ps b = do
   vr <- zoom lensMStoVS v
@@ -119,6 +118,6 @@ funcDecDef v scp ps b = do
   modify (L.set currParameters (s ^. currParameters))
   mkStmtNoEnd $ RC.method f
 
-function :: (RP.ProcRenderMethod r vis) => Label -> r vis -> VS (r TypeData) ->
-  [MS (r ParamData)] -> MSBody r -> MS (r (Method r))
+function :: (RP.ProcRenderMethod r vis md) => Label -> r vis -> VS (r TypeData) ->
+  [MS (r ParamData)] -> MSBody r -> MS (r md)
 function n s t = RP.intFunc False n s (RC.mType t)

--- a/code/drasil-gool/lib/Drasil/GProc/LanguageRenderer/AbstractProc.hs
+++ b/code/drasil-gool/lib/Drasil/GProc/LanguageRenderer/AbstractProc.hs
@@ -6,9 +6,10 @@ module Drasil.GProc.LanguageRenderer.AbstractProc (fileDoc, fileFromData,
   listAdd, funcDecDef, function
 ) where
 
-import Drasil.Shared.InterfaceCommon (Label, SMethod, MSBody, SValue, SVariable,
+import Drasil.Shared.InterfaceCommon (Label, MSBody, SValue, SVariable,
   VariableElim(variableName, variableType), VisibilitySym(..), funcApp,
-  getCodeType, convType, StatementSym, ValueExpression, IndexTranslator)
+  getCodeType, convType, MethodSym(Method), StatementSym, ValueExpression,
+  IndexTranslator)
 import qualified Drasil.Shared.InterfaceCommon as IC
 import Drasil.GProc.InterfaceProc (SFile, FSModule, FileSym (File),
   ModuleSym(Module))
@@ -59,7 +60,7 @@ fileFromData f fpath mdl' = do
 -- methods
 buildModule
   :: (RC.MethodElim r, RP.RenderMod r)
-  => Label -> FS Doc -> FS Doc -> [SMethod r] -> FSModule r
+  => Label -> FS Doc -> FS Doc -> [MS (r (Method r))] -> FSModule r
 buildModule n imps bot fs = RP.modFromData n (do
   fns <- mapM (zoom lensFStoMS) fs
   is <- imps
@@ -119,5 +120,5 @@ funcDecDef v scp ps b = do
   mkStmtNoEnd $ RC.method f
 
 function :: (RP.ProcRenderMethod r vis) => Label -> r vis -> VS (r TypeData) ->
-  [MS (r ParamData)] -> MSBody r -> SMethod r
+  [MS (r ParamData)] -> MSBody r -> MS (r (Method r))
 function n s t = RP.intFunc False n s (RC.mType t)

--- a/code/drasil-gool/lib/Drasil/GProc/LanguageRenderer/JuliaRenderer.hs
+++ b/code/drasil-gool/lib/Drasil/GProc/LanguageRenderer/JuliaRenderer.hs
@@ -113,24 +113,24 @@ instance Applicative JuliaCode where
 instance Monad JuliaCode where
   JLC x >>= f = f x
 
-instance SharedProg JuliaCode Doc (Doc, Terminator)
+instance SharedProg JuliaCode Doc (Doc, Terminator) MethodData
 instance SharedStatement JuliaCode (Doc, Terminator)
-instance ProcProg JuliaCode Doc (Doc, Terminator)
+instance ProcProg JuliaCode Doc (Doc, Terminator) MethodData
 
-instance ProgramSym JuliaCode Doc (Doc, Terminator) where
+instance ProgramSym JuliaCode Doc (Doc, Terminator) MethodData where
   type Program JuliaCode = ProgData
   prog n st files = do
     fs <- mapM (zoom lensGStoFS) files
     modify revFiles
     pure $ onCodeList (progD n st) fs
 
-instance CommonRenderSym JuliaCode Doc (Doc, Terminator)
-instance ProcRenderSym JuliaCode Doc (Doc, Terminator)
+instance CommonRenderSym JuliaCode Doc (Doc, Terminator) MethodData
+instance ProcRenderSym JuliaCode Doc (Doc, Terminator) MethodData
 
 instance UnRepr JuliaCode inner where
   unRepr = unJLC
 
-instance FileSym JuliaCode Doc (Doc, Terminator) where
+instance FileSym JuliaCode Doc (Doc, Terminator) MethodData where
   type File JuliaCode = FileData
   fileDoc m = do
     modify (setFileType Combined)
@@ -566,8 +566,7 @@ instance ParamElim JuliaCode where
   parameterType = variableType . onCodeValue paramVar
   parameter = paramDoc . unJLC
 
-instance MethodSym JuliaCode Doc (Doc, Terminator) where
-  type Method JuliaCode = MethodData
+instance MethodSym JuliaCode Doc (Doc, Terminator) MethodData where
   docMain = mainFunction
   function = A.function
   mainFunction = CP.mainBody
@@ -576,20 +575,20 @@ instance MethodSym JuliaCode Doc (Doc, Terminator) where
   inOutFunc n s = CP.inOutFunc (function n s)
   docInOutFunc n s = CP.docInOutFunc' CP.functionDoc (inOutFunc n s)
 
-instance RenderMethod JuliaCode where
+instance RenderMethod JuliaCode MethodData where
   commentedFunc cmt m = on2StateValues (on2CodeValues updateMthd) m
     (onStateValue (onCodeValue R.commentedItem) cmt)
   mthdFromData _ d = toState $ toCode $ mthd d
 
-instance ProcRenderMethod JuliaCode Doc where
+instance ProcRenderMethod JuliaCode Doc MethodData where
   intFunc _ n _ _ ps b = do
     pms <- sequence ps
     toCode . mthd . jlIntFunc n pms <$> b
 
-instance MethodElim JuliaCode where
+instance MethodElim JuliaCode MethodData where
   method = mthdDoc . unJLC
 
-instance ModuleSym JuliaCode Doc (Doc, Terminator) where
+instance ModuleSym JuliaCode Doc (Doc, Terminator) MethodData where
   type Module JuliaCode = ModData
   buildModule n is fs = jlModContents n is fs <&>
     updateModuleDoc (\m -> emptyIfEmpty m (vibcat [jlModStart n, m, jlEnd]))
@@ -857,7 +856,8 @@ jlForEach i lstVar b = vcat [
   jlEnd]
 
 -- | Creates the contents of a module in Julia
-jlModContents :: Label -> [Label] -> [MS (JuliaCode (Method JuliaCode))] -> FSModule JuliaCode
+jlModContents
+  :: Label -> [Label] -> [MS (JuliaCode MethodData)] -> FSModule JuliaCode
 jlModContents n is = A.buildModule n (do
   lis <- getLangImports
   libis <- getLibImports

--- a/code/drasil-gool/lib/Drasil/GProc/LanguageRenderer/JuliaRenderer.hs
+++ b/code/drasil-gool/lib/Drasil/GProc/LanguageRenderer/JuliaRenderer.hs
@@ -15,9 +15,9 @@ import Drasil.FileHandling.Legacy (indent)
 
 import Drasil.Shared.CodeType (CodeType(..))
 import Drasil.Shared.InterfaceCommon (UnRepr(..), SharedProg, SharedStatement,
-  Label, SValue, SVariable, MSBlock, SMethod, BodySym(..), BlockSym(..),
-  TypeSym(..), TypeElim(..), getTypeString, VariableSym(..), VariableElim(..),
-  ValueSym(..), Argument(..), Literal(..), MathConstant(..), VariableValue(..),
+  Label, SValue, SVariable, MSBlock, BodySym(..), BlockSym(..), TypeSym(..),
+  TypeElim(..), getTypeString, VariableSym(..), VariableElim(..), ValueSym(..),
+  Argument(..), Literal(..), MathConstant(..), VariableValue(..),
   CommandLineArgs(..), NumericExpression(..), BooleanExpression(..),
   Comparison(..), ValueExpression(..), funcApp, extFuncApp, IndexTranslator(..),
   Reference(..), Array(..), List(..), Set(..), NativeVector(..),
@@ -857,7 +857,7 @@ jlForEach i lstVar b = vcat [
   jlEnd]
 
 -- | Creates the contents of a module in Julia
-jlModContents :: Label -> [Label] -> [SMethod JuliaCode] -> FSModule JuliaCode
+jlModContents :: Label -> [Label] -> [MS (JuliaCode (Method JuliaCode))] -> FSModule JuliaCode
 jlModContents n is = A.buildModule n (do
   lis <- getLangImports
   libis <- getLibImports

--- a/code/drasil-gool/lib/Drasil/GProc/LanguageRenderer/MatlabRenderer.hs
+++ b/code/drasil-gool/lib/Drasil/GProc/LanguageRenderer/MatlabRenderer.hs
@@ -90,24 +90,24 @@ instance Applicative MatlabCode where
 instance Monad MatlabCode where
   MLC x >>= f = f x
 
-instance SharedProg MatlabCode Doc (Doc, Terminator)
+instance SharedProg MatlabCode Doc (Doc, Terminator) MethodData
 instance SharedStatement MatlabCode (Doc, Terminator)
-instance ProcProg MatlabCode Doc (Doc, Terminator)
+instance ProcProg MatlabCode Doc (Doc, Terminator) MethodData
 
-instance ProgramSym MatlabCode Doc (Doc, Terminator) where
+instance ProgramSym MatlabCode Doc (Doc, Terminator) MethodData where
   type Program MatlabCode = ProgData
   prog n st files = do
     fs <- mapM (zoom lensGStoFS) files
     modify revFiles
     pure $ onCodeList (progD n st) fs
 
-instance CommonRenderSym MatlabCode Doc (Doc, Terminator)
-instance ProcRenderSym MatlabCode Doc (Doc, Terminator)
+instance CommonRenderSym MatlabCode Doc (Doc, Terminator) MethodData
+instance ProcRenderSym MatlabCode Doc (Doc, Terminator) MethodData
 
 instance UnRepr MatlabCode inner where
   unRepr = unMLC
 
-instance FileSym MatlabCode Doc (Doc, Terminator) where
+instance FileSym MatlabCode Doc (Doc, Terminator) MethodData where
   type File MatlabCode = FileData
   fileDoc m = do
     modify (setFileType Combined)
@@ -511,8 +511,7 @@ instance ParamElim MatlabCode where
   parameterType = variableType . onCodeValue paramVar
   parameter = paramDoc . unMLC
 
-instance MethodSym MatlabCode Doc (Doc, Terminator) where
-  type Method MatlabCode = MethodData
+instance MethodSym MatlabCode Doc (Doc, Terminator) MethodData where
   docMain = mainFunction
   function = A.function
   mainFunction = CP.mainBody
@@ -528,12 +527,12 @@ instance MethodSym MatlabCode Doc (Doc, Terminator) where
     pure $ toCode $ mthd $ mlFuncDoc n (map RC.variable rets) pms (RC.body bod)
   docInOutFunc n s = CP.docInOutFunc' CP.functionDoc (inOutFunc n s)
 
-instance RenderMethod MatlabCode where
+instance RenderMethod MatlabCode MethodData where
   commentedFunc cmt m = on2StateValues (on2CodeValues updateMthd) m
     (onStateValue (onCodeValue R.commentedItem) cmt)
   mthdFromData _ d = toState $ toCode $ mthd d
 
-instance ProcRenderMethod MatlabCode Doc where
+instance ProcRenderMethod MatlabCode Doc MethodData where
   intFunc _ n _ t ps b = do
     pms <- sequence ps
     tp  <- t
@@ -544,10 +543,10 @@ instance ProcRenderMethod MatlabCode Doc where
     let outs = [text mlRet | cType (unMLC tp) /= Void]
     pure $ toCode $ mthd $ mlFuncDoc n outs pms (RC.body bod)
 
-instance MethodElim MatlabCode where
+instance MethodElim MatlabCode MethodData where
   method = mthdDoc . unMLC
 
-instance ModuleSym MatlabCode Doc (Doc, Terminator) where
+instance ModuleSym MatlabCode Doc (Doc, Terminator) MethodData where
   type Module MatlabCode = ModData
   -- Function-file layout (runs in both MATLAB and Octave): the main code
   -- becomes the entry function `function <name>(varargin) ... end` and comes

--- a/code/drasil-gool/lib/Drasil/GProc/RendererClassesProc.hs
+++ b/code/drasil-gool/lib/Drasil/GProc/RendererClassesProc.hs
@@ -6,7 +6,7 @@ module Drasil.GProc.RendererClassesProc (
   ProcRenderMethod(..)
 ) where
 
-import Drasil.Shared.InterfaceCommon (Label, MSBody, BlockSym(..), MethodSym(..))
+import Drasil.Shared.InterfaceCommon (Label, MSBody, BlockSym(..))
 import qualified Drasil.GProc.InterfaceProc as IP (SFile, FSModule, FileSym(..),
   ModuleSym(..))
 import Drasil.Shared.State (FS, MS)
@@ -17,10 +17,9 @@ import Text.PrettyPrint.HughesPJ (Doc)
 import Drasil.Shared.RendererClassesCommon (CommonRenderSym, BlockCommentSym(..),
   RenderMethod(..), MSMthdType)
 
-class (CommonRenderSym r vis smt, IP.FileSym r vis smt, RenderFile r,
-  RenderMod r, ModuleElim r, ProcRenderMethod r vis
-  ) => ProcRenderSym r vis smt
-
+class (CommonRenderSym r vis smt md, IP.FileSym r vis smt md, RenderFile r,
+  RenderMod r, ModuleElim r, ProcRenderMethod r vis md
+  ) => ProcRenderSym r vis smt md
 -- Procedural-Only Typeclasses --
 
 class (BlockCommentSym r) => RenderFile r where
@@ -41,8 +40,8 @@ class RenderMod r where
 class ModuleElim r where
   module' :: r (IP.Module r) -> Doc
 
-class (RenderMethod r) => ProcRenderMethod r vis | r -> vis where
+class (RenderMethod r md) => ProcRenderMethod r vis md | r -> vis where
   -- | Main method?, name, public/private,
   --   return type, parameters, body
   intFunc     :: Bool -> Label -> r vis -> MSMthdType r ->
-    [MS (r ParamData)] -> MSBody r -> MS (r (Method r))
+    [MS (r ParamData)] -> MSBody r -> MS (r md)

--- a/code/drasil-gool/lib/Drasil/GProc/RendererClassesProc.hs
+++ b/code/drasil-gool/lib/Drasil/GProc/RendererClassesProc.hs
@@ -6,7 +6,7 @@ module Drasil.GProc.RendererClassesProc (
   ProcRenderMethod(..)
 ) where
 
-import Drasil.Shared.InterfaceCommon (Label, SMethod, MSBody, BlockSym(..))
+import Drasil.Shared.InterfaceCommon (Label, MSBody, BlockSym(..), MethodSym(..))
 import qualified Drasil.GProc.InterfaceProc as IP (SFile, FSModule, FileSym(..),
   ModuleSym(..))
 import Drasil.Shared.State (FS, MS)
@@ -45,4 +45,4 @@ class (RenderMethod r) => ProcRenderMethod r vis | r -> vis where
   -- | Main method?, name, public/private,
   --   return type, parameters, body
   intFunc     :: Bool -> Label -> r vis -> MSMthdType r ->
-    [MS (r ParamData)] -> MSBody r -> SMethod r
+    [MS (r ParamData)] -> MSBody r -> MS (r (Method r))

--- a/code/drasil-gool/lib/Drasil/Shared/InterfaceCommon.hs
+++ b/code/drasil-gool/lib/Drasil/Shared/InterfaceCommon.hs
@@ -4,9 +4,9 @@
 
 module Drasil.Shared.InterfaceCommon (
   -- Types
-  Label, Library, MSBody, MSBlock, VSBinder, SVariable, SValue, SMethod,
-  NamedArgs, MixedCall, MixedCtorCall, PosCall, PosCtorCall, InOutCall,
-  InOutFunc, DocInOutFunc,
+  Label, Library, MSBody, MSBlock, VSBinder, SVariable, SValue, NamedArgs,
+  MixedCall, MixedCtorCall, PosCall, PosCtorCall, InOutCall, InOutFunc,
+  DocInOutFunc,
   -- Typeclasses
   SharedProg, SharedStatement, UnRepr(..), BodySym(..), bodyStatements, oneLiner,
   BlockSym(..), TypeSym(..), TypeElim(..), getTypeString, VariableSym(..),
@@ -530,28 +530,26 @@ class (VariableSym r) => ParameterSym r where
   param :: SVariable r -> MS (r ParamData)
   pointerParam :: SVariable r -> MS (r ParamData)
 
-type SMethod a = MS (a (Method a))
-
 -- The three lists are inputs, outputs, and both, respectively
 type InOutFunc r = [SVariable r] -> [SVariable r] -> [SVariable r] ->
-  MSBody r -> SMethod r
+  MSBody r -> MS (r (Method r))
 -- Parameters are: brief description of function, input descriptions and
 -- variables, output descriptions and variables, descriptions and variables
 -- for parameters that are both input and output, function body
 type DocInOutFunc r = String -> [(String, SVariable r)] ->
-  [(String, SVariable r)] -> [(String, SVariable r)] -> MSBody r -> SMethod r
+  [(String, SVariable r)] -> [(String, SVariable r)] -> MSBody r -> MS (r (Method r))
 
 class (BodySym r smt, ParameterSym r, VisibilitySym r vis) => MethodSym r vis smt
   where
   type Method r
-  docMain :: MSBody r -> SMethod r
+  docMain :: MSBody r -> MS (r (Method r))
 
   function :: Label -> r vis -> VS (r TypeData) -> [MS (r ParamData)] ->
-    MSBody r -> SMethod r
-  mainFunction  :: MSBody r -> SMethod r
+    MSBody r -> MS (r (Method r))
+  mainFunction  :: MSBody r -> MS (r (Method r))
   -- Parameters are: function description, parameter descriptions,
   --   return value description if applicable, function
-  docFunc :: String -> [String] -> Maybe String -> SMethod r -> SMethod r
+  docFunc :: String -> [String] -> Maybe String -> MS (r (Method r)) -> MS (r (Method r))
 
   inOutFunc :: Label -> r vis -> InOutFunc r
   docInOutFunc :: Label -> r vis -> DocInOutFunc r

--- a/code/drasil-gool/lib/Drasil/Shared/InterfaceCommon.hs
+++ b/code/drasil-gool/lib/Drasil/Shared/InterfaceCommon.hs
@@ -43,8 +43,8 @@ type Library = String
 
 class (UnRepr r TypeData, SharedStatement r smt, FunctionSym r, InternalList r,
   VariableValue r, IndexTranslator r, TypeElim r,
-  VariableElim r, MethodSym r vis smt, ScopeSym r, BinderSym r
-  ) => SharedProg r vis smt
+  VariableElim r, MethodSym r vis smt md, ScopeSym r, BinderSym r
+  ) => SharedProg r vis smt md
 
 class (Array r, AssignStatement r smt, Argument r, BooleanExpression r,
   CommandLineArgs r, CommentStatement r smt, Comparison r,
@@ -531,28 +531,27 @@ class (VariableSym r) => ParameterSym r where
   pointerParam :: SVariable r -> MS (r ParamData)
 
 -- The three lists are inputs, outputs, and both, respectively
-type InOutFunc r = [SVariable r] -> [SVariable r] -> [SVariable r] ->
-  MSBody r -> MS (r (Method r))
+type InOutFunc r md = [SVariable r] -> [SVariable r] -> [SVariable r] ->
+  MSBody r -> MS (r md)
 -- Parameters are: brief description of function, input descriptions and
 -- variables, output descriptions and variables, descriptions and variables
 -- for parameters that are both input and output, function body
-type DocInOutFunc r = String -> [(String, SVariable r)] ->
-  [(String, SVariable r)] -> [(String, SVariable r)] -> MSBody r -> MS (r (Method r))
+type DocInOutFunc r md = String -> [(String, SVariable r)] ->
+  [(String, SVariable r)] -> [(String, SVariable r)] -> MSBody r -> MS (r md)
 
-class (BodySym r smt, ParameterSym r, VisibilitySym r vis) => MethodSym r vis smt
+class (BodySym r smt, ParameterSym r, VisibilitySym r vis) => MethodSym r vis smt md | r -> md
   where
-  type Method r
-  docMain :: MSBody r -> MS (r (Method r))
+  docMain :: MSBody r -> MS (r md)
 
   function :: Label -> r vis -> VS (r TypeData) -> [MS (r ParamData)] ->
-    MSBody r -> MS (r (Method r))
-  mainFunction  :: MSBody r -> MS (r (Method r))
+    MSBody r -> MS (r md)
+  mainFunction  :: MSBody r -> MS (r md)
   -- Parameters are: function description, parameter descriptions,
   --   return value description if applicable, function
-  docFunc :: String -> [String] -> Maybe String -> MS (r (Method r)) -> MS (r (Method r))
+  docFunc :: String -> [String] -> Maybe String -> MS (r md) -> MS (r md)
 
-  inOutFunc :: Label -> r vis -> InOutFunc r
-  docInOutFunc :: Label -> r vis -> DocInOutFunc r
+  inOutFunc :: Label -> r vis -> InOutFunc r md
+  docInOutFunc :: Label -> r vis -> DocInOutFunc r md
 
 -- Utility
 

--- a/code/drasil-gool/lib/Drasil/Shared/LanguageRenderer/CLike.hs
+++ b/code/drasil-gool/lib/Drasil/Shared/LanguageRenderer/CLike.hs
@@ -14,7 +14,7 @@ import Drasil.FileHandling.Legacy (indent)
 
 import Drasil.Shared.CodeType (CodeType(..))
 import Drasil.Shared.InterfaceCommon (UnRepr(..), Label, Library, MSBody,
-  TypeElim(..), SVariable, SValue, SMethod, MixedCall, MixedCtorCall,
+  TypeElim(..), SVariable, SValue, MixedCall, MixedCtorCall, MethodSym(..),
   VariableSym(..), VariableValue(..), VariableElim(..),
   ValueSym(Value, valueType), getCodeType, getTypeString)
 import qualified Drasil.Shared.InterfaceCommon as IC
@@ -283,7 +283,7 @@ while f bStart bEnd v' b'= do
 
 intFunc :: (OORenderMethod r vis) => Bool -> Label -> r vis ->
   r (Attachment r) -> MSMthdType r -> [MS (r ParamData)] -> MSBody r ->
-  SMethod r
+  MS (r (Method r))
 intFunc = intMethod
 
 -- Error Messages --

--- a/code/drasil-gool/lib/Drasil/Shared/LanguageRenderer/CLike.hs
+++ b/code/drasil-gool/lib/Drasil/Shared/LanguageRenderer/CLike.hs
@@ -14,9 +14,9 @@ import Drasil.FileHandling.Legacy (indent)
 
 import Drasil.Shared.CodeType (CodeType(..))
 import Drasil.Shared.InterfaceCommon (UnRepr(..), Label, Library, MSBody,
-  TypeElim(..), SVariable, SValue, MixedCall, MixedCtorCall, MethodSym(..),
-  VariableSym(..), VariableValue(..), VariableElim(..),
-  ValueSym(Value, valueType), getCodeType, getTypeString)
+  TypeElim(..), SVariable, SValue, MixedCall, MixedCtorCall, VariableSym(..),
+  VariableValue(..), VariableElim(..), ValueSym(Value, valueType), getCodeType,
+  getTypeString)
 import qualified Drasil.Shared.InterfaceCommon as IC
 import Drasil.GOOL.InterfaceGOOL (AttachmentSym(..), extNewObj,
   objMethodCallNoParams, ($->))
@@ -281,9 +281,9 @@ while f bStart bEnd v' b'= do
 
 -- Methods --
 
-intFunc :: (OORenderMethod r vis) => Bool -> Label -> r vis ->
+intFunc :: (OORenderMethod r vis md) => Bool -> Label -> r vis ->
   r (Attachment r) -> MSMthdType r -> [MS (r ParamData)] -> MSBody r ->
-  MS (r (Method r))
+  MS (r md)
 intFunc = intMethod
 
 -- Error Messages --

--- a/code/drasil-gool/lib/Drasil/Shared/LanguageRenderer/CommonPseudoOO.hs
+++ b/code/drasil-gool/lib/Drasil/Shared/LanguageRenderer/CommonPseudoOO.hs
@@ -27,7 +27,7 @@ import Drasil.Shared.InterfaceCommon (UnRepr(..), varDecDef, bool,
   TypeSym(infile, outfile, innerType), TypeElim(..), getCodeType, getTypeString,
   VariableElim(variableName, variableType), ValueSym(valueType), Comparison(..),
   (&=), ControlStatement(returnStmt), VisibilitySym(..),
-  MethodSym(Method, function), funcApp, listSize)
+  MethodSym(function), funcApp, listSize)
 import qualified Drasil.Shared.InterfaceCommon as IC
 import Drasil.GOOL.InterfaceGOOL (SFile, FSModule, SClass, CSStateVar,
   OOTypeSym(obj), AttachmentSym(..), Initializers, objMethodCallNoParams,
@@ -93,16 +93,16 @@ int :: (Monad r) => VS (r TypeData)
 int = typeFromData Integer intRender (text intRender)
 
 constructor
-  :: (OORenderSym r vis smt, OOStatement r smt)
-  => Label -> [MS (r ParamData)] -> Initializers r -> MSBody r -> MS (r (Method r))
+  :: (OORenderSym r vis smt md, OOStatement r smt)
+  => Label -> [MS (r ParamData)] -> Initializers r -> MSBody r -> MS (r md)
 constructor fName ps is b = getClassName >>= (\c -> intMethod False fName
   public instanceLevel (RG.construct c) ps (RC.multiBody [initStmts is, b]))
 
-doxFunc :: (RenderMethod r) => String -> [String] -> Maybe String ->
-  MS (r (Method r)) -> MS (r (Method r))
+doxFunc :: (RenderMethod r md) => String -> [String] -> Maybe String ->
+  MS (r md) -> MS (r md)
 doxFunc = docFunc functionDox
 
-doxClass :: (RG.RenderClass r vis) => String -> SClass r -> SClass r
+doxClass :: (RG.RenderClass r vis md) => String -> SClass r -> SClass r
 doxClass = docClass classDox
 
 doxMod :: (RG.RenderFile r) => String -> String -> String -> [String] ->
@@ -144,14 +144,14 @@ discardFileLine n f = IC.valStmt $ objMethodCallNoParams IC.string f n
 --   Parameters: render function, class name, scope, parent, class variables,
 --               constructor(s), methods
 intClass
-  :: (RC.MethodElim r, Monad r, RG.StateVarElim r, RC.VisibilityElim r vis)
+  :: (RC.MethodElim r md, Monad r, RG.StateVarElim r, RC.VisibilityElim r vis)
   => (Label -> Doc -> Doc -> Doc -> Doc -> Doc)
   -> Label
   -> r vis
   -> r ParentSpec
   -> [CSStateVar r]
-  -> [MS (r (Method r))]
-  -> [MS (r (Method r))]
+  -> [MS (r md)]
+  -> [MS (r md)]
   -> CS (r Doc)
 intClass f n s i svrs cstrs mths = do
   modify (setClassName n)
@@ -165,8 +165,8 @@ intClass f n s i svrs cstrs mths = do
 -- after imports), Doc to put at bottom of module, methods, classes
 -- Renamed top to topDoc to fix shadowing error with RendererClassesOO top
 buildModule
-  :: (RG.ClassElim r, RC.MethodElim r, RG.RenderMod r)
-  => Label -> FS Doc -> FS Doc -> FS Doc -> [MS (r (Method r))] -> [SClass r] -> FSModule r
+  :: (RG.ClassElim r, RC.MethodElim r md, RG.RenderMod r)
+  => Label -> FS Doc -> FS Doc -> FS Doc -> [MS (r md)] -> [SClass r] -> FSModule r
 buildModule n imps topDoc bot fs cs = RG.modFromData n (do
   cls <- mapM (zoom lensFStoCS) cs
   fns <- mapM (zoom lensFStoMS) fs
@@ -258,19 +258,19 @@ mainDesc, argsDesc :: String
 mainDesc = "Controls the flow of the program"
 argsDesc = "List of command-line arguments"
 
-docMain :: (OORenderSym r vis smt) => MSBody r -> MS (r (Method r))
+docMain :: (OORenderSym r vis smt md) => MSBody r -> MS (r md)
 docMain b = commentedFunc (docComment $ toState $ functionDox
   mainDesc [(args, argsDesc)] []) (IC.mainFunction b)
 
 mainFunction
   :: ( AttachmentSym r
-     , OORenderMethod r vis
+     , OORenderMethod r vis md
      , IC.ParameterSym r
      , UnRepr r TypeData
      , Monad r
      , VisibilitySym r vis
      )
-  => VS (r TypeData) -> Label -> MSBody r -> MS (r (Method r))
+  => VS (r TypeData) -> Label -> MSBody r -> MS (r md)
 mainFunction s n = RG.intFunc True n public classLevel (mType IC.void)
   [IC.param (IC.var args (s >>= (\argT -> typeFromData (List String)
   (render (renderType argT) ++ array) (renderType argT <> array'))))]
@@ -282,11 +282,11 @@ mainFunction s n = RG.intFunc True n public classLevel (mType IC.void)
 --   ms is the class methods
 --   cs is the classes
 buildModule'
-  :: (OORenderSym r vis smt, UnRepr r Doc)
+  :: (OORenderSym r vis smt md, UnRepr r Doc)
   => Label
   -> (String -> r Doc)
   -> [Label]
-  -> [MS (r (Method r))]
+  -> [MS (r md)]
   -> [SClass r]
   -> FSModule r
 buildModule' n inc is ms cs = RG.modFromData n (do
@@ -328,14 +328,14 @@ string :: (Monad r) => VS (r TypeData)
 string = typeFromData String stringRender (text stringRender)
 
 docInOutFunc
-  :: (RenderMethod r)
-  => ([SVariable r] -> [SVariable r] -> [SVariable r] -> MSBody r -> MS (r (Method r)))
+  :: (RenderMethod r md)
+  => ([SVariable r] -> [SVariable r] -> [SVariable r] -> MSBody r -> MS (r md))
   -> String
   -> [(String, SVariable r)]
   -> [(String, SVariable r)]
   -> [(String, SVariable r)]
   -> MSBody r
-  -> MS (r (Method r))
+  -> MS (r md)
 docInOutFunc f desc is [o] [] b = docFuncRepr functionDox desc (map fst is)
   [fst o] (f (map snd is) [snd o] [] b)
 docInOutFunc f desc is [] [both] b = docFuncRepr functionDox desc (map fst $
@@ -383,13 +383,13 @@ destructorError :: String -> String
 destructorError l = "Destructors not allowed in " ++ l
 
 stateVarDef
-  :: (OORenderSym r vis smt, Monad r)
+  :: (OORenderSym r vis smt md, Monad r)
   => r vis -> r (Attachment r) -> SVariable r -> SValue r -> CS (r Doc)
 stateVarDef s p vr vl = zoom lensCStoMS $ onStateValue (toCode . R.stateVar
   (RC.visibility  s) (RG.perm p) . RC.statement)
   (RC.stmt $ IC.varDecDef vr IC.local vl)
 
-constVar :: (CommonRenderSym r vis smt, Monad r) => Doc -> r vis ->
+constVar :: (CommonRenderSym r vis smt md, Monad r) => Doc -> r vis ->
   SVariable r -> SValue r -> CS (r Doc)
 constVar p s vr vl = zoom lensCStoMS $ onStateValue (toCode . R.stateVar
   (RC.visibility s) p . RC.statement) (RC.stmt $ IC.constDecDef vr IC.local vl)
@@ -417,8 +417,8 @@ litSetFunc s t es = sequence es >>= (\elems -> mkStateVal (IC.arrayType t)
 -- Python, C#, C++, and Swift--
 
 extraClass
-  :: (RG.RenderClass r vis, VisibilitySym r vis)
-  =>  Label -> Maybe Label -> [CSStateVar r] -> [MS (r (Method r))] -> [MS (r (Method r))] -> SClass r
+  :: (RG.RenderClass r vis md, VisibilitySym r vis)
+  =>  Label -> Maybe Label -> [CSStateVar r] -> [MS (r md)] -> [MS (r md)] -> SClass r
 extraClass n = RG.intClass n public . RG.inherit
 
 -- Java, C#, and Swift --
@@ -446,7 +446,7 @@ openFileW
 openFileW f vr vl = vr &= f vl outfile IC.litFalse
 
 stateVar
-  :: (Monad r, OORenderSym r vis smt)
+  :: (Monad r, OORenderSym r vis smt md)
   => r vis -> r (Attachment r) -> SVariable r -> CS (r Doc)
 stateVar s p v = zoom lensCStoMS $ onStateValue (toCode . R.stateVar
   (RC.visibility s) (RG.perm p) . RC.statement) (RC.stmt $ IC.varDec v IC.local)
@@ -493,7 +493,7 @@ listDec
 listDec v scp = listDecDef v scp []
 
 funcDecDef
-  :: (OORenderSym r vis smt)
+  :: (OORenderSym r vis smt md)
   => SVariable r -> r ScopeData -> [SVariable r] -> MSBody r -> MS (r smt)
 funcDecDef v scp ps b = do
   vr <- zoom lensMStoVS v
@@ -522,7 +522,7 @@ forLoopError :: String -> String
 forLoopError l = "Classic for loops not available in " ++ l ++ ", use " ++
   "forRange, forEach, or while instead"
 
-mainBody :: (RC.BodyElim r, RC.RenderMethod r) => MSBody r -> MS (r (Method r))
+mainBody :: (RC.BodyElim r, RC.RenderMethod r md) => MSBody r -> MS (r md)
 mainBody b = do
   modify setCurrMain
   bod <- b
@@ -536,12 +536,12 @@ inOutFunc
      , RenderType r
      , VariableElim r
      )
-  => (VS (r TypeData) -> [MS (r ParamData)] -> MSBody r -> MS (r (Method r)))
+  => (VS (r TypeData) -> [MS (r ParamData)] -> MSBody r -> MS (r md))
   -> [SVariable r]
   -> [SVariable r]
   -> [SVariable r]
   -> MSBody r
-  -> MS (r (Method r))
+  -> MS (r md)
 inOutFunc f ins [] [] b = f IC.void (map IC.param ins) b
 inOutFunc f ins outs both b = f
   (multiType $ map (onStateValue variableType) rets)
@@ -551,14 +551,14 @@ inOutFunc f ins outs both b = f
   where rets = both ++ outs
 
 docInOutFunc'
-  :: (RenderMethod r)
+  :: (RenderMethod r md)
   => FuncDocRenderer
-  -> ([SVariable r] -> [SVariable r] -> [SVariable r] -> MSBody r -> MS (r (Method r)))
+  -> ([SVariable r] -> [SVariable r] -> [SVariable r] -> MSBody r -> MS (r md))
   -> String
   -> [(String, SVariable r)]
   -> [(String, SVariable r)]
   -> [(String, SVariable r)]
-  -> MSBody r -> MS (r (Method r))
+  -> MSBody r -> MS (r md)
 docInOutFunc' dfr f desc is os bs b = docFuncRepr dfr desc (map fst $ bs ++ is)
   (map fst $ bs ++ os) (f (map snd is) (map snd os) (map snd bs) b)
 

--- a/code/drasil-gool/lib/Drasil/Shared/LanguageRenderer/CommonPseudoOO.hs
+++ b/code/drasil-gool/lib/Drasil/Shared/LanguageRenderer/CommonPseudoOO.hs
@@ -23,11 +23,11 @@ import Drasil.Shared.CodeType (CodeType(..))
 
 import Drasil.Shared.InterfaceCommon (UnRepr(..), varDecDef, bool,
   extFuncAppMixedArgs,funcType, extVar, Label, Library, MSBody, SVariable, Value,
-  SValue, SMethod, MixedCall, bodyStatements, oneLiner,
+  SValue, MixedCall, bodyStatements, oneLiner,
   TypeSym(infile, outfile, innerType), TypeElim(..), getCodeType, getTypeString,
   VariableElim(variableName, variableType), ValueSym(valueType), Comparison(..),
-  (&=), ControlStatement(returnStmt), VisibilitySym(..), MethodSym(function),
-  funcApp, listSize)
+  (&=), ControlStatement(returnStmt), VisibilitySym(..),
+  MethodSym(Method, function), funcApp, listSize)
 import qualified Drasil.Shared.InterfaceCommon as IC
 import Drasil.GOOL.InterfaceGOOL (SFile, FSModule, SClass, CSStateVar,
   OOTypeSym(obj), AttachmentSym(..), Initializers, objMethodCallNoParams,
@@ -94,12 +94,12 @@ int = typeFromData Integer intRender (text intRender)
 
 constructor
   :: (OORenderSym r vis smt, OOStatement r smt)
-  => Label -> [MS (r ParamData)] -> Initializers r -> MSBody r -> SMethod r
+  => Label -> [MS (r ParamData)] -> Initializers r -> MSBody r -> MS (r (Method r))
 constructor fName ps is b = getClassName >>= (\c -> intMethod False fName
   public instanceLevel (RG.construct c) ps (RC.multiBody [initStmts is, b]))
 
 doxFunc :: (RenderMethod r) => String -> [String] -> Maybe String ->
-  SMethod r -> SMethod r
+  MS (r (Method r)) -> MS (r (Method r))
 doxFunc = docFunc functionDox
 
 doxClass :: (RG.RenderClass r vis) => String -> SClass r -> SClass r
@@ -150,8 +150,8 @@ intClass
   -> r vis
   -> r ParentSpec
   -> [CSStateVar r]
-  -> [SMethod r]
-  -> [SMethod r]
+  -> [MS (r (Method r))]
+  -> [MS (r (Method r))]
   -> CS (r Doc)
 intClass f n s i svrs cstrs mths = do
   modify (setClassName n)
@@ -166,7 +166,7 @@ intClass f n s i svrs cstrs mths = do
 -- Renamed top to topDoc to fix shadowing error with RendererClassesOO top
 buildModule
   :: (RG.ClassElim r, RC.MethodElim r, RG.RenderMod r)
-  => Label -> FS Doc -> FS Doc -> FS Doc -> [SMethod r] -> [SClass r] -> FSModule r
+  => Label -> FS Doc -> FS Doc -> FS Doc -> [MS (r (Method r))] -> [SClass r] -> FSModule r
 buildModule n imps topDoc bot fs cs = RG.modFromData n (do
   cls <- mapM (zoom lensFStoCS) cs
   fns <- mapM (zoom lensFStoMS) fs
@@ -258,7 +258,7 @@ mainDesc, argsDesc :: String
 mainDesc = "Controls the flow of the program"
 argsDesc = "List of command-line arguments"
 
-docMain :: (OORenderSym r vis smt) => MSBody r -> SMethod r
+docMain :: (OORenderSym r vis smt) => MSBody r -> MS (r (Method r))
 docMain b = commentedFunc (docComment $ toState $ functionDox
   mainDesc [(args, argsDesc)] []) (IC.mainFunction b)
 
@@ -270,7 +270,7 @@ mainFunction
      , Monad r
      , VisibilitySym r vis
      )
-  => VS (r TypeData) -> Label -> MSBody r -> SMethod r
+  => VS (r TypeData) -> Label -> MSBody r -> MS (r (Method r))
 mainFunction s n = RG.intFunc True n public classLevel (mType IC.void)
   [IC.param (IC.var args (s >>= (\argT -> typeFromData (List String)
   (render (renderType argT) ++ array) (renderType argT <> array'))))]
@@ -286,7 +286,7 @@ buildModule'
   => Label
   -> (String -> r Doc)
   -> [Label]
-  -> [SMethod r]
+  -> [MS (r (Method r))]
   -> [SClass r]
   -> FSModule r
 buildModule' n inc is ms cs = RG.modFromData n (do
@@ -329,13 +329,13 @@ string = typeFromData String stringRender (text stringRender)
 
 docInOutFunc
   :: (RenderMethod r)
-  => ([SVariable r] -> [SVariable r] -> [SVariable r] -> MSBody r -> SMethod r)
+  => ([SVariable r] -> [SVariable r] -> [SVariable r] -> MSBody r -> MS (r (Method r)))
   -> String
   -> [(String, SVariable r)]
   -> [(String, SVariable r)]
   -> [(String, SVariable r)]
   -> MSBody r
-  -> SMethod r
+  -> MS (r (Method r))
 docInOutFunc f desc is [o] [] b = docFuncRepr functionDox desc (map fst is)
   [fst o] (f (map snd is) [snd o] [] b)
 docInOutFunc f desc is [] [both] b = docFuncRepr functionDox desc (map fst $
@@ -418,7 +418,7 @@ litSetFunc s t es = sequence es >>= (\elems -> mkStateVal (IC.arrayType t)
 
 extraClass
   :: (RG.RenderClass r vis, VisibilitySym r vis)
-  =>  Label -> Maybe Label -> [CSStateVar r] -> [SMethod r] -> [SMethod r] -> SClass r
+  =>  Label -> Maybe Label -> [CSStateVar r] -> [MS (r (Method r))] -> [MS (r (Method r))] -> SClass r
 extraClass n = RG.intClass n public . RG.inherit
 
 -- Java, C#, and Swift --
@@ -522,7 +522,7 @@ forLoopError :: String -> String
 forLoopError l = "Classic for loops not available in " ++ l ++ ", use " ++
   "forRange, forEach, or while instead"
 
-mainBody :: (RC.BodyElim r, RC.RenderMethod r) => MSBody r -> SMethod r
+mainBody :: (RC.BodyElim r, RC.RenderMethod r) => MSBody r -> MS (r (Method r))
 mainBody b = do
   modify setCurrMain
   bod <- b
@@ -536,12 +536,12 @@ inOutFunc
      , RenderType r
      , VariableElim r
      )
-  => (VS (r TypeData) -> [MS (r ParamData)] -> MSBody r -> SMethod r)
+  => (VS (r TypeData) -> [MS (r ParamData)] -> MSBody r -> MS (r (Method r)))
   -> [SVariable r]
   -> [SVariable r]
   -> [SVariable r]
   -> MSBody r
-  -> SMethod r
+  -> MS (r (Method r))
 inOutFunc f ins [] [] b = f IC.void (map IC.param ins) b
 inOutFunc f ins outs both b = f
   (multiType $ map (onStateValue variableType) rets)
@@ -553,12 +553,12 @@ inOutFunc f ins outs both b = f
 docInOutFunc'
   :: (RenderMethod r)
   => FuncDocRenderer
-  -> ([SVariable r] -> [SVariable r] -> [SVariable r] -> MSBody r -> SMethod r)
+  -> ([SVariable r] -> [SVariable r] -> [SVariable r] -> MSBody r -> MS (r (Method r)))
   -> String
   -> [(String, SVariable r)]
   -> [(String, SVariable r)]
   -> [(String, SVariable r)]
-  -> MSBody r -> SMethod r
+  -> MSBody r -> MS (r (Method r))
 docInOutFunc' dfr f desc is os bs b = docFuncRepr dfr desc (map fst $ bs ++ is)
   (map fst $ bs ++ os) (f (map snd is) (map snd os) (map snd bs) b)
 

--- a/code/drasil-gool/lib/Drasil/Shared/LanguageRenderer/LanguagePolymorphic.hs
+++ b/code/drasil-gool/lib/Drasil/Shared/LanguageRenderer/LanguagePolymorphic.hs
@@ -23,11 +23,11 @@ import Drasil.FileHandling.Legacy (indent)
 import Drasil.Shared.CodeType (CodeType(..), ClassName)
 import Drasil.Shared.InterfaceCommon (UnRepr(..), Label, Library, MSBody,
   MSBlock, SVariable, SValue, NamedArgs, MixedCall, MixedCtorCall, BodySym(Body),
-  bodyStatements, oneLiner, BlockSym(Block), MethodSym(Method),
-  VariableSym(Variable), VisibilitySym(..),
-  VariableElim(variableName, variableType), ValueSym(Value, valueType),
-  NumericExpression((#+), (#-), (#/), sin, cos, tan), Comparison(..), funcApp,
-  StatementSym(multi), AssignStatement((&++)), (&=), TypeElim(..),
+  bodyStatements, oneLiner, BlockSym(Block), VariableSym(Variable),
+  VisibilitySym(..), VariableElim(variableName, variableType),
+  ValueSym(Value, valueType), NumericExpression((#+), (#-), (#/), sin, cos, tan),
+  Comparison(..), funcApp, StatementSym(multi), AssignStatement((&++)), (&=),
+  TypeElim(..),
   IOStatement(printStr, printStrLn, printFile, printFileStr, printFileStrLn),
   ifNoElse, convType, VSBinder, BinderElim(..), getCodeType, getTypeString,
   ValueExpression)
@@ -504,22 +504,22 @@ param f v' = do
   paramFromData v' $ f v
 
 method
-  :: (OORenderMethod r vis)
+  :: (OORenderMethod r vis md)
   => Label
   -> r vis
   -> r (Attachment r)
   -> VS (r TypeData)
   -> [MS (r ParamData)]
   -> MSBody r
-  -> MS (r (Method r))
+  -> MS (r md)
 method n s p t = intMethod False n s p (mType t)
 
-getMethod :: (OORenderSym r vis smt) => SVariable r -> MS (r (Method r))
+getMethod :: (OORenderSym r vis smt md) => SVariable r -> MS (r md)
 getMethod v = zoom lensMStoVS v >>= (\vr -> IG.method (getterName $ variableName
   vr) public instanceLevel (toState $ variableType vr) [] getBody)
   where getBody = oneLiner $ IC.returnStmt (IC.valueOf $ IG.instanceVarSelf v)
 
-setMethod :: (OORenderSym r vis smt) => SVariable r -> MS (r (Method r))
+setMethod :: (OORenderSym r vis smt md) => SVariable r -> MS (r md)
 setMethod v = zoom lensMStoVS v >>= (\vr -> IG.method (setterName $ variableName
   vr) public instanceLevel IC.void [IC.param v] setBody)
   where setBody = oneLiner $ IG.instanceVarSelf v &= IC.valueOf v
@@ -528,34 +528,34 @@ initStmts :: (OOStatement r smt) => Initializers r -> MSBody r
 initStmts = bodyStatements . map (\(vr, vl) -> IG.instanceVarSelf vr &= vl)
 
 function
-  :: (AttachmentSym r, OORenderMethod r vis)
-  => Label -> r vis -> VS (r TypeData) -> [MS (r ParamData)] -> MSBody r -> MS (r (Method r))
+  :: (AttachmentSym r, OORenderMethod r vis md)
+  => Label -> r vis -> VS (r TypeData) -> [MS (r ParamData)] -> MSBody r -> MS (r md)
 function n s t = RO.intFunc False n s classLevel (mType t)
 
-docFuncRepr :: (RenderMethod r) => FuncDocRenderer -> String ->
-  [String] -> [String] -> MS (r (Method r)) -> MS (r (Method r))
+docFuncRepr :: (RenderMethod r md) => FuncDocRenderer -> String ->
+  [String] -> [String] -> MS (r md) -> MS (r md)
 docFuncRepr f desc pComms rComms = commentedFunc (docComment $ onStateValue
   (\ps -> f desc (zip ps pComms) rComms) getParameters)
 
-docFunc :: (RenderMethod r) => FuncDocRenderer -> String -> [String] ->
-  Maybe String -> MS (r (Method r)) -> MS (r (Method r))
+docFunc :: (RenderMethod r md) => FuncDocRenderer -> String -> [String] ->
+  Maybe String -> MS (r md) -> MS (r md)
 docFunc f desc pComms rComm = docFuncRepr f desc pComms (maybeToList rComm)
 
 -- Classes --
 
 buildClass
-  :: (RenderClass r vis, VisibilitySym r vis)
-  =>  Maybe Label -> [CSStateVar r] -> [MS (r (Method r))] -> [MS (r (Method r))] -> SClass r
+  :: (RenderClass r vis md, VisibilitySym r vis)
+  =>  Maybe Label -> [CSStateVar r] -> [MS (r md)] -> [MS (r md)] -> SClass r
 buildClass p stVars constructors methods = do
   n <- zoom lensCStoFS getModuleName
   RO.intClass n public (inherit p) stVars constructors methods
 
-implementingClass :: (RenderClass r vis, VisibilitySym r vis) => Label -> [Label] ->
-  [CSStateVar r] -> [MS (r (Method r))] -> [MS (r (Method r))] -> SClass r
+implementingClass :: (RenderClass r vis md, VisibilitySym r vis) => Label -> [Label] ->
+  [CSStateVar r] -> [MS (r md)] -> [MS (r md)] -> SClass r
 implementingClass n is = RO.intClass n public (implements is)
 
 docClass
-  :: (RenderClass r vis)
+  :: (RenderClass r vis md)
   => ClassDocRenderer -> String -> SClass r -> SClass r
 docClass cdr d = RO.commentedClass (docComment $ toState $ cdr d)
 

--- a/code/drasil-gool/lib/Drasil/Shared/LanguageRenderer/LanguagePolymorphic.hs
+++ b/code/drasil-gool/lib/Drasil/Shared/LanguageRenderer/LanguagePolymorphic.hs
@@ -22,8 +22,8 @@ import Drasil.FileHandling.Legacy (indent)
 
 import Drasil.Shared.CodeType (CodeType(..), ClassName)
 import Drasil.Shared.InterfaceCommon (UnRepr(..), Label, Library, MSBody,
-  MSBlock, SVariable, SValue, SMethod, NamedArgs, MixedCall, MixedCtorCall,
-  BodySym(Body), bodyStatements, oneLiner, BlockSym(Block),
+  MSBlock, SVariable, SValue, NamedArgs, MixedCall, MixedCtorCall, BodySym(Body),
+  bodyStatements, oneLiner, BlockSym(Block), MethodSym(Method),
   VariableSym(Variable), VisibilitySym(..),
   VariableElim(variableName, variableType), ValueSym(Value, valueType),
   NumericExpression((#+), (#-), (#/), sin, cos, tan), Comparison(..), funcApp,
@@ -511,15 +511,15 @@ method
   -> VS (r TypeData)
   -> [MS (r ParamData)]
   -> MSBody r
-  -> SMethod r
+  -> MS (r (Method r))
 method n s p t = intMethod False n s p (mType t)
 
-getMethod :: (OORenderSym r vis smt) => SVariable r -> SMethod r
+getMethod :: (OORenderSym r vis smt) => SVariable r -> MS (r (Method r))
 getMethod v = zoom lensMStoVS v >>= (\vr -> IG.method (getterName $ variableName
   vr) public instanceLevel (toState $ variableType vr) [] getBody)
   where getBody = oneLiner $ IC.returnStmt (IC.valueOf $ IG.instanceVarSelf v)
 
-setMethod :: (OORenderSym r vis smt) => SVariable r -> SMethod r
+setMethod :: (OORenderSym r vis smt) => SVariable r -> MS (r (Method r))
 setMethod v = zoom lensMStoVS v >>= (\vr -> IG.method (setterName $ variableName
   vr) public instanceLevel IC.void [IC.param v] setBody)
   where setBody = oneLiner $ IG.instanceVarSelf v &= IC.valueOf v
@@ -529,29 +529,29 @@ initStmts = bodyStatements . map (\(vr, vl) -> IG.instanceVarSelf vr &= vl)
 
 function
   :: (AttachmentSym r, OORenderMethod r vis)
-  => Label -> r vis -> VS (r TypeData) -> [MS (r ParamData)] -> MSBody r -> SMethod r
+  => Label -> r vis -> VS (r TypeData) -> [MS (r ParamData)] -> MSBody r -> MS (r (Method r))
 function n s t = RO.intFunc False n s classLevel (mType t)
 
 docFuncRepr :: (RenderMethod r) => FuncDocRenderer -> String ->
-  [String] -> [String] -> SMethod r -> SMethod r
+  [String] -> [String] -> MS (r (Method r)) -> MS (r (Method r))
 docFuncRepr f desc pComms rComms = commentedFunc (docComment $ onStateValue
   (\ps -> f desc (zip ps pComms) rComms) getParameters)
 
 docFunc :: (RenderMethod r) => FuncDocRenderer -> String -> [String] ->
-  Maybe String -> SMethod r -> SMethod r
+  Maybe String -> MS (r (Method r)) -> MS (r (Method r))
 docFunc f desc pComms rComm = docFuncRepr f desc pComms (maybeToList rComm)
 
 -- Classes --
 
 buildClass
   :: (RenderClass r vis, VisibilitySym r vis)
-  =>  Maybe Label -> [CSStateVar r] -> [SMethod r] -> [SMethod r] -> SClass r
+  =>  Maybe Label -> [CSStateVar r] -> [MS (r (Method r))] -> [MS (r (Method r))] -> SClass r
 buildClass p stVars constructors methods = do
   n <- zoom lensCStoFS getModuleName
   RO.intClass n public (inherit p) stVars constructors methods
 
 implementingClass :: (RenderClass r vis, VisibilitySym r vis) => Label -> [Label] ->
-  [CSStateVar r] -> [SMethod r] -> [SMethod r] -> SClass r
+  [CSStateVar r] -> [MS (r (Method r))] -> [MS (r (Method r))] -> SClass r
 implementingClass n is = RO.intClass n public (implements is)
 
 docClass

--- a/code/drasil-gool/lib/Drasil/Shared/LanguageRenderer/LoggingFor.hs
+++ b/code/drasil-gool/lib/Drasil/Shared/LanguageRenderer/LoggingFor.hs
@@ -181,7 +181,7 @@ instance (StringStatement r smt, IOStatement r smt, VariableValue r, VariableEli
 
 -- SharedProg Boilerplate
 
-instance (SharedProg r vis smt) => SharedProg (LoggingFor r) vis smt
+instance (SharedProg r vis smt md) => SharedProg (LoggingFor r) vis smt md
 instance (SharedStatement r smt, VariableElim r) => SharedStatement (LoggingFor r) smt
 instance (G.OOStatement r smt, VariableElim r) => G.OOStatement (LoggingFor r) smt
 
@@ -317,8 +317,7 @@ instance (VisibilitySym r vis) => VisibilitySym (LoggingFor r) vis where
   private = liftLogging private
   public = liftLogging public
 
-instance (MethodSym r vis smt) => MethodSym (LoggingFor r) vis smt where
-  type Method (LoggingFor r) = Method r
+instance (MethodSym r vis smt md) => MethodSym (LoggingFor r) vis smt md where
   docMain = liftLogging docMain
   function = liftLogging function
   mainFunction = liftLogging mainFunction
@@ -389,24 +388,24 @@ instance (NativeVector lang) => NativeVector (LoggingFor lang) where
 
 -- GProc
 
-instance (P.ProcProg r vis smt) => P.ProcProg (LoggingFor r) vis smt
+instance (P.ProcProg r vis smt md) => P.ProcProg (LoggingFor r) vis smt md
 
-instance (P.ModuleSym r vis smt) => P.ModuleSym (LoggingFor r) vis smt where
+instance (P.ModuleSym r vis smt md) => P.ModuleSym (LoggingFor r) vis smt md where
   type Module (LoggingFor r) = P.Module r
   buildModule = liftLogging P.buildModule
 
-instance (P.FileSym r vis smt) => P.FileSym (LoggingFor r) vis smt where
+instance (P.FileSym r vis smt md) => P.FileSym (LoggingFor r) vis smt md where
   type File (LoggingFor r) = P.File r
   fileDoc = liftLogging P.fileDoc
   docMod = liftLogging P.docMod
 
-instance (P.ProgramSym r vis smt) => P.ProgramSym (LoggingFor r) vis smt where
+instance (P.ProgramSym r vis smt md) => P.ProgramSym (LoggingFor r) vis smt md where
   type Program (LoggingFor r) = P.Program r
   prog = liftLogging P.prog
 
 -- GOOL
 
-instance (G.OOProg r vis smt) => G.OOProg (LoggingFor r) vis smt
+instance (G.OOProg r vis smt md) => G.OOProg (LoggingFor r) vis smt md
 
 instance (G.GetSet r) => G.GetSet (LoggingFor r) where
   get = liftLogging G.get
@@ -459,7 +458,7 @@ instance (G.AttachmentSym r) => G.AttachmentSym (LoggingFor r) where
   classLevel = liftLogging G.classLevel
   instanceLevel = liftLogging G.instanceLevel
 
-instance (G.OOMethodSym r vis smt) => G.OOMethodSym (LoggingFor r) vis smt where
+instance (G.OOMethodSym r vis smt md) => G.OOMethodSym (LoggingFor r) vis smt md where
   method = liftLogging G.method
   getMethod = liftLogging G.getMethod
   setMethod = liftLogging G.setMethod
@@ -473,23 +472,23 @@ instance (G.StateVarSym r vis) => G.StateVarSym (LoggingFor r) vis where
   stateVarDef = liftLogging G.stateVarDef
   constVar = liftLogging G.constVar
 
-instance (G.ClassSym r vis smt) => G.ClassSym (LoggingFor r) vis smt where
+instance (G.ClassSym r vis smt md) => G.ClassSym (LoggingFor r) vis smt md where
   type Class (LoggingFor r) = G.Class r
   buildClass = liftLogging G.buildClass
   extraClass = liftLogging G.extraClass
   implementingClass = liftLogging G.implementingClass
   docClass = liftLogging G.docClass
 
-instance (G.ModuleSym r vis smt) => G.ModuleSym (LoggingFor r) vis smt where
+instance (G.ModuleSym r vis smt md) => G.ModuleSym (LoggingFor r) vis smt md where
   type Module (LoggingFor r) = G.Module r
   buildModule = liftLogging G.buildModule
 
-instance (G.FileSym r vis smt) => G.FileSym (LoggingFor r) vis smt where
+instance (G.FileSym r vis smt md) => G.FileSym (LoggingFor r) vis smt md where
   type File (LoggingFor r) = G.File r
   fileDoc = liftLogging G.fileDoc
   docMod = liftLogging G.docMod
 
-instance (G.ProgramSym r vis smt) => G.ProgramSym (LoggingFor r) vis smt where
+instance (G.ProgramSym r vis smt md) => G.ProgramSym (LoggingFor r) vis smt md where
   type Program (LoggingFor r) = G.Program r
   prog = liftLogging G.prog
 

--- a/code/drasil-gool/lib/Drasil/Shared/RendererClassesCommon.hs
+++ b/code/drasil-gool/lib/Drasil/Shared/RendererClassesCommon.hs
@@ -21,8 +21,8 @@ import Drasil.Shared.InterfaceCommon (Label, Library, MSBody, MSBlock, SVariable
   NumericExpression(..), BooleanExpression(..), Comparison(..),
   IndexTranslator(..), List(..), InternalList(..), AssignStatement(..),
   DeclStatement(..), IOStatement(..), StringStatement(..), FuncAppStatement(..),
-  CommentStatement(..), ControlStatement(..), ParameterSym(..), MethodSym(..),
-  BinderElim(..), UnRepr(..))
+  CommentStatement(..), ControlStatement(..), ParameterSym(..), BinderElim(..),
+  UnRepr(..))
 import Drasil.Shared.AST (AttachmentTag, Terminator, VisibilityTag, ScopeData,
   OpData, BinderD, TypeData, ParamData, FuncData)
 import Drasil.Shared.State (MS, VS)
@@ -43,9 +43,9 @@ class (AssignStatement r smt, DeclStatement r smt, IOStatement r smt,
   RenderStatement r smt, StatementElim r smt, RenderType r, RenderValue r,
   ValueElim r, RenderVariable r, InternalVarElim r, InternalBinderElim r,
   ImportSym r, UnaryOpSym r, BinaryOpSym r, BlockCommentSym r,
-  BlockCommentElim r, ValueExpression r, RenderMethod r, MethodElim r,
+  BlockCommentElim r, ValueExpression r, RenderMethod r md, MethodElim r md,
   ParameterSym r, ScopeElim r
-  ) => CommonRenderSym r vis smt
+  ) => CommonRenderSym r vis smt md
 
 -- Common Typeclasses --
 
@@ -211,10 +211,10 @@ class (TypeSym r) => MethodTypeSym r where
   type MethodType r
   mType    :: VS (r TypeData) -> MSMthdType r
 
-class (MethodTypeSym r, BlockCommentSym r) => RenderMethod r where
+class (MethodTypeSym r, BlockCommentSym r) => RenderMethod r md | r -> md where
   -- | Takes a BlockComment and a method and generates a function.
-  commentedFunc :: MS (r Doc) -> MS (r (Method r)) -> MS (r (Method r))
-  mthdFromData :: VisibilityTag -> Doc -> MS (r (Method r))
+  commentedFunc :: MS (r Doc) -> MS (r md) -> MS (r md)
+  mthdFromData :: VisibilityTag -> Doc -> MS (r md)
 
-class MethodElim r where
-  method :: r (Method r) -> Doc
+class MethodElim r md | r -> md where
+  method :: r md -> Doc

--- a/code/drasil-gool/lib/Drasil/Shared/RendererClassesCommon.hs
+++ b/code/drasil-gool/lib/Drasil/Shared/RendererClassesCommon.hs
@@ -15,9 +15,9 @@ module Drasil.Shared.RendererClassesCommon (
 ) where
 
 import Drasil.Shared.InterfaceCommon (Label, Library, MSBody, MSBlock, SVariable,
-  SValue, SMethod, MixedCall, BodySym(..), BlockSym(..), TypeSym(..),
-  VariableSym(..), VariableElim(..), ValueSym(..), Argument(..), Literal(..),
-  MathConstant(..), VariableValue(..), ValueExpression(..), CommandLineArgs(..),
+  SValue, MixedCall, BodySym(..), BlockSym(..), TypeSym(..), VariableSym(..),
+  VariableElim(..), ValueSym(..), Argument(..), Literal(..), MathConstant(..),
+  VariableValue(..), ValueExpression(..), CommandLineArgs(..),
   NumericExpression(..), BooleanExpression(..), Comparison(..),
   IndexTranslator(..), List(..), InternalList(..), AssignStatement(..),
   DeclStatement(..), IOStatement(..), StringStatement(..), FuncAppStatement(..),
@@ -213,8 +213,8 @@ class (TypeSym r) => MethodTypeSym r where
 
 class (MethodTypeSym r, BlockCommentSym r) => RenderMethod r where
   -- | Takes a BlockComment and a method and generates a function.
-  commentedFunc :: MS (r Doc) -> SMethod r -> SMethod r
-  mthdFromData :: VisibilityTag -> Doc -> SMethod r
+  commentedFunc :: MS (r Doc) -> MS (r (Method r)) -> MS (r (Method r))
+  mthdFromData :: VisibilityTag -> Doc -> MS (r (Method r))
 
 class MethodElim r where
   method :: r (Method r) -> Doc

--- a/code/drasil-gool/lib/Drasil/Shared/State.hs
+++ b/code/drasil-gool/lib/Drasil/Shared/State.hs
@@ -60,8 +60,8 @@ data GOOLState = GS {
                                      -- needed when using extClassVarAccess and obj
 
   -- Only used in Java and Swift, to generate correct "throws Exception" declarations
-  _methodExceptionMap :: Map QualifiedName [ExceptionType], -- Method to exceptions thrown
-  _callMap :: Map QualifiedName [QualifiedName], -- Method to other methods it calls
+  _methodExceptionMap :: Map QualifiedName [ExceptionType], -- md exceptions thrown
+  _callMap :: Map QualifiedName [QualifiedName], -- md other methods it calls
 
   -- Only used for Swift
   _throwUsed :: Bool, -- to add code so Strings can be used as Errors


### PR DESCRIPTION
Builds on #5298 
Contributes to #5233 

I thought that we could remove this type family entirely, but the C++ renderer defines its own type `MethodData` that's different than the one in `AST.hs`.