### PR TITLE
refactor: move `fromSource` from `Language.Drasil.Sentence.Generators` to `Language.Drasil.Document.SentenceCombinators`

### DIFF
--- a/code/drasil-data/lib/Data/Drasil/Concepts/Math.hs
+++ b/code/drasil-data/lib/Data/Drasil/Concepts/Math.hs
@@ -10,6 +10,7 @@ import Language.Drasil hiding (number, norm, matrix, Sentence(P, S, (:+:)))
 import qualified Language.Drasil as D
 import Language.Drasil.Chunk.Concept.NamedCombinators
 import Language.Drasil.Development (NPStruct(P, S, (:-:)))
+import Language.Drasil.Document (fromSource)
 import Language.Drasil.ShortHands (lX, lY, lZ)
 
 -- Othr Vocabulary

--- a/code/drasil-data/lib/Data/Drasil/Concepts/Physics.hs
+++ b/code/drasil-data/lib/Data/Drasil/Concepts/Physics.hs
@@ -4,6 +4,7 @@ module Data.Drasil.Concepts.Physics where
 --  up with a better one.
 import Drasil.Database (mkUid)
 import Language.Drasil hiding (space)
+import Language.Drasil.Document (fromSource)
 import qualified Language.Drasil.Sentence.Combinators as S
 import Language.Drasil.Chunk.Concept.NamedCombinators
 

--- a/code/drasil-example/bss/lib/Drasil/BinaryStar/Assumptions.hs
+++ b/code/drasil-example/bss/lib/Drasil/BinaryStar/Assumptions.hs
@@ -7,7 +7,7 @@ import Language.Drasil
 import qualified Language.Drasil.Sentence.Combinators as S
 
 import qualified Drasil.SRS.Concepts as SRS (valsOfAuxCons)
-import Language.Drasil.Document (fromSources, namedRef)
+import Language.Drasil.Document (fromSource, fromSources, namedRef)
 
 import Data.Drasil.Concepts.Documentation (assumpDom, consVals)
 import Data.Drasil.Concepts.Physics (gravity, twoD)

--- a/code/drasil-example/gamephysics/lib/Drasil/GamePhysics/TMods.hs
+++ b/code/drasil-example/gamephysics/lib/Drasil/GamePhysics/TMods.hs
@@ -4,6 +4,7 @@ module Drasil.GamePhysics.TMods (tMods, newtonSL, newtonSLR, newtonTL, newtonLUG
 import qualified Data.List.NonEmpty as NE
 
 import Language.Drasil
+import Language.Drasil.Document (fromSource)
 import Theory.Drasil
 import qualified Language.Drasil.Sentence.Combinators as S
 

--- a/code/drasil-lang/lib/Language/Drasil.hs
+++ b/code/drasil-lang/lib/Language/Drasil.hs
@@ -161,7 +161,7 @@ module Language.Drasil (
   , Sentence(..), SentenceStyle(..), TermCapitalization(..), RefInfo(..), (+:+), (+:+.), (+:), (!.), capSent
   , ch, eS, eS', sC, sDash, sParen
   -- Language.Drasil.Sentence.Generators
-  , fromSource, fterms, getTandS, checkValidStr
+  , fterms, getTandS, checkValidStr
   -- Language.Drasil.NounPhrase
   , NounPhrase(..), NP, pn, pn', pn'', pn''', pnIrr, cn, cn', cn'', cn''', cnIP
   , cnIrr, cnIES, cnICES, cnIS, cnUM, nounPhrase, nounPhrase'
@@ -279,7 +279,7 @@ import Language.Drasil.Space (Space(..), RealInterval(..), Inclusive(..),
 import Language.Drasil.Sentence (Sentence(..), SentenceStyle(..), TermCapitalization(..), RefInfo(..), (+:+),
   (+:+.), (+:), (!.), capSent, ch, eS, eS', sC, sDash, sParen)
 import Language.Drasil.Sentence.Fold
-import Language.Drasil.Sentence.Generators (fromSource, fterms, getTandS, checkValidStr)
+import Language.Drasil.Sentence.Generators (fterms, getTandS, checkValidStr)
 import Language.Drasil.Symbol.Helpers (eqSymb, codeSymb, hasStageSymbol,
   autoStage, hat, prime, staged, sub, subStr, sup, unicodeConv, upperLeft, vec,
   label, variable, sortBySymbol, sortBySymbolTuple)

--- a/code/drasil-lang/lib/Language/Drasil/Document/SentenceCombinators.hs
+++ b/code/drasil-lang/lib/Language/Drasil/Document/SentenceCombinators.hs
@@ -34,7 +34,7 @@ import Language.Drasil.ModelExpr.Lang (ModelExpr)
 import Language.Drasil.Sentence (Sentence(S, Percent, (:+:), Sy, EmptyS), eS,
   ch, sParen, sDash, (+:+), sC, (+:+.), (!.), (+:), capSent)
 import Language.Drasil.Sentence.Fold (foldlList, SepType(Comma), FoldType(List), foldlSent)
-import Language.Drasil.Sentence.Generators (fromSource, fterms)
+import Language.Drasil.Sentence.Generators (fterms)
 import Language.Drasil.ShortName (HasShortName(..))
 import Language.Drasil.Document.Core (ItemType(..), ListType(Bullet))
 import Language.Drasil.Document.Reference (refS, namedRef)
@@ -210,6 +210,10 @@ tAndDOnly chunk  = Flat $ atStart chunk `sDash` EmptyS +:+. capSent (chunk ^. de
 -- | Appends "following @reference@" to the end of a 'Sentence'.
 follows :: (Referable r, HasShortName r) => Sentence -> r -> Sentence
 preceding `follows` r = preceding +:+ S "following" +:+ refS r
+
+-- | Wraps "from @reference@" in parentheses.
+fromSource :: (Referable r, HasShortName r) => r -> Sentence
+fromSource r = sParen (S "from" +:+ refS r)
 
 -- | Similar to `fromSource` but takes a list of references instead of one.
 fromSources :: (Referable r, HasShortName r) => [r] -> Sentence

--- a/code/drasil-lang/lib/Language/Drasil/Sentence/Generators.hs
+++ b/code/drasil-lang/lib/Language/Drasil/Sentence/Generators.hs
@@ -1,6 +1,6 @@
 -- | Functions that create sentences from other data
 module Language.Drasil.Sentence.Generators (
-  fromSource, fterms, getTandS,
+  fterms, getTandS,
   -- this does not belong here...
   checkValidStr
   ) where
@@ -9,15 +9,8 @@ import Control.Lens ((^.))
 
 import Language.Drasil.Classes (NamedIdea(..), Quantity)
 import Language.Drasil.Development.Sentence (phrase)
-import Language.Drasil.Label.Type (Referable)
 import Language.Drasil.NaturalLanguage.English.NounPhrase.Core (NP)
-import Language.Drasil.Document.Reference (refS)
-import Language.Drasil.Sentence (Sentence(S),(+:+), sParen, ch)
-import Language.Drasil.ShortName (HasShortName(..))
-
--- | Wraps "from @reference@" in parentheses.
-fromSource :: (Referable r, HasShortName r) => r -> Sentence
-fromSource r = sParen (S "from" +:+ refS r)
+import Language.Drasil.Sentence (Sentence,(+:+), ch)
 
 -- | Apply a binary function to the terms of two named ideas, instead of to the named
 -- ideas themselves. Ex. @fterms compoundPhrase t1 t2@ instead of


### PR DESCRIPTION
Rationale: `fromSource` involves "references" to external links, citations, etc. Currently in Drasil, these are highly related to our encoding of "documents."

Now `fromSource` and `fromSources` are next to each other too.