### PR TITLE
REDO #5425: refactor(srs-gen/`PhySysDesc`): automatically retrieve program name from `SmithEtAlSRS` instead of manually passing around the program name through `SRSDecl`

### DIFF
--- a/code/drasil-example/bss/lib/Drasil/BinaryStar/Body.hs
+++ b/code/drasil-example/bss/lib/Drasil/BinaryStar/Body.hs
@@ -59,7 +59,7 @@ mkSRS = [TableOfContents,
     SSDProg
       [ SSDProblem $ PDProg probDescIntro []
       [ TermsAndDefs Nothing ccsFortermsAndDefsTbl
-      , PhySysDesc progName physSystParts figBSS []
+      , PhySysDesc physSystParts figBSS []
       , Goals goalsInputs
       ]
       , SSDSolChSpec $ SCSProg

--- a/code/drasil-example/dblpend/lib/Drasil/DblPend/Body.hs
+++ b/code/drasil-example/dblpend/lib/Drasil/DblPend/Body.hs
@@ -71,7 +71,7 @@ mkSRS = [TableOfContents, -- This creates the Table of Contents
     SSDProg
       [ SSDProblem $ PDProg purp []                -- This adds a is used to define the problem your system will solve
         [ TermsAndDefs Nothing terms               -- This is used to define the terms to be defined in terminology sub section
-      , PhySysDesc progName physSystParts figMotion [] -- This defines the Physicalsystem sub-section, define the parts
+      , PhySysDesc physSystParts figMotion [] -- This defines the Physicalsystem sub-section, define the parts
                                                           -- of the system using physSysParts, figMotion is a function in figures for the image
       , Goals goalsInputs] -- This adds a goals section and goals input is defined for the preample of the goal.
       , SSDSolChSpec $ SCSProg --This creates the solution characteristics section with a preamble

--- a/code/drasil-example/glassbr/lib/Drasil/GlassBR/Body.hs
+++ b/code/drasil-example/glassbr/lib/Drasil/GlassBR/Body.hs
@@ -75,7 +75,7 @@ mkSRS = [TableOfContents,
   SSDSec $
     SSDProg
       [SSDProblem $ PDProg purp [termsAndDesc]
-        [ PhySysDesc progName physSystParts physSystFig []
+        [ PhySysDesc physSystParts physSystFig []
         , Goals goalInputs],
        SSDSolChSpec $ SCSProg
         [ Assumptions

--- a/code/drasil-example/pdcontroller/lib/Drasil/PDController/Body.hs
+++ b/code/drasil-example/pdcontroller/lib/Drasil/PDController/Body.hs
@@ -63,7 +63,7 @@ mkSRS
               -- alternative definitions for use in the `Terminology and
               -- Definitions` section.
               [TermsAndDefs Nothing defs,
-               PhySysDesc progName sysParts sysFigure [],
+               PhySysDesc sysParts sysFigure [],
                Goals sysGoalInput],
           SSDSolChSpec $
             SCSProg

--- a/code/drasil-example/projectile/lib/Drasil/Projectile/Body.hs
+++ b/code/drasil-example/projectile/lib/Drasil/Projectile/Body.hs
@@ -74,7 +74,7 @@ mkSRS = [TableOfContents,
     SSDProg
       [ SSDProblem $ PDProg purp []
         [ TermsAndDefs Nothing terms
-        , PhySysDesc progName physSystParts figLaunch []
+        , PhySysDesc physSystParts figLaunch []
         , Goals [(phrase iVel +:+ S "vector") `S.the_ofThe` phrase projectile,
                   S "geometric layout" `S.the_ofThe` phrase launcher `S.and_` phrase target]]
       , SSDSolChSpec $ SCSProg

--- a/code/drasil-example/sglpend/lib/Drasil/SglPend/Body.hs
+++ b/code/drasil-example/sglpend/lib/Drasil/SglPend/Body.hs
@@ -57,7 +57,7 @@ mkSRS = [TableOfContents, -- This creates the Table of Contents
     SSDProg
       [ SSDProblem $ PDProg purp []                -- This adds a is used to define the problem your system will solve
         [ TermsAndDefs Nothing terms               -- This is used to define the terms to be defined in terminology sub section
-      , PhySysDesc progName physSystParts figMotion [] -- This defines the Physicalsystem sub-section, define the parts
+      , PhySysDesc physSystParts figMotion [] -- This defines the Physicalsystem sub-section, define the parts
                                                           -- of the system using physSysParts, figMotion is a function in figures for the image
       , Goals goalsInputs] -- This adds a goals section and goals input is defined for the preample of the goal.
       , SSDSolChSpec $ SCSProg --This creates the solution characteristics section with a preamble

--- a/code/drasil-example/ssp/lib/Drasil/SSP/Body.hs
+++ b/code/drasil-example/ssp/lib/Drasil/SSP/Body.hs
@@ -86,7 +86,7 @@ mkSRS = [TableOfContents,
     SSDProg
       [ SSDProblem $ PDProg purp []
         [ TermsAndDefs Nothing terms
-        , PhySysDesc progName physSystParts figPhysSyst physSystContents
+        , PhySysDesc physSystParts figPhysSyst physSystContents
         , Goals goalsInputs]
       , SSDSolChSpec $ SCSProg
         [ Assumptions

--- a/code/drasil-example/swhs/lib/Drasil/SWHS/Body.hs
+++ b/code/drasil-example/swhs/lib/Drasil/SWHS/Body.hs
@@ -117,7 +117,7 @@ mkSRS = [TableOfContents,
     SSDProg
       [ SSDProblem $ PDProg purp []
         [ TermsAndDefs Nothing terms
-        , PhySysDesc progName physSystParts figTank []
+        , PhySysDesc physSystParts figTank []
         , Goals goalInputs]
       , SSDSolChSpec $ SCSProg
         [ Assumptions

--- a/code/drasil-example/swhsnopcm/lib/Drasil/SWHSNoPCM/Body.hs
+++ b/code/drasil-example/swhsnopcm/lib/Drasil/SWHSNoPCM/Body.hs
@@ -108,7 +108,7 @@ mkSRS = [TableOfContents,
     SSDProg
     [ SSDProblem $ PDProg purp []
       [ TermsAndDefs Nothing terms
-      , PhySysDesc progName physSystParts figTank []
+      , PhySysDesc physSystParts figTank []
       , Goals goalInputs]
     , SSDSolChSpec $ SCSProg
       [ Assumptions

--- a/code/drasil-example/template/lib/Drasil/Template/Body.hs
+++ b/code/drasil-example/template/lib/Drasil/Template/Body.hs
@@ -45,7 +45,7 @@ mkSRS = [TableOfContents,
     SSDProg
       [ SSDProblem $ PDProg EmptyS []                --  This adds a is used to define the problem your system will solve
       [ TermsAndDefs Nothing ([] :: [ConceptChunk])   -- This is used to define the terms to be defined in terminology sub section
-      , PhySysDesc progName [] figTemp [] -- This defines the Physicalsystem sub-section, define the parts
+      , PhySysDesc [] figTemp [] -- This defines the Physicalsystem sub-section, define the parts
                                                           -- of the system using physSysParts, figMotion is a function in figures for the image
       , Goals []
       ] -- This adds a goals section and goals input is defined for the preample of the goal.

--- a/code/drasil-srs/lib/Drasil/SRS/DocDecl.hs
+++ b/code/drasil-srs/lib/Drasil/SRS/DocDecl.hs
@@ -73,7 +73,7 @@ data PDSub where
   -- | Terms and Definitions.
   TermsAndDefs :: Concept c => Maybe Sentence -> [c] -> PDSub
   -- | Physical System Description.
-  PhySysDesc :: Idea a => a -> [Sentence] -> LabelledContent -> [Contents] -> PDSub
+  PhySysDesc :: [Sentence] -> LabelledContent -> [Contents] -> PDSub
   -- | Goals.
   Goals :: [Sentence] -> PDSub
 
@@ -139,7 +139,7 @@ mkDocDesc sys = map sec where
 
   pdSub :: PDSub -> DL.PDSub
   pdSub (TermsAndDefs s c) = DL.TermsAndDefs s c
-  pdSub (PhySysDesc i s lc c) = DL.PhySysDesc i s lc c
+  pdSub (PhySysDesc s lc c) = DL.PhySysDesc s lc c
   pdSub (Goals s) = DL.Goals s $ fromConcInsDB goalStmtDom
 
   scsSub :: SCSSub -> DL.SCSSub

--- a/code/drasil-srs/lib/Drasil/SRS/DocumentLanguage.hs
+++ b/code/drasil-srs/lib/Drasil/SRS/DocumentLanguage.hs
@@ -295,9 +295,9 @@ mkSSDSec si (SSDProg l) =
 
 -- | Helper for making the Specific System Description Problem section.
 mkSSDProb :: SmithEtAlSRS -> ProblemDescription -> Section
-mkSSDProb _ (PDProg prob subSec subPD) = SSD.probDescF prob (subSec ++ map mkSubPD subPD)
+mkSSDProb si (PDProg prob subSec subPD) = SSD.probDescF prob (subSec ++ map mkSubPD subPD)
   where mkSubPD (TermsAndDefs sen concepts) = SSD.termDefnF sen concepts
-        mkSubPD (PhySysDesc prog parts dif extra) = SSD.physSystDesc prog parts dif extra
+        mkSubPD (PhySysDesc parts dif extra) = SSD.physSystDesc (si ^. sysName) parts dif extra
         mkSubPD (Goals ins g) = SSD.goalStmtF ins (mkEnumSimpleD g) (length g)
 
 -- | Helper for making the Solution Characteristics Specification section.

--- a/code/drasil-srs/lib/Drasil/SRS/DocumentLanguage/Core.hs
+++ b/code/drasil-srs/lib/Drasil/SRS/DocumentLanguage/Core.hs
@@ -168,7 +168,7 @@ data PDSub where
   -- | Terms and definitions.
   TermsAndDefs :: Concept c => Maybe Sentence -> [c] -> PDSub
   -- | Physical system description.
-  PhySysDesc :: Idea a => a -> [Sentence] -> LabelledContent -> [Contents] -> PDSub
+  PhySysDesc :: [Sentence] -> LabelledContent -> [Contents] -> PDSub
   -- | Goals.
   Goals :: [Sentence] -> [ConceptInstance] -> PDSub
 
@@ -313,7 +313,7 @@ instance Multiplate DLPlate where
     pd (PDProg s sect progs) = PDProg s sect <$> traverse (pdSub p) progs
     pd' (TermsAndDefs s cs) = pure $ TermsAndDefs s cs
     pd' (Goals s ci) = pure $ Goals s ci
-    pd' (PhySysDesc nm s lc c) = pure $ PhySysDesc nm s lc c
+    pd' (PhySysDesc s lc c) = pure $ PhySysDesc s lc c
     sc (Assumptions c) = pure (Assumptions c)
     sc (TMs s f t) = pure $ TMs s f t
     sc (GDs s f g d) = pure $ GDs s f g d

--- a/code/drasil-srs/lib/Drasil/SRS/ExtractDocDesc.hs
+++ b/code/drasil-srs/lib/Drasil/SRS/ExtractDocDesc.hs
@@ -37,7 +37,7 @@ secConPlate mCon mSec = preorderFold $ purePlate {
   pdSec = Constant <$> \(PDProg _ s _) -> mSec s,
   pdSub = Constant <$> \case
     (TermsAndDefs _ _) -> mempty
-    (PhySysDesc _ _ lc c) -> mCon [lc] `mappend` mCon c
+    (PhySysDesc _ lc c) -> mCon [lc] `mappend` mCon c
     (Goals _ _) -> mempty,
   scsSub = Constant <$> \case
     (Constraints _ c) -> mCon [inDataConstTbl c]
@@ -99,7 +99,7 @@ sentencePlate f = appendPlate (secConPlate (f . extractSents') $ f . concatMap g
     pdSub = Constant . f <$> \case
       (TermsAndDefs Nothing cs) -> def cs
       (TermsAndDefs (Just s) cs) -> s : def cs
-      (PhySysDesc _ s lc cs) -> s ++ extractSents lc ++ extractSents' cs
+      (PhySysDesc s lc cs) -> s ++ extractSents lc ++ extractSents' cs
       (Goals s c) -> s ++ def c,
     scsSub = Constant . f <$> \case
       (Assumptions c) -> def c
@@ -139,7 +139,7 @@ sentencePlate f = appendPlate (secConPlate (f . extractSents') $ f . concatMap g
 
     getPDSub :: PDSub -> [Sentence]
     getPDSub (TermsAndDefs ms c) = def c ++ maybe [] pure ms
-    getPDSub (PhySysDesc _ s lc cs) = s ++ extractSents lc ++ extractSents' cs
+    getPDSub (PhySysDesc s lc cs) = s ++ extractSents lc ++ extractSents' cs
     getPDSub (Goals s c) = s ++ def c
 
 -- | Extracts 'Sentence's from a document description.

--- a/code/stable/swhs/SRS/HTML/SWHS_SRS.html
+++ b/code/stable/swhs/SRS/HTML/SWHS_SRS.html
@@ -916,7 +916,7 @@
               <div class="subsubsection">
                 <h3>Physical System Description</h3>
                 <p class="paragraph">
-                  The physical system of <span title="solar water heating system">SWHS</span>, as shown in <a href="#Figure:Tank">Fig:Tank</a>, includes the following elements:
+                  The physical system of <span title="solar water heating systems incorporating PCM">SWHS</span>, as shown in <a href="#Figure:Tank">Fig:Tank</a>, includes the following elements:
                 </p>
                 <div class="list">
                   <p>


### PR DESCRIPTION
This PR is a duplicate of #5425, created because it was originally merged into #5423 but #5423 is currently blocked. So, we can redo that PR targeting `main`. Original PR description:

> Contributes to #5414 
>
> This PR improves how "program names" are reused, moving away from manually reuse towards automatic reuse in the SRSDecl declaration.
