### PR TITLE
Expanded `MSMthdType`

### DIFF
--- a/code/drasil-gool/lib/Drasil/GOOL/LanguageRenderer/CppRenderer.hs
+++ b/code/drasil-gool/lib/Drasil/GOOL/LanguageRenderer/CppRenderer.hs
@@ -36,9 +36,9 @@ import Drasil.Shared.RendererClassesCommon (CommonRenderSym, ImportSym(..),
   ValueElim(valuePrec, valueInt), InternalListFunc(..), RenderFunction(..),
   FunctionElim(functionType), InternalAssignStmt(..), InternalIOStmt(..),
   InternalControlStmt(..), RenderStatement(..), StatementElim(statementTerm),
-  RenderVisibility(..), VisibilityElim, MSMthdType, MethodTypeSym(..),
-  RenderParam(..), ParamElim(parameterName, parameterType), RenderMethod(..),
-  MethodElim, BlockCommentSym(..), BlockCommentElim, ScopeElim(..))
+  RenderVisibility(..), VisibilityElim, MethodTypeSym(..), RenderParam(..),
+  ParamElim(parameterName, parameterType), RenderMethod(..), MethodElim,
+  BlockCommentSym(..), BlockCommentElim, ScopeElim(..))
 import qualified Drasil.Shared.RendererClassesCommon as RC (import', body, block,
   uOp, bOp, variable, value, function, statement, visibility, parameter,
   method, blockComment', InternalBinderElim(binderElim), RenderValue(call))
@@ -2793,19 +2793,27 @@ cppsFunction n t ps b = vcat [
   indent (RC.body b),
   bodyEnd]
 
-cppsIntFunc :: (CppSrcCode TypeData -> [CppSrcCode ParamData] ->
-  CppSrcCode Body -> Doc) -> CppSrcCode (Doc, VisibilityTag) ->
-  MSMthdType CppSrcCode -> [MS (CppSrcCode ParamData)] ->
-  MS (CppSrcCode Body) -> MS (CppSrcCode MethodData)
+cppsIntFunc
+  :: (CppSrcCode TypeData -> [CppSrcCode ParamData] -> CppSrcCode Body -> Doc)
+  -> CppSrcCode (Doc, VisibilityTag)
+  -> MS (CppSrcCode TypeData)
+  -> [MS (CppSrcCode ParamData)]
+  -> MS (CppSrcCode Body)
+  -> MS (CppSrcCode MethodData)
 cppsIntFunc f s t ps b = do
   modify (setVisibility (snd $ unCPPSC s))
   tp <- t
   pms <- sequence ps
   toCode . mthd (snd $ unCPPSC s) . f tp pms <$> b
 
-cpphIntFunc :: Label -> CppHdrCode (Doc, VisibilityTag) ->
-  CppHdrCode attch -> MSMthdType CppHdrCode ->
-  [MS (CppHdrCode ParamData)] -> MS (CppHdrCode Body) -> MS (CppHdrCode MethodData)
+cpphIntFunc
+  :: Label
+  -> CppHdrCode (Doc, VisibilityTag)
+  -> CppHdrCode attch
+  -> MS (CppHdrCode TypeData)
+  -> [MS (CppHdrCode ParamData)]
+  -> MS (CppHdrCode Body)
+  -> MS (CppHdrCode MethodData)
 cpphIntFunc n s _ t ps _ = do
     modify (setVisibility (snd $ unCPPHC s))
     tp <- t

--- a/code/drasil-gool/lib/Drasil/GOOL/LanguageRenderer/SwiftRenderer.hs
+++ b/code/drasil-gool/lib/Drasil/GOOL/LanguageRenderer/SwiftRenderer.hs
@@ -30,14 +30,14 @@ import Drasil.GOOL.InterfaceGOOL (OOProg, StateVar, ProgramSym(..), FileSym(..),
   objMethodCallNoParams, OOFunctionSym(..), ($.), GetSet(..),
   OODeclStatement(..), OOFuncAppStatement(..), ObserverPattern(..),
   StrategyPattern(..), OOMethodSym(..), Initializers, convTypeOO)
-import Drasil.Shared.RendererClassesCommon (MSMthdType, CommonRenderSym,
-  ImportSym(..), RenderBody(..), BodyElim, RenderBlock(..), BlockElim,
-  RenderType(..), UnaryOpSym(..), BinaryOpSym(..), OpElim(uOpPrec, bOpPrec),
-  RenderVariable(..), InternalVarElim(variableBind), RenderValue(..),
-  ValueElim(valuePrec, valueInt), InternalListFunc(..), RenderFunction(..),
-  FunctionElim(functionType), InternalAssignStmt(..), InternalIOStmt(..),
-  InternalControlStmt(..), RenderStatement(..), StatementElim(statementTerm),
-  RenderVisibility(..), VisibilityElim, MethodTypeSym(..), RenderParam(..),
+import Drasil.Shared.RendererClassesCommon (CommonRenderSym, ImportSym(..),
+  RenderBody(..), BodyElim, RenderBlock(..), BlockElim, RenderType(..),
+  UnaryOpSym(..), BinaryOpSym(..), OpElim(uOpPrec, bOpPrec), RenderVariable(..),
+  InternalVarElim(variableBind), RenderValue(..), ValueElim(valuePrec, valueInt),
+  InternalListFunc(..), RenderFunction(..), FunctionElim(functionType),
+  InternalAssignStmt(..), InternalIOStmt(..), InternalControlStmt(..),
+  RenderStatement(..), StatementElim(statementTerm), RenderVisibility(..),
+  VisibilityElim, MethodTypeSym(..), RenderParam(..),
   ParamElim(parameterName, parameterType), RenderMethod(..), MethodElim,
   BlockCommentSym(..), BlockCommentElim, ScopeElim(..), InternalBinderElim(..))
 import qualified Drasil.Shared.RendererClassesCommon as RC (import', body, block,
@@ -1190,9 +1190,14 @@ swiftParam :: Doc -> SwiftCode Variable -> Doc
 swiftParam io v = swiftNoLabel <+> RC.variable v <> swiftTypeSpec <+> io
   <+> renderType (variableType v)
 
-swiftMethod :: Label -> SwiftCode Doc ->
-  SwiftCode Doc -> MSMthdType SwiftCode ->
-  [MS (SwiftCode ParamData)] -> MS (SwiftCode Body) -> MS (SwiftCode MethodData)
+swiftMethod
+  :: Label
+  -> SwiftCode Doc
+  -> SwiftCode Doc
+  -> MS (SwiftCode TypeData)
+  -> [MS (SwiftCode ParamData)]
+  -> MS (SwiftCode Body)
+  -> MS (SwiftCode MethodData)
 swiftMethod n s p t ps b = do
   tp <- t
   pms <- sequence ps

--- a/code/drasil-gool/lib/Drasil/GOOL/RendererClassesOO.hs
+++ b/code/drasil-gool/lib/Drasil/GOOL/RendererClassesOO.hs
@@ -17,8 +17,8 @@ import Drasil.Shared.State (FS, CS, VS, MS)
 
 import Text.PrettyPrint.HughesPJ (Doc)
 
-import Drasil.Shared.RendererClassesCommon (MSMthdType, CommonRenderSym,
-  BlockCommentSym(..), MethodTypeSym(..), RenderMethod(..))
+import Drasil.Shared.RendererClassesCommon (CommonRenderSym, BlockCommentSym(..),
+  MethodTypeSym(..), RenderMethod(..))
 
 class (CommonRenderSym r vis stmt mthd bod block, MethodSym r vis mthd bod,
   IG.OOMethodSym r vis mthd attch bod, IG.ClassSym r vis mthd stvr attch,
@@ -52,17 +52,17 @@ class InternalGetSet r where
   setFunc :: VS (r TypeData) -> SVariable r -> SValue r -> VS (r FuncData)
 
 class (MethodTypeSym r) => OOMethodTypeSym r where
-  construct :: Label -> MSMthdType r
+  construct :: Label -> MS (r TypeData)
 
 class (RenderMethod r mthd, OOMethodTypeSym r) => OORenderMethod r vis mthd attch bod | r -> vis attch bod where
   -- | Main method?, name, public/private, classLevel/instanceLevel,
   --   return type, parameters, body
   intMethod     :: Bool -> Label -> r vis -> r attch ->
-    MSMthdType r -> [MS (r ParamData)] -> MS (r bod) -> MS (r mthd)
+    MS (r TypeData) -> [MS (r ParamData)] -> MS (r bod) -> MS (r mthd)
   -- | True for main function, name, public/private, classLevel/instanceLevel,
   --   return type, parameters, body
   intFunc       :: Bool -> Label -> r vis -> r attch
-    -> MSMthdType r -> [MS (r ParamData)] -> MS (r bod) -> MS (r mthd)
+    -> MS (r TypeData) -> [MS (r ParamData)] -> MS (r bod) -> MS (r mthd)
 
   destructor :: [IG.CSStateVar r stvr] -> MS (r mthd)
 

--- a/code/drasil-gool/lib/Drasil/GProc/RendererClassesProc.hs
+++ b/code/drasil-gool/lib/Drasil/GProc/RendererClassesProc.hs
@@ -9,12 +9,12 @@ module Drasil.GProc.RendererClassesProc (
 import Drasil.Shared.InterfaceCommon (Label, Block, MethodSym)
 import qualified Drasil.GProc.InterfaceProc as IP (FileSym(..), ModuleSym)
 import Drasil.Shared.State (FS, MS)
-import Drasil.Shared.AST (ParamData)
+import Drasil.Shared.AST (ParamData, TypeData)
 
 import Text.PrettyPrint.HughesPJ (Doc)
 
 import Drasil.Shared.RendererClassesCommon (CommonRenderSym, BlockCommentSym(..),
-  RenderMethod(..), MSMthdType)
+  RenderMethod(..))
 
 class (CommonRenderSym r vis stmt mthd bod block, MethodSym r vis mthd bod,
   IP.ModuleSym r mod mthd, IP.FileSym r file mod, RenderFile r file mod,
@@ -43,5 +43,5 @@ class ModuleElim r mod | r -> mod where
 class (RenderMethod r mthd) => ProcRenderMethod r vis mthd bod | r -> vis bod where
   -- | Main method?, name, public/private,
   --   return type, parameters, body
-  intFunc     :: Bool -> Label -> r vis -> MSMthdType r ->
+  intFunc     :: Bool -> Label -> r vis -> MS (r TypeData) ->
     [MS (r ParamData)] -> MS (r bod) -> MS (r mthd)

--- a/code/drasil-gool/lib/Drasil/Shared/RendererClassesCommon.hs
+++ b/code/drasil-gool/lib/Drasil/Shared/RendererClassesCommon.hs
@@ -7,9 +7,9 @@ module Drasil.Shared.RendererClassesCommon (
   InternalBinderElim(..), RenderValue(..), ValueElim(..), InternalListFunc(..),
   RenderFunction(..), FunctionElim(..), InternalAssignStmt(..),
   InternalIOStmt(..), InternalControlStmt(..), RenderStatement(..),
-  StatementElim(..), RenderVisibility(..), VisibilityElim(..), MSMthdType,
-  MethodTypeSym(..), RenderParam(..), ParamElim(..), RenderMethod(..),
-  MethodElim(..), BlockCommentSym(..), BlockCommentElim(..), ScopeElim(..)
+  StatementElim(..), RenderVisibility(..), VisibilityElim(..), MethodTypeSym(..),
+  RenderParam(..), ParamElim(..), RenderMethod(..), MethodElim(..),
+  BlockCommentSym(..), BlockCommentElim(..), ScopeElim(..)
 ) where
 
 import Drasil.Shared.InterfaceCommon (Label, Library, Variable, SVariable, Value,
@@ -202,10 +202,8 @@ class BlockCommentSym r where
 class BlockCommentElim r where
   blockComment' :: r Doc -> Doc
 
-type MSMthdType a = MS (a TypeData)
-
 class (TypeSym r) => MethodTypeSym r where
-  mType    :: VS (r TypeData) -> MSMthdType r
+  mType    :: VS (r TypeData) -> MS (r TypeData)
 
 class (MethodTypeSym r, BlockCommentSym r) => RenderMethod r mthd | r -> mthd where
   -- | Takes a BlockComment and a method and generates a function.


### PR DESCRIPTION
This is necessary for parameterizing `TypeData`, which is my next step with #5328.