### PR TITLE
Introduce `ReasonableValue` ADT and remove `MayHaveRationale`

### DIFF
--- a/code/drasil-lang/lib/Language/Drasil.hs
+++ b/code/drasil-lang/lib/Language/Drasil.hs
@@ -56,7 +56,6 @@ module Language.Drasil (
   , HasUnitSymbol(usymb)
   , Quantity
   , HasReasVal(reasVal)
-  , MayHaveRationale(rationale)
   , Constrained(constraints)
   , HasAdditionalNotes(getNotes)
   , IsUnit(getUnits)
@@ -108,6 +107,8 @@ module Language.Drasil (
   , ConstrConcept(..)
   , constrained', constrainedWithRationale, cuc', cuc'', cucNoUnit', constrainedNRV'
   , cnstrw'
+  -- Language.Drasil.ReasonableValue
+  , ReasonableValue, reasonableValue, reasV, rationale
   -- Language.Drasil.Chunk.UncertainQuantity
   , UncertQ, uq, uqc, uqcND, uqDirect
   -- Language.Drasil.Uncertainty
@@ -242,7 +243,7 @@ import Language.Drasil.Unicode (RenderSpecial(..), Special(..))
 import Language.Drasil.Symbol (HasSymbol(symbol), Decoration, Symbol)
 import Language.Drasil.Classes (Definition(defn), ConceptDomain(cdom), Concept, HasUnitSymbol(usymb),
   IsUnit(getUnits), CommonIdea(abrv), HasAdditionalNotes(getNotes), Constrained(constraints),
-  HasReasVal(reasVal), MayHaveRationale(rationale), DefiningExpr(defnExpr), Quantity)
+  HasReasVal(reasVal), DefiningExpr(defnExpr), Quantity)
 import Language.Drasil.Data.Date (Month(..))
 import Language.Drasil.Chunk.Citation (
     Citation, EntryID, BibRef
@@ -272,6 +273,7 @@ import Language.Drasil.Data.Citation (CiteField(..), HP(..), CitationKind(..)
   , chapter, edition, number, volume, year, month, pages
   , compareAuthYearTitle)
 import Language.Drasil.NaturalLanguage.English.NounPhrase
+import Language.Drasil.ReasonableValue (ReasonableValue, rationale, reasV, reasonableValue)
 import Language.Drasil.ShortName (ShortName, shortname', getSentSN, HasShortName(..))
 import Language.Drasil.Space (Space(..), RealInterval(..), Inclusive(..),
   RTopology(..), DomainDesc(..), ContinuousDomainDesc, DiscreteDomainDesc,

--- a/code/drasil-lang/lib/Language/Drasil/Chunk/Constrained.hs
+++ b/code/drasil-lang/lib/Language/Drasil/Chunk/Constrained.hs
@@ -14,7 +14,7 @@ import Language.Drasil.Chunk.DefinedQuantity (DefinedQuantityDict, dqdWr, quant,
 import Language.Drasil.Symbol (HasSymbol(..), Symbol)
 import Language.Drasil.Classes (NamedIdea(term), Idea(getA), Express(express),
   Definition(defn), Concept, Quantity,
-  Constrained(constraints), HasReasVal(reasVal), MayHaveRationale(rationale))
+  Constrained(constraints), HasReasVal(reasVal))
 import Language.Drasil.Constraint (ConstraintE)
 import Language.Drasil.Chunk.UnitDefn (MayHaveUnit(getUnit), UnitDefn)
 import Language.Drasil.Expr.Lang (Expr(..))
@@ -23,6 +23,7 @@ import Language.Drasil.NaturalLanguage.English.NounPhrase.Core (NP)
 import Language.Drasil.Sentence (Sentence(S))
 import Language.Drasil.Space (Space, HasSpace(..))
 import Language.Drasil.Stages (Stage)
+import Language.Drasil.ReasonableValue (ReasonableValue, reasonableValue)
 
 -- | ConstrConcepts are conceptual symbolic quantities ('DefinedQuantityDict')
 -- with 'Constraint's and maybe a reasonable value.
@@ -32,8 +33,7 @@ import Language.Drasil.Stages (Stage)
 data ConstrConcept = ConstrConcept { _uu         :: UID
                                    , _defq       :: DefinedQuantityDict
                                    , _constr'    :: [ConstraintE]
-                                   , _reasV'     :: Maybe Expr
-                                   , _rationale' :: Maybe Sentence
+                                   , _reasV'     :: Maybe ReasonableValue
                                    }
 makeLenses ''ConstrConcept
 
@@ -57,8 +57,6 @@ instance Definition    ConstrConcept where defn = defq . defn
 instance Constrained   ConstrConcept where constraints  = constr'
 -- | Finds a reasonable value for the 'ConstrConcept'.
 instance HasReasVal    ConstrConcept where reasVal      = reasV'
--- | Finds the rationale for the 'ConstrConcept'.
-instance MayHaveRationale  ConstrConcept where rationale    = rationale'
 -- | Equal if 'UID's are equal.
 instance Eq            ConstrConcept where c1 == c2 = (c1 ^. uid) == (c2 ^. uid)
 -- | Finds the units of the 'DefinedQuantityDict' used to make the 'ConstrConcept'.
@@ -69,39 +67,39 @@ instance Express       ConstrConcept where express = sy
 -- | Creates a 'ConstrConcept' with a quantitative concept, a list of 'Constraint's and an 'Expr'.
 constrained' :: (Concept c, MayHaveUnit c, Quantity c) =>
   c -> [ConstraintE] -> Expr -> ConstrConcept
-constrained' q cs rv = ConstrConcept (q ^. uid) (dqdWr q) cs (Just rv) Nothing
+constrained' q cs rv = ConstrConcept (q ^. uid) (dqdWr q) cs $ Just $ reasonableValue rv Nothing
 
 -- | Similar to 'constrained'', but defaults 'Maybe' 'Expr' to 'Nothing'.
 constrainedNRV' :: (Concept c, MayHaveUnit c, Quantity c) =>
   c -> [ConstraintE] -> ConstrConcept
-constrainedNRV' q cs = ConstrConcept (q ^. uid) (dqdWr q) cs Nothing Nothing
+constrainedNRV' q cs = ConstrConcept (q ^. uid) (dqdWr q) cs Nothing
 
 -- | Similar to 'constrained'', but with a rationale 'Sentence' explaining the reasonable value.
 constrainedWithRationale :: (Concept c, MayHaveUnit c, Quantity c) =>
   c -> [ConstraintE] -> Expr -> Sentence -> ConstrConcept
-constrainedWithRationale q cs rv r = ConstrConcept (q ^. uid) (dqdWr q) cs (Just rv) (Just r)
+constrainedWithRationale q cs rv r = ConstrConcept (q ^. uid) (dqdWr q) cs $ Just $ reasonableValue rv (Just r)
 
 -- | Creates a constrained unitary chunk from a 'UID', term ('NP'), description ('String'), 'Symbol', unit, 'Space', 'Constraint's, and an 'Expr'.
 cuc' :: String -> NP -> String -> Symbol -> UnitDefn
             -> Space -> [ConstraintE] -> Expr -> ConstrConcept
 cuc' nam trm desc sym un space cs rv =
-  ConstrConcept u (quant u trm (S desc) sym space un) cs (Just rv) Nothing
+  ConstrConcept u (quant u trm (S desc) sym space un) cs $ Just $ reasonableValue rv Nothing
   where u = mkUid nam
 
 -- | Similar to cuc', but does not include a unit.
 cucNoUnit' :: String -> NP -> String -> Symbol
             -> Space -> [ConstraintE] -> Expr -> ConstrConcept
 cucNoUnit' nam trm desc sym space cs rv =
-  ConstrConcept u (quantNoUnit u trm (S desc) sym space) cs (Just rv) Nothing
+  ConstrConcept u (quantNoUnit u trm (S desc) sym space) cs $ Just $ reasonableValue rv Nothing
   where u = mkUid nam
 
 -- | Similar to 'cuc'', but 'Symbol' is dependent on 'Stage'.
 cuc'' :: String -> NP -> String -> (Stage -> Symbol) -> UnitDefn
             -> Space -> [ConstraintE] -> Expr -> ConstrConcept
 cuc'' nam trm desc sym un space cs rv =
-  ConstrConcept u (quantAU u trm (S desc) Nothing sym space (Just un)) cs (Just rv) Nothing
+  ConstrConcept u (quantAU u trm (S desc) Nothing sym space (Just un)) cs $ Just $ reasonableValue rv Nothing
   where u = mkUid nam
 
 -- | Similar to 'cnstrw', but types must also have a 'Concept'.
 cnstrw' :: (Quantity c, Concept c, Constrained c, HasReasVal c, MayHaveUnit c) => c -> ConstrConcept
-cnstrw' c = ConstrConcept (c ^. uid) (dqdWr c) (c ^. constraints) (c ^. reasVal) Nothing
+cnstrw' c = ConstrConcept (c ^. uid) (dqdWr c) (c ^. constraints) (c ^. reasVal)

--- a/code/drasil-lang/lib/Language/Drasil/Chunk/UncertainQuantity.hs
+++ b/code/drasil-lang/lib/Language/Drasil/Chunk/UncertainQuantity.hs
@@ -18,15 +18,15 @@ import Language.Drasil.Chunk.Constrained (ConstrConcept(..), cuc')
 import Language.Drasil.Symbol
 import Language.Drasil.Classes (NamedIdea(term), Idea(getA), Express(express),
   Definition(defn), Concept, Quantity,
-  Constrained(constraints), HasReasVal(reasVal), MayHaveRationale(rationale))
+  Constrained(constraints), HasReasVal(reasVal))
 import Language.Drasil.Constraint (ConstraintE)
 import Language.Drasil.Chunk.UnitDefn (MayHaveUnit(getUnit), UnitDefn)
 import Language.Drasil.Expr.Lang (Expr)
 import Language.Drasil.Expr.Class (sy)
 import Language.Drasil.NaturalLanguage.English.NounPhrase.Core (NP)
-import Language.Drasil.Sentence (Sentence)
 import Language.Drasil.Space (Space, HasSpace(..))
 import Language.Drasil.Uncertainty
+import Language.Drasil.ReasonableValue (ReasonableValue)
 
 -- | UncertQs are conceptual symbolic quantities with constraints and an 'Uncertainty'.
 -- Contains the same information as a 'ConstrConcept' with an added 'Uncertainty'.
@@ -35,8 +35,7 @@ import Language.Drasil.Uncertainty
 data UncertQ = UQ { _uu         :: UID
                   , _defq       :: DefinedQuantityDict
                   , _constr'    :: [ConstraintE]
-                  , _reasV'     :: Maybe Expr
-                  , _rationale' :: Maybe Sentence
+                  , _reasV'     :: Maybe ReasonableValue
                   , _unc''      :: Uncertainty
                   }
 makeLenses ''UncertQ
@@ -63,8 +62,6 @@ instance HasUncertainty UncertQ where unc = unc''
 instance Constrained    UncertQ where constraints = constr'
 -- | Finds a reasonable value for the 'UncertQ'.
 instance HasReasVal     UncertQ where reasVal = reasV'
--- | Finds the rationale for the 'UncertQ'.
-instance MayHaveRationale   UncertQ where rationale = rationale'
 -- | Finds definition of the 'DefinedQuantityDict' used to make the 'UncertQ'.
 instance Definition     UncertQ where defn = defq . defn
 -- | Finds the units of the 'DefinedQuantityDict' used to make the 'UncertQ'.
@@ -76,7 +73,7 @@ instance Express        UncertQ where express = sy
 -- | Smart constructor that requires a 'Quantity', a percentage, and a reasonable value with an 'Uncertainty'.
 uq :: (Quantity c, Constrained c, Concept c, HasReasVal c, MayHaveUnit c) =>
   c -> Uncertainty -> UncertQ
-uq q = UQ (q ^. uid) (dqdWr q) (q ^. constraints) (q ^. reasVal) Nothing
+uq q = UQ (q ^. uid) (dqdWr q) (q ^. constraints) (q ^. reasVal)
 
 --FIXME: this is kind of crazy and probably shouldn't be used!
 -- | Uncertainty quantity ('uq') but with a constraint.
@@ -91,4 +88,4 @@ uqcND nam trm sym un space cs val = uq (cuc' nam trm "" sym un space cs val)
 
 -- | Directly wraps a 'ConstrConcept' with an 'Uncertainty', preserving all fields (including rationale).
 uqDirect :: ConstrConcept -> Uncertainty -> UncertQ
-uqDirect c = UQ (c ^. uid) (dqdWr c) (c ^. constraints) (c ^. reasVal) (c ^. rationale)
+uqDirect c = UQ (c ^. uid) (dqdWr c) (c ^. constraints) (c ^. reasVal)

--- a/code/drasil-lang/lib/Language/Drasil/Classes.hs
+++ b/code/drasil-lang/lib/Language/Drasil/Classes.hs
@@ -11,7 +11,6 @@ module Language.Drasil.Classes (
   , Quantity
   , HasUnitSymbol(usymb)
   , HasReasVal(reasVal)
-  , MayHaveRationale(rationale)
   , Constrained(constraints)
   , HasAdditionalNotes(getNotes)
     -- the unsorted rest
@@ -32,8 +31,8 @@ import Language.Drasil.Symbol (HasSymbol)
 import Language.Drasil.Chunk.NamedIdea (Idea(..), NamedIdea(..))
 import Language.Drasil.Constraint (ConstraintE)
 import Language.Drasil.UnitLang (UDefn, USymb)
-import Language.Drasil.Expr.Lang (Expr)
 import Language.Drasil.ExprClasses (Express(express, mexpress))
+import Language.Drasil.ReasonableValue (ReasonableValue)
 import Language.Drasil.Space (HasSpace)
 import Language.Drasil.Sentence (Sentence)
 
@@ -83,12 +82,7 @@ class Constrained c where
 -- | A 'Quantity' that could have a reasonable value.
 class HasReasVal c where
   -- | Provides a 'Lens' to the possible reasonable value.
-  reasVal     :: Lens' c (Maybe Expr)
-
--- | A chunk that may have a rationale explaining why a value or constraint was chosen.
-class MayHaveRationale c where
-  -- | Provides a 'Lens' to the possible rationale 'Sentence'.
-  rationale   :: Lens' c (Maybe Sentence)
+  reasVal     :: Lens' c (Maybe ReasonableValue)
 
 -- | A Quantity is an 'Idea' with a 'Space' and a 'Symbol'.
 -- In theory, it should also restrict to being a part of 'MayHaveUnit', but that causes

--- a/code/drasil-lang/lib/Language/Drasil/ReasonableValue.hs
+++ b/code/drasil-lang/lib/Language/Drasil/ReasonableValue.hs
@@ -1,0 +1,30 @@
+{-# Language TemplateHaskell #-}
+
+module Language.Drasil.ReasonableValue (
+  -- * Reasonable Value
+  ReasonableValue,
+
+  -- ** Constructors
+  reasonableValue,
+
+  -- ** Lenses
+  reasV, rationale
+) where
+
+import Control.Lens (makeLenses)
+
+import Language.Drasil.Expr.Lang (Expr(..))
+import Language.Drasil.Sentence (Sentence)
+
+-- | Represents a reasonable value ('Expr') with an optional
+-- rationale ('Maybe Sentence').
+--
+-- A reasonable value is an example of a value that is physically
+-- admissible.
+data ReasonableValue = RV { _reasV     :: Expr
+                          , _rationale :: Maybe Sentence
+                          }
+makeLenses ''ReasonableValue
+
+reasonableValue :: Expr -> Maybe Sentence -> ReasonableValue
+reasonableValue = RV

--- a/code/drasil-srs/lib/Drasil/SRS/DocDecl.hs
+++ b/code/drasil-srs/lib/Drasil/SRS/DocDecl.hs
@@ -94,7 +94,7 @@ data SCSSub where
   -- | Instance models.
   IMs            :: [Sentence] -> Fields  -> DL.DerivationDisplay -> SCSSub
   -- | Constraints.
-  Constraints    :: (HasUncertainty c, Quantity c, Constrained c, HasReasVal c, MayHaveRationale c, MayHaveUnit c) => Sentence -> [c] -> SCSSub
+  Constraints    :: (HasUncertainty c, Quantity c, Constrained c, HasReasVal c, MayHaveUnit c) => Sentence -> [c] -> SCSSub
   -- | Properties of a correct solution.
   CorrSolnPpties :: (Quantity c, Constrained c) => [c] -> [Contents] -> SCSSub
 

--- a/code/drasil-srs/lib/Drasil/SRS/DocumentLanguage/Core.hs
+++ b/code/drasil-srs/lib/Drasil/SRS/DocumentLanguage/Core.hs
@@ -189,7 +189,7 @@ data SCSSub where
   -- | Instance Models.
   IMs            :: [Sentence] -> Fields  -> [InstanceModel] -> DerivationDisplay -> SCSSub
   -- | Constraints.
-  Constraints    :: (HasUncertainty c, Quantity c, Constrained c, HasReasVal c, MayHaveRationale c, MayHaveUnit c) => Sentence -> [c] -> SCSSub
+  Constraints    :: (HasUncertainty c, Quantity c, Constrained c, HasReasVal c, MayHaveUnit c) => Sentence -> [c] -> SCSSub
   --                  Sentence -> [LabelledContent] Fields  -> [UncertainWrapper] -> [ConstrainedChunk] -> SCSSub --FIXME: temporary definition?
   --FIXME: Work in Progress ^
   -- | Properties of a correct solution.

--- a/code/drasil-srs/lib/Drasil/SRS/Sections/SpecificSystemDescription.hs
+++ b/code/drasil-srs/lib/Drasil/SRS/Sections/SpecificSystemDescription.hs
@@ -24,6 +24,7 @@ module Drasil.SRS.Sections.SpecificSystemDescription (
 
 -- General Haskell
 import Control.Lens ((^.), over)
+import Control.Lens.Prism (_Just)
 import Data.Maybe
 
 -- General Drasil
@@ -201,7 +202,7 @@ inModelIntro r1 r2 r3 r4 = foldlSP [S "This", phrase section_,
   namedRef r4 (plural genDefn)]
 
 -- | Constructor for Data Constraints section. Takes a trailing 'Sentence' (use 'EmptyS' if none) and data constraints.
-datConF :: (HasUncertainty c, Quantity c, Constrained c, HasReasVal c, MayHaveRationale c, MayHaveUnit c) =>
+datConF :: (HasUncertainty c, Quantity c, Constrained c, HasReasVal c, MayHaveUnit c) =>
   Sentence -> [c] -> Section
 datConF _ [] = SRS.datCon [mkParagraph $ emptySectSentPlu [datumConstraint]] []
 datConF t c  = SRS.datCon [dataConstraintParagraph t, LlC $ inDataConstTbl c] []
@@ -256,7 +257,7 @@ mkDataConstraintTable col rf lab = llccTab' rf $ uncurry Table
 
 -- | Creates the input Data Constraints Table.
 -- If any quantity has a rationale, a Rationale column is included.
-inDataConstTbl :: (HasUncertainty c, Quantity c, Constrained c, HasReasVal c, MayHaveRationale c, MayHaveUnit c) =>
+inDataConstTbl :: (HasUncertainty c, Quantity c, Constrained c, HasReasVal c, MayHaveUnit c) =>
   [c] -> LabelledContent
 inDataConstTbl qlst = mkDataConstraintTable (baseCols ++ rationaleCols ++ uncertCols)
             (inDatumConstraint ^. uid) $ titleize' inDatumConstraint
@@ -266,10 +267,10 @@ inDataConstTbl qlst = mkDataConstraintTable (baseCols ++ rationaleCols ++ uncert
     baseCols = [(S "Var", map ch sorted),
                 (titleize' physicalConstraint, map fmtPhys sorted),
                 (titleize' softwareConstraint, map fmtSfwr sorted),
-                (S "Reasonable Value", map (\q -> fmtU (eS $ express $ getRVal q) q) sorted)]
+                (S "Reasonable Value", map (\q -> fmtU (eS $ express $ getRVal q ^. reasV) q) sorted)]
     uncertCols = [(short typUnc, map (\q -> typUncr (uncVal q, uncPrec q)) sorted)]
-    hasAnyRationale = any (\q -> isJust (q ^. rationale)) sorted
-    rationaleCols = [(S "Rationale", map (\q -> fromMaybe EmptyS (q ^. rationale)) sorted) |
+    hasAnyRationale = any (\q -> isJust (q ^. reasVal)) sorted
+    rationaleCols = [(S "Rationale", map (\q -> fromMaybe EmptyS (q ^. reasVal . _Just . rationale)) sorted) |
       hasAnyRationale]
 
 -- | Creates the output Data Constraints Table.


### PR DESCRIPTION
The rationale is now captured in the ADT, rather than being a separate field with a separate typeclass.