### PR TITLE
Made `stateVar` require default values

### DIFF
--- a/code/drasil-code/lib/Language/Drasil/Code/Imperative/ConceptMatch.hs
+++ b/code/drasil-code/lib/Language/Drasil/Code/Imperative/ConceptMatch.hs
@@ -1,6 +1,6 @@
 -- | Contains functions related to the choice of concept matches.
 module Language.Drasil.Code.Imperative.ConceptMatch (
-  chooseConcept, conceptToGOOL
+  chooseConcept, conceptToGOOL, typeDefaultValue
 ) where
 
 import Prelude hiding (pi)
@@ -9,7 +9,8 @@ import Control.Monad.State (State, modify)
 
 import Drasil.Database (UID)
 import Language.Drasil (Sentence(S), (+:+), (+:+.))
-import Drasil.GOOL (SValue, MathConstant(..))
+import Drasil.GOOL (SValue, MathConstant(..), OOTypeSym, CodeType(..),
+  Literal(..), convTypeOO)
 
 import Language.Drasil.Choices (Choices(..), CodeConcept(..),
     MatchedConceptMap, showChs, Maps(..))
@@ -31,3 +32,17 @@ chooseConcept chs = sequence $ Map.mapWithKey chooseConcept' (conceptMatch $ map
 -- | Translates a 'CodeConcept' into GOOL.
 conceptToGOOL :: (MathConstant r) => CodeConcept -> SValue r
 conceptToGOOL Pi = pi
+
+-- | Gives a default value for a given type
+typeDefaultValue :: (Literal r, OOTypeSym r) => CodeType -> SValue r
+typeDefaultValue Boolean = litFalse
+typeDefaultValue Integer = litInt 0
+typeDefaultValue Float = litFloat 0.0
+typeDefaultValue Double = litDouble 0.0
+typeDefaultValue Char = litChar ' '
+typeDefaultValue String = litString ""
+typeDefaultValue (List t) = litList (convTypeOO t) []
+typeDefaultValue (Array t) = litArray (convTypeOO t) []
+typeDefaultValue (Set t) = litSet (convTypeOO t) []
+typeDefaultValue (Reference t) = typeDefaultValue t
+typeDefaultValue t = error $ "Attempt to get default value for type with none: " ++ show t

--- a/code/drasil-code/lib/Language/Drasil/Code/Imperative/Import.hs
+++ b/code/drasil-code/lib/Language/Drasil/Code/Imperative/Import.hs
@@ -28,7 +28,8 @@ import Drasil.Database (UID, HasUID(..), IsChunk)
 import Language.Drasil (HasSymbol, HasSpace(..),
   Space (Rational, Real), RealInterval(..), Constraint(..), Inclusive (..))
 import Language.Drasil.Code.Imperative.Comments (getCommentBrief)
-import Language.Drasil.Code.Imperative.ConceptMatch (conceptToGOOL)
+import Language.Drasil.Code.Imperative.ConceptMatch (conceptToGOOL,
+  typeDefaultValue)
 import Language.Drasil.Code.Imperative.GenerateGOOL (auxClass, fApp, fAppProc,
   ctorCall, genModuleWithImports, genModuleWithImportsProc, primaryClass)
 import Language.Drasil.Code.Imperative.Helpers (convScope)
@@ -66,7 +67,7 @@ import Drasil.GOOL (Label, MSBody, MSBlock, SVariable, SValue, CSStateVar,
   OOStatement)
 import qualified Drasil.GOOL as S (Set(..)) -- TODO [Brandon Bosman, 07/09/2026]: Merge this with OO
 import qualified Drasil.GOOL as OO (SFile)
-import qualified Drasil.GOOL as C (CodeType(List, Array))
+import qualified Drasil.GOOL as C (CodeType(..))
 import Drasil.GProc (ProcProg, NativeVector(..))
 import qualified Drasil.GProc as Proc (SFile)
 import Drasil.System (systemdb)
@@ -571,8 +572,10 @@ genClass f (M.ClassDef n i desc svs cs ms) = let svar Pub = pubDVar
                                                  svar Priv = privDVar
   in do
   modify (\st -> st {currentScope = Local})
-  svrs <- mapM (\(SV s v) -> fmap (svar s . var (codeName v) .
-                convTypeOO) (codeType v)) svs
+  svrs <- mapM (\(SV s v) -> do
+                   cTp <- codeType v
+                   return (svar s (var (codeName v) (convTypeOO cTp))
+                           (typeDefaultValue cTp))) svs
   f n i desc svrs (mapM (genFunc publicMethod svs) cs)
                   (mapM (genFunc publicMethod svs) ms)
 

--- a/code/drasil-code/lib/Language/Drasil/Code/Imperative/Modules.hs
+++ b/code/drasil-code/lib/Language/Drasil/Code/Imperative/Modules.hs
@@ -55,6 +55,7 @@ import Language.Drasil.Code.Imperative.GenerateGOOL (ClassType(..), genModule,
   genModuleProc, genModuleWithImports, genModuleWithImportsProc, primaryClass,
   auxClass)
 import Language.Drasil.Code.Imperative.Helpers (liftS, convScope)
+import Language.Drasil.Code.Imperative.ConceptMatch (typeDefaultValue)
 import Language.Drasil.Code.Imperative.Import (codeType, convExpr, convExprProc,
   convStmt, convStmtProc, genConstructor, mkVal, mkValProc, mkVar, mkVarProc,
   privateInOutMethod, privateMethod, privateFuncProc, publicFunc, publicFuncProc,
@@ -251,8 +252,10 @@ genInputClass scp = do
       genClass [] [] = return Nothing
       genClass inps csts = do
         vals <- mapM (convExpr . (^. codeExpr)) csts
-        inputVars <- mapM (\x -> fmap (pubDVar .
-          var (codeName x) . convTypeOO) (codeType x)) inps
+        inputVars <- mapM (\x -> do
+                              cTp <- codeType x
+                              return $ pubDVar (var (codeName x) (convTypeOO cTp)) (typeDefaultValue cTp)
+                          ) inps
         constVars <- zipWithM (\c vl -> fmap (\t -> constVarFunc (g ^. conRepr)
           (var (codeName c) (convTypeOO t)) vl) (codeType c))
           csts vals

--- a/code/drasil-code/test/GOOL/Observer.hs
+++ b/code/drasil-code/test/GOOL/Observer.hs
@@ -32,7 +32,7 @@ selfX = instanceVarSelf x
 -- | Helper function to create the class.
 helperClass :: (ClassSym r vis smt md svr att, IOStatement r smt, Literal r,
   OOVariableValue r) => SClass r
-helperClass = buildClass Nothing [stateVar public instanceLevel x]
+helperClass = buildClass Nothing [stateVar public instanceLevel x (litInt 0)]
   [observerConstructor] [printNumMethod, getMethod x, setMethod x]
 
 -- | Default value for observer class is 5.

--- a/code/drasil-code/test/HelloWorld.hs
+++ b/code/drasil-code/test/HelloWorld.hs
@@ -377,7 +377,7 @@ helloTryCatch = tryCatch (oneLiner (throw "Good-bye!"))
 
 helloWorldClass :: (OOProg r vis smt md svr att prg) => SClass r
 helloWorldClass = extraClass "TestClass" Nothing
-  [stateVar public instanceLevel (var "a" int)]
+  [stateVar public instanceLevel (var "a" int) (litInt 0)]
   [initializer [param $ var "a" int]
     [(var "a" int, valueOf (var "a" int))]]
   [ method "add" public classLevel (obj "TestClass")

--- a/code/drasil-code/test/OOVector.hs
+++ b/code/drasil-code/test/OOVector.hs
@@ -10,7 +10,7 @@ ooVector = prog "OOVector" "" [fileDoc (buildModule "OOVector" []
 
 vectorClass :: OOProg r vis smt md svr att prg => SClass r
 vectorClass = docClass "Vectors of doubles and common vector-related operations." $
-  extraClass "Vector" Nothing [stateVar private instanceLevel localV]
+  extraClass "Vector" Nothing [stateVar private instanceLevel localV (litArray double [])]
   [docFunc "Construct a vector from an array of doubles." ["The doubles."] Nothing $
    constructor [param argV] [] (body [
      block [

--- a/code/drasil-gool/lib/Drasil/GOOL/CodeInfoOO.hs
+++ b/code/drasil-gool/lib/Drasil/GOOL/CodeInfoOO.hs
@@ -472,7 +472,7 @@ instance OOMethodSym CodeInfoOO () () () () where
   docInOutMethod n _ _ _ _ _ _ = updateMEMandCM n
 
 instance StateVarSym CodeInfoOO () () () where
-  stateVar    _ _ _   = noInfo
+  stateVar    _ _ _ _ = noInfo
   stateVarDef _ _ _ _ = noInfo
   constVar    _ _ _   = noInfo
 

--- a/code/drasil-gool/lib/Drasil/GOOL/InterfaceGOOL.hs
+++ b/code/drasil-gool/lib/Drasil/GOOL/InterfaceGOOL.hs
@@ -121,17 +121,25 @@ type StateVar = Doc
 type CSStateVar r svr = CS (r svr)
 
 class (VisibilitySym r vis, AttachmentSym r att, VariableSym r) => StateVarSym r vis svr att | r -> svr where
-  stateVar :: r vis -> r att -> SVariable r -> CSStateVar r svr
+  -- Given the visibility, attachment, variable, and default value
+  -- (used by Swift), create a stateVar for a class.
+  stateVar :: r vis -> r att -> SVariable r -> SValue r -> CSStateVar r svr
   stateVarDef :: r vis -> r att -> SVariable r -> SValue r -> CSStateVar r svr
   constVar :: r vis ->  SVariable r -> SValue r -> CSStateVar r svr
 
-privDVar :: (StateVarSym r vis svr att) => SVariable r -> CSStateVar r svr
+privDVar
+  :: (StateVarSym r vis svr att)
+  => SVariable r -> SValue r -> CSStateVar r svr
 privDVar = stateVar private instanceLevel
 
-pubDVar :: (StateVarSym r vis svr att) => SVariable r -> CSStateVar r svr
+pubDVar
+  :: (StateVarSym r vis svr att)
+  => SVariable r -> SValue r -> CSStateVar r svr
 pubDVar = stateVar public instanceLevel
 
-pubSVar :: (StateVarSym r vis svr att) => SVariable r -> CSStateVar r svr
+pubSVar
+  :: (StateVarSym r vis svr att)
+  => SVariable r -> SValue r -> CSStateVar r svr
 pubSVar = stateVar public classLevel
 
 -- | Used to differentiate whether a member is attached to the class or the instance

--- a/code/drasil-gool/lib/Drasil/GOOL/LanguageRenderer/CppRenderer.hs
+++ b/code/drasil-gool/lib/Drasil/GOOL/LanguageRenderer/CppRenderer.hs
@@ -774,8 +774,8 @@ instance (Pair p) => MethodElim (p CppSrcCode CppHdrCode) MethodData where
 
 instance (Pair p) => StateVarSym (p CppSrcCode CppHdrCode)
     (Doc, VisibilityTag) StateVarData AttachmentData where
-  stateVar s p = pair1 (stateVar (pfst s) (pfst p)) (stateVar (psnd s) (psnd p))
-    . zoom lensCStoVS
+  stateVar s p vr dflt = pair2 (stateVar (pfst s) (pfst p))
+    (stateVar (psnd s) (psnd p)) (zoom lensCStoVS vr) (zoom lensCStoVS dflt)
   stateVarDef s p vr vl = pair2
     (stateVarDef (pfst s) (pfst p))
     (stateVarDef (psnd s) (psnd p)) (zoom lensCStoVS vr) (zoom lensCStoVS vl)
@@ -1674,7 +1674,7 @@ instance MethodElim CppSrcCode MethodData where
   method = mthdDoc . unCPPSC
 
 instance StateVarSym CppSrcCode (Doc, VisibilityTag) StateVarData AttachmentData where
-  stateVar s _ _ = return $ return $ svd (snd (unCPPSC s)) empty
+  stateVar s _ _ _ = return $ return $ svd (snd (unCPPSC s)) empty
   stateVarDef = cppsStateVarDef empty
   constVar s = cppsStateVarDef constDec' s classLevel
 
@@ -2291,7 +2291,7 @@ instance MethodElim CppHdrCode MethodData where
   method = mthdDoc . unCPPHC
 
 instance StateVarSym CppHdrCode (Doc, VisibilityTag) StateVarData AttachmentData where
-  stateVar s p v = do
+  stateVar s p v _ = do
     dec <- zoom lensCStoMS $ stmt $ C.varDec classLevel instanceLevel empty v local
     pure $ on2CodeValues svd (onCodeValue snd s)
       (toCode $ R.stateVar empty (RC.perm p) (RC.statement dec))

--- a/code/drasil-gool/lib/Drasil/GOOL/LanguageRenderer/PythonRenderer.hs
+++ b/code/drasil-gool/lib/Drasil/GOOL/LanguageRenderer/PythonRenderer.hs
@@ -688,7 +688,7 @@ instance MethodElim PythonCode MethodData where
   method = mthdDoc . unPC
 
 instance StateVarSym PythonCode Doc Doc AttachmentData where
-  stateVar _ _ _ = toState (toCode empty)
+  stateVar _ _ _ _ = toState (toCode empty)
   stateVarDef = CP.stateVarDef
   constVar = CP.constVar (RC.perm
     (classLevel :: PythonCode AttachmentData))

--- a/code/drasil-gool/lib/Drasil/GOOL/LanguageRenderer/SwiftRenderer.hs
+++ b/code/drasil-gool/lib/Drasil/GOOL/LanguageRenderer/SwiftRenderer.hs
@@ -32,7 +32,7 @@ import Drasil.GOOL.InterfaceGOOL (OOProg, StateVar, OOStatement, ProgramSym(..),
   objMethodCall, objMethodCallMixedArgs, objMethodCallNamedArgs,
   objMethodCallNoParams, OOFunctionSym(..), ($.), GetSet(..),
   OODeclStatement(..), OOFuncAppStatement(..), ObserverPattern(..),
-  StrategyPattern(..), OOMethodSym(..), Initializers, convTypeOO)
+  StrategyPattern(..), OOMethodSym(..), Initializers)
 import Drasil.Shared.RendererClassesCommon (MSMthdType, CommonRenderSym,
   ImportSym(..), RenderBody(..), BodyElim, RenderBlock(..), BlockElim,
   RenderType(..), UnaryOpSym(..), BinaryOpSym(..), OpElim(uOpPrec, bOpPrec),
@@ -99,12 +99,11 @@ import Drasil.Shared.AST (Terminator(..), VisibilityTag(..), qualName,
 import Drasil.Shared.Helpers (hicat, emptyIfNull, toCode, toState, onCodeValue,
   onStateValue, on2CodeValues, on2StateValues, onCodeList, onStateList)
 import Drasil.Shared.State (MS, VS, lensGStoFS, lensFStoCS, lensFStoMS,
-  lensCStoVS, lensMStoFS, lensMStoVS, lensVStoFS, revFiles, addLangImportVS,
-  getLangImports, getLibImports, setFileType, getClassName, setModuleName,
-  getModuleName, getCurrMain, getMethodExcMap, getMainDoc, setThrowUsed,
-  getThrowUsed, setErrorDefined, getErrorDefined, incrementLine, incrementWord,
-  getLineIndex, getWordIndex, resetIndices, useVarName, genVarNameIf,
-  setVarScope, getVarScope)
+  lensMStoFS, lensMStoVS, lensVStoFS, revFiles, addLangImportVS, getLangImports,
+  getLibImports, setFileType, getClassName, setModuleName, getModuleName,
+  getCurrMain, getMethodExcMap, getMainDoc, setThrowUsed, getThrowUsed,
+  setErrorDefined, getErrorDefined, incrementLine, incrementWord, getLineIndex,
+  getWordIndex, resetIndices, useVarName, genVarNameIf, setVarScope, getVarScope)
 
 import Prelude hiding (break,print,(<>),sin,cos,tan,floor)
 import Control.Lens.Zoom (zoom)
@@ -714,9 +713,7 @@ instance MethodElim SwiftCode MethodData where
   method = mthdDoc . unSC
 
 instance StateVarSym SwiftCode Doc Doc Doc where
-  stateVar s p vr = do
-    v <- zoom lensCStoVS vr
-    stateVarDef s p vr (typeDfltVal $ getCodeType $ variableType v)
+  stateVar = stateVarDef
   stateVarDef = CP.stateVarDef
   constVar = CP.constVar (RC.perm (classLevel :: SwiftCode Doc))
 
@@ -1241,15 +1238,3 @@ swiftStringError = do
 
 swiftClassDoc :: ClassDocRenderer
 swiftClassDoc desc = [desc | not (null desc)]
-
-typeDfltVal :: (Literal r, OOTypeSym r) => CodeType -> SValue r
-typeDfltVal Boolean = litFalse
-typeDfltVal Integer = litInt 0
-typeDfltVal Float = litFloat 0.0
-typeDfltVal Double = litDouble 0.0
-typeDfltVal Char = litChar ' '
-typeDfltVal String = litString ""
-typeDfltVal (List t) = litList (convTypeOO t) []
-typeDfltVal (Array t) = litArray (convTypeOO t) []
-typeDfltVal (Set t) = litSet (convTypeOO t) []
-typeDfltVal _ = error "Attempt to get default value for type with none."

--- a/code/drasil-gool/lib/Drasil/Shared/LanguageRenderer/CommonPseudoOO.hs
+++ b/code/drasil-gool/lib/Drasil/Shared/LanguageRenderer/CommonPseudoOO.hs
@@ -447,9 +447,9 @@ openFileW f vr vl = vr &= f vl outfile IC.litFalse
 
 stateVar
   :: (Monad r, OORenderSym r vis smt md svr att)
-  => r vis -> r att -> SVariable r -> CS (r Doc)
-stateVar s p v = zoom lensCStoMS $ onStateValue (toCode . R.stateVar
-  (RC.visibility s) (RG.perm p) . RC.statement) (RC.stmt $ IC.varDec v IC.local)
+  => r vis -> r att -> SVariable r -> SValue r -> CS (r Doc)
+stateVar s p vr _ = zoom lensCStoMS $ onStateValue (toCode . R.stateVar
+  (RC.visibility s) (RG.perm p) . RC.statement) (RC.stmt $ IC.varDec vr IC.local)
 
 -- Python and Swift --
 


### PR DESCRIPTION
Closes #2200 

I wasn't sure where to put `typeToDefaultValue`. `ConceptMatch` sort of makes sense, but it was matching two different types of concepts before. @balacij any better ideas?