### PR TITLE
fix(sglpend): Avoid double-inserting quantities

### DIFF
--- a/code/drasil-example/sglpend/lib/Drasil/SglPend/Body.hs
+++ b/code/drasil-example/sglpend/lib/Drasil/SglPend/Body.hs
@@ -1,12 +1,10 @@
 module Drasil.SglPend.Body (mkSRS, si) where
 
-import Control.Lens ((^.))
-
 import Drasil.Database (ChunkDB)
 import Language.Drasil
 import Language.Drasil.Document hiding (organization)
 import qualified Language.Drasil.Development as D
-import Theory.Drasil (TheoryModel, output)
+import Theory.Drasil (TheoryModel)
 import Drasil.SRS hiding (genDefns)
 import Drasil.Generator (withCommonKnowledge)
 import Language.Drasil.Chunk.Concept.NamedCombinators (the)
@@ -86,7 +84,7 @@ si :: SmithEtAlSRS
 si = mkSmithEtAlICO progName [olu]
   [purp] [] [] []
   tMods genDefns dataDefs iMods
-  inputs outputs inConstraints [] allSymbols
+  inputs outputs inConstraints [] symbols
   symbMap
 
 purp :: Sentence
@@ -100,11 +98,8 @@ conceptChunks =
   physicalcon ++ [angular, displacement, iPos, pendulum, motion,
   gravitationalConst, gravity, rigidBody, weight, shm] ++ defs
 
-allSymbols :: [DefinedQuantityDict]
-allSymbols = map (^. output) iMods ++ symbols
-
 symbMap :: ChunkDB
-symbMap = withCommonKnowledge allRefs allSymbols ideaDicts cis
+symbMap = withCommonKnowledge allRefs symbols ideaDicts cis
   conceptChunks [] dataDefs iMods genDefns tMods concIns citations
   labelledContent'
 

--- a/code/drasil-example/sglpend/lib/Drasil/SglPend/Unitals.hs
+++ b/code/drasil-example/sglpend/lib/Drasil/SglPend/Unitals.hs
@@ -26,7 +26,7 @@ import Drasil.DblPend.Concepts (rod, horizontalForce, verticalForce)
 import Drasil.DblPend.Unitals (lRod)
 
 symbols:: [DefinedQuantityDict]
-symbols = unitalChunks ++ unitless ++ NE.toList inputs ++ NE.toList outputs
+symbols = unitalChunks ++ unitless ++ NE.toList inputs
 
 inputs :: NE.NonEmpty DefinedQuantityDict
 inputs = lenRod :| [QPP.mass, QP.angularAccel, pendDisplacementAngle, initialPendAngle]
@@ -35,10 +35,10 @@ outputs :: NE.NonEmpty DefinedQuantityDict
 outputs = NE.singleton pendDisplacementAngle
 
 unitalChunks :: [DefinedQuantityDict]
-unitalChunks = [QPP.len, QPP.mass, QP.force, QP.ixPos, QP.xPos, QP.yPos,
-   QP.angularVelocity, QP.angularAccel, QP.gravitationalAccel, QP.tension, QP.acceleration,
+unitalChunks = [QPP.len, QP.force, QP.ixPos, QP.xPos, QP.yPos,
+   QP.angularVelocity, QP.gravitationalAccel, QP.tension, QP.acceleration,
    QP.yAccel, QP.xAccel, QP.yVel, QP.xVel, QP.iyPos, QP.time, QP.velocity, QP.position, QP.torque,
-   QP.momentOfInertia, QP.angularDisplacement, initialPendAngle, xForce, yForce,
+   QP.momentOfInertia, QP.angularDisplacement, xForce, yForce,
    QP.angularFrequency, QP.frequency, QP.period]
 
 lenRod, xForce, yForce, pendDisplacementAngle, initialPendAngle :: DefinedQuantityDict


### PR DESCRIPTION
Contributes to #5478 

#5478 should pull in `main` if/when merged (or this branch directly).