### PR TITLE
Refine imports on `Language.Drasil.Display` and use appropriate `Symbol` smart constructors instead of raw constructors

### DIFF
--- a/code/drasil-code/lib/Data/Drasil/ExternalLibraries/ODELibraries.hs
+++ b/code/drasil-code/lib/Data/Drasil/ExternalLibraries/ODELibraries.hs
@@ -19,7 +19,6 @@ import Language.Drasil (HasSymbol(symbol), MayHaveUnit(getUnit),
   Vect, Reference), implVar, implVar', compoundPhrase, nounPhrase, nounPhraseSP,
   label, sub, Idea(getA), NamedIdea(term), Stage(..), Definition (defn), (+:+),
   Sentence (S), DefinedQuantityDict, dqdWr, implVarAU')
-import Language.Drasil.Display (Symbol(Label, Concat))
 
 import Drasil.Code.CodeExpr
 import Drasil.Code.CodeExpr.Development
@@ -472,16 +471,16 @@ adamsC = quantfunc $ implVar (mkUid "adams_ctor_apache") (nounPhrase
   "constructor for an Adams-Bashforth integrator"
   "constructors for an Adams-Bashforth integrator")
   "the constructors for an Adams-Bashforth integrator"
-  (Actor adams) (Label adams)
+  (Actor adams) (label adams)
 dp54C = quantfunc $ implVar (mkUid "dp54_ctor_apache") (nounPhrase
   "constructor for a Dormand-Prince 5-4 integrator"
   "constructors for a Dormand-Prince 5-4 integrator")
   "the constructors for a Dormand-Prince 5-4 integrator"
-  (Actor dp54) (Label dp54)
+  (Actor dp54) (label dp54)
 stepHandlerCtor = quantfunc $ implVar (mkUid "StepHandler_ctor_apache") (nounPhrase
   "constructor for StepHandler" "constructors for StepHandler")
   "the constructor for StepHandler"
-  (Actor $ "ODE" ++ sh) (Label $ "ODE" ++ sh)
+  (Actor $ "ODE" ++ sh) (label $ "ODE" ++ sh)
 addStepHandler = quantfunc $ implVar (mkUid "addStepHandler_apache") (nounPhrase
   "method for adding a step handler to an integrator"
   "methods for adding a step handler to an integrator")
@@ -622,22 +621,22 @@ rkdp5C = quantfunc $ implVar (mkUid "rkdp5_odeint") (nounPhrase
   "constructor for stepper using Runge-Kutta-Dopri5 method"
   "constructors for stepper using Runge-Kutta-Dopri5 method")
   "the constructor for stepper using the Runge-Kutta-Dopri5 method"
-  (Actor rkdp5) (Label rkdp5)
+  (Actor rkdp5) (label rkdp5)
 makeControlled = quantfunc $ implVar (mkUid "make_controlled_odeint") (nounPhrase
   "function for adding error control to a stepper"
   "functions for adding error control to a stepper")
   "the function for adding error control to a stepper"
-  (Actor "auto") (Label $ odeNameSpace ++ "make_controlled")
+  (Actor "auto") (label $ odeNameSpace ++ "make_controlled")
 adamsBashC = quantfunc $ implVar (mkUid "adamsBash_odeint") (nounPhrase
   "constructor for stepper using Adams-Bashforth method"
   "constructors for stepper using Adams-Bashforth method")
   "the constructor for stepper using the Adams-Bashforth method"
-  (Actor adamsBash) (Label adamsBash)
+  (Actor adamsBash) (label adamsBash)
 integrateConst = quantfunc $ implVar (mkUid "integrate_const_odeint") (nounPhrase
   "function for integrating with a constant step size"
   "functions for integrating with a constant step size")
   "the function for integrating with a constant step size"
-  Void (Label $ odeNameSpace ++ "integrate_const")
+  Void (label $ odeNameSpace ++ "integrate_const")
 odeOp = quantfunc $ implVar (mkUid "ode_operator_odeint") (nounPhrase
   "method defining override for calling ODE object"
   "methods defining override for calling ODE object")
@@ -709,7 +708,7 @@ diffCodeChunk :: CodeVarChunk -> CodeVarChunk
 diffCodeChunk c = quantvar $ implVarAU' (c +++ "d" )
   (compoundPhrase (nounPhraseSP "change in") (c ^. term))
   (S "the change in" +:+ (c ^. defn)) (getA c)
-  (c ^. typ) (Concat [label "d", symbol c Implementation]) (getUnit c)
+  (c ^. typ) (label "d" <> symbol c Implementation) (getUnit c)
 
 -- FIXME: This is surely a hack, but I can't think of a better way right now.
 -- | Some libraries use an array instead of a list to internally represent the ODE.

--- a/code/drasil-code/lib/Language/Drasil/CodeSpec.hs
+++ b/code/drasil-code/lib/Language/Drasil/CodeSpec.hs
@@ -24,7 +24,6 @@ import qualified Data.List.NonEmpty as NE
 
 import Drasil.FileHandling.Legacy (RelativeFile)
 import Language.Drasil hiding (None)
-import Language.Drasil.Display (Symbol(Variable))
 import Drasil.Database (ChunkDB, UID, HasUID(..), insertAll, mkUid)
 import Drasil.Code.CodeExpr.Development (expr, eNamesRI, eDep)
 import qualified Drasil.SRS as S
@@ -146,9 +145,9 @@ mkCodeSpec si@S.ICO{ S._inputs = ins
 -- | Convert a 'Func' to an implementation-stage 'DefinedQuantityDict' representing the
 -- function.
 asVC :: Func -> DefinedQuantityDict
-asVC (FDef (FuncDef n d _ _ _ _)) = quantNoUnit (mkUid n) (nounPhraseSP n) (S d) (Variable n) Real
-asVC (FDef (CtorDef n d _ _ _))   = quantNoUnit (mkUid n) (nounPhraseSP n) (S d) (Variable n) Real
-asVC (FData (FuncData n d _))     = quantNoUnit (mkUid n) (nounPhraseSP n) (S d) (Variable n) Real
+asVC (FDef (FuncDef n d _ _ _ _)) = quantNoUnit (mkUid n) (nounPhraseSP n) (S d) (variable n) Real
+asVC (FDef (CtorDef n d _ _ _))   = quantNoUnit (mkUid n) (nounPhraseSP n) (S d) (variable n) Real
+asVC (FData (FuncData n d _))     = quantNoUnit (mkUid n) (nounPhraseSP n) (S d) (variable n) Real
 
 -- | Get a 'UID' of a chunk corresponding to a 'Func'.
 funcUID :: Func -> UID

--- a/code/drasil-data/lib/Data/Drasil/Quantities/Math.hs
+++ b/code/drasil-data/lib/Data/Drasil/Quantities/Math.hs
@@ -2,7 +2,7 @@
 module Data.Drasil.Quantities.Math where
 
 import Language.Drasil
-import Language.Drasil.Display
+import Language.Drasil.Display (Symbol(Atop), Decoration(Magnitude))
 import Language.Drasil.ShortHands
 
 import qualified Data.Drasil.Concepts.Math as CM (area, diameter, euclidN, gradient,

--- a/code/drasil-data/lib/Data/Drasil/Quantities/Physics.hs
+++ b/code/drasil-data/lib/Data/Drasil/Quantities/Physics.hs
@@ -2,7 +2,7 @@
 module Data.Drasil.Quantities.Physics where
 
 import Language.Drasil
-import Language.Drasil.Display
+import Language.Drasil.Display (Symbol(Concat, Atop), Decoration(Delta))
 import Language.Drasil.ShortHands
 import qualified Data.Drasil.Concepts.Physics as CP (acceleration, angAccel,
   angDisp, angVelo, chgInVelocity, constAccel, constAccelV, displacement,
@@ -63,12 +63,12 @@ gravitationalMagnitude = dqd CP.gravitationalMagnitude lG                       
 height                 = dqd CP.height                 lH                                          Real        metre
 impulseS               = dqd CP.impulseS               lJ                                          Real        impulseU
 impulseV               = dqd CP.impulseV               (vec cJ)                                    Real        impulseU
-kEnergy                = dqd CP.kEnergy                (Concat [cK, cE])                           Real        joule
+kEnergy                = dqd CP.kEnergy                (cK <> cE)                                  Real        joule
 linearAccel            = dqd CP.linAccel               (Concat [lA, label "(", lT, label ")"])     Real        accelU
 linearDisplacement     = dqd CP.linDisp                (Concat [lU, label "(", lT, label ")"])     Real        metre
 linearVelocity         = dqd CP.linVelo                (Concat [lV, label "(", lT, label ")"])     Real        velU
 momentOfInertia        = dqd CP.momentOfInertia        (vec cI)                                    Real        momtInertU
-chgMomentum            = dqd CP.chgMomentum            (Concat [cDelta,vec cP])                    Real        impulseU
+chgMomentum            = dqd CP.chgMomentum            (cDelta <> vec cP)                          Real        impulseU
 momentum               = dqd CP.momentum               (vec cP)                                    Real        impulseU
 moment                 = dqd CP.moment                 (vec cM)                                    Real        torqueU
 moment2D               = dqd CP.moment2D               cM                                          Real        torqueU
@@ -76,7 +76,7 @@ moment2D               = dqd CP.moment2D               cM                       
 period                 = dqd CP.period                 cT                                          Real        second
 position               = dqd CP.position               (Concat [vec lP, label "(", lT, label ")"]) Real        metre
 positionVec            = dqd CP.positionVec            (vec lR)                                    Real        metre
-potEnergy              = dqd CP.potEnergy              (Concat [cP, cE])                           Real        joule
+potEnergy              = dqd CP.potEnergy              (cP <> cE)                                  Real        joule
 pressure               = dqd CP.pressure               lP                                          Real        pascal
 speed                  = dqd CP.speed                  lV                                          Real        velU
 scalarAccel            = dqd CP.scalarAccel            lA                                          Real        accelU

--- a/code/drasil-data/lib/Data/Drasil/SI_Units.hs
+++ b/code/drasil-data/lib/Data/Drasil/SI_Units.hs
@@ -2,7 +2,7 @@
 module Data.Drasil.SI_Units where
 
 import Language.Drasil
-import Language.Drasil.Display
+import Language.Drasil.Display (Symbol(Special))
 import Language.Drasil.ShortHands (cOmega)
 import Drasil.Database (mkUid)
 
@@ -36,7 +36,6 @@ candela  = fund "candela"  "luminous intensity"   "cd"
 -- * Commonly Defined Units
 
 degree :: UnitDefn --FIXME: define degree in terms of radians and pi
--- degree = UD (dcc "degree" (cn' "degree") "angle") (BaseSI (US [(Special Circle,1)])) ["degree"]
 degree = fund' "degree" "angle" (Special Circle)
 
 -- Some of these units are easiest to define via others less common names,
@@ -62,7 +61,7 @@ calorie = derUC "calorie"
   "calorie" "energy" (label "cal") (scale 4.184 joule)
 
 centigrade = derUC "centigrade"
-  "centigrade" "temperature" (Concat [Special Circle, label "C"])
+  "centigrade" "temperature" (Special Circle <> label "C")
   (shift 273.15 kelvin)
 
 coulomb = derCUC' "coulomb"
@@ -89,10 +88,10 @@ katal = derCUC' "katal"
 
 kilopascal = derUC' "kilopascal"
   "kilopascal" "pressure"
-  (Concat [label "k", label "Pa"]) (scale 1000 pascal)
+  (label "k" <> label "Pa") (scale 1000 pascal)
 
 kilowatt = derUC' "kilowatt"
-  "kilowatt" "power" (Concat [label "k", label "W"]) (scale 1000 watt)
+  "kilowatt" "power" (label "k" <> label "W") (scale 1000 watt)
 
 litre = derUC' "litre"
   "litre" "volume" (label "L") (scale (1/1000) m_3)

--- a/code/drasil-example/bss/lib/Drasil/BinaryStar/Unitals.hs
+++ b/code/drasil-example/bss/lib/Drasil/BinaryStar/Unitals.hs
@@ -124,19 +124,19 @@ xVel_1, yVel_1, xVel_2, yVel_2 :: DefinedQuantityDict
 
 xVel_1 = quant (mkUid "vx_1") (nounPhraseSP "x-velocity of the first star")
   (S "x-component of the" +:+ phrase QP.velocity `S.ofThe` phrase starOne)
-  (sub lV (Concat [labelx, label1])) Real velU
+  (sub lV (labelx <> label1)) Real velU
 
 yVel_1 = quant (mkUid "vy_1") (nounPhraseSP "y-velocity of the first star")
   (S "y-component of the" +:+ phrase QP.velocity `S.ofThe` phrase starOne)
-  (sub lV (Concat [labely, label1])) Real velU
+  (sub lV (labely <> label1)) Real velU
 
 xVel_2 = quant (mkUid "vx_2") (nounPhraseSP "x-velocity of the second star")
   (S "x-component of the" +:+ phrase QP.velocity `S.ofThe` phrase starTwo)
-  (sub lV (Concat [labelx, label2])) Real velU
+  (sub lV (labelx <> label2)) Real velU
 
 yVel_2 = quant (mkUid "vy_2") (nounPhraseSP "y-velocity of the second star")
   (S "y-component of the" +:+ phrase QP.velocity `S.ofThe` phrase starTwo)
-  (sub lV (Concat [labely, label2])) Real velU
+  (sub lV (labely <> label2)) Real velU
 
 ---------------------------------------------------------
 -- Initial velocity quantities
@@ -146,19 +146,19 @@ xVel_1_0, yVel_1_0, xVel_2_0, yVel_2_0 :: DefinedQuantityDict
 
 xVel_1_0 = quant (mkUid "vx_1_0") (nounPhraseSP "initial x-velocity of the first star")
   (S "initial x-component of the" +:+ phrase QP.velocity `S.ofThe` phrase starOne)
-  (sup (sub lV (Concat [labelx, label1])) label0) Real velU
+  (sup (sub lV (labelx <> label1)) label0) Real velU
 
 yVel_1_0 = quant (mkUid "vy_1_0") (nounPhraseSP "initial y-velocity of the first star")
   (S "initial y-component of the" +:+ phrase QP.velocity `S.ofThe` phrase starOne)
-  (sup (sub lV (Concat [labely, label1])) label0) Real velU
+  (sup (sub lV (labely <> label1)) label0) Real velU
 
 xVel_2_0 = quant (mkUid "vx_2_0") (nounPhraseSP "initial x-velocity of the second star")
   (S "initial x-component of the" +:+ phrase QP.velocity `S.ofThe` phrase starTwo)
-  (sup (sub lV (Concat [labelx, label2])) label0) Real velU
+  (sup (sub lV (labelx <> label2)) label0) Real velU
 
 yVel_2_0 = quant (mkUid "vy_2_0") (nounPhraseSP "initial y-velocity of the second star")
   (S "initial y-component of the" +:+ phrase QP.velocity `S.ofThe` phrase starTwo)
-  (sup (sub lV (Concat [labely, label2])) label0) Real velU
+  (sup (sub lV (labely <> label2)) label0) Real velU
 
 ---------------------------------------------------------
 -- Acceleration quantities
@@ -168,19 +168,19 @@ xAccel_1, yAccel_1, xAccel_2, yAccel_2 :: DefinedQuantityDict
 
 xAccel_1 = quant (mkUid "ax_1") (nounPhraseSP "x-acceleration of the first star")
   (S "x-component of the" +:+ phrase QP.acceleration `S.ofThe` phrase starOne)
-  (sub lA (Concat [labelx, label1])) Real accelU
+  (sub lA (labelx <> label1)) Real accelU
 
 yAccel_1 = quant (mkUid "ay_1") (nounPhraseSP "y-acceleration of the first star")
   (S "y-component of the" +:+ phrase QP.acceleration `S.ofThe` phrase starOne)
-  (sub lA (Concat [labely, label1])) Real accelU
+  (sub lA (labely <> label1)) Real accelU
 
 xAccel_2 = quant (mkUid "ax_2") (nounPhraseSP "x-acceleration of the second star")
   (S "x-component of the" +:+ phrase QP.acceleration `S.ofThe` phrase starTwo)
-  (sub lA (Concat [labelx, label2])) Real accelU
+  (sub lA (labelx <> label2)) Real accelU
 
 yAccel_2 = quant (mkUid "ay_2") (nounPhraseSP "y-acceleration of the second star")
   (S "y-component of the" +:+ phrase QP.acceleration `S.ofThe` phrase starTwo)
-  (sub lA (Concat [labely, label2])) Real accelU
+  (sub lA (labely <> label2)) Real accelU
 
 ---------------------------------------------------------
 -- Other quantities
@@ -194,7 +194,7 @@ tFinal = quant (mkUid "t_final") (nounPhraseSP "final time")
 sepDist :: DefinedQuantityDict
 sepDist = quant (mkUid "r_12") (nounPhraseSP "separation distance")
   (S "distance between the two stars")
-  (sub lR (Concat [label1, label2])) Real metre
+  (sub lR (label1 <> label2)) Real metre
 
 ---------------------------------------------------------
 -- Symbol helpers

--- a/code/drasil-example/bss/lib/Drasil/BinaryStar/Unitals.hs
+++ b/code/drasil-example/bss/lib/Drasil/BinaryStar/Unitals.hs
@@ -9,7 +9,7 @@ module Drasil.BinaryStar.Unitals (
 
 import Language.Drasil
 import qualified Language.Drasil.Development as D
-import Language.Drasil.Display (Symbol(..))
+import Language.Drasil.Display (Symbol(Integ))
 import Language.Drasil.ShortHands
 import Language.Drasil.Chunk.Concept.NamedCombinators
 import qualified Language.Drasil.Sentence.Combinators as S

--- a/code/drasil-example/dblpend/lib/Drasil/DblPend/Unitals.hs
+++ b/code/drasil-example/dblpend/lib/Drasil/DblPend/Unitals.hs
@@ -15,7 +15,7 @@ import qualified Data.List.NonEmpty as NE
 import Drasil.Database (mkUid)
 import Language.Drasil
 import qualified Language.Drasil.Development as D (toSent)
-import Language.Drasil.Display (Symbol(..))
+import Language.Drasil.Display (Symbol(Integ))
 import Language.Drasil.ShortHands (cF, cL, cT, lA, lAlpha, lM, lP, lTheta, lV, lW)
 import Language.Drasil.Chunk.Concept.NamedCombinators
 import qualified Language.Drasil.Sentence.Combinators as S

--- a/code/drasil-example/dblpend/lib/Drasil/DblPend/Unitals.hs
+++ b/code/drasil-example/dblpend/lib/Drasil/DblPend/Unitals.hs
@@ -78,67 +78,67 @@ massObj_2 = quant (mkUid "m_2") (mass `ofThe` secondObject)
 
 xPos_1 = quant (mkUid "p_x1") (horizontalPos `ofThe` firstObject)
         (D.toSent (phraseNP (QP.position `the_ofThe` firstObject)) `S.inThe` phrase CM.xDir)
-        (sub lP (Concat [labelx, label1])) Real metre
+        (sub lP (labelx <> label1)) Real metre
 
 xPos_2 = quant (mkUid "p_x2") (horizontalPos `ofThe` secondObject)
         (D.toSent (phraseNP (QP.position `the_ofThe` secondObject)) `S.inThe` phrase CM.xDir)
-        (sub lP (Concat [labelx, label2])) Real metre
+        (sub lP (labelx <> label2)) Real metre
 
 yPos_1 = quant (mkUid "p_y1") (verticalPos `ofThe` firstObject)
         (D.toSent (phraseNP (QP.position `the_ofThe` firstObject)) `S.inThe` phrase CM.yDir)
-        (sub lP (Concat [labely, label1])) Real metre
+        (sub lP (labely <> label1)) Real metre
 
 yPos_2 = quant (mkUid "p_y2") (verticalPos `ofThe` secondObject)
         (D.toSent (phraseNP (QP.position `the_ofThe` secondObject)) `S.inThe` phrase CM.yDir)
-        (sub lP (Concat [labely, label2])) Real metre
+        (sub lP (labely <> label2)) Real metre
 
 xVel_1 = quant (mkUid "v_x1") (horizontalVel `ofThe` firstObject)
         (D.toSent (phraseNP (QP.angularVelocity `the_ofThe` firstObject)) `S.inThe` phrase CM.xDir)
-        (sub lV (Concat [labelx, label1])) Real velU
+        (sub lV (labelx <> label1)) Real velU
 
 xVel_2 = quant (mkUid "v_x2") (horizontalVel `ofThe` secondObject)
         (D.toSent (phraseNP (QP.angularVelocity `the_ofThe` secondObject)) `S.inThe` phrase CM.xDir)
-        (sub lV (Concat [labelx, label2])) Real velU
+        (sub lV (labelx <> label2)) Real velU
 
 yVel_1 = quant (mkUid "v_y1") (verticalVel `ofThe` firstObject)
         (D.toSent (phraseNP (QP.angularVelocity `the_ofThe` firstObject)) `S.inThe` phrase CM.yDir)
-        (sub lV (Concat [labely, label1])) Real velU
+        (sub lV (labely <> label1)) Real velU
 
 yVel_2 = quant (mkUid "v_y2") (verticalVel `ofThe` secondObject)
         (D.toSent (phraseNP (QP.angularVelocity `the_ofThe` secondObject)) `S.inThe` phrase CM.yDir)
-        (sub lV (Concat [labely, label2])) Real velU
+        (sub lV (labely <> label2)) Real velU
 
 xAccel_1 = quant (mkUid "a_x1") (horizontalAccel `ofThe` firstObject)
         (D.toSent (phraseNP (QP.acceleration `the_ofThe` firstObject)) `S.inThe` phrase CM.xDir)
-        (sub lA (Concat [labelx, label1])) Real accelU
+        (sub lA (labelx <> label1)) Real accelU
 
 xAccel_2 = quant (mkUid "a_x2") (horizontalAccel `ofThe` secondObject)
         (D.toSent (phraseNP (QP.acceleration `the_ofThe` secondObject)) `S.inThe` phrase CM.xDir)
-        (sub lA (Concat [labelx, label2])) Real accelU
+        (sub lA (labelx <> label2)) Real accelU
 
 yAccel_1 = quant (mkUid "a_y1") (verticalAccel `ofThe` firstObject)
         (D.toSent (phraseNP (QP.acceleration `the_ofThe` firstObject)) `S.inThe` phrase CM.yDir)
-        (sub lA (Concat [labely, label1])) Real accelU
+        (sub lA (labely <> label1)) Real accelU
 
 yAccel_2 = quant (mkUid "a_y2") (verticalAccel `ofThe` secondObject)
         (D.toSent (phraseNP (QP.acceleration `the_ofThe` secondObject)) `S.inThe` phrase CM.yDir)
-        (sub lA (Concat [labely, label2])) Real accelU
+        (sub lA (labely <> label2)) Real accelU
 
 xForce_1 = quant (mkUid "F_x1") (horizontalForce `onThe` firstObject)
         (D.toSent (phraseNP (QP.force `the_ofThe` firstObject)) `S.inThe` phrase CM.xDir)
-        (sub cF (Concat [labelx, label1])) Real newton
+        (sub cF (labelx <> label1)) Real newton
 
 xForce_2 = quant (mkUid "F_x2") (horizontalForce `onThe` secondObject)
         (D.toSent (phraseNP (QP.force `the_ofThe` secondObject)) `S.inThe` phrase CM.xDir)
-        (sub cF (Concat [labelx, label2])) Real newton
+        (sub cF (labelx <> label2)) Real newton
 
 yForce_1 = quant (mkUid "F_y1") (verticalForce `onThe` firstObject)
         (D.toSent (phraseNP (QP.force `the_ofThe` firstObject)) `S.inThe` phrase CM.yDir)
-        (sub cF (Concat [labely, label1])) Real newton
+        (sub cF (labely <> label1)) Real newton
 
 yForce_2 = quant (mkUid "F_y2") (verticalForce `onThe` secondObject)
         (D.toSent (phraseNP (QP.force `the_ofThe` secondObject)) `S.inThe` phrase CM.yDir)
-        (sub cF (Concat [labely, label2])) Real newton
+        (sub cF (labely <> label2)) Real newton
 
 angularAccel_1 = quant (mkUid "alpha_x1") (QP.angularAccel `ofThe` firstObject)
         (D.toSent (phraseNP (QP.angularAccel `the_ofThe` firstObject)) `S.inThe` phrase CM.xDir)

--- a/code/drasil-example/gamephysics/lib/Drasil/GamePhysics/Unitals.hs
+++ b/code/drasil-example/gamephysics/lib/Drasil/GamePhysics/Unitals.hs
@@ -94,7 +94,7 @@ timeParam n w s = quant
 contParam :: String -> String -> Symbol -> Symbol -> DefinedQuantityDict
 contParam n m w s = quant
  (mkUid $ "r_" ++ n ++ m) contdispN (phrase QP.displacement)
-  (sub (eqSymb QP.displacement) (Concat [w, s])) Real metre
+  (sub (eqSymb QP.displacement) (w <> s)) Real metre
   where contdispN = cn $ "displacement vector between the centre of mass of rigid body " ++
                          n ++ " and contact point " ++ m
 

--- a/code/drasil-example/glassbr/lib/Drasil/GlassBR/ModuleDefs.hs
+++ b/code/drasil-example/glassbr/lib/Drasil/GlassBR/ModuleDefs.hs
@@ -8,8 +8,8 @@ import Drasil.Code.CodeExpr (CodeExpr, LiteralC(int))
 import Drasil.Database (IsChunk, mkUid)
 import Language.Drasil (Space(..), nounPhraseSP,
   label, sub, HasSymbol(..), Symbol, ExprC(..), DefinedQuantityDict, implVar)
-import Language.Drasil.Display (Symbol(..))
-import Language.Drasil.ShortHands
+import Language.Drasil.Display (Symbol(Integ))
+import Language.Drasil.ShortHands (lX, lY, lZ, lV, lI, lJ, lK)
 import Language.Drasil.Code (($:=), Func, FuncStmt(..), Mod,
   asVC, funcDef, fDecDef, ffor, funcData, quantvar,
   multiLine, packmod, repeated, singleLine)

--- a/code/drasil-example/glassbr/lib/Drasil/GlassBR/Unitals.hs
+++ b/code/drasil-example/glassbr/lib/Drasil/GlassBR/Unitals.hs
@@ -1,7 +1,6 @@
 module Drasil.GlassBR.Unitals (module Drasil.GlassBR.Unitals) where --whole file is used
 
 import Language.Drasil
-import Language.Drasil.Display (Symbol(..))
 import Language.Drasil.NaturalLanguage.English.NounPhrase.Combinators (parensNP)
 import Language.Drasil.ShortHands
 import Language.Drasil.Chunk.Concept.NamedCombinators
@@ -91,7 +90,7 @@ aspectRatio = uq (constrained' (dqdNoUnit aspectRatioCon (variable "AR") Real)
 
 pbTol = uq (constrained' (quantNoUnit (mkUid "pbTol") (nounPhraseSP "tolerable probability of breakage")
   (S "the tolerable probability of breakage of the glass plate")
-  (sub cP (Concat [lBreak, lTol])) Real)
+  (sub cP (lBreak <> lTol)) Real)
   [probConstr] (dbl 0.008)) (uncty 0.001 Nothing)
 
 charWeight = uqcND "charWeight" (nounPhraseSP "charge weight")
@@ -141,7 +140,7 @@ probFail = cucNoUnit' "probFail" (nounPhraseSP "probability of failure")
 
 pbTolfail = cucNoUnit' "pbTolfail" (nounPhraseSP "tolerable probability of failure")
   "the tolerable probability of failure of the glass plate"
-  (sub cP (Concat [lFail, lTol])) Real
+  (sub cP (lFail <> lTol)) Real
   [probConstr] (dbl 0.008)
 
   --FIXME: no typical value!

--- a/code/drasil-example/projectile/lib/Drasil/Projectile/Unitals.hs
+++ b/code/drasil-example/projectile/lib/Drasil/Projectile/Unitals.hs
@@ -49,5 +49,3 @@ launAngle = constrained'    (dqd'     C.launAngle (autoStage lTheta  ) Real (Jus
 launSpeed = constrained'    (dqd      C.launSpeed (subStr lV "launch") Real velU  ) [gtZeroConstr] (exactDbl 100)
 offset    = constrainedNRV' (dqd      C.offset    (subStr lD "offset") Real metre ) [physRange $ UpFrom (Exc, neg $ sy targPos)]
 targPos   = constrained'    (dqd      C.targPos   (subStr lP "target") Real metre ) [gtZeroConstr] (exactDbl 1000)
-
----

--- a/code/drasil-example/projectile/lib/Drasil/Projectile/Unitals.hs
+++ b/code/drasil-example/projectile/lib/Drasil/Projectile/Unitals.hs
@@ -8,7 +8,7 @@ import Data.List.NonEmpty (NonEmpty((:|)))
 import qualified Data.List.NonEmpty as NE
 
 import Language.Drasil
-import Language.Drasil.Display (Symbol(..))
+import Language.Drasil.Display (Symbol(Concat))
 import Language.Drasil.ShortHands (lD, lTheta, lV, lP, lT)
 
 import Data.Drasil.Quantities.Math (pi_)

--- a/code/drasil-example/ssp/lib/Drasil/SSP/Unitals.hs
+++ b/code/drasil-example/ssp/lib/Drasil/SSP/Unitals.hs
@@ -5,7 +5,7 @@ import Data.List.NonEmpty (NonEmpty((:|)))
 import qualified Data.List.NonEmpty as NE
 
 import Language.Drasil
-import Language.Drasil.Display (Symbol(..))
+import Language.Drasil.Display (Symbol(Concat))
 import Language.Drasil.ShortHands
 import Language.Drasil.Chunk.Concept.NamedCombinators
 import qualified Language.Drasil.Development as D


### PR DESCRIPTION
Contributes to #5330