### PR TITLE
Made `Variable` not be a type family

### DIFF
--- a/code/drasil-gool/lib/Drasil/GOOL/CodeInfoOO.hs
+++ b/code/drasil-gool/lib/Drasil/GOOL/CodeInfoOO.hs
@@ -5,8 +5,8 @@
 -- Performs code analysis on the GOOL code
 module Drasil.GOOL.CodeInfoOO (CodeInfoOO(..)) where
 
-import Drasil.Shared.InterfaceCommon (UnRepr(..), MSBody, VSBinder, SValue,
-  SharedProg, SharedStatement, BodySym(..), BlockSym(..), TypeSym(..),
+import Drasil.Shared.InterfaceCommon (UnRepr(..), MSBody, VSBinder, Variable,
+  SValue, SharedProg, SharedStatement, BodySym(..), BlockSym(..), TypeSym(..),
   TypeElim(..), VariableSym(..), VariableElim(..), ValueSym(..), Argument(..),
   Literal(..), MathConstant(..), VariableValue(..), CommandLineArgs(..),
   NumericExpression(..), BooleanExpression(..), Comparison(..),
@@ -123,20 +123,19 @@ instance ScopeSym CodeInfoOO where
   local = noInfoScope
 
 instance VariableSym CodeInfoOO where
-  type Variable CodeInfoOO = ()
-  var       _ _ = noInfo
-  constant  _ _ = noInfo
-  extVar  _ _ _ = noInfo
+  var       _ _ = return $ return $ error "[var] The return value of this isn't used, and the thunk shouldn't fire."
+  constant  _ _ = return $ return $ error "[constant] The return value of this isn't used, and the thunk shouldn't fire."
+  extVar  _ _ _ = return $ return $ error "[extVar] The return value of this isn't used, and the thunk shouldn't fire."
 
 instance OOVariableSym CodeInfoOO where
-  classVar _ _ = noInfo
-  classConst _ _ = noInfo
-  classVarAccess    _ _   = noInfo
-  extClassVarAccess _ _   = noInfo
-  instanceVarAccess      _ _   = noInfo
+  classVar _ _ = return $ return $ error "[classVar] The return value of this isn't used, and the thunk shouldn't fire."
+  classConst _ _ = return $ return $ error "[classConst] The return value of this isn't used, and the thunk shouldn't fire."
+  classVarAccess    _ _   = return $ return $ error "[classVarAccess] The return value of this isn't used, and the thunk shouldn't fire."
+  extClassVarAccess _ _   = return $ return $ error "[extClassVarAccess] The return value of this isn't used, and the thunk shouldn't fire."
+  instanceVarAccess      _ _   = return $ return $ error "[instanceVarAccess] The return value of this isn't used, and the thunk shouldn't fire."
 
 instance SelfSym CodeInfoOO where
-  self              = noInfo
+  self              = return $ return $ error "[self] The return value of this isn't used, and the thunk shouldn't fire."
 
 instance VariableElim CodeInfoOO where
   variableName _ = ""
@@ -217,10 +216,13 @@ instance Comparison CodeInfoOO where
 
 instance ValueExpression CodeInfoOO where
   inlineIf = execute3
-  funcAppMixedArgs n _ = currModCall n
+  funcAppMixedArgs n _ = do
+    _ <- currModCall n
+    return $ return $ return $ error "[funcAppMixedArgs] The return value of this isn't used, and the thunk shouldn't fire."
   extFuncAppMixedArgs l n _ vs ns = do
     sequence_ vs
-    executePairList ns
+    mapM_ fst ns
+    mapM_ snd ns
     addExternalCall l n
   libFuncAppMixedArgs = extFuncAppMixedArgs
 
@@ -231,16 +233,21 @@ instance ValueExpression CodeInfoOO where
 instance OOValueExpression CodeInfoOO where
   newObjMixedArgs _ vs ns = do
     sequence_ vs
-    executePairList ns
+    mapM_ fst ns
+    mapM_ snd ns
     return $ return ()
   extNewObjMixedArgs _ _ vs ns = do
     sequence_ vs
-    executePairList ns
+    mapM_ fst ns
+    mapM_ snd ns
     return $ return ()
   libNewObjMixedArgs = extNewObjMixedArgs
 
 instance InternalValueExp CodeInfoOO where
-  objMethodCallMixedArgs' n _ v vs ns = v >> currModCall n vs ns
+  objMethodCallMixedArgs' n _ v vs ns = do
+    v
+    _ <- currModCall n vs ns
+    return $ return $ error "[objMethodCallMixedArgs'] The return value of this isn't used, and the thunk shouldn't fire."
   classMethodCallMixedArgs' n _ cls vs ns = cls >> currModCall n vs ns
 
 instance FunctionSym CodeInfoOO where
@@ -267,7 +274,7 @@ instance Reference CodeInfoOO where
   maybeDeref = execute1
 
 instance Array CodeInfoOO where
-  arrayElem _ _ = noInfo
+  arrayElem _ _ = return $ return $ error "[arrayElem] The return value of this isn't used, and the thunk shouldn't fire."
   arrayLength _ = noInfo
   arrayCopy _ = noInfo
 
@@ -542,13 +549,6 @@ executeList l = do
   sequence_ l
   noInfo
 
-executePairList :: [(State a (CodeInfoOO ()), State a (CodeInfoOO ()))] ->
-  State a (CodeInfoOO ())
-executePairList ps = do
-  mapM_ fst ps
-  mapM_ snd ps
-  noInfo
-
 execute2 :: State a (CodeInfoOO ()) -> State a (CodeInfoOO ()) ->
   State a (CodeInfoOO ())
 execute2 s1 s2 = do
@@ -562,8 +562,9 @@ execute3 s1 s2 s3 = do
   execute2 s2 s3
 
 currModCall :: String -> [VS (CodeInfoOO ())] ->
-  [(VS (CodeInfoOO ()), VS (CodeInfoOO ()))] -> VS (CodeInfoOO ())
+  [(VS (CodeInfoOO Variable), VS (CodeInfoOO ()))] -> VS (CodeInfoOO ())
 currModCall n ps ns = do
   sequence_ ps
-  executePairList ns
+  mapM_ fst ns
+  mapM_ snd ns
   addCurrModCall n

--- a/code/drasil-gool/lib/Drasil/GOOL/LanguageRenderer/CSharpRenderer.hs
+++ b/code/drasil-gool/lib/Drasil/GOOL/LanguageRenderer/CSharpRenderer.hs
@@ -276,7 +276,6 @@ instance ScopeElim CSharpCode where
   scopeData = unCSC
 
 instance VariableSym CSharpCode where
-  type Variable CSharpCode = VarData
   var         = G.var
   constant    = var
   extVar      = CS.extVar

--- a/code/drasil-gool/lib/Drasil/GOOL/LanguageRenderer/CppRenderer.hs
+++ b/code/drasil-gool/lib/Drasil/GOOL/LanguageRenderer/CppRenderer.hs
@@ -15,10 +15,10 @@ import Drasil.FileHandling.Legacy (blank, indent, indentList)
 
 import Drasil.Shared.CodeType (CodeType(..))
 import Drasil.Shared.InterfaceCommon (UnRepr(..), SharedProg, SharedStatement,
-  Label, Body, MSBody, SVariable, SValue, NamedArgs, BodySym(..), bodyStatements,
-  oneLiner, BlockSym(..), TypeSym(..), TypeElim(..), getTypeString,
-  VariableSym(..), VisibilitySym(..), VariableElim(..), ValueSym(..),
-  Argument(..), Literal(..), MathConstant(..), VariableValue(..),
+  Label, Body, MSBody, Variable, SVariable, SValue, NamedArgs, BodySym(..),
+  bodyStatements, oneLiner, BlockSym(..), TypeSym(..), TypeElim(..),
+  getTypeString, VariableSym(..), VisibilitySym(..), VariableElim(..),
+  ValueSym(..), Argument(..), Literal(..), MathConstant(..), VariableValue(..),
   CommandLineArgs(..), NumericExpression(..), BooleanExpression(..),
   Comparison(..), ValueExpression(..), funcApp, extFuncApp, IndexTranslator(..),
   Reference(..), Array(..), List(..), Set(..), InternalList(..),
@@ -286,7 +286,6 @@ instance (Pair p) => ScopeElim (p CppSrcCode CppHdrCode) where
   scopeData = unCPPSC . pfst
 
 instance (Pair p) => VariableSym (p CppSrcCode CppHdrCode) where
-  type Variable (p CppSrcCode CppHdrCode) = VarData
   var n       = pair1 (var n) (var n)
   constant n  = pair1 (constant n) (constant n)
   extVar l n  = pair1 (extVar l n) (extVar l n)
@@ -1187,7 +1186,6 @@ instance ScopeElim CppSrcCode where
   scopeData = unCPPSC
 
 instance VariableSym CppSrcCode where
-  type Variable CppSrcCode = VarData
   var          = G.var
   constant     = var
   extVar l n t = modify (addModuleImportVS l) >> var n t
@@ -1915,7 +1913,6 @@ instance ScopeElim CppHdrCode where
   scopeData = unCPPHC
 
 instance VariableSym CppHdrCode where
-  type Variable CppHdrCode = VarData
   var           = G.var
   constant  _ _ = mkStateVar "" void empty
   extVar  _ _ _ = mkStateVar "" void empty
@@ -2783,7 +2780,7 @@ cppOpenFile mode f n = valStmt $ objMethodCall void (valueOf f) cppOpen [n,
 
 cppPointerParamDoc
   :: (InternalVarElim r, UnRepr r TypeData, VariableElim r)
-  => r (Variable r) -> Doc
+  => r Variable -> Doc
 cppPointerParamDoc v = renderType (variableType v) <+> cppPtr <> RC.variable v
 
 cppsMethod :: [Doc] -> Label -> Label -> CppSrcCode (MethodType CppSrcCode)

--- a/code/drasil-gool/lib/Drasil/GOOL/LanguageRenderer/JavaRenderer.hs
+++ b/code/drasil-gool/lib/Drasil/GOOL/LanguageRenderer/JavaRenderer.hs
@@ -271,7 +271,6 @@ instance ScopeElim JavaCode where
   scopeData = unJC
 
 instance VariableSym JavaCode where
-  type Variable JavaCode = VarData
   var         = G.var
   constant    = var
   extVar      = CS.extVar

--- a/code/drasil-gool/lib/Drasil/GOOL/LanguageRenderer/PythonRenderer.hs
+++ b/code/drasil-gool/lib/Drasil/GOOL/LanguageRenderer/PythonRenderer.hs
@@ -13,7 +13,7 @@ import Drasil.FileHandling.Legacy (blank, indent)
 
 import Drasil.Shared.CodeType (CodeType(..))
 import Drasil.Shared.InterfaceCommon (UnRepr(..), SharedProg, SharedStatement,
-  Label, Library, Body, SVariable, SValue, MixedCtorCall, BodySym(..),
+  Label, Library, Body, Variable, SVariable, SValue, MixedCtorCall, BodySym(..),
   BlockSym(..), TypeSym(..), TypeElim(..), getTypeString, VariableSym(..),
   VisibilitySym(..), VariableElim(..), ValueSym(..), Argument(..), Literal(..),
   MathConstant(..), VariableValue(..), CommandLineArgs(..),
@@ -262,7 +262,6 @@ instance ScopeElim PythonCode where
   scopeData = unPC
 
 instance VariableSym PythonCode where
-  type Variable PythonCode = VarData
   var          = G.var
   constant n   = var $ toConstName n
   extVar l n t = modify (addModuleImportVS l) >> CS.extVar l n t
@@ -964,7 +963,7 @@ pyThrow errMsg = pyRaise <+> exceptionObj' <> parens (RC.value errMsg)
 
 pyForEach
   :: (BodyElim r, InternalVarElim r, ValueElim r)
-  => r (Variable r) -> r (Value r) -> r Body -> Doc
+  => r Variable -> r (Value r) -> r Body -> Doc
 pyForEach i lstVar b = vcat [
   forLabel <+> RC.variable i <+> inLabel <+> RC.value lstVar <> colon,
   indent $ RC.body b]
@@ -998,7 +997,7 @@ pyListSlice vn vo beg end step = zoom lensMStoVS $ do
 pyMethod
   :: Label
   -> PythonCode (Attachment PythonCode)
-  -> PythonCode (Variable PythonCode)
+  -> PythonCode Variable
   -> [PythonCode ParamData]
   -> PythonCode Body
   -> Doc

--- a/code/drasil-gool/lib/Drasil/GOOL/LanguageRenderer/SwiftRenderer.hs
+++ b/code/drasil-gool/lib/Drasil/GOOL/LanguageRenderer/SwiftRenderer.hs
@@ -14,10 +14,10 @@ import Drasil.FileHandling.Legacy (indent)
 
 import Drasil.Shared.CodeType (CodeType(..))
 import Drasil.Shared.InterfaceCommon (UnRepr(..), SharedProg, SharedStatement,
-  Label, Body, MSBody, MSBlock, SVariable, SValue, BodySym(..), oneLiner,
-  bodyStatements, BlockSym(..), TypeSym(..), TypeElim(..), getTypeString,
-  VariableSym(..), VisibilitySym(..), VariableElim(..), ValueSym(..),
-  Argument(..), Literal(..), MathConstant(..), VariableValue(..),
+  Label, Body, MSBody, MSBlock, Variable, SVariable, SValue, BodySym(..),
+  oneLiner, bodyStatements, BlockSym(..), TypeSym(..), TypeElim(..),
+  getTypeString, VariableSym(..), VisibilitySym(..), VariableElim(..),
+  ValueSym(..), Argument(..), Literal(..), MathConstant(..), VariableValue(..),
   CommandLineArgs(..), NumericExpression(..), BooleanExpression(..),
   Comparison(..), ValueExpression(..), funcApp, funcAppNamedArgs, extFuncApp,
   IndexTranslator(..), Reference(..), Array(..), List(..), Set(..), listSlice,
@@ -275,7 +275,6 @@ instance ScopeElim SwiftCode where
   scopeData = unSC
 
 instance VariableSym SwiftCode where
-  type Variable SwiftCode = VarData
   var         = G.var
   constant    = var
   extVar _    = var
@@ -1173,7 +1172,7 @@ swiftThrowDoc errMsg = throwLabel <+> RC.value errMsg
 
 swiftForEach
   :: (BodyElim r, InternalVarElim r, ValueElim r)
-  => r (Variable r) -> r (Value r) -> r Body -> Doc
+  => r Variable -> r (Value r) -> r Body -> Doc
 swiftForEach i lstVar b = vcat [
   forLabel <+> RC.variable i <+> inLabel <+> RC.value lstVar <+> bodyStart,
   indent $ RC.body b,
@@ -1192,7 +1191,7 @@ swiftAssert condition errorMessage = vcat [
   text "assert(" <+> RC.value condition <+> text "," <+> RC.value errorMessage <> text ")"
   ]
 
-swiftParam :: Doc -> SwiftCode (Variable SwiftCode) -> Doc
+swiftParam :: Doc -> SwiftCode Variable -> Doc
 swiftParam io v = swiftNoLabel <+> RC.variable v <> swiftTypeSpec <+> io
   <+> renderType (variableType v)
 

--- a/code/drasil-gool/lib/Drasil/GOOL/Renderers.hs
+++ b/code/drasil-gool/lib/Drasil/GOOL/Renderers.hs
@@ -7,7 +7,7 @@ module Drasil.GOOL.Renderers (
 
 import Drasil.FileHandling.Legacy (indent)
 
-import Drasil.Shared.InterfaceCommon (Body, UnRepr(..), VariableSym(..),
+import Drasil.Shared.InterfaceCommon (Body, Variable, UnRepr(..),
   VariableElim(..), ValueSym(..))
 import Drasil.GOOL.InterfaceGOOL (AttachmentSym(..))
 import Drasil.Shared.RendererClassesCommon (InternalVarElim(..),
@@ -26,7 +26,7 @@ renderType = typeDoc . unRepr
 
 renderParam
   :: (InternalVarElim r, UnRepr r TypeData, VariableElim r)
-  => r (Variable r) -> Doc
+  => r Variable -> Doc
 renderParam v = renderType (variableType v) <+> variable v
 
 renderMethod
@@ -51,12 +51,12 @@ renderMethod n s p t ps b = vcat [
 
 renderListDec
   :: (UnRepr r TypeData, ValueElim r, VariableElim r)
-  => r (Variable r) -> r (Value r) -> Doc
+  => r Variable -> r (Value r) -> Doc
 renderListDec v n = space <> equals <+> new' <+> renderType (variableType v)
   <> parens (value n)
 
 renderConstDecDef
   :: (InternalVarElim r, UnRepr r TypeData, ValueElim r, VariableElim r)
-  =>  r (Variable r) -> r (Value r) -> Doc
+  =>  r Variable -> r (Value r) -> Doc
 renderConstDecDef v def = constDec' <+> renderType (variableType v) <+>
   variable v <+> equals <+> value def

--- a/code/drasil-gool/lib/Drasil/GProc/LanguageRenderer/JuliaRenderer.hs
+++ b/code/drasil-gool/lib/Drasil/GProc/LanguageRenderer/JuliaRenderer.hs
@@ -15,7 +15,7 @@ import Drasil.FileHandling.Legacy (indent)
 
 import Drasil.Shared.CodeType (CodeType(..))
 import Drasil.Shared.InterfaceCommon (UnRepr(..), SharedProg, SharedStatement,
-  Label, Body, SValue, SVariable, MSBlock, BodySym(..), BlockSym(..),
+  Label, Body, SValue, Variable, SVariable, MSBlock, BodySym(..), BlockSym(..),
   TypeSym(..), TypeElim(..), getTypeString, VariableSym(..), VariableElim(..),
   ValueSym(..), Argument(..), Literal(..), MathConstant(..), VariableValue(..),
   CommandLineArgs(..), NumericExpression(..), BooleanExpression(..),
@@ -245,7 +245,6 @@ instance ScopeElim JuliaCode where
   scopeData = unJLC
 
 instance VariableSym JuliaCode where
-  type Variable JuliaCode = VarData
   var = G.var
   constant = var
   extVar l n t = modify (addModuleImportVS l) >> CS.extVar l n t
@@ -844,7 +843,7 @@ jlSpace = OSpace {oSpace = empty}
 -- | Creates a for-each loop in Julia
 jlForEach
   :: (BodyElim r, InternalVarElim r, ValueElim r)
-  => r (Variable r) -> r (Value r) -> r Body -> Doc
+  => r Variable -> r (Value r) -> r Body -> Doc
 jlForEach i lstVar b = vcat [
   forLabel <+> RC.variable i <+> inLabel <+> RC.value lstVar,
   indent $ RC.body b,
@@ -914,7 +913,7 @@ jlBegin      = text "begin"
 jlEnd        = text "end"
 jlThrowLabel = text "error" -- TODO: this hints at an underdeveloped exception system
 
-jlParam :: JuliaCode (Variable JuliaCode) -> Doc
+jlParam :: JuliaCode Variable -> Doc
 jlParam v = RC.variable v <> jlType <> renderType (variableType v)
 
 -- Type names specific to Julia (there's a lot of them)

--- a/code/drasil-gool/lib/Drasil/GProc/LanguageRenderer/MatlabRenderer.hs
+++ b/code/drasil-gool/lib/Drasil/GProc/LanguageRenderer/MatlabRenderer.hs
@@ -10,10 +10,10 @@ module Drasil.GProc.LanguageRenderer.MatlabRenderer (
   MatlabCode(..), mlName, mlVersion
 ) where
 
-import Drasil.Shared.InterfaceCommon (Label, SValue, SVariable, getCodeType,
-  UnRepr(..), SharedProg, SharedStatement, BodySym(..), BlockSym(..),
-  TypeSym(..), TypeElim(..), VariableSym(..), VariableElim(..), ValueSym(..),
-  Argument(..), Literal(..), MathConstant(..), VariableValue(..),
+import Drasil.Shared.InterfaceCommon (Label, SValue, Variable, SVariable,
+  getCodeType, UnRepr(..), SharedProg, SharedStatement, BodySym(..),
+  BlockSym(..), TypeSym(..), TypeElim(..), VariableSym(..), VariableElim(..),
+  ValueSym(..), Argument(..), Literal(..), MathConstant(..), VariableValue(..),
   CommandLineArgs(..), NumericExpression(..), BooleanExpression(..),
   Comparison(..), ValueExpression(..), IndexTranslator(..), Reference(..),
   Array(..), List(..), Set(..), NativeVector(..), InternalList(..),
@@ -60,8 +60,7 @@ import qualified Drasil.Shared.LanguageRenderer.Common as CS (varDecDef,
 import Drasil.Shared.AST (Terminator(..), FileType(Combined), fileD, md,
   updateMod, MethodData, mthd, updateMthd, ParamData, paramVar, paramDoc, pd,
   ProgData, TypeData, cType, ValData, vd, val, valPrec, valInt, valType, opDoc,
-  opPrec, VarData, varName, varType, varBind, varDoc, vard, progD, mthdDoc,
-  modDoc)
+  opPrec, varName, varType, varBind, varDoc, vard, progD, mthdDoc, modDoc)
 import Drasil.Shared.CodeType (CodeType(..))
 import Drasil.Shared.LanguageRenderer.Constructors (typeFromData, unOpPrec,
   powerPrec, unExpr, unExpr', binExpr, mkStateVal, mkVal, compEqualPrec,
@@ -213,7 +212,6 @@ instance ScopeElim MatlabCode where
   scopeData = unMLC
 
 instance VariableSym MatlabCode where
-  type Variable MatlabCode = VarData
   var = G.var
   constant = var
   extVar = undefined
@@ -582,7 +580,7 @@ mlTy :: CodeType -> String -> VS (MatlabCode TypeData)
 mlTy c s = typeFromData c s (text s)
 
 -- | A MATLAB parameter renders as just the variable name.
-mlParam :: MatlabCode (Variable MatlabCode) -> Doc
+mlParam :: MatlabCode Variable -> Doc
 mlParam = RC.variable
 
 -- | Renders a MATLAB function: @function [outs] = name(ins) ... end@.

--- a/code/drasil-gool/lib/Drasil/GProc/Renderers.hs
+++ b/code/drasil-gool/lib/Drasil/GProc/Renderers.hs
@@ -5,8 +5,8 @@ module Drasil.GProc.Renderers (
   renderType, renderParam, renderListDec, renderConstDecDef
 ) where
 
-import Drasil.Shared.InterfaceCommon (UnRepr(..), VariableSym(..),
-  VariableElim(..), ValueSym(..))
+import Drasil.Shared.InterfaceCommon (Variable, UnRepr(..), VariableElim(..),
+  ValueSym(..))
 import Drasil.Shared.RendererClassesCommon (InternalVarElim(..), ValueElim(..))
 import Drasil.Shared.LanguageRenderer (new', constDec')
 import Drasil.Shared.CodeType (CodeType(..))
@@ -22,17 +22,17 @@ renderType tp = case cType $ unRepr tp of
 
 renderParam
   :: (InternalVarElim r, UnRepr r TypeData, VariableElim r)
-  => r (Variable r) -> Doc
+  => r Variable -> Doc
 renderParam v = renderType (variableType v) <+> variable v
 
 renderListDec
   :: (UnRepr r TypeData, ValueElim r, VariableElim r)
-  => r (Variable r) -> r (Value r) -> Doc
+  => r Variable -> r (Value r) -> Doc
 renderListDec v n = space <> equals <+> new' <+> renderType (variableType v)
   <> parens (value n)
 
 renderConstDecDef
   :: (InternalVarElim r, UnRepr r TypeData, ValueElim r, VariableElim r)
-  => r (Variable r) -> r (Value r) -> Doc
+  => r Variable -> r (Value r) -> Doc
 renderConstDecDef v def = constDec' <+> renderType (variableType v) <+>
   variable v <+> equals <+> value def

--- a/code/drasil-gool/lib/Drasil/Shared/InterfaceCommon.hs
+++ b/code/drasil-gool/lib/Drasil/Shared/InterfaceCommon.hs
@@ -4,8 +4,8 @@
 
 module Drasil.Shared.InterfaceCommon (
   -- Types
-  Label, Library, Body, MSBody, Block, MSBlock, VSBinder, SVariable, SValue,
-  NamedArgs, MixedCall, MixedCtorCall, PosCall, PosCtorCall, InOutCall,
+  Label, Library, Body, MSBody, Block, MSBlock, VSBinder, Variable, SVariable,
+  SValue, NamedArgs, MixedCall, MixedCtorCall, PosCall, PosCtorCall, InOutCall,
   InOutFunc, DocInOutFunc,
   -- Typeclasses
   SharedProg, SharedStatement, UnRepr(..), BodySym(..), bodyStatements, oneLiner,
@@ -27,7 +27,7 @@ import Data.Bifunctor (first)
 import Text.PrettyPrint.HughesPJ (Doc)
 
 import Drasil.Shared.AST (ScopeData(..), ScopeTag(..), TypeData(..), BinderD,
-  ParamData)
+  ParamData, VarData)
 import Drasil.Shared.CodeType (CodeType(..))
 import Drasil.Shared.State (MS, VS)
 
@@ -109,10 +109,10 @@ class ScopeSym r where
   mainFn :: r ScopeData -- Main program - either main function or global scope
   local  :: r ScopeData -- Definite local scope
 
-type SVariable a = VS (a (Variable a))
+type Variable = VarData
+type SVariable a = VS (a Variable)
 
 class (TypeSym r) => VariableSym r where
-  type Variable r
   -- | An instance- or function-level variable, separate from its instance (i.e. `v`, not `o.v`)
   var       :: Label -> VS (r TypeData) -> SVariable r
   -- | An instance- or function-level constant, separate from its instance (i.e. `v`, not `o.v`)
@@ -123,8 +123,8 @@ class (TypeSym r) => VariableSym r where
   extVar    :: Library -> Label -> VS (r TypeData) -> SVariable r
 
 class (VariableSym r) => VariableElim r where
-  variableName :: r (Variable r) -> String
-  variableType :: r (Variable r) -> r TypeData
+  variableName :: r Variable -> String
+  variableType :: r Variable -> r TypeData
 
 listVar :: (VariableSym r) => Label -> VS (r TypeData) -> SVariable r
 listVar n t = var n (listType t)

--- a/code/drasil-gool/lib/Drasil/Shared/LanguageRenderer.hs
+++ b/code/drasil-gool/lib/Drasil/Shared/LanguageRenderer.hs
@@ -30,8 +30,8 @@ import Drasil.FileHandling.Legacy (blank, indent, indentList)
 import Utils.Drasil (capitalize, stringList)
 
 import Drasil.Shared.CodeType (CodeType(..))
-import Drasil.Shared.InterfaceCommon (Label, Library, Body, SValue,
-  VariableSym(Variable), ValueSym(..), TypeElim(..))
+import Drasil.Shared.InterfaceCommon (Label, Library, Body, Variable, SValue,
+  ValueSym(..), TypeElim(..))
 import Drasil.Shared.RendererClassesCommon (ValueElim, StatementElim, BodyElim,
   InternalVarElim, InternalBinderElim, ParamElim)
 import qualified Drasil.Shared.RendererClassesCommon as RC (BodyElim(..),
@@ -245,19 +245,19 @@ switch f st v defBody cs =
 
 assign
   :: (InternalVarElim r, ValueElim r)
-  => r (Variable r) -> r (Value r) -> Doc
+  => r Variable -> r (Value r) -> Doc
 assign vr vl = RC.variable vr <+> equals <+> RC.value vl
 
-addAssign :: (InternalVarElim r, ValueElim r) => r (Variable r) -> r (Value r) -> Doc
+addAssign :: (InternalVarElim r, ValueElim r) => r Variable -> r (Value r) -> Doc
 addAssign vr vl = RC.variable vr <+> text "+=" <+> RC.value vl
 
-subAssign :: (InternalVarElim r, ValueElim r) => r (Variable r) -> r (Value r) -> Doc
+subAssign :: (InternalVarElim r, ValueElim r) => r Variable -> r (Value r) -> Doc
 subAssign vr vl = RC.variable vr <+> text "-=" <+> RC.value vl
 
-increment :: (InternalVarElim r) => r (Variable r) -> Doc
+increment :: (InternalVarElim r) => r Variable -> Doc
 increment v = RC.variable v <> text "++"
 
-decrement :: (InternalVarElim r) => r (Variable r) -> Doc
+decrement :: (InternalVarElim r) => r Variable -> Doc
 decrement v = RC.variable v <> text "--"
 
 return' :: (ValueElim r) => [r (Value r)] -> Doc
@@ -407,7 +407,7 @@ commentedMod m cmt = updateFileMod (updateMod (commentedItem $ cmt $+$ blank) (f
 valueList :: (ValueElim r) => [r (Value r)] -> Doc
 valueList = hicat listSep' . map RC.value
 
-variableList :: (InternalVarElim r) => [r (Variable r)] -> Doc
+variableList :: (InternalVarElim r) => [r Variable] -> Doc
 variableList = hicat listSep' . map RC.variable
 
 binderList :: (InternalBinderElim r) => [r BinderD] -> Doc
@@ -418,7 +418,7 @@ parameterList = hicat listSep' . map RC.parameter
 
 namedArgList
   :: (InternalVarElim r, ValueElim r)
-  => Doc -> [(r (Variable r), r (Value r))] -> Doc
+  => Doc -> [(r Variable, r (Value r))] -> Doc
 namedArgList sep = hicat listSep' . map (\(vr,vl) -> RC.variable vr <> sep
   <> RC.value vl)
 

--- a/code/drasil-gool/lib/Drasil/Shared/LanguageRenderer/Common.hs
+++ b/code/drasil-gool/lib/Drasil/Shared/LanguageRenderer/Common.hs
@@ -11,10 +11,9 @@ import Control.Monad.State (modify)
 import Text.PrettyPrint.HughesPJ (text, empty, Doc)
 
 import Drasil.Shared.CodeType (CodeType(..))
-import Drasil.Shared.InterfaceCommon (Body, SVariable, MixedCall, SValue,
-  ValueSym(Value), TypeSym(int), MSBody, VariableElim(variableName),
-  VariableSym(Variable), Label, Library, funcApp, getCodeType, AssignStatement,
-  ValueExpression)
+import Drasil.Shared.InterfaceCommon (Body, Variable, SVariable, MixedCall,
+  SValue, ValueSym(Value), TypeSym(int), MSBody, VariableElim(variableName),
+  Label, Library, funcApp, getCodeType, AssignStatement, ValueExpression)
 import Drasil.Shared.RendererClassesCommon (scopeData, call,
   RenderFunction(funcFromData), RenderVariable, RenderValue, ValueElim,
   RenderStatement, ScopeElim, InternalVarElim)
@@ -62,7 +61,7 @@ listAccessFunc t v = intValue v >>= ((`funcFromData` t) . R.listAccessFunc)
 
 -- Python, Swift, and Julia --
 
-forEach' :: (RenderStatement r smt) => (r (Variable r) -> r (Value r) ->
+forEach' :: (RenderStatement r smt) => (r Variable -> r (Value r) ->
   r Body -> Doc) -> SVariable r -> SValue r -> MSBody r -> MS (r smt)
 forEach' f i' v' b' = do
   i <- zoom lensMStoVS i'

--- a/code/drasil-gool/lib/Drasil/Shared/LanguageRenderer/LanguagePolymorphic.hs
+++ b/code/drasil-gool/lib/Drasil/Shared/LanguageRenderer/LanguagePolymorphic.hs
@@ -22,8 +22,8 @@ import Drasil.FileHandling.Legacy (indent)
 
 import Drasil.Shared.CodeType (CodeType(..), ClassName)
 import Drasil.Shared.InterfaceCommon (UnRepr(..), Label, Library, Body, MSBody,
-  MSBlock, Block, SVariable, SValue, NamedArgs, MixedCall, MixedCtorCall,
-  bodyStatements, oneLiner, VariableSym(Variable), VisibilitySym(..),
+  MSBlock, Block, Variable, SVariable, SValue, NamedArgs, MixedCall,
+  MixedCtorCall, bodyStatements, oneLiner, VisibilitySym(..),
   VariableElim(variableName, variableType), ValueSym(Value, valueType),
   NumericExpression((#+), (#-), (#/), sin, cos, tan), Comparison(..), funcApp,
   StatementSym(multi), AssignStatement((&++)), (&=), TypeElim(..),
@@ -175,7 +175,7 @@ classVar n t = mkClassVar n t (R.var n)
 
 -- | To be used in classVarAccess implementations. Throws an error if the variable is
 -- not class-level since classVarAccess is for accessing class-level variables from a class
-classVarAccessCheck :: (InternalVarElim r) => r (Variable r) -> r (Variable r)
+classVarAccessCheck :: (InternalVarElim r) => r Variable -> r Variable
 classVarAccessCheck v = classVarCS (variableBind v)
   where classVarCS InstanceLevel = error
           "classVarAccess can only be used to access class-level variables"
@@ -494,7 +494,7 @@ construct n = zoom lensMStoVS $ typeFromData (Object n) n empty
 
 param
   :: (RenderParam r, VariableElim r)
-  => (r (Variable r) -> Doc) -> SVariable r -> MS (r ParamData)
+  => (r Variable -> Doc) -> SVariable r -> MS (r ParamData)
 param f v' = do
   v <- zoom lensMStoVS v'
   let n = variableName v

--- a/code/drasil-gool/lib/Drasil/Shared/LanguageRenderer/LoggingFor.hs
+++ b/code/drasil-gool/lib/Drasil/Shared/LanguageRenderer/LoggingFor.hs
@@ -186,7 +186,6 @@ instance (SharedStatement r smt, VariableElim r) => SharedStatement (LoggingFor 
 instance (G.OOStatement r smt, VariableElim r) => G.OOStatement (LoggingFor r) smt
 
 instance (VariableSym r) => VariableSym (LoggingFor r) where
-  type Variable (LoggingFor r) = Variable r
   var = liftLogging var
   constant = liftLogging constant
   extVar = liftLogging extVar

--- a/code/drasil-gool/lib/Drasil/Shared/RendererClassesCommon.hs
+++ b/code/drasil-gool/lib/Drasil/Shared/RendererClassesCommon.hs
@@ -15,14 +15,13 @@ module Drasil.Shared.RendererClassesCommon (
 ) where
 
 import Drasil.Shared.InterfaceCommon (Label, Library, Body, MSBody, Block,
-  MSBlock, SVariable, SValue, MixedCall, TypeSym(..), VariableSym(..),
-  VariableElim(..), ValueSym(..), Argument(..), Literal(..), MathConstant(..),
-  VariableValue(..), ValueExpression(..), CommandLineArgs(..),
-  NumericExpression(..), BooleanExpression(..), Comparison(..),
-  IndexTranslator(..), List(..), InternalList(..), AssignStatement(..),
-  DeclStatement(..), IOStatement(..), StringStatement(..), FuncAppStatement(..),
-  CommentStatement(..), ControlStatement(..), ParameterSym(..), BinderElim(..),
-  UnRepr(..))
+  MSBlock, Variable, SVariable, SValue, MixedCall, TypeSym(..), VariableElim(..),
+  ValueSym(..), Argument(..), Literal(..), MathConstant(..), VariableValue(..),
+  ValueExpression(..), CommandLineArgs(..), NumericExpression(..),
+  BooleanExpression(..), Comparison(..), IndexTranslator(..), List(..),
+  InternalList(..), AssignStatement(..), DeclStatement(..), IOStatement(..),
+  StringStatement(..), FuncAppStatement(..), CommentStatement(..),
+  ControlStatement(..), ParameterSym(..), BinderElim(..), UnRepr(..))
 import Drasil.Shared.AST (AttachmentTag, Terminator, VisibilityTag, ScopeData,
   OpData, BinderD, TypeData, ParamData, FuncData)
 import Drasil.Shared.State (MS, VS)
@@ -123,8 +122,8 @@ class RenderVariable r where
   varFromData :: AttachmentTag -> String -> VS (r TypeData) -> Doc -> SVariable r
 
 class InternalVarElim r where
-  variableBind :: r (Variable r) -> AttachmentTag
-  variable  :: r (Variable r) -> Doc
+  variableBind :: r Variable -> AttachmentTag
+  variable  :: r Variable -> Doc
 
 class InternalBinderElim r where
   binderElim  :: r BinderD -> Doc


### PR DESCRIPTION
Builds on #5315 
Contributes to #5233 