### PR TITLE
chore: remove dead code related to getting `CodeIdea` definitions

### DIFF
--- a/code/drasil-code/lib/Language/Drasil/Code/Imperative/Comments.hs
+++ b/code/drasil-code/lib/Language/Drasil/Code/Imperative/Comments.hs
@@ -1,19 +1,15 @@
 -- | Contains functions for generating code comments that describe a chunk.
 module Language.Drasil.Code.Imperative.Comments (
-  getComment, getCommentBrief
+  getCommentBrief
 ) where
 
 import Control.Monad.State (get)
-import Control.Lens ((^.))
-import Text.PrettyPrint.HughesPJ (Doc, (<+>), colon, empty, parens, render)
+import Text.PrettyPrint.HughesPJ (Doc, (<+>), empty, parens, render)
 
 import Drasil.Code.CodeVar (CodeIdea(..))
-import Drasil.Database (HasUID(..))
-import Drasil.Database.SearchTools (DomDefn (definition), defResolve')
 import Language.Drasil
 import Language.Drasil.Code.Imperative.DrasilState (GenState, DrasilState(..))
 import Language.Drasil.Printers (oneLineSentenceDoc, oneLineUnitDoc)
-import Drasil.System (systemdb)
 
 -- | Gets a plain renderering of the term for a chunk.
 getTermDoc :: (CodeIdea c) => c -> GenState Doc
@@ -21,30 +17,11 @@ getTermDoc c = do
   g <- get
   return $ oneLineSentenceDoc (printfo g) $ phrase $ codeChunk c
 
--- | Gets a plain rendering of the definition of a chunk, preceded by a colon
--- as it is intended to follow the term for the chunk. Returns empty if the
--- chunk has no definition.
-getDefnDoc :: (CodeIdea c) => c -> GenState Doc
-getDefnDoc c = do
-  g <- get
-  let db = g ^. systemdb
-  return $ ((<+>) colon . oneLineSentenceDoc (printfo g))
-    (definition $ defResolve' db (codeChunk c ^. uid))
-
 -- | Gets a plain rendering of the unit of a chunk in parentheses,
 -- or empty if it has no unit.
 getUnitsDoc :: (CodeIdea c) => c -> Doc
 getUnitsDoc c = maybe empty (parens . oneLineUnitDoc . usymb)
   (getUnit $ codeChunk c)
-
--- | Generates a comment string for a chunk, including the term,
--- definition (if applicable), and unit (if applicable).
-getComment :: (CodeIdea c) => c -> GenState String
-getComment l = do
-  t <- getTermDoc l
-  d <- getDefnDoc l
-  let u = getUnitsDoc l
-  return $ render $ (t <> d) <+> u
 
 getCommentBrief :: (CodeIdea c) => c -> GenState String
 getCommentBrief l = do


### PR DESCRIPTION
This is related to #4312

We previously removed our bad "definitions" but we left some dead code in the repo. Removing any/all dead code is helpful because it lessens our burden of searching for usecases for things.

This particular bit of code is easy to rebuild when we want it again. 

Aside: It requires that the chunk we get the definition for is a `CodeIdea`:

```haskell
-- | A 'CodeIdea' must include some code and its name.
class CodeIdea c where
  -- | Name of the idea.
  codeName  :: c -> String
  -- | Code chunk associated with the idea.
  codeChunk :: c -> CodeChunk
```

A `CodeChunk` has a readily accessible "definition:"

```haskell
-- | Basic chunk representation in the code generation context.
-- Contains a DefinedQuantityDict and the kind of code (variable or function).
data CodeChunk = CodeC { _qc  :: DefinedQuantityDict
                       , kind :: VarOrFunc
                       }
...
-- | Finds the Definition contained in the 'DefinedQuantityDict' used to make the CodeChunk
instance Definition    CodeChunk where defn = qc . defn
```

So, this code went about things in a roundabout way as well.