### PR TITLE
refactor(`drasil-lang`): move document `ShortName` to `.Document` namespace

### DIFF
--- a/code/drasil-example/dblpend/lib/Drasil/DblPend/Body.hs
+++ b/code/drasil-example/dblpend/lib/Drasil/DblPend/Body.hs
@@ -8,7 +8,7 @@ import Drasil.Database (ChunkDB)
 import Language.Drasil
 import Language.Drasil.Document (makeURI, ulcc, Section, Contents(..),
   LabelledContent, RawContent(..), Reference, namedRef, refS, foldlSP,
-  foldlSPCol, bulletNested, bulletFlat, ConceptInstance)
+  foldlSPCol, bulletNested, bulletFlat, ConceptInstance, shortname')
 import qualified Language.Drasil.Development as D
 import Theory.Drasil (TheoryModel)
 import Drasil.SRS hiding (constants, genDefns)

--- a/code/drasil-example/ssp/lib/Drasil/SSP/Body.hs
+++ b/code/drasil-example/ssp/lib/Drasil/SSP/Body.hs
@@ -7,7 +7,7 @@ import Drasil.Database (ChunkDB)
 import Language.Drasil hiding (variable)
 import Language.Drasil.Document (fig, llccFig, makeURI, ulcc, Contents(..),
   LabelledContent, RawContent(..), Reference, namedRef, refS, foldlSP,
-  foldlSPCol, bulletNested, bulletFlat, ConceptInstance)
+  foldlSPCol, bulletNested, bulletFlat, ConceptInstance, shortname')
 import qualified Language.Drasil.Development as D
 import Drasil.SRS
 import Drasil.Generator (withCommonKnowledge)

--- a/code/drasil-lang/lib/Language/Drasil.hs
+++ b/code/drasil-lang/lib/Language/Drasil.hs
@@ -136,8 +136,6 @@ module Language.Drasil (
   -- Language.Drasil.Development.Sentence
   , introduceAbb, introduceAbbPlrl, phrase, plural, phrasePoss, pluralPoss, atStart, atStart'
   , titleize, titleize', short
-  -- Language.Drasil.ShortName
-  , ShortName, shortname', getSentSN, HasShortName(..)
 
   -- * Sentence Fold-type utilities.
   -- | From "Utils.Drasil.Fold". Defines many general fold functions
@@ -218,7 +216,6 @@ import Language.Drasil.Chunk.Eq (QDefinition, fromEqn, fromEqn', fromEqnSt,
 import Language.Drasil.Chunk.NamedIdea
 import Language.Drasil.Chunk.UncertainQuantity
 import Language.Drasil.NaturalLanguage.English.NounPhrase
-import Language.Drasil.ShortName (ShortName, shortname', getSentSN, HasShortName(..))
 import Language.Drasil.Space (Space(..), RealInterval(..), Inclusive(..),
   RTopology(..), DomainDesc(..), ContinuousDomainDesc, DiscreteDomainDesc,
   getActorName, getInnerSpace, HasSpace(..), mkFunction, Primitive)

--- a/code/drasil-lang/lib/Language/Drasil/Document.hs
+++ b/code/drasil-lang/lib/Language/Drasil/Document.hs
@@ -10,7 +10,8 @@ module Language.Drasil.Document (
   module Language.Drasil.Document.Labels,
   module Language.Drasil.Document.Reference,
   module Language.Drasil.Document.Sections,
-  module Language.Drasil.Document.SentenceCombinators
+  module Language.Drasil.Document.SentenceCombinators,
+  module Language.Drasil.Document.ShortName
 ) where
 
 import Language.Drasil.Document.Citation.Core
@@ -24,3 +25,4 @@ import Language.Drasil.Document.Labels
 import Language.Drasil.Document.Reference
 import Language.Drasil.Document.Sections
 import Language.Drasil.Document.SentenceCombinators
+import Language.Drasil.Document.ShortName

--- a/code/drasil-lang/lib/Language/Drasil/Document/Citation/Core.hs
+++ b/code/drasil-lang/lib/Language/Drasil/Document/Citation/Core.hs
@@ -20,7 +20,7 @@ import Drasil.Database (HasUID(..), UID, showUID, mkUid, declareHasChunkRefs,
   Generically(..))
 
 import Language.Drasil.People (People)
-import Language.Drasil.ShortName (HasShortName(..), ShortName, shortname')
+import Language.Drasil.Document.ShortName (HasShortName(..), ShortName, shortname')
 import Language.Drasil.Document.Citation.Components (HasFields(..), CitationKind(..), CiteField,
   author, chapter, pages, editor, bookTitle, title,
   year, school, journal, institution, note, publisher)

--- a/code/drasil-lang/lib/Language/Drasil/Document/ConceptInstance.hs
+++ b/code/drasil-lang/lib/Language/Drasil/Document/ConceptInstance.hs
@@ -9,7 +9,7 @@ import Control.Lens (makeLenses, (^.), view)
 import Drasil.Database (UID, HasUID(..), declareHasChunkRefs, Generically(..), nsUid, mkUid)
 
 import Language.Drasil.Chunk.Concept.Core (ConceptChunk, sDom)
-import Language.Drasil.ShortName (HasShortName(..), ShortName, shortname')
+import Language.Drasil.Document.ShortName (HasShortName(..), ShortName, shortname')
 import Language.Drasil.Classes (NamedIdea(term), Idea(getA),
   Definition(defn), ConceptDomain(cdom), Concept)
 import Language.Drasil.Document.Labels ((+::+), defer, name, raw,

--- a/code/drasil-lang/lib/Language/Drasil/Document/Contents.hs
+++ b/code/drasil-lang/lib/Language/Drasil/Document/Contents.hs
@@ -25,7 +25,7 @@ import Language.Drasil.Document.Labels (Referable(refAdd))
 import Language.Drasil.ModelExpr.Lang (ModelExpr)
 import Language.Drasil.Sentence (Sentence(..))
 import Language.Drasil.Sentence.Fold (foldlSent_, foldlSent, foldlSentCol)
-import Language.Drasil.ShortName (HasShortName(..), getSentSN)
+import Language.Drasil.Document.ShortName (HasShortName(..), getSentSN)
 
 -- | Displays a given expression and attaches a 'Reference' to it.
 lbldExpr :: ModelExpr -> Reference -> LabelledContent

--- a/code/drasil-lang/lib/Language/Drasil/Document/Core.hs
+++ b/code/drasil-lang/lib/Language/Drasil/Document/Core.hs
@@ -12,7 +12,7 @@ import Drasil.Database (HasChunkRefs(..), HasUID(..), UID)
 
 import Language.Drasil.Expr.Lang (Expr)
 import Language.Drasil.Document.Citation.Core (BibRef)
-import Language.Drasil.ShortName (HasShortName(shortname))
+import Language.Drasil.Document.ShortName (HasShortName(shortname))
 import Language.Drasil.ModelExpr.Lang (ModelExpr)
 import Language.Drasil.Document.Labels (getAdd, prepend, IRefProg,
   LblType(..), Referable(..), HasRefAddress(..))

--- a/code/drasil-lang/lib/Language/Drasil/Document/DecoratedReference.hs
+++ b/code/drasil-lang/lib/Language/Drasil/Document/DecoratedReference.hs
@@ -16,7 +16,7 @@ import Drasil.Database (HasUID(..), IsChunk, declareHasChunkRefs, Generically(..
 import Language.Drasil.Sentence (RefInfo(..))
 import Language.Drasil.Document.Reference (Reference, ref)
 import Language.Drasil.Document.Labels (HasRefAddress(..))
-import Language.Drasil.ShortName (HasShortName(..))
+import Language.Drasil.Document.ShortName (HasShortName(..))
 
 -- | For holding a 'Reference' that is decorated with extra information (ex. page numbers, equation sources, etc.).
 data DecRef = DR {

--- a/code/drasil-lang/lib/Language/Drasil/Document/Reference.hs
+++ b/code/drasil-lang/lib/Language/Drasil/Document/Reference.hs
@@ -15,7 +15,7 @@ import Control.Lens ((^.), makeLenses, Lens')
 import Drasil.Database (UID, HasUID(..), IsChunk, declareHasChunkRefs, Generically(..))
 
 import Language.Drasil.Document.Labels (LblType, HasRefAddress(..))
-import Language.Drasil.ShortName (HasShortName(..), ShortName)
+import Language.Drasil.Document.ShortName (HasShortName(..), ShortName)
 import Language.Drasil.Sentence (Sentence(Ref, EmptyS), RefInfo(..))
 
 -- | A Reference contains the identifier ('UID'), a reference address ('LblType'),

--- a/code/drasil-lang/lib/Language/Drasil/Document/Sections.hs
+++ b/code/drasil-lang/lib/Language/Drasil/Document/Sections.hs
@@ -13,7 +13,7 @@ import Control.Lens ((^.), makeLenses, view)
 import Drasil.Database (UID, HasUID(..), (+++.), mkUid, nsUid, HasChunkRefs(..))
 import qualified Data.Set as Set
 
-import Language.Drasil.ShortName (HasShortName(..), ShortName, shortname')
+import Language.Drasil.Document.ShortName (HasShortName(..), ShortName, shortname')
 import Language.Drasil.Document.Core (UnlabelledContent(UnlblC),
   LabelledContent(LblC), HasCaption(..), RawContent(Figure, Paragraph),
   Contents(..), Lbl, Filepath, Author, Title, MaxWidthPercent)

--- a/code/drasil-lang/lib/Language/Drasil/Document/SentenceCombinators.hs
+++ b/code/drasil-lang/lib/Language/Drasil/Document/SentenceCombinators.hs
@@ -35,7 +35,7 @@ import Language.Drasil.Sentence (Sentence(S, Percent, (:+:), Sy, EmptyS), eS,
   ch, sParen, sDash, (+:+), sC, (+:+.), (!.), (+:), capSent)
 import Language.Drasil.Sentence.Fold (foldlList, SepType(Comma), FoldType(List), foldlSent)
 import Language.Drasil.Sentence.Generators (fterms)
-import Language.Drasil.ShortName (HasShortName(..))
+import Language.Drasil.Document.ShortName (HasShortName(..))
 import Language.Drasil.Document.Core (ItemType(..), ListType(Bullet))
 import Language.Drasil.Document.Reference (refS, namedRef)
 import Language.Drasil.Document.Sections (Section)

--- a/code/drasil-lang/lib/Language/Drasil/Document/ShortName.hs
+++ b/code/drasil-lang/lib/Language/Drasil/Document/ShortName.hs
@@ -1,6 +1,6 @@
 {-# LANGUAGE TemplateHaskell #-}
 -- | Short names are used for displaying references.
-module Language.Drasil.ShortName (
+module Language.Drasil.Document.ShortName (
   ShortName, shortname', getSentSN, HasShortName(..)
 ) where
 

--- a/code/drasil-printers/lib/Language/Drasil/Printing/Import/Sentence.hs
+++ b/code/drasil-printers/lib/Language/Drasil/Printing/Import/Sentence.hs
@@ -9,9 +9,10 @@ import Drasil.Database (UID)
 import Drasil.Database.SearchTools (termResolve', TermAbbr(..), refResolve)
 import Language.Drasil (Sentence(..), NP, NounPhrase(..), (+:+), sParen,
   atStartNP, atStartNP', titleizeNP, titleizeNP', foldNums, checkValidStr,
-  getSentSN, SentenceStyle(..), TermCapitalization(..), ShortName, RefInfo(..))
+  SentenceStyle(..), TermCapitalization(..), RefInfo(..))
 import Language.Drasil.Development (toSent)
-import Language.Drasil.Document (Reference(..), IRefProg(..), LblType(..))
+import Language.Drasil.Document (Reference(..), IRefProg(..), LblType(..),
+  ShortName, getSentSN)
 import qualified Language.Drasil.Printing.AST as P
 import Language.Drasil.Printing.PrintingInformation (PrintingInformation, sysdb)
 import Language.Drasil.Printing.Import.ExprCommon (lookupSymb)


### PR DESCRIPTION
Contributes to JacquesCarette/Drasil#4038

Similar to #5441 and #5443, this is a follow-up to #5089 and related PRs, moving code around according to the `drasil-lang` module dependency graph.