### PR TITLE
Parameterized `file` in `FileSym` and removed it as a dependency for `ProgramSym`

### DIFF
--- a/code/drasil-code/lib/Language/Drasil/Code/Imperative/GenerateGOOL.hs
+++ b/code/drasil-code/lib/Language/Drasil/Code/Imperative/GenerateGOOL.hs
@@ -25,11 +25,11 @@ import Drasil.Metadata (watermark)
 import Drasil.System (HasSystemMeta(..))
 import Drasil.SRS (HasSmithEtAlSRS(..))
 
-import Drasil.GOOL (SVariable, SValue, Class, CSStateVar, NamedArgs, File,
-  OOProg, CS, FS, MS, VS, TypeData, ValueSym(..), Argument(..),
-  ValueExpression(..), InternalValueExp, OOValueExpression(..), SelfSym(..),
-  VariableValue(..), FuncAppStatement(..), OOFuncAppStatement(..), ClassSym(..),
-  CodeType(..), TypeElim(..), objMethodCallMixedArgs)
+import Drasil.GOOL (SVariable, SValue, Class, CSStateVar, NamedArgs, OOProg, CS,
+  FS, MS, VS, TypeData, ValueSym(..), Argument(..), ValueExpression(..),
+  InternalValueExp, OOValueExpression(..), SelfSym(..), VariableValue(..),
+  FuncAppStatement(..), OOFuncAppStatement(..), ClassSym(..), CodeType(..),
+  TypeElim(..), objMethodCallMixedArgs)
 import qualified Drasil.GOOL as OO (FileSym(..), ModuleSym(..))
 
 -- | Defines a GOOL module. If the user chose 'CommentMod', the module will have
@@ -37,9 +37,14 @@ import qualified Drasil.GOOL as OO (FileSym(..), ModuleSym(..))
 -- 'CommentFunc', a module-level Doxygen comment is still created, though it only
 -- documents the file name, because without this Doxygen will not find the
 -- function-level comments in the file.
-genModuleWithImports :: (OOProg r vis stmt mthd stvr attch prg) => Name -> Description ->
-  [Import] -> [GenState (Maybe (MS (r mthd)))] -> [GenState (Maybe (CS (r Class)))] ->
-  GenState (FS (r File))
+genModuleWithImports
+  :: (OOProg r vis stmt mthd stvr attch prg file)
+  => Name
+  -> Description
+  -> [Import]
+  -> [GenState (Maybe (MS (r mthd)))]
+  -> [GenState (Maybe (CS (r Class)))]
+  -> GenState (FS (r file))
 genModuleWithImports n desc is maybeMs maybeCs = do
   g <- get
   modify (\s -> s { currentModule = n })
@@ -52,9 +57,13 @@ genModuleWithImports n desc is maybeMs maybeCs = do
   return $ commMod $ OO.fileDoc $ OO.buildModule n is (catMaybes ms) (catMaybes cs)
 
 -- | Generates a module for when imports do not need to be explicitly stated.
-genModule :: (OOProg r vis stmt mthd stvr attch prg) => Name -> Description ->
-  [GenState (Maybe (MS (r mthd)))] -> [GenState (Maybe (CS (r Class)))] ->
-  GenState (FS (r File))
+genModule
+  :: (OOProg r vis stmt mthd stvr attch prg file)
+  => Name
+  -> Description
+  -> [GenState (Maybe (MS (r mthd)))]
+  -> [GenState (Maybe (CS (r Class)))]
+  -> GenState (FS (r file))
 genModule n desc = genModuleWithImports n desc []
 
 -- | Generates a Doxygen configuration file if the user has comments enabled.
@@ -185,8 +194,13 @@ fAppInOut m n ins outs both = do
 -- 'CommentFunc', a module-level Doxygen comment is still created, though it only
 -- documents the file name, because without this Doxygen will not find the
 -- function-level comments in the file.
-genModuleWithImportsProc :: (ProcProg r vis stmt mthd prg) => Name -> Description ->
-  [Import] -> [GenState (Maybe (MS (r mthd)))] -> GenState (FS (r File))
+genModuleWithImportsProc
+  :: (ProcProg r vis stmt mthd prg file)
+  => Name
+  -> Description
+  -> [Import]
+  -> [GenState (Maybe (MS (r mthd)))]
+  -> GenState (FS (r file))
 genModuleWithImportsProc n desc is maybeMs = do
   g <- get
   modify (\s -> s { currentModule = n })
@@ -198,8 +212,12 @@ genModuleWithImportsProc n desc is maybeMs = do
   return $ commMod $ Proc.fileDoc $ Proc.buildModule n is (catMaybes ms)
 
 -- | Generates a module for when imports do not need to be explicitly stated.
-genModuleProc :: (ProcProg r vis stmt mthd prg) => Name -> Description ->
-  [GenState (Maybe (MS (r mthd)))] -> GenState (FS (r File))
+genModuleProc
+  :: (ProcProg r vis stmt mthd prg file)
+  => Name
+  -> Description
+  -> [GenState (Maybe (MS (r mthd)))]
+  -> GenState (FS (r file))
 genModuleProc n desc = genModuleWithImportsProc n desc []
 
 -- | Function call generator.

--- a/code/drasil-code/lib/Language/Drasil/Code/Imperative/Generator.hs
+++ b/code/drasil-code/lib/Language/Drasil/Code/Imperative/Generator.hs
@@ -15,8 +15,8 @@ import Text.PrettyPrint.HughesPJ (empty, isEmpty, vcat)
 
 import Drasil.FileHandling (FileLayout, file, directory, exactFile, ps)
 import Language.Drasil
-import Drasil.GOOL (OOProg, File, FS, VisibilityTag(..), headers, sources,
-  mainMod, ProgData(..), initialState, FileData(..), modDoc)
+import Drasil.GOOL (OOProg, FS, VisibilityTag(..), headers, sources, mainMod,
+  ProgData(..), initialState, FileData(..), modDoc)
 import qualified Drasil.GOOL as OO (GSProgram, ProgramSym(..), unCI)
 import Drasil.GProc (ProcProg, NativeVector)
 import qualified Drasil.GProc as Proc (GSProgram, ProgramSym(..))
@@ -119,7 +119,7 @@ generator l dt sd chs cs = let
 
 data SomeProgGenerator where
   SomeProgGenerator
-    :: forall repr vis stmt mthd stvr attch prg. (OOProg repr vis stmt mthd stvr attch prg)
+    :: forall repr vis stmt mthd stvr attch prg file. (OOProg repr vis stmt mthd stvr attch prg file)
     => (repr prg -> ProgData) -> SomeProgGenerator
 
 -- | Generates a package with the given 'DrasilState'. The passed
@@ -176,7 +176,11 @@ insertFile (p, d) m =
 -- GOOL's static code analysis interpreter is called to initialize the state
 -- used by the language renderer.
 genPackage
-  :: (OOProg progRepr vis stmt mthd stvr attch prg, SoftwareDossierSym packRepr, Monad packRepr)
+  ::
+    ( OOProg progRepr vis stmt mthd stvr attch prg file
+    , SoftwareDossierSym packRepr
+    , Monad packRepr
+    )
   => (progRepr prg -> ProgData)
   -> GenState (packRepr PackageData)
 genPackage unRepr = do
@@ -217,7 +221,9 @@ genPackage unRepr = do
   return $ package pd (m:catMaybes [i,rm,d])
 
 -- | Generates an SCS program based on the problem and the user's design choices.
-genProgram :: (OOProg r vis stmt mthd stvr attch prg) => GenState (OO.GSProgram r prg)
+genProgram
+  :: (OOProg r vis stmt mthd stvr attch prg file)
+  => GenState (OO.GSProgram r prg)
 genProgram = do
   g <- get
   ms <- chooseModules $ g ^. modular
@@ -228,12 +234,15 @@ genProgram = do
 
 -- | Generates either a single module or many modules, based on the users choice
 -- of modularity.
-chooseModules :: (OOProg r vis stmt mthd stvr attch prg) => Modularity -> GenState [FS (r File)]
+chooseModules
+  :: (OOProg r vis stmt mthd stvr attch prg file)
+  => Modularity -> GenState [FS (r file)]
 chooseModules Unmodular = liftS genUnmodular
 chooseModules Modular = genModules
 
 -- | Generates an entire SCS program as a single module.
-genUnmodular :: (OOProg r vis stmt mthd stvr attch prg) => GenState (FS (r File))
+genUnmodular
+  :: (OOProg r vis stmt mthd stvr attch prg file) => GenState (FS (r file))
 genUnmodular = do
   g <- get
   umDesc <- unmodularDesc
@@ -252,7 +261,8 @@ genUnmodular = do
       ++ map (fmap Just) (concatMap genModClasses $ modules g))
 
 -- | Generates all modules for an SCS program.
-genModules :: (OOProg r vis stmt mthd stvr attch prg) => GenState [FS (r File)]
+genModules
+  :: (OOProg r vis stmt mthd stvr attch prg file) => GenState [FS (r file)]
 genModules = do
   g <- get
   mn     <- genMain
@@ -271,7 +281,7 @@ genModules = do
 generateCodeProc
   ::
     ( NativeVector progRepr
-    , ProcProg progRepr vis stmt mthd prg
+    , ProcProg progRepr vis stmt mthd prg file
     , SoftwareDossierSym packRepr
     , Monad packRepr
     )
@@ -302,7 +312,7 @@ generateCodeProc l unReprProg unReprPack g =
 genPackageProc
   ::
     ( NativeVector progRepr
-    , ProcProg progRepr vis stmt mthd prg
+    , ProcProg progRepr vis stmt mthd prg file
     , SoftwareDossierSym packRepr
     , Monad packRepr
     )
@@ -344,7 +354,7 @@ genPackageProc unRepr = do
 
 -- | Generates an SCS program based on the problem and the user's design choices.
 genProgramProc
-  :: (NativeVector r, ProcProg r vis stmt mthd prg)
+  :: (NativeVector r, ProcProg r vis stmt mthd prg file)
   => GenState (Proc.GSProgram r prg)
 genProgramProc = do
   g <- get
@@ -356,15 +366,15 @@ genProgramProc = do
 -- | Generates either a single module or many modules, based on the users choice
 -- of modularity.
 chooseModulesProc
-  :: (NativeVector r, ProcProg r vis stmt mthd prg)
-  => Modularity -> GenState [FS (r File)]
+  :: (NativeVector r, ProcProg r vis stmt mthd prg file)
+  => Modularity -> GenState [FS (r file)]
 chooseModulesProc Unmodular = liftS genUnmodularProc
 chooseModulesProc Modular = genModulesProc
 
 -- | Generates an entire SCS program as a single module.
 genUnmodularProc
-  :: (NativeVector r, ProcProg r vis stmt mthd prg)
-  => GenState (FS (r File))
+  :: (NativeVector r, ProcProg r vis stmt mthd prg file)
+  => GenState (FS (r file))
 genUnmodularProc = do
   g <- get
   umDesc <- unmodularDesc
@@ -383,8 +393,8 @@ genUnmodularProc = do
 
 -- | Generates all modules for an SCS program.
 genModulesProc
-  :: ( NativeVector r, ProcProg r vis stmt mthd prg)
-  => GenState [FS (r File)]
+  :: ( NativeVector r, ProcProg r vis stmt mthd prg file)
+  => GenState [FS (r file)]
 genModulesProc = do
   g <- get
   mn     <- genMainProc

--- a/code/drasil-code/lib/Language/Drasil/Code/Imperative/Import.hs
+++ b/code/drasil-code/lib/Language/Drasil/Code/Imperative/Import.hs
@@ -48,8 +48,8 @@ import Language.Drasil.Mod (Func(..), FuncData(..), FuncDef(..), FuncStmt(..),
 import qualified Language.Drasil.Mod as M (Class(..))
 import Language.Drasil.Printers (showHasSymbImpl)
 
-import Drasil.GOOL (Label, File, Body, Block, SVariable, SValue, Class,
-  CSStateVar, NamedArgs, Initializers, OOProg, CS, FS, MS, VS, AttachmentSym(..),
+import Drasil.GOOL (Label, Body, Block, SVariable, SValue, Class, CSStateVar,
+  NamedArgs, Initializers, OOProg, CS, FS, MS, VS, AttachmentSym(..),
   bodyStatements, BlockSym(..), TypeSym(..), VariableSym(..), VariableElim(..),
   VariableValue(..), ScopeSym(..), ScopeData, OOVariableSym(..), SelfSym(..),
   instanceVarSelf, VariableElim(..), ($->), ValueSym(..), Literal(..),
@@ -247,7 +247,7 @@ mkParam p = do
 
 -- | Generates a public function.
 publicFunc
-  :: (OOProg r vis stmt mthd stvr attch prg)
+  :: (OOProg r vis stmt mthd stvr attch prg file)
   => Label
   -> VS (r TypeData)
   -> Description
@@ -261,7 +261,7 @@ publicFunc n t desc ps r b = do
 
 -- | Generates a public method.
 publicMethod
-  :: (OOProg r vis stmt mthd stvr attch prg)
+  :: (OOProg r vis stmt mthd stvr attch prg file)
   => Label
   -> VS (r TypeData)
   -> Description
@@ -273,32 +273,61 @@ publicMethod n t = do
   genMethod (method n public instanceLevel t) n
 
 -- | Generates a private method.
-privateMethod :: (OOProg r vis stmt mthd stvr attch prg) => Label -> VS (r TypeData) -> Description ->
-  [ParameterChunk] -> Maybe Description -> [MS (r Block)] ->
-  GenState (MS (r mthd))
+privateMethod
+  :: (OOProg r vis stmt mthd stvr attch prg file)
+  => Label
+  -> VS (r TypeData)
+  -> Description
+  -> [ParameterChunk]
+  -> Maybe Description
+  -> [MS (r Block)]
+  -> GenState (MS (r mthd))
 privateMethod n t = do
   genMethod (method n private instanceLevel t) n
 
 -- | Generates a public function, defined by its inputs and outputs.
-publicInOutFunc :: (OOProg r vis stmt mthd stvr attch prg) => Label -> Description -> [CodeVarChunk] ->
-  [CodeVarChunk] -> [MS (r Block)] -> GenState (MS (r mthd))
+publicInOutFunc
+  :: (OOProg r vis stmt mthd stvr attch prg file)
+  => Label
+  -> Description
+  -> [CodeVarChunk]
+  -> [CodeVarChunk]
+  -> [MS (r Block)]
+  -> GenState (MS (r mthd))
 publicInOutFunc n = genInOutFunc (inOutFunc n public) (docInOutFunc n public) n
 
 -- | Generates a private method, defined by its inputs and outputs.
-privateInOutMethod :: (OOProg r vis stmt mthd stvr attch prg) => Label -> Description -> [CodeVarChunk] ->
-  [CodeVarChunk] -> [MS (r Block)] -> GenState (MS (r mthd))
+privateInOutMethod
+  :: (OOProg r vis stmt mthd stvr attch prg file)
+  => Label
+  -> Description
+  -> [CodeVarChunk]
+  -> [CodeVarChunk]
+  -> [MS (r Block)]
+  -> GenState (MS (r mthd))
 privateInOutMethod n = genInOutFunc (inOutMethod n private instanceLevel)
   (docInOutMethod n private instanceLevel) n
 
 -- | Generates a constructor.
-genConstructor :: (OOProg r vis stmt mthd stvr attch prg) => Label -> Description -> [ParameterChunk] ->
-  [MS (r Block)] -> GenState (MS (r mthd))
+genConstructor
+  :: (OOProg r vis stmt mthd stvr attch prg file)
+  => Label
+  -> Description
+  -> [ParameterChunk]
+  -> [MS (r Block)]
+  -> GenState (MS (r mthd))
 genConstructor n desc p = do
   genMethod nonInitConstructor n desc p Nothing
 
 -- | Generates a constructor that includes initialization of variables.
-genInitConstructor :: (OOProg r vis stmt mthd stvr attch prg) => Label -> Description -> [ParameterChunk]
-  -> Initializers r -> [MS (r Block)] -> GenState (MS (r mthd))
+genInitConstructor
+  :: (OOProg r vis stmt mthd stvr attch prg file)
+  => Label
+  -> Description
+  -> [ParameterChunk]
+  -> Initializers r
+  -> [MS (r Block)]
+  -> GenState (MS (r mthd))
 genInitConstructor n desc p is = genMethod (`constructor` is) n desc p
   Nothing
 
@@ -306,7 +335,7 @@ genInitConstructor n desc p is = genMethod (`constructor` is) n desc p
 -- parameters are the method's name, description, list of parameters,
 -- description of what is returned (if applicable), and body.
 genMethod
-  :: (OOProg r vis stmt mthd stvr attch prg)
+  :: (OOProg r vis stmt mthd stvr attch prg file)
   => ([MS (r ParamData)] -> MS (r Body) -> MS (r mthd))
   -> Label
   -> Description
@@ -613,8 +642,8 @@ elementSetBoolBfunc SContains = OO.contains
 -- medium hacks --
 
 -- | Converts a 'Mod' to GOOL.
-genModDef :: (OOProg r vis stmt mthd stvr attch prg) =>
-  Mod -> GenState (FS (r File))
+genModDef :: (OOProg r vis stmt mthd stvr attch prg file) =>
+  Mod -> GenState (FS (r file))
 genModDef (Mod n desc is cs fs) = genModuleWithImports n desc is (map (fmap
   Just . genFunc publicFunc []) fs)
   (case cs of [] -> []
@@ -622,17 +651,21 @@ genModDef (Mod n desc is cs fs) = genModuleWithImports n desc is (map (fmap
                 map (fmap Just . genClass auxClass) cls)
 
 -- | Converts a 'Mod'\'s functions to GOOL.
-genModFuncs :: (OOProg r vis stmt mthd stvr attch prg) => Mod -> [GenState (MS (r mthd))]
+genModFuncs
+  :: (OOProg r vis stmt mthd stvr attch prg file)
+  => Mod -> [GenState (MS (r mthd))]
 genModFuncs (Mod _ _ _ _ fs) = map (genFunc publicFunc []) fs
 
 -- | Converts a 'Mod'\'s classes to GOOL.
-genModClasses :: (OOProg r vis stmt mthd stvr attch prg) => Mod -> [GenState (CS (r Class))]
+genModClasses
+  :: (OOProg r vis stmt mthd stvr attch prg file)
+  => Mod -> [GenState (CS (r Class))]
 genModClasses (Mod _ _ _ cs _) = map (genClass auxClass) cs
 
 -- | Converts a Class (from the Mod AST) to GOOL.
 -- The class generator to use is passed as a parameter.
 genClass
-  :: (OOProg r vis stmt mthd stvr attch prg)
+  :: (OOProg r vis stmt mthd stvr attch prg file)
   => (Name -> Maybe Name -> Description -> [CSStateVar r stvr] -> GenState [MS (r mthd)] -> GenState [MS (r mthd)] -> GenState (CS (r Class)))
   -> M.Class
   -> GenState (CS (r Class))
@@ -651,7 +684,7 @@ genClass f (M.ClassDef n i desc svs cs ms) = let svar Pub = pubDVar
 -- the list of StateVariables is needed so they can be included in the list of
 -- declared variables.
 genFunc
-  :: (OOProg r vis stmt mthd stvr attch prg)
+  :: (OOProg r vis stmt mthd stvr attch prg file)
   => (Name -> VS (r TypeData) -> Description -> [ParameterChunk] -> Maybe Description -> [MS (r Block)] -> GenState (MS (r mthd)))
   -> [StateVariable]
   -> Func
@@ -804,7 +837,7 @@ convStmt (FAppend a b) = do
 -- | Generates a function that reads a file whose format is based on the passed
 -- 'DataDesc'.
 genDataFunc
-  :: (OOProg r vis stmt mthd stvr attch prg)
+  :: (OOProg r vis stmt mthd stvr attch prg file)
   => Name -> Description -> DataDesc -> GenState (MS (r mthd))
 genDataFunc nameTitle desc ddef = do
   let parms = getInputs ddef
@@ -1069,10 +1102,10 @@ genModDefProc
     , List r
     , Reference r
     , OO.Set r
-    , ProcProg r vis stmt mthd prg
+    , ProcProg r vis stmt mthd prg file
     , TypeElim r
     )
-  => Mod -> GenState (FS (r File))
+  => Mod -> GenState (FS (r file))
 genModDefProc (Mod n desc is cs fs) = case cs of
   [] -> genModuleWithImportsProc n desc is
           (map (fmap Just . genFuncProc publicFuncProc []) fs)

--- a/code/drasil-code/lib/Language/Drasil/Code/Imperative/Modules.hs
+++ b/code/drasil-code/lib/Language/Drasil/Code/Imperative/Modules.hs
@@ -24,7 +24,7 @@ import Language.Drasil (Constraint(..), RealInterval(..), HasSpace(typ),
   Space(..))
 import Language.Drasil.Printers (showHasSymbImpl, PrintingInformation,
   oneLineCodeExprDoc)
-import Drasil.GOOL (Body, Block, SVariable, SValue, File, CS, FS, MS, CSStateVar,
+import Drasil.GOOL (Body, Block, SVariable, SValue, CS, FS, MS, CSStateVar,
   Class, OOProg, BodySym(..), bodyStatements, oneLiner, BlockSym(..),
   AttachmentSym(..), TypeSym(..), VariableSym(..), ScopeSym(..), ScopeData,
   Literal(..), VariableValue(..), CommandLineArgs(..), NumericExpression(..),
@@ -85,7 +85,7 @@ type ConstraintCE = Constraint CodeExpr
 ---- MAIN ---
 
 -- | Generates a controller module.
-genMain :: (OOProg r vis stmt mthd stvr attch prg) => GenState (FS (r File))
+genMain :: (OOProg r vis stmt mthd stvr attch prg file) => GenState (FS (r file))
 genMain = genModule "Control" "Controls the flow of the program"
   [genMainFunc] []
 
@@ -94,7 +94,9 @@ genMain = genModule "Control" "Controls the flow of the program"
 -- functions for reading input values, calculating derived inputs, checking
 -- constraints, calculating outputs, and printing outputs.
 -- Returns Nothing if the user chose to generate a library.
-genMainFunc :: (OOProg r vis stmt mthd stvr attch prg) => GenState (Maybe (MS (r mthd)))
+genMainFunc
+  :: (OOProg r vis stmt mthd stvr attch prg file)
+  => GenState (Maybe (MS (r mthd)))
 genMainFunc = do
     g <- get
     let mainFunc Library = return Nothing
@@ -234,11 +236,14 @@ initLogFileVar l scp = [varDec varLogFile scp | LogVar `elem` l]
 ------- INPUT ----------
 
 -- | Generates a single module containing all input-related components.
-genInputMod :: (OOProg r vis stmt mthd stvr attch prg) => GenState [FS (r File)]
+genInputMod
+  :: (OOProg r vis stmt mthd stvr attch prg file) => GenState [FS (r file)]
 genInputMod = do
   ipDesc <- modDesc inputParametersDesc
   cname <- genICName InputParameters
-  let genMod :: (OOProg r vis stmt mthd stvr attch prg) => Maybe (CS (r Class)) -> GenState (FS (r File))
+  let genMod
+        :: (OOProg r vis stmt mthd stvr attch prg file)
+        => Maybe (CS (r Class)) -> GenState (FS (r file))
       genMod Nothing = genModule cname ipDesc [genInputFormat Pub,
         genInputDerived Pub, genInputConstraints Pub] []
       genMod _ = genModule cname ipDesc [] [genInputClass Primary]
@@ -261,7 +266,7 @@ constVarFunc Const = constVar public
 -- variables. If the InputParameters constructor is also exported, then the
 -- generated class also contains the input-related functions as private methods.
 genInputClass
-  :: (OOProg r vis stmt mthd stvr attch prg)
+  :: (OOProg r vis stmt mthd stvr attch prg file)
   => ClassType -> GenState (Maybe (CS (r Class)))
 genInputClass scp = do
   g <- get
@@ -271,17 +276,19 @@ genInputClass scp = do
       cs = g ^. constDefns
       filt :: (CodeIdea c) => [c] -> [c]
       filt = filter ((Just cname ==) . flip Map.lookup (clsMap g) . codeName)
-      constructors :: (OOProg r vis stmt mthd stvr attch prg) => GenState [MS (r mthd)]
+      constructors
+        :: (OOProg r vis stmt mthd stvr attch prg file) => GenState [MS (r mthd)]
       constructors = if cname `elem` defSet g
         then concat <$> mapM (fmap maybeToList) [genInputConstructor]
         else return []
-      methods :: (OOProg r vis stmt mthd stvr attch prg) => GenState [MS (r mthd)]
+      methods
+        :: (OOProg r vis stmt mthd stvr attch prg file) => GenState [MS (r mthd)]
       methods = if cname `elem` defSet g
         then concat <$> mapM (fmap maybeToList) [genInputFormat Priv,
         genInputDerived Priv, genInputConstraints Priv]
         else return []
       genClass
-        :: (OOProg r vis stmt mthd stvr attch prg)
+        :: (OOProg r vis stmt mthd stvr attch prg file)
         => [CodeVarChunk] -> [CodeDefinition] -> GenState (Maybe (CS (r Class)))
       genClass [] [] = return Nothing
       genClass inps csts = do
@@ -302,7 +309,9 @@ genInputClass scp = do
 -- | Generates a constructor for the input class, where the constructor calls the
 -- input-related functions. Returns 'Nothing' if no input-related functions are
 -- generated.
-genInputConstructor :: (OOProg r vis stmt mthd stvr attch prg) => GenState (Maybe (MS (r mthd)))
+genInputConstructor
+  :: (OOProg r vis stmt mthd stvr attch prg file)
+  => GenState (Maybe (MS (r mthd)))
 genInputConstructor = do
   g <- get
   ipName <- genICName InputParameters
@@ -323,7 +332,7 @@ genInputConstructor = do
 
 -- | Generates a function for calculating derived inputs.
 genInputDerived
-  :: (OOProg r vis stmt mthd stvr attch prg)
+  :: (OOProg r vis stmt mthd stvr attch prg file)
   => VisibilityTag -> GenState (Maybe (MS (r mthd)))
 genInputDerived s = do
   g <- get
@@ -333,7 +342,7 @@ genInputDerived s = do
       getFunc Pub = publicInOutFunc
       getFunc Priv = privateInOutMethod
       genDerived
-        :: (OOProg r vis stmt mthd stvr attch prg)
+        :: (OOProg r vis stmt mthd stvr attch prg file)
         => Bool -> GenState (Maybe (MS (r mthd)))
       genDerived False = return Nothing
       genDerived _ = do
@@ -347,7 +356,7 @@ genInputDerived s = do
 
 -- | Generates function that checks constraints on the input.
 genInputConstraints
-  :: (OOProg r vis stmt mthd stvr attch prg)
+  :: (OOProg r vis stmt mthd stvr attch prg file)
   => VisibilityTag -> GenState (Maybe (MS (r mthd)))
 genInputConstraints s = do
   g <- get
@@ -357,7 +366,7 @@ genInputConstraints s = do
       getFunc Pub = publicFunc
       getFunc Priv = privateMethod
       genConstraints
-        :: (OOProg r vis stmt mthd stvr attch prg)
+        :: (OOProg r vis stmt mthd stvr attch prg file)
         => Bool -> GenState (Maybe (MS (r mthd)))
       genConstraints False = return Nothing
       genConstraints _ = do
@@ -662,7 +671,7 @@ printExpr e     pinfo = [printStr $ " " ++ render (parens (oneLineCodeExprDoc pi
 
 -- | | Generates a function for reading inputs from a file.
 genInputFormat
-  :: (OOProg r vis stmt mthd stvr attch prg)
+  :: (OOProg r vis stmt mthd stvr attch prg file)
   => VisibilityTag -> GenState (Maybe (MS (r mthd)))
 genInputFormat s = do
   g <- get
@@ -672,7 +681,7 @@ genInputFormat s = do
   let getFunc Pub = publicInOutFunc
       getFunc Priv = privateInOutMethod
       genInFormat
-        :: (OOProg r vis stmt mthd stvr attch prg)
+        :: (OOProg r vis stmt mthd stvr attch prg file)
         => Bool -> GenState (Maybe (MS (r mthd)))
       genInFormat False = return Nothing
       genInFormat _ = do
@@ -705,7 +714,8 @@ genSampleInput = do
 ----- CONSTANTS -----
 
 -- | Generates a module containing the class where constants are stored.
-genConstMod :: (OOProg r vis stmt mthd stvr attch prg) => GenState [FS (r File)]
+genConstMod
+  :: (OOProg r vis stmt mthd stvr attch prg file) => GenState [FS (r file)]
 genConstMod = do
   cDesc <- modDesc $ liftS constModDesc
   cName <- genICName Constants
@@ -714,7 +724,7 @@ genConstMod = do
 -- | Generates a class to store constants, if constants are mapped to the
 -- Constants class in the class definition map, otherwise returns Nothing.
 genConstClass
-  :: (OOProg r vis stmt mthd stvr attch prg)
+  :: (OOProg r vis stmt mthd stvr attch prg file)
   => ClassType -> GenState (Maybe (CS (r Class)))
 genConstClass scp = do
   g <- get
@@ -722,7 +732,7 @@ genConstClass scp = do
   cname <- genICName Constants
   let cs = g ^. constDefns
       genClass
-        :: (OOProg r vis stmt mthd stvr attch prg)
+        :: (OOProg r vis stmt mthd stvr attch prg file)
         => [CodeDefinition] -> GenState (Maybe (CS (r Class)))
       genClass [] = return Nothing
       genClass vs = do
@@ -742,7 +752,8 @@ genConstClass scp = do
 ------- CALC ----------
 
 -- | Generates a module containing calculation functions.
-genCalcMod :: (OOProg r vis stmt mthd stvr attch prg) => GenState (FS (r File))
+genCalcMod
+  :: (OOProg r vis stmt mthd stvr attch prg file) => GenState (FS (r file))
 genCalcMod = do
   g <- get
   cName <- genICName Calculations
@@ -754,7 +765,7 @@ genCalcMod = do
 -- For solving ODEs, the 'ExtLibState' containing the information needed to
 -- generate code is found by looking it up in the external library map.
 genCalcFunc
-  :: (OOProg r vis stmt mthd stvr attch prg)
+  :: (OOProg r vis stmt mthd stvr attch prg file)
   => CodeDefinition -> GenState (MS (r mthd))
 genCalcFunc cdef = do
   g <- get
@@ -861,20 +872,23 @@ genCaseBlock t v c cs = do
 ----- OUTPUT -------
 
 -- | Generates a module containing the function for printing outputs.
-genOutputMod :: (OOProg r vis stmt mthd stvr attch prg) => GenState [FS (r File)]
+genOutputMod
+  :: (OOProg r vis stmt mthd stvr attch prg file) => GenState [FS (r file)]
 genOutputMod = do
   ofName <- genICName OutputFormat
   ofDesc <- modDesc $ liftS outputFormatDesc
   liftS $ genModule ofName ofDesc [genOutputFormat] []
 
 -- | Generates a function for printing output values.
-genOutputFormat :: (OOProg r vis stmt mthd stvr attch prg) => GenState (Maybe (MS (r mthd)))
+genOutputFormat
+  :: (OOProg r vis stmt mthd stvr attch prg file)
+  => GenState (Maybe (MS (r mthd)))
 genOutputFormat = do
   g <- get
   modify (\st -> st {currentScope = Local})
   woName <- genICName WriteOutput
   let genOutput
-        :: (OOProg r vis stmt mthd stvr attch prg)
+        :: (OOProg r vis stmt mthd stvr attch prg file)
         => Maybe String -> GenState (Maybe (MS (r mthd)))
       genOutput Nothing = return Nothing
       genOutput (Just _) = do
@@ -901,8 +915,8 @@ genOutputFormat = do
 
 -- | Generates a controller module.
 genMainProc
-  :: (NativeVector r, ProcProg r vis stmt mthd prg)
-  => GenState (FS (r File))
+  :: (NativeVector r, ProcProg r vis stmt mthd prg file)
+  => GenState (FS (r file))
 genMainProc = genModuleProc "Control" "Controls the flow of the program"
   [genMainFuncProc]
 
@@ -1015,14 +1029,14 @@ checkConstClass = do
 
 -- | Generates a single module containing all input-related components.
 genInputModProc
-  :: (NativeVector r, ProcProg r vis stmt mthd prg)
-  => GenState [FS (r File)]
+  :: (NativeVector r, ProcProg r vis stmt mthd prg file)
+  => GenState [FS (r file)]
 genInputModProc = do
   ipDesc <- modDesc inputParametersDesc
   cname <- genICName InputParameters
   let genMod
-        :: (NativeVector r, ProcProg r vis stmt mthd prg)
-        => Bool -> GenState (FS (r File))
+        :: (NativeVector r, ProcProg r vis stmt mthd prg file)
+        => Bool -> GenState (FS (r file))
       genMod False = genModuleProc cname ipDesc [genInputFormatProc Pub,
         genInputDerivedProc Pub, genInputConstraintsProc Pub]
       genMod True = error "genInputModProc: Procedural renderers do not support bundled inputs"
@@ -1068,8 +1082,8 @@ getInputDeclProc = do
 
 -- | Generates a module containing calculation functions.
 genCalcModProc
-  :: (NativeVector r, ProcProg r vis stmt mthd prg)
-  => GenState (FS (r File))
+  :: (NativeVector r, ProcProg r vis stmt mthd prg file)
+  => GenState (FS (r file))
 genCalcModProc = do
   g <- get
   cName <- genICName Calculations
@@ -1680,8 +1694,8 @@ printConstraintProc c = do
 
 -- | Generates a module containing the function for printing outputs.
 genOutputModProc
-  :: (NativeVector r, ProcProg r vis stmt mthd prg)
-  => GenState [FS (r File)]
+  :: (NativeVector r, ProcProg r vis stmt mthd prg file)
+  => GenState [FS (r file)]
 genOutputModProc = do
   ofName <- genICName OutputFormat
   ofDesc <- modDesc $ liftS outputFormatDesc

--- a/code/drasil-code/test/FileTests.hs
+++ b/code/drasil-code/test/FileTests.hs
@@ -14,14 +14,14 @@ import qualified Drasil.GProc as GProc (GSProgram, ProgramSym(..), FileSym(..),
 
 -- | Creates a program in GOOL to test reading and writing to files.
 fileTestsOO
-  :: (OOProg r vis stmt mthd stvr attch prg)
+  :: (OOProg r vis stmt mthd stvr attch prg file)
   => OO.GSProgram r prg
 fileTestsOO = OO.prog "FileTests" "" [OO.fileDoc (OO.buildModule "FileTests" []
   [fileTestMethod] [])]
 
 -- | Creates a program in GProc to test reading and writing to files.
 fileTestsProc
-  :: (ProcProg r vis stmt mthd prg)
+  :: (ProcProg r vis stmt mthd prg file)
   => GProc.GSProgram r prg
 fileTestsProc = GProc.prog "FileTests" "" [GProc.fileDoc (GProc.buildModule
   "FileTests" [] [fileTestMethod])]

--- a/code/drasil-code/test/GOOL/Observer.hs
+++ b/code/drasil-code/test/GOOL/Observer.hs
@@ -1,7 +1,7 @@
 -- | Part of the PatternTest GOOL tests. Defines an Observer class.
 module GOOL.Observer (observer, observerName, printNum, x) where
 
-import Drasil.GOOL (File, SVariable, Class, OOProg, CS, FS, MS, FileSym(..),
+import Drasil.GOOL (SVariable, Class, OOProg, CS, FS, MS, FileSym(..),
   AttachmentSym(..), oneLiner, TypeSym(..), PrintConsole(..), VariableSym(..),
   SelfSym(..), instanceVarSelf, Literal(..), VariableValue(..), OOVariableValue,
   VisibilitySym(..), OOMethodSym(..), initializer, StateVarSym(..), ClassSym(..),
@@ -17,7 +17,7 @@ observerDesc = "This is an arbitrary class acting as an Observer"
 printNum = "printNum"
 
 -- | Creates the observer class.
-observer :: (OOProg r vis stmt mthd stvr attch prg) => FS (r File)
+observer :: (OOProg r vis stmt mthd stvr attch prg file) => FS (r file)
 observer = fileDoc (buildModule observerName [] [] [docClass observerDesc
   helperClass])
 

--- a/code/drasil-code/test/GOOL/PatternTest.hs
+++ b/code/drasil-code/test/GOOL/PatternTest.hs
@@ -39,7 +39,7 @@ newObserver = extNewObj observerName observerType []
 -- | Creates the pattern test program.
 patternTest
   ::
-    ( OOProg r vis stmt mthd stvr attch prg
+    ( OOProg r vis stmt mthd stvr attch prg file
     , GetSet r
     , StrategyPattern r stmt
     , ObserverPattern r stmt
@@ -50,7 +50,7 @@ patternTest = prog progName "" [fileDoc (buildModule progName []
 -- | Creates the main function for PatternTest.
 patternTestMainMethod
   ::
-    ( OOProg r vis stmt mthd stvr attch prg
+    ( OOProg r vis stmt mthd stvr attch prg file
     , GetSet r
     , StrategyPattern r stmt
     , ObserverPattern r stmt

--- a/code/drasil-code/test/HelloWorld.hs
+++ b/code/drasil-code/test/HelloWorld.hs
@@ -25,14 +25,14 @@ import Prelude hiding (return,print,log,exp,sin,cos,tan,const)
 import Helper (helperOO, helperProc)
 
 -- | Creates the HelloWorld program and necessary files.
-helloWorldOO :: (OOProg r vis stmt mthd stvr attch prg) => OO.GSProgram r prg
+helloWorldOO :: (OOProg r vis stmt mthd stvr attch prg file) => OO.GSProgram r prg
 helloWorldOO = OO.prog "HelloWorld" "" [OO.docMod description watermark
   ["Brooks MacLachlan"] "" $ OO.fileDoc (OO.buildModule "HelloWorld" []
   [helloWorldMainOO] [helloWorldClass]), helperOO]
 
 -- | Creates the HelloWorld program and necessary files.
 helloWorldProc
-  :: (ProcProg r vis stmt mthd prg)
+  :: (ProcProg r vis stmt mthd prg file)
   => GProc.GSProgram r prg
 helloWorldProc = GProc.prog "HelloWorld" "" [GProc.docMod descriptionProc
   watermark
@@ -49,7 +49,7 @@ myOtherList :: (VariableSym r) => SVariable r
 myOtherList = var "myOtherList" (listType double)
 
 -- | Main function. Initializes variables and combines all the helper functions defined below.
-helloWorldMainOO :: (OOProg r vis stmt mthd stvr attch prg) => MS (r mthd)
+helloWorldMainOO :: (OOProg r vis stmt mthd stvr attch prg file) => MS (r mthd)
 helloWorldMainOO = mainFunction (body ([ helloInitVariables, objectTests] ++ listSliceTests
     ++ [block [printLn $ litString "", ifCond [
       (valueOf (var "b" int) ?>= litInt 6, bodyStatements [
@@ -61,7 +61,7 @@ helloWorldMainOO = mainFunction (body ([ helloInitVariables, objectTests] ++ lis
 
 -- | Main function. Initializes variables and combines all the helper functions defined below.
 helloWorldMainProc
-  :: (ProcProg r vis stmt mthd prg)
+  :: (ProcProg r vis stmt mthd prg file)
   => MS (r mthd)
 helloWorldMainProc = mainFunction (body ([ helloInitVariables] ++ listSliceTests
     ++ [block [printLn $ litString "", ifCond [
@@ -138,7 +138,7 @@ helloInitVariables = block [comment "Initializing variables",
   assert (contains (valueOf (var "s" (setType int))) (litInt 7))
     (litString "Set s should contain 7")]
 
-objectTests :: (OOProg r vis stmt mthd stvr attch prg) => MS (r Block)
+objectTests :: (OOProg r vis stmt mthd stvr attch prg file) => MS (r Block)
 objectTests = block [comment "Object tests",
   varDecDef (var "t1" (obj "TestClass")) mainFn (newObj (obj "TestClass") [litInt 5]),
   varDecDef (var "t2" (obj "TestClass")) mainFn (newObj (obj "TestClass") [litInt 4]),
@@ -457,7 +457,7 @@ helloTryCatch
 helloTryCatch = tryCatch (oneLiner (throw "Good-bye!"))
   (oneLiner (printStrLn "Caught intentional error"))
 
-helloWorldClass :: (OOProg r vis stmt mthd stvr attch prg) => CS (r Class)
+helloWorldClass :: (OOProg r vis stmt mthd stvr attch prg file) => CS (r Class)
 helloWorldClass = extraClass "TestClass" Nothing
   [stateVar public instanceLevel (var "a" int)]
   [initializer [param $ var "a" int]

--- a/code/drasil-code/test/Helper.hs
+++ b/code/drasil-code/test/Helper.hs
@@ -1,7 +1,7 @@
 -- | Makes the helper file for the GOOL HelloWorld tests.
 module Helper (helperOO, helperProc) where
 
-import Drasil.GOOL (OOProg, File, FS, MS, bodyStatements, TypeSym(..),
+import Drasil.GOOL (OOProg, FS, MS, bodyStatements, TypeSym(..),
   DeclStatement(..), AssignStatement, ControlStatement(..),
   (&=), VariableSym(var), Literal(..), VariableValue(..),
   NumericExpression(..), VisibilitySym(..), ParameterSym(..), MethodSym(..),
@@ -14,14 +14,14 @@ import Prelude hiding (return,print,log,exp,sin,cos,tan)
 
 -- | Creates Helper module that contains an addition function.
 helperOO
-  :: (OOProg r vis stmt mthd stvr attch prg)
-  => FS (r File)
+  :: (OOProg r vis stmt mthd stvr attch prg file)
+  => FS (r file)
 helperOO = OO.fileDoc (OO.buildModule "Helper" [] [doubleAndAdd] [])
 
 -- | Creates Helper module that contains an addition function.
 helperProc
-  :: (ProcProg r vis stmt mthd prg)
-  => FS (r File)
+  :: (ProcProg r vis stmt mthd prg file)
+  => FS (r file)
 helperProc = GProc.fileDoc (GProc.buildModule "Helper" [] [doubleAndAdd])
 
 -- | Creates a function that doubles the arguments and adds them together.

--- a/code/drasil-code/test/Main.hs
+++ b/code/drasil-code/test/Main.hs
@@ -59,8 +59,8 @@ codeGenTestGroup =
 
 goolTestGroup
   :: String
-  -> ( forall r vis stmt mthd stvr attch prg.
-       ( OOProg r vis stmt mthd stvr attch prg
+  -> ( forall r vis stmt mthd stvr attch prg file.
+       ( OOProg r vis stmt mthd stvr attch prg file
        , GetSet r
        , StrategyPattern r stmt
        , ObserverPattern r stmt
@@ -82,12 +82,12 @@ goolTestGroup n p =
 gProcTestGroup
   :: String
   ->
-    ( forall r vis stmt mthd prg.
+    ( forall r vis stmt mthd prg file.
       ( Literal r
       , Comparison r
       , DeclStatement r stmt
       , ControlStatement r stmt
-      , ProcProg r vis stmt mthd prg
+      , ProcProg r vis stmt mthd prg file
       )
     => Proc.GSProgram r prg)
   -> TestTree
@@ -103,12 +103,12 @@ gProcTestGroup n p =
 gProcVectorTestGroup
   :: String
   ->
-    ( forall r vis stmt mthd prg.
+    ( forall r vis stmt mthd prg file.
       ( Comparison r
       , NativeVector r
       , DeclStatement r stmt
       , ControlStatement r stmt
-      , ProcProg r vis stmt mthd prg
+      , ProcProg r vis stmt mthd prg file
       )
     => Proc.GSProgram r prg
     )
@@ -125,17 +125,17 @@ gProcVectorTestGroup n p =
 genCodeProcNoMake
   ::
     ( NativeVector r
-    , ProcProg r vis stmt mthd ProgData
+    , ProcProg r vis stmt mthd ProgData file
     , Monad r'
     )
   => (r ProgData -> ProgData)
   -> (r' PackageData -> PackageData)
   ->
-    ( forall s vis' stmt' mthd' prg'.
+    ( forall s vis' stmt' mthd' prg' file'.
       ( Comparison s
       , NativeVector s
       , DeclStatement s stmt'
-      , ProcProg s vis' stmt' mthd' prg'
+      , ProcProg s vis' stmt' mthd' prg' file'
       )
     => Proc.GSProgram s prg'
     )
@@ -148,7 +148,7 @@ genCodeProcNoMake unRepr unRepr' p =
 
 genCodeGOOL
   ::
-    ( OOProg r vis stmt mthd stvr attch ProgData
+    ( OOProg r vis stmt mthd stvr attch ProgData file
     , GetSet r
     , StrategyPattern r stmt
     , ObserverPattern r stmt
@@ -157,8 +157,8 @@ genCodeGOOL
     )
   => (r ProgData -> ProgData)
   -> (r' PackageData -> PackageData)
-  -> ( forall s vis' stmt' mthd' stvr' attch' prg'.
-       ( OOProg s vis' stmt' mthd' stvr' attch' prg'
+  -> ( forall s vis' stmt' mthd' stvr' attch' prg' file'.
+       ( OOProg s vis' stmt' mthd' stvr' attch' prg' file'
        , GetSet s
        , StrategyPattern s stmt'
        , ObserverPattern s stmt'
@@ -172,10 +172,10 @@ genCodeGOOL unRepr unRepr' p =
   in genCode' (unRepr p') gs' unRepr'
 
 genCodeProc
-  :: (ProcProg r vis stmt mthd ProgData, SoftwareDossierSym r', Monad r')
+  :: (ProcProg r vis stmt mthd ProgData file, SoftwareDossierSym r', Monad r')
   => (r ProgData -> ProgData)
   -> (r' PackageData -> PackageData)
-  -> (forall s vis' stmt' mthd' prg'. (ProcProg s vis' stmt' mthd' prg') => Proc.GSProgram s prg')
+  -> (forall s vis' stmt' mthd' prg' file'. (ProcProg s vis' stmt' mthd' prg' file') => Proc.GSProgram s prg')
   -> [FileLayout]
 genCodeProc unRepr unRepr' p =
   let

--- a/code/drasil-code/test/NameGenTest.hs
+++ b/code/drasil-code/test/NameGenTest.hs
@@ -10,12 +10,12 @@ import Drasil.GProc (ProcProg)
 import qualified Drasil.GProc as GProc (GSProgram, ProgramSym(..), FileSym(..),
   ModuleSym(..))
 
-nameGenTestOO :: OOProg r vis stmt mthd stvr attch prg => OO.GSProgram r prg
+nameGenTestOO :: OOProg r vis stmt mthd stvr attch prg file => OO.GSProgram r prg
 nameGenTestOO = OO.prog "NameGenTest" "" [OO.fileDoc $ OO.buildModule
   "NameGenTest" [] [main, helper] []]
 
 nameGenTestProc
-  :: (ProcProg r vis stmt mthd prg)
+  :: (ProcProg r vis stmt mthd prg file)
   => GProc.GSProgram r prg
 nameGenTestProc = GProc.prog "NameGenTest" "" [GProc.fileDoc $ GProc.buildModule
   "NameGenTest" [] [main, helper]]

--- a/code/drasil-code/test/OOVector.hs
+++ b/code/drasil-code/test/OOVector.hs
@@ -3,11 +3,11 @@ module OOVector (ooVector) where
 import Drasil.GOOL
 import Prelude hiding (return,print,log,exp,sin,cos,tan)
 
-ooVector :: OOProg r vis stmt mthd stvr attch prg => GSProgram r prg
+ooVector :: OOProg r vis stmt mthd stvr attch prg file => GSProgram r prg
 ooVector = prog "OOVector" "" [fileDoc (buildModule "OOVector" []
   [main] [vectorClass])]
 
-vectorClass :: OOProg r vis stmt mthd stvr attch prg => CS (r Class)
+vectorClass :: OOProg r vis stmt mthd stvr attch prg file => CS (r Class)
 vectorClass = docClass "Vectors of doubles and common vector-related operations." $
   extraClass "Vector" Nothing [stateVar private instanceLevel localV]
   [docFunc "Construct a vector from an array of doubles." ["The doubles."] Nothing $
@@ -31,19 +31,19 @@ localV = var "v" (arrayType double)
 thisV :: (SelfSym r, VariableValue r) => SVariable r
 thisV = instanceVarSelf localV
 
-dimension :: OOProg r vis stmt mthd stvr attch prg => MS (r mthd)
+dimension :: OOProg r vis stmt mthd stvr attch prg file => MS (r mthd)
 dimension = docFunc "Returns the dimension of this vector." [] (Just "The dimension of the vector.") $
   method "dimension" public instanceLevel int [] $ bodyStatements [
     returnStmt $ arrayLength (valueOf thisV)
   ]
 
-magnitude :: OOProg r vis stmt mthd stvr attch prg => MS (r mthd)
+magnitude :: OOProg r vis stmt mthd stvr attch prg file => MS (r mthd)
 magnitude = docFunc "Calculate the Euclidean norm (magnitude) of this vector."
   [] (Just "The magnitude.") $
   pubMethod "magnitude" double [] $ oneLiner $
     returnStmt (classMethodCall double (obj "Vector") "dot" [maybeDeref $ valueOf self, maybeDeref $ valueOf self] #/^)
 
-norm :: OOProg r vis stmt mthd stvr attch prg => MS (r mthd)
+norm :: OOProg r vis stmt mthd stvr attch prg file => MS (r mthd)
 norm = docFunc "Calculate unit vector of this vector."
   [] (Just "A new unit vector.") $
   method "norm" public classLevel (obj "Vector") [param v] $ bodyStatements [
@@ -54,7 +54,7 @@ norm = docFunc "Calculate unit vector of this vector."
   where v = vecVar "v"
         mag = var "mag" double
 
-dot :: OOProg r vis stmt mthd stvr attch prg => MS (r mthd)
+dot :: OOProg r vis stmt mthd stvr attch prg file => MS (r mthd)
 dot = docFunc "Calculate the dot product of two vectors."
   ["First vector.", "Second vector."] (Just "The dot product.") $
   method "dot" public classLevel double [param v1, param v2] $ bodyStatements [
@@ -73,7 +73,7 @@ dot = docFunc "Calculate the dot product of two vectors."
         res = var "res" double
         i = var "i" int
 
-add :: OOProg r vis stmt mthd stvr attch prg => MS (r mthd)
+add :: OOProg r vis stmt mthd stvr attch prg file => MS (r mthd)
 add = docFunc "Calculate the resultant vector of two vectors."
   ["First vector.", "Second vector."] (Just "The resultant vector.") $
   method "add" public classLevel (obj "Vector") [param v1, param v2] $ bodyStatements [
@@ -91,7 +91,7 @@ add = docFunc "Calculate the resultant vector of two vectors."
         res = var "res" (arrayType double)
         i = var "i" int
 
-scale :: OOProg r vis stmt mthd stvr attch prg => MS (r mthd)
+scale :: OOProg r vis stmt mthd stvr attch prg file => MS (r mthd)
 scale = docFunc "Scale this vector by a factor."
   ["Scalar factor."] (Just "A new scaled vector.") $
   method "scale" public classLevel (obj "Vector") [param v, param s] $ bodyStatements [
@@ -106,11 +106,11 @@ scale = docFunc "Scale this vector by a factor."
         res = var "res" (arrayType double)
         i = var "i" int
 
-print_ :: OOProg r vis stmt mthd stvr attch prg => MS (r mthd)
+print_ :: OOProg r vis stmt mthd stvr attch prg file => MS (r mthd)
 print_ = docFunc "Prints the vector elements to console." [] Nothing $
   pubMethod "printSelf" void [] $ oneLiner $ printLn $ valueOf thisV
 
-main :: OOProg r vis stmt mthd stvr attch prg => MS (r mthd)
+main :: OOProg r vis stmt mthd stvr attch prg file => MS (r mthd)
 main = mainFunction $ body [
     block [
       arrayDecDef ds1 mainFn [litDouble 1.0, litDouble 2.0, litDouble 3.0],

--- a/code/drasil-code/test/VectorTest.hs
+++ b/code/drasil-code/test/VectorTest.hs
@@ -17,7 +17,7 @@ import Prelude hiding (return,print,log,exp,sin,cos,tan)
 vectorTestProc
   ::
     ( NativeVector r
-    , ProcProg r vis stmt mthd prg
+    , ProcProg r vis stmt mthd prg file
     )
   => GProc.GSProgram r prg
 vectorTestProc = GProc.prog "VectorTest" ""
@@ -29,7 +29,7 @@ vectorTestProc = GProc.prog "VectorTest" ""
 vectorOps
   ::
     ( NativeVector r
-    , ProcProg r vis stmt mthd prg
+    , ProcProg r vis stmt mthd prg file
     )
   => MS (r mthd)
 vectorOps =

--- a/code/drasil-gen/lib/Drasil/Generator/Code.hs
+++ b/code/drasil-gen/lib/Drasil/Generator/Code.hs
@@ -46,7 +46,11 @@ genCode syst chs = directory [ps|src|] <$> traverse genLangCode (lang chs)
     genLangCode Matlab = genCallProc Matlab unMLC unMLP
 
     genCall
-      :: (OOProg progRepr vis stmt mthd stvr attch prg, SoftwareDossierSym packRepr, Monad packRepr)
+      ::
+        ( OOProg progRepr vis stmt mthd stvr attch prg file
+        , SoftwareDossierSym packRepr
+        , Monad packRepr
+        )
       => Lang
       -> (progRepr prg -> ProgData)
       -> (packRepr PackageData -> PackageData)
@@ -59,7 +63,12 @@ genCode syst chs = directory [ps|src|] <$> traverse genLangCode (lang chs)
       pure $ generateCode lng realUnProgRepr unPackRepr $ generator lng time samples chs spec
 
     genCallProc
-      :: (ProcProg progRepr vis stmt mthd prg, NativeVector progRepr, SoftwareDossierSym packRepr, Monad packRepr)
+      ::
+        ( ProcProg progRepr vis stmt mthd prg file
+        , NativeVector progRepr
+        , SoftwareDossierSym packRepr
+        , Monad packRepr
+        )
       => Lang
       -> (progRepr prg -> ProgData)
       -> (packRepr PackageData -> PackageData)

--- a/code/drasil-gool/lib/Drasil/GOOL.hs
+++ b/code/drasil-gool/lib/Drasil/GOOL.hs
@@ -1,9 +1,9 @@
 -- | re-export smart constructors for external code writing
-module Drasil.GOOL (Label, GSProgram, File, Body, Block, CS, FS, MS, VS,
-  SVariable, SValue, CSStateVar, Class, Module, NamedArgs, Initializers,
-  OOProg, ProgramSym(..), FileSym(..), AttachmentSym(..), BodySym(..),
-  bodyStatements, oneLiner, BlockSym(..), TypeSym(..), OOTypeSym(..),
-  BinderSym(..), EmptyStatement(..), MultiStatement(..), ValueStatement(..),
+module Drasil.GOOL (Label, GSProgram, Body, Block, CS, FS, MS, VS, SVariable,
+  SValue, CSStateVar, Class, Module, NamedArgs, Initializers, OOProg,
+  ProgramSym(..), FileSym(..), AttachmentSym(..), BodySym(..), bodyStatements,
+  oneLiner, BlockSym(..), TypeSym(..), OOTypeSym(..), BinderSym(..),
+  EmptyStatement(..), MultiStatement(..), ValueStatement(..),
   AssignStatement(..), (&=), DeclStatement(..), OODeclStatement(..),
   objDecNewNoParams, extObjDecNewNoParams, PrintConsole(..), ReadConsole(..),
   FileHandling(..), PrintFile(..), ReadFile(..), StringStatement(..),
@@ -49,7 +49,7 @@ import Drasil.Shared.InterfaceCommon (Label, Body, Block, SVariable, SValue,
   VisibilitySym(..), convType,
   -- TODO [Brandon Bosman, 06/09/2026]: Remove these imports
   TypeElim(..), getTypeString)
-import Drasil.GOOL.InterfaceGOOL (GSProgram, File, Module, Class, CSStateVar,
+import Drasil.GOOL.InterfaceGOOL (GSProgram, Module, Class, CSStateVar,
   Initializers, OOProg, ProgramSym(..), FileSym(..), ModuleSym(..), ClassSym(..),
   OOMethodSym(..), OOTypeSym(..), OOVariableSym(..), SelfSym(..),
   instanceVarSelf, ($->), AttachmentSym(..), privMethod, pubMethod, initializer,

--- a/code/drasil-gool/lib/Drasil/GOOL/CodeInfoOO.hs
+++ b/code/drasil-gool/lib/Drasil/GOOL/CodeInfoOO.hs
@@ -51,19 +51,19 @@ instance Applicative CodeInfoOO where
 instance Monad CodeInfoOO where
   CI x >>= f = f x
 
-instance OOProg CodeInfoOO () () () () () GOOLState
+instance OOProg CodeInfoOO () () () () () GOOLState ()
 
 instance UnRepr CodeInfoOO contents where
   unRepr = unCI
 
-instance ProgramSym CodeInfoOO () () () () () GOOLState where
+instance ProgramSym CodeInfoOO GOOLState () where
   prog _ _ fs = do
     mapM_ (zoom lensGStoFS) fs
     modify (updateMEMWithCalls . callMapTransClosure)
     s <- S.get
     toState $ toCode s
 
-instance FileSym CodeInfoOO () () () () () where
+instance FileSym CodeInfoOO () () () () () () where
   fileDoc m = do
     _ <- m
     return $ return $ error "[fileDoc] The return value of this isn't used, and the thunk shouldn't fire."

--- a/code/drasil-gool/lib/Drasil/GOOL/InterfaceGOOL.hs
+++ b/code/drasil-gool/lib/Drasil/GOOL/InterfaceGOOL.hs
@@ -4,7 +4,7 @@
 
 module Drasil.GOOL.InterfaceGOOL (
   -- Types
-  Program, GSProgram, File, Module, Class, StateVar, CSStateVar, Initializers,
+  Program, GSProgram, Module, Class, StateVar, CSStateVar, Initializers,
   -- Typeclasses
   OOProg, ProgramSym(..), FileSym(..), ModuleSym(..), ClassSym(..),
   OOTypeSym(..), OOVariableSym(..), ($->), SelfSym(..), instanceVarSelf,
@@ -38,8 +38,8 @@ import Drasil.Shared.InterfaceCommon (
 import Drasil.Shared.CodeType (CodeType(..), ClassName)
 import Drasil.Shared.Helpers (onStateValue)
 import Drasil.Shared.State (GS, FS, CS, MS, VS)
-import Drasil.Shared.AST (ScopeData, TypeData, ParamData, FileData, FuncData,
-  ModData, ProgData)
+import Drasil.Shared.AST (ScopeData, TypeData, ParamData, FuncData, ModData,
+  ProgData)
 
 import Text.PrettyPrint.HughesPJ (Doc)
 
@@ -55,31 +55,29 @@ class (UnRepr r TypeData, Argument r, CommandLineArgs r, Literal r,
   OODeclStatement r stmt, AssignStatement r stmt, OOFuncAppStatement r stmt,
   ControlStatement r stmt, StringStatement r stmt, PrintConsole r stmt,
   ReadConsole r stmt, FileHandling r stmt, PrintFile r stmt, ReadFile r stmt,
-  ProgramSym r vis stmt mthd stvr attch prg
-  ) => OOProg r vis stmt mthd stvr attch prg
+  FileSym r vis stmt mthd stvr attch file, ProgramSym r prg file
+  ) => OOProg r vis stmt mthd stvr attch prg file
 
 type Program = ProgData
 type GSProgram a prg = GS (a prg)
 
 -- | Class for representing a program.
 -- Usually 'ProgData' is used for the representation.
-class (FileSym r vis stmt mthd stvr attch) => ProgramSym r vis stmt mthd stvr attch prg | r -> prg where
+class ProgramSym r prg file | r -> prg file where
   -- | Given program name, program purpose, and list of files,
   -- Generates a representation of a program.
-  prog :: Label -> Label -> [FS (r File)] -> GSProgram r prg
-
-type File = FileData
+  prog :: Label -> Label -> [FS (r file)] -> GSProgram r prg
 
 -- | Class for representing a file.
-class (ModuleSym r vis stmt mthd stvr attch) => FileSym r vis stmt mthd stvr attch where
+class (ModuleSym r vis stmt mthd stvr attch) => FileSym r vis stmt mthd stvr attch file | r -> file where
   -- | Given a module, generates a representation of a file.
   -- (Implicit assumption: exactly one module per file)
-  fileDoc :: FS (r Module) -> FS (r File)
+  fileDoc :: FS (r Module) -> FS (r file)
 
   -- | Given module description, watermark, list of author names,
   -- date as a String, and file to comment, creates a __documented module__
   -- (i.e. module with a header comment)
-  docMod :: String -> String -> [String] -> String -> FS (r File) -> FS (r File)
+  docMod :: String -> String -> [String] -> String -> FS (r file) -> FS (r file)
 
 type Module = ModData
 

--- a/code/drasil-gool/lib/Drasil/GOOL/LanguageRenderer/CSharpRenderer.hs
+++ b/code/drasil-gool/lib/Drasil/GOOL/LanguageRenderer/CSharpRenderer.hs
@@ -94,7 +94,7 @@ import Drasil.Shared.AST (Terminator(..), FileType(..), fileD, FuncData(..), fd,
   ModData(..), md, updateMod, MethodData(..), mthd, updateMthd, OpData(..),
   ParamData(..), pd, updateParam, ProgData(..), progD, TypeData(..), ValData(..),
   vd, updateValDoc, AttachmentTag(..), VarData(..), vard, ScopeData, BinderD(..),
-  bindFormD)
+  bindFormD, FileData)
 import Drasil.Shared.Helpers (angles, hicat, toCode, toState, onCodeValue,
   onStateValue, on2CodeValues, on2StateValues, on3CodeValues, on3StateValues,
   on2StateWrapped, onCodeList, onStateList)
@@ -128,28 +128,28 @@ instance Applicative CSharpCode where
 instance Monad CSharpCode where
   CSC x >>= f = f x
 
-instance OOProg CSharpCode Doc (Doc, Terminator) MethodData StateVar Doc ProgData
+instance OOProg CSharpCode Doc (Doc, Terminator) MethodData StateVar Doc ProgData FileData
 
-instance ProgramSym CSharpCode Doc (Doc, Terminator) MethodData StateVar Doc ProgData where
+instance ProgramSym CSharpCode ProgData FileData where
   prog n st files = do
     fs <- mapM (zoom lensGStoFS) files
     modify revFiles
     pure $ onCodeList (progD n st) fs
 
 instance CommonRenderSym CSharpCode Doc (Doc, Terminator) MethodData
-instance OORenderSym CSharpCode Doc (Doc, Terminator) MethodData StateVar Doc
+instance OORenderSym CSharpCode Doc (Doc, Terminator) MethodData StateVar Doc FileData
 
 instance UnRepr CSharpCode contents where
   unRepr = unCSC
 
-instance FileSym CSharpCode Doc (Doc, Terminator) MethodData StateVar Doc where
+instance FileSym CSharpCode Doc (Doc, Terminator) MethodData StateVar Doc FileData where
   fileDoc m = do
     modify (setFileType Combined)
     G.fileDoc csExt top bottom m
 
   docMod = CP.doxMod csExt
 
-instance RenderFile CSharpCode where
+instance RenderFile CSharpCode FileData where
   top _ = toCode empty
   bottom = toCode empty
 

--- a/code/drasil-gool/lib/Drasil/GOOL/LanguageRenderer/CppRenderer.hs
+++ b/code/drasil-gool/lib/Drasil/GOOL/LanguageRenderer/CppRenderer.hs
@@ -137,10 +137,9 @@ hdrToSrc :: CppHdrCode a -> CppSrcCode a
 hdrToSrc (CPPHC a) = CPPSC a
 
 instance (Pair p) => OOProg (p CppSrcCode CppHdrCode)
-  (Doc, VisibilityTag) (Doc, Terminator) MethodData StateVarData AttachmentData ProgData
+  (Doc, VisibilityTag) (Doc, Terminator) MethodData StateVarData AttachmentData ProgData FileData
 
-instance (Pair p) => ProgramSym (p CppSrcCode CppHdrCode)
-    (Doc, VisibilityTag) (Doc, Terminator) MethodData StateVarData AttachmentData ProgData where
+instance (Pair p) => ProgramSym (p CppSrcCode CppHdrCode) ProgData FileData where
   prog n st mods = do
     m <-  mapM (zoom lensGStoFS) mods
     let fm = map pfst m
@@ -156,12 +155,12 @@ instance (Pair p) => UnRepr (p CppSrcCode CppHdrCode) contents where
   unRepr c = unCPPSC $ pfst c
 
 instance (Pair p) => FileSym (p CppSrcCode CppHdrCode)
-    (Doc, VisibilityTag) (Doc, Terminator) MethodData StateVarData AttachmentData where
+    (Doc, VisibilityTag) (Doc, Terminator) MethodData StateVarData AttachmentData FileData where
   fileDoc = pair1 fileDoc fileDoc
 
   docMod d wm a dt = pair1 (docMod d wm a dt) (docMod d wm a dt)
 
-instance (Pair p) => RenderFile (p CppSrcCode CppHdrCode) where
+instance (Pair p) => RenderFile (p CppSrcCode CppHdrCode) FileData where
   top m = pair (top $ pfst m) (top $ psnd m)
   bottom = pair bottom bottom
 
@@ -1032,23 +1031,23 @@ instance Applicative CppSrcCode where
 instance Monad CppSrcCode where
   CPPSC x >>= f = f x
 
-instance ProgramSym CppSrcCode (Doc, VisibilityTag) (Doc, Terminator) MethodData StateVarData AttachmentData ProgData where
+instance ProgramSym CppSrcCode ProgData FileData where
   prog n st = onStateList (onCodeList (progD n st)) . map (zoom lensGStoFS)
 
 instance CommonRenderSym CppSrcCode (Doc, VisibilityTag) (Doc, Terminator) MethodData
-instance OORenderSym CppSrcCode (Doc, VisibilityTag) (Doc, Terminator) MethodData StateVarData AttachmentData
+instance OORenderSym CppSrcCode (Doc, VisibilityTag) (Doc, Terminator) MethodData StateVarData AttachmentData FileData
 
 instance UnRepr CppSrcCode contents where
   unRepr = unCPPSC
 
-instance FileSym CppSrcCode (Doc, VisibilityTag) (Doc, Terminator) MethodData StateVarData AttachmentData where
+instance FileSym CppSrcCode (Doc, VisibilityTag) (Doc, Terminator) MethodData StateVarData AttachmentData FileData where
   fileDoc m = do
     modify (setFileType Source)
     G.fileDoc cppSrcExt top bottom m
 
   docMod = CP.doxMod cppSrcExt
 
-instance RenderFile CppSrcCode where
+instance RenderFile CppSrcCode FileData where
   top _ = toCode empty
   bottom = toCode empty
 
@@ -1760,19 +1759,19 @@ instance Monad CppHdrCode where
   CPPHC x >>= f = f x
 
 instance CommonRenderSym CppHdrCode (Doc, VisibilityTag) (Doc, Terminator) MethodData
-instance OORenderSym CppHdrCode (Doc, VisibilityTag) (Doc, Terminator) MethodData StateVarData AttachmentData
+instance OORenderSym CppHdrCode (Doc, VisibilityTag) (Doc, Terminator) MethodData StateVarData AttachmentData FileData
 
 instance UnRepr CppHdrCode contents where
   unRepr = unCPPHC
 
-instance FileSym CppHdrCode (Doc, VisibilityTag) (Doc, Terminator) MethodData StateVarData AttachmentData where
+instance FileSym CppHdrCode (Doc, VisibilityTag) (Doc, Terminator) MethodData StateVarData AttachmentData FileData where
   fileDoc m = do
     modify (setFileType Header)
     G.fileDoc cppHdrExt top bottom m
 
   docMod = CP.doxMod cppHdrExt
 
-instance RenderFile CppHdrCode where
+instance RenderFile CppHdrCode FileData where
   top = onCodeValue cpphtop
   bottom = toCode endif
 

--- a/code/drasil-gool/lib/Drasil/GOOL/LanguageRenderer/JavaRenderer.hs
+++ b/code/drasil-gool/lib/Drasil/GOOL/LanguageRenderer/JavaRenderer.hs
@@ -89,7 +89,7 @@ import Drasil.Shared.AST (Terminator(..), VisibilityTag(..), qualName,
   FileType(..), fileD, FuncData(..), fd, ModData(..), md, updateMod,
   MethodData(..), mthd, updateMthd, OpData(..), ParamData(..), pd, ProgData(..),
   progD, TypeData(..), ValData(..), vd, VarData(..), vard, ScopeData,
-  BinderD(..), bindFormD)
+  BinderD(..), bindFormD, FileData)
 import Drasil.Shared.CodeAnalysis (Exception(..), ExceptionType(..), exception,
   stdExc, HasException(..))
 import Drasil.Shared.Helpers (emptyIfNull, toCode, toState, onCodeValue,
@@ -129,27 +129,27 @@ instance Applicative JavaCode where
 instance Monad JavaCode where
   JC x >>= f = f x
 
-instance OOProg JavaCode Doc (Doc, Terminator) MethodData StateVar Doc ProgData
+instance OOProg JavaCode Doc (Doc, Terminator) MethodData StateVar Doc ProgData FileData
 
-instance ProgramSym JavaCode Doc (Doc, Terminator) MethodData StateVar Doc ProgData where
+instance ProgramSym JavaCode ProgData FileData where
   prog n st fs = modifyReturnList (map (zoom lensGStoFS) fs) (revFiles .
     addProgNameToPaths n) (onCodeList (progD n st . map (R.package n
     endStatement)))
 
 instance CommonRenderSym JavaCode Doc (Doc, Terminator) MethodData
-instance OORenderSym JavaCode Doc (Doc, Terminator) MethodData StateVar Doc
+instance OORenderSym JavaCode Doc (Doc, Terminator) MethodData StateVar Doc FileData
 
 instance UnRepr JavaCode contents where
   unRepr = unJC
 
-instance FileSym JavaCode Doc (Doc, Terminator) MethodData StateVar Doc where
+instance FileSym JavaCode Doc (Doc, Terminator) MethodData StateVar Doc FileData where
   fileDoc m = do
     modify (setFileType Combined)
     G.fileDoc jExt top bottom m
 
   docMod = CP.doxMod jExt
 
-instance RenderFile JavaCode where
+instance RenderFile JavaCode FileData where
   top _ = toCode empty
   bottom = toCode empty
 

--- a/code/drasil-gool/lib/Drasil/GOOL/LanguageRenderer/PythonRenderer.hs
+++ b/code/drasil-gool/lib/Drasil/GOOL/LanguageRenderer/PythonRenderer.hs
@@ -81,7 +81,7 @@ import Drasil.Shared.AST (Terminator(..), FileType(..), fileD, FuncData(..), fd,
   ModData(..), md, updateMod, MethodData(..), mthd, updateMthd, OpData(..),
   ParamData(..), pd, ProgData(..), progD, TypeData(..), ValData(..), vd,
   VarData(..), vard, BinderD(..), bindFormD, AttachmentTag(..),
-  AttachmentData(..), ad)
+  AttachmentData(..), ad, FileData)
 import Drasil.Shared.Helpers (vibcat, emptyIfEmpty, toCode, toState, onCodeValue,
   onStateValue, on2CodeValues, on2StateValues, onCodeList, onStateList,
   on2StateWrapped)
@@ -119,28 +119,28 @@ instance Applicative PythonCode where
 instance Monad PythonCode where
   PC x >>= f = f x
 
-instance OOProg PythonCode Doc (Doc, Terminator) MethodData StateVar AttachmentData ProgData
+instance OOProg PythonCode Doc (Doc, Terminator) MethodData StateVar AttachmentData ProgData FileData
 
-instance ProgramSym PythonCode Doc (Doc, Terminator) MethodData StateVar AttachmentData ProgData where
+instance ProgramSym PythonCode ProgData FileData where
   prog n st files = do
     fs <- mapM (zoom lensGStoFS) files
     modify revFiles
     pure $ onCodeList (progD n st) fs
 
 instance CommonRenderSym PythonCode Doc (Doc, Terminator) MethodData
-instance OORenderSym PythonCode Doc (Doc, Terminator) MethodData StateVar AttachmentData
+instance OORenderSym PythonCode Doc (Doc, Terminator) MethodData StateVar AttachmentData FileData
 
 instance UnRepr PythonCode contents where
   unRepr = unPC
 
-instance FileSym PythonCode Doc (Doc, Terminator) MethodData StateVar AttachmentData where
+instance FileSym PythonCode Doc (Doc, Terminator) MethodData StateVar AttachmentData FileData where
   fileDoc m = do
     modify (setFileType Combined)
     G.fileDoc pyExt top bottom m
 
   docMod = CP.doxMod pyExt
 
-instance RenderFile PythonCode where
+instance RenderFile PythonCode FileData where
   top _ = toCode empty
   bottom = toCode empty
 

--- a/code/drasil-gool/lib/Drasil/GOOL/LanguageRenderer/SwiftRenderer.hs
+++ b/code/drasil-gool/lib/Drasil/GOOL/LanguageRenderer/SwiftRenderer.hs
@@ -92,7 +92,7 @@ import Drasil.Shared.AST (Terminator(..), VisibilityTag(..), qualName,
   FileType(..), fileD, FuncData(..), fd, ModData(..), md, updateMod,
   MethodData(..), mthd, updateMthd, OpData(..), ParamData(..), pd, ProgData(..),
   progD, TypeData(..), ValData(..), vd, AttachmentTag(..), VarData(..), vard,
-  ScopeData, BinderD(..), bindFormD)
+  ScopeData, BinderD(..), bindFormD, FileData)
 import Drasil.Shared.Helpers (hicat, emptyIfNull, toCode, toState, onCodeValue,
   onStateValue, on2CodeValues, on2StateValues, onCodeList, onStateList)
 import Drasil.Shared.State (MS, VS, lensGStoFS, lensFStoCS, lensFStoMS,
@@ -129,28 +129,28 @@ instance Applicative SwiftCode where
 instance Monad SwiftCode where
   SC x >>= f = f x
 
-instance OOProg SwiftCode Doc (Doc, Terminator) MethodData StateVar Doc ProgData
+instance OOProg SwiftCode Doc (Doc, Terminator) MethodData StateVar Doc ProgData FileData
 
-instance ProgramSym SwiftCode Doc (Doc, Terminator) MethodData StateVar Doc ProgData where
+instance ProgramSym SwiftCode ProgData FileData where
   prog n st files = do
     fs <- mapM (zoom lensGStoFS) files
     modify revFiles
     pure $ onCodeList (progD n st) fs
 
 instance CommonRenderSym SwiftCode Doc (Doc, Terminator) MethodData
-instance OORenderSym SwiftCode Doc (Doc, Terminator) MethodData StateVar Doc
+instance OORenderSym SwiftCode Doc (Doc, Terminator) MethodData StateVar Doc FileData
 
 instance UnRepr SwiftCode contents where
   unRepr = unSC
 
-instance FileSym SwiftCode Doc (Doc, Terminator) MethodData StateVar Doc where
+instance FileSym SwiftCode Doc (Doc, Terminator) MethodData StateVar Doc FileData where
   fileDoc m = do
     modify (setFileType Combined)
     G.fileDoc swiftExt top bottom m
 
   docMod = G.docMod CP.modDoc' swiftExt
 
-instance RenderFile SwiftCode where
+instance RenderFile SwiftCode FileData where
   top _ = toCode empty
   bottom = toCode empty
 

--- a/code/drasil-gool/lib/Drasil/GOOL/RendererClassesOO.hs
+++ b/code/drasil-gool/lib/Drasil/GOOL/RendererClassesOO.hs
@@ -8,9 +8,9 @@ module Drasil.GOOL.RendererClassesOO (
 ) where
 
 import Drasil.Shared.InterfaceCommon (Label, Block, Body, SVariable, SValue)
-import qualified Drasil.GOOL.InterfaceGOOL as IG (File, Module, Class,
-  CSStateVar, OOVariableValue, OOValueExpression(..), InternalValueExp(..),
-  FileSym(..), GetSet(..), ObserverPattern(..), StrategyPattern(..))
+import qualified Drasil.GOOL.InterfaceGOOL as IG (Module, Class, CSStateVar,
+  OOVariableValue, OOValueExpression(..), InternalValueExp(..), FileSym(..),
+  GetSet(..), ObserverPattern(..), StrategyPattern(..))
 import Drasil.Shared.AST (AttachmentTag, TypeData, ParamData, FuncData)
 import Drasil.Shared.State (FS, CS, VS, MS)
 
@@ -19,26 +19,26 @@ import Text.PrettyPrint.HughesPJ (Doc)
 import Drasil.Shared.RendererClassesCommon (MSMthdType, CommonRenderSym,
   BlockCommentSym(..), MethodTypeSym(..), RenderMethod(..))
 
-class (CommonRenderSym r vis stmt mthd, IG.FileSym r vis stmt mthd stvr attch,
-  IG.InternalValueExp r, IG.GetSet r, IG.ObserverPattern r stmt,
-  IG.StrategyPattern r stmt, IG.OOVariableValue r,
-  IG.OOValueExpression r, RenderClass r vis mthd stvr, ClassElim r, RenderFile r,
-  InternalGetSet r, OORenderMethod r vis mthd attch, RenderMod r, ModuleElim r,
-  StateVarElim r stvr, PermElim r attch
-  ) => OORenderSym r vis stmt mthd stvr attch
+class (CommonRenderSym r vis stmt mthd,
+  IG.FileSym r vis stmt mthd stvr attch file, IG.InternalValueExp r, IG.GetSet r,
+  IG.ObserverPattern r stmt, IG.StrategyPattern r stmt, IG.OOVariableValue r,
+  IG.OOValueExpression r, RenderClass r vis mthd stvr, ClassElim r,
+  RenderFile r file, InternalGetSet r, OORenderMethod r vis mthd attch,
+  RenderMod r, ModuleElim r, StateVarElim r stvr, PermElim r attch
+  ) => OORenderSym r vis stmt mthd stvr attch file
 
 -- OO-Only Typeclasses --
 
-class (BlockCommentSym r) => RenderFile r where
+class (BlockCommentSym r) => RenderFile r file | r -> file where
   -- top and bottom are only used for pre-processor guards for C++ header
   -- files. FIXME: Remove them (generation of pre-processor guards can be
   -- handled by fileDoc instead)
   top :: r IG.Module -> r Block
   bottom :: r Block
 
-  commentedMod :: FS (r IG.File) -> FS (r Doc) -> FS (r IG.File)
+  commentedMod :: FS (r file) -> FS (r Doc) -> FS (r file)
 
-  fileFromData :: FilePath -> FS (r IG.Module) -> FS (r IG.File)
+  fileFromData :: FilePath -> FS (r IG.Module) -> FS (r file)
 
 class PermElim r attch where
   perm :: r attch -> Doc

--- a/code/drasil-gool/lib/Drasil/GProc.hs
+++ b/code/drasil-gool/lib/Drasil/GProc.hs
@@ -1,5 +1,5 @@
 -- | re-export smart constructors for external code writing
-module Drasil.GProc (Label, GSProgram, File, Body, Block, FS, MS, VS, SVariable,
+module Drasil.GProc (Label, GSProgram, Body, Block, FS, MS, VS, SVariable,
   SValue, Module, NamedArgs, ProcProg, ProgramSym(..), FileSym(..), BodySym(..),
   bodyStatements, oneLiner, BlockSym(..), TypeSym(..), BinderSym(..),
   EmptyStatement(..), MultiStatement(..), ValueStatement(..),
@@ -38,8 +38,8 @@ import Drasil.Shared.InterfaceCommon (Label, Body, Block, SVariable, SValue,
   MethodSym(..), VisibilitySym(..), convType,
   -- TODO [Brandon Bosman, 06/09/2026]: Remove these imports
   TypeElim(..), getTypeString)
-import Drasil.GProc.InterfaceProc (GSProgram, File, Module, ProcProg,
-  ProgramSym(..), FileSym(..), ModuleSym(..))
+import Drasil.GProc.InterfaceProc (GSProgram, Module, ProcProg, ProgramSym(..),
+  FileSym(..), ModuleSym(..))
 
 import Drasil.Shared.AST (FileData(..), ScopeData(..), ModData(..), ProgData(..),
   TypeData(..), VisibilityTag(..), ParamData)

--- a/code/drasil-gool/lib/Drasil/GProc/InterfaceProc.hs
+++ b/code/drasil-gool/lib/Drasil/GProc/InterfaceProc.hs
@@ -4,7 +4,7 @@
 
 module Drasil.GProc.InterfaceProc (
   -- Types
-  Program, GSProgram, File, Module,
+  Program, GSProgram, Module,
   -- Typeclasses
   ProcProg, ProgramSym(..), FileSym(..), ModuleSym(..)
   ) where
@@ -18,7 +18,7 @@ import Drasil.Shared.InterfaceCommon (Label, MethodSym(..), Array,
   ValueExpression, VariableValue, UnRepr, FunctionSym, ScopeSym, BinderSym,
   InternalList, TypeElim, VariableElim)
 import Drasil.Shared.State (GS, FS, MS)
-import Drasil.Shared.AST (FileData, ModData, ProgData, TypeData)
+import Drasil.Shared.AST (ModData, ProgData, TypeData)
 
 -- | Wrapper typeclass that bundles everything essential
 -- for generating a procedural program.
@@ -32,31 +32,29 @@ class (UnRepr r TypeData, FunctionSym r, VariableValue r, ScopeSym r,
   ReadFile r stmt, List r, ListStatement r stmt, Literal r, MathConstant r,
   NumericExpression r, ParameterSym r, Reference r, Set r,
   StringStatement r stmt, ValueExpression r, VariableValue r,
-  ProgramSym r vis stmt mthd prg)
-  => ProcProg r vis stmt mthd prg
+  FileSym r vis stmt mthd file, ProgramSym r prg file)
+  => ProcProg r vis stmt mthd prg file
 
 type Program = ProgData
 type GSProgram a prg = GS (a prg)
 
 -- | Class for representing a program.
 -- Usually 'ProgData' is used for the representation.
-class (FileSym r vis stmt mthd) => ProgramSym r vis stmt mthd prg | r -> prg where
+class ProgramSym r prg file | r -> prg file where
   -- | Given program name, program purpose, and list of files,
   -- Generates a representation of a program.
-  prog :: Label -> Label -> [FS (r File)] -> GSProgram r prg
-
-type File = FileData
+  prog :: Label -> Label -> [FS (r file)] -> GSProgram r prg
 
 -- | Class for representing a file.
-class (ModuleSym r vis stmt mthd) => FileSym r vis stmt mthd where
+class (ModuleSym r vis stmt mthd) => FileSym r vis stmt mthd file | r -> file where
   -- | Given a module, generates a representation of a file.
   -- (Implicit assumption: exactly one module per file)
-  fileDoc :: FS (r Module) -> FS (r File)
+  fileDoc :: FS (r Module) -> FS (r file)
 
   -- | Given module description, watermark, list of author names,
   -- date as a String, and file to comment, creates a __documented module__
   -- (i.e. module with a header comment)
-  docMod :: String -> String -> [String] -> String -> FS (r File) -> FS (r File)
+  docMod :: String -> String -> [String] -> String -> FS (r file) -> FS (r file)
 
 type Module = ModData
 

--- a/code/drasil-gool/lib/Drasil/GProc/LanguageRenderer/AbstractProc.hs
+++ b/code/drasil-gool/lib/Drasil/GProc/LanguageRenderer/AbstractProc.hs
@@ -9,7 +9,7 @@ import Drasil.Shared.InterfaceCommon (Label, Body, SValue, SVariable,
   VariableElim(variableName, variableType), VisibilitySym(..), funcApp,
   getCodeType, convType, ValueStatement(..), ValueExpression, IndexTranslator)
 import qualified Drasil.Shared.InterfaceCommon as IC
-import Drasil.GProc.InterfaceProc (File, Module)
+import Drasil.GProc.InterfaceProc (Module)
 import qualified Drasil.Shared.RendererClassesCommon as RC
 import qualified Drasil.GProc.RendererClassesProc as RP
 import Drasil.Shared.AST (isSource, ScopeData, TypeData, ParamData)
@@ -31,7 +31,7 @@ import Text.PrettyPrint.HughesPJ (Doc, isEmpty, brackets, (<>), render)
 
 -- Files --
 
-fileDoc :: (RP.RenderFile r) => String -> FS (r Module) -> FS (r File)
+fileDoc :: (RP.RenderFile r file) => String -> FS (r Module) -> FS (r file)
 fileDoc ext md = do
   m <- md
   nm <- getModuleName
@@ -40,7 +40,7 @@ fileDoc ext md = do
 
 fileFromData
   :: (RP.ModuleElim r)
-  => (FilePath -> r Module -> r File) -> FilePath -> FS (r Module) -> FS (r File)
+  => (FilePath -> r Module -> r file) -> FilePath -> FS (r Module) -> FS (r file)
 fileFromData f fpath mdl' = do
   -- Add this file to list of files as long as it is not empty
   mdl <- mdl'
@@ -66,8 +66,8 @@ buildModule n imps bot fs = RP.modFromData n (do
   return $ emptyIfEmpty fnDocs (vibcat (filter (not . isEmpty) [is, fnDocs])))
 
 docMod
-  :: (RP.RenderFile r)
-  => String -> String -> String -> [String] -> String -> FS (r File) -> FS (r File)
+  :: (RP.RenderFile r file)
+  => String -> String -> String -> [String] -> String -> FS (r file) -> FS (r file)
 docMod e d wm a dt fl = RP.commentedMod fl
   (RC.docComment $ CP.modDoc' d wm a dt . addExt e <$> getModuleName)
 
@@ -104,8 +104,9 @@ arrayElem arr' i' = do
       vRender = RC.value arr <> brackets (RC.value i)
   mkStateVar vName vType vRender
 
-funcDecDef :: (RP.ProcRenderSym r vis stmt mthd) => SVariable r -> r ScopeData ->
-  [SVariable r] -> MS (r Body) -> MS (r stmt)
+funcDecDef
+  :: (RP.ProcRenderSym r vis stmt mthd file)
+  => SVariable r -> r ScopeData -> [SVariable r] -> MS (r Body) -> MS (r stmt)
 funcDecDef v scp ps b = do
   vr <- zoom lensMStoVS v
   modify $ useVarName $ variableName vr

--- a/code/drasil-gool/lib/Drasil/GProc/LanguageRenderer/JuliaRenderer.hs
+++ b/code/drasil-gool/lib/Drasil/GProc/LanguageRenderer/JuliaRenderer.hs
@@ -79,7 +79,7 @@ import qualified Drasil.Shared.LanguageRenderer.Macros as M (increment1,
 import Drasil.Shared.AST (Terminator(..), FileType(..), fileD, FuncData(..),
   ModData(..), md, updateMod, MethodData(..), mthd, OpData(..), ParamData(..),
   ProgData(..), TypeData(..), ValData(..), vd, VarData(..), vard, progD, fd, pd,
-  updateMthd, ScopeTag(..), ScopeData(..), sd, BinderD(..), bindFormD)
+  updateMthd, ScopeTag(..), ScopeData(..), sd, BinderD(..), bindFormD, FileData)
 import Drasil.Shared.Helpers (vibcat, toCode, toState, onCodeValue, onStateValue,
   on2CodeValues, on2StateValues, onCodeList, onStateList, emptyIfEmpty)
 import Drasil.Shared.State (FS, MS, VS, lensGStoFS, revFiles, setFileType,
@@ -108,27 +108,27 @@ instance Applicative JuliaCode where
 instance Monad JuliaCode where
   JLC x >>= f = f x
 
-instance ProcProg JuliaCode Doc (Doc, Terminator) MethodData ProgData
+instance ProcProg JuliaCode Doc (Doc, Terminator) MethodData ProgData FileData
 
-instance ProgramSym JuliaCode Doc (Doc, Terminator) MethodData ProgData where
+instance ProgramSym JuliaCode ProgData FileData where
   prog n st files = do
     fs <- mapM (zoom lensGStoFS) files
     modify revFiles
     pure $ onCodeList (progD n st) fs
 
 instance CommonRenderSym JuliaCode Doc (Doc, Terminator) MethodData
-instance ProcRenderSym JuliaCode Doc (Doc, Terminator) MethodData
+instance ProcRenderSym JuliaCode Doc (Doc, Terminator) MethodData FileData
 
 instance UnRepr JuliaCode inner where
   unRepr = unJLC
 
-instance FileSym JuliaCode Doc (Doc, Terminator) MethodData where
+instance FileSym JuliaCode Doc (Doc, Terminator) MethodData FileData where
   fileDoc m = do
     modify (setFileType Combined)
     A.fileDoc jlExt m
   docMod = A.docMod jlExt
 
-instance RenderFile JuliaCode where
+instance RenderFile JuliaCode FileData where
   top _ = toCode empty
   bottom = toCode empty
 

--- a/code/drasil-gool/lib/Drasil/GProc/LanguageRenderer/MatlabRenderer.hs
+++ b/code/drasil-gool/lib/Drasil/GProc/LanguageRenderer/MatlabRenderer.hs
@@ -62,7 +62,7 @@ import Drasil.Shared.AST (Terminator(..), FileType(Combined), fileD, md,
   updateMod, MethodData, mthd, mthdName, updateMthd, ParamData, paramVar, paramDoc, pd,
   ProgData, TypeData, cType, vd, val, valPrec, valInt, valType, opDoc, opPrec,
   varName, varType, varBind, varDoc, vard, progD, mthdDoc, modDoc,
-  FuncData(fType, funcDoc), fd, ScopeData)
+  FuncData(fType, funcDoc), fd, ScopeData, FileData)
 import Drasil.Shared.CodeType (CodeType(..))
 import Drasil.Shared.LanguageRenderer.Constructors (typeFromData, unOpPrec,
   powerPrec, multPrec, unExpr, unExpr', binExpr, binExpr', mkStateVal, mkVal,
@@ -91,27 +91,27 @@ instance Applicative MatlabCode where
 instance Monad MatlabCode where
   MLC x >>= f = f x
 
-instance ProcProg MatlabCode Doc (Doc, Terminator) MethodData ProgData
+instance ProcProg MatlabCode Doc (Doc, Terminator) MethodData ProgData FileData
 
-instance ProgramSym MatlabCode Doc (Doc, Terminator) MethodData ProgData where
+instance ProgramSym MatlabCode ProgData FileData where
   prog n st files = do
     fs <- mapM (zoom lensGStoFS) files
     modify revFiles
     pure $ onCodeList (progD n st) fs
 
 instance CommonRenderSym MatlabCode Doc (Doc, Terminator) MethodData
-instance ProcRenderSym MatlabCode Doc (Doc, Terminator) MethodData
+instance ProcRenderSym MatlabCode Doc (Doc, Terminator) MethodData FileData
 
 instance UnRepr MatlabCode inner where
   unRepr = unMLC
 
-instance FileSym MatlabCode Doc (Doc, Terminator) MethodData where
+instance FileSym MatlabCode Doc (Doc, Terminator) MethodData FileData where
   fileDoc m = do
     modify (setFileType Combined)
     A.fileDoc mlExt m
   docMod = A.docMod mlExt
 
-instance RenderFile MatlabCode where
+instance RenderFile MatlabCode FileData where
   top _ = toCode empty
   bottom = toCode empty
   commentedMod = on2StateValues (on2CodeValues R.commentedMod)

--- a/code/drasil-gool/lib/Drasil/GProc/RendererClassesProc.hs
+++ b/code/drasil-gool/lib/Drasil/GProc/RendererClassesProc.hs
@@ -7,7 +7,7 @@ module Drasil.GProc.RendererClassesProc (
 ) where
 
 import Drasil.Shared.InterfaceCommon (Label, Block, Body)
-import qualified Drasil.GProc.InterfaceProc as IP (File, Module, FileSym(..))
+import qualified Drasil.GProc.InterfaceProc as IP (Module, FileSym(..))
 import Drasil.Shared.State (FS, MS)
 import Drasil.Shared.AST (ParamData)
 
@@ -16,21 +16,21 @@ import Text.PrettyPrint.HughesPJ (Doc)
 import Drasil.Shared.RendererClassesCommon (CommonRenderSym, BlockCommentSym(..),
   RenderMethod(..), MSMthdType)
 
-class (CommonRenderSym r vis stmt mthd, IP.FileSym r vis stmt mthd, RenderFile r,
-  RenderMod r, ModuleElim r, ProcRenderMethod r vis mthd
-  ) => ProcRenderSym r vis stmt mthd
+class (CommonRenderSym r vis stmt mthd, IP.FileSym r vis stmt mthd file,
+  RenderFile r file, RenderMod r, ModuleElim r, ProcRenderMethod r vis mthd
+  ) => ProcRenderSym r vis stmt mthd file
 -- Procedural-Only Typeclasses --
 
-class (BlockCommentSym r) => RenderFile r where
+class (BlockCommentSym r) => RenderFile r file | r -> file where
   -- top and bottom are only used for pre-processor guards for C++ header
   -- files. FIXME: Remove them (generation of pre-processor guards can be
   -- handled by fileDoc instead)
   top :: r IP.Module -> r Block
   bottom :: r Block
 
-  commentedMod :: FS (r IP.File) -> FS (r Doc) -> FS (r IP.File)
+  commentedMod :: FS (r file) -> FS (r Doc) -> FS (r file)
 
-  fileFromData :: FilePath -> FS (r IP.Module) -> FS (r IP.File)
+  fileFromData :: FilePath -> FS (r IP.Module) -> FS (r file)
 
 class RenderMod r where
   modFromData :: String -> FS Doc -> FS (r IP.Module)

--- a/code/drasil-gool/lib/Drasil/Shared/LanguageRenderer/CommonPseudoOO.hs
+++ b/code/drasil-gool/lib/Drasil/Shared/LanguageRenderer/CommonPseudoOO.hs
@@ -27,9 +27,8 @@ import Drasil.Shared.InterfaceCommon (UnRepr(..), varDecDef, bool,
   (&=), ValueStatement(valStmt), ControlStatement(returnStmt), VisibilitySym(..),
   MethodSym(function), funcApp, listSize)
 import qualified Drasil.Shared.InterfaceCommon as IC
-import Drasil.GOOL.InterfaceGOOL (File, Module, Class, CSStateVar,
-  OOTypeSym(obj), AttachmentSym(..), Initializers, objMethodCallNoParams,
-  objMethodCall)
+import Drasil.GOOL.InterfaceGOOL (Module, Class, CSStateVar, OOTypeSym(obj),
+  AttachmentSym(..), Initializers, objMethodCallNoParams, objMethodCall)
 import qualified Drasil.GOOL.InterfaceGOOL as IG
 import Drasil.Shared.RendererClassesCommon (CommonRenderSym, RenderBody(..),
   RenderType(..), RenderVariable(varFromData), InternalVarElim(variableBind),
@@ -91,7 +90,7 @@ int :: (Monad r) => VS (r TypeData)
 int = typeFromData Integer intRender (text intRender)
 
 constructor
-  :: (OORenderSym r vis stmt mthd stvr attch)
+  :: (OORenderSym r vis stmt mthd stvr attch file)
   => Label -> [MS (r ParamData)] -> Initializers r -> MS (r Body) -> MS (r mthd)
 constructor fName ps is b = getClassName >>= (\c -> intMethod False fName
   public instanceLevel (RG.construct c) ps (RC.multiBody [initStmts is, b]))
@@ -103,8 +102,8 @@ doxFunc = docFunc functionDox
 doxClass :: (RG.RenderClass r vis mthd stvr) => String -> CS (r Class) -> CS (r Class)
 doxClass = docClass classDox
 
-doxMod :: (RG.RenderFile r) => String -> String -> String -> [String] ->
-  String -> FS (r File) -> FS (r File)
+doxMod :: (RG.RenderFile r file) => String -> String -> String -> [String] ->
+  String -> FS (r file) -> FS (r file)
 doxMod = docMod moduleDox
 
 -- Python, Java, and C# --
@@ -256,7 +255,8 @@ mainDesc, argsDesc :: String
 mainDesc = "Controls the flow of the program"
 argsDesc = "List of command-line arguments"
 
-docMain :: (OORenderSym r vis stmt mthd stvr attch) => MS (r Body) -> MS (r mthd)
+docMain
+  :: (OORenderSym r vis stmt mthd stvr attch file) => MS (r Body) -> MS (r mthd)
 docMain b = commentedFunc (docComment $ toState $ functionDox
   mainDesc [(args, argsDesc)] []) (IC.mainFunction b)
 
@@ -280,7 +280,7 @@ mainFunction s n = RG.intFunc True n public classLevel (mType IC.void)
 --   ms is the class methods
 --   cs is the classes
 buildModule'
-  :: (OORenderSym r vis stmt mthd stvr attch, UnRepr r Doc)
+  :: (OORenderSym r vis stmt mthd stvr attch file, UnRepr r Doc)
   => Label
   -> (String -> r Doc)
   -> [Label]
@@ -381,7 +381,7 @@ destructorError :: String -> String
 destructorError l = "Destructors not allowed in " ++ l
 
 stateVarDef
-  :: (OORenderSym r vis stmt mthd stvr attch, Monad r)
+  :: (OORenderSym r vis stmt mthd stvr attch file, Monad r)
   => r vis -> r attch -> SVariable r -> SValue r -> CS (r Doc)
 stateVarDef s p vr vl = zoom lensCStoMS $ onStateValue (toCode . R.stateVar
   (RC.visibility  s) (RG.perm p) . RC.statement)
@@ -444,7 +444,7 @@ openFileW
 openFileW f vr vl = vr &= f vl outfile IC.litFalse
 
 stateVar
-  :: (Monad r, OORenderSym r vis stmt mthd stvr attch)
+  :: (Monad r, OORenderSym r vis stmt mthd stvr attch file)
   => r vis -> r attch -> SVariable r -> CS (r Doc)
 stateVar s p v = zoom lensCStoMS $ onStateValue (toCode . R.stateVar
   (RC.visibility s) (RG.perm p) . RC.statement) (RC.stmt $ IC.varDec v IC.local)
@@ -491,7 +491,7 @@ listDec
 listDec v scp = listDecDef v scp []
 
 funcDecDef
-  :: (OORenderSym r vis stmt mthd stvr attch)
+  :: (OORenderSym r vis stmt mthd stvr attch file)
   => SVariable r -> r ScopeData -> [SVariable r] -> MS (r Body) -> MS (r stmt)
 funcDecDef v scp ps b = do
   vr <- zoom lensMStoVS v

--- a/code/drasil-gool/lib/Drasil/Shared/LanguageRenderer/LanguagePolymorphic.hs
+++ b/code/drasil-gool/lib/Drasil/Shared/LanguageRenderer/LanguagePolymorphic.hs
@@ -29,7 +29,7 @@ import Drasil.Shared.InterfaceCommon (UnRepr(..), Label, Library, Body, Block,
   VSBinder, BinderElim(..), getCodeType, getTypeString, ValueExpression,
   VariableValue, BodySym)
 import qualified Drasil.Shared.InterfaceCommon as IC
-import Drasil.GOOL.InterfaceGOOL (File, Module, Class, Initializers, CSStateVar,
+import Drasil.GOOL.InterfaceGOOL (Module, Class, Initializers, CSStateVar,
   newObj, objMethodCallNoParams, ($.), AttachmentSym(..), SelfSym)
 import qualified Drasil.GOOL.InterfaceGOOL as IG
 import Drasil.Shared.RendererClassesCommon (InternalVarElim(variableBind),
@@ -546,12 +546,14 @@ method
   -> MS (r mthd)
 method n s p t = intMethod False n s p (mType t)
 
-getMethod :: (OORenderSym r vis stmt mthd stvr attch) => SVariable r -> MS (r mthd)
+getMethod
+  :: (OORenderSym r vis stmt mthd stvr attch file) => SVariable r -> MS (r mthd)
 getMethod v = zoom lensMStoVS v >>= (\vr -> IG.method (getterName $ variableName
   vr) public instanceLevel (toState $ variableType vr) [] getBody)
   where getBody = oneLiner $ IC.returnStmt (IC.valueOf $ IG.instanceVarSelf v)
 
-setMethod :: (OORenderSym r vis stmt mthd stvr attch) => SVariable r -> MS (r mthd)
+setMethod
+  :: (OORenderSym r vis stmt mthd stvr attch file) => SVariable r -> MS (r mthd)
 setMethod v = zoom lensMStoVS v >>= (\vr -> IG.method (setterName $ variableName
   vr) public instanceLevel IC.void [IC.param v] setBody)
   where setBody = oneLiner $ IG.instanceVarSelf v &= IC.valueOf v
@@ -607,8 +609,8 @@ modFromData n f d = modify (setModuleName n) >> onStateValue f d
 -- Files --
 
 fileDoc
-  :: (RC.BlockElim r, RenderMod r, RenderFile r)
-  => String -> (r Module -> r Block) -> r Block -> FS (r Module) -> FS (r File)
+  :: (RC.BlockElim r, RenderMod r, RenderFile r file)
+  => String -> (r Module -> r Block) -> r Block -> FS (r Module) -> FS (r file)
 fileDoc ext topb botb mdl = do
   m <- mdl
   nm <- getModuleName
@@ -626,21 +628,21 @@ fileDoc ext topb botb mdl = do
 --   dt is the date
 --   fl is the file
 docMod
-  :: (RenderFile r)
+  :: (RenderFile r file)
   => ModuleDocRenderer
   -> String
   -> String
   -> String
   -> [String]
   -> String
-  -> FS (r File)
-  -> FS (r File)
+  -> FS (r file)
+  -> FS (r file)
 docMod mdr e wm d a dt fl = commentedMod fl (docComment $ mdr wm d a dt . addExt e
   <$> getModuleName)
 
 fileFromData
   :: (RO.ModuleElim r)
-  => (FilePath -> r Module -> r File) -> FilePath -> FS (r Module) -> FS (r File)
+  => (FilePath -> r Module -> r file) -> FilePath -> FS (r Module) -> FS (r file)
 fileFromData f fpath mdl' = do
   -- Add this file to list of files as long as it is not empty
   mdl <- mdl'

--- a/code/drasil-gool/lib/Drasil/Shared/LanguageRenderer/LoggingFor.hs
+++ b/code/drasil-gool/lib/Drasil/Shared/LanguageRenderer/LoggingFor.hs
@@ -423,21 +423,21 @@ instance (NativeVector lang) => NativeVector (LoggingFor lang) where
 
 -- GProc
 
-instance (P.ProcProg r vis stmt mthd prg) => P.ProcProg (LoggingFor r) vis stmt mthd prg
+instance (P.ProcProg r vis stmt mthd prg file) => P.ProcProg (LoggingFor r) vis stmt mthd prg file
 
 instance (P.ModuleSym r vis stmt mthd) => P.ModuleSym (LoggingFor r) vis stmt mthd where
   buildModule = liftLogging P.buildModule
 
-instance (P.FileSym r vis stmt mthd) => P.FileSym (LoggingFor r) vis stmt mthd where
+instance (P.FileSym r vis stmt mthd file) => P.FileSym (LoggingFor r) vis stmt mthd file where
   fileDoc = liftLogging P.fileDoc
   docMod = liftLogging P.docMod
 
-instance (P.ProgramSym r vis stmt mthd prg) => P.ProgramSym (LoggingFor r) vis stmt mthd prg where
+instance (P.ProgramSym r prg file) => P.ProgramSym (LoggingFor r) prg file where
   prog = liftLogging P.prog
 
 -- GOOL
 
-instance (G.OOProg r vis stmt mthd stvr attch prg) => G.OOProg (LoggingFor r) vis stmt mthd stvr attch prg
+instance (G.OOProg r vis stmt mthd stvr attch prg file) => G.OOProg (LoggingFor r) vis stmt mthd stvr attch prg file
 
 instance (G.GetSet r) => G.GetSet (LoggingFor r) where
   get = liftLogging G.get
@@ -511,11 +511,11 @@ instance (G.ClassSym r vis stmt mthd stvr attch) => G.ClassSym (LoggingFor r) vi
 instance (G.ModuleSym r vis stmt mthd stvr attch) => G.ModuleSym (LoggingFor r) vis stmt mthd stvr attch where
   buildModule = liftLogging G.buildModule
 
-instance (G.FileSym r vis stmt mthd stvr attch) => G.FileSym (LoggingFor r) vis stmt mthd stvr attch where
+instance (G.FileSym r vis stmt mthd stvr attch file) => G.FileSym (LoggingFor r) vis stmt mthd stvr attch file where
   fileDoc = liftLogging G.fileDoc
   docMod = liftLogging G.docMod
 
-instance (G.ProgramSym r vis stmt mthd stvr attch prg) => G.ProgramSym (LoggingFor r) vis stmt mthd stvr attch prg where
+instance (G.ProgramSym r prg file) => G.ProgramSym (LoggingFor r) prg file where
   prog = liftLogging G.prog
 
 instance (G.StrategyPattern r stmt) => G.StrategyPattern (LoggingFor r) stmt where


### PR DESCRIPTION
Contributes to #5328

Once every part of GOOL's current "AST" is parameterized, we can move to the next step of removing the `repr` type and changing the fundeps from `r -> ...` to `<larger language feature repr> -> <smaller language feature repr>`.

For #5328 we'll need to decouple the typeclasses anyway, and it's less work if I start doing it now than if I leave it for later.