### PR TITLE
Removed constraints from a bunch of OO typeclasses

### DIFF
--- a/code/drasil-code/lib/Language/Drasil/Code/Imperative/FunctionCalls.hs
+++ b/code/drasil-code/lib/Language/Drasil/Code/Imperative/FunctionCalls.hs
@@ -40,10 +40,12 @@ genAllInputCalls
     ( Argument r
     , Literal r
     , MathConstant r
+    , OOVariableSym r
     , VariableValue r
     , BooleanExpression r
     , Comparison r
     , NumericExpression r
+    , ValueExpression r
     , SelfSym r
     , InternalValueExp r
     , OOValueExpression r
@@ -99,10 +101,12 @@ genConstraintCall
     ( Argument r
     , Literal r
     , MathConstant r
+    , OOVariableSym r
     , VariableValue r
     , BooleanExpression r
     , Comparison r
     , NumericExpression r
+    , ValueExpression r
     , SelfSym r
     , InternalValueExp r
     , OOValueExpression r
@@ -126,10 +130,12 @@ genCalcCall
     ( Argument r
     , Literal r
     , MathConstant r
+    , OOVariableSym r
     , VariableValue r
     , BooleanExpression r
     , Comparison r
     , NumericExpression r
+    , ValueExpression r
     , SelfSym r
     , InternalValueExp r
     , OOValueExpression r
@@ -155,10 +161,12 @@ genOutputCall
     ( Argument r
     , Literal r
     , MathConstant r
+    , OOVariableSym r
     , VariableValue r
     , BooleanExpression r
     , Comparison r
     , NumericExpression r
+    , ValueExpression r
     , SelfSym r
     , InternalValueExp r
     , OOValueExpression r
@@ -182,10 +190,12 @@ genFuncCall
     ( Argument r
     , Literal r
     , MathConstant r
+    , OOVariableSym r
     , VariableValue r
     , BooleanExpression r
     , Comparison r
     , NumericExpression r
+    , ValueExpression r
     , SelfSym r
     , InternalValueExp r
     , OOValueExpression r

--- a/code/drasil-code/lib/Language/Drasil/Code/Imperative/FunctionCalls.hs
+++ b/code/drasil-code/lib/Language/Drasil/Code/Imperative/FunctionCalls.hs
@@ -25,11 +25,11 @@ import Language.Drasil.Chunk.CodeDefinition (CodeDefinition)
 import Language.Drasil.Mod (Name)
 import Language.Drasil.Choices (InternalConcept(..))
 
-import Drasil.GOOL (SValue, MS, VS, TypeSym(..), VariableValue(..),
-  ValueStatement(valStmt), DeclStatement(..), convType, convTypeOO, TypeData,
-  FuncAppStatement, TypeElim, VariableElim, Argument, Set, ValueExpression,
-  Comparison, BooleanExpression, MathConstant, List, SelfSym, OOFuncAppStatement,
-  InternalValueExp, Literal, OOValueExpression)
+import Drasil.GOOL (SValue, MS, VS, TypeSym(..), OOVariableSym,
+  VariableValue(..), ValueStatement(valStmt), DeclStatement(..), convType,
+  convTypeOO, TypeData, FuncAppStatement, TypeElim, VariableElim, Argument, Set,
+  ValueExpression, Comparison, BooleanExpression, MathConstant, List, SelfSym,
+  OOFuncAppStatement, InternalValueExp, Literal, OOValueExpression)
 import Drasil.GProc (NativeVector, Reference, NumericExpression)
 
 -- | Generates calls to all of the input-related functions. First is the call to
@@ -51,6 +51,7 @@ genAllInputCalls
     , Reference r
     , Set r
     , ValueStatement r stmt
+    , FuncAppStatement r stmt
     , OOFuncAppStatement r stmt
     , TypeElim r
     , VariableElim r
@@ -64,7 +65,14 @@ genAllInputCalls = do
 
 -- | Generates a call to the function for reading inputs from a file.
 genInputCall
-  :: (VariableValue r, SelfSym r, OOFuncAppStatement r stmt, VariableElim r)
+  ::
+    ( OOVariableSym r
+    , VariableValue r
+    , SelfSym r
+    , FuncAppStatement r stmt
+    , OOFuncAppStatement r stmt
+    , VariableElim r
+    )
   => GenState (Maybe (MS (r stmt)))
 genInputCall = do
   giName <- genICName GetInput
@@ -72,7 +80,14 @@ genInputCall = do
 
 -- | Generates a call to the function for calculating derived inputs.
 genDerivedCall
-  :: (VariableValue r, SelfSym r, OOFuncAppStatement r stmt, VariableElim r)
+  ::
+    ( OOVariableSym r
+    , VariableValue r
+    , SelfSym r
+    , FuncAppStatement r stmt
+    , OOFuncAppStatement r stmt
+    , VariableElim r
+    )
   => GenState (Maybe (MS (r stmt)))
 genDerivedCall = do
   dvName <- genICName DerivedValuesFn
@@ -197,7 +212,14 @@ genFuncCall n t funcPs = do
 -- | Generates a function call given the name, inputs, and outputs for the
 -- function.
 genInOutCall
-  :: (VariableValue r, SelfSym r, OOFuncAppStatement r stmt, VariableElim r)
+  ::
+    ( OOVariableSym r
+    , VariableValue r
+    , SelfSym r
+    , FuncAppStatement r stmt
+    , OOFuncAppStatement r stmt
+    , VariableElim r
+    )
   => Name
   -> GenState [CodeVarChunk]
   -> GenState [CodeVarChunk]

--- a/code/drasil-code/lib/Language/Drasil/Code/Imperative/GenerateGOOL.hs
+++ b/code/drasil-code/lib/Language/Drasil/Code/Imperative/GenerateGOOL.hs
@@ -177,8 +177,14 @@ ctorCall m t = fCall (\cm args nargs -> if m /= cm then
   extNewObjMixedArgs m t args nargs else newObjMixedArgs t args nargs)
 
 -- | Logic similar to 'fApp', but for In/Out calls.
-fAppInOut :: (OOFuncAppStatement r stmt) => Name -> Name -> [SValue r] ->
-  [SVariable r] -> [SVariable r] -> GenState (MS (r stmt))
+fAppInOut
+  :: (FuncAppStatement r stmt, OOFuncAppStatement r stmt)
+  => Name
+  -> Name
+  -> [SValue r]
+  -> [SVariable r]
+  -> [SVariable r]
+  -> GenState (MS (r stmt))
 fAppInOut m n ins outs both = do
   g <- get
   let cm = currentModule g

--- a/code/drasil-code/lib/Language/Drasil/Code/Imperative/GenerateGOOL.hs
+++ b/code/drasil-code/lib/Language/Drasil/Code/Imperative/GenerateGOOL.hs
@@ -91,7 +91,7 @@ data ClassType = Primary | Auxiliary
 -- | Generates a primary or auxiliary class with the given name, description,
 -- state variables, and methods. The 'Maybe' 'Name' parameter is the name of the
 -- interface the class implements, if applicable.
-mkClass :: (ClassSym r vis mthd stvr attch) => ClassType -> Name -> Maybe Name ->
+mkClass :: (ClassSym r mthd stvr) => ClassType -> Name -> Maybe Name ->
   Description -> [CSStateVar r stvr] -> GenState [MS (r mthd)] ->
     GenState [MS (r mthd)] -> GenState (CS (r Class))
 mkClass s n l desc vs cstrs mths = do
@@ -110,13 +110,13 @@ mkClass s n l desc vs cstrs mths = do
     else c
 
 -- | Generates a primary class.
-primaryClass :: (ClassSym r vis mthd stvr attch) => Name -> Maybe Name -> Description ->
+primaryClass :: (ClassSym r mthd stvr) => Name -> Maybe Name -> Description ->
   [CSStateVar r stvr] -> GenState [MS (r mthd)] -> GenState [MS (r mthd)] ->
   GenState (CS (r Class))
 primaryClass = mkClass Primary
 
 -- | Generates an auxiliary class (for when a module contains multiple classes).
-auxClass :: (ClassSym r vis mthd stvr attch) => Name -> Maybe Name -> Description ->
+auxClass :: (ClassSym r mthd stvr) => Name -> Maybe Name -> Description ->
   [CSStateVar r stvr] -> GenState [MS (r mthd)] -> GenState [MS (r mthd)] ->
   GenState (CS (r Class))
 auxClass = mkClass Auxiliary

--- a/code/drasil-code/lib/Language/Drasil/Code/Imperative/Import.hs
+++ b/code/drasil-code/lib/Language/Drasil/Code/Imperative/Import.hs
@@ -869,7 +869,8 @@ readData
     , ListStatement r stmt
     , Reference r
     , OO.Set r
-    , OODeclStatement r stmt bod
+    , DeclStatement r stmt bod
+    , OODeclStatement r stmt
     , ControlStatement r stmt bod
     , StringStatement r stmt
     , FileHandling r stmt
@@ -898,7 +899,8 @@ readData ddef = do
             , VariableValue r
             , List r
             , ListStatement r stmt
-            , OODeclStatement r stmt bod
+            , DeclStatement r stmt bod
+            , OODeclStatement r stmt
             , ControlStatement r stmt bod
             , StringStatement r stmt
             , ReadFile r stmt
@@ -932,7 +934,8 @@ readData ddef = do
             ( SelfSym r
             , VariableValue r
             , ListStatement r stmt
-            , OODeclStatement r stmt bod
+            , DeclStatement r stmt bod
+            , OODeclStatement r stmt
             , StringStatement r stmt
             , VariableElim r
             )
@@ -946,13 +949,13 @@ readData ddef = do
             (stringListLists vs v_linetokens) : appendTemps s ds
         ---------------
         clearTemps
-          :: (OODeclStatement r stmt bod)
+          :: (OOTypeSym r, DeclStatement r stmt bod, OODeclStatement r stmt)
           => Maybe String -> [DataItem] -> r ScopeData -> [GenState (MS (r stmt))]
         clearTemps Nothing    _  _   = []
         clearTemps (Just sfx) es scp = map (\v -> clearTemp sfx v scp) es
         ---------------
         clearTemp
-          :: (OODeclStatement r stmt bod)
+          :: (OOTypeSym r, DeclStatement r stmt bod, OODeclStatement r stmt)
           => String -> DataItem -> r ScopeData -> GenState (MS (r stmt))
         clearTemp sfx v scp = fmap (\t -> listDecDef (var (codeName v ++ sfx)
           (innerType $ convTypeOO t)) scp []) (codeType v)

--- a/code/drasil-code/lib/Language/Drasil/Code/Imperative/Import.hs
+++ b/code/drasil-code/lib/Language/Drasil/Code/Imperative/Import.hs
@@ -122,8 +122,9 @@ value u s t = do
 -- If variable is a constant and 'Const' constant representation is chosen,
 -- construct it with 'classConst' and pass to 'constVariable'.
 -- If variable is neither, just construct it with 'var' and return it.
-variable :: (SelfSym r, VariableElim r, VariableValue r) => Name ->
-  VS (r TypeData) -> GenState (SVariable r)
+variable
+  :: (OOVariableSym r, SelfSym r, VariableElim r, VariableValue r)
+  => Name -> VS (r TypeData) -> GenState (SVariable r)
 variable s t = do
   g <- get
   let cs = g
@@ -143,8 +144,9 @@ variable s t = do
 -- WithInputs for constant structure, inputs are 'Bundled', and constant
 -- representation is 'Const'. Variable should be accessed through class, so
 -- 'classVariable' is called.
-inputVariable :: (SelfSym r, VariableElim r, VariableValue r) =>
-  Structure -> ConstantRepr -> SVariable r -> GenState (SVariable r)
+inputVariable
+  :: (OOVariableSym r, SelfSym r, VariableElim r, VariableValue r)
+  => Structure -> ConstantRepr -> SVariable r -> GenState (SVariable r)
 inputVariable Unbundled _ v = return v
 inputVariable Bundled Var v = do
   g <- get
@@ -163,8 +165,9 @@ inputVariable Bundled Const v = do
 -- If constants stored 'WithInputs', call 'inputVariable'.
 -- If constants are 'Inline'd, the generator should not be attempting to make a
 -- variable for one of the constants.
-constVariable :: (SelfSym r, VariableElim r, VariableValue r) =>
-  ConstantStructure -> ConstantRepr -> SVariable r -> GenState (SVariable r)
+constVariable
+  :: (OOVariableSym r, SelfSym r, VariableElim r, VariableValue r)
+  => ConstantStructure -> ConstantRepr -> SVariable r -> GenState (SVariable r)
 constVariable (Store Unbundled) _ v = return v
 constVariable (Store Bundled) Var v = do
   cs <- mkVar (quantvar consts)
@@ -224,8 +227,9 @@ mkVal v = do
   toGOOLVal (v ^. obv)
 
 -- | Generates a GOOL Variable for a variable represented by a 'CodeVarChunk'.
-mkVar :: (SelfSym r, VariableElim r, VariableValue r) =>
-  CodeVarChunk -> GenState (SVariable r)
+mkVar
+  :: (OOVariableSym r, SelfSym r, VariableElim r, VariableValue r)
+  => CodeVarChunk -> GenState (SVariable r)
 mkVar v = do
   t <- codeType v
   let toGOOLVar Nothing = variable (codeName v) (convTypeOO t)
@@ -237,7 +241,13 @@ mkVar v = do
 
 -- | Generates a GOOL Parameter for a parameter represented by a 'ParameterChunk'.
 mkParam
-  :: (VariableValue r, SelfSym r, ParameterSym r, VariableElim r)
+  ::
+    ( OOVariableSym r
+    , VariableValue r
+    , SelfSym r
+    , ParameterSym r
+    , VariableElim r
+    )
   => ParameterChunk -> GenState (MS (r ParamData))
 mkParam p = do
   v <- mkVar (quantvar p)
@@ -360,6 +370,7 @@ genMethod f n desc p r b = do
 genInOutFunc
   ::
     ( OO.Literal r
+    , OOVariableSym r
     , VariableValue r
     , SelfSym r
     , MultiStatement r stmt
@@ -896,6 +907,7 @@ readData ddef = do
             , BodySym r bod block
             , OO.Literal r
             , SelfSym r
+            , OOVariableSym r
             , VariableValue r
             , List r
             , ListStatement r stmt
@@ -932,6 +944,7 @@ readData ddef = do
         lineData
           ::
             ( SelfSym r
+            , OOVariableSym r
             , VariableValue r
             , ListStatement r stmt
             , DeclStatement r stmt bod
@@ -974,8 +987,9 @@ readData ddef = do
           (valueOf $ var (codeName v ++ sfx) (convTypeOO t))) (codeType v)
 
 -- | Get entry variables.
-getEntryVars :: (SelfSym r, VariableElim r, VariableValue r) =>
-  Maybe String -> LinePattern -> GenState [SVariable r]
+getEntryVars
+  :: (OOVariableSym r, SelfSym r, VariableElim r, VariableValue r)
+  => Maybe String -> LinePattern -> GenState [SVariable r]
 getEntryVars s lp = mapM (maybe mkVar (\st v -> codeType v >>=
   (variable (codeName v ++ st) . innerType . convTypeOO))
     s) (getPatternInputs lp)

--- a/code/drasil-code/lib/Language/Drasil/Code/Imperative/Import.hs
+++ b/code/drasil-code/lib/Language/Drasil/Code/Imperative/Import.hs
@@ -88,12 +88,14 @@ value
     ( Argument r
     , OO.Literal r
     , MathConstant r
+    , OOVariableSym r
     , VariableValue r
     , BooleanExpression r
     , Comparison r
     , NumericExpression r
     , SelfSym r
     , InternalValueExp r
+    , ValueExpression r
     , OOValueExpression r
     , List r
     , Reference r
@@ -203,10 +205,12 @@ mkVal
     ( Argument r
     , OO.Literal r
     , MathConstant r
+    , OOVariableSym r
     , VariableValue r
     , BooleanExpression r
     , Comparison r
     , NumericExpression r
+    , ValueExpression r
     , SelfSym r
     , InternalValueExp r
     , OOValueExpression r
@@ -411,11 +415,13 @@ convExpr
   ::
     ( Argument r
     , MathConstant r
+    , OOVariableSym r
     , VariableValue r
     , OO.Literal r
     , BooleanExpression r
     , Comparison r
     , NumericExpression r
+    , ValueExpression r
     , SelfSym r
     , InternalValueExp r
     , OOValueExpression r
@@ -518,11 +524,13 @@ convCall
   ::
     ( Argument r
     , MathConstant r
+    , OOVariableSym r
     , VariableValue r
     , OO.Literal r
     , BooleanExpression r
     , Comparison r
     , NumericExpression r
+    , ValueExpression r
     , SelfSym r
     , InternalValueExp r
     , OOValueExpression r
@@ -732,11 +740,13 @@ convStmt
     , BodySym r bod block
     , Argument r
     , MathConstant r
+    , OOVariableSym r
     , VariableValue r
     , OO.Literal r
     , BooleanExpression r
     , Comparison r
     , NumericExpression r
+    , ValueExpression r
     , SelfSym r
     , InternalValueExp r
     , OOValueExpression r
@@ -873,8 +883,10 @@ readData
     , Comparison r
     , NumericExpression r
     , SelfSym r
+    , OOVariableSym r
     , VariableValue r
     , InternalValueExp r
+    , ValueExpression r
     , OOValueExpression r
     , List r
     , ListStatement r stmt

--- a/code/drasil-code/lib/Language/Drasil/Code/Imperative/Modules.hs
+++ b/code/drasil-code/lib/Language/Drasil/Code/Imperative/Modules.hs
@@ -27,7 +27,7 @@ import Language.Drasil.Printers (showHasSymbImpl, PrintingInformation,
 import Drasil.GOOL (SVariable, SValue, CS, FS, MS, CSStateVar, Class, OOProg,
   BodySym(..), bodyStatements, oneLiner, BlockSym(..), AttachmentSym(..),
   TypeSym(..), VariableSym(..), ScopeSym(..), ScopeData, Literal(..),
-  VariableValue(..), CommandLineArgs(..), NumericExpression(..),
+  OOVariableSym, VariableValue(..), CommandLineArgs(..), NumericExpression(..),
   BooleanExpression(..), Comparison(..), List(..), ListStatement(..),
   EmptyStatement(emptyStmt), MultiStatement(multi), ValueStatement,
   AssignStatement(..), DeclStatement(..), OODeclStatement(..), objDecNewNoParams,
@@ -133,12 +133,14 @@ getInputDecl
     ( Argument r
     , Literal r
     , MathConstant r
+    , OOVariableSym r
     , VariableValue r
     , BooleanExpression r
     , Comparison r
     , NumericExpression r
     , SelfSym r
     , InternalValueExp r
+    , ValueExpression r
     , OOValueExpression r
     , List r
     , Reference r
@@ -188,6 +190,7 @@ initConsts
   ::
     ( Argument r
     , MathConstant r
+    , OOVariableSym r
     , VariableValue r
     , Literal r
     , BooleanExpression r
@@ -195,6 +198,7 @@ initConsts
     , NumericExpression r
     , SelfSym r
     , InternalValueExp r
+    , ValueExpression r
     , OOValueExpression r
     , List r
     , Reference r
@@ -397,6 +401,7 @@ sfwrCBody
     , BodySym r bod block
     , Argument r
     , MathConstant r
+    , OOVariableSym r
     , VariableValue r
     , Literal r
     , BooleanExpression r
@@ -404,6 +409,7 @@ sfwrCBody
     , NumericExpression r
     , SelfSym r
     , InternalValueExp r
+    , ValueExpression r
     , OOValueExpression r
     , List r
     , Reference r
@@ -428,6 +434,7 @@ physCBody
     , BodySym r bod block
     , Argument r
     , MathConstant r
+    , OOVariableSym r
     , VariableValue r
     , Literal r
     , BooleanExpression r
@@ -435,6 +442,7 @@ physCBody
     , NumericExpression r
     , SelfSym r
     , InternalValueExp r
+    , ValueExpression r
     , OOValueExpression r
     , List r
     , Reference r
@@ -460,11 +468,13 @@ chooseConstr
     , BodySym r bod block
     , Argument r
     , MathConstant r
+    , OOVariableSym r
     , VariableValue r
     , Literal r
     , BooleanExpression r
     , Comparison r
     , NumericExpression r
+    , ValueExpression r
     , SelfSym r
     , InternalValueExp r
     , OOValueExpression r
@@ -503,6 +513,7 @@ constrWarn
   ::
     ( Argument r
     , MathConstant r
+    , OOVariableSym r
     , VariableValue r
     , Literal r
     , BooleanExpression r
@@ -510,6 +521,7 @@ constrWarn
     , NumericExpression r
     , SelfSym r
     , InternalValueExp r
+    , ValueExpression r
     , OOValueExpression r
     , List r
     , Reference r
@@ -536,6 +548,7 @@ constrExc
     , BodySym r bod block
     , Argument r
     , MathConstant r
+    , OOVariableSym r
     , VariableValue r
     , Literal r
     , BooleanExpression r
@@ -543,6 +556,7 @@ constrExc
     , NumericExpression r
     , SelfSym r
     , InternalValueExp r
+    , ValueExpression r
     , OOValueExpression r
     , List r
     , Reference r
@@ -564,6 +578,7 @@ constrVarDec
   ::
     ( Argument r
     , MathConstant r
+    , OOVariableSym r
     , VariableValue r
     , Literal r
     , BooleanExpression r
@@ -571,6 +586,7 @@ constrVarDec
     , NumericExpression r
     , SelfSym r
     , InternalValueExp r
+    , ValueExpression r
     , OOValueExpression r
     , List r
     , Reference r
@@ -593,6 +609,7 @@ constraintViolatedMsg
   ::
     ( Argument r
     , MathConstant r
+    , OOVariableSym r
     , VariableValue r
     , Literal r
     , BooleanExpression r
@@ -600,6 +617,7 @@ constraintViolatedMsg
     , NumericExpression r
     , SelfSym r
     , InternalValueExp r
+    , ValueExpression r
     , OOValueExpression r
     , List r
     , Reference r
@@ -623,6 +641,7 @@ printConstraint
   ::
     ( Argument r
     , MathConstant r
+    , OOVariableSym r
     , VariableValue r
     , Literal r
     , BooleanExpression r
@@ -630,6 +649,7 @@ printConstraint
     , NumericExpression r
     , SelfSym r
     , InternalValueExp r
+    , ValueExpression r
     , OOValueExpression r
     , List r
     , Reference r
@@ -646,6 +666,7 @@ printConstraint v c = do
         ::
           ( Argument r
           , MathConstant r
+          , OOVariableSym r
           , VariableValue r
           , Literal r
           , BooleanExpression r
@@ -653,6 +674,7 @@ printConstraint v c = do
           , NumericExpression r
           , SelfSym r
           , InternalValueExp r
+          , ValueExpression r
           , OOValueExpression r
           , List r
           , Reference r
@@ -823,6 +845,7 @@ genCalcBlock
     , BodySym r bod block
     , Argument r
     , MathConstant r
+    , OOVariableSym r
     , VariableValue r
     , Literal r
     , BooleanExpression r
@@ -830,6 +853,7 @@ genCalcBlock
     , NumericExpression r
     , SelfSym r
     , InternalValueExp r
+    , ValueExpression r
     , OOValueExpression r
     , List r
     , Reference r
@@ -856,6 +880,7 @@ genCaseBlock
     , BodySym r bod block
     , Argument r
     , MathConstant r
+    , OOVariableSym r
     , VariableValue r
     , Literal r
     , BooleanExpression r
@@ -863,6 +888,7 @@ genCaseBlock
     , NumericExpression r
     , SelfSym r
     , InternalValueExp r
+    , ValueExpression r
     , OOValueExpression r
     , List r
     , Reference r

--- a/code/drasil-code/lib/Language/Drasil/Code/Imperative/Modules.hs
+++ b/code/drasil-code/lib/Language/Drasil/Code/Imperative/Modules.hs
@@ -144,7 +144,8 @@ getInputDecl
     , Reference r
     , Set r
     , MultiStatement r stmt
-    , OODeclStatement r stmt bod
+    , DeclStatement r stmt bod
+    , OODeclStatement r stmt
     , TypeElim r
     , VariableElim r
     )
@@ -199,7 +200,8 @@ initConsts
     , Reference r
     , Set r
     , MultiStatement r stmt
-    , OODeclStatement r stmt bod
+    , DeclStatement r stmt bod
+    , OODeclStatement r stmt
     , TypeElim r
     , VariableElim r
     )

--- a/code/drasil-code/lib/Language/Drasil/Code/Imperative/Modules.hs
+++ b/code/drasil-code/lib/Language/Drasil/Code/Imperative/Modules.hs
@@ -254,8 +254,14 @@ genInputMod = do
 -- Either generates a declare-define statement for a regular state variable
 -- (if user chose 'Var'),
 -- or a declare-define statement for a constant variable (if user chose 'Const').
-constVarFunc :: (StateVarSym r vis stvr attch) => ConstantRepr ->
-  (SVariable r -> SValue r -> CSStateVar r stvr)
+constVarFunc
+  ::
+    ( AttachmentSym r attch
+    , VisibilitySym r vis
+    , StateVarSym r vis stvr attch
+    )
+  => ConstantRepr
+  -> (SVariable r -> SValue r -> CSStateVar r stvr)
 constVarFunc Var = stateVarDef public instanceLevel
 constVarFunc Const = constVar public
 

--- a/code/drasil-code/test/GOOL/Observer.hs
+++ b/code/drasil-code/test/GOOL/Observer.hs
@@ -34,7 +34,8 @@ helperClass
   ::
     ( BlockSym r block stmt
     , BodySym r bod block
-    , ClassSym r vis mthd stvr attch
+    , StateVarSym r vis stvr attch
+    , ClassSym r mthd stvr
     , OOMethodSym r vis mthd attch bod
     , PrintConsole r stmt
     , Literal r

--- a/code/drasil-code/test/GOOL/Observer.hs
+++ b/code/drasil-code/test/GOOL/Observer.hs
@@ -34,6 +34,7 @@ helperClass
   ::
     ( BlockSym r block stmt
     , BodySym r bod block
+    , AttachmentSym r attch
     , VisibilitySym r vis
     , StateVarSym r vis stvr attch
     , ClassSym r mthd stvr
@@ -64,6 +65,7 @@ printNumMethod
     ( BlockSym r block stmt
     , BodySym r bod block
     , OOMethodSym r vis mthd attch bod
+    , AttachmentSym r attch
     , VisibilitySym r vis
     , PrintConsole r stmt
     , SelfSym r

--- a/code/drasil-code/test/GOOL/Observer.hs
+++ b/code/drasil-code/test/GOOL/Observer.hs
@@ -34,6 +34,7 @@ helperClass
   ::
     ( BlockSym r block stmt
     , BodySym r bod block
+    , VisibilitySym r vis
     , StateVarSym r vis stvr attch
     , ClassSym r mthd stvr
     , OOMethodSym r vis mthd attch bod

--- a/code/drasil-code/test/GOOL/Observer.hs
+++ b/code/drasil-code/test/GOOL/Observer.hs
@@ -3,9 +3,9 @@ module GOOL.Observer (observer, observerName, printNum, x) where
 
 import Drasil.GOOL (SVariable, Class, OOProg, CS, FS, MS, FileSym(..),
   AttachmentSym(..), BodySym, BlockSym, oneLiner, TypeSym(..), PrintConsole(..),
-  VariableSym(..), SelfSym(..), instanceVarSelf, Literal(..), VariableValue(..),
-  VisibilitySym(..), OOMethodSym(..), initializer, StateVarSym(..), ClassSym(..),
-  ModuleSym(..))
+  VariableSym(..), OOVariableSym, SelfSym(..), instanceVarSelf, Literal(..),
+  VariableValue(..), VisibilitySym(..), OOMethodSym(..), initializer,
+  StateVarSym(..), ClassSym(..), ModuleSym(..))
 import Prelude hiding (return,print,log,exp,sin,cos,tan)
 
 observerName, observerDesc, printNum :: String
@@ -26,7 +26,7 @@ x :: (VariableSym r) => SVariable r
 x = var "x" int
 
 -- | Acces the @x@ attribute of @self@.
-selfX :: (SelfSym r, VariableValue r) => SVariable r
+selfX :: (OOVariableSym r, SelfSym r, VariableValue r) => SVariable r
 selfX = instanceVarSelf x
 
 -- | Helper function to create the class.
@@ -41,6 +41,7 @@ helperClass
     , OOMethodSym r vis mthd attch bod
     , PrintConsole r stmt
     , Literal r
+    , OOVariableSym r
     , SelfSym r
     , VariableValue r
     )
@@ -68,6 +69,7 @@ printNumMethod
     , AttachmentSym r attch
     , VisibilitySym r vis
     , PrintConsole r stmt
+    , OOVariableSym r
     , SelfSym r
     , VariableValue r
     )

--- a/code/drasil-code/test/GOOL/PatternTest.hs
+++ b/code/drasil-code/test/GOOL/PatternTest.hs
@@ -33,7 +33,7 @@ obs1 = var obs1Name observerType
 obs2 = var obs2Name observerType
 
 -- | New Observer object.
-newObserver :: (OOValueExpression r) => SValue r
+newObserver :: (OOTypeSym r, OOValueExpression r) => SValue r
 newObserver = extNewObj observerName observerType []
 
 -- | Creates the pattern test program.

--- a/code/drasil-code/test/OOVector.hs
+++ b/code/drasil-code/test/OOVector.hs
@@ -28,7 +28,7 @@ vecVar v = var v (obj "Vector")
 localV :: VariableSym r => SVariable r
 localV = var "v" (arrayType double)
 
-thisV :: (SelfSym r, VariableValue r) => SVariable r
+thisV :: (OOVariableSym r, SelfSym r, VariableValue r) => SVariable r
 thisV = instanceVarSelf localV
 
 dimension :: OOProg r vis stmt mthd stvr attch prg file mod bod block => MS (r mthd)

--- a/code/drasil-gool/lib/Drasil/GOOL/CodeInfoOO.hs
+++ b/code/drasil-gool/lib/Drasil/GOOL/CodeInfoOO.hs
@@ -324,7 +324,7 @@ instance DeclStatement CodeInfoOO () () where
     _ <- bod
     return $ return $ error "[funcDecDef] The return value of this isn't used, and the thunk shouldn't fire."
 
-instance OODeclStatement CodeInfoOO () () where
+instance OODeclStatement CodeInfoOO () where
   objDecDef            _ _ = zoom lensMStoVS . execute1
   objDecNew            _ _ = zoom lensMStoVS . executeListErr
   extObjDecNew       _ _ _ = zoom lensMStoVS . executeListErr

--- a/code/drasil-gool/lib/Drasil/GOOL/CodeInfoOO.hs
+++ b/code/drasil-gool/lib/Drasil/GOOL/CodeInfoOO.hs
@@ -479,7 +479,7 @@ instance StateVarSym CodeInfoOO () () () where
   stateVarDef _ _ _ _ = noInfo
   constVar    _ _ _   = noInfo
 
-instance ClassSym CodeInfoOO () () () () where
+instance ClassSym CodeInfoOO () () where
   buildClass _ _ cs ms = do
     n <- zoom lensCStoFS getModuleName
     implementingClass n [] [] cs ms

--- a/code/drasil-gool/lib/Drasil/GOOL/InterfaceGOOL.hs
+++ b/code/drasil-gool/lib/Drasil/GOOL/InterfaceGOOL.hs
@@ -55,10 +55,10 @@ class (UnRepr r TypeData, Argument r, BodySym r bod block, BlockSym r block stmt
   ClassSym r mthd stvr, TypeElim r, VariableElim r, EmptyStatement r stmt,
   MultiStatement r stmt, ValueStatement r stmt, CommentStatement r stmt,
   DeclStatement r stmt bod, OODeclStatement r stmt, AssignStatement r stmt,
-  OOFuncAppStatement r stmt, ControlStatement r stmt bod, StringStatement r stmt,
-  PrintConsole r stmt, ReadConsole r stmt, FileHandling r stmt, PrintFile r stmt,
-  ReadFile r stmt, ModuleSym r mod mthd, FileSym r file mod,
-  ProgramSym r prg file
+  FuncAppStatement r stmt, OOFuncAppStatement r stmt,
+  ControlStatement r stmt bod, StringStatement r stmt, PrintConsole r stmt,
+  ReadConsole r stmt, FileHandling r stmt, PrintFile r stmt, ReadFile r stmt,
+  ModuleSym r mod mthd, FileSym r file mod, ProgramSym r prg file
   ) => OOProg r vis stmt mthd stvr attch prg file mod bod block
 
 type Program = ProgData
@@ -309,7 +309,7 @@ extObjDecNewNoParams :: (OODeclStatement r stmt) => Library -> SVariable r ->
   r ScopeData -> MS (r stmt)
 extObjDecNewNoParams l v tp = extObjDecNew l v tp []
 
-class (FuncAppStatement r stmt, OOVariableSym r) => OOFuncAppStatement r stmt where
+class OOFuncAppStatement r stmt | r -> stmt where
   selfInOutCall :: InOutCall r stmt
 
 class ObserverPattern r stmt | r -> stmt where

--- a/code/drasil-gool/lib/Drasil/GOOL/InterfaceGOOL.hs
+++ b/code/drasil-gool/lib/Drasil/GOOL/InterfaceGOOL.hs
@@ -108,7 +108,7 @@ class ClassSym r mthd stvr | r -> mthd stvr where
 
 type Initializers r = [(SVariable r, SValue r)]
 
-class (AttachmentSym r attch) => OOMethodSym r vis mthd attch bod | r -> vis mthd bod where
+class OOMethodSym r vis mthd attch bod | r -> vis mthd attch bod where
   method      :: Label -> r vis -> r attch -> VS (r TypeData) ->
     [MS (r ParamData)] -> MS (r bod) -> MS (r mthd)
   getMethod   :: SVariable r -> MS (r mthd)
@@ -120,12 +120,20 @@ class (AttachmentSym r attch) => OOMethodSym r vis mthd attch bod | r -> vis mth
   docInOutMethod :: Label -> r vis -> r attch -> DocInOutFunc r mthd bod
 
 privMethod
-  :: (OOMethodSym r vis mthd attch bod, VisibilitySym r vis)
+  ::
+    ( OOMethodSym r vis mthd attch bod
+    , AttachmentSym r attch
+    , VisibilitySym r vis
+    )
   => Label -> VS (r TypeData) -> [MS (r ParamData)] -> MS (r bod) -> MS (r mthd)
 privMethod n = method n private instanceLevel
 
 pubMethod
-  :: (OOMethodSym r vis mthd attch bod, VisibilitySym r vis)
+  ::
+    ( OOMethodSym r vis mthd attch bod
+    , AttachmentSym r attch
+    , VisibilitySym r vis
+    )
   => Label -> VS (r TypeData) -> [MS (r ParamData)] -> MS (r bod) -> MS (r mthd)
 pubMethod n = method n public instanceLevel
 

--- a/code/drasil-gool/lib/Drasil/GOOL/InterfaceGOOL.hs
+++ b/code/drasil-gool/lib/Drasil/GOOL/InterfaceGOOL.hs
@@ -54,10 +54,11 @@ class (UnRepr r TypeData, Argument r, BodySym r bod block, BlockSym r block stmt
   AttachmentSym r attch, VisibilitySym r vis, StateVarSym r vis stvr attch,
   ClassSym r mthd stvr, TypeElim r, VariableElim r, EmptyStatement r stmt,
   MultiStatement r stmt, ValueStatement r stmt, CommentStatement r stmt,
-  OODeclStatement r stmt bod, AssignStatement r stmt, OOFuncAppStatement r stmt,
-  ControlStatement r stmt bod, StringStatement r stmt, PrintConsole r stmt,
-  ReadConsole r stmt, FileHandling r stmt, PrintFile r stmt, ReadFile r stmt,
-  ModuleSym r mod mthd, FileSym r file mod, ProgramSym r prg file
+  DeclStatement r stmt bod, OODeclStatement r stmt, AssignStatement r stmt,
+  OOFuncAppStatement r stmt, ControlStatement r stmt bod, StringStatement r stmt,
+  PrintConsole r stmt, ReadConsole r stmt, FileHandling r stmt, PrintFile r stmt,
+  ReadFile r stmt, ModuleSym r mod mthd, FileSym r file mod,
+  ProgramSym r prg file
   ) => OOProg r vis stmt mthd stvr attch prg file mod bod block
 
 type Program = ProgData
@@ -290,7 +291,7 @@ classMethodCallNoParams :: (InternalValueExp r) => VS (r TypeData) -> VS (r Type
   Label -> SValue r
 classMethodCallNoParams t c f = classMethodCall t c f []
 
-class (DeclStatement r stmt bod, OOVariableSym r) => OODeclStatement r stmt bod where
+class OODeclStatement r stmt | r -> stmt where
   objDecDef    :: SVariable r -> r ScopeData -> SValue r -> MS (r stmt)
   -- Parameters: variable to store the object, scope of the variable,
   --             constructor arguments.  Object type is not needed,
@@ -299,11 +300,11 @@ class (DeclStatement r stmt bod, OOVariableSym r) => OODeclStatement r stmt bod 
   extObjDecNew :: Library -> SVariable r -> r ScopeData -> [SValue r]
     -> MS (r stmt)
 
-objDecNewNoParams :: (OODeclStatement r stmt bod) => SVariable r -> r ScopeData
+objDecNewNoParams :: (OODeclStatement r stmt) => SVariable r -> r ScopeData
   -> MS (r stmt)
 objDecNewNoParams v tp = objDecNew v tp []
 
-extObjDecNewNoParams :: (OODeclStatement r stmt bod) => Library -> SVariable r ->
+extObjDecNewNoParams :: (OODeclStatement r stmt) => Library -> SVariable r ->
   r ScopeData -> MS (r stmt)
 extObjDecNewNoParams l v tp = extObjDecNew l v tp []
 

--- a/code/drasil-gool/lib/Drasil/GOOL/InterfaceGOOL.hs
+++ b/code/drasil-gool/lib/Drasil/GOOL/InterfaceGOOL.hs
@@ -50,13 +50,13 @@ class (UnRepr r TypeData, Argument r, BodySym r bod block, BlockSym r block stmt
   InternalValueExp r, OOValueExpression r, Array r, List r, ListStatement r stmt,
   Reference r, Set r, OOFunctionSym r, ParameterSym r, VariableValue r,
   ScopeSym r, BinderSym r, InternalList r block, MethodSym r vis mthd bod,
-  OOMethodSym r vis mthd attch bod, ClassSym r vis mthd stvr attch, TypeElim r,
-  VariableElim r, EmptyStatement r stmt, MultiStatement r stmt,
-  ValueStatement r stmt, CommentStatement r stmt, OODeclStatement r stmt bod,
-  AssignStatement r stmt, OOFuncAppStatement r stmt, ControlStatement r stmt bod,
-  StringStatement r stmt, PrintConsole r stmt, ReadConsole r stmt,
-  FileHandling r stmt, PrintFile r stmt, ReadFile r stmt, ModuleSym r mod mthd,
-  FileSym r file mod, ProgramSym r prg file
+  OOMethodSym r vis mthd attch bod, StateVarSym r vis stvr attch,
+  ClassSym r mthd stvr, TypeElim r, VariableElim r, EmptyStatement r stmt,
+  MultiStatement r stmt, ValueStatement r stmt, CommentStatement r stmt,
+  OODeclStatement r stmt bod, AssignStatement r stmt, OOFuncAppStatement r stmt,
+  ControlStatement r stmt bod, StringStatement r stmt, PrintConsole r stmt,
+  ReadConsole r stmt, FileHandling r stmt, PrintFile r stmt, ReadFile r stmt,
+  ModuleSym r mod mthd, FileSym r file mod, ProgramSym r prg file
   ) => OOProg r vis stmt mthd stvr attch prg file mod bod block
 
 type Program = ProgData
@@ -89,7 +89,7 @@ class ModuleSym r mod mthd | r -> mod mthd where
 type Class = Doc
 
 -- | Class for representing an OO class.
-class (StateVarSym r vis stvr attch) => ClassSym r vis mthd stvr attch | r -> mthd where
+class ClassSym r mthd stvr | r -> mthd stvr where
   -- | Main external method for creating a class.
   -- Inputs: parent class, variables, constructor(s), methods
   buildClass :: Maybe Label -> [CSStateVar r stvr] -> [MS (r mthd)] ->

--- a/code/drasil-gool/lib/Drasil/GOOL/InterfaceGOOL.hs
+++ b/code/drasil-gool/lib/Drasil/GOOL/InterfaceGOOL.hs
@@ -47,15 +47,15 @@ import Text.PrettyPrint.HughesPJ (Doc)
 class (UnRepr r TypeData, Argument r, BodySym r bod block, BlockSym r block stmt,
   CommandLineArgs r, Literal r, MathConstant r, VariableValue r, VariableSym r,
   OOVariableSym r, SelfSym r, BooleanExpression r, Comparison r,
-  NumericExpression r, InternalValueExp r, OOValueExpression r, Array r, List r,
-  ListStatement r stmt, Reference r, Set r, FunctionSym r, OOFunctionSym r,
-  ParameterSym r, VariableValue r, ScopeSym r, BinderSym r, InternalList r block,
-  MethodSym r vis mthd bod, OOMethodSym r vis mthd attch bod,
-  AttachmentSym r attch, VisibilitySym r vis, StateVarSym r vis stvr attch,
-  ClassSym r mthd stvr, TypeElim r, VariableElim r, EmptyStatement r stmt,
-  MultiStatement r stmt, ValueStatement r stmt, CommentStatement r stmt,
-  DeclStatement r stmt bod, OODeclStatement r stmt, AssignStatement r stmt,
-  FuncAppStatement r stmt, OOFuncAppStatement r stmt,
+  NumericExpression r, InternalValueExp r, ValueExpression r,
+  OOValueExpression r, Array r, List r, ListStatement r stmt, Reference r, Set r,
+  FunctionSym r, OOFunctionSym r, ParameterSym r, VariableValue r, ScopeSym r,
+  BinderSym r, InternalList r block, MethodSym r vis mthd bod,
+  OOMethodSym r vis mthd attch bod, AttachmentSym r attch, VisibilitySym r vis,
+  StateVarSym r vis stvr attch, ClassSym r mthd stvr, TypeElim r, VariableElim r,
+  EmptyStatement r stmt, MultiStatement r stmt, ValueStatement r stmt,
+  CommentStatement r stmt, DeclStatement r stmt bod, OODeclStatement r stmt,
+  AssignStatement r stmt, FuncAppStatement r stmt, OOFuncAppStatement r stmt,
   ControlStatement r stmt bod, StringStatement r stmt, PrintConsole r stmt,
   ReadConsole r stmt, FileHandling r stmt, PrintFile r stmt, ReadFile r stmt,
   ModuleSym r mod mthd, FileSym r file mod, ProgramSym r prg file
@@ -218,7 +218,7 @@ instanceVarSelf
 instanceVarSelf = instanceVarAccess (valueOf self)
 
 -- for values that can include expressions
-class (ValueExpression r, OOVariableSym r, OOValueSym r) => OOValueExpression r where
+class OOValueExpression r where
   newObjMixedArgs         ::            MixedCtorCall r
   extNewObjMixedArgs      :: Library -> MixedCtorCall r
   libNewObjMixedArgs      :: Library -> MixedCtorCall r

--- a/code/drasil-gool/lib/Drasil/GOOL/InterfaceGOOL.hs
+++ b/code/drasil-gool/lib/Drasil/GOOL/InterfaceGOOL.hs
@@ -310,7 +310,7 @@ extObjDecNewNoParams l v tp = extObjDecNew l v tp []
 class (FuncAppStatement r stmt, OOVariableSym r) => OOFuncAppStatement r stmt where
   selfInOutCall :: InOutCall r stmt
 
-class (OOFunctionSym r) => ObserverPattern r stmt | r -> stmt where
+class ObserverPattern r stmt | r -> stmt where
   notifyObservers :: VS (r FuncData) -> VS (r TypeData) -> MS (r stmt)
 
 observerListName :: Label

--- a/code/drasil-gool/lib/Drasil/GOOL/InterfaceGOOL.hs
+++ b/code/drasil-gool/lib/Drasil/GOOL/InterfaceGOOL.hs
@@ -208,12 +208,13 @@ class (VariableSym r, OOTypeSym r) => OOVariableSym r where
 infixl 9 $->
 ($->) = instanceVarAccess
 
-class (OOVariableSym r) => SelfSym r where
+class SelfSym r where
   -- | `self` keyword
   self              :: SVariable r
 
 -- | Given a variable `v`, creates `self.v`
-instanceVarSelf   :: (SelfSym r, VariableValue r) => SVariable r -> SVariable r
+instanceVarSelf
+  :: (OOVariableSym r, SelfSym r, VariableValue r) => SVariable r -> SVariable r
 instanceVarSelf = instanceVarAccess (valueOf self)
 
 -- for values that can include expressions

--- a/code/drasil-gool/lib/Drasil/GOOL/InterfaceGOOL.hs
+++ b/code/drasil-gool/lib/Drasil/GOOL/InterfaceGOOL.hs
@@ -45,12 +45,13 @@ import Text.PrettyPrint.HughesPJ (Doc)
 -- | Wrapper typeclass that bundles everything essential
 -- for generating an object-oriented program.
 class (UnRepr r TypeData, Argument r, BodySym r bod block, BlockSym r block stmt,
-  CommandLineArgs r, Literal r, MathConstant r, VariableValue r, OOVariableSym r,
-  SelfSym r, BooleanExpression r, Comparison r, NumericExpression r,
-  InternalValueExp r, OOValueExpression r, Array r, List r, ListStatement r stmt,
-  Reference r, Set r, OOFunctionSym r, ParameterSym r, VariableValue r,
-  ScopeSym r, BinderSym r, InternalList r block, MethodSym r vis mthd bod,
-  OOMethodSym r vis mthd attch bod, StateVarSym r vis stvr attch,
+  CommandLineArgs r, Literal r, MathConstant r, VariableValue r, VariableSym r,
+  OOVariableSym r, SelfSym r, BooleanExpression r, Comparison r,
+  NumericExpression r, InternalValueExp r, OOValueExpression r, Array r, List r,
+  ListStatement r stmt, Reference r, Set r, OOFunctionSym r, ParameterSym r,
+  VariableValue r, ScopeSym r, BinderSym r, InternalList r block,
+  MethodSym r vis mthd bod, OOMethodSym r vis mthd attch bod,
+  AttachmentSym r attch, VisibilitySym r vis, StateVarSym r vis stvr attch,
   ClassSym r mthd stvr, TypeElim r, VariableElim r, EmptyStatement r stmt,
   MultiStatement r stmt, ValueStatement r stmt, CommentStatement r stmt,
   OODeclStatement r stmt bod, AssignStatement r stmt, OOFuncAppStatement r stmt,
@@ -145,7 +146,7 @@ type CSStateVar r stvr = CS (r stvr)
 -- Used when creating a class, to hold extra information about `Attachment`
 -- and `Visibility`.
 -- Usually 'Doc' is used for the representation.
-class (VisibilitySym r vis, AttachmentSym r attch, VariableSym r) => StateVarSym r vis stvr attch | r -> stvr where
+class StateVarSym r vis stvr attch | r -> vis stvr attch where
   -- | Given a visibility, attachment, and variable, represent the declaration
   -- of a state variable with no initial value.
   stateVar :: r vis -> r attch -> SVariable r -> CSStateVar r stvr
@@ -156,13 +157,19 @@ class (VisibilitySym r vis, AttachmentSym r attch, VariableSym r) => StateVarSym
   -- a state constant with the given value.
   constVar :: r vis ->  SVariable r -> SValue r -> CSStateVar r stvr
 
-privDVar :: (StateVarSym r vis stvr attch) => SVariable r -> CSStateVar r stvr
+privDVar
+  :: (AttachmentSym r attch, VisibilitySym r vis, StateVarSym r vis stvr attch)
+  => SVariable r -> CSStateVar r stvr
 privDVar = stateVar private instanceLevel
 
-pubDVar :: (StateVarSym r vis stvr attch) => SVariable r -> CSStateVar r stvr
+pubDVar
+  :: (AttachmentSym r attch, VisibilitySym r vis, StateVarSym r vis stvr attch)
+  => SVariable r -> CSStateVar r stvr
 pubDVar = stateVar public instanceLevel
 
-pubSVar :: (StateVarSym r vis stvr attch) => SVariable r -> CSStateVar r stvr
+pubSVar
+  :: (AttachmentSym r attch, VisibilitySym r vis, StateVarSym r vis stvr attch)
+  => SVariable r -> CSStateVar r stvr
 pubSVar = stateVar public classLevel
 
 -- | Used to differentiate whether a member is attached to the class or the instance

--- a/code/drasil-gool/lib/Drasil/GOOL/InterfaceGOOL.hs
+++ b/code/drasil-gool/lib/Drasil/GOOL/InterfaceGOOL.hs
@@ -25,15 +25,15 @@ import Drasil.Shared.InterfaceCommon (
   Label, Library, SVariable, SValue, NamedArgs, MixedCtorCall, PosCall,
   PosCtorCall, InOutCall, InOutFunc, DocInOutFunc,
   -- Typeclasses
-  BodySym(body), BlockSym, TypeSym(..), FunctionSym, MethodSym(..),
-  VariableSym(var), ValueSym(valueType), VariableValue(valueOf), ValueExpression,
-  Array, List(listSize), ListStatement(listAdd), listOf, EmptyStatement,
-  MultiStatement, ValueStatement, AssignStatement, DeclStatement(listDecDef),
-  FuncAppStatement, VisibilitySym(..), Argument, BooleanExpression,
-  CommandLineArgs, CommentStatement, Comparison, ControlStatement, PrintConsole,
-  ReadConsole, FileHandling, PrintFile, ReadFile, Literal, MathConstant,
-  NumericExpression, ParameterSym, Reference, Set, StringStatement, convType,
-  UnRepr, ScopeSym, BinderSym, InternalList, TypeElim, VariableElim)
+  BodySym(body), BlockSym, TypeSym(..), FunctionSym, MethodSym(..), VariableSym(var),
+  ValueSym(valueType), VariableValue(valueOf), ValueExpression, Array,
+  List(listSize), ListStatement(listAdd), listOf, EmptyStatement, MultiStatement,
+  ValueStatement, AssignStatement, DeclStatement(listDecDef), FuncAppStatement,
+  VisibilitySym(..), Argument, BooleanExpression, CommandLineArgs,
+  CommentStatement, Comparison, ControlStatement, PrintConsole, ReadConsole,
+  FileHandling, PrintFile, ReadFile, Literal, MathConstant, NumericExpression,
+  ParameterSym, Reference, Set, StringStatement, convType, UnRepr, ScopeSym,
+  BinderSym, InternalList, TypeElim, VariableElim)
 
 import Drasil.Shared.CodeType (CodeType(..), ClassName)
 import Drasil.Shared.Helpers (onStateValue)
@@ -48,8 +48,8 @@ class (UnRepr r TypeData, Argument r, BodySym r bod block, BlockSym r block stmt
   CommandLineArgs r, Literal r, MathConstant r, VariableValue r, VariableSym r,
   OOVariableSym r, SelfSym r, BooleanExpression r, Comparison r,
   NumericExpression r, InternalValueExp r, OOValueExpression r, Array r, List r,
-  ListStatement r stmt, Reference r, Set r, OOFunctionSym r, ParameterSym r,
-  VariableValue r, ScopeSym r, BinderSym r, InternalList r block,
+  ListStatement r stmt, Reference r, Set r, FunctionSym r, OOFunctionSym r,
+  ParameterSym r, VariableValue r, ScopeSym r, BinderSym r, InternalList r block,
   MethodSym r vis mthd bod, OOMethodSym r vis mthd attch bod,
   AttachmentSym r attch, VisibilitySym r vis, StateVarSym r vis stvr attch,
   ClassSym r mthd stvr, TypeElim r, VariableElim r, EmptyStatement r stmt,
@@ -332,7 +332,7 @@ class (VariableSym r) => StrategyPattern r bod block | r -> bod block where
   runStrategy :: Label -> [(Label, MS (r bod))] -> Maybe (SValue r) ->
     Maybe (SVariable r) -> MS (r block)
 
-class (FunctionSym r) => OOFunctionSym r where
+class OOFunctionSym r where
   func :: Label -> VS (r TypeData) -> [SValue r] -> VS (r FuncData)
   objAccess :: SValue r -> VS (r FuncData) -> SValue r
 

--- a/code/drasil-gool/lib/Drasil/GOOL/LanguageRenderer/CSharpRenderer.hs
+++ b/code/drasil-gool/lib/Drasil/GOOL/LanguageRenderer/CSharpRenderer.hs
@@ -684,7 +684,7 @@ instance StateVarSym CSharpCode Doc StateVar Doc where
 instance StateVarElim CSharpCode StateVar where
   stateVar = unCSC
 
-instance ClassSym CSharpCode Doc MethodData StateVar Doc where
+instance ClassSym CSharpCode MethodData StateVar where
   buildClass = G.buildClass
   extraClass = CP.extraClass
   implementingClass = G.implementingClass

--- a/code/drasil-gool/lib/Drasil/GOOL/LanguageRenderer/CSharpRenderer.hs
+++ b/code/drasil-gool/lib/Drasil/GOOL/LanguageRenderer/CSharpRenderer.hs
@@ -524,7 +524,7 @@ instance DeclStatement CSharpCode (Doc, Terminator) Body where
   constDecDef = CG.constDecDef
   funcDecDef = csFuncDecDef
 
-instance OODeclStatement CSharpCode (Doc, Terminator) Body where
+instance OODeclStatement CSharpCode (Doc, Terminator) where
   objDecDef = varDecDef
   objDecNew = G.objDecNew
   extObjDecNew = C.extObjDecNew

--- a/code/drasil-gool/lib/Drasil/GOOL/LanguageRenderer/CppRenderer.hs
+++ b/code/drasil-gool/lib/Drasil/GOOL/LanguageRenderer/CppRenderer.hs
@@ -550,7 +550,7 @@ instance (Pair p) => DeclStatement (p CppSrcCode CppHdrCode) (Doc, Terminator) B
   funcDecDef v scp ps = pairValListVal (`funcDecDef` pfst scp)
     (`funcDecDef` psnd scp) (zoom lensMStoVS v) (map (zoom lensMStoVS) ps)
 
-instance (Pair p) => OODeclStatement (p CppSrcCode CppHdrCode) (Doc, Terminator) Body where
+instance (Pair p) => OODeclStatement (p CppSrcCode CppHdrCode) (Doc, Terminator) where
   objDecDef o scp v = pair2 (`objDecDef` pfst scp) (`objDecDef` psnd scp)
     (zoom lensMStoVS o) (zoom lensMStoVS v)
   objDecNew vr scp vs = pair1Val1List (`objDecNew` pfst scp)
@@ -1480,7 +1480,7 @@ instance DeclStatement CppSrcCode (Doc, Terminator) Body where
   constDecDef = CG.constDecDef
   funcDecDef = cppFuncDecDef
 
-instance OODeclStatement CppSrcCode (Doc, Terminator) Body where
+instance OODeclStatement CppSrcCode (Doc, Terminator) where
   objDecDef = varDecDef
   objDecNew = G.objDecNew
   extObjDecNew = C.extObjDecNew
@@ -2141,7 +2141,7 @@ instance DeclStatement CppHdrCode (Doc, Terminator) Body where
   constDecDef = CG.constDecDef
   funcDecDef _ _ _ _ = emptyStmt
 
-instance OODeclStatement CppHdrCode (Doc, Terminator) Body where
+instance OODeclStatement CppHdrCode (Doc, Terminator) where
   objDecDef _ _ _ = emptyStmt
   objDecNew _ _ _ = emptyStmt
   extObjDecNew _ _ _ _ = emptyStmt

--- a/code/drasil-gool/lib/Drasil/GOOL/LanguageRenderer/CppRenderer.hs
+++ b/code/drasil-gool/lib/Drasil/GOOL/LanguageRenderer/CppRenderer.hs
@@ -777,8 +777,7 @@ instance (Pair p) => StateVarSym (p CppSrcCode CppHdrCode)
 instance (Pair p) => StateVarElim (p CppSrcCode CppHdrCode) StateVarData where
   stateVar v = RC.stateVar $ pfst v
 
-instance (Pair p) => ClassSym (p CppSrcCode CppHdrCode)
-    (Doc, VisibilityTag) MethodData StateVarData AttachmentData where
+instance (Pair p) => ClassSym (p CppSrcCode CppHdrCode) MethodData StateVarData where
   buildClass p vs cs fs = do
     n <- zoom lensCStoFS getModuleName
     modify (setClassName n)
@@ -1676,7 +1675,7 @@ instance StateVarSym CppSrcCode (Doc, VisibilityTag) StateVarData AttachmentData
 instance StateVarElim CppSrcCode StateVarData where
   stateVar = stVar . unCPPSC
 
-instance ClassSym CppSrcCode (Doc, VisibilityTag) MethodData StateVarData AttachmentData where
+instance ClassSym CppSrcCode MethodData StateVarData where
   buildClass = G.buildClass
   extraClass = CP.extraClass
   implementingClass = G.implementingClass
@@ -2310,7 +2309,7 @@ instance StateVarSym CppHdrCode (Doc, VisibilityTag) StateVarData AttachmentData
 instance StateVarElim CppHdrCode StateVarData where
   stateVar = stVar . unCPPHC
 
-instance ClassSym CppHdrCode (Doc, VisibilityTag) MethodData StateVarData AttachmentData where
+instance ClassSym CppHdrCode MethodData StateVarData where
   buildClass = G.buildClass
   extraClass = CP.extraClass
   implementingClass = G.implementingClass

--- a/code/drasil-gool/lib/Drasil/GOOL/LanguageRenderer/JavaRenderer.hs
+++ b/code/drasil-gool/lib/Drasil/GOOL/LanguageRenderer/JavaRenderer.hs
@@ -713,7 +713,7 @@ instance StateVarSym JavaCode Doc Doc Doc where
 instance StateVarElim JavaCode StateVar where
   stateVar = unJC
 
-instance ClassSym JavaCode Doc MethodData StateVar Doc where
+instance ClassSym JavaCode MethodData StateVar where
   buildClass = G.buildClass
   extraClass = jExtraClass
   implementingClass = G.implementingClass

--- a/code/drasil-gool/lib/Drasil/GOOL/LanguageRenderer/JavaRenderer.hs
+++ b/code/drasil-gool/lib/Drasil/GOOL/LanguageRenderer/JavaRenderer.hs
@@ -547,7 +547,7 @@ instance DeclStatement JavaCode (Doc, Terminator) Body where
   constDecDef = jConstDecDef
   funcDecDef = jFuncDecDef
 
-instance OODeclStatement JavaCode (Doc, Terminator) Body where
+instance OODeclStatement JavaCode (Doc, Terminator) where
   objDecDef = varDecDef
   objDecNew = G.objDecNew
   extObjDecNew = C.extObjDecNew

--- a/code/drasil-gool/lib/Drasil/GOOL/LanguageRenderer/JavaRenderer.hs
+++ b/code/drasil-gool/lib/Drasil/GOOL/LanguageRenderer/JavaRenderer.hs
@@ -1016,11 +1016,14 @@ jInput vr inFn = do
       jInput' _ = error "Attempt to read value of unreadable type"
   jInput' (getCodeType $ variableType v)
 
-jOpenFileR :: (OOValueExpression r) => SValue r -> VS (r TypeData) -> SValue r
+jOpenFileR
+  :: (OOTypeSym r, OOValueExpression r)
+  => SValue r -> VS (r TypeData) -> SValue r
 jOpenFileR n t = newObj t [newObj jFileType [n]]
 
-jOpenFileWorA :: (OOValueExpression r) => SValue r -> VS (r TypeData) ->
-  SValue r -> SValue r
+jOpenFileWorA
+  :: (OOTypeSym r, OOValueExpression r)
+  => SValue r -> VS (r TypeData) -> SValue r -> SValue r
 jOpenFileWorA n t wa = newObj t
   [newObj jFileWriterType [newObj jFileType [n], wa]]
 

--- a/code/drasil-gool/lib/Drasil/GOOL/LanguageRenderer/PythonRenderer.hs
+++ b/code/drasil-gool/lib/Drasil/GOOL/LanguageRenderer/PythonRenderer.hs
@@ -531,7 +531,7 @@ instance DeclStatement PythonCode (Doc, Terminator) Body where
       else error "Cannot safely capitalize constant."
   funcDecDef = CP.funcDecDef
 
-instance OODeclStatement PythonCode (Doc, Terminator) Body where
+instance OODeclStatement PythonCode (Doc, Terminator) where
   objDecDef = varDecDef
   objDecNew = G.objDecNew
   extObjDecNew lib v scp vs = do

--- a/code/drasil-gool/lib/Drasil/GOOL/LanguageRenderer/PythonRenderer.hs
+++ b/code/drasil-gool/lib/Drasil/GOOL/LanguageRenderer/PythonRenderer.hs
@@ -696,7 +696,7 @@ instance StateVarSym PythonCode Doc Doc AttachmentData where
 instance StateVarElim PythonCode StateVar where
   stateVar = unPC
 
-instance ClassSym PythonCode Doc MethodData StateVar AttachmentData where
+instance ClassSym PythonCode MethodData StateVar where
   buildClass par sVars cstrs = if length cstrs <= 1
                                   then G.buildClass par sVars cstrs
                                   else error pyMultCstrsError

--- a/code/drasil-gool/lib/Drasil/GOOL/LanguageRenderer/SwiftRenderer.hs
+++ b/code/drasil-gool/lib/Drasil/GOOL/LanguageRenderer/SwiftRenderer.hs
@@ -725,7 +725,7 @@ instance StateVarSym SwiftCode Doc Doc Doc where
 instance StateVarElim SwiftCode StateVar where
   stateVar = unSC
 
-instance ClassSym SwiftCode Doc MethodData StateVar Doc where
+instance ClassSym SwiftCode MethodData StateVar where
   buildClass = G.buildClass
   extraClass = CP.extraClass
   implementingClass = G.implementingClass

--- a/code/drasil-gool/lib/Drasil/GOOL/LanguageRenderer/SwiftRenderer.hs
+++ b/code/drasil-gool/lib/Drasil/GOOL/LanguageRenderer/SwiftRenderer.hs
@@ -535,7 +535,7 @@ instance DeclStatement SwiftCode (Doc, Terminator) Body where
     mkStmtNoEnd $ RC.statement vdec <+> equals <+> RC.value vl
   funcDecDef = CP.funcDecDef
 
-instance OODeclStatement SwiftCode (Doc, Terminator) Body where
+instance OODeclStatement SwiftCode (Doc, Terminator) where
   objDecDef = varDecDef
   objDecNew = G.objDecNew
   extObjDecNew = C.extObjDecNew

--- a/code/drasil-gool/lib/Drasil/GOOL/RendererClassesOO.hs
+++ b/code/drasil-gool/lib/Drasil/GOOL/RendererClassesOO.hs
@@ -7,11 +7,12 @@ module Drasil.GOOL.RendererClassesOO (
   ModuleElim(..), OORenderMethod(..), OOMethodTypeSym(..)
 ) where
 
-import Drasil.Shared.InterfaceCommon (Label, Block, SVariable, SValue, MethodSym)
+import Drasil.Shared.InterfaceCommon (Label, Block, SVariable, SValue, MethodSym,
+  VariableSym, VisibilitySym)
 import qualified Drasil.GOOL.InterfaceGOOL as IG (Class, CSStateVar,
   OOVariableSym, SelfSym, OOValueExpression(..), InternalValueExp(..),
   FileSym(..), GetSet(..), ObserverPattern(..), StrategyPattern(..), ModuleSym,
-  OOMethodSym, StateVarSym, ClassSym)
+  OOMethodSym, AttachmentSym, StateVarSym, ClassSym)
 import Drasil.Shared.AST (AttachmentTag, TypeData, ParamData, FuncData)
 import Drasil.Shared.State (FS, CS, VS, MS)
 
@@ -20,10 +21,11 @@ import Text.PrettyPrint.HughesPJ (Doc)
 import Drasil.Shared.RendererClassesCommon (CommonRenderSym, BlockCommentSym(..), MethodTypeSym(..), RenderMethod(..))
 
 class (CommonRenderSym r vis stmt mthd bod block, MethodSym r vis mthd bod,
-  IG.OOMethodSym r vis mthd attch bod, IG.StateVarSym r vis stvr attch,
-  IG.ClassSym r mthd stvr, IG.ModuleSym r mod mthd,
-  IG.FileSym r file mod, IG.InternalValueExp r, IG.GetSet r,
-  IG.ObserverPattern r stmt, IG.StrategyPattern r bod block, IG.OOVariableSym r,
+  IG.OOMethodSym r vis mthd attch bod, VisibilitySym r vis,
+  IG.AttachmentSym r attch, IG.StateVarSym r vis stvr attch,
+  IG.ClassSym r mthd stvr, IG.ModuleSym r mod mthd, IG.FileSym r file mod,
+  IG.InternalValueExp r, IG.GetSet r, IG.ObserverPattern r stmt,
+  IG.StrategyPattern r bod block, VariableSym r, IG.OOVariableSym r,
   IG.SelfSym r, IG.OOValueExpression r, RenderClass r vis mthd stvr, ClassElim r,
   RenderFile r file mod, InternalGetSet r, OORenderMethod r vis mthd attch bod,
   RenderMod r mod, ModuleElim r mod, StateVarElim r stvr, PermElim r attch

--- a/code/drasil-gool/lib/Drasil/GOOL/RendererClassesOO.hs
+++ b/code/drasil-gool/lib/Drasil/GOOL/RendererClassesOO.hs
@@ -11,7 +11,7 @@ import Drasil.Shared.InterfaceCommon (Label, Block, SVariable, SValue, MethodSym
 import qualified Drasil.GOOL.InterfaceGOOL as IG (Class, CSStateVar,
   OOVariableSym, SelfSym, OOValueExpression(..), InternalValueExp(..),
   FileSym(..), GetSet(..), ObserverPattern(..), StrategyPattern(..), ModuleSym,
-  OOMethodSym, ClassSym)
+  OOMethodSym, StateVarSym, ClassSym)
 import Drasil.Shared.AST (AttachmentTag, TypeData, ParamData, FuncData)
 import Drasil.Shared.State (FS, CS, VS, MS)
 
@@ -20,13 +20,13 @@ import Text.PrettyPrint.HughesPJ (Doc)
 import Drasil.Shared.RendererClassesCommon (CommonRenderSym, BlockCommentSym(..), MethodTypeSym(..), RenderMethod(..))
 
 class (CommonRenderSym r vis stmt mthd bod block, MethodSym r vis mthd bod,
-  IG.OOMethodSym r vis mthd attch bod, IG.ClassSym r vis mthd stvr attch,
-  IG.ModuleSym r mod mthd, IG.FileSym r file mod, IG.InternalValueExp r,
-  IG.GetSet r, IG.ObserverPattern r stmt, IG.StrategyPattern r bod block,
-  IG.OOVariableSym r, IG.SelfSym r, IG.OOValueExpression r,
-  RenderClass r vis mthd stvr, ClassElim r, RenderFile r file mod,
-  InternalGetSet r, OORenderMethod r vis mthd attch bod, RenderMod r mod,
-  ModuleElim r mod, StateVarElim r stvr, PermElim r attch
+  IG.OOMethodSym r vis mthd attch bod, IG.StateVarSym r vis stvr attch,
+  IG.ClassSym r mthd stvr, IG.ModuleSym r mod mthd,
+  IG.FileSym r file mod, IG.InternalValueExp r, IG.GetSet r,
+  IG.ObserverPattern r stmt, IG.StrategyPattern r bod block, IG.OOVariableSym r,
+  IG.SelfSym r, IG.OOValueExpression r, RenderClass r vis mthd stvr, ClassElim r,
+  RenderFile r file mod, InternalGetSet r, OORenderMethod r vis mthd attch bod,
+  RenderMod r mod, ModuleElim r mod, StateVarElim r stvr, PermElim r attch
   ) => OORenderSym r vis stmt mthd stvr attch file mod bod block
 
 -- OO-Only Typeclasses --

--- a/code/drasil-gool/lib/Drasil/Shared/LanguageRenderer/CommonPseudoOO.hs
+++ b/code/drasil-gool/lib/Drasil/Shared/LanguageRenderer/CommonPseudoOO.hs
@@ -131,11 +131,13 @@ indexOf
   => Label -> SValue r -> SValue r -> SValue r
 indexOf f l v = IC.indexToInt $ IG.objAccess l (IG.func f IC.int [v])
 
-contains :: (IG.OOFunctionSym r) => Label -> SValue r -> SValue r -> SValue r
+contains
+  :: (IC.FunctionSym r, IG.OOFunctionSym r)
+  => Label -> SValue r -> SValue r -> SValue r
 contains f s v = IG.objAccess s (IG.func f IC.bool [v])
 
 containsInt
-  :: (Comparison r, IG.OOFunctionSym r)
+  :: (Comparison r, IC.FunctionSym r, IG.OOFunctionSym r)
   => Label -> Label -> SValue r -> SValue r -> SValue r
 containsInt f fn s v = contains f s v ?!= IG.objAccess s (IG.func fn IC.bool [])
 
@@ -323,11 +325,11 @@ call' _ l o n t ps ns = call empty l o n t ps ns
 namedArgError :: String -> String
 namedArgError l = "Named arguments not supported in " ++ l
 
-listSizeFunc :: (IG.OOFunctionSym r) => VS (r FuncData)
+listSizeFunc :: (IC.FunctionSym r, IG.OOFunctionSym r) => VS (r FuncData)
 listSizeFunc = IG.func "size" IC.int []
 
 listAccessFunc'
-  :: (IG.OOFunctionSym r, TypeElim r)
+  :: (IC.FunctionSym r, IG.OOFunctionSym r, TypeElim r)
   => Label -> VS (r TypeData) -> SValue r -> VS (r FuncData)
 listAccessFunc' f t i = IG.func f t [intValue i]
 

--- a/code/drasil-gool/lib/Drasil/Shared/LanguageRenderer/LanguagePolymorphic.hs
+++ b/code/drasil-gool/lib/Drasil/Shared/LanguageRenderer/LanguagePolymorphic.hs
@@ -28,7 +28,7 @@ import Drasil.Shared.InterfaceCommon (UnRepr(..), Label, Library, Variable,
   VariableValue, BlockSym, BodySym)
 import qualified Drasil.Shared.InterfaceCommon as IC
 import Drasil.GOOL.InterfaceGOOL (Class, Initializers, CSStateVar, newObj,
-  objMethodCallNoParams, ($.), AttachmentSym(..), SelfSym)
+  objMethodCallNoParams, ($.), AttachmentSym(..), SelfSym, OOVariableSym)
 import qualified Drasil.GOOL.InterfaceGOOL as IG
 import Drasil.Shared.RendererClassesCommon (InternalVarElim(variableBind),
   RenderValue(valFromData), RenderFunction(funcFromData),
@@ -572,7 +572,8 @@ setMethod v = zoom lensMStoVS v >>= (\vr -> method (setterName $ variableName
 
 initStmts
   ::
-    ( VariableValue r
+    ( OOVariableSym r
+    , VariableValue r
     , SelfSym r
     , AssignStatement r stmt
     , BlockSym r block stmt

--- a/code/drasil-gool/lib/Drasil/Shared/LanguageRenderer/LanguagePolymorphic.hs
+++ b/code/drasil-gool/lib/Drasil/Shared/LanguageRenderer/LanguagePolymorphic.hs
@@ -295,7 +295,9 @@ get
   => SValue r -> SVariable r -> SValue r
 get v vToGet = v $. RO.getFunc vToGet
 
-set :: (RO.InternalGetSet r, IG.OOFunctionSym r) => SValue r -> SVariable r -> SValue r -> SValue r
+set
+  :: (RO.InternalGetSet r, IC.FunctionSym r, IG.OOFunctionSym r)
+  => SValue r -> SVariable r -> SValue r -> SValue r
 set v vToSet toVal = v $. RO.setFunc (onStateValue valueType v) vToSet toVal
 
 -- TODO [Brandon Bosman, 06/10/2026]: Figure out what to do with this

--- a/code/drasil-gool/lib/Drasil/Shared/LanguageRenderer/LoggingFor.hs
+++ b/code/drasil-gool/lib/Drasil/Shared/LanguageRenderer/LoggingFor.hs
@@ -457,8 +457,8 @@ instance (G.OOVariableSym r) => G.OOVariableSym (LoggingFor r) where
   extClassVarAccess = liftLogging G.extClassVarAccess
   instanceVarAccess = liftLogging G.instanceVarAccess
 
-instance (DeclStatement (LoggingFor r) stmt bod, G.OODeclStatement r stmt bod) =>
-    G.OODeclStatement (LoggingFor r) stmt bod where
+instance (DeclStatement (LoggingFor r) stmt bod, G.OODeclStatement r stmt) =>
+    G.OODeclStatement (LoggingFor r) stmt where
   objDecDef = liftLogging G.objDecDef
   objDecNew = liftLogging G.objDecNew
   extObjDecNew = liftLogging G.extObjDecNew

--- a/code/drasil-gool/lib/Drasil/Shared/LanguageRenderer/LoggingFor.hs
+++ b/code/drasil-gool/lib/Drasil/Shared/LanguageRenderer/LoggingFor.hs
@@ -500,7 +500,7 @@ instance (G.StateVarSym r vis stvr attch) => G.StateVarSym (LoggingFor r) vis st
   stateVarDef = liftLogging G.stateVarDef
   constVar = liftLogging G.constVar
 
-instance (G.ClassSym r vis mthd stvr attch) => G.ClassSym (LoggingFor r) vis mthd stvr attch where
+instance (G.ClassSym r mthd stvr) => G.ClassSym (LoggingFor r) mthd stvr where
   buildClass = liftLogging G.buildClass
   extraClass = liftLogging G.extraClass
   implementingClass = liftLogging G.implementingClass


### PR DESCRIPTION
Contributes to #5328. These are all leaf nodes of the graph I made in #5490, so their constraints need to be removed so that other constraints can be removed, so that eventually we can parameterize `TypeData`, which will allow us to remove `repr`.