### PR TITLE
chore(`-printers`): remove unused `HARDNL` constructor in `Spec`

### DIFF
--- a/code/drasil-printers/lib/Language/Drasil/HTML/Print.hs
+++ b/code/drasil-printers/lib/Language/Drasil/HTML/Print.hs
@@ -31,7 +31,7 @@ import Language.Drasil.HTML.CSS (linkCSS)
 import Language.Drasil.Config (StyleGuide(APA, MLA, Chicago), bibStyleH)
 import Language.Drasil.Printing.AST (ItemType(Flat, Nested),
   ListType(Ordered, Unordered, Definitions, Desc, Simple), Expr, Fence(Curly, Paren, Abs, Norm),
-  Ops(..), Expr(..), Spec(Quote, EmptyS, Ref, HARDNL, Sp, S, E, (:+:), Tooltip),
+  Ops(..), Expr(..), Spec(Quote, EmptyS, Ref, Sp, S, E, (:+:), Tooltip),
   Spacing(Thin), Fonts(Bold, Emph), OverSymb(Hat), Label,
   LinkType(Internal, Cite2, External))
 import Language.Drasil.Printing.Citation (CiteField(Year, Number, Volume, Title, Author,
@@ -125,7 +125,6 @@ print = foldr (($$) . printLO) empty
 -- because newline can't be rendered in an HTML title.
 titleSpec :: Spec -> Doc
 titleSpec (a :+: b) = titleSpec a <> titleSpec b
-titleSpec HARDNL    = empty
 titleSpec s         = pSpec s
 
 -- | Renders the Sentences ('Spec's) in the HTML body (called by 'printLO').
@@ -143,7 +142,6 @@ pSpec (S s)     = either error (text . concatMap escapeChars) $ checkValidStr s 
     escapeChars c = [c]
 pSpec (Tooltip t s) = spanTag' (pSpec t) (pSpec s)
 pSpec (Sp s)    = text $ unPH $ special s
-pSpec HARDNL    = text "<br />"
 pSpec (Ref Internal r a)       = reflink     r $ pSpec a
 pSpec (Ref (Cite2 EmptyS) r a) = reflink     r $ pSpec a -- no difference for citations?
 pSpec (Ref (Cite2 n)   r a)    = reflinkInfo r (pSpec a) (pSpec n) -- no difference for citations?

--- a/code/drasil-printers/lib/Language/Drasil/JSON/Print.hs
+++ b/code/drasil-printers/lib/Language/Drasil/JSON/Print.hs
@@ -17,7 +17,7 @@ import Language.Drasil.Document (MaxWidthPercent)
 
 import Language.Drasil.Printing.AST (Spec (Tooltip), ItemType(Flat, Nested),
   ListType(Ordered, Unordered, Definitions, Desc, Simple), Expr,
-  Ops(..), Expr(..), Spec(Quote, EmptyS, Ref, HARDNL, Sp, S, E, (:+:)),
+  Ops(..), Expr(..), Spec(Quote, EmptyS, Ref, Sp, S, E, (:+:)),
   Fonts(Bold), OverSymb(Hat), Label, LinkType(Internal, Cite2, External))
 import Language.Drasil.Printing.Citation (BibRef)
 import Language.Drasil.Printing.LayoutObj (Document(Document), LayoutObj(..))
@@ -110,7 +110,6 @@ pSpec (S s)     = either error (text . concatMap escapeChars) $ checkValidStr s 
     escapeChars c = [c]
 pSpec (Tooltip _ s) = pSpec s
 pSpec (Sp s)    = text $ unPH $ special s
-pSpec HARDNL    = empty
 pSpec (Ref Internal r a)      = reflink     r $ pSpec a
 pSpec (Ref (Cite2 EmptyS) r a) = reflink     r $ pSpec a -- no difference for citations?
 pSpec (Ref (Cite2 n)   r a)    = reflinkInfo r (pSpec a) (pSpec n)

--- a/code/drasil-printers/lib/Language/Drasil/Markdown/Print.hs
+++ b/code/drasil-printers/lib/Language/Drasil/Markdown/Print.hs
@@ -19,7 +19,7 @@ import Drasil.FileHandling (FileLayout, file, directory, ps)
 
 import Language.Drasil.Printing.AST (ItemType(Flat, Nested),
   ListType(Ordered, Unordered, Definitions, Desc, Simple), Expr,
-  Expr(..), Spec(Quote, EmptyS, Ref, HARDNL, E, (:+:), Tooltip), Label,
+  Expr(..), Spec(Quote, EmptyS, Ref, E, (:+:), Tooltip), Label,
   LinkType(Internal, Cite2, External), OverSymb(Hat), Fonts(Emph, Bold),
   Spacing(Thin), Fence(Abs), Ops(Perc, Mul))
 import Language.Drasil.Printing.Citation (BibRef)
@@ -157,7 +157,6 @@ pSpec :: RefMap -> Spec -> Doc
 pSpec _ (E e)      = text "\\\\(" <> pExpr e <> text "\\\\)"
 pSpec rm (Tooltip _ s) = pSpec rm s
 pSpec rm (a :+: b) = pSpec rm a <> pSpec rm b
-pSpec _ HARDNL     = text "\n"
 pSpec rm (Ref Internal       r a) = reflink     rm r (pSpec rm a)
 pSpec rm (Ref (Cite2 EmptyS) r a) = reflink     rm r (pSpec rm a)
 pSpec rm (Ref (Cite2 n)      r a) = reflinkInfo rm r (pSpec rm a) (pSpec rm n)

--- a/code/drasil-printers/lib/Language/Drasil/Plain/Print.hs
+++ b/code/drasil-printers/lib/Language/Drasil/Plain/Print.hs
@@ -80,8 +80,6 @@ specDoc f (Ref _ r s) = specDoc f s <+> text ("Ref: " ++ r) --may need to change
 specDoc f (s1 :+: s2) = specDoc f s1 <> specDoc f s2
 specDoc _ EmptyS = empty
 specDoc f (Quote s) = doubleQuotes $ specDoc f s
-specDoc MultiLine HARDNL = text "\n"
-specDoc OneLine HARDNL = error "HARDNL encountered in attempt to format linearly"
 
 -- | Helper for printing units in 'Doc' format.
 unitDoc :: SingleLine -> USymb -> Doc

--- a/code/drasil-printers/lib/Language/Drasil/Printing/AST.hs
+++ b/code/drasil-printers/lib/Language/Drasil/Printing/AST.hs
@@ -63,10 +63,7 @@ data Spec = E Expr                   -- ^ Holds an expression.
           | Ref LinkType String Spec -- ^ Holds the actual reference of form 'LinkType', reference address, and display name
           | EmptyS                   -- ^ Empty sentence.
           | Quote Spec               -- ^ Quotes are different in different languages.
-          | HARDNL                   -- Temp fix for multi-line descriptions;
-                                     -- May move to a new LayoutObj, but only exists in TeX
-                                     -- so it's not really a big deal ATM.
-                                     -- ^ Newline.
+
 -- | A title is just a sentence ('Spec').
 type Title    = Spec
 

--- a/code/drasil-printers/lib/Language/Drasil/TeX/Print.hs
+++ b/code/drasil-printers/lib/Language/Drasil/TeX/Print.hs
@@ -17,7 +17,7 @@ import qualified Language.Drasil.Display as LD
 import Language.Drasil.Config (colAwidth, colBwidth, bibStyleT, bibFname)
 import Language.Drasil.Printing.AST (Spec (Tooltip), ItemType(Nested, Flat),
   ListType(Ordered, Unordered, Desc, Definitions, Simple),
-  Spec(Quote, EmptyS, Ref, S, Sp, HARDNL, E, (:+:)),
+  Spec(Quote, EmptyS, Ref, S, Sp, E, (:+:)),
   Fence(Norm, Abs, Curly, Paren), Expr,
   Ops(..), Spacing(Thin), Fonts(Emph, Bold),
   Expr(..), OverSymb(Hat), Label,
@@ -236,7 +236,6 @@ specLength (Ref (Cite2 n)   r i ) = length r + specLength i + specLength n --may
 specLength (Ref External _ t) = specLength t
 specLength EmptyS      = 0
 specLength (Quote q)   = 4 + specLength q
-specLength HARDNL      = 0
 
 -- | Invalid characters, not included in an expression.
 dontCount :: String
@@ -264,7 +263,6 @@ needs (S _)         = Text
 needs (Tooltip _ s) = needs s
 needs (E _)         = Math
 needs (Sp _)        = Math
-needs HARDNL        = Text
 needs Ref{}         = Text
 needs EmptyS        = Text
 needs (Quote _)     = Text
@@ -285,7 +283,6 @@ spec (S s)  = either error (pure . text . concatMap escapeChars) $ L.checkValidS
     escapeChars c = [c]
 spec (Tooltip _ s) = spec s
 spec (Sp s) = pure $ text $ unPL $ L.special s
-spec HARDNL = command0 "newline"
 spec (Ref Internal r sn) = snref r (spec sn)
 spec (Ref (Cite2 n) r _) = cite r (info n)
   where


### PR DESCRIPTION
"Hard newline" was never used. According to its comments, it was only meant to be temporary. We can (and should) remove it before there is any usage of it.