### PR TITLE
CI: Fix stack-work caches

### DIFF
--- a/.github/workflows/Build.yaml
+++ b/.github/workflows/Build.yaml
@@ -63,7 +63,10 @@ jobs:
             code/.stack-work
             code/**/.stack-work
             code/**/.hie
-          key: ${{ runner.os }}-stack-work
+          # We don't expect a hit on this key, but having a key is mandatory
+          key: ${{ runner.os }}-stack-work--${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-stack-work--
 
       - name: "Install dependencies"
         run: make stackArgs="--no-terminal" deps
@@ -117,7 +120,10 @@ jobs:
             code/.stack-work
             code/**/.stack-work
             code/**/.hie
-          key: ${{ runner.os }}-stack-work-haddock
+          # We don't expect a hit on this key, but having a key is mandatory
+          key: ${{ runner.os }}-stack-work-haddock--${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-stack-work-haddock--
 
       - name: "Generate Haddock docs (as test)"
         run: make docs

--- a/.github/workflows/Deploy.yaml
+++ b/.github/workflows/Deploy.yaml
@@ -85,7 +85,7 @@ jobs:
             code/.stack-work
             code/**/.stack-work
             code/**/.hie
-          key: ${{ runner.os }}-stack-work
+          key: ${{ runner.os }}-stack-work--${{ github.sha }}
 
   haddock:
     name: Haddock
@@ -116,7 +116,7 @@ jobs:
             code/.stack-work
             code/**/.stack-work
             code/**/.hie
-          key: ${{ runner.os }}-stack-work-haddock
+          key: ${{ runner.os }}-stack-work-haddock--${{ github.sha }}
 
   gooltest:
     name: "Compile GOOL"
@@ -257,3 +257,37 @@ jobs:
       - name: Deploy GitHub Pages
         id: deployment
         uses: actions/deploy-pages@v5
+
+  # Since GitHub does not allow overrwriting a cache key, we use the commit SHA in the key, then delete old caches with this job
+  # Based on https://github.com/actions/cache/blob/main/tips-and-workarounds.md#force-deletion-of-caches-overriding-default-cache-eviction-policy
+  cleanup_cache:
+    name: "Cleanup Cache"
+    needs: [build, haddock]
+    runs-on: ubuntu-latest
+    permissions:
+      actions: write
+      contents: read
+    steps:
+      - name: "Cleanup Cache"
+        run: |
+          echo "Fetching list of cache keys"
+          gh cache list --key ${{ runner.os }}-stack-work
+          oldCacheKeys=$(gh cache list --key ${{ runner.os }}-stack-work --json id,key --jq "$JQ_FILTER")
+          echo "Keys to delete:"
+          echo $oldCacheKeys
+
+          ## Setting this to not fail the workflow while deleting cache keys.
+          set +e
+          echo "Deleting caches..."
+          for cacheKey in $oldCacheKeys
+          do
+              echo "Deleting $cacheKey..."
+              gh cache delete $cacheKey
+          done
+          echo "Done"
+        working-directory: .
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          # This JQ filter ignores cache keys matching the current commit (the ones we just pushed to the cache)
+          JQ_FILTER: map(select(.key != "${{ runner.os }}-stack-work--${{ github.sha }}" and .key != "${{ runner.os }}-stack-work-haddock--${{ github.sha }}")) | .[].id

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -36,6 +36,7 @@ This workflow is split up into several jobs, some of which run in parallel:
 - Prepare Deployment: After Haddock and Generate Documents are done, runs the `prepare_deployment.sh` script
   to prepare the website deployment. Uploads the ready-to-deploy website.
 - Deploy: After Prepare Deployment, deploys the previously uploaded website to GitHub Pages.
+- Cleanup Caches: After Build & Test and Haddock are done, clean up old stack-work caches. See below for more details.
 
 ## Caching in `Build.yaml` and `Deploy.yaml`
 
@@ -51,6 +52,10 @@ There are three different caches used:
    without excessive cache usage.
 3. The `.stack-work` and `.hie` cache (for Haddock). The same as above, but used in the Haddock
    jobs. Separating the build and Haddock caches seemed to give the fastest Haddock build times.
+
+GitHub does not allow overwriting a cache key, so the Cleanup Caches job in Build & Test is necessary
+to delete old stack-work caches. This job uses the GitHub CLI (`gh`) to automatically delete the
+outdated caches.
 
 ## [`Lint.yaml`](Lint.yaml)
 


### PR DESCRIPTION
GitHub does not allow overwriting a cache key, however doing so does not result in an error and instead results in the impressively incorrect and unhelpful output (which is not treated as a warning or error):

    Failed to save: Unable to reserve cache with key Linux-stack-work, another job may be creating this cache.

Which is why I didn't catch this earlier.

Instead, we incorporate the current commit SHA into the cache key, and add a Cleanup Caches job that uses the GitHub CLI to remove outdated caches.

I tested this in my fork: https://github.com/djarabek/Drasil/actions/runs/29599999495/job/87950986637