### PR TITLE
fix: add missing physics `ConceptChunk` dependencies

### DIFF
--- a/code/drasil-data/lib/Data/Drasil/Concepts/PhysicalProperties.hs
+++ b/code/drasil-data/lib/Data/Drasil/Concepts/PhysicalProperties.hs
@@ -10,7 +10,8 @@ import Data.Drasil.Concepts.Math (centre)
 
 -- | Collects all physical property-related concepts.
 physicalcon :: [ConceptChunk]
-physicalcon = [gaseous, liquid, solid, ctrOfMass, dimension, flexure]
+physicalcon = [gaseous, liquid, solid, ctrOfMass, density, specWeight, mass,
+  len, dimension, vol, flexure]
 
 -- * Physical Properties
 


### PR DESCRIPTION
This is the result of demoing the 'tactical breakage' discussed in JacquesCarette/Drasil#5471.

If the `HasChunkRefs` instances were correct, `make` would have been blocked on these.