### PR TITLE
refactor(code-gen): minimize `SmithEtAlSRS` usage in `drasil-code`

### DIFF
--- a/code/drasil-code/lib/Language/Drasil/Code/Imperative/DrasilState.hs
+++ b/code/drasil-code/lib/Language/Drasil/Code/Imperative/DrasilState.hs
@@ -21,7 +21,6 @@ import Language.Drasil (Space, Expr, DefinedQuantityDict)
 import Language.Drasil.Printers (PrintingInformation)
 import Drasil.GOOL (VisibilityTag(..), CodeType)
 import Drasil.System (systemdb, HasSystemMeta(..), HasProjectName(..))
-import Drasil.SRS (HasSmithEtAlSRS(..))
 
 import Drasil.Code.CodeVar (CodeIdea(..))
 import Language.Drasil.Chunk.ConstraintMap (ConstraintCE)
@@ -179,9 +178,6 @@ instance HasSystemMeta DrasilState where
 
 instance HasProjectName DrasilState where
   projectName = systemMeta . projectName
-
-instance HasSmithEtAlSRS DrasilState where
-  smithEtAlSRS = dsCodeSpec . smithEtAlSRS
 
 -- | Adds a message to the design log if the given 'Space'-'CodeType' match has not
 -- already been logged.

--- a/code/drasil-code/lib/Language/Drasil/CodeSpec.hs
+++ b/code/drasil-code/lib/Language/Drasil/CodeSpec.hs
@@ -26,7 +26,7 @@ import Language.Drasil hiding (None)
 import Drasil.Database (ChunkDB, UID, HasUID(..), insertAll, mkUid)
 import Drasil.Code.CodeExpr.Development (expr, eNamesRI, eDep)
 import qualified Drasil.SRS as S
-import Drasil.System (HasSystemMeta(..), systemdb, HasProjectName(..))
+import Drasil.System (HasSystemMeta(..), systemdb, HasProjectName(..), SystemMeta)
 import Drasil.SRS (HasSmithEtAlSRS(..))
 import Theory.Drasil (DataDefinition, qdEFromDD, getEqModQdsFromIm)
 import Data.List.Extras (subsetOf)
@@ -53,7 +53,7 @@ type ConstantMap = Map.Map UID CodeDefinition
 
 -- | Code Specification. Holds system information and options.
 data CodeSpec = CS {
-  _srs :: S.SmithEtAlSRS,
+  _csSysMeta :: SystemMeta,
   -- | All inputs.
   _inputs :: [Input],
   -- | Explicit inputs (values to be supplied by a file).
@@ -79,11 +79,8 @@ data CodeSpec = CS {
 }
 makeClassy ''CodeSpec
 
-instance HasSmithEtAlSRS CodeSpec where
-  smithEtAlSRS = srs
-
 instance HasSystemMeta CodeSpec where
-  systemMeta = srs . systemMeta
+  systemMeta = csSysMeta
 
 instance HasProjectName CodeSpec where
   projectName = systemMeta . projectName
@@ -112,15 +109,14 @@ mkCodeSpec si@S.ICO{ S._inputs = ins
   let els = extLibs chs
       libReqs = concatMap odeLibReqs els
       infoReqs = concatMap odeInfoReqs els
-      db' = insertAll (libReqs ++ infoReqs) $ si ^. systemdb
-      sys = set systemdb db' si
-      ddefs = sys ^. dataDefns
-      db = sys ^. systemdb
+      db = insertAll (libReqs ++ infoReqs) $ si ^. systemdb
+      sysMeta = set systemdb db $ si ^. systemMeta
+      ddefs = si ^. dataDefns
       inputs' = map quantvar $ NE.toList ins
       const' = map qtov (filter ((`Map.notMember` conceptMatch (maps chs)) . (^. uid))
         cnsts)
       derived = map qtov $ getDerivedInputs ddefs inputs' const' db
-      rels = (map qtoc (getEqModQdsFromIm (sys ^. instModels) ++ mapMaybe qdEFromDD ddefs) \\ derived)
+      rels = (map qtoc (getEqModQdsFromIm (si ^. instModels) ++ mapMaybe qdEFromDD ddefs) \\ derived)
         ++ mapODE (getODE $ extLibs chs)
         ++ map qtoc (handWiredDefs chs)
       -- TODO: When we have better DEModels, we should be deriving our ODE information
@@ -129,7 +125,11 @@ mkCodeSpec si@S.ICO{ S._inputs = ins
       allInputs = inputs' ++ map quantvar derived
       exOrder = solveExecOrder rels (allInputs ++ map quantvar cnsts) outs' db
   in CS {
-        _srs = sys,
+        _csSysMeta = sysMeta,
+        -- FIXME: This _should_ be different in at least one way. The SM from
+        -- the SRS _should_ reference "defining an SRS that ...". This SM should
+        -- reference said SRS, saying "building a software design satisfying
+        -- said SRS."
         _inputs = allInputs,
         _extInputs = inputs',
         _derivedInputs = derived,
@@ -160,8 +160,8 @@ funcUID f = asVC f ^. uid
 -- come from those. If there are none, then the 'QDefinition's are used instead.
 getDerivedInputs :: [DataDefinition] -> [Input] -> [Const] ->
   ChunkDB -> [SimpleQDef]
-getDerivedInputs ddefs ins cnsts sm =
-  filter ((`subsetOf` refSet) . flip codevars sm . expr . (^. defnExpr)) (mapMaybe qdEFromDD ddefs)
+getDerivedInputs ddefs ins cnsts db =
+  filter ((`subsetOf` refSet) . flip codevars db . expr . (^. defnExpr)) (mapMaybe qdEFromDD ddefs)
   where refSet = ins ++ map quantvar cnsts
 
 -- | Get a list of 'Constraint's for a list of 'CodeChunk's.


### PR DESCRIPTION
That is:

1. Remove (the unused) `HasSmithEtAlSRS` instance on `DrasilState`.
2. Replace `SmithEtAlSRS` in `CodeSpec` with minimal necessary components: `SystemMeta`.

With this PR, `drasil-code` only relies on `drasil-srs` for one thing: trying to solve a calculation path between designated inputs to outputs using the SRS's IMs, DDs, and constants. That should be moved elsewhere too (out of scope of this pr -- the "invisible programmer" at work).

The next steps will involve:

* Moving the above mentioned "calculation path" forming code up to `drasil-gen`. This will result in `drasil-code` being completely de-coupled from `drasil-srs` (yay!).
* A discussion: How does the "calculation path" formed in the SRS relate to the "calculation path" we generate for the "`CodeSpec`" (input to the main generator `drasil-code` exposes)? [The answer here should be something we can write about (and use, hopefully). I'm hoping we can talk about non-trivial properties, including a discussion about unit+type conversion, 'hole filling' for incomputable mathematical expressions, permissible `DataDefinition`s and `InstanceModel`s, and how we decide which `GenDefn`s and `TheoryModel`s are shown in the SRS and whether we can automatically gather which ones are relevant according to relationships to related `InstanceModel`s and `GenDefn`s.]
* De-coupling `drasil-code` from `drasil-printers` _and_ `drasil-lang` (which will likely also involve re-splitting `drasil-lang` further).
* Re-designing `drasil-code`... See file analysis document for early steps.
* Another discussion: the "invisible programmer"'s work should be "viewable" in the form of an SDS. That might be worth generating.