### PR TITLE
Removed `MethodSym` as a constraint on `ModuleSym`

### DIFF
--- a/code/drasil-gool/lib/Drasil/GOOL/CodeInfoOO.hs
+++ b/code/drasil-gool/lib/Drasil/GOOL/CodeInfoOO.hs
@@ -501,7 +501,7 @@ instance ClassSym CodeInfoOO () () () () () where
     _ <- c
     return $ error "[docClass] The return value of this isn't used, and the thunk shouldn't fire."
 
-instance ModuleSym CodeInfoOO () () () () () () where
+instance ModuleSym CodeInfoOO () () where
   buildModule n _ funcs classes = do
     modify (setModuleName n)
     mapM_ (zoom lensFStoCS) classes

--- a/code/drasil-gool/lib/Drasil/GOOL/InterfaceGOOL.hs
+++ b/code/drasil-gool/lib/Drasil/GOOL/InterfaceGOOL.hs
@@ -49,13 +49,13 @@ class (UnRepr r TypeData, Argument r, CommandLineArgs r, Literal r,
   NumericExpression r, InternalValueExp r, OOValueExpression r, Array r,
   List r, ListStatement r stmt, Reference r, Set r, OOFunctionSym r,
   ParameterSym r, VariableValue r, ScopeSym r, BinderSym r, InternalList r,
-  MethodSym r vis stmt mthd, TypeElim r, VariableElim r, EmptyStatement r stmt,
-  MultiStatement r stmt, ValueStatement r stmt, CommentStatement r stmt,
-  OODeclStatement r stmt, AssignStatement r stmt, OOFuncAppStatement r stmt,
-  ControlStatement r stmt, StringStatement r stmt, PrintConsole r stmt,
-  ReadConsole r stmt, FileHandling r stmt, PrintFile r stmt, ReadFile r stmt,
-  ModuleSym r vis stmt mthd stvr attch mod, FileSym r file mod,
-  ProgramSym r prg file
+  OOMethodSym r vis stmt mthd attch, ClassSym r vis stmt mthd stvr attch,
+  TypeElim r, VariableElim r, EmptyStatement r stmt, MultiStatement r stmt,
+  ValueStatement r stmt, CommentStatement r stmt, OODeclStatement r stmt,
+  AssignStatement r stmt, OOFuncAppStatement r stmt, ControlStatement r stmt,
+  StringStatement r stmt, PrintConsole r stmt, ReadConsole r stmt,
+  FileHandling r stmt, PrintFile r stmt, ReadFile r stmt,
+  ModuleSym r mod mthd, FileSym r file mod, ProgramSym r prg file
   ) => OOProg r vis stmt mthd stvr attch prg file mod
 
 type Program = ProgData
@@ -80,7 +80,7 @@ class FileSym r file mod | r -> file mod where
   docMod :: String -> String -> [String] -> String -> FS (r file) -> FS (r file)
 
 -- | Class for representing a module.
-class (ClassSym r vis stmt mthd stvr attch) => ModuleSym r vis stmt mthd stvr attch mod | r -> mod where
+class ModuleSym r mod mthd | r -> mod mthd where
   -- | Given module name, list of import names, list of module functions,
   -- and list of module classes, generates a representation of a module.
   buildModule :: Label -> [Label] -> [MS (r mthd)] -> [CS (r Class)] -> FS (r mod)

--- a/code/drasil-gool/lib/Drasil/GOOL/LanguageRenderer/CSharpRenderer.hs
+++ b/code/drasil-gool/lib/Drasil/GOOL/LanguageRenderer/CSharpRenderer.hs
@@ -704,7 +704,7 @@ instance RenderClass CSharpCode Doc MethodData StateVar where
 instance ClassElim CSharpCode where
   class' = unCSC
 
-instance ModuleSym CSharpCode Doc (Doc, Terminator) MethodData StateVar Doc ModData where
+instance ModuleSym CSharpCode ModData MethodData where
   buildModule n = CP.buildModule' n langImport
 
 instance RenderMod CSharpCode ModData where

--- a/code/drasil-gool/lib/Drasil/GOOL/LanguageRenderer/CppRenderer.hs
+++ b/code/drasil-gool/lib/Drasil/GOOL/LanguageRenderer/CppRenderer.hs
@@ -813,7 +813,7 @@ instance (Pair p) => RenderClass (p CppSrcCode CppHdrCode)
 instance (Pair p) => ClassElim (p CppSrcCode CppHdrCode) where
   class' c = RC.class' $ pfst c
 
-instance (Pair p) => ModuleSym (p CppSrcCode CppHdrCode) (Doc, VisibilityTag) (Doc, Terminator) MethodData StateVarData AttachmentData ModData where
+instance (Pair p) => ModuleSym (p CppSrcCode CppHdrCode) ModData MethodData where
   buildModule n is ms cs = do
     modify (setModuleName n)
     pair2Lists (buildModule n is) (buildModule n is)
@@ -1705,7 +1705,7 @@ instance RenderClass CppSrcCode (Doc, VisibilityTag) MethodData StateVarData whe
 instance ClassElim CppSrcCode where
   class' = unCPPSC
 
-instance ModuleSym CppSrcCode (Doc, VisibilityTag) (Doc, Terminator) MethodData StateVarData AttachmentData ModData where
+instance ModuleSym CppSrcCode ModData MethodData where
   buildModule n is ms cs = CP.buildModule n (do
     ds <- getDefines
     lis <- getLangImports
@@ -2344,7 +2344,7 @@ instance RenderClass CppHdrCode (Doc, VisibilityTag) MethodData StateVarData whe
 instance ClassElim CppHdrCode where
   class' = unCPPHC
 
-instance ModuleSym CppHdrCode (Doc, VisibilityTag) (Doc, Terminator) MethodData StateVarData AttachmentData ModData where
+instance ModuleSym CppHdrCode ModData MethodData where
   buildModule n is = CP.buildModule n (do
     ds <- getHeaderDefines
     lis <- getHeaderLangImports

--- a/code/drasil-gool/lib/Drasil/GOOL/LanguageRenderer/JavaRenderer.hs
+++ b/code/drasil-gool/lib/Drasil/GOOL/LanguageRenderer/JavaRenderer.hs
@@ -733,7 +733,7 @@ instance RenderClass JavaCode Doc MethodData StateVar where
 instance ClassElim JavaCode where
   class' = unJC
 
-instance ModuleSym JavaCode Doc (Doc, Terminator) MethodData StateVar Doc ModData where
+instance ModuleSym JavaCode ModData MethodData where
   buildModule n = CP.buildModule' n langImport
 
 instance RenderMod JavaCode ModData where

--- a/code/drasil-gool/lib/Drasil/GOOL/LanguageRenderer/PythonRenderer.hs
+++ b/code/drasil-gool/lib/Drasil/GOOL/LanguageRenderer/PythonRenderer.hs
@@ -725,7 +725,7 @@ instance RenderClass PythonCode Doc MethodData StateVar where
 instance ClassElim PythonCode where
   class' = unPC
 
-instance ModuleSym PythonCode Doc (Doc, Terminator) MethodData StateVar AttachmentData ModData where
+instance ModuleSym PythonCode ModData MethodData where
   buildModule n is = CP.buildModule n (do
     lis <- getLangImports
     libis <- getLibImports

--- a/code/drasil-gool/lib/Drasil/GOOL/LanguageRenderer/SwiftRenderer.hs
+++ b/code/drasil-gool/lib/Drasil/GOOL/LanguageRenderer/SwiftRenderer.hs
@@ -745,7 +745,7 @@ instance RenderClass SwiftCode Doc MethodData StateVar where
 instance ClassElim SwiftCode where
   class' = unSC
 
-instance ModuleSym SwiftCode Doc (Doc, Terminator) MethodData StateVar Doc ModData where
+instance ModuleSym SwiftCode ModData MethodData where
   buildModule n is fs cs = do
     modify (setModuleName n) -- This needs to be set before the functions/
                              -- classes are evaluated. CP.buildModule will

--- a/code/drasil-gool/lib/Drasil/GOOL/RendererClassesOO.hs
+++ b/code/drasil-gool/lib/Drasil/GOOL/RendererClassesOO.hs
@@ -10,7 +10,8 @@ module Drasil.GOOL.RendererClassesOO (
 import Drasil.Shared.InterfaceCommon (Label, Block, Body, SVariable, SValue)
 import qualified Drasil.GOOL.InterfaceGOOL as IG (Class, CSStateVar,
   OOVariableValue, OOValueExpression(..), InternalValueExp(..), FileSym(..),
-  GetSet(..), ObserverPattern(..), StrategyPattern(..), ModuleSym)
+  GetSet(..), ObserverPattern(..), StrategyPattern(..), ModuleSym, OOMethodSym,
+  ClassSym)
 import Drasil.Shared.AST (AttachmentTag, TypeData, ParamData, FuncData)
 import Drasil.Shared.State (FS, CS, VS, MS)
 
@@ -20,12 +21,13 @@ import Drasil.Shared.RendererClassesCommon (MSMthdType, CommonRenderSym,
   BlockCommentSym(..), MethodTypeSym(..), RenderMethod(..))
 
 class (CommonRenderSym r vis stmt mthd,
-  IG.ModuleSym r vis stmt mthd stvr attch mod, IG.FileSym r file mod,
-  IG.InternalValueExp r, IG.GetSet r, IG.ObserverPattern r stmt,
-  IG.StrategyPattern r stmt, IG.OOVariableValue r, IG.OOValueExpression r,
-  RenderClass r vis mthd stvr, ClassElim r, RenderFile r file mod,
-  InternalGetSet r, OORenderMethod r vis mthd attch, RenderMod r mod,
-  ModuleElim r mod, StateVarElim r stvr, PermElim r attch
+  IG.OOMethodSym r vis stmt mthd attch, IG.ClassSym r vis stmt mthd stvr attch,
+  IG.ModuleSym r mod mthd, IG.FileSym r file mod, IG.InternalValueExp r,
+  IG.GetSet r, IG.ObserverPattern r stmt, IG.StrategyPattern r stmt,
+  IG.OOVariableValue r, IG.OOValueExpression r, RenderClass r vis mthd stvr,
+  ClassElim r, RenderFile r file mod, InternalGetSet r,
+  OORenderMethod r vis mthd attch, RenderMod r mod, ModuleElim r mod,
+  StateVarElim r stvr, PermElim r attch
   ) => OORenderSym r vis stmt mthd stvr attch file mod
 
 -- OO-Only Typeclasses --

--- a/code/drasil-gool/lib/Drasil/GProc/InterfaceProc.hs
+++ b/code/drasil-gool/lib/Drasil/GProc/InterfaceProc.hs
@@ -32,7 +32,8 @@ class (UnRepr r TypeData, FunctionSym r, VariableValue r, ScopeSym r,
   ReadFile r stmt, List r, ListStatement r stmt, Literal r, MathConstant r,
   NumericExpression r, ParameterSym r, Reference r, Set r,
   StringStatement r stmt, ValueExpression r, VariableValue r,
-  ModuleSym r vis stmt mthd mod, FileSym r file mod, ProgramSym r prg file)
+  MethodSym r vis stmt mthd, ModuleSym r mod mthd, FileSym r file mod,
+  ProgramSym r prg file)
   => ProcProg r vis stmt mthd prg file mod
 
 type Program = ProgData
@@ -57,7 +58,7 @@ class FileSym r file mod | r -> file mod where
   docMod :: String -> String -> [String] -> String -> FS (r file) -> FS (r file)
 
 -- | Class for representing a module.
-class (MethodSym r vis stmt mthd) => ModuleSym r vis stmt mthd mod | r -> mod where
+class ModuleSym r mod mthd | r -> mod mthd where
   -- | Given module name, list of import names, and list of module functions,
   -- generates a representation of a module.
   buildModule :: Label -> [Label] -> [MS (r mthd)] -> FS (r mod)

--- a/code/drasil-gool/lib/Drasil/GProc/LanguageRenderer/JuliaRenderer.hs
+++ b/code/drasil-gool/lib/Drasil/GProc/LanguageRenderer/JuliaRenderer.hs
@@ -584,7 +584,7 @@ instance ProcRenderMethod JuliaCode Doc MethodData where
 instance MethodElim JuliaCode MethodData where
   method = mthdDoc . unJLC
 
-instance ModuleSym JuliaCode Doc (Doc, Terminator) MethodData ModData where
+instance ModuleSym JuliaCode ModData MethodData where
   buildModule n is fs = jlModContents n is fs <&>
     updateModuleDoc (\m -> emptyIfEmpty m (vibcat [jlModStart n, m, jlEnd]))
 

--- a/code/drasil-gool/lib/Drasil/GProc/LanguageRenderer/MatlabRenderer.hs
+++ b/code/drasil-gool/lib/Drasil/GProc/LanguageRenderer/MatlabRenderer.hs
@@ -569,7 +569,7 @@ instance ProcRenderMethod MatlabCode Doc MethodData where
 instance MethodElim MatlabCode MethodData where
   method = mthdDoc . unMLC
 
-instance ModuleSym MatlabCode Doc (Doc, Terminator) MethodData ModData where
+instance ModuleSym MatlabCode ModData MethodData where
   buildModule n _ fs = modFromData n (do
     fns <- mapM (zoom lensFStoMS) fs
     entryFn <- mlMainFunc n

--- a/code/drasil-gool/lib/Drasil/GProc/RendererClassesProc.hs
+++ b/code/drasil-gool/lib/Drasil/GProc/RendererClassesProc.hs
@@ -6,7 +6,7 @@ module Drasil.GProc.RendererClassesProc (
   ProcRenderMethod(..)
 ) where
 
-import Drasil.Shared.InterfaceCommon (Label, Block, Body)
+import Drasil.Shared.InterfaceCommon (Label, Block, Body, MethodSym)
 import qualified Drasil.GProc.InterfaceProc as IP (FileSym(..), ModuleSym)
 import Drasil.Shared.State (FS, MS)
 import Drasil.Shared.AST (ParamData)
@@ -16,9 +16,9 @@ import Text.PrettyPrint.HughesPJ (Doc)
 import Drasil.Shared.RendererClassesCommon (CommonRenderSym, BlockCommentSym(..),
   RenderMethod(..), MSMthdType)
 
-class (CommonRenderSym r vis stmt mthd, IP.ModuleSym r vis stmt mthd mod,
-  IP.FileSym r file mod, RenderFile r file mod, RenderMod r mod,
-  ModuleElim r mod, ProcRenderMethod r vis mthd
+class (CommonRenderSym r vis stmt mthd, MethodSym r vis stmt mthd,
+  IP.ModuleSym r mod mthd, IP.FileSym r file mod, RenderFile r file mod,
+  RenderMod r mod, ModuleElim r mod, ProcRenderMethod r vis mthd
   ) => ProcRenderSym r vis stmt mthd file mod
 -- Procedural-Only Typeclasses --
 

--- a/code/drasil-gool/lib/Drasil/Shared/LanguageRenderer/LanguagePolymorphic.hs
+++ b/code/drasil-gool/lib/Drasil/Shared/LanguageRenderer/LanguagePolymorphic.hs
@@ -549,14 +549,14 @@ method n s p t = intMethod False n s p (mType t)
 getMethod
   :: (OORenderSym r vis stmt mthd stvr attch file mod)
   => SVariable r -> MS (r mthd)
-getMethod v = zoom lensMStoVS v >>= (\vr -> IG.method (getterName $ variableName
+getMethod v = zoom lensMStoVS v >>= (\vr -> method (getterName $ variableName
   vr) public instanceLevel (toState $ variableType vr) [] getBody)
   where getBody = oneLiner $ IC.returnStmt (IC.valueOf $ IG.instanceVarSelf v)
 
 setMethod
   :: (OORenderSym r vis stmt mthd stvr attch file mod)
   => SVariable r -> MS (r mthd)
-setMethod v = zoom lensMStoVS v >>= (\vr -> IG.method (setterName $ variableName
+setMethod v = zoom lensMStoVS v >>= (\vr -> method (setterName $ variableName
   vr) public instanceLevel IC.void [IC.param v] setBody)
   where setBody = oneLiner $ IG.instanceVarSelf v &= IC.valueOf v
 

--- a/code/drasil-gool/lib/Drasil/Shared/LanguageRenderer/LoggingFor.hs
+++ b/code/drasil-gool/lib/Drasil/Shared/LanguageRenderer/LoggingFor.hs
@@ -425,7 +425,7 @@ instance (NativeVector lang) => NativeVector (LoggingFor lang) where
 
 instance (P.ProcProg r vis stmt mthd prg file mod) => P.ProcProg (LoggingFor r) vis stmt mthd prg file mod
 
-instance (P.ModuleSym r vis stmt mthd mod) => P.ModuleSym (LoggingFor r) vis stmt mthd mod where
+instance (P.ModuleSym r mod mthd) => P.ModuleSym (LoggingFor r) mod mthd where
   buildModule = liftLogging P.buildModule
 
 instance (P.FileSym r file mod) => P.FileSym (LoggingFor r) file mod where
@@ -508,7 +508,7 @@ instance (G.ClassSym r vis stmt mthd stvr attch) => G.ClassSym (LoggingFor r) vi
   implementingClass = liftLogging G.implementingClass
   docClass = liftLogging G.docClass
 
-instance (G.ModuleSym r vis stmt mthd stvr attch mod) => G.ModuleSym (LoggingFor r) vis stmt mthd stvr attch mod where
+instance (G.ModuleSym r mod mthd) => G.ModuleSym (LoggingFor r) mod mthd where
   buildModule = liftLogging G.buildModule
 
 instance (G.FileSym r file mod) => G.FileSym (LoggingFor r) file mod where


### PR DESCRIPTION
Contributes to #5328 

Decoupling the typeclasses seems to have two benefits: it reduces the number of type variables on most type classes, and it's necessary to do before we remove `repr`.