### PR TITLE
refactor(`-gen`): remove unnecessary return values in `writeSmithEtAlSrs`

### DIFF
--- a/code/drasil-gen/lib/Drasil/Generator/CaseStudyVariants.hs
+++ b/code/drasil-gen/lib/Drasil/Generator/CaseStudyVariants.hs
@@ -26,19 +26,19 @@ import Drasil.System (HasProjectName(..))
 
 -- | Internal: Generate documents and construct the SRS directory layout
 -- structure (and debug data) for an example.
-writeSmithEtAlSrs :: SmithEtAlSRS -> SRSDecl -> String -> IO ([FileLayout], SmithEtAlSRS)
+writeSmithEtAlSrs :: SmithEtAlSRS -> SRSDecl -> String -> IO [FileLayout]
 writeSmithEtAlSrs syst srsDecl srsFileName = do
   let (srs, syst') = mkDoc syst srsDecl S.forT'
-  typeCheckSI syst' -- FIXME: This should be done on `System` creation *or* chunk creation!
+  typeCheckSI syst -- FIXME: This should be done on `System` creation *or* chunk creation!
   let layout = genSmithEtAlSrs syst' srs srsFileName
-  pure (layout, syst')
+  pure layout
 
 -- | A case study that only outputs an SRS in each of our supported variants.
 caseStudyMainSRS :: SmithEtAlSRS -> SRSDecl -> String -> IO ()
 caseStudyMainSRS syst srsDecl srsFileName = do
   setSystemLocale
   let exampleName = syst ^. projRepoName
-  (docLayouts, _) <- writeSmithEtAlSrs syst srsDecl srsFileName
+  docLayouts <- writeSmithEtAlSrs syst srsDecl srsFileName
   writeFiles OverwriteAllowed localPath $ directory [ps|{exampleName}|] docLayouts
 
 -- | A case study that outputs both an SRS in each of our supported variants as
@@ -48,8 +48,8 @@ caseStudyMainSRSWCode :: SmithEtAlSRS -> SRSDecl -> String -> Choices -> IO ()
 caseStudyMainSRSWCode syst srsDecl srsFileName choices = do
   setSystemLocale
   let exampleName = syst ^. projRepoName
-  (docLayouts, syst') <- writeSmithEtAlSrs syst srsDecl srsFileName
-  srcLayout <- genCode syst' choices
+  docLayouts <- writeSmithEtAlSrs syst srsDecl srsFileName
+  srcLayout <- genCode syst choices
   writeFiles OverwriteAllowed localPath $ directory [ps|{exampleName}|] $ srcLayout : docLayouts
 
 -- | The same as 'caseStudyMainSRSWCode', except it also produces a
@@ -58,7 +58,7 @@ caseStudyMainSRSWCodeZoo :: SmithEtAlSRS -> SRSDecl -> String -> [Choices] -> IO
 caseStudyMainSRSWCodeZoo syst srsDecl srsFileName choices = do
   setSystemLocale
   let exampleName = syst ^. projRepoName
-  (docLayouts, syst') <- writeSmithEtAlSrs syst srsDecl srsFileName
-  zooLayouts <- genCodeZoo syst' choices
+  docLayouts <- writeSmithEtAlSrs syst srsDecl srsFileName
+  zooLayouts <- genCodeZoo syst choices
   let layout = directory [ps|{exampleName}|] $ docLayouts ++ zooLayouts
   writeFiles OverwriteAllowed localPath layout

--- a/code/drasil-gen/lib/Drasil/Generator/CaseStudyVariants.hs
+++ b/code/drasil-gen/lib/Drasil/Generator/CaseStudyVariants.hs
@@ -14,9 +14,8 @@ import Control.Lens ((^.))
 
 import Drasil.FileHandling (FileLayout, OverwritePolicy(..), directory, localPath, ps,
   writeFiles)
-import Drasil.SRS (SRSDecl, mkDoc, SmithEtAlSRS)
+import Drasil.SRS (SRSDecl, SmithEtAlSRS)
 import Language.Drasil.Code (Choices)
-import qualified Language.Drasil.Sentence.Combinators as S
 
 import Drasil.Generator.Code (genCode, genCodeZoo)
 import Drasil.Generator.SRS (genSmithEtAlSrs)
@@ -28,10 +27,8 @@ import Drasil.System (HasProjectName(..))
 -- structure (and debug data) for an example.
 writeSmithEtAlSrs :: SmithEtAlSRS -> SRSDecl -> String -> IO [FileLayout]
 writeSmithEtAlSrs syst srsDecl srsFileName = do
-  let (srs, syst') = mkDoc syst srsDecl S.forT'
   typeCheckSI syst -- FIXME: This should be done on `System` creation *or* chunk creation!
-  let layout = genSmithEtAlSrs syst' srs srsFileName
-  pure layout
+  pure $ genSmithEtAlSrs syst srsDecl srsFileName
 
 -- | A case study that only outputs an SRS in each of our supported variants.
 caseStudyMainSRS :: SmithEtAlSRS -> SRSDecl -> String -> IO ()

--- a/code/drasil-gen/lib/Drasil/Generator/SRS.hs
+++ b/code/drasil-gen/lib/Drasil/Generator/SRS.hs
@@ -16,30 +16,33 @@ import Language.Drasil.Printers (genericCSS, genHTML, genTeX,
 import Drasil.Makefile ((+:+), makeS, mkCheckedCommand, mkCommand,
   mkFreeVar, mkFile, mkRule, mkMakefile, printMakefile)
 import Drasil.Metadata (watermark)
-import Drasil.SRS (mkGraphInfo, SmithEtAlSRS)
+import Drasil.SRS (mkGraphInfo, SmithEtAlSRS, mkDoc, SRSDecl)
 import Drasil.System (systemdb)
+import qualified Language.Drasil.Sentence.Combinators as S
 
 import Drasil.Generator.Formats (Filename, Format(..))
 import Drasil.Generator.SRS.TraceabilityGraphs (outputDot)
 
 -- | Generate Drasil's SRS (in HTML, TeX, Jupyter, and MDBook formats).
-genSmithEtAlSrs :: SmithEtAlSRS -> Document -> String -> [FileLayout]
-genSmithEtAlSrs syst doc srsFileName =
+genSmithEtAlSrs :: SmithEtAlSRS -> SRSDecl -> String -> [FileLayout]
+genSmithEtAlSrs syst srsDecl srsFileName =
   [ srsLayout,
     traceyLayout
   ]
   where
-    pinfo = piSys (syst ^. systemdb) Equational Engineering
+    (srsDoc, syst') = mkDoc syst srsDecl S.forT'
+
+    pinfo = piSys (syst' ^. systemdb) Equational Engineering
     srsLayout =
       directory [ps|SRS|] $
         map
           ( \x ->
               let x' = show x
               in directory [ps|{x'}|] $
-                    prntDoc doc pinfo srsFileName x
+                    prntDoc srsDoc pinfo srsFileName x
           )
           [HTML, TeX, Jupyter, MDBook]
-    traceyLayout = outputDot (mkGraphInfo syst)
+    traceyLayout = outputDot (mkGraphInfo syst')
 
 -- | Internal: Render an SRS in a specified 'Format' and lay out artifacts into
 -- a `[FileLayout]`.


### PR DESCRIPTION
The reason why the (`SmithEtAlSRS`) 'system' was updated and passed around was because the `ChunkDB` was being updated and the code generator previously relied on the updated `ChunkDB` (a purely operational issue related to `Reference`s being/not being inserted at the right times -- fixed recently). "Growing" a `ChunkDB` is likely something we will want, but not a hard requirement right now. Once we have a need for that, we can build a proper state monad that we can pass a `ChunkDB` through.