### PR TITLE
refactor(`drasil-lang`): move `Citation` to `Language.Drasil.Document` namespace

### DIFF
--- a/code/drasil-data/lib/Data/Drasil/Citations.hs
+++ b/code/drasil-data/lib/Data/Drasil/Citations.hs
@@ -4,7 +4,8 @@ module Data.Drasil.Citations (
   , module Drasil.Metadata.Citations
   ) where
 
-import Language.Drasil --(S,(:+:),(+:+),sC,phrase,F,Accent(..),Citation(..),CiteField(..))
+import Language.Drasil
+import Language.Drasil.Document
 import Data.Drasil.People (dParnas, pcClements, mCampidelli, dmWiess, rodPierce,
   wikiAuthors, rcHibbeler, sRobertson, jRobertson)
 import Drasil.Metadata.Citations

--- a/code/drasil-data/lib/Data/Drasil/Concepts/Documentation.hs
+++ b/code/drasil-data/lib/Data/Drasil/Concepts/Documentation.hs
@@ -10,7 +10,7 @@ module Data.Drasil.Concepts.Documentation (
   ) where
 
 import Drasil.Database (mkUid)
-import Language.Drasil hiding (organization, year, label, variable, sec)
+import Language.Drasil hiding (label, variable, sec)
 import Language.Drasil.Chunk.Concept.NamedCombinators
 
 import Drasil.Metadata.Domains (softEng)

--- a/code/drasil-data/lib/Data/Drasil/Concepts/Education.hs
+++ b/code/drasil-data/lib/Data/Drasil/Concepts/Education.hs
@@ -2,7 +2,7 @@
 module Data.Drasil.Concepts.Education where
 
 import Drasil.Database (mkUid)
-import Language.Drasil hiding (year)
+import Language.Drasil
 import Language.Drasil.Chunk.Concept.NamedCombinators
 
 import Data.Drasil.Concepts.Documentation (first, physics, physical,

--- a/code/drasil-data/lib/Data/Drasil/Concepts/Math.hs
+++ b/code/drasil-data/lib/Data/Drasil/Concepts/Math.hs
@@ -6,7 +6,7 @@ module Data.Drasil.Concepts.Math (
 
 -- General Drasil
 import Drasil.Database (mkUid)
-import Language.Drasil hiding (number, norm, matrix, Sentence(P, S, (:+:)))
+import Language.Drasil hiding (norm, matrix, Sentence(P, S, (:+:)))
 import qualified Language.Drasil as D
 import Language.Drasil.Chunk.Concept.NamedCombinators
 import Language.Drasil.Development (NPStruct(P, S, (:-:)))

--- a/code/drasil-example/bss/lib/Drasil/BinaryStar/References.hs
+++ b/code/drasil-example/bss/lib/Drasil/BinaryStar/References.hs
@@ -1,6 +1,6 @@
 module Drasil.BinaryStar.References (citations) where
 
-import Language.Drasil (BibRef)
+import Language.Drasil.Document (BibRef)
 import Data.Drasil.Citations (parnasClements1986, hibbeler2004,
   velocityWiki, accelerationWiki)
 

--- a/code/drasil-example/dblpend/lib/Drasil/DblPend/Body.hs
+++ b/code/drasil-example/dblpend/lib/Drasil/DblPend/Body.hs
@@ -5,7 +5,7 @@ module Drasil.DblPend.Body (
 ) where
 
 import Drasil.Database (ChunkDB)
-import Language.Drasil hiding (organization)
+import Language.Drasil
 import Language.Drasil.Document (makeURI, ulcc, Section, Contents(..),
   LabelledContent, RawContent(..), Reference, namedRef, refS, foldlSP,
   foldlSPCol, bulletNested, bulletFlat, ConceptInstance)

--- a/code/drasil-example/dblpend/lib/Drasil/DblPend/References.hs
+++ b/code/drasil-example/dblpend/lib/Drasil/DblPend/References.hs
@@ -1,6 +1,6 @@
 module Drasil.DblPend.References (citations) where
 
-import Language.Drasil (BibRef)
+import Language.Drasil.Document (BibRef)
 import Data.Drasil.Citations (accelerationWiki, velocityWiki,
  parnasClements1986, hibbeler2004)
 

--- a/code/drasil-example/gamephysics/lib/Drasil/GamePhysics/Assumptions.hs
+++ b/code/drasil-example/gamephysics/lib/Drasil/GamePhysics/Assumptions.hs
@@ -2,7 +2,7 @@ module Drasil.GamePhysics.Assumptions (
   assumptions, assumpCT, assumpDI, assumpCAJI, assumpOT, assumpOD, assumpAD
 ) where
 
-import Language.Drasil hiding (organization)
+import Language.Drasil
 import Language.Drasil.Document (ConceptInstance, cic)
 
 import Data.Drasil.Concepts.Documentation as Doc (simulation, assumpDom)

--- a/code/drasil-example/gamephysics/lib/Drasil/GamePhysics/LabelledContent.hs
+++ b/code/drasil-example/gamephysics/lib/Drasil/GamePhysics/LabelledContent.hs
@@ -2,8 +2,8 @@ module Drasil.GamePhysics.LabelledContent (
   labelledContent, sysCtxFig1
 ) where
 
-import Language.Drasil hiding (organization)
-import Language.Drasil.Document
+import Language.Drasil
+import Language.Drasil.Document hiding (organization)
 
 import Data.Drasil.Concepts.Documentation as Doc (sysCont)
 

--- a/code/drasil-example/gamephysics/lib/Drasil/GamePhysics/Requirements.hs
+++ b/code/drasil-example/gamephysics/lib/Drasil/GamePhysics/Requirements.hs
@@ -1,7 +1,7 @@
 module Drasil.GamePhysics.Requirements (funcReqs, nonfuncReqs, pymunk) where
 
-import Language.Drasil hiding (organization)
-import Language.Drasil.Document
+import Language.Drasil
+import Language.Drasil.Document hiding (organization)
 import Language.Drasil.Chunk.Concept.NamedCombinators
 import qualified Language.Drasil.Development as D
 import qualified Language.Drasil.Sentence.Combinators as S

--- a/code/drasil-example/glassbr/lib/Drasil/GlassBR/Assumptions.hs
+++ b/code/drasil-example/glassbr/lib/Drasil/GlassBR/Assumptions.hs
@@ -2,8 +2,8 @@ module Drasil.GlassBR.Assumptions (assumpGT, assumpGC, assumpES, assumpSV,
   assumpGL, assumpBC, assumpRT, assumpLDFC, assumptionConstants,
   assumptions) where
 
-import Language.Drasil hiding (organization)
-import Language.Drasil.Document
+import Language.Drasil
+import Language.Drasil.Document hiding (organization)
 import qualified Language.Drasil.Development as D
 import qualified Drasil.SRS.Concepts as SRS (valsOfAuxCons)
 import Language.Drasil.Chunk.Concept.NamedCombinators

--- a/code/drasil-example/glassbr/lib/Drasil/GlassBR/Body.hs
+++ b/code/drasil-example/glassbr/lib/Drasil/GlassBR/Body.hs
@@ -2,8 +2,8 @@ module Drasil.GlassBR.Body (mkSRS, si) where
 
 import Control.Lens ((^.))
 
-import Language.Drasil hiding (organization, variable)
-import Language.Drasil.Document
+import Language.Drasil hiding (variable)
+import Language.Drasil.Document hiding (organization)
 import qualified Language.Drasil.Development as D
 
 import Drasil.Database (ChunkDB)

--- a/code/drasil-example/glassbr/lib/Drasil/GlassBR/References.hs
+++ b/code/drasil-example/glassbr/lib/Drasil/GlassBR/References.hs
@@ -4,6 +4,7 @@ module Drasil.GlassBR.References (
 ) where
 
 import Language.Drasil
+import Language.Drasil.Document
 
 import Data.Drasil.Citations (campidelli, parnasClements1986)
 import Data.Drasil.People (jmBracci, tlKohutek, wlBeason)

--- a/code/drasil-example/hghc/lib/Drasil/HGHC/Body.hs
+++ b/code/drasil-example/hghc/lib/Drasil/HGHC/Body.hs
@@ -3,7 +3,7 @@ module Drasil.HGHC.Body (si, mkSRS) where
 import Drasil.Database (ChunkDB)
 import Drasil.SRS
 import Drasil.Generator (withCommonKnowledge)
-import Language.Drasil hiding (Manual) -- Citation name conflict. FIXME: Move to different namespace
+import Language.Drasil
 
 import Drasil.HGHC.HeatTransfer (fp, dataDefs, htInputs, htOutputs,
     nuclearPhys, symbols)

--- a/code/drasil-example/pdcontroller/lib/Drasil/PDController/References.hs
+++ b/code/drasil-example/pdcontroller/lib/Drasil/PDController/References.hs
@@ -5,6 +5,7 @@ module Drasil.PDController.References (
 import Data.Drasil.Citations (laplaceWiki, pidWiki)
 
 import Language.Drasil
+import Language.Drasil.Document
 
 citations :: BibRef
 citations = [johnson2008, abbasi2015, laplaceWiki, pidWiki]

--- a/code/drasil-example/projectile/lib/Drasil/Projectile/References.hs
+++ b/code/drasil-example/projectile/lib/Drasil/Projectile/References.hs
@@ -1,6 +1,6 @@
 module Drasil.Projectile.References (citations) where
 
-import Language.Drasil
+import Language.Drasil.Document (BibRef)
 import Data.Drasil.Citations (accelerationWiki, velocityWiki,
  hibbeler2004, parnasClements1986)
 

--- a/code/drasil-example/sglpend/lib/Drasil/SglPend/Body.hs
+++ b/code/drasil-example/sglpend/lib/Drasil/SglPend/Body.hs
@@ -3,8 +3,8 @@ module Drasil.SglPend.Body (mkSRS, si) where
 import Control.Lens ((^.))
 
 import Drasil.Database (ChunkDB)
-import Language.Drasil hiding (organization)
-import Language.Drasil.Document
+import Language.Drasil
+import Language.Drasil.Document hiding (organization)
 import qualified Language.Drasil.Development as D
 import Theory.Drasil (TheoryModel, output)
 import Drasil.SRS hiding (genDefns)

--- a/code/drasil-example/ssp/lib/Drasil/SSP/Body.hs
+++ b/code/drasil-example/ssp/lib/Drasil/SSP/Body.hs
@@ -4,7 +4,7 @@ import qualified Data.List.NonEmpty as NE
 import Prelude hiding (sin, cos, tan)
 
 import Drasil.Database (ChunkDB)
-import Language.Drasil hiding (Verb, number, organization, variable)
+import Language.Drasil hiding (variable)
 import Language.Drasil.Document (fig, llccFig, makeURI, ulcc, Contents(..),
   LabelledContent, RawContent(..), Reference, namedRef, refS, foldlSP,
   foldlSPCol, bulletNested, bulletFlat, ConceptInstance)

--- a/code/drasil-example/ssp/lib/Drasil/SSP/References.hs
+++ b/code/drasil-example/ssp/lib/Drasil/SSP/References.hs
@@ -4,6 +4,7 @@ module Drasil.SSP.References (
 ) where
 
 import Language.Drasil
+import Language.Drasil.Document
 
 import Data.Drasil.Citations (jnlCGJ, parnasClements1986, hibbeler2004)
 import Data.Drasil.People (bKarchewski, cfLee, dgFredlund, dStolle, dyZhu,

--- a/code/drasil-example/swhs/lib/Drasil/SWHS/Body.hs
+++ b/code/drasil-example/swhs/lib/Drasil/SWHS/Body.hs
@@ -7,8 +7,8 @@ module Drasil.SWHS.Body (
 import Control.Lens ((^.))
 
 import Drasil.Database (ChunkDB)
-import Language.Drasil hiding (organization, variable)
-import Language.Drasil.Document
+import Language.Drasil hiding (variable)
+import Language.Drasil.Document hiding (organization)
 import Drasil.SRS
 import Drasil.Generator (withCommonKnowledge)
 import qualified Drasil.SRS.Concepts as SRS (inModel)

--- a/code/drasil-example/swhs/lib/Drasil/SWHS/LabelledContent.hs
+++ b/code/drasil-example/swhs/lib/Drasil/SWHS/LabelledContent.hs
@@ -2,8 +2,8 @@ module Drasil.SWHS.LabelledContent (
   labelledContent, sysCntxtFig, figTank
 ) where
 
-import Language.Drasil hiding (organization, variable)
-import Language.Drasil.Document
+import Language.Drasil hiding (variable)
+import Language.Drasil.Document hiding (organization)
 import qualified Language.Drasil.Sentence.Combinators as S
 
 import Data.Drasil.Concepts.Documentation as Doc (sysCont)

--- a/code/drasil-example/swhsnopcm/lib/Drasil/SWHSNoPCM/References.hs
+++ b/code/drasil-example/swhsnopcm/lib/Drasil/SWHSNoPCM/References.hs
@@ -1,6 +1,6 @@
 module Drasil.SWHSNoPCM.References (citations) where
 
-import Language.Drasil
+import Language.Drasil.Document (BibRef)
 
 import Data.Drasil.Citations (parnasClements1986)
 

--- a/code/drasil-gen/lib/Drasil/Generator/CommonKnowledge.hs
+++ b/code/drasil-gen/lib/Drasil/Generator/CommonKnowledge.hs
@@ -4,10 +4,10 @@ module Drasil.Generator.CommonKnowledge (
 ) where
 
 import Drasil.Database (empty, insertAll, ChunkDB, insertAllOutOfOrder13)
-import Language.Drasil (IdeaDict, Citation, ConceptChunk, DefinedQuantityDict,
+import Language.Drasil (IdeaDict, ConceptChunk, DefinedQuantityDict,
   UnitDefn, CI)
 import Language.Drasil.Document (ConceptInstance, LabelledContent, Reference,
-  Section)
+  Section, Citation)
 import Data.Drasil.Citations (cartesianWiki, lineSource, pointSource,
   smithEtAl2007, smithLai2005, smithKoothoor2016, koothoor2013)
 import Data.Drasil.Concepts.Documentation (doccon, doccon', srsDomains)

--- a/code/drasil-lang/lib/Language/Drasil.hs
+++ b/code/drasil-lang/lib/Language/Drasil.hs
@@ -241,7 +241,7 @@ import Language.Drasil.Classes (Definition(defn), ConceptDomain(cdom), Concept, 
   IsUnit(getUnits), CommonIdea(abrv), HasAdditionalNotes(getNotes), Constrained(constraints),
   HasReasVal(reasVal), MayHaveRationale(rationale), DefiningExpr(defnExpr), Quantity)
 import Language.Drasil.Data.Date (Month(..))
-import Language.Drasil.Chunk.Citation (
+import Language.Drasil.Document.Citation.Core (
     Citation, EntryID, BibRef
   , HasCitation(..)
   , citeID, citeKind

--- a/code/drasil-lang/lib/Language/Drasil.hs
+++ b/code/drasil-lang/lib/Language/Drasil.hs
@@ -119,35 +119,8 @@ module Language.Drasil (
   , getAdd, prepend
   , LblType(RP, Citation, URI), IRefProg(..)
 
-  -- *** Citations
-  -- Language.Drasil.Chunk.Citation
-  , EntryID, Citation, BibRef
-  , HasCitation(getCitations)
-  , HasFields(getFields)
-  -- accessors
-  , citeID, citeKind
-  -- smart constructors
-  , cArticle, cBookA, cBookE, cBooklet
-  , cInBookACP, cInBookECP, cInBookAC, cInBookEC, cInBookAP, cInBookEP
-  , cInCollection, cInProceedings, cManual, cMThesis, cMisc, cPhDThesis
-  , cProceedings, cTechReport, cUnpublished
   -- Language.Drasil.Data.Date
   , Month(..)
-  -- Language.Drasil.Data.Citation; should be moved to Language.Drasil.Development
-  , CiteField(..), HP(..), CitationKind(..)
-  , compareAuthYearTitle
-    -- CiteFields smart constructors
-      -- People -> CiteField
-  , author, editor
-      -- Sentence -> CiteField
-  , address, bookTitle, howPublished, howPublishedU, institution, journal, note
-  , organization, publisher, school, series, title, typeField
-      -- Int -> CiteField
-  , chapter, edition, number, volume, year
-      -- [Int] -> CiteField
-  , pages
-      -- Month -> CiteField
-  , month
   -- Language.Drasil.People
   , People, Person, person, HasName, fullName, person', personWM
   , personWM', mononym, nameStr, rendPersLFM, rendPersLFM', rendPersLFM''
@@ -241,14 +214,6 @@ import Language.Drasil.Classes (Definition(defn), ConceptDomain(cdom), Concept, 
   IsUnit(getUnits), CommonIdea(abrv), HasAdditionalNotes(getNotes), Constrained(constraints),
   HasReasVal(reasVal), MayHaveRationale(rationale), DefiningExpr(defnExpr), Quantity)
 import Language.Drasil.Data.Date (Month(..))
-import Language.Drasil.Document.Citation.Core (
-    Citation, EntryID, BibRef
-  , HasCitation(..)
-  , citeID, citeKind
-  , cArticle, cBookA, cBookE, cBooklet
-  , cInBookACP, cInBookECP, cInBookAC, cInBookEC, cInBookAP, cInBookEP
-  , cInCollection, cInProceedings, cManual, cMThesis, cMisc, cPhDThesis
-  , cProceedings, cTechReport, cUnpublished)
 import Language.Drasil.Chunk.CommonIdea
 import Language.Drasil.Chunk.Concept
 import Language.Drasil.Chunk.Concept.Core (sDom)
@@ -261,13 +226,6 @@ import Language.Drasil.Chunk.Eq (QDefinition, fromEqn, fromEqn', fromEqnSt,
   mkFuncDef, mkFuncDef', mkFuncDefByQ, ConstQDef, SimpleQDef, ModelQDef)
 import Language.Drasil.Chunk.NamedIdea
 import Language.Drasil.Chunk.UncertainQuantity
-import Language.Drasil.Document.Citation.Components (CiteField(..), HP(..), CitationKind(..)
-  , HasFields(getFields)
-  , author, editor
-  , address, bookTitle, howPublished, howPublishedU, institution, journal, note
-  , organization, publisher, school, series, title, typeField
-  , chapter, edition, number, volume, year, month, pages
-  , compareAuthYearTitle)
 import Language.Drasil.NaturalLanguage.English.NounPhrase
 import Language.Drasil.ShortName (ShortName, shortname', getSentSN, HasShortName(..))
 import Language.Drasil.Space (Space(..), RealInterval(..), Inclusive(..),

--- a/code/drasil-lang/lib/Language/Drasil.hs
+++ b/code/drasil-lang/lib/Language/Drasil.hs
@@ -261,7 +261,7 @@ import Language.Drasil.Chunk.Eq (QDefinition, fromEqn, fromEqn', fromEqnSt,
   mkFuncDef, mkFuncDef', mkFuncDefByQ, ConstQDef, SimpleQDef, ModelQDef)
 import Language.Drasil.Chunk.NamedIdea
 import Language.Drasil.Chunk.UncertainQuantity
-import Language.Drasil.Data.Citation (CiteField(..), HP(..), CitationKind(..)
+import Language.Drasil.Document.Citation.Components (CiteField(..), HP(..), CitationKind(..)
   , HasFields(getFields)
   , author, editor
   , address, bookTitle, howPublished, howPublishedU, institution, journal, note

--- a/code/drasil-lang/lib/Language/Drasil/Document.hs
+++ b/code/drasil-lang/lib/Language/Drasil/Document.hs
@@ -1,5 +1,7 @@
 -- | Document Description Language.
 module Language.Drasil.Document (
+  module Language.Drasil.Document.Citation.Core,
+  module Language.Drasil.Document.Citation.Components,
   module Language.Drasil.Document.ConceptInstance,
   module Language.Drasil.Document.Contents,
   module Language.Drasil.Document.Core,
@@ -10,6 +12,8 @@ module Language.Drasil.Document (
   module Language.Drasil.Document.SentenceCombinators
 ) where
 
+import Language.Drasil.Document.Citation.Core
+import Language.Drasil.Document.Citation.Components
 import Language.Drasil.Document.ConceptInstance
 import Language.Drasil.Document.Contents
 import Language.Drasil.Document.Core

--- a/code/drasil-lang/lib/Language/Drasil/Document/Citation/Components.hs
+++ b/code/drasil-lang/lib/Language/Drasil/Document/Citation/Components.hs
@@ -1,6 +1,6 @@
 {-# Language TemplateHaskell #-}
 -- | Contains all necessary types and constructors for citing sources in Drasil.
-module Language.Drasil.Data.Citation (
+module Language.Drasil.Document.Citation.Components (
   -- * Types
   CiteField(..), HP(..), CitationKind(..),
   -- * Class

--- a/code/drasil-lang/lib/Language/Drasil/Document/Citation/Core.hs
+++ b/code/drasil-lang/lib/Language/Drasil/Document/Citation/Core.hs
@@ -21,7 +21,7 @@ import Drasil.Database (HasUID(..), UID, showUID, mkUid, declareHasChunkRefs,
 
 import Language.Drasil.People (People)
 import Language.Drasil.ShortName (HasShortName(..), ShortName, shortname')
-import Language.Drasil.Data.Citation (HasFields(..), CitationKind(..), CiteField,
+import Language.Drasil.Document.Citation.Components (HasFields(..), CitationKind(..), CiteField,
   author, chapter, pages, editor, bookTitle, title,
   year, school, journal, institution, note, publisher)
 import Language.Drasil.Sentence (Sentence(S))

--- a/code/drasil-lang/lib/Language/Drasil/Document/Citation/Core.hs
+++ b/code/drasil-lang/lib/Language/Drasil/Document/Citation/Core.hs
@@ -1,6 +1,6 @@
 {-# Language TemplateHaskell #-}
 -- | Defines the chunk type to hold citations.
-module Language.Drasil.Chunk.Citation (
+module Language.Drasil.Document.Citation.Core (
   -- * Types
   Citation, BibRef, EntryID,
   -- * Class

--- a/code/drasil-lang/lib/Language/Drasil/Document/Core.hs
+++ b/code/drasil-lang/lib/Language/Drasil/Document/Core.hs
@@ -11,7 +11,7 @@ import Control.Lens ((^.), makeLenses, Lens', set, view)
 import Drasil.Database (HasChunkRefs(..), HasUID(..), UID)
 
 import Language.Drasil.Expr.Lang (Expr)
-import Language.Drasil.Chunk.Citation (BibRef)
+import Language.Drasil.Document.Citation.Core (BibRef)
 import Language.Drasil.ShortName (HasShortName(shortname))
 import Language.Drasil.ModelExpr.Lang (ModelExpr)
 import Language.Drasil.Label.Type (getAdd, prepend, IRefProg,

--- a/code/drasil-lang/lib/Language/Drasil/Document/Extractors.hs
+++ b/code/drasil-lang/lib/Language/Drasil/Document/Extractors.hs
@@ -13,7 +13,7 @@ import Data.Maybe (mapMaybe)
 import qualified Data.Set as S
 
 import Drasil.Database (UID, ChunkDB, find)
-import Language.Drasil.Chunk.Citation (Citation, BibRef)
+import Language.Drasil.Document.Citation.Core (Citation, BibRef)
 import Language.Drasil.Data.Citation (compareAuthYearTitle)
 import Language.Drasil.Document.Core (RawContent(..), ListTuple, ItemType(..),
   ListType(..), HasContents(..))

--- a/code/drasil-lang/lib/Language/Drasil/Document/Extractors.hs
+++ b/code/drasil-lang/lib/Language/Drasil/Document/Extractors.hs
@@ -14,7 +14,7 @@ import qualified Data.Set as S
 
 import Drasil.Database (UID, ChunkDB, find)
 import Language.Drasil.Document.Citation.Core (Citation, BibRef)
-import Language.Drasil.Data.Citation (compareAuthYearTitle)
+import Language.Drasil.Document.Citation.Components (compareAuthYearTitle)
 import Language.Drasil.Document.Core (RawContent(..), ListTuple, ItemType(..),
   ListType(..), HasContents(..))
 import Language.Drasil.Document.Sections (Section(Section), SecCons(..))

--- a/code/drasil-lesson-plan/lib/Drasil/LessonPlan/ExtractBib.hs
+++ b/code/drasil-lesson-plan/lib/Drasil/LessonPlan/ExtractBib.hs
@@ -4,7 +4,6 @@ module Drasil.LessonPlan.ExtractBib (extractBib) where
 import qualified Data.Set as S
 
 import Drasil.Database (UID, ChunkDB)
-import Language.Drasil
 import Language.Drasil.Document
 
 import Drasil.LessonPlan.Document

--- a/code/drasil-metadata/lib/Drasil/Metadata/Citations.hs
+++ b/code/drasil-metadata/lib/Drasil/Metadata/Citations.hs
@@ -1,7 +1,8 @@
 -- | Defines citations used internally in Drasil.
 module Drasil.Metadata.Citations where
 
-import Language.Drasil --(S,(:+:),(+:+),sC,phrase,F,Accent(..),Citation(..),CiteField(..))
+import Language.Drasil
+import Language.Drasil.Document
 import Drasil.Metadata.People (dParnas, jRalyte, lLai, nKoothoor, nKraiem,
   pcClements, pjAgerfalk, spencerSmith, rKhedri)
 

--- a/code/drasil-printers/lib/Language/Drasil/HTML/Print.hs
+++ b/code/drasil-printers/lib/Language/Drasil/HTML/Print.hs
@@ -18,9 +18,8 @@ import Text.PrettyPrint hiding (Str)
 import Numeric (showEFloat)
 
 import Language.Drasil (People, Person, fullName, rendPersLFM, rendPersLFM',
-  rendPersLFM'', special, checkValidStr, CitationKind(..),
-  numList)
-import Language.Drasil.Document (MaxWidthPercent)
+  rendPersLFM'', special, checkValidStr, numList)
+import Language.Drasil.Document (CitationKind(..), MaxWidthPercent)
 
 import Language.Drasil.HTML.Monad (unPH)
 import Language.Drasil.HTML.Helpers (articleTitle, author, ba, body, bold,

--- a/code/drasil-printers/lib/Language/Drasil/Printing/Citation.hs
+++ b/code/drasil-printers/lib/Language/Drasil/Printing/Citation.hs
@@ -4,7 +4,8 @@ module Language.Drasil.Printing.Citation (
   BibRef, Citation(..), CiteField(..), HP(..)
 ) where
 
-import Language.Drasil (People, EntryID, CitationKind, Month)
+import Language.Drasil (People, Month)
+import Language.Drasil.Document (EntryID, CitationKind)
 
 import Language.Drasil.Printing.AST (Spec)
 

--- a/code/drasil-printers/lib/Language/Drasil/Printing/Import/Citation.hs
+++ b/code/drasil-printers/lib/Language/Drasil/Printing/Import/Citation.hs
@@ -3,7 +3,7 @@ module Language.Drasil.Printing.Import.Citation (layCite) where
 import Control.Lens ((^.))
 
 import Drasil.Database (showUID)
-import Language.Drasil (Citation, CiteField(..), HP (..), citeKind, HasFields (..))
+import Language.Drasil.Document (Citation, CiteField(..), HP(..), citeKind, HasFields(..))
 
 import qualified Language.Drasil.Printing.AST as P
 import qualified Language.Drasil.Printing.Citation as P

--- a/code/drasil-srs/lib/Drasil/SRS/DocumentLanguage/Core.hs
+++ b/code/drasil-srs/lib/Drasil/SRS/DocumentLanguage/Core.hs
@@ -12,8 +12,8 @@ module Drasil.SRS.DocumentLanguage.Core (
 import Data.Generics.Multiplate (Multiplate(multiplate, mkPlate))
 
 import Drasil.Database (UID, IsChunk)
-import Language.Drasil hiding (Manual, Verb) -- Manual - Citation name conflict. FIXME: Move to different namespace
-import Language.Drasil.Document
+import Language.Drasil
+import Language.Drasil.Document hiding (Manual, Verb)
 import Theory.Drasil (DataDefinition, GenDefn, InstanceModel, TheoryModel)
 
 import Drasil.SRS.DocumentLanguage.Definitions (Fields, TraceViewCat)

--- a/code/drasil-srs/lib/Drasil/SRS/Sections/Introduction.hs
+++ b/code/drasil-srs/lib/Drasil/SRS/Sections/Introduction.hs
@@ -5,8 +5,8 @@ module Drasil.SRS.Sections.Introduction (orgSec, introductionSection,
 import Data.Maybe (maybeToList)
 
 -- Generic Drasil
-import Language.Drasil hiding (organization)
-import Language.Drasil.Document
+import Language.Drasil
+import Language.Drasil.Document hiding (organization)
 import Language.Drasil.Chunk.Concept.NamedCombinators (andThe, the)
 import Drasil.SRS.DocumentLanguage.Definitions(Verbosity(..))
 import qualified Language.Drasil.Development as D

--- a/code/drasil-srs/lib/Drasil/SRS/Sections/TableOfSymbols.hs
+++ b/code/drasil-srs/lib/Drasil/SRS/Sections/TableOfSymbols.hs
@@ -7,9 +7,8 @@ import Control.Lens (view)
 import Text.PrettyPrint.HughesPJ (text, render, vcat, (<+>)) -- FIXME
 
 -- Generic Drasil
-import Language.Drasil hiding (Manual, Verb) -- Manual - Citation name conflict. FIXME: Move to different namespace
-                                             -- Vector - Name conflict (defined in file)
-import Language.Drasil.Document
+import Language.Drasil
+import Language.Drasil.Document hiding (Manual, Verb) -- Both name conflicts.
 import Drasil.Database (HasUID(..))
 import Data.List.Extras (mkTable)
 


### PR DESCRIPTION
This is a follow-up to #5089 and related PRs, moving code around according to the `drasil-lang` module dependency graph.