### PR TITLE
fix(`HasChunkRefs InstanceModel`): include chunk references from derivations and decorated references

### DIFF
--- a/code/drasil-theory/lib/Theory/Drasil/InstanceModel.hs
+++ b/code/drasil-theory/lib/Theory/Drasil/InstanceModel.hs
@@ -45,6 +45,8 @@ instance HasChunkRefs InstanceModel where
     [ chunkRefs (imd ^. mk)
     , chunkRefs (map fst (imd ^. imInputs))
     , chunkRefs (imd ^. imOutput . _1)
+    , chunkRefs (imd ^. rf)
+    , chunkRefs (imd ^. deri)
     , chunkRefs (lb imd)
     , chunkRefs (imd ^. notes)
     ]


### PR DESCRIPTION
Updates the "chunk reference" list to include things it previously didn't (a mistake most likely).