### PR TITLE
fix(GlassBR): add missing `UnitDefn` chunk dependencies

### DIFF
--- a/code/drasil-example/glassbr/lib/Drasil/GlassBR/Body.hs
+++ b/code/drasil-example/glassbr/lib/Drasil/GlassBR/Body.hs
@@ -46,6 +46,7 @@ import Drasil.GlassBR.TMods (tMods)
 import Drasil.GlassBR.Unitals (constants, constrained, inputs, outputs,
   specParamVals, glassTypes, lateralLoad, loadTypes, pbTol, probBr, stressDistFac,
   termsWithAccDefn, termsWithDefsOnly, concepts, dataConstraints, symbols)
+import Drasil.GlassBR.Units (units)
 
 si :: SmithEtAlSRS
 si = mkSmithEtAlICO progName
@@ -117,8 +118,8 @@ conceptChunks :: [ConceptChunk]
 conceptChunks = distance : concepts ++ softwarecon ++ physicalcon
 
 symbMap :: ChunkDB
-symbMap = withCommonKnowledge allRefs symbolsWCodeSymbols ideaDicts cis conceptChunks []
-  GB.dataDefs iMods [] tMods concIns citations labCon
+symbMap = withCommonKnowledge allRefs symbolsWCodeSymbols ideaDicts cis
+  conceptChunks units GB.dataDefs iMods [] tMods concIns citations labCon
 
 symbolsWCodeSymbols :: [DefinedQuantityDict]
 symbolsWCodeSymbols = map asVC (concatMap (\(Mod _ _ _ _ l) -> l) allMods)

--- a/code/drasil-example/glassbr/lib/Drasil/GlassBR/Units.hs
+++ b/code/drasil-example/glassbr/lib/Drasil/GlassBR/Units.hs
@@ -1,7 +1,10 @@
-module Drasil.GlassBR.Units (sFlawPU) where
+module Drasil.GlassBR.Units (units, sFlawPU) where
 
 import Language.Drasil (UnitDefn, newUnit, (^$), (^:))
 import Data.Drasil.SI_Units (metre, newton)
+
+units :: [UnitDefn]
+units = [sFlawPU]
 
 --N^(-7)*m^12--
 sFlawPU :: UnitDefn


### PR DESCRIPTION
If the `HasChunkRefs` instances were correct, `make` would have been blocked on these.