### PR TITLE
Implement missing methods in MATLAB renderer

### DIFF
--- a/code/drasil-code/test/HelloWorld.hs
+++ b/code/drasil-code/test/HelloWorld.hs
@@ -13,7 +13,7 @@ import Drasil.GOOL (Class, SVariable, CS, MS, OOProg, BodySym(..),
   ValueExpression(..), extFuncApp, newObj, Reference(..), Array(..), List(..),
   ListStatement(..), InternalList, MethodSym(..), OOMethodSym(..), objMethodCall,
   classMethodCall, initializer, OODeclStatement(objDecDef), Set(..),
-  ParameterSym(..))
+  ParameterSym(..), BinderSym(..))
 import qualified Drasil.GOOL as OO (GSProgram, ProgramSym(..), FileSym(..),
   ModuleSym(..))
 import Drasil.GProc (ProcProg)
@@ -63,7 +63,7 @@ helloWorldMainOO = mainFunction (body ([ helloInitVariables, objectTests] ++ lis
 helloWorldMainProc
   :: (ProcProg r vis stmt mthd prg file mod bod block)
   => MS (r mthd)
-helloWorldMainProc = mainFunction (body ([ helloInitVariables] ++ listSliceTests
+helloWorldMainProc = mainFunction (body ([ helloInitVariables, helloProcTests] ++ listSliceTests
     ++ [block [printLn $ litString "", ifCond [
       (valueOf (var "b" int) ?>= litInt 6, bodyStatements [
         varDecDef (var "dummy" string) mainFn (litString "dummy")]),
@@ -138,6 +138,34 @@ helloInitVariables = block [comment "Initializing variables",
   setDecDef (var "s" (setType int)) mainFn (litSet int [litInt 4, litInt 7, litInt 5]),
   assert (contains (valueOf (var "s" (setType int))) (litInt 7))
     (litString "Set s should contain 7")]
+
+helloProcTests
+  ::
+    ( BlockSym r block stmt
+    , Literal r
+    , VariableValue r
+    , NumericExpression r
+    , Set r
+    , ValueExpression r
+    , BinderSym r
+    , DeclStatement r stmt bod
+    , AssignStatement r stmt
+    , CommentStatement r stmt
+    , PrintConsole r stmt
+    )
+  => MS (r block)
+helloProcTests = block [
+  comment "Set operation and lambda tests",
+  var "s" (setType int) &= setAdd (valueOf (var "s" (setType int))) (litInt 10),
+  var "s" (setType int) &= setRemove (valueOf (var "s" (setType int))) (litInt 7),
+  var "s" (setType int) &= setUnion (valueOf (var "s" (setType int)))
+    (litSet int [litInt 20, litInt 30]),
+  printStr "Set after operations: ",
+  printLn (valueOf (var "s" (setType int))),
+  varDecDef (var "myLambda" double) mainFn
+    (lambda [binder "x" double]
+      (valueOf (var "x" double) #* litDouble 2.0)),
+  printLn $ litString "Lambda defined successfully"]
 
 objectTests :: (OOProg r vis stmt mthd stvr attch prg file mod bod block) => MS (r block)
 objectTests = block [comment "Object tests",

--- a/code/drasil-code/test/golden/HelloWorldProc/julia/HelloWorld.jl
+++ b/code/drasil-code/test/golden/HelloWorldProc/julia/HelloWorld.jl
@@ -59,6 +59,20 @@ println(boringList)
 global s = Set([4, 7, 5])
 @assert in(7, s) "Set s should contain 7"
 
+# Set operation and lambda tests
+global s = push!(s, 10)
+global s = delete!(s, 7)
+global s = union!(s, Set([20, 30]))
+print("Set after operations: ")
+print("{ ")
+for set_i1 in s
+    print(set_i1)
+    print(" ")
+end
+println("}")
+global myLambda = x -> x * 2.0
+println("Lambda defined successfully")
+
 # List slicing tests
 # Create variables for list slices
 global mySlicedList = Float64[]

--- a/code/drasil-code/test/golden/HelloWorldProc/matlab/HelloWorld.m
+++ b/code/drasil-code/test/golden/HelloWorldProc/matlab/HelloWorld.m
@@ -116,6 +116,25 @@ function HelloWorld(varargin)
     s = [4, 7, 5];
     assert(ismember(7, s), "Set s should contain 7");
     
+    % Set operation and lambda tests
+    s = union(s, [10]);
+    s = setdiff(s, [7]);
+    s = union(s, [20, 30]);
+    fprintf('%s', "Set after operations: ");
+    fprintf('%s', "[");
+    list_i1 = 0;
+    while list_i1 < length(s) - 1
+        fprintf('%g', s(list_i1 + 1));
+        fprintf('%s', ", ");
+        list_i1 = list_i1 + 1;
+    end
+    if length(s) > 0
+        fprintf('%g', s(length(s) - 1 + 1));
+    end
+    fprintf('%s\n', "]");
+    myLambda = @(x) x * 2.0;
+    fprintf('%s\n', "Lambda defined successfully");
+    
     % List slicing tests
     % Create variables for list slices
     mySlicedList = [];

--- a/code/drasil-gool/lib/Drasil/GProc/LanguageRenderer/MatlabRenderer.hs
+++ b/code/drasil-gool/lib/Drasil/GProc/LanguageRenderer/MatlabRenderer.hs
@@ -63,8 +63,8 @@ import Drasil.Shared.AST (Terminator(..), FileType(Combined), fileD, md,
   updateMod, MethodData, mthd, mthdName, updateMthd, ParamData, paramVar, paramDoc, pd,
   ProgData, TypeData, cType, vd, val, valPrec, valInt, valType, opDoc, opPrec,
   varName, varType, varBind, varDoc, vard, progD, mthdDoc, modDoc,
-  FuncData(fType, funcDoc), fd, ScopeData, sd, ScopeTag(..), BinderD,
-  FileData, ModData)
+  FuncData(fType, funcDoc), fd, ScopeData, sd, ScopeTag(..),
+  BinderD(bindName, bindType), bindFormD, FileData, ModData)
 import Drasil.Shared.CodeType (CodeType(..))
 import Drasil.Shared.LanguageRenderer.Constructors (typeFromData, unOpPrec,
   powerPrec, multPrec, unExpr, unExpr', binExpr, binExpr', mkStateVal, mkVal,
@@ -352,9 +352,9 @@ instance ListStatement MatlabCode (Doc, Terminator) where
 
 instance Set MatlabCode where
   contains s e = funcApp "ismember" bool [e, s]
-  setAdd = undefined
-  setRemove = undefined
-  setUnion = undefined
+  setAdd s e = funcApp "union" void [s, litList int [e]]
+  setRemove s e = funcApp "setdiff" void [s, litList int [e]]
+  setUnion a b = funcApp "union" void [a, b]
 
 instance NativeVector MatlabCode where
   vecScale = binExpr multOp           -- s * v
@@ -381,14 +381,14 @@ mlCellWrap String = braces
 mlCellWrap _      = parens
 
 instance BinderSym MatlabCode where
-  binder = undefined
+  binder nm tp = onCodeValue (bindFormD nm) <$> tp
 
 instance BinderElim MatlabCode where
-  binderName = undefined
-  binderType = undefined
+  binderName = bindName . unMLC
+  binderType = onCodeValue bindType
 
 instance InternalBinderElim MatlabCode where
-  binderElim = undefined
+  binderElim = text . bindName . unMLC
 
 instance RenderFunction MatlabCode where
   funcFromData d = onStateValue $ onCodeValue (`fd` d)

--- a/code/drasil-gool/lib/Drasil/GProc/LanguageRenderer/MatlabRenderer.hs
+++ b/code/drasil-gool/lib/Drasil/GProc/LanguageRenderer/MatlabRenderer.hs
@@ -6,7 +6,7 @@ module Drasil.GProc.LanguageRenderer.MatlabRenderer (
 ) where
 
 import Drasil.Shared.InterfaceCommon (Label, Value, SValue, Variable, SVariable,
-  getCodeType, UnRepr(..), Body, Block, BodySym(..), BlockSym(..), TypeSym(..),
+  getCodeType, getTypeString, UnRepr(..), Body, Block, BodySym(..), BlockSym(..), TypeSym(..),
   TypeElim(..), VariableSym(..), VariableElim(..), ValueSym(..), Argument(..),
   Literal(..), MathConstant(..), VariableValue(..), CommandLineArgs(..),
   NumericExpression(..), BooleanExpression(..), Comparison(..),
@@ -17,7 +17,7 @@ import Drasil.Shared.InterfaceCommon (Label, Value, SValue, Variable, SVariable,
   FileHandling(..), PrintFile(..), ReadFile(..), StringStatement(..),
   FunctionSym, FuncAppStatement(..), CommentStatement(..), ControlStatement(..),
   switchAsIf, VisibilitySym(..), ScopeSym(..), ParameterSym(..), BinderSym(..),
-  BinderElim(..), MethodSym(..), funcApp, (&=), bodyStatements)
+  BinderElim(..), MethodSym(..), funcApp, extFuncApp, (&=), bodyStatements)
 import Drasil.GProc.InterfaceProc (ProcProg, ProgramSym(..),
   FileSym(..), ModuleSym(..))
 
@@ -48,32 +48,35 @@ import qualified Drasil.Shared.LanguageRenderer.LanguagePolymorphic as G (
   negateOp, plusOp, minusOp, multOp, divideOp, equalOp, greaterOp,
   greaterEqualOp, lessOp, lessEqualOp, csc, sec, cot, valueOf, litChar,
   litDouble, litInt, litString, valStmt, emptyStmt, assign,
-  funcAppMixedArgs, call, print, ifCond, tryCatch, listAccess, smartAdd)
+  funcAppMixedArgs, call, print, ifCond, tryCatch, listAccess, smartAdd, local,
+  lambda)
 import qualified Drasil.Shared.LanguageRenderer.CommonPseudoOO as CP (mainBody,
   functionDoc, docInOutFunc', inOutCall, multiAssign, intToIndex', indexToInt',
-  listDecDef, litSet)
+  listDecDef, argExists, multiReturn, litSet)
 import qualified Drasil.Shared.LanguageRenderer.CLike as C (andOp, orOp, litTrue,
   litFalse, while)
 import qualified Drasil.Shared.LanguageRenderer.Common as CS (varDecDef,
-  funcType, listSize, forEach')
+  extVar, funcType, listSize, forEach')
 import qualified Drasil.Shared.LanguageRenderer.Macros as M (ifExists,
   increment1, decrement1, listSlice, stringListVals, stringListLists)
 import Drasil.Shared.AST (Terminator(..), FileType(Combined), fileD, md,
   updateMod, MethodData, mthd, mthdName, updateMthd, ParamData, paramVar, paramDoc, pd,
   ProgData, TypeData, cType, vd, val, valPrec, valInt, valType, opDoc, opPrec,
   varName, varType, varBind, varDoc, vard, progD, mthdDoc, modDoc,
-  FuncData(fType, funcDoc), fd, ScopeData, FileData, ModData)
+  FuncData(fType, funcDoc), fd, ScopeData, sd, ScopeTag(..), BinderD,
+  FileData, ModData)
 import Drasil.Shared.CodeType (CodeType(..))
 import Drasil.Shared.LanguageRenderer.Constructors (typeFromData, unOpPrec,
   powerPrec, multPrec, unExpr, unExpr', binExpr, binExpr', mkStateVal, mkVal,
   mkStateVar, mkStmtNoEnd, compEqualPrec, typeUnExpr, typeBinExpr)
-import Drasil.Shared.LanguageRenderer (listSep', valueList, intValue)
+import Drasil.Shared.LanguageRenderer (listSep', valueList, intValue, binderList)
 import Drasil.Shared.LanguageRenderer.LanguagePolymorphic (OptionalSpace(..))
 import Drasil.Shared.Helpers (toCode, toState, onCodeValue, onStateValue,
   onCodeList, onStateList, on2CodeValues, on2StateValues, emptyIfEmpty, vibcat)
 import Drasil.Shared.State (MS, VS, FS, lensGStoFS, lensFStoMS, lensMStoVS,
   revFiles, setFileType, setModuleName, getMainDoc)
 
+import Data.List (intercalate)
 import Control.Lens.Zoom (zoom)
 import Control.Monad.State (modify)
 
@@ -118,8 +121,8 @@ instance RenderFile MatlabCode FileData ModData where
   fileFromData = A.fileFromData (onCodeValue . fileD)
 
 instance ImportSym MatlabCode where
-  langImport = undefined
-  modImport = undefined
+  langImport _ = toCode empty
+  modImport _ = toCode empty
 
 instance BodySym MatlabCode Body Block where
   body = onStateList (onCodeList R.body)
@@ -161,7 +164,10 @@ instance TypeElim MatlabCode where
   getCodeType = cType . unMLC
 
 instance RenderType MatlabCode where
-  multiType = undefined
+  multiType ts = do
+    typs <- sequence ts
+    let mt = intercalate ", " $ map getTypeString typs
+    typeFromData Void mt (text mt)
 
 instance UnaryOpSym MatlabCode where
   notOp = unOpPrec "~"
@@ -203,9 +209,9 @@ instance OpElim MatlabCode where
   bOpPrec = opPrec . unMLC
 
 instance ScopeSym MatlabCode where
-  global = undefined
-  mainFn = undefined
-  local = undefined
+  global = toCode $ sd Global
+  mainFn = global
+  local = G.local
 
 instance ScopeElim MatlabCode where
   scopeData = unMLC
@@ -213,7 +219,7 @@ instance ScopeElim MatlabCode where
 instance VariableSym MatlabCode where
   var = G.var
   constant = var
-  extVar = undefined
+  extVar = CS.extVar
 
 instance VariableElim MatlabCode where
   variableName = varName . unMLC
@@ -256,7 +262,7 @@ instance CommandLineArgs MatlabCode where
   -- Args come in through the entry function's varargin (1-based, cell-indexed).
   arg n = mlArg (litInt (n + 1))
   argsList = mkStateVal (arrayType string) (text "varargin")
-  argExists = undefined
+  argExists = CP.argExists
 
 instance NumericExpression MatlabCode where
   (#~) = unExpr' negateOp
@@ -301,7 +307,7 @@ instance ValueExpression MatlabCode where
   funcAppMixedArgs = G.funcAppMixedArgs
   extFuncAppMixedArgs _ = G.funcAppMixedArgs
   libFuncAppMixedArgs _ = G.funcAppMixedArgs
-  lambda = undefined
+  lambda = G.lambda mlLambda
   notNull v = (?!) $ funcApp "isempty" bool [v]
 
 instance RenderValue MatlabCode where
@@ -398,7 +404,7 @@ instance InternalIOStmt MatlabCode (Doc, Terminator) where
   printSt = mlPrint
 
 instance InternalControlStmt MatlabCode (Doc, Terminator) where
-  multiReturn = undefined
+  multiReturn = CP.multiReturn id
 
 instance RenderStatement MatlabCode (Doc, Terminator) where
   stmt = G.stmt
@@ -475,7 +481,7 @@ instance FunctionSym MatlabCode where
 
 instance FuncAppStatement MatlabCode (Doc, Terminator) where
   inOutCall = CP.inOutCall funcApp
-  extInOutCall = undefined
+  extInOutCall m = CP.inOutCall (extFuncApp m)
 
 instance CommentStatement MatlabCode (Doc, Terminator) where
   comment = G.comment mlCmtStart
@@ -514,7 +520,7 @@ instance VisibilitySym MatlabCode Doc where
   public = toCode empty
 
 instance RenderVisibility MatlabCode Doc where
-  visibilityFromData = undefined
+  visibilityFromData _ = toCode
 
 instance VisibilityElim MatlabCode Doc where
   visibility = unMLC
@@ -844,3 +850,7 @@ mlListSet lst' idx' val' = do
                (A.innerType $ return $ valueType lst)
                (RC.value lst <> wrap (RC.value idx))
   lvar &= val'
+
+mlLambda :: (InternalBinderElim r, ValueElim r) => [r BinderD] ->
+  r Value -> Doc
+mlLambda ps ex = text "@" <> parens (binderList ps) <+> RC.value ex


### PR DESCRIPTION
Filled in all remaining `undefined` methods in `MatlabRenderer`. Also added a test block for set ops and lambda, and verified the generated MATLAB.

With this PR, `MatlabRenderer` has all its methods implemented.