### PR TITLE
Remove unneeded `ConceptDomain` instances

### DIFF
--- a/code/drasil-code/lib/Language/Drasil/Chunk/CodeDefinition.hs
+++ b/code/drasil-code/lib/Language/Drasil/Chunk/CodeDefinition.hs
@@ -36,8 +36,6 @@ instance NamedIdea        CodeDefinition where term = cchunk . term
 instance Idea             CodeDefinition where getA = getA . view cchunk
 -- | Finds the Definition of the 'CodeChunk' used to make the 'CodeDefinition'.
 instance Definition       CodeDefinition where defn = cchunk . defn
--- | Finds the concept domains of the 'CodeChunk' used to make the 'CodeDefinition'
-instance ConceptDomain    CodeDefinition where cdom = cdom . view cchunk
 -- | Finds the 'Space' of the 'CodeChunk' used to make the 'CodeDefinition'.
 instance HasSpace         CodeDefinition where typ = cchunk . typ
 -- | Finds the 'Stage' dependent 'Symbol' of the 'CodeChunk' used to make the 'CodeDefinition'.

--- a/code/drasil-code/lib/Language/Drasil/Chunk/NamedArgument.hs
+++ b/code/drasil-code/lib/Language/Drasil/Chunk/NamedArgument.hs
@@ -11,7 +11,7 @@ import Control.Lens ((^.), makeLenses, view)
 import Drasil.Database (HasUID(..), declareHasChunkRefs, Generically(..))
 import Language.Drasil (HasSpace(..), HasSymbol(..),
   Idea(..), MayHaveUnit(..), NamedIdea(..), Quantity,
-  DefinedQuantityDict, Concept, dqdWr, Definition (defn), ConceptDomain (cdom))
+  DefinedQuantityDict, Concept, dqdWr, Definition (defn))
 
 import Drasil.Code.Classes (IsArgumentName)
 
@@ -30,7 +30,6 @@ instance Idea           NamedArgument where getA = getA . view qtd
 
 instance Definition     NamedArgument where defn = qtd . defn
 
-instance ConceptDomain  NamedArgument where cdom = cdom . view qtd
 -- | Finds the 'Space' of the 'DefinedQuantityDict' used to make the 'NamedArgument'.
 instance HasSpace       NamedArgument where typ = qtd . typ
 -- | Finds the 'Symbol' of the 'DefinedQuantityDict' used to make the 'NamedArgument'.

--- a/code/drasil-code/lib/Language/Drasil/Chunk/Parameter.hs
+++ b/code/drasil-code/lib/Language/Drasil/Chunk/Parameter.hs
@@ -30,7 +30,6 @@ instance Idea        ParameterChunk where getA = getA . view pcc
 -- | Finds the definition of the 'CodeChunk' used to make the 'ParameterChunk'.
 instance Definition  ParameterChunk where defn = pcc . defn
 
-instance ConceptDomain ParameterChunk where cdom = cdom . view pcc
 -- | Finds the 'Space' of the 'CodeChunk' used to make the 'ParameterChunk'.
 instance HasSpace    ParameterChunk where typ = pcc . typ
 -- | Finds the 'Stage' dependent 'Symbol' of the 'CodeChunk' used to make the 'ParameterChunk'.

--- a/code/drasil-example/dblpend/lib/Drasil/DblPend/GenDefs.hs
+++ b/code/drasil-example/dblpend/lib/Drasil/DblPend/GenDefs.hs
@@ -224,9 +224,9 @@ xForceMD_1 :: MultiDefn ModelExpr
 xForceMD_1 = mkMultiDefnForQuant xForce_1 EmptyS defns
     where defns = NE.fromList [
                     mkDefiningExpr "xForceWithMass1"
-                      [] EmptyS $ express $ forceGQD ^. defnExpr,
+                      EmptyS $ express $ forceGQD ^. defnExpr,
                     mkDefiningExpr "xForceWithAngle1"
-                      [] EmptyS E.xForceWithAngle_1]
+                      EmptyS E.xForceWithAngle_1]
 
 xForceDeriv_1 :: Derivation
 xForceDeriv_1 = mkDerivName (D.toSent $ phraseNP (force `onThe` firstObject)) [eS' xForceMD_1]
@@ -242,9 +242,9 @@ yForceMD_1 :: MultiDefn ModelExpr
 yForceMD_1 = mkMultiDefnForQuant yForce_1 EmptyS defns
     where defns = NE.fromList [
                     mkDefiningExpr "yForceWithMass1"
-                      [] EmptyS $ express $ forceGQD ^. defnExpr,
+                      EmptyS $ express $ forceGQD ^. defnExpr,
                     mkDefiningExpr "yForceWithAngle1"
-                      [] EmptyS E.yForceWithAngle_1]
+                      EmptyS E.yForceWithAngle_1]
 
 yForceDeriv_1 :: Derivation
 yForceDeriv_1 = mkDerivName (D.toSent $ phraseNP (force `onThe` firstObject)) [eS' yForceMD_1]
@@ -260,9 +260,9 @@ xForceMD_2 :: MultiDefn ModelExpr
 xForceMD_2 = mkMultiDefnForQuant xForce_2 EmptyS defns
     where defns = NE.fromList [
                     mkDefiningExpr "xForceWithMass2"
-                      [] EmptyS $ express $ forceGQD ^. defnExpr,
+                      EmptyS $ express $ forceGQD ^. defnExpr,
                     mkDefiningExpr "xForceWithAngle2"
-                      [] EmptyS E.xForceWithAngle_2]
+                      EmptyS E.xForceWithAngle_2]
 
 xForceDeriv_2 :: Derivation
 xForceDeriv_2 = mkDerivName (D.toSent $ phraseNP (force `onThe` secondObject)) [eS' xForceMD_2]
@@ -278,9 +278,9 @@ yForceMD_2 :: MultiDefn ModelExpr
 yForceMD_2 = mkMultiDefnForQuant yForce_2 EmptyS defns
     where defns = NE.fromList [
                     mkDefiningExpr "yForceWithMass2"
-                      [] EmptyS $ express $ forceGQD ^. defnExpr,
+                      EmptyS $ express $ forceGQD ^. defnExpr,
                     mkDefiningExpr "yForceWithAngle2"
-                      [] EmptyS E.yForceWithAngle_2]
+                      EmptyS E.yForceWithAngle_2]
 
 yForceDeriv_2 :: Derivation
 yForceDeriv_2 = mkDerivName (D.toSent $ phraseNP (force `onThe` secondObject)) [eS' yForceMD_2]

--- a/code/drasil-example/gamephysics/lib/Drasil/GamePhysics/TMods.hs
+++ b/code/drasil-example/gamephysics/lib/Drasil/GamePhysics/TMods.hs
@@ -48,8 +48,8 @@ newtonTLNote = foldlSent [(S "Every action has an equal and opposite reaction" !
 newtonLUGModel :: ModelKind ModelExpr
 newtonLUGModel = equationalRealmN (nounPhraseSP "Newton's law of universal gravitation") $
   mkMultiDefnForQuant fOfGravity EmptyS $ NE.fromList [
-    mkDefiningExpr "newtonLUGviaDeriv" [] EmptyS (sy gravitationalConst $* (sy mass_1 $* sy mass_2 $/ square (sy dispNorm)) $* sy dVect),
-    mkDefiningExpr "newtonLUGviaForm"  [] EmptyS (sy gravitationalConst $* (sy mass_1 $* sy mass_2 $/ square (sy dispNorm)) $* (sy distMass $/ sy dispNorm))
+    mkDefiningExpr "newtonLUGviaDeriv" EmptyS (sy gravitationalConst $* (sy mass_1 $* sy mass_2 $/ square (sy dispNorm)) $* sy dVect),
+    mkDefiningExpr "newtonLUGviaForm"  EmptyS (sy gravitationalConst $* (sy mass_1 $* sy mass_2 $/ square (sy dispNorm)) $* (sy distMass $/ sy dispNorm))
   ]
 
 newtonLUG :: TheoryModel

--- a/code/drasil-example/sglpend/lib/Drasil/SglPend/GenDefs.hs
+++ b/code/drasil-example/sglpend/lib/Drasil/SglPend/GenDefs.hs
@@ -148,9 +148,9 @@ hForceOnPendulumMD :: MultiDefn ModelExpr
 hForceOnPendulumMD = mkMultiDefnForQuant xForce EmptyS defns
     where defns = NE.fromList [
                     mkDefiningExpr "hForceOnPendulumViaComponent"
-                      [] EmptyS $ express E.hForceOnPendulumViaComponent,
+                      EmptyS $ express E.hForceOnPendulumViaComponent,
                     mkDefiningExpr "hForceOnPendulumViaAngle"
-                      [] EmptyS $ express E.hForceOnPendulumViaAngle
+                      EmptyS $ express E.hForceOnPendulumViaAngle
                   ]
 
 hForceOnPendulumDeriv :: Derivation
@@ -165,9 +165,9 @@ vForceOnPendulumMD :: MultiDefn ModelExpr
 vForceOnPendulumMD = mkMultiDefnForQuant yForce EmptyS defns
     where defns = NE.fromList [
                     mkDefiningExpr "vForceOnPendulumViaComponent"
-                      [] EmptyS $ express E.vForceOnPendulumViaComponent,
+                      EmptyS $ express E.vForceOnPendulumViaComponent,
                     mkDefiningExpr "vForceOnPendulumViaAngle"
-                      [] EmptyS $ express E.vForceOnPendulumViaAngle
+                      EmptyS $ express E.vForceOnPendulumViaAngle
                   ]
 
 vForceOnPendulumDeriv :: Derivation

--- a/code/drasil-lang/lib/Drasil/Code/CodeVar.hs
+++ b/code/drasil-lang/lib/Drasil/Code/CodeVar.hs
@@ -13,7 +13,7 @@ import Drasil.Database (HasUID(uid), (+++), declareHasChunkRefs, Generically(..)
 import Drasil.Code.Classes (Callable)
 import Drasil.Code.CodeExpr.Lang (CodeExpr)
 import Language.Drasil.Classes (Quantity, Idea(getA), NamedIdea(..), Concept,
-  Definition(defn), ConceptDomain (cdom))
+  Definition(defn))
 import Language.Drasil.Space (HasSpace(..), Space(..))
 import Language.Drasil.Symbol (HasSymbol(symbol))
 import Language.Drasil.Chunk.UnitDefn (MayHaveUnit(getUnit))
@@ -57,7 +57,6 @@ instance Idea          CodeChunk where getA = getA . view qc
 -- | Finds the Definition contained in the 'DefinedQuantityDict' used to make the CodeChunk
 instance Definition    CodeChunk where defn = qc . defn
 
-instance ConceptDomain CodeChunk where cdom = cdom . view qc
 -- | Finds the 'Space' of the 'DefinedQuantityDict' used to make the 'CodeChunk'.
 instance HasSpace      CodeChunk where typ = qc . typ
 -- | Finds the 'Stage' dependent 'Symbol' of the 'DefinedQuantityDict' used to make the 'CodeChunk'.
@@ -83,7 +82,6 @@ instance Idea          CodeVarChunk where getA = getA . view ccv
 
 instance Definition    CodeVarChunk where defn = ccv . defn
 
-instance ConceptDomain CodeVarChunk where cdom = cdom . view ccv
 -- | Finds the 'Space' of the 'CodeChunk' used to make the 'CodeVarChunk'.
 instance HasSpace      CodeVarChunk where typ = ccv . typ
 -- | Finds the 'Stage' dependent 'Symbol' of the 'CodeChunk' used to make the 'CodeVarChunk'.
@@ -119,8 +117,6 @@ instance NamedIdea     CodeFuncChunk where term = ccf . term
 instance Idea          CodeFuncChunk where getA = getA . view ccf
 -- | Finds the Definition of the 'CodeChunk' used to make the 'CodeFuncChunk'
 instance Definition    CodeFuncChunk where defn = ccf . defn
--- | Finds the ConceptDomain of the 'CodeChunk' used to make the 'CodeFuncChunk'
-instance ConceptDomain CodeFuncChunk where cdom = cdom . view ccf
 -- | Finds the 'Space' of the 'CodeChunk' used to make the 'CodeFuncChunk'.
 instance HasSpace      CodeFuncChunk where typ = ccf . typ
 -- | Finds the 'Stage' dependent 'Symbol' of the 'CodeChunk' used to make the 'CodeFuncChunk'.

--- a/code/drasil-lang/lib/Language/Drasil/Chunk/CommonIdea.hs
+++ b/code/drasil-lang/lib/Language/Drasil/Chunk/CommonIdea.hs
@@ -17,7 +17,7 @@ import Drasil.Database (UID, HasUID(uid), declareHasChunkRefs, Generically(..))
 
 import Language.Drasil.Chunk.NamedIdea (IdeaDict, idea')
 import Language.Drasil.Classes (NamedIdea(term), Idea(getA),
- CommonIdea(abrv), ConceptDomain(cdom))
+ CommonIdea(abrv))
 import Language.Drasil.NaturalLanguage.English.NounPhrase.Core (NP)
 
 -- | The common idea (with 'NounPhrase') data type. It must have a 'UID',
@@ -38,8 +38,6 @@ instance NamedIdea     CI where term = nc' . term
 instance Idea          CI where getA = Just . view ab
 -- | Finds the idea of a 'CI' (abbreviation).
 instance CommonIdea    CI where abrv = view ab
--- | Finds the domain of a 'CI'.
-instance ConceptDomain CI where cdom = cdom'
 
 -- | The commonIdea smart constructor requires a chunk id ('String'), a
 -- term ('NP'), an abbreviation ('String'), and a

--- a/code/drasil-lang/lib/Language/Drasil/Chunk/Concept.hs
+++ b/code/drasil-lang/lib/Language/Drasil/Chunk/Concept.hs
@@ -10,7 +10,7 @@ import Control.Lens ((^.))
 
 import Drasil.Database (HasUID(uid), UID)
 
-import Language.Drasil.Classes (ConceptDomain(cdom), Concept)
+import Language.Drasil.Classes (Concept)
 import Language.Drasil.Chunk.Concept.Core (ConceptChunk(ConDict))
 import Language.Drasil.Sentence (Sentence)
 import Language.Drasil.Chunk.NamedIdea (NamedIdea (..), Idea (..))
@@ -75,4 +75,4 @@ cncpt''' u trm defn = ConDict u trm Nothing defn []
 
 -- | For projecting out to the 'ConceptChunk' data-type.
 cw :: Concept c => c -> ConceptChunk
-cw c = ConDict (c ^. uid) (c ^. term) (getA c) (c ^. D.defn) (cdom c)
+cw c = ConDict (c ^. uid) (c ^. term) (getA c) (c ^. D.defn) []

--- a/code/drasil-lang/lib/Language/Drasil/Chunk/Constrained.hs
+++ b/code/drasil-lang/lib/Language/Drasil/Chunk/Constrained.hs
@@ -13,7 +13,7 @@ import Drasil.Database (HasUID(..), HasChunkRefs(..), UID, mkUid)
 import Language.Drasil.Chunk.DefinedQuantity (DefinedQuantityDict, dqdWr, quant, quantAU, quantNoUnit)
 import Language.Drasil.Symbol (HasSymbol(..), Symbol)
 import Language.Drasil.Classes (NamedIdea(term), Idea(getA), Express(express),
-  Definition(defn), ConceptDomain(cdom), Concept, Quantity,
+  Definition(defn), Concept, Quantity,
   Constrained(constraints), HasReasVal(reasVal), MayHaveRationale(rationale))
 import Language.Drasil.Constraint (ConstraintE)
 import Language.Drasil.Chunk.UnitDefn (MayHaveUnit(getUnit), UnitDefn)
@@ -53,8 +53,6 @@ instance HasSpace      ConstrConcept where typ = defq . typ
 instance HasSymbol     ConstrConcept where symbol c = symbol (c^.defq)
 -- | Finds definition of the 'DefinedQuantityDict' used to make the 'ConstrConcept'.
 instance Definition    ConstrConcept where defn = defq . defn
--- | Finds the domain contained in the 'DefinedQuantityDict' used to make the 'ConstrConcept'.
-instance ConceptDomain ConstrConcept where cdom = cdom . view defq
 -- | Finds the 'Constraint's of a 'ConstrConcept'.
 instance Constrained   ConstrConcept where constraints  = constr'
 -- | Finds a reasonable value for the 'ConstrConcept'.

--- a/code/drasil-lang/lib/Language/Drasil/Chunk/DefinedQuantity.hs
+++ b/code/drasil-lang/lib/Language/Drasil/Chunk/DefinedQuantity.hs
@@ -18,7 +18,7 @@ import qualified Data.Set as Set
 
 import Language.Drasil.Symbol (HasSymbol(symbol), Symbol (Empty))
 import Language.Drasil.Classes (NamedIdea(term), Idea(getA), Concept, Express(..),
-  Definition(defn), ConceptDomain(cdom), Quantity)
+  Definition(defn), Quantity)
 import Language.Drasil.Chunk.Concept (ConceptChunk, cw, cncpt'', cncpt''')
 import Language.Drasil.Expr.Class (sy)
 import Language.Drasil.Chunk.UnitDefn (UnitDefn, MayHaveUnit(getUnit))
@@ -60,8 +60,6 @@ instance NamedIdea     DefinedQuantityDict where term = con . term
 instance Idea          DefinedQuantityDict where getA = getA . view con
 -- | Finds the definition contained in the 'ConceptChunk' used to make the 'DefinedQuantityDict'.
 instance Definition    DefinedQuantityDict where defn = con . defn
--- | Finds the domain of the 'ConceptChunk' used to make the 'DefinedQuantityDict'.
-instance ConceptDomain DefinedQuantityDict where cdom = cdom . view con
 -- | Finds the 'Space' of the 'DefinedQuantityDict'.
 instance HasSpace      DefinedQuantityDict where typ = spa
 -- | Finds the 'Stage' -> 'Symbol' of the 'DefinedQuantityDict'.

--- a/code/drasil-lang/lib/Language/Drasil/Chunk/Eq.hs
+++ b/code/drasil-lang/lib/Language/Drasil/Chunk/Eq.hs
@@ -20,7 +20,7 @@ import Language.Drasil.Chunk.UnitDefn (MayHaveUnit(getUnit), UnitDefn)
 import Language.Drasil.Symbol (HasSymbol(symbol), Symbol)
 import Language.Drasil.Classes (NamedIdea(term), Idea(getA),
   DefiningExpr(defnExpr), Definition(defn), Quantity,
-  ConceptDomain(cdom), Express(express), Concept)
+  Express(express), Concept)
 import Language.Drasil.Chunk.DefinedQuantity (DefinedQuantityDict, DefinesQuantity(defLhs),
   dqdWr, quant, quantNoUnit, quant', quantNoUnit', quantAU)
 import Language.Drasil.Expr.Lang (Expr)
@@ -77,7 +77,6 @@ instance Express e => Express (QDefinition e) where
         -- FIXME: The fact that we have to manually use `C` here is because our
         -- UID references don't carry enough information. This feels hacky at
         -- the moment, and should eventually be fixed.
-instance ConceptDomain (QDefinition e) where cdom = cdom . view qua
 
 instance RequiresChecking (QDefinition Expr) Expr Space where
   -- FIXME: Here, we are type-checking QDefinitions by building it as a relation

--- a/code/drasil-lang/lib/Language/Drasil/Chunk/UncertainQuantity.hs
+++ b/code/drasil-lang/lib/Language/Drasil/Chunk/UncertainQuantity.hs
@@ -17,7 +17,7 @@ import Language.Drasil.Chunk.DefinedQuantity (DefinedQuantityDict, dqdWr)
 import Language.Drasil.Chunk.Constrained (ConstrConcept(..), cuc')
 import Language.Drasil.Symbol
 import Language.Drasil.Classes (NamedIdea(term), Idea(getA), Express(express),
-  Definition(defn), ConceptDomain(cdom), Concept, Quantity,
+  Definition(defn), Concept, Quantity,
   Constrained(constraints), HasReasVal(reasVal), MayHaveRationale(rationale))
 import Language.Drasil.Constraint (ConstraintE)
 import Language.Drasil.Chunk.UnitDefn (MayHaveUnit(getUnit), UnitDefn)
@@ -67,8 +67,6 @@ instance HasReasVal     UncertQ where reasVal = reasV'
 instance MayHaveRationale   UncertQ where rationale = rationale'
 -- | Finds definition of the 'DefinedQuantityDict' used to make the 'UncertQ'.
 instance Definition     UncertQ where defn = defq . defn
--- | Finds the domain contained in the 'DefinedQuantityDict' used to make the 'UncertQ'.
-instance ConceptDomain  UncertQ where cdom = cdom . view defq
 -- | Finds the units of the 'DefinedQuantityDict' used to make the 'UncertQ'.
 instance MayHaveUnit    UncertQ where getUnit = getUnit . view defq
 -- | Convert the symbol of the 'UncertQ' to a 'ModelExpr'.

--- a/code/drasil-lang/lib/Language/Drasil/Chunk/UnitDefn.hs
+++ b/code/drasil-lang/lib/Language/Drasil/Chunk/UnitDefn.hs
@@ -26,7 +26,7 @@ import Drasil.Database (HasChunkRefs(..), UID, HasUID(..), mkUid, nsUid)
 import Language.Drasil.Chunk.Concept (ConceptChunk, cncpt''')
 import Language.Drasil.Sentence (Sentence(..))
 import Language.Drasil.Classes (NamedIdea(term), Idea(getA),
-  Definition(defn), ConceptDomain(cdom), HasUnitSymbol(usymb), IsUnit(udefn, getUnits))
+  Definition(defn), HasUnitSymbol(usymb), IsUnit(udefn, getUnits))
 import Language.Drasil.NaturalLanguage.English.NounPhrase (cn,cn',NP)
 import Language.Drasil.Symbol (Symbol(Label))
 import Language.Drasil.UnitLang (USymb(US), UDefn(UScale, USynonym, UShift),
@@ -58,8 +58,6 @@ instance Idea          UnitDefn where getA c = getA (c ^. vc)
 instance Definition    UnitDefn where defn = vc . defn
 -- | Equal if 'Symbol's are equal.
 instance Eq            UnitDefn where a == b = usymb a == usymb b
--- | Finds the domain contained in the 'ConceptChunk' used to make the 'UnitDefn'.
-instance ConceptDomain UnitDefn where cdom = cdom . view vc
 -- | Finds unit symbol of the 'ConceptChunk' used to make the 'UnitDefn'.
 instance HasUnitSymbol UnitDefn where usymb = getUSymb . view cas
 -- | Gets the UnitDefn and contributing units.

--- a/code/drasil-lang/lib/Language/Drasil/Classes.hs
+++ b/code/drasil-lang/lib/Language/Drasil/Classes.hs
@@ -62,7 +62,7 @@ class ConceptDomain c where
 
 -- TODO: conceptual type synonym?
 -- | Concepts are 'Idea's with definitions and domains.
-type Concept c = (Idea c, Definition c, ConceptDomain c)
+type Concept c = (Idea c, Definition c)
 -- TODO: Would the below make this a bit better to work with?
 --        type Concept = forall c. (Idea c, Definition c, ConceptDomain c) => c
 

--- a/code/drasil-theory/lib/Drasil/Database/SearchTools.hs
+++ b/code/drasil-theory/lib/Drasil/Database/SearchTools.hs
@@ -56,16 +56,11 @@ data DomDefn = DomDefn { domain :: [UID], definition :: Sentence }
 -- and definition. If nothing is found, an error is thrown.
 defResolve :: ([UID] -> Sentence -> c) -> ChunkDB -> UID -> c
 defResolve f db trg
-  | (Just c) <- find trg db :: Maybe DefinedQuantityDict = go f c
   | (Just c) <- find trg db :: Maybe ConceptChunk        = go f c
-  | (Just c) <- find trg db :: Maybe UnitDefn            = go f c
-  | (Just c) <- find trg db :: Maybe InstanceModel       = go f c
-  | (Just c) <- find trg db :: Maybe GenDefn             = go f c
-  | (Just c) <- find trg db :: Maybe TheoryModel         = go f c
   | (Just c) <- find trg db :: Maybe ConceptInstance     = go f c
   | otherwise = error $ "Definition: `" ++ show trg ++ "` not found in ConceptMap"
   where
-    go :: Concept c => ([UID] -> Sentence -> r) -> c -> r
+    go :: (Concept c, ConceptDomain c) => ([UID] -> Sentence -> r) -> c -> r
     go f' c = f' (cdom c) (c ^. defn)
 
 defResolve' :: ChunkDB -> UID -> DomDefn

--- a/code/drasil-theory/lib/Theory/Drasil/ConstraintSet.hs
+++ b/code/drasil-theory/lib/Theory/Drasil/ConstraintSet.hs
@@ -33,8 +33,6 @@ instance NamedIdea     (ConstraintSet e) where term = con . term
 instance Idea          (ConstraintSet e) where getA = getA . (^. con)
 -- | Finds the definition of the 'ConstraintSet'.
 instance Definition    (ConstraintSet e) where defn = con . defn
--- | Finds the domain of the 'ConstraintSet'.
-instance ConceptDomain (ConstraintSet e) where cdom = cdom . (^. con)
 -- | The complete 'ModelExpr' of a ConstraintSet is the logical conjunction of
 --   all the underlying relations (e.g., `a $&& b $&& ... $&& z`).
 instance Express e => Express (ConstraintSet e) where

--- a/code/drasil-theory/lib/Theory/Drasil/DataDefinition.hs
+++ b/code/drasil-theory/lib/Theory/Drasil/DataDefinition.hs
@@ -88,8 +88,6 @@ instance HasAdditionalNotes DataDefinition where getNotes = ddPkt pktSS
 instance HasShortName       DataDefinition where shortname = (^. ddPkt pktSN)
 -- | Finds the reference address of a 'DataDefinition where'.
 instance HasRefAddress      DataDefinition where getRefAdd l = RP (prepend $ abrv l) (l ^. ddPkt pktS)
--- | Finds the domain of the 'QDefinition' used to make the 'DataDefinition where'.
-instance ConceptDomain      DataDefinition where cdom _ = cdom dataDefn
 -- | Finds the idea of a 'DataDefinition where' (abbreviation).
 instance CommonIdea         DataDefinition where abrv _ = abrv dataDefn
 -- | Finds the reference address of a 'DataDefinition where'.

--- a/code/drasil-theory/lib/Theory/Drasil/DifferentialModel.hs
+++ b/code/drasil-theory/lib/Theory/Drasil/DifferentialModel.hs
@@ -17,7 +17,7 @@ import qualified Data.List.NonEmpty as NE
 import Drasil.Database (HasUID(uid), HasChunkRefs(..), mkUid)
 
 import Language.Drasil
-  (ConceptChunk, cncpt''', Express(..), ConceptDomain(..), Definition(..), Idea(..), NamedIdea(..)
+  (ConceptChunk, cncpt''', Express(..), Definition(..), Idea(..), NamedIdea(..)
   , ModelExpr, NP, Sentence, Expr, ModelExprC(nthderiv, equiv), DefinedQuantityDict
   , ExprC(..), columnVec, ConstrConcept, LiteralC(exactDbl, int), RequiresChecking (requiredChecks)
   , Space, HasSpace (..))
@@ -120,8 +120,6 @@ instance NamedIdea     DifferentialModel where term = dmconc . term
 instance Idea          DifferentialModel where getA = getA . view dmconc
 -- | Finds the definition contained in the 'ConceptChunk' used to make the 'DifferentialModel'.
 instance Definition    DifferentialModel where defn = dmconc . defn
--- | Finds the domain of the 'ConceptChunk' used to make the 'DifferentialModel'.
-instance ConceptDomain DifferentialModel where cdom = cdom . view dmconc
 -- | Convert the 'DifferentialModel' into the model expression language.
 instance Express       DifferentialModel where express = formStdODE
 

--- a/code/drasil-theory/lib/Theory/Drasil/GenDefn.hs
+++ b/code/drasil-theory/lib/Theory/Drasil/GenDefn.hs
@@ -39,8 +39,6 @@ instance NamedIdea          GenDefn where term        = mk . term
 instance Idea               GenDefn where getA        = getA . (^. mk)
 -- | Finds the definition of the 'GenDefn'.
 instance Definition         GenDefn where defn        = mk . defn
--- | Finds the domain of the 'GenDefn'.
-instance ConceptDomain      GenDefn where cdom        = cdom . (^. mk)
 -- | Converts the 'GenDefn's related expression into a 'ModelExpr'.
 instance Express            GenDefn where express     = express . (^. mk)
 -- | Finds the derivation of the 'GenDefn'. May contain Nothing.

--- a/code/drasil-theory/lib/Theory/Drasil/InstanceModel.hs
+++ b/code/drasil-theory/lib/Theory/Drasil/InstanceModel.hs
@@ -58,8 +58,6 @@ instance NamedIdea          InstanceModel where term = mk . term
 instance Idea               InstanceModel where getA = getA . (^. mk)
 -- | Finds the definition of the 'InstanceModel'.
 instance Definition         InstanceModel where defn = mk . defn
--- | Finds the domain of the 'InstanceModel'.
-instance ConceptDomain      InstanceModel where cdom = cdom . (^. mk)
 -- | Converts the 'InstanceModel's related expression into the display language.
 instance Express            InstanceModel where express = express . (^. mk)
 -- | Finds the derivation of the 'InstanceModel'. May contain Nothing.

--- a/code/drasil-theory/lib/Theory/Drasil/ModelKinds.hs
+++ b/code/drasil-theory/lib/Theory/Drasil/ModelKinds.hs
@@ -18,7 +18,7 @@ import Data.Maybe (mapMaybe)
 
 import Drasil.Database (UID, HasUID(..), mkUid, nsUid, HasChunkRefs(..))
 import Language.Drasil (NamedIdea(..), NP, QDefinition, Expr,
-  ConceptDomain(..), Definition(..), Idea(..), Express(..),
+  Definition(..), Idea(..), Express(..),
   RequiresChecking(..), Space,
   HasSpace(typ), DefiningExpr(..))
 
@@ -144,8 +144,6 @@ instance NamedIdea     (ModelKinds e) where term    = lensMk term term term term
 instance Idea          (ModelKinds e) where getA    = elimMk (to getA) (to getA) (to getA) (to getA) (to getA)
 -- | Finds the definition of the 'ModelKinds'.
 instance Definition    (ModelKinds e) where defn    = lensMk defn defn defn defn defn
--- | Finds the domain of the 'ModelKinds'.
-instance ConceptDomain (ModelKinds e) where cdom    = elimMk (to cdom) (to cdom) (to cdom) (to cdom) (to cdom)
 -- | Rewrites the underlying model using 'ModelExpr'
 instance Express e => Express (ModelKinds e) where
   mexpress = elimMk (to mexpress) (to mexpress) (to mexpress) (to mexpress) (to mexpress)
@@ -177,8 +175,6 @@ instance NamedIdea     (ModelKind e) where term    = mkTerm
 instance Idea          (ModelKind e) where getA    = getA . (^. mk)
 -- | Finds the definition of the 'ModelKind'.
 instance Definition    (ModelKind e) where defn    = mk . defn
--- | Finds the domain of the 'ModelKind'.
-instance ConceptDomain (ModelKind e) where cdom    = cdom . (^. mk)
 -- | Rewrites the underlying model using 'ModelExpr'
 instance Express e => Express (ModelKind e) where
   mexpress = mexpress . (^. mk)

--- a/code/drasil-theory/lib/Theory/Drasil/MultiDefn.hs
+++ b/code/drasil-theory/lib/Theory/Drasil/MultiDefn.hs
@@ -10,7 +10,6 @@ module Theory.Drasil.MultiDefn(
 ) where
 
 import Control.Lens (makeLenses, view, (^.))
-import Data.List (union)
 import qualified Data.List.NonEmpty as NE
 
 import Drasil.Database (UID, HasUID(..), mkUid, HasChunkRefs(..))
@@ -23,8 +22,6 @@ import Language.Drasil hiding (DefiningExpr)
 data DefiningExpr e = DefiningExpr
   { -- | UID
     _deUid :: UID,
-    -- | Concept domain
-    _cd :: [UID],
     -- | Defining description/statement
     _rvDesc :: Sentence,
     -- | Defining expression
@@ -36,8 +33,6 @@ makeLenses ''DefiningExpr
 instance Eq (DefiningExpr e) where a == b = a ^. uid == b ^. uid
 
 instance HasUID (DefiningExpr e) where uid = deUid
-
-instance ConceptDomain (DefiningExpr e) where cdom = (^. cd)
 
 instance Definition (DefiningExpr e) where defn = rvDesc
 
@@ -75,10 +70,6 @@ instance Idea             (MultiDefn e) where getA    = getA . (^. qd)
 instance HasSpace         (MultiDefn e) where typ     = qd . typ
 instance Definition       (MultiDefn e) where defn    = rDesc
 instance MayHaveUnit      (MultiDefn e) where getUnit = getUnit . view qd
--- | The concept domain of a MultiDefn is the union of the concept domains of
--- the underlying variants.
-instance ConceptDomain    (MultiDefn e) where
-  cdom = foldr1 union . NE.toList . NE.map (^. cd) . (^. rvs)
 instance RequiresChecking (MultiDefn Expr) Expr Space where
   requiredChecks md = map (\x -> (x ^. expr, md ^. typ)) $ NE.toList $ md ^. rvs
 
@@ -103,7 +94,7 @@ mkMultiDefnForQuant :: DefinedQuantityDict -> Sentence -> NE.NonEmpty (DefiningE
 mkMultiDefnForQuant q = mkMultiDefn (q ^. uid) q
 
 -- | Smart constructor for 'DefiningExpr's.
-mkDefiningExpr :: String -> [UID] -> Sentence -> e -> DefiningExpr e
+mkDefiningExpr :: String -> Sentence -> e -> DefiningExpr e
 mkDefiningExpr u = DefiningExpr (mkUid u)
 
 -- | Convert 'MultiDefn's into 'QDefinition's via a specific 'DefiningExpr'.

--- a/code/drasil-theory/lib/Theory/Drasil/RelationConcept.hs
+++ b/code/drasil-theory/lib/Theory/Drasil/RelationConcept.hs
@@ -34,8 +34,6 @@ instance NamedIdea     RelationConcept where term = conc . term
 instance Idea          RelationConcept where getA = getA . view conc
 -- | Finds the definition contained in the 'ConceptChunk' used to make the 'RelationConcept'.
 instance Definition    RelationConcept where defn = conc . defn
--- | Finds the domain of the 'ConceptChunk' used to make the 'RelationConcept'.
-instance ConceptDomain RelationConcept where cdom = cdom . view conc
 -- | Convert the 'RelationConcept' into the model expression language.
 instance Express       RelationConcept where express = (^. rel)
 

--- a/code/drasil-theory/lib/Theory/Drasil/Theory.hs
+++ b/code/drasil-theory/lib/Theory/Drasil/Theory.hs
@@ -55,8 +55,6 @@ instance Definition         TheoryModel where defn = mk . defn
 instance HasReference       TheoryModel where getReferences l = map ref $ rf l-}
 -- | Finds 'DecRef's contained in the 'TheoryModel'.
 instance HasDecRef          TheoryModel where getDecRefs = rf
--- | Finds the domain of the 'ConceptChunk' contained in a 'TheoryModel'.
-instance ConceptDomain      TheoryModel where cdom = cdom . view mk
 -- | Finds any additional notes for the 'TheoryModel'.
 instance HasAdditionalNotes TheoryModel where getNotes = notes
 


### PR DESCRIPTION
Depends on #5405

As discussed in #5404, `ConceptDomain` is used to provide type information for `ConceptInstance`s rather than general domain information.