### PR TITLE
fix(sglpend): "period of pendulum" notes refer to quantities but link to theories

### DIFF
--- a/code/drasil-example/sglpend/lib/Drasil/SglPend/GenDefs.hs
+++ b/code/drasil-example/sglpend/lib/Drasil/SglPend/GenDefs.hs
@@ -238,5 +238,5 @@ periodPendDerivSent2 = S "Therefore from the data definition of the" +:+
 
 periodPendNotes :: Sentence
 periodPendNotes = D.toSent (atStartNP (NP.the (frequency `and_` period))) +:+
-  S "are defined in the data definitions for" +:+ namedRef frequencyDD (phrase frequencyDD) `S.and_`
-        namedRef periodSHMDD (phrase periodSHMDD) +:+ S "respectively"
+  S "are defined in the data definitions for" +:+ namedRef frequencyDD (phrase frequency) `S.and_`
+        namedRef periodSHMDD (phrase period) +:+ S "respectively"


### PR DESCRIPTION
In light of our recent discussion about "term"s, I was interested in how/when we refer to the "terms" of our theories. One interesting find is in the notes of SglPend's [GD:periodPend](https://jacquescarette.github.io/Drasil/examples/sglpend/SRS/HTML/SglPend_SRS.html#GD:periodPend), we write:

> The frequency and period are defined in the data definitions for [frequency](https://jacquescarette.github.io/Drasil/examples/sglpend/SRS/HTML/SglPend_SRS.html#DD:frequencyDD) and [period](https://jacquescarette.github.io/Drasil/examples/sglpend/SRS/HTML/SglPend_SRS.html#DD:periodSHMDD) respectively

Aside: missing a period in that sentence.

What's interesting is that we reuse the "Label" of [DD:frequencyDD](https://jacquescarette.github.io/Drasil/examples/sglpend/SRS/HTML/SglPend_SRS.html#DD:frequencyDD) and [DD:periodSHMDD](https://jacquescarette.github.io/Drasil/examples/sglpend/SRS/HTML/SglPend_SRS.html#DD:periodSHMDD). But what we really mean to refer to here are the _concepts_ (`DefinedQuantityDict`s) of frequency and period while hotlinking to the specific DDs. This PR fixes that.

We normally just write `DD:frequencyDD` and `DD:periodSHMDD`. Here we chose to write `frequency` and `period`. Why? It does help with readability, but we should have a rule. And having a "rule" might mean that we create an option for switching how these formula references are rendered/displayed in-text. For example, we can do a hybrid: `frequency (DD:frequencyDD)`.