### PR TITLE
refactor(srs-gen): retrieve program name from `SmithEtAlSRS` instead manually passing through Client/Customer sections

### DIFF
--- a/code/drasil-example/glassbr/lib/Drasil/GlassBR/Body.hs
+++ b/code/drasil-example/glassbr/lib/Drasil/GlassBR/Body.hs
@@ -66,9 +66,9 @@ mkSRS = [TableOfContents,
      IOrgSec (Just orgOfDocIntroEnd)],
   StkhldrSec $
     StkhldrProg
-      [Client progName $ D.toSent (phraseNP (a_ company))
+      [Client $ D.toSent (phraseNP (a_ company))
         +:+. S "named Entuitive" +:+ S "It is developed by Dr." +:+ S (fullName mCampidelli),
-      Cstmr progName],
+      Cstmr],
   GSDSec $ GSDProg [SysCntxt [sysCtxIntro, LlC sysCtxFig, sysCtxDesc, sysCtxList],
     UsrChars [userCharacteristicsIntro], SystCons [] [] ],
   SSDSec $

--- a/code/drasil-srs/lib/Drasil/SRS/DocumentLanguage.hs
+++ b/code/drasil-srs/lib/Drasil/SRS/DocumentLanguage.hs
@@ -162,7 +162,7 @@ mkSections si dd mbib = map (either renderRefSec id) partialRender
     render :: DocSection -> Section
     render TableOfContents      = mkToC dd
     render (IntroSec is)        = mkIntroSec si is
-    render (StkhldrSec sts)     = mkStkhldrSec sts
+    render (StkhldrSec sts)     = mkStkhldrSec (si ^. sysName) sts
     render (SSDSec ss)          = mkSSDSec si ss
     render (AuxConstntSec acs)  = mkAuxConsSec (si ^. sysName) acs
     render Bibliography         = mkBib $ fromMaybe [] mbib
@@ -264,12 +264,12 @@ mkIntroSec si (IntroProg probIntro progDefn l) =
 -- ** Stakeholders
 
 -- | Helper for making the Stakeholders section.
-mkStkhldrSec :: StkhldrSec -> Section
-mkStkhldrSec (StkhldrProg l) = SRS.stakeholder [Stk.stakeholderIntro] $ map mkSubs l
+mkStkhldrSec :: Idea c => c -> StkhldrSec -> Section
+mkStkhldrSec progN (StkhldrProg l) = SRS.stakeholder [Stk.stakeholderIntro] $ map mkSubs l
   where
     mkSubs :: StkhldrSub -> Section
-    mkSubs (Client kWrd details) = Stk.tClientF kWrd details
-    mkSubs (Cstmr kWrd)          = Stk.tCustomerF kWrd
+    mkSubs (Client details) = Stk.tClientF progN details
+    mkSubs Cstmr            = Stk.tCustomerF progN
 
 -- ** General System Description
 

--- a/code/drasil-srs/lib/Drasil/SRS/DocumentLanguage/Core.hs
+++ b/code/drasil-srs/lib/Drasil/SRS/DocumentLanguage/Core.hs
@@ -128,9 +128,9 @@ newtype StkhldrSec = StkhldrProg [StkhldrSub]
 -- | Stakeholders subsections.
 data StkhldrSub where
   -- | May have a client.
-  Client :: CI -> Sentence -> StkhldrSub
+  Client :: Sentence -> StkhldrSub
   -- | May have a customer.
-  Cstmr  :: CI -> StkhldrSub
+  Cstmr  :: StkhldrSub
 
 -- ** General System Description Section
 
@@ -301,8 +301,8 @@ instance Multiplate DLPlate where
     intro' (IChar s1 s2 s3) = pure $ IChar s1 s2 s3
     intro' (IOrgSec s1) = pure $ IOrgSec s1
     stk (StkhldrProg progs) = StkhldrProg <$> traverse (stkSub p) progs
-    stk' (Client c s) = pure $ Client c s
-    stk' (Cstmr c) = pure (Cstmr c)
+    stk' (Client s) = pure $ Client s
+    stk' Cstmr = pure Cstmr
     gs (GSDProg x) = GSDProg <$> traverse (gsdSub p) x
     gs' (SysCntxt c) = pure $ SysCntxt c
     gs' (UsrChars c) = pure $ UsrChars c

--- a/code/drasil-srs/lib/Drasil/SRS/ExtractDocDesc.hs
+++ b/code/drasil-srs/lib/Drasil/SRS/ExtractDocDesc.hs
@@ -93,8 +93,8 @@ sentencePlate f = appendPlate (secConPlate (f . extractSents') $ f . concatMap g
       (IChar s1 s2 s3) -> concat [s1, s2, s3]
       (IOrgSec s1) -> maybeToList s1,
     stkSub = Constant . f <$> \case
-      (Client _ s) -> [s]
-      (Cstmr _) -> [],
+      (Client s) -> [s]
+      Cstmr -> [],
     pdSec = Constant . f <$> \(PDProg s secs pds) -> s : concatMap getSec secs ++ concatMap getPDSub pds,
     pdSub = Constant . f <$> \case
       (TermsAndDefs Nothing cs) -> def cs

--- a/code/drasil-srs/lib/Drasil/SRS/Sections/TableOfContents.hs
+++ b/code/drasil-srs/lib/Drasil/SRS/Sections/TableOfContents.hs
@@ -121,8 +121,8 @@ mktStkhldrSec (StkhldrProg l) =
   mkHeaderItem (namedRef SRS.stakeholderLabel $ titleize' Doc.stakeholder) $ map mktSub l
   where
     mktSub :: StkhldrSub -> Sentence
-    mktSub (Client _ _) = namedRef SRS.customerLabel $ D.toSent $ titleizeNP $ the Doc.customer
-    mktSub (Cstmr _)    = namedRef SRS.clientLabel   $ D.toSent $ titleizeNP $ the Doc.client
+    mktSub (Client _) = namedRef SRS.customerLabel $ D.toSent $ titleizeNP $ the Doc.customer
+    mktSub Cstmr      = namedRef SRS.clientLabel   $ D.toSent $ titleizeNP $ the Doc.client
 
 -- | Helper for creating the 'General System Description' section ToC entry
 mktGSDSec :: GSDSec -> ItemType


### PR DESCRIPTION
Contributes to #5414

Very similar to #5415, this PR reuses the "program name" field of the SRS encoding to automate the "program name" input in the `SRSDecl`.