### PR TITLE
Removed use of `tail` in Swift renderer

### DIFF
--- a/code/drasil-gool/lib/Drasil/GOOL/LanguageRenderer/SwiftRenderer.hs
+++ b/code/drasil-gool/lib/Drasil/GOOL/LanguageRenderer/SwiftRenderer.hs
@@ -1153,16 +1153,14 @@ swiftSetDec :: Doc -> SVariable SwiftCode -> SwiftCode ScopeData ->
   MS (SwiftCode (Doc, Terminator))
 swiftSetDec dec v' scp = do
   v <- zoom lensMStoVS v'
+  innerTp <- zoom lensMStoVS (innerType $ return $ variableType v)
   modify $ useVarName (variableName v)
   modify $ setVarScope (variableName v) (scopeData scp)
   let bind ClassLevel = classLevel :: SwiftCode Doc
       bind InstanceLevel = instanceLevel :: SwiftCode Doc
       p = bind $ variableBind v
   mkStmtNoEnd (RC.perm p <+> dec <+> RC.variable v <> swiftTypeSpec
-    <+> text (swiftSet ++ replaceBrackets (getTypeString (variableType v))))
-
-replaceBrackets :: String -> String
-replaceBrackets str = "<" ++ (init . tail) str ++ ">"
+    <+> text (swiftSet ++ "<" ++ getTypeString innerTp ++ ">"))
 
 swiftThrowDoc :: (ValueElim r) => r Value -> Doc
 swiftThrowDoc errMsg = throwLabel <+> RC.value errMsg


### PR DESCRIPTION
Contributes to #5382 

In my [comment](https://github.com/JacquesCarette/Drasil/issues/5382#issuecomment-5207183858) I was being led astray by the existing implementation. `TypeData` _already_ gives a sort of AST for nested types, and we just had to make use of it. The fact that the original implementation worked at all is due to a major hack/coincidence, that in Swift the Set type is denoted by wrapping the inner type with brackets.