### PR TITLE
 fix(swhsnopcm): Avoid double-inserting quantities

### DIFF
--- a/code/drasil-example/swhsnopcm/lib/Drasil/SWHSNoPCM/Body.hs
+++ b/code/drasil-example/swhsnopcm/lib/Drasil/SWHSNoPCM/Body.hs
@@ -64,7 +64,7 @@ import Drasil.SWHSNoPCM.Unitals (inputs, constrained, specParamValList, outputs)
 
 -- This contains the list of symbols used throughout the document
 symbols :: [DefinedQuantityDict]
-symbols = dqdWr watE : concepts ++ map dqdWr constrained ++
+symbols = concepts ++ map dqdWr constrained ++
   [gradient, pi_, uNormalVect, surface] ++ symbolConcepts ++
   map dqdWr specParamValList ++ map dqdWr [absTol, relTol] ++ map dqdWr (NE.toList outputs)
 


### PR DESCRIPTION
Builds on #5480 

https://github.com/JacquesCarette/Drasil/pull/5478 should pull in main if/when merged (or this branch directly).