### PR TITLE
Move `ConceptInstance` to Document namespace

### DIFF
--- a/code/drasil-example/bss/lib/Drasil/BinaryStar/Assumptions.hs
+++ b/code/drasil-example/bss/lib/Drasil/BinaryStar/Assumptions.hs
@@ -6,7 +6,8 @@ import Language.Drasil
 import qualified Language.Drasil.Sentence.Combinators as S
 
 import qualified Drasil.SRS.Concepts as SRS (valsOfAuxCons)
-import Language.Drasil.Document (fromSource, fromSources, namedRef)
+import Language.Drasil.Document (ConceptInstance, cic, fromSource,
+  fromSources, namedRef)
 
 import Data.Drasil.Concepts.Documentation (assumpDom, consVals)
 import Data.Drasil.Concepts.Physics (gravity, twoD)

--- a/code/drasil-example/bss/lib/Drasil/BinaryStar/Changes.hs
+++ b/code/drasil-example/bss/lib/Drasil/BinaryStar/Changes.hs
@@ -1,7 +1,7 @@
 module Drasil.BinaryStar.Changes (likelyChgs, unlikelyChgs) where
 
 import Language.Drasil
-import Language.Drasil.Document (refS)
+import Language.Drasil.Document (ConceptInstance, cic, refS)
 import qualified Language.Drasil.Sentence.Combinators as S
 
 import Data.Drasil.Concepts.Documentation (likeChgDom, unlikeChgDom, output_)

--- a/code/drasil-example/bss/lib/Drasil/BinaryStar/Goals.hs
+++ b/code/drasil-example/bss/lib/Drasil/BinaryStar/Goals.hs
@@ -1,6 +1,7 @@
 module Drasil.BinaryStar.Goals (goals, goalsInputs) where
 
 import Language.Drasil
+import Language.Drasil.Document (ConceptInstance, cic)
 import qualified Language.Drasil.Sentence.Combinators as S
 
 import Data.Drasil.Concepts.Documentation (goalStmtDom)

--- a/code/drasil-example/dblpend/lib/Drasil/DblPend/Assumptions.hs
+++ b/code/drasil-example/dblpend/lib/Drasil/DblPend/Assumptions.hs
@@ -4,6 +4,7 @@ module Drasil.DblPend.Assumptions (twoDMotion, cartSys, cartSysR,
 import Language.Drasil
 import Language.Drasil.Chunk.Concept.NamedCombinators
 import qualified Language.Drasil.Development as D
+import Language.Drasil.Document (ConceptInstance, cic)
 import qualified Language.Drasil.Sentence.Combinators as S
 
 import Data.Drasil.Concepts.Documentation (assumpDom)

--- a/code/drasil-example/dblpend/lib/Drasil/DblPend/Body.hs
+++ b/code/drasil-example/dblpend/lib/Drasil/DblPend/Body.hs
@@ -8,7 +8,7 @@ import Drasil.Database (ChunkDB)
 import Language.Drasil hiding (organization)
 import Language.Drasil.Document (makeURI, ulcc, Section, Contents(..),
   LabelledContent, RawContent(..), Reference, namedRef, refS, foldlSP,
-  foldlSPCol, bulletNested, bulletFlat)
+  foldlSPCol, bulletNested, bulletFlat, ConceptInstance)
 import qualified Language.Drasil.Development as D
 import Theory.Drasil (TheoryModel)
 import Drasil.SRS hiding (constants, genDefns)

--- a/code/drasil-example/dblpend/lib/Drasil/DblPend/Goals.hs
+++ b/code/drasil-example/dblpend/lib/Drasil/DblPend/Goals.hs
@@ -5,6 +5,7 @@ import Control.Lens ((^.))
 import Language.Drasil
 import Language.Drasil.Chunk.Concept.NamedCombinators
 import qualified Language.Drasil.Development as D
+import Language.Drasil.Document (ConceptInstance, cic)
 import qualified Language.Drasil.Sentence.Combinators as S
 import Data.Drasil.Concepts.Documentation (goalStmtDom)
 import qualified Data.Drasil.Concepts.PhysicalProperties as CPP (mass, len)

--- a/code/drasil-example/gamephysics/lib/Drasil/GamePhysics/Assumptions.hs
+++ b/code/drasil-example/gamephysics/lib/Drasil/GamePhysics/Assumptions.hs
@@ -3,6 +3,7 @@ module Drasil.GamePhysics.Assumptions (
 ) where
 
 import Language.Drasil hiding (organization)
+import Language.Drasil.Document (ConceptInstance, cic)
 
 import Data.Drasil.Concepts.Documentation as Doc (simulation, assumpDom)
 import qualified Data.Drasil.Concepts.Physics as CP (collision, damping, force,

--- a/code/drasil-example/gamephysics/lib/Drasil/GamePhysics/Changes.hs
+++ b/code/drasil-example/gamephysics/lib/Drasil/GamePhysics/Changes.hs
@@ -4,7 +4,8 @@ module Drasil.GamePhysics.Changes (likelyChgs, unlikelyChgs) where
 
 import Language.Drasil
 import qualified Language.Drasil.Sentence.Combinators as S
-import Language.Drasil.Document (chgsStart, maybeExpanded, maybeChanged)
+import Language.Drasil.Document (ConceptInstance, chgsStart, cic,
+  maybeExpanded, maybeChanged)
 
 import Data.Drasil.Concepts.Documentation as Doc (library, likeChgDom, unlikeChgDom)
 import qualified Data.Drasil.Concepts.Math as CM (ode, constraint)

--- a/code/drasil-example/gamephysics/lib/Drasil/GamePhysics/Goals.hs
+++ b/code/drasil-example/gamephysics/lib/Drasil/GamePhysics/Goals.hs
@@ -3,6 +3,7 @@ module Drasil.GamePhysics.Goals (goals, linearGS, angularGS) where
 import qualified Data.List.NonEmpty as NE
 
 import Language.Drasil
+import Language.Drasil.Document (ConceptInstance, cic)
 
 import Data.Drasil.Concepts.Documentation (goalStmtDom)
 import Data.Drasil.Concepts.Physics (time)

--- a/code/drasil-example/glassbr/lib/Drasil/GlassBR/Goals.hs
+++ b/code/drasil-example/glassbr/lib/Drasil/GlassBR/Goals.hs
@@ -1,6 +1,7 @@
 module Drasil.GlassBR.Goals (goals, willBreakGS) where
 
 import Language.Drasil
+import Language.Drasil.Document (ConceptInstance, cic)
 import qualified Language.Drasil.Sentence.Combinators as S
 
 import Data.Drasil.Concepts.Documentation (goalStmtDom, userInput)

--- a/code/drasil-example/pdcontroller/lib/Drasil/PDController/Changes.hs
+++ b/code/drasil-example/pdcontroller/lib/Drasil/PDController/Changes.hs
@@ -3,7 +3,7 @@ module Drasil.PDController.Changes (likelyChgs) where
 import Language.Drasil
 import Language.Drasil.Chunk.Concept.NamedCombinators
 import qualified Language.Drasil.Development as D
-import Language.Drasil.Document (fromSources)
+import Language.Drasil.Document (ConceptInstance, cic, fromSources)
 
 import Data.Drasil.Concepts.Documentation (likeChgDom)
 import Data.Drasil.Concepts.PhysicalProperties (mass)

--- a/code/drasil-example/pdcontroller/lib/Drasil/PDController/SpSysDesc.hs
+++ b/code/drasil-example/pdcontroller/lib/Drasil/PDController/SpSysDesc.hs
@@ -3,6 +3,7 @@ module Drasil.PDController.SpSysDesc (goals, sysGoalInput, sysParts) where
 import Language.Drasil
 import Language.Drasil.Chunk.Concept.NamedCombinators
 import qualified Language.Drasil.Development as D
+import Language.Drasil.Document (ConceptInstance, cic)
 
 import Data.Drasil.Concepts.Documentation (goalStmtDom)
 

--- a/code/drasil-example/projectile/lib/Drasil/Projectile/Changes.hs
+++ b/code/drasil-example/projectile/lib/Drasil/Projectile/Changes.hs
@@ -3,7 +3,7 @@ module Drasil.Projectile.Changes (likelyChgs) where
 import Language.Drasil
 
 import Data.Drasil.Concepts.Documentation (likeChgDom)
-import Language.Drasil.Document (chgsStart)
+import Language.Drasil.Document (ConceptInstance, chgsStart, cic)
 
 import Drasil.Projectile.Assumptions (neglectDrag)
 import Drasil.Projectile.Concepts (projectile)

--- a/code/drasil-example/projectile/lib/Drasil/Projectile/Goals.hs
+++ b/code/drasil-example/projectile/lib/Drasil/Projectile/Goals.hs
@@ -1,6 +1,7 @@
 module Drasil.Projectile.Goals (goals) where
 
 import Language.Drasil
+import Language.Drasil.Document (ConceptInstance, cic)
 
 import Data.Drasil.Concepts.Documentation (goalStmtDom)
 

--- a/code/drasil-example/sglpend/lib/Drasil/SglPend/Assumptions.hs
+++ b/code/drasil-example/sglpend/lib/Drasil/SglPend/Assumptions.hs
@@ -1,6 +1,6 @@
 module Drasil.SglPend.Assumptions (assumpSingle) where
 
-import Language.Drasil (ConceptInstance)
+import Language.Drasil.Document (ConceptInstance)
 import Drasil.DblPend.Assumptions (assumpBasic)
 
 assumpSingle :: [ConceptInstance]

--- a/code/drasil-example/sglpend/lib/Drasil/SglPend/Goals.hs
+++ b/code/drasil-example/sglpend/lib/Drasil/SglPend/Goals.hs
@@ -3,6 +3,7 @@ module Drasil.SglPend.Goals (goals, goalsInputs) where
 import Language.Drasil
 import Language.Drasil.Chunk.Concept.NamedCombinators
 import qualified Language.Drasil.Development as D
+import Language.Drasil.Document (ConceptInstance, cic)
 import qualified Language.Drasil.Sentence.Combinators as S
 import qualified Language.Drasil.NaturalLanguage.English.NounPhrase.Combinators as NP
 

--- a/code/drasil-example/ssp/lib/Drasil/SSP/Body.hs
+++ b/code/drasil-example/ssp/lib/Drasil/SSP/Body.hs
@@ -7,7 +7,7 @@ import Drasil.Database (ChunkDB)
 import Language.Drasil hiding (Verb, number, organization, variable)
 import Language.Drasil.Document (fig, llccFig, makeURI, ulcc, Contents(..),
   LabelledContent, RawContent(..), Reference, namedRef, refS, foldlSP,
-  foldlSPCol, bulletNested, bulletFlat)
+  foldlSPCol, bulletNested, bulletFlat, ConceptInstance)
 import qualified Language.Drasil.Development as D
 import Drasil.SRS
 import Drasil.Generator (withCommonKnowledge)

--- a/code/drasil-example/ssp/lib/Drasil/SSP/Goals.hs
+++ b/code/drasil-example/ssp/lib/Drasil/SSP/Goals.hs
@@ -4,6 +4,7 @@ module Drasil.SSP.Goals (goals, identifyCritAndFSGS, determineNormalFGS,
 import Language.Drasil
 import Language.Drasil.Chunk.Concept.NamedCombinators
 import qualified Language.Drasil.Development as D
+import Language.Drasil.Document (ConceptInstance, cic)
 import qualified Language.Drasil.Sentence.Combinators as S
 
 import Data.Drasil.Concepts.Documentation (goalStmtDom)

--- a/code/drasil-example/swhs/lib/Drasil/SWHS/Goals.hs
+++ b/code/drasil-example/swhs/lib/Drasil/SWHS/Goals.hs
@@ -2,6 +2,7 @@ module Drasil.SWHS.Goals (goals, waterTempGS, pcmTempGS, waterEnergyGS,
   pcmEnergyGS) where
 
 import Language.Drasil
+import Language.Drasil.Document (ConceptInstance, cic)
 
 import Data.Drasil.Concepts.Documentation (goalStmtDom)
 import Data.Drasil.Concepts.Physics (time)

--- a/code/drasil-example/swhsnopcm/lib/Drasil/SWHSNoPCM/Assumptions.hs
+++ b/code/drasil-example/swhsnopcm/lib/Drasil/SWHSNoPCM/Assumptions.hs
@@ -3,6 +3,7 @@ module Drasil.SWHSNoPCM.Assumptions (module Drasil.SWHSNoPCM.Assumptions) where 
 import Language.Drasil
 import Language.Drasil.Chunk.Concept.NamedCombinators
 import qualified Language.Drasil.Development as D
+import Language.Drasil.Document (ConceptInstance, cic)
 import qualified Language.Drasil.NaturalLanguage.English.NounPhrase.Combinators as NP
 import qualified Language.Drasil.Sentence.Combinators as S
 

--- a/code/drasil-example/swhsnopcm/lib/Drasil/SWHSNoPCM/Goals.hs
+++ b/code/drasil-example/swhsnopcm/lib/Drasil/SWHSNoPCM/Goals.hs
@@ -1,6 +1,6 @@
 module Drasil.SWHSNoPCM.Goals (goals, waterTempGS, waterEnergyGS) where
 
-import Language.Drasil
+import Language.Drasil.Document (ConceptInstance)
 
 import Drasil.SWHS.Goals (waterTempGS, waterEnergyGS)
 

--- a/code/drasil-gen/lib/Drasil/Generator/CommonKnowledge.hs
+++ b/code/drasil-gen/lib/Drasil/Generator/CommonKnowledge.hs
@@ -4,9 +4,10 @@ module Drasil.Generator.CommonKnowledge (
 ) where
 
 import Drasil.Database (empty, insertAll, ChunkDB, insertAllOutOfOrder13)
-import Language.Drasil (IdeaDict, Citation, ConceptChunk, ConceptInstance,
-  DefinedQuantityDict, UnitDefn, CI)
-import Language.Drasil.Document (LabelledContent, Reference, Section)
+import Language.Drasil (IdeaDict, Citation, ConceptChunk, DefinedQuantityDict,
+  UnitDefn, CI)
+import Language.Drasil.Document (ConceptInstance, LabelledContent, Reference,
+  Section)
 import Data.Drasil.Citations (cartesianWiki, lineSource, pointSource,
   smithEtAl2007, smithLai2005, smithKoothoor2016, koothoor2013)
 import Data.Drasil.Concepts.Documentation (doccon, doccon', srsDomains)

--- a/code/drasil-lang/lib/Language/Drasil.hs
+++ b/code/drasil-lang/lib/Language/Drasil.hs
@@ -78,9 +78,9 @@ module Language.Drasil (
 
   -- *** Concepts
   -- Language.Drasil.Chunk.Concept.Core
-  , ConceptChunk, ConceptInstance, sDom
+  , ConceptChunk, sDom
   -- Language.Drasil.Chunk.Concept
-  , cncpt, cncpt', cncpt'', cncpt''', cw, cic
+  , cncpt, cncpt', cncpt'', cncpt''', cw
 
   -- *** Quantities and Units
   -- Language.Drasil.Chunk.Eq

--- a/code/drasil-lang/lib/Language/Drasil/Chunk/Concept.hs
+++ b/code/drasil-lang/lib/Language/Drasil/Chunk/Concept.hs
@@ -4,20 +4,17 @@ module Language.Drasil.Chunk.Concept (
   -- * Concept Chunks
   -- ** From an idea ('IdeaDict')
   ConceptChunk, cncpt, cncpt', cncpt'', cncpt''', cw,
-  -- ** From a 'ConceptChunk'
-  ConceptInstance, cic
   ) where
 
 import Control.Lens ((^.))
 
-import Drasil.Database (HasUID(uid), nsUid, UID, mkUid)
+import Drasil.Database (HasUID(uid), UID)
 
 import Language.Drasil.Classes (ConceptDomain(cdom), Concept)
-import Language.Drasil.Chunk.Concept.Core (ConceptChunk(ConDict), ConceptInstance(ConInst))
-import Language.Drasil.Sentence (Sentence(S))
+import Language.Drasil.Chunk.Concept.Core (ConceptChunk(ConDict))
+import Language.Drasil.Sentence (Sentence)
 import Language.Drasil.Chunk.NamedIdea (NamedIdea (..), Idea (..))
-import Language.Drasil.NaturalLanguage.English.NounPhrase (NP, pn)
-import Language.Drasil.ShortName (shortname')
+import Language.Drasil.NaturalLanguage.English.NounPhrase (NP)
 import qualified Language.Drasil.Classes as D (defn)
 
 -- FIXME: There should only be two smart constructors ultimately for
@@ -79,12 +76,3 @@ cncpt''' u trm defn = ConDict u trm Nothing defn []
 -- | For projecting out to the 'ConceptChunk' data-type.
 cw :: Concept c => c -> ConceptChunk
 cw c = ConDict (c ^. uid) (c ^. term) (getA c) (c ^. D.defn) (cdom c)
-
--- | Constructor for a 'ConceptInstance'. Takes in the Reference Address
--- ('String'), a definition ('Sentence'), a short name ('String'), and a domain
--- (for explicit tagging).
-cic :: Concept c => String -> Sentence -> String -> c -> ConceptInstance
-cic u d sn dom = ConInst (nsUid "instance" $ icc ^. uid) icc u $ shortname' (S sn)
-  where
-    icc = cc (mkUid u) (pn sn) d [dom]
-    cc u' n d' l = ConDict u' n Nothing d' $ map (^. uid) l

--- a/code/drasil-lang/lib/Language/Drasil/Chunk/Concept/Core.hs
+++ b/code/drasil-lang/lib/Language/Drasil/Chunk/Concept/Core.hs
@@ -4,19 +4,15 @@
 module Language.Drasil.Chunk.Concept.Core(
   -- * Concept-related Datatypes
   ConceptChunk(ConDict)
-  , ConceptInstance(ConInst)
   , sDom
 ) where
 
-import Control.Lens (makeLenses, (^.), view)
+import Control.Lens (makeLenses, (^.),)
 
 import Drasil.Database (UID, HasUID(..), declareHasChunkRefs, Generically(..))
 
-import Language.Drasil.ShortName (HasShortName(..), ShortName)
 import Language.Drasil.Classes (NamedIdea(term), Idea(getA),
   Definition(defn), ConceptDomain(cdom))
-import Language.Drasil.Label.Type ((+::+), defer, name, raw,
-  LblType(..), Referable(..), HasRefAddress(..))
 import Language.Drasil.NaturalLanguage.English.NounPhrase.Core (NP)
 import Language.Drasil.Sentence (Sentence)
 
@@ -52,38 +48,3 @@ instance Idea          ConceptChunk where getA = mabbr
 instance Definition    ConceptChunk where defn = defn'
 -- | Finds the domain of 'UID's of a 'ConceptChunk'.
 instance ConceptDomain ConceptChunk where cdom = cdom'
-
--- | Contains a 'ConceptChunk', reference address, and a 'ShortName'.
--- It is a concept that can be referred to, or rather, a instance of where a concept is applied.
--- Often used in Goal Statements, Assumptions, Requirements, etc.
---
--- Ex. Something like the assumption that gravity is 9.81 m/s. When we write our equations,
--- we can then link this assumption so that we do not have to explicitly define
--- that assumption when needed to verify our work.
-data ConceptInstance = ConInst { _ciuid :: UID
-                               , _cc :: ConceptChunk
-                               , ra :: String
-                               , shnm :: ShortName}
-makeLenses ''ConceptInstance
-declareHasChunkRefs ''ConceptInstance
-
--- | Equal if 'UID's are equal.
-instance Eq            ConceptInstance where c1 == c2 = (c1 ^. uid) == (c2 ^. uid)
--- | Finds 'UID' of the 'ConceptChunk' used to make the 'ConceptInstance'.
-instance HasUID        ConceptInstance where uid = ciuid
--- | Finds term ('NP') of the 'ConceptChunk' used to make the 'ConceptInstance'.
-instance NamedIdea     ConceptInstance where term = cc . term
--- | Finds the idea contained in the 'ConceptChunk' used to make the 'ConceptInstance'.
-instance Idea          ConceptInstance where getA = getA . view cc
--- | Finds the definition contained in the 'ConceptChunk' used to make the 'ConceptInstance'.
-instance Definition    ConceptInstance where defn = cc . defn'
--- | Finds the domain contained in the 'ConceptChunk' used to make the 'ConceptInstance'.
-instance ConceptDomain ConceptInstance where cdom = cdom' . view cc
--- | Finds the 'ShortName' contained in a 'ConceptInstance'.
-instance HasShortName  ConceptInstance where shortname = shnm
--- | Finds the reference address contained in a 'ConceptInstance'.
-instance HasRefAddress ConceptInstance where getRefAdd l = RP (defer (sDom $ cdom l) +::+ raw ":" +::+ name) (ra l)
--- | Finds the reference information contained in a 'ConceptInstance'.
-instance Referable     ConceptInstance where
-  refAdd      = ra        -- Finds the reference address contained in a ConceptInstance.
-  renderRef   = getRefAdd -- Finds the reference address but in a diferent form.

--- a/code/drasil-lang/lib/Language/Drasil/Document.hs
+++ b/code/drasil-lang/lib/Language/Drasil/Document.hs
@@ -1,5 +1,6 @@
 -- | Document Description Language.
 module Language.Drasil.Document (
+  module Language.Drasil.Document.ConceptInstance,
   module Language.Drasil.Document.Contents,
   module Language.Drasil.Document.Core,
   module Language.Drasil.Document.DecoratedReference,
@@ -9,6 +10,7 @@ module Language.Drasil.Document (
   module Language.Drasil.Document.SentenceCombinators
 ) where
 
+import Language.Drasil.Document.ConceptInstance
 import Language.Drasil.Document.Contents
 import Language.Drasil.Document.Core
 import Language.Drasil.Document.DecoratedReference

--- a/code/drasil-lang/lib/Language/Drasil/Document/ConceptInstance.hs
+++ b/code/drasil-lang/lib/Language/Drasil/Document/ConceptInstance.hs
@@ -1,0 +1,62 @@
+{-# Language TemplateHaskell #-}
+module Language.Drasil.Document.ConceptInstance (
+  ConceptInstance,
+  cic
+) where
+
+import Control.Lens (makeLenses, (^.), view)
+
+import Drasil.Database (UID, HasUID(..), declareHasChunkRefs, Generically(..), nsUid, mkUid)
+
+import Language.Drasil.Chunk.Concept.Core (ConceptChunk, sDom)
+import Language.Drasil.ShortName (HasShortName(..), ShortName, shortname')
+import Language.Drasil.Classes (NamedIdea(term), Idea(getA),
+  Definition(defn), ConceptDomain(cdom), Concept)
+import Language.Drasil.Label.Type ((+::+), defer, name, raw,
+  LblType(..), Referable(..), HasRefAddress(..))
+import Language.Drasil.Sentence (Sentence (S))
+import Language.Drasil.NaturalLanguage.English.NounPhrase (pn)
+import Language.Drasil.Chunk.Concept (cncpt')
+
+-- | Contains a 'ConceptChunk', reference address, and a 'ShortName'.
+-- It is a concept that can be referred to, or rather, a instance of where a concept is applied.
+-- Often used in Goal Statements, Assumptions, Requirements, etc.
+--
+-- Ex. Something like the assumption that gravity is 9.81 m/s. When we write our equations,
+-- we can then link this assumption so that we do not have to explicitly define
+-- that assumption when needed to verify our work.
+data ConceptInstance = ConInst { _ciuid :: UID
+                               , _cc :: ConceptChunk
+                               , ra :: String
+                               , shnm :: ShortName}
+makeLenses ''ConceptInstance
+declareHasChunkRefs ''ConceptInstance
+
+-- | Equal if 'UID's are equal.
+instance Eq            ConceptInstance where c1 == c2 = (c1 ^. uid) == (c2 ^. uid)
+-- | Finds 'UID' of the 'ConceptChunk' used to make the 'ConceptInstance'.
+instance HasUID        ConceptInstance where uid = ciuid
+-- | Finds term ('NP') of the 'ConceptChunk' used to make the 'ConceptInstance'.
+instance NamedIdea     ConceptInstance where term = cc . term
+-- | Finds the idea contained in the 'ConceptChunk' used to make the 'ConceptInstance'.
+instance Idea          ConceptInstance where getA = getA . view cc
+-- | Finds the definition contained in the 'ConceptChunk' used to make the 'ConceptInstance'.
+instance Definition    ConceptInstance where defn = cc . defn
+-- | Finds the domain contained in the 'ConceptChunk' used to make the 'ConceptInstance'.
+instance ConceptDomain ConceptInstance where cdom = cdom . view cc
+-- | Finds the 'ShortName' contained in a 'ConceptInstance'.
+instance HasShortName  ConceptInstance where shortname = shnm
+-- | Finds the reference address contained in a 'ConceptInstance'.
+instance HasRefAddress ConceptInstance where getRefAdd l = RP (defer (sDom $ cdom l) +::+ raw ":" +::+ name) (ra l)
+-- | Finds the reference information contained in a 'ConceptInstance'.
+instance Referable     ConceptInstance where
+  refAdd      = ra        -- Finds the reference address contained in a ConceptInstance.
+  renderRef   = getRefAdd -- Finds the reference address but in a diferent form.
+
+-- | Constructor for a 'ConceptInstance'. Takes in the Reference Address
+-- ('String'), a definition ('Sentence'), a short name ('String'), and a domain
+-- (for explicit tagging).
+cic :: Concept c => String -> Sentence -> String -> c -> ConceptInstance
+cic u d sn dom = ConInst (nsUid "instance" $ icc ^. uid) icc u $ shortname' (S sn)
+  where
+    icc = cncpt' (mkUid u) (pn sn) d [dom]


### PR DESCRIPTION
As discussed in #5404, `ConceptInstance` is used only for SRS purposes, so it has been moved to reflect that.