### PR TITLE
Add separate UID fields to quantity related chunks

### DIFF
--- a/code/drasil-lang/lib/Language/Drasil/Chunk/Constrained.hs
+++ b/code/drasil-lang/lib/Language/Drasil/Chunk/Constrained.hs
@@ -8,7 +8,7 @@ module Language.Drasil.Chunk.Constrained (
 
 import Control.Lens ((^.), makeLenses, view)
 
-import Drasil.Database (HasUID(..), HasChunkRefs(..), mkUid)
+import Drasil.Database (HasUID(..), HasChunkRefs(..), UID, mkUid)
 
 import Language.Drasil.Chunk.DefinedQuantity (DefinedQuantityDict, dqdWr, quant, quantAU, quantNoUnit)
 import Language.Drasil.Symbol (HasSymbol(..), Symbol)
@@ -29,7 +29,8 @@ import Language.Drasil.Stages (Stage)
 --
 -- Ex. Measuring the length of a pendulum arm could be a concept that has some reasonable value
 -- (between 1 cm and 2 m) and the constraint that the length cannot be a negative value.
-data ConstrConcept = ConstrConcept { _defq       :: DefinedQuantityDict
+data ConstrConcept = ConstrConcept { _uu         :: UID
+                                   , _defq       :: DefinedQuantityDict
                                    , _constr'    :: [ConstraintE]
                                    , _reasV'     :: Maybe Expr
                                    , _rationale' :: Maybe Sentence
@@ -41,7 +42,7 @@ instance HasChunkRefs ConstrConcept where
   {-# INLINABLE chunkRefs #-}
 
 -- | Finds 'UID' of the 'DefinedQuantityDict' used to make the 'ConstrConcept'.
-instance HasUID        ConstrConcept where uid = defq . uid
+instance HasUID        ConstrConcept where uid = uu
 -- | Finds term ('NP') of the 'DefinedQuantityDict' used to make the 'ConstrConcept'.
 instance NamedIdea     ConstrConcept where term = defq . term
 -- | Finds the idea contained in the 'DefinedQuantityDict' used to make the 'ConstrConcept'.
@@ -61,7 +62,7 @@ instance HasReasVal    ConstrConcept where reasVal      = reasV'
 -- | Finds the rationale for the 'ConstrConcept'.
 instance MayHaveRationale  ConstrConcept where rationale    = rationale'
 -- | Equal if 'UID's are equal.
-instance Eq            ConstrConcept where c1 == c2 = (c1 ^.defq.uid) == (c2 ^.defq.uid)
+instance Eq            ConstrConcept where c1 == c2 = (c1 ^. uid) == (c2 ^. uid)
 -- | Finds the units of the 'DefinedQuantityDict' used to make the 'ConstrConcept'.
 instance MayHaveUnit   ConstrConcept where getUnit = getUnit . view defq
 -- | Convert the symbol of the 'ConstrConcept' to a 'ModelExpr'.
@@ -70,36 +71,39 @@ instance Express       ConstrConcept where express = sy
 -- | Creates a 'ConstrConcept' with a quantitative concept, a list of 'Constraint's and an 'Expr'.
 constrained' :: (Concept c, MayHaveUnit c, Quantity c) =>
   c -> [ConstraintE] -> Expr -> ConstrConcept
-constrained' q cs rv = ConstrConcept (dqdWr q) cs (Just rv) Nothing
+constrained' q cs rv = ConstrConcept (q ^. uid) (dqdWr q) cs (Just rv) Nothing
 
 -- | Similar to 'constrained'', but defaults 'Maybe' 'Expr' to 'Nothing'.
 constrainedNRV' :: (Concept c, MayHaveUnit c, Quantity c) =>
   c -> [ConstraintE] -> ConstrConcept
-constrainedNRV' q cs = ConstrConcept (dqdWr q) cs Nothing Nothing
+constrainedNRV' q cs = ConstrConcept (q ^. uid) (dqdWr q) cs Nothing Nothing
 
 -- | Similar to 'constrained'', but with a rationale 'Sentence' explaining the reasonable value.
 constrainedWithRationale :: (Concept c, MayHaveUnit c, Quantity c) =>
   c -> [ConstraintE] -> Expr -> Sentence -> ConstrConcept
-constrainedWithRationale q cs rv r = ConstrConcept (dqdWr q) cs (Just rv) (Just r)
+constrainedWithRationale q cs rv r = ConstrConcept (q ^. uid) (dqdWr q) cs (Just rv) (Just r)
 
 -- | Creates a constrained unitary chunk from a 'UID', term ('NP'), description ('String'), 'Symbol', unit, 'Space', 'Constraint's, and an 'Expr'.
 cuc' :: String -> NP -> String -> Symbol -> UnitDefn
             -> Space -> [ConstraintE] -> Expr -> ConstrConcept
 cuc' nam trm desc sym un space cs rv =
-  ConstrConcept (quant (mkUid nam) trm (S desc) sym space un) cs (Just rv) Nothing
+  ConstrConcept u (quant u trm (S desc) sym space un) cs (Just rv) Nothing
+  where u = mkUid nam
 
 -- | Similar to cuc', but does not include a unit.
 cucNoUnit' :: String -> NP -> String -> Symbol
             -> Space -> [ConstraintE] -> Expr -> ConstrConcept
 cucNoUnit' nam trm desc sym space cs rv =
-  ConstrConcept (quantNoUnit (mkUid nam) trm (S desc) sym space) cs (Just rv) Nothing
+  ConstrConcept u (quantNoUnit u trm (S desc) sym space) cs (Just rv) Nothing
+  where u = mkUid nam
 
 -- | Similar to 'cuc'', but 'Symbol' is dependent on 'Stage'.
 cuc'' :: String -> NP -> String -> (Stage -> Symbol) -> UnitDefn
             -> Space -> [ConstraintE] -> Expr -> ConstrConcept
 cuc'' nam trm desc sym un space cs rv =
-  ConstrConcept (quantAU (mkUid nam) trm (S desc) Nothing sym space (Just un)) cs (Just rv) Nothing
+  ConstrConcept u (quantAU u trm (S desc) Nothing sym space (Just un)) cs (Just rv) Nothing
+  where u = mkUid nam
 
 -- | Similar to 'cnstrw', but types must also have a 'Concept'.
 cnstrw' :: (Quantity c, Concept c, Constrained c, HasReasVal c, MayHaveUnit c) => c -> ConstrConcept
-cnstrw' c = ConstrConcept (dqdWr c) (c ^. constraints) (c ^. reasVal) Nothing
+cnstrw' c = ConstrConcept (c ^. uid) (dqdWr c) (c ^. constraints) (c ^. reasVal) Nothing

--- a/code/drasil-lang/lib/Language/Drasil/Chunk/DefinedQuantity.hs
+++ b/code/drasil-lang/lib/Language/Drasil/Chunk/DefinedQuantity.hs
@@ -32,7 +32,7 @@ import Language.Drasil.Sentence (Sentence(..))
 -- Additionally, it contains a reference to the general concept the value is an instance of ('ConceptChunk').
 --
 -- Ex. A pendulum arm can be defined as a concept with a symbol (l), space (Real numbers), and units (cm, m, etc.).
-data DefinedQuantityDict = DQD { _uu :: UID 
+data DefinedQuantityDict = DQD { _uu :: UID
                                , _con :: ConceptChunk
                                , _symb :: Stage -> Symbol
                                , _spa :: Space

--- a/code/drasil-lang/lib/Language/Drasil/Chunk/DefinedQuantity.hs
+++ b/code/drasil-lang/lib/Language/Drasil/Chunk/DefinedQuantity.hs
@@ -32,7 +32,8 @@ import Language.Drasil.Sentence (Sentence(..))
 -- Additionally, it contains a reference to the general concept the value is an instance of ('ConceptChunk').
 --
 -- Ex. A pendulum arm can be defined as a concept with a symbol (l), space (Real numbers), and units (cm, m, etc.).
-data DefinedQuantityDict = DQD { _con :: ConceptChunk
+data DefinedQuantityDict = DQD { _uu :: UID 
+                               , _con :: ConceptChunk
                                , _symb :: Stage -> Symbol
                                , _spa :: Space
                                , _unit' :: Maybe UnitDefn
@@ -50,7 +51,7 @@ instance HasChunkRefs DefinedQuantityDict where
   {-# INLINABLE chunkRefs #-}
 
 -- | Finds the 'UID' of the 'ConceptChunk' used to make the 'DefinedQuantityDict'.
-instance HasUID        DefinedQuantityDict where uid = con . uid
+instance HasUID        DefinedQuantityDict where uid = uu
 -- | Equal if 'UID's are equal.
 instance Eq            DefinedQuantityDict where a == b = (a ^. uid) == (b ^. uid)
 -- | Finds the term ('NP') of the 'ConceptChunk' used to make the 'DefinedQuantityDict'.
@@ -84,7 +85,7 @@ quant ::
   Space ->
   -- | The unit of the quantity.
   UnitDefn -> DefinedQuantityDict
-quant u trm def s sp un = DQD (cncpt''' u trm def) (const s) sp (Just un)
+quant u trm def s sp un = DQD u (cncpt''' u trm def) (const s) sp (Just un)
 
 -- | Construct a 'DefinedQuantityDict' (/with/ a unit and a symbol dependent on stage)
 quant' ::
@@ -100,7 +101,7 @@ quant' ::
   Space ->
   -- | The unit of the quantity.
   UnitDefn -> DefinedQuantityDict
-quant' u trm def s sp un = DQD (cncpt''' u trm def) s sp (Just un)
+quant' u trm def s sp un = DQD u (cncpt''' u trm def) s sp (Just un)
 
 -- | Construct a 'DefinedQuantityDict' (/with/ an optional unit, optional
 -- abbreviation and a symbol dependent on stage)
@@ -119,7 +120,7 @@ quantAU ::
   Space ->
   -- | The (optional) unit of the quantity.
   Maybe UnitDefn -> DefinedQuantityDict
-quantAU u trm def a = DQD cc
+quantAU u trm def a = DQD u cc
   where cc = maybe (cncpt''' u trm def) (cncpt'' u trm def) a
 
 -- | Construct a 'DefinedQuantityDict' (/without/ a unit)
@@ -134,7 +135,7 @@ quantNoUnit ::
   Symbol ->
   -- | The 'Space' of the quantity.
   Space -> DefinedQuantityDict
-quantNoUnit u trm def s sp = DQD (cncpt''' u trm def) (const s) sp Nothing
+quantNoUnit u trm def s sp = DQD u (cncpt''' u trm def) (const s) sp Nothing
 
 -- | Construct a 'DefinedQuantityDict' (/wihout/ a unit and /with/ a symbol dependent on stage)
 quantNoUnit' ::
@@ -148,29 +149,29 @@ quantNoUnit' ::
   (Stage -> Symbol) ->
   -- | The 'Space' of the quantity.
   Space -> DefinedQuantityDict
-quantNoUnit' u trm def s sp = DQD (cncpt''' u trm def) s sp Nothing
+quantNoUnit' u trm def s sp = DQD u (cncpt''' u trm def) s sp Nothing
 
 {-# DEPRECATED dqd, dqd', dqdNoUnit, dqdNoUnit'
   "Smart constructors allow externally-known chunk nesting; use one of `quant, quant', quantNoUnit, quantNoUnit'` instead." #-}
 
 -- | Smart constructor that creates a DefinedQuantityDict with a 'ConceptChunk', a 'Symbol' independent of 'Stage', a 'Space', and a unit.
 dqd :: ConceptChunk -> Symbol -> Space -> UnitDefn -> DefinedQuantityDict
-dqd c s sp = DQD c (const s) sp . Just
+dqd c s sp = DQD (c ^. uid) c (const s) sp . Just
 
 -- | Similar to 'dqd', but without any units.
 dqdNoUnit :: ConceptChunk -> Symbol -> Space -> DefinedQuantityDict
-dqdNoUnit c s sp = DQD c (const s) sp Nothing
+dqdNoUnit c s sp = DQD (c ^. uid) c (const s) sp Nothing
 
 dqdNoUnit' :: ConceptChunk -> (Stage -> Symbol) -> Space -> DefinedQuantityDict
-dqdNoUnit' c s sp = DQD c s sp Nothing
+dqdNoUnit' c s sp = DQD (c ^. uid) c s sp Nothing
 
 -- | Similar to 'dqd', but the 'Symbol' is now dependent on the 'Stage'.
 dqd' :: ConceptChunk -> (Stage -> Symbol) -> Space -> Maybe UnitDefn -> DefinedQuantityDict
-dqd' = DQD
+dqd' c = DQD (c ^. uid) c
 
 -- | When the input already has all the necessary information. A 'projection' operator from some a type with instances of listed classes to a 'DefinedQuantityDict'.
 dqdWr :: (Quantity c, Concept c, MayHaveUnit c) => c -> DefinedQuantityDict
-dqdWr c = DQD (cw c) (symbol c) (c ^. typ) (getUnit c)
+dqdWr c = DQD (c ^. uid) (cw c) (symbol c) (c ^. typ) (getUnit c)
 
 -- | Makes a variable that is implementation-only.
 implVar :: UID -> NP -> String -> Space -> Symbol -> DefinedQuantityDict

--- a/code/drasil-lang/lib/Language/Drasil/Chunk/Eq.hs
+++ b/code/drasil-lang/lib/Language/Drasil/Chunk/Eq.hs
@@ -98,7 +98,7 @@ fromEqn nm desc def symb sp un =
 fromEqn' :: String -> NP -> Sentence -> Symbol -> Space -> e -> QDefinition e
 fromEqn' nm desc def symb sp =
   QD u (quantNoUnit u desc def symb sp) []
-  where u = (mkUid nm)
+  where u = mkUid nm
 
 -- | Same as 'fromEqn', but symbol depends on stage.
 fromEqnSt :: UID -> NP -> Sentence -> (Stage -> Symbol) ->

--- a/code/drasil-lang/lib/Language/Drasil/Chunk/Eq.hs
+++ b/code/drasil-lang/lib/Language/Drasil/Chunk/Eq.hs
@@ -40,11 +40,12 @@ import Language.Drasil.WellTyped (RequiresChecking(..))
 --
 -- Ex:
 --
--- 1. 'F = ma' (with symbol F, space Real and unit Newtons)
--- 2. 'f(t) = t^2' (with symbol f [displayed as f(t)], space Real and unit seconds^2)
+-- 1. @F = ma@ (with symbol F, space Real and unit Newtons)
+-- 2. @f(t) = t^2@ (with symbol f [displayed as f(t)], space Real and unit seconds^2)
 --
 -- A 'QDefinition' can be thought of as a 'MultiDefn' with only a single formula.
-data QDefinition e = QD { _qua :: DefinedQuantityDict
+data QDefinition e = QD { _uu :: UID
+                        , _qua :: DefinedQuantityDict
                         , _inputs :: [UID]
                         , _expr :: e
                         }
@@ -57,7 +58,7 @@ instance HasChunkRefs (QDefinition e) where
     ]
   {-# INLINABLE chunkRefs #-}
 
-instance HasUID          (QDefinition e) where uid = qua . uid
+instance HasUID          (QDefinition e) where uid = uu
 instance NamedIdea       (QDefinition e) where term = qua . term
 instance Idea            (QDefinition e) where getA = getA . (^. qua)
 instance DefinesQuantity (QDefinition e) where defLhs = qua . to dqdWr
@@ -90,29 +91,32 @@ instance RequiresChecking (QDefinition Expr) Expr Space where
 -- 'Space', unit, and defining expression.
 fromEqn :: String -> NP -> Sentence -> Symbol -> Space -> UnitDefn -> e -> QDefinition e
 fromEqn nm desc def symb sp un =
-  QD (quant (mkUid nm) desc def symb sp un) []
+  QD u (quant u desc def symb sp un) []
+  where u = mkUid nm
 
 -- | Same as 'fromEqn', but has no units.
 fromEqn' :: String -> NP -> Sentence -> Symbol -> Space -> e -> QDefinition e
 fromEqn' nm desc def symb sp =
-  QD (quantNoUnit (mkUid nm) desc def symb sp) []
+  QD u (quantNoUnit u desc def symb sp) []
+  where u = (mkUid nm)
 
 -- | Same as 'fromEqn', but symbol depends on stage.
 fromEqnSt :: UID -> NP -> Sentence -> (Stage -> Symbol) ->
   Space -> UnitDefn -> e -> QDefinition e
 fromEqnSt nm desc def symb sp un =
-  QD (quant' nm desc def symb sp un) []
+  QD nm (quant' nm desc def symb sp un) []
 
 -- | Same as 'fromEqn', but symbol depends on stage and has no units.
 fromEqnSt' :: UID -> NP -> Sentence -> (Stage -> Symbol) -> Space -> e -> QDefinition e
 fromEqnSt' nm desc def symb sp =
-  QD (quantNoUnit' nm desc def symb sp) []
+  QD nm (quantNoUnit' nm desc def symb sp) []
 
 -- | Same as 'fromEqnSt'', but takes a 'String' instead of a 'UID'.
 fromEqnSt'' :: String -> NP -> Sentence -> (Stage -> Symbol) -> Space -> e ->
   QDefinition e
 fromEqnSt'' nm desc def symb sp =
-  QD (quantNoUnit' (mkUid nm) desc def symb sp) []
+  QD u (quantNoUnit' u desc def symb sp) []
+  where u = mkUid nm
 
 -- | Wrapper for fromEqnSt and fromEqnSt'
 mkQDefSt :: UID -> NP -> Sentence -> (Stage -> Symbol) -> Space ->
@@ -134,6 +138,7 @@ mkQuantDef' c t = mkQDefSt (c ^. uid) t EmptyS (symbol c) (c ^. typ) (getUnit c)
 -- equation.
 ec :: (Quantity c, MayHaveUnit c) => c -> e -> QDefinition e
 ec c = QD
+  (c ^. uid)
   (quantAU (c ^. uid) (c ^. term) EmptyS Nothing (symbol c) (c ^. typ) (getUnit c))
   []
 
@@ -144,6 +149,7 @@ mkFuncDef0 :: (IsChunk f, HasSymbol f, HasSpace f,
                IsChunk i, HasSymbol i, HasSpace i) =>
   f -> NP -> Sentence -> Maybe UnitDefn -> [i] -> e -> QDefinition e
 mkFuncDef0 f n s u is = QD
+  (f ^. uid)
   (quantAU (f ^. uid) n s Nothing (symbol f) (f ^. typ) u)
   (map (^. uid) is)
 

--- a/code/drasil-lang/lib/Language/Drasil/Chunk/UncertainQuantity.hs
+++ b/code/drasil-lang/lib/Language/Drasil/Chunk/UncertainQuantity.hs
@@ -11,7 +11,7 @@ module Language.Drasil.Chunk.UncertainQuantity (
 
 import Control.Lens ((^.), makeLenses, view)
 
-import Drasil.Database (HasUID(..), HasChunkRefs(..))
+import Drasil.Database (HasUID(..), HasChunkRefs(..), UID)
 
 import Language.Drasil.Chunk.DefinedQuantity (DefinedQuantityDict, dqdWr)
 import Language.Drasil.Chunk.Constrained (ConstrConcept(..), cuc')
@@ -32,7 +32,8 @@ import Language.Drasil.Uncertainty
 -- Contains the same information as a 'ConstrConcept' with an added 'Uncertainty'.
 --
 -- Ex. Measuring the length of a pendulum arm may be recorded with an uncertainty value.
-data UncertQ = UQ { _defq       :: DefinedQuantityDict
+data UncertQ = UQ { _uu         :: UID
+                  , _defq       :: DefinedQuantityDict
                   , _constr'    :: [ConstraintE]
                   , _reasV'     :: Maybe Expr
                   , _rationale' :: Maybe Sentence
@@ -47,7 +48,7 @@ instance HasChunkRefs UncertQ where
 -- | Equal if 'UID's are equal.
 instance Eq             UncertQ where a == b = (a ^. uid) == (b ^. uid)
 -- | Finds 'UID' of the 'DefinedQuantityDict' used to make the 'UncertQ'.
-instance HasUID         UncertQ where uid = defq . uid
+instance HasUID         UncertQ where uid = uu
 -- | Finds term ('NP') of the 'DefinedQuantityDict' used to make the 'UncertQ'.
 instance NamedIdea      UncertQ where term = defq . term
 -- | Finds the idea contained in the 'DefinedQuantityDict' used to make the 'UncertQ'.
@@ -77,7 +78,7 @@ instance Express        UncertQ where express = sy
 -- | Smart constructor that requires a 'Quantity', a percentage, and a reasonable value with an 'Uncertainty'.
 uq :: (Quantity c, Constrained c, Concept c, HasReasVal c, MayHaveUnit c) =>
   c -> Uncertainty -> UncertQ
-uq q = UQ (dqdWr q) (q ^. constraints) (q ^. reasVal) Nothing
+uq q = UQ (q ^. uid) (dqdWr q) (q ^. constraints) (q ^. reasVal) Nothing
 
 --FIXME: this is kind of crazy and probably shouldn't be used!
 -- | Uncertainty quantity ('uq') but with a constraint.
@@ -92,4 +93,4 @@ uqcND nam trm sym un space cs val = uq (cuc' nam trm "" sym un space cs val)
 
 -- | Directly wraps a 'ConstrConcept' with an 'Uncertainty', preserving all fields (including rationale).
 uqDirect :: ConstrConcept -> Uncertainty -> UncertQ
-uqDirect c = UQ (dqdWr c) (c ^. constraints) (c ^. reasVal) (c ^. rationale)
+uqDirect c = UQ (c ^. uid) (dqdWr c) (c ^. constraints) (c ^. reasVal) (c ^. rationale)


### PR DESCRIPTION
While this currently has no effect, it makes experimenting with separating/namespacing uids (to make them globally unique) much easier. This is also needed to eventually replace certain nested chunks with `UIDRef`