### PR TITLE
refactor: make `Quantity` a constraint alias instead of a unique typeclass

### DIFF
--- a/code/drasil-code/lib/Language/Drasil/Chunk/CodeDefinition.hs
+++ b/code/drasil-code/lib/Language/Drasil/Chunk/CodeDefinition.hs
@@ -42,8 +42,6 @@ instance ConceptDomain    CodeDefinition where cdom = cdom . view cchunk
 instance HasSpace         CodeDefinition where typ = cchunk . typ
 -- | Finds the 'Stage' dependent 'Symbol' of the 'CodeChunk' used to make the 'CodeDefinition'.
 instance HasSymbol        CodeDefinition where symbol c = symbol (c ^. cchunk)
--- | 'CodeDefinition's have a 'Quantity'.
-instance Quantity         CodeDefinition
 -- | Finds the code name of a 'CodeDefinition'.
 -- 'Function' 'CodeDefinition's are named with the function prefix to distinguish
 -- them from the corresponding variable version.

--- a/code/drasil-code/lib/Language/Drasil/Chunk/NamedArgument.hs
+++ b/code/drasil-code/lib/Language/Drasil/Chunk/NamedArgument.hs
@@ -35,8 +35,6 @@ instance ConceptDomain  NamedArgument where cdom = cdom . view qtd
 instance HasSpace       NamedArgument where typ = qtd . typ
 -- | Finds the 'Symbol' of the 'DefinedQuantityDict' used to make the 'NamedArgument'.
 instance HasSymbol      NamedArgument where symbol = symbol . view qtd
--- | 'NamedArgument's have a 'Quantity'.
-instance Quantity       NamedArgument where
 -- | 'NamedArgument's have an argument name.
 instance IsArgumentName NamedArgument where
 -- | Equal if 'UID's are equal.

--- a/code/drasil-code/lib/Language/Drasil/Chunk/Parameter.hs
+++ b/code/drasil-code/lib/Language/Drasil/Chunk/Parameter.hs
@@ -35,8 +35,6 @@ instance ConceptDomain ParameterChunk where cdom = cdom . view pcc
 instance HasSpace    ParameterChunk where typ = pcc . typ
 -- | Finds the 'Stage' dependent 'Symbol' of the 'CodeChunk' used to make the 'ParameterChunk'.
 instance HasSymbol   ParameterChunk where symbol = symbol . view pcc
--- | 'ParameterChunk's have a 'Quantity'.
-instance Quantity    ParameterChunk
 -- | Finds the code name and 'CodeChunk' of a 'ParameterChunk'.
 instance CodeIdea    ParameterChunk where
   codeName = codeName . view pcc

--- a/code/drasil-lang/lib/Drasil/Code/CodeVar.hs
+++ b/code/drasil-lang/lib/Drasil/Code/CodeVar.hs
@@ -62,8 +62,6 @@ instance ConceptDomain CodeChunk where cdom = cdom . view qc
 instance HasSpace      CodeChunk where typ = qc . typ
 -- | Finds the 'Stage' dependent 'Symbol' of the 'DefinedQuantityDict' used to make the 'CodeChunk'.
 instance HasSymbol     CodeChunk where symbol = symbol . view qc
--- | 'CodeChunk's have a 'Quantity'.
-instance Quantity      CodeChunk
 -- | Equal if 'UID's are equal.
 instance Eq            CodeChunk where c1 == c2 = (c1 ^. uid) == (c2 ^. uid)
 -- | Finds the units of the 'DefinedQuantityDict' used to make the 'CodeChunk'.
@@ -90,8 +88,6 @@ instance ConceptDomain CodeVarChunk where cdom = cdom . view ccv
 instance HasSpace      CodeVarChunk where typ = ccv . typ
 -- | Finds the 'Stage' dependent 'Symbol' of the 'CodeChunk' used to make the 'CodeVarChunk'.
 instance HasSymbol     CodeVarChunk where symbol = symbol . view ccv
--- | 'CodeVarChunk's have a 'Quantity'.
-instance Quantity      CodeVarChunk
 -- | Equal if 'UID's are equal.
 instance Eq            CodeVarChunk where c1 == c2 = (c1 ^. uid) == (c2 ^. uid)
 -- | Finds the units of the 'CodeChunk' used to make the 'CodeVarChunk'.
@@ -129,8 +125,6 @@ instance ConceptDomain CodeFuncChunk where cdom = cdom . view ccf
 instance HasSpace      CodeFuncChunk where typ = ccf . typ
 -- | Finds the 'Stage' dependent 'Symbol' of the 'CodeChunk' used to make the 'CodeFuncChunk'.
 instance HasSymbol     CodeFuncChunk where symbol = symbol . view ccf
--- | 'CodeFuncChunk's have a 'Quantity'.
-instance Quantity      CodeFuncChunk
 -- | Functions are Callable.
 instance Callable      CodeFuncChunk
 -- | Equal if 'UID's are equal.

--- a/code/drasil-lang/lib/Language/Drasil/Chunk/Constrained.hs
+++ b/code/drasil-lang/lib/Language/Drasil/Chunk/Constrained.hs
@@ -51,8 +51,6 @@ instance Idea          ConstrConcept where getA = getA . view defq
 instance HasSpace      ConstrConcept where typ = defq . typ
 -- | Finds the 'Symbol' of the 'DefinedQuantityDict' used to make the 'ConstrConcept'.
 instance HasSymbol     ConstrConcept where symbol c = symbol (c^.defq)
--- | 'ConstrConcept's have a 'Quantity'.
-instance Quantity      ConstrConcept where
 -- | Finds definition of the 'DefinedQuantityDict' used to make the 'ConstrConcept'.
 instance Definition    ConstrConcept where defn = defq . defn
 -- | Finds the domain contained in the 'DefinedQuantityDict' used to make the 'ConstrConcept'.

--- a/code/drasil-lang/lib/Language/Drasil/Chunk/DefinedQuantity.hs
+++ b/code/drasil-lang/lib/Language/Drasil/Chunk/DefinedQuantity.hs
@@ -65,8 +65,6 @@ instance ConceptDomain DefinedQuantityDict where cdom = cdom . view con
 instance HasSpace      DefinedQuantityDict where typ = spa
 -- | Finds the 'Stage' -> 'Symbol' of the 'DefinedQuantityDict'.
 instance HasSymbol     DefinedQuantityDict where symbol = view symb
--- | 'DefinedQuantityDict's have a 'Quantity'.
-instance Quantity      DefinedQuantityDict where
 -- | Finds the units of the 'DefinedQuantityDict'.
 instance MayHaveUnit   DefinedQuantityDict where getUnit = view unit'
 -- | Convert the symbol of the 'DefinedQuantityDict' to a 'ModelExpr'.

--- a/code/drasil-lang/lib/Language/Drasil/Chunk/Eq.hs
+++ b/code/drasil-lang/lib/Language/Drasil/Chunk/Eq.hs
@@ -63,7 +63,6 @@ instance DefinesQuantity (QDefinition e) where defLhs = qdQua . to dqdWr
 instance HasSpace        (QDefinition e) where typ = qdQua . typ
 instance HasSymbol       (QDefinition e) where symbol = symbol . (^. qdQua)
 instance Definition      (QDefinition e) where defn = qdQua . defn
-instance Quantity        (QDefinition e) where
 instance Eq              (QDefinition e) where a == b = a ^. uid == b ^. uid
 instance MayHaveUnit     (QDefinition e) where getUnit = getUnit . view qdQua
 instance DefiningExpr     QDefinition    where defnExpr = qdExpr

--- a/code/drasil-lang/lib/Language/Drasil/Chunk/UncertainQuantity.hs
+++ b/code/drasil-lang/lib/Language/Drasil/Chunk/UncertainQuantity.hs
@@ -46,9 +46,7 @@ instance Idea           UncertQ where getA (UQ q _) = getA q
 -- | Finds the 'Space' of the 'ConstrConcept' used to make the 'UncertQ'.
 instance HasSpace       UncertQ where typ = coco . typ
 -- | Finds the 'Symbol' of the 'ConstrConcept' used to make the 'UncertQ'.
-instance HasSymbol      UncertQ where symbol c = symbol (c^.coco)
--- | 'UncertQ's have a 'Quantity'.
-instance Quantity       UncertQ where
+instance HasSymbol      UncertQ where symbol c = symbol (c ^. coco)
 -- | Finds the uncertainty of an 'UncertQ'.
 instance HasUncertainty UncertQ where unc = unc''
 -- | Finds the 'Constraint's of a 'ConstrConcept' used to make the 'UncertQ'.

--- a/code/drasil-lang/lib/Language/Drasil/Classes.hs
+++ b/code/drasil-lang/lib/Language/Drasil/Classes.hs
@@ -95,7 +95,7 @@ class MayHaveRationale c where
 -- | A Quantity is an 'Idea' with a 'Space' and a 'Symbol'.
 -- In theory, it should also restrict to being a part of 'MayHaveUnit', but that causes
 -- all sorts of import cycles (or lots of orphans).
-class (Idea c, HasSpace c, HasSymbol c) => Quantity c where
+type Quantity c = (Idea c, HasSpace c, HasSymbol c)
 
 -- TODO: potential alternative design for "Quantity"?
 --

--- a/code/drasil-srs/lib/Drasil/SRS/Sections/Requirements.hs
+++ b/code/drasil-srs/lib/Drasil/SRS/Sections/Requirements.hs
@@ -159,7 +159,7 @@ reqInputsRef :: Reference
 reqInputsRef = makeTabRef' (reqInput ^. uid)
 
 -- | Creates a table for use in the Functional Requirments section. Takes a list of tuples containing variables and sources, a label, and a caption.
-mkValsSourceTable :: (Quantity i, MayHaveUnit i, Concept i) =>
+mkValsSourceTable :: (Quantity i, MayHaveUnit i) =>
                           [(i, Sentence)] -> String -> Sentence -> LabelledContent
 mkValsSourceTable vals labl cap = llccTab labl $
   Table [atStart symbol_, atStart description, S "Source", atStart' unit_]

--- a/code/drasil-theory/lib/Theory/Drasil/MultiDefn.hs
+++ b/code/drasil-theory/lib/Theory/Drasil/MultiDefn.hs
@@ -76,7 +76,6 @@ instance NamedIdea        (MultiDefn e) where term    = qd . term
 instance Idea             (MultiDefn e) where getA    = getA . (^. qd)
 instance HasSpace         (MultiDefn e) where typ     = qd . typ
 instance Definition       (MultiDefn e) where defn    = rDesc
-instance Quantity         (MultiDefn e)
 instance MayHaveUnit      (MultiDefn e) where getUnit = getUnit . view qd
 -- | The concept domain of a MultiDefn is the union of the concept domains of
 -- the underlying variants.


### PR DESCRIPTION
Reduces code size a little bit, and gets rid of empty typeclass instances.