### PR TITLE
Remove unecessary usages of `cnstrw'`

### DIFF
--- a/code/drasil-example/glassbr/lib/Drasil/GlassBR/Unitals.hs
+++ b/code/drasil-example/glassbr/lib/Drasil/GlassBR/Unitals.hs
@@ -34,7 +34,7 @@ symbols = NE.toList inputs ++ tmSymbols ++ map dqdWr specParamVals ++
   mathunitals ++ physicalquants ++ mathquants
 
 constrained :: [ConstrConcept]
-constrained = map cnstrw' dataConstraints ++ map cnstrw' [nomThick, glassTypeCon]
+constrained = map cnstrw' dataConstraints ++ [nomThick, glassTypeCon]
 
 plateLen, plateWidth, aspectRatio, charWeight, standOffDist :: UncertQ
 pbTol, tNT :: UncertQ
@@ -54,7 +54,7 @@ inputsWUncrtn = pbTol :| [tNT]
 
 --inputs with no uncertainties
 inputsNoUncrtn :: NE.NonEmpty ConstrConcept
-inputsNoUncrtn = NE.map cnstrw' $ glassTypeCon :| [nomThick]
+inputsNoUncrtn = glassTypeCon :| [nomThick]
 
 --derived inputs with units and uncertainties
 derivedInsWUnitsUncrtn :: [UncertQ]

--- a/code/drasil-example/pdcontroller/lib/Drasil/PDController/Body.hs
+++ b/code/drasil-example/pdcontroller/lib/Drasil/PDController/Body.hs
@@ -86,7 +86,7 @@ si = mkSmithEtAlICO
   progName [naveen]
   [purp] [background] [scope] [motivation]
   theoreticalModels genDefns dataDefinitions instanceModels
-  inputs outputs (map cnstrw' inpConstrained) pidConstants allSymbols
+  inputs outputs inpConstrained pidConstants allSymbols
   symbMap allRefs
 
 purp :: Sentence

--- a/code/drasil-example/projectile/lib/Drasil/Projectile/Body.hs
+++ b/code/drasil-example/projectile/lib/Drasil/Projectile/Body.hs
@@ -128,7 +128,7 @@ si = mkSmithEtAlICO progName
   [samCrawford, brooks, spencerSmith]
   [purp] [background] [scope] [motivation]
   tMods genDefns dataDefs iMods
-  inputs outputs (map cnstrw' constrained) constants symbols
+  inputs outputs constrained constants symbols
   symbMap allRefs
 
 labelledContent' :: [LabelledContent]

--- a/code/drasil-example/swhs/lib/Drasil/SWHS/Unitals.hs
+++ b/code/drasil-example/swhs/lib/Drasil/SWHS/Unitals.hs
@@ -239,7 +239,7 @@ aspectRatioMax = quantNoUnit (mkUid "aspectRatioMax")
 -----------------
 
 constrained :: [ConstrConcept]
-constrained = map cnstrw' inputConstraints ++ map cnstrw' (NE.toList outputs)
+constrained = map cnstrw' inputConstraints ++ NE.toList outputs
 
 -- Input Constraints
 inputs :: NE.NonEmpty DefinedQuantityDict

--- a/code/drasil-example/swhsnopcm/lib/Drasil/SWHSNoPCM/Body.hs
+++ b/code/drasil-example/swhsnopcm/lib/Drasil/SWHSNoPCM/Body.hs
@@ -144,7 +144,7 @@ si = mkSmithEtAlICO
   [purp] [introStartNoPCM] [scope] [motivation]
   tMods genDefs NoPCM.dataDefs NoPCM.iMods
   inputs outputs
-  (map cnstrw' constrained ++ map cnstrw' [tempW, watE]) (piConst : specParamValList) symbols
+  (map cnstrw' constrained ++ [tempW, watE]) (piConst : specParamValList) symbols
   symbMap allRefs
 
 purp :: Sentence


### PR DESCRIPTION
`cnstrw'` is only needed when projecting an `UncertQ` to a `CosntrConcept`.