### PR TITLE
refactor(srs-gen): retrieve project title from `SmithEtAlSRS` instead of manually passing through in `SRSDecl`

### DIFF
--- a/code/drasil-example/bss/lib/Drasil/BinaryStar/Body.hs
+++ b/code/drasil-example/bss/lib/Drasil/BinaryStar/Body.hs
@@ -82,7 +82,7 @@ mkSRS = [TableOfContents,
   UCsSec,
   TraceabilitySec $ TraceabilityProg $ traceMatStandard si,
   AuxConstntSec $
-     AuxConsProg progName constants,
+     AuxConsProg constants,
   Bibliography]
 
 ------------------------------

--- a/code/drasil-example/dblpend/lib/Drasil/DblPend/Body.hs
+++ b/code/drasil-example/dblpend/lib/Drasil/DblPend/Body.hs
@@ -91,7 +91,7 @@ mkSRS = [TableOfContents, -- This creates the Table of Contents
     ],
   TraceabilitySec $ TraceabilityProg $ traceMatStandard si,
   AuxConstntSec $
-     AuxConsProg progName [], -- Adds Auxilliary constraint section
+     AuxConsProg [], -- Adds Auxilliary constraint section
   Bibliography                -- Adds reference section
   ]
 

--- a/code/drasil-example/gamephysics/lib/Drasil/GamePhysics/Body.hs
+++ b/code/drasil-example/gamephysics/lib/Drasil/GamePhysics/Body.hs
@@ -80,7 +80,7 @@ mkSRS = [TableOfContents,
     UCsSec,
     OffShelfSolnsSec $ OffShelfSolnsProg offShelfSols,
     TraceabilitySec $ TraceabilityProg $ traceMatStandard si,
-    AuxConstntSec $ AuxConsProg progName [],
+    AuxConstntSec $ AuxConsProg [],
     Bibliography]
       where tableOfSymbols = [TSPurpose, TypogConvention[Vector Bold], SymbOrder, VectorUnits]
 

--- a/code/drasil-example/glassbr/lib/Drasil/GlassBR/Body.hs
+++ b/code/drasil-example/glassbr/lib/Drasil/GlassBR/Body.hs
@@ -93,7 +93,7 @@ mkSRS = [TableOfContents,
   LCsSec,
   UCsSec,
   TraceabilitySec $ TraceabilityProg $ traceMatStandard si,
-  AuxConstntSec $ AuxConsProg progName auxiliaryConstants,
+  AuxConstntSec $ AuxConsProg auxiliaryConstants,
   Bibliography,
   AppndxSec $ AppndxProg [appdxIntro, LlC demandVsSDFig, LlC dimlessloadVsARFig]]
 

--- a/code/drasil-example/projectile/lib/Drasil/Projectile/Body.hs
+++ b/code/drasil-example/projectile/lib/Drasil/Projectile/Body.hs
@@ -96,7 +96,7 @@ mkSRS = [TableOfContents,
   LCsSec,
   TraceabilitySec $ TraceabilityProg $ traceMatStandard si,
   AuxConstntSec $
-    AuxConsProg progName constants,
+    AuxConsProg constants,
   Bibliography
   ]
 

--- a/code/drasil-example/sglpend/lib/Drasil/SglPend/Body.hs
+++ b/code/drasil-example/sglpend/lib/Drasil/SglPend/Body.hs
@@ -80,7 +80,7 @@ mkSRS = [TableOfContents, -- This creates the Table of Contents
     ],
   TraceabilitySec $ TraceabilityProg $ traceMatStandard si,
   AuxConstntSec $
-     AuxConsProg progName [],  -- Adds Auxilliary constraint section
+     AuxConsProg [],  -- Adds Auxilliary constraint section
   Bibliography                    -- Adds reference section
   ]
 

--- a/code/drasil-example/ssp/lib/Drasil/SSP/Body.hs
+++ b/code/drasil-example/ssp/lib/Drasil/SSP/Body.hs
@@ -105,7 +105,7 @@ mkSRS = [TableOfContents,
   LCsSec,
   UCsSec,
   TraceabilitySec $ TraceabilityProg $ traceMatStandard si,
-  AuxConstntSec $ AuxConsProg progName [],
+  AuxConstntSec $ AuxConsProg [],
   Bibliography]
 
 purp :: Sentence

--- a/code/drasil-example/swhs/lib/Drasil/SWHS/Body.hs
+++ b/code/drasil-example/swhs/lib/Drasil/SWHS/Body.hs
@@ -137,7 +137,7 @@ mkSRS = [TableOfContents,
   LCsSec,
   UCsSec,
   TraceabilitySec $ TraceabilityProg $ traceMatStandard si,
-  AuxConstntSec $ AuxConsProg progName specParamValList,
+  AuxConstntSec $ AuxConsProg specParamValList,
   Bibliography]
 
 tSymbIntro :: [TSIntro]

--- a/code/drasil-example/swhsnopcm/lib/Drasil/SWHSNoPCM/Body.hs
+++ b/code/drasil-example/swhsnopcm/lib/Drasil/SWHSNoPCM/Body.hs
@@ -128,7 +128,7 @@ mkSRS = [TableOfContents,
   LCsSec,
   UCsSec,
   TraceabilitySec $ TraceabilityProg $ traceMatStandard si,
-  AuxConstntSec $ AuxConsProg progName specParamValList,
+  AuxConstntSec $ AuxConsProg specParamValList,
   Bibliography]
 
 concIns :: [ConceptInstance]

--- a/code/drasil-example/template/lib/Drasil/Template/Body.hs
+++ b/code/drasil-example/template/lib/Drasil/Template/Body.hs
@@ -72,7 +72,7 @@ mkSRS = [TableOfContents,
   UCsSec,
   TraceabilitySec $ TraceabilityProg $ traceMatStandard si,
   AuxConstntSec $
-     AuxConsProg progName [],
+     AuxConsProg [],
   Bibliography]
 
 inputs :: NE.NonEmpty DefinedQuantityDict

--- a/code/drasil-srs/lib/Drasil/SRS/DocumentLanguage.hs
+++ b/code/drasil-srs/lib/Drasil/SRS/DocumentLanguage.hs
@@ -164,7 +164,7 @@ mkSections si dd mbib = map (either renderRefSec id) partialRender
     render (IntroSec is)        = mkIntroSec si is
     render (StkhldrSec sts)     = mkStkhldrSec sts
     render (SSDSec ss)          = mkSSDSec si ss
-    render (AuxConstntSec acs)  = mkAuxConsSec acs
+    render (AuxConstntSec acs)  = mkAuxConsSec (si ^. sysName) acs
     render Bibliography         = mkBib $ fromMaybe [] mbib
     render (GSDSec gs')         = mkGSDSec gs'
     render (ReqrmntSec r)       = mkReqrmntSec r
@@ -384,8 +384,8 @@ mkOffShelfSolnSec (OffShelfSolnsProg cs) = SRS.offShelfSol cs []
 -- ** Auxiliary Constants
 
 -- | Helper for making the Values of Auxiliary Constants section.
-mkAuxConsSec :: AuxConstntSec -> Section
-mkAuxConsSec (AuxConsProg key listOfCons) = AC.valsOfAuxConstantsF key $ sortBySymbol listOfCons
+mkAuxConsSec :: Idea c => c -> AuxConstntSec -> Section
+mkAuxConsSec c (AuxConsProg listOfCons) = AC.valsOfAuxConstantsF c $ sortBySymbol listOfCons
 
 -- ** References
 

--- a/code/drasil-srs/lib/Drasil/SRS/DocumentLanguage/Core.hs
+++ b/code/drasil-srs/lib/Drasil/SRS/DocumentLanguage/Core.hs
@@ -240,7 +240,7 @@ newtype OffShelfSolnsSec = OffShelfSolnsProg [Contents]
 -- ** Values of Auxiliary Constants Section
 
 -- | Values of Auxiliary Constants section.
-data AuxConstntSec = AuxConsProg CI [ConstQDef]
+newtype AuxConstntSec = AuxConsProg [ConstQDef]
 
 -- ** Appendix Section
 
@@ -328,7 +328,7 @@ instance Multiplate DLPlate where
     ucp (UCsProg c) = pure $ UCsProg c
     ts (TraceabilityProg progs) = pure $ TraceabilityProg progs
     es (OffShelfSolnsProg contents) = pure $ OffShelfSolnsProg contents
-    acs (AuxConsProg ci qdef) = pure $ AuxConsProg ci qdef
+    acs (AuxConsProg qdef) = pure $ AuxConsProg qdef
     aps (AppndxProg con) = pure $ AppndxProg con
   mkPlate b = DLPlate (b docSec) (b refSec) (b introSec) (b introSub) (b stkSec)
     (b stkSub) (b gsdSec) (b gsdSub) (b ssdSec) (b ssdSub) (b pdSec) (b pdSub)

--- a/code/drasil-srs/lib/Drasil/SRS/ExtractDocDesc.hs
+++ b/code/drasil-srs/lib/Drasil/SRS/ExtractDocDesc.hs
@@ -60,7 +60,7 @@ exprPlate = sentencePlate (concatMap sentToExp) `appendPlate` secConPlate (conca
     (GDs _ _ g _) -> go g
     (IMs _ _ i _) -> go i
     _ -> [],
-  auxConsSec = Constant <$> \(AuxConsProg _ qdef) -> go qdef
+  auxConsSec = Constant <$> \(AuxConsProg qdef) -> go qdef
   }) where
       go :: Express a => [a] -> [ModelExpr]
       go = map express
@@ -116,7 +116,7 @@ sentencePlate f = appendPlate (secConPlate (f . extractSents') $ f . concatMap g
     ucsSec = Constant . f <$> \(UCsProg c) -> def c,
     traceSec = Constant . f <$> \(TraceabilityProg progs) ->
       concatMap (\(TraceConfig _ ls s _ _) -> s : ls) progs,
-    auxConsSec = Constant . f <$> \(AuxConsProg _ qdef) -> def qdef
+    auxConsSec = Constant . f <$> \(AuxConsProg qdef) -> def qdef
   } where
     def :: Definition a => [a] -> [Sentence]
     def = map (^. defn)

--- a/code/drasil-srs/lib/Drasil/SRS/Sections/Introduction.hs
+++ b/code/drasil-srs/lib/Drasil/SRS/Sections/Introduction.hs
@@ -103,7 +103,7 @@ overviewParagraph programDefinition introSubs =
      S "of this", endingSentence]
 
 -- | Constructor for Purpose of Document section that each example controls.
-purpDocPara1 :: CI -> Sentence
+purpDocPara1 :: Idea c => c -> Sentence
 purpDocPara1 proName = foldlSent [S "The primary purpose of this", phrase document, S "is to",
   S "record the", plural requirement, S "of" +:+. short proName,
   atStart' goal `sC` plural assumption `sC` plural thModel `sC`
@@ -117,7 +117,7 @@ purpDocPara1 proName = foldlSent [S "The primary purpose of this", phrase docume
 
 -- | Combines 'purpDocPara1' and 'developmentProcessParagraph'.
 -- Verbosity controls if the 'developmentProcessParagraph' is added or not.
-purpDoc :: CI -> Verbosity -> [Sentence]
+purpDoc :: Idea c => c -> Verbosity -> [Sentence]
 purpDoc proName Verbose = [purpDocPara1 proName, developmentProcessParagraph]
 purpDoc proName Succinct = [purpDocPara1 proName]
 

--- a/code/drasil-srs/lib/Drasil/SRS/Sections/TableOfContents.hs
+++ b/code/drasil-srs/lib/Drasil/SRS/Sections/TableOfContents.hs
@@ -180,7 +180,7 @@ mktTraceabilitySec (TraceabilityProg _) = Flat $ namedRef SRS.traceMatricesLabel
 
 -- | Helper for creating the 'Values of Auxiliary Constants' section ToC entry
 mktAuxConsSec :: AuxConstntSec -> ItemType
-mktAuxConsSec (AuxConsProg _ _) = Flat $ namedRef SRS.valsOfAuxConsLabel $ titleize  Doc.consVals
+mktAuxConsSec (AuxConsProg _) = Flat $ namedRef SRS.valsOfAuxConsLabel $ titleize  Doc.consVals
 
 -- | Helper for creating the 'References' section ToC entry
 mktBib :: ItemType

--- a/code/stable/swhs/SRS/HTML/SWHS_SRS.html
+++ b/code/stable/swhs/SRS/HTML/SWHS_SRS.html
@@ -6176,7 +6176,7 @@
       <div class="section">
         <h1>Values of Auxiliary Constants</h1>
         <p class="paragraph">
-          This section contains the standard values that are used for calculations in <span title="solar water heating system">SWHS</span>.
+          This section contains the standard values that are used for calculations in <span title="solar water heating systems incorporating PCM">SWHS</span>.
         </p>
         <div id="Table:TAuxConsts">
           <table class="table">


### PR DESCRIPTION
Contributes to #5414

This field (for `AuxConsProg` of `SRSDecl`) is always intended to be filled with the name of the project. This PR simplifies creation of `AuxConsProg` by reusing the "program name" fields of the SRS instead.