### PR TITLE
Flatten nested `ConstrConcept` in `UncertQ`

### DIFF
--- a/code/drasil-lang/lib/Language/Drasil/Chunk/UncertainQuantity.hs
+++ b/code/drasil-lang/lib/Language/Drasil/Chunk/UncertainQuantity.hs
@@ -11,9 +11,9 @@ module Language.Drasil.Chunk.UncertainQuantity (
 
 import Control.Lens ((^.), makeLenses, view)
 
-import Drasil.Database (HasUID(..), declareHasChunkRefs, Generically(..))
+import Drasil.Database (HasUID(..), HasChunkRefs(..))
 
-import Language.Drasil.Chunk.DefinedQuantity (dqdWr)
+import Language.Drasil.Chunk.DefinedQuantity (DefinedQuantityDict, dqdWr)
 import Language.Drasil.Chunk.Constrained (ConstrConcept(..), cuc')
 import Language.Drasil.Symbol
 import Language.Drasil.Classes (NamedIdea(term), Idea(getA), Express(express),
@@ -24,43 +24,52 @@ import Language.Drasil.Chunk.UnitDefn (MayHaveUnit(getUnit), UnitDefn)
 import Language.Drasil.Expr.Lang (Expr)
 import Language.Drasil.Expr.Class (sy)
 import Language.Drasil.NaturalLanguage.English.NounPhrase.Core (NP)
+import Language.Drasil.Sentence (Sentence)
 import Language.Drasil.Space (Space, HasSpace(..))
 import Language.Drasil.Uncertainty
 
 -- | UncertQs are conceptual symbolic quantities with constraints and an 'Uncertainty'.
--- Contains a 'ConstrConcept' and an 'Uncertainty'.
+-- Contains the same information as a 'ConstrConcept' with an added 'Uncertainty'.
 --
 -- Ex. Measuring the length of a pendulum arm may be recorded with an uncertainty value.
-data UncertQ = UQ { _coco :: ConstrConcept , _unc'' :: Uncertainty }
+data UncertQ = UQ { _defq       :: DefinedQuantityDict
+                  , _constr'    :: [ConstraintE]
+                  , _reasV'     :: Maybe Expr
+                  , _rationale' :: Maybe Sentence
+                  , _unc''      :: Uncertainty
+                  }
 makeLenses ''UncertQ
-declareHasChunkRefs ''UncertQ
+
+instance HasChunkRefs UncertQ where
+  chunkRefs c = chunkRefs (c ^. defq)
+  {-# INLINABLE chunkRefs #-}
 
 -- | Equal if 'UID's are equal.
 instance Eq             UncertQ where a == b = (a ^. uid) == (b ^. uid)
--- | Finds 'UID' of the 'ConstrConcept' used to make the 'UncertQ'.
-instance HasUID         UncertQ where uid = coco . uid
--- | Finds term ('NP') of the 'ConstrConcept' used to make the 'UncertQ'.
-instance NamedIdea      UncertQ where term = coco . term
--- | Finds the idea contained in the 'ConstrConcept' used to make the 'UncertQ'.
-instance Idea           UncertQ where getA (UQ q _) = getA q
--- | Finds the 'Space' of the 'ConstrConcept' used to make the 'UncertQ'.
-instance HasSpace       UncertQ where typ = coco . typ
--- | Finds the 'Symbol' of the 'ConstrConcept' used to make the 'UncertQ'.
-instance HasSymbol      UncertQ where symbol c = symbol (c ^. coco)
+-- | Finds 'UID' of the 'DefinedQuantityDict' used to make the 'UncertQ'.
+instance HasUID         UncertQ where uid = defq . uid
+-- | Finds term ('NP') of the 'DefinedQuantityDict' used to make the 'UncertQ'.
+instance NamedIdea      UncertQ where term = defq . term
+-- | Finds the idea contained in the 'DefinedQuantityDict' used to make the 'UncertQ'.
+instance Idea           UncertQ where getA = getA . view defq
+-- | Finds the 'Space' of the 'DefinedQuantityDict' used to make the 'UncertQ'.
+instance HasSpace       UncertQ where typ = defq . typ
+-- | Finds the 'Symbol' of the 'DefinedQuantityDict' used to make the 'UncertQ'.
+instance HasSymbol      UncertQ where symbol c = symbol (c ^. defq)
 -- | Finds the uncertainty of an 'UncertQ'.
 instance HasUncertainty UncertQ where unc = unc''
--- | Finds the 'Constraint's of a 'ConstrConcept' used to make the 'UncertQ'.
-instance Constrained    UncertQ where constraints = coco . constraints
--- | Finds a reasonable value for the 'ConstrConcept' used to make the 'UncertQ'.
-instance HasReasVal     UncertQ where reasVal = coco . reasVal
--- | Finds the rationale for the 'ConstrConcept' used to make the 'UncertQ'.
-instance MayHaveRationale   UncertQ where rationale = coco . rationale
--- | Finds definition of the 'ConstrConcept' used to make the 'UncertQ'.
-instance Definition     UncertQ where defn = coco . defn
--- | Finds the domain contained in the 'ConstrConcept' used to make the 'UncertQ'.
-instance ConceptDomain  UncertQ where cdom = cdom . view coco
--- | Finds the units of the 'ConstrConcept' used to make the 'UncertQ'.
-instance MayHaveUnit    UncertQ where getUnit = getUnit . view coco
+-- | Finds the 'Constraint's of a 'UncertQ'.
+instance Constrained    UncertQ where constraints = constr'
+-- | Finds a reasonable value for the 'UncertQ'.
+instance HasReasVal     UncertQ where reasVal = reasV'
+-- | Finds the rationale for the 'UncertQ'.
+instance MayHaveRationale   UncertQ where rationale = rationale'
+-- | Finds definition of the 'DefinedQuantityDict' used to make the 'UncertQ'.
+instance Definition     UncertQ where defn = defq . defn
+-- | Finds the domain contained in the 'DefinedQuantityDict' used to make the 'UncertQ'.
+instance ConceptDomain  UncertQ where cdom = cdom . view defq
+-- | Finds the units of the 'DefinedQuantityDict' used to make the 'UncertQ'.
+instance MayHaveUnit    UncertQ where getUnit = getUnit . view defq
 -- | Convert the symbol of the 'UncertQ' to a 'ModelExpr'.
 instance Express        UncertQ where express = sy
 
@@ -68,7 +77,7 @@ instance Express        UncertQ where express = sy
 -- | Smart constructor that requires a 'Quantity', a percentage, and a reasonable value with an 'Uncertainty'.
 uq :: (Quantity c, Constrained c, Concept c, HasReasVal c, MayHaveUnit c) =>
   c -> Uncertainty -> UncertQ
-uq q = UQ (ConstrConcept (dqdWr q) (q ^. constraints) (q ^. reasVal) Nothing)
+uq q = UQ (dqdWr q) (q ^. constraints) (q ^. reasVal) Nothing
 
 --FIXME: this is kind of crazy and probably shouldn't be used!
 -- | Uncertainty quantity ('uq') but with a constraint.
@@ -83,4 +92,4 @@ uqcND nam trm sym un space cs val = uq (cuc' nam trm "" sym un space cs val)
 
 -- | Directly wraps a 'ConstrConcept' with an 'Uncertainty', preserving all fields (including rationale).
 uqDirect :: ConstrConcept -> Uncertainty -> UncertQ
-uqDirect = UQ
+uqDirect c = UQ (dqdWr c) (c ^. constraints) (c ^. reasVal) (c ^. rationale)


### PR DESCRIPTION
Part of https://github.com/JacquesCarette/Drasil/discussions/5330

Some follow up work should be done to review the constructors and their usages. A number of place use the form `uq (constrainted' ...` which should be simplified to a new constructor which doesn't use `ConstrConcept` at all.