### PR TITLE
Flattened `StatementSym` structure

### DIFF
--- a/code/drasil-code/lib/Language/Drasil/Code/Imperative/FunctionCalls.hs
+++ b/code/drasil-code/lib/Language/Drasil/Code/Imperative/FunctionCalls.hs
@@ -50,6 +50,7 @@ genAllInputCalls
     , List r stmt
     , Reference r
     , Set r
+    , StatementSym r stmt
     , OOFuncAppStatement r stmt
     , TypeElim r
     , VariableElim r
@@ -93,6 +94,7 @@ genConstraintCall
     , List r stmt
     , Reference r
     , Set r
+    , StatementSym r stmt
     , TypeElim r
     , VariableElim r
     )
@@ -119,6 +121,7 @@ genCalcCall
     , List r stmt
     , Reference r
     , Set r
+    , StatementSym r stmt
     , DeclStatement r stmt
     , TypeElim r
     , VariableElim r
@@ -148,6 +151,7 @@ genOutputCall
     , List r stmt
     , Reference r
     , Set r
+    , StatementSym r stmt
     , TypeElim r
     , VariableElim r
     )
@@ -174,6 +178,7 @@ genFuncCall
     , List r stmt
     , Reference r
     , Set r
+    , StatementSym r stmt
     , TypeElim r
     , VariableElim r
     )
@@ -249,6 +254,7 @@ genAllInputCallsProc
     , List r stmt
     , Reference r
     , Set r
+    , StatementSym r stmt
     , TypeElim r
     )
   => GenState [MS (r stmt)]
@@ -287,6 +293,7 @@ genConstraintCallProc
     , List r stmt
     , Reference r
     , Set r
+    , StatementSym r stmt
     , TypeElim r
     )
   => GenState (Maybe (MS (r stmt)))
@@ -336,6 +343,7 @@ genOutputCallProc
     , NativeVector r
     , Reference r
     , Set r
+    , StatementSym r stmt
     , TypeElim r
     )
   => GenState (Maybe (MS (r stmt)))

--- a/code/drasil-code/lib/Language/Drasil/Code/Imperative/Import.hs
+++ b/code/drasil-code/lib/Language/Drasil/Code/Imperative/Import.hs
@@ -98,6 +98,7 @@ value
     , List r stmt
     , Reference r
     , OO.Set r
+    , StatementSym r stmt
     , TypeElim r
     , VariableElim r
     )
@@ -210,6 +211,7 @@ mkVal
     , List r stmt
     , Reference r
     , OO.Set r
+    , StatementSym r stmt
     , TypeElim r
     , VariableElim r
     )
@@ -333,6 +335,7 @@ genInOutFunc
     ( OO.Literal r
     , VariableValue r
     , SelfSym r
+    , StatementSym r stmt
     , DeclStatement r stmt
     , FileHandling r stmt
     , PrintFile r stmt
@@ -380,6 +383,7 @@ convExpr
     , List r stmt
     , Reference r
     , OO.Set r
+    , StatementSym r stmt
     , TypeElim r
     , VariableElim r
     )
@@ -487,6 +491,7 @@ convCall
     , List r stmt
     , Reference r
     , OO.Set r
+    , StatementSym r stmt
     , TypeElim r
     , VariableElim r
     )
@@ -695,6 +700,7 @@ convStmt
     , List r stmt
     , Reference r
     , OO.Set r
+    , StatementSym r stmt
     , AssignStatement r stmt
     , ControlStatement r stmt
     , DeclStatement r stmt
@@ -825,6 +831,7 @@ readData
     , List r stmt
     , Reference r
     , OO.Set r
+    , StatementSym r stmt
     , OODeclStatement r stmt
     , ControlStatement r stmt
     , StringStatement r stmt
@@ -1051,6 +1058,7 @@ genModDefProc
     , NumericExpression r
     , ValueExpression r
     , VariableValue r
+    , StatementSym r stmt
     , DeclStatement r stmt
     , AssignStatement r stmt
     , ControlStatement r stmt
@@ -1085,6 +1093,7 @@ publicFuncProc
   ::
     ( OO.Literal r
     , VariableValue r
+    , StatementSym r stmt
     , DeclStatement r stmt
     , FileHandling r stmt
     , PrintFile r stmt
@@ -1108,6 +1117,7 @@ privateFuncProc
   ::
     ( OO.Literal r
     , VariableValue r
+    , StatementSym r stmt
     , DeclStatement r stmt
     , FileHandling r stmt
     , PrintFile r stmt
@@ -1133,6 +1143,7 @@ genMethodProc
   ::
     ( OO.Literal r
     , VariableValue r
+    , StatementSym r stmt
     , DeclStatement r stmt
     , FileHandling r stmt
     , PrintFile r stmt
@@ -1171,6 +1182,7 @@ genFuncProc
     , NumericExpression r
     , ValueExpression r
     , VariableValue r
+    , StatementSym r stmt
     , DeclStatement r stmt
     , AssignStatement r stmt
     , ControlStatement r stmt
@@ -1212,6 +1224,7 @@ genModFuncsProc
     , NumericExpression r
     , ValueExpression r
     , VariableValue r
+    , StatementSym r stmt
     , DeclStatement r stmt
     , AssignStatement r stmt
     , ControlStatement r stmt
@@ -1495,6 +1508,7 @@ convStmtProc
     , NativeVector r
     , Reference r
     , OO.Set r
+    , StatementSym r stmt
     , DeclStatement r stmt
     , AssignStatement r stmt
     , ControlStatement r stmt
@@ -1619,6 +1633,7 @@ genDataFuncProc
     , List r stmt
     , Reference r
     , OO.Set r
+    , StatementSym r stmt
     , MethodSym r vis stmt mthd
     , TypeElim r
     , VariableElim r
@@ -1635,6 +1650,7 @@ publicInOutFuncProc
   ::
     ( OO.Literal r
     , VariableValue r
+    , StatementSym r stmt
     , DeclStatement r stmt
     , FileHandling r stmt
     , PrintFile r stmt
@@ -1654,6 +1670,7 @@ privateInOutFuncProc
   ::
     ( OO.Literal r
     , VariableValue r
+    , StatementSym r stmt
     , DeclStatement r stmt
     , FileHandling r stmt
     , PrintFile r stmt
@@ -1676,6 +1693,7 @@ genInOutFuncProc
   ::
     ( OO.Literal r
     , VariableValue r
+    , StatementSym r stmt
     , DeclStatement r stmt
     , FileHandling r stmt
     , PrintFile r stmt

--- a/code/drasil-code/lib/Language/Drasil/Code/Imperative/Logging.hs
+++ b/code/drasil-code/lib/Language/Drasil/Code/Imperative/Logging.hs
@@ -22,6 +22,7 @@ logBody
   ::
     ( Literal r
     , VariableValue r
+    , StatementSym r stmt
     , DeclStatement r stmt
     , FileHandling r stmt
     , PrintFile r stmt
@@ -42,6 +43,7 @@ loggedMethod
   ::
     ( Literal r
     , VariableValue r
+    , StatementSym r stmt
     , DeclStatement r stmt
     , FileHandling r stmt
     , PrintFile r stmt

--- a/code/drasil-code/lib/Language/Drasil/Code/Imperative/Modules.hs
+++ b/code/drasil-code/lib/Language/Drasil/Code/Imperative/Modules.hs
@@ -140,6 +140,7 @@ getInputDecl
     , List r stmt
     , Reference r
     , Set r
+    , StatementSym r stmt
     , OODeclStatement r stmt
     , TypeElim r
     , VariableElim r
@@ -194,6 +195,7 @@ initConsts
     , List r stmt
     , Reference r
     , Set r
+    , StatementSym r stmt
     , OODeclStatement r stmt
     , TypeElim r
     , VariableElim r
@@ -386,6 +388,7 @@ sfwrCBody
     , List r stmt
     , Reference r
     , Set r
+    , StatementSym r stmt
     , DeclStatement r stmt
     , ControlStatement r stmt
     , PrintConsole r stmt
@@ -414,6 +417,7 @@ physCBody
     , List r stmt
     , Reference r
     , Set r
+    , StatementSym r stmt
     , DeclStatement r stmt
     , ControlStatement r stmt
     , PrintConsole r stmt
@@ -443,6 +447,7 @@ chooseConstr
     , List r stmt
     , Reference r
     , Set r
+    , StatementSym r stmt
     , DeclStatement r stmt
     , ControlStatement r stmt
     , PrintConsole r stmt
@@ -485,6 +490,7 @@ constrWarn
     , List r stmt
     , Reference r
     , Set r
+    , StatementSym r stmt
     , PrintConsole r stmt
     , BodySym r stmt
     , TypeElim r
@@ -515,6 +521,7 @@ constrExc
     , List r stmt
     , Reference r
     , Set r
+    , StatementSym r stmt
     , ControlStatement r stmt
     , PrintConsole r stmt
     , TypeElim r
@@ -543,6 +550,7 @@ constrVarDec
     , List r stmt
     , Reference r
     , Set r
+    , StatementSym r stmt
     , DeclStatement r stmt
     , TypeElim r
     , VariableElim r
@@ -572,6 +580,7 @@ constraintViolatedMsg
     , List r stmt
     , Reference r
     , Set r
+    , StatementSym r stmt
     , PrintConsole r stmt
     , TypeElim r
     , VariableElim r
@@ -602,6 +611,7 @@ printConstraint
     , List r stmt
     , Reference r
     , Set r
+    , StatementSym r stmt
     , PrintConsole r stmt
     , TypeElim r
     , VariableElim r
@@ -625,6 +635,7 @@ printConstraint v c = do
           , List r stmt
           , Reference r
           , Set r
+          , StatementSym r stmt
           , PrintConsole r stmt
           , TypeElim r
           , VariableElim r
@@ -798,6 +809,7 @@ genCalcBlock
     , List r stmt
     , Reference r
     , Set r
+    , StatementSym r stmt
     , AssignStatement r stmt
     , ControlStatement r stmt
     , TypeElim r
@@ -829,6 +841,7 @@ genCaseBlock
     , List r stmt
     , Reference r
     , Set r
+    , StatementSym r stmt
     , AssignStatement r stmt
     , ControlStatement r stmt
     , TypeElim r
@@ -921,6 +934,7 @@ genMainFuncProc
     , NativeVector r
     , Reference r
     , Set r
+    , StatementSym r stmt
     , MethodSym r vis stmt mthd
     , TypeElim r
     )
@@ -970,6 +984,7 @@ initConstsProc
     , NativeVector r
     , Reference r
     , Set r
+    , StatementSym r stmt
     , TypeElim r
     )
   => GenState (Maybe (MS (r stmt)))
@@ -1043,7 +1058,9 @@ checkInputClass = do
 -- the InputParameters class, so 'inParams' should be declared and constructed,
 -- using 'objDecNew' if the inputs are exported by the current module, and
 -- 'extObjDecNew' if they are exported by a different module.
-getInputDeclProc :: (DeclStatement r stmt) => GenState (Maybe (MS (r stmt)))
+getInputDeclProc
+  :: (StatementSym r stmt, DeclStatement r stmt)
+  => GenState (Maybe (MS (r stmt)))
 getInputDeclProc = do
   g <- get
   let scp = convScope $ currentScope g
@@ -1083,6 +1100,7 @@ genCalcFuncProc
     , List r stmt
     , Reference r
     , Set r
+    , StatementSym r stmt
     , DeclStatement r stmt
     , AssignStatement r stmt
     , ControlStatement r stmt
@@ -1210,6 +1228,7 @@ genInputFormatProc
     , Comparison r
     , NumericExpression r
     , ValueExpression r
+    , StatementSym r stmt
     , DeclStatement r stmt
     , ControlStatement r stmt
     , StringStatement r stmt
@@ -1241,6 +1260,7 @@ genInputFormatProc s = do
           , Comparison r
           , NumericExpression r
           , ValueExpression r
+          , StatementSym r stmt
           , DeclStatement r stmt
           , ControlStatement r stmt
           , StringStatement r stmt
@@ -1281,6 +1301,7 @@ genInputDerivedProc
     , List r stmt
     , Reference r
     , Set r
+    , StatementSym r stmt
     , DeclStatement r stmt
     , AssignStatement r stmt
     , ControlStatement r stmt
@@ -1314,6 +1335,7 @@ genInputDerivedProc s = do
           , List r stmt
           , Reference r
           , Set r
+          , StatementSym r stmt
           , DeclStatement r stmt
           , AssignStatement r stmt
           , ControlStatement r stmt
@@ -1350,6 +1372,7 @@ genInputConstraintsProc
     , Reference r
     , Set r
     , List r stmt
+    , StatementSym r stmt
     , DeclStatement r stmt
     , PrintConsole r stmt
     , FileHandling r stmt
@@ -1380,6 +1403,7 @@ genInputConstraintsProc s = do
           , Reference r
           , Set r
           , List r stmt
+          , StatementSym r stmt
           , DeclStatement r stmt
           , PrintConsole r stmt
           , FileHandling r stmt
@@ -1418,6 +1442,7 @@ sfwrCBodyProc
     , Reference r
     , Set r
     , List r stmt
+    , StatementSym r stmt
     , DeclStatement r stmt
     , PrintConsole r stmt
     , ControlStatement r stmt
@@ -1443,6 +1468,7 @@ physCBodyProc
     , Reference r
     , Set r
     , List r stmt
+    , StatementSym r stmt
     , DeclStatement r stmt
     , PrintConsole r stmt
     , ControlStatement r stmt
@@ -1469,6 +1495,7 @@ chooseConstrProc
     , Reference r
     , Set r
     , List r stmt
+    , StatementSym r stmt
     , DeclStatement r stmt
     , PrintConsole r stmt
     , ControlStatement r stmt
@@ -1674,6 +1701,7 @@ genOutputFormatProc
     , List r stmt
     , Reference r
     , Set r
+    , StatementSym r stmt
     , DeclStatement r stmt
     , ControlStatement r stmt
     , FileHandling r stmt
@@ -1700,6 +1728,7 @@ genOutputFormatProc = do
           , List r stmt
           , Reference r
           , Set r
+          , StatementSym r stmt
           , DeclStatement r stmt
           , ControlStatement r stmt
           , FileHandling r stmt

--- a/code/drasil-code/test/HelloWorld.hs
+++ b/code/drasil-code/test/HelloWorld.hs
@@ -305,6 +305,7 @@ helloIfBody
     , BooleanExpression r
     , NumericExpression r
     , ValueExpression r
+    , StatementSym r stmt
     , DeclStatement r stmt
     , AssignStatement r stmt
     , PrintConsole r stmt
@@ -409,7 +410,6 @@ helloForLoop
   ::
     ( Literal r
     , VariableValue r
-    , AssignStatement r stmt
     , ControlStatement r stmt
     , PrintConsole r stmt
     )

--- a/code/drasil-gool/lib/Drasil/GOOL/InterfaceGOOL.hs
+++ b/code/drasil-gool/lib/Drasil/GOOL/InterfaceGOOL.hs
@@ -27,7 +27,7 @@ import Drasil.Shared.InterfaceCommon (
   -- Typeclasses
   BodySym(body), TypeSym(..), FunctionSym, MethodSym(..), VariableSym(var),
   ValueSym(valueType), VariableValue(valueOf), ValueExpression, Array,
-  List(listSize, listAdd), listOf, StatementSym(..), AssignStatement,
+  List(listSize, listAdd), listOf, StatementSym, AssignStatement,
   DeclStatement(listDecDef), FuncAppStatement, VisibilitySym(..), Argument,
   BooleanExpression, CommandLineArgs, CommentStatement, Comparison,
   ControlStatement, PrintConsole, ReadConsole, FileHandling, PrintFile, ReadFile,
@@ -50,11 +50,11 @@ class (UnRepr r TypeData, Argument r, CommandLineArgs r, Literal r,
   NumericExpression r, InternalValueExp r, OOValueExpression r, Array r,
   List r stmt, Reference r, Set r, OOFunctionSym r, ParameterSym r,
   VariableValue r, ScopeSym r, BinderSym r, InternalList r,
-  MethodSym r vis stmt mthd, TypeElim r, VariableElim r, CommentStatement r stmt,
-  OODeclStatement r stmt, AssignStatement r stmt, OOFuncAppStatement r stmt,
-  ControlStatement r stmt, StringStatement r stmt, PrintConsole r stmt,
-  ReadConsole r stmt, FileHandling r stmt, PrintFile r stmt, ReadFile r stmt,
-  ProgramSym r vis stmt mthd stvr attch prg
+  MethodSym r vis stmt mthd, TypeElim r, VariableElim r, StatementSym r stmt,
+  CommentStatement r stmt, OODeclStatement r stmt, AssignStatement r stmt,
+  OOFuncAppStatement r stmt, ControlStatement r stmt, StringStatement r stmt,
+  PrintConsole r stmt, ReadConsole r stmt, FileHandling r stmt, PrintFile r stmt,
+  ReadFile r stmt, ProgramSym r vis stmt mthd stvr attch prg
   ) => OOProg r vis stmt mthd stvr attch prg
 
 type Program = ProgData
@@ -295,7 +295,7 @@ extObjDecNewNoParams l v tp = extObjDecNew l v tp []
 class (FuncAppStatement r stmt, OOVariableSym r) => OOFuncAppStatement r stmt where
   selfInOutCall :: InOutCall r stmt
 
-class (StatementSym r stmt, OOFunctionSym r) => ObserverPattern r stmt where
+class (OOFunctionSym r) => ObserverPattern r stmt | r -> stmt where
   notifyObservers :: VS (r FuncData) -> VS (r TypeData) -> MS (r stmt)
 
 observerListName :: Label

--- a/code/drasil-gool/lib/Drasil/GOOL/LanguageRenderer/CSharpRenderer.hs
+++ b/code/drasil-gool/lib/Drasil/GOOL/LanguageRenderer/CSharpRenderer.hs
@@ -938,6 +938,7 @@ csPrint
     , ValueExpression r
     , VariableValue r
     , List r stmt
+    , StatementSym r stmt
     , DeclStatement r stmt
     , AssignStatement r stmt
     , ControlStatement r stmt

--- a/code/drasil-gool/lib/Drasil/GOOL/LanguageRenderer/JavaRenderer.hs
+++ b/code/drasil-gool/lib/Drasil/GOOL/LanguageRenderer/JavaRenderer.hs
@@ -977,6 +977,7 @@ jOut
     , ValueExpression r
     , VariableValue r
     , List r stmt
+    , StatementSym r stmt
     , DeclStatement r stmt
     , AssignStatement r stmt
     , ControlStatement r stmt

--- a/code/drasil-gool/lib/Drasil/GOOL/LanguageRenderer/PythonRenderer.hs
+++ b/code/drasil-gool/lib/Drasil/GOOL/LanguageRenderer/PythonRenderer.hs
@@ -940,6 +940,7 @@ pyOut
     , Comparison r
     , VariableValue r
     , List r stmt
+    , StatementSym r stmt
     , DeclStatement r stmt
     , AssignStatement r stmt
     , ControlStatement r stmt

--- a/code/drasil-gool/lib/Drasil/GProc/InterfaceProc.hs
+++ b/code/drasil-gool/lib/Drasil/GProc/InterfaceProc.hs
@@ -9,7 +9,7 @@ module Drasil.GProc.InterfaceProc (
   ProcProg, ProgramSym(..), FileSym(..), ModuleSym(..)
   ) where
 
-import Drasil.Shared.InterfaceCommon (Label, MethodSym(..), Array,
+import Drasil.Shared.InterfaceCommon (Label, MethodSym(..), Array, StatementSym,
   AssignStatement, Argument, BooleanExpression, CommandLineArgs, DeclStatement,
   CommentStatement, Comparison, ControlStatement, FuncAppStatement, PrintConsole,
   ReadConsole, FileHandling, PrintFile, ReadFile, List, Literal, MathConstant,
@@ -23,13 +23,14 @@ import Drasil.Shared.AST (FileData, ModData, ProgData, TypeData)
 -- for generating a procedural program.
 class (UnRepr r TypeData, FunctionSym r, VariableValue r, ScopeSym r,
   BinderSym r, InternalList r, MethodSym r vis stmt mthd, TypeElim r,
-  VariableElim r, Array r, AssignStatement r stmt, Argument r,
-  BooleanExpression r, CommandLineArgs r, CommentStatement r stmt, Comparison r,
-  ControlStatement r stmt, DeclStatement r stmt,  FuncAppStatement r stmt,
-  PrintConsole r stmt, ReadConsole r stmt, FileHandling r stmt, PrintFile r stmt,
-  ReadFile r stmt, List r stmt, Literal r, MathConstant r, NumericExpression r,
-  ParameterSym r, Reference r, Set r, StringStatement r stmt, ValueExpression r,
-  VariableValue r, ProgramSym r vis stmt mthd prg)
+  VariableElim r, Array r, StatementSym r stmt, AssignStatement r stmt,
+  Argument r, BooleanExpression r, CommandLineArgs r, CommentStatement r stmt,
+  Comparison r, ControlStatement r stmt, DeclStatement r stmt,
+  FuncAppStatement r stmt, PrintConsole r stmt, ReadConsole r stmt,
+  FileHandling r stmt, PrintFile r stmt, ReadFile r stmt, List r stmt, Literal r,
+  MathConstant r, NumericExpression r, ParameterSym r, Reference r, Set r,
+  StringStatement r stmt, ValueExpression r, VariableValue r,
+  ProgramSym r vis stmt mthd prg)
   => ProcProg r vis stmt mthd prg
 
 type Program = ProgData

--- a/code/drasil-gool/lib/Drasil/GProc/LanguageRenderer/JuliaRenderer.hs
+++ b/code/drasil-gool/lib/Drasil/GProc/LanguageRenderer/JuliaRenderer.hs
@@ -977,6 +977,7 @@ jlOut
     , Comparison r
     , VariableValue r
     , List r stmt
+    , StatementSym r stmt
     , DeclStatement r stmt
     , AssignStatement r stmt
     , ControlStatement r stmt

--- a/code/drasil-gool/lib/Drasil/Shared/InterfaceCommon.hs
+++ b/code/drasil-gool/lib/Drasil/Shared/InterfaceCommon.hs
@@ -65,7 +65,7 @@ type Block = Doc
 -- not for use by the compiler/interpreter
 -- but to improve readability of the generated code.
 -- See the bottom of page 2 of Brook's GOOL paper from 2020 for more details.
-class (StatementSym r stmt) => BlockSym r stmt where
+class BlockSym r stmt | r -> stmt where
   block   :: [MS (r stmt)] -> MS (r Block)
 
 -- | Class for representing a type.
@@ -314,7 +314,7 @@ class (IndexTranslator r) => Array r where
   -- | Given a source array, create a (shallow) copy of it
   arrayCopy :: SValue r -> SValue r
 
-class (IndexTranslator r, StatementSym r stmt) => List r stmt where
+class (IndexTranslator r) => List r stmt | r -> stmt where
   -- | Finds the size of a list.
   --   Arguments are: List
   listSize   :: SValue r -> SValue r
@@ -415,7 +415,7 @@ class (ValueSym r) => StatementSym r stmt | r -> stmt where
   -- | Consolidates a list of statements into a single statement
   multi     :: [MS (r stmt)] -> MS (r stmt)
 
-class (VariableSym r, StatementSym r stmt) => AssignStatement r stmt where
+class (VariableSym r) => AssignStatement r stmt | r -> stmt where
   (&-=)  :: SVariable r -> SValue r -> MS (r stmt)
   infixl 1 &-=
   (&+=)  :: SVariable r -> SValue r -> MS (r stmt)
@@ -431,7 +431,7 @@ class (VariableSym r, StatementSym r stmt) => AssignStatement r stmt where
 infixr 1 &=
 (&=) = assign
 
-class (VariableSym r, StatementSym r stmt, ScopeSym r) => DeclStatement r stmt where
+class (VariableSym r, ScopeSym r) => DeclStatement r stmt | r -> stmt where
   -- | Declare a variable without giving it a value.
   -- Not for use with arrays; use `arrayDec` instead.
   varDec       :: SVariable r -> r ScopeData -> MS (r stmt)
@@ -453,38 +453,38 @@ class (VariableSym r, StatementSym r stmt, ScopeSym r) => DeclStatement r stmt w
   funcDecDef   :: SVariable r -> r ScopeData -> [SVariable r] -> MS (r Body)
     -> MS (r stmt)
 
-class (VariableSym r, StatementSym r stmt) => PrintConsole r stmt where
+class (VariableSym r) => PrintConsole r stmt | r -> stmt where
   print      :: SValue r -> MS (r stmt)
   printLn    :: SValue r -> MS (r stmt)
   -- TODO [Brandon Bosman, 07/23/2026]: Could these be helpers?
   printStr   :: String -> MS (r stmt)
   printStrLn :: String -> MS (r stmt)
 
-class (VariableSym r, StatementSym r stmt) => ReadConsole r stmt where
+class (VariableSym r) => ReadConsole r stmt | r -> stmt where
   getInput         :: SVariable r -> MS (r stmt)
   discardInput     :: MS (r stmt)
 
-class (VariableSym r, StatementSym r stmt) => FileHandling r stmt where
+class (VariableSym r) => FileHandling r stmt | r -> stmt where
   openFileR :: SVariable r -> SValue r -> MS (r stmt)
   openFileW :: SVariable r -> SValue r -> MS (r stmt)
   openFileA :: SVariable r -> SValue r -> MS (r stmt)
   closeFile :: SValue r -> MS (r stmt)
 
-class (VariableSym r, StatementSym r stmt) => PrintFile r stmt where
+class (VariableSym r) => PrintFile r stmt | r -> stmt where
   -- | Given the file handle and value to print, print the value to the file.
   printFile      :: SValue r -> SValue r -> MS (r stmt)
   printFileLn    :: SValue r -> SValue r -> MS (r stmt)
   printFileStr   :: SValue r -> String -> MS (r stmt)
   printFileStrLn :: SValue r -> String -> MS (r stmt)
 
-class (VariableSym r, StatementSym r stmt) => ReadFile r stmt where
+class (VariableSym r) => ReadFile r stmt | r -> stmt where
   getFileInput     :: SValue r -> SVariable r -> MS (r stmt)
   discardFileInput :: SValue r -> MS (r stmt)
   getFileInputLine :: SValue r -> SVariable r -> MS (r stmt)
   discardFileLine  :: SValue r -> MS (r stmt)
   getFileInputAll  :: SValue r -> SVariable r -> MS (r stmt)
 
-class (VariableSym r, StatementSym r stmt) => StringStatement r stmt where
+class (VariableSym r) => StringStatement r stmt | r -> stmt where
   -- | Given a char to split on, variable to store result in, and string to split,
   -- generates a statement splitting the string into a list of strings
   -- delimited by the char.
@@ -500,11 +500,11 @@ class (ValueSym r) => FunctionSym r where
 type InOutCall r stmt = Label -> [SValue r] -> [SVariable r] -> [SVariable r] ->
   MS (r stmt)
 
-class (VariableSym r, StatementSym r stmt) => FuncAppStatement r stmt where
+class (VariableSym r) => FuncAppStatement r stmt | r -> stmt where
   inOutCall    ::            InOutCall r stmt
   extInOutCall :: Library -> InOutCall r stmt
 
-class (StatementSym r stmt) => CommentStatement r stmt where
+class CommentStatement r stmt | r -> stmt where
   comment :: String -> MS (r stmt)
 
 class (BodySym r stmt, VariableSym r) => ControlStatement r stmt where

--- a/code/drasil-gool/lib/Drasil/Shared/LanguageRenderer/Common.hs
+++ b/code/drasil-gool/lib/Drasil/Shared/LanguageRenderer/Common.hs
@@ -12,7 +12,7 @@ import Text.PrettyPrint.HughesPJ (text, empty, Doc)
 import Drasil.Shared.CodeType (CodeType(..))
 import Drasil.Shared.InterfaceCommon (Body, Variable, SVariable, MixedCall,
   Value, SValue, ValueSym, TypeSym(int), VariableElim(variableName), Label,
-  Library, funcApp, getCodeType, AssignStatement, ValueExpression)
+  Library, funcApp, getCodeType, StatementSym, AssignStatement, ValueExpression)
 import Drasil.Shared.RendererClassesCommon (scopeData, call,
   RenderFunction(funcFromData), RenderVariable, RenderValue, ValueElim,
   RenderStatement, ScopeElim, InternalVarElim)
@@ -71,7 +71,7 @@ forEach' f i' v' b' = do
 -- Python and Julia --
 
 varDecDef
-  :: (AssignStatement r stmt, ScopeElim r, VariableElim r)
+  :: (StatementSym r stmt, AssignStatement r stmt, ScopeElim r, VariableElim r)
   => SVariable r -> r ScopeData -> Maybe (SValue r) -> MS (r stmt)
 varDecDef v scp e = do
   v' <- zoom lensMStoVS v

--- a/code/drasil-gool/lib/Drasil/Shared/LanguageRenderer/LanguagePolymorphic.hs
+++ b/code/drasil-gool/lib/Drasil/Shared/LanguageRenderer/LanguagePolymorphic.hs
@@ -374,7 +374,8 @@ objDecNew v scp vs = IC.varDecDef v scp (newObj (onStateValue variableType v) vs
 
 printList
   ::
-    ( IC.DeclStatement r stmt
+    ( StatementSym r stmt
+    , IC.DeclStatement r stmt
     , AssignStatement r stmt
     , IC.ControlStatement r stmt
     , IC.Literal r
@@ -400,7 +401,7 @@ printList n v prFn prStrFn prLnFn = multi [prStrFn "[",
         i = IC.var l_i IC.int
 
 printSet
-  :: (IC.ControlStatement r stmt, IC.VariableValue r)
+  :: (StatementSym r stmt, IC.ControlStatement r stmt, IC.VariableValue r)
   => Integer
   -> SValue r
   -> (SValue r -> MS (r stmt))
@@ -420,7 +421,8 @@ printObj n prLnFn = prLnFn $ "Instance of " ++ n ++ " object"
 
 print
   ::
-    ( PrintConsole r stmt
+    ( StatementSym r stmt
+    , PrintConsole r stmt
     , PrintFile r stmt
     , IC.DeclStatement r stmt
     , AssignStatement r stmt

--- a/code/drasil-gool/lib/Drasil/Shared/LanguageRenderer/LoggingFor.hs
+++ b/code/drasil-gool/lib/Drasil/Shared/LanguageRenderer/LoggingFor.hs
@@ -99,7 +99,8 @@ logVarUpdate x =
   ]
 
 instance
-  ( AssignStatement r stmt
+  ( StatementSym r stmt
+  , AssignStatement r stmt
   , FileHandling r stmt
   , PrintFile r stmt
   , VariableValue r
@@ -124,7 +125,8 @@ instance (List r stmt) => List (LoggingFor r) stmt where
   indexOf = liftLogging indexOf
 
 instance
-  (DeclStatement r stmt
+  ( StatementSym r stmt
+  , DeclStatement r stmt
   , FileHandling r stmt
   , PrintFile r stmt
   , VariableValue r
@@ -156,7 +158,8 @@ instance (PrintConsole r stmt) => PrintConsole (LoggingFor r) stmt where
   printStrLn = liftLogging printStrLn
 
 instance
-  ( FileHandling r stmt
+  ( StatementSym r stmt
+  , FileHandling r stmt
   , PrintFile r stmt
   , ReadConsole r stmt
   , VariableValue r
@@ -180,7 +183,8 @@ instance (PrintFile r stmt) => PrintFile (LoggingFor r) stmt where
   printFileStrLn = liftLogging printFileStrLn
 
 instance
-  ( FileHandling r stmt
+  ( StatementSym r stmt
+  , FileHandling r stmt
   , PrintFile r stmt
   , ReadFile r stmt
   , VariableValue r
@@ -196,7 +200,8 @@ instance
   getFileInputAll = liftLogging getFileInputAll
 
 instance
-  ( StringStatement r stmt
+  ( StatementSym r stmt
+  , StringStatement r stmt
   , FileHandling r stmt
   , PrintFile r stmt
   , VariableValue r
@@ -412,7 +417,7 @@ instance (NativeVector lang) => NativeVector (LoggingFor lang) where
 
 -- GProc
 
-instance (P.ProcProg r vis stmt mthd prg) => P.ProcProg (LoggingFor r) vis stmt mthd prg
+instance (StatementSym r stmt, P.ProcProg r vis stmt mthd prg) => P.ProcProg (LoggingFor r) vis stmt mthd prg
 
 instance (P.ModuleSym r vis stmt mthd) => P.ModuleSym (LoggingFor r) vis stmt mthd where
   buildModule = liftLogging P.buildModule

--- a/code/drasil-gool/lib/Drasil/Shared/LanguageRenderer/Macros.hs
+++ b/code/drasil-gool/lib/Drasil/Shared/LanguageRenderer/Macros.hs
@@ -57,7 +57,8 @@ strat = on2StateValues (\result b -> toCode $ vcat [RC.body b,
   RC.statement result])
 
 runStrategy
-  :: ( IC.AssignStatement r stmt
+  :: ( StatementSym r stmt
+     , IC.AssignStatement r stmt
      , RC.BodyElim r
      , Monad r
      , S.RenderStatement r stmt
@@ -78,7 +79,8 @@ runStrategy l strats rv av = maybe
 
 listSlice
   ::
-    ( IC.DeclStatement r stmt
+    ( StatementSym r stmt
+    , IC.DeclStatement r stmt
     , AssignStatement r stmt
     , IC.ControlStatement r stmt
     , IC.Literal r
@@ -160,7 +162,8 @@ listSlice beg end step vnew vold = do
 --   Output: (SValue): (setter, value) of bound
 makeSetterVal
   ::
-    ( IC.DeclStatement r stmt
+    ( StatementSym r stmt
+    , IC.DeclStatement r stmt
     , Comparison r
     , IC.IndexTranslator r
     , IC.Literal r
@@ -183,7 +186,8 @@ makeSetterVal vName step _       _       lb rb  scp =
   in (theSetter, IC.intToIndex $ IC.valueOf theVar)
 
 stringListVals
-  :: ( IC.AssignStatement r stmt
+  :: ( StatementSym r stmt
+     , IC.AssignStatement r stmt
      , IC.List r stmt
      , IC.Literal r
      , RenderValue r
@@ -263,7 +267,13 @@ obsList :: (IC.VariableValue r) => VS (r TypeData) -> SValue r
 obsList t = IC.valueOf $ listOf observerListName t
 
 notify
-  :: (VariableValue r, List r stmt, OOFunctionSym r, BodySym r stmt)
+  ::
+    ( VariableValue r
+    , List r stmt
+    , StatementSym r stmt
+    , OOFunctionSym r
+    , BodySym r stmt
+    )
   => VS (r TypeData) -> VS (r FuncData) -> MS (r Body)
 notify t f = oneLiner $ IC.valStmt $ at (obsList t) observerIdxVal $. f
 
@@ -273,6 +283,7 @@ notifyObservers
     , VariableValue r
     , Comparison r
     , List r stmt
+    , StatementSym r stmt
     , DeclStatement r stmt
     , AssignStatement r stmt
     , ControlStatement r stmt
@@ -288,6 +299,7 @@ notifyObservers'
     ( Literal r
     , VariableValue r
     , List r stmt
+    , StatementSym r stmt
     , ControlStatement r stmt
     , OOFunctionSym r
     )
@@ -298,7 +310,8 @@ notifyObservers' f t = IC.forRange observerIndex initv (IC.listSize $ obsList t 
 
 arrayDecAsList
   ::
-    ( IC.DeclStatement r stmt
+    ( StatementSym r stmt
+    , IC.DeclStatement r stmt
     , IC.ControlStatement r stmt
     , IC.Literal r
     , IC.VariableValue r


### PR DESCRIPTION
As discussed in #5385, this PR removes the `StatementSym` constraint on all the other Statement typeclasses. This will be necessary for future refactors, and doing it now makes it clearer why we suddenly need a lot more `StatementSym` constraints.