### PR TITLE
docs(`WriteSystem`): clarify default Makefile option set

### DIFF
--- a/code/drasil-gen/lib/Drasil/Generator/WriteSystem.hs
+++ b/code/drasil-gen/lib/Drasil/Generator/WriteSystem.hs
@@ -64,6 +64,8 @@ data WriteOptions = WO
 -- 1. 'overwritePolicy': Always allow file-overwriting.
 -- 2. 'dirName': The example's abbreviation.
 -- 3. 'textEncoding': UTF-8.
+-- 4. 'debugDataPolicy': Dependant on `DEBUG_ENV` environment variable being
+--    set, writing to a nested `.drasil` folder.
 drasilMakefileReqOpts :: WriteOptions
 drasilMakefileReqOpts =
   WO OverwriteAllowed dirName utf8 (CheckEnvVar "DEBUG_ENV" [ps|.drasil|])


### PR DESCRIPTION
This is a follow-up to #5289 where I forgot to add to the documentation.