### PR TITLE
refactor(`srs-gen`): move file-rendering code from `drasil-gen` to `drasil-srs`

### DIFF
--- a/code/drasil-code/lib/Language/Drasil/Code/Imperative/DrasilState.hs
+++ b/code/drasil-code/lib/Language/Drasil/Code/Imperative/DrasilState.hs
@@ -21,7 +21,6 @@ import Language.Drasil (Space, Expr, DefinedQuantityDict)
 import Language.Drasil.Printers (PrintingInformation)
 import Drasil.GOOL (VisibilityTag(..), CodeType)
 import Drasil.System (systemdb, HasSystemMeta(..), HasProjectName(..))
-import Drasil.SRS (HasSmithEtAlSRS(..))
 
 import Drasil.Code.CodeVar (CodeIdea(..))
 import Language.Drasil.Chunk.ConstraintMap (ConstraintCE)
@@ -179,9 +178,6 @@ instance HasSystemMeta DrasilState where
 
 instance HasProjectName DrasilState where
   projectName = systemMeta . projectName
-
-instance HasSmithEtAlSRS DrasilState where
-  smithEtAlSRS = dsCodeSpec . smithEtAlSRS
 
 -- | Adds a message to the design log if the given 'Space'-'CodeType' match has not
 -- already been logged.

--- a/code/drasil-code/lib/Language/Drasil/CodeSpec.hs
+++ b/code/drasil-code/lib/Language/Drasil/CodeSpec.hs
@@ -26,7 +26,7 @@ import Language.Drasil hiding (None)
 import Drasil.Database (ChunkDB, UID, HasUID(..), insertAll, mkUid)
 import Drasil.Code.CodeExpr.Development (expr, eNamesRI, eDep)
 import qualified Drasil.SRS as S
-import Drasil.System (HasSystemMeta(..), systemdb, HasProjectName(..))
+import Drasil.System (HasSystemMeta(..), systemdb, HasProjectName(..), SystemMeta)
 import Drasil.SRS (HasSmithEtAlSRS(..))
 import Theory.Drasil (DataDefinition, qdEFromDD, getEqModQdsFromIm)
 import Data.List.Extras (subsetOf)
@@ -53,7 +53,7 @@ type ConstantMap = Map.Map UID CodeDefinition
 
 -- | Code Specification. Holds system information and options.
 data CodeSpec = CS {
-  _srs :: S.SmithEtAlSRS,
+  _csSysMeta :: SystemMeta,
   -- | All inputs.
   _inputs :: [Input],
   -- | Explicit inputs (values to be supplied by a file).
@@ -79,11 +79,8 @@ data CodeSpec = CS {
 }
 makeClassy ''CodeSpec
 
-instance HasSmithEtAlSRS CodeSpec where
-  smithEtAlSRS = srs
-
 instance HasSystemMeta CodeSpec where
-  systemMeta = srs . systemMeta
+  systemMeta = csSysMeta
 
 instance HasProjectName CodeSpec where
   projectName = systemMeta . projectName
@@ -112,15 +109,14 @@ mkCodeSpec si@S.ICO{ S._inputs = ins
   let els = extLibs chs
       libReqs = concatMap odeLibReqs els
       infoReqs = concatMap odeInfoReqs els
-      db' = insertAll (libReqs ++ infoReqs) $ si ^. systemdb
-      sys = set systemdb db' si
-      ddefs = sys ^. dataDefns
-      db = sys ^. systemdb
+      db = insertAll (libReqs ++ infoReqs) $ si ^. systemdb
+      sysMeta = set systemdb db $ si ^. systemMeta
+      ddefs = si ^. dataDefns
       inputs' = map quantvar $ NE.toList ins
       const' = map qtov (filter ((`Map.notMember` conceptMatch (maps chs)) . (^. uid))
         cnsts)
       derived = map qtov $ getDerivedInputs ddefs inputs' const' db
-      rels = (map qtoc (getEqModQdsFromIm (sys ^. instModels) ++ mapMaybe qdEFromDD ddefs) \\ derived)
+      rels = (map qtoc (getEqModQdsFromIm (si ^. instModels) ++ mapMaybe qdEFromDD ddefs) \\ derived)
         ++ mapODE (getODE $ extLibs chs)
         ++ map qtoc (handWiredDefs chs)
       -- TODO: When we have better DEModels, we should be deriving our ODE information
@@ -129,7 +125,11 @@ mkCodeSpec si@S.ICO{ S._inputs = ins
       allInputs = inputs' ++ map quantvar derived
       exOrder = solveExecOrder rels (allInputs ++ map quantvar cnsts) outs' db
   in CS {
-        _srs = sys,
+        _csSysMeta = sysMeta,
+        -- FIXME: This _should_ be different in at least one way. The SM from
+        -- the SRS _should_ reference "defining an SRS that ...". This SM should
+        -- reference said SRS, saying "building a software design satisfying
+        -- said SRS."
         _inputs = allInputs,
         _extInputs = inputs',
         _derivedInputs = derived,
@@ -160,8 +160,8 @@ funcUID f = asVC f ^. uid
 -- come from those. If there are none, then the 'QDefinition's are used instead.
 getDerivedInputs :: [DataDefinition] -> [Input] -> [Const] ->
   ChunkDB -> [SimpleQDef]
-getDerivedInputs ddefs ins cnsts sm =
-  filter ((`subsetOf` refSet) . flip codevars sm . expr . (^. defnExpr)) (mapMaybe qdEFromDD ddefs)
+getDerivedInputs ddefs ins cnsts db =
+  filter ((`subsetOf` refSet) . flip codevars db . expr . (^. defnExpr)) (mapMaybe qdEFromDD ddefs)
   where refSet = ins ++ map quantvar cnsts
 
 -- | Get a list of 'Constraint's for a list of 'CodeChunk's.

--- a/code/drasil-gen/lib/Drasil/Generator.hs
+++ b/code/drasil-gen/lib/Drasil/Generator.hs
@@ -2,7 +2,6 @@ module Drasil.Generator
   ( module Drasil.Generator.CaseStudyVariants,
     module Drasil.Generator.Code,
     module Drasil.Generator.CommonKnowledge,
-    module Drasil.Generator.Formats,
     module Drasil.Generator.WriteSystem,
   )
 where
@@ -10,5 +9,4 @@ where
 import Drasil.Generator.CaseStudyVariants
 import Drasil.Generator.Code
 import Drasil.Generator.CommonKnowledge
-import Drasil.Generator.Formats
 import Drasil.Generator.WriteSystem

--- a/code/drasil-gen/lib/Drasil/Generator/CaseStudyVariants.hs
+++ b/code/drasil-gen/lib/Drasil/Generator/CaseStudyVariants.hs
@@ -14,12 +14,10 @@ import Control.Lens ((^.))
 
 import Drasil.FileHandling (FileLayout, OverwritePolicy(..), directory, localPath, ps,
   writeFiles)
-import Drasil.SRS (SRSDecl, SmithEtAlSRS)
+import Drasil.SRS (SRSDecl, SmithEtAlSRS, genSmithEtAlSrs, typeCheckSI)
 import Language.Drasil.Code (Choices)
 
 import Drasil.Generator.Code (genCode, genCodeZoo)
-import Drasil.Generator.SRS (genSmithEtAlSrs)
-import Drasil.Generator.SRS.TypeCheck (typeCheckSI)
 import Drasil.Generator.WriteSystem (setSystemLocale)
 import Drasil.System (HasProjectName(..))
 

--- a/code/drasil-srs/lib/Drasil/SRS.hs
+++ b/code/drasil-srs/lib/Drasil/SRS.hs
@@ -1,10 +1,12 @@
 -- | Re-export document language types and functions for easy use in other packages.
 module Drasil.SRS (
   module Drasil.SRS.SmithEtAlSRS,
+  module Drasil.SRS.Generator,
+  module Drasil.SRS.Generator.Formats,
+  module Drasil.SRS.TypeCheck,
+
   -- * Document Language
   -- ** SRS
-  -- | For generating Software Requirements Specifications.
-
   -- *** Types
   -- Drasil.DocDecl
   SRSDecl, DocSection(..), ReqrmntSec(..), ReqsSub(..),
@@ -18,8 +20,6 @@ module Drasil.SRS (
   TConvention(..), TraceabilitySec(TraceabilityProg), TSIntro(..), TUIntro(..),
   PurposeDescription(..),
   -- *** Functions
-  -- Drasil.DocumentLanguage
-  mkDoc,
   -- * Subsection Functions
   -- ** Definitions and Models
   -- Drasil.DocumentLanguage.Definitions
@@ -29,8 +29,6 @@ module Drasil.SRS (
   mkGraphInfo, traceyGraphGetRefs,
   -- Drasil.Sections.TraceabilityMandGs
   traceMatStandard, traceMatOtherReq,
-  -- Drasil.Tracetable
-  generateTraceMap,
   -- ** Auxiliary Constants
   -- Drasil.Sections.AuxiliaryConstants
   tableOfConstants,
@@ -56,7 +54,6 @@ module Drasil.SRS (
 import Drasil.SRS.DocDecl (SRSDecl, DocSection(..), ReqrmntSec(..), ReqsSub(..),
   PDSub(..), ProblemDescription(..), SSDSec(..), SSDSub(..), SCSSub(..),
   SolChSpec(..))
-import Drasil.SRS.DocumentLanguage (mkDoc)
 import Drasil.SRS.DocumentLanguage.Core (AppndxSec(..), AuxConstntSec(..),
   DerivationDisplay(..), DocDesc, Emphasis(..), OffShelfSolnsSec(..), GSDSec(..),
   GSDSub(UsrChars, SystCons, SysCntxt), IntroSec(..), IntroSub(..), LFunc(..),
@@ -75,5 +72,8 @@ import Drasil.SRS.Sections.SpecificSystemDescription (auxSpecSent, termDefnF', i
 import Drasil.SRS.Sections.TableOfSymbols (tsymb, tsymb'')
 import Drasil.SRS.Sections.TableOfUnits (unitTableRef, tunit, tunit',tunitNone)
 import Drasil.SRS.Sections.TraceabilityMandGs (traceMatStandard, traceMatOtherReq)
+
+import Drasil.SRS.Generator
+import Drasil.SRS.Generator.Formats
 import Drasil.SRS.SmithEtAlSRS
-import Drasil.SRS.TraceTable (generateTraceMap)
+import Drasil.SRS.TypeCheck

--- a/code/drasil-srs/lib/Drasil/SRS/DocumentLanguage.hs
+++ b/code/drasil-srs/lib/Drasil/SRS/DocumentLanguage.hs
@@ -1,10 +1,9 @@
 {-# Language TupleSections #-}
 ---------------------------------------------------------------------------
 -- | Start the process of moving away from Document as the main internal
--- representation of information, to something more informative.
--- Over time, we'll want to have a cleaner separation, but doing that
--- all at once would break too much for too long.  So we start here
--- instead.
+-- representation of information, to something more informative. Over time,
+-- we'll want to have a cleaner separation, but doing that all at once would
+-- break too much for too long. So we start here instead.
 module Drasil.SRS.DocumentLanguage (mkDoc) where
 
 -- General Haskell

--- a/code/drasil-srs/lib/Drasil/SRS/Generator.hs
+++ b/code/drasil-srs/lib/Drasil/SRS/Generator.hs
@@ -1,7 +1,8 @@
 {-# LANGUAGE QuasiQuotes #-}
-module Drasil.Generator.SRS (
+module Drasil.SRS.Generator (
   -- * SRS Generator
-  genSmithEtAlSrs
+  genSmithEtAlSrs,
+  typeCheckSI
 ) where
 
 import Prelude hiding (id)
@@ -16,12 +17,16 @@ import Language.Drasil.Printers (genericCSS, genHTML, genTeX,
 import Drasil.Makefile ((+:+), makeS, mkCheckedCommand, mkCommand,
   mkFreeVar, mkFile, mkRule, mkMakefile, printMakefile)
 import Drasil.Metadata (watermark)
-import Drasil.SRS (mkGraphInfo, SmithEtAlSRS, mkDoc, SRSDecl)
 import Drasil.System (systemdb)
 import qualified Language.Drasil.Sentence.Combinators as S
 
-import Drasil.Generator.Formats (Filename, Format(..))
-import Drasil.Generator.SRS.TraceabilityGraphs (outputDot)
+import Drasil.SRS.DocDecl (SRSDecl)
+import Drasil.SRS.DocumentLanguage (mkDoc)
+import Drasil.SRS.DocumentLanguage.TraceabilityGraph (mkGraphInfo)
+import Drasil.SRS.Generator.Formats (Filename, Format(..))
+import Drasil.SRS.Generator.TraceabilityGraphs (outputDot)
+import Drasil.SRS.SmithEtAlSRS (SmithEtAlSRS)
+import Drasil.SRS.TypeCheck (typeCheckSI)
 
 -- | Generate Drasil's SRS (in HTML, TeX, Jupyter, and MDBook formats).
 genSmithEtAlSrs :: SmithEtAlSRS -> SRSDecl -> String -> [FileLayout]

--- a/code/drasil-srs/lib/Drasil/SRS/Generator/Formats.hs
+++ b/code/drasil-srs/lib/Drasil/SRS/Generator/Formats.hs
@@ -1,5 +1,5 @@
 -- | Defines output formats for the different documents we can generate.
-module Drasil.Generator.Formats (
+module Drasil.SRS.Generator.Formats (
   -- * Types (Printing Options)
   Filename, Format(..)
 ) where

--- a/code/drasil-srs/lib/Drasil/SRS/Generator/TraceabilityGraphs.hs
+++ b/code/drasil-srs/lib/Drasil/SRS/Generator/TraceabilityGraphs.hs
@@ -1,6 +1,6 @@
 {-# LANGUAGE QuasiQuotes #-}
 
-module Drasil.Generator.SRS.TraceabilityGraphs (outputDot) where
+module Drasil.SRS.Generator.TraceabilityGraphs (outputDot) where
 
 import Prelude hiding ((<>))
 

--- a/code/drasil-srs/lib/Drasil/SRS/TypeCheck.hs
+++ b/code/drasil-srs/lib/Drasil/SRS/TypeCheck.hs
@@ -1,4 +1,4 @@
-module Drasil.Generator.SRS.TypeCheck (
+module Drasil.SRS.TypeCheck (
   -- * Type check a Drasil 'System'
   typeCheckSI
 ) where
@@ -12,7 +12,8 @@ import qualified Data.Map.Strict as M
 import Drasil.Database (UID, HasUID(..))
 import Language.Drasil (Expr, Space, temporaryIndent, HasSpace(typ),
   RequiresChecking(..), TypeError, Typed(check))
-import Drasil.SRS (SmithEtAlSRS, HasSmithEtAlSRS(..))
+
+import Drasil.SRS.SmithEtAlSRS (SmithEtAlSRS, HasSmithEtAlSRS(..))
 
 -- Note: this should be externally configurable wrt verbosity!
 typeCheckSI :: SmithEtAlSRS -> IO ()

--- a/code/drasil-srs/package.yaml
+++ b/code/drasil-srs/package.yaml
@@ -23,8 +23,11 @@ dependencies:
 - transformers
 - multiplate
 - drasil-database
+- drasil-file-handling
 - drasil-lang
+- drasil-makefile
 - drasil-metadata
+- drasil-printers
 - drasil-system
 - drasil-theory
 - drasil-utils

--- a/code/drasil-website/lib/Drasil/Website/Example.hs
+++ b/code/drasil-website/lib/Drasil/Website/Example.hs
@@ -9,9 +9,9 @@ import Control.Lens ((^.), lens)
 import Language.Drasil hiding (E)
 import Language.Drasil.Document
 import Drasil.System (ProjectName, purpose, HasSystemMeta(..), HasProjectName(..))
-import Drasil.SRS (SmithEtAlSRS(..))
+import Drasil.SRS (SmithEtAlSRS(..), Format(..))
 import Language.Drasil.Code (Choices(..), Lang(..))
-import Drasil.Generator (codedHRName, codedDirName, Format(..))
+import Drasil.Generator (codedHRName, codedDirName)
 
 import qualified Drasil.BinaryStar.Body as BSS (si)
 import qualified Drasil.DblPend.Body as DblPend (si)


### PR DESCRIPTION
Needed to recreate #5436 because `gh stack rebase` somehow erroneously merged it into #5435.

A result of #5309 

Now all 'secrets' related to the generated SRS artifacts are contained within `drasil-srs`. For example, the `TraceyGraph` folder name was a kind of secret that was shared between both `drasil-gen` and `drasil-srs`. Now, only `drasil-srs`.